### PR TITLE
docs: align public project metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ authors = [
     "James Brink <brink.james@gmail.com>",
     "Jeffrey Dilley <jeff.dilley@gmail.com>",
 ]
-description = "Local AI image generation CLI — FLUX, SD3.5, SD 1.5, SDXL, Z-Image, Flux.2, Qwen-Image, Wuerstchen, LTX Video, & LTX-2 diffusion models on your GPU"
+description = "CLI-native local AI image and video generation for people, scripts, and agents"
 rust-version = "1.85"
 homepage = "https://github.com/utensils/mold"
 repository = "https://github.com/utensils/mold"

--- a/crates/mold-cli/Cargo.toml
+++ b/crates/mold-cli/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 readme.workspace = true
 keywords.workspace = true
 categories.workspace = true
-description = "Local AI image generation CLI — FLUX, SDXL, SD3.5, Z-Image diffusion models on your GPU"
+description = "CLI-native local AI image and video generation for people, scripts, and agents"
 
 [[bin]]
 name = "mold"

--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -14,7 +14,56 @@ export default defineConfig({
     },
   },
 
-  head: [['link', { rel: 'icon', href: '/mold/logo-transparent.png' }]],
+  head: [
+    ['link', { rel: 'icon', href: '/mold/logo-transparent.png' }],
+    ['meta', { property: 'og:type', content: 'website' }],
+    [
+      'meta',
+      {
+        property: 'og:title',
+        content: 'mold — CLI-native local AI image and video generation',
+      },
+    ],
+    [
+      'meta',
+      {
+        property: 'og:description',
+        content:
+          'CLI-native local AI image and video generation for people, scripts, and agents.',
+      },
+    ],
+    [
+      'meta',
+      {
+        property: 'og:image',
+        content: 'https://utensils.io/mold/screenshots/mold-studio-desktop.png',
+      },
+    ],
+    ['meta', { property: 'og:url', content: 'https://utensils.io/mold/' }],
+    ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
+    [
+      'meta',
+      {
+        name: 'twitter:title',
+        content: 'mold — CLI-native local AI image and video generation',
+      },
+    ],
+    [
+      'meta',
+      {
+        name: 'twitter:description',
+        content:
+          'CLI-native local AI image and video generation for people, scripts, and agents.',
+      },
+    ],
+    [
+      'meta',
+      {
+        name: 'twitter:image',
+        content: 'https://utensils.io/mold/screenshots/mold-studio-desktop.png',
+      },
+    ],
+  ],
 
   lastUpdated: true,
 

--- a/website/guide/index.md
+++ b/website/guide/index.md
@@ -62,7 +62,7 @@ mold run "a sunset over mountains"
 
 ## What You Get
 
-- **11 model families** — FLUX.1, SDXL, SD 1.5, SD 3.5, Z-Image, Flux.2 Klein,
+- **Broad model support** — FLUX.1, SDXL, SD 1.5, SD 3.5, Z-Image, Flux.2 Klein,
   Qwen-Image, Qwen-Image-Edit, Wuerstchen v2, LTX Video, LTX-2 / LTX-2.3
 - **txt2img, img2img, multimodal edit, inpainting, ControlNet** — all in one binary
 - **Image upscaling** — Real-ESRGAN super-resolution (2x/4x) via CLI, server API, or TUI

--- a/website/index.md
+++ b/website/index.md
@@ -3,7 +3,7 @@ layout: home
 
 hero:
   name: mold
-  text: AI Image Generation on Your GPU
+  text: Local AI Image & Video Generation on Your GPU
   tagline:
     'CLI-native and built for people, scripts, and agents. CUDA on Linux, Metal
     on macOS, and the same local engine behind desktop, web, TUI, iPhone, REST,
@@ -35,7 +35,7 @@ features:
       terminals, shell pipelines, CI, and agents.'
   - icon:
       src: /icons/grid.svg
