### PR TITLE
fix(discord): keep /generate model autocomplete off the hot path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Discord `/generate` model dropdown no longer fails with "Loading options failed".** The autocomplete handler previously called `cached_models()` which, on a stale cache, synchronously fetched `/api/models` from the mold server on the hot path. When the server was slow or cold (or when a `/generate` invocation happened before the first successful fetch), the round-trip regularly exceeded Discord's 3-second autocomplete budget and the client rendered "Loading options failed" instead of the model list. Fixed by: (1) spawning a background refresher at bot startup that keeps `model_cache` warm every 30 s, (2) making `cached_models()` a pure lock-read that never blocks on I/O, (3) falling back to the static manifest names (excluding utility families) when the cache is still cold so the dropdown renders immediately on first use, and (4) wrapping the autocomplete computation in a 1.5 s `tokio::time::timeout` as a last-ditch guard. `MoldClient` now derives `Clone` so the refresher task can own its own handle.
+
 ### Added
 
 - **Discord bot now supports video generation and img2img / img-to-video.** `/generate` accepts an optional `source_image` attachment (PNG/JPEG, ≤10 MiB) that is forwarded to the server as `source_image` — image-family models run img2img, LTX-2 runs image-to-video with the attachment as the first frame. New `video_format` choice (MP4 default, animated GIF) plus `frames`, `fps`, `audio` (LTX-2 only), `pipeline` (LTX-2 one-stage / two-stage / two-stage-hq / distilled / a2vid / retake), `strength`, and `negative_prompt` params wire through to the underlying `GenerateRequest`. Video families default to 25 frames @ 24 fps when unspecified. The handler picks up `GenerateResponse.video` and attaches the MP4/GIF bytes (plus a "Video Generated" embed with frame count, fps, and optional audio flag); when the primary MP4 exceeds Discord's ~24 MiB effective upload cap it automatically falls back to the always-generated GIF preview and notes the swap in the embed footer.

--- a/crates/mold-core/src/client.rs
+++ b/crates/mold-core/src/client.rs
@@ -8,6 +8,7 @@ use anyhow::Result;
 use base64::Engine as _;
 use reqwest::Client;
 
