### PR TITLE
feat(ios): add host catalog and resolution parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,16 +101,20 @@ live in the desktop guide.
 
 ## iPhone app
 
-Mold for iPhone is a remote-only Tauri companion focused on Generate and
-Gallery. Add a host by LAN discovery, IP address, hostname, or Tailscale
-MagicDNS name; generation and media remain on that remote Mold server. The app
-uses the same HTTP, SSE, model defaults, and generation request contract as the
-desktop app. Prompts can be submitted while other work is queued or developing,
-with independent status and cancellation for every job. Saved results stream
-from the host instead of crossing the iPhone WebView as encoded media. Internal
-TestFlight builds are produced from relevant `main` changes, with release checks
-that verify Tauri's embedded `index.html` and the opaque Mold-branded Apple icon
-catalog before upload.
+Mold for iPhone is a remote-only Tauri companion with first-class Generate,
+Gallery, Catalog, and Hosts views. Add a host by LAN discovery, IP address,
+hostname, or Tailscale MagicDNS name; generation, model management, and media
+remain on that remote Mold server. Host details expose live resources, queue,
+downloads, and installed models, while Catalog can browse one host and send a
+pull to another without silently changing the host selected for generation.
+The app uses the same HTTP, SSE, model defaults, resolution presets, and
+generation request contract as the desktop app. Prompts can be submitted while
+other work is queued or developing, with independent status and cancellation
+for every job. Saved results stream from the host instead of crossing the
+iPhone WebView as encoded media; full-screen images swipe between prints and
+videos retain native playback controls. Internal TestFlight builds are produced
+from relevant `main` changes, with release checks that verify Tauri's embedded
+`index.html` and the opaque Mold-branded Apple icon catalog before upload.
 
 On macOS, `nix develop` exposes `ios-dev`, `ios-run`, `ios-check`, and
 `ios-build`. Xcode, CocoaPods, and Apple signing are required for device and App

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -78,10 +78,12 @@ const print: GalleryImage = {
 let wrapper: VueWrapper | null = null;
 let objectUrlSequence = 0;
 const openStreams: Array<{
+  path: string;
   options: {
     body: Record<string, unknown>;
     headers?: Record<string, string>;
     signal: AbortSignal;
+    onOpen?: () => void;
     onEvent: (event: string, data: string) => void;
   };
   resolve: () => void;
@@ -134,16 +136,17 @@ beforeEach(() => {
   openStreams.length = 0;
   sseStream.mockReset().mockImplementation(
     (
-      _path: string,
+      path: string,
       options: {
         body: Record<string, unknown>;
         headers?: Record<string, string>;
         signal: AbortSignal;
+        onOpen?: () => void;
         onEvent: (event: string, data: string) => void;
       },
     ) =>
       new Promise<void>((resolve) => {
-        openStreams.push({ options, resolve });
+        openStreams.push({ path, options, resolve });
       }),
   );
   streamableMediaUrl.mockReset().mockResolvedValue("https://studio/media/full-video");
@@ -165,6 +168,41 @@ describe("MobileApp generation queue", () => {
     await wrapper?.get("[data-test='mobile-develop-button']").trigger("click");
     await flushPromises();
   }
+
+  it("applies model defaults to the resolution picker and snapshots those dimensions", async () => {
+    const imageModel: ModelEntry = {
+      ...model,
+      name: "flux:image",
+      family: "flux",
+      default_width: 1024,
+      default_height: 1024,
+      default_steps: 24,
+      default_guidance: 3.5,
+    };
+    apiJsonTo.mockImplementation((_target: unknown, path: string) => {
+      if (path === "/api/status") return Promise.resolve(status);
+      if (path === "/api/models") return Promise.resolve([imageModel, model]);
+      if (path === "/api/gallery") return Promise.resolve([]);
+      return Promise.reject(new Error(`Unexpected API path: ${path}`));
+    });
+
+    wrapper = mountMobileApp();
+    await flushPromises();
+    expect(wrapper.get("[data-test='mobile-resolution-summary']").text()).toContain("1024 × 1024");
+
+    await fieldControl("Model").setValue(model.name);
+    await flushPromises();
+    expect(wrapper.get("[data-test='mobile-resolution-summary']").text()).toContain("768 × 512");
+    expect(wrapper.get("[data-test='mobile-resolution-summary']").text()).toContain("Landscape");
+
+    await submitPrompt("use the video defaults");
+    expect(openStreams).toHaveLength(1);
+    expect(openStreams[0]?.options.body).toMatchObject({
+      model: model.name,
+      width: 768,
+      height: 512,
+    });
+  });
 
   it("snapshots multiple prompts, shows their live queue, and cancels only one", async () => {
     wrapper = mountMobileApp();
@@ -846,9 +884,7 @@ describe("MobileApp gallery", () => {
     await tile.trigger("click");
     await flushPromises();
 
-    expect(wrapper.get("[data-test='mobile-tab-gallery']").attributes("aria-selected")).toBe(
-      "true",
-    );
+    expect(wrapper.get("[data-test='mobile-tab-gallery']").attributes("aria-current")).toBe("page");
     expect(wrapper.find("[data-test='gallery-viewer-video']").exists()).toBe(true);
     expect(streamableMediaUrl).toHaveBeenCalledWith("/api/gallery/image/storm%20clip.mp4", {
       target,
@@ -858,9 +894,7 @@ describe("MobileApp gallery", () => {
 
     await wrapper.get("[data-test='gallery-viewer-close']").trigger("click");
     expect(wrapper.find("[data-test='gallery-viewer']").exists()).toBe(false);
-    expect(wrapper.get("[data-test='mobile-tab-gallery']").attributes("aria-selected")).toBe(
-      "true",
-    );
+    expect(wrapper.get("[data-test='mobile-tab-gallery']").attributes("aria-current")).toBe("page");
 
     await wrapper.get("[data-test='gallery-item']").trigger("click");
     await flushPromises();
@@ -868,13 +902,12 @@ describe("MobileApp gallery", () => {
     await flushPromises();
 
     expect(wrapper.find("[data-test='gallery-viewer']").exists()).toBe(false);
-    expect(wrapper.get("[data-test='mobile-tab-generate']").attributes("aria-selected")).toBe(
-      "true",
+    expect(wrapper.get("[data-test='mobile-tab-generate']").attributes("aria-current")).toBe(
+      "page",
     );
     expect(wrapper.get("#mobile-prompt").element).toHaveProperty("value", print.metadata.prompt);
     expect(fieldControl("Negative prompt").element).toHaveProperty("value", "calm water");
-    expect(fieldControl("Width").element).toHaveProperty("value", "768");
-    expect(fieldControl("Height").element).toHaveProperty("value", "512");
+    expect(wrapper.get("[data-test='mobile-resolution-summary']").text()).toContain("768 × 512");
     expect(fieldControl("Format").element).toHaveProperty("value", "mp4");
     expect(fieldControl("Frames").element).toHaveProperty("value", "121");
     expect(fieldControl("FPS").element).toHaveProperty("value", "30");
@@ -925,9 +958,7 @@ describe("MobileApp gallery", () => {
 
     expect(wrapper.find("[data-test='gallery-viewer']").exists()).toBe(true);
     expect(wrapper.get("[role='alert']").text()).toContain("Couldn’t load models from Remote");
-    expect(wrapper.get("[data-test='mobile-tab-gallery']").attributes("aria-selected")).toBe(
-      "true",
-    );
+    expect(wrapper.get("[data-test='mobile-tab-gallery']").attributes("aria-current")).toBe("page");
   });
 
   it("reloads model ownership after removing the active host before reuse", async () => {
@@ -991,7 +1022,11 @@ describe("MobileApp gallery", () => {
       .findAll(".host-row")
       .find((row) => row.find(".host-name").text() === "Studio");
     if (!studioRow) throw new Error("Missing Studio host row");
-    await studioRow.get("button.danger-button").trigger("click");
+    await studioRow.get("[data-test='mobile-host-row']").trigger("click");
+    const forget = wrapper.get("[data-test='host-detail-forget']");
+    await forget.trigger("click");
+    expect(forget.text()).toContain("Forget Studio?");
+    await forget.trigger("click");
     await vi.waitFor(() => expect(apiJsonTo).toHaveBeenCalledWith(remoteTarget, "/api/models"));
 
     await wrapper.get("[data-test='mobile-tab-gallery']").trigger("click");
@@ -1007,5 +1042,172 @@ describe("MobileApp gallery", () => {
       .findAll("button")
       .find((button) => button.text() === "Develop print");
     expect(developButton?.attributes("disabled")).toBeUndefined();
+  });
+});
+
+describe("MobileApp host and catalog coordination", () => {
+  const remoteTarget = { baseUrl: "http://render.tailnet.ts.net:7680", apiKey: "secret" };
+
+  function installTwoHosts(): void {
+    localStorage.setItem(
+      "mold.mobile.hosts.v1",
+      JSON.stringify([
+        {
+          id: "studio-id",
+          name: "Studio",
+          baseUrl: target.baseUrl,
+          hostname: "studio",
+          version: "0.18.0",
+          online: false,
+        },
+        {
+          id: "render-id",
+          name: "Render Box",
+          baseUrl: remoteTarget.baseUrl,
+          hostname: "render",
+          version: "0.18.0",
+          online: false,
+        },
+      ]),
+    );
+  }
+
+  it("keeps newer host probe results and aborts superseded and unmounted probes", async () => {
+    vi.useFakeTimers();
+    try {
+      installTwoHosts();
+      const remoteProbes: Array<{
+        resolve: (value: ServerStatus) => void;
+        reject: (reason: Error) => void;
+        signal: AbortSignal | undefined;
+      }> = [];
+      apiJsonTo.mockImplementation(
+        (requestTarget: unknown, path: string, init?: { signal?: AbortSignal }) => {
+          const baseUrl = (requestTarget as { baseUrl: string }).baseUrl;
+          if (path === "/api/models") return Promise.resolve([model]);
+          if (path === "/api/status" && baseUrl === target.baseUrl) return Promise.resolve(status);
+          if (path === "/api/status") {
+            return new Promise<ServerStatus>((resolve, reject) => {
+              remoteProbes.push({ resolve, reject, signal: init?.signal });
+            });
+          }
+          return Promise.reject(new Error(`Unexpected API path: ${path}`));
+        },
+      );
+
+      wrapper = mountMobileApp();
+      await flushPromises();
+      expect(remoteProbes).toHaveLength(1);
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(remoteProbes).toHaveLength(2);
+      expect(remoteProbes[0]?.signal?.aborted).toBe(true);
+
+      remoteProbes[1]?.resolve({ ...status, version: "0.19.0", hostname: "render" });
+      await flushPromises();
+      remoteProbes[0]?.reject(new Error("stale timeout"));
+      await flushPromises();
+
+      await wrapper.get("[data-test='mobile-tab-hosts']").trigger("click");
+      const remoteRow = wrapper
+        .findAll(".host-row")
+        .find((row) => row.find(".host-name").text() === "Render Box");
+      expect(remoteRow?.text()).toContain("v0.19.0");
+      expect(remoteRow?.text()).not.toContain("offline");
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(remoteProbes).toHaveLength(3);
+      const unmountedSignal = remoteProbes[2]?.signal;
+      wrapper.unmount();
+      wrapper = null;
+      expect(unmountedSignal?.aborted).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("opens Catalog on the viewed host without changing the generation host", async () => {
+    installTwoHosts();
+    apiJsonTo.mockImplementation((requestTarget: unknown, path: string) => {
+      const baseUrl = (requestTarget as { baseUrl: string }).baseUrl;
+      if (path === "/api/status") {
+        return Promise.resolve({
+          ...status,
+          hostname: baseUrl === remoteTarget.baseUrl ? "render" : "studio",
+        });
+      }
+      if (path === "/api/models") return Promise.resolve([model]);
+      if (path === "/api/catalog/families") return Promise.resolve({ families: [] });
+      if (path.startsWith("/api/catalog/search")) return Promise.resolve({ entries: [] });
+      if (path === "/api/queue") return Promise.resolve({ entries: [] });
+      return Promise.reject(new Error(`Unexpected API path: ${path}`));
+    });
+    apiFetchTo.mockImplementation((_target: unknown, path: string) => {
+      if (path === "/api/models") {
+        return Promise.resolve({ json: () => Promise.resolve([model]) } as Response);
+      }
+      return Promise.resolve({ blob: () => Promise.resolve(new Blob()) } as Response);
+    });
+
+    wrapper = mountMobileApp();
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-tab-hosts']").trigger("click");
+    const remoteRow = wrapper
+      .findAll(".host-row")
+      .find((row) => row.find(".host-name").text() === "Render Box");
+    if (!remoteRow) throw new Error("Missing Render Box host row");
+    await remoteRow.get("[data-test='mobile-host-row']").trigger("click");
+    await flushPromises();
+    await wrapper.get("[data-test='host-detail-catalog']").trigger("click");
+    await flushPromises();
+
+    expect(wrapper.get("select[aria-label='Catalog host']").element).toHaveProperty(
+      "value",
+      "render-id",
+    );
+    expect(wrapper.get(".mobile-header .host-chip").text()).toBe("Studio");
+    expect(wrapper.get("[data-test='mobile-tab-catalog']").attributes("aria-current")).toBe("page");
+  });
+
+  it("keeps the catalog download stream alive off-tab and refreshes Generate models", async () => {
+    const pulledModel = { ...model, name: "ltx2:new-download" };
+    let downloadFinished = false;
+    apiJsonTo.mockImplementation((_target: unknown, path: string) => {
+      if (path === "/api/status") return Promise.resolve(status);
+      if (path === "/api/models") {
+        return Promise.resolve(downloadFinished ? [model, pulledModel] : [model]);
+      }
+      if (path === "/api/catalog/families") return Promise.resolve({ families: [] });
+      if (path.startsWith("/api/catalog/search")) return Promise.resolve({ entries: [] });
+      return Promise.reject(new Error(`Unexpected API path: ${path}`));
+    });
+    apiFetchTo.mockImplementation((_target: unknown, path: string) => {
+      if (path === "/api/models") {
+        return Promise.resolve({ json: () => Promise.resolve([model]) } as Response);
+      }
+      return Promise.resolve({ blob: () => Promise.resolve(new Blob()) } as Response);
+    });
+
+    wrapper = mountMobileApp();
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-tab-catalog']").trigger("click");
+    await flushPromises();
+    const downloadStream = openStreams.find((stream) => stream.path === "/api/downloads/stream");
+    if (!downloadStream) throw new Error("Catalog download stream did not open");
+    downloadStream.options.onOpen?.();
+
+    await wrapper.get("[data-test='mobile-tab-generate']").trigger("click");
+    expect(downloadStream.options.signal.aborted).toBe(false);
+    downloadFinished = true;
+    downloadStream.options.onEvent(
+      "message",
+      JSON.stringify({ type: "job_done", id: "download-1", model: pulledModel.name }),
+    );
+    await flushPromises();
+
+    const options = fieldControl("Model")
+      .findAll("option")
+      .map((option) => option.text());
+    expect(options).toContain(pulledModel.name);
   });
 });

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -18,21 +18,14 @@ import {
   useGenerationStore,
   type Job,
 } from "../stores/generation";
-import { normalizeRemoteAddress, remoteHostId } from "./hosts";
+import { mobileHostTarget, normalizeRemoteAddress, remoteHostId, type MobileHost } from "./hosts";
 import { applyMobileGalleryMetadata } from "./reuse";
+import MobileCatalogView from "./MobileCatalogView.vue";
 import MobileGalleryViewer from "./MobileGalleryViewer.vue";
+import MobileHostDetail from "./MobileHostDetail.vue";
+import MobileResolutionPicker from "./MobileResolutionPicker.vue";
 
-type Tab = "generate" | "gallery" | "hosts";
-
-interface SavedHost {
-  id: string;
-  name: string;
-  baseUrl: string;
-  apiKey: string;
-  hostname: string | undefined;
-  version: string | undefined;
-  online: boolean;
-}
+type Tab = "generate" | "gallery" | "catalog" | "hosts";
 
 interface DiscoveredHost {
   name: string;
@@ -55,9 +48,12 @@ interface PendingGalleryPrint extends GalleryImage {
 
 const STORAGE_KEY = "mold.mobile.hosts.v1";
 const SELECTED_KEY = "mold.mobile.selected-host.v1";
+const HOST_PROBE_TIMEOUT_MS = 9_000;
 const tab = ref<Tab>("generate");
-const hosts = ref<SavedHost[]>(loadHosts());
+const hosts = ref<MobileHost[]>(loadHosts());
 const selectedHostId = ref(localStorage.getItem(SELECTED_KEY) ?? hosts.value[0]?.id ?? "");
+const catalogHostId = ref(selectedHostId.value || hosts.value[0]?.id || "");
+const hostDetailId = ref("");
 const hostInput = reactive({ name: "", address: "", apiKey: "" });
 const discovered = ref<DiscoveredHost[]>([]);
 const discovering = ref(false);
@@ -88,12 +84,26 @@ let galleryRefreshTask: Promise<void> | null = null;
 let galleryOperationTail: Promise<void> = Promise.resolve();
 let resultMediaRecoveryClientId: number | null = null;
 let resultMediaRecoveryAttempts = 0;
+let hostProbeTimer: ReturnType<typeof setInterval> | null = null;
+let hostProbeEpoch = 0;
+const hostProbes = new Map<
+  string,
+  { epoch: number; controller: AbortController; timeout: ReturnType<typeof setTimeout> }
+>();
 const generation = useGenerationStore();
 
 const selectedHost = computed(() => hosts.value.find((host) => host.id === selectedHostId.value));
+const hostDetail = computed(() => hosts.value.find((host) => host.id === hostDetailId.value));
+const selectedPrintIndex = computed(() => {
+  const selected = selectedPrint.value;
+  if (!selected) return -1;
+  return gallery.value.findIndex(
+    (print) => print.hostId === selected.hostId && print.filename === selected.filename,
+  );
+});
 const selectedTarget = computed<ApiTarget | null>(() => {
   const host = selectedHost.value;
-  return host ? { baseUrl: host.baseUrl, apiKey: host.apiKey || null } : null;
+  return host ? mobileHostTarget(host) : null;
 });
 const outputFormats = computed(() => outputFormatsForFamily(form.family));
 const selectedModelAvailable = computed(
@@ -152,9 +162,9 @@ const generationStatus = computed(() => {
   }
 });
 
-function loadHosts(): SavedHost[] {
+function loadHosts(): MobileHost[] {
   try {
-    const raw = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "[]") as SavedHost[];
+    const raw = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "[]") as MobileHost[];
     return raw.map((host) => ({ ...host, apiKey: "", online: false }));
   } catch {
     return [];
@@ -183,15 +193,25 @@ async function connectHost(address?: string, discoveredName?: string): Promise<v
     const baseUrl = normalizeRemoteAddress(address ?? hostInput.address);
     const target = { baseUrl, apiKey: hostInput.apiKey.trim() || null };
     const status = await apiJsonTo<ServerStatus>(target, "/api/status");
-    const id = status.instance_id || remoteHostId(baseUrl);
-    const existing = hosts.value.find((host) => host.id === id || host.baseUrl === baseUrl);
-    const saved: SavedHost = {
+    const instanceId = status.instance_id ?? undefined;
+    const existing = hosts.value.find(
+      (host) =>
+        host.baseUrl === baseUrl ||
+        (instanceId &&
+          (host.instanceId === instanceId || host.id === instanceId) &&
+          (!host.hostname || !status.hostname || host.hostname === status.hostname)),
+    );
+    // URL identity keeps two machines that copied the same MOLD_HOME distinct;
+    // a compatible saved alias keeps its existing keychain id.
+    const id = existing?.id ?? remoteHostId(baseUrl);
+    const saved: MobileHost = {
       id,
       name: hostInput.name.trim() || discoveredName || status.hostname || new URL(baseUrl).hostname,
       baseUrl,
       apiKey: hostInput.apiKey.trim(),
       hostname: status.hostname ?? undefined,
       version: status.version,
+      instanceId,
       online: true,
     };
     if (existing) Object.assign(existing, saved);
@@ -203,6 +223,7 @@ async function connectHost(address?: string, discoveredName?: string): Promise<v
     }
     persistHosts();
     selectedHostId.value = saved.id;
+    catalogHostId.value = saved.id;
     tab.value = "generate";
     hostInput.name = "";
     hostInput.address = "";
@@ -230,8 +251,67 @@ async function selectHost(id: string): Promise<void> {
   await refreshModels();
 }
 
+function showHostDetail(id: string): void {
+  hostDetailId.value = id;
+}
+
+function renameHost(payload: { id: string; name: string }): void {
+  const host = hosts.value.find((candidate) => candidate.id === payload.id);
+  if (!host) return;
+  host.name = payload.name;
+  persistHosts();
+}
+
+function updateHostStatus(payload: { id: string; status: ServerStatus | null }): void {
+  const host = hosts.value.find((candidate) => candidate.id === payload.id);
+  if (!host) return;
+  host.online = payload.status !== null;
+  if (payload.status) {
+    host.version = payload.status.version;
+    host.hostname = payload.status.hostname ?? undefined;
+    host.instanceId = payload.status.instance_id ?? host.instanceId;
+  }
+}
+
+function cancelHostProbe(id: string): void {
+  const probe = hostProbes.get(id);
+  if (!probe) return;
+  probe.controller.abort();
+  clearTimeout(probe.timeout);
+  hostProbes.delete(id);
+}
+
+async function probeHost(host: MobileHost): Promise<void> {
+  cancelHostProbe(host.id);
+  const controller = new AbortController();
+  const epoch = ++hostProbeEpoch;
+  const timeout = setTimeout(() => controller.abort(), HOST_PROBE_TIMEOUT_MS);
+  const probe = { epoch, controller, timeout };
+  hostProbes.set(host.id, probe);
+  try {
+    const status = await apiJsonTo<ServerStatus>(mobileHostTarget(host), "/api/status", {
+      signal: controller.signal,
+    });
+    if (hostProbes.get(host.id)?.epoch !== epoch) return;
+    updateHostStatus({ id: host.id, status });
+  } catch {
+    if (hostProbes.get(host.id)?.epoch !== epoch) return;
+    updateHostStatus({ id: host.id, status: null });
+  } finally {
+    if (hostProbes.get(host.id)?.epoch === epoch) hostProbes.delete(host.id);
+    clearTimeout(timeout);
+  }
+}
+
+function probeHosts(): void {
+  for (const host of hosts.value) void probeHost(host);
+}
+
 function removeHost(id: string): void {
+  cancelHostProbe(id);
   const removedSelectedHost = selectedHostId.value === id;
+  const removedCatalogHost = catalogHostId.value === id;
+  if (hostDetailId.value === id) hostDetailId.value = "";
   hosts.value = hosts.value.filter((host) => host.id !== id);
   if (removedSelectedHost) {
     selectedHostId.value = hosts.value[0]?.id ?? "";
@@ -239,8 +319,26 @@ function removeHost(id: string): void {
     modelsHostId.value = "";
     void refreshModels();
   }
+  if (removedCatalogHost) catalogHostId.value = hosts.value[0]?.id ?? "";
   persistHosts();
   void invoke("keychain_delete_api_key", { hostId: id });
+}
+
+function selectCatalogHost(id: string): void {
+  if (hosts.value.some((host) => host.id === id)) catalogHostId.value = id;
+}
+
+function openCatalog(id?: string): void {
+  if (id && hosts.value.some((host) => host.id === id)) catalogHostId.value = id;
+  else if (!hosts.value.some((host) => host.id === catalogHostId.value)) {
+    catalogHostId.value = selectedHostId.value || hosts.value[0]?.id || "";
+  }
+  hostDetailId.value = "";
+  tab.value = "catalog";
+}
+
+function catalogModelsChanged(hostId: string): void {
+  if (hostId === selectedHostId.value) void refreshModels();
 }
 
 async function refreshModels(): Promise<boolean> {
@@ -555,6 +653,13 @@ function openPrint(print: GalleryPrint): void {
   selectedPrint.value = print;
 }
 
+function navigateSelectedPrint(delta: -1 | 1): void {
+  const next = gallery.value[selectedPrintIndex.value + delta];
+  if (!next || reusingPrint.value) return;
+  reusePrintError.value = "";
+  selectedPrint.value = next;
+}
+
 function closePrint(): void {
   if (reusingPrint.value) return;
   reusePrintError.value = "";
@@ -583,6 +688,7 @@ watch(selectedHostId, (id) => {
 
 watch(tab, (next) => {
   if (next === "gallery") void refreshGallery();
+  if (next !== "hosts") hostDetailId.value = "";
 });
 
 watch(resultPreviewError, (error) => {
@@ -593,11 +699,25 @@ watch(resultPreviewError, (error) => {
 
 onMounted(async () => {
   await hydrateApiKeys();
-  if (selectedHost.value) await refreshModels();
-  else tab.value = "hosts";
+  // Start the cadence before awaiting individual tailnet hosts. One slow host
+  // must not prevent every other saved host from being probed on schedule.
+  hostProbeTimer = setInterval(probeHosts, 10_000);
+  if (selectedHost.value) {
+    await Promise.all([
+      refreshModels(),
+      ...hosts.value
+        .filter((host) => host.id !== selectedHostId.value)
+        .map((host) => probeHost(host)),
+    ]);
+  } else {
+    tab.value = "hosts";
+  }
 });
 
 onBeforeUnmount(() => {
+  if (hostProbeTimer) clearInterval(hostProbeTimer);
+  hostProbeTimer = null;
+  for (const id of [...hostProbes.keys()]) cancelHostProbe(id);
   generation.resetJobs();
   for (const url of objectUrls) URL.revokeObjectURL(url);
 });
@@ -655,19 +775,13 @@ onBeforeUnmount(() => {
             <span>Negative prompt</span>
             <input v-model="form.negativePrompt" class="control" placeholder="Optional" />
           </label>
+          <MobileResolutionPicker
+            v-model:width="form.width"
+            v-model:height="form.height"
+            :family="form.family"
+            :disabled="loadingModels"
+          />
           <div class="field-grid">
-            <label class="field"
-              ><span>Width</span
-              ><input v-model.number="form.width" class="control" type="number" inputmode="numeric"
-            /></label>
-            <label class="field"
-              ><span>Height</span
-              ><input
-                v-model.number="form.height"
-                class="control"
-                type="number"
-                inputmode="numeric"
-            /></label>
             <label class="field"
               ><span>Steps</span
               ><input v-model.number="form.steps" class="control" type="number" inputmode="numeric"
@@ -826,90 +940,124 @@ onBeforeUnmount(() => {
         </button>
       </template>
 
-      <template v-else>
-        <h1 class="section-title">Hosts</h1>
-        <p class="section-note">LAN discovery, Tailscale MagicDNS, or an address</p>
-        <button
-          class="secondary-button"
-          type="button"
-          :disabled="discovering"
-          @click="discoverHosts"
-        >
-          {{ discovering ? "Scanning…" : "Discover nearby" }}
-        </button>
-        <div v-for="host in discovered" :key="`${host.host}:${host.port}`" class="host-row">
-          <div class="host-row-head">
-            <div>
-              <div class="host-name">{{ host.name }}</div>
-              <div class="host-url">{{ host.host }}:{{ host.port }}</div>
+      <template v-else-if="tab === 'hosts'">
+        <MobileHostDetail
+          v-if="hostDetail"
+          :host="hostDetail"
+          :active="hostDetail.id === selectedHostId"
+          @back="hostDetailId = ''"
+          @select="selectHost"
+          @rename="renameHost"
+          @forget="removeHost"
+          @catalog="openCatalog"
+          @status="updateHostStatus"
+        />
+        <template v-else>
+          <h1 class="section-title">Hosts</h1>
+          <p class="section-note">LAN discovery, Tailscale MagicDNS, or an address</p>
+          <button
+            class="secondary-button"
+            type="button"
+            :disabled="discovering"
+            @click="discoverHosts"
+          >
+            {{ discovering ? "Scanning…" : "Discover nearby" }}
+          </button>
+          <div v-for="host in discovered" :key="`${host.host}:${host.port}`" class="host-row">
+            <div class="host-row-head">
+              <div>
+                <div class="host-name">{{ host.name }}</div>
+                <div class="host-url">{{ host.host }}:{{ host.port }}</div>
+              </div>
+              <button
+                class="secondary-button"
+                type="button"
+                @click="connectHost(`${host.host}:${host.port}`, host.name)"
+              >
+                Connect
+              </button>
             </div>
-            <button
-              class="secondary-button"
-              type="button"
-              @click="connectHost(`${host.host}:${host.port}`, host.name)"
-            >
-              Connect
-            </button>
           </div>
-        </div>
-        <form style="margin-top: 20px" @submit.prevent="connectHost()">
-          <label class="field"
-            ><span>Name</span
-            ><input
-              v-model="hostInput.name"
-              class="control"
-              placeholder="Studio Mac (optional)"
-              autocomplete="off"
-          /></label>
-          <label class="field"
-            ><span>Address or MagicDNS name</span
-            ><input
-              v-model="hostInput.address"
-              class="control"
-              placeholder="studio.tailnet.ts.net or 192.168.1.20"
-              autocapitalize="none"
-              autocomplete="url"
-              required
-          /></label>
-          <label class="field"
-            ><span>API key</span
-            ><input
-              v-model="hostInput.apiKey"
-              class="control"
-              type="password"
-              placeholder="If required"
-              autocomplete="off"
-          /></label>
-          <button class="primary-button" type="submit">Test and save</button>
-        </form>
-        <p v-if="hostError" class="status-line error-text">{{ hostError }}</p>
-        <div v-for="host in hosts" :key="host.id" class="host-row">
-          <div class="host-row-head">
-            <div>
-              <div class="host-name">{{ host.name }}</div>
-              <div class="host-url">{{ host.baseUrl }}</div>
+          <form style="margin-top: 20px" @submit.prevent="connectHost()">
+            <label class="field"
+              ><span>Name</span
+              ><input
+                v-model="hostInput.name"
+                class="control"
+                placeholder="Studio Mac (optional)"
+                autocomplete="off"
+            /></label>
+            <label class="field"
+              ><span>Address or MagicDNS name</span
+              ><input
+                v-model="hostInput.address"
+                class="control"
+                placeholder="studio.tailnet.ts.net or 192.168.1.20"
+                autocapitalize="none"
+                autocomplete="url"
+                required
+            /></label>
+            <label class="field"
+              ><span>API key</span
+              ><input
+                v-model="hostInput.apiKey"
+                class="control"
+                type="password"
+                placeholder="If required"
+                autocomplete="off"
+            /></label>
+            <button class="primary-button" type="submit">Test and save</button>
+          </form>
+          <p v-if="hostError" class="status-line error-text">{{ hostError }}</p>
+          <div v-for="host in hosts" :key="host.id" class="host-row">
+            <button
+              class="host-row-button"
+              type="button"
+              :aria-label="`View ${host.name}`"
+              data-test="mobile-host-row"
+              @click="showHostDetail(host.id)"
+            >
+              <span class="host-row-head">
+                <span>
+                  <span class="host-name">{{ host.name }}</span>
+                  <span class="host-url">{{ host.baseUrl }}</span>
+                </span>
+                <span class="host-row-state">
+                  <span class="status-dot" :class="host.online ? 'is-ready' : 'is-error'" />
+                  <span class="host-chip">{{
+                    host.online ? `v${host.version ?? ""}` : "offline"
+                  }}</span>
+                  <span aria-hidden="true">›</span>
+                </span>
+              </span>
+            </button>
+            <div class="row-actions">
+              <button
+                class="secondary-button"
+                type="button"
+                :disabled="host.id === selectedHostId"
+                @click="selectHost(host.id)"
+              >
+                {{ host.id === selectedHostId ? "Active" : "Use host" }}
+              </button>
             </div>
-            <span class="host-chip">{{ host.online ? `v${host.version ?? ""}` : "offline" }}</span>
           </div>
-          <div class="row-actions">
-            <button
-              class="secondary-button"
-              type="button"
-              :disabled="host.id === selectedHostId"
-              @click="selectHost(host.id)"
-            >
-              {{ host.id === selectedHostId ? "Active" : "Use host" }}</button
-            ><button class="danger-button" type="button" @click="removeHost(host.id)">
-              Remove
-            </button>
-          </div>
-        </div>
+        </template>
       </template>
+
+      <KeepAlive>
+        <MobileCatalogView
+          v-if="tab === 'catalog'"
+          :hosts="hosts"
+          :selected-host-id="catalogHostId"
+          @select-host="selectCatalogHost"
+          @models-changed="catalogModelsChanged"
+        />
+      </KeepAlive>
     </section>
 
     <MobileGalleryViewer
       v-if="selectedPrint"
-      :key="`${selectedPrint.hostId}:${selectedPrint.filename}`"
       :item="selectedPrint"
       :target="selectedPrint.target"
       :cache-key="selectedPrint.hostId"
@@ -918,15 +1066,21 @@ onBeforeUnmount(() => {
       :reusing="reusingPrint"
       :reuse-error="reusePrintError"
       :generation-announcement="generationAnnouncement"
+      :position="selectedPrintIndex + 1"
+      :total="gallery.length"
+      :has-previous="selectedPrintIndex > 0"
+      :has-next="selectedPrintIndex >= 0 && selectedPrintIndex < gallery.length - 1"
       @close="closePrint"
       @reuse="reuseSelectedPrint"
+      @previous="navigateSelectedPrint(-1)"
+      @next="navigateSelectedPrint(1)"
     />
 
     <nav class="mobile-tabs" aria-label="Primary">
       <button
         class="mobile-tab"
         type="button"
-        :aria-selected="tab === 'generate'"
+        :aria-current="tab === 'generate' ? 'page' : undefined"
         data-test="mobile-tab-generate"
         @click="tab = 'generate'"
       >
@@ -935,7 +1089,7 @@ onBeforeUnmount(() => {
       <button
         class="mobile-tab"
         type="button"
-        :aria-selected="tab === 'gallery'"
+        :aria-current="tab === 'gallery' ? 'page' : undefined"
         data-test="mobile-tab-gallery"
         @click="tab = 'gallery'"
       >
@@ -944,7 +1098,17 @@ onBeforeUnmount(() => {
       <button
         class="mobile-tab"
         type="button"
-        :aria-selected="tab === 'hosts'"
+        :aria-current="tab === 'catalog' ? 'page' : undefined"
+        data-test="mobile-tab-catalog"
+        @click="openCatalog()"
+      >
+        Catalog
+      </button>
+      <button
+        class="mobile-tab"
+        type="button"
+        :aria-current="tab === 'hosts' ? 'page' : undefined"
+        data-test="mobile-tab-hosts"
         @click="tab = 'hosts'"
       >
         Hosts

--- a/desktop/src/mobile/MobileCatalogView.test.ts
+++ b/desktop/src/mobile/MobileCatalogView.test.ts
@@ -1,4 +1,5 @@
 import { flushPromises, mount, type VueWrapper } from "@vue/test-utils";
+import { defineComponent, h, KeepAlive, nextTick, ref } from "vue";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   CatalogEntry,
@@ -361,6 +362,46 @@ describe("MobileCatalogView", () => {
     await flushPromises();
     expect(wrapper.get(".mobile-catalog").attributes()).not.toHaveProperty("inert");
     expect(document.activeElement).toBe(catalogCard!.get(".mobile-catalog-card-open").element);
+  });
+
+  it("suspends global dialog handling while the kept-alive catalog is off-tab", async () => {
+    const active = ref(true);
+    const OtherView = defineComponent({
+      setup: () => () => h("section", { "data-test": "other-view" }, "Other view"),
+    });
+    const Harness = defineComponent({
+      setup: () => () =>
+        h(KeepAlive, null, {
+          default: () =>
+            active.value
+              ? h(MobileCatalogView, { hosts: [studio, renderBox], selectedHostId: studio.id })
+              : h(OtherView),
+        }),
+    });
+
+    wrapper = mount(Harness, { attachTo: document.body });
+    await flushPromises();
+
+    const catalogCard = wrapper
+      .findAll("[data-test='mobile-catalog-card']")
+      .find((candidate) => candidate.text().includes("Catalog model"));
+    expect(catalogCard).toBeDefined();
+    await catalogCard!.get(".mobile-catalog-card-open").trigger("click");
+    await flushPromises();
+
+    const catalog = wrapper.get(".mobile-catalog").element as HTMLElement;
+    expect(catalog.hasAttribute("inert")).toBe(true);
+
+    active.value = false;
+    await nextTick();
+    expect(catalog.hasAttribute("inert")).toBe(false);
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+
+    active.value = true;
+    await nextTick();
+    await nextTick();
+    expect(document.querySelector("[data-test='mobile-catalog-detail']")).not.toBeNull();
+    expect(catalog.hasAttribute("inert")).toBe(true);
   });
 
   it("waits for the download stream to open before posting a pull", async () => {

--- a/desktop/src/mobile/MobileCatalogView.test.ts
+++ b/desktop/src/mobile/MobileCatalogView.test.ts
@@ -1,0 +1,638 @@
+import { flushPromises, mount, type VueWrapper } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  CatalogEntry,
+  CatalogSearchResponse,
+  DownloadEvent,
+  ModelEntry,
+} from "../lib/api/types";
+import type { ApiTarget } from "../lib/api/client";
+import type { MobileHost } from "./hosts";
+
+const {
+  apiFetchTo,
+  fetchCatalogDetail,
+  fetchCatalogFamilies,
+  fetchModelComponents,
+  loadModel,
+  removeModel,
+  searchCatalog,
+  sseStream,
+  startCatalogDownload,
+  unloadModel,
+  streams,
+} = vi.hoisted(() => ({
+  apiFetchTo: vi.fn(),
+  fetchCatalogDetail: vi.fn(),
+  fetchCatalogFamilies: vi.fn(),
+  fetchModelComponents: vi.fn(),
+  loadModel: vi.fn(),
+  removeModel: vi.fn(),
+  searchCatalog: vi.fn(),
+  sseStream: vi.fn(),
+  startCatalogDownload: vi.fn(),
+  unloadModel: vi.fn(),
+  streams: [] as Array<{
+    target: ApiTarget;
+    signal: AbortSignal;
+    onOpen?: () => void;
+    onOpenError?: (error: Error) => void;
+    onClose?: (error: Error | null) => void;
+    onEvent: (event: string, data: string) => void;
+  }>,
+}));
+
+vi.mock("../lib/api/client", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../lib/api/client")>()),
+  apiFetchTo,
+}));
+
+vi.mock("../lib/api/catalog", () => ({
+  fetchCatalogDetail,
+  fetchCatalogFamilies,
+  searchCatalog,
+  startCatalogDownload,
+}));
+
+vi.mock("../lib/api/models", () => ({
+  fetchModelComponents,
+  loadModel,
+  removeModel,
+  unloadModel,
+}));
+
+vi.mock("../lib/api/sse", () => ({ sseStream }));
+
+import MobileCatalogView from "./MobileCatalogView.vue";
+
+const studio: MobileHost = {
+  id: "studio-id",
+  name: "Studio",
+  baseUrl: "https://studio.tailnet.ts.net:7680",
+  apiKey: "studio-key",
+  hostname: "studio",
+  version: "0.18.0",
+  online: true,
+};
+
+const renderBox: MobileHost = {
+  id: "render-id",
+  name: "Render Box",
+  baseUrl: "https://render.tailnet.ts.net:7680",
+  apiKey: "render-key",
+  hostname: "render",
+  version: "0.18.0",
+  online: true,
+};
+
+const targets = {
+  studio: { baseUrl: studio.baseUrl, apiKey: studio.apiKey },
+  render: { baseUrl: renderBox.baseUrl, apiKey: renderBox.apiKey },
+};
+
+function model(
+  name: string,
+  family: string,
+  downloaded: boolean,
+  overrides: Partial<ModelEntry> = {},
+): ModelEntry {
+  return {
+    name,
+    family,
+    size_gb: 12,
+    is_loaded: false,
+    hf_repo: "mold/safe-model",
+    default_steps: 30,
+    default_guidance: 4,
+    default_width: 1024,
+    default_height: 1024,
+    description: "A test model",
+    downloaded,
+    ...overrides,
+  };
+}
+
+function entry(name: string, overrides: Partial<CatalogEntry> = {}): CatalogEntry {
+  return {
+    id: `hf:${name}`,
+    source: "hf",
+    source_id: `example/${name}`,
+    name,
+    family: "flux",
+    kind: "checkpoint",
+    nsfw: false,
+    installed: false,
+    size_bytes: 8_000_000_000,
+    thumbnail_url: null,
+    ...overrides,
+  };
+}
+
+function searchResponse(entries: CatalogEntry[]): CatalogSearchResponse {
+  return { entries, page: 1, page_size: 24, total: entries.length };
+}
+
+function jsonResponse<T>(value: T): Response {
+  return { json: () => Promise.resolve(value) } as Response;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+let wrapper: VueWrapper | null = null;
+
+function mountCatalog(
+  selectedHostId = studio.id,
+  hosts: MobileHost[] = [studio, renderBox],
+): VueWrapper {
+  return mount(MobileCatalogView, {
+    attachTo: document.body,
+    props: { hosts, selectedHostId },
+  });
+}
+
+beforeEach(() => {
+  streams.length = 0;
+  vi.clearAllMocks();
+  fetchCatalogFamilies.mockResolvedValue(["flux", "ltx2"]);
+  fetchCatalogDetail.mockImplementation((id: string) =>
+    Promise.resolve({ ...entry("detail"), id, name: "Catalog model", description: "Full detail" }),
+  );
+  fetchModelComponents.mockResolvedValue({ model: "installed:q8", components: [] });
+  loadModel.mockResolvedValue(new Response(null, { status: 204 }));
+  unloadModel.mockResolvedValue(new Response(null, { status: 204 }));
+  removeModel.mockResolvedValue({ removed: [], kept: [], freed_bytes: 1_000_000_000 });
+  startCatalogDownload.mockResolvedValue("download-1");
+  searchCatalog.mockResolvedValue(searchResponse([entry("Catalog model")]));
+  apiFetchTo.mockImplementation((target: ApiTarget, path: string) => {
+    if (path === "/api/models") {
+      return Promise.resolve(
+        jsonResponse(
+          target.baseUrl === studio.baseUrl
+            ? [
+                model("installed:q8", "flux", true),
+                model("safe-variant:q4", "ltx2", false, {
+                  size_gb: 4,
+                  remaining_download_bytes: 6_000_000_000,
+                }),
+              ]
+            : [model("installed:q8", "flux", true)],
+        ),
+      );
+    }
+    return Promise.resolve(new Response(null, { status: 204 }));
+  });
+  sseStream.mockImplementation(
+    (
+      _path: string,
+      options: {
+        target: ApiTarget;
+        signal: AbortSignal;
+        onOpen?: () => void;
+        onOpenError?: (error: Error) => void;
+        onClose?: (error: Error | null) => void;
+        onEvent: (event: string, data: string) => void;
+      },
+    ) => {
+      streams.push(options);
+      options.onOpen?.();
+      return Promise.resolve();
+    },
+  );
+});
+
+afterEach(() => {
+  wrapper?.unmount();
+  wrapper = null;
+  document.body.innerHTML = "";
+  vi.useRealTimers();
+});
+
+describe("MobileCatalogView", () => {
+  it("searches the selected remote host and merges installed models with host labels", async () => {
+    searchCatalog.mockResolvedValue(
+      searchResponse([
+        entry("Aggregate repo", {
+          source_id: "mold/safe-model",
+          bundling: "separated",
+          size_bytes: 250_000_000_000,
+        }),
+        entry("Catalog model"),
+      ]),
+    );
+    wrapper = mountCatalog();
+    await flushPromises();
+
+    expect(searchCatalog).toHaveBeenCalledWith(
+      {
+        q: undefined,
+        family: undefined,
+        source: undefined,
+        include_nsfw: false,
+        page: 1,
+        page_size: 24,
+      },
+      false,
+      targets.studio,
+    );
+    expect(fetchCatalogFamilies).toHaveBeenCalledWith(false, targets.studio);
+
+    const text = wrapper.text();
+    expect(text).toContain("installed:q8");
+    expect(text).toContain("Studio");
+    expect(text).toContain("Render Box");
+    expect(text).toContain("safe-variant:q4");
+    expect(text).toContain("Catalog model");
+    expect(text).not.toContain("Aggregate repo");
+    expect(wrapper.findAll("[data-test='mobile-catalog-card']")).toHaveLength(3);
+  });
+
+  it("debounces search and ignores a late response from the previous host", async () => {
+    vi.useFakeTimers();
+    const pending: Array<(response: CatalogSearchResponse) => void> = [];
+    searchCatalog.mockImplementation(
+      () =>
+        new Promise<CatalogSearchResponse>((resolve) => {
+          pending.push(resolve);
+        }),
+    );
+    wrapper = mountCatalog();
+    await vi.waitFor(() => expect(searchCatalog).toHaveBeenCalledTimes(1));
+
+    await wrapper.get("[data-test='mobile-catalog-search']").setValue("portrait");
+    await vi.advanceTimersByTimeAsync(399);
+    expect(searchCatalog).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(searchCatalog).toHaveBeenCalledTimes(2);
+
+    await wrapper.setProps({ selectedHostId: renderBox.id });
+    await vi.waitFor(() => expect(searchCatalog).toHaveBeenCalledTimes(3));
+    pending[2]!(searchResponse([entry("Render result")]));
+    await flushPromises();
+    pending[0]!(searchResponse([entry("Old Studio result")]));
+    pending[1]!(searchResponse([entry("Old query result")]));
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("Render result");
+    expect(wrapper.text()).not.toContain("Old Studio result");
+    expect(wrapper.text()).not.toContain("Old query result");
+  });
+
+  it("chooses a remote target for a pull and opens detail on the selected host", async () => {
+    wrapper = mountCatalog();
+    await flushPromises();
+
+    const catalogCard = wrapper
+      .findAll("[data-test='mobile-catalog-card']")
+      .find((candidate) => candidate.text().includes("Catalog model"));
+    expect(catalogCard).toBeDefined();
+    (catalogCard!.get(".mobile-catalog-card-open").element as HTMLButtonElement).focus();
+    await catalogCard!.get(".mobile-catalog-card-open").trigger("click");
+    await flushPromises();
+
+    expect(fetchCatalogDetail).toHaveBeenCalledWith("hf:Catalog model", false, targets.studio);
+    expect(document.querySelector("[data-test='mobile-catalog-detail']")?.textContent).toContain(
+      "Full detail",
+    );
+    expect(wrapper.get(".mobile-catalog").attributes()).toHaveProperty("inert");
+
+    const detailClose = document.querySelector<HTMLButtonElement>(
+      "[aria-label='Close model details']",
+    )!;
+    const detailAction = document.querySelector<HTMLButtonElement>(
+      ".mobile-catalog-detail-action button",
+    )!;
+    expect(document.activeElement).toBe(detailClose);
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "Tab",
+        shiftKey: true,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+    expect(document.activeElement).toBe(detailAction);
+
+    detailAction.click();
+    await flushPromises();
+    const detailDialog = document.querySelector<HTMLElement>(
+      "[data-test='mobile-catalog-detail']",
+    )!;
+    expect(document.querySelector("[data-test='mobile-catalog-target-sheet']")).not.toBeNull();
+    expect(detailDialog.hasAttribute("inert")).toBe(true);
+
+    const targetClose = document.querySelector<HTMLButtonElement>(
+      "[aria-label='Close host picker']",
+    )!;
+    const targetButtons = document.querySelectorAll<HTMLButtonElement>(
+      ".mobile-catalog-target-list button",
+    );
+    expect(targetButtons).toHaveLength(2);
+    expect(document.activeElement).toBe(targetClose);
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "Tab",
+        shiftKey: true,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+    expect(document.activeElement).toBe(targetButtons[1]);
+    window.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Tab", bubbles: true, cancelable: true }),
+    );
+    expect(document.activeElement).toBe(targetClose);
+    targetButtons[1]!.click();
+    await flushPromises();
+
+    expect(startCatalogDownload).toHaveBeenCalledWith("hf:Catalog model", targets.render, false);
+    expect(document.body.textContent).toContain("Pulling Catalog model on Render Box");
+    expect(detailDialog.hasAttribute("inert")).toBe(false);
+    expect(wrapper.get(".mobile-catalog").attributes()).toHaveProperty("inert");
+
+    detailClose.click();
+    await flushPromises();
+    expect(wrapper.get(".mobile-catalog").attributes()).not.toHaveProperty("inert");
+    expect(document.activeElement).toBe(catalogCard!.get(".mobile-catalog-card-open").element);
+  });
+
+  it("waits for the download stream to open before posting a pull", async () => {
+    sseStream.mockImplementation(
+      (
+        _path: string,
+        options: {
+          target: ApiTarget;
+          signal: AbortSignal;
+          onOpen?: () => void;
+          onOpenError?: (error: Error) => void;
+          onClose?: (error: Error | null) => void;
+          onEvent: (event: string, data: string) => void;
+        },
+      ) => {
+        streams.push(options);
+        return Promise.resolve();
+      },
+    );
+    wrapper = mountCatalog(studio.id, [studio]);
+    await flushPromises();
+
+    const catalogCard = wrapper
+      .findAll("[data-test='mobile-catalog-card']")
+      .find((candidate) => candidate.text().includes("Catalog model"))!;
+    await catalogCard.get(".mobile-catalog-pull").trigger("click");
+    await flushPromises();
+
+    expect(startCatalogDownload).not.toHaveBeenCalled();
+    expect(wrapper.get("[data-test='mobile-catalog-action-status']").text()).toContain(
+      "Connecting to downloads on Studio",
+    );
+
+    streams[0]!.onOpen?.();
+    await flushPromises();
+    expect(startCatalogDownload).toHaveBeenCalledWith("hf:Catalog model", targets.studio, false);
+    expect(wrapper.get("[data-test='mobile-catalog-action-status']").text()).toContain(
+      "Pulling Catalog model on Studio",
+    );
+  });
+
+  it("shows a visible error and does not POST when the download stream cannot open", async () => {
+    sseStream.mockImplementation(
+      (
+        _path: string,
+        options: {
+          target: ApiTarget;
+          signal: AbortSignal;
+          onOpen?: () => void;
+          onOpenError?: (error: Error) => void;
+          onClose?: (error: Error | null) => void;
+          onEvent: (event: string, data: string) => void;
+        },
+      ) => {
+        streams.push(options);
+        return Promise.resolve();
+      },
+    );
+    wrapper = mountCatalog(studio.id, [studio]);
+    await flushPromises();
+
+    const catalogCard = wrapper
+      .findAll("[data-test='mobile-catalog-card']")
+      .find((candidate) => candidate.text().includes("Catalog model"))!;
+    await catalogCard.get(".mobile-catalog-pull").trigger("click");
+    streams[0]!.onOpenError?.(new Error("HTTP 401"));
+    await flushPromises();
+
+    expect(startCatalogDownload).not.toHaveBeenCalled();
+    const status = wrapper.get("[data-test='mobile-catalog-action-status']");
+    expect(status.attributes("role")).toBe("alert");
+    expect(status.text()).toContain("Could not pull Catalog model on Studio: HTTP 401");
+  });
+
+  it("repairs an installed model on its owning host and labels component presence in text", async () => {
+    fetchModelComponents.mockResolvedValue({
+      model: "installed:q8",
+      components: [
+        { name: "weights.safetensors", kind: "weights", present: true },
+        { name: "text_encoder", kind: "companion", present: false },
+      ],
+    });
+    wrapper = mountCatalog();
+    await flushPromises();
+
+    const installedCard = wrapper
+      .findAll("[data-test='mobile-catalog-card']")
+      .find((candidate) => candidate.text().includes("installed:q8"))!;
+    await installedCard.get(".mobile-catalog-card-open").trigger("click");
+    await flushPromises();
+
+    const detail = document.querySelector<HTMLElement>("[data-test='mobile-catalog-detail']")!;
+    expect(detail.textContent).toContain("Present · weights");
+    expect(detail.textContent).toContain("Missing · companion");
+    expect(detail.querySelector("[aria-label='Present: weights']")).not.toBeNull();
+    expect(detail.querySelector("[aria-label='Missing: companion']")).not.toBeNull();
+
+    detail.querySelector<HTMLButtonElement>(".mobile-catalog-detail-action button")!.click();
+    await flushPromises();
+
+    expect(document.querySelector("[data-test='mobile-catalog-target-sheet']")).toBeNull();
+    expect(startCatalogDownload).toHaveBeenCalledWith("installed:q8", targets.studio, false);
+  });
+
+  it("clears a hidden family filter when switching to installed models", async () => {
+    wrapper = mountCatalog();
+    await flushPromises();
+
+    await wrapper.get(".mobile-catalog-filters select").setValue("ltx2");
+    const installedSource = wrapper
+      .findAll(".mobile-catalog-sources button")
+      .find((button) => button.text() === "Installed")!;
+    await installedSource.trigger("click");
+    await flushPromises();
+
+    expect(wrapper.find(".mobile-catalog-filters select").exists()).toBe(false);
+    expect(wrapper.text()).toContain("installed:q8");
+  });
+
+  it("resets detail loading state when a pending installed detail is replaced", async () => {
+    const components = deferred<{ model: string; components: [] }>();
+    fetchModelComponents.mockReturnValue(components.promise);
+    wrapper = mountCatalog();
+    await flushPromises();
+
+    const installedCard = wrapper
+      .findAll("[data-test='mobile-catalog-card']")
+      .find((candidate) => candidate.text().includes("installed:q8"))!;
+    await installedCard.get(".mobile-catalog-card-open").trigger("click");
+    await flushPromises();
+    expect(document.body.textContent).toContain("Checking files");
+
+    document.querySelector<HTMLButtonElement>("[aria-label='Close model details']")!.click();
+    await flushPromises();
+    const catalogCard = wrapper
+      .findAll("[data-test='mobile-catalog-card']")
+      .find((candidate) => candidate.text().includes("Catalog model"))!;
+    await catalogCard.get(".mobile-catalog-card-open").trigger("click");
+    await flushPromises();
+    expect(
+      document.querySelector("[data-test='mobile-catalog-detail']")?.textContent,
+    ).not.toContain("Checking files");
+
+    components.resolve({ model: "installed:q8", components: [] });
+    await flushPromises();
+  });
+
+  it("does not let a completed removal close a newly opened model detail", async () => {
+    const removal = deferred<{ removed: string[]; kept: string[]; freed_bytes: number }>();
+    removeModel.mockReturnValue(removal.promise);
+    fetchCatalogDetail.mockImplementation((id: string) =>
+      Promise.resolve(
+        entry(id === "hf:Catalog model" ? "Fresh catalog" : "Installed model", {
+          id,
+          installed: false,
+        }),
+      ),
+    );
+    wrapper = mountCatalog();
+    await flushPromises();
+
+    const installedCard = wrapper
+      .findAll("[data-test='mobile-catalog-card']")
+      .find((candidate) => candidate.text().includes("installed:q8"))!;
+    await installedCard.get(".mobile-catalog-card-open").trigger("click");
+    await flushPromises();
+    let removeButton = document.querySelector<HTMLButtonElement>(
+      ".mobile-catalog-installed-actions .danger-button",
+    )!;
+    removeButton.click();
+    await flushPromises();
+    expect(removeButton.textContent).toContain("Tap again to remove");
+
+    document.querySelector<HTMLButtonElement>("[aria-label='Close model details']")!.click();
+    await flushPromises();
+    await installedCard.get(".mobile-catalog-card-open").trigger("click");
+    await flushPromises();
+    removeButton = document.querySelector<HTMLButtonElement>(
+      ".mobile-catalog-installed-actions .danger-button",
+    )!;
+    expect(removeButton.textContent).toContain("Remove from host");
+    removeButton.click();
+    removeButton.click();
+    await flushPromises();
+    expect(removeModel).toHaveBeenCalledWith("installed:q8", targets.studio);
+
+    document.querySelector<HTMLButtonElement>("[aria-label='Close model details']")!.click();
+    await flushPromises();
+    const catalogCard = wrapper
+      .findAll("[data-test='mobile-catalog-card']")
+      .find((candidate) => candidate.text().includes("Catalog model"))!;
+    await catalogCard.get(".mobile-catalog-card-open").trigger("click");
+    await flushPromises();
+    expect(document.querySelector("[data-test='mobile-catalog-detail']")?.textContent).toContain(
+      "Fresh catalog",
+    );
+    expect(
+      document.querySelector<HTMLButtonElement>(".mobile-catalog-detail-action button")!.disabled,
+    ).toBe(false);
+
+    removal.resolve({ removed: ["installed:q8"], kept: [], freed_bytes: 1_000_000_000 });
+    await flushPromises();
+    expect(document.querySelector("[data-test='mobile-catalog-detail']")?.textContent).toContain(
+      "Fresh catalog",
+    );
+  });
+
+  it("reduces download SSE snapshots, exposes progress, cancels explicitly, and aborts streams", async () => {
+    wrapper = mountCatalog();
+    await flushPromises();
+    expect(streams).toHaveLength(2);
+
+    const event: DownloadEvent = {
+      type: "snapshot",
+      listing: {
+        active_jobs: [
+          {
+            id: "job-1",
+            model: "flux-dev:q8",
+            status: "active",
+            files_done: 1,
+            files_total: 4,
+            bytes_done: 25,
+            bytes_total: 100,
+          },
+        ],
+        queued: [],
+        history: [
+          {
+            id: "finished-while-suspended",
+            model: "offline-finish:q8",
+            status: "completed",
+            files_done: 1,
+            files_total: 1,
+            bytes_done: 100,
+            bytes_total: 100,
+          },
+        ],
+      },
+    };
+    streams[0]!.onEvent("download", JSON.stringify(event));
+    await flushPromises();
+
+    const row = wrapper.get("[data-test='mobile-catalog-download']");
+    expect(row.text()).toContain("flux-dev:q8");
+    expect(row.get("[role='progressbar']").attributes("aria-valuenow")).toBe("25");
+    expect(wrapper.emitted("models-changed")).toContainEqual([studio.id]);
+
+    streams[0]!.onEvent(
+      "download",
+      JSON.stringify({ type: "job_done", id: "job-1", model: "flux-dev:q8" }),
+    );
+    await flushPromises();
+    expect(wrapper.emitted("models-changed")).toContainEqual([studio.id]);
+    expect(wrapper.get("[data-test='mobile-catalog-action-status']").text()).toContain(
+      "flux-dev:q8 is ready on Studio",
+    );
+
+    // Put the row back into the snapshot so cancellation remains independently
+    // covered after the terminal-event reconciliation above.
+    streams[0]!.onEvent("download", JSON.stringify(event));
+    await flushPromises();
+    const activeRow = wrapper.get("[data-test='mobile-catalog-download']");
+    await activeRow.get("button").trigger("click");
+    await flushPromises();
+    expect(apiFetchTo).toHaveBeenCalledWith(targets.studio, "/api/downloads/job-1", {
+      method: "DELETE",
+    });
+
+    const signals = streams.map((stream) => stream.signal);
+    wrapper.unmount();
+    wrapper = null;
+    expect(signals.every((signal) => signal.aborted)).toBe(true);
+  });
+});

--- a/desktop/src/mobile/MobileCatalogView.vue
+++ b/desktop/src/mobile/MobileCatalogView.vue
@@ -1,0 +1,1319 @@
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, onMounted, reactive, ref, watch } from "vue";
+import { apiFetchTo, ApiError, type ApiTarget } from "../lib/api/client";
+import {
+  fetchCatalogDetail,
+  fetchCatalogFamilies,
+  searchCatalog,
+  startCatalogDownload,
+} from "../lib/api/catalog";
+import { sseStream } from "../lib/api/sse";
+import {
+  catalogFetchCaption,
+  catalogPullLabel,
+  catalogSizeInfo,
+  catalogSizeLabel,
+  sortInstalledFirst,
+} from "../lib/catalog";
+import {
+  buildDownloadContents,
+  canDownloadEntry,
+  catalogActionLabel,
+  downloadContentsTotalBytes,
+  installedModelToEntry,
+} from "../lib/catalogDetail";
+import { catalogThumbnailUrl } from "../lib/catalogThumbnails";
+import { isVideoFamily } from "../lib/capabilities";
+import { formatCount, formatGB, percent } from "../lib/format";
+import { isUtilityModel } from "../lib/models";
+import { fetchModelComponents, loadModel, removeModel, unloadModel } from "../lib/api/models";
+import type {
+  CatalogEntry,
+  DownloadEvent,
+  DownloadJob,
+  ModelComponentStatus,
+  ModelEntry,
+} from "../lib/api/types";
+import { applyDownloadEvent, emptyDownloadsState, type DownloadsState } from "../stores/downloads";
+import { mobileHostTarget, type MobileHost } from "./hosts";
+
+type MediaType = "all" | "image" | "video";
+type CatalogSource = "all" | "hf" | "civitai" | "installed";
+
+type MobileCatalogEntry = CatalogEntry & {
+  hostIds?: string[];
+  hostLabels?: string[];
+};
+
+interface DownloadRow {
+  host: MobileHost;
+  job: DownloadJob;
+}
+
+interface StreamSubscription {
+  signature: string;
+  controller: AbortController;
+  ready: Promise<void>;
+  close: () => void;
+}
+
+const props = defineProps<{
+  hosts: MobileHost[];
+  selectedHostId: string;
+}>();
+
+const emit = defineEmits<{
+  (event: "select-host", hostId: string): void;
+  (event: "models-changed", hostId: string): void;
+}>();
+
+const PAGE_SIZE = 24;
+const MAX_AUTO_PAGES = 5;
+const STREAM_OPEN_TIMEOUT_MS = 10_000;
+const FOCUSABLE_SELECTOR = [
+  "button:not([disabled])",
+  "[href]",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  "[tabindex]:not([tabindex='-1'])",
+].join(",");
+
+const query = ref("");
+const mediaType = ref<MediaType>("all");
+const source = ref<CatalogSource>("all");
+const family = ref("");
+const includeNsfw = ref(false);
+const families = ref<string[]>([]);
+const entries = ref<CatalogEntry[]>([]);
+const page = ref(1);
+const hasMore = ref(false);
+const loading = ref(false);
+const error = ref("");
+const announcement = ref("");
+const announcementIsError = ref(false);
+const modelsByHost = ref<Record<string, ModelEntry[]>>({});
+const pulling = reactive(new Set<string>());
+const cancelling = reactive(new Set<string>());
+const downloadsByHost = reactive<Record<string, DownloadsState>>({});
+const subscriptions = new Map<string, StreamSubscription>();
+const terminalJobsByHost = new Map<string, Set<string>>();
+
+const detailEntry = ref<MobileCatalogEntry | null>(null);
+const detail = ref<CatalogEntry | null>(null);
+const detailLoading = ref(false);
+const detailComponents = ref<ModelComponentStatus[]>([]);
+const detailComponentsLoading = ref(false);
+const detailBusy = ref("");
+const detailRemoveConfirm = ref(false);
+const catalogRoot = ref<HTMLElement | null>(null);
+const detailDialog = ref<HTMLElement | null>(null);
+const detailCloseButton = ref<HTMLButtonElement | null>(null);
+const targetEntry = ref<MobileCatalogEntry | null>(null);
+const targetDialog = ref<HTMLElement | null>(null);
+const targetCloseButton = ref<HTMLButtonElement | null>(null);
+let restoreFocus: HTMLElement | null = null;
+let targetRestoreFocus: HTMLElement | null = null;
+let inertBackground: HTMLElement | null = null;
+
+let mounted = false;
+let searchEpoch = 0;
+let familyEpoch = 0;
+let modelsEpoch = 0;
+let detailEpoch = 0;
+let debounce: ReturnType<typeof setTimeout> | null = null;
+
+const selectedHost = computed(
+  () => props.hosts.find((host) => host.id === props.selectedHostId) ?? null,
+);
+
+const selectedTarget = computed<ApiTarget | null>(() => {
+  const host = selectedHost.value;
+  return host ? mobileHostTarget(host) : null;
+});
+
+/** The selected host remains usable while its latest reachability probe is pending. */
+const downloadHosts = computed(() =>
+  props.hosts.filter((host) => host.online || host.id === props.selectedHostId),
+);
+
+const installedEntries = computed<MobileCatalogEntry[]>(() => {
+  const byName = new Map<string, { model: ModelEntry; hostIds: string[]; hostLabels: string[] }>();
+  for (const host of props.hosts) {
+    for (const model of modelsByHost.value[host.id] ?? []) {
+      if (!model.downloaded) continue;
+      const found = byName.get(model.name);
+      if (found) {
+        found.hostIds.push(host.id);
+        found.hostLabels.push(host.name);
+      } else {
+        byName.set(model.name, {
+          model,
+          hostIds: [host.id],
+          hostLabels: [host.name],
+        });
+      }
+    }
+  }
+  return [...byName.values()].map(({ model, hostIds, hostLabels }) => ({
+    ...installedModelToEntry(model),
+    hostIds,
+    hostLabels,
+  }));
+});
+
+const installedNames = computed(() => new Set(installedEntries.value.map((entry) => entry.name)));
+
+/** Curated `/api/models` variants are safe pull targets and must beat an aggregate HF repo row. */
+const manifestEntries = computed<MobileCatalogEntry[]>(() => {
+  const q = query.value.trim().toLowerCase();
+  return (modelsByHost.value[props.selectedHostId] ?? [])
+    .filter((model) => !model.downloaded && !isUtilityModel(model))
+    .filter((model) => !installedNames.value.has(model.name))
+    .filter((model) => !q || model.name.toLowerCase().includes(q))
+    .filter((model) => !family.value || model.family === family.value)
+    .map((model) => {
+      const weights = Math.round(model.size_gb * 1_000_000_000);
+      const fetch = model.remaining_download_bytes ?? weights;
+      const shared = Math.max(0, fetch - weights);
+      return {
+        id: model.name,
+        source: "hf",
+        source_id: model.hf_repo || null,
+        name: model.name,
+        family: model.family,
+        kind: "checkpoint",
+        nsfw: false,
+        installed: false,
+        size_bytes: weights,
+        thumbnail_url: null,
+        page_url: model.hf_repo ? `https://huggingface.co/${model.hf_repo}` : null,
+        companion_details:
+          shared > 0 ? [{ name: "shared runtime components", size_bytes: shared }] : [],
+      } satisfies MobileCatalogEntry;
+    });
+});
+
+function sourceMatches(entry: CatalogEntry): boolean {
+  if (source.value === "all" || source.value === "installed") return true;
+  return entry.source === source.value;
+}
+
+function mediaMatches(entry: CatalogEntry): boolean {
+  if (mediaType.value === "all") return true;
+  if (isUtilityModel({ family: entry.family } as ModelEntry)) return false;
+  return isVideoFamily(entry.family) === (mediaType.value === "video");
+}
+
+const filteredInstalled = computed(() => {
+  const q = query.value.trim().toLowerCase();
+  return installedEntries.value
+    .filter((entry) => !q || entry.name.toLowerCase().includes(q))
+    .filter((entry) => !family.value || entry.family === family.value)
+    .filter(sourceMatches)
+    .filter(mediaMatches);
+});
+
+const combinedEntries = computed<MobileCatalogEntry[]>(() => {
+  if (source.value === "installed") return filteredInstalled.value;
+
+  const knownRepos = new Set(
+    (modelsByHost.value[props.selectedHostId] ?? [])
+      .map((model) => model.hf_repo)
+      .filter((repo): repo is string => Boolean(repo)),
+  );
+  const safeLive = entries.value.filter(
+    (entry) =>
+      !(
+        entry.source === "hf" &&
+        entry.kind === "checkpoint" &&
+        (entry.bundling === "separated" ||
+          Boolean(entry.source_id && knownRepos.has(entry.source_id)))
+      ),
+  );
+  const installedByName = new Set(filteredInstalled.value.map((entry) => entry.name));
+  const byId = new Map<string, MobileCatalogEntry>();
+  for (const entry of [
+    ...filteredInstalled.value,
+    ...manifestEntries.value.filter(sourceMatches).filter(mediaMatches),
+    ...safeLive.filter((entry) => !installedByName.has(entry.name)).filter(mediaMatches),
+  ]) {
+    if (!byId.has(entry.id)) byId.set(entry.id, entry);
+  }
+  return sortInstalledFirst([...byId.values()]);
+});
+
+const downloadRows = computed<DownloadRow[]>(() =>
+  props.hosts.flatMap((host) => {
+    const state = downloadsByHost[host.id];
+    return state ? [...state.activeJobs, ...state.queued].map((job) => ({ host, job })) : [];
+  }),
+);
+
+const mergedDetail = computed<CatalogEntry | null>(() => {
+  const summary = detailEntry.value;
+  if (!summary) return null;
+  return detail.value
+    ? { ...summary, ...detail.value, installed: summary.installed || detail.value.installed }
+    : summary;
+});
+
+const detailDownloadItems = computed(() =>
+  mergedDetail.value ? buildDownloadContents(mergedDetail.value) : [],
+);
+const detailDownloadTotal = computed(() => downloadContentsTotalBytes(detailDownloadItems.value));
+const detailModel = computed(() => {
+  const entry = detailEntry.value;
+  const host = entry ? owningHost(entry) : null;
+  return host
+    ? ((modelsByHost.value[host.id] ?? []).find(
+        (model) => model.name === entry?.name || model.name === entry?.id,
+      ) ?? null)
+    : null;
+});
+
+function hostSignature(host: MobileHost): string {
+  return `${host.baseUrl}|${host.apiKey}`;
+}
+
+function announce(message: string, isError = false): void {
+  announcement.value = message;
+  announcementIsError.value = isError;
+}
+
+function errorMessage(cause: unknown): string {
+  return cause instanceof Error ? cause.message : String(cause);
+}
+
+function setInert(element: HTMLElement | null, inert: boolean): void {
+  if (!element) return;
+  element.inert = inert;
+  if (inert) element.setAttribute("inert", "");
+  else element.removeAttribute("inert");
+}
+
+function updateModalInert(): void {
+  const overlayOpen = Boolean(detailEntry.value || targetEntry.value);
+  const nextBackground = overlayOpen
+    ? (catalogRoot.value?.closest<HTMLElement>(".mobile-shell") ?? catalogRoot.value)
+    : null;
+  if (inertBackground && inertBackground !== nextBackground) setInert(inertBackground, false);
+  if (nextBackground) setInert(nextBackground, true);
+  inertBackground = nextBackground;
+  setInert(detailDialog.value, Boolean(targetEntry.value));
+}
+
+function clearModalInert(): void {
+  setInert(detailDialog.value, false);
+  setInert(inertBackground, false);
+  inertBackground = null;
+}
+
+function pullKey(entry: CatalogEntry, hostId?: string): string {
+  return `${hostId ?? "any"}:${entry.id}`;
+}
+
+function owningHost(entry: MobileCatalogEntry): MobileHost | null {
+  const ids = entry.hostIds ?? [];
+  const preferred = ids.includes(props.selectedHostId) ? props.selectedHostId : ids[0];
+  return props.hosts.find((host) => host.id === preferred) ?? selectedHost.value;
+}
+
+function targetForEntry(entry: MobileCatalogEntry): ApiTarget | null {
+  const host = entry.installed ? owningHost(entry) : selectedHost.value;
+  return host ? mobileHostTarget(host) : null;
+}
+
+function scheduleSearch(): void {
+  if (debounce) clearTimeout(debounce);
+  if (source.value === "installed") {
+    ++searchEpoch;
+    loading.value = false;
+    error.value = "";
+    return;
+  }
+  debounce = setTimeout(() => void runSearch(true), 400);
+}
+
+async function runSearch(reset: boolean): Promise<void> {
+  const target = selectedTarget.value;
+  if (!target || source.value === "installed") return;
+  const epoch = ++searchEpoch;
+  if (reset) {
+    page.value = 1;
+    entries.value = [];
+  }
+  loading.value = true;
+  error.value = "";
+  try {
+    for (let fetched = 0; ; fetched += 1) {
+      const response = await searchCatalog(
+        {
+          q: query.value.trim() || undefined,
+          family: family.value || undefined,
+          source: source.value === "all" ? undefined : source.value,
+          include_nsfw: includeNsfw.value,
+          page: page.value,
+          page_size: PAGE_SIZE,
+        },
+        false,
+        target,
+      );
+      if (epoch !== searchEpoch) return;
+      entries.value = [...entries.value, ...response.entries];
+      hasMore.value = response.entries.length === PAGE_SIZE;
+      const filtered = combinedEntries.value.some(mediaMatches);
+      if (mediaType.value === "all" || filtered || !hasMore.value || fetched + 1 >= MAX_AUTO_PAGES)
+        break;
+      page.value += 1;
+    }
+  } catch (cause) {
+    if (epoch !== searchEpoch) return;
+    error.value = cause instanceof Error ? cause.message : String(cause);
+    hasMore.value = false;
+  } finally {
+    if (epoch === searchEpoch) loading.value = false;
+  }
+}
+
+function loadMore(): void {
+  if (loading.value || !hasMore.value) return;
+  page.value += 1;
+  void runSearch(false);
+}
+
+async function loadFamilies(): Promise<void> {
+  const target = selectedTarget.value;
+  const epoch = ++familyEpoch;
+  families.value = [];
+  if (!target) return;
+  try {
+    // The iPhone shell has no desktop `secret_get` command. Remote catalog
+    // hosts use their own configured HF/Civitai credentials; only the Mold
+    // host API key from `target` crosses the wire.
+    const result = await fetchCatalogFamilies(false, target);
+    if (epoch === familyEpoch) families.value = result;
+  } catch {
+    // Family filtering is optional; catalog search remains fully usable.
+  }
+}
+
+async function refreshModels(): Promise<void> {
+  const epoch = ++modelsEpoch;
+  const next: Record<string, ModelEntry[]> = {};
+  await Promise.all(
+    downloadHosts.value.map(async (host) => {
+      try {
+        const response = await apiFetchTo(mobileHostTarget(host), "/api/models");
+        const result = (await response.json()) as ModelEntry[];
+        if (epoch === modelsEpoch) next[host.id] = result;
+      } catch {
+        // One unavailable host must not blank models from the other hosts.
+      }
+    }),
+  );
+  if (epoch === modelsEpoch) modelsByHost.value = next;
+}
+
+function ensureDownloadStream(host: MobileHost): Promise<void> {
+  const signature = hostSignature(host);
+  const existing = subscriptions.get(host.id);
+  if (existing?.signature === signature && !existing.controller.signal.aborted)
+    return existing.ready;
+  existing?.close();
+
+  downloadsByHost[host.id] ??= emptyDownloadsState();
+  const controller = new AbortController();
+  let readySettled = false;
+  let openTimer: ReturnType<typeof setTimeout>;
+  let resolveReady!: () => void;
+  let rejectReady!: (error: Error) => void;
+  const ready = new Promise<void>((resolve, reject) => {
+    resolveReady = resolve;
+    rejectReady = reject;
+  });
+  // `syncDownloadStreams` starts subscriptions eagerly, before anyone awaits
+  // them. Keep the rejection observable to pull callers without generating an
+  // unhandled rejection during ordinary host probing.
+  void ready.catch(() => {});
+
+  const markReady = () => {
+    if (readySettled) return;
+    readySettled = true;
+    clearTimeout(openTimer);
+    resolveReady();
+  };
+  const failReady = (cause: Error) => {
+    if (readySettled) return;
+    readySettled = true;
+    clearTimeout(openTimer);
+    controller.abort();
+    if (subscriptions.get(host.id)?.controller === controller) subscriptions.delete(host.id);
+    rejectReady(cause);
+  };
+  const close = () => {
+    if (!readySettled) {
+      failReady(new Error(`Download monitoring stopped on ${host.name}.`));
+      return;
+    }
+    controller.abort();
+  };
+
+  openTimer = setTimeout(
+    () => failReady(new Error(`Timed out connecting to downloads on ${host.name}.`)),
+    STREAM_OPEN_TIMEOUT_MS,
+  );
+  subscriptions.set(host.id, { signature, controller, ready, close });
+  void sseStream("/api/downloads/stream", {
+    target: mobileHostTarget(host),
+    signal: controller.signal,
+    retry: true,
+    onOpen: markReady,
+    onOpenError: failReady,
+    onClose: (cause) => {
+      if (!readySettled) {
+        failReady(cause ?? new Error(`Download stream closed on ${host.name}.`));
+        return;
+      }
+      if (subscriptions.get(host.id)?.controller === controller) subscriptions.delete(host.id);
+      if (mounted && cause && !controller.signal.aborted)
+        announce(`Download monitoring stopped on ${host.name}: ${cause.message}`, true);
+    },
+    onEvent: (_event, data) => {
+      if (controller.signal.aborted) return;
+      try {
+        const event = JSON.parse(data) as DownloadEvent;
+        downloadsByHost[host.id] = applyDownloadEvent(
+          downloadsByHost[host.id] ?? emptyDownloadsState(),
+          event,
+        );
+        if (event.type === "job_done") {
+          const known = terminalJobsByHost.get(host.id) ?? new Set<string>();
+          known.add(event.id);
+          terminalJobsByHost.set(host.id, known);
+          announce(`${event.model} is ready on ${host.name}.`);
+          emit("models-changed", host.id);
+          void refreshModels();
+          if (host.id === props.selectedHostId) void runSearch(true);
+        } else if (event.type === "job_failed") {
+          const known = terminalJobsByHost.get(host.id) ?? new Set<string>();
+          known.add(event.id);
+          terminalJobsByHost.set(host.id, known);
+          announce(`Download failed on ${host.name}: ${event.error}`, true);
+        } else if (event.type === "snapshot") {
+          const hadSnapshot = terminalJobsByHost.has(host.id);
+          const known = terminalJobsByHost.get(host.id) ?? new Set<string>();
+          const settled = event.listing.history.filter(
+            (job) => job.status === "completed" || job.status === "failed",
+          );
+          const newlySettled = settled.filter((job) => !known.has(job.id));
+          terminalJobsByHost.set(host.id, new Set(settled.map((job) => job.id)));
+
+          // A snapshot is the reconciliation point after launch/reconnect. A
+          // completed pull may have happened while the iPhone was suspended,
+          // so refresh both the local and parent model views even on the first
+          // snapshot. Only announce deltas after the baseline snapshot.
+          if (
+            (!hadSnapshot && settled.some((job) => job.status === "completed")) ||
+            newlySettled.some((job) => job.status === "completed")
+          ) {
+            emit("models-changed", host.id);
+            void refreshModels();
+            if (host.id === props.selectedHostId) void runSearch(true);
+          }
+          if (hadSnapshot) {
+            const failed = newlySettled.find((job) => job.status === "failed");
+            const completed = newlySettled.find((job) => job.status === "completed");
+            if (failed)
+              announce(
+                `Download of ${failed.model} failed on ${host.name}${failed.error ? `: ${failed.error}` : "."}`,
+                true,
+              );
+            else if (completed) announce(`${completed.model} is ready on ${host.name}.`);
+          }
+        }
+      } catch {
+        // Ignore malformed frames; the next snapshot/delta repairs state.
+      }
+    },
+  });
+  return ready;
+}
+
+function syncDownloadStreams(): void {
+  const keep = new Set(downloadHosts.value.map((host) => host.id));
+  for (const [hostId, subscription] of subscriptions) {
+    if (keep.has(hostId)) continue;
+    subscription.close();
+    subscriptions.delete(hostId);
+    delete downloadsByHost[hostId];
+    terminalJobsByHost.delete(hostId);
+  }
+  for (const host of downloadHosts.value) {
+    void ensureDownloadStream(host).catch((cause) => {
+      if (!mounted) return;
+      announce(`Could not monitor downloads on ${host.name}: ${errorMessage(cause)}`, true);
+    });
+  }
+}
+
+async function cancelDownload(row: DownloadRow): Promise<void> {
+  const key = `${row.host.id}:${row.job.id}`;
+  if (cancelling.has(key)) return;
+  cancelling.add(key);
+  try {
+    await apiFetchTo(
+      mobileHostTarget(row.host),
+      `/api/downloads/${encodeURIComponent(row.job.id)}`,
+      { method: "DELETE" },
+    );
+    announce(`Cancelling ${row.job.model}.`);
+  } catch (cause) {
+    announce(errorMessage(cause), true);
+  } finally {
+    cancelling.delete(key);
+  }
+}
+
+function requestPull(entry: MobileCatalogEntry): void {
+  if (entry.installed) {
+    const host = owningHost(entry);
+    if (host) void pullTo(entry, host);
+    return;
+  }
+  if (downloadHosts.value.length > 1) {
+    targetRestoreFocus = document.activeElement as HTMLElement | null;
+    targetEntry.value = entry;
+    updateModalInert();
+    void nextTick(() => {
+      updateModalInert();
+      targetCloseButton.value?.focus();
+    });
+    return;
+  }
+  const host = downloadHosts.value[0] ?? selectedHost.value;
+  if (host) void pullTo(entry, host);
+}
+
+async function pullTo(entry: MobileCatalogEntry, host: MobileHost): Promise<void> {
+  const key = pullKey(entry, host.id);
+  if (pulling.has(key)) return;
+  pulling.add(key);
+  closeTargetPicker();
+  announce(`Connecting to downloads on ${host.name}…`);
+  try {
+    // Subscribe first so even an immediately-started download cannot race its
+    // `enqueued` / `started` events past the iPhone UI.
+    await ensureDownloadStream(host);
+    await startCatalogDownload(entry.id, mobileHostTarget(host), false);
+    announce(`${catalogActionLabel(entry)}ing ${entry.name} on ${host.name}.`);
+  } catch (cause) {
+    const alreadyQueued = cause instanceof ApiError && cause.status === 409;
+    announce(
+      alreadyQueued
+        ? `${entry.name} is already queued on ${host.name}.`
+        : `Could not ${catalogActionLabel(entry).toLowerCase()} ${entry.name} on ${host.name}: ${errorMessage(cause)}`,
+      !alreadyQueued,
+    );
+  } finally {
+    pulling.delete(key);
+  }
+}
+
+async function openDetail(entry: MobileCatalogEntry): Promise<void> {
+  restoreFocus = document.activeElement as HTMLElement | null;
+  announcement.value = "";
+  announcementIsError.value = false;
+  detailEntry.value = entry;
+  detail.value = null;
+  detailComponents.value = [];
+  detailComponentsLoading.value = false;
+  detailBusy.value = "";
+  detailRemoveConfirm.value = false;
+  const target = targetForEntry(entry);
+  const epoch = ++detailEpoch;
+  detailLoading.value = true;
+  updateModalInert();
+  void nextTick(() => {
+    updateModalInert();
+    detailCloseButton.value?.focus();
+  });
+
+  if (target) {
+    void fetchCatalogDetail(entry.id, false, target)
+      .then((result) => {
+        if (epoch === detailEpoch) detail.value = result;
+      })
+      .catch(() => {
+        // Summary data remains useful when an older host has no detail endpoint.
+      })
+      .finally(() => {
+        if (epoch === detailEpoch) detailLoading.value = false;
+      });
+  } else {
+    detailLoading.value = false;
+  }
+
+  if (entry.installed && target) {
+    detailComponentsLoading.value = true;
+    void fetchModelComponents(entry.id, target)
+      .then((result) => {
+        if (epoch === detailEpoch) detailComponents.value = result.components;
+      })
+      .catch(() => {
+        if (epoch === detailEpoch) detailComponents.value = [];
+      })
+      .finally(() => {
+        if (epoch === detailEpoch) detailComponentsLoading.value = false;
+      });
+  }
+}
+
+function closeDetail(): void {
+  ++detailEpoch;
+  detailEntry.value = null;
+  detail.value = null;
+  detailComponents.value = [];
+  detailLoading.value = false;
+  detailComponentsLoading.value = false;
+  detailBusy.value = "";
+  detailRemoveConfirm.value = false;
+  updateModalInert();
+  const focus = restoreFocus;
+  restoreFocus = null;
+  void nextTick(() => focus?.focus?.());
+}
+
+function closeTargetPicker(): void {
+  if (!targetEntry.value) return;
+  targetEntry.value = null;
+  updateModalInert();
+  const focus = targetRestoreFocus;
+  targetRestoreFocus = null;
+  void nextTick(() => focus?.focus?.());
+}
+
+async function changeLoadedState(load: boolean): Promise<void> {
+  const entry = detailEntry.value;
+  const host = entry ? owningHost(entry) : null;
+  if (!entry || !host) return;
+  const epoch = detailEpoch;
+  detailBusy.value = load ? "load" : "unload";
+  try {
+    if (load) await loadModel(entry.name, mobileHostTarget(host));
+    else await unloadModel(entry.name, mobileHostTarget(host));
+    announce(`${entry.name} ${load ? "loaded" : "unloaded"} on ${host.name}.`);
+    emit("models-changed", host.id);
+    await refreshModels();
+  } catch (cause) {
+    announce(errorMessage(cause), true);
+  } finally {
+    if (epoch === detailEpoch && detailEntry.value === entry) detailBusy.value = "";
+  }
+}
+
+async function removeInstalled(): Promise<void> {
+  const entry = detailEntry.value;
+  const host = entry ? owningHost(entry) : null;
+  if (!entry || !host) return;
+  if (!detailRemoveConfirm.value) {
+    detailRemoveConfirm.value = true;
+    return;
+  }
+  const epoch = detailEpoch;
+  detailBusy.value = "remove";
+  try {
+    const result = await removeModel(entry.name, mobileHostTarget(host));
+    announce(`Removed ${entry.name} from ${host.name}; freed ${formatGB(result.freed_bytes)}.`);
+    emit("models-changed", host.id);
+    // The user may close this sheet and inspect another model while removal is
+    // still in flight. Never let the old operation dismiss that new sheet.
+    if (epoch === detailEpoch && detailEntry.value === entry) closeDetail();
+    await refreshModels();
+    await runSearch(true);
+  } catch (cause) {
+    const onGpu = cause instanceof ApiError && cause.status === 409;
+    announce(onGpu ? `${entry.name} is on the GPU. Unload it first.` : errorMessage(cause), true);
+  } finally {
+    if (epoch === detailEpoch && detailEntry.value === entry) detailBusy.value = "";
+  }
+}
+
+function detailTotalLabel(): string {
+  const total = detailDownloadTotal.value;
+  if (total.bytes == null) return "Size unavailable";
+  return `${total.complete ? "" : "At least "}${formatGB(total.bytes)}`;
+}
+
+function selectHost(event: Event): void {
+  emit("select-host", (event.target as HTMLSelectElement).value);
+}
+
+function trapFocus(event: KeyboardEvent, dialog: HTMLElement): void {
+  const focusable = [...dialog.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)];
+  if (focusable.length === 0) {
+    event.preventDefault();
+    return;
+  }
+  const first = focusable[0]!;
+  const last = focusable[focusable.length - 1]!;
+  const active = document.activeElement;
+  if (event.shiftKey && (active === first || !dialog.contains(active))) {
+    event.preventDefault();
+    last.focus();
+  } else if (!event.shiftKey && (active === last || !dialog.contains(active))) {
+    event.preventDefault();
+    first.focus();
+  }
+}
+
+function onKeydown(event: KeyboardEvent): void {
+  if (event.key === "Tab") {
+    const dialog = targetDialog.value ?? detailDialog.value;
+    if (dialog) trapFocus(event, dialog);
+    return;
+  }
+  if (event.key !== "Escape") return;
+  if (targetEntry.value) {
+    closeTargetPicker();
+    return;
+  }
+  if (detailEntry.value) closeDetail();
+}
+
+watch(
+  source,
+  (next) => {
+    if (next === "installed") family.value = "";
+  },
+  { flush: "sync" },
+);
+
+watch([query, source, family, includeNsfw], scheduleSearch);
+
+watch(mediaType, () => {
+  if (source.value === "installed" || loading.value || mediaType.value === "all") return;
+  if (!combinedEntries.value.some(mediaMatches) && hasMore.value) loadMore();
+});
+
+watch(
+  () => props.selectedHostId,
+  () => {
+    if (!mounted) return;
+    closeDetail();
+    family.value = "";
+    void loadFamilies();
+    void runSearch(true);
+  },
+);
+
+watch(
+  () =>
+    props.hosts
+      .map(
+        (host) =>
+          `${host.id}:${host.baseUrl}:${host.apiKey}:${host.online}:${host.name}:${host.version ?? ""}`,
+      )
+      .join("|"),
+  () => {
+    if (!mounted) return;
+    syncDownloadStreams();
+    void refreshModels();
+  },
+);
+
+onMounted(() => {
+  mounted = true;
+  window.addEventListener("keydown", onKeydown);
+  syncDownloadStreams();
+  void refreshModels();
+  void loadFamilies();
+  void runSearch(true);
+});
+
+onBeforeUnmount(() => {
+  mounted = false;
+  ++searchEpoch;
+  ++familyEpoch;
+  ++modelsEpoch;
+  ++detailEpoch;
+  if (debounce) clearTimeout(debounce);
+  window.removeEventListener("keydown", onKeydown);
+  clearModalInert();
+  for (const subscription of subscriptions.values()) subscription.close();
+  subscriptions.clear();
+});
+</script>
+
+<template>
+  <section ref="catalogRoot" class="mobile-catalog" aria-labelledby="mobile-catalog-title">
+    <header class="mobile-catalog-header">
+      <div>
+        <h1 id="mobile-catalog-title" class="section-title">Catalog</h1>
+        <p class="section-note">Models for your remote Mold hosts</p>
+      </div>
+      <label v-if="hosts.length > 1" class="mobile-catalog-host-picker">
+        <span>Browse on</span>
+        <select :value="selectedHostId" aria-label="Catalog host" @change="selectHost">
+          <option v-for="host in hosts" :key="host.id" :value="host.id">
+            {{ host.name }}{{ host.online ? "" : " · offline" }}
+          </option>
+        </select>
+      </label>
+    </header>
+
+    <p
+      v-if="announcement && !detailEntry && !targetEntry"
+      class="mobile-catalog-action-status mobile-catalog-error"
+      :class="{ 'error-text': announcementIsError }"
+      :role="announcementIsError ? 'alert' : 'status'"
+      aria-atomic="true"
+      data-test="mobile-catalog-action-status"
+    >
+      {{ announcement }}
+    </p>
+
+    <div v-if="!selectedHost" class="mobile-catalog-empty empty-state">
+      Add and select a remote host to browse its catalog.
+    </div>
+
+    <template v-else>
+      <section
+        v-if="downloadRows.length"
+        class="mobile-catalog-downloads"
+        aria-labelledby="mobile-catalog-downloads-title"
+      >
+        <div class="mobile-catalog-downloads-head">
+          <h2 id="mobile-catalog-downloads-title">Downloads</h2>
+          <span>{{ downloadRows.length }} active</span>
+        </div>
+        <ul>
+          <li
+            v-for="row in downloadRows"
+            :key="`${row.host.id}:${row.job.id}`"
+            class="mobile-catalog-download"
+            data-test="mobile-catalog-download"
+          >
+            <div class="mobile-catalog-download-copy">
+              <strong>{{ row.job.model }}</strong>
+              <span>{{ row.host.name }} · {{ row.job.status }}</span>
+            </div>
+            <div
+              class="mobile-catalog-download-progress"
+              role="progressbar"
+              aria-valuemin="0"
+              aria-valuemax="100"
+              :aria-valuenow="percent(row.job.bytes_done, row.job.bytes_total)"
+              :aria-label="`Downloading ${row.job.model} on ${row.host.name}`"
+            >
+              <span :style="{ width: `${percent(row.job.bytes_done, row.job.bytes_total)}%` }" />
+            </div>
+            <span class="mobile-catalog-download-size">
+              <template v-if="row.job.bytes_total">
+                {{ formatGB(row.job.bytes_done) }} / {{ formatGB(row.job.bytes_total) }}
+              </template>
+              <template v-else>Waiting…</template>
+            </span>
+            <button
+              type="button"
+              :disabled="cancelling.has(`${row.host.id}:${row.job.id}`)"
+              :aria-label="`Cancel download of ${row.job.model} on ${row.host.name}`"
+              @click="cancelDownload(row)"
+            >
+              {{ cancelling.has(`${row.host.id}:${row.job.id}`) ? "…" : "Cancel" }}
+            </button>
+          </li>
+        </ul>
+      </section>
+
+      <div class="mobile-catalog-search-row">
+        <input
+          v-model="query"
+          type="search"
+          inputmode="search"
+          autocomplete="off"
+          aria-label="Search catalog"
+          placeholder="Search models…"
+          data-test="mobile-catalog-search"
+        />
+      </div>
+
+      <div class="mobile-catalog-media" role="group" aria-label="Media type">
+        <button
+          v-for="option in ['all', 'image', 'video'] as const"
+          :key="option"
+          type="button"
+          :aria-pressed="mediaType === option"
+          @click="mediaType = option"
+        >
+          {{ option === "all" ? "All" : option === "image" ? "Images" : "Video" }}
+        </button>
+      </div>
+
+      <div class="mobile-catalog-sources" role="group" aria-label="Catalog source">
+        <button
+          v-for="option in ['all', 'hf', 'civitai', 'installed'] as const"
+          :key="option"
+          type="button"
+          :aria-pressed="source === option"
+          @click="source = option"
+        >
+          {{
+            option === "all"
+              ? "All"
+              : option === "hf"
+                ? "HuggingFace"
+                : option === "civitai"
+                  ? "Civitai"
+                  : "Installed"
+          }}
+        </button>
+      </div>
+
+      <div v-if="source !== 'installed'" class="mobile-catalog-filters">
+        <label>
+          <span>Family</span>
+          <select v-model="family">
+            <option value="">All families</option>
+            <option v-for="option in families" :key="option" :value="option">
+              {{ option }}
+            </option>
+          </select>
+        </label>
+        <label class="mobile-catalog-nsfw">
+          <input v-model="includeNsfw" type="checkbox" />
+          <span>Include NSFW</span>
+        </label>
+      </div>
+
+      <p v-if="error" class="mobile-catalog-error error-text" role="alert">{{ error }}</p>
+      <div v-if="loading && combinedEntries.length === 0" class="mobile-catalog-empty empty-state">
+        Loading models…
+      </div>
+      <div
+        v-else-if="combinedEntries.length === 0"
+        class="mobile-catalog-empty empty-state"
+        data-test="mobile-catalog-empty"
+      >
+        <template v-if="source === 'installed'">No installed models match these filters.</template>
+        <template v-else-if="query.trim()">Nothing found for “{{ query.trim() }}”.</template>
+        <template v-else>No catalog models found.</template>
+      </div>
+
+      <ul v-else class="mobile-catalog-results" aria-label="Catalog models">
+        <li
+          v-for="entry in combinedEntries"
+          :key="entry.id"
+          class="mobile-catalog-card"
+          data-test="mobile-catalog-card"
+        >
+          <button
+            type="button"
+            class="mobile-catalog-card-open"
+            :aria-label="`${entry.name} — view details`"
+            @click="openDetail(entry)"
+          >
+            <span class="mobile-catalog-card-preview">
+              <img
+                v-if="entry.thumbnail_url"
+                :src="catalogThumbnailUrl(entry.thumbnail_url)"
+                alt=""
+                loading="lazy"
+                decoding="async"
+              />
+              <span v-else aria-hidden="true">{{ entry.family.slice(0, 3).toUpperCase() }}</span>
+            </span>
+            <span class="mobile-catalog-card-body">
+              <span class="mobile-catalog-card-title">{{ entry.name }}</span>
+              <span class="mobile-catalog-card-meta">
+                {{ entry.author ? `${entry.author} · ` : "" }}{{ entry.family }}
+                <template v-if="entry.download_count">
+                  · ↓ {{ formatCount(entry.download_count) }}
+                </template>
+              </span>
+              <span v-if="entry.hostLabels?.length" class="mobile-catalog-host-labels">
+                <span v-for="label in entry.hostLabels" :key="label">{{ label }}</span>
+              </span>
+              <span v-if="entry.size_bytes != null" class="mobile-catalog-card-size">
+                {{ catalogSizeLabel(catalogSizeInfo(entry)) }}
+              </span>
+            </span>
+          </button>
+          <span v-if="entry.installed" class="mobile-catalog-installed">Installed</span>
+          <button
+            v-else
+            type="button"
+            class="mobile-catalog-pull"
+            :disabled="pulling.has(pullKey(entry, downloadHosts[0]?.id))"
+            @click="requestPull(entry)"
+          >
+            {{
+              pulling.has(pullKey(entry, downloadHosts[0]?.id))
+                ? "Queuing…"
+                : catalogPullLabel(catalogSizeInfo(entry))
+            }}
+          </button>
+        </li>
+      </ul>
+
+      <button
+        v-if="source !== 'installed' && hasMore"
+        class="mobile-catalog-more secondary-button"
+        type="button"
+        :disabled="loading"
+        @click="loadMore"
+      >
+        {{ loading ? "Loading…" : "Load more" }}
+      </button>
+    </template>
+
+    <Teleport to="body">
+      <section
+        v-if="detailEntry && mergedDetail"
+        ref="detailDialog"
+        class="mobile-catalog-detail"
+        role="dialog"
+        aria-modal="true"
+        :aria-labelledby="`mobile-catalog-detail-${detailEntry.id}`"
+        data-test="mobile-catalog-detail"
+      >
+        <header class="mobile-catalog-detail-header">
+          <button
+            ref="detailCloseButton"
+            type="button"
+            aria-label="Close model details"
+            @click="closeDetail"
+          >
+            ‹ <span>Catalog</span>
+          </button>
+          <strong :id="`mobile-catalog-detail-${detailEntry.id}`">Model details</strong>
+          <span aria-hidden="true" />
+        </header>
+
+        <div class="mobile-catalog-detail-scroll">
+          <div class="mobile-catalog-detail-preview">
+            <img
+              v-if="mergedDetail.thumbnail_url"
+              :src="catalogThumbnailUrl(mergedDetail.thumbnail_url)"
+              alt=""
+            />
+            <span v-else aria-hidden="true">{{ mergedDetail.family.toUpperCase() }}</span>
+          </div>
+
+          <article class="mobile-catalog-detail-copy">
+            <div class="mobile-catalog-detail-title">
+              <div>
+                <h2>{{ mergedDetail.name }}</h2>
+                <p v-if="mergedDetail.author">by {{ mergedDetail.author }}</p>
+              </div>
+              <span v-if="mergedDetail.installed">Installed</span>
+            </div>
+
+            <dl class="mobile-catalog-detail-meta">
+              <div>
+                <dt>Family</dt>
+                <dd>{{ mergedDetail.family }}</dd>
+              </div>
+              <div v-if="mergedDetail.modality">
+                <dt>Modality</dt>
+                <dd>{{ mergedDetail.modality }}</dd>
+              </div>
+              <div v-if="mergedDetail.file_format">
+                <dt>Format</dt>
+                <dd>{{ mergedDetail.file_format }}</dd>
+              </div>
+              <div v-if="mergedDetail.size_bytes != null">
+                <dt>Weights</dt>
+                <dd>{{ formatGB(mergedDetail.size_bytes) }}</dd>
+              </div>
+              <div v-if="mergedDetail.license">
+                <dt>License</dt>
+                <dd>{{ mergedDetail.license }}</dd>
+              </div>
+              <div v-if="mergedDetail.rating != null">
+                <dt>Rating</dt>
+                <dd>★ {{ mergedDetail.rating.toFixed(1) }}</dd>
+              </div>
+            </dl>
+
+            <p v-if="mergedDetail.description" class="mobile-catalog-detail-description">
+              {{ mergedDetail.description }}
+            </p>
+            <p v-else-if="detailLoading" class="mobile-catalog-detail-muted">Loading details…</p>
+
+            <div v-if="mergedDetail.tags?.length" class="mobile-catalog-detail-tags">
+              <span v-for="tag in mergedDetail.tags" :key="tag">{{ tag }}</span>
+            </div>
+
+            <section
+              v-if="detailDownloadItems.length"
+              class="mobile-catalog-detail-section"
+              aria-labelledby="mobile-catalog-contents-title"
+            >
+              <div class="mobile-catalog-detail-section-head">
+                <h3 id="mobile-catalog-contents-title">Download contents</h3>
+                <span>{{ detailTotalLabel() }}</span>
+              </div>
+              <ul>
+                <li v-for="item in detailDownloadItems" :key="item.key">
+                  <span>{{ item.label }}</span>
+                  <span
+                    >{{ item.kind }} · {{ item.sizeBytes ? formatGB(item.sizeBytes) : "—" }}</span
+                  >
+                </li>
+              </ul>
+            </section>
+
+            <section
+              v-if="detailComponents.length || detailComponentsLoading"
+              class="mobile-catalog-detail-section"
+              aria-labelledby="mobile-catalog-components-title"
+            >
+              <div class="mobile-catalog-detail-section-head">
+                <h3 id="mobile-catalog-components-title">On this host</h3>
+                <span v-if="detailComponents.length">
+                  {{ detailComponents.filter((item) => item.present).length }}/{{
+                    detailComponents.length
+                  }}
+                  present
+                </span>
+              </div>
+              <p v-if="detailComponentsLoading" class="mobile-catalog-detail-muted">
+                Checking files…
+              </p>
+              <ul v-else>
+                <li v-for="component in detailComponents" :key="component.name">
+                  <span>{{ component.name }}</span>
+                  <span
+                    class="mobile-catalog-component-status"
+                    :data-present="component.present"
+                    :aria-label="`${component.present ? 'Present' : 'Missing'}: ${component.kind}`"
+                  >
+                    <span
+                      class="mobile-catalog-component-dot"
+                      :data-present="component.present"
+                      aria-hidden="true"
+                    />
+                    {{ component.present ? "Present" : "Missing" }} · {{ component.kind }}
+                  </span>
+                </li>
+              </ul>
+            </section>
+
+            <section
+              v-if="mergedDetail.installed && detailModel"
+              class="mobile-catalog-installed-actions"
+              aria-label="Installed model actions"
+            >
+              <button
+                v-if="detailModel.is_loaded"
+                type="button"
+                class="secondary-button"
+                :disabled="Boolean(detailBusy)"
+                @click="changeLoadedState(false)"
+              >
+                {{ detailBusy === "unload" ? "Unloading…" : "Unload from GPU" }}
+              </button>
+              <button
+                v-else
+                type="button"
+                class="secondary-button"
+                :disabled="Boolean(detailBusy)"
+                @click="changeLoadedState(true)"
+              >
+                {{ detailBusy === "load" ? "Loading…" : "Load on GPU" }}
+              </button>
+              <button
+                type="button"
+                class="danger-button"
+                :disabled="Boolean(detailBusy)"
+                @blur="detailRemoveConfirm = false"
+                @click="removeInstalled"
+              >
+                {{
+                  detailBusy === "remove"
+                    ? "Removing…"
+                    : detailRemoveConfirm
+                      ? "Tap again to remove"
+                      : "Remove from host"
+                }}
+              </button>
+            </section>
+          </article>
+        </div>
+
+        <footer class="mobile-catalog-detail-action">
+          <p
+            v-if="announcement"
+            class="mobile-catalog-action-status"
+            :class="{ 'error-text': announcementIsError }"
+            :role="announcementIsError ? 'alert' : 'status'"
+            aria-atomic="true"
+            data-test="mobile-catalog-detail-action-status"
+          >
+            {{ announcement }}
+          </p>
+          <p v-if="mergedDetail.engine_phase != null && !canDownloadEntry(mergedDetail)">
+            This catalog package is not supported by a shipped Mold engine yet.
+          </p>
+          <p v-else-if="catalogFetchCaption(catalogSizeInfo(mergedDetail))">
+            {{ catalogFetchCaption(catalogSizeInfo(mergedDetail)) }}
+          </p>
+          <button
+            type="button"
+            class="primary-button"
+            :disabled="!canDownloadEntry(mergedDetail)"
+            @click="requestPull(detailEntry)"
+          >
+            {{ catalogActionLabel(mergedDetail) }}
+            <template v-if="detailDownloadTotal.bytes != null">
+              · {{ detailTotalLabel() }}</template
+            >
+          </button>
+        </footer>
+      </section>
+
+      <section
+        v-if="targetEntry"
+        ref="targetDialog"
+        class="mobile-catalog-target-sheet"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="mobile-catalog-target-title"
+        data-test="mobile-catalog-target-sheet"
+      >
+        <div class="mobile-catalog-target-backdrop" @click="closeTargetPicker" />
+        <div class="mobile-catalog-target-panel">
+          <header>
+            <div>
+              <h2 id="mobile-catalog-target-title">Choose a host</h2>
+              <p>{{ catalogActionLabel(targetEntry) }} {{ targetEntry.name }}</p>
+            </div>
+            <button
+              ref="targetCloseButton"
+              type="button"
+              aria-label="Close host picker"
+              @click="closeTargetPicker"
+            >
+              Close
+            </button>
+          </header>
+          <div class="mobile-catalog-target-list">
+            <button
+              v-for="host in downloadHosts"
+              :key="host.id"
+              type="button"
+              @click="pullTo(targetEntry, host)"
+            >
+              <span>
+                <strong>{{ host.name }}</strong>
+                <small>{{ host.baseUrl }}</small>
+              </span>
+              <span>{{ host.id === selectedHostId ? "Current" : "" }} ›</span>
+            </button>
+          </div>
+        </div>
+      </section>
+    </Teleport>
+  </section>
+</template>

--- a/desktop/src/mobile/MobileCatalogView.vue
+++ b/desktop/src/mobile/MobileCatalogView.vue
@@ -1,5 +1,15 @@
 <script setup lang="ts">
-import { computed, nextTick, onBeforeUnmount, onMounted, reactive, ref, watch } from "vue";
+import {
+  computed,
+  nextTick,
+  onActivated,
+  onBeforeUnmount,
+  onDeactivated,
+  onMounted,
+  reactive,
+  ref,
+  watch,
+} from "vue";
 import { apiFetchTo, ApiError, type ApiTarget } from "../lib/api/client";
 import {
   fetchCatalogDetail,
@@ -117,6 +127,7 @@ let targetRestoreFocus: HTMLElement | null = null;
 let inertBackground: HTMLElement | null = null;
 
 let mounted = false;
+let interactionListenersActive = false;
 let searchEpoch = 0;
 let familyEpoch = 0;
 let modelsEpoch = 0;
@@ -781,6 +792,26 @@ function onKeydown(event: KeyboardEvent): void {
   if (detailEntry.value) closeDetail();
 }
 
+function activateInteractions(): void {
+  if (!interactionListenersActive) {
+    window.addEventListener("keydown", onKeydown);
+    interactionListenersActive = true;
+  }
+  void nextTick(() => {
+    updateModalInert();
+    if (targetEntry.value) targetCloseButton.value?.focus();
+    else if (detailEntry.value) detailCloseButton.value?.focus();
+  });
+}
+
+function deactivateInteractions(): void {
+  if (interactionListenersActive) {
+    window.removeEventListener("keydown", onKeydown);
+    interactionListenersActive = false;
+  }
+  clearModalInert();
+}
+
 watch(
   source,
   (next) => {
@@ -824,12 +855,15 @@ watch(
 
 onMounted(() => {
   mounted = true;
-  window.addEventListener("keydown", onKeydown);
+  activateInteractions();
   syncDownloadStreams();
   void refreshModels();
   void loadFamilies();
   void runSearch(true);
 });
+
+onActivated(activateInteractions);
+onDeactivated(deactivateInteractions);
 
 onBeforeUnmount(() => {
   mounted = false;
@@ -838,8 +872,7 @@ onBeforeUnmount(() => {
   ++modelsEpoch;
   ++detailEpoch;
   if (debounce) clearTimeout(debounce);
-  window.removeEventListener("keydown", onKeydown);
-  clearModalInert();
+  deactivateInteractions();
   for (const subscription of subscriptions.values()) subscription.close();
   subscriptions.clear();
 });

--- a/desktop/src/mobile/MobileGalleryViewer.test.ts
+++ b/desktop/src/mobile/MobileGalleryViewer.test.ts
@@ -33,7 +33,15 @@ const image: GalleryImage = {
 
 let wrapper: VueWrapper | null = null;
 
-function mountViewer(item: GalleryImage = image): VueWrapper {
+function mountViewer(
+  item: GalleryImage = image,
+  navigation: {
+    position?: number;
+    total?: number;
+    hasPrevious?: boolean;
+    hasNext?: boolean;
+  } = {},
+): VueWrapper {
   wrapper = mount(MobileGalleryViewer, {
     attachTo: document.body,
     props: {
@@ -42,6 +50,7 @@ function mountViewer(item: GalleryImage = image): VueWrapper {
       cacheKey: "studio",
       hostName: "Studio",
       thumbnailUrl: "blob:thumbnail",
+      ...navigation,
     },
   });
   return wrapper;
@@ -104,6 +113,22 @@ describe("MobileGalleryViewer", () => {
     await video.trigger("loadedmetadata");
     expect(view.find("[role='status']").exists()).toBe(false);
 
+    await video.trigger("pointerdown", {
+      pointerId: 7,
+      pointerType: "touch",
+      isPrimary: true,
+      clientX: 280,
+      clientY: 200,
+    });
+    await view.get("[data-test='gallery-viewer-stage']").trigger("pointerup", {
+      pointerId: 7,
+      pointerType: "touch",
+      isPrimary: true,
+      clientX: 80,
+      clientY: 200,
+    });
+    expect(view.emitted("next")).toBeUndefined();
+
     await view.get("dialog").trigger("cancel");
     expect(view.emitted("close")).toHaveLength(1);
   });
@@ -143,6 +168,79 @@ describe("MobileGalleryViewer", () => {
     expect(evictMedia).toHaveBeenCalledWith("/api/gallery/image/print%20one.png", "studio");
   });
 
+  it("reloads changed image items and evicts each item's own media path", async () => {
+    streamableMediaUrl
+      .mockResolvedValueOnce("https://studio/media/one")
+      .mockResolvedValueOnce("https://studio/media/two");
+    const view = mountViewer();
+    await flushPromises();
+
+    expect(view.get("[data-test='gallery-viewer-image']").attributes("src")).toBe(
+      "https://studio/media/one",
+    );
+
+    await view.setProps({
+      item: { ...image, filename: "print two.png" },
+      thumbnailUrl: "blob:thumbnail-two",
+    });
+    await flushPromises();
+
+    expect(streamableMediaUrl).toHaveBeenLastCalledWith("/api/gallery/image/print%20two.png", {
+      target,
+      cacheKey: "studio",
+      allowLegacyBlob: true,
+    });
+    expect(view.get("[data-test='gallery-viewer-image']").attributes("src")).toBe(
+      "https://studio/media/two",
+    );
+    expect(evictMedia).toHaveBeenCalledWith("/api/gallery/image/print%20one.png", "studio");
+
+    view.unmount();
+    wrapper = null;
+    expect(evictMedia).toHaveBeenLastCalledWith("/api/gallery/image/print%20two.png", "studio");
+  });
+
+  it("reloads across hosts and ignores a stale resolution from the previous host", async () => {
+    let resolveStudio!: (url: string) => void;
+    streamableMediaUrl
+      .mockImplementationOnce(
+        () =>
+          new Promise<string>((resolve) => {
+            resolveStudio = resolve;
+          }),
+      )
+      .mockResolvedValueOnce("https://remote/media/full");
+    const view = mountViewer();
+    const remoteTarget = { baseUrl: "https://remote.example.com", apiKey: "remote-secret" };
+
+    await view.setProps({
+      target: remoteTarget,
+      cacheKey: "remote",
+      hostName: "Remote",
+    });
+    await flushPromises();
+
+    expect(streamableMediaUrl).toHaveBeenLastCalledWith("/api/gallery/image/print%20one.png", {
+      target: remoteTarget,
+      cacheKey: "remote",
+      allowLegacyBlob: true,
+    });
+    expect(view.get("[data-test='gallery-viewer-image']").attributes("src")).toBe(
+      "https://remote/media/full",
+    );
+    expect(evictMedia).toHaveBeenCalledWith("/api/gallery/image/print%20one.png", "studio");
+
+    resolveStudio("https://studio/media/stale");
+    await flushPromises();
+    expect(view.get("[data-test='gallery-viewer-image']").attributes("src")).toBe(
+      "https://remote/media/full",
+    );
+
+    view.unmount();
+    wrapper = null;
+    expect(evictMedia).toHaveBeenLastCalledWith("/api/gallery/image/print%20one.png", "remote");
+  });
+
   it("does not offer reuse when the host only synthesized file metadata", async () => {
     const view = mountViewer({ ...image, metadata_synthetic: true });
     await flushPromises();
@@ -150,5 +248,111 @@ describe("MobileGalleryViewer", () => {
     const reuse = view.get("[data-test='gallery-viewer-reuse']");
     expect(reuse.attributes("disabled")).toBe("");
     expect(reuse.text()).toBe("Prompt unavailable");
+  });
+
+  it("shows an accessible position and previous/next controls", async () => {
+    const view = mountViewer(image, { position: 2, total: 4 });
+    await flushPromises();
+
+    expect(view.get("[data-test='gallery-viewer-position']").text()).toBe("2 of 4");
+    expect(view.get("[data-test='gallery-viewer-position']").attributes()).toMatchObject({
+      role: "status",
+      "aria-live": "polite",
+    });
+
+    const previous = view.get("[data-test='gallery-viewer-previous']");
+    const next = view.get("[data-test='gallery-viewer-next']");
+    expect(previous.attributes("aria-label")).toBe("Previous print");
+    expect(next.attributes("aria-label")).toBe("Next print");
+
+    await previous.trigger("click");
+    await next.trigger("click");
+    expect(view.emitted("previous")).toHaveLength(1);
+    expect(view.emitted("next")).toHaveLength(1);
+  });
+
+  it("disables navigation at the gallery boundaries", async () => {
+    const view = mountViewer(image, {
+      position: 1,
+      total: 3,
+      hasPrevious: false,
+      hasNext: true,
+    });
+    await flushPromises();
+
+    const previous = view.get("[data-test='gallery-viewer-previous']");
+    const next = view.get("[data-test='gallery-viewer-next']");
+    expect(previous.attributes("disabled")).toBe("");
+    expect(next.attributes("disabled")).toBeUndefined();
+    await previous.trigger("click");
+    await next.trigger("click");
+    expect(view.emitted("previous")).toBeUndefined();
+    expect(view.emitted("next")).toHaveLength(1);
+  });
+
+  it("navigates horizontally with swipe gestures and ignores vertical drags", async () => {
+    const view = mountViewer(image, { position: 2, total: 4 });
+    await flushPromises();
+    const stage = view.get("[data-test='gallery-viewer-stage']");
+
+    await stage.trigger("pointerdown", {
+      pointerId: 11,
+      pointerType: "touch",
+      isPrimary: true,
+      clientX: 300,
+      clientY: 200,
+    });
+    await stage.trigger("pointerup", {
+      pointerId: 11,
+      pointerType: "touch",
+      isPrimary: true,
+      clientX: 180,
+      clientY: 208,
+    });
+    expect(view.emitted("next")).toHaveLength(1);
+
+    await stage.trigger("pointerdown", {
+      pointerId: 12,
+      pointerType: "touch",
+      isPrimary: true,
+      clientX: 80,
+      clientY: 200,
+    });
+    await stage.trigger("pointerup", {
+      pointerId: 12,
+      pointerType: "touch",
+      isPrimary: true,
+      clientX: 190,
+      clientY: 206,
+    });
+    expect(view.emitted("previous")).toHaveLength(1);
+
+    await stage.trigger("pointerdown", {
+      pointerId: 13,
+      pointerType: "touch",
+      isPrimary: true,
+      clientX: 180,
+      clientY: 100,
+    });
+    await stage.trigger("pointerup", {
+      pointerId: 13,
+      pointerType: "touch",
+      isPrimary: true,
+      clientX: 170,
+      clientY: 220,
+    });
+    expect(view.emitted("previous")).toHaveLength(1);
+    expect(view.emitted("next")).toHaveLength(1);
+  });
+
+  it("supports keyboard navigation without stealing keys from video controls", async () => {
+    const view = mountViewer(image, { position: 2, total: 4 });
+    await flushPromises();
+
+    const dialog = view.get("dialog");
+    await dialog.trigger("keydown", { key: "ArrowLeft" });
+    await dialog.trigger("keydown", { key: "ArrowRight" });
+    expect(view.emitted("previous")).toHaveLength(1);
+    expect(view.emitted("next")).toHaveLength(1);
   });
 });

--- a/desktop/src/mobile/MobileGalleryViewer.vue
+++ b/desktop/src/mobile/MobileGalleryViewer.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref } from "vue";
+import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import type { ApiTarget } from "../lib/api/client";
 import type { GalleryImage } from "../lib/api/types";
 import {
@@ -19,11 +19,23 @@ const props = withDefaults(
     reusing?: boolean;
     reuseError?: string;
     generationAnnouncement?: string;
+    position?: number;
+    total?: number;
+    hasPrevious?: boolean | null;
+    hasNext?: boolean | null;
   }>(),
-  { reusing: false, reuseError: "", generationAnnouncement: "" },
+  {
+    reusing: false,
+    reuseError: "",
+    generationAnnouncement: "",
+    position: 1,
+    total: 1,
+    hasPrevious: null,
+    hasNext: null,
+  },
 );
 
-const emit = defineEmits<{ close: []; reuse: [] }>();
+const emit = defineEmits<{ close: []; reuse: []; previous: []; next: [] }>();
 
 const dialog = ref<HTMLDialogElement | null>(null);
 const closeButton = ref<HTMLButtonElement | null>(null);
@@ -32,28 +44,67 @@ const loading = ref(true);
 const loadError = ref("");
 const mediaLoadKey = ref(0);
 const video = computed(() => isVideoItem(props.item));
-const mediaPath = computed(() => galleryMediaPath(props.item.filename, "host"));
 const canReuse = computed(
   () => !props.item.metadata_synthetic && !!props.item.metadata.prompt?.trim(),
 );
 const actionLabel = computed(() =>
   props.reusing ? "Loading prompt…" : canReuse.value ? "Use as prompt" : "Prompt unavailable",
 );
+const galleryTotal = computed(() => Math.max(1, Math.floor(props.total)));
+const galleryPosition = computed(() =>
+  Math.min(galleryTotal.value, Math.max(1, Math.floor(props.position))),
+);
+const hasPrevious = computed(
+  () => !props.reusing && (props.hasPrevious ?? galleryPosition.value > 1),
+);
+const hasNext = computed(
+  () => !props.reusing && (props.hasNext ?? galleryPosition.value < galleryTotal.value),
+);
+const showNavigation = computed(() => galleryTotal.value > 1);
 
 let restoreFocusElement: HTMLElement | null = null;
 let loadEpoch = 0;
+let mounted = false;
+let activeMedia: MediaLoad | null = null;
+let gesturePointerId: number | null = null;
+let gestureStartX = 0;
+let gestureStartY = 0;
 
-async function loadMedia(): Promise<void> {
+const SWIPE_DISTANCE = 48;
+const HORIZONTAL_INTENT_RATIO = 1.25;
+
+interface MediaLoad {
+  path: string;
+  target: ApiTarget;
+  cacheKey: string;
+  allowLegacyBlob: boolean;
+}
+
+function currentMediaLoad(): MediaLoad {
+  return {
+    path: galleryMediaPath(props.item.filename, "host"),
+    target: { baseUrl: props.target.baseUrl, apiKey: props.target.apiKey },
+    cacheKey: props.cacheKey,
+    allowLegacyBlob: !isVideoItem(props.item),
+  };
+}
+
+function evictLoad(load: MediaLoad | null): void {
+  if (load) evictMedia(load.path, load.cacheKey);
+}
+
+async function loadMedia(load = currentMediaLoad()): Promise<void> {
   const epoch = ++loadEpoch;
+  activeMedia = load;
   loading.value = true;
   loadError.value = "";
   mediaUrl.value = "";
   mediaLoadKey.value += 1;
   try {
-    const url = await streamableMediaUrl(mediaPath.value, {
-      target: props.target,
-      cacheKey: props.cacheKey,
-      allowLegacyBlob: !video.value,
+    const url = await streamableMediaUrl(load.path, {
+      target: load.target,
+      cacheKey: load.cacheKey,
+      allowLegacyBlob: load.allowLegacyBlob,
     });
     if (epoch !== loadEpoch) return;
     mediaUrl.value = url;
@@ -68,9 +119,14 @@ async function loadMedia(): Promise<void> {
   }
 }
 
+function reloadMedia(): void {
+  evictLoad(activeMedia);
+  void loadMedia(currentMediaLoad());
+}
+
 function retry(): void {
-  evictMedia(mediaPath.value, props.cacheKey);
-  void loadMedia();
+  evictLoad(activeMedia);
+  void loadMedia(currentMediaLoad());
 }
 
 function mediaReady(): void {
@@ -88,7 +144,96 @@ function cancelViewer(): void {
   if (!props.reusing) emit("close");
 }
 
+function navigate(direction: "previous" | "next"): void {
+  if (direction === "previous") {
+    if (hasPrevious.value) emit("previous");
+  } else if (hasNext.value) {
+    emit("next");
+  }
+}
+
+function isMediaControl(target: EventTarget | null): boolean {
+  return (
+    target instanceof Element &&
+    !!target.closest("video, button, input, textarea, select, a, [contenteditable='true']")
+  );
+}
+
+function beginSwipe(event: PointerEvent): void {
+  if (
+    props.reusing ||
+    isMediaControl(event.target) ||
+    event.isPrimary === false ||
+    (event.pointerType === "mouse" && event.button !== 0)
+  ) {
+    return;
+  }
+
+  gesturePointerId = event.pointerId;
+  gestureStartX = event.clientX;
+  gestureStartY = event.clientY;
+  if (event.currentTarget instanceof Element && "setPointerCapture" in event.currentTarget) {
+    try {
+      event.currentTarget.setPointerCapture(event.pointerId);
+    } catch {
+      // WebKit can reject pointer capture when the gesture has already ended.
+    }
+  }
+}
+
+function trackSwipe(event: PointerEvent): void {
+  if (gesturePointerId !== event.pointerId) return;
+  const deltaX = event.clientX - gestureStartX;
+  const deltaY = event.clientY - gestureStartY;
+  if (Math.abs(deltaX) > 12 && Math.abs(deltaX) > Math.abs(deltaY)) event.preventDefault();
+}
+
+function finishSwipe(event: PointerEvent): void {
+  if (gesturePointerId !== event.pointerId) return;
+  const deltaX = event.clientX - gestureStartX;
+  const deltaY = event.clientY - gestureStartY;
+  gesturePointerId = null;
+
+  if (
+    Math.abs(deltaX) < SWIPE_DISTANCE ||
+    Math.abs(deltaX) < Math.abs(deltaY) * HORIZONTAL_INTENT_RATIO
+  ) {
+    return;
+  }
+  navigate(deltaX < 0 ? "next" : "previous");
+}
+
+function cancelSwipe(event?: PointerEvent): void {
+  if (!event || gesturePointerId === event.pointerId) gesturePointerId = null;
+}
+
+function handleViewerKeydown(event: KeyboardEvent): void {
+  if (isMediaControl(event.target)) return;
+  if (event.key === "ArrowLeft" && hasPrevious.value) {
+    event.preventDefault();
+    navigate("previous");
+  } else if (event.key === "ArrowRight" && hasNext.value) {
+    event.preventDefault();
+    navigate("next");
+  }
+}
+
+watch(
+  () => [
+    props.item.filename,
+    props.item.format,
+    !!props.item.metadata.video_frames,
+    props.target.baseUrl,
+    props.target.apiKey,
+    props.cacheKey,
+  ],
+  () => {
+    if (mounted) reloadMedia();
+  },
+);
+
 onMounted(() => {
+  mounted = true;
   restoreFocusElement = document.activeElement as HTMLElement | null;
   try {
     dialog.value?.showModal();
@@ -100,9 +245,11 @@ onMounted(() => {
 });
 
 onBeforeUnmount(() => {
+  mounted = false;
   loadEpoch += 1;
   if (dialog.value?.open && typeof dialog.value.close === "function") dialog.value.close();
-  evictMedia(mediaPath.value, props.cacheKey);
+  evictLoad(activeMedia);
+  activeMedia = null;
   restoreFocusElement?.focus?.();
 });
 </script>
@@ -116,6 +263,7 @@ onBeforeUnmount(() => {
     aria-labelledby="gallery-viewer-title"
     data-test="gallery-viewer"
     @cancel.prevent="cancelViewer"
+    @keydown="handleViewerKeydown"
   >
     <p class="sr-only" aria-live="polite" aria-atomic="true">
       {{ generationAnnouncement }}
@@ -136,16 +284,35 @@ onBeforeUnmount(() => {
       <div class="gallery-viewer-origin">
         <h1 id="gallery-viewer-title">Print preview</h1>
         <span>{{ hostName }}</span>
+        <span
+          v-if="showNavigation"
+          class="gallery-viewer-position"
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+          data-test="gallery-viewer-position"
+        >
+          {{ galleryPosition }} of {{ galleryTotal }}
+        </span>
       </div>
     </header>
 
-    <div class="gallery-viewer-stage">
+    <div
+      class="gallery-viewer-stage"
+      data-test="gallery-viewer-stage"
+      @pointerdown="beginSwipe"
+      @pointermove="trackSwipe"
+      @pointerup="finishSwipe"
+      @pointercancel="cancelSwipe"
+      @lostpointercapture="cancelSwipe"
+    >
       <img
         v-if="!mediaUrl"
         class="gallery-viewer-placeholder"
         :src="thumbnailUrl"
         alt=""
         aria-hidden="true"
+        draggable="false"
       />
       <video
         v-else-if="video"
@@ -167,6 +334,7 @@ onBeforeUnmount(() => {
         :src="mediaUrl"
         :alt="item.metadata.prompt || item.filename"
         data-test="gallery-viewer-image"
+        draggable="false"
         @load="mediaReady"
         @error="mediaFailed"
       />
@@ -178,6 +346,29 @@ onBeforeUnmount(() => {
         <span>{{ loadError }}</span>
         <button type="button" @click="retry">Try again</button>
       </div>
+
+      <template v-if="showNavigation">
+        <button
+          class="gallery-viewer-nav gallery-viewer-nav-previous"
+          type="button"
+          aria-label="Previous print"
+          data-test="gallery-viewer-previous"
+          :disabled="!hasPrevious"
+          @click="navigate('previous')"
+        >
+          <span aria-hidden="true">‹</span>
+        </button>
+        <button
+          class="gallery-viewer-nav gallery-viewer-nav-next"
+          type="button"
+          aria-label="Next print"
+          data-test="gallery-viewer-next"
+          :disabled="!hasNext"
+          @click="navigate('next')"
+        >
+          <span aria-hidden="true">›</span>
+        </button>
+      </template>
     </div>
 
     <footer class="gallery-viewer-details">
@@ -201,3 +392,58 @@ onBeforeUnmount(() => {
     </footer>
   </dialog>
 </template>
+
+<style scoped>
+.gallery-viewer-media:not(video),
+.gallery-viewer-placeholder {
+  touch-action: pan-y;
+  user-select: none;
+  -webkit-user-drag: none;
+}
+
+.gallery-viewer-position {
+  margin-top: 2px;
+  color: rgba(245, 239, 255, 0.84) !important;
+}
+
+.gallery-viewer-nav {
+  position: absolute;
+  z-index: 2;
+  top: 50%;
+  display: grid;
+  width: 48px;
+  height: 56px;
+  place-items: center;
+  transform: translateY(-50%);
+  border: 1px solid rgba(245, 239, 255, 0.24);
+  border-radius: 999px;
+  background: rgba(8, 7, 12, 0.68);
+  color: #f5efff;
+  font-size: 38px;
+  line-height: 1;
+  -webkit-tap-highlight-color: transparent;
+  backdrop-filter: blur(8px);
+}
+
+.gallery-viewer-nav:disabled {
+  opacity: 0.28;
+}
+
+.gallery-viewer-nav:not(:disabled):active {
+  background: rgba(245, 239, 255, 0.2);
+}
+
+.gallery-viewer-nav-previous {
+  left: max(10px, env(safe-area-inset-left));
+}
+
+.gallery-viewer-nav-next {
+  right: max(10px, env(safe-area-inset-right));
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .gallery-viewer-nav:not(:disabled):hover {
+    background: rgba(245, 239, 255, 0.16);
+  }
+}
+</style>

--- a/desktop/src/mobile/MobileHostDetail.test.ts
+++ b/desktop/src/mobile/MobileHostDetail.test.ts
@@ -1,0 +1,525 @@
+import { flushPromises, mount, type VueWrapper } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ModelEntry, ServerStatus } from "../lib/api/types";
+import type { QueueEntry } from "../stores/jobs";
+import type { MobileHost } from "./hosts";
+
+interface SseCall {
+  path: string;
+  options: {
+    target: { baseUrl: string; apiKey: string | null };
+    signal: AbortSignal;
+    retry?: boolean;
+    onEvent: (event: string, data: string) => void;
+  };
+}
+
+const { apiJsonTo, unloadModel, sseCalls } = vi.hoisted(() => ({
+  apiJsonTo: vi.fn(),
+  unloadModel: vi.fn(),
+  sseCalls: [] as SseCall[],
+}));
+
+vi.mock("../lib/api/client", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../lib/api/client")>()),
+  apiJsonTo,
+}));
+
+vi.mock("../lib/api/sse", () => ({
+  sseStream: (path: string, options: SseCall["options"]) => {
+    sseCalls.push({ path, options });
+    return new Promise<void>(() => {});
+  },
+}));
+
+vi.mock("../lib/api/models", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../lib/api/models")>()),
+  unloadModel,
+}));
+
+import MobileHostDetail from "./MobileHostDetail.vue";
+
+const studio: MobileHost = {
+  id: "studio-id",
+  name: "Studio",
+  baseUrl: "http://studio.tailnet.ts.net:7680",
+  apiKey: "studio-secret",
+  hostname: "studio",
+  version: "0.18.0",
+  online: true,
+};
+
+const renderBox: MobileHost = {
+  id: "render-id",
+  name: "Render Box",
+  baseUrl: "https://render.example.com:8443",
+  apiKey: "render-secret",
+  hostname: "render",
+  version: "0.19.0",
+  online: true,
+};
+
+const studioTarget = { baseUrl: studio.baseUrl, apiKey: studio.apiKey };
+const renderTarget = { baseUrl: renderBox.baseUrl, apiKey: renderBox.apiKey };
+
+function serverStatus(overrides: Partial<ServerStatus> = {}): ServerStatus {
+  return {
+    version: "0.18.0",
+    models_loaded: ["flux-dev:q8"],
+    uptime_secs: 3_661,
+    hostname: "studio",
+    gpu_info: {
+      name: "NVIDIA GeForce RTX 4090",
+      backend: "cuda",
+      vram_total_mb: 24_000,
+      vram_used_mb: 6_000,
+    },
+    queue_depth: 2,
+    queue_capacity: 8,
+    models_disk: { total_bytes: 2_000_000_000_000, free_bytes: 500_000_000_000 },
+    ...overrides,
+  };
+}
+
+function model(name: string, family: string, overrides: Partial<ModelEntry> = {}): ModelEntry {
+  return {
+    name,
+    family,
+    size_gb: 12,
+    is_loaded: false,
+    hf_repo: `example/${name}`,
+    default_steps: 30,
+    default_guidance: 4,
+    default_width: 1024,
+    default_height: 1024,
+    description: "",
+    downloaded: true,
+    ...overrides,
+  };
+}
+
+const queueEntries: QueueEntry[] = [
+  {
+    id: "job-running",
+    model: "flux-dev:q8",
+    state: "running",
+    started_at_unix_ms: Date.now() - 5_000,
+    position: 0,
+    gpu: 0,
+  },
+  {
+    id: "job-queued",
+    model: "z-image:q8",
+    state: "queued",
+    started_at_unix_ms: Date.now(),
+    position: 2,
+  },
+];
+
+function installApi(): void {
+  apiJsonTo.mockImplementation((target: { baseUrl: string }, path: string): Promise<unknown> => {
+    if (path === "/api/status") {
+      return Promise.resolve(
+        target.baseUrl === renderBox.baseUrl
+          ? serverStatus({
+              version: "0.19.0",
+              hostname: "render",
+              models_loaded: ["qwen-image:bf16"],
+            })
+          : serverStatus(),
+      );
+    }
+    if (path === "/api/models") {
+      return Promise.resolve(
+        target.baseUrl === renderBox.baseUrl
+          ? [model("qwen-image:bf16", "qwen-image")]
+          : [
+              model("flux-dev:q8", "flux", { is_loaded: true }),
+              model("z-image:q8", "z-image"),
+              model("not-installed", "flux", { downloaded: false }),
+            ],
+      );
+    }
+    if (path === "/api/queue") {
+      return Promise.resolve({ entries: target.baseUrl === renderBox.baseUrl ? [] : queueEntries });
+    }
+    return Promise.reject(new Error(`Unexpected API path: ${path}`));
+  });
+}
+
+function stream(path: string, target = studioTarget): SseCall {
+  const call = [...sseCalls]
+    .reverse()
+    .find(
+      (candidate) => candidate.path === path && candidate.options.target.baseUrl === target.baseUrl,
+    );
+  if (!call) throw new Error(`Missing ${path} stream for ${target.baseUrl}`);
+  return call;
+}
+
+function buttonWithText(wrapper: VueWrapper, text: string) {
+  const button = wrapper.findAll("button").find((candidate) => candidate.text() === text);
+  if (!button) throw new Error(`Missing ${text} button`);
+  return button;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+let wrapper: VueWrapper | null = null;
+
+async function mountDetail(host: MobileHost = studio, active = false): Promise<VueWrapper> {
+  wrapper = mount(MobileHostDetail, { props: { host, active } });
+  await flushPromises();
+  return wrapper;
+}
+
+beforeEach(() => {
+  apiJsonTo.mockReset();
+  unloadModel.mockReset().mockResolvedValue(undefined);
+  sseCalls.length = 0;
+  installApi();
+});
+
+afterEach(() => {
+  wrapper?.unmount();
+  wrapper = null;
+});
+
+describe("MobileHostDetail remote host data", () => {
+  it("targets the exact remote and renders telemetry, queue, downloads, and installed models", async () => {
+    const view = await mountDetail();
+
+    expect(apiJsonTo).toHaveBeenCalledWith(studioTarget, "/api/status");
+    expect(apiJsonTo).toHaveBeenCalledWith(studioTarget, "/api/models");
+    expect(apiJsonTo).toHaveBeenCalledWith(studioTarget, "/api/queue");
+    expect(stream("/api/resources/stream").options).toMatchObject({
+      target: studioTarget,
+      retry: true,
+    });
+    expect(stream("/api/downloads/stream").options).toMatchObject({
+      target: studioTarget,
+      retry: true,
+    });
+
+    expect(view.text()).toContain("NVIDIA GeForce RTX 4090");
+    expect(view.text()).toContain("6.0 GB/24.0 GB");
+    expect(view.text()).toContain("500.0 GB free");
+    expect(view.text()).toContain("UP 1h 1m");
+
+    const queueRows = view.get("[data-test='host-detail-queue']").findAll("li");
+    expect(queueRows).toHaveLength(2);
+    expect(queueRows[0]!.text()).toContain("flux-dev:q8RUNNING · GPU 0");
+    expect(queueRows[1]!.text()).toContain("z-image:q8QUEUED #2");
+
+    const modelRows = view.get("[data-test='host-detail-models']").findAll("li");
+    expect(modelRows).toHaveLength(2);
+    expect(modelRows[0]!.text()).toContain("flux-dev:q8");
+    expect(modelRows[0]!.text()).toContain("LOADED");
+    expect(view.text()).not.toContain("not-installed");
+
+    stream("/api/resources/stream").options.onEvent(
+      "snapshot",
+      JSON.stringify({
+        hostname: "studio",
+        timestamp: 1,
+        gpus: [
+          {
+            ordinal: 0,
+            name: "NVIDIA RTX 6000 Ada",
+            backend: "cuda",
+            vram_total: 48_000_000_000,
+            vram_used: 18_000_000_000,
+            gpu_utilization: 93,
+          },
+        ],
+        system_ram: {
+          total: 128_000_000_000,
+          used: 32_000_000_000,
+          used_by_mold: 16_000_000_000,
+          used_by_other: 16_000_000_000,
+        },
+        cpu: { cores: 32, usage_percent: 43.2 },
+      }),
+    );
+    stream("/api/downloads/stream").options.onEvent(
+      "download",
+      JSON.stringify({
+        type: "snapshot",
+        listing: {
+          active_jobs: [
+            {
+              id: "download-1",
+              model: "qwen-image:bf16",
+              status: "active",
+              files_done: 2,
+              files_total: 4,
+              bytes_done: 250,
+              bytes_total: 1_000,
+            },
+          ],
+          queued: [],
+          history: [],
+        },
+      }),
+    );
+    await flushPromises();
+
+    expect(view.text()).toContain("NVIDIA RTX 6000 Ada");
+    expect(view.text()).toContain("18.0 GB/48.0 GB");
+    expect(view.text()).toContain("43% · 32 cores");
+    expect(view.text()).toContain("32.0 GB/128.0 GB");
+    expect(view.text()).toContain("qwen-image:bf16");
+    expect(view.text()).toContain("2/4 files");
+    expect(
+      view
+        .get("[role='meter'][aria-label='VRAM usage for NVIDIA RTX 6000 Ada']")
+        .attributes("aria-valuenow"),
+    ).toBe("38");
+    expect(view.get("[role='meter'][aria-label='CPU usage']").attributes("aria-valuenow")).toBe(
+      "43",
+    );
+    expect(view.get("[role='meter'][aria-label='RAM usage']").attributes("aria-valuenow")).toBe(
+      "25",
+    );
+    expect(
+      view.get("[role='meter'][aria-label='Models disk usage']").attributes("aria-valuenow"),
+    ).toBe("75");
+    expect(
+      view
+        .get("[role='meter'][aria-label='Download progress for qwen-image:bf16']")
+        .attributes("aria-valuenow"),
+    ).toBe("25");
+    expect(view.emitted("status")).toEqual([[{ id: studio.id, status: serverStatus() }]]);
+  });
+
+  it("uses the live queue count after the queue API responds", async () => {
+    apiJsonTo.mockImplementation((target: { baseUrl: string }, path: string): Promise<unknown> => {
+      if (path === "/api/status") return Promise.resolve(serverStatus({ queue_depth: 7 }));
+      if (path === "/api/models") return Promise.resolve([]);
+      if (path === "/api/queue") return Promise.resolve({ entries: [queueEntries[0]] });
+      return Promise.reject(new Error(`Unexpected API path: ${path} for ${target.baseUrl}`));
+    });
+
+    const view = await mountDetail();
+
+    expect(view.get("[aria-labelledby='host-queue-title'] .mobile-section-head span").text()).toBe(
+      "1/8",
+    );
+  });
+
+  it("falls back to the status queue depth when the queue API is unavailable", async () => {
+    apiJsonTo.mockImplementation((_target: { baseUrl: string }, path: string): Promise<unknown> => {
+      if (path === "/api/status") return Promise.resolve(serverStatus({ queue_depth: 7 }));
+      if (path === "/api/models") return Promise.resolve([]);
+      if (path === "/api/queue") return Promise.reject(new Error("queue unsupported"));
+      return Promise.reject(new Error(`Unexpected API path: ${path}`));
+    });
+
+    const view = await mountDetail();
+
+    expect(view.get("[aria-labelledby='host-queue-title'] .mobile-section-head span").text()).toBe(
+      "7/8",
+    );
+  });
+
+  it("recovers from a transient initial failure when retrying the same host", async () => {
+    let statusAttempts = 0;
+    apiJsonTo.mockImplementation((_target: { baseUrl: string }, path: string): Promise<unknown> => {
+      if (path === "/api/status") {
+        statusAttempts += 1;
+        return statusAttempts === 1
+          ? Promise.reject(new Error("temporary network failure"))
+          : Promise.resolve(serverStatus());
+      }
+      if (path === "/api/models") {
+        return Promise.resolve([model("flux-dev:q8", "flux", { is_loaded: true })]);
+      }
+      if (path === "/api/queue") return Promise.resolve({ entries: [] });
+      return Promise.reject(new Error(`Unexpected API path: ${path}`));
+    });
+
+    const view = await mountDetail();
+    expect(view.get("[role='alert']").text()).toContain("temporary network failure");
+    expect(sseCalls).toHaveLength(0);
+
+    await view.get("[data-test='host-detail-retry']").trigger("click");
+    await flushPromises();
+
+    expect(statusAttempts).toBe(2);
+    expect(view.find("[data-test='host-detail-retry']").exists()).toBe(false);
+    expect(view.text()).toContain("flux-dev:q8");
+    expect(sseCalls).toHaveLength(2);
+    expect(view.emitted("status")).toEqual([
+      [{ id: studio.id, status: null }],
+      [{ id: studio.id, status: serverStatus() }],
+    ]);
+  });
+
+  it("selects an online host and reflects the active state", async () => {
+    const view = await mountDetail();
+    const select = view.get("[data-test='host-detail-select']");
+
+    await select.trigger("click");
+    expect(view.emitted("select")).toEqual([[studio.id]]);
+
+    await view.setProps({ active: true });
+    expect(select.text()).toBe("Used for generations");
+    expect(select.attributes()).toHaveProperty("disabled");
+  });
+
+  it("renames, confirms forget on the second tap, and opens Catalog", async () => {
+    const view = await mountDetail();
+
+    await buttonWithText(view, "Rename").trigger("click");
+    await view.get(".mobile-inline-form input").setValue("  Main Studio  ");
+    await view.get(".mobile-inline-form").trigger("submit");
+    expect(view.emitted("rename")).toEqual([[{ id: studio.id, name: "Main Studio" }]]);
+
+    const forget = view.get("[data-test='host-detail-forget']");
+    await forget.trigger("click");
+    expect(view.emitted("forget")).toBeUndefined();
+    expect(forget.text()).toBe("Forget Studio?");
+    await forget.trigger("click");
+    expect(view.emitted("forget")).toEqual([[studio.id]]);
+
+    await view.get("[data-test='host-detail-catalog']").trigger("click");
+    expect(view.emitted("catalog")).toEqual([[studio.id]]);
+  });
+
+  it("unloads a resident model on the exact remote and updates the loaded list", async () => {
+    const pending = deferred<void>();
+    unloadModel.mockReturnValueOnce(pending.promise);
+    const view = await mountDetail();
+    const unload = view.get("[aria-label='Unload flux-dev:q8']");
+
+    await unload.trigger("click");
+    expect(unloadModel).toHaveBeenCalledWith("flux-dev:q8", studioTarget);
+    expect(unload.attributes()).toHaveProperty("disabled");
+    expect(unload.text()).toBe("…");
+
+    pending.resolve();
+    await flushPromises();
+    expect(view.find("[aria-label='Unload flux-dev:q8']").exists()).toBe(false);
+    expect(view.text()).toContain("No models are loaded on the GPU.");
+    expect(view.get("[data-test='host-detail-models']").text()).not.toContain("LOADED");
+    expect(view.emitted("status")?.at(-1)).toEqual([
+      { id: studio.id, status: serverStatus({ models_loaded: [] }) },
+    ]);
+  });
+});
+
+describe("MobileHostDetail host switching", () => {
+  it("aborts old streams, ignores their stale frames, and retargets every live service", async () => {
+    const view = await mountDetail();
+    const oldResources = stream("/api/resources/stream");
+    const oldDownloads = stream("/api/downloads/stream");
+
+    await view.setProps({ host: renderBox });
+    await flushPromises();
+
+    expect(oldResources.options.signal.aborted).toBe(true);
+    expect(oldDownloads.options.signal.aborted).toBe(true);
+    expect(apiJsonTo).toHaveBeenCalledWith(renderTarget, "/api/status");
+    expect(apiJsonTo).toHaveBeenCalledWith(renderTarget, "/api/models");
+    expect(apiJsonTo).toHaveBeenCalledWith(renderTarget, "/api/queue");
+    expect(stream("/api/resources/stream", renderTarget).options.signal.aborted).toBe(false);
+    expect(stream("/api/downloads/stream", renderTarget).options.signal.aborted).toBe(false);
+
+    oldResources.options.onEvent(
+      "snapshot",
+      JSON.stringify({
+        hostname: "studio",
+        timestamp: 2,
+        gpus: [
+          {
+            ordinal: 0,
+            name: "STALE STUDIO GPU",
+            backend: "cuda",
+            vram_total: 1_000,
+            vram_used: 1_000,
+          },
+        ],
+        system_ram: {
+          total: 1_000,
+          used: 1_000,
+          used_by_mold: 1_000,
+          used_by_other: 0,
+        },
+      }),
+    );
+    await flushPromises();
+
+    expect(view.text()).toContain("Render Box");
+    expect(view.text()).toContain("qwen-image:bf16");
+    expect(view.text()).not.toContain("STALE STUDIO GPU");
+
+    view.unmount();
+    wrapper = null;
+    expect(stream("/api/resources/stream", renderTarget).options.signal.aborted).toBe(true);
+    expect(stream("/api/downloads/stream", renderTarget).options.signal.aborted).toBe(true);
+  });
+
+  it("ignores a late status response from the previously selected host", async () => {
+    const oldStatus = deferred<ServerStatus>();
+    apiJsonTo.mockImplementation((target: { baseUrl: string }, path: string): Promise<unknown> => {
+      if (path === "/api/status") {
+        return target.baseUrl === studio.baseUrl
+          ? oldStatus.promise
+          : Promise.resolve(
+              serverStatus({
+                version: "0.19.0",
+                hostname: "render",
+                models_loaded: ["qwen-image:bf16"],
+              }),
+            );
+      }
+      if (path === "/api/models") {
+        return Promise.resolve(
+          target.baseUrl === studio.baseUrl
+            ? [model("stale-model", "flux")]
+            : [model("qwen-image:bf16", "qwen-image")],
+        );
+      }
+      if (path === "/api/queue") return Promise.resolve({ entries: [] });
+      return Promise.reject(new Error(`Unexpected API path: ${path}`));
+    });
+
+    wrapper = mount(MobileHostDetail, { props: { host: studio, active: false } });
+    await flushPromises();
+    await wrapper.setProps({ host: renderBox });
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("Render Box");
+    expect(wrapper.text()).toContain("qwen-image:bf16");
+    expect(wrapper.emitted("status")).toEqual([
+      [
+        {
+          id: renderBox.id,
+          status: serverStatus({
+            version: "0.19.0",
+            hostname: "render",
+            models_loaded: ["qwen-image:bf16"],
+          }),
+        },
+      ],
+    ]);
+
+    oldStatus.resolve(
+      serverStatus({
+        version: "0.17.0",
+        hostname: "old-studio",
+        models_loaded: ["stale-model"],
+      }),
+    );
+    await flushPromises();
+
+    expect(wrapper.text()).not.toContain("stale-model");
+    expect(wrapper.emitted("status")).toHaveLength(1);
+  });
+});

--- a/desktop/src/mobile/MobileHostDetail.vue
+++ b/desktop/src/mobile/MobileHostDetail.vue
@@ -1,0 +1,474 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, ref, watch } from "vue";
+import { apiJsonTo } from "../lib/api/client";
+import { sseStream } from "../lib/api/sse";
+import type {
+  DownloadEvent,
+  GpuSnapshot,
+  ModelEntry,
+  ResourceSnapshot,
+  ServerStatus,
+} from "../lib/api/types";
+import { formatGB, formatUptime, percent } from "../lib/format";
+import { inferBackendFromGpuName } from "../lib/hosts";
+import { unloadModel } from "../lib/api/models";
+import { modelSizeLabels } from "../lib/models";
+import { applyDownloadEvent, emptyDownloadsState, type DownloadsState } from "../stores/downloads";
+import type { QueueEntry } from "../stores/jobs";
+import { mobileHostTarget, type MobileHost } from "./hosts";
+
+type DetailSnapshot = ResourceSnapshot & {
+  cpu?: { cores: number; usage_percent: number } | null;
+};
+
+const props = defineProps<{
+  host: MobileHost;
+  active: boolean;
+}>();
+
+const emit = defineEmits<{
+  (event: "back"): void;
+  (event: "select", id: string): void;
+  (event: "rename", payload: { id: string; name: string }): void;
+  (event: "forget", id: string): void;
+  (event: "catalog", hostId: string): void;
+  (event: "status", payload: { id: string; status: ServerStatus | null }): void;
+}>();
+
+const status = ref<ServerStatus | null>(null);
+const snapshot = ref<DetailSnapshot | null>(null);
+const installed = ref<ModelEntry[]>([]);
+const queue = ref<QueueEntry[]>([]);
+const queueApiAvailable = ref(false);
+const downloads = ref<DownloadsState>(emptyDownloadsState());
+const loading = ref(false);
+const error = ref("");
+const renaming = ref(false);
+const renameValue = ref("");
+const forgetPending = ref(false);
+const unloading = ref<Set<string>>(new Set());
+let loadEpoch = 0;
+let resourceAbort: AbortController | null = null;
+let downloadsAbort: AbortController | null = null;
+let queueTimer: ReturnType<typeof setInterval> | null = null;
+
+const target = computed(() => mobileHostTarget(props.host));
+const inFlightDownloads = computed(() => [
+  ...downloads.value.activeJobs,
+  ...downloads.value.queued,
+]);
+const loadedModels = computed(() => status.value?.models_loaded ?? []);
+const uptime = computed(() => status.value?.uptime_secs ?? null);
+const queueDepth = computed(() =>
+  queueApiAvailable.value ? queue.value.length : (status.value?.queue_depth ?? queue.value.length),
+);
+
+const gpus = computed<GpuSnapshot[]>(() => {
+  if (snapshot.value?.gpus.length) return snapshot.value.gpus;
+  const gpu = status.value?.gpu_info;
+  if (!gpu) return [];
+  return [
+    {
+      ordinal: 0,
+      name: gpu.name,
+      backend: gpu.backend ?? inferBackendFromGpuName(gpu.name),
+      vram_total: gpu.vram_total_mb * 1_000_000,
+      vram_used: gpu.vram_used_mb * 1_000_000,
+      gpu_utilization: null,
+    },
+  ];
+});
+
+const ram = computed(() => snapshot.value?.system_ram ?? null);
+const cpu = computed(() => snapshot.value?.cpu ?? null);
+const disk = computed(() => status.value?.models_disk ?? null);
+
+function stopLiveServices(): void {
+  resourceAbort?.abort();
+  downloadsAbort?.abort();
+  resourceAbort = null;
+  downloadsAbort = null;
+  if (queueTimer) clearInterval(queueTimer);
+  queueTimer = null;
+}
+
+async function refreshQueue(epoch = loadEpoch): Promise<void> {
+  try {
+    const listing = await apiJsonTo<{ entries: QueueEntry[] }>(target.value, "/api/queue");
+    if (epoch === loadEpoch) {
+      queue.value = listing.entries;
+      queueApiAvailable.value = true;
+    }
+  } catch {
+    // Older hosts can omit the queue API. Status depth still renders above.
+  }
+}
+
+function startLiveServices(epoch: number): void {
+  resourceAbort = new AbortController();
+  void sseStream("/api/resources/stream", {
+    target: target.value,
+    signal: resourceAbort.signal,
+    retry: true,
+    onEvent(event, data) {
+      if (event !== "snapshot" || epoch !== loadEpoch) return;
+      try {
+        snapshot.value = JSON.parse(data) as DetailSnapshot;
+      } catch {
+        // A malformed telemetry frame must not tear down the detail view.
+      }
+    },
+  });
+
+  downloadsAbort = new AbortController();
+  void sseStream("/api/downloads/stream", {
+    target: target.value,
+    signal: downloadsAbort.signal,
+    retry: true,
+    onEvent(_event, data) {
+      if (epoch !== loadEpoch) return;
+      try {
+        downloads.value = applyDownloadEvent(downloads.value, JSON.parse(data) as DownloadEvent);
+      } catch {
+        // Keep the last good snapshot when an older host sends an unknown frame.
+      }
+    },
+  });
+
+  void refreshQueue(epoch);
+  queueTimer = setInterval(() => void refreshQueue(epoch), 5_000);
+}
+
+async function loadHost(): Promise<void> {
+  const epoch = ++loadEpoch;
+  stopLiveServices();
+  loading.value = true;
+  error.value = "";
+  status.value = null;
+  snapshot.value = null;
+  installed.value = [];
+  queue.value = [];
+  queueApiAvailable.value = false;
+  downloads.value = emptyDownloadsState();
+  renameValue.value = props.host.name;
+  renaming.value = false;
+  forgetPending.value = false;
+
+  try {
+    const [nextStatus, models] = await Promise.all([
+      apiJsonTo<ServerStatus>(target.value, "/api/status"),
+      apiJsonTo<ModelEntry[]>(target.value, "/api/models"),
+    ]);
+    if (epoch !== loadEpoch) return;
+    status.value = nextStatus;
+    installed.value = models.filter((model) => model.downloaded);
+    emit("status", { id: props.host.id, status: nextStatus });
+    startLiveServices(epoch);
+  } catch (caught) {
+    if (epoch !== loadEpoch) return;
+    error.value = caught instanceof Error ? caught.message : String(caught);
+    emit("status", { id: props.host.id, status: null });
+  } finally {
+    if (epoch === loadEpoch) loading.value = false;
+  }
+}
+
+function saveRename(): void {
+  const name = renameValue.value.trim();
+  if (!name) return;
+  emit("rename", { id: props.host.id, name });
+  renaming.value = false;
+}
+
+function requestForget(): void {
+  if (!forgetPending.value) {
+    forgetPending.value = true;
+    return;
+  }
+  emit("forget", props.host.id);
+}
+
+async function unload(name: string): Promise<void> {
+  if (unloading.value.has(name)) return;
+  unloading.value.add(name);
+  try {
+    await unloadModel(name, target.value);
+    if (status.value) {
+      const nextStatus = {
+        ...status.value,
+        models_loaded: status.value.models_loaded.filter((model) => model !== name),
+      };
+      status.value = nextStatus;
+      installed.value = installed.value.map((model) =>
+        model.name === name ? { ...model, is_loaded: false } : model,
+      );
+      emit("status", { id: props.host.id, status: nextStatus });
+    }
+  } catch (caught) {
+    error.value = caught instanceof Error ? caught.message : String(caught);
+  } finally {
+    unloading.value.delete(name);
+  }
+}
+
+function queueCode(entry: QueueEntry): string {
+  if (entry.state === "running")
+    return entry.gpu == null ? "RUNNING" : `RUNNING · GPU ${entry.gpu}`;
+  return entry.position > 0 ? `QUEUED #${entry.position}` : "QUEUED";
+}
+
+function downloadPercent(done: number, total: number): number {
+  return total > 0 ? percent(done, total) : 0;
+}
+
+watch(() => props.host.id, loadHost, { immediate: true });
+onBeforeUnmount(() => {
+  loadEpoch += 1;
+  stopLiveServices();
+});
+</script>
+
+<template>
+  <div class="mobile-detail" data-test="mobile-host-detail">
+    <div class="mobile-detail-nav">
+      <button
+        class="mobile-back-button"
+        type="button"
+        data-test="host-detail-back"
+        @click="emit('back')"
+      >
+        <span aria-hidden="true">‹</span> Hosts
+      </button>
+      <span class="host-chip">{{ host.online ? `v${host.version ?? ""}` : "offline" }}</span>
+    </div>
+
+    <div class="mobile-detail-title">
+      <span class="status-dot" :class="host.online ? 'is-ready' : 'is-error'" aria-hidden="true" />
+      <div>
+        <h1 class="section-title">{{ host.name }}</h1>
+        <p class="host-url">{{ host.baseUrl }}</p>
+      </div>
+    </div>
+
+    <div class="row-actions mobile-host-actions">
+      <button
+        class="secondary-button"
+        type="button"
+        :disabled="active || !host.online"
+        data-test="host-detail-select"
+        @click="emit('select', host.id)"
+      >
+        {{ active ? "Used for generations" : "Use for generations" }}
+      </button>
+      <button class="secondary-button" type="button" @click="renaming = !renaming">Rename</button>
+    </div>
+
+    <form v-if="renaming" class="mobile-inline-form" @submit.prevent="saveRename">
+      <label class="field">
+        <span>Host name</span>
+        <input v-model="renameValue" class="control" autocomplete="off" />
+      </label>
+      <div class="row-actions">
+        <button class="primary-button" type="submit">Save name</button>
+        <button class="secondary-button" type="button" @click="renaming = false">Cancel</button>
+      </div>
+    </form>
+
+    <p v-if="loading" class="status-line">Reading host…</p>
+    <div v-if="error" class="row-actions">
+      <p class="status-line error-text" role="alert">{{ error }}</p>
+      <button
+        class="secondary-button"
+        type="button"
+        data-test="host-detail-retry"
+        :disabled="loading"
+        @click="loadHost"
+      >
+        Retry connection
+      </button>
+    </div>
+
+    <template v-if="status">
+      <section class="mobile-detail-section" aria-labelledby="host-telemetry-title">
+        <div class="mobile-section-head">
+          <h2 id="host-telemetry-title">Telemetry</h2>
+          <span v-if="uptime !== null">UP {{ formatUptime(uptime) }}</span>
+        </div>
+        <div v-if="gpus.length || cpu || ram || disk" class="telemetry-panel">
+          <template v-for="gpu in gpus" :key="gpu.ordinal">
+            <div class="telemetry-label">
+              <strong>{{ gpu.name }}</strong>
+              <span>{{ (gpu.backend || inferBackendFromGpuName(gpu.name)).toUpperCase() }}</span>
+            </div>
+            <div class="telemetry-meter-row">
+              <span>VRAM</span>
+              <div
+                class="meter"
+                role="meter"
+                :aria-label="`VRAM usage for ${gpu.name}`"
+                :aria-valuenow="Math.round(percent(gpu.vram_used, gpu.vram_total))"
+                aria-valuemin="0"
+                aria-valuemax="100"
+              >
+                <span :style="{ width: `${percent(gpu.vram_used, gpu.vram_total)}%` }" />
+              </div>
+              <strong>{{ formatGB(gpu.vram_used) }}/{{ formatGB(gpu.vram_total) }}</strong>
+            </div>
+          </template>
+          <div v-if="cpu" class="telemetry-meter-row">
+            <span>CPU</span>
+            <div
+              class="meter"
+              role="meter"
+              aria-label="CPU usage"
+              :aria-valuenow="Math.round(cpu.usage_percent)"
+              aria-valuemin="0"
+              aria-valuemax="100"
+            >
+              <span :style="{ width: `${cpu.usage_percent}%` }" />
+            </div>
+            <strong>{{ cpu.usage_percent.toFixed(0) }}% · {{ cpu.cores }} cores</strong>
+          </div>
+          <div v-if="ram" class="telemetry-meter-row">
+            <span>RAM</span>
+            <div
+              class="meter"
+              role="meter"
+              aria-label="RAM usage"
+              :aria-valuenow="Math.round(percent(ram.used, ram.total))"
+              aria-valuemin="0"
+              aria-valuemax="100"
+            >
+              <span :style="{ width: `${percent(ram.used, ram.total)}%` }" />
+            </div>
+            <strong>{{ formatGB(ram.used) }}/{{ formatGB(ram.total) }}</strong>
+          </div>
+          <div v-if="disk" class="telemetry-meter-row">
+            <span>DISK</span>
+            <div
+              class="meter"
+              role="meter"
+              aria-label="Models disk usage"
+              :aria-valuenow="
+                Math.round(percent(disk.total_bytes - disk.free_bytes, disk.total_bytes))
+              "
+              aria-valuemin="0"
+              aria-valuemax="100"
+            >
+              <span
+                :style="{
+                  width: `${percent(disk.total_bytes - disk.free_bytes, disk.total_bytes)}%`,
+                }"
+              />
+            </div>
+            <strong>{{ formatGB(disk.free_bytes) }} free</strong>
+          </div>
+        </div>
+        <p v-else class="mobile-empty-note">No live telemetry from this host yet.</p>
+      </section>
+
+      <section class="mobile-detail-section" aria-labelledby="host-queue-title">
+        <div class="mobile-section-head">
+          <h2 id="host-queue-title">Queue</h2>
+          <span
+            >{{ queueDepth
+            }}<template v-if="status.queue_capacity">/{{ status.queue_capacity }}</template></span
+          >
+        </div>
+        <ul v-if="queue.length" class="mobile-data-list" data-test="host-detail-queue">
+          <li v-for="entry in queue" :key="entry.id">
+            <div>
+              <strong>{{ entry.model }}</strong>
+              <span>{{ queueCode(entry) }}</span>
+            </div>
+          </li>
+        </ul>
+        <p v-else class="mobile-empty-note">Queue is empty.</p>
+
+        <div v-if="loadedModels.length" class="mobile-chip-list" aria-label="Loaded models">
+          <span v-for="model in loadedModels" :key="model" class="mobile-model-chip">
+            <span>{{ model }}</span>
+            <button
+              type="button"
+              :disabled="unloading.has(model)"
+              :aria-label="`Unload ${model}`"
+              @click="unload(model)"
+            >
+              {{ unloading.has(model) ? "…" : "×" }}
+            </button>
+          </span>
+        </div>
+        <p v-else class="mobile-empty-note">No models are loaded on the GPU.</p>
+      </section>
+
+      <section
+        v-if="inFlightDownloads.length"
+        class="mobile-detail-section"
+        aria-labelledby="host-downloads-title"
+      >
+        <div class="mobile-section-head">
+          <h2 id="host-downloads-title">Downloads</h2>
+          <span>{{ inFlightDownloads.length }}</span>
+        </div>
+        <ul class="mobile-data-list">
+          <li v-for="job in inFlightDownloads" :key="job.id">
+            <div class="download-row-copy">
+              <strong>{{ job.model }}</strong>
+              <span>{{
+                job.status === "queued" ? "Waiting" : `${job.files_done}/${job.files_total} files`
+              }}</span>
+              <div
+                v-if="job.status === 'active'"
+                class="meter"
+                role="meter"
+                :aria-label="`Download progress for ${job.model}`"
+                :aria-valuenow="downloadPercent(job.bytes_done, job.bytes_total)"
+                aria-valuemin="0"
+                aria-valuemax="100"
+              >
+                <span :style="{ width: `${downloadPercent(job.bytes_done, job.bytes_total)}%` }" />
+              </div>
+            </div>
+          </li>
+        </ul>
+      </section>
+
+      <section class="mobile-detail-section" aria-labelledby="host-models-title">
+        <div class="mobile-section-head">
+          <h2 id="host-models-title">Models on this host</h2>
+          <button type="button" data-test="host-detail-catalog" @click="emit('catalog', host.id)">
+            Catalog ›
+          </button>
+        </div>
+        <ul v-if="installed.length" class="mobile-data-list" data-test="host-detail-models">
+          <li v-for="model in installed" :key="model.name">
+            <div>
+              <strong>{{ model.name }}</strong>
+              <span
+                >{{ model.family
+                }}<template v-if="modelSizeLabels(model).weights">
+                  · {{ modelSizeLabels(model).weights }}</template
+                ></span
+              >
+            </div>
+            <span v-if="model.is_loaded" class="status-badge">LOADED</span>
+          </li>
+        </ul>
+        <p v-else class="mobile-empty-note">No installed models reported.</p>
+      </section>
+    </template>
+
+    <section class="mobile-danger-zone">
+      <button
+        class="danger-button"
+        type="button"
+        data-test="host-detail-forget"
+        @click="requestForget"
+        @blur="forgetPending = false"
+      >
+        {{ forgetPending ? `Forget ${host.name}?` : "Forget host" }}
+      </button>
+      <p>Forgetting removes this address and its API key from this iPhone.</p>
+    </section>
+  </div>
+</template>

--- a/desktop/src/mobile/MobileResolutionPicker.test.ts
+++ b/desktop/src/mobile/MobileResolutionPicker.test.ts
@@ -1,0 +1,142 @@
+import { flushPromises, mount, type VueWrapper } from "@vue/test-utils";
+import { defineComponent, reactive } from "vue";
+import { describe, expect, it } from "vitest";
+import MobileResolutionPicker from "./MobileResolutionPicker.vue";
+
+interface PickerState {
+  width: number;
+  height: number;
+  family: string;
+}
+
+function mountPicker(width: number, height: number, family = "flux") {
+  const state = reactive<PickerState>({ width, height, family });
+  const Harness = defineComponent({
+    components: { MobileResolutionPicker },
+    setup: () => ({ state }),
+    template: `
+      <MobileResolutionPicker
+        v-model:width="state.width"
+        v-model:height="state.height"
+        :family="state.family"
+      />
+    `,
+  });
+  return { wrapper: mount(Harness), state };
+}
+
+function buttonWithText(wrapper: VueWrapper, text: string) {
+  const button = wrapper.findAll("button").find((candidate) => candidate.text() === text);
+  if (!button) throw new Error(`Missing ${text} button`);
+  return button;
+}
+
+describe("MobileResolutionPicker", () => {
+  it("reuses family presets and applies an orientation-aware resolution", async () => {
+    const { wrapper, state } = mountPicker(1024, 1024, "flux");
+
+    expect(wrapper.get("[data-test='mobile-resolution-summary']").text()).toContain("1024 × 1024");
+    expect(wrapper.get("[data-test='mobile-resolution-summary']").text()).toContain("1:1 · Square");
+    expect(wrapper.get("[data-orientation='square']").attributes("aria-pressed")).toBe("true");
+
+    await wrapper.get("[data-orientation='portrait']").trigger("click");
+    expect(state).toMatchObject({ width: 896, height: 1152 });
+    expect(wrapper.get("[data-test='mobile-resolution-summary']").text()).toContain(
+      "3:4 · Portrait",
+    );
+    expect(wrapper.get("[data-aspect='3:4']").attributes("aria-pressed")).toBe("true");
+
+    await wrapper.get("[data-aspect='9:16']").trigger("click");
+    expect(state).toMatchObject({ width: 768, height: 1344 });
+  });
+
+  it("offers named resolution tiers for repeated Qwen aspect buckets", async () => {
+    const { wrapper, state } = mountPicker(1024, 1024, "qwen-image");
+    const tier = wrapper.get("[data-test='mobile-resolution-tier']");
+    const options = tier.findAll("option");
+
+    expect(options).toHaveLength(4);
+    expect(options.map((option) => option.text())).toEqual([
+      "Compact · 512 × 512 · 0.3 MP",
+      "Standard · 768 × 768 · 0.6 MP",
+      "High · 1024 × 1024 · 1.0 MP",
+      "Max · 1328 × 1328 · 1.8 MP",
+    ]);
+
+    await tier.setValue("1:1 · 1328×1328");
+    expect(state).toMatchObject({ width: 1328, height: 1328 });
+
+    await wrapper.get("[data-orientation='portrait']").trigger("click");
+    expect(state).toMatchObject({ width: 928, height: 1664 });
+    expect(wrapper.get("[data-test='mobile-resolution-summary']").text()).toContain(
+      "≈9:16 · Portrait",
+    );
+
+    await wrapper.get("[data-aspect='4:7']").trigger("click");
+    expect(state).toMatchObject({ width: 768, height: 1344 });
+  });
+
+  it("falls back to iPhone-friendly custom fields and snaps values to 16", async () => {
+    const { wrapper, state } = mountPicker(1000, 777);
+
+    expect(wrapper.find("[data-test='mobile-resolution-tier']").exists()).toBe(false);
+    expect(wrapper.find("[data-test='mobile-resolution-custom']").exists()).toBe(true);
+    expect(wrapper.get("[data-test='mobile-resolution-summary']").text()).toContain(
+      "1000:777 · Landscape",
+    );
+
+    const width = wrapper.get("input[aria-label='Custom width']");
+    const height = wrapper.get("input[aria-label='Custom height']");
+    expect(width.attributes()).toMatchObject({ inputmode: "numeric", min: "64", step: "16" });
+    expect(height.attributes()).toMatchObject({ inputmode: "numeric", min: "64", step: "16" });
+
+    await width.setValue("1001");
+    await width.trigger("change");
+    await height.setValue("20");
+    await height.trigger("change");
+    expect(state).toMatchObject({ width: 1008, height: 64 });
+
+    await wrapper.get("[aria-label='Swap width and height']").trigger("click");
+    expect(state).toMatchObject({ width: 64, height: 1008 });
+  });
+
+  it("lets a preset size reveal manual fields without changing dimensions", async () => {
+    const { wrapper, state } = mountPicker(1024, 1024);
+
+    expect(wrapper.find("[data-test='mobile-resolution-custom']").exists()).toBe(false);
+    const toggle = wrapper.get("[data-test='mobile-resolution-custom-toggle']");
+    expect(toggle.attributes("aria-expanded")).toBe("false");
+
+    await toggle.trigger("click");
+    expect(wrapper.find("[data-test='mobile-resolution-custom']").exists()).toBe(true);
+    expect(state).toMatchObject({ width: 1024, height: 1024 });
+    expect(toggle.text()).toBe("Hide custom size");
+  });
+
+  it("disables orientations that the desktop family does not recommend", async () => {
+    const { wrapper, state } = mountPicker(1024, 576, "ltx2");
+
+    expect(wrapper.get("[data-orientation='square']").attributes()).toHaveProperty("disabled");
+    expect(wrapper.get("[data-orientation='portrait']").attributes()).toHaveProperty("disabled");
+    expect(wrapper.get("[data-orientation='landscape']").attributes("aria-pressed")).toBe("true");
+    expect(wrapper.findAll(".mobile-resolution-aspect").map((button) => button.text())).toEqual([
+      "22:15",
+      "3:2",
+      "16:9",
+    ]);
+
+    await wrapper.get("[data-orientation='portrait']").trigger("click");
+    await flushPromises();
+    expect(state).toMatchObject({ width: 1024, height: 576 });
+  });
+
+  it("exposes controlled width and height update events", async () => {
+    const wrapper = mount(MobileResolutionPicker, {
+      props: { family: "sdxl", width: 1024, height: 1024 },
+    });
+
+    await buttonWithText(wrapper, "Portrait").trigger("click");
+    expect(wrapper.emitted("update:width")).toEqual([[896]]);
+    expect(wrapper.emitted("update:height")).toEqual([[1152]]);
+  });
+});

--- a/desktop/src/mobile/MobileResolutionPicker.vue
+++ b/desktop/src/mobile/MobileResolutionPicker.vue
@@ -1,0 +1,230 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import {
+  aspectRatioLabel,
+  matchPreset,
+  orientationLabel,
+  presetsForFamily,
+  type ResolutionPreset,
+} from "../lib/resolutions";
+import {
+  aspectsForOrientation,
+  closestResolutionPreset,
+  MOBILE_RESOLUTION_ORIENTATIONS,
+  presetsForOrientation,
+  resolutionTierLabel,
+  snapMobileDimension,
+  sortedResolutionTiers,
+  type ResolutionOrientation,
+} from "./resolutionPicker";
+
+const props = withDefaults(
+  defineProps<{
+    family: string;
+    disabled?: boolean;
+  }>(),
+  { disabled: false },
+);
+
+const width = defineModel<number>("width", { required: true });
+const height = defineModel<number>("height", { required: true });
+
+const manualOpen = ref(false);
+const presets = computed(() => presetsForFamily(props.family));
+const currentPreset = computed(() => matchPreset(width.value, height.value, props.family));
+const currentOrientation = computed(() => orientationLabel(width.value, height.value));
+const currentAspect = computed(() => aspectRatioLabel(width.value, height.value, props.family));
+const customVisible = computed(() => manualOpen.value || !currentPreset.value);
+const aspectOptions = computed(() =>
+  aspectsForOrientation(presets.value, currentOrientation.value),
+);
+const tierOptions = computed(() =>
+  currentPreset.value ? sortedResolutionTiers(presets.value, currentPreset.value.aspect) : [],
+);
+const aspectShapeStyle = computed(() => ({
+  aspectRatio: `${width.value} / ${height.value}`,
+  ...(width.value > height.value ? { width: "34px" } : { height: "30px" }),
+}));
+
+function isOrientationAvailable(orientation: ResolutionOrientation): boolean {
+  return presetsForOrientation(presets.value, orientation).length > 0;
+}
+
+function applyResolution(preset: ResolutionPreset | null): void {
+  if (!preset) return;
+  width.value = preset.width;
+  height.value = preset.height;
+  manualOpen.value = false;
+}
+
+function setOrientation(orientation: ResolutionOrientation): void {
+  applyResolution(
+    closestResolutionPreset(
+      presetsForOrientation(presets.value, orientation),
+      width.value,
+      height.value,
+    ),
+  );
+}
+
+function setAspect(aspect: string): void {
+  applyResolution(
+    closestResolutionPreset(
+      presets.value.filter((preset) => preset.aspect === aspect),
+      width.value,
+      height.value,
+    ),
+  );
+}
+
+function setTier(event: Event): void {
+  const label = (event.target as HTMLSelectElement).value;
+  applyResolution(tierOptions.value.find((preset) => preset.label === label) ?? null);
+}
+
+function tierOptionLabel(preset: ResolutionPreset, index: number): string {
+  const tier = resolutionTierLabel(index, tierOptions.value.length);
+  const megapixels = ((preset.width * preset.height) / 1_000_000).toFixed(1);
+  return `${tier} · ${preset.width} × ${preset.height} · ${megapixels} MP`;
+}
+
+function changedDimension(event: Event): number {
+  return snapMobileDimension(Number((event.target as HTMLInputElement).value));
+}
+
+function snapWidth(event: Event): void {
+  width.value = changedDimension(event);
+}
+
+function snapHeight(event: Event): void {
+  height.value = changedDimension(event);
+}
+
+function swapDimensions(): void {
+  [width.value, height.value] = [height.value, width.value];
+}
+</script>
+
+<template>
+  <fieldset class="mobile-resolution-picker" :disabled="disabled">
+    <legend class="mobile-resolution-legend">Resolution</legend>
+
+    <div
+      class="mobile-resolution-summary"
+      data-test="mobile-resolution-summary"
+      role="status"
+      aria-live="polite"
+    >
+      <div class="mobile-resolution-preview" aria-hidden="true">
+        <span data-test="mobile-resolution-shape" :style="aspectShapeStyle" />
+      </div>
+      <div class="mobile-resolution-copy">
+        <strong>{{ width }} × {{ height }}</strong>
+        <span>{{ currentAspect }} · {{ currentOrientation }}</span>
+      </div>
+      <span v-if="!currentPreset" class="mobile-resolution-custom-badge">Custom</span>
+    </div>
+
+    <div class="mobile-resolution-group">
+      <span class="mobile-resolution-label">Orientation</span>
+      <div class="mobile-resolution-segments" role="group" aria-label="Orientation">
+        <button
+          v-for="orientation in MOBILE_RESOLUTION_ORIENTATIONS"
+          :key="orientation"
+          type="button"
+          class="mobile-resolution-segment"
+          :class="{ 'is-selected': currentOrientation === orientation }"
+          :aria-pressed="currentOrientation === orientation"
+          :disabled="!isOrientationAvailable(orientation)"
+          :data-orientation="orientation.toLowerCase()"
+          @click="setOrientation(orientation)"
+        >
+          {{ orientation }}
+        </button>
+      </div>
+    </div>
+
+    <div class="mobile-resolution-group">
+      <span class="mobile-resolution-label">Aspect ratio</span>
+      <div class="mobile-resolution-aspects" aria-label="Aspect ratio presets">
+        <button
+          v-for="aspect in aspectOptions"
+          :key="aspect"
+          type="button"
+          class="mobile-resolution-aspect"
+          :class="{ 'is-selected': currentPreset?.aspect === aspect }"
+          :aria-pressed="currentPreset?.aspect === aspect"
+          :data-aspect="aspect"
+          @click="setAspect(aspect)"
+        >
+          {{ aspect }}
+        </button>
+      </div>
+    </div>
+
+    <label v-if="currentPreset" class="field mobile-resolution-tier">
+      <span>Resolution tier</span>
+      <select
+        class="control"
+        data-test="mobile-resolution-tier"
+        :value="currentPreset.label"
+        @change="setTier"
+      >
+        <option v-for="(preset, index) in tierOptions" :key="preset.label" :value="preset.label">
+          {{ tierOptionLabel(preset, index) }}
+        </option>
+      </select>
+    </label>
+
+    <button
+      v-if="currentPreset"
+      type="button"
+      class="secondary-button mobile-resolution-custom-toggle"
+      data-test="mobile-resolution-custom-toggle"
+      :aria-expanded="manualOpen"
+      @click="manualOpen = !manualOpen"
+    >
+      {{ manualOpen ? "Hide custom size" : "Custom size" }}
+    </button>
+
+    <div v-if="customVisible" class="mobile-resolution-custom" data-test="mobile-resolution-custom">
+      <label class="field">
+        <span>Width</span>
+        <input
+          v-model.number="width"
+          class="control"
+          type="number"
+          inputmode="numeric"
+          min="64"
+          step="16"
+          aria-label="Custom width"
+          @change="snapWidth"
+        />
+      </label>
+      <button
+        type="button"
+        class="secondary-button mobile-resolution-swap"
+        aria-label="Swap width and height"
+        @click="swapDimensions"
+      >
+        ⇄
+      </button>
+      <label class="field">
+        <span>Height</span>
+        <input
+          v-model.number="height"
+          class="control"
+          type="number"
+          inputmode="numeric"
+          min="64"
+          step="16"
+          aria-label="Custom height"
+          @change="snapHeight"
+        />
+      </label>
+    </div>
+    <p v-if="customVisible" class="mobile-resolution-note">
+      Custom dimensions snap to multiples of 16 for model compatibility.
+    </p>
+  </fieldset>
+</template>

--- a/desktop/src/mobile/hosts.ts
+++ b/desktop/src/mobile/hosts.ts
@@ -1,7 +1,52 @@
-// Mobile and desktop intentionally share host normalization and secret-key
-// slugs. Keeping one implementation prevents the same remote from acquiring
-// different identities across the two clients.
+import type { ApiTarget } from "../lib/api/client";
+import type { HostView } from "../stores/hosts";
+
+// Mobile and desktop intentionally share host normalization, secret-key
+// slugs, and the host shape consumed by the reusable queue/download stores.
+// Keeping one implementation prevents the same remote from acquiring
+// different identities or subtly different API routing across clients.
 export {
   hostIdFromUrl as remoteHostId,
   normalizeHostUrl as normalizeRemoteAddress,
 } from "../lib/hosts";
+
+export interface MobileHost {
+  id: string;
+  name: string;
+  baseUrl: string;
+  apiKey: string;
+  hostname: string | undefined;
+  version: string | undefined;
+  /** Stable server installation id, kept separate from the URL-based row id. */
+  instanceId?: string | undefined;
+  online: boolean;
+}
+
+export function mobileHostTarget(host: MobileHost): ApiTarget {
+  return { baseUrl: host.baseUrl, apiKey: host.apiKey || null };
+}
+
+/**
+ * Adapt the remote-only iPhone record to the shared desktop host contract.
+ * The iOS shell deliberately does not initialize `useHostsStore`: that store
+ * owns a desktop-local engine and invokes native commands the phone does not
+ * ship. Pure consumers such as the jobs and downloads stores can still share
+ * their proven per-host logic through this narrow adapter.
+ */
+export function mobileHostView(host: MobileHost): HostView {
+  return {
+    id: host.id,
+    label: host.name,
+    kind: "remote",
+    baseUrl: host.baseUrl,
+    apiKey: host.apiKey || null,
+    status: host.online ? "ready" : "error",
+    // "Selected" on iPhone is a generation preference, not a desktop-local
+    // primary connection. Keep every mobile host remote for shared stores.
+    primary: false,
+    queueDepth: null,
+    queueCapacity: null,
+    version: host.version ?? null,
+    instanceId: host.instanceId ?? null,
+  };
+}

--- a/desktop/src/mobile/mobile.css
+++ b/desktop/src/mobile/mobile.css
@@ -100,7 +100,7 @@ button {
   font-size: var(--text-data);
 }
 
-.mobile-tab[aria-selected="true"] {
+.mobile-tab[aria-current="page"] {
   background: color-mix(in srgb, var(--safelight) 12%, transparent);
   color: var(--safelight);
 }

--- a/desktop/src/mobile/mobile.css
+++ b/desktop/src/mobile/mobile.css
@@ -33,6 +33,10 @@ button {
 
 .mobile-shell {
   height: 100%;
+  height: 100dvh;
+  min-height: 0;
+  box-sizing: border-box;
+  overflow: hidden;
   display: grid;
   grid-template-rows: auto minmax(0, 1fr) auto;
   background: var(--bath);
@@ -46,7 +50,7 @@ button {
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  padding: 8px 16px;
+  padding: 8px max(16px, env(safe-area-inset-right)) 8px max(16px, env(safe-area-inset-left));
   border-bottom: 1px solid var(--edge);
   background: var(--bench);
 }
@@ -70,15 +74,18 @@ button {
 }
 
 .mobile-content {
-  overflow: auto;
-  -webkit-overflow-scrolling: touch;
-  padding: 16px;
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: none;
+  padding: 16px max(16px, env(safe-area-inset-right)) 16px max(16px, env(safe-area-inset-left));
 }
 
 .mobile-tabs {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  padding: 6px 10px calc(6px + env(safe-area-inset-bottom));
+  grid-template-columns: repeat(4, 1fr);
+  padding: 6px max(10px, env(safe-area-inset-right)) calc(6px + env(safe-area-inset-bottom))
+    max(10px, env(safe-area-inset-left));
   border-top: 1px solid var(--edge);
   background: var(--bench);
 }
@@ -145,6 +152,165 @@ textarea.control {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 0 10px;
+}
+
+.mobile-resolution-picker {
+  min-width: 0;
+  margin: 4px 0 18px;
+  border: 0;
+  padding: 0;
+}
+
+.mobile-resolution-legend,
+.mobile-resolution-label {
+  color: var(--ink-3);
+  font-family: var(--font-utility);
+  font-size: var(--text-edge-code);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.mobile-resolution-summary {
+  display: grid;
+  grid-template-columns: 48px minmax(0, 1fr) auto;
+  min-height: 58px;
+  align-items: center;
+  gap: 10px;
+  margin-top: 7px;
+  padding: 7px 11px;
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-control);
+  background: var(--bench);
+}
+
+.mobile-resolution-preview {
+  display: grid;
+  width: 44px;
+  height: 38px;
+  place-items: center;
+}
+
+.mobile-resolution-preview > span {
+  display: block;
+  max-width: 34px;
+  max-height: 30px;
+  border: 1px solid var(--halide);
+  background: color-mix(in srgb, var(--halide) 12%, transparent);
+}
+
+.mobile-resolution-copy {
+  min-width: 0;
+}
+
+.mobile-resolution-copy strong,
+.mobile-resolution-copy span {
+  display: block;
+}
+
+.mobile-resolution-copy strong {
+  color: var(--rebate);
+  font-family: var(--font-utility);
+  font-size: var(--text-data);
+}
+
+.mobile-resolution-copy span {
+  margin-top: 3px;
+  color: var(--ink-3);
+  font-size: var(--text-caption);
+}
+
+.mobile-resolution-custom-badge {
+  color: var(--halide);
+  font-family: var(--font-utility);
+  font-size: var(--text-edge-code);
+}
+
+.mobile-resolution-group {
+  display: grid;
+  gap: 7px;
+  margin-top: 13px;
+}
+
+.mobile-resolution-segments {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 3px;
+  padding: 3px;
+  border: 1px solid var(--control-edge);
+  border-radius: var(--radius-control);
+  background: var(--bench);
+}
+
+.mobile-resolution-segment {
+  min-height: 44px;
+  border: 0;
+  border-radius: calc(var(--radius-control) - 2px);
+  background: transparent;
+  color: var(--ink-3);
+  font-family: var(--font-utility);
+  font-size: var(--text-data);
+}
+
+.mobile-resolution-segment.is-selected {
+  background: color-mix(in srgb, var(--safelight) 15%, transparent);
+  color: var(--safelight);
+}
+
+.mobile-resolution-aspects {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+
+.mobile-resolution-aspect {
+  min-width: 54px;
+  min-height: 44px;
+  border: 1px solid var(--control-edge);
+  border-radius: var(--radius-control);
+  padding: 6px 10px;
+  background: transparent;
+  color: var(--ink-2);
+  font-family: var(--font-utility);
+  font-size: var(--text-data);
+}
+
+.mobile-resolution-aspect.is-selected {
+  border-color: var(--safelight);
+  color: var(--safelight);
+}
+
+.mobile-resolution-tier {
+  margin-top: 13px;
+}
+
+.mobile-resolution-custom-toggle {
+  width: 100%;
+  margin-top: 2px;
+}
+
+.mobile-resolution-custom {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  align-items: end;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.mobile-resolution-custom .field {
+  margin: 0;
+}
+
+.mobile-resolution-swap {
+  width: 44px;
+  min-width: 44px;
+  padding: 0;
+  font-size: 20px;
+}
+
+.mobile-resolution-note {
+  margin: 8px 0 0;
+  color: var(--ink-3);
+  font-size: var(--text-caption);
 }
 
 .primary-button,
@@ -350,6 +516,7 @@ button:disabled {
   z-index: 100;
   width: 100%;
   height: 100%;
+  height: 100dvh;
   max-width: none;
   max-height: none;
   grid-template-rows: auto minmax(0, 1fr) auto;
@@ -378,7 +545,7 @@ button:disabled {
   align-items: center;
   justify-content: space-between;
   gap: 16px;
-  padding: 6px 16px;
+  padding: 6px max(16px, env(safe-area-inset-right)) 6px max(16px, env(safe-area-inset-left));
   border-bottom: 1px solid rgba(245, 239, 255, 0.12);
   background: rgba(8, 7, 12, 0.92);
 }
@@ -479,7 +646,7 @@ button:disabled {
 .gallery-viewer-details {
   display: grid;
   gap: 14px;
-  padding: 14px 16px 16px;
+  padding: 14px max(16px, env(safe-area-inset-right)) 16px max(16px, env(safe-area-inset-left));
   border-top: 1px solid rgba(245, 239, 255, 0.12);
   background: #12101d;
 }
@@ -532,9 +699,733 @@ button:disabled {
   margin-top: 14px;
 }
 
+.mobile-catalog {
+  min-width: 0;
+}
+
+.mobile-catalog-header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.mobile-catalog-header .section-note {
+  margin-bottom: 14px;
+}
+
+.mobile-catalog-host-picker {
+  display: grid;
+  flex: 0 1 150px;
+  gap: 4px;
+  color: var(--ink-3);
+  font-family: var(--font-utility);
+  font-size: var(--text-edge-code);
+  text-transform: uppercase;
+}
+
+.mobile-catalog-host-picker select,
+.mobile-catalog-filters select,
+.mobile-catalog-search-row input {
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 44px;
+  border: 1px solid var(--control-edge);
+  border-radius: var(--radius-control);
+  background: var(--bench);
+  color: var(--rebate);
+}
+
+.mobile-catalog-host-picker select,
+.mobile-catalog-filters select {
+  padding: 7px 9px;
+  text-transform: none;
+}
+
+.mobile-catalog-downloads {
+  margin: 2px 0 14px;
+  overflow: hidden;
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-control);
+  background: var(--bench);
+}
+
+.mobile-catalog-downloads-head {
+  display: flex;
+  min-height: 38px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 0 11px;
+  border-bottom: 1px solid var(--edge);
+  color: var(--ink-3);
+  font-family: var(--font-utility);
+  font-size: var(--text-edge-code);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.mobile-catalog-downloads-head h2 {
+  margin: 0;
+  color: var(--rebate);
+  font: inherit;
+}
+
+.mobile-catalog-downloads ul,
+.mobile-catalog-results,
+.mobile-catalog-detail-section ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.mobile-catalog-download {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 7px 12px;
+  align-items: center;
+  padding: 10px 11px;
+}
+
+.mobile-catalog-download + .mobile-catalog-download {
+  border-top: 1px solid var(--edge);
+}
+
+.mobile-catalog-download-copy,
+.mobile-catalog-download-size {
+  min-width: 0;
+}
+
+.mobile-catalog-download-copy strong,
+.mobile-catalog-download-copy span {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mobile-catalog-download-copy strong {
+  font-size: var(--text-body);
+}
+
+.mobile-catalog-download-copy span,
+.mobile-catalog-download-size {
+  color: var(--ink-3);
+  font-family: var(--font-utility);
+  font-size: var(--text-edge-code);
+}
+
+.mobile-catalog-download-progress {
+  height: 6px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: var(--bath);
+}
+
+.mobile-catalog-download-progress > span {
+  display: block;
+  height: 100%;
+  min-width: 2px;
+  border-radius: inherit;
+  background: var(--halide);
+}
+
+.mobile-catalog-download > button {
+  grid-row: 1 / span 2;
+  grid-column: 2;
+  min-width: 64px;
+  min-height: 44px;
+  border: 0;
+  background: transparent;
+  color: var(--stop);
+  font-family: var(--font-utility);
+  font-size: var(--text-data);
+}
+
+.mobile-catalog-search-row {
+  position: sticky;
+  top: -16px;
+  z-index: 5;
+  margin: 0 -1px;
+  padding: 10px 1px 8px;
+  background: var(--bath);
+}
+
+.mobile-catalog-search-row input {
+  padding: 9px 12px;
+}
+
+.mobile-catalog-media {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 3px;
+  padding: 3px;
+  border: 1px solid var(--control-edge);
+  border-radius: var(--radius-control);
+  background: var(--bench);
+}
+
+.mobile-catalog-media button {
+  min-height: 44px;
+  border: 0;
+  border-radius: calc(var(--radius-control) - 2px);
+  background: transparent;
+  color: var(--ink-3);
+  font-family: var(--font-utility);
+  font-size: var(--text-data);
+}
+
+.mobile-catalog-media button[aria-pressed="true"] {
+  background: color-mix(in srgb, var(--safelight) 15%, transparent);
+  color: var(--safelight);
+}
+
+.mobile-catalog-sources {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin-top: 11px;
+}
+
+.mobile-catalog-sources button {
+  min-height: 44px;
+  border: 1px solid var(--control-edge);
+  border-radius: 999px;
+  padding: 6px 11px;
+  background: transparent;
+  color: var(--ink-2);
+  font-size: var(--text-caption);
+}
+
+.mobile-catalog-sources button[aria-pressed="true"] {
+  border-color: var(--safelight);
+  background: var(--safelight);
+  color: var(--on-accent);
+}
+
+.mobile-catalog-filters {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: end;
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.mobile-catalog-filters > label:first-child {
+  display: grid;
+  gap: 5px;
+  color: var(--ink-3);
+  font-family: var(--font-utility);
+  font-size: var(--text-edge-code);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.mobile-catalog-nsfw {
+  display: flex;
+  min-height: 44px;
+  align-items: center;
+  gap: 7px;
+  color: var(--ink-2);
+  font-size: var(--text-caption);
+}
+
+.mobile-catalog-nsfw input {
+  width: 20px;
+  height: 20px;
+  accent-color: var(--safelight);
+}
+
+.mobile-catalog-error {
+  margin: 14px 0;
+}
+
+.mobile-catalog-action-status {
+  overflow-wrap: anywhere;
+  border: 1px solid color-mix(in srgb, var(--halide) 45%, var(--edge));
+  border-radius: var(--radius-control);
+  padding: 9px 11px;
+  background: color-mix(in srgb, var(--halide) 8%, transparent);
+  color: var(--halide);
+  font-family: var(--font-utility);
+  font-size: var(--text-edge-code);
+  line-height: 1.45;
+}
+
+.mobile-catalog-action-status.error-text {
+  border-color: color-mix(in srgb, var(--stop) 55%, var(--edge));
+  background: color-mix(in srgb, var(--stop) 9%, transparent);
+  color: var(--stop);
+}
+
+.mobile-catalog-empty {
+  min-height: 32vh;
+}
+
+.mobile-catalog-results {
+  margin-top: 15px;
+  overflow: hidden;
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-control);
+  background: var(--bench);
+}
+
+.mobile-catalog-card {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  min-height: 92px;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 9px;
+}
+
+.mobile-catalog-card + .mobile-catalog-card {
+  border-top: 1px solid var(--edge);
+}
+
+.mobile-catalog-card-open {
+  display: grid;
+  min-width: 0;
+  min-height: 72px;
+  grid-template-columns: 68px minmax(0, 1fr);
+  align-items: center;
+  gap: 10px;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  text-align: left;
+}
+
+.mobile-catalog-card-preview {
+  display: grid;
+  width: 68px;
+  height: 68px;
+  overflow: hidden;
+  place-items: center;
+  border-radius: var(--radius-media);
+  background: var(--bath);
+  color: var(--ink-3);
+  font-family: var(--font-utility);
+  font-size: var(--text-data);
+}
+
+.mobile-catalog-card-preview img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.mobile-catalog-card-body,
+.mobile-catalog-card-title,
+.mobile-catalog-card-meta,
+.mobile-catalog-card-size {
+  display: block;
+  min-width: 0;
+}
+
+.mobile-catalog-card-title {
+  display: -webkit-box;
+  overflow: hidden;
+  color: var(--rebate);
+  font-size: var(--text-body);
+  font-weight: 700;
+  line-height: 1.25;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.mobile-catalog-card-meta,
+.mobile-catalog-card-size {
+  overflow: hidden;
+  margin-top: 4px;
+  color: var(--ink-3);
+  font-family: var(--font-utility);
+  font-size: var(--text-edge-code);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mobile-catalog-host-labels {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 5px;
+}
+
+.mobile-catalog-host-labels > span {
+  border: 1px solid var(--edge);
+  border-radius: 999px;
+  padding: 1px 6px;
+  color: var(--halide);
+  font-family: var(--font-utility);
+  font-size: var(--text-edge-code);
+}
+
+.mobile-catalog-installed {
+  color: var(--halide);
+  font-family: var(--font-utility);
+  font-size: var(--text-edge-code);
+  text-transform: uppercase;
+}
+
+.mobile-catalog-pull {
+  min-width: 72px;
+  min-height: 44px;
+  border: 1px solid var(--control-edge);
+  border-radius: var(--radius-control);
+  padding: 6px 9px;
+  background: transparent;
+  color: var(--safelight);
+  font-family: var(--font-utility);
+  font-size: var(--text-edge-code);
+}
+
+.mobile-catalog-more {
+  width: 100%;
+  margin-top: 14px;
+}
+
+.mobile-catalog-detail {
+  position: fixed;
+  inset: 0;
+  z-index: 80;
+  display: grid;
+  min-height: 0;
+  height: 100dvh;
+  box-sizing: border-box;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  padding-top: env(safe-area-inset-top);
+  padding-bottom: env(safe-area-inset-bottom);
+  background: var(--bath);
+  color: var(--rebate);
+}
+
+.mobile-catalog-detail-header {
+  display: grid;
+  min-height: 52px;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 10px;
+  padding: 5px max(12px, env(safe-area-inset-right)) 5px max(12px, env(safe-area-inset-left));
+  border-bottom: 1px solid var(--edge);
+  background: var(--bench);
+}
+
+.mobile-catalog-detail-header button {
+  min-height: 44px;
+  justify-self: start;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: var(--safelight);
+  font-size: 24px;
+}
+
+.mobile-catalog-detail-header button span,
+.mobile-catalog-detail-header strong {
+  font-family: var(--font-utility);
+  font-size: var(--text-data);
+}
+
+.mobile-catalog-detail-scroll {
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: none;
+}
+
+.mobile-catalog-detail-preview {
+  display: grid;
+  aspect-ratio: 16 / 10;
+  width: 100%;
+  max-height: 42vh;
+  overflow: hidden;
+  place-items: center;
+  border-bottom: 1px solid var(--edge);
+  background: var(--color-print-surface);
+  color: var(--ink-3);
+  font-family: var(--font-display);
+  font-size: var(--text-display);
+}
+
+.mobile-catalog-detail-preview img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.mobile-catalog-detail-copy {
+  display: grid;
+  gap: 18px;
+  max-width: 680px;
+  margin: 0 auto;
+  padding: 18px max(16px, env(safe-area-inset-right)) 28px max(16px, env(safe-area-inset-left));
+}
+
+.mobile-catalog-detail-title {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.mobile-catalog-detail-title h2 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: var(--text-title);
+  overflow-wrap: anywhere;
+}
+
+.mobile-catalog-detail-title p {
+  margin: 4px 0 0;
+  color: var(--ink-3);
+}
+
+.mobile-catalog-detail-title > span {
+  flex: none;
+  color: var(--halide);
+  font-family: var(--font-utility);
+  font-size: var(--text-edge-code);
+  text-transform: uppercase;
+}
+
+.mobile-catalog-detail-meta {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 11px;
+  margin: 0;
+}
+
+.mobile-catalog-detail-meta div {
+  min-width: 0;
+}
+
+.mobile-catalog-detail-meta dt {
+  color: var(--ink-3);
+  font-size: var(--text-caption);
+}
+
+.mobile-catalog-detail-meta dd {
+  overflow: hidden;
+  margin: 3px 0 0;
+  color: var(--ink-2);
+  font-family: var(--font-utility);
+  font-size: var(--text-data);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mobile-catalog-detail-description {
+  max-width: 70ch;
+  margin: 0;
+  color: var(--ink-2);
+  line-height: 1.5;
+  white-space: pre-line;
+}
+
+.mobile-catalog-detail-muted {
+  margin: 0;
+  color: var(--ink-3);
+}
+
+.mobile-catalog-detail-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.mobile-catalog-detail-tags span {
+  border: 1px solid var(--edge);
+  border-radius: 999px;
+  padding: 3px 8px;
+  color: var(--ink-2);
+  font-size: var(--text-caption);
+}
+
+.mobile-catalog-detail-section {
+  border-top: 1px solid var(--edge);
+  padding-top: 13px;
+}
+
+.mobile-catalog-detail-section-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.mobile-catalog-detail-section-head h3 {
+  margin: 0;
+  font-family: var(--font-utility);
+  font-size: var(--text-data);
+}
+
+.mobile-catalog-detail-section-head > span {
+  color: var(--ink-3);
+  font-family: var(--font-utility);
+  font-size: var(--text-edge-code);
+}
+
+.mobile-catalog-detail-section ul {
+  margin-top: 8px;
+}
+
+.mobile-catalog-detail-section li {
+  display: flex;
+  min-height: 38px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border-top: 1px solid color-mix(in srgb, var(--edge) 65%, transparent);
+  color: var(--ink-2);
+  font-size: var(--text-caption);
+}
+
+.mobile-catalog-detail-section li > span:last-child {
+  color: var(--ink-3);
+  font-family: var(--font-utility);
+  font-size: var(--text-edge-code);
+  text-align: right;
+}
+
+.mobile-catalog-component-status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 2px;
+}
+
+.mobile-catalog-component-dot {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  margin-right: 5px;
+  border-radius: 50%;
+  background: var(--stop);
+}
+
+.mobile-catalog-component-dot[data-present="true"] {
+  background: var(--safelight);
+}
+
+.mobile-catalog-installed-actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.mobile-catalog-detail-action {
+  padding: 10px max(16px, env(safe-area-inset-right)) 12px max(16px, env(safe-area-inset-left));
+  border-top: 1px solid var(--edge);
+  background: var(--bench);
+}
+
+.mobile-catalog-detail-action p {
+  margin: 0 0 8px;
+  color: var(--ink-3);
+  font-size: var(--text-caption);
+  text-align: center;
+}
+
+.mobile-catalog-target-sheet {
+  position: fixed;
+  inset: 0;
+  z-index: 90;
+  display: grid;
+  align-items: end;
+}
+
+.mobile-catalog-target-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.62);
+}
+
+.mobile-catalog-target-panel {
+  position: relative;
+  max-height: min(70vh, 620px);
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: none;
+  padding: 16px max(16px, env(safe-area-inset-right)) calc(16px + env(safe-area-inset-bottom))
+    max(16px, env(safe-area-inset-left));
+  border-top: 1px solid var(--edge);
+  border-radius: 14px 14px 0 0;
+  background: var(--bench);
+}
+
+.mobile-catalog-target-panel > header {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.mobile-catalog-target-panel h2 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: var(--text-title);
+}
+
+.mobile-catalog-target-panel p {
+  margin: 4px 0 0;
+  color: var(--ink-3);
+}
+
+.mobile-catalog-target-panel header button {
+  min-height: 44px;
+  border: 0;
+  padding: 0 4px;
+  background: transparent;
+  color: var(--safelight);
+}
+
+.mobile-catalog-target-list {
+  display: grid;
+  gap: 7px;
+  margin-top: 14px;
+}
+
+.mobile-catalog-target-list > button {
+  display: flex;
+  min-height: 60px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-control);
+  padding: 8px 11px;
+  background: var(--bath);
+  text-align: left;
+}
+
+.mobile-catalog-target-list strong,
+.mobile-catalog-target-list small {
+  display: block;
+}
+
+.mobile-catalog-target-list small {
+  max-width: 72vw;
+  overflow: hidden;
+  margin-top: 3px;
+  color: var(--ink-3);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .host-row {
   padding: 14px 0;
   border-bottom: 1px solid var(--edge);
+}
+
+.host-row-button {
+  display: block;
+  width: 100%;
+  min-height: 44px;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  text-align: left;
 }
 
 .host-row-head {
@@ -545,10 +1436,12 @@ button:disabled {
 }
 
 .host-name {
+  display: block;
   font-weight: 700;
 }
 
 .host-url {
+  display: block;
   margin-top: 3px;
   color: var(--ink-3);
   font-family: var(--font-utility);
@@ -556,10 +1449,333 @@ button:disabled {
   overflow-wrap: anywhere;
 }
 
+.host-row-state {
+  display: flex;
+  flex: none;
+  align-items: center;
+  gap: 8px;
+}
+
+.status-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  flex: none;
+  border-radius: 50%;
+  background: var(--ink-3);
+}
+
+.status-dot.is-ready {
+  background: var(--safelight);
+}
+
+.status-dot.is-error {
+  background: var(--stop);
+}
+
 .row-actions {
   display: flex;
   gap: 8px;
   margin-top: 10px;
+}
+
+.mobile-detail {
+  max-width: 680px;
+  margin: 0 auto;
+  padding-bottom: 24px;
+}
+
+.mobile-detail-nav {
+  display: flex;
+  min-height: 44px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin: -6px 0 12px;
+}
+
+.mobile-back-button {
+  min-height: 44px;
+  border: 0;
+  padding: 0 8px 0 0;
+  background: transparent;
+  color: var(--safelight);
+  font-family: var(--font-utility);
+  font-size: var(--text-data);
+}
+
+.mobile-back-button > span {
+  margin-right: 3px;
+  font-family: var(--font-body);
+  font-size: 28px;
+  font-weight: 300;
+  line-height: 0;
+  vertical-align: -2px;
+}
+
+.mobile-detail-title {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: start;
+  gap: 10px;
+}
+
+.mobile-detail-title .status-dot {
+  margin-top: 10px;
+}
+
+.mobile-detail-title .host-url {
+  margin-top: 5px;
+}
+
+.mobile-host-actions {
+  flex-wrap: wrap;
+  margin-top: 16px;
+}
+
+.mobile-host-actions .secondary-button {
+  flex: 1 1 180px;
+}
+
+.mobile-inline-form {
+  margin-top: 14px;
+  padding: 14px;
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-control);
+  background: var(--bench);
+}
+
+.mobile-inline-form .field {
+  margin-bottom: 0;
+}
+
+.mobile-inline-form .primary-button {
+  flex: 1;
+}
+
+.mobile-detail-section {
+  margin-top: 28px;
+}
+
+.mobile-section-head {
+  display: flex;
+  min-height: 32px;
+  align-items: center;
+  gap: 10px;
+  border-bottom: 1px solid var(--edge);
+  color: var(--ink-3);
+  font-family: var(--font-utility);
+  font-size: var(--text-edge-code);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.mobile-section-head h2 {
+  margin: 0;
+  color: var(--rebate);
+  font: inherit;
+}
+
+.mobile-section-head > span,
+.mobile-section-head > button {
+  margin-left: auto;
+}
+
+.mobile-section-head > button {
+  min-height: 44px;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: var(--safelight);
+  font: inherit;
+}
+
+.telemetry-panel {
+  display: grid;
+  gap: 11px;
+  margin-top: 10px;
+  padding: 13px;
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-control);
+  background: var(--bench);
+}
+
+.telemetry-label {
+  display: flex;
+  min-width: 0;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.telemetry-label strong {
+  overflow: hidden;
+  font-size: var(--text-body);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.telemetry-label span,
+.telemetry-meter-row > span {
+  color: var(--ink-3);
+  font-family: var(--font-utility);
+  font-size: var(--text-edge-code);
+}
+
+.telemetry-meter-row {
+  display: grid;
+  grid-template-columns: auto minmax(50px, 1fr) auto;
+  align-items: center;
+  gap: 9px;
+}
+
+.telemetry-meter-row strong {
+  color: var(--ink-3);
+  font-family: var(--font-utility);
+  font-size: var(--text-edge-code);
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.meter {
+  height: 6px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: var(--bath);
+}
+
+.meter > span {
+  display: block;
+  height: 100%;
+  min-width: 2px;
+  border-radius: inherit;
+  background: var(--halide);
+  transition: width 180ms ease-out;
+}
+
+.mobile-data-list {
+  margin: 10px 0 0;
+  padding: 0;
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-control);
+  overflow: hidden;
+  background: var(--bench);
+  list-style: none;
+}
+
+.mobile-data-list li {
+  display: flex;
+  min-height: 52px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 9px 12px;
+}
+
+.mobile-data-list li + li {
+  border-top: 1px solid var(--edge);
+}
+
+.mobile-data-list li > div {
+  min-width: 0;
+  flex: 1;
+}
+
+.mobile-data-list strong,
+.mobile-data-list span {
+  display: block;
+}
+
+.mobile-data-list strong {
+  overflow: hidden;
+  font-size: var(--text-body);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mobile-data-list div > span {
+  margin-top: 4px;
+  color: var(--ink-3);
+  font-family: var(--font-utility);
+  font-size: var(--text-edge-code);
+}
+
+.mobile-data-list .meter {
+  margin-top: 8px;
+}
+
+.status-badge {
+  flex: none;
+  color: var(--halide);
+  font-family: var(--font-utility);
+  font-size: var(--text-edge-code);
+}
+
+.mobile-empty-note {
+  margin: 10px 0 0;
+  color: var(--ink-3);
+  font-size: var(--text-body);
+}
+
+.mobile-chip-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin-top: 11px;
+}
+
+.mobile-model-chip {
+  display: inline-flex;
+  min-height: 44px;
+  align-items: center;
+  gap: 7px;
+  max-width: 100%;
+  border: 1px solid var(--edge);
+  border-radius: 999px;
+  padding: 2px 4px 2px 10px;
+  color: var(--rebate);
+  font-family: var(--font-utility);
+  font-size: var(--text-edge-code);
+}
+
+.mobile-model-chip > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mobile-model-chip button {
+  width: 44px;
+  height: 44px;
+  flex: none;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--stop);
+  font-size: 20px;
+}
+
+.mobile-danger-zone {
+  margin-top: 34px;
+  padding-top: 18px;
+  border-top: 1px solid var(--edge);
+}
+
+.mobile-danger-zone .danger-button {
+  width: 100%;
+}
+
+.mobile-danger-zone p {
+  margin: 8px 0 0;
+  color: var(--ink-3);
+  font-size: var(--text-caption);
+  text-align: center;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .meter > span {
+    transition: none;
+  }
 }
 
 .empty-state {

--- a/desktop/src/mobile/mobile.css.test.ts
+++ b/desktop/src/mobile/mobile.css.test.ts
@@ -28,6 +28,13 @@ describe("mobile scrolling", () => {
   });
 });
 
+describe("mobile navigation", () => {
+  it("visually marks the tab exposed as the current page", () => {
+    expect(css).toMatch(/\.mobile-tab\[aria-current="page"\]\s*\{/);
+    expect(css).not.toMatch(/\.mobile-tab\[aria-selected="true"\]\s*\{/);
+  });
+});
+
 describe("mobile safe areas", () => {
   it("keeps the shell inside the dynamic viewport and clears both landscape notches", () => {
     const shell = css.match(/\.mobile-shell\s*\{([^}]*)\}/s);

--- a/desktop/src/mobile/mobile.css.test.ts
+++ b/desktop/src/mobile/mobile.css.test.ts
@@ -12,3 +12,51 @@ describe("mobile editable controls", () => {
     expect(editables?.[1]).toMatch(/font-size:\s*16px\s*;/);
   });
 });
+
+describe("mobile scrolling", () => {
+  it("locks the WebView root and contains the one vertical content scroller", () => {
+    const root = css.match(/html,\s*body,\s*#app\s*\{([^}]*)\}/s);
+    const content = css.match(/\.mobile-content\s*\{([^}]*)\}/s);
+
+    expect(root?.[1]).toMatch(/overflow:\s*hidden\s*;/);
+    expect(root?.[1]).toMatch(/overscroll-behavior:\s*none\s*;/);
+    expect(content?.[1]).toMatch(/min-height:\s*0\s*;/);
+    expect(content?.[1]).toMatch(/overflow-x:\s*hidden\s*;/);
+    expect(content?.[1]).toMatch(/overflow-y:\s*auto\s*;/);
+    expect(content?.[1]).toMatch(/overscroll-behavior:\s*none\s*;/);
+    expect(content?.[1]).not.toMatch(/-webkit-overflow-scrolling/);
+  });
+});
+
+describe("mobile safe areas", () => {
+  it("keeps the shell inside the dynamic viewport and clears both landscape notches", () => {
+    const shell = css.match(/\.mobile-shell\s*\{([^}]*)\}/s);
+    const header = css.match(/\.mobile-header\s*\{([^}]*)\}/s);
+    const content = css.match(/\.mobile-content\s*\{([^}]*)\}/s);
+    const tabs = css.match(/\.mobile-tabs\s*\{([^}]*)\}/s);
+
+    expect(shell?.[1]).toMatch(/height:\s*100dvh\s*;/);
+    expect(shell?.[1]).toMatch(/box-sizing:\s*border-box\s*;/);
+    for (const rule of [header?.[1], content?.[1], tabs?.[1]]) {
+      expect(rule).toContain("env(safe-area-inset-left)");
+      expect(rule).toContain("env(safe-area-inset-right)");
+    }
+  });
+
+  it("keeps frequent resolution and catalog controls at least 44px tall", () => {
+    for (const selector of [
+      ".mobile-resolution-segment",
+      ".mobile-resolution-aspect",
+      ".mobile-catalog-media button",
+      ".mobile-catalog-sources button",
+      ".mobile-section-head > button",
+    ]) {
+      const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      const rules = [...css.matchAll(new RegExp(`${escaped}\\s*\\{([^}]*)\\}`, "gs"))];
+      expect(
+        rules.some((rule) => /min-height:\s*44px\s*;/.test(rule[1] ?? "")),
+        selector,
+      ).toBe(true);
+    }
+  });
+});

--- a/desktop/src/mobile/resolutionPicker.ts
+++ b/desktop/src/mobile/resolutionPicker.ts
@@ -1,0 +1,66 @@
+import { orientationLabel, type ResolutionPreset } from "../lib/resolutions";
+
+export type ResolutionOrientation = ReturnType<typeof orientationLabel>;
+
+/** Phone-first order: the neutral square first, then the two directional choices. */
+export const MOBILE_RESOLUTION_ORIENTATIONS: readonly ResolutionOrientation[] = [
+  "Square",
+  "Portrait",
+  "Landscape",
+];
+
+export function presetsForOrientation(
+  presets: readonly ResolutionPreset[],
+  orientation: ResolutionOrientation,
+): ResolutionPreset[] {
+  return presets.filter((preset) => orientationLabel(preset.width, preset.height) === orientation);
+}
+
+/** Preserve desktop ordering while collapsing repeated ratios into one chip. */
+export function aspectsForOrientation(
+  presets: readonly ResolutionPreset[],
+  orientation: ResolutionOrientation,
+): string[] {
+  return [...new Set(presetsForOrientation(presets, orientation).map((preset) => preset.aspect))];
+}
+
+/** Pick the available bucket whose pixel area is closest to the current size. */
+export function closestResolutionPreset(
+  presets: readonly ResolutionPreset[],
+  width: number,
+  height: number,
+): ResolutionPreset | null {
+  if (presets.length === 0) return null;
+  const targetArea = Math.max(1, width * height);
+  return presets.reduce((closest, candidate) => {
+    const closestDelta = Math.abs(closest.width * closest.height - targetArea);
+    const candidateDelta = Math.abs(candidate.width * candidate.height - targetArea);
+    return candidateDelta < closestDelta ? candidate : closest;
+  });
+}
+
+/** Desktop generation also snaps manual dimensions to the engine's latent stride. */
+export function snapMobileDimension(value: number, minimum = 64): number {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return minimum;
+  return Math.max(minimum, Math.round(numeric / 16) * 16);
+}
+
+export function resolutionTierLabel(index: number, total: number): string {
+  if (total <= 1) return "Recommended";
+  if (total === 2) return index === 0 ? "Standard" : "High";
+  if (total === 3) return ["Compact", "Standard", "High"][index] ?? "High";
+  if (total === 4) return ["Compact", "Standard", "High", "Max"][index] ?? "Max";
+  if (index === 0) return "Compact";
+  if (index === total - 1) return "Max";
+  return `Tier ${index + 1}`;
+}
+
+export function sortedResolutionTiers(
+  presets: readonly ResolutionPreset[],
+  aspect: string,
+): ResolutionPreset[] {
+  return presets
+    .filter((preset) => preset.aspect === aspect)
+    .sort((left, right) => left.width * left.height - right.width * right.height);
+}


### PR DESCRIPTION
## Summary

- add first-class iPhone Hosts and Catalog views backed by the selected remote Mold host
- reuse desktop resolution presets with orientation, aspect ratio, size-tier, and custom controls
- preserve multi-prompt queueing while generation is active
- add full-screen image and video viewing with swipe and button navigation plus prompt reuse
- harden remote host identity, probing, Tailscale and MagicDNS URLs, catalog downloads, and live status streams
- disable iOS input zoom and elastic web scrolling while respecting safe areas and touch target sizing

## User impact

The iPhone app now covers the core remote generation workflow with desktop-like host management, catalog browsing and model actions, resolution selection, queued prompts, and gallery inspection. Catalog browsing stays scoped to the viewed host without unexpectedly switching the generation host.

## Validation

- `bun run test` (133 files, 1204 tests)
- `bun run test -- src/mobile` (8 files, 69 tests)
- `bun run build`
- `bun run build:mobile`
- `scripts/tests/ios-release-assets.sh`
- Prettier and `git diff --check`
- iPhone 17 Pro Simulator UAT against a live remote Mold server, including preset selection, real gallery loading, full-screen viewing, and next/previous navigation