### PR TITLE
fix(rm): scope orphan cleanup to runtime GGUF cache dirs only

### DIFF
--- a/crates/mold-cli/src/commands/rm.rs
+++ b/crates/mold-cli/src/commands/rm.rs
@@ -108,6 +108,10 @@ fn collect_hf_cache_blob_paths(
     blobs
 }
 
+/// Runtime GGUF cache subdirectories under `shared/` that may contain
+/// auto-downloaded quantized encoders not tracked in config.toml.
+const RUNTIME_GGUF_CACHE_DIRS: &[&str] = &["t5-gguf", "qwen3-gguf"];
+
 /// Remove orphaned files from runtime GGUF cache directories under `shared/`
 /// that are not referenced by any remaining model config entry, then clean up
 /// empty directories under `shared/`.
@@ -120,8 +124,6 @@ fn collect_hf_cache_blob_paths(
 /// Only the known runtime cache directories are scanned — other shared dirs
 /// (e.g. `shared/flux/`, `shared/sdxl/`) are left alone because manifest-discovered
 /// models may reference those files without having an explicit config entry.
-const RUNTIME_GGUF_CACHE_DIRS: &[&str] = &["t5-gguf", "qwen3-gguf"];
-
 fn clean_orphaned_shared_files(config: &Config) {
     let models_dir = config.resolved_models_dir();
     let shared_dir = models_dir.join("shared");


### PR DESCRIPTION
## Summary

Follow-up to #80 — addresses a P1 found during Codex peer review.

- Restrict orphan file cleanup to `shared/t5-gguf/` and `shared/qwen3-gguf/` (runtime GGUF cache dirs) instead of walking all of `shared/`
- Files in `shared/flux/`, `shared/sdxl/`, etc. are no longer touched, protecting manifest-discovered models that may lack explicit config entries

## Root Cause

The original fix (#80) scanned all of `shared/` and deleted files not found in `config.models`. But manifest-discovered models can exist on disk without a config entry (via `Config::manifest_model_is_downloaded()` / `discovered_manifest_paths()`), and their shared assets in `shared/flux/` etc. would be incorrectly treated as orphans.

## Test Plan

- [x] `orphaned_gguf_cache_files_deleted_when_unreferenced` — GGUF orphans in cache dirs are deleted
- [x] `scoped_cleanup_does_not_touch_non_cache_shared_dirs` — files in shared/flux/ survive even when unreferenced
- [x] All 37 tests pass, clippy clean, fmt clean

Ref #78