### PR TITLE
chore(attribution): credit both core contributors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Project attribution now consistently credits both core contributors and equal owners.** Desktop, web, and iPhone About surfaces; native package metadata; Rust crate authors; website and README ownership copy; and AUR maintainer headers now name James Brink and Jeffrey Dilley, matching the MIT license.
+
 - **TestFlight uploads now support external testers.** The iOS export no longer marks every IPA as internal-only, so the same validated build can stay in `Mold Internal` and be selected by an external group for Beta App Review; the iOS CI gate prevents that restriction from returning.
 
 - **The TUI Create form dropped its Mode and Host rows** — routing is owned by the Machines workspace's sticky generation target (`mold tui --local` still pins the local engine), and the host-input popup is superseded by the Machines connect flow. The **Info sub-panel and Recent strip are retired**: telemetry lives in Machines and the chrome host chip, the model description moved under the Model row, and the Timeline's `✓ Saved <file>` lines absorb Recent. **Unload model** left Create (Models owns `u`), the old always-visible Negative panel (and its `tui.negative_collapsed` flag) gave way to the accordion's inline editor, and Width/Height merged into the Size row (per-model saved dimensions still round-trip unchanged).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,10 @@ resolver = "2"
 version = "0.20.2"
 edition = "2021"
 license = "MIT"
-authors = ["James Brink <brink.james@gmail.com>"]
+authors = [
+    "James Brink <brink.james@gmail.com>",
+    "Jeffrey Dilley <jeff.dilley@gmail.com>",
+]
 description = "Local AI image generation CLI — FLUX, SD3.5, SD 1.5, SDXL, Z-Image, Flux.2, Qwen-Image, Wuerstchen, LTX Video, & LTX-2 diffusion models on your GPU"
 rust-version = "1.85"
 homepage = "https://github.com/utensils/mold"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 
 Generate images and short video clips on your own GPU. No cloud, no Python, no fuss.
 
