### PR TITLE
fix(cli): reject qwen-image-edit batch loops

### DIFF
--- a/crates/mold-cli/src/commands/generate.rs
+++ b/crates/mold-cli/src/commands/generate.rs
@@ -133,6 +133,15 @@ fn effective_negative_prompt(
     }
 }
 
+fn validate_cli_batch_for_family(family: Option<&str>, batch: u32) -> Result<()> {
+    if family == Some("qwen-image-edit") && batch > 1 {
+        anyhow::bail!(
+            "qwen-image-edit only supports --batch 1. Run separate commands for multiple edits."
+        );
+    }
+    Ok(())
+}
+
 #[cfg(any(feature = "cuda", feature = "metal", test))]
 fn apply_local_engine_env_overrides(
     t5_variant_override: Option<&str>,
@@ -254,6 +263,7 @@ pub async fn run(
     let effective_frames = frames.or_else(|| model_cfg.effective_frames());
     let effective_fps = fps.or_else(|| model_cfg.effective_fps());
     let is_ltx2 = family.as_deref() == Some("ltx2");
+    validate_cli_batch_for_family(family.as_deref(), batch)?;
 
     // Default video models to a sensible container unless the user explicitly picked one.
     let output_format = if format == OutputFormat::Png && effective_frames.is_some() {
@@ -2055,6 +2065,20 @@ mod tests {
             effective_negative_prompt(Some("qwen-image-edit"), 1.0, None),
             None
         );
+    }
+
+    #[test]
+    fn qwen_image_edit_rejects_cli_batch_above_one() {
+        let err = validate_cli_batch_for_family(Some("qwen-image-edit"), 2).unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("qwen-image-edit only supports --batch 1"));
+    }
+
+    #[test]
+    fn cli_batch_guard_allows_single_edit_and_other_families() {
+        validate_cli_batch_for_family(Some("qwen-image-edit"), 1).unwrap();
+        validate_cli_batch_for_family(Some("flux"), 4).unwrap();
+        validate_cli_batch_for_family(None, 4).unwrap();
     }
 
     #[test]

--- a/crates/mold-cli/tests/cli_integration.rs
+++ b/crates/mold-cli/tests/cli_integration.rs
@@ -471,6 +471,29 @@ fn run_mask_requires_image_flag() {
         .failure();
 }
 
+#[test]
+fn run_qwen_image_edit_rejects_batch_before_remote_generation() {
+    let env = TestEnv::new();
+    let image = env.home.join("edit.png");
+    let img = image::RgbImage::from_fn(16, 16, |_, _| image::Rgb([255, 0, 0]));
+    img.save(&image).unwrap();
+
+    env.cmd()
+        .args([
+            "run",
+            "qwen-image-edit-2511:q4",
+            "replace the background",
+            "--image",
+        ])
+        .arg(&image)
+        .args(["--batch", "2", "--output", "out.png"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "qwen-image-edit only supports --batch 1",
+        ));
+}
+
 // ── mold pull (error paths) ───────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

- Reject `qwen-image-edit` CLI runs with `--batch > 1` before request construction.
- Add unit coverage for the family/batch guard.
- Add a blackbox CLI test for `mold run qwen-image-edit-2511:q4 ... --batch 2` so the remote per-item loop cannot regress.

## Context

References #291.

The server/core validation already rejects `qwen-image-edit` requests whose wire `batch_size` is not `1`. The CLI remote path, however, implements `--batch N` as `N` separate requests and rewrites each request to `batch_size = 1`, so `--batch 5` could still enter multiple sequential edit generations and hit the “batch 2” OOM behavior tracked in #291.

This PR closes that CLI escape hatch. It does not claim to resolve the remaining server-side memory parity question in #291.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p mold-ai-core validation::tests::qwen_image_edit_rejects_batch_size_above_one -- --nocapture`
- `cargo test -p mold-ai qwen_image_edit_rejects_cli_batch_above_one -- --nocapture`
- `cargo test -p mold-ai cli_batch_guard_allows_single_edit_and_other_families -- --nocapture`
- `cargo test -p mold-ai run_qwen_image_edit_rejects_batch_before_remote_generation -- --nocapture`
- `cargo test -p mold-ai generate::tests -- --nocapture`
- `cargo check -p mold-ai`
- `cargo clippy -p mold-ai --all-targets -- -D warnings`
