### PR TITLE
feat: add Wuerstchen v2 model support

### DIFF
--- a/crates/mold-cli/src/commands/generate.rs
+++ b/crates/mold-cli/src/commands/generate.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use colored::Colorize;
 use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle};
 use mold_core::{
-    Config, GenerateRequest, GenerateResponse, ImageData, MoldClient, OutputFormat,
+    Config, GenerateRequest, GenerateResponse, ImageData, MoldClient, OutputFormat, Scheduler,
     SseProgressEvent,
 };
 use rand::Rng;
@@ -28,6 +28,7 @@ pub async fn run(
     local: bool,
     t5_variant: Option<String>,
     qwen3_variant: Option<String>,
+    scheduler: Option<Scheduler>,
     eager: bool,
 ) -> Result<()> {
     let output_format = format;
@@ -79,6 +80,7 @@ pub async fn run(
         seed,
         batch_size: batch,
         output_format,
+        scheduler,
     };
 
     if let Some(desc) = &model_cfg.description {

--- a/crates/mold-cli/src/commands/info.rs
+++ b/crates/mold-cli/src/commands/info.rs
@@ -37,6 +37,7 @@ fn resolve_file_path(
         ModelComponent::ClipEncoder2 => mcfg.clip_encoder_2.clone(),
         ModelComponent::ClipTokenizer2 => mcfg.clip_tokenizer_2.clone(),
         ModelComponent::TextTokenizer => mcfg.text_tokenizer.clone(),
+        ModelComponent::Decoder => mcfg.decoder.clone(),
         ModelComponent::TransformerShard | ModelComponent::TextEncoder => None,
     }
 }
@@ -59,6 +60,7 @@ fn resolve_verify_path(
             ModelComponent::ClipEncoder2 => paths.clip_encoder_2.as_ref(),
             ModelComponent::ClipTokenizer2 => paths.clip_tokenizer_2.as_ref(),
             ModelComponent::TextTokenizer => paths.text_tokenizer.as_ref(),
+            ModelComponent::Decoder => paths.decoder.as_ref(),
             // Shards and text encoder files are multi-valued; fall through to config
             ModelComponent::TransformerShard | ModelComponent::TextEncoder => None,
         };
@@ -96,6 +98,7 @@ fn component_label(component: &ModelComponent) -> &'static str {
         ModelComponent::ClipTokenizer2 => "CLIP-G Tokenizer",
         ModelComponent::TextEncoder => "Text Encoder",
         ModelComponent::TextTokenizer => "Text Tokenizer",
+        ModelComponent::Decoder => "Decoder",
     }
 }
 

--- a/crates/mold-cli/src/commands/run.rs
+++ b/crates/mold-cli/src/commands/run.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use clap_complete::engine::CompletionCandidate;
 use mold_core::manifest::{all_model_names, is_known_model, resolve_model_name};
-use mold_core::{Config, OutputFormat};
+use mold_core::{Config, OutputFormat, Scheduler};
 use std::io::{IsTerminal, Read};
 
 use super::generate;
@@ -62,6 +62,7 @@ pub async fn run(
     local: bool,
     t5_variant: Option<String>,
     qwen3_variant: Option<String>,
+    scheduler: Option<Scheduler>,
     eager: bool,
 ) -> Result<()> {
     let config = Config::load_or_default();
@@ -107,6 +108,7 @@ pub async fn run(
         local,
         t5_variant,
         qwen3_variant,
+        scheduler,
         eager,
     )
     .await

--- a/crates/mold-cli/src/main.rs
+++ b/crates/mold-cli/src/main.rs
@@ -3,7 +3,7 @@ mod output;
 
 use clap::{CommandFactory, Parser, Subcommand};
 use clap_complete::engine::ArgValueCandidates;
-use mold_core::OutputFormat;
+use mold_core::{OutputFormat, Scheduler};
 
 #[derive(Clone, clap::ValueEnum)]
 enum LogFormat {
@@ -109,6 +109,11 @@ Examples:
         /// Qwen3 text encoder variant (Z-Image): auto (default), bf16, q8, q6, iq4, q3
         #[arg(long, help_heading = "Advanced")]
         qwen3_variant: Option<String>,
+
+        /// Scheduler algorithm for UNet models: ddim, euler-ancestral, uni-pc
+        /// Ignored by flow-matching models (FLUX, SD3, Z-Image, Flux.2, Qwen-Image).
+        #[arg(long, env = "MOLD_SCHEDULER", help_heading = "Advanced")]
+        scheduler: Option<Scheduler>,
 
         /// Keep all model components loaded simultaneously (faster but uses more memory).
         /// By default, components are loaded and unloaded sequentially to reduce peak memory.
@@ -308,6 +313,7 @@ async fn run() -> anyhow::Result<()> {
             local,
             t5_variant,
             qwen3_variant,
+            scheduler,
             eager,
         } => {
             commands::run::run(
@@ -325,6 +331,7 @@ async fn run() -> anyhow::Result<()> {
                 local,
                 t5_variant,
                 qwen3_variant,
+                scheduler,
                 eager,
             )
             .await?;

--- a/crates/mold-core/src/config.rs
+++ b/crates/mold-core/src/config.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use crate::manifest::resolve_model_name;
+use crate::types::Scheduler;
 
 /// Per-model file path + default settings configuration.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
@@ -24,6 +25,8 @@ pub struct ModelConfig {
     pub text_encoder_files: Option<Vec<String>>,
     /// Generic text encoder tokenizer path (Qwen3 for Z-Image)
     pub text_tokenizer: Option<String>,
+    /// Stage B decoder weights path (Wuerstchen only)
+    pub decoder: Option<String>,
 
     // --- generation defaults ---
     /// Default inference steps (e.g. 4 for schnell, 25 for dev)
@@ -40,8 +43,8 @@ pub struct ModelConfig {
     /// Whether this model uses a turbo (few-step distilled) schedule.
     /// If None, auto-detected from the model name.
     pub is_turbo: Option<bool>,
-    /// Scheduler type: "ddim", "euler_ancestral" (SDXL only; FLUX uses flow-matching)
-    pub scheduler: Option<String>,
+    /// Scheduler algorithm for UNet-based models (SD1.5, SDXL). Ignored by flow-matching models.
+    pub scheduler: Option<Scheduler>,
 
     // --- metadata ---
     pub description: Option<String>,
@@ -63,6 +66,7 @@ impl ModelConfig {
             &self.clip_encoder_2,
             &self.clip_tokenizer_2,
             &self.text_tokenizer,
+            &self.decoder,
         ];
         for p in singles.into_iter().flatten() {
             paths.push(p.clone());
@@ -118,6 +122,8 @@ pub struct ModelPaths {
     pub text_encoder_files: Vec<PathBuf>,
     /// Generic text encoder tokenizer (Qwen3 for Z-Image)
     pub text_tokenizer: Option<PathBuf>,
+    /// Stage B decoder weights (Wuerstchen only)
+    pub decoder: Option<PathBuf>,
 }
 
 impl ModelPaths {
@@ -168,6 +174,10 @@ impl ModelPaths {
             model_cfg.and_then(|m| m.text_tokenizer.as_deref()),
             "MOLD_TEXT_TOKENIZER_PATH",
         );
+        let decoder = Self::resolve_path(
+            model_cfg.and_then(|m| m.decoder.as_deref()),
+            "MOLD_DECODER_PATH",
+        );
 
         Some(Self {
             transformer,
@@ -181,6 +191,7 @@ impl ModelPaths {
             clip_tokenizer_2,
             text_encoder_files,
             text_tokenizer,
+            decoder,
         })
     }
 

--- a/crates/mold-core/src/lib.rs
+++ b/crates/mold-core/src/lib.rs
@@ -13,5 +13,6 @@ pub use client::MoldClient;
 pub use config::{Config, ModelConfig, ModelPaths};
 pub use error::{MoldError, Result as MoldResult};
 pub use types::GenerateRequest;
+pub use types::Scheduler;
 pub use types::*;
 pub use validation::validate_generate_request;

--- a/crates/mold-core/src/manifest.rs
+++ b/crates/mold-core/src/manifest.rs
@@ -1,4 +1,5 @@
 use crate::config::ModelConfig;
+use crate::types::Scheduler;
 use crate::ModelPaths;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -17,6 +18,7 @@ pub enum ModelComponent {
     ClipTokenizer2, // CLIP-G tokenizer (SDXL)
     TextEncoder,    // Generic text encoder shard (Qwen3 for Z-Image)
     TextTokenizer,  // Generic text encoder tokenizer
+    Decoder,        // Stage B decoder weights (Wuerstchen)
 }
 
 #[derive(Debug, Clone)]
@@ -37,8 +39,8 @@ pub struct ManifestDefaults {
     pub width: u32,
     pub height: u32,
     pub is_schnell: bool,
-    /// Scheduler type: None for FLUX (uses flow-matching), "ddim" or "euler_ancestral" for SDXL.
-    pub scheduler: Option<&'static str>,
+    /// Scheduler algorithm: None for flow-matching models, Some for UNet-based models.
+    pub scheduler: Option<Scheduler>,
 }
 
 #[derive(Debug, Clone)]
@@ -107,13 +109,17 @@ impl ModelManifest {
                 .text_tokenizer
                 .as_ref()
                 .map(|p| p.to_string_lossy().to_string()),
+            decoder: paths
+                .decoder
+                .as_ref()
+                .map(|p| p.to_string_lossy().to_string()),
             default_steps: Some(self.defaults.steps),
             default_guidance: Some(self.defaults.guidance),
             default_width: Some(self.defaults.width),
             default_height: Some(self.defaults.height),
             is_schnell: Some(self.defaults.is_schnell),
             is_turbo: None,
-            scheduler: self.defaults.scheduler.map(|s| s.to_string()),
+            scheduler: self.defaults.scheduler,
             description: Some(self.description.clone()),
             family: Some(self.family.clone()),
         }
@@ -467,6 +473,7 @@ fn build_known_manifests() -> Vec<ModelManifest> {
     manifests.extend(zimage_manifests());
     manifests.extend(flux2_manifests());
     manifests.extend(qwen_image_manifests());
+    manifests.extend(wuerstchen_manifests());
     manifests
 }
 
@@ -724,7 +731,7 @@ fn sd15_manifests() -> Vec<ModelManifest> {
                 width: 512,
                 height: 512,
                 is_schnell: false,
-                scheduler: Some("ddim"),
+                scheduler: Some(Scheduler::Ddim),
             },
         },
         ModelManifest {
@@ -753,7 +760,7 @@ fn sd15_manifests() -> Vec<ModelManifest> {
                 width: 512,
                 height: 512,
                 is_schnell: false,
-                scheduler: Some("ddim"),
+                scheduler: Some(Scheduler::Ddim),
             },
         },
         ModelManifest {
@@ -781,7 +788,7 @@ fn sd15_manifests() -> Vec<ModelManifest> {
                 width: 512,
                 height: 512,
                 is_schnell: false,
-                scheduler: Some("ddim"),
+                scheduler: Some(Scheduler::Ddim),
             },
         },
     ]
@@ -865,7 +872,7 @@ fn sdxl_manifests() -> Vec<ModelManifest> {
                 width: 1024,
                 height: 1024,
                 is_schnell: false,
-                scheduler: Some("ddim"),
+                scheduler: Some(Scheduler::Ddim),
             },
         },
         ModelManifest {
@@ -893,7 +900,7 @@ fn sdxl_manifests() -> Vec<ModelManifest> {
                 width: 1024,
                 height: 1024,
                 is_schnell: false,
-                scheduler: Some("euler_ancestral"),
+                scheduler: Some(Scheduler::EulerAncestral),
             },
         },
         ModelManifest {
@@ -921,7 +928,7 @@ fn sdxl_manifests() -> Vec<ModelManifest> {
                 width: 1024,
                 height: 1024,
                 is_schnell: false,
-                scheduler: Some("ddim"),
+                scheduler: Some(Scheduler::Ddim),
             },
         },
         ModelManifest {
@@ -949,7 +956,7 @@ fn sdxl_manifests() -> Vec<ModelManifest> {
                 width: 1024,
                 height: 1024,
                 is_schnell: false,
-                scheduler: Some("ddim"),
+                scheduler: Some(Scheduler::Ddim),
             },
         },
         ModelManifest {
@@ -977,7 +984,7 @@ fn sdxl_manifests() -> Vec<ModelManifest> {
                 width: 1024,
                 height: 1024,
                 is_schnell: false,
-                scheduler: Some("ddim"),
+                scheduler: Some(Scheduler::Ddim),
             },
         },
         // --- Turbo SDXL (Euler Ancestral, 1-4 steps, guidance 0.0) ---
@@ -1006,7 +1013,7 @@ fn sdxl_manifests() -> Vec<ModelManifest> {
                 width: 512,
                 height: 512,
                 is_schnell: false,
-                scheduler: Some("euler_ancestral"),
+                scheduler: Some(Scheduler::EulerAncestral),
             },
         },
     ]
@@ -1117,7 +1124,7 @@ fn zimage_manifests() -> Vec<ModelManifest> {
                 width: 1024,
                 height: 1024,
                 is_schnell: false,
-                scheduler: Some("flow_match_euler"),
+                scheduler: None,
             },
         },
         // GGUF quantized variants (transformer only; shared components are always BF16)
@@ -1146,7 +1153,7 @@ fn zimage_manifests() -> Vec<ModelManifest> {
                 width: 1024,
                 height: 1024,
                 is_schnell: false,
-                scheduler: Some("flow_match_euler"),
+                scheduler: None,
             },
         },
         ModelManifest {
@@ -1174,7 +1181,7 @@ fn zimage_manifests() -> Vec<ModelManifest> {
                 width: 1024,
                 height: 1024,
                 is_schnell: false,
-                scheduler: Some("flow_match_euler"),
+                scheduler: None,
             },
         },
         ModelManifest {
@@ -1202,7 +1209,7 @@ fn zimage_manifests() -> Vec<ModelManifest> {
                 width: 1024,
                 height: 1024,
                 is_schnell: false,
-                scheduler: Some("flow_match_euler"),
+                scheduler: None,
             },
         },
     ]
