### PR TITLE
fix(about): align privacy and contributor details

### DIFF
--- a/.claude/skills/mold/SKILL.md
+++ b/.claude/skills/mold/SKILL.md
@@ -9,10 +9,10 @@ allowed-tools: Bash, Read, Glob, Grep
 
 Generate images and video from text prompts using FLUX, SD1.5, SDXL, SD3.5, Z-Image, Flux.2 Klein, Qwen-Image, LTX Video, LTX-2 / LTX-2.3, and Wuerstchen diffusion models running on local GPU hardware.
 
-The iPhone app's public privacy policy is sourced at `website/privacy.md`,
-published at `https://utensils.io/mold/privacy`, and linked from its Settings →
-About surface. Keep the page and app link aligned when mobile data practices
-change.
+The native apps' public privacy policy is sourced at `website/privacy.md`,
+published at `https://utensils.io/mold/privacy`, and linked from the desktop and
+iPhone Settings → About surfaces. Keep the page and app links aligned when data
+practices change.
 
 ## Quick Reference
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Mold Remote now publishes and links its privacy policy.** The website has a dedicated policy covering on-device storage, Keychain credentials, user-selected Mold server traffic, third-party model catalogs, TestFlight, and deletion choices; iPhone Settings → About opens it in the external browser for an App Store-compliant in-app disclosure.
+- **Mold Remote now publishes and links its privacy policy.** The website has a dedicated policy covering on-device storage, Keychain credentials, user-selected Mold server traffic, third-party model catalogs, TestFlight, and deletion choices; iPhone and desktop Settings → About open it in the external browser for an App Store-compliant in-app disclosure and cross-platform parity.
 
-- **Project attribution now consistently credits both core contributors and equal owners.** Desktop, web, and iPhone About surfaces; native package metadata; Rust crate authors; website and README ownership copy; and AUR maintainer headers now name James Brink and Jeffrey Dilley, matching the MIT license.
+- **Project attribution now consistently credits both core contributors.** Desktop, web, and iPhone About surfaces; native package metadata; Rust crate authors; website and README ownership copy; and AUR maintainer headers now name James Brink and Jeffrey Dilley, matching the MIT license.
 
 - **TestFlight uploads now support external testers.** The iOS export no longer marks every IPA as internal-only, so the same validated build can stay in `Mold Internal` and be selected by an external group for Beta App Review; the iOS CI gate prevents that restriction from returning.
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ independently of This Mac's startup; unreachable hosts stay visible and retry.
 Chain authoring inside Create also uses the all-host video-model union and keeps
 creation, progress, previews, and durable job actions routed to the selected
 model's host.
+Desktop Settings → About links to the public
+[Mold privacy policy](https://utensils.io/mold/privacy), matching the iPhone app.
 
 Desktop prompt expansion follows the visible Batch count. Batch 1 is a quick
 rewrite with undo; larger batches prepare exactly N editable variations for

--- a/desktop/docs/architecture.md
+++ b/desktop/docs/architecture.md
@@ -54,6 +54,8 @@ Per-view consumer IDs and synchronous unmount invalidation keep late
 expansion, preprocessing, pull, and retry callbacks from acting on a remount.
 Capability discovery is advisory
 per host and never participates in fallback routing.
+Desktop Settings → About opens the public Mold privacy policy through the native
+external-browser opener, matching the iPhone disclosure.
 Library merges every saved remote host, streams full-size media through a
 short-lived path-scoped ticket, plays videos with native seeking, swipes between
 prints, and exposes explicit Use as prompt / Use as source actions. Host detail

--- a/desktop/src-tauri/src/menu.rs
+++ b/desktop/src-tauri/src/menu.rs
@@ -32,9 +32,7 @@ fn about_metadata(app_name: &str) -> AboutMetadata<'static> {
         license: Some("MIT License".into()),
         website: Some("https://github.com/utensils/mold".into()),
         website_label: Some("Mold on GitHub".into()),
-        credits: Some(
-            "Core contributors and equal project owners:\nJames Brink\nJeffrey Dilley".into(),
-        ),
+        credits: Some("Core contributors:\nJames Brink\nJeffrey Dilley".into()),
         ..Default::default()
     }
 }
