### PR TITLE
chore(desktop): sync Cargo.lock with mold-db's new fs2 dependency

### DIFF
--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -2052,6 +2052,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3896,6 +3906,7 @@ name = "mold-ai-db"
 version = "0.20.2"
 dependencies = [
  "anyhow",
+ "fs2",
  "hostname",
  "image",
  "mold-ai-core",


### PR DESCRIPTION
The gallery-recovery work (#521) added `fs2` to `mold-ai-db`, but `desktop/src-tauri/Cargo.lock` was not regenerated — every local cargo run against the desktop root dirties the checkout with this exact hunk. This checks in the regenerated lockfile.