### PR TITLE
Persist Generate drafts and run upscalers

### DIFF
--- a/crates/mold-server/src/gpu_worker.rs
+++ b/crates/mold-server/src/gpu_worker.rs
@@ -1,6 +1,7 @@
 use crate::gpu_pool::{ActiveGeneration, GpuJob, GpuWorker};
 use crate::model_cache::ModelResidency;
 use crate::queue::{
+    apply_output_dimensions_to_metadata, apply_upscale_response_to_image_generation,
     build_sse_complete_event, clean_error_message, save_image_to_dir, save_video_to_dir,
 };
 use crate::state::{GenerationJobResult, SseMessage};
@@ -130,6 +131,56 @@ pub(crate) fn oom_user_message_for_request(
 
 fn is_video_family(family_slug: &str) -> bool {
     matches!(family_slug, "ltx-video" | "ltx2" | "ltx-2" | "ltx-2.3")
+}
+
+fn upscale_generated_image_on_worker(
+    worker: &GpuWorker,
+    job: &GpuJob,
+    upscale_model: &str,
+    img: ImageData,
+    response: &mut mold_core::GenerateResponse,
+) -> Result<ImageData, String> {
+    let model_name = mold_core::manifest::resolve_model_name(upscale_model);
+    let weights_path = {
+        let config = job.config.blocking_read();
+        config
+            .models
+            .get(&model_name)
+            .and_then(|c| c.transformer.as_ref())
+            .map(std::path::PathBuf::from)
+    }
+    .ok_or_else(|| format!("upscaler model '{model_name}' is not downloaded"))?;
+
+    if let Some(ref tx) = job.progress_tx {
+        let _ = tx.send(SseMessage::Progress(SseProgressEvent::StageStart {
+            name: format!("Loading upscaler {model_name}"),
+        }));
+    }
+    let mut engine = mold_inference::create_upscale_engine(
+        model_name.clone(),
+        weights_path,
+        mold_inference::LoadStrategy::Eager,
+        worker.gpu.ordinal,
+    )
+    .map_err(|e| format!("failed to load upscaler: {e}"))?;
+    if let Some(ref tx) = job.progress_tx {
+        let tx = tx.clone();
+        engine.set_on_progress(Box::new(move |event| {
+            let _ = tx.send(SseMessage::Progress(progress_to_sse(event)));
+        }));
+    }
+    let req = mold_core::UpscaleRequest {
+        model: model_name,
+        image: img.data.clone(),
+        output_format: img.format,
+        tile_size: None,
+    };
+    let upscaled = engine
+        .upscale(&req)
+        .map_err(|e| format!("upscale failed: {e}"))?;
+    engine.clear_on_progress();
+    apply_upscale_response_to_image_generation(&job.request, response, img, upscaled)
+        .map_err(|e| format!("upscale failed: {e}"))
 }
 
 fn cuda_oom_user_message(
@@ -401,7 +452,7 @@ fn process_job(worker: &GpuWorker, job: GpuJob) {
             }
 
             // Extract the primary image (or video thumbnail).
-            let img = if !response.images.is_empty() {
+            let mut img = if !response.images.is_empty() {
                 response.images.remove(0)
             } else if let Some(ref video) = response.video {
                 ImageData {
@@ -415,6 +466,35 @@ fn process_job(worker: &GpuWorker, job: GpuJob) {
                 unreachable!("checked above");
             };
 
+            if response.video.is_none() {
+                if let Some(upscale_model) = job
+                    .request
+                    .upscale_model
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|m| !m.is_empty())
+                {
+                    match upscale_generated_image_on_worker(
+                        worker,
+                        &job,
+                        upscale_model,
+                        img.clone(),
+                        &mut response,
+                    ) {
+                        Ok(upscaled) => img = upscaled,
+                        Err(err_msg) => {
+                            if let Some(ref tx) = job.progress_tx {
+                                let _ = tx.send(SseMessage::Error(SseErrorEvent {
+                                    message: err_msg.clone(),
+                                }));
+                            }
+                            let _ = job.result_tx.send(Err(err_msg));
+                            return;
+                        }
+                    }
+                }
+            }
+
             // Save to output directory if configured. Routes through the
             // shared queue helpers so the metadata-DB upsert (and embedded
             // chunks, hostname/backend tagging) cannot drift between the
@@ -423,12 +503,15 @@ fn process_job(worker: &GpuWorker, job: GpuJob) {
             // invisible to /api/gallery until the next reconcile on
             // server restart.
             if let Some(ref dir) = job.output_dir {
-                let metadata = OutputMetadata::from_generate_request(
+                let mut metadata = OutputMetadata::from_generate_request(
                     &job.request,
                     response.seed_used,
                     None,
                     mold_core::build_info::version_string(),
                 );
+                if response.video.is_none() {
+                    apply_output_dimensions_to_metadata(&mut metadata, &img);
+                }
                 let generation_time_ms = response.generation_time_ms as i64;
                 let db = job.metadata_db.as_ref().as_ref();
                 if let Some(ref video) = response.video {
@@ -1030,8 +1113,12 @@ pub fn run_chain_blocking<T, E>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::job_registry::JobRegistry;
     use crate::model_cache::ModelCache;
-    use mold_core::{Config, GenerateRequest, GenerateResponse};
+    use crate::state::QueueHandle;
+    use mold_core::{
+        Config, GenerateRequest, GenerateResponse, ImageData, ModelConfig, OutputFormat,
+    };
     use mold_inference::device::DiscoveredGpu;
     use mold_inference::shared_pool::SharedPool;
     use mold_inference::InferenceEngine;
@@ -1099,6 +1186,99 @@ mod tests {
             degraded_until: RwLock::new(None),
             job_tx,
         })
+    }
+
+    fn fake_upscale_job(config: Config, upscale_model: &str) -> GpuJob {
+        let (result_tx, _result_rx) = tokio::sync::oneshot::channel();
+        let (queue_tx, _queue_rx) = tokio::sync::mpsc::channel(1);
+        let mut request: GenerateRequest = serde_json::from_str(
+            r#"{"prompt":"portrait","model":"flux-dev:q4","width":512,"height":512,"steps":4,"guidance":3.5,"batch_size":1}"#,
+        )
+        .unwrap();
+        request.upscale_model = Some(upscale_model.to_string());
+        GpuJob {
+            id: "job-upscale-test".to_string(),
+            model: request.model.clone(),
+            request,
+            progress_tx: None,
+            result_tx,
+            output_dir: None,
+            config: Arc::new(tokio::sync::RwLock::new(config)),
+            metadata_db: Arc::new(None),
+            queue: QueueHandle::new(queue_tx),
+            registry: JobRegistry::new(),
+        }
+    }
+
+    fn fake_upscale_image() -> ImageData {
+        ImageData {
+            data: vec![0x89, 0x50, 0x4E, 0x47],
+            format: OutputFormat::Png,
+            width: 512,
+            height: 512,
+            index: 0,
+        }
+    }
+
+    #[test]
+    fn worker_post_upscale_reports_missing_downloaded_model() {
+        let worker = single_worker_pool_with_parked("flux-dev:q4", Duration::ZERO);
+        let job = fake_upscale_job(Config::default(), "real-esrgan-x4plus:fp16");
+        let mut response = GenerateResponse {
+            images: vec![],
+            video: None,
+            generation_time_ms: 10,
+            model: job.request.model.clone(),
+            seed_used: 7,
+            gpu: None,
+        };
+
+        let err = upscale_generated_image_on_worker(
+            &worker,
+            &job,
+            "real-esrgan-x4plus:fp16",
+            fake_upscale_image(),
+            &mut response,
+        )
+        .expect_err("worker should reject a missing upscaler config");
+
+        assert!(err.contains("not downloaded"), "got: {err}");
+    }
+
+    #[test]
+    fn worker_post_upscale_surfaces_missing_weights_path() {
+        let worker = single_worker_pool_with_parked("flux-dev:q4", Duration::ZERO);
+        let tmp = tempfile::TempDir::new().unwrap();
+        let missing_weights = tmp.path().join("missing-upscaler.safetensors");
+        let mut config = Config::default();
+        config.models.insert(
+            "real-esrgan-x4plus:fp16".to_string(),
+            ModelConfig {
+                transformer: Some(missing_weights.display().to_string()),
+                ..Default::default()
+            },
+        );
+        let job = fake_upscale_job(config, "real-esrgan-x4plus:fp16");
+        let mut response = GenerateResponse {
+            images: vec![],
+            video: None,
+            generation_time_ms: 10,
+            model: job.request.model.clone(),
+            seed_used: 7,
+            gpu: None,
+        };
+
+        let err = upscale_generated_image_on_worker(
+            &worker,
+            &job,
+            "real-esrgan-x4plus:fp16",
+            fake_upscale_image(),
+            &mut response,
+        )
+        .expect_err("worker should surface missing weight files before generation completes");
+
+        assert!(err.contains("failed to load upscaler"), "got: {err}");
+        assert!(err.contains("upscaler weights not found"), "got: {err}");
     }
 
     /// Two concurrent callers into `run_chain_blocking` on the same worker

--- a/crates/mold-server/src/queue.rs
+++ b/crates/mold-server/src/queue.rs
@@ -197,6 +197,129 @@ pub(crate) fn save_video_to_dir(
     }
 }
 
+fn requested_post_upscale_model(req: &mold_core::GenerateRequest) -> Option<&str> {
+    req.upscale_model
+        .as_deref()
+        .map(str::trim)
+        .filter(|m| !m.is_empty())
+}
+
+pub(crate) fn apply_output_dimensions_to_metadata(metadata: &mut OutputMetadata, img: &ImageData) {
+    metadata.width = img.width;
+    metadata.height = img.height;
+}
+
+pub(crate) fn apply_upscale_response_to_image_generation(
+    req: &mold_core::GenerateRequest,
+    response: &mut mold_core::GenerateResponse,
+    original: ImageData,
+    upscaled: mold_core::UpscaleResponse,
+) -> anyhow::Result<ImageData> {
+    if response.video.is_some() || requested_post_upscale_model(req).is_none() {
+        return Ok(original);
+    }
+    if upscaled.image.data.is_empty() {
+        anyhow::bail!("upscaler returned an empty image");
+    }
+    response.generation_time_ms = response
+        .generation_time_ms
+        .saturating_add(upscaled.upscale_time_ms);
+    Ok(ImageData {
+        index: original.index,
+        ..upscaled.image
+    })
+}
+
+async fn upscale_generated_image_on_single_worker(
+    state: &AppState,
+    req: &mold_core::GenerateRequest,
+    img: ImageData,
+    progress_tx: Option<&tokio::sync::mpsc::UnboundedSender<SseMessage>>,
+) -> Result<ImageData, String> {
+    let Some(upscale_model) = requested_post_upscale_model(req).map(str::to_string) else {
+        return Ok(img);
+    };
+    let model_name = mold_core::manifest::resolve_model_name(&upscale_model);
+    if let Some(tx) = progress_tx {
+        let _ = tx.send(SseMessage::Progress(SseProgressEvent::StageStart {
+            name: format!("Loading upscaler {model_name}"),
+        }));
+    }
+
+    let needs_pull = {
+        let config = state.config.read().await;
+        config
+            .models
+            .get(&model_name)
+            .and_then(|c| c.transformer.as_ref())
+            .is_none()
+    };
+    if needs_pull {
+        if mold_core::manifest::find_manifest(&model_name).is_none() {
+            return Err(format!("unknown upscaler model '{model_name}'"));
+        }
+        model_manager::pull_model(state, &model_name, None)
+            .await
+            .map_err(|e| format!("failed to pull upscaler model: {}", e.error))?;
+    }
+
+    let weights_path = {
+        let config = state.config.read().await;
+        config
+            .models
+            .get(&model_name)
+            .and_then(|c| c.transformer.as_ref())
+            .map(std::path::PathBuf::from)
+    }
+    .ok_or_else(|| format!("upscaler model '{model_name}' not configured after pull"))?;
+
+    let upscale_req = mold_core::UpscaleRequest {
+        model: model_name.clone(),
+        image: img.data.clone(),
+        output_format: img.format,
+        tile_size: None,
+    };
+    let upscaler_cache = state.upscaler_cache.clone();
+    let progress_tx_for_blocking = progress_tx.cloned();
+    let upscaled =
+        tokio::task::spawn_blocking(move || -> anyhow::Result<mold_core::UpscaleResponse> {
+            let mut cache = upscaler_cache.lock().unwrap_or_else(|e| e.into_inner());
+            let needs_new = cache.as_ref().is_none_or(|e| e.model_name() != model_name);
+            if needs_new {
+                let new_engine = mold_inference::create_upscale_engine(
+                    model_name.clone(),
+                    weights_path,
+                    mold_inference::LoadStrategy::Eager,
+                    0,
+                )?;
+                *cache = Some(new_engine);
+            }
+            let engine = cache.as_mut().unwrap();
+            if let Some(tx) = progress_tx_for_blocking {
+                engine.set_on_progress(Box::new(move |event| {
+                    let _ = tx.send(SseMessage::Progress(progress_to_sse(event)));
+                }));
+            }
+            let result = engine.upscale(&upscale_req);
+            engine.clear_on_progress();
+            result
+        })
+        .await
+        .map_err(|e| format!("upscale task failed: {e}"))?
+        .map_err(|e| format!("upscale failed: {e}"))?;
+
+    let mut response = mold_core::GenerateResponse {
+        images: vec![],
+        video: None,
+        generation_time_ms: 0,
+        model: req.model.clone(),
+        seed_used: req.seed.unwrap_or(0),
+        gpu: None,
+    };
+    apply_upscale_response_to_image_generation(req, &mut response, img, upscaled)
+        .map_err(|e| format!("upscale failed: {e}"))
+}
+
 /// Persist a video's `.preview.gif` sidecar to the server's preview cache
 /// (`$MOLD_HOME/cache/previews/<filename>.preview.gif`). Best-effort —
 /// warnings log and return so a failure here never fails the save path.
@@ -714,7 +837,7 @@ async fn process_job(state: &AppState, job: GenerationJob) {
             }
             // For video-only responses, synthesize an ImageData from the thumbnail
             // so the existing queue/SSE pipeline can handle it.
-            let img = if !response.images.is_empty() {
+            let mut img = if !response.images.is_empty() {
                 response.images.remove(0)
             } else if let Some(ref video) = response.video {
                 ImageData {
@@ -727,6 +850,29 @@ async fn process_job(state: &AppState, job: GenerationJob) {
             } else {
                 unreachable!("checked above");
             };
+            if response.video.is_none() && requested_post_upscale_model(&job.request).is_some() {
+                match upscale_generated_image_on_single_worker(
+                    state,
+                    &job.request,
+                    img,
+                    job.progress_tx.as_ref(),
+                )
+                .await
+                {
+                    Ok(upscaled) => {
+                        img = upscaled;
+                    }
+                    Err(err_msg) => {
+                        if let Some(ref tx) = job.progress_tx {
+                            let _ = tx.send(SseMessage::Error(SseErrorEvent {
+                                message: err_msg.clone(),
+                            }));
+                        }
+                        let _ = job.result_tx.send(Err(err_msg));
+                        return;
+                    }
+                }
+            }
 
             // Save to output directory if configured.
             // Builds OutputMetadata from the request + the engine's actual
@@ -736,12 +882,15 @@ async fn process_job(state: &AppState, job: GenerationJob) {
                 let model = job.request.model.clone();
                 let batch_size = job.request.batch_size;
                 let generation_time_ms = response.generation_time_ms as i64;
-                let metadata = OutputMetadata::from_generate_request(
+                let mut metadata = OutputMetadata::from_generate_request(
                     &job.request,
                     response.seed_used,
                     None,
                     mold_core::build_info::version_string(),
                 );
+                if response.video.is_none() {
+                    apply_output_dimensions_to_metadata(&mut metadata, &img);
+                }
                 let db = state.metadata_db.clone();
                 if let Some(ref video) = response.video {
                     let video_data = video.data.clone();
@@ -1109,7 +1258,7 @@ mod tests {
     use crate::gpu_pool::{GpuPool, GpuWorker};
     use crate::model_cache::ModelCache;
     use crate::state::QueueHandle;
-    use mold_core::{GenerateRequest, ImageData, OutputFormat};
+    use mold_core::{GenerateRequest, ImageData, ModelConfig, OutputFormat};
     use mold_db::MetadataDb;
     use mold_inference::device::DiscoveredGpu;
     use mold_inference::shared_pool::SharedPool;
@@ -1200,6 +1349,15 @@ mod tests {
             job_tx,
         });
         (worker, job_rx)
+    }
+
+    fn empty_test_state(config: mold_core::Config) -> crate::state::AppState {
+        crate::state::AppState::empty(
+            config,
+            QueueHandle::new(tokio::sync::mpsc::channel(1).0),
+            crate::state::AppState::empty_gpu_pool(),
+            200,
+        )
     }
 
     #[test]
@@ -1522,6 +1680,180 @@ mod tests {
         assert!(event.video_gif_preview.is_none());
         assert!(!event.video_has_audio);
         assert!(event.video_duration_ms.is_none());
+    }
+
+    #[test]
+    fn post_generation_upscale_replaces_image_response_dimensions() {
+        let mut req = fake_request("flux-dev:q4");
+        req.upscale_model = Some("real-esrgan-x4plus:fp16".to_string());
+        let mut response = mold_core::GenerateResponse {
+            images: vec![],
+            video: None,
+            generation_time_ms: 100,
+            model: "flux-dev:q4".to_string(),
+            seed_used: 5,
+            gpu: None,
+        };
+        let img = fake_image();
+        let upscaled = mold_core::UpscaleResponse {
+            image: ImageData {
+                data: vec![1, 2, 3],
+                format: OutputFormat::Png,
+                width: 2048,
+                height: 2048,
+                index: 0,
+            },
+            upscale_time_ms: 42,
+            model: "real-esrgan-x4plus:fp16".to_string(),
+            scale_factor: 4,
+            original_width: 512,
+            original_height: 512,
+        };
+
+        let next = apply_upscale_response_to_image_generation(&req, &mut response, img, upscaled)
+            .expect("image upscale should apply");
+        let event = build_sse_complete_event(&response, &next);
+        let mut metadata =
+            OutputMetadata::from_generate_request(&req, response.seed_used, None, "test-version");
+        apply_output_dimensions_to_metadata(&mut metadata, &next);
+
+        assert_eq!(next.width, 2048);
+        assert_eq!(next.height, 2048);
+        assert_eq!(event.width, 2048);
+        assert_eq!(event.height, 2048);
+        assert_eq!(metadata.width, 2048);
+        assert_eq!(metadata.height, 2048);
+        assert_eq!(
+            metadata.upscale_model.as_deref(),
+            Some("real-esrgan-x4plus:fp16")
+        );
+    }
+
+    #[test]
+    fn post_generation_upscale_skips_video_responses() {
+        let mut req = fake_request("ltx-video:fp16");
+        req.upscale_model = Some("real-esrgan-x4plus:fp16".to_string());
+        let video = mold_core::VideoData {
+            data: vec![0, 0, 0, 24],
+            format: OutputFormat::Mp4,
+            width: 512,
+            height: 512,
+            frames: 25,
+            fps: 24,
+            thumbnail: vec![9, 9],
+            gif_preview: vec![],
+            has_audio: false,
+            duration_ms: None,
+            audio_sample_rate: None,
+            audio_channels: None,
+        };
+        let mut response = mold_core::GenerateResponse {
+            images: vec![],
+            video: Some(video),
+            generation_time_ms: 100,
+            model: "ltx-video:fp16".to_string(),
+            seed_used: 5,
+            gpu: None,
+        };
+        let img = fake_image();
+        let upscaled = mold_core::UpscaleResponse {
+            image: ImageData {
+                data: vec![1, 2, 3],
+                format: OutputFormat::Png,
+                width: 2048,
+                height: 2048,
+                index: 0,
+            },
+            upscale_time_ms: 42,
+            model: "real-esrgan-x4plus:fp16".to_string(),
+            scale_factor: 4,
+            original_width: 512,
+            original_height: 512,
+        };
+
+        let next = apply_upscale_response_to_image_generation(&req, &mut response, img, upscaled)
+            .expect("video upscale should be skipped");
+
+        assert_eq!(next.width, 512);
+        assert_eq!(next.height, 512);
+        assert!(response.video.is_some());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn single_worker_post_upscale_noops_without_model() {
+        let state = empty_test_state(mold_core::Config::default());
+        let req = fake_request("flux-dev:q4");
+
+        let next = upscale_generated_image_on_single_worker(&state, &req, fake_image(), None)
+            .await
+            .expect("missing upscale model should leave the image unchanged");
+
+        assert_eq!(next.width, 512);
+        assert_eq!(next.height, 512);
+        assert_eq!(next.index, 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn single_worker_post_upscale_rejects_unknown_upscaler_manifest() {
+        let state = empty_test_state(mold_core::Config::default());
+        let mut req = fake_request("flux-dev:q4");
+        req.upscale_model = Some("definitely-not-a-real-upscaler:fp16".to_string());
+        let (progress_tx, mut progress_rx) = tokio::sync::mpsc::unbounded_channel();
+
+        let err = upscale_generated_image_on_single_worker(
+            &state,
+            &req,
+            fake_image(),
+            Some(&progress_tx),
+        )
+        .await
+        .expect_err("unknown upscalers should fail before generation completes");
+
+        assert!(err.contains("unknown upscaler model"), "got: {err}");
+        let first_progress = progress_rx
+            .try_recv()
+            .expect("loading stage should be emitted before validation fails");
+        assert!(matches!(
+            first_progress,
+            SseMessage::Progress(SseProgressEvent::StageStart { .. })
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn single_worker_post_upscale_surfaces_missing_weights_path() {
+        let tmp = TempDir::new().unwrap();
+        let missing_weights = tmp.path().join("missing-upscaler.safetensors");
+        let mut config = mold_core::Config::default();
+        config.models.insert(
+            "real-esrgan-x4plus:fp16".to_string(),
+            ModelConfig {
+                transformer: Some(missing_weights.display().to_string()),
+                ..Default::default()
+            },
+        );
+        let state = empty_test_state(config);
+        let mut req = fake_request("flux-dev:q4");
+        req.upscale_model = Some("real-esrgan-x4plus:fp16".to_string());
+        let (progress_tx, mut progress_rx) = tokio::sync::mpsc::unbounded_channel();
+
+        let err = upscale_generated_image_on_single_worker(
+            &state,
+            &req,
+            fake_image(),
+            Some(&progress_tx),
+        )
+        .await
+        .expect_err("missing weight files should be surfaced");
+
+        assert!(err.contains("upscale failed"), "got: {err}");
+        assert!(err.contains("upscaler weights not found"), "got: {err}");
+        let first_progress = progress_rx
+            .try_recv()
+            .expect("loading stage should be emitted before loading fails");
+        assert!(matches!(
+            first_progress,
+            SseMessage::Progress(SseProgressEvent::StageStart { .. })
+        ));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -13,6 +13,8 @@ import type {
   SseChainCompleteEvent,
   SseCompleteEvent,
   SseProgressEvent,
+  SseUpscaleCompleteEvent,
+  UpscaleRequestWire,
   QueueEntry,
   QueueListing,
 } from "./types";
@@ -263,6 +265,72 @@ export async function generateStream(
   } catch (err) {
     if (signal?.aborted) return; // user canceled
     if (terminal) return;
+    handlers.onError({
+      kind: "network",
+      message: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+export interface UpscaleStreamHandlers {
+  onProgress: (evt: SseProgressEvent) => void;
+  onComplete: (evt: SseUpscaleCompleteEvent) => void;
+  onError: (
+    err:
+      | { kind: "http"; status: number; retryAfter?: number; body: string }
+      | { kind: "network"; message: string },
+  ) => void;
+}
+
+export async function upscaleStream(
+  req: UpscaleRequestWire,
+  handlers: UpscaleStreamHandlers,
+  signal?: AbortSignal,
+): Promise<void> {
+  let terminal = false;
+  try {
+    await streamSse({
+      url: `${base}/api/upscale/stream`,
+      body: req,
+      signal,
+      onEvent: (evt) => {
+        if (!evt.data) return;
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(evt.data);
+        } catch {
+          return;
+        }
+        if (evt.event === "complete") {
+          terminal = true;
+          handlers.onComplete(parsed as SseUpscaleCompleteEvent);
+        } else if (evt.event === "error") {
+          terminal = true;
+          handlers.onError({ kind: "http", status: 0, body: evt.data });
+        } else {
+          handlers.onProgress(parsed as SseProgressEvent);
+        }
+      },
+      onHttpError: (res) => {
+        terminal = true;
+        res
+          .text()
+          .then((body) =>
+            handlers.onError({ kind: "http", status: res.status, body }),
+          )
+          .catch(() =>
+            handlers.onError({ kind: "http", status: res.status, body: "" }),
+          );
+      },
+    });
+    if (!terminal && !signal?.aborted) {
+      handlers.onError({
+        kind: "network",
+        message: "upscale stream closed before completion",
+      });
+    }
+  } catch (err) {
+    if (signal?.aborted || terminal) return;
     handlers.onError({
       kind: "network",
       message: err instanceof Error ? err.message : String(err),

--- a/web/src/components/GenerateParamsPanel.test.ts
+++ b/web/src/components/GenerateParamsPanel.test.ts
@@ -421,6 +421,21 @@ describe("GenerateParamsPanel", () => {
     expect(picker.attributes("data-multiple")).toBe("false");
   });
 
+  it("mask base picker also seeds the generation source image", async () => {
+    const w = mountPanel();
+    await w.find("[data-test='params-summary-toggle']").trigger("click");
+
+    await w.get("[data-test='pick-mask-base']").trigger("click");
+    await w.get("[data-test='stub-pick-mask-base']").trigger("click");
+
+    const events = w.emitted("update:modelValue");
+    expect(events).toBeTruthy();
+    const last = events![events!.length - 1][0] as GenerateFormState;
+    expect(last.imageAttachments).toEqual([
+      { kind: "gallery", filename: "gallery-base.png", base64: "GALLERY_BASE" },
+    ]);
+  });
+
   it("hides mask controls for Qwen image edit", async () => {
     const qwenEdit = {
       ...baseModel,

--- a/web/src/components/GenerateParamsPanel.vue
+++ b/web/src/components/GenerateParamsPanel.vue
@@ -563,6 +563,9 @@ function onPickMaskBase(images: SourceImageState[]) {
   showMaskBasePicker.value = false;
   if (!image) return;
   maskEditorSource.value = image;
+  if (!currentSourceImage.value) {
+    patch("imageAttachments", [image]);
+  }
   showMaskEditor.value = true;
 }
 
@@ -573,6 +576,33 @@ function onApplyMask(mask: SourceImageState) {
 
 async function setControlImage(event: Event) {
   patch("controlImage", await readImageState(event));
+}
+
+function setSourceFitPolicy(raw: string) {
+  if (raw === "crop-fill") {
+    patch("sourceFitPolicy", {
+      mode: "crop-fill",
+      alignX: "center",
+      alignY: "center",
+    });
+    return;
+  }
+  if (raw === "lanczos-resize") {
+    patch("sourceFitPolicy", { mode: "lanczos-resize" });
+    return;
+  }
+  if (raw === "upscale-then-fit") {
+    patch("sourceFitPolicy", {
+      mode: "upscale-then-fit",
+      upscalerModel:
+        props.modelValue.upscaleModel || upscalerModels.value[0]?.name || "",
+      fit: { mode: "pad-repaint" },
+    });
+    return;
+  }
+  patch("sourceFitPolicy", {
+    mode: raw === "pad-fit" ? "pad-fit" : "pad-repaint",
+  });
 }
 
 async function setAudioFile(event: Event) {
@@ -877,6 +907,23 @@ function removeKeyframe(index: number) {
 
       <section v-if="!isQwenImageEditFamily(family)" class="mt-4 space-y-3">
         <label class="text-xs uppercase text-slate-400">Image inputs</label>
+        <label class="block text-xs text-slate-300">
+          Source fit
+          <select
+            :value="modelValue.sourceFitPolicy?.mode ?? 'pad-repaint'"
+            class="mt-1 w-full rounded-lg bg-slate-900/60 px-2 py-1 text-sm text-slate-100"
+            data-test="source-fit-policy"
+            @change="
+              setSourceFitPolicy(($event.target as HTMLSelectElement).value)
+            "
+          >
+            <option value="pad-repaint">Pad repaint</option>
+            <option value="crop-fill">Crop fill</option>
+            <option value="pad-fit">Pad fit</option>
+            <option value="lanczos-resize">Lanczos resize</option>
+            <option value="upscale-then-fit">Upscale then fit</option>
+          </select>
+        </label>
         <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
           <label class="rounded-lg bg-slate-900/40 p-2 text-xs text-slate-300">
             Mask image

--- a/web/src/components/RunningJobCard.upscaler.test.ts
+++ b/web/src/components/RunningJobCard.upscaler.test.ts
@@ -1,0 +1,47 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+import RunningJobCard from "./RunningJobCard.vue";
+import type { Job } from "../composables/useGenerateStream";
+
+function makeJob(): Job {
+  return {
+    id: "job-upscale",
+    request: {
+      prompt: "a cat",
+      model: "flux-dev:fp16",
+      width: 512,
+      height: 512,
+      steps: 4,
+      guidance: 3.5,
+      upscale_model: "real-esrgan-x4plus:fp16",
+    },
+    startedAt: 0,
+    controller: new AbortController(),
+    progress: {
+      stage: "Upscaling",
+      step: null,
+      totalSteps: null,
+      weightBytesLoaded: null,
+      weightBytesTotal: null,
+      queuePosition: null,
+      gpu: null,
+      elapsedMs: null,
+    },
+    result: null,
+    error: null,
+    state: "running",
+    chain: null,
+    lastProgressAt: Date.now(),
+    serverId: "server-job-upscale",
+    workStarted: true,
+  };
+}
+
+describe("RunningJobCard upscaler status", () => {
+  it("shows the selected upscaler on a running generation card", () => {
+    const wrapper = mount(RunningJobCard, { props: { job: makeJob() } });
+
+    expect(wrapper.text()).toContain("real-esrgan-x4plus:fp16");
+    expect(wrapper.text()).toContain("Upscaling");
+  });
+});

--- a/web/src/components/RunningJobCard.vue
+++ b/web/src/components/RunningJobCard.vue
@@ -62,6 +62,12 @@ const pct = computed(() => {
   return null;
 });
 
+const upscalerModel = computed(() => {
+  const model = (props.job.request as { upscale_model?: string | null })
+    .upscale_model;
+  return model?.trim() || null;
+});
+
 const thumbSrc = computed(() => {
   const r = props.job.result;
   if (!r) return null;
@@ -110,6 +116,9 @@ const thumbSrc = computed(() => {
       </div>
     </div>
     <div class="text-xs text-slate-300">{{ job.progress.stage }}</div>
+    <div v-if="upscalerModel" class="truncate text-[11px] text-slate-400">
+      Upscaler: {{ upscalerModel }}
+    </div>
     <div
       v-if="isStale"
       role="status"

--- a/web/src/composables/useGenerateForm.test.ts
+++ b/web/src/composables/useGenerateForm.test.ts
@@ -5,6 +5,7 @@ import {
   cloneTemplateForm,
   sanitizePersistedForm,
   useGenerateForm,
+  __testing__,
 } from "./useGenerateForm";
 import type {
   GenerateFormState,
@@ -37,6 +38,7 @@ function makeModel(
 describe("useGenerateForm", () => {
   beforeEach(() => {
     localStorage.clear();
+    __testing__.resetForTest();
     vi.useFakeTimers();
   });
 
@@ -53,6 +55,43 @@ describe("useGenerateForm", () => {
     expect(form.state.value.batchSize).toBe(1);
     expect(form.state.value.outputFormat).toBe("png");
     expect(form.state.value.imageAttachments).toEqual([]);
+    expect(form.state.value.sourceFitPolicy).toEqual({ mode: "pad-repaint" });
+  });
+
+  it("shares a singleton state across route remounts", () => {
+    const first = useGenerateForm();
+    first.state.value.prompt = "persistent cat";
+    first.state.value.width = 768;
+    first.state.value.upscaleModel = "real-esrgan-x4plus:fp16";
+    first.state.value.imageAttachments = [
+      {
+        kind: "upload",
+        filename: "source.png",
+        base64: "SOURCE_BYTES",
+        draftId: "draft-source",
+        width: 640,
+        height: 480,
+        mime: "image/png",
+      },
+    ];
+    first.state.value.maskImage = {
+      kind: "upload",
+      filename: "mask.png",
+      base64: "MASK_BYTES",
+      draftId: "draft-mask",
+      width: 640,
+      height: 480,
+      mime: "image/png",
+    };
+
+    const second = useGenerateForm();
+
+    expect(second.state).toBe(first.state);
+    expect(second.state.value.prompt).toBe("persistent cat");
+    expect(second.state.value.width).toBe(768);
+    expect(second.state.value.upscaleModel).toBe("real-esrgan-x4plus:fp16");
+    expect(second.state.value.imageAttachments[0]?.base64).toBe("SOURCE_BYTES");
+    expect(second.state.value.maskImage?.base64).toBe("MASK_BYTES");
   });
 
   it("migrates a version 1 persisted snapshot but drops source image bytes", () => {
@@ -115,9 +154,41 @@ describe("useGenerateForm", () => {
     expect(raw).not.toBeNull();
     const parsed = JSON.parse(raw!);
     expect(parsed.prompt).toBe("a fox");
-    expect(parsed.sourceImage).toBeUndefined();
-    expect(parsed.imageAttachments).toEqual([]);
+    expect(parsed.imageAttachments[0]).toMatchObject({
+      filename: "x.png",
+      draftId: expect.any(String),
+    });
+    expect(parsed.imageAttachments[0].base64).toBeUndefined();
     expect(raw).not.toContain("SECRETBYTES");
+  });
+
+  it("hydrates media drafts from the draft store after refresh", async () => {
+    const first = useGenerateForm();
+    first.state.value.imageAttachments = [
+      { kind: "upload", filename: "source.png", base64: "SOURCE_BYTES" },
+    ];
+    first.state.value.maskImage = {
+      kind: "upload",
+      filename: "mask.png",
+      base64: "MASK_BYTES",
+    };
+    first.state.value.controlImage = {
+      kind: "upload",
+      filename: "control.png",
+      base64: "CONTROL_BYTES",
+    };
+    await nextTick();
+    vi.advanceTimersByTime(300);
+    await __testing__.flushDraftWrites();
+
+    __testing__.resetForTest();
+    const second = useGenerateForm();
+    await __testing__.flushHydration();
+
+    expect(second.state.value.imageAttachments[0]?.base64).toBe("SOURCE_BYTES");
+    expect(second.state.value.maskImage?.base64).toBe("MASK_BYTES");
+    expect(second.state.value.controlImage?.base64).toBe("CONTROL_BYTES");
+    expect(localStorage.getItem(STORAGE_KEY)).not.toContain("_BYTES");
   });
 
   it("applyModelDefaults copies model defaults and clears video fields for non-video families", () => {
@@ -624,6 +695,7 @@ describe("generate form serialization helpers", () => {
       placement: null,
       loras: [],
       enableAudio: null,
+      sourceFitPolicy: { mode: "pad-repaint" },
       ...overrides,
     };
   }
@@ -661,12 +733,28 @@ describe("generate form serialization helpers", () => {
 
     const sanitized = sanitizePersistedForm(form);
 
-    expect(sanitized.imageAttachments).toEqual([]);
-    expect(sanitized.maskImage).toBeNull();
-    expect(sanitized.controlImage).toBeNull();
-    expect(sanitized.audioFile).toBeNull();
-    expect(sanitized.sourceVideo).toBeNull();
-    expect(sanitized.keyframes).toEqual([]);
+    expect(sanitized.imageAttachments).toEqual([
+      { kind: "gallery", filename: "source.png" },
+    ]);
+    expect(sanitized.maskImage).toEqual({
+      kind: "upload",
+      filename: "mask.png",
+    });
+    expect(sanitized.controlImage).toEqual({
+      kind: "upload",
+      filename: "control.png",
+    });
+    expect(sanitized.audioFile).toEqual({
+      kind: "upload",
+      filename: "voice.wav",
+    });
+    expect(sanitized.sourceVideo).toEqual({
+      kind: "upload",
+      filename: "clip.mp4",
+    });
+    expect(sanitized.keyframes).toEqual([
+      { frame: 24, image: { kind: "upload", filename: "kf.png" } },
+    ]);
     expect(sanitized.audioFilePath).toBe("/srv/voice.wav");
     expect(sanitized.sourceVideoPath).toBe("/srv/clip.mp4");
     expect(JSON.stringify(sanitized)).not.toContain("_BYTES");

--- a/web/src/composables/useGenerateForm.ts
+++ b/web/src/composables/useGenerateForm.ts
@@ -1,4 +1,4 @@
-import { ref, watch, type Ref } from "vue";
+import { ref, watch, type Ref, type WatchStopHandle } from "vue";
 import type {
   GenerateFormState,
   GenerateRequestWire,
@@ -9,6 +9,12 @@ import type {
   Scheduler,
 } from "../types";
 import { MAX_LORA_STACK } from "../types";
+import {
+  clearMemoryDraftsForTest,
+  getDraftMedia,
+  newDraftId,
+  putDraftMedia,
+} from "../lib/draftMediaStore";
 import {
   generationCapabilitiesForFamily,
   isQwenImageEditFamily,
@@ -32,7 +38,7 @@ export function defaultOutputFormat(family: string): OutputFormat {
 }
 
 const STORAGE_KEY = "mold.generate.form";
-const FORM_VERSION = 2;
+const FORM_VERSION = 2 as const;
 const QWEN_IMAGE_EDIT_FAMILY = "qwen-image-edit";
 
 function selectedFamily(s: GenerateFormState): string {
@@ -76,6 +82,7 @@ function defaultForm(): GenerateFormState {
     cfgPlus: false,
     outputFormat: "png",
     expand: { enabled: false, variations: 1, familyOverride: null },
+    sourceFitPolicy: { mode: "pad-repaint" },
     imageAttachments: [],
     maskImage: null,
     controlImage: null,
@@ -98,8 +105,8 @@ function defaultForm(): GenerateFormState {
   };
 }
 
-function cloneFormState(state: GenerateFormState): GenerateFormState {
-  return JSON.parse(JSON.stringify(state)) as GenerateFormState;
+function cloneFormState<T>(state: T): T {
+  return JSON.parse(JSON.stringify(state)) as T;
 }
 
 /** Remove browser-only binary media from a form snapshot before writing it to
@@ -109,16 +116,22 @@ function cloneFormState(state: GenerateFormState): GenerateFormState {
 export function sanitizePersistedForm(
   state: GenerateFormState,
 ): GenerateFormState {
-  return {
+  const sanitized = {
     ...cloneFormState(state),
     version: FORM_VERSION,
-    imageAttachments: [],
-    maskImage: null,
-    controlImage: null,
-    audioFile: null,
-    sourceVideo: null,
-    keyframes: [],
+    imageAttachments: state.imageAttachments.map(stripMediaBytes),
+    maskImage: state.maskImage ? stripMediaBytes(state.maskImage) : null,
+    controlImage: state.controlImage
+      ? stripMediaBytes(state.controlImage)
+      : null,
+    audioFile: state.audioFile ? stripMediaBytes(state.audioFile) : null,
+    sourceVideo: state.sourceVideo ? stripMediaBytes(state.sourceVideo) : null,
+    keyframes: state.keyframes.map((k) => ({
+      ...k,
+      image: stripMediaBytes(k.image),
+    })),
   };
+  return sanitized;
 }
 
 /** Clone the generation configuration that can be safely represented in a
@@ -275,19 +288,123 @@ function migrateLegacy(parsed: LegacyFormState): Partial<GenerateFormState> {
   const {
     lora,
     sourceImage: _sourceImage,
-    imageAttachments: _imageAttachments,
+    imageAttachments,
     version: _version,
     ...rest
   } = parsed;
   const next: Partial<GenerateFormState> = {
     ...rest,
     version: FORM_VERSION,
-    imageAttachments: [],
+    imageAttachments: parsed.version === 1 ? [] : (imageAttachments ?? []),
   };
   if (!Array.isArray(rest.loras)) {
     next.loras = lora ? [lora] : [];
   }
   return next;
+}
+
+function stripMediaBytes<T extends { base64: string }>(media: T): T {
+  const { base64: _base64, ...rest } = cloneFormState(media) as T & {
+    base64?: string;
+  };
+  void _base64;
+  return rest as T;
+}
+
+function ensureDraftIds(state: GenerateFormState) {
+  const ensure = <T extends { base64: string; draftId?: string } | null>(
+    media: T,
+  ): T => {
+    if (media?.base64 && !media.draftId) media.draftId = newDraftId();
+    return media;
+  };
+  state.imageAttachments = state.imageAttachments.map((m) => ensure(m)!);
+  state.maskImage = ensure(state.maskImage);
+  state.controlImage = ensure(state.controlImage);
+  state.audioFile = ensure(state.audioFile);
+  state.sourceVideo = ensure(state.sourceVideo);
+  state.keyframes = state.keyframes.map((k) => ({
+    ...k,
+    image: ensure(k.image)!,
+  }));
+}
+
+function mediaFromState(state: GenerateFormState) {
+  return [
+    ...state.imageAttachments,
+    state.maskImage,
+    state.controlImage,
+    state.audioFile,
+    state.sourceVideo,
+    ...state.keyframes.map((k) => k.image),
+  ].filter((m): m is NonNullable<typeof m> => Boolean(m?.base64));
+}
+
+let pendingDraftWrites: Promise<unknown>[] = [];
+let pendingHydration: Promise<unknown> | null = null;
+
+function persistDraftMedia(state: GenerateFormState) {
+  ensureDraftIds(state);
+  pendingDraftWrites = mediaFromState(state).map((m) => putDraftMedia(m));
+  return Promise.allSettled(pendingDraftWrites);
+}
+
+async function hydrateDraftMedia(state: GenerateFormState) {
+  const hydrate = async <
+    T extends { draftId?: string; base64?: string } | null,
+  >(
+    media: T,
+  ): Promise<T> => {
+    if (!media?.draftId || media.base64) return media;
+    const stored = await getDraftMedia(media.draftId);
+    return stored ? ({ ...media, ...stored } as T) : media;
+  };
+  const attachmentIds = state.imageAttachments.map((m) => m.draftId ?? "");
+  const attachments = await Promise.all(
+    state.imageAttachments.map((m) => hydrate(m)),
+  );
+  if (
+    state.imageAttachments.length === attachmentIds.length &&
+    state.imageAttachments.every(
+      (m, i) => (m.draftId ?? "") === attachmentIds[i],
+    )
+  ) {
+    state.imageAttachments = attachments;
+  }
+
+  const maskId = state.maskImage?.draftId ?? "";
+  const mask = await hydrate(state.maskImage);
+  if ((state.maskImage?.draftId ?? "") === maskId) state.maskImage = mask;
+
+  const controlId = state.controlImage?.draftId ?? "";
+  const control = await hydrate(state.controlImage);
+  if ((state.controlImage?.draftId ?? "") === controlId)
+    state.controlImage = control;
+
+  const audioId = state.audioFile?.draftId ?? "";
+  const audio = await hydrate(state.audioFile);
+  if ((state.audioFile?.draftId ?? "") === audioId) state.audioFile = audio;
+
+  const sourceVideoId = state.sourceVideo?.draftId ?? "";
+  const sourceVideo = await hydrate(state.sourceVideo);
+  if ((state.sourceVideo?.draftId ?? "") === sourceVideoId) {
+    state.sourceVideo = sourceVideo;
+  }
+
+  const keyframeIds = state.keyframes.map(
+    (k) => `${k.frame}:${k.image.draftId ?? ""}`,
+  );
+  const keyframes = await Promise.all(
+    state.keyframes.map(async (k) => ({ ...k, image: await hydrate(k.image) })),
+  );
+  if (
+    state.keyframes.length === keyframeIds.length &&
+    state.keyframes.every(
+      (k, i) => `${k.frame}:${k.image.draftId ?? ""}` === keyframeIds[i],
+    )
+  ) {
+    state.keyframes = keyframes;
+  }
 }
 
 function load(): GenerateFormState {
@@ -312,6 +429,7 @@ function load(): GenerateFormState {
 
 function persist(state: GenerateFormState) {
   try {
+    void persistDraftMedia(state);
     // Drop base64 bytes from localStorage — they blow past the quota quickly
     // and the attachment is re-picked trivially on reload.
     localStorage.setItem(
@@ -348,20 +466,25 @@ export interface UseGenerateForm {
   supportsLora: (family: string) => boolean;
 }
 
-export function useGenerateForm(): UseGenerateForm {
-  const state = ref<GenerateFormState>(load());
+let singleton: UseGenerateForm | null = null;
+let stopPersistWatch: WatchStopHandle | null = null;
+let persistTimer: ReturnType<typeof setTimeout> | null = null;
 
-  let timer: ReturnType<typeof setTimeout> | null = null;
-  watch(
+export function useGenerateForm(): UseGenerateForm {
+  if (singleton) return singleton;
+  const state = ref<GenerateFormState>(load());
+  pendingHydration = hydrateDraftMedia(state.value);
+
+  stopPersistWatch = watch(
     state,
     (v) => {
-      if (timer) clearTimeout(timer);
-      timer = setTimeout(() => persist(v), 300);
+      if (persistTimer) clearTimeout(persistTimer);
+      persistTimer = setTimeout(() => persist(v), 300);
     },
     { deep: true },
   );
 
-  return {
+  singleton = {
     state,
     reset: () => {
       state.value = defaultForm();
@@ -490,9 +613,31 @@ export function useGenerateForm(): UseGenerateForm {
     supportsScheduler,
     supportsLora,
   };
+  return singleton;
 }
 
 // Scheduler type is re-exported so callers can type-narrow without importing
 // both modules.
 export type { Scheduler };
 export { isQwenImageEditFamily };
+
+export const __testing__ = {
+  resetForTest() {
+    stopPersistWatch?.();
+    stopPersistWatch = null;
+    if (persistTimer) clearTimeout(persistTimer);
+    persistTimer = null;
+    singleton = null;
+    pendingDraftWrites = [];
+    pendingHydration = null;
+  },
+  async flushDraftWrites() {
+    await Promise.allSettled(pendingDraftWrites);
+  },
+  async flushHydration() {
+    await pendingHydration;
+  },
+  clearDraftsForTest() {
+    clearMemoryDraftsForTest();
+  },
+};

--- a/web/src/lib/draftMediaStore.ts
+++ b/web/src/lib/draftMediaStore.ts
@@ -1,0 +1,64 @@
+import type { SourceImageState, SourceMediaState } from "../types";
+
+type DraftMedia = SourceImageState | SourceMediaState;
+
+const DB_NAME = "mold-generate-drafts";
+const STORE_NAME = "media";
+const DB_VERSION = 1;
+const memory = new Map<string, DraftMedia>();
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function openDb(): Promise<IDBDatabase | null> {
+  if (typeof indexedDB === "undefined") return Promise.resolve(null);
+  return new Promise((resolve) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => {
+      req.result.createObjectStore(STORE_NAME, { keyPath: "draftId" });
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => resolve(null);
+  });
+}
+
+async function withStore<T>(
+  mode: IDBTransactionMode,
+  fn: (store: IDBObjectStore) => IDBRequest<T>,
+): Promise<T | null> {
+  const db = await openDb();
+  if (!db) return null;
+  return new Promise((resolve) => {
+    const tx = db.transaction(STORE_NAME, mode);
+    const req = fn(tx.objectStore(STORE_NAME));
+    req.onsuccess = () => resolve(req.result ?? null);
+    req.onerror = () => resolve(null);
+    tx.oncomplete = () => db.close();
+    tx.onerror = () => db.close();
+  });
+}
+
+export function newDraftId(): string {
+  return crypto.randomUUID();
+}
+
+export async function putDraftMedia(media: DraftMedia): Promise<void> {
+  if (!media.draftId || !media.base64) return;
+  const saved = clone(media);
+  memory.set(media.draftId, saved);
+  await withStore("readwrite", (store) => store.put(saved));
+}
+
+export async function getDraftMedia<T extends DraftMedia>(
+  draftId: string,
+): Promise<T | null> {
+  const fromDb = await withStore<T>("readonly", (store) => store.get(draftId));
+  if (fromDb) return fromDb;
+  const fromMemory = memory.get(draftId);
+  return fromMemory ? (clone(fromMemory) as T) : null;
+}
+
+export function clearMemoryDraftsForTest() {
+  memory.clear();
+}

--- a/web/src/lib/generationTemplates.test.ts
+++ b/web/src/lib/generationTemplates.test.ts
@@ -85,8 +85,13 @@ describe("generation templates", () => {
 
     expect(saved.name).toBe("Portrait Base");
     expect(saved.form.prompt).toBe("cinematic cat");
-    expect(saved.form.imageAttachments).toEqual([]);
-    expect(saved.form.maskImage).toBeNull();
+    expect(saved.form.imageAttachments).toEqual([
+      { kind: "gallery", filename: "source.png" },
+    ]);
+    expect(saved.form.maskImage).toEqual({
+      kind: "upload",
+      filename: "mask.png",
+    });
     expect(saved.form.audioFilePath).toBe("/srv/audio.wav");
     expect(saved.form.loras).toEqual([
       { path: "/loras/a.safetensors", scale: 0.7, trainedWords: ["style a"] },

--- a/web/src/lib/sourceFit.test.ts
+++ b/web/src/lib/sourceFit.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import {
+  describeSourceFit,
+  maskPaddingRectangles,
+  resolveSourceFitTransform,
+} from "./sourceFit";
+
+describe("source fit policies", () => {
+  it("defaults to pad repaint, preserving requested dimensions and repainting added pixels", () => {
+    const transform = resolveSourceFitTransform(
+      { width: 640, height: 480 },
+      { width: 1024, height: 1024 },
+      { mode: "pad-repaint" },
+    );
+
+    expect(transform).toMatchObject({
+      outputWidth: 1024,
+      outputHeight: 1024,
+      drawWidth: 1024,
+      drawHeight: 768,
+      offsetX: 0,
+      offsetY: 128,
+      maskPaddedPixels: true,
+    });
+    expect(maskPaddingRectangles(transform)).toEqual([
+      { x: 0, y: 0, width: 1024, height: 128 },
+      { x: 0, y: 896, width: 1024, height: 128 },
+    ]);
+  });
+
+  it("supports crop fill with explicit side alignment", () => {
+    const transform = resolveSourceFitTransform(
+      { width: 640, height: 480 },
+      { width: 1024, height: 1024 },
+      { mode: "crop-fill", alignX: "left", alignY: "center" },
+    );
+
+    expect(transform).toMatchObject({
+      outputWidth: 1024,
+      outputHeight: 1024,
+      drawWidth: 1365,
+      drawHeight: 1024,
+      offsetX: 0,
+      offsetY: 0,
+      maskPaddedPixels: false,
+    });
+  });
+
+  it("describes prefit upscaler policies for submit preprocessing", () => {
+    expect(
+      describeSourceFit({
+        mode: "upscale-then-fit",
+        upscalerModel: "real-esrgan-x2plus:fp16",
+        fit: { mode: "pad-repaint" },
+      }),
+    ).toContain("real-esrgan-x2plus:fp16");
+  });
+});

--- a/web/src/lib/sourceFit.ts
+++ b/web/src/lib/sourceFit.ts
@@ -1,0 +1,133 @@
+import type { SourceFitPolicy } from "../types";
+
+export interface Size {
+  width: number;
+  height: number;
+}
+
+export interface Rect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface SourceFitTransform {
+  outputWidth: number;
+  outputHeight: number;
+  drawWidth: number;
+  drawHeight: number;
+  offsetX: number;
+  offsetY: number;
+  maskPaddedPixels: boolean;
+}
+
+function alignOffset(
+  available: number,
+  align: "left" | "center" | "right" | "top" | "bottom" | undefined,
+): number {
+  if (align === "left" || align === "top") return 0;
+  if (align === "right" || align === "bottom") return available;
+  return Math.round(available / 2);
+}
+
+export function resolveSourceFitTransform(
+  source: Size,
+  target: Size,
+  policy: SourceFitPolicy,
+): SourceFitTransform {
+  const fit = policy.mode === "upscale-then-fit" ? policy.fit : policy;
+  const outputWidth = target.width;
+  const outputHeight = target.height;
+  if (fit.mode === "lanczos-resize") {
+    return {
+      outputWidth,
+      outputHeight,
+      drawWidth: outputWidth,
+      drawHeight: outputHeight,
+      offsetX: 0,
+      offsetY: 0,
+      maskPaddedPixels: false,
+    };
+  }
+
+  const sourceRatio = source.width / source.height;
+  const targetRatio = target.width / target.height;
+  const crop = fit.mode === "crop-fill";
+  const scale = crop
+    ? targetRatio > sourceRatio
+      ? target.width / source.width
+      : target.height / source.height
+    : targetRatio < sourceRatio
+      ? target.width / source.width
+      : target.height / source.height;
+  const drawWidth = Math.round(source.width * scale);
+  const drawHeight = Math.round(source.height * scale);
+  const availableX = outputWidth - drawWidth;
+  const availableY = outputHeight - drawHeight;
+  let offsetX = crop
+    ? -alignOffset(-availableX, fit.alignX)
+    : Math.round(availableX / 2);
+  let offsetY = crop
+    ? -alignOffset(-availableY, fit.alignY)
+    : Math.round(availableY / 2);
+  if (Object.is(offsetX, -0)) offsetX = 0;
+  if (Object.is(offsetY, -0)) offsetY = 0;
+
+  return {
+    outputWidth,
+    outputHeight,
+    drawWidth,
+    drawHeight,
+    offsetX,
+    offsetY,
+    maskPaddedPixels: fit.mode === "pad-repaint",
+  };
+}
+
+export function maskPaddingRectangles(t: SourceFitTransform): Rect[] {
+  if (!t.maskPaddedPixels) return [];
+  const rects: Rect[] = [];
+  const left = Math.max(0, t.offsetX);
+  const top = Math.max(0, t.offsetY);
+  const right = Math.max(0, t.outputWidth - (t.offsetX + t.drawWidth));
+  const bottom = Math.max(0, t.outputHeight - (t.offsetY + t.drawHeight));
+  if (top > 0) rects.push({ x: 0, y: 0, width: t.outputWidth, height: top });
+  if (bottom > 0)
+    rects.push({
+      x: 0,
+      y: t.outputHeight - bottom,
+      width: t.outputWidth,
+      height: bottom,
+    });
+  if (left > 0)
+    rects.push({
+      x: 0,
+      y: top,
+      width: left,
+      height: t.outputHeight - top - bottom,
+    });
+  if (right > 0)
+    rects.push({
+      x: t.outputWidth - right,
+      y: top,
+      width: right,
+      height: t.outputHeight - top - bottom,
+    });
+  return rects.filter((r) => r.width > 0 && r.height > 0);
+}
+
+export function describeSourceFit(policy: SourceFitPolicy): string {
+  switch (policy.mode) {
+    case "pad-repaint":
+      return "Pad to fit and repaint added pixels";
+    case "pad-fit":
+      return "Pad to fit";
+    case "crop-fill":
+      return "Crop fill";
+    case "lanczos-resize":
+      return "Lanczos resize";
+    case "upscale-then-fit":
+      return `Upscale with ${policy.upscalerModel}, then ${describeSourceFit(policy.fit)}`;
+  }
+}

--- a/web/src/pages/GeneratePage.test.ts
+++ b/web/src/pages/GeneratePage.test.ts
@@ -2,6 +2,7 @@ import { flushPromises, mount } from "@vue/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { defineComponent, nextTick } from "vue";
 import GeneratePage from "./GeneratePage.vue";
+import { __testing__ as generateFormTesting } from "../composables/useGenerateForm";
 import type {
   GalleryImage,
   GenerateFormState,
@@ -31,8 +32,10 @@ const fetchModelsMock = vi.hoisted(() =>
 
 vi.mock("../api", () => ({
   fetchModels: fetchModelsMock,
+  fetchQueue: vi.fn(async () => ({ entries: [] })),
   listGallery: vi.fn(async () => [entry]),
   deleteGalleryImage: vi.fn(async () => undefined),
+  upscaleStream: vi.fn(async () => undefined),
   updateQueueJobTargetGpu: vi.fn(async () => undefined),
 }));
 
@@ -88,8 +91,10 @@ const qwenEditModel: ModelInfoExtended = {
 describe("GeneratePage layout and visibility", () => {
   beforeEach(() => {
     localStorage.clear();
+    generateFormTesting.resetForTest();
     submitMock.mockClear();
     fetchModelsMock.mockResolvedValue([]);
+    vi.stubGlobal("prompt", vi.fn());
   });
 
   it("uses a wider large-screen shell and controls rail", () => {
@@ -166,14 +171,51 @@ describe("GeneratePage layout and visibility", () => {
     expect(req.mask_image).toBeUndefined();
     expect(req.source_image).toBeUndefined();
   });
+
+  it("prompts before replacing a source image while a mask exists", async () => {
+    fetchModelsMock.mockResolvedValue([fluxModel]);
+    const promptSpy = vi.mocked(window.prompt).mockReturnValue("reset");
+    const wrapper = mount(GeneratePage, {
+      global: { stubs: pageStubs() },
+    });
+    await flushPromises();
+
+    const params = wrapper.getComponent({ name: "GenerateParamsPanel" });
+    const current = params.props("modelValue") as GenerateFormState;
+    params.vm.$emit("update:modelValue", {
+      ...current,
+      imageAttachments: [
+        { kind: "upload", filename: "old.png", base64: "OLD" },
+      ],
+      maskImage: { kind: "upload", filename: "mask.png", base64: "MASK" },
+    });
+    await nextTick();
+
+    wrapper.getComponent({ name: "Composer" }).vm.$emit("open-image-picker");
+    await nextTick();
+    wrapper
+      .getComponent({ name: "ImagePickerModal" })
+      .vm.$emit("pick", [
+        { kind: "upload", filename: "new.png", base64: "NEW" },
+      ]);
+    await nextTick();
+
+    const updated = wrapper
+      .getComponent({ name: "GenerateParamsPanel" })
+      .props("modelValue") as GenerateFormState;
+    expect(promptSpy).toHaveBeenCalled();
+    expect(updated.imageAttachments[0]?.filename).toBe("new.png");
+    expect(updated.maskImage).toBeNull();
+  });
 });
 
 function pageStubs() {
   return {
     TopBar: { template: "<header />" },
     Composer: {
+      name: "Composer",
       props: ["submitError"],
-      emits: ["submit"],
+      emits: ["submit", "open-image-picker", "clear-source"],
       template:
         '<section><p v-if="submitError">{{ submitError }}</p><button data-test="composer-submit" @click="$emit(\'submit\')">submit</button></section>',
     },
@@ -188,7 +230,12 @@ function pageStubs() {
     ModelPicker: { template: "<div />" },
     PreferencesModal: { template: "<div />" },
     ExpandModal: { template: "<div />" },
-    ImagePickerModal: { template: "<div />" },
+    ImagePickerModal: {
+      name: "ImagePickerModal",
+      props: ["open"],
+      emits: ["pick", "close"],
+      template: "<div v-if='open' />",
+    },
     RunningStrip: { template: "<div />" },
     GalleryFeed: GalleryFeedStub,
     DetailDrawer: { template: "<div />" },

--- a/web/src/pages/GeneratePage.vue
+++ b/web/src/pages/GeneratePage.vue
@@ -16,6 +16,7 @@ import {
   deleteGalleryImage,
   fetchModels,
   listGallery,
+  upscaleStream,
   updateQueueJobTargetGpu,
 } from "../api";
 import {
@@ -27,6 +28,10 @@ import { useGenerateStream, type Job } from "../composables/useGenerateStream";
 import { useQueue } from "../composables/useQueue";
 import { decideChainRouting } from "../lib/chainRouting";
 import { isStandaloneGenerationModel } from "../lib/modelFilters";
+import {
+  maskPaddingRectangles,
+  resolveSourceFitTransform,
+} from "../lib/sourceFit";
 import { useStatusPoll } from "../composables/useStatusPoll";
 import type {
   ChainRequestWire,
@@ -35,6 +40,7 @@ import type {
   GalleryImage,
   LoraSelection,
   ModelInfoExtended,
+  SourceFitPolicy,
   SourceImageState,
 } from "../types";
 import { supportsLora } from "../types";
@@ -85,6 +91,49 @@ const showPreferences = ref(false);
 const showExpand = ref(false);
 const showPicker = ref(false);
 const composerError = ref<string | null>(null);
+const preprocessingStatus = ref<string | null>(null);
+const submitStatus = computed(
+  () => composerError.value ?? preprocessingStatus.value,
+);
+
+function mediaUrl(image: SourceImageState): string {
+  return `data:${image.mime || "image/png"};base64,${image.base64}`;
+}
+
+function loadHtmlImage(image: SourceImageState): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error(`failed to decode ${image.filename}`));
+    img.src = mediaUrl(image);
+  });
+}
+
+function canvasToSourceImage(
+  canvas: HTMLCanvasElement,
+  original: SourceImageState,
+  suffix: string,
+): SourceImageState {
+  const dataUrl = canvas.toDataURL("image/png");
+  const comma = dataUrl.indexOf(",");
+  return {
+    ...original,
+    filename: original.filename.replace(/(\.[^.]+)?$/, `${suffix}.png`),
+    base64: comma >= 0 ? dataUrl.slice(comma + 1) : dataUrl,
+    width: canvas.width,
+    height: canvas.height,
+    mime: "image/png",
+  };
+}
+
+function drawableFitPolicy(
+  policy: SourceFitPolicy | undefined,
+): SourceFitPolicy {
+  if (!policy || policy.mode === "upscale-then-fit") {
+    return { mode: "pad-repaint" };
+  }
+  return policy;
+}
 
 function loadComposerMode(): ComposerMode {
   try {
@@ -254,8 +303,130 @@ function onAppendPromptPhrase(phrase: string) {
   form.appendPromptPhrase(phrase);
 }
 
-function onSubmit() {
+async function preprocessSourceIfNeeded(): Promise<boolean> {
+  const policy = form.state.value.sourceFitPolicy;
+  const source = form.state.value.imageAttachments[0];
+  if (policy?.mode !== "upscale-then-fit" || !source) return true;
+  const model = policy.upscalerModel || form.state.value.upscaleModel;
+  if (!model) return true;
+  preprocessingStatus.value = `Preprocessing source with ${model}`;
+  let completed = false;
+  await upscaleStream(
+    {
+      model,
+      image: source.base64,
+      output_format: "png",
+    },
+    {
+      onProgress: (evt) => {
+        if (evt.type === "stage_start") preprocessingStatus.value = evt.name;
+        if (evt.type === "stage_done")
+          preprocessingStatus.value = `${evt.name} (done)`;
+        if (evt.type === "info") preprocessingStatus.value = evt.message;
+      },
+      onComplete: (evt) => {
+        form.state.value.imageAttachments = [
+          {
+            ...source,
+            filename: source.filename.replace(/(\.[^.]+)?$/, "-prefit.png"),
+            base64: evt.image,
+            width: undefined,
+            height: undefined,
+            mime: "image/png",
+          },
+        ];
+        completed = true;
+      },
+      onError: (err) => {
+        composerError.value =
+          err.kind === "http"
+            ? `Source preprocessing failed: ${err.body}`
+            : `Source preprocessing failed: ${err.message}`;
+      },
+    },
+  );
+  preprocessingStatus.value = null;
+  return completed;
+}
+
+async function fitStillSourceToRequest(): Promise<void> {
+  const family = currentModel.value?.family ?? form.state.value.modelFamily;
+  if (isQwenImageEditFamily(family) || form.state.value.frames) return;
+  const source = form.state.value.imageAttachments[0];
+  if (!source) return;
+  const target = {
+    width: form.state.value.width,
+    height: form.state.value.height,
+  };
+  const sourceImg = await loadHtmlImage(source);
+  if (
+    sourceImg.naturalWidth === target.width &&
+    sourceImg.naturalHeight === target.height
+  ) {
+    return;
+  }
+  const policy = drawableFitPolicy(form.state.value.sourceFitPolicy);
+  const transform = resolveSourceFitTransform(
+    { width: sourceImg.naturalWidth, height: sourceImg.naturalHeight },
+    target,
+    policy,
+  );
+  const canvas = document.createElement("canvas");
+  canvas.width = transform.outputWidth;
+  canvas.height = transform.outputHeight;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return;
+  ctx.fillStyle = "black";
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  ctx.drawImage(
+    sourceImg,
+    transform.offsetX,
+    transform.offsetY,
+    transform.drawWidth,
+    transform.drawHeight,
+  );
+  form.state.value.imageAttachments = [
+    canvasToSourceImage(canvas, source, "-fit"),
+  ];
+
+  if (policy.mode !== "pad-repaint" && !form.state.value.maskImage) return;
+  const maskCanvas = document.createElement("canvas");
+  maskCanvas.width = transform.outputWidth;
+  maskCanvas.height = transform.outputHeight;
+  const maskCtx = maskCanvas.getContext("2d");
+  if (!maskCtx) return;
+  maskCtx.fillStyle = "black";
+  maskCtx.fillRect(0, 0, maskCanvas.width, maskCanvas.height);
+  if (form.state.value.maskImage) {
+    const maskImg = await loadHtmlImage(form.state.value.maskImage);
+    maskCtx.drawImage(
+      maskImg,
+      transform.offsetX,
+      transform.offsetY,
+      transform.drawWidth,
+      transform.drawHeight,
+    );
+  }
+  if (policy.mode === "pad-repaint") {
+    maskCtx.fillStyle = "white";
+    for (const rect of maskPaddingRectangles(transform)) {
+      maskCtx.fillRect(rect.x, rect.y, rect.width, rect.height);
+    }
+  }
+  form.state.value.maskImage = canvasToSourceImage(
+    maskCanvas,
+    form.state.value.maskImage ?? {
+      kind: source.kind,
+      filename: "pad-mask.png",
+      base64: "",
+    },
+    "-fit-mask",
+  );
+}
+
+async function onSubmit() {
   composerError.value = null;
+  preprocessingStatus.value = null;
   if (!form.state.value.model) {
     // First-run / nothing-downloaded case. The user has to pick a model
     // before submit can do anything; force-expand the params panel so
@@ -288,6 +459,8 @@ function onSubmit() {
     alert(decision.reason);
     return;
   }
+  if (!(await preprocessSourceIfNeeded())) return;
+  await fitStillSourceToRequest();
   const req = form.toRequest();
   stream.submit(req, decision);
   if (
@@ -340,6 +513,7 @@ function onExpandStage(stageIndex: number, prompt: string) {
 }
 
 function onClearSource() {
+  if (form.state.value.maskImage && !resolveMaskSourceConflict()) return;
   form.state.value.imageAttachments = [];
 }
 
@@ -348,10 +522,37 @@ function onPickSource(v: SourceImageState[]) {
     isQwenImageEditFamily(
       currentModel.value?.family ?? form.state.value.modelFamily,
     ) || form.state.value.model.startsWith("qwen-image-edit:");
+  if (
+    !qwenEdit &&
+    form.state.value.maskImage &&
+    form.state.value.imageAttachments.length > 0 &&
+    v.length > 0 &&
+    !resolveMaskSourceConflict()
+  ) {
+    return;
+  }
   form.state.value.imageAttachments = qwenEdit
     ? [...form.state.value.imageAttachments, ...v]
     : v.slice(0, 1);
   composerError.value = null;
+}
+
+function resolveMaskSourceConflict(): boolean {
+  const choice = window.prompt(
+    "This source image has a mask. Type reset to clear the mask, keep to keep/scale it, or cancel.",
+    "reset",
+  );
+  const normalized = choice?.trim().toLowerCase();
+  if (
+    normalized === "cancel" ||
+    normalized === null ||
+    normalized === undefined
+  ) {
+    return false;
+  }
+  if (normalized === "keep") return true;
+  form.state.value.maskImage = null;
+  return true;
 }
 
 function openItem(item: GalleryImage) {
@@ -509,7 +710,7 @@ onBeforeUnmount(() => {
           :expand-active="form.state.value.expand.enabled"
           :family="currentFamily"
           :chain-decision="chainDecision"
-          :submit-error="composerError"
+          :submit-error="submitStatus"
           @submit="onSubmit"
           @submit-script="onSubmitScript"
           @update:mode="setComposerMode"

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -302,6 +302,23 @@ export interface SseCompleteEvent {
   gpu?: number | null;
 }
 
+export interface UpscaleRequestWire {
+  model: string;
+  image: string;
+  output_format?: OutputFormat;
+  tile_size?: number | null;
+}
+
+export interface SseUpscaleCompleteEvent {
+  image: string;
+  format: OutputFormat;
+  model: string;
+  scale_factor: number;
+  original_width: number;
+  original_height: number;
+  upscale_time_ms: number;
+}
+
 // ── Chained video generation (POST /api/generate/chain/stream) ────────────
 // Mirrors `mold_core::chain::{ChainRequest, ChainStage,
 // ChainProgressEvent, SseChainCompleteEvent}`.
@@ -390,12 +407,18 @@ export interface SourceImageState {
   kind: "upload" | "gallery";
   filename: string;
   base64: string; // stripped before localStorage persist
+  draftId?: string;
+  width?: number | null;
+  height?: number | null;
+  mime?: string | null;
 }
 
 export interface SourceMediaState {
   kind: "upload";
   filename: string;
   base64: string; // stripped before localStorage persist
+  draftId?: string;
+  mime?: string | null;
 }
 
 export interface KeyframeConditionState {
@@ -413,6 +436,21 @@ export interface ExpandFormState {
   variations: 1 | 3 | 5;
   familyOverride: string | null;
 }
+
+export type SourceFitPolicy =
+  | { mode: "pad-repaint" }
+  | { mode: "pad-fit" }
+  | {
+      mode: "crop-fill";
+      alignX?: "left" | "center" | "right";
+      alignY?: "top" | "center" | "bottom";
+    }
+  | { mode: "lanczos-resize" }
+  | {
+      mode: "upscale-then-fit";
+      upscalerModel: string;
+      fit: Exclude<SourceFitPolicy, { mode: "upscale-then-fit" }>;
+    };
 
 export interface LoraSelection {
   path: string;
@@ -472,6 +510,7 @@ export interface GenerateFormState {
   cfgPlus: boolean;
   outputFormat: OutputFormat;
   expand: ExpandFormState;
+  sourceFitPolicy?: SourceFitPolicy;
   imageAttachments: SourceImageState[];
   maskImage: SourceImageState | null;
   controlImage: SourceImageState | null;


### PR DESCRIPTION
## Summary
- persist Generate form drafts across remounts and refreshes with IndexedDB-backed media blobs plus localStorage metadata
- add source fit policy controls and pre-submit fitting/upscale preprocessing for still image sources and masks
- run selected upscalers after still-image generation in server workers and surface upscaler progress/status

## Verification
- bun run test
- bun run build
- cargo test -p mold-ai-server
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace