### PR TITLE
fix(nix): use isolated linker for mold-web to unblock Darwin sandbox builds

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -183,8 +183,12 @@
             bunDeps = pkgs.bun2nix.fetchBunDeps {
               bunNix = ./web/bun.nix;
             };
-            # vue-tsc + vite resolve peer deps via hoisted lookups.
-            bunInstallFlags = [ "--linker=hoisted" ];
+            # --linker=isolated gives each package its own node_modules, which
+            # sidesteps bun's AccessDenied failures when the hoisted linker tries
+            # to create nested `@vue/compiler-*/node_modules/estree-walker`
+            # directories during a sandboxed Darwin build (Vue pulls v2 while
+            # Vitest pulls v3, so the tree can't be flattened).
+            bunInstallFlags = [ "--linker=isolated" ];
             buildPhase = ''
               runHook preBuild
               bun run build


### PR DESCRIPTION
## Summary

On sandboxed Darwin builds (e.g. `nix-darwin`'s `nixosConfigurations` path), bun's hoisted linker fails with:

```
AccessDenied: Failed to open node_modules folder for estree-walker in .../web/node_modules/@vue/compiler-sfc/node_modules
AccessDenied: Failed to open node_modules folder for estree-walker in .../web/node_modules/@vue/compiler-core/node_modules
...
Failed to install 2 packages
```

when it tries to create the nested `node_modules/@vue/compiler-*/node_modules/estree-walker` directories. Vue 3.5.x pulls `estree-walker@^2.0.2` (CJS) while Vitest 4 pulls `^3.0.3` (ESM-only), so the dependency tree can't be flattened and bun's hoisted linker blows up mid-install on the sandboxed fs.

## Fix

Switch `bunInstallFlags` from `--linker=hoisted` to `--linker=isolated`. Isolated gives every package its own `node_modules`, so:

- Vue's CJS `require('estree-walker')` still resolves — each `@vue/compiler-*` package owns a local v2 copy.
- Vitest's ESM imports get their own v3 copy.
- No nested-create step, no Darwin sandbox conflict.

A top-level `"overrides": { "estree-walker": "^3.0.3" }` is **not** a fix here — forcing v3 breaks Vue because v2 is CJS and v3 is ESM-only. I tried it; `vite build` then fails with `Cannot find package 'estree-walker' from @vue/compiler-core/dist/compiler-core.cjs.js`.

## Verified

- `nix build .#mold-web --rebuild` on aarch64-darwin succeeds and produces the identical dist bundle (169 KB JS / 44 KB CSS, same hashes).
- Non-Nix dev path unaffected: `cd web && bun install && bun run fmt:check && bun run test && bun run build` all clean (36 vitest tests).
- The embedded SPA still resolves at runtime via `rust-embed` — no change to `crates/mold-server/{build.rs,web_ui.rs}`.

## Scope

Flake-only — no Rust, CLI, or API changes, no version bump.

## Test plan

- [ ] CI green
- [ ] After merge: `nix-darwin` rebuild against the updated flake succeeds on arm64 Mac hosts (reproduces the original failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)