### PR TITLE
fix(ui): move RailClip type out of the SFC so clean-sandbox builds pass

### DIFF
--- a/ui/components/ClipRail.test.ts
+++ b/ui/components/ClipRail.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { mount } from "@vue/test-utils";
 import ClipRail from "./ClipRail.vue";
-import type { RailClip } from "./ClipRail.vue";
+import type { RailClip } from "./types";
 
 function clips(count: number): RailClip[] {
   return Array.from({ length: count }, (_, i) => ({

--- a/ui/components/ClipRail.vue
+++ b/ui/components/ClipRail.vue
@@ -10,15 +10,11 @@ import { computed } from "vue";
 import { VueDraggable } from "vue-draggable-plus";
 import ClipPill from "./ClipPill.vue";
 import SeamPill from "./SeamPill.vue";
-import type { SequenceTransition } from "../lib/seam";
+import type { RailClip } from "./types";
 
-export interface RailClip {
-  id: string;
-  prompt: string;
-  frames: number;
-  transition: SequenceTransition;
-  fadeFrames: number;
-}
+// Re-exported for convenience; the canonical home is ./types (see its
+// header comment — SFC named exports break clean-sandbox builds).
+export type { RailClip };
 
 const props = withDefaults(
   defineProps<{

--- a/ui/components/types.ts
+++ b/ui/components/types.ts
@@ -24,3 +24,12 @@ export interface PaletteItem {
   section: string;
   label: string;
 }
+
+/** One clip on the sequence rail (ClipRail's generic element constraint). */
+export interface RailClip {
+  id: string;
+  prompt: string;
+  frames: number;
+  transition: import("../lib/seam").SequenceTransition;
+  fadeFrames: number;
+}


### PR DESCRIPTION
Follow-up to #568: its nix-web check failed because ClipRail.test.ts imported the `RailClip` named export from ClipRail.vue — passes locally against a warm tsbuildinfo, fails the cold Nix sandbox where the apps compile against the `declare module "*.vue"` shim (default export only; the exact pattern `ui/components/types.ts` documents). `RailClip` now lives in types.ts with the SFC re-exporting it. Desktop suite 2207 green, cold vue-tsc clean in both shells.