### PR TITLE
fix(web): stabilize gallery grid and restore tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The web Library grid no longer changes size as lazy thumbnails load while scrolling.** Responsive tracks now ignore media intrinsic widths, and every print carries the same host badge plus hover/focus model and seed edge label as desktop Library.
 - **The desktop Create settings inspector is resizable again and no longer wraps its shape controls by default.** Its left-edge divider supports pointer and keyboard resizing from 280–480 px, committed widths persist across launches, and double-click resets to the new 340 px default that keeps all five ratios on one row.
 - **Repeated source-fit generations now reuse preprocessed images.** Desktop, web, and iPhone keep per-Create-form caches for the expensive Upscale then fit pass and the final canvas fit/mask. Prompt, seed, and generation-parameter iterations no longer rerun or retransmit unchanged source preprocessing; changing dimensions only invalidates the fit layer, while source, upscaler, fit-policy, and mask changes invalidate the layers they affect. Concurrent Batch siblings share an in-flight pass, and processed bytes stay request-local so the editable source remains intact.
 - Keep the desktop Advanced LoRA picker inside its accordion and ensure modal drawers cover floating workbench controls such as Templates.

--- a/web/src/components/gallery/GalleryGrid.test.ts
+++ b/web/src/components/gallery/GalleryGrid.test.ts
@@ -72,6 +72,26 @@ describe("GalleryGrid", () => {
     expect(badges[0]!.text()).toContain("1.0s");
   });
 
