### PR TITLE
feat(ios): improve ratio and seed controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Mold for iPhone.** A first-class Tauri iOS companion connects only to remote Mold hosts and focuses the initial release on generation and the merged gallery. It reuses the desktop wire types, capability-aware request builder, and SSE client; supports saved hosts, Keychain-backed API keys, Tailscale MagicDNS names, and native Bonjour discovery of `_mold._tcp`; and ships with simulator CI plus an internal TestFlight nightly pipeline.
 - **The iPhone gallery now opens prints in a full-screen viewer.** Photos are shown uncropped, videos stream with native inline playback controls, and a clearly labeled **Use as prompt** action carries the prompt and visible generation settings into Generate instead of making a gallery tile tap silently replace the composer. Authenticated hosts issue short-lived read-only media tickets so videos can seek without exposing API keys or buffering entire files in phone memory.
 
+### Changed
+
+- **iPhone generation controls now make aspect and seed choices explicit.** Every aspect-ratio option includes a proportional frame inside its full-size touch target, while Seed uses clear Random and Fixed modes with last-seed reuse, one-tap replacement, and validation that prevents invalid fixed values from silently becoming random requests.
+
 ### Fixed
 
 - **iPhone builds now launch the bundled mobile UI and show Mold's real icon.** The mobile Vite build emits the `index.html` entry Tauri boots, every Apple icon size is generated from the Mold bowl on an opaque app-theme background, and CI rejects archives with a missing entry point, stale frontend embed, or stock Tauri icon.

--- a/README.md
+++ b/README.md
@@ -108,13 +108,15 @@ remain on that remote Mold server. Host details expose live resources, queue,
 downloads, and installed models, while Catalog can browse one host and send a
 pull to another without silently changing the host selected for generation.
 The app uses the same HTTP, SSE, model defaults, resolution presets, and
-generation request contract as the desktop app. Prompts can be submitted while
-other work is queued or developing, with independent status and cancellation
-for every job. Saved results stream from the host instead of crossing the
-iPhone WebView as encoded media; full-screen images swipe between prints and
-videos retain native playback controls. Internal TestFlight builds are produced
-from relevant `main` changes, with release checks that verify Tauri's embedded
-`index.html` and the opaque Mold-branded Apple icon catalog before upload.
+generation request contract as the desktop app. Generate shows the physical
+shape of every aspect-ratio choice and provides explicit Random and Fixed seed
+modes for repeatable prints. Prompts can be submitted while other work is queued
+or developing, with independent status and cancellation for every job. Saved
+results stream from the host instead of crossing the iPhone WebView as encoded
+media; full-screen images swipe between prints and videos retain native playback
+controls. Internal TestFlight builds are produced from relevant `main` changes,
+with release checks that verify Tauri's embedded `index.html` and the opaque
+Mold-branded Apple icon catalog before upload.
 
 On macOS, `nix develop` exposes `ios-dev`, `ios-run`, `ios-check`, and
 `ios-build`. Xcode, CocoaPods, and Apple signing are required for device and App

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -204,6 +204,33 @@ describe("MobileApp generation queue", () => {
     });
   });
 