@@ -1354,7 +1361,7 @@ fn qwen_image_manifests() -> Vec<ModelManifest> {
         width: 1024,
         height: 1024,
         is_schnell: false,
-        scheduler: Some("flow_match_euler"),
+        scheduler: None,
     };
 
     vec![
@@ -1451,6 +1458,66 @@ fn qwen_image_manifests() -> Vec<ModelManifest> {
             defaults,
         },
     ]
+}
+
+fn wuerstchen_manifests() -> Vec<ModelManifest> {
+    let defaults = ManifestDefaults {
+        steps: 60,
+        guidance: 4.0,
+        width: 1024,
+        height: 1024,
+        is_schnell: false,
+        scheduler: None,
+    };
+    vec![ModelManifest {
+        name: "wuerstchen-v2:fp16".to_string(),
+        family: "wuerstchen".to_string(),
+        description: "Wuerstchen v2 FP16 — 3-stage cascade with 42x latent compression".to_string(),
+        size_gb: 5.6,
+        files: vec![
+            ModelFile {
+                hf_repo: "warp-ai/wuerstchen".to_string(),
+                hf_filename: "model_v2_stage_b.safetensors".to_string(),
+                component: ModelComponent::Decoder,
+                size_bytes: 1_500_000_000,
+                gated: false,
+                sha256: None,
+            },
+            ModelFile {
+                hf_repo: "warp-ai/wuerstchen".to_string(),
+                hf_filename: "vqgan_f4_v1_500k.safetensors".to_string(),
+                component: ModelComponent::Vae,
+                size_bytes: 100_000_000,
+                gated: false,
+                sha256: None,
+            },
+            ModelFile {
+                hf_repo: "warp-ai/wuerstchen-prior".to_string(),
+                hf_filename: "model_v2.safetensors".to_string(),
+                component: ModelComponent::Transformer,
+                size_bytes: 3_000_000_000,
+                gated: false,
+                sha256: None,
+            },
+            ModelFile {
+                hf_repo: "warp-ai/wuerstchen-prior".to_string(),
+                hf_filename: "model_text_encoder.safetensors".to_string(),
+                component: ModelComponent::ClipEncoder2,
+                size_bytes: 800_000_000,
+                gated: false,
+                sha256: None,
+            },
+            ModelFile {
+                hf_repo: "warp-ai/wuerstchen-prior".to_string(),
+                hf_filename: "tokenizer.json".to_string(),
+                component: ModelComponent::ClipTokenizer2,
+                size_bytes: 2_000_000,
+                gated: false,
+                sha256: None,
+            },
+        ],
+        defaults,
+    }]
 }
 
 /// Resolve a user-provided model name to its canonical `name:tag` form.
@@ -1675,6 +1742,7 @@ pub fn paths_from_downloads(downloads: &[(ModelComponent, PathBuf)]) -> Option<M
         clip_tokenizer_2: find(ModelComponent::ClipTokenizer2),
         text_encoder_files: collect(ModelComponent::TextEncoder),
         text_tokenizer: find(ModelComponent::TextTokenizer),
+        decoder: find(ModelComponent::Decoder),
     })
 }
 
