### PR TITLE
feat(inference): add ControlNet support for SD1.5 models

### DIFF
--- a/crates/mold-cli/src/commands/generate.rs
+++ b/crates/mold-cli/src/commands/generate.rs
@@ -32,6 +32,10 @@ pub async fn run(
     eager: bool,
     source_image: Option<Vec<u8>>,
     strength: f64,
+    mask_image: Option<Vec<u8>>,
+    control_image: Option<Vec<u8>>,
+    control_model: Option<String>,
+    control_scale: f64,
 ) -> Result<()> {
     let output_format = format;
     let piped = is_piped();
@@ -112,6 +116,10 @@ pub async fn run(
         scheduler,
         source_image: source_image.clone(),
         strength,
+        mask_image: mask_image.clone(),
+        control_image: control_image.clone(),
+        control_model: control_model.clone(),
+        control_scale,
     };
 
     if let Some(desc) = &model_cfg.description {
@@ -122,8 +130,22 @@ pub async fn run(
             crate::output::colorize_description(desc)
         );
     }
-    if source_image.is_some() {
+    if mask_image.is_some() {
+        status!(
+            "{} inpainting mode (strength: {:.2})",
+            "●".magenta(),
+            strength,
+        );
+    } else if source_image.is_some() {
         status!("{} img2img mode (strength: {:.2})", "●".magenta(), strength,);
+    }
+    if let Some(ref cm) = control_model {
+        status!(
+            "{} ControlNet: {} (scale: {:.2})",
+            "●".magenta(),
+            cm.bold(),
+            control_scale
+        );
     }
     status!(
         "{} Generating {}x{} ({} steps, guidance {:.1})",

--- a/crates/mold-cli/src/commands/run.rs
+++ b/crates/mold-cli/src/commands/run.rs
@@ -66,6 +66,10 @@ pub async fn run(
     eager: bool,
     image: Option<String>,
     strength: f64,
+    mask: Option<String>,
+    control: Option<String>,
+    control_model: Option<String>,
+    control_scale: f64,
 ) -> Result<()> {
     let config = Config::load_or_default();
     let (model, prompt) = resolve_run_args(model_or_prompt.as_deref(), &prompt_rest, &config);
@@ -81,6 +85,24 @@ pub async fn run(
             std::fs::read(img_path)
                 .map_err(|e| anyhow::anyhow!("failed to read image '{}': {e}", img_path))?
         };
+        Some(bytes)
+    } else {
+        None
+    };
+
+    // Read control image if --control specified
+    let control_image = if let Some(ref ctrl_path) = control {
+        let bytes = std::fs::read(ctrl_path)
+            .map_err(|e| anyhow::anyhow!("failed to read control image '{}': {e}", ctrl_path))?;
+        Some(bytes)
+    } else {
+        None
+    };
+
+    // Read mask image if --mask specified
+    let mask_image = if let Some(ref mask_path) = mask {
+        let bytes = std::fs::read(mask_path)
+            .map_err(|e| anyhow::anyhow!("failed to read mask '{}': {e}", mask_path))?;
         Some(bytes)
     } else {
         None
@@ -131,6 +153,10 @@ pub async fn run(
         eager,
         source_image,
         strength,
+        mask_image,
+        control_image,
+        control_model,
+        control_scale,
     )
     .await
 }

--- a/crates/mold-cli/src/main.rs
+++ b/crates/mold-cli/src/main.rs
@@ -42,6 +42,7 @@ struct Cli {
 }
 
 #[derive(Subcommand)]
+#[allow(clippy::large_enum_variant)]
 enum Commands {
     /// Generate images from a text prompt
     ///
@@ -127,6 +128,22 @@ Examples:
         /// Denoising strength for img2img (0.0 = no change, 1.0 = full noise)
         #[arg(long, default_value = "0.75", help_heading = "img2img")]
         strength: f64,
+
+        /// Mask image for inpainting (file path; white = repaint, black = preserve)
+        #[arg(long, requires = "image", help_heading = "img2img")]
+        mask: Option<String>,
+
+        /// Control image for ControlNet conditioning (file path, e.g. edges.png)
+        #[arg(long, help_heading = "ControlNet")]
+        control: Option<String>,
+
+        /// ControlNet model name (e.g. controlnet-canny-sd15)
+        #[arg(long, requires = "control", help_heading = "ControlNet")]
+        control_model: Option<String>,
+
+        /// ControlNet conditioning scale (0.0 = no effect, 1.0 = full, up to 2.0)
+        #[arg(long, default_value = "1.0", help_heading = "ControlNet")]
+        control_scale: f64,
     },
 
     /// Start the inference server
@@ -325,6 +342,10 @@ async fn run() -> anyhow::Result<()> {
             eager,
             image,
             strength,
+            mask,
+            control,
+            control_model,
+            control_scale,
         } => {
             commands::run::run(
                 model_or_prompt,
@@ -345,6 +366,10 @@ async fn run() -> anyhow::Result<()> {
                 eager,
                 image,
                 strength,
+                mask,
+                control,
+                control_model,
+                control_scale,
             )
             .await?;
         }

--- a/crates/mold-core/src/manifest.rs
+++ b/crates/mold-core/src/manifest.rs
@@ -474,6 +474,7 @@ fn build_known_manifests() -> Vec<ModelManifest> {
     manifests.extend(flux2_manifests());
     manifests.extend(qwen_image_manifests());
     manifests.extend(wuerstchen_manifests());
+    manifests.extend(controlnet_manifests());
     manifests
 }
 
@@ -1746,6 +1747,64 @@ pub fn paths_from_downloads(downloads: &[(ModelComponent, PathBuf)]) -> Option<M
     })
 }
 
+fn controlnet_manifests() -> Vec<ModelManifest> {
+    let defaults = ManifestDefaults {
+        steps: 25,
+        guidance: 7.5,
+        width: 512,
+        height: 512,
+        is_schnell: false,
+        scheduler: Some(Scheduler::Ddim),
+    };
+    vec![
+        ModelManifest {
+            name: "controlnet-canny-sd15:fp16".to_string(),
+            family: "controlnet".to_string(),
+            description: "ControlNet Canny edge detection for SD1.5".to_string(),
+            size_gb: 1.4,
+            files: vec![ModelFile {
+                hf_repo: "lllyasviel/control_v11p_sd15_canny".to_string(),
+                hf_filename: "diffusion_pytorch_model.fp16.safetensors".to_string(),
+                component: ModelComponent::Transformer,
+                size_bytes: 1_450_000_000,
+                gated: false,
+                sha256: None,
+            }],
+            defaults: defaults.clone(),
+        },
+        ModelManifest {
+            name: "controlnet-depth-sd15:fp16".to_string(),
+            family: "controlnet".to_string(),
+            description: "ControlNet depth estimation for SD1.5".to_string(),
+            size_gb: 1.4,
+            files: vec![ModelFile {
+                hf_repo: "lllyasviel/control_v11f1p_sd15_depth".to_string(),
+                hf_filename: "diffusion_pytorch_model.fp16.safetensors".to_string(),
+                component: ModelComponent::Transformer,
+                size_bytes: 1_450_000_000,
+                gated: false,
+                sha256: None,
+            }],
+            defaults: defaults.clone(),
+        },
+        ModelManifest {
+            name: "controlnet-openpose-sd15:fp16".to_string(),
+            family: "controlnet".to_string(),
+            description: "ControlNet OpenPose body detection for SD1.5".to_string(),
+            size_gb: 1.4,
+            files: vec![ModelFile {
+                hf_repo: "lllyasviel/control_v11p_sd15_openpose".to_string(),
+                hf_filename: "diffusion_pytorch_model.fp16.safetensors".to_string(),
+                component: ModelComponent::Transformer,
+                size_bytes: 1_450_000_000,
+                gated: false,
+                sha256: None,
+            }],
+            defaults,
+        },
+    ]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1943,20 +2002,22 @@ mod tests {
 
     #[test]
     fn known_manifests_count() {
-        // 9 FLUX + 3 SD1.5 + 4 SD3 + 6 SDXL + 4 Z-Image + 1 Flux.2 + 4 Qwen-Image + 1 Wuerstchen = 32
-        assert_eq!(known_manifests().len(), 32);
+        // 9 FLUX + 3 SD1.5 + 4 SD3 + 6 SDXL + 4 Z-Image + 1 Flux.2 + 4 Qwen-Image + 1 Wuerstchen + 3 ControlNet = 35
+        assert_eq!(known_manifests().len(), 35);
     }
 
     #[test]
     fn manifest_has_required_components() {
         for manifest in known_manifests() {
             let components: Vec<_> = manifest.files.iter().map(|f| f.component).collect();
-            // All models need VAE
-            assert!(
-                components.contains(&ModelComponent::Vae),
-                "{} missing Vae",
-                manifest.name
-            );
+            // All models need VAE (except ControlNet, which uses the base model's VAE)
+            if manifest.family != "controlnet" {
+                assert!(
+                    components.contains(&ModelComponent::Vae),
+                    "{} missing Vae",
+                    manifest.name
+                );
+            }
 
             match manifest.family.as_str() {
                 "flux" => {
@@ -2149,6 +2210,14 @@ mod tests {
                     assert!(
                         !components.contains(&ModelComponent::ClipEncoder),
                         "{} (qwen-image) should not have ClipEncoder",
+                        manifest.name
+                    );
+                }
+                "controlnet" => {
+                    // ControlNet only needs the transformer weights (no VAE, CLIP, etc.)
+                    assert!(
+                        components.contains(&ModelComponent::Transformer),
+                        "{} (controlnet) missing Transformer",
                         manifest.name
                     );
                 }

--- a/crates/mold-core/src/types.rs
+++ b/crates/mold-core/src/types.rs
@@ -105,6 +105,19 @@ pub struct GenerateRequest {
     /// Denoising strength for img2img (0.0 = no change, 1.0 = full noise / txt2img).
     #[serde(default = "default_strength")]
     pub strength: f64,
+    /// Mask image for inpainting (raw PNG/JPEG bytes, base64-encoded in JSON).
+    /// White (255) = repaint, black (0) = preserve. Requires source_image.
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "base64_opt")]
+    pub mask_image: Option<Vec<u8>>,
+    /// Control image for ControlNet conditioning (raw PNG/JPEG bytes, base64-encoded in JSON).
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "base64_opt")]
+    pub control_image: Option<Vec<u8>>,
+    /// ControlNet model name (e.g. "controlnet-canny-sd15").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub control_model: Option<String>,
+    /// ControlNet conditioning scale (0.0 = no effect, 1.0 = full conditioning).
+    #[serde(default = "default_control_scale")]
+    pub control_scale: f64,
 }
 
 fn default_guidance() -> f64 {
@@ -117,6 +130,10 @@ fn default_batch_size() -> u32 {
 
 fn default_strength() -> f64 {
     0.75
+}
+
+fn default_control_scale() -> f64 {
+    1.0
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
@@ -323,6 +340,10 @@ mod tests {
             scheduler: None,
             source_image: None,
             strength: 0.75,
+            mask_image: None,
+            control_image: None,
+            control_model: None,
+            control_scale: 1.0,
         };
         let json = serde_json::to_string(&req).unwrap();
         let back: GenerateRequest = serde_json::from_str(&json).unwrap();
@@ -511,6 +532,10 @@ mod tests {
             scheduler: None,
             source_image: Some(image_bytes.clone()),
             strength: 0.5,
+            mask_image: None,
+            control_image: None,
+            control_model: None,
+            control_scale: 1.0,
         };
         let json = serde_json::to_string(&req).unwrap();
         // Verify base64 encoding is in the JSON
@@ -552,8 +577,99 @@ mod tests {
             scheduler: None,
             source_image: None,
             strength: 0.75,
+            mask_image: None,
+            control_image: None,
+            control_model: None,
+            control_scale: 1.0,
         };
         let json = serde_json::to_string(&req).unwrap();
         assert!(!json.contains("source_image"));
+        assert!(!json.contains("control_image"));
+    }
+
+    // ── ControlNet field tests ─────────────────────────────────────────────
+
+    #[test]
+    fn generate_request_control_image_base64_roundtrip() {
+        let control_bytes = vec![0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+        let req = GenerateRequest {
+            prompt: "test".to_string(),
+            model: "test".to_string(),
+            width: 512,
+            height: 512,
+            steps: 4,
+            guidance: 3.5,
+            seed: None,
+            batch_size: 1,
+            output_format: OutputFormat::Png,
+            scheduler: None,
+            source_image: None,
+            strength: 0.75,
+            mask_image: None,
+            control_image: Some(control_bytes.clone()),
+            control_model: Some("controlnet-canny-sd15".to_string()),
+            control_scale: 0.8,
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("control_image"));
+        assert!(json.contains("controlnet-canny-sd15"));
+        let back: GenerateRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.control_image, Some(control_bytes));
+        assert_eq!(back.control_model.as_deref(), Some("controlnet-canny-sd15"));
+        assert_eq!(back.control_scale, 0.8);
+    }
+
+    #[test]
+    fn generate_request_backward_compat_no_control_fields() {
+        let json =
+            r#"{"prompt":"test","model":"test","width":512,"height":512,"steps":4,"batch_size":1}"#;
+        let req: GenerateRequest = serde_json::from_str(json).unwrap();
+        assert!(req.control_image.is_none());
+        assert!(req.control_model.is_none());
+        assert!((req.control_scale - 1.0).abs() < 0.001);
+    }
+
+    #[test]
+    fn generate_request_control_scale_defaults_to_1() {
+        let json = r#"{"prompt":"test","model":"test","width":512,"height":512,"steps":4}"#;
+        let req: GenerateRequest = serde_json::from_str(json).unwrap();
+        assert!((req.control_scale - 1.0).abs() < 0.001);
+    }
+    // ── Inpainting field tests ────────────────────────────────────────────
+
+    #[test]
+    fn generate_request_mask_image_base64_roundtrip() {
+        let mask_bytes = vec![0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+        let source_bytes = vec![0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+        let req = GenerateRequest {
+            prompt: "test".to_string(),
+            model: "test".to_string(),
+            width: 512,
+            height: 512,
+            steps: 4,
+            guidance: 3.5,
+            seed: None,
+            batch_size: 1,
+            output_format: OutputFormat::Png,
+            scheduler: None,
+            source_image: Some(source_bytes),
+            strength: 0.75,
+            mask_image: Some(mask_bytes.clone()),
+            control_image: None,
+            control_model: None,
+            control_scale: 1.0,
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("mask_image"));
+        let back: GenerateRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.mask_image, Some(mask_bytes));
+    }
+
+    #[test]
+    fn generate_request_backward_compat_no_mask_image() {
+        let json =
+            r#"{"prompt":"test","model":"test","width":512,"height":512,"steps":4,"batch_size":1}"#;
+        let req: GenerateRequest = serde_json::from_str(json).unwrap();
+        assert!(req.mask_image.is_none());
     }
 }

--- a/crates/mold-core/src/validation.rs
+++ b/crates/mold-core/src/validation.rs
@@ -66,6 +66,37 @@ pub fn validate_generate_request(req: &GenerateRequest) -> Result<(), String> {
             return Err("source_image must be a PNG or JPEG image".to_string());
         }
     }
+    // ControlNet validation
+    if let Some(ref ctrl) = req.control_image {
+        if req.control_model.is_none() {
+            return Err("control_image requires control_model to also be provided".to_string());
+        }
+        let is_png = ctrl.len() >= 4 && ctrl[..4] == [0x89, 0x50, 0x4E, 0x47];
+        let is_jpeg = ctrl.len() >= 2 && ctrl[..2] == [0xFF, 0xD8];
+        if !is_png && !is_jpeg {
+            return Err("control_image must be a PNG or JPEG image".to_string());
+        }
+        if req.control_scale < 0.0 {
+            return Err(format!(
+                "control_scale ({}) must be >= 0.0",
+                req.control_scale
+            ));
+        }
+    }
+    if req.control_model.is_some() && req.control_image.is_none() {
+        return Err("control_model requires control_image to also be provided".to_string());
+    }
+    // Inpainting validation
+    if let Some(ref mask) = req.mask_image {
+        if req.source_image.is_none() {
+            return Err("mask_image requires source_image to also be provided".to_string());
+        }
+        let is_png = mask.len() >= 4 && mask[..4] == [0x89, 0x50, 0x4E, 0x47];
+        let is_jpeg = mask.len() >= 2 && mask[..2] == [0xFF, 0xD8];
+        if !is_png && !is_jpeg {
+            return Err("mask_image must be a PNG or JPEG image".to_string());
+        }
+    }
     Ok(())
 }
 
@@ -88,6 +119,10 @@ mod tests {
             scheduler: None,
             source_image: None,
             strength: 0.75,
+            mask_image: None,
+            control_image: None,
+            control_model: None,
+            control_scale: 1.0,
         }
     }
 
@@ -303,6 +338,126 @@ mod tests {
         let mut req = valid_req();
         req.source_image = None;
         req.strength = 0.0; // Would fail if source_image present, but should pass without
+        assert!(validate_generate_request(&req).is_ok());
+    }
+
+    // ── ControlNet validation tests ────────────────────────────────────────
+
+    #[test]
+    fn controlnet_valid_request() {
+        let mut req = valid_req();
+        req.control_image = Some(png_bytes());
+        req.control_model = Some("controlnet-canny-sd15".to_string());
+        req.control_scale = 0.8;
+        assert!(validate_generate_request(&req).is_ok());
+    }
+
+    #[test]
+    fn controlnet_image_without_model_rejected() {
+        let mut req = valid_req();
+        req.control_image = Some(png_bytes());
+        req.control_model = None;
+        assert!(validate_generate_request(&req)
+            .unwrap_err()
+            .contains("control_model"));
+    }
+
+    #[test]
+    fn controlnet_model_without_image_rejected() {
+        let mut req = valid_req();
+        req.control_image = None;
+        req.control_model = Some("controlnet-canny-sd15".to_string());
+        assert!(validate_generate_request(&req)
+            .unwrap_err()
+            .contains("control_image"));
+    }
+
+    #[test]
+    fn controlnet_invalid_image_rejected() {
+        let mut req = valid_req();
+        req.control_image = Some(vec![0x00, 0x01, 0x02, 0x03]);
+        req.control_model = Some("controlnet-canny-sd15".to_string());
+        assert!(validate_generate_request(&req)
+            .unwrap_err()
+            .contains("PNG or JPEG"));
+    }
+
+    #[test]
+    fn controlnet_negative_scale_rejected() {
+        let mut req = valid_req();
+        req.control_image = Some(png_bytes());
+        req.control_model = Some("controlnet-canny-sd15".to_string());
+        req.control_scale = -0.1;
+        assert!(validate_generate_request(&req)
+            .unwrap_err()
+            .contains("control_scale"));
+    }
+
+    #[test]
+    fn controlnet_zero_scale_accepted() {
+        let mut req = valid_req();
+        req.control_image = Some(png_bytes());
+        req.control_model = Some("controlnet-canny-sd15".to_string());
+        req.control_scale = 0.0;
+        assert!(validate_generate_request(&req).is_ok());
+    }
+
+    #[test]
+    fn controlnet_high_scale_accepted() {
+        let mut req = valid_req();
+        req.control_image = Some(png_bytes());
+        req.control_model = Some("controlnet-canny-sd15".to_string());
+        req.control_scale = 2.0;
+        assert!(validate_generate_request(&req).is_ok());
+    }
+
+    #[test]
+    fn controlnet_jpeg_accepted() {
+        let mut req = valid_req();
+        req.control_image = Some(jpeg_bytes());
+        req.control_model = Some("controlnet-canny-sd15".to_string());
+        assert!(validate_generate_request(&req).is_ok());
+    }
+    // ── Inpainting validation tests ───────────────────────────────────────
+
+    #[test]
+    fn mask_without_source_image_rejected() {
+        let mut req = valid_req();
+        req.mask_image = Some(png_bytes());
+        assert!(validate_generate_request(&req)
+            .unwrap_err()
+            .contains("mask_image requires source_image"));
+    }
+
+    #[test]
+    fn mask_with_source_image_accepted() {
+        let mut req = valid_req();
+        req.source_image = Some(png_bytes());
+        req.mask_image = Some(png_bytes());
+        assert!(validate_generate_request(&req).is_ok());
+    }
+
+    #[test]
+    fn mask_jpeg_accepted() {
+        let mut req = valid_req();
+        req.source_image = Some(png_bytes());
+        req.mask_image = Some(jpeg_bytes());
+        assert!(validate_generate_request(&req).is_ok());
+    }
+
+    #[test]
+    fn mask_invalid_bytes_rejected() {
+        let mut req = valid_req();
+        req.source_image = Some(png_bytes());
+        req.mask_image = Some(vec![0x00, 0x01, 0x02, 0x03]);
+        assert!(validate_generate_request(&req)
+            .unwrap_err()
+            .contains("mask_image must be a PNG or JPEG"));
+    }
+
+    #[test]
+    fn no_mask_no_source_passes() {
+        let req = valid_req();
         assert!(validate_generate_request(&req).is_ok());
     }
 }

--- a/crates/mold-inference/src/controlnet/mod.rs
+++ b/crates/mold-inference/src/controlnet/mod.rs
@@ -1,0 +1,2 @@
+mod model;
+pub use model::ControlNetModel;

--- a/crates/mold-inference/src/controlnet/model.rs
+++ b/crates/mold-inference/src/controlnet/model.rs
@@ -1,0 +1,336 @@
+//! ControlNet model for SD1.5.
+//!
+//! Implements the ControlNet architecture: a copy of the UNet encoder half
+//! with zero-initialized convolution outputs at each skip connection.
+//! The outputs are injected into the UNet via `forward_with_additional_residuals`.
+
+use candle_core::{DType, Device, Module, Result, Tensor};
+use candle_nn as nn;
+use candle_transformers::models::stable_diffusion::embeddings::{TimestepEmbedding, Timesteps};
+use candle_transformers::models::stable_diffusion::unet_2d::{
+    BlockConfig, UNet2DConditionModelConfig,
+};
+use candle_transformers::models::stable_diffusion::unet_2d_blocks::*;
+use candle_transformers::models::with_tracing::{conv2d, Conv2d};
+
+/// ControlNet conditioning embedding — projects a 3-channel control image
+/// to the UNet's block channel dimension via a series of convolutions.
+///
+/// Architecture: 3 -> 16 -> 32 -> 96 -> 256 -> block_channels (e.g. 320)
+struct ControlNetConditioningEmbedding {
+    blocks: Vec<Conv2d>,
+}
+
+impl ControlNetConditioningEmbedding {
+    fn new(
+        vs: nn::VarBuilder,
+        conditioning_channels: usize,
+        block_channels: usize,
+    ) -> Result<Self> {
+        let channels = [16, 32, 96, 256];
+        let mut blocks = Vec::new();
+
+        // First conv: 3 -> 16
+        let cfg_pad = nn::Conv2dConfig {
+            padding: 1,
+            ..Default::default()
+        };
+        blocks.push(conv2d(
+            conditioning_channels,
+            channels[0],
+            3,
+            cfg_pad,
+            vs.pp("blocks.0"),
+        )?);
+
+        // Middle convs with stride 2: 16->32, 32->96, 96->256
+        for i in 0..3 {
+            let cfg_stride = nn::Conv2dConfig {
+                padding: 1,
+                stride: 2,
+                ..Default::default()
+            };
+            blocks.push(conv2d(
+                channels[i],
+                channels[i],
+                3,
+                cfg_pad,
+                vs.pp(format!("blocks.{}", 2 * i + 1)),
+            )?);
+            blocks.push(conv2d(
+                channels[i],
+                channels[i + 1],
+                3,
+                cfg_stride,
+                vs.pp(format!("blocks.{}", 2 * i + 2)),
+            )?);
+        }
+
+        // Final conv: 256 -> block_channels
+        blocks.push(conv2d(
+            channels[3],
+            block_channels,
+            3,
+            cfg_pad,
+            vs.pp(format!("blocks.{}", 2 * 3 + 1)),
+        )?);
+
+        Ok(Self { blocks })
+    }
+
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let mut h = xs.clone();
+        for (i, block) in self.blocks.iter().enumerate() {
+            h = block.forward(&h)?;
+            // Apply SiLU after every conv except the last
+            if i < self.blocks.len() - 1 {
+                h = nn::ops::silu(&h)?;
+            }
+        }
+        Ok(h)
+    }
+}
+
+/// Down block types mirroring the UNet (re-exported from candle).
+enum ControlNetDownBlock {
+    Basic(DownBlock2D),
+    CrossAttn(CrossAttnDownBlock2D),
+}
+
+/// ControlNet model: UNet encoder half with zero convolution outputs.
+pub struct ControlNetModel {
+    controlnet_cond_embedding: ControlNetConditioningEmbedding,
+    conv_in: Conv2d,
+    time_proj: Timesteps,
+    time_embedding: TimestepEmbedding,
+    down_blocks: Vec<ControlNetDownBlock>,
+    mid_block: UNetMidBlock2DCrossAttn,
+    /// Zero-initialized 1x1 convolutions, one per down block residual.
+    controlnet_down_blocks: Vec<Conv2d>,
+    /// Zero-initialized 1x1 convolution for the mid block output.
+    controlnet_mid_block: Conv2d,
+}
+
+impl ControlNetModel {
+    /// Load a ControlNet model from safetensors weights.
+    pub fn load<P: AsRef<std::path::Path>>(
+        weights_path: P,
+        device: &Device,
+        dtype: DType,
+        config: UNet2DConditionModelConfig,
+    ) -> anyhow::Result<Self> {
+        let vs =
+            unsafe { nn::VarBuilder::from_mmaped_safetensors(&[weights_path], dtype, device)? };
+        let model = Self::new(vs, config)?;
+        Ok(model)
+    }
+
+    fn new(vs: nn::VarBuilder, config: UNet2DConditionModelConfig) -> Result<Self> {
+        let n_blocks = config.blocks.len();
+        let b_channels = config.blocks[0].out_channels;
+        let bl_channels = config.blocks.last().unwrap().out_channels;
+        let bl_attention_head_dim = config.blocks.last().unwrap().attention_head_dim;
+        let time_embed_dim = b_channels * 4;
+
+        let conv_cfg = nn::Conv2dConfig {
+            padding: 1,
+            ..Default::default()
+        };
+        let conv_in = conv2d(4, b_channels, 3, conv_cfg, vs.pp("conv_in"))?;
+
+        let time_proj = Timesteps::new(b_channels, config.flip_sin_to_cos, config.freq_shift);
+        let time_embedding =
+            TimestepEmbedding::new(vs.pp("time_embedding"), b_channels, time_embed_dim)?;
+
+        // Conditioning embedding for the control image
+        let controlnet_cond_embedding = ControlNetConditioningEmbedding::new(
+            vs.pp("controlnet_cond_embedding"),
+            3,
+            b_channels,
+        )?;
+
+        // Build down blocks (same architecture as UNet encoder)
+        let vs_db = vs.pp("down_blocks");
+        let mut down_blocks = Vec::new();
+        let mut zero_conv_channels = Vec::new();
+
+        // Track channels for zero convs: conv_in output
+        zero_conv_channels.push(b_channels);
+
+        for i in 0..n_blocks {
+            let BlockConfig {
+                out_channels,
+                use_cross_attn,
+                attention_head_dim,
+            } = config.blocks[i];
+
+            let sliced_attention_size = match config.sliced_attention_size {
+                Some(0) => Some(attention_head_dim / 2),
+                _ => config.sliced_attention_size,
+            };
+
+            let in_channels = if i > 0 {
+                config.blocks[i - 1].out_channels
+            } else {
+                b_channels
+            };
+
+            let db_cfg = DownBlock2DConfig {
+                num_layers: config.layers_per_block,
+                resnet_eps: config.norm_eps,
+                resnet_groups: config.norm_num_groups,
+                add_downsample: i < n_blocks - 1,
+                downsample_padding: config.downsample_padding,
+                ..Default::default()
+            };
+
+            // Each resnet produces one residual
+            for _ in 0..config.layers_per_block {
+                zero_conv_channels.push(out_channels);
+            }
+            // Downsample produces one more residual
+            if i < n_blocks - 1 {
+                zero_conv_channels.push(out_channels);
+            }
+
+            if let Some(transformer_layers_per_block) = use_cross_attn {
+                let ca_cfg = CrossAttnDownBlock2DConfig {
+                    downblock: db_cfg,
+                    attn_num_head_channels: attention_head_dim,
+                    cross_attention_dim: config.cross_attention_dim,
+                    sliced_attention_size,
+                    use_linear_projection: config.use_linear_projection,
+                    transformer_layers_per_block,
+                };
+                let block = CrossAttnDownBlock2D::new(
+                    vs_db.pp(i.to_string()),
+                    in_channels,
+                    out_channels,
+                    Some(time_embed_dim),
+                    false, // use_flash_attn
+                    ca_cfg,
+                )?;
+                down_blocks.push(ControlNetDownBlock::CrossAttn(block));
+            } else {
+                let block = DownBlock2D::new(
+                    vs_db.pp(i.to_string()),
+                    in_channels,
+                    out_channels,
+                    Some(time_embed_dim),
+                    db_cfg,
+                )?;
+                down_blocks.push(ControlNetDownBlock::Basic(block));
+            }
+        }
+
+        // Mid block
+        let mid_transformer_layers_per_block = match config.blocks.last() {
+            None => 1,
+            Some(block) => block.use_cross_attn.unwrap_or(1),
+        };
+        let mid_cfg = UNetMidBlock2DCrossAttnConfig {
+            resnet_eps: config.norm_eps,
+            output_scale_factor: config.mid_block_scale_factor,
+            cross_attn_dim: config.cross_attention_dim,
+            attn_num_head_channels: bl_attention_head_dim,
+            resnet_groups: Some(config.norm_num_groups),
+            use_linear_projection: config.use_linear_projection,
+            transformer_layers_per_block: mid_transformer_layers_per_block,
+            ..Default::default()
+        };
+        let mid_block = UNetMidBlock2DCrossAttn::new(
+            vs.pp("mid_block"),
+            bl_channels,
+            Some(time_embed_dim),
+            false, // use_flash_attn
+            mid_cfg,
+        )?;
+
+        // Zero convolutions for down block residuals
+        let zero_cfg = nn::Conv2dConfig::default(); // 1x1 convolution, no padding
+        let vs_zero = vs.pp("controlnet_down_blocks");
+        let controlnet_down_blocks = zero_conv_channels
+            .iter()
+            .enumerate()
+            .map(|(i, &ch)| conv2d(ch, ch, 1, zero_cfg, vs_zero.pp(i.to_string())))
+            .collect::<Result<Vec<_>>>()?;
+
+        // Zero convolution for mid block
+        let controlnet_mid_block = conv2d(
+            bl_channels,
+            bl_channels,
+            1,
+            zero_cfg,
+            vs.pp("controlnet_mid_block"),
+        )?;
+
+        Ok(Self {
+            controlnet_cond_embedding,
+            conv_in,
+            time_proj,
+            time_embedding,
+            down_blocks,
+            mid_block,
+            controlnet_down_blocks,
+            controlnet_mid_block,
+        })
+    }
+
+    /// Forward pass: returns (down_block_residuals, mid_block_residual).
+    ///
+    /// These are injected into the UNet via `forward_with_additional_residuals`.
+    pub fn forward(
+        &self,
+        xs: &Tensor,
+        timestep: f64,
+        encoder_hidden_states: &Tensor,
+        controlnet_cond: &Tensor,
+        conditioning_scale: f64,
+    ) -> anyhow::Result<(Vec<Tensor>, Tensor)> {
+        let (bsize, _channels, _height, _width) = xs.dims4()?;
+        let device = xs.device();
+
+        // 1. Time embedding
+        let emb = (Tensor::ones(bsize, xs.dtype(), device)? * timestep)?;
+        let emb = self.time_proj.forward(&emb)?;
+        let emb = self.time_embedding.forward(&emb)?;
+
+        // 2. Pre-process: conv_in + conditioning embedding
+        let xs = self.conv_in.forward(xs)?;
+        let cond = self.controlnet_cond_embedding.forward(controlnet_cond)?;
+        let mut xs = (xs + cond)?;
+
+        // 3. Down blocks
+        let mut down_block_res_samples = vec![xs.clone()];
+        for down_block in &self.down_blocks {
+            let (_xs, res_xs) = match down_block {
+                ControlNetDownBlock::Basic(b) => b.forward(&xs, Some(&emb))?,
+                ControlNetDownBlock::CrossAttn(b) => {
+                    b.forward(&xs, Some(&emb), Some(encoder_hidden_states))?
+                }
+            };
+            down_block_res_samples.extend(res_xs);
+            xs = _xs;
+        }
+
+        // 4. Mid block
+        let mid = self
+            .mid_block
+            .forward(&xs, Some(&emb), Some(encoder_hidden_states))?;
+
+        // 5. Apply zero convolutions and scale
+        let mut controlnet_down_samples = Vec::with_capacity(down_block_res_samples.len());
+        for (sample, zero_conv) in down_block_res_samples
+            .iter()
+            .zip(&self.controlnet_down_blocks)
+        {
+            let out = zero_conv.forward(sample)?;
+            controlnet_down_samples.push((out * conditioning_scale)?);
+        }
+
+        let mid_out = self.controlnet_mid_block.forward(&mid)?;
+        let mid_out = (mid_out * conditioning_scale)?;
+
+        Ok((controlnet_down_samples, mid_out))
+    }
+}

