### PR TITLE
feat(download): fail on SHA-256 mismatch and add atomic pull markers

### DIFF
--- a/.claude/skills/mold/SKILL.md
+++ b/.claude/skills/mold/SKILL.md
@@ -164,6 +164,7 @@ Force stdout in interactive mode: `mold run "a cat" --output -`
 ```bash
 mold list                    # List downloaded + available models
 mold pull flux-dev:q4        # Download a model
+mold pull flux-dev:q4 --skip-verify  # Download, skip SHA-256 check
 mold info                    # Installation overview (paths, models, server status)
 mold info flux-dev:q4        # Show model details and file sizes
 mold rm flux-dev:q4          # Remove a downloaded model

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ Shared library used by all other crates:
 - **`client.rs`** — `MoldClient` HTTP client; `is_connection_error()` for local fallback detection
 - **`config.rs`** — `Config`, `ModelConfig`, `ModelPaths`; loads from `~/.config/mold/config.toml` (XDG) or `~/.mold/config.toml` (legacy)
 - **`manifest.rs`** — `ModelManifest` registry of downloadable models with HF sources; `resolve_model_name()` for `name:tag` resolution
-- **`download.rs`** — `pull_model()` wrapping `hf-hub` with progress bars
+- **`download.rs`** — `pull_model()` wrapping `hf-hub` with progress bars; SHA-256 integrity verification (fails on mismatch, `--skip-verify` to override); `.pulling` marker for atomic pull detection; `PullOptions` for controlling verification behavior
 - **`validation.rs`** — `validate_generate_request()` — shared validation (used by both server and CLI)
 - **`error.rs`** — `MoldError` enum with thiserror
 
@@ -189,7 +189,7 @@ mold run [MODEL] [PROMPT...] [OPTIONS]
         --preview               Display generated image(s) inline in the terminal (requires `preview` feature)
 
 mold serve [--port N] [--bind ADDR] [--models-dir PATH]
-mold pull <MODEL>               Download model from HuggingFace
+mold pull <MODEL> [--skip-verify]  Download model from HuggingFace
 mold rm <MODELS...> [--force]  Remove downloaded models
 mold list                       List configured and available models (with disk usage)
 mold info [MODEL] [--verify]    Show installation overview, or model details with optional SHA-256 verify

--- a/crates/mold-cli/src/commands/generate.rs
+++ b/crates/mold-cli/src/commands/generate.rs
@@ -549,7 +549,11 @@ async fn prepare_local_engine(
                     theme::icon_info(),
                     model_name.bold(),
                 );
-                let updated_config = super::pull::pull_and_configure(&model_name).await?;
+                let updated_config = super::pull::pull_and_configure(
+                    &model_name,
+                    &mold_core::download::PullOptions::default(),
+                )
+                .await?;
                 paths = ModelPaths::resolve(&model_name, &updated_config).ok_or_else(|| {
                     anyhow::anyhow!(
                         "model '{}' was pulled but paths could not be resolved",

--- a/crates/mold-cli/src/commands/list.rs
+++ b/crates/mold-cli/src/commands/list.rs
@@ -10,11 +10,15 @@ fn description_with_gated(desc: &str, model_name: &str) -> String {
     let is_gated = mold_core::manifest::find_manifest(model_name)
         .map(|m| m.is_gated())
         .unwrap_or(false);
-    if is_gated && !desc.contains("[gated]") {
-        format!("{desc} [gated]")
-    } else {
-        desc.to_string()
+    let has_marker = mold_core::download::has_pulling_marker(model_name);
+    let mut result = desc.to_string();
+    if has_marker && !result.contains("[incomplete]") {
+        result = format!("{result} [incomplete]");
     }
+    if is_gated && !result.contains("[gated]") {
+        result = format!("{result} [gated]");
+    }
+    result
 }
 
 fn format_fetch_size(remaining_bytes: u64) -> String {

--- a/crates/mold-cli/src/commands/pull.rs
+++ b/crates/mold-cli/src/commands/pull.rs
@@ -12,7 +12,10 @@ use crate::ui::print_server_fallback;
 use crate::AlreadyReported;
 
 /// Download a model and write its config. Returns the updated Config.
-pub async fn pull_and_configure(model: &str) -> Result<Config> {
+pub async fn pull_and_configure(
+    model: &str,
+    opts: &mold_core::download::PullOptions,
+) -> Result<Config> {
     let canonical = resolve_model_name(model);
 
     // Pre-flight: print status and validate manifest exists (for CLI-specific error formatting)
@@ -51,7 +54,7 @@ pub async fn pull_and_configure(model: &str) -> Result<Config> {
     status!("");
 
     // Delegate to core pull_and_configure
-    let (config, _paths) = mold_core::download::pull_and_configure(model)
+    let (config, _paths) = mold_core::download::pull_and_configure(model, opts)
         .await
         .map_err(|e| -> anyhow::Error {
             match e {
@@ -96,6 +99,27 @@ pub async fn pull_and_configure(model: &str) -> Result<Config> {
                     eprintln!("  4. Set: export HF_TOKEN=hf_...");
                     eprintln!("  5. Retry: mold pull {}", canonical);
                 }
+                DownloadError::Sha256Mismatch {
+                    filename,
+                    expected,
+                    actual,
+                    ..
+                } => {
+                    eprintln!();
+                    eprintln!(
+                        "{} SHA-256 mismatch for {}",
+                        theme::icon_fail(),
+                        filename.bold()
+                    );
+                    eprintln!("  Expected: {expected}");
+                    eprintln!("  Got:      {actual}");
+                    eprintln!();
+                    eprintln!("The corrupted file has been removed.");
+                    eprintln!("  Re-run: mold pull {}", canonical);
+                    eprintln!();
+                    eprintln!("If the file was intentionally updated on HuggingFace, use:");
+                    eprintln!("  mold pull {} --skip-verify", canonical);
+                }
                 other => {
                     eprintln!();
                     eprintln!("{} Download failed: {other}", theme::icon_fail());
@@ -131,7 +155,7 @@ fn print_unknown_model_error(model: &str) {
     eprintln!("Usage: mold pull <model>");
 }
 
-pub async fn run(model: &str) -> Result<()> {
+pub async fn run(model: &str, opts: &mold_core::download::PullOptions) -> Result<()> {
     let canonical = resolve_model_name(model);
     let manifest = match find_manifest(&canonical) {
         Some(m) => m,
@@ -147,7 +171,7 @@ pub async fn run(model: &str) -> Result<()> {
         Err(e) => match classify_server_error(&e) {
             ServerAvailability::FallbackLocal => {
                 print_server_fallback(ctx.client().host(), "pulling locally");
-                pull_and_configure(model).await?;
+                pull_and_configure(model, opts).await?;
             }
             ServerAvailability::SurfaceError => return Err(e),
         },

--- a/crates/mold-cli/src/commands/rm.rs
+++ b/crates/mold-cli/src/commands/rm.rs
@@ -143,8 +143,9 @@ pub async fn run(models: &[String], force: bool) -> Result<()> {
             }
         }
 
-        // Remove from config
+        // Remove from config and clean up pull marker
         config.remove_model(&canonical);
+        mold_core::download::remove_pulling_marker(&canonical);
 
         // Handle default_model update
         if config.default_model == canonical {

--- a/crates/mold-cli/src/main.rs
+++ b/crates/mold-cli/src/main.rs
@@ -205,6 +205,10 @@ Run 'mold list' to see all available models.")]
         /// Model name to download
         #[arg(add = ArgValueCandidates::new(commands::run::complete_model_name))]
         model: String,
+
+        /// Skip SHA-256 verification after download
+        #[arg(long)]
+        skip_verify: bool,
     },
 
     /// Remove downloaded model(s) and their unique files
@@ -461,8 +465,9 @@ async fn run() -> anyhow::Result<()> {
         } => {
             commands::serve::run(port, &bind, models_dir).await?;
         }
-        Commands::Pull { model } => {
-            commands::pull::run(&model).await?;
+        Commands::Pull { model, skip_verify } => {
+            let opts = mold_core::download::PullOptions { skip_verify };
+            commands::pull::run(&model, &opts).await?;
         }
         Commands::Rm { models, force } => {
             commands::rm::run(&models, force).await?;

--- a/crates/mold-core/src/config.rs
+++ b/crates/mold-core/src/config.rs
@@ -509,6 +509,9 @@ impl Config {
     }
 
     pub fn discovered_manifest_paths(&self, name: &str) -> Option<ModelPaths> {
+        if crate::download::has_pulling_marker(name) {
+            return None;
+        }
         let manifest = crate::manifest::find_manifest(name)?;
         let models_dir = self.resolved_models_dir();
         let downloads = manifest
@@ -523,6 +526,9 @@ impl Config {
     }
 
     pub fn manifest_model_is_downloaded(&self, name: &str) -> bool {
+        if crate::download::has_pulling_marker(name) {
+            return false;
+        }
         self.resolved_local_manifest_model_config(name).is_some()
     }
 

--- a/crates/mold-core/src/download.rs
+++ b/crates/mold-core/src/download.rs
@@ -39,6 +39,13 @@ pub enum DownloadProgressEvent {
 /// Callback type for download progress reporting.
 pub type DownloadProgressCallback = Arc<dyn Fn(DownloadProgressEvent) + Send + Sync>;
 
+/// Options controlling model pull behavior.
+#[derive(Debug, Clone, Default)]
+pub struct PullOptions {
+    /// Skip SHA-256 verification after download (use when HF updated a file).
+    pub skip_verify: bool,
+}
+
 #[derive(Debug, Error)]
 pub enum DownloadError {
     #[error(
@@ -56,6 +63,14 @@ pub enum DownloadError {
         repo: String,
         filename: String,
         source: ApiError,
+    },
+
+    #[error("SHA-256 mismatch for {filename}\n  Expected: {expected}\n  Got:      {actual}\n\nThe corrupted file has been removed. Re-run: mold pull {model}\nIf the file was intentionally updated on HuggingFace, use: mold pull {model} --skip-verify")]
+    Sha256Mismatch {
+        filename: String,
+        expected: String,
+        actual: String,
+        model: String,
     },
 
     #[error("Failed to build HuggingFace API client: {0}")]
@@ -190,18 +205,97 @@ fn hardlink_or_copy(src: &std::path::Path, dst: &std::path::Path) -> Result<(), 
     Ok(())
 }
 
-/// Verify the SHA-256 digest of a file against an expected hex string.
-///
-/// Returns `Ok(true)` when the digest matches, `Ok(false)` on mismatch.
-/// Errors only on I/O failures (e.g. file not found).
-pub fn verify_sha256(path: &std::path::Path, expected: &str) -> anyhow::Result<bool> {
+/// Compute the SHA-256 hex digest of a file.
+pub fn compute_sha256(path: &std::path::Path) -> anyhow::Result<String> {
     use sha2::{Digest, Sha256};
 
     let mut file = std::fs::File::open(path)?;
     let mut hasher = Sha256::new();
     std::io::copy(&mut file, &mut hasher)?;
-    let digest = format!("{:x}", hasher.finalize());
-    Ok(digest == expected)
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+/// Verify the SHA-256 digest of a file against an expected hex string.
+///
+/// Returns `Ok(true)` when the digest matches, `Ok(false)` on mismatch.
+/// Errors only on I/O failures (e.g. file not found).
+pub fn verify_sha256(path: &std::path::Path, expected: &str) -> anyhow::Result<bool> {
+    Ok(compute_sha256(path)? == expected)
+}
+
+// ── Pull marker file (.pulling) ──────────────────────────────────────────────
+
+/// Path to the `.pulling` marker for a model: `<models_dir>/<sanitized-name>/.pulling`.
+fn pulling_marker_path(model_name: &str) -> PathBuf {
+    let sanitized = model_name.replace(':', "-");
+    models_dir().join(sanitized).join(".pulling")
+}
+
+/// Write a `.pulling` marker to signal an in-progress download.
+fn write_pulling_marker(model_name: &str) -> Result<(), DownloadError> {
+    let path = pulling_marker_path(model_name);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| {
+            DownloadError::FilePlacement(format!(
+                "failed to create directory for pull marker {}: {e}",
+                parent.display()
+            ))
+        })?;
+    }
+    std::fs::write(&path, model_name).map_err(|e| {
+        DownloadError::FilePlacement(format!(
+            "failed to write pull marker {}: {e}",
+            path.display()
+        ))
+    })
+}
+
+/// Remove the `.pulling` marker (best-effort, ignores errors).
+pub fn remove_pulling_marker(model_name: &str) {
+    let path = pulling_marker_path(model_name);
+    let _ = std::fs::remove_file(path);
+}
+
+/// Check whether a model has an active `.pulling` marker (incomplete download).
+pub fn has_pulling_marker(model_name: &str) -> bool {
+    let canonical = crate::manifest::resolve_model_name(model_name);
+    pulling_marker_path(&canonical).exists()
+}
+
+/// Verify SHA-256 integrity of a downloaded file. On mismatch, deletes the
+/// corrupted file and returns `Sha256Mismatch`. Respects `skip_verify`.
+fn verify_file_integrity(
+    clean_path: &std::path::Path,
+    file: &ModelFile,
+    model_name: &str,
+    skip_verify: bool,
+) -> Result<(), DownloadError> {
+    let expected = match file.sha256 {
+        Some(h) => h,
+        None => return Ok(()),
+    };
+    if skip_verify {
+        return Ok(());
+    }
+    match compute_sha256(clean_path) {
+        Ok(actual) if actual == expected => Ok(()),
+        Ok(actual) => {
+            let _ = std::fs::remove_file(clean_path);
+            Err(DownloadError::Sha256Mismatch {
+                filename: file.hf_filename.clone(),
+                expected: expected.to_string(),
+                actual,
+                model: model_name.to_string(),
+            })
+        }
+        Err(e) => {
+            eprintln!(
+                "warning: failed to verify SHA-256 for {}: {e}",
+                file.hf_filename
+            );
+            Ok(())
+        }
+    }
 }
 
 /// Truncate a string to fit within `max_len`, replacing the middle with "..." if needed.
@@ -327,7 +421,15 @@ impl Progress for CallbackProgress {
 /// then files are hardlinked to clean paths:
 /// - Transformers → `<model-name>/<filename>`
 /// - Shared components → `shared/<family>/<filename>`
-pub async fn pull_model(manifest: &ModelManifest) -> Result<ModelPaths, DownloadError> {
+///
+/// A `.pulling` marker file is written before downloads begin and removed on
+/// success. If the pull is interrupted, the marker signals an incomplete state.
+pub async fn pull_model(
+    manifest: &ModelManifest,
+    opts: &PullOptions,
+) -> Result<ModelPaths, DownloadError> {
+    write_pulling_marker(&manifest.name)?;
+
     let mut builder = ApiBuilder::from_env().with_cache_dir(hf_cache_dir());
     if let Some(token) = resolve_hf_token() {
         builder = builder.with_token(Some(token));
@@ -363,28 +465,12 @@ pub async fn pull_model(manifest: &ModelManifest) -> Result<ModelPaths, Download
         let clean_path = mdir.join(&clean_rel);
         hardlink_or_copy(&hf_path, &clean_path)?;
 
-        // Verify SHA-256 when expected digest is known
-        if let Some(expected) = file.sha256 {
-            match verify_sha256(&clean_path, expected) {
-                Ok(true) => {}
-                Ok(false) => {
-                    eprintln!(
-                        "warning: SHA-256 mismatch for {} (file may have been updated on HuggingFace)",
-                        file.hf_filename
-                    );
-                }
-                Err(e) => {
-                    eprintln!(
-                        "warning: failed to verify SHA-256 for {}: {e}",
-                        file.hf_filename
-                    );
-                }
-            }
-        }
+        verify_file_integrity(&clean_path, file, &manifest.name, opts.skip_verify)?;
 
         downloads.push((file.component, clean_path));
     }
 
+    remove_pulling_marker(&manifest.name);
     paths_from_downloads(&downloads).ok_or(DownloadError::MissingComponent)
 }
 
@@ -395,7 +481,10 @@ pub async fn pull_model(manifest: &ModelManifest) -> Result<ModelPaths, Download
 pub async fn pull_model_with_callback(
     manifest: &ModelManifest,
     callback: DownloadProgressCallback,
+    opts: &PullOptions,
 ) -> Result<ModelPaths, DownloadError> {
+    write_pulling_marker(&manifest.name)?;
+
     let mut builder = ApiBuilder::from_env().with_cache_dir(hf_cache_dir());
     if let Some(token) = resolve_hf_token() {
         builder = builder.with_token(Some(token));
@@ -415,28 +504,12 @@ pub async fn pull_model_with_callback(
         let clean_path = mdir.join(&clean_rel);
         hardlink_or_copy(&hf_path, &clean_path)?;
 
-        // Verify SHA-256 when expected digest is known
-        if let Some(expected) = file.sha256 {
-            match verify_sha256(&clean_path, expected) {
-                Ok(true) => {}
-                Ok(false) => {
-                    eprintln!(
-                        "warning: SHA-256 mismatch for {} (file may have been updated on HuggingFace)",
-                        file.hf_filename
-                    );
-                }
-                Err(e) => {
-                    eprintln!(
-                        "warning: failed to verify SHA-256 for {}: {e}",
-                        file.hf_filename
-                    );
-                }
-            }
-        }
+        verify_file_integrity(&clean_path, file, &manifest.name, opts.skip_verify)?;
 
         downloads.push((file.component, clean_path));
     }
 
+    remove_pulling_marker(&manifest.name);
     paths_from_downloads(&downloads).ok_or(DownloadError::MissingComponent)
 }
 
@@ -595,7 +668,10 @@ pub fn cached_file_path(
 /// Download a model and save its paths to config. Returns the updated config
 /// and resolved model paths. Used by both the CLI `pull` command and the
 /// server's auto-pull logic.
-pub async fn pull_and_configure(model: &str) -> Result<(crate::Config, ModelPaths), DownloadError> {
+pub async fn pull_and_configure(
+    model: &str,
+    opts: &PullOptions,
+) -> Result<(crate::Config, ModelPaths), DownloadError> {
     use crate::config::Config;
     use crate::manifest::{find_manifest, resolve_model_name};
 
@@ -605,7 +681,7 @@ pub async fn pull_and_configure(model: &str) -> Result<(crate::Config, ModelPath
         model: model.to_string(),
     })?;
 
-    let paths = pull_model(manifest).await?;
+    let paths = pull_model(manifest, opts).await?;
 
     let mut config = Config::load_or_default();
     let model_config = manifest.to_model_config(&paths);
@@ -628,6 +704,7 @@ pub async fn pull_and_configure(model: &str) -> Result<(crate::Config, ModelPath
 pub async fn pull_and_configure_with_callback(
     model: &str,
     callback: DownloadProgressCallback,
+    opts: &PullOptions,
 ) -> Result<(crate::Config, ModelPaths), DownloadError> {
     use crate::config::Config;
     use crate::manifest::{find_manifest, resolve_model_name};
@@ -638,7 +715,7 @@ pub async fn pull_and_configure_with_callback(
         model: model.to_string(),
     })?;
 
-    let paths = pull_model_with_callback(manifest, callback).await?;
+    let paths = pull_model_with_callback(manifest, callback, opts).await?;
 
     let mut config = Config::load_or_default();
     let model_config = manifest.to_model_config(&paths);
@@ -745,6 +822,20 @@ mod tests {
     }
 
     #[test]
+    fn compute_sha256_correct_digest() {
+        let dir = std::env::temp_dir().join("mold_test_sha256_compute");
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join("test_file.bin");
+        std::fs::write(&path, b"hello world").unwrap();
+        let digest = compute_sha256(&path).unwrap();
+        assert_eq!(
+            digest,
+            "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
     fn verify_sha256_matches() {
         let dir = std::env::temp_dir().join("mold_test_sha256_match");
         let _ = std::fs::create_dir_all(&dir);
@@ -765,5 +856,110 @@ mod tests {
         let wrong = "0000000000000000000000000000000000000000000000000000000000000000";
         assert!(!verify_sha256(&path, wrong).unwrap());
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn verify_file_integrity_deletes_on_mismatch() {
+        use crate::manifest::{ModelComponent, ModelFile};
+        let dir = std::env::temp_dir().join("mold_test_integrity_mismatch");
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join("corrupted.bin");
+        std::fs::write(&path, b"corrupted data").unwrap();
+
+        let file = ModelFile {
+            hf_repo: "test/repo".to_string(),
+            hf_filename: "corrupted.bin".to_string(),
+            component: ModelComponent::Transformer,
+            size_bytes: 14,
+            gated: false,
+            sha256: Some("0000000000000000000000000000000000000000000000000000000000000000"),
+        };
+
+        let result = verify_file_integrity(&path, &file, "test-model:q8", false);
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            DownloadError::Sha256Mismatch { .. }
+        ),);
+        // File should be deleted
+        assert!(!path.exists());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn verify_file_integrity_skip_verify_ignores_mismatch() {
+        use crate::manifest::{ModelComponent, ModelFile};
+        let dir = std::env::temp_dir().join("mold_test_integrity_skip");
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join("file.bin");
+        std::fs::write(&path, b"some data").unwrap();
+
+        let file = ModelFile {
+            hf_repo: "test/repo".to_string(),
+            hf_filename: "file.bin".to_string(),
+            component: ModelComponent::Transformer,
+            size_bytes: 9,
+            gated: false,
+            sha256: Some("0000000000000000000000000000000000000000000000000000000000000000"),
+        };
+
+        let result = verify_file_integrity(&path, &file, "test-model:q8", true);
+        assert!(result.is_ok());
+        // File should still exist
+        assert!(path.exists());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn verify_file_integrity_no_hash_is_ok() {
+        use crate::manifest::{ModelComponent, ModelFile};
+        let dir = std::env::temp_dir().join("mold_test_integrity_nohash");
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join("file.bin");
+        std::fs::write(&path, b"data").unwrap();
+
+        let file = ModelFile {
+            hf_repo: "test/repo".to_string(),
+            hf_filename: "file.bin".to_string(),
+            component: ModelComponent::Transformer,
+            size_bytes: 4,
+            gated: false,
+            sha256: None,
+        };
+
+        assert!(verify_file_integrity(&path, &file, "test:q8", false).is_ok());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn pulling_marker_roundtrip() {
+        let dir = std::env::temp_dir().join("mold_test_marker_roundtrip");
+        let _ = std::fs::create_dir_all(&dir);
+        let marker = dir.join(".pulling");
+
+        // Write
+        std::fs::write(&marker, "test-model:q8").unwrap();
+        assert!(marker.exists());
+
+        // Remove
+        let _ = std::fs::remove_file(&marker);
+        assert!(!marker.exists());
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn sha256_mismatch_error_message() {
+        let err = DownloadError::Sha256Mismatch {
+            filename: "transformer.gguf".to_string(),
+            expected: "aaa".to_string(),
+            actual: "bbb".to_string(),
+            model: "flux-dev:q8".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("SHA-256 mismatch"));
+        assert!(msg.contains("transformer.gguf"));
+        assert!(msg.contains("mold pull flux-dev:q8"));
+        assert!(msg.contains("--skip-verify"));
     }
 }

--- a/crates/mold-server/src/model_manager.rs
+++ b/crates/mold-server/src/model_manager.rs
@@ -135,11 +135,14 @@ pub(crate) async fn pull_model(
 
     tracing::info!(model = %model, "pulling model via API");
 
+    let opts = mold_core::download::PullOptions::default();
     let new_config = match progress {
-        Some(callback) => mold_core::download::pull_and_configure_with_callback(model, callback)
-            .await
-            .map(|(config, _)| config),
-        None => mold_core::download::pull_and_configure(model)
+        Some(callback) => {
+            mold_core::download::pull_and_configure_with_callback(model, callback, &opts)
+                .await
+                .map(|(config, _)| config)
+        }
+        None => mold_core::download::pull_and_configure(model, &opts)
             .await
             .map(|(config, _)| config),
     }


### PR DESCRIPTION
## Summary

Implements Phase 1 of #45 (download integrity hardening):

- **SHA-256 mismatch is now a hard error** — corrupted files are deleted on mismatch and the pull fails with actionable instructions. Previously this was a silent warning that left bad files in place.
- **Atomic `.pulling` marker** — written before downloads begin, removed on success. Interrupted pulls are detected by `mold list` (shows `[incomplete]`) and `manifest_model_is_downloaded()` returns false, preventing attempts to load incomplete models.
- **`--skip-verify` flag** on `mold pull` for cases where HuggingFace intentionally updated a file and the manifest hash is stale.
- **`PullOptions`** struct threaded through all pull functions (CLI, server, auto-pull in `mold run`).
- **Marker cleanup** on `mold rm` to prevent stale markers.

### Files changed

| File | Change |
|------|--------|
| `crates/mold-core/src/download.rs` | `PullOptions`, `Sha256Mismatch` error, `compute_sha256()`, `.pulling` marker functions, `verify_file_integrity()`, updated pull functions |
| `crates/mold-core/src/config.rs` | Marker-aware `discovered_manifest_paths()` and `manifest_model_is_downloaded()` |
| `crates/mold-cli/src/main.rs` | `--skip-verify` flag on `Pull` command |
| `crates/mold-cli/src/commands/pull.rs` | Thread `PullOptions`, handle `Sha256Mismatch` with user-friendly output |
| `crates/mold-cli/src/commands/generate.rs` | Pass `PullOptions::default()` to auto-pull |
| `crates/mold-cli/src/commands/list.rs` | Show `[incomplete]` for models with active pull markers |
| `crates/mold-cli/src/commands/rm.rs` | Clean up pull markers on model removal |
| `crates/mold-server/src/model_manager.rs` | Pass `PullOptions::default()` to server-side pulls |

## Test plan

- [x] `cargo check` — compiles cleanly
- [x] `cargo clippy -- -D warnings` — no warnings
- [x] `cargo fmt --check` — formatted
- [x] `cargo test --workspace` — all 534 tests pass (7 new)
- [ ] Manual: `mold pull --help` shows `--skip-verify` flag
- [ ] Manual: interrupt `mold pull` mid-download, verify `mold list` shows `[incomplete]`
- [ ] Manual: corrupt a downloaded file, re-pull, verify SHA mismatch error with helpful message

Closes #45 (Phase 1)