-    title: 11 Model Families
+    title: Broad Model Support
     details: FLUX.1, SDXL, SD 1.5, SD 3.5, Z-Image, Flux.2 Klein, Qwen-Image,
       Qwen-Image-Edit, Wuerstchen v2, LTX Video, and LTX-2 / LTX-2.3. Images,
       native joint audio-video, and quantized variants that fit a wide range of

--- a/website/models/index.md
+++ b/website/models/index.md
@@ -1,7 +1,8 @@
 # Models
 
-mold supports 11 model families spanning different architectures, quality levels,
-and VRAM requirements — including both image and video generation.
+mold supports a broad range of model families spanning different architectures,
+quality levels, and VRAM requirements — including both image and video
+generation.
 
 ::: tip Community models from Civitai
 The models documented here are not the limit. Open **Models → Discover** in

--- a/website/scripts/verify-docs.mjs
+++ b/website/scripts/verify-docs.mjs
@@ -58,6 +58,7 @@ const configSource = readFileSync(
   join(websiteDir, '.vitepress/config.ts'),
   'utf8'
 )
+const normalizedConfigSource = configSource.replace(/\s+/gu, ' ')
 const sidebarLinks = [...configSource.matchAll(/link:\s*'([^']+)'/g)]
   .map((m) => m[1])
   .filter((link) => link.startsWith('/'))
@@ -70,6 +71,47 @@ for (const link of sidebarLinks) {
 
 if (!configSource.includes("hostname: 'https://utensils.io/mold/'")) {
   fail('sitemap hostname must be https://utensils.io/mold/')
+}
+
+const requiredSocialMetadata = [
+  "property: 'og:title'",
+  "property: 'og:description'",
+  "property: 'og:image'",
+  "content: 'https://utensils.io/mold/screenshots/mold-studio-desktop.png'",
+  "property: 'og:url'",
+  "name: 'twitter:card'",
+  "content: 'summary_large_image'",
+  "name: 'twitter:image'",
+]
+for (const metadata of requiredSocialMetadata) {
+  if (!normalizedConfigSource.includes(metadata)) {
+    fail(`site config missing social metadata: ${metadata}`)
+  }
+}
+
+const homeSource = readRel('index.md')
+if (
+  !homeSource.includes('text: Local AI Image & Video Generation on Your GPU')
+) {
+  fail('homepage hero must describe local image and video generation')
+}
+if (homeSource.includes('11 Model Families')) {
+  fail('homepage must not hard-code a model-family count')
+}
+
+for (const relPath of ['guide/index.md', 'models/index.md']) {
+  if (readRel(relPath).toLowerCase().includes('11 model families')) {
+    fail(`${relPath} must not hard-code a model-family count`)
+  }
+}
+
+const expectedPackageDescription =
+  'CLI-native local AI image and video generation for people, scripts, and agents'
+for (const relPath of ['Cargo.toml', 'crates/mold-cli/Cargo.toml']) {
+  const manifest = readFileSync(join(repoRoot, relPath), 'utf8')
+  if (!manifest.includes(`description = "${expectedPackageDescription}"`)) {
+    fail(`${relPath} must use the canonical package description`)
+  }
 }
 
 const visibleLinks = new Set(sidebarLinks)


### PR DESCRIPTION
## Summary

- position Mold consistently as CLI-native local image and video generation
- replace brittle model-family counts with future-proof language
- add Open Graph and Twitter card metadata backed by the desktop-app screenshot
- align workspace and CLI package descriptions
- add docs-contract checks that prevent these public fields from drifting

The repository homepage and topics were also updated directly in GitHub to use the canonical website and include video generation, Tauri, MCP, and AI-agent discovery terms.

## Validation

- `cd website && bun run fmt:check`
- `cd website && bun run verify`
- `cd website && bun run build`
- `cargo metadata --no-deps --format-version 1`
- `git diff --check`
- browser QA at desktop and 390x844 mobile viewports
- verified Get Started and View Models navigation, Civitai copy, social metadata, screenshot loading, and zero console warnings/errors
