### PR TITLE
fix: transport VideoData through HTTP paths — video outputs as real mp4/gif/apng (#224)

### DIFF
--- a/.claude/skills/mold/SKILL.md
+++ b/.claude/skills/mold/SKILL.md
@@ -532,3 +532,21 @@ services.mold.discord = {
   tokenFile = config.age.secrets.discord-token.path;
 };
 ```
+
+## Updating This Skill
+
+This skill is maintained in the mold repository on GitHub. To pull the latest version:
+
+```bash
+# Source repository
+https://github.com/utensils/mold
+
+# Skill file location within the repo
+.claude/skills/mold/SKILL.md
+
+# Fetch the latest skill directly
+curl -sL https://raw.githubusercontent.com/utensils/mold/main/.claude/skills/mold/SKILL.md \
+  -o ~/.claude/skills/mold/SKILL.md
+```
+
+When copying this skill to other workspaces or agents, always pull from `main` to get the latest model support, CLI flags, and environment variables.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-04-16
+
+### Fixed
+
+- **Video outputs saved as single-frame PNGs instead of real mp4/gif/apng files**: both the SSE and non-SSE HTTP transport paths between server and client discarded `VideoData`, causing the CLI to save a first-frame PNG thumbnail with the requested video extension. The SSE `SseCompleteEvent` now carries optional video metadata fields (`video_frames`, `video_fps`, `video_thumbnail`, `video_gif_preview`, audio metadata) and the non-SSE path sends `x-mold-video-*` response headers so the client can reconstruct the full `VideoData` in both code paths ([#224](https://github.com/utensils/mold/issues/224)).
+
 ## [0.7.0] - 2026-04-14
 
 *Native Rust LTX-2 / LTX-2.3 joint audio-video generation.*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2859,7 +2859,7 @@ dependencies = [
 
 [[package]]
 name = "mold-ai"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2897,7 +2897,7 @@ dependencies = [
 
 [[package]]
 name = "mold-ai-core"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2920,7 +2920,7 @@ dependencies = [
 
 [[package]]
 name = "mold-ai-discord"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "mold-ai-core",
@@ -2934,7 +2934,7 @@ dependencies = [
 
 [[package]]
 name = "mold-ai-inference"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "candle-core-mold",
@@ -2964,7 +2964,7 @@ dependencies = [
 
 [[package]]
 name = "mold-ai-server"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -2997,7 +2997,7 @@ dependencies = [
 
 [[package]]
 name = "mold-ai-tui"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "crossterm 0.28.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 license = "MIT"
 authors = ["James Brink <brink.james@gmail.com>"]

--- a/crates/mold-cli/src/commands/generate.rs
+++ b/crates/mold-cli/src/commands/generate.rs
@@ -551,11 +551,15 @@ pub async fn run(
                 );
             }
             if preview {
-                // Show first frame preview (viuer doesn't support animation)
+                // Show first frame preview (viuer doesn't support animation).
+                // Fallback to the video data itself for GIF/APNG/WebP (decodable
+                // as images) when thumbnail/gif_preview are absent (non-SSE path).
                 if !video.gif_preview.is_empty() {
                     preview_image(&video.gif_preview);
                 } else if !video.thumbnail.is_empty() {
                     preview_image(&video.thumbnail);
+                } else {
+                    preview_image(&video.data);
                 }
             }
         }

--- a/crates/mold-cli/src/commands/stats.rs
+++ b/crates/mold-cli/src/commands/stats.rs
@@ -109,7 +109,7 @@ fn collect_model_stats(config: &Config) -> (Vec<ModelStats>, u64) {
     }
 
     // Sort by size descending
-    models.sort_by(|a, b| b.bytes.cmp(&a.bytes));
+    models.sort_by_key(|m| std::cmp::Reverse(m.bytes));
 
     (models, shared_bytes)
 }

--- a/crates/mold-cli/src/commands/upscale.rs
+++ b/crates/mold-cli/src/commands/upscale.rs
@@ -184,12 +184,10 @@ async fn upscale_local(
                 ProgressEvent::Info { message } => {
                     eprintln!("{} {message}", theme::icon_info());
                 }
-                ProgressEvent::DenoiseStep { step, total, .. } => {
-                    if total > 1 {
-                        eprint!("\r{} Tile {step}/{total}", theme::icon_info());
-                        if step == total {
-                            eprintln!();
-                        }
+                ProgressEvent::DenoiseStep { step, total, .. } if total > 1 => {
+                    eprint!("\r{} Tile {step}/{total}", theme::icon_info());
+                    if step == total {
+                        eprintln!();
                     }
                 }
                 _ => {}

--- a/crates/mold-core/src/catalog.rs
+++ b/crates/mold-core/src/catalog.rs
@@ -54,7 +54,7 @@ pub fn build_model_catalog(
         .iter()
         .filter(|(name, _)| crate::manifest::find_manifest(name).is_none())
         .collect();
-    config_only.sort_by(|(left, _), (right, _)| left.cmp(right));
+    config_only.sort_by_key(|(name, _)| *name);
 
     for (name, model_cfg) in config_only {
         let (disk_usage_bytes, size_gb_f64) = model_cfg.disk_usage();

--- a/crates/mold-core/src/client.rs
+++ b/crates/mold-core/src/client.rs
@@ -2,6 +2,7 @@ use crate::error::MoldError;
 use crate::types::{
     ExpandRequest, ExpandResponse, GalleryImage, GenerateRequest, GenerateResponse, ImageData,
     ModelInfo, ModelInfoExtended, ServerStatus, SseCompleteEvent, SseErrorEvent, SseProgressEvent,
+    VideoData,
 };
 use anyhow::Result;
 use base64::Engine as _;
@@ -58,7 +59,10 @@ impl MoldClient {
         Ok(bytes)
     }
 
-    /// Generate an image and return a minimal response wrapping the raw bytes.
+    /// Generate an image or video and return the response wrapping the raw bytes.
+    ///
+    /// For video responses the server sends `x-mold-video-*` metadata headers
+    /// alongside the raw video bytes so we can reconstruct [`VideoData`].
     pub async fn generate(&self, req: GenerateRequest) -> Result<GenerateResponse> {
         let fallback_seed = req.seed.unwrap_or(0);
         let width = req.width;
@@ -84,21 +88,46 @@ impl MoldClient {
             .and_then(|s| s.parse::<u64>().ok())
             .unwrap_or(fallback_seed);
 
+        // Detect video response via x-mold-video-frames header
+        let video_meta = parse_video_headers(resp.headers());
+
         let data = resp.bytes().await?.to_vec();
         let generation_time_ms = start.elapsed().as_millis() as u64;
 
-        Ok(GenerateResponse {
-            images: vec![ImageData {
+        let video = video_meta.map(|meta| VideoData {
+            data: data.clone(),
+            format,
+            width: meta.width.unwrap_or(width),
+            height: meta.height.unwrap_or(height),
+            frames: meta.frames,
+            fps: meta.fps,
+            thumbnail: Vec::new(),
+            gif_preview: Vec::new(),
+            has_audio: meta.has_audio,
+            duration_ms: meta.duration_ms,
+            audio_sample_rate: meta.audio_sample_rate,
+            audio_channels: meta.audio_channels,
+        });
+
+        // For video responses, images is empty — the payload lives in `video`.
+        let images = if video.is_some() {
+            Vec::new()
+        } else {
+            vec![ImageData {
                 data,
                 format,
                 width,
                 height,
                 index: 0,
-            }],
+            }]
+        };
+
+        Ok(GenerateResponse {
+            images,
             generation_time_ms,
             model,
             seed_used,
-            video: None,
+            video,
         })
     }
 
@@ -204,8 +233,9 @@ impl MoldClient {
                     }
                     "complete" => {
                         let complete: SseCompleteEvent = serde_json::from_str(&data)?;
-                        let image_data =
+                        let payload =
                             base64::engine::general_purpose::STANDARD.decode(&complete.image)?;
+                        let b64 = base64::engine::general_purpose::STANDARD;
                         // Use server-provided model name (source of truth);
                         // fall back to request model for backwards compat with
                         // older servers that don't include it.
@@ -214,18 +244,53 @@ impl MoldClient {
                         } else {
                             complete.model
                         };
-                        return Ok(Some(GenerateResponse {
-                            images: vec![ImageData {
-                                data: image_data,
+
+                        // Detect video response via video_frames field
+                        let (images, video) = if let (Some(frames), Some(fps)) =
+                            (complete.video_frames, complete.video_fps)
+                        {
+                            let thumbnail = complete
+                                .video_thumbnail
+                                .as_deref()
+                                .and_then(|s| b64.decode(s).ok())
+                                .unwrap_or_default();
+                            let gif_preview = complete
+                                .video_gif_preview
+                                .as_deref()
+                                .and_then(|s| b64.decode(s).ok())
+                                .unwrap_or_default();
+                            let vd = VideoData {
+                                data: payload,
+                                format: complete.format,
+                                width: complete.width,
+                                height: complete.height,
+                                frames,
+                                fps,
+                                thumbnail,
+                                gif_preview,
+                                has_audio: complete.video_has_audio,
+                                duration_ms: complete.video_duration_ms,
+                                audio_sample_rate: complete.video_audio_sample_rate,
+                                audio_channels: complete.video_audio_channels,
+                            };
+                            (Vec::new(), Some(vd))
+                        } else {
+                            let img = ImageData {
+                                data: payload,
                                 format: complete.format,
                                 width: complete.width,
                                 height: complete.height,
                                 index: 0,
-                            }],
+                            };
+                            (vec![img], None)
+                        };
+
+                        return Ok(Some(GenerateResponse {
+                            images,
                             generation_time_ms: complete.generation_time_ms,
                             model,
                             seed_used: complete.seed_used,
-                            video: None,
+                            video,
                         }));
                     }
                     "error" => {
@@ -519,6 +584,68 @@ impl MoldClient {
     }
 }
 
+/// Parsed video metadata from `x-mold-video-*` response headers.
+struct VideoMeta {
+    frames: u32,
+    fps: u32,
+    width: Option<u32>,
+    height: Option<u32>,
+    has_audio: bool,
+    duration_ms: Option<u64>,
+    audio_sample_rate: Option<u32>,
+    audio_channels: Option<u32>,
+}
+
+/// Parse video metadata from HTTP response headers.
+/// Returns `Some` when `x-mold-video-frames` is present, indicating a video response.
+fn parse_video_headers(headers: &reqwest::header::HeaderMap) -> Option<VideoMeta> {
+    let frames = headers
+        .get("x-mold-video-frames")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<u32>().ok())?;
+    let fps = headers
+        .get("x-mold-video-fps")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<u32>().ok())
+        .unwrap_or(24);
+    let width = headers
+        .get("x-mold-video-width")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<u32>().ok());
+    let height = headers
+        .get("x-mold-video-height")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<u32>().ok());
+    let has_audio = headers
+        .get("x-mold-video-has-audio")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s == "1")
+        .unwrap_or(false);
+    let duration_ms = headers
+        .get("x-mold-video-duration-ms")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<u64>().ok());
+    let audio_sample_rate = headers
+        .get("x-mold-video-audio-sample-rate")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<u32>().ok());
+    let audio_channels = headers
+        .get("x-mold-video-audio-channels")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<u32>().ok());
+
+    Some(VideoMeta {
+        frames,
+        fps,
+        width,
+        height,
+        has_audio,
+        duration_ms,
+        audio_sample_rate,
+        audio_channels,
+    })
+}
+
 fn next_sse_event(buffer: &mut String) -> Option<String> {
     for separator in ["\r\n\r\n", "\n\n"] {
         if let Some(pos) = buffer.find(separator) {
@@ -737,5 +864,69 @@ mod tests {
         let event = next_sse_event(&mut buffer).expect("expected one event");
         assert!(event.contains("event: progress"));
         assert_eq!(buffer, "rest");
+    }
+
+    // ── Video header parsing tests ───────────────────────────────────────
+
+    #[test]
+    fn parse_video_headers_returns_none_without_frames() {
+        let headers = reqwest::header::HeaderMap::new();
+        assert!(parse_video_headers(&headers).is_none());
+    }
+
+    #[test]
+    fn parse_video_headers_returns_some_with_frames() {
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert("x-mold-video-frames", "33".parse().unwrap());
+        headers.insert("x-mold-video-fps", "12".parse().unwrap());
+        headers.insert("x-mold-video-width", "832".parse().unwrap());
+        headers.insert("x-mold-video-height", "480".parse().unwrap());
+
+        let meta = parse_video_headers(&headers).expect("should detect video");
+        assert_eq!(meta.frames, 33);
+        assert_eq!(meta.fps, 12);
+        assert_eq!(meta.width, Some(832));
+        assert_eq!(meta.height, Some(480));
+        assert!(!meta.has_audio);
+        assert!(meta.duration_ms.is_none());
+    }
+
+    #[test]
+    fn parse_video_headers_with_audio_metadata() {
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert("x-mold-video-frames", "17".parse().unwrap());
+        headers.insert("x-mold-video-fps", "24".parse().unwrap());
+        headers.insert("x-mold-video-has-audio", "1".parse().unwrap());
+        headers.insert("x-mold-video-duration-ms", "2750".parse().unwrap());
+        headers.insert("x-mold-video-audio-sample-rate", "44100".parse().unwrap());
+        headers.insert("x-mold-video-audio-channels", "2".parse().unwrap());
+
+        let meta = parse_video_headers(&headers).expect("should detect video");
+        assert_eq!(meta.frames, 17);
+        assert_eq!(meta.fps, 24);
+        assert!(meta.has_audio);
+        assert_eq!(meta.duration_ms, Some(2750));
+        assert_eq!(meta.audio_sample_rate, Some(44100));
+        assert_eq!(meta.audio_channels, Some(2));
+    }
+
+    #[test]
+    fn parse_video_headers_fps_defaults_to_24() {
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert("x-mold-video-frames", "10".parse().unwrap());
+        // No fps header — should default to 24
+
+        let meta = parse_video_headers(&headers).expect("should detect video");
+        assert_eq!(meta.fps, 24);
+    }
+
+    #[test]
+    fn parse_video_headers_has_audio_absent_is_false() {
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert("x-mold-video-frames", "10".parse().unwrap());
+        // No has-audio header
+
+        let meta = parse_video_headers(&headers).expect("should detect video");
+        assert!(!meta.has_audio);
     }
 }

--- a/crates/mold-core/src/types.rs
+++ b/crates/mold-core/src/types.rs
@@ -784,10 +784,15 @@ pub enum SseProgressEvent {
     },
 }
 
-/// Completion event sent when image generation finishes successfully.
+/// Completion event sent when image/video generation finishes successfully.
+///
+/// For image responses, `image` contains base64-encoded image data and the
+/// `video_*` fields are absent.  For video responses, `image` contains
+/// base64-encoded video data (MP4/GIF/APNG/WebP) and the `video_*` fields
+/// carry the metadata needed to reconstruct [`VideoData`] on the client.
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct SseCompleteEvent {
-    /// Base64-encoded image data.
+    /// Base64-encoded payload — image bytes for images, video bytes for video.
     pub image: String,
     pub format: OutputFormat,
     #[schema(example = 1024)]
@@ -802,6 +807,32 @@ pub struct SseCompleteEvent {
     #[serde(default)]
     #[schema(example = "flux-schnell:q8")]
     pub model: String,
+
+    // ── Video-only fields (absent for image responses) ──────────────────
+    /// Number of frames.  Presence of this field signals a video response.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub video_frames: Option<u32>,
+    /// Frames per second.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub video_fps: Option<u32>,
+    /// Base64-encoded first-frame PNG thumbnail.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub video_thumbnail: Option<String>,
+    /// Base64-encoded animated GIF preview.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub video_gif_preview: Option<String>,
+    /// Whether this video includes a synchronized audio track.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub video_has_audio: bool,
+    /// Total encoded duration in milliseconds.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub video_duration_ms: Option<u64>,
+    /// Audio sample rate in Hz (when audio is present).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub video_audio_sample_rate: Option<u32>,
+    /// Number of audio channels (when audio is present).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub video_audio_channels: Option<u32>,
 }
 
 /// SSE event emitted when an upscale request completes.
@@ -1309,12 +1340,24 @@ mod tests {
             seed_used: 42,
             generation_time_ms: 5000,
             model: "flux-schnell:q8".to_string(),
+            video_frames: None,
+            video_fps: None,
+            video_thumbnail: None,
+            video_gif_preview: None,
+            video_has_audio: false,
+            video_duration_ms: None,
+            video_audio_sample_rate: None,
+            video_audio_channels: None,
         };
         let json = serde_json::to_string(&event).unwrap();
+        // Video fields should be absent from the serialized JSON
+        assert!(!json.contains("video_frames"));
+        assert!(!json.contains("video_fps"));
         let back: SseCompleteEvent = serde_json::from_str(&json).unwrap();
         assert_eq!(back.width, 1024);
         assert_eq!(back.seed_used, 42);
         assert_eq!(back.model, "flux-schnell:q8");
+        assert!(back.video_frames.is_none());
     }
 
     #[test]
@@ -1852,6 +1895,125 @@ mod tests {
             r#"{"prompt":"test","model":"test","width":512,"height":512,"steps":4,"batch_size":1}"#;
         let req: GenerateRequest = serde_json::from_str(json).unwrap();
         assert!(req.upscale_model.is_none());
+    }
+
+    // ── Video SSE transport tests ────────────────────────────────────────
+
+    #[test]
+    fn sse_complete_event_video_roundtrip() {
+        let event = SseCompleteEvent {
+            image: "dmlkZW9fYnl0ZXM=".to_string(), // "video_bytes" base64
+            format: OutputFormat::Mp4,
+            width: 832,
+            height: 480,
+            seed_used: 99,
+            generation_time_ms: 12000,
+            model: "ltx-2.3-22b-distilled:fp8".to_string(),
+            video_frames: Some(33),
+            video_fps: Some(12),
+            video_thumbnail: Some("dGh1bWI=".to_string()), // "thumb" base64
+            video_gif_preview: Some("Z2lm".to_string()),   // "gif" base64
+            video_has_audio: true,
+            video_duration_ms: Some(2750),
+            video_audio_sample_rate: Some(44100),
+            video_audio_channels: Some(2),
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains("video_frames"));
+        assert!(json.contains("video_fps"));
+        assert!(json.contains("video_thumbnail"));
+        assert!(json.contains("video_gif_preview"));
+        assert!(json.contains("video_has_audio"));
+        assert!(json.contains("video_duration_ms"));
+        assert!(json.contains("video_audio_sample_rate"));
+        assert!(json.contains("video_audio_channels"));
+
+        let back: SseCompleteEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.video_frames, Some(33));
+        assert_eq!(back.video_fps, Some(12));
+        assert!(back.video_has_audio);
+        assert_eq!(back.video_duration_ms, Some(2750));
+        assert_eq!(back.video_audio_sample_rate, Some(44100));
+        assert_eq!(back.video_audio_channels, Some(2));
+        assert_eq!(back.video_thumbnail.as_deref(), Some("dGh1bWI="));
+        assert_eq!(back.video_gif_preview.as_deref(), Some("Z2lm"));
+        assert_eq!(back.format, OutputFormat::Mp4);
+    }
+
+    #[test]
+    fn sse_complete_event_video_no_audio_omits_audio_fields() {
+        let event = SseCompleteEvent {
+            image: "data".to_string(),
+            format: OutputFormat::Gif,
+            width: 512,
+            height: 512,
+            seed_used: 1,
+            generation_time_ms: 100,
+            model: "ltx-video:bf16".to_string(),
+            video_frames: Some(17),
+            video_fps: Some(24),
+            video_thumbnail: Some("dGh1bWI=".to_string()),
+            video_gif_preview: None,
+            video_has_audio: false,
+            video_duration_ms: None,
+            video_audio_sample_rate: None,
+            video_audio_channels: None,
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        // Audio-related fields should be absent when not set
+        assert!(!json.contains("video_has_audio"));
+        assert!(!json.contains("video_audio_sample_rate"));
+        assert!(!json.contains("video_audio_channels"));
+        assert!(!json.contains("video_gif_preview"));
+        // But video fields should be present
+        assert!(json.contains("video_frames"));
+        assert!(json.contains("video_fps"));
+
+        let back: SseCompleteEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.video_frames, Some(17));
+        assert!(!back.video_has_audio);
+        assert!(back.video_gif_preview.is_none());
+    }
+
+    #[test]
+    fn sse_complete_event_backward_compat_no_video_fields() {
+        // Older servers send no video fields at all — everything defaults.
+        let json = r#"{"image":"aW1n","format":"png","width":1024,"height":1024,"seed_used":42,"generation_time_ms":5000,"model":"flux-dev:q8"}"#;
+        let event: SseCompleteEvent = serde_json::from_str(json).unwrap();
+        assert!(event.video_frames.is_none());
+        assert!(event.video_fps.is_none());
+        assert!(event.video_thumbnail.is_none());
+        assert!(event.video_gif_preview.is_none());
+        assert!(!event.video_has_audio);
+        assert!(event.video_duration_ms.is_none());
+        assert!(event.video_audio_sample_rate.is_none());
+        assert!(event.video_audio_channels.is_none());
+        assert_eq!(event.model, "flux-dev:q8");
+        assert_eq!(event.width, 1024);
+    }
+
+    #[test]
+    fn sse_complete_event_image_no_video_fields_in_json() {
+        // An image-only event should not include any video_* keys in JSON
+        let event = SseCompleteEvent {
+            image: "aW1n".to_string(),
+            format: OutputFormat::Png,
+            width: 1024,
+            height: 1024,
+            seed_used: 1,
+            generation_time_ms: 100,
+            model: "flux-dev:q8".to_string(),
+            video_frames: None,
+            video_fps: None,
+            video_thumbnail: None,
+            video_gif_preview: None,
+            video_has_audio: false,
+            video_duration_ms: None,
+            video_audio_sample_rate: None,
+            video_audio_channels: None,
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(!json.contains("video_"));
     }
 }
 

--- a/crates/mold-discord/src/format.rs
+++ b/crates/mold-discord/src/format.rs
@@ -95,11 +95,7 @@ pub fn format_progress(event: &SseProgressEvent) -> String {
 /// Build a text progress bar: `[=========>          ]`
 fn progress_bar(current: usize, total: usize) -> String {
     let width = 20;
-    let filled = if total > 0 {
-        (current * width) / total
-    } else {
-        0
-    };
+    let filled = (current * width).checked_div(total).unwrap_or(0);
     let fill_len = if filled > 0 && filled < width {
         filled - 1
     } else {

--- a/crates/mold-inference/src/flux/lora.rs
+++ b/crates/mold-inference/src/flux/lora.rs
@@ -240,9 +240,8 @@ fn fused_slice_range(
     component: usize,
     num_components: usize,
 ) -> (usize, usize) {
-    if num_components > 0 {
+    if let Some(component_size) = base_rows.checked_div(num_components) {
         // Equal split (e.g. QKV fused: each is base_rows / 3)
-        let component_size = base_rows / num_components;
         (component * component_size, component_size)
     } else {
         // Single-block linear1: [Q, K, V, MLP]

--- a/crates/mold-inference/src/qwen_image/offload.rs
+++ b/crates/mold-inference/src/qwen_image/offload.rs
@@ -528,12 +528,8 @@ impl OffloadedQwenImageTransformer {
         // Load first block on CPU to measure actual size
         let first_block = OffloadedQwenBlock::load(cfg, cpu_vb.pp("transformer_blocks").pp(0))?;
         let block_size = Self::block_size_bytes(&first_block);
-        let max_gpu_blocks = if block_size > 0 {
-            (vram_budget / block_size) as usize
-        } else {
-            0
-        }
-        .min(cfg.num_layers);
+        let max_gpu_blocks = vram_budget.checked_div(block_size).unwrap_or(0) as usize;
+        let max_gpu_blocks = max_gpu_blocks.min(cfg.num_layers);
 
         progress.info(&format!(
             "Block size: {} MB, VRAM budget: {} MB → {} of {} blocks on GPU",

--- a/crates/mold-server/src/lib.rs
+++ b/crates/mold-server/src/lib.rs
@@ -231,6 +231,15 @@ fn build_cors_layer() -> Result<CorsLayer> {
                     axum::http::header::HeaderName::from_static("x-mold-seed-used"),
                     axum::http::header::HeaderName::from_static("x-request-id"),
                     axum::http::header::HeaderName::from_static("retry-after"),
+                    axum::http::header::HeaderName::from_static("x-mold-video-frames"),
+                    axum::http::header::HeaderName::from_static("x-mold-video-fps"),
+                    axum::http::header::HeaderName::from_static("x-mold-video-width"),
+                    axum::http::header::HeaderName::from_static("x-mold-video-height"),
+                    axum::http::header::HeaderName::from_static("x-mold-video-has-audio"),
+                    axum::http::header::HeaderName::from_static("x-mold-video-duration-ms"),
+                    axum::http::header::HeaderName::from_static("x-mold-video-audio-sample-rate"),
+                    axum::http::header::HeaderName::from_static("x-mold-video-audio-channels"),
+                    axum::http::header::HeaderName::from_static("x-mold-dimension-warning"),
                 ])
         }
         _ => CorsLayer::permissive(),

--- a/crates/mold-server/src/queue.rs
+++ b/crates/mold-server/src/queue.rs
@@ -264,15 +264,51 @@ async fn process_job(state: &AppState, job: GenerationJob) {
 
             // Send SSE complete event
             if let Some(ref tx) = job.progress_tx {
-                let _ = tx.send(SseMessage::Complete(SseCompleteEvent {
-                    image: base64::engine::general_purpose::STANDARD.encode(&img.data),
-                    format: img.format,
-                    width: img.width,
-                    height: img.height,
-                    seed_used: response.seed_used,
-                    generation_time_ms: response.generation_time_ms,
-                    model: response.model.clone(),
-                }));
+                let b64 = base64::engine::general_purpose::STANDARD;
+                let event = if let Some(ref video) = response.video {
+                    // Video response: encode the actual video data + metadata
+                    SseCompleteEvent {
+                        image: b64.encode(&video.data),
+                        format: video.format,
+                        width: video.width,
+                        height: video.height,
+                        seed_used: response.seed_used,
+                        generation_time_ms: response.generation_time_ms,
+                        model: response.model.clone(),
+                        video_frames: Some(video.frames),
+                        video_fps: Some(video.fps),
+                        video_thumbnail: Some(b64.encode(&video.thumbnail)),
+                        video_gif_preview: if video.gif_preview.is_empty() {
+                            None
+                        } else {
+                            Some(b64.encode(&video.gif_preview))
+                        },
+                        video_has_audio: video.has_audio,
+                        video_duration_ms: video.duration_ms,
+                        video_audio_sample_rate: video.audio_sample_rate,
+                        video_audio_channels: video.audio_channels,
+                    }
+                } else {
+                    // Image response: same as before
+                    SseCompleteEvent {
+                        image: b64.encode(&img.data),
+                        format: img.format,
+                        width: img.width,
+                        height: img.height,
+                        seed_used: response.seed_used,
+                        generation_time_ms: response.generation_time_ms,
+                        model: response.model.clone(),
+                        video_frames: None,
+                        video_fps: None,
+                        video_thumbnail: None,
+                        video_gif_preview: None,
+                        video_has_audio: false,
+                        video_duration_ms: None,
+                        video_audio_sample_rate: None,
+                        video_audio_channels: None,
+                    }
+                };
+                let _ = tx.send(SseMessage::Complete(event));
             }
 
             // Send result through oneshot

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -1458,7 +1458,7 @@ fn scan_gallery_dir(dir: &std::path::Path) -> Vec<mold_core::GalleryImage> {
         }
     }
 
-    images.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+    images.sort_by_key(|img| std::cmp::Reverse(img.timestamp));
     images
 }
 

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -320,9 +320,40 @@ async fn generate(
                 }
             }
             // For video responses, return the actual video data (not the thumbnail)
+            // and send video metadata in headers so the client can reconstruct VideoData.
             let output_data = if let Some(ref video) = response.video {
                 let ct = HeaderValue::from_static(video.format.content_type());
                 headers.insert(header::CONTENT_TYPE, ct);
+                if let Ok(v) = HeaderValue::from_str(&video.frames.to_string()) {
+                    headers.insert("x-mold-video-frames", v);
+                }
+                if let Ok(v) = HeaderValue::from_str(&video.fps.to_string()) {
+                    headers.insert("x-mold-video-fps", v);
+                }
+                if let Ok(v) = HeaderValue::from_str(&video.width.to_string()) {
+                    headers.insert("x-mold-video-width", v);
+                }
+                if let Ok(v) = HeaderValue::from_str(&video.height.to_string()) {
+                    headers.insert("x-mold-video-height", v);
+                }
+                if video.has_audio {
+                    headers.insert("x-mold-video-has-audio", HeaderValue::from_static("1"));
+                }
+                if let Some(dur) = video.duration_ms {
+                    if let Ok(v) = HeaderValue::from_str(&dur.to_string()) {
+                        headers.insert("x-mold-video-duration-ms", v);
+                    }
+                }
+                if let Some(sr) = video.audio_sample_rate {
+                    if let Ok(v) = HeaderValue::from_str(&sr.to_string()) {
+                        headers.insert("x-mold-video-audio-sample-rate", v);
+                    }
+                }
+                if let Some(ch) = video.audio_channels {
+                    if let Ok(v) = HeaderValue::from_str(&ch.to_string()) {
+                        headers.insert("x-mold-video-audio-channels", v);
+                    }
+                }
                 video.data.clone()
             } else {
                 img.data

--- a/crates/mold-tui/src/app.rs
+++ b/crates/mold-tui/src/app.rs
@@ -1778,15 +1778,11 @@ impl App {
                             self.update_model(&model);
                         }
                     }
-                    KeyCode::Up | KeyCode::Char('k') => {
-                        if *selected > 0 {
-                            *selected -= 1;
-                        }
+                    KeyCode::Up | KeyCode::Char('k') if *selected > 0 => {
+                        *selected -= 1;
                     }
-                    KeyCode::Down | KeyCode::Char('j') => {
-                        if *selected + 1 < filtered.len() {
-                            *selected += 1;
-                        }
+                    KeyCode::Down | KeyCode::Char('j') if *selected + 1 < filtered.len() => {
+                        *selected += 1;
                     }
                     KeyCode::Char(c) => {
                         filter.push(c);
@@ -1810,15 +1806,11 @@ impl App {
                             self.spawn_upscale(model);
                         }
                     }
-                    KeyCode::Up | KeyCode::Char('k') => {
-                        if *selected > 0 {
-                            *selected -= 1;
-                        }
+                    KeyCode::Up | KeyCode::Char('k') if *selected > 0 => {
+                        *selected -= 1;
                     }
-                    KeyCode::Down | KeyCode::Char('j') => {
-                        if *selected + 1 < filtered.len() {
-                            *selected += 1;
-                        }
+                    KeyCode::Down | KeyCode::Char('j') if *selected + 1 < filtered.len() => {
+                        *selected += 1;
                     }
                     KeyCode::Char(c) => {
                         filter.push(c);
@@ -1927,18 +1919,16 @@ impl App {
                         }
                     }
                     KeyCode::Up | KeyCode::Char('k')
-                        if key.modifiers == KeyModifiers::NONE || key.code == KeyCode::Up =>
+                        if (key.modifiers == KeyModifiers::NONE || key.code == KeyCode::Up)
+                            && *selected > 0 =>
                     {
-                        if *selected > 0 {
-                            *selected -= 1;
-                        }
+                        *selected -= 1;
                     }
                     KeyCode::Down | KeyCode::Char('j')
-                        if key.modifiers == KeyModifiers::NONE || key.code == KeyCode::Down =>
+                        if (key.modifiers == KeyModifiers::NONE || key.code == KeyCode::Down)
+                            && *selected + 1 < results.len() =>
                     {
-                        if *selected + 1 < results.len() {
-                            *selected += 1;
-                        }
+                        *selected += 1;
                     }
                     KeyCode::Char(c) => {
                         filter.push(c);
@@ -2226,21 +2216,17 @@ impl App {
                     View::Settings => View::Models,
                 };
             }
-            Action::FocusNext => {
-                if self.active_view == View::Generate {
-                    self.generate.focus = self
-                        .generate
-                        .focus
-                        .next(self.generate.capabilities.supports_negative_prompt);
-                }
+            Action::FocusNext if self.active_view == View::Generate => {
+                self.generate.focus = self
+                    .generate
+                    .focus
+                    .next(self.generate.capabilities.supports_negative_prompt);
             }
-            Action::FocusPrev => {
-                if self.active_view == View::Generate {
-                    self.generate.focus = self
-                        .generate
-                        .focus
-                        .prev(self.generate.capabilities.supports_negative_prompt);
-                }
+            Action::FocusPrev if self.active_view == View::Generate => {
+                self.generate.focus = self
+                    .generate
+                    .focus
+                    .prev(self.generate.capabilities.supports_negative_prompt);
             }
             Action::Up => match self.active_view {
                 View::Generate => {
@@ -2320,10 +2306,8 @@ impl App {
                     self.increment_param(-1);
                 }
             }
-            Action::Generate => {
-                if self.active_view == View::Generate && !self.generate.generating {
-                    self.start_generation();
-                }
+            Action::Generate if self.active_view == View::Generate && !self.generate.generating => {
+                self.start_generation();
             }
             Action::Confirm => match self.active_view {
                 View::Generate => {
@@ -2356,46 +2340,44 @@ impl App {
                 }
                 View::Settings => self.settings_confirm(),
             },
-            Action::PullModel => {
-                if self.active_view == View::Models {
-                    if let Some(model) = self.models.catalog.get(self.models.selected) {
-                        let model_name = model.name.clone();
-                        let tx = self.bg_tx.clone();
+            Action::PullModel if self.active_view == View::Models => {
+                if let Some(model) = self.models.catalog.get(self.models.selected) {
+                    let model_name = model.name.clone();
+                    let tx = self.bg_tx.clone();
 
-                        if self.should_poll_remote() {
-                            // Pull via server when connected remotely
-                            let url = self.server_url.clone().unwrap();
-                            self.tokio_handle.spawn(async move {
-                                let client = mold_core::MoldClient::new(&url);
-                                let (progress_tx, mut progress_rx) =
-                                    mpsc::unbounded_channel::<SseProgressEvent>();
-                                let tx_fwd = tx.clone();
-                                tokio::spawn(async move {
-                                    while let Some(event) = progress_rx.recv().await {
-                                        let _ = tx_fwd.send(BackgroundEvent::Progress(event));
-                                    }
-                                });
-                                match client.pull_model_stream(&model_name, progress_tx).await {
-                                    Ok(()) => {
-                                        let _ = tx.send(BackgroundEvent::PullComplete(model_name));
-                                    }
-                                    Err(e) => {
-                                        let _ = tx.send(BackgroundEvent::Error(format!(
-                                            "Server pull failed: {e}"
-                                        )));
-                                    }
+                    if self.should_poll_remote() {
+                        // Pull via server when connected remotely
+                        let url = self.server_url.clone().unwrap();
+                        self.tokio_handle.spawn(async move {
+                            let client = mold_core::MoldClient::new(&url);
+                            let (progress_tx, mut progress_rx) =
+                                mpsc::unbounded_channel::<SseProgressEvent>();
+                            let tx_fwd = tx.clone();
+                            tokio::spawn(async move {
+                                while let Some(event) = progress_rx.recv().await {
+                                    let _ = tx_fwd.send(BackgroundEvent::Progress(event));
                                 }
                             });
-                        } else {
-                            // Pull locally when no server connected
-                            self.tokio_handle.spawn(async move {
-                                if let Err(msg) =
-                                    crate::backend::auto_pull_model(&model_name, &tx).await
-                                {
-                                    let _ = tx.send(BackgroundEvent::Error(msg));
+                            match client.pull_model_stream(&model_name, progress_tx).await {
+                                Ok(()) => {
+                                    let _ = tx.send(BackgroundEvent::PullComplete(model_name));
                                 }
-                            });
-                        }
+                                Err(e) => {
+                                    let _ = tx.send(BackgroundEvent::Error(format!(
+                                        "Server pull failed: {e}"
+                                    )));
+                                }
+                            }
+                        });
+                    } else {
+                        // Pull locally when no server connected
+                        self.tokio_handle.spawn(async move {
+                            if let Err(msg) =
+                                crate::backend::auto_pull_model(&model_name, &tx).await
+                            {
+                                let _ = tx.send(BackgroundEvent::Error(msg));
+                            }
+                        });
                     }
                 }
             }
@@ -2466,32 +2448,30 @@ impl App {
                     self.generate.error_message = None;
                 }
             }
-            Action::HistoryPrev => {
+            Action::HistoryPrev
                 if self.active_view == View::Generate
-                    && self.generate.focus == GenerateFocus::Prompt
-                {
-                    let current = self.generate.prompt.lines().join("\n");
-                    if let Some(prompt) = self.history.prev(&current) {
-                        self.generate.prompt =
-                            TextArea::new(prompt.lines().map(String::from).collect());
-                        self.generate
-                            .prompt
-                            .set_cursor_line_style(ratatui::style::Style::default());
-                    }
+                    && self.generate.focus == GenerateFocus::Prompt =>
+            {
+                let current = self.generate.prompt.lines().join("\n");
+                if let Some(prompt) = self.history.prev(&current) {
+                    self.generate.prompt =
+                        TextArea::new(prompt.lines().map(String::from).collect());
+                    self.generate
+                        .prompt
+                        .set_cursor_line_style(ratatui::style::Style::default());
                 }
             }
-            Action::HistoryNext => {
+            Action::HistoryNext
                 if self.active_view == View::Generate
-                    && self.generate.focus == GenerateFocus::Prompt
-                {
-                    let current = self.generate.prompt.lines().join("\n");
-                    if let Some(prompt) = self.history.next(&current) {
-                        self.generate.prompt =
-                            TextArea::new(prompt.lines().map(String::from).collect());
-                        self.generate
-                            .prompt
-                            .set_cursor_line_style(ratatui::style::Style::default());
-                    }
+                    && self.generate.focus == GenerateFocus::Prompt =>
+            {
+                let current = self.generate.prompt.lines().join("\n");
+                if let Some(prompt) = self.history.next(&current) {
+                    self.generate.prompt =
+                        TextArea::new(prompt.lines().map(String::from).collect());
+                    self.generate
+                        .prompt
+                        .set_cursor_line_style(ratatui::style::Style::default());
                 }
             }
             Action::SearchHistory => {
@@ -2507,93 +2487,80 @@ impl App {
                     results: all,
                 });
             }
-            Action::Unfocus => {
-                if self.active_view == View::Generate {
-                    self.generate.focus = GenerateFocus::Navigation;
-                }
+            Action::Unfocus if self.active_view == View::Generate => {
+                self.generate.focus = GenerateFocus::Navigation;
             }
-            Action::GridLeft => {
+            Action::GridLeft
                 if self.active_view == View::Gallery
                     && self.gallery.view_mode == GalleryViewMode::Grid
-                    && self.gallery.selected > 0
-                {
-                    self.gallery.selected -= 1;
-                }
+                    && self.gallery.selected > 0 =>
+            {
+                self.gallery.selected -= 1;
             }
-            Action::GridRight => {
+            Action::GridRight
                 if self.active_view == View::Gallery
                     && self.gallery.view_mode == GalleryViewMode::Grid
-                    && self.gallery.selected + 1 < self.gallery.entries.len()
-                {
-                    self.gallery.selected += 1;
+                    && self.gallery.selected + 1 < self.gallery.entries.len() =>
+            {
+                self.gallery.selected += 1;
+            }
+            Action::EditAndGenerate if self.active_view == View::Gallery => {
+                self.load_gallery_into_generate();
+            }
+            Action::Regenerate if self.active_view == View::Gallery => {
+                self.load_gallery_into_generate();
+                if !self.generate.generating {
+                    self.start_generation();
                 }
             }
-            Action::EditAndGenerate => {
-                if self.active_view == View::Gallery {
-                    self.load_gallery_into_generate();
-                }
-            }
-            Action::Regenerate => {
-                if self.active_view == View::Gallery {
-                    self.load_gallery_into_generate();
-                    if !self.generate.generating {
-                        self.start_generation();
-                    }
-                }
-            }
-            Action::DeleteImage => {
-                if self.active_view == View::Gallery {
-                    if let Some(entry) = self.gallery.entries.get(self.gallery.selected) {
-                        let filename = entry.filename();
-                        self.popup = Some(Popup::Confirm {
-                            message: format!("Delete {filename}?"),
-                            on_confirm: ConfirmAction::DeleteGalleryImage,
-                        });
-                    }
+            Action::DeleteImage if self.active_view == View::Gallery => {
+                if let Some(entry) = self.gallery.entries.get(self.gallery.selected) {
+                    let filename = entry.filename();
+                    self.popup = Some(Popup::Confirm {
+                        message: format!("Delete {filename}?"),
+                        on_confirm: ConfirmAction::DeleteGalleryImage,
+                    });
                 }
             }
             Action::OpenFile => {
                 self.open_gallery_file();
             }
-            Action::UpscaleImage => {
+            Action::UpscaleImage
                 if self.active_view == View::Gallery
                     && !self.upscale_in_progress
-                    && self.gallery.entries.get(self.gallery.selected).is_some()
-                {
-                    let models = self.available_upscaler_models();
-                    self.popup = Some(Popup::UpscaleModelSelector {
-                        filter: String::new(),
-                        selected: 0,
-                        filtered: models,
-                    });
-                }
+                    && self.gallery.entries.get(self.gallery.selected).is_some() =>
+            {
+                let models = self.available_upscaler_models();
+                self.popup = Some(Popup::UpscaleModelSelector {
+                    filter: String::new(),
+                    selected: 0,
+                    filtered: models,
+                });
             }
-            Action::RemoveModel => {
-                if self.active_view == View::Models {
-                    if let Some(model) = self.models.catalog.get(self.models.selected) {
-                        if !model.downloaded {
-                            return;
-                        }
-                        let name = model.info.name.clone();
-
-                        // Block removal during active generation or pull
-                        if self.generate.generating && self.generate.params.model == name {
-                            self.generate.error_message =
-                                Some("Cannot remove a model while generating".to_string());
-                            return;
-                        }
-                        if mold_core::download::has_pulling_marker(&name) {
-                            self.generate.error_message =
-                                Some("Cannot remove a model while it is being pulled".to_string());
-                            return;
-                        }
-
-                        let message = self.build_remove_model_message(&name);
-                        self.popup = Some(Popup::Confirm {
-                            message,
-                            on_confirm: ConfirmAction::RemoveModel(name),
-                        });
+            Action::RemoveModel if self.active_view == View::Models => {
+                if let Some(model) = self.models.catalog.get(self.models.selected) {
+                    if !model.downloaded {
+                        return;
                     }
+                    let name = model.info.name.clone();
+
+                    // Block removal during active generation or pull
+                    if self.generate.generating && self.generate.params.model == name {
+                        self.generate.error_message =
+                            Some("Cannot remove a model while generating".to_string());
+                        return;
+                    }
+                    if mold_core::download::has_pulling_marker(&name) {
+                        self.generate.error_message =
+                            Some("Cannot remove a model while it is being pulled".to_string());
+                        return;
+                    }
+
+                    let message = self.build_remove_model_message(&name);
+                    self.popup = Some(Popup::Confirm {
+                        message,
+                        on_confirm: ConfirmAction::RemoveModel(name),
+                    });
                 }
             }
             _ => {}
@@ -3507,10 +3474,8 @@ impl App {
             SettingsFieldType::Number { min, max, step } => {
                 self.settings_adjust_number(key, delta as f64 * step, min, max);
             }
-            SettingsFieldType::Toggle { options } => {
-                if !options.is_empty() {
-                    self.settings_cycle_toggle(key, &options, delta);
-                }
+            SettingsFieldType::Toggle { options } if !options.is_empty() => {
+                self.settings_cycle_toggle(key, &options, delta);
             }
             SettingsFieldType::Bool => {
                 self.settings_toggle_bool(key);

--- a/crates/mold-tui/src/gallery_scan.rs
+++ b/crates/mold-tui/src/gallery_scan.rs
@@ -133,7 +133,7 @@ pub fn scan_images_local() -> Vec<GalleryEntry> {
         }
     }
 
-    entries.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+    entries.sort_by_key(|e| std::cmp::Reverse(e.timestamp));
     entries
 }
 

--- a/crates/mold-tui/src/ui/param_form.rs
+++ b/crates/mold-tui/src/ui/param_form.rs
@@ -70,13 +70,11 @@ pub fn render(frame: &mut Frame, theme: &Theme, state: &GenerateState, area: Rec
         // Add indicator for dropdown/toggle fields
         let suffix = match field {
             ParamField::Model => " \u{25bc}", // down triangle
-            ParamField::Format | ParamField::Mode | ParamField::Expand | ParamField::Offload => {
-                if is_selected {
-                    " \u{25c0}\u{25b6}"
-                } else {
-                    ""
-                } // left/right arrows
-            }
+            ParamField::Format | ParamField::Mode | ParamField::Expand | ParamField::Offload
+                if is_selected =>
+            {
+                " \u{25c0}\u{25b6}"
+            } // left/right arrows
             ParamField::Width
             | ParamField::Height
             | ParamField::Steps
@@ -85,12 +83,10 @@ pub fn render(frame: &mut Frame, theme: &Theme, state: &GenerateState, area: Rec
             | ParamField::Frames
             | ParamField::Fps
             | ParamField::Strength
-            | ParamField::ControlScale => {
-                if is_selected {
-                    " \u{25c0}\u{25b6}"
-                } else {
-                    ""
-                }
+            | ParamField::ControlScale
+                if is_selected =>
+            {
+                " \u{25c0}\u{25b6}"
             }
             _ => "",
         };

--- a/crates/mold-tui/src/ui/settings.rs
+++ b/crates/mold-tui/src/ui/settings.rs
@@ -77,21 +77,15 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect) {
                     ""
                 } else {
                     match field_type {
-                        SettingsFieldType::Text | SettingsFieldType::Path => {
-                            if is_selected {
-                                " \u{25bc}"
-                            } else {
-                                ""
-                            }
+                        SettingsFieldType::Text | SettingsFieldType::Path if is_selected => {
+                            " \u{25bc}"
                         }
                         SettingsFieldType::Number { .. }
                         | SettingsFieldType::Toggle { .. }
-                        | SettingsFieldType::Bool => {
-                            if is_selected {
-                                " \u{25c0}\u{25b6}"
-                            } else {
-                                ""
-                            }
+                        | SettingsFieldType::Bool
+                            if is_selected =>
+                        {
+                            " \u{25c0}\u{25b6}"
                         }
                         _ => "",
                     }

--- a/flake.lock
+++ b/flake.lock
@@ -101,11 +101,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773284828,
-        "narHash": "sha256-0qI+a9z7KpYCBbp4ENN32b2tf0VmC3MhgFw1KAroqxQ=",
+        "lastModified": 1776350315,
+        "narHash": "sha256-ijD4bgb5Iyap9F3MX73vLAZF/SYu+q7Gd7Ux4cbfCWw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "2b18fe48d9a8a4ff3850d56b67cfe72f2a589237",
+        "rev": "62e3b8aedabc240e5b0cc9fae003bc9edfebbc9b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

Fixes #224 — video outputs were saved as single-frame PNGs instead of real mp4/gif/apng files.

- **Root cause**: Both the SSE and non-SSE HTTP transport paths between server and client discarded `VideoData`, hardcoding `response.video = None`. The CLI then fell through to the image save path, writing a first-frame PNG thumbnail with the requested video extension.
- **SSE path**: `SseCompleteEvent` now carries optional `video_frames`, `video_fps`, `video_thumbnail`, `video_gif_preview`, and audio metadata fields. Server populates them from `VideoData`; client reconstructs `VideoData` when `video_frames` is present.
- **Non-SSE path**: Server sends `x-mold-video-*` response headers (frames, fps, dimensions, audio info). Client detects `x-mold-video-frames` and reconstructs `VideoData` from headers + body bytes.
- **CORS**: All new `x-mold-video-*` headers exposed via `Access-Control-Expose-Headers` for cross-origin browser clients.
- **Preview fallback**: Non-SSE video responses fall back to previewing the raw video data (works for GIF/APNG/WebP; silently skips MP4).
- Bumps version to **0.7.1**.

## Test plan

- [x] `cargo check --workspace` — clean
- [x] `cargo clippy --workspace -- -D warnings` — zero warnings
- [x] `cargo test --workspace` — 1,897 tests pass
- [x] `cargo check -p mold-ai --features preview,discord,expand,tui,webp,mp4` — feature-gated build clean
- [x] `cargo fmt --check` — clean
- [x] New tests: `SseCompleteEvent` video roundtrip, backward compat (no video fields), image-only event omits `video_*` keys, `parse_video_headers` with/without frames/audio/fps
- [x] Codex peer review — both findings (CORS headers, preview fallback) addressed
- [ ] End-to-end: `mold run ltx-2.3-22b-distilled:fp8 "..." --format mp4` produces a real MP4
- [ ] End-to-end: `mold run ltx-video-0.9.8-2b-distilled:bf16 "..." --format gif` produces an animated GIF
- [ ] End-to-end: remote client via `MOLD_HOST` produces correct video files