### PR TITLE
feat(ios): add full-screen gallery playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Mold for iPhone.** A first-class Tauri iOS companion connects only to remote Mold hosts and focuses the initial release on generation and the merged gallery. It reuses the desktop wire types, capability-aware request builder, and SSE client; supports saved hosts, Keychain-backed API keys, Tailscale MagicDNS names, and native Bonjour discovery of `_mold._tcp`; and ships with simulator CI plus an internal TestFlight nightly pipeline.
+- **The iPhone gallery now opens prints in a full-screen viewer.** Photos are shown uncropped, videos stream with native inline playback controls, and a clearly labeled **Use as prompt** action carries the prompt and visible generation settings into Generate instead of making a gallery tile tap silently replace the composer. Authenticated hosts issue short-lived read-only media tickets so videos can seek without exposing API keys or buffering entire files in phone memory.
 
 ### Fixed
 
 - **iPhone builds now launch the bundled mobile UI and show Mold's real icon.** The mobile Vite build emits the `index.html` entry Tauri boots, every Apple icon size is generated from the Mold bowl on an opaque app-theme background, and CI rejects archives with a missing entry point, stale frontend embed, or stock Tauri icon.
+- **iPhone form fields no longer magnify the app when focused.** Every editable mobile control now uses the 16px minimum that prevents iOS WebKit's automatic input zoom while preserving normal accessibility zoom gestures.
+- **Simulator builds can exercise Keychain-backed remote hosts.** The local iPhone bundle now keeps Xcode's complete ad-hoc bundle signature, so saving and restoring API keys works during simulator UAT instead of failing with a missing-entitlement error.
 
 ## [0.18.0] - 2026-07-19
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,6 +1253,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -2209,6 +2210,15 @@ dependencies = [
  "tokio",
  "ureq",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -3234,7 +3244,9 @@ dependencies = [
  "dirs 5.0.1",
  "futures",
  "futures-core",
+ "getrandom 0.3.4",
  "governor",
+ "hmac",
  "hostname",
  "image",
  "libc",

--- a/crates/mold-server/Cargo.toml
+++ b/crates/mold-server/Cargo.toml
@@ -60,6 +60,8 @@ dirs = "5"
 futures = "0.3"
 utoipa = { version = "5", features = ["preserve_order"] }
 sha2 = "0.10"
+hmac = "0.12"
+getrandom = "0.3"
 walkdir = "2"
 image = "0.25"
 governor = { version = "0.8", features = ["std"] }

--- a/crates/mold-server/src/auth.rs
+++ b/crates/mold-server/src/auth.rs
@@ -1,15 +1,25 @@
 use axum::{
     extract::Request,
-    http::{HeaderValue, StatusCode},
+    http::{HeaderValue, Method, StatusCode},
     middleware::Next,
     response::{IntoResponse, Response},
     Json,
 };
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use hmac::{Hmac, Mac};
 use serde::Serialize;
+use sha2::Sha256;
 use std::collections::HashSet;
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 use subtle::ConstantTimeEq;
 use tracing::warn;
+
+const GALLERY_MEDIA_TOKEN_CONTEXT: &[u8] = b"mold-gallery-media-v2\nGET\n";
+pub(crate) const GALLERY_MEDIA_TOKEN_TTL_SECS: u64 = 15 * 60;
+const GALLERY_SIGNING_SECRET_BYTES: usize = 32;
+
+type HmacSha256 = Hmac<Sha256>;
 
 /// Shared auth state — `None` means authentication is disabled.
 pub type AuthState = Option<Arc<ApiKeySet>>;
@@ -17,11 +27,32 @@ pub type AuthState = Option<Arc<ApiKeySet>>;
 /// Set of valid API keys loaded from `MOLD_API_KEY`.
 pub struct ApiKeySet {
     keys: HashSet<String>,
+    gallery_signing_secret: [u8; GALLERY_SIGNING_SECRET_BYTES],
 }
 
 impl ApiKeySet {
     pub fn new(keys: HashSet<String>) -> Self {
-        Self { keys }
+        Self::try_new(keys).expect("OS randomness is required for gallery media authentication")
+    }
+
+    fn try_new(keys: HashSet<String>) -> Result<Self, getrandom::Error> {
+        let mut gallery_signing_secret = [0_u8; GALLERY_SIGNING_SECRET_BYTES];
+        getrandom::fill(&mut gallery_signing_secret)?;
+        Ok(Self {
+            keys,
+            gallery_signing_secret,
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_with_gallery_signing_secret(
+        keys: HashSet<String>,
+        gallery_signing_secret: [u8; GALLERY_SIGNING_SECRET_BYTES],
+    ) -> Self {
+        Self {
+            keys,
+            gallery_signing_secret,
+        }
     }
 
     pub fn contains(&self, candidate: &str) -> bool {
@@ -34,7 +65,51 @@ impl ApiKeySet {
         }
         found.into()
     }
+
+    fn validates_gallery_media_token(
+        &self,
+        token: &str,
+        media_path: &str,
+        expires_at: u64,
+        now: u64,
+    ) -> bool {
+        if now >= expires_at {
+            return false;
+        }
+
+        let Ok(signature) = URL_SAFE_NO_PAD.decode(token) else {
+            return false;
+        };
+        if signature.len() != 32 {
+            return false;
+        }
+
+        let mac = gallery_media_mac(&self.gallery_signing_secret, media_path, expires_at);
+        mac.verify_slice(&signature).is_ok()
+    }
+
+    pub(crate) fn issue_gallery_media_token(&self, media_path: &str) -> (String, u64) {
+        let expires_at = unix_timestamp().saturating_add(GALLERY_MEDIA_TOKEN_TTL_SECS);
+        (
+            sign_gallery_media_token(&self.gallery_signing_secret, media_path, expires_at),
+            expires_at,
+        )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn sign_gallery_media_token_for_tests(
+        &self,
+        media_path: &str,
+        expires_at: u64,
+    ) -> String {
+        sign_gallery_media_token(&self.gallery_signing_secret, media_path, expires_at)
+    }
 }
+
+/// Marker proving normal API-key authentication succeeded for this request.
+/// The matched API key itself deliberately never leaves the middleware.
+#[derive(Clone, Copy)]
+pub(crate) struct ApiKeyAuthenticated;
 
 #[derive(Debug, Serialize)]
 struct AuthError {
@@ -78,7 +153,9 @@ pub fn load_api_keys() -> anyhow::Result<AuthState> {
     }
 
     tracing::info!(num_keys = keys.len(), "API key authentication enabled");
-    Ok(Some(Arc::new(ApiKeySet { keys })))
+    let key_set = ApiKeySet::try_new(keys)
+        .map_err(|error| anyhow::anyhow!("failed to generate gallery signing secret: {error}"))?;
+    Ok(Some(Arc::new(key_set)))
 }
 
 /// Paths that are exempt from API key authentication.
@@ -86,6 +163,8 @@ const EXEMPT_PATHS: &[&str] = &["/health", "/api/docs", "/api/openapi.json"];
 
 /// Axum middleware that enforces API key authentication.
 pub async fn require_api_key(request: Request, next: Next) -> Response {
+    let mut request = request;
+
     // Auth state is stored as an extension by the layer setup in lib.rs.
     let auth_state = request.extensions().get::<AuthState>().cloned();
 
@@ -100,11 +179,29 @@ pub async fn require_api_key(request: Request, next: Next) -> Response {
         return next.run(request).await;
     }
 
+    // Browser media elements cannot attach an X-Api-Key header to their own
+    // streaming and Range requests. Accept a short-lived signed ticket only
+    // for GET/HEAD reads of the full-size gallery media route; all other paths and
+    // methods continue through normal API-key authentication below.
+    if is_gallery_image_read(&request) {
+        if let Some((token, expires_at)) = gallery_media_ticket_query(&request) {
+            let now = unix_timestamp();
+            if key_set.validates_gallery_media_token(token, path, expires_at, now) {
+                return next.run(request).await;
+            }
+            if request.headers().get("x-api-key").is_none() {
+                warn!(path = %path, "rejected request with invalid or expired gallery media token");
+                return unauthorized("invalid or expired gallery media token");
+            }
+        }
+    }
+
     // Check the X-Api-Key header.
     match request.headers().get("x-api-key") {
         Some(value) => {
             let candidate = value.to_str().unwrap_or("");
             if key_set.contains(candidate) {
+                request.extensions_mut().insert(ApiKeyAuthenticated);
                 next.run(request).await
             } else {
                 warn!("rejected request with invalid API key");
@@ -116,6 +213,66 @@ pub async fn require_api_key(request: Request, next: Next) -> Response {
             unauthorized("missing X-Api-Key header")
         }
     }
+}
+
+fn is_gallery_image_read(request: &Request) -> bool {
+    if request.method() != Method::GET && request.method() != Method::HEAD {
+        return false;
+    }
+
+    is_gallery_image_path(request.uri().path())
+}
+
+pub(crate) fn is_gallery_image_path(path: &str) -> bool {
+    if path.contains('?') || path.contains('#') {
+        return false;
+    }
+
+    path.strip_prefix("/api/gallery/image/")
+        .is_some_and(|filename| !filename.is_empty() && !filename.contains('/'))
+}
+
+fn gallery_media_ticket_query(request: &Request) -> Option<(&str, u64)> {
+    let mut token = None;
+    let mut expires_at = None;
+
+    for pair in request.uri().query()?.split('&') {
+        let (name, value) = pair.split_once('=').unwrap_or((pair, ""));
+        match name {
+            "media_token" if token.is_none() => token = Some(value),
+            "expires" if expires_at.is_none() => expires_at = value.parse::<u64>().ok(),
+            // Reject duplicate credential fields instead of letting a proxy
+            // and the application disagree about which one is authoritative.
+            "media_token" | "expires" => return None,
+            _ => {}
+        }
+    }
+
+    Some((token?, expires_at?))
+}
+
+fn gallery_media_mac(signing_secret: &[u8], media_path: &str, expires_at: u64) -> HmacSha256 {
+    let mut mac =
+        HmacSha256::new_from_slice(signing_secret).expect("HMAC-SHA256 accepts keys of any length");
+    mac.update(GALLERY_MEDIA_TOKEN_CONTEXT);
+    mac.update(media_path.as_bytes());
+    mac.update(b"\n");
+    mac.update(expires_at.to_string().as_bytes());
+    mac
+}
+
+fn sign_gallery_media_token(signing_secret: &[u8], media_path: &str, expires_at: u64) -> String {
+    let signature = gallery_media_mac(signing_secret, media_path, expires_at)
+        .finalize()
+        .into_bytes();
+    URL_SAFE_NO_PAD.encode(signature)
+}
+
+fn unix_timestamp() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
 }
 
 fn unauthorized(msg: &str) -> Response {
@@ -218,5 +375,69 @@ mod tests {
         assert!(ks.contains("correct-key"));
         assert!(!ks.contains("wrong-key"));
         assert!(!ks.contains(""));
+    }
+
+    #[test]
+    fn gallery_media_token_is_url_safe_and_valid_until_expiry() {
+        const MEDIA_PATH: &str = "/api/gallery/image/clip.mp4";
+        let ks = ApiKeySet::new_with_gallery_signing_secret(
+            HashSet::from(["correct-key".to_string()]),
+            [0x42; GALLERY_SIGNING_SECRET_BYTES],
+        );
+        let token = ks.sign_gallery_media_token_for_tests(MEDIA_PATH, 1_900);
+
+        assert_eq!(token.len(), 43);
+        assert!(token
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-' || byte == b'_'));
+        assert!(ks.validates_gallery_media_token(&token, MEDIA_PATH, 1_900, 1_000));
+        assert!(!ks.validates_gallery_media_token(&token, MEDIA_PATH, 1_900, 1_900));
+    }
+
+    #[test]
+    fn gallery_media_token_rejects_tampering_and_other_signing_secrets() {
+        const MEDIA_PATH: &str = "/api/gallery/image/clip.mp4";
+        let ks = ApiKeySet::new_with_gallery_signing_secret(
+            HashSet::from(["correct-key".to_string()]),
+            [0x42; GALLERY_SIGNING_SECRET_BYTES],
+        );
+        let token = ks.sign_gallery_media_token_for_tests(MEDIA_PATH, 1_900);
+        let mut tampered = token.clone();
+        tampered.replace_range(..1, if token.starts_with('A') { "B" } else { "A" });
+
+        assert!(!ks.validates_gallery_media_token(&tampered, MEDIA_PATH, 1_900, 1_000));
+        assert!(!ks.validates_gallery_media_token(
+            &sign_gallery_media_token(&[0x24; GALLERY_SIGNING_SECRET_BYTES], MEDIA_PATH, 1_900,),
+            MEDIA_PATH,
+            1_900,
+            1_000,
+        ));
+        assert!(!ks.validates_gallery_media_token("not+url/safe", MEDIA_PATH, 1_900, 1_000,));
+        assert!(!ks.validates_gallery_media_token(
+            &token,
+            "/api/gallery/image/other.mp4",
+            1_900,
+            1_000,
+        ));
+    }
+
+    #[test]
+    fn gallery_media_token_cannot_be_reproduced_from_a_weak_api_key() {
+        const WEAK_API_KEY: &str = "password";
+        const MEDIA_PATH: &str = "/api/gallery/image/clip.mp4";
+        let ks = ApiKeySet::new_with_gallery_signing_secret(
+            HashSet::from([WEAK_API_KEY.to_string()]),
+            [0x42; GALLERY_SIGNING_SECRET_BYTES],
+        );
+        let token = ks.sign_gallery_media_token_for_tests(MEDIA_PATH, 1_900);
+        let api_key_derived = sign_gallery_media_token(WEAK_API_KEY.as_bytes(), MEDIA_PATH, 1_900);
+        let other_process =
+            sign_gallery_media_token(&[0x24; GALLERY_SIGNING_SECRET_BYTES], MEDIA_PATH, 1_900);
+
+        assert_ne!(token, api_key_derived);
+        assert_ne!(token, other_process);
+        assert!(!ks.validates_gallery_media_token(&api_key_derived, MEDIA_PATH, 1_900, 1_000,));
+        assert!(!ks.validates_gallery_media_token(&other_process, MEDIA_PATH, 1_900, 1_000,));
+        assert!(ks.contains(WEAK_API_KEY));
     }
 }

--- a/crates/mold-server/src/lib.rs
+++ b/crates/mold-server/src/lib.rs
@@ -53,6 +53,12 @@ use state::QueueHandle;
 
 const MAX_REQUEST_BODY_BYTES: usize = 64 * 1024 * 1024;
 
+fn trace_request_path<B>(request: &axum::http::Request<B>) -> &str {
+    // Deliberately omit the query string: gallery media tickets are bearer
+    // credentials and must never be copied into request spans or logs.
+    request.uri().path()
+}
+
 pub async fn run_server(
     bind: &str,
     port: u16,
@@ -514,7 +520,16 @@ pub async fn run_server(
 
     let app = app
         .layer(middleware::from_fn(request_id::request_id_middleware))
-        .layer(TraceLayer::new_for_http())
+        .layer(TraceLayer::new_for_http().make_span_with(
+            |request: &axum::http::Request<axum::body::Body>| {
+                tracing::debug_span!(
+                    "http-request",
+                    method = %request.method(),
+                    path = %trace_request_path(request),
+                    version = ?request.version(),
+                )
+            },
+        ))
         .layer(cors);
 
     let addr: SocketAddr = format!("{bind}:{port}").parse()?;
@@ -695,6 +710,7 @@ fn build_cors_layer() -> Result<CorsLayer> {
                 .allow_origin(origin)
                 .allow_methods([
                     axum::http::Method::GET,
+                    axum::http::Method::HEAD,
                     axum::http::Method::POST,
                     axum::http::Method::DELETE,
                 ])
@@ -721,7 +737,7 @@ fn build_cors_layer() -> Result<CorsLayer> {
 
 #[cfg(test)]
 mod tests {
-    use super::build_cors_layer;
+    use super::{build_cors_layer, trace_request_path};
     use std::sync::Mutex;
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
@@ -742,5 +758,17 @@ mod tests {
         let result = build_cors_layer();
         std::env::remove_var("MOLD_CORS_ORIGIN");
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn trace_path_omits_gallery_bearer_ticket_query() {
+        let request = axum::http::Request::builder()
+            .uri("/api/gallery/image/clip.mp4?media_token=secret-ticket&expires=1900")
+            .body(())
+            .unwrap();
+
+        let path = trace_request_path(&request);
+        assert_eq!(path, "/api/gallery/image/clip.mp4");
+        assert!(!path.contains("secret-ticket"));
     }
 }

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -2915,8 +2915,8 @@ async fn serve_range(
             header::CONTENT_RANGE,
             format!("bytes {start}-{end}/{total_len}"),
         )
-        // Partial content is less cacheable at intermediaries than a plain
-        // 200; keep a short TTL so the client's own cache still helps.
+        // Gallery media may be authorized by a short-lived bearer ticket, so
+        // neither browsers nor intermediaries should retain partial responses.
         .header(header::CACHE_CONTROL, "private, no-store")
         .body(body)
         .unwrap())

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -1,5 +1,5 @@
 use axum::{
-    extract::{Path, Request, State},
+    extract::{Extension, Path, Request, State},
     http::{header, HeaderMap, HeaderValue, StatusCode},
     response::{
         sse::{Event as SseEvent, KeepAlive, Sse},
@@ -182,6 +182,7 @@ use crate::queue::clean_error_message;
         pull_model_endpoint,
         unload_model,
         delete_model,
+        create_gallery_media_token,
         server_status,
         list_queue,
         patch_queue_job,
@@ -265,6 +266,8 @@ use crate::queue::clean_error_message;
         crate::job_registry::JobEntry,
         crate::job_registry::QueueListing,
         crate::chain_limits::ChainLimits,
+        GalleryMediaTokenRequest,
+        GalleryMediaTokenResponse,
     )),
     tags(
         (name = "generation", description = "Image generation"),
@@ -338,6 +341,7 @@ pub fn create_router(state: AppState) -> Router {
         .route("/api/models/pull", post(pull_model_endpoint))
         .route("/api/models/unload", delete(unload_model))
         .route("/api/gallery", get(list_gallery))
+        .route("/api/gallery/media-token", post(create_gallery_media_token))
         .route(
             "/api/gallery/image/:filename",
             get(get_gallery_image).delete(delete_gallery_image),
@@ -2640,6 +2644,78 @@ async fn shutdown_server(State(state): State<AppState>, request: Request) -> imp
 
 // ── /api/gallery ──────────────────────────────────────────────────────────────
 
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
+pub struct GalleryMediaTokenRequest {
+    path: String,
+}
+
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct GalleryMediaTokenResponse {
+    token: Option<String>,
+    expires_at: Option<u64>,
+    auth_required: bool,
+}
+
+/// Issue a short-lived credential for a browser media element.
+///
+/// The endpoint itself always uses normal `X-Api-Key` authentication. The
+/// auth middleware records only an authenticated marker in request extensions;
+/// this handler signs with an independent random per-process secret. The
+/// resulting ticket can authenticate GET, HEAD, and Range requests to
+/// `/api/gallery/image/:filename` until `expires_at` without exposing the
+/// long-lived API key in the URL or making the URL an offline API-key verifier.
+#[utoipa::path(
+    post,
+    path = "/api/gallery/media-token",
+    tag = "server",
+    request_body = GalleryMediaTokenRequest,
+    responses(
+        (status = 200, description = "Short-lived gallery media ticket", body = GalleryMediaTokenResponse),
+        (status = 401, description = "API key authentication is required"),
+        (status = 422, description = "Requested path is not a gallery media path"),
+    )
+)]
+async fn create_gallery_media_token(
+    auth_state: Option<Extension<crate::auth::AuthState>>,
+    authenticated: Option<Extension<crate::auth::ApiKeyAuthenticated>>,
+    Json(request): Json<GalleryMediaTokenRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    if !crate::auth::is_gallery_image_path(&request.path) {
+        return Err(ApiError::validation(
+            "media token path must match /api/gallery/image/:filename",
+        ));
+    }
+
+    let key_set = auth_state.and_then(|Extension(state)| state);
+    let (token, expires_at, auth_required) = match key_set {
+        Some(key_set) => {
+            let _authenticated = authenticated.ok_or_else(|| {
+                ApiError::with_code(
+                    "API key authentication is required to issue a media token",
+                    "UNAUTHORIZED",
+                    StatusCode::UNAUTHORIZED,
+                )
+            })?;
+            let (token, expires_at) = key_set.issue_gallery_media_token(&request.path);
+            (Some(token), Some(expires_at), true)
+        }
+        // Headerless servers need no ticket. Returning an explicit response
+        // lets clients with a stale saved key use the ordinary direct URL.
+        None => (None, None, false),
+    };
+
+    let mut headers = HeaderMap::new();
+    headers.insert(header::CACHE_CONTROL, HeaderValue::from_static("no-store"));
+    Ok((
+        headers,
+        Json(GalleryMediaTokenResponse {
+            token,
+            expires_at,
+            auth_required,
+        }),
+    ))
+}
+
 /// List gallery images from the server's output directory.
 ///
 /// Prefers the SQLite metadata DB when available so listings stay fast on
@@ -2762,7 +2838,7 @@ async fn get_gallery_image(
         .header(header::CONTENT_TYPE, content_type)
         .header(header::ACCEPT_RANGES, "bytes")
         .header(header::CONTENT_LENGTH, total_len)
-        .header(header::CACHE_CONTROL, "public, max-age=3600")
+        .header(header::CACHE_CONTROL, "private, no-store")
         .body(body)
         .unwrap())
 }
@@ -2841,7 +2917,7 @@ async fn serve_range(
         )
         // Partial content is less cacheable at intermediaries than a plain
         // 200; keep a short TTL so the client's own cache still helps.
-        .header(header::CACHE_CONTROL, "public, max-age=300")
+        .header(header::CACHE_CONTROL, "private, no-store")
         .body(body)
         .unwrap())
 }

--- a/crates/mold-server/src/routes_test.rs
+++ b/crates/mold-server/src/routes_test.rs
@@ -3817,6 +3817,298 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn gallery_media_token_endpoint_issues_scoped_streaming_credential() {
+        const MEDIA_ROUTE: &str = "/api/gallery/image/clip.mp4";
+        const TOKEN_REQUEST: &str = r#"{"path":"/api/gallery/image/clip.mp4"}"#;
+        let output_dir = tempfile::tempdir().unwrap();
+        let media_path = output_dir.path().join("clip.mp4");
+        std::fs::write(&media_path, b"0123456789").unwrap();
+        std::fs::write(output_dir.path().join("other.mp4"), b"abcdefghij").unwrap();
+
+        let config = mold_core::Config {
+            output_dir: Some(output_dir.path().to_string_lossy().into_owned()),
+            ..Default::default()
+        };
+        let (tx, _rx) = tokio::sync::mpsc::channel(16);
+        let state = AppState::empty(
+            config,
+            crate::state::QueueHandle::new(tx),
+            AppState::empty_gpu_pool_for_test(),
+            200,
+        );
+        let keys = std::collections::HashSet::from(["test-key".to_string()]);
+        let key_set = std::sync::Arc::new(crate::auth::ApiKeySet::new_with_gallery_signing_secret(
+            keys, [0x42; 32],
+        ));
+        let auth = Some(key_set.clone());
+        let app = create_router(state)
+            .layer(axum::middleware::from_fn(crate::auth::require_api_key))
+            .layer(axum::middleware::from_fn_with_state(
+                auth,
+                crate::auth::inject_auth_state,
+            ));
+
+        // The issuing endpoint itself still requires the normal API key.
+        let missing_key = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/gallery/media-token")
+                    .header(axum::http::header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(TOKEN_REQUEST))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(missing_key.status(), StatusCode::UNAUTHORIZED);
+
+        let before = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/gallery/media-token")
+                    .header("x-api-key", "test-key")
+                    .header(axum::http::header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(TOKEN_REQUEST))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get(axum::http::header::CACHE_CONTROL)
+                .and_then(|value| value.to_str().ok()),
+            Some("no-store")
+        );
+        let ticket = json_body(response).await;
+        assert_eq!(ticket["auth_required"], true);
+        let token = ticket["token"].as_str().unwrap();
+        let expires_at = ticket["expires_at"].as_u64().unwrap();
+        let after = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        assert!((before + crate::auth::GALLERY_MEDIA_TOKEN_TTL_SECS
+            ..=after + crate::auth::GALLERY_MEDIA_TOKEN_TTL_SECS)
+            .contains(&expires_at));
+        assert!(!token.contains("test-key"));
+
+        let full_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!(
+                        "/api/gallery/image/clip.mp4?media_token={token}&expires={expires_at}"
+                    ))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(full_response.status(), StatusCode::OK);
+        assert_eq!(
+            full_response
+                .headers()
+                .get(axum::http::header::CACHE_CONTROL)
+                .and_then(|value| value.to_str().ok()),
+            Some("private, no-store")
+        );
+        let body = axum::body::to_bytes(full_response.into_body(), 1024)
+            .await
+            .unwrap();
+        assert_eq!(body.as_ref(), b"0123456789");
+
+        // A browser-style Range request succeeds without X-Api-Key and keeps
+        // the existing video streaming semantics intact.
+        let range_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!(
+                        "/api/gallery/image/clip.mp4?media_token={token}&expires={expires_at}"
+                    ))
+                    .header(axum::http::header::RANGE, "bytes=2-5")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(range_response.status(), StatusCode::PARTIAL_CONTENT);
+        assert_eq!(
+            range_response
+                .headers()
+                .get(axum::http::header::CACHE_CONTROL)
+                .and_then(|value| value.to_str().ok()),
+            Some("private, no-store")
+        );
+        assert_eq!(
+            range_response
+                .headers()
+                .get(axum::http::header::CONTENT_RANGE)
+                .and_then(|value| value.to_str().ok()),
+            Some("bytes 2-5/10")
+        );
+        let body = axum::body::to_bytes(range_response.into_body(), 1024)
+            .await
+            .unwrap();
+        assert_eq!(body.as_ref(), b"2345");
+
+        // Media stacks may probe with HEAD before opening a Range stream. It
+        // uses the same read-only ticket but never broadens it to other verbs.
+        let head_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("HEAD")
+                    .uri(format!(
+                        "{MEDIA_ROUTE}?media_token={token}&expires={expires_at}"
+                    ))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(head_response.status(), StatusCode::OK);
+        assert_eq!(
+            head_response
+                .headers()
+                .get(axum::http::header::CACHE_CONTROL)
+                .and_then(|value| value.to_str().ok()),
+            Some("private, no-store")
+        );
+        let head_body = axum::body::to_bytes(head_response.into_body(), 1024)
+            .await
+            .unwrap();
+        assert!(head_body.is_empty());
+
+        // Tampered and correctly signed-but-expired tickets both remain 401.
+        let invalid = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!(
+                        "/api/gallery/image/clip.mp4?media_token=invalid&expires={expires_at}"
+                    ))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(invalid.status(), StatusCode::UNAUTHORIZED);
+
+        let wrong_filename = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!(
+                        "/api/gallery/image/other.mp4?media_token={token}&expires={expires_at}"
+                    ))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(wrong_filename.status(), StatusCode::UNAUTHORIZED);
+
+        let expired_at = before.saturating_sub(1);
+        let expired_token = key_set.sign_gallery_media_token_for_tests(MEDIA_ROUTE, expired_at);
+        let expired = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!(
+                        "/api/gallery/image/clip.mp4?media_token={expired_token}&expires={expired_at}"
+                    ))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(expired.status(), StatusCode::UNAUTHORIZED);
+
+        // The ticket is scoped to GET /api/gallery/image/:filename. It cannot
+        // authenticate another API route or a destructive gallery method.
+        let wrong_path = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!(
+                        "/api/status?media_token={token}&expires={expires_at}"
+                    ))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(wrong_path.status(), StatusCode::UNAUTHORIZED);
+
+        let delete = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!(
+                        "/api/gallery/image/clip.mp4?media_token={token}&expires={expires_at}"
+                    ))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(delete.status(), StatusCode::UNAUTHORIZED);
+        assert!(media_path.is_file());
+
+        let invalid_issue_path = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/gallery/media-token")
+                    .header("x-api-key", "test-key")
+                    .header(axum::http::header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"path":"/api/status"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            invalid_issue_path.status(),
+            StatusCode::UNPROCESSABLE_ENTITY
+        );
+    }
+
+    #[tokio::test]
+    async fn gallery_media_token_endpoint_reports_when_auth_is_disabled() {
+        let app = app_with_auth(None);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/gallery/media-token")
+                    // Simulate a stale key retained for a host that disabled auth.
+                    .header("x-api-key", "stale-key")
+                    .header(axum::http::header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"path":"/api/gallery/image/clip.mp4"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = json_body(response).await;
+        assert_eq!(body["auth_required"], false);
+        assert!(body["token"].is_null());
+        assert!(body["expires_at"].is_null());
+    }
+
+    #[tokio::test]
     async fn request_id_generated() {
         let app = app_empty().layer(axum::middleware::from_fn(
             crate::request_id::request_id_middleware,

--- a/desktop/src/lib/gallery/media.test.ts
+++ b/desktop/src/lib/gallery/media.test.ts
@@ -1,10 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { apiFetch, apiFetchTo } from "../api/client";
-import { authedMediaUrl, evictHostMedia, evictMedia, galleryMediaPath } from "./media";
+import { ApiError, apiFetch, apiFetchTo, currentTarget } from "../api/client";
+import {
+  authedMediaUrl,
+  evictHostMedia,
+  evictMedia,
+  galleryMediaPath,
+  streamableMediaUrl,
+} from "./media";
 
-vi.mock("../api/client", () => ({
+vi.mock("../api/client", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../api/client")>()),
   apiFetch: vi.fn(),
   apiFetchTo: vi.fn(),
+  currentTarget: vi.fn(),
 }));
 
 const blobResponse = () =>
@@ -17,9 +25,98 @@ beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(apiFetch).mockImplementation(() => Promise.resolve(blobResponse()));
   vi.mocked(apiFetchTo).mockImplementation(() => Promise.resolve(blobResponse()));
+  vi.mocked(currentTarget).mockReturnValue({ baseUrl: "http://primary:7680", apiKey: null });
   revoked.length = 0;
   URL.createObjectURL = vi.fn(() => `blob:mock-${++objectUrlSeq}`);
   URL.revokeObjectURL = vi.fn((url: string) => void revoked.push(url));
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+describe("streamableMediaUrl", () => {
+  it("uses the direct host URL when no API key is required", async () => {
+    const target = { baseUrl: "http://studio.tailnet.ts.net:7680", apiKey: null };
+
+    await expect(
+      streamableMediaUrl("/api/gallery/image/clip.mp4", { target, cacheKey: "studio" }),
+    ).resolves.toBe("http://studio.tailnet.ts.net:7680/api/gallery/image/clip.mp4");
+    expect(apiFetchTo).not.toHaveBeenCalled();
+  });
+
+  it("exchanges an API key for a short-lived streamable gallery URL", async () => {
+    const target = { baseUrl: "https://studio.example", apiKey: "secret" };
+    vi.mocked(apiFetchTo).mockResolvedValueOnce({
+      json: () =>
+        Promise.resolve({
+          token: "short_lived-ticket",
+          expires_at: 1_800_000_000,
+          auth_required: true,
+        }),
+    } as Response);
+
+    const url = await streamableMediaUrl("/api/gallery/image/clip%20one.mp4", {
+      target,
+      cacheKey: "studio",
+    });
+
+    expect(apiFetchTo).toHaveBeenCalledWith(target, "/api/gallery/media-token", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ path: "/api/gallery/image/clip%20one.mp4" }),
+    });
+    expect(url).toBe(
+      "https://studio.example/api/gallery/image/clip%20one.mp4?media_token=short_lived-ticket&expires=1800000000",
+    );
+  });
+
+  it("uses the direct URL when a current auth-disabled host sees a stale saved key", async () => {
+    const target = { baseUrl: "http://studio:7680", apiKey: "stale-key" };
+    vi.mocked(apiFetchTo).mockResolvedValueOnce({
+      json: () => Promise.resolve({ token: null, expires_at: null, auth_required: false }),
+    } as Response);
+
+    await expect(
+      streamableMediaUrl("/api/gallery/image/clip.mp4", { target, cacheKey: "studio" }),
+    ).resolves.toBe("http://studio:7680/api/gallery/image/clip.mp4");
+  });
+
+  it("probes and directly streams video from an older auth-disabled host", async () => {
+    const target = { baseUrl: "http://old-public:7680", apiKey: "stale-key" };
+    vi.mocked(apiFetchTo).mockRejectedValueOnce(new ApiError("missing", 404));
+    vi.mocked(fetch).mockResolvedValueOnce({ ok: true } as Response);
+
+    await expect(
+      streamableMediaUrl("/api/gallery/image/clip.mp4", { target, cacheKey: "old" }),
+    ).resolves.toBe("http://old-public:7680/api/gallery/image/clip.mp4");
+    expect(fetch).toHaveBeenCalledWith("http://old-public:7680/api/gallery/image/clip.mp4", {
+      method: "HEAD",
+    });
+  });
+
+  it("allows still images on older hosts to use the bounded blob path", async () => {
+    const target = { baseUrl: "http://old-host:7680", apiKey: "secret" };
+    vi.mocked(apiFetchTo)
+      .mockRejectedValueOnce(new ApiError("missing", 404))
+      .mockResolvedValueOnce(blobResponse());
+    vi.mocked(fetch).mockResolvedValueOnce({ ok: false } as Response);
+
+    await expect(
+      streamableMediaUrl("/api/gallery/image/print.png", {
+        target,
+        cacheKey: "old",
+        allowLegacyBlob: true,
+      }),
+    ).resolves.toMatch(/^blob:mock-/);
+  });
+
+  it("refuses to buffer videos from hosts without streaming tickets", async () => {
+    const target = { baseUrl: "http://old-host:7680", apiKey: "secret" };
+    vi.mocked(apiFetchTo).mockRejectedValueOnce(new ApiError("missing", 404));
+    vi.mocked(fetch).mockResolvedValueOnce({ ok: false } as Response);
+
+    await expect(
+      streamableMediaUrl("/api/gallery/image/clip.mp4", { target, cacheKey: "old" }),
+    ).rejects.toThrow("Update this Mold host");
+  });
 });
 
 describe("galleryMediaPath", () => {

--- a/desktop/src/lib/gallery/media.ts
+++ b/desktop/src/lib/gallery/media.ts
@@ -1,4 +1,4 @@
-import { apiFetch, apiFetchTo, type ApiTarget } from "../api/client";
+import { ApiError, apiFetch, apiFetchTo, currentTarget, type ApiTarget } from "../api/client";
 import type { GalleryImage } from "../api/types";
 
 /**
@@ -6,9 +6,9 @@ import type { GalleryImage } from "../api/types";
  * headers — so media is fetched with auth and served to the DOM as object
  * URLs. Entries are cached per (origin, path): the same API path on two
  * hosts is two different images, so the cache key is prefixed with an
- * origin `cacheKey` ("primary" = the app's primary connection). (A
- * tokenized media URL is a candidate upstream improvement to let <video>
- * stream with Range instead of full-buffering.)
+ * origin `cacheKey` ("primary" = the app's primary connection). Video
+ * viewers should use `streamableMediaUrl` instead, which preserves Range
+ * requests through a short-lived read-only ticket.
  */
 const cache = new Map<string, Promise<string>>();
 
@@ -17,6 +17,18 @@ export interface AuthedMediaOptions {
   target?: ApiTarget;
   /** Cache bucket, usually the origin host id; defaults to "primary". */
   cacheKey?: string;
+}
+
+interface GalleryMediaTicket {
+  token: string | null;
+  expires_at: number | null;
+  auth_required?: boolean;
+}
+
+export interface StreamableMediaOptions extends AuthedMediaOptions {
+  /** Older hosts have no streaming-ticket endpoint. Images may safely fall
+   * back to a blob; videos must not buffer an unbounded file on iPhone. */
+  allowLegacyBlob?: boolean;
 }
 
 const keyOf = (path: string, cacheKey?: string) => `${cacheKey ?? "primary"}|${path}`;
@@ -34,6 +46,61 @@ export function authedMediaUrl(path: string, opts: AuthedMediaOptions = {}): Pro
     url.catch(() => cache.delete(key));
   }
   return url;
+}
+
+/**
+ * Return a URL an `<img>` or `<video>` can load directly. Headerless hosts use
+ * their ordinary media URL, preserving HTTP Range requests. Authenticated
+ * hosts exchange the API key for a short-lived, read-only gallery ticket so
+ * WebKit can stream and seek without putting the long-lived key in the URL.
+ */
+export async function streamableMediaUrl(
+  path: string,
+  opts: StreamableMediaOptions = {},
+): Promise<string> {
+  if (path.startsWith("mold-local:")) return path;
+  const target = opts.target ?? currentTarget();
+  const directUrl = `${target.baseUrl.replace(/\/$/, "")}${path}`;
+  if (!target.apiKey) return directUrl;
+
+  try {
+    const response = await apiFetchTo(target, "/api/gallery/media-token", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ path }),
+    });
+    const ticket = (await response.json()) as GalleryMediaTicket;
+    // A key can remain in Keychain after a host disables authentication. New
+    // hosts make that state explicit so the media element can use its normal
+    // direct URL instead of treating the harmless stale key as a failure.
+    if (ticket.auth_required === false) return directUrl;
+    if (!ticket.token || !Number.isSafeInteger(ticket.expires_at)) {
+      throw new Error("The host returned an invalid gallery media ticket.");
+    }
+    const url = new URL(directUrl);
+    url.searchParams.set("media_token", ticket.token);
+    url.searchParams.set("expires", String(ticket.expires_at));
+    return url.toString();
+  } catch (error) {
+    const endpointMissing =
+      error instanceof ApiError && (error.status === 404 || error.status === 405);
+    // Older auth-disabled hosts have no ticket endpoint. A headerless HEAD is
+    // bounded and distinguishes them from older authenticated hosts without
+    // ever buffering the underlying video.
+    if (endpointMissing) {
+      try {
+        const probe = await fetch(directUrl, { method: "HEAD" });
+        if (probe.ok) return directUrl;
+      } catch {
+        // Fall through to the bounded image fallback / upgrade guidance.
+      }
+    }
+    if (endpointMissing && opts.allowLegacyBlob) return authedMediaUrl(path, opts);
+    if (endpointMissing) {
+      throw new Error("Update this Mold host to stream videos on iPhone.");
+    }
+    throw error;
+  }
 }
 
 export function evictMedia(path: string, cacheKey?: string): void {

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -1,0 +1,306 @@
+import { flushPromises, mount, type DOMWrapper, type VueWrapper } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { installMemoryLocalStorage } from "../lib/testSupport/memoryLocalStorage";
+import type { GalleryImage, ModelEntry, ServerStatus } from "../lib/api/types";
+
+const { invoke, apiFetchTo, apiJsonTo, sseStream, streamableMediaUrl, evictMedia } = vi.hoisted(
+  () => ({
+    invoke: vi.fn(),
+    apiFetchTo: vi.fn(),
+    apiJsonTo: vi.fn(),
+    sseStream: vi.fn(),
+    streamableMediaUrl: vi.fn(),
+    evictMedia: vi.fn(),
+  }),
+);
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke }));
+vi.mock("../lib/api/client", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../lib/api/client")>()),
+  apiFetchTo,
+  apiJsonTo,
+}));
+vi.mock("../lib/api/sse", () => ({ sseStream }));
+vi.mock("../lib/gallery/media", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../lib/gallery/media")>()),
+  streamableMediaUrl,
+  evictMedia,
+}));
+
+import MobileApp from "./MobileApp.vue";
+
+installMemoryLocalStorage();
+
+const target = { baseUrl: "http://studio.tailnet.ts.net:7680", apiKey: "secret" };
+const status: ServerStatus = {
+  version: "0.18.0",
+  models_loaded: [],
+  uptime_secs: 60,
+  hostname: "studio",
+  instance_id: "studio-id",
+};
+const model: ModelEntry = {
+  name: "ltx2:q8",
+  family: "ltx2",
+  size_gb: 20,
+  is_loaded: false,
+  hf_repo: "example/ltx2",
+  default_steps: 30,
+  default_guidance: 3,
+  default_width: 768,
+  default_height: 512,
+  description: "Video model",
+  downloaded: true,
+};
+const print: GalleryImage = {
+  filename: "storm clip.mp4",
+  timestamp: 1_700_000_000,
+  format: "mp4",
+  metadata: {
+    prompt: "a ship crossing violet lightning",
+    negative_prompt: "calm water",
+    model: model.name,
+    seed: 77,
+    steps: 28,
+    guidance: 4.25,
+    width: 1536,
+    height: 1024,
+    generation_width: 768,
+    generation_height: 512,
+    output_format: "mp4",
+    scheduler: "ddim",
+    frames: 121,
+    fps: 30,
+  },
+};
+
+let wrapper: VueWrapper | null = null;
+let objectUrlSequence = 0;
+
+function fieldControl(label: string): DOMWrapper<Element> {
+  const field = wrapper
+    ?.findAll("label.field")
+    .find((candidate) => candidate.find("span").text() === label);
+  if (!field) throw new Error(`Missing ${label} field`);
+  return field.find("input, textarea, select");
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  localStorage.setItem(
+    "mold.mobile.hosts.v1",
+    JSON.stringify([
+      {
+        id: "studio-id",
+        name: "Studio",
+        baseUrl: target.baseUrl,
+        hostname: "studio",
+        version: "0.18.0",
+        online: false,
+      },
+    ]),
+  );
+  invoke
+    .mockReset()
+    .mockImplementation((command: string) =>
+      Promise.resolve(command === "keychain_get_api_key" ? target.apiKey : null),
+    );
+  apiJsonTo.mockReset().mockImplementation((_target: unknown, path: string) => {
+    if (path === "/api/status") return Promise.resolve(status);
+    if (path === "/api/models") return Promise.resolve([model]);
+    if (path === "/api/gallery") return Promise.resolve([print]);
+    return Promise.reject(new Error(`Unexpected API path: ${path}`));
+  });
+  apiFetchTo.mockReset().mockResolvedValue({
+    blob: () => Promise.resolve(new Blob(["thumbnail"])),
+  } as Response);
+  sseStream.mockReset();
+  streamableMediaUrl.mockReset().mockResolvedValue("https://studio/media/full-video");
+  evictMedia.mockReset();
+  objectUrlSequence = 0;
+  URL.createObjectURL = vi.fn(() => `blob:thumbnail-${++objectUrlSequence}`);
+  URL.revokeObjectURL = vi.fn();
+});
+
+afterEach(() => {
+  wrapper?.unmount();
+  wrapper = null;
+  document.body.innerHTML = "";
+});
+
+describe("MobileApp gallery", () => {
+  it("opens media first, then explicitly reuses the prompt and visible settings", async () => {
+    wrapper = mount(MobileApp, { attachTo: document.body });
+    await flushPromises();
+
+    await wrapper.get("[data-test='mobile-tab-gallery']").trigger("click");
+    await vi.waitFor(() => expect(wrapper?.find("[data-test='gallery-item']").exists()).toBe(true));
+
+    const tile = wrapper.get("[data-test='gallery-item']");
+    expect(tile.attributes("aria-label")).toBe("Open storm clip.mp4 from Studio");
+    await tile.trigger("click");
+    await flushPromises();
+
+    expect(wrapper.get("[data-test='mobile-tab-gallery']").attributes("aria-selected")).toBe(
+      "true",
+    );
+    expect(wrapper.find("[data-test='gallery-viewer-video']").exists()).toBe(true);
+    expect(streamableMediaUrl).toHaveBeenCalledWith("/api/gallery/image/storm%20clip.mp4", {
+      target,
+      cacheKey: "studio-id",
+      allowLegacyBlob: false,
+    });
+
+    await wrapper.get("[data-test='gallery-viewer-close']").trigger("click");
+    expect(wrapper.find("[data-test='gallery-viewer']").exists()).toBe(false);
+    expect(wrapper.get("[data-test='mobile-tab-gallery']").attributes("aria-selected")).toBe(
+      "true",
+    );
+
+    await wrapper.get("[data-test='gallery-item']").trigger("click");
+    await flushPromises();
+    await wrapper.get("[data-test='gallery-viewer-reuse']").trigger("click");
+    await flushPromises();
+
+    expect(wrapper.find("[data-test='gallery-viewer']").exists()).toBe(false);
+    expect(wrapper.get("[data-test='mobile-tab-generate']").attributes("aria-selected")).toBe(
+      "true",
+    );
+    expect(wrapper.get("#mobile-prompt").element).toHaveProperty("value", print.metadata.prompt);
+    expect(fieldControl("Negative prompt").element).toHaveProperty("value", "calm water");
+    expect(fieldControl("Width").element).toHaveProperty("value", "768");
+    expect(fieldControl("Height").element).toHaveProperty("value", "512");
+    expect(fieldControl("Format").element).toHaveProperty("value", "mp4");
+    expect(fieldControl("Frames").element).toHaveProperty("value", "121");
+    expect(fieldControl("FPS").element).toHaveProperty("value", "30");
+  });
+
+  it("keeps the viewer open when the print host's models cannot be loaded", async () => {
+    const remoteTarget = { baseUrl: "http://remote.tailnet.ts.net:7680", apiKey: "secret" };
+    localStorage.setItem(
+      "mold.mobile.hosts.v1",
+      JSON.stringify([
+        {
+          id: "studio-id",
+          name: "Studio",
+          baseUrl: target.baseUrl,
+          hostname: "studio",
+          version: "0.18.0",
+          online: false,
+        },
+        {
+          id: "remote-id",
+          name: "Remote",
+          baseUrl: remoteTarget.baseUrl,
+          hostname: "remote",
+          version: "0.18.0",
+          online: false,
+        },
+      ]),
+    );
+    apiJsonTo.mockImplementation((requestTarget: unknown, path: string) => {
+      const baseUrl = (requestTarget as { baseUrl: string }).baseUrl;
+      if (path === "/api/gallery") {
+        return Promise.resolve(baseUrl === remoteTarget.baseUrl ? [print] : []);
+      }
+      if (baseUrl === remoteTarget.baseUrl) return Promise.reject(new Error("offline"));
+      if (path === "/api/status") return Promise.resolve(status);
+      if (path === "/api/models") return Promise.resolve([model]);
+      return Promise.reject(new Error(`Unexpected API path: ${path}`));
+    });
+
+    wrapper = mount(MobileApp, { attachTo: document.body });
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-tab-gallery']").trigger("click");
+    await vi.waitFor(() => expect(wrapper?.find("[data-test='gallery-item']").exists()).toBe(true));
+    await wrapper.get("[data-test='gallery-item']").trigger("click");
+    await flushPromises();
+    await wrapper.get("[data-test='gallery-viewer-reuse']").trigger("click");
+    await flushPromises();
+
+    expect(wrapper.find("[data-test='gallery-viewer']").exists()).toBe(true);
+    expect(wrapper.get("[role='alert']").text()).toContain("Couldn’t load models from Remote");
+    expect(wrapper.get("[data-test='mobile-tab-gallery']").attributes("aria-selected")).toBe(
+      "true",
+    );
+  });
+
+  it("reloads model ownership after removing the active host before reuse", async () => {
+    const remoteTarget = { baseUrl: "http://remote.tailnet.ts.net:7680", apiKey: "secret" };
+    const studioModel: ModelEntry = {
+      ...model,
+      name: "flux:studio-only",
+      family: "flux",
+      default_width: 1024,
+      default_height: 1024,
+    };
+    localStorage.setItem(
+      "mold.mobile.hosts.v1",
+      JSON.stringify([
+        {
+          id: "studio-id",
+          name: "Studio",
+          baseUrl: target.baseUrl,
+          hostname: "studio",
+          version: "0.18.0",
+          online: false,
+        },
+        {
+          id: "remote-id",
+          name: "Remote",
+          baseUrl: remoteTarget.baseUrl,
+          hostname: "remote",
+          version: "0.18.0",
+          online: false,
+        },
+      ]),
+    );
+    apiJsonTo.mockImplementation((requestTarget: unknown, path: string) => {
+      const baseUrl = (requestTarget as { baseUrl: string }).baseUrl;
+      if (path === "/api/status") {
+        return Promise.resolve({
+          ...status,
+          hostname: baseUrl === remoteTarget.baseUrl ? "remote" : "studio",
+        });
+      }
+      if (path === "/api/models") {
+        return Promise.resolve(baseUrl === remoteTarget.baseUrl ? [model] : [studioModel]);
+      }
+      if (path === "/api/gallery") {
+        return Promise.resolve(baseUrl === remoteTarget.baseUrl ? [print] : []);
+      }
+      return Promise.reject(new Error(`Unexpected API path: ${path}`));
+    });
+
+    wrapper = mount(MobileApp, { attachTo: document.body });
+    await vi.waitFor(() =>
+      expect(fieldControl("Model").element).toHaveProperty("value", studioModel.name),
+    );
+
+    const hostsTab = wrapper
+      .findAll("button.mobile-tab")
+      .find((button) => button.text() === "Hosts");
+    if (!hostsTab) throw new Error("Missing Hosts tab");
+    await hostsTab.trigger("click");
+    const studioRow = wrapper
+      .findAll(".host-row")
+      .find((row) => row.find(".host-name").text() === "Studio");
+    if (!studioRow) throw new Error("Missing Studio host row");
+    await studioRow.get("button.danger-button").trigger("click");
+    await vi.waitFor(() => expect(apiJsonTo).toHaveBeenCalledWith(remoteTarget, "/api/models"));
+
+    await wrapper.get("[data-test='mobile-tab-gallery']").trigger("click");
+    await vi.waitFor(() => expect(wrapper?.find("[data-test='gallery-item']").exists()).toBe(true));
+    await wrapper.get("[data-test='gallery-item']").trigger("click");
+    await flushPromises();
+    await wrapper.get("[data-test='gallery-viewer-reuse']").trigger("click");
+    await flushPromises();
+
+    expect(fieldControl("Model").element).toHaveProperty("value", model.name);
+    expect(wrapper.get(".status-line").text()).toBe("Prompt settings restored");
+    const developButton = wrapper
+      .findAll("button")
+      .find((button) => button.text() === "Develop print");
+    expect(developButton?.attributes("disabled")).toBeUndefined();
+  });
+});

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -17,7 +17,10 @@ import {
   newGenerateForm,
   type GenerateForm,
 } from "../lib/generateForm";
