### PR TITLE
ci(release): enable webp, mp4, and metrics features in release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Install nasm (required by openh264 source build for mp4 feature)
+        run: sudo apt-get update && sudo apt-get install -y nasm
+
       - uses: Jimver/cuda-toolkit@v0.2.35
         with:
           cuda: "12.8.1"
@@ -74,6 +77,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+
+      - name: Install nasm (required by openh264 source build for mp4 feature)
+        run: sudo apt-get update && sudo apt-get install -y nasm
 
       - uses: Jimver/cuda-toolkit@v0.2.35
         with:


### PR DESCRIPTION
## Summary

- Add `webp`, `mp4`, and `metrics` features to all three release build targets (macOS Metal, Linux CUDA sm_89, Linux CUDA sm_120)
- Update `cargo install` instructions in release notes to include full feature set

These features were already enabled in Docker images and Nix builds but missing from the GitHub release binaries. Both `webp` and `mp4` use static/source builds (`features = ["static"]` / `features = ["source"]`) so no system library dependencies are introduced.

| Feature | What it enables |
|---------|----------------|
| `webp` | Animated WebP video output via libwebp FFI |
| `mp4` | H.264/MP4 video output via OpenH264 |
| `metrics` | Prometheus `/metrics` endpoint on `mold serve` |

## Test plan

- [ ] CI passes on all three build targets
- [ ] Verify binary size is reasonable (webp/mp4/metrics add ~1-2 MB)