### PR TITLE
fix(nix): put real NVIDIA driver ahead of stubs in LIBRARY_PATH

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -257,14 +257,18 @@
               {
                 name = "LIBRARY_PATH";
                 value =
-                  lib.makeLibraryPath [
+                  # /run/opengl-driver/lib MUST come before cuda_cudart/lib/stubs
+                  # so the real libcuda.so (NVIDIA driver) is found before the
+                  # stub placeholder. Without this, debug builds link against
+                  # the stub and fail at runtime with CUDA_ERROR_STUB_LIBRARY.
+                  "/run/opengl-driver/lib:"
+                  + lib.makeLibraryPath [
                     pkgs.cudaPackages.cuda_cudart
                     pkgs.cudaPackages.libcublas.lib
                     pkgs.cudaPackages.cuda_nvrtc.lib
                     pkgs.cudaPackages.libcurand.lib
                   ]
-                  + ":${pkgs.cudaPackages.cuda_cudart}/lib/stubs"
-                  + ":/run/opengl-driver/lib";
+                  + ":${pkgs.cudaPackages.cuda_cudart}/lib/stubs";
               }
               {
                 name = "LD_LIBRARY_PATH";


### PR DESCRIPTION
## Summary

Fix `CUDA_ERROR_STUB_LIBRARY` runtime error when running `mold run --local` from the devshell.

## Root Cause

The devshell's `LIBRARY_PATH` had `cuda_cudart/lib/stubs` before `/run/opengl-driver/lib`. The linker picked up the stub `libcuda.so` (105K placeholder) instead of the real NVIDIA driver library, causing debug builds to fail at runtime with `CUDA_ERROR_STUB_LIBRARY`.

## Fix

Move `/run/opengl-driver/lib` to the front of `LIBRARY_PATH` so the real `libcuda.so` is found first. Stubs remain at the end as a fallback for the linker to resolve symbols against.

`LD_LIBRARY_PATH` (runtime) already had the correct order — this only affected `LIBRARY_PATH` (link-time).

## Test plan

- [x] `direnv reload` then `echo $LIBRARY_PATH` shows `/run/opengl-driver/lib` before stubs
- [x] `cargo build -p mold-ai --features cuda,preview,discord` links against real driver
- [x] `mold run flux-dev:bf16 "test" --local --preview` runs without CUDA_ERROR_STUB_LIBRARY