### PR TITLE
feat(server): queue-cancel and prompt-history endpoints for desktop surfaces

### DIFF
--- a/.claude/skills/mold/SKILL.md
+++ b/.claude/skills/mold/SKILL.md
@@ -691,6 +691,8 @@ Core endpoints exposed by `mold serve` (full list + schemas at `/api/docs`):
 - `GET /api/gallery` · `GET /api/gallery/image/:name` · `GET /api/gallery/thumbnail/:name` · `DELETE /api/gallery/image/:name`
 - `POST /api/upscale` · `POST /api/upscale/stream`
 - `GET /api/queue` — authoritative server-side job listing for SPA reconciliation (queued + running jobs with UUIDv4 ids)
+- `DELETE /api/queue/:id` — cancel a still-queued generation job (204; 404 unknown; 409 once running)
+- `GET /api/history?query=&limit=` · `DELETE /api/history[?keep=N]` — prompt history (newest first, substring filter, limit ≤ 500; 503 when the metadata DB is disabled)
 - `GET /api/status` · `GET /health` · `GET /api/capabilities`
 
 ### Prometheus Metrics

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Queue-cancel and prompt-history server endpoints** (desktop-app surfaces): `DELETE /api/queue/:id` cancels a still-queued generation job (204; 404 unknown id; 409 `QUEUE_JOB_RUNNING` once a worker owns it — the blocking `POST /api/generate` waiter resolves with a 499 `CANCELLED` error and the SSE stream emits a terminal `error` event and closes), and `GET /api/history?query=&limit=` / `DELETE /api/history[?keep=N]` expose the prompt-history DB over HTTP (newest first, substring filtering, limit default 50 / max 500; both return 503 `HISTORY_UNAVAILABLE` under `MOLD_DB_DISABLE=1`).
+
 ### Fixed
 
 - **`mold run --local` chains now run the missing-assets repair pull.** The local chain path shares the single-clip model resolve/pull preamble, so a model with deleted or corrupted component files is repaired automatically instead of failing at engine load.

--- a/crates/mold-core/src/types.rs
+++ b/crates/mold-core/src/types.rs
@@ -1896,6 +1896,26 @@ mod tests {
     }
 
     #[test]