+Mold is equally owned and maintained by its core contributors,
+[James Brink](https://jamesbrink.online/) and
+[Jeffrey Dilley](mailto:jeff.dilley@gmail.com).
+
 **[Documentation](https://utensils.io/mold/)** | **[Getting Started](https://utensils.io/mold/guide/)** | **[Models](https://utensils.io/mold/models/)** | **[API](https://utensils.io/mold/api/)**
 
 ```bash

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -1,5 +1,8 @@
 # Mold for iPhone
 
+Mold is equally owned and maintained by core contributors James Brink and
+Jeffrey Dilley.
+
 Mold for iPhone is a remote-only Tauri 2 client. It never links or embeds the
 GPU inference stack; a saved Mold server owns the models, queue, downloads,
 generation work, and gallery media.

--- a/apps/mobile/src-tauri/Cargo.toml
+++ b/apps/mobile/src-tauri/Cargo.toml
@@ -4,7 +4,10 @@ version = "0.20.2"
 edition = "2024"
 license = "MIT"
 description = "Mold iOS companion for remote generation and gallery access"
-authors = ["James Brink <brink.james@gmail.com>"]
+authors = [
+    "James Brink <brink.james@gmail.com>",
+    "Jeffrey Dilley <jeff.dilley@gmail.com>",
+]
 
 [workspace]
 

--- a/apps/mobile/src-tauri/tauri.conf.json
+++ b/apps/mobile/src-tauri/tauri.conf.json
@@ -27,7 +27,8 @@
     "icon": [
       "../../../desktop/src-tauri/icons/icon.png"
     ],
-    "publisher": "James Brink",
+    "publisher": "James Brink and Jeffrey Dilley",
+    "copyright": "Copyright \u00a9 2026 James Brink and Jeffrey Dilley. MIT License.",
     "category": "GraphicsAndDesign",
     "shortDescription": "Generate with remote Mold hosts from iPhone.",
     "longDescription": "Mold for iPhone connects to remote Mold engines over your LAN or Tailscale for generation, gallery, model catalog, host monitoring, and appearance settings.",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -2,7 +2,10 @@
 name = "mold-desktop"
 version = "0.20.2"
 description = "Mold — native desktop app for local AI image/video generation"
-authors = ["James Brink <brink.james@gmail.com>"]
+authors = [
+    "James Brink <brink.james@gmail.com>",
+    "Jeffrey Dilley <jeff.dilley@gmail.com>",
+]
 license = "MIT"
 repository = "https://github.com/utensils/mold"
 edition = "2021"

--- a/desktop/src-tauri/src/menu.rs
+++ b/desktop/src-tauri/src/menu.rs
@@ -23,6 +23,22 @@ fn app_name(is_development: bool) -> &'static str {
     }
 }
 
+fn about_metadata(app_name: &str) -> AboutMetadata<'static> {
+    AboutMetadata {
+        name: Some(app_name.into()),
+        authors: Some(vec!["James Brink".into(), "Jeffrey Dilley".into()]),
+        comments: Some("Local AI image and video generation.".into()),
+        copyright: Some("Copyright © 2026 James Brink and Jeffrey Dilley".into()),
+        license: Some("MIT License".into()),
+        website: Some("https://github.com/utensils/mold".into()),
+        website_label: Some("Mold on GitHub".into()),
+        credits: Some(
+            "Core contributors and equal project owners:\nJames Brink\nJeffrey Dilley".into(),
+        ),
+        ..Default::default()
+    }
+}
+
 #[cfg(target_os = "macos")]
 pub fn set_process_name(is_development: bool) {
     if is_development {
@@ -38,11 +54,7 @@ pub fn set_process_name(_is_development: bool) {}
 pub fn build<R: Runtime>(app: &AppHandle<R>, is_development: bool) -> tauri::Result<Menu<R>> {
     let app_name = app_name(is_development);
     let about_label = format!("About {app_name}");
-    let about = AboutMetadata {
-        name: Some(app_name.into()),
-        comments: Some("Local AI image and video generation.".into()),
-        ..Default::default()
-    };
+    let about = about_metadata(app_name);
 
     let app_menu = SubmenuBuilder::new(app, app_name)
         .item(&PredefinedMenuItem::about(
@@ -235,7 +247,19 @@ pub fn build<R: Runtime>(app: &AppHandle<R>, is_development: bool) -> tauri::Res
 
 #[cfg(test)]
 mod tests {
-    use super::{accelerator, app_name};
+    use super::{about_metadata, accelerator, app_name};
+
+    #[test]
+    fn about_metadata_credits_both_core_contributors() {
+        let about = about_metadata("Mold");
+
+        assert_eq!(
+            about.authors,
+            Some(vec!["James Brink".into(), "Jeffrey Dilley".into()])
+        );
+        assert!(about.credits.as_deref().unwrap().contains("James Brink"));
+        assert!(about.credits.as_deref().unwrap().contains("Jeffrey Dilley"));
+    }
 
     #[test]
     fn uses_the_platform_primary_modifier() {

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -29,9 +29,9 @@
   "bundle": {
     "active": true,
     "targets": "all",
-    "publisher": "James Brink",
+    "publisher": "James Brink and Jeffrey Dilley",
     "homepage": "https://github.com/utensils/mold",
-    "copyright": "Copyright \u00a9 2026 James Brink. MIT License.",
+    "copyright": "Copyright \u00a9 2026 James Brink and Jeffrey Dilley. MIT License.",
     "category": "GraphicsAndDesign",
     "shortDescription": "Local AI image and video generation.",
     "longDescription": "Mold generates images and video locally on your GPU \u2014 FLUX, SD, SDXL, SD3.5, Z-Image, Qwen-Image, LTX video and more \u2014 with a gallery, model manager, and multi-stage chain composer. Runs its engine in-process or connects to a remote mold server.",

--- a/desktop/src/components/settings/AboutSection.test.ts
+++ b/desktop/src/components/settings/AboutSection.test.ts
@@ -1,0 +1,24 @@
+import { mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import AboutSection from "./AboutSection.vue";
+
+vi.mock("../../lib/api/client", () => ({
+  apiJson: vi.fn().mockRejectedValue(new Error("offline")),
+}));
+
+vi.mock("../../lib/ipc", () => ({
+  inTauri: () => false,
+  ipc: { openLogsDir: vi.fn() },
+}));
+
+describe("AboutSection", () => {
+  beforeEach(() => setActivePinia(createPinia()));
+
+  it("credits both core contributors", () => {
+    const wrapper = mount(AboutSection);
+
+    expect(wrapper.text()).toContain("James Brink");
+    expect(wrapper.text()).toContain("Jeffrey Dilley");
+  });
+});

--- a/desktop/src/components/settings/AboutSection.vue
+++ b/desktop/src/components/settings/AboutSection.vue
@@ -53,6 +53,9 @@ async function copyDiagnostics() {
     <SettingRow label="Processing" help="Where generations run.">
       <span class="data-mono text-body text-ink-3">Local + your hosts</span>
     </SettingRow>
+    <SettingRow label="Core contributors" help="Equal project owners.">
+      <span class="text-right text-body text-ink-2">James Brink · Jeffrey Dilley</span>
+    </SettingRow>
     <SettingRow label="Logs" help="Engine and app logs live in ~/.mold/logs.">
       <button
         type="button"

--- a/desktop/src/mobile/MobileSettingsView.test.ts
+++ b/desktop/src/mobile/MobileSettingsView.test.ts
@@ -16,6 +16,8 @@ describe("MobileSettingsView", () => {
     expect(wrapper.text()).toContain("Change the chrome without changing the color of your prints");
     expect(wrapper.text()).toContain("2 hosts saved");
     expect(wrapper.text()).toContain("0.18.0");
+    expect(wrapper.text()).toContain("James Brink");
+    expect(wrapper.text()).toContain("Jeffrey Dilley");
 
     await wrapper.get('input[name="mobile-theme-family"][value="safelight"]').setValue(true);
     await wrapper.get('input[name="mobile-theme-appearance"][value="light"]').setValue(true);

--- a/desktop/src/mobile/MobileSettingsView.vue
+++ b/desktop/src/mobile/MobileSettingsView.vue
@@ -129,6 +129,10 @@ const appearances: Array<{ value: Theme; label: string; description: string }> =
           <dt>Updates</dt>
           <dd>TestFlight</dd>
         </div>
+        <div>
+          <dt>Core contributors</dt>
+          <dd>James Brink · Jeffrey Dilley<br />Equal project owners</dd>
+        </div>
       </dl>
     </section>
   </div>

--- a/packaging/aur/mold-ai-bin/PKGBUILD
+++ b/packaging/aur/mold-ai-bin/PKGBUILD
@@ -1,4 +1,5 @@
 # Maintainer: James Brink <brink.james@gmail.com>
+# Maintainer: Jeffrey Dilley <jeff.dilley@gmail.com>
 
 pkgname=mold-ai-bin
 _pkgname=mold-ai

--- a/packaging/aur/mold-ai-git/PKGBUILD
+++ b/packaging/aur/mold-ai-git/PKGBUILD
@@ -1,4 +1,5 @@
 # Maintainer: James Brink <brink.james@gmail.com>
+# Maintainer: Jeffrey Dilley <jeff.dilley@gmail.com>
 
 pkgname=mold-ai-git
 _pkgname=mold-ai

--- a/packaging/aur/mold-ai/PKGBUILD
+++ b/packaging/aur/mold-ai/PKGBUILD
@@ -1,4 +1,5 @@
 # Maintainer: James Brink <brink.james@gmail.com>
+# Maintainer: Jeffrey Dilley <jeff.dilley@gmail.com>
 
 pkgname=mold-ai
 _binname=mold

--- a/web/src/pages/SettingsPage.test.ts
+++ b/web/src/pages/SettingsPage.test.ts
@@ -38,6 +38,8 @@ describe("SettingsPage", () => {
     expect(wrapper.get("h1").text()).toBe("Settings");
     expect(wrapper.get('[data-test="about-version"]').text()).toBe("9.9.9");
     expect(wrapper.text()).toContain("local + your hosts");
+    expect(wrapper.text()).toContain("James Brink");
+    expect(wrapper.text()).toContain("Jeffrey Dilley");
   });
 
   it("falls back to an em dash when the server version is unknown", () => {

--- a/web/src/pages/SettingsPage.vue
+++ b/web/src/pages/SettingsPage.vue
@@ -264,11 +264,15 @@ const version = computed(() => status.value?.version ?? "—");
           version
         }}</span>
       </div>
-      <div class="about-row about-row--last">
+      <div class="about-row">
         <span class="about-row__key">Processing</span>
         <span class="about-row__val about-row__val--muted">
           local + your hosts
         </span>
+      </div>
+      <div class="about-row about-row--last">
+        <span class="about-row__key">Core contributors · equal owners</span>
+        <span class="about-row__val">James Brink · Jeffrey Dilley</span>
       </div>
     </CardSurface>
   </div>

--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -130,7 +130,7 @@ export default defineConfig({
     footer: {
       message: 'Released under the MIT License.',
       copyright:
-        'Copyright <a href="https://jamesbrink.online/">James Brink</a>',
+        'Copyright <a href="https://jamesbrink.online/">James Brink</a> and <a href="mailto:jeff.dilley@gmail.com">Jeffrey Dilley</a>',
     },
 
     editLink: {

--- a/website/guide/desktop.md
+++ b/website/guide/desktop.md
@@ -130,6 +130,8 @@ surface powers it, so anything the app does maps to a documented endpoint.
   create), and Advanced — every remaining `/api/config` row with its provenance
   tag (⌂ db / ⛁ file / ⚿ env); environment-overridden rows are locked with the
   variable that owns them.
+  About credits core contributors and equal project owners James Brink and
+  Jeffrey Dilley in both the Settings workspace and the native app menu.
 - **Command palette** — **Cmd/Ctrl+K** for navigation, actions, model search, and
   prompt-history search in one field.
 - **Native desktop integration** — platform menus and shortcuts, Linux native

--- a/website/guide/iphone.md
+++ b/website/guide/iphone.md
@@ -167,7 +167,8 @@ cover:
 - **Color family:** the Mold Studio theme families, Mold or Safelight
 - **Appearance:** System, Dark, or Light
 - **Remote hosts:** saved-host count and a shortcut to manage them
-- **About:** app version, remote-only processing, and TestFlight updates
+- **About:** app version, remote-only processing, TestFlight updates, and equal
+  project-owner credit for core contributors James Brink and Jeffrey Dilley
 
 Fresh installs start with the Safelight color family and System appearance.
 Existing users keep any valid Mold or Safelight choice they already saved.


### PR DESCRIPTION
## Summary

- credit James Brink and Jeffrey Dilley as core contributors and equal project owners across Desktop, Web, iPhone, package metadata, website, README, and AUR surfaces
- enrich the native desktop About metadata with both authors, copyright, license, project link, and macOS credits
- add regression coverage for all three About UIs and native About metadata

## Validation

- bun run check:frontend
- bun run build:mobile
- website: bun run fmt:check && bun run verify && bun run build
- native desktop About regression test in nix develop
- standalone iPhone cargo check in nix develop
- cargo metadata for workspace, desktop, and mobile manifests
- git diff --check