@@ -257,8 +255,10 @@ mod tests {
             about.authors,
             Some(vec!["James Brink".into(), "Jeffrey Dilley".into()])
         );
-        assert!(about.credits.as_deref().unwrap().contains("James Brink"));
-        assert!(about.credits.as_deref().unwrap().contains("Jeffrey Dilley"));
+        assert_eq!(
+            about.credits.as_deref(),
+            Some("Core contributors:\nJames Brink\nJeffrey Dilley")
+        );
     }
 
     #[test]

--- a/desktop/src/components/settings/AboutSection.test.ts
+++ b/desktop/src/components/settings/AboutSection.test.ts
@@ -3,6 +3,9 @@ import { createPinia, setActivePinia } from "pinia";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import AboutSection from "./AboutSection.vue";
 
+const { openExternalMock } = vi.hoisted(() => ({ openExternalMock: vi.fn() }));
+vi.mock("../../lib/openExternal", () => ({ openExternal: openExternalMock }));
+
 vi.mock("../../lib/api/client", () => ({
   apiJson: vi.fn().mockRejectedValue(new Error("offline")),
 }));
@@ -13,12 +16,26 @@ vi.mock("../../lib/ipc", () => ({
 }));
 
 describe("AboutSection", () => {
-  beforeEach(() => setActivePinia(createPinia()));
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    openExternalMock.mockClear();
+  });
 
   it("credits both core contributors", () => {
     const wrapper = mount(AboutSection);
 
+    expect(wrapper.text()).toContain("Core contributors");
     expect(wrapper.text()).toContain("James Brink");
     expect(wrapper.text()).toContain("Jeffrey Dilley");
+    expect(wrapper.text()).not.toMatch(/equal (project )?owners/i);
+  });
+
+  it("opens the public privacy policy", async () => {
+    const wrapper = mount(AboutSection);
+
+    await wrapper.get("[data-test='desktop-privacy-policy']").trigger("click");
+
+    expect(openExternalMock).toHaveBeenCalledOnce();
+    expect(openExternalMock).toHaveBeenCalledWith("https://utensils.io/mold/privacy");
   });
 });

--- a/desktop/src/components/settings/AboutSection.vue
+++ b/desktop/src/components/settings/AboutSection.vue
@@ -3,6 +3,7 @@ import { onMounted, ref } from "vue";
 import SettingRow from "./SettingRow.vue";
 import { apiJson } from "../../lib/api/client";
 import { ipc, inTauri } from "../../lib/ipc";
+import { openExternal } from "../../lib/openExternal";
 import { useConnectionStore } from "../../stores/connection";
 import { useToastStore } from "../../stores/toasts";
 import type { ServerStatus } from "../../lib/api/types";
@@ -11,6 +12,7 @@ const conn = useConnectionStore();
 const toasts = useToastStore();
 const engine = ref<ServerStatus | null>(null);
 const appVersion = ref<string | null>(null);
