### PR TITLE
Rename broken model descriptions to alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,18 +199,18 @@ MOLD_HOST=http://gpu-server:7680 mold run "a cat"
 | `z-image-turbo:q4` | 9 | 3.8GB | Lighter, still good |
 | `z-image-turbo:bf16` | 9 | 12.2GB | Full precision |
 
-### Wuerstchen v2 / Flux.2 / Qwen-Image (broken on MPS)
+### Wuerstchen v2 / Flux.2 / Qwen-Image (alpha, improving on CUDA/MPS)
 
-> **Warning**: These model families produce poor quality output on Apple Silicon (MPS/Metal). They are work-in-progress and may work better on CUDA. Use FLUX, SDXL, SD1.5, SD3.5, or Z-Image for production use.
+> **Warning**: These model families are still in active alpha development. Results vary by backend and may be better on CUDA than Apple Silicon (MPS/Metal). Use FLUX, SDXL, SD1.5, SD3.5, or Z-Image for production use.
 
 | Model | Steps | Size | Notes |
 |-------|-------|------|-------|
-| `wuerstchen-v2:fp16` | 30 | 5.6GB | 3-stage cascade, rendering artifacts on MPS |
-| `flux2-klein:q8` | 4 | 4.3GB | Flux.2 Klein 4B Q8, poor quality on MPS |
-| `flux2-klein:q4` | 4 | 2.6GB | Flux.2 Klein 4B Q4, poor quality on MPS |
-| `flux2-klein:bf16` | 4 | 7.8GB | Flux.2 Klein 4B BF16, poor quality on MPS |
-| `qwen-image:q8` | 28 | 21.8GB | Qwen-Image-2512, poor quality on MPS |
-| `qwen-image:q4` | 28 | 12.3GB | Qwen-Image, smallest footprint |
+| `wuerstchen-v2:fp16` | 30 | 5.6GB | Alpha 3-stage cascade, backend-dependent output quality |
+| `flux2-klein:q8` | 4 | 4.3GB | Alpha Flux.2 Klein 4B Q8, actively being improved |
+| `flux2-klein:q4` | 4 | 2.6GB | Alpha Flux.2 Klein 4B Q4, smaller footprint |
+| `flux2-klein:bf16` | 4 | 7.8GB | Alpha Flux.2 Klein 4B BF16, backend-dependent output quality |
+| `qwen-image:q8` | 28 | 21.8GB | Alpha Qwen-Image-2512, actively being improved |
+| `qwen-image:q4` | 28 | 12.3GB | Alpha Qwen-Image, smallest footprint |
 
 > Bare names resolve by trying `:q8` → `:fp16` → `:bf16` → `:fp8` in order. So `mold run flux-schnell "a cat"` just works.
 

