### PR TITLE
ci(release): sync desktop workspace-crate dep requirements on release PR

### DIFF
--- a/scripts/release/sync-release-pr.sh
+++ b/scripts/release/sync-release-pr.sh
@@ -54,15 +54,19 @@ else
 fi
 
 # --- 2. Desktop app version ------------------------------------------------
-# First `version = "..."` line is the [package] version in both files.
+# First `version = "..."` line is the [package] version; the path dependencies
+# on workspace crates (package = "mold-ai-*") carry version requirements that
+# must track the workspace version or cargo fails to select them.
 awk -v ver="$version" '
   !done && /^version = "/ { print "version = \"" ver "\""; done = 1; next }
+  /package = "mold-ai-/ { gsub(/version = "[^"]*"/, "version = \"" ver "\"") }
   { print }
 ' desktop/src-tauri/Cargo.toml > desktop/src-tauri/Cargo.toml.tmp \
   && mv desktop/src-tauri/Cargo.toml.tmp desktop/src-tauri/Cargo.toml
 
+# mold-desktop itself plus every workspace crate resolved via path deps.
 awk -v ver="$version" '
-  /^name = "mold-desktop"$/ { print; sync = 1; next }
+  /^name = "mold-desktop"$/ || /^name = "mold-ai-/ { print; sync = 1; next }
   sync && /^version = / { print "version = \"" ver "\""; sync = 0; next }
   { print }
 ' desktop/src-tauri/Cargo.lock > desktop/src-tauri/Cargo.lock.tmp \

--- a/scripts/tests/release-sync-pr.sh
+++ b/scripts/tests/release-sync-pr.sh
@@ -46,6 +46,10 @@ version = "0.14.0"
 edition = "2021"
 
 [dependencies]
+mold-core = { path = "../../crates/mold-core", package = "mold-ai-core", version = "0.14.0" }
+mold-server = { path = "../../crates/mold-server", package = "mold-ai-server", version = "0.14.0", features = [
+  "preview",
+] }
 serde = { version = "1", features = ["derive"] }
 EOF
 
@@ -89,9 +93,12 @@ awk '/^## \[Unreleased\]$/{getline; getline; exit ($0 ~ /^## \[0.15.0\]/) ? 0 : 
 
 grep -q '^version = "0.15.0"$' "$tmp/desktop/src-tauri/Cargo.toml" || fail "desktop Cargo.toml version not synced"
 grep -q '^edition = "2021"$' "$tmp/desktop/src-tauri/Cargo.toml" || fail "desktop Cargo.toml collateral damage"
+grep -q 'package = "mold-ai-core", version = "0.15.0"' "$tmp/desktop/src-tauri/Cargo.toml" || fail "mold-ai-core dep requirement not synced"
+grep -q 'package = "mold-ai-server", version = "0.15.0", features' "$tmp/desktop/src-tauri/Cargo.toml" || fail "mold-ai-server dep requirement not synced (inline attrs lost?)"
+grep -q 'serde = { version = "1", features' "$tmp/desktop/src-tauri/Cargo.toml" || fail "serde dep requirement was touched"
 grep -q '"version": "0.15.0"' "$tmp/desktop/package.json" || fail "desktop package.json version not synced"
 awk '/^name = "mold-desktop"$/{getline; exit ($0 == "version = \"0.15.0\"") ? 0 : 1}' "$tmp/desktop/src-tauri/Cargo.lock" || fail "Cargo.lock mold-desktop version not synced"
-awk '/^name = "mold-ai-core"$/{getline; exit ($0 == "version = \"0.14.0\"") ? 0 : 1}' "$tmp/desktop/src-tauri/Cargo.lock" || fail "Cargo.lock touched an unrelated package"
+awk '/^name = "mold-ai-core"$/{getline; exit ($0 == "version = \"0.15.0\"") ? 0 : 1}' "$tmp/desktop/src-tauri/Cargo.lock" || fail "Cargo.lock mold-ai-core version not synced"
 awk '/^name = "serde"$/{getline; exit ($0 == "version = \"1.0.0\"") ? 0 : 1}' "$tmp/desktop/src-tauri/Cargo.lock" || fail "Cargo.lock touched serde"
 
 # Idempotency: second run must not change anything.


### PR DESCRIPTION
The desktop Rust job failed on release PR #354: `desktop/src-tauri/Cargo.toml` pins its path deps with version requirements (`package = "mold-ai-core", version = "0.14.0"`), which `scripts/release/sync-release-pr.sh` didn't bump, so cargo couldn't select `mold-ai-core ^0.14.0` against the bumped 0.15.0 workspace crates.

Now the sync script also rewrites those dep requirements and the matching `mold-ai-*` package entries in `desktop/src-tauri/Cargo.lock`. Test updated first (fixture reproduces the inline multi-attr dep shape from the real manifest, including the multiline `features = [` form); idempotency assertion still passes. shellcheck clean.

Once merged, the next release-plz run re-syncs PR #354 with the fixed script.