### PR TITLE
feat(website): direct desktop-app download link

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -313,7 +313,7 @@ jobs:
           merge-multiple: true
 
       - name: Generate checksums
-        run: cd artifacts && sha256sum *.tar.gz > SHA256SUMS
+        run: cd artifacts && sha256sum ./*.tar.gz > SHA256SUMS
 
       - name: Create/update release
         uses: softprops/action-gh-release@v2
@@ -373,8 +373,14 @@ jobs:
           path: artifacts
           merge-multiple: true
 
+      # The website links to releases/latest/download/Mold-macos-arm64.dmg, so
+      # every release must carry the DMG under that stable name alongside the
+      # versioned Mold_x.y.z_aarch64.dmg.
+      - name: Stable-named desktop DMG
+        run: cp artifacts/Mold_*_aarch64.dmg artifacts/Mold-macos-arm64.dmg
+
       - name: Generate checksums
-        run: cd artifacts && sha256sum *.tar.gz *.dmg *.zip > SHA256SUMS
+        run: cd artifacts && sha256sum ./*.tar.gz ./*.dmg ./*.zip > SHA256SUMS
 
       - name: Create release
         uses: softprops/action-gh-release@v2
@@ -417,7 +423,7 @@ jobs:
 
             ## Desktop app (macOS)
 
-            `Mold_*_aarch64.dmg` — signed, notarized, and stapled. Drag Mold to Applications; no quarantine dance needed.
+            `Mold-macos-arm64.dmg` (also attached with its versioned name) — signed, notarized, and stapled. Drag Mold to Applications; no quarantine dance needed. Stable link to the newest build: https://github.com/utensils/mold/releases/latest/download/Mold-macos-arm64.dmg
 
   # Publish to crates.io on v* tags
   publish:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Direct desktop-app download link.** Releases now also attach the DMG under the stable name `Mold-macos-arm64.dmg`, so `https://github.com/utensils/mold/releases/latest/download/Mold-macos-arm64.dmg` always fetches the newest signed build (backfilled onto v0.15.0). The website links it from the homepage hero (**Download for Mac**) and a new **Download** section in the desktop guide.
+
 ### Fixed
 
 - **FlakeHub publishing failed on v0.15.0** — the flake source archive outgrew FlakeHub's 75 MB limit. The two LTX gallery demos on the website were 23 MB animated WebPs each; they are now 135 KB VP9 `webm` videos (same frames, same size, autoplaying loop), shrinking the tracked tree by ~46 MB so tagged releases publish to FlakeHub again. v0.15.0 itself is not on FlakeHub; `nix run github:utensils/mold/v0.15.0` is unaffected.

--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ for full subcommand reference (`doctor`, `gpus`, `network-volume`, `list`,
 
 ### Native macOS desktop
 
+**[Download the signed DMG](https://github.com/utensils/mold/releases/latest/download/Mold-macos-arm64.dmg)** (Apple Silicon; notarized and stapled — drag to Applications).
+
 The experimental Tauri desktop app in `desktop/` embeds the Metal engine or
 connects to any local/remote `mold serve`. It includes Generate, a local/remote
 Gallery, parallel model downloads with real cancellation, chains, model

--- a/website/guide/desktop.md
+++ b/website/guide/desktop.md
@@ -7,9 +7,19 @@ developed.
 
 ::: warning Experimental
 The desktop app lives in `desktop/` and is under active development. It is
-macOS-first (Apple Silicon, Metal) and not yet part of a tagged release. Build
-it from source with the devshell commands below.
+macOS-first (Apple Silicon, Metal).
 :::
+
+## Download
+
+Every tagged release ships a signed, notarized, stapled DMG:
+
+**[⬇ Download Mold for macOS (Apple Silicon)](https://github.com/utensils/mold/releases/latest/download/Mold-macos-arm64.dmg)**
+
+Open the DMG and drag **Mold** to Applications — no quarantine dance needed.
+Version-pinned DMGs and `SHA256SUMS` are on the
+[releases page](https://github.com/utensils/mold/releases). You can also build
+from source with the devshell commands below.
 
 ## What it is
 

--- a/website/index.md
+++ b/website/index.md
@@ -16,6 +16,9 @@ hero:
       text: Get Started
       link: /guide/
     - theme: alt
+      text: Download for Mac
+      link: https://github.com/utensils/mold/releases/latest/download/Mold-macos-arm64.dmg
+    - theme: alt
       text: View Models
       link: /models/
     - theme: alt


### PR DESCRIPTION
Adds a permanent, direct download URL for the desktop app:

**https://github.com/utensils/mold/releases/latest/download/Mold-macos-arm64.dmg**

- `release.yml` now attaches the DMG under the stable name `Mold-macos-arm64.dmg` alongside the versioned one (both checksummed); backfilled onto v0.15.0 (byte-identical copy + updated SHA256SUMS), so the link already resolves (HTTP 200, 22.3 MB).
- Homepage hero gains **Download for Mac**; the desktop guide gets a **Download** section and loses its stale "not yet part of a tagged release / build from source" warning; README links the DMG.
- Cleans up shellcheck SC2035 info notes in the checksum steps.

Website `fmt:check` + `verify` + `build` and actionlint pass. Merging deploys via pages.yml (website/** path trigger).