### PR TITLE
fix(desktop): restore gallery print deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Desktop Gallery deletion now works from the keyboard and context menu.** Delete/Backspace claims WebKit's history-back shortcut when a print is selected and uses a visible two-step confirmation before removing it; the tile context menu shares the same confirmation path instead of issuing a silent fire-and-forget delete. Text fields retain native editing behavior, and delete failures surface as errors.
 - **Desktop image drops now work from Finder anywhere in Generate.** Native Tauri file-drop events bridge PNG/JPEG paths into the source controls, reject files larger than 64 MiB before ingestion, and restore prompt, model, seed, dimensions, and other settings from embedded Mold metadata before attaching the dropped still as the family-appropriate source or Qwen edit target. Loaded previews, gallery actions, and strength controls remain vertically separated inside the narrow inspector instead of overlapping.
 - **Desktop scrolling stays anchored at its limits.** The app shell disables WebKit elastic overscroll so trackpad scrolling no longer rubber-bands the desktop interface past its edges.
 - **Desktop prompt recall now includes every connected host.** Up/Down in the Generate composer merges prompt history from This device and all ready remote hosts, and a newly submitted prompt is available immediately while its owning host persists it.

--- a/desktop/src/views/GalleryView.test.ts
+++ b/desktop/src/views/GalleryView.test.ts
@@ -1,0 +1,245 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { flushPromises, mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { createMemoryHistory, createRouter } from "vue-router";
+
+const { apiFetchTo, localGalleryDelete, localGalleryList } = vi.hoisted(() => ({
+  apiFetchTo: vi.fn().mockResolvedValue(new Response()),
+  localGalleryDelete: vi.fn().mockResolvedValue(undefined),
+  localGalleryList: vi.fn(),
+}));
+
+vi.mock("@tanstack/vue-virtual", () => ({
+  useVirtualizer: (options: { value: { count: number } }) => ({
+    getTotalSize: () => options.value.count * 188,
+    getVirtualItems: () =>
+      Array.from({ length: options.value.count }, (_, index) => ({
+        index,
+        key: index,
+        start: index * 188,
+      })),
+  }),
+}));
+vi.mock("../lib/gallery/layout", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/gallery/layout")>();
+  return {
+    ...actual,
+    layoutJustifiedRows: (items: GalleryImage[]) =>
+      items.map((item) => ({
+        height: 180,
+        items: [{ item, width: 180, height: 180 }],
+      })),
+  };
+});
+vi.mock("../lib/api/client", () => ({
+  apiFetch: vi.fn(),
+  apiFetchTo,
+  apiJsonTo: vi.fn(),
+  currentTarget: () => ({ baseUrl: "http://x", apiKey: null }),
+}));
+vi.mock("../lib/ipc", () => ({
+  inTauri: () => false,
+  ipc: {
+    localGalleryDelete,
+    localGalleryList,
+    revealOutputFile: vi.fn(),
+    saveOutputBytes: vi.fn(),
+  },
+}));
+
+import GalleryView from "./GalleryView.vue";
+import { useConnectionStore } from "../stores/connection";
+import { useContextMenuStore, type MenuEntry } from "../stores/contextMenu";
+import { useGalleryStore } from "../stores/gallery";
+import { useHostsStore } from "../stores/hosts";
+import { useToastStore } from "../stores/toasts";
+import type { GalleryImage } from "../lib/api/types";
+
+const prints: GalleryImage[] = [
+  {
+    filename: "first.png",
+    timestamp: 2,
+    metadata: {
+      prompt: "first print",
+      model: "flux-dev:q8",
+      seed: 1,
+      steps: 4,
+      guidance: 1,
+      width: 1024,
+      height: 1024,
+    },
+  },
+  {
+    filename: "second.png",
+    timestamp: 1,
+    metadata: {
+      prompt: "second print",
+      model: "flux-dev:q8",
+      seed: 2,
+      steps: 4,
+      guidance: 1,
+      width: 1024,
+      height: 1024,
+    },
+  },
+];
+
+async function mountView(remotePrint?: GalleryImage) {
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: "/gallery", component: { template: "<div />" } },
+      { path: "/generate", component: { template: "<div />" } },
+    ],
+  });
+  await router.push("/gallery");
+
+  const pinia = createPinia();
+  setActivePinia(pinia);
+  const connection = useConnectionStore();
+  connection.info = null;
+  connection.status = "error";
+  const gallery = useGalleryStore();
+  gallery.buckets.local = {
+    items: [...prints],
+    loading: false,
+    error: null,
+    loaded: true,
+  };
+  if (remotePrint) {
+    useHostsStore().extras.push({
+      id: "plato-7680",
+      label: "plato",
+      url: "http://plato:7680",
+      apiKey: "secret",
+      status: "ready",
+      error: null,
+      instanceId: null,
+    });
+    gallery.buckets["plato-7680"] = {
+      items: [remotePrint],
+      loading: false,
+      error: null,
+      loaded: true,
+    };
+  }
+  localGalleryList.mockResolvedValue([...prints]);
+
+  const wrapper = mount(GalleryView, {
+    global: {
+      plugins: [pinia, router],
+      stubs: {
+        AuthedMedia: { template: "<div />" },
+        HostFilterChips: { template: "<div />" },
+      },
+    },
+  });
+  await flushPromises();
+  return { wrapper, gallery, router };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  apiFetchTo.mockResolvedValue(new Response());
+});
+
+describe("GalleryView delete keyboard handling", () => {
+  it.each(["Delete", "Backspace"])(
+    "prevents %s navigation and requires a second press before deleting",
+    async (key) => {
+      const { wrapper, gallery, router } = await mountView();
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft", cancelable: true }));
+
+      const first = new KeyboardEvent("keydown", { key, cancelable: true });
+      expect(window.dispatchEvent(first)).toBe(false);
+      await flushPromises();
+
+      expect(localGalleryDelete).not.toHaveBeenCalled();
+      expect(wrapper.get('[data-test="single-delete-confirm"]').text()).toContain(
+        "Delete first.png?",
+      );
+      expect(router.currentRoute.value.path).toBe("/gallery");
+
+      const second = new KeyboardEvent("keydown", { key, cancelable: true });
+      expect(window.dispatchEvent(second)).toBe(false);
+      await flushPromises();
+
+      expect(localGalleryDelete).toHaveBeenCalledWith("first.png");
+      expect(gallery.filtered.map((entry) => entry.item.filename)).toEqual(["second.png"]);
+      expect(router.currentRoute.value.path).toBe("/gallery");
+      wrapper.unmount();
+    },
+  );
+
+  it("routes context-menu confirmation to the selected remote host", async () => {
+    const remotePrint: GalleryImage = {
+      ...prints[0]!,
+      filename: "remote.png",
+      timestamp: 3,
+      metadata: { ...prints[0]!.metadata, seed: 9 },
+    };
+    const { wrapper, gallery } = await mountView(remotePrint);
+    const tile = wrapper.findAll("button").find((button) => button.text().includes("S 9"));
+    expect(tile).toBeDefined();
+    await tile!.trigger("contextmenu");
+
+    const menu = useContextMenuStore();
+    const deleteEntry = menu.entries.find(
+      (entry): entry is Exclude<MenuEntry, { separator: true }> =>
+        !("separator" in entry) && entry.label === "Delete",
+    );
+    expect(deleteEntry).toBeDefined();
+    menu.activate(deleteEntry!);
+    await flushPromises();
+
+    expect(apiFetchTo).not.toHaveBeenCalled();
+    await wrapper.get('[data-test="single-delete-confirm"] button').trigger("click");
+    await flushPromises();
+
+    expect(apiFetchTo).toHaveBeenCalledWith(
+      { baseUrl: "http://plato:7680", apiKey: "secret" },
+      "/api/gallery/image/remote.png",
+      { method: "DELETE" },
+    );
+    expect(gallery.filtered.some((entry) => entry.item.filename === "remote.png")).toBe(false);
+    wrapper.unmount();
+  });
+
+  it("surfaces a remote context-menu delete failure and keeps the print", async () => {
+    const remotePrint: GalleryImage = {
+      ...prints[0]!,
+      filename: "remote.png",
+      timestamp: 3,
+      metadata: { ...prints[0]!.metadata, seed: 9 },
+    };
+    apiFetchTo.mockRejectedValueOnce(new Error("Forbidden"));
+    const { wrapper, gallery } = await mountView(remotePrint);
+    const tile = wrapper.findAll("button").find((button) => button.text().includes("S 9"));
+    await tile!.trigger("contextmenu");
+    const menu = useContextMenuStore();
+    const deleteEntry = menu.entries.find(
+      (entry) => !("separator" in entry) && entry.label === "Delete",
+    )!;
+    menu.activate(deleteEntry);
+    await flushPromises();
+    await wrapper.get('[data-test="single-delete-confirm"] button').trigger("click");
+    await flushPromises();
+
+    expect(useToastStore().items.at(-1)).toMatchObject({ message: "Forbidden", kind: "error" });
+    expect(gallery.filtered.some((entry) => entry.item.filename === "remote.png")).toBe(true);
+    wrapper.unmount();
+  });
+
+  it("leaves Backspace native while the gallery search field is being edited", async () => {
+    const { wrapper } = await mountView();
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowLeft", cancelable: true }));
+    const search = wrapper.get("input[type='search']").element as HTMLInputElement;
+    search.focus();
+
+    const event = new KeyboardEvent("keydown", { key: "Backspace", cancelable: true });
+    expect(search.dispatchEvent(event)).toBe(true);
+    expect(localGalleryDelete).not.toHaveBeenCalled();
+    expect(wrapper.find('[data-test="single-delete-confirm"]').exists()).toBe(false);
+    wrapper.unmount();
+  });
+});

