### PR TITLE
fix(server): ship the real web UI in release binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,14 @@ jobs:
           key: macos-release
           cache-on-failure: true
 
+      - uses: oven-sh/setup-bun@v2
+
+      # Build the web SPA before cargo so mold-server's build.rs embeds the
+      # real gallery UI instead of the placeholder stub (web/dist is
+      # gitignored, so a bare checkout has nothing to embed).
+      - name: Build embedded web SPA
+        run: ./scripts/ensure-web-dist.sh
+
       - name: Build (Metal)
         run: cargo build --release -p mold-ai --features metal,preview,discord,expand,tui,webp,mp4,metrics,mdns
 
@@ -123,6 +131,11 @@ jobs:
           key: linux-cuda-sm89-release
           cache-on-failure: true
 
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Build embedded web SPA
+        run: ./scripts/ensure-web-dist.sh
+
       - name: Build (CUDA sm_89)
         env:
           CUDA_COMPUTE_CAP: "89"
@@ -200,6 +213,11 @@ jobs:
         with:
           key: linux-cuda-sm120-release
           cache-on-failure: true
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Build embedded web SPA
+        run: ./scripts/ensure-web-dist.sh
 
       - name: Build (CUDA sm_120)
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Release binaries now embed the real web UI.** The GitHub-release tarballs (and the AUR `mold-ai` source package) were built from a bare checkout where `web/dist` doesn't exist, so `mold serve` from any released binary through v0.15.0 served the inline placeholder page instead of the gallery SPA. The release build jobs and the PKGBUILD now run `scripts/ensure-web-dist.sh` before cargo, and `mold-server`'s build script emits a loud `cargo:warning` whenever a release-profile build falls back to the placeholder. Docker images were unaffected (their build already had a dedicated web stage).
 - **FlakeHub publishing failed on v0.15.0** — the flake source archive outgrew FlakeHub's 75 MB limit. The two LTX gallery demos on the website were 23 MB animated WebPs each; they are now 135 KB VP9 `webm` videos (same frames, same size, autoplaying loop), shrinking the tracked tree by ~46 MB so tagged releases publish to FlakeHub again. v0.15.0 itself is not on FlakeHub; `nix run github:utensils/mold/v0.15.0` is unaffected.
 
 ## [0.15.0] - 2026-07-11

--- a/crates/mold-server/build.rs
+++ b/crates/mold-server/build.rs
@@ -81,6 +81,16 @@ fn resolve_web_dist(crate_dir: &Path, out_dir: &Path) -> PathBuf {
 }
 
 fn write_stub(out_dir: &Path) -> PathBuf {
+    // A release binary without the real SPA is almost always a packaging
+    // mistake (this shipped placeholder-only tarballs through v0.15.0), so
+    // make it loud. Debug/check builds stay quiet — building Rust before the
+    // SPA is normal in development.
+    if env::var("PROFILE").as_deref() == Ok("release") {
+        println!(
+            "cargo:warning=mold-server: embedding placeholder web UI — web/dist is missing and \
+             MOLD_WEB_DIST is unset; run scripts/ensure-web-dist.sh first to embed the real SPA"
+        );
+    }
     let stub = out_dir.join("web-stub");
     fs::create_dir_all(&stub).expect("create web stub dir");
     fs::write(stub.join("index.html"), PLACEHOLDER_INDEX_HTML).expect("write stub index.html");

--- a/packaging/aur/mold-ai/PKGBUILD
+++ b/packaging/aur/mold-ai/PKGBUILD
@@ -29,6 +29,7 @@ makedepends=(
   'clang'
   'lld'
   'nasm'
+  'bun'
 )
 
 provides=("${pkgname}=${pkgver}")
@@ -45,6 +46,10 @@ prepare() {
   cd "mold-${pkgver}"
   export CARGO_HOME="${srcdir}/cargo-home"
   cargo fetch --locked
+  # Build the web SPA here (prepare may use the network for `bun install`;
+  # build() runs --offline) so mold-server's build.rs embeds the real
+  # gallery UI instead of the placeholder stub.
+  ./scripts/ensure-web-dist.sh
 }
 
 build() {


### PR DESCRIPTION
Verified against the actual v0.15.0 release tarball: ran the released `mold serve` and `/` returns the inline placeholder page, not the gallery SPA. Root cause: the release build jobs (and the AUR `mold-ai` source PKGBUILD) build from a bare checkout — `web/dist` is gitignored, so `mold-server`'s build.rs embeds the stub. Docker images are unaffected (dedicated web-builder stage).

- The three binary build jobs in `release.yml` now run `oven-sh/setup-bun` + `scripts/ensure-web-dist.sh` before `cargo build`.
- The AUR PKGBUILD builds the SPA in `prepare()` (network allowed there; `build()` keeps `--frozen --offline`), with `bun` added to makedepends (it's in `[extra]`).
- `mold-server/build.rs` emits `cargo:warning` when a **release-profile** build falls back to the placeholder, so this class of gap is loud in CI logs from now on. Debug/check builds stay quiet (building Rust before the SPA is normal in dev). Verified locally: warning fires on `cargo check --release` without `web/dist`, absent with it.

This is a `fix:` commit touching `crates/mold-server`, so release-plz will queue a v0.15.1 — merging that release PR ships repaired tarballs.