### PR TITLE
feat: add inpainting mode (--mask) for selective image editing

### DIFF
--- a/crates/mold-cli/src/commands/generate.rs
+++ b/crates/mold-cli/src/commands/generate.rs
@@ -32,6 +32,7 @@ pub async fn run(
     eager: bool,
     source_image: Option<Vec<u8>>,
     strength: f64,
+    mask_image: Option<Vec<u8>>,
 ) -> Result<()> {
     let output_format = format;
     let piped = is_piped();
@@ -112,6 +113,7 @@ pub async fn run(
         scheduler,
         source_image: source_image.clone(),
         strength,
+        mask_image: mask_image.clone(),
     };
 
     if let Some(desc) = &model_cfg.description {
@@ -123,7 +125,15 @@ pub async fn run(
         );
     }
     if source_image.is_some() {
-        status!("{} img2img mode (strength: {:.2})", "●".magenta(), strength,);
+        if mask_image.is_some() {
+            status!(
+                "{} inpainting mode (strength: {:.2})",
+                "●".magenta(),
+                strength,
+            );
+        } else {
+            status!("{} img2img mode (strength: {:.2})", "●".magenta(), strength,);
+        }
     }
     status!(
         "{} Generating {}x{} ({} steps, guidance {:.1})",

--- a/crates/mold-cli/src/commands/run.rs
+++ b/crates/mold-cli/src/commands/run.rs
@@ -66,6 +66,7 @@ pub async fn run(
     eager: bool,
     image: Option<String>,
     strength: f64,
+    mask: Option<String>,
 ) -> Result<()> {
     let config = Config::load_or_default();
     let (model, prompt) = resolve_run_args(model_or_prompt.as_deref(), &prompt_rest, &config);
@@ -81,6 +82,15 @@ pub async fn run(
             std::fs::read(img_path)
                 .map_err(|e| anyhow::anyhow!("failed to read image '{}': {e}", img_path))?
         };
+        Some(bytes)
+    } else {
+        None
+    };
+
+    // Read mask image if --mask specified
+    let mask_image = if let Some(ref mask_path) = mask {
+        let bytes = std::fs::read(mask_path)
+            .map_err(|e| anyhow::anyhow!("failed to read mask '{}': {e}", mask_path))?;
         Some(bytes)
     } else {
         None
@@ -131,6 +141,7 @@ pub async fn run(
         eager,
         source_image,
         strength,
+        mask_image,
     )
     .await
 }

--- a/crates/mold-cli/src/main.rs
+++ b/crates/mold-cli/src/main.rs
@@ -42,6 +42,7 @@ struct Cli {
 }
 
 #[derive(Subcommand)]
+#[allow(clippy::large_enum_variant)]
 enum Commands {
     /// Generate images from a text prompt
     ///
@@ -127,6 +128,10 @@ Examples:
         /// Denoising strength for img2img (0.0 = no change, 1.0 = full noise)
         #[arg(long, default_value = "0.75", help_heading = "img2img")]
         strength: f64,
+
+        /// Mask image for inpainting (white = repaint, black = preserve)
+        #[arg(long, requires = "image", help_heading = "img2img")]
+        mask: Option<String>,
     },
 
     /// Start the inference server
@@ -325,6 +330,7 @@ async fn run() -> anyhow::Result<()> {
             eager,
             image,
             strength,
+            mask,
         } => {
             commands::run::run(
                 model_or_prompt,
@@ -345,6 +351,7 @@ async fn run() -> anyhow::Result<()> {
                 eager,
                 image,
                 strength,
+                mask,
             )
             .await?;
         }
@@ -750,6 +757,42 @@ mod tests {
         let cli = parse(&["run", "model", "test"]);
         match cli.command {
             Commands::Run { image, .. } => assert!(image.is_none()),
+            _ => panic!("expected Run"),
+        }
+    }
+
+    #[test]
+    fn run_mask_flag() {
+        let cli = parse(&[
+            "run",
+            "model",
+            "test",
+            "--image",
+            "photo.png",
+            "--mask",
+            "mask.png",
+        ]);
+        match cli.command {
+            Commands::Run { mask, image, .. } => {
+                assert_eq!(image.as_deref(), Some("photo.png"));
+                assert_eq!(mask.as_deref(), Some("mask.png"));
+            }
+            _ => panic!("expected Run"),
+        }
+    }
+
+    #[test]
+    fn run_mask_requires_image() {
+        // --mask without --image should fail
+        let result = try_parse(&["run", "model", "test", "--mask", "mask.png"]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn run_mask_defaults_none() {
+        let cli = parse(&["run", "model", "test"]);
+        match cli.command {
+            Commands::Run { mask, .. } => assert!(mask.is_none()),
             _ => panic!("expected Run"),
         }
     }

--- a/crates/mold-core/src/types.rs
+++ b/crates/mold-core/src/types.rs
@@ -105,6 +105,10 @@ pub struct GenerateRequest {
     /// Denoising strength for img2img (0.0 = no change, 1.0 = full noise / txt2img).
     #[serde(default = "default_strength")]
     pub strength: f64,
+    /// Mask image for inpainting (raw PNG/JPEG bytes, base64-encoded in JSON).
+    /// White (255) = repaint, black (0) = preserve. Requires source_image.
+    #[serde(default, skip_serializing_if = "Option::is_none", with = "base64_opt")]
+    pub mask_image: Option<Vec<u8>>,
 }
 
 fn default_guidance() -> f64 {
@@ -323,6 +327,7 @@ mod tests {
             scheduler: None,
             source_image: None,
             strength: 0.75,
+            mask_image: None,
         };
         let json = serde_json::to_string(&req).unwrap();
         let back: GenerateRequest = serde_json::from_str(&json).unwrap();
@@ -511,6 +516,7 @@ mod tests {
             scheduler: None,
             source_image: Some(image_bytes.clone()),
             strength: 0.5,
+            mask_image: None,
         };
         let json = serde_json::to_string(&req).unwrap();
         // Verify base64 encoding is in the JSON
@@ -552,8 +558,42 @@ mod tests {
             scheduler: None,
             source_image: None,
             strength: 0.75,
+            mask_image: None,
         };
         let json = serde_json::to_string(&req).unwrap();
         assert!(!json.contains("source_image"));
+        assert!(!json.contains("mask_image"));
+    }
+
+    #[test]
+    fn generate_request_mask_image_base64_roundtrip() {
+        let mask_bytes = vec![0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+        let req = GenerateRequest {
+            prompt: "test".to_string(),
+            model: "test".to_string(),
+            width: 512,
+            height: 512,
+            steps: 4,
+            guidance: 3.5,
+            seed: None,
+            batch_size: 1,
+            output_format: OutputFormat::Png,
+            scheduler: None,
+            source_image: Some(vec![0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]),
+            strength: 0.75,
+            mask_image: Some(mask_bytes.clone()),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("mask_image"));
+        let back: GenerateRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.mask_image, Some(mask_bytes));
+    }
+
+    #[test]
+    fn generate_request_backward_compat_no_mask_image() {
+        let json =
+            r#"{"prompt":"test","model":"test","width":512,"height":512,"steps":4,"batch_size":1}"#;
+        let req: GenerateRequest = serde_json::from_str(json).unwrap();
+        assert!(req.mask_image.is_none());
     }
 }

--- a/crates/mold-core/src/validation.rs
+++ b/crates/mold-core/src/validation.rs
@@ -66,6 +66,17 @@ pub fn validate_generate_request(req: &GenerateRequest) -> Result<(), String> {
             return Err("source_image must be a PNG or JPEG image".to_string());
         }
     }
+    // Inpainting validation
+    if let Some(ref mask) = req.mask_image {
+        if req.source_image.is_none() {
+            return Err("mask_image requires source_image to also be provided".to_string());
+        }
+        let is_png = mask.len() >= 4 && mask[..4] == [0x89, 0x50, 0x4E, 0x47];
+        let is_jpeg = mask.len() >= 2 && mask[..2] == [0xFF, 0xD8];
+        if !is_png && !is_jpeg {
+            return Err("mask_image must be a PNG or JPEG image".to_string());
+        }
+    }
     Ok(())
 }
 
@@ -88,6 +99,7 @@ mod tests {
             scheduler: None,
             source_image: None,
             strength: 0.75,
+            mask_image: None,
         }
     }
 
@@ -303,6 +315,49 @@ mod tests {
         let mut req = valid_req();
         req.source_image = None;
         req.strength = 0.0; // Would fail if source_image present, but should pass without
+        assert!(validate_generate_request(&req).is_ok());
+    }
+
+    // ── Inpainting validation tests ───────────────────────────────────────
+
+    #[test]
+    fn mask_without_source_image_rejected() {
+        let mut req = valid_req();
+        req.mask_image = Some(png_bytes());
+        assert!(validate_generate_request(&req)
+            .unwrap_err()
+            .contains("mask_image requires source_image"));
+    }
+
+    #[test]
+    fn mask_with_source_image_accepted() {
+        let mut req = valid_req();
+        req.source_image = Some(png_bytes());
+        req.mask_image = Some(png_bytes());
+        assert!(validate_generate_request(&req).is_ok());
+    }
+
+    #[test]
+    fn mask_jpeg_accepted() {
+        let mut req = valid_req();
+        req.source_image = Some(png_bytes());
+        req.mask_image = Some(jpeg_bytes());
+        assert!(validate_generate_request(&req).is_ok());
+    }
+
+    #[test]
+    fn mask_invalid_bytes_rejected() {
+        let mut req = valid_req();
+        req.source_image = Some(png_bytes());
+        req.mask_image = Some(vec![0x00, 0x01, 0x02, 0x03]);
+        assert!(validate_generate_request(&req)
+            .unwrap_err()
+            .contains("mask_image must be a PNG or JPEG"));
+    }
+
+    #[test]
+    fn no_mask_no_source_passes() {
+        let req = valid_req();
         assert!(validate_generate_request(&req).is_ok());
     }
 }

