### PR TITLE
Release 0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.2] - 2026-04-03
+
+### Fixed
+
+- **TUI metadata race condition**: switching models while a generation was running caused the saved image to record the newly selected model instead of the model that actually generated it; now uses `response.model` from the server as source of truth ([#161](https://github.com/utensils/mold/issues/161), [#163](https://github.com/utensils/mold/pull/163))
+- **TUI batch mode**: setting batch > 1 in the TUI had no effect — only one image was generated; now loops client-side with seed increment, matching CLI behavior ([#162](https://github.com/utensils/mold/issues/162), [#163](https://github.com/utensils/mold/pull/163))
+- **SSE protocol**: `SseCompleteEvent` now includes the `model` field so the server confirms which model generated the image; backward-compatible with older servers via `#[serde(default)]`
+
 ## [0.5.1] - 2026-04-03
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2692,7 +2692,7 @@ dependencies = [
 
 [[package]]
 name = "mold-ai"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -2722,7 +2722,7 @@ dependencies = [
 
 [[package]]
 name = "mold-ai-core"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2745,7 +2745,7 @@ dependencies = [
 
 [[package]]
 name = "mold-ai-discord"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "mold-ai-core",
@@ -2759,7 +2759,7 @@ dependencies = [
 
 [[package]]
 name = "mold-ai-inference"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "candle-core-mold",
@@ -2781,7 +2781,7 @@ dependencies = [
 
 [[package]]
 name = "mold-ai-server"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -2811,7 +2811,7 @@ dependencies = [
 
 [[package]]
 name = "mold-ai-tui"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "crossterm 0.28.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 license = "MIT"
 authors = ["James Brink <brink.james@gmail.com>"]


### PR DESCRIPTION
## Summary

Patch release with two TUI bug fixes from #163.

### Fixed

- **TUI metadata race condition**: switching models during generation recorded the wrong model in saved image metadata (#161)
- **TUI batch mode**: setting batch > 1 generated only one image instead of the requested count (#162)
- **SSE protocol**: `SseCompleteEvent` now includes `model` field (backward-compatible)

### Changes

- `Cargo.toml` / `Cargo.lock`: version bump 0.5.1 → 0.5.2
- `CHANGELOG.md`: added 0.5.2 entry

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy` clean
- [x] All workspace tests pass
- [x] No docs changes needed (features already documented, OpenAPI spec auto-generated)