@@ -1875,8 +1943,8 @@ mod tests {
 
     #[test]
     fn known_manifests_count() {
-        // 9 FLUX + 3 SD1.5 + 4 SD3 + 6 SDXL + 4 Z-Image + 1 Flux.2 + 4 Qwen-Image = 31
-        assert_eq!(known_manifests().len(), 31);
+        // 9 FLUX + 3 SD1.5 + 4 SD3 + 6 SDXL + 4 Z-Image + 1 Flux.2 + 4 Qwen-Image + 1 Wuerstchen = 32
+        assert_eq!(known_manifests().len(), 32);
     }
 
     #[test]
@@ -2156,7 +2224,7 @@ mod tests {
     #[test]
     fn sdxl_turbo_uses_euler_ancestral() {
         let manifest = find_manifest("sdxl-turbo").unwrap();
-        assert_eq!(manifest.defaults.scheduler, Some("euler_ancestral"));
+        assert_eq!(manifest.defaults.scheduler, Some(Scheduler::EulerAncestral));
         assert_eq!(manifest.defaults.steps, 4);
         assert_eq!(manifest.defaults.guidance, 0.0);
     }
@@ -2164,7 +2232,7 @@ mod tests {
     #[test]
     fn sdxl_base_uses_ddim() {
         let manifest = find_manifest("sdxl-base").unwrap();
-        assert_eq!(manifest.defaults.scheduler, Some("ddim"));
+        assert_eq!(manifest.defaults.scheduler, Some(Scheduler::Ddim));
         assert_eq!(manifest.defaults.steps, 25);
     }
 
@@ -2214,7 +2282,7 @@ mod tests {
     fn sd15_defaults() {
         for manifest in known_manifests() {
             if manifest.family == "sd15" {
-                assert_eq!(manifest.defaults.scheduler, Some("ddim"));
+                assert_eq!(manifest.defaults.scheduler, Some(Scheduler::Ddim));
                 assert_eq!(manifest.defaults.width, 512);
                 assert_eq!(manifest.defaults.height, 512);
             }
@@ -2229,7 +2297,7 @@ mod tests {
         assert_eq!(manifest.defaults.steps, 25);
         assert_eq!(manifest.defaults.width, 512);
         assert_eq!(manifest.defaults.guidance, 7.5);
-        assert_eq!(manifest.defaults.scheduler, Some("ddim"));
+        assert_eq!(manifest.defaults.scheduler, Some(Scheduler::Ddim));
     }
 
     #[test]
@@ -2269,7 +2337,7 @@ mod tests {
         assert_eq!(manifest.family, "z-image");
         assert_eq!(manifest.defaults.steps, 9);
         assert_eq!(manifest.defaults.guidance, 0.0);
-        assert_eq!(manifest.defaults.scheduler, Some("flow_match_euler"));
+        assert_eq!(manifest.defaults.scheduler, None);
     }
 
     // --- Qwen3 variant registry tests ---
@@ -2326,7 +2394,7 @@ mod tests {
             if manifest.family == "z-image" {
                 assert_eq!(manifest.defaults.steps, 9);
                 assert_eq!(manifest.defaults.guidance, 0.0);
-                assert_eq!(manifest.defaults.scheduler, Some("flow_match_euler"));
+                assert_eq!(manifest.defaults.scheduler, None);
             }
         }
     }

--- a/crates/mold-core/src/types.rs
+++ b/crates/mold-core/src/types.rs
@@ -1,5 +1,42 @@
 use serde::{Deserialize, Serialize};
 
+/// Scheduler algorithm for UNet-based diffusion models (SD1.5, SDXL).
+///
+/// Flow-matching models (FLUX, SD3, Z-Image, Flux.2, Qwen-Image) ignore this setting.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum Scheduler {
+    #[default]
+    Ddim,
+    EulerAncestral,
+    UniPc,
+}
+
+impl std::fmt::Display for Scheduler {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Scheduler::Ddim => write!(f, "ddim"),
+            Scheduler::EulerAncestral => write!(f, "euler-ancestral"),
+            Scheduler::UniPc => write!(f, "uni-pc"),
+        }
+    }
+}
+
+impl std::str::FromStr for Scheduler {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "ddim" => Ok(Scheduler::Ddim),
+            "euler-ancestral" | "euler_ancestral" => Ok(Scheduler::EulerAncestral),
+            "uni-pc" | "unipc" | "uni_pc" => Ok(Scheduler::UniPc),
+            other => Err(format!(
+                "unknown scheduler: '{other}'. Valid: ddim, euler-ancestral, uni-pc"
+            )),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct GenerateRequest {
     #[schema(example = "a cat sitting on a windowsill at sunset")]
@@ -23,6 +60,10 @@ pub struct GenerateRequest {
     pub batch_size: u32,
     #[serde(default)]
     pub output_format: OutputFormat,
+    /// Scheduler override for UNet-based models (SD1.5, SDXL).
+    /// Ignored by flow-matching models (FLUX, SD3, Z-Image, Flux.2, Qwen-Image).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scheduler: Option<Scheduler>,
 }
 
 fn default_guidance() -> f64 {
@@ -234,12 +275,14 @@ mod tests {
             seed: Some(42),
             batch_size: 1,
             output_format: OutputFormat::Png,
+            scheduler: None,
         };
         let json = serde_json::to_string(&req).unwrap();
         let back: GenerateRequest = serde_json::from_str(&json).unwrap();
         assert_eq!(back.prompt, req.prompt);
         assert_eq!(back.width, req.width);
         assert_eq!(back.seed, req.seed);
+        assert_eq!(back.scheduler, None);
     }
 
     #[test]
@@ -288,6 +331,57 @@ mod tests {
     #[test]
     fn output_format_default_is_png() {
         assert_eq!(OutputFormat::default(), OutputFormat::Png);
+    }
+
+    #[test]
+    fn scheduler_serde_roundtrip() {
+        let sched = Scheduler::EulerAncestral;
+        let json = serde_json::to_string(&sched).unwrap();
+        assert_eq!(json, r#""euler-ancestral""#);
+        let back: Scheduler = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, sched);
+    }
+
+    #[test]
+    fn scheduler_from_str_aliases() {
+        assert_eq!("ddim".parse::<Scheduler>().unwrap(), Scheduler::Ddim);
+        assert_eq!(
+            "euler-ancestral".parse::<Scheduler>().unwrap(),
+            Scheduler::EulerAncestral
+        );
+        assert_eq!(
+            "euler_ancestral".parse::<Scheduler>().unwrap(),
+            Scheduler::EulerAncestral
+        );
+        assert_eq!("uni-pc".parse::<Scheduler>().unwrap(), Scheduler::UniPc);
+        assert_eq!("unipc".parse::<Scheduler>().unwrap(), Scheduler::UniPc);
+        assert_eq!("uni_pc".parse::<Scheduler>().unwrap(), Scheduler::UniPc);
+    }
+
+    #[test]
+    fn scheduler_from_str_invalid() {
+        assert!("unknown".parse::<Scheduler>().is_err());
+    }
+
+    #[test]
+    fn scheduler_display() {
+        assert_eq!(Scheduler::Ddim.to_string(), "ddim");
+        assert_eq!(Scheduler::EulerAncestral.to_string(), "euler-ancestral");
+        assert_eq!(Scheduler::UniPc.to_string(), "uni-pc");
+    }
+
+    #[test]
+    fn scheduler_default_is_ddim() {
+        assert_eq!(Scheduler::default(), Scheduler::Ddim);
+    }
+
+    #[test]
+    fn generate_request_backward_compat_no_scheduler() {
+        // Existing JSON without scheduler field should deserialize fine
+        let json =
+            r#"{"prompt":"test","model":"test","width":512,"height":512,"steps":4,"batch_size":1}"#;
+        let req: GenerateRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.scheduler, None);
     }
 
     // ── SSE type tests ──────────────────────────────────────────────────────

--- a/crates/mold-core/src/validation.rs
+++ b/crates/mold-core/src/validation.rs
@@ -70,6 +70,7 @@ mod tests {
             seed: Some(42),
             batch_size: 1,
             output_format: OutputFormat::Png,
+            scheduler: None,
         }
     }
 

--- a/crates/mold-inference/src/factory.rs
+++ b/crates/mold-inference/src/factory.rs
@@ -1,5 +1,5 @@
 use anyhow::{bail, Result};
-use mold_core::{Config, ModelPaths};
+use mold_core::{Config, ModelPaths, Scheduler};
 
 use crate::engine::{InferenceEngine, LoadStrategy};
 use crate::flux::FluxEngine;
@@ -8,6 +8,7 @@ use crate::qwen_image::QwenImageEngine;
 use crate::sd15::SD15Engine;
 use crate::sd3::SD3Engine;
 use crate::sdxl::SDXLEngine;
+use crate::wuerstchen::WuerstchenEngine;
 use crate::zimage::ZImageEngine;
 
 /// Determine the model family from config or manifest, defaulting to "flux".
@@ -56,23 +57,27 @@ pub fn create_engine(
             )))
         }
         "sd15" | "sd1.5" | "stable-diffusion-1.5" => {
-            let scheduler_name = model_cfg.scheduler.unwrap_or_else(|| "ddim".to_string());
+            let scheduler = model_cfg.scheduler.unwrap_or(Scheduler::Ddim);
             Ok(Box::new(SD15Engine::new(
                 model_name,
                 paths,
-                scheduler_name,
+                scheduler,
                 load_strategy,
             )))
         }
         "sdxl" => {
-            let scheduler_name = model_cfg.scheduler.unwrap_or_else(|| "ddim".to_string());
-            let is_turbo = model_cfg.is_turbo.unwrap_or_else(|| {
-                scheduler_name == "euler_ancestral" || model_name.contains("turbo")
+            let is_turbo = model_cfg
+                .is_turbo
+                .unwrap_or_else(|| model_name.contains("turbo"));
+            let scheduler = model_cfg.scheduler.unwrap_or(if is_turbo {
+                Scheduler::EulerAncestral
+            } else {
+                Scheduler::Ddim
             });
             Ok(Box::new(SDXLEngine::new(
                 model_name,
                 paths,
-                scheduler_name,
+                scheduler,
                 is_turbo,
                 load_strategy,
             )))
@@ -121,8 +126,13 @@ pub fn create_engine(
             paths,
             load_strategy,
         ))),
+        "wuerstchen" | "wuerstchen-v2" => Ok(Box::new(WuerstchenEngine::new(
+            model_name,
+            paths,
+            load_strategy,
+        ))),
         other => bail!(
-            "unknown model family '{}' for model '{}'. Supported: flux, flux2, sd15, sd3, sdxl, z-image, qwen-image",
+            "unknown model family '{}' for model '{}'. Supported: flux, flux2, sd15, sd3, sdxl, z-image, qwen-image, wuerstchen",
             other,
             model_name
         ),
@@ -147,6 +157,7 @@ mod tests {
             clip_tokenizer_2: None,
             text_encoder_files: vec![],
             text_tokenizer: None,
+            decoder: None,
         }
     }
 
