### PR TITLE
feat(flux2): GGUF transformer support, BF16 encoder fix, production quality

### DIFF
--- a/.claude/skills/mold/SKILL.md
+++ b/.claude/skills/mold/SKILL.md
@@ -100,13 +100,15 @@ Default model if none specified: `flux-schnell:q8`
 
 **Z-Image**: `z-image-turbo:bf16`, `z-image-turbo:q8`, `z-image-turbo:q6`, `z-image-turbo:q4`
 
-**Alpha**: `flux2-klein:bf16`, `flux2-klein:q8`, `flux2-klein:q6`, `flux2-klein:q4`, `qwen-image:bf16`, `qwen-image:q8`, `qwen-image:q6`, `qwen-image:q4`, `wuerstchen-v2:fp16`
+**Flux.2 Klein**: `flux2-klein:bf16`, `flux2-klein:q8`, `flux2-klein:q6`, `flux2-klein:q4`
+
+**Alpha**: `qwen-image:bf16`, `qwen-image:q8`, `qwen-image:q6`, `qwen-image:q4`, `wuerstchen-v2:fp16`
 
 **ControlNet (SD1.5)**: `controlnet-canny-sd15:fp16`, `controlnet-depth-sd15:fp16`, `controlnet-openpose-sd15:fp16`
 
 ### Name Resolution
 
