### PR TITLE
fix(cli): distinguish remote CUDA OOM from local Metal OOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Remote CUDA OOMs no longer mislabeled as "Metal out of memory" on macOS clients** ([#241](https://github.com/utensils/mold/issues/241)). Previously `mold run --batch N` against a remote CUDA server would report `Metal out of memory` with local-only hints (`--width 512 --height 512`, "source image resolution is used by default") whenever the server's GPU OOM'd, because the error formatter keyed off `cfg!(target_os = "macos")` rather than where the generation actually ran. Errors originating from the remote API path are now tagged with the server host via a new `RemoteInferenceError` wrapper; the top-level handler downcasts to that tag before labeling the error and picks hints that make sense for the remote context (reduce `--batch`, use a smaller model, ask the operator to `mold unload`, fall back to `--local`). Local Metal / CUDA OOM paths keep their existing behavior. (Issue also notes a separate server-side VRAM-growth suspicion on Qwen-Image-Edit between batch iterations; that is tracked independently.)
+
 ### Changed
 
 - **Gallery metadata DB now canonicalizes `output_dir` before keying rows** so the CLI (which canonicalized via `std::fs::canonicalize`) and the server (which used the raw `config.effective_output_dir()` value) can no longer produce two rows for the same underlying file. On macOS `/tmp/foo` and `/private/tmp/foo` collapse to one `UNIQUE(output_dir, filename)` key, so the gallery no longer shows duplicates when both surfaces share a single `MOLD_HOME/mold.db`. A v2 data migration rewrites existing v1 rows to the canonical form on first open so upgrades from unreleased-feature builds don't leave orphaned legacy-keyed rows behind.

--- a/crates/mold-cli/src/commands/generate.rs
+++ b/crates/mold-cli/src/commands/generate.rs
@@ -16,9 +16,17 @@ use std::io::Write;
 use std::time::Duration;
 
 use crate::control::{stream_server_pull, CliContext};
+use crate::errors::RemoteInferenceError;
 use crate::output::{is_piped, status};
 use crate::theme;
 use crate::ui::{print_server_pull_missing_model, print_using_local_inference, render_progress};
+
+/// Tag an error as originating from the remote server so the top-level handler
+/// can produce a remote-context diagnostic (e.g. distinguishing a server-side
+/// CUDA OOM from a local Metal OOM on the client).
+fn tag_remote(client: &MoldClient, e: anyhow::Error) -> anyhow::Error {
+    RemoteInferenceError::wrap(client.host(), e)
+}
 
 /// Fit source image dimensions to the model's native resolution, preserving aspect ratio.
 fn source_image_model_dimensions(bytes: &[u8], model_w: u32, model_h: u32) -> Result<(u32, u32)> {
@@ -712,7 +720,9 @@ async fn generate_remote(
             match classify_generate_error(&e) {
                 GenerateServerAction::PullModelAndRetry => {
                     print_server_pull_missing_model(model);
-                    stream_server_pull(client, model).await?;
+                    stream_server_pull(client, model)
+                        .await
+                        .map_err(|e| tag_remote(client, e))?;
 
                     status!("{} Generating...", theme::icon_info());
 
@@ -723,9 +733,16 @@ async fn generate_remote(
                             let _ = render2.await;
                             Ok(response)
                         }
-                        _ => {
+                        Ok(None) => {
                             let _ = render2.await;
-                            Ok(client.generate(req.clone()).await?)
+                            client
+                                .generate(req.clone())
+                                .await
+                                .map_err(|e| tag_remote(client, e))
+                        }
+                        Err(e2) => {
+                            let _ = render2.await;
+                            Err(tag_remote(client, e2))
                         }
                     }
                 }
@@ -747,7 +764,7 @@ async fn generate_remote(
                     )
                     .await
                 }
-                GenerateServerAction::SurfaceError => Err(e),
+                GenerateServerAction::SurfaceError => Err(tag_remote(client, e)),
             }
         }
     }
@@ -800,9 +817,14 @@ async fn generate_remote_blocking(
             match classify_generate_error(&e) {
                 GenerateServerAction::PullModelAndRetry => {
                     print_server_pull_missing_model(model);
-                    stream_server_pull(client, model).await?;
+                    stream_server_pull(client, model)
+                        .await
+                        .map_err(|e| tag_remote(client, e))?;
                     status!("{} Generating...", theme::icon_info());
-                    Ok(client.generate(req.clone()).await?)
+                    client
+                        .generate(req.clone())
+                        .await
+                        .map_err(|e| tag_remote(client, e))
                 }
                 GenerateServerAction::FallbackLocal => {
                     print_using_local_inference();
@@ -822,7 +844,7 @@ async fn generate_remote_blocking(
                     )
                     .await
                 }
-                GenerateServerAction::SurfaceError => Err(e),
+                GenerateServerAction::SurfaceError => Err(tag_remote(client, e)),
             }
         }
     }

