### PR TITLE
fix(server): ignore SIGPIPE so a dropped client connection can't kill mold serve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`mold serve` no longer dies from SIGPIPE when a client connection drops mid-write.** The CLI resets SIGPIPE to `SIG_DFL` in `main()` so short-lived piped commands (e.g. `mold run … | head`) terminate cleanly, but for the long-running server that disposition was fatal — a single client disconnecting mid-response (a timed-out request, a health check, the Discord bot's `/api/models` poll) delivered SIGPIPE and silently took down the whole server with no panic or error log. `mold_server::run_server()` now re-arms `SIG_IGN` at startup so such writes surface as recoverable `EPIPE` errors handled per-request by axum/hyper. ([#342](https://github.com/utensils/mold/issues/342))
 - **Nix CUDA packages now install `mold` with a complete RUNPATH.** Linux builds auto-patch `$out/bin/mold` for `libstdc++` and CUDA toolkit libraries, add `/run/opengl-driver/lib` for the host NVIDIA driver, and assert those entries during fixup so the NixOS service no longer needs `LD_LIBRARY_PATH` to start. ([#338](https://github.com/utensils/mold/issues/338))
 - **Nix CUDA RUNPATH assertions no longer require unused `libcudart`.** The Linux package now checks the CUDA runtime RUNPATH only when `$out/bin/mold` actually declares a `libcudart.so` dependency, so driver-API builds that need cuBLAS/cuRAND but not dynamic cudart can pass fixup. ([#340](https://github.com/utensils/mold/issues/340))
 

--- a/crates/mold-cli/src/main.rs
+++ b/crates/mold-cli/src/main.rs
@@ -1222,6 +1222,9 @@ async fn main() {
     // Reset SIGPIPE to default (terminate) so piping doesn't panic.
     // Rust ignores SIGPIPE by default, causing "broken pipe" panics when
     // stdout is a pipe and the reader closes (e.g. `mold run ... | head`).
+    // NOTE: this disposition is wrong for long-running servers — a client
+    // dropping mid-write would kill the process via SIGPIPE. `mold serve`
+    // re-arms SIG_IGN in `mold_server::run_server()` (see issue #342).
     #[cfg(unix)]
     unsafe {
         libc::signal(libc::SIGPIPE, libc::SIG_DFL);

--- a/crates/mold-server/src/lib.rs
+++ b/crates/mold-server/src/lib.rs
@@ -19,6 +19,7 @@ pub mod request_id;
 pub mod resources;
 pub mod routes;
 pub mod routes_chain;
+pub mod signals;
 pub mod state;
 pub mod web_ui;
 
@@ -52,6 +53,13 @@ pub async fn run_server(
     gpu_selection: GpuSelection,
     queue_size: usize,
 ) -> Result<()> {
+    // Re-arm SIG_IGN for SIGPIPE. The CLI resets it to SIG_DFL in main() for
+    // clean piping of short-lived commands, but for this long-running server
+    // that is fatal — a single client dropping mid-write would kill the whole
+    // process (issue #342). With SIG_IGN, such writes surface as EPIPE and are
+    // handled per-request by hyper/axum.
+    signals::ignore_sigpipe();
+
     Config::install_runtime_models_dir_override(models_dir.clone());
 
     let mut config = Config::load_or_default();

--- a/crates/mold-server/src/lib.rs
+++ b/crates/mold-server/src/lib.rs
@@ -19,7 +19,7 @@ pub mod request_id;
 pub mod resources;
 pub mod routes;
 pub mod routes_chain;
-pub mod signals;
+mod signals;
 pub mod state;
 pub mod web_ui;
 

--- a/crates/mold-server/src/signals.rs
+++ b/crates/mold-server/src/signals.rs
@@ -16,18 +16,24 @@
 /// `EPIPE` rather than terminating the process. Idempotent; safe to call after
 /// the CLI has reset the disposition to `SIG_DFL`. No-op on non-unix targets.
 #[cfg(unix)]
-pub fn ignore_sigpipe() {
+pub(crate) fn ignore_sigpipe() {
     // SAFETY: installing `SIG_IGN` for a signal is async-signal-safe and has no
-    // memory-safety implications. `libc::signal` returns the previous handler,
-    // which we intentionally discard.
-    unsafe {
-        libc::signal(libc::SIGPIPE, libc::SIG_IGN);
-    }
+    // memory-safety implications.
+    let prev = unsafe { libc::signal(libc::SIGPIPE, libc::SIG_IGN) };
+    // `signal()` cannot fail for SIGPIPE + SIG_IGN in practice (no EINVAL), but
+    // a debug assertion makes a regression visible in dev/test without any cost
+    // in release builds.
+    debug_assert_ne!(
+        prev,
+        libc::SIG_ERR,
+        "failed to set SIGPIPE to SIG_IGN: {}",
+        std::io::Error::last_os_error()
+    );
 }
 
 /// No-op on non-unix targets, where SIGPIPE does not exist.
 #[cfg(not(unix))]
-pub fn ignore_sigpipe() {}
+pub(crate) fn ignore_sigpipe() {}
 
 #[cfg(all(test, unix))]
 mod tests {
@@ -52,13 +58,35 @@ mod tests {
         oldact.sa_sigaction
     }
 
+    /// Restores the SIGPIPE disposition captured at construction when dropped, so
+    /// a test that mutates this process-global state doesn't leak it to the rest
+    /// of the suite — even if the test panics partway through.
+    struct RestoreSigpipe(libc::sighandler_t);
+
+    impl RestoreSigpipe {
+        fn capture() -> Self {
+            Self(current_sigpipe_handler())
+        }
+    }
+
+    impl Drop for RestoreSigpipe {
+        fn drop(&mut self) {
+            unsafe {
+                libc::signal(libc::SIGPIPE, self.0);
+            }
+        }
+    }
+
     /// The actual failure mode from #342: with `SIG_DFL` a write to a pipe whose
     /// read end is closed kills the process; with our fix it must return `EPIPE`.
     /// If `ignore_sigpipe()` did nothing, this test would terminate the whole test
     /// binary via SIGPIPE instead of failing an assertion.
     #[test]
     fn write_to_broken_pipe_returns_epipe_not_signal() {
-        let _guard = SIGPIPE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = SIGPIPE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        // Declared after the lock so it drops first: restore SIGPIPE while still
+        // holding the mutex, before any other test can observe it.
+        let _restore = RestoreSigpipe::capture();
 
         // Worst case: the CLI's global reset is in effect.
         unsafe {
@@ -97,7 +125,8 @@ mod tests {
     /// to `SIG_DFL` first (mirroring the CLI's `main()` global reset).
     #[test]
     fn ignore_sigpipe_installs_sig_ign_over_sig_dfl() {
-        let _guard = SIGPIPE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _lock = SIGPIPE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _restore = RestoreSigpipe::capture();
 
         unsafe {
             libc::signal(libc::SIGPIPE, libc::SIG_DFL);

--- a/crates/mold-server/src/signals.rs
+++ b/crates/mold-server/src/signals.rs
@@ -1,0 +1,111 @@
+//! SIGPIPE disposition for the long-running server process.
+//!
+//! Rust's runtime installs `SIG_IGN` for `SIGPIPE` at startup, so a `write()` to
+//! a peer that has closed its end returns `EPIPE` (a recoverable per-request
+//! error) instead of a fatal signal. The `mold` CLI deliberately resets SIGPIPE
+//! to `SIG_DFL` in `main()` so short-lived commands terminate cleanly when their
+//! stdout pipe closes (e.g. `mold run "a cat" | head`).
+//!
+//! For a long-running HTTP server that `SIG_DFL` disposition is fatal: a single
+//! client disconnecting mid-write delivers SIGPIPE and kills the whole process —
+//! no panic, no error log (see issue #342). Restoring `SIG_IGN` at server startup
+//! makes such writes return `EPIPE`, which hyper/axum handle as a normal client
+//! disconnect.
+
+/// Restore `SIG_IGN` for `SIGPIPE` so writes to a dropped connection surface as
+/// `EPIPE` rather than terminating the process. Idempotent; safe to call after
+/// the CLI has reset the disposition to `SIG_DFL`. No-op on non-unix targets.
+#[cfg(unix)]
+pub fn ignore_sigpipe() {
+    // SAFETY: installing `SIG_IGN` for a signal is async-signal-safe and has no
+    // memory-safety implications. `libc::signal` returns the previous handler,
+    // which we intentionally discard.
+    unsafe {
+        libc::signal(libc::SIGPIPE, libc::SIG_IGN);
+    }
+}
+
+/// No-op on non-unix targets, where SIGPIPE does not exist.
+#[cfg(not(unix))]
+pub fn ignore_sigpipe() {}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // Signal disposition is process-global and cargo runs tests in parallel
+    // threads, so serialize the tests that mutate it.
+    static SIGPIPE_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Read the current SIGPIPE handler without modifying it: pass a null `act`
+    /// and capture the existing disposition into `oldact`.
+    fn current_sigpipe_handler() -> libc::sighandler_t {
+        let mut oldact: libc::sigaction = unsafe { std::mem::zeroed() };
+        let rc = unsafe { libc::sigaction(libc::SIGPIPE, std::ptr::null(), &mut oldact) };
+        assert_eq!(
+            rc,
+            0,
+            "sigaction query failed: {}",
+            std::io::Error::last_os_error()
+        );
+        oldact.sa_sigaction
+    }
+
+    /// The actual failure mode from #342: with `SIG_DFL` a write to a pipe whose
+    /// read end is closed kills the process; with our fix it must return `EPIPE`.
+    /// If `ignore_sigpipe()` did nothing, this test would terminate the whole test
+    /// binary via SIGPIPE instead of failing an assertion.
+    #[test]
+    fn write_to_broken_pipe_returns_epipe_not_signal() {
+        let _guard = SIGPIPE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        // Worst case: the CLI's global reset is in effect.
+        unsafe {
+            libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+        }
+        ignore_sigpipe();
+
+        let mut fds = [0 as libc::c_int; 2];
+        assert_eq!(
+            unsafe { libc::pipe(fds.as_mut_ptr()) },
+            0,
+            "pipe() failed: {}",
+            std::io::Error::last_os_error()
+        );
+        let (read_fd, write_fd) = (fds[0], fds[1]);
+
+        // Close the reader so any write to `write_fd` gets EPIPE.
+        assert_eq!(unsafe { libc::close(read_fd) }, 0);
+
+        let buf = [0u8; 16];
+        let n = unsafe { libc::write(write_fd, buf.as_ptr() as *const libc::c_void, buf.len()) };
+        let err = std::io::Error::last_os_error();
+        unsafe {
+            libc::close(write_fd);
+        }
+
+        assert_eq!(n, -1, "write to broken pipe should fail");
+        assert_eq!(
+            err.raw_os_error(),
+            Some(libc::EPIPE),
+            "broken-pipe write should report EPIPE"
+        );
+    }
+
+    /// `ignore_sigpipe()` must leave SIGPIPE at `SIG_IGN` even when it was reset
+    /// to `SIG_DFL` first (mirroring the CLI's `main()` global reset).
+    #[test]
+    fn ignore_sigpipe_installs_sig_ign_over_sig_dfl() {
+        let _guard = SIGPIPE_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        unsafe {
+            libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+        }
+        assert_eq!(current_sigpipe_handler(), libc::SIG_DFL);
+
+        ignore_sigpipe();
+
+        assert_eq!(current_sigpipe_handler(), libc::SIG_IGN);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #342 — `mold serve` was killed by **SIGPIPE (signal 13)** whenever a client connection dropped while the server was mid-write (a timed-out request, a health check, the Discord bot's `/api/models` poll, a cancelled browser request). A single broken client connection took down the entire image-generation server with **no panic and no error log** — just a clean `Deactivated successfully`. Because SIGPIPE is in systemd's "clean exit" set, `Restart=on-failure` did **not** restart it, so the server stayed down silently.

## Root cause

Rust's runtime installs `SIG_IGN` for `SIGPIPE` at startup so writes to a closed peer return `EPIPE` (a recoverable per-request error) instead of a fatal signal. The `mold` CLI deliberately resets SIGPIPE to `SIG_DFL` in `main()` to get clean Unix piping for short-lived commands like `mold run "a cat" | head`:

```rust
// crates/mold-cli/src/main.rs
#[cfg(unix)]
unsafe { libc::signal(libc::SIGPIPE, libc::SIG_DFL); }
```

That reset runs **globally, before subcommand dispatch**, so it also applied to `mold serve`. For a long-running HTTP server that disposition is fatal: any socket write to a peer that has closed its end raises SIGPIPE and kills the process.

## Fix

`mold_server::run_server()` now re-arms `SIG_IGN` for SIGPIPE as its first action (new `crates/mold-server/src/signals.rs`). Broken-pipe writes once again surface as `EPIPE` and are handled per-request by hyper/axum. The CLI's `SIG_DFL` reset is intentionally kept for the pipe-friendly short-lived commands; only the long-running server overrides it. Placing the re-arm in the server library also protects the standalone `mold-server` binary and any other library consumer.

## Tests (TDD — red first)

`crates/mold-server/src/signals.rs` adds two `#[cfg(all(test, unix))]` tests, serialized with a module-level mutex since signal disposition is process-global:

1. **`write_to_broken_pipe_returns_epipe_not_signal`** — reproduces the actual #342 failure mode: set `SIG_DFL` (the CLI's global reset), call `ignore_sigpipe()`, then write to a pipe whose read end is closed and assert the write returns `EPIPE` rather than delivering a fatal signal. Without the fix this test terminates the whole test binary via SIGPIPE; with it, the write returns `EPIPE`.
2. **`ignore_sigpipe_installs_sig_ign_over_sig_dfl`** — queries SIGPIPE disposition via `sigaction` and asserts it is `SIG_IGN` after the call, even when it was `SIG_DFL` beforehand.

Verified the red state first (disposition test fails without the fix), then green after.

## Verification

- `cargo test -p mold-ai-server signals` — both new tests pass (process survives the broken-pipe write)
- `cargo test -p mold-ai-server` — full crate suite green
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

No CLI flags / env vars / endpoints / models change, so `SKILL.md` and the website need no updates. CHANGELOG `[Unreleased] → Fixed` updated.