+  it("uses an explicit mobile seed mode and submits the fixed value", async () => {
+    wrapper = mountMobileApp();
+    await flushPromises();
+
+    expect(wrapper.get("[data-test='mobile-seed-mode-random']").attributes("aria-pressed")).toBe(
+      "true",
+    );
+    expect(wrapper.find("[data-test='mobile-seed-input']").exists()).toBe(false);
+
+    await wrapper.get("[data-test='mobile-seed-mode-fixed']").trigger("click");
+    await fieldControl("Prompt").setValue("repeat this print");
+    await wrapper.get("[data-test='mobile-seed-input']").setValue("not-a-number");
+    expect(wrapper.get("[data-test='mobile-develop-button']").attributes()).toHaveProperty(
+      "disabled",
+    );
+    await wrapper.get("[data-test='mobile-seed-input']").setValue("1234");
+    expect(wrapper.get("[data-test='mobile-develop-button']").attributes()).not.toHaveProperty(
+      "disabled",
+    );
+    await wrapper.get("[data-test='mobile-develop-button']").trigger("click");
+    await flushPromises();
+
+    expect(openStreams[0]?.options.body).toMatchObject({ seed: 1234 });
+    await wrapper.get("[data-test='mobile-seed-mode-random']").trigger("click");
+    expect(wrapper.find("[data-test='mobile-seed-input']").exists()).toBe(false);
+  });
+
   it("snapshots multiple prompts, shows their live queue, and cancels only one", async () => {
     wrapper = mountMobileApp();
     await flushPromises();

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -24,6 +24,7 @@ import MobileCatalogView from "./MobileCatalogView.vue";
 import MobileGalleryViewer from "./MobileGalleryViewer.vue";
 import MobileHostDetail from "./MobileHostDetail.vue";
 import MobileResolutionPicker from "./MobileResolutionPicker.vue";
+import MobileSeedPicker from "./MobileSeedPicker.vue";
 
 type Tab = "generate" | "gallery" | "catalog" | "hosts";
 
@@ -62,6 +63,7 @@ const models = ref<ModelEntry[]>([]);
 const modelsHostId = ref("");
 const loadingModels = ref(false);
 const form = reactive<GenerateForm>(newGenerateForm());
+const seedValid = ref(true);
 const progress = ref("Ready");
 const generationAnnouncement = ref("");
 const gallery = ref<GalleryPrint[]>([]);
@@ -393,7 +395,8 @@ function revokeObjectUrl(url: string): void {
 function generate(): void {
   const host = selectedHost.value;
   const target = selectedTarget.value;
-  if (!host || !target || !form.prompt.trim() || !selectedModelAvailable.value) return;
+  if (!host || !target || !form.prompt.trim() || !selectedModelAvailable.value || !seedValid.value)
+    return;
 
   // Exactly like desktop: snapshot the request and host for this tap, open a
   // separate SSE stream immediately, and let the remote engine schedule it.
@@ -795,19 +798,20 @@ onBeforeUnmount(() => {
                 inputmode="decimal"
                 step="0.1"
             /></label>
-            <label class="field"
-              ><span>Seed</span
-              ><input v-model="form.seed" class="control" inputmode="numeric" placeholder="Random"
-            /></label>
-            <label class="field"
-              ><span>Format</span
-              ><select v-model="form.outputFormat" class="control">
-                <option v-for="format in outputFormats" :key="format" :value="format">
-                  {{ format.toUpperCase() }}
-                </option>
-              </select></label
-            >
           </div>
+          <MobileSeedPicker
+            v-model="form.seed"
+            :last-seed="generation.lastSeedUsed"
+            @validity-change="seedValid = $event"
+          />
+          <label class="field"
+            ><span>Format</span
+            ><select v-model="form.outputFormat" class="control">
+              <option v-for="format in outputFormats" :key="format" :value="format">
+                {{ format.toUpperCase() }}
+              </option>
+            </select></label
+          >
           <template v-if="form.family.includes('video') || form.family.includes('ltx2')">
             <div class="field-grid">
               <label class="field"
@@ -827,7 +831,7 @@ onBeforeUnmount(() => {
           <button
             class="primary-button"
             type="button"
-            :disabled="!form.prompt.trim() || !selectedModelAvailable"
+            :disabled="!form.prompt.trim() || !selectedModelAvailable || !seedValid"
             data-test="mobile-develop-button"
             @click="generate"
           >

--- a/desktop/src/mobile/MobileResolutionPicker.test.ts
+++ b/desktop/src/mobile/MobileResolutionPicker.test.ts
@@ -76,6 +76,26 @@ describe("MobileResolutionPicker", () => {
     expect(state).toMatchObject({ width: 768, height: 1344 });
   });
 
+  it("shows each aspect choice as a proportionally accurate frame", async () => {
+    const { wrapper } = mountPicker(928, 1664, "qwen-image");
+    const choices = wrapper.findAll(".mobile-resolution-aspect");
+
+    expect(choices.map((choice) => choice.text())).toEqual(["7:9", "13:19", "4:7", "≈9:16"]);
+    const frames = choices.map((choice) =>
+      choice.get("[data-test='mobile-resolution-aspect-shape']"),
+    );
+    expect(frames.every((frame) => frame.attributes("aria-hidden") === "true")).toBe(true);
+    expect(frames.every((frame) => frame.attributes("style")?.includes("height: 28px"))).toBe(true);
+
+    const widths = frames.map((frame) =>
+      Number.parseFloat((frame.element as HTMLElement).style.width),
+    );
+    expect(widths[0]).toBeGreaterThan(widths[1]!);
+    expect(widths[1]).toBeGreaterThan(widths[2]!);
+    expect(widths[2]).toBeGreaterThan(widths[3]!);
+    expect(choices[3]?.attributes("aria-label")).toBe("Approximately 9 by 16 aspect ratio");
+  });
+
   it("falls back to iPhone-friendly custom fields and snaps values to 16", async () => {
     const { wrapper, state } = mountPicker(1000, 777);
 

--- a/desktop/src/mobile/MobileResolutionPicker.test.ts
+++ b/desktop/src/mobile/MobileResolutionPicker.test.ts
@@ -85,7 +85,11 @@ describe("MobileResolutionPicker", () => {
       choice.get("[data-test='mobile-resolution-aspect-shape']"),
     );
     expect(frames.every((frame) => frame.attributes("aria-hidden") === "true")).toBe(true);
-    expect(frames.every((frame) => frame.attributes("style")?.includes("height: 28px"))).toBe(true);
+    expect(
+      frames.every(
+        (frame) => Number.parseFloat((frame.element as HTMLElement).style.height) === 28,
+      ),
+    ).toBe(true);
 
     const widths = frames.map((frame) =>
       Number.parseFloat((frame.element as HTMLElement).style.width),

--- a/desktop/src/mobile/MobileResolutionPicker.vue
+++ b/desktop/src/mobile/MobileResolutionPicker.vue
@@ -41,10 +41,41 @@ const aspectOptions = computed(() =>
 const tierOptions = computed(() =>
   currentPreset.value ? sortedResolutionTiers(presets.value, currentPreset.value.aspect) : [],
 );
-const aspectShapeStyle = computed(() => ({
-  aspectRatio: `${width.value} / ${height.value}`,
-  ...(width.value > height.value ? { width: "34px" } : { height: "30px" }),
-}));
+const aspectShapeStyle = computed(() => proportionalShapeStyle(width.value, height.value, 34, 30));
+
+function proportionalShapeStyle(
+  shapeWidth: number,
+  shapeHeight: number,
+  maxWidth: number,
+  maxHeight: number,
+): Record<string, string> {
+  const safeWidth = Math.max(1, shapeWidth);
+  const safeHeight = Math.max(1, shapeHeight);
+  const scale = Math.min(maxWidth / safeWidth, maxHeight / safeHeight);
+  return {
+    width: `${(safeWidth * scale).toFixed(2)}px`,
+    height: `${(safeHeight * scale).toFixed(2)}px`,
+  };
+}
+
+function aspectDimensions(aspect: string): [number, number] {
+  const preset = presets.value.find((candidate) => candidate.aspect === aspect);
+  if (preset) return [preset.width, preset.height];
+  const match = aspect.replace(/^≈/, "").match(/^(\d+(?:\.\d+)?):(\d+(?:\.\d+)?)$/);
+  if (!match) return [1, 1];
+  return [Number(match[1]), Number(match[2])];
+}
+
+function aspectOptionShapeStyle(aspect: string): Record<string, string> {
+  const [shapeWidth, shapeHeight] = aspectDimensions(aspect);
+  return proportionalShapeStyle(shapeWidth, shapeHeight, 30, 28);
+}
+
+function aspectAccessibleLabel(aspect: string): string {
+  const approximate = aspect.startsWith("≈");
+  const [left, right] = aspect.replace(/^≈/, "").split(":");
+  return `${approximate ? "Approximately " : ""}${left} by ${right} aspect ratio`;
+}
 
 function isOrientationAvailable(orientation: ResolutionOrientation): boolean {
   return presetsForOrientation(presets.value, orientation).length > 0;
@@ -146,7 +177,7 @@ function swapDimensions(): void {
 
     <div class="mobile-resolution-group">
       <span class="mobile-resolution-label">Aspect ratio</span>
-      <div class="mobile-resolution-aspects" aria-label="Aspect ratio presets">
+      <div class="mobile-resolution-aspects" role="group" aria-label="Aspect ratio presets">
         <button
           v-for="aspect in aspectOptions"
           :key="aspect"
@@ -154,10 +185,19 @@ function swapDimensions(): void {
           class="mobile-resolution-aspect"
           :class="{ 'is-selected': currentPreset?.aspect === aspect }"
           :aria-pressed="currentPreset?.aspect === aspect"
+          :aria-label="aspectAccessibleLabel(aspect)"
           :data-aspect="aspect"
           @click="setAspect(aspect)"
         >
-          {{ aspect }}
+          <span class="mobile-resolution-aspect-visual" aria-hidden="true">
+            <span
+              class="mobile-resolution-aspect-shape"
+              data-test="mobile-resolution-aspect-shape"
+              aria-hidden="true"
+              :style="aspectOptionShapeStyle(aspect)"
+            />
+          </span>
+          <span class="mobile-resolution-aspect-label">{{ aspect }}</span>
         </button>
       </div>
     </div>

--- a/desktop/src/mobile/MobileSeedPicker.test.ts
+++ b/desktop/src/mobile/MobileSeedPicker.test.ts
@@ -1,0 +1,131 @@
+import { mount } from "@vue/test-utils";
+import { defineComponent, nextTick, reactive } from "vue";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import MobileSeedPicker from "./MobileSeedPicker.vue";
+
+function mountPicker(seed = "", lastSeed: number | null = null) {
+  const state = reactive({ seed, lastSeed, valid: true });
+  const Harness = defineComponent({
+    components: { MobileSeedPicker },
+    setup: () => ({ state }),
+    template: `
+      <MobileSeedPicker
+        v-model="state.seed"
+        :last-seed="state.lastSeed"
+        @validity-change="state.valid = $event"
+      />
+    `,
+  });
+  return { wrapper: mount(Harness), state };
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("MobileSeedPicker", () => {
+  it("makes random generation explicit without showing a misleading empty input", () => {
+    const { wrapper } = mountPicker();
+
+    expect(wrapper.get("[data-test='mobile-seed-mode-random']").attributes("aria-pressed")).toBe(
+      "true",
+    );
+    expect(wrapper.get("[data-test='mobile-seed-mode-fixed']").attributes("aria-pressed")).toBe(
+      "false",
+    );
+    expect(wrapper.find("[data-test='mobile-seed-input']").exists()).toBe(false);
+    expect(wrapper.get("[data-test='mobile-seed-note']").text()).toBe("New seed for every print.");
+  });
+
+  it("turns Fixed into a populated, numeric mobile input", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    const { wrapper, state } = mountPicker();
+
+    await wrapper.get("[data-test='mobile-seed-mode-fixed']").trigger("click");
+
+    expect(state.seed).toBe("2147483647");
+    const input = wrapper.get("[data-test='mobile-seed-input']");
+    expect(input.attributes()).toMatchObject({
+      inputmode: "numeric",
+      enterkeyhint: "done",
+      pattern: "[0-9]*",
+      "aria-label": "Fixed seed value",
+    });
+    expect(wrapper.get("[data-test='mobile-seed-mode-fixed']").attributes("aria-pressed")).toBe(
+      "true",
+    );
+    expect(wrapper.get("[data-test='mobile-seed-note']").text()).toBe(
+      "Repeat this seed for matching results.",
+    );
+  });
+
+  it("can lock the most recent generated seed or roll a new fixed value", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.25);
+    const { wrapper, state } = mountPicker("", 91);
+
+    await wrapper.get("[data-test='mobile-use-last-seed']").trigger("click");
+    expect(state.seed).toBe("91");
+
+    await wrapper.get("[data-test='mobile-new-seed']").trigger("click");
+    expect(state.seed).toBe("1073741823");
+  });
+
+  it("returns to Random by clearing the fixed value", async () => {
+    const { wrapper, state } = mountPicker("1234");
+
+    expect(wrapper.get("[data-test='mobile-seed-mode-fixed']").attributes("aria-pressed")).toBe(
+      "true",
+    );
+    await wrapper.get("[data-test='mobile-seed-mode-random']").trigger("click");
+
+    expect(state.seed).toBe("");
+    expect(wrapper.find("[data-test='mobile-seed-input']").exists()).toBe(false);
+  });
+
+  it("keeps fixed mode stable while editing and explains invalid values", async () => {
+    const { wrapper, state } = mountPicker("7");
+    const input = wrapper.get("[data-test='mobile-seed-input']");
+
+    await input.setValue("");
+    expect(state.seed).toBe("");
+    expect(wrapper.get("[data-test='mobile-seed-mode-fixed']").attributes("aria-pressed")).toBe(
+      "true",
+    );
+    expect(wrapper.get("[data-test='mobile-seed-note']").text()).toBe(
+      "Enter a whole number, or choose Random.",
+    );
+
+    state.seed = "not-a-number";
+    await nextTick();
+    expect(wrapper.get("[data-test='mobile-seed-note']").text()).toBe(
+      "Use a whole number, 0 or higher.",
+    );
+  });
+
+  it.each(["-1", "1.5", "not-a-number", "9007199254740992"])(
+    "marks %s invalid instead of silently treating it as random",
+    async (value) => {
+      const { wrapper, state } = mountPicker("7");
+      const input = wrapper.get("[data-test='mobile-seed-input']");
+
+      await input.setValue(value);
+
+      expect(state.valid).toBe(false);
+      expect(input.attributes("aria-invalid")).toBe("true");
+      expect(input.attributes("aria-describedby")).toBe(
+        wrapper.get("[data-test='mobile-seed-note']").attributes("id"),
+      );
+      expect(wrapper.get("[data-test='mobile-seed-note']").attributes("role")).toBe("alert");
+    },
+  );
+
+  it("accepts zero as a real fixed seed", async () => {
+    const { wrapper, state } = mountPicker("7");
+
+    await wrapper.get("[data-test='mobile-seed-input']").setValue("0");
+
+    expect(state.seed).toBe("0");
+    expect(state.valid).toBe(true);
+    expect(wrapper.get("[data-test='mobile-seed-input']").attributes("aria-invalid")).toBe(
+      undefined,
+    );
+  });
+});

--- a/desktop/src/mobile/MobileSeedPicker.vue
+++ b/desktop/src/mobile/MobileSeedPicker.vue
@@ -1,0 +1,141 @@
+<script setup lang="ts">
+import { computed, ref, useId, watch } from "vue";
+import { seedMode } from "../lib/generateForm";
+import { randomSeed } from "../stores/generation";
+
+const props = withDefaults(
+  defineProps<{
+    lastSeed?: number | null;
+    disabled?: boolean;
+  }>(),
+  { lastSeed: null, disabled: false },
+);
+
+const seed = defineModel<string>({ required: true });
+const emit = defineEmits<{
+  "validity-change": [valid: boolean];
+}>();
+const uiMode = ref<"random" | "fixed">(seedMode(seed.value));
+const noteId = `mobile-seed-note-${useId()}`;
+
+watch(seed, (next) => {
+  // External reuse and history actions should reveal the fixed editor. Keep
+  // the editor open when its value is cleared mid-entry so focus is stable.
+  if (seedMode(next) === "fixed") uiMode.value = "fixed";
+});
+
+const seedNote = computed(() => {
+  if (uiMode.value === "random") return "New seed for every print.";
+  const raw = seed.value.trim();
+  if (raw === "") return "Enter a whole number, or choose Random.";
+  if (!/^\d+$/.test(raw)) return "Use a whole number, 0 or higher.";
+  if (!Number.isSafeInteger(Number(raw))) return "Seed is too large to reproduce exactly.";
+  return "Repeat this seed for matching results.";
+});
+
+const seedValid = computed(() => {
+  if (uiMode.value === "random") return true;
+  const raw = seed.value.trim();
+  return /^\d+$/.test(raw) && Number.isSafeInteger(Number(raw));
+});
+const seedInvalid = computed(() => !seedValid.value);
+
+watch(seedValid, (valid) => emit("validity-change", valid), { immediate: true });
+
+function setMode(mode: "random" | "fixed"): void {
+  uiMode.value = mode;
+  if (mode === "random") {
+    seed.value = "";
+  } else if (seedMode(seed.value) === "random") {
+    seed.value = String(props.lastSeed ?? randomSeed());
+  }
+}
+
+function useLastSeed(): void {
+  if (props.lastSeed === null) return;
+  uiMode.value = "fixed";
+  seed.value = String(props.lastSeed);
+}
+
+function newSeed(): void {
+  uiMode.value = "fixed";
+  seed.value = String(randomSeed());
+}
+</script>
+
+<template>
+  <fieldset class="mobile-seed-picker" :disabled="disabled">
+    <legend class="mobile-seed-legend">Seed</legend>
+    <div class="mobile-seed-modes" role="group" aria-label="Seed mode">
+      <button
+        type="button"
+        class="mobile-seed-mode"
+        :class="{ 'is-selected': uiMode === 'random' }"
+        :aria-pressed="uiMode === 'random'"
+        data-test="mobile-seed-mode-random"
+        @click="setMode('random')"
+      >
+        Random
+      </button>
+      <button
+        type="button"
+        class="mobile-seed-mode"
+        :class="{ 'is-selected': uiMode === 'fixed' }"
+        :aria-pressed="uiMode === 'fixed'"
+        data-test="mobile-seed-mode-fixed"
+        @click="setMode('fixed')"
+      >
+        Fixed
+      </button>
+    </div>
+
+    <div v-if="uiMode === 'fixed'" class="mobile-seed-fixed">
+      <input
+        v-model="seed"
+        class="control mobile-seed-input"
+        data-selectable
+        data-test="mobile-seed-input"
+        type="text"
+        inputmode="numeric"
+        enterkeyhint="done"
+        pattern="[0-9]*"
+        autocomplete="off"
+        autocapitalize="none"
+        :spellcheck="false"
+        aria-label="Fixed seed value"
+        :aria-invalid="seedInvalid || undefined"
+        :aria-describedby="noteId"
+      />
+      <button
+        type="button"
+        class="secondary-button mobile-seed-new"
+        data-test="mobile-new-seed"
+        aria-label="Generate a new fixed seed"
+        @click="newSeed"
+      >
+        New value
+      </button>
+    </div>
+
+    <div class="mobile-seed-footer">
+      <p
+        class="mobile-seed-note"
+        :class="{ 'is-error': seedInvalid }"
+        :id="noteId"
+        data-test="mobile-seed-note"
+        :role="seedInvalid ? 'alert' : undefined"
+      >
+        {{ seedNote }}
+      </p>
+      <button
+        v-if="uiMode === 'random' && lastSeed !== null"
+        type="button"
+        class="mobile-seed-use-last"
+        data-test="mobile-use-last-seed"
+        @click="useLastSeed"
+      >
+        Use last <span>{{ lastSeed }}</span>
+      </button>
+    </div>
+  </fieldset>
+</template>

--- a/desktop/src/mobile/mobile.css
+++ b/desktop/src/mobile/mobile.css
@@ -257,17 +257,21 @@ textarea.control {
 }
 
 .mobile-resolution-aspects {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(64px, 84px));
   gap: 7px;
 }
 
 .mobile-resolution-aspect {
-  min-width: 54px;
-  min-height: 44px;
+  min-width: 0;
+  min-height: 72px;
+  display: grid;
+  grid-template-rows: 32px auto;
+  place-items: center;
+  gap: 5px;
   border: 1px solid var(--control-edge);
   border-radius: var(--radius-control);
-  padding: 6px 10px;
+  padding: 7px 5px 6px;
   background: transparent;
   color: var(--ink-2);
   font-family: var(--font-utility);
@@ -276,7 +280,32 @@ textarea.control {
 
 .mobile-resolution-aspect.is-selected {
   border-color: var(--safelight);
+  background: color-mix(in srgb, var(--safelight) 9%, transparent);
   color: var(--safelight);
+}
+
+.mobile-resolution-aspect-visual {
+  display: grid;
+  width: 34px;
+  height: 30px;
+  place-items: center;
+}
+
+.mobile-resolution-aspect-shape {
+  box-sizing: border-box;
+  display: block;
+  border: 1px solid currentColor;
+  border-radius: 2px;
+  background: color-mix(in srgb, currentColor 5%, transparent);
+}
+
+.mobile-resolution-aspect.is-selected .mobile-resolution-aspect-shape {
+  border-width: 2px;
+  background: color-mix(in srgb, currentColor 22%, transparent);
+}
+
+.mobile-resolution-aspect-label {
+  line-height: 1;
 }
 
 .mobile-resolution-tier {
@@ -311,6 +340,101 @@ textarea.control {
   margin: 8px 0 0;
   color: var(--ink-3);
   font-size: var(--text-caption);
+}
+
+.mobile-seed-picker {
+  min-width: 0;
+  margin: 2px 0 14px;
+  border: 0;
+  padding: 0;
+}
+
+.mobile-seed-legend {
+  color: var(--ink-3);
+  font-family: var(--font-utility);
+  font-size: var(--text-edge-code);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.mobile-seed-modes {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 2px;
+  margin-top: 7px;
+  padding: 3px;
+  border: 1px solid var(--control-edge);
+  border-radius: var(--radius-control);
+  background: var(--bench);
+}
+
+.mobile-seed-mode {
+  min-height: 44px;
+  border: 0;
+  border-radius: calc(var(--radius-control) - 2px);
+  background: transparent;
+  color: var(--ink-3);
+  font-family: var(--font-utility);
+  font-size: var(--text-data);
+}
+
+.mobile-seed-mode.is-selected {
+  background: color-mix(in srgb, var(--safelight) 15%, transparent);
+  color: var(--safelight);
+}
+
+.mobile-seed-fixed {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.mobile-seed-input {
+  min-width: 0;
+  font-family: var(--font-utility);
+  font-variant-numeric: tabular-nums;
+}
+
+.mobile-seed-new {
+  min-width: 104px;
+  min-height: 44px;
+  padding-inline: 12px;
+}
+
+.mobile-seed-footer {
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.mobile-seed-note {
+  min-width: 0;
+  margin: 7px 0 0;
+  color: var(--ink-3);
+  font-size: var(--text-caption);
+  text-wrap: pretty;
+}
+
+.mobile-seed-note.is-error {
+  color: var(--stop);
+}
+
+.mobile-seed-use-last {
+  min-height: 44px;
+  flex: none;
+  border: 0;
+  padding: 0 2px;
+  background: transparent;
+  color: var(--halide);
+  font-family: var(--font-utility);
+  font-size: var(--text-caption);
+}
+
+.mobile-seed-use-last span {
+  font-variant-numeric: tabular-nums;
 }
 
 .primary-button,

--- a/desktop/src/mobile/mobile.css.test.ts
+++ b/desktop/src/mobile/mobile.css.test.ts
@@ -61,9 +61,23 @@ describe("mobile safe areas", () => {
       const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
       const rules = [...css.matchAll(new RegExp(`${escaped}\\s*\\{([^}]*)\\}`, "gs"))];
       expect(
-        rules.some((rule) => /min-height:\s*44px\s*;/.test(rule[1] ?? "")),
+        rules.some((rule) => {
+          const height = rule[1]?.match(/min-height:\s*(\d+)px\s*;/)?.[1];
+          return height !== undefined && Number(height) >= 44;
+        }),
         selector,
       ).toBe(true);
     }
+  });
+
+  it("gives aspect choices a proportional visual frame inside a uniform touch tile", () => {
+    const aspects = css.match(/\.mobile-resolution-aspects\s*\{([^}]*)\}/s);
+    const choice = css.match(/\.mobile-resolution-aspect\s*\{([^}]*)\}/s);
+    const shape = css.match(/\.mobile-resolution-aspect-shape\s*\{([^}]*)\}/s);
+
+    expect(aspects?.[1]).toMatch(/display:\s*grid\s*;/);
+    expect(aspects?.[1]).toMatch(/minmax\(64px,\s*84px\)/);
+    expect(choice?.[1]).toMatch(/min-height:\s*72px\s*;/);
+    expect(shape?.[1]).toMatch(/border:\s*1px solid currentColor\s*;/);
   });
 });


### PR DESCRIPTION
## Summary

- render every iPhone aspect-ratio choice as a proportional visual tile while retaining equal, accessible touch targets
- replace the ambiguous empty Seed input with explicit Random and Fixed modes, last-seed reuse, and one-tap seed renewal
- reject invalid or unsafe fixed seeds before submission and document the updated iPhone Generate controls

## Why

The resolution summary visualized the selected canvas, but the ratio choices themselves were text-only. Seed also relied on an empty field and a `Random` placeholder, which did not clearly communicate whether a generation would be reproducible.

## Validation

- `cd desktop && bun run test` (1,219 tests)
- `cd desktop && bun run build`
- `cd desktop && bun run build:mobile`
- `cd desktop && bun run fmt:check`
- `bash scripts/tests/ios-release-assets.sh`
- `./scripts/ios.sh simulator`
- installed and visually verified the signed debug bundle on iPhone 17 Pro / iOS 26.5 Simulator
- `git diff --check`