+#[derive(Clone)]
 pub struct MoldClient {
     base_url: String,
     client: Client,

--- a/crates/mold-discord/src/commands/generate.rs
+++ b/crates/mold-discord/src/commands/generate.rs
@@ -4,18 +4,83 @@ use crate::state::Context;
 use anyhow::Result;
 use mold_core::{GenerateRequest, Ltx2PipelineMode, ModelInfoExtended, OutputFormat};
 use poise::serenity_prelude as serenity;
+use std::time::Duration;
 
-/// Autocomplete function for model names.
-async fn autocomplete_model(ctx: Context<'_>, partial: &str) -> Vec<String> {
-    let models = ctx.data().cached_models().await;
+/// Hard ceiling on how long we're willing to spend computing autocomplete
+/// choices. Discord drops the interaction after 3 s and shows "Loading options
+/// failed" — we stay well under that.
+const AUTOCOMPLETE_BUDGET: Duration = Duration::from_millis(1500);
+
+/// Pick the best set of model names to suggest for the given partial input.
+///
+/// Pure function so we can test the ranking logic without a live bot. The
+/// autocomplete fn wraps this and adds the Discord-plumbing + timeout guard.
+pub fn rank_model_suggestions(
+    cached: &[ModelInfoExtended],
+    fallback_names: &[&str],
+    partial: &str,
+) -> Vec<String> {
     let lower = partial.to_lowercase();
-    models
+    let matches_partial =
+        |name: &str| -> bool { lower.is_empty() || name.to_lowercase().contains(&lower) };
+
+    // When we have a populated cache, prefer downloaded models and fall back
+    // to undownloaded (they still work — the server auto-pulls on demand).
+    if !cached.is_empty() {
+        let mut downloaded: Vec<String> = cached
+            .iter()
+            .filter(|m| m.downloaded && matches_partial(&m.info.name))
+            .map(|m| m.info.name.clone())
+            .collect();
+        if downloaded.len() < 25 {
+            let room = 25 - downloaded.len();
+            let also: Vec<String> = cached
+                .iter()
+                .filter(|m| !m.downloaded && matches_partial(&m.info.name))
+                .take(room)
+                .map(|m| m.info.name.clone())
+                .collect();
+            downloaded.extend(also);
+        }
+        downloaded.truncate(25);
+        return downloaded;
+    }
+
+    // Cold cache (bot just started / server unreachable): offer manifest
+    // names so the dropdown still renders instead of "Loading options failed".
+    fallback_names
         .iter()
-        .filter(|m| m.downloaded)
-        .filter(|m| m.info.name.to_lowercase().contains(&lower))
-        .map(|m| m.info.name.clone())
-        .take(25) // Discord autocomplete limit
+        .filter(|n| matches_partial(n))
+        .take(25)
+        .map(|n| n.to_string())
         .collect()
+}
+
+fn manifest_fallback_names() -> Vec<String> {
+    mold_core::manifest::visible_manifests()
+        .filter(|m| !mold_core::manifest::UTILITY_FAMILIES.contains(&m.family.as_str()))
+        .map(|m| m.name.clone())
+        .collect()
+}
+
+/// Autocomplete function for model names. Reads the cached model list without
+/// blocking on network I/O; the cache is refreshed by a background task so the
+/// hot path here is always a quick `RwLock::read`. Falls back to the static
+/// manifest if the cache is still cold so users never see "Loading options
+/// failed" due to a slow first fetch.
+async fn autocomplete_model(ctx: Context<'_>, partial: &str) -> Vec<String> {
+    let partial = partial.to_string();
+    let data = ctx.data();
+    let work = async {
+        let cached = data.cached_models().await;
+        let fallback = manifest_fallback_names();
+        let fallback_refs: Vec<&str> = fallback.iter().map(String::as_str).collect();
+        rank_model_suggestions(&cached, &fallback_refs, &partial)
+    };
+    match tokio::time::timeout(AUTOCOMPLETE_BUDGET, work).await {
+        Ok(v) => v,
+        Err(_) => manifest_fallback_names().into_iter().take(25).collect(),
+    }
 }
 
 /// Discord-selectable container for video generations. Videos are always
@@ -694,6 +759,92 @@ mod tests {
         // Landscape aspect preserved roughly
         let (w, h) = snap_dims_to_multiple_of_16(800, 600, 1024);
         assert_eq!((w, h), (800, 608));
+    }
+
+    // --- autocomplete ranking ---
+
+    fn mk_model(name: &str, family: &str, downloaded: bool) -> ModelInfoExtended {
+        ModelInfoExtended {
+            info: mold_core::ModelInfo {
+                name: name.to_string(),
+                family: family.to_string(),
+                size_gb: 1.0,
+                is_loaded: false,
+                last_used: None,
+                hf_repo: "test/repo".to_string(),
+            },
+            defaults: defaults(),
+            downloaded,
+            disk_usage_bytes: None,
+            remaining_download_bytes: None,
+        }
+    }
+
+    #[test]
+    fn rank_prefers_downloaded_then_undownloaded() {
+        let models = vec![
+            mk_model("flux-schnell:q8", "flux", true),
+            mk_model("flux-dev:q4", "flux", false),
+            mk_model("ltx-2-19b-distilled:fp8", "ltx2", true),
+        ];
+        let out = rank_model_suggestions(&models, &[], "");
+        assert_eq!(
+            out,
+            vec![
+                "flux-schnell:q8".to_string(),
+                "ltx-2-19b-distilled:fp8".to_string(),
+                "flux-dev:q4".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn rank_filters_by_partial_case_insensitive() {
+        let models = vec![
+            mk_model("flux-schnell:q8", "flux", true),
+            mk_model("flux-dev:q4", "flux", true),
+            mk_model("ltx-2-19b-distilled:fp8", "ltx2", true),
+        ];
+        let out = rank_model_suggestions(&models, &[], "FLUX");
+        assert!(out.iter().all(|n| n.to_lowercase().contains("flux")));
+        assert!(out.contains(&"flux-schnell:q8".to_string()));
+        assert!(!out.contains(&"ltx-2-19b-distilled:fp8".to_string()));
+    }
+
+    #[test]
+    fn rank_caps_at_discord_limit() {
+        let models: Vec<_> = (0..40)
+            .map(|i| mk_model(&format!("model-{i}:q8"), "flux", true))
+            .collect();
+        let out = rank_model_suggestions(&models, &[], "");
+        assert_eq!(out.len(), 25);
+    }
+
+    #[test]
+    fn rank_falls_back_to_manifest_when_cache_cold() {
+        // Simulate bot just started: cache empty, rely on static manifest.
+        let fallback = vec!["flux-schnell:q8", "ltx-2-19b-distilled:fp8", "sd15:fp16"];
+        let out = rank_model_suggestions(&[], &fallback, "ltx");
+        assert_eq!(out, vec!["ltx-2-19b-distilled:fp8".to_string()]);
+    }
+
+    #[test]
+    fn rank_empty_partial_returns_everything_within_limit() {
+        let models: Vec<_> = (0..5)
+            .map(|i| mk_model(&format!("m{i}:q8"), "flux", true))
+            .collect();
+        let out = rank_model_suggestions(&models, &[], "");
+        assert_eq!(out.len(), 5);
+    }
+
+    #[test]
+    fn manifest_fallback_is_non_empty_and_excludes_utilities() {
+        let names = manifest_fallback_names();
+        assert!(!names.is_empty(), "manifest should supply fallback names");
+        assert!(
+            !names.iter().any(|n| n.starts_with("qwen3-expand")),
+            "utility models should be excluded from suggestions: {names:?}"
+        );
     }
 
     // --- Header sniff ---

--- a/crates/mold-discord/src/lib.rs
+++ b/crates/mold-discord/src/lib.rs
@@ -89,7 +89,11 @@ pub async fn run() -> Result<()> {
                 info!("Bot connected, registering slash commands...");
                 poise::builtins::register_globally(ctx, &framework.options().commands).await?;
                 info!("Slash commands registered");
-                Ok(BotState::new(client, config))
+                let state = BotState::new(client.clone(), config);
+                // Keep the model cache warm so autocomplete never races Discord's
+                // 3-second interaction budget against server latency.
+                BotState::spawn_model_cache_refresher(state.model_cache.clone(), client);
+                Ok(state)
             })
         })
         .build();

--- a/crates/mold-discord/src/state.rs
+++ b/crates/mold-discord/src/state.rs
@@ -2,8 +2,10 @@ use crate::access::{AllowedRoles, BlockList};
 use crate::cooldown::CooldownTracker;
 use crate::quota::QuotaTracker;
 use mold_core::{ModelInfoExtended, MoldClient};
-use std::time::Instant;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
+use tracing::{debug, warn};
 
 /// Bot-wide configuration loaded from environment variables.
 #[derive(Debug)]
@@ -23,8 +25,16 @@ pub struct BotState {
     pub cooldowns: CooldownTracker,
     pub quotas: QuotaTracker,
     pub block_list: BlockList,
-    pub model_cache: RwLock<(Instant, Vec<ModelInfoExtended>)>,
+    /// Server-reported model list + the `Instant` it was last refreshed.
+    /// A background task refreshes this every `MODEL_CACHE_TTL`; callers
+    /// never trigger a fetch on the hot path, so Discord's 3-second
+    /// autocomplete budget is never at the mercy of server latency.
+    pub model_cache: Arc<RwLock<(Instant, Vec<ModelInfoExtended>)>>,
 }
+
+/// Background-refresh interval for `model_cache`. Kept well under Discord's
+/// 3-second autocomplete timeout so even a cold fetch never stalls users.
+pub const MODEL_CACHE_TTL: Duration = Duration::from_secs(30);
 
 impl std::fmt::Debug for BotState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -46,33 +56,58 @@ impl BotState {
             cooldowns: CooldownTracker::new(),
             quotas: QuotaTracker::new(),
             block_list: BlockList::new(),
-            model_cache: RwLock::new((Instant::now() - std::time::Duration::from_secs(60), vec![])),
+            model_cache: Arc::new(RwLock::new((
+                Instant::now() - Duration::from_secs(60),
+                vec![],
+            ))),
         }
     }
 
-    /// Get cached models list, refreshing if older than 30 seconds.
+    /// Read the current model cache without blocking on the network. Returns
+    /// whatever is there — possibly empty when the bot just started and the
+    /// background refresher hasn't completed its first fetch yet. Callers
+    /// that need a fallback (e.g. autocomplete) should substitute
+    /// `mold_core::manifest::visible_manifests()` in that case.
     pub async fn cached_models(&self) -> Vec<ModelInfoExtended> {
-        let cache_ttl = std::time::Duration::from_secs(30);
+        self.model_cache.read().await.1.clone()
+    }
 
-        {
-            let cache = self.model_cache.read().await;
-            if cache.0.elapsed() < cache_ttl && !cache.1.is_empty() {
-                return cache.1.clone();
-            }
-        }
+    /// Force-refresh the model cache. Used by the background refresher and
+    /// by commands like `/models` that can afford to pay a round-trip.
+    pub async fn refresh_models(&self) -> Result<(), mold_core::MoldError> {
+        let models = self.client.list_models_extended().await?;
+        let mut cache = self.model_cache.write().await;
+        *cache = (Instant::now(), models);
+        Ok(())
+    }
 
-        // Cache miss — fetch from server
-        match self.client.list_models_extended().await {
-            Ok(models) => {
-                let mut cache = self.model_cache.write().await;
-                *cache = (Instant::now(), models.clone());
-                models
+    /// Spawn a background task that refreshes `model_cache` every
+    /// `MODEL_CACHE_TTL`. The first refresh runs immediately so the very
+    /// first `/generate` invocation after startup already has data.
+    pub fn spawn_model_cache_refresher(
+        cache: Arc<RwLock<(Instant, Vec<ModelInfoExtended>)>>,
+        client: MoldClient,
+    ) {
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(MODEL_CACHE_TTL);
+            // First tick fires immediately; subsequent ticks wait the full interval.
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            loop {
+                ticker.tick().await;
+                match client.list_models_extended().await {
+                    Ok(models) => {
+                        let mut guard = cache.write().await;
+                        *guard = (Instant::now(), models);
+                        debug!("model cache refreshed ({} entries)", guard.1.len());
+                    }
+                    Err(e) => {
+                        warn!(
+                            error = %e,
+                            "model cache refresh failed; keeping previous entries",
+                        );
+                    }
+                }
             }
-            Err(_) => {
-                // Return stale cache on error
-                let cache = self.model_cache.read().await;
-                cache.1.clone()
-            }
-        }
+        });
     }
 }


