### PR TITLE
chore: release 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-04-17
+
+*Native RunPod CLI, web gallery UI, and hardening across the board.*
+
 ### Added
 
 - **Native RunPod support via `mold runpod` subcommand tree**: manage RunPod cloud GPU pods end-to-end from the same `mold` binary. `mold runpod run "<prompt>"` creates a pod with smart defaults (cheapest GPU with enough VRAM for the requested model, matching GHCR image tag, automatic DC fallback when scheduling stalls), waits for the mold server to boot, streams generation progress over SSE, and saves the result to `./mold-outputs/`. Full subcommand surface: `doctor`, `gpus`, `datacenters`, `list`, `get`, `create`, `stop`, `start`, `delete`, `connect`, `logs`, `usage`, `run`. Adds a `[runpod]` config section (`api_key`, `default_gpu`, `default_datacenter`, `default_network_volume_id`, `auto_teardown`, `auto_teardown_idle_mins`, `cost_alert_usd`, `endpoint`), `RUNPOD_API_KEY` env precedence, dynamic shell completion for pod/gpu/datacenter/cloud-type arguments, and spend history in `~/.mold/runpod-history.jsonl`. NixOS module gains a `runpodApiKeyFile` option that mirrors the existing `hfTokenFile`/`apiKeyFile` secret-loader pattern.
