### PR TITLE
docs: restore contributor email link

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,6 @@ app, or custom client. The documentation covers the
 
 Core contributors:
 [James Brink](https://jamesbrink.online/) and
-[Jeffrey Dilley](https://github.com/jdilley).
+[Jeffrey Dilley](mailto:jeff.dilley@gmail.com).
 
 Licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary

- restore the README contributor link for Jeffrey Dilley to his contributor email address
- keep the existing email-based attribution in licensing and package metadata consistent

## Validation

- `bunx prettier --check ../README.md`
- `git diff --check`
