### PR TITLE
feat(inference): add scheduler selection for UNet-based models

### DIFF
--- a/crates/mold-cli/src/commands/generate.rs
+++ b/crates/mold-cli/src/commands/generate.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use colored::Colorize;
 use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle};
 use mold_core::{
-    Config, GenerateRequest, GenerateResponse, ImageData, MoldClient, OutputFormat,
+    Config, GenerateRequest, GenerateResponse, ImageData, MoldClient, OutputFormat, Scheduler,
     SseProgressEvent,
 };
 use rand::Rng;
@@ -28,6 +28,7 @@ pub async fn run(
     local: bool,
     t5_variant: Option<String>,
     qwen3_variant: Option<String>,
+    scheduler: Option<Scheduler>,
     eager: bool,
 ) -> Result<()> {
     let output_format = format;
@@ -79,6 +80,7 @@ pub async fn run(
         seed,
         batch_size: batch,
         output_format,
+        scheduler,
     };
 
     if let Some(desc) = &model_cfg.description {

--- a/crates/mold-cli/src/commands/run.rs
+++ b/crates/mold-cli/src/commands/run.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use clap_complete::engine::CompletionCandidate;
 use mold_core::manifest::{all_model_names, is_known_model, resolve_model_name};
-use mold_core::{Config, OutputFormat};
+use mold_core::{Config, OutputFormat, Scheduler};
 use std::io::{IsTerminal, Read};
 
 use super::generate;
@@ -62,6 +62,7 @@ pub async fn run(
     local: bool,
     t5_variant: Option<String>,
     qwen3_variant: Option<String>,
+    scheduler: Option<Scheduler>,
     eager: bool,
 ) -> Result<()> {
     let config = Config::load_or_default();
@@ -107,6 +108,7 @@ pub async fn run(
         local,
         t5_variant,
         qwen3_variant,
+        scheduler,
         eager,
     )
     .await

--- a/crates/mold-cli/src/main.rs
+++ b/crates/mold-cli/src/main.rs
@@ -3,7 +3,7 @@ mod output;
 
 use clap::{CommandFactory, Parser, Subcommand};
 use clap_complete::engine::ArgValueCandidates;
-use mold_core::OutputFormat;
+use mold_core::{OutputFormat, Scheduler};
 
 #[derive(Clone, clap::ValueEnum)]
 enum LogFormat {
@@ -109,6 +109,11 @@ Examples:
         /// Qwen3 text encoder variant (Z-Image): auto (default), bf16, q8, q6, iq4, q3
         #[arg(long, help_heading = "Advanced")]
         qwen3_variant: Option<String>,
+
+        /// Scheduler algorithm for UNet models: ddim, euler-ancestral, uni-pc
+        /// Ignored by flow-matching models (FLUX, SD3, Z-Image, Flux.2, Qwen-Image).
+        #[arg(long, env = "MOLD_SCHEDULER", help_heading = "Advanced")]
+        scheduler: Option<Scheduler>,
 
         /// Keep all model components loaded simultaneously (faster but uses more memory).
         /// By default, components are loaded and unloaded sequentially to reduce peak memory.
@@ -308,6 +313,7 @@ async fn run() -> anyhow::Result<()> {
             local,
             t5_variant,
             qwen3_variant,
+            scheduler,
             eager,
         } => {
             commands::run::run(
@@ -325,6 +331,7 @@ async fn run() -> anyhow::Result<()> {
                 local,
                 t5_variant,
                 qwen3_variant,
+                scheduler,
                 eager,
             )
             .await?;

--- a/crates/mold-core/src/config.rs
+++ b/crates/mold-core/src/config.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use crate::manifest::resolve_model_name;
+use crate::types::Scheduler;
 
 /// Per-model file path + default settings configuration.
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
@@ -40,8 +41,8 @@ pub struct ModelConfig {
     /// Whether this model uses a turbo (few-step distilled) schedule.
     /// If None, auto-detected from the model name.
     pub is_turbo: Option<bool>,
-    /// Scheduler type: "ddim", "euler_ancestral" (SDXL only; FLUX uses flow-matching)
-    pub scheduler: Option<String>,
+    /// Scheduler algorithm for UNet-based models (SD1.5, SDXL). Ignored by flow-matching models.
+    pub scheduler: Option<Scheduler>,
 
     // --- metadata ---
     pub description: Option<String>,

--- a/crates/mold-core/src/lib.rs
+++ b/crates/mold-core/src/lib.rs
@@ -13,5 +13,6 @@ pub use client::MoldClient;
 pub use config::{Config, ModelConfig, ModelPaths};
 pub use error::{MoldError, Result as MoldResult};
 pub use types::GenerateRequest;
+pub use types::Scheduler;
 pub use types::*;
 pub use validation::validate_generate_request;

--- a/crates/mold-core/src/manifest.rs
+++ b/crates/mold-core/src/manifest.rs
@@ -1,4 +1,5 @@
 use crate::config::ModelConfig;
+use crate::types::Scheduler;
 use crate::ModelPaths;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -37,8 +38,8 @@ pub struct ManifestDefaults {
     pub width: u32,
     pub height: u32,
     pub is_schnell: bool,
-    /// Scheduler type: None for FLUX (uses flow-matching), "ddim" or "euler_ancestral" for SDXL.
-    pub scheduler: Option<&'static str>,
+    /// Scheduler algorithm: None for flow-matching models, Some for UNet-based models.
+    pub scheduler: Option<Scheduler>,
 }
 
 #[derive(Debug, Clone)]
@@ -113,7 +114,7 @@ impl ModelManifest {
             default_height: Some(self.defaults.height),
             is_schnell: Some(self.defaults.is_schnell),
             is_turbo: None,
-            scheduler: self.defaults.scheduler.map(|s| s.to_string()),
+            scheduler: self.defaults.scheduler,
             description: Some(self.description.clone()),
             family: Some(self.family.clone()),
         }
@@ -724,7 +725,7 @@ fn sd15_manifests() -> Vec<ModelManifest> {
                 width: 512,
                 height: 512,
                 is_schnell: false,
-                scheduler: Some("ddim"),
+                scheduler: Some(Scheduler::Ddim),
             },
         },
         ModelManifest {
@@ -753,7 +754,7 @@ fn sd15_manifests() -> Vec<ModelManifest> {
                 width: 512,
                 height: 512,
                 is_schnell: false,
-                scheduler: Some("ddim"),
+                scheduler: Some(Scheduler::Ddim),
             },
         },
         ModelManifest {
@@ -781,7 +782,7 @@ fn sd15_manifests() -> Vec<ModelManifest> {
                 width: 512,
                 height: 512,
                 is_schnell: false,
-                scheduler: Some("ddim"),
+                scheduler: Some(Scheduler::Ddim),
             },
         },
     ]
@@ -865,7 +866,7 @@ fn sdxl_manifests() -> Vec<ModelManifest> {
                 width: 1024,
                 height: 1024,
                 is_schnell: false,
-                scheduler: Some("ddim"),
+                scheduler: Some(Scheduler::Ddim),
             },
         },
         ModelManifest {
@@ -893,7 +894,7 @@ fn sdxl_manifests() -> Vec<ModelManifest> {
                 width: 1024,
                 height: 1024,
                 is_schnell: false,
-                scheduler: Some("euler_ancestral"),
+                scheduler: Some(Scheduler::EulerAncestral),
             },
         },
         ModelManifest {
@@ -921,7 +922,7 @@ fn sdxl_manifests() -> Vec<ModelManifest> {
                 width: 1024,
                 height: 1024,
                 is_schnell: false,
-                scheduler: Some("ddim"),
+                scheduler: Some(Scheduler::Ddim),
             },
         },
         ModelManifest {
@@ -949,7 +950,7 @@ fn sdxl_manifests() -> Vec<ModelManifest> {
                 width: 1024,
                 height: 1024,
                 is_schnell: false,
-                scheduler: Some("ddim"),
+                scheduler: Some(Scheduler::Ddim),
             },
         },
         ModelManifest {
@@ -977,7 +978,7 @@ fn sdxl_manifests() -> Vec<ModelManifest> {
                 width: 1024,
                 height: 1024,
                 is_schnell: false,
-                scheduler: Some("ddim"),
+                scheduler: Some(Scheduler::Ddim),
             },
         },
         // --- Turbo SDXL (Euler Ancestral, 1-4 steps, guidance 0.0) ---
@@ -1006,7 +1007,7 @@ fn sdxl_manifests() -> Vec<ModelManifest> {
                 width: 512,
                 height: 512,
                 is_schnell: false,
-                scheduler: Some("euler_ancestral"),
+                scheduler: Some(Scheduler::EulerAncestral),
             },
         },
     ]
@@ -1117,7 +1118,7 @@ fn zimage_manifests() -> Vec<ModelManifest> {
                 width: 1024,
                 height: 1024,
                 is_schnell: false,
-                scheduler: Some("flow_match_euler"),
+                scheduler: None,
             },
         },
         // GGUF quantized variants (transformer only; shared components are always BF16)
@@ -1146,7 +1147,7 @@ fn zimage_manifests() -> Vec<ModelManifest> {
                 width: 1024,
                 height: 1024,
                 is_schnell: false,
-                scheduler: Some("flow_match_euler"),
+                scheduler: None,
             },
         },
         ModelManifest {
@@ -1174,7 +1175,7 @@ fn zimage_manifests() -> Vec<ModelManifest> {
                 width: 1024,
                 height: 1024,
                 is_schnell: false,
-                scheduler: Some("flow_match_euler"),
+                scheduler: None,
             },
         },
         ModelManifest {
@@ -1202,7 +1203,7 @@ fn zimage_manifests() -> Vec<ModelManifest> {
                 width: 1024,
                 height: 1024,
                 is_schnell: false,
-                scheduler: Some("flow_match_euler"),
+                scheduler: None,
             },
         },
     ]
