### PR TITLE
fix(website): call out Apple Silicon on the download CTA

### DIFF
--- a/website/index.md
+++ b/website/index.md
@@ -16,7 +16,7 @@ hero:
       text: Get Started
       link: /guide/
     - theme: alt
-      text: Download for Mac
+      text: Download for Mac (Apple Silicon)
       link: https://github.com/utensils/mold/releases/latest/download/Mold-macos-arm64.dmg
     - theme: alt
       text: View Models


### PR DESCRIPTION
Follow-up to #359 addressing the Copilot finding: the hero button now reads **Download for Mac (Apple Silicon)** since the DMG is aarch64-only (mold ships no Intel build).