### PR TITLE
feat(tui,cli): animated GIF/APNG/WebP playback in gallery + preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Animated video playback in TUI gallery detail and CLI `--preview`**: GIF/APNG/animated-WebP previews now play their full frame sequence instead of freezing on the first frame. The TUI gallery detail view, generation viewport, and CLI `--preview` all decode every frame up front, advance on each frame's recorded delay (clamped to ≥20 ms / ≤50 fps), and loop. The CLI replays short clips (<1.5 s gets 3 plays, <3 s gets 2, longer plays once) using ANSI cursor save/restore so each frame overwrites the previous in place. Decoder lives in `crates/mold-tui/src/animation.rs` and is shared by the gallery preview path and the post-generation video preview ([#179](https://github.com/utensils/mold/issues/179)).
+
 ## [0.8.1] - 2026-04-17
 
 *Single-binary web gallery: SPA is now embedded at compile time.*

--- a/crates/mold-cli/src/commands/generate.rs
+++ b/crates/mold-cli/src/commands/generate.rs
@@ -1382,18 +1382,127 @@ pub(crate) fn preview_image(data: &[u8]) {
         return;
     }
 
+    let term_program = std::env::var("TERM_PROGRAM").ok();
+    let term = std::env::var("TERM").ok();
+    let backend = preview_backend(term_program.as_deref(), term.as_deref());
+
+    // Try to decode as an animated container first (GIF/APNG/animated WebP).
+    if let Some(frames) = decode_preview_animation(data) {
+        if frames.len() >= 2 {
+            animate_preview(&frames, backend);
+            return;
+        }
+    }
+
     let Ok(img) = image::load_from_memory(data) else {
         return;
     };
-    let term_program = std::env::var("TERM_PROGRAM").ok();
-    let term = std::env::var("TERM").ok();
-    match preview_backend(term_program.as_deref(), term.as_deref()) {
+    render_preview_frame(&img, backend);
+}
+
+#[cfg(feature = "preview")]
+fn render_preview_frame(img: &image::DynamicImage, backend: PreviewBackend) {
+    match backend {
         PreviewBackend::GhosttyKitty => {
-            let _ = print_ghostty_kitty_preview(&img);
+            let _ = print_ghostty_kitty_preview(img);
         }
         PreviewBackend::ViuerAuto => {
             let conf = preview_config();
-            let _ = viuer::print(&img, &conf);
+            let _ = viuer::print(img, &conf);
+        }
+    }
+}
+
+/// Decoded frame for CLI preview animation.
+#[cfg(feature = "preview")]
+struct CliAnimatedFrame {
+    image: image::DynamicImage,
+    delay: Duration,
+}
+
+#[cfg(feature = "preview")]
+fn decode_preview_animation(data: &[u8]) -> Option<Vec<CliAnimatedFrame>> {
+    use image::AnimationDecoder;
+    use std::io::Cursor;
+
+    // Sniff the container before paying for a full decode.
+    let is_gif = data.len() >= 6 && (data.starts_with(b"GIF87a") || data.starts_with(b"GIF89a"));
+    let is_png_sig =
+        data.len() >= 8 && data[..8] == [0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A];
+    let is_webp = data.len() >= 12 && &data[..4] == b"RIFF" && &data[8..12] == b"WEBP";
+
+    let frames: Vec<_> = if is_gif {
+        image::codecs::gif::GifDecoder::new(Cursor::new(data))
+            .ok()?
+            .into_frames()
+            .collect_frames()
+            .ok()?
+    } else if is_png_sig {
+        let decoder = image::codecs::png::PngDecoder::new(Cursor::new(data)).ok()?;
+        decoder.apng().ok()?.into_frames().collect_frames().ok()?
+    } else if is_webp {
+        image::codecs::webp::WebPDecoder::new(Cursor::new(data))
+            .ok()?
+            .into_frames()
+            .collect_frames()
+            .ok()?
+    } else {
+        return None;
+    };
+
+    let mut out = Vec::with_capacity(frames.len());
+    for frame in frames {
+        let (num, den) = frame.delay().numer_denom_ms();
+        // `numer_denom_ms()` is the delay in ms as the ratio num/den.
+        let micros = if den == 0 {
+            100_000
+        } else {
+            (u64::from(num) * 1000) / u64::from(den.max(1))
+        };
+        let delay = Duration::from_micros(micros).max(Duration::from_millis(20));
+        let image = image::DynamicImage::ImageRgba8(frame.into_buffer());
+        out.push(CliAnimatedFrame { image, delay });
+    }
+    if out.is_empty() {
+        None
+    } else {
+        Some(out)
+    }
+}
+
+/// Decide how many times to loop the animation for the CLI preview. A short
+/// clip gets looped a couple of times so the motion is easy to see; longer
+/// clips play once. Pure function for testability.
+#[cfg(any(feature = "preview", test))]
+fn preview_loop_count(total: Duration) -> u32 {
+    if total < Duration::from_millis(1500) {
+        3
+    } else if total < Duration::from_secs(3) {
+        2
+    } else {
+        1
+    }
+}
+
+#[cfg(feature = "preview")]
+fn animate_preview(frames: &[CliAnimatedFrame], backend: PreviewBackend) {
+    let total: Duration = frames.iter().map(|f| f.delay).sum();
+    let loops = preview_loop_count(total);
+
+    // Save the cursor position once; restore before each frame so every
+    // render lands at the same spot and overwrites the previous frame.
+    // After the final frame, the backend naturally leaves the cursor
+    // below the image — no further restore needed.
+    let mut stdout = std::io::stdout();
+    let _ = stdout.write_all(b"\x1b[s");
+    let _ = stdout.flush();
+
+    for _ in 0..loops {
+        for frame in frames {
+            let _ = stdout.write_all(b"\x1b[u");
+            let _ = stdout.flush();
+            render_preview_frame(&frame.image, backend);
+            std::thread::sleep(frame.delay);
         }
     }
 }
