### PR TITLE
feat: add img2img mode (--image, --strength)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2268,6 +2268,7 @@ dependencies = [
  "clap_complete",
  "colored",
  "dirs",
+ "image",
  "indicatif 0.17.11",
  "libc",
  "mold-ai-core",

--- a/crates/mold-cli/Cargo.toml
+++ b/crates/mold-cli/Cargo.toml
@@ -26,6 +26,7 @@ anyhow = "1"
 clap = { version = "4", features = ["derive", "env", "unstable-ext"] }
 clap_complete = { version = "4", features = ["unstable-dynamic"] }
 colored = "3"
+image = "0.25"
 libc = "0.2"
 dirs = "6"
 indicatif = "0.17"

--- a/crates/mold-cli/src/commands/generate.rs
+++ b/crates/mold-cli/src/commands/generate.rs
@@ -30,6 +30,8 @@ pub async fn run(
     qwen3_variant: Option<String>,
     scheduler: Option<Scheduler>,
     eager: bool,
+    source_image: Option<Vec<u8>>,
+    strength: f64,
 ) -> Result<()> {
     let output_format = format;
     let piped = is_piped();
@@ -65,8 +67,35 @@ pub async fn run(
         model_cfg
     };
 
-    let effective_width = width.unwrap_or_else(|| model_cfg.effective_width(&config));
-    let effective_height = height.unwrap_or_else(|| model_cfg.effective_height(&config));
+    // When source_image is provided and width/height not specified, derive from image dimensions
+    let (effective_width, effective_height) =
+        if source_image.is_some() && width.is_none() && height.is_none() {
+            if let Some(ref img_bytes) = source_image {
+                let reader = image::ImageReader::new(std::io::Cursor::new(img_bytes))
+                    .with_guessed_format()
+                    .ok()
+                    .and_then(|r| r.into_dimensions().ok());
+                match reader {
+                    Some((w, h)) => {
+                        // Round to nearest multiple of 16
+                        let w = ((w + 8) / 16) * 16;
+                        let h = ((h + 8) / 16) * 16;
+                        (w, h)
+                    }
+                    None => (
+                        width.unwrap_or_else(|| model_cfg.effective_width(&config)),
+                        height.unwrap_or_else(|| model_cfg.effective_height(&config)),
+                    ),
+                }
+            } else {
+                unreachable!()
+            }
+        } else {
+            (
+                width.unwrap_or_else(|| model_cfg.effective_width(&config)),
+                height.unwrap_or_else(|| model_cfg.effective_height(&config)),
+            )
+        };
     let effective_steps = steps.unwrap_or_else(|| model_cfg.effective_steps(&config));
     let effective_guidance = guidance.unwrap_or_else(|| model_cfg.effective_guidance());
 
@@ -81,6 +110,8 @@ pub async fn run(
         batch_size: batch,
         output_format,
         scheduler,
+        source_image: source_image.clone(),
+        strength,
     };
 
     if let Some(desc) = &model_cfg.description {
@@ -90,6 +121,9 @@ pub async fn run(
             model.bold(),
             crate::output::colorize_description(desc)
         );
+    }
+    if source_image.is_some() {
+        status!("{} img2img mode (strength: {:.2})", "●".magenta(), strength,);
     }
     status!(
         "{} Generating {}x{} ({} steps, guidance {:.1})",

--- a/crates/mold-cli/src/commands/run.rs
+++ b/crates/mold-cli/src/commands/run.rs
@@ -64,14 +64,33 @@ pub async fn run(
     qwen3_variant: Option<String>,
     scheduler: Option<Scheduler>,
     eager: bool,
+    image: Option<String>,
+    strength: f64,
 ) -> Result<()> {
     let config = Config::load_or_default();
     let (model, prompt) = resolve_run_args(model_or_prompt.as_deref(), &prompt_rest, &config);
 
+    // Read source image if --image specified
+    let source_image = if let Some(ref img_path) = image {
+        let bytes = if img_path == "-" {
+            // Read binary image from stdin
+            let mut buf = Vec::new();
+            std::io::stdin().read_to_end(&mut buf)?;
+            buf
+        } else {
+            std::fs::read(img_path)
+                .map_err(|e| anyhow::anyhow!("failed to read image '{}': {e}", img_path))?
+        };
+        Some(bytes)
+    } else {
+        None
+    };
+
     // If no prompt from args, try reading from stdin (supports piping)
+    // When --image - is used, stdin is consumed for the image, so prompt must come from args.
     let prompt = match prompt {
         Some(p) => Some(p),
-        None if !std::io::stdin().is_terminal() => {
+        None if image.as_deref() != Some("-") && !std::io::stdin().is_terminal() => {
             let mut buf = String::new();
             std::io::stdin().read_to_string(&mut buf)?;
             let trimmed = buf.trim().to_string();
@@ -110,6 +129,8 @@ pub async fn run(
         qwen3_variant,
         scheduler,
         eager,
+        source_image,
+        strength,
     )
     .await
 }

--- a/crates/mold-cli/src/main.rs
+++ b/crates/mold-cli/src/main.rs
@@ -119,6 +119,14 @@ Examples:
         /// By default, components are loaded and unloaded sequentially to reduce peak memory.
         #[arg(long, help_heading = "Advanced")]
         eager: bool,
+
+        /// Source image for img2img (file path or - for stdin)
+        #[arg(short = 'i', long, help_heading = "img2img")]
+        image: Option<String>,
+
+        /// Denoising strength for img2img (0.0 = no change, 1.0 = full noise)
+        #[arg(long, default_value = "0.75", help_heading = "img2img")]
+        strength: f64,
     },
 
     /// Start the inference server
@@ -315,6 +323,8 @@ async fn run() -> anyhow::Result<()> {
             qwen3_variant,
             scheduler,
             eager,
+            image,
+            strength,
         } => {
             commands::run::run(
                 model_or_prompt,
@@ -333,6 +343,8 @@ async fn run() -> anyhow::Result<()> {
                 qwen3_variant,
                 scheduler,
                 eager,
+                image,
+                strength,
             )
             .await?;
         }
@@ -684,6 +696,60 @@ mod tests {
         let cli = parse(&["run", "model", "test", "--format", "jpg"]);
         match cli.command {
             Commands::Run { format, .. } => assert_eq!(format, OutputFormat::Jpeg),
+            _ => panic!("expected Run"),
+        }
+    }
+
+    #[test]
+    fn run_image_flag() {
+        let cli = parse(&["run", "model", "test", "--image", "photo.png"]);
+        match cli.command {
+            Commands::Run { image, .. } => assert_eq!(image.as_deref(), Some("photo.png")),
+            _ => panic!("expected Run"),
+        }
+    }
+
+    #[test]
+    fn run_image_stdin() {
+        let cli = parse(&["run", "model", "test", "--image", "-"]);
+        match cli.command {
+            Commands::Run { image, .. } => assert_eq!(image.as_deref(), Some("-")),
+            _ => panic!("expected Run"),
+        }
+    }
+
+    #[test]
+    fn run_image_short_flag() {
+        let cli = parse(&["run", "model", "test", "-i", "input.jpg"]);
+        match cli.command {
+            Commands::Run { image, .. } => assert_eq!(image.as_deref(), Some("input.jpg")),
+            _ => panic!("expected Run"),
+        }
+    }
+
+    #[test]
+    fn run_strength_flag() {
+        let cli = parse(&["run", "model", "test", "--strength", "0.5"]);
+        match cli.command {
+            Commands::Run { strength, .. } => assert_eq!(strength, 0.5),
+            _ => panic!("expected Run"),
+        }
+    }
+
+    #[test]
+    fn run_strength_default() {
+        let cli = parse(&["run", "model", "test"]);
+        match cli.command {
+            Commands::Run { strength, .. } => assert_eq!(strength, 0.75),
+            _ => panic!("expected Run"),
+        }
+    }
+
+    #[test]
+    fn run_image_defaults_none() {
+        let cli = parse(&["run", "model", "test"]);
+        match cli.command {
+            Commands::Run { image, .. } => assert!(image.is_none()),
             _ => panic!("expected Run"),
         }
     }

--- a/crates/mold-core/src/types.rs
+++ b/crates/mold-core/src/types.rs
@@ -1,5 +1,40 @@
 use serde::{Deserialize, Serialize};
 
+/// Serde helpers for `Option<Vec<u8>>` as base64 in JSON.
+mod base64_opt {
+    use base64::Engine as _;
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S>(data: &Option<Vec<u8>>, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match data {
+            Some(bytes) => {
+                let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
+                s.serialize_some(&encoded)
+            }
+            None => s.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D>(d: D) -> Result<Option<Vec<u8>>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let opt: Option<String> = Option::deserialize(d)?;
+        match opt {
+            Some(encoded) => {
+                let bytes = base64::engine::general_purpose::STANDARD
+                    .decode(&encoded)
+                    .map_err(serde::de::Error::custom)?;
+                Ok(Some(bytes))
+            }
+            None => Ok(None),
+        }
+    }
+}
+
 /// Scheduler algorithm for UNet-based diffusion models (SD1.5, SDXL).
 ///
 /// Flow-matching models (FLUX, SD3, Z-Image, Flux.2, Qwen-Image) ignore this setting.
@@ -64,6 +99,12 @@ pub struct GenerateRequest {
     /// Ignored by flow-matching models (FLUX, SD3, Z-Image, Flux.2, Qwen-Image).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scheduler: Option<Scheduler>,
+    /// Source image for img2img generation (raw PNG/JPEG bytes, base64-encoded in JSON).
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "base64_opt")]
+    pub source_image: Option<Vec<u8>>,
+    /// Denoising strength for img2img (0.0 = no change, 1.0 = full noise / txt2img).
+    #[serde(default = "default_strength")]
+    pub strength: f64,
 }
 
 fn default_guidance() -> f64 {
@@ -72,6 +113,10 @@ fn default_guidance() -> f64 {
 
 fn default_batch_size() -> u32 {
     1
+}
+
+fn default_strength() -> f64 {
+    0.75
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
@@ -276,6 +321,8 @@ mod tests {
             batch_size: 1,
             output_format: OutputFormat::Png,
             scheduler: None,
+            source_image: None,
+            strength: 0.75,
         };
         let json = serde_json::to_string(&req).unwrap();
         let back: GenerateRequest = serde_json::from_str(&json).unwrap();
@@ -443,5 +490,70 @@ mod tests {
         let json = serde_json::to_string(&event).unwrap();
         let back: SseErrorEvent = serde_json::from_str(&json).unwrap();
         assert_eq!(back.message, "something failed");
+    }
+
+    // ── img2img field tests ────────────────────────────────────────────────
+
+    #[test]
+    fn generate_request_source_image_base64_roundtrip() {
+        // Minimal PNG-like bytes for testing
+        let image_bytes = vec![0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+        let req = GenerateRequest {
+            prompt: "test".to_string(),
+            model: "test".to_string(),
+            width: 512,
+            height: 512,
+            steps: 4,
+            guidance: 3.5,
+            seed: None,
+            batch_size: 1,
+            output_format: OutputFormat::Png,
+            scheduler: None,
+            source_image: Some(image_bytes.clone()),
+            strength: 0.5,
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        // Verify base64 encoding is in the JSON
+        assert!(json.contains("source_image"));
+        let back: GenerateRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.source_image, Some(image_bytes));
+        assert_eq!(back.strength, 0.5);
+    }
+
+    #[test]
+    fn generate_request_backward_compat_no_source_image() {
+        // Existing JSON without source_image/strength should deserialize fine
+        let json =
+            r#"{"prompt":"test","model":"test","width":512,"height":512,"steps":4,"batch_size":1}"#;
+        let req: GenerateRequest = serde_json::from_str(json).unwrap();
+        assert!(req.source_image.is_none());
+        assert!((req.strength - 0.75).abs() < 0.001);
+    }
+
+    #[test]
+    fn generate_request_strength_defaults_to_075() {
+        let json = r#"{"prompt":"test","model":"test","width":512,"height":512,"steps":4}"#;
+        let req: GenerateRequest = serde_json::from_str(json).unwrap();
+        assert!((req.strength - 0.75).abs() < 0.001);
+    }
+
+    #[test]
+    fn generate_request_source_image_omitted_in_json_when_none() {
+        let req = GenerateRequest {
+            prompt: "test".to_string(),
+            model: "test".to_string(),
+            width: 512,
+            height: 512,
+            steps: 4,
+            guidance: 3.5,
+            seed: None,
+            batch_size: 1,
+            output_format: OutputFormat::Png,
+            scheduler: None,
+            source_image: None,
+            strength: 0.75,
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(!json.contains("source_image"));
     }
 }

--- a/crates/mold-core/src/validation.rs
+++ b/crates/mold-core/src/validation.rs
@@ -51,6 +51,21 @@ pub fn validate_generate_request(req: &GenerateRequest) -> Result<(), String> {
             req.prompt.len()
         ));
     }
+    // img2img validation
+    if let Some(ref img) = req.source_image {
+        if req.strength <= 0.0 || req.strength > 1.0 {
+            return Err(format!(
+                "strength ({}) must be in range (0.0, 1.0] when source_image is provided",
+                req.strength
+            ));
+        }
+        // Quick format check: PNG magic or JPEG magic
+        let is_png = img.len() >= 4 && img[..4] == [0x89, 0x50, 0x4E, 0x47];
+        let is_jpeg = img.len() >= 2 && img[..2] == [0xFF, 0xD8];
+        if !is_png && !is_jpeg {
+            return Err("source_image must be a PNG or JPEG image".to_string());
+        }
+    }
     Ok(())
 }
 
@@ -71,7 +86,19 @@ mod tests {
             batch_size: 1,
             output_format: OutputFormat::Png,
             scheduler: None,
+            source_image: None,
+            strength: 0.75,
         }
+    }
+
+    /// Minimal valid PNG header bytes for testing.
+    fn png_bytes() -> Vec<u8> {
+        vec![0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]
+    }
+
+    /// Minimal valid JPEG header bytes for testing.
+    fn jpeg_bytes() -> Vec<u8> {
+        vec![0xFF, 0xD8, 0xFF, 0xE0]
     }
 
     #[test]
@@ -222,6 +249,60 @@ mod tests {
     fn seed_is_optional() {
         let mut req = valid_req();
         req.seed = None;
+        assert!(validate_generate_request(&req).is_ok());
+    }
+
+    // ── img2img validation tests ────────────────────────────────────────────
+
+    #[test]
+    fn img2img_strength_zero_rejected() {
+        let mut req = valid_req();
+        req.source_image = Some(png_bytes());
+        req.strength = 0.0;
+        assert!(validate_generate_request(&req)
+            .unwrap_err()
+            .contains("strength"));
+    }
+
+    #[test]
+    fn img2img_strength_one_accepted() {
+        let mut req = valid_req();
+        req.source_image = Some(png_bytes());
+        req.strength = 1.0;
+        assert!(validate_generate_request(&req).is_ok());
+    }
+
+    #[test]
+    fn img2img_strength_half_accepted() {
+        let mut req = valid_req();
+        req.source_image = Some(png_bytes());
+        req.strength = 0.5;
+        assert!(validate_generate_request(&req).is_ok());
+    }
+
+    #[test]
+    fn img2img_invalid_magic_bytes_rejected() {
+        let mut req = valid_req();
+        req.source_image = Some(vec![0x00, 0x01, 0x02, 0x03]);
+        req.strength = 0.75;
+        assert!(validate_generate_request(&req)
+            .unwrap_err()
+            .contains("PNG or JPEG"));
+    }
+
+    #[test]
+    fn img2img_jpeg_accepted() {
+        let mut req = valid_req();
+        req.source_image = Some(jpeg_bytes());
+        req.strength = 0.75;
+        assert!(validate_generate_request(&req).is_ok());
+    }
+
+    #[test]
+    fn img2img_no_source_image_skips_strength_check() {
+        let mut req = valid_req();
+        req.source_image = None;
+        req.strength = 0.0; // Would fail if source_image present, but should pass without
         assert!(validate_generate_request(&req).is_ok());
     }
 }

--- a/crates/mold-inference/src/flux/pipeline.rs
+++ b/crates/mold-inference/src/flux/pipeline.rs
@@ -533,8 +533,36 @@ impl FluxEngine {
         let noise_dtype = if is_quantized { DType::F32 } else { gpu_dtype };
         let latent_h = height / 16 * 2;
         let latent_w = width / 16 * 2;
-        let img =
-            crate::engine::seeded_randn(seed, &[1, 16, latent_h, latent_w], &device, noise_dtype)?;
+        let img = if let Some(ref source_bytes) = req.source_image {
+            self.progress.stage_start("Encoding source image (VAE)");
+            let encode_start = Instant::now();
+            let source_tensor = crate::img_utils::decode_source_image(
+                source_bytes,
+                req.width,
+                req.height,
+                crate::img_utils::NormalizeRange::ZeroToOne,
+                &device,
+                gpu_dtype,
+            )?;
+            // FLUX VAE encode returns latents directly (shift/scale applied internally)
+            let encoded = vae.encode(&source_tensor)?;
+            self.progress
+                .stage_done("Encoding source image (VAE)", encode_start.elapsed());
+
+            // Flow-matching img2img: interpolate between encoded latents and noise
+            let noise = crate::engine::seeded_randn(
+                seed,
+                &[1, 16, latent_h, latent_w],
+                &device,
+                noise_dtype,
+            )?;
+            let encoded = encoded.to_dtype(noise_dtype)?;
+            let strength = req.strength;
+            // latent = (1 - strength) * encoded + strength * noise
+            ((&encoded * (1.0 - strength))? + (&noise * strength)?)?
+        } else {
+            crate::engine::seeded_randn(seed, &[1, 16, latent_h, latent_w], &device, noise_dtype)?
+        };
 
         let (t5_emb_state, clip_emb_state, img_state) = if is_quantized {
             (
@@ -548,11 +576,25 @@ impl FluxEngine {
 
         let state = flux::sampling::State::new(&t5_emb_state, &clip_emb_state, &img_state)?;
 
-        let timesteps = if is_schnell {
+        let mut timesteps = if is_schnell {
             flux::sampling::get_schedule(req.steps as usize, None)
         } else {
             flux::sampling::get_schedule(req.steps as usize, Some((state.img.dim(1)?, 0.5, 1.15)))
         };
+
+        // For img2img, slice timestep schedule to start from strength
+        if req.source_image.is_some() {
+            let strength = req.strength;
+            // Keep only timesteps >= (1 - strength), since flow-matching goes from 1.0 -> 0.0
+            let start_idx = timesteps.iter().position(|&t| t <= strength).unwrap_or(0);
+            timesteps = timesteps[start_idx..].to_vec();
+            tracing::info!(
+                strength,
+                start_idx,
+                remaining_steps = timesteps.len().saturating_sub(1),
+                "img2img: trimmed timestep schedule"
+            );
+        }
 
         let denoise_label = format!("Denoising ({} steps)", timesteps.len().saturating_sub(1));
         self.progress.stage_start(&denoise_label);
@@ -749,12 +791,37 @@ impl InferenceEngine for FluxEngine {
         };
         let latent_h = height / 16 * 2;
         let latent_w = width / 16 * 2;
-        let img = crate::engine::seeded_randn(
-            seed,
-            &[1, 16, latent_h, latent_w],
-            &loaded.device,
-            noise_dtype,
-        )?;
+        let img = if let Some(ref source_bytes) = req.source_image {
+            progress.stage_start("Encoding source image (VAE)");
+            let encode_start = Instant::now();
+            let source_tensor = crate::img_utils::decode_source_image(
+                source_bytes,
+                req.width,
+                req.height,
+                crate::img_utils::NormalizeRange::ZeroToOne,
+                &loaded.device,
+                loaded.dtype,
+            )?;
+            let encoded = loaded.vae.encode(&source_tensor)?;
+            progress.stage_done("Encoding source image (VAE)", encode_start.elapsed());
+
+            let noise = crate::engine::seeded_randn(
+                seed,
+                &[1, 16, latent_h, latent_w],
+                &loaded.device,
+                noise_dtype,
+            )?;
+            let encoded = encoded.to_dtype(noise_dtype)?;
+            let strength = req.strength;
+            ((&encoded * (1.0 - strength))? + (&noise * strength)?)?
+        } else {
+            crate::engine::seeded_randn(
+                seed,
+                &[1, 16, latent_h, latent_w],
+                &loaded.device,
+                noise_dtype,
+            )?
+        };
 
         // For quantized model, state tensors must be F32
         let (t5_emb_state, clip_emb_state, img_state) = if loaded.is_quantized {
@@ -771,11 +838,24 @@ impl InferenceEngine for FluxEngine {
         let state = flux::sampling::State::new(&t5_emb_state, &clip_emb_state, &img_state)?;
 
         // 5. Get timestep schedule
-        let timesteps = if loaded.is_schnell {
+        let mut timesteps = if loaded.is_schnell {
             flux::sampling::get_schedule(req.steps as usize, None)
         } else {
             flux::sampling::get_schedule(req.steps as usize, Some((state.img.dim(1)?, 0.5, 1.15)))
         };
+
+        // For img2img, trim timestep schedule
+        if req.source_image.is_some() {
+            let strength = req.strength;
+            let start_idx = timesteps.iter().position(|&t| t <= strength).unwrap_or(0);
+            timesteps = timesteps[start_idx..].to_vec();
+            tracing::info!(
+                strength,
+                start_idx,
+                remaining_steps = timesteps.len().saturating_sub(1),
+                "img2img: trimmed timestep schedule"
+            );
+        }
 
         let denoise_label = format!("Denoising ({} steps)", timesteps.len().saturating_sub(1));
         progress.stage_start(&denoise_label);

--- a/crates/mold-inference/src/flux2/pipeline.rs
+++ b/crates/mold-inference/src/flux2/pipeline.rs
@@ -506,6 +506,9 @@ impl InferenceEngine for Flux2Engine {
                 "scheduler selection not supported for Flux.2 (flow-matching), ignoring"
             );
         }
+        if req.source_image.is_some() {
+            tracing::warn!("img2img not yet supported for Flux.2 — generating from text only");
+        }
 
         // Sequential mode: load-use-drop each component
         if self.load_strategy == LoadStrategy::Sequential {

--- a/crates/mold-inference/src/img_utils.rs
+++ b/crates/mold-inference/src/img_utils.rs
@@ -1,0 +1,135 @@
+//! Image decoding and preprocessing utilities for img2img.
+
+use anyhow::Result;
+use candle_core::{DType, Device, Tensor};
+
+/// Normalization range for source images before VAE encoding.
+pub enum NormalizeRange {
+    /// [-1, 1] for SD1.5 and SDXL (UNet-based models).
+    MinusOneToOne,
+    /// [0, 1] for FLUX, SD3, Z-Image, Flux.2, Qwen-Image (flow-matching models).
+    ZeroToOne,
+}
+
+/// Decode PNG/JPEG bytes into a [1, 3, H, W] tensor normalized to the specified range,
+/// resized to target dimensions.
+pub fn decode_source_image(
+    bytes: &[u8],
+    target_w: u32,
+    target_h: u32,
+    range: NormalizeRange,
+    device: &Device,
+    dtype: DType,
+) -> Result<Tensor> {
+    let img = image::load_from_memory(bytes)
+        .map_err(|e| anyhow::anyhow!("failed to decode source image: {e}"))?;
+
+    let img = img.resize_exact(target_w, target_h, image::imageops::FilterType::Lanczos3);
+    let img = img.to_rgb8();
+
+    let (w, h) = (img.width() as usize, img.height() as usize);
+    let raw = img.into_raw();
+
+    // raw is HWC u8, convert to f32 [0, 1]
+    let data: Vec<f32> = raw.iter().map(|&v| v as f32 / 255.0).collect();
+
+    // Reshape to [H, W, 3] then permute to [3, H, W]
+    let tensor = Tensor::from_vec(data, (h, w, 3), &Device::Cpu)?;
+    let tensor = tensor.permute((2, 0, 1))?; // [3, H, W]
+
+    // Normalize to desired range
+    let tensor = match range {
+        NormalizeRange::MinusOneToOne => {
+            // [0,1] -> [-1,1]: x * 2 - 1
+            ((tensor * 2.0)? - 1.0)?
+        }
+        NormalizeRange::ZeroToOne => tensor,
+    };
+
+    // Add batch dimension: [1, 3, H, W]
+    let tensor = tensor.unsqueeze(0)?;
+    // Cast to target dtype and move to device
+    let tensor = tensor.to_dtype(dtype)?.to_device(device)?;
+
+    Ok(tensor)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Create a tiny 4x4 red PNG for testing.
+    fn tiny_png() -> Vec<u8> {
+        let img = image::RgbImage::from_fn(4, 4, |_, _| image::Rgb([255, 0, 0]));
+        let mut buf = std::io::Cursor::new(Vec::new());
+        img.write_to(&mut buf, image::ImageFormat::Png).unwrap();
+        buf.into_inner()
+    }
+
+    #[test]
+    fn decode_source_image_shape() {
+        let png = tiny_png();
+        let tensor = decode_source_image(
+            &png,
+            8,
+            8,
+            NormalizeRange::ZeroToOne,
+            &Device::Cpu,
+            DType::F32,
+        )
+        .unwrap();
+        assert_eq!(tensor.dims(), &[1, 3, 8, 8]);
+    }
+
+    #[test]
+    fn decode_source_image_minus_one_to_one_range() {
+        let png = tiny_png();
+        let tensor = decode_source_image(
+            &png,
+            4,
+            4,
+            NormalizeRange::MinusOneToOne,
+            &Device::Cpu,
+            DType::F32,
+        )
+        .unwrap();
+        // Red channel should be ~1.0 (was 255/255=1.0, then 1.0*2-1=1.0)
+        let min = tensor.min_all().unwrap().to_scalar::<f32>().unwrap();
+        let max = tensor.max_all().unwrap().to_scalar::<f32>().unwrap();
+        assert!(min >= -1.0 - 0.01);
+        assert!(max <= 1.0 + 0.01);
+    }
+
+    #[test]
+    fn decode_source_image_zero_to_one_range() {
+        let png = tiny_png();
+        let tensor = decode_source_image(
+            &png,
+            4,
+            4,
+            NormalizeRange::ZeroToOne,
+            &Device::Cpu,
+            DType::F32,
+        )
+        .unwrap();
+        let min = tensor.min_all().unwrap().to_scalar::<f32>().unwrap();
+        let max = tensor.max_all().unwrap().to_scalar::<f32>().unwrap();
+        assert!(min >= 0.0 - 0.01);
+        assert!(max <= 1.0 + 0.01);
+    }
+
+    #[test]
+    fn decode_source_image_resize() {
+        let png = tiny_png(); // 4x4 source
+        let tensor = decode_source_image(
+            &png,
+            16,
+            16,
+            NormalizeRange::ZeroToOne,
+            &Device::Cpu,
+            DType::F32,
+        )
+        .unwrap();
+        assert_eq!(tensor.dims(), &[1, 3, 16, 16]);
+    }
+}

--- a/crates/mold-inference/src/lib.rs
+++ b/crates/mold-inference/src/lib.rs
@@ -6,6 +6,7 @@ mod factory;
 pub mod flux;
 pub mod flux2;
 mod image;
+pub mod img_utils;
 pub mod model_registry;
 pub mod progress;
 pub mod qwen_image;

--- a/crates/mold-inference/src/qwen_image/pipeline.rs
+++ b/crates/mold-inference/src/qwen_image/pipeline.rs
@@ -579,6 +579,9 @@ impl InferenceEngine for QwenImageEngine {
                 "scheduler selection not supported for Qwen-Image (flow-matching), ignoring"
             );
         }
+        if req.source_image.is_some() {
+            tracing::warn!("img2img not yet supported for Qwen-Image — generating from text only");
+        }
 
         // Sequential mode: load-use-drop each component
         if self.load_strategy == LoadStrategy::Sequential {

--- a/crates/mold-inference/src/sd15/pipeline.rs
+++ b/crates/mold-inference/src/sd15/pipeline.rs
@@ -186,6 +186,9 @@ impl SD15Engine {
     }
 
     /// Run the denoising loop (shared between eager and sequential).
+    ///
+    /// `start_step` allows starting from a later timestep for img2img (0 = full txt2img).
+    #[allow(clippy::too_many_arguments)]
     fn denoise_loop(
         &self,
         unet: &stable_diffusion::unet_2d::UNet2DConditionModel,
@@ -194,6 +197,7 @@ impl SD15Engine {
         latents: &mut Tensor,
         guidance: f64,
         steps: u32,
+        start_step: usize,
     ) -> Result<()> {
         let use_cfg = guidance > 1.0;
         let mut scheduler = crate::scheduler::build_scheduler(
@@ -203,12 +207,13 @@ impl SD15Engine {
             false,
         )?;
         let timesteps = scheduler.timesteps().to_vec();
+        let active_timesteps = &timesteps[start_step..];
 
-        let denoise_label = format!("Denoising ({} steps)", timesteps.len());
+        let denoise_label = format!("Denoising ({} steps)", active_timesteps.len());
         self.progress.stage_start(&denoise_label);
         let denoise_start = Instant::now();
 
-        for (step_idx, &t) in timesteps.iter().enumerate() {
+        for (step_idx, &t) in active_timesteps.iter().enumerate() {
             let step_start = std::time::Instant::now();
             let latent_input = if use_cfg {
                 Tensor::cat(&[&*latents, &*latents], 0)?
@@ -231,7 +236,7 @@ impl SD15Engine {
             *latents = scheduler.step(&noise_pred, t, &*latents)?;
             self.progress.emit(ProgressEvent::DenoiseStep {
                 step: step_idx + 1,
-                total: timesteps.len(),
+                total: active_timesteps.len(),
                 elapsed: step_start.elapsed(),
             });
         }
@@ -239,6 +244,80 @@ impl SD15Engine {
         self.progress
             .stage_done(&denoise_label, denoise_start.elapsed());
         Ok(())
+    }
+
+    /// Prepare img2img latents: VAE encode source image, add noise at the appropriate timestep.
+    /// Returns (noised_latents, start_step).
+    #[allow(clippy::too_many_arguments)]
+    fn prepare_img2img_latents(
+        &self,
+        vae: &stable_diffusion::vae::AutoEncoderKL,
+        source_bytes: &[u8],
+        width: u32,
+        height: u32,
+        strength: f64,
+        steps: u32,
+        sched: Scheduler,
+        seed: u64,
+        device: &Device,
+        dtype: DType,
+    ) -> Result<(Tensor, usize)> {
+        use crate::img_utils::{decode_source_image, NormalizeRange};
+
+        self.progress.stage_start("Encoding source image (VAE)");
+        let encode_start = Instant::now();
+
+        // Decode and preprocess source image to [-1, 1]
+        let source_tensor = decode_source_image(
+            source_bytes,
+            width,
+            height,
+            NormalizeRange::MinusOneToOne,
+            device,
+            dtype,
+        )?;
+
+        // VAE encode: returns DiagonalGaussianDistribution, sample from it
+        let encoded = vae.encode(&source_tensor)?;
+        let encoded = (encoded.sample()? * VAE_SCALE)?;
+
+        self.progress
+            .stage_done("Encoding source image (VAE)", encode_start.elapsed());
+
+        // Compute start step
+        let start_step = ((steps as f64) * (1.0 - strength)).round() as usize;
+        let start_step = start_step.min(steps as usize);
+
+        // Build scheduler to get timesteps and add noise
+        let scheduler = crate::scheduler::build_scheduler(
+            sched,
+            steps as usize,
+            PredictionType::Epsilon,
+            false,
+        )?;
+        let timesteps = scheduler.timesteps().to_vec();
+
+        let latent_h = height as usize / 8;
+        let latent_w = width as usize / 8;
+        let noise =
+            crate::engine::seeded_randn(seed, &[1, 4, latent_h, latent_w], device, DType::F32)?;
+        let noise = noise.to_dtype(dtype)?;
+
+        // Add noise at the start timestep
+        let noised = if start_step < timesteps.len() {
+            scheduler.add_noise(&encoded, noise, timesteps[start_step])?
+        } else {
+            encoded
+        };
+
+        tracing::info!(
+            start_step,
+            total_steps = steps,
+            strength,
+            "img2img: starting from step {start_step}"
+        );
+
+        Ok((noised, start_step))
     }
 
     /// Encode prompt with the single CLIP-L encoder.
@@ -368,20 +447,58 @@ impl SD15Engine {
             .stage_done("Loading UNet (GPU)", unet_start.elapsed());
 
         let sched = req.scheduler.unwrap_or(self.scheduler);
-        let latent_h = height / 8;
-        let latent_w = width / 8;
-        let init_scheduler = crate::scheduler::build_scheduler(
-            sched,
-            req.steps as usize,
-            PredictionType::Epsilon,
-            false,
-        )?;
-        let init_noise_sigma = init_scheduler.init_noise_sigma();
-        drop(init_scheduler);
-        let mut latents =
-            (crate::engine::seeded_randn(seed, &[1, 4, latent_h, latent_w], &device, DType::F32)?
-                * init_noise_sigma)?;
-        latents = latents.to_dtype(dtype)?;
+        let is_img2img = req.source_image.is_some();
+
+        // For img2img in sequential mode, we need the VAE for encoding before the UNet
+        let (mut latents, start_step) = if let Some(ref source_bytes) = req.source_image {
+            self.progress
+                .info("img2img mode: encoding source image before denoising");
+
+            // Load VAE first for encoding
+            self.progress.stage_start("Loading VAE (GPU)");
+            let vae_start = Instant::now();
+            let vae = sd_config.build_vae(&self.paths.vae, &device, dtype)?;
+            self.progress
+                .stage_done("Loading VAE (GPU)", vae_start.elapsed());
+
+            let (latents, start_step) = self.prepare_img2img_latents(
+                &vae,
+                source_bytes,
+                req.width,
+                req.height,
+                req.strength,
+                req.steps,
+                sched,
+                seed,
+                &device,
+                dtype,
+            )?;
+
+            // Drop VAE to free memory for UNet
+            drop(vae);
+            self.progress.info("Freed VAE (will reload for decode)");
+            device.synchronize()?;
+
+            (latents, start_step)
+        } else {
+            let latent_h = height / 8;
+            let latent_w = width / 8;
+            let init_scheduler = crate::scheduler::build_scheduler(
+                sched,
+                req.steps as usize,
+                PredictionType::Epsilon,
+                false,
+            )?;
+            let init_noise_sigma = init_scheduler.init_noise_sigma();
+            drop(init_scheduler);
+            let latents = (crate::engine::seeded_randn(
+                seed,
+                &[1, 4, latent_h, latent_w],
+                &device,
+                DType::F32,
+            )? * init_noise_sigma)?;
+            (latents.to_dtype(dtype)?, 0)
+        };
 
         self.denoise_loop(
             &unet,
@@ -390,6 +507,7 @@ impl SD15Engine {
             &mut latents,
             guidance,
             req.steps,
+            start_step,
         )?;
 
         // Drop UNet to free memory for VAE decode
@@ -400,11 +518,17 @@ impl SD15Engine {
         tracing::info!("UNet dropped (sequential mode)");
 
         // --- Phase 3: Load VAE and decode ---
-        self.progress.stage_start("Loading VAE (GPU)");
+        // (img2img already loaded+dropped VAE above; reload for decode)
+        let vae_load_label = if is_img2img {
+            "Reloading VAE (GPU)"
+        } else {
+            "Loading VAE (GPU)"
+        };
+        self.progress.stage_start(vae_load_label);
         let vae_start = Instant::now();
         let vae = sd_config.build_vae(&self.paths.vae, &device, dtype)?;
         self.progress
-            .stage_done("Loading VAE (GPU)", vae_start.elapsed());
+            .stage_done(vae_load_label, vae_start.elapsed());
 
         self.progress.stage_start("VAE decode");
         let vae_decode_start = Instant::now();
@@ -486,23 +610,39 @@ impl InferenceEngine for SD15Engine {
 
         // 2. Build scheduler and create initial latents
         let sched = req.scheduler.unwrap_or(self.scheduler);
-        let latent_h = height / 8;
-        let latent_w = width / 8;
-        let init_scheduler = crate::scheduler::build_scheduler(
-            sched,
-            req.steps as usize,
-            PredictionType::Epsilon,
-            false,
-        )?;
-        let init_noise_sigma = init_scheduler.init_noise_sigma();
-        drop(init_scheduler);
-        let mut latents = (crate::engine::seeded_randn(
-            seed,
-            &[1, 4, latent_h, latent_w],
-            &loaded.device,
-            DType::F32,
-        )? * init_noise_sigma)?;
-        latents = latents.to_dtype(loaded.dtype)?;
+
+        let (mut latents, start_step) = if let Some(ref source_bytes) = req.source_image {
+            self.prepare_img2img_latents(
+                &loaded.vae,
+                source_bytes,
+                req.width,
+                req.height,
+                req.strength,
+                req.steps,
+                sched,
+                seed,
+                &loaded.device,
+                loaded.dtype,
+            )?
+        } else {
+            let latent_h = height / 8;
+            let latent_w = width / 8;
+            let init_scheduler = crate::scheduler::build_scheduler(
+                sched,
+                req.steps as usize,
+                PredictionType::Epsilon,
+                false,
+            )?;
+            let init_noise_sigma = init_scheduler.init_noise_sigma();
+            drop(init_scheduler);
+            let latents = (crate::engine::seeded_randn(
+                seed,
+                &[1, 4, latent_h, latent_w],
+                &loaded.device,
+                DType::F32,
+            )? * init_noise_sigma)?;
+            (latents.to_dtype(loaded.dtype)?, 0)
+        };
 
         // 3. Denoising loop
         self.denoise_loop(
@@ -512,6 +652,7 @@ impl InferenceEngine for SD15Engine {
             &mut latents,
             guidance,
             req.steps,
+            start_step,
         )?;
 
         // 4. VAE decode

--- a/crates/mold-inference/src/sd3/pipeline.rs
+++ b/crates/mold-inference/src/sd3/pipeline.rs
@@ -543,6 +543,9 @@ impl InferenceEngine for SD3Engine {
         if req.scheduler.is_some() {
             tracing::warn!("scheduler selection not supported for SD3 (flow-matching), ignoring");
         }
+        if req.source_image.is_some() {
+            tracing::warn!("img2img not yet supported for SD3 — generating from text only");
+        }
 
         // Sequential mode: load-use-drop each component
         if self.load_strategy == LoadStrategy::Sequential {

--- a/crates/mold-inference/src/sdxl/pipeline.rs
+++ b/crates/mold-inference/src/sdxl/pipeline.rs
@@ -243,6 +243,9 @@ impl SDXLEngine {
     }
 
     /// Run the denoising loop (shared between eager and sequential).
+    ///
+    /// `start_step` allows starting from a later timestep for img2img (0 = full txt2img).
+    #[allow(clippy::too_many_arguments)]
     fn denoise_loop(
         &self,
         unet: &stable_diffusion::unet_2d::UNet2DConditionModel,
@@ -251,6 +254,7 @@ impl SDXLEngine {
         latents: &mut Tensor,
         guidance: f64,
         steps: u32,
+        start_step: usize,
     ) -> Result<()> {
         let use_cfg = guidance > 1.0;
         let mut scheduler = crate::scheduler::build_scheduler(
@@ -260,12 +264,13 @@ impl SDXLEngine {
             self.is_turbo,
         )?;
         let timesteps = scheduler.timesteps().to_vec();
+        let active_timesteps = &timesteps[start_step..];
 
-        let denoise_label = format!("Denoising ({} steps)", timesteps.len());
+        let denoise_label = format!("Denoising ({} steps)", active_timesteps.len());
         self.progress.stage_start(&denoise_label);
         let denoise_start = Instant::now();
 
-        for (step_idx, &t) in timesteps.iter().enumerate() {
+        for (step_idx, &t) in active_timesteps.iter().enumerate() {
             let step_start = std::time::Instant::now();
             let latent_input = if use_cfg {
                 Tensor::cat(&[&*latents, &*latents], 0)?
@@ -288,7 +293,7 @@ impl SDXLEngine {
             *latents = scheduler.step(&noise_pred, t, &*latents)?;
             self.progress.emit(ProgressEvent::DenoiseStep {
                 step: step_idx + 1,
-                total: timesteps.len(),
+                total: active_timesteps.len(),
                 elapsed: step_start.elapsed(),
             });
         }
@@ -296,6 +301,81 @@ impl SDXLEngine {
         self.progress
             .stage_done(&denoise_label, denoise_start.elapsed());
         Ok(())
+    }
+
+    /// Prepare img2img latents: VAE encode source image, add noise at the appropriate timestep.
+    /// Returns (noised_latents, start_step).
+    #[allow(clippy::too_many_arguments)]
+    fn prepare_img2img_latents(
+        &self,
+        vae: &stable_diffusion::vae::AutoEncoderKL,
+        source_bytes: &[u8],
+        width: u32,
+        height: u32,
+        strength: f64,
+        steps: u32,
+        sched: Scheduler,
+        seed: u64,
+        device: &Device,
+        dtype: DType,
+    ) -> Result<(Tensor, usize)> {
+        use crate::img_utils::{decode_source_image, NormalizeRange};
+
+        self.progress.stage_start("Encoding source image (VAE)");
+        let encode_start = Instant::now();
+
+        let source_tensor = decode_source_image(
+            source_bytes,
+            width,
+            height,
+            NormalizeRange::MinusOneToOne,
+            device,
+            dtype,
+        )?;
+
+        let vae_scale = if self.is_turbo {
+            VAE_SCALE_TURBO
+        } else {
+            VAE_SCALE_STANDARD
+        };
+
+        let encoded = vae.encode(&source_tensor)?;
+        let encoded = (encoded.sample()? * vae_scale)?;
+
+        self.progress
+            .stage_done("Encoding source image (VAE)", encode_start.elapsed());
+
+        let start_step = ((steps as f64) * (1.0 - strength)).round() as usize;
+        let start_step = start_step.min(steps as usize);
+
+        let scheduler = crate::scheduler::build_scheduler(
+            sched,
+            steps as usize,
+            PredictionType::Epsilon,
+            self.is_turbo,
+        )?;
+        let timesteps = scheduler.timesteps().to_vec();
+
+        let latent_h = height as usize / 8;
+        let latent_w = width as usize / 8;
+        let noise =
+            crate::engine::seeded_randn(seed, &[1, 4, latent_h, latent_w], device, DType::F32)?;
+        let noise = noise.to_dtype(dtype)?;
+
+        let noised = if start_step < timesteps.len() {
+            scheduler.add_noise(&encoded, noise, timesteps[start_step])?
+        } else {
+            encoded
+        };
+
+        tracing::info!(
+            start_step,
+            total_steps = steps,
+            strength,
+            "img2img: starting from step {start_step}"
+        );
+
+        Ok((noised, start_step))
     }
 
     /// Encode prompt with both CLIP encoders.
@@ -464,20 +544,55 @@ impl SDXLEngine {
             .stage_done("Loading UNet (GPU)", unet_start.elapsed());
 
         let sched = req.scheduler.unwrap_or(self.scheduler);
-        let latent_h = height / 8;
-        let latent_w = width / 8;
-        let init_scheduler = crate::scheduler::build_scheduler(
-            sched,
-            req.steps as usize,
-            PredictionType::Epsilon,
-            self.is_turbo,
-        )?;
-        let init_noise_sigma = init_scheduler.init_noise_sigma();
-        drop(init_scheduler);
-        let mut latents =
-            (crate::engine::seeded_randn(seed, &[1, 4, latent_h, latent_w], &device, DType::F32)?
-                * init_noise_sigma)?;
-        latents = latents.to_dtype(dtype)?;
+        let is_img2img = req.source_image.is_some();
+
+        let (mut latents, start_step) = if let Some(ref source_bytes) = req.source_image {
+            self.progress
+                .info("img2img mode: encoding source image before denoising");
+
+            self.progress.stage_start("Loading VAE (GPU)");
+            let vae_start_t = Instant::now();
+            let vae = sd_config.build_vae(&self.paths.vae, &device, dtype)?;
+            self.progress
+                .stage_done("Loading VAE (GPU)", vae_start_t.elapsed());
+
+            let (latents, start_step) = self.prepare_img2img_latents(
+                &vae,
+                source_bytes,
+                req.width,
+                req.height,
+                req.strength,
+                req.steps,
+                sched,
+                seed,
+                &device,
+                dtype,
+            )?;
+
+            drop(vae);
+            self.progress.info("Freed VAE (will reload for decode)");
+            device.synchronize()?;
+
+            (latents, start_step)
+        } else {
+            let latent_h = height / 8;
+            let latent_w = width / 8;
+            let init_scheduler = crate::scheduler::build_scheduler(
+                sched,
+                req.steps as usize,
+                PredictionType::Epsilon,
+                self.is_turbo,
+            )?;
+            let init_noise_sigma = init_scheduler.init_noise_sigma();
+            drop(init_scheduler);
+            let latents = (crate::engine::seeded_randn(
+                seed,
+                &[1, 4, latent_h, latent_w],
+                &device,
+                DType::F32,
+            )? * init_noise_sigma)?;
+            (latents.to_dtype(dtype)?, 0)
+        };
 
         self.denoise_loop(
             &unet,
@@ -486,6 +601,7 @@ impl SDXLEngine {
             &mut latents,
             guidance,
             req.steps,
+            start_step,
         )?;
 
         // Drop UNet to free memory for VAE decode
@@ -496,11 +612,16 @@ impl SDXLEngine {
         tracing::info!("UNet dropped (sequential mode)");
 
         // --- Phase 3: Load VAE and decode ---
-        self.progress.stage_start("Loading VAE (GPU)");
+        let vae_load_label = if is_img2img {
+            "Reloading VAE (GPU)"
+        } else {
+            "Loading VAE (GPU)"
+        };
+        self.progress.stage_start(vae_load_label);
         let vae_start = Instant::now();
         let vae = sd_config.build_vae(&self.paths.vae, &device, dtype)?;
         self.progress
-            .stage_done("Loading VAE (GPU)", vae_start.elapsed());
+            .stage_done(vae_load_label, vae_start.elapsed());
 
         self.progress.stage_start("VAE decode");
         let vae_decode_start = Instant::now();
@@ -588,25 +709,41 @@ impl InferenceEngine for SDXLEngine {
             guidance,
         )?;
 
-        // 3. Build scheduler
+        // 3. Build scheduler and create initial latents
         let sched = req.scheduler.unwrap_or(self.scheduler);
-        let latent_h = height / 8;
-        let latent_w = width / 8;
-        let init_scheduler = crate::scheduler::build_scheduler(
-            sched,
-            req.steps as usize,
-            PredictionType::Epsilon,
-            self.is_turbo,
-        )?;
-        let init_noise_sigma = init_scheduler.init_noise_sigma();
-        drop(init_scheduler);
-        let mut latents = (crate::engine::seeded_randn(
-            seed,
-            &[1, 4, latent_h, latent_w],
-            &loaded.device,
-            DType::F32,
-        )? * init_noise_sigma)?;
-        latents = latents.to_dtype(loaded.dtype)?;
+
+        let (mut latents, start_step) = if let Some(ref source_bytes) = req.source_image {
+            self.prepare_img2img_latents(
+                &loaded.vae,
+                source_bytes,
+                req.width,
+                req.height,
+                req.strength,
+                req.steps,
+                sched,
+                seed,
+                &loaded.device,
+                loaded.dtype,
+            )?
+        } else {
+            let latent_h = height / 8;
+            let latent_w = width / 8;
+            let init_scheduler = crate::scheduler::build_scheduler(
+                sched,
+                req.steps as usize,
+                PredictionType::Epsilon,
+                self.is_turbo,
+            )?;
+            let init_noise_sigma = init_scheduler.init_noise_sigma();
+            drop(init_scheduler);
+            let latents = (crate::engine::seeded_randn(
+                seed,
+                &[1, 4, latent_h, latent_w],
+                &loaded.device,
+                DType::F32,
+            )? * init_noise_sigma)?;
+            (latents.to_dtype(loaded.dtype)?, 0)
+        };
 
         // 5. Denoising loop
         self.denoise_loop(
@@ -616,6 +753,7 @@ impl InferenceEngine for SDXLEngine {
             &mut latents,
             guidance,
             req.steps,
+            start_step,
         )?;
 
         // 6. VAE decode

--- a/crates/mold-inference/src/wuerstchen/pipeline.rs
+++ b/crates/mold-inference/src/wuerstchen/pipeline.rs
@@ -564,6 +564,9 @@ impl InferenceEngine for WuerstchenEngine {
         if req.scheduler.is_some() {
             tracing::warn!("scheduler selection not supported for Wuerstchen, ignoring");
         }
+        if req.source_image.is_some() {
+            tracing::warn!("img2img not yet supported for Wuerstchen — generating from text only");
+        }
 
         if self.load_strategy == LoadStrategy::Sequential {
             return self.generate_sequential(req);

--- a/crates/mold-inference/src/zimage/pipeline.rs
+++ b/crates/mold-inference/src/zimage/pipeline.rs
@@ -596,6 +596,9 @@ impl InferenceEngine for ZImageEngine {
                 "scheduler selection not supported for Z-Image (flow-matching), ignoring"
             );
         }
+        if req.source_image.is_some() {
+            tracing::warn!("img2img not yet supported for Z-Image — generating from text only");
+        }
 
         // Sequential mode: load-use-drop each component
         if self.load_strategy == LoadStrategy::Sequential {


### PR DESCRIPTION
## Summary

Implements img2img (image-to-image) generation for the SD1.5, SDXL, and FLUX model families, allowing users to provide a source image that guides generation output.

- **Core types**: Added `source_image` (base64-encoded bytes) and `strength` fields to `GenerateRequest` with custom serde module for `Option<Vec<u8>>` base64 wire format
- **Image utilities**: New `img_utils.rs` with `decode_source_image()` for PNG/JPEG decode, Lanczos3 resize, and configurable normalization (`[-1,1]` for UNet, `[0,1]` for flow-matching)
- **SD1.5 & SDXL**: VAE encode → `add_noise` at strength-derived DDIM timestep → denoise from `start_step`. Both eager and sequential loading paths supported
- **FLUX**: VAE encode → linear interpolation `(1-strength)*encoded + strength*noise` → timestep schedule trimmed to start from strength
- **CLI**: `--image <path|->` and `--strength <0.0-1.0>` flags; auto-derives dimensions from source image (rounded to 16); `--image -` reads from stdin
- **Validation**: Strength range `(0.0, 1.0]`, PNG/JPEG magic byte detection
- **Stubs**: SD3, Z-Image, Flux2, Qwen-Image, Wuerstchen log warnings (VAEs lack encode methods)

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo fmt --all --check` passes
- [x] `cargo test --workspace` — 201 tests pass (67 mold-core + 134 mold-cli)
- [ ] Manual: `mold run flux-schnell "a cat in space" --image source.png --strength 0.7`
- [ ] Manual: `cat photo.png | mold run --image - "oil painting style"`
- [ ] Manual: Verify SD1.5 and SDXL img2img with `--local`

Closes #21