### PR TITLE
Force sequential Klein 9B BF16 loads on 24GB GPUs

### DIFF
--- a/crates/mold-server/src/gpu_worker.rs
+++ b/crates/mold-server/src/gpu_worker.rs
@@ -597,7 +597,6 @@ fn select_load_strategy_for_worker(
     let available =
         crate::model_manager::effective_load_available_bytes(active_vram, worker.gpu.ordinal);
     let strategy = crate::model_manager::select_server_load_strategy_for_device(
-        model_name,
         paths,
         available,
         Some(worker.gpu.total_vram_bytes),

--- a/crates/mold-server/src/gpu_worker.rs
+++ b/crates/mold-server/src/gpu_worker.rs
@@ -596,8 +596,13 @@ fn select_load_strategy_for_worker(
         .active_vram_bytes();
     let available =
         crate::model_manager::effective_load_available_bytes(active_vram, worker.gpu.ordinal);
-    let strategy =
-        crate::model_manager::select_server_load_strategy_for_budget(paths, available, hint);
+    let strategy = crate::model_manager::select_server_load_strategy_for_device(
+        model_name,
+        paths,
+        available,
+        Some(worker.gpu.total_vram_bytes),
+        hint,
+    );
     if strategy == mold_inference::LoadStrategy::Sequential {
         tracing::info!(
             gpu = worker.gpu.ordinal,

--- a/crates/mold-server/src/model_manager.rs
+++ b/crates/mold-server/src/model_manager.rs
@@ -415,6 +415,22 @@ pub(crate) fn select_server_load_strategy_for_budget(
         mold_inference::LoadStrategy::Eager
     }
 }
+
+pub(crate) fn select_server_load_strategy_for_device(
+    model_name: &str,
+    paths: &ModelPaths,
+    available_bytes: Option<u64>,
+    device_total_bytes: Option<u64>,
+    hint: Option<ActivationHint>,
+) -> mold_inference::LoadStrategy {
+    if model_name == "flux2-klein-9b:bf16"
+        && device_total_bytes.is_some_and(|total| total < 32_000_000_000)
+    {
+        return mold_inference::LoadStrategy::Sequential;
+    }
+
+    select_server_load_strategy_for_budget(paths, available_bytes, hint)
+}
 pub(crate) type DownloadProgressCallback =
     Arc<dyn Fn(mold_core::download::DownloadProgressEvent) + Send + Sync>;
 
@@ -1505,9 +1521,11 @@ async fn create_and_load_engine(
         cache.active_vram_bytes()
     };
     preflight_memory_guard(model_name, &paths, active_vram, 0, hint)?;
-    let load_strategy = select_server_load_strategy_for_budget(
+    let load_strategy = select_server_load_strategy_for_device(
+        model_name,
         &paths,
         effective_load_available_bytes(active_vram, 0),
+        mold_inference::device::total_vram_bytes(0),
         hint,
     );
     if load_strategy == mold_inference::LoadStrategy::Sequential {
@@ -2090,6 +2108,34 @@ mod tests {
             mold_inference::LoadStrategy::Sequential,
             "server must use load-use-drop for Klein-9B BF16 on 24 GB so the \
              text encoder is not co-resident with the transformer"
+        );
+    }
+
+    #[test]
+    fn server_load_strategy_forces_klein9b_bf16_sequential_on_24gb_even_with_overgenerous_budget() {
+        let (_dir, paths) = flux2_klein9b_bf16_paths();
+        let hint = ActivationHint {
+            width: 1024,
+            height: 1024,
+            batch: 1,
+            dtype_bytes: 2,
+            family: ActivationFamily::Flux2Dit,
+        };
+
+        let strategy = select_server_load_strategy_for_device(
+            "flux2-klein-9b:bf16",
+            &paths,
+            Some(128 * GB),
+            Some(24 * GB),
+            Some(hint),
+        );
+
+        assert_eq!(
+            strategy,
+            mold_inference::LoadStrategy::Sequential,
+            "Klein-9B BF16 must not use eager loading on 24 GB cards even if \
+             the live free-memory query is over-generous or falls back to \
+             system memory"
         );
     }
 

--- a/crates/mold-server/src/model_manager.rs
+++ b/crates/mold-server/src/model_manager.rs
@@ -417,19 +417,21 @@ pub(crate) fn select_server_load_strategy_for_budget(
 }
 
 pub(crate) fn select_server_load_strategy_for_device(
-    model_name: &str,
     paths: &ModelPaths,
     available_bytes: Option<u64>,
     device_total_bytes: Option<u64>,
     hint: Option<ActivationHint>,
 ) -> mold_inference::LoadStrategy {
-    if model_name == "flux2-klein-9b:bf16"
-        && device_total_bytes.is_some_and(|total| total < 32_000_000_000)
-    {
-        return mold_inference::LoadStrategy::Sequential;
-    }
+    let capped_available = match (
+        available_bytes.filter(|available| *available > 0),
+        device_total_bytes.filter(|total| *total > 0),
+    ) {
+        (Some(available), Some(total)) => Some(available.min(total)),
+        (available, None) => available,
+        (None, Some(_)) => None,
+    };
 
-    select_server_load_strategy_for_budget(paths, available_bytes, hint)
+    select_server_load_strategy_for_budget(paths, capped_available, hint)
 }
 pub(crate) type DownloadProgressCallback =
     Arc<dyn Fn(mold_core::download::DownloadProgressEvent) + Send + Sync>;
@@ -1522,7 +1524,6 @@ async fn create_and_load_engine(
     };
     preflight_memory_guard(model_name, &paths, active_vram, 0, hint)?;
     let load_strategy = select_server_load_strategy_for_device(
-        model_name,
         &paths,
         effective_load_available_bytes(active_vram, 0),
         mold_inference::device::total_vram_bytes(0),
@@ -2123,7 +2124,6 @@ mod tests {
         };
 
         let strategy = select_server_load_strategy_for_device(
-            "flux2-klein-9b:bf16",
             &paths,
             Some(128 * GB),
             Some(24 * GB),
@@ -2136,6 +2136,33 @@ mod tests {
             "Klein-9B BF16 must not use eager loading on 24 GB cards even if \
              the live free-memory query is over-generous or falls back to \
              system memory"
+        );
+    }
+
+    #[test]
+    fn server_load_strategy_caps_overgenerous_budget_for_klein_like_bf16_model() {
+        let (_dir, paths) = flux2_klein9b_bf16_paths();
+        let hint = ActivationHint {
+            width: 1024,
+            height: 1024,
+            batch: 1,
+            dtype_bytes: 2,
+            family: ActivationFamily::Flux2Dit,
+        };
+
+        let strategy = select_server_load_strategy_for_device(
+            &paths,
+            Some(128 * GB),
+            Some(24 * GB),
+            Some(hint),
+        );
+
+        assert_eq!(
+            strategy,
+            mold_inference::LoadStrategy::Sequential,
+            "Klein-9B-shaped BF16 loads must use device VRAM as the budget cap \
+             even when the live available-memory reading falls back to a larger \
+             system-memory value"
         );
     }
 


### PR DESCRIPTION
## Summary
- add device-aware server load strategy selection
- force `flux2-klein-9b:bf16` to sequential load-use-drop on cards under 32 GB
- add regression coverage for over-generous memory readings on 24 GB GPUs

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p mold-ai-server server_load_strategy --features cuda -- --nocapture`
- `cargo clippy -p mold-ai-server --features cuda --all-targets -- -D warnings`
- `./scripts/ensure-web-dist.sh && cargo build --release -p mold-ai --features cuda,preview,expand,tui,webp,mp4`
- restarted `mold-server.service`; live `flux2-klein-9b:bf16` request logged `server load strategy degraded to sequential to fit memory budget`, completed, and saved `/home/killswitch/.mold/output/mold-flux2-klein-9b-bf16-1779465458409.png` without entering the multi-GPU OOM cooldown
