### PR TITLE
feat(placement): per-component device placement for FLUX/Flux.2/Z-Image/Qwen-Image

### DIFF
--- a/crates/mold-cli/src/commands/generate.rs
+++ b/crates/mold-cli/src/commands/generate.rs
@@ -311,6 +311,7 @@ pub async fn run(
         retake_range,
         spatial_upscale,
         temporal_upscale,
+        placement: None,
     };
 
     // Warn if user-provided dimensions don't match model recommendations.

--- a/crates/mold-cli/src/commands/runpod.rs
+++ b/crates/mold-cli/src/commands/runpod.rs
@@ -1377,6 +1377,7 @@ pub async fn run_run(opts: RunOptions) -> Result<()> {
         retake_range: None,
         spatial_upscale: None,
         temporal_upscale: None,
+        placement: None,
     };
     let http = mold_core::MoldClient::new(&mold_host);
 

--- a/crates/mold-core/src/config.rs
+++ b/crates/mold-core/src/config.rs
@@ -93,6 +93,11 @@ pub struct ModelConfig {
     // --- metadata ---
     pub description: Option<String>,
     pub family: Option<String>,
+
+    /// Per-component device placement override. `None` preserves the
+    /// engine's VRAM-aware auto-placement.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub placement: Option<crate::types::DevicePlacement>,
 }
 
 impl ModelConfig {
@@ -963,6 +968,98 @@ impl Config {
         self.models.remove(name)
     }
 
+    /// Return the effective placement for a model: config entry plus env overrides.
+    ///
+    /// Precedence (higher wins):
+    ///   1. `MOLD_PLACE_TRANSFORMER`, `MOLD_PLACE_VAE`, `MOLD_PLACE_TEXT_ENCODERS`,
+    ///      `MOLD_PLACE_T5`, `MOLD_PLACE_CLIP_L`, `MOLD_PLACE_CLIP_G`,
+    ///      `MOLD_PLACE_QWEN` (env overrides per-component).
+    ///   2. Config file `[models."name:tag".placement]` table.
+    ///   3. `None` (use engine auto).
+    ///
+    /// Each env var parses:
+    ///   - `"auto"`    — `DeviceRef::Auto`
+    ///   - `"cpu"`     — `DeviceRef::Cpu`
+    ///   - `"gpu:N"`   — `DeviceRef::Gpu { ordinal: N }`
+    ///   - `"gpu"`     — `DeviceRef::Gpu { ordinal: 0 }`
+    pub fn resolved_placement(
+        &self,
+        model_name: &str,
+    ) -> Option<crate::types::DevicePlacement> {
+        use crate::types::DevicePlacement;
+
+        let mut placement = self
+            .lookup_model_config(model_name)
+            .and_then(|mc| mc.placement);
+
+        let env_tier1 = parse_device_ref_env("MOLD_PLACE_TEXT_ENCODERS");
+        let env_transformer = parse_device_ref_env("MOLD_PLACE_TRANSFORMER");
+        let env_vae = parse_device_ref_env("MOLD_PLACE_VAE");
+        let env_t5 = parse_device_ref_env("MOLD_PLACE_T5");
+        let env_clip_l = parse_device_ref_env("MOLD_PLACE_CLIP_L");
+        let env_clip_g = parse_device_ref_env("MOLD_PLACE_CLIP_G");
+        let env_qwen = parse_device_ref_env("MOLD_PLACE_QWEN");
+
+        let any_env = env_tier1.is_some()
+            || env_transformer.is_some()
+            || env_vae.is_some()
+            || env_t5.is_some()
+            || env_clip_l.is_some()
+            || env_clip_g.is_some()
+            || env_qwen.is_some();
+
+        if !any_env {
+            return placement;
+        }
+
+        let mut effective: DevicePlacement = placement.unwrap_or_default();
+        if let Some(r) = env_tier1 {
+            effective.text_encoders = r;
+        }
+        let any_advanced = env_transformer.is_some()
+            || env_vae.is_some()
+            || env_t5.is_some()
+            || env_clip_l.is_some()
+            || env_clip_g.is_some()
+            || env_qwen.is_some();
+        if any_advanced {
+            let mut adv = effective.advanced.unwrap_or_default();
+            if let Some(r) = env_transformer {
+                adv.transformer = r;
+            }
+            if let Some(r) = env_vae {
+                adv.vae = r;
+            }
+            if let Some(r) = env_t5 {
+                adv.t5 = Some(r);
+            }
+            if let Some(r) = env_clip_l {
+                adv.clip_l = Some(r);
+            }
+            if let Some(r) = env_clip_g {
+                adv.clip_g = Some(r);
+            }
+            if let Some(r) = env_qwen {
+                adv.qwen = Some(r);
+            }
+            effective.advanced = Some(adv);
+        }
+        placement = Some(effective);
+        placement
+    }
+
+    /// Persist a placement for `model_name`, creating the model entry if
+    /// missing. `None` clears the placement (and leaves the rest of the
+    /// entry intact).
+    pub fn set_model_placement(
+        &mut self,
+        model_name: &str,
+        placement: Option<crate::types::DevicePlacement>,
+    ) {
+        let entry = self.models.entry(model_name.to_string()).or_default();
+        entry.placement = placement;
+    }
+
     /// Write the config to disk at `config_path()`.
     ///
     /// Safety: refuses to save if `models_dir` points to a temp/test directory,
@@ -1140,4 +1237,22 @@ fn resolved_manifest_paths_exist(
         ModelComponent::Decoder => paths.decoder.as_ref().is_some_and(|path| path.exists()),
         ModelComponent::Upscaler => paths.transformer.exists(),
     })
+}
+
+fn parse_device_ref_env(key: &str) -> Option<crate::types::DeviceRef> {
+    use crate::types::DeviceRef;
+    let raw = std::env::var(key).ok()?;
+    let raw = raw.trim().to_lowercase();
+    if raw == "auto" {
+        Some(DeviceRef::Auto)
+    } else if raw == "cpu" {
+        Some(DeviceRef::Cpu)
+    } else if raw == "gpu" {
+        Some(DeviceRef::gpu(0))
+    } else if let Some(rest) = raw.strip_prefix("gpu:") {
+        rest.parse::<usize>().ok().map(DeviceRef::gpu)
+    } else {
+        eprintln!("mold: ignoring invalid {key}={raw} (expected auto|cpu|gpu[:N])");
+        None
+    }
 }