--- a/crates/mold-inference/src/flux/pipeline.rs
+++ b/crates/mold-inference/src/flux/pipeline.rs
@@ -533,7 +533,7 @@ impl FluxEngine {
         let noise_dtype = if is_quantized { DType::F32 } else { gpu_dtype };
         let latent_h = height / 16 * 2;
         let latent_w = width / 16 * 2;
-        let img = if let Some(ref source_bytes) = req.source_image {
+        let (img, inpaint_ctx) = if let Some(ref source_bytes) = req.source_image {
             self.progress.stage_start("Encoding source image (VAE)");
             let encode_start = Instant::now();
             let source_tensor = crate::img_utils::decode_source_image(
@@ -558,10 +558,36 @@ impl FluxEngine {
             )?;
             let encoded = encoded.to_dtype(noise_dtype)?;
             let strength = req.strength;
+
+            // Build inpaint context if mask provided
+            let inpaint_ctx = if let Some(ref mask_bytes) = req.mask_image {
+                let mask = crate::img_utils::decode_mask_image(
+                    mask_bytes,
+                    latent_h,
+                    latent_w,
+                    &device,
+                    noise_dtype,
+                )?;
+                Some(crate::img_utils::InpaintContext {
+                    original_latents: encoded.clone(),
+                    mask,
+                    noise: noise.clone(),
+                })
+            } else {
+                None
+            };
+
             // latent = (1 - strength) * encoded + strength * noise
-            ((&encoded * (1.0 - strength))? + (&noise * strength)?)?
+            let img = ((&encoded * (1.0 - strength))? + (&noise * strength)?)?;
+            (img, inpaint_ctx)
         } else {
-            crate::engine::seeded_randn(seed, &[1, 16, latent_h, latent_w], &device, noise_dtype)?
+            let img = crate::engine::seeded_randn(
+                seed,
+                &[1, 16, latent_h, latent_w],
+                &device,
+                noise_dtype,
+            )?;
+            (img, None)
         };
 
         let (t5_emb_state, clip_emb_state, img_state) = if is_quantized {
@@ -609,6 +635,7 @@ impl FluxEngine {
             &timesteps,
             req.guidance,
             &self.progress,
+            inpaint_ctx.as_ref(),
         )?;
 
         let img = flux::sampling::unpack(&img, height, width)?;
@@ -616,6 +643,7 @@ impl FluxEngine {
             .stage_done(&denoise_label, denoise_start.elapsed());
 
         // Drop transformer + state to free memory for VAE decode
+        drop(inpaint_ctx);
         drop(flux_model);
         self.progress.info("Freed FLUX transformer");
         drop(state);
@@ -791,7 +819,7 @@ impl InferenceEngine for FluxEngine {
         };
         let latent_h = height / 16 * 2;
         let latent_w = width / 16 * 2;
-        let img = if let Some(ref source_bytes) = req.source_image {
+        let (img, inpaint_ctx) = if let Some(ref source_bytes) = req.source_image {
             progress.stage_start("Encoding source image (VAE)");
             let encode_start = Instant::now();
             let source_tensor = crate::img_utils::decode_source_image(
@@ -813,14 +841,34 @@ impl InferenceEngine for FluxEngine {
             )?;
             let encoded = encoded.to_dtype(noise_dtype)?;
             let strength = req.strength;
-            ((&encoded * (1.0 - strength))? + (&noise * strength)?)?
+
+            let inpaint_ctx = if let Some(ref mask_bytes) = req.mask_image {
+                let mask = crate::img_utils::decode_mask_image(
+                    mask_bytes,
+                    latent_h,
+                    latent_w,
+                    &loaded.device,
+                    noise_dtype,
+                )?;
+                Some(crate::img_utils::InpaintContext {
+                    original_latents: encoded.clone(),
+                    mask,
+                    noise: noise.clone(),
+                })
+            } else {
+                None
+            };
+
+            let img = ((&encoded * (1.0 - strength))? + (&noise * strength)?)?;
+            (img, inpaint_ctx)
         } else {
-            crate::engine::seeded_randn(
+            let img = crate::engine::seeded_randn(
                 seed,
                 &[1, 16, latent_h, latent_w],
                 &loaded.device,
                 noise_dtype,
-            )?
+            )?;
+            (img, None)
         };
 
         // For quantized model, state tensors must be F32
@@ -880,6 +928,7 @@ impl InferenceEngine for FluxEngine {
                 &timesteps,
                 req.guidance,
                 progress,
+                inpaint_ctx.as_ref(),
             )?;
 
         // 7. Unpack latent to spatial

--- a/crates/mold-inference/src/flux/transformer.rs
+++ b/crates/mold-inference/src/flux/transformer.rs
@@ -3,6 +3,7 @@ use candle_core::Tensor;
 use candle_transformers::models::flux::{self, WithForward};
 use std::time::Instant;
 
+use crate::img_utils::InpaintContext;
 use crate::progress::{ProgressEvent, ProgressReporter};
 
 /// BF16 or quantized (GGUF) FLUX transformer.
@@ -28,6 +29,7 @@ impl FluxTransformer {
         timesteps: &[f64],
         guidance: f64,
         progress: &ProgressReporter,
+        inpaint_ctx: Option<&InpaintContext>,
     ) -> Result<Tensor> {
         let b_sz = img.dim(0)?;
         let dev = img.device();
@@ -63,6 +65,15 @@ impl FluxTransformer {
                 )?,
             };
             img = (img + pred * (t_prev - t_curr))?;
+
+            // Inpainting: blend preserved regions back at current noise level
+            if let Some(ctx) = inpaint_ctx {
+                let t = *t_prev;
+                // Re-noise original latents to current timestep (flow-matching schedule)
+                let noised_original = ((&ctx.original_latents * (1.0 - t))? + (&ctx.noise * t)?)?;
+                // mask=1 -> repaint (use denoised), mask=0 -> preserve (use noised original)
+                img = ((&ctx.mask * &img)? + (&(1.0 - &ctx.mask)? * &noised_original)?)?;
+            }
 
             progress.emit(ProgressEvent::DenoiseStep {
                 step: step + 1,

--- a/crates/mold-inference/src/flux2/pipeline.rs
+++ b/crates/mold-inference/src/flux2/pipeline.rs
@@ -509,6 +509,9 @@ impl InferenceEngine for Flux2Engine {
         if req.source_image.is_some() {
             tracing::warn!("img2img not yet supported for Flux.2 — generating from text only");
         }
+        if req.mask_image.is_some() {
+            tracing::warn!("inpainting not yet supported for Flux.2 -- ignoring mask");
+        }
 
         // Sequential mode: load-use-drop each component
         if self.load_strategy == LoadStrategy::Sequential {

--- a/crates/mold-inference/src/img_utils.rs
+++ b/crates/mold-inference/src/img_utils.rs
@@ -54,6 +54,45 @@ pub fn decode_source_image(
     Ok(tensor)
 }
 
+/// Decode a mask image (PNG/JPEG) into a [1, 1, latent_h, latent_w] tensor with values in [0, 1].
+/// White (255) = 1.0 = repaint region, Black (0) = 0.0 = preserve region.
+/// RGB images are converted to grayscale.
+pub fn decode_mask_image(
+    bytes: &[u8],
+    latent_height: usize,
+    latent_width: usize,
+    device: &Device,
+    dtype: DType,
+) -> Result<Tensor> {
+    let img = image::load_from_memory(bytes)
+        .map_err(|e| anyhow::anyhow!("failed to decode mask image: {e}"))?;
+
+    let img = img.resize_exact(
+        latent_width as u32,
+        latent_height as u32,
+        image::imageops::FilterType::Lanczos3,
+    );
+    let gray = img.to_luma8();
+
+    let data: Vec<f32> = gray.as_raw().iter().map(|&v| v as f32 / 255.0).collect();
+
+    let tensor = Tensor::from_vec(data, (1, 1, latent_height, latent_width), &Device::Cpu)?;
+    let tensor = tensor.to_dtype(dtype)?.to_device(device)?;
+
+    Ok(tensor)
+}
+
+/// Context for inpainting: holds pre-computed tensors needed during the denoising loop.
+pub struct InpaintContext {
+    /// VAE-encoded original latents (unnoised).
+    pub original_latents: Tensor,
+    /// Mask tensor [1, 1, latent_h, latent_w] with values in [0, 1].
+    /// 1.0 = repaint, 0.0 = preserve.
+    pub mask: Tensor,
+    /// Noise tensor matching latent shape, for re-noising the original at each step.
+    pub noise: Tensor,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -131,5 +170,58 @@ mod tests {
         )
         .unwrap();
         assert_eq!(tensor.dims(), &[1, 3, 16, 16]);
+    }
+    // ── Mask decoding tests ───────────────────────────────────────────────
+
+    /// Create a 4x4 white PNG (mask = repaint everywhere).
+    fn white_mask_png() -> Vec<u8> {
+        let img = image::GrayImage::from_fn(4, 4, |_, _| image::Luma([255]));
+        let mut buf = std::io::Cursor::new(Vec::new());
+        img.write_to(&mut buf, image::ImageFormat::Png).unwrap();
+        buf.into_inner()
+    }
+
+    /// Create a 4x4 black PNG (mask = preserve everywhere).
+    fn black_mask_png() -> Vec<u8> {
+        let img = image::GrayImage::from_fn(4, 4, |_, _| image::Luma([0]));
+        let mut buf = std::io::Cursor::new(Vec::new());
+        img.write_to(&mut buf, image::ImageFormat::Png).unwrap();
+        buf.into_inner()
+    }
+
+    #[test]
+    fn decode_mask_shape() {
+        let mask = white_mask_png();
+        let tensor = decode_mask_image(&mask, 8, 8, &Device::Cpu, DType::F32).unwrap();
+        assert_eq!(tensor.dims(), &[1, 1, 8, 8]);
+    }
+
+    #[test]
+    fn decode_mask_white_is_one() {
+        let mask = white_mask_png();
+        let tensor = decode_mask_image(&mask, 4, 4, &Device::Cpu, DType::F32).unwrap();
+        let min = tensor.min_all().unwrap().to_scalar::<f32>().unwrap();
+        assert!(min > 0.99, "white mask should be ~1.0, got {min}");
+    }
+
+    #[test]
+    fn decode_mask_black_is_zero() {
+        let mask = black_mask_png();
+        let tensor = decode_mask_image(&mask, 4, 4, &Device::Cpu, DType::F32).unwrap();
+        let max = tensor.max_all().unwrap().to_scalar::<f32>().unwrap();
+        assert!(max < 0.01, "black mask should be ~0.0, got {max}");
+    }
+
+    #[test]
+    fn decode_mask_rgb_converted_to_grayscale() {
+        // Red RGB image -- grayscale luminance of pure red is ~76/255 ~ 0.3
+        let rgb = tiny_png(); // 4x4 red
+        let tensor = decode_mask_image(&rgb, 4, 4, &Device::Cpu, DType::F32).unwrap();
+        assert_eq!(tensor.dims(), &[1, 1, 4, 4]);
+        let val = tensor.min_all().unwrap().to_scalar::<f32>().unwrap();
+        assert!(
+            val > 0.1 && val < 0.5,
+            "red -> grayscale should be ~0.3, got {val}"
+        );
     }
 }

--- a/crates/mold-inference/src/lib.rs
+++ b/crates/mold-inference/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod controlnet;
 pub mod device;
 mod encoders;
 pub mod engine;

--- a/crates/mold-inference/src/qwen_image/pipeline.rs
+++ b/crates/mold-inference/src/qwen_image/pipeline.rs
@@ -582,6 +582,9 @@ impl InferenceEngine for QwenImageEngine {
         if req.source_image.is_some() {
             tracing::warn!("img2img not yet supported for Qwen-Image — generating from text only");
         }
+        if req.mask_image.is_some() {
+            tracing::warn!("inpainting not yet supported for Qwen-Image -- ignoring mask");
+        }
 
         // Sequential mode: load-use-drop each component
         if self.load_strategy == LoadStrategy::Sequential {

--- a/crates/mold-inference/src/sd15/pipeline.rs
+++ b/crates/mold-inference/src/sd15/pipeline.rs
@@ -5,6 +5,7 @@ use candle_transformers::models::stable_diffusion::schedulers::PredictionType;
 use mold_core::{GenerateRequest, GenerateResponse, ImageData, ModelPaths, Scheduler};
 use std::time::Instant;
 
+use crate::controlnet::ControlNetModel;
 use crate::device::{check_memory_budget, memory_status_string, preflight_memory_check};
 use crate::engine::{rand_seed, InferenceEngine, LoadStrategy};
 use crate::image::encode_image;
@@ -12,6 +13,13 @@ use crate::progress::{ProgressCallback, ProgressEvent, ProgressReporter};
 
 /// VAE scaling factor for SD1.5 models.
 const VAE_SCALE: f64 = 0.18215;
+
+/// ControlNet context: loaded model, preprocessed control tensor, and scale.
+struct ControlNetContext {
+    model: ControlNetModel,
+    control_tensor: Tensor,
+    scale: f64,
+}
 
 /// Loaded SD1.5 model components, ready for inference.
 struct LoadedSD15 {
@@ -198,6 +206,8 @@ impl SD15Engine {
         guidance: f64,
         steps: u32,
         start_step: usize,
+        inpaint_ctx: Option<&crate::img_utils::InpaintContext>,
+        controlnet_ctx: Option<&ControlNetContext>,
     ) -> Result<()> {
         let use_cfg = guidance > 1.0;
         let mut scheduler = crate::scheduler::build_scheduler(
@@ -222,7 +232,25 @@ impl SD15Engine {
             };
 
             let latent_input = scheduler.scale_model_input(latent_input, t)?;
-            let noise_pred = unet.forward(&latent_input, t as f64, text_embeddings)?;
+
+            let noise_pred = if let Some(cn_ctx) = controlnet_ctx {
+                let (down_residuals, mid_residual) = cn_ctx.model.forward(
+                    &latent_input,
+                    t as f64,
+                    text_embeddings,
+                    &cn_ctx.control_tensor,
+                    cn_ctx.scale,
+                )?;
+                unet.forward_with_additional_residuals(
+                    &latent_input,
+                    t as f64,
+                    text_embeddings,
+                    Some(&down_residuals),
+                    Some(&mid_residual),
+                )?
+            } else {
+                unet.forward(&latent_input, t as f64, text_embeddings)?
+            };
 
             let noise_pred = if use_cfg {
                 let chunks = noise_pred.chunk(2, 0)?;
@@ -234,6 +262,14 @@ impl SD15Engine {
             };
 
             *latents = scheduler.step(&noise_pred, t, &*latents)?;
+
+            // Inpainting: blend preserved regions back at current noise level
+            if let Some(ctx) = inpaint_ctx {
+                let noised_original =
+                    scheduler.add_noise(&ctx.original_latents, ctx.noise.clone(), t)?;
+                *latents = ((&ctx.mask * &*latents)? + (&(1.0 - &ctx.mask)? * &noised_original)?)?;
+            }
+
             self.progress.emit(ProgressEvent::DenoiseStep {
                 step: step_idx + 1,
                 total: active_timesteps.len(),
@@ -247,7 +283,7 @@ impl SD15Engine {
     }
 
     /// Prepare img2img latents: VAE encode source image, add noise at the appropriate timestep.
-    /// Returns (noised_latents, start_step).
+    /// Returns (noised_latents, start_step, encoded_latents, noise) -- extra fields for inpainting.
     #[allow(clippy::too_many_arguments)]
     fn prepare_img2img_latents(
         &self,
@@ -261,7 +297,7 @@ impl SD15Engine {
         seed: u64,
         device: &Device,
         dtype: DType,
-    ) -> Result<(Tensor, usize)> {
+    ) -> Result<(Tensor, usize, Tensor, Tensor)> {
         use crate::img_utils::{decode_source_image, NormalizeRange};
 
         self.progress.stage_start("Encoding source image (VAE)");
@@ -305,9 +341,9 @@ impl SD15Engine {
 
         // Add noise at the start timestep
         let noised = if start_step < timesteps.len() {
-            scheduler.add_noise(&encoded, noise, timesteps[start_step])?
+            scheduler.add_noise(&encoded, noise.clone(), timesteps[start_step])?
         } else {
-            encoded
+            encoded.clone()
         };
 
         tracing::info!(
@@ -317,7 +353,7 @@ impl SD15Engine {
             "img2img: starting from step {start_step}"
         );
 
-        Ok((noised, start_step))
+        Ok((noised, start_step, encoded, noise))
     }
 
     /// Encode prompt with the single CLIP-L encoder.
@@ -350,6 +386,70 @@ impl SD15Engine {
         };
 
         Ok(text_embeddings.to_dtype(dtype)?)
+    }
+
+    /// Load ControlNet model and prepare control tensor from the request.
+    fn load_controlnet(
+        &self,
+        req: &GenerateRequest,
+        device: &Device,
+        dtype: DType,
+    ) -> Result<Option<ControlNetContext>> {
+        let (control_bytes, control_model_name, scale) =
+            match (req.control_image.as_ref(), req.control_model.as_ref()) {
+                (Some(bytes), Some(name)) => (bytes, name, req.control_scale),
+                _ => return Ok(None),
+            };
+
+        self.progress.stage_start("Loading ControlNet");
+        let cn_start = Instant::now();
+
+        // Resolve ControlNet model weights path
+        let config = mold_core::Config::load_or_default();
+        let cn_paths =
+            mold_core::ModelPaths::resolve(control_model_name, &config).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "ControlNet model '{}' not found. Pull it with: mold pull {}",
+                    control_model_name,
+                    control_model_name,
+                )
+            })?;
+
+        // Use default SD1.5 UNet config for ControlNet architecture
+        let unet_config =
+            candle_transformers::models::stable_diffusion::unet_2d::UNet2DConditionModelConfig::default();
+        let model = ControlNetModel::load(&cn_paths.transformer, device, dtype, unet_config)?;
+
+        self.progress
+            .stage_done("Loading ControlNet", cn_start.elapsed());
+
+        // Decode and preprocess control image
+        self.progress.stage_start("Preprocessing control image");
+        let preprocess_start = Instant::now();
+
+        let control_tensor = crate::img_utils::decode_source_image(
+            control_bytes,
+            req.width,
+            req.height,
+            crate::img_utils::NormalizeRange::ZeroToOne,
+            device,
+            dtype,
+        )?;
+
+        self.progress
+            .stage_done("Preprocessing control image", preprocess_start.elapsed());
+
+        tracing::info!(
+            control_model = %control_model_name,
+            scale,
+            "ControlNet loaded and control image preprocessed"
+        );
+
+        Ok(Some(ControlNetContext {
+            model,
+            control_tensor,
+            scale,
+        }))
     }
 
     /// Generate an image using sequential loading strategy.
@@ -450,55 +550,76 @@ impl SD15Engine {
         let is_img2img = req.source_image.is_some();
 
         // For img2img in sequential mode, we need the VAE for encoding before the UNet
-        let (mut latents, start_step) = if let Some(ref source_bytes) = req.source_image {
-            self.progress
-                .info("img2img mode: encoding source image before denoising");
+        let (mut latents, start_step, inpaint_ctx) =
+            if let Some(ref source_bytes) = req.source_image {
+                self.progress
+                    .info("img2img mode: encoding source image before denoising");
 
-            // Load VAE first for encoding
-            self.progress.stage_start("Loading VAE (GPU)");
-            let vae_start = Instant::now();
-            let vae = sd_config.build_vae(&self.paths.vae, &device, dtype)?;
-            self.progress
-                .stage_done("Loading VAE (GPU)", vae_start.elapsed());
+                // Load VAE first for encoding
+                self.progress.stage_start("Loading VAE (GPU)");
+                let vae_start = Instant::now();
+                let vae = sd_config.build_vae(&self.paths.vae, &device, dtype)?;
+                self.progress
+                    .stage_done("Loading VAE (GPU)", vae_start.elapsed());
 
-            let (latents, start_step) = self.prepare_img2img_latents(
-                &vae,
-                source_bytes,
-                req.width,
-                req.height,
-                req.strength,
-                req.steps,
-                sched,
-                seed,
-                &device,
-                dtype,
-            )?;
+                let (latents, start_step, encoded, noise) = self.prepare_img2img_latents(
+                    &vae,
+                    source_bytes,
+                    req.width,
+                    req.height,
+                    req.strength,
+                    req.steps,
+                    sched,
+                    seed,
+                    &device,
+                    dtype,
+                )?;
 
-            // Drop VAE to free memory for UNet
-            drop(vae);
-            self.progress.info("Freed VAE (will reload for decode)");
-            device.synchronize()?;
+                // Drop VAE to free memory for UNet
+                let inpaint_ctx = if let Some(ref mask_bytes) = req.mask_image {
+                    let mask = crate::img_utils::decode_mask_image(
+                        mask_bytes,
+                        height / 8,
+                        width / 8,
+                        &device,
+                        dtype,
+                    )?;
+                    Some(crate::img_utils::InpaintContext {
+                        original_latents: encoded,
+                        mask,
+                        noise,
+                    })
+                } else {
+                    None
+                };
 
-            (latents, start_step)
-        } else {
-            let latent_h = height / 8;
-            let latent_w = width / 8;
-            let init_scheduler = crate::scheduler::build_scheduler(
-                sched,
-                req.steps as usize,
-                PredictionType::Epsilon,
-                false,
-            )?;
-            let init_noise_sigma = init_scheduler.init_noise_sigma();
-            drop(init_scheduler);
-            let latents = (crate::engine::seeded_randn(
-                seed,
-                &[1, 4, latent_h, latent_w],
-                &device,
-                DType::F32,
-            )? * init_noise_sigma)?;
-            (latents.to_dtype(dtype)?, 0)
-        };
+                drop(vae);
+                self.progress.info("Freed VAE (will reload for decode)");
+                device.synchronize()?;
+
+                (latents, start_step, inpaint_ctx)
+            } else {
+                let latent_h = height / 8;
+                let latent_w = width / 8;
+                let init_scheduler = crate::scheduler::build_scheduler(
+                    sched,
+                    req.steps as usize,
+                    PredictionType::Epsilon,
+                    false,
+                )?;
+                let init_noise_sigma = init_scheduler.init_noise_sigma();
+                drop(init_scheduler);
+                let latents = (crate::engine::seeded_randn(
+                    seed,
+                    &[1, 4, latent_h, latent_w],
+                    &device,
+                    DType::F32,
+                )? * init_noise_sigma)?;
+                (latents.to_dtype(dtype)?, 0, None)
+            };
+
+        // Load ControlNet if requested
+        let controlnet_ctx = self.load_controlnet(req, &device, dtype)?;
 
         self.denoise_loop(
             &unet,
@@ -508,9 +629,13 @@ impl SD15Engine {
             guidance,
             req.steps,
             start_step,
+            inpaint_ctx.as_ref(),
+            controlnet_ctx.as_ref(),
         )?;
 
         // Drop UNet to free memory for VAE decode
+        drop(controlnet_ctx);
+        drop(inpaint_ctx);
         drop(unet);
         drop(text_embeddings);
         device.synchronize()?;
@@ -611,40 +736,61 @@ impl InferenceEngine for SD15Engine {
         // 2. Build scheduler and create initial latents
         let sched = req.scheduler.unwrap_or(self.scheduler);
 
-        let (mut latents, start_step) = if let Some(ref source_bytes) = req.source_image {
-            self.prepare_img2img_latents(
-                &loaded.vae,
-                source_bytes,
-                req.width,
-                req.height,
-                req.strength,
-                req.steps,
-                sched,
-                seed,
-                &loaded.device,
-                loaded.dtype,
-            )?
-        } else {
-            let latent_h = height / 8;
-            let latent_w = width / 8;
-            let init_scheduler = crate::scheduler::build_scheduler(
-                sched,
-                req.steps as usize,
-                PredictionType::Epsilon,
-                false,
-            )?;
-            let init_noise_sigma = init_scheduler.init_noise_sigma();
-            drop(init_scheduler);
-            let latents = (crate::engine::seeded_randn(
-                seed,
-                &[1, 4, latent_h, latent_w],
-                &loaded.device,
-                DType::F32,
-            )? * init_noise_sigma)?;
-            (latents.to_dtype(loaded.dtype)?, 0)
-        };
+        let (mut latents, start_step, inpaint_ctx) =
+            if let Some(ref source_bytes) = req.source_image {
+                let (latents, start_step, encoded, noise) = self.prepare_img2img_latents(
+                    &loaded.vae,
+                    source_bytes,
+                    req.width,
+                    req.height,
+                    req.strength,
+                    req.steps,
+                    sched,
+                    seed,
+                    &loaded.device,
+                    loaded.dtype,
+                )?;
+                let inpaint_ctx = if let Some(ref mask_bytes) = req.mask_image {
+                    let mask = crate::img_utils::decode_mask_image(
+                        mask_bytes,
+                        height / 8,
+                        width / 8,
+                        &loaded.device,
+                        loaded.dtype,
+                    )?;
+                    Some(crate::img_utils::InpaintContext {
+                        original_latents: encoded,
+                        mask,
+                        noise,
+                    })
+                } else {
+                    None
+                };
+                (latents, start_step, inpaint_ctx)
+            } else {
+                let latent_h = height / 8;
+                let latent_w = width / 8;
+                let init_scheduler = crate::scheduler::build_scheduler(
+                    sched,
+                    req.steps as usize,
+                    PredictionType::Epsilon,
+                    false,
+                )?;
+                let init_noise_sigma = init_scheduler.init_noise_sigma();
+                drop(init_scheduler);
+                let latents = (crate::engine::seeded_randn(
+                    seed,
+                    &[1, 4, latent_h, latent_w],
+                    &loaded.device,
+                    DType::F32,
+                )? * init_noise_sigma)?;
+                (latents.to_dtype(loaded.dtype)?, 0, None)
+            };
 
-        // 3. Denoising loop
+        // 3. Load ControlNet if requested
+        let controlnet_ctx = self.load_controlnet(req, &loaded.device, loaded.dtype)?;
+
+        // 4. Denoising loop
         self.denoise_loop(
             &loaded.unet,
             &text_embeddings,
@@ -653,9 +799,11 @@ impl InferenceEngine for SD15Engine {
             guidance,
             req.steps,
             start_step,
+            inpaint_ctx.as_ref(),
+            controlnet_ctx.as_ref(),
         )?;
 
-        // 4. VAE decode
+        // 5. VAE decode
         self.progress.stage_start("VAE decode");
         let vae_start = Instant::now();
 

--- a/crates/mold-inference/src/sd3/pipeline.rs
+++ b/crates/mold-inference/src/sd3/pipeline.rs
@@ -546,6 +546,9 @@ impl InferenceEngine for SD3Engine {
         if req.source_image.is_some() {
             tracing::warn!("img2img not yet supported for SD3 — generating from text only");
         }
+        if req.mask_image.is_some() {
+            tracing::warn!("inpainting not yet supported for SD3 -- ignoring mask");
+        }
 
         // Sequential mode: load-use-drop each component
         if self.load_strategy == LoadStrategy::Sequential {

--- a/crates/mold-inference/src/sdxl/pipeline.rs
+++ b/crates/mold-inference/src/sdxl/pipeline.rs
@@ -255,6 +255,7 @@ impl SDXLEngine {
         guidance: f64,
         steps: u32,
         start_step: usize,
+        inpaint_ctx: Option<&crate::img_utils::InpaintContext>,
     ) -> Result<()> {
         let use_cfg = guidance > 1.0;
         let mut scheduler = crate::scheduler::build_scheduler(
@@ -291,6 +292,13 @@ impl SDXLEngine {
             };
 
             *latents = scheduler.step(&noise_pred, t, &*latents)?;
+
+            if let Some(ctx) = inpaint_ctx {
+                let noised_original =
+                    scheduler.add_noise(&ctx.original_latents, ctx.noise.clone(), t)?;
+                *latents = ((&ctx.mask * &*latents)? + (&(1.0 - &ctx.mask)? * &noised_original)?)?;
+            }
+
             self.progress.emit(ProgressEvent::DenoiseStep {
                 step: step_idx + 1,
                 total: active_timesteps.len(),
@@ -304,7 +312,7 @@ impl SDXLEngine {
     }
 
     /// Prepare img2img latents: VAE encode source image, add noise at the appropriate timestep.
-    /// Returns (noised_latents, start_step).
+    /// Returns (noised_latents, start_step, encoded, noise).
     #[allow(clippy::too_many_arguments)]
     fn prepare_img2img_latents(
         &self,
@@ -318,7 +326,7 @@ impl SDXLEngine {
         seed: u64,
         device: &Device,
         dtype: DType,
-    ) -> Result<(Tensor, usize)> {
+    ) -> Result<(Tensor, usize, Tensor, Tensor)> {
         use crate::img_utils::{decode_source_image, NormalizeRange};
 
         self.progress.stage_start("Encoding source image (VAE)");
@@ -363,9 +371,9 @@ impl SDXLEngine {
         let noise = noise.to_dtype(dtype)?;
 
         let noised = if start_step < timesteps.len() {
-            scheduler.add_noise(&encoded, noise, timesteps[start_step])?
+            scheduler.add_noise(&encoded, noise.clone(), timesteps[start_step])?
         } else {
-            encoded
+            encoded.clone()
         };
 
         tracing::info!(
@@ -375,7 +383,7 @@ impl SDXLEngine {
             "img2img: starting from step {start_step}"
         );
 
-        Ok((noised, start_step))
+        Ok((noised, start_step, encoded, noise))
     }
 
     /// Encode prompt with both CLIP encoders.
@@ -546,53 +554,71 @@ impl SDXLEngine {
         let sched = req.scheduler.unwrap_or(self.scheduler);
         let is_img2img = req.source_image.is_some();
 
-        let (mut latents, start_step) = if let Some(ref source_bytes) = req.source_image {
-            self.progress
-                .info("img2img mode: encoding source image before denoising");
+        let (mut latents, start_step, inpaint_ctx) =
+            if let Some(ref source_bytes) = req.source_image {
+                self.progress
+                    .info("img2img mode: encoding source image before denoising");
 
-            self.progress.stage_start("Loading VAE (GPU)");
-            let vae_start_t = Instant::now();
-            let vae = sd_config.build_vae(&self.paths.vae, &device, dtype)?;
-            self.progress
-                .stage_done("Loading VAE (GPU)", vae_start_t.elapsed());
+                self.progress.stage_start("Loading VAE (GPU)");
+                let vae_start_t = Instant::now();
+                let vae = sd_config.build_vae(&self.paths.vae, &device, dtype)?;
+                self.progress
+                    .stage_done("Loading VAE (GPU)", vae_start_t.elapsed());
 
-            let (latents, start_step) = self.prepare_img2img_latents(
-                &vae,
-                source_bytes,
-                req.width,
-                req.height,
-                req.strength,
-                req.steps,
-                sched,
-                seed,
-                &device,
-                dtype,
-            )?;
+                let (latents, start_step, encoded, noise) = self.prepare_img2img_latents(
+                    &vae,
+                    source_bytes,
+                    req.width,
+                    req.height,
+                    req.strength,
+                    req.steps,
+                    sched,
+                    seed,
+                    &device,
+                    dtype,
+                )?;
 
-            drop(vae);
-            self.progress.info("Freed VAE (will reload for decode)");
-            device.synchronize()?;
+                let inpaint_ctx = if let Some(ref mask_bytes) = req.mask_image {
+                    let mask = crate::img_utils::decode_mask_image(
+                        mask_bytes,
+                        height / 8,
+                        width / 8,
+                        &device,
+                        dtype,
+                    )?;
+                    Some(crate::img_utils::InpaintContext {
+                        original_latents: encoded,
+                        mask,
+                        noise,
+                    })
+                } else {
+                    None
+                };
 
-            (latents, start_step)
-        } else {
-            let latent_h = height / 8;
-            let latent_w = width / 8;
-            let init_scheduler = crate::scheduler::build_scheduler(
-                sched,
-                req.steps as usize,
-                PredictionType::Epsilon,
-                self.is_turbo,
-            )?;
-            let init_noise_sigma = init_scheduler.init_noise_sigma();
-            drop(init_scheduler);
-            let latents = (crate::engine::seeded_randn(
-                seed,
-                &[1, 4, latent_h, latent_w],
-                &device,
-                DType::F32,
-            )? * init_noise_sigma)?;
-            (latents.to_dtype(dtype)?, 0)
-        };
+                drop(vae);
+                self.progress.info("Freed VAE (will reload for decode)");
+                device.synchronize()?;
+
+                (latents, start_step, inpaint_ctx)
+            } else {
+                let latent_h = height / 8;
+                let latent_w = width / 8;
+                let init_scheduler = crate::scheduler::build_scheduler(
+                    sched,
+                    req.steps as usize,
+                    PredictionType::Epsilon,
+                    self.is_turbo,
+                )?;
+                let init_noise_sigma = init_scheduler.init_noise_sigma();
+                drop(init_scheduler);
+                let latents = (crate::engine::seeded_randn(
+                    seed,
+                    &[1, 4, latent_h, latent_w],
+                    &device,
+                    DType::F32,
+                )? * init_noise_sigma)?;
+                (latents.to_dtype(dtype)?, 0, None)
+            };
 
         self.denoise_loop(
             &unet,
@@ -602,9 +628,10 @@ impl SDXLEngine {
             guidance,
             req.steps,
             start_step,
+            inpaint_ctx.as_ref(),
         )?;
 
-        // Drop UNet to free memory for VAE decode
+        drop(inpaint_ctx);
         drop(unet);
         drop(text_embeddings);
         device.synchronize()?;
@@ -712,38 +739,56 @@ impl InferenceEngine for SDXLEngine {
         // 3. Build scheduler and create initial latents
         let sched = req.scheduler.unwrap_or(self.scheduler);
 
-        let (mut latents, start_step) = if let Some(ref source_bytes) = req.source_image {
-            self.prepare_img2img_latents(
-                &loaded.vae,
-                source_bytes,
-                req.width,
-                req.height,
-                req.strength,
-                req.steps,
-                sched,
-                seed,
-                &loaded.device,
-                loaded.dtype,
-            )?
-        } else {
-            let latent_h = height / 8;
-            let latent_w = width / 8;
-            let init_scheduler = crate::scheduler::build_scheduler(
-                sched,
-                req.steps as usize,
-                PredictionType::Epsilon,
-                self.is_turbo,
-            )?;
-            let init_noise_sigma = init_scheduler.init_noise_sigma();
-            drop(init_scheduler);
-            let latents = (crate::engine::seeded_randn(
-                seed,
-                &[1, 4, latent_h, latent_w],
-                &loaded.device,
-                DType::F32,
-            )? * init_noise_sigma)?;
-            (latents.to_dtype(loaded.dtype)?, 0)
-        };
+        let (mut latents, start_step, inpaint_ctx) =
+            if let Some(ref source_bytes) = req.source_image {
+                let (latents, start_step, encoded, noise) = self.prepare_img2img_latents(
+                    &loaded.vae,
+                    source_bytes,
+                    req.width,
+                    req.height,
+                    req.strength,
+                    req.steps,
+                    sched,
+                    seed,
+                    &loaded.device,
+                    loaded.dtype,
+                )?;
+                let inpaint_ctx = if let Some(ref mask_bytes) = req.mask_image {
+                    let mask = crate::img_utils::decode_mask_image(
+                        mask_bytes,
+                        height / 8,
+                        width / 8,
+                        &loaded.device,
+                        loaded.dtype,
+                    )?;
+                    Some(crate::img_utils::InpaintContext {
+                        original_latents: encoded,
+                        mask,
+                        noise,
+                    })
+                } else {
+                    None
+                };
+                (latents, start_step, inpaint_ctx)
+            } else {
+                let latent_h = height / 8;
+                let latent_w = width / 8;
+                let init_scheduler = crate::scheduler::build_scheduler(
+                    sched,
+                    req.steps as usize,
+                    PredictionType::Epsilon,
+                    self.is_turbo,
+                )?;
+                let init_noise_sigma = init_scheduler.init_noise_sigma();
+                drop(init_scheduler);
+                let latents = (crate::engine::seeded_randn(
+                    seed,
+                    &[1, 4, latent_h, latent_w],
+                    &loaded.device,
+                    DType::F32,
+                )? * init_noise_sigma)?;
+                (latents.to_dtype(loaded.dtype)?, 0, None)
+            };
 
         // 5. Denoising loop
         self.denoise_loop(
@@ -754,6 +799,7 @@ impl InferenceEngine for SDXLEngine {
             guidance,
             req.steps,
             start_step,
+            inpaint_ctx.as_ref(),
         )?;
 
         // 6. VAE decode

--- a/crates/mold-inference/src/wuerstchen/pipeline.rs
+++ b/crates/mold-inference/src/wuerstchen/pipeline.rs
@@ -567,6 +567,9 @@ impl InferenceEngine for WuerstchenEngine {
         if req.source_image.is_some() {
             tracing::warn!("img2img not yet supported for Wuerstchen — generating from text only");
         }
+        if req.mask_image.is_some() {
+            tracing::warn!("inpainting not yet supported for Wuerstchen -- ignoring mask");
+        }
 
         if self.load_strategy == LoadStrategy::Sequential {
             return self.generate_sequential(req);

--- a/crates/mold-inference/src/zimage/pipeline.rs
+++ b/crates/mold-inference/src/zimage/pipeline.rs
@@ -599,6 +599,9 @@ impl InferenceEngine for ZImageEngine {
         if req.source_image.is_some() {
             tracing::warn!("img2img not yet supported for Z-Image — generating from text only");
         }
+        if req.mask_image.is_some() {
+            tracing::warn!("inpainting not yet supported for Z-Image -- ignoring mask");
+        }
 
         // Sequential mode: load-use-drop each component
         if self.load_strategy == LoadStrategy::Sequential {


### PR DESCRIPTION
## Summary

Implements GitHub issue #23: ControlNet support for SD1.5 models.

- **ControlNet model** (`crates/mold-inference/src/controlnet/`): UNet encoder half with zero-initialized convolution outputs, loaded from safetensors weights. Architecture mirrors the SD1.5 UNet encoder blocks with conditioning embedding (3->16->32->96->256->320) and 13 zero convolutions (12 down + 1 mid).
- **Core types**: Added `control_image`, `control_model`, `control_scale` fields to `GenerateRequest` with base64 serde support, validation (mutual dependency, image format checks, scale bounds), and backward-compatible defaults.
- **Model manifests**: 3 ControlNet models registered: `controlnet-canny-sd15:fp16`, `controlnet-depth-sd15:fp16`, `controlnet-openpose-sd15:fp16` (from lllyasviel's HuggingFace repos).
- **SD1.5 integration**: ControlNet forward pass runs before each UNet step, producing down-block and mid-block residuals that are injected via `unet.forward_with_additional_residuals()`. Works in both sequential and eager loading modes.
- **CLI flags**: `--control <path>`, `--control-model <name>`, `--control-scale <float>` under a "ControlNet" help heading.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `cargo test --workspace` (152 tests pass)
- [ ] Manual test: `mold run sd15 "a house" --control edges.png --control-model controlnet-canny-sd15:fp16`

Closes #23