-Bare names auto-resolve: `flux-dev` -> `flux-dev:q8`, `sdxl-base` -> `sdxl-base:fp16`, `sd15` -> `sd15:fp16`
+Bare names auto-resolve: `flux2-klein` -> `flux2-klein:q8`, `flux-dev` -> `flux-dev:q8`, `sdxl-base` -> `sdxl-base:fp16`, `sd15` -> `sd15:fp16`
 
 FP8 safetensors models are automatically quantized to Q8 GGUF on first use (one-time conversion, cached at `$MOLD_HOME/cache/`).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ pub trait InferenceEngine: Send + Sync {
 - `"sd15"` (also `"sd1.5"`, `"stable-diffusion-1.5"`) → `SD15Engine` — CLIP-L text encoding, UNet with DDIM, classifier-free guidance (512x512 default)
 - `"sdxl"` → `SDXLEngine` — Dual-CLIP (CLIP-L + CLIP-G), UNet with DDIM/Euler Ancestral, classifier-free guidance
 - `"sd3"` (also `"sd3.5"`, `"stable-diffusion-3"`) → `SD3Engine` — Triple encoder (CLIP-L + CLIP-G + T5-XXL), quantized MMDiT with NaN-safe inference
-- `"flux2"` (also `"flux.2"`, `"flux2-klein"`) → `Flux2Engine` — Qwen3 text encoder (GGUF, layers 9/18/27), shared modulation transformer, BN-VAE (beta)
+- `"flux2"` (also `"flux.2"`, `"flux2-klein"`) → `Flux2Engine` — Qwen3 text encoder (BF16 or GGUF, layers 9/18/27), shared modulation transformer (BF16 or GGUF), BN-VAE
 - `"qwen-image"` (also `"qwen_image"`) → `QwenImageEngine` — Qwen2.5-VL text encoder, 3D causal VAE (2D temporal-slice), flow-matching (beta)
 - `"z-image"` → `ZImageEngine` — Qwen3 text encoder, flow-matching transformer with 3D RoPE
 - `"wuerstchen"` (also `"wuerstchen-v2"`) → `WuerstchenEngine` — CLIP-G text encoder, 3-stage cascade (Prior → Decoder → VQ-GAN), 42x latent compression

--- a/crates/mold-core/src/manifest.rs
+++ b/crates/mold-core/src/manifest.rs
@@ -1672,9 +1672,8 @@ fn flux2_manifests() -> Vec<ModelManifest> {
         ModelManifest {
             name: "flux2-klein:bf16".to_string(),
             family: "flux2".to_string(),
-            description:
-                "[alpha] Flux.2 Klein-4B BF16 — Apache 2.0, 4B param distilled flow-matching"
-                    .to_string(),
+            description: "Flux.2 Klein-4B BF16 — Apache 2.0, 4B param distilled flow-matching"
+                .to_string(),
             files: {
                 let mut files = shared_flux2_files();
                 files.push(ModelFile {
@@ -1689,7 +1688,7 @@ fn flux2_manifests() -> Vec<ModelManifest> {
             },
             defaults: ManifestDefaults {
                 steps: 4,
-                guidance: 0.0, // Klein is distilled, no CFG needed
+                guidance: 0.0, // Klein is distilled — no guidance embedding, value is ignored
                 width: 1024,
                 height: 1024,
                 is_schnell: false,
@@ -1700,7 +1699,7 @@ fn flux2_manifests() -> Vec<ModelManifest> {
         ModelManifest {
             name: "flux2-klein:q8".to_string(),
             family: "flux2".to_string(),
-            description: "[alpha] Flux.2 Klein-4B Q8 — best GGUF quality".to_string(),
+            description: "Flux.2 Klein-4B Q8 GGUF — smaller download, reduced quality".to_string(),
             files: {
                 let mut files = shared_flux2_files();
                 files.push(ModelFile {
@@ -1725,7 +1724,7 @@ fn flux2_manifests() -> Vec<ModelManifest> {
         ModelManifest {
             name: "flux2-klein:q6".to_string(),
             family: "flux2".to_string(),
-            description: "[alpha] Flux.2 Klein-4B Q6 — good quality/size trade-off".to_string(),
+            description: "Flux.2 Klein-4B Q6 GGUF — smaller download, reduced quality".to_string(),
             files: {
                 let mut files = shared_flux2_files();
                 files.push(ModelFile {
@@ -1750,7 +1749,7 @@ fn flux2_manifests() -> Vec<ModelManifest> {
         ModelManifest {
             name: "flux2-klein:q4".to_string(),
             family: "flux2".to_string(),
-            description: "[alpha] Flux.2 Klein-4B Q4 — smaller footprint".to_string(),
+            description: "Flux.2 Klein-4B Q4 GGUF — smallest download, reduced quality".to_string(),
             files: {
                 let mut files = shared_flux2_files();
                 files.push(ModelFile {
@@ -2035,7 +2034,7 @@ pub fn resolve_model_name(input: &str) -> String {
             return format!("{base}:{suffix}");
         }
     }
-    // Try default tags in preference order: :q8 (FLUX/GGUF), :fp16 (SDXL), :bf16 (Z-Image), :fp8 (community fine-tunes)
+    // Try default tags in preference order: :q8 (GGUF, smaller), :fp16 (SDXL), :bf16, :fp8 (community)
     for tag in ["q8", "fp16", "bf16", "fp8"] {
         let candidate = format!("{input}:{tag}");
         if find_manifest_exact(&candidate).is_some() {
@@ -2752,8 +2751,7 @@ mod tests {
 
     #[test]
     fn flux2_klein_resolves_to_q8() {
-        // bare "flux2-klein" should resolve to :q8 (not :bf16) since q8 is tried first
-        // Actually, it tries :q8 first in resolve_model_name
+        // bare "flux2-klein" resolves to :q8 (tried first, matches existing installs)
         let name = resolve_model_name("flux2-klein");
         assert_eq!(name, "flux2-klein:q8");
     }

--- a/crates/mold-inference/src/encoders/mod.rs
+++ b/crates/mold-inference/src/encoders/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod clip;
 pub(crate) mod qwen2_text;
 pub(crate) mod qwen3;
+pub(crate) mod qwen3_bf16;
 pub(crate) mod qwen3_gguf;
 pub(crate) mod sd3_clip;
 pub(crate) mod t5;

--- a/crates/mold-inference/src/encoders/qwen3.rs
+++ b/crates/mold-inference/src/encoders/qwen3.rs
@@ -1,27 +1,27 @@
-//! Qwen3 text encoder wrapper for Z-Image.
+//! Qwen3 text encoder wrapper.
 //!
-//! Wraps either the BF16 `ZImageTextEncoder` (from candle) or the quantized
-//! `GgufQwen3Encoder` (from this crate), providing a unified load/encode/drop/reload
+//! Wraps either the native BF16 `Bf16Qwen3Encoder` (with multi-layer extraction)
+//! or the quantized `GgufQwen3Encoder`, providing a unified load/encode/drop/reload
 //! interface that mirrors `T5Encoder`.
 
 use anyhow::Result;
 use candle_core::{DType, Device, Tensor};
 use candle_nn::VarBuilder;
-use candle_transformers::models::z_image::{TextEncoderConfig, ZImageTextEncoder};
 use std::path::{Path, PathBuf};
 
+use super::qwen3_bf16::Bf16Qwen3Encoder;
 use super::qwen3_gguf::GgufQwen3Encoder;
 
 /// BF16 (safetensors) or quantized (GGUF) Qwen3 text encoder.
 pub(crate) enum Qwen3Model {
-    BF16(ZImageTextEncoder),
+    BF16(Bf16Qwen3Encoder),
     Quantized(GgufQwen3Encoder),
 }
 
 impl Qwen3Model {
     pub fn forward(&mut self, input_ids: &Tensor) -> Result<Tensor> {
         match self {
-            Self::BF16(m) => Ok(m.forward(input_ids)?),
+            Self::BF16(m) => m.forward(input_ids),
             Self::Quantized(m) => m.forward(input_ids),
         }
     }
@@ -35,14 +35,7 @@ impl Qwen3Model {
         layer_indices: &[usize],
     ) -> Result<Tensor> {
         match self {
-            Self::BF16(m) => {
-                // BF16 ZImageTextEncoder only returns penultimate layer.
-                // For multi-layer extraction, fall back to repeating the single output.
-                // TODO: Add forward_with_layers to ZImageTextEncoder upstream.
-                let emb = m.forward(input_ids)?;
-                let copies: Vec<&Tensor> = (0..layer_indices.len()).map(|_| &emb).collect();
-                Ok(Tensor::cat(&copies, 2)?)
-            }
+            Self::BF16(m) => m.forward_with_layers(input_ids, layer_indices),
             Self::Quantized(m) => m.forward_with_layers(input_ids, layer_indices),
         }
     }
@@ -88,13 +81,12 @@ impl Qwen3Encoder {
         device: &Device,
         dtype: DType,
     ) -> Result<Self> {
-        let te_cfg = TextEncoderConfig::z_image();
         let path_strs: Vec<&str> = encoder_paths
             .iter()
             .map(|p| p.to_str().expect("non-UTF8 path"))
             .collect();
         let vb = unsafe { VarBuilder::from_mmaped_safetensors(&path_strs, dtype, device)? };
-        let model = Qwen3Model::BF16(ZImageTextEncoder::new(&te_cfg, vb)?);
+        let model = Qwen3Model::BF16(Bf16Qwen3Encoder::load(vb)?);
 
         let tokenizer = tokenizers::Tokenizer::from_file(tokenizer_path)
             .map_err(|e| anyhow::anyhow!("failed to load Qwen3 tokenizer: {e}"))?;
@@ -207,7 +199,6 @@ impl Qwen3Encoder {
                 &self.device,
             )?));
         } else {
-            let te_cfg = TextEncoderConfig::z_image();
             let path_strs: Vec<&str> = self
                 .encoder_paths
                 .iter()
@@ -216,7 +207,7 @@ impl Qwen3Encoder {
             let vb = unsafe {
                 VarBuilder::from_mmaped_safetensors(&path_strs, self.dtype, &self.device)?
             };
-            self.model = Some(Qwen3Model::BF16(ZImageTextEncoder::new(&te_cfg, vb)?));
+            self.model = Some(Qwen3Model::BF16(Bf16Qwen3Encoder::load(vb)?));
         }
         Ok(())
     }

--- a/crates/mold-inference/src/encoders/qwen3_bf16.rs
+++ b/crates/mold-inference/src/encoders/qwen3_bf16.rs
@@ -1,0 +1,377 @@
+//! Native BF16 Qwen3-4B encoder for safetensors weights.
+//!
+//! Provides `forward_with_layers()` for multi-layer hidden state extraction,
+//! required by Flux.2 Klein (layers 9, 18, 27 → 7680-dim stacked embeddings).
+//!
+//! This replaces the upstream `ZImageTextEncoder` which only returns the
+//! penultimate layer and has no multi-layer extraction support.
+//!
+//! Architecture: 36 layers, 32 Q heads, 8 KV heads (GQA 4:1), 2560 hidden,
+//! 128 head_dim, SwiGLU MLP (9728 intermediate), RoPE theta=1e6, RMSNorm eps=1e-6.
+//!
+//! HuggingFace safetensors weight names:
+//! - `model.embed_tokens.weight`
+//! - `model.layers.{i}.self_attn.{q,k,v,o}_proj.weight`
+//! - `model.layers.{i}.self_attn.{q,k}_norm.weight`
+//! - `model.layers.{i}.input_layernorm.weight`
+//! - `model.layers.{i}.post_attention_layernorm.weight`
+//! - `model.layers.{i}.mlp.{gate,up,down}_proj.weight`
+
+use anyhow::Result;
+use candle_core::{DType, Device, Module, Tensor};
+use candle_nn::VarBuilder;
+
+// ── Architecture constants ──────────────────────────────────────────────────
+
+const NUM_HIDDEN_LAYERS: usize = 36;
+const NUM_ATTENTION_HEADS: usize = 32;
+const NUM_KV_HEADS: usize = 8;
+const HEAD_DIM: usize = 128;
+const HIDDEN_SIZE: usize = 2560;
+const INTERMEDIATE_SIZE: usize = 9728;
+const ROPE_THETA: f64 = 1_000_000.0;
+const RMS_NORM_EPS: f64 = 1e-6;
+const VOCAB_SIZE: usize = 151936;
+const MAX_POSITION_EMBEDDINGS: usize = 40960;
+const KV_REPEAT: usize = NUM_ATTENTION_HEADS / NUM_KV_HEADS; // 4
+
+// ── Rotary Embedding ────────────────────────────────────────────────────────
+
+struct RotaryEmbedding {
+    sin: Tensor,
+    cos: Tensor,
+}
+
+impl RotaryEmbedding {
+    fn new(dtype: DType, device: &Device) -> Result<Self> {
+        let dim = HEAD_DIM;
+        let inv_freq: Vec<f32> = (0..dim)
+            .step_by(2)
+            .map(|i| 1f32 / ROPE_THETA.powf(i as f64 / dim as f64) as f32)
+            .collect();
+        let inv_freq_len = inv_freq.len();
+        let inv_freq =
+            Tensor::from_vec(inv_freq, (1, inv_freq_len), device)?.to_dtype(DType::F32)?;
+        let t = Tensor::arange(0u32, MAX_POSITION_EMBEDDINGS as u32, device)?
+            .to_dtype(DType::F32)?
+            .reshape((MAX_POSITION_EMBEDDINGS, 1))?;
+        let freqs = t.matmul(&inv_freq)?;
+        Ok(Self {
+            sin: freqs.sin()?.to_dtype(dtype)?,
+            cos: freqs.cos()?.to_dtype(dtype)?,
+        })
+    }
+
+    /// Apply RoPE to q, k tensors of shape (B, H, L, D).
+    fn apply(&self, q: &Tensor, k: &Tensor, offset: usize) -> Result<(Tensor, Tensor)> {
+        let (_, _, seq_len, _) = q.dims4()?;
+        let cos = self.cos.narrow(0, offset, seq_len)?;
+        let sin = self.sin.narrow(0, offset, seq_len)?;
+        let q_embed = candle_nn::rotary_emb::rope(&q.contiguous()?, &cos, &sin)?;
+        let k_embed = candle_nn::rotary_emb::rope(&k.contiguous()?, &cos, &sin)?;
+        Ok((q_embed, k_embed))
+    }
+}
+
+// ── GQA repeat_kv ───────────────────────────────────────────────────────────
+
+fn repeat_kv(x: Tensor, n_rep: usize) -> Result<Tensor> {
+    if n_rep == 1 {
+        return Ok(x);
+    }
+    let (b, n_kv_heads, seq_len, head_dim) = x.dims4()?;
+    x.unsqueeze(2)?
+        .broadcast_as((b, n_kv_heads, n_rep, seq_len, head_dim))?
+        .reshape((b, n_kv_heads * n_rep, seq_len, head_dim))
+        .map_err(Into::into)
+}
+
+// ── RmsNorm (per-head variant for Q/K norms) ────────────────────────────────
+
+struct RmsNorm {
+    weight: Tensor,
+    eps: f64,
+}
+
+impl RmsNorm {
+    fn new(size: usize, eps: f64, vb: VarBuilder) -> Result<Self> {
+        let weight = vb.get(size, "weight")?;
+        Ok(Self { weight, eps })
+    }
+
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        candle_nn::ops::rms_norm(xs, &self.weight, self.eps as f32).map_err(Into::into)
+    }
+}
+
+// ── SwiGLU MLP ──────────────────────────────────────────────────────────────
+
+struct SwiGluMlp {
+    gate_proj: candle_nn::Linear,
+    up_proj: candle_nn::Linear,
+    down_proj: candle_nn::Linear,
+}
+
+impl SwiGluMlp {
+    fn new(vb: VarBuilder) -> Result<Self> {
+        Ok(Self {
+            gate_proj: candle_nn::linear_no_bias(
+                HIDDEN_SIZE,
+                INTERMEDIATE_SIZE,
+                vb.pp("gate_proj"),
+            )?,
+            up_proj: candle_nn::linear_no_bias(HIDDEN_SIZE, INTERMEDIATE_SIZE, vb.pp("up_proj"))?,
+            down_proj: candle_nn::linear_no_bias(
+                INTERMEDIATE_SIZE,
+                HIDDEN_SIZE,
+                vb.pp("down_proj"),
+            )?,
+        })
+    }
+
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let gate = candle_nn::Activation::Silu.forward(&xs.apply(&self.gate_proj)?)?;
+        let up = xs.apply(&self.up_proj)?;
+        (gate * up)?.apply(&self.down_proj).map_err(Into::into)
+    }
+}
+
+// ── Attention ───────────────────────────────────────────────────────────────
+
+struct Attention {
+    q_proj: candle_nn::Linear,
+    k_proj: candle_nn::Linear,
+    v_proj: candle_nn::Linear,
+    o_proj: candle_nn::Linear,
+    q_norm: RmsNorm,
+    k_norm: RmsNorm,
+    rotary_emb: std::sync::Arc<RotaryEmbedding>,
+}
+
+impl Attention {
+    fn new(rotary_emb: std::sync::Arc<RotaryEmbedding>, vb: VarBuilder) -> Result<Self> {
+        let q_proj = candle_nn::linear_no_bias(
+            HIDDEN_SIZE,
+            NUM_ATTENTION_HEADS * HEAD_DIM,
+            vb.pp("q_proj"),
+        )?;
+        let k_proj =
+            candle_nn::linear_no_bias(HIDDEN_SIZE, NUM_KV_HEADS * HEAD_DIM, vb.pp("k_proj"))?;
+        let v_proj =
+            candle_nn::linear_no_bias(HIDDEN_SIZE, NUM_KV_HEADS * HEAD_DIM, vb.pp("v_proj"))?;
+        let o_proj = candle_nn::linear_no_bias(
+            NUM_ATTENTION_HEADS * HEAD_DIM,
+            HIDDEN_SIZE,
+            vb.pp("o_proj"),
+        )?;
+        let q_norm = RmsNorm::new(HEAD_DIM, RMS_NORM_EPS, vb.pp("q_norm"))?;
+        let k_norm = RmsNorm::new(HEAD_DIM, RMS_NORM_EPS, vb.pp("k_norm"))?;
+
+        Ok(Self {
+            q_proj,
+            k_proj,
+            v_proj,
+            o_proj,
+            q_norm,
+            k_norm,
+            rotary_emb,
+        })
+    }
+
+    fn forward(&self, xs: &Tensor, mask: Option<&Tensor>) -> Result<Tensor> {
+        let (b, l, _) = xs.dims3()?;
+
+        let q = self.q_proj.forward(xs)?;
+        let k = self.k_proj.forward(xs)?;
+        let v = self.v_proj.forward(xs)?;
+
+        // Reshape to (B, L, H, D) then transpose to (B, H, L, D)
+        let q = q
+            .reshape((b, l, NUM_ATTENTION_HEADS, HEAD_DIM))?
+            .transpose(1, 2)?;
+        let k = k.reshape((b, l, NUM_KV_HEADS, HEAD_DIM))?.transpose(1, 2)?;
+        let v = v.reshape((b, l, NUM_KV_HEADS, HEAD_DIM))?.transpose(1, 2)?;
+
+        // Per-head RMSNorm (flatten batch+heads, norm, reshape back)
+        let q_flat = q.flatten(0, 2)?;
+        let k_flat = k.flatten(0, 2)?;
+        let q_flat = self.q_norm.forward(&q_flat)?;
+        let k_flat = self.k_norm.forward(&k_flat)?;
+        let q = q_flat.reshape((b, NUM_ATTENTION_HEADS, l, HEAD_DIM))?;
+        let k = k_flat.reshape((b, NUM_KV_HEADS, l, HEAD_DIM))?;
+
+        // RoPE
+        let (q, k) = self.rotary_emb.apply(&q, &k, 0)?;
+
+        // GQA repeat KV
+        let k = repeat_kv(k, KV_REPEAT)?.contiguous()?;
+        let v = repeat_kv(v, KV_REPEAT)?.contiguous()?;
+
+        // Scaled dot-product attention
+        let scale = 1.0 / (HEAD_DIM as f64).sqrt();
+        let mut scores = (q.matmul(&k.transpose(2, 3)?)? * scale)?;
+        if let Some(m) = mask {
+            scores = scores.broadcast_add(m)?;
+        }
+        let attn_weights = candle_nn::ops::softmax_last_dim(&scores)?;
+        let ctx = attn_weights.matmul(&v)?;
+
+        // Output projection
+        ctx.transpose(1, 2)?
+            .reshape((b, l, NUM_ATTENTION_HEADS * HEAD_DIM))?
+            .apply(&self.o_proj)
+            .map_err(Into::into)
+    }
+}
+
+// ── Decoder Layer ───────────────────────────────────────────────────────────
+
+struct DecoderLayer {
+    self_attn: Attention,
+    mlp: SwiGluMlp,
+    input_layernorm: RmsNorm,
+    post_attention_layernorm: RmsNorm,
+}
+
+impl DecoderLayer {
+    fn new(rotary_emb: std::sync::Arc<RotaryEmbedding>, vb: VarBuilder) -> Result<Self> {
+        let self_attn = Attention::new(rotary_emb, vb.pp("self_attn"))?;
+        let mlp = SwiGluMlp::new(vb.pp("mlp"))?;
+        let input_layernorm = RmsNorm::new(HIDDEN_SIZE, RMS_NORM_EPS, vb.pp("input_layernorm"))?;
+        let post_attention_layernorm =
+            RmsNorm::new(HIDDEN_SIZE, RMS_NORM_EPS, vb.pp("post_attention_layernorm"))?;
+        Ok(Self {
+            self_attn,
+            mlp,
+            input_layernorm,
+            post_attention_layernorm,
+        })
+    }
+
+    fn forward(&self, xs: &Tensor, mask: Option<&Tensor>) -> Result<Tensor> {
+        let h = self.input_layernorm.forward(xs)?;
+        let h = self.self_attn.forward(&h, mask)?;
+        let xs = (xs + h)?;
+        let h = self.post_attention_layernorm.forward(&xs)?;
+        let h = self.mlp.forward(&h)?;
+        (xs + h).map_err(Into::into)
+    }
+}
+
+// ── Bf16Qwen3Encoder ───────────────────────────────────────────────────────
+
+/// Native BF16 Qwen3-4B encoder with multi-layer hidden state extraction.
+pub(crate) struct Bf16Qwen3Encoder {
+    embed_tokens: candle_nn::Embedding,
+    layers: Vec<DecoderLayer>,
+    device: Device,
+    dtype: DType,
+}
+
+impl Bf16Qwen3Encoder {
+    /// Load from HuggingFace safetensors files.
+    pub fn load(vb: VarBuilder) -> Result<Self> {
+        let device = vb.device().clone();
+        let dtype = vb.dtype();
+        let vb_model = vb.pp("model");
+
+        let embed_tokens =
+            candle_nn::embedding(VOCAB_SIZE, HIDDEN_SIZE, vb_model.pp("embed_tokens"))?;
+
+        let rotary_emb = std::sync::Arc::new(RotaryEmbedding::new(dtype, &device)?);
+
+        let vb_layers = vb_model.pp("layers");
+        let mut layers = Vec::with_capacity(NUM_HIDDEN_LAYERS);
+        for i in 0..NUM_HIDDEN_LAYERS {
+            layers.push(DecoderLayer::new(rotary_emb.clone(), vb_layers.pp(i))?);
+        }
+
+        Ok(Self {
+            embed_tokens,
+            layers,
+            device,
+            dtype,
+        })
+    }
+
+    /// Create causal attention mask.
+    fn causal_mask(&self, b: usize, tgt: usize) -> Result<Tensor> {
+        let minf = f32::NEG_INFINITY;
+        let mask: Vec<f32> = (0..tgt)
+            .flat_map(|i| (0..tgt).map(move |j| if j <= i { 0.0 } else { minf }))
+            .collect();
+        Tensor::from_slice(&mask, (b, 1, tgt, tgt), &self.device)?
+            .to_dtype(self.dtype)
+            .map_err(Into::into)
+    }
+
+    /// Encode text, returning second-to-last layer hidden states (no final norm).
+    /// Compatible with the upstream `ZImageTextEncoder::forward` behavior.
+    pub fn forward(&self, input_ids: &Tensor) -> Result<Tensor> {
+        let (b, l) = input_ids.dims2()?;
+        let mut hidden_states = self.embed_tokens.forward(input_ids)?;
+
+        let mask = if l == 1 {
+            None
+        } else {
+            Some(self.causal_mask(b, l)?)
+        };
+
+        let target_layer = NUM_HIDDEN_LAYERS - 2; // layer 34
+
+        for (i, layer) in self.layers.iter().enumerate() {
+            hidden_states = layer.forward(&hidden_states, mask.as_ref())?;
+            if i == target_layer {
+                return Ok(hidden_states);
+            }
+        }
+
+        Ok(hidden_states)
+    }
+
+    /// Run forward pass and collect hidden states from specific layers.
+    /// Returns (B, seq_len, num_layers * hidden_size).
+    /// Used by Flux.2 Klein which stacks layers 9, 18, 27 → 7680-dim embeddings.
+    pub fn forward_with_layers(
+        &self,
+        input_ids: &Tensor,
+        layer_indices: &[usize],
+    ) -> Result<Tensor> {
+        if layer_indices.is_empty() {
+            anyhow::bail!("layer_indices must not be empty");
+        }
+        let max_layer = layer_indices.iter().copied().max().unwrap_or(0);
+        if max_layer >= self.layers.len() {
+            anyhow::bail!(
+                "layer index {max_layer} out of bounds (model has {} layers)",
+                self.layers.len()
+            );
+        }
+
+        let (b, l) = input_ids.dims2()?;
+        let mut hidden_states = self.embed_tokens.forward(input_ids)?;
+
+        let mask = if l == 1 {
+            None
+        } else {
+            Some(self.causal_mask(b, l)?)
+        };
+
+        let n_run = max_layer + 1;
+        let mut collected: Vec<Tensor> = Vec::with_capacity(layer_indices.len());
+
+        for (i, layer) in self.layers[..n_run].iter().enumerate() {
+            hidden_states = layer.forward(&hidden_states, mask.as_ref())?;
+            if layer_indices.contains(&i) {
+                collected.push(hidden_states.clone());
+            }
+        }
+
+        // Stack: (B, num_layers, seq, hidden) → permute → (B, seq, num_layers * hidden)
+        let stacked = Tensor::stack(&collected, 1)?;
+        let (b, _n, s, h) = stacked.dims4()?;
+        Ok(stacked
+            .permute((0, 2, 1, 3))?
+            .reshape((b, s, collected.len() * h))?)
+    }
+}

--- a/crates/mold-inference/src/encoders/qwen3_gguf.rs
+++ b/crates/mold-inference/src/encoders/qwen3_gguf.rs
@@ -356,13 +356,23 @@ impl GgufQwen3Encoder {
         input_ids: &Tensor,
         layer_indices: &[usize],
     ) -> Result<Tensor> {
+        if layer_indices.is_empty() {
+            anyhow::bail!("layer_indices must not be empty");
+        }
+        let max_layer = layer_indices.iter().copied().max().unwrap_or(0);
+        if max_layer >= self.blocks.len() {
+            anyhow::bail!(
+                "layer index {max_layer} out of bounds (model has {} layers)",
+                self.blocks.len()
+            );
+        }
+
         let (_batch, seq_len) = input_ids.dims2()?;
         let mut xs = self.embedding.forward(input_ids)?;
         let (cos, sin) = compute_rope(seq_len, xs.device())?;
         let mask = causal_mask(seq_len, xs.dtype(), xs.device())?;
 
-        let max_layer = layer_indices.iter().copied().max().unwrap_or(0);
-        let n_run = (max_layer + 1).min(self.blocks.len());
+        let n_run = max_layer + 1;
         let mut collected: Vec<Tensor> = Vec::with_capacity(layer_indices.len());
 
         for (i, block) in self.blocks[..n_run].iter_mut().enumerate() {

--- a/crates/mold-inference/src/encoders/variant_resolution.rs
+++ b/crates/mold-inference/src/encoders/variant_resolution.rs
@@ -186,8 +186,8 @@ pub(crate) fn resolve_t5_gguf_path(
 /// - `bf16_paths`: BF16 shard paths (may be empty if not available).
 /// - `have_bf16`: whether BF16 shards exist on disk.
 /// - `prefer_gguf`: if true, auto mode prefers GGUF over BF16 even when BF16 fits.
-///   Flux.2 sets this to true because multi-layer extraction (layers 9, 18, 27)
-///   only works with the GGUF encoder.
+///   Flux.2 sets this to true because GGUF is smaller and faster to load.
+///   Both GGUF and BF16 encoders support multi-layer extraction (layers 9, 18, 27).
 pub(crate) fn resolve_qwen3_variant(
     progress: &ProgressReporter,
     preference: Option<&str>,

--- a/crates/mold-inference/src/flux2/mod.rs
+++ b/crates/mold-inference/src/flux2/mod.rs
@@ -1,4 +1,5 @@
 mod pipeline;
+pub(crate) mod quantized_transformer;
 pub(crate) mod sampling;
 pub(crate) mod transformer;
 pub(crate) mod vae;

--- a/crates/mold-inference/src/flux2/pipeline.rs
+++ b/crates/mold-inference/src/flux2/pipeline.rs
@@ -114,6 +114,54 @@ impl Flux2Engine {
         Ok(text_tokenizer_path.clone())
     }
 
+    /// Check if the transformer file is a GGUF (quantized) file.
+    fn is_gguf_transformer(&self) -> bool {
+        self.base
+            .paths
+            .transformer
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(|e| e.eq_ignore_ascii_case("gguf"))
+            .unwrap_or(false)
+    }
+
+    /// Load the transformer from either GGUF or BF16 safetensors.
+    fn load_transformer(
+        &self,
+        cfg: &Flux2Config,
+        gpu_dtype: DType,
+        device: &Device,
+    ) -> Result<(Flux2TransformerWrapper, &'static str)> {
+        if self.is_gguf_transformer() {
+            let gguf_vb = candle_transformers::quantized_var_builder::VarBuilder::from_gguf(
+                &self.base.paths.transformer,
+                device,
+            )?;
+            Ok((
+                Flux2TransformerWrapper::Quantized(
+                    super::quantized_transformer::QuantizedFlux2Transformer::new(
+                        cfg, gguf_vb, gpu_dtype, device,
+                    )?,
+                ),
+                "Loading Flux.2 transformer (GPU, GGUF)",
+            ))
+        } else {
+            let xformer_paths = if !self.base.paths.transformer_shards.is_empty() {
+                self.base.paths.transformer_shards.clone()
+            } else {
+                vec![self.base.paths.transformer.clone()]
+            };
+            let flux_vb =
+                unsafe { VarBuilder::from_mmaped_safetensors(&xformer_paths, gpu_dtype, device)? };
+            Ok((
+                Flux2TransformerWrapper::BF16(super::transformer::Flux2Transformer::new(
+                    cfg, flux_vb,
+                )?),
+                "Loading Flux.2 transformer (GPU, BF16)",
+            ))
+        }
+    }
+
     /// Get text encoder file paths (shards or single file).
     fn text_encoder_paths(&self) -> Vec<std::path::PathBuf> {
         if !self.base.paths.text_encoder_files.is_empty() {
@@ -209,31 +257,12 @@ impl Flux2Engine {
         tracing::info!("GPU device: {:?}, GPU dtype: {:?}", device, gpu_dtype);
 
         // --- Load transformer on GPU first ---
+        let flux2_cfg = Flux2Config::klein();
+        let xformer_stage = Instant::now();
+        let (transformer, xformer_label) = self.load_transformer(&flux2_cfg, gpu_dtype, &device)?;
         self.base
             .progress
-            .stage_start("Loading Flux.2 transformer (GPU, BF16)");
-        let xformer_stage = Instant::now();
-        tracing::info!(
-            path = %self.base.paths.transformer.display(),
-            "loading Flux.2 transformer on GPU..."
-        );
-
-        let flux2_cfg = Flux2Config::klein();
-        let xformer_paths = if !self.base.paths.transformer_shards.is_empty() {
-            self.base.paths.transformer_shards.clone()
-        } else {
-            vec![self.base.paths.transformer.clone()]
-        };
-        let flux_vb =
-            unsafe { VarBuilder::from_mmaped_safetensors(&xformer_paths, gpu_dtype, &device)? };
-        let transformer = Flux2TransformerWrapper::BF16(super::transformer::Flux2Transformer::new(
-            &flux2_cfg, flux_vb,
-        )?);
-        self.base.progress.stage_done(
-            "Loading Flux.2 transformer (GPU, BF16)",
-            xformer_stage.elapsed(),
-        );
-        tracing::info!("Flux.2 transformer loaded on GPU");
+            .stage_done(xformer_label, xformer_stage.elapsed());
 
         // --- Load VAE on GPU ---
         self.base.progress.stage_start("Loading VAE (GPU)");
@@ -430,26 +459,11 @@ impl Flux2Engine {
         }
 
         let flux2_cfg = Flux2Config::klein();
-
+        let xformer_stage = Instant::now();
+        let (transformer, xformer_label) = self.load_transformer(&flux2_cfg, gpu_dtype, &device)?;
         self.base
             .progress
-            .stage_start("Loading Flux.2 transformer (GPU, BF16)");
-        let xformer_stage = Instant::now();
-
-        let xformer_paths = if !self.base.paths.transformer_shards.is_empty() {
-            self.base.paths.transformer_shards.clone()
-        } else {
-            vec![self.base.paths.transformer.clone()]
-        };
-        let flux_vb =
-            unsafe { VarBuilder::from_mmaped_safetensors(&xformer_paths, gpu_dtype, &device)? };
-        let transformer = Flux2TransformerWrapper::BF16(super::transformer::Flux2Transformer::new(
-            &flux2_cfg, flux_vb,
-        )?);
-        self.base.progress.stage_done(
-            "Loading Flux.2 transformer (GPU, BF16)",
-            xformer_stage.elapsed(),
-        );
+            .stage_done(xformer_label, xformer_stage.elapsed());
 
         // Load VAE
         self.base.progress.stage_start("Loading VAE (GPU)");
@@ -494,6 +508,7 @@ impl Flux2Engine {
         )?;
 
         let img = sampling::unpack(&img, height, width)?;
+
         self.base
             .progress
             .stage_done(&denoise_label, denoise_start.elapsed());
@@ -554,6 +569,12 @@ impl InferenceEngine for Flux2Engine {
         if req.scheduler.is_some() {
             tracing::warn!(
                 "scheduler selection not supported for Flux.2 (flow-matching), ignoring"
+            );
+        }
+        if req.guidance != 0.0 {
+            tracing::debug!(
+                guidance = req.guidance,
+                "Flux.2 Klein is distilled — guidance value is ignored (no guidance embedding)"
             );
         }
         if req.source_image.is_some() {

--- a/crates/mold-inference/src/flux2/quantized_transformer.rs
+++ b/crates/mold-inference/src/flux2/quantized_transformer.rs
@@ -1,0 +1,597 @@
+//! GGUF Flux.2 Klein transformer — dequantize-on-CPU approach.
+//!
+//! Loads GGUF weights, dequantizes on CPU to BF16, moves to GPU, then uses
+//! standard `candle_nn::Linear` for inference. This produces identical precision
+//! to the BF16 safetensors path since all inference runs through BF16 matmul.
+//!
+//! GGUF tensor naming (unsloth convention):
+//! - `double_blocks.{i}.img_attn.qkv.weight` (fused Q+K+V)
+//! - `double_blocks.{i}.img_mlp.0.weight` (gate+up fused), `.2.weight` (down)
+//! - `single_blocks.{i}.linear1.weight`, `.linear2.weight`
+//! - Norms: `.norm.{query,key}_norm.scale`
+//! - Embedders: `time_in`, `img_in`, `txt_in`, modulations, `final_layer`
+
+use anyhow::Result;
+use candle_core::{DType, Device, IndexOp, Tensor, D};
+use candle_nn::{LayerNorm, Linear, RmsNorm};
+use candle_transformers::quantized_var_builder::VarBuilder;
+
+use super::transformer::EmbedNd;
+use super::transformer::Flux2Config;
+use super::transformer::{attention, timestep_embedding};
+
+// ---------------------------------------------------------------------------
+// Utility: dequantize GGUF → BF16 on CPU → move to GPU
+// ---------------------------------------------------------------------------
+
+fn dequant_linear(vb: &VarBuilder, name: &str, dtype: DType, device: &Device) -> Result<Linear> {
+    let w = vb
+        .get_no_shape(name)?
+        .dequantize(vb.device())?
+        .to_dtype(dtype)?
+        .to_device(device)?;
+    Ok(Linear::new(w, None))
+}
+
+fn dequant_tensor(vb: &VarBuilder, name: &str, dtype: DType, device: &Device) -> Result<Tensor> {
+    Ok(vb
+        .get_no_shape(name)?
+        .dequantize(vb.device())?
+        .to_dtype(dtype)?
+        .to_device(device)?)
+}
+
+fn make_layer_norm(h_sz: usize, dtype: DType, device: &Device) -> Result<LayerNorm> {
+    Ok(LayerNorm::new_no_bias(
+        Tensor::ones(h_sz, dtype, device)?,
+        1e-6,
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// Building blocks (all use candle_nn::Linear, BF16 on GPU)
+// ---------------------------------------------------------------------------
+
+struct MlpEmbedder {
+    in_layer: Linear,
+    out_layer: Linear,
+}
+
+impl MlpEmbedder {
+    fn new(vb: &VarBuilder, prefix: &str, dtype: DType, device: &Device) -> Result<Self> {
+        Ok(Self {
+            in_layer: dequant_linear(vb, &format!("{prefix}.in_layer.weight"), dtype, device)?,
+            out_layer: dequant_linear(vb, &format!("{prefix}.out_layer.weight"), dtype, device)?,
+        })
+    }
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        Ok(xs.apply(&self.in_layer)?.silu()?.apply(&self.out_layer)?)
+    }
+}
+
+struct ModulationOut {
+    shift: Tensor,
+    scale: Tensor,
+    gate: Tensor,
+}
+
+impl ModulationOut {
+    fn scale_shift(&self, xs: &Tensor) -> Result<Tensor> {
+        Ok(xs
+            .broadcast_mul(&(&self.scale + 1.)?)?
+            .broadcast_add(&self.shift)?)
+    }
+    fn gate(&self, xs: &Tensor) -> Result<Tensor> {
+        Ok(self.gate.broadcast_mul(xs)?)
+    }
+}
+
+struct Modulation1 {
+    lin: Linear,
+}
+
+impl Modulation1 {
+    fn new(vb: &VarBuilder, name: &str, dtype: DType, device: &Device) -> Result<Self> {
+        Ok(Self {
+            lin: dequant_linear(vb, &format!("{name}.lin.weight"), dtype, device)?,
+        })
+    }
+    fn forward(&self, vec_: &Tensor) -> Result<ModulationOut> {
+        let ys = vec_
+            .silu()?
+            .apply(&self.lin)?
+            .unsqueeze(1)?
+            .chunk(3, D::Minus1)?;
+        Ok(ModulationOut {
+            shift: ys[0].clone(),
+            scale: ys[1].clone(),
+            gate: ys[2].clone(),
+        })
+    }
+}
+
+struct Modulation2 {
+    lin: Linear,
+}
+
+impl Modulation2 {
+    fn new(vb: &VarBuilder, name: &str, dtype: DType, device: &Device) -> Result<Self> {
+        Ok(Self {
+            lin: dequant_linear(vb, &format!("{name}.lin.weight"), dtype, device)?,
+        })
+    }
+    fn forward(&self, vec_: &Tensor) -> Result<(ModulationOut, ModulationOut)> {
+        let ys = vec_
+            .silu()?
+            .apply(&self.lin)?
+            .unsqueeze(1)?
+            .chunk(6, D::Minus1)?;
+        Ok((
+            ModulationOut {
+                shift: ys[0].clone(),
+                scale: ys[1].clone(),
+                gate: ys[2].clone(),
+            },
+            ModulationOut {
+                shift: ys[3].clone(),
+                scale: ys[4].clone(),
+                gate: ys[5].clone(),
+            },
+        ))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// DoubleStreamBlock
+// ---------------------------------------------------------------------------
+
+struct QDoubleStreamBlock {
+    img_qkv: Linear,
+    img_proj: Linear,
+    img_q_norm: RmsNorm,
+    img_k_norm: RmsNorm,
+    img_norm1: LayerNorm,
+    img_mlp_in: Linear,
+    img_mlp_out: Linear,
+    img_norm2: LayerNorm,
+    txt_qkv: Linear,
+    txt_proj: Linear,
+    txt_q_norm: RmsNorm,
+    txt_k_norm: RmsNorm,
+    txt_norm1: LayerNorm,
+    txt_mlp_in: Linear,
+    txt_mlp_out: Linear,
+    txt_norm2: LayerNorm,
+    num_heads: usize,
+    mlp_sz: usize,
+}
+
+impl QDoubleStreamBlock {
+    fn new(
+        cfg: &Flux2Config,
+        vb: &VarBuilder,
+        prefix: &str,
+        dtype: DType,
+        device: &Device,
+    ) -> Result<Self> {
+        let h_sz = cfg.hidden_size;
+        let mlp_sz = (h_sz as f64 * cfg.mlp_ratio) as usize;
+        let p = |suffix: &str| format!("{prefix}.{suffix}");
+
+        Ok(Self {
+            img_qkv: dequant_linear(vb, &p("img_attn.qkv.weight"), dtype, device)?,
+            img_proj: dequant_linear(vb, &p("img_attn.proj.weight"), dtype, device)?,
+            img_q_norm: RmsNorm::new(
+                dequant_tensor(vb, &p("img_attn.norm.query_norm.scale"), dtype, device)?,
+                1e-6,
+            ),
+            img_k_norm: RmsNorm::new(
+                dequant_tensor(vb, &p("img_attn.norm.key_norm.scale"), dtype, device)?,
+                1e-6,
+            ),
+            img_norm1: make_layer_norm(h_sz, dtype, device)?,
+            img_mlp_in: dequant_linear(vb, &p("img_mlp.0.weight"), dtype, device)?,
+            img_mlp_out: dequant_linear(vb, &p("img_mlp.2.weight"), dtype, device)?,
+            img_norm2: make_layer_norm(h_sz, dtype, device)?,
+            txt_qkv: dequant_linear(vb, &p("txt_attn.qkv.weight"), dtype, device)?,
+            txt_proj: dequant_linear(vb, &p("txt_attn.proj.weight"), dtype, device)?,
+            txt_q_norm: RmsNorm::new(
+                dequant_tensor(vb, &p("txt_attn.norm.query_norm.scale"), dtype, device)?,
+                1e-6,
+            ),
+            txt_k_norm: RmsNorm::new(
+                dequant_tensor(vb, &p("txt_attn.norm.key_norm.scale"), dtype, device)?,
+                1e-6,
+            ),
+            txt_norm1: make_layer_norm(h_sz, dtype, device)?,
+            txt_mlp_in: dequant_linear(vb, &p("txt_mlp.0.weight"), dtype, device)?,
+            txt_mlp_out: dequant_linear(vb, &p("txt_mlp.2.weight"), dtype, device)?,
+            txt_norm2: make_layer_norm(h_sz, dtype, device)?,
+            num_heads: cfg.num_heads,
+            mlp_sz,
+        })
+    }
+
+    fn qkv_from_fused(
+        &self,
+        xs: &Tensor,
+        qkv_proj: &Linear,
+        q_norm: &RmsNorm,
+        k_norm: &RmsNorm,
+    ) -> Result<(Tensor, Tensor, Tensor)> {
+        let (b, l, _) = xs.dims3()?;
+        let qkv = xs.apply(qkv_proj)?;
+        let qkv = qkv.reshape((b, l, 3, self.num_heads, ()))?;
+        let q = qkv.i((.., .., 0))?.transpose(1, 2)?.apply(q_norm)?;
+        let k = qkv.i((.., .., 1))?.transpose(1, 2)?.apply(k_norm)?;
+        let v = qkv.i((.., .., 2))?.transpose(1, 2)?;
+        Ok((q, k, v))
+    }
+
+    fn mlp_swiglu(&self, xs: &Tensor, mlp_in: &Linear, mlp_out: &Linear) -> Result<Tensor> {
+        let x = xs.apply(mlp_in)?;
+        let gate = x.narrow(D::Minus1, 0, self.mlp_sz)?.silu()?;
+        let val = x.narrow(D::Minus1, self.mlp_sz, self.mlp_sz)?;
+        (gate * val)?.apply(mlp_out).map_err(Into::into)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn forward(
+        &self,
+        img: &Tensor,
+        txt: &Tensor,
+        img_mod1: &ModulationOut,
+        img_mod2: &ModulationOut,
+        txt_mod1: &ModulationOut,
+        txt_mod2: &ModulationOut,
+        pe: &Tensor,
+    ) -> Result<(Tensor, Tensor)> {
+        let img_modulated = img_mod1.scale_shift(&img.apply(&self.img_norm1)?)?;
+        let (img_q, img_k, img_v) = self.qkv_from_fused(
+            &img_modulated,
+            &self.img_qkv,
+            &self.img_q_norm,
+            &self.img_k_norm,
+        )?;
+        let txt_modulated = txt_mod1.scale_shift(&txt.apply(&self.txt_norm1)?)?;
+        let (txt_q, txt_k, txt_v) = self.qkv_from_fused(
+            &txt_modulated,
+            &self.txt_qkv,
+            &self.txt_q_norm,
+            &self.txt_k_norm,
+        )?;
+
+        let q = Tensor::cat(&[txt_q, img_q], 2)?;
+        let k = Tensor::cat(&[txt_k, img_k], 2)?;
+        let v = Tensor::cat(&[txt_v, img_v], 2)?;
+        let attn = attention(&q, &k, &v, pe)?;
+        let txt_attn_out = attn.narrow(1, 0, txt.dim(1)?)?;
+        let img_attn_out = attn.narrow(1, txt.dim(1)?, attn.dim(1)? - txt.dim(1)?)?;
+
+        let img = (img + img_mod1.gate(&img_attn_out.apply(&self.img_proj)?)?)?;
+        let img = (&img
+            + img_mod2.gate(&self.mlp_swiglu(
+                &img_mod2.scale_shift(&img.apply(&self.img_norm2)?)?,
+                &self.img_mlp_in,
+                &self.img_mlp_out,
+            )?)?)?;
+        let txt = (txt + txt_mod1.gate(&txt_attn_out.apply(&self.txt_proj)?)?)?;
+        let txt = (&txt
+            + txt_mod2.gate(&self.mlp_swiglu(
+                &txt_mod2.scale_shift(&txt.apply(&self.txt_norm2)?)?,
+                &self.txt_mlp_in,
+                &self.txt_mlp_out,
+            )?)?)?;
+
+        Ok((img, txt))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SingleStreamBlock
+// ---------------------------------------------------------------------------
+
+struct QSingleStreamBlock {
+    linear1: Linear,
+    linear2: Linear,
+    norm_q: RmsNorm,
+    norm_k: RmsNorm,
+    pre_norm: LayerNorm,
+    h_sz: usize,
+    mlp_sz: usize,
+    num_heads: usize,
+}
+
+impl QSingleStreamBlock {
+    fn new(
+        cfg: &Flux2Config,
+        vb: &VarBuilder,
+        prefix: &str,
+        dtype: DType,
+        device: &Device,
+    ) -> Result<Self> {
+        let h_sz = cfg.hidden_size;
+        let mlp_sz = (h_sz as f64 * cfg.mlp_ratio) as usize;
+
+        Ok(Self {
+            linear1: dequant_linear(vb, &format!("{prefix}.linear1.weight"), dtype, device)?,
+            linear2: dequant_linear(vb, &format!("{prefix}.linear2.weight"), dtype, device)?,
+            norm_q: RmsNorm::new(
+                dequant_tensor(
+                    vb,
+                    &format!("{prefix}.norm.query_norm.scale"),
+                    dtype,
+                    device,
+                )?,
+                1e-6,
+            ),
+            norm_k: RmsNorm::new(
+                dequant_tensor(vb, &format!("{prefix}.norm.key_norm.scale"), dtype, device)?,
+                1e-6,
+            ),
+            pre_norm: make_layer_norm(h_sz, dtype, device)?,
+            h_sz,
+            mlp_sz,
+            num_heads: cfg.num_heads,
+        })
+    }
+
+    fn forward(&self, xs: &Tensor, mod_out: &ModulationOut, pe: &Tensor) -> Result<Tensor> {
+        let x_mod = mod_out.scale_shift(&xs.apply(&self.pre_norm)?)?;
+        let x_mod = x_mod.apply(&self.linear1)?;
+        let qkv = x_mod.narrow(D::Minus1, 0, 3 * self.h_sz)?;
+        let (b, l, _) = qkv.dims3()?;
+        let qkv = qkv.reshape((b, l, 3, self.num_heads, ()))?;
+        let q = qkv.i((.., .., 0))?.transpose(1, 2)?.apply(&self.norm_q)?;
+        let k = qkv.i((.., .., 1))?.transpose(1, 2)?.apply(&self.norm_k)?;
+        let v = qkv.i((.., .., 2))?.transpose(1, 2)?;
+        let mlp_portion = x_mod.narrow(D::Minus1, 3 * self.h_sz, self.mlp_sz * 2)?;
+        let attn = attention(&q, &k, &v, pe)?;
+        let mlp_gate = mlp_portion.narrow(D::Minus1, 0, self.mlp_sz)?.silu()?;
+        let mlp_val = mlp_portion.narrow(D::Minus1, self.mlp_sz, self.mlp_sz)?;
+        let mlp_out = (mlp_gate * mlp_val)?;
+        let output = Tensor::cat(&[attn, mlp_out], 2)?.apply(&self.linear2)?;
+        Ok((xs + mod_out.gate(&output)?)?)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// LastLayer
+// ---------------------------------------------------------------------------
+
+struct QLastLayer {
+    norm_final: LayerNorm,
+    linear: Linear,
+    ada_ln_modulation: Linear,
+}
+
+impl QLastLayer {
+    fn new(vb: &VarBuilder, dtype: DType, h_sz: usize, device: &Device) -> Result<Self> {
+        Ok(Self {
+            norm_final: make_layer_norm(h_sz, dtype, device)?,
+            linear: dequant_linear(vb, "final_layer.linear.weight", dtype, device)?,
+            ada_ln_modulation: dequant_linear(
+                vb,
+                "final_layer.adaLN_modulation.1.weight",
+                dtype,
+                device,
+            )?,
+        })
+    }
+    fn forward(&self, xs: &Tensor, vec: &Tensor) -> Result<Tensor> {
+        let chunks = vec.silu()?.apply(&self.ada_ln_modulation)?.chunk(2, 1)?;
+        // BFL format: shift first, scale second (opposite of diffusers format)
+        let (shift, scale) = (&chunks[0], &chunks[1]);
+        let xs = xs
+            .apply(&self.norm_final)?
+            .broadcast_mul(&(scale.unsqueeze(1)? + 1.0)?)?
+            .broadcast_add(&shift.unsqueeze(1)?)?;
+        xs.apply(&self.linear).map_err(Into::into)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// QuantizedFlux2Transformer
+// ---------------------------------------------------------------------------
+
+/// Flux.2 Klein transformer loaded from GGUF.
+///
+/// Weights are dequantized on CPU to BF16, then moved to GPU. Inference uses
+/// standard `candle_nn::Linear` (BF16 matmul), giving identical precision to
+/// the BF16 safetensors path. GGUF advantage: smaller download (Q8: 4.3GB vs 7.7GB).
+pub(crate) struct QuantizedFlux2Transformer {
+    img_in: Linear,
+    txt_in: Linear,
+    time_in: MlpEmbedder,
+    pe_embedder: EmbedNd,
+    double_mod_img: Modulation2,
+    double_mod_txt: Modulation2,
+    single_mod: Modulation1,
+    double_blocks: Vec<QDoubleStreamBlock>,
+    single_blocks: Vec<QSingleStreamBlock>,
+    final_layer: QLastLayer,
+}
+
+impl QuantizedFlux2Transformer {
+    /// Load from a GGUF VarBuilder (on CPU). Dequantizes to `gpu_dtype` and moves to `device`.
+    pub fn new(
+        cfg: &Flux2Config,
+        vb: VarBuilder,
+        gpu_dtype: DType,
+        device: &Device,
+    ) -> Result<Self> {
+        let dtype = gpu_dtype;
+        let img_in = dequant_linear(&vb, "img_in.weight", dtype, device)?;
+        let txt_in = dequant_linear(&vb, "txt_in.weight", dtype, device)?;
+        let time_in = MlpEmbedder::new(&vb, "time_in", dtype, device)?;
+
+        let double_mod_img = Modulation2::new(&vb, "double_stream_modulation_img", dtype, device)?;
+        let double_mod_txt = Modulation2::new(&vb, "double_stream_modulation_txt", dtype, device)?;
+        let single_mod = Modulation1::new(&vb, "single_stream_modulation", dtype, device)?;
+
+        let mut double_blocks = Vec::with_capacity(cfg.depth);
+        for i in 0..cfg.depth {
+            double_blocks.push(QDoubleStreamBlock::new(
+                cfg,
+                &vb,
+                &format!("double_blocks.{i}"),
+                dtype,
+                device,
+            )?);
+        }
+
+        let mut single_blocks = Vec::with_capacity(cfg.depth_single_blocks);
+        for i in 0..cfg.depth_single_blocks {
+            single_blocks.push(QSingleStreamBlock::new(
+                cfg,
+                &vb,
+                &format!("single_blocks.{i}"),
+                dtype,
+                device,
+            )?);
+        }
+
+        let final_layer = QLastLayer::new(&vb, dtype, cfg.hidden_size, device)?;
+        let pe_embedder = EmbedNd::new(cfg.theta, cfg.axes_dim.to_vec());
+
+        Ok(Self {
+            img_in,
+            txt_in,
+            time_in,
+            pe_embedder,
+            double_mod_img,
+            double_mod_txt,
+            single_mod,
+            double_blocks,
+            single_blocks,
+            final_layer,
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn forward(
+        &self,
+        img: &Tensor,
+        img_ids: &Tensor,
+        txt: &Tensor,
+        txt_ids: &Tensor,
+        timesteps: &Tensor,
+        _y: &Tensor,
+        _guidance: Option<&Tensor>,
+    ) -> Result<Tensor> {
+        if txt.rank() != 3 || img.rank() != 3 {
+            anyhow::bail!("expected rank 3, got txt={} img={}", txt.rank(), img.rank())
+        }
+        let dtype = img.dtype();
+
+        let pe = {
+            let ids = Tensor::cat(&[txt_ids, img_ids], 1)?;
+            ids.apply(&self.pe_embedder)?
+        };
+        let mut txt = txt.apply(&self.txt_in)?;
+        let mut img = img.apply(&self.img_in)?;
+        let vec_ = self
+            .time_in
+            .forward(&timestep_embedding(timesteps, 256, dtype)?)?;
+
+        let (img_mod1, img_mod2) = self.double_mod_img.forward(&vec_)?;
+        let (txt_mod1, txt_mod2) = self.double_mod_txt.forward(&vec_)?;
+
+        for block in &self.double_blocks {
+            (img, txt) =
+                block.forward(&img, &txt, &img_mod1, &img_mod2, &txt_mod1, &txt_mod2, &pe)?;
+        }
+
+        let single_mod = self.single_mod.forward(&vec_)?;
+        let mut img = Tensor::cat(&[&txt, &img], 1)?;
+        for block in &self.single_blocks {
+            img = block.forward(&img, &single_mod, &pe)?;
+        }
+        let img = img.i((.., txt.dim(1)?..))?;
+        self.final_layer.forward(&img, &vec_)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candle_core::Device;
+
+    /// Verify that GGUF QLastLayer uses BFL ordering (shift, scale) not diffusers (scale, shift).
+    ///
+    /// The BFL reference code unpacks adaLN_modulation output as:
+    ///   shift, scale = self.adaLN_modulation(c).chunk(2, dim=1)
+    /// while diffusers uses:
+    ///   scale, shift = ...chunk(2, dim=1)
+    ///
+    /// GGUF files use BFL naming/convention, so the quantized transformer must use
+    /// BFL ordering. Getting this wrong causes ~3x output amplitude divergence.
+    /// Verify QLastLayer uses BFL ordering (shift, scale) not diffusers (scale, shift).
+    ///
+    /// Constructs a layer where the first half of ada_ln output is nonzero (intended
+    /// as shift in BFL) and the second half is zero. With non-uniform input, the two
+    /// orderings produce numerically different results:
+    ///   BFL:      result = norm(xs) * (0 + 1) + shift   = norm(xs) + shift
+    ///   diffusers: result = norm(xs) * (shift + 1) + 0  = norm(xs) * (shift + 1)
+    #[test]
+    fn qlast_layer_uses_bfl_shift_scale_ordering() {
+        let device = Device::Cpu;
+        let dtype = DType::F32;
+        let h_sz = 8;
+        let out_c = 4;
+
+        // ada_ln weight: first h_sz rows = identity (produces silu(vec)·1 ≈ 0.73),
+        // second h_sz rows = zeros. So chunks[0] ≈ 0.73, chunks[1] = 0.
+        let mut ada_data = vec![0f32; 2 * h_sz * h_sz];
+        for i in 0..h_sz {
+            ada_data[i * h_sz + i] = 1.0;
+        }
+        let ada_w = Tensor::from_vec(ada_data, (2 * h_sz, h_sz), &device).unwrap();
+
+        let layer = QLastLayer {
+            norm_final: make_layer_norm(h_sz, dtype, &device).unwrap(),
+            linear: Linear::new(Tensor::ones((out_c, h_sz), dtype, &device).unwrap(), None),
+            ada_ln_modulation: Linear::new(ada_w, None),
+        };
+
+        // Non-uniform input so norm(xs) != 1, making the two orderings distinguishable
+        let xs_data: Vec<f32> = (0..2 * h_sz).map(|i| (i as f32) * 0.3 + 0.1).collect();
+        let xs = Tensor::from_vec(xs_data, (1, 2, h_sz), &device).unwrap();
+        let vec = Tensor::ones((1, h_sz), dtype, &device).unwrap();
+
+        let out = layer.forward(&xs, &vec).unwrap();
+        let out_vals: Vec<f32> = out.flatten_all().unwrap().to_vec1().unwrap();
+
+        // Compute expected BFL result manually:
+        // shift ≈ silu(1.0) = 0.7311 per element, scale = 0
+        // result_elem = norm(xs_elem) * (0 + 1) + 0.7311
+        // With diffusers ordering it would be: norm(xs_elem) * (0.7311 + 1) + 0
+        // These differ when norm(xs) != 1.
+        let silu_1 = 1.0_f32 / (1.0 + (-1.0_f32).exp()); // silu(1) ≈ 0.7311
+
+        // For BFL: each output element = sum_over_h_sz(norm_elem + silu_1) = sum(norm) + h_sz * silu_1
+        // For diffusers: each output element = sum_over_h_sz(norm_elem * (silu_1 + 1)) = sum(norm) * (silu_1 + 1)
+        // These are only equal when sum(norm) = h_sz * silu_1 / silu_1 = h_sz, i.e. norm=1.
+        // With our non-uniform input, norm != 1, so they differ.
+        for v in &out_vals {
+            assert!(v.is_finite(), "QLastLayer output contains non-finite: {v}");
+        }
+
+        // Verify we get the BFL result, not the diffusers result.
+        // Pick the first output element (sum over h_sz of the first token's processed values).
+        let first = out_vals[0];
+        // The BFL result includes an additive shift term. With scale=0, the multiplication
+        // factor is exactly 1.0, so the output is: sum(norm(xs[0])) + h_sz * silu_1.
+        // The diffusers result would multiply by (silu_1 + 1) with no additive term.
+        // The additive shift makes BFL output LARGER than pure multiplicative scaling
+        // when norm values are small (our input starts at 0.1).
+        let expected_shift_contribution = h_sz as f32 * silu_1;
+        // If the shift is additive (BFL), subtracting it should leave just sum(norm).
+        // If the shift is multiplicative (diffusers), the value structure is different.
+        // Assert the output is consistent with additive shift (BFL ordering).
+        assert!(
+            (first - expected_shift_contribution).abs() < first.abs(),
+            "Output {first} not consistent with BFL additive shift of {expected_shift_contribution}"
+        );
+    }
+}

--- a/crates/mold-inference/src/flux2/transformer.rs
+++ b/crates/mold-inference/src/flux2/transformer.rs
@@ -62,7 +62,7 @@ fn layer_norm(dim: usize, vb: &VarBuilder) -> Result<LayerNorm> {
     Ok(LayerNorm::new_no_bias(ws, 1e-6))
 }
 
-fn scaled_dot_product_attention(q: &Tensor, k: &Tensor, v: &Tensor) -> Result<Tensor> {
+pub(crate) fn scaled_dot_product_attention(q: &Tensor, k: &Tensor, v: &Tensor) -> Result<Tensor> {
     let dim = q.dim(D::Minus1)?;
     let scale_factor = 1.0 / (dim as f64).sqrt();
     let mut batch_dims = q.dims().to_vec();
@@ -78,7 +78,7 @@ fn scaled_dot_product_attention(q: &Tensor, k: &Tensor, v: &Tensor) -> Result<Te
     attn_scores.reshape(batch_dims)
 }
 
-fn rope(pos: &Tensor, dim: usize, theta: usize) -> Result<Tensor> {
+pub(crate) fn rope(pos: &Tensor, dim: usize, theta: usize) -> Result<Tensor> {
     if dim % 2 == 1 {
         candle_core::bail!("dim {dim} is odd")
     }
@@ -99,7 +99,7 @@ fn rope(pos: &Tensor, dim: usize, theta: usize) -> Result<Tensor> {
     out.reshape((b, n, d, 2, 2))
 }
 
-fn apply_rope(x: &Tensor, freq_cis: &Tensor) -> Result<Tensor> {
+pub(crate) fn apply_rope(x: &Tensor, freq_cis: &Tensor) -> Result<Tensor> {
     let dims = x.dims();
     let (b_sz, n_head, seq_len, n_embd) = x.dims4()?;
     let x = x.reshape((b_sz, n_head, seq_len, n_embd / 2, 2))?;
@@ -110,14 +110,14 @@ fn apply_rope(x: &Tensor, freq_cis: &Tensor) -> Result<Tensor> {
     (fr0.broadcast_mul(&x0)? + fr1.broadcast_mul(&x1)?)?.reshape(dims.to_vec())
 }
 
-fn attention(q: &Tensor, k: &Tensor, v: &Tensor, pe: &Tensor) -> Result<Tensor> {
+pub(crate) fn attention(q: &Tensor, k: &Tensor, v: &Tensor, pe: &Tensor) -> Result<Tensor> {
     let q = apply_rope(q, pe)?.contiguous()?;
     let k = apply_rope(k, pe)?.contiguous()?;
     let x = scaled_dot_product_attention(&q, &k, v)?;
     x.transpose(1, 2)?.flatten_from(2)
 }
 
-fn timestep_embedding(t: &Tensor, dim: usize, dtype: DType) -> Result<Tensor> {
+pub(crate) fn timestep_embedding(t: &Tensor, dim: usize, dtype: DType) -> Result<Tensor> {
     const TIME_FACTOR: f64 = 1000.;
     const MAX_PERIOD: f64 = 10000.;
     if dim % 2 == 1 {
@@ -140,13 +140,13 @@ fn timestep_embedding(t: &Tensor, dim: usize, dtype: DType) -> Result<Tensor> {
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Clone)]
-struct EmbedNd {
+pub(crate) struct EmbedNd {
     theta: usize,
     axes_dim: Vec<usize>,
 }
 
 impl EmbedNd {
-    fn new(theta: usize, axes_dim: Vec<usize>) -> Self {
+    pub(crate) fn new(theta: usize, axes_dim: Vec<usize>) -> Self {
         Self { theta, axes_dim }
     }
 }
@@ -681,12 +681,13 @@ impl Flux2Transformer {
 }
 
 // ---------------------------------------------------------------------------
-// Wrapper enum for BF16 (future: GGUF quantized)
+// Wrapper enum for BF16 and GGUF quantized
 // ---------------------------------------------------------------------------
 
 #[allow(clippy::large_enum_variant)]
 pub(crate) enum Flux2TransformerWrapper {
     BF16(Flux2Transformer),
+    Quantized(super::quantized_transformer::QuantizedFlux2Transformer),
 }
 
 impl Flux2TransformerWrapper {
@@ -721,6 +722,15 @@ impl Flux2TransformerWrapper {
 
             let pred = match self {
                 Self::BF16(m) => m.forward(
+                    &img,
+                    img_ids,
+                    txt,
+                    txt_ids,
+                    &t_vec,
+                    vec_,
+                    Some(&guidance_tensor),
+                )?,
+                Self::Quantized(m) => m.forward(
                     &img,
                     img_ids,
                     txt,


### PR DESCRIPTION
## Summary

Brings Flux.2 Klein from alpha to production quality by fixing three critical issues:

- **Native BF16 Qwen3 encoder** with proper multi-layer extraction (layers 9/18/27) — the upstream `ZImageTextEncoder` only returned the penultimate layer, so BF16 users got three identical copies instead of distinct layer representations
- **GGUF quantized transformer loading** (Q8/Q6/Q4) — was completely missing, causing "header too large" errors. Dequantizes to BF16 at load time using `candle_nn::Linear` for identical inference precision
- **Fixed scale/shift swap in GGUF final layer** — BFL format outputs `(shift, scale)` but code was treating it as diffusers' `(scale, shift)`, causing 3x output amplitude divergence and visible dithering artifacts

Also removes `[alpha]` status, updates docs/skills, and adds guidance logging.

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes  
- [x] `cargo test --workspace` — 644 tests pass (including new `qlast_layer_uses_bfl_shift_scale_ordering` test)
- [x] `mold run flux2-klein:q8 "prompt" --preview` produces photorealistic output
- [x] `mold run flux2-klein:bf16 "prompt" --preview` produces photorealistic output
- [x] GGUF VRAM usage matches BF16 (dequantizes to gpu_dtype, not F32)
- [x] Bare `flux2-klein` resolves to `:q8` (preserves existing installs)