### PR TITLE
fix(cli): colorize Wuerstchen family label

### DIFF
--- a/crates/mold-cli/src/commands/info.rs
+++ b/crates/mold-cli/src/commands/info.rs
@@ -81,6 +81,7 @@ fn format_family(family: &str) -> String {
         "sdxl" => "SDXL".yellow().to_string(),
         "z-image" => "Z-Image".cyan().to_string(),
         "qwen-image" | "qwen_image" => "Qwen-Image".bright_cyan().to_string(),
+        "wuerstchen" | "wuerstchen-v2" => "Wuerstchen".bright_yellow().to_string(),
         other => other.to_uppercase(),
     }
 }

--- a/crates/mold-cli/src/commands/list.rs
+++ b/crates/mold-cli/src/commands/list.rs
@@ -14,6 +14,7 @@ fn family_label(family: &str) -> &str {
         "sdxl" => "SDXL",
         "z-image" => "Z-Image",
         "qwen-image" | "qwen_image" => "Qwen-Image",
+        "wuerstchen" | "wuerstchen-v2" => "Wuerstchen",
         other => other,
     }
 }
@@ -29,6 +30,7 @@ fn format_family_padded(family: &str, width: usize) -> String {
         "sdxl" => padded.yellow().to_string(),
         "z-image" => padded.cyan().to_string(),
         "qwen-image" | "qwen_image" => padded.bright_cyan().to_string(),
+        "wuerstchen" | "wuerstchen-v2" => padded.bright_yellow().to_string(),
         _ => padded,
     }
 }


### PR DESCRIPTION
## Summary

Add bright yellow color to the Wuerstchen family label in `mold list` and `mold info` output, matching the existing colorization for all other model families.

### Changes
- `list.rs`: Add `"wuerstchen" | "wuerstchen-v2"` to `family_label()` (→ "Wuerstchen") and `format_family_padded()` (→ bright_yellow)
- `info.rs`: Add `"wuerstchen" | "wuerstchen-v2"` to `format_family()` (→ bright_yellow)

## Test plan
- [x] `cargo test -p mold-ai` — 67 tests pass
- [x] `cargo clippy` clean