### PR TITLE
fix(server): add /api/upscale/stream to generation-tier rate limiting

### DIFF
--- a/crates/mold-server/src/rate_limit.rs
+++ b/crates/mold-server/src/rate_limit.rs
@@ -174,9 +174,14 @@ pub fn classify_route(path: &str, method: &axum::http::Method) -> Option<RouteTi
     }
 
     match (method.as_str(), path) {
-        ("POST", "/api/generate" | "/api/generate/stream" | "/api/expand" | "/api/upscale") => {
-            Some(RouteTier::Generation)
-        }
+        (
+            "POST",
+            "/api/generate"
+            | "/api/generate/stream"
+            | "/api/expand"
+            | "/api/upscale"
+            | "/api/upscale/stream",
+        ) => Some(RouteTier::Generation),
         ("POST", "/api/models/load" | "/api/models/pull") => Some(RouteTier::Generation),
         ("DELETE", "/api/models/unload") => Some(RouteTier::Generation),
         ("DELETE", _) if path.starts_with("/api/gallery/") => Some(RouteTier::Generation),
@@ -320,6 +325,10 @@ mod tests {
         );
         assert_eq!(
             classify_route("/api/upscale", &Method::POST),
+            Some(RouteTier::Generation)
+        );
+        assert_eq!(
+            classify_route("/api/upscale/stream", &Method::POST),
             Some(RouteTier::Generation)
         );
     }

--- a/website/api/index.md
+++ b/website/api/index.md
@@ -59,8 +59,9 @@ automatically.
 When `MOLD_RATE_LIMIT` is set, per-IP rate limiting is enforced with two tiers:
 
 - **Generation tier** (configured rate): `/api/generate`,
-  `/api/generate/stream`, `/api/expand`, `/api/upscale`, `/api/models/load`,
-  `/api/models/pull`, `/api/models/unload`
+  `/api/generate/stream`, `/api/expand`, `/api/upscale`,
+  `/api/upscale/stream`, `/api/models/load`, `/api/models/pull`,
+  `/api/models/unload`
 - **Read tier** (10x the configured rate): `/api/models`, `/api/status`,
   `/api/gallery/*`
 


### PR DESCRIPTION
## Summary

- Add `/api/upscale/stream` to the generation-tier match arm in `classify_route()` so SSE upscale requests are rate-limited at the configured generation rate, not the 10x read tier
- Add regression test for the route classification
- Update website API docs to list `/api/upscale/stream` in the generation tier

Closes #176

## Test plan

- [x] `cargo test -p mold-ai-server` — all 103 tests pass (including new `classify_route("/api/upscale/stream")` assertion)
- [x] `cargo clippy -p mold-ai-server -- -D warnings` — clean
- [x] `cargo fmt -p mold-ai-server -- --check` — clean