--- a/desktop/src/views/GalleryView.vue
+++ b/desktop/src/views/GalleryView.vue
@@ -467,10 +467,8 @@ async function removeEntry(entry: MergedPrint) {
 async function requestSingleDelete(entry: MergedPrint) {
   select(entry);
   const target = { sourceKey: entry.sourceKey, filename: entry.item.filename };
-  if (
-    confirmingSingleDelete.value?.sourceKey !== target.sourceKey ||
-    confirmingSingleDelete.value.filename !== target.filename
-  ) {
+  const pending = confirmingSingleDelete.value;
+  if (!pending || pending.sourceKey !== target.sourceKey || pending.filename !== target.filename) {
     confirmingSingleDelete.value = target;
     return;
   }

--- a/desktop/src/views/GalleryView.vue
+++ b/desktop/src/views/GalleryView.vue
@@ -20,6 +20,7 @@ import { useToastStore } from "../stores/toasts";
 import { inTauri, ipc } from "../lib/ipc";
 import { copyImageBytesToClipboard } from "../lib/clipboard";
 import { primaryModifierPressed } from "../lib/platform";
+import { allowsNativeContextMenu } from "../lib/shortcuts";
 import type { GalleryImage } from "../lib/api/types";
 
 const GAP = 8;
@@ -208,10 +209,7 @@ function tileMenu(entry: MergedPrint): MenuEntry[] {
     {
       label: "Delete",
       danger: true,
-      action: () => {
-        select(entry);
-        void removeSelected().then(() => toasts.push("Deleted"));
-      },
+      action: () => void requestSingleDelete(entry),
     },
   ];
 }
@@ -219,6 +217,7 @@ function tileMenu(entry: MergedPrint): MenuEntry[] {
 const scrollEl = ref<HTMLElement | null>(null);
 const containerWidth = ref(0);
 const selected = ref<{ sourceKey: string; filename: string } | null>(null);
+const confirmingSingleDelete = ref<{ sourceKey: string; filename: string } | null>(null);
 const lightboxOpen = ref(false);
 const rowHeight = ref(180);
 
@@ -254,6 +253,7 @@ const bulkDeleting = ref(false);
 
 function setSelectMode(next: boolean) {
   selectMode.value = next;
+  confirmingSingleDelete.value = null;
   if (!next) {
     bulkSelection.value = new Set();
     bulkAnchor.value = null;
@@ -364,7 +364,15 @@ const isSelected = (entry: MergedPrint) =>
   selected.value.filename === entry.item.filename;
 
 function select(entry: MergedPrint) {
-  selected.value = { sourceKey: entry.sourceKey, filename: entry.item.filename };
+  const next = { sourceKey: entry.sourceKey, filename: entry.item.filename };
+  if (
+    confirmingSingleDelete.value &&
+    (confirmingSingleDelete.value.sourceKey !== next.sourceKey ||
+      confirmingSingleDelete.value.filename !== next.filename)
+  ) {
+    confirmingSingleDelete.value = null;
+  }
+  selected.value = next;
 }
 
 const selectedIndex = computed(() => gallery.filtered.findIndex((e) => isSelected(e)));
@@ -412,7 +420,19 @@ function onKeydown(e: KeyboardEvent) {
     return;
   }
   if (e.metaKey || e.ctrlKey || e.altKey) return;
-  if (e.key === "ArrowRight") {
+  if (e.key === "Delete" || e.key === "Backspace") {
+    // WebKit treats an unhandled Backspace/Delete as history-back. Keep the
+    // native editing behavior in text fields, but always claim it elsewhere
+    // in Gallery so deleting a print can never navigate to Generate.
+    if (allowsNativeContextMenu(e.target as Element | null)) return;
+    e.preventDefault();
+    if (e.repeat) return;
+    if (selectMode.value && bulkSelection.value.size > 0) {
+      void deleteSelectedPrints();
+    } else if (selectedEntry.value) {
+      void requestSingleDelete(selectedEntry.value);
+    }
+  } else if (e.key === "ArrowRight") {
     e.preventDefault();
     moveSelection(1);
   } else if (e.key === "ArrowLeft") {
@@ -422,23 +442,50 @@ function onKeydown(e: KeyboardEvent) {
     e.preventDefault();
     if (selected.value) lightboxOpen.value = !lightboxOpen.value;
   } else if (e.key === "Escape") {
-    if (lightboxOpen.value) lightboxOpen.value = false;
+    if (confirmingSingleDelete.value) confirmingSingleDelete.value = null;
+    else if (lightboxOpen.value) lightboxOpen.value = false;
     else if (selectMode.value) setSelectMode(false);
   }
 }
 
-async function removeSelected() {
-  const entry = selectedEntry.value;
-  if (!entry) return;
-  const index = selectedIndex.value;
+async function removeEntry(entry: MergedPrint) {
+  const index = gallery.filtered.findIndex(
+    (candidate) =>
+      candidate.sourceKey === entry.sourceKey && candidate.item.filename === entry.item.filename,
+  );
   await gallery.remove(entry.sourceKey, entry.item.filename);
+  if (!isSelected(entry)) return;
   const remaining = gallery.filtered;
   if (remaining.length === 0) {
     lightboxOpen.value = false;
     selected.value = null;
   } else {
-    select(remaining[Math.min(index, remaining.length - 1)]!);
+    select(remaining[Math.min(Math.max(index, 0), remaining.length - 1)]!);
   }
+}
+
+async function requestSingleDelete(entry: MergedPrint) {
+  select(entry);
+  const target = { sourceKey: entry.sourceKey, filename: entry.item.filename };
+  if (
+    confirmingSingleDelete.value?.sourceKey !== target.sourceKey ||
+    confirmingSingleDelete.value.filename !== target.filename
+  ) {
+    confirmingSingleDelete.value = target;
+    return;
+  }
+  confirmingSingleDelete.value = null;
+  try {
+    await removeEntry(entry);
+    toasts.push("Deleted print");
+  } catch (error) {
+    toasts.push(error instanceof Error ? error.message : String(error), "error");
+  }
+}
+
+async function removeSelected() {
+  const entry = selectedEntry.value;
+  if (entry) await removeEntry(entry);
 }
 
 // Deep link: /gallery?host=<bucket key> pre-picks a chip ("local" = This
@@ -650,6 +697,31 @@ onUnmounted(() => {
           </button>
         </div>
       </div>
+    </div>
+
+    <div
+      v-if="confirmingSingleDelete && !selectMode"
+      data-test="single-delete-confirm"
+      class="border-edge absolute bottom-4 left-1/2 z-50 flex max-w-[calc(100%-2rem)] -translate-x-1/2 items-center gap-2 rounded-chrome border bg-bench px-3 py-2 shadow-lg"
+      role="alert"
+    >
+      <span class="text-caption text-ink">
+        Delete {{ confirmingSingleDelete.filename }}? This can't be undone.
+      </span>
+      <button
+        type="button"
+        class="h-7 rounded-control bg-stop px-2.5 text-caption font-semibold text-on-accent"
+        @click="selectedEntry && requestSingleDelete(selectedEntry)"
+      >
+        Delete
+      </button>
+      <button
+        type="button"
+        class="h-7 rounded-control px-2.5 text-caption text-ink-2 hover:text-ink"
+        @click="confirmingSingleDelete = null"
+      >
+        Cancel
+      </button>
     </div>
 
     <!-- Floating bulk-action bar while select mode is active. -->


### PR DESCRIPTION
## Summary

- intercept unmodified `Delete` and `Backspace` in the desktop Gallery so WebKit cannot treat them as history-back navigation
- add a visible two-step single-print confirmation shared by keyboard and tile context-menu deletion
- preserve native deletion in editable fields and ignore key-repeat so holding Delete cannot confirm accidentally
- route remote-origin deletes through the selected host and surface failures as error toasts instead of unhandled silent rejections
- retain the existing neighbor-selection behavior after a successful delete

## Tests

- added `GalleryView` regressions for:
  - Delete default prevention + two-press confirmation
  - Backspace default prevention + two-press confirmation
  - native Backspace behavior in the Gallery search input
  - authenticated remote-host context-menu deletion
  - remote delete failure visibility and print retention
- `cd desktop && bun run test` — 145 files, 1321 tests passed
- `cd desktop && bunx vue-tsc -b`
- `cd desktop && bun run fmt:check`
- `git diff --check`
- independent `codex review --uncommitted` — no findings; Codex also reran the full desktop frontend suite and type check

Closes #455
