### PR TITLE
fix(nix): patch installed mold RUNPATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Nix CUDA packages now install `mold` with a complete RUNPATH.** Linux builds auto-patch `$out/bin/mold` for `libstdc++` and CUDA toolkit libraries, add `/run/opengl-driver/lib` for the host NVIDIA driver, and assert those entries during fixup so the NixOS service no longer needs `LD_LIBRARY_PATH` to start. ([#338](https://github.com/utensils/mold/issues/338))
+
 ## [0.13.1] - 2026-06-20
 
 ### Fixed

--- a/contrib/mold-server.service
+++ b/contrib/mold-server.service
@@ -21,7 +21,7 @@ Environment=MOLD_PORT=7680
 # Environment=MOLD_RATE_LIMIT=10/min
 # Environment=MOLD_RATE_LIMIT_BURST=20
 
-# NixOS: CUDA driver access
+# NixOS with a non-flake /usr/local/bin/mold: CUDA driver access
 # Environment=LD_LIBRARY_PATH=/run/opengl-driver/lib
 
 # Security hardening

--- a/flake.nix
+++ b/flake.nix
@@ -120,6 +120,7 @@
               pkgs.libiconv
             ]
             ++ lib.optionals isLinux [
+              pkgs.stdenv.cc.cc.lib
               pkgs.cudaPackages.cuda_cudart
               pkgs.cudaPackages.libcublas.lib
               pkgs.cudaPackages.cuda_nvtx.lib
@@ -256,10 +257,17 @@
                 postInstall =
                   if isLinux then
                     ''
+                      # Build a CUDA-free helper for completion generation, then
+                      # patch its RUNPATH before execing it. The installed binary
+                      # is CUDA-linked and cannot run in the sandbox because the
+                      # host-only NVIDIA driver (`libcuda.so.1`) is absent.
+                      cargoWithProfile build -p mold-ai --features ${completionFeatures}
+                      patchelf --set-rpath ${lib.makeLibraryPath [ pkgs.stdenv.cc.cc.lib ]} target/release/mold
+
                       installShellCompletion --cmd mold \
-                        --bash <(cargoWithProfile run -p mold-ai --features ${completionFeatures} -- completions bash) \
-                        --zsh <(cargoWithProfile run -p mold-ai --features ${completionFeatures} -- completions zsh) \
-                        --fish <(cargoWithProfile run -p mold-ai --features ${completionFeatures} -- completions fish)
+                        --bash <(target/release/mold completions bash) \
+                        --zsh <(target/release/mold completions zsh) \
+                        --fish <(target/release/mold completions fish)
                     ''
                   else
                     ''
@@ -272,16 +280,50 @@
               }
               // lib.optionalAttrs isLinux {
                 CUDA_COMPUTE_CAP = computeCap;
+                nativeBuildInputs = commonArgs.nativeBuildInputs ++ [
+                  pkgs.installShellFiles
+                  pkgs.autoPatchelfHook
+                  pkgs.autoAddDriverRunpath
+                  (pkgs.writeTextFile {
+                    name = "mold-runpath-assert-hook";
+                    destination = "/nix-support/setup-hook";
+                    text = ''
+                      assertMoldRunpath() {
+                        rpath="$(patchelf --print-rpath $out/bin/mold)"
+                        echo "mold RUNPATH: $rpath"
 
-                # Linux postInstall generates shell completions by execing the
-                # freshly-built CUDA-free target binary before Nix fixup patches
-                # its runtime paths. Keep libstdc++ visible so sandboxed builds
-                # do not fail in the dynamic loader before reaching `main()`.
-                preInstall = ''
-                  export LD_LIBRARY_PATH=${
-                    lib.makeLibraryPath [ pkgs.stdenv.cc.cc.lib ]
-                  }''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
-                '';
+                        case ":$rpath:" in
+                          *":${pkgs.stdenv.cc.cc.lib}/lib:"*) ;;
+                          *) echo "missing libstdc++ RUNPATH entry" >&2; exit 1 ;;
+                        esac
+                        case ":$rpath:" in
+                          *":${pkgs.cudaPackages.cuda_cudart}/lib:"*) ;;
+                          *) echo "missing CUDA runtime RUNPATH entry" >&2; exit 1 ;;
+                        esac
+                        case ":$rpath:" in
+                          *":${pkgs.cudaPackages.libcublas.lib}/lib:"*) ;;
+                          *) echo "missing libcublas RUNPATH entry" >&2; exit 1 ;;
+                        esac
+                        case ":$rpath:" in
+                          *":${pkgs.cudaPackages.libcurand.lib}/lib:"*) ;;
+                          *) echo "missing libcurand RUNPATH entry" >&2; exit 1 ;;
+                        esac
+                        case ":$rpath:" in
+                          *":/run/opengl-driver/lib:"*) ;;
+                          *) echo "missing NVIDIA driver RUNPATH entry" >&2; exit 1 ;;
+                        esac
+                      }
+
+                      postFixupHooks+=(assertMoldRunpath)
+                    '';
+                  })
+                ];
+
+                # `libcuda.so.1` comes from the host NVIDIA driver and is not
+                # available in the Nix build sandbox. Resolve CUDA toolkit libs
+                # with autoPatchelf, then let autoAddDriverRunpath add the stable
+                # NixOS driver RUNPATH after autoPatchelf's `--set-rpath` pass.
+                autoPatchelfIgnoreMissingDeps = [ "libcuda.so.1" ];
 
                 # Sandboxed Linux builders do not provide the host NVIDIA
                 # driver (`libcuda.so.1`). The CUDA-linked CLI can therefore

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -304,7 +304,6 @@ in
         MOLD_PORT = toString cfg.port;
         MOLD_MODELS_DIR = cfg.modelsDir;
         MOLD_LOG = cfg.logLevel;
