### PR TITLE
fix(weight_loader): load via CPU when dtype conversion needed

### DIFF
--- a/crates/mold-inference/src/weight_loader.rs
+++ b/crates/mold-inference/src/weight_loader.rs
@@ -55,12 +55,18 @@ pub fn load_safetensors_with_progress<'a>(
 
     let mut tensor_map: HashMap<String, Tensor> = HashMap::with_capacity(tensor_list.len());
     for (name, byte_size) in &tensor_list {
-        // Load tensor from mmap (triggers page fault → disk read → device transfer)
-        let tensor = st.load(name, device)?;
-        let tensor = if tensor.dtype() != dtype {
-            tensor.to_dtype(dtype)?
+        let needs_conversion = st.get(name).is_ok_and(|v| v.dtype() != dtype.into());
+        let tensor = if needs_conversion {
+            // On-disk dtype differs from target: load to CPU, convert, transfer.
+            // We avoid calling to_dtype() on a GPU tensor because the CUDA
+            // type-conversion kernel can conflict with GGUF quantized kernel
+            // contexts loaded on the same device.
+            st.load(name, &candle_core::Device::Cpu)?
+                .to_dtype(dtype)?
+                .to_device(device)?
         } else {
-            tensor
+            // On-disk dtype matches target — load directly to device.
+            st.load(name, device)?
         };
         tensor_map.insert(name.clone(), tensor);
 


### PR DESCRIPTION
## Summary

- Fixes `CUDA_ERROR_NOT_FOUND: "named symbol not found"` when running `flux2-klein:q4` (and other GGUF models with safetensors VAE)
- Root cause: `load_safetensors_with_progress` loaded tensors to GPU in on-disk dtype (F32), then called `to_dtype(BF16)` on-device, triggering CUDA type-conversion kernels that conflicted with GGUF quantized kernel contexts
- Fix: when dtype conversion is needed, load to CPU first, convert there, transfer to GPU. When dtypes match (common case), load directly to device — no performance regression

## Test plan

- [x] `cargo check` / `cargo clippy` / `cargo fmt --check` / `cargo test --workspace` — all pass
- [x] Manual: `flux2-klein:q4` generates successfully (was crashing before)
- [x] Manual: `flux-schnell:q8` generates successfully (fast path, no dtype conversion)
- [x] Manual: `flux-dev:q6 --lora` generates successfully (LoRA not broken)

Fixes #96