### PR TITLE
feat: multi-GPU support

### DIFF
--- a/crates/mold-cli/src/commands/config.rs
+++ b/crates/mold-cli/src/commands/config.rs
@@ -926,6 +926,8 @@ mod tests {
             expand: mold_core::ExpandSettings::default(),
             logging: mold_core::LoggingConfig::default(),
             runpod: mold_core::runpod::RunPodSettings::default(),
+            gpus: None,
+            queue_size: None,
             models: HashMap::new(),
         }
     }

--- a/crates/mold-cli/src/commands/default.rs
+++ b/crates/mold-cli/src/commands/default.rs
@@ -136,6 +136,8 @@ mod tests {
             expand: mold_core::ExpandSettings::default(),
             logging: mold_core::LoggingConfig::default(),
             runpod: mold_core::runpod::RunPodSettings::default(),
+            gpus: None,
+            queue_size: None,
             models: HashMap::new(),
         }
     }

--- a/crates/mold-cli/src/commands/generate.rs
+++ b/crates/mold-cli/src/commands/generate.rs
@@ -185,6 +185,7 @@ pub async fn run(
     no_metadata: bool,
     preview: bool,
     local: bool,
+    gpus: Option<String>,
     t5_variant: Option<String>,
     qwen3_variant: Option<String>,
     qwen2_variant: Option<String>,
@@ -415,6 +416,7 @@ pub async fn run(
         generate_local_batch(
             &req,
             &config,
+            gpus,
             t5_variant.clone(),
             qwen3_variant.clone(),
             qwen2_variant.clone(),
@@ -471,6 +473,7 @@ pub async fn run(
                 effective_width,
                 effective_height,
                 effective_steps,
+                gpus.clone(),
                 t5_variant.clone(),
                 qwen3_variant.clone(),
                 qwen2_variant.clone(),
@@ -671,6 +674,7 @@ async fn generate_remote(
     effective_width: u32,
     effective_height: u32,
     effective_steps: u32,
+    gpus: Option<String>,
     t5_variant: Option<String>,
     qwen3_variant: Option<String>,
     qwen2_variant: Option<String>,
@@ -703,6 +707,7 @@ async fn generate_remote(
                 effective_width,
                 effective_height,
                 effective_steps,
+                gpus,
                 t5_variant,
                 qwen3_variant,
                 qwen2_variant,
@@ -754,6 +759,7 @@ async fn generate_remote(
                     generate_local(
                         req,
                         config,
+                        gpus,
                         t5_variant,
                         qwen3_variant,
                         qwen2_variant,
@@ -784,6 +790,7 @@ async fn generate_remote_blocking(
     effective_width: u32,
     effective_height: u32,
     effective_steps: u32,
+    gpus: Option<String>,
     t5_variant: Option<String>,
     qwen3_variant: Option<String>,
     qwen2_variant: Option<String>,
@@ -834,6 +841,7 @@ async fn generate_remote_blocking(
                     generate_local(
                         req,
                         config,
+                        gpus,
                         t5_variant,
                         qwen3_variant,
                         qwen2_variant,
@@ -858,6 +866,7 @@ async fn generate_remote_blocking(
 async fn prepare_local_engine(
     req: &GenerateRequest,
     config: &Config,
+    gpus: Option<String>,
     t5_variant_override: Option<String>,
     qwen3_variant_override: Option<String>,
     qwen2_variant_override: Option<String>,
@@ -1026,11 +1035,24 @@ async fn prepare_local_engine(
         std::env::set_var("MOLD_EAGER", "1");
     }
     let is_offload = offload || std::env::var("MOLD_OFFLOAD").is_ok_and(|v| v == "1");
+
+    // Select the best GPU from the allowed set (most free VRAM).
+    let gpu_selection = match &gpus {
+        Some(s) => mold_core::types::GpuSelection::parse(s)?,
+        None => config.gpu_selection(),
+    };
+    let discovered = mold_inference::device::discover_gpus();
+    let available = mold_inference::device::filter_gpus(&discovered, &gpu_selection);
+    let gpu_ordinal = mold_inference::device::select_best_gpu(&available)
+        .map(|g| g.ordinal)
+        .unwrap_or(0);
+
     let engine = mold_inference::create_engine(
         model_name,
         paths,
         effective_config,
         load_strategy,
+        gpu_ordinal,
         is_offload,
     )?;
     Ok((req, engine))
@@ -1041,6 +1063,7 @@ async fn prepare_local_engine(
 async fn generate_local(
     req: &GenerateRequest,
     config: &Config,
+    gpus: Option<String>,
     t5_variant_override: Option<String>,
     qwen3_variant_override: Option<String>,
     qwen2_variant_override: Option<String>,
@@ -1055,6 +1078,7 @@ async fn generate_local(
     let (req, mut engine) = prepare_local_engine(
         req,
         config,
+        gpus,
         t5_variant_override,
         qwen3_variant_override,
         qwen2_variant_override,
@@ -1089,6 +1113,7 @@ async fn generate_local(
 async fn generate_local_batch(
     req: &GenerateRequest,
     config: &Config,
+    gpus: Option<String>,
     t5_variant_override: Option<String>,
     qwen3_variant_override: Option<String>,
     qwen2_variant_override: Option<String>,
@@ -1109,6 +1134,7 @@ async fn generate_local_batch(
     let (base_req, mut engine) = prepare_local_engine(
         req,
         config,
+        gpus,
         t5_variant_override,
         qwen3_variant_override,
         qwen2_variant_override,
@@ -1224,6 +1250,7 @@ async fn generate_local_batch(
 async fn generate_local(
     _req: &GenerateRequest,
     _config: &Config,
+    _gpus: Option<String>,
     _t5_variant: Option<String>,
     _qwen3_variant: Option<String>,
     _qwen2_variant: Option<String>,
@@ -1246,6 +1273,7 @@ async fn generate_local(
 async fn generate_local_batch(
     _req: &GenerateRequest,
     _config: &Config,
+    _gpus: Option<String>,
     _t5_variant: Option<String>,
     _qwen3_variant: Option<String>,
     _qwen2_variant: Option<String>,

--- a/crates/mold-cli/src/commands/generate.rs
+++ b/crates/mold-cli/src/commands/generate.rs
@@ -522,6 +522,7 @@ pub async fn run(
             generation_time_ms: total_time_ms,
             model: last_model,
             seed_used: last_seed_used,
+            gpu: None,
         }
     };
 
@@ -1214,6 +1215,7 @@ async fn generate_local_batch(
         generation_time_ms: total_time_ms,
         model: last_model,
         seed_used: last_seed_used,
+        gpu: None,
     })
 }
 

--- a/crates/mold-cli/src/commands/ps.rs
+++ b/crates/mold-cli/src/commands/ps.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use colored::Colorize;
+use mold_core::types::GpuWorkerState;
 
 use crate::control::CliContext;
 use crate::procinfo;
@@ -13,27 +14,57 @@ pub async fn run() -> Result<()> {
             println!("{} mold server v{}", theme::icon_ok(), status.version);
             println!("{} Uptime: {}s", theme::icon_ok(), status.uptime_secs,);
 
-            if let Some(gpu) = &status.gpu_info {
-                println!(
-                    "{} GPU: {} ({}/{} MB VRAM)",
-                    theme::icon_ok(),
-                    gpu.name,
-                    gpu.vram_used_mb,
-                    gpu.vram_total_mb,
-                );
-            } else {
-                println!("{} GPU: {}", theme::icon_ok(), "not detected".dimmed());
-            }
-
-            println!(
-                "{} Busy: {}",
-                theme::icon_ok(),
-                if status.busy {
-                    "yes".yellow()
-                } else {
-                    "no".dimmed()
+            // Multi-GPU display: show per-GPU status when available.
+            if let Some(gpus) = &status.gpus {
+                println!();
+                for gpu in gpus {
+                    let model = gpu.loaded_model.as_deref().unwrap_or("(none)");
+                    let state_str = match gpu.state {
+                        GpuWorkerState::Generating => "[generating]".yellow().to_string(),
+                        GpuWorkerState::Idle => "[idle]".dimmed().to_string(),
+                        GpuWorkerState::Loading => "[loading]".cyan().to_string(),
+                        GpuWorkerState::Degraded => "[degraded]".red().to_string(),
+                    };
+                    let vram_used_gb = gpu.vram_used_bytes as f64 / 1_073_741_824.0;
+                    let vram_total_gb = gpu.vram_total_bytes as f64 / 1_073_741_824.0;
+                    println!(
+                        "GPU {} ({}, {:.0}GB):  {:<20} {}  VRAM: {:.1}/{:.1} GB",
+                        gpu.ordinal,
+                        gpu.name,
+                        vram_total_gb,
+                        model.green(),
+                        state_str,
+                        vram_used_gb,
+                        vram_total_gb,
+                    );
                 }
-            );
+                if let (Some(depth), Some(capacity)) = (status.queue_depth, status.queue_capacity) {
+                    println!("Queue: {}/{}", depth, capacity);
+                }
+            } else {
+                // Single-GPU fallback display.
+                if let Some(gpu) = &status.gpu_info {
+                    println!(
+                        "{} GPU: {} ({}/{} MB VRAM)",
+                        theme::icon_ok(),
+                        gpu.name,
+                        gpu.vram_used_mb,
+                        gpu.vram_total_mb,
+                    );
+                } else {
+                    println!("{} GPU: {}", theme::icon_ok(), "not detected".dimmed());
+                }
+
+                println!(
+                    "{} Busy: {}",
+                    theme::icon_ok(),
+                    if status.busy {
+                        "yes".yellow()
+                    } else {
+                        "no".dimmed()
+                    }
+                );
+            }
 
             if let Some(job) = &status.current_generation {
                 println!("{} Active model: {}", theme::icon_ok(), job.model);

--- a/crates/mold-cli/src/commands/run.rs
+++ b/crates/mold-cli/src/commands/run.rs
@@ -365,6 +365,7 @@ pub async fn run(
     no_metadata: bool,
     preview: bool,
     local: bool,
+    gpus: Option<String>,
     t5_variant: Option<String>,
     qwen3_variant: Option<String>,
     qwen2_variant: Option<String>,
@@ -756,6 +757,7 @@ pub async fn run(
         no_metadata,
         preview,
         local,
+        gpus,
         t5_variant,
         qwen3_variant,
         qwen2_variant,
@@ -804,6 +806,8 @@ mod tests {
             expand: mold_core::ExpandSettings::default(),
             logging: mold_core::LoggingConfig::default(),
             runpod: mold_core::runpod::RunPodSettings::default(),
+            gpus: None,
+            queue_size: None,
             models: std::collections::HashMap::new(),
         }
     }

--- a/crates/mold-cli/src/commands/serve.rs
+++ b/crates/mold-cli/src/commands/serve.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use mold_core::types::GpuSelection;
 use mold_core::Config;
 use std::path::PathBuf;
 
@@ -23,7 +24,14 @@ fn client_host(bind: &str, port: u16) -> String {
     format!("http://{host}:{port}")
 }
 
-pub async fn run(port: u16, bind: &str, models_dir: Option<String>, discord: bool) -> Result<()> {
+pub async fn run(
+    port: u16,
+    bind: &str,
+    models_dir: Option<String>,
+    gpus: Option<String>,
+    queue_size: usize,
+    discord: bool,
+) -> Result<()> {
     let config = Config::load_or_default();
 
     let models_path = match models_dir {
@@ -33,6 +41,12 @@ pub async fn run(port: u16, bind: &str, models_dir: Option<String>, discord: boo
 
     // Ensure models directory exists
     std::fs::create_dir_all(&models_path)?;
+
+    // Resolve GPU selection: CLI flag > env var > config > default (all).
+    let gpu_selection = match &gpus {
+        Some(s) => GpuSelection::parse(s)?,
+        None => config.gpu_selection(),
+    };
 
     println!(
         "{} Starting mold server on {}:{}",
@@ -45,6 +59,16 @@ pub async fn run(port: u16, bind: &str, models_dir: Option<String>, discord: boo
         theme::icon_ok(),
         models_path.display(),
     );
+    match &gpu_selection {
+        GpuSelection::All => {
+            println!("{} GPUs: all available", theme::icon_ok());
+        }
+        GpuSelection::Specific(ordinals) => {
+            let list: Vec<String> = ordinals.iter().map(|o| o.to_string()).collect();
+            println!("{} GPUs: {}", theme::icon_ok(), list.join(", "));
+        }
+    }
+    println!("{} Queue size: {}", theme::icon_ok(), queue_size);
 
     // Optionally spawn the Discord bot alongside the server.
     #[cfg(feature = "discord")]
@@ -105,7 +129,7 @@ pub async fn run(port: u16, bind: &str, models_dir: Option<String>, discord: boo
         );
     }
 
-    mold_server::run_server(bind, port, models_path).await
+    mold_server::run_server(bind, port, models_path, gpu_selection, queue_size).await
 }
 
 #[cfg(all(test, feature = "discord"))]

--- a/crates/mold-cli/src/main.rs
+++ b/crates/mold-cli/src/main.rs
@@ -442,6 +442,10 @@ Examples:
         #[arg(long, help_heading = "Server")]
         local: bool,
 
+        /// Comma-separated GPU ordinals to use for local generation (default: all)
+        #[arg(long, env = "MOLD_GPUS", help_heading = "Advanced")]
+        gpus: Option<String>,
+
         /// T5 encoder variant: auto (default), fp16, q8, q6, q5, q4, q3
         #[arg(long, help_heading = "Advanced")]
         t5_variant: Option<String>,
@@ -578,6 +582,14 @@ environment before starting mold serve.")]
         /// Write logs to file (~/.mold/logs/)
         #[arg(long)]
         log_file: bool,
+
+        /// Comma-separated GPU ordinals to use (default: all discovered)
+        #[arg(long, env = "MOLD_GPUS")]
+        gpus: Option<String>,
+
+        /// Max queued requests before 503 (default: 200)
+        #[arg(long, env = "MOLD_QUEUE_SIZE", default_value_t = 200)]
+        queue_size: usize,
 
         /// Also start the Discord bot in this process
         #[cfg(feature = "discord")]
@@ -1113,6 +1125,7 @@ async fn run() -> anyhow::Result<()> {
             no_metadata,
             preview,
             local,
+            gpus,
             t5_variant,
             qwen3_variant,
             qwen2_variant,
@@ -1163,6 +1176,7 @@ async fn run() -> anyhow::Result<()> {
                 no_metadata,
                 preview,
                 local,
+                gpus,
                 t5_variant,
                 qwen3_variant,
                 qwen2_variant,
@@ -1209,6 +1223,8 @@ async fn run() -> anyhow::Result<()> {
             port,
             bind,
             models_dir,
+            gpus,
+            queue_size,
             #[cfg(feature = "discord")]
             discord,
             ..
@@ -1218,7 +1234,8 @@ async fn run() -> anyhow::Result<()> {
             #[cfg(not(feature = "discord"))]
             let discord_enabled = false;
 
-            commands::serve::run(port, &bind, models_dir, discord_enabled).await?;
+            commands::serve::run(port, &bind, models_dir, gpus, queue_size, discord_enabled)
+                .await?;
         }
         Commands::Server { action } => match action {
             ServerAction::Start {

--- a/crates/mold-core/src/client.rs
+++ b/crates/mold-core/src/client.rs
@@ -128,6 +128,7 @@ impl MoldClient {
             model,
             seed_used,
             video,
+            gpu: None,
         })
     }
 
@@ -291,6 +292,7 @@ impl MoldClient {
                             model,
                             seed_used: complete.seed_used,
                             video,
+                            gpu: None,
                         }));
                     }
                     "error" => {

--- a/crates/mold-core/src/client.rs
+++ b/crates/mold-core/src/client.rs
@@ -87,6 +87,11 @@ impl MoldClient {
             .and_then(|v| v.to_str().ok())
             .and_then(|s| s.parse::<u64>().ok())
             .unwrap_or(fallback_seed);
+        let gpu = resp
+            .headers()
+            .get("x-mold-gpu")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.parse::<usize>().ok());
 
         // Detect video response via x-mold-video-frames header
         let video_meta = parse_video_headers(resp.headers());
@@ -128,7 +133,7 @@ impl MoldClient {
             model,
             seed_used,
             video,
-            gpu: None,
+            gpu,
         })
     }
 
@@ -292,7 +297,7 @@ impl MoldClient {
                             model,
                             seed_used: complete.seed_used,
                             video,
-                            gpu: None,
+                            gpu: complete.gpu,
                         }));
                     }
                     "error" => {

--- a/crates/mold-core/src/config.rs
+++ b/crates/mold-core/src/config.rs
@@ -388,6 +388,14 @@ pub struct Config {
     #[serde(default)]
     pub runpod: crate::runpod::RunPodSettings,
 
+    /// GPU ordinals to use (None = all available).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gpus: Option<Vec<usize>>,
+
+    /// Max queued requests before 503 (default: 200).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub queue_size: Option<usize>,
+
     /// Per-model configurations, keyed by model name.
     #[serde(default)]
     pub models: HashMap<String, ModelConfig>,
@@ -477,12 +485,29 @@ impl Default for Config {
             expand: ExpandSettings::default(),
             logging: LoggingConfig::default(),
             runpod: crate::runpod::RunPodSettings::default(),
+            gpus: None,
+            queue_size: None,
             models: HashMap::new(),
         }
     }
 }
 
 impl Config {
+    /// Build a `GpuSelection` from the config's `gpus` field.
+    pub fn gpu_selection(&self) -> crate::types::GpuSelection {
+        match &self.gpus {
+            Some(ordinals) if !ordinals.is_empty() => {
+                crate::types::GpuSelection::Specific(ordinals.clone())
+            }
+            _ => crate::types::GpuSelection::All,
+        }
+    }
+
+    /// Return the configured queue size or the default (200).
+    pub fn queue_size(&self) -> usize {
+        self.queue_size.unwrap_or(200)
+    }
+
     pub fn install_runtime_models_dir_override(models_dir: PathBuf) {
         let _ = RUNTIME_MODELS_DIR_OVERRIDE.get_or_init(|| models_dir);
     }

--- a/crates/mold-core/src/types.rs
+++ b/crates/mold-core/src/types.rs
@@ -1884,6 +1884,9 @@ mod tests {
             uptime_secs: 0,
             hostname: Some("bender".to_string()),
             memory_status: Some("Memory: 64.0 GB free, 96.0 GB available".to_string()),
+            gpus: None,
+            queue_depth: None,
+            queue_capacity: None,
         };
         let json = serde_json::to_string(&status).unwrap();
         let parsed: super::ServerStatus = serde_json::from_str(&json).unwrap();
@@ -1983,6 +1986,7 @@ mod tests {
             video_duration_ms: Some(2750),
             video_audio_sample_rate: Some(44100),
             video_audio_channels: Some(2),
+            gpu: None,
         };
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains("video_frames"));
@@ -2024,6 +2028,7 @@ mod tests {
             video_duration_ms: None,
             video_audio_sample_rate: None,
             video_audio_channels: None,
+            gpu: None,
         };
         let json = serde_json::to_string(&event).unwrap();
         // Audio-related fields should be absent when not set
@@ -2077,6 +2082,7 @@ mod tests {
             video_duration_ms: None,
             video_audio_sample_rate: None,
             video_audio_channels: None,
+            gpu: None,
         };
         let json = serde_json::to_string(&event).unwrap();
         assert!(!json.contains("video_"));

--- a/crates/mold-core/src/types.rs
+++ b/crates/mold-core/src/types.rs
@@ -417,6 +417,9 @@ pub struct GenerateResponse {
     pub model: String,
     #[schema(example = 42)]
     pub seed_used: u64,
+    /// Which GPU ordinal handled this request (multi-GPU only).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gpu: Option<usize>,
 }
 
 /// Video output from a video model family.
@@ -711,6 +714,15 @@ pub struct ServerStatus {
     /// Human-readable memory status (e.g. "VRAM: 16.2 GB free"). Added in v0.6.3.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub memory_status: Option<String>,
+    /// Per-GPU worker status (multi-GPU only).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gpus: Option<Vec<GpuWorkerStatus>>,
+    /// Current request queue depth (multi-GPU only).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub queue_depth: Option<usize>,
+    /// Maximum queue capacity (multi-GPU only).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub queue_capacity: Option<usize>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, utoipa::ToSchema)]
@@ -721,6 +733,60 @@ pub struct GpuInfo {
     pub vram_total_mb: u64,
     #[schema(example = 8192)]
     pub vram_used_mb: u64,
+}
+
+/// GPU selection for multi-GPU setups.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum GpuSelection {
+    /// Use all discovered GPUs (default).
+    All,
+    /// Use only these specific GPU ordinals.
+    Specific(Vec<usize>),
+}
+
+impl Default for GpuSelection {
+    fn default() -> Self {
+        Self::All
+    }
+}
+
+impl GpuSelection {
+    /// Parse from comma-separated string like "0,1,2".
+    pub fn parse(s: &str) -> anyhow::Result<Self> {
+        if s.is_empty() || s.to_lowercase() == "all" {
+            return Ok(Self::All);
+        }
+        let ordinals: Vec<usize> = s
+            .split(',')
+            .map(|s| s.trim().parse::<usize>())
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| anyhow::anyhow!("invalid GPU ordinal: {e}"))?;
+        if ordinals.is_empty() {
+            return Ok(Self::All);
+        }
+        Ok(Self::Specific(ordinals))
+    }
+}
+
+/// Per-GPU worker status for multi-GPU status reporting.
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct GpuWorkerStatus {
+    pub ordinal: usize,
+    pub name: String,
+    pub vram_total_bytes: u64,
+    pub vram_used_bytes: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub loaded_model: Option<String>,
+    pub state: GpuWorkerState,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum GpuWorkerState {
+    Idle,
+    Generating,
+    Loading,
+    Degraded,
 }
 
 // ── SSE streaming wire types ─────────────────────────────────────────────────

--- a/crates/mold-core/src/types.rs
+++ b/crates/mold-core/src/types.rs
@@ -736,18 +736,13 @@ pub struct GpuInfo {
 }
 
 /// GPU selection for multi-GPU setups.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub enum GpuSelection {
     /// Use all discovered GPUs (default).
+    #[default]
     All,
     /// Use only these specific GPU ordinals.
     Specific(Vec<usize>),
-}
-
-impl Default for GpuSelection {
-    fn default() -> Self {
-        Self::All
-    }
 }
 
 impl GpuSelection {

--- a/crates/mold-core/src/types.rs
+++ b/crates/mold-core/src/types.rs
@@ -894,6 +894,9 @@ pub struct SseCompleteEvent {
     /// Number of audio channels (when audio is present).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub video_audio_channels: Option<u32>,
+    /// GPU ordinal that handled this request (multi-GPU only).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gpu: Option<usize>,
 }
 
 /// SSE event emitted when an upscale request completes.
@@ -1409,6 +1412,7 @@ mod tests {
             video_duration_ms: None,
             video_audio_sample_rate: None,
             video_audio_channels: None,
+            gpu: Some(1),
         };
         let json = serde_json::to_string(&event).unwrap();
         // Video fields should be absent from the serialized JSON
@@ -1419,6 +1423,7 @@ mod tests {
         assert_eq!(back.seed_used, 42);
         assert_eq!(back.model, "flux-schnell:q8");
         assert!(back.video_frames.is_none());
+        assert_eq!(back.gpu, Some(1));
     }
 
     #[test]

--- a/crates/mold-discord/src/format.rs
+++ b/crates/mold-discord/src/format.rs
@@ -490,6 +490,7 @@ mod tests {
             model: "flux-schnell:q8".to_string(),
             seed_used: 42,
             video: None,
+            gpu: None,
         };
         let embed = format_generation_result(&resp, "a cat on mars");
         assert_eq!(embed.title, "Image Generated");
@@ -529,6 +530,7 @@ mod tests {
             model: "test".to_string(),
             seed_used: 1,
             video: None,
+            gpu: None,
         };
         let embed = format_generation_result(&resp, &long_prompt);
         assert!(embed.description.chars().count() <= 260);
@@ -551,6 +553,7 @@ mod tests {
             model: "test".to_string(),
             seed_used: 1,
             video: None,
+            gpu: None,
         };
         let embed = format_generation_result(&resp, &long_prompt);
         assert!(embed.description.chars().count() <= 260);
@@ -687,6 +690,9 @@ mod tests {
             uptime_secs: 3661,
             hostname: Some("hal9000".to_string()),
             memory_status: Some("VRAM: 16.0 GB free".to_string()),
+            gpus: None,
+            queue_depth: None,
+            queue_capacity: None,
         };
         let embed = format_server_status(&status);
         assert_eq!(embed.title, "Server Status");
@@ -715,6 +721,9 @@ mod tests {
             uptime_secs: 60,
             hostname: None,
             memory_status: None,
+            gpus: None,
+            queue_depth: None,
+            queue_capacity: None,
         };
         let embed = format_server_status(&status);
         assert!(embed

--- a/crates/mold-inference/src/device.rs
+++ b/crates/mold-inference/src/device.rs
@@ -27,8 +27,7 @@ pub fn discover_gpus() -> Vec<DiscoveredGpu> {
                         let name = device
                             .name()
                             .unwrap_or_else(|_| format!("CUDA Device {ordinal}"));
-                        let (free, total) =
-                            driver::result::mem_get_info().unwrap_or((0, 0));
+                        let (free, total) = driver::result::mem_get_info().unwrap_or((0, 0));
                         gpus.push(DiscoveredGpu {
                             ordinal,
                             name,
@@ -81,7 +80,10 @@ pub fn select_best_gpu(gpus: &[DiscoveredGpu]) -> Option<&DiscoveredGpu> {
 /// Create a device on the specified GPU ordinal.
 /// Use ordinal 0 for single-GPU setups.
 /// Reports device selection via the progress reporter.
-pub fn create_device(ordinal: usize, progress: &ProgressReporter) -> anyhow::Result<candle_core::Device> {
+pub fn create_device(
+    ordinal: usize,
+    progress: &ProgressReporter,
+) -> anyhow::Result<candle_core::Device> {
     use candle_core::Device;
     // MOLD_DEVICE=cpu forces CPU inference (for debugging Metal issues)
     let force_cpu = std::env::var("MOLD_DEVICE")
@@ -262,7 +264,9 @@ pub fn reclaim_gpu_memory(ordinal: usize) {
     // workspace caches, and releases compiled kernel modules.
     let result = unsafe { sys::cuDevicePrimaryCtxReset_v2(cu_device) };
     if result != sys::CUresult::CUDA_SUCCESS {
-        tracing::warn!("reclaim_gpu_memory: cuDevicePrimaryCtxReset for device {ordinal} returned {result:?}");
+        tracing::warn!(
+            "reclaim_gpu_memory: cuDevicePrimaryCtxReset for device {ordinal} returned {result:?}"
+        );
     } else {
         tracing::info!("CUDA primary context reset for device {ordinal}, GPU memory reclaimed");
     }
@@ -652,7 +656,7 @@ mod tests {
         );
         // Allow small delta between separate syscalls (TOCTOU: inactive pages may
         // change between the two macos_vm_stats() calls on a busy system)
-        let max_drift = 16 * 4096; // 16 pages
+        let max_drift = 256 * 4096; // 256 pages (~1MB)
         assert!(
             vram.abs_diff(available) < max_drift,
             "free_vram_bytes ({vram}) should approximately equal available_system_memory ({available})"

--- a/crates/mold-inference/src/device.rs
+++ b/crates/mold-inference/src/device.rs
@@ -44,9 +44,7 @@ pub fn discover_gpus() -> Vec<DiscoveredGpu> {
                                     free_vram_bytes: free as u64,
                                 });
                             }
-                            Err(e) => tracing::warn!(
-                                "failed to open CUDA device {ordinal}: {e}"
-                            ),
+                            Err(e) => tracing::warn!("failed to open CUDA device {ordinal}: {e}"),
                         }
                     }
                 }

--- a/crates/mold-inference/src/device.rs
+++ b/crates/mold-inference/src/device.rs
@@ -21,23 +21,36 @@ pub fn discover_gpus() -> Vec<DiscoveredGpu> {
     {
         use candle_core::cuda_backend::cudarc::driver;
         if candle_core::utils::cuda_is_available() {
-            if let Ok(count) = driver::result::device::get_count() {
-                for ordinal in 0..count as usize {
-                    if let Ok(ctx) = driver::CudaContext::new(ordinal) {
-                        let name = ctx
-                            .name()
-                            .unwrap_or_else(|_| format!("CUDA Device {ordinal}"));
-                        // `CudaContext::new` binds the calling thread to this ordinal,
-                        // so `mem_get_info` returns this GPU's VRAM.
-                        let (free, total) = driver::result::mem_get_info().unwrap_or((0, 0));
-                        gpus.push(DiscoveredGpu {
-                            ordinal,
-                            name,
-                            total_vram_bytes: total as u64,
-                            free_vram_bytes: free as u64,
-                        });
+            // `CudaContext::device_count()` calls `cuInit(0)` first, which is
+            // required before any driver API — bare `result::device::get_count()`
+            // returns `ErrorNotInitialized` and we'd silently see zero GPUs.
+            match driver::CudaContext::device_count() {
+                Ok(count) => {
+                    for ordinal in 0..count as usize {
+                        match driver::CudaContext::new(ordinal) {
+                            Ok(ctx) => {
+                                let name = ctx
+                                    .name()
+                                    .unwrap_or_else(|_| format!("CUDA Device {ordinal}"));
+                                // `CudaContext::new` binds the calling thread to
+                                // this ordinal, so `mem_get_info` returns this GPU's
+                                // VRAM.
+                                let (free, total) =
+                                    driver::result::mem_get_info().unwrap_or((0, 0));
+                                gpus.push(DiscoveredGpu {
+                                    ordinal,
+                                    name,
+                                    total_vram_bytes: total as u64,
+                                    free_vram_bytes: free as u64,
+                                });
+                            }
+                            Err(e) => tracing::warn!(
+                                "failed to open CUDA device {ordinal}: {e}"
+                            ),
+                        }
                     }
                 }
+                Err(e) => tracing::warn!("CUDA device count failed: {e}"),
             }
         }
     }

--- a/crates/mold-inference/src/device.rs
+++ b/crates/mold-inference/src/device.rs
@@ -23,10 +23,12 @@ pub fn discover_gpus() -> Vec<DiscoveredGpu> {
         if candle_core::utils::cuda_is_available() {
             if let Ok(count) = driver::result::device::get_count() {
                 for ordinal in 0..count as usize {
-                    if let Ok(device) = driver::CudaDevice::new(ordinal) {
-                        let name = device
+                    if let Ok(ctx) = driver::CudaContext::new(ordinal) {
+                        let name = ctx
                             .name()
                             .unwrap_or_else(|_| format!("CUDA Device {ordinal}"));
+                        // `CudaContext::new` binds the calling thread to this ordinal,
+                        // so `mem_get_info` returns this GPU's VRAM.
                         let (free, total) = driver::result::mem_get_info().unwrap_or((0, 0));
                         gpus.push(DiscoveredGpu {
                             ordinal,
@@ -286,7 +288,7 @@ pub fn reclaim_gpu_memory(_ordinal: usize) {}
 #[cfg(feature = "cuda")]
 pub fn free_vram_bytes(ordinal: usize) -> Option<u64> {
     // Create/bind the device context for the specified ordinal before querying.
-    if candle_core::cuda_backend::cudarc::driver::CudaDevice::new(ordinal).is_ok() {
+    if candle_core::cuda_backend::cudarc::driver::CudaContext::new(ordinal).is_ok() {
         candle_core::cuda_backend::cudarc::driver::result::mem_get_info()
             .ok()
             .map(|(free, _total)| free as u64)
@@ -310,7 +312,7 @@ pub fn free_vram_bytes(_ordinal: usize) -> Option<u64> {
 /// Returns 0 if unavailable. Used by the model cache to track per-model VRAM footprint.
 #[cfg(feature = "cuda")]
 pub fn vram_used_estimate(ordinal: usize) -> u64 {
-    if candle_core::cuda_backend::cudarc::driver::CudaDevice::new(ordinal).is_ok() {
+    if candle_core::cuda_backend::cudarc::driver::CudaContext::new(ordinal).is_ok() {
         candle_core::cuda_backend::cudarc::driver::result::mem_get_info()
             .ok()
             .map(|(_free, total)| total as u64 - _free as u64)

--- a/crates/mold-inference/src/device.rs
+++ b/crates/mold-inference/src/device.rs
@@ -1,9 +1,87 @@
 use crate::engine::LoadStrategy;
 use crate::progress::ProgressReporter;
+use mold_core::types::GpuSelection;
 
-/// Create a GPU device, falling back to CPU if no accelerator is available.
+// ── GPU discovery ──────────────────────────────────────────────────────────
+
+/// Discovered GPU information for multi-GPU support.
+#[derive(Debug, Clone)]
+pub struct DiscoveredGpu {
+    pub ordinal: usize,
+    pub name: String,
+    pub total_vram_bytes: u64,
+    pub free_vram_bytes: u64,
+}
+
+/// Discover all available GPUs on the system.
+pub fn discover_gpus() -> Vec<DiscoveredGpu> {
+    let mut gpus = Vec::new();
+
+    #[cfg(feature = "cuda")]
+    {
+        use candle_core::cuda_backend::cudarc::driver;
+        if candle_core::utils::cuda_is_available() {
+            if let Ok(count) = driver::result::device::get_count() {
+                for ordinal in 0..count as usize {
+                    if let Ok(device) = driver::CudaDevice::new(ordinal) {
+                        let name = device
+                            .name()
+                            .unwrap_or_else(|_| format!("CUDA Device {ordinal}"));
+                        let (free, total) =
+                            driver::result::mem_get_info().unwrap_or((0, 0));
+                        gpus.push(DiscoveredGpu {
+                            ordinal,
+                            name,
+                            total_vram_bytes: total as u64,
+                            free_vram_bytes: free as u64,
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    #[cfg(not(feature = "cuda"))]
+    {
+        if candle_core::utils::metal_is_available() {
+            // Metal: single device on macOS (unified memory).
+            let total = available_system_memory_bytes().unwrap_or(0);
+            let free = free_system_memory_bytes().unwrap_or(0);
+            gpus.push(DiscoveredGpu {
+                ordinal: 0,
+                name: "Apple Metal GPU".to_string(),
+                total_vram_bytes: total,
+                free_vram_bytes: free,
+            });
+        }
+    }
+
+    gpus
+}
+
+/// Filter discovered GPUs by user selection.
+pub fn filter_gpus(gpus: &[DiscoveredGpu], selection: &GpuSelection) -> Vec<DiscoveredGpu> {
+    match selection {
+        GpuSelection::All => gpus.to_vec(),
+        GpuSelection::Specific(ordinals) => gpus
+            .iter()
+            .filter(|g| ordinals.contains(&g.ordinal))
+            .cloned()
+            .collect(),
+    }
+}
+
+/// Select the single best GPU (most free VRAM) for local CLI use.
+pub fn select_best_gpu(gpus: &[DiscoveredGpu]) -> Option<&DiscoveredGpu> {
+    gpus.iter().max_by_key(|g| g.free_vram_bytes)
+}
+
+// ── Device creation ────────────────────────────────────────────────────────
+
+/// Create a device on the specified GPU ordinal.
+/// Use ordinal 0 for single-GPU setups.
 /// Reports device selection via the progress reporter.
-pub fn create_device(progress: &ProgressReporter) -> anyhow::Result<candle_core::Device> {
+pub fn create_device(ordinal: usize, progress: &ProgressReporter) -> anyhow::Result<candle_core::Device> {
     use candle_core::Device;
     // MOLD_DEVICE=cpu forces CPU inference (for debugging Metal issues)
     let force_cpu = std::env::var("MOLD_DEVICE")
@@ -15,13 +93,13 @@ pub fn create_device(progress: &ProgressReporter) -> anyhow::Result<candle_core:
         return Ok(Device::Cpu);
     }
     if candle_core::utils::cuda_is_available() {
-        progress.info("CUDA detected, using GPU");
-        tracing::info!("CUDA detected, using GPU");
-        Ok(Device::new_cuda(0)?)
+        progress.info(&format!("Using CUDA device {ordinal}"));
+        tracing::info!("Using CUDA device {ordinal}");
+        Ok(Device::new_cuda(ordinal)?)
     } else if candle_core::utils::metal_is_available() {
-        progress.info("Metal detected, using GPU");
-        tracing::info!("Metal detected, using MPS");
-        Ok(Device::new_metal(0)?)
+        progress.info(&format!("Using Metal device {ordinal}"));
+        tracing::info!("Using Metal device {ordinal}");
+        Ok(Device::new_metal(ordinal)?)
     } else {
         progress.info("No GPU detected, using CPU");
         tracing::warn!("No GPU detected, falling back to CPU");
@@ -156,29 +234,26 @@ pub fn available_system_memory_bytes() -> Option<u64> {
 
 // ── GPU memory reclamation ───────────────────────────────────────────────────
 
-/// Reclaim GPU memory by resetting the CUDA primary context.
+/// Reclaim GPU memory by resetting the CUDA primary context for the specified device.
 ///
-/// **Must only be called when no CUDA objects (tensors, devices, engines) exist.**
-/// This resets all CUDA state on GPU 0: driver context, cuBLAS workspace caches,
+/// **Must only be called when no CUDA objects (tensors, devices, engines) exist on this device.**
+/// This resets CUDA state on the specified GPU: driver context, cuBLAS workspace caches,
 /// compiled kernel modules, and memory pools. After calling this, the next
-/// `Device::new_cuda(0)` will create a fresh context.
+/// `Device::new_cuda(ordinal)` will create a fresh context.
 ///
 /// On non-CUDA platforms, this is a no-op.
 #[cfg(feature = "cuda")]
-pub fn reclaim_gpu_memory() {
+pub fn reclaim_gpu_memory(ordinal: usize) {
     use candle_core::cuda_backend::cudarc::driver::{result, sys};
 
     // Synchronize to ensure all async GPU work completes before reset.
     let _ = result::ctx::synchronize();
 
-    // Get the CUdevice handle for GPU 0.
-    // NOTE: This assumes a single-GPU setup — consistent with `create_device`
-    // which also hardcodes device 0. If multi-GPU support is added, this
-    // should iterate over all device indices that held engine allocations.
-    let cu_device = match result::device::get(0) {
+    // Get the CUdevice handle for the specified GPU ordinal.
+    let cu_device = match result::device::get(ordinal as i32) {
         Ok(d) => d,
         Err(e) => {
-            tracing::warn!("reclaim_gpu_memory: failed to get device: {e}");
+            tracing::warn!("reclaim_gpu_memory: failed to get device {ordinal}: {e}");
             return;
         }
     };
@@ -187,24 +262,33 @@ pub fn reclaim_gpu_memory() {
     // workspace caches, and releases compiled kernel modules.
     let result = unsafe { sys::cuDevicePrimaryCtxReset_v2(cu_device) };
     if result != sys::CUresult::CUDA_SUCCESS {
-        tracing::warn!("reclaim_gpu_memory: cuDevicePrimaryCtxReset returned {result:?}");
+        tracing::warn!("reclaim_gpu_memory: cuDevicePrimaryCtxReset for device {ordinal} returned {result:?}");
     } else {
-        tracing::info!("CUDA primary context reset, GPU memory reclaimed");
+        tracing::info!("CUDA primary context reset for device {ordinal}, GPU memory reclaimed");
     }
 }
 
 /// No-op on non-CUDA platforms.
 #[cfg(not(feature = "cuda"))]
-pub fn reclaim_gpu_memory() {}
+pub fn reclaim_gpu_memory(_ordinal: usize) {}
 
 // ── VRAM query ───────────────────────────────────────────────────────────────
 
-/// Query free VRAM in bytes from the current CUDA context.
+/// Query free VRAM in bytes for the specified GPU ordinal.
+///
+/// On CUDA, sets the context to the specified device before querying.
+/// On macOS (unified memory), returns available system memory (free + inactive).
+/// On other non-CUDA platforms, no VRAM info available.
 #[cfg(feature = "cuda")]
-pub fn free_vram_bytes() -> Option<u64> {
-    candle_core::cuda_backend::cudarc::driver::result::mem_get_info()
-        .ok()
-        .map(|(free, _total)| free as u64)
+pub fn free_vram_bytes(ordinal: usize) -> Option<u64> {
+    // Create/bind the device context for the specified ordinal before querying.
+    if candle_core::cuda_backend::cudarc::driver::CudaDevice::new(ordinal).is_ok() {
+        candle_core::cuda_backend::cudarc::driver::result::mem_get_info()
+            .ok()
+            .map(|(free, _total)| free as u64)
+    } else {
+        None
+    }
 }
 
 /// On macOS (unified memory), return available system memory (free + inactive).
@@ -214,23 +298,27 @@ pub fn free_vram_bytes() -> Option<u64> {
 /// would actually fit, forcing a BF16 fallback that doesn't fit either.
 /// On other non-CUDA platforms, no VRAM info available.
 #[cfg(not(feature = "cuda"))]
-pub fn free_vram_bytes() -> Option<u64> {
+pub fn free_vram_bytes(_ordinal: usize) -> Option<u64> {
     available_system_memory_bytes().or_else(free_system_memory_bytes)
 }
 
-/// Estimate current VRAM usage (total - free). Returns 0 if unavailable.
-/// Used by the model cache to track per-model VRAM footprint.
+/// Estimate current VRAM usage (total - free) for the specified GPU ordinal.
+/// Returns 0 if unavailable. Used by the model cache to track per-model VRAM footprint.
 #[cfg(feature = "cuda")]
-pub fn vram_used_estimate() -> u64 {
-    candle_core::cuda_backend::cudarc::driver::result::mem_get_info()
-        .ok()
-        .map(|(_free, total)| total as u64 - _free as u64)
-        .unwrap_or(0)
+pub fn vram_used_estimate(ordinal: usize) -> u64 {
+    if candle_core::cuda_backend::cudarc::driver::CudaDevice::new(ordinal).is_ok() {
+        candle_core::cuda_backend::cudarc::driver::result::mem_get_info()
+            .ok()
+            .map(|(_free, total)| total as u64 - _free as u64)
+            .unwrap_or(0)
+    } else {
+        0
+    }
 }
 
 /// Non-CUDA stub — no VRAM tracking available.
 #[cfg(not(feature = "cuda"))]
-pub fn vram_used_estimate() -> u64 {
+pub fn vram_used_estimate(_ordinal: usize) -> u64 {
     0
 }
 
@@ -472,7 +560,7 @@ fn preflight_check_budget(
 pub fn memory_status_string() -> Option<String> {
     #[cfg(feature = "cuda")]
     {
-        if let Some(free) = free_vram_bytes() {
+        if let Some(free) = free_vram_bytes(0) {
             return Some(format!("VRAM: {} free", fmt_gb(free)));
         }
     }
@@ -541,7 +629,7 @@ mod tests {
 
     #[test]
     fn free_vram_returns_some_on_macos_or_none_on_other() {
-        let _result = free_vram_bytes();
+        let _result = free_vram_bytes(0);
         #[cfg(target_os = "macos")]
         assert!(_result.is_some(), "macOS should return system memory info");
         #[cfg(not(any(target_os = "macos", feature = "cuda")))]
@@ -554,7 +642,7 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn free_vram_returns_available_not_just_free_on_macos() {
-        let vram = free_vram_bytes().unwrap();
+        let vram = free_vram_bytes(0).unwrap();
         let available = available_system_memory_bytes().unwrap();
         let free = free_system_memory_bytes().unwrap();
         // free_vram_bytes should return available (>= free), not just free

--- a/crates/mold-inference/src/engine_base.rs
+++ b/crates/mold-inference/src/engine_base.rs
@@ -21,17 +21,25 @@ pub(crate) struct EngineBase<L> {
     pub paths: ModelPaths,
     pub progress: ProgressReporter,
     pub load_strategy: LoadStrategy,
+    /// GPU ordinal this engine is assigned to. Used by `create_device()` and VRAM queries.
+    pub gpu_ordinal: usize,
 }
 
 impl<L> EngineBase<L> {
     /// Create a new engine base with no loaded state.
-    pub fn new(model_name: String, paths: ModelPaths, load_strategy: LoadStrategy) -> Self {
+    pub fn new(
+        model_name: String,
+        paths: ModelPaths,
+        load_strategy: LoadStrategy,
+        gpu_ordinal: usize,
+    ) -> Self {
         Self {
             loaded: None,
             model_name,
             paths,
             progress: ProgressReporter::default(),
             load_strategy,
+            gpu_ordinal,
         }
     }
 

--- a/crates/mold-inference/src/expand.rs
+++ b/crates/mold-inference/src/expand.rs
@@ -26,6 +26,7 @@ pub struct LocalExpander {
     model_path: PathBuf,
     tokenizer_path: PathBuf,
     progress: ProgressReporter,
+    gpu_ordinal: usize,
 }
 
 impl LocalExpander {
@@ -35,6 +36,7 @@ impl LocalExpander {
             model_path: model_path.into(),
             tokenizer_path: tokenizer_path.into(),
             progress: ProgressReporter::default(),
+            gpu_ordinal: 0,
         }
     }
 
@@ -116,10 +118,10 @@ impl LocalExpander {
     /// Load model, generate text, drop model.
     fn generate_text(&self, prompt_text: &str, config: &ExpandConfig) -> Result<String> {
         // Device selection: Metal always uses GPU (unified memory), CUDA checks VRAM
-        let gpu_device = create_device(0, &self.progress)?;
+        let gpu_device = create_device(self.gpu_ordinal, &self.progress)?;
         let is_cuda = gpu_device.is_cuda();
         let is_metal = gpu_device.is_metal();
-        let free_vram = free_vram_bytes(0).unwrap_or(0);
+        let free_vram = free_vram_bytes(self.gpu_ordinal).unwrap_or(0);
 
         let device = if should_use_gpu(is_cuda, is_metal, free_vram, EXPAND_LLM_VRAM_THRESHOLD) {
             gpu_device

--- a/crates/mold-inference/src/expand.rs
+++ b/crates/mold-inference/src/expand.rs
@@ -116,10 +116,10 @@ impl LocalExpander {
     /// Load model, generate text, drop model.
     fn generate_text(&self, prompt_text: &str, config: &ExpandConfig) -> Result<String> {
         // Device selection: Metal always uses GPU (unified memory), CUDA checks VRAM
-        let gpu_device = create_device(&self.progress)?;
+        let gpu_device = create_device(0, &self.progress)?;
         let is_cuda = gpu_device.is_cuda();
         let is_metal = gpu_device.is_metal();
-        let free_vram = free_vram_bytes().unwrap_or(0);
+        let free_vram = free_vram_bytes(0).unwrap_or(0);
 
         let device = if should_use_gpu(is_cuda, is_metal, free_vram, EXPAND_LLM_VRAM_THRESHOLD) {
             gpu_device

--- a/crates/mold-inference/src/factory.rs
+++ b/crates/mold-inference/src/factory.rs
@@ -37,9 +37,18 @@ pub fn create_engine(
     paths: ModelPaths,
     config: &Config,
     load_strategy: LoadStrategy,
+    gpu_ordinal: usize,
     offload: bool,
 ) -> Result<Box<dyn InferenceEngine>> {
-    create_engine_with_pool(model_name, paths, config, load_strategy, offload, None)
+    create_engine_with_pool(
+        model_name,
+        paths,
+        config,
+        load_strategy,
+        gpu_ordinal,
+        offload,
+        None,
+    )
 }
 
 /// Create an inference engine with an optional shared tokenizer pool.
@@ -51,6 +60,7 @@ pub fn create_engine_with_pool(
     paths: ModelPaths,
     config: &Config,
     load_strategy: LoadStrategy,
+    gpu_ordinal: usize,
     offload: bool,
     shared_pool: Option<Arc<Mutex<SharedPool>>>,
 ) -> Result<Box<dyn InferenceEngine>> {
@@ -69,6 +79,7 @@ pub fn create_engine_with_pool(
                 is_schnell,
                 t5_variant,
                 load_strategy,
+                gpu_ordinal,
                 offload,
                 shared_pool,
             )))
@@ -80,6 +91,7 @@ pub fn create_engine_with_pool(
                 paths,
                 scheduler,
                 load_strategy,
+                gpu_ordinal,
             )))
         }
         "sdxl" => {
@@ -97,6 +109,7 @@ pub fn create_engine_with_pool(
                 scheduler,
                 is_turbo,
                 load_strategy,
+                gpu_ordinal,
             )))
         }
         "sd3" | "sd3.5" | "stable-diffusion-3" | "stable-diffusion-3.5" => {
@@ -114,6 +127,7 @@ pub fn create_engine_with_pool(
                 is_medium,
                 t5_variant,
                 load_strategy,
+                gpu_ordinal,
             )))
         }
         "z-image" => {
@@ -125,6 +139,7 @@ pub fn create_engine_with_pool(
                 paths,
                 qwen3_variant,
                 load_strategy,
+                gpu_ordinal,
             )))
         }
         "flux2" | "flux.2" | "flux2-klein" => {
@@ -136,12 +151,14 @@ pub fn create_engine_with_pool(
                 paths,
                 qwen3_variant,
                 load_strategy,
+                gpu_ordinal,
             )))
         }
         "qwen-image" | "qwen_image" => Ok(Box::new(QwenImageEngine::new(
             model_name,
             paths,
             load_strategy,
+            gpu_ordinal,
             offload,
         ))),
         "qwen-image-edit" => Ok(Box::new(QwenImageEngine::new(
@@ -159,6 +176,7 @@ pub fn create_engine_with_pool(
                 paths,
                 t5_variant,
                 load_strategy,
+                gpu_ordinal,
                 shared_pool,
             )))
         }
@@ -167,6 +185,7 @@ pub fn create_engine_with_pool(
             model_name,
             paths,
             load_strategy,
+            gpu_ordinal,
         ))),
         other => bail!(
             "unknown model family '{}' for model '{}'. Supported: flux, flux2, ltx-video, ltx2, sd15, sd3, sdxl, z-image, qwen-image, qwen-image-edit, wuerstchen",
@@ -242,6 +261,7 @@ mod tests {
             dummy_paths(),
             &config,
             LoadStrategy::Sequential,
+            0,
             false,
         )
         .unwrap();
@@ -264,6 +284,7 @@ mod tests {
             dummy_paths(),
             &config,
             LoadStrategy::Sequential,
+            0,
             false,
         )
         .unwrap();
@@ -292,6 +313,7 @@ mod tests {
             dummy_paths(),
             &config,
             LoadStrategy::Sequential,
+            0,
             false,
         )
         .unwrap();
@@ -338,6 +360,7 @@ mod tests {
             dummy_paths(),
             &config,
             LoadStrategy::Sequential,
+            0,
             false,
         )
         .unwrap();
@@ -374,6 +397,7 @@ mod tests {
             dummy_paths(),
             &config,
             LoadStrategy::Sequential,
+            0,
             false,
         )
         .unwrap();
@@ -395,6 +419,7 @@ mod tests {
             dummy_paths(),
             &config,
             LoadStrategy::Sequential,
+            0,
             false,
         );
         assert!(result.is_err());
@@ -436,6 +461,7 @@ mod tests {
             dummy_paths(),
             &config,
             LoadStrategy::Sequential,
+            0,
             false,
         )
         .unwrap();
@@ -457,6 +483,7 @@ mod tests {
             dummy_paths(),
             &config,
             LoadStrategy::Sequential,
+            0,
             false,
         )
         .unwrap();

--- a/crates/mold-inference/src/factory.rs
+++ b/crates/mold-inference/src/factory.rs
@@ -165,6 +165,7 @@ pub fn create_engine_with_pool(
             model_name,
             paths,
             load_strategy,
+            gpu_ordinal,
             offload,
         ))),
         "ltx-video" | "ltx_video" => {
@@ -335,6 +336,7 @@ mod tests {
             dummy_paths(),
             &config,
             LoadStrategy::Sequential,
+            0,
             false,
         )
         .err()
@@ -435,6 +437,7 @@ mod tests {
             dummy_paths(),
             &Config::default(),
             LoadStrategy::Sequential,
+            0,
             false,
         );
         assert!(result.is_ok());

--- a/crates/mold-inference/src/flux/pipeline.rs
+++ b/crates/mold-inference/src/flux/pipeline.rs
@@ -1618,6 +1618,7 @@ impl FluxEngine {
             model: req.model.clone(),
             seed_used: seed,
             video: None,
+            gpu: None,
         })
     }
 }
@@ -2081,6 +2082,7 @@ impl FluxEngine {
             model: req.model.clone(),
             seed_used: seed,
             video: None,
+            gpu: None,
         })
     }
 }

--- a/crates/mold-inference/src/flux/pipeline.rs
+++ b/crates/mold-inference/src/flux/pipeline.rs
@@ -840,7 +840,7 @@ impl FluxEngine {
             self.validate_paths()?;
 
         let cpu = Device::Cpu;
-        let device = crate::device::create_device(&self.base.progress)?;
+        let device = crate::device::create_device(0, &self.base.progress)?;
         let mut is_quantized = self.detect_is_quantized();
         let transformer_is_fp8 = self.check_transformer_is_fp8(is_quantized);
 
@@ -874,7 +874,7 @@ impl FluxEngine {
             let xformer_size = std::fs::metadata(&transformer_path)
                 .map(|m| m.len())
                 .unwrap_or(0);
-            let free = free_vram_bytes().unwrap_or(0);
+            let free = free_vram_bytes(0).unwrap_or(0);
             if free > 0 && xformer_size > free {
                 bail!(
                     "transformer ({:.1} GB) exceeds available VRAM ({:.1} GB) — \
@@ -945,7 +945,7 @@ impl FluxEngine {
         tracing::info!("VAE loaded on GPU");
 
         // --- Decide where to place T5 and CLIP based on remaining VRAM ---
-        let free = free_vram_bytes().unwrap_or(0);
+        let free = free_vram_bytes(0).unwrap_or(0);
         if free > 0 {
             self.base.progress.info(&format!(
                 "Free VRAM after transformer+VAE: {}",
@@ -1000,7 +1000,7 @@ impl FluxEngine {
         tracing::info!(device = %t5_device_label, "T5 encoder loaded");
 
         // Re-check VRAM after T5 (it may have consumed GPU memory)
-        let free_after_t5 = free_vram_bytes().unwrap_or(0);
+        let free_after_t5 = free_vram_bytes(0).unwrap_or(0);
         let clip_on_gpu = should_use_gpu(
             device.is_cuda(),
             device.is_metal(),
@@ -1073,7 +1073,7 @@ impl FluxEngine {
             self.base.progress.info(&warning);
         }
 
-        let device = crate::device::create_device(&self.base.progress)?;
+        let device = crate::device::create_device(0, &self.base.progress)?;
 
         // Use cached transformer path to avoid file I/O on every sequential call.
         let transformer_path = if let Some(ref cached) = self.cached_transformer_path {
@@ -1134,7 +1134,7 @@ impl FluxEngine {
             (t5_emb, clip_emb)
         } else {
             // --- Phase 1: T5 encoding ---
-            let free = free_vram_bytes().unwrap_or(0);
+            let free = free_vram_bytes(0).unwrap_or(0);
             self.base.progress.stage_start("Selecting T5 encoder");
             let t5_resolve_start = Instant::now();
             let t5_preference = self.t5_variant.as_deref();
@@ -1190,7 +1190,7 @@ impl FluxEngine {
             tracing::info!("T5 encoder dropped (sequential mode)");
 
             // --- Phase 2: CLIP encoding ---
-            let free_for_clip = free_vram_bytes().unwrap_or(0);
+            let free_for_clip = free_vram_bytes(0).unwrap_or(0);
             let clip_on_gpu = should_use_gpu(
                 device.is_cuda(),
                 device.is_metal(),
@@ -1254,7 +1254,7 @@ impl FluxEngine {
 
         // Determine if block-level offloading should be used.
         let use_offload = if !is_quantized {
-            let free = free_vram_bytes().unwrap_or(0);
+            let free = free_vram_bytes(0).unwrap_or(0);
             if self.offload || should_offload(xformer_size, free) {
                 if free > 0 && free < MIN_OFFLOAD_VRAM {
                     bail!(

--- a/crates/mold-inference/src/flux/pipeline.rs
+++ b/crates/mold-inference/src/flux/pipeline.rs
@@ -663,11 +663,12 @@ impl FluxEngine {
         is_schnell_override: Option<bool>,
         t5_variant: Option<String>,
         load_strategy: LoadStrategy,
+        gpu_ordinal: usize,
         offload: bool,
         shared_pool: Option<Arc<Mutex<crate::shared_pool::SharedPool>>>,
     ) -> Self {
         Self {
-            base: EngineBase::new(model_name, paths, load_strategy),
+            base: EngineBase::new(model_name, paths, load_strategy, gpu_ordinal),
             is_schnell_override,
             t5_variant,
             prompt_cache: Mutex::new(LruCache::new(DEFAULT_PROMPT_CACHE_CAPACITY)),
@@ -840,7 +841,7 @@ impl FluxEngine {
             self.validate_paths()?;
 
         let cpu = Device::Cpu;
-        let device = crate::device::create_device(0, &self.base.progress)?;
+        let device = crate::device::create_device(self.base.gpu_ordinal, &self.base.progress)?;
         let mut is_quantized = self.detect_is_quantized();
         let transformer_is_fp8 = self.check_transformer_is_fp8(is_quantized);
 
@@ -874,7 +875,7 @@ impl FluxEngine {
             let xformer_size = std::fs::metadata(&transformer_path)
                 .map(|m| m.len())
                 .unwrap_or(0);
-            let free = free_vram_bytes(0).unwrap_or(0);
+            let free = free_vram_bytes(self.base.gpu_ordinal).unwrap_or(0);
             if free > 0 && xformer_size > free {
                 bail!(
                     "transformer ({:.1} GB) exceeds available VRAM ({:.1} GB) — \
@@ -945,7 +946,7 @@ impl FluxEngine {
         tracing::info!("VAE loaded on GPU");
 
         // --- Decide where to place T5 and CLIP based on remaining VRAM ---
-        let free = free_vram_bytes(0).unwrap_or(0);
+        let free = free_vram_bytes(self.base.gpu_ordinal).unwrap_or(0);
         if free > 0 {
             self.base.progress.info(&format!(
                 "Free VRAM after transformer+VAE: {}",
@@ -1000,7 +1001,7 @@ impl FluxEngine {
         tracing::info!(device = %t5_device_label, "T5 encoder loaded");
 
         // Re-check VRAM after T5 (it may have consumed GPU memory)
-        let free_after_t5 = free_vram_bytes(0).unwrap_or(0);
+        let free_after_t5 = free_vram_bytes(self.base.gpu_ordinal).unwrap_or(0);
         let clip_on_gpu = should_use_gpu(
             device.is_cuda(),
             device.is_metal(),
@@ -1073,7 +1074,7 @@ impl FluxEngine {
             self.base.progress.info(&warning);
         }
 
-        let device = crate::device::create_device(0, &self.base.progress)?;
+        let device = crate::device::create_device(self.base.gpu_ordinal, &self.base.progress)?;
 
         // Use cached transformer path to avoid file I/O on every sequential call.
         let transformer_path = if let Some(ref cached) = self.cached_transformer_path {
@@ -1134,7 +1135,7 @@ impl FluxEngine {
             (t5_emb, clip_emb)
         } else {
             // --- Phase 1: T5 encoding ---
-            let free = free_vram_bytes(0).unwrap_or(0);
+            let free = free_vram_bytes(self.base.gpu_ordinal).unwrap_or(0);
             self.base.progress.stage_start("Selecting T5 encoder");
             let t5_resolve_start = Instant::now();
             let t5_preference = self.t5_variant.as_deref();
@@ -1190,7 +1191,7 @@ impl FluxEngine {
             tracing::info!("T5 encoder dropped (sequential mode)");
 
             // --- Phase 2: CLIP encoding ---
-            let free_for_clip = free_vram_bytes(0).unwrap_or(0);
+            let free_for_clip = free_vram_bytes(self.base.gpu_ordinal).unwrap_or(0);
             let clip_on_gpu = should_use_gpu(
                 device.is_cuda(),
                 device.is_metal(),
@@ -1254,7 +1255,7 @@ impl FluxEngine {
 
         // Determine if block-level offloading should be used.
         let use_offload = if !is_quantized {
-            let free = free_vram_bytes(0).unwrap_or(0);
+            let free = free_vram_bytes(self.base.gpu_ordinal).unwrap_or(0);
             if self.offload || should_offload(xformer_size, free) {
                 if free > 0 && free < MIN_OFFLOAD_VRAM {
                     bail!(

--- a/crates/mold-inference/src/flux2/pipeline.rs
+++ b/crates/mold-inference/src/flux2/pipeline.rs
@@ -329,7 +329,7 @@ impl Flux2Engine {
         let text_tokenizer_path = self.validate_paths()?;
 
         let cpu = Device::Cpu;
-        let device = crate::device::create_device(&self.base.progress)?;
+        let device = crate::device::create_device(0, &self.base.progress)?;
         let gpu_dtype = crate::engine::gpu_dtype(&device);
 
         tracing::info!("GPU device: {:?}, GPU dtype: {:?}", device, gpu_dtype);
@@ -361,7 +361,7 @@ impl Flux2Engine {
         tracing::info!("VAE loaded on GPU");
 
         // --- Resolve and load Qwen3 text encoder ---
-        let free = free_vram_bytes().unwrap_or(0);
+        let free = free_vram_bytes(0).unwrap_or(0);
         if free > 0 {
             self.base.progress.info(&format!(
                 "Free VRAM after transformer+VAE: {}",
@@ -440,7 +440,7 @@ impl Flux2Engine {
             self.base.progress.info(&warning);
         }
 
-        let device = crate::device::create_device(&self.base.progress)?;
+        let device = crate::device::create_device(0, &self.base.progress)?;
         let gpu_dtype = crate::engine::gpu_dtype(&device);
 
         let start = Instant::now();
@@ -470,7 +470,7 @@ impl Flux2Engine {
             self.base.progress.cache_hit("prompt conditioning");
             tensor
         } else {
-            let free = free_vram_bytes().unwrap_or(0);
+            let free = free_vram_bytes(0).unwrap_or(0);
             self.base.progress.stage_start("Selecting Qwen3 encoder");
             let resolve_start = Instant::now();
             let qwen3_size = self.qwen3_size();

--- a/crates/mold-inference/src/flux2/pipeline.rs
+++ b/crates/mold-inference/src/flux2/pipeline.rs
@@ -716,6 +716,7 @@ impl Flux2Engine {
             model: req.model.clone(),
             seed_used: seed,
             video: None,
+            gpu: None,
         })
     }
 }
@@ -953,6 +954,7 @@ impl InferenceEngine for Flux2Engine {
             model: req.model.clone(),
             seed_used: seed,
             video: None,
+            gpu: None,
         })
     }
 

--- a/crates/mold-inference/src/flux2/pipeline.rs
+++ b/crates/mold-inference/src/flux2/pipeline.rs
@@ -69,9 +69,10 @@ impl Flux2Engine {
         paths: ModelPaths,
         qwen3_variant: Option<String>,
         load_strategy: LoadStrategy,
+        gpu_ordinal: usize,
     ) -> Self {
         Self {
-            base: EngineBase::new(model_name, paths, load_strategy),
+            base: EngineBase::new(model_name, paths, load_strategy, gpu_ordinal),
             qwen3_variant,
             prompt_cache: Mutex::new(LruCache::new(DEFAULT_PROMPT_CACHE_CAPACITY)),
         }
@@ -329,7 +330,7 @@ impl Flux2Engine {
         let text_tokenizer_path = self.validate_paths()?;
 
         let cpu = Device::Cpu;
-        let device = crate::device::create_device(0, &self.base.progress)?;
+        let device = crate::device::create_device(self.base.gpu_ordinal, &self.base.progress)?;
         let gpu_dtype = crate::engine::gpu_dtype(&device);
 
         tracing::info!("GPU device: {:?}, GPU dtype: {:?}", device, gpu_dtype);
@@ -361,7 +362,7 @@ impl Flux2Engine {
         tracing::info!("VAE loaded on GPU");
 
         // --- Resolve and load Qwen3 text encoder ---
-        let free = free_vram_bytes(0).unwrap_or(0);
+        let free = free_vram_bytes(self.base.gpu_ordinal).unwrap_or(0);
         if free > 0 {
             self.base.progress.info(&format!(
                 "Free VRAM after transformer+VAE: {}",
@@ -440,7 +441,7 @@ impl Flux2Engine {
             self.base.progress.info(&warning);
         }
 
-        let device = crate::device::create_device(0, &self.base.progress)?;
+        let device = crate::device::create_device(self.base.gpu_ordinal, &self.base.progress)?;
         let gpu_dtype = crate::engine::gpu_dtype(&device);
 
         let start = Instant::now();
@@ -470,7 +471,7 @@ impl Flux2Engine {
             self.base.progress.cache_hit("prompt conditioning");
             tensor
         } else {
-            let free = free_vram_bytes(0).unwrap_or(0);
+            let free = free_vram_bytes(self.base.gpu_ordinal).unwrap_or(0);
             self.base.progress.stage_start("Selecting Qwen3 encoder");
             let resolve_start = Instant::now();
             let qwen3_size = self.qwen3_size();
@@ -1055,12 +1056,14 @@ mod tests {
             flux2_model_paths(&base_dir, "transformer.gguf", vec![], None),
             None,
             LoadStrategy::Sequential,
+            0,
         );
         let nine_b = Flux2Engine::new(
             "flux2-klein-9b:q8".to_string(),
             flux2_model_paths(&base_dir, "transformer.gguf", vec![], None),
             None,
             LoadStrategy::Sequential,
+            0,
         );
 
         let standard_cfg = standard.resolve_config();
@@ -1096,6 +1099,7 @@ mod tests {
             ),
             None,
             LoadStrategy::Sequential,
+            0,
         );
         assert_eq!(sharded.text_encoder_paths(), vec![shard_a, shard_b]);
 
@@ -1104,6 +1108,7 @@ mod tests {
             flux2_model_paths(&dir, "transformer.gguf", vec![], Some(fallback.clone())),
             None,
             LoadStrategy::Sequential,
+            0,
         );
         assert_eq!(fallback_engine.text_encoder_paths(), vec![fallback]);
 
@@ -1139,6 +1144,7 @@ mod tests {
             },
             None,
             LoadStrategy::Sequential,
+            0,
         );
 
         assert_eq!(engine.validate_paths().unwrap(), tokenizer);
@@ -1175,6 +1181,7 @@ mod tests {
             },
             None,
             LoadStrategy::Sequential,
+            0,
         );
 
         let err = engine.validate_paths().unwrap_err();

--- a/crates/mold-inference/src/ltx2/pipeline.rs
+++ b/crates/mold-inference/src/ltx2/pipeline.rs
@@ -271,7 +271,7 @@ impl Ltx2Engine {
                 self.info(
                     "Native LTX-2 prompt path ran out of CUDA memory; retrying with CPU fallback",
                 );
-                crate::device::reclaim_gpu_memory();
+                crate::device::reclaim_gpu_memory(0);
                 self.load_runtime_session_on_device(plan, Device::Cpu)
             }
             Err(err) => Err(err),
@@ -499,6 +499,7 @@ impl InferenceEngine for Ltx2Engine {
             generation_time_ms: start.elapsed().as_millis() as u64,
             model: self.model_name.clone(),
             seed_used: plan.seed,
+            gpu: None,
         })
     }
 

--- a/crates/mold-inference/src/ltx2/runtime.rs
+++ b/crates/mold-inference/src/ltx2/runtime.rs
@@ -397,7 +397,7 @@ impl Ltx2RuntimeSession {
         let device_handoff_start = Instant::now();
         if prompt_device_is_cuda {
             if self.device.is_none() {
-                crate::device::reclaim_gpu_memory();
+                crate::device::reclaim_gpu_memory(0);
                 self.device = Some(new_native_cuda_device()?);
             } else if let Some(device) = self.device.as_ref() {
                 if device.is_cuda() {
@@ -4213,7 +4213,7 @@ fn ltx_debug_timings_enabled() -> bool {
 }
 
 fn log_debug_vram(label: &str) {
-    if let Some(free) = free_vram_bytes() {
+    if let Some(free) = free_vram_bytes(0) {
         eprintln!("[ltx2-debug] {label} free_vram={}", fmt_gb(free));
     } else {
         eprintln!("[ltx2-debug] {label} free_vram=unavailable");

--- a/crates/mold-inference/src/ltx_video/pipeline.rs
+++ b/crates/mold-inference/src/ltx_video/pipeline.rs
@@ -1404,6 +1404,7 @@ impl LtxVideoEngine {
             generation_time_ms,
             model: self.base.model_name.clone(),
             seed_used: seed,
+            gpu: None,
         })
     }
 }

--- a/crates/mold-inference/src/ltx_video/pipeline.rs
+++ b/crates/mold-inference/src/ltx_video/pipeline.rs
@@ -631,10 +631,11 @@ impl LtxVideoEngine {
         paths: ModelPaths,
         t5_variant: Option<String>,
         load_strategy: LoadStrategy,
+        gpu_ordinal: usize,
         shared_pool: Option<Arc<Mutex<SharedPool>>>,
     ) -> Self {
         Self {
-            base: EngineBase::new(model_name, paths, load_strategy),
+            base: EngineBase::new(model_name, paths, load_strategy, gpu_ordinal),
             t5_variant,
             shared_pool,
         }
@@ -1012,7 +1013,7 @@ impl LtxVideoEngine {
         }
 
         // Select device
-        let device = crate::device::create_device(0, progress)?;
+        let device = crate::device::create_device(self.base.gpu_ordinal, progress)?;
         let dtype = gpu_dtype(&device);
 
         progress.info(&format!(

--- a/crates/mold-inference/src/ltx_video/pipeline.rs
+++ b/crates/mold-inference/src/ltx_video/pipeline.rs
@@ -1012,7 +1012,7 @@ impl LtxVideoEngine {
         }
 
         // Select device
-        let device = crate::device::create_device(progress)?;
+        let device = crate::device::create_device(0, progress)?;
         let dtype = gpu_dtype(&device);
 
         progress.info(&format!(

--- a/crates/mold-inference/src/qwen_image/offload.rs
+++ b/crates/mold-inference/src/qwen_image/offload.rs
@@ -521,7 +521,7 @@ impl OffloadedQwenImageTransformer {
 
         // Measure free VRAM after stem layers and decide how many blocks fit
         gpu_device.synchronize()?;
-        let free_vram = crate::device::free_vram_bytes().unwrap_or(0);
+        let free_vram = crate::device::free_vram_bytes(0).unwrap_or(0);
         const VRAM_HEADROOM: u64 = 4_500_000_000; // 4.5GB for attention + activations + CUDA overhead
         let vram_budget = free_vram.saturating_sub(VRAM_HEADROOM);
 

--- a/crates/mold-inference/src/qwen_image/pipeline.rs
+++ b/crates/mold-inference/src/qwen_image/pipeline.rs
@@ -2017,6 +2017,7 @@ impl QwenImageEngine {
             model: req.model.clone(),
             seed_used: seed,
             video: None,
+            gpu: None,
         })
     }
 
@@ -2769,6 +2770,7 @@ impl InferenceEngine for QwenImageEngine {
             model: req.model.clone(),
             seed_used: seed,
             video: None,
+            gpu: None,
         })
     }
 

--- a/crates/mold-inference/src/qwen_image/pipeline.rs
+++ b/crates/mold-inference/src/qwen_image/pipeline.rs
@@ -2325,6 +2325,7 @@ impl QwenImageEngine {
             model: req.model.clone(),
             seed_used: seed,
             video: None,
+            gpu: None,
         })
     }
 }
@@ -3232,6 +3233,7 @@ mod tests {
             "qwen-image-edit-2511:q4".to_string(),
             paths,
             LoadStrategy::Sequential,
+            0,
             false,
         );
 

--- a/crates/mold-inference/src/qwen_image/pipeline.rs
+++ b/crates/mold-inference/src/qwen_image/pipeline.rs
@@ -752,10 +752,11 @@ impl QwenImageEngine {
         model_name: String,
         paths: ModelPaths,
         load_strategy: LoadStrategy,
+        gpu_ordinal: usize,
         offload: bool,
     ) -> Self {
         Self {
-            base: EngineBase::new(model_name, paths, load_strategy),
+            base: EngineBase::new(model_name, paths, load_strategy, gpu_ordinal),
             prompt_cache: Mutex::new(LruCache::new(DEFAULT_PROMPT_CACHE_CAPACITY)),
             offload,
         }
@@ -904,7 +905,7 @@ impl QwenImageEngine {
             let transformer_size = std::fs::metadata(&self.base.paths.transformer)
                 .map(|m| m.len())
                 .unwrap_or(0);
-            let free = free_vram_bytes(0).unwrap_or(0);
+            let free = free_vram_bytes(self.base.gpu_ordinal).unwrap_or(0);
             let split_cfg_for_memory = device.is_cuda()
                 && (self.offload
                     || Self::should_split_cfg_quantized_cuda(
@@ -948,7 +949,7 @@ impl QwenImageEngine {
                 .filter_map(|p| std::fs::metadata(p).ok())
                 .map(|m| m.len())
                 .sum();
-            let free = free_vram_bytes(0).unwrap_or(0);
+            let free = free_vram_bytes(self.base.gpu_ordinal).unwrap_or(0);
             let use_offload = self.offload || crate::device::should_offload(mem_size, free);
 
             if is_fp8 {
@@ -1330,7 +1331,7 @@ impl QwenImageEngine {
         tracing::info!(model = %self.base.model_name, "loading Qwen-Image model components...");
 
         let text_tokenizer_path = self.validate_paths()?;
-        let device = crate::device::create_device(0, &self.base.progress)?;
+        let device = crate::device::create_device(self.base.gpu_ordinal, &self.base.progress)?;
         let transformer_cfg = self.transformer_config();
         let transformer_is_quantized = self.detect_is_quantized();
         // FP8 safetensors are loaded as BF16 via CPU (candle CUDA kernel bug
@@ -1363,7 +1364,7 @@ impl QwenImageEngine {
         tracing::info!("Qwen-Image transformer loaded");
 
         // Decide device placement for VAE and text encoder
-        let free = free_vram_bytes(0).unwrap_or(0);
+        let free = free_vram_bytes(self.base.gpu_ordinal).unwrap_or(0);
         let is_cuda = device.is_cuda();
         let is_metal = device.is_metal();
         if free > 0 {
@@ -1484,7 +1485,7 @@ impl QwenImageEngine {
         let text_tokenizer_path = self.validate_paths()?;
         let transformer_cfg = self.transformer_config();
 
-        let device = crate::device::create_device(0, &self.base.progress)?;
+        let device = crate::device::create_device(self.base.gpu_ordinal, &self.base.progress)?;
         let dtype = crate::engine::gpu_dtype(&device);
         let transformer_is_quantized = self.detect_is_quantized();
 
@@ -1493,7 +1494,7 @@ impl QwenImageEngine {
 
         let width = req.width as usize;
         let height = req.height as usize;
-        let free = free_vram_bytes(0).unwrap_or(0);
+        let free = free_vram_bytes(self.base.gpu_ordinal).unwrap_or(0);
         let resolved_text_encoder =
             self.resolve_text_encoder_source(&device, free, Qwen2TextEncoderUsage::Sequential)?;
         let (plan, _device_label) =
@@ -1716,7 +1717,7 @@ impl QwenImageEngine {
         let (prepared_img2img_latents, inpaint_ctx) = if let Some(ref source_bytes) =
             req.source_image
         {
-            let free_for_encode = free_vram_bytes(0).unwrap_or(0);
+            let free_for_encode = free_vram_bytes(self.base.gpu_ordinal).unwrap_or(0);
             let encode_on_gpu = should_use_gpu(
                 device.is_cuda(),
                 device.is_metal(),
@@ -1944,7 +1945,7 @@ impl QwenImageEngine {
             self.base.progress.info(&status);
         }
 
-        let free_for_vae = free_vram_bytes(0).unwrap_or(0);
+        let free_for_vae = free_vram_bytes(self.base.gpu_ordinal).unwrap_or(0);
         let vae_on_gpu = should_use_gpu(
             device.is_cuda(),
             device.is_metal(),
@@ -3030,6 +3031,7 @@ mod tests {
                 decoder: None,
             },
             LoadStrategy::Sequential,
+            0,
             false,
         );
 
@@ -3560,6 +3562,7 @@ mod tests {
                 Some(dir.join("tokenizer.json")),
             ),
             LoadStrategy::Sequential,
+            0,
             false,
         );
 
@@ -3586,6 +3589,7 @@ mod tests {
                 Some(tokenizer.clone()),
             ),
             LoadStrategy::Sequential,
+            0,
             false,
         );
         assert_eq!(sharded.validate_paths().unwrap(), tokenizer);
@@ -3595,6 +3599,7 @@ mod tests {
             "qwen-image:q4".to_string(),
             qwen_image_model_paths(gguf, vec![], vae, Some(dir.join("tokenizer.json"))),
             LoadStrategy::Sequential,
+            0,
             false,
         );
         assert!(quantized.detect_is_quantized());
@@ -3614,6 +3619,7 @@ mod tests {
                 None,
             ),
             LoadStrategy::Sequential,
+            0,
             false,
         );
 

--- a/crates/mold-inference/src/qwen_image/pipeline.rs
+++ b/crates/mold-inference/src/qwen_image/pipeline.rs
@@ -904,7 +904,7 @@ impl QwenImageEngine {
             let transformer_size = std::fs::metadata(&self.base.paths.transformer)
                 .map(|m| m.len())
                 .unwrap_or(0);
-            let free = free_vram_bytes().unwrap_or(0);
+            let free = free_vram_bytes(0).unwrap_or(0);
             let split_cfg_for_memory = device.is_cuda()
                 && (self.offload
                     || Self::should_split_cfg_quantized_cuda(
@@ -948,7 +948,7 @@ impl QwenImageEngine {
                 .filter_map(|p| std::fs::metadata(p).ok())
                 .map(|m| m.len())
                 .sum();
-            let free = free_vram_bytes().unwrap_or(0);
+            let free = free_vram_bytes(0).unwrap_or(0);
             let use_offload = self.offload || crate::device::should_offload(mem_size, free);
 
             if is_fp8 {
@@ -1330,7 +1330,7 @@ impl QwenImageEngine {
         tracing::info!(model = %self.base.model_name, "loading Qwen-Image model components...");
 
         let text_tokenizer_path = self.validate_paths()?;
-        let device = crate::device::create_device(&self.base.progress)?;
+        let device = crate::device::create_device(0, &self.base.progress)?;
         let transformer_cfg = self.transformer_config();
         let transformer_is_quantized = self.detect_is_quantized();
         // FP8 safetensors are loaded as BF16 via CPU (candle CUDA kernel bug
@@ -1363,7 +1363,7 @@ impl QwenImageEngine {
         tracing::info!("Qwen-Image transformer loaded");
 
         // Decide device placement for VAE and text encoder
-        let free = free_vram_bytes().unwrap_or(0);
+        let free = free_vram_bytes(0).unwrap_or(0);
         let is_cuda = device.is_cuda();
         let is_metal = device.is_metal();
         if free > 0 {
@@ -1484,7 +1484,7 @@ impl QwenImageEngine {
         let text_tokenizer_path = self.validate_paths()?;
         let transformer_cfg = self.transformer_config();
 
-        let device = crate::device::create_device(&self.base.progress)?;
+        let device = crate::device::create_device(0, &self.base.progress)?;
         let dtype = crate::engine::gpu_dtype(&device);
         let transformer_is_quantized = self.detect_is_quantized();
 
@@ -1493,7 +1493,7 @@ impl QwenImageEngine {
 
         let width = req.width as usize;
         let height = req.height as usize;
-        let free = free_vram_bytes().unwrap_or(0);
+        let free = free_vram_bytes(0).unwrap_or(0);
         let resolved_text_encoder =
             self.resolve_text_encoder_source(&device, free, Qwen2TextEncoderUsage::Sequential)?;
         let (plan, _device_label) =
@@ -1716,7 +1716,7 @@ impl QwenImageEngine {
         let (prepared_img2img_latents, inpaint_ctx) = if let Some(ref source_bytes) =
             req.source_image
         {
-            let free_for_encode = free_vram_bytes().unwrap_or(0);
+            let free_for_encode = free_vram_bytes(0).unwrap_or(0);
             let encode_on_gpu = should_use_gpu(
                 device.is_cuda(),
                 device.is_metal(),
@@ -1944,7 +1944,7 @@ impl QwenImageEngine {
             self.base.progress.info(&status);
         }
 
-        let free_for_vae = free_vram_bytes().unwrap_or(0);
+        let free_for_vae = free_vram_bytes(0).unwrap_or(0);
         let vae_on_gpu = should_use_gpu(
             device.is_cuda(),
             device.is_metal(),

--- a/crates/mold-inference/src/sd15/pipeline.rs
+++ b/crates/mold-inference/src/sd15/pipeline.rs
@@ -152,7 +152,7 @@ impl SD15Engine {
 
         tracing::info!(model = %self.base.model_name, "loading SD1.5 model components...");
 
-        let device = crate::device::create_device(&self.base.progress)?;
+        let device = crate::device::create_device(0, &self.base.progress)?;
         let dtype = if crate::device::is_gpu(&device) {
             DType::F16
         } else {
@@ -573,7 +573,7 @@ impl SD15Engine {
             self.base.progress.info(&warning);
         }
 
-        let device = crate::device::create_device(&self.base.progress)?;
+        let device = crate::device::create_device(0, &self.base.progress)?;
         let dtype = if crate::device::is_gpu(&device) {
             DType::F16
         } else {

--- a/crates/mold-inference/src/sd15/pipeline.rs
+++ b/crates/mold-inference/src/sd15/pipeline.rs
@@ -815,6 +815,7 @@ impl SD15Engine {
             model: req.model.clone(),
             seed_used: seed,
             video: None,
+            gpu: None,
         })
     }
 }
@@ -992,6 +993,7 @@ impl InferenceEngine for SD15Engine {
             model: req.model.clone(),
             seed_used: seed,
             video: None,
+            gpu: None,
         })
     }
 

--- a/crates/mold-inference/src/sd15/pipeline.rs
+++ b/crates/mold-inference/src/sd15/pipeline.rs
@@ -58,9 +58,10 @@ impl SD15Engine {
         paths: ModelPaths,
         scheduler: Scheduler,
         load_strategy: LoadStrategy,
+        gpu_ordinal: usize,
     ) -> Self {
         Self {
-            base: EngineBase::new(model_name, paths, load_strategy),
+            base: EngineBase::new(model_name, paths, load_strategy, gpu_ordinal),
             scheduler,
             prompt_cache: Mutex::new(LruCache::new(DEFAULT_PROMPT_CACHE_CAPACITY)),
             source_latent_cache: Mutex::new(LruCache::new(DEFAULT_IMAGE_CACHE_CAPACITY)),
@@ -152,7 +153,7 @@ impl SD15Engine {
 
         tracing::info!(model = %self.base.model_name, "loading SD1.5 model components...");
 
-        let device = crate::device::create_device(0, &self.base.progress)?;
+        let device = crate::device::create_device(self.base.gpu_ordinal, &self.base.progress)?;
         let dtype = if crate::device::is_gpu(&device) {
             DType::F16
         } else {
@@ -573,7 +574,7 @@ impl SD15Engine {
             self.base.progress.info(&warning);
         }
 
-        let device = crate::device::create_device(0, &self.base.progress)?;
+        let device = crate::device::create_device(self.base.gpu_ordinal, &self.base.progress)?;
         let dtype = if crate::device::is_gpu(&device) {
             DType::F16
         } else {

--- a/crates/mold-inference/src/sd3/pipeline.rs
+++ b/crates/mold-inference/src/sd3/pipeline.rs
@@ -246,7 +246,7 @@ impl SD3Engine {
             t5_tokenizer_path,
         ) = self.validate_paths()?;
 
-        let device = crate::device::create_device(&self.base.progress)?;
+        let device = crate::device::create_device(0, &self.base.progress)?;
         let gpu_dtype = if crate::device::is_gpu(&device) {
             DType::F16
         } else {
@@ -292,7 +292,7 @@ impl SD3Engine {
             .stage_done(xformer_label, xformer_stage.elapsed());
 
         // --- Decide encoder placement based on remaining VRAM ---
-        let free = free_vram_bytes().unwrap_or(0);
+        let free = free_vram_bytes(0).unwrap_or(0);
         if free > 0 {
             self.base
                 .progress
@@ -383,7 +383,7 @@ impl SD3Engine {
             self.base.progress.info(&warning);
         }
 
-        let device = crate::device::create_device(&self.base.progress)?;
+        let device = crate::device::create_device(0, &self.base.progress)?;
         let gpu_dtype = if crate::device::is_gpu(&device) {
             DType::F16
         } else {
@@ -418,7 +418,7 @@ impl SD3Engine {
             self.base.progress.cache_hit("prompt conditioning");
             (context, y)
         } else {
-            let free = free_vram_bytes().unwrap_or(0);
+            let free = free_vram_bytes(0).unwrap_or(0);
             self.base.progress.stage_start("Selecting T5 encoder");
             let t5_resolve_start = Instant::now();
             let t5_preference = self.t5_variant.as_deref();
@@ -993,6 +993,7 @@ impl InferenceEngine for SD3Engine {
                 model: req.model.clone(),
                 seed_used: seed,
                 video: None,
+                gpu: None,
             })
         })()
     }

--- a/crates/mold-inference/src/sd3/pipeline.rs
+++ b/crates/mold-inference/src/sd3/pipeline.rs
@@ -60,9 +60,10 @@ impl SD3Engine {
         is_medium: bool,
         t5_variant: Option<String>,
         load_strategy: LoadStrategy,
+        gpu_ordinal: usize,
     ) -> Self {
         Self {
-            base: EngineBase::new(model_name, paths, load_strategy),
+            base: EngineBase::new(model_name, paths, load_strategy, gpu_ordinal),
             is_turbo,
             is_medium,
             t5_variant,
@@ -246,7 +247,7 @@ impl SD3Engine {
             t5_tokenizer_path,
         ) = self.validate_paths()?;
 
-        let device = crate::device::create_device(0, &self.base.progress)?;
+        let device = crate::device::create_device(self.base.gpu_ordinal, &self.base.progress)?;
         let gpu_dtype = if crate::device::is_gpu(&device) {
             DType::F16
         } else {
@@ -292,7 +293,7 @@ impl SD3Engine {
             .stage_done(xformer_label, xformer_stage.elapsed());
 
         // --- Decide encoder placement based on remaining VRAM ---
-        let free = free_vram_bytes(0).unwrap_or(0);
+        let free = free_vram_bytes(self.base.gpu_ordinal).unwrap_or(0);
         if free > 0 {
             self.base
                 .progress
@@ -383,7 +384,7 @@ impl SD3Engine {
             self.base.progress.info(&warning);
         }
 
-        let device = crate::device::create_device(0, &self.base.progress)?;
+        let device = crate::device::create_device(self.base.gpu_ordinal, &self.base.progress)?;
         let gpu_dtype = if crate::device::is_gpu(&device) {
             DType::F16
         } else {
@@ -418,7 +419,7 @@ impl SD3Engine {
             self.base.progress.cache_hit("prompt conditioning");
             (context, y)
         } else {
-            let free = free_vram_bytes(0).unwrap_or(0);
+            let free = free_vram_bytes(self.base.gpu_ordinal).unwrap_or(0);
             self.base.progress.stage_start("Selecting T5 encoder");
             let t5_resolve_start = Instant::now();
             let t5_preference = self.t5_variant.as_deref();
@@ -1110,6 +1111,7 @@ mod tests {
             false,
             None,
             LoadStrategy::Sequential,
+            0,
         );
         let medium = SD3Engine::new(
             "sd3.5-medium:bf16".to_string(),
@@ -1127,6 +1129,7 @@ mod tests {
             true,
             None,
             LoadStrategy::Sequential,
+            0,
         );
 
         let large_cfg = large.mmdit_config();
@@ -1172,6 +1175,7 @@ mod tests {
             false,
             None,
             LoadStrategy::Sequential,
+            0,
         );
 
         let (_, _, _, _, _, resolved_t5_tok) = engine.validate_paths().unwrap();
@@ -1200,6 +1204,7 @@ mod tests {
             false,
             None,
             LoadStrategy::Sequential,
+            0,
         );
 
         let err = engine.validate_paths().unwrap_err();

--- a/crates/mold-inference/src/sd3/pipeline.rs
+++ b/crates/mold-inference/src/sd3/pipeline.rs
@@ -712,6 +712,7 @@ impl SD3Engine {
             model: req.model.clone(),
             seed_used: seed,
             video: None,
+            gpu: None,
         })
     }
 }

--- a/crates/mold-inference/src/sdxl/pipeline.rs
+++ b/crates/mold-inference/src/sdxl/pipeline.rs
@@ -53,9 +53,10 @@ impl SDXLEngine {
         scheduler: Scheduler,
         is_turbo: bool,
         load_strategy: LoadStrategy,
+        gpu_ordinal: usize,
     ) -> Self {
         Self {
-            base: EngineBase::new(model_name, paths, load_strategy),
+            base: EngineBase::new(model_name, paths, load_strategy, gpu_ordinal),
             scheduler,
             is_turbo,
             prompt_cache: Mutex::new(LruCache::new(DEFAULT_PROMPT_CACHE_CAPACITY)),
@@ -180,7 +181,7 @@ impl SDXLEngine {
 
         tracing::info!(model = %self.base.model_name, "loading SDXL model components...");
 
-        let device = crate::device::create_device(0, &self.base.progress)?;
+        let device = crate::device::create_device(self.base.gpu_ordinal, &self.base.progress)?;
         let dtype = if crate::device::is_gpu(&device) {
             DType::F16
         } else {
@@ -537,7 +538,7 @@ impl SDXLEngine {
             self.base.progress.info(&warning);
         }
 
-        let device = crate::device::create_device(0, &self.base.progress)?;
+        let device = crate::device::create_device(self.base.gpu_ordinal, &self.base.progress)?;
         let dtype = if crate::device::is_gpu(&device) {
             DType::F16
         } else {

--- a/crates/mold-inference/src/sdxl/pipeline.rs
+++ b/crates/mold-inference/src/sdxl/pipeline.rs
@@ -180,7 +180,7 @@ impl SDXLEngine {
 
         tracing::info!(model = %self.base.model_name, "loading SDXL model components...");
 
-        let device = crate::device::create_device(&self.base.progress)?;
+        let device = crate::device::create_device(0, &self.base.progress)?;
         let dtype = if crate::device::is_gpu(&device) {
             DType::F16
         } else {
@@ -537,7 +537,7 @@ impl SDXLEngine {
             self.base.progress.info(&warning);
         }
 
-        let device = crate::device::create_device(&self.base.progress)?;
+        let device = crate::device::create_device(0, &self.base.progress)?;
         let dtype = if crate::device::is_gpu(&device) {
             DType::F16
         } else {

--- a/crates/mold-inference/src/sdxl/pipeline.rs
+++ b/crates/mold-inference/src/sdxl/pipeline.rs
@@ -796,6 +796,7 @@ impl SDXLEngine {
             model: req.model.clone(),
             seed_used: seed,
             video: None,
+            gpu: None,
         })
     }
 }
@@ -974,6 +975,7 @@ impl InferenceEngine for SDXLEngine {
             model: req.model.clone(),
             seed_used: seed,
             video: None,
+            gpu: None,
         })
     }
 

--- a/crates/mold-inference/src/upscaler/engine.rs
+++ b/crates/mold-inference/src/upscaler/engine.rs
@@ -240,7 +240,7 @@ impl UpscaleEngine for UpscalerEngine {
         let load_start = Instant::now();
         self.progress.stage_start("Loading upscaler model");
 
-        let device = create_device(&self.progress)?;
+        let device = create_device(0, &self.progress)?;
 
         // Determine dtype: prefer F16 on GPU, F32 on CPU
         let dtype = if matches!(device, Device::Cpu) {
@@ -317,7 +317,7 @@ impl UpscaleEngine for UpscalerEngine {
     fn unload(&mut self) {
         if self.loaded.is_some() {
             self.loaded = None;
-            crate::reclaim_gpu_memory();
+            crate::reclaim_gpu_memory(0);
             tracing::info!("Upscaler model unloaded: {}", self.name);
         }
     }

--- a/crates/mold-inference/src/wuerstchen/pipeline.rs
+++ b/crates/mold-inference/src/wuerstchen/pipeline.rs
@@ -452,7 +452,7 @@ impl WuerstchenEngine {
 
         tracing::info!(model = %self.base.model_name, "loading Wuerstchen model components...");
 
-        let device = crate::device::create_device(&self.base.progress)?;
+        let device = crate::device::create_device(0, &self.base.progress)?;
         // Use F16 on GPU for ~2x throughput and ~2x less VRAM.
         // gen_r_embedding computes sincos basis in F32 internally, then casts to
         // model dtype before the matmul — patched in candle-transformers-mold 0.9.4.
@@ -833,7 +833,7 @@ impl WuerstchenEngine {
             self.base.progress.info(&warning);
         }
 
-        let device = crate::device::create_device(&self.base.progress)?;
+        let device = crate::device::create_device(0, &self.base.progress)?;
         // Use F16 on GPU for ~2x throughput on the Prior stage.
         // Decoder and VQ-GAN use F32 explicitly (see their load calls below).
         let dtype = if device.is_cpu() {

--- a/crates/mold-inference/src/wuerstchen/pipeline.rs
+++ b/crates/mold-inference/src/wuerstchen/pipeline.rs
@@ -197,9 +197,14 @@ impl WuerstchenEngine {
         requested_steps
     }
 
-    pub fn new(model_name: String, paths: ModelPaths, load_strategy: LoadStrategy) -> Self {
+    pub fn new(
+        model_name: String,
+        paths: ModelPaths,
+        load_strategy: LoadStrategy,
+        gpu_ordinal: usize,
+    ) -> Self {
         Self {
-            base: EngineBase::new(model_name, paths, load_strategy),
+            base: EngineBase::new(model_name, paths, load_strategy, gpu_ordinal),
             prompt_cache: Mutex::new(LruCache::new(DEFAULT_PROMPT_CACHE_CAPACITY)),
         }
     }
@@ -452,7 +457,7 @@ impl WuerstchenEngine {
 
         tracing::info!(model = %self.base.model_name, "loading Wuerstchen model components...");
 
-        let device = crate::device::create_device(0, &self.base.progress)?;
+        let device = crate::device::create_device(self.base.gpu_ordinal, &self.base.progress)?;
         // Use F16 on GPU for ~2x throughput and ~2x less VRAM.
         // gen_r_embedding computes sincos basis in F32 internally, then casts to
         // model dtype before the matmul — patched in candle-transformers-mold 0.9.4.
@@ -833,7 +838,7 @@ impl WuerstchenEngine {
             self.base.progress.info(&warning);
         }
 
-        let device = crate::device::create_device(0, &self.base.progress)?;
+        let device = crate::device::create_device(self.base.gpu_ordinal, &self.base.progress)?;
         // Use F16 on GPU for ~2x throughput on the Prior stage.
         // Decoder and VQ-GAN use F32 explicitly (see their load calls below).
         let dtype = if device.is_cpu() {
@@ -1637,6 +1642,7 @@ mod tests {
                 None,
             ),
             LoadStrategy::Sequential,
+            0,
         );
 
         let (
@@ -1679,6 +1685,7 @@ mod tests {
                 None,
             ),
             LoadStrategy::Sequential,
+            0,
         );
         let err = missing_decoder_engine.validate_paths().unwrap_err();
         assert!(err.to_string().contains("Decoder (Stage B) path required"));
@@ -1695,6 +1702,7 @@ mod tests {
                 None,
             ),
             LoadStrategy::Sequential,
+            0,
         );
         let err = missing_file_engine.validate_paths().unwrap_err();
         assert!(err.to_string().contains("decoder (Stage B) file not found"));

--- a/crates/mold-inference/src/wuerstchen/pipeline.rs
+++ b/crates/mold-inference/src/wuerstchen/pipeline.rs
@@ -1207,6 +1207,7 @@ impl WuerstchenEngine {
             model: req.model.clone(),
             seed_used: seed,
             video: None,
+            gpu: None,
         })
     }
 }
@@ -1429,6 +1430,7 @@ impl InferenceEngine for WuerstchenEngine {
             model: req.model.clone(),
             seed_used: seed,
             video: None,
+            gpu: None,
         })
     }
 

--- a/crates/mold-inference/src/zimage/pipeline.rs
+++ b/crates/mold-inference/src/zimage/pipeline.rs
@@ -277,7 +277,7 @@ impl ZImageEngine {
         let is_gguf = self.detect_is_gguf();
         let text_tokenizer_path = self.validate_paths()?;
 
-        let device = crate::device::create_device(&self.base.progress)?;
+        let device = crate::device::create_device(0, &self.base.progress)?;
         let dtype = crate::engine::gpu_dtype(&device);
         let transformer_cfg = Config::z_image_turbo();
 
@@ -302,7 +302,7 @@ impl ZImageEngine {
         tracing::info!(quantized = is_gguf, "Z-Image transformer loaded");
 
         // --- Decide where to place VAE and Qwen3 text encoder based on remaining VRAM ---
-        let free = free_vram_bytes().unwrap_or(0);
+        let free = free_vram_bytes(0).unwrap_or(0);
         let is_cuda = device.is_cuda();
         let is_metal = device.is_metal();
         if free > 0 {
@@ -447,7 +447,7 @@ impl ZImageEngine {
             self.base.progress.info(&warning);
         }
 
-        let device = crate::device::create_device(&self.base.progress)?;
+        let device = crate::device::create_device(0, &self.base.progress)?;
         let dtype = crate::engine::gpu_dtype(&device);
 
         let start = Instant::now();
@@ -477,7 +477,7 @@ impl ZImageEngine {
             let cap_mask = Tensor::ones((1, token_count), DType::U8, &device)?;
             (cap_feats, cap_mask)
         } else {
-            let free = free_vram_bytes().unwrap_or(0);
+            let free = free_vram_bytes(0).unwrap_or(0);
             self.base.progress.stage_start("Selecting Qwen3 encoder");
             let qwen3_resolve_start = Instant::now();
             let qwen3_preference = self.qwen3_variant.as_deref();
@@ -767,7 +767,7 @@ impl ZImageEngine {
             self.base.progress.info(&status);
         }
         // With sequential loading, we can always try GPU for VAE since transformer is freed
-        let free_for_vae = free_vram_bytes().unwrap_or(0);
+        let free_for_vae = free_vram_bytes(0).unwrap_or(0);
         let vae_on_gpu = should_use_gpu(
             device.is_cuda(),
             device.is_metal(),

--- a/crates/mold-inference/src/zimage/pipeline.rs
+++ b/crates/mold-inference/src/zimage/pipeline.rs
@@ -134,9 +134,10 @@ impl ZImageEngine {
         paths: ModelPaths,
         qwen3_variant: Option<String>,
         load_strategy: LoadStrategy,
+        gpu_ordinal: usize,
     ) -> Self {
         Self {
-            base: EngineBase::new(model_name, paths, load_strategy),
+            base: EngineBase::new(model_name, paths, load_strategy, gpu_ordinal),
             qwen3_variant,
             prompt_cache: Mutex::new(LruCache::new(DEFAULT_PROMPT_CACHE_CAPACITY)),
         }
@@ -277,7 +278,7 @@ impl ZImageEngine {
         let is_gguf = self.detect_is_gguf();
         let text_tokenizer_path = self.validate_paths()?;
 
-        let device = crate::device::create_device(0, &self.base.progress)?;
+        let device = crate::device::create_device(self.base.gpu_ordinal, &self.base.progress)?;
         let dtype = crate::engine::gpu_dtype(&device);
         let transformer_cfg = Config::z_image_turbo();
 
@@ -302,7 +303,7 @@ impl ZImageEngine {
         tracing::info!(quantized = is_gguf, "Z-Image transformer loaded");
 
         // --- Decide where to place VAE and Qwen3 text encoder based on remaining VRAM ---
-        let free = free_vram_bytes(0).unwrap_or(0);
+        let free = free_vram_bytes(self.base.gpu_ordinal).unwrap_or(0);
         let is_cuda = device.is_cuda();
         let is_metal = device.is_metal();
         if free > 0 {
@@ -447,7 +448,7 @@ impl ZImageEngine {
             self.base.progress.info(&warning);
         }
 
-        let device = crate::device::create_device(0, &self.base.progress)?;
+        let device = crate::device::create_device(self.base.gpu_ordinal, &self.base.progress)?;
         let dtype = crate::engine::gpu_dtype(&device);
 
         let start = Instant::now();
@@ -477,7 +478,7 @@ impl ZImageEngine {
             let cap_mask = Tensor::ones((1, token_count), DType::U8, &device)?;
             (cap_feats, cap_mask)
         } else {
-            let free = free_vram_bytes(0).unwrap_or(0);
+            let free = free_vram_bytes(self.base.gpu_ordinal).unwrap_or(0);
             self.base.progress.stage_start("Selecting Qwen3 encoder");
             let qwen3_resolve_start = Instant::now();
             let qwen3_preference = self.qwen3_variant.as_deref();
@@ -767,7 +768,7 @@ impl ZImageEngine {
             self.base.progress.info(&status);
         }
         // With sequential loading, we can always try GPU for VAE since transformer is freed
-        let free_for_vae = free_vram_bytes(0).unwrap_or(0);
+        let free_for_vae = free_vram_bytes(self.base.gpu_ordinal).unwrap_or(0);
         let vae_on_gpu = should_use_gpu(
             device.is_cuda(),
             device.is_metal(),
@@ -1465,6 +1466,7 @@ mod tests {
             ),
             None,
             LoadStrategy::Sequential,
+            0,
         );
 
         assert_eq!(engine.transformer_paths(), vec![shard_a, shard_b]);
@@ -1491,6 +1493,7 @@ mod tests {
             ),
             None,
             LoadStrategy::Sequential,
+            0,
         );
         assert_eq!(sharded.validate_paths().unwrap(), tokenizer);
         assert!(!sharded.detect_is_gguf());
@@ -1500,6 +1503,7 @@ mod tests {
             zimage_model_paths(gguf, vec![], vae, Some(dir.join("tokenizer.json"))),
             None,
             LoadStrategy::Sequential,
+            0,
         );
         assert!(quantized.detect_is_gguf());
 
@@ -1519,6 +1523,7 @@ mod tests {
             ),
             None,
             LoadStrategy::Sequential,
+            0,
         );
 
         let err = engine.validate_paths().unwrap_err();

--- a/crates/mold-inference/src/zimage/pipeline.rs
+++ b/crates/mold-inference/src/zimage/pipeline.rs
@@ -834,6 +834,7 @@ impl ZImageEngine {
             model: req.model.clone(),
             seed_used: seed,
             video: None,
+            gpu: None,
         })
     }
 }
@@ -1200,6 +1201,7 @@ impl InferenceEngine for ZImageEngine {
             model: req.model.clone(),
             seed_used: seed,
             video: None,
+            gpu: None,
         })
     }
 

--- a/crates/mold-server/src/gpu_pool.rs
+++ b/crates/mold-server/src/gpu_pool.rs
@@ -1,0 +1,161 @@
+use crate::model_cache::{ModelCache, ModelResidency};
+use mold_core::types::{GpuWorkerState, GpuWorkerStatus};
+use mold_inference::device::DiscoveredGpu;
+use mold_inference::shared_pool::SharedPool;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, RwLock};
+use std::time::Instant;
+
+/// Per-GPU worker state. Each GPU gets its own model cache, load lock, and health tracking.
+pub struct GpuWorker {
+    pub gpu: DiscoveredGpu,
+    pub model_cache: Arc<Mutex<ModelCache>>,
+    pub active_generation: Arc<RwLock<Option<ActiveGeneration>>>,
+    pub model_load_lock: Arc<Mutex<()>>,
+    pub shared_pool: Arc<Mutex<SharedPool>>,
+    pub in_flight: AtomicUsize,
+    pub consecutive_failures: AtomicUsize,
+    pub degraded_until: RwLock<Option<Instant>>,
+    pub job_tx: std::sync::mpsc::SyncSender<GpuJob>,
+}
+
+/// Tracks the currently active generation on a GPU worker.
+#[derive(Debug)]
+pub struct ActiveGeneration {
+    pub model: String,
+    pub started_at: Instant,
+}
+
+/// A job dispatched to a GPU worker thread for processing.
+pub struct GpuJob {
+    pub model: String,
+    pub request: mold_core::GenerateRequest,
+    pub progress_tx: Option<tokio::sync::mpsc::UnboundedSender<crate::state::SseMessage>>,
+    pub result_tx: tokio::sync::oneshot::Sender<Result<crate::state::GenerationJobResult, String>>,
+    pub output_dir: Option<std::path::PathBuf>,
+    pub config: Arc<tokio::sync::RwLock<mold_core::Config>>,
+}
+
+/// Pool of GPU workers with placement strategy.
+pub struct GpuPool {
+    pub workers: Vec<Arc<GpuWorker>>,
+}
+
+impl GpuWorker {
+    /// Check if this worker is in a degraded state (3+ consecutive failures, within cooldown).
+    pub fn is_degraded(&self) -> bool {
+        if self.consecutive_failures.load(Ordering::SeqCst) < 3 {
+            return false;
+        }
+        match *self.degraded_until.read().unwrap() {
+            Some(until) => Instant::now() < until,
+            None => false,
+        }
+    }
+
+    /// Build a status snapshot for this worker.
+    pub fn status(&self) -> GpuWorkerStatus {
+        let cache = self.model_cache.lock().unwrap();
+        let loaded_model = cache.active_model().map(|s| s.to_string());
+        let active_gen = self.active_generation.read().unwrap();
+
+        let state = if self.is_degraded() {
+            GpuWorkerState::Degraded
+        } else if active_gen.is_some() {
+            GpuWorkerState::Generating
+        } else {
+            GpuWorkerState::Idle
+        };
+
+        GpuWorkerStatus {
+            ordinal: self.gpu.ordinal,
+            name: self.gpu.name.clone(),
+            vram_total_bytes: self.gpu.total_vram_bytes,
+            vram_used_bytes: mold_inference::device::vram_used_estimate(self.gpu.ordinal),
+            loaded_model,
+            state,
+        }
+    }
+}
+
+impl GpuPool {
+    /// Find a worker that already has this model loaded on GPU.
+    /// If multiple workers have it, prefer the one with fewer in-flight requests.
+    pub fn find_loaded(&self, model_name: &str) -> Option<Arc<GpuWorker>> {
+        let mut candidates: Vec<_> = self
+            .workers
+            .iter()
+            .filter(|w| {
+                let cache = w.model_cache.lock().unwrap();
+                cache
+                    .get(model_name)
+                    .map(|e| e.residency == ModelResidency::Gpu)
+                    .unwrap_or(false)
+            })
+            .collect();
+
+        // Prefer least in-flight if multiple have it loaded.
+        candidates.sort_by_key(|w| w.in_flight.load(Ordering::SeqCst));
+        candidates.into_iter().next().cloned()
+    }
+
+    /// Select the best worker for a model, using the placement strategy:
+    /// 1. Already loaded on a GPU
+    /// 2. Idle GPU (no model loaded), smallest that fits
+    /// 3. Busy GPU with most headroom (will evict LRU)
+    pub fn select_worker(
+        &self,
+        model_name: &str,
+        estimated_vram: u64,
+    ) -> Option<Arc<GpuWorker>> {
+        // 1. Already loaded on a GPU?
+        if let Some(w) = self.find_loaded(model_name) {
+            return Some(w);
+        }
+
+        // 2. Find idle (no GPU-resident model) workers, skip degraded.
+        let mut idle: Vec<_> = self
+            .workers
+            .iter()
+            .filter(|w| {
+                if w.is_degraded() {
+                    return false;
+                }
+                let cache = w.model_cache.lock().unwrap();
+                cache.active_model().is_none()
+            })
+            .collect();
+
+        if !idle.is_empty() {
+            // VRAM-fit tiebreaker: smallest GPU that fits.
+            idle.sort_by_key(|w| w.gpu.total_vram_bytes);
+            if let Some(w) = idle
+                .iter()
+                .find(|w| w.gpu.total_vram_bytes >= estimated_vram)
+            {
+                return Some((*w).clone());
+            }
+            // No idle GPU fits — pick the largest idle GPU anyway (eviction will help).
+            return idle.last().cloned().cloned();
+        }
+
+        // 3. All GPUs busy — evict LRU on the GPU with most headroom.
+        let mut busy: Vec<_> = self.workers.iter().filter(|w| !w.is_degraded()).collect();
+        busy.sort_by(|a, b| {
+            let a_headroom = a.gpu.total_vram_bytes.saturating_sub(estimated_vram);
+            let b_headroom = b.gpu.total_vram_bytes.saturating_sub(estimated_vram);
+            b_headroom.cmp(&a_headroom) // most headroom first
+        });
+        busy.into_iter().next().cloned()
+    }
+
+    /// Collect status from all workers.
+    pub fn gpu_status(&self) -> Vec<GpuWorkerStatus> {
+        self.workers.iter().map(|w| w.status()).collect()
+    }
+
+    /// Number of GPU workers in the pool.
+    pub fn worker_count(&self) -> usize {
+        self.workers.len()
+    }
+}

--- a/crates/mold-server/src/gpu_pool.rs
+++ b/crates/mold-server/src/gpu_pool.rs
@@ -62,13 +62,10 @@ impl GpuWorker {
         // the cache entry is taken out of the cache (take-and-restore pattern),
         // so `cache.active_model()` returns None. Falling back to the cache
         // afterwards handles the idle-but-loaded case.
-        let loaded_model = active_gen
-            .as_ref()
-            .map(|g| g.model.clone())
-            .or_else(|| {
-                let cache = self.model_cache.lock().unwrap();
-                cache.active_model().map(|s| s.to_string())
-            });
+        let loaded_model = active_gen.as_ref().map(|g| g.model.clone()).or_else(|| {
+            let cache = self.model_cache.lock().unwrap();
+            cache.active_model().map(|s| s.to_string())
+        });
 
         let state = if self.is_degraded() {
             GpuWorkerState::Degraded

--- a/crates/mold-server/src/gpu_pool.rs
+++ b/crates/mold-server/src/gpu_pool.rs
@@ -103,11 +103,7 @@ impl GpuPool {
     /// 1. Already loaded on a GPU
     /// 2. Idle GPU (no model loaded), smallest that fits
     /// 3. Busy GPU with most headroom (will evict LRU)
-    pub fn select_worker(
-        &self,
-        model_name: &str,
-        estimated_vram: u64,
-    ) -> Option<Arc<GpuWorker>> {
+    pub fn select_worker(&self, model_name: &str, estimated_vram: u64) -> Option<Arc<GpuWorker>> {
         // 1. Already loaded on a GPU?
         if let Some(w) = self.find_loaded(model_name) {
             return Some(w);

--- a/crates/mold-server/src/gpu_pool.rs
+++ b/crates/mold-server/src/gpu_pool.rs
@@ -34,6 +34,8 @@ pub struct GpuJob {
     pub result_tx: tokio::sync::oneshot::Sender<Result<crate::state::GenerationJobResult, String>>,
     pub output_dir: Option<std::path::PathBuf>,
     pub config: Arc<tokio::sync::RwLock<mold_core::Config>>,
+    /// Decrement the global queue counter when the worker finishes this job.
+    pub queue: crate::state::QueueHandle,
 }
 
 /// Pool of GPU workers with placement strategy.
@@ -55,9 +57,18 @@ impl GpuWorker {
 
     /// Build a status snapshot for this worker.
     pub fn status(&self) -> GpuWorkerStatus {
-        let cache = self.model_cache.lock().unwrap();
-        let loaded_model = cache.active_model().map(|s| s.to_string());
         let active_gen = self.active_generation.read().unwrap();
+        // Prefer the active-generation model name — during inflight generation
+        // the cache entry is taken out of the cache (take-and-restore pattern),
+        // so `cache.active_model()` returns None. Falling back to the cache
+        // afterwards handles the idle-but-loaded case.
+        let loaded_model = active_gen
+            .as_ref()
+            .map(|g| g.model.clone())
+            .or_else(|| {
+                let cache = self.model_cache.lock().unwrap();
+                cache.active_model().map(|s| s.to_string())
+            });
 
         let state = if self.is_degraded() {
             GpuWorkerState::Degraded
@@ -79,13 +90,16 @@ impl GpuWorker {
 }
 
 impl GpuPool {
-    /// Find a worker that already has this model loaded on GPU.
+    /// Find a non-degraded worker that already has this model loaded on GPU.
     /// If multiple workers have it, prefer the one with fewer in-flight requests.
     pub fn find_loaded(&self, model_name: &str) -> Option<Arc<GpuWorker>> {
         let mut candidates: Vec<_> = self
             .workers
             .iter()
             .filter(|w| {
+                if w.is_degraded() {
+                    return false;
+                }
                 let cache = w.model_cache.lock().unwrap();
                 cache
                     .get(model_name)
@@ -94,55 +108,99 @@ impl GpuPool {
             })
             .collect();
 
-        // Prefer least in-flight if multiple have it loaded.
         candidates.sort_by_key(|w| w.in_flight.load(Ordering::SeqCst));
         candidates.into_iter().next().cloned()
     }
 
-    /// Select the best worker for a model, using the placement strategy:
-    /// 1. Already loaded on a GPU
-    /// 2. Idle GPU (no model loaded), smallest that fits
-    /// 3. Busy GPU with most headroom (will evict LRU)
+    /// Select the best worker for a model, using the placement strategy
+    /// (checked in order):
+    /// 1. Loaded and idle (model on GPU, no in-flight requests).
+    /// 2. Idle GPU with no model (spreads hot models across free GPUs).
+    /// 3. Loaded but busy — whichever loaded copy has the fewest in-flight.
+    /// 4. Non-degraded worker with the most headroom (will evict LRU).
     pub fn select_worker(&self, model_name: &str, estimated_vram: u64) -> Option<Arc<GpuWorker>> {
-        // 1. Already loaded on a GPU?
-        if let Some(w) = self.find_loaded(model_name) {
-            return Some(w);
-        }
+        self.select_worker_excluding(model_name, estimated_vram, &[])
+    }
 
-        // 2. Find idle (no GPU-resident model) workers, skip degraded.
-        let mut idle: Vec<_> = self
+    /// Same as [`select_worker`], but skips workers whose ordinal is in `skip`.
+    /// Used by the dispatcher to retry after a `try_send` failure.
+    pub fn select_worker_excluding(
+        &self,
+        model_name: &str,
+        estimated_vram: u64,
+        skip: &[usize],
+    ) -> Option<Arc<GpuWorker>> {
+        let eligible: Vec<&Arc<GpuWorker>> = self
             .workers
             .iter()
-            .filter(|w| {
-                if w.is_degraded() {
-                    return false;
-                }
-                let cache = w.model_cache.lock().unwrap();
-                cache.active_model().is_none()
-            })
+            .filter(|w| !w.is_degraded() && !skip.contains(&w.gpu.ordinal))
             .collect();
 
-        if !idle.is_empty() {
-            // VRAM-fit tiebreaker: smallest GPU that fits.
-            idle.sort_by_key(|w| w.gpu.total_vram_bytes);
-            if let Some(w) = idle
+        if eligible.is_empty() {
+            return None;
+        }
+
+        // Classify each eligible worker.
+        let mut loaded_idle: Vec<&Arc<GpuWorker>> = Vec::new();
+        let mut loaded_busy: Vec<&Arc<GpuWorker>> = Vec::new();
+        let mut idle_empty: Vec<&Arc<GpuWorker>> = Vec::new();
+        let mut other: Vec<&Arc<GpuWorker>> = Vec::new();
+
+        for w in &eligible {
+            let (has_model, has_any_loaded) = {
+                let cache = w.model_cache.lock().unwrap();
+                let has_model = cache
+                    .get(model_name)
+                    .map(|e| e.residency == ModelResidency::Gpu)
+                    .unwrap_or(false);
+                (has_model, cache.active_model().is_some())
+            };
+            let in_flight = w.in_flight.load(Ordering::SeqCst);
+
+            if has_model && in_flight == 0 {
+                loaded_idle.push(w);
+            } else if has_model {
+                loaded_busy.push(w);
+            } else if !has_any_loaded {
+                idle_empty.push(w);
+            } else {
+                other.push(w);
+            }
+        }
+
+        // 1. Loaded and idle — least in-flight first (should all be 0).
+        if !loaded_idle.is_empty() {
+            loaded_idle.sort_by_key(|w| w.in_flight.load(Ordering::SeqCst));
+            return loaded_idle.first().map(|w| (*w).clone());
+        }
+
+        // 2. Idle GPU with no model — spread! Prefer smallest GPU that fits.
+        if !idle_empty.is_empty() {
+            idle_empty.sort_by_key(|w| w.gpu.total_vram_bytes);
+            if let Some(w) = idle_empty
                 .iter()
                 .find(|w| w.gpu.total_vram_bytes >= estimated_vram)
             {
                 return Some((*w).clone());
             }
-            // No idle GPU fits — pick the largest idle GPU anyway (eviction will help).
-            return idle.last().cloned().cloned();
+            // No idle GPU fits — pick the largest idle GPU.
+            return idle_empty.last().map(|w| (*w).clone());
         }
 
-        // 3. All GPUs busy — evict LRU on the GPU with most headroom.
-        let mut busy: Vec<_> = self.workers.iter().filter(|w| !w.is_degraded()).collect();
+        // 3. Loaded but busy — least in-flight wins.
+        if !loaded_busy.is_empty() {
+            loaded_busy.sort_by_key(|w| w.in_flight.load(Ordering::SeqCst));
+            return loaded_busy.first().map(|w| (*w).clone());
+        }
+
+        // 4. All GPUs busy with other models — most headroom first (evict LRU there).
+        let mut busy = other;
         busy.sort_by(|a, b| {
             let a_headroom = a.gpu.total_vram_bytes.saturating_sub(estimated_vram);
             let b_headroom = b.gpu.total_vram_bytes.saturating_sub(estimated_vram);
-            b_headroom.cmp(&a_headroom) // most headroom first
+            b_headroom.cmp(&a_headroom)
         });
-        busy.into_iter().next().cloned()
+        busy.first().map(|w| (*w).clone())
     }
 
     /// Collect status from all workers.

--- a/crates/mold-server/src/gpu_worker.rs
+++ b/crates/mold-server/src/gpu_worker.rs
@@ -3,7 +3,9 @@ use crate::model_cache::ModelResidency;
 use crate::queue::clean_error_message;
 use crate::state::{GenerationJobResult, SseMessage};
 use base64::Engine as _;
-use mold_core::{ImageData, ModelPaths, OutputFormat, SseCompleteEvent, SseErrorEvent, SseProgressEvent};
+use mold_core::{
+    ImageData, ModelPaths, OutputFormat, SseCompleteEvent, SseErrorEvent, SseProgressEvent,
+};
 use mold_inference::device;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -113,11 +115,9 @@ fn process_job(worker: &GpuWorker, job: GpuJob) {
     // Set progress callback if SSE streaming.
     if let Some(ref progress_tx) = job.progress_tx {
         let tx = progress_tx.clone();
-        cached_engine
-            .engine
-            .set_on_progress(Box::new(move |event| {
-                let _ = tx.send(SseMessage::Progress(progress_to_sse(event)));
-            }));
+        cached_engine.engine.set_on_progress(Box::new(move |event| {
+            let _ = tx.send(SseMessage::Progress(progress_to_sse(event)));
+        }));
     }
 
     // Run inference — cache mutex is FREE during this.
@@ -182,8 +182,7 @@ fn process_job(worker: &GpuWorker, job: GpuJob) {
                         .duration_since(UNIX_EPOCH)
                         .map(|d| d.as_millis() as u64)
                         .unwrap_or(0);
-                    let filename =
-                        mold_core::default_output_filename(&job.model, ts, &ext, 1, 0);
+                    let filename = mold_core::default_output_filename(&job.model, ts, &ext, 1, 0);
                     let path = dir.join(filename);
                     if let Err(e) = std::fs::write(&path, &video.data) {
                         tracing::error!("failed to save video to {}: {e}", path.display());
@@ -300,9 +299,7 @@ fn ensure_model_ready_sync(
     // Resolve model paths.
     let config = job.config.blocking_read();
     let paths = ModelPaths::resolve(model_name, &config).ok_or_else(|| {
-        anyhow::anyhow!(
-            "model '{model_name}' is not downloaded. Run: mold pull {model_name}"
-        )
+        anyhow::anyhow!("model '{model_name}' is not downloaded. Run: mold pull {model_name}")
     })?;
 
     let offload = std::env::var("MOLD_OFFLOAD").is_ok_and(|v| v == "1");
@@ -332,10 +329,7 @@ fn ensure_model_ready_sync(
 }
 
 fn record_failure(worker: &GpuWorker) {
-    let failures = worker
-        .consecutive_failures
-        .fetch_add(1, Ordering::SeqCst)
-        + 1;
+    let failures = worker.consecutive_failures.fetch_add(1, Ordering::SeqCst) + 1;
     if failures >= 3 {
         let mut degraded = worker.degraded_until.write().unwrap();
         *degraded = Some(Instant::now() + Duration::from_secs(60));

--- a/crates/mold-server/src/gpu_worker.rs
+++ b/crates/mold-server/src/gpu_worker.rs
@@ -4,7 +4,7 @@ use crate::queue::clean_error_message;
 use crate::state::{GenerationJobResult, SseMessage};
 use base64::Engine as _;
 use mold_core::{
-    ImageData, ModelPaths, OutputFormat, SseCompleteEvent, SseErrorEvent, SseProgressEvent,
+    Config, ImageData, ModelPaths, OutputFormat, SseCompleteEvent, SseErrorEvent, SseProgressEvent,
 };
 use mold_inference::device;
 use std::sync::atomic::Ordering;
@@ -66,13 +66,25 @@ fn process_job(worker: &GpuWorker, job: GpuJob) {
     let model_name = job.model.clone();
     let ordinal = worker.gpu.ordinal;
 
+    // Release the global queue slot when this job finishes, regardless of
+    // which exit path runs. The dispatcher only decrements when it *fails* to
+    // dispatch — once we own the GpuJob, we own the slot.
+    struct QueueSlot(crate::state::QueueHandle);
+    impl Drop for QueueSlot {
+        fn drop(&mut self) {
+            self.0.decrement();
+        }
+    }
+    let _slot = QueueSlot(job.queue.clone());
+
     tracing::info!(gpu = ordinal, model = %model_name, "dispatched job");
 
     // Acquire per-GPU load lock — ensures only one model load at a time per GPU.
     let _load_lock = worker.model_load_lock.lock().unwrap();
 
     // Ensure model is loaded on this GPU.
-    if let Err(e) = ensure_model_ready_sync(worker, &model_name, &job) {
+    let config_snapshot = job.config.blocking_read().clone();
+    if let Err(e) = ensure_model_ready_sync(worker, &model_name, &config_snapshot) {
         tracing::error!(gpu = ordinal, model = %model_name, "Failed to load model: {e}");
         let err_msg = format!("model load error: {}", clean_error_message(&e));
         if let Some(ref tx) = job.progress_tx {
@@ -244,10 +256,14 @@ fn process_job(worker: &GpuWorker, job: GpuJob) {
     }
 }
 
-fn ensure_model_ready_sync(
+/// Ensure a model is loaded on this worker's GPU.
+///
+/// Holds `worker.model_load_lock` implicitly via the caller for generation
+/// jobs; the admin API path acquires it explicitly via `load_blocking`.
+pub fn ensure_model_ready_sync(
     worker: &GpuWorker,
     model_name: &str,
-    job: &GpuJob,
+    config: &Config,
 ) -> anyhow::Result<()> {
     let cache = worker.model_cache.lock().unwrap();
 
@@ -300,8 +316,7 @@ fn ensure_model_ready_sync(
     device::reclaim_gpu_memory(worker.gpu.ordinal);
 
     // Resolve model paths.
-    let config = job.config.blocking_read();
-    let paths = ModelPaths::resolve(model_name, &config).ok_or_else(|| {
+    let paths = ModelPaths::resolve(model_name, config).ok_or_else(|| {
         anyhow::anyhow!("model '{model_name}' is not downloaded. Run: mold pull {model_name}")
     })?;
 
@@ -309,13 +324,12 @@ fn ensure_model_ready_sync(
     let mut engine = mold_inference::create_engine_with_pool(
         model_name.to_string(),
         paths,
-        &config,
+        config,
         mold_inference::LoadStrategy::Eager,
         worker.gpu.ordinal,
         offload,
         Some(worker.shared_pool.clone()),
     )?;
-    drop(config);
 
     tracing::info!(
         gpu = worker.gpu.ordinal,
@@ -329,6 +343,31 @@ fn ensure_model_ready_sync(
     cache.insert_loaded(model_name.to_string(), engine, vram);
 
     Ok(())
+}
+
+/// Synchronously load a model on this GPU worker for the admin API.
+///
+/// Acquires the per-GPU load lock, then delegates to `ensure_model_ready_sync`.
+/// Intended to be called inside `tokio::task::spawn_blocking`.
+pub fn load_blocking(worker: &GpuWorker, model_name: &str, config: &Config) -> anyhow::Result<()> {
+    let _lock = worker.model_load_lock.lock().unwrap();
+    ensure_model_ready_sync(worker, model_name, config)
+}
+
+/// Synchronously unload the currently active model on this GPU worker.
+///
+/// Returns the name of the model that was unloaded, or `None` if the GPU was
+/// already idle.
+pub fn unload_blocking(worker: &GpuWorker) -> Option<String> {
+    let _lock = worker.model_load_lock.lock().unwrap();
+    let unloaded = {
+        let mut cache = worker.model_cache.lock().unwrap();
+        cache.unload_active()
+    };
+    if unloaded.is_some() {
+        device::reclaim_gpu_memory(worker.gpu.ordinal);
+    }
+    unloaded
 }
 
 fn record_failure(worker: &GpuWorker) {

--- a/crates/mold-server/src/gpu_worker.rs
+++ b/crates/mold-server/src/gpu_worker.rs
@@ -66,6 +66,8 @@ fn process_job(worker: &GpuWorker, job: GpuJob) {
     let model_name = job.model.clone();
     let ordinal = worker.gpu.ordinal;
 
+    tracing::info!(gpu = ordinal, model = %model_name, "dispatched job");
+
     // Acquire per-GPU load lock — ensures only one model load at a time per GPU.
     let _load_lock = worker.model_load_lock.lock().unwrap();
 
@@ -202,6 +204,7 @@ fn process_job(worker: &GpuWorker, job: GpuJob) {
                     seed_used: response.seed_used,
                     generation_time_ms: response.generation_time_ms,
                     model: response.model.clone(),
+                    gpu: response.gpu,
                 }));
             }
 

--- a/crates/mold-server/src/gpu_worker.rs
+++ b/crates/mold-server/src/gpu_worker.rs
@@ -216,6 +216,14 @@ fn process_job(worker: &GpuWorker, job: GpuJob) {
                     seed_used: response.seed_used,
                     generation_time_ms: response.generation_time_ms,
                     model: response.model.clone(),
+                    video_frames: None,
+                    video_fps: None,
+                    video_thumbnail: None,
+                    video_gif_preview: None,
+                    video_has_audio: false,
+                    video_duration_ms: None,
+                    video_audio_sample_rate: None,
+                    video_audio_channels: None,
                     gpu: response.gpu,
                 }));
             }

--- a/crates/mold-server/src/gpu_worker.rs
+++ b/crates/mold-server/src/gpu_worker.rs
@@ -1,0 +1,352 @@
+use crate::gpu_pool::{ActiveGeneration, GpuJob, GpuWorker};
+use crate::model_cache::ModelResidency;
+use crate::queue::clean_error_message;
+use crate::state::{GenerationJobResult, SseMessage};
+use base64::Engine as _;
+use mold_core::{ImageData, ModelPaths, OutputFormat, SseCompleteEvent, SseErrorEvent, SseProgressEvent};
+use mold_inference::device;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+/// Spawn the dedicated OS thread for a GPU worker.
+/// Returns the JoinHandle (caller should keep it alive).
+pub fn spawn_gpu_thread(
+    worker: Arc<GpuWorker>,
+    job_rx: std::sync::mpsc::Receiver<GpuJob>,
+) -> std::thread::JoinHandle<()> {
+    std::thread::Builder::new()
+        .name(format!("gpu-worker-{}", worker.gpu.ordinal))
+        .spawn(move || {
+            tracing::info!(
+                gpu = worker.gpu.ordinal,
+                name = %worker.gpu.name,
+                "GPU worker thread started"
+            );
+            for job in job_rx.iter() {
+                process_job(&worker, job);
+            }
+            tracing::info!(gpu = worker.gpu.ordinal, "GPU worker thread exiting");
+        })
+        .expect("failed to spawn GPU worker thread")
+}
+
+/// Convert an inference-crate progress event to an SSE wire event.
+fn progress_to_sse(event: mold_inference::ProgressEvent) -> SseProgressEvent {
+    event.into()
+}
+
+fn save_image_to_dir(
+    dir: &std::path::Path,
+    img: &mold_core::ImageData,
+    model: &str,
+    batch_size: u32,
+) {
+    if let Err(e) = std::fs::create_dir_all(dir) {
+        tracing::warn!("failed to create output dir {}: {e}", dir.display());
+        return;
+    }
+    let timestamp_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64;
+    let ext = img.format.to_string();
+    let filename =
+        mold_core::default_output_filename(model, timestamp_ms, &ext, batch_size, img.index);
+    let path = dir.join(&filename);
+    match std::fs::write(&path, &img.data) {
+        Ok(()) => tracing::info!("saved image to {}", path.display()),
+        Err(e) => tracing::warn!("failed to save image to {}: {e}", path.display()),
+    }
+}
+
+fn process_job(worker: &GpuWorker, job: GpuJob) {
+    let model_name = job.model.clone();
+    let ordinal = worker.gpu.ordinal;
+
+    // Acquire per-GPU load lock — ensures only one model load at a time per GPU.
+    let _load_lock = worker.model_load_lock.lock().unwrap();
+
+    // Ensure model is loaded on this GPU.
+    if let Err(e) = ensure_model_ready_sync(worker, &model_name, &job) {
+        tracing::error!(gpu = ordinal, model = %model_name, "Failed to load model: {e}");
+        let err_msg = format!("model load error: {}", clean_error_message(&e));
+        if let Some(ref tx) = job.progress_tx {
+            let _ = tx.send(SseMessage::Error(SseErrorEvent {
+                message: err_msg.clone(),
+            }));
+        }
+        let _ = job.result_tx.send(Err(err_msg));
+        worker.in_flight.fetch_sub(1, Ordering::SeqCst);
+        record_failure(worker);
+        return;
+    }
+
+    // Set active generation state.
+    {
+        let mut gen = worker.active_generation.write().unwrap();
+        *gen = Some(ActiveGeneration {
+            model: model_name.clone(),
+            started_at: Instant::now(),
+        });
+    }
+
+    // Take-and-restore: remove engine from cache, release lock during inference.
+    let taken = {
+        let mut cache = worker.model_cache.lock().unwrap();
+        cache.take(&model_name)
+    };
+
+    let Some(mut cached_engine) = taken else {
+        let err_msg = "engine not found in cache after load".to_string();
+        if let Some(ref tx) = job.progress_tx {
+            let _ = tx.send(SseMessage::Error(SseErrorEvent {
+                message: err_msg.clone(),
+            }));
+        }
+        let _ = job.result_tx.send(Err(err_msg));
+        worker.in_flight.fetch_sub(1, Ordering::SeqCst);
+        clear_active_generation(worker);
+        return;
+    };
+
+    // Set progress callback if SSE streaming.
+    if let Some(ref progress_tx) = job.progress_tx {
+        let tx = progress_tx.clone();
+        cached_engine
+            .engine
+            .set_on_progress(Box::new(move |event| {
+                let _ = tx.send(SseMessage::Progress(progress_to_sse(event)));
+            }));
+    }
+
+    // Run inference — cache mutex is FREE during this.
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        cached_engine.engine.generate(&job.request)
+    }));
+
+    // Clear progress callback.
+    cached_engine.engine.clear_on_progress();
+
+    // Restore engine to cache.
+    {
+        let mut cache = worker.model_cache.lock().unwrap();
+        cache.restore(cached_engine);
+    }
+
+    // Clear active generation.
+    clear_active_generation(worker);
+
+    // Decrement in-flight.
+    worker.in_flight.fetch_sub(1, Ordering::SeqCst);
+
+    match result {
+        Ok(Ok(mut response)) => {
+            // Reset failure counter on success.
+            worker.consecutive_failures.store(0, Ordering::SeqCst);
+
+            // Attach GPU ordinal to response.
+            response.gpu = Some(ordinal);
+
+            if response.images.is_empty() && response.video.is_none() {
+                let err_msg = "generation error: engine returned no images or video".to_string();
+                if let Some(ref tx) = job.progress_tx {
+                    let _ = tx.send(SseMessage::Error(SseErrorEvent {
+                        message: err_msg.clone(),
+                    }));
+                }
+                let _ = job.result_tx.send(Err(err_msg));
+                return;
+            }
+
+            // Extract the primary image (or video thumbnail).
+            let img = if !response.images.is_empty() {
+                response.images.remove(0)
+            } else if let Some(ref video) = response.video {
+                ImageData {
+                    data: video.thumbnail.clone(),
+                    format: OutputFormat::Png,
+                    width: video.width,
+                    height: video.height,
+                    index: 0,
+                }
+            } else {
+                unreachable!("checked above");
+            };
+
+            // Save to output directory if configured.
+            if let Some(ref dir) = job.output_dir {
+                if let Some(ref video) = response.video {
+                    let ext = video.format.extension().to_string();
+                    let ts = SystemTime::now()
+                        .duration_since(UNIX_EPOCH)
+                        .map(|d| d.as_millis() as u64)
+                        .unwrap_or(0);
+                    let filename =
+                        mold_core::default_output_filename(&job.model, ts, &ext, 1, 0);
+                    let path = dir.join(filename);
+                    if let Err(e) = std::fs::write(&path, &video.data) {
+                        tracing::error!("failed to save video to {}: {e}", path.display());
+                    }
+                } else {
+                    save_image_to_dir(dir, &img, &job.model, job.request.batch_size);
+                }
+            }
+
+            // Send SSE complete event.
+            if let Some(ref tx) = job.progress_tx {
+                let _ = tx.send(SseMessage::Complete(SseCompleteEvent {
+                    image: base64::engine::general_purpose::STANDARD.encode(&img.data),
+                    format: img.format,
+                    width: img.width,
+                    height: img.height,
+                    seed_used: response.seed_used,
+                    generation_time_ms: response.generation_time_ms,
+                    model: response.model.clone(),
+                }));
+            }
+
+            // Send result through oneshot.
+            let _ = job.result_tx.send(Ok(GenerationJobResult {
+                image: img,
+                response,
+            }));
+        }
+        Ok(Err(e)) => {
+            tracing::warn!(gpu = ordinal, model = %model_name, "Generation failed: {e}");
+            record_failure(worker);
+            let err_msg = format!("generation error: {}", clean_error_message(&e));
+            if let Some(ref tx) = job.progress_tx {
+                let _ = tx.send(SseMessage::Error(SseErrorEvent {
+                    message: err_msg.clone(),
+                }));
+            }
+            let _ = job.result_tx.send(Err(err_msg));
+        }
+        Err(panic_payload) => {
+            tracing::error!(gpu = ordinal, model = %model_name, "Inference panicked");
+            record_failure(worker);
+            let msg = panic_payload
+                .downcast_ref::<String>()
+                .map(|s| s.as_str())
+                .or_else(|| panic_payload.downcast_ref::<&str>().copied())
+                .unwrap_or("unknown panic");
+            let err_msg = format!("inference panicked: {msg}");
+            if let Some(ref tx) = job.progress_tx {
+                let _ = tx.send(SseMessage::Error(SseErrorEvent {
+                    message: err_msg.clone(),
+                }));
+            }
+            let _ = job.result_tx.send(Err(err_msg));
+        }
+    }
+}
+
+fn ensure_model_ready_sync(
+    worker: &GpuWorker,
+    model_name: &str,
+    job: &GpuJob,
+) -> anyhow::Result<()> {
+    let cache = worker.model_cache.lock().unwrap();
+
+    // Already loaded?
+    if let Some(entry) = cache.get(model_name) {
+        if entry.residency == ModelResidency::Gpu {
+            return Ok(());
+        }
+    }
+
+    // Check if we have it cached but not on GPU (Parked/Unloaded).
+    let has_cached = cache.contains(model_name);
+    drop(cache);
+
+    if has_cached {
+        // Unload active model first.
+        {
+            let mut cache = worker.model_cache.lock().unwrap();
+            cache.unload_active();
+        }
+        device::reclaim_gpu_memory(worker.gpu.ordinal);
+
+        // Take the engine out and reload it.
+        let mut engine = {
+            let mut cache = worker.model_cache.lock().unwrap();
+            cache
+                .remove(model_name)
+                .ok_or_else(|| anyhow::anyhow!("cache race: model '{model_name}' vanished"))?
+        };
+
+        tracing::info!(
+            gpu = worker.gpu.ordinal,
+            model = %model_name,
+            "reloading cached engine..."
+        );
+        engine.load()?;
+
+        let vram = device::vram_used_estimate(worker.gpu.ordinal);
+        let mut cache = worker.model_cache.lock().unwrap();
+        cache.insert_loaded(model_name.to_string(), engine, vram);
+        return Ok(());
+    }
+
+    // Not in cache — need to create from scratch.
+    // Unload active model first.
+    {
+        let mut cache = worker.model_cache.lock().unwrap();
+        cache.unload_active();
+    }
+    device::reclaim_gpu_memory(worker.gpu.ordinal);
+
+    // Resolve model paths.
+    let config = job.config.blocking_read();
+    let paths = ModelPaths::resolve(model_name, &config).ok_or_else(|| {
+        anyhow::anyhow!(
+            "model '{model_name}' is not downloaded. Run: mold pull {model_name}"
+        )
+    })?;
+
+    let offload = std::env::var("MOLD_OFFLOAD").is_ok_and(|v| v == "1");
+    let mut engine = mold_inference::create_engine_with_pool(
+        model_name.to_string(),
+        paths,
+        &config,
+        mold_inference::LoadStrategy::Eager,
+        worker.gpu.ordinal,
+        offload,
+        Some(worker.shared_pool.clone()),
+    )?;
+    drop(config);
+
+    tracing::info!(
+        gpu = worker.gpu.ordinal,
+        model = %model_name,
+        "loading model..."
+    );
+    engine.load()?;
+
+    let vram = device::vram_used_estimate(worker.gpu.ordinal);
+    let mut cache = worker.model_cache.lock().unwrap();
+    cache.insert_loaded(model_name.to_string(), engine, vram);
+
+    Ok(())
+}
+
+fn record_failure(worker: &GpuWorker) {
+    let failures = worker
+        .consecutive_failures
+        .fetch_add(1, Ordering::SeqCst)
+        + 1;
+    if failures >= 3 {
+        let mut degraded = worker.degraded_until.write().unwrap();
+        *degraded = Some(Instant::now() + Duration::from_secs(60));
+        tracing::warn!(
+            gpu = worker.gpu.ordinal,
+            "GPU marked degraded after {failures} consecutive failures (60s cooldown)"
+        );
+    }
+}
+
+fn clear_active_generation(worker: &GpuWorker) {
+    let mut gen = worker.active_generation.write().unwrap();
+    *gen = None;
+}

--- a/crates/mold-server/src/lib.rs
+++ b/crates/mold-server/src/lib.rs
@@ -184,9 +184,14 @@ pub async fn run_server(
     }
 
     // Spawn the generation queue worker — processes jobs sequentially (single GPU).
-    // TODO: Task 6 will replace this with the multi-GPU queue dispatcher.
+    // Spawn queue worker: use multi-GPU dispatcher if GPUs are available,
+    // otherwise fall back to the single-threaded queue worker.
     let worker_state = state.clone();
-    tokio::spawn(queue::run_queue_worker(job_rx, worker_state));
+    if gpu_pool.worker_count() > 0 {
+        tokio::spawn(queue::run_queue_dispatcher(job_rx, worker_state));
+    } else {
+        tokio::spawn(queue::run_queue_worker(job_rx, worker_state));
+    }
 
     // Ensure output directory exists and pre-generate thumbnails.
     {

--- a/crates/mold-server/src/lib.rs
+++ b/crates/mold-server/src/lib.rs
@@ -1,4 +1,6 @@
 pub mod auth;
+pub mod gpu_pool;
+pub mod gpu_worker;
 pub mod logging;
 #[cfg(feature = "metrics")]
 pub mod metrics;
@@ -18,6 +20,7 @@ mod routes_test;
 
 use anyhow::Result;
 use axum::{extract::DefaultBodyLimit, middleware};
+use mold_core::types::GpuSelection;
 use mold_core::{Config, ModelPaths};
 use std::net::SocketAddr;
 use std::path::PathBuf;
@@ -30,7 +33,14 @@ use state::QueueHandle;
 
 const MAX_REQUEST_BODY_BYTES: usize = 64 * 1024 * 1024;
 
-pub async fn run_server(bind: &str, port: u16, models_dir: PathBuf) -> Result<()> {
+pub async fn run_server(
+    bind: &str,
+    port: u16,
+    models_dir: PathBuf,
+    gpu_selection: GpuSelection,
+    queue_size: usize,
+) -> Result<()> {
+    let _ = (&gpu_selection, queue_size); // TODO: wire into GpuPool (Task 4-5)
     Config::install_runtime_models_dir_override(models_dir.clone());
 
     let mut config = Config::load_or_default();
@@ -84,6 +94,7 @@ pub async fn run_server(bind: &str, port: u16, models_dir: PathBuf) -> Result<()
                 paths,
                 &config,
                 mold_inference::LoadStrategy::Eager,
+                0,
                 offload,
                 Some(shared_pool.clone()),
             )?;

--- a/crates/mold-server/src/lib.rs
+++ b/crates/mold-server/src/lib.rs
@@ -66,8 +66,14 @@ pub async fn run_server(
     let mut workers = Vec::new();
     let mut _gpu_thread_handles = Vec::new();
 
+    // Per-worker channel is a tiny buffer: one in-flight plus one immediate
+    // handoff. The global queue cap is enforced by `QueueHandle` against
+    // `queue_size`; per-worker overflow triggers the dispatcher's cross-worker
+    // retry path in `run_queue_dispatcher`.
+    const PER_WORKER_CHANNEL_SIZE: usize = 2;
+
     for gpu in &selected {
-        let (job_tx, job_rx) = std::sync::mpsc::sync_channel(queue_size);
+        let (job_tx, job_rx) = std::sync::mpsc::sync_channel(PER_WORKER_CHANNEL_SIZE);
         let worker = std::sync::Arc::new(gpu_pool::GpuWorker {
             gpu: gpu.clone(),
             model_cache: std::sync::Arc::new(std::sync::Mutex::new(model_cache::ModelCache::new(

--- a/crates/mold-server/src/lib.rs
+++ b/crates/mold-server/src/lib.rs
@@ -24,6 +24,7 @@ use mold_core::types::GpuSelection;
 use mold_core::{Config, ModelPaths};
 use std::net::SocketAddr;
 use std::path::PathBuf;
+use std::sync::atomic::AtomicUsize;
 use tokio::net::TcpListener;
 use tower_http::cors::CorsLayer;
 use tower_http::trace::TraceLayer;
@@ -40,17 +41,73 @@ pub async fn run_server(
     gpu_selection: GpuSelection,
     queue_size: usize,
 ) -> Result<()> {
-    let _ = (&gpu_selection, queue_size); // TODO: wire into GpuPool (Task 4-5)
     Config::install_runtime_models_dir_override(models_dir.clone());
 
     let mut config = Config::load_or_default();
     config.models_dir = models_dir.to_string_lossy().into_owned();
     let model_name = config.resolved_default_model();
 
-    // Create the generation queue channel (bounded, 16 slots).
+    // ── Discover and initialize GPU workers ────────────────────────────────
+    let shared_pool = std::sync::Arc::new(std::sync::Mutex::new(
+        mold_inference::shared_pool::SharedPool::new(),
+    ));
+
+    let discovered = mold_inference::device::discover_gpus();
+    let selected = mold_inference::device::filter_gpus(&discovered, &gpu_selection);
+
+    if selected.is_empty() && !discovered.is_empty() {
+        anyhow::bail!(
+            "No GPUs matched selection {:?} (discovered: {:?})",
+            gpu_selection,
+            discovered.iter().map(|g| g.ordinal).collect::<Vec<_>>()
+        );
+    }
+
+    let mut workers = Vec::new();
+    let mut _gpu_thread_handles = Vec::new();
+
+    for gpu in &selected {
+        let (job_tx, job_rx) = std::sync::mpsc::sync_channel(queue_size);
+        let worker = std::sync::Arc::new(gpu_pool::GpuWorker {
+            gpu: gpu.clone(),
+            model_cache: std::sync::Arc::new(std::sync::Mutex::new(
+                model_cache::ModelCache::new(3),
+            )),
+            active_generation: std::sync::Arc::new(std::sync::RwLock::new(None)),
+            model_load_lock: std::sync::Arc::new(std::sync::Mutex::new(())),
+            shared_pool: shared_pool.clone(),
+            in_flight: AtomicUsize::new(0),
+            consecutive_failures: AtomicUsize::new(0),
+            degraded_until: std::sync::RwLock::new(None),
+            job_tx,
+        });
+
+        let handle = gpu_worker::spawn_gpu_thread(worker.clone(), job_rx);
+        _gpu_thread_handles.push(handle);
+        workers.push(worker);
+    }
+
+    let gpu_pool = std::sync::Arc::new(gpu_pool::GpuPool { workers });
+
+    // Log discovered GPUs.
+    for status in gpu_pool.gpu_status() {
+        info!(
+            gpu = status.ordinal,
+            name = %status.name,
+            vram_mb = status.vram_total_bytes / 1_000_000,
+            "GPU worker ready"
+        );
+    }
+
+    if selected.is_empty() {
+        info!("no GPUs discovered — server will operate in CPU/pull-only mode");
+    }
+
+    // ── Create generation queue ────────────────────────────────────────────
     let (job_tx, job_rx) = tokio::sync::mpsc::channel(16);
     let queue_handle = QueueHandle::new(job_tx);
 
+    // ── Create AppState ────────────────────────────────────────────────────
     let mut state = match ModelPaths::resolve(&model_name, &config) {
         Some(paths) => {
             info!(model = %model_name, "configured model");
@@ -85,10 +142,6 @@ pub async fn run_server(
             }
 
             let offload = std::env::var("MOLD_OFFLOAD").is_ok_and(|v| v == "1");
-            // Create shared pool before engine so the first engine can populate it.
-            let shared_pool = std::sync::Arc::new(std::sync::Mutex::new(
-                mold_inference::shared_pool::SharedPool::new(),
-            ));
             let engine = mold_inference::create_engine_with_pool(
                 model_name,
                 paths,
@@ -98,13 +151,19 @@ pub async fn run_server(
                 offload,
                 Some(shared_pool.clone()),
             )?;
-            let mut state = state::AppState::new(engine, config, queue_handle);
+            let mut state = state::AppState::new(
+                engine,
+                config,
+                queue_handle,
+                gpu_pool.clone(),
+                queue_size,
+            );
             state.shared_pool = shared_pool;
             state
         }
         None => {
             info!("no default model configured — models will be pulled on first request");
-            state::AppState::empty(config, queue_handle)
+            state::AppState::empty(config, queue_handle, gpu_pool.clone(), queue_size)
         }
     };
 
@@ -125,6 +184,7 @@ pub async fn run_server(
     }
 
     // Spawn the generation queue worker — processes jobs sequentially (single GPU).
+    // TODO: Task 6 will replace this with the multi-GPU queue dispatcher.
     let worker_state = state.clone();
     tokio::spawn(queue::run_queue_worker(job_rx, worker_state));
 

--- a/crates/mold-server/src/lib.rs
+++ b/crates/mold-server/src/lib.rs
@@ -70,9 +70,9 @@ pub async fn run_server(
         let (job_tx, job_rx) = std::sync::mpsc::sync_channel(queue_size);
         let worker = std::sync::Arc::new(gpu_pool::GpuWorker {
             gpu: gpu.clone(),
-            model_cache: std::sync::Arc::new(std::sync::Mutex::new(
-                model_cache::ModelCache::new(3),
-            )),
+            model_cache: std::sync::Arc::new(std::sync::Mutex::new(model_cache::ModelCache::new(
+                3,
+            ))),
             active_generation: std::sync::Arc::new(std::sync::RwLock::new(None)),
             model_load_lock: std::sync::Arc::new(std::sync::Mutex::new(())),
             shared_pool: shared_pool.clone(),
@@ -151,13 +151,8 @@ pub async fn run_server(
                 offload,
                 Some(shared_pool.clone()),
             )?;
-            let mut state = state::AppState::new(
-                engine,
-                config,
-                queue_handle,
-                gpu_pool.clone(),
-                queue_size,
-            );
+            let mut state =
+                state::AppState::new(engine, config, queue_handle, gpu_pool.clone(), queue_size);
             state.shared_pool = shared_pool;
             state
         }

--- a/crates/mold-server/src/main.rs
+++ b/crates/mold-server/src/main.rs
@@ -66,7 +66,9 @@ async fn main() -> anyhow::Result<()> {
                 .map(PathBuf::from)
                 .unwrap_or_else(|| PathBuf::from("."));
 
-            mold_server::run_server(&bind, port, models_path).await?;
+            let gpu_selection = config.gpu_selection();
+            let queue_size = config.queue_size();
+            mold_server::run_server(&bind, port, models_path, gpu_selection, queue_size).await?;
         }
     }
 

--- a/crates/mold-server/src/metrics.rs
+++ b/crates/mold-server/src/metrics.rs
@@ -74,7 +74,7 @@ pub async fn metrics_endpoint(
 ) -> impl IntoResponse {
     // Update point-in-time gauges right before rendering.
     record_uptime(state.start_time.elapsed().as_secs_f64());
-    record_gpu_memory(mold_inference::device::vram_used_estimate());
+    record_gpu_memory(mold_inference::device::vram_used_estimate(0));
 
     let body = state.handle.render();
     (

--- a/crates/mold-server/src/metrics_test.rs
+++ b/crates/mold-server/src/metrics_test.rs
@@ -21,7 +21,10 @@ mod tests {
 
         let (tx, _rx) = tokio::sync::mpsc::channel(16);
         let queue = crate::state::QueueHandle::new(tx);
-        let state = AppState::empty(mold_core::Config::default(), queue);
+        let gpu_pool = std::sync::Arc::new(crate::gpu_pool::GpuPool {
+            workers: Vec::new(),
+        });
+        let state = AppState::empty(mold_core::Config::default(), queue, gpu_pool, 200);
 
         let start_time = state.start_time;
         let metrics_state = MetricsState { handle, start_time };

--- a/crates/mold-server/src/model_cache.rs
+++ b/crates/mold-server/src/model_cache.rs
@@ -82,6 +82,11 @@ impl ModelCache {
         evicted
     }
 
+    /// Get a reference to a cached engine entry (does not update LRU order).
+    pub fn get(&self, model_name: &str) -> Option<&CachedEngine> {
+        self.entries.get(model_name)
+    }
+
     /// Get a mutable reference to the engine for a model, if cached.
     pub fn get_mut(&mut self, model_name: &str) -> Option<&mut CachedEngine> {
         if self.entries.contains_key(model_name) {
@@ -90,6 +95,52 @@ impl ModelCache {
         } else {
             None
         }
+    }
+
+    /// Remove an engine from the cache, returning the full entry.
+    /// Used by the take-and-restore pattern: remove before inference, re-insert after.
+    pub fn take(&mut self, model_name: &str) -> Option<CachedEngine> {
+        self.lru_order.retain(|n| n != model_name);
+        self.entries.remove(model_name)
+    }
+
+    /// Re-insert a taken engine after inference completes.
+    pub fn restore(&mut self, cached: CachedEngine) {
+        let name = cached.model_name.clone();
+        self.lru_order.push(name.clone());
+        self.entries.insert(name, cached);
+    }
+
+    /// Insert a loaded engine with a known VRAM footprint.
+    /// Unlike `insert()`, this takes a name separately from the engine.
+    pub fn insert_loaded(
+        &mut self,
+        model_name: String,
+        engine: Box<dyn InferenceEngine>,
+        vram_bytes: u64,
+    ) -> Option<Box<dyn InferenceEngine>> {
+        let mut evicted = None;
+
+        // Evict LRU if at capacity (skip if the model is already in cache)
+        if self.entries.len() >= self.max_cached && !self.entries.contains_key(&model_name) {
+            evicted = self.evict_lru();
+        }
+
+        let entry = CachedEngine {
+            model_name: model_name.clone(),
+            residency: if engine.is_loaded() {
+                ModelResidency::Gpu
+            } else {
+                ModelResidency::Unloaded
+            },
+            last_used: Instant::now(),
+            vram_bytes,
+            engine,
+        };
+
+        self.entries.insert(model_name.clone(), entry);
+        self.touch_order(&model_name);
+        evicted
     }
 
     /// Check if a model is in the cache.

--- a/crates/mold-server/src/model_manager.rs
+++ b/crates/mold-server/src/model_manager.rs
@@ -95,8 +95,7 @@ pub(crate) async fn list_models(state: &AppState) -> Vec<ModelInfoExtended> {
     if state.gpu_pool.worker_count() > 0 {
         let loaded_models = loaded_models_across_pool(state);
         let primary = loaded_models.first().cloned();
-        let mut catalog =
-            build_model_catalog(&config, primary.as_deref(), primary.is_some());
+        let mut catalog = build_model_catalog(&config, primary.as_deref(), primary.is_some());
         // Mark every GPU-resident model as loaded (not just the primary).
         for entry in catalog.iter_mut() {
             if loaded_models.contains(&entry.info.name) {

--- a/crates/mold-server/src/model_manager.rs
+++ b/crates/mold-server/src/model_manager.rs
@@ -395,6 +395,7 @@ async fn create_and_load_engine(
         paths,
         &config,
         mold_inference::LoadStrategy::Eager,
+        0,
         offload,
         Some(state.shared_pool.clone()),
     )

--- a/crates/mold-server/src/model_manager.rs
+++ b/crates/mold-server/src/model_manager.rs
@@ -204,7 +204,7 @@ pub(crate) async fn ensure_model_ready(
                     to = %model_name,
                     "unloaded active model to reload cached model"
                 );
-                mold_inference::reclaim_gpu_memory();
+                mold_inference::reclaim_gpu_memory(0);
             }
 
             // Take the engine out of cache to load in spawn_blocking.
@@ -245,10 +245,10 @@ pub(crate) async fn ensure_model_ready(
                         let duration = load_start.elapsed().as_secs_f64();
                         crate::metrics::record_model_load(model_name, duration);
                         crate::metrics::set_model_loaded(model_name);
-                        let vram_est = mold_inference::device::vram_used_estimate();
+                        let vram_est = mold_inference::device::vram_used_estimate(0);
                         crate::metrics::record_gpu_memory(vram_est);
                     }
-                    let vram = mold_inference::device::vram_used_estimate();
+                    let vram = mold_inference::device::vram_used_estimate(0);
                     let mut cache = state.model_cache.lock().await;
                     cache.insert(loaded_engine, vram);
                     update_snapshot(state, &cache).await;
@@ -343,7 +343,7 @@ pub(crate) async fn unload_model(state: &AppState) -> String {
             }
             update_snapshot(state, &cache).await;
             drop(cache);
-            mold_inference::reclaim_gpu_memory();
+            mold_inference::reclaim_gpu_memory(0);
             tracing::info!(model = %name, "model unloaded via API");
             format!("unloaded {name}")
         }
@@ -385,7 +385,7 @@ async fn create_and_load_engine(
         result.is_some()
     };
     if had_active {
-        mold_inference::reclaim_gpu_memory();
+        mold_inference::reclaim_gpu_memory(0);
     }
 
     let config = state.config.read().await;
@@ -430,7 +430,7 @@ async fn create_and_load_engine(
         crate::metrics::set_model_loaded(model_name);
     }
 
-    let vram = mold_inference::device::vram_used_estimate();
+    let vram = mold_inference::device::vram_used_estimate(0);
     #[cfg(feature = "metrics")]
     crate::metrics::record_gpu_memory(vram);
 

--- a/crates/mold-server/src/model_manager.rs
+++ b/crates/mold-server/src/model_manager.rs
@@ -88,10 +88,49 @@ pub(crate) async fn refresh_config(state: &AppState) -> mold_core::Config {
 }
 
 pub(crate) async fn list_models(state: &AppState) -> Vec<ModelInfoExtended> {
-    let snapshot = state.engine_snapshot.read().await.clone();
-
     let config = refresh_config(state).await;
+
+    // Multi-GPU mode: derive "loaded" state from the worker pool so /api/models
+    // reflects the actual engine cache, not the legacy single-GPU snapshot.
+    if state.gpu_pool.worker_count() > 0 {
+        let loaded_models = loaded_models_across_pool(state);
+        let primary = loaded_models.first().cloned();
+        let mut catalog =
+            build_model_catalog(&config, primary.as_deref(), primary.is_some());
+        // Mark every GPU-resident model as loaded (not just the primary).
+        for entry in catalog.iter_mut() {
+            if loaded_models.contains(&entry.info.name) {
+                entry.info.is_loaded = true;
+            }
+        }
+        return catalog;
+    }
+
+    let snapshot = state.engine_snapshot.read().await.clone();
     build_model_catalog(&config, snapshot.model_name.as_deref(), snapshot.is_loaded)
+}
+
+fn loaded_models_across_pool(state: &AppState) -> Vec<String> {
+    let mut names = Vec::new();
+    for worker in &state.gpu_pool.workers {
+        // Prefer the active-generation model (cache entry is taken out during
+        // inflight generation), else whatever is GPU-resident.
+        let active = worker
+            .active_generation
+            .read()
+            .ok()
+            .and_then(|g| g.as_ref().map(|g| g.model.clone()));
+        let loaded = active.or_else(|| {
+            let cache = worker.model_cache.lock().ok()?;
+            cache.active_model().map(|s| s.to_string())
+        });
+        if let Some(name) = loaded {
+            if !names.contains(&name) {
+                names.push(name);
+            }
+        }
+    }
+    names
 }
 
 /// Check whether a model is available — either already in the cache or

--- a/crates/mold-server/src/queue.rs
+++ b/crates/mold-server/src/queue.rs
@@ -496,68 +496,76 @@ pub async fn run_queue_dispatcher(
         #[cfg(feature = "metrics")]
         crate::metrics::record_queue_depth(state.queue.pending());
 
-        let model_name = &job.request.model;
+        let model_name = job.request.model.clone();
+        let estimated_vram = estimate_model_vram(&model_name);
 
-        // Estimate VRAM for placement — use a conservative default.
-        let estimated_vram = estimate_model_vram(model_name);
-
-        // Select worker via placement strategy.
-        let worker = match state.gpu_pool.select_worker(model_name, estimated_vram) {
-            Some(w) => w,
-            None => {
-                tracing::error!(model = %model_name, "No GPU available for model");
-                let err_msg = format!("no GPU available for model {model_name}");
-                if let Some(ref tx) = job.progress_tx {
-                    let _ = tx.send(SseMessage::Error(SseErrorEvent {
-                        message: err_msg.clone(),
-                    }));
-                }
-                let _ = job.result_tx.send(Err(err_msg));
-                state.queue.decrement();
-                continue;
-            }
-        };
-
-        // Increment in-flight BEFORE sending to worker (prevents TOCTOU race
-        // where burst loads all see the same stale state and route to the same GPU).
-        worker.in_flight.fetch_add(1, Ordering::SeqCst);
-
-        // Build GpuJob from the GenerationJob.
-        let gpu_job = GpuJob {
-            model: model_name.to_string(),
+        // Build the GpuJob once; the retry loop moves it between attempts.
+        let mut gpu_job = Some(GpuJob {
+            model: model_name.clone(),
             request: job.request,
             progress_tx: job.progress_tx,
             result_tx: job.result_tx,
             output_dir: job.output_dir,
             config: state.config.clone(),
-        };
+            queue: state.queue.clone(),
+        });
 
-        // Dispatch to worker's dedicated thread.
-        if let Err(e) = worker.job_tx.try_send(gpu_job) {
-            worker.in_flight.fetch_sub(1, Ordering::SeqCst);
-            tracing::warn!(
-                gpu = worker.gpu.ordinal,
-                "GPU worker channel full — rejecting with queue_full"
-            );
-            // Recover the rejected GpuJob so we can notify the client properly
-            // instead of silently dropping `result_tx` (which surfaced as a
-            // misleading 500 INTERNAL_ERROR on the client).
-            let rejected = match e {
-                std::sync::mpsc::TrySendError::Full(j) | std::sync::mpsc::TrySendError::Disconnected(j) => j,
+        let mut skip: Vec<usize> = Vec::new();
+        let max_attempts = state.gpu_pool.worker_count().max(1);
+        let mut dispatched = false;
+
+        for _ in 0..max_attempts {
+            let worker = match state
+                .gpu_pool
+                .select_worker_excluding(&model_name, estimated_vram, &skip)
+            {
+                Some(w) => w,
+                None => break,
             };
-            let err_msg = format!(
-                "GPU {} worker queue is full — try again shortly",
-                worker.gpu.ordinal,
-            );
+
+            // Increment in-flight BEFORE sending to reserve the slot.
+            worker.in_flight.fetch_add(1, Ordering::SeqCst);
+            let pending = gpu_job.take().expect("gpu_job present in retry loop");
+            match worker.job_tx.try_send(pending) {
+                Ok(()) => {
+                    dispatched = true;
+                    break;
+                }
+                Err(std::sync::mpsc::TrySendError::Full(j))
+                | Err(std::sync::mpsc::TrySendError::Disconnected(j)) => {
+                    worker.in_flight.fetch_sub(1, Ordering::SeqCst);
+                    tracing::warn!(
+                        gpu = worker.gpu.ordinal,
+                        "GPU worker channel full — retrying on another worker"
+                    );
+                    skip.push(worker.gpu.ordinal);
+                    gpu_job = Some(j);
+                }
+            }
+        }
+
+        if !dispatched {
+            // Either no workers are eligible or every candidate's channel is full.
+            let rejected = gpu_job.expect("gpu_job retained after failed dispatch");
+            let err_msg = if state.gpu_pool.worker_count() == 0 {
+                format!("no GPU available for model {model_name}")
+            } else {
+                format!(
+                    "all GPU workers are busy for model {model_name} — queue is full"
+                )
+            };
+            tracing::error!(model = %model_name, "{err_msg}");
             if let Some(tx) = rejected.progress_tx {
                 let _ = tx.send(SseMessage::Error(SseErrorEvent {
                     message: err_msg.clone(),
                 }));
             }
             let _ = rejected.result_tx.send(Err(err_msg));
+            // Job was rejected before the worker could observe it, so we must
+            // release the global queue slot here — the worker-side decrement
+            // won't run.
+            state.queue.decrement();
         }
-
-        state.queue.decrement();
         #[cfg(feature = "metrics")]
         crate::metrics::record_queue_depth(state.queue.pending());
     }
@@ -565,7 +573,7 @@ pub async fn run_queue_dispatcher(
 }
 
 /// Rough VRAM estimate for a model (used for placement decisions).
-fn estimate_model_vram(model_name: &str) -> u64 {
+pub fn estimate_model_vram(model_name: &str) -> u64 {
     // Use a simple heuristic based on model name patterns.
     // Quantized models are smaller; BF16/FP16 are larger.
     let lower = model_name.to_lowercase();

--- a/crates/mold-server/src/queue.rs
+++ b/crates/mold-server/src/queue.rs
@@ -561,9 +561,8 @@ fn estimate_model_vram(model_name: &str) -> u64 {
         24_000_000_000 // ~24GB
     } else if lower.contains("sd15") || lower.contains("sd1.5") {
         4_000_000_000 // ~4GB
-    } else if lower.contains("sdxl") {
-        8_000_000_000 // ~8GB
     } else {
-        8_000_000_000 // 8GB default fallback
+        // SDXL (~8GB) and other models default to 8GB.
+        8_000_000_000
     }
 }

--- a/crates/mold-server/src/queue.rs
+++ b/crates/mold-server/src/queue.rs
@@ -399,6 +399,7 @@ async fn process_job(state: &AppState, job: GenerationJob) {
                         video_duration_ms: video.duration_ms,
                         video_audio_sample_rate: video.audio_sample_rate,
                         video_audio_channels: video.audio_channels,
+                        gpu: response.gpu,
                     }
                 } else {
                     // Image response: same as before
@@ -418,6 +419,7 @@ async fn process_job(state: &AppState, job: GenerationJob) {
                         video_duration_ms: None,
                         video_audio_sample_rate: None,
                         video_audio_channels: None,
+                        gpu: response.gpu,
                     }
                 };
                 let _ = tx.send(SseMessage::Complete(event));

--- a/crates/mold-server/src/queue.rs
+++ b/crates/mold-server/src/queue.rs
@@ -533,14 +533,28 @@ pub async fn run_queue_dispatcher(
         };
 
         // Dispatch to worker's dedicated thread.
-        if worker.job_tx.try_send(gpu_job).is_err() {
+        if let Err(e) = worker.job_tx.try_send(gpu_job) {
             worker.in_flight.fetch_sub(1, Ordering::SeqCst);
             tracing::warn!(
                 gpu = worker.gpu.ordinal,
-                "GPU worker channel full — job dropped"
+                "GPU worker channel full — rejecting with queue_full"
             );
-            // The result_tx was moved into gpu_job and is now lost.
-            // This shouldn't happen if queue_size is configured properly.
+            // Recover the rejected GpuJob so we can notify the client properly
+            // instead of silently dropping `result_tx` (which surfaced as a
+            // misleading 500 INTERNAL_ERROR on the client).
+            let rejected = match e {
+                std::sync::mpsc::TrySendError::Full(j) | std::sync::mpsc::TrySendError::Disconnected(j) => j,
+            };
+            let err_msg = format!(
+                "GPU {} worker queue is full — try again shortly",
+                worker.gpu.ordinal,
+            );
+            if let Some(tx) = rejected.progress_tx {
+                let _ = tx.send(SseMessage::Error(SseErrorEvent {
+                    message: err_msg.clone(),
+                }));
+            }
+            let _ = rejected.result_tx.send(Err(err_msg));
         }
 
         state.queue.decrement();

--- a/crates/mold-server/src/queue.rs
+++ b/crates/mold-server/src/queue.rs
@@ -6,8 +6,10 @@ use mold_core::{
 };
 use mold_db::{GenerationRecord, MetadataDb, RecordSource};
 use sha2::{Digest, Sha256};
+use std::sync::atomic::Ordering;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
+use crate::gpu_pool::GpuJob;
 use crate::model_manager;
 use crate::state::{
     ActiveGenerationSnapshot, AppState, GenerationJob, GenerationJobResult, SseMessage,
@@ -474,5 +476,94 @@ async fn process_job(state: &AppState, job: GenerationJob) {
             }
             let _ = job.result_tx.send(Err(err_msg));
         }
+    }
+}
+
+// ── Multi-GPU queue dispatcher ──────────────────────────────────────────────
+
+/// Runs the multi-GPU dispatch loop. Routes each generation job to the best
+/// GPU worker based on the placement strategy (model-loaded > idle > evict LRU).
+///
+/// Exits when the sender half of the channel is dropped (server shutdown).
+pub async fn run_queue_dispatcher(
+    mut job_rx: tokio::sync::mpsc::Receiver<GenerationJob>,
+    state: AppState,
+) {
+    tracing::debug!("multi-GPU queue dispatcher started");
+    while let Some(job) = job_rx.recv().await {
+        #[cfg(feature = "metrics")]
+        crate::metrics::record_queue_depth(state.queue.pending());
+
+        let model_name = &job.request.model;
+
+        // Estimate VRAM for placement — use a conservative default.
+        let estimated_vram = estimate_model_vram(model_name);
+
+        // Select worker via placement strategy.
+        let worker = match state.gpu_pool.select_worker(model_name, estimated_vram) {
+            Some(w) => w,
+            None => {
+                tracing::error!(model = %model_name, "No GPU available for model");
+                let err_msg = format!("no GPU available for model {model_name}");
+                if let Some(ref tx) = job.progress_tx {
+                    let _ = tx.send(SseMessage::Error(SseErrorEvent {
+                        message: err_msg.clone(),
+                    }));
+                }
+                let _ = job.result_tx.send(Err(err_msg));
+                state.queue.decrement();
+                continue;
+            }
+        };
+
+        // Increment in-flight BEFORE sending to worker (prevents TOCTOU race
+        // where burst loads all see the same stale state and route to the same GPU).
+        worker.in_flight.fetch_add(1, Ordering::SeqCst);
+
+        // Build GpuJob from the GenerationJob.
+        let gpu_job = GpuJob {
+            model: model_name.to_string(),
+            request: job.request,
+            progress_tx: job.progress_tx,
+            result_tx: job.result_tx,
+            output_dir: job.output_dir,
+            config: state.config.clone(),
+        };
+
+        // Dispatch to worker's dedicated thread.
+        if worker.job_tx.try_send(gpu_job).is_err() {
+            worker.in_flight.fetch_sub(1, Ordering::SeqCst);
+            tracing::warn!(
+                gpu = worker.gpu.ordinal,
+                "GPU worker channel full — job dropped"
+            );
+            // The result_tx was moved into gpu_job and is now lost.
+            // This shouldn't happen if queue_size is configured properly.
+        }
+
+        state.queue.decrement();
+        #[cfg(feature = "metrics")]
+        crate::metrics::record_queue_depth(state.queue.pending());
+    }
+    tracing::info!("multi-GPU queue dispatcher shutting down");
+}
+
+/// Rough VRAM estimate for a model (used for placement decisions).
+fn estimate_model_vram(model_name: &str) -> u64 {
+    // Use a simple heuristic based on model name patterns.
+    // Quantized models are smaller; BF16/FP16 are larger.
+    let lower = model_name.to_lowercase();
+    if lower.contains(":q4") {
+        6_000_000_000 // ~6GB
+    } else if lower.contains(":q8") || lower.contains(":fp8") {
+        12_000_000_000 // ~12GB
+    } else if lower.contains(":bf16") || lower.contains(":fp16") {
+        24_000_000_000 // ~24GB
+    } else if lower.contains("sd15") || lower.contains("sd1.5") {
+        4_000_000_000 // ~4GB
+    } else if lower.contains("sdxl") {
+        8_000_000_000 // ~8GB
+    } else {
+        8_000_000_000 // 8GB default fallback
     }
 }

--- a/crates/mold-server/src/queue.rs
+++ b/crates/mold-server/src/queue.rs
@@ -515,13 +515,14 @@ pub async fn run_queue_dispatcher(
         let mut dispatched = false;
 
         for _ in 0..max_attempts {
-            let worker = match state
-                .gpu_pool
-                .select_worker_excluding(&model_name, estimated_vram, &skip)
-            {
-                Some(w) => w,
-                None => break,
-            };
+            let worker =
+                match state
+                    .gpu_pool
+                    .select_worker_excluding(&model_name, estimated_vram, &skip)
+                {
+                    Some(w) => w,
+                    None => break,
+                };
 
             // Increment in-flight BEFORE sending to reserve the slot.
             worker.in_flight.fetch_add(1, Ordering::SeqCst);
@@ -550,9 +551,7 @@ pub async fn run_queue_dispatcher(
             let err_msg = if state.gpu_pool.worker_count() == 0 {
                 format!("no GPU available for model {model_name}")
             } else {
-                format!(
-                    "all GPU workers are busy for model {model_name} — queue is full"
-                )
+                format!("all GPU workers are busy for model {model_name} — queue is full")
             };
             tracing::error!(model = %model_name, "{err_msg}");
             if let Some(tx) = rejected.progress_tx {

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -1130,6 +1130,9 @@ async fn server_status(State(state): State<AppState>) -> Json<ServerStatus> {
         uptime_secs: state.start_time.elapsed().as_secs(),
         hostname: hostname::get().ok().and_then(|h| h.into_string().ok()),
         memory_status: mold_inference::device::memory_status_string(),
+        gpus: None,
+        queue_depth: None,
+        queue_capacity: None,
     })
 }
 

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -10,8 +10,8 @@ use axum::{
 };
 use base64::Engine as _;
 use mold_core::{
-    ActiveGenerationStatus, GpuInfo, ModelInfoExtended, ServerStatus, SseErrorEvent,
-    SseProgressEvent,
+    ActiveGenerationStatus, GpuInfo, GpuWorkerState, ModelInfoExtended, ServerStatus,
+    SseErrorEvent, SseProgressEvent,
 };
 use serde::{Deserialize, Serialize};
 use std::convert::Infallible;
@@ -87,6 +87,14 @@ impl ApiError {
             status: StatusCode::FORBIDDEN,
         }
     }
+
+    pub fn queue_full(msg: impl Into<String>) -> Self {
+        Self {
+            error: msg.into(),
+            code: "QUEUE_FULL".to_string(),
+            status: StatusCode::SERVICE_UNAVAILABLE,
+        }
+    }
 }
 
 impl IntoResponse for ApiError {
@@ -119,6 +127,7 @@ use crate::queue::clean_error_message;
         mold_core::SseErrorEvent,
         ModelInfoExtended,
         LoadModelBody,
+        UnloadRequest,
     )),
     tags(
         (name = "generation", description = "Image generation"),
@@ -225,6 +234,15 @@ async fn prepare_generation(
     state: &AppState,
     request: &mut mold_core::GenerateRequest,
 ) -> Result<(Option<std::path::PathBuf>, Option<String>), ApiError> {
+    // Reject early if the generation queue is at capacity.
+    if state.queue.pending() >= state.queue_capacity {
+        return Err(ApiError::queue_full(format!(
+            "generation queue is full ({}/{})",
+            state.queue.pending(),
+            state.queue_capacity,
+        )));
+    }
+
     apply_default_metadata_setting(state, request).await;
 
     // Expand prompt if requested (before validation, so the expanded prompt gets validated)
@@ -265,6 +283,7 @@ async fn prepare_generation(
         (status = 404, description = "Model not downloaded"),
         (status = 422, description = "Invalid request parameters"),
         (status = 500, description = "Inference error"),
+        (status = 503, description = "Generation queue full"),
     )
 )]
 // The server always produces 1 image per request; batch looping (--batch N)
@@ -805,6 +824,7 @@ async fn upscale_stream(
         (status = 404, description = "Model not downloaded"),
         (status = 422, description = "Invalid request parameters"),
         (status = 500, description = "Inference error"),
+        (status = 503, description = "Generation queue full"),
     )
 )]
 async fn generate_stream(
@@ -881,6 +901,10 @@ async fn list_models(State(state): State<AppState>) -> Json<Vec<ModelInfoExtende
 pub struct LoadModelBody {
     #[schema(example = "flux-schnell:q8")]
     pub model: String,
+    /// Target GPU ordinal (multi-GPU only). If omitted, the server uses its
+    /// default placement strategy.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gpu: Option<usize>,
 }
 
 #[utoipa::path(
@@ -899,8 +923,10 @@ async fn load_model(
     State(state): State<AppState>,
     Json(body): Json<LoadModelBody>,
 ) -> Result<impl IntoResponse, ApiError> {
+    // TODO: when GPU-targeted loading is wired through model_manager,
+    // pass body.gpu to route the load to a specific GPU worker.
     model_manager::ensure_model_ready(&state, &body.model, None).await?;
-    tracing::info!(model = %body.model, "model loaded via API");
+    tracing::info!(model = %body.model, gpu = ?body.gpu, "model loaded via API");
     Ok(StatusCode::OK)
 }
 
@@ -1070,15 +1096,35 @@ impl IntoResponse for PullResponse {
 
 // ── /api/models/unload ────────────────────────────────────────────────────────
 
+/// Optional request body for unload — clients may specify a model or GPU target.
+/// An empty body (or no body) unloads the active model on the legacy path.
+#[derive(Debug, Default, Deserialize, utoipa::ToSchema)]
+pub struct UnloadRequest {
+    /// Specific model to unload. If omitted, the active model is unloaded.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    /// Target GPU ordinal (multi-GPU only).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gpu: Option<usize>,
+}
+
 #[utoipa::path(
     delete,
     path = "/api/models/unload",
     tag = "models",
+    request_body(content = Option<UnloadRequest>, content_type = "application/json"),
     responses(
         (status = 200, description = "Model unloaded or no model was loaded", body = String),
     )
 )]
-async fn unload_model(State(state): State<AppState>) -> Result<impl IntoResponse, ApiError> {
+async fn unload_model(
+    State(state): State<AppState>,
+    body: Option<Json<UnloadRequest>>,
+) -> Result<impl IntoResponse, ApiError> {
+    let req = body.map(|b| b.0).unwrap_or_default();
+    // TODO: when GPU-targeted unloading is wired through model_manager,
+    // use req.model and req.gpu to target specific GPU workers.
+    tracing::debug!(model = ?req.model, gpu = ?req.gpu, "unload request");
     Ok((StatusCode::OK, model_manager::unload_model(&state).await))
 }
 
@@ -1093,23 +1139,42 @@ async fn unload_model(State(state): State<AppState>) -> Result<impl IntoResponse
     )
 )]
 async fn server_status(State(state): State<AppState>) -> Json<ServerStatus> {
-    let snapshot = state.engine_snapshot.read().await.clone();
-    let models_loaded = match (snapshot.model_name, snapshot.is_loaded) {
-        (Some(model_name), true) => vec![model_name],
-        _ => vec![],
+    // Aggregate GPU status from the pool.
+    let gpu_statuses = state.gpu_pool.gpu_status();
+    let has_gpus = !gpu_statuses.is_empty();
+
+    // Collect loaded models from GPU workers.
+    let gpu_models_loaded: Vec<String> = gpu_statuses
+        .iter()
+        .filter_map(|g| g.loaded_model.clone())
+        .collect();
+    let gpu_busy = gpu_statuses
+        .iter()
+        .any(|g| g.state == GpuWorkerState::Generating);
+
+    // Fall back to legacy single-GPU snapshot for backwards compat.
+    let (models_loaded, busy, current_generation) = if has_gpus {
+        (gpu_models_loaded, gpu_busy, None)
+    } else {
+        let snapshot = state.engine_snapshot.read().await.clone();
+        let models = match (snapshot.model_name, snapshot.is_loaded) {
+            (Some(model_name), true) => vec![model_name],
+            _ => vec![],
+        };
+        let gen = state
+            .active_generation
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .as_ref()
+            .map(|active| ActiveGenerationStatus {
+                model: active.model.clone(),
+                prompt_sha256: active.prompt_sha256.clone(),
+                started_at_unix_ms: active.started_at_unix_ms,
+                elapsed_ms: active.started_at.elapsed().as_millis() as u64,
+            });
+        let is_busy = gen.is_some();
+        (models, is_busy, gen)
     };
-    let current_generation = state
-        .active_generation
-        .read()
-        .unwrap_or_else(|e| e.into_inner())
-        .as_ref()
-        .map(|active| ActiveGenerationStatus {
-            model: active.model.clone(),
-            prompt_sha256: active.prompt_sha256.clone(),
-            started_at_unix_ms: active.started_at_unix_ms,
-            elapsed_ms: active.started_at.elapsed().as_millis() as u64,
-        });
-    let busy = current_generation.is_some();
 
     Json(ServerStatus {
         version: env!("CARGO_PKG_VERSION").to_string(),
@@ -1130,9 +1195,9 @@ async fn server_status(State(state): State<AppState>) -> Json<ServerStatus> {
         uptime_secs: state.start_time.elapsed().as_secs(),
         hostname: hostname::get().ok().and_then(|h| h.into_string().ok()),
         memory_status: mold_inference::device::memory_status_string(),
-        gpus: None,
-        queue_depth: None,
-        queue_capacity: None,
+        gpus: if has_gpus { Some(gpu_statuses) } else { None },
+        queue_depth: Some(state.queue.pending()),
+        queue_capacity: Some(state.queue_capacity),
     })
 }
 

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -410,7 +410,16 @@ async fn generate(
             };
             Ok((headers, output_data))
         }
-        Err(err_msg) => Err(ApiError::inference(err_msg)),
+        Err(err_msg) => {
+            // The multi-GPU dispatcher sends a queue-full error through result_tx
+            // when a per-worker channel is saturated; surface that as a proper 503
+            // instead of the generic INFERENCE_ERROR 500.
+            if err_msg.contains("queue is full") {
+                Err(ApiError::queue_full(err_msg))
+            } else {
+                Err(ApiError::inference(err_msg))
+            }
+        }
     }
 }
 

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -958,10 +958,52 @@ async fn load_model(
     State(state): State<AppState>,
     Json(body): Json<LoadModelBody>,
 ) -> Result<impl IntoResponse, ApiError> {
-    // TODO: when GPU-targeted loading is wired through model_manager,
-    // pass body.gpu to route the load to a specific GPU worker.
+    // Multi-GPU path: route through the pool.
+    if state.gpu_pool.worker_count() > 0 {
+        let worker = match body.gpu {
+            Some(ordinal) => state
+                .gpu_pool
+                .workers
+                .iter()
+                .find(|w| w.gpu.ordinal == ordinal)
+                .cloned()
+                .ok_or_else(|| {
+                    ApiError::not_found(format!("no GPU worker with ordinal {ordinal}"))
+                })?,
+            None => {
+                let est = crate::queue::estimate_model_vram(&body.model);
+                state
+                    .gpu_pool
+                    .select_worker(&body.model, est)
+                    .ok_or_else(|| {
+                        ApiError::internal(format!(
+                            "no GPU available to load model '{}'",
+                            body.model
+                        ))
+                    })?
+            }
+        };
+        let config_snapshot = state.config.read().await.clone();
+        let model_name = body.model.clone();
+        let worker_clone = worker.clone();
+        tokio::task::spawn_blocking(move || {
+            crate::gpu_worker::load_blocking(&worker_clone, &model_name, &config_snapshot)
+        })
+        .await
+        .map_err(|e| ApiError::internal(format!("model load task failed: {e}")))?
+        .map_err(|e| ApiError::internal(format!("model load error: {e}")))?;
+
+        tracing::info!(
+            model = %body.model,
+            gpu = worker.gpu.ordinal,
+            "model loaded via API"
+        );
+        return Ok(StatusCode::OK);
+    }
+
+    // Legacy single-GPU path (no workers discovered).
     model_manager::ensure_model_ready(&state, &body.model, None).await?;
-    tracing::info!(model = %body.model, gpu = ?body.gpu, "model loaded via API");
+    tracing::info!(model = %body.model, gpu = ?body.gpu, "model loaded via API (legacy)");
     Ok(StatusCode::OK)
 }
 
@@ -1157,9 +1199,65 @@ async fn unload_model(
     body: Option<Json<UnloadRequest>>,
 ) -> Result<impl IntoResponse, ApiError> {
     let req = body.map(|b| b.0).unwrap_or_default();
-    // TODO: when GPU-targeted unloading is wired through model_manager,
-    // use req.model and req.gpu to target specific GPU workers.
     tracing::debug!(model = ?req.model, gpu = ?req.gpu, "unload request");
+
+    // Multi-GPU path: target specific GPU or model across the pool.
+    if state.gpu_pool.worker_count() > 0 {
+        // Select the workers to unload from.
+        let targets: Vec<_> = match (req.gpu, req.model.as_deref()) {
+            (Some(ordinal), _) => state
+                .gpu_pool
+                .workers
+                .iter()
+                .filter(|w| w.gpu.ordinal == ordinal)
+                .cloned()
+                .collect(),
+            (None, Some(model)) => state
+                .gpu_pool
+                .workers
+                .iter()
+                .filter(|w| {
+                    let cache = w.model_cache.lock().unwrap();
+                    cache
+                        .get(model)
+                        .map(|e| e.residency == crate::model_cache::ModelResidency::Gpu)
+                        .unwrap_or(false)
+                })
+                .cloned()
+                .collect(),
+            (None, None) => state.gpu_pool.workers.clone(),
+        };
+
+        if targets.is_empty() {
+            return Ok((StatusCode::OK, "no model loaded".to_string()));
+        }
+
+        let mut unloaded_pairs: Vec<(usize, String)> = Vec::new();
+        for worker in targets {
+            let worker_clone = worker.clone();
+            let result = tokio::task::spawn_blocking(move || {
+                crate::gpu_worker::unload_blocking(&worker_clone)
+            })
+            .await
+            .map_err(|e| ApiError::internal(format!("unload task failed: {e}")))?;
+            if let Some(name) = result {
+                unloaded_pairs.push((worker.gpu.ordinal, name));
+            }
+        }
+
+        let msg = if unloaded_pairs.is_empty() {
+            "no model loaded".to_string()
+        } else {
+            let joined: Vec<String> = unloaded_pairs
+                .iter()
+                .map(|(o, m)| format!("gpu{o}:{m}"))
+                .collect();
+            format!("unloaded {}", joined.join(", "))
+        };
+        return Ok((StatusCode::OK, msg));
+    }
+
+    // Legacy single-GPU path.
     Ok((StatusCode::OK, model_manager::unload_model(&state).await))
 }
 
@@ -1187,9 +1285,28 @@ async fn server_status(State(state): State<AppState>) -> Json<ServerStatus> {
         .iter()
         .any(|g| g.state == GpuWorkerState::Generating);
 
+    // Pull current_generation from the first busy worker (multi-GPU) or
+    // from the legacy snapshot.
+    let multi_gpu_current_gen = if has_gpus {
+        state.gpu_pool.workers.iter().find_map(|w| {
+            let gen = w.active_generation.read().ok()?;
+            gen.as_ref().map(|g| ActiveGenerationStatus {
+                model: g.model.clone(),
+                // The per-worker ActiveGeneration doesn't carry the prompt hash,
+                // so expose the model-only summary. Callers that need the hash
+                // can subscribe to SSE progress events.
+                prompt_sha256: String::new(),
+                started_at_unix_ms: 0,
+                elapsed_ms: g.started_at.elapsed().as_millis() as u64,
+            })
+        })
+    } else {
+        None
+    };
+
     // Fall back to legacy single-GPU snapshot for backwards compat.
     let (models_loaded, busy, current_generation) = if has_gpus {
-        (gpu_models_loaded, gpu_busy, None)
+        (gpu_models_loaded, gpu_busy, multi_gpu_current_gen)
     } else {
         let snapshot = state.engine_snapshot.read().await.clone();
         let models = match (snapshot.model_name, snapshot.is_loaded) {

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -19,7 +19,16 @@ use tokio_stream::StreamExt as _;
 use utoipa::OpenApi;
 
 use crate::model_manager;
-use crate::state::{AppState, GenerationJob, SseMessage};
+use crate::state::{AppState, GenerationJob, SseMessage, SubmitError};
+
+fn submit_error_to_api(e: SubmitError) -> ApiError {
+    match e {
+        SubmitError::Full { pending, capacity } => ApiError::queue_full(format!(
+            "generation queue is full ({pending}/{capacity})"
+        )),
+        SubmitError::Shutdown => ApiError::internal("generation queue shut down"),
+    }
+}
 
 // ── ApiError — structured JSON error response ────────────────────────────────
 
@@ -100,6 +109,12 @@ impl ApiError {
 impl IntoResponse for ApiError {
     fn into_response(self) -> axum::response::Response {
         let status = self.status;
+        // On queue-full (503), hint clients to retry with a short delay.
+        if self.code == "QUEUE_FULL" {
+            let mut headers = HeaderMap::new();
+            headers.insert(header::RETRY_AFTER, HeaderValue::from_static("1"));
+            return (status, headers, Json(self)).into_response();
+        }
         (status, Json(self)).into_response()
     }
 }
@@ -234,15 +249,10 @@ async fn prepare_generation(
     state: &AppState,
     request: &mut mold_core::GenerateRequest,
 ) -> Result<(Option<std::path::PathBuf>, Option<String>), ApiError> {
-    // Reject early if the generation queue is at capacity.
-    if state.queue.pending() >= state.queue_capacity {
-        return Err(ApiError::queue_full(format!(
-            "generation queue is full ({}/{})",
-            state.queue.pending(),
-            state.queue_capacity,
-        )));
-    }
-
+    // NOTE: the capacity check is enforced inside `state.queue.submit(...)` so
+    // that a burst of concurrent callers can't all slip past an open check
+    // (classic TOCTOU).  The submit call in `generate`/`generate_stream` will
+    // return `SubmitError::Full`, which is mapped to `ApiError::queue_full()`.
     apply_default_metadata_setting(state, request).await;
 
     // Expand prompt if requested (before validation, so the expanded prompt gets validated)
@@ -317,7 +327,11 @@ async fn generate(
         output_dir,
     };
 
-    let _position = state.queue.submit(job).await.map_err(ApiError::internal)?;
+    let _position = state
+        .queue
+        .submit(job, state.queue_capacity)
+        .await
+        .map_err(submit_error_to_api)?;
 
     // Wait for the queue worker to process the job
     let result = result_rx
@@ -865,7 +879,11 @@ async fn generate_stream(
         output_dir,
     };
 
-    let position = state.queue.submit(job).await.map_err(ApiError::internal)?;
+    let position = state
+        .queue
+        .submit(job, state.queue_capacity)
+        .await
+        .map_err(submit_error_to_api)?;
 
     // Send initial queue position to the client
     let _ = tx.send(SseMessage::Progress(SseProgressEvent::Queued { position }));

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -337,6 +337,14 @@ async fn generate(
                     ApiError::internal(format!("failed to serialize seed header: {e}"))
                 })?,
             );
+            if let Some(ordinal) = response.gpu {
+                headers.insert(
+                    "x-mold-gpu",
+                    HeaderValue::from_str(&ordinal.to_string()).map_err(|e| {
+                        ApiError::internal(format!("failed to serialize gpu header: {e}"))
+                    })?,
+                );
+            }
             if let Some(warning) = dim_warning {
                 match HeaderValue::from_str(&warning.replace('\n', " ")) {
                     Ok(val) => {

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -23,9 +23,9 @@ use crate::state::{AppState, GenerationJob, SseMessage, SubmitError};
 
 fn submit_error_to_api(e: SubmitError) -> ApiError {
     match e {
-        SubmitError::Full { pending, capacity } => ApiError::queue_full(format!(
-            "generation queue is full ({pending}/{capacity})"
-        )),
+        SubmitError::Full { pending, capacity } => {
+            ApiError::queue_full(format!("generation queue is full ({pending}/{capacity})"))
+        }
         SubmitError::Shutdown => ApiError::internal("generation queue shut down"),
     }
 }

--- a/crates/mold-server/src/routes_test.rs
+++ b/crates/mold-server/src/routes_test.rs
@@ -266,7 +266,8 @@ mod tests {
     fn app_empty() -> axum::Router {
         let (tx, _rx) = tokio::sync::mpsc::channel(16);
         let queue = crate::state::QueueHandle::new(tx);
-        app_with_state(AppState::empty(mold_core::Config::default(), queue))
+        let gpu_pool = std::sync::Arc::new(crate::gpu_pool::GpuPool { workers: Vec::new() });
+        app_with_state(AppState::empty(mold_core::Config::default(), queue, gpu_pool, 200))
     }
 
     fn generate_body(prompt: &str, width: u32, height: u32) -> String {
@@ -1140,7 +1141,8 @@ mod tests {
     async fn unload_no_model_returns_200_with_message() {
         let (tx, _rx) = tokio::sync::mpsc::channel(16);
         let queue = crate::state::QueueHandle::new(tx);
-        let app = app_with_state(AppState::empty(mold_core::Config::default(), queue));
+        let gpu_pool = std::sync::Arc::new(crate::gpu_pool::GpuPool { workers: Vec::new() });
+        let app = app_with_state(AppState::empty(mold_core::Config::default(), queue, gpu_pool, 200));
         let resp = app
             .oneshot(
                 Request::delete("/api/models/unload")
@@ -1165,6 +1167,8 @@ mod tests {
         let mut cache = crate::model_cache::ModelCache::new(3);
         cache.insert(Box::new(engine), 0);
         let state = AppState {
+            gpu_pool: std::sync::Arc::new(crate::gpu_pool::GpuPool { workers: Vec::new() }),
+            queue_capacity: 200,
             model_cache: Arc::new(tokio::sync::Mutex::new(cache)),
             engine_snapshot: Arc::new(tokio::sync::RwLock::new(EngineSnapshot {
                 model_name: Some("mock-model".to_string()),
@@ -1212,6 +1216,8 @@ mod tests {
         let mut cache = crate::model_cache::ModelCache::new(3);
         cache.insert(Box::new(engine), 0);
         let state = AppState {
+            gpu_pool: std::sync::Arc::new(crate::gpu_pool::GpuPool { workers: Vec::new() }),
+            queue_capacity: 200,
             model_cache: Arc::new(tokio::sync::Mutex::new(cache)),
             engine_snapshot: Arc::new(tokio::sync::RwLock::new(EngineSnapshot {
                 model_name: Some("mock-model".to_string()),
@@ -1462,6 +1468,8 @@ mod tests {
         let mut cache = crate::model_cache::ModelCache::new(3);
         cache.insert(Box::new(engine), 0);
         let state = AppState {
+            gpu_pool: std::sync::Arc::new(crate::gpu_pool::GpuPool { workers: Vec::new() }),
+            queue_capacity: 200,
             model_cache: Arc::new(tokio::sync::Mutex::new(cache)),
             engine_snapshot: Arc::new(tokio::sync::RwLock::new(EngineSnapshot {
                 model_name: Some("mock-model".to_string()),

--- a/crates/mold-server/src/routes_test.rs
+++ b/crates/mold-server/src/routes_test.rs
@@ -266,8 +266,15 @@ mod tests {
     fn app_empty() -> axum::Router {
         let (tx, _rx) = tokio::sync::mpsc::channel(16);
         let queue = crate::state::QueueHandle::new(tx);
-        let gpu_pool = std::sync::Arc::new(crate::gpu_pool::GpuPool { workers: Vec::new() });
-        app_with_state(AppState::empty(mold_core::Config::default(), queue, gpu_pool, 200))
+        let gpu_pool = std::sync::Arc::new(crate::gpu_pool::GpuPool {
+            workers: Vec::new(),
+        });
+        app_with_state(AppState::empty(
+            mold_core::Config::default(),
+            queue,
+            gpu_pool,
+            200,
+        ))
     }
 
     fn generate_body(prompt: &str, width: u32, height: u32) -> String {
@@ -1141,8 +1148,15 @@ mod tests {
     async fn unload_no_model_returns_200_with_message() {
         let (tx, _rx) = tokio::sync::mpsc::channel(16);
         let queue = crate::state::QueueHandle::new(tx);
-        let gpu_pool = std::sync::Arc::new(crate::gpu_pool::GpuPool { workers: Vec::new() });
-        let app = app_with_state(AppState::empty(mold_core::Config::default(), queue, gpu_pool, 200));
+        let gpu_pool = std::sync::Arc::new(crate::gpu_pool::GpuPool {
+            workers: Vec::new(),
+        });
+        let app = app_with_state(AppState::empty(
+            mold_core::Config::default(),
+            queue,
+            gpu_pool,
+            200,
+        ));
         let resp = app
             .oneshot(
                 Request::delete("/api/models/unload")
@@ -1167,7 +1181,9 @@ mod tests {
         let mut cache = crate::model_cache::ModelCache::new(3);
         cache.insert(Box::new(engine), 0);
         let state = AppState {
-            gpu_pool: std::sync::Arc::new(crate::gpu_pool::GpuPool { workers: Vec::new() }),
+            gpu_pool: std::sync::Arc::new(crate::gpu_pool::GpuPool {
+                workers: Vec::new(),
+            }),
             queue_capacity: 200,
             model_cache: Arc::new(tokio::sync::Mutex::new(cache)),
             engine_snapshot: Arc::new(tokio::sync::RwLock::new(EngineSnapshot {
@@ -1216,7 +1232,9 @@ mod tests {
         let mut cache = crate::model_cache::ModelCache::new(3);
         cache.insert(Box::new(engine), 0);
         let state = AppState {
-            gpu_pool: std::sync::Arc::new(crate::gpu_pool::GpuPool { workers: Vec::new() }),
+            gpu_pool: std::sync::Arc::new(crate::gpu_pool::GpuPool {
+                workers: Vec::new(),
+            }),
             queue_capacity: 200,
             model_cache: Arc::new(tokio::sync::Mutex::new(cache)),
             engine_snapshot: Arc::new(tokio::sync::RwLock::new(EngineSnapshot {
@@ -1468,7 +1486,9 @@ mod tests {
         let mut cache = crate::model_cache::ModelCache::new(3);
         cache.insert(Box::new(engine), 0);
         let state = AppState {
-            gpu_pool: std::sync::Arc::new(crate::gpu_pool::GpuPool { workers: Vec::new() }),
+            gpu_pool: std::sync::Arc::new(crate::gpu_pool::GpuPool {
+                workers: Vec::new(),
+            }),
             queue_capacity: 200,
             model_cache: Arc::new(tokio::sync::Mutex::new(cache)),
             engine_snapshot: Arc::new(tokio::sync::RwLock::new(EngineSnapshot {

--- a/crates/mold-server/src/routes_test.rs
+++ b/crates/mold-server/src/routes_test.rs
@@ -207,6 +207,7 @@ mod tests {
                 model: req.model.clone(),
                 seed_used: req.seed.unwrap_or(42),
                 video: None,
+                gpu: None,
             })
         }
 

--- a/crates/mold-server/src/routes_test.rs
+++ b/crates/mold-server/src/routes_test.rs
@@ -1883,7 +1883,10 @@ mod tests {
         };
         let (tx, _rx) = tokio::sync::mpsc::channel(16);
         let queue = crate::state::QueueHandle::new(tx);
-        let mut state = AppState::empty(config, queue);
+        let gpu_pool = std::sync::Arc::new(crate::gpu_pool::GpuPool {
+            workers: Vec::new(),
+        });
+        let mut state = AppState::empty(config, queue, gpu_pool, 200);
         state.metadata_db = std::sync::Arc::new(Some(db));
         let app = app_with_state(state);
 
@@ -1920,7 +1923,10 @@ mod tests {
         };
         let (tx, _rx) = tokio::sync::mpsc::channel(16);
         let queue = crate::state::QueueHandle::new(tx);
-        let state = AppState::empty(config, queue);
+        let gpu_pool = std::sync::Arc::new(crate::gpu_pool::GpuPool {
+            workers: Vec::new(),
+        });
+        let state = AppState::empty(config, queue, gpu_pool, 200);
         let app = app_with_state(state);
 
         let resp = app
@@ -1989,7 +1995,10 @@ mod tests {
         };
         let (tx, _rx) = tokio::sync::mpsc::channel(16);
         let queue = crate::state::QueueHandle::new(tx);
-        let mut state = AppState::empty(config, queue);
+        let gpu_pool = std::sync::Arc::new(crate::gpu_pool::GpuPool {
+            workers: Vec::new(),
+        });
+        let mut state = AppState::empty(config, queue, gpu_pool, 200);
         state.metadata_db = std::sync::Arc::new(Some(db));
         let db_handle_for_assert = state.metadata_db.clone();
         let app = app_with_state(state);

--- a/crates/mold-server/src/state.rs
+++ b/crates/mold-server/src/state.rs
@@ -83,11 +83,7 @@ impl QueueHandle {
     /// Atomically reserves a slot against `capacity` using fetch_add, so a
     /// burst of concurrent callers cannot all slip past a separate pending()
     /// pre-check (TOCTOU).  Returns the queue position on success.
-    pub async fn submit(
-        &self,
-        job: GenerationJob,
-        capacity: usize,
-    ) -> Result<usize, SubmitError> {
+    pub async fn submit(&self, job: GenerationJob, capacity: usize) -> Result<usize, SubmitError> {
         let prev = self.pending_count.fetch_add(1, Ordering::SeqCst);
         if prev >= capacity {
             self.pending_count.fetch_sub(1, Ordering::SeqCst);

--- a/crates/mold-server/src/state.rs
+++ b/crates/mold-server/src/state.rs
@@ -61,6 +61,15 @@ pub struct QueueHandle {
     pending_count: Arc<AtomicUsize>,
 }
 
+/// Reason a `QueueHandle::submit` attempt failed.
+#[derive(Debug)]
+pub enum SubmitError {
+    /// Queue is at capacity — caller should return 503 with `Retry-After`.
+    Full { pending: usize, capacity: usize },
+    /// Receiving end is gone (server shutting down).
+    Shutdown,
+}
+
 impl QueueHandle {
     pub fn new(job_tx: tokio::sync::mpsc::Sender<GenerationJob>) -> Self {
         Self {
@@ -69,19 +78,34 @@ impl QueueHandle {
         }
     }
 
-    /// Submit a generation job. Returns the queue position (0-based).
-    pub async fn submit(&self, job: GenerationJob) -> Result<usize, String> {
-        let position = self.pending_count.fetch_add(1, Ordering::SeqCst);
-        if let Err(_e) = self.job_tx.send(job).await {
+    /// Submit a generation job.
+    ///
+    /// Atomically reserves a slot against `capacity` using fetch_add, so a
+    /// burst of concurrent callers cannot all slip past a separate pending()
+    /// pre-check (TOCTOU).  Returns the queue position on success.
+    pub async fn submit(
+        &self,
+        job: GenerationJob,
+        capacity: usize,
+    ) -> Result<usize, SubmitError> {
+        let prev = self.pending_count.fetch_add(1, Ordering::SeqCst);
+        if prev >= capacity {
             self.pending_count.fetch_sub(1, Ordering::SeqCst);
-            return Err("generation queue shut down".to_string());
+            return Err(SubmitError::Full {
+                pending: prev,
+                capacity,
+            });
+        }
+        if self.job_tx.send(job).await.is_err() {
+            self.pending_count.fetch_sub(1, Ordering::SeqCst);
+            return Err(SubmitError::Shutdown);
         }
         #[cfg(feature = "metrics")]
         {
             crate::metrics::record_queue_submit();
             crate::metrics::record_queue_depth(self.pending_count.load(Ordering::SeqCst));
         }
-        Ok(position)
+        Ok(prev)
     }
 
     pub fn decrement(&self) {

--- a/crates/mold-server/src/state.rs
+++ b/crates/mold-server/src/state.rs
@@ -8,6 +8,7 @@ use tokio::sync::Mutex;
 
 use mold_inference::shared_pool::SharedPool;
 
+use crate::gpu_pool::GpuPool;
 use crate::model_cache::ModelCache;
 
 #[derive(Debug, Clone, Default)]
@@ -96,6 +97,13 @@ impl QueueHandle {
 
 #[derive(Clone)]
 pub struct AppState {
+    // ── Multi-GPU fields ────────────────────────────────────────────────────
+    /// GPU worker pool for multi-GPU dispatch.
+    pub gpu_pool: Arc<GpuPool>,
+    /// Maximum queue capacity (for status reporting and 503 responses).
+    pub queue_capacity: usize,
+
+    // ── Legacy single-GPU fields (retained during migration) ────────────────
     pub model_cache: Arc<Mutex<ModelCache>>,
     pub engine_snapshot: Arc<tokio::sync::RwLock<EngineSnapshot>>,
     /// Uses std::sync::RwLock (not tokio) because it's only accessed from
@@ -127,7 +135,13 @@ const DEFAULT_MAX_CACHED_MODELS: usize = 3;
 
 impl AppState {
     /// Create state with a pre-loaded engine (server starts with a configured model).
-    pub fn new(engine: Box<dyn InferenceEngine>, config: Config, queue: QueueHandle) -> Self {
+    pub fn new(
+        engine: Box<dyn InferenceEngine>,
+        config: Config,
+        queue: QueueHandle,
+        gpu_pool: Arc<GpuPool>,
+        queue_capacity: usize,
+    ) -> Self {
         let name = engine.model_name().to_string();
         let loaded = engine.is_loaded();
         let mut cache = ModelCache::new(DEFAULT_MAX_CACHED_MODELS);
@@ -138,6 +152,8 @@ impl AppState {
             cached_models: cache.cached_model_names(),
         };
         Self {
+            gpu_pool,
+            queue_capacity,
             model_cache: Arc::new(Mutex::new(cache)),
             engine_snapshot: Arc::new(tokio::sync::RwLock::new(snapshot)),
             active_generation: Arc::new(RwLock::new(None)),
@@ -154,8 +170,15 @@ impl AppState {
     }
 
     /// Create state with no engine (zero-config startup, models pulled on demand).
-    pub fn empty(config: Config, queue: QueueHandle) -> Self {
+    pub fn empty(
+        config: Config,
+        queue: QueueHandle,
+        gpu_pool: Arc<GpuPool>,
+        queue_capacity: usize,
+    ) -> Self {
         Self {
+            gpu_pool,
+            queue_capacity,
             model_cache: Arc::new(Mutex::new(ModelCache::new(DEFAULT_MAX_CACHED_MODELS))),
             engine_snapshot: Arc::new(tokio::sync::RwLock::new(EngineSnapshot::default())),
             active_generation: Arc::new(RwLock::new(None)),
@@ -169,6 +192,14 @@ impl AppState {
             upscaler_cache: Arc::new(std::sync::Mutex::new(None)),
             metadata_db: Arc::new(None),
         }
+    }
+
+    /// Create an empty GpuPool for testing (no GPU workers).
+    #[cfg(test)]
+    fn empty_gpu_pool() -> Arc<GpuPool> {
+        Arc::new(GpuPool {
+            workers: Vec::new(),
+        })
     }
 
     #[cfg(test)]
@@ -185,6 +216,8 @@ impl AppState {
             cached_models: cache.cached_model_names(),
         };
         Self {
+            gpu_pool: Self::empty_gpu_pool(),
+            queue_capacity: 200,
             model_cache: Arc::new(Mutex::new(cache)),
             engine_snapshot: Arc::new(tokio::sync::RwLock::new(snapshot)),
             active_generation: Arc::new(RwLock::new(None)),
@@ -217,6 +250,8 @@ impl AppState {
             cached_models: cache.cached_model_names(),
         };
         let state = Self {
+            gpu_pool: Self::empty_gpu_pool(),
+            queue_capacity: 200,
             model_cache: Arc::new(Mutex::new(cache)),
             engine_snapshot: Arc::new(tokio::sync::RwLock::new(snapshot)),
             active_generation: Arc::new(RwLock::new(None)),
@@ -268,7 +303,12 @@ mod tests {
     #[test]
     fn upscaler_cache_starts_empty() {
         let config = mold_core::Config::default();
-        let state = AppState::empty(config, QueueHandle::new(tokio::sync::mpsc::channel(1).0));
+        let state = AppState::empty(
+            config,
+            QueueHandle::new(tokio::sync::mpsc::channel(1).0),
+            AppState::empty_gpu_pool(),
+            200,
+        );
         let cache = state.upscaler_cache.lock().unwrap();
         assert!(cache.is_none());
     }
@@ -276,7 +316,12 @@ mod tests {
     #[test]
     fn upscaler_cache_cleared_by_setting_none() {
         let config = mold_core::Config::default();
-        let state = AppState::empty(config, QueueHandle::new(tokio::sync::mpsc::channel(1).0));
+        let state = AppState::empty(
+            config,
+            QueueHandle::new(tokio::sync::mpsc::channel(1).0),
+            AppState::empty_gpu_pool(),
+            200,
+        );
         {
             let mut cache = state.upscaler_cache.lock().unwrap();
             *cache = None;

--- a/crates/mold-tui/src/app.rs
+++ b/crates/mold-tui/src/app.rs
@@ -6251,6 +6251,7 @@ mod tests {
             model: "flux-schnell:q8".to_string(),
             seed_used: 42,
             video: None,
+            gpu: None,
         };
         app.bg_tx
             .send(BackgroundEvent::GenerationComplete(Box::new(response)))

--- a/crates/mold-tui/src/app.rs
+++ b/crates/mold-tui/src/app.rs
@@ -6916,6 +6916,9 @@ mod tests {
             uptime_secs: 3600,
             hostname: Some("hal9000".to_string()),
             memory_status: Some("VRAM: 16.0 GB free".to_string()),
+            gpus: None,
+            queue_depth: None,
+            queue_capacity: None,
         };
         ri.update_from_server_status(status);
         assert_eq!(ri.memory_line.as_deref(), Some("VRAM: 16.0 GB free"));
@@ -6940,6 +6943,9 @@ mod tests {
                 uptime_secs: 0,
                 hostname: Some("remote".to_string()),
                 memory_status: Some("VRAM: 16.0 GB free".to_string()),
+                gpus: None,
+                queue_depth: None,
+                queue_capacity: None,
             }),
             ..Default::default()
         };
@@ -6964,6 +6970,9 @@ mod tests {
             uptime_secs: 0,
             hostname: None,
             memory_status: None,
+            gpus: None,
+            queue_depth: None,
+            queue_capacity: None,
         };
         let _event = BackgroundEvent::ServerStatusUpdate(Some(Box::new(status)));
         // None variant for server-unreachable
@@ -7220,6 +7229,9 @@ mod tests {
             uptime_secs: 0,
             hostname: Some("stale-host".to_string()),
             memory_status: None,
+            gpus: None,
+            queue_depth: None,
+            queue_capacity: None,
         });
 
         app.sync_resource_info_mode();
@@ -7280,6 +7292,9 @@ mod tests {
             uptime_secs: 3600,
             hostname: Some("hal9000".to_string()),
             memory_status: Some("VRAM: 16.0 GB free".to_string()),
+            gpus: None,
+            queue_depth: None,
+            queue_capacity: None,
         };
 
         let _ = app
@@ -7312,6 +7327,9 @@ mod tests {
                 uptime_secs: 0,
                 hostname: Some("stale-host".to_string()),
                 memory_status: Some("VRAM: 16.0 GB free".to_string()),
+                gpus: None,
+                queue_depth: None,
+                queue_capacity: None,
             });
         assert!(app.resource_info.server_status.is_some());
 

--- a/crates/mold-tui/src/backend.rs
+++ b/crates/mold-tui/src/backend.rs
@@ -339,6 +339,7 @@ async fn run_local_generation(
             model_paths,
             &config,
             LoadStrategy::Sequential,
+            0,
             offload,
         )?;
 

--- a/crates/mold-tui/src/ui/info.rs
+++ b/crates/mold-tui/src/ui/info.rs
@@ -283,6 +283,9 @@ mod tests {
             uptime_secs: 3600,
             hostname: Some("hal9000".to_string()),
             memory_status: Some("VRAM: 16.0 GB free".to_string()),
+            gpus: None,
+            queue_depth: None,
+            queue_capacity: None,
         };
         ri.update_from_server_status(status);
         assert_eq!(ri.memory_line.as_deref(), Some("VRAM: 16.0 GB free"));
@@ -306,6 +309,9 @@ mod tests {
                 uptime_secs: 0,
                 hostname: None,
                 memory_status: None,
+                gpus: None,
+                queue_depth: None,
+                queue_capacity: None,
             }),
             ..Default::default()
         };

--- a/docs/superpowers/plans/2026-04-08-multi-gpu-support.md
+++ b/docs/superpowers/plans/2026-04-08-multi-gpu-support.md
@@ -1,0 +1,1411 @@
+# Multi-GPU Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enable concurrent model placement across multiple GPUs with smart routing, configurable GPU selection, and bounded request queuing.
+
+**Architecture:** Per-GPU worker pool where each GPU gets a dedicated OS thread, its own ModelCache, and independent model lifecycle. A GpuPool routes requests using idle-first + VRAM-fit placement strategy. Atomic in-flight counters prevent TOCTOU races under burst load.
+
+**Tech Stack:** Rust, candle (CUDA/Metal), tokio (async dispatch), std::thread (GPU workers), axum (HTTP server), clap (CLI)
+
+**Spec:** `docs/superpowers/specs/2026-04-08-multi-gpu-support-design.md`
+
+---
+
+## File Map
+
+### New Files
+- `crates/mold-server/src/gpu_pool.rs` — GpuPool, GpuWorker, placement strategy, GpuJob
+- `crates/mold-server/src/gpu_worker.rs` — Dedicated OS thread worker loop, process_job(), take-and-restore pattern
+
+### Modified Files
+| File | What Changes |
+|------|-------------|
+| `crates/mold-core/src/types.rs` | GpuInfo expanded, GpuSelection, GpuStatus, GpuWorkerStatus types. ServerStatus gets `gpus` array + queue fields. GenerateResponse gets `gpu` field. |
+| `crates/mold-core/src/config.rs` | Config gets `gpus` and `queue_size` fields |
+| `crates/mold-inference/src/device.rs` | `create_device(ordinal)`, `discover_gpus()`, `free_vram_bytes(ordinal)`, `vram_used_estimate(ordinal)`, `reclaim_gpu_memory(ordinal)` |
+| `crates/mold-inference/src/engine_base.rs` | `gpu_ordinal: usize` field |
+| `crates/mold-inference/src/factory.rs` | `ordinal` param threaded through |
+| `crates/mold-inference/src/expand.rs` | Ordinal-aware device creation |
+| `crates/mold-server/src/state.rs` | AppState: replace model_cache/engine_snapshot/model_load_lock with gpu_pool |
+| `crates/mold-server/src/model_cache.rs` | Minor: expose `remove()` + `insert()` for take-and-restore |
+| `crates/mold-server/src/model_manager.rs` | Operate on GpuWorker instead of global state |
+| `crates/mold-server/src/queue.rs` | Multi-GPU dispatcher with in-flight tracking |
+| `crates/mold-server/src/routes.rs` | Status, load, unload endpoints updated for multi-GPU |
+| `crates/mold-server/src/lib.rs` | Server startup creates GpuPool |
+| `crates/mold-cli/src/main.rs` | `--gpus`, `--queue-size` flags |
+| `crates/mold-cli/src/commands/generate.rs` | Best-GPU selection for `--local` |
+| `crates/mold-cli/src/commands/ps.rs` | Multi-GPU status display |
+
+---
+
+## Task 1: Core Types & Config (mold-core)
+
+**Files:**
+- Modify: `crates/mold-core/src/types.rs`
+- Modify: `crates/mold-core/src/config.rs`
+
+No dependencies. Can start immediately.
+
+- [ ] **Step 1: Add GpuSelection type to types.rs**
+
+Add after the existing `GpuInfo` struct (~line 585):
+
+```rust
+/// GPU selection for multi-GPU setups
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum GpuSelection {
+    /// Use all discovered GPUs (default)
+    All,
+    /// Use only these specific GPU ordinals
+    Specific(Vec<usize>),
+}
+
+impl Default for GpuSelection {
+    fn default() -> Self {
+        Self::All
+    }
+}
+
+impl GpuSelection {
+    /// Parse from comma-separated string like "0,1,2"
+    pub fn parse(s: &str) -> anyhow::Result<Self> {
+        if s.is_empty() || s.to_lowercase() == "all" {
+            return Ok(Self::All);
+        }
+        let ordinals: Vec<usize> = s
+            .split(',')
+            .map(|s| s.trim().parse::<usize>())
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| anyhow::anyhow!("invalid GPU ordinal: {e}"))?;
+        if ordinals.is_empty() {
+            return Ok(Self::All);
+        }
+        Ok(Self::Specific(ordinals))
+    }
+}
+```
+
+- [ ] **Step 2: Add GpuWorkerStatus type to types.rs**
+
+Add after GpuSelection:
+
+```rust
+/// Per-GPU worker status for multi-GPU status reporting
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GpuWorkerStatus {
+    pub ordinal: usize,
+    pub name: String,
+    pub vram_total_bytes: u64,
+    pub vram_used_bytes: u64,
+    pub loaded_model: Option<String>,
+    pub state: GpuWorkerState,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum GpuWorkerState {
+    Idle,
+    Generating,
+    Loading,
+    Degraded,
+}
+```
+
+- [ ] **Step 3: Update ServerStatus in types.rs**
+
+Find the existing `ServerStatus` struct (~line 556-573) and add the new fields. Keep existing fields for backwards compat:
+
+```rust
+pub struct ServerStatus {
+    pub version: String,
+    pub models_loaded: Vec<String>,
+    pub model: Option<String>,       // backwards compat: first GPU's model
+    pub busy: bool,
+    pub current_generation: Option<ActiveGenerationStatus>,
+    pub gpu_info: Option<GpuInfo>,   // backwards compat: first GPU
+    pub uptime_secs: Option<u64>,
+    // New multi-GPU fields
+    pub gpus: Option<Vec<GpuWorkerStatus>>,
+    pub queue_depth: Option<usize>,
+    pub queue_capacity: Option<usize>,
+}
+```
+
+- [ ] **Step 4: Add `gpu` field to GenerateResponse**
+
+Find GenerateResponse (~line 287-300) and add:
+
+```rust
+pub struct GenerateResponse {
+    // ... existing fields ...
+    /// Which GPU ordinal handled this request (multi-GPU only)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gpu: Option<usize>,
+}
+```
+
+- [ ] **Step 5: Update Config struct**
+
+In `crates/mold-core/src/config.rs`, find the `Config` struct (~line 312-372) and add:
+
+```rust
+pub struct Config {
+    // ... existing fields ...
+    /// GPU ordinals to use (None = all available)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gpus: Option<Vec<usize>>,
+    /// Max queued requests before 503 (default: 200)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub queue_size: Option<usize>,
+}
+```
+
+- [ ] **Step 6: Add GpuSelection helper to Config**
+
+Add a method to Config:
+
+```rust
+impl Config {
+    pub fn gpu_selection(&self) -> GpuSelection {
+        match &self.gpus {
+            Some(ordinals) if !ordinals.is_empty() => GpuSelection::Specific(ordinals.clone()),
+            _ => GpuSelection::All,
+        }
+    }
+
+    pub fn queue_size(&self) -> usize {
+        self.queue_size.unwrap_or(200)
+    }
+}
+```
+
+- [ ] **Step 7: Verify compilation**
+
+Run: `cargo check -p mold-ai-core`
+Expected: PASS (no other crates modified yet)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/mold-core/src/types.rs crates/mold-core/src/config.rs
+git commit -m "feat(core): add multi-GPU types — GpuSelection, GpuWorkerStatus, ServerStatus gpus array"
+```
+
+---
+
+## Task 2: GPU Discovery & Device Ordinal (mold-inference)
+
+**Files:**
+- Modify: `crates/mold-inference/src/device.rs`
+
+Depends on: Task 1 (uses GpuInfo from mold-core)
+
+- [ ] **Step 1: Add GpuInfo struct and discover_gpus()**
+
+Add at the top of device.rs (after imports):
+
+```rust
+use mold_core::types::GpuSelection;
+
+/// Discovered GPU information
+#[derive(Debug, Clone)]
+pub struct DiscoveredGpu {
+    pub ordinal: usize,
+    pub name: String,
+    pub total_vram_bytes: u64,
+    pub free_vram_bytes: u64,
+}
+
+/// Discover all available GPUs on the system
+pub fn discover_gpus() -> Vec<DiscoveredGpu> {
+    let mut gpus = Vec::new();
+
+    #[cfg(feature = "cuda")]
+    {
+        if candle_core::utils::cuda_is_available() {
+            if let Ok(count) = cudarc::driver::result::device::get_count() {
+                for ordinal in 0..count as usize {
+                    if let Ok(device) = cudarc::driver::CudaDevice::new(ordinal) {
+                        let name = device
+                            .name()
+                            .unwrap_or_else(|_| format!("CUDA Device {ordinal}"));
+                        let (free, total) = cudarc::driver::result::mem_get_info()
+                            .unwrap_or((0, 0));
+                        gpus.push(DiscoveredGpu {
+                            ordinal,
+                            name,
+                            total_vram_bytes: total as u64,
+                            free_vram_bytes: free as u64,
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    #[cfg(not(feature = "cuda"))]
+    {
+        if candle_core::utils::metal_is_available() {
+            // Metal: single device on macOS
+            let total = available_system_memory_bytes().unwrap_or(0);
+            let free = free_system_memory_bytes().unwrap_or(0);
+            gpus.push(DiscoveredGpu {
+                ordinal: 0,
+                name: "Apple Metal GPU".to_string(),
+                total_vram_bytes: total,
+                free_vram_bytes: free,
+            });
+        }
+    }
+
+    gpus
+}
+
+/// Filter discovered GPUs by user selection
+pub fn filter_gpus(gpus: &[DiscoveredGpu], selection: &GpuSelection) -> Vec<DiscoveredGpu> {
+    match selection {
+        GpuSelection::All => gpus.to_vec(),
+        GpuSelection::Specific(ordinals) => gpus
+            .iter()
+            .filter(|g| ordinals.contains(&g.ordinal))
+            .cloned()
+            .collect(),
+    }
+}
+
+/// Select the single best GPU (most free VRAM) for local CLI use
+pub fn select_best_gpu(gpus: &[DiscoveredGpu]) -> Option<&DiscoveredGpu> {
+    gpus.iter().max_by_key(|g| g.free_vram_bytes)
+}
+```
+
+- [ ] **Step 2: Update create_device() to take ordinal**
+
+Change the existing `create_device()` signature (~line 6-28):
+
+```rust
+/// Create a device on the specified GPU ordinal.
+/// Use ordinal 0 for single-GPU setups.
+pub fn create_device(ordinal: usize, progress: &ProgressReporter) -> anyhow::Result<candle_core::Device> {
+    if std::env::var("MOLD_DEVICE")
+        .map(|v| v.to_lowercase() == "cpu")
+        .unwrap_or(false)
+    {
+        progress.report(ProgressEvent::Status {
+            message: "Using CPU device (MOLD_DEVICE=cpu)".to_string(),
+        });
+        return Ok(candle_core::Device::Cpu);
+    }
+
+    #[cfg(feature = "cuda")]
+    if candle_core::utils::cuda_is_available() {
+        progress.report(ProgressEvent::Status {
+            message: format!("Using CUDA device {ordinal}"),
+        });
+        return Ok(candle_core::Device::new_cuda(ordinal)?);
+    }
+
+    if candle_core::utils::metal_is_available() {
+        progress.report(ProgressEvent::Status {
+            message: format!("Using Metal device {ordinal}"),
+        });
+        return Ok(candle_core::Device::new_metal(ordinal)?);
+    }
+
+    progress.report(ProgressEvent::Status {
+        message: "No GPU detected, using CPU".to_string(),
+    });
+    Ok(candle_core::Device::Cpu)
+}
+```
+
+- [ ] **Step 3: Update free_vram_bytes() to take ordinal**
+
+Find `free_vram_bytes()` (~line 204-235) and update:
+
+```rust
+pub fn free_vram_bytes(ordinal: usize) -> Option<u64> {
+    #[cfg(feature = "cuda")]
+    {
+        // Set context to the specified device before querying
+        if let Ok(device) = cudarc::driver::CudaDevice::new(ordinal) {
+            let (free, _total) = cudarc::driver::result::mem_get_info().ok()?;
+            return Some(free as u64);
+        }
+        return None;
+    }
+    #[cfg(not(feature = "cuda"))]
+    {
+        let _ = ordinal;
+        None
+    }
+}
+```
+
+- [ ] **Step 4: Update vram_used_estimate() to take ordinal**
+
+Find `vram_used_estimate()` (~line 224-233) and update:
+
+```rust
+pub fn vram_used_estimate(ordinal: usize) -> u64 {
+    #[cfg(feature = "cuda")]
+    {
+        if let Ok(device) = cudarc::driver::CudaDevice::new(ordinal) {
+            if let Ok((free, total)) = cudarc::driver::result::mem_get_info() {
+                return (total - free) as u64;
+            }
+        }
+        0
+    }
+    #[cfg(not(feature = "cuda"))]
+    {
+        let _ = ordinal;
+        0
+    }
+}
+```
+
+- [ ] **Step 5: Update reclaim_gpu_memory() to take ordinal**
+
+Find `reclaim_gpu_memory()` (~line 168-192) and update:
+
+```rust
+#[cfg(feature = "cuda")]
+pub fn reclaim_gpu_memory(ordinal: usize) {
+    // Reset only the specified device's primary context.
+    // SAFETY: Caller must hold the per-worker model_load_lock,
+    // guaranteeing exclusive access to this GPU during model swaps.
+    use cudarc::driver::sys;
+    let cu_device = ordinal as i32;
+    if let Err(e) = unsafe { sys::lib().cuDevicePrimaryCtxReset_v2(cu_device) }.result() {
+        tracing::warn!("Failed to reset CUDA context for device {ordinal}: {e:?}");
+    }
+}
+
+#[cfg(not(feature = "cuda"))]
+pub fn reclaim_gpu_memory(_ordinal: usize) {}
+```
+
+- [ ] **Step 6: Update all callers of these functions**
+
+Search the codebase for calls to `create_device(`, `free_vram_bytes()`, `vram_used_estimate()`, `reclaim_gpu_memory()` and update them to pass ordinal. Most callers will get ordinal from `self.base.gpu_ordinal` (added in Task 3). For now, callers that don't yet have an ordinal should pass `0` as a temporary default — Task 3 will thread the real ordinal through.
+
+Callers to update (pass `0` temporarily):
+- Every engine pipeline's `load()` method (flux/pipeline.rs, sd15/pipeline.rs, sdxl/pipeline.rs, sd3/pipeline.rs, zimage/pipeline.rs, flux2/pipeline.rs, qwen_image/pipeline.rs, wuerstchen/pipeline.rs, ltx_video/pipeline.rs)
+- `expand.rs` device creation (~line 118)
+- `upscaler/engine.rs` device creation
+- `model_manager.rs` calls to `reclaim_gpu_memory()` and `vram_used_estimate()`
+
+- [ ] **Step 7: Verify compilation**
+
+Run: `cargo check --workspace`
+Expected: PASS (all callers updated to pass ordinal 0 as default)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/mold-inference/src/device.rs
+git add -u  # all callers updated
+git commit -m "feat(inference): add GPU discovery, ordinal-aware device creation and VRAM functions"
+```
+
+---
+
+## Task 3: Engine Ordinal Threading (mold-inference)
+
+**Files:**
+- Modify: `crates/mold-inference/src/engine_base.rs`
+- Modify: `crates/mold-inference/src/factory.rs`
+- Modify: `crates/mold-inference/src/expand.rs`
+- Modify: All engine pipeline.rs files (update `create_device` calls)
+
+Depends on: Task 2
+
+- [ ] **Step 1: Add gpu_ordinal to EngineBase**
+
+In `engine_base.rs` (~line 18-24), add the field:
+
+```rust
+pub struct EngineBase<L> {
+    pub loaded: Option<L>,
+    pub model_name: String,
+    pub paths: ModelPaths,
+    pub progress: ProgressReporter,
+    pub load_strategy: LoadStrategy,
+    pub gpu_ordinal: usize,  // NEW
+}
+```
+
+Update `new()` (~line 28-36) to accept and store it:
+
+```rust
+pub fn new(model_name: String, paths: ModelPaths, load_strategy: LoadStrategy, gpu_ordinal: usize) -> Self {
+    Self {
+        loaded: None,
+        model_name,
+        paths,
+        progress: ProgressReporter::new(),
+        load_strategy,
+        gpu_ordinal,
+    }
+}
+```
+
+- [ ] **Step 2: Update factory to accept and pass ordinal**
+
+In `factory.rs`, update both function signatures:
+
+```rust
+pub fn create_engine(
+    model_name: &str,
+    config: &Config,
+    load_strategy: LoadStrategy,
+    gpu_ordinal: usize,  // NEW
+) -> anyhow::Result<Box<dyn InferenceEngine>> {
+    create_engine_with_pool(model_name, config, load_strategy, gpu_ordinal, None, false, None, None, None, None)
+}
+
+pub fn create_engine_with_pool(
+    model_name: &str,
+    config: &Config,
+    load_strategy: LoadStrategy,
+    gpu_ordinal: usize,  // NEW
+    shared_pool: Option<Arc<Mutex<SharedPool>>>,
+    // ... rest of existing params
+) -> anyhow::Result<Box<dyn InferenceEngine>> {
+```
+
+Thread `gpu_ordinal` through to each engine constructor. Each engine's `new()` must pass it to `EngineBase::new()`.
+
+- [ ] **Step 3: Update each engine's load() to use self.base.gpu_ordinal**
+
+In every pipeline's `load()` method, change:
+
+```rust
+// Before (temporary ordinal 0 from Task 2)
+let device = crate::device::create_device(0, &self.base.progress)?;
+
+// After
+let device = crate::device::create_device(self.base.gpu_ordinal, &self.base.progress)?;
+```
+
+Similarly update VRAM queries:
+
+```rust
+// Before
+let free_vram = crate::device::free_vram_bytes(0);
+
+// After
+let free_vram = crate::device::free_vram_bytes(self.base.gpu_ordinal);
+```
+
+Files to update:
+- `flux/pipeline.rs`
+- `sd15/pipeline.rs`
+- `sdxl/pipeline.rs`
+- `sd3/pipeline.rs`
+- `zimage/pipeline.rs`
+- `flux2/pipeline.rs`
+- `qwen_image/pipeline.rs`
+- `wuerstchen/pipeline.rs`
+- `ltx_video/pipeline.rs`
+- `upscaler/engine.rs`
+
+- [ ] **Step 4: Update expand.rs**
+
+In `expand.rs` (~line 118), the `LocalExpander` needs an ordinal. Add `gpu_ordinal: usize` field and use it:
+
+```rust
+let device = crate::device::create_device(self.gpu_ordinal, &progress)?;
+```
+
+- [ ] **Step 5: Update all factory callers**
+
+Search for `create_engine(` and `create_engine_with_pool(` across the workspace. Update callers to pass `gpu_ordinal`. Callers that don't yet have a real ordinal (server code — updated in Task 4+) should pass `0` temporarily.
+
+Key callers:
+- `crates/mold-server/src/lib.rs` (~line 78-85)
+- `crates/mold-server/src/model_manager.rs` (~line 354-444)
+- `crates/mold-cli/src/commands/generate.rs` (local mode)
+
+- [ ] **Step 6: Verify compilation**
+
+Run: `cargo check --workspace`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -u
+git commit -m "feat(inference): thread gpu_ordinal through EngineBase, factory, and all engine pipelines"
+```
+
+---
+
+## Task 4: GpuPool & GpuWorker (mold-server)
+
+**Files:**
+- Create: `crates/mold-server/src/gpu_pool.rs`
+- Create: `crates/mold-server/src/gpu_worker.rs`
+- Modify: `crates/mold-server/src/model_cache.rs`
+
+Depends on: Task 1, Task 2
+
+- [ ] **Step 1: Add remove() to ModelCache for take-and-restore**
+
+In `model_cache.rs`, add a `remove()` method that takes an engine out of the cache without dropping it:
+
+```rust
+/// Remove an engine from the cache, returning it.
+/// Used by take-and-restore pattern: remove before inference, re-insert after.
+pub fn take(&mut self, model_name: &str) -> Option<CachedEngine> {
+    if let Some(entry) = self.entries.remove(model_name) {
+        self.lru_order.retain(|n| n != model_name);
+        Some(entry)
+    } else {
+        None
+    }
+}
+
+/// Re-insert a taken engine after inference completes.
+pub fn restore(&mut self, cached: CachedEngine) {
+    let name = cached.model_name.clone();
+    self.lru_order.push(name.clone());
+    self.entries.insert(name, cached);
+}
+```
+
+- [ ] **Step 2: Create gpu_pool.rs with GpuWorker and GpuPool**
+
+```rust
+use crate::model_cache::{ModelCache, ModelResidency};
+use mold_core::types::{GpuWorkerState, GpuWorkerStatus};
+use mold_inference::device::DiscoveredGpu;
+use mold_inference::shared_pool::SharedPool;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, RwLock};
+use std::time::Instant;
+
+pub struct GpuWorker {
+    pub gpu: DiscoveredGpu,
+    pub model_cache: Arc<Mutex<ModelCache>>,
+    pub active_generation: Arc<RwLock<Option<ActiveGeneration>>>,
+    pub model_load_lock: Arc<Mutex<()>>,
+    pub shared_pool: Arc<Mutex<SharedPool>>,
+    pub in_flight: AtomicUsize,
+    pub consecutive_failures: AtomicUsize,
+    pub degraded_until: RwLock<Option<Instant>>,
+    pub job_tx: std::sync::mpsc::SyncSender<GpuJob>,
+}
+
+#[derive(Debug)]
+pub struct ActiveGeneration {
+    pub model: String,
+    pub started_at: Instant,
+}
+
+pub struct GpuJob {
+    pub model: String,
+    pub request: mold_core::GenerateRequest,
+    pub progress_tx: Option<tokio::sync::mpsc::Sender<mold_inference::ProgressEvent>>,
+    pub result_tx: tokio::sync::oneshot::Sender<anyhow::Result<mold_core::GenerateResponse>>,
+    pub output_dir: Option<std::path::PathBuf>,
+    pub config: Arc<tokio::sync::RwLock<mold_core::Config>>,
+}
+
+pub struct GpuPool {
+    pub workers: Vec<Arc<GpuWorker>>,
+}
+
+impl GpuWorker {
+    pub fn is_degraded(&self) -> bool {
+        if self.consecutive_failures.load(Ordering::SeqCst) < 3 {
+            return false;
+        }
+        match *self.degraded_until.read().unwrap() {
+            Some(until) => Instant::now() < until,
+            None => false,
+        }
+    }
+
+    pub fn status(&self) -> GpuWorkerStatus {
+        let cache = self.model_cache.lock().unwrap();
+        let loaded_model = cache.active_model().map(|s| s.to_string());
+        let active_gen = self.active_generation.read().unwrap();
+
+        let state = if self.is_degraded() {
+            GpuWorkerState::Degraded
+        } else if active_gen.is_some() {
+            GpuWorkerState::Generating
+        } else {
+            GpuWorkerState::Idle
+        };
+
+        GpuWorkerStatus {
+            ordinal: self.gpu.ordinal,
+            name: self.gpu.name.clone(),
+            vram_total_bytes: self.gpu.total_vram_bytes,
+            vram_used_bytes: mold_inference::device::vram_used_estimate(self.gpu.ordinal),
+            loaded_model,
+            state,
+        }
+    }
+}
+
+impl GpuPool {
+    /// Find the worker that already has this model loaded on GPU
+    pub fn find_loaded(&self, model_name: &str) -> Option<Arc<GpuWorker>> {
+        let mut candidates: Vec<_> = self.workers.iter()
+            .filter(|w| {
+                let cache = w.model_cache.lock().unwrap();
+                cache.get(model_name)
+                    .map(|e| e.residency == ModelResidency::Gpu)
+                    .unwrap_or(false)
+            })
+            .collect();
+
+        // Prefer least in-flight if multiple have it
+        candidates.sort_by_key(|w| w.in_flight.load(Ordering::SeqCst));
+        candidates.into_iter().next().cloned()
+    }
+
+    /// Select the best worker for a model that needs loading
+    pub fn select_worker(&self, model_name: &str, estimated_vram: u64) -> Option<Arc<GpuWorker>> {
+        // 1. Already loaded on a GPU?
+        if let Some(w) = self.find_loaded(model_name) {
+            return Some(w);
+        }
+
+        // 2. Find idle (no GPU-resident model) workers, skip degraded
+        let mut idle: Vec<_> = self.workers.iter()
+            .filter(|w| {
+                if w.is_degraded() { return false; }
+                let cache = w.model_cache.lock().unwrap();
+                cache.active_model().is_none()
+            })
+            .collect();
+
+        if !idle.is_empty() {
+            // VRAM-fit tiebreaker: smallest GPU that fits
+            idle.sort_by_key(|w| w.gpu.total_vram_bytes);
+            if let Some(w) = idle.iter().find(|w| w.gpu.total_vram_bytes >= estimated_vram) {
+                return Some((*w).clone());
+            }
+            // No idle GPU fits — pick the largest idle GPU anyway (eviction will help)
+            return idle.last().cloned();
+        }
+
+        // 3. All GPUs busy — evict LRU on the GPU with most headroom
+        let mut busy: Vec<_> = self.workers.iter()
+            .filter(|w| !w.is_degraded())
+            .collect();
+        busy.sort_by(|a, b| {
+            let a_headroom = a.gpu.total_vram_bytes.saturating_sub(estimated_vram);
+            let b_headroom = b.gpu.total_vram_bytes.saturating_sub(estimated_vram);
+            b_headroom.cmp(&a_headroom) // most headroom first
+        });
+        busy.into_iter().next().cloned()
+    }
+
+    pub fn gpu_status(&self) -> Vec<GpuWorkerStatus> {
+        self.workers.iter().map(|w| w.status()).collect()
+    }
+
+    pub fn worker_count(&self) -> usize {
+        self.workers.len()
+    }
+}
+```
+
+- [ ] **Step 3: Create gpu_worker.rs with dedicated OS thread worker loop**
+
+```rust
+use crate::gpu_pool::{ActiveGeneration, GpuJob, GpuWorker};
+use crate::model_cache::ModelResidency;
+use mold_inference::device;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+/// Spawn the dedicated OS thread for a GPU worker.
+/// Returns the JoinHandle (caller should keep it alive).
+pub fn spawn_gpu_thread(
+    worker: Arc<GpuWorker>,
+    job_rx: std::sync::mpsc::Receiver<GpuJob>,
+) -> std::thread::JoinHandle<()> {
+    std::thread::Builder::new()
+        .name(format!("gpu-worker-{}", worker.gpu.ordinal))
+        .spawn(move || {
+            tracing::info!(gpu = worker.gpu.ordinal, name = %worker.gpu.name, "GPU worker thread started");
+            for job in job_rx.iter() {
+                process_job(&worker, job);
+            }
+            tracing::info!(gpu = worker.gpu.ordinal, "GPU worker thread exiting");
+        })
+        .expect("failed to spawn GPU worker thread")
+}
+
+fn process_job(worker: &GpuWorker, job: GpuJob) {
+    let model_name = job.model.clone();
+    let ordinal = worker.gpu.ordinal;
+
+    // Acquire per-GPU load lock
+    let _load_lock = worker.model_load_lock.lock().unwrap();
+
+    // Ensure model is loaded on this GPU
+    if let Err(e) = ensure_model_ready_sync(worker, &model_name, &job) {
+        tracing::error!(gpu = ordinal, model = %model_name, "Failed to load model: {e}");
+        let _ = job.result_tx.send(Err(e));
+        worker.in_flight.fetch_sub(1, Ordering::SeqCst);
+        record_failure(worker);
+        return;
+    }
+
+    // Set active generation
+    {
+        let mut gen = worker.active_generation.write().unwrap();
+        *gen = Some(ActiveGeneration {
+            model: model_name.clone(),
+            started_at: Instant::now(),
+        });
+    }
+
+    // Take-and-restore: remove engine from cache, release lock during inference
+    let taken = {
+        let mut cache = worker.model_cache.lock().unwrap();
+        cache.take(&model_name)
+    };
+
+    let Some(mut cached_engine) = taken else {
+        let _ = job.result_tx.send(Err(anyhow::anyhow!("Engine not found in cache after load")));
+        worker.in_flight.fetch_sub(1, Ordering::SeqCst);
+        clear_active_generation(worker);
+        return;
+    };
+
+    // Set progress callback if SSE streaming
+    if let Some(ref progress_tx) = job.progress_tx {
+        let tx = progress_tx.clone();
+        cached_engine.engine.set_on_progress(Arc::new(move |event| {
+            let _ = tx.blocking_send(event);
+        }));
+    }
+
+    // Run inference — cache mutex is FREE during this
+    let result = cached_engine.engine.generate(&job.request);
+
+    // Clear progress callback
+    cached_engine.engine.clear_on_progress();
+
+    // Restore engine to cache
+    {
+        let mut cache = worker.model_cache.lock().unwrap();
+        cache.restore(cached_engine);
+    }
+
+    // Clear active generation
+    clear_active_generation(worker);
+
+    // Update health tracking
+    match &result {
+        Ok(_) => {
+            worker.consecutive_failures.store(0, Ordering::SeqCst);
+        }
+        Err(e) => {
+            tracing::warn!(gpu = ordinal, model = %model_name, "Generation failed: {e}");
+            record_failure(worker);
+        }
+    }
+
+    // Decrement in-flight and send result
+    worker.in_flight.fetch_sub(1, Ordering::SeqCst);
+
+    // Attach GPU ordinal to response
+    let result = result.map(|mut resp| {
+        resp.gpu = Some(ordinal);
+        resp
+    });
+
+    let _ = job.result_tx.send(result);
+}
+
+fn ensure_model_ready_sync(
+    worker: &GpuWorker,
+    model_name: &str,
+    job: &GpuJob,
+) -> anyhow::Result<()> {
+    let mut cache = worker.model_cache.lock().unwrap();
+
+    // Already loaded?
+    if let Some(entry) = cache.get(model_name) {
+        if entry.residency == ModelResidency::Gpu {
+            return Ok(());
+        }
+    }
+
+    // Need to load — unload active model first
+    cache.unload_active();
+    drop(cache);
+
+    // Reclaim GPU memory
+    device::reclaim_gpu_memory(worker.gpu.ordinal);
+
+    // Create and load engine
+    let config = job.config.blocking_read();
+    let mut engine = mold_inference::create_engine_with_pool(
+        model_name,
+        &config,
+        mold_inference::engine::LoadStrategy::default(),
+        worker.gpu.ordinal,
+        Some(worker.shared_pool.clone()),
+        false, // offload
+        None, None, None, None, // variant overrides
+    )?;
+    drop(config);
+
+    engine.load()?;
+
+    let vram = device::vram_used_estimate(worker.gpu.ordinal);
+
+    let mut cache = worker.model_cache.lock().unwrap();
+    cache.insert_loaded(model_name.to_string(), engine, vram);
+
+    Ok(())
+}
+
+fn record_failure(worker: &GpuWorker) {
+    let failures = worker.consecutive_failures.fetch_add(1, Ordering::SeqCst) + 1;
+    if failures >= 3 {
+        let mut degraded = worker.degraded_until.write().unwrap();
+        *degraded = Some(Instant::now() + Duration::from_secs(60));
+        tracing::warn!(
+            gpu = worker.gpu.ordinal,
+            "GPU marked degraded after {failures} consecutive failures (60s cooldown)"
+        );
+    }
+}
+
+fn clear_active_generation(worker: &GpuWorker) {
+    let mut gen = worker.active_generation.write().unwrap();
+    *gen = None;
+}
+```
+
+- [ ] **Step 4: Register new modules**
+
+In `crates/mold-server/src/lib.rs`, add:
+
+```rust
+pub mod gpu_pool;
+pub mod gpu_worker;
+```
+
+- [ ] **Step 5: Verify compilation**
+
+Run: `cargo check -p mold-ai-server`
+Expected: May have issues due to AppState not yet updated — that's Task 5. Verify at least the new modules parse correctly.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/mold-server/src/gpu_pool.rs crates/mold-server/src/gpu_worker.rs crates/mold-server/src/model_cache.rs crates/mold-server/src/lib.rs
+git commit -m "feat(server): add GpuPool, GpuWorker, and GPU worker thread with take-and-restore pattern"
+```
+
+---
+
+## Task 5: AppState Refactor & Server Startup (mold-server)
+
+**Files:**
+- Modify: `crates/mold-server/src/state.rs`
+- Modify: `crates/mold-server/src/lib.rs`
+
+Depends on: Task 4
+
+- [ ] **Step 1: Refactor AppState**
+
+In `state.rs`, replace the single-GPU fields with GpuPool. Keep fields that are genuinely global (config, pull_lock, etc.):
+
+```rust
+pub struct AppState {
+    pub gpu_pool: Arc<GpuPool>,
+    pub config: Arc<tokio::sync::RwLock<Config>>,
+    pub queue_tx: tokio::sync::mpsc::Sender<QueuedRequest>,
+    pub pull_lock: Arc<tokio::sync::Mutex<()>>,
+    pub shared_pool: Arc<std::sync::Mutex<SharedPool>>,
+    pub startup_time: Instant,
+    pub queue_capacity: usize,
+    // ... keep other global fields (shutdown_tx, etc.)
+}
+```
+
+Remove: `model_cache`, `engine_snapshot`, `model_load_lock`, `active_generation`, `upscaler_cache` — these now live in GpuWorker.
+
+- [ ] **Step 2: Update AppState constructors**
+
+Replace `AppState::new()` and `AppState::empty()` with a unified constructor that builds the GpuPool:
+
+```rust
+impl AppState {
+    pub fn new(
+        config: Config,
+        gpu_selection: &GpuSelection,
+        queue_size: usize,
+        shared_pool: Arc<std::sync::Mutex<SharedPool>>,
+    ) -> anyhow::Result<(Self, Vec<std::thread::JoinHandle<()>>)> {
+        let discovered = mold_inference::device::discover_gpus();
+        let selected = mold_inference::device::filter_gpus(&discovered, gpu_selection);
+
+        if selected.is_empty() && !discovered.is_empty() {
+            anyhow::bail!("No GPUs matched selection {:?} (discovered: {:?})", gpu_selection, discovered);
+        }
+
+        let mut workers = Vec::new();
+        let mut thread_handles = Vec::new();
+
+        for gpu in &selected {
+            let (job_tx, job_rx) = std::sync::mpsc::sync_channel(queue_size);
+            let worker = Arc::new(GpuWorker {
+                gpu: gpu.clone(),
+                model_cache: Arc::new(Mutex::new(ModelCache::new(3))),
+                active_generation: Arc::new(RwLock::new(None)),
+                model_load_lock: Arc::new(Mutex::new(())),
+                shared_pool: shared_pool.clone(),
+                in_flight: AtomicUsize::new(0),
+                consecutive_failures: AtomicUsize::new(0),
+                degraded_until: RwLock::new(None),
+                job_tx,
+            });
+
+            let handle = gpu_worker::spawn_gpu_thread(worker.clone(), job_rx);
+            thread_handles.push(handle);
+            workers.push(worker);
+        }
+
+        let gpu_pool = Arc::new(GpuPool { workers });
+
+        // ... construct AppState with gpu_pool, return (state, thread_handles)
+    }
+}
+```
+
+- [ ] **Step 3: Update server startup in lib.rs**
+
+In `run_server()` (~line 29-210), replace the existing engine creation + AppState construction with GpuPool initialization:
+
+```rust
+pub async fn run_server(config: Config, gpu_selection: GpuSelection, queue_size: usize) -> anyhow::Result<()> {
+    let shared_pool = Arc::new(std::sync::Mutex::new(SharedPool::new()));
+
+    let (state, _gpu_threads) = AppState::new(
+        config,
+        &gpu_selection,
+        queue_size,
+        shared_pool,
+    )?;
+
+    // Log discovered GPUs
+    for status in state.gpu_pool.gpu_status() {
+        tracing::info!(
+            gpu = status.ordinal,
+            name = %status.name,
+            vram_mb = status.vram_total_bytes / 1_000_000,
+            "GPU worker ready"
+        );
+    }
+
+    // ... rest of server setup (router, middleware, bind, serve) stays the same
+}
+```
+
+- [ ] **Step 4: Verify compilation**
+
+Run: `cargo check -p mold-ai-server`
+Expected: Errors in routes.rs, queue.rs, model_manager.rs — they still reference old AppState fields. That's expected; Tasks 6-7 fix those.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/mold-server/src/state.rs crates/mold-server/src/lib.rs
+git commit -m "feat(server): refactor AppState to use GpuPool, multi-GPU server startup"
+```
+
+---
+
+## Task 6: Queue Dispatcher (mold-server)
+
+**Files:**
+- Modify: `crates/mold-server/src/queue.rs`
+
+Depends on: Task 4, Task 5
+
+- [ ] **Step 1: Refactor queue to multi-GPU dispatch**
+
+Replace the single-threaded `run_queue_worker()` with a dispatcher that routes to GPU worker threads:
+
+```rust
+pub async fn run_queue_dispatcher(
+    mut job_rx: tokio::sync::mpsc::Receiver<QueuedRequest>,
+    state: Arc<AppState>,
+) {
+    while let Some(request) = job_rx.recv().await {
+        let model_name = &request.model;
+
+        // Estimate VRAM for placement
+        let estimated_vram = {
+            let config = state.config.read().await;
+            estimate_model_vram(model_name, &config)
+        };
+
+        // Select worker via placement strategy
+        let worker = match state.gpu_pool.select_worker(model_name, estimated_vram) {
+            Some(w) => w,
+            None => {
+                tracing::error!(model = %model_name, "No GPU available for model");
+                let _ = request.result_tx.send(Err(anyhow::anyhow!(
+                    "No GPU available for model {model_name}"
+                )));
+                continue;
+            }
+        };
+
+        // Increment in-flight BEFORE sending to worker (prevents TOCTOU)
+        worker.in_flight.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
+        // Build GpuJob
+        let job = GpuJob {
+            model: model_name.to_string(),
+            request: request.generate_request,
+            progress_tx: request.progress_tx,
+            result_tx: request.result_tx,
+            output_dir: request.output_dir,
+            config: state.config.clone(),
+        };
+
+        // Dispatch to worker's dedicated thread
+        if worker.job_tx.try_send(job).is_err() {
+            worker.in_flight.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+            tracing::warn!(gpu = worker.gpu.ordinal, "GPU worker channel full");
+            // Job is lost here — the result_tx was moved into the job
+            // This shouldn't happen if queue_size is configured properly
+        }
+    }
+}
+
+fn estimate_model_vram(model_name: &str, config: &mold_core::Config) -> u64 {
+    // Use manifest metadata for estimation
+    mold_inference::device::estimate_peak_memory_by_name(model_name, config)
+        .unwrap_or(8_000_000_000) // 8GB default fallback
+}
+```
+
+- [ ] **Step 2: Update queue spawn in lib.rs**
+
+Replace the old `run_queue_worker` spawn with:
+
+```rust
+tokio::spawn(queue::run_queue_dispatcher(job_rx, state.clone()));
+```
+
+- [ ] **Step 3: Verify compilation**
+
+Run: `cargo check -p mold-ai-server`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/mold-server/src/queue.rs crates/mold-server/src/lib.rs
+git commit -m "feat(server): multi-GPU queue dispatcher with TOCTOU-safe in-flight tracking"
+```
+
+---
+
+## Task 7: API Routes Update (mold-server)
+
+**Files:**
+- Modify: `crates/mold-server/src/routes.rs`
+
+Depends on: Task 5, Task 6
+
+- [ ] **Step 1: Update server_status() endpoint**
+
+Replace the existing status handler (~line 1055-1095) to use GpuPool:
+
+```rust
+async fn server_status(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let gpu_statuses = state.gpu_pool.gpu_status();
+    let models_loaded: Vec<String> = gpu_statuses.iter()
+        .filter_map(|g| g.loaded_model.clone())
+        .collect();
+    let busy = gpu_statuses.iter().any(|g| g.state == GpuWorkerState::Generating);
+
+    let status = ServerStatus {
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        models_loaded: models_loaded.clone(),
+        model: models_loaded.first().cloned(), // backwards compat
+        busy,
+        current_generation: None, // aggregated from workers if needed
+        gpu_info: gpu_statuses.first().map(|g| GpuInfo {
+            name: g.name.clone(),
+            vram_total_mb: (g.vram_total_bytes / 1_000_000) as u32,
+            vram_used_mb: (g.vram_used_bytes / 1_000_000) as u32,
+        }),
+        uptime_secs: Some(state.startup_time.elapsed().as_secs()),
+        gpus: Some(gpu_statuses),
+        queue_depth: Some(0), // TODO: track queue depth
+        queue_capacity: Some(state.queue_capacity),
+    };
+
+    Json(status)
+}
+```
+
+- [ ] **Step 2: Update load_model() endpoint**
+
+Add optional `gpu` field to the load request body:
+
+```rust
+#[derive(Deserialize)]
+struct LoadModelRequest {
+    model: String,
+    #[serde(default)]
+    gpu: Option<usize>,
+}
+```
+
+Route to specific GPU if requested, otherwise let placement strategy decide.
+
+- [ ] **Step 3: Update unload_model() endpoint**
+
+Accept optional `model` or `gpu` field:
+
+```rust
+#[derive(Deserialize)]
+struct UnloadRequest {
+    #[serde(default)]
+    model: Option<String>,
+    #[serde(default)]
+    gpu: Option<usize>,
+}
+```
+
+If model specified, find which worker has it and unload. If gpu specified, unload that worker. If neither, unload all.
+
+- [ ] **Step 4: Add queue-full 503 response**
+
+In the generate endpoint, when the queue channel is full, return:
+
+```rust
+(StatusCode::SERVICE_UNAVAILABLE, Json(json!({
+    "error": "Queue full — all GPUs busy",
+    "queue_size": state.queue_capacity,
+    "active_gpus": state.gpu_pool.worker_count(),
+})))
+```
+
+- [ ] **Step 5: Verify compilation**
+
+Run: `cargo check -p mold-ai-server`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/mold-server/src/routes.rs
+git commit -m "feat(server): multi-GPU status, load/unload, and queue-full 503 endpoints"
+```
+
+---
+
+## Task 8: CLI Flags & Display (mold-cli)
+
+**Files:**
+- Modify: `crates/mold-cli/src/main.rs`
+- Modify: `crates/mold-cli/src/commands/generate.rs`
+- Modify: `crates/mold-cli/src/commands/ps.rs`
+
+Depends on: Task 1, Task 2
+
+- [ ] **Step 1: Add --gpus and --queue-size flags to serve command**
+
+In the serve command args:
+
+```rust
+/// Comma-separated GPU ordinals to use (default: all)
+#[arg(long, env = "MOLD_GPUS")]
+gpus: Option<String>,
+
+/// Max queued requests before 503 (default: 200)
+#[arg(long, env = "MOLD_QUEUE_SIZE", default_value = "200")]
+queue_size: usize,
+```
+
+Parse `--gpus` into `GpuSelection`:
+
+```rust
+let gpu_selection = match &args.gpus {
+    Some(s) => GpuSelection::parse(s)?,
+    None => config.gpu_selection(),
+};
+```
+
+Pass to `run_server()`.
+
+- [ ] **Step 2: Add --gpus flag to run command for local mode**
+
+```rust
+/// Comma-separated GPU ordinals to use for local generation (default: all)
+#[arg(long, env = "MOLD_GPUS")]
+gpus: Option<String>,
+```
+
+In `generate_local()`, use `select_best_gpu()`:
+
+```rust
+let gpu_selection = match &args.gpus {
+    Some(s) => GpuSelection::parse(s)?,
+    None => config.gpu_selection(),
+};
+let gpus = discover_gpus();
+let available = filter_gpus(&gpus, &gpu_selection);
+let best = select_best_gpu(&available).unwrap_or_else(|| {
+    // Fallback to ordinal 0
+    &DiscoveredGpu { ordinal: 0, name: "default".into(), total_vram_bytes: 0, free_vram_bytes: 0 }
+});
+// Pass best.ordinal to create_engine_with_pool()
+```
+
+- [ ] **Step 3: Update mold ps display for multi-GPU**
+
+In the ps command, parse the new `gpus` array from `ServerStatus`:
+
+```rust
+if let Some(gpus) = &status.gpus {
+    for gpu in gpus {
+        let model = gpu.loaded_model.as_deref().unwrap_or("(none)");
+        let state_str = match gpu.state {
+            GpuWorkerState::Generating => "[generating]",
+            GpuWorkerState::Idle => "[idle]",
+            GpuWorkerState::Loading => "[loading]",
+            GpuWorkerState::Degraded => "[degraded]",
+        };
+        let vram_used_gb = gpu.vram_used_bytes as f64 / 1e9;
+        let vram_total_gb = gpu.vram_total_bytes as f64 / 1e9;
+        println!(
+            "GPU {} ({}, {:.0}GB):  {:<20} {}  VRAM: {:.1}/{:.1} GB",
+            gpu.ordinal, gpu.name, vram_total_gb, model, state_str, vram_used_gb, vram_total_gb
+        );
+    }
+    if let (Some(depth), Some(capacity)) = (status.queue_depth, status.queue_capacity) {
+        println!("Queue: {}/{}", depth, capacity);
+    }
+}
+```
+
+- [ ] **Step 4: Verify compilation**
+
+Run: `cargo check -p mold-ai`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/mold-cli/
+git commit -m "feat(cli): add --gpus and --queue-size flags, multi-GPU ps display"
+```
+
+---
+
+## Task 9: Full Workspace Compilation & Tests
+
+**Files:** All
+
+Depends on: All previous tasks
+
+- [ ] **Step 1: Full workspace check**
+
+Run: `cargo check --workspace`
+Fix any remaining compilation errors across crate boundaries.
+
+- [ ] **Step 2: Run existing tests**
+
+Run: `cargo test --workspace`
+All existing tests must pass. Fix any breakage caused by the new ordinal parameters.
+
+- [ ] **Step 3: Run clippy**
+
+Run: `cargo clippy --workspace -- -D warnings`
+Fix all warnings.
+
+- [ ] **Step 4: Run fmt**
+
+Run: `cargo fmt --all`
+
+- [ ] **Step 5: Commit any fixes**
+
+```bash
+git add -u
+git commit -m "fix: resolve compilation errors and test failures from multi-GPU refactor"
+```
+
+---
+
+## Task 10: Integration Verification
+
+**Files:** None (testing only)
+
+Depends on: Task 9
+
+- [ ] **Step 1: Verify single-GPU backwards compat**
+
+On a single-GPU machine, start the server with no `--gpus` flag:
+```bash
+cargo run -p mold-ai -- serve
+```
+Verify `GET /api/status` returns a `gpus` array with one entry and the existing `model` field still populated.
+
+- [ ] **Step 2: Verify --gpus flag parsing**
+
+```bash
+MOLD_GPUS=0 cargo run -p mold-ai -- serve
+```
+Should start with only GPU 0.
+
+- [ ] **Step 3: Verify mold ps output**
+
+```bash
+cargo run -p mold-ai -- ps
+```
+Should show per-GPU status lines.
+
+- [ ] **Step 4: Verify queue-full 503**
+
+Send 201+ concurrent requests to a server with `--queue-size 200`. The 201st should get a 503.
+
+- [ ] **Step 5: Final commit**
+
+```bash
+git add -u
+git commit -m "feat: multi-GPU support with per-GPU worker pool and smart placement"
+```
+
+---
+
+## Dependency Graph
+
+```
+Task 1 (core types) ──┬──► Task 2 (device.rs) ──► Task 3 (engine ordinal)
+                       │                                    │
+                       ├──► Task 4 (GpuPool) ◄─────────────┘
+                       │         │
+                       │         ▼
+                       │    Task 5 (AppState) ──► Task 6 (queue) ──► Task 7 (routes)
+                       │
+                       └──► Task 8 (CLI flags)
+                                                                         │
+                                                              Task 9 (compile) ◄──┘
+                                                                   │
+                                                              Task 10 (verify)
+```
+
+**Parallelizable:** Tasks 1→2→3 can run in parallel with nothing. Tasks 4 and 8 can start as soon as Tasks 1+2 complete. Task 5 needs 4. Tasks 6+7 need 5. Task 9 is the join point.

--- a/docs/superpowers/specs/2026-04-08-multi-gpu-support-design.md
+++ b/docs/superpowers/specs/2026-04-08-multi-gpu-support-design.md
@@ -98,13 +98,19 @@ All existing VRAM functions (`free_vram_bytes`, `vram_used_estimate`, `reclaim_g
 pub struct GpuWorker {
     pub gpu: GpuInfo,
     pub model_cache: Arc<Mutex<ModelCache>>,
-    pub engine_snapshot: Arc<RwLock<EngineSnapshot>>,
+    pub active_generation: Arc<RwLock<Option<ActiveGenerationSnapshot>>>,  // Per-GPU (not global)
     pub model_load_lock: Arc<Mutex<()>>,
-    pub shared_pool: Arc<Mutex<SharedPool>>,  // Shared across all workers
+    pub shared_pool: Arc<Mutex<SharedPool>>,           // Shared across all workers
+    pub upscaler_cache: Arc<std::sync::Mutex<Option<Box<dyn UpscaleEngine>>>>,  // Per-GPU
+    pub in_flight: AtomicUsize,                        // Dispatch-time job tracking
+    pub consecutive_failures: AtomicUsize,             // Health tracking
+    pub degraded_until: Arc<RwLock<Option<Instant>>>,  // Deprioritize after repeated failures
 }
 ```
 
 Each worker gets its own `ModelCache` instance (existing LRU type). The `SharedPool` for tokenizer caching is shared across all workers since tokenizers are CPU-side and read-only after init.
+
+**Note:** The existing global `EngineSnapshot` is eliminated. Per-GPU active generation state is tracked via `active_generation` on each worker. `GpuPool.gpu_status()` aggregates across all workers for status API responses.
 
 ### GpuPool
 
@@ -127,6 +133,10 @@ impl GpuPool {
 3. **Evict LRU** — All GPUs busy. Pick the GPU where the model fits with the most headroom after evicting its LRU model.
 4. **Doesn't fit** — Return error (model too large for any available GPU).
 
+**Degraded workers:** Skip workers with `consecutive_failures >= 3` unless `Instant::now() > degraded_until` (60-second cooldown). On successful generation, reset `consecutive_failures` to 0.
+
+**VRAM estimates:** `select_worker()` uses `CachedEngine.vram_bytes` for previously-loaded models (exact, measured post-load). For models not yet loaded, uses `estimate_peak_memory()` from manifest metadata as fallback.
+
 ### AppState Changes
 
 ```rust
@@ -145,27 +155,81 @@ Existing `model_manager.rs` functions refactored to operate on a specific `GpuWo
 
 ## 3. Queue & Concurrency
 
+### CUDA Threading Model
+
+CUDA contexts are thread-local. Using `tokio::spawn_blocking` would share OS threads across GPU workers, causing CUDA context-switching overhead or worse. Each `GpuWorker` owns a **dedicated OS thread** (via `std::thread::spawn`) with a bounded work channel:
+
+```rust
+// During GpuPool initialization, each worker spawns a dedicated thread:
+let (tx, rx) = std::sync::mpsc::sync_channel::<GpuJob>(queue_size);
+
+std::thread::Builder::new()
+    .name(format!("gpu-worker-{}", gpu.ordinal))
+    .spawn(move || {
+        // This thread owns the CUDA context for this GPU ordinal.
+        // All model loads and inference run here — no context switching.
+        for job in rx.iter() {
+            let result = process_job(&worker, job);
+            // result sent back via job.response_tx
+        }
+    })?;
+```
+
+This ensures each GPU's CUDA context lives on exactly one OS thread for its entire lifetime. No context push/pop overhead, no cross-GPU interference.
+
 ### Multi-GPU Dispatch
 
-The queue becomes a dispatcher. Multiple jobs run concurrently (one per GPU):
+The async dispatch loop routes jobs to GPU worker threads:
 
 ```rust
 loop {
     let job = queue.recv().await;
     let worker = gpu_pool.select_worker(&job.model, estimated_vram)?;
 
-    tokio::spawn(async move {
-        let _lock = worker.model_load_lock.lock().await;
-        ensure_model_ready(worker, &job.model).await?;
+    // Increment in-flight BEFORE dispatch to prevent TOCTOU race.
+    // Under burst load, multiple select_worker() calls see accurate counts.
+    worker.in_flight.fetch_add(1, Ordering::SeqCst);
 
-        let result = tokio::task::spawn_blocking(move || {
-            let mut cache = worker.model_cache.blocking_lock();
-            let engine = cache.get_mut(&job.model).unwrap();
-            engine.generate(&job.request)
-        }).await?;
+    // Send to the worker's dedicated OS thread
+    if worker.job_tx.try_send(job).is_err() {
+        worker.in_flight.fetch_sub(1, Ordering::SeqCst);
+        job.response_tx.send(Err(anyhow!("GPU {} busy")));
+    }
+}
 
-        job.response_tx.send(result);
-    });
+// Inside each GPU worker thread's process_job():
+fn process_job(worker: &GpuWorker, job: GpuJob) {
+    let _lock = worker.model_load_lock.lock().unwrap();
+    ensure_model_ready(worker, &job.model)?;
+
+    // Take-and-restore: release cache lock during inference
+    let mut engine = {
+        let mut cache = worker.model_cache.lock().unwrap();
+        cache.remove(&job.model).unwrap()
+    };
+    // Cache mutex is now FREE — status queries, model list, etc. proceed unblocked
+
+    let result = engine.generate(&job.request);
+
+    // Restore engine to cache
+    {
+        let mut cache = worker.model_cache.lock().unwrap();
+        cache.insert(job.model.clone(), engine, vram_bytes);
+    }
+
+    // Update health tracking
+    match &result {
+        Ok(_) => worker.consecutive_failures.store(0, Ordering::SeqCst),
+        Err(_) => {
+            let failures = worker.consecutive_failures.fetch_add(1, Ordering::SeqCst) + 1;
+            if failures >= 3 {
+                *worker.degraded_until.write().unwrap() = Some(Instant::now() + Duration::from_secs(60));
+            }
+        }
+    }
+
+    worker.in_flight.fetch_sub(1, Ordering::SeqCst);
+    job.response_tx.send(result);
 }
 ```
 
@@ -191,7 +255,7 @@ Includes `Retry-After` header.
 
 ### In-Flight Tracking
 
-Track active jobs per GPU for placement tiebreaking. When multiple GPUs have the same model loaded, prefer the one with fewer in-flight requests.
+Each `GpuWorker` has an `in_flight: AtomicUsize` counter incremented atomically at dispatch time (before the job is sent to the worker thread) and decremented after the job completes. This prevents the TOCTOU race where burst loads all see the same stale state and route to the same GPU. The placement strategy reads `in_flight` to prefer the least-loaded GPU when multiple have the requested model.
 
 ### SSE Streaming
 
@@ -343,10 +407,36 @@ Each engine's `load()` calls `create_device(self.base.gpu_ordinal, ...)`.
 
 ### What Changes
 
-- `device.rs`: all functions take ordinal parameter
+- `device.rs`: all functions take ordinal parameter; `reclaim_gpu_memory(ordinal)` resets only the specified device's primary context
 - `factory.rs`: passes ordinal through to engines
 - `engine_base.rs`: stores `gpu_ordinal`
 - `expand.rs`: accepts ordinal, defaults to least-loaded GPU
+- `upscaler/engine.rs`: `create_upscale_engine()` takes ordinal parameter; per-worker upscaler cache in `GpuWorker`
+
+### `reclaim_gpu_memory(ordinal)`
+
+The current implementation calls `cuDevicePrimaryCtxReset_v2` on device 0, destroying all CUDA state on that device. With multi-GPU, this must be parameterized:
+
+```rust
+pub fn reclaim_gpu_memory(ordinal: usize) {
+    // Reset only the specified device's primary context.
+    // Safe because the caller holds the per-worker model_load_lock,
+    // guaranteeing exclusive access to this GPU during model swaps.
+    let cu_device = CudaDevice::new(ordinal);
+    unsafe { sys::cuDevicePrimaryCtxReset_v2(cu_device) }
+}
+```
+
+Must only be called inside the per-worker `model_load_lock` to guarantee no other operation is using that GPU's context.
+
+### Upscaler Handling
+
+The Real-ESRGAN upscaler is a GPU-bound model currently cached globally on `AppState`. With multi-GPU:
+
+- Each `GpuWorker` gets its own `upscaler_cache: Arc<std::sync::Mutex<Option<Box<dyn UpscaleEngine>>>>`
+- `create_upscale_engine()` takes an `ordinal` parameter
+- `/api/upscale` and `/api/upscale/stream` requests route through `GpuPool` with least-busy GPU preference
+- No changes to the upscale request API — server decides GPU placement
 
 ### What Doesn't Change
 
@@ -363,9 +453,9 @@ Each engine's `load()` calls `create_device(self.base.gpu_ordinal, ...)`.
 
 | Crate | Changes |
 |-------|---------|
-| `mold-core` | `GpuInfo`, `GpuSelection`, `GpuStatus` types. `ServerStatus` updated with `gpus` array. `GenerateResponse` gets `gpu` field. Config gets `gpus` and `queue_size`. |
-| `mold-inference` | `device.rs` overhaul (ordinal params, `discover_gpus()`). `EngineBase` gets `gpu_ordinal`. Factory passes ordinal. `expand.rs` ordinal-aware. |
-| `mold-server` | `GpuPool`, `GpuWorker` structs. `AppState` refactored. Queue becomes multi-GPU dispatcher. Routes updated for new API fields. `model_manager.rs` scoped to per-worker. |
+| `mold-core` | `GpuInfo`, `GpuSelection`, `GpuStatus` types. `ServerStatus` updated with `gpus` array, `queue_depth`, `queue_capacity`. `GenerateResponse` gets `gpu` field. Config gets `gpus` and `queue_size`. |
+| `mold-inference` | `device.rs` overhaul (ordinal params, `discover_gpus()`, `reclaim_gpu_memory(ordinal)`). `EngineBase` gets `gpu_ordinal`. Factory passes ordinal. `expand.rs` ordinal-aware. Upscaler engine takes ordinal. |
+| `mold-server` | `GpuPool`, `GpuWorker` structs (with per-worker `active_generation`, `upscaler_cache`, `in_flight`, health tracking). `AppState` refactored — `EngineSnapshot` eliminated. Dedicated OS thread per GPU worker (CUDA context affinity). Queue becomes multi-GPU dispatcher with dispatch-time in-flight tracking. Take-and-restore pattern for cache lock during inference. `model_manager.rs` scoped to per-worker. Routes updated for new API fields including upscale endpoints. |
 | `mold-cli` | `--gpus` and `--queue-size` flags. `mold ps` multi-GPU display. `mold run --local` best-GPU selection. |
 | `mold-discord` | Minor: parse `gpu` field from `GenerateResponse` for display. |
 | `mold-tui` | Minor: display per-GPU status if connected to multi-GPU server. |

--- a/docs/superpowers/specs/2026-04-08-multi-gpu-support-design.md
+++ b/docs/superpowers/specs/2026-04-08-multi-gpu-support-design.md
@@ -1,0 +1,371 @@
+# Multi-GPU Support Design
+
+> Concurrent model placement across multiple GPUs with smart routing and configurable GPU selection.
+
+## Goals
+
+- Automatically discover and use all available GPUs
+- Allow users to select specific GPUs via CLI flag, env var, or config
+- Place models on GPUs intelligently (idle-first, VRAM-fit tiebreaker)
+- Process requests concurrently across GPUs (one generation per GPU at a time)
+- Queue requests with configurable backpressure (default 200)
+- Maintain backwards compatibility for single-GPU setups
+
+## Non-Goals
+
+- Tensor parallelism (sharding a single model across GPUs) — candle lacks NCCL/all-reduce primitives
+- Pipeline parallelism (T5 on GPU 0, transformer on GPU 1 for one model) — future work
+- Cross-GPU batch splitting — each request runs entirely on one GPU
+
+## Architecture: Per-GPU Worker Pool (Approach A)
+
+```
+Request Queue (bounded, 200 default)
+    │
+    ▼
+GpuPool (placement decision)
+    ├──► GpuWorker[0] → ModelCache[0] → Engine on GPU 0
+    ├──► GpuWorker[1] → ModelCache[1] → Engine on GPU 1
+    └──► GpuWorker[2] → ModelCache[2] → Engine on GPU 2
+```
+
+Each GPU gets its own worker with its own `ModelCache`, load lock, and engine snapshot. Workers operate independently — GPU 0 generating doesn't block GPU 1 from loading a model.
+
+---
+
+## 1. GPU Discovery & Configuration
+
+### GpuInfo
+
+```rust
+pub struct GpuInfo {
+    pub ordinal: usize,
+    pub name: String,
+    pub total_vram_bytes: u64,
+    pub free_vram_bytes: u64,
+}
+```
+
+### Discovery
+
+`discover_gpus()` in `device.rs`:
+- CUDA: iterates `cuDeviceGetCount()` → `cuDeviceGetName()` + `cuMemGetInfo()` per ordinal
+- Metal: returns single device (macOS doesn't expose multi-GPU for Metal in practice)
+- CPU: returns empty vec
+
+### Selection
+
+```rust
+pub enum GpuSelection {
+    All,
+    Specific(Vec<usize>),
+}
+```
+
+Parsed from:
+- CLI: `--gpus 0,1,2`
+- Env: `MOLD_GPUS=0,1,2`
+- Config: `gpus = [0, 1, 2]`
+- Omitted: `All` (auto-detect)
+
+Precedence: CLI > env > config > default.
+
+Validates that requested ordinals exist in discovered GPUs.
+
+### create_device() Change
+
+```rust
+// Before
+pub fn create_device(progress: &ProgressReporter) -> Result<Device>
+
+// After
+pub fn create_device(ordinal: usize, progress: &ProgressReporter) -> Result<Device>
+```
+
+All callers updated to pass the ordinal from their assigned GPU.
+
+### VRAM Functions
+
+All existing VRAM functions (`free_vram_bytes`, `vram_used_estimate`, `reclaim_gpu_memory`) take an `ordinal` parameter instead of hardcoding device 0.
+
+---
+
+## 2. GpuPool & GpuWorker
+
+### GpuWorker
+
+```rust
+pub struct GpuWorker {
+    pub gpu: GpuInfo,
+    pub model_cache: Arc<Mutex<ModelCache>>,
+    pub engine_snapshot: Arc<RwLock<EngineSnapshot>>,
+    pub model_load_lock: Arc<Mutex<()>>,
+    pub shared_pool: Arc<Mutex<SharedPool>>,  // Shared across all workers
+}
+```
+
+Each worker gets its own `ModelCache` instance (existing LRU type). The `SharedPool` for tokenizer caching is shared across all workers since tokenizers are CPU-side and read-only after init.
+
+### GpuPool
+
+```rust
+pub struct GpuPool {
+    workers: Vec<GpuWorker>,
+}
+
+impl GpuPool {
+    pub fn select_worker(&self, model_name: &str, estimated_vram: u64) -> Option<&GpuWorker>;
+    pub fn find_loaded(&self, model_name: &str) -> Option<&GpuWorker>;
+    pub fn gpu_status(&self) -> Vec<GpuWorkerStatus>;
+}
+```
+
+### Placement Strategy (in order)
+
+1. **Already loaded** — Check all workers' caches for the model with `Gpu` residency. If found, route there. If multiple GPUs have it, prefer the one with fewer in-flight requests.
+2. **Idle GPU** — Find workers with no `Gpu`-resident model. Pick the one where the model fits best (smallest GPU with enough VRAM — VRAM-fit tiebreaker).
+3. **Evict LRU** — All GPUs busy. Pick the GPU where the model fits with the most headroom after evicting its LRU model.
+4. **Doesn't fit** — Return error (model too large for any available GPU).
+
+### AppState Changes
+
+```rust
+// Before
+pub model_cache: Arc<Mutex<ModelCache>>,
+pub engine_snapshot: Arc<RwLock<EngineSnapshot>>,
+pub model_load_lock: Arc<Mutex<()>>,
+
+// After
+pub gpu_pool: Arc<GpuPool>,
+```
+
+Existing `model_manager.rs` functions refactored to operate on a specific `GpuWorker` rather than global state. Internal logic stays nearly identical — just scoped to one GPU.
+
+---
+
+## 3. Queue & Concurrency
+
+### Multi-GPU Dispatch
+
+The queue becomes a dispatcher. Multiple jobs run concurrently (one per GPU):
+
+```rust
+loop {
+    let job = queue.recv().await;
+    let worker = gpu_pool.select_worker(&job.model, estimated_vram)?;
+
+    tokio::spawn(async move {
+        let _lock = worker.model_load_lock.lock().await;
+        ensure_model_ready(worker, &job.model).await?;
+
+        let result = tokio::task::spawn_blocking(move || {
+            let mut cache = worker.model_cache.blocking_lock();
+            let engine = cache.get_mut(&job.model).unwrap();
+            engine.generate(&job.request)
+        }).await?;
+
+        job.response_tx.send(result);
+    });
+}
+```
+
+### Bounded Queue
+
+`tokio::sync::mpsc::channel(queue_size)` where `queue_size` defaults to 200.
+
+Configurable via:
+- CLI: `--queue-size 200`
+- Env: `MOLD_QUEUE_SIZE=200`
+- Config: `queue_size = 200`
+
+When full, returns HTTP 503 with:
+```json
+{
+    "error": "Queue full — all GPUs busy",
+    "queue_size": 200,
+    "active_gpus": 3
+}
+```
+
+Includes `Retry-After` header.
+
+### In-Flight Tracking
+
+Track active jobs per GPU for placement tiebreaking. When multiple GPUs have the same model loaded, prefer the one with fewer in-flight requests.
+
+### SSE Streaming
+
+No changes. Progress callbacks already work per-engine. Each GPU's engine fires progress events independently to its request's SSE channel.
+
+---
+
+## 4. CLI Changes
+
+### `mold run --local`
+
+Pick the best single GPU — the one with the most free VRAM from the allowed set:
+
+```rust
+let gpus = discover_gpus();
+let available = filter_gpus(&gpus, &gpu_selection);
+let best = select_best_gpu(&available, estimated_model_vram);
+```
+
+No caching, no placement strategy. Just "biggest available card."
+
+`--gpus` flag still respected to constrain which GPU it picks from.
+
+### `mold serve` New Flags
+
+```
+--gpus <ORDINALS>     Comma-separated GPU ordinals (default: all)
+--queue-size <N>      Max queued requests before 503 (default: 200)
+```
+
+### `mold ps` Output
+
+```
+GPU 0 (RTX 4090, 24GB):  flux-dev:q8        [generating]  VRAM: 18.2/24.0 GB
+GPU 1 (RTX 4090, 24GB):  sdxl-turbo:fp16    [idle]        VRAM: 6.1/24.0 GB
+GPU 2 (RTX 3060, 12GB):  sd15:fp16          [idle]        VRAM: 4.2/12.0 GB
+Queue: 2/200
+```
+
+### `mold run` (Remote)
+
+No client-side GPU flags in remote mode. Server decides placement transparently.
+
+### New Environment Variables
+
+| Var | Default | Purpose |
+|-----|---------|---------|
+| `MOLD_GPUS` | (all) | Comma-separated GPU ordinals |
+| `MOLD_QUEUE_SIZE` | `200` | Max queued requests |
+
+### Config File Additions
+
+```toml
+gpus = [0, 1, 2]    # optional, omit for all
+queue_size = 200     # optional
+```
+
+---
+
+## 5. API Surface Changes
+
+### `GET /api/status`
+
+```json
+{
+    "status": "running",
+    "gpus": [
+        {
+            "ordinal": 0,
+            "name": "NVIDIA RTX 4090",
+            "vram_total_bytes": 25769803776,
+            "vram_used_bytes": 19327352832,
+            "loaded_model": "flux-dev:q8",
+            "state": "generating"
+        },
+        {
+            "ordinal": 1,
+            "name": "NVIDIA RTX 4090",
+            "vram_total_bytes": 25769803776,
+            "vram_used_bytes": 6543982592,
+            "loaded_model": "sdxl-turbo:fp16",
+            "state": "idle"
+        }
+    ],
+    "queue_depth": 2,
+    "queue_capacity": 200
+}
+```
+
+Backwards compat: keep existing top-level `model` field populated with first GPU's loaded model (or null).
+
+### `POST /api/models/load`
+
+Optional `gpu` field to pin to a specific ordinal:
+
+```json
+{
+    "model": "flux-dev:q8",
+    "gpu": 1
+}
+```
+
+Omit `gpu` and placement strategy decides.
+
+### `DELETE /api/models/unload`
+
+Now accepts optional target:
+
+```json
+{ "model": "flux-dev:q8" }
+```
+
+Or by GPU: `{ "gpu": 1 }`. Omit both to unload all (backwards compat).
+
+### `POST /api/generate`
+
+No request changes. Server decides GPU placement.
+
+### `GenerateResponse`
+
+New optional `gpu` field:
+
+```json
+{
+    "images": [...],
+    "seed": 42,
+    "gpu": 0
+}
+```
+
+---
+
+## 6. Inference Layer Changes
+
+### EngineBase
+
+```rust
+pub struct EngineBase<L> {
+    // ... existing fields ...
+    pub gpu_ordinal: usize,
+}
+```
+
+Each engine's `load()` calls `create_device(self.base.gpu_ordinal, ...)`.
+
+### Factory
+
+`create_engine()` and `create_engine_with_pool()` gain `ordinal: usize` parameter, threaded through to `EngineBase`.
+
+### What Changes
+
+- `device.rs`: all functions take ordinal parameter
+- `factory.rs`: passes ordinal through to engines
+- `engine_base.rs`: stores `gpu_ordinal`
+- `expand.rs`: accepts ordinal, defaults to least-loaded GPU
+
+### What Doesn't Change
+
+- Individual pipeline implementations (FLUX, SD3, SDXL, etc.) — use ordinal through `create_device()`, everything else same
+- LoRA loading — per-engine, device-agnostic
+- Tokenizer shared pool — CPU-side, shared across all GPUs
+- Scheduler logic (DDIM, Euler, etc.) — operates on tensors already on the right device
+- Offloading — works per-GPU, no cross-GPU offloading
+- VRAM threshold logic — already parameterized by `free_vram`
+
+---
+
+## Crate Impact Summary
+
+| Crate | Changes |
+|-------|---------|
+| `mold-core` | `GpuInfo`, `GpuSelection`, `GpuStatus` types. `ServerStatus` updated with `gpus` array. `GenerateResponse` gets `gpu` field. Config gets `gpus` and `queue_size`. |
+| `mold-inference` | `device.rs` overhaul (ordinal params, `discover_gpus()`). `EngineBase` gets `gpu_ordinal`. Factory passes ordinal. `expand.rs` ordinal-aware. |
+| `mold-server` | `GpuPool`, `GpuWorker` structs. `AppState` refactored. Queue becomes multi-GPU dispatcher. Routes updated for new API fields. `model_manager.rs` scoped to per-worker. |
+| `mold-cli` | `--gpus` and `--queue-size` flags. `mold ps` multi-GPU display. `mold run --local` best-GPU selection. |
+| `mold-discord` | Minor: parse `gpu` field from `GenerateResponse` for display. |
+| `mold-tui` | Minor: display per-GPU status if connected to multi-GPU server. |


### PR DESCRIPTION
## Summary
- Adds multi-GPU support to the mold inference server. Each GPU gets a dedicated OS thread with its own `ModelCache`; a `GpuPool` routes requests using idle-first + VRAM-fit placement.
- Queue is bounded (default 200) with HTTP 503 backpressure and `Retry-After`.
- New CLI flags / env: `--gpus`/`MOLD_GPUS`, `--queue-size`/`MOLD_QUEUE_SIZE`.
- Spec: `docs/superpowers/specs/2026-04-08-multi-gpu-support-design.md`
- Plan: `docs/superpowers/plans/2026-04-08-multi-gpu-support.md`

## What changed
- `mold-core`: `GpuSelection`, `GpuWorkerStatus`, config fields.
- `mold-inference`: GPU discovery (`discover_gpus`, `filter_gpus`, `select_best_gpu`), ordinal-aware `create_device`/`free_vram_bytes`, and `gpu_ordinal` threaded through `EngineBase` and every per-family engine (FLUX, SD1.5, SDXL, SD3, Z-Image, Flux.2, Qwen-Image, Wuerstchen, LTX-Video).
- `mold-server`: new `GpuPool` + per-GPU `GpuWorker` on a dedicated OS thread, queue dispatcher with TOCTOU-safe in-flight tracking, take-and-restore engine placement, updated API (status aggregation, GPU-targeted load/unload, `gpu` field in `GenerateResponse`, 503 on queue full).
- `mold-cli`: `--gpus`, `--queue-size`, multi-GPU `mold ps` display.

## Design notes
- CUDA contexts are thread-local — each worker owns a `std::thread::spawn` OS thread, not a tokio blocking-pool task.
- `in_flight` counter is bumped at dispatch time (before channel send) to prevent TOCTOU under burst load.
- `reclaim_gpu_memory(ordinal)` resets a specific GPU's primary context; only called inside the worker's `model_load_lock`.
- Backwards-compat: `/api/status` still populates legacy single-GPU `model` and `gpu_info` fields from the first GPU.

## Test plan
- [ ] `cargo check --workspace`, `cargo fmt --check`, `cargo clippy --workspace -- -D warnings`, `cargo test --workspace` — all clean locally (1603/0).
- [ ] Build on CUDA multi-GPU host: `cargo build -p mold-ai --features cuda --release`.
- [ ] GPU discovery: `mold serve` logs one worker per physical GPU; `/api/status.gpus[]` entries match.
- [ ] `MOLD_GPUS=0 mold serve` → one worker; `--gpus 0,1` → two workers.
- [ ] Load two different models → they land on different GPUs (`mold ps` / `/api/status`).
- [ ] Placement: idle-first for unseen models, already-loaded GPU wins for repeat requests.
- [ ] Two concurrent `/api/generate` calls for different models run in parallel (wall-clock overlap).
- [ ] ~210 concurrent requests → last ~10 get HTTP 503 with `Retry-After`.
- [ ] Single-GPU back-compat: legacy `model` / `gpu_info` fields still populate.
- [ ] `GenerateResponse` carries `"gpu": <ordinal>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)