+    fn history_listing_serde_roundtrip() {
+        // Wire contract for GET /api/history — `{ "entries": [...] }` with
+        // exactly { prompt, model, used_at } per row.
+        let listing = HistoryListing {
+            entries: vec![HistoryEntry {
+                prompt: "a cat".to_string(),
+                model: "flux-dev:q8".to_string(),
+                used_at: 1_700_000_000_000,
+            }],
+        };
+        let json = serde_json::to_string(&listing).unwrap();
+        assert!(json.contains(r#""prompt":"a cat""#), "got: {json}");
+        assert!(json.contains(r#""used_at":1700000000000"#), "got: {json}");
+        let back: HistoryListing = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.entries.len(), 1);
+        assert_eq!(back.entries[0].model, "flux-dev:q8");
+        assert_eq!(back.entries[0].used_at, 1_700_000_000_000);
+    }
+
+    #[test]
     fn sse_progress_queued_roundtrip() {
         let event = SseProgressEvent::Queued {
             position: 3,
@@ -2702,6 +2722,25 @@ pub struct CatalogCapabilities {
 pub struct ServerCapabilities {
     pub gallery: GalleryCapabilities,
     pub catalog: CatalogCapabilities,
+}
+
+/// One prompt-history row returned by `GET /api/history`. Deliberately a
+/// small wire-facing projection of the richer `prompt_history` DB row —
+/// clients get what they need to re-run a prompt, nothing more.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct HistoryEntry {
+    pub prompt: String,
+    pub model: String,
+    /// Unix epoch milliseconds when the prompt was recorded.
+    pub used_at: i64,
+}
+
+/// Whole-history listing returned by `GET /api/history`. Wrapped in a struct
+/// so the response can grow extra fields (totals, paging cursors, …) without
+/// a breaking change — same rationale as `QueueListing`.
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct HistoryListing {
+    pub entries: Vec<HistoryEntry>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]

--- a/crates/mold-server/src/job_registry.rs
+++ b/crates/mold-server/src/job_registry.rs
@@ -18,6 +18,7 @@
 use serde::Serialize;
 use std::sync::{Arc, RwLock};
 use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::sync::Notify;
 
 /// Wire-facing job state. Mirrors the actual lifecycle:
 ///
@@ -69,10 +70,23 @@ struct EntryInternal {
     started_at_unix_ms: u64,
     gpu: Option<usize>,
     target_gpu: Option<usize>,
+    /// Cancellation signal for `DELETE /api/queue/:id`. The submitting
+    /// handler holds the clone returned by `register*()` and selects on
+    /// `notified()` alongside the job's result channel; `cancel_queued`
+    /// fires `notify_one()` so the permit survives even when the cancel
+    /// lands before the waiter starts awaiting.
+    cancel: Arc<Notify>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TargetGpuUpdateError {
+    NotFound,
+    AlreadyRunning,
+}
+
+/// Why a `DELETE /api/queue/:id` cancel attempt was rejected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QueuedJobCancelError {
     NotFound,
     AlreadyRunning,
 }
@@ -96,21 +110,29 @@ impl JobRegistry {
     }
 
     /// Insert a freshly-submitted job at the tail in `Queued` state.
-    pub fn register(&self, id: impl Into<String>, model: impl Into<String>) {
-        self.register_with_target_gpu(id, model, None);
+    /// Returns the job's cancellation signal — see `register_with_target_gpu`.
+    pub fn register(&self, id: impl Into<String>, model: impl Into<String>) -> Arc<Notify> {
+        self.register_with_target_gpu(id, model, None)
     }
 
     /// Insert a freshly-submitted job with an optional queued lane target.
+    ///
+    /// Returns the job's cancellation signal. The submitting handler must
+    /// hold it and select on `notified()` alongside the result channel —
+    /// `cancel_queued` resolves it when `DELETE /api/queue/:id` removes the
+    /// entry. Callers that never wait (tests poking the registry directly)
+    /// can drop the handle.
     pub fn register_with_target_gpu(
         &self,
         id: impl Into<String>,
         model: impl Into<String>,
         target_gpu: Option<usize>,
-    ) {
+    ) -> Arc<Notify> {
         let started_at_unix_ms = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
             .as_millis() as u64;
+        let cancel = Arc::new(Notify::new());
         let mut entries = self.inner.write().unwrap_or_else(|e| e.into_inner());
         entries.push(EntryInternal {
             id: id.into(),
@@ -119,7 +141,31 @@ impl JobRegistry {
             started_at_unix_ms,
             gpu: None,
             target_gpu,
+            cancel: cancel.clone(),
         });
+        cancel
+    }
+
+    /// Cancel a still-queued job: remove its entry and fire the cancel
+    /// signal returned by `register*()` so the waiting request future
+    /// resolves with a cancellation error. Running jobs are not cancelable
+    /// — the GPU worker owns them and there is no safe preemption point.
+    ///
+    /// The state check and removal happen under the same write lock that
+    /// `mark_running` takes, so a job can never be both cancelled and
+    /// promoted. (A worker that already dequeued the job before the cancel
+    /// landed will observe the closed result channel and skip it.)
+    pub fn cancel_queued(&self, id: &str) -> Result<(), QueuedJobCancelError> {
+        let mut entries = self.inner.write().unwrap_or_else(|e| e.into_inner());
+        let Some(pos) = entries.iter().position(|e| e.id == id) else {
+            return Err(QueuedJobCancelError::NotFound);
+        };
+        if entries[pos].state == JobLifecycle::Running {
+            return Err(QueuedJobCancelError::AlreadyRunning);
+        }
+        let entry = entries.remove(pos);
+        entry.cancel.notify_one();
+        Ok(())
     }
 
     /// Promote a registry entry from `Queued` to `Running`. No-op if `id`
@@ -302,6 +348,48 @@ mod tests {
         reg.remove("");
         reg.remove("never-existed");
         assert!(reg.is_empty());
+    }
+
+    #[test]
+    fn cancel_queued_removes_the_entry() {
+        let reg = JobRegistry::new();
+        reg.register("a", "flux-dev:fp16");
+        reg.register("b", "sdxl:q8");
+        reg.cancel_queued("a").unwrap();
+        let snap = reg.snapshot();
+        assert_eq!(snap.entries.len(), 1);
+        assert_eq!(snap.entries[0].id, "b");
+        assert_eq!(snap.entries[0].position, 0);
+    }
+
+    #[test]
+    fn cancel_queued_rejects_running_jobs_and_keeps_the_entry() {
+        let reg = JobRegistry::new();
+        reg.register("a", "flux-dev:fp16");
+        reg.mark_running("a", Some(0));
+        let err = reg.cancel_queued("a").unwrap_err();
+        assert_eq!(err, QueuedJobCancelError::AlreadyRunning);
+        assert_eq!(reg.len(), 1, "running entry must survive a cancel attempt");
+    }
+
+    #[test]
+    fn cancel_queued_unknown_id_is_not_found() {
+        let reg = JobRegistry::new();
+        let err = reg.cancel_queued("never-existed").unwrap_err();
+        assert_eq!(err, QueuedJobCancelError::NotFound);
+    }
+
+    #[tokio::test]
+    async fn cancel_queued_signals_the_registered_waiter() {
+        // The handle returned by register() must resolve `notified()` even
+        // when the cancel fires before the waiter starts awaiting — Notify
+        // stores the permit from notify_one().
+        let reg = JobRegistry::new();
+        let cancel = reg.register("a", "flux-dev:fp16");
+        reg.cancel_queued("a").unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(1), cancel.notified())
+            .await
+            .expect("cancel signal must resolve the waiter");
     }
 
     #[test]

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -115,6 +115,18 @@ impl ApiError {
         }
     }
 
+    /// Job cancelled while queued. 499 is the de-facto "client closed
+    /// request" status (nginx); we reuse it for "request cancelled before
+    /// the server did any work" so clients can distinguish cancellation
+    /// from real inference failures.
+    pub fn cancelled(msg: impl Into<String>) -> Self {
+        Self {
+            error: msg.into(),
+            code: "CANCELLED".to_string(),
+            status: StatusCode::from_u16(499).expect("499 is a valid status code"),
+        }
+    }
+
     pub fn insufficient_memory(msg: impl Into<String>) -> Self {
         Self {
             error: msg.into(),
@@ -171,6 +183,9 @@ use crate::queue::clean_error_message;
         server_status,
         list_queue,
         patch_queue_job,
+        cancel_queue_job,
+        list_history,
+        delete_history,
         health,
         capabilities_chain_limits,
         crate::routes_chain::generate_chain,
@@ -223,6 +238,8 @@ use crate::queue::clean_error_message;
         LoadModelBody,
         UnloadRequest,
         QueuePatchRequest,
+        mold_core::HistoryEntry,
+        mold_core::HistoryListing,
         crate::job_registry::JobEntry,
         crate::job_registry::QueueListing,
         crate::chain_limits::ChainLimits,
@@ -335,7 +352,11 @@ pub fn create_router(state: AppState) -> Router {
         .route("/api/resources/stream", get(get_resources_stream))
         .route("/api/status", get(server_status))
         .route("/api/queue", get(list_queue))
-        .route("/api/queue/:id", patch(patch_queue_job))
+        .route(
+            "/api/queue/:id",
+            patch(patch_queue_job).delete(cancel_queue_job),
+        )
+        .route("/api/history", get(list_history).delete(delete_history))
         .route("/api/capabilities", get(server_capabilities))
         .route(
             "/api/capabilities/chain-limits",
@@ -596,7 +617,7 @@ async fn generate(
     // SSE clients. Cleanup happens unconditionally on every terminal
     // path (drop guard in `gpu_worker::process_job`).
     let job_id = uuid::Uuid::new_v4().to_string();
-    state
+    let cancel = state
         .job_registry
         .register_with_target_gpu(&job_id, &req.model, preferred_gpu);
     let job = GenerationJob {
@@ -614,10 +635,19 @@ async fn generate(
         .inspect_err(|_| state.job_registry.remove(&job_id))
         .map_err(submit_error_to_api)?;
 
-    // Wait for the queue worker to process the job
-    let result = result_rx
-        .await
-        .map_err(|_| ApiError::internal("generation queue worker dropped the job"))?;
+    // Wait for the queue worker to process the job — or for
+    // `DELETE /api/queue/:id` to cancel it while it's still queued.
+    // Returning here drops `result_rx`, so the worker's is_closed()
+    // check skips the job when it eventually reaches the head.
+    let result = tokio::select! {
+        result = result_rx => result
+            .map_err(|_| ApiError::internal("generation queue worker dropped the job"))?,
+        _ = cancel.notified() => {
+            return Err(ApiError::cancelled(format!(
+                "generation job {job_id} was cancelled while queued"
+            )));
+        }
+    };
 
     match result {
         Ok(job_result) => {
@@ -1310,7 +1340,7 @@ async fn generate_stream(
     // Assign a server-side ID and register before submit so the entry is
     // visible to /api/queue from the moment we accept the request.
     let job_id = uuid::Uuid::new_v4().to_string();
-    state
+    let cancel = state
         .job_registry
         .register_with_target_gpu(&job_id, &req.model, preferred_gpu);
     let job = GenerationJob {
@@ -1337,15 +1367,37 @@ async fn generate_stream(
 
     // Hold `tx` alive in a background task until the job completes, so the SSE
     // stream never closes prematurely even if the queue worker hasn't received
-    // the job yet.
+    // the job yet. A `DELETE /api/queue/:id` cancel resolves the select's
+    // second arm: emit a terminal error event, then drop both channel ends —
+    // dropping `result_rx` closes the job's result channel, which is what
+    // makes the queue worker/dispatcher skip the job when it dequeues it.
     tokio::spawn(async move {
-        let _ = result_rx.await;
+        tokio::select! {
+            _ = result_rx => {}
+            _ = cancel.notified() => {
+                let _ = tx.send(SseMessage::Error(SseErrorEvent {
+                    message: "cancelled".to_string(),
+                }));
+            }
+        }
         drop(tx); // closes the SSE stream
     });
 
-    // Build SSE stream from the channel receiver.
-    let stream = tokio_stream::wrappers::UnboundedReceiverStream::new(rx)
-        .map(|msg| Ok::<_, Infallible>(sse_message_to_event(msg)));
+    // Build SSE stream from the channel receiver. Error events are terminal
+    // on this endpoint (the worker always follows them by resolving the
+    // job), so end the stream right after one — a cancelled job's queued
+    // `GenerationJob` still holds a sender clone, and without the explicit
+    // break the stream would stay open until the worker drained it.
+    let stream = async_stream::stream! {
+        let mut rx = rx;
+        while let Some(msg) = rx.recv().await {
+            let is_error = matches!(msg, SseMessage::Error(_));
+            yield Ok::<_, Infallible>(sse_message_to_event(msg));
+            if is_error {
+                break;
+            }
+        }
+    };
 
     Ok(Sse::new(stream).keep_alive(
         KeepAlive::new()
@@ -1949,6 +2001,141 @@ async fn patch_queue_job(
         .entry(&id)
         .ok_or_else(|| ApiError::queue_job_not_found(format!("queue job {id} not found")))?;
     Ok(Json(entry))
+}
+
+/// Cancel a still-queued generation job. Only queued jobs are cancelable —
+/// once a GPU worker owns the job there is no safe preemption point, so
+/// running jobs return 409. The waiting client observes the cancellation as
+/// a 499 `CANCELLED` error (blocking `POST /api/generate`) or a terminal
+/// SSE `error` event (`POST /api/generate/stream`).
+#[utoipa::path(
+    delete,
+    path = "/api/queue/{id}",
+    tag = "queue",
+    params(("id" = String, Path, description = "Queue job id")),
+    responses(
+        (status = 204, description = "Queued job cancelled"),
+        (status = 404, description = "Queue job not found"),
+        (status = 409, description = "Queue job is already running"),
+    )
+)]
+async fn cancel_queue_job(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<StatusCode, ApiError> {
+    state.job_registry.cancel_queued(&id).map_err(|e| match e {
+        crate::job_registry::QueuedJobCancelError::NotFound => {
+            ApiError::queue_job_not_found(format!("queue job {id} not found"))
+        }
+        crate::job_registry::QueuedJobCancelError::AlreadyRunning => ApiError::queue_job_running(
+            format!("queue job {id} is already running; only queued jobs can be cancelled"),
+        ),
+    })?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+// ── /api/history ─────────────────────────────────────────────────────────────
+
+/// Default number of history rows returned when `limit` is omitted.
+const HISTORY_DEFAULT_LIMIT: usize = 50;
+/// Hard cap on `limit` — matches the legacy 500-entry history bound.
+const HISTORY_MAX_LIMIT: usize = 500;
+
+/// 503 error code when the metadata DB is disabled (`MOLD_DB_DISABLE=1`).
+const HISTORY_UNAVAILABLE: &str = "HISTORY_UNAVAILABLE";
+
+fn history_db(state: &AppState) -> Result<&mold_db::MetadataDb, ApiError> {
+    state.metadata_db.as_ref().as_ref().ok_or_else(|| {
+        ApiError::with_code(
+            "prompt history is unavailable because the metadata DB is disabled",
+            HISTORY_UNAVAILABLE,
+            StatusCode::SERVICE_UNAVAILABLE,
+        )
+    })
+}
+
+#[derive(Debug, Deserialize)]
+struct HistoryListQuery {
+    /// Case-insensitive substring filter over the prompt text.
+    query: Option<String>,
+    /// Max rows to return (default 50, capped at 500).
+    limit: Option<usize>,
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/history",
+    tag = "server",
+    params(
+        ("query" = Option<String>, Query, description = "Substring filter over prompt text (case-insensitive)"),
+        ("limit" = Option<usize>, Query, description = "Max rows to return (default 50, max 500)"),
+    ),
+    responses(
+        (status = 200, description = "Prompt history, newest first", body = mold_core::HistoryListing),
+        (status = 503, description = "Metadata DB disabled"),
+    )
+)]
+async fn list_history(
+    State(state): State<AppState>,
+    axum::extract::Query(params): axum::extract::Query<HistoryListQuery>,
+) -> Result<Json<mold_core::HistoryListing>, ApiError> {
+    let db = history_db(&state)?;
+    let limit = params
+        .limit
+        .unwrap_or(HISTORY_DEFAULT_LIMIT)
+        .min(HISTORY_MAX_LIMIT);
+    let history = mold_db::PromptHistory::new(db);
+    let rows = match params
+        .query
+        .as_deref()
+        .map(str::trim)
+        .filter(|q| !q.is_empty())
+    {
+        Some(query) => history.search(query, limit),
+        None => history.recent(limit),
+    }
+    .map_err(|e| ApiError::internal(format!("failed to read prompt history: {e:#}")))?;
+    let entries = rows
+        .into_iter()
+        .map(|e| mold_core::HistoryEntry {
+            prompt: e.prompt,
+            model: e.model,
+            used_at: e.created_at_ms,
+        })
+        .collect();
+    Ok(Json(mold_core::HistoryListing { entries }))
+}
+
+#[derive(Debug, Deserialize)]
+struct HistoryDeleteQuery {
+    /// When present, trim to the most recent N entries instead of clearing.
+    keep: Option<usize>,
+}
+
+#[utoipa::path(
+    delete,
+    path = "/api/history",
+    tag = "server",
+    params(
+        ("keep" = Option<usize>, Query, description = "Keep only the most recent N entries instead of clearing everything"),
+    ),
+    responses(
+        (status = 204, description = "Prompt history cleared (or trimmed)"),
+        (status = 503, description = "Metadata DB disabled"),
+    )
+)]
+async fn delete_history(
+    State(state): State<AppState>,
+    axum::extract::Query(params): axum::extract::Query<HistoryDeleteQuery>,
+) -> Result<StatusCode, ApiError> {
+    let db = history_db(&state)?;
+    let history = mold_db::PromptHistory::new(db);
+    match params.keep {
+        Some(keep) => history.trim_to(keep),
+        None => history.clear(),
+    }
+    .map_err(|e| ApiError::internal(format!("failed to clear prompt history: {e:#}")))?;
+    Ok(StatusCode::NO_CONTENT)
 }
 
 // ── /api/capabilities ────────────────────────────────────────────────────────

--- a/crates/mold-server/src/routes_test.rs
+++ b/crates/mold-server/src/routes_test.rs
@@ -684,6 +684,394 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn delete_queue_cancels_queued_job_with_204_and_removes_it() {
+        let (state, _rx) = AppState::with_engine_and_queue(MockEngine::ready());
+        state.job_registry.register("aaaa", "flux-dev:fp16");
+
+        let app = app_with_state(state);
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::delete("/api/queue/aaaa")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+        let resp = app
+            .oneshot(Request::get("/api/queue").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let body = json_body(resp).await;
+        assert_eq!(body["entries"], serde_json::json!([]));
+    }
+
+    #[tokio::test]
+    async fn delete_queue_unknown_id_returns_404() {
+        let (state, _rx) = AppState::with_engine_and_queue(MockEngine::ready());
+        let app = app_with_state(state);
+        let resp = app
+            .oneshot(
+                Request::delete("/api/queue/not-here")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let body = json_body(resp).await;
+        assert_eq!(body["code"], "QUEUE_JOB_NOT_FOUND");
+    }
+
+    #[tokio::test]
+    async fn delete_queue_running_job_returns_409() {
+        let (state, _rx) = AppState::with_engine_and_queue(MockEngine::ready());
+        state.job_registry.register("aaaa", "flux-dev:fp16");
+        state.job_registry.mark_running("aaaa", Some(0));
+
+        let app = app_with_state(state.clone());
+        let resp = app
+            .oneshot(
+                Request::delete("/api/queue/aaaa")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+        let body = json_body(resp).await;
+        assert_eq!(body["code"], "QUEUE_JOB_RUNNING");
+        assert_eq!(
+            state.job_registry.len(),
+            1,
+            "running job must survive the cancel attempt"
+        );
+    }
+
+    /// Poll the registry until the submitted job shows up (the generate
+    /// handler registers before submit, so this resolves almost instantly).
+    async fn wait_for_registered_job(state: &AppState) -> String {
+        for _ in 0..500 {
+            if let Some(entry) = state.job_registry.snapshot().entries.first() {
+                return entry.id.clone();
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        panic!("job never appeared in the registry");
+    }
+
+    #[tokio::test]
+    async fn delete_queue_resolves_blocking_generate_with_cancelled_error() {
+        // No queue worker is spawned — the submitted job sits queued in the
+        // channel exactly like a job stuck behind a long-running generation.
+        let (state, _rx) = AppState::with_engine_and_queue(MockEngine::ready());
+        let app = app_with_state(state.clone());
+
+        let gen_app = app.clone();
+        let gen_task = tokio::spawn(async move {
+            gen_app
+                .oneshot(
+                    Request::post("/api/generate")
+                        .header("content-type", "application/json")
+                        .body(Body::from(generate_body("a cat", 512, 512)))
+                        .unwrap(),
+                )
+                .await
+                .unwrap()
+        });
+
+        let id = wait_for_registered_job(&state).await;
+        let resp = app
+            .oneshot(
+                Request::delete(format!("/api/queue/{id}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+        let gen_resp = tokio::time::timeout(Duration::from_secs(5), gen_task)
+            .await
+            .expect("blocking generate must resolve after cancel")
+            .unwrap();
+        assert_eq!(gen_resp.status().as_u16(), 499);
+        let body = json_body(gen_resp).await;
+        assert_eq!(body["code"], "CANCELLED");
+    }
+
+    #[tokio::test]
+    async fn delete_queue_emits_sse_error_and_closes_the_stream() {
+        // No queue worker — the streaming job stays queued until cancelled.
+        let (state, _rx) = AppState::with_engine_and_queue(MockEngine::ready());
+        let app = app_with_state(state.clone());
+
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::post("/api/generate/stream")
+                    .header("content-type", "application/json")
+                    .body(Body::from(generate_body("a cat", 512, 512)))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let id = wait_for_registered_job(&state).await;
+        let del = app
+            .oneshot(
+                Request::delete(format!("/api/queue/{id}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(del.status(), StatusCode::NO_CONTENT);
+
+        // The stream must emit an `error` event and then CLOSE — to_bytes
+        // only returns once the body stream terminates, so the timeout is
+        // the regression guard against a stream that stays open after
+        // cancellation.
+        let bytes = tokio::time::timeout(
+            Duration::from_secs(5),
+            axum::body::to_bytes(resp.into_body(), 1024 * 1024),
+        )
+        .await
+        .expect("SSE stream must close after cancel")
+        .unwrap();
+        let text = String::from_utf8(bytes.to_vec()).unwrap();
+        assert!(text.contains("event: error"), "missing error event: {text}");
+        assert!(text.contains("cancelled"), "missing cancel message: {text}");
+    }
+
+    // ── /api/history ─────────────────────────────────────────────────────────
+
+    fn history_entry(prompt: &str, model: &str, ts: i64) -> mold_db::HistoryEntry {
+        mold_db::HistoryEntry {
+            prompt: prompt.into(),
+            negative: None,
+            model: model.into(),
+            created_at_ms: ts,
+        }
+    }
+
+    /// State + router backed by an in-memory metadata DB. Returns the shared
+    /// DB handle so tests can seed/inspect prompt history around requests.
+    fn app_with_history_db() -> (axum::Router, Arc<Option<mold_db::MetadataDb>>) {
+        let mut state = AppState::for_tests();
+        let db = Arc::new(Some(mold_db::MetadataDb::open_in_memory().unwrap()));
+        state.metadata_db = db.clone();
+        (app_with_state(state), db)
+    }
+
+    fn seed_history(db: &Arc<Option<mold_db::MetadataDb>>, entries: &[(&str, &str, i64)]) {
+        let db = db.as_ref().as_ref().expect("test DB present");
+        let history = mold_db::PromptHistory::new(db);
+        for (prompt, model, ts) in entries {
+            history.push(&history_entry(prompt, model, *ts)).unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn history_returns_recent_entries_newest_first() {
+        let (app, db) = app_with_history_db();
+        seed_history(
+            &db,
+            &[
+                ("first", "flux-dev:q4", 1_000),
+                ("second", "flux-dev:q4", 2_000),
+                ("third", "sdxl:fp16", 3_000),
+            ],
+        );
+
+        let resp = app
+            .oneshot(Request::get("/api/history").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = json_body(resp).await;
+        let entries = body["entries"].as_array().expect("entries array");
+        assert_eq!(entries.len(), 3);
+        assert_eq!(
+            entries[0],
+            serde_json::json!({
+                "prompt": "third",
+                "model": "sdxl:fp16",
+                "used_at": 3_000,
+            })
+        );
+        assert_eq!(entries[2]["prompt"], "first");
+    }
+
+    #[tokio::test]
+    async fn history_query_filters_by_substring() {
+        let (app, db) = app_with_history_db();
+        seed_history(
+            &db,
+            &[
+                ("A Sunny Day", "m", 1),
+                ("cloudy morning", "m", 2),
+                ("SUNSET over sea", "m", 3),
+            ],
+        );
+
+        let resp = app
+            .oneshot(
+                Request::get("/api/history?query=sun")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = json_body(resp).await;
+        let prompts: Vec<&str> = body["entries"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|e| e["prompt"].as_str().unwrap())
+            .collect();
+        assert_eq!(prompts, vec!["SUNSET over sea", "A Sunny Day"]);
+    }
+
+    #[tokio::test]
+    async fn history_limit_defaults_to_50_and_caps_at_500() {
+        let (app, db) = app_with_history_db();
+        let rows: Vec<(String, &str, i64)> = (0..510)
+            .map(|i| (format!("p{i}"), "m", (i as i64 + 1) * 10))
+            .collect();
+        {
+            let db = db.as_ref().as_ref().unwrap();
+            let history = mold_db::PromptHistory::new(db);
+            for (prompt, model, ts) in &rows {
+                history.push(&history_entry(prompt, model, *ts)).unwrap();
+            }
+        }
+
+        // Default limit is 50.
+        let resp = app
+            .clone()
+            .oneshot(Request::get("/api/history").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let body = json_body(resp).await;
+        assert_eq!(body["entries"].as_array().unwrap().len(), 50);
+
+        // Explicit limits are honored…
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::get("/api/history?limit=2")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = json_body(resp).await;
+        assert_eq!(body["entries"].as_array().unwrap().len(), 2);
+
+        // …but capped at 500.
+        let resp = app
+            .oneshot(
+                Request::get("/api/history?limit=10000")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = json_body(resp).await;
+        assert_eq!(body["entries"].as_array().unwrap().len(), 500);
+    }
+
+    #[tokio::test]
+    async fn history_returns_503_when_db_disabled() {
+        // AppState::for_tests() has metadata_db = None — same state the
+        // server boots into under MOLD_DB_DISABLE=1.
+        let app = app_with_state(AppState::for_tests());
+        let resp = app
+            .oneshot(Request::get("/api/history").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body = json_body(resp).await;
+        assert_eq!(body["code"], "HISTORY_UNAVAILABLE");
+        assert!(body["error"].as_str().unwrap().contains("metadata DB"));
+    }
+
+    #[tokio::test]
+    async fn delete_history_clears_all_and_returns_204() {
+        let (app, db) = app_with_history_db();
+        seed_history(&db, &[("a", "m", 1), ("b", "m", 2)]);
+
+        let resp = app
+            .clone()
+            .oneshot(Request::delete("/api/history").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+        let resp = app
+            .oneshot(Request::get("/api/history").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let body = json_body(resp).await;
+        assert_eq!(body["entries"], serde_json::json!([]));
+    }
+
+    #[tokio::test]
+    async fn delete_history_keep_trims_to_most_recent_n() {
+        let (app, db) = app_with_history_db();
+        seed_history(
+            &db,
+            &[
+                ("p0", "m", 100),
+                ("p1", "m", 200),
+                ("p2", "m", 300),
+                ("p3", "m", 400),
+            ],
+        );
+
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::delete("/api/history?keep=2")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+        let resp = app
+            .oneshot(Request::get("/api/history").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let body = json_body(resp).await;
+        let prompts: Vec<&str> = body["entries"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|e| e["prompt"].as_str().unwrap())
+            .collect();
+        assert_eq!(prompts, vec!["p3", "p2"]);
+    }
+
+    #[tokio::test]
+    async fn delete_history_returns_503_when_db_disabled() {
+        let app = app_with_state(AppState::for_tests());
+        let resp = app
+            .oneshot(Request::delete("/api/history").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let body = json_body(resp).await;
+        assert_eq!(body["code"], "HISTORY_UNAVAILABLE");
+    }
+
+    #[tokio::test]
     async fn status_when_no_model() {
         let app = app_empty();
         let resp = app

--- a/website/api/index.md
+++ b/website/api/index.md
@@ -48,6 +48,9 @@ When running `mold serve`, you get a REST API for remote image generation.
 | `GET`    | `/api/resources/stream`                   | Resource snapshots as SSE                                                                                         |
 | `GET`    | `/api/queue`                              | Server-authoritative job listing (queued + running, UUIDv4 ids); used by the SPA to reconcile dropped SSE streams |
 | `PATCH`  | `/api/queue/:id`                          | Update the preferred GPU lane for a queued job                                                                    |
+| `DELETE` | `/api/queue/:id`                          | Cancel a still-queued generation job                                                                              |
+| `GET`    | `/api/history`                            | Prompt history, newest first (`?query=` substring filter, `?limit=` up to 500)                                    |
+| `DELETE` | `/api/history`                            | Clear prompt history (`?keep=N` trims to the most recent N)                                                       |
 | `GET`    | `/api/capabilities`                       | Feature capabilities (gallery delete, chain limits, …)                                                            |
 | `GET`    | `/api/capabilities/chain-limits`          | Chain-generation request limits                                                                                   |
 | `PUT`    | `/api/config/model/:name/placement`       | Save model-specific device placement defaults                                                                     |
@@ -306,6 +309,51 @@ curl -X PATCH http://localhost:7680/api/queue/00000000-0000-0000-0000-0000000000
 
 Set `target_gpu` to `null` to return the queued job to automatic placement.
 Already-running jobs reject lane changes.
+
+Use `DELETE /api/queue/:id` to cancel a job that is still queued:
+
+```bash
+curl -X DELETE http://localhost:7680/api/queue/00000000-0000-0000-0000-000000000000
+```
+
+Returns `204 No Content` on success, `404` for unknown ids, and `409`
+(`QUEUE_JOB_RUNNING`) once a GPU worker owns the job — only queued jobs are
+cancelable. The waiting client observes the cancellation immediately: a
+blocking `POST /api/generate` resolves with a `499` `CANCELLED` error, and a
+`POST /api/generate/stream` connection receives a terminal `error` event and
+closes.
+
+## `/api/history`
+
+`GET /api/history` returns recent prompt history from the metadata DB, newest
+first. `?query=` filters by case-insensitive prompt substring; `?limit=`
+bounds the row count (default 50, max 500).
+
+```bash
+curl "http://localhost:7680/api/history?query=sunset&limit=10"
+```
+
+```json
+{
+  "entries": [
+    {
+      "prompt": "sunset over sea",
+      "model": "flux-dev:q8",
+      "used_at": 1700000000000
+    }
+  ]
+}
+```
+
+`DELETE /api/history` clears the history (`204 No Content`). Pass `?keep=N`
+to trim to the most recent N entries instead:
+
+```bash
+curl -X DELETE "http://localhost:7680/api/history?keep=100"
+```
+
+Both endpoints return `503` (`HISTORY_UNAVAILABLE`) when the metadata DB is
+disabled (`MOLD_DB_DISABLE=1`).
 
 ## `/api/loras`
 


### PR DESCRIPTION
Adds two additive API surfaces needed by the experimental Tauri desktop app (branch `experiment/desktop`), designed to land on main independently:

## DELETE /api/queue/:id
Cancel a **queued** generation job. 204 on success, 404 unknown, 409 `QUEUE_JOB_RUNNING` when already running (matches the existing PATCH re-lane error code). The blocking `POST /api/generate` path resolves with **499 `CANCELLED`**; the SSE stream emits the standard error event and now actually closes after any error event.

## GET /api/history · DELETE /api/history
Prompt history over HTTP (was DB-direct, CLI/TUI-only): `?query=` substring search, `limit` default 50 / cap 500; delete clears or `?keep=N` trims. 503 `HISTORY_UNAVAILABLE` when the metadata DB is disabled. New `HistoryEntry`/`HistoryListing` wire types in mold-core.

TDD throughout (failing tests first); 442 mold-server tests green, clippy -D warnings clean, CHANGELOG/SKILL.md/website synced.

https://claude.ai/code/session_01MK1BZxzYc4FuJRHtHA9Bfw