@@ -421,7 +425,9 @@ Initial public release on [crates.io](https://crates.io/crates/mold-ai).
 | [`mold-ai-inference`](https://crates.io/crates/mold-ai-inference) | Candle-based inference engine           |
 | [`mold-ai-server`](https://crates.io/crates/mold-ai-server)       | Axum HTTP inference server              |
 
-[Unreleased]: https://github.com/utensils/mold/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/utensils/mold/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/utensils/mold/compare/v0.7.1...v0.8.0
+[0.7.1]: https://github.com/utensils/mold/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/utensils/mold/compare/v0.6.3...v0.7.0
 [0.6.3]: https://github.com/utensils/mold/compare/v0.6.2...v0.6.3
 [0.6.2]: https://github.com/utensils/mold/compare/v0.6.1...v0.6.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2893,7 +2893,7 @@ dependencies = [
 
 [[package]]
 name = "mold-ai"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2931,7 +2931,7 @@ dependencies = [
 
 [[package]]
 name = "mold-ai-core"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2955,7 +2955,7 @@ dependencies = [
 
 [[package]]
 name = "mold-ai-discord"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "mold-ai-core",
@@ -2969,7 +2969,7 @@ dependencies = [
 
 [[package]]
 name = "mold-ai-inference"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "candle-core-mold",
@@ -2999,7 +2999,7 @@ dependencies = [
 
 [[package]]
 name = "mold-ai-server"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3033,7 +3033,7 @@ dependencies = [
 
 [[package]]
 name = "mold-ai-tui"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "crossterm 0.28.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.7.1"
+version = "0.8.0"
 edition = "2021"
 license = "MIT"
 authors = ["James Brink <brink.james@gmail.com>"]

--- a/crates/mold-cli/Cargo.toml
+++ b/crates/mold-cli/Cargo.toml
@@ -26,9 +26,9 @@ mp4 = ["mold-inference/mp4"]
 metrics = ["mold-server/metrics"]
 
 [dependencies]
-mold-core = { path = "../mold-core", package = "mold-ai-core", version = "0.7.0" }
-mold-inference = { path = "../mold-inference", package = "mold-ai-inference", version = "0.7.0" }
-mold-server = { path = "../mold-server", package = "mold-ai-server", version = "0.7.0" }
+mold-core = { path = "../mold-core", package = "mold-ai-core", version = "0.8.0" }
+mold-inference = { path = "../mold-inference", package = "mold-ai-inference", version = "0.8.0" }
+mold-server = { path = "../mold-server", package = "mold-ai-server", version = "0.8.0" }
 anyhow = "1"
 base64 = "0.22"
 clap = { version = "4", features = ["derive", "env", "unstable-ext"] }
@@ -51,8 +51,8 @@ tokio = { version = "1", features = ["full"] }
 toml = "0.8"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 viuer = { version = "0.11", optional = true }
-mold-discord = { path = "../mold-discord", package = "mold-ai-discord", version = "0.7.0", optional = true }
-mold-tui = { path = "../mold-tui", package = "mold-ai-tui", version = "0.7.0", optional = true }
+mold-discord = { path = "../mold-discord", package = "mold-ai-discord", version = "0.8.0", optional = true }
+mold-tui = { path = "../mold-tui", package = "mold-ai-tui", version = "0.8.0", optional = true }
 walkdir = "2.5.0"
 
 [dev-dependencies]

--- a/crates/mold-discord/Cargo.toml
+++ b/crates/mold-discord/Cargo.toml
@@ -14,7 +14,7 @@ name = "mold-discord"
 path = "src/main.rs"
 
 [dependencies]
-mold-core = { path = "../mold-core", package = "mold-ai-core", version = "0.7.0" }
+mold-core = { path = "../mold-core", package = "mold-ai-core", version = "0.8.0" }
 poise = "0.6"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"

--- a/crates/mold-inference/Cargo.toml
+++ b/crates/mold-inference/Cargo.toml
@@ -38,7 +38,7 @@ path = "src/bin/ltx2_vae_probe.rs"
 required-features = ["dev-bins", "mp4"]
 
 [dependencies]
-mold-core = { path = "../mold-core", package = "mold-ai-core", version = "0.7.0" }
+mold-core = { path = "../mold-core", package = "mold-ai-core", version = "0.8.0" }
 anyhow = "1"
 candle-core = { package = "candle-core-mold", version = "0.9.10" }
 candle-nn = { package = "candle-nn-mold", version = "0.9.10" }

--- a/crates/mold-server/Cargo.toml
+++ b/crates/mold-server/Cargo.toml
@@ -25,8 +25,8 @@ metrics = ["dep:metrics", "dep:metrics-exporter-prometheus"]
 
 
 [dependencies]
-mold-core = { path = "../mold-core", package = "mold-ai-core", version = "0.7.0" }
-mold-inference = { path = "../mold-inference", package = "mold-ai-inference", version = "0.7.0" }
+mold-core = { path = "../mold-core", package = "mold-ai-core", version = "0.8.0" }
+mold-inference = { path = "../mold-inference", package = "mold-ai-inference", version = "0.8.0" }
 anyhow = "1"
 axum = "0.7"
 serde = { version = "1", features = ["derive"] }

--- a/crates/mold-tui/Cargo.toml
+++ b/crates/mold-tui/Cargo.toml
@@ -16,8 +16,8 @@ metal = ["mold-inference/metal"]
 expand = ["mold-inference/expand"]
 
 [dependencies]
-mold-core = { path = "../mold-core", package = "mold-ai-core", version = "0.7.0" }
-mold-inference = { path = "../mold-inference", package = "mold-ai-inference", version = "0.7.0" }
+mold-core = { path = "../mold-core", package = "mold-ai-core", version = "0.8.0" }
+mold-inference = { path = "../mold-inference", package = "mold-ai-inference", version = "0.8.0" }
 ratatui = { version = "0.29", features = ["crossterm"] }
 crossterm = "0.28"
 ratatui-image = "4"

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mold-web",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "private": true,
   "type": "module",
   "description": "Web gallery for the mold AI image/video generation server.",


### PR DESCRIPTION
## Summary

Tags the six-week `[Unreleased]` accumulation as **0.8.0** — native RunPod CLI, web gallery UI, and a pile of hardening across gallery + RunPod + docs.

### Version bumps

| Surface | Before | After |
|---|---|---|
| `Cargo.toml` workspace.package.version | `0.7.1` | `0.8.0` |
| Inter-crate dep minima (`mold-core`, `mold-inference`, `mold-server`, `mold-discord`, `mold-tui`) | `0.7.0` | `0.8.0` |
| `web/package.json` | `0.7.1` | `0.8.0` |
| `CHANGELOG.md` `[Unreleased]` section | — | `[0.8.0] - 2026-04-17` |
| `CHANGELOG.md` footer compare link | `v0.7.0...HEAD` | `v0.8.0...HEAD`, plus new `[0.7.1]` + `[0.8.0]` entries |

### What's in 0.8.0

Big headline features from the [Unreleased] block now tagged:

- **Native RunPod support** — `mold runpod` subcommand tree (doctor, gpus, datacenters, list, get, create, stop, start, delete, connect, logs, usage, run)
- **Web gallery UI** — Vue 3 + Vite + Tailwind v4.2 SPA, bundled into the RunPod container at `/opt/mold/web`, `MOLD_WEB_DIR` preset
- **Gallery API** — full format matrix (png/jpeg/gif/apng/webp/mp4), HTTP Range for `<video>` scrubbing, MP4 first-frame thumbnails via openh264, scan-time validation with solid-black heuristic
- **Gallery delete is opt-in** — `MOLD_GALLERY_ALLOW_DELETE=1` + `/api/capabilities` for client-side affordance gating
- **Agent-safe RunPod** — no interactive prompts anywhere; SIGINT-safe provisioning; model-size-aware GPU picking; smart HF_TOKEN resolution; network-volume DC pinning
- Plus the usual hardening (warm-pod reuse respects `--gpu`/`--dc`, GraphQL endpoint override, dockerignore asset preservation, apt retry, bun lockfile compat)

Full list is in `CHANGELOG.md` under `[0.8.0]`.

## Test plan

- [x] `cargo check -p mold-ai` compiles clean at 0.8.0 across all crates
- [x] `CHANGELOG.md` footer links verified (no duplicates, compare URLs resolve once the tag lands)
- [ ] Auto-merge → release workflow tags `v0.8.0`, builds GHCR images, publishes GitHub release