--- a/crates/mold-cli/src/commands/generate.rs
+++ b/crates/mold-cli/src/commands/generate.rs
@@ -733,16 +733,18 @@ async fn generate_remote(
                             let _ = render2.await;
                             Ok(response)
                         }
-                        Ok(None) => {
+                        // Either the server has no SSE endpoint (Ok(None)) or
+                        // the SSE stream failed (Err) — some proxies/servers
+                        // close the stream before the final `complete` event
+                        // even though the blocking `/api/generate` path still
+                        // works. Fall back to the blocking endpoint before
+                        // giving up.
+                        _ => {
                             let _ = render2.await;
                             client
                                 .generate(req.clone())
                                 .await
                                 .map_err(|e| tag_remote(client, e))
-                        }
-                        Err(e2) => {
-                            let _ = render2.await;
-                            Err(tag_remote(client, e2))
                         }
                     }
                 }

--- a/crates/mold-cli/src/errors.rs
+++ b/crates/mold-cli/src/errors.rs
@@ -1,0 +1,244 @@
+//! Error types shared across CLI commands.
+//!
+//! `RemoteInferenceError` tags an error as originating from a remote server so the
+//! top-level error handler can distinguish remote failures (e.g. a CUDA OOM on the
+//! server) from local-device failures and produce the right diagnostic message.
+
+use std::fmt;
+
+/// Wraps an `anyhow::Error` with the host URL of the remote server it came from.
+///
+/// Construct with [`RemoteInferenceError::wrap`]. Retrieve at the top-level error
+/// handler via `err.downcast_ref::<RemoteInferenceError>()`.
+#[derive(Debug)]
+pub struct RemoteInferenceError {
+    pub host: String,
+    pub inner: anyhow::Error,
+}
+
+impl RemoteInferenceError {
+    /// Wrap an existing error with a remote-server host tag.
+    pub fn wrap(host: impl Into<String>, inner: anyhow::Error) -> anyhow::Error {
+        anyhow::Error::new(RemoteInferenceError {
+            host: host.into(),
+            inner,
+        })
+    }
+}
+
+impl fmt::Display for RemoteInferenceError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Transparent: the wrapper exists to carry host metadata, not to rewrite
+        // the user-visible error string. The top-level handler consults the host
+        // via downcast_ref and formats a proper remote-context message.
+        write!(f, "{}", self.inner)
+    }
+}
+
+impl std::error::Error for RemoteInferenceError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(AsRef::<dyn std::error::Error + 'static>::as_ref(
+            &self.inner,
+        ))
+    }
+}
+
+/// Whether the generation that produced an error ran locally or on a remote server.
+#[derive(Debug, Clone, Copy)]
+pub enum OomContext<'a> {
+    Local,
+    Remote { host: &'a str },
+}
+
+/// True if `msg` looks like a GPU OOM error from candle/CUDA/Metal.
+pub fn is_oom_message(msg: &str) -> bool {
+    msg.contains("CUDA_ERROR_OUT_OF_MEMORY")
+        || msg.contains("out of memory")
+        || msg.contains("exceeds available VRAM")
+        || msg.contains("Failed to create metal resource")
+}
+
+/// Build the human-readable OOM label + hint lines for the given context.
+///
+/// `macos_client` should be `cfg!(target_os = "macos")` at the call site — we take
+/// it as a parameter so tests can exercise both platforms without cross-compiling.
+/// `fallback` is the already-cleaned error text to use when we can't confidently
+/// pick a backend label (e.g. unknown local error).
+pub fn format_oom_message(
+    msg: &str,
+    ctx: OomContext<'_>,
+    macos_client: bool,
+    fallback: &str,
+) -> (String, Vec<String>) {
+    let label = match ctx {
+        OomContext::Remote { host } => format!("Remote server GPU out of memory ({host})"),
+        OomContext::Local => {
+            // candle wraps Metal allocation failures as CUDA_ERROR_OUT_OF_MEMORY
+            // on macOS, so we gate the "Metal" label on the client platform.
+            let is_metal = macos_client
+                && (msg.contains("CUDA_ERROR_OUT_OF_MEMORY")
+                    || msg.contains("Failed to create metal resource"));
+            let is_cuda = !macos_client && msg.contains("CUDA_ERROR_OUT_OF_MEMORY");
+            if is_metal {
+                "Metal out of memory".to_string()
+            } else if is_cuda {
+                "CUDA out of memory".to_string()
+            } else {
+                fallback.to_string()
+            }
+        }
+    };
+
+    let hints = match ctx {
+        OomContext::Remote { .. } => vec![
+            "The remote GPU ran out of memory during generation.".to_string(),
+            "Try these fixes:".to_string(),
+            String::new(),
+            "    Reduce batch size:    --batch 1".to_string(),
+            "    Use a smaller model:  mold run <model>:q4 \"...\"".to_string(),
+            "    Lower resolution:     --width 512 --height 512".to_string(),
+            String::new(),
+            "  The server keeps models resident between requests; ask the".to_string(),
+            "  operator to free VRAM (`mold unload`) if other workloads share".to_string(),
+            "  the GPU. Use `--local` to force local inference instead.".to_string(),
+        ],
+        OomContext::Local => vec![
+            "GPU ran out of memory during generation.".to_string(),
+            "Try these fixes:".to_string(),
+            String::new(),
+            "    Reduce resolution:  --width 512 --height 512".to_string(),
+            "    Use a smaller model: mold run <model>:q4 \"...\"".to_string(),
+            String::new(),
+            "  For img2img, the source image resolution is used by default.".to_string(),
+            "  Override with --width/--height to reduce VRAM usage.".to_string(),
+            "  Run 'mold list' to see available models and sizes.".to_string(),
+        ],
+    };
+
+    (label, hints)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn remote_oom_labels_host_regardless_of_client_platform() {
+        // Simulate a macOS client talking to a remote CUDA server.
+        let msg = "CUDA_ERROR_OUT_OF_MEMORY: out of memory";
+        let (label, hints) = format_oom_message(
+            msg,
+            OomContext::Remote {
+                host: "http://hal9000:7680",
+            },
+            true, // macOS client
+            msg,
+        );
+        assert_eq!(
+            label,
+            "Remote server GPU out of memory (http://hal9000:7680)"
+        );
+        assert!(!label.contains("Metal"));
+        let hints_blob = hints.join("\n");
+        assert!(hints_blob.contains("--batch 1"));
+        assert!(hints_blob.contains("--local"));
+    }
+
+    #[test]
+    fn remote_oom_labels_host_on_linux_client() {
+        let (label, _) = format_oom_message(
+            "CUDA_ERROR_OUT_OF_MEMORY",
+            OomContext::Remote {
+                host: "http://gpu-box:7680",
+            },
+            false,
+            "fallback",
+        );
+        assert_eq!(
+            label,
+            "Remote server GPU out of memory (http://gpu-box:7680)"
+        );
+    }
+
+    #[test]
+    fn local_metal_oom_on_macos_client() {
+        let msg = "CUDA_ERROR_OUT_OF_MEMORY";
+        let (label, hints) = format_oom_message(msg, OomContext::Local, true, msg);
+        assert_eq!(label, "Metal out of memory");
+        assert!(hints.iter().any(|h| h.contains("--width 512")));
+    }
+
+    #[test]
+    fn local_metal_resource_failure_on_macos_client() {
+        let msg = "Failed to create metal resource";
+        let (label, _) = format_oom_message(msg, OomContext::Local, true, msg);
+        assert_eq!(label, "Metal out of memory");
+    }
+
+    #[test]
+    fn local_cuda_oom_on_linux_client() {
+        let msg = "CUDA_ERROR_OUT_OF_MEMORY";
+        let (label, _) = format_oom_message(msg, OomContext::Local, false, msg);
+        assert_eq!(label, "CUDA out of memory");
+    }
+
+    #[test]
+    fn local_cuda_oom_on_macos_client_not_mislabeled_as_cuda() {
+        // When the client is macOS and the error came from local Metal (candle
+        // reports it as CUDA_ERROR_OUT_OF_MEMORY), we must NOT say "CUDA".
+        let msg = "CUDA_ERROR_OUT_OF_MEMORY";
+        let (label, _) = format_oom_message(msg, OomContext::Local, true, msg);
+        assert_ne!(label, "CUDA out of memory");
+        assert_eq!(label, "Metal out of memory");
+    }
+
+    #[test]
+    fn unknown_local_oom_falls_back_to_raw_message() {
+        let msg = "exceeds available VRAM: need 10 GB, have 8 GB";
+        let (label, _) = format_oom_message(msg, OomContext::Local, false, msg);
+        assert_eq!(label, msg);
+    }
+
+    #[test]
+    fn is_oom_message_detects_all_variants() {
+        assert!(is_oom_message("CUDA_ERROR_OUT_OF_MEMORY"));
+        assert!(is_oom_message("the GPU reports out of memory"));
+        assert!(is_oom_message("exceeds available VRAM"));
+        assert!(is_oom_message("Failed to create metal resource"));
+        assert!(!is_oom_message("network timeout"));
+    }
+
+    #[test]
+    fn remote_inference_error_preserves_display_transparently() {
+        let inner = anyhow::anyhow!("CUDA_ERROR_OUT_OF_MEMORY: device ran out of memory");
+        let wrapped = RemoteInferenceError::wrap("http://server:7680", inner);
+        // Wrapper must not alter the user-visible error text.
+        let rendered = format!("{wrapped}");
+        assert!(rendered.contains("CUDA_ERROR_OUT_OF_MEMORY"));
+        assert!(!rendered.contains("http://server:7680"));
+    }
+
+    #[test]
+    fn remote_inference_error_downcasts_by_type() {
+        let inner = anyhow::anyhow!("boom");
+        let wrapped = RemoteInferenceError::wrap("http://server:7680", inner);
+        let got = wrapped.downcast_ref::<RemoteInferenceError>();
+        assert!(got.is_some());
+        assert_eq!(got.unwrap().host, "http://server:7680");
+    }
+
+    #[test]
+    fn remote_inference_error_downcasts_through_context() {
+        // Simulate a caller adding `.context()` above our wrapper as the error
+        // propagates up through `?`. We must still be able to recover the host.
+        use anyhow::Context;
+        let inner = anyhow::anyhow!("CUDA_ERROR_OUT_OF_MEMORY: out of memory");
+        let wrapped = RemoteInferenceError::wrap("http://server:7680", inner);
+        let with_ctx = Err::<(), _>(wrapped)
+            .context("batch 2/5 failed")
+            .unwrap_err();
+        let got = with_ctx.downcast_ref::<RemoteInferenceError>();
+        assert!(got.is_some(), "downcast must traverse context chain");
+        assert_eq!(got.unwrap().host, "http://server:7680");
+    }
+}

