### PR TITLE
fix(nix): make cudart runpath assertion conditional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Nix CUDA packages now install `mold` with a complete RUNPATH.** Linux builds auto-patch `$out/bin/mold` for `libstdc++` and CUDA toolkit libraries, add `/run/opengl-driver/lib` for the host NVIDIA driver, and assert those entries during fixup so the NixOS service no longer needs `LD_LIBRARY_PATH` to start. ([#338](https://github.com/utensils/mold/issues/338))
+- **Nix CUDA RUNPATH assertions no longer require unused `libcudart`.** The Linux package now checks the CUDA runtime RUNPATH only when `$out/bin/mold` actually declares a `libcudart.so` dependency, so driver-API builds that need cuBLAS/cuRAND but not dynamic cudart can pass fixup. ([#340](https://github.com/utensils/mold/issues/340))
 
 ## [0.13.1] - 2026-06-20
 

--- a/flake.nix
+++ b/flake.nix
@@ -427,14 +427,16 @@
               base_rpath="/nix/store/test-libstdcxx/lib:/nix/store/test-libcublas/lib:/nix/store/test-libcurand/lib:/run/opengl-driver/lib"
 
               MOLD_TEST_RPATH="$base_rpath"
-              MOLD_TEST_NEEDED="libcublas.so.12
-              libcurand.so.10"
+              MOLD_TEST_NEEDED="$(printf '%s\n' \
+                "libcublas.so.12" \
+                "libcurand.so.10")"
               export MOLD_TEST_RPATH MOLD_TEST_NEEDED
               assertMoldRunpath
 
-              MOLD_TEST_NEEDED="libcudart.so.12
-              libcublas.so.12
-              libcurand.so.10"
+              MOLD_TEST_NEEDED="$(printf '%s\n' \
+                "libcudart.so.12" \
+                "libcublas.so.12" \
+                "libcurand.so.10")"
               export MOLD_TEST_NEEDED
               if ( assertMoldRunpath ); then
                 echo "expected missing libcudart RUNPATH to fail when libcudart is needed" >&2

--- a/flake.nix
+++ b/flake.nix
@@ -181,6 +181,64 @@
             ./scripts/ensure-web-dist.sh
           '';
 
+          assertMoldRunpathScriptFor =
+            {
+              ccLib,
+              cudaCudart,
+              libcublas,
+              libcurand,
+            }:
+            ''
+              assertMoldRunpath() {
+                rpath="$(patchelf --print-rpath $out/bin/mold)"
+                needed="$(patchelf --print-needed $out/bin/mold)"
+                echo "mold RUNPATH: $rpath"
+                echo "mold NEEDED: $needed"
+
+                case ":$rpath:" in
+                  *":${ccLib}/lib:"*) ;;
+                  *) echo "missing libstdc++ RUNPATH entry" >&2; exit 1 ;;
+                esac
+                case "$needed" in
+                  *libcudart.so*)
+                    case ":$rpath:" in
+                      *":${cudaCudart}/lib:"*) ;;
+                      *) echo "missing CUDA runtime RUNPATH entry" >&2; exit 1 ;;
+                    esac
+                    ;;
+                esac
+                case ":$rpath:" in
+                  *":${libcublas}/lib:"*) ;;
+                  *) echo "missing libcublas RUNPATH entry" >&2; exit 1 ;;
+                esac
+                case ":$rpath:" in
+                  *":${libcurand}/lib:"*) ;;
+                  *) echo "missing libcurand RUNPATH entry" >&2; exit 1 ;;
+                esac
+                case ":$rpath:" in
+                  *":/run/opengl-driver/lib:"*) ;;
+                  *) echo "missing NVIDIA driver RUNPATH entry" >&2; exit 1 ;;
+                esac
+              }
+            '';
+
+          assertMoldRunpathScript = assertMoldRunpathScriptFor {
+            ccLib = "${pkgs.stdenv.cc.cc.lib}";
+            cudaCudart = "${pkgs.cudaPackages.cuda_cudart}";
+            libcublas = "${pkgs.cudaPackages.libcublas.lib}";
+            libcurand = "${pkgs.cudaPackages.libcurand.lib}";
+          };
+
+          moldRunpathAssertHook = pkgs.writeTextFile {
+            name = "mold-runpath-assert-hook";
+            destination = "/nix-support/setup-hook";
+            text = ''
+              ${assertMoldRunpathScript}
+
+              postFixupHooks+=(assertMoldRunpath)
+            '';
+          };
+
           # Merged CUDA toolkit so bindgen_cuda can find both bin/nvcc and include/cuda.h
           cudaToolkit = pkgs.symlinkJoin {
             name = "cuda-toolkit-merged";
@@ -284,39 +342,7 @@
                   pkgs.installShellFiles
                   pkgs.autoPatchelfHook
                   pkgs.autoAddDriverRunpath
-                  (pkgs.writeTextFile {
-                    name = "mold-runpath-assert-hook";
-                    destination = "/nix-support/setup-hook";
-                    text = ''
-                      assertMoldRunpath() {
-                        rpath="$(patchelf --print-rpath $out/bin/mold)"
-                        echo "mold RUNPATH: $rpath"
-
-                        case ":$rpath:" in
-                          *":${pkgs.stdenv.cc.cc.lib}/lib:"*) ;;
-                          *) echo "missing libstdc++ RUNPATH entry" >&2; exit 1 ;;
-                        esac
-                        case ":$rpath:" in
-                          *":${pkgs.cudaPackages.cuda_cudart}/lib:"*) ;;
-                          *) echo "missing CUDA runtime RUNPATH entry" >&2; exit 1 ;;
-                        esac
-                        case ":$rpath:" in
-                          *":${pkgs.cudaPackages.libcublas.lib}/lib:"*) ;;
-                          *) echo "missing libcublas RUNPATH entry" >&2; exit 1 ;;
-                        esac
-                        case ":$rpath:" in
-                          *":${pkgs.cudaPackages.libcurand.lib}/lib:"*) ;;
-                          *) echo "missing libcurand RUNPATH entry" >&2; exit 1 ;;
-                        esac
-                        case ":$rpath:" in
-                          *":/run/opengl-driver/lib:"*) ;;
-                          *) echo "missing NVIDIA driver RUNPATH entry" >&2; exit 1 ;;
-                        esac
-                      }
-
-                      postFixupHooks+=(assertMoldRunpath)
-                    '';
-                  })
+                  moldRunpathAssertHook
                 ];
 
                 # `libcuda.so.1` comes from the host NVIDIA driver and is not