### PR DESCRIPTION
## Summary

`/generate` began showing **Loading options failed** on the model dropdown after #253. The autocomplete handler ultimately called `cached_models()` which, on a stale cache, synchronously fetched `/api/models` from the server. On a slow/cold server that round-trip exceeded Discord's 3-second autocomplete budget and the client surfaced a generic error instead of the model list.

![repro](https://github.com/utensils/mold/issues)

### Fix

- **Background refresher** — spawned at bot setup, keeps `model_cache` warm every 30 s regardless of command traffic.
- **Lock-only hot path** — `cached_models()` is now a pure `RwLock::read`. No network I/O from command handlers ever again.
- **Manifest fallback** — when the cache is still cold (bot just booted, first `/generate`), autocomplete returns names from `mold_core::manifest::visible_manifests()` (utility families excluded) so the dropdown renders immediately.
- **Last-ditch timeout** — autocomplete computation is wrapped in a 1.5 s `tokio::time::timeout`; if anything stalls, we still return the manifest names.
- **MoldClient derives Clone** so the refresher task owns its own handle.

6 new unit tests cover the ranking function (prefers downloaded, filters case-insensitively, caps at 25, falls back to manifest when cold, handles empty partial) plus a sanity check that `manifest_fallback_names()` is non-empty and excludes utility families.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test -p mold-ai-discord` (102 pass, was 96)
- [ ] Smoke: start bot against a live server; `/generate` shows model list on the very first invocation (no "Loading options failed").
- [ ] Smoke: `/generate` continues to show the list if the server later becomes unreachable (returns whatever the last successful fetch cached).