+import { galleryMediaPath, isVideoItem } from "../lib/gallery/media";
 import { normalizeRemoteAddress, remoteHostId } from "./hosts";
+import { applyMobileGalleryMetadata } from "./reuse";
+import MobileGalleryViewer from "./MobileGalleryViewer.vue";
 
 type Tab = "generate" | "gallery" | "hosts";
 
@@ -40,7 +43,8 @@ interface DiscoveredHost {
 interface GalleryPrint extends GalleryImage {
   hostId: string;
   hostName: string;
-  mediaUrl: string;
+  target: ApiTarget;
+  thumbnailUrl: string;
 }
 
 interface PendingGalleryPrint extends GalleryImage {
@@ -59,6 +63,7 @@ const discovered = ref<DiscoveredHost[]>([]);
 const discovering = ref(false);
 const hostError = ref("");
 const models = ref<ModelEntry[]>([]);
+const modelsHostId = ref("");
 const loadingModels = ref(false);
 const form = reactive<GenerateForm>(newGenerateForm());
 const generating = ref(false);
@@ -70,9 +75,13 @@ const galleryLoading = ref(false);
 const galleryLoadingMore = ref(false);
 const galleryError = ref("");
 const galleryRemaining = ref(0);
+const selectedPrint = ref<GalleryPrint | null>(null);
+const reusingPrint = ref(false);
+const reusePrintError = ref("");
 let generationAbort: AbortController | null = null;
 const objectUrls = new Set<string>();
 let pendingGallery: PendingGalleryPrint[] = [];
+let modelLoadEpoch = 0;
 
 const selectedHost = computed(() => hosts.value.find((host) => host.id === selectedHostId.value));
 const selectedTarget = computed<ApiTarget | null>(() => {
@@ -81,6 +90,11 @@ const selectedTarget = computed<ApiTarget | null>(() => {
 });
 const resultIsVideo = computed(() => resultFormat.value === "mp4");
 const outputFormats = computed(() => outputFormatsForFamily(form.family));
+const selectedModelAvailable = computed(
+  () =>
+    modelsHostId.value === selectedHostId.value &&
+    models.value.some((model) => model.name === form.model),
+);
 
 function loadHosts(): SavedHost[] {
   try {
@@ -161,36 +175,54 @@ async function selectHost(id: string): Promise<void> {
 }
 
 function removeHost(id: string): void {
+  const removedSelectedHost = selectedHostId.value === id;
   hosts.value = hosts.value.filter((host) => host.id !== id);
-  if (selectedHostId.value === id) selectedHostId.value = hosts.value[0]?.id ?? "";
+  if (removedSelectedHost) {
+    selectedHostId.value = hosts.value[0]?.id ?? "";
+    models.value = [];
+    modelsHostId.value = "";
+    void refreshModels();
+  }
   persistHosts();
   void invoke("keychain_delete_api_key", { hostId: id });
 }
 
-async function refreshModels(): Promise<void> {
-  const target = selectedTarget.value;
-  if (!target) return;
+async function refreshModels(): Promise<boolean> {
+  const epoch = ++modelLoadEpoch;
+  const host = selectedHost.value;
+  if (!host) {
+    models.value = [];
+    modelsHostId.value = "";
+    loadingModels.value = false;
+    return false;
+  }
+  const hostId = host.id;
+  const target = { baseUrl: host.baseUrl, apiKey: host.apiKey || null };
   loadingModels.value = true;
+  models.value = [];
+  modelsHostId.value = "";
   try {
     const [status, entries] = await Promise.all([
       apiJsonTo<ServerStatus>(target, "/api/status"),
       apiJsonTo<ModelEntry[]>(target, "/api/models"),
     ]);
-    const host = selectedHost.value;
-    if (host) {
-      host.online = true;
-      host.version = status.version;
-      host.hostname = status.hostname ?? undefined;
-    }
+    if (epoch !== modelLoadEpoch || selectedHostId.value !== hostId) return false;
+    host.online = true;
+    host.version = status.version;
+    host.hostname = status.hostname ?? undefined;
     models.value = entries.filter((model) => model.downloaded);
+    modelsHostId.value = hostId;
     if (!models.value.some((model) => model.name === form.model) && models.value[0]) {
       applyModelDefaults(form, models.value[0]);
     }
+    return true;
   } catch (error) {
-    if (selectedHost.value) selectedHost.value.online = false;
+    if (epoch !== modelLoadEpoch || selectedHostId.value !== hostId) return false;
+    host.online = false;
     progress.value = error instanceof Error ? error.message : String(error);
+    return false;
   } finally {
-    loadingModels.value = false;
+    if (epoch === modelLoadEpoch && selectedHostId.value === hostId) loadingModels.value = false;
   }
 }
 
@@ -219,7 +251,7 @@ function revokeObjectUrl(url: string): void {
 
 async function generate(): Promise<void> {
   const target = selectedTarget.value;
-  if (!target || !form.prompt.trim() || !form.model) return;
+  if (!target || !form.prompt.trim() || !selectedModelAvailable.value) return;
   generationAbort?.abort();
   const controller = new AbortController();
   generationAbort = controller;
@@ -278,11 +310,8 @@ function stopGeneration(): void {
   progress.value = "Cancelled";
 }
 
-async function mediaUrl(target: ApiTarget, filename: string): Promise<string> {
-  const response = await apiFetchTo(
-    target,
-    `/api/gallery/thumbnail/${encodeURIComponent(filename)}`,
-  );
+async function thumbnailUrl(target: ApiTarget, filename: string): Promise<string> {
+  const response = await apiFetchTo(target, galleryMediaPath(filename, "host", true));
   const url = URL.createObjectURL(await response.blob());
   objectUrls.add(url);
   return url;
@@ -293,7 +322,7 @@ async function refreshGallery(): Promise<void> {
   galleryError.value = "";
   const prior = gallery.value;
   gallery.value = [];
-  for (const item of prior) revokeObjectUrl(item.mediaUrl);
+  for (const item of prior) revokeObjectUrl(item.thumbnailUrl);
   const results = await Promise.allSettled(
     hosts.value.map(async (host) => {
       const target = { baseUrl: host.baseUrl, apiKey: host.apiKey || null };
@@ -322,7 +351,8 @@ async function loadMoreGallery(): Promise<void> {
     const batch = await Promise.allSettled(
       page.slice(offset, offset + 4).map(async ({ target, ...print }) => ({
         ...print,
-        mediaUrl: await mediaUrl(target, print.filename),
+        target,
+        thumbnailUrl: await thumbnailUrl(target, print.filename),
       })),
     );
     gallery.value.push(
@@ -334,22 +364,49 @@ async function loadMoreGallery(): Promise<void> {
 }
 
 async function reusePrint(print: GalleryPrint): Promise<void> {
-  if (selectedHostId.value !== print.hostId) {
-    selectedHostId.value = print.hostId;
-    await refreshModels();
+  if (reusingPrint.value || print.metadata_synthetic || !print.metadata.prompt?.trim()) return;
+  reusingPrint.value = true;
+  reusePrintError.value = "";
+  try {
+    if (selectedHostId.value !== print.hostId) {
+      selectedHostId.value = print.hostId;
+    }
+    if (modelsHostId.value !== print.hostId) {
+      if (!(await refreshModels())) {
+        reusePrintError.value = `Couldn’t load models from ${print.hostName}. Check the host and try again.`;
+        return;
+      }
+    }
+    if (models.value.length === 0) {
+      reusePrintError.value = `${print.hostName} has no downloaded models available.`;
+      return;
+    }
+    const reuse = applyMobileGalleryMetadata(form, print.metadata, models.value);
+    progress.value = reuse.substitutedModel
+      ? `The original model isn’t installed on ${print.hostName}; using ${reuse.modelName}.`
+      : "Prompt settings restored";
+    selectedPrint.value = null;
+    tab.value = "generate";
+    void nextTick(() => document.querySelector<HTMLTextAreaElement>("#mobile-prompt")?.focus());
+  } finally {
+    reusingPrint.value = false;
   }
-  const meta = print.metadata;
-  const model = models.value.find((entry) => entry.name === meta.model);
-  if (model) applyModelDefaults(form, model);
-  form.prompt = meta.prompt;
-  form.negativePrompt = meta.negative_prompt ?? "";
-  form.width = meta.generation_width ?? meta.width;
-  form.height = meta.generation_height ?? meta.height;
-  form.steps = meta.steps;
-  form.guidance = meta.guidance;
-  form.seed = String(meta.seed);
-  tab.value = "generate";
-  void nextTick(() => document.querySelector<HTMLTextAreaElement>("#mobile-prompt")?.focus());
+}
+
+function openPrint(print: GalleryPrint): void {
+  reusePrintError.value = "";
+  selectedPrint.value = print;
+}
+
+function closePrint(): void {
+  if (reusingPrint.value) return;
+  reusePrintError.value = "";
+  selectedPrint.value = null;
+}
+
+function reuseSelectedPrint(): void {
+  const print = selectedPrint.value;
+  if (print) void reusePrint(print);
 }
 
 watch(selectedHostId, (id) => {
@@ -477,7 +534,7 @@ onBeforeUnmount(() => {
             v-if="!generating"
             class="primary-button"
             type="button"
-            :disabled="!form.prompt.trim() || !form.model"
+            :disabled="!form.prompt.trim() || !selectedModelAvailable"
             @click="generate"
           >
             Develop print
@@ -513,14 +570,16 @@ onBeforeUnmount(() => {
             :key="`${print.hostId}:${print.filename}`"
             class="gallery-item"
             type="button"
-            :aria-label="`Reuse settings from ${print.filename} on ${print.hostName}`"
-            @click="reusePrint(print)"
+            :aria-label="`Open ${print.filename} from ${print.hostName}`"
+            data-test="gallery-item"
+            @click="openPrint(print)"
           >
             <img
-              :src="print.mediaUrl"
+              :src="print.thumbnailUrl"
               :alt="print.metadata.prompt || print.filename"
               loading="lazy"
             />
+            <span v-if="isVideoItem(print)" class="gallery-video-badge" aria-hidden="true">▶</span>
           </button>
         </div>
         <div v-else class="empty-state">No prints found.</div>
@@ -616,11 +675,26 @@ onBeforeUnmount(() => {
       </template>
     </section>
 
+    <MobileGalleryViewer
+      v-if="selectedPrint"
+      :key="`${selectedPrint.hostId}:${selectedPrint.filename}`"
+      :item="selectedPrint"
+      :target="selectedPrint.target"
+      :cache-key="selectedPrint.hostId"
+      :host-name="selectedPrint.hostName"
+      :thumbnail-url="selectedPrint.thumbnailUrl"
+      :reusing="reusingPrint"
+      :reuse-error="reusePrintError"
+      @close="closePrint"
+      @reuse="reuseSelectedPrint"
+    />
+
     <nav class="mobile-tabs" aria-label="Primary">
       <button
         class="mobile-tab"
         type="button"
         :aria-selected="tab === 'generate'"
+        data-test="mobile-tab-generate"
         @click="tab = 'generate'"
       >
         Generate
@@ -629,6 +703,7 @@ onBeforeUnmount(() => {
         class="mobile-tab"
         type="button"
         :aria-selected="tab === 'gallery'"
+        data-test="mobile-tab-gallery"
         @click="tab = 'gallery'"
       >
         Gallery

--- a/desktop/src/mobile/MobileGalleryViewer.test.ts
+++ b/desktop/src/mobile/MobileGalleryViewer.test.ts
@@ -1,0 +1,154 @@
+import { flushPromises, mount, type VueWrapper } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { GalleryImage } from "../lib/api/types";
+
+const { streamableMediaUrl, evictMedia } = vi.hoisted(() => ({
+  streamableMediaUrl: vi.fn(),
+  evictMedia: vi.fn(),
+}));
+
+vi.mock("../lib/gallery/media", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../lib/gallery/media")>()),
+  streamableMediaUrl,
+  evictMedia,
+}));
+
+import MobileGalleryViewer from "./MobileGalleryViewer.vue";
+
+const target = { baseUrl: "http://studio.tailnet.ts.net:7680", apiKey: "secret" };
+const image: GalleryImage = {
+  filename: "print one.png",
+  timestamp: 1_700_000_000,
+  format: "png",
+  metadata: {
+    prompt: "a lighthouse at dusk",
+    model: "flux-dev:q8",
+    seed: 42,
+    steps: 4,
+    guidance: 3.5,
+    width: 1024,
+    height: 1024,
+  },
+};
+
+let wrapper: VueWrapper | null = null;
+
+function mountViewer(item: GalleryImage = image): VueWrapper {
+  wrapper = mount(MobileGalleryViewer, {
+    attachTo: document.body,
+    props: {
+      item,
+      target,
+      cacheKey: "studio",
+      hostName: "Studio",
+      thumbnailUrl: "blob:thumbnail",
+    },
+  });
+  return wrapper;
+}
+
+beforeEach(() => {
+  streamableMediaUrl.mockReset().mockResolvedValue("https://studio/media/full");
+  evictMedia.mockReset();
+});
+
+afterEach(() => {
+  wrapper?.unmount();
+  wrapper = null;
+  document.body.innerHTML = "";
+});
+
+describe("MobileGalleryViewer", () => {
+  it("opens full image media in an accessible viewer with explicit reuse", async () => {
+    const view = mountViewer();
+    await flushPromises();
+
+    const dialog = view.get("[role='dialog']");
+    expect(dialog.element.tagName).toBe("DIALOG");
+    expect(dialog.attributes("aria-modal")).toBe("true");
+    expect(dialog.attributes("open")).toBe("");
+    expect(view.get("[data-test='gallery-viewer-image']").attributes("src")).toBe(
+      "https://studio/media/full",
+    );
+    expect(streamableMediaUrl).toHaveBeenCalledWith("/api/gallery/image/print%20one.png", {
+      target,
+      cacheKey: "studio",
+      allowLegacyBlob: true,
+    });
+
+    await view.get("[data-test='gallery-viewer-reuse']").trigger("click");
+    expect(view.emitted("reuse")).toHaveLength(1);
+  });
+
+  it("renders MP4 gallery items with native inline playback controls", async () => {
+    const view = mountViewer({
+      ...image,
+      filename: "developed clip.mp4",
+      format: "mp4",
+    });
+    await flushPromises();
+
+    const video = view.get("[data-test='gallery-viewer-video']");
+    expect(video.attributes()).toMatchObject({
+      src: "https://studio/media/full",
+      controls: "",
+      playsinline: "",
+      preload: "metadata",
+    });
+    expect(streamableMediaUrl).toHaveBeenCalledWith("/api/gallery/image/developed%20clip.mp4", {
+      target,
+      cacheKey: "studio",
+      allowLegacyBlob: false,
+    });
+    expect(view.find("[role='status']").exists()).toBe(true);
+    await video.trigger("loadedmetadata");
+    expect(view.find("[role='status']").exists()).toBe(false);
+
+    await view.get("dialog").trigger("cancel");
+    expect(view.emitted("close")).toHaveLength(1);
+  });
+
+  it("shows a retryable error when full media cannot be fetched", async () => {
+    streamableMediaUrl.mockRejectedValueOnce(new Error("offline"));
+    const view = mountViewer();
+    await flushPromises();
+
+    expect(view.get("[role='alert']").text()).toContain("Couldn’t load");
+    await view.get("[role='alert'] button").trigger("click");
+    await flushPromises();
+
+    expect(streamableMediaUrl).toHaveBeenCalledTimes(2);
+    expect(view.find("[role='alert']").exists()).toBe(false);
+    expect(view.find("[data-test='gallery-viewer-image']").exists()).toBe(true);
+  });
+
+  it("preserves the host-upgrade guidance for legacy authenticated video hosts", async () => {
+    streamableMediaUrl.mockRejectedValueOnce(
+      new Error("Update this Mold host to stream videos on iPhone."),
+    );
+    const view = mountViewer({ ...image, filename: "legacy.mp4", format: "mp4" });
+    await flushPromises();
+
+    expect(view.get("[role='alert']").text()).toContain(
+      "Update this Mold host to stream videos on iPhone.",
+    );
+  });
+
+  it("evicts the full-media blob when the viewer closes", async () => {
+    const view = mountViewer();
+    await flushPromises();
+    view.unmount();
+    wrapper = null;
+
+    expect(evictMedia).toHaveBeenCalledWith("/api/gallery/image/print%20one.png", "studio");
+  });
+
+  it("does not offer reuse when the host only synthesized file metadata", async () => {
+    const view = mountViewer({ ...image, metadata_synthetic: true });
+    await flushPromises();
+
+    const reuse = view.get("[data-test='gallery-viewer-reuse']");
+    expect(reuse.attributes("disabled")).toBe("");
+    expect(reuse.text()).toBe("Prompt unavailable");
+  });
+});

--- a/desktop/src/mobile/MobileGalleryViewer.vue
+++ b/desktop/src/mobile/MobileGalleryViewer.vue
@@ -1,0 +1,199 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref } from "vue";
+import type { ApiTarget } from "../lib/api/client";
+import type { GalleryImage } from "../lib/api/types";
+import {
+  evictMedia,
+  galleryMediaPath,
+  isVideoItem,
+  streamableMediaUrl,
+} from "../lib/gallery/media";
+
+const props = withDefaults(
+  defineProps<{
+    item: GalleryImage;
+    target: ApiTarget;
+    cacheKey: string;
+    hostName: string;
+    thumbnailUrl: string;
+    reusing?: boolean;
+    reuseError?: string;
+  }>(),
+  { reusing: false, reuseError: "" },
+);
+
+const emit = defineEmits<{ close: []; reuse: [] }>();
+
+const dialog = ref<HTMLDialogElement | null>(null);
+const closeButton = ref<HTMLButtonElement | null>(null);
+const mediaUrl = ref("");
+const loading = ref(true);
+const loadError = ref("");
+const mediaLoadKey = ref(0);
+const video = computed(() => isVideoItem(props.item));
+const mediaPath = computed(() => galleryMediaPath(props.item.filename, "host"));
+const canReuse = computed(
+  () => !props.item.metadata_synthetic && !!props.item.metadata.prompt?.trim(),
+);
+const actionLabel = computed(() =>
+  props.reusing ? "Loading prompt…" : canReuse.value ? "Use as prompt" : "Prompt unavailable",
+);
+
+let restoreFocusElement: HTMLElement | null = null;
+let loadEpoch = 0;
+
+async function loadMedia(): Promise<void> {
+  const epoch = ++loadEpoch;
+  loading.value = true;
+  loadError.value = "";
+  mediaUrl.value = "";
+  mediaLoadKey.value += 1;
+  try {
+    const url = await streamableMediaUrl(mediaPath.value, {
+      target: props.target,
+      cacheKey: props.cacheKey,
+      allowLegacyBlob: !video.value,
+    });
+    if (epoch !== loadEpoch) return;
+    mediaUrl.value = url;
+  } catch (error) {
+    if (epoch !== loadEpoch) return;
+    loadError.value =
+      error instanceof Error && error.message.startsWith("Update this Mold host")
+        ? error.message
+        : "Couldn’t load the full print from this host.";
+  } finally {
+    if (epoch === loadEpoch && loadError.value) loading.value = false;
+  }
+}
+
+function retry(): void {
+  evictMedia(mediaPath.value, props.cacheKey);
+  void loadMedia();
+}
+
+function mediaReady(): void {
+  loading.value = false;
+}
+
+function mediaFailed(): void {
+  loading.value = false;
+  loadError.value = video.value
+    ? "Couldn’t play this video from the host."
+    : "Couldn’t load the full print from this host.";
+}
+
+function cancelViewer(): void {
+  if (!props.reusing) emit("close");
+}
+
+onMounted(() => {
+  restoreFocusElement = document.activeElement as HTMLElement | null;
+  try {
+    dialog.value?.showModal();
+  } catch {
+    dialog.value?.setAttribute("open", "");
+  }
+  closeButton.value?.focus();
+  void loadMedia();
+});
+
+onBeforeUnmount(() => {
+  loadEpoch += 1;
+  if (dialog.value?.open && typeof dialog.value.close === "function") dialog.value.close();
+  evictMedia(mediaPath.value, props.cacheKey);
+  restoreFocusElement?.focus?.();
+});
+</script>
+
+<template>
+  <dialog
+    ref="dialog"
+    class="gallery-viewer"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="gallery-viewer-title"
+    data-test="gallery-viewer"
+    @cancel.prevent="cancelViewer"
+  >
+    <header class="gallery-viewer-header">
+      <button
+        ref="closeButton"
+        class="gallery-viewer-close"
+        type="button"
+        aria-label="Close print"
+        data-test="gallery-viewer-close"
+        :disabled="reusing"
+        @click="emit('close')"
+      >
+        <span aria-hidden="true">×</span>
+        <span>Close</span>
+      </button>
+      <div class="gallery-viewer-origin">
+        <h1 id="gallery-viewer-title">Print preview</h1>
+        <span>{{ hostName }}</span>
+      </div>
+    </header>
+
+    <div class="gallery-viewer-stage">
+      <img
+        v-if="!mediaUrl"
+        class="gallery-viewer-placeholder"
+        :src="thumbnailUrl"
+        alt=""
+        aria-hidden="true"
+      />
+      <video
+        v-else-if="video"
+        :key="mediaLoadKey"
+        class="gallery-viewer-media"
+        :src="mediaUrl"
+        :poster="thumbnailUrl"
+        controls
+        playsinline
+        preload="metadata"
+        data-test="gallery-viewer-video"
+        @loadedmetadata="mediaReady"
+        @error="mediaFailed"
+      />
+      <img
+        v-else
+        :key="mediaLoadKey"
+        class="gallery-viewer-media"
+        :src="mediaUrl"
+        :alt="item.metadata.prompt || item.filename"
+        data-test="gallery-viewer-image"
+        @load="mediaReady"
+        @error="mediaFailed"
+      />
+
+      <div v-if="loading" class="gallery-viewer-loading" role="status">
+        Loading full resolution…
+      </div>
+      <div v-else-if="loadError" class="gallery-viewer-error" role="alert">
+        <span>{{ loadError }}</span>
+        <button type="button" @click="retry">Try again</button>
+      </div>
+    </div>
+
+    <footer class="gallery-viewer-details">
+      <div class="gallery-viewer-prompt">
+        <span>Prompt</span>
+        <p data-selectable>{{ item.metadata.prompt || "No prompt saved with this print." }}</p>
+        <p v-if="reuseError" class="gallery-viewer-reuse-error" role="alert">
+          {{ reuseError }}
+        </p>
+      </div>
+      <button
+        class="primary-button gallery-viewer-reuse"
+        type="button"
+        data-test="gallery-viewer-reuse"
+        :disabled="!canReuse || reusing"
+        :aria-busy="reusing"
+        @click="emit('reuse')"
+      >
+        {{ actionLabel }}
+      </button>
+    </footer>
+  </dialog>
+</template>

--- a/desktop/src/mobile/mobile.css
+++ b/desktop/src/mobile/mobile.css
@@ -19,6 +19,14 @@ select {
   font: inherit;
 }
 
+input,
+textarea,
+select,
+[contenteditable="true"] {
+  /* iOS WebKit magnifies focused editable controls below 16 CSS pixels. */
+  font-size: 16px;
+}
+
 button {
   color: inherit;
 }
@@ -210,6 +218,207 @@ button:disabled {
   width: 100%;
   height: 100%;
   object-fit: cover;
+}
+
+.gallery-video-badge {
+  position: absolute;
+  right: 8px;
+  bottom: 8px;
+  display: grid;
+  width: 32px;
+  height: 32px;
+  place-items: center;
+  border: 1px solid rgba(245, 239, 255, 0.32);
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.68);
+  color: #f5efff;
+  font-size: 13px;
+  line-height: 1;
+  text-indent: 2px;
+  backdrop-filter: blur(8px);
+}
+
+.gallery-viewer {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  max-height: none;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  box-sizing: border-box;
+  margin: 0;
+  border: 0;
+  padding-right: 0;
+  padding-left: 0;
+  padding-top: env(safe-area-inset-top);
+  padding-bottom: env(safe-area-inset-bottom);
+  background: #08070c;
+  color: #f5efff;
+}
+
+.gallery-viewer[open] {
+  display: grid;
+}
+
+.gallery-viewer::backdrop {
+  background: #08070c;
+}
+
+.gallery-viewer-header {
+  display: flex;
+  min-height: 52px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 6px 16px;
+  border-bottom: 1px solid rgba(245, 239, 255, 0.12);
+  background: rgba(8, 7, 12, 0.92);
+}
+
+.gallery-viewer-close {
+  display: inline-flex;
+  min-width: 44px;
+  min-height: 44px;
+  align-items: center;
+  gap: 7px;
+  border: 0;
+  padding: 0 4px;
+  background: transparent;
+  color: #f5efff;
+  font-family: var(--font-utility);
+  font-size: var(--text-data);
+}
+
+.gallery-viewer-close > span:first-child {
+  font-family: var(--font-body);
+  font-size: 24px;
+  font-weight: 300;
+  line-height: 1;
+}
+
+.gallery-viewer-origin {
+  min-width: 0;
+  text-align: right;
+}
+
+.gallery-viewer-origin h1,
+.gallery-viewer-origin span {
+  display: block;
+  overflow: hidden;
+  margin: 0;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.gallery-viewer-origin h1 {
+  font-size: var(--text-body-lg);
+  font-weight: 700;
+}
+
+.gallery-viewer-origin span {
+  color: rgba(245, 239, 255, 0.68);
+  font-family: var(--font-utility);
+  font-size: var(--text-edge-code);
+}
+
+.gallery-viewer-stage {
+  position: relative;
+  min-height: 0;
+  overflow: hidden;
+  background: #000;
+}
+
+.gallery-viewer-media,
+.gallery-viewer-placeholder {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.gallery-viewer-placeholder {
+  filter: brightness(0.55);
+}
+
+.gallery-viewer-loading,
+.gallery-viewer-error {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-content: center;
+  gap: 12px;
+  padding: 24px;
+  background: rgba(0, 0, 0, 0.32);
+  color: rgba(245, 239, 255, 0.78);
+  font-family: var(--font-utility);
+  font-size: var(--text-data);
+  text-align: center;
+}
+
+.gallery-viewer-error {
+  background: rgba(0, 0, 0, 0.64);
+}
+
+.gallery-viewer-error button {
+  min-height: 44px;
+  border: 1px solid rgba(245, 239, 255, 0.4);
+  border-radius: var(--radius-control);
+  padding: 8px 14px;
+  background: rgba(245, 239, 255, 0.08);
+  color: #f5efff;
+}
+
+.gallery-viewer-details {
+  display: grid;
+  gap: 14px;
+  padding: 14px 16px 16px;
+  border-top: 1px solid rgba(245, 239, 255, 0.12);
+  background: #12101d;
+}
+
+.gallery-viewer-prompt > span {
+  color: rgba(245, 239, 255, 0.62);
+  font-family: var(--font-utility);
+  font-size: var(--text-edge-code);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.gallery-viewer-prompt p {
+  display: -webkit-box;
+  overflow: hidden;
+  margin: 5px 0 0;
+  color: #f5efff;
+  font-size: var(--text-body-lg);
+  line-height: 1.4;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+}
+
+.gallery-viewer-prompt .gallery-viewer-reuse-error {
+  display: block;
+  margin-top: 8px;
+  color: #ffb4ab;
+  font-family: var(--font-utility);
+  font-size: var(--text-data);
+}
+
+.gallery-viewer-reuse {
+  flex: none;
+}
+
+@media (min-width: 700px) and (min-height: 700px) {
+  .gallery-viewer-details {
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: end;
+  }
+
+  .gallery-viewer-reuse {
+    width: auto;
+    min-width: 220px;
+  }
 }
 
 .gallery-more {

--- a/desktop/src/mobile/mobile.css.test.ts
+++ b/desktop/src/mobile/mobile.css.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const css = readFileSync("src/mobile/mobile.css", "utf8");
+
+describe("mobile editable controls", () => {
+  it("keeps every editable control at the iOS no-focus-zoom size", () => {
+    const editables = css.match(
+      /input,\s*textarea,\s*select,\s*\[contenteditable="true"\]\s*\{([^}]*)\}/s,
+    );
+
+    expect(editables?.[1]).toMatch(/font-size:\s*16px\s*;/);
+  });
+});

--- a/desktop/src/mobile/reuse.test.ts
+++ b/desktop/src/mobile/reuse.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import type { ModelEntry, OutputMetadata } from "../lib/api/types";
+import { buildRequest, newGenerateForm } from "../lib/generateForm";
+import { applyMobileGalleryMetadata } from "./reuse";
+
+const model: ModelEntry = {
+  name: "ltx2:q8",
+  family: "ltx2",
+  size_gb: 20,
+  is_loaded: false,
+  hf_repo: "example/ltx2",
+  default_steps: 30,
+  default_guidance: 3,
+  default_width: 768,
+  default_height: 512,
+  description: "Video model",
+  downloaded: true,
+};
+
+const metadata: OutputMetadata = {
+  prompt: "a ship crossing violet lightning",
+  original_prompt: "a ship",
+  negative_prompt: "calm water",
+  model: model.name,
+  seed: 77,
+  steps: 28,
+  guidance: 4.25,
+  width: 1536,
+  height: 1024,
+  generation_width: 768,
+  generation_height: 512,
+  output_format: "mp4",
+  scheduler: "ddim",
+  cfg_plus: true,
+  loras: [{ path: "hidden.safetensors", scale: 0.8 }],
+  upscale_model: "hidden-upscaler",
+  enable_audio: true,
+  frames: 121,
+  fps: 30,
+  pipeline: "two-stage-hq",
+  spatial_upscale: "x2",
+  temporal_upscale: "x2",
+};
+
+describe("applyMobileGalleryMetadata", () => {
+  it("restores visible prompt controls without retaining invisible advanced settings", () => {
+    const form = newGenerateForm();
+    const result = applyMobileGalleryMetadata(form, metadata, [model]);
+
+    expect(result).toEqual({ modelName: model.name, substitutedModel: false });
+
+    expect(form).toMatchObject({
+      prompt: metadata.prompt,
+      negativePrompt: metadata.negative_prompt,
+      model: model.name,
+      width: 768,
+      height: 512,
+      steps: 28,
+      guidance: 4.25,
+      seed: "77",
+      outputFormat: "mp4",
+      frames: 121,
+      fps: 30,
+      scheduler: "default",
+      cfgPlus: false,
+      loras: [],
+      upscaleModel: "",
+      enableAudio: false,
+      pipeline: null,
+      spatialUpscale: null,
+      temporalUpscale: null,
+    });
+
+    expect(buildRequest(form)).not.toMatchObject({
+      loras: expect.anything(),
+      enable_audio: expect.anything(),
+      pipeline: expect.anything(),
+      spatial_upscale: expect.anything(),
+      temporal_upscale: expect.anything(),
+    });
+  });
+
+  it("keeps generation valid when the print's original model is no longer installed", () => {
+    const replacement = {
+      ...model,
+      name: "flux:replacement",
+      family: "flux",
+      default_width: 1024,
+      default_height: 1024,
+    };
+    const form = newGenerateForm();
+
+    const result = applyMobileGalleryMetadata(form, metadata, [replacement]);
+
+    expect(result).toEqual({ modelName: replacement.name, substitutedModel: true });
+    expect(form.model).toBe(replacement.name);
+    expect(form.family).toBe(replacement.family);
+    expect(form.outputFormat).toBe("png");
+    expect(buildRequest(form).model).toBe(replacement.name);
+  });
+});

--- a/desktop/src/mobile/reuse.ts
+++ b/desktop/src/mobile/reuse.ts
@@ -1,0 +1,57 @@
+import type { ModelEntry, OutputMetadata } from "../lib/api/types";
+import { defaultOutputFormat, outputFormatsForFamily } from "../lib/capabilities";
+import { applyMetadataToForm, type GenerateForm } from "../lib/generateForm";
+
+export interface MobileGalleryReuseResult {
+  modelName: string;
+  substitutedModel: boolean;
+}
+
+/**
+ * Restore the gallery fields the iPhone composer actually exposes. Start from
+ * the desktop's canonical metadata mapper so model defaults and legacy fields
+ * stay consistent, then neutralize advanced controls that mobile cannot show
+ * or clear yet. A reused prompt must never submit invisible settings.
+ */
+export function applyMobileGalleryMetadata(
+  form: GenerateForm,
+  metadata: OutputMetadata,
+  models: ModelEntry[],
+): MobileGalleryReuseResult {
+  const originalModelInstalled = models.some((model) => model.name === metadata.model);
+  const fallbackModel = models.find((model) => model.name === form.model) ?? models[0];
+  const mobileMetadata =
+    originalModelInstalled || !fallbackModel
+      ? metadata
+      : { ...metadata, model: fallbackModel.name };
+
+  applyMetadataToForm(form, mobileMetadata, models);
+
+  // A substituted model can belong to a different family. Keep the original
+  // canvas/settings where they remain portable, but never leave an impossible
+  // output format selected (for example MP4 on an image-only model).
+  if (!outputFormatsForFamily(form.family).includes(form.outputFormat)) {
+    form.outputFormat = defaultOutputFormat(form.family);
+  }
+
+  form.originalPrompt = null;
+  form.scheduler = "default";
+  form.cfgPlus = false;
+  form.batchSize = 1;
+  form.upscaleModel = "";
+  form.strength = 0.75;
+  form.controlModel = "";
+  form.controlScale = 1;
+  form.loras = [];
+  form.enableAudio = false;
+  form.pipeline = null;
+  form.retakeRange = null;
+  form.spatialUpscale = null;
+  form.temporalUpscale = null;
+  form.cameraControl = null;
+
+  return {
+    modelName: form.model,
+    substitutedModel: !originalModelInstalled && !!fallbackModel,
+  };
+}

--- a/scripts/ios.sh
+++ b/scripts/ios.sh
@@ -46,11 +46,14 @@ case "$ACTION" in
     ;;
   simulator)
     prepare_build
-    cargo tauri ios build --debug --target aarch64-sim --no-sign --ci "$@"
+    # Keep Tauri/Xcode's local simulator signature. A --no-sign build is only
+    # linker-signed and cannot read or write the iOS Keychain.
+    cargo tauri ios build --debug --target aarch64-sim --ci "$@"
     test -x gen/apple/build/arm64-sim/Mold.app/Mold || {
       echo "iOS simulator build did not produce Mold.app" >&2
       exit 1
     }
+    codesign --verify --deep --strict gen/apple/build/arm64-sim/Mold.app
     ;;
   build)
     prepare_build


### PR DESCRIPTION
## Summary

- open iPhone gallery images and videos in a first-class full-screen viewer with native video playback
- make Use as prompt explicit and restore mobile-visible generation settings safely across remote hosts
- prevent iOS input focus zoom without disabling accessibility zoom
- add short-lived, read-only authenticated media tickets so WebKit can seek remote videos without exposing API keys
- keep simulator bundles signed for Keychain-backed host UAT

## Validation

- 1,128 frontend tests pass
- Rust fmt and mold-ai-server clippy with warnings denied pass
- mobile TypeScript check, production bundle, Prettier, release assets, icon checks, and packaged frontend entry test pass
- clean scripts/ios.sh simulator build passes and restores the Keychain API key after reinstall
- iPhone 17 Pro simulator UAT: contained full-screen image, native MP4 playback, prompt reuse, cross-host model fallback, and focused controls without viewport zoom
- authenticated Range request UAT returns 206 with private, no-store caching

## Release

- ready for review
- merge triggers the same successful-main nightly cadence as desktop, followed by TestFlight processing and internal tester verification