### PR TITLE
fix(web): working filters, upscale, overlays, and machine routing

### DIFF
--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -219,19 +219,39 @@ export interface GenerateStreamHandlers {
   onError: (err: StreamError) => void;
 }
 
+/**
+ * Where a generation stream is dispatched. Omitted = the serving origin (the
+ * single-host case and every non-routed caller). The key travels as the
+ * server's `x-api-key` header — never in the URL.
+ */
+export interface StreamTarget {
+  baseUrl: string;
+  apiKey?: string;
+}
+
+function targetBase(target?: StreamTarget): string {
+  return target?.baseUrl ?? base;
+}
+
+function targetHeaders(target?: StreamTarget): Record<string, string> {
+  return target?.apiKey ? { "x-api-key": target.apiKey } : {};
+}
+
 export async function generateStream(
   req: GenerateRequestWire,
   handlers: GenerateStreamHandlers,
   signal?: AbortSignal,
+  target?: StreamTarget,
 ): Promise<void> {
   await postSseJsonStream<
     GenerateRequestWire,
     SseProgressEvent,
     SseCompleteEvent
   >({
-    url: `${base}/api/generate/stream`,
+    url: `${targetBase(target)}/api/generate/stream`,
     body: req,
     signal,
+    headers: targetHeaders(target),
     handlers,
     silentCloseMessage: "stream closed before completion",
   });
@@ -274,15 +294,17 @@ export async function generateChainStream(
   req: ChainRequestWire,
   handlers: ChainStreamHandlers,
   signal?: AbortSignal,
+  target?: StreamTarget,
 ): Promise<void> {
   await postSseJsonStream<
     ChainRequestWire,
     ChainProgressEvent,
     SseChainCompleteEvent
   >({
-    url: `${base}/api/generate/chain/stream`,
+    url: `${targetBase(target)}/api/generate/chain/stream`,
     body: req,
     signal,
+    headers: targetHeaders(target),
     handlers,
     silentCloseMessage: "stream closed before completion",
   });

--- a/web/src/components/CatalogCardGrid.test.ts
+++ b/web/src/components/CatalogCardGrid.test.ts
@@ -46,6 +46,9 @@ const baseEntry = {
 
 let mockState: {
   entries: any;
+  visibleEntries: any;
+  resultCount: any;
+  total: any;
   loading: any;
   loadingMore: any;
   hasMore: any;
@@ -63,6 +66,9 @@ beforeEach(() => {
   (globalThis as any).IntersectionObserver = FakeIntersectionObserver;
   mockState = {
     entries: ref([baseEntry]),
+    visibleEntries: ref([baseEntry]),
+    resultCount: ref(1),
+    total: ref<number | null>(1),
     loading: ref(false),
     loadingMore: ref(false),
     hasMore: ref(true),
@@ -76,6 +82,50 @@ beforeEach(() => {
 afterEach(() => {
   vi.restoreAllMocks();
   delete (globalThis as any).IntersectionObserver;
+});
+
+describe("CatalogCardGrid result count", () => {
+  // The unfiltered feed is checkpoint-heavy, so switching between All and
+  // Models leaves the first ~130 cards byte-identical — the filter applied
+  // but the visible screen did not move, which read as "the chips do
+  // nothing". A count is the one piece of feedback every filter changes.
+  it("reports the count the composable resolved", () => {
+    mockState.resultCount = ref(854);
+    const w = mount(CatalogCardGrid);
+    expect(w.find('[data-testid="catalog-result-count"]').text()).toContain(
+      "854",
+    );
+  });
+
+  it("singularises a one-row result", () => {
+    mockState.resultCount = ref(1);
+    const w = mount(CatalogCardGrid);
+    expect(w.find('[data-testid="catalog-result-count"]').text()).toBe(
+      "1 result",
+    );
+  });
+});
+
+describe("CatalogCardGrid client-side filtering", () => {
+  // The grid renders the modality-filtered view, not the raw fetched page:
+  // rendering `entries` would put image models under the Video chip.
+  it("renders visibleEntries rather than every fetched entry", () => {
+    const video = { ...baseEntry, id: "hf:row-1", modality: "video" };
+    mockState.entries = ref([baseEntry, video]);
+    mockState.visibleEntries = ref([video]);
+    mockState.resultCount = ref(1);
+    const w = mount(CatalogCardGrid);
+    expect(w.findAllComponents({ name: "CatalogCard" }).length).toBe(1);
+  });
+
+  it("shows the empty state when the filter hides every fetched row", () => {
+    mockState.entries = ref([baseEntry]);
+    mockState.visibleEntries = ref([]);
+    mockState.resultCount = ref(0);
+    mockState.hasMore = ref(false);
+    const w = mount(CatalogCardGrid);
+    expect(w.text()).toContain("No models found.");
+  });
 });
 
 describe("CatalogCardGrid infinite scroll", () => {

--- a/web/src/components/CatalogCardGrid.test.ts
+++ b/web/src/components/CatalogCardGrid.test.ts
@@ -118,6 +118,15 @@ describe("CatalogCardGrid client-side filtering", () => {
     expect(w.findAllComponents({ name: "CatalogCard" }).length).toBe(1);
   });
 
+  it("does not send the user to a 'Refresh catalog' control that no longer exists", () => {
+    mockState.visibleEntries = ref([]);
+    mockState.resultCount = ref(0);
+    mockState.hasMore = ref(false);
+    const w = mount(CatalogCardGrid);
+    expect(w.text()).toContain("No models found.");
+    expect(w.text()).not.toContain("Refresh catalog");
+  });
+
   it("shows the empty state when the filter hides every fetched row", () => {
     mockState.entries = ref([baseEntry]);
     mockState.visibleEntries = ref([]);

--- a/web/src/components/CatalogCardGrid.vue
+++ b/web/src/components/CatalogCardGrid.vue
@@ -69,7 +69,7 @@ function pullCard(id: string) {
 
     <!-- Empty state -->
     <div
-      v-else-if="cat.entries.value.length === 0"
+      v-else-if="cat.visibleEntries.value.length === 0"
       class="flex flex-col items-center justify-center gap-2 py-16 text-ink-3"
     >
       <p class="text-sm">No models found.</p>
@@ -82,9 +82,18 @@ function pullCard(id: string) {
 
     <!-- Grid -->
     <template v-else>
+      <p
+        data-testid="catalog-result-count"
+        class="mb-3 text-[12px] text-ink-3"
+        aria-live="polite"
+      >
+        {{ cat.resultCount.value.toLocaleString() }}
+        {{ cat.resultCount.value === 1 ? "result" : "results" }}
+      </p>
+
       <div class="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
         <CatalogCard
-          v-for="entry in cat.entries.value"
+          v-for="entry in cat.visibleEntries.value"
           :key="entry.id"
           :entry="entry"
           @open="openCard(entry.id)"

--- a/web/src/components/CatalogCardGrid.vue
+++ b/web/src/components/CatalogCardGrid.vue
@@ -74,9 +74,7 @@ function pullCard(id: string) {
     >
       <p class="text-sm">No models found.</p>
       <p class="text-xs">
-        Try adjusting filters or click
-        <span class="text-ink-2">Refresh catalog</span>
-        in the top bar.
+        No catalog entry matches every filter you've set — try widening one.
       </p>
     </div>
 

--- a/web/src/components/CatalogTopbar.test.ts
+++ b/web/src/components/CatalogTopbar.test.ts
@@ -118,6 +118,19 @@ describe("CatalogTopbar", () => {
     );
   });
 
+  it("unchecking Include NSFW sends include_nsfw=false rather than omitting it", async () => {
+    // The server's `include_nsfw` defaults to *true* when the parameter is
+    // absent, so dropping it on uncheck left NSFW rows in the grid while the
+    // box read as off. The off state has to be stated explicitly.
+    mockFilter.value = { include_nsfw: true };
+    const w = mount(CatalogTopbar);
+    const box = w.find("input[type=checkbox]");
+    await box.setValue(false);
+    expect(mockSetFilter).toHaveBeenCalledWith(
+      expect.objectContaining({ include_nsfw: false }),
+    );
+  });
+
   it("clicking the kind 'All' chip clears the kind filter", async () => {
     mockFilter.value = { kind: "lora" };
     const w = mount(CatalogTopbar);

--- a/web/src/components/CatalogTopbar.vue
+++ b/web/src/components/CatalogTopbar.vue
@@ -58,8 +58,11 @@ function setKind(k: KindFilter | undefined) {
   cat.setFilter({ kind: k });
 }
 
+// `include_nsfw` must be stated in both directions: the server treats an
+// absent parameter as `true`, so omitting it on uncheck left NSFW rows in
+// the grid under an unchecked box.
 function setNsfw(on: boolean) {
-  cat.setFilter({ include_nsfw: on || undefined });
+  cat.setFilter({ include_nsfw: on });
 }
 
 function clearSearch() {

--- a/web/src/components/ExpandModal.test.ts
+++ b/web/src/components/ExpandModal.test.ts
@@ -1,5 +1,6 @@
 import { flushPromises, mount } from "@vue/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { nextTick } from "vue";
 import ExpandModal from "./ExpandModal.vue";
 import type { ExpandFormState } from "../types";
 
@@ -57,6 +58,65 @@ describe("ExpandModal", () => {
       prompt: "a lighthouse",
       model_family: "flux",
       variations: 1,
+    });
+  });
+
+  describe("overlay contract", () => {
+    function dialog(): HTMLElement {
+      const el = document.body.querySelector<HTMLElement>("[role=dialog]");
+      expect(el).not.toBeNull();
+      return el as HTMLElement;
+    }
+
+    it("is a labelled modal dialog", () => {
+      factory();
+      const el = dialog();
+      expect(el.getAttribute("aria-modal")).toBe("true");
+      expect(el.getAttribute("aria-label")).toBe("Prompt expansion");
+    });
+
+    it("closes on Escape and on backdrop click, but not inside the panel", async () => {
+      const wrapper = factory();
+
+      const panel = document.body.querySelector(
+        ".ms-modal__panel",
+      ) as HTMLElement;
+      panel.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await nextTick();
+      expect(wrapper.emitted("close")).toBeUndefined();
+
+      dialog().dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await nextTick();
+      expect(wrapper.emitted("close")).toHaveLength(1);
+
+      dialog().dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+      );
+      await nextTick();
+      expect(wrapper.emitted("close")).toHaveLength(2);
+    });
+
+    it("restores focus to the opener when it closes", async () => {
+      const opener = document.createElement("button");
+      document.body.appendChild(opener);
+      opener.focus();
+
+      const wrapper = factory({ open: false });
+      await wrapper.setProps({ open: true });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(dialog().contains(document.activeElement)).toBe(true);
+
+      await wrapper.setProps({ open: false });
+      expect(document.activeElement).toBe(opener);
+    });
+
+    it("renders no emoji and no hard-coded hex colors", async () => {
+      const wrapper = factory();
+      await nextTick();
+      expect(wrapper.html()).not.toMatch(
+        /[\u{1F000}-\u{1FAFF}\u{2190}-\u{21FF}\u{2300}-\u{27BF}\u{2B00}-\u{2BFF}\u{FE0F}]/u,
+      );
+      expect(wrapper.html()).not.toMatch(/#[0-9a-fA-F]{3,8}\b/);
     });
   });
 });

--- a/web/src/components/ExpandModal.vue
+++ b/web/src/components/ExpandModal.vue
@@ -1,6 +1,19 @@
 <script setup lang="ts">
+/*
+ * Prompt-expansion overlay (spec §06 Create). Previews LLM rewrites of the
+ * composer prompt and applies the one the user picks.
+ *
+ * Mold Studio migration: was a hand-rolled `fixed inset-0` panel with an emoji
+ * title, Tailwind utility colors and no Escape handling. Now @ui ModalPanel +
+ * SegmentedControl + Icon, with `useOverlayFocus` supplying the Tab trap and
+ * opener restoration the kit leaves to the host.
+ */
 import { computed, ref } from "vue";
+import ModalPanel from "@ui/components/ModalPanel.vue";
+import SegmentedControl from "@ui/components/SegmentedControl.vue";
+import Icon from "@ui/components/Icon.vue";
 import { expandPrompt } from "../api";
+import { useOverlayFocus } from "../composables/useOverlayFocus";
 import type { ExpandFormState, ModelInfoExtended } from "../types";
 
 const props = defineProps<{
@@ -30,11 +43,23 @@ const previewing = ref(false);
 const previewError = ref<string | null>(null);
 const previewResults = ref<string[]>([]);
 
+const host = ref<HTMLElement | null>(null);
+const isOpen = computed(() => props.open);
+const { onKeydown } = useOverlayFocus(isOpen, host);
+
 const effectiveFamily = computed(
   () => props.expand.familyOverride ?? props.currentModel?.family ?? "flux",
 );
 
-const variationsOptions = [1, 3, 5] as const;
+type Variations = ExpandFormState["variations"];
+
+// Typed to the literal union so SegmentedControl's generic resolves to
+// `1 | 3 | 5` rather than widening to `number` at the update handler.
+const variationsOptions: { value: Variations; label: string }[] = [
+  { value: 1, label: "1" },
+  { value: 3, label: "3" },
+  { value: 5, label: "5" },
+];
 
 function patch<K extends keyof ExpandFormState>(key: K, v: ExpandFormState[K]) {
   emit("update:expand", { ...props.expand, [key]: v });
@@ -66,116 +91,309 @@ function pick(text: string) {
 </script>
 
 <template>
-  <Teleport to="body">
-    <div
-      v-if="open"
-      class="fixed inset-0 z-40 flex items-center justify-center bg-bath/70 backdrop-blur-sm"
-      @click.self="emit('close')"
+  <!-- Viewport-fixed host: ModalPanel is `position: absolute; inset: 0` and
+       Create is a long scrolling column, so mounting inline would draw the
+       panel at the top of the document. Same host pattern as
+       ModelDetailDrawer. -->
+  <div
+    v-if="open"
+    ref="host"
+    class="xm-host"
+    data-test="expand-modal-host"
+    @keydown="onKeydown"
+  >
+    <ModalPanel
+      :open="open"
+      :width="560"
+      label="Prompt expansion"
+      @close="emit('close')"
     >
-      <div
-        class="bg-bench border border-edge max-h-[90vh] w-full max-w-xl overflow-y-auto rounded-3xl p-6 sm:p-8"
-      >
-        <div class="flex items-center justify-between">
-          <h2 class="text-lg font-semibold text-rebate">✨ Prompt expansion</h2>
+      <div class="xm">
+        <header class="xm__head">
+          <h2 class="xm__title">
+            <Icon name="sparkle" :size="17" />
+            <span>Prompt expansion</span>
+          </h2>
           <button
             type="button"
-            class="text-ink-3 hover:text-rebate"
+            class="xm__close"
+            aria-label="Close"
+            data-test="expand-close"
             @click="emit('close')"
           >
-            ✕
+            <Icon name="close" :size="15" />
           </button>
-        </div>
+        </header>
 
-        <label class="mt-4 flex items-center gap-2 text-sm text-ink-2">
-          <input
-            type="checkbox"
-            :checked="expand.enabled"
-            @change="
-              patch('enabled', ($event.target as HTMLInputElement).checked)
-            "
-          />
-          Enable expansion before submit
-        </label>
-
-        <div class="mt-3">
-          <label class="text-xs uppercase text-ink-3">Variations</label>
-          <div class="mt-1 flex gap-1">
-            <button
-              v-for="n in variationsOptions"
-              :key="n"
-              type="button"
-              class="rounded-full px-3 py-1 text-sm"
-              :class="
-                expand.variations === n
-                  ? 'bg-safelight text-white'
-                  : 'bg-bench/60 text-ink-2'
+        <div class="xm__body">
+          <label class="xm__check">
+            <input
+              type="checkbox"
+              :checked="expand.enabled"
+              @change="
+                patch('enabled', ($event.target as HTMLInputElement).checked)
               "
-              @click="patch('variations', n)"
-            >
-              {{ n }}
-            </button>
+            />
+            <span>Enable expansion before submit</span>
+          </label>
+
+          <div class="xm__field">
+            <span class="xm__label">Variations</span>
+            <SegmentedControl
+              :model-value="expand.variations"
+              :options="variationsOptions"
+              label="Variations"
+              @update:model-value="(v: Variations) => patch('variations', v)"
+            />
           </div>
-        </div>
 
-        <details class="mt-3 text-sm text-ink-2">
-          <summary class="cursor-pointer text-ink-3">
-            Advanced: model family override
-          </summary>
-          <input
-            type="text"
-            :value="expand.familyOverride ?? ''"
-            placeholder="auto"
-            class="mt-1 w-full rounded-lg bg-bench/60 px-2 py-1 text-rebate"
-            @change="
-              patch(
-                'familyOverride',
-                ($event.target as HTMLInputElement).value || null,
-              )
-            "
-          />
-        </details>
+          <details class="xm__adv">
+            <summary>Advanced: model family override</summary>
+            <input
+              type="text"
+              :value="expand.familyOverride ?? ''"
+              placeholder="auto"
+              class="xm__input"
+              @change="
+                patch(
+                  'familyOverride',
+                  ($event.target as HTMLInputElement).value || null,
+                )
+              "
+            />
+          </details>
 
-        <div class="mt-4 flex items-center gap-2">
-          <button
-            type="button"
-            class="rounded-lg bg-safelight px-3 py-1.5 text-sm text-white disabled:opacity-50"
-            :disabled="previewing || !prompt.trim() || queueBusy"
-            :title="
-              queueBusy
-                ? 'Another generation is in the queue — wait for it to finish before previewing.'
-                : undefined
-            "
-            data-test="expand-preview"
-            @click="preview"
-          >
-            {{ previewing ? "Expanding…" : "Preview" }}
-          </button>
-          <span v-if="queueBusy" class="text-xs text-ink-3">
-            Queue busy — preview disabled.
-          </span>
-        </div>
-
-        <div v-if="previewError" class="mt-2 text-sm text-rose-300">
-          {{ previewError }}
-        </div>
-
-        <ul v-if="previewResults.length" class="mt-4 flex flex-col gap-2">
-          <li v-for="(text, i) in previewResults" :key="i">
+          <div class="xm__actions">
             <button
               type="button"
-              class="w-full rounded-xl bg-bench/60 p-3 text-left text-sm text-rebate hover:bg-surface/80"
-              @click="pick(text)"
+              class="xm__go"
+              :disabled="previewing || !prompt.trim() || queueBusy"
+              :title="
+                queueBusy
+                  ? 'Another generation is in the queue — wait for it to finish before previewing.'
+                  : undefined
+              "
+              data-test="expand-preview"
+              @click="preview"
             >
-              {{ text }}
+              {{ previewing ? "Expanding…" : "Preview" }}
             </button>
-          </li>
-        </ul>
+            <span v-if="queueBusy" class="xm__note">
+              queue busy — preview disabled
+            </span>
+          </div>
 
-        <p class="mt-4 text-xs text-ink-3">
-          Backend model, temperature, and thinking mode are controlled by the
-          server config. Ask your operator to adjust them.
-        </p>
+          <p v-if="previewError" class="xm__error">{{ previewError }}</p>
+
+          <ul v-if="previewResults.length" class="xm__results">
+            <li v-for="(text, i) in previewResults" :key="i">
+              <button type="button" class="xm__result" @click="pick(text)">
+                {{ text }}
+              </button>
+            </li>
+          </ul>
+
+          <p class="xm__foot">
+            Backend model, temperature, and thinking mode are controlled by the
+            server config. Ask your operator to adjust them.
+          </p>
+        </div>
       </div>
-    </div>
-  </Teleport>
+    </ModalPanel>
+  </div>
 </template>
+
+<style scoped>
+.xm-host {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+}
+
+.xm {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  color: var(--rebate);
+}
+
+.xm__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.xm__title {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  margin: 0;
+  font-family: var(--f-display);
+  font-size: 17px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.xm__title svg {
+  color: var(--safelight);
+}
+
+.xm__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--ce);
+  border-radius: var(--radius-control);
+  background: transparent;
+  color: var(--ink-3);
+  cursor: pointer;
+  transition:
+    color var(--dur-quick) var(--ease),
+    background var(--dur-quick) var(--ease);
+}
+
+.xm__close:hover {
+  color: var(--rebate);
+  background: var(--surface);
+}
+
+.xm__body {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  max-height: min(62vh, 520px);
+  overflow-y: auto;
+}
+
+.xm__check {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  font-size: 13px;
+  color: var(--ink-2);
+  cursor: pointer;
+}
+
+.xm__check input {
+  accent-color: var(--safelight);
+}
+
+.xm__field {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.xm__label {
+  font-family: var(--f-mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+}
+
+.xm__adv {
+  font-size: 13px;
+  color: var(--ink-2);
+}
+
+.xm__adv summary {
+  cursor: pointer;
+  color: var(--ink-3);
+  font-size: 12px;
+}
+
+.xm__input {
+  width: 100%;
+  margin-top: 8px;
+  padding: 9px 12px;
+  background: var(--bath);
+  border: 1px solid var(--ce);
+  border-radius: var(--radius-control);
+  color: var(--rebate);
+  font-family: var(--f-mono);
+  font-size: 13px;
+  outline: none;
+}
+
+.xm__input:focus-visible {
+  outline: 2px solid var(--safelight);
+  outline-offset: 2px;
+}
+
+.xm__actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.xm__go {
+  border: 0;
+  background: var(--safelight);
+  color: var(--on-accent);
+  padding: 9px 18px;
+  border-radius: var(--radius-control-lg);
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.xm__go:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.xm__note,
+.xm__error {
+  margin: 0;
+  font-family: var(--f-mono);
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  color: var(--ink-3);
+}
+
+.xm__error {
+  color: var(--stop);
+}
+
+.xm__results {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.xm__result {
+  width: 100%;
+  padding: 12px;
+  text-align: left;
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-control-lg);
+  background: var(--bath);
+  color: var(--rebate);
+  font-family: var(--f-body);
+  font-size: 13px;
+  line-height: 1.5;
+  cursor: pointer;
+  transition:
+    background var(--dur-quick) var(--ease),
+    border-color var(--dur-quick) var(--ease);
+}
+
+.xm__result:hover {
+  background: var(--surface);
+  border-color: var(--safelight);
+}
+
+.xm__foot {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--ink-3);
+}
+</style>

--- a/web/src/components/ImagePickerModal.test.ts
+++ b/web/src/components/ImagePickerModal.test.ts
@@ -1,5 +1,6 @@
 import { flushPromises, mount } from "@vue/test-utils";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { defineComponent, h, nextTick, ref } from "vue";
 import ImagePickerModal from "./ImagePickerModal.vue";
 
 vi.mock("../api", () => ({
@@ -13,6 +14,19 @@ vi.mock("../lib/base64", () => ({
     blob.name ? `b64:${blob.name}` : "b64:blob",
   ),
 }));
+
+/**
+ * Pictographs, dingbats, arrows and the variation selector. The Mold Studio
+ * voice is icons-only, so any hit in rendered chrome is a regression.
+ */
+const EMOJI =
+  /[\u{1F000}-\u{1FAFF}\u{2190}-\u{21FF}\u{2300}-\u{27BF}\u{2B00}-\u{2BFF}\u{FE0F}]/u;
+
+function dialog(): HTMLElement {
+  const el = document.body.querySelector<HTMLElement>("[role=dialog]");
+  expect(el).not.toBeNull();
+  return el as HTMLElement;
+}
 
 describe("ImagePickerModal", () => {
   afterEach(() => {
@@ -70,5 +84,147 @@ describe("ImagePickerModal", () => {
         base64: "b64:mask-base.png",
       },
     ]);
+  });
+
+  it("is a labelled modal dialog", () => {
+    mount(ImagePickerModal, {
+      props: { open: true },
+      attachTo: document.body,
+    });
+
+    const el = dialog();
+    expect(el.getAttribute("aria-modal")).toBe("true");
+    expect(el.getAttribute("aria-label")).toBe("Source image");
+  });
+
+  it("closes on Escape", async () => {
+    const w = mount(ImagePickerModal, {
+      props: { open: true },
+      attachTo: document.body,
+    });
+
+    dialog().dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+    );
+    await nextTick();
+
+    expect(w.emitted("close")).toHaveLength(1);
+  });
+
+  it("closes on backdrop click but not on a click inside the panel", async () => {
+    const w = mount(ImagePickerModal, {
+      props: { open: true },
+      attachTo: document.body,
+    });
+
+    const panel = document.body.querySelector(
+      ".ms-modal__panel",
+    ) as HTMLElement;
+    panel.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await nextTick();
+    expect(w.emitted("close")).toBeUndefined();
+
+    dialog().dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await nextTick();
+    expect(w.emitted("close")).toHaveLength(1);
+  });
+
+  it("moves focus into the panel on open and restores it to the opener on close", async () => {
+    const Harness = defineComponent({
+      setup() {
+        const open = ref(false);
+        return () => [
+          h("button", {
+            id: "opener",
+            onClick: () => (open.value = true),
+          }),
+          h(ImagePickerModal, {
+            open: open.value,
+            onClose: () => (open.value = false),
+          }),
+        ];
+      },
+    });
+
+    const w = mount(Harness, { attachTo: document.body });
+    const opener = document.body.querySelector("#opener") as HTMLButtonElement;
+    opener.focus();
+    expect(document.activeElement).toBe(opener);
+
+    await w.get("#opener").trigger("click");
+    await flushPromises();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const el = dialog();
+    expect(el.contains(document.activeElement)).toBe(true);
+
+    el.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+    );
+    await flushPromises();
+
+    expect(document.activeElement).toBe(opener);
+    w.unmount();
+  });
+
+  it("traps Tab inside the panel", async () => {
+    mount(ImagePickerModal, {
+      props: { open: true },
+      attachTo: document.body,
+    });
+    await flushPromises();
+
+    const el = dialog();
+    const tabbable = Array.from(
+      el.querySelectorAll<HTMLElement>(
+        'a[href],button:not([disabled]):not([tabindex="-1"]),input:not([disabled]):not([tabindex="-1"])',
+      ),
+    );
+    expect(tabbable.length).toBeGreaterThan(1);
+    const first = tabbable[0] as HTMLElement;
+    const last = tabbable[tabbable.length - 1] as HTMLElement;
+
+    last.focus();
+    last.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Tab", bubbles: true }),
+    );
+    expect(document.activeElement).toBe(first);
+
+    first.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "Tab",
+        bubbles: true,
+        shiftKey: true,
+      }),
+    );
+    expect(document.activeElement).toBe(last);
+  });
+
+  it("renders no emoji and no hard-coded hex colors", async () => {
+    const w = mount(ImagePickerModal, {
+      props: { open: true },
+      attachTo: document.body,
+    });
+    await flushPromises();
+
+    const html = w.html();
+    expect(html).not.toMatch(EMOJI);
+    expect(html).not.toMatch(/#[0-9a-fA-F]{3,8}\b/);
+  });
+
+  it("marks the drop target while a file is dragged over it", async () => {
+    const w = mount(ImagePickerModal, {
+      props: { open: true },
+      attachTo: document.body,
+    });
+
+    const drop = w.get("[data-test='image-picker-drop']");
+    expect(drop.attributes("data-dragging")).toBeUndefined();
+
+    await drop.trigger("dragenter");
+    expect(drop.attributes("data-dragging")).toBe("true");
+
+    await drop.trigger("dragleave", { relatedTarget: document.body });
+    expect(drop.attributes("data-dragging")).toBeUndefined();
   });
 });

--- a/web/src/components/ImagePickerModal.vue
+++ b/web/src/components/ImagePickerModal.vue
@@ -1,7 +1,23 @@
 <script setup lang="ts">
-import { onMounted, ref } from "vue";
+/*
+ * Source-image picker (spec §05 overlays, §06 Create). Upload from disk or
+ * reuse a gallery print.
+ *
+ * Mold Studio migration: this was a hand-rolled `fixed inset-0` panel with an
+ * emoji title, Tailwind utility colors, and no Escape handling. It now runs on
+ * the @ui panels — ModalPanel at desk width, full SheetPanel on phones, which
+ * is how ModelDetailDrawer and the Advanced sheet choose — plus
+ * `useOverlayFocus` for the Tab trap and opener restoration the kit leaves to
+ * the host.
+ */
+import { computed, markRaw, onBeforeUnmount, onMounted, ref } from "vue";
+import ModalPanel from "@ui/components/ModalPanel.vue";
+import SheetPanel from "@ui/components/SheetPanel.vue";
+import SegmentedControl from "@ui/components/SegmentedControl.vue";
+import Icon from "@ui/components/Icon.vue";
 import { listGallery, thumbnailUrl, imageUrl } from "../api";
 import { blobToBase64 } from "../lib/base64";
+import { useOverlayFocus } from "../composables/useOverlayFocus";
 import type { GalleryImage, SourceImageState } from "../types";
 
 const props = withDefaults(
@@ -20,8 +36,41 @@ const tab = ref<"upload" | "gallery">("upload");
 const entries = ref<GalleryImage[]>([]);
 const loading = ref(false);
 const error = ref<string | null>(null);
+const dragging = ref(false);
+const fileInput = ref<HTMLInputElement | null>(null);
+
+const host = ref<HTMLElement | null>(null);
+const isOpen = computed(() => props.open);
+const { onKeydown } = useOverlayFocus(isOpen, host);
+
+const tabOptions = [
+  { value: "upload" as const, label: "Upload" },
+  { value: "gallery" as const, label: "From gallery" },
+];
+
+// Phone surfaces get the full-screen sheet; everything else the centered modal.
+const isPhone = ref(false);
+let mq: MediaQueryList | null = null;
+function onMediaChange(event: MediaQueryListEvent) {
+  isPhone.value = event.matches;
+}
+
+const panelComponent = computed(() =>
+  markRaw(isPhone.value ? SheetPanel : ModalPanel),
+);
+const panelProps = computed(() =>
+  isPhone.value
+    ? { variant: "full" as const, title: props.title }
+    : { width: 720, label: props.title },
+);
 
 onMounted(async () => {
+  mq = window.matchMedia?.("(max-width: 639px)") ?? null;
+  if (mq) {
+    isPhone.value = mq.matches;
+    mq.addEventListener?.("change", onMediaChange);
+  }
+
   loading.value = true;
   try {
     entries.value = await listGallery();
@@ -32,9 +81,9 @@ onMounted(async () => {
   }
 });
 
-async function onFiles(event: Event) {
-  const input = event.target as HTMLInputElement;
-  const files = Array.from(input.files ?? []);
+onBeforeUnmount(() => mq?.removeEventListener?.("change", onMediaChange));
+
+async function emitFiles(files: File[]) {
   const selected = props.multiple ? files : files.slice(0, 1);
   if (!files.length) return;
   const picked = await Promise.all(
@@ -48,20 +97,29 @@ async function onFiles(event: Event) {
   emit("close");
 }
 
+async function onFiles(event: Event) {
+  const input = event.target as HTMLInputElement;
+  await emitFiles(Array.from(input.files ?? []));
+}
+
 async function onDrop(event: DragEvent) {
   event.preventDefault();
-  const files = Array.from(event.dataTransfer?.files ?? []);
-  const selected = props.multiple ? files : files.slice(0, 1);
-  if (!files.length) return;
-  const picked = await Promise.all(
-    selected.map(async (file) => ({
-      kind: "upload" as const,
-      filename: file.name,
-      base64: await blobToBase64(file),
-    })),
-  );
-  emit("pick", picked);
-  emit("close");
+  dragging.value = false;
+  await emitFiles(Array.from(event.dataTransfer?.files ?? []));
+}
+
+function onDragEnter(event: DragEvent) {
+  event.preventDefault();
+  dragging.value = true;
+}
+
+function onDragLeave(event: DragEvent) {
+  // Only clear when the pointer actually leaves the drop target — dragleave
+  // also fires when it crosses onto a child node.
+  const next = event.relatedTarget;
+  const target = event.currentTarget as HTMLElement;
+  if (next instanceof Node && target.contains(next)) return;
+  dragging.value = false;
 }
 
 async function pickFromGallery(item: GalleryImage) {
@@ -78,92 +136,315 @@ async function pickFromGallery(item: GalleryImage) {
 </script>
 
 <template>
-  <Teleport to="body">
-    <div
-      v-if="open"
-      class="fixed inset-0 z-40 flex items-center justify-center bg-bath/70 backdrop-blur-sm"
-      @click.self="emit('close')"
+  <!-- Viewport-fixed host: the @ui panels are `position: absolute; inset: 0`
+       so they fill their nearest positioned ancestor. Create is a long
+       scrolling column, so mounting inline would draw the panel at the top of
+       the document instead of where the user is looking. Same host pattern as
+       ModelDetailDrawer. -->
+  <div
+    v-if="open"
+    ref="host"
+    class="ip-host"
+    data-test="image-picker-host"
+    @keydown="onKeydown"
+  >
+    <component
+      :is="panelComponent"
+      v-bind="panelProps"
+      :open="open"
+      @close="emit('close')"
     >
-      <div
-        class="bg-bench border border-edge flex max-h-[90vh] w-full max-w-3xl flex-col overflow-hidden rounded-3xl p-6"
-      >
-        <div class="flex items-center justify-between">
-          <h2 class="text-lg font-semibold text-rebate">🖼️ {{ title }}</h2>
+      <div class="ip">
+        <!-- SheetPanel draws its own header + close control; the modal needs
+             one. -->
+        <header v-if="!isPhone" class="ip__head">
+          <h2 class="ip__title">
+            <Icon name="image" :size="17" />
+            <span>{{ title }}</span>
+          </h2>
           <button
             type="button"
-            class="text-ink-3 hover:text-rebate"
+            class="ip__close"
+            aria-label="Close"
+            data-test="image-picker-close"
             @click="emit('close')"
           >
-            ✕
+            <Icon name="close" :size="15" />
           </button>
-        </div>
+        </header>
 
-        <div class="mt-4 flex gap-2">
-          <button
-            type="button"
-            class="rounded-full px-3 py-1 text-sm"
-            :class="
-              tab === 'upload'
-                ? 'bg-safelight text-white'
-                : 'bg-bench/60 text-ink-2'
-            "
-            @click="tab = 'upload'"
-          >
-            Upload
-          </button>
-          <button
-            type="button"
-            class="rounded-full px-3 py-1 text-sm"
-            :class="
-              tab === 'gallery'
-                ? 'bg-safelight text-white'
-                : 'bg-bench/60 text-ink-2'
-            "
-            @click="tab = 'gallery'"
-          >
-            From gallery
-          </button>
-        </div>
+        <SegmentedControl
+          v-model="tab"
+          :options="tabOptions"
+          label="Image source"
+          class="ip__seg"
+        />
 
-        <div v-if="tab === 'upload'" class="mt-4 flex-1 overflow-y-auto">
+        <div v-if="tab === 'upload'" class="ip__body">
           <div
-            class="flex h-48 w-full items-center justify-center rounded-2xl border-2 border-dashed border-edge bg-bench/40 text-ink-3"
+            class="ip__drop"
+            :data-dragging="dragging ? 'true' : undefined"
+            data-test="image-picker-drop"
             @dragover.prevent
+            @dragenter="onDragEnter"
+            @dragleave="onDragLeave"
             @drop="onDrop"
           >
-            <label class="cursor-pointer text-center">
-              <span>Drop an image here or click to browse</span>
-              <input
-                type="file"
-                accept="image/*"
-                :multiple="multiple"
-                class="hidden"
-                @change="onFiles"
-              />
-            </label>
+            <button
+              type="button"
+              class="ip__drop-btn"
+              data-test="image-picker-browse"
+              @click="fileInput?.click()"
+            >
+              <span class="ip__drop-icon" aria-hidden="true">
+                <Icon name="upload" :size="22" />
+              </span>
+              <span class="ip__drop-lead">Drop an image here</span>
+              <span class="ip__drop-sub">or click to browse</span>
+            </button>
+            <input
+              ref="fileInput"
+              type="file"
+              accept="image/*"
+              :multiple="multiple"
+              class="ip__file"
+              tabindex="-1"
+              aria-hidden="true"
+              @change="onFiles"
+            />
           </div>
         </div>
 
-        <div v-else class="mt-4 flex-1 overflow-y-auto">
-          <p v-if="loading" class="text-sm text-ink-3">Loading…</p>
-          <p v-else-if="error" class="text-sm text-rose-300">{{ error }}</p>
-          <ul v-else class="grid grid-cols-3 gap-2 sm:grid-cols-5">
+        <div v-else class="ip__body">
+          <p v-if="loading" class="ip__status">loading gallery…</p>
+          <p v-else-if="error" class="ip__status ip__status--error">
+            {{ error }}
+          </p>
+          <p v-else-if="!entries.length" class="ip__status">
+            no prints in the gallery yet
+          </p>
+          <ul v-else class="ip__grid">
             <li v-for="item in entries" :key="item.filename">
               <button
                 type="button"
-                class="group relative overflow-hidden rounded-xl bg-bench/40"
+                class="ip__tile"
+                :title="item.filename"
                 @click="pickFromGallery(item)"
               >
                 <img
                   :src="thumbnailUrl(item.filename)"
                   :alt="item.filename"
-                  class="h-24 w-full object-cover transition group-hover:opacity-80"
+                  loading="lazy"
                 />
               </button>
             </li>
           </ul>
         </div>
       </div>
-    </div>
-  </Teleport>
+    </component>
+  </div>
 </template>
+
+<style scoped>
+.ip-host {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+}
+
+.ip {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  color: var(--rebate);
+}
+
+.ip__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.ip__title {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  margin: 0;
+  font-family: var(--f-display);
+  font-size: 17px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--rebate);
+}
+
+.ip__title svg {
+  color: var(--ink-3);
+}
+
+.ip__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--ce);
+  border-radius: var(--radius-control);
+  background: transparent;
+  color: var(--ink-3);
+  cursor: pointer;
+  transition:
+    color var(--dur-quick) var(--ease),
+    background var(--dur-quick) var(--ease);
+}
+
+.ip__close:hover {
+  color: var(--rebate);
+  background: var(--surface);
+}
+
+.ip__body {
+  min-height: 0;
+  max-height: min(56vh, 460px);
+  overflow-y: auto;
+}
+
+.ip__drop {
+  border: 1px dashed var(--ce);
+  border-radius: var(--radius-card);
+  background: var(--bath);
+  transition:
+    border-color var(--dur-quick) var(--ease),
+    background var(--dur-quick) var(--ease);
+}
+
+.ip__drop[data-dragging="true"] {
+  border-color: var(--safelight);
+  border-style: solid;
+  background: var(--sel-bg);
+}
+
+.ip__drop-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  width: 100%;
+  min-height: 184px;
+  padding: 24px;
+  border: 0;
+  border-radius: inherit;
+  background: transparent;
+  color: var(--ink-2);
+  font-family: var(--f-body);
+  cursor: pointer;
+}
+
+.ip__drop-btn:focus-visible {
+  outline: 2px solid var(--safelight);
+  outline-offset: -4px;
+}
+
+.ip__drop-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  margin-bottom: 4px;
+  border-radius: var(--radius-pill);
+  background: var(--surface);
+  color: var(--ink-3);
+}
+
+.ip__drop[data-dragging="true"] .ip__drop-icon {
+  color: var(--safelight);
+}
+
+.ip__drop-lead {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--rebate);
+}
+
+.ip__drop-sub {
+  font-family: var(--f-mono);
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  color: var(--ink-3);
+}
+
+/* Visually hidden, not display:none — a hidden input cannot be opened by
+   .click() in every engine, and Safari needs it laid out. */
+.ip__file {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}
+
+.ip__status {
+  margin: 0;
+  padding: 24px 0;
+  font-family: var(--f-mono);
+  font-size: 12px;
+  letter-spacing: 0.02em;
+  color: var(--ink-3);
+}
+
+.ip__status--error {
+  color: var(--stop);
+}
+
+.ip__grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+@media (min-width: 640px) {
+  .ip__grid {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+  }
+}
+
+.ip__tile {
+  display: block;
+  width: 100%;
+  padding: 0;
+  overflow: hidden;
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-control);
+  background: var(--bath);
+  cursor: pointer;
+  transition:
+    border-color var(--dur-quick) var(--ease),
+    opacity var(--dur-quick) var(--ease);
+}
+
+.ip__tile:hover {
+  border-color: var(--safelight);
+  opacity: 0.85;
+}
+
+.ip__tile:focus-visible {
+  outline: 2px solid var(--safelight);
+  outline-offset: 2px;
+}
+
+.ip__tile img {
+  display: block;
+  width: 100%;
+  height: 96px;
+  object-fit: cover;
+}
+</style>

--- a/web/src/components/LoraPicker.test.ts
+++ b/web/src/components/LoraPicker.test.ts
@@ -154,18 +154,28 @@ describe("LoraPicker — multi-LoRA stack", () => {
     expect(w.emitted("append-prompt")?.at(-1)?.[0]).toBe("cinematic style");
   });
 
-  it("clicking the ✕ button on a row removes it from the stack", async () => {
+  it("clicking the remove button on a row removes it from the stack", async () => {
     const w = mountPicker([
       { path: "/loras/cinematic.safetensors", scale: 1.0 },
       { path: "/loras/pixel.safetensors", scale: 0.6 },
     ]);
     await flushPromises();
-    const removeBtns = w.findAll("button").filter((b) => b.text() === "✕");
+    // The control is a kit Icon with no text, so it is addressed by its
+    // accessible name — the spec voice bans emoji glyphs as buttons.
+    const removeBtns = w.findAll("[aria-label='Remove this LoRA']");
     expect(removeBtns).toHaveLength(2);
     await removeBtns[0].trigger("click");
     const last = w.emitted("update:modelValue")?.at(-1)?.[0] as LoraSelection[];
     expect(last).toHaveLength(1);
     expect(last[0].path).toBe("/loras/pixel.safetensors");
+  });
+
+  it("renders row controls as kit icons, never emoji glyphs", async () => {
+    const w = mountPicker([{ path: "/loras/cinematic.safetensors", scale: 1 }]);
+    await flushPromises();
+    expect(w.html()).not.toMatch(
+      /[\u{1F000}-\u{1FAFF}\u{2190}-\u{21FF}\u{2300}-\u{27BF}\u{2B00}-\u{2BFF}\u{FE0F}]/u,
+    );
   });
 
   it("uses only explicit up/down buttons for row movement", async () => {

--- a/web/src/components/LoraPicker.vue
+++ b/web/src/components/LoraPicker.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
 import { RouterLink } from "vue-router";
+import Icon from "@ui/components/Icon.vue";
 import { fetchCatalogInstalled } from "../api";
 import type { CatalogEntryWire, LoraSelection } from "../types";
 import { MAX_LORA_STACK } from "../types";
@@ -200,7 +201,7 @@ function addAnother() {
             :disabled="index === 0"
             @click="moveAt(index, index - 1)"
           >
-            ↑
+            <Icon name="arrow-up" :size="14" />
           </button>
           <button
             type="button"
@@ -209,7 +210,7 @@ function addAnother() {
             :disabled="index === modelValue.length - 1"
             @click="moveAt(index, index + 1)"
           >
-            ↓
+            <Icon name="arrow-down" :size="14" />
           </button>
           <button
             type="button"
@@ -217,7 +218,7 @@ function addAnother() {
             aria-label="Remove this LoRA"
             @click="removeAt(index)"
           >
-            ✕
+            <Icon name="close" :size="14" />
           </button>
         </div>
       </div>

--- a/web/src/components/MaskEditorModal.test.ts
+++ b/web/src/components/MaskEditorModal.test.ts
@@ -122,9 +122,13 @@ describe("MaskEditorModal", () => {
     expect(wrapper.exists()).toBe(true);
     await nextTick();
 
-    await bodyGet<HTMLButtonElement>("[data-test='mask-mode-erase']").trigger(
-      "click",
+    // The tool picker is the @ui SegmentedControl: two role=radio segments,
+    // Brush then Erase.
+    const segments = document.body.querySelectorAll<HTMLButtonElement>(
+      "[data-test='mask-mode'] [role=radio]",
     );
+    expect(segments).toHaveLength(2);
+    await new DOMWrapper(segments[1] as HTMLButtonElement).trigger("click");
     await bodyGet<HTMLInputElement>("[data-test='mask-brush-size']").setValue(
       "48",
     );
@@ -141,5 +145,75 @@ describe("MaskEditorModal", () => {
       0,
       Math.PI * 2,
     );
+  });
+
+  describe("overlay contract", () => {
+    function dialog(): HTMLElement {
+      const el = document.body.querySelector<HTMLElement>("[role=dialog]");
+      expect(el).not.toBeNull();
+      return el as HTMLElement;
+    }
+
+    it("is a labelled modal dialog", () => {
+      mount(MaskEditorModal, {
+        props: { open: true, sourceImage },
+        attachTo: document.body,
+      });
+      const el = dialog();
+      expect(el.getAttribute("aria-modal")).toBe("true");
+      expect(el.getAttribute("aria-label")).toBe("Mask editor");
+    });
+
+    it("closes on Escape and on backdrop click, but not inside the panel", async () => {
+      const wrapper = mount(MaskEditorModal, {
+        props: { open: true, sourceImage },
+        attachTo: document.body,
+      });
+
+      const panel = document.body.querySelector(
+        ".ms-modal__panel",
+      ) as HTMLElement;
+      panel.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await nextTick();
+      expect(wrapper.emitted("close")).toBeUndefined();
+
+      dialog().dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await nextTick();
+      expect(wrapper.emitted("close")).toHaveLength(1);
+
+      dialog().dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+      );
+      await nextTick();
+      expect(wrapper.emitted("close")).toHaveLength(2);
+    });
+
+    it("restores focus to the opener when it closes", async () => {
+      const opener = document.createElement("button");
+      document.body.appendChild(opener);
+      opener.focus();
+
+      const wrapper = mount(MaskEditorModal, {
+        props: { open: false, sourceImage },
+        attachTo: document.body,
+      });
+      await wrapper.setProps({ open: true });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(dialog().contains(document.activeElement)).toBe(true);
+
+      await wrapper.setProps({ open: false });
+      expect(document.activeElement).toBe(opener);
+    });
+
+    it("renders no emoji", async () => {
+      const wrapper = mount(MaskEditorModal, {
+        props: { open: true, sourceImage },
+        attachTo: document.body,
+      });
+      await nextTick();
+      expect(wrapper.html()).not.toMatch(
+        /[\u{1F000}-\u{1FAFF}\u{2190}-\u{21FF}\u{2300}-\u{27BF}\u{2B00}-\u{2BFF}\u{FE0F}]/u,
+      );
+    });
   });
 });

--- a/web/src/components/MaskEditorModal.vue
+++ b/web/src/components/MaskEditorModal.vue
@@ -1,5 +1,18 @@
 <script setup lang="ts">
-import { nextTick, ref, watch } from "vue";
+/*
+ * Inpaint mask editor (spec §06 Create). Paint/erase a white mask over the
+ * source print and hand the flattened PNG back to the composer.
+ *
+ * Mold Studio migration: was a hand-rolled `fixed inset-0` panel with an emoji
+ * close glyph, Tailwind utility colors and no Escape handling. Now @ui
+ * ModalPanel + SegmentedControl + Icon, with `useOverlayFocus` supplying the
+ * Tab trap and opener restoration the kit leaves to the host.
+ */
+import { computed, nextTick, ref, watch } from "vue";
+import ModalPanel from "@ui/components/ModalPanel.vue";
+import SegmentedControl from "@ui/components/SegmentedControl.vue";
+import Icon from "@ui/components/Icon.vue";
+import { useOverlayFocus } from "../composables/useOverlayFocus";
 import type { SourceImageState } from "../types";
 
 const props = defineProps<{
@@ -14,6 +27,14 @@ const emit = defineEmits<{
 }>();
 
 const canvasRef = ref<HTMLCanvasElement | null>(null);
+const host = ref<HTMLElement | null>(null);
+const visible = computed(() => props.open && props.sourceImage !== null);
+const { onKeydown } = useOverlayFocus(visible, host);
+
+const modeOptions = [
+  { value: "brush" as const, label: "Brush" },
+  { value: "erase" as const, label: "Erase" },
+];
 const mode = ref<"brush" | "erase">("brush");
 const brushSize = ref(32);
 const drawing = ref(false);
@@ -202,88 +223,76 @@ function applyMask() {
 </script>
 
 <template>
-  <Teleport to="body">
-    <div
-      v-if="open && sourceImage"
-      class="fixed inset-0 z-50 flex items-center justify-center bg-bath/75 p-4 backdrop-blur-sm"
-      @click.self="emit('close')"
+  <!-- Viewport-fixed host: ModalPanel is `position: absolute; inset: 0` and
+       Create is a long scrolling column, so mounting inline would draw the
+       panel at the top of the document. Same host pattern as
+       ModelDetailDrawer. -->
+  <div
+    v-if="visible && sourceImage"
+    ref="host"
+    class="me-host"
+    data-test="mask-editor-host"
+    @keydown="onKeydown"
+  >
+    <ModalPanel
+      :open="true"
+      :width="900"
+      label="Mask editor"
+      @close="emit('close')"
     >
-      <div
-        class="bg-bench border border-edge flex max-h-[92vh] w-full max-w-4xl flex-col overflow-hidden rounded-2xl p-4"
-      >
-        <div class="flex items-center justify-between gap-3">
-          <h2 class="truncate text-lg font-semibold text-rebate">
-            Mask editor
+      <div class="me">
+        <header class="me__head">
+          <h2 class="me__title">
+            <Icon name="mask" :size="17" />
+            <span>Mask editor</span>
           </h2>
           <button
             type="button"
-            class="text-ink-3 hover:text-rebate"
+            class="me__close"
+            aria-label="Close"
+            data-test="mask-close"
             @click="emit('close')"
           >
-            ✕
+            <Icon name="close" :size="15" />
           </button>
-        </div>
+        </header>
 
-        <div
-          class="mt-4 flex flex-wrap items-center gap-2 border-y border-edge py-3"
-        >
-          <button
-            type="button"
-            class="rounded-lg px-3 py-1 text-sm"
-            :class="
-              mode === 'brush'
-                ? 'bg-safelight text-white'
-                : 'bg-bench/60 text-ink-2'
-            "
-            data-test="mask-mode-brush"
-            @click="mode = 'brush'"
-          >
-            Brush
-          </button>
-          <button
-            type="button"
-            class="rounded-lg px-3 py-1 text-sm"
-            :class="
-              mode === 'erase'
-                ? 'bg-safelight text-white'
-                : 'bg-bench/60 text-ink-2'
-            "
-            data-test="mask-mode-erase"
-            @click="mode = 'erase'"
-          >
-            Erase
-          </button>
-          <label class="ml-2 flex items-center gap-2 text-sm text-ink-2">
-            Size
+        <div class="me__tools">
+          <div class="me__mode" data-test="mask-mode">
+            <SegmentedControl
+              v-model="mode"
+              :options="modeOptions"
+              label="Mask tool"
+            />
+          </div>
+          <label class="me__size">
+            <span>Size</span>
             <input
               v-model.number="brushSize"
               type="range"
               min="4"
               max="128"
               step="1"
-              class="w-32"
               data-test="mask-brush-size"
             />
+            <span class="me__size-val">{{ brushSize }}</span>
           </label>
+          <span class="me__spacer" />
           <button
             type="button"
-            class="rounded-lg bg-bench/60 px-3 py-1 text-sm text-ink-2"
+            class="me__tool"
             data-test="mask-clear"
             @click="clearMask"
           >
             Clear
           </button>
-          <button
-            type="button"
-            class="rounded-lg bg-bench/60 px-3 py-1 text-sm text-ink-2"
-            @click="invertMask"
-          >
+          <button type="button" class="me__tool" @click="invertMask">
             Invert
           </button>
           <button
             type="button"
-            class="rounded-lg bg-bench/60 px-3 py-1 text-sm text-ink-2 disabled:opacity-40"
-            :class="{ 'opacity-40': undoStack.length === 0 }"
+            class="me__tool"
+            :disabled="undoStack.length === 0"
             data-test="mask-undo"
             @click="undo"
           >
@@ -291,8 +300,8 @@ function applyMask() {
           </button>
           <button
             type="button"
-            class="rounded-lg bg-bench/60 px-3 py-1 text-sm text-ink-2 disabled:opacity-40"
-            :class="{ 'opacity-40': redoStack.length === 0 }"
+            class="me__tool"
+            :disabled="redoStack.length === 0"
             data-test="mask-redo"
             @click="redo"
           >
@@ -300,18 +309,18 @@ function applyMask() {
           </button>
         </div>
 
-        <div class="mt-4 flex min-h-0 justify-center overflow-auto">
-          <div class="relative max-h-[65vh] max-w-full overflow-hidden">
+        <div class="me__stage">
+          <div class="me__canvas-wrap">
             <img
               :src="sourceUrl(sourceImage)"
               :alt="sourceImage.filename"
-              class="max-h-[65vh] max-w-full select-none object-contain"
+              class="me__source"
               draggable="false"
               @load="onSourceLoaded"
             />
             <canvas
               ref="canvasRef"
-              class="absolute inset-0 h-full w-full cursor-crosshair touch-none opacity-70"
+              class="me__canvas"
               data-test="mask-canvas"
               @pointerdown="startDrawing"
               @pointermove="keepDrawing"
@@ -320,25 +329,206 @@ function applyMask() {
             ></canvas>
           </div>
         </div>
-
-        <div class="mt-4 flex justify-end gap-2">
-          <button
-            type="button"
-            class="rounded-lg bg-bench/60 px-4 py-2 text-sm text-ink-2"
-            @click="emit('close')"
-          >
-            Cancel
-          </button>
-          <button
-            type="button"
-            class="rounded-lg bg-safelight px-4 py-2 text-sm text-white"
-            data-test="mask-apply"
-            @click="applyMask"
-          >
-            Apply
-          </button>
-        </div>
       </div>
-    </div>
-  </Teleport>
+      <template #footer>
+        <span class="me__spacer" />
+        <button type="button" class="me__cancel" @click="emit('close')">
+          Cancel
+        </button>
+        <button
+          type="button"
+          class="me__apply"
+          data-test="mask-apply"
+          @click="applyMask"
+        >
+          Apply
+        </button>
+      </template>
+    </ModalPanel>
+  </div>
 </template>
+
+<style scoped>
+.me-host {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+}
+
+.me {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  color: var(--rebate);
+}
+
+.me__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.me__title {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  margin: 0;
+  min-width: 0;
+  font-family: var(--f-display);
+  font-size: 17px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.me__title svg {
+  color: var(--ink-3);
+  flex: none;
+}
+
+.me__title span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.me__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--ce);
+  border-radius: var(--radius-control);
+  background: transparent;
+  color: var(--ink-3);
+  cursor: pointer;
+  transition:
+    color var(--dur-quick) var(--ease),
+    background var(--dur-quick) var(--ease);
+}
+
+.me__close:hover {
+  color: var(--rebate);
+  background: var(--surface);
+}
+
+.me__tools {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 0;
+  border-top: 1px solid var(--edge);
+  border-bottom: 1px solid var(--edge);
+}
+
+.me__mode {
+  width: 168px;
+}
+
+.me__size {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--f-mono);
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  color: var(--ink-3);
+}
+
+.me__size input {
+  width: 120px;
+  accent-color: var(--safelight);
+}
+
+.me__size-val {
+  min-width: 22px;
+  color: var(--ink-2);
+}
+
+.me__spacer {
+  flex: 1;
+}
+
+.me__tool {
+  border: 1px solid var(--ce);
+  border-radius: var(--radius-control);
+  background: transparent;
+  color: var(--ink-2);
+  padding: 7px 13px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background var(--dur-quick) var(--ease),
+    color var(--dur-quick) var(--ease);
+}
+
+.me__tool:hover:not(:disabled) {
+  background: var(--surface);
+  color: var(--rebate);
+}
+
+.me__tool:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.me__stage {
+  display: flex;
+  justify-content: center;
+  min-height: 0;
+  overflow: auto;
+}
+
+.me__canvas-wrap {
+  position: relative;
+  max-width: 100%;
+  max-height: 58vh;
+  overflow: hidden;
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-control-lg);
+  background: var(--bath);
+}
+
+.me__source {
+  display: block;
+  max-width: 100%;
+  max-height: 58vh;
+  object-fit: contain;
+  user-select: none;
+}
+
+.me__canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  cursor: crosshair;
+  touch-action: none;
+  opacity: 0.7;
+}
+
+.me__cancel {
+  border: 1px solid var(--ce);
+  border-radius: var(--radius-control-lg);
+  background: transparent;
+  color: var(--ink-2);
+  padding: 10px 16px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.me__apply {
+  border: 0;
+  border-radius: var(--radius-control-lg);
+  background: var(--safelight);
+  color: var(--on-accent);
+  padding: 10px 20px;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+}
+</style>

--- a/web/src/components/Metadata.vue
+++ b/web/src/components/Metadata.vue
@@ -90,7 +90,7 @@ function onCopy(text: string, kind: CopyTarget) {
         class="text-[11px] font-medium text-safelight transition hover:text-safelight"
         @click="onCopy(item.metadata.prompt, 'prompt')"
       >
-        {{ copied === "prompt" ? "copied ✓" : "copy" }}
+        {{ copied === "prompt" ? "copied" : "copy" }}
       </button>
     </div>
     <p

--- a/web/src/components/create/ActivityStrip.vue
+++ b/web/src/components/create/ActivityStrip.vue
@@ -10,8 +10,16 @@ import { computed } from "vue";
 import ProgressBar from "@ui/components/ProgressBar.vue";
 import Icon from "@ui/components/Icon.vue";
 import type { Job } from "../../composables/useGenerateStream";
+import { ORIGIN_HOST_ID } from "../../lib/hostRegistry";
 
 const props = defineProps<{ jobs: Job[] }>();
+
+/** Which machine a job is running on — omitted when it's this server, so the
+ * single-host case stays uncluttered and a routed job is always attributed. */
+function hostBadge(job: Job): string | null {
+  if (!job.hostId || job.hostId === ORIGIN_HOST_ID) return null;
+  return job.hostLabel ?? job.hostId;
+}
 
 const emit = defineEmits<{
   cancel: [id: string];
@@ -56,7 +64,15 @@ const active = computed(() => running.value.length + queued.value.length > 0);
     >
       <span class="activity__thumb ms-shimmer" aria-hidden="true" />
       <span class="activity__body">
-        <span class="activity__prompt">{{ promptFor(job) }}</span>
+        <span class="activity__prompt">
+          <span
+            v-if="hostBadge(job)"
+            class="activity__host"
+            :data-test="`activity-host-${job.id}`"
+            >{{ hostBadge(job) }}</span
+          >
+          {{ promptFor(job) }}
+        </span>
         <ProgressBar
           :value="percentFor(job) ?? 0"
           tone="accent"
@@ -79,7 +95,15 @@ const active = computed(() => running.value.length + queued.value.length > 0);
         class="activity__pill"
         :data-test="`activity-queued-${job.id}`"
       >
-        <span class="activity__pill-text">{{ promptFor(job) }}</span>
+        <span class="activity__pill-text">
+          <span
+            v-if="hostBadge(job)"
+            class="activity__host"
+            :data-test="`activity-host-${job.id}`"
+            >{{ hostBadge(job) }}</span
+          >
+          {{ promptFor(job) }}
+        </span>
         <button
           type="button"
           class="activity__cancel"
@@ -144,6 +168,20 @@ const active = computed(() => running.value.length + queued.value.length > 0);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.activity__host {
+  display: inline-block;
+  font-family: var(--f-mono);
+  font-size: 9px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--halide);
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-pill);
+  padding: 1px 6px;
+  margin-right: 5px;
+  vertical-align: middle;
 }
 
 .activity__pct {

--- a/web/src/components/create/AdvancedDrawer.test.ts
+++ b/web/src/components/create/AdvancedDrawer.test.ts
@@ -1,11 +1,38 @@
-import { mount } from "@vue/test-utils";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { flushPromises, mount } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import AdvancedDrawer from "./AdvancedDrawer.vue";
 import {
   useGenerateForm,
   __testing__,
 } from "../../composables/useGenerateForm";
-import type { GenerateFormState } from "../../types";
+import type { GenerateFormState, ModelInfoExtended } from "../../types";
+
+// The upscale section reads the host's model list. Only upscalers matter here.
+const UPSCALERS: ModelInfoExtended[] = [
+  {
+    name: "real-esrgan-x4plus:fp16",
+    family: "upscaler",
+    size_gb: 0.03,
+    is_loaded: false,
+    last_used: null,
+    hf_repo: "",
+    downloaded: true,
+    default_steps: 0,
+    default_guidance: 0,
+    default_width: 0,
+    default_height: 0,
+    description: "Real-ESRGAN x4+ FP16",
+  } as ModelInfoExtended,
+];
+vi.mock("../../api", () => ({
+  fetchModels: vi.fn(async () => UPSCALERS),
+  fetchCatalogInstalled: vi.fn(async () => ({
+    entries: [],
+    page: 1,
+    page_size: 0,
+    total: 0,
+  })),
+}));
 
 function baseForm(
   overrides: Partial<GenerateFormState> = {},
@@ -26,6 +53,7 @@ function factory(
       stubs: {
         LoraPicker: { template: "<div data-test='lora-picker-stub' />" },
         PlacementPanel: { template: "<div data-test='placement-stub' />" },
+        RouterLink: { template: "<a><slot /></a>" },
       },
     },
   });
@@ -75,6 +103,13 @@ describe("AdvancedDrawer capability matrix", () => {
 
   it("ltx2 exposes the video section", () => {
     expect(sections("ltx2").video).toBe(true);
+  });
+
+  it("offers post-generate upscale for stills but not for video", () => {
+    // The server skips the post-upscaler whenever the response is a video
+    // (queue.rs), so the section must not pretend otherwise.
+    expect(sections("flux").upscale).toBe(true);
+    expect(sections("ltx2").upscale).toBe(false);
   });
 
   it("shows GPU placement only when GPUs are reported", () => {
@@ -361,6 +396,40 @@ describe("AdvancedDrawer interactions", () => {
     };
     expect(swapped.width).toBe(704);
     expect(swapped.height).toBe(1216);
+  });
+
+  it("round-trips 'Upscale after generate' into the generate request", async () => {
+    // The toggle is only honest if the chosen upscaler survives into the wire
+    // request as `upscale_model` — and disappears again when it is turned off.
+    const form = useGenerateForm();
+    const wrapper = mount(AdvancedDrawer, {
+      props: { open: true, modelValue: form.state.value, family: "flux" },
+      global: {
+        stubs: {
+          LoraPicker: { template: "<div />" },
+          PlacementPanel: { template: "<div />" },
+          RouterLink: { template: "<a><slot /></a>" },
+        },
+      },
+    });
+    await flushPromises();
+
+    await wrapper.get("[data-test='upscale-toggle']").trigger("click");
+    let next = wrapper.emitted("update:modelValue")!.at(-1)![0] as
+      | GenerateFormState
+      | undefined;
+    Object.assign(form.state.value, next);
+    expect(form.state.value.upscaleModel).toBe("real-esrgan-x4plus:fp16");
+    expect(form.toRequest().upscale_model).toBe("real-esrgan-x4plus:fp16");
+
+    await wrapper.setProps({ modelValue: { ...form.state.value } });
+    await wrapper.get("[data-test='upscale-toggle']").trigger("click");
+    next = wrapper.emitted("update:modelValue")!.at(-1)![0] as
+      | GenerateFormState
+      | undefined;
+    Object.assign(form.state.value, next);
+    expect(form.state.value.upscaleModel).toBe("");
+    expect(form.toRequest().upscale_model).toBeUndefined();
   });
 
   it("emits close from Done in the phone sheet", async () => {

--- a/web/src/components/create/AdvancedDrawer.vue
+++ b/web/src/components/create/AdvancedDrawer.vue
@@ -23,6 +23,7 @@ import Chip from "@ui/components/Chip.vue";
 import LoraPicker from "../LoraPicker.vue";
 import PlacementPanel from "../PlacementPanel.vue";
 import Ltx2VideoControls from "./advanced/Ltx2VideoControls.vue";
+import UpscaleSection from "./advanced/UpscaleSection.vue";
 import type {
   DevicePlacement,
   GenerateFormState,
@@ -99,17 +100,23 @@ const showScheduler = computed(
 );
 const showPlacement = computed(() => props.placementGpus.length > 0);
 
-// Sections actually rendered for this family, in template order. Upscale,
-// Output & seed are always present; the rest are capability-gated. Used to
-// pick a sensible default-open section (never a hidden one like Scheduler on
-// a flux model) and to honour `openTo`.
+// Post-generate upscale applies to stills only — the server skips the
+// upscaler whenever the response is a video (`queue.rs`), so video families
+// never see the section.
+const showUpscale = computed(() => !caps.value.supportsVideo);
+
+// Sections that take part in the single-open accordion, in template order.
+// Output & seed is always present; the rest are capability-gated. Used to pick
+// a sensible default-open section (never a hidden one like Scheduler on a flux
+// model) and to honour `openTo`. Upscale is deliberately absent: it is a switch
+// row whose body follows the switch, not the accordion.
 const visibleSections = computed<SectionKey[]>(() => {
   const out: SectionKey[] = [];
   if (showScheduler.value) out.push("scheduler");
   if (caps.value.supportsNegativePrompt) out.push("negative");
   if (caps.value.sourceImageMode === "single") out.push("source");
   if (caps.value.supportsLora) out.push("lora");
-  out.push("upscale", "output");
+  out.push("output");
   if (caps.value.supportsVideo) out.push("video");
   if (showPlacement.value) out.push("placement");
   return out;
@@ -227,13 +234,6 @@ function clearControl() {
 // exactly those families, so it doubles as the suite gate; plain
 // ltx-video keeps just frames/fps/GIF.
 const showLtx2 = computed(() => caps.value.supportsAudio);
-
-// ── Upscale ───────────────────────────────────────────────────────────
-const upscaleOn = computed(() => props.modelValue.upscaleModel.trim() !== "");
-function toggleUpscale(on: boolean) {
-  patch({ upscaleModel: on ? props.modelValue.upscaleModel || "" : "" });
-  if (on) openSection.value = "upscale";
-}
 
 // ── Output & seed: exact size (snap to the 16px grid, like desktop) ───
 function snapDim(v: number): number {
@@ -551,35 +551,11 @@ function resetAdvanced() {
         />
       </AccordionSection>
 
-      <AccordionSection
-        icon="upscale"
-        title="Upscale after generate"
-        :summary="upscaleOn ? 'Higher-res output' : 'Off'"
-        :header-interactive="false"
-        :open="openSection === 'upscale'"
-        data-test="section-upscale"
-      >
-        <template #action>
-          <SwitchToggle
-            :model-value="upscaleOn"
-            label="Upscale after generate"
-            data-test="upscale-toggle"
-            @update:model-value="toggleUpscale"
-          />
-        </template>
-        <div v-if="upscaleOn" class="adv__field">
-          <label class="adv__label">Upscaler model</label>
-          <input
-            class="adv__input"
-            data-test="upscale-model"
-            placeholder="e.g. real-esrgan-x4plus"
-            :value="modelValue.upscaleModel"
-            @input="
-              patch({ upscaleModel: ($event.target as HTMLInputElement).value })
-            "
-          />
-        </div>
-      </AccordionSection>
+      <UpscaleSection
+        v-if="showUpscale"
+        :model-value="modelValue.upscaleModel"
+        @update:model-value="patch({ upscaleModel: $event })"
+      />
 
       <AccordionSection
         icon="output"

--- a/web/src/components/create/ControlsAside.test.ts
+++ b/web/src/components/create/ControlsAside.test.ts
@@ -9,12 +9,26 @@ import {
   useGenerateForm,
   __testing__,
 } from "../../composables/useGenerateForm";
-import { addHost, setGenerateTargetId } from "../../lib/hostRegistry";
+import {
+  addHost,
+  getGenerateTargetId,
+  setGenerateTargetId,
+} from "../../lib/hostRegistry";
+import { __testing__ as routingTesting } from "../../composables/useHostRouting";
+import { CAPABLE_TARGET_ID } from "../../lib/hostRouting";
 import type { GenerateFormState } from "../../types";
 
 const pushMock = vi.hoisted(() => vi.fn());
 vi.mock("vue-router", () => ({
   useRouter: () => ({ push: pushMock }),
+}));
+
+// The rail's host picker polls every registered machine. Keep the unit under
+// test off the network: no host answers, so rows render from the registry with
+// their pre-poll status.
+vi.mock("../machines/hostClient", () => ({
+  hostStatus: () => Promise.reject(new Error("offline in tests")),
+  hostModels: () => Promise.reject(new Error("offline in tests")),
 }));
 
 function baseForm(
@@ -35,6 +49,7 @@ describe("ControlsAside", () => {
   beforeEach(() => {
     localStorage.clear();
     pushMock.mockClear();
+    routingTesting.reset();
   });
   afterEach(() => __testing__.resetForTest());
 
@@ -151,31 +166,45 @@ describe("ControlsAside", () => {
     expect(last.seed).toBeNull();
   });
 
-  it("defaults the run-on row to this server with no caption", () => {
+  it("collapses the run-on row to this server with no remote machines", () => {
     const wrapper = factory();
     expect(wrapper.get("[data-test='controls-host']").text()).toContain(
-      "this server",
+      "Run on this server",
     );
-    expect(wrapper.find("[data-test='controls-host-note']").exists()).toBe(
-      false,
-    );
+    expect(wrapper.find("[data-test='host-chip']").exists()).toBe(false);
   });
 
-  it("reflects a non-origin generate target with an honest caption", () => {
-    const host = addHost({ url: "http://studio:7680", name: "Studio" });
-    setGenerateTargetId(host.id);
-    const wrapper = factory();
-    expect(wrapper.get("[data-test='controls-host']").text()).toContain(
-      "Studio",
-    );
-    expect(wrapper.get("[data-test='controls-host-note']").text()).toContain(
-      "generation runs on this server for now",
-    );
-  });
-
-  it("opens the machines workspace when the host row is clicked", async () => {
+  it("opens the machines workspace when the collapsed host row is clicked", async () => {
     const wrapper = factory();
     await wrapper.get("[data-test='controls-host']").trigger("click");
     expect(pushMock).toHaveBeenCalledWith("/machines");
+  });
+
+  it("offers the routing menu once a remote machine is registered", async () => {
+    const host = addHost({ url: "http://studio:7680", name: "Studio" });
+    const wrapper = factory();
+    await wrapper.get("[data-test='host-chip']").trigger("click");
+    expect(wrapper.find("[data-test='host-option-auto']").exists()).toBe(true);
+    expect(wrapper.find(`[data-test='host-option-${host.id}']`).exists()).toBe(
+      true,
+    );
+  });
+
+  it("persists a routing pick made from the rail", async () => {
+    addHost({ url: "http://studio:7680", name: "Studio" });
+    const wrapper = factory();
+    await wrapper.get("[data-test='host-chip']").trigger("click");
+    await wrapper.get("[data-test='host-option-capable']").trigger("click");
+    expect(getGenerateTargetId()).toBe(CAPABLE_TARGET_ID);
+  });
+
+  it("names an already-persisted sticky pick on the chip", async () => {
+    const host = addHost({ url: "http://studio:7680", name: "Studio" });
+    setGenerateTargetId(host.id);
+    const wrapper = factory();
+    await wrapper.vm.$nextTick();
+    expect(wrapper.get("[data-test='host-chip']").text()).toContain(
+      "Run on Studio",
+    );
   });
 });

--- a/web/src/components/create/ControlsAside.vue
+++ b/web/src/components/create/ControlsAside.vue
@@ -20,12 +20,8 @@ import { ASPECTS, dimsForMp } from "@ui/lib/resolution";
 import type { GenerateFormState } from "../../types";
 import { generationCapabilitiesForFamily } from "../../lib/generateCapabilities";
 import { projectResolution } from "./resolutionProjection";
-import {
-  ORIGIN_HOST_ID,
-  getGenerateTargetId,
-  getHost,
-  originHost,
-} from "../../lib/hostRegistry";
+import HostRoutingPicker from "./HostRoutingPicker.vue";
+import { useHostRouting } from "../../composables/useHostRouting";
 
 const props = withDefaults(
   defineProps<{
@@ -58,17 +54,12 @@ function reroll() {
   patch({ seedMode: "random", seed: null });
 }
 
-// Generation target row (spec §08 multi-host, light). The row reflects the
-// chosen target from the host registry (origin by default) and opens Machines
-// on click. Cross-host dispatch from the browser is a follow-up — a non-origin
-// target here is honest that generation still runs on this server for now.
+// Generation target (spec §08 multi-host). The picker owns the routing choice —
+// Auto, Most capable, or a sticky host — and the submit path in GeneratePage
+// resolves the same persisted pick through the same singleton, so what the row
+// claims and where the job lands can't drift apart.
 const router = useRouter();
-// Read once at setup — ControlsAside remounts on returning to Create, so a
-// target changed on the Machines page is picked up on the next visit.
-const targetHost = computed(
-  () => getHost(getGenerateTargetId()) ?? originHost(),
-);
-const targetIsOrigin = computed(() => targetHost.value.id === ORIGIN_HOST_ID);
+const routing = useHostRouting();
 function openMachines() {
   void router?.push("/machines");
 }
@@ -232,29 +223,12 @@ function setSeed(value: number) {
       >
     </button>
 
-    <button
-      type="button"
-      class="controls__host"
-      data-test="controls-host"
-      @click="openMachines"
-    >
-      <span
-        class="controls__dot"
-        :class="{ 'controls__dot--remote': !targetIsOrigin }"
-      />
-      <span class="controls__host-label">Run on {{ targetHost.name }}</span>
-      <span v-if="!targetIsOrigin" class="controls__host-hint">
-        opens machines
-      </span>
-      <Icon name="chevron-right" :size="14" />
-    </button>
-    <p
-      v-if="!targetIsOrigin"
-      class="controls__host-note"
-      data-test="controls-host-note"
-    >
-      generation runs on this server for now
-    </p>
+    <HostRoutingPicker
+      :hosts="routing.hosts.value"
+      :target-id="routing.targetId.value"
+      @select="routing.setTarget"
+      @open-machines="openMachines"
+    />
   </aside>
 </template>
 
@@ -356,61 +330,5 @@ function setSeed(value: number) {
   gap: 8px;
   margin-bottom: 16px;
   cursor: pointer;
-}
-
-.controls__host {
-  width: 100%;
-  border: 0;
-  border-top: 1px solid var(--edge);
-  background: transparent;
-  padding: 14px 0 0;
-  margin-top: 2px;
-  display: flex;
-  align-items: center;
-  gap: 9px;
-  cursor: pointer;
-  color: var(--ink-2);
-  text-align: left;
-}
-
-.controls__host:hover .controls__host-label {
-  color: var(--rebate);
-}
-
-.controls__host:focus-visible {
-  outline: 2px solid var(--safelight);
-  outline-offset: 2px;
-}
-
-.controls__dot {
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  background: var(--success);
-  flex: 0 0 7px;
-}
-
-.controls__dot--remote {
-  background: var(--halide);
-}
-
-.controls__host-label {
-  font-size: 12px;
-  color: var(--ink-2);
-  flex: 1;
-}
-
-.controls__host-hint {
-  font-family: var(--f-mono);
-  font-size: 9px;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--ink-3);
-}
-
-.controls__host-note {
-  margin: 8px 0 0;
-  font-size: 11px;
-  color: var(--ink-3);
 }
 </style>

--- a/web/src/components/create/HostRoutingPicker.test.ts
+++ b/web/src/components/create/HostRoutingPicker.test.ts
@@ -1,0 +1,139 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+import HostRoutingPicker from "./HostRoutingPicker.vue";
+import { ORIGIN_HOST_ID } from "../../lib/hostRegistry";
+import {
+  AUTO_TARGET_ID,
+  CAPABLE_TARGET_ID,
+  type RoutableHost,
+} from "../../lib/hostRouting";
+
+function host(overrides: Partial<RoutableHost> & { id: string }): RoutableHost {
+  return {
+    label: overrides.id,
+    url: `http://${overrides.id}:7680`,
+    status: "ready",
+    queueDepth: 0,
+    gpu: null,
+    ...overrides,
+  };
+}
+
+const origin = host({
+  id: ORIGIN_HOST_ID,
+  label: "this server",
+  url: "http://localhost:7680",
+});
+const studio = host({ id: "studio", label: "Studio", queueDepth: 3 });
+
+function factory(hosts: RoutableHost[], targetId = AUTO_TARGET_ID) {
+  return mount(HostRoutingPicker, { props: { hosts, targetId } });
+}
+
+describe("HostRoutingPicker", () => {
+  it("collapses to an honest row with only this server", () => {
+    const wrapper = factory([origin]);
+    const row = wrapper.get("[data-test='controls-host']");
+    expect(row.text()).toContain("Run on this server");
+    expect(wrapper.find("[data-test='host-chip']").exists()).toBe(false);
+    expect(wrapper.find("[data-test='host-menu']").exists()).toBe(false);
+  });
+
+  it("doorways into Machines from the collapsed row", async () => {
+    const wrapper = factory([origin]);
+    await wrapper.get("[data-test='controls-host']").trigger("click");
+    expect(wrapper.emitted("open-machines")).toHaveLength(1);
+  });
+
+  it("offers Auto, Most capable and every host once a remote is registered", async () => {
+    const wrapper = factory([origin, studio]);
+    expect(wrapper.find("[data-test='host-menu']").exists()).toBe(false);
+    await wrapper.get("[data-test='host-chip']").trigger("click");
+
+    const menu = wrapper.get("[data-test='host-menu']");
+    expect(menu.find("[data-test='host-option-auto']").exists()).toBe(true);
+    expect(menu.find("[data-test='host-option-capable']").exists()).toBe(true);
+    expect(
+      menu.get(`[data-test='host-option-${ORIGIN_HOST_ID}']`).text(),
+    ).toContain("this server");
+    expect(menu.get("[data-test='host-option-studio']").text()).toContain(
+      "Studio",
+    );
+  });
+
+  it("lists this server first", async () => {
+    const wrapper = factory([origin, studio]);
+    await wrapper.get("[data-test='host-chip']").trigger("click");
+    const rows = wrapper
+      .get("[data-test='host-menu']")
+      .findAll("[role='menuitemradio']");
+    // Auto, Most capable, then the hosts in registry order (origin first).
+    expect(rows[2]?.attributes("data-test")).toBe(
+      `host-option-${ORIGIN_HOST_ID}`,
+    );
+    expect(rows[3]?.attributes("data-test")).toBe("host-option-studio");
+  });
+
+  it("shows each host's live queue depth", async () => {
+    const wrapper = factory([origin, studio]);
+    await wrapper.get("[data-test='host-chip']").trigger("click");
+    expect(wrapper.get("[data-test='host-option-studio']").text()).toContain(
+      "queue 3",
+    );
+  });
+
+  it("emits the pick and closes the menu", async () => {
+    const wrapper = factory([origin, studio]);
+    await wrapper.get("[data-test='host-chip']").trigger("click");
+    await wrapper.get("[data-test='host-option-studio']").trigger("click");
+    expect(wrapper.emitted("select")).toEqual([["studio"]]);
+    expect(wrapper.find("[data-test='host-menu']").exists()).toBe(false);
+  });
+
+  it("emits the Most capable sentinel", async () => {
+    const wrapper = factory([origin, studio]);
+    await wrapper.get("[data-test='host-chip']").trigger("click");
+    await wrapper.get("[data-test='host-option-capable']").trigger("click");
+    expect(wrapper.emitted("select")).toEqual([[CAPABLE_TARGET_ID]]);
+  });
+
+  it("names the current pick on the chip", () => {
+    expect(factory([origin, studio], AUTO_TARGET_ID).text()).toContain(
+      "Run on Auto",
+    );
+    expect(factory([origin, studio], CAPABLE_TARGET_ID).text()).toContain(
+      "Run on Most capable",
+    );
+    expect(factory([origin, studio], "studio").text()).toContain(
+      "Run on Studio",
+    );
+  });
+
+  it("checks the current pick in the menu", async () => {
+    const wrapper = factory([origin, studio], "studio");
+    await wrapper.get("[data-test='host-chip']").trigger("click");
+    expect(
+      wrapper
+        .get("[data-test='host-option-studio']")
+        .attributes("aria-checked"),
+    ).toBe("true");
+    expect(
+      wrapper.get("[data-test='host-option-auto']").attributes("aria-checked"),
+    ).toBe("false");
+  });
+
+  it("disables an offline host and reports it as offline", async () => {
+    const offline = { ...studio, status: "error" as const };
+    const wrapper = factory([origin, offline]);
+    await wrapper.get("[data-test='host-chip']").trigger("click");
+    const row = wrapper.get("[data-test='host-option-studio']");
+    expect(row.attributes("disabled")).toBeDefined();
+    expect(row.text()).toContain("offline");
+  });
+
+  it("says a pinned host is offline on the chip rather than claiming ready", () => {
+    const offline = { ...studio, status: "error" as const };
+    const wrapper = factory([origin, offline], "studio");
+    expect(wrapper.get("[data-test='host-chip']").text()).toContain("offline");
+  });
+});

--- a/web/src/components/create/HostRoutingPicker.vue
+++ b/web/src/components/create/HostRoutingPicker.vue
@@ -1,0 +1,338 @@
+<script setup lang="ts">
+/*
+ * Generation host picker (spec §08 multi-host) — the web twin of the desktop
+ * Create header's host chip. With more than one machine registered the chip
+ * opens a routing menu: Auto (model-aware least busy), Most capable (strongest
+ * GPU), or a sticky explicit host. With only this server it collapses to an
+ * honest one-line row that doorways into Machines rather than offering an
+ * empty menu.
+ *
+ * Presentational on purpose: routing state comes in as props and the pick goes
+ * out as an event, so the decisions stay in `lib/hostRouting.ts`.
+ */
+import { computed, onBeforeUnmount, onMounted, ref } from "vue";
+import Icon from "@ui/components/Icon.vue";
+import {
+  AUTO_TARGET_ID,
+  CAPABLE_TARGET_ID,
+  type RoutableHost,
+} from "../../lib/hostRouting";
+import { ORIGIN_HOST_ID } from "../../lib/hostRegistry";
+
+const props = defineProps<{
+  hosts: RoutableHost[];
+  /** Normalized pick: "auto", "capable", or a listed host id. */
+  targetId: string;
+}>();
+
+const emit = defineEmits<{ select: [id: string]; "open-machines": [] }>();
+
+const multiHost = computed(() => props.hosts.length > 1);
+
+const pinnedHost = computed(() =>
+  props.targetId === AUTO_TARGET_ID || props.targetId === CAPABLE_TARGET_ID
+    ? null
+    : (props.hosts.find((h) => h.id === props.targetId) ?? null),
+);
+
+const originHostEntry = computed(
+  () => props.hosts.find((h) => h.id === ORIGIN_HOST_ID) ?? null,
+);
+
+const chipLabel = computed(() => {
+  if (props.targetId === AUTO_TARGET_ID)
+    return multiHost.value ? "Auto" : "this server";
+  if (props.targetId === CAPABLE_TARGET_ID) return "Most capable";
+  return (
+    pinnedHost.value?.label ?? originHostEntry.value?.label ?? "this server"
+  );
+});
+
+/** The chip's dot: green once the pick can actually take a job. */
+const chipReady = computed(() => {
+  if (
+    props.targetId === AUTO_TARGET_ID ||
+    props.targetId === CAPABLE_TARGET_ID
+  ) {
+    return props.hosts.some((h) => h.status === "ready");
+  }
+  return pinnedHost.value?.status === "ready";
+});
+
+const chipStatus = computed(() => {
+  if (
+    props.targetId === AUTO_TARGET_ID ||
+    props.targetId === CAPABLE_TARGET_ID
+  ) {
+    return chipReady.value ? "ready" : "connecting";
+  }
+  const status = pinnedHost.value?.status;
+  if (status === "ready") return "ready";
+  if (status === "error") return "offline";
+  return status ?? "connecting";
+});
+
+function hostLine(host: RoutableHost): string {
+  if (host.status === "error") return "offline";
+  if (host.status === "connecting") return "connecting";
+  return host.queueDepth !== null ? `queue ${host.queueDepth}` : "ready";
+}
+
+const open = ref(false);
+const rootEl = ref<HTMLDivElement | null>(null);
+
+function toggle() {
+  open.value = !open.value;
+}
+
+function pick(id: string) {
+  emit("select", id);
+  open.value = false;
+}
+
+function onPointerDown(event: PointerEvent) {
+  if (!open.value || !rootEl.value) return;
+  if (!event.composedPath().includes(rootEl.value)) open.value = false;
+}
+function onKeydown(event: KeyboardEvent) {
+  if (event.key === "Escape") open.value = false;
+}
+onMounted(() => {
+  document.addEventListener("pointerdown", onPointerDown);
+  document.addEventListener("keydown", onKeydown);
+});
+onBeforeUnmount(() => {
+  document.removeEventListener("pointerdown", onPointerDown);
+  document.removeEventListener("keydown", onKeydown);
+});
+</script>
+
+<template>
+  <div ref="rootEl" class="hostpick">
+    <!-- Single machine: no routing to offer, so say what is true and point at
+         Machines instead of dangling an empty menu. -->
+    <button
+      v-if="!multiHost"
+      type="button"
+      class="hostpick__row"
+      data-test="controls-host"
+      @click="emit('open-machines')"
+    >
+      <span
+        class="hostpick__dot"
+        :class="{ 'hostpick__dot--wait': !chipReady }"
+      />
+      <span class="hostpick__label">Run on {{ chipLabel }}</span>
+      <span class="hostpick__hint">add a machine</span>
+      <Icon name="chevron-right" :size="14" />
+    </button>
+
+    <template v-else>
+      <button
+        type="button"
+        class="hostpick__row hostpick__row--chip"
+        data-test="host-chip"
+        :aria-expanded="open"
+        aria-haspopup="menu"
+        @click="toggle"
+      >
+        <span
+          class="hostpick__dot"
+          :class="{ 'hostpick__dot--wait': !chipReady }"
+        />
+        <span class="hostpick__label">Run on {{ chipLabel }}</span>
+        <span class="hostpick__hint">{{ chipStatus }}</span>
+        <Icon name="chevron-down" :size="14" />
+      </button>
+
+      <div
+        v-if="open"
+        class="hostpick__menu"
+        role="menu"
+        aria-label="Generation host"
+        data-test="host-menu"
+      >
+        <div class="hostpick__kicker">run on</div>
+        <button
+          type="button"
+          role="menuitemradio"
+          class="hostpick__item"
+          data-test="host-option-auto"
+          :aria-checked="targetId === AUTO_TARGET_ID"
+          @click="pick(AUTO_TARGET_ID)"
+        >
+          <span class="hostpick__item-label">Auto</span>
+          <span class="hostpick__item-sub">least busy</span>
+          <span v-if="targetId === AUTO_TARGET_ID" class="hostpick__check"
+            >✓</span
+          >
+        </button>
+        <button
+          type="button"
+          role="menuitemradio"
+          class="hostpick__item"
+          data-test="host-option-capable"
+          :aria-checked="targetId === CAPABLE_TARGET_ID"
+          @click="pick(CAPABLE_TARGET_ID)"
+        >
+          <span class="hostpick__item-label">Most capable</span>
+          <span class="hostpick__item-sub">strongest gpu</span>
+          <span v-if="targetId === CAPABLE_TARGET_ID" class="hostpick__check"
+            >✓</span
+          >
+        </button>
+        <div class="hostpick__rule" />
+        <button
+          v-for="host in hosts"
+          :key="host.id"
+          type="button"
+          role="menuitemradio"
+          class="hostpick__item"
+          :data-test="`host-option-${host.id}`"
+          :disabled="host.status !== 'ready'"
+          :aria-checked="targetId === host.id"
+          @click="pick(host.id)"
+        >
+          <span
+            class="hostpick__dot"
+            :class="{ 'hostpick__dot--wait': host.status !== 'ready' }"
+          />
+          <span class="hostpick__item-label">{{ host.label }}</span>
+          <span class="hostpick__item-sub">{{ hostLine(host) }}</span>
+          <span v-if="targetId === host.id" class="hostpick__check">✓</span>
+        </button>
+      </div>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.hostpick {
+  position: relative;
+}
+
+.hostpick__row {
+  width: 100%;
+  border: 0;
+  border-top: 1px solid var(--edge);
+  background: transparent;
+  padding: 14px 0 0;
+  margin-top: 2px;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  cursor: pointer;
+  color: var(--ink-2);
+  text-align: left;
+}
+
+.hostpick__row:hover .hostpick__label {
+  color: var(--rebate);
+}
+
+.hostpick__row:focus-visible {
+  outline: 2px solid var(--safelight);
+  outline-offset: 2px;
+}
+
+.hostpick__dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--success);
+  flex: 0 0 7px;
+}
+
+.hostpick__dot--wait {
+  background: var(--halide);
+}
+
+.hostpick__label {
+  font-size: 12px;
+  color: var(--ink-2);
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hostpick__hint {
+  font-family: var(--f-mono);
+  font-size: 9px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+}
+
+.hostpick__menu {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 6px);
+  z-index: 30;
+  min-width: 232px;
+  padding: 7px;
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-card);
+  background: var(--bench);
+  box-shadow: var(--shadow-raised);
+}
+
+.hostpick__kicker {
+  font-family: var(--f-mono);
+  font-size: 9px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-3);
+  padding: 4px 8px 6px;
+}
+
+.hostpick__item {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  border: 0;
+  background: transparent;
+  border-radius: var(--radius-control);
+  padding: 7px 8px;
+  cursor: pointer;
+  color: var(--ink-2);
+  text-align: left;
+}
+
+.hostpick__item:hover:not(:disabled) {
+  background: var(--bath);
+}
+
+.hostpick__item:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.hostpick__item-label {
+  font-size: 12px;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hostpick__item-sub {
+  font-family: var(--f-mono);
+  font-size: 9.5px;
+  color: var(--ink-3);
+}
+
+.hostpick__check {
+  color: var(--safelight);
+  font-size: 11px;
+}
+
+.hostpick__rule {
+  height: 1px;
+  background: var(--edge);
+  margin: 6px 4px;
+}
+</style>

--- a/web/src/components/create/advanced/UpscaleSection.test.ts
+++ b/web/src/components/create/advanced/UpscaleSection.test.ts
@@ -1,0 +1,174 @@
+import { flushPromises, mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import UpscaleSection from "./UpscaleSection.vue";
+import type { ModelInfoExtended } from "../../../types";
+
+const fetchModelsMock = vi.fn();
+vi.mock("../../../api", () => ({
+  fetchModels: (...args: unknown[]) => fetchModelsMock(...args),
+}));
+
+function model(
+  name: string,
+  overrides: Partial<ModelInfoExtended> = {},
+): ModelInfoExtended {
+  return {
+    name,
+    family: "upscaler",
+    size_gb: 0.03,
+    is_loaded: false,
+    last_used: null,
+    hf_repo: "",
+    downloaded: true,
+    default_steps: 0,
+    default_guidance: 0,
+    default_width: 0,
+    default_height: 0,
+    description: "",
+    ...overrides,
+  } as ModelInfoExtended;
+}
+
+const UPSCALERS = [
+  model("real-esrgan-x4plus:fp16"),
+  model("real-esrgan-x2plus:fp16"),
+  model("real-esrgan-anime-v3:fp32", {
+    downloaded: false,
+    description: "fast anime 4x upscaler",
+  }),
+];
+
+function factory(modelValue = "", models: ModelInfoExtended[] | null = null) {
+  return mount(UpscaleSection, {
+    props: { modelValue, models },
+    global: { stubs: { RouterLink: { template: "<a><slot /></a>" } } },
+  });
+}
+
+function lastEmit(wrapper: ReturnType<typeof factory>): string | undefined {
+  const events = wrapper.emitted("update:modelValue");
+  return events?.at(-1)?.[0] as string | undefined;
+}
+
+describe("UpscaleSection", () => {
+  beforeEach(() => {
+    fetchModelsMock.mockReset();
+    fetchModelsMock.mockResolvedValue([
+      model("flux-dev:q8", { family: "flux" }),
+      ...UPSCALERS,
+    ]);
+  });
+
+  it("starts off with no picker rendered", async () => {
+    const wrapper = factory("", UPSCALERS);
+    await flushPromises();
+    expect(wrapper.find("[data-test='upscale-model']").exists()).toBe(false);
+    expect(wrapper.text()).toContain("Off");
+  });
+
+  it("selects a real upscaler when the switch is flipped on", async () => {
+    const wrapper = factory("", UPSCALERS);
+    await flushPromises();
+    await wrapper.get("[data-test='upscale-toggle']").trigger("click");
+
+    // The toggle must produce a usable value — not leave the form empty.
+    expect(lastEmit(wrapper)).toBe("real-esrgan-x2plus:fp16");
+
+    await wrapper.setProps({ modelValue: "real-esrgan-x2plus:fp16" });
+    expect(wrapper.find("[data-test='upscale-model']").exists()).toBe(true);
+  });
+
+  it("clears the model when the switch is flipped off", async () => {
+    const wrapper = factory("real-esrgan-x4plus:fp16", UPSCALERS);
+    await flushPromises();
+    expect(wrapper.find("[data-test='upscale-model']").exists()).toBe(true);
+    await wrapper.get("[data-test='upscale-toggle']").trigger("click");
+    expect(lastEmit(wrapper)).toBe("");
+  });
+
+  it("round-trips a different upscaler from the picker", async () => {
+    const wrapper = factory("real-esrgan-x4plus:fp16", UPSCALERS);
+    await flushPromises();
+    const select = wrapper.get("[data-test='upscale-model']");
+    (select.element as HTMLSelectElement).value = "real-esrgan-x2plus:fp16";
+    await select.trigger("change");
+    expect(lastEmit(wrapper)).toBe("real-esrgan-x2plus:fp16");
+  });
+
+  it("labels upscalers that are not on disk yet", async () => {
+    const wrapper = factory("real-esrgan-x4plus:fp16", UPSCALERS);
+    await flushPromises();
+    expect(wrapper.get("[data-test='upscale-model']").text()).toContain(
+      "downloads on first use",
+    );
+  });
+
+  it("shows the derived scale factor for the chosen upscaler", async () => {
+    const wrapper = factory("real-esrgan-x2plus:fp16", UPSCALERS);
+    await flushPromises();
+    expect(wrapper.get("[data-test='upscale-factor']").text()).toContain("2");
+  });
+
+  it("explains itself instead of offering a dead toggle when the host has none", async () => {
+    const wrapper = factory("", [model("flux-dev:q8", { family: "flux" })]);
+    await flushPromises();
+
+    const empty = wrapper.get("[data-test='upscale-empty']");
+    expect(empty.text().toLowerCase()).toContain("no upscalers");
+    expect(wrapper.find("[data-test='upscale-browse']").exists()).toBe(true);
+
+    const toggle = wrapper.get("[data-test='upscale-toggle']");
+    expect((toggle.element as HTMLButtonElement).disabled).toBe(true);
+    await toggle.trigger("click");
+    expect(wrapper.emitted("update:modelValue")).toBeUndefined();
+  });
+
+  it("keeps an upscaler the host does not list so the request stays visible", async () => {
+    // Reused metadata (or a host switch) can name an upscaler this listing
+    // lacks — the request still carries it, so the picker must admit that
+    // rather than showing an empty state while submitting an upscale.
+    const wrapper = factory("real-esrgan-x4plus:fp16", []);
+    await flushPromises();
+    expect(wrapper.find("[data-test='upscale-empty']").exists()).toBe(false);
+    const select = wrapper.get("[data-test='upscale-model']");
+    expect(select.text()).toContain("not listed on this server");
+    expect((select.element as HTMLSelectElement).value).toBe(
+      "real-esrgan-x4plus:fp16",
+    );
+    await wrapper.get("[data-test='upscale-toggle']").trigger("click");
+    expect(lastEmit(wrapper)).toBe("");
+  });
+
+  it("fetches the model list itself when the parent does not supply one", async () => {
+    const wrapper = factory("", null);
+    await flushPromises();
+    expect(fetchModelsMock).toHaveBeenCalled();
+    await wrapper.get("[data-test='upscale-toggle']").trigger("click");
+    expect(lastEmit(wrapper)).toBe("real-esrgan-x2plus:fp16");
+  });
+
+  it("still enables once the model list arrives after the switch is flipped", async () => {
+    let resolve: (v: ModelInfoExtended[]) => void = () => {};
+    fetchModelsMock.mockReturnValue(
+      new Promise<ModelInfoExtended[]>((r) => {
+        resolve = r;
+      }),
+    );
+    const wrapper = factory("", null);
+    await wrapper.get("[data-test='upscale-toggle']").trigger("click");
+    expect(wrapper.emitted("update:modelValue")).toBeUndefined();
+
+    resolve(UPSCALERS);
+    await flushPromises();
+    expect(lastEmit(wrapper)).toBe("real-esrgan-x2plus:fp16");
+  });
+
+  it("reports an unreachable model list rather than pretending it is empty", async () => {
+    fetchModelsMock.mockRejectedValue(new Error("offline"));
+    const wrapper = factory("", null);
+    await flushPromises();
+    expect(wrapper.get("[data-test='upscale-empty']").text()).toContain(
+      "could not read",
+    );
+  });
+});

--- a/web/src/components/create/advanced/UpscaleSection.vue
+++ b/web/src/components/create/advanced/UpscaleSection.vue
@@ -1,0 +1,230 @@
+<script setup lang="ts">
+/*
+ * "Upscale after generate" — the post-generation Real-ESRGAN pass.
+ *
+ * The switch is meaningless on its own: the wire contract is a single
+ * `GenerateRequest.upscale_model` string, so "on" has to resolve to a concrete
+ * checkpoint. Flipping it on therefore selects the host's best available
+ * upscaler straight away and reveals the picker; flipping it off clears the
+ * field. When the host publishes no upscaler at all we say so and point at
+ * Models instead of leaving a switch that does nothing.
+ *
+ * The model list is fetched here (like LoraPicker owns its catalog fetch) so
+ * the section is self-contained; a host-aware parent can pass `models` to skip
+ * the fetch and scope it to the routed machine.
+ */
+import { computed, onMounted, ref, watch } from "vue";
+import { RouterLink } from "vue-router";
+import AccordionSection from "@ui/components/AccordionSection.vue";
+import SwitchToggle from "@ui/components/SwitchToggle.vue";
+import { fetchModels } from "../../../api";
+import type { ModelInfoExtended } from "../../../types";
+import { defaultUpscaler, selectUpscalers, upscaleFactor } from "./upscalers";
+
+const props = withDefaults(
+  defineProps<{
+    /** The form's `upscaleModel` — "" means the pass is off. */
+    modelValue: string;
+    /** Pre-fetched `/api/models` rows. Null → this section fetches them. */
+    models?: ModelInfoExtended[] | null;
+  }>(),
+  { models: null },
+);
+
+const emit = defineEmits<{ "update:modelValue": [value: string] }>();
+
+const fetched = ref<ModelInfoExtended[] | null>(null);
+const failed = ref(false);
+
+onMounted(async () => {
+  if (props.models) return;
+  try {
+    fetched.value = await fetchModels();
+  } catch {
+    failed.value = true;
+    fetched.value = [];
+  }
+});
+
+/** Null until a listing (injected or fetched) has arrived. */
+const listing = computed(() => props.models ?? fetched.value);
+const loaded = computed(() => listing.value !== null);
+const upscalers = computed(() => selectUpscalers(listing.value ?? []));
+const selected = computed(() => props.modelValue.trim());
+
+/*
+ * A reused print (or a switched host) can carry an upscaler this listing does
+ * not contain. The request would still send it, so the picker keeps it as a
+ * row rather than silently disagreeing with what will be submitted.
+ */
+const options = computed(() => {
+  const rows = upscalers.value;
+  if (!selected.value || rows.some((m) => m.name === selected.value)) {
+    return rows;
+  }
+  return [{ name: selected.value, downloaded: false, unlisted: true }, ...rows];
+});
+const none = computed(
+  () => loaded.value && upscalers.value.length === 0 && !selected.value,
+);
+// "On" is intent, not just a non-empty value: the switch can be flipped before
+// the model list lands, in which case we select a default the moment it does.
+const on = ref(selected.value !== "");
+
+watch(selected, (next, previous) => {
+  if (next) on.value = true;
+  else if (previous) on.value = false; // parent cleared it (e.g. Reset)
+});
+
+watch([on, upscalers], () => {
+  if (!on.value || selected.value || upscalers.value.length === 0) return;
+  emit("update:modelValue", defaultUpscaler(upscalers.value));
+});
+
+function setOn(next: boolean) {
+  on.value = next;
+  if (!next) {
+    if (selected.value) emit("update:modelValue", "");
+    return;
+  }
+  if (!selected.value && upscalers.value.length > 0) {
+    emit("update:modelValue", defaultUpscaler(upscalers.value));
+  }
+}
+
+function optionLabel(model: {
+  name: string;
+  downloaded: boolean;
+  unlisted?: boolean;
+}): string {
+  if (model.unlisted) return `${model.name} — not listed on this server`;
+  return model.downloaded
+    ? model.name
+    : `${model.name} — downloads on first use`;
+}
+
+const factor = computed(() => {
+  const model = upscalers.value.find((m) => m.name === selected.value);
+  return model ? upscaleFactor(model) : null;
+});
+
+const summary = computed(() => {
+  if (none.value) return "No upscalers on this server";
+  if (!on.value || !selected.value) return "Off";
+  return factor.value ? `${selected.value} · ${factor.value}×` : selected.value;
+});
+
+// Body is visible whenever the pass is on (the header is a switch row, not a
+// disclosure) or when we need to explain why the switch is unavailable.
+const bodyOpen = computed(() => (on.value && loaded.value) || none.value);
+</script>
+
+<template>
+  <AccordionSection
+    icon="upscale"
+    title="Upscale after generate"
+    :summary="summary"
+    :header-interactive="false"
+    :open="bodyOpen"
+    data-test="section-upscale"
+  >
+    <template #action>
+      <SwitchToggle
+        :model-value="on"
+        :disabled="none"
+        label="Upscale after generate"
+        data-test="upscale-toggle"
+        @update:model-value="setOn"
+      />
+    </template>
+
+    <div v-if="none" class="up__empty" data-test="upscale-empty">
+      <p class="up__note">
+        {{
+          failed
+            ? "could not read this server's model list."
+            : "no upscalers installed on this server."
+        }}
+      </p>
+      <RouterLink to="/models" class="up__link" data-test="upscale-browse">
+        Pull one from Models
+      </RouterLink>
+    </div>
+
+    <div v-else class="up__field">
+      <label class="up__label" for="upscale-model-select">Upscaler model</label>
+      <select
+        id="upscale-model-select"
+        class="up__select"
+        data-test="upscale-model"
+        :value="selected"
+        @change="
+          emit('update:modelValue', ($event.target as HTMLSelectElement).value)
+        "
+      >
+        <option v-for="u in options" :key="u.name" :value="u.name">
+          {{ optionLabel(u) }}
+        </option>
+      </select>
+      <p v-if="factor" class="up__note" data-test="upscale-factor">
+        each print is enlarged {{ factor }}× after it renders.
+      </p>
+      <p v-else class="up__note" data-test="upscale-factor">
+        scale is set by the checkpoint you pick.
+      </p>
+    </div>
+  </AccordionSection>
+</template>
+
+<style scoped>
+.up__label {
+  display: block;
+  font-size: 12px;
+  color: var(--ink-2);
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+.up__select {
+  width: 100%;
+  box-sizing: border-box;
+  height: 40px;
+  background: var(--bench);
+  border: 1px solid var(--ce);
+  border-radius: var(--radius-control);
+  color: var(--rebate);
+  padding: 0 12px;
+  font-size: 13px;
+  font-family: var(--f-mono);
+}
+.up__note {
+  font-family: var(--f-mono);
+  font-size: 10.5px;
+  color: var(--ink-3);
+  margin-top: 6px;
+}
+.up__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+}
+.up__empty .up__note {
+  margin-top: 0;
+}
+.up__link {
+  border: 1px solid var(--ce);
+  border-radius: var(--radius-pill);
+  color: var(--ink-2);
+  padding: 5px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  text-decoration: none;
+  transition:
+    border-color var(--dur-quick) var(--ease),
+    color var(--dur-quick) var(--ease);
+}
+.up__link:hover {
+  border-color: var(--safelight);
+  color: var(--rebate);
+}
+</style>

--- a/web/src/components/create/advanced/upscalers.test.ts
+++ b/web/src/components/create/advanced/upscalers.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import type { ModelInfoExtended } from "../../../types";
+import {
+  defaultUpscaler,
+  isUpscalerModel,
+  selectUpscalers,
+  upscaleFactor,
+} from "./upscalers";
+
+function model(
+  name: string,
+  overrides: Partial<ModelInfoExtended> = {},
+): ModelInfoExtended {
+  return {
+    name,
+    family: "upscaler",
+    size_gb: 0.03,
+    is_loaded: false,
+    last_used: null,
+    hf_repo: "",
+    downloaded: false,
+    default_steps: 0,
+    default_guidance: 0,
+    default_width: 0,
+    default_height: 0,
+    description: "",
+    ...overrides,
+  } as ModelInfoExtended;
+}
+
+describe("upscaler model selection", () => {
+  it("recognises the server's upscaler family", () => {
+    expect(isUpscalerModel(model("real-esrgan-x4plus:fp16"))).toBe(true);
+    // Older/remote servers that tag the family differently still match on name.
+    expect(
+      isUpscalerModel(model("Real-ESRGAN-x2plus", { family: "real-esrgan" })),
+    ).toBe(true);
+    expect(isUpscalerModel(model("flux-dev:q8", { family: "flux" }))).toBe(
+      false,
+    );
+  });
+
+  it("keeps downloaded upscalers first, then sorts by name", () => {
+    const picked = selectUpscalers([
+      model("flux-dev:q8", { family: "flux" }),
+      model("real-esrgan-x4plus:fp32"),
+      model("real-esrgan-x2plus:fp16", { downloaded: true }),
+      model("real-esrgan-x4plus:fp16", { downloaded: true }),
+    ]).map((m) => m.name);
+
+    expect(picked).toEqual([
+      "real-esrgan-x2plus:fp16",
+      "real-esrgan-x4plus:fp16",
+      "real-esrgan-x4plus:fp32",
+    ]);
+  });
+
+  it("defaults to a downloaded upscaler, and to none when the host has none", () => {
+    expect(
+      defaultUpscaler([
+        model("real-esrgan-x4plus:fp32", { downloaded: true }),
+        model("real-esrgan-x2plus:fp16"),
+      ]),
+    ).toBe("real-esrgan-x4plus:fp32");
+    expect(defaultUpscaler([model("flux-dev:q8", { family: "flux" })])).toBe(
+      "",
+    );
+  });
+
+  it("defaults to the smallest scale when several upscalers are on disk", () => {
+    // 4× quadruples the canvas; 2× is the conservative first choice.
+    expect(
+      defaultUpscaler([
+        model("real-esrgan-x4plus:fp16", { downloaded: true }),
+        model("real-esrgan-x2plus:fp16", { downloaded: true }),
+      ]),
+    ).toBe("real-esrgan-x2plus:fp16");
+  });
+
+  it("derives the scale factor from the model name or description", () => {
+    expect(upscaleFactor(model("real-esrgan-x4plus:fp16"))).toBe(4);
+    expect(upscaleFactor(model("real-esrgan-x2plus:fp32"))).toBe(2);
+    expect(
+      upscaleFactor(
+        model("real-esrgan-anime-v3:fp32", {
+          description: "Real-ESRGAN Anime Video v3 FP32 — fast anime 4x",
+        }),
+      ),
+    ).toBe(4);
+    expect(upscaleFactor(model("mystery-upscaler:fp16"))).toBe(null);
+  });
+});

--- a/web/src/components/create/advanced/upscalers.ts
+++ b/web/src/components/create/advanced/upscalers.ts
@@ -1,0 +1,73 @@
+/*
+ * Post-generate upscalers — pure selection helpers shared by the Advanced
+ * "Upscale after generate" section and its tests.
+ *
+ * The server publishes upscalers through the same `/api/models` listing as
+ * generation models, tagged `family: "upscaler"` (Real-ESRGAN today). They are
+ * never runnable as generators, so every other model surface filters them out
+ * (`isStandaloneGenerationModel`); this module is the inverse view.
+ *
+ * `GenerateRequest.upscale_model` is the ONLY wire field — there is no separate
+ * factor. The scale is a property of the chosen checkpoint (x4plus → 4×), so we
+ * derive it for display instead of inventing a control the server would ignore.
+ */
+import type { ModelInfoExtended } from "../../../types";
+
+const UPSCALER_FAMILIES = new Set(["upscaler", "real-esrgan", "realesrgan"]);
+const UPSCALER_NAME = /real[-_ ]?esrgan|upscal(e|er|ing)/i;
+
+/** True when a `/api/models` row is a post-generate upscaler. */
+export function isUpscalerModel(model: ModelInfoExtended): boolean {
+  if (UPSCALER_FAMILIES.has(model.family.toLowerCase())) return true;
+  return UPSCALER_NAME.test(model.name);
+}
+
+/**
+ * The upscalers in a model listing, on-disk ones first (they run without a
+ * download) and name-sorted within each group.
+ */
+export function selectUpscalers(
+  models: ModelInfoExtended[],
+): ModelInfoExtended[] {
+  return models
+    .filter(isUpscalerModel)
+    .slice()
+    .sort((a, b) => {
+      if (a.downloaded !== b.downloaded) return a.downloaded ? -1 : 1;
+      return a.name.localeCompare(b.name);
+    });
+}
+
+/**
+ * Model name to select when the switch is flipped on. Prefers an on-disk
+ * upscaler (no download stall), then the smallest known scale factor — 2× is
+ * the conservative enlargement, 4× quadruples the canvas and the VRAM the
+ * post-pass needs. `""` when the host has none, which the section renders as
+ * an explicit empty state instead of a dead switch.
+ */
+export function defaultUpscaler(models: ModelInfoExtended[]): string {
+  const ranked = selectUpscalers(models)
+    .slice()
+    .sort((a, b) => {
+      if (a.downloaded !== b.downloaded) return a.downloaded ? -1 : 1;
+      const fa = upscaleFactor(a) ?? Number.POSITIVE_INFINITY;
+      const fb = upscaleFactor(b) ?? Number.POSITIVE_INFINITY;
+      if (fa !== fb) return fa - fb;
+      return a.name.localeCompare(b.name);
+    });
+  return ranked[0]?.name ?? "";
+}
+
+/**
+ * Scale factor implied by the checkpoint (`…-x4plus:fp16` → 4). Falls back to
+ * the manifest description (`"fast anime 4x upscaler"`) for names that do not
+ * carry it, and returns null rather than guessing.
+ */
+export function upscaleFactor(model: ModelInfoExtended): number | null {
+  const fromName = model.name.match(/[-_ ]x(\d+(?:\.\d+)?)/i)?.[1];
+  if (fromName) return Number(fromName);
+  const fromDescription = (model.description ?? "").match(
+    /(\d+(?:\.\d+)?)\s*x\b/i,
+  )?.[1];
+  return fromDescription ? Number(fromDescription) : null;
+}

--- a/web/src/components/shell/DownloadsBody.vue
+++ b/web/src/components/shell/DownloadsBody.vue
@@ -2,10 +2,12 @@
 /*
  * Downloads panel body (spec §06, prototype web downloads popover). Three
  * sections — Downloading (name · % · progress bar · rate/eta), Queued, and a
- * divider then Recently installed (✓ · name · size). Cancel on active/queued,
+ * divider then Recently installed (status glyph · name · size). Cancel on
+ * active/queued,
  * retry on a failed history row. Presentational: the parent owns the download
  * state and wraps this in either an anchored panel or a bottom sheet.
  */
+import Icon from "@ui/components/Icon.vue";
 import ProgressBar from "@ui/components/ProgressBar.vue";
 import type { DownloadJobWire } from "../../types";
 
@@ -86,7 +88,7 @@ const isEmpty = () =>
             :aria-label="`Cancel ${job.model}`"
             @click="emit('cancel', job.id)"
           >
-            ✕
+            <Icon name="close" :size="12" />
           </button>
         </div>
         <ProgressBar :value="pct(job)" tone="accent" :height="6" />
@@ -116,7 +118,7 @@ const isEmpty = () =>
           :aria-label="`Cancel queued ${job.model}`"
           @click="emit('cancel', job.id)"
         >
-          ✕
+          <Icon name="close" :size="12" />
         </button>
       </div>
     </template>
@@ -139,7 +141,8 @@ const isEmpty = () =>
               job.status === 'failed' || job.status === 'cancelled',
           }"
         >
-          {{ job.status === "completed" ? "✓" : "!" }}
+          <Icon v-if="job.status === 'completed'" name="check" :size="12" />
+          <Icon v-else name="close" :size="12" />
         </span>
         <span class="dl-row__name">{{ job.model }}</span>
         <span v-if="job.status === 'completed'" class="dl-row__meta">
@@ -274,8 +277,10 @@ const isEmpty = () =>
 
 .dl-glyph {
   flex: 0 0 auto;
-  font-size: 12px;
+  display: inline-flex;
+  align-items: center;
   line-height: 1;
+  color: var(--ink-3);
 }
 
 .dl-glyph--ok {
@@ -289,6 +294,8 @@ const isEmpty = () =>
 /* ── Actions ────────────────────────────────────────────────────────── */
 .dl-cancel {
   flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
   border: 0;
   background: transparent;
   color: var(--ink-3);

--- a/web/src/components/shell/DownloadsPopover.test.ts
+++ b/web/src/components/shell/DownloadsPopover.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { mount } from "@vue/test-utils";
+import { flushPromises, mount } from "@vue/test-utils";
 import DownloadsPopover from "./DownloadsPopover.vue";
 
 const makeJob = (over: Record<string, unknown> = {}) => ({
@@ -126,5 +126,56 @@ describe("DownloadsPopover", () => {
   it("shows an empty message when there is nothing to show", () => {
     const wrapper = mountPopover({});
     expect(wrapper.text()).toContain("No downloads yet");
+  });
+});
+
+function baseProps() {
+  return {
+    open: true,
+    active: [],
+    queued: [],
+    history: [],
+    etaByJob: {},
+    rateByJob: {},
+  };
+}
+
+describe("DownloadsPopover dismissal", () => {
+  it("closes on Escape from anywhere, not just when focus is inside it", async () => {
+    // The handler used to sit on the <aside>, which never receives key events
+    // because opening the popover doesn't focus it — so Escape did nothing.
+    const w = mount(DownloadsPopover, { props: baseProps() });
+    await flushPromises();
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    await flushPromises();
+    expect(w.emitted("close")).toBeTruthy();
+    w.unmount();
+  });
+
+  it("closes when clicking outside the panel", async () => {
+    const w = mount(DownloadsPopover, {
+      props: baseProps(),
+      attachTo: document.body,
+    });
+    await flushPromises();
+    document.body.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    await flushPromises();
+    expect(w.emitted("close")).toBeTruthy();
+    w.unmount();
+  });
+
+  it("stays open when clicking inside the panel", async () => {
+    const w = mount(DownloadsPopover, {
+      props: baseProps(),
+      attachTo: document.body,
+    });
+    await flushPromises();
+    const panel = w.get("[data-test='downloads-popover']");
+    (panel.element as HTMLElement).dispatchEvent(
+      new MouseEvent("mousedown", { bubbles: true }),
+    );
+    await flushPromises();
+    expect(w.emitted("close")).toBeFalsy();
+    w.unmount();
   });
 });

--- a/web/src/components/shell/DownloadsPopover.vue
+++ b/web/src/components/shell/DownloadsPopover.vue
@@ -6,12 +6,13 @@
  * `mold:open-downloads` window event (App owns the state); the AppNav button
  * and ⌘K palette both dispatch it.
  */
-import { onBeforeUnmount, onMounted, ref } from "vue";
+import { onBeforeUnmount, onMounted, ref, watch } from "vue";
 import SheetPanel from "@ui/components/SheetPanel.vue";
+import Icon from "@ui/components/Icon.vue";
 import DownloadsBody from "./DownloadsBody.vue";
 import type { DownloadJobWire } from "../../types";
 
-defineProps<{
+const props = defineProps<{
   open: boolean;
   active: DownloadJobWire[];
   queued: DownloadJobWire[];
@@ -26,6 +27,30 @@ const emit = defineEmits<{
   (e: "retry", model: string): void;
 }>();
 
+// Dismissal. The Escape handler must live on the document, not on the panel:
+// opening the popover doesn't move focus into it, so a keydown bound to the
+// element itself never fires. Outside-click uses mousedown so a drag that ends
+// outside doesn't count as "clicking away".
+const panelEl = ref<HTMLElement | null>(null);
+
+function onKeydown(e: KeyboardEvent) {
+  if (e.key === "Escape") emit("close");
+}
+function onPointerDownOutside(e: MouseEvent) {
+  const target = e.target as Node | null;
+  if (target && panelEl.value?.contains(target)) return;
+  emit("close");
+}
+
+function bindDismiss() {
+  document.addEventListener("keydown", onKeydown);
+  document.addEventListener("mousedown", onPointerDownOutside);
+}
+function unbindDismiss() {
+  document.removeEventListener("keydown", onKeydown);
+  document.removeEventListener("mousedown", onPointerDownOutside);
+}
+
 // Bottom-sheet only on phones; anchored panel everywhere else. Default to the
 // anchored panel when matchMedia is unavailable (jsdom / SSR).
 const isNarrow = ref(false);
@@ -33,6 +58,12 @@ let mql: MediaQueryList | null = null;
 function sync() {
   isNarrow.value = mql?.matches ?? false;
 }
+
+watch(
+  () => props.open,
+  (open) => (open ? bindDismiss() : unbindDismiss()),
+  { immediate: true },
+);
 
 onMounted(() => {
   if (typeof window.matchMedia === "function") {
@@ -42,6 +73,7 @@ onMounted(() => {
   }
 });
 onBeforeUnmount(() => {
+  unbindDismiss();
   mql?.removeEventListener?.("change", sync);
 });
 </script>
@@ -71,7 +103,7 @@ onBeforeUnmount(() => {
     role="dialog"
     aria-label="Downloads"
     data-test="downloads-popover"
-    @keydown.escape="emit('close')"
+    ref="panelEl"
   >
     <header class="dl-pop__head">
       <span class="dl-pop__title">Downloads</span>
@@ -81,7 +113,7 @@ onBeforeUnmount(() => {
         aria-label="Close downloads"
         @click="emit('close')"
       >
-        ✕
+        <Icon name="close" :size="14" />
       </button>
     </header>
     <DownloadsBody

--- a/web/src/composables/useCatalog.test.ts
+++ b/web/src/composables/useCatalog.test.ts
@@ -73,6 +73,39 @@ function installFetchMock(opts: { total: number; pageSize: number }) {
   }) as typeof fetch;
 }
 
+/**
+ * Serves a fixed list of pages whose rows carry the given modalities, so a
+ * test can describe "page 1 is all image, page 2 has two video rows" and
+ * exercise the client-side modality filter across page boundaries.
+ */
+function installModalityFetchMock(opts: { pages: string[][] }) {
+  const total = opts.pages.reduce((n, p) => n + p.length, 0);
+  globalThis.fetch = vi.fn().mockImplementation(async (url: string) => {
+    if (url.startsWith("/api/catalog/families")) {
+      return { ok: true, json: async () => ({ families: [] }) };
+    }
+    if (url.startsWith("/api/catalog/search")) {
+      const params = new URL(url, "http://localhost").searchParams;
+      const page = Number(params.get("page") ?? "1");
+      const rows = opts.pages[page - 1] ?? [];
+      const offset = opts.pages
+        .slice(0, page - 1)
+        .reduce((n, p) => n + p.length, 0);
+      const entries = rows.map((modality, i) => ({
+        ...makePageEntries(1, 1)[0],
+        id: `hf:row-${offset + i}`,
+        name: `Row ${offset + i}`,
+        modality,
+      }));
+      return {
+        ok: true,
+        json: async () => ({ entries, page, page_size: 48, total }),
+      };
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  }) as typeof fetch;
+}
+
 beforeEach(() => {
   __resetCatalogSingletonForTests();
   installFetchMock({ total: 1, pageSize: 48 });
@@ -89,6 +122,18 @@ describe("useCatalog", () => {
     await cat.refresh();
     expect(cat.entries.value.length).toBe(1);
     expect(cat.families.value[0].family).toBe("flux");
+  });
+
+  it("states include_nsfw=false by default so the unchecked box matches the server", async () => {
+    // `GET /api/catalog/search` treats a missing `include_nsfw` as *true*.
+    // Leaving it out of the default filter meant the topbar rendered an
+    // unchecked box over an NSFW-inclusive result set.
+    const cat = useCatalog();
+    await cat.refresh();
+    const searchUrl = (globalThis.fetch as any).mock.calls
+      .map((c: any[]) => c[0] as string)
+      .find((u: string) => u.startsWith("/api/catalog/search"));
+    expect(searchUrl).toContain("include_nsfw=false");
   });
 
   it("setFilter triggers a re-fetch", async () => {
@@ -256,6 +301,65 @@ describe("useCatalog", () => {
   });
 });
 
+describe("useCatalog modality filter", () => {
+  // `GET /api/catalog/search` has no `modality` parameter — Axum drops it
+  // silently, so the Image/Video chips filtered nothing. Every entry does
+  // carry a `modality`, so the filter is applied to the fetched rows.
+  it("narrows visibleEntries to the selected modality", async () => {
+    installModalityFetchMock({ pages: [["image", "video", "image", "video"]] });
+    const cat = useCatalog();
+    cat.setFilter({ modality: "video" });
+    await cat.refresh();
+    expect(cat.entries.value.length).toBe(4);
+    expect(cat.visibleEntries.value.map((e) => e.id)).toEqual([
+      "hf:row-1",
+      "hf:row-3",
+    ]);
+  });
+
+  it("leaves visibleEntries untouched when no modality is selected", async () => {
+    installModalityFetchMock({ pages: [["image", "video"]] });
+    const cat = useCatalog();
+    await cat.refresh();
+    expect(cat.visibleEntries.value.length).toBe(2);
+  });
+
+  it("layers on top of the server-side filters instead of replacing them", async () => {
+    // The regression the user hit was combinational: picking Video alongside
+    // a kind/source must keep sending those to the server and only then
+    // narrow by modality locally.
+    installModalityFetchMock({ pages: [["image", "video"]] });
+    const cat = useCatalog();
+    cat.setFilter({ modality: "video", kind: "lora", source: "civitai" });
+    await cat.refresh();
+    const url = (globalThis.fetch as any).mock.calls
+      .map((c: any[]) => c[0] as string)
+      .find((u: string) => u.startsWith("/api/catalog/search"));
+    expect(url).toContain("kind=lora");
+    expect(url).toContain("source=civitai");
+    expect(url).toContain("include_nsfw=false");
+    expect(cat.visibleEntries.value.map((e) => e.id)).toEqual(["hf:row-1"]);
+  });
+
+  it("resultCount reports the surviving rows while a modality filter is on", async () => {
+    installModalityFetchMock({ pages: [["image", "video", "image"]] });
+    const cat = useCatalog();
+    cat.setFilter({ modality: "video" });
+    await cat.refresh();
+    // The server total (3) describes the unfiltered feed and would overstate
+    // what the grid actually shows.
+    expect(cat.total.value).toBe(3);
+    expect(cat.resultCount.value).toBe(1);
+  });
+
+  it("resultCount reports the server total when no modality filter is on", async () => {
+    installFetchMock({ total: 130, pageSize: 48 });
+    const cat = useCatalog();
+    await cat.refresh();
+    expect(cat.resultCount.value).toBe(130);
+  });
+});
+
 describe("useCatalog infinite scroll", () => {
   it("exposes total and hasMore from the list response", async () => {
     installFetchMock({ total: 130, pageSize: 48 });
@@ -304,6 +408,41 @@ describe("useCatalog infinite scroll", () => {
     await new Promise((r) => setTimeout(r, 300)); // past debounce
     expect(cat.entries.value.length).toBe(48);
     expect(cat.entries.value[0].id).toBe("hf:row-0");
+  });
+
+  it("keeps fetching while a modality filter hides every row of a page", async () => {
+    // Client-side filtering after a paged fetch can hide an entire page. The
+    // grid must not settle on "No models found." while the server still has
+    // pages left — keep pulling until something survives or the feed ends.
+    installModalityFetchMock({
+      pages: [
+        Array(48).fill("image"),
+        Array(48).fill("image"),
+        ["video", "image", "video"],
+      ],
+    });
+    const cat = useCatalog();
+    cat.setFilter({ modality: "video" });
+    await cat.refresh();
+    expect(cat.visibleEntries.value.length).toBe(2);
+    expect(cat.visibleEntries.value.every((e) => e.modality === "video")).toBe(
+      true,
+    );
+  });
+
+  it("stops auto-filling once the feed is exhausted instead of looping", async () => {
+    installModalityFetchMock({
+      pages: [Array(48).fill("image"), Array(20).fill("image")],
+    });
+    const cat = useCatalog();
+    cat.setFilter({ modality: "video" });
+    await cat.refresh();
+    expect(cat.visibleEntries.value.length).toBe(0);
+    expect(cat.hasMore.value).toBe(false);
+    const calls = (globalThis.fetch as any).mock.calls.filter((c: any[]) =>
+      (c[0] as string).startsWith("/api/catalog/search"),
+    );
+    expect(calls.length).toBe(2);
   });
 
   it("concurrent loadMore calls do not double-fetch the same page", async () => {

--- a/web/src/composables/useCatalog.ts
+++ b/web/src/composables/useCatalog.ts
@@ -74,7 +74,10 @@ type CatalogFilter = Omit<CatalogListParams, "page" | "page_size">;
 let singleton: ReturnType<typeof build> | null = null;
 
 function build() {
-  const filter = ref<CatalogFilter>({ sort: "downloads" });
+  // `include_nsfw` is spelled out because the server defaults a missing one
+  // to true — leaving it unset put the topbar's unchecked box over an
+  // NSFW-inclusive result set.
+  const filter = ref<CatalogFilter>({ sort: "downloads", include_nsfw: false });
   const page = ref(1);
   const entries = ref<CatalogEntryWire[]>([]);
   const total = ref<number | null>(null);
@@ -108,7 +111,60 @@ function build() {
     return entries.value.length % PAGE_SIZE === 0;
   });
 
+  // `modality` is the one filter the server has no parameter for — Axum
+  // drops it, so the Image/Video chips narrowed nothing. Every entry carries
+  // its own `modality` (derived upstream from the family), so it is applied
+  // to the rows we already hold. It is still sent on the request: today the
+  // server ignores it, and the day it grows a `modality` parameter this
+  // becomes a pass-through rather than something to remember to re-wire.
+  const visibleEntries = computed(() => {
+    const m = filter.value.modality;
+    if (!m) return entries.value;
+    return entries.value.filter((e) => e.modality === m);
+  });
+
+  /** Rows the grid actually shows. The server total describes the unfiltered
+   * feed, so it overstates the grid whenever a client-side filter is on. */
+  const resultCount = computed(() => {
+    if (filter.value.modality) return visibleEntries.value.length;
+    if (total.value !== null) return total.value;
+    return entries.value.length;
+  });
+
+  // Bounds `autoFill` so a feed that never yields a matching row can't spin
+  // through every page — the grid settles on its empty state instead.
+  const AUTO_FILL_MAX_PAGES = 10;
+
   let debounceHandle: ReturnType<typeof setTimeout> | null = null;
+
+  /** Fetch the page after the current one. Returns false when there was
+   * nothing left to fetch, so callers can tell progress from exhaustion. */
+  async function fetchNextPage(): Promise<boolean> {
+    if (!hasMore.value) return false;
+    const next = page.value + 1;
+    const list = await fetchCatalogSearch({
+      ...filter.value,
+      page: next,
+      page_size: PAGE_SIZE,
+    });
+    entries.value = [...entries.value, ...list.entries];
+    page.value = next;
+    if (typeof list.total === "number") total.value = list.total;
+    return list.entries.length > 0;
+  }
+
+  /** Client-side filtering can hide a whole page. Keep pulling pages while
+   * the visible set is empty so the user never sees "No models found." over
+   * a feed the server still has rows for. Runs with `loading`/`loadingMore`
+   * still set, so the grid shows its loading state rather than flashing an
+   * empty one. */
+  async function autoFill() {
+    if (!filter.value.modality) return;
+    for (let i = 0; i < AUTO_FILL_MAX_PAGES; i += 1) {
+      if (visibleEntries.value.length > 0 || !hasMore.value) return;
+      if (!(await fetchNextPage())) return;
+    }
+  }
 
   async function refresh() {
     loading.value = true;
@@ -122,6 +178,7 @@ function build() {
       total.value = typeof list.total === "number" ? list.total : null;
       page.value = 1;
       families.value = fams.families;
+      await autoFill();
     } catch (e: unknown) {
       errorMsg.value = e instanceof Error ? e.message : String(e);
     } finally {
@@ -134,15 +191,8 @@ function build() {
     if (!hasMore.value) return;
     loadingMore.value = true;
     try {
-      const next = page.value + 1;
-      const list = await fetchCatalogSearch({
-        ...filter.value,
-        page: next,
-        page_size: PAGE_SIZE,
-      });
-      entries.value = [...entries.value, ...list.entries];
-      page.value = next;
-      if (typeof list.total === "number") total.value = list.total;
+      await fetchNextPage();
+      await autoFill();
     } catch (e: unknown) {
       errorMsg.value = e instanceof Error ? e.message : String(e);
     } finally {
@@ -321,6 +371,8 @@ function build() {
     filter,
     page,
     entries,
+    visibleEntries,
+    resultCount,
     total,
     hasMore,
     families,

--- a/web/src/composables/useGenerateStream.test.ts
+++ b/web/src/composables/useGenerateStream.test.ts
@@ -11,7 +11,12 @@ import type {
   SseCompleteEvent,
 } from "../types";
 import type { ChainRoutingDecision } from "../lib/chainRouting";
-import type { ChainStreamHandlers, GenerateStreamHandlers } from "../api";
+import type {
+  ChainStreamHandlers,
+  GenerateStreamHandlers,
+  StreamTarget,
+} from "../api";
+import type { HostRoute } from "../lib/hostRouting";
 
 // Capture the most recent handlers passed into `generateStream` /
 // `generateChainStream` so each test can drive the SSE lifecycle (complete /
@@ -19,6 +24,10 @@ import type { ChainStreamHandlers, GenerateStreamHandlers } from "../api";
 // resolve immediately — no network.
 let lastSingleHandlers: GenerateStreamHandlers | null = null;
 let lastChainHandlers: ChainStreamHandlers | null = null;
+// The dispatch target the singleton threaded through — `undefined` means the
+// submission was never routed and lands on the serving origin.
+let lastSingleTarget: StreamTarget | undefined;
+let lastChainTarget: StreamTarget | undefined;
 
 vi.mock("../api", () => ({
   generateStream: vi.fn(
@@ -26,8 +35,10 @@ vi.mock("../api", () => ({
       _req: GenerateRequestWire,
       handlers: GenerateStreamHandlers,
       _signal?: AbortSignal,
+      target?: StreamTarget,
     ) => {
       lastSingleHandlers = handlers;
+      lastSingleTarget = target;
       return Promise.resolve();
     },
   ),
@@ -36,8 +47,10 @@ vi.mock("../api", () => ({
       _req: ChainRequestWire,
       handlers: ChainStreamHandlers,
       _signal?: AbortSignal,
+      target?: StreamTarget,
     ) => {
       lastChainHandlers = handlers;
+      lastChainTarget = target;
       return Promise.resolve();
     },
   ),
@@ -506,5 +519,102 @@ describe("auto-remove completed jobs", () => {
     expect(stream.jobs.value.find((j) => j.id === id)?.state).toBe("done");
     vi.advanceTimersByTime(__testing__.AUTO_REMOVE_DONE_MS + 1);
     expect(stream.jobs.value.find((j) => j.id === id)).toBeUndefined();
+  });
+});
+
+describe("useGenerateStream host routing", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    lastSingleTarget = undefined;
+    lastChainTarget = undefined;
+  });
+
+  const studioRoute: HostRoute = {
+    hostId: "studio",
+    label: "Studio",
+    target: { baseUrl: "http://studio:7680", apiKey: "sk-studio" },
+  };
+
+  it("dispatches a single-clip submission to the routed host with its key", () => {
+    const stream = useGenerateStream();
+    stream.submit(singleGen({ frames: 1 }), { kind: "single" }, studioRoute);
+    expect(lastSingleTarget).toEqual({
+      baseUrl: "http://studio:7680",
+      apiKey: "sk-studio",
+    });
+  });
+
+  it("dispatches an auto-promoted chain submission to the routed host", () => {
+    const stream = useGenerateStream();
+    stream.submit(singleGen({ frames: 241 }), chainDecision(), studioRoute);
+    expect(lastChainTarget).toEqual({
+      baseUrl: "http://studio:7680",
+      apiKey: "sk-studio",
+    });
+  });
+
+  it("leaves the target undefined when no route is supplied (origin)", () => {
+    const stream = useGenerateStream();
+    stream.submit(singleGen({ frames: 1 }), { kind: "single" });
+    expect(lastSingleTarget).toBeUndefined();
+  });
+
+  it("attributes the job to the host it was routed to", () => {
+    const stream = useGenerateStream();
+    const id = stream.submit(
+      singleGen({ frames: 1 }),
+      { kind: "single" },
+      studioRoute,
+    );
+    const job = stream.jobs.value.find((j) => j.id === id);
+    expect(job?.hostId).toBe("studio");
+    expect(job?.hostLabel).toBe("Studio");
+  });
+
+  it("leaves an unrouted job unattributed rather than guessing", () => {
+    const stream = useGenerateStream();
+    const id = stream.submit(singleGen({ frames: 1 }), { kind: "single" });
+    const job = stream.jobs.value.find((j) => j.id === id);
+    expect(job?.hostId).toBeNull();
+    expect(job?.hostLabel).toBeNull();
+  });
+
+  it("round-trips the host attribution through persistence", () => {
+    const restored = __testing__.loadPersistedJobs(
+      JSON.stringify([
+        {
+          id: "j1",
+          request: singleGen({ frames: 1 }),
+          startedAt: 1,
+          progress: null,
+          result: null,
+          error: null,
+          state: "done",
+          chain: null,
+          hostId: "studio",
+          hostLabel: "Studio",
+        },
+      ]),
+    );
+    expect(restored[0]?.hostId).toBe("studio");
+    expect(restored[0]?.hostLabel).toBe("Studio");
+  });
+
+  it("reads a pre-routing persisted payload as unattributed", () => {
+    const restored = __testing__.loadPersistedJobs(
+      JSON.stringify([
+        {
+          id: "j1",
+          request: singleGen({ frames: 1 }),
+          startedAt: 1,
+          progress: null,
+          result: null,
+          error: null,
+          state: "done",
+          chain: null,
+        },
+      ]),
+    );
+    expect(restored[0]?.hostId).toBeNull();
   });
 });

--- a/web/src/composables/useGenerateStream.ts
+++ b/web/src/composables/useGenerateStream.ts
@@ -9,6 +9,7 @@ import type {
   SseProgressEvent,
 } from "../types";
 import type { ChainRoutingDecision } from "../lib/chainRouting";
+import type { HostRoute } from "../lib/hostRouting";
 
 export interface JobProgress {
   stage: string;
@@ -47,6 +48,13 @@ export interface Job {
    * quiet for a long time, so stale-stream warnings must stay suppressed
    * until this flips. */
   workStarted: boolean;
+  /** Registry id of the host this job was dispatched to, and that host's
+   * label. `null` for submissions that were never routed (single-host web, or
+   * jobs persisted before routing existed) — those ran on the origin. Carried
+   * so the activity strip and the result caption can attribute the print to
+   * the machine that actually rendered it. */
+  hostId: string | null;
+  hostLabel: string | null;
   /** Server-assigned UUID, captured from the first `queued` SSE event.
    * `null` until that event arrives (e.g. between submit and HTTP
    * handshake), and stays `null` against legacy servers that predate
@@ -278,6 +286,7 @@ export interface UseGenerateStream {
   submit: (
     req: GenerateRequestWire | ChainRequestWire,
     decision?: ChainRoutingDecision,
+    route?: HostRoute | null,
   ) => string;
   cancel: (id: string) => void;
   clearDone: () => void;
@@ -326,6 +335,9 @@ interface PersistedJob {
   lastProgressAt?: number;
   /** Optional — pre-queue-stale-fix payloads don't carry workStarted. */
   workStarted?: boolean;
+  /** Optional — pre-routing payloads don't carry a host. */
+  hostId?: string | null;
+  hostLabel?: string | null;
   /** Optional — pre-L3 payloads don't carry a serverId. */
   serverId?: string | null;
 }
@@ -389,6 +401,8 @@ function loadPersistedJobs(raw: string | null): Job[] {
         chain: p.chain,
         lastProgressAt: p.lastProgressAt ?? p.startedAt,
         workStarted: p.workStarted ?? state !== "running",
+        hostId: p.hostId ?? null,
+        hostLabel: p.hostLabel ?? null,
         serverId: p.serverId ?? null,
       };
     });
@@ -420,6 +434,8 @@ function persistJobs(jobs: Job[]) {
       chain: j.chain,
       lastProgressAt: j.lastProgressAt,
       workStarted: j.workStarted,
+      hostId: j.hostId,
+      hostLabel: j.hostLabel,
       serverId: j.serverId,
     }));
     localStorage.setItem(STORAGE_KEY, JSON.stringify(serializable));
@@ -520,6 +536,7 @@ export const __testing__ = {
 function submitJob(
   req: GenerateRequestWire | ChainRequestWire,
   decision: ChainRoutingDecision = { kind: "single" },
+  route: HostRoute | null = null,
 ): string {
   const id = crypto.randomUUID();
   const controller = new AbortController();
@@ -549,6 +566,8 @@ function submitJob(
       : null,
     lastProgressAt: now,
     workStarted: false,
+    hostId: route?.hostId ?? null,
+    hostLabel: route?.label ?? null,
     serverId: null,
   }) as Job;
   jobs.value = [job, ...jobs.value];
@@ -588,6 +607,7 @@ function submitJob(
         onError: onErrorCommon,
       },
       controller.signal,
+      route?.target,
     );
   } else if (isPrebuiltChainRequest(req)) {
     // Caller bug: a stages-based ChainRequestWire was submitted with a
@@ -613,6 +633,7 @@ function submitJob(
         onError: onErrorCommon,
       },
       controller.signal,
+      route?.target,
     );
   }
 

--- a/web/src/composables/useHostRouting.test.ts
+++ b/web/src/composables/useHostRouting.test.ts
@@ -1,0 +1,301 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { __testing__, useHostRouting } from "./useHostRouting";
+import {
+  addHost,
+  ORIGIN_HOST_ID,
+  setGenerateTargetId,
+} from "../lib/hostRegistry";
+import { AUTO_TARGET_ID, CAPABLE_TARGET_ID } from "../lib/hostRouting";
+import type { HostEntry } from "../lib/hostRegistry";
+import type { ModelInfoExtended } from "../types";
+
+/** Per-host canned `/api/status` + `/api/models` responses, keyed by host id. */
+const statuses = new Map<string, unknown>();
+const models = new Map<string, ModelInfoExtended[]>();
+
+vi.mock("../components/machines/hostClient", () => ({
+  hostStatus: (host: HostEntry) => {
+    const canned = statuses.get(host.id);
+    return canned
+      ? Promise.resolve(canned)
+      : Promise.reject(new Error("unreachable"));
+  },
+  hostModels: (host: HostEntry) => {
+    const canned = models.get(host.id);
+    return canned
+      ? Promise.resolve(canned)
+      : Promise.reject(new Error("unreachable"));
+  },
+}));
+
+function model(
+  name: string,
+  overrides: Partial<ModelInfoExtended> = {},
+): ModelInfoExtended {
+  return {
+    name,
+    family: "flux",
+    description: "",
+    size_gb: 1,
+    default_width: 1024,
+    default_height: 1024,
+    default_steps: 20,
+    default_guidance: 3.5,
+    is_loaded: false,
+    hf_repo: "acme/thing",
+    downloaded: true,
+    ...overrides,
+  } as ModelInfoExtended;
+}
+
+function status(overrides: Record<string, unknown> = {}) {
+  return {
+    version: "0.17.0",
+    models_loaded: [],
+    busy: false,
+    uptime_secs: 1,
+    queue_depth: 0,
+    ...overrides,
+  };
+}
+
+describe("useHostRouting", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    statuses.clear();
+    models.clear();
+    __testing__.reset();
+  });
+
+  afterEach(() => {
+    __testing__.reset();
+  });
+
+  it("lists this server alone when no remote is registered", async () => {
+    statuses.set(ORIGIN_HOST_ID, status());
+    models.set(ORIGIN_HOST_ID, [model("flux2-klein:q4")]);
+    const routing = useHostRouting();
+    await routing.refresh();
+
+    expect(routing.hosts.value.map((h) => h.id)).toEqual([ORIGIN_HOST_ID]);
+    expect(routing.multiHost.value).toBe(false);
+  });
+
+  it("reports a remote host as ready with its live queue depth and GPU", async () => {
+    const studio = addHost({ url: "http://studio:7680", name: "Studio" });
+    statuses.set(ORIGIN_HOST_ID, status({ queue_depth: 2 }));
+    models.set(ORIGIN_HOST_ID, []);
+    statuses.set(
+      studio.id,
+      status({
+        queue_depth: 5,
+        gpu_info: {
+          name: "NVIDIA RTX 4090",
+          vram_total_mb: 24576,
+          vram_used_mb: 0,
+          backend: "cuda",
+        },
+      }),
+    );
+    models.set(studio.id, [model("flux-dev:q4")]);
+
+    const routing = useHostRouting();
+    await routing.refresh();
+
+    const remote = routing.hosts.value.find((h) => h.id === studio.id);
+    expect(remote?.status).toBe("ready");
+    expect(remote?.queueDepth).toBe(5);
+    expect(remote?.gpu).toEqual({
+      backend: "cuda",
+      name: "NVIDIA RTX 4090",
+      vramTotalMb: 24576,
+    });
+    expect(routing.multiHost.value).toBe(true);
+  });
+
+  it("marks an unreachable host errored without dropping it from the list", async () => {
+    const studio = addHost({ url: "http://studio:7680", name: "Studio" });
+    statuses.set(ORIGIN_HOST_ID, status());
+    models.set(ORIGIN_HOST_ID, [model("flux2-klein:q4")]);
+
+    const routing = useHostRouting();
+    await routing.refresh();
+
+    const remote = routing.hosts.value.find((h) => h.id === studio.id);
+    expect(remote?.status).toBe("error");
+    // Auto never routes to it.
+    expect(routing.resolve("flux2-klein:q4")?.hostId).toBe(ORIGIN_HOST_ID);
+  });
+
+  it("carries the remote's api key into the resolved route, never a URL", async () => {
+    const studio = addHost({
+      url: "http://studio:7680",
+      name: "Studio",
+      apiKey: "sk-studio",
+    });
+    statuses.set(ORIGIN_HOST_ID, status());
+    models.set(ORIGIN_HOST_ID, []);
+    statuses.set(studio.id, status());
+    models.set(studio.id, [model("flux-dev:q4")]);
+    setGenerateTargetId(studio.id);
+
+    const routing = useHostRouting();
+    await routing.refresh();
+
+    const route = routing.resolve("flux-dev:q4");
+    expect(route?.target).toEqual({
+      baseUrl: "http://studio:7680",
+      apiKey: "sk-studio",
+    });
+    expect(route?.target.baseUrl).not.toContain("sk-studio");
+  });
+
+  it("shows only the pinned host's models when a host is pinned", async () => {
+    const studio = addHost({ url: "http://studio:7680", name: "Studio" });
+    statuses.set(ORIGIN_HOST_ID, status());
+    models.set(ORIGIN_HOST_ID, [model("flux2-klein:q4")]);
+    statuses.set(studio.id, status());
+    models.set(studio.id, [model("z-image:bf16")]);
+    setGenerateTargetId(studio.id);
+
+    const routing = useHostRouting();
+    await routing.refresh();
+
+    expect(routing.targetModels.value.map((m) => m.name)).toEqual([
+      "z-image:bf16",
+    ]);
+  });
+
+  it("shows the union of ready hosts' models under Auto", async () => {
+    const studio = addHost({ url: "http://studio:7680", name: "Studio" });
+    statuses.set(ORIGIN_HOST_ID, status());
+    models.set(ORIGIN_HOST_ID, [model("flux2-klein:q4")]);
+    statuses.set(studio.id, status());
+    models.set(studio.id, [model("z-image:bf16")]);
+    setGenerateTargetId(AUTO_TARGET_ID);
+
+    const routing = useHostRouting();
+    await routing.refresh();
+
+    expect(routing.targetModels.value.map((m) => m.name).sort()).toEqual([
+      "flux2-klein:q4",
+      "z-image:bf16",
+    ]);
+  });
+
+  it("excludes an unreachable host's stale models from the Auto union", async () => {
+    addHost({ url: "http://studio:7680", name: "Studio" });
+    statuses.set(ORIGIN_HOST_ID, status());
+    models.set(ORIGIN_HOST_ID, [model("flux2-klein:q4")]);
+    setGenerateTargetId(AUTO_TARGET_ID);
+
+    const routing = useHostRouting();
+    await routing.refresh();
+
+    expect(routing.targetModels.value.map((m) => m.name)).toEqual([
+      "flux2-klein:q4",
+    ]);
+  });
+
+  it("gates the empty state until every listed host's models settle", async () => {
+    addHost({ url: "http://studio:7680", name: "Studio" });
+    statuses.set(ORIGIN_HOST_ID, status());
+    models.set(ORIGIN_HOST_ID, []);
+
+    const routing = useHostRouting();
+    expect(routing.modelsSettled.value).toBe(false);
+    await routing.refresh();
+    // Both hosts answered (one with a rejection) — the gate opens.
+    expect(routing.modelsSettled.value).toBe(true);
+  });
+
+  it("routes Auto to the host that already holds the model", async () => {
+    const studio = addHost({ url: "http://studio:7680", name: "Studio" });
+    // The origin is idle but lacks the weights; the busy remote has them.
+    statuses.set(ORIGIN_HOST_ID, status({ queue_depth: 0 }));
+    models.set(ORIGIN_HOST_ID, []);
+    statuses.set(studio.id, status({ queue_depth: 6 }));
+    models.set(studio.id, [model("z-image:bf16")]);
+    setGenerateTargetId(AUTO_TARGET_ID);
+
+    const routing = useHostRouting();
+    await routing.refresh();
+
+    expect(routing.resolve("z-image:bf16")?.hostId).toBe(studio.id);
+  });
+
+  it("routes Most capable to the strongest GPU", async () => {
+    const studio = addHost({ url: "http://studio:7680", name: "Studio" });
+    statuses.set(
+      ORIGIN_HOST_ID,
+      status({
+        gpu_info: {
+          name: "Apple M3 Max",
+          vram_total_mb: 65536,
+          vram_used_mb: 0,
+        },
+      }),
+    );
+    models.set(ORIGIN_HOST_ID, [model("flux-dev:q4")]);
+    statuses.set(
+      studio.id,
+      status({
+        gpu_info: {
+          name: "NVIDIA RTX 4090",
+          vram_total_mb: 24576,
+          vram_used_mb: 0,
+        },
+      }),
+    );
+    models.set(studio.id, [model("flux-dev:q4")]);
+    setGenerateTargetId(CAPABLE_TARGET_ID);
+
+    const routing = useHostRouting();
+    await routing.refresh();
+
+    // Backend is inferred from the GPU name on servers that omit the field.
+    expect(routing.resolve("flux-dev:q4")?.hostId).toBe(studio.id);
+  });
+
+  it("reads a forgotten sticky pick as Auto", async () => {
+    setGenerateTargetId("ghost-host-7680");
+    statuses.set(ORIGIN_HOST_ID, status());
+    models.set(ORIGIN_HOST_ID, [model("flux2-klein:q4")]);
+
+    const routing = useHostRouting();
+    await routing.refresh();
+
+    expect(routing.targetId.value).toBe(AUTO_TARGET_ID);
+    expect(routing.resolve("flux2-klein:q4")?.hostId).toBe(ORIGIN_HOST_ID);
+  });
+
+  it("refuses to reroute a pinned host that went offline", async () => {
+    const studio = addHost({ url: "http://studio:7680", name: "Studio" });
+    statuses.set(ORIGIN_HOST_ID, status());
+    models.set(ORIGIN_HOST_ID, [model("flux-dev:q4")]);
+    setGenerateTargetId(studio.id);
+
+    const routing = useHostRouting();
+    await routing.refresh();
+
+    expect(routing.targetId.value).toBe(studio.id);
+    expect(routing.resolve("flux-dev:q4")).toBeNull();
+  });
+
+  it("persists a new pick", async () => {
+    const studio = addHost({ url: "http://studio:7680", name: "Studio" });
+    statuses.set(ORIGIN_HOST_ID, status());
+    models.set(ORIGIN_HOST_ID, []);
+    statuses.set(studio.id, status());
+    models.set(studio.id, []);
+
+    const routing = useHostRouting();
+    await routing.refresh();
+    routing.setTarget(CAPABLE_TARGET_ID);
+
+    expect(routing.targetId.value).toBe(CAPABLE_TARGET_ID);
+    expect(localStorage.getItem("mold.web.generateTarget.v1")).toBe(
+      CAPABLE_TARGET_ID,
+    );
+  });
+});

--- a/web/src/composables/useHostRouting.ts
+++ b/web/src/composables/useHostRouting.ts
@@ -1,0 +1,249 @@
+/*
+ * Generation host routing state for the Create surface — the browser's answer
+ * to the desktop app's hosts store (web has no Pinia; module-singleton
+ * composables are the state layer).
+ *
+ * It polls every host in the registry for `/api/status` (queue depth + GPU, the
+ * routers' inputs) and `/api/models` (so the model picker reflects where the
+ * job will actually run, and so Auto/Most-capable can prefer a host that
+ * already holds the weights). All the decisions live in `lib/hostRouting.ts`;
+ * this file is only the plumbing that keeps them fed.
+ */
+import {
+  computed,
+  onBeforeUnmount,
+  ref,
+  type ComputedRef,
+  type Ref,
+} from "vue";
+import {
+  ORIGIN_HOST_ID,
+  getGenerateTargetId,
+  listHosts,
+  setGenerateTargetId,
+  type HostEntry,
+} from "../lib/hostRegistry";
+import { hostModels, hostStatus } from "../components/machines/hostClient";
+import {
+  AUTO_TARGET_ID,
+  CAPABLE_TARGET_ID,
+  hostIdsForModel,
+  normalizeTargetId,
+  resolveRoute,
+  unionModels,
+  type HostRoute,
+  type HostRoutingStatus,
+  type ModelsByHost,
+  type RoutableGpu,
+  type RoutableHost,
+} from "../lib/hostRouting";
+import type { GpuInfo, ModelInfoExtended } from "../types";
+
+/** `gpu_info` plus the additive `backend` field newer servers report. */
+type GpuInfoWithBackend = GpuInfo & { backend?: string | null };
+
+interface HostTelemetry {
+  status: HostRoutingStatus;
+  queueDepth: number | null;
+  gpu: RoutableGpu | null;
+}
+
+export interface HostRouting {
+  /** Every registry host with its live routing inputs, origin first. */
+  hosts: Ref<RoutableHost[]>;
+  /** The persisted pick, normalized (a forgotten host reads as Auto). */
+  targetId: ComputedRef<string>;
+  setTarget: (id: string) => void;
+  /** True once the browser knows about a machine other than this server. */
+  multiHost: ComputedRef<boolean>;
+  /** Models available where a job would land: the target host's list, or the
+   * union across ready hosts under Auto / Most capable. */
+  targetModels: ComputedRef<ModelInfoExtended[]>;
+  /** True once every listed host's `/api/models` has settled — the empty-state
+   * gate, so a slow remote can't make Create flash "nothing installed". */
+  modelsSettled: Ref<boolean>;
+  /** Resolve the concrete dispatch route for a model, or null if unreachable. */
+  resolve: (model: string | null) => HostRoute | null;
+  /** Re-read the registry and poll every host once. */
+  refresh: () => Promise<void>;
+  /** Start/stop the poll loop; ref-counted across consumers. */
+  start: () => void;
+  stop: () => void;
+}
+
+const POLL_INTERVAL_MS = 8000;
+
+const entries = ref<HostEntry[]>([]);
+const telemetry = ref<Record<string, HostTelemetry>>({});
+const modelsByHost = ref<ModelsByHost>({});
+const settledHostIds = ref<string[]>([]);
+const modelsSettled = ref(false);
+const rawTargetId = ref<string>("");
+
+function readRegistry(): void {
+  entries.value = typeof localStorage === "undefined" ? [] : listHosts();
+}
+
+const hosts = computed<RoutableHost[]>(() =>
+  entries.value.map((entry) => {
+    const live = telemetry.value[entry.id];
+    const host: RoutableHost = {
+      id: entry.id,
+      label: entry.name,
+      url: entry.url,
+      status: live?.status ?? "connecting",
+      queueDepth: live?.queueDepth ?? null,
+      gpu: live?.gpu ?? null,
+    };
+    if (entry.apiKey) host.apiKey = entry.apiKey;
+    return host;
+  }),
+);
+
+const targetId = computed(() =>
+  normalizeTargetId(rawTargetId.value, hosts.value),
+);
+
+const readyHostIds = computed(() =>
+  hosts.value.filter((h) => h.status === "ready").map((h) => h.id),
+);
+
+const targetModels = computed<ModelInfoExtended[]>(() => {
+  const sel = targetId.value;
+  if (sel !== AUTO_TARGET_ID && sel !== CAPABLE_TARGET_ID) {
+    return modelsByHost.value[sel] ?? [];
+  }
+  // Auto / Most capable can land anywhere, so the picker offers the union.
+  // Before the first poll resolves nothing is "ready" yet — fall back to every
+  // listed host so the picker isn't empty during boot.
+  const ids = readyHostIds.value.length
+    ? readyHostIds.value
+    : hosts.value.map((h) => h.id);
+  return unionModels(modelsByHost.value, ids);
+});
+
+function gpuFrom(
+  info: GpuInfoWithBackend | null | undefined,
+): RoutableGpu | null {
+  if (!info) return null;
+  return {
+    backend: info.backend ?? null,
+    name: info.name,
+    vramTotalMb: info.vram_total_mb,
+  };
+}
+
+async function pollHost(entry: HostEntry): Promise<void> {
+  const [status, models] = await Promise.allSettled([
+    hostStatus(entry),
+    hostModels(entry),
+  ]);
+  if (status.status === "fulfilled") {
+    telemetry.value = {
+      ...telemetry.value,
+      [entry.id]: {
+        status: "ready",
+        queueDepth: status.value.queue_depth ?? null,
+        gpu: gpuFrom(status.value.gpu_info as GpuInfoWithBackend | null),
+      },
+    };
+  } else {
+    telemetry.value = {
+      ...telemetry.value,
+      [entry.id]: { status: "error", queueDepth: null, gpu: null },
+    };
+  }
+  if (models.status === "fulfilled") {
+    modelsByHost.value = { ...modelsByHost.value, [entry.id]: models.value };
+  } else if (!modelsByHost.value[entry.id]) {
+    // Keep the last good list for a host that blipped; only seed an empty one.
+    modelsByHost.value = { ...modelsByHost.value, [entry.id]: [] };
+  }
+  if (!settledHostIds.value.includes(entry.id)) {
+    settledHostIds.value = [...settledHostIds.value, entry.id];
+  }
+}
+
+async function refresh(): Promise<void> {
+  readRegistry();
+  await Promise.all(entries.value.map((entry) => pollHost(entry)));
+  modelsSettled.value = entries.value.every((e) =>
+    settledHostIds.value.includes(e.id),
+  );
+}
+
+let timer: ReturnType<typeof setTimeout> | null = null;
+let consumers = 0;
+
+function tick(): void {
+  timer = setTimeout(() => {
+    void refresh().finally(() => {
+      if (consumers > 0) tick();
+    });
+  }, POLL_INTERVAL_MS);
+}
+
+function start(): void {
+  consumers += 1;
+  if (consumers > 1) return;
+  readRegistry();
+  rawTargetId.value = getGenerateTargetId();
+  void refresh();
+  tick();
+}
+
+function stop(): void {
+  consumers = Math.max(0, consumers - 1);
+  if (consumers > 0) return;
+  if (timer) clearTimeout(timer);
+  timer = null;
+}
+
+function setTarget(id: string): void {
+  rawTargetId.value = id;
+  setGenerateTargetId(id);
+}
+
+/** Hosts that hold `model` downloaded — the model-aware routing input. */
+function hostsForModel(model: string | null): string[] {
+  return model ? hostIdsForModel(modelsByHost.value, model) : [];
+}
+
+function resolve(model: string | null): HostRoute | null {
+  return resolveRoute(hosts.value, rawTargetId.value, hostsForModel(model));
+}
+
+export function useHostRouting(): HostRouting {
+  start();
+  onBeforeUnmount(stop);
+  return {
+    hosts,
+    targetId,
+    setTarget,
+    multiHost: computed(() => hosts.value.length > 1),
+    targetModels,
+    modelsSettled,
+    resolve,
+    refresh,
+    start,
+    stop,
+  };
+}
+
+/** Reset the singleton between tests. */
+export const __testing__ = {
+  POLL_INTERVAL_MS,
+  reset(): void {
+    if (timer) clearTimeout(timer);
+    timer = null;
+    consumers = 0;
+    entries.value = [];
+    telemetry.value = {};
+    modelsByHost.value = {};
+    settledHostIds.value = [];
+    modelsSettled.value = false;
+    rawTargetId.value = "";
+  },
+};
+
+export { ORIGIN_HOST_ID };

--- a/web/src/composables/useOverlayFocus.test.ts
+++ b/web/src/composables/useOverlayFocus.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import { mount } from "@vue/test-utils";
+import { defineComponent, h, ref } from "vue";
+import { focusableWithin, useOverlayFocus } from "./useOverlayFocus";
+
+/**
+ * Minimal overlay host: a wrapper div bound to the trap plus three buttons,
+ * one of which carries `tabindex="-1"` (the shape a roving-tabindex kit
+ * control or a visually-hidden file input produces).
+ */
+const Overlay = defineComponent({
+  props: { open: { type: Boolean, default: false } },
+  setup(props) {
+    const host = ref<HTMLElement | null>(null);
+    const open = ref(props.open);
+    const { onKeydown } = useOverlayFocus(open, host);
+    return { host, onKeydown, open };
+  },
+  render() {
+    if (!this.open) return null;
+    return h("div", { ref: "host", onKeydown: this.onKeydown }, [
+      h("button", { id: "a" }, "a"),
+      h("button", { id: "skip", tabindex: "-1" }, "skip"),
+      h("button", { id: "b" }, "b"),
+    ]);
+  },
+});
+
+function press(el: HTMLElement, shiftKey = false) {
+  el.dispatchEvent(
+    new KeyboardEvent("keydown", { key: "Tab", bubbles: true, shiftKey }),
+  );
+}
+
+describe("focusableWithin", () => {
+  it("skips disabled and tabindex=-1 nodes", () => {
+    const root = document.createElement("div");
+    root.innerHTML = `
+      <button id="one"></button>
+      <button id="two" disabled></button>
+      <button id="three" tabindex="-1"></button>
+      <input id="four" />
+    `;
+    expect(focusableWithin(root).map((el) => el.id)).toEqual(["one", "four"]);
+  });
+});
+
+describe("useOverlayFocus", () => {
+  it("cycles Tab and Shift+Tab across the panel's edges", () => {
+    const w = mount(Overlay, {
+      props: { open: true },
+      attachTo: document.body,
+    });
+    const first = document.querySelector("#a") as HTMLButtonElement;
+    const last = document.querySelector("#b") as HTMLButtonElement;
+
+    last.focus();
+    press(last);
+    expect(document.activeElement).toBe(first);
+
+    press(first, true);
+    expect(document.activeElement).toBe(last);
+    w.unmount();
+  });
+
+  it("pulls focus back inside when it sits outside the panel", () => {
+    const outside = document.createElement("button");
+    document.body.appendChild(outside);
+    const w = mount(Overlay, {
+      props: { open: true },
+      attachTo: document.body,
+    });
+    const host = w.element as HTMLElement;
+
+    outside.focus();
+    press(host);
+    expect(document.activeElement).toBe(document.querySelector("#a"));
+
+    outside.focus();
+    press(host, true);
+    expect(document.activeElement).toBe(document.querySelector("#b"));
+
+    outside.remove();
+    w.unmount();
+  });
+
+  it("returns focus to the opener when the overlay closes", async () => {
+    const opener = document.createElement("button");
+    document.body.appendChild(opener);
+    opener.focus();
+
+    const w = mount(Overlay, {
+      props: { open: false },
+      attachTo: document.body,
+    });
+    w.vm.open = true;
+    await w.vm.$nextTick();
+    (document.querySelector("#a") as HTMLButtonElement).focus();
+
+    w.vm.open = false;
+    await w.vm.$nextTick();
+    expect(document.activeElement).toBe(opener);
+
+    opener.remove();
+    w.unmount();
+  });
+
+  it("returns focus to the opener when an open overlay unmounts", async () => {
+    const opener = document.createElement("button");
+    document.body.appendChild(opener);
+    opener.focus();
+
+    const w = mount(Overlay, {
+      props: { open: false },
+      attachTo: document.body,
+    });
+    w.vm.open = true;
+    await w.vm.$nextTick();
+    (document.querySelector("#a") as HTMLButtonElement).focus();
+
+    w.unmount();
+    expect(document.activeElement).toBe(opener);
+    opener.remove();
+  });
+
+  it("does not throw when the opener left the document", async () => {
+    const opener = document.createElement("button");
+    document.body.appendChild(opener);
+    opener.focus();
+
+    const w = mount(Overlay, {
+      props: { open: false },
+      attachTo: document.body,
+    });
+    w.vm.open = true;
+    await w.vm.$nextTick();
+    opener.remove();
+
+    expect(() => {
+      w.vm.open = false;
+    }).not.toThrow();
+    w.unmount();
+  });
+});

--- a/web/src/composables/useOverlayFocus.ts
+++ b/web/src/composables/useOverlayFocus.ts
@@ -1,0 +1,111 @@
+/*
+ * Overlay focus contract (spec §05) — the half the @ui panels do not cover.
+ *
+ * `ModalPanel` / `SheetPanel` / `DrawerPanel` already give an overlay its
+ * `role="dialog"` + `aria-modal` + accessible name, close on Escape and on
+ * backdrop click, and move focus onto the dialog root when it opens. What they
+ * deliberately do NOT do — because it needs the host component's DOM and the
+ * element that opened the overlay — is:
+ *
+ *   1. trap Tab / Shift+Tab inside the panel while it is open, and
+ *   2. return focus to the opener when it closes.
+ *
+ * This composable supplies both, so an overlay only has to bind `onKeydown`
+ * to the element that wraps its panel. Keep it here rather than in `ui/`: the
+ * kit is shared with the desktop and iPhone shells, which have their own
+ * focus-restoration rules.
+ */
+import { onBeforeUnmount, watch, type Ref } from "vue";
+
+/**
+ * Tabbable descendants. `[tabindex="-1"]` is excluded on every branch so the
+ * dialog root itself and roving-tabindex members (SegmentedControl's inactive
+ * segments, visually-hidden file inputs) never become trap boundaries.
+ */
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button",
+  "input",
+  "select",
+  "textarea",
+  "summary",
+  "[tabindex]",
+]
+  .map((base) => `${base}:not([disabled]):not([tabindex="-1"]):not([hidden])`)
+  .join(",");
+
+export function focusableWithin(root: HTMLElement): HTMLElement[] {
+  return Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+}
+
+/**
+ * @param open       reactive open flag for the overlay
+ * @param container  the element wrapping the panel; the trap's boundary
+ */
+export function useOverlayFocus(
+  open: Ref<boolean>,
+  container: Ref<HTMLElement | null>,
+) {
+  let opener: HTMLElement | null = null;
+
+  function restore() {
+    const target = opener;
+    opener = null;
+    // A re-rendered opener is gone from the document; focusing it would throw
+    // focus to <body> anyway, so skip rather than guess at a replacement.
+    if (target && target.isConnected) target.focus();
+  }
+
+  watch(
+    open,
+    (isOpen, wasOpen) => {
+      if (isOpen && !wasOpen) {
+        const active = document.activeElement;
+        opener = active instanceof HTMLElement ? active : null;
+      } else if (!isOpen && wasOpen) {
+        restore();
+      }
+    },
+    { immediate: true },
+  );
+
+  onBeforeUnmount(() => {
+    if (open.value) restore();
+  });
+
+  /** Bind to the overlay host: `@keydown="onKeydown"`. */
+  function onKeydown(event: KeyboardEvent) {
+    if (event.key !== "Tab") return;
+    const root = container.value;
+    if (!root) return;
+
+    const items = focusableWithin(root);
+    if (items.length === 0) {
+      // Nothing to move to — keep focus from escaping to the page behind.
+      event.preventDefault();
+      return;
+    }
+
+    const first = items[0] as HTMLElement;
+    const last = items[items.length - 1] as HTMLElement;
+    const active = document.activeElement;
+    const index = active instanceof HTMLElement ? items.indexOf(active) : -1;
+
+    // Focus is on the dialog root (tabindex="-1") or somewhere outside the
+    // panel: pull it back to the near edge in the direction of travel.
+    if (index === -1) {
+      event.preventDefault();
+      (event.shiftKey ? last : first).focus();
+      return;
+    }
+    if (event.shiftKey && active === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && active === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+
+  return { onKeydown };
+}

--- a/web/src/composables/useQueueReconciler.test.ts
+++ b/web/src/composables/useQueueReconciler.test.ts
@@ -47,6 +47,8 @@ function makeJob(overrides: Partial<Job> = {}): Job {
     chain: null,
     lastProgressAt: 1000,
     workStarted: true,
+    hostId: null,
+    hostLabel: null,
     serverId: "srv-1",
     ...overrides,
   };

--- a/web/src/lib/apiStream.ts
+++ b/web/src/lib/apiStream.ts
@@ -14,6 +14,8 @@ export interface PostSseJsonOptions<TBody, TProgress, TComplete> {
   url: string;
   body: TBody;
   signal?: AbortSignal;
+  /** Extra request headers (the routed host's `x-api-key`). */
+  headers?: Record<string, string>;
   handlers: PostSseJsonHandlers<TProgress, TComplete>;
   silentCloseMessage: string;
 }
@@ -34,6 +36,7 @@ export async function postSseJsonStream<TBody, TProgress, TComplete>(
       url: opts.url,
       body: opts.body,
       signal: opts.signal,
+      headers: opts.headers,
       onEvent: (evt) => {
         if (!evt.data) return;
         let parsed: unknown;

--- a/web/src/lib/hostRouting.test.ts
+++ b/web/src/lib/hostRouting.test.ts
@@ -1,0 +1,329 @@
+import { describe, expect, it } from "vitest";
+import {
+  AUTO_TARGET_ID,
+  CAPABLE_TARGET_ID,
+  backendRank,
+  hostIdsForModel,
+  inferBackendFromGpuName,
+  normalizeTargetId,
+  pickAutoHost,
+  pickMostCapableHost,
+  resolveRoute,
+  unionModels,
+  type RoutableHost,
+} from "./hostRouting";
+import { ORIGIN_HOST_ID } from "./hostRegistry";
+import type { ModelInfoExtended } from "../types";
+
+function host(overrides: Partial<RoutableHost> & { id: string }): RoutableHost {
+  return {
+    label: overrides.id,
+    url: `http://${overrides.id}:7680`,
+    status: "ready",
+    queueDepth: 0,
+    gpu: null,
+    ...overrides,
+  };
+}
+
+function model(
+  name: string,
+  overrides: Partial<ModelInfoExtended> = {},
+): ModelInfoExtended {
+  return {
+    name,
+    family: "flux",
+    description: "",
+    size_gb: 1,
+    default_width: 1024,
+    default_height: 1024,
+    default_steps: 20,
+    default_guidance: 3.5,
+    is_loaded: false,
+    hf_repo: "acme/thing",
+    downloaded: true,
+    ...overrides,
+  } as ModelInfoExtended;
+}
+
+describe("pickAutoHost", () => {
+  it("returns null when nothing is ready", () => {
+    expect(
+      pickAutoHost([
+        host({ id: "a", status: "connecting" }),
+        host({ id: "b", status: "error" }),
+      ]),
+    ).toBeNull();
+  });
+
+  it("picks the ready host with the shallowest queue", () => {
+    const picked = pickAutoHost([
+      host({ id: ORIGIN_HOST_ID, queueDepth: 3 }),
+      host({ id: "b", queueDepth: 1 }),
+      host({ id: "c", queueDepth: 5 }),
+    ]);
+    expect(picked?.id).toBe("b");
+  });
+
+  it("treats an unknown queue depth as busiest", () => {
+    const picked = pickAutoHost([
+      host({ id: "a", queueDepth: null }),
+      host({ id: "b", queueDepth: 4 }),
+    ]);
+    expect(picked?.id).toBe("b");
+  });
+
+  it("breaks ties toward this server (no network hop)", () => {
+    const picked = pickAutoHost([
+      host({ id: "remote", queueDepth: 2 }),
+      host({ id: ORIGIN_HOST_ID, queueDepth: 2 }),
+    ]);
+    expect(picked?.id).toBe(ORIGIN_HOST_ID);
+  });
+
+  it("never returns an unready host", () => {
+    const picked = pickAutoHost([
+      host({ id: "down", status: "error", queueDepth: 0 }),
+      host({ id: "up", queueDepth: 9 }),
+    ]);
+    expect(picked?.id).toBe("up");
+  });
+});
+
+describe("backend ranking", () => {
+  it("infers a backend from the GPU marketing name", () => {
+    expect(inferBackendFromGpuName("NVIDIA GeForce RTX 4090")).toBe("cuda");
+    expect(inferBackendFromGpuName("Apple M3 Max")).toBe("metal");
+    expect(inferBackendFromGpuName("Some Accelerator")).toBe("cpu");
+  });
+
+  it("ranks CUDA above Metal above unknown", () => {
+    expect(backendRank("cuda")).toBeGreaterThan(backendRank("metal"));
+    expect(backendRank("metal")).toBeGreaterThan(backendRank(null));
+  });
+
+  it("falls back to name inference when the wire field is missing", () => {
+    expect(backendRank(null, "NVIDIA RTX A6000")).toBe(backendRank("cuda"));
+  });
+});
+
+describe("pickMostCapableHost", () => {
+  it("prefers CUDA over Metal even when Metal is idle", () => {
+    const picked = pickMostCapableHost(
+      [
+        host({
+          id: ORIGIN_HOST_ID,
+          queueDepth: 0,
+          gpu: { backend: "metal", name: "Apple M3", vramTotalMb: 65536 },
+        }),
+        host({
+          id: "rig",
+          queueDepth: 4,
+          gpu: { backend: "cuda", name: "RTX 4090", vramTotalMb: 24576 },
+        }),
+      ],
+      null,
+    );
+    expect(picked?.id).toBe("rig");
+  });
+
+  it("breaks a backend tie on VRAM, then queue depth", () => {
+    const byVram = pickMostCapableHost(
+      [
+        host({
+          id: "small",
+          gpu: { backend: "cuda", name: "A", vramTotalMb: 12288 },
+        }),
+        host({
+          id: "big",
+          gpu: { backend: "cuda", name: "B", vramTotalMb: 49152 },
+        }),
+      ],
+      null,
+    );
+    expect(byVram?.id).toBe("big");
+
+    const byQueue = pickMostCapableHost(
+      [
+        host({
+          id: "busy",
+          queueDepth: 6,
+          gpu: { backend: "cuda", name: "A", vramTotalMb: 24576 },
+        }),
+        host({
+          id: "idle",
+          queueDepth: 0,
+          gpu: { backend: "cuda", name: "B", vramTotalMb: 24576 },
+        }),
+      ],
+      null,
+    );
+    expect(byQueue?.id).toBe("idle");
+  });
+
+  it("restricts to hosts that already hold the model when any ready host does", () => {
+    const picked = pickMostCapableHost(
+      [
+        host({
+          id: "strong",
+          gpu: { backend: "cuda", name: "A", vramTotalMb: 49152 },
+        }),
+        host({
+          id: "weak",
+          gpu: { backend: "metal", name: "Apple M1", vramTotalMb: 16384 },
+        }),
+      ],
+      ["weak"],
+    );
+    expect(picked?.id).toBe("weak");
+  });
+
+  it("ignores the model restriction when no ready host has it", () => {
+    const picked = pickMostCapableHost(
+      [
+        host({
+          id: "strong",
+          gpu: { backend: "cuda", name: "A", vramTotalMb: 49152 },
+        }),
+      ],
+      ["offline-box"],
+    );
+    expect(picked?.id).toBe("strong");
+  });
+
+  it("returns null when nothing is ready", () => {
+    expect(
+      pickMostCapableHost([host({ id: "a", status: "error" })], null),
+    ).toBeNull();
+  });
+});
+
+describe("normalizeTargetId", () => {
+  const hosts = [{ id: ORIGIN_HOST_ID }, { id: "studio" }];
+
+  it("passes through the sentinels", () => {
+    expect(normalizeTargetId(AUTO_TARGET_ID, hosts)).toBe(AUTO_TARGET_ID);
+    expect(normalizeTargetId(CAPABLE_TARGET_ID, hosts)).toBe(CAPABLE_TARGET_ID);
+  });
+
+  it("passes through a listed host id", () => {
+    expect(normalizeTargetId("studio", hosts)).toBe("studio");
+  });
+
+  it("reads a forgotten host as Auto", () => {
+    expect(normalizeTargetId("ghost", hosts)).toBe(AUTO_TARGET_ID);
+    expect(normalizeTargetId(null, hosts)).toBe(AUTO_TARGET_ID);
+  });
+});
+
+describe("resolveRoute", () => {
+  const origin = host({
+    id: ORIGIN_HOST_ID,
+    label: "this server",
+    url: "http://localhost:7680",
+    queueDepth: 2,
+  });
+  const studio = host({
+    id: "studio",
+    label: "Studio",
+    url: "http://studio:7680",
+    apiKey: "sk-studio",
+    queueDepth: 0,
+  });
+
+  it("routes a sticky explicit pick to that host, with its key", () => {
+    const route = resolveRoute([origin, studio], "studio");
+    expect(route).toEqual({
+      hostId: "studio",
+      label: "Studio",
+      target: { baseUrl: "http://studio:7680", apiKey: "sk-studio" },
+    });
+  });
+
+  it("refuses a sticky pick that is listed but offline", () => {
+    const offline = { ...studio, status: "error" as const };
+    expect(resolveRoute([origin, offline], "studio")).toBeNull();
+  });
+
+  it("falls back to Auto when the sticky pick was forgotten", () => {
+    const route = resolveRoute([origin], "studio");
+    expect(route?.hostId).toBe(ORIGIN_HOST_ID);
+  });
+
+  it("Auto prefers a ready host that already holds the model", () => {
+    // origin has the shallower queue but not the model.
+    const shallow = { ...origin, queueDepth: 0 };
+    const deep = { ...studio, queueDepth: 7 };
+    const route = resolveRoute([shallow, deep], AUTO_TARGET_ID, ["studio"]);
+    expect(route?.hostId).toBe("studio");
+  });
+
+  it("Auto falls back to the least-busy host when nobody has the model", () => {
+    const route = resolveRoute([origin, studio], AUTO_TARGET_ID, ["ghost"]);
+    expect(route?.hostId).toBe("studio");
+  });
+
+  it("Most capable uses the capability ladder", () => {
+    const metal = {
+      ...origin,
+      gpu: { backend: "metal", name: "Apple M3", vramTotalMb: 65536 },
+    };
+    const cuda = {
+      ...studio,
+      gpu: { backend: "cuda", name: "RTX 4090", vramTotalMb: 24576 },
+    };
+    const route = resolveRoute([metal, cuda], CAPABLE_TARGET_ID);
+    expect(route?.hostId).toBe("studio");
+  });
+
+  it("returns null when no host is reachable at all", () => {
+    const down = { ...origin, status: "error" as const };
+    expect(resolveRoute([down], AUTO_TARGET_ID)).toBeNull();
+  });
+
+  it("omits the api key for a host that has none", () => {
+    const route = resolveRoute([origin], AUTO_TARGET_ID);
+    expect(route?.target.apiKey).toBeUndefined();
+  });
+});
+
+describe("model unions", () => {
+  it("dedupes by name across hosts, preferring a downloaded copy", () => {
+    const merged = unionModels(
+      {
+        origin: [model("flux-dev:q4", { downloaded: false })],
+        studio: [model("flux-dev:q4"), model("z-image:bf16")],
+      },
+      [ORIGIN_HOST_ID, "studio"],
+    );
+    // The `origin` key isn't in the requested host list — only `studio` counts.
+    expect(merged.map((m) => m.name)).toEqual(["flux-dev:q4", "z-image:bf16"]);
+    expect(merged[0]?.downloaded).toBe(true);
+  });
+
+  it("prefers a downloaded copy even when an undownloaded one comes first", () => {
+    const merged = unionModels(
+      {
+        a: [model("flux-dev:q4", { downloaded: false })],
+        b: [model("flux-dev:q4", { downloaded: true })],
+      },
+      ["a", "b"],
+    );
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.downloaded).toBe(true);
+  });
+
+  it("returns an empty union for hosts that reported nothing", () => {
+    expect(unionModels({}, ["a"])).toEqual([]);
+  });
+
+  it("lists the hosts that hold a downloaded model", () => {
+    const byHost = {
+      a: [model("flux-dev:q4", { downloaded: false })],
+      b: [model("flux-dev:q4")],
+      c: [model("z-image:bf16")],
+    };
+    expect(hostIdsForModel(byHost, "flux-dev:q4")).toEqual(["b"]);
+    expect(hostIdsForModel(byHost, "nothing")).toEqual([]);
+  });
+});

--- a/web/src/lib/hostRouting.ts
+++ b/web/src/lib/hostRouting.ts
@@ -1,0 +1,214 @@
+/*
+ * Generation host routing for the web Create surface (spec §08 multi-host).
+ *
+ * TS twin of the desktop app's `desktop/src/lib/hosts.ts` router: the browser
+ * has no Pinia store and no Tauri IPC, so the *logic* is ported rather than the
+ * code. Every rule here must keep agreeing with desktop — Auto is model-aware
+ * least-busy, "Most capable" walks the CUDA > Metal > unknown ladder, and a
+ * sticky explicit pick is honoured until the host disappears from the registry.
+ *
+ * The origin host plays desktop's "local" role in tie-breaks: same-origin
+ * dispatch costs no network hop, so it wins a dead heat.
+ */
+import { ORIGIN_HOST_ID } from "./hostRegistry";
+import type { ModelInfoExtended } from "../types";
+
+/** Least-busy routing across every ready host. */
+export const AUTO_TARGET_ID = "auto";
+/** Strongest-GPU routing (desktop's `generateTargetHost = "capable"`). */
+export const CAPABLE_TARGET_ID = "capable";
+
+export type HostRoutingStatus = "connecting" | "ready" | "error";
+
+/** GPU summary as `/api/status` reports it. `backend` is an additive field —
+ *  servers that predate it fall back to name inference. */
+export interface RoutableGpu {
+  backend?: string | null;
+  name?: string | null;
+  vramTotalMb?: number | null;
+}
+
+/** The slice of a registry host the routers reason over. */
+export interface RoutableHost {
+  id: string;
+  label: string;
+  /** Origin URL used as the request base; never carries a key. */
+  url: string;
+  /** Per-host key, sent as `x-api-key`. Never placed in a URL. */
+  apiKey?: string;
+  status: HostRoutingStatus;
+  /** Live queue depth; null while unknown (counts as busiest). */
+  queueDepth: number | null;
+  gpu: RoutableGpu | null;
+}
+
+/** Where a submission is dispatched: the host's base URL plus its key. */
+export interface HostTarget {
+  baseUrl: string;
+  apiKey?: string;
+}
+
+export interface HostRoute {
+  hostId: string;
+  label: string;
+  target: HostTarget;
+}
+
+function isOrigin(host: { id: string }): boolean {
+  return host.id === ORIGIN_HOST_ID;
+}
+
+function depth(host: RoutableHost): number {
+  return host.queueDepth ?? Number.MAX_SAFE_INTEGER;
+}
+
+/**
+ * Auto routing: the ready host with the shallowest queue wins; unknown depth
+ * counts as busiest; this server wins ties. Null when nothing is ready.
+ */
+export function pickAutoHost<T extends RoutableHost>(
+  hosts: readonly T[],
+): T | null {
+  const ready = hosts.filter((h) => h.status === "ready");
+  if (ready.length === 0) return null;
+  return ready.reduce((best, h) => {
+    if (depth(h) < depth(best)) return h;
+    if (depth(h) === depth(best) && isOrigin(h) && !isOrigin(best)) return h;
+    return best;
+  });
+}
+
+/**
+ * Guess the compute backend from a GPU's marketing name. Only used when a host
+ * doesn't report `gpu_info.backend` (servers ≤ 0.16); the explicit field wins.
+ */
+export function inferBackendFromGpuName(
+  name: string,
+): "cuda" | "metal" | "cpu" {
+  const n = name.toLowerCase();
+  if (/nvidia|rtx|geforce|gtx|quadro|tesla|a100|h100|l40/.test(n))
+    return "cuda";
+  if (/apple|\bm[1-4]\b/.test(n)) return "metal";
+  return "cpu";
+}
+
+/** Capability ladder: CUDA (2) > Metal (1) > CPU/unknown (0). */
+export function backendRank(
+  backend: string | null | undefined,
+  gpuName?: string | null,
+): number {
+  const b = backend ?? (gpuName ? inferBackendFromGpuName(gpuName) : null);
+  if (b === "cuda") return 2;
+  if (b === "metal") return 1;
+  return 0;
+}
+
+/**
+ * "Most capable" routing: among ready hosts — restricted to the ones that
+ * already hold the model when `modelHostIds` says at least one ready host does
+ * — rank by backend, then total VRAM descending, then queue depth ascending. A
+ * fully tied origin wins. Null when nothing is ready.
+ */
+export function pickMostCapableHost<T extends RoutableHost>(
+  hosts: readonly T[],
+  modelHostIds: readonly string[] | null,
+): T | null {
+  let ready = hosts.filter((h) => h.status === "ready");
+  if (modelHostIds !== null) {
+    const withModel = ready.filter((h) => modelHostIds.includes(h.id));
+    if (withModel.length > 0) ready = withModel;
+  }
+  if (ready.length === 0) return null;
+  const rank = (x: RoutableHost) => backendRank(x.gpu?.backend, x.gpu?.name);
+  const vram = (x: RoutableHost) => x.gpu?.vramTotalMb ?? 0;
+  return ready.reduce((best, h) => {
+    if (rank(h) !== rank(best)) return rank(h) > rank(best) ? h : best;
+    if (vram(h) !== vram(best)) return vram(h) > vram(best) ? h : best;
+    if (depth(h) !== depth(best)) return depth(h) < depth(best) ? h : best;
+    if (isOrigin(h) && !isOrigin(best)) return h;
+    return best;
+  });
+}
+
+/**
+ * Normalize the persisted target the way the picker displays it: the sentinels
+ * and a currently-listed host id pass through; a ghost id (the host was
+ * forgotten) reads as Auto. Every consumer must read the pref through this so
+ * the picker's selection and the dispatch decision can never disagree.
+ */
+export function normalizeTargetId(
+  selection: string | null | undefined,
+  hosts: ReadonlyArray<{ id: string }>,
+): string {
+  if (!selection || selection === AUTO_TARGET_ID) return AUTO_TARGET_ID;
+  if (selection === CAPABLE_TARGET_ID) return CAPABLE_TARGET_ID;
+  return hosts.some((h) => h.id === selection) ? selection : AUTO_TARGET_ID;
+}
+
+/**
+ * Resolve the concrete host a submission dispatches to.
+ *
+ * A sticky pick that is listed but not ready resolves to null — the caller must
+ * surface that as an error rather than silently rerouting the user's print to a
+ * different machine (the desktop rule). A pick that is *gone* from the registry
+ * has already degraded to Auto via `normalizeTargetId`.
+ */
+export function resolveRoute(
+  hosts: readonly RoutableHost[],
+  selection: string | null | undefined,
+  modelHostIds: readonly string[] = [],
+): HostRoute | null {
+  const sel = normalizeTargetId(selection, hosts);
+  let chosen: RoutableHost | null;
+  if (sel === CAPABLE_TARGET_ID) {
+    chosen = pickMostCapableHost(
+      hosts,
+      modelHostIds.length > 0 ? modelHostIds : null,
+    );
+  } else if (sel !== AUTO_TARGET_ID) {
+    chosen = hosts.find((h) => h.id === sel && h.status === "ready") ?? null;
+  } else {
+    const withModel = hosts.filter(
+      (h) => h.status === "ready" && modelHostIds.includes(h.id),
+    );
+    chosen = pickAutoHost(withModel.length > 0 ? withModel : hosts);
+  }
+  if (!chosen) return null;
+  const target: HostTarget = { baseUrl: chosen.url };
+  if (chosen.apiKey) target.apiKey = chosen.apiKey;
+  return { hostId: chosen.id, label: chosen.label, target };
+}
+
+/** Per-host `/api/models` snapshots, keyed by registry host id. */
+export type ModelsByHost = Record<string, ModelInfoExtended[]>;
+
+/**
+ * The model list for a set of hosts, deduped by name. A downloaded copy always
+ * beats an undownloaded one — a model installed on any host in the set is
+ * installed as far as routing is concerned.
+ */
+export function unionModels(
+  modelsByHost: ModelsByHost,
+  hostIds: readonly string[],
+): ModelInfoExtended[] {
+  const byName = new Map<string, ModelInfoExtended>();
+  for (const id of hostIds) {
+    for (const model of modelsByHost[id] ?? []) {
+      const existing = byName.get(model.name);
+      if (!existing || (!existing.downloaded && model.downloaded)) {
+        byName.set(model.name, model);
+      }
+    }
+  }
+  return [...byName.values()];
+}
+
+/** Ids of the hosts that have `name` downloaded — the model-aware routing input. */
+export function hostIdsForModel(
+  modelsByHost: ModelsByHost,
+  name: string,
+): string[] {
+  return Object.entries(modelsByHost)
+    .filter(([, models]) => models.some((m) => m.name === name && m.downloaded))
+    .map(([id]) => id);
+}

--- a/web/src/lib/sse.ts
+++ b/web/src/lib/sse.ts
@@ -16,6 +16,8 @@ export interface StreamSseOptions<TBody> {
   url: string;
   body: TBody;
   signal?: AbortSignal;
+  /** Extra request headers — how a cross-host stream carries its `x-api-key`. */
+  headers?: Record<string, string>;
   onEvent: (evt: SseEvent) => void;
   /** Called once with the Response if the server returned a non-2xx. */
   onHttpError?: (res: Response) => void;
@@ -29,6 +31,7 @@ export async function streamSse<TBody>(
     headers: {
       "Content-Type": "application/json",
       Accept: "text/event-stream",
+      ...opts.headers,
     },
     body: JSON.stringify(opts.body),
     signal: opts.signal,

--- a/web/src/pages/GeneratePage.test.ts
+++ b/web/src/pages/GeneratePage.test.ts
@@ -12,6 +12,9 @@ import {
   useNotifications,
 } from "../lib/toasts";
 import { styleHint } from "../lib/stylePresets";
+import { __testing__ as hostRoutingTesting } from "../composables/useHostRouting";
+import { addHost, ORIGIN_HOST_ID } from "../lib/hostRegistry";
+import { AUTO_TARGET_ID, CAPABLE_TARGET_ID } from "../lib/hostRouting";
 import type { ChainJobDetail, GalleryImage } from "../types";
 
 const entry: GalleryImage = {
@@ -75,6 +78,28 @@ vi.mock("../composables/useStatusPoll", () => ({
   useStatusPoll: () => ({ status: { value: null } }),
 }));
 
+// Create now reads its model list (and routing inputs) from the per-host poll.
+// Canned responses keep the page deterministic and off the network.
+const hostStatusMock = vi.hoisted(() =>
+  vi.fn(
+    async (_host: { id: string }): Promise<Record<string, unknown>> => ({
+      version: "test",
+      models_loaded: [],
+      busy: false,
+      uptime_secs: 1,
+      queue_depth: 0,
+    }),
+  ),
+);
+const hostModelsMock = vi.hoisted(() =>
+  vi.fn(async (_host: { id: string }): Promise<unknown[]> => []),
+);
+
+vi.mock("../components/machines/hostClient", () => ({
+  hostStatus: hostStatusMock,
+  hostModels: hostModelsMock,
+}));
+
 const RecentGridStub = defineComponent({
   name: "RecentGrid",
   props: {
@@ -85,7 +110,12 @@ const RecentGridStub = defineComponent({
 });
 
 describe("GeneratePage layout and behavior", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    // The routing singleton outlives a test's component; let any poll still in
+    // flight from the previous test land, then discard what it wrote.
+    hostRoutingTesting.reset();
+    await flushPromises();
+    hostRoutingTesting.reset();
     localStorage.clear();
     generateFormTesting.resetForTest();
     resetNotifications();
@@ -93,6 +123,9 @@ describe("GeneratePage layout and behavior", () => {
     createChainJobMock.mockClear();
     createChainJobMock.mockResolvedValue({ job_id: "job-1" });
     chainJobDetailRef.value = null;
+    hostStatusMock.mockClear();
+    hostModelsMock.mockClear();
+    hostModelsMock.mockResolvedValue([]);
     vi.stubGlobal("prompt", vi.fn());
   });
 
@@ -456,6 +489,299 @@ describe("GeneratePage layout and behavior", () => {
     expect(
       wrapper.getComponent({ name: "ChainJobCard" }).props("job"),
     ).toMatchObject({ id: "job-1", state: "queued" });
+  });
+});
+
+// ── Multi-host generation routing (spec §08) ────────────────────────────────
+describe("GeneratePage host routing", () => {
+  const flux = {
+    name: "flux2-klein:q4",
+    family: "flux2",
+    description: "Flux.2 Klein Q4",
+    size_gb: 4,
+    default_width: 1024,
+    default_height: 1024,
+    default_steps: 20,
+    default_guidance: 3.5,
+    is_loaded: false,
+    hf_repo: "unsloth/FLUX.2-klein-4B-GGUF",
+    downloaded: true,
+  };
+  const zimage = { ...flux, name: "z-image:bf16", family: "z-image" };
+
+  beforeEach(async () => {
+    // The routing singleton outlives a test's component; let any poll still in
+    // flight from the previous test land, then discard what it wrote.
+    hostRoutingTesting.reset();
+    await flushPromises();
+    hostRoutingTesting.reset();
+    localStorage.clear();
+    generateFormTesting.resetForTest();
+    resetNotifications();
+    submitMock.mockClear();
+    hostStatusMock.mockReset();
+    hostStatusMock.mockResolvedValue({
+      version: "test",
+      models_loaded: [],
+      busy: false,
+      uptime_secs: 1,
+      queue_depth: 0,
+    });
+    hostModelsMock.mockReset();
+    hostModelsMock.mockResolvedValue([]);
+    vi.stubGlobal("prompt", vi.fn());
+  });
+
+  it("submits unrouted when this server is the only machine", async () => {
+    hostModelsMock.mockResolvedValue([flux]);
+    const wrapper = mount(GeneratePage, { global: { stubs: pageStubs() } });
+    await flushPromises();
+
+    await wrapper.get("[data-test='composer-submit']").trigger("click");
+    await flushPromises();
+
+    expect(submitMock).toHaveBeenCalledTimes(1);
+    // Third argument is the route — null means "stay on the serving origin".
+    expect(submitMock.mock.calls[0]?.[2]).toBeNull();
+  });
+
+  it("dispatches to the pinned machine with its base URL and key", async () => {
+    const studio = addHost({
+      url: "http://studio:7680",
+      name: "Studio",
+      apiKey: "sk-studio",
+    });
+    localStorage.setItem("mold.web.generateTarget.v1", studio.id);
+    hostModelsMock.mockResolvedValue([flux]);
+
+    const wrapper = mount(GeneratePage, { global: { stubs: pageStubs() } });
+    await flushPromises();
+
+    await wrapper.get("[data-test='composer-submit']").trigger("click");
+    await flushPromises();
+
+    expect(submitMock.mock.calls[0]?.[2]).toEqual({
+      hostId: studio.id,
+      label: "Studio",
+      target: { baseUrl: "http://studio:7680", apiKey: "sk-studio" },
+    });
+  });
+
+  it("refuses to reroute when the pinned machine is unreachable", async () => {
+    const studio = addHost({ url: "http://studio:7680", name: "Studio" });
+    localStorage.setItem("mold.web.generateTarget.v1", studio.id);
+    hostModelsMock.mockResolvedValue([flux]);
+    hostStatusMock.mockImplementation(async (host: { id: string }) => {
+      if (host.id !== ORIGIN_HOST_ID) throw new Error("unreachable");
+      return {
+        version: "test",
+        models_loaded: [],
+        busy: false,
+        uptime_secs: 1,
+        queue_depth: 0,
+      };
+    });
+
+    const wrapper = mount(GeneratePage, { global: { stubs: pageStubs() } });
+    await flushPromises();
+
+    await wrapper.get("[data-test='composer-submit']").trigger("click");
+    await flushPromises();
+
+    expect(submitMock).not.toHaveBeenCalled();
+    const notifications = useNotifications();
+    expect(notifications.toasts.map((t) => t.text).join(" ")).toMatch(
+      /isn't reachable/i,
+    );
+  });
+
+  // An offline pinned machine reports no models, so a model-first check would
+  // blame the model. Name the machine — that's the thing the user can fix.
+  it("blames the unreachable machine, not the empty model list", async () => {
+    const studio = addHost({ url: "http://studio:7680", name: "Studio" });
+    localStorage.setItem("mold.web.generateTarget.v1", studio.id);
+    hostStatusMock.mockImplementation(async (host: { id: string }) => {
+      if (host.id !== ORIGIN_HOST_ID) throw new Error("unreachable");
+      return {
+        version: "test",
+        models_loaded: [],
+        busy: false,
+        uptime_secs: 1,
+        queue_depth: 0,
+      };
+    });
+    hostModelsMock.mockImplementation(async (host: { id: string }) => {
+      if (host.id !== ORIGIN_HOST_ID) throw new Error("unreachable");
+      return [flux];
+    });
+
+    const wrapper = mount(GeneratePage, { global: { stubs: pageStubs() } });
+    await flushPromises();
+
+    await wrapper.get("[data-test='composer-submit']").trigger("click");
+    await flushPromises();
+
+    expect(submitMock).not.toHaveBeenCalled();
+    const notifications = useNotifications();
+    expect(notifications.toasts.map((t) => t.text).join(" ")).toMatch(
+      /isn't reachable/i,
+    );
+    // The generic "Pick a model to start." never fires in its place.
+    expect(wrapper.find("[data-test='composer-submit-error']").exists()).toBe(
+      false,
+    );
+  });
+
+  it("routes Auto to the machine that already holds the model", async () => {
+    const studio = addHost({ url: "http://studio:7680", name: "Studio" });
+    localStorage.setItem("mold.web.generateTarget.v1", AUTO_TARGET_ID);
+    // Only the remote has the weights; the origin is idle but empty.
+    hostModelsMock.mockImplementation(async (host: { id: string }) =>
+      host.id === ORIGIN_HOST_ID ? [] : [zimage],
+    );
+
+    const wrapper = mount(GeneratePage, { global: { stubs: pageStubs() } });
+    await flushPromises();
+    await nextTick();
+
+    await wrapper.get("[data-test='composer-submit']").trigger("click");
+    await flushPromises();
+
+    expect(submitMock.mock.calls[0]?.[2]).toMatchObject({ hostId: studio.id });
+  });
+
+  it("offers the union of every ready machine's models under Auto", async () => {
+    addHost({ url: "http://studio:7680", name: "Studio" });
+    localStorage.setItem("mold.web.generateTarget.v1", AUTO_TARGET_ID);
+    hostModelsMock.mockImplementation(async (host: { id: string }) =>
+      host.id === ORIGIN_HOST_ID ? [flux] : [zimage],
+    );
+
+    const wrapper = mount(GeneratePage, { global: { stubs: pageStubs() } });
+    await flushPromises();
+
+    const picker = wrapper.getComponent({ name: "CreateModelPicker" });
+    const names = (picker.props("models") as { name: string }[]).map(
+      (m) => m.name,
+    );
+    expect(names.sort()).toEqual(["flux2-klein:q4", "z-image:bf16"]);
+  });
+
+  it("shows only the pinned machine's models", async () => {
+    const studio = addHost({ url: "http://studio:7680", name: "Studio" });
+    localStorage.setItem("mold.web.generateTarget.v1", studio.id);
+    hostModelsMock.mockImplementation(async (host: { id: string }) =>
+      host.id === ORIGIN_HOST_ID ? [flux] : [zimage],
+    );
+
+    const wrapper = mount(GeneratePage, { global: { stubs: pageStubs() } });
+    await flushPromises();
+
+    const picker = wrapper.getComponent({ name: "CreateModelPicker" });
+    expect(
+      (picker.props("models") as { name: string }[]).map((m) => m.name),
+    ).toEqual(["z-image:bf16"]);
+  });
+
+  // Regression: a persisted model the server no longer has left the <select>
+  // with no matching <option>, which renders BLANK — the picker looked empty
+  // even though models were installed.
+  it("re-homes the form when the persisted model isn't installed", async () => {
+    const form = useGenerateForm();
+    form.state.value.model = "flux-dev:q8";
+    form.state.value.modelFamily = "flux";
+    hostModelsMock.mockResolvedValue([flux]);
+
+    const wrapper = mount(GeneratePage, { global: { stubs: pageStubs() } });
+    await flushPromises();
+    await nextTick();
+
+    expect(form.state.value.model).toBe("flux2-klein:q4");
+    expect(
+      wrapper.getComponent({ name: "CreateModelPicker" }).props("model"),
+    ).toBe("flux2-klein:q4");
+  });
+
+  it("leaves the selection alone when the persisted model is installed", async () => {
+    const form = useGenerateForm();
+    form.state.value.model = "flux2-klein:q4";
+    form.state.value.modelFamily = "flux2";
+    hostModelsMock.mockResolvedValue([flux, zimage]);
+
+    mount(GeneratePage, { global: { stubs: pageStubs() } });
+    await flushPromises();
+    await nextTick();
+
+    expect(form.state.value.model).toBe("flux2-klein:q4");
+  });
+
+  it("keeps the cold-start guide hidden while a machine is still answering", async () => {
+    addHost({ url: "http://studio:7680", name: "Studio" });
+    const deferred: { release: (models: unknown[]) => void } = {
+      release: () => {},
+    };
+    const pendingRemote = new Promise<unknown[]>((resolve) => {
+      deferred.release = resolve;
+    });
+    hostModelsMock.mockImplementation((host: { id: string }) =>
+      host.id === ORIGIN_HOST_ID ? Promise.resolve([]) : pendingRemote,
+    );
+
+    const wrapper = mount(GeneratePage, { global: { stubs: pageStubs() } });
+    await flushPromises();
+    expect(wrapper.find("[data-test='cold-start-stub']").exists()).toBe(false);
+
+    deferred.release([]);
+    await flushPromises();
+    await nextTick();
+    expect(wrapper.find("[data-test='cold-start-stub']").exists()).toBe(true);
+  });
+
+  it("says sequences stay on this server when the route points elsewhere", async () => {
+    const studio = addHost({ url: "http://studio:7680", name: "Studio" });
+    localStorage.setItem("mold.web.generateTarget.v1", studio.id);
+    localStorage.setItem("mold.composer.mode", "script");
+    hostModelsMock.mockResolvedValue([
+      { ...flux, name: "ltx-2:fp8", family: "ltx2" },
+    ]);
+
+    const wrapper = mount(GeneratePage, { global: { stubs: pageStubs() } });
+    await flushPromises();
+    await nextTick();
+
+    expect(wrapper.find("[data-test='sequence-origin-note']").exists()).toBe(
+      true,
+    );
+  });
+
+  it("routes Most capable to the strongest GPU", async () => {
+    const studio = addHost({ url: "http://studio:7680", name: "Studio" });
+    localStorage.setItem("mold.web.generateTarget.v1", CAPABLE_TARGET_ID);
+    hostModelsMock.mockResolvedValue([flux]);
+    hostStatusMock.mockImplementation(async (host: { id: string }) => ({
+      version: "test",
+      models_loaded: [],
+      busy: false,
+      uptime_secs: 1,
+      queue_depth: 0,
+      gpu_info:
+        host.id === ORIGIN_HOST_ID
+          ? { name: "Apple M3", vram_total_mb: 65536, vram_used_mb: 0 }
+          : {
+              name: "NVIDIA RTX 4090",
+              vram_total_mb: 24576,
+              vram_used_mb: 0,
+              backend: "cuda",
+            },
+    }));
+
+    const wrapper = mount(GeneratePage, { global: { stubs: pageStubs() } });
+    await flushPromises();
+
+    await wrapper.get("[data-test='composer-submit']").trigger("click");
+    await flushPromises();
+
+    expect(submitMock.mock.calls[0]?.[2]).toMatchObject({ hostId: studio.id });
   });
 });
 

--- a/web/src/pages/GeneratePage.vue
+++ b/web/src/pages/GeneratePage.vue
@@ -32,7 +32,6 @@ import { ASPECTS } from "@ui/lib/resolution";
 import {
   createChainJob,
   deleteGalleryImage,
-  fetchModels,
   fetchPromptHistory,
   imageUrl,
   listGallery,
@@ -59,7 +58,10 @@ import {
   resolveSourceFitTransform,
 } from "../lib/sourceFit";
 import { useStatusPoll } from "../composables/useStatusPoll";
+import { useHostRouting } from "../composables/useHostRouting";
+import { ORIGIN_HOST_ID } from "../lib/hostRegistry";
 import { generationCapabilitiesForFamily } from "../lib/generateCapabilities";
+import type { HostRoute } from "../lib/hostRouting";
 import type {
   ChainRequestWire,
   ChainStageWire,
@@ -84,10 +86,15 @@ function loadMuted(): boolean {
 const form = useGenerateForm();
 const { status } = useStatusPoll();
 const queue = useQueue();
-const models = ref<ModelInfoExtended[]>([]);
-// Gates the cold-start guide (spec §08 G10): only after the first models load
-// resolves so we never flash the guide while the list is still in flight.
-const modelsLoaded = ref(false);
+const routing = useHostRouting();
+// The model list follows the routing target: a pinned machine shows its own
+// models, Auto / Most capable show the union across ready machines. Single-host
+// installs collapse to exactly the origin's `/api/models`, as before.
+const models = computed<ModelInfoExtended[]>(() => routing.targetModels.value);
+// Gates the cold-start guide (spec §08 G10): only after every listed host's
+// models have settled, so a slow remote can't make Create flash "nothing
+// installed" while the list is still in flight.
+const modelsLoaded = routing.modelsSettled;
 const galleryEntries = ref<GalleryImage[]>([]);
 const promptHistory = ref<string[]>([]);
 const muted = ref(loadMuted());
@@ -210,16 +217,6 @@ const submittedChainJobId = ref<string | null>(null);
 const submittedChainJob = useChainJobStream(submittedChainJobId);
 const submittedChainJobDetail = submittedChainJob.detail;
 
-async function refreshModels() {
-  try {
-    models.value = await fetchModels();
-  } catch (e) {
-    console.error(e);
-  } finally {
-    modelsLoaded.value = true;
-  }
-}
-
 async function refreshGallery() {
   try {
     galleryEntries.value = await listGallery();
@@ -259,26 +256,20 @@ watch(
 );
 
 let galleryTimer: ReturnType<typeof setInterval> | null = null;
-let modelsTimer: ReturnType<typeof setInterval> | null = null;
 
 function startAutoRefresh() {
   stopAutoRefresh();
   galleryTimer = setInterval(() => {
     if (!document.hidden) void refreshGallery();
   }, 10_000);
-  modelsTimer = setInterval(() => {
-    if (!document.hidden) void refreshModels();
-  }, 15_000);
+  // Models refresh on the host-routing poll — one sweep feeds every machine's
+  // model list and queue depth, so Create doesn't duplicate the origin fetch.
 }
 
 function stopAutoRefresh() {
   if (galleryTimer) {
     clearInterval(galleryTimer);
     galleryTimer = null;
-  }
-  if (modelsTimer) {
-    clearInterval(modelsTimer);
-    modelsTimer = null;
   }
 }
 
@@ -333,6 +324,25 @@ const showColdStart = computed(
 function selectModel(model: ModelInfoExtended) {
   form.applyModelDefaults(model);
 }
+
+// The persisted model can name something the routing target doesn't have — it
+// was deleted, or the user pinned a machine that never installed it. A <select>
+// whose value matches no option renders BLANK, which reads as "this server has
+// no models" even when it has several. Re-home the form onto a model that is
+// actually there instead.
+watch(
+  [installedModels, modelsLoaded],
+  () => {
+    if (!modelsLoaded.value) return;
+    const first = installedModels.value[0];
+    if (!first) return;
+    const current = form.state.value.model;
+    if (current && installedModels.value.some((m) => m.name === current))
+      return;
+    form.applyModelDefaults(first);
+  },
+  { immediate: true },
+);
 
 const composerCardRef = ref<InstanceType<typeof ComposerCard> | null>(null);
 
@@ -457,10 +467,13 @@ const resultSrc = computed(() => {
   return `data:image/${r.format};base64,${r.image}`;
 });
 const resultCaption = computed(() => {
-  const r = latestDone.value?.result;
+  const job = latestDone.value;
+  const r = job?.result;
   if (!r) return "";
   const secs = Math.round(r.generation_time_ms / 1000);
-  return `${r.model} · seed ${r.seed_used} · ${secs}s · this server`;
+  // Name the machine that actually rendered it — an unrouted job ran here.
+  const where = job?.hostLabel ?? "this server";
+  return `${r.model} · seed ${r.seed_used} · ${secs}s · ${where}`;
 });
 
 function openLatestResult() {
@@ -613,7 +626,34 @@ function validateSubmit(): boolean {
   return true;
 }
 
+/**
+ * The machine this submission dispatches to.
+ *
+ * `null` means "don't route" — the single-machine case, where requests stay
+ * relative to the serving origin exactly as they always have. `false` means the
+ * user's pick is currently unreachable: a pinned machine that went offline is
+ * an error, never a silent reroute of their print to a different GPU.
+ */
+function resolveSubmitRoute(): HostRoute | null | false {
+  if (!routing.multiHost.value) return null;
+  const route = routing.resolve(form.state.value.model || null);
+  if (!route) {
+    toast(
+      "error",
+      "The machine you picked isn't reachable. Choose another under Run on.",
+    );
+    return false;
+  }
+  return route;
+}
+
 async function onSubmit() {
+  // The route is settled first, and before source preprocessing, for two
+  // reasons: an unreachable pinned machine is the real complaint (its model
+  // list is empty, so a model check first would blame the model instead), and
+  // the upscale pass has to land on the same machine as the render.
+  const route = resolveSubmitRoute();
+  if (route === false) return;
   if (!validateSubmit()) return;
   const decision = chainDecision.value;
   if (decision.kind === "reject") {
@@ -623,7 +663,7 @@ async function onSubmit() {
   if (!(await preprocessSourceIfNeeded())) return;
   await fitStillSourceToRequest();
   const req = form.toRequest();
-  stream.submit(req, decision);
+  stream.submit(req, decision, route);
   // Push to history immediately so ↑ recalls it before the server round-trips.
   composerCardRef.value?.record(req.prompt);
   if (
@@ -633,6 +673,16 @@ async function onSubmit() {
     form.state.value.seed += Math.max(1, form.state.value.batchSize);
   }
 }
+
+// Sequences are submitted as durable chain jobs and followed with an
+// EventSource, which cannot carry a per-host `x-api-key` — so they stay on this
+// server. Say so rather than letting the Run on chip imply otherwise.
+const sequenceIgnoresRouting = computed(
+  () =>
+    routing.multiHost.value &&
+    (routing.resolve(form.state.value.model || null)?.hostId ??
+      ORIGIN_HOST_ID) !== ORIGIN_HOST_ID,
+);
 
 async function onSubmitScript(script: ChainScriptToml) {
   const stages: ChainStageWire[] = script.stage.map((s) => ({
@@ -751,6 +801,10 @@ function discardVariations() {
 }
 
 async function queueVariations() {
+  // One route for the whole review set — siblings of a batch belong together
+  // on one machine.
+  const route = resolveSubmitRoute();
+  if (route === false) return;
   if (!validateSubmit()) return;
   const decision = chainDecision.value;
   if (decision.kind === "reject") {
@@ -765,7 +819,7 @@ async function queueVariations() {
     // prompt — override the base request's prompt rather than re-appending.
     // Each is one print; the batch size drove the variation count, not the
     // per-job image count.
-    stream.submit({ ...base, prompt, batch_size: 1 }, decision);
+    stream.submit({ ...base, prompt, batch_size: 1 }, decision, route);
   }
 }
 
@@ -895,17 +949,15 @@ onMounted(async () => {
     syncPhone();
     phoneQuery.addEventListener?.("change", syncPhone);
   }
-  await refreshModels();
+  // Models arrive from the host-routing poll (every machine, not just this
+  // one); the watcher above homes the form onto one that's actually installed.
+  void routing.refresh();
   try {
     galleryEntries.value = await listGallery();
   } catch (e) {
     console.error(e);
   }
   void refreshHistory();
-  if (!form.state.value.model) {
-    const first = installedModels.value[0];
-    if (first) form.applyModelDefaults(first);
-  }
   window.addEventListener("mold:new-print", onNewPrint);
   startAutoRefresh();
 });
@@ -965,6 +1017,15 @@ onBeforeUnmount(() => {
               <GenerationTemplatesPanel v-model="form.state.value" />
             </div>
           </div>
+        </div>
+
+        <div
+          v-if="composerMode === 'script' && sequenceIgnoresRouting"
+          class="rounded-control bg-halide/10 px-3 py-1.5 text-xs text-halide"
+          data-test="sequence-origin-note"
+        >
+          Sequences render on this server — the Run on choice applies to single
+          prints.
         </div>
 
         <div


### PR DESCRIPTION
Follow-ups to #467, found during UAT after it merged. Each one is a control that rendered correctly but did not do what it claimed.

- **Catalog filters actually filter.** The Image/Video chips sent a `modality` parameter `/api/catalog/search` has never accepted; Axum drops unknown query params, so the chips did nothing and combining them with the kind chips left the grid unchanged. Modality is applied client-side against each entry's derived field until the endpoint grows a parameter, and the count line now describes the rows actually shown. The empty state no longer points at a "Refresh catalog" control that doesn't exist.
- **Upscale after generate is a real control.** The toggle revealed nothing and never reached the request; it now opens an upscaler + factor section that round-trips as `upscale_model`, and says so honestly when no upscalers are installed.
- **Machine routing on Create.** Replaces a dead "generation runs on this server for now" row with desktop's picker — Auto (least busy, ties to this server), Most capable (CUDA > Metal, then VRAM, then queue), or a sticky per-host pick. Submit *and* the SSE stream dispatch to the chosen host with its key as an `x-api-key` header, never in a URL. A pinned host that is offline refuses the submit rather than silently rerouting the print. Sequence mode stays on this server and says so, because `EventSource` cannot send the key header.
- **Empty model dropdown.** A persisted form can name a model that isn't installed, and a native select whose value matches no option renders blank. The form re-homes onto an installed model once the list settles.
- **Overlay dismissal.** The Source image picker still had a pre-redesign look and could not be dismissed with Escape; the downloads popover bound Escape to an element that never receives key events and had no outside-click handler. Those plus the expand, mask, LoRA and metadata overlays now share one contract: Escape closes, backdrop closes, focus enters, is trapped, and returns to the opener.

Gates: web tests + prettier + build, desktop tests + vue-tsc + prettier, all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)