### PR TITLE
fix(web): restore Create input contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Web Create restores the full model-specific input contract.** Qwen-Image-Edit exposes its required target/reference attachment path; the real GPU Placement panel is rendered and tested; SDXL guidance reaches 20; source fitting offers Contain, Cover, Pad + repaint, Lanczos, and Upscale + fit; ControlNet suggests installed checkpoints while preserving custom input; and still-image requests no longer leak source strength or video-only fields.
 - **Web Create now owns remote work end to end.** Cancel sends `DELETE /api/queue/:id` to the job's snapshotted host instead of only closing the browser stream, queue reconciliation checks each machine's own queue, running work has a Cancel control, generation failures stay visible in the canvas, and source preprocessing plus prompt expansion use the selected route. Batch expansion now requests the exact number of prompts from `/api/expand`, preserves reviewed work when its prompt/model/family/host inputs become stale, and records one shared `batch_id` with one-based sibling indexes and the original prompt.
 - `mold tui` / `mold serve` builds no longer fail with a vite `Plugin<any> is not assignable to PluginOption` type explosion on checkouts that predate the unified frontend workspace: `scripts/ensure-web-dist.sh` now removes a leftover per-package `web/node_modules` (detected by it containing its own vite copy) before building, so TypeScript resolves exactly one vite/rollup toolchain from the repo-root workspace.
 

