### PR TITLE
fix(release): include shared UI in Docker build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,9 +60,11 @@ jobs:
               - 'nix/**'
               - '.github/workflows/ci.yml'
             release:
+              - 'Dockerfile'
               - 'release-plz.toml'
               - 'scripts/release/**'
               - 'scripts/tests/ci-coverage-disk-guard.sh'
+              - 'scripts/tests/docker-web-context.sh'
               - 'scripts/tests/release-sync-pr.sh'
               - '.github/workflows/release-plz.yml'
               - '.github/workflows/ci.yml'
@@ -77,6 +79,8 @@ jobs:
         run: bash scripts/tests/release-sync-pr.sh
       - name: Test CI coverage disk guard
         run: bash scripts/tests/ci-coverage-disk-guard.sh
+      - name: Test Docker web build context
+        run: bash scripts/tests/docker-web-context.sh
 
   docs:
     needs: changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Docker release images include the shared Mold Studio UI kit.** The container web-builder now copies repo-root `ui/` beside `/web` before running the SPA build, so `@ui/*` aliases resolve in the release-only Docker context instead of failing TypeScript compilation after otherwise-green web, desktop, and Nix checks.
+
 ## [0.20.0] - 2026-07-21
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ FROM oven/bun:1.3-alpine AS web-builder
 WORKDIR /web
 COPY web/package.json web/bun.lock web/tsconfig.json web/tsconfig.app.json web/tsconfig.node.json web/vite.config.ts web/index.html ./
 RUN bun install --frozen-lockfile
+COPY ui /ui
 COPY web/src ./src
 COPY web/public ./public
 RUN bun run build

--- a/scripts/tests/docker-web-context.sh
+++ b/scripts/tests/docker-web-context.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+dockerfile="$repo_root/Dockerfile"
+
+ui_copy_line="$(grep -n -m1 '^COPY ui /ui$' "$dockerfile" | cut -d: -f1 || true)"
+web_build_line="$(grep -n -m1 '^RUN bun run build$' "$dockerfile" | cut -d: -f1 || true)"
+
+if [[ -z "$ui_copy_line" ]]; then
+  echo "FAIL: Docker web-builder must copy repo-root ui/ to /ui for @ui imports" >&2
+  exit 1
+fi
+
+if [[ -z "$web_build_line" || "$ui_copy_line" -ge "$web_build_line" ]]; then
+  echo "FAIL: Docker web-builder must copy ui/ before running the web SPA build" >&2
+  exit 1
+fi
+
+grep -Fq '"@ui/*": ["../ui/*"]' "$repo_root/web/tsconfig.app.json" || {
+  echo "FAIL: web TypeScript @ui alias no longer resolves from /web to /ui" >&2
+  exit 1
+}
+
+grep -Fq 'new URL("../ui", import.meta.url)' "$repo_root/web/vite.config.ts" || {
+  echo "FAIL: web Vite @ui alias no longer resolves from /web to /ui" >&2
+  exit 1
+}
+
+echo "PASS: Docker web-builder includes the shared ui/ source before build"


### PR DESCRIPTION
## What changed

- copy the repo-root `ui/` kit into the Docker web-builder at `/ui` before the SPA build
- add a regression test for the `@ui` Docker build context and run it in CI
- record the release-only fix under `[Unreleased]`

## Root cause

The Mold Studio web app resolves `@ui/*` through `../ui`, but the Docker multi-stage build copied only `web/`. Normal web, desktop, and Nix checks had the repository root available, while the release container did not.

## Verification

- `bash scripts/tests/docker-web-context.sh`
- `bash scripts/tests/release-sync-pr.sh`
- `bash scripts/tests/ci-coverage-disk-guard.sh`
- `git diff --check`

A live Docker build was unavailable locally because the OrbStack Docker daemon is not running; the release workflow is the container proof.