### PR TITLE
fix(desktop): clarify job status interactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The desktop model picker now dismisses when clicking elsewhere.** Opening the Generate view's model menu no longer leaves it covering the parameter controls after the user moves on to another part of the composer.
+- **Desktop job statuses now use plain language.** The sidebar and full Jobs view say **Finalizing**, **Done**, and **Failed** instead of the darkroom-inspired but ambiguous **Fixing**, **Fixed**, and **Stopped**, while cancelled jobs remain clearly labelled **Cancelled**.
 - **Desktop host pages no longer collapse and rebuild during background health polls.** A host's telemetry, storage, queue, downloads, and model components remain mounted while connectivity changes, preserving the last good snapshot until each live source updates its own values.
 - **Desktop Chains now uses video models installed on connected hosts.** The Chains model picker merges every ready host's installed inventory, routes chain limits, creation, durable job actions, live events, and stage previews through the host that owns the selected model, and no longer disables a remote CUDA LTX-2 model merely because This Mac uses Metal.
 - **The desktop now attempts every remembered host immediately on every launch.** Remote reconnects start in parallel with This Mac instead of waiting for the local engine, and a saved host can no longer be skipped because an older reconnect-marker list is missing or stale. Unreachable hosts remain visible as errored rows and continue to self-heal through polling.

--- a/desktop/src/components/shell/NavRail.vue
+++ b/desktop/src/components/shell/NavRail.vue
@@ -7,6 +7,7 @@ import {
   useGenerationStore,
   jobPhase,
   jobProgress,
+  jobStatusCode,
   railOrder,
   type Job,
 } from "../../stores/generation";
@@ -281,23 +282,6 @@ const railJobs = computed<Job[]>(() => {
   return [...live, ...done];
 });
 
