### PR TITLE
fix(web): fake installed models list, and unusable phone navigation

### DIFF
--- a/web/src/components/shell/AppNav.test.ts
+++ b/web/src/components/shell/AppNav.test.ts
@@ -152,3 +152,18 @@ describe("AppNav", () => {
     expect(markGalleryVisitedMock).toHaveBeenCalled();
   });
 });
+
+describe("mobile nav sheet anchoring", () => {
+  it("mounts the sheet in a viewport-fixed host, not inside the 52px bar", async () => {
+    // SheetPanel is `position: absolute; inset: 0`; inside the relative header
+    // it resolved against the compact bar and rendered as a 52px sliver, which
+    // made the whole phone navigation unusable.
+    const w = mountNav();
+    const host = w.get("[data-test='mobile-nav-host']");
+    // Closed: no fixed overlay, so it can't swallow clicks on the page.
+    expect(host.classes()).not.toContain("fixed");
+    await w.get('[data-test="nav-hamburger"]').trigger("click");
+    expect(host.classes()).toContain("fixed");
+    expect(host.classes()).toContain("inset-0");
+  });
+});

--- a/web/src/components/shell/AppNav.vue
+++ b/web/src/components/shell/AppNav.vue
@@ -225,7 +225,16 @@ const menuOpen = ref(false);
       </button>
     </div>
 
-    <MobileNavSheet :open="menuOpen" @close="menuOpen = false" />
+    <!-- Viewport-fixed host: SheetPanel is `position: absolute; inset: 0`, so
+         mounted inside this `position: relative` header it resolved against the
+         52px compact bar and the whole mobile navigation rendered as a sliver.
+         Same fix the Create Advanced sheet and the model drawer needed. -->
+    <div
+      :class="menuOpen ? 'fixed inset-0 z-50' : ''"
+      data-test="mobile-nav-host"
+    >
+      <MobileNavSheet :open="menuOpen" @close="menuOpen = false" />
+    </div>
   </header>
 </template>
 

--- a/web/src/composables/useCatalog.ts
+++ b/web/src/composables/useCatalog.ts
@@ -11,6 +11,7 @@ import {
   unloadModel,
 } from "../api";
 import { useDownloads } from "./useDownloads";
+import { isStandaloneGenerationModel } from "../lib/modelFilters";
 import type {
   CatalogEntryWire,
   CatalogFamilyCount,
@@ -302,7 +303,14 @@ function build() {
     installedLoading.value = true;
     installedError.value = null;
     try {
-      installed.value = await fetchModels();
+      // Only models actually on disk are "installed". /api/models returns
+      // the whole manifest (97 rows here, 2 downloaded), so an unfiltered
+      // assignment renders the entire catalog as if it were installed — and
+      // the tab heuristic below then always lands on a shelf of models the
+      // user does not have. Host detail already filters this way.
+      installed.value = (await fetchModels()).filter(
+        (m) => m.downloaded && isStandaloneGenerationModel(m),
+      );
       // First load with no explicit user choice: land on Installed when the
       // user has models, otherwise open straight into Discover.
       if (!tabTouched) {


### PR DESCRIPTION
The two highest-impact findings from the web parity audit, both one-liners.

**Models → Installed showed 97 models as installed; two are actually on disk.** `useCatalog` assigned `fetchModels()` unfiltered, so the whole manifest rendered as an installed shelf with sizes. `MachineDetailPage` already filtered the same endpoint correctly and showed 2 — same page load, two different answers. Filtered now to downloaded generation models via the existing `isStandaloneGenerationModel`. This also repairs the landing-tab heuristic, which keyed off `installed.length > 0` and therefore always sent even a model-less user to a fake Installed shelf instead of Discover.

**The phone navigation rendered as a 52px sliver.** `SheetPanel` is `position: absolute; inset: 0`, and it was mounted inside the `position: relative` compact header, so it resolved against the 52px bar — the entire mobile menu was unusable. It now anchors to the viewport while open, and adds no overlay when closed so it can't swallow page clicks. This is the third instance of the same root cause (after the Create Advanced sheet and the model detail drawer), so the test asserts the anchoring rather than just the open prop.

Gates: web tests, prettier, build — all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)