@@ -1788,5 +1897,16 @@ mod tests {
             build_ghostty_kitty_preview_payload(&img, 80, 24).expect("payload should build");
         assert_eq!((cell_w, cell_h), (80, 23));
         assert!(payload.starts_with("\u{1b}_Gf=100,a=T,t=d,c=80,r=23,"));
+    }
+
+    #[test]
+    fn preview_loop_count_replays_short_clips() {
+        // ≤1.5s gets 3 plays, ≤3s gets 2, longer plays once.
+        assert_eq!(preview_loop_count(Duration::from_millis(500)), 3);
+        assert_eq!(preview_loop_count(Duration::from_millis(1499)), 3);
+        assert_eq!(preview_loop_count(Duration::from_millis(1500)), 2);
+        assert_eq!(preview_loop_count(Duration::from_millis(2999)), 2);
+        assert_eq!(preview_loop_count(Duration::from_millis(3000)), 1);
+        assert_eq!(preview_loop_count(Duration::from_secs(30)), 1);
     }
 }

--- a/crates/mold-tui/src/animation.rs
+++ b/crates/mold-tui/src/animation.rs
@@ -1,0 +1,291 @@
+//! Decoding helpers for animated previews (GIF/APNG/WebP).
+//!
+//! The TUI gallery detail view and generation viewport need frame-by-frame
+//! playback for video previews, but `ratatui-image` only renders a single
+//! image. This module decodes an animated file into a `Vec<AnimatedFrame>`
+//! that callers can advance on a timer.
+
+use std::fs::File;
+use std::io::{BufRead, BufReader, Cursor, Seek};
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use anyhow::{anyhow, Context, Result};
+use image::{AnimationDecoder, DynamicImage};
+
+/// A single decoded animation frame plus its delay before the next frame.
+#[derive(Debug, Clone)]
+pub struct AnimatedFrame {
+    pub image: DynamicImage,
+    pub delay: Duration,
+}
+
+/// Per-source animation state used by the TUI to drive frame advancement.
+pub struct AnimationState {
+    pub frames: Vec<AnimatedFrame>,
+    pub current: usize,
+    pub last_advance: Instant,
+}
+
+impl AnimationState {
+    pub fn new(frames: Vec<AnimatedFrame>) -> Option<Self> {
+        if frames.len() < 2 {
+            return None;
+        }
+        Some(Self {
+            frames,
+            current: 0,
+            last_advance: Instant::now(),
+        })
+    }
+
+    /// Advance to the next frame if the current frame's delay has elapsed.
+    /// Returns `true` when the frame index changed (caller should rebuild
+    /// the image protocol).
+    pub fn tick(&mut self) -> bool {
+        if self.frames.len() < 2 {
+            return false;
+        }
+        let delay = self.frames[self.current].delay;
+        if self.last_advance.elapsed() < delay {
+            return false;
+        }
+        self.current = (self.current + 1) % self.frames.len();
+        self.last_advance = Instant::now();
+        true
+    }
+
+    pub fn current_image(&self) -> &DynamicImage {
+        &self.frames[self.current].image
+    }
+}
+
+/// Decode an animated file from disk. Supports GIF, APNG, and WebP. Returns
+/// `Err` for non-animated or unsupported inputs.
+pub fn decode_animation_path(path: &Path) -> Result<Vec<AnimatedFrame>> {
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|s| s.to_lowercase());
+    let file = File::open(path).with_context(|| format!("opening {}", path.display()))?;
+    let reader = BufReader::new(file);
+    decode_with_hint(reader, ext.as_deref(), Some(path))
+}
+
+/// Decode animation from raw bytes. `hint_ext` is an optional file extension
+/// (without the dot) used to dispatch to the right codec; when omitted we
+/// sniff the magic bytes.
+pub fn decode_animation_bytes(data: &[u8], hint_ext: Option<&str>) -> Result<Vec<AnimatedFrame>> {
+    let ext = hint_ext
+        .map(|s| s.to_lowercase())
+        .or_else(|| sniff_ext(data));
+    decode_with_hint(Cursor::new(data), ext.as_deref(), None)
+}
+
+/// Cheap check: does this byte buffer look like an animated container we
+/// know how to play (GIF/APNG/WebP)? Used by the CLI preview to decide
+/// whether to call into the animated playback path.
+pub fn is_animated_bytes(data: &[u8]) -> bool {
+    match sniff_ext(data).as_deref() {
+        Some("gif") => true,
+        Some("png") => is_apng(data),
+        Some("webp") => is_animated_webp(data),
+        _ => false,
+    }
+}
+
+fn sniff_ext(data: &[u8]) -> Option<String> {
+    if data.len() >= 6 && (data.starts_with(b"GIF87a") || data.starts_with(b"GIF89a")) {
+        return Some("gif".into());
+    }
+    if data.len() >= 8 && data[..8] == [0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A] {
+        return Some("png".into());
+    }
+    if data.len() >= 12 && &data[..4] == b"RIFF" && &data[8..12] == b"WEBP" {
+        return Some("webp".into());
+    }
+    None
+}
+
+fn is_apng(data: &[u8]) -> bool {
+    // After the 8-byte PNG signature, scan chunks for an `acTL` (animation
+    // control) chunk, which is the apng marker. Stop at IDAT (start of
+    // image data) since acTL must precede IDAT.
+    if data.len() < 8 || &data[..8] != [0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A].as_slice() {
+        return false;
+    }
+    let mut i = 8usize;
+    while i + 8 <= data.len() {
+        let len = u32::from_be_bytes([data[i], data[i + 1], data[i + 2], data[i + 3]]) as usize;
+        let kind = &data[i + 4..i + 8];
+        if kind == b"acTL" {
+            return true;
+        }
+        if kind == b"IDAT" {
+            return false;
+        }
+        // Advance past length(4) + type(4) + data(len) + crc(4)
+        let next = i.saturating_add(8).saturating_add(len).saturating_add(4);
+        if next <= i {
+            return false;
+        }
+        i = next;
+    }
+    false
+}
+
+fn is_animated_webp(data: &[u8]) -> bool {
+    // RIFF....WEBPVP8X<flags>... — animated bit (0x02) set in VP8X flags.
+    if data.len() < 21 || &data[12..16] != b"VP8X" {
+        return false;
+    }
+    let flags = data[20];
+    flags & 0x02 != 0
+}
+
+fn decode_with_hint<R: BufRead + Seek>(
+    reader: R,
+    ext: Option<&str>,
+    path: Option<&Path>,
+) -> Result<Vec<AnimatedFrame>> {
+    match ext {
+        Some("gif") => collect(image::codecs::gif::GifDecoder::new(reader)?.into_frames()),
+        Some("png") | Some("apng") => {
+            let decoder = image::codecs::png::PngDecoder::new(reader)?;
+            let apng = decoder
+                .apng()
+                .map_err(|e| anyhow!("not an animated PNG: {e}"))?;
+            collect(apng.into_frames())
+        }
+        Some("webp") => collect(image::codecs::webp::WebPDecoder::new(reader)?.into_frames()),
+        other => Err(anyhow!(
+            "unsupported animation format: {} ({})",
+            other.unwrap_or("<unknown>"),
+            path.map(|p| p.display().to_string())
+                .unwrap_or_else(|| "<bytes>".into())
+        )),
+    }
+}
+
+fn collect<I: Iterator<Item = image::ImageResult<image::Frame>>>(
+    frames: I,
+) -> Result<Vec<AnimatedFrame>> {
+    let mut out = Vec::new();
+    for frame in frames {
+        let frame = frame.context("decoding animation frame")?;
+        let (num, den) = frame.delay().numer_denom_ms();
+        // `numer_denom_ms()` returns the delay in milliseconds as a ratio
+        // num/den. Convert to microseconds for sub-millisecond accuracy and
+        // clamp at ~50 fps so a malformed `0/0` or absurdly small delay
+        // can't peg the event loop.
+        let micros = if den == 0 {
+            100_000
+        } else {
+            (u64::from(num) * 1000) / u64::from(den.max(1))
+        };
+        let delay = Duration::from_micros(micros).max(Duration::from_millis(20));
+        let image = DynamicImage::ImageRgba8(frame.into_buffer());
+        out.push(AnimatedFrame { image, delay });
+    }
+    if out.is_empty() {
+        return Err(anyhow!("animation contained no frames"));
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use image::codecs::gif::GifEncoder;
+    use image::Frame;
+
+    fn synth_gif(frames: u32, w: u32, h: u32) -> Vec<u8> {
+        let mut buf = Vec::new();
+        {
+            let mut enc = GifEncoder::new(&mut buf);
+            enc.set_repeat(image::codecs::gif::Repeat::Infinite)
+                .unwrap();
+            for i in 0..frames {
+                let img = image::RgbaImage::from_pixel(
+                    w,
+                    h,
+                    image::Rgba([(i * 30) as u8 % 255, 0, 0, 255]),
+                );
+                let delay = image::Delay::from_numer_denom_ms(80, 1);
+                enc.encode_frame(Frame::from_parts(img, 0, 0, delay))
+                    .unwrap();
+            }
+        }
+        buf
+    }
+
+    #[test]
+    fn sniff_gif_signature() {
+        let bytes = synth_gif(2, 4, 4);
+        assert_eq!(sniff_ext(&bytes).as_deref(), Some("gif"));
+        assert!(is_animated_bytes(&bytes));
+    }
+
+    #[test]
+    fn decode_multiframe_gif() {
+        let bytes = synth_gif(5, 8, 8);
+        let frames = decode_animation_bytes(&bytes, Some("gif")).unwrap();
+        assert_eq!(frames.len(), 5);
+        for f in &frames {
+            assert_eq!(f.image.width(), 8);
+            assert_eq!(f.image.height(), 8);
+            assert!(f.delay >= Duration::from_millis(20));
+        }
+    }
+
+    #[test]
+    fn animation_state_advances_after_delay() {
+        let bytes = synth_gif(3, 4, 4);
+        let frames = decode_animation_bytes(&bytes, Some("gif")).unwrap();
+        let mut state = AnimationState::new(frames).expect("multi-frame");
+        assert_eq!(state.current, 0);
+        // Force the delay to have elapsed.
+        state.last_advance = Instant::now() - Duration::from_secs(1);
+        assert!(state.tick());
+        assert_eq!(state.current, 1);
+        // Immediately ticking again should be a no-op (delay not elapsed).
+        assert!(!state.tick());
+    }
+
+    #[test]
+    fn animation_state_wraps_around() {
+        let bytes = synth_gif(2, 4, 4);
+        let frames = decode_animation_bytes(&bytes, Some("gif")).unwrap();
+        let mut state = AnimationState::new(frames).unwrap();
+        state.last_advance = Instant::now() - Duration::from_secs(1);
+        assert!(state.tick());
+        assert_eq!(state.current, 1);
+        state.last_advance = Instant::now() - Duration::from_secs(1);
+        assert!(state.tick());
+        assert_eq!(state.current, 0);
+    }
+
+    #[test]
+    fn animation_state_rejects_single_frame() {
+        let bytes = synth_gif(1, 4, 4);
+        let frames = decode_animation_bytes(&bytes, Some("gif")).unwrap();
+        assert!(AnimationState::new(frames).is_none());
+    }
+
+    #[test]
+    fn sniff_ignores_non_animated_inputs() {
+        assert!(sniff_ext(b"not an image").is_none());
+        assert!(!is_animated_bytes(b"not an image"));
+    }
+
+    #[test]
+    fn unsupported_format_errors() {
+        // JPEG bytes — not in the supported animated set.
+        let mut buf = Vec::new();
+        let img = image::RgbImage::from_pixel(4, 4, image::Rgb([10, 20, 30]));
+        image::DynamicImage::ImageRgb8(img)
+            .write_to(&mut Cursor::new(&mut buf), image::ImageFormat::Jpeg)
+            .unwrap();
+        assert!(decode_animation_bytes(&buf, Some("jpeg")).is_err());
+    }
+}

--- a/crates/mold-tui/src/app.rs
+++ b/crates/mold-tui/src/app.rs
@@ -646,6 +646,10 @@ pub struct GenerateState {
     pub progress: ProgressState,
     pub preview_image: Option<image::DynamicImage>,
     pub image_state: Option<StatefulProtocol>,
+    /// When the preview is an animated GIF/APNG/WebP, holds the decoded
+    /// frame list and current playback cursor. `image_state` always shows
+    /// the frame at `animation.current`.
+    pub animation: Option<crate::animation::AnimationState>,
     pub generating: bool,
     /// Number of images remaining in the current batch (0 when not batching).
     pub batch_remaining: u32,
@@ -669,6 +673,8 @@ pub struct GalleryState {
     pub selected: usize,
     pub preview_image: Option<image::DynamicImage>,
     pub image_state: Option<StatefulProtocol>,
+    /// Frame loop for animated previews (GIF/APNG/WebP).
+    pub animation: Option<crate::animation::AnimationState>,
     pub scanning: bool,
     pub view_mode: GalleryViewMode,
     /// Thumbnail StatefulProtocol instances, lazily populated during render.
@@ -1113,6 +1119,7 @@ impl App {
                 progress: ProgressState::default(),
                 preview_image: None,
                 image_state: None,
+                animation: None,
                 generating: false,
                 batch_remaining: 0,
                 last_seed: None,
@@ -1125,6 +1132,7 @@ impl App {
                 selected: 0,
                 preview_image: None,
                 image_state: None,
+                animation: None,
                 scanning: false,
                 view_mode: GalleryViewMode::Grid,
                 thumbnail_states: Vec::new(),
@@ -1263,6 +1271,7 @@ impl App {
             self.gallery.view_mode = GalleryViewMode::Grid;
             self.gallery.preview_image = None;
             self.gallery.image_state = None;
+            self.gallery.animation = None;
         }
 
         let tx = self.bg_tx.clone();
@@ -2444,6 +2453,7 @@ impl App {
                     self.gallery.view_mode = GalleryViewMode::Grid;
                     self.gallery.preview_image = None;
                     self.gallery.image_state = None;
+                    self.gallery.animation = None;
                 } else {
                     self.generate.error_message = None;
                 }
@@ -2645,10 +2655,14 @@ impl App {
                 let cache_path = crate::gallery_scan::image_cache_dir().join(&filename);
                 if cache_path.is_file() {
                     // Cached locally — load synchronously
+                    if self.try_install_gallery_animation(&cache_path) {
+                        return;
+                    }
                     if let Ok(img) = image::open(&cache_path) {
                         let protocol = self.picker.new_resize_protocol(img.clone());
                         self.gallery.preview_image = Some(img);
                         self.gallery.image_state = Some(protocol);
+                        self.gallery.animation = None;
                         return;
                     }
                 }
@@ -2664,24 +2678,69 @@ impl App {
                 });
                 self.gallery.preview_image = None;
                 self.gallery.image_state = None;
+                self.gallery.animation = None;
             } else if entry.path.exists() && entry.path.is_file() {
                 // For video files, prefer the cached GIF preview (animated)
                 let gif_path = crate::thumbnails::preview_gif_path(&entry.path);
                 let load_path = if gif_path.is_file() {
-                    &gif_path
+                    gif_path.clone()
                 } else {
-                    &entry.path
+                    entry.path.clone()
                 };
-                if let Ok(img) = image::open(load_path) {
+                if self.try_install_gallery_animation(&load_path) {
+                    return;
+                }
+                if let Ok(img) = image::open(&load_path) {
                     let protocol = self.picker.new_resize_protocol(img.clone());
                     self.gallery.preview_image = Some(img);
                     self.gallery.image_state = Some(protocol);
+                    self.gallery.animation = None;
                     return;
                 }
             }
         }
         self.gallery.preview_image = None;
         self.gallery.image_state = None;
+        self.gallery.animation = None;
+    }
+
+    /// Try to decode `path` as an animated container and install it as the
+    /// active gallery preview. Returns `true` when animation was installed.
+    fn try_install_gallery_animation(&mut self, path: &std::path::Path) -> bool {
+        let frames = match crate::animation::decode_animation_path(path) {
+            Ok(f) => f,
+            Err(_) => return false,
+        };
+        let state = match crate::animation::AnimationState::new(frames) {
+            Some(s) => s,
+            None => return false,
+        };
+        let first = state.current_image().clone();
+        let protocol = self.picker.new_resize_protocol(first.clone());
+        self.gallery.preview_image = Some(first);
+        self.gallery.image_state = Some(protocol);
+        self.gallery.animation = Some(state);
+        true
+    }
+
+    /// Advance any active animations in the gallery/generate previews and
+    /// rebuild their image protocols so the next render shows the new
+    /// frame. Called once per event-loop tick.
+    pub fn tick_animations(&mut self) {
+        if let Some(anim) = self.gallery.animation.as_mut() {
+            if anim.tick() {
+                let img = anim.current_image().clone();
+                self.gallery.preview_image = Some(img.clone());
+                self.gallery.image_state = Some(self.picker.new_resize_protocol(img));
+            }
+        }
+        if let Some(anim) = self.generate.animation.as_mut() {
+            if anim.tick() {
+                let img = anim.current_image().clone();
+                self.generate.preview_image = Some(img.clone());
+                self.generate.image_state = Some(self.picker.new_resize_protocol(img));
+            }
+        }
     }
 
     /// Load the selected gallery entry's metadata into the Generate view.
@@ -2783,6 +2842,7 @@ impl App {
 
         self.gallery.preview_image = None;
         self.gallery.image_state = None;
+        self.gallery.animation = None;
     }
 
     /// Open the selected gallery image in the system viewer.
@@ -3764,6 +3824,7 @@ impl App {
         self.generate.progress.clear();
         self.generate.preview_image = None;
         self.generate.image_state = None;
+        self.generate.animation = None;
 
         let neg = self
             .generate
@@ -3862,6 +3923,7 @@ impl App {
                                 let protocol = self.picker.new_resize_protocol(img.clone());
                                 self.generate.preview_image = Some(img);
                                 self.generate.image_state = Some(protocol);
+                                self.generate.animation = None;
                             }
                         }
                     }
@@ -3892,10 +3954,28 @@ impl App {
                         }
                         // Show GIF preview in the generate viewport (animated)
                         if !video.gif_preview.is_empty() {
-                            if let Ok(img) = image::load_from_memory(&video.gif_preview) {
+                            if let Ok(frames) = crate::animation::decode_animation_bytes(
+                                &video.gif_preview,
+                                Some("gif"),
+                            ) {
+                                if let Some(state) = crate::animation::AnimationState::new(frames) {
+                                    let first = state.current_image().clone();
+                                    let protocol = self.picker.new_resize_protocol(first.clone());
+                                    self.generate.preview_image = Some(first);
+                                    self.generate.image_state = Some(protocol);
+                                    self.generate.animation = Some(state);
+                                } else if let Ok(img) = image::load_from_memory(&video.gif_preview)
+                                {
+                                    let protocol = self.picker.new_resize_protocol(img.clone());
+                                    self.generate.preview_image = Some(img);
+                                    self.generate.image_state = Some(protocol);
+                                    self.generate.animation = None;
+                                }
+                            } else if let Ok(img) = image::load_from_memory(&video.gif_preview) {
                                 let protocol = self.picker.new_resize_protocol(img.clone());
                                 self.generate.preview_image = Some(img);
                                 self.generate.image_state = Some(protocol);
+                                self.generate.animation = None;
                             }
                         }
                     }
@@ -4098,10 +4178,26 @@ impl App {
                     });
                 }
                 BackgroundEvent::GalleryPreviewReady(data) => {
-                    if let Ok(img) = image::load_from_memory(&data) {
-                        let protocol = self.picker.new_resize_protocol(img.clone());
-                        self.gallery.preview_image = Some(img);
-                        self.gallery.image_state = Some(protocol);
+                    let mut installed_animation = false;
+                    if crate::animation::is_animated_bytes(&data) {
+                        if let Ok(frames) = crate::animation::decode_animation_bytes(&data, None) {
+                            if let Some(state) = crate::animation::AnimationState::new(frames) {
+                                let first = state.current_image().clone();
+                                let protocol = self.picker.new_resize_protocol(first.clone());
+                                self.gallery.preview_image = Some(first);
+                                self.gallery.image_state = Some(protocol);
+                                self.gallery.animation = Some(state);
+                                installed_animation = true;
+                            }
+                        }
+                    }
+                    if !installed_animation {
+                        if let Ok(img) = image::load_from_memory(&data) {
+                            let protocol = self.picker.new_resize_protocol(img.clone());
+                            self.gallery.preview_image = Some(img);
+                            self.gallery.image_state = Some(protocol);
+                            self.gallery.animation = None;
+                        }
                     }
                 }
                 BackgroundEvent::ThumbnailsReady => {
@@ -5343,6 +5439,7 @@ mod tests {
             selected: 0,
             preview_image: None,
             image_state: None,
+            animation: None,
             scanning: false,
             view_mode: GalleryViewMode::Grid,
             thumbnail_states: Vec::new(),
@@ -5433,6 +5530,7 @@ mod tests {
                 progress: ProgressState::default(),
                 preview_image: None,
                 image_state: None,
+                animation: None,
                 generating: false,
                 batch_remaining: 0,
                 last_seed: None,
@@ -5445,6 +5543,7 @@ mod tests {
                 selected: 0,
                 preview_image: None,
                 image_state: None,
+                animation: None,
                 scanning: false,
                 view_mode: GalleryViewMode::Grid,
                 thumbnail_states: Vec::new(),
@@ -6198,6 +6297,7 @@ mod tests {
             progress: ProgressState::default(),
             preview_image: None,
             image_state: None,
+            animation: None,
             generating: true,
             batch_remaining: 3,
             last_seed: None,
@@ -6253,6 +6353,7 @@ mod tests {
             progress: ProgressState::default(),
             preview_image: None,
             image_state: None,
+            animation: None,
             generating: true,
             batch_remaining: 4,
             last_seed: None,
@@ -6289,6 +6390,7 @@ mod tests {
             progress: ProgressState::default(),
             preview_image: None,
             image_state: None,
+            animation: None,
             generating: false,
             batch_remaining: 0,
             last_seed: None,

--- a/crates/mold-tui/src/lib.rs
+++ b/crates/mold-tui/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(dead_code)]
 
 mod action;
+mod animation;
 mod app;
 mod backend;
 mod event;
@@ -94,6 +95,10 @@ async fn run_event_loop(
 
         // Process any background task results
         app.process_background_events();
+
+        // Advance any animated previews so the next draw shows the next frame
+        // when its delay has elapsed.
+        app.tick_animations();
 
         // Refresh resource info every 2 seconds
         if last_resource_refresh.elapsed() >= std::time::Duration::from_secs(2) {


### PR DESCRIPTION
## Summary

Closes #179. The TUI gallery detail view, generation viewport, and CLI `--preview` were freezing on the first frame of GIF/APNG video previews because both `ratatui-image` and `viuer` only render a single image. This PR makes them play back frame-by-frame.

- New `mold-tui::animation` module decodes GIF / APNG / animated-WebP via `image::AnimationDecoder` into `Vec<{image, delay}>`.
- `AnimationState` advances on each event-loop tick; when a frame's recorded delay elapses the gallery / generate preview rebuilds its `StatefulProtocol` from the next frame so `ratatui-image` re-renders.
- `load_gallery_preview` and the post-generation video preview install animation state automatically when the source is animated; falls back to the existing single-frame path when not.
- CLI `preview_image()` sniffs the same containers, decodes them, and replays via `viuer` / the existing Ghostty-kitty backend with ANSI cursor save / restore so each frame overwrites the previous in place. Short clips loop a few times (<1.5 s → 3 plays, <3 s → 2, longer → 1).
- Frame delays are clamped to ≥20 ms (≤50 fps) so a malformed `0/0` delay can't peg the event loop.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 555 pass; 1 unrelated pre-existing failure (`mold_inference::device::tests::free_vram_returns_available_not_just_free_on_macos`, also fails on `main`).
- [x] New unit tests cover the decoder (multi-frame GIF, single-frame rejection, sniff signatures, unsupported format error), `AnimationState::tick` advancement / wrap-around, and the CLI `preview_loop_count` function.
- [ ] Manual: open a video output in `mold tui` gallery → frame plays through animation. Run `mold run ltx-video "..." --preview` → CLI preview loops the GIF in place.