### PR TITLE
fix(tui): info panel crash on multi-byte model descriptions

### DIFF
--- a/crates/mold-tui/src/ui/info.rs
+++ b/crates/mold-tui/src/ui/info.rs
@@ -208,7 +208,7 @@ mod tests {
             let max = width as usize - 2;
             let boundary = desc.floor_char_boundary(max);
             let truncated = format!("{}..", &desc[..boundary]);
-            assert!(truncated.len() <= width as usize + 2); // +2 for ".."
+            assert!(truncated.len() <= width as usize);
             assert!(truncated.ends_with(".."));
         }
     }


### PR DESCRIPTION
## Summary

- Fix panic when truncating model descriptions containing multi-byte UTF-8 characters (e.g., em dash `—`) in the info panel
- Use `str::floor_char_boundary()` instead of raw byte indexing to find a valid truncation point
- Add regression test for multi-byte truncation

Closes #159