@@ -310,5 +321,51 @@ mod tests {
         assert!(result.is_err());
         let err = format!("{}", result.err().unwrap());
         assert!(err.contains("nosuchfamily"));
+    }
+
+    #[test]
+    fn resolve_family_from_manifest_wuerstchen() {
+        let config = Config::default();
+        assert_eq!(resolve_family("wuerstchen-v2:fp16", &config), "wuerstchen");
+    }
+
+    #[test]
+    fn create_engine_wuerstchen() {
+        let mut config = Config::default();
+        config.models.insert(
+            "my-wuerstchen".to_string(),
+            mold_core::config::ModelConfig {
+                family: Some("wuerstchen".to_string()),
+                ..Default::default()
+            },
+        );
+        let engine = create_engine(
+            "my-wuerstchen".to_string(),
+            dummy_paths(),
+            &config,
+            LoadStrategy::Sequential,
+        )
+        .unwrap();
+        assert_eq!(engine.model_name(), "my-wuerstchen");
+    }
+
+    #[test]
+    fn create_engine_wuerstchen_family_alias() {
+        let mut config = Config::default();
+        config.models.insert(
+            "my-wurst".to_string(),
+            mold_core::config::ModelConfig {
+                family: Some("wuerstchen-v2".to_string()),
+                ..Default::default()
+            },
+        );
+        let engine = create_engine(
+            "my-wurst".to_string(),
+            dummy_paths(),
+            &config,
+            LoadStrategy::Sequential,
+        )
+        .unwrap();
+        assert_eq!(engine.model_name(), "my-wurst");
     }
 }