@@ -363,6 +389,62 @@
           }
           // lib.optionalAttrs isLinux {
             mold-sm120 = mkMold "120"; # Blackwell (RTX 50-series)
+          };
+
+          checks = {
+            runpath-assertion = pkgs.runCommand "mold-runpath-assertion-check" { } ''
+              set -eu
+
+              mkdir -p "$out/bin" "$TMPDIR/bin"
+              touch "$out/bin/mold"
+
+              cat > "$TMPDIR/bin/patchelf" <<'EOF'
+              #!${pkgs.runtimeShell}
+              set -eu
+              case "$1" in
+                --print-rpath)
+                  printf '%s\n' "$MOLD_TEST_RPATH"
+                  ;;
+                --print-needed)
+                  printf '%s\n' "$MOLD_TEST_NEEDED"
+                  ;;
+                *)
+                  echo "unexpected patchelf args: $*" >&2
+                  exit 2
+                  ;;
+              esac
+              EOF
+              chmod +x "$TMPDIR/bin/patchelf"
+              export PATH="$TMPDIR/bin:$PATH"
+
+              ${assertMoldRunpathScriptFor {
+                ccLib = "/nix/store/test-libstdcxx";
+                cudaCudart = "/nix/store/test-cuda-cudart";
+                libcublas = "/nix/store/test-libcublas";
+                libcurand = "/nix/store/test-libcurand";
+              }}
+
+              base_rpath="/nix/store/test-libstdcxx/lib:/nix/store/test-libcublas/lib:/nix/store/test-libcurand/lib:/run/opengl-driver/lib"
+
+              MOLD_TEST_RPATH="$base_rpath"
+              MOLD_TEST_NEEDED="libcublas.so.12
+              libcurand.so.10"
+              export MOLD_TEST_RPATH MOLD_TEST_NEEDED
+              assertMoldRunpath
+
+              MOLD_TEST_NEEDED="libcudart.so.12
+              libcublas.so.12
+              libcurand.so.10"
+              export MOLD_TEST_NEEDED
+              if ( assertMoldRunpath ); then
+                echo "expected missing libcudart RUNPATH to fail when libcudart is needed" >&2
+                exit 1
+              fi
+
+              MOLD_TEST_RPATH="$base_rpath:/nix/store/test-cuda-cudart/lib"
+              export MOLD_TEST_RPATH
+              assertMoldRunpath
+            '';
           };
 
           apps.default = {


### PR DESCRIPTION
## Summary

- make `assertMoldRunpath` inspect `patchelf --print-needed` before requiring the CUDA runtime RUNPATH
- keep the existing libstdc++, cuBLAS, cuRAND, and NVIDIA driver RUNPATH assertions intact
- add a fast flake check that exercises the assertion logic with fake `patchelf` outputs
- document the #340 fix in the changelog

Closes #340

## Validation

- `nix fmt`
- `nix build .#checks.aarch64-darwin.runpath-assertion --print-build-logs`
- `nix eval .#checks.x86_64-linux.runpath-assertion.drvPath --raw`
- `nix eval .#packages.x86_64-linux.default.drvPath --raw`
- `nix build .#packages.x86_64-linux.default --dry-run`
- `git diff --check`

Note: `nix flake check --no-build` currently fails locally before building this change with `path '/nix/store/pi3mzj3fkgvygj1alb6d9r169mf7bl54-source' is not valid` while evaluating the aarch64-darwin package's Cargo vendoring source. Rerunning with `--refresh --no-eval-cache` hit the same local Nix store validity error.