--- a/crates/mold-cli/src/commands/list.rs
+++ b/crates/mold-cli/src/commands/list.rs
@@ -247,7 +247,7 @@ pub async fn run() -> Result<()> {
                         mcfg.effective_width(&config),
                         mcfg.effective_height(&config),
                         colorize_description(
-                            // Prefer manifest description (has [broken]/[beta] tags)
+                            // Prefer manifest description (has [alpha]/[beta] tags)
                             // over config description (may be stale from older pull)
                             mold_core::manifest::find_manifest(name)
                                 .map(|m| m.description.as_str())

--- a/crates/mold-cli/src/output.rs
+++ b/crates/mold-cli/src/output.rs
@@ -24,12 +24,12 @@ macro_rules! status {
 
 pub(crate) use status;
 
-/// Colorize a model description: render `[broken]` or `[beta]` prefix in
-/// bright red bold, rest dimmed. Normal descriptions are fully dimmed.
+/// Colorize a model description: render `[alpha]` or `[beta]` prefix in
+/// bright yellow bold, rest dimmed. Normal descriptions are fully dimmed.
 pub fn colorize_description(desc: &str) -> String {
     use colored::Colorize;
-    if let Some(rest) = desc.strip_prefix("[broken] ") {
-        format!("{} {}", "[broken]".bright_red().bold(), rest.dimmed())
+    if let Some(rest) = desc.strip_prefix("[alpha] ") {
+        format!("{} {}", "[alpha]".bright_yellow().bold(), rest.dimmed())
     } else if let Some(rest) = desc.strip_prefix("[beta] ") {
         format!("{} {}", "[beta]".bright_yellow().bold(), rest.dimmed())
     } else {
@@ -55,30 +55,29 @@ mod tests {
     }
 
     #[test]
+    fn test_colorize_description_alpha() {
+        let result = colorize_description("[alpha] Experimental model");
+        // Should contain the [alpha] text and the rest of the description.
+        assert!(result.contains("[alpha]"));
+        assert!(result.contains("Experimental model"));
+    }
+
+    #[test]
     fn test_colorize_description_beta() {
         let result = colorize_description("[beta] Experimental model");
-        // Should contain the [beta] text and the rest of the description
-        // The output includes ANSI escape codes for bright_red bold and dimmed
         assert!(result.contains("[beta]"));
         assert!(result.contains("Experimental model"));
     }
 
     #[test]
-    fn test_colorize_description_no_beta() {
+    fn test_colorize_description_no_tag() {
         let result = colorize_description("A stable model description");
-        // Should contain the description text, fully dimmed
         assert!(result.contains("A stable model description"));
-        // Should NOT contain any [beta] styling (no bright_red bold sequences separate from dimmed)
-        // The entire string is wrapped in dimmed formatting only
     }
 
     #[test]
     fn test_colorize_description_empty() {
-        // Empty string should not panic
         let result = colorize_description("");
-        // Empty string has no "[beta] " prefix, so it takes the dimmed path
-        // Result contains ANSI codes wrapping an empty string; should not be empty
-        // because dimmed() adds escape sequences
         let _ = result;
     }
 }

--- a/crates/mold-core/src/manifest.rs
+++ b/crates/mold-core/src/manifest.rs
@@ -1668,7 +1668,7 @@ fn flux2_manifests() -> Vec<ModelManifest> {
             name: "flux2-klein:bf16".to_string(),
             family: "flux2".to_string(),
             description:
-                "[broken] Flux.2 Klein-4B BF16 — Apache 2.0, 4B param distilled flow-matching"
+                "[alpha] Flux.2 Klein-4B BF16 — Apache 2.0, 4B param distilled flow-matching"
                     .to_string(),
             files: {
                 let mut files = shared_flux2_files();
@@ -1695,7 +1695,7 @@ fn flux2_manifests() -> Vec<ModelManifest> {
         ModelManifest {
             name: "flux2-klein:q8".to_string(),
             family: "flux2".to_string(),
-            description: "[broken] Flux.2 Klein-4B Q8 — best GGUF quality".to_string(),
+            description: "[alpha] Flux.2 Klein-4B Q8 — best GGUF quality".to_string(),
             files: {
                 let mut files = shared_flux2_files();
                 files.push(ModelFile {
@@ -1720,7 +1720,7 @@ fn flux2_manifests() -> Vec<ModelManifest> {
         ModelManifest {
             name: "flux2-klein:q6".to_string(),
             family: "flux2".to_string(),
-            description: "[broken] Flux.2 Klein-4B Q6 — good quality/size trade-off".to_string(),
+            description: "[alpha] Flux.2 Klein-4B Q6 — good quality/size trade-off".to_string(),
             files: {
                 let mut files = shared_flux2_files();
                 files.push(ModelFile {
@@ -1745,7 +1745,7 @@ fn flux2_manifests() -> Vec<ModelManifest> {
         ModelManifest {
             name: "flux2-klein:q4".to_string(),
             family: "flux2".to_string(),
-            description: "[broken] Flux.2 Klein-4B Q4 — smaller footprint".to_string(),
+            description: "[alpha] Flux.2 Klein-4B Q4 — smaller footprint".to_string(),
             files: {
                 let mut files = shared_flux2_files();
                 files.push(ModelFile {
@@ -1844,7 +1844,7 @@ fn qwen_image_manifests() -> Vec<ModelManifest> {
         ModelManifest {
             name: "qwen-image:bf16".to_string(),
             family: "qwen-image".to_string(),
-            description: "[broken] Qwen-Image-2512 BF16 — 60-block flow-matching transformer"
+            description: "[alpha] Qwen-Image-2512 BF16 — 60-block flow-matching transformer"
                 .to_string(),
             files: {
                 let mut files = shared_qwen_image_files();
@@ -1874,7 +1874,7 @@ fn qwen_image_manifests() -> Vec<ModelManifest> {
         ModelManifest {
             name: "qwen-image:q8".to_string(),
             family: "qwen-image".to_string(),
-            description: "[broken] Qwen-Image-2512 Q8 — quantized transformer, best quality"
+            description: "[alpha] Qwen-Image-2512 Q8 — quantized transformer, best quality"
                 .to_string(),
             files: {
                 let mut files = shared_qwen_image_files();
@@ -1893,7 +1893,7 @@ fn qwen_image_manifests() -> Vec<ModelManifest> {
         ModelManifest {
             name: "qwen-image:q6".to_string(),
             family: "qwen-image".to_string(),
-            description: "[broken] Qwen-Image-2512 Q6 — quantized, best quality/size trade-off"
+            description: "[alpha] Qwen-Image-2512 Q6 — quantized, best quality/size trade-off"
                 .to_string(),
             files: {
                 let mut files = shared_qwen_image_files();
@@ -1912,7 +1912,7 @@ fn qwen_image_manifests() -> Vec<ModelManifest> {
         ModelManifest {
             name: "qwen-image:q4".to_string(),
             family: "qwen-image".to_string(),
-            description: "[broken] Qwen-Image-2512 Q4 — quantized, smallest practical footprint"
+            description: "[alpha] Qwen-Image-2512 Q4 — quantized, smallest practical footprint"
                 .to_string(),
             files: {
                 let mut files = shared_qwen_image_files();
@@ -1943,7 +1943,7 @@ fn wuerstchen_manifests() -> Vec<ModelManifest> {
     vec![ModelManifest {
         name: "wuerstchen-v2:fp16".to_string(),
         family: "wuerstchen".to_string(),
-        description: "[broken] Wuerstchen v2 FP16 — 3-stage cascade with 42x latent compression"
+        description: "[alpha] Wuerstchen v2 FP16 — 3-stage cascade with 42x latent compression"
             .to_string(),
         files: vec![
             ModelFile {


### PR DESCRIPTION
## Summary
- rename Flux.2, Qwen-Image, and Wuerstchen manifest description prefixes from `[broken]` to `[alpha]`
- update CLI description rendering/comments/tests to recognize `[alpha]`
- revise the README section to describe these model families as active alpha work with backend-dependent results

## Verification
- `cargo fmt --all`
- `env CXX=clang++ cargo check --workspace`
- `env CXX=clang++ cargo clippy --workspace -- -D warnings` *(fails on pre-existing `clippy::uninlined_format_args` warnings in `crates/mold-inference`, unrelated to this diff)*
- `env SDKROOT=$(xcrun --show-sdk-path) CXX=clang++ cargo test --workspace` *(fails linking `mold-ai-core` tests with `ld: library not found for -liconv` in the local macOS environment)*