### PR TITLE
docs(changelog): record the web fixes released as 0.20.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Models → Installed no longer lists models you don't have.** The shelf rendered every entry the server's manifest knows about — 97 rows on a machine with two models on disk — as though each were installed. It now shows only downloaded generation models, which also fixes the landing tab: a user with nothing installed was always sent to a fake Installed shelf instead of Discover.
+- **The mobile navigation menu is usable again.** On phones the nav sheet rendered as a 52-pixel sliver at the top of the screen, hiding every destination behind it.
+
 ## [0.20.1] - 2026-07-21
 
 ### Fixed


### PR DESCRIPTION
Unblocks the release job, which failed on `CHANGELOG.md has no notes for [0.20.2]`.

#472 merged without a changelog entry, so `[Unreleased]` was empty when `scripts/release/sync-release-pr.sh` promoted it — producing a version section with no notes, which the script correctly refuses.

Adds the two entries for what #472 actually fixed.