### PR TITLE
fix(web): purge stale pre-workspace web/node_modules before building

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `mold tui` / `mold serve` builds no longer fail with a vite `Plugin<any> is not assignable to PluginOption` type explosion on checkouts that predate the unified frontend workspace: `scripts/ensure-web-dist.sh` now removes a leftover per-package `web/node_modules` (detected by it containing its own vite copy) before building, so TypeScript resolves exactly one vite/rollup toolchain from the repo-root workspace.
+
 - **Metadata-DB access is now safe under concurrent processes.** Connections set a 5-second SQLite busy timeout (previously an instant `SQLITE_BUSY` that most read paths swallowed as "no value"), and schema migrations now run under an immediate transaction that re-reads `user_version` inside the write lock. Before this, `mold tui` racing its auto-spawned `mold serve` over a fresh or not-yet-migrated `mold.db` could double-apply an `ALTER TABLE` — corrupting the file so every later open failed with "duplicate column" — or intermittently read settings back empty.
 
 - **The web Library grid no longer changes size as lazy thumbnails load while scrolling.** Responsive tracks now ignore media intrinsic widths, and every print carries the same host badge plus hover/focus model and seed edge label as desktop Library.

--- a/scripts/ensure-web-dist.sh
+++ b/scripts/ensure-web-dist.sh
@@ -8,6 +8,17 @@ dist_dir="$web_dir/dist"
 stamp_file="$dist_dir/.mold-build-stamp"
 workspace_install_stamp="$repo_root/node_modules/.mold-install-stamp"
 
+# A `web/node_modules` containing its own vite is a leftover from the
+# pre-workspace layout (each package used to install independently).
+# It shadows the repo-root workspace install and makes `vue-tsc` see two
+# incompatible copies of vite/rollup ("Plugin<any> is not assignable to
+# PluginOption"). Bun never hoists vite into web/ under the unified
+# workspace, so its presence is always stale — remove it.
+if [ -d "$web_dir/node_modules/vite" ]; then
+    echo "ensure-web-dist: removing stale $web_dir/node_modules (pre-workspace install)" >&2
+    rm -rf "$web_dir/node_modules"
+fi
+
 needs_build=0
 
 if [ ! -f "$dist_dir/index.html" ] || [ ! -f "$stamp_file" ]; then
@@ -44,17 +55,6 @@ fi
 
 if [ "$needs_build" -eq 0 ]; then
     exit 0
-fi
-
-# A `web/node_modules` containing its own vite is a leftover from the
-# pre-workspace layout (each package used to install independently).
-# It shadows the repo-root workspace install and makes `vue-tsc` see two
-# incompatible copies of vite/rollup ("Plugin<any> is not assignable to
-# PluginOption"). Bun never hoists vite into web/ under the unified
-# workspace, so its presence is always stale — remove it.
-if [ -d "$web_dir/node_modules/vite" ]; then
-    echo "ensure-web-dist: removing stale $web_dir/node_modules (pre-workspace install)" >&2
-    rm -rf "$web_dir/node_modules"
 fi
 
 if [ ! -d "$repo_root/node_modules" ] \

--- a/scripts/ensure-web-dist.sh
+++ b/scripts/ensure-web-dist.sh
@@ -46,6 +46,17 @@ if [ "$needs_build" -eq 0 ]; then
     exit 0
 fi
 
+# A `web/node_modules` containing its own vite is a leftover from the
+# pre-workspace layout (each package used to install independently).
+# It shadows the repo-root workspace install and makes `vue-tsc` see two
+# incompatible copies of vite/rollup ("Plugin<any> is not assignable to
+# PluginOption"). Bun never hoists vite into web/ under the unified
+# workspace, so its presence is always stale — remove it.
+if [ -d "$web_dir/node_modules/vite" ]; then
+    echo "ensure-web-dist: removing stale $web_dir/node_modules (pre-workspace install)" >&2
+    rm -rf "$web_dir/node_modules"
+fi
+
 if [ ! -d "$repo_root/node_modules" ] \
     || [ ! -f "$workspace_install_stamp" ] \
     || [ "$repo_root/package.json" -nt "$workspace_install_stamp" ] \


### PR DESCRIPTION
## Summary

Checkouts that installed frontend deps under the old per-package layout keep a `web/node_modules` with its own vite copy. Under the new unified repo-root bun workspace that shadow install makes `vue-tsc` resolve **two incompatible vite/rollup toolchains**, and the embedded-SPA build (`mold tui` / `mold serve` via `ensure-web-dist.sh`) fails with the `Plugin<any> is not assignable to PluginOption` type explosion — hit on a real workstation today right after the workspace consolidation merged.

`ensure-web-dist.sh` now detects the stale directory (bun never hoists vite into `web/` under the workspace, so `web/node_modules/vite` existing is always pre-consolidation residue), removes it with a stderr notice, and does so before the fresh-dist early exit so the cleanup happens even when no rebuild is needed.

## Test plan
- Reproduced the failure, then with the guard: stale dir detected + removed, `vue-tsc -b && vite build` green.
- Guard re-verified by planting `web/node_modules/vite` and running the script twice (removal message once, `GUARD_WORKS` assertion).
- `bash -n` clean; legit workspace artifacts (`desktop/node_modules` link farm, standalone `website/node_modules`) untouched by the vite-specific detection.