### PR TITLE
feat(server): DELETE /api/models/:model with shared-component refcounting

### DIFF
--- a/.claude/skills/mold/SKILL.md
+++ b/.claude/skills/mold/SKILL.md
@@ -688,6 +688,7 @@ Core endpoints exposed by `mold serve` (full list + schemas at `/api/docs`):
   - `DELETE /api/chain-jobs/:id` · `POST /api/chain-jobs/gc` · `GET /api/chain-jobs/:id/stages/:idx/preview`
 - `POST /api/expand` — LLM prompt expansion
 - `GET /api/models` · `GET /api/loras` · `POST /api/models/load` · `POST /api/models/pull` · `DELETE /api/models/unload`
+- `DELETE /api/models/:model` — remove a downloaded model (HTTP `mold rm`): deletes only exclusively-owned files, keeps shared components, returns `{ removed, kept, freed_bytes }`; 409 while loaded
 - `GET /api/gallery` · `GET /api/gallery/image/:name` · `GET /api/gallery/thumbnail/:name` · `DELETE /api/gallery/image/:name`
 - `POST /api/upscale` · `POST /api/upscale/stream`
 - `GET /api/queue` — authoritative server-side job listing for SPA reconciliation (queued + running jobs with UUIDv4 ids)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`DELETE /api/models/:model` — model removal over HTTP** (previously CLI-only via `mold rm`): deletes only files exclusively owned by the model, keeps components still referenced by other downloaded models (shared T5/CLIP/Qwen encoders, VAEs), and cleans up the hardlinked hf-hub cache blobs so freed bytes are real. Responds `200` with `{ removed, kept: [{ component, used_by }], freed_bytes }`; `404 UNKNOWN_MODEL` when not installed; `409 MODEL_LOADED` while the model is GPU-resident (unload first). The ref-counting core moved to `mold_core::removal` and is now shared by `mold rm` and the server.
+
 ### Fixed
 
 - **`mold run --local` chains now run the missing-assets repair pull.** The local chain path shares the single-clip model resolve/pull preamble, so a model with deleted or corrupted component files is repaired automatically instead of failing at engine load.

--- a/crates/mold-cli/src/commands/cleanup.rs
+++ b/crates/mold-cli/src/commands/cleanup.rs
@@ -11,36 +11,11 @@ use mold_core::Config;
 use crate::theme;
 use crate::ui::format_bytes;
 
+// NOTE: `file_size` and `build_ref_counts` moved to `mold_core::removal`
+// so the server's `DELETE /api/models/:model` shares the same ref-counting
+// core as `mold rm` and `mold clean`.
+
 pub const STALE_PULL_MAX_AGE: Duration = Duration::from_secs(6 * 60 * 60);
-
-/// Get file size, returning 0 if the file doesn't exist or can't be read.
-pub fn file_size(path: &str) -> u64 {
-    std::fs::metadata(path).map(|m| m.len()).unwrap_or(0)
-}
-
-/// Build a map of file_path -> list of model names that reference it.
-pub fn build_ref_counts(config: &Config) -> HashMap<String, Vec<String>> {
-    let mut refs: HashMap<String, Vec<String>> = HashMap::new();
-    for (model_name, model_config) in &config.models {
-        for path in model_config.all_file_paths() {
-            refs.entry(path).or_default().push(model_name.clone());
-        }
-    }
-    // Include manifest-backed downloaded models that have no config entry.
-    // Without this, shared components (VAE, encoders) referenced by another
-    // manifest-only install would be deleted when removing a model.
-    for manifest in known_manifests() {
-        if config.models.contains_key(&manifest.name) {
-            continue; // already counted above
-        }
-        if config.manifest_model_is_downloaded(&manifest.name) {
-            for path in config.model_config(&manifest.name).all_file_paths() {
-                refs.entry(path).or_default().push(manifest.name.clone());
-            }
-        }
-    }
-    refs
-}
 
 /// Collect all file paths still referenced by remaining models.
 ///

--- a/crates/mold-cli/src/commands/rm.rs
+++ b/crates/mold-cli/src/commands/rm.rs
@@ -1,22 +1,21 @@
 use std::collections::HashSet;
 use std::io::{self, Write};
-use std::path::PathBuf;
 
 use anyhow::Result;
 use clap_complete::engine::CompletionCandidate;
 use colored::Colorize;
 use mold_core::manifest::resolve_model_name;
+use mold_core::removal::{execute_removal, plan_removal};
 use mold_core::Config;
 
-use super::cleanup::{
-    build_ref_counts, clean_hf_cache, clean_orphaned_shared_files, clean_stale_pull_markers,
-    file_size,
-};
+use super::cleanup::{clean_hf_cache, clean_orphaned_shared_files, clean_stale_pull_markers};
 #[cfg(test)]
 use super::cleanup::{remove_empty_dirs_recursive, remove_orphaned_files_recursive, HfCacheIndex};
 use crate::theme;
 use crate::ui::format_bytes;
 use crate::AlreadyReported;
+#[cfg(test)]
+use mold_core::removal::build_ref_counts;
 
 /// Provide completions for installed model names (config + manifest-backed).
 pub fn complete_installed_model_name() -> Vec<CompletionCandidate> {
@@ -28,80 +27,6 @@ pub fn complete_installed_model_name() -> Vec<CompletionCandidate> {
         }
     }
     names.into_iter().map(CompletionCandidate::new).collect()
