### PR TITLE
fix(ci): prevent coverage runner disk exhaustion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
             release:
               - 'release-plz.toml'
               - 'scripts/release/**'
+              - 'scripts/tests/ci-coverage-disk-guard.sh'
               - 'scripts/tests/release-sync-pr.sh'
               - '.github/workflows/release-plz.yml'
               - '.github/workflows/ci.yml'
@@ -74,6 +75,8 @@ jobs:
       - uses: actions/checkout@v6
       - name: Test release PR synchronization
         run: bash scripts/tests/release-sync-pr.sh
+      - name: Test CI coverage disk guard
+        run: bash scripts/tests/ci-coverage-disk-guard.sh
 
   docs:
     needs: changes
@@ -181,6 +184,22 @@ jobs:
       SCCACHE_GHA_ENABLED: "true"
     steps:
       - uses: actions/checkout@v6
+
+      - name: Free runner disk space
+        shell: bash
+        run: |
+          set -euxo pipefail
+          df -h
+          sudo rm -rf \
+            /usr/share/dotnet \
+            /usr/local/lib/android \
+            /opt/ghc \
+            /usr/local/.ghcup \
+            /usr/local/share/boost \
+            "$AGENT_TOOLSDIRECTORY"
+          sudo apt-get clean
+          sudo rm -rf /var/lib/apt/lists/*
+          df -h
 
       - uses: dtolnay/rust-toolchain@stable
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Coverage CI now reserves enough runner disk for instrumented workspace builds.** The coverage job removes large unused preinstalled SDKs before installing Rust and compiling the workspace, preventing GitHub-hosted runners from aborting with `No space left on device` while generating LCOV output.
 - **macOS notifications now show the Mold app icon.** Bundled desktop builds supply their `icon.icns` as the notification identity image instead of relying on Tauri's bundle-ID lookup, which could leave completion notifications with a blank placeholder icon.
 - **Post-generation upscaling now preserves both artifacts and their reusable settings.** The server saves the original generated image and the upscaled result as distinct `-original` / `-upscaled` gallery entries on single- and multi-GPU hosts, and remote desktop auto-save mirrors both to This Mac. Gallery metadata still reports each file's real raster size, while **Reuse settings** restores the pre-upscale generation canvas instead of attempting to generate directly at 2x/4x dimensions. If the upscaler fails after generation, Mold now completes with the original image instead of discarding the successful output.
 

--- a/scripts/tests/ci-coverage-disk-guard.sh
+++ b/scripts/tests/ci-coverage-disk-guard.sh
@@ -9,10 +9,18 @@ fail() {
   exit 1
 }
 
-coverage_job="$(sed -n '/^  coverage:/,$p' "$workflow")"
+extract_coverage_job() {
+  awk '
+    /^  coverage:$/ { in_coverage = 1; next }
+    in_coverage && /^  [[:alnum:]_-]+:$/ { exit }
+    in_coverage { print }
+  ' "$1"
+}
 
-cleanup_line="$(grep -nF -- '- name: Free runner disk space' <<< "$coverage_job" | cut -d: -f1 || true)"
-coverage_line="$(grep -nF -- '- name: Generate coverage' <<< "$coverage_job" | cut -d: -f1 || true)"
+coverage_job="$(extract_coverage_job "$workflow")"
+
+cleanup_line="$(grep -m1 -nF -- '- name: Free runner disk space' <<< "$coverage_job" | cut -d: -f1 || true)"
+coverage_line="$(grep -m1 -nF -- '- name: Generate coverage' <<< "$coverage_job" | cut -d: -f1 || true)"
 
 [[ -n "$cleanup_line" ]] || fail "coverage job does not free runner disk space"
 [[ -n "$coverage_line" ]] || fail "coverage job does not generate coverage"
@@ -22,5 +30,15 @@ grep -Fq '/usr/local/lib/android' <<< "$coverage_job" \
   || fail "coverage cleanup does not remove the preinstalled Android SDK"
 grep -Fq 'df -h' <<< "$coverage_job" \
   || fail "coverage cleanup does not report disk capacity"
+
+fixture="$(mktemp)"
+trap 'rm -f "$fixture"' EXIT
+{
+  cat "$workflow"
+  printf '%s\n' '  future-job:' '    steps:' '      - name: Future job sentinel'
+} > "$fixture"
+if extract_coverage_job "$fixture" | grep -Fq 'Future job sentinel'; then
+  fail "coverage job extraction includes subsequent workflow jobs"
+fi
 
 echo "CI coverage disk guard checks passed"

--- a/scripts/tests/ci-coverage-disk-guard.sh
+++ b/scripts/tests/ci-coverage-disk-guard.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+workflow="$repo_root/.github/workflows/ci.yml"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+coverage_job="$(sed -n '/^  coverage:/,$p' "$workflow")"
+
+cleanup_line="$(grep -nF -- '- name: Free runner disk space' <<< "$coverage_job" | cut -d: -f1 || true)"
+coverage_line="$(grep -nF -- '- name: Generate coverage' <<< "$coverage_job" | cut -d: -f1 || true)"
+
+[[ -n "$cleanup_line" ]] || fail "coverage job does not free runner disk space"
+[[ -n "$coverage_line" ]] || fail "coverage job does not generate coverage"
+((cleanup_line < coverage_line)) || fail "runner disk cleanup must happen before coverage generation"
+
+grep -Fq '/usr/local/lib/android' <<< "$coverage_job" \
+  || fail "coverage cleanup does not remove the preinstalled Android SDK"
+grep -Fq 'df -h' <<< "$coverage_job" \
+  || fail "coverage cleanup does not report disk capacity"
+
+echo "CI coverage disk guard checks passed"


### PR DESCRIPTION
## Summary

- free large unused preinstalled SDKs before the Rust coverage build
- report runner disk capacity before and after cleanup
- add a regression guard that pins cleanup ahead of coverage generation
- document the CI reliability fix in the changelog

## Root cause

The coverage job on main exhausted the GitHub-hosted runner filesystem while `cargo llvm-cov` was compiling the instrumented workspace. GitHub terminated the runner with `System.IO.IOException: No space left on device`; no Mold test failed.

## Validation

- `nix run nixpkgs#actionlint -- .github/workflows/ci.yml`
- `nix fmt`
- `bash scripts/tests/ci-coverage-disk-guard.sh`
- `bash scripts/tests/release-sync-pr.sh`
- `shellcheck scripts/tests/ci-coverage-disk-guard.sh`
- YAML parse and `git diff --check`