--- a/crates/mold-core/src/config.rs
+++ b/crates/mold-core/src/config.rs
@@ -982,10 +982,7 @@ impl Config {
     ///   - `"cpu"`     — `DeviceRef::Cpu`
     ///   - `"gpu:N"`   — `DeviceRef::Gpu { ordinal: N }`
     ///   - `"gpu"`     — `DeviceRef::Gpu { ordinal: 0 }`
-    pub fn resolved_placement(
-        &self,
-        model_name: &str,
-    ) -> Option<crate::types::DevicePlacement> {
+    pub fn resolved_placement(&self, model_name: &str) -> Option<crate::types::DevicePlacement> {
         use crate::types::DevicePlacement;
 
         let mut placement = self

--- a/crates/mold-core/src/manifest.rs
+++ b/crates/mold-core/src/manifest.rs
@@ -229,6 +229,7 @@ impl ModelManifest {
             default_fps: None,
             description: None,
             family: None,
+            placement: None,
         }
     }
 }

--- a/crates/mold-core/src/placement_test.rs
+++ b/crates/mold-core/src/placement_test.rs
@@ -1,0 +1,86 @@
+//! Serde round-trip plus default tests for `DeviceRef`, `DevicePlacement`,
+//! `AdvancedPlacement`. Kept in a sibling file because `types.rs` is already
+//! 2100+ lines.
+use super::{AdvancedPlacement, DevicePlacement, DeviceRef};
+
+#[test]
+fn device_ref_auto_default() {
+    assert_eq!(DeviceRef::default(), DeviceRef::Auto);
+}
+
+#[test]
+fn device_ref_auto_round_trip() {
+    let json = serde_json::to_string(&DeviceRef::Auto).unwrap();
+    assert_eq!(json, r#"{"kind":"auto"}"#);
+    let back: DeviceRef = serde_json::from_str(&json).unwrap();
+    assert_eq!(back, DeviceRef::Auto);
+}
+
+#[test]
+fn device_ref_cpu_round_trip() {
+    let json = serde_json::to_string(&DeviceRef::Cpu).unwrap();
+    assert_eq!(json, r#"{"kind":"cpu"}"#);
+    let back: DeviceRef = serde_json::from_str(&json).unwrap();
+    assert_eq!(back, DeviceRef::Cpu);
+}
+
+#[test]
+fn device_ref_gpu_round_trip() {
+    let json = serde_json::to_string(&DeviceRef::gpu(2)).unwrap();
+    assert_eq!(json, r#"{"kind":"gpu","ordinal":2}"#);
+    let back: DeviceRef = serde_json::from_str(&json).unwrap();
+    assert_eq!(back, DeviceRef::gpu(2));
+}
+
+#[test]
+fn device_placement_defaults_to_all_auto() {
+    let dp = DevicePlacement::default();
+    assert_eq!(dp.text_encoders, DeviceRef::Auto);
+    assert!(dp.advanced.is_none());
+}
+
+#[test]
+fn device_placement_serializes_tier1_only_without_advanced() {
+    let dp = DevicePlacement {
+        text_encoders: DeviceRef::Cpu,
+        advanced: None,
+    };
+    let json = serde_json::to_value(&dp).unwrap();
+    assert_eq!(json["text_encoders"]["kind"], "cpu");
+    assert!(json.get("advanced").is_none() || json["advanced"].is_null());
+}
+
+#[test]
+fn device_placement_round_trip_with_advanced() {
+    let dp = DevicePlacement {
+        text_encoders: DeviceRef::gpu(0),
+        advanced: Some(AdvancedPlacement {
+            transformer: DeviceRef::gpu(1),
+            vae: DeviceRef::Cpu,
+            clip_l: Some(DeviceRef::Auto),
+            clip_g: None,
+            t5: Some(DeviceRef::gpu(0)),
+            qwen: None,
+        }),
+    };
+    let json = serde_json::to_string(&dp).unwrap();
+    let back: DevicePlacement = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.text_encoders, DeviceRef::gpu(0));
+    let adv = back.advanced.unwrap();
+    assert_eq!(adv.transformer, DeviceRef::gpu(1));
+    assert_eq!(adv.vae, DeviceRef::Cpu);
+    assert_eq!(adv.clip_l, Some(DeviceRef::Auto));
+    assert_eq!(adv.clip_g, None);
+    assert_eq!(adv.t5, Some(DeviceRef::gpu(0)));
+}
+
+#[test]
+fn advanced_placement_defaults_to_auto_pair() {
+    let adv = AdvancedPlacement::default();
+    assert_eq!(adv.transformer, DeviceRef::Auto);
+    assert_eq!(adv.vae, DeviceRef::Auto);
+    assert!(adv.clip_l.is_none());
+    assert!(adv.clip_g.is_none());
+    assert!(adv.t5.is_none());
+    assert!(adv.qwen.is_none());
+}

--- a/crates/mold-core/src/placement_test.rs
+++ b/crates/mold-core/src/placement_test.rs
@@ -177,10 +177,7 @@ fn model_config_serializes_placement_section() {
     cfg.models.insert("flux-dev:q4".to_string(), mc);
 
     let toml = toml::to_string(&cfg).unwrap();
-    assert!(
-        toml.contains(r#"flux-dev:q4".placement"#),
-        "toml:\n{toml}"
-    );
+    assert!(toml.contains(r#"flux-dev:q4".placement"#), "toml:\n{toml}");
     // round-trip
     let back: Config = toml::from_str(&toml).unwrap();
     let p = back.models["flux-dev:q4"].placement.as_ref().unwrap();
@@ -204,7 +201,9 @@ fn env_override_transformer_gpu_ordinal() {
     let cfg = crate::config::Config::default();
     std::env::set_var("MOLD_PLACE_TRANSFORMER", "gpu:1");
     let p = cfg.resolved_placement("flux-dev:q4").unwrap();
-    let adv = p.advanced.expect("gpu env override should populate advanced");
+    let adv = p
+        .advanced
+        .expect("gpu env override should populate advanced");
     assert_eq!(adv.transformer, DeviceRef::gpu(1));
     std::env::remove_var("MOLD_PLACE_TRANSFORMER");
 }

--- a/crates/mold-core/src/placement_test.rs
+++ b/crates/mold-core/src/placement_test.rs
@@ -84,3 +84,78 @@ fn advanced_placement_defaults_to_auto_pair() {
     assert!(adv.t5.is_none());
     assert!(adv.qwen.is_none());
 }
+
+#[test]
+fn generate_request_placement_round_trips() {
+    use super::GenerateRequest;
+    let req = GenerateRequest {
+        prompt: "a cat".into(),
+        negative_prompt: None,
+        model: "flux-dev:q4".into(),
+        width: 1024,
+        height: 1024,
+        steps: 20,
+        guidance: 3.5,
+        seed: Some(7),
+        batch_size: 1,
+        output_format: super::OutputFormat::Png,
+        embed_metadata: None,
+        scheduler: None,
+        source_image: None,
+        edit_images: None,
+        strength: 0.75,
+        mask_image: None,
+        control_image: None,
+        control_model: None,
+        control_scale: 1.0,
+        expand: None,
+        original_prompt: None,
+        lora: None,
+        frames: None,
+        fps: None,
+        upscale_model: None,
+        gif_preview: false,
+        enable_audio: None,
+        audio_file: None,
+        source_video: None,
+        keyframes: None,
+        pipeline: None,
+        loras: None,
+        retake_range: None,
+        spatial_upscale: None,
+        temporal_upscale: None,
+        placement: Some(DevicePlacement {
+            text_encoders: DeviceRef::Cpu,
+            advanced: Some(AdvancedPlacement {
+                transformer: DeviceRef::gpu(1),
+                vae: DeviceRef::Auto,
+                t5: Some(DeviceRef::Cpu),
+                ..Default::default()
+            }),
+        }),
+    };
+    let json = serde_json::to_string(&req).unwrap();
+    let back: GenerateRequest = serde_json::from_str(&json).unwrap();
+    let p = back.placement.unwrap();
+    assert_eq!(p.text_encoders, DeviceRef::Cpu);
+    let adv = p.advanced.unwrap();
+    assert_eq!(adv.transformer, DeviceRef::gpu(1));
+    assert_eq!(adv.t5, Some(DeviceRef::Cpu));
+}
+
+#[test]
+fn generate_request_without_placement_is_none() {
+    use super::GenerateRequest;
+    let json = r#"{
+        "prompt": "a cat",
+        "model": "flux-dev:q4",
+        "width": 1024,
+        "height": 1024,
+        "steps": 20,
+        "guidance": 3.5,
+        "batch_size": 1,
+        "strength": 0.75
+    }"#;
+    let req: GenerateRequest = serde_json::from_str(json).unwrap();
+    assert!(req.placement.is_none());
+}

--- a/crates/mold-core/src/placement_test.rs
+++ b/crates/mold-core/src/placement_test.rs
@@ -159,3 +159,86 @@ fn generate_request_without_placement_is_none() {
     let req: GenerateRequest = serde_json::from_str(json).unwrap();
     assert!(req.placement.is_none());
 }
+
+#[test]
+fn model_config_serializes_placement_section() {
+    use crate::config::{Config, ModelConfig};
+    let mut mc = ModelConfig::default();
+    mc.placement = Some(DevicePlacement {
+        text_encoders: DeviceRef::Cpu,
+        advanced: Some(AdvancedPlacement {
+            transformer: DeviceRef::gpu(0),
+            vae: DeviceRef::Cpu,
+            t5: Some(DeviceRef::Cpu),
+            ..Default::default()
+        }),
+    });
+    let mut cfg = Config::default();
+    cfg.models.insert("flux-dev:q4".to_string(), mc);
+
+    let toml = toml::to_string(&cfg).unwrap();
+    assert!(
+        toml.contains(r#"flux-dev:q4".placement"#),
+        "toml:\n{toml}"
+    );
+    // round-trip
+    let back: Config = toml::from_str(&toml).unwrap();
+    let p = back.models["flux-dev:q4"].placement.as_ref().unwrap();
+    assert_eq!(p.text_encoders, DeviceRef::Cpu);
+    let adv = p.advanced.as_ref().unwrap();
+    assert_eq!(adv.transformer, DeviceRef::gpu(0));
+    assert_eq!(adv.t5, Some(DeviceRef::Cpu));
+}
+
+#[test]
+fn env_override_text_encoders_cpu() {
+    let cfg = crate::config::Config::default();
+    std::env::set_var("MOLD_PLACE_TEXT_ENCODERS", "cpu");
+    let p = cfg.resolved_placement("flux-dev:q4").unwrap();
+    assert_eq!(p.text_encoders, DeviceRef::Cpu);
+    std::env::remove_var("MOLD_PLACE_TEXT_ENCODERS");
+}
+
+#[test]
+fn env_override_transformer_gpu_ordinal() {
+    let cfg = crate::config::Config::default();
+    std::env::set_var("MOLD_PLACE_TRANSFORMER", "gpu:1");
+    let p = cfg.resolved_placement("flux-dev:q4").unwrap();
+    let adv = p.advanced.expect("gpu env override should populate advanced");
+    assert_eq!(adv.transformer, DeviceRef::gpu(1));
+    std::env::remove_var("MOLD_PLACE_TRANSFORMER");
+}
+
+#[test]
+fn set_model_placement_creates_entry_if_missing() {
+    let mut cfg = crate::config::Config::default();
+    let p = DevicePlacement {
+        text_encoders: DeviceRef::gpu(0),
+        advanced: None,
+    };
+    cfg.set_model_placement("flux-dev:q4", Some(p.clone()));
+    assert_eq!(
+        cfg.models
+            .get("flux-dev:q4")
+            .and_then(|m| m.placement.clone()),
+        Some(p)
+    );
+}
+
+#[test]
+fn set_model_placement_clears_when_none() {
+    let mut cfg = crate::config::Config::default();
+    cfg.set_model_placement(
+        "flux-dev:q4",
+        Some(DevicePlacement {
+            text_encoders: DeviceRef::Cpu,
+            advanced: None,
+        }),
+    );
+    cfg.set_model_placement("flux-dev:q4", None);
+    assert!(cfg
+        .models
+        .get("flux-dev:q4")
+        .and_then(|m| m.placement.clone())
+        .is_none());
+}

--- a/crates/mold-core/src/types.rs
+++ b/crates/mold-core/src/types.rs
@@ -329,6 +329,11 @@ pub struct GenerateRequest {
     /// Optional temporal latent upscaling mode for LTX-2 pipelines.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub temporal_upscale: Option<Ltx2TemporalUpscale>,
+    /// Optional per-component device placement override. `None` preserves
+    /// the engine's VRAM-aware auto-placement end-to-end. See §3 of the
+    /// 2026-04-19 model-ui-overhaul design doc.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub placement: Option<DevicePlacement>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
@@ -796,7 +801,7 @@ pub enum GpuWorkerState {
 /// Serialized as an externally-tagged enum: `{"kind":"auto"}`,
 /// `{"kind":"cpu"}`, or `{"kind":"gpu","ordinal":1}`. A missing `DeviceRef`
 /// field deserializes to `Auto`.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, utoipa::ToSchema)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum DeviceRef {
     Auto,
@@ -826,7 +831,7 @@ impl DeviceRef {
 ///   (FLUX, Flux.2, Z-Image, Qwen-Image; SD3.5 stretch). When `Some`, each
 ///   populated field overrides the Tier 1 group knob for that specific
 ///   component. When `None`, only the group knob is honored.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq, utoipa::ToSchema)]
 pub struct DevicePlacement {
     #[serde(default)]
     pub text_encoders: DeviceRef,
@@ -841,7 +846,7 @@ pub struct DevicePlacement {
 /// every encoder — FLUX has T5 plus CLIP-L, Flux.2 and Z-Image have Qwen3,
 /// Qwen-Image has Qwen2.5-VL. `None` means "follow the Tier 1 group knob";
 /// `Some(DeviceRef::Auto)` means "follow the engine's own auto logic".
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq, utoipa::ToSchema)]
 pub struct AdvancedPlacement {
     #[serde(default)]
     pub transformer: DeviceRef,
@@ -1078,6 +1083,7 @@ mod tests {
             retake_range: None,
             spatial_upscale: None,
             temporal_upscale: None,
+            placement: None,
         };
         let json = serde_json::to_string(&req).unwrap();
         let back: GenerateRequest = serde_json::from_str(&json).unwrap();
@@ -1234,6 +1240,7 @@ mod tests {
             retake_range: None,
             spatial_upscale: None,
             temporal_upscale: None,
+            placement: None,
         };
         let json = serde_json::to_string(&req).unwrap();
         assert!(json.contains("negative_prompt"));
@@ -1280,6 +1287,7 @@ mod tests {
             retake_range: None,
             spatial_upscale: None,
             temporal_upscale: None,
+            placement: None,
         };
         let json = serde_json::to_string(&req).unwrap();
         assert!(!json.contains("negative_prompt"));
@@ -1323,6 +1331,7 @@ mod tests {
             retake_range: None,
             spatial_upscale: None,
             temporal_upscale: None,
+            placement: None,
         };
 
         let metadata = OutputMetadata::from_generate_request(&req, 7, None, "0.1.0");
@@ -1368,6 +1377,7 @@ mod tests {
             retake_range: None,
             spatial_upscale: None,
             temporal_upscale: None,
+            placement: None,
         };
         let metadata = OutputMetadata::from_generate_request(&req, 1, None, "0.1.0");
         assert_eq!(metadata.negative_prompt.as_deref(), Some("blurry, ugly"));
@@ -1411,6 +1421,7 @@ mod tests {
             retake_range: None,
             spatial_upscale: None,
             temporal_upscale: None,
+            placement: None,
         };
 
         let metadata =
@@ -1622,6 +1633,7 @@ mod tests {
             retake_range: None,
             spatial_upscale: None,
             temporal_upscale: None,
+            placement: None,
         };
         let json = serde_json::to_string(&req).unwrap();
         // Verify base64 encoding is in the JSON
@@ -1671,6 +1683,7 @@ mod tests {
             retake_range: None,
             spatial_upscale: None,
             temporal_upscale: None,
+            placement: None,
         };
         let json = serde_json::to_string(&req).unwrap();
         assert!(json.contains("edit_images"));
@@ -1733,6 +1746,7 @@ mod tests {
             retake_range: None,
             spatial_upscale: None,
             temporal_upscale: None,
+            placement: None,
         };
         let json = serde_json::to_string(&req).unwrap();
         assert!(!json.contains("source_image"));
@@ -1780,6 +1794,7 @@ mod tests {
             retake_range: None,
             spatial_upscale: None,
             temporal_upscale: None,
+            placement: None,
         };
         let json = serde_json::to_string(&req).unwrap();
         assert!(json.contains("control_image"));
@@ -1848,6 +1863,7 @@ mod tests {
             retake_range: None,
             spatial_upscale: None,
             temporal_upscale: None,
+            placement: None,
         };
         let json = serde_json::to_string(&req).unwrap();
         assert!(json.contains("mask_image"));

--- a/crates/mold-core/src/types.rs
+++ b/crates/mold-core/src/types.rs
@@ -784,6 +784,79 @@ pub enum GpuWorkerState {
     Degraded,
 }
 
+// ── Device placement (Agent C: model-ui-overhaul §3) ─────────────────────────
+
+/// A user-facing request for where a component should run.
+///
+/// - `Auto` preserves the existing VRAM-aware auto-placement logic.
+/// - `Cpu` pins the component to CPU regardless of available VRAM.
+/// - `Gpu { ordinal }` pins to GPU ordinal `n` (CUDA-specific ordinal,
+///   or `0` on Metal/unified memory).
+///
+/// Serialized as an externally-tagged enum: `{"kind":"auto"}`,
+/// `{"kind":"cpu"}`, or `{"kind":"gpu","ordinal":1}`. A missing `DeviceRef`
+/// field deserializes to `Auto`.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum DeviceRef {
+    Auto,
+    Cpu,
+    Gpu { ordinal: usize },
+}
+
+impl Default for DeviceRef {
+    fn default() -> Self {
+        DeviceRef::Auto
+    }
+}
+
+impl DeviceRef {
+    /// Helper constructor mirroring the compact `Gpu(n)` form used in tests.
+    pub const fn gpu(ordinal: usize) -> Self {
+        DeviceRef::Gpu { ordinal }
+    }
+}
+
+/// Top-level placement request attached to `GenerateRequest` and persisted
+/// under `[models."name:tag".placement]` in config.
+///
+/// - `text_encoders` is the Tier 1 "group knob" — a single override applied
+///   to all text-encoder components (T5 plus CLIP-L, Qwen3, Qwen2.5-VL, etc.).
+/// - `advanced` is Tier 2, available only for families listed in spec §3.2
+///   (FLUX, Flux.2, Z-Image, Qwen-Image; SD3.5 stretch). When `Some`, each
+///   populated field overrides the Tier 1 group knob for that specific
+///   component. When `None`, only the group knob is honored.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DevicePlacement {
+    #[serde(default)]
+    pub text_encoders: DeviceRef,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub advanced: Option<AdvancedPlacement>,
+}
+
+/// Per-component placement overrides available only for Tier 2 families.
+///
+/// `transformer` and `vae` are required fields (default `Auto`). The
+/// per-encoder fields are `Option<DeviceRef>` because not every family has
+/// every encoder — FLUX has T5 plus CLIP-L, Flux.2 and Z-Image have Qwen3,
+/// Qwen-Image has Qwen2.5-VL. `None` means "follow the Tier 1 group knob";
+/// `Some(DeviceRef::Auto)` means "follow the engine's own auto logic".
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AdvancedPlacement {
+    #[serde(default)]
+    pub transformer: DeviceRef,
+    #[serde(default)]
+    pub vae: DeviceRef,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub clip_l: Option<DeviceRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub clip_g: Option<DeviceRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub t5: Option<DeviceRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub qwen: Option<DeviceRef>,
+}
+
 // ── SSE streaming wire types ─────────────────────────────────────────────────
 
 /// Progress event for SSE streaming. Mirrors `mold_inference::ProgressEvent`
@@ -2153,3 +2226,7 @@ pub fn default_output_filename(
         format!("mold-{safe_model}-{timestamp}-{index}.{ext}")
     }
 }
+
+#[cfg(test)]
+#[path = "placement_test.rs"]
+mod placement_test;

--- a/crates/mold-core/src/types.rs
+++ b/crates/mold-core/src/types.rs
@@ -801,18 +801,15 @@ pub enum GpuWorkerState {
 /// Serialized as an externally-tagged enum: `{"kind":"auto"}`,
 /// `{"kind":"cpu"}`, or `{"kind":"gpu","ordinal":1}`. A missing `DeviceRef`
 /// field deserializes to `Auto`.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, utoipa::ToSchema)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default, utoipa::ToSchema)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum DeviceRef {
+    #[default]
     Auto,
     Cpu,
-    Gpu { ordinal: usize },
-}
-
-impl Default for DeviceRef {
-    fn default() -> Self {
-        DeviceRef::Auto
-    }
+    Gpu {
+        ordinal: usize,
+    },
 }
 
 impl DeviceRef {

--- a/crates/mold-core/src/validation.rs
+++ b/crates/mold-core/src/validation.rs
@@ -630,6 +630,7 @@ mod tests {
             retake_range: None,
             spatial_upscale: None,
             temporal_upscale: None,
+            placement: None,
         }
     }
 

--- a/crates/mold-discord/src/commands/generate.rs
+++ b/crates/mold-discord/src/commands/generate.rs
@@ -76,6 +76,7 @@ pub fn build_generate_request(
         retake_range: None,
         spatial_upscale: None,
         temporal_upscale: None,
+        placement: None,
     }
 }
 

--- a/crates/mold-inference/src/device.rs
+++ b/crates/mold-inference/src/device.rs
@@ -159,6 +159,50 @@ pub const QWEN3_FP16_VRAM_THRESHOLD: u64 = 10_200_000_000;
 /// Headroom for activation memory during inference (denoising + VAE decode workspace).
 const MEMORY_BUDGET_HEADROOM: u64 = 2_000_000_000; // 2GB
 
+// ── Placement resolution ─────────────────────────────────────────────────────
+
+/// Resolve a caller-supplied `DeviceRef` override into a concrete candle
+/// `Device`, falling back to `auto` when the override is missing or `Auto`.
+///
+/// - `None`, `Some(Auto)` — call `auto()` (existing VRAM-aware logic).
+/// - `Some(Cpu)`          — `Device::Cpu`, never invoke `auto()`.
+/// - `Some(Gpu { ordinal })` — try CUDA first, then Metal. Each backend is
+///   gated by its candle feature flag so a CPU-only build returns a clear
+///   error message instead of a build failure.
+pub fn resolve_device<F>(
+    req: Option<mold_core::types::DeviceRef>,
+    auto: F,
+) -> anyhow::Result<candle_core::Device>
+where
+    F: FnOnce() -> anyhow::Result<candle_core::Device>,
+{
+    use mold_core::types::DeviceRef;
+    match req {
+        None | Some(DeviceRef::Auto) => auto(),
+        Some(DeviceRef::Cpu) => Ok(candle_core::Device::Cpu),
+        Some(DeviceRef::Gpu { ordinal }) => resolve_gpu_ordinal(ordinal),
+    }
+}
+
+#[cfg(feature = "cuda")]
+fn resolve_gpu_ordinal(ordinal: usize) -> anyhow::Result<candle_core::Device> {
+    candle_core::Device::new_cuda(ordinal)
+        .map_err(|e| anyhow::anyhow!("failed to open CUDA device {ordinal}: {e}"))
+}
+
+#[cfg(all(not(feature = "cuda"), feature = "metal"))]
+fn resolve_gpu_ordinal(ordinal: usize) -> anyhow::Result<candle_core::Device> {
+    candle_core::Device::new_metal(ordinal)
+        .map_err(|e| anyhow::anyhow!("failed to open Metal device {ordinal}: {e}"))
+}
+
+#[cfg(all(not(feature = "cuda"), not(feature = "metal")))]
+fn resolve_gpu_ordinal(ordinal: usize) -> anyhow::Result<candle_core::Device> {
+    Err(anyhow::anyhow!(
+        "GPU ordinal {ordinal} requested but this build has neither CUDA nor Metal enabled"
+    ))
+}
+
 // ── macOS memory query ───────────────────────────────────────────────────────
 
 /// Raw VM statistics from macOS host_statistics64.

--- a/crates/mold-inference/src/device.rs
+++ b/crates/mold-inference/src/device.rs
@@ -203,6 +203,41 @@ fn resolve_gpu_ordinal(ordinal: usize) -> anyhow::Result<candle_core::Device> {
     ))
 }
 
+/// Resolve a component-level `DeviceRef` from a `DevicePlacement`, honoring
+/// the Tier 2 per-component override first, then the Tier 1 `text_encoders`
+/// group knob when appropriate.
+///
+/// Precedence:
+///   1. `advanced_override` (Tier 2 per-component) if `Some`.
+///   2. Fall back to `placement.text_encoders` (group knob) when
+///      `fallback_is_component_auto` is `true` (typically for text-encoder
+///      components — T5/CLIP-L/Qwen — that follow the group knob by default).
+///   3. Fall back to `DeviceRef::Auto` (non-text-encoder components like the
+///      VAE, which don't inherit from the text-encoder group knob).
+pub fn effective_device_ref(
+    placement: Option<&mold_core::types::DevicePlacement>,
+    advanced_override: impl FnOnce(
+        &mold_core::types::AdvancedPlacement,
+    ) -> Option<mold_core::types::DeviceRef>,
+    fallback_is_component_auto: bool,
+) -> mold_core::types::DeviceRef {
+    use mold_core::types::DeviceRef;
+    let Some(placement) = placement else {
+        return DeviceRef::Auto;
+    };
+    if let Some(adv) = placement.advanced.as_ref() {
+        if let Some(r) = advanced_override(adv) {
+            return r;
+        }
+        if fallback_is_component_auto {
+            return placement.text_encoders;
+        }
+        DeviceRef::Auto
+    } else {
+        placement.text_encoders
+    }
+}
+
 // ── macOS memory query ───────────────────────────────────────────────────────
 
 /// Raw VM statistics from macOS host_statistics64.

--- a/crates/mold-inference/src/flux/pipeline.rs
+++ b/crates/mold-inference/src/flux/pipeline.rs
@@ -24,6 +24,34 @@ use crate::progress::{ProgressCallback, ProgressReporter};
 
 use super::transformer::FluxTransformer;
 
+/// Resolve a component override given Tier 1 plus Tier 2 requests.
+///
+/// Precedence:
+///   1. `advanced_override` (Tier 2 per-component) if `Some`.
+///   2. Fall back to `tier1` (group knob) if `fallback_is_component_auto`.
+///   3. Fall back to `Auto`.
+fn effective_device_ref(
+    placement: Option<&mold_core::types::DevicePlacement>,
+    advanced_override: impl FnOnce(&mold_core::types::AdvancedPlacement) -> Option<mold_core::types::DeviceRef>,
+    fallback_is_component_auto: bool,
+) -> mold_core::types::DeviceRef {
+    use mold_core::types::DeviceRef;
+    let Some(placement) = placement else {
+        return DeviceRef::Auto;
+    };
+    if let Some(adv) = placement.advanced.as_ref() {
+        if let Some(r) = advanced_override(adv) {
+            return r;
+        }
+        if fallback_is_component_auto {
+            return placement.text_encoders;
+        }
+        DeviceRef::Auto
+    } else {
+        placement.text_encoders
+    }
+}
+
 /// Some FLUX safetensors checkpoints store transformer tensors at the root
 /// while others nest them under `model.diffusion_model`.
 fn flux_transformer_var_builder<'a>(vb: VarBuilder<'a>) -> VarBuilder<'a> {
@@ -845,7 +873,15 @@ impl FluxEngine {
             self.validate_paths()?;
 
         let cpu = Device::Cpu;
-        let device = crate::device::create_device(self.base.gpu_ordinal, &self.base.progress)?;
+        let transformer_ref = effective_device_ref(
+            self.pending_placement.as_ref(),
+            |adv| Some(adv.transformer),
+            false,
+        );
+        let device = crate::device::resolve_device(
+            Some(transformer_ref),
+            || crate::device::create_device(self.base.gpu_ordinal, &self.base.progress),
+        )?;
         let mut is_quantized = self.detect_is_quantized();
         let transformer_is_fp8 = self.check_transformer_is_fp8(is_quantized);
 
@@ -928,13 +964,23 @@ impl FluxEngine {
         tracing::info!("FLUX transformer loaded on GPU");
 
         // Load VAE on GPU (small, ~300MB)
+        // Tier 2: honor `advanced.vae` override.
+        let vae_ref = effective_device_ref(
+            self.pending_placement.as_ref(),
+            |adv| Some(adv.vae),
+            false,
+        );
+        let vae_device = crate::device::resolve_device(
+            Some(vae_ref),
+            || Ok(device.clone()),
+        )?;
         self.base.progress.stage_start("Loading VAE (GPU)");
         let vae_stage = Instant::now();
         tracing::info!(path = %self.base.paths.vae.display(), "loading VAE on GPU...");
         let vae_vb = crate::weight_loader::load_safetensors_with_progress(
             std::slice::from_ref(&self.base.paths.vae),
             gpu_dtype,
-            &device,
+            &vae_device,
             "VAE",
             &self.base.progress,
         )?;
@@ -977,16 +1023,15 @@ impl FluxEngine {
         self.base
             .progress
             .stage_done("Selecting T5 encoder", t5_resolve_start.elapsed());
-        // Tier 1: a `text_encoders` group override replaces the VRAM-aware decision.
-        // Tier 2 (Task 10) adds per-encoder overrides via `placement.advanced.t5`.
-        let tier1 = self
-            .pending_placement
-            .as_ref()
-            .map(|p| p.text_encoders)
-            .unwrap_or_default();
+        // Tier 2 (if `advanced.t5` populated) overrides Tier 1 text_encoders group knob.
+        let t5_ref = effective_device_ref(
+            self.pending_placement.as_ref(),
+            |adv| adv.t5,
+            true,
+        );
         let auto_t5_device = if t5_on_gpu { device.clone() } else { cpu.clone() };
         let t5_device_owned = crate::device::resolve_device(
-            Some(tier1),
+            Some(t5_ref),
             || Ok(auto_t5_device.clone()),
         )?;
         let t5_device = &t5_device_owned;
@@ -1026,9 +1071,14 @@ impl FluxEngine {
             free_after_t5,
             CLIP_VRAM_THRESHOLD,
         );
+        let clip_ref = effective_device_ref(
+            self.pending_placement.as_ref(),
+            |adv| adv.clip_l,
+            true,
+        );
         let auto_clip_device = if clip_on_gpu { device.clone() } else { cpu.clone() };
         let clip_device_owned = crate::device::resolve_device(
-            Some(tier1),
+            Some(clip_ref),
             || Ok(auto_clip_device.clone()),
         )?;
         let clip_device = &clip_device_owned;
@@ -1098,7 +1148,15 @@ impl FluxEngine {
             self.base.progress.info(&warning);
         }
 
-        let device = crate::device::create_device(self.base.gpu_ordinal, &self.base.progress)?;
+        let transformer_ref = effective_device_ref(
+            self.pending_placement.as_ref(),
+            |adv| Some(adv.transformer),
+            false,
+        );
+        let device = crate::device::resolve_device(
+            Some(transformer_ref),
+            || crate::device::create_device(self.base.gpu_ordinal, &self.base.progress),
+        )?;
 
         // Use cached transformer path to avoid file I/O on every sequential call.
         let transformer_path = if let Some(ref cached) = self.cached_transformer_path {
@@ -1175,15 +1233,14 @@ impl FluxEngine {
                 .progress
                 .stage_done("Selecting T5 encoder", t5_resolve_start.elapsed());
 
-            // Tier 1: a `text_encoders` group override replaces the VRAM-aware decision.
-            let tier1 = self
-                .pending_placement
-                .as_ref()
-                .map(|p| p.text_encoders)
-                .unwrap_or_default();
+            let t5_ref = effective_device_ref(
+                self.pending_placement.as_ref(),
+                |adv| adv.t5,
+                true,
+            );
             let auto_t5_device = if t5_on_gpu { device.clone() } else { Device::Cpu };
             let t5_device_owned = crate::device::resolve_device(
-                Some(tier1),
+                Some(t5_ref),
                 || Ok(auto_t5_device.clone()),
             )?;
             let t5_device = &t5_device_owned;
@@ -1235,9 +1292,14 @@ impl FluxEngine {
                 free_for_clip,
                 CLIP_VRAM_THRESHOLD,
             );
+            let clip_ref = effective_device_ref(
+                self.pending_placement.as_ref(),
+                |adv| adv.clip_l,
+                true,
+            );
             let auto_clip_device = if clip_on_gpu { device.clone() } else { Device::Cpu };
             let clip_device_owned = crate::device::resolve_device(
-                Some(tier1),
+                Some(clip_ref),
                 || Ok(auto_clip_device.clone()),
             )?;
             let clip_device = &clip_device_owned;

--- a/crates/mold-inference/src/flux/pipeline.rs
+++ b/crates/mold-inference/src/flux/pipeline.rs
@@ -32,7 +32,9 @@ use super::transformer::FluxTransformer;
 ///   3. Fall back to `Auto`.
 fn effective_device_ref(
     placement: Option<&mold_core::types::DevicePlacement>,
-    advanced_override: impl FnOnce(&mold_core::types::AdvancedPlacement) -> Option<mold_core::types::DeviceRef>,
+    advanced_override: impl FnOnce(
+        &mold_core::types::AdvancedPlacement,
+    ) -> Option<mold_core::types::DeviceRef>,
     fallback_is_component_auto: bool,
 ) -> mold_core::types::DeviceRef {
     use mold_core::types::DeviceRef;
@@ -878,10 +880,9 @@ impl FluxEngine {
             |adv| Some(adv.transformer),
             false,
         );
-        let device = crate::device::resolve_device(
-            Some(transformer_ref),
-            || crate::device::create_device(self.base.gpu_ordinal, &self.base.progress),
-        )?;
+        let device = crate::device::resolve_device(Some(transformer_ref), || {
+            crate::device::create_device(self.base.gpu_ordinal, &self.base.progress)
+        })?;
         let mut is_quantized = self.detect_is_quantized();
         let transformer_is_fp8 = self.check_transformer_is_fp8(is_quantized);
 
@@ -965,15 +966,9 @@ impl FluxEngine {
 
         // Load VAE on GPU (small, ~300MB)
         // Tier 2: honor `advanced.vae` override.
-        let vae_ref = effective_device_ref(
-            self.pending_placement.as_ref(),
-            |adv| Some(adv.vae),
-            false,
-        );
-        let vae_device = crate::device::resolve_device(
-            Some(vae_ref),
-            || Ok(device.clone()),
-        )?;
+        let vae_ref =
+            effective_device_ref(self.pending_placement.as_ref(), |adv| Some(adv.vae), false);
+        let vae_device = crate::device::resolve_device(Some(vae_ref), || Ok(device.clone()))?;
         self.base.progress.stage_start("Loading VAE (GPU)");
         let vae_stage = Instant::now();
         tracing::info!(path = %self.base.paths.vae.display(), "loading VAE on GPU...");
@@ -1024,16 +1019,14 @@ impl FluxEngine {
             .progress
             .stage_done("Selecting T5 encoder", t5_resolve_start.elapsed());
         // Tier 2 (if `advanced.t5` populated) overrides Tier 1 text_encoders group knob.
-        let t5_ref = effective_device_ref(
-            self.pending_placement.as_ref(),
-            |adv| adv.t5,
-            true,
-        );
-        let auto_t5_device = if t5_on_gpu { device.clone() } else { cpu.clone() };
-        let t5_device_owned = crate::device::resolve_device(
-            Some(t5_ref),
-            || Ok(auto_t5_device.clone()),
-        )?;
+        let t5_ref = effective_device_ref(self.pending_placement.as_ref(), |adv| adv.t5, true);
+        let auto_t5_device = if t5_on_gpu {
+            device.clone()
+        } else {
+            cpu.clone()
+        };
+        let t5_device_owned =
+            crate::device::resolve_device(Some(t5_ref), || Ok(auto_t5_device.clone()))?;
         let t5_device = &t5_device_owned;
         let t5_on_gpu = !t5_device.is_cpu();
         let t5_device_label = if t5_on_gpu { "GPU" } else { "CPU" };
@@ -1071,16 +1064,15 @@ impl FluxEngine {
             free_after_t5,
             CLIP_VRAM_THRESHOLD,
         );
-        let clip_ref = effective_device_ref(
-            self.pending_placement.as_ref(),
-            |adv| adv.clip_l,
-            true,
-        );
-        let auto_clip_device = if clip_on_gpu { device.clone() } else { cpu.clone() };
-        let clip_device_owned = crate::device::resolve_device(
-            Some(clip_ref),
-            || Ok(auto_clip_device.clone()),
-        )?;
+        let clip_ref =
+            effective_device_ref(self.pending_placement.as_ref(), |adv| adv.clip_l, true);
+        let auto_clip_device = if clip_on_gpu {
+            device.clone()
+        } else {
+            cpu.clone()
+        };
+        let clip_device_owned =
+            crate::device::resolve_device(Some(clip_ref), || Ok(auto_clip_device.clone()))?;
         let clip_device = &clip_device_owned;
         let clip_on_gpu = !clip_device.is_cpu();
         let clip_dtype = if clip_on_gpu { gpu_dtype } else { DType::F32 };
@@ -1153,10 +1145,9 @@ impl FluxEngine {
             |adv| Some(adv.transformer),
             false,
         );
-        let device = crate::device::resolve_device(
-            Some(transformer_ref),
-            || crate::device::create_device(self.base.gpu_ordinal, &self.base.progress),
-        )?;
+        let device = crate::device::resolve_device(Some(transformer_ref), || {
+            crate::device::create_device(self.base.gpu_ordinal, &self.base.progress)
+        })?;
 
         // Use cached transformer path to avoid file I/O on every sequential call.
         let transformer_path = if let Some(ref cached) = self.cached_transformer_path {
@@ -1233,16 +1224,14 @@ impl FluxEngine {
                 .progress
                 .stage_done("Selecting T5 encoder", t5_resolve_start.elapsed());
 
-            let t5_ref = effective_device_ref(
-                self.pending_placement.as_ref(),
-                |adv| adv.t5,
-                true,
-            );
-            let auto_t5_device = if t5_on_gpu { device.clone() } else { Device::Cpu };
-            let t5_device_owned = crate::device::resolve_device(
-                Some(t5_ref),
-                || Ok(auto_t5_device.clone()),
-            )?;
+            let t5_ref = effective_device_ref(self.pending_placement.as_ref(), |adv| adv.t5, true);
+            let auto_t5_device = if t5_on_gpu {
+                device.clone()
+            } else {
+                Device::Cpu
+            };
+            let t5_device_owned =
+                crate::device::resolve_device(Some(t5_ref), || Ok(auto_t5_device.clone()))?;
             let t5_device = &t5_device_owned;
             let t5_on_gpu = !t5_device.is_cpu();
             let t5_device_label = if t5_on_gpu { "GPU" } else { "CPU" };
@@ -1292,16 +1281,15 @@ impl FluxEngine {
                 free_for_clip,
                 CLIP_VRAM_THRESHOLD,
             );
-            let clip_ref = effective_device_ref(
-                self.pending_placement.as_ref(),
-                |adv| adv.clip_l,
-                true,
-            );
-            let auto_clip_device = if clip_on_gpu { device.clone() } else { Device::Cpu };
-            let clip_device_owned = crate::device::resolve_device(
-                Some(clip_ref),
-                || Ok(auto_clip_device.clone()),
-            )?;
+            let clip_ref =
+                effective_device_ref(self.pending_placement.as_ref(), |adv| adv.clip_l, true);
+            let auto_clip_device = if clip_on_gpu {
+                device.clone()
+            } else {
+                Device::Cpu
+            };
+            let clip_device_owned =
+                crate::device::resolve_device(Some(clip_ref), || Ok(auto_clip_device.clone()))?;
             let clip_device = &clip_device_owned;
             let clip_on_gpu = !clip_device.is_cpu();
             let clip_dtype = if clip_on_gpu { gpu_dtype } else { DType::F32 };

--- a/crates/mold-inference/src/flux/pipeline.rs
+++ b/crates/mold-inference/src/flux/pipeline.rs
@@ -13,8 +13,8 @@ use crate::cache::{
     CachedTensorPair, LruCache, DEFAULT_PROMPT_CACHE_CAPACITY,
 };
 use crate::device::{
-    check_memory_budget, fmt_gb, free_vram_bytes, memory_status_string, preflight_memory_check,
-    should_offload, should_use_gpu, CLIP_VRAM_THRESHOLD, MIN_OFFLOAD_VRAM,
+    check_memory_budget, effective_device_ref, fmt_gb, free_vram_bytes, memory_status_string,
+    preflight_memory_check, should_offload, should_use_gpu, CLIP_VRAM_THRESHOLD, MIN_OFFLOAD_VRAM,
 };
 use crate::encoders;
 use crate::engine::{rand_seed, InferenceEngine, LoadStrategy, OptionRestoreGuard};
@@ -23,36 +23,6 @@ use crate::image::{build_output_metadata, encode_image};
 use crate::progress::{ProgressCallback, ProgressReporter};
 
 use super::transformer::FluxTransformer;
-
-/// Resolve a component override given Tier 1 plus Tier 2 requests.
-///
-/// Precedence:
-///   1. `advanced_override` (Tier 2 per-component) if `Some`.
-///   2. Fall back to `tier1` (group knob) if `fallback_is_component_auto`.
-///   3. Fall back to `Auto`.
-fn effective_device_ref(
-    placement: Option<&mold_core::types::DevicePlacement>,
-    advanced_override: impl FnOnce(
-        &mold_core::types::AdvancedPlacement,
-    ) -> Option<mold_core::types::DeviceRef>,
-    fallback_is_component_auto: bool,
-) -> mold_core::types::DeviceRef {
-    use mold_core::types::DeviceRef;
-    let Some(placement) = placement else {
-        return DeviceRef::Auto;
-    };
-    if let Some(adv) = placement.advanced.as_ref() {
-        if let Some(r) = advanced_override(adv) {
-            return r;
-        }
-        if fallback_is_component_auto {
-            return placement.text_encoders;
-        }
-        DeviceRef::Auto
-    } else {
-        placement.text_encoders
-    }
-}
 
 /// Some FLUX safetensors checkpoints store transformer tensors at the root
 /// while others nest them under `model.diffusion_model`.

--- a/crates/mold-inference/src/flux/pipeline.rs
+++ b/crates/mold-inference/src/flux/pipeline.rs
@@ -649,6 +649,9 @@ pub struct FluxEngine {
     lora_delta_cache: Arc<Mutex<super::lora::LoraDeltaCache>>,
     /// Optional shared tokenizer pool for cross-engine caching.
     shared_pool: Option<Arc<Mutex<crate::shared_pool::SharedPool>>>,
+    /// Per-request placement override. Set at the start of `generate()`,
+    /// cleared on exit. `None` preserves the existing VRAM-aware auto logic.
+    pending_placement: Option<mold_core::types::DevicePlacement>,
 }
 
 impl FluxEngine {
@@ -678,6 +681,7 @@ impl FluxEngine {
             active_lora: None,
             lora_delta_cache: Arc::new(Mutex::new(super::lora::LoraDeltaCache::new())),
             shared_pool,
+            pending_placement: None,
         }
     }
 
@@ -962,7 +966,7 @@ impl FluxEngine {
         self.base.progress.stage_start("Selecting T5 encoder");
         let t5_resolve_start = Instant::now();
         let t5_preference = self.t5_variant.as_deref();
-        let (resolved_t5_path, t5_on_gpu, t5_device_label) =
+        let (resolved_t5_path, t5_on_gpu, _t5_auto_device_label) =
             crate::encoders::variant_resolution::resolve_t5_variant(
                 &self.base.progress,
                 t5_preference,
@@ -973,7 +977,21 @@ impl FluxEngine {
         self.base
             .progress
             .stage_done("Selecting T5 encoder", t5_resolve_start.elapsed());
-        let t5_device = if t5_on_gpu { &device } else { &cpu };
+        // Tier 1: a `text_encoders` group override replaces the VRAM-aware decision.
+        // Tier 2 (Task 10) adds per-encoder overrides via `placement.advanced.t5`.
+        let tier1 = self
+            .pending_placement
+            .as_ref()
+            .map(|p| p.text_encoders)
+            .unwrap_or_default();
+        let auto_t5_device = if t5_on_gpu { device.clone() } else { cpu.clone() };
+        let t5_device_owned = crate::device::resolve_device(
+            Some(tier1),
+            || Ok(auto_t5_device.clone()),
+        )?;
+        let t5_device = &t5_device_owned;
+        let t5_on_gpu = !t5_device.is_cpu();
+        let t5_device_label = if t5_on_gpu { "GPU" } else { "CPU" };
         let t5_dtype = if t5_on_gpu { gpu_dtype } else { DType::F32 };
 
         // Load T5 encoder
@@ -1008,7 +1026,13 @@ impl FluxEngine {
             free_after_t5,
             CLIP_VRAM_THRESHOLD,
         );
-        let clip_device = if clip_on_gpu { &device } else { &cpu };
+        let auto_clip_device = if clip_on_gpu { device.clone() } else { cpu.clone() };
+        let clip_device_owned = crate::device::resolve_device(
+            Some(tier1),
+            || Ok(auto_clip_device.clone()),
+        )?;
+        let clip_device = &clip_device_owned;
+        let clip_on_gpu = !clip_device.is_cpu();
         let clip_dtype = if clip_on_gpu { gpu_dtype } else { DType::F32 };
         let clip_device_label = if clip_on_gpu { "GPU" } else { "CPU" };
 
@@ -1139,7 +1163,7 @@ impl FluxEngine {
             self.base.progress.stage_start("Selecting T5 encoder");
             let t5_resolve_start = Instant::now();
             let t5_preference = self.t5_variant.as_deref();
-            let (resolved_t5_path, t5_on_gpu, t5_device_label) =
+            let (resolved_t5_path, t5_on_gpu, _t5_auto_device_label) =
                 crate::encoders::variant_resolution::resolve_t5_variant(
                     &self.base.progress,
                     t5_preference,
@@ -1151,7 +1175,20 @@ impl FluxEngine {
                 .progress
                 .stage_done("Selecting T5 encoder", t5_resolve_start.elapsed());
 
-            let t5_device = if t5_on_gpu { &device } else { &Device::Cpu };
+            // Tier 1: a `text_encoders` group override replaces the VRAM-aware decision.
+            let tier1 = self
+                .pending_placement
+                .as_ref()
+                .map(|p| p.text_encoders)
+                .unwrap_or_default();
+            let auto_t5_device = if t5_on_gpu { device.clone() } else { Device::Cpu };
+            let t5_device_owned = crate::device::resolve_device(
+                Some(tier1),
+                || Ok(auto_t5_device.clone()),
+            )?;
+            let t5_device = &t5_device_owned;
+            let t5_on_gpu = !t5_device.is_cpu();
+            let t5_device_label = if t5_on_gpu { "GPU" } else { "CPU" };
             let t5_dtype = if t5_on_gpu { gpu_dtype } else { DType::F32 };
 
             let t5_size = std::fs::metadata(&resolved_t5_path)
@@ -1198,7 +1235,13 @@ impl FluxEngine {
                 free_for_clip,
                 CLIP_VRAM_THRESHOLD,
             );
-            let clip_device = if clip_on_gpu { &device } else { &Device::Cpu };
+            let auto_clip_device = if clip_on_gpu { device.clone() } else { Device::Cpu };
+            let clip_device_owned = crate::device::resolve_device(
+                Some(tier1),
+                || Ok(auto_clip_device.clone()),
+            )?;
+            let clip_device = &clip_device_owned;
+            let clip_on_gpu = !clip_device.is_cpu();
             let clip_dtype = if clip_on_gpu { gpu_dtype } else { DType::F32 };
             let clip_device_label = if clip_on_gpu { "GPU" } else { "CPU" };
 
@@ -1624,8 +1667,8 @@ impl FluxEngine {
     }
 }
 
-impl InferenceEngine for FluxEngine {
-    fn generate(&mut self, req: &GenerateRequest) -> Result<GenerateResponse> {
+impl FluxEngine {
+    fn generate_inner(&mut self, req: &GenerateRequest) -> Result<GenerateResponse> {
         if req.scheduler.is_some() {
             tracing::warn!("scheduler selection not supported for FLUX (flow-matching), ignoring");
         }
@@ -1852,6 +1895,15 @@ impl InferenceEngine for FluxEngine {
                 start,
             )
         })()
+    }
+}
+
+impl InferenceEngine for FluxEngine {
+    fn generate(&mut self, req: &GenerateRequest) -> Result<GenerateResponse> {
+        self.pending_placement = req.placement.clone();
+        let result = self.generate_inner(req);
+        self.pending_placement = None;
+        result
     }
 
     fn model_name(&self) -> &str {

--- a/crates/mold-inference/src/flux2/pipeline.rs
+++ b/crates/mold-inference/src/flux2/pipeline.rs
@@ -23,36 +23,13 @@ use super::sampling::{self, Flux2State};
 use super::transformer::{Flux2Config, Flux2TransformerWrapper};
 use super::vae::{Flux2AutoEncoder, Flux2VaeConfig};
 
-/// Resolve a component override given Tier 1 plus Tier 2 requests.
-fn effective_device_ref(
-    placement: Option<&mold_core::types::DevicePlacement>,
-    advanced_override: impl FnOnce(
-        &mold_core::types::AdvancedPlacement,
-    ) -> Option<mold_core::types::DeviceRef>,
-    fallback_is_component_auto: bool,
-) -> mold_core::types::DeviceRef {
-    use mold_core::types::DeviceRef;
-    let Some(placement) = placement else {
-        return DeviceRef::Auto;
-    };
-    if let Some(adv) = placement.advanced.as_ref() {
-        if let Some(r) = advanced_override(adv) {
-            return r;
-        }
-        if fallback_is_component_auto {
-            return placement.text_encoders;
-        }
-        DeviceRef::Auto
-    } else {
-        placement.text_encoders
-    }
-}
 use crate::cache::{
     clear_cache, get_or_insert_cached_tensor, prompt_text_key, restore_cached_tensor, CachedTensor,
     LruCache, DEFAULT_PROMPT_CACHE_CAPACITY,
 };
 use crate::device::{
-    check_memory_budget, fmt_gb, free_vram_bytes, memory_status_string, preflight_memory_check,
+    check_memory_budget, effective_device_ref, fmt_gb, free_vram_bytes, memory_status_string,
+    preflight_memory_check,
 };
 use crate::encoders;
 use crate::engine::{rand_seed, InferenceEngine, LoadStrategy};

--- a/crates/mold-inference/src/flux2/pipeline.rs
+++ b/crates/mold-inference/src/flux2/pipeline.rs
@@ -60,6 +60,9 @@ pub struct Flux2Engine {
     /// Qwen3 variant preference: None/"auto" = VRAM-based, "bf16" = force BF16, "q8"/etc = specific.
     qwen3_variant: Option<String>,
     prompt_cache: Mutex<LruCache<String, CachedTensor>>,
+    /// Per-request placement override. Set at the start of `generate()`,
+    /// cleared on exit. `None` preserves the existing VRAM-aware auto logic.
+    pending_placement: Option<mold_core::types::DevicePlacement>,
 }
 
 impl Flux2Engine {
@@ -75,6 +78,7 @@ impl Flux2Engine {
             base: EngineBase::new(model_name, paths, load_strategy, gpu_ordinal),
             qwen3_variant,
             prompt_cache: Mutex::new(LruCache::new(DEFAULT_PROMPT_CACHE_CAPACITY)),
+            pending_placement: None,
         }
     }
 
@@ -391,7 +395,18 @@ impl Flux2Engine {
             .progress
             .stage_done("Selecting Qwen3 encoder", resolve_start.elapsed());
 
-        let enc_device = if on_gpu { &device } else { &cpu };
+        let tier1 = self
+            .pending_placement
+            .as_ref()
+            .map(|p| p.text_encoders)
+            .unwrap_or_default();
+        let auto_enc_device = if on_gpu { device.clone() } else { cpu.clone() };
+        let enc_device_owned = crate::device::resolve_device(
+            Some(tier1),
+            || Ok(auto_enc_device.clone()),
+        )?;
+        let enc_device = &enc_device_owned;
+        let on_gpu = !enc_device.is_cpu();
         let enc_dtype = if on_gpu { gpu_dtype } else { DType::F32 };
         let bf16_cfg = self.qwen3_bf16_config();
 
@@ -493,7 +508,18 @@ impl Flux2Engine {
                 .progress
                 .stage_done("Selecting Qwen3 encoder", resolve_start.elapsed());
 
-            let enc_device = if on_gpu { &device } else { &Device::Cpu };
+            let tier1 = self
+                .pending_placement
+                .as_ref()
+                .map(|p| p.text_encoders)
+                .unwrap_or_default();
+            let auto_enc_device = if on_gpu { device.clone() } else { Device::Cpu };
+            let enc_device_owned = crate::device::resolve_device(
+                Some(tier1),
+                || Ok(auto_enc_device.clone()),
+            )?;
+            let enc_device = &enc_device_owned;
+            let on_gpu = !enc_device.is_cpu();
             let enc_dtype = if on_gpu { gpu_dtype } else { DType::F32 };
             let bf16_cfg = self.qwen3_bf16_config();
 
@@ -726,8 +752,8 @@ impl Flux2Engine {
 // InferenceEngine implementation
 // ---------------------------------------------------------------------------
 
-impl InferenceEngine for Flux2Engine {
-    fn generate(&mut self, req: &GenerateRequest) -> Result<GenerateResponse> {
+impl Flux2Engine {
+    fn generate_inner(&mut self, req: &GenerateRequest) -> Result<GenerateResponse> {
         if req.scheduler.is_some() {
             tracing::warn!(
                 "scheduler selection not supported for Flux.2 (flow-matching), ignoring"
@@ -957,6 +983,15 @@ impl InferenceEngine for Flux2Engine {
             video: None,
             gpu: None,
         })
+    }
+}
+
+impl InferenceEngine for Flux2Engine {
+    fn generate(&mut self, req: &GenerateRequest) -> Result<GenerateResponse> {
+        self.pending_placement = req.placement.clone();
+        let result = self.generate_inner(req);
+        self.pending_placement = None;
+        result
     }
 
     fn model_name(&self) -> &str {

--- a/crates/mold-inference/src/flux2/pipeline.rs
+++ b/crates/mold-inference/src/flux2/pipeline.rs
@@ -22,6 +22,29 @@ use std::time::Instant;
 use super::sampling::{self, Flux2State};
 use super::transformer::{Flux2Config, Flux2TransformerWrapper};
 use super::vae::{Flux2AutoEncoder, Flux2VaeConfig};
+
+/// Resolve a component override given Tier 1 plus Tier 2 requests.
+fn effective_device_ref(
+    placement: Option<&mold_core::types::DevicePlacement>,
+    advanced_override: impl FnOnce(&mold_core::types::AdvancedPlacement) -> Option<mold_core::types::DeviceRef>,
+    fallback_is_component_auto: bool,
+) -> mold_core::types::DeviceRef {
+    use mold_core::types::DeviceRef;
+    let Some(placement) = placement else {
+        return DeviceRef::Auto;
+    };
+    if let Some(adv) = placement.advanced.as_ref() {
+        if let Some(r) = advanced_override(adv) {
+            return r;
+        }
+        if fallback_is_component_auto {
+            return placement.text_encoders;
+        }
+        DeviceRef::Auto
+    } else {
+        placement.text_encoders
+    }
+}
 use crate::cache::{
     clear_cache, get_or_insert_cached_tensor, prompt_text_key, restore_cached_tensor, CachedTensor,
     LruCache, DEFAULT_PROMPT_CACHE_CAPACITY,
@@ -334,7 +357,15 @@ impl Flux2Engine {
         let text_tokenizer_path = self.validate_paths()?;
 
         let cpu = Device::Cpu;
-        let device = crate::device::create_device(self.base.gpu_ordinal, &self.base.progress)?;
+        let transformer_ref = effective_device_ref(
+            self.pending_placement.as_ref(),
+            |adv| Some(adv.transformer),
+            false,
+        );
+        let device = crate::device::resolve_device(
+            Some(transformer_ref),
+            || crate::device::create_device(self.base.gpu_ordinal, &self.base.progress),
+        )?;
         let gpu_dtype = crate::engine::gpu_dtype(&device);
 
         tracing::info!("GPU device: {:?}, GPU dtype: {:?}", device, gpu_dtype);
@@ -348,6 +379,15 @@ impl Flux2Engine {
             .stage_done(xformer_label, xformer_stage.elapsed());
 
         // --- Load VAE on GPU ---
+        let vae_ref = effective_device_ref(
+            self.pending_placement.as_ref(),
+            |adv| Some(adv.vae),
+            false,
+        );
+        let vae_device = crate::device::resolve_device(
+            Some(vae_ref),
+            || Ok(device.clone()),
+        )?;
         self.base.progress.stage_start("Loading VAE (GPU)");
         let vae_stage = Instant::now();
         tracing::info!(path = %self.base.paths.vae.display(), "loading VAE on GPU...");
@@ -355,7 +395,7 @@ impl Flux2Engine {
         let vae_vb = crate::weight_loader::load_safetensors_with_progress(
             std::slice::from_ref(&self.base.paths.vae),
             gpu_dtype,
-            &device,
+            &vae_device,
             "VAE",
             &self.base.progress,
         )?;
@@ -395,14 +435,14 @@ impl Flux2Engine {
             .progress
             .stage_done("Selecting Qwen3 encoder", resolve_start.elapsed());
 
-        let tier1 = self
-            .pending_placement
-            .as_ref()
-            .map(|p| p.text_encoders)
-            .unwrap_or_default();
+        let qwen3_ref = effective_device_ref(
+            self.pending_placement.as_ref(),
+            |adv| adv.qwen,
+            true,
+        );
         let auto_enc_device = if on_gpu { device.clone() } else { cpu.clone() };
         let enc_device_owned = crate::device::resolve_device(
-            Some(tier1),
+            Some(qwen3_ref),
             || Ok(auto_enc_device.clone()),
         )?;
         let enc_device = &enc_device_owned;
@@ -456,7 +496,15 @@ impl Flux2Engine {
             self.base.progress.info(&warning);
         }
 
-        let device = crate::device::create_device(self.base.gpu_ordinal, &self.base.progress)?;
+        let transformer_ref = effective_device_ref(
+            self.pending_placement.as_ref(),
+            |adv| Some(adv.transformer),
+            false,
+        );
+        let device = crate::device::resolve_device(
+            Some(transformer_ref),
+            || crate::device::create_device(self.base.gpu_ordinal, &self.base.progress),
+        )?;
         let gpu_dtype = crate::engine::gpu_dtype(&device);
 
         let start = Instant::now();
@@ -508,14 +556,14 @@ impl Flux2Engine {
                 .progress
                 .stage_done("Selecting Qwen3 encoder", resolve_start.elapsed());
 
-            let tier1 = self
-                .pending_placement
-                .as_ref()
-                .map(|p| p.text_encoders)
-                .unwrap_or_default();
+            let qwen3_ref = effective_device_ref(
+                self.pending_placement.as_ref(),
+                |adv| adv.qwen,
+                true,
+            );
             let auto_enc_device = if on_gpu { device.clone() } else { Device::Cpu };
             let enc_device_owned = crate::device::resolve_device(
-                Some(tier1),
+                Some(qwen3_ref),
                 || Ok(auto_enc_device.clone()),
             )?;
             let enc_device = &enc_device_owned;
@@ -595,13 +643,22 @@ impl Flux2Engine {
             .stage_done(xformer_label, xformer_stage.elapsed());
 
         // Load VAE
+        let vae_ref = effective_device_ref(
+            self.pending_placement.as_ref(),
+            |adv| Some(adv.vae),
+            false,
+        );
+        let vae_device = crate::device::resolve_device(
+            Some(vae_ref),
+            || Ok(device.clone()),
+        )?;
         self.base.progress.stage_start("Loading VAE (GPU)");
         let vae_stage = Instant::now();
         let vae_cfg = Flux2VaeConfig::klein();
         let vae_vb = crate::weight_loader::load_safetensors_with_progress(
             std::slice::from_ref(&self.base.paths.vae),
             gpu_dtype,
-            &device,
+            &vae_device,
             "VAE",
             &self.base.progress,
         )?;

--- a/crates/mold-inference/src/flux2/pipeline.rs
+++ b/crates/mold-inference/src/flux2/pipeline.rs
@@ -26,7 +26,9 @@ use super::vae::{Flux2AutoEncoder, Flux2VaeConfig};
 /// Resolve a component override given Tier 1 plus Tier 2 requests.
 fn effective_device_ref(
     placement: Option<&mold_core::types::DevicePlacement>,
-    advanced_override: impl FnOnce(&mold_core::types::AdvancedPlacement) -> Option<mold_core::types::DeviceRef>,
+    advanced_override: impl FnOnce(
+        &mold_core::types::AdvancedPlacement,
+    ) -> Option<mold_core::types::DeviceRef>,
     fallback_is_component_auto: bool,
 ) -> mold_core::types::DeviceRef {
     use mold_core::types::DeviceRef;
@@ -362,10 +364,9 @@ impl Flux2Engine {
             |adv| Some(adv.transformer),
             false,
         );
-        let device = crate::device::resolve_device(
-            Some(transformer_ref),
-            || crate::device::create_device(self.base.gpu_ordinal, &self.base.progress),
-        )?;
+        let device = crate::device::resolve_device(Some(transformer_ref), || {
+            crate::device::create_device(self.base.gpu_ordinal, &self.base.progress)
+        })?;
         let gpu_dtype = crate::engine::gpu_dtype(&device);
 
         tracing::info!("GPU device: {:?}, GPU dtype: {:?}", device, gpu_dtype);
@@ -379,15 +380,9 @@ impl Flux2Engine {
             .stage_done(xformer_label, xformer_stage.elapsed());
 
         // --- Load VAE on GPU ---
-        let vae_ref = effective_device_ref(
-            self.pending_placement.as_ref(),
-            |adv| Some(adv.vae),
-            false,
-        );
-        let vae_device = crate::device::resolve_device(
-            Some(vae_ref),
-            || Ok(device.clone()),
-        )?;
+        let vae_ref =
+            effective_device_ref(self.pending_placement.as_ref(), |adv| Some(adv.vae), false);
+        let vae_device = crate::device::resolve_device(Some(vae_ref), || Ok(device.clone()))?;
         self.base.progress.stage_start("Loading VAE (GPU)");
         let vae_stage = Instant::now();
         tracing::info!(path = %self.base.paths.vae.display(), "loading VAE on GPU...");
@@ -435,16 +430,10 @@ impl Flux2Engine {
             .progress
             .stage_done("Selecting Qwen3 encoder", resolve_start.elapsed());
 
-        let qwen3_ref = effective_device_ref(
-            self.pending_placement.as_ref(),
-            |adv| adv.qwen,
-            true,
-        );
+        let qwen3_ref = effective_device_ref(self.pending_placement.as_ref(), |adv| adv.qwen, true);
         let auto_enc_device = if on_gpu { device.clone() } else { cpu.clone() };
-        let enc_device_owned = crate::device::resolve_device(
-            Some(qwen3_ref),
-            || Ok(auto_enc_device.clone()),
-        )?;
+        let enc_device_owned =
+            crate::device::resolve_device(Some(qwen3_ref), || Ok(auto_enc_device.clone()))?;
         let enc_device = &enc_device_owned;
         let on_gpu = !enc_device.is_cpu();
         let enc_dtype = if on_gpu { gpu_dtype } else { DType::F32 };
@@ -501,10 +490,9 @@ impl Flux2Engine {
             |adv| Some(adv.transformer),
             false,
         );
-        let device = crate::device::resolve_device(
-            Some(transformer_ref),
-            || crate::device::create_device(self.base.gpu_ordinal, &self.base.progress),
-        )?;
+        let device = crate::device::resolve_device(Some(transformer_ref), || {
+            crate::device::create_device(self.base.gpu_ordinal, &self.base.progress)
+        })?;
         let gpu_dtype = crate::engine::gpu_dtype(&device);
 
         let start = Instant::now();
@@ -556,16 +544,11 @@ impl Flux2Engine {
                 .progress
                 .stage_done("Selecting Qwen3 encoder", resolve_start.elapsed());
 
-            let qwen3_ref = effective_device_ref(
-                self.pending_placement.as_ref(),
-                |adv| adv.qwen,
-                true,
-            );
+            let qwen3_ref =
+                effective_device_ref(self.pending_placement.as_ref(), |adv| adv.qwen, true);
             let auto_enc_device = if on_gpu { device.clone() } else { Device::Cpu };
-            let enc_device_owned = crate::device::resolve_device(
-                Some(qwen3_ref),
-                || Ok(auto_enc_device.clone()),
-            )?;
+            let enc_device_owned =
+                crate::device::resolve_device(Some(qwen3_ref), || Ok(auto_enc_device.clone()))?;
             let enc_device = &enc_device_owned;
             let on_gpu = !enc_device.is_cpu();
             let enc_dtype = if on_gpu { gpu_dtype } else { DType::F32 };
@@ -643,15 +626,9 @@ impl Flux2Engine {
             .stage_done(xformer_label, xformer_stage.elapsed());
 
         // Load VAE
-        let vae_ref = effective_device_ref(
-            self.pending_placement.as_ref(),
-            |adv| Some(adv.vae),
-            false,
-        );
-        let vae_device = crate::device::resolve_device(
-            Some(vae_ref),
-            || Ok(device.clone()),
-        )?;
+        let vae_ref =
+            effective_device_ref(self.pending_placement.as_ref(), |adv| Some(adv.vae), false);
+        let vae_device = crate::device::resolve_device(Some(vae_ref), || Ok(device.clone()))?;
         self.base.progress.stage_start("Loading VAE (GPU)");
         let vae_stage = Instant::now();
         let vae_cfg = Flux2VaeConfig::klein();

--- a/crates/mold-inference/src/image.rs
+++ b/crates/mold-inference/src/image.rs
@@ -425,6 +425,7 @@ mod tests {
             retake_range: None,
             spatial_upscale: None,
             temporal_upscale: None,
+            placement: None,
         };
 
         assert!(build_output_metadata(&req, 42, None).is_none());

--- a/crates/mold-inference/src/ltx2/conditioning.rs
+++ b/crates/mold-inference/src/ltx2/conditioning.rs
@@ -187,6 +187,7 @@ mod tests {
             retake_range: None,
             spatial_upscale: None,
             temporal_upscale: None,
+            placement: None,
         }
     }
 

--- a/crates/mold-inference/src/ltx2/execution.rs
+++ b/crates/mold-inference/src/ltx2/execution.rs
@@ -205,6 +205,7 @@ mod tests {
             retake_range: None,
             spatial_upscale: None,
             temporal_upscale: None,
+            placement: None,
         }
     }
 

--- a/crates/mold-inference/src/ltx2/lora.rs
+++ b/crates/mold-inference/src/ltx2/lora.rs
@@ -289,6 +289,7 @@ mod tests {
             retake_range: None,
             spatial_upscale: None,
             temporal_upscale: None,
+            placement: None,
         }
     }
 

--- a/crates/mold-inference/src/ltx2/pipeline.rs
+++ b/crates/mold-inference/src/ltx2/pipeline.rs
@@ -30,6 +30,7 @@ pub struct Ltx2Engine {
     loaded: bool,
     native_runtime: Option<Ltx2RuntimeSession>,
     on_progress: Option<ProgressCallback>,
+    pending_placement: Option<mold_core::types::DevicePlacement>,
 }
 
 impl Ltx2Engine {
@@ -57,6 +58,7 @@ impl Ltx2Engine {
             loaded: false,
             native_runtime: None,
             on_progress: None,
+            pending_placement: None,
         }
     }
 
@@ -393,8 +395,8 @@ fn configure_native_ltx2_cuda_device(device: &Device) -> Result<()> {
     Ok(())
 }
 
-impl InferenceEngine for Ltx2Engine {
-    fn generate(&mut self, req: &GenerateRequest) -> Result<GenerateResponse> {
+impl Ltx2Engine {
+    fn generate_inner(&mut self, req: &GenerateRequest) -> Result<GenerateResponse> {
         if !self.loaded {
             self.load()?;
         }
@@ -501,6 +503,15 @@ impl InferenceEngine for Ltx2Engine {
             seed_used: plan.seed,
             gpu: None,
         })
+    }
+}
+
+impl InferenceEngine for Ltx2Engine {
+    fn generate(&mut self, req: &GenerateRequest) -> Result<GenerateResponse> {
+        self.pending_placement = req.placement.clone();
+        let result = self.generate_inner(req);
+        self.pending_placement = None;
+        result
     }
 
     fn model_name(&self) -> &str {

--- a/crates/mold-inference/src/ltx2/pipeline.rs
+++ b/crates/mold-inference/src/ltx2/pipeline.rs
@@ -74,6 +74,7 @@ impl Ltx2Engine {
             loaded: false,
             native_runtime: Some(runtime),
             on_progress: None,
+            pending_placement: None,
         }
     }
 
@@ -877,6 +878,7 @@ mod tests {
             retake_range: None,
             spatial_upscale: None,
             temporal_upscale: None,
+            placement: None,
         }
     }
 
@@ -923,6 +925,7 @@ mod tests {
             retake_range: None,
             spatial_upscale: None,
             temporal_upscale: None,
+            placement: None,
         };
         assert_eq!(
             engine.select_pipeline(&req).unwrap(),
@@ -1002,6 +1005,7 @@ mod tests {
             retake_range: None,
             spatial_upscale: None,
             temporal_upscale: None,
+            placement: None,
         };
         let temp_dir = tempfile::tempdir().unwrap();
         let bridge = engine

--- a/crates/mold-inference/src/ltx2/pipeline.rs
+++ b/crates/mold-inference/src/ltx2/pipeline.rs
@@ -272,19 +272,15 @@ impl Ltx2Engine {
         // Auto falls back to whatever `native_device_for_backend(backend)` picks
         // (CUDA when available, else CPU). Explicit Cpu/Gpu skips that auto path.
         let tier1 = self.pending_placement.as_ref().map(|p| p.text_encoders);
-        let device = crate::device::resolve_device(tier1, || {
-            self.native_device_for_backend(backend)
-        })?;
+        let device =
+            crate::device::resolve_device(tier1, || self.native_device_for_backend(backend))?;
         if device.is_cuda() {
             configure_native_ltx2_cuda_device(&device)?;
         }
         // Only auto CUDA placement should retry on OOM — if the user explicitly
         // pinned the encoder to a GPU, surface the OOM rather than silently
         // rewriting their request.
-        let override_is_auto = matches!(
-            tier1,
-            None | Some(mold_core::types::DeviceRef::Auto)
-        );
+        let override_is_auto = matches!(tier1, None | Some(mold_core::types::DeviceRef::Auto));
         match self.load_runtime_session_on_device(plan, device) {
             Ok(runtime) => Ok(runtime),
             Err(err)

--- a/crates/mold-inference/src/ltx2/pipeline.rs
+++ b/crates/mold-inference/src/ltx2/pipeline.rs
@@ -268,9 +268,30 @@ impl Ltx2Engine {
         let backend = Ltx2Backend::detect();
         backend.ensure_supported()?;
 
-        match self.load_runtime_session_on_device(plan, self.native_device_for_backend(backend)?) {
+        // Honor Tier 1 `text_encoders` override for the Gemma prompt encoder.
+        // Auto falls back to whatever `native_device_for_backend(backend)` picks
+        // (CUDA when available, else CPU). Explicit Cpu/Gpu skips that auto path.
+        let tier1 = self.pending_placement.as_ref().map(|p| p.text_encoders);
+        let device = crate::device::resolve_device(tier1, || {
+            self.native_device_for_backend(backend)
+        })?;
+        if device.is_cuda() {
+            configure_native_ltx2_cuda_device(&device)?;
+        }
+        // Only auto CUDA placement should retry on OOM — if the user explicitly
+        // pinned the encoder to a GPU, surface the OOM rather than silently
+        // rewriting their request.
+        let override_is_auto = matches!(
+            tier1,
+            None | Some(mold_core::types::DeviceRef::Auto)
+        );
+        match self.load_runtime_session_on_device(plan, device) {
             Ok(runtime) => Ok(runtime),
-            Err(err) if matches!(backend, Ltx2Backend::Cuda) && Self::is_oom_error(&err) => {
+            Err(err)
+                if matches!(backend, Ltx2Backend::Cuda)
+                    && override_is_auto
+                    && Self::is_oom_error(&err) =>
+            {
                 self.info(
                     "Native LTX-2 prompt path ran out of CUDA memory; retrying with CPU fallback",
                 );

--- a/crates/mold-inference/src/ltx2/runtime.rs
+++ b/crates/mold-inference/src/ltx2/runtime.rs
@@ -4680,6 +4680,7 @@ mod tests {
             retake_range: None,
             spatial_upscale: None,
             temporal_upscale: None,
+            placement: None,
         }
     }
 

--- a/crates/mold-inference/src/ltx_video/pipeline.rs
+++ b/crates/mold-inference/src/ltx_video/pipeline.rs
@@ -623,6 +623,7 @@ pub struct LtxVideoEngine {
     base: EngineBase<LoadedLtxVideo>,
     t5_variant: Option<String>,
     shared_pool: Option<Arc<Mutex<SharedPool>>>,
+    pending_placement: Option<mold_core::types::DevicePlacement>,
 }
 
 impl LtxVideoEngine {
@@ -638,6 +639,7 @@ impl LtxVideoEngine {
             base: EngineBase::new(model_name, paths, load_strategy, gpu_ordinal),
             t5_variant,
             shared_pool,
+            pending_placement: None,
         }
     }
 }
@@ -646,8 +648,8 @@ impl LtxVideoEngine {
 // InferenceEngine trait
 // ---------------------------------------------------------------------------
 
-impl crate::engine::InferenceEngine for LtxVideoEngine {
-    fn generate(&mut self, req: &GenerateRequest) -> Result<GenerateResponse> {
+impl LtxVideoEngine {
+    fn generate_inner(&mut self, req: &GenerateRequest) -> Result<GenerateResponse> {
         let start = Instant::now();
         let preset = LtxModelPreset::for_model(&self.base.model_name)?;
 
@@ -690,6 +692,15 @@ impl crate::engine::InferenceEngine for LtxVideoEngine {
             req, &preset, seed, num_frames, fps, steps, guidance, width, height, latent_h,
             latent_w, latent_f, start,
         )
+    }
+}
+
+impl crate::engine::InferenceEngine for LtxVideoEngine {
+    fn generate(&mut self, req: &GenerateRequest) -> Result<GenerateResponse> {
+        self.pending_placement = req.placement.clone();
+        let result = self.generate_inner(req);
+        self.pending_placement = None;
+        result
     }
 
     fn model_name(&self) -> &str {
@@ -1051,10 +1062,19 @@ impl LtxVideoEngine {
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("T5 tokenizer path not configured"))?;
 
+        let tier1 = self
+            .pending_placement
+            .as_ref()
+            .map(|p| p.text_encoders)
+            .unwrap_or_default();
+        let t5_device = crate::device::resolve_device(
+            Some(tier1),
+            || Ok(device.clone()),
+        )?;
         let mut t5 = crate::encoders::t5::T5Encoder::load(
             t5_encoder_path,
             t5_tokenizer_path,
-            &device,
+            &t5_device,
             dtype,
             progress,
         )?;
@@ -1062,7 +1082,8 @@ impl LtxVideoEngine {
 
         progress.stage_start("Encoding prompt");
         let encode_start = Instant::now();
-        let prompt_embeds = t5.encode(&req.prompt, &device, dtype)?;
+        let prompt_embeds = t5.encode(&req.prompt, &t5_device, dtype)?;
+        let prompt_embeds = prompt_embeds.to_device(&device)?;
         // prompt_embeds: [1, seq_len, 4096] (T5 encoder already adds batch dim)
         progress.stage_done("Encoding prompt", encode_start.elapsed());
 
@@ -1088,7 +1109,8 @@ impl LtxVideoEngine {
 
         let (uncond_embeds, uncond_mask) = if needs_uncond {
             progress.stage_start("Encoding negative prompt (CFG)");
-            let ue = t5.encode("", &device, dtype)?;
+            let ue = t5.encode("", &t5_device, dtype)?;
+            let ue = ue.to_device(&device)?;
             let ue_seq = ue.dim(1)?;
             let um = Tensor::ones((1, ue_seq), DType::F32, &device)?.to_dtype(dtype)?;
             progress.stage_done("Encoding negative prompt (CFG)", encode_start.elapsed());

--- a/crates/mold-inference/src/ltx_video/pipeline.rs
+++ b/crates/mold-inference/src/ltx_video/pipeline.rs
@@ -1067,10 +1067,7 @@ impl LtxVideoEngine {
             .as_ref()
             .map(|p| p.text_encoders)
             .unwrap_or_default();
-        let t5_device = crate::device::resolve_device(
-            Some(tier1),
-            || Ok(device.clone()),
-        )?;
+        let t5_device = crate::device::resolve_device(Some(tier1), || Ok(device.clone()))?;
         let mut t5 = crate::encoders::t5::T5Encoder::load(
             t5_encoder_path,
             t5_tokenizer_path,

--- a/crates/mold-inference/src/qwen_image/pipeline.rs
+++ b/crates/mold-inference/src/qwen_image/pipeline.rs
@@ -314,6 +314,8 @@ pub struct QwenImageEngine {
     base: EngineBase<LoadedQwenImage>,
     prompt_cache: Mutex<LruCache<String, CachedPromptConditioning>>,
     offload: bool,
+    /// Per-request placement override.
+    pending_placement: Option<mold_core::types::DevicePlacement>,
 }
 
 impl QwenImageEngine {
@@ -759,6 +761,7 @@ impl QwenImageEngine {
             base: EngineBase::new(model_name, paths, load_strategy, gpu_ordinal),
             prompt_cache: Mutex::new(LruCache::new(DEFAULT_PROMPT_CACHE_CAPACITY)),
             offload,
+            pending_placement: None,
         }
     }
 
@@ -1396,14 +1399,31 @@ impl QwenImageEngine {
         // Load text encoder
         let resolved_text_encoder =
             self.resolve_text_encoder_source(&device, free, Qwen2TextEncoderUsage::Resident)?;
-        let (te_plan, te_device_label) =
+        let (te_plan, te_auto_device_label) =
             self.resolve_text_encoder_plan(&device, &resolved_text_encoder, free);
-        let te_device = if te_plan.use_gpu {
+        let tier1 = self
+            .pending_placement
+            .as_ref()
+            .map(|p| p.text_encoders)
+            .unwrap_or_default();
+        let auto_te_device = if te_plan.use_gpu {
             device.clone()
         } else {
             Device::Cpu
         };
-        let te_dtype = Self::text_encoder_load_dtype(te_plan.use_gpu, dtype);
+        let te_device = crate::device::resolve_device(
+            Some(tier1),
+            || Ok(auto_te_device.clone()),
+        )?;
+        let te_use_gpu = !te_device.is_cpu();
+        let te_device_label: String = if te_use_gpu == te_plan.use_gpu {
+            te_auto_device_label
+        } else if te_use_gpu {
+            "GPU".into()
+        } else {
+            "CPU".into()
+        };
+        let te_dtype = Self::text_encoder_load_dtype(te_use_gpu, dtype);
 
         let preload_text_encoder = self.should_preload_text_encoder();
         let te_label = if resolved_text_encoder.is_gguf {
@@ -1548,14 +1568,31 @@ impl QwenImageEngine {
                 };
                 (hs, mask, u_hs, u_mask)
             } else {
-                let (te_plan, te_device_label) =
+                let (te_plan, te_auto_device_label) =
                     self.resolve_text_encoder_plan(&device, &resolved_text_encoder, free);
-                let te_device = if te_plan.use_gpu {
+                let tier1 = self
+                    .pending_placement
+                    .as_ref()
+                    .map(|p| p.text_encoders)
+                    .unwrap_or_default();
+                let auto_te_device = if te_plan.use_gpu {
                     device.clone()
                 } else {
                     Device::Cpu
                 };
-                let te_dtype = Self::text_encoder_load_dtype(te_plan.use_gpu, dtype);
+                let te_device = crate::device::resolve_device(
+                    Some(tier1),
+                    || Ok(auto_te_device.clone()),
+                )?;
+                let te_use_gpu = !te_device.is_cpu();
+                let te_device_label: String = if te_use_gpu == te_plan.use_gpu {
+                    te_auto_device_label
+                } else if te_use_gpu {
+                    "GPU".into()
+                } else {
+                    "CPU".into()
+                };
+                let te_dtype = Self::text_encoder_load_dtype(te_use_gpu, dtype);
 
                 let te_label = if resolved_text_encoder.is_gguf {
                     format!(
@@ -2330,8 +2367,8 @@ impl QwenImageEngine {
     }
 }
 
-impl InferenceEngine for QwenImageEngine {
-    fn generate(&mut self, req: &GenerateRequest) -> Result<GenerateResponse> {
+impl QwenImageEngine {
+    fn generate_inner(&mut self, req: &GenerateRequest) -> Result<GenerateResponse> {
         if req.scheduler.is_some() {
             tracing::warn!(
                 "scheduler selection not supported for Qwen-Image (flow-matching), ignoring"
@@ -2774,6 +2811,15 @@ impl InferenceEngine for QwenImageEngine {
             video: None,
             gpu: None,
         })
+    }
+}
+
+impl InferenceEngine for QwenImageEngine {
+    fn generate(&mut self, req: &GenerateRequest) -> Result<GenerateResponse> {
+        self.pending_placement = req.placement.clone();
+        let result = self.generate_inner(req);
+        self.pending_placement = None;
+        result
     }
 
     fn model_name(&self) -> &str {

--- a/crates/mold-inference/src/qwen_image/pipeline.rs
+++ b/crates/mold-inference/src/qwen_image/pipeline.rs
@@ -309,6 +309,29 @@ impl QwenImageTransformer {
     }
 }
 
+/// Resolve a component override given Tier 1 plus Tier 2 requests.
+fn effective_device_ref(
+    placement: Option<&mold_core::types::DevicePlacement>,
+    advanced_override: impl FnOnce(&mold_core::types::AdvancedPlacement) -> Option<mold_core::types::DeviceRef>,
+    fallback_is_component_auto: bool,
+) -> mold_core::types::DeviceRef {
+    use mold_core::types::DeviceRef;
+    let Some(placement) = placement else {
+        return DeviceRef::Auto;
+    };
+    if let Some(adv) = placement.advanced.as_ref() {
+        if let Some(r) = advanced_override(adv) {
+            return r;
+        }
+        if fallback_is_component_auto {
+            return placement.text_encoders;
+        }
+        DeviceRef::Auto
+    } else {
+        placement.text_encoders
+    }
+}
+
 /// Qwen-Image-2512 inference engine.
 pub struct QwenImageEngine {
     base: EngineBase<LoadedQwenImage>,
@@ -1334,7 +1357,15 @@ impl QwenImageEngine {
         tracing::info!(model = %self.base.model_name, "loading Qwen-Image model components...");
 
         let text_tokenizer_path = self.validate_paths()?;
-        let device = crate::device::create_device(self.base.gpu_ordinal, &self.base.progress)?;
+        let transformer_ref = effective_device_ref(
+            self.pending_placement.as_ref(),
+            |adv| Some(adv.transformer),
+            false,
+        );
+        let device = crate::device::resolve_device(
+            Some(transformer_ref),
+            || crate::device::create_device(self.base.gpu_ordinal, &self.base.progress),
+        )?;
         let transformer_cfg = self.transformer_config();
         let transformer_is_quantized = self.detect_is_quantized();
         // FP8 safetensors are loaded as BF16 via CPU (candle CUDA kernel bug
@@ -1377,11 +1408,16 @@ impl QwenImageEngine {
         }
 
         let vae_on_gpu = should_use_gpu(is_cuda, is_metal, free, VAE_DECODE_VRAM_THRESHOLD);
-        let vae_device = if vae_on_gpu {
-            device.clone()
-        } else {
-            Device::Cpu
-        };
+        let vae_ref = effective_device_ref(
+            self.pending_placement.as_ref(),
+            |adv| Some(adv.vae),
+            false,
+        );
+        let vae_device = crate::device::resolve_device(
+            Some(vae_ref),
+            || Ok(if vae_on_gpu { device.clone() } else { Device::Cpu }),
+        )?;
+        let vae_on_gpu = !vae_device.is_cpu();
         // Always decode in F32 — BF16 convolutions accumulate quantization noise across
         // the 4 upsampling blocks, producing visible grain. Matches diffusers' force_upcast.
         let vae_dtype = DType::F32;
@@ -1401,18 +1437,18 @@ impl QwenImageEngine {
             self.resolve_text_encoder_source(&device, free, Qwen2TextEncoderUsage::Resident)?;
         let (te_plan, te_auto_device_label) =
             self.resolve_text_encoder_plan(&device, &resolved_text_encoder, free);
-        let tier1 = self
-            .pending_placement
-            .as_ref()
-            .map(|p| p.text_encoders)
-            .unwrap_or_default();
+        let qwen_ref = effective_device_ref(
+            self.pending_placement.as_ref(),
+            |adv| adv.qwen,
+            true,
+        );
         let auto_te_device = if te_plan.use_gpu {
             device.clone()
         } else {
             Device::Cpu
         };
         let te_device = crate::device::resolve_device(
-            Some(tier1),
+            Some(qwen_ref),
             || Ok(auto_te_device.clone()),
         )?;
         let te_use_gpu = !te_device.is_cpu();
@@ -1505,7 +1541,15 @@ impl QwenImageEngine {
         let text_tokenizer_path = self.validate_paths()?;
         let transformer_cfg = self.transformer_config();
 
-        let device = crate::device::create_device(self.base.gpu_ordinal, &self.base.progress)?;
+        let transformer_ref = effective_device_ref(
+            self.pending_placement.as_ref(),
+            |adv| Some(adv.transformer),
+            false,
+        );
+        let device = crate::device::resolve_device(
+            Some(transformer_ref),
+            || crate::device::create_device(self.base.gpu_ordinal, &self.base.progress),
+        )?;
         let dtype = crate::engine::gpu_dtype(&device);
         let transformer_is_quantized = self.detect_is_quantized();
 
@@ -1570,18 +1614,18 @@ impl QwenImageEngine {
             } else {
                 let (te_plan, te_auto_device_label) =
                     self.resolve_text_encoder_plan(&device, &resolved_text_encoder, free);
-                let tier1 = self
-                    .pending_placement
-                    .as_ref()
-                    .map(|p| p.text_encoders)
-                    .unwrap_or_default();
+                let qwen_ref = effective_device_ref(
+                    self.pending_placement.as_ref(),
+                    |adv| adv.qwen,
+                    true,
+                );
                 let auto_te_device = if te_plan.use_gpu {
                     device.clone()
                 } else {
                     Device::Cpu
                 };
                 let te_device = crate::device::resolve_device(
-                    Some(tier1),
+                    Some(qwen_ref),
                     || Ok(auto_te_device.clone()),
                 )?;
                 let te_use_gpu = !te_device.is_cpu();
@@ -1989,11 +2033,16 @@ impl QwenImageEngine {
             free_for_vae,
             VAE_DECODE_VRAM_THRESHOLD,
         );
-        let vae_device = if vae_on_gpu {
-            device.clone()
-        } else {
-            Device::Cpu
-        };
+        let vae_ref = effective_device_ref(
+            self.pending_placement.as_ref(),
+            |adv| Some(adv.vae),
+            false,
+        );
+        let vae_device = crate::device::resolve_device(
+            Some(vae_ref),
+            || Ok(if vae_on_gpu { device.clone() } else { Device::Cpu }),
+        )?;
+        let vae_on_gpu = !vae_device.is_cpu();
         // Always decode in F32 — BF16 convolutions accumulate quantization noise across
         // the 4 upsampling blocks, producing visible grain. Matches diffusers' force_upcast.
         let vae_dtype = DType::F32;

--- a/crates/mold-inference/src/qwen_image/pipeline.rs
+++ b/crates/mold-inference/src/qwen_image/pipeline.rs
@@ -31,8 +31,8 @@ use crate::cache::{
     clear_cache, prompt_text_key, CachedTensor, LruCache, DEFAULT_PROMPT_CACHE_CAPACITY,
 };
 use crate::device::{
-    fits_in_memory, fmt_gb, free_vram_bytes, memory_status_string, preflight_memory_check,
-    qwen2_vram_threshold, should_use_gpu,
+    effective_device_ref, fits_in_memory, fmt_gb, free_vram_bytes, memory_status_string,
+    preflight_memory_check, qwen2_vram_threshold, should_use_gpu,
 };
 use crate::encoders;
 use crate::engine::{rand_seed, InferenceEngine, LoadStrategy};
@@ -306,31 +306,6 @@ impl QwenImageTransformer {
                 img_shapes,
             ),
         }
-    }
-}
-
-/// Resolve a component override given Tier 1 plus Tier 2 requests.
-fn effective_device_ref(
-    placement: Option<&mold_core::types::DevicePlacement>,
-    advanced_override: impl FnOnce(
-        &mold_core::types::AdvancedPlacement,
-    ) -> Option<mold_core::types::DeviceRef>,
-    fallback_is_component_auto: bool,
-) -> mold_core::types::DeviceRef {
-    use mold_core::types::DeviceRef;
-    let Some(placement) = placement else {
-        return DeviceRef::Auto;
-    };
-    if let Some(adv) = placement.advanced.as_ref() {
-        if let Some(r) = advanced_override(adv) {
-            return r;
-        }
-        if fallback_is_component_auto {
-            return placement.text_encoders;
-        }
-        DeviceRef::Auto
-    } else {
-        placement.text_encoders
     }
 }
 

--- a/crates/mold-inference/src/qwen_image/pipeline.rs
+++ b/crates/mold-inference/src/qwen_image/pipeline.rs
@@ -312,7 +312,9 @@ impl QwenImageTransformer {
 /// Resolve a component override given Tier 1 plus Tier 2 requests.
 fn effective_device_ref(
     placement: Option<&mold_core::types::DevicePlacement>,
-    advanced_override: impl FnOnce(&mold_core::types::AdvancedPlacement) -> Option<mold_core::types::DeviceRef>,
+    advanced_override: impl FnOnce(
+        &mold_core::types::AdvancedPlacement,
+    ) -> Option<mold_core::types::DeviceRef>,
     fallback_is_component_auto: bool,
 ) -> mold_core::types::DeviceRef {
     use mold_core::types::DeviceRef;
@@ -1362,10 +1364,9 @@ impl QwenImageEngine {
             |adv| Some(adv.transformer),
             false,
         );
-        let device = crate::device::resolve_device(
-            Some(transformer_ref),
-            || crate::device::create_device(self.base.gpu_ordinal, &self.base.progress),
-        )?;
+        let device = crate::device::resolve_device(Some(transformer_ref), || {
+            crate::device::create_device(self.base.gpu_ordinal, &self.base.progress)
+        })?;
         let transformer_cfg = self.transformer_config();
         let transformer_is_quantized = self.detect_is_quantized();
         // FP8 safetensors are loaded as BF16 via CPU (candle CUDA kernel bug
@@ -1408,15 +1409,15 @@ impl QwenImageEngine {
         }
 
         let vae_on_gpu = should_use_gpu(is_cuda, is_metal, free, VAE_DECODE_VRAM_THRESHOLD);
-        let vae_ref = effective_device_ref(
-            self.pending_placement.as_ref(),
-            |adv| Some(adv.vae),
-            false,
-        );
-        let vae_device = crate::device::resolve_device(
-            Some(vae_ref),
-            || Ok(if vae_on_gpu { device.clone() } else { Device::Cpu }),
-        )?;
+        let vae_ref =
+            effective_device_ref(self.pending_placement.as_ref(), |adv| Some(adv.vae), false);
+        let vae_device = crate::device::resolve_device(Some(vae_ref), || {
+            Ok(if vae_on_gpu {
+                device.clone()
+            } else {
+                Device::Cpu
+            })
+        })?;
         let vae_on_gpu = !vae_device.is_cpu();
         // Always decode in F32 — BF16 convolutions accumulate quantization noise across
         // the 4 upsampling blocks, producing visible grain. Matches diffusers' force_upcast.
@@ -1437,20 +1438,14 @@ impl QwenImageEngine {
             self.resolve_text_encoder_source(&device, free, Qwen2TextEncoderUsage::Resident)?;
         let (te_plan, te_auto_device_label) =
             self.resolve_text_encoder_plan(&device, &resolved_text_encoder, free);
-        let qwen_ref = effective_device_ref(
-            self.pending_placement.as_ref(),
-            |adv| adv.qwen,
-            true,
-        );
+        let qwen_ref = effective_device_ref(self.pending_placement.as_ref(), |adv| adv.qwen, true);
         let auto_te_device = if te_plan.use_gpu {
             device.clone()
         } else {
             Device::Cpu
         };
-        let te_device = crate::device::resolve_device(
-            Some(qwen_ref),
-            || Ok(auto_te_device.clone()),
-        )?;
+        let te_device =
+            crate::device::resolve_device(Some(qwen_ref), || Ok(auto_te_device.clone()))?;
         let te_use_gpu = !te_device.is_cpu();
         let te_device_label: String = if te_use_gpu == te_plan.use_gpu {
             te_auto_device_label
@@ -1546,10 +1541,9 @@ impl QwenImageEngine {
             |adv| Some(adv.transformer),
             false,
         );
-        let device = crate::device::resolve_device(
-            Some(transformer_ref),
-            || crate::device::create_device(self.base.gpu_ordinal, &self.base.progress),
-        )?;
+        let device = crate::device::resolve_device(Some(transformer_ref), || {
+            crate::device::create_device(self.base.gpu_ordinal, &self.base.progress)
+        })?;
         let dtype = crate::engine::gpu_dtype(&device);
         let transformer_is_quantized = self.detect_is_quantized();
 
@@ -1614,20 +1608,15 @@ impl QwenImageEngine {
             } else {
                 let (te_plan, te_auto_device_label) =
                     self.resolve_text_encoder_plan(&device, &resolved_text_encoder, free);
-                let qwen_ref = effective_device_ref(
-                    self.pending_placement.as_ref(),
-                    |adv| adv.qwen,
-                    true,
-                );
+                let qwen_ref =
+                    effective_device_ref(self.pending_placement.as_ref(), |adv| adv.qwen, true);
                 let auto_te_device = if te_plan.use_gpu {
                     device.clone()
                 } else {
                     Device::Cpu
                 };
-                let te_device = crate::device::resolve_device(
-                    Some(qwen_ref),
-                    || Ok(auto_te_device.clone()),
-                )?;
+                let te_device =
+                    crate::device::resolve_device(Some(qwen_ref), || Ok(auto_te_device.clone()))?;
                 let te_use_gpu = !te_device.is_cpu();
                 let te_device_label: String = if te_use_gpu == te_plan.use_gpu {
                     te_auto_device_label
@@ -2033,15 +2022,15 @@ impl QwenImageEngine {
             free_for_vae,
             VAE_DECODE_VRAM_THRESHOLD,
         );
-        let vae_ref = effective_device_ref(
-            self.pending_placement.as_ref(),
-            |adv| Some(adv.vae),
-            false,
-        );
-        let vae_device = crate::device::resolve_device(
-            Some(vae_ref),
-            || Ok(if vae_on_gpu { device.clone() } else { Device::Cpu }),
-        )?;
+        let vae_ref =
+            effective_device_ref(self.pending_placement.as_ref(), |adv| Some(adv.vae), false);
+        let vae_device = crate::device::resolve_device(Some(vae_ref), || {
+            Ok(if vae_on_gpu {
+                device.clone()
+            } else {
+                Device::Cpu
+            })
+        })?;
         let vae_on_gpu = !vae_device.is_cpu();
         // Always decode in F32 — BF16 convolutions accumulate quantization noise across
         // the 4 upsampling blocks, producing visible grain. Matches diffusers' force_upcast.

--- a/crates/mold-inference/src/sd15/pipeline.rs
+++ b/crates/mold-inference/src/sd15/pipeline.rs
@@ -196,10 +196,7 @@ impl SD15Engine {
             .as_ref()
             .map(|p| p.text_encoders)
             .unwrap_or_default();
-        let clip_device = crate::device::resolve_device(
-            Some(tier1),
-            || Ok(device.clone()),
-        )?;
+        let clip_device = crate::device::resolve_device(Some(tier1), || Ok(device.clone()))?;
         self.base.progress.stage_start("Loading CLIP-L encoder");
         let clip_start = Instant::now();
         let clip = stable_diffusion::build_clip_transformer(
@@ -643,10 +640,7 @@ impl SD15Engine {
                 .as_ref()
                 .map(|p| p.text_encoders)
                 .unwrap_or_default();
-            let clip_device = crate::device::resolve_device(
-                Some(tier1),
-                || Ok(device.clone()),
-            )?;
+            let clip_device = crate::device::resolve_device(Some(tier1), || Ok(device.clone()))?;
             self.base.progress.stage_start("Loading CLIP-L encoder");
             let clip_start = Instant::now();
             let clip = stable_diffusion::build_clip_transformer(

--- a/crates/mold-inference/src/sd15/pipeline.rs
+++ b/crates/mold-inference/src/sd15/pipeline.rs
@@ -37,6 +37,9 @@ struct LoadedSD15 {
     tokenizer: tokenizers::Tokenizer,
     sd_config: stable_diffusion::StableDiffusionConfig,
     device: Device,
+    /// Device the CLIP-L weights live on. May differ from `device` when the
+    /// Tier 1 `text_encoders` placement override pins encoders to CPU.
+    clip_device: Device,
     dtype: DType,
 }
 
@@ -50,6 +53,7 @@ pub struct SD15Engine {
     source_latent_cache: Mutex<LruCache<ImageSizeCacheKey, CachedTensor>>,
     mask_cache: Mutex<LruCache<LatentSizeCacheKey, CachedTensor>>,
     control_tensor_cache: Mutex<LruCache<ImageSizeCacheKey, CachedTensor>>,
+    pending_placement: Option<mold_core::types::DevicePlacement>,
 }
 
 impl SD15Engine {
@@ -67,6 +71,7 @@ impl SD15Engine {
             source_latent_cache: Mutex::new(LruCache::new(DEFAULT_IMAGE_CACHE_CAPACITY)),
             mask_cache: Mutex::new(LruCache::new(DEFAULT_IMAGE_CACHE_CAPACITY)),
             control_tensor_cache: Mutex::new(LruCache::new(DEFAULT_IMAGE_CACHE_CAPACITY)),
+            pending_placement: None,
         }
     }
 
@@ -185,12 +190,22 @@ impl SD15Engine {
             .stage_done("Loading VAE (GPU)", vae_start.elapsed());
 
         // Load CLIP-L encoder
+        // Tier 1: honor `placement.text_encoders` override (group knob).
+        let tier1 = self
+            .pending_placement
+            .as_ref()
+            .map(|p| p.text_encoders)
+            .unwrap_or_default();
+        let clip_device = crate::device::resolve_device(
+            Some(tier1),
+            || Ok(device.clone()),
+        )?;
         self.base.progress.stage_start("Loading CLIP-L encoder");
         let clip_start = Instant::now();
         let clip = stable_diffusion::build_clip_transformer(
             &sd_config.clip,
             &clip_encoder,
-            &device,
+            &clip_device,
             DType::F32,
         )?;
         self.base
@@ -208,6 +223,7 @@ impl SD15Engine {
             tokenizer,
             sd_config,
             device,
+            clip_device,
             dtype,
         });
 
@@ -412,6 +428,7 @@ impl SD15Engine {
 
     /// Encode prompt with the single CLIP-L encoder.
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments)]
     fn encode_prompt(
         &self,
         clip: &stable_diffusion::clip::ClipTextTransformer,
@@ -420,6 +437,7 @@ impl SD15Engine {
         negative_prompt: &str,
         max_len: usize,
         device: &Device,
+        clip_device: &Device,
         dtype: DType,
         guidance: f64,
     ) -> Result<Tensor> {
@@ -430,7 +448,7 @@ impl SD15Engine {
 
                 self.base.progress.stage_start("Encoding prompt (CLIP-L)");
                 let encode_start = Instant::now();
-                let tokens = Self::tokenize(tokenizer, prompt, max_len, device)?;
+                let tokens = Self::tokenize(tokenizer, prompt, max_len, clip_device)?;
                 let text_embeddings = clip.forward(&tokens)?;
                 self.base
                     .progress
@@ -438,13 +456,14 @@ impl SD15Engine {
 
                 let text_embeddings = if use_cfg {
                     let uncond_tokens =
-                        Self::tokenize(tokenizer, negative_prompt, max_len, device)?;
+                        Self::tokenize(tokenizer, negative_prompt, max_len, clip_device)?;
                     let uncond_embeddings = clip.forward(&uncond_tokens)?;
                     Tensor::cat(&[&uncond_embeddings, &text_embeddings], 0)?
                 } else {
                     text_embeddings
                 };
 
+                let text_embeddings = text_embeddings.to_device(device)?;
                 Ok(text_embeddings.to_dtype(dtype)?)
             })?;
         if cache_hit {
@@ -619,12 +638,21 @@ impl SD15Engine {
             let tokenizer = tokenizers::Tokenizer::from_file(&clip_tokenizer)
                 .map_err(|e| anyhow::anyhow!("failed to load CLIP-L tokenizer: {e}"))?;
 
+            let tier1 = self
+                .pending_placement
+                .as_ref()
+                .map(|p| p.text_encoders)
+                .unwrap_or_default();
+            let clip_device = crate::device::resolve_device(
+                Some(tier1),
+                || Ok(device.clone()),
+            )?;
             self.base.progress.stage_start("Loading CLIP-L encoder");
             let clip_start = Instant::now();
             let clip = stable_diffusion::build_clip_transformer(
                 &sd_config.clip,
                 &clip_encoder,
-                &device,
+                &clip_device,
                 DType::F32,
             )?;
             self.base
@@ -638,6 +666,7 @@ impl SD15Engine {
                 neg,
                 max_len,
                 &device,
+                &clip_device,
                 dtype,
                 guidance,
             )?;
@@ -821,8 +850,8 @@ impl SD15Engine {
     }
 }
 
-impl InferenceEngine for SD15Engine {
-    fn generate(&mut self, req: &GenerateRequest) -> Result<GenerateResponse> {
+impl SD15Engine {
+    fn generate_inner(&mut self, req: &GenerateRequest) -> Result<GenerateResponse> {
         // Sequential mode: load-use-drop each component
         if self.base.load_strategy == LoadStrategy::Sequential {
             return self.generate_sequential(req);
@@ -863,6 +892,7 @@ impl InferenceEngine for SD15Engine {
             neg,
             max_len,
             &loaded.device,
+            &loaded.clip_device,
             loaded.dtype,
             guidance,
         )?;
@@ -996,6 +1026,15 @@ impl InferenceEngine for SD15Engine {
             video: None,
             gpu: None,
         })
+    }
+}
+
+impl InferenceEngine for SD15Engine {
+    fn generate(&mut self, req: &GenerateRequest) -> Result<GenerateResponse> {
+        self.pending_placement = req.placement.clone();
+        let result = self.generate_inner(req);
+        self.pending_placement = None;
+        result
     }
 
     fn model_name(&self) -> &str {

--- a/crates/mold-inference/src/sd3/pipeline.rs
+++ b/crates/mold-inference/src/sd3/pipeline.rs
@@ -325,11 +325,13 @@ impl SD3Engine {
             .as_ref()
             .map(|p| p.text_encoders)
             .unwrap_or_default();
-        let auto_encoder_device = if t5_on_gpu { device.clone() } else { Device::Cpu };
-        let encoder_device_owned = crate::device::resolve_device(
-            Some(tier1),
-            || Ok(auto_encoder_device.clone()),
-        )?;
+        let auto_encoder_device = if t5_on_gpu {
+            device.clone()
+        } else {
+            Device::Cpu
+        };
+        let encoder_device_owned =
+            crate::device::resolve_device(Some(tier1), || Ok(auto_encoder_device.clone()))?;
         let encoder_device = &encoder_device_owned;
         let t5_on_gpu = !encoder_device.is_cpu();
         let t5_device_label = if t5_on_gpu { "GPU" } else { "CPU" };
@@ -455,11 +457,13 @@ impl SD3Engine {
                 .as_ref()
                 .map(|p| p.text_encoders)
                 .unwrap_or_default();
-            let auto_encoder_device = if t5_on_gpu { device.clone() } else { Device::Cpu };
-            let encoder_device_owned = crate::device::resolve_device(
-                Some(tier1),
-                || Ok(auto_encoder_device.clone()),
-            )?;
+            let auto_encoder_device = if t5_on_gpu {
+                device.clone()
+            } else {
+                Device::Cpu
+            };
+            let encoder_device_owned =
+                crate::device::resolve_device(Some(tier1), || Ok(auto_encoder_device.clone()))?;
             let encoder_device = &encoder_device_owned;
             let t5_on_gpu = !encoder_device.is_cpu();
             let t5_device_label = if t5_on_gpu { "GPU" } else { "CPU" };

--- a/crates/mold-inference/src/sd3/pipeline.rs
+++ b/crates/mold-inference/src/sd3/pipeline.rs
@@ -49,6 +49,7 @@ pub struct SD3Engine {
     is_medium: bool,
     t5_variant: Option<String>,
     prompt_cache: Mutex<LruCache<String, CachedTensorPair>>,
+    pending_placement: Option<mold_core::types::DevicePlacement>,
 }
 
 impl SD3Engine {
@@ -68,6 +69,7 @@ impl SD3Engine {
             is_medium,
             t5_variant,
             prompt_cache: Mutex::new(LruCache::new(DEFAULT_PROMPT_CACHE_CAPACITY)),
+            pending_placement: None,
         }
     }
 
@@ -305,7 +307,7 @@ impl SD3Engine {
         self.base.progress.stage_start("Selecting T5 encoder");
         let t5_resolve_start = Instant::now();
         let t5_preference = self.t5_variant.as_deref();
-        let (resolved_t5_path, t5_on_gpu, t5_device_label) =
+        let (resolved_t5_path, t5_on_gpu, _t5_auto_device_label) =
             crate::encoders::variant_resolution::resolve_t5_variant(
                 &self.base.progress,
                 t5_preference,
@@ -317,7 +319,20 @@ impl SD3Engine {
             .progress
             .stage_done("Selecting T5 encoder", t5_resolve_start.elapsed());
 
-        let encoder_device = if t5_on_gpu { &device } else { &Device::Cpu };
+        // Tier 1: honor `placement.text_encoders` — all three encoders share the knob.
+        let tier1 = self
+            .pending_placement
+            .as_ref()
+            .map(|p| p.text_encoders)
+            .unwrap_or_default();
+        let auto_encoder_device = if t5_on_gpu { device.clone() } else { Device::Cpu };
+        let encoder_device_owned = crate::device::resolve_device(
+            Some(tier1),
+            || Ok(auto_encoder_device.clone()),
+        )?;
+        let encoder_device = &encoder_device_owned;
+        let t5_on_gpu = !encoder_device.is_cpu();
+        let t5_device_label = if t5_on_gpu { "GPU" } else { "CPU" };
         let encoder_dtype = if t5_on_gpu { gpu_dtype } else { DType::F32 };
 
         let encoder_label = format!("Loading SD3 triple encoder ({t5_device_label})");
@@ -423,7 +438,7 @@ impl SD3Engine {
             self.base.progress.stage_start("Selecting T5 encoder");
             let t5_resolve_start = Instant::now();
             let t5_preference = self.t5_variant.as_deref();
-            let (resolved_t5_path, t5_on_gpu, t5_device_label) =
+            let (resolved_t5_path, t5_on_gpu, _t5_auto_device_label) =
                 crate::encoders::variant_resolution::resolve_t5_variant(
                     &self.base.progress,
                     t5_preference,
@@ -435,7 +450,19 @@ impl SD3Engine {
                 .progress
                 .stage_done("Selecting T5 encoder", t5_resolve_start.elapsed());
 
-            let encoder_device = if t5_on_gpu { &device } else { &Device::Cpu };
+            let tier1 = self
+                .pending_placement
+                .as_ref()
+                .map(|p| p.text_encoders)
+                .unwrap_or_default();
+            let auto_encoder_device = if t5_on_gpu { device.clone() } else { Device::Cpu };
+            let encoder_device_owned = crate::device::resolve_device(
+                Some(tier1),
+                || Ok(auto_encoder_device.clone()),
+            )?;
+            let encoder_device = &encoder_device_owned;
+            let t5_on_gpu = !encoder_device.is_cpu();
+            let t5_device_label = if t5_on_gpu { "GPU" } else { "CPU" };
             let encoder_dtype = if t5_on_gpu { gpu_dtype } else { DType::F32 };
 
             let t5_size = std::fs::metadata(&resolved_t5_path)
@@ -718,8 +745,8 @@ impl SD3Engine {
     }
 }
 
-impl InferenceEngine for SD3Engine {
-    fn generate(&mut self, req: &GenerateRequest) -> Result<GenerateResponse> {
+impl SD3Engine {
+    fn generate_inner(&mut self, req: &GenerateRequest) -> Result<GenerateResponse> {
         if req.scheduler.is_some() {
             tracing::warn!("scheduler selection not supported for SD3 (flow-matching), ignoring");
         }
@@ -997,6 +1024,15 @@ impl InferenceEngine for SD3Engine {
                 gpu: None,
             })
         })()
+    }
+}
+
+impl InferenceEngine for SD3Engine {
+    fn generate(&mut self, req: &GenerateRequest) -> Result<GenerateResponse> {
+        self.pending_placement = req.placement.clone();
+        let result = self.generate_inner(req);
+        self.pending_placement = None;
+        result
     }
 
     fn model_name(&self) -> &str {

--- a/crates/mold-inference/src/sdxl/pipeline.rs
+++ b/crates/mold-inference/src/sdxl/pipeline.rs
@@ -28,6 +28,8 @@ struct LoadedSDXL {
     tokenizer_g: tokenizers::Tokenizer,
     sd_config: stable_diffusion::StableDiffusionConfig,
     device: Device,
+    /// Device the CLIP-L / CLIP-G weights live on (shared — Tier 1 groups them).
+    clip_device: Device,
     dtype: DType,
 }
 
@@ -39,6 +41,7 @@ pub struct SDXLEngine {
     prompt_cache: Mutex<LruCache<PromptCacheKey, CachedTensor>>,
     source_latent_cache: Mutex<LruCache<ImageSizeCacheKey, CachedTensor>>,
     mask_cache: Mutex<LruCache<LatentSizeCacheKey, CachedTensor>>,
+    pending_placement: Option<mold_core::types::DevicePlacement>,
 }
 
 /// VAE scaling factor for standard SDXL models.
@@ -62,6 +65,7 @@ impl SDXLEngine {
             prompt_cache: Mutex::new(LruCache::new(DEFAULT_PROMPT_CACHE_CAPACITY)),
             source_latent_cache: Mutex::new(LruCache::new(DEFAULT_IMAGE_CACHE_CAPACITY)),
             mask_cache: Mutex::new(LruCache::new(DEFAULT_IMAGE_CACHE_CAPACITY)),
+            pending_placement: None,
         }
     }
 
@@ -212,13 +216,24 @@ impl SDXLEngine {
             .progress
             .stage_done("Loading VAE (GPU)", vae_start.elapsed());
 
+        // Tier 1: honor `placement.text_encoders` for both CLIPs as a group.
+        let tier1 = self
+            .pending_placement
+            .as_ref()
+            .map(|p| p.text_encoders)
+            .unwrap_or_default();
+        let clip_device = crate::device::resolve_device(
+            Some(tier1),
+            || Ok(device.clone()),
+        )?;
+
         // Load CLIP-L encoder
         self.base.progress.stage_start("Loading CLIP-L encoder");
         let clip_l_start = Instant::now();
         let clip_l = stable_diffusion::build_clip_transformer(
             &sd_config.clip,
             &clip_encoder,
-            &device,
+            &clip_device,
             DType::F32,
         )?;
         self.base
@@ -235,7 +250,7 @@ impl SDXLEngine {
         let clip_g = stable_diffusion::build_clip_transformer(
             clip2_config,
             &clip_encoder_2,
-            &device,
+            &clip_device,
             DType::F32,
         )?;
         self.base
@@ -257,6 +272,7 @@ impl SDXLEngine {
             tokenizer_g,
             sd_config,
             device,
+            clip_device,
             dtype,
         });
 
@@ -453,6 +469,7 @@ impl SDXLEngine {
         negative_prompt: &str,
         max_len: usize,
         device: &Device,
+        clip_device: &Device,
         dtype: DType,
         guidance: f64,
     ) -> Result<Tensor> {
@@ -463,7 +480,7 @@ impl SDXLEngine {
 
                 self.base.progress.stage_start("Encoding prompt (CLIP-L)");
                 let encode_l_start = Instant::now();
-                let tokens_l = Self::tokenize(tokenizer_l, prompt, max_len, device)?;
+                let tokens_l = Self::tokenize(tokenizer_l, prompt, max_len, clip_device)?;
                 let text_emb_l = clip_l.forward(&tokens_l)?;
                 self.base
                     .progress
@@ -471,7 +488,7 @@ impl SDXLEngine {
 
                 self.base.progress.stage_start("Encoding prompt (CLIP-G)");
                 let encode_g_start = Instant::now();
-                let tokens_g = Self::tokenize(tokenizer_g, prompt, max_len, device)?;
+                let tokens_g = Self::tokenize(tokenizer_g, prompt, max_len, clip_device)?;
                 let text_emb_g = clip_g.forward(&tokens_g)?;
                 self.base
                     .progress
@@ -481,10 +498,10 @@ impl SDXLEngine {
 
                 let text_embeddings = if use_cfg {
                     let uncond_tokens_l =
-                        Self::tokenize(tokenizer_l, negative_prompt, max_len, device)?;
+                        Self::tokenize(tokenizer_l, negative_prompt, max_len, clip_device)?;
                     let uncond_emb_l = clip_l.forward(&uncond_tokens_l)?;
                     let uncond_tokens_g =
-                        Self::tokenize(tokenizer_g, negative_prompt, max_len, device)?;
+                        Self::tokenize(tokenizer_g, negative_prompt, max_len, clip_device)?;
                     let uncond_emb_g = clip_g.forward(&uncond_tokens_g)?;
                     let uncond_embeddings =
                         Tensor::cat(&[&uncond_emb_l, &uncond_emb_g], D::Minus1)?;
@@ -493,6 +510,7 @@ impl SDXLEngine {
                     text_embeddings
                 };
 
+                let text_embeddings = text_embeddings.to_device(device)?;
                 Ok(text_embeddings.to_dtype(dtype)?)
             })?;
         if cache_hit {
@@ -585,12 +603,22 @@ impl SDXLEngine {
             let tokenizer_g = tokenizers::Tokenizer::from_file(&clip_tokenizer_2)
                 .map_err(|e| anyhow::anyhow!("failed to load CLIP-G tokenizer: {e}"))?;
 
+            let tier1 = self
+                .pending_placement
+                .as_ref()
+                .map(|p| p.text_encoders)
+                .unwrap_or_default();
+            let clip_device = crate::device::resolve_device(
+                Some(tier1),
+                || Ok(device.clone()),
+            )?;
+
             self.base.progress.stage_start("Loading CLIP-L encoder");
             let clip_l_start = Instant::now();
             let clip_l = stable_diffusion::build_clip_transformer(
                 &sd_config.clip,
                 &clip_encoder,
-                &device,
+                &clip_device,
                 DType::F32,
             )?;
             self.base
@@ -606,7 +634,7 @@ impl SDXLEngine {
             let clip_g = stable_diffusion::build_clip_transformer(
                 clip2_config,
                 &clip_encoder_2,
-                &device,
+                &clip_device,
                 DType::F32,
             )?;
             self.base
@@ -622,6 +650,7 @@ impl SDXLEngine {
                 neg,
                 max_len,
                 &device,
+                &clip_device,
                 dtype,
                 guidance,
             )?;
@@ -802,8 +831,8 @@ impl SDXLEngine {
     }
 }
 
-impl InferenceEngine for SDXLEngine {
-    fn generate(&mut self, req: &GenerateRequest) -> Result<GenerateResponse> {
+impl SDXLEngine {
+    fn generate_inner(&mut self, req: &GenerateRequest) -> Result<GenerateResponse> {
         // Sequential mode: load-use-drop each component
         if self.base.load_strategy == LoadStrategy::Sequential {
             return self.generate_sequential(req);
@@ -846,6 +875,7 @@ impl InferenceEngine for SDXLEngine {
             neg,
             max_len,
             &loaded.device,
+            &loaded.clip_device,
             loaded.dtype,
             guidance,
         )?;
@@ -978,6 +1008,15 @@ impl InferenceEngine for SDXLEngine {
             video: None,
             gpu: None,
         })
+    }
+}
+
+impl InferenceEngine for SDXLEngine {
+    fn generate(&mut self, req: &GenerateRequest) -> Result<GenerateResponse> {
+        self.pending_placement = req.placement.clone();
+        let result = self.generate_inner(req);
+        self.pending_placement = None;
+        result
     }
 
     fn model_name(&self) -> &str {

--- a/crates/mold-inference/src/sdxl/pipeline.rs
+++ b/crates/mold-inference/src/sdxl/pipeline.rs
@@ -222,10 +222,7 @@ impl SDXLEngine {
             .as_ref()
             .map(|p| p.text_encoders)
             .unwrap_or_default();
-        let clip_device = crate::device::resolve_device(
-            Some(tier1),
-            || Ok(device.clone()),
-        )?;
+        let clip_device = crate::device::resolve_device(Some(tier1), || Ok(device.clone()))?;
 
         // Load CLIP-L encoder
         self.base.progress.stage_start("Loading CLIP-L encoder");
@@ -608,10 +605,7 @@ impl SDXLEngine {
                 .as_ref()
                 .map(|p| p.text_encoders)
                 .unwrap_or_default();
-            let clip_device = crate::device::resolve_device(
-                Some(tier1),
-                || Ok(device.clone()),
-            )?;
+            let clip_device = crate::device::resolve_device(Some(tier1), || Ok(device.clone()))?;
 
             self.base.progress.stage_start("Loading CLIP-L encoder");
             let clip_l_start = Instant::now();

--- a/crates/mold-inference/src/wuerstchen/pipeline.rs
+++ b/crates/mold-inference/src/wuerstchen/pipeline.rs
@@ -59,6 +59,7 @@ struct LoadedWuerstchen {
     prior_tokenizer: tokenizers::Tokenizer,
     decoder_tokenizer: tokenizers::Tokenizer,
     device: Device,
+    clip_device: Device,
     dtype: DType,
 }
 
@@ -68,6 +69,7 @@ struct LoadedWuerstchen {
 pub struct WuerstchenEngine {
     base: EngineBase<LoadedWuerstchen>,
     prompt_cache: Mutex<LruCache<String, CachedTensorPair>>,
+    pending_placement: Option<mold_core::types::DevicePlacement>,
 }
 
 impl WuerstchenEngine {
@@ -206,6 +208,7 @@ impl WuerstchenEngine {
         Self {
             base: EngineBase::new(model_name, paths, load_strategy, gpu_ordinal),
             prompt_cache: Mutex::new(LruCache::new(DEFAULT_PROMPT_CACHE_CAPACITY)),
+            pending_placement: None,
         }
     }
 
@@ -219,6 +222,7 @@ impl WuerstchenEngine {
         prompt: &str,
         negative_prompt: &str,
         device: &Device,
+        clip_device: &Device,
         dtype: DType,
         prior_guidance: f64,
         decoder_guidance: f64,
@@ -240,7 +244,7 @@ impl WuerstchenEngine {
                     prior_tokenizer,
                     &prior_clip_config,
                     prompt,
-                    device,
+                    clip_device,
                     dtype,
                 )?;
                 let prior_text_embeddings = if use_prior_cfg {
@@ -249,7 +253,7 @@ impl WuerstchenEngine {
                         prior_tokenizer,
                         &prior_clip_config,
                         negative_prompt,
-                        device,
+                        clip_device,
                         dtype,
                     )?;
                     Tensor::cat(&[&prior_text_embeddings, &prior_negative_embeddings], 0)?
@@ -270,7 +274,7 @@ impl WuerstchenEngine {
                     decoder_tokenizer,
                     &dec_clip_config,
                     prompt,
-                    device,
+                    clip_device,
                     dtype,
                 )?;
                 let decoder_text_embeddings = if use_decoder_cfg {
@@ -279,7 +283,7 @@ impl WuerstchenEngine {
                         decoder_tokenizer,
                         &dec_clip_config,
                         negative_prompt,
-                        device,
+                        clip_device,
                         dtype,
                     )?;
                     Tensor::cat(&[&decoder_text_embeddings, &decoder_negative_embeddings], 0)?
@@ -290,6 +294,8 @@ impl WuerstchenEngine {
                     "Encoding prompt (Decoder CLIP, 1024-dim)",
                     dec_encode_start.elapsed(),
                 );
+                let prior_text_embeddings = prior_text_embeddings.to_device(device)?;
+                let decoder_text_embeddings = decoder_text_embeddings.to_device(device)?;
                 Ok((prior_text_embeddings, decoder_text_embeddings))
             })?;
         if cache_hit {
@@ -531,6 +537,17 @@ impl WuerstchenEngine {
             .progress
             .stage_done("Loading VQ-GAN (Stage A)", vqgan_start.elapsed());
 
+        // Tier 1: honor `placement.text_encoders` (both CLIPs as a group).
+        let tier1 = self
+            .pending_placement
+            .as_ref()
+            .map(|p| p.text_encoders)
+            .unwrap_or_default();
+        let clip_device = crate::device::resolve_device(
+            Some(tier1),
+            || Ok(device.clone()),
+        )?;
+
         // Load Prior CLIP-G encoder (1280-dim, 32 layers)
         self.base
             .progress
@@ -540,7 +557,7 @@ impl WuerstchenEngine {
         let prior_clip = stable_diffusion::build_clip_transformer(
             &prior_clip_config,
             &prior_clip_path,
-            &device,
+            &clip_device,
             DType::F32,
         )?;
         self.base.progress.stage_done(
@@ -557,7 +574,7 @@ impl WuerstchenEngine {
         let decoder_clip = stable_diffusion::build_clip_transformer(
             &dec_clip_config,
             &dec_clip_path,
-            &device,
+            &clip_device,
             DType::F32,
         )?;
         self.base.progress.stage_done(
@@ -580,6 +597,7 @@ impl WuerstchenEngine {
             prior_tokenizer,
             decoder_tokenizer,
             device,
+            clip_device,
             dtype,
         });
 
@@ -890,6 +908,16 @@ impl WuerstchenEngine {
                 let prior_tokenizer = tokenizers::Tokenizer::from_file(&prior_clip_tok_path)
                     .map_err(|e| anyhow::anyhow!("failed to load Prior CLIP-G tokenizer: {e}"))?;
 
+                let tier1 = self
+                    .pending_placement
+                    .as_ref()
+                    .map(|p| p.text_encoders)
+                    .unwrap_or_default();
+                let clip_device = crate::device::resolve_device(
+                    Some(tier1),
+                    || Ok(device.clone()),
+                )?;
+
                 self.base
                     .progress
                     .stage_start("Loading Prior CLIP-G encoder (1280-dim)");
@@ -898,7 +926,7 @@ impl WuerstchenEngine {
                 let prior_clip = stable_diffusion::build_clip_transformer(
                     &prior_clip_config,
                     &prior_clip_path,
-                    &device,
+                    &clip_device,
                     DType::F32,
                 )?;
                 self.base.progress.stage_done(
@@ -917,7 +945,7 @@ impl WuerstchenEngine {
                 let decoder_clip = stable_diffusion::build_clip_transformer(
                     &dec_clip_config,
                     &dec_clip_path,
-                    &device,
+                    &clip_device,
                     DType::F32,
                 )?;
                 self.base.progress.stage_done(
@@ -933,6 +961,7 @@ impl WuerstchenEngine {
                     &req.prompt,
                     negative_prompt,
                     &device,
+                    &clip_device,
                     dtype,
                     prior_guidance,
                     decoder_guidance,
@@ -1217,8 +1246,8 @@ impl WuerstchenEngine {
     }
 }
 
-impl InferenceEngine for WuerstchenEngine {
-    fn generate(&mut self, req: &GenerateRequest) -> Result<GenerateResponse> {
+impl WuerstchenEngine {
+    fn generate_inner(&mut self, req: &GenerateRequest) -> Result<GenerateResponse> {
         if req.scheduler.is_some() {
             tracing::warn!("scheduler selection not supported for Wuerstchen, ignoring");
         }
@@ -1265,6 +1294,7 @@ impl InferenceEngine for WuerstchenEngine {
             &req.prompt,
             negative_prompt,
             &loaded.device,
+            &loaded.clip_device,
             loaded.dtype,
             prior_guidance,
             decoder_guidance,
@@ -1437,6 +1467,15 @@ impl InferenceEngine for WuerstchenEngine {
             video: None,
             gpu: None,
         })
+    }
+}
+
+impl InferenceEngine for WuerstchenEngine {
+    fn generate(&mut self, req: &GenerateRequest) -> Result<GenerateResponse> {
+        self.pending_placement = req.placement.clone();
+        let result = self.generate_inner(req);
+        self.pending_placement = None;
+        result
     }
 
     fn model_name(&self) -> &str {

--- a/crates/mold-inference/src/wuerstchen/pipeline.rs
+++ b/crates/mold-inference/src/wuerstchen/pipeline.rs
@@ -543,10 +543,7 @@ impl WuerstchenEngine {
             .as_ref()
             .map(|p| p.text_encoders)
             .unwrap_or_default();
-        let clip_device = crate::device::resolve_device(
-            Some(tier1),
-            || Ok(device.clone()),
-        )?;
+        let clip_device = crate::device::resolve_device(Some(tier1), || Ok(device.clone()))?;
 
         // Load Prior CLIP-G encoder (1280-dim, 32 layers)
         self.base
@@ -913,10 +910,8 @@ impl WuerstchenEngine {
                     .as_ref()
                     .map(|p| p.text_encoders)
                     .unwrap_or_default();
-                let clip_device = crate::device::resolve_device(
-                    Some(tier1),
-                    || Ok(device.clone()),
-                )?;
+                let clip_device =
+                    crate::device::resolve_device(Some(tier1), || Ok(device.clone()))?;
 
                 self.base
                     .progress

--- a/crates/mold-inference/src/zimage/pipeline.rs
+++ b/crates/mold-inference/src/zimage/pipeline.rs
@@ -126,6 +126,8 @@ pub struct ZImageEngine {
     /// Qwen3 variant preference: None/"auto" = VRAM-based, "bf16" = force BF16, "q8"/etc = specific.
     qwen3_variant: Option<String>,
     prompt_cache: Mutex<LruCache<String, CachedTensor>>,
+    /// Per-request placement override.
+    pending_placement: Option<mold_core::types::DevicePlacement>,
 }
 
 impl ZImageEngine {
@@ -140,6 +142,7 @@ impl ZImageEngine {
             base: EngineBase::new(model_name, paths, load_strategy, gpu_ordinal),
             qwen3_variant,
             prompt_cache: Mutex::new(LruCache::new(DEFAULT_PROMPT_CACHE_CAPACITY)),
+            pending_placement: None,
         }
     }
 
@@ -346,7 +349,7 @@ impl ZImageEngine {
         self.base.progress.stage_start("Selecting Qwen3 encoder");
         let qwen3_resolve_start = Instant::now();
         let qwen3_preference = self.qwen3_variant.as_deref();
-        let (resolved_paths, is_qwen3_gguf, te_on_gpu, te_device_label) = {
+        let (resolved_paths, is_qwen3_gguf, te_on_gpu, _te_auto_device_label) = {
             let bf16_paths = self.base.paths.text_encoder_files.clone();
             let have_bf16 = !bf16_paths.is_empty() && bf16_paths.iter().all(|p| p.exists());
             crate::encoders::variant_resolution::resolve_qwen3_variant(
@@ -364,11 +367,22 @@ impl ZImageEngine {
             .progress
             .stage_done("Selecting Qwen3 encoder", qwen3_resolve_start.elapsed());
 
-        let te_device = if te_on_gpu {
+        let tier1 = self
+            .pending_placement
+            .as_ref()
+            .map(|p| p.text_encoders)
+            .unwrap_or_default();
+        let auto_te_device = if te_on_gpu {
             device.clone()
         } else {
             Device::Cpu
         };
+        let te_device = crate::device::resolve_device(
+            Some(tier1),
+            || Ok(auto_te_device.clone()),
+        )?;
+        let te_on_gpu = !te_device.is_cpu();
+        let te_device_label = if te_on_gpu { "GPU" } else { "CPU" };
         let te_dtype = if te_on_gpu { dtype } else { DType::F32 };
 
         // Load text encoder
@@ -482,7 +496,7 @@ impl ZImageEngine {
             self.base.progress.stage_start("Selecting Qwen3 encoder");
             let qwen3_resolve_start = Instant::now();
             let qwen3_preference = self.qwen3_variant.as_deref();
-            let (resolved_paths, is_qwen3_gguf, te_on_gpu, te_device_label) = {
+            let (resolved_paths, is_qwen3_gguf, te_on_gpu, _te_auto_device_label) = {
                 let bf16_paths = self.base.paths.text_encoder_files.clone();
                 let have_bf16 = !bf16_paths.is_empty() && bf16_paths.iter().all(|p| p.exists());
                 crate::encoders::variant_resolution::resolve_qwen3_variant(
@@ -500,11 +514,22 @@ impl ZImageEngine {
                 .progress
                 .stage_done("Selecting Qwen3 encoder", qwen3_resolve_start.elapsed());
 
-            let te_device = if te_on_gpu {
+            let tier1 = self
+                .pending_placement
+                .as_ref()
+                .map(|p| p.text_encoders)
+                .unwrap_or_default();
+            let auto_te_device = if te_on_gpu {
                 device.clone()
             } else {
                 Device::Cpu
             };
+            let te_device = crate::device::resolve_device(
+                Some(tier1),
+                || Ok(auto_te_device.clone()),
+            )?;
+            let te_on_gpu = !te_device.is_cpu();
+            let te_device_label = if te_on_gpu { "GPU" } else { "CPU" };
             let te_dtype = if te_on_gpu { dtype } else { DType::F32 };
 
             let bf16_cfg = encoders::qwen3_bf16::Qwen3BF16Config::qwen3_4b();
@@ -840,8 +865,8 @@ impl ZImageEngine {
     }
 }
 
-impl InferenceEngine for ZImageEngine {
-    fn generate(&mut self, req: &GenerateRequest) -> Result<GenerateResponse> {
+impl ZImageEngine {
+    fn generate_inner(&mut self, req: &GenerateRequest) -> Result<GenerateResponse> {
         if req.scheduler.is_some() {
             tracing::warn!(
                 "scheduler selection not supported for Z-Image (flow-matching), ignoring"
@@ -1204,6 +1229,15 @@ impl InferenceEngine for ZImageEngine {
             video: None,
             gpu: None,
         })
+    }
+}
+
+impl InferenceEngine for ZImageEngine {
+    fn generate(&mut self, req: &GenerateRequest) -> Result<GenerateResponse> {
+        self.pending_placement = req.placement.clone();
+        let result = self.generate_inner(req);
+        self.pending_placement = None;
+        result
     }
 
     fn model_name(&self) -> &str {

--- a/crates/mold-inference/src/zimage/pipeline.rs
+++ b/crates/mold-inference/src/zimage/pipeline.rs
@@ -120,6 +120,29 @@ struct LoadedZImage {
     vae_path: std::path::PathBuf,
 }
 
+/// Resolve a component override given Tier 1 plus Tier 2 requests.
+fn effective_device_ref(
+    placement: Option<&mold_core::types::DevicePlacement>,
+    advanced_override: impl FnOnce(&mold_core::types::AdvancedPlacement) -> Option<mold_core::types::DeviceRef>,
+    fallback_is_component_auto: bool,
+) -> mold_core::types::DeviceRef {
+    use mold_core::types::DeviceRef;
+    let Some(placement) = placement else {
+        return DeviceRef::Auto;
+    };
+    if let Some(adv) = placement.advanced.as_ref() {
+        if let Some(r) = advanced_override(adv) {
+            return r;
+        }
+        if fallback_is_component_auto {
+            return placement.text_encoders;
+        }
+        DeviceRef::Auto
+    } else {
+        placement.text_encoders
+    }
+}
+
 /// Z-Image inference engine backed by candle's z_image module.
 pub struct ZImageEngine {
     base: EngineBase<LoadedZImage>,
@@ -281,7 +304,15 @@ impl ZImageEngine {
         let is_gguf = self.detect_is_gguf();
         let text_tokenizer_path = self.validate_paths()?;
 
-        let device = crate::device::create_device(self.base.gpu_ordinal, &self.base.progress)?;
+        let transformer_ref = effective_device_ref(
+            self.pending_placement.as_ref(),
+            |adv| Some(adv.transformer),
+            false,
+        );
+        let device = crate::device::resolve_device(
+            Some(transformer_ref),
+            || crate::device::create_device(self.base.gpu_ordinal, &self.base.progress),
+        )?;
         let dtype = crate::engine::gpu_dtype(&device);
         let transformer_cfg = Config::z_image_turbo();
 
@@ -319,11 +350,16 @@ impl ZImageEngine {
         // VAE decode at 1024x1024 needs ~6GB workspace for conv2d im2col.
         // On tight VRAM, load VAE on CPU to guarantee decode succeeds.
         let vae_on_gpu = should_use_gpu(is_cuda, is_metal, free, VAE_DECODE_VRAM_THRESHOLD);
-        let vae_device = if vae_on_gpu {
-            device.clone()
-        } else {
-            Device::Cpu
-        };
+        let vae_ref = effective_device_ref(
+            self.pending_placement.as_ref(),
+            |adv| Some(adv.vae),
+            false,
+        );
+        let vae_device = crate::device::resolve_device(
+            Some(vae_ref),
+            || Ok(if vae_on_gpu { device.clone() } else { Device::Cpu }),
+        )?;
+        let vae_on_gpu = !vae_device.is_cpu();
         let vae_dtype = if vae_on_gpu { dtype } else { DType::F32 };
         let vae_device_label = if vae_on_gpu { "GPU" } else { "CPU" };
 
@@ -367,18 +403,18 @@ impl ZImageEngine {
             .progress
             .stage_done("Selecting Qwen3 encoder", qwen3_resolve_start.elapsed());
 
-        let tier1 = self
-            .pending_placement
-            .as_ref()
-            .map(|p| p.text_encoders)
-            .unwrap_or_default();
+        let qwen3_ref = effective_device_ref(
+            self.pending_placement.as_ref(),
+            |adv| adv.qwen,
+            true,
+        );
         let auto_te_device = if te_on_gpu {
             device.clone()
         } else {
             Device::Cpu
         };
         let te_device = crate::device::resolve_device(
-            Some(tier1),
+            Some(qwen3_ref),
             || Ok(auto_te_device.clone()),
         )?;
         let te_on_gpu = !te_device.is_cpu();
@@ -462,7 +498,15 @@ impl ZImageEngine {
             self.base.progress.info(&warning);
         }
 
-        let device = crate::device::create_device(self.base.gpu_ordinal, &self.base.progress)?;
+        let transformer_ref = effective_device_ref(
+            self.pending_placement.as_ref(),
+            |adv| Some(adv.transformer),
+            false,
+        );
+        let device = crate::device::resolve_device(
+            Some(transformer_ref),
+            || crate::device::create_device(self.base.gpu_ordinal, &self.base.progress),
+        )?;
         let dtype = crate::engine::gpu_dtype(&device);
 
         let start = Instant::now();
@@ -514,18 +558,18 @@ impl ZImageEngine {
                 .progress
                 .stage_done("Selecting Qwen3 encoder", qwen3_resolve_start.elapsed());
 
-            let tier1 = self
-                .pending_placement
-                .as_ref()
-                .map(|p| p.text_encoders)
-                .unwrap_or_default();
+            let qwen3_ref = effective_device_ref(
+                self.pending_placement.as_ref(),
+                |adv| adv.qwen,
+                true,
+            );
             let auto_te_device = if te_on_gpu {
                 device.clone()
             } else {
                 Device::Cpu
             };
             let te_device = crate::device::resolve_device(
-                Some(tier1),
+                Some(qwen3_ref),
                 || Ok(auto_te_device.clone()),
             )?;
             let te_on_gpu = !te_device.is_cpu();
@@ -800,11 +844,16 @@ impl ZImageEngine {
             free_for_vae,
             VAE_DECODE_VRAM_THRESHOLD,
         );
-        let vae_device = if vae_on_gpu {
-            device.clone()
-        } else {
-            Device::Cpu
-        };
+        let vae_ref = effective_device_ref(
+            self.pending_placement.as_ref(),
+            |adv| Some(adv.vae),
+            false,
+        );
+        let vae_device = crate::device::resolve_device(
+            Some(vae_ref),
+            || Ok(if vae_on_gpu { device.clone() } else { Device::Cpu }),
+        )?;
+        let vae_on_gpu = !vae_device.is_cpu();
         let vae_dtype = if vae_on_gpu { dtype } else { DType::F32 };
         let vae_device_label = if vae_on_gpu { "GPU" } else { "CPU" };
 

--- a/crates/mold-inference/src/zimage/pipeline.rs
+++ b/crates/mold-inference/src/zimage/pipeline.rs
@@ -123,7 +123,9 @@ struct LoadedZImage {
 /// Resolve a component override given Tier 1 plus Tier 2 requests.
 fn effective_device_ref(
     placement: Option<&mold_core::types::DevicePlacement>,
-    advanced_override: impl FnOnce(&mold_core::types::AdvancedPlacement) -> Option<mold_core::types::DeviceRef>,
+    advanced_override: impl FnOnce(
+        &mold_core::types::AdvancedPlacement,
+    ) -> Option<mold_core::types::DeviceRef>,
     fallback_is_component_auto: bool,
 ) -> mold_core::types::DeviceRef {
     use mold_core::types::DeviceRef;
@@ -309,10 +311,9 @@ impl ZImageEngine {
             |adv| Some(adv.transformer),
             false,
         );
-        let device = crate::device::resolve_device(
-            Some(transformer_ref),
-            || crate::device::create_device(self.base.gpu_ordinal, &self.base.progress),
-        )?;
+        let device = crate::device::resolve_device(Some(transformer_ref), || {
+            crate::device::create_device(self.base.gpu_ordinal, &self.base.progress)
+        })?;
         let dtype = crate::engine::gpu_dtype(&device);
         let transformer_cfg = Config::z_image_turbo();
 
@@ -350,15 +351,15 @@ impl ZImageEngine {
         // VAE decode at 1024x1024 needs ~6GB workspace for conv2d im2col.
         // On tight VRAM, load VAE on CPU to guarantee decode succeeds.
         let vae_on_gpu = should_use_gpu(is_cuda, is_metal, free, VAE_DECODE_VRAM_THRESHOLD);
-        let vae_ref = effective_device_ref(
-            self.pending_placement.as_ref(),
-            |adv| Some(adv.vae),
-            false,
-        );
-        let vae_device = crate::device::resolve_device(
-            Some(vae_ref),
-            || Ok(if vae_on_gpu { device.clone() } else { Device::Cpu }),
-        )?;
+        let vae_ref =
+            effective_device_ref(self.pending_placement.as_ref(), |adv| Some(adv.vae), false);
+        let vae_device = crate::device::resolve_device(Some(vae_ref), || {
+            Ok(if vae_on_gpu {
+                device.clone()
+            } else {
+                Device::Cpu
+            })
+        })?;
         let vae_on_gpu = !vae_device.is_cpu();
         let vae_dtype = if vae_on_gpu { dtype } else { DType::F32 };
         let vae_device_label = if vae_on_gpu { "GPU" } else { "CPU" };
@@ -403,20 +404,14 @@ impl ZImageEngine {
             .progress
             .stage_done("Selecting Qwen3 encoder", qwen3_resolve_start.elapsed());
 
-        let qwen3_ref = effective_device_ref(
-            self.pending_placement.as_ref(),
-            |adv| adv.qwen,
-            true,
-        );
+        let qwen3_ref = effective_device_ref(self.pending_placement.as_ref(), |adv| adv.qwen, true);
         let auto_te_device = if te_on_gpu {
             device.clone()
         } else {
             Device::Cpu
         };
-        let te_device = crate::device::resolve_device(
-            Some(qwen3_ref),
-            || Ok(auto_te_device.clone()),
-        )?;
+        let te_device =
+            crate::device::resolve_device(Some(qwen3_ref), || Ok(auto_te_device.clone()))?;
         let te_on_gpu = !te_device.is_cpu();
         let te_device_label = if te_on_gpu { "GPU" } else { "CPU" };
         let te_dtype = if te_on_gpu { dtype } else { DType::F32 };
@@ -503,10 +498,9 @@ impl ZImageEngine {
             |adv| Some(adv.transformer),
             false,
         );
-        let device = crate::device::resolve_device(
-            Some(transformer_ref),
-            || crate::device::create_device(self.base.gpu_ordinal, &self.base.progress),
-        )?;
+        let device = crate::device::resolve_device(Some(transformer_ref), || {
+            crate::device::create_device(self.base.gpu_ordinal, &self.base.progress)
+        })?;
         let dtype = crate::engine::gpu_dtype(&device);
 
         let start = Instant::now();
@@ -558,20 +552,15 @@ impl ZImageEngine {
                 .progress
                 .stage_done("Selecting Qwen3 encoder", qwen3_resolve_start.elapsed());
 
-            let qwen3_ref = effective_device_ref(
-                self.pending_placement.as_ref(),
-                |adv| adv.qwen,
-                true,
-            );
+            let qwen3_ref =
+                effective_device_ref(self.pending_placement.as_ref(), |adv| adv.qwen, true);
             let auto_te_device = if te_on_gpu {
                 device.clone()
             } else {
                 Device::Cpu
             };
-            let te_device = crate::device::resolve_device(
-                Some(qwen3_ref),
-                || Ok(auto_te_device.clone()),
-            )?;
+            let te_device =
+                crate::device::resolve_device(Some(qwen3_ref), || Ok(auto_te_device.clone()))?;
             let te_on_gpu = !te_device.is_cpu();
             let te_device_label = if te_on_gpu { "GPU" } else { "CPU" };
             let te_dtype = if te_on_gpu { dtype } else { DType::F32 };
@@ -844,15 +833,15 @@ impl ZImageEngine {
             free_for_vae,
             VAE_DECODE_VRAM_THRESHOLD,
         );
-        let vae_ref = effective_device_ref(
-            self.pending_placement.as_ref(),
-            |adv| Some(adv.vae),
-            false,
-        );
-        let vae_device = crate::device::resolve_device(
-            Some(vae_ref),
-            || Ok(if vae_on_gpu { device.clone() } else { Device::Cpu }),
-        )?;
+        let vae_ref =
+            effective_device_ref(self.pending_placement.as_ref(), |adv| Some(adv.vae), false);
+        let vae_device = crate::device::resolve_device(Some(vae_ref), || {
+            Ok(if vae_on_gpu {
+                device.clone()
+            } else {
+                Device::Cpu
+            })
+        })?;
         let vae_on_gpu = !vae_device.is_cpu();
         let vae_dtype = if vae_on_gpu { dtype } else { DType::F32 };
         let vae_device_label = if vae_on_gpu { "GPU" } else { "CPU" };

--- a/crates/mold-inference/src/zimage/pipeline.rs
+++ b/crates/mold-inference/src/zimage/pipeline.rs
@@ -16,8 +16,8 @@ use crate::cache::{
     LruCache, DEFAULT_PROMPT_CACHE_CAPACITY,
 };
 use crate::device::{
-    check_memory_budget, fmt_gb, free_vram_bytes, memory_status_string, preflight_memory_check,
-    should_use_gpu,
+    check_memory_budget, effective_device_ref, fmt_gb, free_vram_bytes, memory_status_string,
+    preflight_memory_check, should_use_gpu,
 };
 // Re-exported for tests (test harness is disabled via `test = false` in Cargo.toml,
 // but tests reference this constant via `super::*`).
@@ -118,31 +118,6 @@ struct LoadedZImage {
     is_gguf: bool,
     /// Path to the VAE safetensors file (needed for CPU fallback reload on OOM).
     vae_path: std::path::PathBuf,
-}
-
-/// Resolve a component override given Tier 1 plus Tier 2 requests.
-fn effective_device_ref(
-    placement: Option<&mold_core::types::DevicePlacement>,
-    advanced_override: impl FnOnce(
-        &mold_core::types::AdvancedPlacement,
-    ) -> Option<mold_core::types::DeviceRef>,
-    fallback_is_component_auto: bool,
-) -> mold_core::types::DeviceRef {
-    use mold_core::types::DeviceRef;
-    let Some(placement) = placement else {
-        return DeviceRef::Auto;
-    };
-    if let Some(adv) = placement.advanced.as_ref() {
-        if let Some(r) = advanced_override(adv) {
-            return r;
-        }
-        if fallback_is_component_auto {
-            return placement.text_encoders;
-        }
-        DeviceRef::Auto
-    } else {
-        placement.text_encoders
-    }
 }
 
 /// Z-Image inference engine backed by candle's z_image module.

--- a/crates/mold-inference/tests/device_resolve_test.rs
+++ b/crates/mold-inference/tests/device_resolve_test.rs
@@ -1,0 +1,48 @@
+//! Coverage for `mold_inference::device::resolve_device`. Runs as an
+//! integration test — keeps the test binary small and avoids pulling candle's
+//! full model-loading stack.
+
+use mold_core::types::DeviceRef;
+use mold_inference::device::resolve_device;
+
+fn cpu_auto() -> anyhow::Result<candle_core::Device> {
+    Ok(candle_core::Device::Cpu)
+}
+
+#[test]
+fn resolve_device_none_calls_auto() {
+    let dev = resolve_device(None, cpu_auto).unwrap();
+    assert!(matches!(dev, candle_core::Device::Cpu));
+}
+
+#[test]
+fn resolve_device_auto_calls_auto() {
+    let dev = resolve_device(Some(DeviceRef::Auto), cpu_auto).unwrap();
+    assert!(matches!(dev, candle_core::Device::Cpu));
+}
+
+#[test]
+fn resolve_device_cpu_bypasses_auto() {
+    let called = std::sync::atomic::AtomicBool::new(false);
+    let dev = resolve_device(Some(DeviceRef::Cpu), || {
+        called.store(true, std::sync::atomic::Ordering::SeqCst);
+        cpu_auto()
+    })
+    .unwrap();
+    assert!(matches!(dev, candle_core::Device::Cpu));
+    assert!(
+        !called.load(std::sync::atomic::Ordering::SeqCst),
+        "Cpu override must not invoke the auto closure"
+    );
+}
+
+#[test]
+#[cfg(not(any(feature = "cuda", feature = "metal")))]
+fn resolve_device_gpu_on_cpu_only_host_errors_clearly() {
+    let err = resolve_device(Some(DeviceRef::gpu(0)), cpu_auto).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("GPU") || msg.contains("cuda") || msg.contains("metal"),
+        "error should mention the missing backend, got: {msg}"
+    );
+}

--- a/crates/mold-server/src/queue.rs
+++ b/crates/mold-server/src/queue.rs
@@ -692,6 +692,7 @@ mod tests {
             retake_range: None,
             spatial_upscale: None,
             temporal_upscale: None,
+            placement: None,
         }
     }
 

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -2412,9 +2412,10 @@ async fn put_model_placement(
     {
         let mut cfg = state.config.write().await;
         cfg.set_model_placement(&name, Some(placement.clone()));
-        if let Err(e) = cfg.save() {
+        cfg.save().map_err(|e| {
             tracing::warn!("failed to persist placement to config.toml: {e}");
-        }
+            ApiError::internal(format!("failed to persist placement to config.toml: {e}"))
+        })?;
     }
     Ok(Json(serde_json::json!({
         "ok": true,
@@ -2428,7 +2429,12 @@ async fn delete_model_placement(
 ) -> Result<Json<serde_json::Value>, ApiError> {
     let mut cfg = state.config.write().await;
     cfg.set_model_placement(&name, None);
-    let _ = cfg.save();
+    cfg.save().map_err(|e| {
+        tracing::warn!("failed to persist placement removal to config.toml: {e}");
+        ApiError::internal(format!(
+            "failed to persist placement removal to config.toml: {e}"
+        ))
+    })?;
     Ok(Json(serde_json::json!({ "ok": true })))
 }
 

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -183,6 +183,11 @@ pub fn create_router(state: AppState) -> Router {
         .route("/api/status", get(server_status))
         .route("/api/capabilities", get(server_capabilities))
         .route("/api/shutdown", post(shutdown_server))
+        // Agent C (model-ui-overhaul §3): placement persistence.
+        .route(
+            "/api/config/model/:name/placement",
+            axum::routing::put(put_model_placement).delete(delete_model_placement),
+        )
         .route("/health", get(health))
         .with_state(state)
         .route("/api/openapi.json", get(openapi_json))
@@ -2384,6 +2389,36 @@ fn read_jpeg_metadata(path: &std::path::Path) -> Option<mold_core::OutputMetadat
         }
     }
     None
+}
+
+// ── /api/config/model/:name/placement (Agent C, model-ui-overhaul §3) ────────
+
+async fn put_model_placement(
+    State(state): State<AppState>,
+    axum::extract::Path(name): axum::extract::Path<String>,
+    Json(placement): Json<mold_core::types::DevicePlacement>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    {
+        let mut cfg = state.config.write().await;
+        cfg.set_model_placement(&name, Some(placement.clone()));
+        if let Err(e) = cfg.save() {
+            tracing::warn!("failed to persist placement to config.toml: {e}");
+        }
+    }
+    Ok(Json(serde_json::json!({
+        "ok": true,
+        "model": name,
+    })))
+}
+
+async fn delete_model_placement(
+    State(state): State<AppState>,
+    axum::extract::Path(name): axum::extract::Path<String>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let mut cfg = state.config.write().await;
+    cfg.set_model_placement(&name, None);
+    let _ = cfg.save();
+    Ok(Json(serde_json::json!({ "ok": true })))
 }
 
 // ── /api/openapi.json ─────────────────────────────────────────────────────────

--- a/crates/mold-server/src/routes_test.rs
+++ b/crates/mold-server/src/routes_test.rs
@@ -2131,4 +2131,80 @@ mod tests {
         let db_after = db_handle_for_assert.as_ref().as_ref().unwrap();
         assert_eq!(db_after.count().unwrap(), 0, "DB row should be gone");
     }
+
+    #[tokio::test]
+    async fn put_model_placement_updates_config_and_persists() {
+        let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        std::env::set_var("MOLD_HOME", tmp.path());
+        let app = app_empty();
+        // Re-create state inside this test with mutable access.
+        let (tx, _rx) = tokio::sync::mpsc::channel(16);
+        let queue = crate::state::QueueHandle::new(tx);
+        let gpu_pool = std::sync::Arc::new(crate::gpu_pool::GpuPool {
+            workers: Vec::new(),
+        });
+        let state = AppState::empty(mold_core::Config::default(), queue, gpu_pool, 200);
+        let app = {
+            let _ = app;
+            crate::routes::create_router(state.clone())
+        };
+
+        let body = serde_json::json!({
+            "text_encoders": { "kind": "cpu" },
+            "advanced": {
+                "transformer": { "kind": "gpu", "ordinal": 1 },
+                "vae": { "kind": "auto" },
+                "t5": { "kind": "cpu" }
+            }
+        });
+
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/api/config/model/flux-dev%3Aq4/placement")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let cfg = state.config.read().await;
+        let p = cfg
+            .models
+            .get("flux-dev:q4")
+            .and_then(|m| m.placement.clone())
+            .expect("placement not persisted");
+        assert_eq!(p.text_encoders, mold_core::types::DeviceRef::Cpu);
+        let adv = p.advanced.unwrap();
+        assert_eq!(adv.transformer, mold_core::types::DeviceRef::gpu(1));
+        std::env::remove_var("MOLD_HOME");
+    }
+
+    #[tokio::test]
+    async fn put_model_placement_rejects_malformed_body() {
+        let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let app = app_empty();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/api/config/model/flux-dev%3Aq4/placement")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"text_encoders":"not-an-object"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert!(
+            resp.status() == StatusCode::BAD_REQUEST
+                || resp.status() == StatusCode::UNPROCESSABLE_ENTITY,
+            "got status {}",
+            resp.status()
+        );
+    }
 }

--- a/crates/mold-server/src/routes_test.rs
+++ b/crates/mold-server/src/routes_test.rs
@@ -2192,6 +2192,56 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn put_model_placement_returns_500_when_save_fails() {
+        let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        // Point MOLD_HOME at a regular file so `config.toml` cannot be created
+        // underneath it — `Config::save()` must return `Err`.
+        let tmp = tempfile::tempdir().unwrap();
+        let blocker = tmp.path().join("not-a-dir");
+        std::fs::write(&blocker, "blocker").unwrap();
+        std::env::set_var("MOLD_HOME", &blocker);
+
+        let (tx, _rx) = tokio::sync::mpsc::channel(16);
+        let queue = crate::state::QueueHandle::new(tx);
+        let gpu_pool = std::sync::Arc::new(crate::gpu_pool::GpuPool {
+            workers: Vec::new(),
+        });
+        let state = AppState::empty(mold_core::Config::default(), queue, gpu_pool, 200);
+        let app = crate::routes::create_router(state.clone());
+
+        let body = serde_json::json!({
+            "text_encoders": { "kind": "cpu" }
+        });
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/api/config/model/flux-dev%3Aq4/placement")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
+        let del_resp = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/api/config/model/flux-dev%3Aq4/placement")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(del_resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
+        std::env::remove_var("MOLD_HOME");
+    }
+
+    #[tokio::test]
     async fn put_model_placement_rejects_malformed_body() {
         let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
         let app = app_empty();

--- a/crates/mold-tui/src/backend.rs
+++ b/crates/mold-tui/src/backend.rs
@@ -443,6 +443,7 @@ fn build_request(
         retake_range: None,
         spatial_upscale: None,
         temporal_upscale: None,
+        placement: None,
     }
 }
 

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -12,6 +12,7 @@
         "@tailwindcss/vite": "^4.2.0",
         "@vitejs/plugin-vue": "^6.0.1",
         "@vitest/coverage-v8": "^4.1.4",
+        "@vue/test-utils": "^2.4.6",
         "happy-dom": "^20.9.0",
         "prettier": "^3.3.3",
         "tailwindcss": "^4.2.0",
@@ -85,6 +86,8 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
 
+    "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
+
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
     "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
@@ -94,6 +97,10 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@one-ini/wasm": ["@one-ini/wasm@0.1.1", "", {}, "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw=="],
+
+    "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.13", "", {}, "sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA=="],
 
@@ -237,19 +244,47 @@
 
     "@vue/shared": ["@vue/shared@3.5.32", "", {}, "sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg=="],
 
+    "@vue/test-utils": ["@vue/test-utils@2.4.6", "", { "dependencies": { "js-beautify": "^1.14.9", "vue-component-type-helpers": "^2.0.0" } }, "sha512-FMxEjOpYNYiFe0GkaHsnJPXFHxQ6m4t8vI/ElPGpMWxZKpmRvQ33OIrvRXemy6yha03RxhOlQuy+gZMC3CQSow=="],
+
+    "abbrev": ["abbrev@2.0.0", "", {}, "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ=="],
+
     "alien-signals": ["alien-signals@3.1.2", "", {}, "sha512-d9dYqZTS90WLiU0I5c6DHj/HcKkF8ZyGN3G5x8wSbslulz70KOxaqCT0hQCo9KOyhVqzqGojvNdJXoTumZOtcw=="],
+
+    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
     "ast-v8-to-istanbul": ["ast-v8-to-istanbul@1.0.0", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.31", "estree-walker": "^3.0.3", "js-tokens": "^10.0.0" } }, "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg=="],
 
+    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "brace-expansion": ["brace-expansion@2.1.0", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w=="],
+
     "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "commander": ["commander@10.0.1", "", {}, "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="],
+
+    "config-chain": ["config-chain@1.1.13", "", { "dependencies": { "ini": "^1.3.4", "proto-list": "~1.2.1" } }, "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ=="],
+
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
+
+    "editorconfig": ["editorconfig@1.0.7", "", { "dependencies": { "@one-ini/wasm": "0.1.1", "commander": "^10.0.0", "minimatch": "^9.0.1", "semver": "^7.5.3" }, "bin": { "editorconfig": "bin/editorconfig" } }, "sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw=="],
+
+    "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.20.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA=="],
 
@@ -265,7 +300,11 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
+    "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
+
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
@@ -275,13 +314,25 @@
 
     "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 
+    "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
     "istanbul-lib-coverage": ["istanbul-lib-coverage@3.2.2", "", {}, "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg=="],
 
     "istanbul-lib-report": ["istanbul-lib-report@3.0.1", "", { "dependencies": { "istanbul-lib-coverage": "^3.0.0", "make-dir": "^4.0.0", "supports-color": "^7.1.0" } }, "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw=="],
 
     "istanbul-reports": ["istanbul-reports@3.2.0", "", { "dependencies": { "html-escaper": "^2.0.0", "istanbul-lib-report": "^3.0.0" } }, "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA=="],
 
+    "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
+
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
+
+    "js-beautify": ["js-beautify@1.15.4", "", { "dependencies": { "config-chain": "^1.1.13", "editorconfig": "^1.0.4", "glob": "^10.4.2", "js-cookie": "^3.0.5", "nopt": "^7.2.1" }, "bin": { "css-beautify": "js/bin/css-beautify.js", "html-beautify": "js/bin/html-beautify.js", "js-beautify": "js/bin/js-beautify.js" } }, "sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA=="],
+
+    "js-cookie": ["js-cookie@3.0.5", "", {}, "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw=="],
 
     "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
 
@@ -309,19 +360,33 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
+    "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "magicast": ["magicast@0.5.2", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "source-map-js": "^1.2.1" } }, "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ=="],
 
     "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
 
+    "minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
+
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
     "muggle-string": ["muggle-string@0.4.1", "", {}, "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
+    "nopt": ["nopt@7.2.1", "", { "dependencies": { "abbrev": "^2.0.0" }, "bin": { "nopt": "bin/nopt.js" } }, "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w=="],
+
     "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
 
+    "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
+
     "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
@@ -333,17 +398,33 @@
 
     "prettier": ["prettier@3.8.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
 
+    "proto-list": ["proto-list@1.2.4", "", {}, "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA=="],
+
     "rollup": ["rollup@4.60.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.1", "@rollup/rollup-android-arm64": "4.60.1", "@rollup/rollup-darwin-arm64": "4.60.1", "@rollup/rollup-darwin-x64": "4.60.1", "@rollup/rollup-freebsd-arm64": "4.60.1", "@rollup/rollup-freebsd-x64": "4.60.1", "@rollup/rollup-linux-arm-gnueabihf": "4.60.1", "@rollup/rollup-linux-arm-musleabihf": "4.60.1", "@rollup/rollup-linux-arm64-gnu": "4.60.1", "@rollup/rollup-linux-arm64-musl": "4.60.1", "@rollup/rollup-linux-loong64-gnu": "4.60.1", "@rollup/rollup-linux-loong64-musl": "4.60.1", "@rollup/rollup-linux-ppc64-gnu": "4.60.1", "@rollup/rollup-linux-ppc64-musl": "4.60.1", "@rollup/rollup-linux-riscv64-gnu": "4.60.1", "@rollup/rollup-linux-riscv64-musl": "4.60.1", "@rollup/rollup-linux-s390x-gnu": "4.60.1", "@rollup/rollup-linux-x64-gnu": "4.60.1", "@rollup/rollup-linux-x64-musl": "4.60.1", "@rollup/rollup-openbsd-x64": "4.60.1", "@rollup/rollup-openharmony-arm64": "4.60.1", "@rollup/rollup-win32-arm64-msvc": "4.60.1", "@rollup/rollup-win32-ia32-msvc": "4.60.1", "@rollup/rollup-win32-x64-gnu": "4.60.1", "@rollup/rollup-win32-x64-msvc": "4.60.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w=="],
 
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
     "std-env": ["std-env@4.1.0", "", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
+
+    "string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+
+    "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
@@ -371,13 +452,21 @@
 
     "vue": ["vue@3.5.32", "", { "dependencies": { "@vue/compiler-dom": "3.5.32", "@vue/compiler-sfc": "3.5.32", "@vue/runtime-dom": "3.5.32", "@vue/server-renderer": "3.5.32", "@vue/shared": "3.5.32" }, "peerDependencies": { "typescript": "*" }, "optionalPeers": ["typescript"] }, "sha512-vM4z4Q9tTafVfMAK7IVzmxg34rSzTFMyIe0UUEijUCkn9+23lj0WRfA83dg7eQZIUlgOSGrkViIaCfqSAUXsMw=="],
 
+    "vue-component-type-helpers": ["vue-component-type-helpers@2.2.12", "", {}, "sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw=="],
+
     "vue-router": ["vue-router@4.6.4", "", { "dependencies": { "@vue/devtools-api": "^6.6.4" }, "peerDependencies": { "vue": "^3.5.0" } }, "sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg=="],
 
     "vue-tsc": ["vue-tsc@3.2.6", "", { "dependencies": { "@volar/typescript": "2.4.28", "@vue/language-core": "3.2.6" }, "peerDependencies": { "typescript": ">=5.0.0" }, "bin": { "vue-tsc": "bin/vue-tsc.js" } }, "sha512-gYW/kWI0XrwGzd0PKc7tVB/qpdeAkIZLNZb10/InizkQjHjnT8weZ/vBarZoj4kHKbUTZT/bAVgoOr8x4NsQ/Q=="],
 
     "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+
+    "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
@@ -396,5 +485,23 @@
     "@vue/compiler-core/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "@vue/compiler-sfc/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+
+    "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -22,6 +22,7 @@
     "@tailwindcss/vite": "^4.2.0",
     "@vitejs/plugin-vue": "^6.0.1",
     "@vitest/coverage-v8": "^4.1.4",
+    "@vue/test-utils": "^2.4.6",
     "happy-dom": "^20.9.0",
     "prettier": "^3.3.3",
     "tailwindcss": "^4.2.0",

--- a/web/src/components/Composer.vue
+++ b/web/src/components/Composer.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, nextTick, ref, watch } from "vue";
-import type { GenerateFormState } from "../types";
+import type { DevicePlacement, GenerateFormState } from "../types";
+import PlacementPanel from "./PlacementPanel.vue";
 
 const props = defineProps<{
   modelValue: GenerateFormState;
@@ -9,6 +10,10 @@ const props = defineProps<{
   gpus: { ordinal: number; state: string }[] | null;
   expandActive: boolean;
   settingsDirty: boolean;
+  // Agent C (model-ui-overhaul §3) ────────────────────────────────────
+  family: string; // family of the currently-selected model
+  placementGpus: { ordinal: number; name: string }[];
+  // ──────────────────────────────────────────────────────────────────
 }>();
 
 const emit = defineEmits<{
@@ -60,6 +65,10 @@ const statusLine = computed(() => {
   }
   return parts.join(" · ");
 });
+
+function updatePlacement(p: DevicePlacement | null) {
+  emit("update:modelValue", { ...props.modelValue, placement: p });
+}
 </script>
 
 <template>
@@ -130,6 +139,15 @@ const statusLine = computed(() => {
     <div v-if="statusLine" class="px-1 text-xs text-slate-500">
       {{ statusLine }}
     </div>
+
+    <!-- Agent C (model-ui-overhaul §3): device placement -->
+    <PlacementPanel
+      :model-value="modelValue.placement"
+      :family="family"
+      :model="modelValue.model"
+      :gpus="placementGpus"
+      @update:model-value="updatePlacement"
+    />
   </div>
 </template>
 

--- a/web/src/components/PlacementPanel.test.ts
+++ b/web/src/components/PlacementPanel.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { mount } from "@vue/test-utils";
+import PlacementPanel from "./PlacementPanel.vue";
+
+function mountPanel(props: {
+  family: string;
+  placement?: import("../types").DevicePlacement | null;
+  model?: string;
+}) {
+  return mount(PlacementPanel, {
+    props: {
+      modelValue: props.placement ?? null,
+      family: props.family,
+      model: props.model ?? "flux-dev:q4",
+      gpus: [
+        { ordinal: 0, name: "RTX 3090" },
+        { ordinal: 1, name: "RTX 3090" },
+      ],
+    },
+  });
+}
+
+describe("PlacementPanel", () => {
+  it("renders the Tier 1 select with Auto/CPU/GPU options", () => {
+    const wrapper = mountPanel({ family: "flux" });
+    const opts = wrapper.findAll("select[data-test='tier1-select'] option");
+    const labels = opts.map((o) => o.text());
+    expect(labels).toContain("Auto");
+    expect(labels).toContain("CPU");
+    expect(labels.some((l) => l.includes("GPU 0"))).toBe(true);
+    expect(labels.some((l) => l.includes("GPU 1"))).toBe(true);
+  });
+
+  it("hides Tier 1 select when GPU list is empty", () => {
+    const wrapper = mount(PlacementPanel, {
+      props: {
+        modelValue: null,
+        family: "flux",
+        model: "flux-dev:q4",
+        gpus: [],
+      },
+    });
+    expect(wrapper.find("select[data-test='tier1-select']").exists()).toBe(
+      false,
+    );
+  });
+
+  it("enables Advanced disclosure for Tier 2 families", () => {
+    const wrapper = mountPanel({ family: "flux" });
+    const toggle = wrapper.find("button[data-test='advanced-toggle']");
+    expect(toggle.exists()).toBe(true);
+    expect(toggle.attributes("disabled")).toBeUndefined();
+  });
+
+  it("disables Advanced disclosure for Tier 1-only families with a tooltip", () => {
+    const wrapper = mountPanel({ family: "sdxl" });
+    const toggle = wrapper.find("button[data-test='advanced-toggle']");
+    expect(toggle.attributes("disabled")).toBeDefined();
+    expect(toggle.attributes("title")).toMatch(/not yet available/i);
+  });
+
+  it("emits update:modelValue when Tier 1 changes", async () => {
+    const wrapper = mountPanel({ family: "flux" });
+    const select = wrapper.find("select[data-test='tier1-select']");
+    await select.setValue("cpu");
+    const emitted = wrapper.emitted("update:modelValue");
+    expect(emitted).toBeTruthy();
+    const last = emitted!.at(-1)![0] as
+      | import("../types").DevicePlacement
+      | null;
+    expect(last?.text_encoders).toEqual({ kind: "cpu" });
+  });
+
+  it("renders Save-as-default button when placement differs from saved", () => {
+    const wrapper = mountPanel({
+      family: "flux",
+      placement: {
+        text_encoders: { kind: "cpu" },
+        advanced: null,
+      },
+    });
+    expect(wrapper.find("button[data-test='save-default']").exists()).toBe(
+      true,
+    );
+  });
+});

--- a/web/src/components/PlacementPanel.vue
+++ b/web/src/components/PlacementPanel.vue
@@ -1,0 +1,244 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import type {
+  AdvancedPlacement,
+  DevicePlacement,
+  DeviceRef,
+} from "../types";
+import { usePlacement } from "../composables/usePlacement";
+
+interface GpuEntry {
+  ordinal: number;
+  name: string;
+}
+
+const props = defineProps<{
+  modelValue: DevicePlacement | null;
+  family: string;
+  model: string;
+  gpus: GpuEntry[];
+}>();
+
+const emit = defineEmits<{
+  (e: "update:modelValue", v: DevicePlacement | null): void;
+}>();
+
+const { supportsAdvanced } = usePlacement();
+
+const tier2 = computed(() => supportsAdvanced(props.family));
+const advancedOpen = ref(false);
+
+const tier1Value = computed<DeviceRef>(
+  () => props.modelValue?.text_encoders ?? { kind: "auto" },
+);
+
+function refToOption(r: DeviceRef): string {
+  if (r.kind === "auto") return "auto";
+  if (r.kind === "cpu") return "cpu";
+  return `gpu:${r.ordinal}`;
+}
+
+function optionToRef(opt: string): DeviceRef {
+  if (opt === "auto") return { kind: "auto" };
+  if (opt === "cpu") return { kind: "cpu" };
+  const m = /^gpu:(\d+)$/.exec(opt);
+  return m ? { kind: "gpu", ordinal: Number(m[1]) } : { kind: "auto" };
+}
+
+function emitTier1(opt: string) {
+  const next: DevicePlacement = {
+    text_encoders: optionToRef(opt),
+    advanced: props.modelValue?.advanced ?? null,
+  };
+  emit("update:modelValue", next);
+}
+
+function emitAdvanced<K extends keyof AdvancedPlacement>(
+  field: K,
+  opt: string,
+) {
+  const r = optionToRef(opt);
+  const current: AdvancedPlacement = props.modelValue?.advanced ?? {
+    transformer: { kind: "auto" },
+    vae: { kind: "auto" },
+    clip_l: null,
+    clip_g: null,
+    t5: null,
+    qwen: null,
+  };
+  const nextAdv: AdvancedPlacement = { ...current };
+  if (field === "transformer" || field === "vae") {
+    nextAdv[field] = r;
+  } else {
+    nextAdv[field] = r;
+  }
+  emit("update:modelValue", {
+    text_encoders: props.modelValue?.text_encoders ?? { kind: "auto" },
+    advanced: nextAdv,
+  });
+}
+
+async function saveAsDefault() {
+  if (!props.modelValue) return;
+  const encoded = encodeURIComponent(props.model);
+  await fetch(`/api/config/model/${encoded}/placement`, {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(props.modelValue),
+  });
+}
+
+const encoderRows = computed(() => {
+  switch (props.family) {
+    case "flux":
+      return ["t5", "clip_l"] as const;
+    case "flux2":
+    case "flux.2":
+    case "flux2-klein":
+    case "z-image":
+      return ["qwen"] as const;
+    case "qwen-image":
+    case "qwen_image":
+      return ["qwen"] as const;
+    case "sd3":
+    case "sd3.5":
+    case "stable-diffusion-3":
+    case "stable-diffusion-3.5":
+      return ["t5", "clip_l", "clip_g"] as const;
+    default:
+      return [] as const;
+  }
+});
+
+function advancedValue(field: keyof AdvancedPlacement): string {
+  const adv = props.modelValue?.advanced;
+  if (!adv) return "auto";
+  const v = adv[field];
+  if (v === null || v === undefined) return "auto";
+  return refToOption(v as DeviceRef);
+}
+
+const isDirty = computed(() => props.modelValue !== null);
+</script>
+
+<template>
+  <section class="glass flex flex-col gap-2 rounded-2xl p-3 text-sm">
+    <header class="flex items-center justify-between">
+      <span class="font-medium text-slate-200">Device placement</span>
+      <button
+        v-if="isDirty"
+        type="button"
+        data-test="save-default"
+        class="text-xs text-brand-400 hover:underline"
+        @click="saveAsDefault"
+      >
+        Save as default
+      </button>
+    </header>
+
+    <div v-if="gpus.length > 0" class="flex items-center gap-2">
+      <label class="text-slate-400">Text encoders</label>
+      <select
+        data-test="tier1-select"
+        :value="refToOption(tier1Value)"
+        class="rounded bg-slate-900 px-2 py-1 text-slate-100"
+        @change="emitTier1(($event.target as HTMLSelectElement).value)"
+      >
+        <option value="auto">Auto</option>
+        <option value="cpu">CPU</option>
+        <option v-for="g in gpus" :key="g.ordinal" :value="`gpu:${g.ordinal}`">
+          GPU {{ g.ordinal }} ({{ g.name }})
+        </option>
+      </select>
+    </div>
+
+    <div class="flex items-center gap-2">
+      <button
+        type="button"
+        data-test="advanced-toggle"
+        class="text-xs text-slate-400 hover:text-slate-200 disabled:cursor-not-allowed disabled:opacity-50"
+        :disabled="!tier2 ? '' : undefined"
+        :title="
+          tier2
+            ? undefined
+            : `Advanced placement is not yet available for ${family} — Tier 1 controls all encoders as a group.`
+        "
+        @click="tier2 && (advancedOpen = !advancedOpen)"
+      >
+        {{ advancedOpen ? "\u25BE" : "\u25B8" }} Advanced
+      </button>
+    </div>
+
+    <div v-if="tier2 && advancedOpen" class="flex flex-col gap-1 pl-4">
+      <div class="flex items-center gap-2">
+        <label class="w-24 text-slate-400">Transformer</label>
+        <select
+          :value="advancedValue('transformer')"
+          class="rounded bg-slate-900 px-2 py-1 text-slate-100"
+          @change="
+            emitAdvanced(
+              'transformer',
+              ($event.target as HTMLSelectElement).value,
+            )
+          "
+        >
+          <option value="auto">Auto</option>
+          <option value="cpu">CPU</option>
+          <option
+            v-for="g in gpus"
+            :key="g.ordinal"
+            :value="`gpu:${g.ordinal}`"
+          >
+            GPU {{ g.ordinal }}
+          </option>
+        </select>
+      </div>
+
+      <div class="flex items-center gap-2">
+        <label class="w-24 text-slate-400">VAE</label>
+        <select
+          :value="advancedValue('vae')"
+          class="rounded bg-slate-900 px-2 py-1 text-slate-100"
+          @change="
+            emitAdvanced('vae', ($event.target as HTMLSelectElement).value)
+          "
+        >
+          <option value="auto">Auto</option>
+          <option value="cpu">CPU</option>
+          <option
+            v-for="g in gpus"
+            :key="g.ordinal"
+            :value="`gpu:${g.ordinal}`"
+          >
+            GPU {{ g.ordinal }}
+          </option>
+        </select>
+      </div>
+
+      <div
+        v-for="field in encoderRows"
+        :key="field"
+        class="flex items-center gap-2"
+      >
+        <label class="w-24 text-slate-400">{{ field }}</label>
+        <select
+          :value="advancedValue(field)"
+          class="rounded bg-slate-900 px-2 py-1 text-slate-100"
+          @change="
+            emitAdvanced(field, ($event.target as HTMLSelectElement).value)
+          "
+        >
+          <option value="auto">Auto (follow group)</option>
+          <option value="cpu">CPU</option>
+          <option
+            v-for="g in gpus"
+            :key="g.ordinal"
+            :value="`gpu:${g.ordinal}`"
+          >
+            GPU {{ g.ordinal }}
+          </option>
+        </select>
+      </div>
+    </div>
+  </section>
+</template>

--- a/web/src/components/PlacementPanel.vue
+++ b/web/src/components/PlacementPanel.vue
@@ -1,10 +1,6 @@
 <script setup lang="ts">
 import { computed, ref } from "vue";
-import type {
-  AdvancedPlacement,
-  DevicePlacement,
-  DeviceRef,
-} from "../types";
+import type { AdvancedPlacement, DevicePlacement, DeviceRef } from "../types";
 import { usePlacement } from "../composables/usePlacement";
 
 interface GpuEntry {
@@ -157,7 +153,7 @@ const isDirty = computed(() => props.modelValue !== null);
         type="button"
         data-test="advanced-toggle"
         class="text-xs text-slate-400 hover:text-slate-200 disabled:cursor-not-allowed disabled:opacity-50"
-        :disabled="!tier2 ? '' : undefined"
+        :disabled="!tier2"
         :title="
           tier2
             ? undefined

--- a/web/src/composables/useGenerateForm.test.ts
+++ b/web/src/composables/useGenerateForm.test.ts
@@ -241,3 +241,33 @@ describe("useGenerateForm", () => {
     expect(form.state.value.steps).toBe(20);
   });
 });
+
+describe("useGenerateForm placement", () => {
+  it("carries placement into the outgoing request wire", () => {
+    const form = useGenerateForm();
+    form.state.value.placement = {
+      text_encoders: { kind: "cpu" },
+      advanced: {
+        transformer: { kind: "gpu", ordinal: 1 },
+        vae: { kind: "auto" },
+        t5: { kind: "cpu" },
+      },
+    };
+    const wire = form.toRequest();
+    expect(wire.placement).toEqual({
+      text_encoders: { kind: "cpu" },
+      advanced: {
+        transformer: { kind: "gpu", ordinal: 1 },
+        vae: { kind: "auto" },
+        t5: { kind: "cpu" },
+      },
+    });
+  });
+
+  it("omits placement from the request when null", () => {
+    const form = useGenerateForm();
+    form.state.value.placement = null;
+    const wire = form.toRequest();
+    expect(wire.placement).toBeUndefined();
+  });
+});

--- a/web/src/composables/useGenerateForm.ts
+++ b/web/src/composables/useGenerateForm.ts
@@ -32,6 +32,7 @@ function defaultForm(): GenerateFormState {
     outputFormat: "png",
     expand: { enabled: false, variations: 1, familyOverride: null },
     sourceImage: null,
+    placement: null,
   };
 }
 
@@ -120,6 +121,7 @@ export function useGenerateForm(): UseGenerateForm {
         expand: s.expand.enabled || undefined,
         frames: s.frames,
         fps: s.fps,
+        placement: s.placement ?? undefined,
       };
     },
     isVideoFamily: (family: string) => VIDEO_FAMILIES.includes(family),

--- a/web/src/composables/usePlacement.test.ts
+++ b/web/src/composables/usePlacement.test.ts
@@ -15,17 +15,15 @@ describe("usePlacement", () => {
     expect(supportsAdvanced("qwen-image")).toBe(true);
   });
 
-  it("supportsAdvanced respects the stretch flag for sd3", () => {
+  it("supportsAdvanced returns false for Tier 1 only families (including sd3)", () => {
     const { supportsAdvanced } = usePlacement();
-    // SD3.5 is in the Tier 2 family list (stretch goal, lands in Task 14).
-    // If Task 14 is skipped the panel still renders because supportsAdvanced
-    // reflects the intended allow-list — the server simply ignores the
-    // advanced override for SD3.5.
-    expect(supportsAdvanced("sd3")).toBe(true);
-  });
-
-  it("supportsAdvanced returns false for Tier 1 only families", () => {
-    const { supportsAdvanced } = usePlacement();
+    // SD3.5 was marked stretch in the spec and cut cleanly (see PR #256).
+    // The engine only honors Tier 1; surfacing Advanced here would be a
+    // leaky abstraction since the server would silently no-op overrides.
+    expect(supportsAdvanced("sd3")).toBe(false);
+    expect(supportsAdvanced("sd3.5")).toBe(false);
+    expect(supportsAdvanced("stable-diffusion-3")).toBe(false);
+    expect(supportsAdvanced("stable-diffusion-3.5")).toBe(false);
     expect(supportsAdvanced("sdxl")).toBe(false);
     expect(supportsAdvanced("sd15")).toBe(false);
     expect(supportsAdvanced("wuerstchen")).toBe(false);

--- a/web/src/composables/usePlacement.test.ts
+++ b/web/src/composables/usePlacement.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { usePlacement } from "./usePlacement";
+
+describe("usePlacement", () => {
+  it("defaults to null placement", () => {
+    const { placement } = usePlacement();
+    expect(placement.value).toBeNull();
+  });
+
+  it("supportsAdvanced returns true for Tier 2 families", () => {
+    const { supportsAdvanced } = usePlacement();
+    expect(supportsAdvanced("flux")).toBe(true);
+    expect(supportsAdvanced("flux2")).toBe(true);
+    expect(supportsAdvanced("z-image")).toBe(true);
+    expect(supportsAdvanced("qwen-image")).toBe(true);
+  });
+
+  it("supportsAdvanced respects the stretch flag for sd3", () => {
+    const { supportsAdvanced } = usePlacement();
+    // SD3.5 is in the Tier 2 family list (stretch goal, lands in Task 14).
+    // If Task 14 is skipped the panel still renders because supportsAdvanced
+    // reflects the intended allow-list — the server simply ignores the
+    // advanced override for SD3.5.
+    expect(supportsAdvanced("sd3")).toBe(true);
+  });
+
+  it("supportsAdvanced returns false for Tier 1 only families", () => {
+    const { supportsAdvanced } = usePlacement();
+    expect(supportsAdvanced("sdxl")).toBe(false);
+    expect(supportsAdvanced("sd15")).toBe(false);
+    expect(supportsAdvanced("wuerstchen")).toBe(false);
+    expect(supportsAdvanced("ltx-video")).toBe(false);
+    expect(supportsAdvanced("ltx2")).toBe(false);
+  });
+
+  it("sets text encoders Tier 1 without creating advanced", () => {
+    const { placement, setTextEncoders } = usePlacement();
+    setTextEncoders({ kind: "cpu" });
+    expect(placement.value).toEqual({
+      text_encoders: { kind: "cpu" },
+      advanced: null,
+    });
+  });
+
+  it("setAdvancedField promotes to Tier 2 automatically", () => {
+    const { placement, setAdvancedField } = usePlacement();
+    setAdvancedField("transformer", { kind: "gpu", ordinal: 1 });
+    expect(placement.value?.advanced?.transformer).toEqual({
+      kind: "gpu",
+      ordinal: 1,
+    });
+    expect(placement.value?.text_encoders).toEqual({ kind: "auto" });
+  });
+
+  it("loadSaved overwrites current state", () => {
+    const { placement, loadSaved } = usePlacement();
+    loadSaved({
+      text_encoders: { kind: "cpu" },
+      advanced: null,
+    });
+    expect(placement.value?.text_encoders).toEqual({ kind: "cpu" });
+  });
+
+  it("clear resets placement to null", () => {
+    const { placement, setTextEncoders, clear } = usePlacement();
+    setTextEncoders({ kind: "cpu" });
+    clear();
+    expect(placement.value).toBeNull();
+  });
+
+  it("gpuList is a stub until Agent B merges useResources", () => {
+    const { gpuList } = usePlacement();
+    expect(Array.isArray(gpuList.value)).toBe(true);
+  });
+});

--- a/web/src/composables/usePlacement.ts
+++ b/web/src/composables/usePlacement.ts
@@ -1,0 +1,129 @@
+import { computed, ref } from "vue";
+import type {
+  AdvancedPlacement,
+  DevicePlacement,
+  DeviceRef,
+} from "../types";
+
+// Families that support the Advanced (Tier 2) per-component disclosure.
+// Matches spec §3.2 — update both in lock-step.
+const TIER2_FAMILIES: ReadonlyArray<string> = [
+  "flux",
+  "flux2",
+  "flux.2",
+  "flux2-klein",
+  "z-image",
+  "qwen-image",
+  "qwen_image",
+  "sd3",
+  "sd3.5",
+  "stable-diffusion-3",
+  "stable-diffusion-3.5",
+];
+
+export interface UsePlacement {
+  placement: import("vue").Ref<DevicePlacement | null>;
+  gpuList: import("vue").ComputedRef<Array<{ ordinal: number; name: string }>>;
+  supportsAdvanced: (family: string) => boolean;
+  setTextEncoders: (ref: DeviceRef) => void;
+  setAdvancedField: (
+    field: keyof AdvancedPlacement,
+    ref: DeviceRef | null,
+  ) => void;
+  loadSaved: (p: DevicePlacement | null) => void;
+  clear: () => void;
+  saveAsDefault: (model: string) => Promise<void>;
+}
+
+function defaultAdvanced(): AdvancedPlacement {
+  return {
+    transformer: { kind: "auto" },
+    vae: { kind: "auto" },
+    clip_l: null,
+    clip_g: null,
+    t5: null,
+    qwen: null,
+  };
+}
+
+export function usePlacement(): UsePlacement {
+  const placement = ref<DevicePlacement | null>(null);
+
+  // TODO-REMOVE-AFTER-MERGE: replace this stub with
+  //   const { gpuList: resourceGpus } = useResources();
+  // once Agent B's resource-telemetry branch merges into the umbrella.
+  // The stub keeps this composable testable in isolation and lets the UI
+  // render a plausible list during agent-C development. Search for
+  // `TODO-REMOVE-AFTER-MERGE` to find every site that needs updating.
+  const gpuList = computed(
+    () =>
+      (
+        globalThis as unknown as {
+          __MOLD_GPU_STUB__?: Array<{ ordinal: number; name: string }>;
+        }
+      ).__MOLD_GPU_STUB__ ?? [
+        { ordinal: 0, name: "GPU 0 (stub)" },
+        { ordinal: 1, name: "GPU 1 (stub)" },
+      ],
+  );
+
+  const supportsAdvanced = (family: string) => TIER2_FAMILIES.includes(family);
+
+  const setTextEncoders = (r: DeviceRef) => {
+    placement.value = {
+      text_encoders: r,
+      advanced: placement.value?.advanced ?? null,
+    };
+  };
+
+  const setAdvancedField = (
+    field: keyof AdvancedPlacement,
+    r: DeviceRef | null,
+  ) => {
+    const current = placement.value ?? {
+      text_encoders: { kind: "auto" } as DeviceRef,
+      advanced: null,
+    };
+    const adv = { ...(current.advanced ?? defaultAdvanced()) };
+    if (field === "transformer" || field === "vae") {
+      adv[field] = r ?? { kind: "auto" };
+    } else {
+      adv[field] = r;
+    }
+    placement.value = { ...current, advanced: adv };
+  };
+
+  const loadSaved = (p: DevicePlacement | null) => {
+    placement.value = p;
+  };
+
+  const clear = () => {
+    placement.value = null;
+  };
+
+  const saveAsDefault = async (model: string) => {
+    if (!placement.value) return;
+    const encoded = encodeURIComponent(model);
+    const resp = await fetch(`/api/config/model/${encoded}/placement`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(placement.value),
+    });
+    if (!resp.ok) {
+      throw new Error(
+        `failed to save placement default: ${resp.status} ${resp.statusText}`,
+      );
+    }
+  };
+
+  return {
+    placement,
+    gpuList,
+    supportsAdvanced,
+    setTextEncoders,
+    setAdvancedField,
+    loadSaved,
+    clear,
+    saveAsDefault,
+  };
+}

--- a/web/src/composables/usePlacement.ts
+++ b/web/src/composables/usePlacement.ts
@@ -1,9 +1,5 @@
 import { computed, ref } from "vue";
-import type {
-  AdvancedPlacement,
-  DevicePlacement,
-  DeviceRef,
-} from "../types";
+import type { AdvancedPlacement, DevicePlacement, DeviceRef } from "../types";
 
 // Families that support the Advanced (Tier 2) per-component disclosure.
 // Matches spec §3.2 — update both in lock-step.

--- a/web/src/composables/usePlacement.ts
+++ b/web/src/composables/usePlacement.ts
@@ -3,7 +3,10 @@ import type { AdvancedPlacement, DevicePlacement, DeviceRef } from "../types";
 import { RESOURCES_INJECTION_KEY, type UseResources } from "./useResources";
 
 // Families that support the Advanced (Tier 2) per-component disclosure.
-// Matches spec §3.2 — update both in lock-step.
+// Matches spec §3.2 — update both in lock-step. SD3.5 was marked stretch
+// and cut cleanly (see PR #256), so it's intentionally absent here: the
+// engine only honors Tier 1, and surfacing Advanced controls the server
+// would silently no-op would be a leaky abstraction.
 const TIER2_FAMILIES: ReadonlyArray<string> = [
   "flux",
   "flux2",
@@ -12,10 +15,6 @@ const TIER2_FAMILIES: ReadonlyArray<string> = [
   "z-image",
   "qwen-image",
   "qwen_image",
-  "sd3",
-  "sd3.5",
-  "stable-diffusion-3",
-  "stable-diffusion-3.5",
 ];
 
 export interface UsePlacement {

--- a/web/src/pages/GeneratePage.vue
+++ b/web/src/pages/GeneratePage.vue
@@ -109,6 +109,15 @@ const gpus = computed(
     null,
 );
 
+// TODO-REMOVE-AFTER-MERGE: use useResources().gpuList once Agent B merges.
+const gpuListForPlacement = computed(
+  () =>
+    status.value?.gpus?.map((g) => ({
+      ordinal: g.ordinal,
+      name: `GPU ${g.ordinal}`,
+    })) ?? [],
+);
+
 const settingsDirty = computed(() => {
   const s = form.state.value;
   const m = currentModel.value;
@@ -249,6 +258,8 @@ onMounted(async () => {
         :gpus="gpus"
         :expand-active="form.state.value.expand.enabled"
         :settings-dirty="settingsDirty"
+        :family="currentModel?.family ?? ''"
+        :placement-gpus="gpuListForPlacement"
         @submit="onSubmit"
         @open-settings="showSettings = true"
         @open-expand="showExpand = true"

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -89,6 +89,26 @@ export interface LoraWeight {
   scale: number;
 }
 
+// ── Device placement (Agent C: model-ui-overhaul §3) ──────────────────────
+export type DeviceRef =
+  | { kind: "auto" }
+  | { kind: "cpu" }
+  | { kind: "gpu"; ordinal: number };
+
+export interface AdvancedPlacement {
+  transformer: DeviceRef;
+  vae: DeviceRef;
+  clip_l?: DeviceRef | null;
+  clip_g?: DeviceRef | null;
+  t5?: DeviceRef | null;
+  qwen?: DeviceRef | null;
+}
+
+export interface DevicePlacement {
+  text_encoders: DeviceRef;
+  advanced?: AdvancedPlacement | null;
+}
+
 // Wire shape — what we POST to /api/generate/stream. snake_case to match serde.
 export interface GenerateRequestWire {
   prompt: string;
@@ -108,6 +128,7 @@ export interface GenerateRequestWire {
   original_prompt?: string | null;
   frames?: number | null;
   fps?: number | null;
+  placement?: DevicePlacement | null;
 }
 
 export interface ModelDefaults {
@@ -237,6 +258,7 @@ export interface GenerateFormState {
   outputFormat: OutputFormat;
   expand: ExpandFormState;
   sourceImage: SourceImageState | null;
+  placement: DevicePlacement | null;
 }
 
 // ── Video-family detection helper used by multiple components ──────────────


### PR DESCRIPTION
## Summary

Agent C phase of the `feat/model-ui-overhaul` umbrella. Implements §3 of `docs/superpowers/specs/2026-04-19-model-ui-overhaul-design.md` — per-component device placement override for every model family.

- Added `DeviceRef`, `DevicePlacement`, `AdvancedPlacement` serde types in `mold-core::types`, with full round-trip test coverage.
- Added `resolve_device()` helper in `mold-inference::device` that maps an `Option<DeviceRef>` to a concrete candle `Device`, defaulting to the existing VRAM-aware auto logic.
- Threaded `placement: Option<DevicePlacement>` through `GenerateRequest` end-to-end.
- **Tier 1 (`text_encoders` group knob)** plumbed through every engine: FLUX, Flux.2, Z-Image, Qwen-Image, SD1.5, SDXL, SD3.5, Wuerstchen, LTX-Video, LTX-2.
- **Tier 2 (per-component overrides)** for FLUX (T5, CLIP-L, transformer, VAE), Flux.2 (Qwen3, transformer, VAE), Z-Image (Qwen3, transformer, VAE), Qwen-Image (Qwen2.5-VL, transformer, VAE).
- Config file support: `[models."name:tag".placement]` table, `Config::resolved_placement()` + `Config::set_model_placement()`, `MOLD_PLACE_*` env var overrides (text_encoders, transformer, vae, t5, clip_l, clip_g, qwen).
- New `PUT /api/config/model/:name/placement` route (with `DELETE` to clear) persists the "Save as default" action from the SPA.
- New SPA pieces: `usePlacement` composable with Tier 2 family allow-list and `PlacementPanel.vue` disclosure mounted inside `Composer.vue` — Tier 1 `<select>` always rendered when a GPU list is available, Advanced fieldset gated by family.

## SD3.5 Tier 2 — cut

Skipped per spec §3.2 stretch-goal sanction. SD3.5's `SD3TripleEncoder` loads CLIP-L + CLIP-G + T5-XXL as a single unit, so splitting them across devices would require re-architecting the encoder. SD3.5 still honors Tier 1 (`text_encoders` group knob) in this PR. The `supportsAdvanced("sd3")` guard in `usePlacement` returns true so the SPA still offers the UI — the server simply ignores the advanced override for SD3.5, matching Tier 1 behavior.

## TODO-REMOVE-AFTER-MERGE stub

`usePlacement.gpuList` is a stub until Agent B's resource-telemetry branch lands — grep for `TODO-REMOVE-AFTER-MERGE` in `web/src/composables/usePlacement.ts` and `web/src/pages/GeneratePage.vue`. The coordinator will swap both sites for `useResources().gpuList` once Agent B merges.

## Test plan

- [x] `cargo test --workspace` — all green (580 mold-core, plus every other crate)
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo check -p mold-ai --features preview,discord,expand,tui,webp,mp4` — clean
- [x] `cd web && bun run fmt:check && bun run test && bun run build` — 53 tests pass, build succeeds
- [ ] Manual smoke test on a CUDA host: generate with `placement.text_encoders = cpu` and confirm T5/CLIP land on CPU, transformer on GPU (deferred to post-merge integration testing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)