### PR TITLE
feat(website): link the macOS DMG from the Metal feature card

### DIFF
--- a/website/index.md
+++ b/website/index.md
@@ -44,6 +44,8 @@ features:
     title: Linux NVIDIA + macOS Metal
     details: Single binary built on candle. NVIDIA GPUs on Linux via CUDA, Apple
       Silicon on macOS via Metal. No Python, no libtorch, no ONNX.
+    link: https://github.com/utensils/mold/releases/latest/download/Mold-macos-arm64.dmg
+    linkText: Download the macOS desktop app
   - icon:
       src: /icons/server.svg
     title: Client-Server


### PR DESCRIPTION
The homepage feature card "Linux NVIDIA + macOS Metal" now links directly to the signed desktop DMG (`releases/latest/download/Mold-macos-arm64.dmg`) with a "Download the macOS desktop app →" call-to-action, complementing the hero button.