--- a/web/src/components/create/AdvancedDrawer.test.ts
+++ b/web/src/components/create/AdvancedDrawer.test.ts
@@ -52,7 +52,6 @@ function factory(
     global: {
       stubs: {
         LoraPicker: { template: "<div data-test='lora-picker-stub' />" },
-        PlacementPanel: { template: "<div data-test='placement-stub' />" },
         RouterLink: { template: "<a><slot /></a>" },
       },
     },
@@ -97,8 +96,11 @@ describe("AdvancedDrawer capability matrix", () => {
     expect(s.output).toBe(true);
   });
 
-  it("qwen-image-edit hides the single-image source section", () => {
-    expect(sections("qwen-image-edit").source).toBe(false);
+  it("qwen-image-edit exposes its required edit-image attachment section", async () => {
+    const wrapper = factory("qwen-image-edit");
+    expect(sections("qwen-image-edit").source).toBe(true);
+    expect(wrapper.find("[data-test='source-attach']").exists()).toBe(true);
+    expect(wrapper.text()).toContain("Edit images");
   });
 
   it("ltx2 exposes the video section", () => {
@@ -118,6 +120,42 @@ describe("AdvancedDrawer capability matrix", () => {
       sections("flux", { placementGpus: [{ ordinal: 0, name: "GPU 0" }] })
         .placement,
     ).toBe(true);
+  });
+
+  it("renders the real placement child with the selected placement", async () => {
+    const placement = { text_encoders: { kind: "cpu" as const } };
+    const wrapper = factory(
+      "flux",
+      { placement },
+      { placementGpus: [{ ordinal: 0, name: "GPU 0" }] },
+    );
+    await wrapper
+      .get("[data-test='section-placement'] .ms-acc__head")
+      .trigger("click");
+    expect(
+      wrapper.getComponent({ name: "PlacementPanel" }).props("modelValue"),
+    ).toEqual(placement);
+  });
+
+  it("offers all five source-fit policies", async () => {
+    const wrapper = factory("sdxl", {
+      imageAttachments: [
+        { kind: "upload", filename: "source.png", base64: "AA" },
+      ],
+    });
+    await wrapper
+      .get("[data-test='section-source'] .ms-acc__head")
+      .trigger("click");
+    const labels = wrapper
+      .findAll("[aria-label='Fit to canvas'] button")
+      .map((button) => button.text());
+    expect(labels).toEqual([
+      "Contain",
+      "Cover",
+      "Pad + repaint",
+      "Lanczos",
+      "Upscale + fit",
+    ]);
   });
 });
 
@@ -198,6 +236,27 @@ describe("AdvancedDrawer ControlNet block", () => {
       GenerateFormState,
     ];
     expect(next.controlModel).toBe("control_v11p_sd15_canny");
+  });
+
+  it("suggests installed ControlNet models while retaining custom input", async () => {
+    const wrapper = await openSource("sd15", {
+      controlImage: { kind: "upload", filename: "canny.png", base64: "AA" },
+    });
+    await wrapper.setProps({
+      models: [
+        {
+          ...UPSCALERS[0],
+          name: "controlnet-canny-sd15:fp16",
+          family: "controlnet",
+        },
+      ],
+    });
+    expect(wrapper.get("[data-test='control-model']").attributes("list")).toBe(
+      "installed-controlnet-models",
+    );
+    expect(
+      wrapper.get("#installed-controlnet-models option").attributes("value"),
+    ).toBe("controlnet-canny-sd15:fp16");
   });
 
   it("round-trips the control scale slider", async () => {

--- a/web/src/components/create/AdvancedDrawer.vue
+++ b/web/src/components/create/AdvancedDrawer.vue
@@ -28,6 +28,7 @@ import type {
   DevicePlacement,
   GenerateFormState,
   LoraSelection,
+  ModelInfoExtended,
   OutputFormat,
   Scheduler,
   SourceFitPolicy,
@@ -61,6 +62,8 @@ const props = withDefaults(
     openTo?: SectionKey | null;
     /** GPUs for the placement section (empty → section hidden). */
     placementGpus?: { ordinal: number; name: string }[];
+    /** Installed models on the selected generation route. */
+    models?: ModelInfoExtended[];
   }>(),
   {
     open: false,
@@ -68,6 +71,7 @@ const props = withDefaults(
     mobile: false,
     openTo: null,
     placementGpus: () => [],
+    models: () => [],
   },
 );
 
@@ -114,7 +118,7 @@ const visibleSections = computed<SectionKey[]>(() => {
   const out: SectionKey[] = [];
   if (showScheduler.value) out.push("scheduler");
   if (caps.value.supportsNegativePrompt) out.push("negative");
-  if (caps.value.sourceImageMode === "single") out.push("source");
+  out.push("source");
   if (caps.value.supportsLora) out.push("lora");
   out.push("output");
   if (caps.value.supportsVideo) out.push("video");
@@ -191,11 +195,24 @@ const fitOptions = [
   { value: "pad-fit", label: "Contain" },
   { value: "crop-fill", label: "Cover" },
   { value: "pad-repaint", label: "Pad + repaint" },
+  { value: "lanczos-resize", label: "Lanczos" },
+  { value: "upscale-then-fit", label: "Upscale + fit" },
 ] as const;
 const fitMode = computed(
   () => props.modelValue.sourceFitPolicy?.mode ?? "pad-repaint",
 );
 function setFit(mode: string) {
+  if (mode === "upscale-then-fit") {
+    patch({
+      sourceFitPolicy: {
+        mode,
+        upscalerModel:
+          props.modelValue.upscaleModel || "real-esrgan-x4plus:fp16",
+        fit: { mode: "crop-fill" },
+      },
+    });
+    return;
+  }
   patch({ sourceFitPolicy: { mode } as SourceFitPolicy });
 }
 
@@ -208,6 +225,11 @@ function setFit(mode: string) {
 // only when a control image is present).
 const showControlNet = computed(() => caps.value.supportsControlNet);
 const hasControl = computed(() => props.modelValue.controlImage != null);
+const controlModels = computed(() =>
+  props.models.filter(
+    (model) => model.downloaded && model.family === "controlnet",
+  ),
+);
 async function readControlImage(
   event: Event,
 ): Promise<SourceImageState | null> {
@@ -404,13 +426,18 @@ function resetAdvanced() {
       </AccordionSection>
 
       <AccordionSection
-        v-if="caps.sourceImageMode === 'single'"
         icon="image"
-        title="Source image"
+        :title="
+          caps.sourceImageMode === 'qwen-edit' ? 'Edit images' : 'Source image'
+        "
         :summary="
           hasSource
-            ? `1 image · denoise ${modelValue.strength.toFixed(2)}`
-            : 'Image-to-image & inpainting'
+            ? caps.sourceImageMode === 'qwen-edit'
+              ? `${modelValue.imageAttachments.length} attached`
+              : `1 image · denoise ${modelValue.strength.toFixed(2)}`
+            : caps.sourceImageMode === 'qwen-edit'
+              ? 'Target and reference images'
+              : 'Image-to-image & inpainting'
         "
         :open="openSection === 'source'"
         data-test="section-source"
@@ -423,7 +450,11 @@ function resetAdvanced() {
           data-test="source-attach"
           @click="emit('open-picker')"
         >
-          Drop an image or <span class="adv__accent">browse</span>
+          {{
+            caps.sourceImageMode === "qwen-edit"
+              ? "Attach images or "
+              : "Drop an image or "
+          }}<span class="adv__accent">browse</span>
         </button>
         <div v-else>
           <div class="adv__source-row">
@@ -440,6 +471,7 @@ function resetAdvanced() {
             </button>
           </div>
           <SliderRow
+            v-if="caps.sourceImageMode === 'single'"
             label="Denoise strength"
             :model-value="modelValue.strength"
             :min="0"
@@ -448,7 +480,7 @@ function resetAdvanced() {
             :value-label="modelValue.strength.toFixed(2)"
             @update:model-value="patch({ strength: $event })"
           />
-          <div class="adv__field">
+          <div v-if="caps.sourceImageMode === 'single'" class="adv__field">
             <label class="adv__label">Fit to canvas</label>
             <SegmentedControl
               :model-value="fitMode"
@@ -511,6 +543,7 @@ function resetAdvanced() {
               <input
                 class="adv__input"
                 data-test="control-model"
+                list="installed-controlnet-models"
                 placeholder="e.g. control_v11p_sd15_canny"
                 :value="modelValue.controlModel"
                 @input="
@@ -519,6 +552,13 @@ function resetAdvanced() {
                   })
                 "
               />
+              <datalist id="installed-controlnet-models">
+                <option
+                  v-for="model in controlModels"
+                  :key="model.name"
+                  :value="model.name"
+                />
+              </datalist>
             </div>
             <SliderRow
               label="Control scale"

--- a/web/src/components/create/ControlsAside.test.ts
+++ b/web/src/components/create/ControlsAside.test.ts
@@ -4,6 +4,7 @@ import ControlsAside from "./ControlsAside.vue";
 import ShapePicker from "@ui/components/ShapePicker.vue";
 import ResolutionSelector from "@ui/components/ResolutionSelector.vue";
 import Stepper from "@ui/components/Stepper.vue";
+import SliderRow from "@ui/components/SliderRow.vue";
 import { dimsForMp } from "@ui/lib/resolution";
 import {
   useGenerateForm,
@@ -61,6 +62,14 @@ describe("ControlsAside", () => {
     expect(wrapper.getComponent(ResolutionSelector).props("modelValue")).toBe(
       1,
     );
+  });
+
+  it("keeps the full SDXL guidance range reachable", () => {
+    const wrapper = factory({}, "sdxl");
+    const strength = wrapper
+      .findAllComponents(SliderRow)
+      .find((row) => row.props("label") === "Prompt strength");
+    expect(strength?.props("max")).toBe(20);
   });
 
   it("applies the projected dims when a shape is picked", async () => {

--- a/web/src/components/create/ControlsAside.vue
+++ b/web/src/components/create/ControlsAside.vue
@@ -153,7 +153,7 @@ function setSeed(value: number) {
         label="Prompt strength"
         :model-value="modelValue.guidance"
         :min="0"
-        :max="12"
+        :max="20"
         :step="0.5"
         :value-label="modelValue.guidance.toFixed(1)"
         @update:model-value="patch({ guidance: $event })"

--- a/web/src/composables/useGenerateForm.test.ts
+++ b/web/src/composables/useGenerateForm.test.ts
@@ -426,6 +426,25 @@ describe("useGenerateForm", () => {
     expect(wire.edit_images).toBeUndefined();
   });
 
+  it("prunes source and video fields that are irrelevant to the selected family", () => {
+    const form = useGenerateForm();
+    Object.assign(form.state.value, {
+      model: "sdxl:fp16",
+      modelFamily: "sdxl",
+      imageAttachments: [],
+      strength: 0.42,
+      frames: 97,
+      fps: 30,
+      gifPreview: true,
+    });
+
+    const wire = form.toRequest();
+    expect(wire.strength).toBeUndefined();
+    expect(wire.frames).toBeUndefined();
+    expect(wire.fps).toBeUndefined();
+    expect(wire.gif_preview).toBeUndefined();
+  });
+
   it("serializes backend-supported advanced generation knobs", () => {
     const form = useGenerateForm();
     Object.assign(form.state.value, {

--- a/web/src/composables/useGenerateForm.ts
+++ b/web/src/composables/useGenerateForm.ts
@@ -563,7 +563,7 @@ export function useGenerateForm(): UseGenerateForm {
               source_image_name: attachments[0]?.base64
                 ? attachments[0].filename
                 : undefined,
-              strength: s.strength,
+              strength: attachments[0]?.base64 ? s.strength : undefined,
               mask_image: s.maskImage?.base64 ?? undefined,
               control_image: capabilities.supportsControlNet
                 ? (s.controlImage?.base64 ?? undefined)
@@ -574,10 +574,11 @@ export function useGenerateForm(): UseGenerateForm {
                 s.controlImage && controlModel ? s.controlScale : undefined,
             }),
         expand: s.expand.enabled || undefined,
-        frames: s.frames,
-        fps: s.fps,
+        frames: capabilities.supportsVideo ? s.frames : undefined,
+        fps: capabilities.supportsVideo ? s.fps : undefined,
         upscale_model: upscaleModel || undefined,
-        gif_preview: s.gifPreview || undefined,
+        gif_preview:
+          capabilities.supportsVideo && s.gifPreview ? true : undefined,
         placement: s.placement ?? undefined,
         loras,
         enable_audio: s.enableAudio ?? undefined,

--- a/web/src/pages/CreatePage.vue
+++ b/web/src/pages/CreatePage.vue
@@ -1419,6 +1419,7 @@ onBeforeUnmount(() => {
           :adv-count="advCount"
           :open-to="advOpenTo"
           :placement-gpus="gpuListForPlacement"
+          :models="models"
           @open-picker="showPicker = true"
           @clear-source="onClearSource"
           @open-mask="showMask = true"
@@ -1439,6 +1440,7 @@ onBeforeUnmount(() => {
         :adv-count="advCount"
         :open-to="advOpenTo"
         :placement-gpus="gpuListForPlacement"
+        :models="models"
         @close="showAdvanced = false"
         @open-picker="showPicker = true"
         @clear-source="onClearSource"
@@ -1467,6 +1469,10 @@ onBeforeUnmount(() => {
     />
     <ImagePickerModal
       :open="showPicker"
+      :title="
+        currentFamily === 'qwen-image-edit' ? 'Edit images' : 'Source image'
+      "
+      :multiple="currentFamily === 'qwen-image-edit'"
       @pick="onPickSource"
       @close="showPicker = false"
     />

--- a/website/guide/generating.md
+++ b/website/guide/generating.md
@@ -77,6 +77,11 @@ Use regular img2img families when you need `--strength`-based denoising.
 Use `qwen-image-edit` when you want instruction-following edits against one or
 more reference images.
 
+In Mold Studio's web Create workspace, open **Advanced → Edit images** to attach
+the ordered target and reference images. Ordinary source-image families instead
+show denoise strength plus all five fit policies; SD1.5 also suggests installed
+ControlNet checkpoints while allowing a custom checkpoint name.
+
 ## Video Generation
 
 mold supports text-to-video generation with the LTX Video model family. Video


### PR DESCRIPTION
## What changed

- expose Qwen-Image-Edit target/reference attachments in Advanced
- render and test the real GPU placement child
- restore SDXL guidance through 20 and all five source-fit policies
- suggest installed ControlNet checkpoints while retaining custom-name input
- prune source strength and video-only fields from unrelated requests
- label the source picker for single-source versus edit-image workflows

## Why

The Mold Studio redesign left several valid backend capabilities unreachable or emitted stale fields from families that do not accept them. Qwen edit was especially severe: the model could be selected, but there was no UI path to attach its required images.

## Validation

- bun run check:architecture
- bun run check:dead-code
- bun run --cwd web test (738 tests)
- bun run --cwd web build
- bun run --cwd web fmt:check
- bun run --cwd website fmt:check
- bun run --cwd website verify
- bun run --cwd website build

Progresses #473 and #465.