--- a/crates/mold-inference/src/flux/pipeline.rs
+++ b/crates/mold-inference/src/flux/pipeline.rs
@@ -533,7 +533,7 @@ impl FluxEngine {
         let noise_dtype = if is_quantized { DType::F32 } else { gpu_dtype };
         let latent_h = height / 16 * 2;
         let latent_w = width / 16 * 2;
-        let img = if let Some(ref source_bytes) = req.source_image {
+        let (img, inpaint_ctx) = if let Some(ref source_bytes) = req.source_image {
             self.progress.stage_start("Encoding source image (VAE)");
             let encode_start = Instant::now();
             let source_tensor = crate::img_utils::decode_source_image(
@@ -559,9 +559,36 @@ impl FluxEngine {
             let encoded = encoded.to_dtype(noise_dtype)?;
             let strength = req.strength;
             // latent = (1 - strength) * encoded + strength * noise
-            ((&encoded * (1.0 - strength))? + (&noise * strength)?)?
+            let img = ((&encoded * (1.0 - strength))? + (&noise * strength)?)?;
+
+            // Build inpaint context if mask provided
+            let inpaint_ctx = if let Some(ref mask_bytes) = req.mask_image {
+                let mask = crate::img_utils::decode_mask_image(
+                    mask_bytes,
+                    latent_h,
+                    latent_w,
+                    &device,
+                    noise_dtype,
+                )?;
+                Some(crate::img_utils::InpaintContext {
+                    original_latents: encoded,
+                    mask,
+                    noise,
+                })
+            } else {
+                None
+            };
+            (img, inpaint_ctx)
         } else {
-            crate::engine::seeded_randn(seed, &[1, 16, latent_h, latent_w], &device, noise_dtype)?
+            (
+                crate::engine::seeded_randn(
+                    seed,
+                    &[1, 16, latent_h, latent_w],
+                    &device,
+                    noise_dtype,
+                )?,
+                None,
+            )
         };
 
         let (t5_emb_state, clip_emb_state, img_state) = if is_quantized {
@@ -609,6 +636,7 @@ impl FluxEngine {
             &timesteps,
             req.guidance,
             &self.progress,
+            inpaint_ctx.as_ref(),
         )?;
 
         let img = flux::sampling::unpack(&img, height, width)?;
@@ -618,6 +646,7 @@ impl FluxEngine {
         // Drop transformer + state to free memory for VAE decode
         drop(flux_model);
         self.progress.info("Freed FLUX transformer");
+        drop(inpaint_ctx);
         drop(state);
         drop(t5_emb_state);
         drop(clip_emb_state);
@@ -791,7 +820,7 @@ impl InferenceEngine for FluxEngine {
         };
         let latent_h = height / 16 * 2;
         let latent_w = width / 16 * 2;
-        let img = if let Some(ref source_bytes) = req.source_image {
+        let (img, inpaint_ctx) = if let Some(ref source_bytes) = req.source_image {
             progress.stage_start("Encoding source image (VAE)");
             let encode_start = Instant::now();
             let source_tensor = crate::img_utils::decode_source_image(
@@ -813,14 +842,35 @@ impl InferenceEngine for FluxEngine {
             )?;
             let encoded = encoded.to_dtype(noise_dtype)?;
             let strength = req.strength;
-            ((&encoded * (1.0 - strength))? + (&noise * strength)?)?
+            let img = ((&encoded * (1.0 - strength))? + (&noise * strength)?)?;
+
+            let inpaint_ctx = if let Some(ref mask_bytes) = req.mask_image {
+                let mask = crate::img_utils::decode_mask_image(
+                    mask_bytes,
+                    latent_h,
+                    latent_w,
+                    &loaded.device,
+                    noise_dtype,
+                )?;
+                Some(crate::img_utils::InpaintContext {
+                    original_latents: encoded,
+                    mask,
+                    noise,
+                })
+            } else {
+                None
+            };
+            (img, inpaint_ctx)
         } else {
-            crate::engine::seeded_randn(
-                seed,
-                &[1, 16, latent_h, latent_w],
-                &loaded.device,
-                noise_dtype,
-            )?
+            (
+                crate::engine::seeded_randn(
+                    seed,
+                    &[1, 16, latent_h, latent_w],
+                    &loaded.device,
+                    noise_dtype,
+                )?,
+                None,
+            )
         };
 
         // For quantized model, state tensors must be F32
@@ -880,6 +930,7 @@ impl InferenceEngine for FluxEngine {
                 &timesteps,
                 req.guidance,
                 progress,
+                inpaint_ctx.as_ref(),
             )?;
 
         // 7. Unpack latent to spatial
@@ -890,6 +941,7 @@ impl InferenceEngine for FluxEngine {
         // Free denoising intermediates and transformer before VAE decode.
         // On discrete GPUs (CUDA), the Q8 transformer alone is ~13GB — VAE decode
         // needs that VRAM for conv2d intermediates. Transformer is reloaded next generate.
+        drop(inpaint_ctx);
         drop(state);
         drop(t5_emb_state);
         drop(clip_emb_state);

--- a/crates/mold-inference/src/flux/transformer.rs
+++ b/crates/mold-inference/src/flux/transformer.rs
@@ -3,6 +3,7 @@ use candle_core::Tensor;
 use candle_transformers::models::flux::{self, WithForward};
 use std::time::Instant;
 
+use crate::img_utils::InpaintContext;
 use crate::progress::{ProgressEvent, ProgressReporter};
 
 /// BF16 or quantized (GGUF) FLUX transformer.
@@ -28,6 +29,7 @@ impl FluxTransformer {
         timesteps: &[f64],
         guidance: f64,
         progress: &ProgressReporter,
+        inpaint_ctx: Option<&InpaintContext>,
     ) -> Result<Tensor> {
         let b_sz = img.dim(0)?;
         let dev = img.device();
@@ -63,6 +65,15 @@ impl FluxTransformer {
                 )?,
             };
             img = (img + pred * (t_prev - t_curr))?;
+
+            // Inpainting: blend preserved regions back using re-noised original latents
+            if let Some(ctx) = inpaint_ctx {
+                let t = *t_prev;
+                // Flow-matching re-noising: noised = (1 - t) * original + t * noise
+                let noised_original = ((&ctx.original_latents * (1.0 - t))? + (&ctx.noise * t)?)?;
+                // mask=1 → repaint (keep denoised), mask=0 → preserve (use noised original)
+                img = ((&ctx.mask * &img)? + (&(1.0 - &ctx.mask)? * &noised_original)?)?;
+            }
 
             progress.emit(ProgressEvent::DenoiseStep {
                 step: step + 1,

--- a/crates/mold-inference/src/flux2/pipeline.rs
+++ b/crates/mold-inference/src/flux2/pipeline.rs
@@ -509,6 +509,9 @@ impl InferenceEngine for Flux2Engine {
         if req.source_image.is_some() {
             tracing::warn!("img2img not yet supported for Flux.2 — generating from text only");
         }
+        if req.mask_image.is_some() {
+            tracing::warn!("inpainting not yet supported for Flux.2 — ignoring mask");
+        }
 
         // Sequential mode: load-use-drop each component
         if self.load_strategy == LoadStrategy::Sequential {

--- a/crates/mold-inference/src/img_utils.rs
+++ b/crates/mold-inference/src/img_utils.rs
@@ -54,6 +54,50 @@ pub fn decode_source_image(
     Ok(tensor)
 }
 
+/// Decode a mask image (PNG/JPEG bytes) into a [1, 1, latent_h, latent_w] tensor in [0, 1].
+/// White (255) = 1.0 = repaint region; black (0) = 0.0 = preserve region.
+pub fn decode_mask_image(
+    bytes: &[u8],
+    latent_height: usize,
+    latent_width: usize,
+    device: &Device,
+    dtype: DType,
+) -> Result<Tensor> {
+    let img = image::load_from_memory(bytes)
+        .map_err(|e| anyhow::anyhow!("failed to decode mask image: {e}"))?;
+
+    // Convert to grayscale, resize to latent dimensions
+    let img = img.into_luma8();
+    let img = image::imageops::resize(
+        &img,
+        latent_width as u32,
+        latent_height as u32,
+        image::imageops::FilterType::Lanczos3,
+    );
+
+    let (w, h) = (img.width() as usize, img.height() as usize);
+    let raw = img.into_raw();
+
+    // Normalize to [0, 1]
+    let data: Vec<f32> = raw.iter().map(|&v| v as f32 / 255.0).collect();
+
+    // Shape: [1, 1, H, W]
+    let tensor = Tensor::from_vec(data, (1, 1, h, w), &Device::Cpu)?;
+    let tensor = tensor.to_dtype(dtype)?.to_device(device)?;
+
+    Ok(tensor)
+}
+
+/// Context for inpainting: holds pre-encoded original latents, the mask, and noise for re-noising.
+pub struct InpaintContext {
+    /// VAE-encoded original image latents (unnoised).
+    pub original_latents: Tensor,
+    /// Mask tensor [1, 1, latent_h, latent_w] in [0, 1]. 1.0 = repaint, 0.0 = preserve.
+    pub mask: Tensor,
+    /// Noise tensor for re-noising the original latents at each step.
+    pub noise: Tensor,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -131,5 +175,58 @@ mod tests {
         )
         .unwrap();
         assert_eq!(tensor.dims(), &[1, 3, 16, 16]);
+    }
+
+    /// Create a 4x4 white PNG (all 255) for mask testing.
+    fn white_png() -> Vec<u8> {
+        let img = image::RgbImage::from_fn(4, 4, |_, _| image::Rgb([255, 255, 255]));
+        let mut buf = std::io::Cursor::new(Vec::new());
+        img.write_to(&mut buf, image::ImageFormat::Png).unwrap();
+        buf.into_inner()
+    }
+
+    /// Create a 4x4 black PNG (all 0) for mask testing.
+    fn black_png() -> Vec<u8> {
+        let img = image::RgbImage::from_fn(4, 4, |_, _| image::Rgb([0, 0, 0]));
+        let mut buf = std::io::Cursor::new(Vec::new());
+        img.write_to(&mut buf, image::ImageFormat::Png).unwrap();
+        buf.into_inner()
+    }
+
+    #[test]
+    fn decode_mask_shape() {
+        let png = white_png();
+        let tensor = decode_mask_image(&png, 8, 8, &Device::Cpu, DType::F32).unwrap();
+        assert_eq!(tensor.dims(), &[1, 1, 8, 8]);
+    }
+
+    #[test]
+    fn decode_mask_white_is_one() {
+        let png = white_png();
+        let tensor = decode_mask_image(&png, 4, 4, &Device::Cpu, DType::F32).unwrap();
+        let min = tensor.min_all().unwrap().to_scalar::<f32>().unwrap();
+        assert!(min > 0.99, "white mask should be ~1.0, got {min}");
+    }
+
+    #[test]
+    fn decode_mask_black_is_zero() {
+        let png = black_png();
+        let tensor = decode_mask_image(&png, 4, 4, &Device::Cpu, DType::F32).unwrap();
+        let max = tensor.max_all().unwrap().to_scalar::<f32>().unwrap();
+        assert!(max < 0.01, "black mask should be ~0.0, got {max}");
+    }
+
+    #[test]
+    fn decode_mask_rgb_converted_to_grayscale() {
+        // A colored image should be converted to grayscale before processing
+        let png = tiny_png(); // red image
+        let tensor = decode_mask_image(&png, 4, 4, &Device::Cpu, DType::F32).unwrap();
+        assert_eq!(tensor.dims(), &[1, 1, 4, 4]);
+        // Red in grayscale is ~76/255 ≈ 0.3
+        let max = tensor.max_all().unwrap().to_scalar::<f32>().unwrap();
+        assert!(
+            max > 0.1 && max < 0.5,
+            "red in grayscale should be ~0.3, got {max}"
+        );
     }
 }

--- a/crates/mold-inference/src/qwen_image/pipeline.rs
+++ b/crates/mold-inference/src/qwen_image/pipeline.rs
@@ -582,6 +582,9 @@ impl InferenceEngine for QwenImageEngine {
         if req.source_image.is_some() {
             tracing::warn!("img2img not yet supported for Qwen-Image — generating from text only");
         }
+        if req.mask_image.is_some() {
+            tracing::warn!("inpainting not yet supported for Qwen-Image — ignoring mask");
+        }
 
         // Sequential mode: load-use-drop each component
         if self.load_strategy == LoadStrategy::Sequential {

--- a/crates/mold-inference/src/sd15/pipeline.rs
+++ b/crates/mold-inference/src/sd15/pipeline.rs
@@ -198,6 +198,7 @@ impl SD15Engine {
         guidance: f64,
         steps: u32,
         start_step: usize,
+        inpaint_ctx: Option<&crate::img_utils::InpaintContext>,
     ) -> Result<()> {
         let use_cfg = guidance > 1.0;
         let mut scheduler = crate::scheduler::build_scheduler(
@@ -234,6 +235,15 @@ impl SD15Engine {
             };
 
             *latents = scheduler.step(&noise_pred, t, &*latents)?;
+
+            // Inpainting: blend preserved regions using re-noised original latents
+            if let Some(ctx) = inpaint_ctx {
+                let noised_original =
+                    scheduler.add_noise(&ctx.original_latents, ctx.noise.clone(), t)?;
+                // mask=1 → repaint (keep denoised), mask=0 → preserve (use noised original)
+                *latents = ((&ctx.mask * &*latents)? + (&(1.0 - &ctx.mask)? * &noised_original)?)?;
+            }
+
             self.progress.emit(ProgressEvent::DenoiseStep {
                 step: step_idx + 1,
                 total: active_timesteps.len(),
@@ -247,7 +257,8 @@ impl SD15Engine {
     }
 
     /// Prepare img2img latents: VAE encode source image, add noise at the appropriate timestep.
-    /// Returns (noised_latents, start_step).
+    /// Returns (noised_latents, start_step, encoded_latents, noise) — the extra two are needed
+    /// for inpainting (re-noising at each denoising step).
     #[allow(clippy::too_many_arguments)]
     fn prepare_img2img_latents(
         &self,
@@ -261,7 +272,7 @@ impl SD15Engine {
         seed: u64,
         device: &Device,
         dtype: DType,
-    ) -> Result<(Tensor, usize)> {
+    ) -> Result<(Tensor, usize, Tensor, Tensor)> {
         use crate::img_utils::{decode_source_image, NormalizeRange};
 
         self.progress.stage_start("Encoding source image (VAE)");
@@ -305,9 +316,9 @@ impl SD15Engine {
 
         // Add noise at the start timestep
         let noised = if start_step < timesteps.len() {
-            scheduler.add_noise(&encoded, noise, timesteps[start_step])?
+            scheduler.add_noise(&encoded, noise.clone(), timesteps[start_step])?
         } else {
-            encoded
+            encoded.clone()
         };
 
         tracing::info!(
@@ -317,7 +328,7 @@ impl SD15Engine {
             "img2img: starting from step {start_step}"
         );
 
-        Ok((noised, start_step))
+        Ok((noised, start_step, encoded, noise))
     }
 
     /// Encode prompt with the single CLIP-L encoder.
@@ -450,55 +461,72 @@ impl SD15Engine {
         let is_img2img = req.source_image.is_some();
 
         // For img2img in sequential mode, we need the VAE for encoding before the UNet
-        let (mut latents, start_step) = if let Some(ref source_bytes) = req.source_image {
-            self.progress
-                .info("img2img mode: encoding source image before denoising");
+        let (mut latents, start_step, inpaint_ctx) =
+            if let Some(ref source_bytes) = req.source_image {
+                self.progress
+                    .info("img2img mode: encoding source image before denoising");
 
-            // Load VAE first for encoding
-            self.progress.stage_start("Loading VAE (GPU)");
-            let vae_start = Instant::now();
-            let vae = sd_config.build_vae(&self.paths.vae, &device, dtype)?;
-            self.progress
-                .stage_done("Loading VAE (GPU)", vae_start.elapsed());
+                // Load VAE first for encoding
+                self.progress.stage_start("Loading VAE (GPU)");
+                let vae_start = Instant::now();
+                let vae = sd_config.build_vae(&self.paths.vae, &device, dtype)?;
+                self.progress
+                    .stage_done("Loading VAE (GPU)", vae_start.elapsed());
 
-            let (latents, start_step) = self.prepare_img2img_latents(
-                &vae,
-                source_bytes,
-                req.width,
-                req.height,
-                req.strength,
-                req.steps,
-                sched,
-                seed,
-                &device,
-                dtype,
-            )?;
+                let (latents, start_step, encoded, noise) = self.prepare_img2img_latents(
+                    &vae,
+                    source_bytes,
+                    req.width,
+                    req.height,
+                    req.strength,
+                    req.steps,
+                    sched,
+                    seed,
+                    &device,
+                    dtype,
+                )?;
 
-            // Drop VAE to free memory for UNet
-            drop(vae);
-            self.progress.info("Freed VAE (will reload for decode)");
-            device.synchronize()?;
+                // Build inpaint context if mask provided
+                let inpaint_ctx = if let Some(ref mask_bytes) = req.mask_image {
+                    let latent_h = req.height as usize / 8;
+                    let latent_w = req.width as usize / 8;
+                    let mask = crate::img_utils::decode_mask_image(
+                        mask_bytes, latent_h, latent_w, &device, dtype,
+                    )?;
+                    Some(crate::img_utils::InpaintContext {
+                        original_latents: encoded,
+                        mask,
+                        noise,
+                    })
+                } else {
+                    None
+                };
 
-            (latents, start_step)
-        } else {
-            let latent_h = height / 8;
-            let latent_w = width / 8;
-            let init_scheduler = crate::scheduler::build_scheduler(
-                sched,
-                req.steps as usize,
-                PredictionType::Epsilon,
-                false,
-            )?;
-            let init_noise_sigma = init_scheduler.init_noise_sigma();
-            drop(init_scheduler);
-            let latents = (crate::engine::seeded_randn(
-                seed,
-                &[1, 4, latent_h, latent_w],
-                &device,
-                DType::F32,
-            )? * init_noise_sigma)?;
-            (latents.to_dtype(dtype)?, 0)
-        };
+                // Drop VAE to free memory for UNet
+                drop(vae);
+                self.progress.info("Freed VAE (will reload for decode)");
+                device.synchronize()?;
+
+                (latents, start_step, inpaint_ctx)
+            } else {
+                let latent_h = height / 8;
+                let latent_w = width / 8;
+                let init_scheduler = crate::scheduler::build_scheduler(
+                    sched,
+                    req.steps as usize,
+                    PredictionType::Epsilon,
+                    false,
+                )?;
+                let init_noise_sigma = init_scheduler.init_noise_sigma();
+                drop(init_scheduler);
+                let latents = (crate::engine::seeded_randn(
+                    seed,
+                    &[1, 4, latent_h, latent_w],
+                    &device,
+                    DType::F32,
+                )? * init_noise_sigma)?;
+                (latents.to_dtype(dtype)?, 0, None)
+            };
 
         self.denoise_loop(
             &unet,
@@ -508,6 +536,7 @@ impl SD15Engine {
             guidance,
             req.steps,
             start_step,
+            inpaint_ctx.as_ref(),
         )?;
 
         // Drop UNet to free memory for VAE decode
@@ -611,38 +640,58 @@ impl InferenceEngine for SD15Engine {
         // 2. Build scheduler and create initial latents
         let sched = req.scheduler.unwrap_or(self.scheduler);
 
-        let (mut latents, start_step) = if let Some(ref source_bytes) = req.source_image {
-            self.prepare_img2img_latents(
-                &loaded.vae,
-                source_bytes,
-                req.width,
-                req.height,
-                req.strength,
-                req.steps,
-                sched,
-                seed,
-                &loaded.device,
-                loaded.dtype,
-            )?
-        } else {
-            let latent_h = height / 8;
-            let latent_w = width / 8;
-            let init_scheduler = crate::scheduler::build_scheduler(
-                sched,
-                req.steps as usize,
-                PredictionType::Epsilon,
-                false,
-            )?;
-            let init_noise_sigma = init_scheduler.init_noise_sigma();
-            drop(init_scheduler);
-            let latents = (crate::engine::seeded_randn(
-                seed,
-                &[1, 4, latent_h, latent_w],
-                &loaded.device,
-                DType::F32,
-            )? * init_noise_sigma)?;
-            (latents.to_dtype(loaded.dtype)?, 0)
-        };
+        let (mut latents, start_step, inpaint_ctx) =
+            if let Some(ref source_bytes) = req.source_image {
+                let (latents, start_step, encoded, noise) = self.prepare_img2img_latents(
+                    &loaded.vae,
+                    source_bytes,
+                    req.width,
+                    req.height,
+                    req.strength,
+                    req.steps,
+                    sched,
+                    seed,
+                    &loaded.device,
+                    loaded.dtype,
+                )?;
+                let inpaint_ctx = if let Some(ref mask_bytes) = req.mask_image {
+                    let latent_h = req.height as usize / 8;
+                    let latent_w = req.width as usize / 8;
+                    let mask = crate::img_utils::decode_mask_image(
+                        mask_bytes,
+                        latent_h,
+                        latent_w,
+                        &loaded.device,
+                        loaded.dtype,
+                    )?;
+                    Some(crate::img_utils::InpaintContext {
+                        original_latents: encoded,
+                        mask,
+                        noise,
+                    })
+                } else {
+                    None
+                };
+                (latents, start_step, inpaint_ctx)
+            } else {
+                let latent_h = height / 8;
+                let latent_w = width / 8;
+                let init_scheduler = crate::scheduler::build_scheduler(
+                    sched,
+                    req.steps as usize,
+                    PredictionType::Epsilon,
+                    false,
+                )?;
+                let init_noise_sigma = init_scheduler.init_noise_sigma();
+                drop(init_scheduler);
+                let latents = (crate::engine::seeded_randn(
+                    seed,
+                    &[1, 4, latent_h, latent_w],
+                    &loaded.device,
+                    DType::F32,
+                )? * init_noise_sigma)?;
+                (latents.to_dtype(loaded.dtype)?, 0, None)
+            };
 
         // 3. Denoising loop
         self.denoise_loop(
@@ -653,6 +702,7 @@ impl InferenceEngine for SD15Engine {
             guidance,
             req.steps,
             start_step,
+            inpaint_ctx.as_ref(),
         )?;
 
         // 4. VAE decode

--- a/crates/mold-inference/src/sd3/pipeline.rs
+++ b/crates/mold-inference/src/sd3/pipeline.rs
@@ -546,6 +546,9 @@ impl InferenceEngine for SD3Engine {
         if req.source_image.is_some() {
             tracing::warn!("img2img not yet supported for SD3 — generating from text only");
         }
+        if req.mask_image.is_some() {
+            tracing::warn!("inpainting not yet supported for SD3 — ignoring mask");
+        }
 
         // Sequential mode: load-use-drop each component
         if self.load_strategy == LoadStrategy::Sequential {

--- a/crates/mold-inference/src/sdxl/pipeline.rs
+++ b/crates/mold-inference/src/sdxl/pipeline.rs
@@ -255,6 +255,7 @@ impl SDXLEngine {
         guidance: f64,
         steps: u32,
         start_step: usize,
+        inpaint_ctx: Option<&crate::img_utils::InpaintContext>,
     ) -> Result<()> {
         let use_cfg = guidance > 1.0;
         let mut scheduler = crate::scheduler::build_scheduler(
@@ -291,6 +292,14 @@ impl SDXLEngine {
             };
 
             *latents = scheduler.step(&noise_pred, t, &*latents)?;
+
+            // Inpainting: blend preserved regions using re-noised original latents
+            if let Some(ctx) = inpaint_ctx {
+                let noised_original =
+                    scheduler.add_noise(&ctx.original_latents, ctx.noise.clone(), t)?;
+                *latents = ((&ctx.mask * &*latents)? + (&(1.0 - &ctx.mask)? * &noised_original)?)?;
+            }
+
             self.progress.emit(ProgressEvent::DenoiseStep {
                 step: step_idx + 1,
                 total: active_timesteps.len(),
@@ -304,7 +313,8 @@ impl SDXLEngine {
     }
 
     /// Prepare img2img latents: VAE encode source image, add noise at the appropriate timestep.
-    /// Returns (noised_latents, start_step).
+    /// Returns (noised_latents, start_step, encoded_latents, noise) — the extra two are needed
+    /// for inpainting (re-noising at each denoising step).
     #[allow(clippy::too_many_arguments)]
     fn prepare_img2img_latents(
         &self,
@@ -318,7 +328,7 @@ impl SDXLEngine {
         seed: u64,
         device: &Device,
         dtype: DType,
-    ) -> Result<(Tensor, usize)> {
+    ) -> Result<(Tensor, usize, Tensor, Tensor)> {
         use crate::img_utils::{decode_source_image, NormalizeRange};
 
         self.progress.stage_start("Encoding source image (VAE)");
@@ -363,9 +373,9 @@ impl SDXLEngine {
         let noise = noise.to_dtype(dtype)?;
 
         let noised = if start_step < timesteps.len() {
-            scheduler.add_noise(&encoded, noise, timesteps[start_step])?
+            scheduler.add_noise(&encoded, noise.clone(), timesteps[start_step])?
         } else {
-            encoded
+            encoded.clone()
         };
 
         tracing::info!(
@@ -375,7 +385,7 @@ impl SDXLEngine {
             "img2img: starting from step {start_step}"
         );
 
-        Ok((noised, start_step))
+        Ok((noised, start_step, encoded, noise))
     }
 
     /// Encode prompt with both CLIP encoders.
@@ -546,53 +556,69 @@ impl SDXLEngine {
         let sched = req.scheduler.unwrap_or(self.scheduler);
         let is_img2img = req.source_image.is_some();
 
-        let (mut latents, start_step) = if let Some(ref source_bytes) = req.source_image {
-            self.progress
-                .info("img2img mode: encoding source image before denoising");
+        let (mut latents, start_step, inpaint_ctx) =
+            if let Some(ref source_bytes) = req.source_image {
+                self.progress
+                    .info("img2img mode: encoding source image before denoising");
 
-            self.progress.stage_start("Loading VAE (GPU)");
-            let vae_start_t = Instant::now();
-            let vae = sd_config.build_vae(&self.paths.vae, &device, dtype)?;
-            self.progress
-                .stage_done("Loading VAE (GPU)", vae_start_t.elapsed());
+                self.progress.stage_start("Loading VAE (GPU)");
+                let vae_start_t = Instant::now();
+                let vae = sd_config.build_vae(&self.paths.vae, &device, dtype)?;
+                self.progress
+                    .stage_done("Loading VAE (GPU)", vae_start_t.elapsed());
 
-            let (latents, start_step) = self.prepare_img2img_latents(
-                &vae,
-                source_bytes,
-                req.width,
-                req.height,
-                req.strength,
-                req.steps,
-                sched,
-                seed,
-                &device,
-                dtype,
-            )?;
+                let (latents, start_step, encoded, noise) = self.prepare_img2img_latents(
+                    &vae,
+                    source_bytes,
+                    req.width,
+                    req.height,
+                    req.strength,
+                    req.steps,
+                    sched,
+                    seed,
+                    &device,
+                    dtype,
+                )?;
 
-            drop(vae);
-            self.progress.info("Freed VAE (will reload for decode)");
-            device.synchronize()?;
+                let inpaint_ctx = if let Some(ref mask_bytes) = req.mask_image {
+                    let latent_h = req.height as usize / 8;
+                    let latent_w = req.width as usize / 8;
+                    let mask = crate::img_utils::decode_mask_image(
+                        mask_bytes, latent_h, latent_w, &device, dtype,
+                    )?;
+                    Some(crate::img_utils::InpaintContext {
+                        original_latents: encoded,
+                        mask,
+                        noise,
+                    })
+                } else {
+                    None
+                };
 
-            (latents, start_step)
-        } else {
-            let latent_h = height / 8;
-            let latent_w = width / 8;
-            let init_scheduler = crate::scheduler::build_scheduler(
-                sched,
-                req.steps as usize,
-                PredictionType::Epsilon,
-                self.is_turbo,
-            )?;
-            let init_noise_sigma = init_scheduler.init_noise_sigma();
-            drop(init_scheduler);
-            let latents = (crate::engine::seeded_randn(
-                seed,
-                &[1, 4, latent_h, latent_w],
-                &device,
-                DType::F32,
-            )? * init_noise_sigma)?;
-            (latents.to_dtype(dtype)?, 0)
-        };
+                drop(vae);
+                self.progress.info("Freed VAE (will reload for decode)");
+                device.synchronize()?;
+
+                (latents, start_step, inpaint_ctx)
+            } else {
+                let latent_h = height / 8;
+                let latent_w = width / 8;
+                let init_scheduler = crate::scheduler::build_scheduler(
+                    sched,
+                    req.steps as usize,
+                    PredictionType::Epsilon,
+                    self.is_turbo,
+                )?;
+                let init_noise_sigma = init_scheduler.init_noise_sigma();
+                drop(init_scheduler);
+                let latents = (crate::engine::seeded_randn(
+                    seed,
+                    &[1, 4, latent_h, latent_w],
+                    &device,
+                    DType::F32,
+                )? * init_noise_sigma)?;
+                (latents.to_dtype(dtype)?, 0, None)
+            };
 
         self.denoise_loop(
             &unet,
@@ -602,6 +628,7 @@ impl SDXLEngine {
             guidance,
             req.steps,
             start_step,
+            inpaint_ctx.as_ref(),
         )?;
 
         // Drop UNet to free memory for VAE decode
@@ -712,38 +739,58 @@ impl InferenceEngine for SDXLEngine {
         // 3. Build scheduler and create initial latents
         let sched = req.scheduler.unwrap_or(self.scheduler);
 
-        let (mut latents, start_step) = if let Some(ref source_bytes) = req.source_image {
-            self.prepare_img2img_latents(
-                &loaded.vae,
-                source_bytes,
-                req.width,
-                req.height,
-                req.strength,
-                req.steps,
-                sched,
-                seed,
-                &loaded.device,
-                loaded.dtype,
-            )?
-        } else {
-            let latent_h = height / 8;
-            let latent_w = width / 8;
-            let init_scheduler = crate::scheduler::build_scheduler(
-                sched,
-                req.steps as usize,
-                PredictionType::Epsilon,
-                self.is_turbo,
-            )?;
-            let init_noise_sigma = init_scheduler.init_noise_sigma();
-            drop(init_scheduler);
-            let latents = (crate::engine::seeded_randn(
-                seed,
-                &[1, 4, latent_h, latent_w],
-                &loaded.device,
-                DType::F32,
-            )? * init_noise_sigma)?;
-            (latents.to_dtype(loaded.dtype)?, 0)
-        };
+        let (mut latents, start_step, inpaint_ctx) =
+            if let Some(ref source_bytes) = req.source_image {
+                let (latents, start_step, encoded, noise) = self.prepare_img2img_latents(
+                    &loaded.vae,
+                    source_bytes,
+                    req.width,
+                    req.height,
+                    req.strength,
+                    req.steps,
+                    sched,
+                    seed,
+                    &loaded.device,
+                    loaded.dtype,
+                )?;
+                let inpaint_ctx = if let Some(ref mask_bytes) = req.mask_image {
+                    let latent_h = req.height as usize / 8;
+                    let latent_w = req.width as usize / 8;
+                    let mask = crate::img_utils::decode_mask_image(
+                        mask_bytes,
+                        latent_h,
+                        latent_w,
+                        &loaded.device,
+                        loaded.dtype,
+                    )?;
+                    Some(crate::img_utils::InpaintContext {
+                        original_latents: encoded,
+                        mask,
+                        noise,
+                    })
+                } else {
+                    None
+                };
+                (latents, start_step, inpaint_ctx)
+            } else {
+                let latent_h = height / 8;
+                let latent_w = width / 8;
+                let init_scheduler = crate::scheduler::build_scheduler(
+                    sched,
+                    req.steps as usize,
+                    PredictionType::Epsilon,
+                    self.is_turbo,
+                )?;
+                let init_noise_sigma = init_scheduler.init_noise_sigma();
+                drop(init_scheduler);
+                let latents = (crate::engine::seeded_randn(
+                    seed,
+                    &[1, 4, latent_h, latent_w],
+                    &loaded.device,
+                    DType::F32,
+                )? * init_noise_sigma)?;
+                (latents.to_dtype(loaded.dtype)?, 0, None)
+            };
 
         // 5. Denoising loop
         self.denoise_loop(
@@ -754,6 +801,7 @@ impl InferenceEngine for SDXLEngine {
             guidance,
             req.steps,
             start_step,
+            inpaint_ctx.as_ref(),
         )?;
 
         // 6. VAE decode

--- a/crates/mold-inference/src/wuerstchen/pipeline.rs
+++ b/crates/mold-inference/src/wuerstchen/pipeline.rs
@@ -567,6 +567,9 @@ impl InferenceEngine for WuerstchenEngine {
         if req.source_image.is_some() {
             tracing::warn!("img2img not yet supported for Wuerstchen — generating from text only");
         }
+        if req.mask_image.is_some() {
+            tracing::warn!("inpainting not yet supported for Wuerstchen — ignoring mask");
+        }
 
         if self.load_strategy == LoadStrategy::Sequential {
             return self.generate_sequential(req);

--- a/crates/mold-inference/src/zimage/pipeline.rs
+++ b/crates/mold-inference/src/zimage/pipeline.rs
@@ -599,6 +599,9 @@ impl InferenceEngine for ZImageEngine {
         if req.source_image.is_some() {
             tracing::warn!("img2img not yet supported for Z-Image — generating from text only");
         }
+        if req.mask_image.is_some() {
+            tracing::warn!("inpainting not yet supported for Z-Image — ignoring mask");
+        }
 
         // Sequential mode: load-use-drop each component
         if self.load_strategy == LoadStrategy::Sequential {


### PR DESCRIPTION
## Summary

- Adds mask-based inpainting for FLUX, SD1.5, and SDXL pipelines via a new `--mask` CLI flag
- White mask regions (255) are repainted while black regions (0) are preserved from the source image
- Uses latent-space mask blending at each denoising step with model-appropriate re-noising:
  - **FLUX**: flow-matching formula `(1-t)*original + t*noise`
  - **SD1.5/SDXL**: `scheduler.add_noise()` at the current timestep
- Unsupported engines (SD3, Z-Image, Wuerstchen, Flux.2, Qwen-Image) log a warning and ignore the mask

### Changes

- `mold-core`: `mask_image` field on `GenerateRequest` (base64 serde, backward-compatible)
- `mold-core`: Inpainting validation (mask requires source_image, PNG/JPEG format check)
- `mold-inference`: `decode_mask_image()` (grayscale, resize to latent dims) and `InpaintContext` struct
- `mold-inference`: Mask blending in FLUX transformer, SD1.5, and SDXL denoise loops
- `mold-inference`: `prepare_img2img_latents` returns encoded latents + noise for inpaint context
- `mold-cli`: `--mask <path>` flag (requires `--image`), status message for inpainting mode

### Usage

```bash
mold run flux-dev:q4 "a cat wearing a hat" --image photo.png --mask mask.png
mold run sd15:fp16 "repaint this area" --image input.jpg --mask mask.jpg --strength 0.8
```

Closes #22

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `cargo test --workspace` (211 tests pass, including new inpainting tests)
- [ ] Manual test: generate inpainted image with FLUX model + mask
- [ ] Manual test: generate inpainted image with SD1.5 model + mask