-}
-
-/// Collect hf-hub cache blob paths for a model's files.
-///
-/// When `mold pull` downloads files, the hf-hub crate stores blobs at:
-///   `<models_dir>/.hf-cache/models--<org>--<repo>/blobs/<sha256>`
-/// and creates snapshot symlinks pointing to them. The clean storage paths
-/// are then hardlinked from these blobs. This function walks the hf-cache
-/// snapshot dirs looking for files whose names match the manifest's
-/// `hf_filename` entries, then resolves their symlinks to find the blob paths.
-pub(super) fn collect_hf_cache_blob_paths(
-    model_name: &str,
-    unique_clean_paths: &[(String, u64)],
-) -> Vec<PathBuf> {
-    let manifest = match mold_core::manifest::find_manifest(model_name) {
-        Some(m) => m,
-        None => return Vec::new(),
-    };
-
-    let config = Config::load_or_default();
-    let models_dir = config.resolved_models_dir();
-    let cache_dir = models_dir.join(".hf-cache");
-    if !cache_dir.is_dir() {
-        return Vec::new();
-    }
-
-    // Build a set of unique clean paths to restrict which manifest files we
-    // collect cache blobs for. Shared components (VAE, T5, CLIP) that are
-    // still referenced by other models must NOT have their blobs deleted.
-    let unique_set: HashSet<String> = unique_clean_paths.iter().map(|(p, _)| p.clone()).collect();
-
-    let mut blobs = Vec::new();
-
-    for file in &manifest.files {
-        // Only collect blobs for files whose clean paths are being deleted.
-        let clean_path = models_dir
-            .join(mold_core::manifest::storage_path(manifest, file))
-            .to_string_lossy()
-            .to_string();
-        if !unique_set.contains(&clean_path) {
-            continue;
-        }
-        // hf-hub stores repos as models--<org>--<repo>
-        let repo_dir_name = format!("models--{}", file.hf_repo.replace('/', "--"));
-        let repo_dir = cache_dir.join(&repo_dir_name);
-        if !repo_dir.is_dir() {
-            continue;
-        }
-
-        // Walk snapshots/<rev>/ looking for the filename
-        let snapshots_dir = repo_dir.join("snapshots");
-        if !snapshots_dir.is_dir() {
-            continue;
-        }
-
-        // Use the full relative hf_filename (e.g. "text_encoder/model.safetensors")
-        // because hf-hub preserves nested paths in snapshot directories.
-        if let Ok(revisions) = std::fs::read_dir(&snapshots_dir) {
-            for rev in revisions.flatten() {
-                let snap_file = rev.path().join(&file.hf_filename);
-                // The snapshot entry is a symlink to ../../blobs/<sha>.
-                // Resolve it to get the blob path.
-                if snap_file.symlink_metadata().is_ok() {
-                    if let Ok(blob) = snap_file.canonicalize() {
-                        blobs.push(blob);
-                    }
-                    // Also collect the symlink itself for cleanup
-                    blobs.push(snap_file);
-                }
-            }
-        }
-    }
-
-    blobs
 }
 
 pub async fn run(models: &[String], force: bool) -> Result<()> {
@@ -124,39 +49,17 @@ pub async fn run(models: &[String], force: bool) -> Result<()> {
             continue;
         }
 
-        // Build reference counts across all installed models
-        let ref_counts = build_ref_counts(&config);
+        // Classify files as unique (only this model) or shared — the
+        // ref-counting core is shared with the server's DELETE endpoint.
+        let plan = plan_removal(&config, &canonical);
+        let unique_files = &plan.unique_files;
+        let shared_files = &plan.shared_files;
 
-        // Get the model config — either from config.models or resolved from
-        // the manifest registry for manifest-backed models without a config entry.
-        let model_config = if let Some(cfg) = config.models.get(&canonical) {
-            cfg.clone()
-        } else {
-            config.resolved_model_config(&canonical)
-        };
-        let all_paths = model_config.all_file_paths();
-
-        // Classify files as unique (only this model) or shared
-        let mut unique_files: Vec<(String, u64)> = Vec::new();
-        let mut shared_files: Vec<(String, Vec<String>)> = Vec::new();
-
-        for path in &all_paths {
-            let refs = ref_counts.get(path).cloned().unwrap_or_default();
-            let other_refs: Vec<String> =
-                refs.into_iter().filter(|name| name != &canonical).collect();
-
-            if other_refs.is_empty() {
-                unique_files.push((path.clone(), file_size(path)));
-            } else {
-                shared_files.push((path.clone(), other_refs));
-            }
-        }
-
-        let total_freed: u64 = unique_files.iter().map(|(_, size)| size).sum();
+        let total_freed: u64 = plan.total_unique_bytes();
 
         // Display summary
         println!("{}", canonical.bold());
-        for (path, size) in &unique_files {
+        for (path, size) in unique_files {
             let filename = std::path::Path::new(path)
                 .file_name()
                 .map(|f| f.to_string_lossy().to_string())
@@ -168,7 +71,7 @@ pub async fn run(models: &[String], force: bool) -> Result<()> {
                 format_bytes(*size)
             );
         }
-        for (path, refs) in &shared_files {
+        for (path, refs) in shared_files {
             let filename = std::path::Path::new(path)
                 .file_name()
                 .map(|f| f.to_string_lossy().to_string())
@@ -203,67 +106,14 @@ pub async fn run(models: &[String], force: bool) -> Result<()> {
             }
         }
 
-        // Delete unique files and their hf-cache counterparts.
-        //
-        // When `mold pull` downloads a file, it hardlinks the hf-hub cache
-        // blob to a clean storage path under models_dir. Deleting only the
-        // clean path leaves the cache blob on disk — the inode's link count
-        // doesn't drop to zero, so `du` still reports the same usage.
-        //
-        // We use the manifest to locate the corresponding hf-cache blob
-        // paths and delete those too.
-        let mut freed: u64 = 0;
-        let hf_cache_blobs = collect_hf_cache_blob_paths(&canonical, &unique_files);
-
-        for (path, _size) in &unique_files {
-            match std::fs::remove_file(path) {
-                Ok(()) => {}
-                Err(e) if e.kind() == io::ErrorKind::NotFound => {
-                    eprintln!("{} {} already deleted", theme::prefix_warning(), path);
-                }
-                Err(e) => {
-                    eprintln!(
-                        "{} failed to delete {}: {}",
-                        theme::prefix_warning(),
-                        path,
-                        e
-                    );
-                }
-            }
+        // Delete unique files and their hf-cache counterparts (shared core
+        // with the server endpoint — see mold_core::removal for the hf-cache
+        // hardlink accounting).
+        let outcome = execute_removal(&config, &plan);
+        for warning in &outcome.warnings {
+            eprintln!("{} {}", theme::prefix_warning(), warning);
         }
-
-        // Delete hf-cache blobs that were hardlinked to the clean paths.
-        // Space is only actually freed when the last hardlink (the blob) is removed,
-        // so we count freed bytes here rather than at clean-path deletion.
-        for blob_path in &hf_cache_blobs {
-            if blob_path.exists() {
-                let size = file_size(&blob_path.to_string_lossy());
-                match std::fs::remove_file(blob_path) {
-                    Ok(()) => freed += size,
-                    Err(e) => {
-                        eprintln!(
-                            "{} failed to clean up cache file {}: {}",
-                            theme::prefix_warning(),
-                            blob_path.display(),
-                            e
-                        );
-                    }
-                }
-            }
-        }
-
-        // For non-manifest models (no hf-cache blobs), the clean path deletion
-        // itself freed the space, so use the pre-computed total.
-        if hf_cache_blobs.is_empty() {
-            freed = total_freed;
-        }
-
-        // Clean up empty model-specific directories left behind.
-        if let Some(ref t) = model_config.transformer {
-            if let Some(parent) = std::path::Path::new(t).parent() {
-                let _ = std::fs::remove_dir(parent); // only succeeds if empty
-            }
-        }
+        let freed = outcome.freed_bytes;
 
         // Remove from config and clean up pull marker
         config.remove_model(&canonical);

--- a/crates/mold-core/src/lib.rs
+++ b/crates/mold-core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod install_error;
 pub mod lambda;
 pub mod manifest;
 pub mod media_paths;
+pub mod removal;
 pub mod runpod;
 pub mod safetensors_probe;
 pub mod time;

--- a/crates/mold-core/src/removal.rs
+++ b/crates/mold-core/src/removal.rs
@@ -1,0 +1,379 @@
+//! Shared model-removal core used by `mold rm` (CLI) and the server's
+//! `DELETE /api/models/:model` endpoint.
+//!
+//! Several models share components (T5/CLIP/Qwen encoders, VAEs) under the
+//! models dir — this is why manifest SIZE (model weights only) differs from
+//! FETCH (total download including shared deps). Removal therefore
+//! ref-counts every file path across all installed models and only deletes
+//! paths exclusively owned by the model being removed.
+//!
+//! The split is plan → execute:
+//! - [`plan_removal`] classifies the model's files as unique vs shared
+//!   (pure given a `Config`, no filesystem mutation).
+//! - [`execute_removal`] deletes the unique clean paths plus their hf-hub
+//!   cache blobs/snapshot symlinks (space is only freed when the last
+//!   hardlink goes), returning what was removed, bytes freed, and any
+//!   non-fatal warnings for the caller to surface.
+
+use std::collections::{HashMap, HashSet};
+use std::io;
+use std::path::PathBuf;
+
+use crate::manifest::known_manifests;
+use crate::Config;
+
+/// Get file size, returning 0 if the file doesn't exist or can't be read.
+pub fn file_size(path: &str) -> u64 {
+    std::fs::metadata(path).map(|m| m.len()).unwrap_or(0)
+}
+
+/// Build a map of file_path -> list of model names that reference it.
+pub fn build_ref_counts(config: &Config) -> HashMap<String, Vec<String>> {
+    let mut refs: HashMap<String, Vec<String>> = HashMap::new();
+    for (model_name, model_config) in &config.models {
+        for path in model_config.all_file_paths() {
+            refs.entry(path).or_default().push(model_name.clone());
+        }
+    }
+    // Include manifest-backed downloaded models that have no config entry.
+    // Without this, shared components (VAE, encoders) referenced by another
+    // manifest-only install would be deleted when removing a model.
+    for manifest in known_manifests() {
+        if config.models.contains_key(&manifest.name) {
+            continue; // already counted above
+        }
+        if config.manifest_model_is_downloaded(&manifest.name) {
+            for path in config.model_config(&manifest.name).all_file_paths() {
+                refs.entry(path).or_default().push(manifest.name.clone());
+            }
+        }
+    }
+    refs
+}
+
+/// True when `canonical` is removable: it has an explicit config entry or
+/// its manifest files are fully present on disk.
+pub fn is_model_installed(config: &Config, canonical: &str) -> bool {
+    config.models.contains_key(canonical) || config.manifest_model_is_downloaded(canonical)
+}
+
+/// Classification of one model's files into exclusively-owned vs shared.
+#[derive(Debug, Clone)]
+pub struct RemovalPlan {
+    /// Canonical model name the plan was built for.
+    pub model: String,
+    /// `(path, size_bytes)` for files referenced only by this model.
+    pub unique_files: Vec<(String, u64)>,
+    /// `(path, other_referencing_models)` for files that must be kept.
+    pub shared_files: Vec<(String, Vec<String>)>,
+    /// Transformer path (used to clean up the model's now-empty directory).
+    pub transformer: Option<String>,
+}
+
+impl RemovalPlan {
+    /// Sum of the unique files' sizes at plan time. Used for the CLI
+    /// confirmation prompt and as the freed-bytes fallback when a model
+    /// has no hf-cache blobs.
+    pub fn total_unique_bytes(&self) -> u64 {
+        self.unique_files.iter().map(|(_, size)| size).sum()
+    }
+}
+
+/// Classify `canonical`'s files as unique (deletable) or shared (kept)
+/// by ref-counting paths across every installed model.
+pub fn plan_removal(config: &Config, canonical: &str) -> RemovalPlan {
+    let ref_counts = build_ref_counts(config);
+
+    // Get the model config — either from config.models or resolved from
+    // the manifest registry for manifest-backed models without a config entry.
+    let model_config = if let Some(cfg) = config.models.get(canonical) {
+        cfg.clone()
+    } else {
+        config.resolved_model_config(canonical)
+    };
+
+    let mut unique_files: Vec<(String, u64)> = Vec::new();
+    let mut shared_files: Vec<(String, Vec<String>)> = Vec::new();
+
+    for path in &model_config.all_file_paths() {
+        let refs = ref_counts.get(path).cloned().unwrap_or_default();
+        let other_refs: Vec<String> = refs.into_iter().filter(|name| name != canonical).collect();
+
+        if other_refs.is_empty() {
+            unique_files.push((path.clone(), file_size(path)));
+        } else {
+            shared_files.push((path.clone(), other_refs));
+        }
+    }
+
+    RemovalPlan {
+        model: canonical.to_string(),
+        unique_files,
+        shared_files,
+        transformer: model_config.transformer.clone(),
+    }
+}
+
+/// Collect hf-hub cache blob paths for a model's files.
+///
+/// When `mold pull` downloads files, the hf-hub crate stores blobs at:
+///   `<models_dir>/.hf-cache/models--<org>--<repo>/blobs/<sha256>`
+/// and creates snapshot symlinks pointing to them. The clean storage paths
+/// are then hardlinked from these blobs. This function walks the hf-cache
+/// snapshot dirs looking for files whose names match the manifest's
+/// `hf_filename` entries, then resolves their symlinks to find the blob paths.
+///
+/// Only files whose clean paths appear in `unique_clean_paths` are collected —
+/// shared components (VAE, T5, CLIP) still referenced by other models must
+/// NOT have their blobs deleted.
+pub fn collect_hf_cache_blob_paths(
+    config: &Config,
+    model_name: &str,
+    unique_clean_paths: &[(String, u64)],
+) -> Vec<PathBuf> {
+    let manifest = match crate::manifest::find_manifest(model_name) {
+        Some(m) => m,
+        None => return Vec::new(),
+    };
+
+    let models_dir = config.resolved_models_dir();
+    let cache_dir = models_dir.join(".hf-cache");
+    if !cache_dir.is_dir() {
+        return Vec::new();
+    }
+
+    let unique_set: HashSet<String> = unique_clean_paths.iter().map(|(p, _)| p.clone()).collect();
+
+    let mut blobs = Vec::new();
+
+    for file in &manifest.files {
+        // Only collect blobs for files whose clean paths are being deleted.
+        let clean_path = models_dir
+            .join(crate::manifest::storage_path(manifest, file))
+            .to_string_lossy()
+            .to_string();
+        if !unique_set.contains(&clean_path) {
+            continue;
+        }
+        // hf-hub stores repos as models--<org>--<repo>
+        let repo_dir_name = format!("models--{}", file.hf_repo.replace('/', "--"));
+        let repo_dir = cache_dir.join(&repo_dir_name);
+        if !repo_dir.is_dir() {
+            continue;
+        }
+
+        // Walk snapshots/<rev>/ looking for the filename
+        let snapshots_dir = repo_dir.join("snapshots");
+        if !snapshots_dir.is_dir() {
+            continue;
+        }
+
+        // Use the full relative hf_filename (e.g. "text_encoder/model.safetensors")
+        // because hf-hub preserves nested paths in snapshot directories.
+        if let Ok(revisions) = std::fs::read_dir(&snapshots_dir) {
+            for rev in revisions.flatten() {
+                let snap_file = rev.path().join(&file.hf_filename);
+                // The snapshot entry is a symlink to ../../blobs/<sha>.
+                // Resolve it to get the blob path.
+                if snap_file.symlink_metadata().is_ok() {
+                    if let Ok(blob) = snap_file.canonicalize() {
+                        blobs.push(blob);
+                    }
+                    // Also collect the symlink itself for cleanup
+                    blobs.push(snap_file);
+                }
+            }
+        }
+    }
+
+    blobs
+}
+
+/// Result of [`execute_removal`].
+#[derive(Debug, Clone, Default)]
+pub struct RemovalOutcome {
+    /// Clean storage paths that were actually deleted.
+    pub removed: Vec<String>,
+    /// Bytes freed on disk. Counted at hf-cache blob removal when blobs
+    /// exist (the clean path is a hardlink, so unlinking it alone frees
+    /// nothing); otherwise the sum of the unique files' sizes.
+    pub freed_bytes: u64,
+    /// Non-fatal problems (missing files, failed unlinks). The CLI prints
+    /// these with its warning prefix; the server logs them.
+    pub warnings: Vec<String>,
+}
+
+/// Delete the plan's unique clean paths and their hf-cache counterparts,
+/// then clean up the model's now-empty directory. Never touches shared
+/// files. Errors are collected as warnings — removal is best-effort per
+/// file, matching `mold rm`.
+pub fn execute_removal(config: &Config, plan: &RemovalPlan) -> RemovalOutcome {
+    let mut outcome = RemovalOutcome::default();
+
+    // When `mold pull` downloads a file, it hardlinks the hf-hub cache
+    // blob to a clean storage path under models_dir. Deleting only the
+    // clean path leaves the cache blob on disk — the inode's link count
+    // doesn't drop to zero, so `du` still reports the same usage.
+    //
+    // We use the manifest to locate the corresponding hf-cache blob
+    // paths and delete those too.
+    let hf_cache_blobs = collect_hf_cache_blob_paths(config, &plan.model, &plan.unique_files);
+
+    for (path, _size) in &plan.unique_files {
+        match std::fs::remove_file(path) {
+            Ok(()) => outcome.removed.push(path.clone()),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {
+                outcome.warnings.push(format!("{path} already deleted"));
+            }
+            Err(e) => {
+                outcome
+                    .warnings
+                    .push(format!("failed to delete {path}: {e}"));
+            }
+        }
+    }
+
+    // Delete hf-cache blobs that were hardlinked to the clean paths.
+    // Space is only actually freed when the last hardlink (the blob) is removed,
+    // so we count freed bytes here rather than at clean-path deletion.
+    for blob_path in &hf_cache_blobs {
+        if blob_path.exists() {
+            let size = file_size(&blob_path.to_string_lossy());
+            match std::fs::remove_file(blob_path) {
+                Ok(()) => outcome.freed_bytes += size,
+                Err(e) => {
+                    outcome.warnings.push(format!(
+                        "failed to clean up cache file {}: {e}",
+                        blob_path.display()
+                    ));
+                }
+            }
+        }
+    }
+
+    // For non-manifest models (no hf-cache blobs), the clean path deletion
+    // itself freed the space, so use the pre-computed total.
+    if hf_cache_blobs.is_empty() {
+        outcome.freed_bytes = plan.total_unique_bytes();
+    }
+
+    // Clean up empty model-specific directories left behind.
+    if let Some(ref t) = plan.transformer {
+        if let Some(parent) = std::path::Path::new(t).parent() {
+            let _ = std::fs::remove_dir(parent); // only succeeds if empty
+        }
+    }
+
+    outcome
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ModelConfig;
+
+    fn tmp_dir(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "mold-removal-{}-{}",
+            label,
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+    }
+
+    fn two_model_config(tmp: &std::path::Path) -> Config {
+        let shared_vae = tmp.join("shared-vae.safetensors");
+        let mut config = Config::default();
+        config.models.insert(
+            "model-a".into(),
+            ModelConfig {
+                transformer: Some(tmp.join("unique-a.gguf").to_string_lossy().into_owned()),
+                vae: Some(shared_vae.to_string_lossy().into_owned()),
+                ..Default::default()
+            },
+        );
+        config.models.insert(
+            "model-b".into(),
+            ModelConfig {
+                transformer: Some(tmp.join("unique-b.gguf").to_string_lossy().into_owned()),
+                vae: Some(shared_vae.to_string_lossy().into_owned()),
+                ..Default::default()
+            },
+        );
+        config
+    }
+
+    #[test]
+    fn build_ref_counts_counts_shared_files_across_models() {
+        let tmp = tmp_dir("refs");
+        let config = two_model_config(&tmp);
+        let refs = build_ref_counts(&config);
+        let shared = tmp.join("shared-vae.safetensors");
+        assert_eq!(refs[&shared.to_string_lossy().into_owned()].len(), 2);
+        assert_eq!(
+            refs[&tmp.join("unique-a.gguf").to_string_lossy().into_owned()].len(),
+            1
+        );
+    }
+
+    #[test]
+    fn plan_classifies_unique_and_shared_files() {
+        let tmp = tmp_dir("plan");
+        let config = two_model_config(&tmp);
+
+        let plan = plan_removal(&config, "model-a");
+        assert_eq!(plan.model, "model-a");
+        assert_eq!(plan.unique_files.len(), 1, "only the transformer is unique");
+        assert!(plan.unique_files[0].0.ends_with("unique-a.gguf"));
+        assert_eq!(plan.shared_files.len(), 1, "the VAE is shared");
+        assert!(plan.shared_files[0].0.ends_with("shared-vae.safetensors"));
+        assert_eq!(plan.shared_files[0].1, vec!["model-b".to_string()]);
+    }
+
+    #[test]
+    fn execute_removal_deletes_unique_files_and_keeps_shared() {
+        let tmp = tmp_dir("exec");
+        std::fs::create_dir_all(&tmp).unwrap();
+        let unique_a = tmp.join("unique-a.gguf");
+        let unique_b = tmp.join("unique-b.gguf");
+        let shared_vae = tmp.join("shared-vae.safetensors");
+        std::fs::write(&unique_a, b"transformer-a").unwrap(); // 13 bytes
+        std::fs::write(&unique_b, b"transformer-b").unwrap();
+        std::fs::write(&shared_vae, b"vae").unwrap();
+
+        let config = two_model_config(&tmp);
+        let plan = plan_removal(&config, "model-a");
+        let outcome = execute_removal(&config, &plan);
+
+        assert!(!unique_a.exists(), "exclusive file must be deleted");
+        assert!(shared_vae.exists(), "shared file must survive");
+        assert!(unique_b.exists(), "other model's file must survive");
+        assert_eq!(
+            outcome.removed,
+            vec![unique_a.to_string_lossy().into_owned()]
+        );
+        assert_eq!(outcome.freed_bytes, 13, "freed = unique file size");
+        assert!(outcome.warnings.is_empty(), "got: {:?}", outcome.warnings);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn execute_removal_reports_missing_files_as_warnings() {
+        let tmp = tmp_dir("missing");
+        // Files never created — every unique path is already gone.
+        let config = two_model_config(&tmp);
+        let plan = plan_removal(&config, "model-a");
+        let outcome = execute_removal(&config, &plan);
+
+        assert!(outcome.removed.is_empty());
+        assert_eq!(outcome.warnings.len(), 1);
+        assert!(
+            outcome.warnings[0].ends_with("already deleted"),
+            "got: {:?}",
+            outcome.warnings
+        );
+    }
+}

--- a/crates/mold-core/src/types.rs
+++ b/crates/mold-core/src/types.rs
@@ -1896,6 +1896,28 @@ mod tests {
     }
 
     #[test]
+    fn model_removal_response_serde_roundtrip() {
+        // Wire contract for DELETE /api/models/:model — removed paths,
+        // kept shared components with their surviving referents, and the
+        // bytes actually freed on disk.
+        let resp = ModelRemovalResponse {
+            removed: vec!["/models/flux-schnell-q8/transformer.gguf".to_string()],
+            kept: vec![KeptComponent {
+                component: "/models/shared/flux/ae.safetensors".to_string(),
+                used_by: vec!["flux-dev:q8".to_string()],
+            }],
+            freed_bytes: 12_345,
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(json.contains(r#""freed_bytes":12345"#), "got: {json}");
+        assert!(json.contains(r#""used_by":["flux-dev:q8"]"#), "got: {json}");
+        let back: ModelRemovalResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.removed.len(), 1);
+        assert_eq!(back.kept[0].used_by, vec!["flux-dev:q8".to_string()]);
+        assert_eq!(back.freed_bytes, 12_345);
+    }
+
+    #[test]
     fn sse_progress_queued_roundtrip() {
         let event = SseProgressEvent::Queued {
             position: 3,
@@ -2702,6 +2724,28 @@ pub struct CatalogCapabilities {
 pub struct ServerCapabilities {
     pub gallery: GalleryCapabilities,
     pub catalog: CatalogCapabilities,
+}
+
+/// One shared component kept on disk by `DELETE /api/models/:model`
+/// because other downloaded models still reference it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct KeptComponent {
+    /// Absolute path of the kept file.
+    pub component: String,
+    /// Models (other than the removed one) that still reference it.
+    pub used_by: Vec<String>,
+}
+
+/// Response of `DELETE /api/models/:model` — what was deleted, what was
+/// kept for other models, and how many bytes were actually freed on disk.
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct ModelRemovalResponse {
+    /// Absolute paths of the files that were deleted.
+    pub removed: Vec<String>,
+    /// Shared components kept because another model still uses them.
+    pub kept: Vec<KeptComponent>,
+    /// Bytes freed on disk (hf-cache hardlinks accounted for).
+    pub freed_bytes: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -168,6 +168,7 @@ use crate::queue::clean_error_message;
         load_model,
         pull_model_endpoint,
         unload_model,
+        delete_model,
         server_status,
         list_queue,
         patch_queue_job,
@@ -222,6 +223,8 @@ use crate::queue::clean_error_message;
         ModelInfoExtended,
         LoadModelBody,
         UnloadRequest,
+        mold_core::ModelRemovalResponse,
+        mold_core::KeptComponent,
         QueuePatchRequest,
         crate::job_registry::JobEntry,
         crate::job_registry::QueueListing,
@@ -292,6 +295,7 @@ pub fn create_router(state: AppState) -> Router {
         )
         .route("/api/expand", post(expand_prompt))
         .route("/api/models", get(list_models))
+        .route("/api/models/:model", delete(delete_model))
         .route("/api/models/:model/components", get(model_components))
         .route("/api/loras", get(crate::catalog_api::list_loras))
         .route("/api/models/load", post(load_model))
@@ -1772,6 +1776,140 @@ async fn unload_model(
 
     // Legacy single-GPU path.
     Ok((StatusCode::OK, model_manager::unload_model(&state).await))
+}
+
+// ── DELETE /api/models/:model ─────────────────────────────────────────────────
+
+/// True when an engine for `canonical` is currently GPU-resident (or mid-
+/// generation) anywhere on this server — the single-GPU cache, any pool
+/// worker's cache, or an active-generation snapshot on either path.
+async fn model_is_gpu_resident(state: &AppState, canonical: &str) -> bool {
+    {
+        let cache = state.model_cache.lock().await;
+        if cache.active_model() == Some(canonical) {
+            return true;
+        }
+    }
+    if state
+        .active_generation
+        .read()
+        .unwrap_or_else(|e| e.into_inner())
+        .as_ref()
+        .is_some_and(|g| g.model == canonical)
+    {
+        return true;
+    }
+    for worker in &state.gpu_pool.workers {
+        if let Ok(active) = worker.active_generation.read() {
+            if active.as_ref().is_some_and(|g| g.model == canonical) {
+                return true;
+            }
+        }
+        if let Ok(cache) = worker.model_cache.lock() {
+            if cache.active_model() == Some(canonical) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Remove a downloaded model's files — the HTTP counterpart of `mold rm`.
+///
+/// Ref-counts every file path across all installed models and deletes only
+/// paths exclusively owned by this model; components still referenced by
+/// another downloaded model (shared T5/CLIP/Qwen encoders, VAEs) are kept
+/// and reported in `kept` with the surviving referents. hf-hub cache blobs
+/// hardlinked to the deleted clean paths are removed too, so `freed_bytes`
+/// reflects real disk savings.
+#[utoipa::path(
+    delete,
+    path = "/api/models/{model}",
+    tag = "models",
+    params(("model" = String, Path, description = "Model name (e.g. flux-schnell:q8)")),
+    responses(
+        (status = 200, description = "Model removed", body = mold_core::ModelRemovalResponse),
+        (status = 404, description = "Model not installed"),
+        (status = 409, description = "Model is currently loaded — unload it first"),
+    )
+)]
+async fn delete_model(
+    State(state): State<AppState>,
+    Path(model): Path<String>,
+) -> Result<Json<mold_core::ModelRemovalResponse>, ApiError> {
+    let canonical = mold_core::manifest::resolve_model_name(&model);
+
+    // Refuse while the model is GPU-resident — there is no safe way to pull
+    // files out from under a loaded engine. Check the raw input too: engines
+    // register under their own model_name, which for non-manifest models may
+    // not round-trip through resolve_model_name. (Best-effort check: a load
+    // that races past it just keeps working off its already-open mmaps.)
+    if model_is_gpu_resident(&state, &canonical).await
+        || (model != canonical && model_is_gpu_resident(&state, &model).await)
+    {
+        return Err(ApiError::with_code(
+            format!(
+                "model '{canonical}' is currently loaded; unload it first (DELETE /api/models/unload)"
+            ),
+            "MODEL_LOADED",
+            StatusCode::CONFLICT,
+        ));
+    }
+
+    // Hold the config write lock across plan + delete so a concurrent pull
+    // or placement write can't interleave with the removal.
+    let mut config = state.config.write().await;
+    let in_config = config.models.contains_key(&canonical);
+    if !in_config && !config.manifest_model_is_downloaded(&canonical) {
+        return Err(ApiError::with_code(
+            format!("model '{canonical}' is not installed"),
+            "UNKNOWN_MODEL",
+            StatusCode::NOT_FOUND,
+        ));
+    }
+
+    tracing::info!(model = %canonical, "model removal requested");
+    let plan = mold_core::removal::plan_removal(&config, &canonical);
+    let outcome = mold_core::removal::execute_removal(&config, &plan);
+    for warning in &outcome.warnings {
+        tracing::warn!(model = %canonical, "model removal: {warning}");
+    }
+
+    mold_core::download::remove_pulling_marker(&canonical);
+    if in_config {
+        config.remove_model(&canonical);
+        if let Err(e) = config.save() {
+            tracing::warn!("failed to persist model removal to config.toml: {e}");
+        }
+    }
+    drop(config);
+
+    // Evict any parked (non-GPU-resident) engine so a later request can't
+    // reactivate an engine whose files are gone.
+    {
+        let mut cache = state.model_cache.lock().await;
+        let _ = cache.remove(&canonical);
+    }
+    for worker in &state.gpu_pool.workers {
+        if let Ok(mut cache) = worker.model_cache.lock() {
+            let _ = cache.remove(&canonical);
+        }
+    }
+
+    let kept = plan
+        .shared_files
+        .iter()
+        .map(|(path, used_by)| mold_core::KeptComponent {
+            component: path.clone(),
+            used_by: used_by.clone(),
+        })
+        .collect();
+
+    Ok(Json(mold_core::ModelRemovalResponse {
+        removed: outcome.removed,
+        kept,
+        freed_bytes: outcome.freed_bytes,
+    }))
 }
 
 // ── /api/status ───────────────────────────────────────────────────────────────

--- a/crates/mold-server/src/routes_test.rs
+++ b/crates/mold-server/src/routes_test.rs
@@ -683,6 +683,200 @@ mod tests {
         assert_eq!(body["code"], "QUEUE_JOB_RUNNING");
     }
 
+    // ── DELETE /api/models/:model ────────────────────────────────────────────
+
+    /// All clean storage paths for a manifest model under `models_dir`.
+    fn manifest_clean_paths(models_dir: &std::path::Path, model: &str) -> Vec<std::path::PathBuf> {
+        let manifest = mold_core::manifest::find_manifest(model).unwrap();
+        manifest
+            .files
+            .iter()
+            .map(|file| models_dir.join(mold_core::manifest::storage_path(manifest, file)))
+            .collect()
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn delete_model_removes_exclusively_owned_files() {
+        let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let models_dir = test_models_dir("delete-model-solo");
+        populate_manifest_files(&models_dir, "flux-schnell:q8");
+        std::env::set_var("MOLD_MODELS_DIR", &models_dir);
+
+        let app = app_empty();
+        let resp = app
+            .oneshot(
+                Request::delete("/api/models/flux-schnell:q8")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = json_body(resp).await;
+
+        // No other model references anything — every file is exclusively
+        // owned, nothing is kept, and real bytes were freed.
+        let removed = body["removed"].as_array().expect("removed array");
+        assert!(!removed.is_empty(), "expected removed files: {body}");
+        assert_eq!(body["kept"], serde_json::json!([]));
+        assert!(
+            body["freed_bytes"].as_u64().unwrap() > 0,
+            "freed_bytes must be > 0: {body}"
+        );
+
+        for path in manifest_clean_paths(&models_dir, "flux-schnell:q8") {
+            assert!(
+                !path.exists(),
+                "exclusively-owned file must be deleted: {}",
+                path.display()
+            );
+        }
+
+        std::env::remove_var("MOLD_MODELS_DIR");
+        let _ = std::fs::remove_dir_all(models_dir);
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn delete_model_keeps_components_shared_with_another_model() {
+        let _lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let models_dir = test_models_dir("delete-model-shared");
+        // flux-schnell:q8 and flux-dev:q8 share VAE/T5/CLIP under shared/.
+        populate_manifest_files(&models_dir, "flux-schnell:q8");
+        populate_manifest_files(&models_dir, "flux-dev:q8");
+        std::env::set_var("MOLD_MODELS_DIR", &models_dir);
+
+        let schnell_paths = manifest_clean_paths(&models_dir, "flux-schnell:q8");
+        let dev_paths: std::collections::HashSet<_> =
+            manifest_clean_paths(&models_dir, "flux-dev:q8")
+                .into_iter()
+                .collect();
+        let shared: Vec<_> = schnell_paths
+            .iter()
+            .filter(|p| dev_paths.contains(*p))
+            .collect();
+        let unique: Vec<_> = schnell_paths
+            .iter()
+            .filter(|p| !dev_paths.contains(*p))
+            .collect();
+        assert!(
+            !shared.is_empty() && !unique.is_empty(),
+            "test premise: the two models must share some files and own others"
+        );
+
+        let app = app_empty();
+        let resp = app
+            .oneshot(
+                Request::delete("/api/models/flux-schnell:q8")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = json_body(resp).await;
+
+        // Exclusive files (the transformer) are gone; shared components stay.
+        for path in &unique {
+            assert!(
+                !path.exists(),
+                "exclusive file must be deleted: {}",
+                path.display()
+            );
+        }
+        for path in &shared {
+            assert!(
+                path.exists(),
+                "shared component must survive: {}",
+                path.display()
+            );
+        }
+
+        // The kept list reports every shared component with the surviving
+        // referencing model.
+        let kept = body["kept"].as_array().expect("kept array");
+        assert_eq!(kept.len(), shared.len(), "kept must cover shared: {body}");
+        for entry in kept {
+            let used_by: Vec<&str> = entry["used_by"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|v| v.as_str().unwrap())
+                .collect();
+            assert!(
+                used_by.contains(&"flux-dev:q8"),
+                "kept entry must name the surviving model: {entry}"
+            );
+            let component = entry["component"].as_str().unwrap();
+            assert!(
+                shared.iter().any(|p| p.to_string_lossy() == component),
+                "kept component must be a shared path: {entry}"
+            );
+        }
+
+        // The removed list must not contain any shared path.
+        let removed: Vec<&str> = body["removed"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        for path in &shared {
+            assert!(
+                !removed.contains(&path.to_string_lossy().as_ref()),
+                "shared path must not be reported as removed: {}",
+                path.display()
+            );
+        }
+
+        // The sibling model is untouched.
+        for path in &dev_paths {
+            assert!(
+                path.exists(),
+                "sibling model file must survive: {}",
+                path.display()
+            );
+        }
+
+        std::env::remove_var("MOLD_MODELS_DIR");
+        let _ = std::fs::remove_dir_all(models_dir);
+    }
+
+    #[tokio::test]
+    async fn delete_model_unknown_returns_404_unknown_model() {
+        let app = app_empty();
+        let resp = app
+            .oneshot(
+                Request::delete("/api/models/definitely-not-a-model")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let body = json_body(resp).await;
+        assert_eq!(body["code"], "UNKNOWN_MODEL");
+    }
+
+    #[tokio::test]
+    async fn delete_model_gpu_resident_returns_409_model_loaded() {
+        // MockEngine::ready() is GPU-resident in the cache as "mock-model" —
+        // deletion must be refused until the model is unloaded.
+        let app = app_with_state(AppState::with_engine(MockEngine::ready()));
+        let resp = app
+            .oneshot(
+                Request::delete("/api/models/mock-model")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+        let body = json_body(resp).await;
+        assert_eq!(body["code"], "MODEL_LOADED");
+    }
+
     #[tokio::test]
     async fn status_when_no_model() {
         let app = app_empty();

--- a/website/api/index.md
+++ b/website/api/index.md
@@ -28,6 +28,7 @@ When running `mold serve`, you get a REST API for remote image generation.
 | `POST`   | `/api/models/load`                        | Load/swap the active model                                                                                        |
 | `POST`   | `/api/models/pull`                        | Pull/download a model                                                                                             |
 | `DELETE` | `/api/models/unload`                      | Unload model to free GPU memory                                                                                   |
+| `DELETE` | `/api/models/:model`                      | Remove a downloaded model (keeps components shared with other models)                                             |
 | `GET`    | `/api/gallery`                            | List saved images                                                                                                 |
 | `GET`    | `/api/gallery/image/:name`                | Fetch a saved image                                                                                               |
 | `DELETE` | `/api/gallery/image/:name`                | Delete a saved image                                                                                              |
@@ -289,6 +290,38 @@ with a path back to the model catalog.
 ```bash
 curl "http://localhost:7680/api/models/flux-dev:q8/components"
 ```
+
+## `DELETE /api/models/:model`
+
+`DELETE /api/models/:model` removes a downloaded model — the HTTP counterpart
+of `mold rm`. Several models share components (T5/CLIP/Qwen encoders, VAEs)
+under the models directory, so removal ref-counts every file across all
+installed models and deletes only files exclusively owned by the target;
+shared components still referenced by another downloaded model are kept.
+Hardlinked hf-hub cache blobs are cleaned up too, so `freed_bytes` reflects
+real disk savings.
+
+```bash
+curl -X DELETE http://localhost:7680/api/models/flux-schnell:q8
+```
+
+```json
+{
+  "removed": ["/models/flux-schnell-q8/flux1-schnell-Q8_0.gguf"],
+  "kept": [
+    {
+      "component": "/models/shared/flux/ae.safetensors",
+      "used_by": ["flux-dev:q8"]
+    }
+  ],
+  "freed_bytes": 12726374912
+}
+```
+
+Returns `404` (`UNKNOWN_MODEL`) when the model isn't installed, and `409`
+(`MODEL_LOADED`) while the model is GPU-resident — unload it first via
+`DELETE /api/models/unload`. This is a destructive endpoint; pair with
+`MOLD_API_KEY` when the server is exposed beyond localhost.
 
 ## `/api/queue`
 


### PR DESCRIPTION
Third upstream surface for the experimental desktop app (`experiment/desktop`), independent of #345.

`mold rm`'s refcount/deletion logic is extracted into a shared `mold_core::removal` module (plan_removal / execute_removal / build_ref_counts) — the CLI delegates to it with byte-identical output, and the new endpoint reuses it:

- **409 `MODEL_LOADED`** when GPU-resident (single-GPU cache, pool workers, or mid-generation) — unload first
- **404 `UNKNOWN_MODEL`** when not installed
- **200** `{ removed, kept: [{component, used_by}], freed_bytes }` — deletes only exclusively-owned files; components still referenced by another installed model are kept and reported ("Keeps t5-xxl (used by …)")
- Config write lock held across plan+delete; parked engines for the model evicted post-delete

TDD (failing first); full workspace tests/clippy/fmt green; CHANGELOG/SKILL.md/website synced.

https://claude.ai/code/session_01MK1BZxzYc4FuJRHtHA9Bfw