### PR TITLE
fix(discord): prevent seed word-wrap and group models by family

### DIFF
--- a/crates/mold-discord/src/format.rs
+++ b/crates/mold-discord/src/format.rs
@@ -131,8 +131,9 @@ pub fn format_generation_result(resp: &GenerateResponse, prompt: &str) -> EmbedD
 }
 
 /// Format the model list into embed data, grouped by family.
-/// Downloaded/loaded models are shown inline; undownloaded models are collapsed
-/// into a count per family so all families (including alpha) remain visible.
+/// Downloaded/loaded models are shown in bold; undownloaded models are shown in
+/// plain text. All models in every family are listed individually.
+/// Alpha families are tagged with `(alpha)` in the section header.
 pub fn format_model_list(models: &[ModelInfoExtended]) -> EmbedData {
     if models.is_empty() {
         return EmbedData {


### PR DESCRIPTION
## Summary

- Move Seed to a full-width (non-inline) embed field so long u64 seed values don't wrap mid-number on narrow Discord views
- Group `/models` output by model family (FLUX, SD3, SD1.5, etc.) with bold names for downloaded/loaded models and plain text for undownloaded variants
- Tag alpha families (Z-Image, Flux.2, Qwen-Image, Wuerstchen) with `(alpha)` in the header
- All model families now visible within Discord's 4000-char embed description limit

## Test plan

- [x] `cargo test -p mold-ai-discord` — 34 tests pass
- [x] `cargo clippy -p mold-ai-discord` — no warnings
- [x] `cargo fmt --check` — clean
- [ ] Visual verification in Discord after deploy