### PR TITLE
ci: path-aware gating — skip Rust gates on non-code changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,53 @@ env:
 #
 # Cache strategy: jobs that compile the same features share a cache key.
 # Only main-branch pushes save caches; PRs read from main's cache.
+#
+# Path-aware gating: the `changes` job classifies the diff, and each gate only
+# runs when its surface actually changed — a docs-only PR no longer compiles
+# the Rust workspace twice. This MUST stay as job-level `if:` conditions, NOT
+# `on.<event>.paths` filters: rust/coverage/docs/web are required status
+# checks, and a workflow that never triggers leaves them "Expected — waiting"
+# forever (blocking every docs-only PR and the release-plz PR). A job skipped
+# by `if:` reports "skipped", which branch protection counts as passing.
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
+      website: ${{ steps.filter.outputs.website }}
+      web: ${{ steps.filter.outputs.web }}
+      nix: ${{ steps.filter.outputs.nix }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            rust:
+              - 'crates/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - '.github/workflows/ci.yml'
+            website:
+              - 'website/**'
+              - '.github/workflows/ci.yml'
+            web:
+              - 'web/**'
+              - '.github/workflows/ci.yml'
+            nix:
+              - 'web/**'
+              - 'flake.nix'
+              - 'flake.lock'
+              - 'nix/**'
+              - '.github/workflows/ci.yml'
+
   docs:
+    needs: changes
+    if: needs.changes.outputs.website == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -38,6 +82,8 @@ jobs:
         run: bun run build
 
   web:
+    needs: changes
+    if: needs.changes.outputs.web == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -58,6 +104,8 @@ jobs:
         run: bun run build
 
   nix-web:
+    needs: changes
+    if: needs.changes.outputs.nix == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -66,6 +114,8 @@ jobs:
         run: nix build .#mold-web --print-build-logs
 
   rust:
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     env:
       RUSTC_WRAPPER: sccache
@@ -107,6 +157,8 @@ jobs:
         run: cargo check -p mold-ai --features preview,discord,expand,tui,webp,mp4,mdns
 
   coverage:
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     env:
       RUSTC_WRAPPER: sccache

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -3,9 +3,23 @@ name: Desktop
 # CI for the experimental Tauri desktop app (desktop/). The root ci.yml is
 # untouched by this surface: desktop/src-tauri is excluded from the cargo
 # workspace, so --workspace gates never see it.
+# These jobs are NOT required status checks, so plain `paths` trigger filters
+# are safe here (a filtered-out run reports nothing and blocks nothing) — the
+# required checks in ci.yml use job-level `if:` gating instead.
 on:
   push:
     branches: [main]
+    paths:
+      - "desktop/**"
+      - "crates/mold-core/**"
+      - "crates/mold-catalog/**"
+      - "crates/mold-db/**"
+      - "crates/mold-inference/**"
+      - "crates/mold-server/**"
+      - "flake.nix"
+      - "Cargo.toml"
+      - ".github/workflows/desktop.yml"
+      - "scripts/verify-desktop-release.sh"
   pull_request:
     paths:
       - "desktop/**"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **CI is path-aware.** A `changes` job classifies each push/PR diff; the Rust workspace gates (`rust`, `coverage`) only run when `crates/**`, `Cargo.toml`, `Cargo.lock`, or `ci.yml` changed, and `docs` / `web` / `nix-web` gate on their own surfaces. Docs-only changes no longer compile the workspace twice. Required checks stay job-level `if:` skips (which branch protection counts as passing) — never `on.paths` filters, which would leave them "Expected" forever. The desktop workflow's main-push trigger now uses the same path filters as its PR trigger.
+
 ### Added
 
 - **Direct desktop-app download link.** Releases now also attach the DMG under the stable name `Mold-macos-arm64.dmg`, so `https://github.com/utensils/mold/releases/latest/download/Mold-macos-arm64.dmg` always fetches the newest signed build (backfilled onto v0.15.0). The website links it from the homepage hero (**Download for Mac**) and a new **Download** section in the desktop guide.


### PR DESCRIPTION
Docs-only and website-only changes currently compile the entire Rust workspace twice (`rust` + `coverage`, ~20 min each). This makes CI path-aware:

- New `changes` job (dorny/paths-filter) classifies the push/PR diff.
- `rust` + `coverage` run only when `crates/**`, `Cargo.toml`, `Cargo.lock`, or `ci.yml` changed.
- `docs` gates on `website/**`, `web` on `web/**`, `nix-web` on `web/** + flake.nix + flake.lock + nix/**`.
- `desktop.yml`'s main-push trigger gets the same path filters its PR trigger already had (saves a macOS runner build per non-desktop merge).

**Why job-level `if:` and not `on.paths`:** `rust`/`coverage`/`docs`/`web` are required status checks. A workflow that never triggers leaves them "Expected — waiting" forever, blocking every docs-only PR and the release-plz release PR. A job skipped via `if:` reports "skipped", which branch protection counts as passing. (desktop.yml's jobs aren't required, so plain trigger filters are safe there.) Comment in ci.yml documents this so it doesn't regress.

The release-plz release PR touches `Cargo.toml`/`Cargo.lock`, so it always gets the full Rust gates. actionlint clean.

Note: this PR itself touches ci.yml, so all gates run here — the savings show on the next docs-only PR.