### PR TITLE
chore(design): add design-sync inputs for the Mold Studio claude.ai/design project

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -1,0 +1,52 @@
+# design-sync notes — mold
+
+- **This is a tokens-only sync by deliberate decision (2026-07-21).** The Mold
+  Studio kit (`ui/`) is Vue 3; claude.ai/design renders React, so the 21 Vue
+  primitives are NOT bundled. What ships: `tokens.css` + `kit.css` (as
+  `_ds_bundle.css`), the three OFL variable fonts, `window.MoldStudio` =
+  `icons.ts` + `theme.ts` (framework-agnostic), guidelines distilled from
+  `docs/design/mold-studio-spec.html` (v0.12), and the conventions README
+  header. The user chose this over aborting or Vue-in-React shims (shims
+  rejected: Vue slots can't take React children).
+- `ui/` has **no build and no dist** — `--entry`/`cfg.entry` points at
+  `ui/icons.ts` (any real file works; its walk-up finds `ui/package.json` so
+  PKG_DIR = ui/). No `buildCmd` needed.
+- The repo is a **Bun workspace with no React**: converter deps AND
+  `react`/`react-dom`/`playwright@1.61.0` are npm-installed into
+  `.ds-sync/node_modules`, and `--node-modules .ds-sync/node_modules` keeps
+  workspaceRoot = the mold repo (a scratch dir outside the repo would make
+  cfgPath reject every `ui/` path).
+- CSS routing: `kit.css` rides the esbuild graph via
+  `.design-sync/ds-css.ts` (extraEntries); `tokens.css` rides `cfg.cssEntry`
+  so the append path preserves its documentation comments verbatim.
+  `cfg.cssEntry` being set is also what flips the adapter into tokens-only
+  mode (zero components would otherwise be fatal).
+- Fonts: `cfg.extraFonts: ["fonts/fonts.css"]` — the TTF url()s must stay OUT
+  of the JS graph (no .ttf esbuild loader).
+- Playwright: local cache has chromium build **1228** → playwright **1.61.0**
+  (installed in `.ds-sync`). Render check trivially passes (0 previews).
+- `[DTS_REACT]` warn on build is expected and harmless here (zero components,
+  no .d.ts emitted).
+
+## Known render warns
+
+(none — tokens-only, no component previews)
+
+## Re-sync risks
+
+- **Token/kit drift is the main risk**: any edit to `ui/tokens.css`,
+  `ui/kit.css`, `ui/fonts/fonts.css`, `ui/icons.ts`, or `ui/theme.ts` needs a
+  re-sync; nothing here regenerates automatically.
+- The guidelines file (`.design-sync/guidelines/mold-studio-guidelines.md`)
+  and `conventions.md` are **hand-distilled from the spec at v0.12** — when
+  `docs/design/mold-studio-spec.html` bumps, re-validate both against the new
+  spec (token names, component vocabulary, IA) before re-uploading.
+- `conventions.md` names specific tokens/classes/icons — the validation pass
+  (grep tokens/classes in `ds-bundle/_ds_bundle.css`, icon names against
+  `MoldStudio.ICONS`) must be re-run on every re-sync.
+- If the kit ever grows a React (or compiled-to-React) layer, revisit the
+  tokens-only decision — the full component pipeline was skipped, not
+  attempted and failed.
+- Chromium cache build vs playwright pin can drift after a `playwright`
+  update elsewhere on the machine — re-verify before trusting the render
+  check.

--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -27,6 +27,19 @@
   (installed in `.ds-sync`). Render check trivially passes (0 previews).
 - `[DTS_REACT]` warn on build is expected and harmless here (zero components,
   no .d.ts emitted).
+- **Claude Design compiler feedback (2026-07-21) drove a tokens.css
+  restructure**: its token registry only reads custom properties under plain
+  attribute scopes, so the light media blocks' `:root:not([data-theme="dark"])`
+  selectors were replaced with bare `:root` / `:root[data-theme-family="mold"]`
+  plus explicit forced-dark blocks (`[data-theme="dark"]`), and 8 tokens got
+  trailing `/* @kind ... */` comments (`--grad` color; `--f-*` font;
+  `--dur-*`/`--ease` other). Behavior verified identical across 36
+  states × 41 computed values (playwright matrix) and guarded by
+  `ui/tokens.test.ts` (mirror invariants + cascade order + annotations).
+  If the compiler still flags props inside `@media (prefers-color-scheme:
+  light)` after this, the remaining option is attribute-only theming (theme.ts
+  stamps the resolved appearance) — a cross-surface product refactor; get
+  explicit sign-off first.
 
 ## Known render warns
 
@@ -37,6 +50,9 @@
 - **Token/kit drift is the main risk**: any edit to `ui/tokens.css`,
   `ui/kit.css`, `ui/fonts/fonts.css`, `ui/icons.ts`, or `ui/theme.ts` needs a
   re-sync; nothing here regenerates automatically.
+- `ui/tokens.css` must keep its design-tool constraints: no `:not()` scopes,
+  and `@kind` annotations on non-inferable tokens — `ui/tokens.test.ts`
+  enforces both, so keep it green rather than deleting it.
 - The guidelines file (`.design-sync/guidelines/mold-studio-guidelines.md`)
   and `conventions.md` are **hand-distilled from the spec at v0.12** — when
   `docs/design/mold-studio-spec.html` bumps, re-validate both against the new

--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -1,0 +1,12 @@
+{
+  "projectId": "3a486f26-d6b6-42eb-8f25-90364a83d8a5",
+  "shape": "package",
+  "pkg": "@mold/ui",
+  "globalName": "MoldStudio",
+  "entry": "ui/icons.ts",
+  "cssEntry": "tokens.css",
+  "extraEntries": ["./theme.ts", "../.design-sync/ds-css.ts"],
+  "extraFonts": ["fonts/fonts.css"],
+  "guidelinesGlob": ["../.design-sync/guidelines/*.md"],
+  "readmeHeader": ".design-sync/conventions.md"
+}

--- a/.design-sync/conventions.md
+++ b/.design-sync/conventions.md
@@ -1,0 +1,74 @@
+# Mold Studio conventions
+
+This design system ships **tokens, fonts, kit classes, an icon registry, and
+theme helpers — no prebuilt React components**. You compose every control
+yourself from the token vocabulary below (the product's own primitives are Vue
+and are deliberately not bundled). `guidelines/mold-studio-guidelines.md`
+defines the component vocabulary, states, and voice to imitate — read it
+before building.
+
+## Setup
+
+No provider is needed. Theming is driven by two attributes on the **root
+element** (set them on `document.documentElement`, or call
+`MoldStudio.applyTheme(theme, family)`):
+
+- `data-theme-family`: `"mold"` (cyan/magenta) or `"safelight"` (warm amber — the default when absent)
+- `data-theme`: `"dark"` or `"light"` (absent = follow `prefers-color-scheme`)
+
+All four combinations work with zero component changes because every color is
+a CSS custom property. Fonts (Bricolage Grotesque, Schibsted Grotesk, Martian
+Mono) ship with the bundle and load via `styles.css`. Add the class `ms-kit`
+to your app root so keyboard `:focus-visible` gets the standard 2px accent ring.
+
+## Styling idiom: token custom properties, never hex
+
+Style with `var(--*)` from the shipped stylesheet. The vocabulary
+(full table in `guidelines/mold-studio-guidelines.md`):
+
+- Surfaces, stepping upward: `--desk` → `--bath` → `--bench` (cards/panels) → `--surface` (nested/hover)
+- Ink: `--rebate` (primary), `--ink-2`, `--ink-3`; borders `--edge` (hairline), `--ce` (controls)
+- Accents with fixed jobs: `--safelight` = actions/focus/selection (warm); `--halide` = models/telemetry/links (cool)
+- Selection (accent-derived): `--sel-ink`, `--sel-bg`, `--sel-border`, `--sel-fill`, `--sel-ring`
+- Semantic: `--success`, `--warning`, `--stop`; on accent fills: `--on-accent`; brand gradient `--grad`
+- Media bed: `--print`, `--on-media` (prints sit on a dark bed; never inverts)
+- Type: `--f-display` (titles), `--f-body` (UI), `--f-mono` (data, model ids)
+- Radius: `--radius-control-sm|control|control-lg` (6–10px), `--radius-card|card-lg` (12–16px), `--radius-pill` (20px)
+- Motion: `--dur-quick|base|slow` (120/180/240ms) with `--ease`
+
+Kit classes (the only global classes): `.ms-shimmer` (loading placeholder),
+`.ms-fade-up` (overlay/result entrance), `.ms-focus` (explicit focus ring).
+
+## Icons
+
+`MoldStudio.ICONS` maps names (`create`, `library`, `models`, `machines`,
+`settings`, `search`, `close`, `check`, `plus`, `play`, `download`, `trash`,
+`image`, `video`, …all in `MoldStudio.ICON_NAMES`) to inner-SVG strings drawn
+with `currentColor` on a 24-unit grid.
+
+## Idiomatic build example
+
+```jsx
+const Icon = ({ name, size = 16 }) => (
+  <svg width={size} height={size} viewBox="0 0 24 24" fill="none"
+    stroke="currentColor" strokeWidth="1.75" strokeLinecap="round"
+    strokeLinejoin="round"
+    dangerouslySetInnerHTML={{ __html: MoldStudio.ICONS[name] }} />
+);
+
+const GenerateButton = () => (
+  <button style={{
+    background: "var(--safelight)", color: "var(--on-accent)",
+    fontFamily: "var(--f-body)", fontWeight: 600,
+    border: "none", borderRadius: "var(--radius-control)",
+    padding: "10px 18px", display: "inline-flex", gap: 8,
+    alignItems: "center", cursor: "pointer",
+  }}>
+    <Icon name="sparkle" /> Generate
+  </button>
+);
+```
+
+Voice: product name **mold** lowercase; status values lowercase (`loaded`,
+`developing`); model ids as `family:variant` in `--f-mono`; glyphs ✓ ★ • only,
+no emoji.

--- a/.design-sync/ds-css.ts
+++ b/.design-sync/ds-css.ts
@@ -1,0 +1,8 @@
+/*
+ * design-sync CSS carrier — pulls kit.css into the esbuild graph so
+ * _ds_bundle.css ships the shared effects (shimmer, fade-up, focus ring).
+ * tokens.css deliberately rides cfg.cssEntry instead: the append path copies
+ * it verbatim, preserving its documentation comments for the design agent.
+ */
+import "../ui/kit.css";
+export {};

--- a/.design-sync/guidelines/mold-studio-guidelines.md
+++ b/.design-sync/guidelines/mold-studio-guidelines.md
@@ -1,0 +1,119 @@
+# Mold Studio — design guidelines
+
+Distilled from `docs/design/mold-studio-spec.html` (v0.12), the design source of
+truth for **mold** — a local, no-cloud AI image/video generation studio. One
+design system across five surfaces (macOS, iOS, web, mobile web, terminal).
+
+## Principles
+
+- **Dead-simple by default; power on demand.** The primary path — describe,
+  choose a look, generate — is one screen with no scrolling to essentials. If a
+  screen feels empty, that is correct, not a gap to fill.
+- **Progressive disclosure.** Advanced capability lives behind one
+  clearly-labelled entry (Advanced, More options) and opens collapsed. Never
+  surface a control a beginner can't act on.
+- **Contained, not global.** Every overlay (drawer, sheet, lightbox, palette,
+  modal) renders inside the frame it belongs to — never a page-level layer.
+- **Local-first voice.** Terse, lowercase, technical, dry. Reinforce "runs on
+  your machine" everywhere it's true. No cloud, no Python, no fuss.
+
+## Color: role tokens only
+
+Two theme families — **Mold** (cyan & magenta) and **Safelight** (warm darkroom
+amber) — each in Dark and Light. Selected via root dataset attributes:
+`data-theme-family="mold" | "safelight"` (absent = safelight) and
+`data-theme="dark" | "light"` (absent = follow `prefers-color-scheme`). The four
+combinations are the only supported palettes. **Never hard-code hex** — all
+color goes through the custom properties defined in the shipped stylesheet:
+
+| Token | Role |
+| --- | --- |
+| `--desk` | Behind the window / canvas (deepest plane) |
+| `--bath` | Base surface (screens) |
+| `--bench` | Elevated panel / card / bar |
+| `--surface` | Nested / hover tier (3rd plane) |
+| `--rebate` | Primary text / ink (family-tinted) |
+| `--ink-2` / `--ink-3` | Secondary / tertiary text |
+| `--edge` / `--ce` | Hairline border / control border |
+| `--safelight` | **Primary accent** — action, focus, selection (warm) |
+| `--halide` | **Info accent** — models, telemetry, links (cool) |
+| `--success` / `--warning` / `--stop` | Semantic: done / in-progress / destructive |
+| `--sel-ink` / `--sel-bg` / `--sel-border` / `--sel-fill` / `--sel-ring` | Selection set, derived from the accent — never a new hue |
+| `--on-accent` | Text/icon on accent fills |
+| `--grad` | Ink gradient — brand moments only (wordmark, hero) |
+| `--card-hi` | 1px top inner-highlight on cards/tiles |
+| `--print` / `--on-media` | Media bed — prints are always viewed on a dark bed, never inverts |
+
+Surfaces step `desk → bath → bench → surface` with real tonal jumps. The two
+accents have fixed jobs — safelight is warm/primary, halide is cool/informational
+— a warm↔cool rhythm that avoids monotony without rainbow.
+
+## Type, radius, motion, icons
+
+- **Display** (titles, wordmark): Bricolage Grotesque 600–800 (`--f-display`)
+- **Body / UI**: Schibsted Grotesk 400–700 (`--f-body`)
+- **Mono** (data, model ids, labels, code): Martian Mono 300–700 (`--f-mono`)
+- **Radii**: controls 6–10px (`--radius-control-sm/-control/-control-lg`),
+  cards 12–16px (`--radius-card`, `--radius-card-lg`), pills/chips 20px
+  (`--radius-pill`)
+- **Motion**: `--dur-quick` 120ms · `--dur-base` 180ms · `--dur-slow` 240ms,
+  all `--ease` `cubic-bezier(0.16,1,0.3,1)`. Shimmer 1.6s loop for
+  "developing" placeholders (`.ms-shimmer`); entrance for overlays/results is
+  `.ms-fade-up` (never on core chrome). No bounce, no parallax, no fade-in of
+  core UI. Honor `prefers-reduced-motion`.
+- **Icons**: line icons, 1.7–1.8 stroke, round caps, 24-unit grid, drawn with
+  `currentColor`. Sizes 14/16/17/22. Never mix fills or weights (Lucide-
+  compatible geometry). The shipped registry is `MoldStudio.ICONS`.
+
+## Component vocabulary
+
+New UI composes from this kit — do not invent a control when one fits:
+Segmented control (2–4 exclusive options, accent-tinted active segment) ·
+Chip (style presets; tapping an active chip deselects; 20px pill, accent fill
+when on) · Nav item (icon + label; active = accent-tinted bg + accent icon) ·
+Shape picker (aspect ratios drawn proportionally: 1:1 · 3:4 · 4:3 · 16:9 ·
+9:16) · Resolution selector (megapixel-based human labels, resolved px below) ·
+Slider / Stepper / Switch (accent thumb/track/knob) · Accordion section (the
+disclosure primitive — collapsed by default; powers Advanced) · Card & Tile
+(flat `--bench` card, hairline border; square image tiles, lift on hover, NEW
+badge) · Progress ring (in-canvas generate) and bar (downloads, telemetry) ·
+Drawer (right-side, wide surfaces) · Sheet (full-screen or bottom, phone) ·
+Modal (centered focused task; stepped with 3-dot progress) · Command palette
+(⌘K: search + grouped actions) · Empty state (dashed frame + one-line
+what-to-do) · Badge (count/status pill) · Keycap (⌘↵ on primary Generate).
+
+## Component states
+
+Rest is the baseline; the rest are deltas:
+
+- **Rest**: token surface + `--ce` border, `--ink-2` label.
+- **Hover**: border strengthens / background lifts (rebate @ 5–7%); no movement on press.
+- **Active/selected**: `--sel-bg` fill, `--sel-ink` label, `--sel-ring` ring; icon takes the accent.
+- **Focus (keyboard)**: 2px accent ring, offset from the control, always visible.
+- **Disabled**: 60% opacity, no hover, `not-allowed`; layout unchanged.
+- **Loading**: shimmer (tiles) or ring (actions); label becomes present-tense status.
+- **Error**: `--stop` border + one blunt line beneath; entered value preserved.
+- **Empty**: dashed frame + one-line guidance; never a bare blank region.
+
+## Information architecture
+
+Four workspaces plus Settings — the entire surface area; do not re-expand it:
+
+1. **Create** — compose & generate (home). Prompt, style, model, shape, resolution, result, activity.
+2. **Library** — browse everything generated. Prints, filters, search, viewer.
+3. **Models** — installed & discoverable weights. Rows, detail, pull.
+4. **Machines** — local + remote GPUs. Host cards, telemetry, connect flow.
+5. **Settings** — appearance & about.
+
+Advanced (Create) is six collapsed accordion sections: Scheduler & sampling ·
+Negative prompt · Source image · LoRA stack · Upscale after generate · Output &
+seed — with an active-count badge and a Reset. On web at tablet width and
+above, these render inline in the Create controls region (still collapsed);
+phone surfaces keep the Advanced sheet.
+
+## Content & voice
+
+- Product name **mold** always lowercase; commands lowercase mono (`mold run`, `mold pull flux-dev:q4`).
+- Section titles Title Case; table headers UPPERCASE; status values lowercase (`loaded`, `ready`, `developing`).
+- Model ids as `family:variant`. Units tight: `6.9 GB`, `18.4 MiB/s`, `eta 6m 12s`.
+- Feedback glyphs only: ✓ done · ★ loaded · • info. **No emoji** in product UI. Error copy is blunt and short.

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,10 @@ uat-*
 *.mp4
 *.zip
 .superpowers/
+
+# design-sync (claude.ai/design) — staged scripts, build output, machine state
+.ds-sync/
+ds-bundle/
+.design-sync/.cache/
+.design-sync/learnings/
+.design-sync/node_modules

--- a/desktop/src/styles/tokens.contrast.test.ts
+++ b/desktop/src/styles/tokens.contrast.test.ts
@@ -9,17 +9,20 @@ const css = readFileSync("../ui/tokens.css", "utf8");
 
 type Palette = Record<string, string>;
 
-function block(selector: string): string {
+function block(selector: string, nth = 1): string {
   const marker = `${selector} {`;
-  const start = css.indexOf(marker);
-  if (start < 0) throw new Error(`Missing CSS block: ${selector}`);
+  let start = -1;
+  for (let i = 0; i < nth; i++) {
+    start = css.indexOf(marker, start + 1);
+    if (start < 0) throw new Error(`Missing CSS block: ${selector} (occurrence ${nth})`);
+  }
   const bodyStart = start + marker.length;
   return css.slice(bodyStart, css.indexOf("}", bodyStart));
 }
 
-function declarations(selector: string): Palette {
+function declarations(selector: string, nth = 1): Palette {
   return Object.fromEntries(
-    [...block(selector).matchAll(/--([\w-]+):\s*([^;]+);/g)].map((match) => [
+    [...block(selector, nth).matchAll(/--([\w-]+):\s*([^;]+);/g)].map((match) => [
       match[1]!,
       match[2]!.trim(),
     ]),
@@ -78,16 +81,20 @@ function token(theme: Palette, name: string): string {
   return value;
 }
 
+// System-light palettes live in `@media (prefers-color-scheme: light)` blocks
+// whose selectors are plain `:root` / `:root[data-theme-family="mold"]` (the
+// design-tool token compiler can't read :not() scopes), so they are the SECOND
+// occurrence of those selectors; ui/tokens.test.ts pins that source order.
 const base = declarations(":root");
 const themes = {
   "Safelight dark": base,
-  "Safelight system light": { ...base, ...declarations(':root:not([data-theme="dark"])') },
+  "Safelight system light": { ...base, ...declarations(":root", 2) },
   "Safelight light": { ...base, ...declarations(':root[data-theme="light"]') },
   "Mold dark": { ...base, ...declarations(':root[data-theme-family="mold"]') },
   "Mold system light": {
     ...base,
     ...declarations(':root[data-theme-family="mold"]'),
-    ...declarations(':root[data-theme-family="mold"]:not([data-theme="dark"])'),
+    ...declarations(':root[data-theme-family="mold"]', 2),
   },
   "Mold light": {
     ...base,

--- a/ui/tokens.css
+++ b/ui/tokens.css
@@ -12,6 +12,16 @@
  * halide is cool/informational (models, telemetry, links). Selection derives
  * one set (--sel-*) from the accent — never a new hue. No component may
  * hard-code hex; a new theme is added by extending this file only.
+ *
+ * Scope structure: every block is a plain attribute scope — the light media
+ * blocks use bare :root / :root[data-theme-family="mold"], and explicit
+ * [data-theme="dark"] blocks (specificity over the media block) restore the
+ * dark palette when dark is forced under a light system preference. Design
+ * tokenizers only register properties under plain scopes, so no :not()
+ * selectors here. The resulting cross-scope duplication is guarded by
+ * ui/tokens.test.ts — palettes must stay mirrored between their system-follow
+ * and forced blocks. Trailing "@kind" comments type the tokens whose kind
+ * can't be inferred from the value.
  */
 
 :root {
@@ -27,7 +37,12 @@
   --warning: #f5a623;
   --stop: #e5715a;
   --on-accent: #1a1206;
-  --grad: linear-gradient(96deg, #f0b429, #f0743f 55%, #d96b8f);
+  --grad: linear-gradient(
+    96deg,
+    #f0b429,
+    #f0743f 55%,
+    #d96b8f
+  ); /* @kind color */
   --card-hi: rgba(255, 244, 230, 0.05);
 
   /* ── Derived (recompute automatically per palette) ─────────────── */
@@ -46,9 +61,9 @@
   --on-media: #f5efff;
 
   /* ── Type ──────────────────────────────────────────────────────── */
-  --f-display: "Bricolage Grotesque", system-ui, sans-serif;
-  --f-body: "Schibsted Grotesk", system-ui, sans-serif;
-  --f-mono: "Martian Mono", ui-monospace, monospace;
+  --f-display: "Bricolage Grotesque", system-ui, sans-serif; /* @kind font */
+  --f-body: "Schibsted Grotesk", system-ui, sans-serif; /* @kind font */
+  --f-mono: "Martian Mono", ui-monospace, monospace; /* @kind font */
 
   /* ── Radius: controls 6–10 · cards 12–16 · pills/chips 20 ─────── */
   --radius-control-sm: 6px;
@@ -59,17 +74,17 @@
   --radius-pill: 20px;
 
   /* ── Motion (spec §09) ─────────────────────────────────────────── */
-  --dur-quick: 120ms;
-  --dur-base: 180ms;
-  --dur-slow: 240ms;
-  --ease: cubic-bezier(0.16, 1, 0.3, 1);
+  --dur-quick: 120ms; /* @kind other */
+  --dur-base: 180ms; /* @kind other */
+  --dur-slow: 240ms; /* @kind other */
+  --ease: cubic-bezier(0.16, 1, 0.3, 1); /* @kind other */
 
   color-scheme: dark;
 }
 
-/* ── Safelight · Light ("lights on") ─────────────────────────────── */
+/* ── Safelight · Light ("lights on", following the system) ───────── */
 @media (prefers-color-scheme: light) {
-  :root:not([data-theme="dark"]) {
+  :root {
     --desk: #e6dcc7;
     --bath: #f7f1e6;
     --bench: #fffdf8;
@@ -86,6 +101,26 @@
     color-scheme: light;
   }
 }
+
+/* ── Safelight · forced Dark (undoes the light media block above) ── */
+:root[data-theme="dark"] {
+  --desk: #0a0805;
+  --bath: #171210;
+  --bench: #241c15;
+  --surface: #332619;
+  --rebate: #f1e8da;
+  --halide: #8fb4c4;
+  --safelight: #f79433;
+  --success: #8fd39a;
+  --stop: #e5715a;
+  --on-accent: #1a1206;
+  --grad: linear-gradient(96deg, #f0b429, #f0743f 55%, #d96b8f);
+  --card-hi: rgba(255, 244, 230, 0.05);
+  --ce: color-mix(in srgb, var(--rebate) 30%, transparent);
+  color-scheme: dark;
+}
+
+/* ── Safelight · forced Light ────────────────────────────────────── */
 :root[data-theme="light"] {
   --desk: #e6dcc7;
   --bath: #f7f1e6;
@@ -121,9 +156,9 @@
   color-scheme: dark;
 }
 
-/* ── Mold · Light ────────────────────────────────────────────────── */
+/* ── Mold · Light (following the system) ─────────────────────────── */
 @media (prefers-color-scheme: light) {
-  :root[data-theme-family="mold"]:not([data-theme="dark"]) {
+  :root[data-theme-family="mold"] {
     --desk: #e5e0f1;
     --bath: #f6f4fb;
     --bench: #ffffff;
@@ -140,6 +175,26 @@
     color-scheme: light;
   }
 }
+
+/* ── Mold · forced Dark (undoes the light media block above) ─────── */
+:root[data-theme-family="mold"][data-theme="dark"] {
+  --desk: #08060f;
+  --bath: #14111f;
+  --bench: #221c34;
+  --surface: #2e2743;
+  --rebate: #f3effb;
+  --halide: #5cd0ff;
+  --safelight: #e879f9;
+  --success: #6ee7a5;
+  --stop: #fb7185;
+  --on-accent: #150f1e;
+  --grad: linear-gradient(96deg, #89dceb, #89b4fa 45%, #cba6f7);
+  --card-hi: rgba(255, 255, 255, 0.055);
+  --ce: color-mix(in srgb, var(--rebate) 30%, transparent);
+  color-scheme: dark;
+}
+
+/* ── Mold · forced Light ─────────────────────────────────────────── */
 :root[data-theme-family="mold"][data-theme="light"] {
   --desk: #e5e0f1;
   --bath: #f6f4fb;

--- a/ui/tokens.test.ts
+++ b/ui/tokens.test.ts
@@ -1,0 +1,204 @@
+/*
+ * Structural invariants for tokens.css.
+ *
+ * The file deliberately duplicates palette values across scopes so that both
+ * the browser cascade (system-follow via media query, forced modes via
+ * data-theme) and design-tool token compilers (which only register custom
+ * properties under plain attribute scopes, not :not() selectors) read the
+ * same palettes. Duplication is safe only while these mirrors hold.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const css = readFileSync(join(__dirname, "tokens.css"), "utf8");
+
+/** Strip comments, then collect `selector -> declarations` per media context. */
+function parseBlocks(source: string) {
+  const text = source.replace(/\/\*[\s\S]*?\*\//g, "");
+  const blocks: { media: string | null; selector: string; body: string }[] = [];
+  let i = 0;
+  const readBody = (from: number): [string, number] => {
+    let depth = 1;
+    let j = from;
+    while (j < text.length && depth > 0) {
+      if (text[j] === "{") depth++;
+      else if (text[j] === "}") depth--;
+      j++;
+    }
+    return [text.slice(from, j - 1), j];
+  };
+  while (i < text.length) {
+    const open = text.indexOf("{", i);
+    if (open === -1) break;
+    const selector = text.slice(i, open).trim().split("}").pop()!.trim();
+    if (selector.startsWith("@media")) {
+      const [inner, end] = readBody(open + 1);
+      for (const b of parseBlocks(inner)) {
+        blocks.push({ ...b, media: selector });
+      }
+      i = end;
+    } else {
+      const [body, end] = readBody(open + 1);
+      blocks.push({ media: null, selector, body });
+      i = end;
+    }
+  }
+  return blocks;
+}
+
+function props(body: string): Map<string, string> {
+  const out = new Map<string, string>();
+  for (const m of body.matchAll(/(--[\w-]+)\s*:\s*([^;]+);/g)) {
+    // CSS treats runs of whitespace (incl. prettier's value wrapping) and
+    // paren-adjacent whitespace as insignificant — normalize before comparing.
+    out.set(
+      m[1],
+      m[2]
+        .replace(/\s+/g, " ")
+        .replace(/\(\s+/g, "(")
+        .replace(/\s+\)/g, ")")
+        .trim(),
+    );
+  }
+  return out;
+}
+
+const blocks = parseBlocks(css);
+const find = (selector: string, media: "light" | null) => {
+  const hit = blocks.find(
+    (b) =>
+      b.selector === selector &&
+      (media === "light"
+        ? b.media?.includes("prefers-color-scheme: light")
+        : b.media === null),
+  );
+  expect(
+    hit,
+    `block \`${selector}\`${media ? " in light media query" : ""}`,
+  ).toBeDefined();
+  return props(hit!.body);
+};
+
+const expectMirror = (
+  a: Map<string, string>,
+  b: Map<string, string>,
+  label: string,
+) => {
+  expect([...a.keys()].sort(), `${label}: property sets differ`).toEqual(
+    [...b.keys()].sort(),
+  );
+  for (const [k, v] of a) {
+    expect(b.get(k), `${label}: ${k}`).toBe(v);
+  }
+};
+
+describe("tokens.css scope structure", () => {
+  it("uses only compiler-recognized scopes (no :not() selectors)", () => {
+    for (const b of blocks) {
+      expect(
+        b.selector,
+        "selectors must stay plain attribute scopes",
+      ).not.toContain(":not(");
+    }
+  });
+
+  it("system-follow light mirrors forced light (Safelight)", () => {
+    expectMirror(
+      find(":root", "light"),
+      find(':root[data-theme="light"]', null),
+      "safelight light",
+    );
+  });
+
+  it("system-follow light mirrors forced light (Mold)", () => {
+    expectMirror(
+      find(':root[data-theme-family="mold"]', "light"),
+      find(':root[data-theme-family="mold"][data-theme="light"]', null),
+      "mold light",
+    );
+  });
+
+  it("forced dark mirrors the base palette for every light-overridden prop (Safelight)", () => {
+    const base = find(":root", null);
+    const forcedDark = find(':root[data-theme="dark"]', null);
+    // The forced-dark block exists to undo the light media block, so it must
+    // cover exactly the same property names, with the base dark values.
+    expect([...forcedDark.keys()].sort()).toEqual(
+      [...find(":root", "light").keys()].sort(),
+    );
+    for (const [k, v] of forcedDark) {
+      expect(base.get(k), `forced dark ${k} must equal the base value`).toBe(v);
+    }
+  });
+
+  it("forced dark mirrors the family palette for every light-overridden prop (Mold)", () => {
+    const moldBase = find(':root[data-theme-family="mold"]', null);
+    const forcedDark = find(
+      ':root[data-theme-family="mold"][data-theme="dark"]',
+      null,
+    );
+    expect([...forcedDark.keys()].sort()).toEqual(
+      [...find(':root[data-theme-family="mold"]', "light").keys()].sort(),
+    );
+    for (const [k, v] of forcedDark) {
+      expect(
+        moldBase.get(k),
+        `mold forced dark ${k} must equal the family base value`,
+      ).toBe(v);
+    }
+  });
+
+  it("keeps the cascade tie-breaks: safelight before mold, family base before its light media block", () => {
+    const order = (selector: string, media: boolean) => {
+      const rx = new RegExp(
+        selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") + "\\s*\\{",
+      );
+      const idx = [...css.matchAll(new RegExp(rx, "g"))].map((m) => m.index!);
+      // Media-wrapped and bare occurrences are disambiguated by surrounding text.
+      for (const at of idx) {
+        const before = css.slice(0, at);
+        const inMedia =
+          (before.match(/@media[^{]*\{/g) ?? []).length >
+          (before.match(/\}\s*\}/g) ?? []).length;
+        if (inMedia === media) return at;
+      }
+      return -1;
+    };
+    const safelightForcedLight = order(':root[data-theme="light"]', false);
+    const moldBase = order(':root[data-theme-family="mold"]', false);
+    const moldLightMedia = order(':root[data-theme-family="mold"]', true);
+    expect(safelightForcedLight).toBeGreaterThan(-1);
+    expect(moldBase).toBeGreaterThan(safelightForcedLight);
+    expect(moldLightMedia).toBeGreaterThan(moldBase);
+  });
+});
+
+describe("tokens.css design-tool annotations", () => {
+  // Tokens whose kind a compiler cannot infer from the value carry an
+  // explicit `/* @kind ... */` trailing comment at their base definition.
+  const kinds: Record<string, string> = {
+    "--grad": "color",
+    "--f-display": "font",
+    "--f-body": "font",
+    "--f-mono": "font",
+    "--dur-quick": "other",
+    "--dur-base": "other",
+    "--dur-slow": "other",
+    "--ease": "other",
+  };
+  for (const [token, kind] of Object.entries(kinds)) {
+    it(`${token} is annotated @kind ${kind}`, () => {
+      const rx = new RegExp(
+        token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") +
+          String.raw`\s*:[^;]+;\s*/\*\s*@kind ` +
+          kind +
+          String.raw`\s*\*/`,
+      );
+      expect(
+        rx.test(css),
+        `${token} needs a trailing /* @kind ${kind} */`,
+      ).toBe(true);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Durable inputs from the design-system sync of the Mold Studio kit (`ui/`) to claude.ai/design, plus upstream fixes for the two issues the Claude Design compiler reported against the synced tokens.

### Sync inputs (first commit)

- `.design-sync/config.json` — converter config (tokens-only shape, entry, CSS routing, fonts, guidelines glob, README header) pinned to the "Mold Studio" design project
- `.design-sync/NOTES.md` — repo-specific gotchas + re-sync risks (spec-drift watch-list)
- `.design-sync/conventions.md` — the README header inlined into the design agent's prompt: token idiom, theme attributes, icon usage, voice — every named token/class/icon validated against the built bundle
- `.design-sync/guidelines/mold-studio-guidelines.md` — distilled from `docs/design/mold-studio-spec.html` v0.12
- `.design-sync/ds-css.ts` — 2-line carrier that routes `kit.css` through the esbuild CSS graph
- `.gitignore` — excludes the staged converter scripts, build output, and machine state

### Token-compiler fixes (`refactor(ui)` commit)

The Claude Design compiler flagged two things in the synced CSS, both rooted in `ui/tokens.css`:

1. **26 declarations invisible to its token registry** — they sat under `:root:not([data-theme="dark"])` inside `@media (prefers-color-scheme: light)`, a scope shape token compilers don't read. The light media blocks now use bare `:root` / `:root[data-theme-family="mold"]`, with new explicit forced-dark blocks (`[data-theme="dark"]`) restoring the dark palette when dark is forced under a light system preference.
2. **8 tokens with non-inferable kinds** — `--grad`, `--f-display/--f-body/--f-mono`, `--dur-quick/--dur-base/--dur-slow/--ease` now carry trailing `/* @kind ... */` comments.

**Behavior is provably unchanged**: a 36-state playwright matrix (family × data-theme × color-scheme × reduced-motion, with resolved paint probes) compares old vs new computed values — zero differences — and an adversarial cascade review covering unknown/empty attribute values, specificity ties, and value-by-value palette diffs confirmed equivalence. A repo-wide sweep found no code or styles competing with the changed selector specificity.

**Guard rails added**:
- `ui/tokens.test.ts` (runs in the desktop vitest gate) enforces the new invariants: no `:not()` scopes, system-follow palettes mirror their forced twins, forced-dark mirrors the base palettes, cascade order, and the `@kind` annotations.
- `desktop/src/styles/tokens.contrast.test.ts` updated to address the media-wrapped second occurrence of a selector (the WCAG contrast guard now covers the same six themes as before).
- Both files are prettier-formatted per the desktop `fmt:check` gate that covers `ui/`.

The synced project has been re-uploaded with the fixed tokens; the two compiler flags should clear on next open. If the compiler still can't read media-wrapped plain scopes, the documented fallback (see NOTES.md) is attribute-only theming — a cross-surface refactor that needs explicit sign-off first.