### PR TITLE
chore: release 0.7.0 — native LTX-2 / LTX-2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-04-14
+
+*Native Rust LTX-2 / LTX-2.3 joint audio-video generation.*
+
 ### Added
 
 - **LTX-2 / LTX-2.3 joint audio-video generation**: added the new `ltx2` model family with `ltx-2-19b-{dev,distilled}:fp8` and `ltx-2.3-22b-{dev,distilled}:fp8` manifests, synchronized MP4-first video metadata, request fields for audio/video/keyframes/retake/upscaling, and a separate `Ltx2Engine` wired into the inference factory through the in-tree Rust runtime.
@@ -382,7 +386,9 @@ Initial public release on [crates.io](https://crates.io/crates/mold-ai).
 | [`mold-ai-inference`](https://crates.io/crates/mold-ai-inference) | Candle-based inference engine           |
 | [`mold-ai-server`](https://crates.io/crates/mold-ai-server)       | Axum HTTP inference server              |
 
-[Unreleased]: https://github.com/utensils/mold/compare/v0.6.2...HEAD
+[Unreleased]: https://github.com/utensils/mold/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/utensils/mold/compare/v0.6.3...v0.7.0
+[0.6.3]: https://github.com/utensils/mold/compare/v0.6.2...v0.6.3
 [0.6.2]: https://github.com/utensils/mold/compare/v0.6.1...v0.6.2
 [0.6.1]: https://github.com/utensils/mold/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/utensils/mold/compare/v0.5.3...v0.6.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,7 +128,7 @@ Shared library used by all other crates:
 
 ### mold-inference
 
-Nine model families, each with its own pipeline implementing the `InferenceEngine` trait:
+Ten model families, each with its own pipeline implementing the `InferenceEngine` trait:
 
 ```rust
 pub trait InferenceEngine: Send + Sync {
@@ -152,6 +152,7 @@ pub trait InferenceEngine: Send + Sync {
 - `"z-image"` → `ZImageEngine` — Qwen3 text encoder, flow-matching transformer with 3D RoPE
 - `"wuerstchen"` (also `"wuerstchen-v2"`) → `WuerstchenEngine` — CLIP-G text encoder, 3-stage cascade (Prior → Decoder → VQ-GAN), 42x latent compression
 - `"ltx-video"` → `LtxVideoEngine` — T5-XXL text encoding, flow-matching transformer, 3D causal VAE, text-to-video (APNG/GIF/WebP/MP4 output). Current supported checkpoints are `0.9.6` and `0.9.8`; `0.9.8` pulls a spatial upscaler asset and currently runs first-pass generation only.
+- `"ltx2"` (also `"ltx-2"`) → `Ltx2Engine` — Gemma 3 text encoder with LTX-2 connectors, joint audio-video DiT transformer, 3D causal video VAE, audio VAE + vocoder, MP4-first output with real AAC audio. Covers 19B/22B text+audio-video, image-to-video, audio-to-video, keyframe, retake, public IC-LoRA, spatial upscale (`x1.5`/`x2`), and temporal upscale (`x2`). **CUDA-only for real generation** — CPU is a correctness-oriented fallback, and Metal is explicitly unsupported for this family. The native runtime is in `ltx2/` with runtime orchestration, guidance/perturbation paths, stacked LoRAs + camera-control presets, and a native MP4/GIF/APNG/WebP media pipeline.
 
 **Additional modules:**
 - `encoders/variant_resolution.rs` — Shared T5/Qwen3 encoder variant resolution (auto-fallback quantization)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2859,7 +2859,7 @@ dependencies = [
 
 [[package]]
 name = "mold-ai"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2897,7 +2897,7 @@ dependencies = [
 
 [[package]]
 name = "mold-ai-core"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2920,7 +2920,7 @@ dependencies = [
 
 [[package]]
 name = "mold-ai-discord"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "mold-ai-core",
@@ -2934,7 +2934,7 @@ dependencies = [
 
 [[package]]
 name = "mold-ai-inference"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "candle-core-mold",
@@ -2964,7 +2964,7 @@ dependencies = [
 
 [[package]]
 name = "mold-ai-server"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2997,7 +2997,7 @@ dependencies = [
 
 [[package]]
 name = "mold-ai-tui"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "crossterm 0.28.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,11 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.3"
+version = "0.7.0"
 edition = "2021"
 license = "MIT"
 authors = ["James Brink <brink.james@gmail.com>"]
-description = "Local AI image generation CLI — FLUX, SD3.5, SD 1.5, SDXL, Z-Image, Flux.2, Qwen-Image, & Wuerstchen diffusion models on your GPU"
+description = "Local AI image generation CLI — FLUX, SD3.5, SD 1.5, SDXL, Z-Image, Flux.2, Qwen-Image, Wuerstchen, LTX Video, & LTX-2 diffusion models on your GPU"
 rust-version = "1.85"
 homepage = "https://github.com/utensils/mold"
 repository = "https://github.com/utensils/mold"

--- a/Dockerfile
+++ b/Dockerfile
@@ -122,6 +122,9 @@ ENV MOLD_LOG=info \
 # MOLD_PREVIEW=            (1 to display images inline)
 # Video
 # MOLD_LTX_DEBUG=          (1 for per-step LTX Video diagnostics)
+# MOLD_LTX2_DEBUG=         (1 for per-step LTX-2 / LTX-2.3 diagnostics)
+# NOTE: LTX-2 / LTX-2.3 is CUDA-only — no Metal support, CPU is correctness-only.
+# NOTE: LTX-2 Gemma text-encoder assets are HuggingFace-gated; set HF_TOKEN.
 # Expansion
 # MOLD_EXPAND=             (1 to enable LLM prompt expansion)
 # MOLD_EXPAND_BACKEND=local

--- a/crates/mold-cli/Cargo.toml
+++ b/crates/mold-cli/Cargo.toml
@@ -26,9 +26,9 @@ mp4 = ["mold-inference/mp4"]
 metrics = ["mold-server/metrics"]
 
 [dependencies]
-mold-core = { path = "../mold-core", package = "mold-ai-core", version = "0.6.0" }
-mold-inference = { path = "../mold-inference", package = "mold-ai-inference", version = "0.6.0" }
-mold-server = { path = "../mold-server", package = "mold-ai-server", version = "0.6.0" }
+mold-core = { path = "../mold-core", package = "mold-ai-core", version = "0.7.0" }
+mold-inference = { path = "../mold-inference", package = "mold-ai-inference", version = "0.7.0" }
+mold-server = { path = "../mold-server", package = "mold-ai-server", version = "0.7.0" }
 anyhow = "1"
 base64 = "0.22"
 clap = { version = "4", features = ["derive", "env", "unstable-ext"] }
@@ -51,8 +51,8 @@ tokio = { version = "1", features = ["full"] }
 toml = "0.8"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 viuer = { version = "0.11", optional = true }
-mold-discord = { path = "../mold-discord", package = "mold-ai-discord", version = "0.6.0", optional = true }
-mold-tui = { path = "../mold-tui", package = "mold-ai-tui", version = "0.6.0", optional = true }
+mold-discord = { path = "../mold-discord", package = "mold-ai-discord", version = "0.7.0", optional = true }
+mold-tui = { path = "../mold-tui", package = "mold-ai-tui", version = "0.7.0", optional = true }
 walkdir = "2.5.0"
 
 [dev-dependencies]

--- a/crates/mold-discord/Cargo.toml
+++ b/crates/mold-discord/Cargo.toml
@@ -14,7 +14,7 @@ name = "mold-discord"
 path = "src/main.rs"
 
 [dependencies]
-mold-core = { path = "../mold-core", package = "mold-ai-core", version = "0.6.0" }
+mold-core = { path = "../mold-core", package = "mold-ai-core", version = "0.7.0" }
 poise = "0.6"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"

--- a/crates/mold-inference/Cargo.toml
+++ b/crates/mold-inference/Cargo.toml
@@ -38,7 +38,7 @@ path = "src/bin/ltx2_vae_probe.rs"
 required-features = ["dev-bins", "mp4"]
 
 [dependencies]
-mold-core = { path = "../mold-core", package = "mold-ai-core", version = "0.6.0" }
+mold-core = { path = "../mold-core", package = "mold-ai-core", version = "0.7.0" }
 anyhow = "1"
 candle-core = { package = "candle-core-mold", version = "0.9.10" }
 candle-nn = { package = "candle-nn-mold", version = "0.9.10" }

--- a/crates/mold-server/Cargo.toml
+++ b/crates/mold-server/Cargo.toml
@@ -25,8 +25,8 @@ metrics = ["dep:metrics", "dep:metrics-exporter-prometheus"]
 
 
 [dependencies]
-mold-core = { path = "../mold-core", package = "mold-ai-core", version = "0.6.0" }
-mold-inference = { path = "../mold-inference", package = "mold-ai-inference", version = "0.6.0" }
+mold-core = { path = "../mold-core", package = "mold-ai-core", version = "0.7.0" }
+mold-inference = { path = "../mold-inference", package = "mold-ai-inference", version = "0.7.0" }
 anyhow = "1"
 axum = "0.7"
 serde = { version = "1", features = ["derive"] }

--- a/crates/mold-tui/Cargo.toml
+++ b/crates/mold-tui/Cargo.toml
@@ -16,8 +16,8 @@ metal = ["mold-inference/metal"]
 expand = ["mold-inference/expand"]
 
 [dependencies]
-mold-core = { path = "../mold-core", package = "mold-ai-core", version = "0.6.0" }
-mold-inference = { path = "../mold-inference", package = "mold-ai-inference", version = "0.6.0" }
+mold-core = { path = "../mold-core", package = "mold-ai-core", version = "0.7.0" }
+mold-inference = { path = "../mold-inference", package = "mold-ai-inference", version = "0.7.0" }
 ratatui = { version = "0.29", features = ["crossterm"] }
 crossterm = "0.28"
 ratatui-image = "4"

--- a/website/guide/feature-matrix.md
+++ b/website/guide/feature-matrix.md
@@ -77,6 +77,27 @@ The recommended LTX default today is `ltx-video-0.9.6-distilled:bf16`. The
 `0.9.8` family is available, pulls its spatial upscaler asset, and now runs
 the full multiscale refinement path.
 
+## Backend Support
+
+| Family          | CUDA | Metal       | CPU              |
+| --------------- | ---- | ----------- | ---------------- |
+| FLUX.1 / FLUX.2 | Yes  | Yes         | Yes (slow)       |
+| SDXL / SD 1.5   | Yes  | Yes         | Yes              |
+| SD 3.5          | Yes  | Yes         | Yes              |
+| Z-Image         | Yes  | Yes         | Yes              |
+| Wuerstchen v2   | Yes  | Yes         | Yes              |
+| Qwen-Image      | Yes  | Yes         | Yes              |
+| Qwen-Image-Edit | Yes  | Yes         | Yes              |
+| LTX Video       | Yes  | Yes         | Yes              |
+| **LTX-2**       | Yes  | **Not yet** | Correctness-only |
+
+::: warning LTX-2 is CUDA-only for real generation
+LTX-2 / LTX-2.3 does **not** support Apple Metal in this release. The native
+runtime runs on CUDA; the CPU path exists for correctness-oriented coverage and
+can be extremely slow. On macOS you can still use every other family through
+the Metal backend — LTX-2 is the only family that is currently CUDA-gated.
+:::
+
 ## Notes
 
 - ControlNet is currently available only for SD 1.5.
@@ -96,6 +117,8 @@ the full multiscale refinement path.
 - LTX-2's native CUDA path is validated across text+audio-video, image-to-video,
   audio-to-video, keyframe, retake, public IC-LoRA, spatial upscale, and
   temporal upscale workflows.
+- LTX-2 is CUDA-only for real generation: CPU is correctness-only, and Metal is
+  not supported in this release.
 
 For model size and VRAM fit, see [Models Overview](/models/). For usage
 examples, see [Generating Images](/guide/generating).

--- a/website/models/index.md
+++ b/website/models/index.md
@@ -153,3 +153,10 @@ for more options.
 
 Each family page lists recommended dimensions for non-square aspect ratios.
 Using non-recommended dimensions will trigger a warning.
+
+::: warning Backend compatibility
+All image families and `LTX Video` run on CUDA, Apple Metal, and CPU. **LTX-2 /
+LTX-2.3 is CUDA-only for real generation** — its CPU path exists for
+correctness-oriented coverage and can be extremely slow, and Metal is not
+supported for this family in this release.
+:::


### PR DESCRIPTION
## Summary

Release **0.7.0**. Headline change: native Rust **LTX-2 / LTX-2.3** joint audio-video generation (landed via #220). This PR prepares the release artifacts — version bump, CHANGELOG rollover, docs sync — without introducing new code changes.

## What's In This Release

- **Feature headliner**: native Rust LTX-2 / LTX-2.3 for text+audio-video, image-to-video, audio-to-video, keyframe, retake, IC-LoRA, spatial (`x1.5`/`x2`) and temporal (`x2`) upscale (#220 / #187)
- **Qwen-Image-Edit-2511** (already shipped in 0.6.3): multimodal edit family with repeatable `--image` and a dedicated TUI flow (#219)
- **TUI remote server awareness** (already shipped in 0.6.3): remote-connected info, defaults, and model management (#218 / #158)

## Changes In This PR

- **Version bump**: workspace `0.6.3` → `0.7.0`. All inter-crate `mold-ai-*` dependency pins bumped to `^0.7.0` so the workspace resolves (cargo rejects `^0.6.0` against `0.7.0`).
- **CHANGELOG**: promoted the `[Unreleased]` LTX-2 block to `[0.7.0] - 2026-04-14` with a short tagline; refreshed the reference-link footer with `[0.7.0]`, `[0.6.3]`, and re-pointed `[Unreleased]`.
- **LTX-2 Metal policy — made explicit everywhere it matters**:
  - `CLAUDE.md`: ``ltx2`` entry added to the engine-family list with the CUDA-only / Metal-unsupported caveat; family count updated from "Nine" to "Ten".
  - `website/guide/feature-matrix.md`: new *Backend Support* table with an LTX-2 row calling out `Not yet` for Metal and `Correctness-only` for CPU, plus an explicit `::: warning LTX-2 is CUDA-only for real generation` callout and a matching bullet in the Notes list.
  - `website/models/index.md`: `::: warning Backend compatibility` callout under the family table stating that LTX-2 is CUDA-only for real generation in this release.
  - Other pages (`README.md`, `website/models/ltx2.md`, `website/guide/generating.md`, `website/guide/performance.md`, `website/guide/cli-reference.md`) already carry the "Metal explicitly unsupported" wording and were verified.
- **Dockerfile**: documented `MOLD_LTX2_DEBUG` in the env-var block and added inline notes that LTX-2 is CUDA-only and that its Gemma text-encoder assets are HuggingFace-gated. Workspace description string in `Cargo.toml` updated to mention LTX Video + LTX-2.

## Docker Verification

The release Docker image was built cleanly against this branch on the release-candidate head:

- ``docker build -t mold-server:0.7.0 .`` produced a 3.46 GB image.
- Inside the image: ``/usr/local/bin/mold`` is present (~59 MB, stripped release build) and all non-CUDA dynamic deps resolve. ``libcuda.so.1`` is intentionally absent — it's injected at runtime by the NVIDIA Container Toolkit per the Dockerfile comment.
- Image verified, then removed from the local Docker cache.

## Verification

Against this branch head, matching the CI matrix:

- ✅ ``cargo fmt --all -- --check``
- ✅ ``cargo clippy --workspace --all-targets -- -D warnings``
- ✅ ``cargo test --workspace``
- ✅ ``cargo check -p mold-ai --features preview,discord,expand,tui,webp,mp4``
- ✅ ``bun run fmt:check && bun run verify && bun run build`` in ``website/``
- ✅ ``docker build -t mold-server:0.7.0 .``

## Codex Peer Review

The release commit was reviewed by Codex (``codex review --commit <sha>`` with high reasoning). Outcome: no code regressions; ``cargo check --all-targets`` and the website docs build both verified clean. The CHANGELOG reference-link footer was updated for ``0.7.0`` / ``0.6.3`` as a follow-up to the review session.

## Out of Scope

- Tagging is intentionally deferred — this PR only prepares the release metadata. Post-merge the project can cut ``v0.7.0`` from ``main`` at its usual cadence.
- Throughput and parity follow-up for native LTX-2 continues on #221.