### PR TITLE
feat(api): advertise per-model frame defaults and caps on /api/models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`/api/models` now advertises per-model frame semantics.** Video models
+  carry additive `default_frames`, `default_fps`, `max_frames` (the
+  no-temporal-upscale single-request ceiling: 153 for LTX-2's RoPE budget,
+  257 for LTX-Video), and `frame_step` (valid counts are `k·step+1`; 8 for
+  the LTX families) sourced from the same manifest defaults and validator
+  constants the server enforces; image models omit all four. Chain limits'
+  `frames_per_clip_recommended` now follows the model's own default frame
+  count instead of the family cap — LTX-2 recommends 97 per clip while
+  LTX-Video recommends its shipped 25 — so clients can stop hardcoding a
+  25-frame default that ignored the selected model.
 - **iPhone Create now supports explicit multi-clip video sequences.** The
   touch-native Single / Sequence switch starts with two required clips,
   filters to compatible installed video models, keeps duration and seed tools

--- a/crates/mold-catalog/src/defaults.rs
+++ b/crates/mold-catalog/src/defaults.rs
@@ -5,6 +5,10 @@ pub struct CatalogRuntimeDefaults {
     pub steps: u32,
     pub guidance: f64,
     pub is_schnell: Option<bool>,
+    /// Default video frame count; None for image families.
+    pub frames: Option<u32>,
+    /// Default video FPS; None for image families.
+    pub fps: Option<u32>,
 }
 
 pub fn runtime_defaults_for_family(
@@ -19,6 +23,8 @@ pub fn runtime_defaults_for_family(
                 steps: 4,
                 guidance: 0.0,
                 is_schnell: Some(true),
+                frames: None,
+                fps: None,
             },
             _ => CatalogRuntimeDefaults {
                 width: 1024,
@@ -26,6 +32,8 @@ pub fn runtime_defaults_for_family(
                 steps: 25,
                 guidance: 3.5,
                 is_schnell: Some(false),
+                frames: None,
+                fps: None,
             },
         },
         "flux2" => CatalogRuntimeDefaults {
@@ -34,6 +42,8 @@ pub fn runtime_defaults_for_family(
             steps: 4,
             guidance: 1.0,
             is_schnell: None,
+            frames: None,
+            fps: None,
         },
         "z-image" => CatalogRuntimeDefaults {
             width: 1024,
@@ -41,6 +51,8 @@ pub fn runtime_defaults_for_family(
             steps: 9,
             guidance: 0.0,
             is_schnell: None,
+            frames: None,
+            fps: None,
         },
         "ltx2" => CatalogRuntimeDefaults {
             width: 1216,
@@ -48,6 +60,8 @@ pub fn runtime_defaults_for_family(
             steps: 8,
             guidance: 3.0,
             is_schnell: None,
+            frames: Some(97),
+            fps: Some(24),
         },
         "ltx-video" => CatalogRuntimeDefaults {
             width: 1216,
@@ -55,6 +69,8 @@ pub fn runtime_defaults_for_family(
             steps: 30,
             guidance: 8.0,
             is_schnell: None,
+            frames: Some(25),
+            fps: Some(30),
         },
         "sdxl" => CatalogRuntimeDefaults {
             width: 1024,
@@ -62,6 +78,8 @@ pub fn runtime_defaults_for_family(
             steps: 25,
             guidance: 7.5,
             is_schnell: None,
+            frames: None,
+            fps: None,
         },
         "sd15" => CatalogRuntimeDefaults {
             width: 512,
@@ -69,6 +87,8 @@ pub fn runtime_defaults_for_family(
             steps: 25,
             guidance: 7.5,
             is_schnell: None,
+            frames: None,
+            fps: None,
         },
         "qwen-image" | "qwen-image-edit" => CatalogRuntimeDefaults {
             width: 1328,
@@ -76,6 +96,8 @@ pub fn runtime_defaults_for_family(
             steps: 50,
             guidance: 4.0,
             is_schnell: None,
+            frames: None,
+            fps: None,
         },
         _ => CatalogRuntimeDefaults {
             width: 1024,
@@ -83,6 +105,8 @@ pub fn runtime_defaults_for_family(
             steps: 20,
             guidance: 3.5,
             is_schnell: None,
+            frames: None,
+            fps: None,
         },
     }
 }
@@ -90,6 +114,23 @@ pub fn runtime_defaults_for_family(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Video families must carry frame defaults matching their manifest
+    /// counterparts (ltx2 → 97@24, ltx-video → 25@30); image families none.
+    #[test]
+    fn video_families_carry_frame_defaults() {
+        let ltx2 = runtime_defaults_for_family("ltx2", None);
+        assert_eq!(ltx2.frames, Some(97));
+        assert_eq!(ltx2.fps, Some(24));
+
+        let ltx_video = runtime_defaults_for_family("ltx-video", None);
+        assert_eq!(ltx_video.frames, Some(25));
+        assert_eq!(ltx_video.fps, Some(30));
+
+        let flux = runtime_defaults_for_family("flux", None);
+        assert_eq!(flux.frames, None);
+        assert_eq!(flux.fps, None);
+    }
 
     #[test]
     fn flux_dev_and_schnell_subfamilies_have_distinct_defaults() {
@@ -101,6 +142,8 @@ mod tests {
                 steps: 25,
                 guidance: 3.5,
                 is_schnell: Some(false),
+                frames: None,
+                fps: None,
             }
         );
         assert_eq!(
@@ -111,6 +154,8 @@ mod tests {
                 steps: 4,
                 guidance: 0.0,
                 is_schnell: Some(true),
+                frames: None,
+                fps: None,
             }
         );
     }

--- a/crates/mold-cli/src/commands/list.rs
+++ b/crates/mold-cli/src/commands/list.rs
@@ -387,6 +387,7 @@ mod tests {
                 default_width: 1024,
                 default_height: 1024,
                 description: "test".to_string(),
+                ..Default::default()
             },
             downloaded: false,
             disk_usage_bytes: None,

--- a/crates/mold-core/src/catalog.rs
+++ b/crates/mold-core/src/catalog.rs
@@ -26,6 +26,10 @@ pub fn build_model_catalog(
                 default_guidance: model_cfg.effective_guidance(),
                 default_width: model_cfg.effective_width(config),
                 default_height: model_cfg.effective_height(config),
+                default_frames: model_cfg.effective_frames(),
+                default_fps: model_cfg.effective_fps(),
+                max_frames: crate::validation::max_frames_for_family(&manifest.family),
+                frame_step: crate::validation::frame_step_for_family(&manifest.family),
                 description: model_cfg
                     .description
                     .unwrap_or_else(|| manifest.name.clone()),
@@ -73,6 +77,10 @@ pub fn build_model_catalog(
     for (name, model_cfg) in config_only {
         let (disk_usage_bytes, size_gb_f64) = model_cfg.disk_usage();
         let size_gb = size_gb_f64 as f32;
+        let family = model_cfg
+            .family
+            .clone()
+            .unwrap_or_else(|| "flux".to_string());
 
         models.push(ModelInfoExtended {
             downloaded: true,
@@ -81,6 +89,10 @@ pub fn build_model_catalog(
                 default_guidance: model_cfg.effective_guidance(),
                 default_width: model_cfg.effective_width(config),
                 default_height: model_cfg.effective_height(config),
+                default_frames: model_cfg.effective_frames(),
+                default_fps: model_cfg.effective_fps(),
+                max_frames: crate::validation::max_frames_for_family(&family),
+                frame_step: crate::validation::frame_step_for_family(&family),
                 description: model_cfg
                     .description
                     .clone()
@@ -88,10 +100,7 @@ pub fn build_model_catalog(
             },
             info: ModelInfo {
                 name: name.clone(),
-                family: model_cfg
-                    .family
-                    .clone()
-                    .unwrap_or_else(|| "flux".to_string()),
+                family,
                 size_gb,
                 is_loaded: loaded_model.is_some_and(|loaded| engine_is_loaded && loaded == name),
                 last_used: None,
@@ -179,6 +188,47 @@ mod tests {
             // would otherwise fail the size-match fallback).
             crate::download::write_sha256_marker(&path, "deadbeef").unwrap();
         }
+    }
+
+    /// Video models must advertise their manifest frame defaults and the
+    /// family frame constraints so clients stop hardcoding 25 frames; image
+    /// models must omit all four fields.
+    #[test]
+    fn build_model_catalog_emits_video_frame_defaults() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let config = Config::default();
+        let catalog = build_model_catalog(&config, None, false);
+
+        let ltx2 = catalog
+            .iter()
+            .find(|model| model.family == "ltx2")
+            .expect("an ltx2 manifest model should exist");
+        assert_eq!(ltx2.defaults.default_frames, Some(97));
+        assert_eq!(ltx2.defaults.default_fps, Some(24));
+        assert_eq!(
+            ltx2.defaults.max_frames,
+            Some(153),
+            "no-temporal-upscale RoPE ceiling",
+        );
+        assert_eq!(ltx2.defaults.frame_step, Some(8));
+
+        let ltx_video = catalog
+            .iter()
+            .find(|model| model.family == "ltx-video")
+            .expect("an ltx-video manifest model should exist");
+        assert_eq!(ltx_video.defaults.default_frames, Some(25));
+        assert_eq!(ltx_video.defaults.default_fps, Some(30));
+        assert_eq!(ltx_video.defaults.max_frames, Some(257));
+        assert_eq!(ltx_video.defaults.frame_step, Some(8));
+
+        let flux = catalog
+            .iter()
+            .find(|model| model.family == "flux")
+            .expect("a flux manifest model should exist");
+        assert_eq!(flux.defaults.default_frames, None);
+        assert_eq!(flux.defaults.default_fps, None);
+        assert_eq!(flux.defaults.max_frames, None);
+        assert_eq!(flux.defaults.frame_step, None);
     }
 
     #[test]
@@ -284,6 +334,7 @@ mod tests {
                     default_width: 1024,
                     default_height: 1024,
                     description: String::new(),
+                    ..Default::default()
                 },
                 downloaded: false,
                 disk_usage_bytes: None,

--- a/crates/mold-core/src/types.rs
+++ b/crates/mold-core/src/types.rs
@@ -854,7 +854,7 @@ pub struct ModelInfo {
     pub hf_repo: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct ModelDefaults {
     #[schema(example = 4)]
     pub default_steps: u32,
@@ -866,6 +866,26 @@ pub struct ModelDefaults {
     pub default_height: u32,
     #[schema(example = "FLUX Schnell Q8 — fast 4-step generation")]
     pub description: String,
+    /// Default video frame count (additive; absent for image models).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schema(example = 97)]
+    pub default_frames: Option<u32>,
+    /// Default video FPS (additive; absent for image models).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schema(example = 24)]
+    pub default_fps: Option<u32>,
+    /// Maximum frames a single request may ask for WITHOUT temporal
+    /// upscaling (additive; absent for image models). Clients with
+    /// temporal-upscale support keep their own doubling math; the server
+    /// validator remains authoritative.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schema(example = 153)]
+    pub max_frames: Option<u32>,
+    /// Valid frame counts are `k * frame_step + 1` (additive; absent for
+    /// image models). 8 for the LTX families.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schema(example = 8)]
+    pub frame_step: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
@@ -983,6 +1003,55 @@ impl std::ops::Deref for ModelInfoExtended {
 }
 
 #[cfg(test)]
+mod model_defaults_frame_tests {
+    use super::ModelDefaults;
+
+    /// Old wire shape (no frame fields) must keep parsing, and the new
+    /// fields must default to None and be omitted from serialized output —
+    /// image models never advertise frame semantics.
+    #[test]
+    fn model_defaults_frame_fields_roundtrip_and_default_to_none() {
+        let legacy = r#"{
+            "default_steps": 4,
+            "default_guidance": 3.5,
+            "default_width": 1024,
+            "default_height": 1024,
+            "description": "flux schnell"
+        }"#;
+        let parsed: ModelDefaults = serde_json::from_str(legacy).unwrap();
+        assert_eq!(parsed.default_frames, None);
+        assert_eq!(parsed.default_fps, None);
+        assert_eq!(parsed.max_frames, None);
+        assert_eq!(parsed.frame_step, None);
+
+        let out = serde_json::to_value(&parsed).unwrap();
+        assert!(out.get("default_frames").is_none());
+        assert!(out.get("default_fps").is_none());
+        assert!(out.get("max_frames").is_none());
+        assert!(out.get("frame_step").is_none());
+
+        let video = ModelDefaults {
+            default_frames: Some(97),
+            default_fps: Some(24),
+            max_frames: Some(153),
+            frame_step: Some(8),
+            ..parsed
+        };
+        let out = serde_json::to_value(&video).unwrap();
+        assert_eq!(out["default_frames"], 97);
+        assert_eq!(out["default_fps"], 24);
+        assert_eq!(out["max_frames"], 153);
+        assert_eq!(out["frame_step"], 8);
+
+        let back: ModelDefaults = serde_json::from_value(out).unwrap();
+        assert_eq!(back.default_frames, Some(97));
+        assert_eq!(back.default_fps, Some(24));
+        assert_eq!(back.max_frames, Some(153));
+        assert_eq!(back.frame_step, Some(8));
+    }
+}
+
+#[cfg(test)]
 mod model_display_name_tests {
     use super::{ModelDefaults, ModelInfo, ModelInfoExtended};
 
@@ -1002,6 +1071,7 @@ mod model_display_name_tests {
                 default_width: 1024,
                 default_height: 1024,
                 description: description.to_string(),
+                ..Default::default()
             },
             downloaded: true,
             disk_usage_bytes: None,

--- a/crates/mold-core/src/validation.rs
+++ b/crates/mold-core/src/validation.rs
@@ -29,6 +29,26 @@ pub fn family_supports_lora(family: &str) -> bool {
 /// RoPE normalization and collapses output into random-color noise.
 pub const LTX2_MAX_FRAMES: u32 = 153;
 
+/// Global frame ceiling applied to every video request regardless of family.
+pub const MAX_FRAMES_GLOBAL: u32 = 257;
+
+/// Per-family single-request frame ceiling WITHOUT temporal upscaling — the
+/// value `/api/models` advertises as `max_frames`. Must stay in agreement
+/// with `validate_generate_request`'s rejections, which consume this helper.
+pub fn max_frames_for_family(family: &str) -> Option<u32> {
+    match family {
+        "ltx2" => Some(LTX2_MAX_FRAMES),
+        "ltx-video" => Some(MAX_FRAMES_GLOBAL),
+        _ => None,
+    }
+}
+
+/// Frame-count grid for a family: valid counts are `k * step + 1`. The value
+/// `/api/models` advertises as `frame_step`; the validator consumes it.
+pub fn frame_step_for_family(family: &str) -> Option<u32> {
+    matches!(family, "ltx2" | "ltx-video").then_some(8)
+}
+
 fn megapixel_limit_label() -> String {
     format!("{:.1}MP", MAX_PIXELS as f64 / 1_000_000.0)
 }
@@ -409,13 +429,15 @@ pub fn validate_generate_request_with_family(
         if frames == 0 {
             return Err("frames must be >= 1".to_string());
         }
-        if matches!(family, Some("ltx-video" | "ltx2")) && frames > 1 && (frames - 1) % 8 != 0 {
-            return Err(format!(
-                "frames ({frames}) must be 8n+1 for current LTX-Video / LTX-2 models (e.g. 9, 17, 25, 33, 41, 49, …)"
-            ));
+        if let Some(step) = family.and_then(frame_step_for_family) {
+            if frames > 1 && (frames - 1) % step != 0 {
+                return Err(format!(
+                    "frames ({frames}) must be {step}n+1 for current LTX-Video / LTX-2 models (e.g. 9, 17, 25, 33, 41, 49, …)"
+                ));
+            }
         }
-        if frames > 257 {
-            return Err(format!("frames ({frames}) must be <= 257"));
+        if frames > MAX_FRAMES_GLOBAL {
+            return Err(format!("frames ({frames}) must be <= {MAX_FRAMES_GLOBAL}"));
         }
         // LTX-2 transformers ship `positional_embedding_max_pos: [20, 2048, 2048]`
         // — exceeding 20 latent frames wraps RoPE into an untrained region and
@@ -1198,6 +1220,39 @@ mod tests {
         let err = validate_generate_request(&req).unwrap_err();
         assert!(err.contains("8n+1"), "got: {err}");
         assert!(err.contains("LTX-Video / LTX-2"), "got: {err}");
+    }
+
+    /// The helper values are what /api/models advertises as max_frames /
+    /// frame_step; they must agree with what the validator enforces so the
+    /// wire contract can't drift from the actual rejection rules.
+    #[test]
+    fn frame_constraint_helpers_match_validator_behavior() {
+        assert_eq!(max_frames_for_family("ltx2"), Some(LTX2_MAX_FRAMES));
+        assert_eq!(max_frames_for_family("ltx-video"), Some(257));
+        assert_eq!(max_frames_for_family("flux"), None);
+        assert_eq!(max_frames_for_family("sdxl"), None);
+        assert_eq!(frame_step_for_family("ltx2"), Some(8));
+        assert_eq!(frame_step_for_family("ltx-video"), Some(8));
+        assert_eq!(frame_step_for_family("flux"), None);
+
+        // One grid step past the advertised ltx-video cap must be rejected,
+        // and the rejection must quote the same cap the wire advertises.
+        let cap = max_frames_for_family("ltx-video").unwrap();
+        let mut req = valid_req();
+        req.model = "ltx-video-0.9.6-distilled:bf16".to_string();
+        req.output_format = Some(OutputFormat::Mp4);
+        req.frames = Some(cap + 8); // stays on the 8n+1 grid so only the cap trips
+        let err = validate_generate_request(&req).unwrap_err();
+        assert!(err.contains(&cap.to_string()), "got: {err}");
+
+        // Same agreement for the ltx2 no-temporal-upscale ceiling.
+        let cap = max_frames_for_family("ltx2").unwrap();
+        let mut req = valid_req();
+        req.model = "ltx-2-19b-distilled:fp8".to_string();
+        req.output_format = Some(OutputFormat::Mp4);
+        req.frames = Some(cap + 8);
+        let err = validate_generate_request(&req).unwrap_err();
+        assert!(err.contains(&cap.to_string()), "got: {err}");
     }
 
     #[test]

--- a/crates/mold-discord/src/commands/generate.rs
+++ b/crates/mold-discord/src/commands/generate.rs
@@ -495,6 +495,7 @@ mod tests {
             default_width: 1024,
             default_height: 1024,
             description: "test".to_string(),
+            ..Default::default()
         }
     }
 
@@ -565,6 +566,7 @@ mod tests {
             default_width: 512,
             default_height: 512,
             description: "test".to_string(),
+            ..Default::default()
         };
         let req = build_generate_request(BuildParams {
             width: Some(768),
@@ -759,6 +761,7 @@ mod tests {
             default_width: 1024,
             default_height: 1024,
             description: String::new(),
+            ..Default::default()
         }
     }
 

--- a/crates/mold-discord/src/format.rs
+++ b/crates/mold-discord/src/format.rs
@@ -700,6 +700,7 @@ mod tests {
                 default_width: 1024,
                 default_height: 1024,
                 description: "Fast flux".to_string(),
+                ..Default::default()
             },
             downloaded: true,
             disk_usage_bytes: None,
@@ -735,6 +736,7 @@ mod tests {
                     default_width: 1024,
                     default_height: 1024,
                     description: "FLUX Schnell Q8".to_string(),
+                    ..Default::default()
                 },
                 downloaded: true,
                 disk_usage_bytes: None,
@@ -760,6 +762,7 @@ mod tests {
                     default_width: 1024,
                     default_height: 1024,
                     description: "FLUX Dev Q4".to_string(),
+                    ..Default::default()
                 },
                 downloaded: false,
                 disk_usage_bytes: None,
@@ -785,6 +788,7 @@ mod tests {
                     default_width: 1024,
                     default_height: 1024,
                     description: "Wuerstchen v2".to_string(),
+                    ..Default::default()
                 },
                 downloaded: false,
                 disk_usage_bytes: None,

--- a/crates/mold-server/src/chain_limits.rs
+++ b/crates/mold-server/src/chain_limits.rs
@@ -80,13 +80,34 @@ pub fn sequence_support(model: &str, family: &str, has_spatial_upscaler: bool) -
 /// `family` is the canonical family string (e.g. "ltx2").
 /// `quant` is the quantization slug ("fp8", "fp16", "q8", ...).
 /// `free_vram_bytes` is the current free VRAM on the primary GPU.
-pub fn compute_limits(model: &str, family: &str, quant: &str, free_vram_bytes: u64) -> ChainLimits {
+/// `default_frames` is the model's own default frame count (manifest or
+/// catalog sidecar) and drives the recommended per-clip frames.
+pub fn compute_limits(
+    model: &str,
+    family: &str,
+    quant: &str,
+    free_vram_bytes: u64,
+    default_frames: Option<u32>,
+) -> ChainLimits {
     let cap = family_cap(family).unwrap_or(97);
-    // Hardware-derived recommended: for distilled LTX-2, 97 is already
-    // the binding constraint. Reserve the derivation scaffolding for
-    // future non-distilled models.
-    let _ = free_vram_bytes; // suppress unused for now; D wires this up
-    let recommended = cap;
+    // Suppress unused for now; sub-project D wires free VRAM up.
+    let _ = free_vram_bytes;
+    // Recommend the model's own default frame count (LTX-Video ships 25,
+    // LTX-2 ships 97) so new clips start at what the model actually runs;
+    // clamp to the family cap and snap down onto the 8n+1 grid. Without a
+    // model default, fall back to the cap (old behavior).
+    let recommended = default_frames
+        .map(|frames| {
+            let clamped = frames.min(cap);
+            if clamped > 1 {
+                clamped - ((clamped - 1) % 8)
+            } else {
+                clamped
+            }
+        })
+        .unwrap_or(cap)
+        .max(9)
+        .min(cap);
 
     const MAX_STAGES: u32 = 16;
     let canonical_model = mold_core::manifest::resolve_model_name(model);
@@ -148,9 +169,40 @@ mod tests {
         assert_eq!(family_cap("sdxl"), None);
     }
 
+    /// The recommended per-clip frames must follow the model's own default
+    /// frame count (LTX-Video ships 25, LTX-2 ships 97) instead of the
+    /// family cap, so new clips default to what the model actually runs.
+    #[test]
+    fn recommended_uses_model_default_frames() {
+        let ltx_video = compute_limits("ltx-video-0.9.6:bf16", "ltx-video", "bf16", 0, Some(25));
+        assert_eq!(ltx_video.frames_per_clip_cap, 97);
+        assert_eq!(ltx_video.frames_per_clip_recommended, 25);
+
+        let ltx2 = compute_limits("ltx-2-19b-distilled:fp8", "ltx2", "fp8", 0, Some(97));
+        assert_eq!(ltx2.frames_per_clip_recommended, 97);
+
+        // No model default → fall back to the family cap (old behavior).
+        let unknown = compute_limits("cv:123", "ltx2", "", 0, None);
+        assert_eq!(unknown.frames_per_clip_recommended, 97);
+
+        // Off-grid defaults snap DOWN onto the 8n+1 grid.
+        let off_grid = compute_limits("cv:456", "ltx-video", "", 0, Some(30));
+        assert_eq!(off_grid.frames_per_clip_recommended, 25);
+
+        // Defaults above the cap clamp to the cap.
+        let oversized = compute_limits("cv:789", "ltx2", "", 0, Some(500));
+        assert_eq!(oversized.frames_per_clip_recommended, 97);
+    }
+
     #[test]
     fn compute_limits_for_distilled() {
-        let lim = compute_limits("ltx-2-19b-distilled:fp8", "ltx2", "fp8", 8_000_000_000);
+        let lim = compute_limits(
+            "ltx-2-19b-distilled:fp8",
+            "ltx2",
+            "fp8",
+            8_000_000_000,
+            None,
+        );
         assert_eq!(lim.frames_per_clip_cap, 97);
         assert_eq!(lim.frames_per_clip_recommended, 97);
         assert_eq!(lim.max_stages, 16);
@@ -185,7 +237,7 @@ mod tests {
 
     #[test]
     fn ltx2_dev_legacy_alias_keeps_two_stage_sequence_gate() {
-        let limits = compute_limits("ltx-2.3-22b-dev-fp8", "ltx2", "fp8", 0);
+        let limits = compute_limits("ltx-2.3-22b-dev-fp8", "ltx2", "fp8", 0, None);
         assert!(!limits.supports_sequence);
         assert!(limits
             .sequence_unsupported_reason
@@ -204,7 +256,7 @@ mod tests {
     fn compute_limits_for_ltx_video_has_no_audio() {
         // LTX-Video is video-only; the SPA must hide the audio toggle and the
         // chain endpoint will reject `enable_audio: true` upstream regardless.
-        let lim = compute_limits("ltx-video-0.9.7-distilled:fp8", "ltx-video", "fp8", 0);
+        let lim = compute_limits("ltx-video-0.9.7-distilled:fp8", "ltx-video", "fp8", 0, None);
         assert!(
             !lim.supports_audio,
             "ltx-video has no audio path — toggle must stay off",

--- a/crates/mold-server/src/model_manager.rs
+++ b/crates/mold-server/src/model_manager.rs
@@ -489,6 +489,14 @@ fn installed_catalog_models(
             .as_ref()
             .and_then(|cfg| cfg.default_guidance)
             .unwrap_or(defaults.guidance);
+        let frames = user_cfg
+            .as_ref()
+            .and_then(|cfg| cfg.default_frames)
+            .or(defaults.frames);
+        let fps = user_cfg
+            .as_ref()
+            .and_then(|cfg| cfg.default_fps)
+            .or(defaults.fps);
 
         let description = sidecar
             .description
@@ -506,6 +514,10 @@ fn installed_catalog_models(
                 default_height: h,
                 default_steps: steps,
                 default_guidance: guidance,
+                default_frames: frames,
+                default_fps: fps,
+                max_frames: mold_core::validation::max_frames_for_family(&sidecar.family),
+                frame_step: mold_core::validation::frame_step_for_family(&sidecar.family),
                 description,
             },
             info: ModelInfo {
@@ -1427,6 +1439,12 @@ mod tests {
         let state = AppState::for_tests();
         let video_only = installed_catalog_models(&state, &config, dir.path(), None, false);
         assert_eq!(video_only[0].supports_audio, Some(false));
+        // Catalog sidecars have no manifest, so frame defaults come from the
+        // family runtime defaults and the family constraint helpers.
+        assert_eq!(video_only[0].defaults.default_frames, Some(97));
+        assert_eq!(video_only[0].defaults.default_fps, Some(24));
+        assert_eq!(video_only[0].defaults.max_frames, Some(153));
+        assert_eq!(video_only[0].defaults.frame_step, Some(8));
 
         write_safetensors_with_keys(
             &primary,

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -2792,7 +2792,7 @@ async fn capabilities_chain_limits(
     };
 
     let resolved = mold_core::manifest::resolve_model_name(&raw_model);
-    let (family, quant, supports_audio) =
+    let (family, quant, supports_audio, default_frames) =
         if let Some(manifest) = mold_core::manifest::find_manifest(&resolved) {
             let quant = resolved
                 .split_once(':')
@@ -2800,7 +2800,13 @@ async fn capabilities_chain_limits(
                 .unwrap_or_default();
             let family = manifest.family.clone();
             let supports_audio = crate::chain_limits::family_supports_audio(&family);
-            (family, quant, supports_audio)
+            let default_frames = state
+                .config
+                .read()
+                .await
+                .resolved_model_config(&resolved)
+                .effective_frames();
+            (family, quant, supports_audio, default_frames)
         } else {
             // Installed live-catalog models retain opaque `cv:` / `hf:` ids and
             // therefore cannot be found in the built-in manifest. Resolve them
@@ -2818,7 +2824,12 @@ async fn capabilities_chain_limits(
             let supports_audio = entry
                 .supports_audio
                 .unwrap_or_else(|| crate::chain_limits::family_supports_audio(&family));
-            (family, String::new(), supports_audio)
+            (
+                family,
+                String::new(),
+                supports_audio,
+                entry.defaults.default_frames,
+            )
         };
 
     if crate::chain_limits::family_cap(&family).is_none() {
@@ -2826,7 +2837,8 @@ async fn capabilities_chain_limits(
     }
 
     // TODO(sub-project D): pass live free VRAM from AppState.
-    let mut limits = crate::chain_limits::compute_limits(&raw_model, &family, &quant, 0);
+    let mut limits =
+        crate::chain_limits::compute_limits(&raw_model, &family, &quant, 0, default_frames);
     limits.supports_audio = supports_audio;
     Json(limits).into_response()
 }

--- a/crates/mold-server/src/routes_test.rs
+++ b/crates/mold-server/src/routes_test.rs
@@ -5690,6 +5690,84 @@ mod tests {
         assert!(limits["sequence_unsupported_reason"].is_null());
     }
 
+    /// The endpoint must recommend the model's manifest default frames
+    /// (25 for LTX-Video, 97 for LTX-2), not the family cap, so clients
+    /// can default new clips to what the model actually ships with.
+    #[tokio::test]
+    async fn chain_limits_recommends_manifest_default_frames() {
+        let app = app_empty();
+        let response = app
+            .oneshot(
+                Request::get("/api/capabilities/chain-limits?model=ltx-video-0.9.6:bf16")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let limits: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(limits["frames_per_clip_cap"], 97);
+        assert_eq!(
+            limits["frames_per_clip_recommended"], 25,
+            "LTX-Video manifests declare frames: 25",
+        );
+
+        let app = app_empty();
+        let response = app
+            .oneshot(
+                Request::get("/api/capabilities/chain-limits?model=ltx-2-19b-distilled:fp8")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let limits: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            limits["frames_per_clip_recommended"], 97,
+            "LTX-2 manifests declare frames: 97",
+        );
+    }
+
+    /// /api/models must carry the additive per-model frame fields for video
+    /// models and omit them for image models.
+    #[tokio::test]
+    async fn models_endpoint_advertises_frame_defaults_for_video_models() {
+        let app = app_empty();
+        let response = app
+            .oneshot(Request::get("/api/models").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let models: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
+
+        let ltx2 = models
+            .iter()
+            .find(|m| m["family"] == "ltx2")
+            .expect("an ltx2 model should be listed");
+        assert_eq!(ltx2["default_frames"], 97);
+        assert_eq!(ltx2["default_fps"], 24);
+        assert_eq!(ltx2["max_frames"], 153);
+        assert_eq!(ltx2["frame_step"], 8);
+
+        let flux = models
+            .iter()
+            .find(|m| m["family"] == "flux")
+            .expect("a flux model should be listed");
+        assert!(flux.get("default_frames").is_none());
+        assert!(flux.get("max_frames").is_none());
+        assert!(flux.get("frame_step").is_none());
+    }
+
     #[tokio::test]
     async fn capabilities_chain_limits_rejects_ltx2_two_stage_pipeline_up_front() {
         let app = app_empty();

--- a/crates/mold-tui/src/app.rs
+++ b/crates/mold-tui/src/app.rs
@@ -10035,6 +10035,7 @@ mod tests {
                 default_width: width,
                 default_height: height,
                 description: desc.to_string(),
+                ..Default::default()
             },
             downloaded: true,
             disk_usage_bytes: None,
@@ -11675,6 +11676,7 @@ mod tests {
                 default_width: 1024,
                 default_height: 1024,
                 description: format!("synthetic {name} fixture"),
+                ..Default::default()
             },
             downloaded,
             disk_usage_bytes: None,


### PR DESCRIPTION
Part 1 of the Unified Generate View redesign (backend enablers).

## What

- **`/api/models`**: video models carry additive `default_frames`, `default_fps`, `max_frames` (no-temporal-upscale ceiling — 153 for LTX-2's RoPE budget, 257 for LTX-Video), and `frame_step` (valid counts are `k·step+1`; 8 for LTX families). Image models omit all four. Populated from manifest defaults (`effective_frames`/`effective_fps`, user-config overridable) and new drift-proof validator helpers `max_frames_for_family` / `frame_step_for_family` that `validate_generate_request` itself consumes — the wire values cannot drift from the enforced rules.
- **Catalog sidecar installs** (`cv:` / `hf:`): `CatalogRuntimeDefaults` gains `frames`/`fps` (ltx2 → 97@24, ltx-video → 25@30), with `model_prefs`-style user-config overrides following the existing width/height pattern.
- **`/api/capabilities/chain-limits`**: `frames_per_clip_recommended` now follows the model's own default frame count (clamped to the family cap, snapped down onto the 8n+1 grid) instead of always echoing the 97-frame family cap. LTX-2 recommends 97; LTX-Video recommends its shipped 25.

## Why

The frontends hardcode a 25-frame default for every video model; LTX-2 runs 97 by default. This PR gives all three surfaces (desktop/web/iOS) a server-sourced default so upcoming Create-redesign PRs can default frames per selected model.

## Compat

All new fields are `Option` + `skip_serializing_if` — older clients never see them; older servers simply omit them (clients keep their fallbacks). Only behavioral change: `frames_per_clip_recommended` for ltx-video drops 97 → 25, which matches the value every client already hardcodes (`DEFAULT_SEQUENCE_CLIP_FRAMES = 25`).

## Tests

TDD-first: `model_defaults_frame_fields_roundtrip_and_default_to_none`, `build_model_catalog_emits_video_frame_defaults`, `frame_constraint_helpers_match_validator_behavior`, `recommended_uses_model_default_frames`, `chain_limits_recommends_manifest_default_frames`, `models_endpoint_advertises_frame_defaults_for_video_models`, sidecar frame-default assertions, `video_families_carry_frame_defaults`.

Note: `mold-ai-catalog`'s `merged_search_fetches_civitai_and_hf_in_parallel` is intermittently flaky on unmodified main (verified via stash) — unrelated to this PR.