+  it("shows the owning host plus model and seed tags on each print", () => {
+    const wrapper = mount(GalleryGrid, {
+      props: {
+        entries: [
+          {
+            ...image,
+            hostId: "origin",
+            hostLabel: "this server",
+          },
+        ],
+        loading: false,
+      },
+    });
+
+    expect(wrapper.get('[data-test="host-badge"]').text()).toBe("this server");
+    expect(wrapper.get('[data-test="print-metadata"]').text()).toBe(
+      "flux-dev:fp16 · S 7",
+    );
+  });
+
   it("opens a print on tile click when not selecting", async () => {
     const wrapper = mount(GalleryGrid, {
       props: { entries: [image], loading: false },

--- a/web/src/components/gallery/GalleryGrid.vue
+++ b/web/src/components/gallery/GalleryGrid.vue
@@ -117,6 +117,10 @@ function hostOf(entry: GalleryImage) {
   return id ? getHost(id) : null;
 }
 
+function hostLabel(entry: GalleryImage): string {
+  return (entry as { hostLabel?: string }).hostLabel ?? "";
+}
+
 /** Composite identity for a tile: two hosts can hold the same filename. */
 function keyOf(entry: GalleryImage): string {
   return printKey(entry as { hostId?: string; filename: string });
@@ -302,6 +306,22 @@ onBeforeUnmount(() => {
             </template>
           </MediaTile>
 
+          <span
+            v-if="hostLabel(entry)"
+            class="gg__host"
+            data-test="host-badge"
+            :title="`Generated on ${hostLabel(entry)}`"
+          >
+            {{ hostLabel(entry) }}
+          </span>
+          <span
+            class="gg__metadata"
+            data-test="print-metadata"
+            :title="`${entry.metadata.model} · Seed ${entry.metadata.seed}`"
+          >
+            {{ entry.metadata.model }} · S {{ entry.metadata.seed }}
+          </span>
+
           <!-- Selection hit layer (select mode only). Sits above the tile so a
                click toggles instead of opening; keeps shift/meta range logic. -->
           <button
@@ -369,27 +389,33 @@ onBeforeUnmount(() => {
 
 .gg__grid {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  width: 100%;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 12px;
 }
 @media (min-width: 640px) {
   .gg__grid {
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 }
 @media (min-width: 900px) {
   .gg__grid {
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 }
 @media (min-width: 1200px) {
   .gg__grid {
-    grid-template-columns: repeat(5, 1fr);
+    grid-template-columns: repeat(5, minmax(0, 1fr));
   }
 }
 
 .gg__cell {
   position: relative;
+  min-width: 0;
+  aspect-ratio: 1;
+  overflow: hidden;
+  border-radius: var(--radius-control);
+  contain: inline-size layout paint;
 }
 
 .gg__skel {
@@ -398,7 +424,13 @@ onBeforeUnmount(() => {
   background: color-mix(in srgb, var(--rebate) 5%, transparent);
 }
 
-/* Video/animated badge pinned bottom-right via MediaTile's overlay slot. */
+/* Video/animated badge stays top-right so gallery metadata owns the bottom edge. */
+:deep(.ms-tile__overlay) {
+  top: 8px;
+  right: 8px;
+  bottom: auto;
+}
+
 .gg__vbadge {
   display: inline-flex;
   align-items: center;
@@ -415,6 +447,54 @@ onBeforeUnmount(() => {
 .gg__vplay {
   width: 10px;
   height: 10px;
+}
+
+.gg__host,
+.gg__metadata {
+  position: absolute;
+  z-index: 1;
+  pointer-events: none;
+  color: var(--on-media);
+  font-family: var(--f-mono);
+  font-size: 10px;
+  line-height: 1.4;
+}
+
+.gg__host {
+  bottom: 8px;
+  left: 8px;
+  max-width: 70%;
+  overflow: hidden;
+  padding: 2px 6px;
+  border-radius: var(--radius-control-sm);
+  background: rgba(0, 0, 0, 0.62);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  transition: opacity var(--dur-quick) var(--ease);
+}
+
+.gg__metadata {
+  right: 0;
+  bottom: 0;
+  left: 0;
+  overflow: hidden;
+  padding: 3px 7px;
+  background: rgba(0, 0, 0, 0.62);
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  transform: translateY(100%);
+  transition: transform var(--dur-quick) var(--ease);
+}
+
+.gg__cell:hover .gg__host,
+.gg__cell:focus-within .gg__host {
+  opacity: 0;
+}
+
+.gg__cell:hover .gg__metadata,
+.gg__cell:focus-within .gg__metadata {
+  transform: translateY(0);
 }
 
 .gg__hit {

--- a/web/src/components/gallery/GalleryGrid.vue
+++ b/web/src/components/gallery/GalleryGrid.vue
@@ -431,6 +431,12 @@ onBeforeUnmount(() => {
   bottom: auto;
 }
 
+/* The cell deliberately clips intrinsic media. Keep keyboard focus inside that
+ * paint boundary so the shared tile's outward ring remains fully visible. */
+:deep(.ms-tile:focus-visible) {
+  outline-offset: -2px;
+}
+
 .gg__vbadge {
   display: inline-flex;
   align-items: center;
@@ -512,7 +518,7 @@ onBeforeUnmount(() => {
 }
 .gg__hit:focus-visible {
   outline: 2px solid var(--safelight);
-  outline-offset: 2px;
+  outline-offset: -2px;
 }
 
 .gg__check {

--- a/web/src/pages/LibraryPage.vue
+++ b/web/src/pages/LibraryPage.vue
@@ -833,9 +833,11 @@ onMounted(async () => {
 <style scoped>
 .gal {
   position: relative;
+  width: 100%;
   max-width: 1800px;
   margin: 0 auto;
   padding: 22px 20px 160px;
+  box-sizing: border-box;
 }
 
 .gal__head {


### PR DESCRIPTION
## Summary

- keep the web Library at its intended full responsive width from first paint through lazy-loaded gallery chunks
- prevent intrinsic thumbnail dimensions from changing CSS Grid track sizing
- restore desktop-parity print tags: owning host at rest, model and seed on hover or keyboard focus
- move video duration to the top-right so metadata tags never overlap it

## Root cause

`LibraryPage` is a child of the app's column flex frame. It had a max width and auto horizontal margins, but no explicit width, so the flex cross-size was shrink-to-content. As additional lazy thumbnails loaded while scrolling, their intrinsic dimensions changed that content contribution and the whole gallery expanded toward its 1800 px cap. The grid tracks also used bare `1fr`, whose automatic minimum can honor intrinsic media widths.

The page now owns `width: 100%` with border-box sizing, every responsive track uses `minmax(0, 1fr)`, and cells contain their media layout.

## User impact

The column count and tile dimensions no longer jump while browsing large libraries. Each print now identifies its host, and hovering or keyboard-focusing a tile reveals the model and seed just like desktop Library.

## Validation

- TDD: added a failing GalleryGrid tag contract before implementation
- `bun run check:architecture`
- `bun run check:dead-code`
- `bun run test:web` — 75 files, 719 tests
- `bun run build:web`
- `nix build .#mold-web`
- Playwright against the live Vite/proxied gallery:
  - 2048x1080: grid stayed 1760 px and tiles stayed 342.39 px from scroll 0 through 13,434 px while entries grew 150 → 200
  - 390x844: grid stayed 350 px and tiles stayed 169 px from scroll 0 through 17,729 px while entries grew 150 → 200
  - page identity and content verified, no Vite overlay, no console errors or warnings
  - host badge visible at rest; model/seed edge label verified after hover