-function statusCode(job: Job): string {
-  switch (job.status) {
-    case "denoising":
-      return `${job.step}/${job.total}`;
-    case "finishing":
-      return "FIXING";
-    case "loading":
-      return "LOADING";
-    case "queued":
-      return job.queuePosition && job.queuePosition > 0 ? `QUEUED #${job.queuePosition}` : "QUEUED";
-    case "complete":
-      return "FIXED";
-    case "error":
-      return job.error === "Cancelled" ? "CANCELLED" : "STOPPED";
-  }
-}
-
 function jobMenu(job: Job): MenuEntry[] {
   const live = job.status !== "complete" && job.status !== "error";
   return [
@@ -458,7 +442,7 @@ function jobMenu(job: Job): MenuEntry[] {
             {{ job.model }}<template v-if="job.hostLabel"> · {{ job.hostLabel }}</template>
           </div>
           <div class="edge-code" :class="job.status === 'error' ? 'text-stop' : ''">
-            {{ statusCode(job) }}
+            {{ jobStatusCode(job) }}
           </div>
         </div>
       </RouterLink>

--- a/desktop/src/stores/generation.test.ts
+++ b/desktop/src/stores/generation.test.ts
@@ -95,6 +95,11 @@ describe("job status labels", () => {
     expect(jobStatusCode(withStatus("loading"))).toBe("LOADING");
     expect(jobStatusCode({ ...withStatus("denoising"), step: 3, total: 8 })).toBe("3/8");
   });
+
+  it("keeps malformed or future runtime statuses readable", () => {
+    const unexpected = { ...withStatus("queued"), status: "future" } as unknown as Job;
+    expect(jobStatusCode(unexpected)).toBe("UNKNOWN");
+  });
 });
 
 describe("batch sequencing", () => {

--- a/desktop/src/stores/generation.test.ts
+++ b/desktop/src/stores/generation.test.ts
@@ -3,6 +3,7 @@ import {
   applyProgress,
   jobPhase,
   jobProgress,
+  jobStatusCode,
   newJob,
   planBatchRequests,
   resolveBaseSeed,
@@ -74,6 +75,25 @@ describe("generation SSE reducer", () => {
     const job = newJob(req);
     expect(job.total).toBe(4);
     expect(jobProgress(job)).toBe(0);
+  });
+});
+
+describe("job status labels", () => {
+  function withStatus(status: JobStatus, error: string | null = null): Job {
+    return { ...newJob(req), status, error };
+  }
+
+  it("uses plain-language labels for terminal and finalizing states", () => {
+    expect(jobStatusCode(withStatus("finishing"))).toBe("FINALIZING");
+    expect(jobStatusCode(withStatus("complete"))).toBe("DONE");
+    expect(jobStatusCode(withStatus("error", "out of memory"))).toBe("FAILED");
+    expect(jobStatusCode(withStatus("error", "Cancelled"))).toBe("CANCELLED");
+  });
+
+  it("preserves queue, loading, and progress detail", () => {
+    expect(jobStatusCode({ ...withStatus("queued"), queuePosition: 2 })).toBe("QUEUED #2");
+    expect(jobStatusCode(withStatus("loading"))).toBe("LOADING");
+    expect(jobStatusCode({ ...withStatus("denoising"), step: 3, total: 8 })).toBe("3/8");
   });
 });
 

--- a/desktop/src/stores/generation.ts
+++ b/desktop/src/stores/generation.ts
@@ -172,6 +172,7 @@ export function jobStatusCode(job: Job): string {
     case "error":
       return job.error === "Cancelled" ? "CANCELLED" : "FAILED";
   }
+  return "UNKNOWN";
 }
 
 export function base64ToBlobUrl(b64: string, mime: string): string {

--- a/desktop/src/stores/generation.ts
+++ b/desktop/src/stores/generation.ts
@@ -156,6 +156,24 @@ export function jobProgress(job: Job): number {
   return job.step / job.total;
 }
 
+/** Compact, plain-language status shared by every jobs surface. */
+export function jobStatusCode(job: Job): string {
+  switch (job.status) {
+    case "denoising":
+      return `${job.step}/${job.total}`;
+    case "finishing":
+      return "FINALIZING";
+    case "loading":
+      return "LOADING";
+    case "queued":
+      return job.queuePosition && job.queuePosition > 0 ? `QUEUED #${job.queuePosition}` : "QUEUED";
+    case "complete":
+      return "DONE";
+    case "error":
+      return job.error === "Cancelled" ? "CANCELLED" : "FAILED";
+  }
+}
+
 export function base64ToBlobUrl(b64: string, mime: string): string {
   const bytes = Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
   return URL.createObjectURL(new Blob([bytes], { type: mime }));

--- a/desktop/src/views/GenerateView.persistence.test.ts
+++ b/desktop/src/views/GenerateView.persistence.test.ts
@@ -10,9 +10,10 @@ import { useHostsStore } from "../stores/hosts";
 import type { ModelEntry } from "../lib/api/types";
 
 vi.mock("vue-router", () => ({ useRouter: () => ({ push: vi.fn() }) }));
+const apiJson = vi.fn();
 const apiJsonTo = vi.fn();
 vi.mock("../lib/api/client", () => ({
-  apiJson: vi.fn(() => Promise.resolve([])),
+  apiJson: (...args: unknown[]) => apiJson(...args),
   apiJsonTo: (...args: unknown[]) => apiJsonTo(...args),
   apiFetch: vi.fn(),
 }));
@@ -35,6 +36,8 @@ function mountView() {
 describe("GenerateView form persistence", () => {
   beforeEach(() => {
     setActivePinia(createPinia());
+    apiJson.mockReset();
+    apiJson.mockResolvedValue([]);
     apiJsonTo.mockReset();
     apiJsonTo.mockResolvedValue([]);
   });
@@ -68,6 +71,24 @@ describe("GenerateView form persistence", () => {
 
     // The immediate auto-select watch must respect the existing choice.
     expect(store.form.model).toBe("flux-schnell:q8");
+  });
+
+  it("closes the model picker when the user clicks elsewhere", async () => {
+    const conn = useConnectionStore();
+    conn.info = { mode: "local", baseUrl: "http://127.0.0.1:7680", apiKey: "local-key" };
+    conn.status = "ready";
+    useHostsStore().initialized = true;
+    apiJson.mockResolvedValue([model]);
+    useModelStore().all = [model];
+
+    const wrapper = mountView();
+    await flushPromises();
+    await wrapper.get('[data-test="selected-model-name"]').trigger("click");
+    expect(wrapper.find('[data-test="model-option-name"]').exists()).toBe(true);
+
+    await wrapper.get("textarea").trigger("pointerdown");
+    await flushPromises();
+    expect(wrapper.find('[data-test="model-option-name"]').exists()).toBe(false);
   });
 
   it("renders the workbench and auto-selects a model installed only on a remote host", async () => {

--- a/desktop/src/views/GenerateView.persistence.test.ts
+++ b/desktop/src/views/GenerateView.persistence.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createPinia, setActivePinia } from "pinia";
-import { mount, flushPromises } from "@vue/test-utils";
+import { enableAutoUnmount, mount, flushPromises } from "@vue/test-utils";
 import GenerateView from "./GenerateView.vue";
 import { useGenerateFormStore } from "../stores/generateForm";
 import { useModelStore } from "../stores/models";
@@ -18,6 +18,8 @@ vi.mock("../lib/api/client", () => ({
   apiFetch: vi.fn(),
 }));
 vi.mock("../lib/ipc", () => ({ ipc: {} }));
+
+enableAutoUnmount(afterEach);
 
 const model: ModelEntry = {
   name: "flux-dev:q8",

--- a/desktop/src/views/GenerateView.vue
+++ b/desktop/src/views/GenerateView.vue
@@ -76,7 +76,13 @@ const promptEl = ref<HTMLTextAreaElement | null>(null);
 const previewRegion = ref<HTMLDivElement | null>(null);
 const previewFrameSize = ref({ width: 0, height: 0 });
 const expandControl = ref<InstanceType<typeof ExpandControl> | null>(null);
+const pickerEl = ref<HTMLDivElement | null>(null);
 const pickerOpen = ref(false);
+
+function onDocumentPointerDown(event: PointerEvent) {
+  if (!pickerOpen.value || !pickerEl.value) return;
+  if (!event.composedPath().includes(pickerEl.value)) pickerOpen.value = false;
+}
 
 // Live inspector width while dragging its left-edge handle; null follows the
 // persisted preference (appPrefs.generateParamsWidth). Persist only on commit.
@@ -521,6 +527,7 @@ watch(
 );
 
 onMounted(() => {
+  document.addEventListener("pointerdown", onDocumentPointerDown);
   promptEl.value?.focus();
   if (previewRegion.value && typeof ResizeObserver !== "undefined") {
     previewResizeObserver = new ResizeObserver(([entry]) => {
@@ -531,7 +538,10 @@ onMounted(() => {
   resizePreview();
 });
 
-onBeforeUnmount(() => previewResizeObserver?.disconnect());
+onBeforeUnmount(() => {
+  document.removeEventListener("pointerdown", onDocumentPointerDown);
+  previewResizeObserver?.disconnect();
+});
 </script>
 
 <template>
@@ -714,9 +724,10 @@ onBeforeUnmount(() => previewResizeObserver?.disconnect());
         <span class="edge-code">Model</span>
         <div class="border-edge h-px flex-1 border-t" />
       </div>
-      <div class="relative">
+      <div ref="pickerEl" class="relative">
         <button
           type="button"
+          :aria-expanded="pickerOpen"
           class="border-edge flex min-h-9 w-full items-center justify-between gap-2 rounded-control border bg-bath px-2 py-1.5 text-body text-ink"
           @click="pickerOpen = !pickerOpen"
         >
@@ -729,6 +740,7 @@ onBeforeUnmount(() => previewResizeObserver?.disconnect());
         </button>
         <div
           v-if="pickerOpen"
+          data-test="model-picker-menu"
           class="border-edge absolute z-10 mt-1 max-h-72 w-full overflow-y-auto rounded-chrome border bg-bench shadow-raised"
         >
           <template v-for="[family, list] in pickerFamilies" :key="family">

--- a/desktop/src/views/JobsView.vue
+++ b/desktop/src/views/JobsView.vue
@@ -2,7 +2,13 @@
 import { computed, onMounted, onUnmounted, ref } from "vue";
 import { useRouter } from "vue-router";
 import DevelopCanvas from "../lib/develop/DevelopCanvas.vue";
-import { useGenerationStore, jobPhase, jobProgress, type Job } from "../stores/generation";
+import {
+  useGenerationStore,
+  jobPhase,
+  jobProgress,
+  jobStatusCode,
+  type Job,
+} from "../stores/generation";
 import { useHostsStore, type HostView } from "../stores/hosts";
 import { enrichQueueEntries, useJobsStore, type EnrichedQueueEntry } from "../stores/jobs";
 import { useComposerStore } from "../stores/composer";
@@ -177,11 +183,6 @@ const finished = computed(() =>
     .slice()
     .reverse(),
 );
-
-function finishedCode(job: Job): string {
-  if (job.status === "complete") return "FIXED";
-  return job.error === "Cancelled" ? "CANCELLED" : "STOPPED";
-}
 
 function reuse(job: Job) {
   composer.set({
@@ -382,7 +383,7 @@ function reuse(job: Job) {
               <div class="truncate text-body text-ink" :title="job.prompt">{{ job.prompt }}</div>
               <div class="mt-0.5 flex items-center gap-2">
                 <span class="edge-code" :class="job.status === 'error' ? 'text-stop' : ''">
-                  {{ finishedCode(job) }}
+                  {{ jobStatusCode(job) }}
                 </span>
                 <span class="text-caption text-ink-3">
                   {{ job.model }}<template v-if="job.hostLabel"> · {{ job.hostLabel }}</template>


### PR DESCRIPTION
## Summary
- replace darkroom-specific job labels with plain-language statuses across the sidebar and Jobs view
- centralize job status formatting so both surfaces stay consistent
- dismiss the Generate model picker when the user clicks elsewhere

## Validation
- `cd desktop && bun run test` (961 tests)
- `cd desktop && bun run fmt:check`
- `cd desktop && bun run build`
- rendered Generate-view QA in the in-app browser: model picker opens, clicking the prompt dismisses it, zero console warnings/errors