### PR TITLE
fix: SIZE column shows total model size, FETCH shows remaining download

### DIFF
--- a/crates/mold-cli/src/commands/list.rs
+++ b/crates/mold-cli/src/commands/list.rs
@@ -137,23 +137,26 @@ pub async fn run() -> Result<()> {
                     fw = fw,
                 );
                 for m in &available {
-                    let size_str = if m.size_gb > 0.0 {
-                        format!("{:.1}GB", m.size_gb)
-                    } else {
-                        "—".to_string()
-                    };
-                    let fetch_col = if let Some(mf) = mold_core::manifest::find_manifest(&m.name) {
-                        let (_total_bytes, remaining_bytes) =
-                            mold_core::manifest::compute_download_size(mf);
-                        let remaining_gb = remaining_bytes as f64 / 1_073_741_824.0;
-                        if remaining_bytes == 0 {
-                            "cached".dimmed().to_string()
+                    let (size_str, fetch_col) =
+                        if let Some(mf) = mold_core::manifest::find_manifest(&m.name) {
+                            let (total_bytes, remaining_bytes) =
+                                mold_core::manifest::compute_download_size(mf);
+                            let total_gb = total_bytes as f64 / 1_073_741_824.0;
+                            let remaining_gb = remaining_bytes as f64 / 1_073_741_824.0;
+                            let fetch = if remaining_bytes == 0 {
+                                format!("{:>7}", "cached").dimmed().to_string()
+                            } else {
+                                format!("{:.1}GB", remaining_gb)
+                            };
+                            (format!("{:.1}GB", total_gb), fetch)
                         } else {
-                            format!("{:.1}GB", remaining_gb)
-                        }
-                    } else {
-                        size_str.clone()
-                    };
+                            let s = if m.size_gb > 0.0 {
+                                format!("{:.1}GB", m.size_gb)
+                            } else {
+                                "—".to_string()
+                            };
+                            (s.clone(), s)
+                        };
                     println!(
                         "  {:<nw$} {} {:>7}  {:>7}  {}",
                         m.name.bold(),
@@ -278,10 +281,11 @@ pub async fn run() -> Result<()> {
                     fw = fw,
                 );
                 for m in &available {
-                    let (_total_bytes, remaining_bytes) =
+                    let (total_bytes, remaining_bytes) =
                         mold_core::manifest::compute_download_size(m);
+                    let total_gb = total_bytes as f64 / 1_073_741_824.0;
                     let remaining_gb = remaining_bytes as f64 / 1_073_741_824.0;
-                    let size_str = format!("{:.1}GB", m.size_gb);
+                    let size_str = format!("{:.1}GB", total_gb);
                     let fetch_col = if remaining_bytes == 0 {
                         format!("{:>7}", "cached").dimmed().to_string()
                     } else {

--- a/crates/mold-core/src/manifest.rs
+++ b/crates/mold-core/src/manifest.rs
@@ -2536,4 +2536,57 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn total_download_size_equals_sum_of_file_sizes() {
+        for manifest in known_manifests() {
+            let total = total_download_size(&manifest);
+            let sum: u64 = manifest.files.iter().map(|f| f.size_bytes).sum();
+            assert_eq!(
+                total, sum,
+                "total_download_size mismatch for {}",
+                manifest.name
+            );
+        }
+    }
+
+    #[test]
+    fn compute_download_remaining_lte_total() {
+        // remaining_bytes must always be <= total_bytes
+        for manifest in known_manifests() {
+            let (total, remaining) = compute_download_size(&manifest);
+            assert!(
+                remaining <= total,
+                "remaining ({remaining}) > total ({total}) for {}",
+                manifest.name
+            );
+        }
+    }
+
+    #[test]
+    fn total_file_bytes_is_positive_for_all_manifests() {
+        // Every manifest must have files that sum to a positive total
+        for manifest in known_manifests() {
+            let total = total_download_size(&manifest);
+            assert!(total > 0, "total_download_size is 0 for {}", manifest.name);
+        }
+    }
+
+    #[test]
+    fn wuerstchen_no_storage_path_collisions() {
+        let manifest = find_manifest("wuerstchen-v2:fp16").unwrap();
+        let paths: Vec<_> = manifest
+            .files
+            .iter()
+            .map(|f| storage_path(&manifest, f))
+            .collect();
+        // No two files should resolve to the same local path
+        let unique: std::collections::HashSet<_> = paths.iter().collect();
+        assert_eq!(
+            paths.len(),
+            unique.len(),
+            "storage path collision in wuerstchen manifest: {:?}",
+            paths
+        );
+    }
 }


### PR DESCRIPTION
## Summary

The SIZE column in `mold list` was showing `manifest.size_gb` (transformer only) while FETCH showed remaining download of **all** files including shared components. This caused FETCH > SIZE for models with large shared components (e.g. `qwen-image:q8` showed SIZE=21.8GB, FETCH=35.0GB).

### Fix
SIZE now shows `total_bytes` (all files) from `compute_download_size()`, so **SIZE >= FETCH always holds**. Applied to both online and offline `mold list` modes.

### Test coverage added
- `total_download_size` equals sum of file sizes (all manifests)
- `remaining_bytes <= total_bytes` invariant (all manifests)
- Total file bytes is positive for all manifests
- Wuerstchen has no storage path collisions (dual CLIP from different repos)

## Test plan
- [x] `cargo check/clippy/fmt` all pass
- [x] `cargo test --workspace` — 223 tests pass
- [x] `mold list` SIZE >= FETCH for all models