### PR TITLE
feat(ltx2): engine transitions (cut/fade/stitch) (Phase 2/6)

### DIFF
--- a/crates/mold-core/src/chain.rs
+++ b/crates/mold-core/src/chain.rs
@@ -380,6 +380,28 @@ pub enum ChainProgressEvent {
     Stitching { total_frames: u32 },
 }
 
+/// Structured error payload returned in the 502 response body when a chain
+/// stage fails mid-run. Allows UIs to show actionable retry hints (e.g.,
+/// "stage 2 of 5 failed — retry from here").
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct ChainFailure {
+    /// Human-readable summary of where the failure landed.
+    #[schema(example = "stage render failed")]
+    pub error: String,
+    /// Zero-based index of the stage whose render returned Err.
+    #[schema(example = 2)]
+    pub failed_stage_idx: u32,
+    /// Number of stages that completed successfully before the failure.
+    #[schema(example = 2)]
+    pub elapsed_stages: u32,
+    /// Cumulative generation time across the completed stages, in ms.
+    #[schema(example = 12_340)]
+    pub elapsed_ms: u64,
+    /// Inner error message from the orchestrator (`format!("{e:#}")`).
+    #[schema(example = "simulated GPU OOM on stage 2")]
+    pub stage_error: String,
+}
+
 fn default_motion_tail_frames() -> u32 {
     4
 }

--- a/crates/mold-core/src/lib.rs
+++ b/crates/mold-core/src/lib.rs
@@ -21,8 +21,9 @@ mod test_support;
 
 pub use catalog::build_model_catalog;
 pub use chain::{
-    ChainProgressEvent, ChainRequest, ChainResponse, ChainScript, ChainScriptChain, ChainStage,
-    LoraSpec, NamedRef, SseChainCompleteEvent, TransitionMode, VramEstimate, MAX_CHAIN_STAGES,
+    ChainFailure, ChainProgressEvent, ChainRequest, ChainResponse, ChainScript, ChainScriptChain,
+    ChainStage, LoraSpec, NamedRef, SseChainCompleteEvent, TransitionMode, VramEstimate,
+    MAX_CHAIN_STAGES,
 };
 pub use client::MoldClient;
 pub use config::{

--- a/crates/mold-inference/src/ltx2/chain.rs
+++ b/crates/mold-inference/src/ltx2/chain.rs
@@ -147,17 +147,17 @@ pub trait ChainStageRenderer {
     ) -> Result<StageOutcome>;
 }
 
-/// Output of an end-to-end chain run: accumulated RGB frames with motion-
-/// tail prefix already trimmed on continuations, the number of stages
-/// that ran, and the total elapsed render time.
+/// Output of an end-to-end chain run.
 ///
-/// The orchestrator does *not* trim to a target total frame count or
-/// encode the frames into an output video — those are the caller's job
-/// (server / CLI). Keeps the orchestrator single-purpose: produce a
-/// coherent frame stream from a stages list.
+/// The orchestrator no longer trims motion-tail prefixes at run time —
+/// that moved into [`super::stitch::StitchPlan::assemble`] so the stitch
+/// logic can also implement `Cut` (no trim) and `Fade` (post-stitch alpha
+/// blend) on the same per-boundary seam.
 #[derive(Debug)]
 pub struct ChainRunOutput {
-    pub frames: Vec<RgbImage>,
+    /// Per-stage frame vectors in stage order, each containing the full
+    /// un-trimmed pixel clip emitted by the renderer.
+    pub stage_frames: Vec<Vec<RgbImage>>,
     pub stage_count: u32,
     pub generation_time_ms: u64,
 }
@@ -205,8 +205,7 @@ impl<'a, R: ChainStageRenderer + ?Sized> Ltx2ChainOrchestrator<'a, R> {
         }
 
         let base_seed = req.seed.unwrap_or(0);
-        let motion_tail_drop = req.motion_tail_frames as usize;
-        let mut accumulated_frames: Vec<RgbImage> = Vec::new();
+        let mut stage_frames: Vec<Vec<RgbImage>> = Vec::with_capacity(req.stages.len());
         let mut total_generation_ms: u64 = 0;
         let mut carry: Option<ChainTail> = None;
 
@@ -250,18 +249,8 @@ impl<'a, R: ChainStageRenderer + ?Sized> Ltx2ChainOrchestrator<'a, R> {
                 )?,
             };
 
-            let mut frames = outcome.frames;
-            if idx > 0 && motion_tail_drop > 0 {
-                if motion_tail_drop >= frames.len() {
-                    bail!(
-                        "stage {stage_idx}: emitted {} frames but motion_tail_drop={motion_tail_drop} — tail would consume the whole clip",
-                        frames.len(),
-                    );
-                }
-                frames.drain(..motion_tail_drop);
-            }
-            let frames_emitted = frames.len() as u32;
-            accumulated_frames.extend(frames);
+            let frames_emitted = outcome.frames.len() as u32;
+            stage_frames.push(outcome.frames);
             total_generation_ms = total_generation_ms.saturating_add(outcome.generation_time_ms);
             carry = Some(outcome.tail);
 
@@ -274,13 +263,14 @@ impl<'a, R: ChainStageRenderer + ?Sized> Ltx2ChainOrchestrator<'a, R> {
         }
 
         if let Some(cb) = chain_progress.as_mut() {
+            let total: u32 = stage_frames.iter().map(|s| s.len() as u32).sum();
             cb(ChainProgressEvent::Stitching {
-                total_frames: accumulated_frames.len() as u32,
+                total_frames: total,
             });
         }
 
         Ok(ChainRunOutput {
-            frames: accumulated_frames,
+            stage_frames,
             stage_count,
             generation_time_ms: total_generation_ms,
         })
@@ -624,9 +614,10 @@ mod tests {
         let mut renderer = FakeRenderer::new();
         let mut orch = Ltx2ChainOrchestrator::new(&mut renderer);
         let out = orch.run(&req, None).expect("chain runs");
-        // Stage 0 keeps all 97 frames; each continuation drops the
-        // leading 4 frames, so delivered = 97 + 2 * (97 - 4) = 97 + 186 = 283.
-        assert_eq!(out.frames.len(), 97 + 93 * 2);
+        // Each stage keeps its full un-trimmed frame count in the per-stage
+        // vector. Total across all stages = 97 * 3 = 291.
+        let total_frames: usize = out.stage_frames.iter().map(|s| s.len()).sum();
+        assert_eq!(total_frames, 97 * 3);
         assert_eq!(out.stage_count, 3);
         assert_eq!(renderer.calls.len(), 3);
         // Stage 0 has no carry; later stages do.
@@ -642,10 +633,11 @@ mod tests {
         let mut renderer = FakeRenderer::new();
         let mut orch = Ltx2ChainOrchestrator::new(&mut renderer);
         let out = orch.run(&req, None).expect("chain runs");
+        let total_frames: usize = out.stage_frames.iter().map(|s| s.len()).sum();
         assert_eq!(
-            out.frames.len(),
+            total_frames,
             97 * 2,
-            "zero motion tail must keep every frame on continuations",
+            "zero motion tail must keep every frame in each stage's vector",
         );
     }
 
@@ -831,5 +823,47 @@ mod tests {
             Some(100 ^ 0xDEADBEEFu64),
             "seed_offset must XOR into the stable base seed when a stage opts in to variation",
         );
+    }
+
+    #[test]
+    fn chain_run_output_preserves_per_stage_frames() {
+        let req = sample_chain_request(3, TransitionMode::Smooth);
+        let mut renderer = FakeRenderer::new();
+        let mut orch = Ltx2ChainOrchestrator::new(&mut renderer);
+        let out = orch.run(&req, None).unwrap();
+        assert_eq!(out.stage_frames.len(), 3);
+        // Each stage holds its full un-trimmed frame count.
+        assert_eq!(out.stage_frames[0].len() as u32, req.stages[0].frames);
+        assert_eq!(out.stage_frames[1].len() as u32, req.stages[1].frames);
+        assert_eq!(out.stage_frames[2].len() as u32, req.stages[2].frames);
+    }
+
+    fn sample_chain_request(count: usize, transition: TransitionMode) -> ChainRequest {
+        // Use motion_tail_frames=0 so effective=clip_frames=97, which makes
+        // build_auto_expand_stages produce exactly `count` stages for
+        // total_frames = 97 * count (no ceil rounding complication).
+        let req = ChainRequest {
+            model: "ltx-2-19b-distilled:fp8".into(),
+            stages: Vec::new(),
+            motion_tail_frames: 0,
+            width: 1216,
+            height: 704,
+            fps: 24,
+            seed: Some(0),
+            steps: 8,
+            guidance: 3.0,
+            strength: 1.0,
+            output_format: mold_core::OutputFormat::Mp4,
+            placement: None,
+            prompt: Some("x".into()),
+            total_frames: Some(97 * count as u32),
+            clip_frames: Some(97),
+            source_image: None,
+        };
+        let mut req = req.normalise().unwrap();
+        for s in req.stages.iter_mut().skip(1) {
+            s.transition = transition;
+        }
+        req
     }
 }

--- a/crates/mold-inference/src/ltx2/chain.rs
+++ b/crates/mold-inference/src/ltx2/chain.rs
@@ -15,7 +15,7 @@
 use anyhow::{anyhow, bail, Context, Result};
 use candle_core::Tensor;
 use image::RgbImage;
-use mold_core::chain::{ChainProgressEvent, ChainRequest, ChainStage};
+use mold_core::chain::{ChainProgressEvent, ChainRequest, ChainStage, TransitionMode};
 use mold_core::{GenerateRequest, OutputFormat};
 
 use crate::ltx2::model::shapes::SpatioTemporalScaleFactors;
@@ -218,6 +218,16 @@ impl<'a, R: ChainStageRenderer + ?Sized> Ltx2ChainOrchestrator<'a, R> {
             let stage_seed = derive_stage_seed(base_seed, idx, stage);
             let stage_req = build_stage_generate_request(stage, req, stage_seed, idx);
 
+            // Cut and Fade transitions produce a visual reset: the prior
+            // stage's motion-tail latent is NOT threaded into this stage.
+            // Smooth is the only transition that passes carry through.
+            // Carry is still captured unconditionally at the end of the loop
+            // so a later Smooth stage can pick it up.
+            let effective_carry = match stage.transition {
+                TransitionMode::Smooth => carry.as_ref(),
+                TransitionMode::Cut | TransitionMode::Fade => None,
+            };
+
             // Wrap the chain progress subscriber so per-stage denoise
             // events land on it with `stage_idx` tagged in. The wrapping
             // closure holds a mutable reborrow of the outer callback for
@@ -236,14 +246,14 @@ impl<'a, R: ChainStageRenderer + ?Sized> Ltx2ChainOrchestrator<'a, R> {
                     };
                     self.renderer.render_stage(
                         &stage_req,
-                        carry.as_ref(),
+                        effective_carry,
                         req.motion_tail_frames,
                         Some(&mut wrapping),
                     )?
                 }
                 None => self.renderer.render_stage(
                     &stage_req,
-                    carry.as_ref(),
+                    effective_carry,
                     req.motion_tail_frames,
                     None,
                 )?,
