### PR TITLE
feat(ios): add settings, themes, and pull progress

### DIFF
--- a/apps/mobile/src-tauri/Cargo.lock
+++ b/apps/mobile/src-tauri/Cargo.lock
@@ -1726,6 +1726,7 @@ name = "mold-mobile"
 version = "0.18.0"
 dependencies = [
  "libc",
+ "objc2-ui-kit",
  "security-framework",
  "security-framework-sys",
  "serde",

--- a/apps/mobile/src-tauri/Cargo.toml
+++ b/apps/mobile/src-tauri/Cargo.toml
@@ -24,5 +24,8 @@ tauri = { version = "2", features = [] }
 security-framework = "3"
 security-framework-sys = "2"
 
+[target.'cfg(target_os = "ios")'.dependencies]
+objc2-ui-kit = { version = "0.3.2", default-features = false, features = ["UIInterface", "UIResponder", "UIViewController"] }
+
 [features]
 default = []

--- a/apps/mobile/src-tauri/Info.ios.plist
+++ b/apps/mobile/src-tauri/Info.ios.plist
@@ -10,6 +10,8 @@
   <array>
     <string>_mold._tcp</string>
   </array>
+  <key>UIViewControllerBasedStatusBarAppearance</key>
+  <true/>
   <key>NSAppTransportSecurity</key>
   <dict>
     <key>NSAllowsLocalNetworking</key>

--- a/apps/mobile/src-tauri/gen/apple/mold-mobile_iOS/Info.plist
+++ b/apps/mobile/src-tauri/gen/apple/mold-mobile_iOS/Info.plist
@@ -39,6 +39,8 @@
 	<array>
 		<string>arm64</string>
 	</array>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<true/>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/apps/mobile/src-tauri/gen/apple/project.yml
+++ b/apps/mobile/src-tauri/gen/apple/project.yml
@@ -42,6 +42,7 @@ targets:
         LSRequiresIPhoneOS: true
         UILaunchStoryboardName: LaunchScreen
         UIRequiredDeviceCapabilities: [arm64]
+        UIViewControllerBasedStatusBarAppearance: true
         NSLocalNetworkUsageDescription: Mold discovers and connects to generation hosts on your local network.
         NSBonjourServices:
           - _mold._tcp

--- a/apps/mobile/src-tauri/src/appearance.rs
+++ b/apps/mobile/src-tauri/src/appearance.rs
@@ -1,0 +1,90 @@
+use serde::Deserialize;
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum MobileAppearance {
+    System,
+    Light,
+    Dark,
+}
+
+#[cfg(any(test, target_os = "ios"))]
+impl MobileAppearance {
+    const fn native_style(self) -> NativeUserInterfaceStyle {
+        match self {
+            Self::System => NativeUserInterfaceStyle::Unspecified,
+            Self::Light => NativeUserInterfaceStyle::Light,
+            Self::Dark => NativeUserInterfaceStyle::Dark,
+        }
+    }
+}
+
+#[cfg(any(test, target_os = "ios"))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum NativeUserInterfaceStyle {
+    Unspecified,
+    Light,
+    Dark,
+}
+
+/// Keep UIKit's appearance in step with Mold's WebView appearance. UIKit's
+/// default status-bar style follows this trait, so the glyphs remain readable
+/// over both light and dark safe-area chrome.
+#[tauri::command]
+pub fn set_mobile_appearance(
+    window: tauri::WebviewWindow,
+    appearance: MobileAppearance,
+) -> Result<(), String> {
+    window
+        .with_webview(move |webview| {
+            #[cfg(target_os = "ios")]
+            {
+                use objc2_ui_kit::{UIUserInterfaceStyle, UIViewController};
+
+                let style = match appearance.native_style() {
+                    NativeUserInterfaceStyle::Unspecified => UIUserInterfaceStyle::Unspecified,
+                    NativeUserInterfaceStyle::Light => UIUserInterfaceStyle::Light,
+                    NativeUserInterfaceStyle::Dark => UIUserInterfaceStyle::Dark,
+                };
+
+                // SAFETY: Tauri documents `view_controller()` as the live
+                // UIViewController for this WebView. `with_webview` executes
+                // this callback on the main thread, as UIKit requires.
+                let controller = unsafe {
+                    webview
+                        .view_controller()
+                        .cast::<UIViewController>()
+                        .as_ref()
+                };
+                if let Some(controller) = controller {
+                    controller.setOverrideUserInterfaceStyle(style);
+                    controller.setNeedsStatusBarAppearanceUpdate();
+                }
+            }
+
+            #[cfg(not(target_os = "ios"))]
+            let _ = (webview, appearance);
+        })
+        .map_err(|error| format!("failed to update mobile appearance: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_each_web_appearance_to_the_matching_native_trait() {
+        assert_eq!(
+            MobileAppearance::System.native_style(),
+            NativeUserInterfaceStyle::Unspecified
+        );
+        assert_eq!(
+            MobileAppearance::Light.native_style(),
+            NativeUserInterfaceStyle::Light
+        );
+        assert_eq!(
+            MobileAppearance::Dark.native_style(),
+            NativeUserInterfaceStyle::Dark
+        );
+    }
+}

--- a/apps/mobile/src-tauri/src/lib.rs
+++ b/apps/mobile/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 //! Thin native shell for Mold on iPhone. Generation and gallery logic use the
 //! shared Vue wire types while the phone connects only to remote Mold servers.
 
+mod appearance;
 mod discovery;
 mod keychain;
 
@@ -12,6 +13,7 @@ fn app_context() -> tauri::Context<tauri::Wry> {
 pub fn run() {
     tauri::Builder::default()
         .invoke_handler(tauri::generate_handler![
+            appearance::set_mobile_appearance,
             discovery::discover_mold_hosts,
             keychain::keychain_set_api_key,
             keychain::keychain_get_api_key,
@@ -39,11 +41,24 @@ mod tests {
             "embedded index.html must be the Mold mobile entry"
         );
         assert!(
+            index.contains("maximum-scale=1") && index.contains("user-scalable=no"),
+            "embedded mobile viewport must disable iPhone document zoom"
+        );
+        assert!(
             context
                 .assets()
                 .get(&AssetKey::from("index.mobile.html"))
                 .is_none(),
             "the source filename must be renamed before Tauri embeds it"
+        );
+    }
+
+    #[test]
+    fn ios_uses_view_controller_status_bar_appearance() {
+        let plist = include_str!("../Info.ios.plist");
+        assert!(
+            plist.contains("<key>UIViewControllerBasedStatusBarAppearance</key>\n  <true/>"),
+            "iOS must let the Tauri view controller update status-bar appearance"
         );
     }
 }

--- a/desktop/index.mobile.html
+++ b/desktop/index.mobile.html
@@ -2,7 +2,10 @@
 <html lang="en" data-theme-family="mold">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+    />
     <meta name="theme-color" content="#12101d" />
     <meta name="mold-mobile-entry" content="mold-mobile-entry-v1" />
     <title>Mold</title>

--- a/desktop/src/lib/ipc.ts
+++ b/desktop/src/lib/ipc.ts
@@ -7,6 +7,9 @@ import type {
   RunPodPod,
 } from "./runpod";
 import type { GalleryImage, OutputMetadata } from "./api/types";
+import type { Theme, ThemeFamily } from "./theme";
+
+export type { Theme, ThemeFamily } from "./theme";
 
 /**
  * Typed wrappers around Tauri IPC. In a plain browser (`bun run dev` /
@@ -27,8 +30,6 @@ export interface LocalServerInfo {
   port: number;
 }
 
-export type Theme = "system" | "dark" | "light";
-export type ThemeFamily = "safelight" | "mold";
 export type UpdateChannel = "stable" | "nightly";
 
 export interface UpdateCandidate {

--- a/desktop/src/lib/theme.test.ts
+++ b/desktop/src/lib/theme.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { applyTheme, isTheme, isThemeFamily, resolveThemeAttributes } from "./theme";
+
+afterEach(() => {
+  delete document.documentElement.dataset.theme;
+  delete document.documentElement.dataset.themeFamily;
+  document.documentElement.style.removeProperty("--bath");
+  document.head.innerHTML = "";
+});
+
+describe("shared theme contract", () => {
+  it("keeps appearance independent from the palette family", () => {
+    expect(resolveThemeAttributes("dark", "mold")).toEqual({
+      appearance: "dark",
+      family: "mold",
+    });
+    expect(resolveThemeAttributes("system", "safelight")).toEqual({
+      appearance: null,
+      family: "safelight",
+    });
+  });
+
+  it("validates only supported persisted values", () => {
+    expect(isTheme("light")).toBe(true);
+    expect(isTheme("sepia")).toBe(false);
+    expect(isThemeFamily("mold")).toBe(true);
+    expect(isThemeFamily("neon")).toBe(false);
+  });
+
+  it("applies root attributes and clears explicit appearance for System", () => {
+    document.head.innerHTML = '<meta name="theme-color" content="#000000">';
+    document.documentElement.style.setProperty("--bath", "#f7f5fa");
+
+    applyTheme("light", "mold");
+    expect(document.documentElement.dataset.theme).toBe("light");
+    expect(document.documentElement.dataset.themeFamily).toBe("mold");
+    expect(document.querySelector<HTMLMetaElement>('meta[name="theme-color"]')?.content).toBe(
+      "#f7f5fa",
+    );
+
+    applyTheme("system", "safelight");
+    expect(document.documentElement.dataset.theme).toBeUndefined();
+    expect(document.documentElement.dataset.themeFamily).toBe("safelight");
+  });
+});

--- a/desktop/src/lib/theme.ts
+++ b/desktop/src/lib/theme.ts
@@ -1,0 +1,64 @@
+export type Theme = "system" | "dark" | "light";
+export type ThemeFamily = "safelight" | "mold";
+
+export const THEMES = ["system", "dark", "light"] as const satisfies readonly Theme[];
+export const THEME_FAMILIES = ["mold", "safelight"] as const satisfies readonly ThemeFamily[];
+
+export function isTheme(value: unknown): value is Theme {
+  return typeof value === "string" && (THEMES as readonly string[]).includes(value);
+}
+
+export function isThemeFamily(value: unknown): value is ThemeFamily {
+  return typeof value === "string" && (THEME_FAMILIES as readonly string[]).includes(value);
+}
+
+/**
+ * Resolve the independent palette-family and light/dark root attributes.
+ * A null appearance lets the system color-scheme media query drive the UI.
+ */
+export function resolveThemeAttributes(
+  theme: Theme,
+  family: ThemeFamily,
+): { appearance: "light" | "dark" | null; family: ThemeFamily } {
+  return {
+    appearance: theme === "system" ? null : theme,
+    family,
+  };
+}
+
+/** Keep native browser/WebView chrome aligned with the active Bath token. */
+export function syncThemeColor(
+  root: HTMLElement = document.documentElement,
+  documentNode: Document = document,
+): void {
+  const meta = documentNode.querySelector<HTMLMetaElement>('meta[name="theme-color"]');
+  if (!meta || typeof getComputedStyle !== "function") return;
+  const bath = getComputedStyle(root).getPropertyValue("--bath").trim();
+  if (bath) meta.content = bath;
+}
+
+/** Apply the shared desktop/mobile theme contract to a document root. */
+export function applyTheme(
+  theme: Theme,
+  family: ThemeFamily,
+  root: HTMLElement = document.documentElement,
+): void {
+  const attrs = resolveThemeAttributes(theme, family);
+  if (attrs.appearance === null) delete root.dataset.theme;
+  else root.dataset.theme = attrs.appearance;
+  root.dataset.themeFamily = attrs.family;
+  syncThemeColor(root, root.ownerDocument);
+}
+
+/**
+ * System appearance can change while the app is running. The CSS palette
+ * follows automatically; this listener keeps the native status-bar color in
+ * step as well.
+ */
+export function installSystemThemeColorSync(): () => void {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") return () => {};
+  const query = window.matchMedia("(prefers-color-scheme: light)");
+  const sync = () => syncThemeColor();
+  query.addEventListener?.("change", sync);
+  return () => query.removeEventListener?.("change", sync);
+}

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -179,6 +179,8 @@ afterEach(() => {
   wrapper?.unmount();
   wrapper = null;
   document.body.innerHTML = "";
+  delete document.documentElement.dataset.theme;
+  delete document.documentElement.dataset.themeFamily;
 });
 
 describe("MobileApp generation queue", () => {
@@ -1279,6 +1281,58 @@ describe("MobileApp generation queue", () => {
     await vi.waitFor(() => expect(galleryCalls).toBe(2));
     await vi.waitFor(() => expect(wrapper?.findAll("[data-test='gallery-item']")).toHaveLength(40));
     expect(document.activeElement).toBe(wrapper.get("[data-test='mobile-tab-gallery']").element);
+  });
+});
+
+describe("MobileApp settings", () => {
+  it("opens as a focused destination and returns to the unchanged primary tab", async () => {
+    wrapper = mountMobileApp();
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-tab-gallery']").trigger("click");
+    await flushPromises();
+
+    await wrapper.get("[data-test='mobile-open-settings']").trigger("click");
+    await flushPromises();
+
+    expect(wrapper.get("[data-test='mobile-settings']").isVisible()).toBe(true);
+    expect(wrapper.find(".mobile-tabs").exists()).toBe(false);
+    expect(document.activeElement).toBe(wrapper.get("[data-test='mobile-settings-back']").element);
+
+    await wrapper.get("[data-test='mobile-settings-back']").trigger("click");
+    await flushPromises();
+    expect(wrapper.get("[data-test='mobile-tab-gallery']").attributes("aria-current")).toBe("page");
+    expect(document.activeElement).toBe(wrapper.get("[data-test='mobile-open-settings']").element);
+  });
+
+  it("applies and persists family and appearance changes immediately", async () => {
+    wrapper = mountMobileApp();
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-open-settings']").trigger("click");
+
+    await wrapper.get('input[name="mobile-theme-family"][value="safelight"]').setValue(true);
+    await wrapper.get('input[name="mobile-theme-appearance"][value="light"]').setValue(true);
+    await flushPromises();
+
+    expect(document.documentElement.dataset.themeFamily).toBe("safelight");
+    expect(document.documentElement.dataset.theme).toBe("light");
+    expect(JSON.parse(localStorage.getItem("mold.mobile.settings.v1") ?? "{}")).toEqual({
+      theme: "light",
+      themeFamily: "safelight",
+    });
+
+    await wrapper.get('input[name="mobile-theme-appearance"][value="system"]').setValue(true);
+    expect(document.documentElement.dataset.theme).toBeUndefined();
+  });
+
+  it("opens host management from Settings", async () => {
+    wrapper = mountMobileApp();
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-open-settings']").trigger("click");
+    await wrapper.get(".mobile-settings-manage").trigger("click");
+    await flushPromises();
+
+    expect(wrapper.find("[data-test='mobile-settings']").exists()).toBe(false);
+    expect(wrapper.get("[data-test='mobile-tab-hosts']").attributes("aria-current")).toBe("page");
   });
 });
 

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -51,8 +51,14 @@ import MobileLoraControls from "./MobileLoraControls.vue";
 import MobilePromptTools from "./MobilePromptTools.vue";
 import MobileResolutionPicker from "./MobileResolutionPicker.vue";
 import MobileSeedPicker from "./MobileSeedPicker.vue";
+import MobileSettingsView from "./MobileSettingsView.vue";
 import MobileSourceControls from "./MobileSourceControls.vue";
 import MobileTemplates from "./MobileTemplates.vue";
+import {
+  loadMobileSettings,
+  updateMobileSettings as persistMobileSettings,
+  type MobileSettings,
+} from "./settings";
 
 type Tab = "generate" | "gallery" | "catalog" | "hosts";
 
@@ -79,6 +85,11 @@ const STORAGE_KEY = "mold.mobile.hosts.v1";
 const SELECTED_KEY = "mold.mobile.selected-host.v1";
 const HOST_PROBE_TIMEOUT_MS = 9_000;
 const tab = ref<Tab>("generate");
+const settingsOpen = ref(false);
+const settingsButton = ref<HTMLButtonElement | null>(null);
+const settingsBackButton = ref<HTMLButtonElement | null>(null);
+const mobileSettings = reactive<MobileSettings>(loadMobileSettings());
+const appVersion = ref(import.meta.env.DEV ? "Development build" : "Current build");
 const hosts = ref<MobileHost[]>(loadHosts());
 const selectedHostId = ref(localStorage.getItem(SELECTED_KEY) ?? hosts.value[0]?.id ?? "");
 const catalogHostId = ref(selectedHostId.value || hosts.value[0]?.id || "");
@@ -938,6 +949,28 @@ function reuseSelectedPrint(): void {
   if (print) void reusePrint(print);
 }
 
+function openSettings(): void {
+  settingsOpen.value = true;
+  void nextTick(() => settingsBackButton.value?.focus());
+}
+
+function closeSettings(): void {
+  settingsOpen.value = false;
+  void nextTick(() => settingsButton.value?.focus());
+}
+
+function manageHostsFromSettings(): void {
+  settingsOpen.value = false;
+  tab.value = "hosts";
+  void nextTick(() => {
+    document.querySelector<HTMLButtonElement>("[data-test='mobile-tab-hosts']")?.focus();
+  });
+}
+
+function updateSettings(patch: Partial<MobileSettings>): void {
+  Object.assign(mobileSettings, persistMobileSettings(mobileSettings, patch));
+}
+
 watch(selectedHostId, (id, previousId) => {
   if (id !== previousId) clearHostScopedGenerationSelections();
   if (id) localStorage.setItem(SELECTED_KEY, id);
@@ -956,6 +989,14 @@ watch(resultPreviewError, (error) => {
 });
 
 onMounted(async () => {
+  if ("__TAURI_INTERNALS__" in window) {
+    void import("@tauri-apps/api/app")
+      .then(({ getVersion }) => getVersion())
+      .then((version) => {
+        appVersion.value = version;
+      })
+      .catch(() => {});
+  }
   await hydrateApiKeys();
   // Start the cadence before awaiting individual tailnet hosts. One slow host
   // must not prevent every other saved host from being probed on schedule.
@@ -982,10 +1023,38 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <main class="mobile-shell">
-    <header class="mobile-header">
+  <main class="mobile-shell" :class="{ 'is-settings-open': settingsOpen }">
+    <header v-if="settingsOpen" class="mobile-header mobile-settings-nav">
+      <button
+        ref="settingsBackButton"
+        class="mobile-settings-back"
+        type="button"
+        data-test="mobile-settings-back"
+        @click="closeSettings"
+      >
+        <span aria-hidden="true">‹</span>
+        Back
+      </button>
+      <strong>Settings</strong>
+      <span class="mobile-settings-nav-spacer" aria-hidden="true" />
+    </header>
+    <header v-else class="mobile-header">
       <div class="mobile-wordmark">Mold</div>
-      <div class="host-chip">{{ selectedHost?.name ?? "Remote only" }}</div>
+      <div class="mobile-header-actions">
+        <div class="host-chip">{{ selectedHost?.name ?? "Remote only" }}</div>
+        <button
+          ref="settingsButton"
+          class="mobile-settings-button"
+          type="button"
+          aria-label="Open settings"
+          data-test="mobile-open-settings"
+          @click="openSettings"
+        >
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M4 7h10M18 7h2M4 17h2M10 17h10M14 4v6M7 14v6" />
+          </svg>
+        </button>
+      </div>
     </header>
 
     <p class="sr-only" aria-live="polite" aria-atomic="true">
@@ -996,7 +1065,15 @@ onBeforeUnmount(() => {
     </p>
 
     <section class="mobile-content">
-      <template v-if="tab === 'generate'">
+      <MobileSettingsView
+        v-if="settingsOpen"
+        :settings="mobileSettings"
+        :host-count="hosts.length"
+        :app-version="appVersion"
+        @update="updateSettings"
+        @manage-hosts="manageHostsFromSettings"
+      />
+      <template v-else-if="tab === 'generate'">
         <div v-if="!selectedHost" class="empty-state">
           <div>
             <h1 class="section-title">Connect a host</h1>
@@ -1415,7 +1492,7 @@ onBeforeUnmount(() => {
 
       <KeepAlive>
         <MobileCatalogView
-          v-if="tab === 'catalog'"
+          v-if="!settingsOpen && tab === 'catalog'"
           :hosts="hosts"
           :selected-host-id="catalogHostId"
           @select-host="selectCatalogHost"
@@ -1447,7 +1524,7 @@ onBeforeUnmount(() => {
       @next="navigateSelectedPrint(1)"
     />
 
-    <nav class="mobile-tabs" aria-label="Primary">
+    <nav v-if="!settingsOpen" class="mobile-tabs" aria-label="Primary">
       <button
         class="mobile-tab"
         type="button"

--- a/desktop/src/mobile/MobileCatalogView.test.ts
+++ b/desktop/src/mobile/MobileCatalogView.test.ts
@@ -577,6 +577,52 @@ describe("MobileCatalogView", () => {
     expect((pullButton.element as HTMLButtonElement).disabled).toBe(false);
   });
 
+  it("clears a pending pull when the host returns no job id despite an HF model mismatch", async () => {
+    startCatalogDownload.mockResolvedValue(null);
+    searchCatalog.mockResolvedValue(
+      searchResponse([
+        entry("Friendly repo name", {
+          id: "hf:owner/repo",
+          source_id: "owner/repo",
+        }),
+      ]),
+    );
+    wrapper = mountCatalog(studio.id, [studio]);
+    await flushPromises();
+
+    const pullButton = wrapper
+      .findAll("[data-test='mobile-catalog-card']")
+      .find((candidate) => candidate.text().includes("Friendly repo name"))!
+      .get(".mobile-catalog-pull");
+    await pullButton.trigger("click");
+    await flushPromises();
+
+    expect(startCatalogDownload).toHaveBeenCalledWith("hf:owner/repo", targets.studio, false);
+    expect(pullButton.text()).not.toBe("Starting…");
+    expect((pullButton.element as HTMLButtonElement).disabled).toBe(false);
+    expect(wrapper.get("[data-test='mobile-catalog-action-status']").text()).toContain(
+      "Studio did not return a download job",
+    );
+
+    streams[0]!.onEvent(
+      "download",
+      JSON.stringify({
+        type: "enqueued",
+        id: "canonical-job",
+        model: "canonical-manifest-name",
+        position: 0,
+      } satisfies DownloadEvent),
+    );
+    await flushPromises();
+
+    expect(pullButton.text()).not.toBe("Starting…");
+    expect((pullButton.element as HTMLButtonElement).disabled).toBe(false);
+
+    await pullButton.trigger("click");
+    await flushPromises();
+    expect(startCatalogDownload).toHaveBeenCalledTimes(2);
+  });
+
   it("does not POST when an asynchronous opening snapshot adopts an existing pull", async () => {
     sseStream.mockImplementation(
       (

--- a/desktop/src/mobile/MobileCatalogView.test.ts
+++ b/desktop/src/mobile/MobileCatalogView.test.ts
@@ -137,6 +137,13 @@ function jsonResponse<T>(value: T): Response {
   return { json: () => Promise.resolve(value) } as Response;
 }
 
+function emptyDownloadSnapshot(): DownloadEvent {
+  return {
+    type: "snapshot",
+    listing: { active_jobs: [], queued: [], history: [] },
+  };
+}
+
 function deferred<T>() {
   let resolve!: (value: T) => void;
   let reject!: (reason?: unknown) => void;
@@ -204,6 +211,7 @@ beforeEach(() => {
     ) => {
       streams.push(options);
       options.onOpen?.();
+      options.onEvent("download", JSON.stringify(emptyDownloadSnapshot()));
       return Promise.resolve();
     },
   );
@@ -404,7 +412,7 @@ describe("MobileCatalogView", () => {
     expect(catalog.hasAttribute("inert")).toBe(true);
   });
 
-  it("waits for the download stream to open before posting a pull", async () => {
+  it("waits for the opening download snapshot before posting a pull", async () => {
     sseStream.mockImplementation(
       (
         _path: string,
@@ -437,10 +445,274 @@ describe("MobileCatalogView", () => {
 
     streams[0]!.onOpen?.();
     await flushPromises();
+    expect(startCatalogDownload).not.toHaveBeenCalled();
+    expect(wrapper.get("[data-test='mobile-catalog-action-status']").text()).toContain(
+      "Connecting to downloads on Studio",
+    );
+
+    streams[0]!.onEvent("download", JSON.stringify(emptyDownloadSnapshot()));
+    await flushPromises();
     expect(startCatalogDownload).toHaveBeenCalledWith("hf:Catalog model", targets.studio, false);
     expect(wrapper.get("[data-test='mobile-catalog-action-status']").text()).toContain(
       "Pulling Catalog model on Studio",
     );
+  });
+
+  it("keeps a pull button busy until SSE adopts the job and then shows live progress", async () => {
+    const start = deferred<string | null>();
+    startCatalogDownload.mockReturnValue(start.promise);
+    searchCatalog.mockResolvedValue(
+      searchResponse([
+        entry("repo", {
+          id: "hf:owner/repo",
+          source_id: "owner/repo",
+        }),
+      ]),
+    );
+    sseStream.mockImplementation(
+      (
+        _path: string,
+        options: {
+          target: ApiTarget;
+          signal: AbortSignal;
+          onOpen?: () => void;
+          onOpenError?: (error: Error) => void;
+          onClose?: (error: Error | null) => void;
+          onEvent: (event: string, data: string) => void;
+        },
+      ) => {
+        streams.push(options);
+        return Promise.resolve();
+      },
+    );
+    wrapper = mountCatalog(studio.id, [studio]);
+    await flushPromises();
+
+    const catalogCard = wrapper
+      .findAll("[data-test='mobile-catalog-card']")
+      .find((candidate) => candidate.text().includes("repo"))!;
+    const pullButton = catalogCard.get(".mobile-catalog-pull");
+    await pullButton.trigger("click");
+    expect(pullButton.text()).toBe("Connecting…");
+    expect((pullButton.element as HTMLButtonElement).disabled).toBe(true);
+
+    streams[0]!.onOpen?.();
+    await flushPromises();
+    expect(startCatalogDownload).not.toHaveBeenCalled();
+    expect(pullButton.text()).toBe("Connecting…");
+
+    streams[0]!.onEvent("download", JSON.stringify(emptyDownloadSnapshot()));
+    await flushPromises();
+    expect(startCatalogDownload).toHaveBeenCalledTimes(1);
+    expect(pullButton.text()).toBe("Starting…");
+
+    // Even a programmatic second action is ignored while the POST is in flight.
+    (pullButton.element as HTMLButtonElement).click();
+    expect(startCatalogDownload).toHaveBeenCalledTimes(1);
+
+    start.resolve("download-1");
+    await flushPromises();
+    expect(pullButton.text()).toBe("Starting…");
+
+    streams[0]!.onEvent(
+      "download",
+      JSON.stringify({
+        type: "enqueued",
+        id: "download-1",
+        model: "owner/repo",
+        position: 0,
+      } satisfies DownloadEvent),
+    );
+    await flushPromises();
+    expect(pullButton.text()).toBe("Queued");
+    expect(wrapper.findAll("[data-test='mobile-catalog-download']")).toHaveLength(1);
+
+    // Duplicate stream deltas must not add another download row or action.
+    streams[0]!.onEvent(
+      "download",
+      JSON.stringify({
+        type: "enqueued",
+        id: "download-1",
+        model: "owner/repo",
+        position: 0,
+      } satisfies DownloadEvent),
+    );
+    await flushPromises();
+    expect(wrapper.findAll("[data-test='mobile-catalog-download']")).toHaveLength(1);
+
+    streams[0]!.onEvent(
+      "download",
+      JSON.stringify({ type: "started", id: "download-1", files_total: 2, bytes_total: 3 }),
+    );
+    streams[0]!.onEvent(
+      "download",
+      JSON.stringify({
+        type: "progress",
+        id: "download-1",
+        files_done: 0,
+        bytes_done: 1,
+      } satisfies DownloadEvent),
+    );
+    await flushPromises();
+    expect(pullButton.text()).toBe("Pulling 33%");
+
+    streams[0]!.onEvent(
+      "download",
+      JSON.stringify({
+        type: "progress",
+        id: "download-1",
+        files_done: 2,
+        bytes_done: 4,
+      } satisfies DownloadEvent),
+    );
+    await flushPromises();
+    expect(pullButton.text()).toBe("Pulling 100%");
+
+    streams[0]!.onEvent(
+      "download",
+      JSON.stringify({ type: "job_failed", id: "download-1", error: "disk full" }),
+    );
+    await flushPromises();
+    expect(pullButton.text()).toContain("Pull");
+    expect((pullButton.element as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("does not POST when an asynchronous opening snapshot adopts an existing pull", async () => {
+    sseStream.mockImplementation(
+      (
+        _path: string,
+        options: {
+          target: ApiTarget;
+          signal: AbortSignal;
+          onOpen?: () => void;
+          onOpenError?: (error: Error) => void;
+          onClose?: (error: Error | null) => void;
+          onEvent: (event: string, data: string) => void;
+        },
+      ) => {
+        streams.push(options);
+        return Promise.resolve();
+      },
+    );
+    wrapper = mountCatalog(studio.id, [studio]);
+    await flushPromises();
+
+    const pullButton = wrapper
+      .findAll("[data-test='mobile-catalog-card']")
+      .find((candidate) => candidate.text().includes("Catalog model"))!
+      .get(".mobile-catalog-pull");
+    await pullButton.trigger("click");
+    streams[0]!.onOpen?.();
+    // Drain the transport-open continuation before delivering the opening
+    // snapshot. Resolving readiness from `onOpen` would POST at this point.
+    await flushPromises();
+    expect(startCatalogDownload).not.toHaveBeenCalled();
+    expect(pullButton.text()).toBe("Connecting…");
+
+    streams[0]!.onEvent(
+      "download",
+      JSON.stringify({
+        type: "snapshot",
+        listing: {
+          active_jobs: [
+            {
+              id: "existing-pull",
+              model: "Catalog model",
+              catalog_id: "hf:Catalog model",
+              status: "active",
+              files_done: 0,
+              files_total: 1,
+              bytes_done: 20,
+              bytes_total: 100,
+            },
+          ],
+          queued: [],
+          history: [],
+        },
+      } satisfies DownloadEvent),
+    );
+    await flushPromises();
+
+    expect(startCatalogDownload).not.toHaveBeenCalled();
+    expect(pullButton.text()).toBe("Pulling 20%");
+    expect(wrapper.findAll("[data-test='mobile-catalog-download']")).toHaveLength(1);
+  });
+
+  it("shows per-host pull state in the card, detail, and host picker", async () => {
+    const start = deferred<string | null>();
+    startCatalogDownload.mockReturnValue(start.promise);
+    wrapper = mountCatalog();
+    await flushPromises();
+
+    const catalogCard = wrapper
+      .findAll("[data-test='mobile-catalog-card']")
+      .find((candidate) => candidate.text().includes("Catalog model"))!;
+    await catalogCard.get(".mobile-catalog-pull").trigger("click");
+    await flushPromises();
+    let targetButtons = document.querySelectorAll<HTMLButtonElement>(
+      ".mobile-catalog-target-list button",
+    );
+    targetButtons[1]!.click();
+    await flushPromises();
+
+    expect(catalogCard.get(".mobile-catalog-pull").text()).toBe("Starting…");
+    expect(startCatalogDownload).toHaveBeenCalledTimes(1);
+
+    // Reopening the picker makes the chosen host's duplicate-safe state explicit.
+    await catalogCard.get(".mobile-catalog-pull").trigger("click");
+    await flushPromises();
+    targetButtons = document.querySelectorAll<HTMLButtonElement>(
+      ".mobile-catalog-target-list button",
+    );
+    expect(targetButtons[0]!.disabled).toBe(false);
+    expect(targetButtons[1]!.disabled).toBe(true);
+    expect(targetButtons[1]!.textContent).toContain("Starting…");
+    targetButtons[1]!.click();
+    expect(startCatalogDownload).toHaveBeenCalledTimes(1);
+
+    start.resolve("download-render");
+    await flushPromises();
+    streams[1]!.onEvent(
+      "download",
+      JSON.stringify({
+        type: "enqueued",
+        id: "download-render",
+        model: "Catalog model",
+        position: 0,
+      } satisfies DownloadEvent),
+    );
+    await flushPromises();
+    expect(targetButtons[1]!.textContent).toContain("Queued");
+
+    document.querySelector<HTMLButtonElement>("[aria-label='Close host picker']")!.click();
+    await catalogCard.get(".mobile-catalog-card-open").trigger("click");
+    await flushPromises();
+    const detailAction = document.querySelector<HTMLButtonElement>(
+      ".mobile-catalog-detail-action button",
+    )!;
+    expect(detailAction.textContent).toContain("Queued");
+
+    streams[1]!.onEvent(
+      "download",
+      JSON.stringify({
+        type: "started",
+        id: "download-render",
+        files_total: 2,
+        bytes_total: 100,
+      } satisfies DownloadEvent),
+    );
+    streams[1]!.onEvent(
+      "download",
+      JSON.stringify({
+        type: "progress",
+        id: "download-render",
+        files_done: 1,
+        bytes_done: 60,
+      } satisfies DownloadEvent),
+    );
+    await flushPromises();
+    expect(detailAction.textContent).toContain("Pulling 60%");
+    expect(catalogCard.get(".mobile-catalog-pull").text()).toBe("Pulling 60%");
   });
 
   it("shows a visible error and does not POST when the download stream cannot open", async () => {

--- a/desktop/src/mobile/MobileCatalogView.vue
+++ b/desktop/src/mobile/MobileCatalogView.vue
@@ -745,7 +745,12 @@ async function pullTo(entry: MobileCatalogEntry, host: MobileHost): Promise<void
     if (pendingPulls.get(key) !== pending) return;
     pending.phase = "starting";
     const jobId = await startCatalogDownload(entry.id, mobileHostTarget(host), false);
+    // A null id is a valid server response when no primary download was
+    // enqueued. Without an id, a later HF delta may use a canonical model
+    // name that cannot be matched back to this catalog card, leaving the
+    // button stuck in "Starting…" indefinitely.
     if (pendingPulls.get(key) === pending) {
+      if (jobId === null) throw new Error(`${host.name} did not return a download job.`);
       pending.jobId = jobId;
       reconcilePendingPulls(host.id);
     }

--- a/desktop/src/mobile/MobileCatalogView.vue
+++ b/desktop/src/mobile/MobileCatalogView.vue
@@ -60,6 +60,21 @@ interface DownloadRow {
   job: DownloadJob;
 }
 
+type PendingPullPhase = "connecting" | "starting";
+
+interface PendingPull {
+  entryId: string;
+  entryName: string;
+  hostId: string;
+  jobId: string | null;
+  phase: PendingPullPhase;
+}
+
+interface PullStatus {
+  label: string;
+  phase: PendingPullPhase | "queued" | "active";
+}
+
 interface StreamSubscription {
   signature: string;
   controller: AbortController;
@@ -103,7 +118,7 @@ const error = ref("");
 const announcement = ref("");
 const announcementIsError = ref(false);
 const modelsByHost = ref<Record<string, ModelEntry[]>>({});
-const pulling = reactive(new Set<string>());
+const pendingPulls = reactive(new Map<string, PendingPull>());
 const cancelling = reactive(new Set<string>());
 const downloadsByHost = reactive<Record<string, DownloadsState>>({});
 const subscriptions = new Map<string, StreamSubscription>();
@@ -254,12 +269,21 @@ const combinedEntries = computed<MobileCatalogEntry[]>(() => {
   return sortInstalledFirst([...byId.values()]);
 });
 
-const downloadRows = computed<DownloadRow[]>(() =>
-  props.hosts.flatMap((host) => {
+const downloadRows = computed<DownloadRow[]>(() => {
+  const seen = new Set<string>();
+  return props.hosts.flatMap((host) => {
     const state = downloadsByHost[host.id];
-    return state ? [...state.activeJobs, ...state.queued].map((job) => ({ host, job })) : [];
-  }),
-);
+    if (!state) return [];
+    return [...state.activeJobs, ...state.queued]
+      .filter((job) => {
+        const key = `${host.id}:${job.id}`;
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      })
+      .map((job) => ({ host, job }));
+  });
+});
 
 const mergedDetail = computed<CatalogEntry | null>(() => {
   const summary = detailEntry.value;
@@ -322,6 +346,87 @@ function clearModalInert(): void {
 
 function pullKey(entry: CatalogEntry, hostId?: string): string {
   return `${hostId ?? "any"}:${entry.id}`;
+}
+
+function pullJobMatches(entry: CatalogEntry, job: DownloadJob, pending?: PendingPull): boolean {
+  if (pending?.jobId && pending.jobId === job.id) return true;
+  if (job.catalog_id === entry.id) return true;
+  return job.model === entry.id || job.model === entry.name;
+}
+
+function jobsForHost(hostId: string): DownloadJob[] {
+  const state = downloadsByHost[hostId];
+  return state ? [...state.activeJobs, ...state.queued] : [];
+}
+
+function pullStatusForHost(entry: CatalogEntry, hostId: string): PullStatus | null {
+  const pending = pendingPulls.get(pullKey(entry, hostId));
+  const job = jobsForHost(hostId).find((candidate) => pullJobMatches(entry, candidate, pending));
+  if (job?.status === "active") {
+    const progress =
+      job.bytes_total > 0 ? ` ${Math.round(percent(job.bytes_done, job.bytes_total))}%` : "";
+    return { label: `Pulling${progress}`, phase: "active" };
+  }
+  if (job?.status === "queued") return { label: "Queued", phase: "queued" };
+  if (pending)
+    return {
+      label: pending.phase === "connecting" ? "Connecting…" : "Starting…",
+      phase: pending.phase,
+    };
+  return null;
+}
+
+function pullStatus(entry: MobileCatalogEntry, hostId?: string): PullStatus | null {
+  if (hostId) return pullStatusForHost(entry, hostId);
+  const preferred = entry.installed ? owningHost(entry) : selectedHost.value;
+  const orderedHosts = preferred
+    ? [preferred, ...downloadHosts.value.filter((host) => host.id !== preferred.id)]
+    : downloadHosts.value;
+  for (const host of orderedHosts) {
+    const status = pullStatusForHost(entry, host.id);
+    if (status) return status;
+  }
+  return null;
+}
+
+function pullButtonLabel(entry: MobileCatalogEntry): string {
+  return pullStatus(entry)?.label ?? catalogPullLabel(catalogSizeInfo(entry));
+}
+
+function reconcilePendingPulls(hostId: string, event?: DownloadEvent): void {
+  const state = downloadsByHost[hostId];
+  if (!state) return;
+  const inFlight = [...state.activeJobs, ...state.queued];
+  const terminalId =
+    event?.type === "job_done" || event?.type === "job_failed" || event?.type === "job_cancelled"
+      ? event.id
+      : null;
+  const terminalModel = event?.type === "job_done" ? event.model : null;
+  const terminalIds = terminalJobsByHost.get(hostId);
+  for (const [key, pending] of pendingPulls) {
+    if (pending.hostId !== hostId) continue;
+    const entry = { id: pending.entryId, name: pending.entryName } as CatalogEntry;
+    const inFlightMatch = inFlight.some((job) => pullJobMatches(entry, job, pending));
+    if (
+      // An opening snapshot can adopt a pre-existing pull before we POST.
+      // Once our POST returns a job id, keep the pending record as the
+      // entry-to-job association: delta events do not carry `catalog_id`, and
+      // an HF job's canonical model can differ from both entry id and label.
+      (inFlightMatch && pending.jobId == null) ||
+      (pending.jobId != null && state.history.some((job) => job.id === pending.jobId)) ||
+      (pending.jobId != null && terminalIds?.has(pending.jobId)) ||
+      (terminalId != null && pending.jobId === terminalId) ||
+      (terminalModel != null &&
+        (terminalModel === pending.entryId || terminalModel === pending.entryName))
+    )
+      pendingPulls.delete(key);
+  }
+}
+
+function clearPendingPullsForHost(hostId: string): void {
+  for (const [key, pending] of pendingPulls) {
+    if (pending.hostId === hostId) pendingPulls.delete(key);
+  }
 }
 
 function owningHost(entry: MobileCatalogEntry): MobileHost | null {
@@ -479,7 +584,6 @@ function ensureDownloadStream(host: MobileHost): Promise<void> {
     target: mobileHostTarget(host),
     signal: controller.signal,
     retry: true,
-    onOpen: markReady,
     onOpenError: failReady,
     onClose: (cause) => {
       if (!readySettled) {
@@ -487,8 +591,10 @@ function ensureDownloadStream(host: MobileHost): Promise<void> {
         return;
       }
       if (subscriptions.get(host.id)?.controller === controller) subscriptions.delete(host.id);
-      if (mounted && cause && !controller.signal.aborted)
+      if (mounted && cause && !controller.signal.aborted) {
+        clearPendingPullsForHost(host.id);
         announce(`Download monitoring stopped on ${host.name}: ${cause.message}`, true);
+      }
     },
     onEvent: (_event, data) => {
       if (controller.signal.aborted) return;
@@ -511,6 +617,10 @@ function ensureDownloadStream(host: MobileHost): Promise<void> {
           known.add(event.id);
           terminalJobsByHost.set(host.id, known);
           announce(`Download failed on ${host.name}: ${event.error}`, true);
+        } else if (event.type === "job_cancelled") {
+          const known = terminalJobsByHost.get(host.id) ?? new Set<string>();
+          known.add(event.id);
+          terminalJobsByHost.set(host.id, known);
         } else if (event.type === "snapshot") {
           const hadSnapshot = terminalJobsByHost.has(host.id);
           const known = terminalJobsByHost.get(host.id) ?? new Set<string>();
@@ -543,6 +653,11 @@ function ensureDownloadStream(host: MobileHost): Promise<void> {
             else if (completed) announce(`${completed.model} is ready on ${host.name}.`);
           }
         }
+        reconcilePendingPulls(host.id, event);
+        // Opening the transport does not prove that existing server jobs have
+        // been reconciled. Resolve only after reducing the opening snapshot,
+        // otherwise a delayed first frame can race a duplicate POST.
+        if (event.type === "snapshot") markReady();
       } catch {
         // Ignore malformed frames; the next snapshot/delta repairs state.
       }
@@ -559,6 +674,7 @@ function syncDownloadStreams(): void {
     subscriptions.delete(hostId);
     delete downloadsByHost[hostId];
     terminalJobsByHost.delete(hostId);
+    clearPendingPullsForHost(hostId);
   }
   for (const host of downloadHosts.value) {
     void ensureDownloadStream(host).catch((cause) => {
@@ -608,17 +724,34 @@ function requestPull(entry: MobileCatalogEntry): void {
 
 async function pullTo(entry: MobileCatalogEntry, host: MobileHost): Promise<void> {
   const key = pullKey(entry, host.id);
-  if (pulling.has(key)) return;
-  pulling.add(key);
+  if (pullStatusForHost(entry, host.id)) return;
+  const pending = reactive<PendingPull>({
+    entryId: entry.id,
+    entryName: entry.name,
+    hostId: host.id,
+    jobId: null,
+    phase: "connecting",
+  });
+  pendingPulls.set(key, pending);
   closeTargetPicker();
   announce(`Connecting to downloads on ${host.name}…`);
   try {
     // Subscribe first so even an immediately-started download cannot race its
     // `enqueued` / `started` events past the iPhone UI.
     await ensureDownloadStream(host);
-    await startCatalogDownload(entry.id, mobileHostTarget(host), false);
+    // The stream's opening snapshot may reveal that this exact pull already
+    // exists. In that case its live job becomes authoritative and no POST is
+    // needed.
+    if (pendingPulls.get(key) !== pending) return;
+    pending.phase = "starting";
+    const jobId = await startCatalogDownload(entry.id, mobileHostTarget(host), false);
+    if (pendingPulls.get(key) === pending) {
+      pending.jobId = jobId;
+      reconcilePendingPulls(host.id);
+    }
     announce(`${catalogActionLabel(entry)}ing ${entry.name} on ${host.name}.`);
   } catch (cause) {
+    if (pendingPulls.get(key) === pending) pendingPulls.delete(key);
     const alreadyQueued = cause instanceof ApiError && cause.status === 409;
     announce(
       alreadyQueued
@@ -626,8 +759,6 @@ async function pullTo(entry: MobileCatalogEntry, host: MobileHost): Promise<void
         : `Could not ${catalogActionLabel(entry).toLowerCase()} ${entry.name} on ${host.name}: ${errorMessage(cause)}`,
       !alreadyQueued,
     );
-  } finally {
-    pulling.delete(key);
   }
 }
 
@@ -875,6 +1006,7 @@ onBeforeUnmount(() => {
   deactivateInteractions();
   for (const subscription of subscriptions.values()) subscription.close();
   subscriptions.clear();
+  pendingPulls.clear();
 });
 </script>
 
@@ -1077,14 +1209,12 @@ onBeforeUnmount(() => {
             v-else
             type="button"
             class="mobile-catalog-pull"
-            :disabled="pulling.has(pullKey(entry, downloadHosts[0]?.id))"
+            :disabled="downloadHosts.length <= 1 && Boolean(pullStatus(entry))"
+            :aria-busy="Boolean(pullStatus(entry))"
+            :data-pull-state="pullStatus(entry)?.phase"
             @click="requestPull(entry)"
           >
-            {{
-              pulling.has(pullKey(entry, downloadHosts[0]?.id))
-                ? "Queuing…"
-                : catalogPullLabel(catalogSizeInfo(entry))
-            }}
+            {{ pullButtonLabel(entry) }}
           </button>
         </li>
       </ul>
@@ -1295,11 +1425,16 @@ onBeforeUnmount(() => {
           <button
             type="button"
             class="primary-button"
-            :disabled="!canDownloadEntry(mergedDetail)"
+            :disabled="
+              !canDownloadEntry(mergedDetail) ||
+              (downloadHosts.length <= 1 && Boolean(pullStatus(detailEntry)))
+            "
+            :aria-busy="Boolean(pullStatus(detailEntry))"
+            :data-pull-state="pullStatus(detailEntry)?.phase"
             @click="requestPull(detailEntry)"
           >
-            {{ catalogActionLabel(mergedDetail) }}
-            <template v-if="detailDownloadTotal.bytes != null">
+            {{ pullStatus(detailEntry)?.label ?? catalogActionLabel(mergedDetail) }}
+            <template v-if="!pullStatus(detailEntry) && detailDownloadTotal.bytes != null">
               · {{ detailTotalLabel() }}</template
             >
           </button>
@@ -1336,13 +1471,22 @@ onBeforeUnmount(() => {
               v-for="host in downloadHosts"
               :key="host.id"
               type="button"
+              :disabled="Boolean(pullStatus(targetEntry, host.id))"
+              :aria-busy="Boolean(pullStatus(targetEntry, host.id))"
+              :data-pull-state="pullStatus(targetEntry, host.id)?.phase"
               @click="pullTo(targetEntry, host)"
             >
               <span>
                 <strong>{{ host.name }}</strong>
                 <small>{{ host.baseUrl }}</small>
               </span>
-              <span>{{ host.id === selectedHostId ? "Current" : "" }} ›</span>
+              <span>
+                {{
+                  pullStatus(targetEntry, host.id)?.label ??
+                  (host.id === selectedHostId ? "Current" : "")
+                }}
+                <template v-if="!pullStatus(targetEntry, host.id)"> ›</template>
+              </span>
             </button>
           </div>
         </div>

--- a/desktop/src/mobile/MobileSettingsView.test.ts
+++ b/desktop/src/mobile/MobileSettingsView.test.ts
@@ -1,0 +1,42 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+import MobileSettingsView from "./MobileSettingsView.vue";
+
+describe("MobileSettingsView", () => {
+  it("offers accessible theme choices and emits immediate updates", async () => {
+    const wrapper = mount(MobileSettingsView, {
+      props: {
+        settings: { theme: "system", themeFamily: "mold" },
+        hostCount: 2,
+        appVersion: "0.18.0",
+      },
+    });
+
+    expect(wrapper.findAll("fieldset")).toHaveLength(2);
+    expect(wrapper.text()).toContain("Change the chrome without changing the color of your prints");
+    expect(wrapper.text()).toContain("2 hosts saved");
+    expect(wrapper.text()).toContain("0.18.0");
+
+    await wrapper.get('input[name="mobile-theme-family"][value="safelight"]').setValue(true);
+    await wrapper.get('input[name="mobile-theme-appearance"][value="light"]').setValue(true);
+
+    expect(wrapper.emitted("update")).toEqual([
+      [{ themeFamily: "safelight" }],
+      [{ theme: "light" }],
+    ]);
+  });
+
+  it("routes host management through an explicit action", async () => {
+    const wrapper = mount(MobileSettingsView, {
+      props: {
+        settings: { theme: "dark", themeFamily: "mold" },
+        hostCount: 0,
+        appVersion: "Development build",
+      },
+    });
+
+    expect(wrapper.text()).toContain("No hosts saved");
+    await wrapper.get(".mobile-settings-manage").trigger("click");
+    expect(wrapper.emitted("manage-hosts")).toHaveLength(1);
+  });
+});

--- a/desktop/src/mobile/MobileSettingsView.vue
+++ b/desktop/src/mobile/MobileSettingsView.vue
@@ -1,0 +1,135 @@
+<script setup lang="ts">
+import type { Theme, ThemeFamily } from "../lib/theme";
+import type { MobileSettings } from "./settings";
+
+defineProps<{
+  settings: MobileSettings;
+  hostCount: number;
+  appVersion: string;
+}>();
+
+const emit = defineEmits<{
+  update: [patch: Partial<MobileSettings>];
+  "manage-hosts": [];
+}>();
+
+const families: Array<{
+  value: ThemeFamily;
+  label: string;
+  description: string;
+}> = [
+  { value: "mold", label: "Mold", description: "Cyan and magenta studio color." },
+  { value: "safelight", label: "Safelight", description: "Warm, classic darkroom color." },
+];
+
+const appearances: Array<{ value: Theme; label: string; description: string }> = [
+  { value: "system", label: "System", description: "Match iPhone" },
+  { value: "dark", label: "Dark", description: "Lights off" },
+  { value: "light", label: "Light", description: "Lights on" },
+];
+</script>
+
+<template>
+  <div class="mobile-settings" data-test="mobile-settings">
+    <section class="mobile-settings-section" aria-labelledby="mobile-settings-theme-title">
+      <div class="mobile-settings-section-copy">
+        <h1 id="mobile-settings-theme-title">Theme</h1>
+        <p>Change the chrome without changing the color of your prints or videos.</p>
+      </div>
+
+      <fieldset class="mobile-settings-fieldset">
+        <legend>Color family</legend>
+        <div class="mobile-theme-options">
+          <label
+            v-for="family in families"
+            :key="family.value"
+            class="mobile-theme-option"
+            :data-selected="settings.themeFamily === family.value"
+          >
+            <input
+              class="sr-only"
+              type="radio"
+              name="mobile-theme-family"
+              :value="family.value"
+              :checked="settings.themeFamily === family.value"
+              @change="emit('update', { themeFamily: family.value })"
+            />
+            <span class="mobile-theme-preview" :data-theme-family="family.value" aria-hidden="true">
+              <span />
+              <span />
+              <span />
+            </span>
+            <span class="mobile-theme-option-copy">
+              <strong>{{ family.label }}</strong>
+              <small>{{ family.description }}</small>
+            </span>
+            <span class="mobile-settings-check" aria-hidden="true">✓</span>
+          </label>
+        </div>
+      </fieldset>
+
+      <fieldset class="mobile-settings-fieldset">
+        <legend>Appearance</legend>
+        <div class="mobile-appearance-options">
+          <label
+            v-for="appearance in appearances"
+            :key="appearance.value"
+            class="mobile-appearance-option"
+            :data-selected="settings.theme === appearance.value"
+          >
+            <input
+              class="sr-only"
+              type="radio"
+              name="mobile-theme-appearance"
+              :value="appearance.value"
+              :checked="settings.theme === appearance.value"
+              @change="emit('update', { theme: appearance.value })"
+            />
+            <strong>{{ appearance.label }}</strong>
+            <small>{{ appearance.description }}</small>
+          </label>
+        </div>
+      </fieldset>
+    </section>
+
+    <section class="mobile-settings-section" aria-labelledby="mobile-settings-hosts-title">
+      <div class="mobile-settings-section-copy">
+        <h2 id="mobile-settings-hosts-title">Remote hosts</h2>
+        <p>
+          {{
+            hostCount === 0
+              ? "No hosts saved."
+              : `${hostCount} host${hostCount === 1 ? "" : "s"} saved. API keys stay in your iPhone Keychain.`
+          }}
+        </p>
+      </div>
+      <button
+        class="secondary-button mobile-settings-manage"
+        type="button"
+        @click="emit('manage-hosts')"
+      >
+        Manage hosts
+      </button>
+    </section>
+
+    <section class="mobile-settings-section" aria-labelledby="mobile-settings-about-title">
+      <div class="mobile-settings-section-copy">
+        <h2 id="mobile-settings-about-title">About</h2>
+      </div>
+      <dl class="mobile-settings-about">
+        <div>
+          <dt>Version</dt>
+          <dd>{{ appVersion }}</dd>
+        </div>
+        <div>
+          <dt>Processing</dt>
+          <dd>Remote hosts only</dd>
+        </div>
+        <div>
+          <dt>Updates</dt>
+          <dd>TestFlight</dd>
+        </div>
+      </dl>
+    </section>
+  </div>
+</template>

--- a/desktop/src/mobile/main.ts
+++ b/desktop/src/mobile/main.ts
@@ -3,6 +3,10 @@ import { createPinia } from "pinia";
 import App from "./MobileApp.vue";
 import "../styles/base.css";
 import "./mobile.css";
+import { installSystemThemeColorSync } from "../lib/theme";
+import { applyMobileSettings, loadMobileSettings } from "./settings";
 
 document.documentElement.classList.add("mobile-surface");
+applyMobileSettings(loadMobileSettings());
+installSystemThemeColorSync();
 createApp(App).use(createPinia()).mount("#app");

--- a/desktop/src/mobile/mobile.css
+++ b/desktop/src/mobile/mobile.css
@@ -5,6 +5,7 @@ body,
   width: 100%;
   overflow: hidden;
   overscroll-behavior: none;
+  touch-action: manipulation;
 }
 
 body {
@@ -55,6 +56,82 @@ button {
   background: var(--bench);
 }
 
+.mobile-header-actions {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.mobile-header-actions .host-chip {
+  max-width: min(58vw, 220px);
+}
+
+.mobile-settings-button,
+.mobile-settings-back {
+  min-width: 44px;
+  min-height: 44px;
+  border: 0;
+  border-radius: var(--radius-control);
+  background: transparent;
+  color: var(--ink-2);
+}
+
+.mobile-settings-button {
+  display: grid;
+  flex: 0 0 44px;
+  place-items: center;
+}
+
+.mobile-settings-button:active,
+.mobile-settings-back:active {
+  background: color-mix(in srgb, var(--safelight) 12%, transparent);
+  color: var(--safelight);
+}
+
+.mobile-settings-button svg {
+  width: 21px;
+  height: 21px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-width: 1.8;
+}
+
+.mobile-settings-nav {
+  display: grid;
+  grid-template-columns: minmax(72px, 1fr) auto minmax(72px, 1fr);
+}
+
+.mobile-settings-nav > strong {
+  font-size: var(--text-body-lg);
+  font-weight: 700;
+}
+
+.mobile-settings-back {
+  display: inline-flex;
+  width: fit-content;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 3px;
+  padding: 0 8px 0 2px;
+  color: var(--safelight);
+  font-size: var(--text-body);
+}
+
+.mobile-settings-back > span {
+  margin-top: -2px;
+  font-size: 28px;
+  line-height: 1;
+}
+
+.mobile-settings-nav-spacer {
+  width: 44px;
+  justify-self: end;
+}
+
 .mobile-wordmark {
   font-family: var(--font-display);
   font-size: var(--text-display);
@@ -78,7 +155,12 @@ button {
   overflow-x: hidden;
   overflow-y: auto;
   overscroll-behavior: none;
+  touch-action: manipulation;
   padding: 16px max(16px, env(safe-area-inset-right)) 16px max(16px, env(safe-area-inset-left));
+}
+
+.mobile-shell.is-settings-open .mobile-content {
+  padding-bottom: max(24px, env(safe-area-inset-bottom));
 }
 
 .mobile-tabs {
@@ -103,6 +185,250 @@ button {
 .mobile-tab[aria-current="page"] {
   background: color-mix(in srgb, var(--safelight) 12%, transparent);
   color: var(--safelight);
+}
+
+.mobile-settings {
+  width: min(620px, 100%);
+  margin: 0 auto;
+}
+
+.mobile-settings-section {
+  padding: 22px 0;
+  border-bottom: 1px solid var(--edge);
+}
+
+.mobile-settings-section:first-child {
+  padding-top: 2px;
+}
+
+.mobile-settings-section:last-child {
+  border-bottom: 0;
+}
+
+.mobile-settings-section-copy {
+  margin-bottom: 14px;
+}
+
+.mobile-settings-section-copy h1,
+.mobile-settings-section-copy h2 {
+  margin: 0;
+  color: var(--rebate);
+  font-family: var(--font-display);
+  font-size: var(--text-display-sm);
+  letter-spacing: -0.02em;
+}
+
+.mobile-settings-section-copy p {
+  max-width: 54ch;
+  margin: 5px 0 0;
+  color: var(--ink-3);
+  font-size: var(--text-body);
+  line-height: 1.45;
+}
+
+.mobile-settings-fieldset {
+  min-width: 0;
+  margin: 18px 0 0;
+  border: 0;
+  padding: 0;
+}
+
+.mobile-settings-fieldset legend {
+  margin-bottom: 7px;
+  color: var(--ink-3);
+  font-family: var(--font-utility);
+  font-size: var(--text-edge-code);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.mobile-theme-options {
+  overflow: hidden;
+  border: 1px solid var(--control-edge);
+  border-radius: var(--radius-control);
+  background: var(--bench);
+}
+
+.mobile-theme-option {
+  display: grid;
+  min-height: 72px;
+  box-sizing: border-box;
+  grid-template-columns: 52px minmax(0, 1fr) 24px;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+}
+
+.mobile-theme-option + .mobile-theme-option {
+  border-top: 1px solid var(--edge);
+}
+
+.mobile-theme-option[data-selected="true"] {
+  background: color-mix(in srgb, var(--safelight) 10%, transparent);
+}
+
+.mobile-theme-option:has(input:focus-visible),
+.mobile-appearance-option:has(input:focus-visible) {
+  outline: 2px solid var(--safelight);
+  outline-offset: -2px;
+}
+
+.mobile-theme-preview {
+  position: relative;
+  display: block;
+  width: 52px;
+  height: 38px;
+  overflow: hidden;
+  box-sizing: border-box;
+  border: 1px solid color-mix(in srgb, white 18%, transparent);
+  border-radius: var(--radius-media);
+  background: var(--preview-bath);
+}
+
+.mobile-theme-preview[data-theme-family="mold"] {
+  --preview-bath: #12101d;
+  --preview-bench: #201b30;
+  --preview-halide: #67e8f9;
+  --preview-safelight: #e879f9;
+}
+
+.mobile-theme-preview[data-theme-family="safelight"] {
+  --preview-bath: #141110;
+  --preview-bench: #211b16;
+  --preview-halide: #93a7b0;
+  --preview-safelight: #f08a24;
+}
+
+.mobile-theme-preview > span:first-child {
+  position: absolute;
+  inset: 0 0 auto;
+  height: 10px;
+  background: var(--preview-bench);
+}
+
+.mobile-theme-preview > span:nth-child(2),
+.mobile-theme-preview > span:nth-child(3) {
+  position: absolute;
+  bottom: 7px;
+  width: 15px;
+  height: 9px;
+  border-radius: 1px;
+}
+
+.mobile-theme-preview > span:nth-child(2) {
+  left: 8px;
+  background: var(--preview-halide);
+}
+
+.mobile-theme-preview > span:nth-child(3) {
+  right: 8px;
+  background: var(--preview-safelight);
+}
+
+.mobile-theme-option-copy,
+.mobile-theme-option-copy strong,
+.mobile-theme-option-copy small {
+  display: block;
+  min-width: 0;
+}
+
+.mobile-theme-option-copy strong {
+  color: var(--rebate);
+  font-size: var(--text-body-lg);
+}
+
+.mobile-theme-option-copy small {
+  margin-top: 2px;
+  color: var(--ink-3);
+  font-size: var(--text-caption);
+}
+
+.mobile-settings-check {
+  opacity: 0;
+  color: var(--safelight);
+  font-size: 18px;
+  font-weight: 800;
+  text-align: center;
+}
+
+.mobile-theme-option[data-selected="true"] .mobile-settings-check {
+  opacity: 1;
+}
+
+.mobile-appearance-options {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  overflow: hidden;
+  border: 1px solid var(--control-edge);
+  border-radius: var(--radius-control);
+  background: var(--bench);
+}
+
+.mobile-appearance-option {
+  display: grid;
+  min-height: 58px;
+  box-sizing: border-box;
+  align-content: center;
+  gap: 2px;
+  padding: 7px 4px;
+  color: var(--ink-3);
+  text-align: center;
+}
+
+.mobile-appearance-option + .mobile-appearance-option {
+  border-left: 1px solid var(--edge);
+}
+
+.mobile-appearance-option strong {
+  font-size: var(--text-body);
+}
+
+.mobile-appearance-option small {
+  font-size: var(--text-edge-code);
+}
+
+.mobile-appearance-option[data-selected="true"] {
+  background: color-mix(in srgb, var(--safelight) 14%, transparent);
+  color: var(--safelight);
+}
+
+.mobile-settings-manage {
+  width: 100%;
+}
+
+.mobile-settings-about {
+  overflow: hidden;
+  margin: 0;
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-control);
+  background: var(--bench);
+}
+
+.mobile-settings-about > div {
+  display: grid;
+  min-height: 44px;
+  box-sizing: border-box;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 16px;
+  padding: 8px 11px;
+}
+
+.mobile-settings-about > div + div {
+  border-top: 1px solid var(--edge);
+}
+
+.mobile-settings-about dt {
+  color: var(--ink-3);
+  font-size: var(--text-body);
+}
+
+.mobile-settings-about dd {
+  margin: 0;
+  color: var(--rebate);
+  font-family: var(--font-utility);
+  font-size: var(--text-edge-code);
+  text-align: right;
 }
 
 .section-title {
@@ -1089,6 +1415,7 @@ button.mobile-generate-disclosure {
 
 .mobile-surface .mask-editor-stage {
   flex: 1;
+  touch-action: manipulation;
 }
 
 .primary-button,
@@ -1868,6 +2195,19 @@ button:disabled {
   font-size: var(--text-edge-code);
 }
 
+.mobile-catalog-pull[data-pull-state],
+.mobile-catalog-detail-action button[data-pull-state] {
+  border-color: var(--halide);
+  background: var(--halide);
+  color: var(--on-accent);
+  opacity: 1;
+}
+
+.mobile-catalog-target-list > button[data-pull-state] {
+  color: var(--halide);
+  opacity: 1;
+}
+
 .mobile-catalog-more {
   width: 100%;
   margin-top: 14px;
@@ -1920,6 +2260,7 @@ button:disabled {
   overflow-x: hidden;
   overflow-y: auto;
   overscroll-behavior: none;
+  touch-action: manipulation;
 }
 
 .mobile-catalog-detail-preview {
@@ -2135,6 +2476,7 @@ button:disabled {
   overflow-x: hidden;
   overflow-y: auto;
   overscroll-behavior: none;
+  touch-action: manipulation;
   padding: 16px max(16px, env(safe-area-inset-right)) calc(16px + env(safe-area-inset-bottom))
     max(16px, env(safe-area-inset-left));
   border-top: 1px solid var(--edge);

--- a/desktop/src/mobile/mobile.css.test.ts
+++ b/desktop/src/mobile/mobile.css.test.ts
@@ -2,6 +2,19 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 const css = readFileSync("src/mobile/mobile.css", "utf8");
+const mobileHtml = readFileSync("index.mobile.html", "utf8");
+
+describe("mobile viewport scaling", () => {
+  it("disables iPhone page and double-tap zoom without document gesture handlers", () => {
+    expect(mobileHtml).toMatch(/maximum-scale=1/);
+    expect(mobileHtml).toMatch(/user-scalable=no/);
+
+    const root = css.match(/html,\s*body,\s*#app\s*\{([^}]*)\}/s);
+    const content = css.match(/\.mobile-content\s*\{([^}]*)\}/s);
+    expect(root?.[1]).toMatch(/touch-action:\s*manipulation\s*;/);
+    expect(content?.[1]).toMatch(/touch-action:\s*manipulation\s*;/);
+  });
+});
 
 describe("mobile editable controls", () => {
   it("keeps every editable control at the iOS no-focus-zoom size", () => {
@@ -32,6 +45,17 @@ describe("mobile navigation", () => {
   it("visually marks the tab exposed as the current page", () => {
     expect(css).toMatch(/\.mobile-tab\[aria-current="page"\]\s*\{/);
     expect(css).not.toMatch(/\.mobile-tab\[aria-selected="true"\]\s*\{/);
+  });
+
+  it("keeps four primary tabs and gives Settings a full-size header control", () => {
+    const tabs = css.match(/\.mobile-tabs\s*\{([^}]*)\}/s);
+    const settingsControls = css.match(
+      /\.mobile-settings-button,\s*\.mobile-settings-back\s*\{([^}]*)\}/s,
+    );
+
+    expect(tabs?.[1]).toMatch(/grid-template-columns:\s*repeat\(4,\s*1fr\)\s*;/);
+    expect(settingsControls?.[1]).toMatch(/min-width:\s*44px\s*;/);
+    expect(settingsControls?.[1]).toMatch(/min-height:\s*44px\s*;/);
   });
 });
 

--- a/desktop/src/mobile/settings.test.ts
+++ b/desktop/src/mobile/settings.test.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_MOBILE_SETTINGS,
   MOBILE_SETTINGS_STORAGE_KEY,
   loadMobileSettings,
+  syncMobileNativeAppearance,
   updateMobileSettings,
 } from "./settings";
 
@@ -71,6 +72,50 @@ describe("mobile settings persistence", () => {
 
     expect(nativeInvoke).toHaveBeenCalledWith("set_mobile_appearance", {
       appearance: "system",
+    });
+  });
+
+  it("serializes native updates and applies only the latest pending appearance", async () => {
+    let finishFirst: (() => void) | undefined;
+    const firstUpdate = new Promise<void>((resolve) => {
+      finishFirst = resolve;
+    });
+    const nativeInvoke = vi.fn().mockReturnValueOnce(firstUpdate).mockResolvedValue(undefined);
+
+    const darkUpdate = syncMobileNativeAppearance("dark", nativeInvoke);
+    const lightUpdate = syncMobileNativeAppearance("light", nativeInvoke);
+    const systemUpdate = syncMobileNativeAppearance("system", nativeInvoke);
+
+    expect(nativeInvoke).toHaveBeenCalledTimes(1);
+    expect(nativeInvoke).toHaveBeenNthCalledWith(1, "set_mobile_appearance", {
+      appearance: "dark",
+    });
+
+    finishFirst?.();
+    await Promise.all([darkUpdate, lightUpdate, systemUpdate]);
+
+    expect(nativeInvoke).toHaveBeenCalledTimes(2);
+    expect(nativeInvoke).toHaveBeenNthCalledWith(2, "set_mobile_appearance", {
+      appearance: "system",
+    });
+  });
+
+  it("starts a new native flush for a request made as the prior bridge resolves", async () => {
+    let finishFirst: (() => void) | undefined;
+    const firstUpdate = new Promise<void>((resolve) => {
+      finishFirst = resolve;
+    });
+    const nativeInvoke = vi.fn().mockReturnValueOnce(firstUpdate).mockResolvedValue(undefined);
+
+    const darkUpdate = syncMobileNativeAppearance("dark", nativeInvoke);
+    const lightUpdate = firstUpdate.then(() => syncMobileNativeAppearance("light", nativeInvoke));
+
+    finishFirst?.();
+    await Promise.all([darkUpdate, lightUpdate]);
+
+    expect(nativeInvoke).toHaveBeenCalledTimes(2);
+    expect(nativeInvoke).toHaveBeenLastCalledWith("set_mobile_appearance", {
+      appearance: "light",
     });
   });
 });

--- a/desktop/src/mobile/settings.test.ts
+++ b/desktop/src/mobile/settings.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_MOBILE_SETTINGS,
+  MOBILE_SETTINGS_STORAGE_KEY,
+  loadMobileSettings,
+  updateMobileSettings,
+} from "./settings";
+
+function memoryStorage(initial?: string) {
+  const values = new Map<string, string>();
+  if (initial !== undefined) values.set(MOBILE_SETTINGS_STORAGE_KEY, initial);
+  return {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => values.set(key, value),
+    value: () => values.get(MOBILE_SETTINGS_STORAGE_KEY) ?? null,
+  };
+}
+
+afterEach(() => {
+  delete document.documentElement.dataset.theme;
+  delete document.documentElement.dataset.themeFamily;
+});
+
+describe("mobile settings persistence", () => {
+  it("defaults new and corrupt installs to Mold with system appearance", () => {
+    expect(loadMobileSettings(memoryStorage())).toEqual(DEFAULT_MOBILE_SETTINGS);
+    expect(loadMobileSettings(memoryStorage("not json"))).toEqual(DEFAULT_MOBILE_SETTINGS);
+  });
+
+  it("keeps each valid field when another stored value is unknown", () => {
+    expect(
+      loadMobileSettings(
+        memoryStorage(JSON.stringify({ theme: "light", themeFamily: "unknown", future: true })),
+      ),
+    ).toEqual({ theme: "light", themeFamily: "mold" });
+    expect(
+      loadMobileSettings(
+        memoryStorage(JSON.stringify({ theme: "sepia", themeFamily: "safelight" })),
+      ),
+    ).toEqual({ theme: "system", themeFamily: "safelight" });
+  });
+
+  it("persists and applies a change immediately, including native iOS appearance", () => {
+    const storage = memoryStorage();
+    const nativeInvoke = vi.fn().mockResolvedValue(undefined);
+    const next = updateMobileSettings(
+      { theme: "system", themeFamily: "mold" },
+      { theme: "dark", themeFamily: "safelight" },
+      storage,
+      nativeInvoke,
+    );
+
+    expect(next).toEqual({ theme: "dark", themeFamily: "safelight" });
+    expect(JSON.parse(storage.value() ?? "{}")).toEqual(next);
+    expect(document.documentElement.dataset.theme).toBe("dark");
+    expect(document.documentElement.dataset.themeFamily).toBe("safelight");
+    expect(nativeInvoke).toHaveBeenCalledWith("set_mobile_appearance", {
+      appearance: "dark",
+    });
+  });
+
+  it("returns native iOS appearance control to the system", () => {
+    const nativeInvoke = vi.fn().mockResolvedValue(undefined);
+
+    updateMobileSettings(
+      { theme: "dark", themeFamily: "mold" },
+      { theme: "system" },
+      memoryStorage(),
+      nativeInvoke,
+    );
+
+    expect(nativeInvoke).toHaveBeenCalledWith("set_mobile_appearance", {
+      appearance: "system",
+    });
+  });
+});

--- a/desktop/src/mobile/settings.ts
+++ b/desktop/src/mobile/settings.ts
@@ -15,6 +15,32 @@ export const DEFAULT_MOBILE_SETTINGS: Readonly<MobileSettings> = {
 
 type SettingsStorage = Pick<Storage, "getItem" | "setItem">;
 type MobileAppearanceInvoker = (command: string, args: { appearance: Theme }) => Promise<unknown>;
+type NativeAppearanceRequest = {
+  appearance: Theme;
+  bridge: MobileAppearanceInvoker;
+};
+
+let pendingNativeAppearance: NativeAppearanceRequest | null = null;
+let nativeAppearanceFlush: Promise<void> | null = null;
+
+async function flushNativeAppearanceQueue(): Promise<void> {
+  try {
+    while (pendingNativeAppearance) {
+      const next = pendingNativeAppearance;
+      pendingNativeAppearance = null;
+      try {
+        await next.bridge("set_mobile_appearance", { appearance: next.appearance });
+      } catch (error) {
+        console.warn("Unable to synchronize the native mobile appearance", error);
+      }
+    }
+  } finally {
+    // Clear ownership before the flush promise resolves. A new request made
+    // from another promise reaction can then start its own drain instead of
+    // attaching to an already-finished flush and becoming stranded.
+    nativeAppearanceFlush = null;
+  }
+}
 
 function defaultStorage(): SettingsStorage | null {
   return typeof localStorage === "undefined" ? null : localStorage;
@@ -65,11 +91,12 @@ export async function syncMobileNativeAppearance(
       : null);
   if (!bridge) return;
 
-  try {
-    await bridge("set_mobile_appearance", { appearance });
-  } catch (error) {
-    console.warn("Unable to synchronize the native mobile appearance", error);
+  pendingNativeAppearance = { appearance, bridge };
+  if (!nativeAppearanceFlush) {
+    nativeAppearanceFlush = flushNativeAppearanceQueue();
   }
+
+  await nativeAppearanceFlush;
 }
 
 export function applyMobileSettings(

--- a/desktop/src/mobile/settings.ts
+++ b/desktop/src/mobile/settings.ts
@@ -1,0 +1,96 @@
+import { invoke } from "@tauri-apps/api/core";
+import { applyTheme, isTheme, isThemeFamily, type Theme, type ThemeFamily } from "../lib/theme";
+
+export const MOBILE_SETTINGS_STORAGE_KEY = "mold.mobile.settings.v1";
+
+export interface MobileSettings {
+  theme: Theme;
+  themeFamily: ThemeFamily;
+}
+
+export const DEFAULT_MOBILE_SETTINGS: Readonly<MobileSettings> = {
+  theme: "system",
+  themeFamily: "mold",
+};
+
+type SettingsStorage = Pick<Storage, "getItem" | "setItem">;
+type MobileAppearanceInvoker = (command: string, args: { appearance: Theme }) => Promise<unknown>;
+
+function defaultStorage(): SettingsStorage | null {
+  return typeof localStorage === "undefined" ? null : localStorage;
+}
+
+/** Load only known values, preserving a valid preference when its sibling is corrupt. */
+export function loadMobileSettings(
+  storage: SettingsStorage | null = defaultStorage(),
+): MobileSettings {
+  if (!storage) return { ...DEFAULT_MOBILE_SETTINGS };
+  try {
+    const parsed = JSON.parse(storage.getItem(MOBILE_SETTINGS_STORAGE_KEY) ?? "{}") as Record<
+      string,
+      unknown
+    >;
+    return {
+      theme: isTheme(parsed.theme) ? parsed.theme : DEFAULT_MOBILE_SETTINGS.theme,
+      themeFamily: isThemeFamily(parsed.themeFamily)
+        ? parsed.themeFamily
+        : DEFAULT_MOBILE_SETTINGS.themeFamily,
+    };
+  } catch {
+    return { ...DEFAULT_MOBILE_SETTINGS };
+  }
+}
+
+export function saveMobileSettings(
+  settings: MobileSettings,
+  storage: SettingsStorage | null = defaultStorage(),
+): void {
+  if (!storage) return;
+  try {
+    storage.setItem(MOBILE_SETTINGS_STORAGE_KEY, JSON.stringify(settings));
+  } catch {
+    // Appearance should still apply when WebKit storage is unavailable.
+  }
+}
+
+/** Synchronize UIKit's trait so iOS chooses readable status-bar glyphs. */
+export async function syncMobileNativeAppearance(
+  appearance: Theme,
+  nativeInvoke?: MobileAppearanceInvoker,
+): Promise<void> {
+  const bridge =
+    nativeInvoke ??
+    ("__TAURI_INTERNALS__" in globalThis
+      ? (command: string, args: { appearance: Theme }) => invoke(command, args)
+      : null);
+  if (!bridge) return;
+
+  try {
+    await bridge("set_mobile_appearance", { appearance });
+  } catch (error) {
+    console.warn("Unable to synchronize the native mobile appearance", error);
+  }
+}
+
+export function applyMobileSettings(
+  settings: MobileSettings,
+  nativeInvoke?: MobileAppearanceInvoker,
+): void {
+  applyTheme(settings.theme, settings.themeFamily);
+  void syncMobileNativeAppearance(settings.theme, nativeInvoke);
+}
+
+export function updateMobileSettings(
+  current: MobileSettings,
+  patch: Partial<MobileSettings>,
+  storage: SettingsStorage | null = defaultStorage(),
+  nativeInvoke?: MobileAppearanceInvoker,
+): MobileSettings {
+  const next: MobileSettings = {
+    theme: isTheme(patch.theme) ? patch.theme : current.theme,
+    themeFamily: isThemeFamily(patch.themeFamily) ? patch.themeFamily : current.themeFamily,
+  };
+  saveMobileSettings(next, storage);
+  applyMobileSettings(next, nativeInvoke);
+  return next;
+}

--- a/desktop/src/stores/appPrefs.ts
+++ b/desktop/src/stores/appPrefs.ts
@@ -1,37 +1,10 @@
 import { defineStore } from "pinia";
-import {
-  ipc,
-  type AppSettings,
-  type Theme,
-  type ThemeFamily,
-  type UpdateChannel,
-} from "../lib/ipc";
+import { ipc, type AppSettings, type UpdateChannel } from "../lib/ipc";
 import { applyUiScale, nextUiScale, type UiScaleDirection } from "../lib/uiScale";
 import { normalizePanelWidth } from "../lib/panelResize";
+import { applyTheme, type Theme, type ThemeFamily } from "../lib/theme";
 
-/**
- * Resolve what `data-theme` should be on the root element. Pure — exported
- * for tests. `null` means "remove the attribute and let the system media
- * query drive the palette".
- */
-export function resolveThemeAttributes(
-  theme: Theme,
-  family: ThemeFamily,
-): { appearance: "light" | "dark" | null; family: ThemeFamily } {
-  return {
-    appearance: theme === "system" ? null : theme,
-    family,
-  };
-}
-
-function applyTheme(theme: Theme, family: ThemeFamily) {
-  const attrs = resolveThemeAttributes(theme, family);
-  const root = document.documentElement;
-  if (attrs.appearance === null) delete root.dataset.theme;
-  else root.dataset.theme = attrs.appearance;
-  root.dataset.themeFamily = attrs.family;
-}
-
+export { resolveThemeAttributes } from "../lib/theme";
 /**
  * App-side preferences (settings.json via IPC): theme, notifications, dock
  * badge, engine env knobs. Loaded once at boot; every update persists and


### PR DESCRIPTION
## Summary

- add a first-class iPhone Settings destination with persisted Mold/Safelight color families and System/Dark/Light appearance choices
- synchronize WebView and native UIKit appearance so status-bar glyphs remain readable
- prevent iPhone input and double-tap document zoom while preserving gallery swipe behavior
- make Catalog pulls immediately show Connecting, Starting, Queued, and live Pulling progress across cards, detail, and host selection
- reconcile the opening download snapshot before POSTing and retain exact job identity for HF pulls whose catalog ID, canonical model, and display name differ
- reuse the shared desktop theme contract without changing desktop preference behavior

## Why

The mobile app could still zoom unexpectedly, had no settings/theme surface, and provided weak feedback after starting a remote model pull. Pull state also had two races: an opening SSE snapshot could arrive after a duplicate POST, and canonical Hugging Face job names could make an active pull appear idle.

## Verification

- 144 frontend test files / 1,315 tests
- desktop and mobile production builds
- Prettier and `git diff --check`
- iOS release-asset validation
- mobile Rust unit tests
- iOS simulator Clippy with warnings denied
- full Tauri/Xcode iPhone Simulator package build
- install and launch on iPhone 17 Pro simulator, iOS 26.5
- independent final diff review with the HF identity edge case fixed and retested
- both Copilot race findings addressed with regression coverage

After merge, the existing iOS workflow will trigger the TestFlight nightly pipeline, wait for App Store Connect `VALID`, and ensure `brink.james@gmail.com` remains in the `Mold Internal` group.
