### PR TITLE
feat(discord): LTX video, img2img, and img-to-video

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Discord bot now supports video generation and img2img / img-to-video.** `/generate` accepts an optional `source_image` attachment (PNG/JPEG, ≤10 MiB) that is forwarded to the server as `source_image` — image-family models run img2img, LTX-2 runs image-to-video with the attachment as the first frame. New `video_format` choice (MP4 default, animated GIF) plus `frames`, `fps`, `audio` (LTX-2 only), `pipeline` (LTX-2 one-stage / two-stage / two-stage-hq / distilled / a2vid / retake), `strength`, and `negative_prompt` params wire through to the underlying `GenerateRequest`. Video families default to 25 frames @ 24 fps when unspecified. The handler picks up `GenerateResponse.video` and attaches the MP4/GIF bytes (plus a "Video Generated" embed with frame count, fps, and optional audio flag); when the primary MP4 exceeds Discord's ~24 MiB effective upload cap it automatically falls back to the always-generated GIF preview and notes the swap in the embed footer.
+
+### Fixed
+
+- **Discord bot no longer silently drops video-family generations.** Previously `/generate` hard-coded `output_format: Png` and `resp.images.first()` for the attachment, so LTX-Video / LTX-2 jobs either bounced off server validation (LTX-2 rejects non-video containers) or came back with the video missing from the reply.
+
 ## [0.9.0] - 2026-04-19
 
 *Multi-GPU inference server, browser-driven generate UI, SQLite gallery metadata, and animated video previews.*

--- a/crates/mold-discord/src/commands/generate.rs
+++ b/crates/mold-discord/src/commands/generate.rs
@@ -2,7 +2,8 @@ use crate::checks::{self, AuthResult};
 use crate::handler;
 use crate::state::Context;
 use anyhow::Result;
