### PR TITLE
test(desktop): harden LoRA layout assertion

### DIFF
--- a/desktop/src/components/generate/LoraStack.layout.test.ts
+++ b/desktop/src/components/generate/LoraStack.layout.test.ts
@@ -5,6 +5,6 @@ describe("LoraStack layout", () => {
   it("keeps the picker in document flow so the accordion grows instead of clipping it", () => {
     const picker = source.match(/<div\s+v-if="pickerOpen"\s+[^>]*>/s)?.[0] ?? "";
     expect(picker).toContain('data-test="lora-picker"');
-    expect(picker).not.toContain(" absolute ");
+    expect(picker).not.toMatch(/\babsolute\b/);
   });
 });


### PR DESCRIPTION
## Summary

- make the LoRA picker layout regression reject `absolute` as a CSS class token in any position
- follow up on Copilot's valid review of #477 so the merged clipping fix cannot regress through class reordering

## Verification

- `cd desktop && bun run test -- src/components/generate/LoraStack.layout.test.ts`