-        LD_LIBRARY_PATH = "/run/opengl-driver/lib";
       }
       // lib.optionalAttrs (cfg.corsOrigin != null) {
         MOLD_CORS_ORIGIN = cfg.corsOrigin;

--- a/website/deployment/index.md
+++ b/website/deployment/index.md
@@ -39,6 +39,6 @@ Key settings:
 [Service]
 ExecStart=/usr/local/bin/mold serve --port 7680 --bind 0.0.0.0
 Environment=MOLD_LOG=info
-# NixOS: uncomment for CUDA driver access
+# NixOS with a non-flake `/usr/local/bin/mold`: uncomment for CUDA driver access
 # Environment=LD_LIBRARY_PATH=/run/opengl-driver/lib
 ```

--- a/website/deployment/nixos.md
+++ b/website/deployment/nixos.md
@@ -173,7 +173,6 @@ so Prometheus/Grafana Agent can scrape it without an API key.
 - **System user** `mold:mold` with home at `homeDir`
 - **Directories** via tmpfiles: `homeDir`, `modelsDir`, and `outputDir` (if set)
 - **Systemd service** `mold.service` — runs `mold serve` with:
-  - `LD_LIBRARY_PATH=/run/opengl-driver/lib` for NixOS CUDA driver access
   - `video` and `render` supplementary groups for GPU access
   - Hardened: `NoNewPrivileges`, `ProtectSystem=full`, `ProtectHome`,
     `PrivateTmp`


### PR DESCRIPTION
## Summary

- patch Linux Nix installs with `autoPatchelfHook` plus `autoAddDriverRunpath` so `$out/bin/mold` carries libstdc++, CUDA toolkit libs, and `/run/opengl-driver/lib` in RUNPATH
- add a post-fixup assertion setup hook so future Nix builds fail if the installed binary loses required RUNPATH entries
- remove the NixOS module's service-level `LD_LIBRARY_PATH` workaround while keeping the generic `/usr/local/bin` systemd docs hint for non-flake binaries

Closes #338.

## Validation

- `nix fmt`
- `nix build .#packages.x86_64-linux.mold --dry-run`
- `nix derivation show .#packages.x86_64-linux.mold` confirmed Linux native build inputs include `autoPatchelfHook`, `autoAddDriverRunpath`, and the custom RUNPATH assertion hook
- `git diff --check`
- `codex review --uncommitted` (final pass: no discrete correctness issues)

Note: full x86_64-linux package build was intentionally skipped per request after dry-run/evaluation validation.
