### PR TITLE
fix: reject LTX-2.3 camera-control preset aliases at the CLI layer (#227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **LTX-2.3 camera-control preset validation**: `--camera-control` preset aliases (`dolly-in`, `dolly-left`, `dolly-out`, `dolly-right`, `jib-down`, `jib-up`, `static`) now fail locally at the CLI layer with an explicit "Lightricks has not released camera-control LoRAs for LTX-2.3 yet" message when paired with an LTX-2.3 model, instead of failing server-side after the HTTP round-trip. Explicit `.safetensors` paths still work for LTX-2.3. `--camera-control` help text now documents the 19B-only preset limitation ([#227](https://github.com/utensils/mold/issues/227)).
 - **Remote pull progress bars dropped file names on completion**: completed download progress bars showed `done` as the prefix instead of the file name (e.g. `[1/20] config.json`), so only the in-flight file was identifiable. Completed bars now keep their `[i/N] <filename>` label both during and after download ([#223](https://github.com/utensils/mold/issues/223)).
+
 
 ## [0.7.1] - 2026-04-16
 

--- a/crates/mold-cli/src/commands/run.rs
+++ b/crates/mold-cli/src/commands/run.rs
@@ -97,6 +97,7 @@ struct FileArgRefs<'a> {
     video: Option<&'a str>,
     camera_control: Option<&'a str>,
     output: Option<&'a str>,
+    model: Option<&'a str>,
 }
 
 #[cfg(test)]
@@ -211,18 +212,26 @@ fn validate_file_args_full(args: FileArgRefs<'_>) -> Result<()> {
         }
     }
 
-    if let Some(camera_control_path) = args
-        .camera_control
-        .filter(|value| value.ends_with(".safetensors"))
-    {
-        let p = Path::new(camera_control_path);
-        if p.is_dir() {
-            anyhow::bail!(
-                "--camera-control path is a directory, not a .safetensors file: {camera_control_path}"
-            );
-        }
-        if !p.exists() {
-            anyhow::bail!("--camera-control file not found: {camera_control_path}");
+    if let Some(camera_control_value) = args.camera_control {
+        if camera_control_value.ends_with(".safetensors") {
+            let p = Path::new(camera_control_value);
+            if p.is_dir() {
+                anyhow::bail!(
+                    "--camera-control path is a directory, not a .safetensors file: {camera_control_value}"
+                );
+            }
+            if !p.exists() {
+                anyhow::bail!("--camera-control file not found: {camera_control_value}");
+            }
+        } else if let Some(model) = args.model {
+            if model.contains("ltx-2.3") {
+                anyhow::bail!(
+                    "--camera-control preset '{camera_control_value}' is published only for LTX-2 19B; \
+                     Lightricks has not released camera-control LoRAs for LTX-2.3 yet. \
+                     Pass an explicit .safetensors path with --camera-control /path/to/lora.safetensors, \
+                     or switch to an LTX-2 19B model."
+                );
+            }
         }
     }
 
@@ -393,6 +402,7 @@ pub async fn run(
         video: video.as_deref(),
         camera_control: camera_control.as_deref(),
         output: output.as_deref(),
+        model: Some(model.as_str()),
     })?;
     for lora_path in &lora {
         validate_file_args_full(FileArgRefs {
@@ -1011,6 +1021,44 @@ mod tests {
     #[test]
     fn validate_lora_camera_control_alias() {
         assert!(validate_file_args(Some("camera-control:static"), None, None, None, None).is_ok());
+    }
+
+    #[test]
+    fn camera_control_preset_rejected_on_ltx_2_3() {
+        let err = validate_file_args_full(FileArgRefs {
+            camera_control: Some("dolly-in"),
+            model: Some("ltx-2.3-22b-distilled:fp8"),
+            ..FileArgRefs::default()
+        })
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("LTX-2 19B") && msg.contains("LTX-2.3"),
+            "expected LTX-2.3 publishing gap message, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn camera_control_preset_accepted_on_ltx_2_19b() {
+        assert!(validate_file_args_full(FileArgRefs {
+            camera_control: Some("dolly-in"),
+            model: Some("ltx-2-19b-distilled:fp8"),
+            ..FileArgRefs::default()
+        })
+        .is_ok());
+    }
+
+    #[test]
+    fn camera_control_explicit_path_accepted_on_ltx_2_3() {
+        let path = std::env::temp_dir().join("mold-test-ltx23-camera.safetensors");
+        std::fs::write(&path, b"dummy").unwrap();
+        let result = validate_file_args_full(FileArgRefs {
+            camera_control: Some(path.to_str().unwrap()),
+            model: Some("ltx-2.3-22b-distilled:fp8"),
+            ..FileArgRefs::default()
+        });
+        std::fs::remove_file(&path).ok();
+        assert!(result.is_ok(), "explicit .safetensors should bypass gate");
     }
 
     // -- --image tests --

--- a/crates/mold-cli/src/main.rs
+++ b/crates/mold-cli/src/main.rs
@@ -244,6 +244,11 @@ Examples:
         temporal_upscale: Option<Ltx2TemporalUpscaleArg>,
 
         /// Camera-control LoRA preset name or .safetensors path.
+        ///
+        /// Preset aliases (dolly-in, dolly-left, dolly-out, dolly-right,
+        /// jib-down, jib-up, static) currently resolve only Lightricks' LTX-2
+        /// 19B LoRAs; LTX-2.3 has no published presets yet, so use an explicit
+        /// .safetensors path for LTX-2.3.
         #[arg(long, help_heading = "Video")]
         camera_control: Option<String>,
 


### PR DESCRIPTION
## Summary

- Validate `--camera-control` preset aliases against the model family at the CLI layer instead of after the HTTP round-trip.
- Emit an explicit "Lightricks has not released camera-control LoRAs for LTX-2.3 yet" error that names the escape hatch (explicit `.safetensors` path).
- Document the 19B-only preset limitation in the `--camera-control` help text.

## Context

Closes #227.

Preset aliases (`dolly-in`, `dolly-left`, `dolly-out`, `dolly-right`, `jib-down`, `jib-up`, `static`) currently resolve only to the published `Lightricks/LTX-2-19b-LoRA-Camera-Control-*` repos — LTX-2.3 has no published camera-control LoRAs at the time of writing. Previously the CLI accepted the flag on any LTX-2 model, built the `camera-control:<preset>` virtual alias, and sent the request, only to have `resolve_camera_control_preset_path()` in `mold-inference` bail with a generic message after reaching the server.

With this change, the same command fails locally before any request is sent, and the error explicitly names the root cause plus the `--camera-control /path/to/lora.safetensors` escape hatch. Explicit `.safetensors` paths continue to work for LTX-2.3.

## Changes

- `crates/mold-cli/src/commands/run.rs`: `FileArgRefs` gains `model: Option<&'a str>`; `validate_file_args_full` rejects preset aliases on `ltx-2.3` models before the request is built.
- `crates/mold-cli/src/main.rs`: `--camera-control` help text documents the 19B-only preset limitation.
- `CHANGELOG.md`: `Unreleased` fix entry.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p mold-ai --bin mold -- -D warnings` — clean
- [x] `cargo test -p mold-ai --bin mold` — 319 passed, 0 failed
- [x] Three new tests cover the gate:
  - `camera_control_preset_rejected_on_ltx_2_3`
  - `camera_control_preset_accepted_on_ltx_2_19b`
  - `camera_control_explicit_path_accepted_on_ltx_2_3`

## Not in this PR

#226 (LTX-2 19B distilled rainbow/static output) is being investigated separately — the root cause is a frame-count budget issue (`frames > 153` overflows the LTX-2 temporal RoPE `max_pos[0] = 20`), not related to camera-control handling. A follow-up PR will cover that validation tightening.