-use mold_core::{GenerateRequest, OutputFormat};
+use mold_core::{GenerateRequest, Ltx2PipelineMode, ModelInfoExtended, OutputFormat};
+use poise::serenity_prelude as serenity;
 
 /// Autocomplete function for model names.
 async fn autocomplete_model(ctx: Context<'_>, partial: &str) -> Vec<String> {
@@ -17,20 +18,99 @@ async fn autocomplete_model(ctx: Context<'_>, partial: &str) -> Vec<String> {
         .collect()
 }
 
-/// Build a GenerateRequest from slash command parameters, using model defaults.
-#[allow(clippy::too_many_arguments)]
-pub fn build_generate_request(
-    prompt: &str,
-    model: &str,
-    width: Option<u32>,
-    height: Option<u32>,
-    steps: Option<u32>,
-    guidance: Option<f64>,
-    seed: Option<u64>,
-    negative_prompt: Option<&str>,
-    defaults: Option<&mold_core::ModelDefaults>,
-) -> GenerateRequest {
-    let (def_w, def_h, def_steps, def_guidance) = match defaults {
+/// Discord-selectable container for video generations. Videos are always
+/// returned as either MP4 or animated GIF — nothing else is delivered through
+/// the bot.
+#[derive(Debug, Clone, Copy, poise::ChoiceParameter)]
+pub enum VideoFormat {
+    #[name = "MP4 (default)"]
+    Mp4,
+    #[name = "Animated GIF"]
+    Gif,
+}
+
+impl VideoFormat {
+    fn to_output_format(self) -> OutputFormat {
+        match self {
+            VideoFormat::Mp4 => OutputFormat::Mp4,
+            VideoFormat::Gif => OutputFormat::Gif,
+        }
+    }
+}
+
+/// Slash-command facing LTX-2 pipeline selector. Only pipelines that are
+/// fully satisfiable from the Discord command surface are exposed — modes
+/// like `a2vid` / `retake` / `ic-lora` / `keyframe` require extra inputs
+/// (`audio_file`, `source_video`, LoRA stacks, ≥2 keyframes) that the slash
+/// command doesn't collect, and server validation would reject them outright.
+#[derive(Debug, Clone, Copy, poise::ChoiceParameter)]
+pub enum PipelineChoice {
+    #[name = "one-stage"]
+    OneStage,
+    #[name = "two-stage"]
+    TwoStage,
+    #[name = "two-stage-hq"]
+    TwoStageHq,
+    #[name = "distilled"]
+    Distilled,
+}
+
+impl PipelineChoice {
+    fn to_mode(self) -> Ltx2PipelineMode {
+        match self {
+            PipelineChoice::OneStage => Ltx2PipelineMode::OneStage,
+            PipelineChoice::TwoStage => Ltx2PipelineMode::TwoStage,
+            PipelineChoice::TwoStageHq => Ltx2PipelineMode::TwoStageHq,
+            PipelineChoice::Distilled => Ltx2PipelineMode::Distilled,
+        }
+    }
+}
+
+/// Classify a model family: returns `Some("ltx-video")`, `Some("ltx2")`, or
+/// `None` for anything that isn't a recognized video-producing family.
+pub fn video_family(family: &str) -> Option<&str> {
+    match family {
+        "ltx-video" | "ltx2" => Some(family),
+        _ => None,
+    }
+}
+
+/// Look up the family for a resolved model name from the bot's cached models.
+pub fn family_for_model<'a>(models: &'a [ModelInfoExtended], name: &str) -> Option<&'a str> {
+    models
+        .iter()
+        .find(|m| m.info.name == name)
+        .map(|m| m.info.family.as_str())
+}
+
+/// Parameters collected from the Discord slash command before they are turned
+/// into a concrete `GenerateRequest`. Keeps `build_generate_request` signature
+/// small and makes test fixtures explicit.
+#[derive(Debug, Clone, Default)]
+pub struct BuildParams<'a> {
+    pub prompt: &'a str,
+    pub model: &'a str,
+    pub family: Option<&'a str>,
+    pub width: Option<u32>,
+    pub height: Option<u32>,
+    pub steps: Option<u32>,
+    pub guidance: Option<f64>,
+    pub seed: Option<u64>,
+    pub negative_prompt: Option<&'a str>,
+    pub defaults: Option<&'a mold_core::ModelDefaults>,
+    pub source_image: Option<Vec<u8>>,
+    pub frames: Option<u32>,
+    pub fps: Option<u32>,
+    pub strength: Option<f64>,
+    pub video_format: Option<VideoFormat>,
+    pub audio: Option<bool>,
+    pub pipeline: Option<Ltx2PipelineMode>,
+}
+
+/// Build a `GenerateRequest` from slash command parameters, honoring model
+/// defaults and routing video families to an appropriate container.
+pub fn build_generate_request(params: BuildParams<'_>) -> GenerateRequest {
+    let (def_w, def_h, def_steps, def_guidance) = match params.defaults {
         Some(d) => (
             d.default_width,
             d.default_height,
@@ -40,22 +120,51 @@ pub fn build_generate_request(
         None => (1024, 1024, 20, 3.5),
     };
 
+    let is_video_family = params.family.and_then(video_family).is_some();
+    let is_ltx2 = params.family == Some("ltx2");
+
+    // Video families always deliver MP4 or GIF. Image models stay PNG.
+    let output_format = if is_video_family {
+        params
+            .video_format
+            .map(VideoFormat::to_output_format)
+            .unwrap_or(OutputFormat::Mp4)
+    } else {
+        OutputFormat::Png
+    };
+
+    // Default to a sensible frame count for video models when the user didn't
+    // specify one: 25 frames (8n+1) ≈ 1 second at 24 FPS.
+    let frames = if is_video_family {
+        Some(params.frames.unwrap_or(25))
+    } else {
+        params.frames
+    };
+    let fps = if is_video_family {
+        Some(params.fps.unwrap_or(24))
+    } else {
+        params.fps
+    };
+
+    // LTX-2 audio only flows through MP4 container.
+    let enable_audio = if is_ltx2 { params.audio } else { None };
+
     GenerateRequest {
-        prompt: prompt.to_string(),
-        negative_prompt: negative_prompt.map(|s| s.to_string()),
-        model: model.to_string(),
-        width: width.unwrap_or(def_w),
-        height: height.unwrap_or(def_h),
-        steps: steps.unwrap_or(def_steps),
-        guidance: guidance.unwrap_or(def_guidance),
-        seed,
+        prompt: params.prompt.to_string(),
+        negative_prompt: params.negative_prompt.map(|s| s.to_string()),
+        model: params.model.to_string(),
+        width: params.width.unwrap_or(def_w),
+        height: params.height.unwrap_or(def_h),
+        steps: params.steps.unwrap_or(def_steps),
+        guidance: params.guidance.unwrap_or(def_guidance),
+        seed: params.seed,
         batch_size: 1,
-        output_format: OutputFormat::Png,
+        output_format,
         embed_metadata: None,
         scheduler: None,
         edit_images: None,
-        source_image: None,
-        strength: 0.75,
+        source_image: params.source_image,
+        strength: params.strength.unwrap_or(0.75),
         mask_image: None,
         control_image: None,
         control_model: None,
@@ -63,15 +172,18 @@ pub fn build_generate_request(
         expand: None,
         original_prompt: None,
         lora: None,
-        frames: None,
-        fps: None,
+        frames,
+        fps,
         upscale_model: None,
-        gif_preview: false,
-        enable_audio: None,
+        // Always request a GIF preview for video jobs: if the primary MP4
+        // exceeds Discord's upload ceiling we fall back to the preview so the
+        // user still sees the generation.
+        gif_preview: is_video_family,
+        enable_audio,
         audio_file: None,
         source_video: None,
         keyframes: None,
-        pipeline: None,
+        pipeline: if is_ltx2 { params.pipeline } else { None },
         loras: None,
         retake_range: None,
         spatial_upscale: None,
@@ -108,20 +220,87 @@ fn resolve_default_model(models: &[mold_core::ModelInfoExtended]) -> String {
     "flux2-klein:q8".to_string()
 }
 
-/// Generate an AI image from a text prompt.
+/// Maximum inline attachment size we will accept for `source_image`. Discord
+/// caps uploads to 25 MiB for free users (100 MiB with Nitro), but very large
+/// images are almost always a mistake for img2img — resizing happens inside
+/// the server. Keep the bar well below Discord's hard limit to avoid obvious
+/// abuse.
+const MAX_SOURCE_IMAGE_BYTES: u64 = 10 * 1024 * 1024;
+
+/// Snap `(w, h)` to multiples of 16 (FLUX patch / LTX tile constraint) while
+/// keeping the aspect ratio roughly intact and staying inside `[16, max_dim]`.
+/// Used to derive img2img dimensions from a Discord attachment's reported
+/// width/height when the user didn't supply explicit values — otherwise the
+/// server would `resize_exact` a landscape photo into a square default.
+pub fn snap_dims_to_multiple_of_16(w: u32, h: u32, max_dim: u32) -> (u32, u32) {
+    let clamp = |v: u32| -> u32 {
+        let capped = v.min(max_dim.max(16));
+        let rounded = ((capped + 8) / 16) * 16;
+        rounded.max(16)
+    };
+    (clamp(w), clamp(h))
+}
+
+/// Download an attachment and sanity-check that it looks like a PNG or JPEG
+/// before we ship the bytes to the server (which will reject anything else
+/// with a less friendly error).
+async fn fetch_source_image(att: &serenity::Attachment) -> Result<Vec<u8>, String> {
+    if att.size as u64 > MAX_SOURCE_IMAGE_BYTES {
+        return Err(format!(
+            "Source image is too large ({:.1} MiB). Keep it under {} MiB.",
+            att.size as f64 / (1024.0 * 1024.0),
+            MAX_SOURCE_IMAGE_BYTES / (1024 * 1024)
+        ));
+    }
+    if let Some(ct) = &att.content_type {
+        if !(ct.starts_with("image/png") || ct.starts_with("image/jpeg")) {
+            return Err(format!("Source image must be PNG or JPEG, got `{ct}`."));
+        }
+    }
+    let bytes = att
+        .download()
+        .await
+        .map_err(|e| format!("Failed to download source image: {e}"))?;
+    if !looks_like_png_or_jpeg(&bytes) {
+        return Err("Source image must be a valid PNG or JPEG file.".to_string());
+    }
+    Ok(bytes)
+}
+
+fn looks_like_png_or_jpeg(bytes: &[u8]) -> bool {
+    let is_png = bytes.len() >= 4 && bytes[..4] == [0x89, 0x50, 0x4E, 0x47];
+    let is_jpeg = bytes.len() >= 2 && bytes[..2] == [0xFF, 0xD8];
+    is_png || is_jpeg
+}
+
+/// Generate an image (PNG) or video (MP4 by default, GIF on request).
 #[allow(clippy::too_many_arguments)]
 #[poise::command(slash_command)]
 pub async fn generate(
     ctx: Context<'_>,
-    #[description = "Text prompt describing the image to generate"] prompt: String,
-    #[description = "Model to use (e.g. flux-schnell:q8)"]
+    #[description = "Text prompt describing the image or video to generate"] prompt: String,
+    #[description = "Model to use (e.g. flux-schnell:q8, ltx-2-19b-distilled:fp8)"]
     #[autocomplete = "autocomplete_model"]
     model: Option<String>,
+    #[description = "Source image for img2img / img-to-video (PNG or JPEG)"] source_image: Option<
+        serenity::Attachment,
+    >,
+    #[description = "Video container (MP4 default, GIF for easier sharing) — video models only"]
+    video_format: Option<VideoFormat>,
+    #[description = "Number of video frames (video models only; LTX prefers 8n+1)"] frames: Option<
+        u32,
+    >,
+    #[description = "Video FPS (video models only, default 24)"] fps: Option<u32>,
     #[description = "Image width in pixels"] width: Option<u32>,
     #[description = "Image height in pixels"] height: Option<u32>,
     #[description = "Number of inference steps"] steps: Option<u32>,
     #[description = "Guidance scale (0.0 for schnell, ~3.5 for dev)"] guidance: Option<f64>,
     #[description = "Random seed for reproducibility"] seed: Option<u64>,
+    #[description = "img2img strength (0.0 = preserve source, 1.0 = full noise)"] strength: Option<
+        f64,
+    >,
+    #[description = "Enable synchronized audio (LTX-2 + MP4 only)"] audio: Option<bool>,
+    #[description = "LTX-2 pipeline mode (advanced)"] pipeline: Option<PipelineChoice>,
     #[description = "Negative prompt — what to avoid (CFG models: SD1.5, SDXL, SD3)"]
     negative_prompt: Option<String>,
 ) -> Result<()> {
@@ -151,23 +330,69 @@ pub async fn generate(
     let models = ctx.data().cached_models().await;
     let model_name = model.unwrap_or_else(|| resolve_default_model(&models));
 
-    // Look up model defaults from cache
-    let model_defaults = models
-        .iter()
-        .find(|m| m.info.name == model_name)
-        .map(|m| &m.defaults);
+    // Look up model defaults + family from cache
+    let model_entry = models.iter().find(|m| m.info.name == model_name);
+    let model_defaults = model_entry.map(|m| &m.defaults);
+    let family = model_entry.map(|m| m.info.family.as_str());
 
-    let req = build_generate_request(
-        &prompt,
-        &model_name,
-        width,
-        height,
+    // Fetch source image bytes if an attachment was supplied. This also covers
+    // the LTX-2 image-to-video path — the server forwards a source_image to
+    // LTX-2 as the first keyframe automatically.
+    let source_bytes = if let Some(att) = source_image.as_ref() {
+        match fetch_source_image(att).await {
+            Ok(bytes) => Some(bytes),
+            Err(msg) => {
+                ctx.data().quotas.refund(user_id);
+                handler::send_error(ctx, &msg).await?;
+                return Ok(());
+            }
+        }
+    } else {
+        None
+    };
+
+    // When a source image is attached and the user didn't pass explicit dims,
+    // use the attachment's reported width/height (snapped to multiples of 16)
+    // instead of falling through to the model's square default. Without this
+    // landscape/portrait photos get `resize_exact`'d to 1024x1024.
+    let (effective_width, effective_height) =
+        if source_bytes.is_some() && width.is_none() && height.is_none() {
+            match (
+                source_image.as_ref().and_then(|a| a.width),
+                source_image.as_ref().and_then(|a| a.height),
+            ) {
+                (Some(w), Some(h)) => {
+                    let max_dim = model_defaults
+                        .map(|d| d.default_width.max(d.default_height))
+                        .unwrap_or(1024);
+                    let (sw, sh) = snap_dims_to_multiple_of_16(w, h, max_dim);
+                    (Some(sw), Some(sh))
+                }
+                _ => (width, height),
+            }
+        } else {
+            (width, height)
+        };
+
+    let req = build_generate_request(BuildParams {
+        prompt: &prompt,
+        model: &model_name,
+        family,
+        width: effective_width,
+        height: effective_height,
         steps,
         guidance,
         seed,
-        negative_prompt.as_deref(),
-        model_defaults,
-    );
+        negative_prompt: negative_prompt.as_deref(),
+        defaults: model_defaults,
+        source_image: source_bytes,
+        frames,
+        fps,
+        strength,
+        video_format,
+        audio,
+        pipeline: pipeline.map(PipelineChoice::to_mode),
+    });
 
     match handler::run_generation(ctx, req).await {
         Ok(()) => {
@@ -195,26 +420,31 @@ pub async fn generate(
 mod tests {
     use super::*;
 
-    #[test]
-    fn build_request_with_defaults() {
-        let defaults = mold_core::ModelDefaults {
+    fn defaults() -> mold_core::ModelDefaults {
+        mold_core::ModelDefaults {
             default_steps: 4,
             default_guidance: 0.0,
             default_width: 1024,
             default_height: 1024,
             description: "test".to_string(),
-        };
-        let req = build_generate_request(
-            "a cat",
-            "flux2-klein:q8",
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            Some(&defaults),
-        );
+        }
+    }
+
+    fn base_params<'a>(prompt: &'a str, model: &'a str) -> BuildParams<'a> {
+        BuildParams {
+            prompt,
+            model,
+            ..BuildParams::default()
+        }
+    }
+
+    #[test]
+    fn build_request_with_defaults() {
+        let defs = defaults();
+        let req = build_generate_request(BuildParams {
+            defaults: Some(&defs),
+            ..base_params("a cat", "flux2-klein:q8")
+        });
         assert_eq!(req.prompt, "a cat");
         assert_eq!(req.model, "flux2-klein:q8");
         assert_eq!(req.width, 1024);
@@ -224,28 +454,24 @@ mod tests {
         assert!(req.seed.is_none());
         assert!(req.negative_prompt.is_none());
         assert_eq!(req.batch_size, 1);
+        assert_eq!(req.output_format, OutputFormat::Png);
+        assert!(req.frames.is_none());
+        assert!(req.fps.is_none());
+        assert!(req.source_image.is_none());
     }
 
     #[test]
     fn build_request_overrides() {
-        let defaults = mold_core::ModelDefaults {
-            default_steps: 4,
-            default_guidance: 0.0,
-            default_width: 1024,
-            default_height: 1024,
-            description: "test".to_string(),
-        };
-        let req = build_generate_request(
-            "a dog",
-            "flux-dev:q4",
-            Some(768),
-            Some(512),
-            Some(28),
-            Some(7.5),
-            Some(42),
-            None,
-            Some(&defaults),
-        );
+        let defs = defaults();
+        let req = build_generate_request(BuildParams {
+            width: Some(768),
+            height: Some(512),
+            steps: Some(28),
+            guidance: Some(7.5),
+            seed: Some(42),
+            defaults: Some(&defs),
+            ..base_params("a dog", "flux-dev:q4")
+        });
         assert_eq!(req.width, 768);
         assert_eq!(req.height, 512);
         assert_eq!(req.steps, 28);
@@ -255,44 +481,28 @@ mod tests {
 
     #[test]
     fn build_request_no_defaults() {
-        let req = build_generate_request(
-            "test",
-            "unknown-model",
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-        );
+        let req = build_generate_request(base_params("test", "unknown-model"));
         assert_eq!(req.width, 1024);
         assert_eq!(req.height, 1024);
         assert_eq!(req.steps, 20);
         assert_eq!(req.guidance, 3.5);
+        assert_eq!(req.output_format, OutputFormat::Png);
     }
 
     #[test]
     fn build_request_partial_overrides() {
-        let defaults = mold_core::ModelDefaults {
+        let defs = mold_core::ModelDefaults {
             default_steps: 4,
             default_guidance: 0.0,
             default_width: 512,
             default_height: 512,
             description: "test".to_string(),
         };
-        // Override only width, rest from defaults
-        let req = build_generate_request(
-            "test",
-            "sd15:fp16",
-            Some(768),
-            None,
-            None,
-            None,
-            None,
-            None,
-            Some(&defaults),
-        );
+        let req = build_generate_request(BuildParams {
+            width: Some(768),
+            defaults: Some(&defs),
+            ..base_params("test", "sd15:fp16")
+        });
         assert_eq!(req.width, 768);
         assert_eq!(req.height, 512); // from defaults
         assert_eq!(req.steps, 4); // from defaults
@@ -300,24 +510,244 @@ mod tests {
 
     #[test]
     fn build_request_with_negative_prompt() {
-        let req = build_generate_request(
-            "a cat",
-            "sd15:fp16",
-            None,
-            None,
-            None,
-            None,
-            None,
-            Some("blurry, low quality"),
-            None,
-        );
+        let req = build_generate_request(BuildParams {
+            negative_prompt: Some("blurry, low quality"),
+            ..base_params("a cat", "sd15:fp16")
+        });
         assert_eq!(req.negative_prompt.as_deref(), Some("blurry, low quality"));
     }
+
+    // --- Video routing tests ---
+
+    #[test]
+    fn ltx_video_defaults_to_mp4_with_frames() {
+        let req = build_generate_request(BuildParams {
+            family: Some("ltx-video"),
+            ..base_params("a drone shot", "ltx-video-0.9.6-distilled:bf16")
+        });
+        assert_eq!(req.output_format, OutputFormat::Mp4);
+        assert_eq!(req.frames, Some(25));
+        assert_eq!(req.fps, Some(24));
+    }
+
+    #[test]
+    fn ltx2_defaults_to_mp4() {
+        let req = build_generate_request(BuildParams {
+            family: Some("ltx2"),
+            ..base_params("panning over a beach", "ltx-2-19b-distilled:fp8")
+        });
+        assert_eq!(req.output_format, OutputFormat::Mp4);
+        assert_eq!(req.frames, Some(25));
+    }
+
+    #[test]
+    fn ltx2_can_select_gif() {
+        let req = build_generate_request(BuildParams {
+            family: Some("ltx2"),
+            video_format: Some(VideoFormat::Gif),
+            ..base_params("waves", "ltx-2-19b-distilled:fp8")
+        });
+        assert_eq!(req.output_format, OutputFormat::Gif);
+    }
+
+    #[test]
+    fn video_frames_and_fps_pass_through() {
+        let req = build_generate_request(BuildParams {
+            family: Some("ltx2"),
+            frames: Some(49),
+            fps: Some(30),
+            ..base_params("spinning cube", "ltx-2-19b-distilled:fp8")
+        });
+        assert_eq!(req.frames, Some(49));
+        assert_eq!(req.fps, Some(30));
+    }
+
+    #[test]
+    fn image_family_ignores_video_format() {
+        // If someone passes video_format on a non-video model, we still return PNG
+        // instead of silently producing an unsupported container.
+        let req = build_generate_request(BuildParams {
+            family: Some("flux"),
+            video_format: Some(VideoFormat::Mp4),
+            ..base_params("a cat", "flux-schnell:q8")
+        });
+        assert_eq!(req.output_format, OutputFormat::Png);
+        assert!(req.frames.is_none());
+    }
+
+    #[test]
+    fn ltx2_audio_only_for_ltx2() {
+        let req = build_generate_request(BuildParams {
+            family: Some("ltx2"),
+            audio: Some(true),
+            ..base_params("storm at sea", "ltx-2-19b-distilled:fp8")
+        });
+        assert_eq!(req.enable_audio, Some(true));
+
+        // LTX-Video doesn't support audio
+        let req = build_generate_request(BuildParams {
+            family: Some("ltx-video"),
+            audio: Some(true),
+            ..base_params("storm at sea", "ltx-video-0.9.6-distilled:bf16")
+        });
+        assert!(req.enable_audio.is_none());
+    }
+
+    #[test]
+    fn ltx2_pipeline_plumbed_through() {
+        let req = build_generate_request(BuildParams {
+            family: Some("ltx2"),
+            pipeline: Some(Ltx2PipelineMode::Distilled),
+            ..base_params("a city timelapse", "ltx-2-19b-distilled:fp8")
+        });
+        assert_eq!(req.pipeline, Some(Ltx2PipelineMode::Distilled));
+
+        // Pipeline is ignored for non-LTX-2 families (server validates this too)
+        let req = build_generate_request(BuildParams {
+            family: Some("ltx-video"),
+            pipeline: Some(Ltx2PipelineMode::Distilled),
+            ..base_params("a city timelapse", "ltx-video-0.9.6-distilled:bf16")
+        });
+        assert!(req.pipeline.is_none());
+    }
+
+    #[test]
+    fn img2img_source_image_passes_through() {
+        let bytes = vec![0x89, b'P', b'N', b'G', 0u8, 1, 2, 3];
+        let req = build_generate_request(BuildParams {
+            family: Some("flux"),
+            source_image: Some(bytes.clone()),
+            strength: Some(0.55),
+            ..base_params("a cat", "flux-schnell:q8")
+        });
+        assert_eq!(req.source_image.as_ref(), Some(&bytes));
+        assert!((req.strength - 0.55).abs() < 1e-9);
+    }
+
+    #[test]
+    fn img2video_on_ltx2_routes_to_mp4() {
+        // A source_image on an LTX-2 request is the I2V path (server treats it
+        // as a first-frame keyframe).
+        let bytes = vec![0xFF, 0xD8, 0xFF, 0xE0, 0, 1, 2, 3];
+        let req = build_generate_request(BuildParams {
+            family: Some("ltx2"),
+            source_image: Some(bytes.clone()),
+            ..base_params("dolly in", "ltx-2-19b-distilled:fp8")
+        });
+        assert_eq!(req.output_format, OutputFormat::Mp4);
+        assert_eq!(req.source_image.as_ref(), Some(&bytes));
+        assert_eq!(req.frames, Some(25));
+    }
+
+    #[test]
+    fn video_family_requests_gif_preview() {
+        let req = build_generate_request(BuildParams {
+            family: Some("ltx2"),
+            ..base_params("a cat", "ltx-2-19b-distilled:fp8")
+        });
+        assert!(req.gif_preview);
+
+        let req = build_generate_request(BuildParams {
+            family: Some("ltx-video"),
+            ..base_params("a cat", "ltx-video-0.9.6-distilled:bf16")
+        });
+        assert!(req.gif_preview);
+    }
+
+    #[test]
+    fn image_family_does_not_request_gif_preview() {
+        let req = build_generate_request(base_params("a cat", "flux-schnell:q8"));
+        assert!(!req.gif_preview);
+    }
+
+    #[test]
+    fn pipeline_choice_maps_to_supported_modes_only() {
+        // Round-trip every exposed variant and assert it maps to an
+        // Ltx2PipelineMode the slash command can actually satisfy.
+        assert_eq!(
+            PipelineChoice::OneStage.to_mode(),
+            Ltx2PipelineMode::OneStage
+        );
+        assert_eq!(
+            PipelineChoice::TwoStage.to_mode(),
+            Ltx2PipelineMode::TwoStage
+        );
+        assert_eq!(
+            PipelineChoice::TwoStageHq.to_mode(),
+            Ltx2PipelineMode::TwoStageHq
+        );
+        assert_eq!(
+            PipelineChoice::Distilled.to_mode(),
+            Ltx2PipelineMode::Distilled
+        );
+    }
+
+    // --- snap_dims ---
+
+    #[test]
+    fn snap_dims_rounds_to_multiples_of_16() {
+        assert_eq!(snap_dims_to_multiple_of_16(1000, 1000, 1024), (1008, 1008));
+        assert_eq!(snap_dims_to_multiple_of_16(1920, 1080, 1024), (1024, 1024));
+        assert_eq!(snap_dims_to_multiple_of_16(777, 513, 1024), (784, 512));
+        // Under the multiple-of-16 floor
+        assert_eq!(snap_dims_to_multiple_of_16(3, 5, 1024), (16, 16));
+        // Landscape aspect preserved roughly
+        let (w, h) = snap_dims_to_multiple_of_16(800, 600, 1024);
+        assert_eq!((w, h), (800, 608));
+    }
+
+    // --- Header sniff ---
+
+    #[test]
+    fn looks_like_png_or_jpeg_sniffs_magic_bytes() {
+        assert!(looks_like_png_or_jpeg(&[
+            0x89, 0x50, 0x4E, 0x47, 0, 0, 0, 0
+        ]));
+        assert!(looks_like_png_or_jpeg(&[0xFF, 0xD8, 0xFF, 0xE0]));
+        assert!(!looks_like_png_or_jpeg(&[]));
+        assert!(!looks_like_png_or_jpeg(&[0x47, 0x49, 0x46, 0x38])); // GIF89a
+        assert!(!looks_like_png_or_jpeg(&[0x00, 0x00, 0x00, 0x20])); // MP4-ish
+    }
+
+    // --- video_family / family_for_model ---
+
+    #[test]
+    fn video_family_classification() {
+        assert_eq!(video_family("ltx-video"), Some("ltx-video"));
+        assert_eq!(video_family("ltx2"), Some("ltx2"));
+        assert!(video_family("flux").is_none());
+        assert!(video_family("sdxl").is_none());
+    }
+
+    #[test]
+    fn family_for_model_lookup() {
+        let models = vec![ModelInfoExtended {
+            info: mold_core::ModelInfo {
+                name: "ltx-2-19b-distilled:fp8".to_string(),
+                family: "ltx2".to_string(),
+                size_gb: 19.0,
+                is_loaded: false,
+                last_used: None,
+                hf_repo: "test/repo".to_string(),
+            },
+            defaults: defaults(),
+            downloaded: true,
+            disk_usage_bytes: None,
+            remaining_download_bytes: None,
+        }];
+        assert_eq!(
+            family_for_model(&models, "ltx-2-19b-distilled:fp8"),
+            Some("ltx2")
+        );
+        assert!(family_for_model(&models, "unknown").is_none());
+    }
+
+    // --- resolve_default_model (unchanged behavior) ---
 
     #[test]
     fn resolve_default_prefers_loaded() {
         let models = vec![
-            mold_core::ModelInfoExtended {
+            ModelInfoExtended {
                 info: mold_core::ModelInfo {
                     name: "flux-dev:q4".to_string(),
                     family: "flux".to_string(),
@@ -326,18 +756,12 @@ mod tests {
                     last_used: None,
                     hf_repo: "test/repo".to_string(),
                 },
-                defaults: mold_core::ModelDefaults {
-                    default_steps: 25,
-                    default_guidance: 3.5,
-                    default_width: 1024,
-                    default_height: 1024,
-                    description: "test".to_string(),
-                },
+                defaults: defaults(),
                 downloaded: true,
                 disk_usage_bytes: None,
                 remaining_download_bytes: None,
             },
-            mold_core::ModelInfoExtended {
+            ModelInfoExtended {
                 info: mold_core::ModelInfo {
                     name: "flux2-klein:q8".to_string(),
                     family: "flux".to_string(),
@@ -346,13 +770,7 @@ mod tests {
                     last_used: None,
                     hf_repo: "test/repo".to_string(),
                 },
-                defaults: mold_core::ModelDefaults {
-                    default_steps: 4,
-                    default_guidance: 0.0,
-                    default_width: 1024,
-                    default_height: 1024,
-                    description: "test".to_string(),
-                },
+                defaults: defaults(),
                 downloaded: true,
                 disk_usage_bytes: None,
                 remaining_download_bytes: None,
@@ -363,7 +781,7 @@ mod tests {
 
     #[test]
     fn resolve_default_falls_back_to_downloaded() {
-        let models = vec![mold_core::ModelInfoExtended {
+        let models = vec![ModelInfoExtended {
             info: mold_core::ModelInfo {
                 name: "flux-dev:q4".to_string(),
                 family: "flux".to_string(),
@@ -372,13 +790,7 @@ mod tests {
                 last_used: None,
                 hf_repo: "test/repo".to_string(),
             },
-            defaults: mold_core::ModelDefaults {
-                default_steps: 25,
-                default_guidance: 3.5,
-                default_width: 1024,
-                default_height: 1024,
-                description: "test".to_string(),
-            },
+            defaults: defaults(),
             downloaded: true,
             disk_usage_bytes: None,
             remaining_download_bytes: None,
@@ -392,57 +804,9 @@ mod tests {
     }
 
     #[test]
-    fn resolve_default_picks_smallest_when_multiple_downloaded() {
-        let models = vec![
-            mold_core::ModelInfoExtended {
-                info: mold_core::ModelInfo {
-                    name: "flux-schnell:bf16".to_string(),
-                    family: "flux".to_string(),
-                    size_gb: 22.1,
-                    is_loaded: false,
-                    last_used: None,
-                    hf_repo: "test/repo".to_string(),
-                },
-                defaults: mold_core::ModelDefaults {
-                    default_steps: 4,
-                    default_guidance: 0.0,
-                    default_width: 1024,
-                    default_height: 1024,
-                    description: "test".to_string(),
-                },
-                downloaded: true,
-                disk_usage_bytes: None,
-                remaining_download_bytes: None,
-            },
-            mold_core::ModelInfoExtended {
-                info: mold_core::ModelInfo {
-                    name: "flux2-klein:q8".to_string(),
-                    family: "flux".to_string(),
-                    size_gb: 4.5,
-                    is_loaded: false,
-                    last_used: None,
-                    hf_repo: "test/repo".to_string(),
-                },
-                defaults: mold_core::ModelDefaults {
-                    default_steps: 4,
-                    default_guidance: 0.0,
-                    default_width: 1024,
-                    default_height: 1024,
-                    description: "test".to_string(),
-                },
-                downloaded: true,
-                disk_usage_bytes: None,
-                remaining_download_bytes: None,
-            },
-        ];
-        // Should pick q8 (4.5GB) over bf16 (22.1GB)
-        assert_eq!(resolve_default_model(&models), "flux2-klein:q8");
-    }
-
-    #[test]
     fn resolve_default_skips_utility_models() {
         let models = vec![
-            mold_core::ModelInfoExtended {
+            ModelInfoExtended {
                 info: mold_core::ModelInfo {
                     name: "qwen3-expand:q8".to_string(),
                     family: "qwen3-expand".to_string(),
@@ -451,18 +815,12 @@ mod tests {
                     last_used: None,
                     hf_repo: "test/repo".to_string(),
                 },
-                defaults: mold_core::ModelDefaults {
-                    default_steps: 0,
-                    default_guidance: 0.0,
-                    default_width: 0,
-                    default_height: 0,
-                    description: "Expand model".to_string(),
-                },
+                defaults: defaults(),
                 downloaded: true,
                 disk_usage_bytes: None,
                 remaining_download_bytes: None,
             },
-            mold_core::ModelInfoExtended {
+            ModelInfoExtended {
                 info: mold_core::ModelInfo {
                     name: "flux2-klein:q8".to_string(),
                     family: "flux".to_string(),
@@ -471,52 +829,19 @@ mod tests {
                     last_used: None,
                     hf_repo: "test/repo".to_string(),
                 },
-                defaults: mold_core::ModelDefaults {
-                    default_steps: 4,
-                    default_guidance: 0.0,
-                    default_width: 1024,
-                    default_height: 1024,
-                    description: "test".to_string(),
-                },
+                defaults: defaults(),
                 downloaded: true,
                 disk_usage_bytes: None,
                 remaining_download_bytes: None,
             },
         ];
-        // Should pick flux2-klein:q8, not the utility model
-        assert_eq!(resolve_default_model(&models), "flux2-klein:q8");
-    }
-
-    #[test]
-    fn resolve_default_only_utility_downloaded_falls_back() {
-        let models = vec![mold_core::ModelInfoExtended {
-            info: mold_core::ModelInfo {
-                name: "qwen3-expand:q8".to_string(),
-                family: "qwen3-expand".to_string(),
-                size_gb: 1.8,
-                is_loaded: false,
-                last_used: None,
-                hf_repo: "test/repo".to_string(),
-            },
-            defaults: mold_core::ModelDefaults {
-                default_steps: 0,
-                default_guidance: 0.0,
-                default_width: 0,
-                default_height: 0,
-                description: "Expand model".to_string(),
-            },
-            downloaded: true,
-            disk_usage_bytes: None,
-            remaining_download_bytes: None,
-        }];
-        // Only utility model downloaded — should fall back to default
         assert_eq!(resolve_default_model(&models), "flux2-klein:q8");
     }
 
     #[test]
     fn resolve_default_skips_controlnet() {
         let models = vec![
-            mold_core::ModelInfoExtended {
+            ModelInfoExtended {
                 info: mold_core::ModelInfo {
                     name: "controlnet-canny-sd15:fp16".to_string(),
                     family: "controlnet".to_string(),
@@ -525,18 +850,12 @@ mod tests {
                     last_used: None,
                     hf_repo: "test/repo".to_string(),
                 },
-                defaults: mold_core::ModelDefaults {
-                    default_steps: 25,
-                    default_guidance: 7.5,
-                    default_width: 512,
-                    default_height: 512,
-                    description: "test".to_string(),
-                },
+                defaults: defaults(),
                 downloaded: true,
                 disk_usage_bytes: None,
                 remaining_download_bytes: None,
             },
-            mold_core::ModelInfoExtended {
+            ModelInfoExtended {
                 info: mold_core::ModelInfo {
                     name: "flux2-klein:q8".to_string(),
                     family: "flux".to_string(),
@@ -545,19 +864,12 @@ mod tests {
                     last_used: None,
                     hf_repo: "test/repo".to_string(),
                 },
-                defaults: mold_core::ModelDefaults {
-                    default_steps: 4,
-                    default_guidance: 0.0,
-                    default_width: 1024,
-                    default_height: 1024,
-                    description: "test".to_string(),
-                },
+                defaults: defaults(),
                 downloaded: true,
                 disk_usage_bytes: None,
                 remaining_download_bytes: None,
             },
         ];
-        // Should pick flux2-klein:q8, not the smaller controlnet
         assert_eq!(resolve_default_model(&models), "flux2-klein:q8");
     }
 }

--- a/crates/mold-discord/src/format.rs
+++ b/crates/mold-discord/src/format.rs
@@ -111,14 +111,10 @@ fn progress_bar(current: usize, total: usize) -> String {
     )
 }
 
-/// Format a completed generation result into embed data.
+/// Format a completed generation result into embed data. Video responses get
+/// a distinct title and include frame/fps metadata alongside the usual fields.
 pub fn format_generation_result(resp: &GenerateResponse, prompt: &str) -> EmbedData {
     let time_secs = resp.generation_time_ms as f64 / 1000.0;
-    let dims = resp
-        .images
-        .first()
-        .map(|img| format!("{}x{}", img.width, img.height))
-        .unwrap_or_default();
 
     let truncated_prompt = if prompt.chars().count() > 256 {
         let truncated: String = prompt.chars().take(253).collect();
@@ -127,15 +123,50 @@ pub fn format_generation_result(resp: &GenerateResponse, prompt: &str) -> EmbedD
         prompt.to_string()
     };
 
-    EmbedData {
-        title: "Image Generated".to_string(),
-        description: truncated_prompt,
-        fields: vec![
+    let (title, mut fields) = if let Some(video) = resp.video.as_ref() {
+        let format_label = video.format.extension().to_ascii_uppercase();
+        let mut fields = vec![
+            ("Model".to_string(), resp.model.clone(), true),
+            (
+                "Size".to_string(),
+                format!("{}x{}", video.width, video.height),
+                true,
+            ),
+            ("Time".to_string(), format!("{time_secs:.1}s"), true),
+            (
+                "Frames".to_string(),
+                format!("{} @ {} fps", video.frames, video.fps),
+                true,
+            ),
+            ("Format".to_string(), format_label, true),
+        ];
+        if video.has_audio {
+            fields.push(("Audio".to_string(), "yes".to_string(), true));
+        }
+        fields.push(("Seed".to_string(), resp.seed_used.to_string(), false));
+        ("Video Generated".to_string(), fields)
+    } else {
+        let dims = resp
+            .images
+            .first()
+            .map(|img| format!("{}x{}", img.width, img.height))
+            .unwrap_or_default();
+        let fields = vec![
             ("Model".to_string(), resp.model.clone(), true),
             ("Size".to_string(), dims, true),
             ("Time".to_string(), format!("{time_secs:.1}s"), true),
             ("Seed".to_string(), resp.seed_used.to_string(), false),
-        ],
+        ];
+        ("Image Generated".to_string(), fields)
+    };
+
+    // Preserve insertion order so tests/UI stay stable.
+    fields.retain(|(_, v, _)| !v.is_empty());
+
+    EmbedData {
+        title,
+        description: truncated_prompt,
+        fields,
         color: COLOR_SUCCESS,
     }
 }
@@ -535,6 +566,81 @@ mod tests {
         let embed = format_generation_result(&resp, &long_prompt);
         assert!(embed.description.chars().count() <= 260);
         assert!(embed.description.ends_with("..."));
+    }
+
+    #[test]
+    fn generation_result_video_has_frame_and_format_fields() {
+        let resp = GenerateResponse {
+            images: vec![],
+            video: Some(mold_core::VideoData {
+                data: vec![0u8; 16],
+                format: OutputFormat::Mp4,
+                width: 768,
+                height: 512,
+                frames: 25,
+                fps: 24,
+                thumbnail: vec![],
+                gif_preview: vec![],
+                has_audio: true,
+                duration_ms: Some(1000),
+                audio_sample_rate: Some(44_100),
+                audio_channels: Some(2),
+            }),
+            generation_time_ms: 10_000,
+            model: "ltx-2-19b-distilled:fp8".to_string(),
+            seed_used: 7,
+            gpu: None,
+        };
+        let embed = format_generation_result(&resp, "a drone shot");
+        assert_eq!(embed.title, "Video Generated");
+        assert!(embed
+            .fields
+            .iter()
+            .any(|(k, v, _)| k == "Frames" && v == "25 @ 24 fps"));
+        assert!(embed
+            .fields
+            .iter()
+            .any(|(k, v, _)| k == "Format" && v == "MP4"));
+        assert!(embed
+            .fields
+            .iter()
+            .any(|(k, v, _)| k == "Audio" && v == "yes"));
+        assert!(embed
+            .fields
+            .iter()
+            .any(|(k, v, _)| k == "Size" && v == "768x512"));
+    }
+
+    #[test]
+    fn generation_result_video_gif_shows_gif_label() {
+        let resp = GenerateResponse {
+            images: vec![],
+            video: Some(mold_core::VideoData {
+                data: vec![0u8; 16],
+                format: OutputFormat::Gif,
+                width: 512,
+                height: 512,
+                frames: 17,
+                fps: 12,
+                thumbnail: vec![],
+                gif_preview: vec![],
+                has_audio: false,
+                duration_ms: None,
+                audio_sample_rate: None,
+                audio_channels: None,
+            }),
+            generation_time_ms: 500,
+            model: "ltx-video-0.9.6-distilled:bf16".to_string(),
+            seed_used: 3,
+            gpu: None,
+        };
+        let embed = format_generation_result(&resp, "loop");
+        assert_eq!(embed.title, "Video Generated");
+        assert!(embed
+            .fields
+            .iter()
+            .any(|(k, v, _)| k == "Format" && v == "GIF"));
+        assert!(!embed.fields.iter().any(|(k, _, _)| k == "Audio"));
     }
 
     #[test]

--- a/crates/mold-discord/src/handler.rs
+++ b/crates/mold-discord/src/handler.rs
@@ -1,12 +1,17 @@
 use crate::format::{self, EmbedData};
 use crate::state::Context;
 use anyhow::Result;
-use mold_core::{GenerateRequest, MoldClient};
+use mold_core::{GenerateRequest, MoldClient, OutputFormat};
 use poise::serenity_prelude::{CreateAttachment, CreateEmbed};
 use std::time::Instant;
 
 /// Minimum interval between Discord embed edits to avoid rate limits.
 const EDIT_THROTTLE: std::time::Duration = std::time::Duration::from_secs(3);
+
+/// Discord free-tier upload ceiling. We stay conservatively under the 25 MiB
+/// boundary to leave headroom for multipart overhead. If the primary video
+/// payload exceeds this we fall back to the always-generated gif_preview.
+const MAX_ATTACHMENT_BYTES: usize = 24 * 1024 * 1024;
 
 /// Convert our format::EmbedData into a serenity CreateEmbed.
 pub fn embed_data_to_create_embed(data: &EmbedData) -> CreateEmbed {
@@ -81,6 +86,53 @@ pub async fn run_generation(ctx: Context<'_>, req: GenerateRequest) -> Result<()
     Ok(())
 }
 
+/// Pick the attachment bytes we want to send to Discord. Video responses take
+/// precedence over image payloads; oversized MP4s fall back to the GIF preview
+/// the server always bundles so users still see *something* in their channel.
+pub fn select_attachment(resp: &mold_core::GenerateResponse, seed: u64) -> Option<DiscordPayload> {
+    if let Some(video) = resp.video.as_ref() {
+        let primary_too_big = video.data.len() > MAX_ATTACHMENT_BYTES;
+        let has_preview = !video.gif_preview.is_empty();
+        if primary_too_big && has_preview {
+            return Some(DiscordPayload {
+                filename: format!("mold-{seed}.gif"),
+                data: video.gif_preview.clone(),
+                note: Some(format!(
+                    "Primary {} exceeded Discord's upload limit ({:.1} MiB); falling back to GIF preview.",
+                    video.format.extension().to_ascii_uppercase(),
+                    video.data.len() as f64 / (1024.0 * 1024.0)
+                )),
+            });
+        }
+        return Some(DiscordPayload {
+            filename: format!("mold-{seed}.{}", video.format.extension()),
+            data: video.data.clone(),
+            note: None,
+        });
+    }
+
+    resp.images.first().map(|image| {
+        let ext = match image.format {
+            OutputFormat::Png => "png",
+            other => other.extension(),
+        };
+        DiscordPayload {
+            filename: format!("mold-{seed}.{ext}"),
+            data: image.data.clone(),
+            note: None,
+        }
+    })
+}
+
+/// Bytes + filename destined for a Discord attachment.
+#[derive(Debug, Clone)]
+pub struct DiscordPayload {
+    pub filename: String,
+    pub data: Vec<u8>,
+    /// Optional user-visible note (e.g. "primary output was too large, here's the preview").
+    pub note: Option<String>,
+}
+
 /// Edit the existing reply with the final generation result and image attachment.
 async fn send_result_edit(
     handle: &poise::ReplyHandle<'_>,
@@ -93,11 +145,12 @@ async fn send_result_edit(
 
     let mut reply = poise::CreateReply::default();
 
-    if let Some(image) = resp.images.first() {
-        let ext = image.format.extension();
-        let filename = format!("mold-{}.{ext}", resp.seed_used);
-        let attachment = CreateAttachment::bytes(image.data.clone(), filename.clone());
-        embed = embed.attachment(&filename);
+    if let Some(payload) = select_attachment(resp, resp.seed_used) {
+        if let Some(note) = &payload.note {
+            embed = embed.footer(poise::serenity_prelude::CreateEmbedFooter::new(note));
+        }
+        let attachment = CreateAttachment::bytes(payload.data.clone(), payload.filename.clone());
+        embed = embed.attachment(&payload.filename);
         reply = reply.attachment(attachment);
     }
 
@@ -113,4 +166,110 @@ pub async fn send_error(ctx: Context<'_>, message: &str) -> Result<()> {
     let embed = embed_data_to_create_embed(&embed_data);
     ctx.send(poise::CreateReply::default().embed(embed)).await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mold_core::{GenerateResponse, ImageData, OutputFormat, VideoData};
+
+    fn video_response(data: Vec<u8>, preview: Vec<u8>, format: OutputFormat) -> GenerateResponse {
+        GenerateResponse {
+            images: vec![],
+            video: Some(VideoData {
+                data,
+                format,
+                width: 768,
+                height: 512,
+                frames: 25,
+                fps: 24,
+                thumbnail: vec![],
+                gif_preview: preview,
+                has_audio: false,
+                duration_ms: Some(1000),
+                audio_sample_rate: None,
+                audio_channels: None,
+            }),
+            generation_time_ms: 1234,
+            model: "ltx-2-19b-distilled:fp8".to_string(),
+            seed_used: 7,
+            gpu: None,
+        }
+    }
+
+    #[test]
+    fn select_attachment_prefers_video_mp4() {
+        let resp = video_response(vec![0u8; 1024], vec![], OutputFormat::Mp4);
+        let payload = select_attachment(&resp, 7).expect("payload");
+        assert_eq!(payload.filename, "mold-7.mp4");
+        assert_eq!(payload.data.len(), 1024);
+        assert!(payload.note.is_none());
+    }
+
+    #[test]
+    fn select_attachment_uses_gif_for_gif_format() {
+        let resp = video_response(vec![0u8; 512], vec![], OutputFormat::Gif);
+        let payload = select_attachment(&resp, 42).expect("payload");
+        assert_eq!(payload.filename, "mold-42.gif");
+    }
+
+    #[test]
+    fn select_attachment_falls_back_when_video_too_large() {
+        // Primary > MAX_ATTACHMENT_BYTES; preview has content.
+        let huge = vec![0u8; MAX_ATTACHMENT_BYTES + 1];
+        let preview = vec![0x47, 0x49, 0x46, 0x38, 0x39, 0x61]; // GIF89a stub
+        let resp = video_response(huge, preview.clone(), OutputFormat::Mp4);
+        let payload = select_attachment(&resp, 9).expect("payload");
+        assert_eq!(payload.filename, "mold-9.gif");
+        assert_eq!(payload.data, preview);
+        assert!(payload.note.is_some());
+        let note = payload.note.unwrap();
+        assert!(note.contains("MP4"));
+        assert!(note.contains("preview"));
+    }
+
+    #[test]
+    fn select_attachment_keeps_large_video_when_no_preview() {
+        // If there's no preview to fall back to, keep the big video — Discord
+        // will reject it, which is better than silently dropping the output.
+        let huge = vec![0u8; MAX_ATTACHMENT_BYTES + 1];
+        let resp = video_response(huge.clone(), vec![], OutputFormat::Mp4);
+        let payload = select_attachment(&resp, 1).expect("payload");
+        assert_eq!(payload.filename, "mold-1.mp4");
+        assert_eq!(payload.data.len(), huge.len());
+    }
+
+    #[test]
+    fn select_attachment_falls_back_to_images_when_no_video() {
+        let resp = GenerateResponse {
+            images: vec![ImageData {
+                data: vec![1, 2, 3],
+                format: OutputFormat::Png,
+                width: 1024,
+                height: 1024,
+                index: 0,
+            }],
+            video: None,
+            generation_time_ms: 100,
+            model: "flux-schnell:q8".to_string(),
+            seed_used: 5,
+            gpu: None,
+        };
+        let payload = select_attachment(&resp, 5).expect("payload");
+        assert_eq!(payload.filename, "mold-5.png");
+        assert_eq!(payload.data, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn select_attachment_returns_none_when_empty() {
+        let resp = GenerateResponse {
+            images: vec![],
+            video: None,
+            generation_time_ms: 10,
+            model: "empty".to_string(),
+            seed_used: 0,
+            gpu: None,
+        };
+        assert!(select_attachment(&resp, 0).is_none());
+    }
 }

--- a/website/api/discord.md
+++ b/website/api/discord.md
@@ -25,16 +25,16 @@ MOLD_HOST=http://gpu-host:7680 MOLD_DISCORD_TOKEN="your-token" mold discord
 
 ## Slash Commands
 
-| Command              | Description                                                                              |
-| -------------------- | ---------------------------------------------------------------------------------------- |
+| Command              | Description                                                                                                                                                           |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `/generate`          | Generate an image or video (prompt, model, source_image, video_format, frames, fps, width, height, steps, guidance, seed, strength, audio, pipeline, negative_prompt) |
-| `/expand`            | Expand a short prompt into detailed generation prompts                                   |
-| `/models`            | List available models with download/loaded status                                        |
-| `/status`            | Show server health, GPU info, uptime                                                     |
-| `/quota`             | Check your remaining daily generation quota                                              |
-| `/admin reset-quota` | Reset a user's daily quota (requires Manage Server)                                      |
-| `/admin block`       | Temporarily block a user from generating (requires Manage Server)                        |
-| `/admin unblock`     | Unblock a previously blocked user (requires Manage Server)                               |
+| `/expand`            | Expand a short prompt into detailed generation prompts                                                                                                                |
+| `/models`            | List available models with download/loaded status                                                                                                                     |
+| `/status`            | Show server health, GPU info, uptime                                                                                                                                  |
+| `/quota`             | Check your remaining daily generation quota                                                                                                                           |
+| `/admin reset-quota` | Reset a user's daily quota (requires Manage Server)                                                                                                                   |
+| `/admin block`       | Temporarily block a user from generating (requires Manage Server)                                                                                                     |
+| `/admin unblock`     | Unblock a previously blocked user (requires Manage Server)                                                                                                            |
 
 ## Configuration
 

--- a/website/api/discord.md
+++ b/website/api/discord.md
@@ -27,7 +27,7 @@ MOLD_HOST=http://gpu-host:7680 MOLD_DISCORD_TOKEN="your-token" mold discord
 
 | Command              | Description                                                                              |
 | -------------------- | ---------------------------------------------------------------------------------------- |
-| `/generate`          | Generate an image (prompt, model, width, height, steps, guidance, seed, negative_prompt) |
+| `/generate`          | Generate an image or video (prompt, model, source_image, video_format, frames, fps, width, height, steps, guidance, seed, strength, audio, pipeline, negative_prompt) |
 | `/expand`            | Expand a short prompt into detailed generation prompts                                   |
 | `/models`            | List available models with download/loaded status                                        |
 | `/status`            | Show server health, GPU info, uptime                                                     |
@@ -45,6 +45,14 @@ MOLD_HOST=http://gpu-host:7680 MOLD_DISCORD_TOKEN="your-token" mold discord
 | `MOLD_DISCORD_COOLDOWN`      | `10`                    | Per-user cooldown (s)                                                   |
 | `MOLD_DISCORD_ALLOWED_ROLES` | —                       | Comma-separated role names/IDs for access control (unset = all)         |
 | `MOLD_DISCORD_DAILY_QUOTA`   | —                       | Max generations per user per UTC day (unset = unlimited; 0 = block all) |
+
+::: tip Video generation
+Running `/generate` against a video model (`ltx-video-*`, `ltx-2-*`) produces an
+MP4 by default. Pass `video_format: Animated GIF` to receive a GIF instead. You
+can also attach a `source_image` for img2img on regular models, or as the first
+frame for LTX-2 image-to-video. When the rendered MP4 exceeds Discord's upload
+ceiling the bot falls back to the always-bundled GIF preview.
+:::
 
 ::: info Block List
 The `/admin block` command stores blocks in memory. Blocks clear when the bot


### PR DESCRIPTION
## Summary

- Extend Discord `/generate` to support video-family models (LTX-Video, LTX-2) with **MP4 by default** and **animated GIF** as the alternative container.
- Accept optional `source_image` attachment for img2img on image models and as the first frame for LTX-2 image-to-video; preserves aspect ratio (snapped to multiples of 16) instead of stretching to the model's square default.
- Plumb `frames`, `fps`, `audio` (LTX-2 only), `pipeline` (LTX-2 OneStage/TwoStage/TwoStageHq/Distilled — modes needing extra inputs are intentionally hidden), `strength`, and `negative_prompt`.
- Handler attaches `resp.video` bytes and falls back to the bundled `gif_preview` when the primary MP4 exceeds Discord's ~24 MiB ceiling; embed footer notes the swap.
- Address Codex peer-review findings: request `gif_preview: true` so fallback actually fires, remove `a2vid` / `retake` pipeline choices the command can't satisfy, snap source-image dims to preserve aspect.
- 96 unit tests in `mold-ai-discord` (video routing, img2img/img2video wiring, attachment fallback, dim snapping, pipeline gating).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test -p mold-ai-discord` (96 pass)
- [ ] Smoke against a live LTX-2 server:
  - [ ] `/generate ltx-2-19b-distilled:fp8 "a drone shot of a beach"` returns MP4
  - [ ] `/generate video_format: Animated GIF` returns GIF
  - [ ] `/generate` with `source_image` attachment + flux model runs img2img at the photo's aspect ratio
  - [ ] `/generate` with `source_image` attachment + LTX-2 runs image-to-video
  - [ ] Oversized MP4 gracefully falls back to GIF preview with footer note