### PR TITLE
fix: code quality cleanup and server reliability

### DIFF
--- a/crates/mold-cli/src/commands/run.rs
+++ b/crates/mold-cli/src/commands/run.rs
@@ -166,9 +166,10 @@ mod tests {
     use super::*;
 
     fn test_config() -> Config {
-        let mut config = Config::default();
-        config.default_model = "flux-schnell".to_string();
-        config
+        Config {
+            default_model: "flux-schnell".to_string(),
+            ..Config::default()
+        }
     }
 
     #[test]

--- a/crates/mold-cli/src/output.rs
+++ b/crates/mold-cli/src/output.rs
@@ -44,9 +44,7 @@ mod tests {
     #[test]
     fn is_piped_returns_bool() {
         // In test context, stdout is typically not a terminal (piped by cargo test)
-        let result = is_piped();
-        // Just verify it doesn't panic; actual value depends on test runner
-        assert!(result == true || result == false);
+        let _ = is_piped();
     }
 
     #[test]

--- a/crates/mold-core/src/config.rs
+++ b/crates/mold-core/src/config.rs
@@ -196,10 +196,10 @@ impl ModelPaths {
     }
 
     fn resolve_path(config_val: Option<&str>, env_var: &str) -> Option<PathBuf> {
-        if let Some(path) = config_val {
+        if let Ok(path) = std::env::var(env_var) {
             return Some(PathBuf::from(path));
         }
-        if let Ok(path) = std::env::var(env_var) {
+        if let Some(path) = config_val {
             return Some(PathBuf::from(path));
         }
         None

--- a/crates/mold-core/src/config_test.rs
+++ b/crates/mold-core/src/config_test.rs
@@ -227,9 +227,9 @@ is_schnell = false
     }
 
     #[test]
-    fn model_paths_config_takes_precedence_over_env() {
+    fn model_paths_env_takes_precedence_over_config() {
         let _lock = ENV_LOCK.lock().unwrap();
-        std::env::set_var("MOLD_TRANSFORMER_PATH", "/env/should-not-use.gguf");
+        std::env::set_var("MOLD_TRANSFORMER_PATH", "/env/transformer.gguf");
 
         let mut models = HashMap::new();
         models.insert("flux-schnell".to_string(), full_model_config("/cfg"));
@@ -240,11 +240,38 @@ is_schnell = false
         let paths = ModelPaths::resolve("flux-schnell", &cfg).unwrap();
         assert_eq!(
             paths.transformer.to_str().unwrap(),
-            "/cfg/transformer.gguf",
-            "config path should override env var"
+            "/env/transformer.gguf",
+            "env path should override config path"
         );
 
         std::env::remove_var("MOLD_TRANSFORMER_PATH");
+    }
+
+    #[test]
+    fn model_paths_optional_env_takes_precedence_over_config() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        std::env::set_var("MOLD_T5_PATH", "/env/t5.safetensors");
+        std::env::set_var("MOLD_CLIP_TOKENIZER_PATH", "/env/clip.tokenizer.json");
+
+        let mut models = HashMap::new();
+        models.insert("flux-schnell".to_string(), full_model_config("/cfg"));
+        let cfg = Config {
+            models,
+            ..Config::default()
+        };
+        let paths = ModelPaths::resolve("flux-schnell", &cfg).unwrap();
+
+        assert_eq!(
+            paths.t5_encoder.as_ref().unwrap().to_str().unwrap(),
+            "/env/t5.safetensors"
+        );
+        assert_eq!(
+            paths.clip_tokenizer.as_ref().unwrap().to_str().unwrap(),
+            "/env/clip.tokenizer.json"
+        );
+
+        std::env::remove_var("MOLD_T5_PATH");
+        std::env::remove_var("MOLD_CLIP_TOKENIZER_PATH");
     }
 
     // ── resolved_models_dir ───────────────────────────────────────────────────

--- a/crates/mold-core/src/manifest.rs
+++ b/crates/mold-core/src/manifest.rs
@@ -1863,7 +1863,7 @@ mod tests {
             .iter()
             .find(|f| f.component == ModelComponent::Transformer)
             .unwrap();
-        let path = storage_path(&manifest, transformer_file);
+        let path = storage_path(manifest, transformer_file);
         assert!(
             path.starts_with("flux-schnell-q8"),
             "transformer should be under model-specific dir, got: {}",
@@ -1876,7 +1876,7 @@ mod tests {
     fn storage_path_shared_components_under_family() {
         let manifest = find_manifest("flux-schnell:q8").unwrap();
         for file in &manifest.files {
-            let path = storage_path(&manifest, file);
+            let path = storage_path(manifest, file);
             match file.component {
                 ModelComponent::Transformer | ModelComponent::TransformerShard => {
                     assert!(path.starts_with("flux-schnell-q8"));
@@ -1901,7 +1901,7 @@ mod tests {
             .iter()
             .find(|f| f.component == ModelComponent::TextEncoder)
             .unwrap();
-        let path = storage_path(&manifest, encoder_file);
+        let path = storage_path(manifest, encoder_file);
         // Nested HF filename like "text_encoder/model-00001-of-00003.safetensors"
         // should be preserved under shared/z-image/
         assert!(
@@ -1920,7 +1920,7 @@ mod tests {
             .iter()
             .find(|f| f.component == ModelComponent::Transformer)
             .unwrap();
-        let path = storage_path(&manifest, transformer_file);
+        let path = storage_path(manifest, transformer_file);
         assert!(
             path.starts_with("sdxl-base-fp16"),
             "got: {}",
@@ -1936,7 +1936,7 @@ mod tests {
             .iter()
             .find(|f| f.component == ModelComponent::Transformer)
             .unwrap();
-        let path = storage_path(&manifest, transformer_file);
+        let path = storage_path(manifest, transformer_file);
         assert!(
             !path.to_string_lossy().contains(':'),
             "colons should be replaced with dashes"
@@ -2517,7 +2517,7 @@ mod tests {
     #[test]
     fn total_download_size_equals_sum_of_file_sizes() {
         for manifest in known_manifests() {
-            let total = total_download_size(&manifest);
+            let total = total_download_size(manifest);
             let sum: u64 = manifest.files.iter().map(|f| f.size_bytes).sum();
             assert_eq!(
                 total, sum,
@@ -2531,7 +2531,7 @@ mod tests {
     fn compute_download_remaining_lte_total() {
         // remaining_bytes must always be <= total_bytes
         for manifest in known_manifests() {
-            let (total, remaining) = compute_download_size(&manifest);
+            let (total, remaining) = compute_download_size(manifest);
             assert!(
                 remaining <= total,
                 "remaining ({remaining}) > total ({total}) for {}",
@@ -2544,7 +2544,7 @@ mod tests {
     fn total_file_bytes_is_positive_for_all_manifests() {
         // Every manifest must have files that sum to a positive total
         for manifest in known_manifests() {
-            let total = total_download_size(&manifest);
+            let total = total_download_size(manifest);
             assert!(total > 0, "total_download_size is 0 for {}", manifest.name);
         }
     }
@@ -2664,7 +2664,7 @@ mod tests {
         let paths: Vec<_> = manifest
             .files
             .iter()
-            .map(|f| storage_path(&manifest, f))
+            .map(|f| storage_path(manifest, f))
             .collect();
         // No two files should resolve to the same local path
         let unique: std::collections::HashSet<_> = paths.iter().collect();

--- a/crates/mold-inference/src/device.rs
+++ b/crates/mold-inference/src/device.rs
@@ -566,14 +566,16 @@ mod tests {
 
     #[test]
     fn t5_threshold_accounts_for_headroom() {
-        assert!(T5_VRAM_THRESHOLD > 9_200_000_000);
-        assert!(T5_VRAM_THRESHOLD < 25_000_000_000);
+        let threshold = std::hint::black_box(T5_VRAM_THRESHOLD);
+        assert!(threshold > 9_200_000_000);
+        assert!(threshold < 25_000_000_000);
     }
 
     #[test]
     fn clip_threshold_accounts_for_headroom() {
-        assert!(CLIP_VRAM_THRESHOLD > 246_000_000);
-        assert!(CLIP_VRAM_THRESHOLD < 2_000_000_000);
+        let threshold = std::hint::black_box(CLIP_VRAM_THRESHOLD);
+        assert!(threshold > 246_000_000);
+        assert!(threshold < 2_000_000_000);
     }
 
     // --- Dynamic T5 threshold tests ---
@@ -663,7 +665,7 @@ mod tests {
     #[test]
     fn budget_hard_fail_when_exceeds_90pct_available() {
         // 19 GB component, 20 GB available → 19 > 18 (90% of 20) → fail
-        let result = preflight_check_budget("UNet", 19 * GB, 20 * GB, Some(1 * GB));
+        let result = preflight_check_budget("UNet", 19 * GB, 20 * GB, Some(GB));
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
         assert!(msg.contains("Not enough memory"), "got: {msg}");
@@ -672,7 +674,7 @@ mod tests {
     #[test]
     fn budget_ok_at_exactly_90pct_available() {
         // 18 GB component, 20 GB available → 18 == 18 (90% of 20) → pass (not >)
-        let result = preflight_check_budget("UNet", 18 * GB, 20 * GB, Some(1 * GB));
+        let result = preflight_check_budget("UNet", 18 * GB, 20 * GB, Some(GB));
         assert!(result.is_ok());
     }
 
@@ -716,7 +718,7 @@ mod tests {
 
     #[test]
     fn budget_error_message_includes_component_name() {
-        let result = preflight_check_budget("MyModel", 19 * GB, 20 * GB, Some(1 * GB));
+        let result = preflight_check_budget("MyModel", 19 * GB, 20 * GB, Some(GB));
         let msg = result.unwrap_err().to_string();
         assert!(
             msg.contains("MyModel"),
@@ -726,7 +728,7 @@ mod tests {
 
     #[test]
     fn budget_error_message_includes_sizes() {
-        let result = preflight_check_budget("UNet", 19 * GB, 20 * GB, Some(1 * GB));
+        let result = preflight_check_budget("UNet", 19 * GB, 20 * GB, Some(GB));
         let msg = result.unwrap_err().to_string();
         assert!(msg.contains("19.0 GB"), "should show needed size");
         assert!(msg.contains("20.0 GB"), "should show available size");

--- a/crates/mold-inference/src/flux2/vae.rs
+++ b/crates/mold-inference/src/flux2/vae.rs
@@ -14,8 +14,6 @@ use candle_nn::{conv2d, group_norm, Conv2d, Conv2dConfig, GroupNorm, Linear, Mod
 /// Flux.2 VAE configuration.
 #[derive(Debug, Clone)]
 pub struct Flux2VaeConfig {
-    #[allow(dead_code)]
-    pub in_channels: usize,
     pub out_channels: usize,
     pub block_out_channels: Vec<usize>,
     pub layers_per_block: usize,
@@ -30,7 +28,6 @@ pub struct Flux2VaeConfig {
 impl Flux2VaeConfig {
     pub fn klein() -> Self {
         Self {
-            in_channels: 3,
             out_channels: 3,
             block_out_channels: vec![128, 256, 512, 512],
             layers_per_block: 2,

--- a/crates/mold-inference/src/image.rs
+++ b/crates/mold-inference/src/image.rs
@@ -37,8 +37,8 @@ mod tests {
     fn solid_red_tensor(h: usize, w: usize) -> Tensor {
         let mut data = vec![0u8; 3 * h * w];
         // Channel 0 (R) = 255, channels 1 and 2 stay 0
-        for i in 0..(h * w) {
-            data[i] = 255;
+        for value in data.iter_mut().take(h * w) {
+            *value = 255;
         }
         Tensor::from_vec(data, (3, h, w), &Device::Cpu)
             .unwrap()

--- a/crates/mold-inference/src/qwen_image/sampling.rs
+++ b/crates/mold-inference/src/qwen_image/sampling.rs
@@ -87,12 +87,6 @@ impl QwenImageScheduler {
         }
     }
 
-    /// Get the current sigma value.
-    #[allow(dead_code)]
-    pub fn current_sigma(&self) -> f64 {
-        self.sigmas[self.step_index]
-    }
-
     /// Get the current timestep normalized for model input.
     ///
     /// Returns `sigma * num_train_timesteps` which the transformer expects.
@@ -114,12 +108,6 @@ impl QwenImageScheduler {
 
         self.step_index += 1;
         Ok(prev_sample)
-    }
-
-    /// Reset scheduler to the beginning.
-    #[allow(dead_code)]
-    pub fn reset(&mut self) {
-        self.step_index = 0;
     }
 }
 

--- a/crates/mold-inference/src/qwen_image/transformer.rs
+++ b/crates/mold-inference/src/qwen_image/transformer.rs
@@ -41,9 +41,6 @@ pub(crate) struct QwenImageConfig {
     pub patch_size: usize,
     /// 3D RoPE axis dimensions [16, 56, 56].
     pub axes_dims_rope: Vec<usize>,
-    /// Whether to include guidance embedding (false for Qwen-Image).
-    #[allow(dead_code)]
-    pub guidance_embeds: bool,
     /// RMSNorm epsilon.
     pub norm_eps: f64,
 }
@@ -69,7 +66,6 @@ impl QwenImageConfig {
             out_channels: 16, // VAE latent channels
             patch_size: 2,
             axes_dims_rope: vec![16, 56, 56],
-            guidance_embeds: false,
             norm_eps: 1e-6,
         }
     }
@@ -163,8 +159,6 @@ struct JointAttention {
     // Dimensions
     n_heads: usize,
     head_dim: usize,
-    #[allow(dead_code)]
-    use_accelerated_attn: bool,
 }
 
 impl JointAttention {
@@ -208,7 +202,6 @@ impl JointAttention {
             norm_added_k,
             n_heads,
             head_dim,
-            use_accelerated_attn: true,
         })
     }
 
@@ -687,11 +680,5 @@ impl QwenImageTransformer2DModel {
         // 7. Unpatchify: (B, num_patches, patch_dim) -> (B, C, 1, H, W) -> squeeze -> (B, C, H, W)
         let x_out = unpatchify(&img_out, orig_size, patch_size, 1, self.cfg.out_channels)?;
         x_out.squeeze(2)
-    }
-
-    /// Get the model configuration.
-    #[allow(dead_code)]
-    pub fn config(&self) -> &QwenImageConfig {
-        &self.cfg
     }
 }

--- a/crates/mold-inference/src/zimage/pipeline.rs
+++ b/crates/mold-inference/src/zimage/pipeline.rs
@@ -975,17 +975,20 @@ mod tests {
     fn qwen3_threshold_allows_gpu_on_24gb_with_quantized_xformer() {
         // Key improvement: with drop-and-reload, BF16 Qwen3 fits on GPU
         // when quantized transformer is used on 24GB cards
-        assert!(QWEN3_FP16_VRAM_THRESHOLD < 17_000_000_000);
+        let threshold = std::hint::black_box(QWEN3_FP16_VRAM_THRESHOLD);
+        assert!(threshold < 17_000_000_000);
     }
 
     #[test]
     fn qwen3_threshold_exceeds_encoder_size() {
-        assert!(QWEN3_FP16_VRAM_THRESHOLD > 8_200_000_000);
+        let threshold = std::hint::black_box(QWEN3_FP16_VRAM_THRESHOLD);
+        assert!(threshold > 8_200_000_000);
     }
 
     #[test]
     fn vae_threshold_accounts_for_decode_workspace() {
-        assert!(VAE_DECODE_VRAM_THRESHOLD > 160_000_000);
-        assert!(VAE_DECODE_VRAM_THRESHOLD < 15_000_000_000);
+        let threshold = std::hint::black_box(VAE_DECODE_VRAM_THRESHOLD);
+        assert!(threshold > 160_000_000);
+        assert!(threshold < 15_000_000_000);
     }
 }

--- a/crates/mold-server/src/lib.rs
+++ b/crates/mold-server/src/lib.rs
@@ -62,24 +62,7 @@ pub async fn run_server(bind: &str, port: u16, models_dir: PathBuf) -> Result<()
         }
     };
 
-    let cors = match std::env::var("MOLD_CORS_ORIGIN") {
-        Ok(origin) if !origin.is_empty() => CorsLayer::new()
-            .allow_origin(
-                origin
-                    .parse::<axum::http::HeaderValue>()
-                    .expect("invalid MOLD_CORS_ORIGIN value"),
-            )
-            .allow_methods([
-                axum::http::Method::GET,
-                axum::http::Method::POST,
-                axum::http::Method::DELETE,
-            ])
-            .allow_headers(tower_http::cors::Any)
-            .expose_headers(["x-mold-seed-used"
-                .parse::<axum::http::HeaderName>()
-                .unwrap()]),
-        _ => CorsLayer::permissive(),
-    };
+    let cors = build_cors_layer()?;
 
     let app = routes::create_router(state)
         .layer(TraceLayer::new_for_http())
@@ -92,4 +75,53 @@ pub async fn run_server(bind: &str, port: u16, models_dir: PathBuf) -> Result<()
     axum::serve(listener, app).await?;
 
     Ok(())
+}
+
+fn build_cors_layer() -> Result<CorsLayer> {
+    let cors = match std::env::var("MOLD_CORS_ORIGIN") {
+        Ok(origin) if !origin.is_empty() => {
+            let origin = origin
+                .parse::<axum::http::HeaderValue>()
+                .map_err(|_| anyhow::anyhow!("invalid MOLD_CORS_ORIGIN value: {origin}"))?;
+            CorsLayer::new()
+                .allow_origin(origin)
+                .allow_methods([
+                    axum::http::Method::GET,
+                    axum::http::Method::POST,
+                    axum::http::Method::DELETE,
+                ])
+                .allow_headers(tower_http::cors::Any)
+                .expose_headers([axum::http::header::HeaderName::from_static(
+                    "x-mold-seed-used",
+                )])
+        }
+        _ => CorsLayer::permissive(),
+    };
+    Ok(cors)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_cors_layer;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn invalid_cors_origin_returns_error() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        std::env::set_var("MOLD_CORS_ORIGIN", "\nnot-a-header");
+        let result = build_cors_layer();
+        std::env::remove_var("MOLD_CORS_ORIGIN");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn valid_cors_origin_builds_layer() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        std::env::set_var("MOLD_CORS_ORIGIN", "https://example.com");
+        let result = build_cors_layer();
+        std::env::remove_var("MOLD_CORS_ORIGIN");
+        assert!(result.is_ok());
+    }
 }

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -1,6 +1,6 @@
 use axum::{
     extract::State,
-    http::{header, HeaderMap, StatusCode},
+    http::{header, HeaderMap, HeaderValue, StatusCode},
     response::{
         sse::{Event as SseEvent, KeepAlive, Sse},
         IntoResponse,
@@ -181,6 +181,37 @@ fn progress_to_sse(event: mold_inference::ProgressEvent) -> SseProgressEvent {
     event.into()
 }
 
+fn sse_message_to_event(msg: SseMessage) -> SseEvent {
+    fn serialize_event<T: Serialize>(event_name: &str, payload: &T) -> SseEvent {
+        match serde_json::to_string(payload) {
+            Ok(data) => SseEvent::default().event(event_name).data(data),
+            Err(err) => SseEvent::default().event("error").data(
+                serde_json::json!({
+                    "message": format!("failed to serialize SSE payload: {err}")
+                })
+                .to_string(),
+            ),
+        }
+    }
+
+    match msg {
+        SseMessage::Progress(payload) => serialize_event("progress", &payload),
+        SseMessage::Complete(payload) => serialize_event("complete", &payload),
+        SseMessage::Error(payload) => serialize_event("error", &payload),
+    }
+}
+
+fn take_generated_image(
+    response: &mut mold_core::GenerateResponse,
+) -> Result<mold_core::ImageData, ApiError> {
+    if response.images.is_empty() {
+        return Err(ApiError::inference(
+            "generation error: engine returned no images",
+        ));
+    }
+    Ok(response.images.remove(0))
+}
+
 /// Check model availability without loading. Returns:
 /// - `Ok(None)` — model is already loaded and ready
 /// - `Ok(Some(paths))` — model paths resolved, needs loading
@@ -231,8 +262,38 @@ async fn check_model_available(
 
 /// Ensure the requested model is loaded and ready for inference.
 async fn ensure_model_ready(state: &AppState, model_name: &str) -> Result<(), ApiError> {
+    ensure_model_ready_with_progress(state, model_name, None).await
+}
+
+async fn ensure_model_ready_with_progress(
+    state: &AppState,
+    model_name: &str,
+    progress_tx: Option<&tokio::sync::mpsc::UnboundedSender<SseMessage>>,
+) -> Result<(), ApiError> {
+    let _guard = state.model_load_lock.lock().await;
+    {
+        let mut engine = state.engine.lock().await;
+        if let Some(engine) = engine.as_mut() {
+            if engine.model_name() == model_name {
+                if let Some(tx) = progress_tx {
+                    let tx = tx.clone();
+                    engine.set_on_progress(Box::new(move |event| {
+                        let _ = tx.send(SseMessage::Progress(progress_to_sse(event)));
+                    }));
+                }
+                if !engine.is_loaded() {
+                    tracing::info!(model = %model_name, "loading existing engine...");
+                    engine.load().map_err(|e| {
+                        tracing::error!("model load failed: {e:#}");
+                        ApiError::internal(format!("model load error: {e}"))
+                    })?;
+                }
+                return Ok(());
+            }
+        }
+    }
     match check_model_available(state, model_name).await? {
-        Some(paths) => create_and_load_engine(state, model_name, paths, None).await,
+        Some(paths) => create_and_load_engine(state, model_name, paths, progress_tx).await,
         None => Ok(()),
     }
 }
@@ -338,7 +399,10 @@ async fn generate(
     let result = tokio::task::spawn_blocking(move || {
         std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let mut guard = engine.blocking_lock();
-            guard.as_mut().unwrap().generate(&req)
+            let engine = guard.as_mut().ok_or_else(|| {
+                anyhow::anyhow!("no engine available after model readiness check")
+            })?;
+            engine.generate(&req)
         }))
     })
     .await
@@ -367,16 +431,17 @@ async fn generate(
         }
     };
 
-    let img = response.images.remove(0);
+    let img = take_generated_image(&mut response)?;
     let content_type = match img.format {
-        OutputFormat::Png => "image/png",
-        OutputFormat::Jpeg => "image/jpeg",
+        OutputFormat::Png => HeaderValue::from_static("image/png"),
+        OutputFormat::Jpeg => HeaderValue::from_static("image/jpeg"),
     };
     let mut headers = HeaderMap::new();
-    headers.insert(header::CONTENT_TYPE, content_type.parse().unwrap());
+    headers.insert(header::CONTENT_TYPE, content_type);
     headers.insert(
         "x-mold-seed-used",
-        response.seed_used.to_string().parse().unwrap(),
+        HeaderValue::from_str(&response.seed_used.to_string())
+            .map_err(|e| ApiError::internal(format!("failed to serialize seed header: {e}")))?,
     );
     Ok((headers, img.data))
 }
@@ -415,7 +480,7 @@ async fn generate_stream(
     }
 
     // Check model availability (404/400 returned as HTTP errors before SSE starts)
-    let model_paths = check_model_available(&state, &req.model).await?;
+    let _ = check_model_available(&state, &req.model).await?;
 
     // Create SSE channel
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<SseMessage>();
@@ -424,15 +489,13 @@ async fn generate_stream(
     let bg_tx = tx;
     tokio::spawn(async move {
         // Load model if needed (with progress events)
-        if let Some(paths) = model_paths {
-            if let Err(api_err) =
-                create_and_load_engine(&state, &req.model, paths, Some(&bg_tx)).await
-            {
-                let _ = bg_tx.send(SseMessage::Error(SseErrorEvent {
-                    message: api_err.error,
-                }));
-                return;
-            }
+        if let Err(api_err) =
+            ensure_model_ready_with_progress(&state, &req.model, Some(&bg_tx)).await
+        {
+            let _ = bg_tx.send(SseMessage::Error(SseErrorEvent {
+                message: api_err.error,
+            }));
+            return;
         }
 
         // Run inference in blocking thread with progress callback
@@ -442,7 +505,9 @@ async fn generate_stream(
         let result = tokio::task::spawn_blocking(move || {
             std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 let mut guard = engine.blocking_lock();
-                let e = guard.as_mut().unwrap();
+                let e = guard.as_mut().ok_or_else(|| {
+                    anyhow::anyhow!("no engine available after model readiness check")
+                })?;
                 // Install progress callback for the generate phase
                 let progress_tx = gen_tx.clone();
                 e.set_on_progress(Box::new(move |event| {
@@ -455,7 +520,13 @@ async fn generate_stream(
 
         match result {
             Ok(Ok(Ok(mut response))) => {
-                let img = response.images.remove(0);
+                let img = match take_generated_image(&mut response) {
+                    Ok(img) => img,
+                    Err(err) => {
+                        let _ = bg_tx.send(SseMessage::Error(SseErrorEvent { message: err.error }));
+                        return;
+                    }
+                };
                 let _ = bg_tx.send(SseMessage::Complete(SseCompleteEvent {
                     image: base64::engine::general_purpose::STANDARD.encode(&img.data),
                     format: img.format,
@@ -492,20 +563,8 @@ async fn generate_stream(
     });
 
     // Build SSE stream from the channel receiver
-    let stream = tokio_stream::wrappers::UnboundedReceiverStream::new(rx).map(|msg| {
-        let event = match msg {
-            SseMessage::Progress(p) => SseEvent::default()
-                .event("progress")
-                .data(serde_json::to_string(&p).unwrap()),
-            SseMessage::Complete(c) => SseEvent::default()
-                .event("complete")
-                .data(serde_json::to_string(&c).unwrap()),
-            SseMessage::Error(e) => SseEvent::default()
-                .event("error")
-                .data(serde_json::to_string(&e).unwrap()),
-        };
-        Ok::<_, Infallible>(event)
-    });
+    let stream = tokio_stream::wrappers::UnboundedReceiverStream::new(rx)
+        .map(|msg| Ok::<_, Infallible>(sse_message_to_event(msg)));
 
     Ok(Sse::new(stream).keep_alive(
         KeepAlive::new()
@@ -762,20 +821,8 @@ async fn pull_model_endpoint(
         }
     });
 
-    let stream = tokio_stream::wrappers::UnboundedReceiverStream::new(rx).map(|msg| {
-        let event = match msg {
-            SseMessage::Progress(p) => SseEvent::default()
-                .event("progress")
-                .data(serde_json::to_string(&p).unwrap()),
-            SseMessage::Complete(c) => SseEvent::default()
-                .event("complete")
-                .data(serde_json::to_string(&c).unwrap()),
-            SseMessage::Error(e) => SseEvent::default()
-                .event("error")
-                .data(serde_json::to_string(&e).unwrap()),
-        };
-        Ok::<_, Infallible>(event)
-    });
+    let stream = tokio_stream::wrappers::UnboundedReceiverStream::new(rx)
+        .map(|msg| Ok::<_, Infallible>(sse_message_to_event(msg)));
 
     Ok(PullResponse::Sse(
         Sse::new(stream)

--- a/crates/mold-server/src/routes_test.rs
+++ b/crates/mold-server/src/routes_test.rs
@@ -6,6 +6,11 @@ mod tests {
     };
     use mold_core::{GenerateRequest, GenerateResponse, ImageData};
     use mold_inference::InferenceEngine;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+    use std::time::Duration;
     use tower::ServiceExt;
 
     use crate::{routes::create_router, state::AppState};
@@ -22,6 +27,9 @@ mod tests {
     struct MockEngine {
         loaded: bool,
         fail: bool,
+        empty_images: bool,
+        load_count: Arc<AtomicUsize>,
+        load_delay: Duration,
     }
 
     impl MockEngine {
@@ -29,12 +37,36 @@ mod tests {
             Self {
                 loaded: true,
                 fail: false,
+                empty_images: false,
+                load_count: Arc::new(AtomicUsize::new(0)),
+                load_delay: Duration::from_millis(0),
             }
         }
         fn failing() -> Self {
             Self {
                 loaded: true,
                 fail: true,
+                empty_images: false,
+                load_count: Arc::new(AtomicUsize::new(0)),
+                load_delay: Duration::from_millis(0),
+            }
+        }
+        fn empty_images() -> Self {
+            Self {
+                loaded: true,
+                fail: false,
+                empty_images: true,
+                load_count: Arc::new(AtomicUsize::new(0)),
+                load_delay: Duration::from_millis(0),
+            }
+        }
+        fn unloaded(load_count: Arc<AtomicUsize>, load_delay: Duration) -> Self {
+            Self {
+                loaded: false,
+                fail: false,
+                empty_images: false,
+                load_count,
+                load_delay,
             }
         }
     }
@@ -44,15 +76,19 @@ mod tests {
             if self.fail {
                 anyhow::bail!("mock engine error");
             }
-            // Return a minimal 1x1 transparent PNG
-            Ok(GenerateResponse {
-                images: vec![ImageData {
+            let images = if self.empty_images {
+                vec![]
+            } else {
+                vec![ImageData {
                     data: minimal_png(),
                     format: req.output_format,
                     width: req.width,
                     height: req.height,
                     index: 0,
-                }],
+                }]
+            };
+            Ok(GenerateResponse {
+                images,
                 generation_time_ms: 1,
                 model: req.model.clone(),
                 seed_used: req.seed.unwrap_or(42),
@@ -68,19 +104,25 @@ mod tests {
         }
 
         fn load(&mut self) -> anyhow::Result<()> {
+            self.load_count.fetch_add(1, Ordering::SeqCst);
+            if !self.load_delay.is_zero() {
+                std::thread::sleep(self.load_delay);
+            }
             self.loaded = true;
             Ok(())
         }
     }
 
     fn app_with(engine: MockEngine) -> axum::Router {
-        let state = AppState::with_engine(engine);
+        app_with_state(AppState::with_engine(engine))
+    }
+
+    fn app_with_state(state: AppState) -> axum::Router {
         create_router(state)
     }
 
     fn app_empty() -> axum::Router {
-        let state = AppState::empty(mold_core::Config::default());
-        create_router(state)
+        app_with_state(AppState::empty(mold_core::Config::default()))
     }
 
     fn generate_body(prompt: &str, width: u32, height: u32) -> String {
@@ -356,6 +398,28 @@ mod tests {
             .contains("mock engine error"));
     }
 
+    #[tokio::test]
+    async fn generate_empty_images_returns_500() {
+        let app = app_with(MockEngine::empty_images());
+        let body = generate_body("a cat", 768, 768);
+        let resp = app
+            .oneshot(
+                Request::post("/api/generate")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let body = json_body(resp).await;
+        assert_eq!(body["code"], "INFERENCE_ERROR");
+        assert!(body["error"]
+            .as_str()
+            .unwrap()
+            .contains("returned no images"));
+    }
+
     // ── /api/generate — unknown model ────────────────────────────────────────
 
     #[tokio::test]
@@ -576,5 +640,74 @@ mod tests {
             text.contains("mock engine error"),
             "error event should contain the engine error message"
         );
+    }
+
+    #[tokio::test]
+    async fn stream_empty_images_returns_sse_error() {
+        let app = app_with(MockEngine::empty_images());
+        let body = generate_body("a cat", 768, 768);
+        let resp = app
+            .oneshot(
+                Request::post("/api/generate/stream")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(resp.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let text = String::from_utf8_lossy(&body);
+        assert!(text.contains("event: error"));
+        assert!(text.contains("returned no images"));
+    }
+
+    #[tokio::test]
+    async fn unload_loaded_model_returns_200() {
+        let app = app_with(MockEngine::ready());
+        let resp = app
+            .oneshot(
+                Request::delete("/api/models/unload")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        assert!(String::from_utf8_lossy(&body).contains("unloaded mock-model"));
+    }
+
+    #[tokio::test]
+    async fn concurrent_requests_only_load_existing_engine_once() {
+        let load_count = Arc::new(AtomicUsize::new(0));
+        let state = AppState {
+            engine: Arc::new(tokio::sync::Mutex::new(Some(Box::new(
+                MockEngine::unloaded(load_count.clone(), Duration::from_millis(50)),
+            )))),
+            config: Arc::new(tokio::sync::RwLock::new(mold_core::Config::default())),
+            start_time: std::time::Instant::now(),
+            model_load_lock: Arc::new(tokio::sync::Mutex::new(())),
+            pull_lock: Arc::new(tokio::sync::Mutex::new(())),
+        };
+        let app = app_with_state(state);
+        let req1 = Request::post("/api/generate")
+            .header("content-type", "application/json")
+            .body(Body::from(generate_body("a cat", 768, 768)))
+            .unwrap();
+        let req2 = Request::post("/api/generate")
+            .header("content-type", "application/json")
+            .body(Body::from(generate_body("a cat", 768, 768)))
+            .unwrap();
+
+        let (resp1, resp2) = tokio::join!(app.clone().oneshot(req1), app.oneshot(req2));
+        assert_eq!(resp1.unwrap().status(), StatusCode::OK);
+        assert_eq!(resp2.unwrap().status(), StatusCode::OK);
+        assert_eq!(load_count.load(Ordering::SeqCst), 1);
     }
 }

--- a/crates/mold-server/src/state.rs
+++ b/crates/mold-server/src/state.rs
@@ -9,6 +9,8 @@ pub struct AppState {
     pub engine: Arc<Mutex<Option<Box<dyn InferenceEngine>>>>,
     pub config: Arc<tokio::sync::RwLock<Config>>,
     pub start_time: Instant,
+    /// Guards concurrent model loads and hot-swaps.
+    pub model_load_lock: Arc<Mutex<()>>,
     /// Guards concurrent pulls — only one download at a time.
     pub pull_lock: Arc<Mutex<()>>,
 }
@@ -20,6 +22,7 @@ impl AppState {
             engine: Arc::new(Mutex::new(Some(engine))),
             config: Arc::new(tokio::sync::RwLock::new(config)),
             start_time: Instant::now(),
+            model_load_lock: Arc::new(Mutex::new(())),
             pull_lock: Arc::new(Mutex::new(())),
         }
     }
@@ -30,6 +33,7 @@ impl AppState {
             engine: Arc::new(Mutex::new(None)),
             config: Arc::new(tokio::sync::RwLock::new(config)),
             start_time: Instant::now(),
+            model_load_lock: Arc::new(Mutex::new(())),
             pull_lock: Arc::new(Mutex::new(())),
         }
     }
@@ -40,6 +44,7 @@ impl AppState {
             engine: Arc::new(Mutex::new(Some(Box::new(engine)))),
             config: Arc::new(tokio::sync::RwLock::new(Config::default())),
             start_time: Instant::now(),
+            model_load_lock: Arc::new(Mutex::new(())),
             pull_lock: Arc::new(Mutex::new(())),
         }
     }


### PR DESCRIPTION
## Summary

- **Fix env var precedence bug**: `resolve_path` now checks env vars before config values, matching documented behavior ("Env vars take precedence over config file values")
- **Fix concurrent model load race condition**: Added `model_load_lock` to serialize model loads, preventing duplicate loads when concurrent requests hit an unloaded engine. `ensure_model_ready_with_progress` rechecks state under the lock.
- **Eliminate runtime panics**: Replaced `.unwrap()` calls on external/dynamic values with proper error propagation — empty image vec, SSE serialization, CORS origin parsing, header construction, engine guard access
- **Remove dead code**: Removed 6 `#[allow(dead_code)]` items across `flux2/vae.rs`, `qwen_image/sampling.rs`, `qwen_image/transformer.rs`
- **Deduplicate SSE event mapping**: Extracted `sse_message_to_event()` and `take_generated_image()` helpers used by both `generate_stream` and `pull_model_endpoint`
- **Clippy/idiom fixes**: `1 * GB` -> `GB`, iterator-based loop, needless borrow removal, struct init syntax, `HeaderValue::from_static()` for compile-time validated headers

## Test plan

- [x] `cargo test --workspace` — 236 tests pass
- [x] `cargo clippy --workspace` — clean
- [x] `cargo fmt --check` — clean
- [x] New tests: `generate_empty_images_returns_500`, `stream_empty_images_returns_sse_error`, `unload_loaded_model_returns_200`, `concurrent_requests_only_load_existing_engine_once`, `invalid_cors_origin_returns_error`, `valid_cors_origin_builds_layer`, `model_paths_optional_env_takes_precedence_over_config`