+const PRIVACY_POLICY_URL = "https://utensils.io/mold/privacy";
 
 onMounted(async () => {
   try {
@@ -38,6 +40,10 @@ async function copyDiagnostics() {
   await navigator.clipboard.writeText(JSON.stringify(report, null, 2));
   toasts.push("Diagnostics copied");
 }
+
+function openPrivacyPolicy(): void {
+  void openExternal(PRIVACY_POLICY_URL);
+}
 </script>
 
 <template>
@@ -53,8 +59,18 @@ async function copyDiagnostics() {
     <SettingRow label="Processing" help="Where generations run.">
       <span class="data-mono text-body text-ink-3">Local + your hosts</span>
     </SettingRow>
-    <SettingRow label="Core contributors" help="Equal project owners.">
+    <SettingRow label="Core contributors">
       <span class="text-right text-body text-ink-2">James Brink · Jeffrey Dilley</span>
+    </SettingRow>
+    <SettingRow label="Privacy" help="How Mold handles app and server data.">
+      <button
+        type="button"
+        data-test="desktop-privacy-policy"
+        class="border-edge h-7 rounded-control border px-2.5 text-body text-ink-2 hover:text-ink"
+        @click="openPrivacyPolicy"
+      >
+        Privacy policy
+      </button>
     </SettingRow>
     <SettingRow label="Logs" help="Engine and app logs live in ~/.mold/logs.">
       <button

--- a/desktop/src/mobile/MobileSettingsView.test.ts
+++ b/desktop/src/mobile/MobileSettingsView.test.ts
@@ -25,6 +25,7 @@ describe("MobileSettingsView", () => {
     expect(wrapper.text()).toContain("0.18.0");
     expect(wrapper.text()).toContain("James Brink");
     expect(wrapper.text()).toContain("Jeffrey Dilley");
+    expect(wrapper.text()).not.toMatch(/equal (project )?owners/i);
 
     await wrapper.get('input[name="mobile-theme-family"][value="safelight"]').setValue(true);
     await wrapper.get('input[name="mobile-theme-appearance"][value="light"]').setValue(true);

--- a/desktop/src/mobile/MobileSettingsView.vue
+++ b/desktop/src/mobile/MobileSettingsView.vue
@@ -151,7 +151,7 @@ function openPrivacyPolicy(): void {
         </div>
         <div>
           <dt>Core contributors</dt>
-          <dd>James Brink · Jeffrey Dilley<br />Equal project owners</dd>
+          <dd>James Brink · Jeffrey Dilley</dd>
         </div>
       </dl>
     </section>

--- a/web/src/pages/SettingsPage.test.ts
+++ b/web/src/pages/SettingsPage.test.ts
@@ -38,8 +38,10 @@ describe("SettingsPage", () => {
     expect(wrapper.get("h1").text()).toBe("Settings");
     expect(wrapper.get('[data-test="about-version"]').text()).toBe("9.9.9");
     expect(wrapper.text()).toContain("local + your hosts");
+    expect(wrapper.text()).toContain("Core contributors");
     expect(wrapper.text()).toContain("James Brink");
     expect(wrapper.text()).toContain("Jeffrey Dilley");
+    expect(wrapper.text()).not.toMatch(/equal (project )?owners/i);
   });
 
   it("falls back to an em dash when the server version is unknown", () => {

--- a/web/src/pages/SettingsPage.vue
+++ b/web/src/pages/SettingsPage.vue
@@ -271,7 +271,7 @@ const version = computed(() => status.value?.version ?? "—");
         </span>
       </div>
       <div class="about-row about-row--last">
-        <span class="about-row__key">Core contributors · equal owners</span>
+        <span class="about-row__key">Core contributors</span>
         <span class="about-row__val">James Brink · Jeffrey Dilley</span>
       </div>
     </CardSurface>

--- a/website/guide/desktop.md
+++ b/website/guide/desktop.md
@@ -130,8 +130,8 @@ surface powers it, so anything the app does maps to a documented endpoint.
   create), and Advanced — every remaining `/api/config` row with its provenance
   tag (⌂ db / ⛁ file / ⚿ env); environment-overridden rows are locked with the
   variable that owns them.
-  About credits core contributors and equal project owners James Brink and
-  Jeffrey Dilley in both the Settings workspace and the native app menu.
+  About credits core contributors James Brink and Jeffrey Dilley in both the
+  Settings workspace and the native app menu.
 - **Command palette** — **Cmd/Ctrl+K** for navigation, actions, model search, and
   prompt-history search in one field.
 - **Native desktop integration** — platform menus and shortcuts, Linux native


### PR DESCRIPTION
## Summary

- add the published privacy-policy link to Desktop Settings → About
- standardize desktop, native macOS, web, and iPhone attribution as “Core contributors”
- remove the awkward “equal owners” wording and keep documentation aligned

## Why

The desktop app was missing the privacy-policy link already available on iPhone, and the native About dialog’s long contributor heading wrapped awkwardly.

## Validation

- desktop About and iPhone Settings tests
- web Settings tests
- native Tauri About metadata test through `nix develop`
- desktop, mobile, and web production builds
- Prettier and `git diff --check`
