### PR TITLE
docs: audit + sync docs/website with current code

### DIFF
--- a/.claude/skills/mold/SKILL.md
+++ b/.claude/skills/mold/SKILL.md
@@ -131,11 +131,10 @@ selected LoRA — clicking a chip appends the phrase to the active prompt.
 
 **Requirements:**
 
-- FLUX (BF16 + GGUF), LTX-2, Flux.2, and Z-Image families support LoRAs.
-  SD1.5 / SDXL / SD3 / Qwen-Image / Wuerstchen / LTX-Video are not yet
-  wired — the server returns a 400 with a "LoRA is currently supported
-  for FLUX, LTX-2 and Z-Image models" message for any other family. (The
-  message text is centralised in `mold-core::validation::require_lora_capable_family`
+- FLUX (BF16 + GGUF), Flux.2, LTX-2, SD1.5, SD3, SDXL, Qwen-Image (+ Qwen-Image-Edit),
+  and Z-Image families support LoRAs. Wuerstchen and LTX-Video are not yet wired —
+  the server returns a 400 with the list of supported families for any other family.
+  (The message text is centralised in `mold-core::validation::require_lora_capable_family`
   and will list whichever families are wired at the time it's surfaced.)
 - LoRA file must be `.safetensors` format. Z-Image / FLUX accept
   diffusers (PEFT canonical), Kohya/sd-scripts, OneTrainer, and PEFT
@@ -642,6 +641,7 @@ Core endpoints exposed by `mold serve` (full list + schemas at `/api/docs`):
 - `GET /api/models` · `POST /api/models/load` · `POST /api/models/pull` · `DELETE /api/models/unload`
 - `GET /api/gallery` · `GET /api/gallery/image/:name` · `GET /api/gallery/thumbnail/:name` · `DELETE /api/gallery/image/:name`
 - `POST /api/upscale` · `POST /api/upscale/stream`
+- `GET /api/queue` — authoritative server-side job listing for SPA reconciliation (queued + running jobs with UUIDv4 ids)
 - `GET /api/status` · `GET /health` · `GET /api/capabilities`
 
 ### Prometheus Metrics
@@ -655,7 +655,7 @@ Metrics include: HTTP request rates/latency, generation duration, queue depth, m
 | Variable                    | Default                 | Purpose                                                                    |
 | --------------------------- | ----------------------- | -------------------------------------------------------------------------- |
 | `MOLD_HOME`                 | `~/.mold`               | Base directory for config, cache, and default models                       |
-| `MOLD_DEFAULT_MODEL`        | `flux2-klein`           | Default model (smart fallback to only downloaded model)                    |
+| `MOLD_DEFAULT_MODEL`        | `flux2-klein:q8`        | Default model (smart fallback to only downloaded model)                    |
 | `MOLD_HOST`                 | `http://localhost:7680` | Remote server URL                                                          |
 | `MOLD_MODELS_DIR`           | `$MOLD_HOME/models`     | Model storage path                                                         |
 | `MOLD_OUTPUT_DIR`           | `~/.mold/output`        | Image output directory (set empty to disable)                              |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ Inside `nix develop` the devshell exposes shortcuts (`build`, `build-release`, `
 ```
 crates/
 ├── mold-core/        Shared types, HTTP client, config, manifest, validation, download
+├── mold-catalog/     Live HF + Civitai model-discovery proxy (5-min in-proc cache, no bulk-scrape DB). Depended on by mold-cli + mold-server only — mold-discord and mold-tui MUST NOT transitively depend on it.
 ├── mold-db/          SQLite (rusqlite, bundled, WAL) — gallery, settings, model_prefs, prompt_history
 ├── mold-inference/   Candle engines per family (FLUX, SD1.5/XL/3, Z-Image, Flux.2, Qwen-Image, Wuerstchen, LTX-Video, LTX-2)
 ├── mold-server/      Axum HTTP server (consumed as lib by mold-cli)
@@ -50,6 +51,7 @@ crates/
 |---|---|
 | `mold-cli/` | `mold-ai` (binary: `mold`) |
 | `mold-core/` | `mold-ai-core` |
+| `mold-catalog/` | `mold-ai-catalog` |
 | `mold-db/` | `mold-ai-db` |
 | `mold-inference/` | `mold-ai-inference` |
 | `mold-server/` | `mold-ai-server` |

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,9 +64,13 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 
 WORKDIR /build
 
-# Copy manifests first for layer caching of dependency builds
+# Copy manifests first for layer caching of dependency builds.
+# Must include every workspace member listed in the root Cargo.toml — cargo
+# fails to resolve the workspace if any member's manifest is missing.
 COPY Cargo.toml Cargo.lock ./
 COPY crates/mold-core/Cargo.toml crates/mold-core/Cargo.toml
+COPY crates/mold-catalog/Cargo.toml crates/mold-catalog/Cargo.toml
+COPY crates/mold-db/Cargo.toml crates/mold-db/Cargo.toml
 COPY crates/mold-inference/Cargo.toml crates/mold-inference/Cargo.toml
 COPY crates/mold-server/Cargo.toml crates/mold-server/Cargo.toml
 COPY crates/mold-cli/Cargo.toml crates/mold-cli/Cargo.toml
@@ -75,12 +79,16 @@ COPY crates/mold-tui/Cargo.toml crates/mold-tui/Cargo.toml
 
 # Create stub source files so cargo can resolve and build dependencies
 RUN mkdir -p crates/mold-core/src \
+             crates/mold-catalog/src \
+             crates/mold-db/src \
              crates/mold-inference/src \
              crates/mold-server/src \
              crates/mold-cli/src \
              crates/mold-discord/src \
              crates/mold-tui/src \
     && echo "// stub" > crates/mold-core/src/lib.rs \
+    && echo "// stub" > crates/mold-catalog/src/lib.rs \
+    && echo "// stub" > crates/mold-db/src/lib.rs \
     && echo "// stub" > crates/mold-inference/src/lib.rs \
     && echo "// stub" > crates/mold-server/src/lib.rs \
     && echo 'fn main() { println!("stub"); }' > crates/mold-cli/src/main.rs \

--- a/config.example.toml
+++ b/config.example.toml
@@ -9,7 +9,7 @@
 #      into this candle build. Use a GGUF-quantized version instead.
 #   ❌ Scaled FP8 (fp8_scaled) — ComfyUI-only custom format, not supported.
 
-default_model = "flux2-klein"
+default_model = "flux2-klein:q8"
 server_port   = 7680
 default_width  = 768
 default_height = 768

--- a/website/api/index.md
+++ b/website/api/index.md
@@ -4,29 +4,32 @@ When running `mold serve`, you get a REST API for remote image generation.
 
 ## Endpoints
 
-| Method   | Path                           | Description                          |
-| -------- | ------------------------------ | ------------------------------------ |
-| `POST`   | `/api/generate`                | Generate images from prompt          |
-| `POST`   | `/api/generate/stream`         | Generate with SSE progress streaming |
-| `POST`   | `/api/generate/chain`          | Chained video generation (LTX-2)     |
-| `POST`   | `/api/generate/chain/stream`   | Chained video with SSE progress      |
-| `POST`   | `/api/expand`                  | Expand a prompt using LLM            |
-| `GET`    | `/api/models`                  | List available models                |
-| `POST`   | `/api/models/load`             | Load/swap the active model           |
-| `POST`   | `/api/models/pull`             | Pull/download a model                |
-| `DELETE` | `/api/models/unload`           | Unload model to free GPU memory      |
-| `GET`    | `/api/gallery`                 | List saved images                    |
-| `GET`    | `/api/gallery/image/:name`     | Fetch a saved image                  |
-| `DELETE` | `/api/gallery/image/:name`     | Delete a saved image                 |
-| `GET`    | `/api/gallery/thumbnail/:name` | Fetch a cached thumbnail             |
-| `POST`   | `/api/upscale`                 | Upscale image with Real-ESRGAN       |
-| `POST`   | `/api/upscale/stream`          | Upscale with SSE tile progress       |
-| `POST`   | `/api/shutdown`                | Trigger graceful server shutdown     |
-| `GET`    | `/api/status`                  | Server health + status               |
-| `GET`    | `/health`                      | Simple 200 OK health check           |
-| `GET`    | `/api/openapi.json`            | OpenAPI spec                         |
-| `GET`    | `/api/docs`                    | Interactive API docs (Scalar)        |
-| `GET`    | `/metrics`                     | Prometheus metrics (feature-gated)   |
+| Method   | Path                             | Description                                                                                                       |
+| -------- | -------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `POST`   | `/api/generate`                  | Generate images from prompt                                                                                       |
+| `POST`   | `/api/generate/stream`           | Generate with SSE progress streaming                                                                              |
+| `POST`   | `/api/generate/chain`            | Chained video generation (LTX-2)                                                                                  |
+| `POST`   | `/api/generate/chain/stream`     | Chained video with SSE progress                                                                                   |
+| `POST`   | `/api/expand`                    | Expand a prompt using LLM                                                                                         |
+| `GET`    | `/api/models`                    | List available models                                                                                             |
+| `POST`   | `/api/models/load`               | Load/swap the active model                                                                                        |
+| `POST`   | `/api/models/pull`               | Pull/download a model                                                                                             |
+| `DELETE` | `/api/models/unload`             | Unload model to free GPU memory                                                                                   |
+| `GET`    | `/api/gallery`                   | List saved images                                                                                                 |
+| `GET`    | `/api/gallery/image/:name`       | Fetch a saved image                                                                                               |
+| `DELETE` | `/api/gallery/image/:name`       | Delete a saved image                                                                                              |
+| `GET`    | `/api/gallery/thumbnail/:name`   | Fetch a cached thumbnail                                                                                          |
+| `POST`   | `/api/upscale`                   | Upscale image with Real-ESRGAN                                                                                    |
+| `POST`   | `/api/upscale/stream`            | Upscale with SSE tile progress                                                                                    |
+| `GET`    | `/api/queue`                     | Server-authoritative job listing (queued + running, UUIDv4 ids); used by the SPA to reconcile dropped SSE streams |
+| `GET`    | `/api/capabilities`              | Feature capabilities (gallery delete, chain limits, …)                                                            |
+| `GET`    | `/api/capabilities/chain-limits` | Chain-generation request limits                                                                                   |
+| `POST`   | `/api/shutdown`                  | Trigger graceful server shutdown                                                                                  |
+| `GET`    | `/api/status`                    | Server health + status                                                                                            |
+| `GET`    | `/health`                        | Simple 200 OK health check                                                                                        |
+| `GET`    | `/api/openapi.json`              | OpenAPI spec                                                                                                      |
+| `GET`    | `/api/docs`                      | Interactive API docs (Scalar)                                                                                     |
+| `GET`    | `/metrics`                       | Prometheus metrics (feature-gated)                                                                                |
 
 ## Authentication
 

--- a/website/guide/configuration.md
+++ b/website/guide/configuration.md
@@ -121,14 +121,14 @@ Environment variables take precedence over config file values.
 
 ### Core
 
-| Variable             | Default                 | Description                         |
-| -------------------- | ----------------------- | ----------------------------------- |
-| `MOLD_HOME`          | `~/.mold`               | Base directory for config and cache |
-| `MOLD_DEFAULT_MODEL` | `flux2-klein`           | Default model name                  |
-| `MOLD_HOST`          | `http://localhost:7680` | Remote server URL                   |
-| `MOLD_MODELS_DIR`    | `$MOLD_HOME/models`     | Model storage directory             |
-| `MOLD_PORT`          | `7680`                  | Server port                         |
-| `MOLD_LOG`           | `warn` / `info`         | Log level                           |
+| Variable             | Default                            | Description                         |
+| -------------------- | ---------------------------------- | ----------------------------------- |
+| `MOLD_HOME`          | `~/.mold`                          | Base directory for config and cache |
+| `MOLD_DEFAULT_MODEL` | `flux2-klein:q8`                   | Default model name                  |
+| `MOLD_HOST`          | `http://localhost:7680`            | Remote server URL                   |
+| `MOLD_MODELS_DIR`    | `$MOLD_HOME/models`                | Model storage directory             |
+| `MOLD_PORT`          | `7680`                             | Server port                         |
+| `MOLD_LOG`           | `info` (serve) / `warn` (cli, tui) | Log level                           |
 
 ### Generation
 
@@ -168,19 +168,26 @@ Environment variables take precedence over config file values.
 
 ### Server
 
-| Variable                | Default             | Description                                                                                                                                                       |
-| ----------------------- | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `MOLD_GPUS`             | all visible         | Which GPUs the server uses: comma-separated ordinals (`0,1`) or `all`. See [Multi-GPU](/guide/cli-reference#multi-gpu)                                            |
-| `MOLD_QUEUE_SIZE`       | `200`               | Max queued generation jobs; overflow returns HTTP 503 with `Retry-After`                                                                                          |
-| `MOLD_OUTPUT_DIR`       | `~/.mold/output`    | Image output directory (set empty to disable)                                                                                                                     |
-| `MOLD_THUMBNAIL_WARMUP` | —                   | `1` to prebuild gallery thumbnails at server startup (default: disabled)                                                                                          |
-| `MOLD_WEB_DIR`          | —                   | Override the web gallery SPA bundle location. First resolved path among this, `$XDG_DATA_HOME/mold/web`, `~/.mold/web`, `<binary dir>/web`, and `./web/dist` wins |
-| `MOLD_DB_PATH`          | `MOLD_HOME/mold.db` | Override the SQLite gallery metadata DB location                                                                                                                  |
-| `MOLD_DB_DISABLE`       | —                   | `1` to disable the SQLite metadata DB entirely — server and CLI fall back to filesystem walks                                                                     |
-| `MOLD_CORS_ORIGIN`      | —                   | Restrict CORS to specific origin                                                                                                                                  |
-| `MOLD_API_KEY`          | —                   | API key for authentication (single key, comma-separated, or `@/path/to/keys.txt`)                                                                                 |
-| `MOLD_RATE_LIMIT`       | —                   | Per-IP rate limit for generation endpoints (e.g., `10/min`, `5/sec`, `100/hour`)                                                                                  |
-| `MOLD_RATE_LIMIT_BURST` | —                   | Burst allowance override (defaults to 2x rate, capped at 100)                                                                                                     |
+| Variable                      | Default             | Description                                                                                                                                                                              |
+| ----------------------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MOLD_GPUS`                   | all visible         | Which GPUs the server uses: comma-separated ordinals (`0,1`) or `all`. See [Multi-GPU](/guide/cli-reference#multi-gpu)                                                                   |
+| `MOLD_QUEUE_SIZE`             | `200`               | Max queued generation jobs; overflow returns HTTP 503 with `Retry-After`                                                                                                                 |
+| `MOLD_OUTPUT_DIR`             | `~/.mold/output`    | Image output directory (set empty to disable)                                                                                                                                            |
+| `MOLD_THUMBNAIL_WARMUP`       | —                   | `1` to prebuild gallery thumbnails at server startup (default: disabled)                                                                                                                 |
+| `MOLD_WEB_DIR`                | —                   | Override the web gallery SPA bundle location. First resolved path among this, `$XDG_DATA_HOME/mold/web`, `~/.mold/web`, `<binary dir>/web`, and `./web/dist` wins                        |
+| `MOLD_DB_PATH`                | `MOLD_HOME/mold.db` | Override the SQLite gallery metadata DB location                                                                                                                                         |
+| `MOLD_DB_DISABLE`             | —                   | `1` to disable the SQLite metadata DB entirely — server and CLI fall back to filesystem walks                                                                                            |
+| `MOLD_CORS_ORIGIN`            | —                   | Restrict CORS to specific origin                                                                                                                                                         |
+| `MOLD_API_KEY`                | —                   | API key for authentication (single key, comma-separated, or `@/path/to/keys.txt`)                                                                                                        |
+| `MOLD_RATE_LIMIT`             | —                   | Per-IP rate limit for generation endpoints (e.g., `10/min`, `5/sec`, `100/hour`)                                                                                                         |
+| `MOLD_RATE_LIMIT_BURST`       | —                   | Burst allowance override (defaults to 2x rate, capped at 100)                                                                                                                            |
+| `MOLD_MAX_CACHED_MODELS`      | `3`                 | LRU model-cache capacity (range `1..=16`). At most one entry stays GPU-resident; the rest are parked in CPU RAM. Out-of-range values warn and fall back to default.                      |
+| `MOLD_CACHE_IDLE_TTL_SECS`    | `1800` (30 min)     | Idle timeout for parked cache entries (range `60..=86400`). Untouched entries are evicted past this TTL.                                                                                 |
+| `MOLD_QUEUE_LOOKAHEAD_BUFFER` | `8`                 | Server queue lookahead size (range `1..=64`). The dispatcher peeks this many jobs ahead to honour locality.                                                                              |
+| `MOLD_QUEUE_MAX_DEFERRALS`    | `3`                 | Per-job starvation budget (range `0..=32`). A job can be deferred this many times before forced pickup.                                                                                  |
+| `MOLD_MALLOC_TRIM`            | `1` (Linux/glibc)   | `0` disables the post-generation `malloc_trim(0)` call. Cheap (~ms) but Linux-only; reclaims arena pages after large GGUF+LoRA rebuilds.                                                 |
+| `MOLD_FLUX_DELTA_CACHE`       | `1`                 | `0` disables the CPU-side FLUX LoRA delta cache (~25 GB host RAM on typical FLUX LoRAs). Disabling forces a sub-second `B@A·scale` recompute on each rebuild.                            |
+| `MOLD_FLUX_KEEP_TRANSFORMER`  | `0`                 | `1` keeps the FLUX transformer GPU-resident across same-LoRA generations (saves a full GGUF+LoRA rebuild). Server force-drops it if VAE decode headroom is too tight at that resolution. |
 
 ### Upscaling
 

--- a/website/guide/custom-models.md
+++ b/website/guide/custom-models.md
@@ -101,9 +101,10 @@ comma-separation — no more flipping back to the Civitai page to copy/paste.
 
 ## LoRA Rules
 
-- FLUX only — SD1.5 / SDXL LoRA inference is not yet implemented. The
-  server returns a 400 with "LoRA is currently supported only for FLUX
-  models" if you attach a LoRA to any other family.
+- Supported families: **FLUX, Flux.2, LTX-2, SD1.5, SD3, SDXL, Qwen-Image
+  (+ Qwen-Image-Edit), Z-Image**. Wuerstchen and LTX-Video are not yet wired —
+  attaching a LoRA there returns a 400 with the current supported-family list.
+  (Source of truth: `mold-core::validation::require_lora_capable_family`.)
 - `.safetensors` only
 - scale must be between `0.0` and `2.0`
 - the server resolves the path on the machine doing inference

--- a/website/guide/generating.md
+++ b/website/guide/generating.md
@@ -195,12 +195,13 @@ mold run sd15:fp16 "a cat" --scheduler uni-pc         # Fast convergence
 mold run sd15:fp16 "a cat" --scheduler euler-ancestral # Stochastic
 ```
 
-## LoRA Adapters (FLUX)
+## LoRA Adapters
 
-Apply fine-tuned style adapters to FLUX models:
+Apply fine-tuned style adapters across the supported families — **FLUX, Flux.2,
+LTX-2, SD1.5, SD3, SDXL, Qwen-Image (+ Qwen-Image-Edit), Z-Image**:
 
 ```bash
-# Basic LoRA
+# Basic LoRA (FLUX example)
 mold run flux-dev:bf16 "a portrait" --lora style.safetensors
 
 # Adjust strength (0.0 = no effect, 1.0 = full, up to 2.0)
@@ -208,10 +209,17 @@ mold run flux-dev:bf16 "anime style" --lora style.safetensors --lora-scale 0.7
 
 # Works with quantized models too
 mold run flux-dev:q4 "a portrait" --lora style.safetensors --lora-scale 0.8
+
+# Same flag syntax across families
+mold run sdxl:fp16    "a sunset" --lora sdxl-style.safetensors
+mold run z-image:bf16 "anime"    --lora cv:2904324
 ```
 
 ::: tip LoRA requirements
-FLUX models only (BF16 or GGUF quantized). Requires `.safetensors` format with diffusers-format keys. BF16 models on 24GB cards auto-use block-level offloading.
+Requires `.safetensors` format. Z-Image / FLUX accept diffusers (PEFT canonical),
+Kohya/sd-scripts, OneTrainer, and PEFT default-adapter naming. BF16 FLUX on
+24 GB cards auto-uses block-level offloading. Wuerstchen and LTX-Video are not
+yet wired — attaching a LoRA there returns a 400 with the supported-family list.
 :::
 
 ## Inline Preview

--- a/website/guide/index.md
+++ b/website/guide/index.md
@@ -37,14 +37,14 @@ mold run "a sunset over mountains"
 
 ## What You Get
 
-- **10 model families** — FLUX.1, SDXL, SD 1.5, SD 3.5, Z-Image, Flux.2 Klein,
-  Qwen-Image, Qwen-Image-Edit, Wuerstchen v2, LTX Video
+- **11 model families** — FLUX.1, SDXL, SD 1.5, SD 3.5, Z-Image, Flux.2 Klein,
+  Qwen-Image, Qwen-Image-Edit, Wuerstchen v2, LTX Video, LTX-2 / LTX-2.3
 - **txt2img, img2img, multimodal edit, inpainting, ControlNet** — all in one binary
 - **Image upscaling** — Real-ESRGAN super-resolution (2x/4x) via CLI, server API, or TUI
 - **Pipe-friendly** — `mold run "a cat" | viu -` just works
 - **Client-server** — run the GPU part on one machine, generate from anywhere
 - **Prompt expansion** — short prompts become detailed via local LLM
-- **LoRA adapters** — apply fine-tuned styles to FLUX models
+- **LoRA adapters** — apply fine-tuned styles across FLUX, Flux.2, LTX-2, SD1.5, SD3, SDXL, Qwen-Image, and Z-Image
 - **PNG metadata** — generation parameters embedded for reproducibility
 
 ## Requirements

--- a/website/scripts/verify-docs.mjs
+++ b/website/scripts/verify-docs.mjs
@@ -82,6 +82,15 @@ const ignoredEnvVars = new Set([
   // the web SPA bundle for rust-embed. Not user-facing runtime config.
   'MOLD_EMBED_WEB_DIR',
   'MOLD_WEB_DIST',
+  // Debug / dev / test-only — intentionally not user-facing.
+  // `MOLD_FLUX2_DUMP_LATENT` is a developer probe that dumps pre-VAE
+  // latents to a path; `MOLD_NVFP4_PROBE_PATH` gates the NVFP4 single-file
+  // load probe behind an external test fixture; `MOLD_TEST_CLIP_TOKENIZER`
+  // is a unit-test fixture path. Surfacing them in docs would invite users
+  // to set them in normal operation, which is wrong.
+  'MOLD_FLUX2_DUMP_LATENT',
+  'MOLD_NVFP4_PROBE_PATH',
+  'MOLD_TEST_CLIP_TOKENIZER',
 ])
 const docsText = walk(websiteDir)
   .filter((file) => /\.(md|ts|css)$/u.test(file))


### PR DESCRIPTION
## Summary

Cross-cutting docs drift cleanup so every doc surface (CLAUDE.md, SKILL.md, config.example.toml, website/, Dockerfile) matches the code on `main` (`0673554`).

- **Catalog crate**: `CLAUDE.md` + `SKILL.md` now list the `mold-catalog` crate added recently.
- **LoRA family list**: source of truth is `mold-core::validation::require_lora_capable_family` — **FLUX, Flux.2, LTX-2, SD1.5, SD3, SDXL, Qwen-Image (+ Edit), Z-Image**. Updated `SKILL.md`, `website/guide/{custom-models,generating,index}.md` which still said "FLUX only".
- **API endpoint docs**: `website/api/index.md` + `SKILL.md` now list `GET /api/queue` (added in the queue-stability fix), `GET /api/capabilities`, and `GET /api/capabilities/chain-limits`.
- **`MOLD_DEFAULT_MODEL` default**: corrected to `flux2-klein:q8` (matches `mold_core::config::default_model`) across `config.example.toml`, `website/guide/configuration.md`, and `SKILL.md`.
- **`MOLD_LOG` default** disambiguated: `info` for `mold serve`, `warn` for CLI/TUI (matches `mold-cli/src/main.rs:1207..1242`).
- **Previously-undocumented env vars** documented in `configuration.md`: `MOLD_MAX_CACHED_MODELS`, `MOLD_CACHE_IDLE_TTL_SECS`, `MOLD_QUEUE_LOOKAHEAD_BUFFER`, `MOLD_QUEUE_MAX_DEFERRALS`, `MOLD_MALLOC_TRIM`, `MOLD_FLUX_DELTA_CACHE`, `MOLD_FLUX_KEEP_TRANSFORMER`.
- **`verify-docs.mjs` allowlist**: three internal-only env vars excluded (`MOLD_FLUX2_DUMP_LATENT`, `MOLD_NVFP4_PROBE_PATH`, `MOLD_TEST_CLIP_TOKENIZER` — dev probes / test fixtures, not user knobs).
- **Model-family count**: `website/guide/index.md` 10 → 11 (LTX-2 / LTX-2.3 was missing from the bullet despite README and `models/index.md` both counting it).
- **Dockerfile build bug** (the only behavioural fix): `mold-db` and `mold-catalog` are workspace members and `mold-ai` deps, but the Dockerfile only copied 6 of 8 crate manifests in the dep-prebuild layer. `cargo` would fail to resolve the workspace at release-build time. Now copies + stubs all 8 crates.

The Dockerfile bug was hidden because the `docker` job only runs in `release.yml` on tagged releases — the next release build would have broken.

## Test plan

- [x] `bun run verify` (website/) — passes (was failing on `main` with 10 undocumented env vars)
- [x] `bun run fmt:check` (website/) — passes (prettier-formatted the two edited tables)
- [ ] CI green on this PR
- [ ] Sanity: pull the docker image after merge + next release tag, confirm the workspace resolves

## Audit notes

Items verified clean (no change needed):

- README.md — model list, feature flags, install instructions, version (`0.9.0`), MSRV (`1.85`), screenshot paths, HTTP endpoints
- `install.sh` — release-artifact URLs, repo slug, binary name
- All scheduler / variant flag tables in `configuration.md`
- `MOLD_KEEP_TE_RAM`, `MOLD_LORA_BYPASS`, `MOLD_VAE_TILED`, `MOLD_ATTN`, `MOLD_OFFLOAD`, `MOLD_*_VARIANT` — still wired up in code, descriptions accurate
- LTX-2 CUDA-only claim