@@ -836,6 +846,28 @@ mod tests {
         assert_eq!(out.stage_frames[0].len() as u32, req.stages[0].frames);
         assert_eq!(out.stage_frames[1].len() as u32, req.stages[1].frames);
         assert_eq!(out.stage_frames[2].len() as u32, req.stages[2].frames);
+    }
+
+    #[test]
+    fn orchestrator_passes_none_carry_for_cut_transition() {
+        let mut renderer = FakeRenderer::new();
+        let req = sample_chain_request(3, TransitionMode::Cut);
+        let mut orch = Ltx2ChainOrchestrator::new(&mut renderer);
+        orch.run(&req, None).unwrap();
+        // Stage 0 always has None; stages 1/2 should also have None because
+        // their transition is Cut.
+        let has_carry: Vec<bool> = renderer.calls.iter().map(|c| c.has_carry).collect();
+        assert_eq!(has_carry, vec![false, false, false]);
+    }
+
+    #[test]
+    fn orchestrator_passes_some_carry_for_smooth_transition() {
+        let mut renderer = FakeRenderer::new();
+        let req = sample_chain_request(3, TransitionMode::Smooth);
+        let mut orch = Ltx2ChainOrchestrator::new(&mut renderer);
+        orch.run(&req, None).unwrap();
+        let has_carry: Vec<bool> = renderer.calls.iter().map(|c| c.has_carry).collect();
+        assert_eq!(has_carry, vec![false, true, true]);
     }
 
     fn sample_chain_request(count: usize, transition: TransitionMode) -> ChainRequest {

--- a/crates/mold-inference/src/ltx2/chain.rs
+++ b/crates/mold-inference/src/ltx2/chain.rs
@@ -665,7 +665,7 @@ mod tests {
     }
 
     #[test]
-    fn chain_runs_all_stages_and_drops_tail_prefix_from_continuations() {
+    fn chain_orchestrator_emits_full_per_stage_clips() {
         let stages = vec![stage("a", 97), stage("a", 97), stage("a", 97)];
         let req = chain_req(stages, 4);
         let mut renderer = FakeRenderer::new();
@@ -935,6 +935,44 @@ mod tests {
         orch.run(&req, None).unwrap();
         let has_carry: Vec<bool> = renderer.calls.iter().map(|c| c.has_carry).collect();
         assert_eq!(has_carry, vec![false, true, true]);
+    }
+
+    #[test]
+    fn mixed_transitions_end_to_end() {
+        let mut renderer = FakeRenderer::new();
+        let mut req = sample_chain_request(4, TransitionMode::Smooth);
+        // sample_chain_request uses motion_tail_frames=0; override so the
+        // Smooth boundary trim math has something to trim.
+        req.motion_tail_frames = 25;
+        req.stages[1].transition = TransitionMode::Smooth;
+        req.stages[2].transition = TransitionMode::Cut;
+        req.stages[3].transition = TransitionMode::Fade;
+        req.stages[3].fade_frames = Some(8);
+        let mut orch = Ltx2ChainOrchestrator::new(&mut renderer);
+        let out = orch.run(&req, None).unwrap();
+
+        // Expected frame count after StitchPlan::assemble:
+        //   stage 0 kept whole (97)
+        //   + stage 1 Smooth (drop motion_tail 25) = 97 - 25 = 72
+        //   + stage 2 Cut (keep whole) = 97
+        //   + stage 3 Fade (consume 2*fade_len into fade_len, net -fade_len=8)
+        //     = 97 - 8 = 89
+        //   total = 97 + 72 + 97 + 89 = 355
+        let boundaries: Vec<_> = req.stages.iter().skip(1).map(|s| s.transition).collect();
+        let fade_lens: Vec<_> = req
+            .stages
+            .iter()
+            .skip(1)
+            .map(|s| s.fade_frames.unwrap_or(8))
+            .collect();
+        let plan = crate::ltx2::stitch::StitchPlan {
+            clips: out.stage_frames,
+            boundaries,
+            fade_lens,
+            motion_tail_frames: req.motion_tail_frames,
+        };
+        let frames = plan.assemble().unwrap();
+        assert_eq!(frames.len(), 355);
     }
 
     fn sample_chain_request(count: usize, transition: TransitionMode) -> ChainRequest {

--- a/crates/mold-inference/src/ltx2/chain.rs
+++ b/crates/mold-inference/src/ltx2/chain.rs
@@ -111,6 +111,45 @@ pub fn extract_tail_latents(final_latents: &Tensor, pixel_frames: u32) -> Result
         .with_context(|| format!("narrow last {tail} latent frames off time axis"))
 }
 
+/// Typed error returned by [`Ltx2ChainOrchestrator::run`].
+#[derive(Debug)]
+pub enum ChainOrchestratorError {
+    /// Request failed pre-flight validation (empty stages, bad motion_tail).
+    Invalid(anyhow::Error),
+    /// A stage render call returned `Err` mid-chain.
+    StageFailed {
+        stage_idx: u32,
+        elapsed_stages: u32,
+        elapsed_ms: u64,
+        inner: anyhow::Error,
+    },
+}
+
+impl std::fmt::Display for ChainOrchestratorError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Invalid(e) => write!(f, "chain validation error: {e:#}"),
+            Self::StageFailed {
+                stage_idx,
+                elapsed_stages,
+                inner,
+                ..
+            } => write!(
+                f,
+                "chain stage {stage_idx} failed after {elapsed_stages} completed stage(s): {inner:#}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ChainOrchestratorError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Invalid(e) | Self::StageFailed { inner: e, .. } => Some(e.as_ref()),
+        }
+    }
+}
+
 // ── Orchestrator: loops stages, drops motion-tail prefix, accumulates frames
 
 /// Per-stage progress events the orchestrator observes from the renderer.
@@ -189,11 +228,13 @@ impl<'a, R: ChainStageRenderer + ?Sized> Ltx2ChainOrchestrator<'a, R> {
         &mut self,
         req: &ChainRequest,
         mut chain_progress: Option<&mut dyn FnMut(ChainProgressEvent)>,
-    ) -> Result<ChainRunOutput> {
+    ) -> std::result::Result<ChainRunOutput, ChainOrchestratorError> {
         if req.stages.is_empty() {
-            bail!("Ltx2ChainOrchestrator::run: chain request has no stages");
+            return Err(ChainOrchestratorError::Invalid(anyhow::anyhow!(
+                "Ltx2ChainOrchestrator::run: chain request has no stages"
+            )));
         }
-        validate_motion_tail(req)?;
+        validate_motion_tail(req).map_err(ChainOrchestratorError::Invalid)?;
 
         let stage_count = req.stages.len() as u32;
         let estimated_total_frames = estimate_stitched_frames(req);
@@ -233,7 +274,7 @@ impl<'a, R: ChainStageRenderer + ?Sized> Ltx2ChainOrchestrator<'a, R> {
             // closure holds a mutable reborrow of the outer callback for
             // just the duration of this call — `render_stage` is
             // synchronous so the reborrow ends before the next iteration.
-            let outcome = match chain_progress.as_deref_mut() {
+            let render_result = match chain_progress.as_deref_mut() {
                 Some(chain_cb) => {
                     let mut wrapping = |event: StageProgressEvent| match event {
                         StageProgressEvent::DenoiseStep { step, total } => {
@@ -249,15 +290,21 @@ impl<'a, R: ChainStageRenderer + ?Sized> Ltx2ChainOrchestrator<'a, R> {
                         effective_carry,
                         req.motion_tail_frames,
                         Some(&mut wrapping),
-                    )?
+                    )
                 }
                 None => self.renderer.render_stage(
                     &stage_req,
                     effective_carry,
                     req.motion_tail_frames,
                     None,
-                )?,
+                ),
             };
+            let outcome = render_result.map_err(|inner| ChainOrchestratorError::StageFailed {
+                stage_idx,
+                elapsed_stages: idx as u32,
+                elapsed_ms: total_generation_ms,
+                inner,
+            })?;
 
             let frames_emitted = outcome.frames.len() as u32;
             stage_frames.push(outcome.frames);
@@ -657,10 +704,15 @@ mod tests {
         let mut renderer = FakeRenderer::new();
         let mut orch = Ltx2ChainOrchestrator::new(&mut renderer);
         let err = orch.run(&req, None).expect_err("empty stages must fail");
-        assert!(
-            format!("{err}").contains("has no stages"),
-            "error must name the missing stages, got: {err}",
-        );
+        match err {
+            ChainOrchestratorError::Invalid(inner) => {
+                assert!(
+                    format!("{inner}").contains("has no stages"),
+                    "error must name the missing stages, got: {inner}",
+                );
+            }
+            other => panic!("expected Invalid, got {other:?}"),
+        }
         assert!(renderer.calls.is_empty());
     }
 
@@ -677,10 +729,20 @@ mod tests {
         let err = orch
             .run(&req, None)
             .expect_err("mid-chain failure must bubble up");
-        assert!(
-            format!("{err}").contains("simulated GPU OOM"),
-            "error must carry the renderer's message, got: {err}",
-        );
+        match err {
+            ChainOrchestratorError::StageFailed {
+                stage_idx: 1,
+                elapsed_stages: 1,
+                inner,
+                ..
+            } => {
+                assert!(
+                    format!("{inner}").contains("simulated GPU OOM"),
+                    "inner error must carry the renderer's message, got: {inner}",
+                );
+            }
+            other => panic!("expected StageFailed at stage 1, got {other:?}"),
+        }
         // Stage 0 ran (recorded), stage 1 failed (recorded before bail),
         // stage 2 never ran.
         assert_eq!(renderer.calls.len(), 2);
@@ -809,10 +871,15 @@ mod tests {
         let mut renderer = FakeRenderer::new();
         let mut orch = Ltx2ChainOrchestrator::new(&mut renderer);
         let err = orch.run(&req, None).expect_err("must fail");
-        assert!(
-            format!("{err}").contains("motion_tail_frames"),
-            "error must name motion_tail_frames, got: {err}",
-        );
+        match err {
+            ChainOrchestratorError::Invalid(inner) => {
+                assert!(
+                    format!("{inner}").contains("motion_tail_frames"),
+                    "error must name motion_tail_frames, got: {inner}",
+                );
+            }
+            other => panic!("expected Invalid, got {other:?}"),
+        }
         // Renderer never gets called because validation runs up-front.
         assert!(renderer.calls.is_empty());
     }

--- a/crates/mold-inference/src/ltx2/media.rs
+++ b/crates/mold-inference/src/ltx2/media.rs
@@ -699,6 +699,53 @@ fn contact_sheet_image(frames: &[RgbImage]) -> Result<RgbImage> {
     Ok(sheet)
 }
 
+/// Cross-fade the last `fade_len` frames of clip N with the first
+/// `fade_len` frames of clip N+1. Returns a new `Vec<RgbImage>` of length
+/// `fade_len` with pixel-wise linear interpolation:
+///
+/// ```text
+/// out[i] = (1 - alpha) * tail[tail.len() - fade_len + i]
+///        +      alpha  * head[i]
+/// where alpha = i / fade_len
+/// ```
+///
+/// Panics if `tail.len() < fade_len` or `head.len() < fade_len`.
+pub fn fade_boundary(
+    tail: &[image::RgbImage],
+    head: &[image::RgbImage],
+    fade_len: u32,
+) -> Vec<image::RgbImage> {
+    let n = fade_len as usize;
+    assert!(
+        tail.len() >= n && head.len() >= n,
+        "tail and head must have length >= fade_len"
+    );
+    let tail_slice = &tail[tail.len() - n..];
+    let head_slice = &head[..n];
+    let (w, h) = tail_slice[0].dimensions();
+
+    let mut out = Vec::with_capacity(n);
+    for i in 0..n {
+        let alpha = i as f32 / fade_len as f32;
+        let inv = 1.0 - alpha;
+        let mut blended = image::RgbImage::new(w, h);
+        for y in 0..h {
+            for x in 0..w {
+                let a = tail_slice[i].get_pixel(x, y).0;
+                let b = head_slice[i].get_pixel(x, y).0;
+                let mixed = [
+                    (a[0] as f32 * inv + b[0] as f32 * alpha) as u8,
+                    (a[1] as f32 * inv + b[1] as f32 * alpha) as u8,
+                    (a[2] as f32 * inv + b[2] as f32 * alpha) as u8,
+                ];
+                blended.put_pixel(x, y, image::Rgb(mixed));
+            }
+        }
+        out.push(blended);
+    }
+    out
+}
+
 #[cfg(all(test, feature = "mp4"))]
 mod tests {
     use super::*;
@@ -918,5 +965,56 @@ mod tests {
         );
         assert_eq!(&wav[36..40], b"data");
         assert_eq!(u32::from_le_bytes([wav[40], wav[41], wav[42], wav[43]]), 16);
+    }
+}
+
+#[cfg(test)]
+mod fade_tests {
+    use super::*;
+    use image::RgbImage;
+
+    fn solid(w: u32, h: u32, rgb: [u8; 3]) -> RgbImage {
+        let mut img = RgbImage::new(w, h);
+        for px in img.pixels_mut() {
+            *px = image::Rgb(rgb);
+        }
+        img
+    }
+
+    #[test]
+    fn fade_length_matches_requested_fade_len() {
+        let tail = vec![solid(4, 4, [255, 0, 0]); 8];
+        let head = vec![solid(4, 4, [0, 255, 0]); 8];
+        let blended = fade_boundary(&tail, &head, 8);
+        assert_eq!(blended.len(), 8);
+    }
+
+    #[test]
+    fn fade_first_frame_matches_tail() {
+        let tail = vec![solid(2, 2, [200, 0, 0]); 4];
+        let head = vec![solid(2, 2, [0, 200, 0]); 4];
+        let blended = fade_boundary(&tail, &head, 4);
+        // alpha[0] = 0/4 = 0 → pure tail
+        let p = blended[0].get_pixel(0, 0);
+        assert_eq!(p.0, [200, 0, 0]);
+    }
+
+    #[test]
+    fn fade_last_frame_is_close_to_head() {
+        let tail = vec![solid(2, 2, [200, 0, 0]); 4];
+        let head = vec![solid(2, 2, [0, 200, 0]); 4];
+        let blended = fade_boundary(&tail, &head, 4);
+        // alpha[3] = 3/4 = 0.75 → 0.25*tail + 0.75*head = [50, 150, 0]
+        let p = blended[3].get_pixel(0, 0);
+        assert!((p.0[0] as i32 - 50).abs() <= 2, "R was {}", p.0[0]);
+        assert!((p.0[1] as i32 - 150).abs() <= 2, "G was {}", p.0[1]);
+    }
+
+    #[test]
+    #[should_panic(expected = "tail and head must have length >= fade_len")]
+    fn fade_shorter_than_fade_len_panics() {
+        let tail = vec![solid(1, 1, [0, 0, 0]); 2];
+        let head = vec![solid(1, 1, [0, 0, 0]); 2];
+        let _ = fade_boundary(&tail, &head, 4);
     }
 }

--- a/crates/mold-inference/src/ltx2/mod.rs
+++ b/crates/mold-inference/src/ltx2/mod.rs
@@ -16,7 +16,7 @@ pub mod stitch;
 mod text;
 
 pub use chain::{
-    extract_tail_latents, tail_latent_frame_count, ChainRunOutput, ChainStageRenderer, ChainTail,
-    Ltx2ChainOrchestrator, StageOutcome, StageProgressEvent,
+    extract_tail_latents, tail_latent_frame_count, ChainOrchestratorError, ChainRunOutput,
+    ChainStageRenderer, ChainTail, Ltx2ChainOrchestrator, StageOutcome, StageProgressEvent,
 };
 pub use pipeline::Ltx2Engine;

--- a/crates/mold-inference/src/ltx2/mod.rs
+++ b/crates/mold-inference/src/ltx2/mod.rs
@@ -12,6 +12,7 @@ mod plan;
 mod preset;
 mod runtime;
 mod sampler;
+pub mod stitch;
 mod text;
 
 pub use chain::{

--- a/crates/mold-inference/src/ltx2/pipeline.rs
+++ b/crates/mold-inference/src/ltx2/pipeline.rs
@@ -614,6 +614,12 @@ impl Ltx2Engine {
         // identity drift compounds stage-over-stage because each clip's
         // only long-range reference is its own drifted last-frame carry.
         if let Some(tail) = carry {
+            if req.source_image.is_some() {
+                tracing::warn!(
+                    "smooth continuation received source_image; it will be repurposed as a soft \
+                     identity anchor. Use transition: cut|fade to seed the stage with a fresh i2v."
+                );
+            }
             if tail.tail_rgb_frames.is_empty() {
                 bail!(
                     "render_chain_stage: carry.tail_rgb_frames is empty; caller must provide at least one frame"

--- a/crates/mold-inference/src/ltx2/stitch.rs
+++ b/crates/mold-inference/src/ltx2/stitch.rs
@@ -1,0 +1,190 @@
+//! Chain stitch planner.
+//!
+//! Takes the orchestrator's per-stage frame vectors and a parallel list of
+//! boundary transitions, and assembles a single output `Vec<RgbImage>`
+//! honouring the per-boundary rule:
+//! - `Smooth`: drop leading `motion_tail_frames` of the incoming clip.
+//! - `Cut`: concatenate as-is.
+//! - `Fade`: replace trailing `fade_len` of prior + leading `fade_len` of
+//!   incoming with a single blended block of `fade_len` frames.
+
+use image::RgbImage;
+use mold_core::TransitionMode;
+
+use crate::ltx2::media::fade_boundary;
+
+pub struct StitchPlan {
+    pub clips: Vec<Vec<RgbImage>>,
+    /// Transition on the incoming side of each boundary.
+    /// `boundaries.len() == clips.len() - 1`.
+    pub boundaries: Vec<TransitionMode>,
+    /// Per-boundary fade length in pixel frames. For non-fade boundaries
+    /// the value is ignored. `fade_lens.len() == clips.len() - 1`.
+    pub fade_lens: Vec<u32>,
+    pub motion_tail_frames: u32,
+}
+
+impl StitchPlan {
+    /// Assemble the final stitched frame vector. Consumes `self.clips`.
+    pub fn assemble(mut self) -> Result<Vec<RgbImage>, StitchError> {
+        if self.clips.is_empty() {
+            return Err(StitchError::NoClips);
+        }
+        let expected_boundaries = self.clips.len() - 1;
+        if self.boundaries.len() != expected_boundaries {
+            return Err(StitchError::BoundaryMismatch {
+                clips: self.clips.len(),
+                boundaries: self.boundaries.len(),
+            });
+        }
+        if self.fade_lens.len() != expected_boundaries {
+            return Err(StitchError::FadeLenMismatch);
+        }
+
+        // Validate each boundary's lengths up front so we fail before any work.
+        for (i, &t) in self.boundaries.iter().enumerate() {
+            let prior = &self.clips[i];
+            let next = &self.clips[i + 1];
+            match t {
+                TransitionMode::Smooth => {
+                    let need = self.motion_tail_frames as usize;
+                    if next.len() < need {
+                        return Err(StitchError::ClipTooShortForTrim {
+                            stage: i + 1,
+                            have: next.len(),
+                            need,
+                        });
+                    }
+                }
+                TransitionMode::Cut => {}
+                TransitionMode::Fade => {
+                    let fl = self.fade_lens[i] as usize;
+                    if prior.len() < fl || next.len() < fl {
+                        return Err(StitchError::ClipTooShortForFade {
+                            stage: i + 1,
+                            fade_len: fl,
+                        });
+                    }
+                }
+            }
+        }
+
+        // Stage 0 goes in whole; trim/blend on each incoming boundary.
+        let mut out: Vec<RgbImage> = Vec::new();
+        let mut clips = std::mem::take(&mut self.clips).into_iter();
+        let first = clips.next().unwrap();
+        out.extend(first);
+
+        for (i, next_clip) in clips.enumerate() {
+            match self.boundaries[i] {
+                TransitionMode::Smooth => {
+                    let drop = self.motion_tail_frames as usize;
+                    out.extend(next_clip.into_iter().skip(drop));
+                }
+                TransitionMode::Cut => {
+                    out.extend(next_clip);
+                }
+                TransitionMode::Fade => {
+                    let fl = self.fade_lens[i];
+                    let fl_usize = fl as usize;
+                    // Pull the trailing fade_len frames off `out` (they're
+                    // the tail of the prior clip now that it's been pushed).
+                    let tail_start = out.len() - fl_usize;
+                    let tail: Vec<RgbImage> = out.drain(tail_start..).collect();
+                    let blended = fade_boundary(&tail, &next_clip, fl);
+                    out.extend(blended);
+                    // Append the post-fade remainder of next_clip.
+                    out.extend(next_clip.into_iter().skip(fl_usize));
+                }
+            }
+        }
+        Ok(out)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum StitchError {
+    #[error("stitch plan has no clips")]
+    NoClips,
+    #[error("stitch plan has {clips} clips but {boundaries} boundaries (expected {})", clips.saturating_sub(1))]
+    BoundaryMismatch { clips: usize, boundaries: usize },
+    #[error("fade_lens length does not match boundaries length")]
+    FadeLenMismatch,
+    #[error("stage {stage} has {have} frames, needs at least {need} for motion-tail trim")]
+    ClipTooShortForTrim {
+        stage: usize,
+        have: usize,
+        need: usize,
+    },
+    #[error("stage {stage} is shorter than fade_len {fade_len}")]
+    ClipTooShortForFade { stage: usize, fade_len: usize },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use image::RgbImage;
+
+    fn solid(w: u32, h: u32, rgb: [u8; 3]) -> RgbImage {
+        let mut img = RgbImage::new(w, h);
+        for px in img.pixels_mut() {
+            *px = image::Rgb(rgb);
+        }
+        img
+    }
+
+    fn clip(len: usize, rgb: [u8; 3]) -> Vec<RgbImage> {
+        (0..len).map(|_| solid(2, 2, rgb)).collect()
+    }
+
+    #[test]
+    fn all_smooth_drops_motion_tail() {
+        let plan = StitchPlan {
+            clips: vec![clip(97, [0, 0, 0]); 3],
+            boundaries: vec![TransitionMode::Smooth, TransitionMode::Smooth],
+            fade_lens: vec![0, 0],
+            motion_tail_frames: 25,
+        };
+        let out = plan.assemble().unwrap();
+        assert_eq!(out.len(), 97 + 72 + 72);
+    }
+
+    #[test]
+    fn all_cut_keeps_everything() {
+        let plan = StitchPlan {
+            clips: vec![clip(97, [0, 0, 0]); 3],
+            boundaries: vec![TransitionMode::Cut, TransitionMode::Cut],
+            fade_lens: vec![0, 0],
+            motion_tail_frames: 25,
+        };
+        let out = plan.assemble().unwrap();
+        assert_eq!(out.len(), 97 * 3);
+    }
+
+    #[test]
+    fn fade_boundary_consumes_2x_fade_len_net() {
+        let plan = StitchPlan {
+            clips: vec![clip(97, [255, 0, 0]), clip(97, [0, 255, 0])],
+            boundaries: vec![TransitionMode::Fade],
+            fade_lens: vec![8],
+            motion_tail_frames: 25,
+        };
+        let out = plan.assemble().unwrap();
+        // 97 + (97 - 8) = 186
+        assert_eq!(out.len(), 186);
+    }
+
+    #[test]
+    fn mismatched_boundaries_errors() {
+        let plan = StitchPlan {
+            clips: vec![clip(97, [0, 0, 0]); 3],
+            boundaries: vec![TransitionMode::Smooth], // expected 2
+            fade_lens: vec![0, 0],
+            motion_tail_frames: 25,
+        };
+        assert!(matches!(
+            plan.assemble().unwrap_err(),
+            StitchError::BoundaryMismatch { .. }
+        ));
+    }
+}

--- a/crates/mold-server/src/routes_chain.rs
+++ b/crates/mold-server/src/routes_chain.rs
@@ -366,7 +366,18 @@ async fn run_chain(
     let chain_output = outcome?;
     let stage_count = chain_output.stage_count;
     let generation_time_ms = chain_output.generation_time_ms;
-    let mut frames = chain_output.frames;
+
+    // Temporary — replaced with StitchPlan::assemble in Task 2.4/2.6.
+    // Naïve smooth-only concat + motion-tail trim on continuations.
+    let motion_tail = req.motion_tail_frames as usize;
+    let mut frames: Vec<image::RgbImage> = Vec::new();
+    for (idx, stage_clip) in chain_output.stage_frames.into_iter().enumerate() {
+        if idx == 0 {
+            frames.extend(stage_clip);
+        } else {
+            frames.extend(stage_clip.into_iter().skip(motion_tail));
+        }
+    }
     trim_to_total_frames(&mut frames, req.total_frames);
 
     if frames.is_empty() {

--- a/crates/mold-server/src/routes_chain.rs
+++ b/crates/mold-server/src/routes_chain.rs
@@ -282,8 +282,10 @@ enum ChainRunError {
     UnsupportedModel(String),
     /// Engine missing from cache after `ensure_model_ready` (500).
     CacheMiss(String),
-    /// Orchestrator returned an error mid-chain (502).
+    /// Orchestrator returned an error mid-chain from an invalid request (502).
     Inference(String),
+    /// Orchestrator returned a typed stage failure mid-chain (502 with body).
+    StageFailed(mold_core::chain::ChainFailure),
     /// Output encoding failure (500).
     Encode(String),
     /// `StitchPlan::assemble` failed (500).
@@ -300,6 +302,16 @@ impl From<ChainRunError> for ApiError {
             ChainRunError::Inference(msg) => {
                 ApiError::internal_with_status(msg, axum::http::StatusCode::BAD_GATEWAY)
             }
+            // The SSE error channel is string-only (`ChainSseMessage::Error(String)`),
+            // so the structured fields (`failed_stage_idx`, `elapsed_stages`,
+            // `elapsed_ms`) are deliberately collapsed to `stage_error` here.
+            // Clients that need the typed shape use the non-streaming
+            // `/api/generate/chain` handler which returns a `ChainFailure`
+            // body at status 502.
+            ChainRunError::StageFailed(failure) => ApiError::internal_with_status(
+                failure.stage_error,
+                axum::http::StatusCode::BAD_GATEWAY,
+            ),
             ChainRunError::Encode(msg) => ApiError::internal(msg),
             ChainRunError::StitchFailed(msg) => ApiError::internal(msg),
             ChainRunError::Internal(msg) => ApiError::internal(msg),
@@ -363,7 +375,26 @@ async fn run_chain(
                     } else {
                         orch.run(&req_for_task, None)
                     };
-                    result.map_err(|e| ChainRunError::Inference(format!("{e:#}")))
+                    result.map_err(|e| {
+                        use mold_inference::ltx2::ChainOrchestratorError;
+                        match e {
+                            ChainOrchestratorError::StageFailed {
+                                stage_idx,
+                                elapsed_stages,
+                                elapsed_ms,
+                                inner,
+                            } => ChainRunError::StageFailed(mold_core::chain::ChainFailure {
+                                error: "stage render failed".into(),
+                                failed_stage_idx: stage_idx,
+                                elapsed_stages,
+                                elapsed_ms,
+                                stage_error: format!("{inner:#}"),
+                            }),
+                            ChainOrchestratorError::Invalid(inner) => {
+                                ChainRunError::Inference(format!("{inner:#}"))
+                            }
+                        }
+                    })
                 }
                 None => Err(ChainRunError::UnsupportedModel(format!(
                     "model '{}' does not support chained video generation",
@@ -467,16 +498,20 @@ async fn run_chain(
         (status = 200, description = "Stitched chain video", body = mold_core::ChainResponse),
         (status = 422, description = "Invalid request or unsupported model"),
         (status = 500, description = "Chain render failed"),
-        (status = 502, description = "Chain render failed mid-stage"),
+        (status = 502, description = "Chain render failed mid-stage", body = mold_core::ChainFailure),
     )
 )]
 pub async fn generate_chain(
     State(state): State<AppState>,
     Json(req): Json<ChainRequest>,
-) -> Result<Json<ChainResponse>, ApiError> {
-    let req = req
-        .normalise()
-        .map_err(|e| ApiError::validation(e.to_string()))?;
+) -> axum::response::Response {
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse;
+
+    let req = match req.normalise() {
+        Ok(r) => r,
+        Err(e) => return ApiError::validation(e.to_string()).into_response(),
+    };
 
     tracing::info!(
         model = %req.model,
@@ -487,8 +522,13 @@ pub async fn generate_chain(
         "generate/chain request"
     );
 
-    let (response, _elapsed_ms) = run_chain(&state, req, None).await?;
-    Ok(Json(response))
+    match run_chain(&state, req, None).await {
+        Ok((response, _elapsed_ms)) => Json(response).into_response(),
+        Err(ChainRunError::StageFailed(failure)) => {
+            (StatusCode::BAD_GATEWAY, Json(failure)).into_response()
+        }
+        Err(other) => ApiError::from(other).into_response(),
+    }
 }
 
 /// `POST /api/generate/chain/stream` — SSE-streamed chain generation. Emits
@@ -772,14 +812,51 @@ mod tests {
             .await
             .expect_err("mid-chain failure must bubble up");
         match err {
-            ChainRunError::Inference(msg) => {
+            ChainRunError::StageFailed(failure) => {
+                assert_eq!(
+                    failure.failed_stage_idx, 1,
+                    "failed_stage_idx must be 1, got {}",
+                    failure.failed_stage_idx
+                );
                 assert!(
-                    msg.contains("simulated chain failure"),
-                    "inference error must carry renderer message, got: {msg}"
+                    failure.stage_error.contains("simulated chain failure"),
+                    "stage_error must carry renderer message, got: {}",
+                    failure.stage_error
                 );
             }
-            other => panic!("expected Inference error, got {other:?}"),
+            other => panic!("expected StageFailed error, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn generate_chain_handler_returns_502_with_chain_failure_body() {
+        use axum::body::to_bytes;
+        use axum::http::StatusCode;
+        use axum::response::IntoResponse;
+
+        let engine = ChainMockEngine::failing_at(1);
+        let state = state_with_chain_engine(engine);
+        let req = chain_req_for_mock("ltx-2-19b-distilled:mock", 3);
+
+        let resp = generate_chain(State(state), Json(req)).await;
+        let (parts, body) = resp.into_response().into_parts();
+
+        assert_eq!(parts.status, StatusCode::BAD_GATEWAY, "must be 502");
+
+        let bytes = to_bytes(body, usize::MAX).await.unwrap();
+        let failure: mold_core::chain::ChainFailure =
+            serde_json::from_slice(&bytes).expect("body must be ChainFailure JSON");
+
+        assert_eq!(
+            failure.failed_stage_idx, 1,
+            "failed_stage_idx must be 1, got {}",
+            failure.failed_stage_idx
+        );
+        assert!(
+            failure.stage_error.contains("simulated chain failure"),
+            "stage_error must carry renderer message, got: {}",
+            failure.stage_error
+        );
     }
 
     #[tokio::test]

--- a/crates/mold-server/src/routes_chain.rs
+++ b/crates/mold-server/src/routes_chain.rs
@@ -169,6 +169,30 @@ fn trim_to_total_frames(frames: &mut Vec<image::RgbImage>, total_frames: Option<
     }
 }
 
+/// Assemble per-stage frame clips into a single output buffer using
+/// [`mold_inference::ltx2::stitch::StitchPlan`], honouring per-boundary
+/// transition rules (Smooth / Cut / Fade).
+pub(crate) fn stitch_chain_output(
+    chain_output: mold_inference::ltx2::chain::ChainRunOutput,
+    req: &mold_core::chain::ChainRequest,
+) -> Result<Vec<image::RgbImage>, mold_inference::ltx2::stitch::StitchError> {
+    use mold_inference::ltx2::stitch::StitchPlan;
+    let boundaries: Vec<_> = req.stages.iter().skip(1).map(|s| s.transition).collect();
+    let fade_lens: Vec<_> = req
+        .stages
+        .iter()
+        .skip(1)
+        .map(|s| s.fade_frames.unwrap_or(8))
+        .collect();
+    let plan = StitchPlan {
+        clips: chain_output.stage_frames,
+        boundaries,
+        fade_lens,
+        motion_tail_frames: req.motion_tail_frames,
+    };
+    plan.assemble()
+}
+
 /// Produce a PNG thumbnail for the chain output — best-effort, returns
 /// an empty `Vec` on failure so the save/response paths still succeed.
 fn chain_thumbnail(frames: &[image::RgbImage]) -> Vec<u8> {
@@ -260,8 +284,10 @@ enum ChainRunError {
     CacheMiss(String),
     /// Orchestrator returned an error mid-chain (502).
     Inference(String),
-    /// Output encoding / stitch failure (500).
+    /// Output encoding failure (500).
     Encode(String),
+    /// `StitchPlan::assemble` failed (500).
+    StitchFailed(String),
     /// Task panic or join error (500).
     Internal(String),
 }
@@ -275,6 +301,7 @@ impl From<ChainRunError> for ApiError {
                 ApiError::internal_with_status(msg, axum::http::StatusCode::BAD_GATEWAY)
             }
             ChainRunError::Encode(msg) => ApiError::internal(msg),
+            ChainRunError::StitchFailed(msg) => ApiError::internal(msg),
             ChainRunError::Internal(msg) => ApiError::internal(msg),
         }
     }
@@ -367,17 +394,8 @@ async fn run_chain(
     let stage_count = chain_output.stage_count;
     let generation_time_ms = chain_output.generation_time_ms;
 
-    // Temporary — replaced with StitchPlan::assemble in Task 2.4/2.6.
-    // Naïve smooth-only concat + motion-tail trim on continuations.
-    let motion_tail = req.motion_tail_frames as usize;
-    let mut frames: Vec<image::RgbImage> = Vec::new();
-    for (idx, stage_clip) in chain_output.stage_frames.into_iter().enumerate() {
-        if idx == 0 {
-            frames.extend(stage_clip);
-        } else {
-            frames.extend(stage_clip.into_iter().skip(motion_tail));
-        }
-    }
+    let mut frames = stitch_chain_output(chain_output, &req)
+        .map_err(|e| ChainRunError::StitchFailed(e.to_string()))?;
     trim_to_total_frames(&mut frames, req.total_frames);
 
     if frames.is_empty() {

--- a/tasks/multi-prompt-chain-v2-resume-phase2.md
+++ b/tasks/multi-prompt-chain-v2-resume-phase2.md
@@ -1,0 +1,221 @@
+# multi-prompt-chain v2 — session 2 resume handoff
+
+> Paste the prompt at the bottom of this file into a fresh Claude Code session
+> to continue sub-project A starting from **Task 2.7**. Everything above the
+> prompt is reference material.
+
+## Status on handoff (2026-04-22)
+
+### Branch & PR
+
+- Working branch: `feat/multi-prompt-chain-v2` (local)
+- **Phase 1 PR:** [utensils/mold#266](https://github.com/utensils/mold/pull/266) — **open, not merged**. Title: `feat(chain): wire format + TOML I/O + capabilities endpoint (Phase 1/6)`. Remote head: `adac9b1`.
+- **Tasks 2.1–2.6 are local only** on top of Phase 1 — NOT pushed yet (no mid-phase pushes per handoff discipline). The fresh session should continue adding Phase 2 commits and push once Phase 2 is gate-green, opening the Phase 2 PR stacked on the Phase 1 branch.
+
+### Local git state
+
+Current HEAD: `de01ed8`. Local commits ahead of `origin/feat/multi-prompt-chain-v2`:
+
+```
+de01ed8 feat(server): chain route uses StitchPlan for per-boundary stitch
+90cadd1 feat(ltx2): source_image honored on Cut/Fade continuation stages
+81e1216 feat(ltx2): StitchPlan assembler with per-boundary rules
+f986e4f feat(ltx2): fade_boundary helper for post-stitch crossfade
+0908597 feat(ltx2): orchestrator passes None carry for cut/fade stages
+13a78b9 feat(ltx2): expose per-stage frames from chain orchestrator
+---  adac9b1 (origin/feat/multi-prompt-chain-v2, last pushed)  ---
+adac9b1 chore(chain): sync Cargo.lock after adding tracing dep to mold-core
+ddd39e4 feat(chain): echo ChainScript in SseChainCompleteEvent + consume in client
+cfb2b6c feat(server): /api/capabilities/chain-limits endpoint
+b9adb3d feat(server): ChainLimits shape + family-cap lookup
+b6a9249 feat(chain): re-export new wire types from mold-core
+8825f5c test(chain): TOML round-trip + normalisation invariants
+7ec6efb feat(chain): TOML reader with schema version gate
+29d0e15 feat(chain): chain_toml module with script writer
+fb3d095 feat(chain): add estimated_total_frames with transition-aware math
+79089ae feat(chain): normalise coerces stage 0 transition + rejects reserved fields
+b68cbbb feat(chain): add ChainScript canonical echo + VramEstimate slot
+6445cd4 feat(chain): extend ChainStage with transition/fade_frames + reserved fields
+0e17516 feat(chain): reserve LoraSpec and NamedRef wire types for sub-project B
+89035c1 feat(chain): add TransitionMode enum with smooth/cut/fade variants
+3df5e34 docs(chain): multi-prompt chain v2 implementation plan
+9cd8860 docs(chain): multi-prompt chain v2 authoring design spec
+```
+
+CI gate at each commit: `cargo fmt --all -- --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace` — all green for every commit above (there's a **pre-existing flake** on `theme_save_then_load_round_trip_preserves_preset` in `mold-ai-tui` under parallel workspace tests; retry if it's the only failure — see `project_tui_theme_test_flake.md` in user memory).
+
+### Phase progress
+
+| Phase | Tasks | Status |
+|---|---|---|
+| 1 | 1.1–1.14 | ✅ complete, PR #266 open |
+| 2 | 2.1–2.9 | **in progress** — 2.1–2.6 committed locally; 2.6 is unreviewed; 2.7–2.9 pending |
+| 3 | 3.1–3.7 | pending (blocked on Phase 2) |
+| 4 | 4.1–4.8 | pending (blocked on Phase 2) |
+| 5 | 5.1–5.10 | pending (blocked on Phase 2) |
+| 6 | 6.1–6.4 | pending (blocked on Phase 3/4/5) |
+
+### Review notes for already-committed tasks
+
+Tasks 2.1–2.5 had combined spec+quality reviews dispatched via subagent and came back APPROVED with only Minor issues flagged. Task 2.6 (`de01ed8`, StitchPlan wired into routes_chain) is **committed but not yet reviewed** — fmt/clippy/workspace-tests all pass. Fresh session should dispatch a combined review for 2.6 before starting 2.7.
+
+Outstanding Minor issues deferred to later tasks (not blocking):
+
+- **Stale test name in `ltx2::chain`** (`chain_runs_all_stages_and_drops_tail_prefix_from_continuations`) — orchestrator no longer trims since 2.1; test body still correct but name is misleading. Rename opportunity in 2.8.
+- **`Stitching` progress event over-reports by `(N-1) * motion_tail`** — cosmetic; progress bar length uses `ChainStart.estimated_total_frames` not this. Worth fixing alongside 2.7.
+- **`StitchPlan::assemble` on Smooth when next clip shorter than `motion_tail_frames`** returns `ClipTooShortForTrim` — this case should be prevented upstream by `ChainRequest::normalise`'s `motion_tail < stage.frames` check, but worth confirming the error propagates as a typed 500/502 in 2.7.
+
+## What's left on Phase 2 (3 tasks)
+
+### Task 2.7 — Enrich mid-chain 502 payload
+
+- Add `ChainFailure` type to `crates/mold-core/src/chain.rs` (fields: `error`, `failed_stage_idx`, `elapsed_stages`, `elapsed_ms`, `stage_error`) + re-export from `lib.rs`.
+- `Ltx2ChainOrchestrator::run` needs to return a typed error with the stage index embedded (new enum variant on `ChainRunError` or similar), so `routes_chain.rs` can map to 502 with `ChainFailure` JSON.
+- Route test: inject `FakeRenderer` with `fail_on: vec![(1, "boom".into())]`, assert 502 response body shape.
+- Plan file: `docs/superpowers/plans/2026-04-21-multi-prompt-chain-v2.md` Task 2.7 (~line 2504).
+- Commit scope: `feat(chain)`.
+
+### Task 2.8 — End-to-end mixed-transition test via FakeRenderer
+
+- Add `mixed_transitions_end_to_end` test to `crates/mold-inference/src/ltx2/chain.rs` (inside `#[cfg(test)] mod tests`).
+- Uses existing `FakeRenderer` + `sample_chain_request` helpers from Task 2.1/2.2.
+- Builds a 4-stage chain (Smooth / Smooth / Cut / Fade(8)), drives orchestrator, pipes `stage_frames` through `StitchPlan::assemble`, asserts `frames.len() == 355` (= `97 + 72 + 97 + 89`).
+- Plan file ~line 2563. Commit scope: `test(chain)`.
+
+### Task 2.9 — Phase 2 gate
+
+1. `cargo fmt --all`
+2. `cargo clippy --workspace --all-targets -- -D warnings`
+3. `cargo test --workspace`
+4. **Killswitch box end-to-end renders** (requires SSH access to `killswitch@192.168.1.67`, mold repo at `~/github/mold`, sm_86 CUDA build):
+   - 3-stage all-smooth chain
+   - 3-stage all-cut chain
+   - 3-stage all-fade chain
+   - mixed (smooth/cut/fade)
+   - Visual inspection of output MP4s for seam quality
+5. Open Phase 2 PR titled `feat(ltx2): engine transitions (cut/fade/stitch) (Phase 2/6)`.
+
+**If the killswitch box is unreachable** from the session, the fresh session should leave Phase 2 at the unit-test/integration-test level (green there) and flag the user to do the manual smoke before merging Phase 2.
+
+## What's left after Phase 2
+
+**Phase 3** (CLI surface, 7 tasks) — `--script shot.toml`, `--dry-run`, repeated `--prompt` sugar, `mold chain validate` subcommand, progress display with transition tags. Plan section starts at line 2674.
+
+**Phase 4** (TUI script mode, 8 tasks) — `ScriptComposer` ratatui widget, stage list nav `j/k/J/K`, add/delete `a/A/d`, transition cycle `t`, prompt/frames editors `i/f`, TOML save/load `Ctrl-S/Ctrl-O`, submit `Enter`, `tui-uat.sh` scenario. Plan section starts at line 3295.
+
+**Phase 5** (Web composer script mode, 10 tasks) — `smol-toml` (or `@iarna/toml` fallback) dep, `chainToml.ts`, `fetchChainLimits`, `StageCard.vue`, `ScriptComposer.vue`, mode toggle on `Composer.vue`, chain submit, per-stage expand modal, drag-reorder via `vue-draggable-plus`, footer chain-limits clamp, `bun run verify && bun run build` gate. Plan section starts at line 3907.
+
+**Phase 6** (Docs + release, 4 tasks) — `website/guide/video.md`, `CHANGELOG.md [Unreleased]`, `.claude/skills/mold/SKILL.md`, `CLAUDE.md`. Each a separate `docs(chain)` commit. Plan section starts at line 4603.
+
+Dependency graph: `Phase 2 → {3, 4, 5}` (concurrent) `→ 6`. After Phase 2 lands, the fresh session can dispatch Phases 3/4/5 in parallel using separate subagent-driven flows — though sequential is also fine and easier to track.
+
+## Working conventions to preserve
+
+- **One scope per commit** — `feat(chain) / feat(ltx2) / feat(server) / feat(cli) / feat(tui) / feat(web) / test(chain) / docs(chain)`.
+- **No mid-phase pushes** — each phase is one PR when complete.
+- **TDD** — failing test first, then implementation, then verify pass, then commit. Deviations (e.g. Task 2.3 skipped the explicit fail verify) should be rare and only for pure-math helpers where Step 2 adds no real signal.
+- **`superpowers:subagent-driven-development`** — fresh general-purpose subagent per task. Sonnet for mechanical tasks, opus only if the task requires architectural judgment. Combined spec+quality review works well for plan-verbatim tasks; split into two-stage for complex/cross-crate work.
+- **Prompt the subagent with full task text** — don't send a "read the plan and implement 2.7" instruction. Paste the plan's text inline and flag pre-investigation findings (manifest API differences, existing construction sites, etc.) so the subagent doesn't re-discover them.
+- **Pre-grep before dispatching** — when a task changes a public struct (like `ChainStage` did), `grep -rn 'StructName {' crates/` across the workspace and list every construction site in the brief. CI's `cargo test --workspace` contract is what forces cross-crate scope expansion; the plan's file-list is often incomplete for that reason.
+
+## Gotchas the new session should know
+
+- **`MoldError::Other`** takes `anyhow::Error`, not `String` — use `MoldError::Other(anyhow::anyhow!(...))`.
+- **`mold_core::manifest`** has `find_manifest(&name).map(|m| m.family.clone())` for family lookup; there's no `resolve_family` or `resolve_quant` despite what the plan hints at. Quant = `name.split_once(':').map(|(_, t)| t.to_string()).unwrap_or_default()`.
+- **`toml-rs` sorts keys alphabetically** within tables — force the `schema = "..."` header to the top manually in `write_script` (Task 1.7 already handled this with a replace-and-prepend fallback).
+- **`#[serde(default)]` on required struct fields** needs a `Default` impl. `ChainScript` + `ChainScriptChain` derive `Default` as of Task 1.13; `OutputFormat::Png` is the `#[default]` variant so `ChainScriptChain::default().output_format == Png` — semantically weird for a video context but only used for serde fallback deserialization. See commit `ddd39e4` for the "placeholder with odd default" note.
+- **`ChainSseMessage::Complete(Box<SseChainCompleteEvent>)`** — Task 1.13 boxed this after adding `script`/`vram_estimate` to silence `large_enum_variant`. If you add more fields to `SseChainCompleteEvent`, keep the box; don't un-box.
+- **`placeholder_for_sse_transition`** helper was deleted in Task 1.13. Don't resurrect it.
+- **TUI theme test flake** — see user auto-memory `project_tui_theme_test_flake.md`. If only `theme_save_then_load_round_trip_preserves_preset` fails under `cargo test --workspace`, retry once. Not your regression.
+
+## Verification commands the new session will need
+
+```bash
+# Pre-flight: confirm branch state
+cd /Users/jeffreydilley/github/mold
+git log --oneline origin/main..HEAD | head -25
+# Should show 16 commits (Phase 1 + 2.1–2.6 + docs).
+
+# Sanity check CI before writing any new code
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace  # retry once if only TUI flake fires
+
+# Once Phase 2 is complete, push + open PR
+git push
+gh pr create --title "feat(ltx2): engine transitions (cut/fade/stitch) (Phase 2/6)" \
+  --body "..."  # stack on Phase 1 branch
+```
+
+## Spec & plan references
+
+- Spec: `docs/superpowers/specs/2026-04-21-multi-prompt-chain-v2-design.md` (681 lines). §3 decisions are NOT up for debate.
+- Plan: `docs/superpowers/plans/2026-04-21-multi-prompt-chain-v2.md` (4805 lines, 51 tasks).
+- Prior handoff: `tasks/multi-prompt-chain-v2-handoff.md` (the session-1 kickoff prompt).
+- Prior-art handoff for style: `tasks/render-chain-v1-handoff.md` (the v1 chain plan executed with the same conventions).
+
+---
+
+## The prompt
+
+Paste from here into a fresh Claude Code session:
+
+---
+
+I'm resuming execution of **multi-prompt chain v2, sub-project A** for the mold repo, starting at **Task 2.7** (mid-Phase 2). This is session 2 of a multi-session project.
+
+## Read first, in this order
+
+1. `~/.claude-personal/CLAUDE.md` (global) and `/Users/jeffreydilley/github/mold/CLAUDE.md` (project) — coding conventions.
+2. `tasks/multi-prompt-chain-v2-resume-phase2.md` — **your primary briefing**. Read end-to-end. Status, gotchas, completion map, working conventions.
+3. `docs/superpowers/specs/2026-04-21-multi-prompt-chain-v2-design.md` — approved design. §3 decisions not up for debate.
+4. `docs/superpowers/plans/2026-04-21-multi-prompt-chain-v2.md` — 51-task plan. You'll be executing 2.7 onward.
+5. `tasks/multi-prompt-chain-v2-handoff.md` — session-1 kickoff prompt (for context on how Phase 1 was run).
+
+## Status on entry
+
+- Branch: `feat/multi-prompt-chain-v2`, HEAD `de01ed8`. Phase 1 PR open at [utensils/mold#266](https://github.com/utensils/mold/pull/266). Tasks 2.1–2.6 local only (no mid-phase pushes).
+- Task 2.6 (`de01ed8`, StitchPlan wired into routes_chain) is committed, tests pass, but **not yet dispatched through a spec+quality review**. Your first action should be to dispatch that review before starting 2.7.
+- Design is approved. Plan is approved. No more brainstorming.
+
+## What you're doing
+
+Execute Tasks **2.7 → 2.8 → 2.9** (Phase 2 finish) via `superpowers:subagent-driven-development`. Then Phase 2 PR, then Phases 3/4/5 (concurrent ok) + 6. Use `superpowers:verification-before-completion` before declaring any phase done. TDD discipline per task.
+
+Gate every phase with `cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace` (plus `bun run verify` / `bun run build` for Phase 5). **No mid-phase pushes.** One PR per phase.
+
+## How to work
+
+- **Primary skill:** `superpowers:subagent-driven-development`. The plan is sized for it. One fresh subagent per task.
+- **Verification skill:** `superpowers:verification-before-completion` before claiming any phase done.
+- **Review discipline:** combined spec+quality review is fine for plan-verbatim mechanical tasks; split into two-stage for complex/cross-crate work. Session 1 used sonnet for implementers and reviewers — that worked well.
+- **Pre-grep before dispatching** — when a task changes a public type, `grep -rn 'TypeName {' crates/` across the workspace and enumerate construction sites in the brief. CI `cargo test --workspace` will break if you miss any.
+- **Paste full task text** to each subagent — don't make them read the plan file.
+
+## Start here
+
+1. Confirm branch state:
+   ```bash
+   cd /Users/jeffreydilley/github/mold
+   git log --oneline origin/main..HEAD | head -20
+   git status  # should be clean
+   cargo test --workspace  # green; retry once on TUI flake if it fires
+   ```
+   You should see `de01ed8` at the top of the log.
+
+2. Dispatch the **deferred spec+quality review for Task 2.6** (`de01ed8`). The implementer claimed DONE with all gates green but no reviewer has seen it. Acceptance criteria and context are in `tasks/multi-prompt-chain-v2-resume-phase2.md` under "Review notes for already-committed tasks".
+
+3. Start Task 2.7 (`ChainFailure` typed error). Pre-investigation to do:
+   - `grep -n 'ChainRunError' crates/mold-server/src/routes_chain.rs` — current error enum.
+   - `grep -n 'bail!' crates/mold-inference/src/ltx2/chain.rs | head` — current orchestrator error surface (stringly-typed via `anyhow::Context`).
+   - Decide: do you add a `StageFailed { stage_idx, elapsed_stages, elapsed_ms, inner }` variant on the orchestrator's error type, or propagate via a new `OrchestratorError` wrapper? Plan §2.7 sketches the former.
+
+4. Task 2.8 (`mixed_transitions_end_to_end` test) is a straightforward test addition — use the existing `FakeRenderer` and `sample_chain_request` helpers already added in Tasks 2.1/2.2.
+
+5. Task 2.9 (Phase 2 gate) — fmt + clippy + test + manual killswitch smoke. If killswitch is unreachable, green the unit/integration layer and flag to the user before opening the Phase 2 PR.
+
+6. Open the Phase 2 PR: title `feat(ltx2): engine transitions (cut/fade/stitch) (Phase 2/6)`. It stacks on the Phase 1 branch (target: `main`); link Phase 1 PR #266 in the body.
+
+## If you hit a surprise
+
+If a type signature doesn't match, a test harness is harder than the plan assumed, a clippy lint the plan's code would trigger, a model-family hardcode that conflicts with live manifest state — **stop, capture the surprise, ask the user before pressing forward.** The handoff `tasks/multi-prompt-chain-v2-handoff.md` (session 1) documents the expected gotchas; anything beyond that list is a real surprise.

--- a/tasks/multi-prompt-chain-v2-resume-phase3.md
+++ b/tasks/multi-prompt-chain-v2-resume-phase3.md
@@ -1,0 +1,248 @@
+# multi-prompt-chain v2 — session 3 resume handoff
+
+> Paste the prompt at the bottom of this file into a fresh Claude Code session
+> to continue sub-project A starting from **Phase 3**. Everything above the
+> prompt is reference material.
+
+## Status on handoff (2026-04-22)
+
+### Branches & PRs
+
+| Phase | Branch | PR | State | Base |
+|---|---|---|---|---|
+| 1 | `feat/multi-prompt-chain-v2` | [#266](https://github.com/utensils/mold/pull/266) | open | `main` |
+| 2 | `feat/multi-prompt-chain-v2-phase2` | [#267](https://github.com/utensils/mold/pull/267) | open, stacked on #266 | `feat/multi-prompt-chain-v2` |
+| 3/4/5/6 | — | — | not started | — |
+
+**Stacking rule for future phases:** each phase gets its own branch `feat/multi-prompt-chain-v2-phaseN` stacked on the predecessor branch. When #266 merges to `main`, GitHub auto-retargets #267 to `main`. Same pattern for subsequent phases.
+
+### Phase 2 automated gate (green on HEAD `10f435a`)
+
+- `cargo fmt --all -- --check` ✓
+- `cargo clippy --workspace --all-targets -- -D warnings` ✓
+- `cargo test --workspace` ✓ — full suite green, no TUI flake this run
+
+### Phase 2 manual verification (pending)
+
+**Killswitch end-to-end smoke on `killswitch@192.168.1.67` (CUDA sm_86) is NOT yet done.** The plan called for three renders (smooth / cut / fade / mixed) with visual inspection of seam quality. This is user work — the renders complete on the GPU, but whether the seams *look right* is a human judgment.
+
+To run it:
+
+```bash
+ssh killswitch@192.168.1.67
+cd ~/github/mold
+git fetch origin feat/multi-prompt-chain-v2-phase2
+git checkout feat/multi-prompt-chain-v2-phase2
+CUDA_COMPUTE_CAP=86 nix build .#mold
+./result/bin/mold serve --bind 0.0.0.0 --port 7680 &
+
+# Per chain_smooth/cut/fade/mixed.json, POST to /api/generate/chain and
+# scp the MP4s back. Visual acceptance criteria are in PR #267's body.
+```
+
+If the smoke reveals a regression, fix on `feat/multi-prompt-chain-v2-phase2` and update #267. If it passes, flag that in the PR.
+
+### Deferred minors (tracked in PR #267 body)
+
+- Task 2.6: dedicated route-layer Cut/Fade test is missing (covered at adjacent layers).
+- Task 2.6: `fade_frames.unwrap_or(8)` duplicates `DEFAULT_FADE_FRAMES` (which is private).
+- Task 2.7: `"stage render failed"` duplicated between construction site and `#[schema(example)]`.
+- `ChainProgressEvent::Stitching { total_frames }` over-reports by `(N-1) * motion_tail` (cosmetic).
+- `StitchPlan::assemble` on `Smooth` with `ClipTooShortForTrim` → 500 today; arguably 422. Unreachable in practice because `normalise` validates.
+
+None block Phase 2 merge.
+
+## Phase 3 — CLI surface
+
+**Goal:** `mold run --script shot.toml` canonical path + repeated `--prompt` sugar for uniform trivial chains + `mold chain validate` subcommand + `--dry-run`. Integrates with the existing chain endpoint from Phase 1.
+
+**Commit scope:** `feat(cli)`. Plan section starts at `docs/superpowers/plans/2026-04-21-multi-prompt-chain-v2.md` line 2674.
+
+**Tasks 3.1–3.7 (7 tasks).** Summary:
+
+- 3.1: Add `--script` flag + `--dry-run` flag to `mold run` (clap parser).
+- 3.2: `run_from_script` helper in `commands/chain.rs` + CLI integration test for `--dry-run`.
+- 3.3: Repeated `--prompt` sugar — `mold run --prompt "..." --prompt "..." --prompt "..."` auto-expands into `ChainRequest.stages`.
+- 3.4: `mold chain validate <path>` subcommand (schema gate, normalise, pretty-print stage summary).
+- 3.5: `mold run --script` posts to `/api/generate/chain/stream` with SSE progress display, including transition tags per stage.
+- 3.6: Progress-bar integration honoring `ChainStart.estimated_total_frames` and per-stage transitions.
+- 3.7: Phase 3 gate — `cargo fmt && cargo clippy && cargo test` + CLI smoke (`mold chain validate` against a hand-authored TOML).
+
+## Phase 4 — TUI script mode
+
+**Goal:** A `ScriptComposer` ratatui widget in the TUI for authoring chain scripts interactively.
+
+**Commit scope:** `feat(tui)`. Plan section starts at line 3295.
+
+**Tasks 4.1–4.8 (8 tasks).** Summary:
+
+- 4.1: `ScriptComposer` widget scaffolding under `crates/mold-tui/src/widgets/script_composer.rs`.
+- 4.2: Stage list with `j/k` navigation, `J/K` reorder.
+- 4.3: `a`/`A` add stage (after/before current), `d` delete.
+- 4.4: `t` cycle transition (Smooth → Cut → Fade → Smooth), `f` editor for `fade_frames`.
+- 4.5: `i` prompt editor (opens a multi-line text area).
+- 4.6: `Ctrl-S`/`Ctrl-O` save/load TOML (via `mold_core::chain_toml`).
+- 4.7: `Enter` submits — drives `/api/generate/chain/stream` with progress forwarded into the TUI's status bar.
+- 4.8: `tui-uat.sh` scenario covering a 3-stage author-save-submit flow.
+
+## Phase 5 — Web composer script mode
+
+**Goal:** A Vue-side composer for chain authoring that round-trips the canonical TOML shape and posts via `/api/generate/chain/stream`.
+
+**Commit scope:** `feat(web)`. Plan section starts at line 3907.
+
+**Tasks 5.1–5.10 (10 tasks).** Summary:
+
+- 5.1: Add `smol-toml` (or `@iarna/toml` fallback) dep. `bun run verify` must pass.
+- 5.2: `web/src/chain/chainToml.ts` — parse/serialize TOML mirroring `mold_core::chain_toml`.
+- 5.3: `fetchChainLimits()` in `web/src/api/chain.ts` — hits `/api/capabilities/chain-limits`.
+- 5.4: `StageCard.vue` — renders one stage's prompt/frames/transition + fade_frames.
+- 5.5: `ScriptComposer.vue` — list of StageCards + top-bar controls.
+- 5.6: Mode toggle on `Composer.vue` — switches between single-prompt and script modes.
+- 5.7: Chain submit path — posts `ChainRequest`, consumes SSE `progress`/`complete`/`error`.
+- 5.8: Per-stage expand modal — calls `/api/expand` with stage prompt.
+- 5.9: Drag-reorder via `vue-draggable-plus` — reorders `StageCard` list in-place.
+- 5.10: Footer chain-limits clamp — read `ChainLimits.max_stages` / `max_total_frames` and disable "add stage" when at cap. `bun run verify && bun run build` gate.
+
+## Phase 6 — Docs + release
+
+**Goal:** Document the new composer UX for end users; update the changelog and skill file.
+
+**Commit scope:** `docs(chain)`. Plan section starts at line 4603.
+
+**Tasks 6.1–6.4 (4 tasks).**
+
+- 6.1: `website/guide/video.md` — new section on multi-prompt chains + TOML authoring + transitions.
+- 6.2: `CHANGELOG.md [Unreleased]` — bullet list of new API endpoints, CLI flags, TUI commands, web composer.
+- 6.3: `.claude/skills/mold/SKILL.md` — update for the new `mold chain validate` subcommand, `--script` flag, and `TransitionMode` concept.
+- 6.4: `CLAUDE.md` — add a "chain authoring" sub-section under the CLI reference + mention the canonical TOML schema.
+
+## Dependency graph
+
+```
+Phase 1 (merged before Phase 2 lands)
+  ↓
+Phase 2 (#267, pending merge)
+  ↓
+Phase 3 (CLI)  Phase 4 (TUI)  Phase 5 (web) — concurrent safe
+  └────────────┴──────────────┘
+                ↓
+             Phase 6 (docs)
+```
+
+Phases 3/4/5 are independent after Phase 2 lands: they each consume `ChainRequest` / `/api/generate/chain` / `chain_toml` but don't touch each other's crate trees. A single session can drive all three sequentially, or three parallel worktrees can run concurrently.
+
+Phase 6 depends on 3/4/5 having landed (or at least having their final shape locked) because the docs describe the final CLI/TUI/web surface.
+
+## Working conventions to preserve
+
+- **One scope per commit** — `feat(chain) / feat(ltx2) / feat(server) / feat(cli) / feat(tui) / feat(web) / test(chain) / docs(chain)`.
+- **No mid-phase pushes** — each phase is one PR when complete. Exceptions: intentional doc-only commits like this handoff, which land on the phase branch naturally.
+- **TDD** — failing test first, then implementation, then verify pass, then commit.
+- **`superpowers:subagent-driven-development`** — fresh general-purpose subagent per task. Sonnet for mechanical tasks, opus only if the task requires architectural judgment. Combined spec+quality review works well for plan-verbatim tasks; split into two-stage for complex/cross-crate work (as done for Task 2.7).
+- **Prompt the subagent with full task text** — don't send a "read the plan and implement" instruction. Paste the plan's text inline and flag pre-investigation findings.
+- **Pre-grep before dispatching** — when a task changes a public struct, `grep -rn 'StructName {' crates/` and list every construction site in the brief.
+
+## Gotchas accumulated through Phase 2
+
+Carried forward from session-2 (still relevant):
+
+- **`MoldError::Other`** takes `anyhow::Error`, not `String`.
+- **`mold_core::manifest`** has `find_manifest(&name).map(|m| m.family.clone())` for family lookup.
+- **`toml-rs` sorts keys alphabetically** within tables — `write_script` prepends the `schema = "..."` header manually.
+- **`ChainSseMessage::Complete(Box<SseChainCompleteEvent>)`** — boxed for `large_enum_variant`. Don't un-box.
+- **TUI theme test flake** — retry once if only `theme_save_then_load_round_trip_preserves_preset` fires.
+
+New in session 2 / Phase 2:
+
+- **`ChainOrchestratorError`** (in `mold-inference::ltx2`) is the typed error from `Ltx2ChainOrchestrator::run`. `Invalid(anyhow::Error)` for pre-flight failures; `StageFailed { stage_idx, elapsed_stages, elapsed_ms, inner: anyhow::Error }` for mid-chain failures.
+- **`ChainFailure`** (in `mold-core::chain`) is the wire-type version of the above, returned as the 502 JSON body from `generate_chain` (non-SSE only; SSE collapses to a string).
+- **`ChainRunError::StageFailed(ChainFailure)`** is the server-internal variant bridging the two. `From<ChainRunError> for ApiError` has a comment explaining the intentional SSE lossiness.
+- **`generate_chain` signature** changed from `Result<Json<ChainResponse>, ApiError>` to `axum::response::Response` to support the structured 502 body. The SSE handler `generate_chain_stream` is unchanged.
+- **`StitchPlan`** in `mold-inference::ltx2::stitch` is the per-boundary stitch assembler. Called from `routes_chain.rs::stitch_chain_output`.
+- **`fade_frames`** defaults are `8` in two places: `mold_core::chain::DEFAULT_FADE_FRAMES` (private `const`) and the literal `8` in `stitch_chain_output` + `mixed_transitions_end_to_end`.
+- **Branch naming** — `feat/multi-prompt-chain-v2-phaseN`, each stacked on predecessor. PRs target the predecessor branch; auto-retarget on merge.
+
+## Verification commands the new session will need
+
+```bash
+# Pre-flight: confirm branch state
+cd /Users/jeffreydilley/github/mold
+git fetch origin
+git checkout feat/multi-prompt-chain-v2-phase2  # or skip if starting a new phase-N
+git log --oneline origin/main..HEAD | head -25
+# Should show 24 commits (Phase 1 + Phase 2) on this branch.
+
+# Sanity check CI before writing any new code
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+
+# Phase N kickoff (example for Phase 3):
+git checkout -b feat/multi-prompt-chain-v2-phase3
+# ... work tasks 3.1-3.7 ...
+git push -u origin feat/multi-prompt-chain-v2-phase3
+gh pr create --base feat/multi-prompt-chain-v2-phase2 \
+  --head feat/multi-prompt-chain-v2-phase3 \
+  --title "feat(cli): script mode for chain authoring (Phase 3/6)" --body "..."
+```
+
+## Spec & plan references
+
+- Spec: `docs/superpowers/specs/2026-04-21-multi-prompt-chain-v2-design.md` (681 lines). §3 decisions NOT up for debate.
+- Plan: `docs/superpowers/plans/2026-04-21-multi-prompt-chain-v2.md` (4805 lines, 51 tasks). Phase 3 starts at line 2674.
+- Session-2 handoff: `tasks/multi-prompt-chain-v2-resume-phase2.md`.
+- Session-1 handoff: `tasks/multi-prompt-chain-v2-handoff.md`.
+
+---
+
+## The prompt
+
+Paste from here into a fresh Claude Code session:
+
+---
+
+I'm resuming execution of **multi-prompt chain v2, sub-project A** for the mold repo, starting at **Phase 3 (CLI surface)**. This is session 3 of a multi-session project. Phase 1 and Phase 2 are complete; their PRs are open and stacked ([#266](https://github.com/utensils/mold/pull/266), [#267](https://github.com/utensils/mold/pull/267)).
+
+## Read first, in this order
+
+1. `~/.claude-personal/CLAUDE.md` (global) and `/Users/jeffreydilley/github/mold/CLAUDE.md` (project) — coding conventions.
+2. `tasks/multi-prompt-chain-v2-resume-phase3.md` — **your primary briefing**. Read end-to-end. Phase 2 status, what's next, working conventions, gotchas.
+3. `docs/superpowers/specs/2026-04-21-multi-prompt-chain-v2-design.md` — approved design. §3 decisions not up for debate.
+4. `docs/superpowers/plans/2026-04-21-multi-prompt-chain-v2.md` — 51-task plan. Phase 3 starts ~line 2674.
+5. `tasks/multi-prompt-chain-v2-resume-phase2.md` and `tasks/multi-prompt-chain-v2-handoff.md` — prior session context.
+
+## Status on entry
+
+- Branch strategy: `feat/multi-prompt-chain-v2-phase3` will be created from `feat/multi-prompt-chain-v2-phase2` (Phase 2 tip).
+- Phase 1 PR #266 + Phase 2 PR #267 both open, stacked on `main`. Do not merge them from this session without explicit user confirmation.
+- Phase 2's killswitch smoke is still pending manual verification. If the user hasn't run it yet and asks you to, see `tasks/multi-prompt-chain-v2-resume-phase3.md` §"Phase 2 manual verification".
+
+## What you're doing
+
+Execute Tasks **3.1 → 3.7** (Phase 3, CLI surface) via `superpowers:subagent-driven-development`. Then Phase 3 PR, stacked on Phase 2. Optionally follow with Phase 4 (TUI, 8 tasks) and Phase 5 (web, 10 tasks) — these are concurrent-safe, but sequential execution is easier to track. Phase 6 (docs, 4 tasks) after 3/4/5 are in.
+
+Gate every phase with `cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace`. Phase 5 also needs `bun run verify && bun run build` in `website/`. **No mid-phase pushes.** One PR per phase.
+
+## Start here
+
+1. Confirm state:
+   ```bash
+   cd /Users/jeffreydilley/github/mold
+   git fetch origin
+   git checkout feat/multi-prompt-chain-v2-phase2
+   git log --oneline origin/main..HEAD | head -25
+   git status
+   cargo test --workspace  # should be green; retry once on TUI flake
+   ```
+
+2. Create the Phase 3 branch:
+   ```bash
+   git checkout -b feat/multi-prompt-chain-v2-phase3
+   ```
+
+3. Start Task 3.1 (`--script` + `--dry-run` flags). Plan at line 2682. Pre-investigation: `grep -n 'Commands::Run' crates/mold-cli/src/main.rs` for the current `Run` variant shape.
+
+## If you hit a surprise
+
+Read `tasks/multi-prompt-chain-v2-resume-phase3.md` §"Gotchas accumulated through Phase 2" before assuming anything about typed error surfaces, branch strategy, or the `ChainFailure` shape. If the surprise is beyond that list, stop and ask the user.


### PR DESCRIPTION
## Stack

Stacked on #266 (Phase 1). This PR's base is `feat/multi-prompt-chain-v2`; when #266 lands on `main`, GitHub will auto-retarget this PR's base. Do **not** merge before #266.

## Summary

Phase 2 of the multi-prompt chain v2 plan (`docs/superpowers/plans/2026-04-21-multi-prompt-chain-v2.md`). This phase makes the engine layer honor `TransitionMode::{Smooth,Cut,Fade}` per-stage, implements the shared `StitchPlan` assembler that lives between the orchestrator and the server's output encoder, and returns a structured 502 payload on mid-chain failure so UIs can show actionable retry hints.

- **Smooth** — current v1 behavior: drop motion-tail prefix on continuations (now done at stitch time, not orchestrator time).
- **Cut** — no latent carry between stages; continuation runs fresh i2v (if `source_image`) or t2v; stitch concatenates whole clips.
- **Fade** — same engine path as Cut, plus a post-stitch alpha blend that consumes `2*fade_frames` pixel frames into `fade_frames` at each boundary.

Nothing user-facing yet — Phase 3 adds the `--script` CLI flag and Phase 4/5 add the TUI/web composers.

## Task breakdown

| Task | Commit | Scope |
|---|---|---|
| 2.1 | `13a78b9` | `ChainRunOutput.stage_frames` (per-stage frames), orchestrator no longer trims |
| 2.2 | `0908597` | `None` carry on `Cut`/`Fade` stages |
| 2.3 | `f986e4f` | `fade_boundary` helper (post-stitch crossfade) |
| 2.4 | `81e1216` | `StitchPlan::assemble` with per-boundary rules |
| 2.5 | `90cadd1` | `source_image` honored on `Cut`/`Fade` continuations (+ `Smooth` warn) |
| 2.6 | `de01ed8` | `routes_chain` uses `StitchPlan::assemble` (+ `StitchFailed` variant → 500) |
| 2.7 | `39c602d` | Typed `ChainFailure` in `mold-core`, `ChainOrchestratorError::StageFailed` in `mold-inference`, 502 JSON body in handler |
| 2.8 | `10f435a` | Mixed-transition `end_to_end` test via `FakeRenderer` + opportunistic rename of stale Task 2.1 test |

Plus `f7c9c43` — session-2 resume handoff doc (cross-phase bookkeeping, not a functional change).

## Test plan

Automated gate (all green on `10f435a`):

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — full suite green; no TUI flake on this run
- [x] `mixed_transitions_end_to_end` unit test: asserts `97 + 72 + 97 + 89 = 355` frames for a Smooth/Smooth/Cut/Fade(8) chain end-to-end through `FakeRenderer` + `StitchPlan::assemble`
- [x] `generate_chain_handler_returns_502_with_chain_failure_body` test: drives the real axum handler with a `ChainMockEngine::failing_at(1)`, asserts 502 status + `ChainFailure` JSON body deserialization
- [x] `StitchPlan` unit tests cover Smooth-only (dedupe motion-tail), Cut-only (whole concat), Fade-only (net -fade_frames), and mismatched-boundary error paths

Manual verification (pending — recommend running before merge):

- [ ] **Killswitch end-to-end smoke** on `killswitch@192.168.1.67`, CUDA sm_86 build:
  ```bash
  ssh killswitch@192.168.1.67
  cd ~/github/mold && git fetch origin feat/multi-prompt-chain-v2-phase2 \
    && git checkout feat/multi-prompt-chain-v2-phase2
  CUDA_COMPUTE_CAP=86 nix build .#mold
  ./result/bin/mold serve --bind 0.0.0.0 --port 7680 &

  # 3-stage all-smooth (existing behavior unchanged)
  curl -X POST http://localhost:7680/api/generate/chain \
    -H 'content-type: application/json' -d @chain_smooth.json \
    --output out_smooth.mp4

  # 3-stage all-cut
  curl -X POST http://localhost:7680/api/generate/chain \
    -H 'content-type: application/json' -d @chain_cut.json \
    --output out_cut.mp4

  # 3-stage all-fade (fade_frames=8)
  curl -X POST http://localhost:7680/api/generate/chain \
    -H 'content-type: application/json' -d @chain_fade.json \
    --output out_fade.mp4

  # Mixed Smooth/Cut/Fade
  curl -X POST http://localhost:7680/api/generate/chain \
    -H 'content-type: application/json' -d @chain_mixed.json \
    --output out_mixed.mp4
  ```
  Visual acceptance criteria:
  - `smooth`: continuous visual flow; no hard cuts; slight prompt-change morph.
  - `cut`: obvious hard scene change at each boundary; no visible artifacts.
  - `fade`: visible crossfade over ~8 frames at each boundary.
  - `mixed`: each boundary matches the per-stage `transition` field.

## Deferred minors (non-blocking)

Captured during subagent review for carry-forward to future phases:

- **Task 2.6 review:** the plan's Step 1 described a dedicated `stitched_mixed_chain_has_expected_frame_count` route-layer test covering Cut/Fade via `stitch_chain_output`. That specific test was not added; coverage is provided by Task 2.8 at the orchestrator layer (`mixed_transitions_end_to_end`) and by `StitchPlan` unit tests in `stitch.rs`. Fine-grained route-layer transition test is a cheap follow-up if desired.
- **Task 2.6 minor (style):** `fade_frames.unwrap_or(8)` in `stitch_chain_output` duplicates `mold_core::chain::DEFAULT_FADE_FRAMES` (which is currently private); import + use if that constant ever becomes `pub`.
- **Task 2.7 minor (style):** `"stage render failed"` is duplicated between the `ChainFailure` construction site and `#[schema(example = ...)]`; not factor-able to a `const` because `#[schema]` only accepts literals.
- **Progress `Stitching` over-report:** cosmetic; `ChainProgressEvent::Stitching { total_frames }` over-reports by `(N-1) * motion_tail`. UIs use `ChainStart.estimated_total_frames` for the progress-bar length, so the `Stitching` value only lands on an already-completed terminal event. Fix alongside SSE restructure when that lands.
- **`StitchPlan::assemble` on `Smooth` when next clip shorter than `motion_tail_frames`** returns `ClipTooShortForTrim` → currently maps to 500 via `StitchFailed`. Validation in `ChainRequest::normalise` prevents this in practice (`motion_tail < stage.frames`), so it's unreachable on well-formed inputs. If a future caller constructs a stage with `frames < motion_tail_frames` without round-tripping `normalise`, the response code should probably be 422; revisit during Phase 5 if web composer can author such a state.

## Review hints for a reader coming in cold

- The stitch logic is a pure function: `StitchPlan::assemble(Vec<clips>, Vec<boundaries>, Vec<fade_lens>, motion_tail) -> Vec<RgbImage>`. All the per-transition complexity lives in one file (`crates/mold-inference/src/ltx2/stitch.rs`) with full unit coverage.
- The orchestrator's `None`-carry branch for `Cut`/`Fade` is literally one match (`crates/mold-inference/src/ltx2/chain.rs` line ~226). That's the one-liner that makes transitions work at the engine level.
- Structured 502s are the only server-facing behavior change: non-SSE handler returns `ChainFailure` JSON with 502; SSE still emits a string-only `event: error`. The intentional asymmetry is documented inline at the `From<ChainRunError> for ApiError` arm for `StageFailed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)