### PR TITLE
fix(studio): persist migrated sequence drafts immediately; SeamEditor a11y

### DIFF
--- a/studio/stores/sequenceDraft.test.ts
+++ b/studio/stores/sequenceDraft.test.ts
@@ -166,6 +166,34 @@ describe("sequence draft store", () => {
     expect(localStorage.getItem(LEGACY_MOBILE_MODE_KEY)).toBeNull();
   });
 
+  it("persists a migrated legacy draft immediately (no-edit session survives)", () => {
+    // migrateLegacy() deletes the legacy keys while `hydrated` is still
+    // false, so the deep watcher alone would never write the new key — a
+    // reload before any edit would lose the migrated draft entirely.
+    localStorage.setItem(
+      LEGACY_WEB_DRAFT_KEY,
+      JSON.stringify({
+        schema: "mold.chain.v1",
+        chain: { model: "ltx-2-19b-distilled:fp8" },
+        stages: [
+          { prompt: "opening", frames: 97 },
+          { prompt: "landing", frames: 33 },
+        ],
+      }),
+    );
+
+    const store = freshStore();
+    store.hydrate();
+    // No edits, no timers — the migrated draft must already be durable.
+    const saved = JSON.parse(localStorage.getItem(SEQUENCE_DRAFT_KEY)!);
+    expect(saved.clips).toHaveLength(2);
+    expect(saved.clips[0].prompt).toBe("opening");
+
+    const reloaded = freshStore();
+    reloaded.hydrate();
+    expect(reloaded.clips[0]?.prompt).toBe("opening");
+  });
+
   it("tracks an edit session without persisting it", () => {
     const store = freshStore();
     store.hydrate();

--- a/studio/stores/sequenceDraft.ts
+++ b/studio/stores/sequenceDraft.ts
@@ -160,15 +160,21 @@ export const useSequenceDraftStore = defineStore("sequence-draft", () => {
   function hydrate() {
     if (hydrated.value) return;
     const saved = readJson<PersistedDraftV1>(SEQUENCE_DRAFT_KEY);
+    let migrated = false;
     if (saved?.version === 1) {
       applyPersisted(saved);
     } else {
       migrateLegacy();
+      migrated = clips.length > 0 || output.value === "sequence";
     }
     if (clips.length > 0 && !activeClipId.value) {
       activeClipId.value = clips[clips.length - 1]?.id ?? null;
     }
     hydrated.value = true;
+    // migrateLegacy() consumed the legacy keys while `hydrated` was still
+    // false (the watcher won't schedule persistence), so a reload before
+    // any edit would lose the migrated draft — make it durable right away.
+    if (migrated) persistNow();
   }
 
   /** A sequence always has at least two clips (repo invariant). */

--- a/ui/components/SeamEditor.test.ts
+++ b/ui/components/SeamEditor.test.ts
@@ -40,6 +40,14 @@ describe("SeamEditor", () => {
     expect(wrapper.emitted("update:transition")?.[0]).toEqual(["cut"]);
   });
 
+  it("contains the radios in a labelled radiogroup (ARIA pattern)", () => {
+    const wrapper = make();
+    const group = wrapper.find("[role=radiogroup]");
+    expect(group.exists()).toBe(true);
+    expect(group.attributes("aria-label")).toBe("Transition");
+    expect(group.findAll("[role=radio]")).toHaveLength(3);
+  });
+
   it("emits apply-all on an alt-modified pick", async () => {
     const wrapper = make();
     const rows = wrapper.findAll("[role=radio]");

--- a/ui/components/SeamEditor.vue
+++ b/ui/components/SeamEditor.vue
@@ -63,41 +63,68 @@ function pick(option: SequenceTransition, event: MouseEvent) {
   }
   emit("update:transition", option);
 }
+
+// Roving tabindex — arrow keys move the selection, matching the ARIA radio
+// pattern SegmentedControl uses.
+function onOptionKeydown(event: KeyboardEvent) {
+  const delta =
+    event.key === "ArrowDown" || event.key === "ArrowRight"
+      ? 1
+      : event.key === "ArrowUp" || event.key === "ArrowLeft"
+        ? -1
+        : 0;
+  if (delta === 0) return;
+  event.preventDefault();
+  const index = OPTIONS.indexOf(props.transition);
+  const next = OPTIONS[(index + delta + OPTIONS.length) % OPTIONS.length];
+  if (next) emit("update:transition", next);
+}
 </script>
 
 <template>
   <div class="ms-seam-editor" :class="{ 'ms-seam-editor--large': large }">
     <div v-if="context" class="ms-seam-editor__context">{{ context }}</div>
-    <button
-      v-for="option in OPTIONS"
-      :key="option"
-      type="button"
-      class="ms-seam-editor__row"
-      role="radio"
-      :aria-checked="option === transition"
-      :data-on="option === transition ? 'true' : undefined"
-      @click="pick(option, $event)"
+    <div
+      class="ms-seam-editor__options"
+      role="radiogroup"
+      aria-label="Transition"
     >
-      <span class="ms-seam-editor__diagram" aria-hidden="true">
-        <span v-if="option === 'smooth'" class="ms-seam-editor__line-smooth" />
-        <span v-else-if="option === 'cut'" class="ms-seam-editor__line-cut" />
-        <span v-else class="ms-seam-editor__line-fade" />
-      </span>
-      <span class="ms-seam-editor__text">
-        <span class="ms-seam-editor__label">{{
-          transitionLabel(option, motionTail)
-        }}</span>
-        <span class="ms-seam-editor__desc">{{
-          transitionDescription(option, motionTail)
-        }}</span>
-      </span>
-      <span
-        v-if="option === transition"
-        class="ms-seam-editor__check"
-        aria-hidden="true"
-        >✓</span
+      <button
+        v-for="option in OPTIONS"
+        :key="option"
+        type="button"
+        class="ms-seam-editor__row"
+        role="radio"
+        :aria-checked="option === transition"
+        :data-on="option === transition ? 'true' : undefined"
+        :tabindex="option === transition ? 0 : -1"
+        @click="pick(option, $event)"
+        @keydown="onOptionKeydown"
       >
-    </button>
+        <span class="ms-seam-editor__diagram" aria-hidden="true">
+          <span
+            v-if="option === 'smooth'"
+            class="ms-seam-editor__line-smooth"
+          />
+          <span v-else-if="option === 'cut'" class="ms-seam-editor__line-cut" />
+          <span v-else class="ms-seam-editor__line-fade" />
+        </span>
+        <span class="ms-seam-editor__text">
+          <span class="ms-seam-editor__label">{{
+            transitionLabel(option, motionTail)
+          }}</span>
+          <span class="ms-seam-editor__desc">{{
+            transitionDescription(option, motionTail)
+          }}</span>
+        </span>
+        <span
+          v-if="option === transition"
+          class="ms-seam-editor__check"
+          aria-hidden="true"
+          >✓</span
+        >
+      </button>
+    </div>
 
     <template v-if="transition === 'fade'">
       <div class="ms-seam-editor__divider" />
@@ -141,6 +168,16 @@ function pick(option: SequenceTransition, event: MouseEvent) {
   text-transform: uppercase;
   color: var(--ink-3);
   padding: 4px 8px 6px;
+}
+
+.ms-seam-editor__options {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.ms-seam-editor--large .ms-seam-editor__options {
+  gap: 8px;
 }
 
 .ms-seam-editor__row {


### PR DESCRIPTION
Follow-up to #565, addressing both Copilot findings (verified real):

1. **Migrated drafts could vanish.** `hydrate()` runs `migrateLegacy()` — which deletes the legacy `mold.chain.draft.v2` / `mold.composer.mode` / `mold.mobile.create-mode.v1` keys — while `hydrated` is still false, so the persistence watcher never scheduled a write. A reload before any edit lost the migrated draft entirely. Migration now persists synchronously at the end of hydration; regression test reloads a migrated store with no edits and asserts the clips survive.

2. **SeamEditor ARIA radio pattern.** The three `role="radio"` rows had no containing `radiogroup`. They now sit in a labelled `radiogroup` with roving tabindex + arrow-key selection (same pattern as `SegmentedControl`).

Suites: studio 101, desktop 2203 (incl. ui) — all green.