### PR TITLE
fix(cli): type LTX-2 pipeline flag

### DIFF
--- a/crates/mold-cli/src/commands/run.rs
+++ b/crates/mold-cli/src/commands/run.rs
@@ -12,7 +12,7 @@ use mold_core::{
 use std::io::{IsTerminal, Read};
 use std::path::Path;
 
-use crate::{Ltx2SpatialUpscaleArg, Ltx2TemporalUpscaleArg};
+use crate::{Ltx2PipelineArg, Ltx2SpatialUpscaleArg, Ltx2TemporalUpscaleArg};
 
 use super::generate;
 
@@ -291,20 +291,17 @@ fn validate_image_args_for_family(family: &str, image: &[String]) -> Result<()> 
     Ok(())
 }
 
-fn parse_pipeline(value: Option<String>) -> Result<Option<Ltx2PipelineMode>> {
-    value
-        .map(|value| match value.as_str() {
-            "one-stage" => Ok(Ltx2PipelineMode::OneStage),
-            "two-stage" => Ok(Ltx2PipelineMode::TwoStage),
-            "two-stage-hq" => Ok(Ltx2PipelineMode::TwoStageHq),
-            "distilled" => Ok(Ltx2PipelineMode::Distilled),
-            "ic-lora" => Ok(Ltx2PipelineMode::IcLora),
-            "keyframe" => Ok(Ltx2PipelineMode::Keyframe),
-            "a2vid" => Ok(Ltx2PipelineMode::A2Vid),
-            "retake" => Ok(Ltx2PipelineMode::Retake),
-            _ => anyhow::bail!("unsupported LTX-2 pipeline: {value}"),
-        })
-        .transpose()
+fn parse_pipeline(value: Option<Ltx2PipelineArg>) -> Option<Ltx2PipelineMode> {
+    value.map(|value| match value {
+        Ltx2PipelineArg::OneStage => Ltx2PipelineMode::OneStage,
+        Ltx2PipelineArg::TwoStage => Ltx2PipelineMode::TwoStage,
+        Ltx2PipelineArg::TwoStageHq => Ltx2PipelineMode::TwoStageHq,
+        Ltx2PipelineArg::Distilled => Ltx2PipelineMode::Distilled,
+        Ltx2PipelineArg::IcLora => Ltx2PipelineMode::IcLora,
+        Ltx2PipelineArg::Keyframe => Ltx2PipelineMode::Keyframe,
+        Ltx2PipelineArg::A2Vid => Ltx2PipelineMode::A2Vid,
+        Ltx2PipelineArg::Retake => Ltx2PipelineMode::Retake,
+    })
 }
 
 fn parse_spatial_upscale(value: Option<Ltx2SpatialUpscaleArg>) -> Option<Ltx2SpatialUpscale> {
@@ -460,7 +457,7 @@ pub async fn run(
     audio_file: Option<String>,
     video: Option<String>,
     keyframe: Vec<String>,
-    pipeline: Option<String>,
+    pipeline: Option<Ltx2PipelineArg>,
     retake: Option<String>,
     spatial_upscale: Option<Ltx2SpatialUpscaleArg>,
     temporal_upscale: Option<Ltx2TemporalUpscaleArg>,
@@ -580,7 +577,7 @@ pub async fn run(
     let audio_file_bytes = audio_file.as_deref().map(std::fs::read).transpose()?;
     let source_video_bytes = video.as_deref().map(std::fs::read).transpose()?;
     let keyframes = parse_keyframes(&keyframe)?;
-    let pipeline = parse_pipeline(pipeline)?;
+    let pipeline = parse_pipeline(pipeline);
     let retake_range = parse_retake_range(retake)?;
     let spatial_upscale = parse_spatial_upscale(spatial_upscale);
     let temporal_upscale = parse_temporal_upscale(temporal_upscale);

--- a/crates/mold-cli/src/main.rs
+++ b/crates/mold-cli/src/main.rs
@@ -43,6 +43,26 @@ pub(crate) enum Ltx2TemporalUpscaleArg {
     X2,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, clap::ValueEnum)]
+pub(crate) enum Ltx2PipelineArg {
+    #[value(name = "one-stage")]
+    OneStage,
+    #[value(name = "two-stage")]
+    TwoStage,
+    #[value(name = "two-stage-hq")]
+    TwoStageHq,
+    #[value(name = "distilled")]
+    Distilled,
+    #[value(name = "ic-lora")]
+    IcLora,
+    #[value(name = "keyframe")]
+    Keyframe,
+    #[value(name = "a2vid")]
+    A2Vid,
+    #[value(name = "retake")]
+    Retake,
+}
+
 /// Sentinel error: the command already printed diagnostics to stderr.
 /// The main handler should just exit(1) without printing anything extra.
 #[derive(Debug)]
@@ -464,12 +484,8 @@ Examples:
         keyframe: Vec<String>,
 
         /// LTX-2 pipeline mode.
-        #[arg(
-            long,
-            help_heading = "Video",
-            value_parser = ["one-stage", "two-stage", "two-stage-hq", "distilled", "ic-lora", "keyframe", "a2vid", "retake"]
-        )]
-        pipeline: Option<String>,
+        #[arg(long, help_heading = "Video", value_enum)]
+        pipeline: Option<Ltx2PipelineArg>,
 
         /// Retake time range in the form <start:end> seconds.
         #[arg(long, help_heading = "Video")]
@@ -1907,6 +1923,40 @@ mod tests {
             Commands::Run { steps, .. } => assert_eq!(steps, Some(20)),
             _ => panic!("expected Run"),
         }
+    }
+
+    #[test]
+    fn run_pipeline_uses_typed_value_enum() {
+        let cli = parse(&[
+            "run",
+            "ltx-2-19b-distilled:fp8",
+            "a clip",
+            "--pipeline",
+            "two-stage-hq",
+        ]);
+        match cli.command {
+            Commands::Run { pipeline, .. } => {
+                assert_eq!(pipeline, Some(Ltx2PipelineArg::TwoStageHq));
+            }
+            _ => panic!("expected Run"),
+        }
+    }
+
+    #[test]
+    fn run_pipeline_rejects_unknown_value_at_parse_time() {
+        let err = match try_parse(&[
+            "run",
+            "ltx-2-19b-distilled:fp8",
+            "a clip",
+            "--pipeline",
+            "unknown",
+        ]) {
+            Ok(_) => panic!("expected invalid pipeline value"),
+            Err(err) => err,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("invalid value 'unknown'"), "got: {msg}");
+        assert!(msg.contains("two-stage-hq"), "got: {msg}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Replace the stringly typed `mold run --pipeline` parser with a clap `ValueEnum`.
- Preserve the existing accepted LTX-2 pipeline values.
- Add CLI parser tests for a valid pipeline value and parse-time rejection of an unknown value.

## Context

References #221. This addresses the small CLI productization item from the LTX-2 follow-up list; the larger runtime throughput/parity work remains open.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p mold-ai run_pipeline_uses_typed_value_enum -- --nocapture`
- `cargo test -p mold-ai run_pipeline_rejects_unknown_value_at_parse_time -- --nocapture`
- `cargo test -p mold-ai main::tests -- --nocapture`
- `cargo check -p mold-ai`
- `cargo clippy -p mold-ai --all-targets -- -D warnings`

## Review

- Subagent review found no issues: accepted values are preserved, parse-time clap rejection is consistent with the other LTX-2 enum flags, and no required docs/call-site updates were missed.
