### PR TITLE
fix(ios): correct mobile frontend hook path

### DIFF
--- a/apps/mobile/src-tauri/tauri.conf.json
+++ b/apps/mobile/src-tauri/tauri.conf.json
@@ -4,8 +4,8 @@
   "version": "0.18.0",
   "identifier": "com.utensils.mold",
   "build": {
-    "beforeDevCommand": "bash -c 'cd ../../../desktop && bun run dev:mobile'",
-    "beforeBuildCommand": "bash -c 'cd ../../../desktop && bun run build:mobile'",
+    "beforeDevCommand": "bash -c 'cd ../../desktop && bun run dev:mobile'",
+    "beforeBuildCommand": "bash -c 'cd ../../desktop && bun run build:mobile'",
     "devUrl": "http://localhost:1431",
     "frontendDist": "../../../desktop/dist-mobile"
   },


### PR DESCRIPTION
## Summary
- run Tauri mobile frontend hooks from the frontend directory that Tauri actually selects (`apps/mobile`)
- preserve config-relative paths for built assets and icons

## Validation
- `python3 -m json.tool apps/mobile/src-tauri/tauri.conf.json`
- `(cd apps/mobile && bash -c 'cd ../../desktop && bun run build:mobile')`

## Context
The first post-merge TestFlight nightly reached the archive step but failed because Tauri launches build hooks from `apps/mobile`; the previous `../../../desktop` path escaped the repository.