### PR TITLE
fix(flake): fix mold-web bun install hang on aarch64-darwin + pure flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,7 +3,6 @@
     "bun2nix": {
       "inputs": {
         "flake-parts": "flake-parts",
-        "import-tree": "import-tree",
         "nixpkgs": [
           "nixpkgs"
         ],
@@ -11,11 +10,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1770895533,
-        "narHash": "sha256-v3QaK9ugy9bN9RXDnjw0i2OifKmz2NnKM82agtqm/UY=",
+        "lastModified": 1778446047,
+        "narHash": "sha256-oQvcadh2BCkrog+SGrG6YffKJrveYpjj3TdQJWaKhaM=",
         "owner": "nix-community",
         "repo": "bun2nix",
-        "rev": "c843f477b15f51151f8c6bcc886954699440a6e1",
+        "rev": "f2bc12af1a6369648aac41041ceeaa0b866599c6",
         "type": "github"
       },
       "original": {
@@ -61,14 +60,17 @@
     },
     "flake-parts": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib"
+        "nixpkgs-lib": [
+          "bun2nix",
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1769996383,
-        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
+        "lastModified": 1777988971,
+        "narHash": "sha256-qIoWPDs+0/8JecyYgE3gpKQxW/4bLW/gp45vow9ioCQ=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
+        "rev": "0678d8986be1661af6bb555f3489f2fdfc31f6ff",
         "type": "github"
       },
       "original": {
@@ -95,21 +97,6 @@
         "type": "github"
       }
     },
-    "import-tree": {
-      "locked": {
-        "lastModified": 1763762820,
-        "narHash": "sha256-ZvYKbFib3AEwiNMLsejb/CWs/OL/srFQ8AogkebEPF0=",
-        "owner": "vic",
-        "repo": "import-tree",
-        "rev": "3c23749d8013ec6daa1d7255057590e9ca726646",
-        "type": "github"
-      },
-      "original": {
-        "owner": "vic",
-        "repo": "import-tree",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1773476965,
@@ -123,21 +110,6 @@
         "owner": "NixOS",
         "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-lib": {
-      "locked": {
-        "lastModified": 1769909678,
-        "narHash": "sha256-cBEymOf4/o3FD5AZnzC3J9hLbiZ+QDT/KDuyHXVJOpM=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "72716169fe93074c333e8d0173151350670b824c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
         "type": "github"
       }
     },
@@ -210,11 +182,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770228511,
-        "narHash": "sha256-wQ6NJSuFqAEmIg2VMnLdCnUc0b7vslUohqqGGD+Fyxk=",
+        "lastModified": 1775636079,
+        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "337a4fe074be1042a35086f15481d763b8ddc0e7",
+        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -215,8 +215,9 @@
             #                      that hang inside the Nix sandbox (issue #286).
             #
             # Skip the lifecycle-scripts phase (second bun install without
-            # --ignore-scripts). esbuild and rollup ship their Darwin native binaries
-            # as explicit packages already in bunDeps; their postinstall download
+            # --ignore-scripts). All native-binary packages (esbuild, rollup,
+            # @tailwindcss/oxide, lightningcss) ship their platform-specific tarballs
+            # as explicit entries in bunDeps already; their postinstall download
             # scripts would attempt network access the sandbox blocks.
             dontRunLifecycleScripts = true;
             buildPhase = ''

--- a/flake.nix
+++ b/flake.nix
@@ -93,7 +93,7 @@
           commonArgs = {
             inherit src;
             pname = "mold";
-            version = "0.9.0";
+            version = "0.10.0";
             strictDeps = true;
 
             # Pass git metadata so build.rs can embed it (no .git in Nix sandbox).
@@ -199,18 +199,26 @@
           # `mold` binary by `rust-embed` (see `crates/mold-server/build.rs`).
           mold-web = pkgs.stdenv.mkDerivation {
             pname = "mold-web";
-            version = "0.9.0";
+            version = "0.10.0";
             src = ./web;
             nativeBuildInputs = [ pkgs.bun2nix.hook ];
             bunDeps = pkgs.bun2nix.fetchBunDeps {
               bunNix = ./web/bun.nix;
             };
-            # --linker=isolated gives each package its own node_modules, which
-            # sidesteps bun's AccessDenied failures when the hoisted linker tries
-            # to create nested `@vue/compiler-*/node_modules/estree-walker`
-            # directories during a sandboxed Darwin build (Vue pulls v2 while
-            # Vitest pulls v3, so the tree can't be flattened).
-            bunInstallFlags = [ "--linker=isolated" ];
+            # Do NOT set bunInstallFlags here. The bun2nix hook defaults to
+            # "--linker=isolated --backend=symlink", which is exactly what we need:
+            #   --linker=isolated  avoids AccessDenied when the hoisted linker tries
+            #                      to create nested estree-walker dirs (Vue v2 vs v3).
+            #   --backend=symlink  makes bun resolve packages from BUN_INSTALL_CACHE_DIR
+            #                      via symlinks; without it bun ignores the pre-fetched
+            #                      cache on aarch64-darwin and makes live npm fetches
+            #                      that hang inside the Nix sandbox (issue #286).
+            #
+            # Skip the lifecycle-scripts phase (second bun install without
+            # --ignore-scripts). esbuild and rollup ship their Darwin native binaries
+            # as explicit packages already in bunDeps; their postinstall download
+            # scripts would attempt network access the sandbox blocks.
+            dontRunLifecycleScripts = true;
             buildPhase = ''
               runHook preBuild
               bun run build

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mold-web",
-  "version": "0.8.1",
+  "version": "0.10.0",
   "private": true,
   "type": "module",
   "description": "Web gallery for the mold AI image/video generation server.",


### PR DESCRIPTION
## Summary

- **Root cause**: `bunInstallFlags = [ "--linker=isolated" ]` was overriding bun2nix's hook defaults, silently dropping `--backend=symlink`. Without it, bun ignores `BUN_INSTALL_CACHE_DIR` on macOS and makes live npm network fetches — which the Nix sandbox blocks, hanging indefinitely (issue #286).
- **Fix**: Remove explicit `bunInstallFlags`; rely on bun2nix defaults (`--linker=isolated --backend=symlink`).
- **Lifecycle scripts**: Add `dontRunLifecycleScripts = true` to skip the second `bun install` (without `--ignore-scripts`). All native-binary packages (esbuild, rollup, `@tailwindcss/oxide`, `lightningcss`) ship platform tarballs in `bunDeps` already; their postinstall scripts would attempt network access the sandbox blocks.
- **bun2nix bump**: v2.0.8 → v2.1.0. Drops `import-tree` transitive dep; `flake-parts`'s `nixpkgs-lib` now follows `["bun2nix", "nixpkgs"]` instead of a separate pinned `nixpkgs.lib` node. Lock cleaned up accordingly.
- **Version sync**: Bump `commonArgs.version`, `mold-web.version`, and `web/package.json` from `0.9.0`/`0.8.1` → `0.10.0` to match workspace `Cargo.toml`.

## Test plan

- [ ] `nix build .#mold-web` completes without hanging on aarch64-darwin
- [ ] `nix flake check` passes
- [ ] `nix build` (full mold binary) succeeds on aarch64-darwin and x86_64-linux
- [ ] `nix fmt` reports no changes