@@ -1354,7 +1355,7 @@ fn qwen_image_manifests() -> Vec<ModelManifest> {
         width: 1024,
         height: 1024,
         is_schnell: false,
-        scheduler: Some("flow_match_euler"),
+        scheduler: None,
     };
 
     vec![
@@ -2156,7 +2157,7 @@ mod tests {
     #[test]
     fn sdxl_turbo_uses_euler_ancestral() {
         let manifest = find_manifest("sdxl-turbo").unwrap();
-        assert_eq!(manifest.defaults.scheduler, Some("euler_ancestral"));
+        assert_eq!(manifest.defaults.scheduler, Some(Scheduler::EulerAncestral));
         assert_eq!(manifest.defaults.steps, 4);
         assert_eq!(manifest.defaults.guidance, 0.0);
     }
@@ -2164,7 +2165,7 @@ mod tests {
     #[test]
     fn sdxl_base_uses_ddim() {
         let manifest = find_manifest("sdxl-base").unwrap();
-        assert_eq!(manifest.defaults.scheduler, Some("ddim"));
+        assert_eq!(manifest.defaults.scheduler, Some(Scheduler::Ddim));
         assert_eq!(manifest.defaults.steps, 25);
     }
 
@@ -2214,7 +2215,7 @@ mod tests {
     fn sd15_defaults() {
         for manifest in known_manifests() {
             if manifest.family == "sd15" {
-                assert_eq!(manifest.defaults.scheduler, Some("ddim"));
+                assert_eq!(manifest.defaults.scheduler, Some(Scheduler::Ddim));
                 assert_eq!(manifest.defaults.width, 512);
                 assert_eq!(manifest.defaults.height, 512);
             }
@@ -2229,7 +2230,7 @@ mod tests {
         assert_eq!(manifest.defaults.steps, 25);
         assert_eq!(manifest.defaults.width, 512);
         assert_eq!(manifest.defaults.guidance, 7.5);
-        assert_eq!(manifest.defaults.scheduler, Some("ddim"));
+        assert_eq!(manifest.defaults.scheduler, Some(Scheduler::Ddim));
     }
 
     #[test]
@@ -2269,7 +2270,7 @@ mod tests {
         assert_eq!(manifest.family, "z-image");
         assert_eq!(manifest.defaults.steps, 9);
         assert_eq!(manifest.defaults.guidance, 0.0);
-        assert_eq!(manifest.defaults.scheduler, Some("flow_match_euler"));
+        assert_eq!(manifest.defaults.scheduler, None);
     }
 
     // --- Qwen3 variant registry tests ---
@@ -2326,7 +2327,7 @@ mod tests {
             if manifest.family == "z-image" {
                 assert_eq!(manifest.defaults.steps, 9);
                 assert_eq!(manifest.defaults.guidance, 0.0);
-                assert_eq!(manifest.defaults.scheduler, Some("flow_match_euler"));
+                assert_eq!(manifest.defaults.scheduler, None);
             }
         }
     }

--- a/crates/mold-core/src/types.rs
+++ b/crates/mold-core/src/types.rs
@@ -1,5 +1,42 @@
 use serde::{Deserialize, Serialize};
 
+/// Scheduler algorithm for UNet-based diffusion models (SD1.5, SDXL).
+///
+/// Flow-matching models (FLUX, SD3, Z-Image, Flux.2, Qwen-Image) ignore this setting.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum Scheduler {
+    #[default]
+    Ddim,
+    EulerAncestral,
+    UniPc,
+}
+
+impl std::fmt::Display for Scheduler {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Scheduler::Ddim => write!(f, "ddim"),
+            Scheduler::EulerAncestral => write!(f, "euler-ancestral"),
+            Scheduler::UniPc => write!(f, "uni-pc"),
+        }
+    }
+}
+
+impl std::str::FromStr for Scheduler {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "ddim" => Ok(Scheduler::Ddim),
+            "euler-ancestral" | "euler_ancestral" => Ok(Scheduler::EulerAncestral),
+            "uni-pc" | "unipc" | "uni_pc" => Ok(Scheduler::UniPc),
+            other => Err(format!(
+                "unknown scheduler: '{other}'. Valid: ddim, euler-ancestral, uni-pc"
+            )),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct GenerateRequest {
     #[schema(example = "a cat sitting on a windowsill at sunset")]
@@ -23,6 +60,10 @@ pub struct GenerateRequest {
     pub batch_size: u32,
     #[serde(default)]
     pub output_format: OutputFormat,
+    /// Scheduler override for UNet-based models (SD1.5, SDXL).
+    /// Ignored by flow-matching models (FLUX, SD3, Z-Image, Flux.2, Qwen-Image).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scheduler: Option<Scheduler>,
 }
 
 fn default_guidance() -> f64 {
@@ -234,12 +275,14 @@ mod tests {
             seed: Some(42),
             batch_size: 1,
             output_format: OutputFormat::Png,
+            scheduler: None,
         };
         let json = serde_json::to_string(&req).unwrap();
         let back: GenerateRequest = serde_json::from_str(&json).unwrap();
         assert_eq!(back.prompt, req.prompt);
         assert_eq!(back.width, req.width);
         assert_eq!(back.seed, req.seed);
+        assert_eq!(back.scheduler, None);
     }
 
     #[test]
@@ -288,6 +331,57 @@ mod tests {
     #[test]
     fn output_format_default_is_png() {
         assert_eq!(OutputFormat::default(), OutputFormat::Png);
+    }
+
+    #[test]
+    fn scheduler_serde_roundtrip() {
+        let sched = Scheduler::EulerAncestral;
+        let json = serde_json::to_string(&sched).unwrap();
+        assert_eq!(json, r#""euler-ancestral""#);
+        let back: Scheduler = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, sched);
+    }
+
+    #[test]
+    fn scheduler_from_str_aliases() {
+        assert_eq!("ddim".parse::<Scheduler>().unwrap(), Scheduler::Ddim);
+        assert_eq!(
+            "euler-ancestral".parse::<Scheduler>().unwrap(),
+            Scheduler::EulerAncestral
+        );
+        assert_eq!(
+            "euler_ancestral".parse::<Scheduler>().unwrap(),
+            Scheduler::EulerAncestral
+        );
+        assert_eq!("uni-pc".parse::<Scheduler>().unwrap(), Scheduler::UniPc);
+        assert_eq!("unipc".parse::<Scheduler>().unwrap(), Scheduler::UniPc);
+        assert_eq!("uni_pc".parse::<Scheduler>().unwrap(), Scheduler::UniPc);
+    }
+
+    #[test]
+    fn scheduler_from_str_invalid() {
+        assert!("unknown".parse::<Scheduler>().is_err());
+    }
+
+    #[test]
+    fn scheduler_display() {
+        assert_eq!(Scheduler::Ddim.to_string(), "ddim");
+        assert_eq!(Scheduler::EulerAncestral.to_string(), "euler-ancestral");
+        assert_eq!(Scheduler::UniPc.to_string(), "uni-pc");
+    }
+
+    #[test]
+    fn scheduler_default_is_ddim() {
+        assert_eq!(Scheduler::default(), Scheduler::Ddim);
+    }
+
+    #[test]
+    fn generate_request_backward_compat_no_scheduler() {
+        // Existing JSON without scheduler field should deserialize fine
+        let json =
+            r#"{"prompt":"test","model":"test","width":512,"height":512,"steps":4,"batch_size":1}"#;
+        let req: GenerateRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.scheduler, None);
     }
 
     // ── SSE type tests ──────────────────────────────────────────────────────

--- a/crates/mold-core/src/validation.rs
+++ b/crates/mold-core/src/validation.rs
@@ -70,6 +70,7 @@ mod tests {
             seed: Some(42),
             batch_size: 1,
             output_format: OutputFormat::Png,
+            scheduler: None,
         }
     }
 

--- a/crates/mold-inference/src/factory.rs
+++ b/crates/mold-inference/src/factory.rs
@@ -1,5 +1,5 @@
 use anyhow::{bail, Result};
-use mold_core::{Config, ModelPaths};
+use mold_core::{Config, ModelPaths, Scheduler};
 
 use crate::engine::{InferenceEngine, LoadStrategy};
 use crate::flux::FluxEngine;
@@ -56,23 +56,27 @@ pub fn create_engine(
             )))
         }
         "sd15" | "sd1.5" | "stable-diffusion-1.5" => {
-            let scheduler_name = model_cfg.scheduler.unwrap_or_else(|| "ddim".to_string());
+            let scheduler = model_cfg.scheduler.unwrap_or(Scheduler::Ddim);
             Ok(Box::new(SD15Engine::new(
                 model_name,
                 paths,
-                scheduler_name,
+                scheduler,
                 load_strategy,
             )))
         }
         "sdxl" => {
-            let scheduler_name = model_cfg.scheduler.unwrap_or_else(|| "ddim".to_string());
-            let is_turbo = model_cfg.is_turbo.unwrap_or_else(|| {
-                scheduler_name == "euler_ancestral" || model_name.contains("turbo")
+            let is_turbo = model_cfg
+                .is_turbo
+                .unwrap_or_else(|| model_name.contains("turbo"));
+            let scheduler = model_cfg.scheduler.unwrap_or(if is_turbo {
+                Scheduler::EulerAncestral
+            } else {
+                Scheduler::Ddim
             });
             Ok(Box::new(SDXLEngine::new(
                 model_name,
                 paths,
-                scheduler_name,
+                scheduler,
                 is_turbo,
                 load_strategy,
             )))

--- a/crates/mold-inference/src/flux/pipeline.rs
+++ b/crates/mold-inference/src/flux/pipeline.rs
@@ -618,6 +618,10 @@ impl FluxEngine {
 
 impl InferenceEngine for FluxEngine {
     fn generate(&mut self, req: &GenerateRequest) -> Result<GenerateResponse> {
+        if req.scheduler.is_some() {
+            tracing::warn!("scheduler selection not supported for FLUX (flow-matching), ignoring");
+        }
+
         // Sequential mode: load-use-drop each component
         if self.load_strategy == LoadStrategy::Sequential {
             return self.generate_sequential(req);

--- a/crates/mold-inference/src/flux2/pipeline.rs
+++ b/crates/mold-inference/src/flux2/pipeline.rs
@@ -501,6 +501,12 @@ impl Flux2Engine {
 
 impl InferenceEngine for Flux2Engine {
     fn generate(&mut self, req: &GenerateRequest) -> Result<GenerateResponse> {
+        if req.scheduler.is_some() {
+            tracing::warn!(
+                "scheduler selection not supported for Flux.2 (flow-matching), ignoring"
+            );
+        }
+
         // Sequential mode: load-use-drop each component
         if self.load_strategy == LoadStrategy::Sequential {
             return self.generate_sequential(req);

--- a/crates/mold-inference/src/lib.rs
+++ b/crates/mold-inference/src/lib.rs
@@ -9,6 +9,7 @@ mod image;
 pub mod model_registry;
 pub mod progress;
 pub mod qwen_image;
+pub mod scheduler;
 pub mod sd15;
 pub mod sd3;
 pub mod sdxl;

--- a/crates/mold-inference/src/qwen_image/pipeline.rs
+++ b/crates/mold-inference/src/qwen_image/pipeline.rs
@@ -574,6 +574,12 @@ impl QwenImageEngine {
 
 impl InferenceEngine for QwenImageEngine {
     fn generate(&mut self, req: &GenerateRequest) -> Result<GenerateResponse> {
+        if req.scheduler.is_some() {
+            tracing::warn!(
+                "scheduler selection not supported for Qwen-Image (flow-matching), ignoring"
+            );
+        }
+
         // Sequential mode: load-use-drop each component
         if self.load_strategy == LoadStrategy::Sequential {
             return self.generate_sequential(req);
@@ -804,6 +810,7 @@ mod tests {
                 clip_tokenizer_2: None,
                 text_encoder_files: vec![],
                 text_tokenizer: Some(PathBuf::from("/tmp/tokenizer.json")),
+                decoder: None,
             },
             LoadStrategy::Sequential,
         );

--- a/crates/mold-inference/src/scheduler.rs
+++ b/crates/mold-inference/src/scheduler.rs
@@ -1,0 +1,50 @@
+use anyhow::Result;
+use candle_transformers::models::stable_diffusion::{
+    ddim::DDIMSchedulerConfig,
+    euler_ancestral_discrete::EulerAncestralDiscreteSchedulerConfig,
+    schedulers::{PredictionType, Scheduler, SchedulerConfig, TimestepSpacing},
+    uni_pc::UniPCSchedulerConfig,
+};
+use mold_core::Scheduler as MoldScheduler;
+
+/// Build a candle scheduler from a mold `Scheduler` enum value.
+///
+/// `prediction_type` and `is_turbo` come from the model config (e.g. Epsilon
+/// for SD1.5/SDXL, Trailing timesteps for SDXL Turbo).
+pub fn build_scheduler(
+    scheduler: MoldScheduler,
+    inference_steps: usize,
+    prediction_type: PredictionType,
+    is_turbo: bool,
+) -> Result<Box<dyn Scheduler>> {
+    let result = match scheduler {
+        MoldScheduler::Ddim => {
+            let config = DDIMSchedulerConfig {
+                prediction_type,
+                ..Default::default()
+            };
+            config.build(inference_steps)
+        }
+        MoldScheduler::EulerAncestral => {
+            let timestep_spacing = if is_turbo {
+                TimestepSpacing::Trailing
+            } else {
+                TimestepSpacing::Leading
+            };
+            let config = EulerAncestralDiscreteSchedulerConfig {
+                prediction_type,
+                timestep_spacing,
+                ..Default::default()
+            };
+            config.build(inference_steps)
+        }
+        MoldScheduler::UniPc => {
+            let config = UniPCSchedulerConfig {
+                prediction_type,
+                ..Default::default()
+            };
+            config.build(inference_steps)
+        }
+    };
+    result.map_err(|e| anyhow::anyhow!("{e}"))
+}

--- a/crates/mold-inference/src/sd15/pipeline.rs
+++ b/crates/mold-inference/src/sd15/pipeline.rs
@@ -1,7 +1,8 @@
 use anyhow::{bail, Result};
 use candle_core::{DType, Device, Module, Tensor};
 use candle_transformers::models::stable_diffusion;
-use mold_core::{GenerateRequest, GenerateResponse, ImageData, ModelPaths};
+use candle_transformers::models::stable_diffusion::schedulers::PredictionType;
+use mold_core::{GenerateRequest, GenerateResponse, ImageData, ModelPaths, Scheduler};
 use std::time::Instant;
 
 use crate::device::{check_memory_budget, memory_status_string, preflight_memory_check};
@@ -30,7 +31,7 @@ pub struct SD15Engine {
     loaded: Option<LoadedSD15>,
     model_name: String,
     paths: ModelPaths,
-    scheduler_name: String,
+    scheduler: Scheduler,
     progress: ProgressReporter,
     load_strategy: LoadStrategy,
 }
@@ -39,14 +40,14 @@ impl SD15Engine {
     pub fn new(
         model_name: String,
         paths: ModelPaths,
-        scheduler_name: String,
+        scheduler: Scheduler,
         load_strategy: LoadStrategy,
     ) -> Self {
         Self {
             loaded: None,
             model_name,
             paths,
-            scheduler_name,
+            scheduler,
             progress: ProgressReporter::default(),
             load_strategy,
         }
@@ -189,13 +190,18 @@ impl SD15Engine {
         &self,
         unet: &stable_diffusion::unet_2d::UNet2DConditionModel,
         text_embeddings: &Tensor,
-        sd_config: &stable_diffusion::StableDiffusionConfig,
+        sched: Scheduler,
         latents: &mut Tensor,
         guidance: f64,
         steps: u32,
     ) -> Result<()> {
         let use_cfg = guidance > 1.0;
-        let mut scheduler = sd_config.build_scheduler(steps as usize)?;
+        let mut scheduler = crate::scheduler::build_scheduler(
+            sched,
+            steps as usize,
+            PredictionType::Epsilon,
+            false,
+        )?;
         let timesteps = scheduler.timesteps().to_vec();
 
         let denoise_label = format!("Denoising ({} steps)", timesteps.len());
@@ -361,10 +367,17 @@ impl SD15Engine {
         self.progress
             .stage_done("Loading UNet (GPU)", unet_start.elapsed());
 
+        let sched = req.scheduler.unwrap_or(self.scheduler);
         let latent_h = height / 8;
         let latent_w = width / 8;
-        let scheduler = sd_config.build_scheduler(req.steps as usize)?;
-        let init_noise_sigma = scheduler.init_noise_sigma();
+        let init_scheduler = crate::scheduler::build_scheduler(
+            sched,
+            req.steps as usize,
+            PredictionType::Epsilon,
+            false,
+        )?;
+        let init_noise_sigma = init_scheduler.init_noise_sigma();
+        drop(init_scheduler);
         let mut latents =
             (crate::engine::seeded_randn(seed, &[1, 4, latent_h, latent_w], &device, DType::F32)?
                 * init_noise_sigma)?;
@@ -373,7 +386,7 @@ impl SD15Engine {
         self.denoise_loop(
             &unet,
             &text_embeddings,
-            &sd_config,
+            sched,
             &mut latents,
             guidance,
             req.steps,
@@ -455,7 +468,7 @@ impl InferenceEngine for SD15Engine {
             seed, width, height,
             steps = req.steps,
             guidance,
-            scheduler = %self.scheduler_name,
+            scheduler = %self.scheduler,
             "starting SD1.5 generation"
         );
 
@@ -472,10 +485,17 @@ impl InferenceEngine for SD15Engine {
         )?;
 
         // 2. Build scheduler and create initial latents
+        let sched = req.scheduler.unwrap_or(self.scheduler);
         let latent_h = height / 8;
         let latent_w = width / 8;
-        let scheduler = loaded.sd_config.build_scheduler(req.steps as usize)?;
-        let init_noise_sigma = scheduler.init_noise_sigma();
+        let init_scheduler = crate::scheduler::build_scheduler(
+            sched,
+            req.steps as usize,
+            PredictionType::Epsilon,
+            false,
+        )?;
+        let init_noise_sigma = init_scheduler.init_noise_sigma();
+        drop(init_scheduler);
         let mut latents = (crate::engine::seeded_randn(
             seed,
             &[1, 4, latent_h, latent_w],
@@ -488,7 +508,7 @@ impl InferenceEngine for SD15Engine {
         self.denoise_loop(
             &loaded.unet,
             &text_embeddings,
-            &loaded.sd_config,
+            sched,
             &mut latents,
             guidance,
             req.steps,

--- a/crates/mold-inference/src/sd3/pipeline.rs
+++ b/crates/mold-inference/src/sd3/pipeline.rs
@@ -540,6 +540,10 @@ impl SD3Engine {
 
 impl InferenceEngine for SD3Engine {
     fn generate(&mut self, req: &GenerateRequest) -> Result<GenerateResponse> {
+        if req.scheduler.is_some() {
+            tracing::warn!("scheduler selection not supported for SD3 (flow-matching), ignoring");
+        }
+
         // Sequential mode: load-use-drop each component
         if self.load_strategy == LoadStrategy::Sequential {
             return self.generate_sequential(req);

--- a/crates/mold-inference/src/sdxl/pipeline.rs
+++ b/crates/mold-inference/src/sdxl/pipeline.rs
@@ -1,7 +1,8 @@
 use anyhow::{bail, Result};
 use candle_core::{DType, Device, Module, Tensor, D};
 use candle_transformers::models::stable_diffusion;
-use mold_core::{GenerateRequest, GenerateResponse, ImageData, ModelPaths};
+use candle_transformers::models::stable_diffusion::schedulers::PredictionType;
+use mold_core::{GenerateRequest, GenerateResponse, ImageData, ModelPaths, Scheduler};
 use std::time::Instant;
 
 use crate::device::{check_memory_budget, memory_status_string, preflight_memory_check};
@@ -27,7 +28,7 @@ pub struct SDXLEngine {
     loaded: Option<LoadedSDXL>,
     model_name: String,
     paths: ModelPaths,
-    scheduler_name: String,
+    scheduler: Scheduler,
     is_turbo: bool,
     progress: ProgressReporter,
     /// How to load model components (Eager = all at once, Sequential = load-use-drop).
@@ -43,7 +44,7 @@ impl SDXLEngine {
     pub fn new(
         model_name: String,
         paths: ModelPaths,
-        scheduler_name: String,
+        scheduler: Scheduler,
         is_turbo: bool,
         load_strategy: LoadStrategy,
     ) -> Self {
@@ -51,7 +52,7 @@ impl SDXLEngine {
             loaded: None,
             model_name,
             paths,
-            scheduler_name,
+            scheduler,
             is_turbo,
             progress: ProgressReporter::default(),
             load_strategy,
@@ -246,13 +247,18 @@ impl SDXLEngine {
         &self,
         unet: &stable_diffusion::unet_2d::UNet2DConditionModel,
         text_embeddings: &Tensor,
-        sd_config: &stable_diffusion::StableDiffusionConfig,
+        sched: Scheduler,
         latents: &mut Tensor,
         guidance: f64,
         steps: u32,
     ) -> Result<()> {
         let use_cfg = guidance > 1.0;
-        let mut scheduler = sd_config.build_scheduler(steps as usize)?;
+        let mut scheduler = crate::scheduler::build_scheduler(
+            sched,
+            steps as usize,
+            PredictionType::Epsilon,
+            self.is_turbo,
+        )?;
         let timesteps = scheduler.timesteps().to_vec();
 
         let denoise_label = format!("Denoising ({} steps)", timesteps.len());
@@ -457,10 +463,17 @@ impl SDXLEngine {
         self.progress
             .stage_done("Loading UNet (GPU)", unet_start.elapsed());
 
+        let sched = req.scheduler.unwrap_or(self.scheduler);
         let latent_h = height / 8;
         let latent_w = width / 8;
-        let scheduler = sd_config.build_scheduler(req.steps as usize)?;
-        let init_noise_sigma = scheduler.init_noise_sigma();
+        let init_scheduler = crate::scheduler::build_scheduler(
+            sched,
+            req.steps as usize,
+            PredictionType::Epsilon,
+            self.is_turbo,
+        )?;
+        let init_noise_sigma = init_scheduler.init_noise_sigma();
+        drop(init_scheduler);
         let mut latents =
             (crate::engine::seeded_randn(seed, &[1, 4, latent_h, latent_w], &device, DType::F32)?
                 * init_noise_sigma)?;
@@ -469,7 +482,7 @@ impl SDXLEngine {
         self.denoise_loop(
             &unet,
             &text_embeddings,
-            &sd_config,
+            sched,
             &mut latents,
             guidance,
             req.steps,
@@ -557,7 +570,7 @@ impl InferenceEngine for SDXLEngine {
             seed, width, height,
             steps = req.steps,
             guidance,
-            scheduler = %self.scheduler_name,
+            scheduler = %self.scheduler,
             "starting SDXL generation"
         );
 
@@ -576,10 +589,17 @@ impl InferenceEngine for SDXLEngine {
         )?;
 
         // 3. Build scheduler
+        let sched = req.scheduler.unwrap_or(self.scheduler);
         let latent_h = height / 8;
         let latent_w = width / 8;
-        let scheduler = loaded.sd_config.build_scheduler(req.steps as usize)?;
-        let init_noise_sigma = scheduler.init_noise_sigma();
+        let init_scheduler = crate::scheduler::build_scheduler(
+            sched,
+            req.steps as usize,
+            PredictionType::Epsilon,
+            self.is_turbo,
+        )?;
+        let init_noise_sigma = init_scheduler.init_noise_sigma();
+        drop(init_scheduler);
         let mut latents = (crate::engine::seeded_randn(
             seed,
             &[1, 4, latent_h, latent_w],
@@ -592,7 +612,7 @@ impl InferenceEngine for SDXLEngine {
         self.denoise_loop(
             &loaded.unet,
             &text_embeddings,
-            &loaded.sd_config,
+            sched,
             &mut latents,
             guidance,
             req.steps,

--- a/crates/mold-inference/src/zimage/pipeline.rs
+++ b/crates/mold-inference/src/zimage/pipeline.rs
@@ -591,6 +591,12 @@ impl ZImageEngine {
 
 impl InferenceEngine for ZImageEngine {
     fn generate(&mut self, req: &GenerateRequest) -> Result<GenerateResponse> {
+        if req.scheduler.is_some() {
+            tracing::warn!(
+                "scheduler selection not supported for Z-Image (flow-matching), ignoring"
+            );
+        }
+
         // Sequential mode: load-use-drop each component
         if self.load_strategy == LoadStrategy::Sequential {
             return self.generate_sequential(req);


### PR DESCRIPTION
## Summary

Implements #20 — scheduler selection for mold.

- Adds `Scheduler` enum (`Ddim`, `EulerAncestral`, `UniPc`) to `mold-core` with serde, Display, and FromStr support
- New `--scheduler` CLI flag (with `MOLD_SCHEDULER` env var) and per-request `scheduler` field in `GenerateRequest`
- SD1.5 and SDXL pipelines use configurable scheduler via `build_scheduler()` bridge in new `crates/mold-inference/src/scheduler.rs`
- Flow-matching engines (FLUX, SD3, Z-Image, Flux2, Qwen-Image) emit a warning when scheduler is set and ignore it
- Manifest defaults and per-model config converted from string literals to typed `Scheduler` enum

## Test plan

- [x] All 124 existing tests pass (`cargo test --workspace`)
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [ ] Manual test: `mold run sd15:fp16 "a cat" --scheduler euler-ancestral`
- [ ] Manual test: `mold run flux-schnell "a cat" --scheduler ddim` (should warn and ignore)

Closes #20