### PR TITLE
fix(docker): pin web-builder to bun 1.3 for new lockfile format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,11 @@
 # The gallery is served by `mold serve` as a SPA fallback. Building it
 # in a dedicated stage keeps the Rust builder free of Node/bun tooling
 # and avoids re-running `bun install` on every cargo cache invalidation.
-FROM oven/bun:1.1-alpine AS web-builder
+#
+# Pinned to bun 1.3 — `web/bun.lock` is a v1 text lockfile written by
+# bun 1.2+; older bun versions (e.g. 1.1.x) reject it with
+# "Unknown lockfile version".
+FROM oven/bun:1.3-alpine AS web-builder
 WORKDIR /web
 COPY web/package.json web/bun.lock web/tsconfig.json web/tsconfig.app.json web/tsconfig.node.json web/vite.config.ts web/index.html ./
 RUN bun install --frozen-lockfile


### PR DESCRIPTION
## Summary

Main-branch Docker build started failing after #235 merged:

```
#15 [web-builder 4/7] RUN bun install --frozen-lockfile
error: Unknown lockfile version
    at bun.lock:2:22
InvalidLockfileVersion: failed to parse lockfile: 'bun.lock'
error: lockfile had changes, but lockfile is frozen
```

The `oven/bun:1.1-alpine` base ships bun 1.1.45. Our `web/bun.lock` is a v1 text lockfile (bun 1.2+ format), written locally with bun 1.3.12. Bumping the web-builder stage to `oven/bun:1.3-alpine` aligns it with the lockfile generator.

## Test plan

- [x] `head -2 web/bun.lock` confirms `"lockfileVersion": 1` (the new text format)
- [ ] Docker CI build succeeds on this PR (will confirm once workflow runs)