--- a/crates/mold-cli/src/errors.rs
+++ b/crates/mold-cli/src/errors.rs
@@ -228,6 +228,34 @@ mod tests {
     }
 
     #[test]
+    fn remote_inference_error_inner_chain_does_not_duplicate_top_message() {
+        // Regression for the duplicate `error:` / `cause:` lines on the generic
+        // remote-error path. `main` prints the top-level display and then walks
+        // `chain().skip(1)` for "caused by" lines; when the error came from the
+        // remote path, we must iterate the *inner* chain so the wrapper (which
+        // transparently forwards Display to `inner`) doesn't appear as both the
+        // header and the first cause.
+        let inner = anyhow::anyhow!("server error 500: boom");
+        let wrapped = RemoteInferenceError::wrap("http://server:7680", inner);
+
+        let top = format!("{wrapped}");
+        assert_eq!(top, "server error 500: boom");
+
+        // Simulate what main.rs does: grab the inner from the wrapper and walk
+        // the inner's chain.
+        let inner_ref = &wrapped
+            .downcast_ref::<RemoteInferenceError>()
+            .expect("wrapped")
+            .inner;
+        let causes: Vec<String> = inner_ref.chain().skip(1).map(|c| c.to_string()).collect();
+
+        assert!(
+            !causes.iter().any(|c| c == &top),
+            "top message must not appear as its own cause: causes={causes:?}",
+        );
+    }
+
+    #[test]
     fn remote_inference_error_downcasts_through_context() {
         // Simulate a caller adding `.context()` above our wrapper as the error
         // propagates up through `?`. We must still be able to recover the host.

--- a/crates/mold-cli/src/main.rs
+++ b/crates/mold-cli/src/main.rs
@@ -1,5 +1,6 @@
 mod commands;
 mod control;
+mod errors;
 mod metadata_db;
 mod output;
 mod procinfo;
@@ -987,36 +988,25 @@ async fn main() {
         // Detect CUDA/Metal OOM and print a friendly message with suggestions.
         // Note: candle wraps Metal allocation failures as CUDA_ERROR_OUT_OF_MEMORY,
         // and Metal buffer creation failures as "Failed to create metal resource".
-        let is_oom = msg.contains("CUDA_ERROR_OUT_OF_MEMORY")
-            || msg.contains("out of memory")
-            || msg.contains("exceeds available VRAM")
-            || msg.contains("Failed to create metal resource");
-        if is_oom {
-            // Show platform-appropriate message instead of raw candle error.
-            // On macOS: candle wraps Metal failures as CUDA_ERROR_OUT_OF_MEMORY.
-            // On Linux/CUDA: show "CUDA out of memory" for actual CUDA OOM.
-            let is_metal_oom = cfg!(target_os = "macos")
-                && (msg.contains("CUDA_ERROR_OUT_OF_MEMORY")
-                    || msg.contains("Failed to create metal resource"));
-            let is_cuda_oom =
-                cfg!(not(target_os = "macos")) && msg.contains("CUDA_ERROR_OUT_OF_MEMORY");
-            if is_metal_oom {
-                eprintln!("{} Metal out of memory", theme::prefix_error());
-            } else if is_cuda_oom {
-                eprintln!("{} CUDA out of memory", theme::prefix_error());
-            } else {
-                eprintln!("{} {display}", theme::prefix_error());
+        // If the error came from a remote server, we must not label it with the
+        // *client* platform's backend — see errors::RemoteInferenceError.
+        if errors::is_oom_message(&msg) {
+            let remote = e.downcast_ref::<errors::RemoteInferenceError>();
+            let ctx = match remote {
+                Some(r) => errors::OomContext::Remote { host: &r.host },
+                None => errors::OomContext::Local,
+            };
+            let (label, hints) =
+                errors::format_oom_message(&msg, ctx, cfg!(target_os = "macos"), display);
+            eprintln!("{} {label}", theme::prefix_error());
+            eprintln!();
+            for line in &hints {
+                if line.is_empty() {
+                    eprintln!();
+                } else {
+                    eprintln!("  {line}");
+                }
             }
-            eprintln!();
-            eprintln!("  GPU ran out of memory during generation.");
-            eprintln!("  Try these fixes:");
-            eprintln!();
-            eprintln!("    Reduce resolution:  --width 512 --height 512");
-            eprintln!("    Use a smaller model: mold run <model>:q4 \"...\"");
-            eprintln!();
-            eprintln!("  For img2img, the source image resolution is used by default.");
-            eprintln!("  Override with --width/--height to reduce VRAM usage.");
-            eprintln!("  Run 'mold list' to see available models and sizes.");
             std::process::exit(1);
         }
 

--- a/crates/mold-cli/src/main.rs
+++ b/crates/mold-cli/src/main.rs
@@ -1021,8 +1021,19 @@ async fn main() {
         }
 
         // For all other errors, print the stripped message (no candle backtraces).
+        // If the error is wrapped in `RemoteInferenceError`, iterate the inner
+        // error's chain: our wrapper's `Display` forwards to `inner`, so using
+        // `e.chain()` would print the same message twice — once as the top-level
+        // `error:` line and again as the first `cause:` entry.
+        let chain_source = e
+            .downcast_ref::<errors::RemoteInferenceError>()
+            .map(|r| &r.inner);
         eprintln!("{} {display}", theme::prefix_error());
-        for cause in e.chain().skip(1) {
+        let chain = match chain_source {
+            Some(inner) => inner.chain().skip(1),
+            None => e.chain().skip(1),
+        };
+        for cause in chain {
             eprintln!("  {} {cause}", theme::prefix_cause());
         }
         std::process::exit(1);


### PR DESCRIPTION
## Summary

Closes the Bug 1 portion of #241: running `mold run --batch N` from a macOS client against a remote CUDA server via `MOLD_HOST` no longer mislabels a server-side GPU OOM as `Metal out of memory` with local-only hints.

- Adds `crates/mold-cli/src/errors.rs` with a `RemoteInferenceError` wrapper that tags an error with the remote server host, plus pure-Rust `format_oom_message(...)` helpers that the top-level handler and unit tests both consume.
- `generate_remote` / `generate_remote_blocking` wrap their surface-error and retry-after-pull exits with the remote tag via `tag_remote(client, e)`. The `FallbackLocal` branch is deliberately left untagged so local fallbacks continue to route through the local OOM formatter.
- `main.rs` now downcasts to `RemoteInferenceError` before choosing the OOM label/suggestions. Remote OOMs render as `Remote server GPU out of memory (<host>)` with hints pointing at `--batch`, smaller models, `mold unload` on the operator side, and `--local` as a last resort. Local Metal / local CUDA paths keep their existing labels and hints.

Bug 2 from the issue (server-side VRAM growth between remote batch iterations on `qwen-image-edit-2511:q4`) is a separate server-side investigation and is **not** addressed here.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace` — all tests pass except a pre-existing macOS timing flake in `mold-inference/src/device.rs::free_vram_returns_available_not_just_free_on_macos` that also fails on `main` under workspace load and passes in isolation (unrelated to this change)
- [x] New unit tests (`crates/mold-cli/src/errors.rs`) cover:
  - remote OOM on macOS client (verifies host in label, no "Metal", `--batch 1` + `--local` hints)
  - remote OOM on Linux client
  - local Metal OOM on macOS client (candle reports Metal failures as `CUDA_ERROR_OUT_OF_MEMORY`)
  - local "Failed to create metal resource" on macOS client
  - local CUDA OOM on Linux client
  - local macOS OOM is not mislabeled as CUDA
  - unknown local OOM falls back to raw message
  - `is_oom_message` matches all four candle variants
  - `RemoteInferenceError` Display is transparent (host is carried only as metadata)
  - `downcast_ref::<RemoteInferenceError>` works on the outer wrapper
  - `downcast_ref::<RemoteInferenceError>` still works after `.context(...)` is added above it