--- a/crates/mold-inference/src/flux/pipeline.rs
+++ b/crates/mold-inference/src/flux/pipeline.rs
@@ -618,6 +618,10 @@ impl FluxEngine {
 
 impl InferenceEngine for FluxEngine {
     fn generate(&mut self, req: &GenerateRequest) -> Result<GenerateResponse> {
+        if req.scheduler.is_some() {
+            tracing::warn!("scheduler selection not supported for FLUX (flow-matching), ignoring");
+        }
+
         // Sequential mode: load-use-drop each component
         if self.load_strategy == LoadStrategy::Sequential {
             return self.generate_sequential(req);

--- a/crates/mold-inference/src/flux2/pipeline.rs
+++ b/crates/mold-inference/src/flux2/pipeline.rs
@@ -501,6 +501,12 @@ impl Flux2Engine {
 
 impl InferenceEngine for Flux2Engine {
     fn generate(&mut self, req: &GenerateRequest) -> Result<GenerateResponse> {
+        if req.scheduler.is_some() {
+            tracing::warn!(
+                "scheduler selection not supported for Flux.2 (flow-matching), ignoring"
+            );
+        }
+
         // Sequential mode: load-use-drop each component
         if self.load_strategy == LoadStrategy::Sequential {
             return self.generate_sequential(req);

--- a/crates/mold-inference/src/lib.rs
+++ b/crates/mold-inference/src/lib.rs
@@ -9,9 +9,11 @@ mod image;
 pub mod model_registry;
 pub mod progress;
 pub mod qwen_image;
+pub mod scheduler;
 pub mod sd15;
 pub mod sd3;
 pub mod sdxl;
+pub mod wuerstchen;
 pub mod zimage;
 
 pub use engine::{InferenceEngine, LoadStrategy};
@@ -25,4 +27,5 @@ pub use qwen_image::QwenImageEngine;
 pub use sd15::SD15Engine;
 pub use sd3::SD3Engine;
 pub use sdxl::SDXLEngine;
+pub use wuerstchen::WuerstchenEngine;
 pub use zimage::ZImageEngine;

--- a/crates/mold-inference/src/qwen_image/pipeline.rs
+++ b/crates/mold-inference/src/qwen_image/pipeline.rs
@@ -574,6 +574,12 @@ impl QwenImageEngine {
 
 impl InferenceEngine for QwenImageEngine {
     fn generate(&mut self, req: &GenerateRequest) -> Result<GenerateResponse> {
+        if req.scheduler.is_some() {
+            tracing::warn!(
+                "scheduler selection not supported for Qwen-Image (flow-matching), ignoring"
+            );
+        }
+
         // Sequential mode: load-use-drop each component
         if self.load_strategy == LoadStrategy::Sequential {
             return self.generate_sequential(req);
@@ -804,6 +810,7 @@ mod tests {
                 clip_tokenizer_2: None,
                 text_encoder_files: vec![],
                 text_tokenizer: Some(PathBuf::from("/tmp/tokenizer.json")),
+                decoder: None,
             },
             LoadStrategy::Sequential,
         );

--- a/crates/mold-inference/src/scheduler.rs
+++ b/crates/mold-inference/src/scheduler.rs
@@ -1,0 +1,50 @@
+use anyhow::Result;
+use candle_transformers::models::stable_diffusion::{
+    ddim::DDIMSchedulerConfig,
+    euler_ancestral_discrete::EulerAncestralDiscreteSchedulerConfig,
+    schedulers::{PredictionType, Scheduler, SchedulerConfig, TimestepSpacing},
+    uni_pc::UniPCSchedulerConfig,
+};
+use mold_core::Scheduler as MoldScheduler;
+
+/// Build a candle scheduler from a mold `Scheduler` enum value.
+///
+/// `prediction_type` and `is_turbo` come from the model config (e.g. Epsilon
+/// for SD1.5/SDXL, Trailing timesteps for SDXL Turbo).
+pub fn build_scheduler(
+    scheduler: MoldScheduler,
+    inference_steps: usize,
+    prediction_type: PredictionType,
+    is_turbo: bool,
+) -> Result<Box<dyn Scheduler>> {
+    let result = match scheduler {
+        MoldScheduler::Ddim => {
+            let config = DDIMSchedulerConfig {
+                prediction_type,
+                ..Default::default()
+            };
+            config.build(inference_steps)
+        }
+        MoldScheduler::EulerAncestral => {
+            let timestep_spacing = if is_turbo {
+                TimestepSpacing::Trailing
+            } else {
+                TimestepSpacing::Leading
+            };
+            let config = EulerAncestralDiscreteSchedulerConfig {
+                prediction_type,
+                timestep_spacing,
+                ..Default::default()
+            };
+            config.build(inference_steps)
+        }
+        MoldScheduler::UniPc => {
+            let config = UniPCSchedulerConfig {
+                prediction_type,
+                ..Default::default()
+            };
+            config.build(inference_steps)
+        }
+    };
+    result.map_err(|e| anyhow::anyhow!("{e}"))
+}

--- a/crates/mold-inference/src/sd15/pipeline.rs
+++ b/crates/mold-inference/src/sd15/pipeline.rs
@@ -1,7 +1,8 @@
 use anyhow::{bail, Result};
 use candle_core::{DType, Device, Module, Tensor};
 use candle_transformers::models::stable_diffusion;
-use mold_core::{GenerateRequest, GenerateResponse, ImageData, ModelPaths};
+use candle_transformers::models::stable_diffusion::schedulers::PredictionType;
+use mold_core::{GenerateRequest, GenerateResponse, ImageData, ModelPaths, Scheduler};
 use std::time::Instant;
 
 use crate::device::{check_memory_budget, memory_status_string, preflight_memory_check};
@@ -30,7 +31,7 @@ pub struct SD15Engine {
     loaded: Option<LoadedSD15>,
     model_name: String,
     paths: ModelPaths,
-    scheduler_name: String,
+    scheduler: Scheduler,
     progress: ProgressReporter,
     load_strategy: LoadStrategy,
 }
@@ -39,14 +40,14 @@ impl SD15Engine {
     pub fn new(
         model_name: String,
         paths: ModelPaths,
-        scheduler_name: String,
+        scheduler: Scheduler,
         load_strategy: LoadStrategy,
     ) -> Self {
         Self {
             loaded: None,
             model_name,
             paths,
-            scheduler_name,
+            scheduler,
             progress: ProgressReporter::default(),
             load_strategy,
         }
@@ -189,13 +190,18 @@ impl SD15Engine {
         &self,
         unet: &stable_diffusion::unet_2d::UNet2DConditionModel,
         text_embeddings: &Tensor,
-        sd_config: &stable_diffusion::StableDiffusionConfig,
+        sched: Scheduler,
         latents: &mut Tensor,
         guidance: f64,
         steps: u32,
     ) -> Result<()> {
         let use_cfg = guidance > 1.0;
-        let mut scheduler = sd_config.build_scheduler(steps as usize)?;
+        let mut scheduler = crate::scheduler::build_scheduler(
+            sched,
+            steps as usize,
+            PredictionType::Epsilon,
+            false,
+        )?;
         let timesteps = scheduler.timesteps().to_vec();
 
         let denoise_label = format!("Denoising ({} steps)", timesteps.len());
@@ -361,10 +367,17 @@ impl SD15Engine {
         self.progress
             .stage_done("Loading UNet (GPU)", unet_start.elapsed());
 
+        let sched = req.scheduler.unwrap_or(self.scheduler);
         let latent_h = height / 8;
         let latent_w = width / 8;
-        let scheduler = sd_config.build_scheduler(req.steps as usize)?;
-        let init_noise_sigma = scheduler.init_noise_sigma();
+        let init_scheduler = crate::scheduler::build_scheduler(
+            sched,
+            req.steps as usize,
+            PredictionType::Epsilon,
+            false,
+        )?;
+        let init_noise_sigma = init_scheduler.init_noise_sigma();
+        drop(init_scheduler);
         let mut latents =
             (crate::engine::seeded_randn(seed, &[1, 4, latent_h, latent_w], &device, DType::F32)?
                 * init_noise_sigma)?;
@@ -373,7 +386,7 @@ impl SD15Engine {
         self.denoise_loop(
             &unet,
             &text_embeddings,
-            &sd_config,
+            sched,
             &mut latents,
             guidance,
             req.steps,
@@ -455,7 +468,7 @@ impl InferenceEngine for SD15Engine {
             seed, width, height,
             steps = req.steps,
             guidance,
-            scheduler = %self.scheduler_name,
+            scheduler = %self.scheduler,
             "starting SD1.5 generation"
         );
 
@@ -472,10 +485,17 @@ impl InferenceEngine for SD15Engine {
         )?;
 
         // 2. Build scheduler and create initial latents
+        let sched = req.scheduler.unwrap_or(self.scheduler);
         let latent_h = height / 8;
         let latent_w = width / 8;
-        let scheduler = loaded.sd_config.build_scheduler(req.steps as usize)?;
-        let init_noise_sigma = scheduler.init_noise_sigma();
+        let init_scheduler = crate::scheduler::build_scheduler(
+            sched,
+            req.steps as usize,
+            PredictionType::Epsilon,
+            false,
+        )?;
+        let init_noise_sigma = init_scheduler.init_noise_sigma();
+        drop(init_scheduler);
         let mut latents = (crate::engine::seeded_randn(
             seed,
             &[1, 4, latent_h, latent_w],
@@ -488,7 +508,7 @@ impl InferenceEngine for SD15Engine {
         self.denoise_loop(
             &loaded.unet,
             &text_embeddings,
-            &loaded.sd_config,
+            sched,
             &mut latents,
             guidance,
             req.steps,

--- a/crates/mold-inference/src/sd3/pipeline.rs
+++ b/crates/mold-inference/src/sd3/pipeline.rs
@@ -540,6 +540,10 @@ impl SD3Engine {
 
 impl InferenceEngine for SD3Engine {
     fn generate(&mut self, req: &GenerateRequest) -> Result<GenerateResponse> {
+        if req.scheduler.is_some() {
+            tracing::warn!("scheduler selection not supported for SD3 (flow-matching), ignoring");
+        }
+
         // Sequential mode: load-use-drop each component
         if self.load_strategy == LoadStrategy::Sequential {
             return self.generate_sequential(req);

--- a/crates/mold-inference/src/sdxl/pipeline.rs
+++ b/crates/mold-inference/src/sdxl/pipeline.rs
@@ -1,7 +1,8 @@
 use anyhow::{bail, Result};
 use candle_core::{DType, Device, Module, Tensor, D};
 use candle_transformers::models::stable_diffusion;
-use mold_core::{GenerateRequest, GenerateResponse, ImageData, ModelPaths};
+use candle_transformers::models::stable_diffusion::schedulers::PredictionType;
+use mold_core::{GenerateRequest, GenerateResponse, ImageData, ModelPaths, Scheduler};
 use std::time::Instant;
 
 use crate::device::{check_memory_budget, memory_status_string, preflight_memory_check};
@@ -27,7 +28,7 @@ pub struct SDXLEngine {
     loaded: Option<LoadedSDXL>,
     model_name: String,
     paths: ModelPaths,
-    scheduler_name: String,
+    scheduler: Scheduler,
     is_turbo: bool,
     progress: ProgressReporter,
     /// How to load model components (Eager = all at once, Sequential = load-use-drop).
@@ -43,7 +44,7 @@ impl SDXLEngine {
     pub fn new(
         model_name: String,
         paths: ModelPaths,
-        scheduler_name: String,
+        scheduler: Scheduler,
         is_turbo: bool,
         load_strategy: LoadStrategy,
     ) -> Self {
@@ -51,7 +52,7 @@ impl SDXLEngine {
             loaded: None,
             model_name,
             paths,
-            scheduler_name,
+            scheduler,
             is_turbo,
             progress: ProgressReporter::default(),
             load_strategy,
@@ -246,13 +247,18 @@ impl SDXLEngine {
         &self,
         unet: &stable_diffusion::unet_2d::UNet2DConditionModel,
         text_embeddings: &Tensor,
-        sd_config: &stable_diffusion::StableDiffusionConfig,
+        sched: Scheduler,
         latents: &mut Tensor,
         guidance: f64,
         steps: u32,
     ) -> Result<()> {
         let use_cfg = guidance > 1.0;
-        let mut scheduler = sd_config.build_scheduler(steps as usize)?;
+        let mut scheduler = crate::scheduler::build_scheduler(
+            sched,
+            steps as usize,
+            PredictionType::Epsilon,
+            self.is_turbo,
+        )?;
         let timesteps = scheduler.timesteps().to_vec();
 
         let denoise_label = format!("Denoising ({} steps)", timesteps.len());
@@ -457,10 +463,17 @@ impl SDXLEngine {
         self.progress
             .stage_done("Loading UNet (GPU)", unet_start.elapsed());
 
+        let sched = req.scheduler.unwrap_or(self.scheduler);
         let latent_h = height / 8;
         let latent_w = width / 8;
-        let scheduler = sd_config.build_scheduler(req.steps as usize)?;
-        let init_noise_sigma = scheduler.init_noise_sigma();
+        let init_scheduler = crate::scheduler::build_scheduler(
+            sched,
+            req.steps as usize,
+            PredictionType::Epsilon,
+            self.is_turbo,
+        )?;
+        let init_noise_sigma = init_scheduler.init_noise_sigma();
+        drop(init_scheduler);
         let mut latents =
             (crate::engine::seeded_randn(seed, &[1, 4, latent_h, latent_w], &device, DType::F32)?
                 * init_noise_sigma)?;
@@ -469,7 +482,7 @@ impl SDXLEngine {
         self.denoise_loop(
             &unet,
             &text_embeddings,
-            &sd_config,
+            sched,
             &mut latents,
             guidance,
             req.steps,
@@ -557,7 +570,7 @@ impl InferenceEngine for SDXLEngine {
             seed, width, height,
             steps = req.steps,
             guidance,
-            scheduler = %self.scheduler_name,
+            scheduler = %self.scheduler,
             "starting SDXL generation"
         );
 
@@ -576,10 +589,17 @@ impl InferenceEngine for SDXLEngine {
         )?;
 
         // 3. Build scheduler
+        let sched = req.scheduler.unwrap_or(self.scheduler);
         let latent_h = height / 8;
         let latent_w = width / 8;
-        let scheduler = loaded.sd_config.build_scheduler(req.steps as usize)?;
-        let init_noise_sigma = scheduler.init_noise_sigma();
+        let init_scheduler = crate::scheduler::build_scheduler(
+            sched,
+            req.steps as usize,
+            PredictionType::Epsilon,
+            self.is_turbo,
+        )?;
+        let init_noise_sigma = init_scheduler.init_noise_sigma();
+        drop(init_scheduler);
         let mut latents = (crate::engine::seeded_randn(
             seed,
             &[1, 4, latent_h, latent_w],
@@ -592,7 +612,7 @@ impl InferenceEngine for SDXLEngine {
         self.denoise_loop(
             &loaded.unet,
             &text_embeddings,
-            &loaded.sd_config,
+            sched,
             &mut latents,
             guidance,
             req.steps,

--- a/crates/mold-inference/src/wuerstchen/mod.rs
+++ b/crates/mold-inference/src/wuerstchen/mod.rs
@@ -1,0 +1,3 @@
+mod pipeline;
+
+pub use pipeline::WuerstchenEngine;

--- a/crates/mold-inference/src/wuerstchen/pipeline.rs
+++ b/crates/mold-inference/src/wuerstchen/pipeline.rs
@@ -1,0 +1,692 @@
+use anyhow::{bail, Result};
+use candle_core::{DType, Device, Module, Tensor};
+use candle_transformers::models::stable_diffusion;
+use candle_transformers::models::wuerstchen::ddpm::{DDPMWScheduler, DDPMWSchedulerConfig};
+use candle_transformers::models::wuerstchen::diffnext::WDiffNeXt;
+use candle_transformers::models::wuerstchen::paella_vq::PaellaVQ;
+use candle_transformers::models::wuerstchen::prior::WPrior;
+use mold_core::{GenerateRequest, GenerateResponse, ImageData, ModelPaths};
+use std::time::Instant;
+
+use crate::device::{check_memory_budget, memory_status_string, preflight_memory_check};
+use crate::engine::{rand_seed, InferenceEngine, LoadStrategy};
+use crate::image::encode_image;
+use crate::progress::{ProgressCallback, ProgressEvent, ProgressReporter};
+
+/// Wuerstchen v2 prior dimensions.
+const PRIOR_C_IN: usize = 16;
+const PRIOR_C: usize = 1536;
+const PRIOR_C_COND: usize = 1280;
+const PRIOR_C_R: usize = 64;
+const PRIOR_DEPTH: usize = 32;
+const PRIOR_NHEAD: usize = 24;
+
+/// Wuerstchen v2 decoder (Stage B) dimensions.
+const DECODER_C_IN: usize = 4;
+const DECODER_C_OUT: usize = 4;
+const DECODER_C_R: usize = 64;
+const DECODER_C_COND: usize = 1280;
+const DECODER_CLIP_EMBD: usize = 1280;
+const DECODER_PATCH_SIZE: usize = 2;
+
+/// Latent compression ratio for Stage C (prior).
+/// Wuerstchen operates in a 42x compressed latent space.
+const LATENT_DIM_SCALE: f64 = 42.67;
+
+/// Latent compression ratio for Stage B (decoder → VQ-GAN input).
+const STAGE_B_SCALE: usize = 4;
+
+/// Loaded Wuerstchen model components, ready for inference.
+struct LoadedWuerstchen {
+    prior: WPrior,
+    decoder: WDiffNeXt,
+    vqgan: PaellaVQ,
+    clip_g: stable_diffusion::clip::ClipTextTransformer,
+    tokenizer: tokenizers::Tokenizer,
+    device: Device,
+    dtype: DType,
+}
+
+/// Wuerstchen v2 inference engine.
+///
+/// Three-stage cascade: CLIP-G encode -> Prior (Stage C) -> Decoder (Stage B) -> VQ-GAN (Stage A).
+pub struct WuerstchenEngine {
+    loaded: Option<LoadedWuerstchen>,
+    model_name: String,
+    paths: ModelPaths,
+    progress: ProgressReporter,
+    load_strategy: LoadStrategy,
+}
+
+impl WuerstchenEngine {
+    pub fn new(model_name: String, paths: ModelPaths, load_strategy: LoadStrategy) -> Self {
+        Self {
+            loaded: None,
+            model_name,
+            paths,
+            progress: ProgressReporter::default(),
+            load_strategy,
+        }
+    }
+
+    /// Validate and return required Wuerstchen paths.
+    fn validate_paths(
+        &self,
+    ) -> Result<(std::path::PathBuf, std::path::PathBuf, std::path::PathBuf)> {
+        let decoder = self
+            .paths
+            .decoder
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("Decoder (Stage B) path required for Wuerstchen"))?
+            .clone();
+        let clip_encoder = self
+            .paths
+            .clip_encoder_2
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("CLIP-G encoder path required for Wuerstchen"))?
+            .clone();
+        let clip_tokenizer = self
+            .paths
+            .clip_tokenizer_2
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("CLIP-G tokenizer path required for Wuerstchen"))?
+            .clone();
+
+        for (label, path) in [
+            ("prior (Stage C)", &self.paths.transformer),
+            ("decoder (Stage B)", &decoder),
+            ("vqgan (Stage A)", &self.paths.vae),
+            ("clip_encoder (CLIP-G)", &clip_encoder),
+            ("clip_tokenizer (CLIP-G)", &clip_tokenizer),
+        ] {
+            if !path.exists() {
+                bail!("{label} file not found: {}", path.display());
+            }
+        }
+
+        Ok((decoder, clip_encoder, clip_tokenizer))
+    }
+
+    /// Load all Wuerstchen model components (Eager mode).
+    pub fn load(&mut self) -> Result<()> {
+        if self.loaded.is_some() {
+            return Ok(());
+        }
+
+        if self.load_strategy == LoadStrategy::Sequential {
+            return Ok(());
+        }
+
+        let (decoder_path, clip_encoder_path, clip_tokenizer_path) = self.validate_paths()?;
+
+        tracing::info!(model = %self.model_name, "loading Wuerstchen model components...");
+
+        let device = crate::device::create_device(&self.progress)?;
+        let dtype = if device.is_cuda() || device.is_metal() {
+            DType::F16
+        } else {
+            DType::F32
+        };
+
+        // Load Prior (Stage C)
+        self.progress.stage_start("Loading Prior (Stage C)");
+        let prior_start = Instant::now();
+        let prior_vb = unsafe {
+            candle_nn::VarBuilder::from_mmaped_safetensors(
+                &[&self.paths.transformer],
+                dtype,
+                &device,
+            )?
+        };
+        let prior = WPrior::new(
+            PRIOR_C_IN,
+            PRIOR_C,
+            PRIOR_C_COND,
+            PRIOR_C_R,
+            PRIOR_DEPTH,
+            PRIOR_NHEAD,
+            false,
+            prior_vb,
+        )?;
+        self.progress
+            .stage_done("Loading Prior (Stage C)", prior_start.elapsed());
+
+        // Load Decoder (Stage B)
+        self.progress.stage_start("Loading Decoder (Stage B)");
+        let decoder_start = Instant::now();
+        let decoder_vb = unsafe {
+            candle_nn::VarBuilder::from_mmaped_safetensors(&[&decoder_path], dtype, &device)?
+        };
+        let decoder = WDiffNeXt::new(
+            DECODER_C_IN,
+            DECODER_C_OUT,
+            DECODER_C_R,
+            DECODER_C_COND,
+            DECODER_CLIP_EMBD,
+            DECODER_PATCH_SIZE,
+            false,
+            decoder_vb,
+        )?;
+        self.progress
+            .stage_done("Loading Decoder (Stage B)", decoder_start.elapsed());
+
+        // Load VQ-GAN (Stage A)
+        self.progress.stage_start("Loading VQ-GAN (Stage A)");
+        let vqgan_start = Instant::now();
+        let vqgan_vb = unsafe {
+            candle_nn::VarBuilder::from_mmaped_safetensors(&[&self.paths.vae], dtype, &device)?
+        };
+        let vqgan = PaellaVQ::new(vqgan_vb)?;
+        self.progress
+            .stage_done("Loading VQ-GAN (Stage A)", vqgan_start.elapsed());
+
+        // Load CLIP-G encoder
+        self.progress.stage_start("Loading CLIP-G encoder");
+        let clip_start = Instant::now();
+        let clip_config = stable_diffusion::clip::Config::wuerstchen_prior();
+        let clip_g = stable_diffusion::build_clip_transformer(
+            &clip_config,
+            &clip_encoder_path,
+            &device,
+            DType::F32,
+        )?;
+        self.progress
+            .stage_done("Loading CLIP-G encoder", clip_start.elapsed());
+
+        // Load tokenizer
+        let tokenizer = tokenizers::Tokenizer::from_file(&clip_tokenizer_path)
+            .map_err(|e| anyhow::anyhow!("failed to load CLIP-G tokenizer: {e}"))?;
+
+        self.loaded = Some(LoadedWuerstchen {
+            prior,
+            decoder,
+            vqgan,
+            clip_g,
+            tokenizer,
+            device,
+            dtype,
+        });
+
+        tracing::info!(model = %self.model_name, "all Wuerstchen components loaded successfully");
+        Ok(())
+    }
+
+    /// Tokenize a prompt for the CLIP-G encoder.
+    fn tokenize(
+        tokenizer: &tokenizers::Tokenizer,
+        prompt: &str,
+        max_len: usize,
+        device: &Device,
+    ) -> Result<Tensor> {
+        let encoding = tokenizer
+            .encode(prompt, true)
+            .map_err(|e| anyhow::anyhow!("tokenization failed: {e}"))?;
+        let mut ids = encoding.get_ids().to_vec();
+        ids.truncate(max_len);
+        while ids.len() < max_len {
+            ids.push(49407); // CLIP EOS/PAD token
+        }
+        let ids = ids.into_iter().map(|i| i as i64).collect::<Vec<_>>();
+        Ok(Tensor::new(ids, device)?.unsqueeze(0)?)
+    }
+
+    /// Run the Stage C (Prior) denoising loop.
+    fn denoise_prior(
+        &self,
+        prior: &WPrior,
+        text_embeddings: &Tensor,
+        latents: &mut Tensor,
+        steps: usize,
+        guidance: f64,
+        device: &Device,
+    ) -> Result<()> {
+        let use_cfg = guidance > 1.0;
+        let scheduler = DDPMWScheduler::new(steps, DDPMWSchedulerConfig::default())?;
+        let timesteps = scheduler.timesteps().to_vec();
+
+        let label = format!("Stage C Prior ({} steps)", timesteps.len() - 1);
+        self.progress.stage_start(&label);
+        let start = Instant::now();
+
+        for (step_idx, &t) in timesteps.iter().enumerate() {
+            if step_idx + 1 >= timesteps.len() {
+                break; // last timestep is 0.0, not used for denoising
+            }
+            let step_start = Instant::now();
+
+            let r = Tensor::new(&[t], device)?.to_dtype(latents.dtype())?;
+
+            let noise_pred = if use_cfg {
+                let latent_input = Tensor::cat(&[&*latents, &*latents], 0)?;
+                let r_input = Tensor::cat(&[&r, &r], 0)?;
+                let uncond = Tensor::zeros_like(text_embeddings)?;
+                let c_input = Tensor::cat(&[&uncond, text_embeddings], 0)?;
+                let pred = prior.forward(&latent_input, &r_input, &c_input)?;
+                let chunks = pred.chunk(2, 0)?;
+                let pred_uncond = &chunks[0];
+                let pred_cond = &chunks[1];
+                (pred_uncond + ((pred_cond - pred_uncond)? * guidance)?)?
+            } else {
+                prior.forward(&*latents, &r, text_embeddings)?
+            };
+
+            *latents = scheduler.step(&noise_pred, t, &*latents)?;
+
+            self.progress.emit(ProgressEvent::DenoiseStep {
+                step: step_idx + 1,
+                total: timesteps.len() - 1,
+                elapsed: step_start.elapsed(),
+            });
+        }
+
+        self.progress.stage_done(&label, start.elapsed());
+        Ok(())
+    }
+
+    /// Run the Stage B (Decoder) denoising loop.
+    fn denoise_decoder(
+        &self,
+        decoder: &WDiffNeXt,
+        text_embeddings: &Tensor,
+        latents: &mut Tensor,
+        steps: usize,
+        guidance: f64,
+        device: &Device,
+    ) -> Result<()> {
+        let use_cfg = guidance > 1.0;
+        let scheduler = DDPMWScheduler::new(steps, DDPMWSchedulerConfig::default())?;
+        let timesteps = scheduler.timesteps().to_vec();
+
+        // EfficientNet features: pass zeros (matching candle example approach)
+        let effnet = Tensor::zeros(
+            (1, 16, latents.dim(2)?, latents.dim(3)?),
+            latents.dtype(),
+            device,
+        )?;
+
+        let label = format!("Stage B Decoder ({} steps)", timesteps.len() - 1);
+        self.progress.stage_start(&label);
+        let start = Instant::now();
+
+        for (step_idx, &t) in timesteps.iter().enumerate() {
+            if step_idx + 1 >= timesteps.len() {
+                break;
+            }
+            let step_start = Instant::now();
+
+            let r = Tensor::new(&[t], device)?.to_dtype(latents.dtype())?;
+
+            let noise_pred = if use_cfg {
+                let latent_input = Tensor::cat(&[&*latents, &*latents], 0)?;
+                let r_input = Tensor::cat(&[&r, &r], 0)?;
+                let effnet_input = Tensor::cat(&[&effnet, &effnet], 0)?;
+                let uncond = Tensor::zeros_like(text_embeddings)?;
+                let c_input = Tensor::cat(&[&uncond, text_embeddings], 0)?;
+                let pred =
+                    decoder.forward(&latent_input, &r_input, &effnet_input, Some(&c_input))?;
+                let chunks = pred.chunk(2, 0)?;
+                let pred_uncond = &chunks[0];
+                let pred_cond = &chunks[1];
+                (pred_uncond + ((pred_cond - pred_uncond)? * guidance)?)?
+            } else {
+                decoder.forward(&*latents, &r, &effnet, Some(text_embeddings))?
+            };
+
+            *latents = scheduler.step(&noise_pred, t, &*latents)?;
+
+            self.progress.emit(ProgressEvent::DenoiseStep {
+                step: step_idx + 1,
+                total: timesteps.len() - 1,
+                elapsed: step_start.elapsed(),
+            });
+        }
+
+        self.progress.stage_done(&label, start.elapsed());
+        Ok(())
+    }
+
+    /// Generate an image using sequential loading strategy.
+    fn generate_sequential(&mut self, req: &GenerateRequest) -> Result<GenerateResponse> {
+        let (decoder_path, clip_encoder_path, clip_tokenizer_path) = self.validate_paths()?;
+
+        if let Some(warning) = check_memory_budget(&self.paths, LoadStrategy::Sequential) {
+            self.progress.info(&warning);
+        }
+
+        let device = crate::device::create_device(&self.progress)?;
+        let dtype = if device.is_cuda() || device.is_metal() {
+            DType::F16
+        } else {
+            DType::F32
+        };
+
+        let start = Instant::now();
+        let seed = req.seed.unwrap_or_else(rand_seed);
+        let width = req.width as usize;
+        let height = req.height as usize;
+        let guidance = req.guidance;
+        let prior_steps = req.steps as usize;
+        let decoder_steps = 12;
+
+        tracing::info!(
+            prompt = %req.prompt,
+            seed, width, height,
+            prior_steps,
+            decoder_steps,
+            guidance,
+            "starting sequential Wuerstchen generation"
+        );
+
+        self.progress
+            .info("Using sequential loading (load-use-drop) to minimize peak memory");
+
+        // --- Phase 1: CLIP-G encode ---
+        if let Some(status) = memory_status_string() {
+            self.progress.info(&status);
+        }
+
+        let tokenizer = tokenizers::Tokenizer::from_file(&clip_tokenizer_path)
+            .map_err(|e| anyhow::anyhow!("failed to load CLIP-G tokenizer: {e}"))?;
+
+        self.progress.stage_start("Loading CLIP-G encoder");
+        let clip_start = Instant::now();
+        let clip_config = stable_diffusion::clip::Config::wuerstchen_prior();
+        let clip_g = stable_diffusion::build_clip_transformer(
+            &clip_config,
+            &clip_encoder_path,
+            &device,
+            DType::F32,
+        )?;
+        self.progress
+            .stage_done("Loading CLIP-G encoder", clip_start.elapsed());
+
+        self.progress.stage_start("Encoding prompt (CLIP-G)");
+        let encode_start = Instant::now();
+        let tokens = Self::tokenize(
+            &tokenizer,
+            &req.prompt,
+            clip_config.max_position_embeddings,
+            &device,
+        )?;
+        let text_embeddings = clip_g.forward(&tokens)?.to_dtype(dtype)?;
+        self.progress
+            .stage_done("Encoding prompt (CLIP-G)", encode_start.elapsed());
+
+        drop(clip_g);
+        self.progress.info("Freed CLIP-G encoder");
+        tracing::info!("CLIP-G encoder dropped (sequential mode)");
+
+        // --- Phase 2: Prior (Stage C) ---
+        let prior_size = std::fs::metadata(&self.paths.transformer)
+            .map(|m| m.len())
+            .unwrap_or(0);
+        preflight_memory_check("Prior (Stage C)", prior_size)?;
+        if let Some(status) = memory_status_string() {
+            self.progress.info(&status);
+        }
+
+        self.progress.stage_start("Loading Prior (Stage C)");
+        let prior_start = Instant::now();
+        let prior_vb = unsafe {
+            candle_nn::VarBuilder::from_mmaped_safetensors(
+                &[&self.paths.transformer],
+                dtype,
+                &device,
+            )?
+        };
+        let prior = WPrior::new(
+            PRIOR_C_IN,
+            PRIOR_C,
+            PRIOR_C_COND,
+            PRIOR_C_R,
+            PRIOR_DEPTH,
+            PRIOR_NHEAD,
+            false,
+            prior_vb,
+        )?;
+        self.progress
+            .stage_done("Loading Prior (Stage C)", prior_start.elapsed());
+
+        // Stage C latent dimensions: 42x compression
+        let latent_h = (height as f64 / LATENT_DIM_SCALE).ceil() as usize;
+        let latent_w = (width as f64 / LATENT_DIM_SCALE).ceil() as usize;
+        let mut prior_latents = crate::engine::seeded_randn(
+            seed,
+            &[1, PRIOR_C_IN, latent_h, latent_w],
+            &device,
+            dtype,
+        )?;
+
+        self.denoise_prior(
+            &prior,
+            &text_embeddings,
+            &mut prior_latents,
+            prior_steps,
+            guidance,
+            &device,
+        )?;
+
+        drop(prior);
+        device.synchronize()?;
+        self.progress.info("Freed Prior (Stage C)");
+
+        // --- Phase 3: Decoder (Stage B) ---
+        let decoder_size = std::fs::metadata(&decoder_path)
+            .map(|m| m.len())
+            .unwrap_or(0);
+        preflight_memory_check("Decoder (Stage B)", decoder_size)?;
+        if let Some(status) = memory_status_string() {
+            self.progress.info(&status);
+        }
+
+        self.progress.stage_start("Loading Decoder (Stage B)");
+        let dec_start = Instant::now();
+        let decoder_vb = unsafe {
+            candle_nn::VarBuilder::from_mmaped_safetensors(&[&decoder_path], dtype, &device)?
+        };
+        let decoder = WDiffNeXt::new(
+            DECODER_C_IN,
+            DECODER_C_OUT,
+            DECODER_C_R,
+            DECODER_C_COND,
+            DECODER_CLIP_EMBD,
+            DECODER_PATCH_SIZE,
+            false,
+            decoder_vb,
+        )?;
+        self.progress
+            .stage_done("Loading Decoder (Stage B)", dec_start.elapsed());
+
+        let stage_b_h = latent_h * STAGE_B_SCALE;
+        let stage_b_w = latent_w * STAGE_B_SCALE;
+        let mut decoder_latents =
+            crate::engine::seeded_randn(seed + 1, &[1, 4, stage_b_h, stage_b_w], &device, dtype)?;
+
+        self.denoise_decoder(
+            &decoder,
+            &text_embeddings,
+            &mut decoder_latents,
+            decoder_steps,
+            guidance,
+            &device,
+        )?;
+
+        drop(decoder);
+        drop(text_embeddings);
+        device.synchronize()?;
+        self.progress.info("Freed Decoder (Stage B)");
+
+        // --- Phase 4: VQ-GAN decode (Stage A) ---
+        self.progress.stage_start("Loading VQ-GAN (Stage A)");
+        let vqgan_start = Instant::now();
+        let vqgan_vb = unsafe {
+            candle_nn::VarBuilder::from_mmaped_safetensors(&[&self.paths.vae], dtype, &device)?
+        };
+        let vqgan = PaellaVQ::new(vqgan_vb)?;
+        self.progress
+            .stage_done("Loading VQ-GAN (Stage A)", vqgan_start.elapsed());
+
+        self.progress.stage_start("VQ-GAN decode");
+        let decode_start = Instant::now();
+        let img = vqgan.decode(&decoder_latents)?;
+        let img = img.clamp(0f32, 1f32)?;
+        let img = (img * 255.)?.to_dtype(DType::U8)?;
+        let img = img.squeeze(0)?;
+        self.progress
+            .stage_done("VQ-GAN decode", decode_start.elapsed());
+
+        let image_bytes = encode_image(&img, req.output_format, req.width, req.height)?;
+
+        let generation_time_ms = start.elapsed().as_millis() as u64;
+        tracing::info!(
+            generation_time_ms,
+            seed,
+            "sequential Wuerstchen generation complete"
+        );
+
+        Ok(GenerateResponse {
+            images: vec![ImageData {
+                data: image_bytes,
+                format: req.output_format,
+                width: req.width,
+                height: req.height,
+                index: 0,
+            }],
+            generation_time_ms,
+            model: req.model.clone(),
+            seed_used: seed,
+        })
+    }
+}
+
+impl InferenceEngine for WuerstchenEngine {
+    fn generate(&mut self, req: &GenerateRequest) -> Result<GenerateResponse> {
+        if req.scheduler.is_some() {
+            tracing::warn!("scheduler selection not supported for Wuerstchen, ignoring");
+        }
+
+        if self.load_strategy == LoadStrategy::Sequential {
+            return self.generate_sequential(req);
+        }
+
+        let loaded = self
+            .loaded
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("model not loaded — call load() first"))?;
+
+        let start = Instant::now();
+        let seed = req.seed.unwrap_or_else(rand_seed);
+        let width = req.width as usize;
+        let height = req.height as usize;
+        let guidance = req.guidance;
+        let prior_steps = req.steps as usize;
+        let decoder_steps = 12;
+
+        tracing::info!(
+            prompt = %req.prompt,
+            seed, width, height,
+            prior_steps,
+            decoder_steps,
+            guidance,
+            "starting Wuerstchen generation"
+        );
+
+        // 1. Encode prompt with CLIP-G
+        let clip_config = stable_diffusion::clip::Config::wuerstchen_prior();
+        let max_len = clip_config.max_position_embeddings;
+
+        self.progress.stage_start("Encoding prompt (CLIP-G)");
+        let encode_start = Instant::now();
+        let tokens = Self::tokenize(&loaded.tokenizer, &req.prompt, max_len, &loaded.device)?;
+        let text_embeddings = loaded.clip_g.forward(&tokens)?.to_dtype(loaded.dtype)?;
+        self.progress
+            .stage_done("Encoding prompt (CLIP-G)", encode_start.elapsed());
+
+        // 2. Stage C (Prior): denoise in highly compressed latent space
+        let latent_h = (height as f64 / LATENT_DIM_SCALE).ceil() as usize;
+        let latent_w = (width as f64 / LATENT_DIM_SCALE).ceil() as usize;
+        let mut prior_latents = crate::engine::seeded_randn(
+            seed,
+            &[1, PRIOR_C_IN, latent_h, latent_w],
+            &loaded.device,
+            loaded.dtype,
+        )?;
+
+        self.denoise_prior(
+            &loaded.prior,
+            &text_embeddings,
+            &mut prior_latents,
+            prior_steps,
+            guidance,
+            &loaded.device,
+        )?;
+
+        // 3. Stage B (Decoder): decode prior latents to VQ-GAN latent space
+        let stage_b_h = latent_h * STAGE_B_SCALE;
+        let stage_b_w = latent_w * STAGE_B_SCALE;
+        let mut decoder_latents = crate::engine::seeded_randn(
+            seed + 1,
+            &[1, 4, stage_b_h, stage_b_w],
+            &loaded.device,
+            loaded.dtype,
+        )?;
+
+        self.denoise_decoder(
+            &loaded.decoder,
+            &text_embeddings,
+            &mut decoder_latents,
+            decoder_steps,
+            guidance,
+            &loaded.device,
+        )?;
+
+        // 4. Stage A (VQ-GAN): decode to pixel space
+        self.progress.stage_start("VQ-GAN decode");
+        let decode_start = Instant::now();
+        let img = loaded.vqgan.decode(&decoder_latents)?;
+        let img = img.clamp(0f32, 1f32)?;
+        let img = (img * 255.)?.to_dtype(DType::U8)?;
+        let img = img.squeeze(0)?;
+        self.progress
+            .stage_done("VQ-GAN decode", decode_start.elapsed());
+
+        // 5. Encode to image format
+        let image_bytes = encode_image(&img, req.output_format, req.width, req.height)?;
+
+        let generation_time_ms = start.elapsed().as_millis() as u64;
+        tracing::info!(generation_time_ms, seed, "Wuerstchen generation complete");
+
+        Ok(GenerateResponse {
+            images: vec![ImageData {
+                data: image_bytes,
+                format: req.output_format,
+                width: req.width,
+                height: req.height,
+                index: 0,
+            }],
+            generation_time_ms,
+            model: req.model.clone(),
+            seed_used: seed,
+        })
+    }
+
+    fn model_name(&self) -> &str {
+        &self.model_name
+    }
+
+    fn is_loaded(&self) -> bool {
+        self.load_strategy == LoadStrategy::Sequential || self.loaded.is_some()
+    }
+
+    fn load(&mut self) -> Result<()> {
+        WuerstchenEngine::load(self)
+    }
+
+    fn unload(&mut self) {
+        self.loaded = None;
+    }
+
+    fn set_on_progress(&mut self, callback: ProgressCallback) {
+        self.progress.set_callback(callback);
+    }
+}

--- a/crates/mold-inference/src/zimage/pipeline.rs
+++ b/crates/mold-inference/src/zimage/pipeline.rs
@@ -591,6 +591,12 @@ impl ZImageEngine {
 
 impl InferenceEngine for ZImageEngine {
     fn generate(&mut self, req: &GenerateRequest) -> Result<GenerateResponse> {
+        if req.scheduler.is_some() {
+            tracing::warn!(
+                "scheduler selection not supported for Z-Image (flow-matching), ignoring"
+            );
+        }
+
         // Sequential mode: load-use-drop each component
         if self.load_strategy == LoadStrategy::Sequential {
             return self.generate_sequential(req);


### PR DESCRIPTION
## Summary
- Add Wuerstchen v2 as the 8th model family (`wuerstchen-v2:fp16`) with three-stage cascade architecture (42x latent compression)
- Stage C (WPrior): text-conditioned prior, DDPM scheduler, ~60 steps
- Stage B (WDiffNeXt): decoder, DDPM scheduler, ~12 steps, EfficientNet features = zeros
- Stage A (PaellaVQ): VQ-GAN pixel-space decoder
- CLIP-G text encoder (1280-dim, 32 layers via `wuerstchen_prior()` config)
- Both eager and sequential load strategies supported
- Add `decoder` field to `ModelConfig`/`ModelPaths` for Stage B weights
- Add `Decoder` variant to `ModelComponent` enum and wire into manifest/download/info systems
- Register `wuerstchen-v2:fp16` manifest with HF sources (`warp-ai/wuerstchen`, `warp-ai/wuerstchen-prior`)
- Also includes `Scheduler` enum for UNet-based scheduler selection (DDIM, Euler Ancestral, UniPC)

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all --check` passes
- [x] `cargo test --workspace` passes (all 185 tests including 3 new Wuerstchen factory tests)
- [ ] End-to-end: `mold pull wuerstchen-v2:fp16 && mold run wuerstchen-v2:fp16 "a cat"` (requires GPU)

Closes #19