### PR TITLE
fix(desktop): prevent advanced control clipping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Repeated source-fit generations now reuse preprocessed images.** Desktop, web, and iPhone keep per-Create-form caches for the expensive Upscale then fit pass and the final canvas fit/mask. Prompt, seed, and generation-parameter iterations no longer rerun or retransmit unchanged source preprocessing; changing dimensions only invalidates the fit layer, while source, upscaler, fit-policy, and mask changes invalidate the layers they affect. Concurrent Batch siblings share an in-flight pass, and processed bytes stay request-local so the editable source remains intact.
+- Keep the desktop Advanced LoRA picker inside its accordion and ensure modal drawers cover floating workbench controls such as Templates.
 
 ## [0.20.2] - 2026-07-21
 

--- a/desktop/src/components/generate/LoraStack.layout.test.ts
+++ b/desktop/src/components/generate/LoraStack.layout.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import source from "./LoraStack.vue?raw";
+
+describe("LoraStack layout", () => {
+  it("keeps the picker in document flow so the accordion grows instead of clipping it", () => {
+    const picker = source.match(/<div\s+v-if="pickerOpen"\s+[^>]*>/s)?.[0] ?? "";
+    expect(picker).toContain('data-test="lora-picker"');
+    expect(picker).not.toContain(" absolute ");
+  });
+});

--- a/desktop/src/components/generate/LoraStack.vue
+++ b/desktop/src/components/generate/LoraStack.vue
@@ -97,7 +97,7 @@ watch(
       </div>
     </div>
 
-    <div class="relative">
+    <div>
       <button
         type="button"
         class="text-body text-halide hover:text-ink disabled:opacity-40"
@@ -108,7 +108,8 @@ watch(
       </button>
       <div
         v-if="pickerOpen"
-        class="border-edge absolute z-10 mt-1 max-h-60 w-full overflow-y-auto rounded-chrome border bg-bench shadow-raised"
+        data-test="lora-picker"
+        class="border-edge mt-2 max-h-60 w-full overflow-y-auto rounded-chrome border bg-bench shadow-raised"
       >
         <p v-if="loading" class="px-2 py-2 text-caption text-ink-3">Loading…</p>
         <p v-else-if="error" class="px-2 py-2 text-caption text-stop">{{ error }}</p>

--- a/ui/components/DrawerPanel.test.ts
+++ b/ui/components/DrawerPanel.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { mount } from "@vue/test-utils";
 import DrawerPanel from "./DrawerPanel.vue";
+import drawerSource from "./DrawerPanel.vue?raw";
 
 function make(
   props: Record<string, unknown> = {},
@@ -24,6 +25,10 @@ describe("DrawerPanel", () => {
     expect(dialog.attributes("aria-modal")).toBe("true");
     expect(dialog.attributes("aria-label")).toBe("Model details");
     expect(dialog.attributes("tabindex")).toBe("-1");
+  });
+
+  it("stacks above workbench popovers while open", () => {
+    expect(drawerSource).toMatch(/\.ms-drawer\s*\{[^}]*z-index:\s*40;/s);
   });
 
   it("renders the title and the default slot body", () => {

--- a/ui/components/DrawerPanel.vue
+++ b/ui/components/DrawerPanel.vue
@@ -93,6 +93,7 @@ watch(
 .ms-drawer {
   position: absolute;
   inset: 0;
+  z-index: 40;
   background: rgba(6, 5, 10, 0.72);
   backdrop-filter: blur(5px);
   display: flex;


### PR DESCRIPTION
## Summary

- keep the Advanced LoRA chooser in document flow so its accordion grows instead of clipping the picker
- give shared modal drawers an explicit top layer so the floating Templates control stays beneath Advanced
- add focused layout regressions and document the fix in the changelog

## Verification

- `cd desktop && bun run test` (206 files, 1,920 tests)
- `cd desktop && bun run fmt:check`
- `cd desktop && bun run build`
- Playwright rendered interaction at 1190×546: Create → Advanced → LoRA stack → Add LoRA; picker remained wholly inside the drawer and Templates was covered by the drawer top layer
