### PR TITLE
fix(ui): clean up mobile segments and sequence rail

### DIFF
--- a/desktop/src/mobile/mobile.css
+++ b/desktop/src/mobile/mobile.css
@@ -180,13 +180,20 @@ button {
 
 .mobile-output-mode .ms-seg {
   gap: 0;
-  overflow: hidden;
   padding: 0;
 }
 
 .mobile-output-mode .ms-seg .ms-seg__btn {
   min-height: 44px;
   border-radius: 0;
+}
+
+.mobile-output-mode .ms-seg .ms-seg__btn:first-child {
+  border-radius: calc(var(--radius-control) - 1px) 0 0 calc(var(--radius-control) - 1px);
+}
+
+.mobile-output-mode .ms-seg .ms-seg__btn:last-child {
+  border-radius: 0 calc(var(--radius-control) - 1px) calc(var(--radius-control) - 1px) 0;
 }
 
 .mobile-output-mode .ms-seg .ms-seg__btn + .ms-seg__btn {

--- a/desktop/src/mobile/mobile.css
+++ b/desktop/src/mobile/mobile.css
@@ -178,8 +178,23 @@ button {
   margin-top: 14px;
 }
 
+.mobile-output-mode .ms-seg {
+  gap: 0;
+  overflow: hidden;
+  padding: 0;
+}
+
 .mobile-output-mode .ms-seg .ms-seg__btn {
   min-height: 44px;
+  border-radius: 0;
+}
+
+.mobile-output-mode .ms-seg .ms-seg__btn + .ms-seg__btn {
+  border-left: 1px solid var(--ce);
+}
+
+.mobile-output-mode .ms-seg .ms-seg__btn[data-on="true"] {
+  box-shadow: inset 0 0 0 1.5px color-mix(in srgb, var(--safelight) 60%, transparent);
 }
 
 .mobile-output-mode-label {

--- a/desktop/src/mobile/mobile.css.test.ts
+++ b/desktop/src/mobile/mobile.css.test.ts
@@ -314,6 +314,20 @@ describe("mobile safe areas", () => {
       expect(css).not.toContain(selector);
     }
   });
+
+  it("renders Output as two flush segments instead of nested rounded pills", () => {
+    const control = css.match(/\.mobile-output-mode \.ms-seg\s*\{([^}]*)\}/s);
+    const button = css.match(/\.mobile-output-mode \.ms-seg \.ms-seg__btn\s*\{([^}]*)\}/s);
+    const seam = css.match(
+      /\.mobile-output-mode \.ms-seg \.ms-seg__btn \+ \.ms-seg__btn\s*\{([^}]*)\}/s,
+    );
+
+    expect(control?.[1]).toMatch(/gap:\s*0\s*;/);
+    expect(control?.[1]).toMatch(/padding:\s*0\s*;/);
+    expect(control?.[1]).toMatch(/overflow:\s*hidden\s*;/);
+    expect(button?.[1]).toMatch(/border-radius:\s*0\s*;/);
+    expect(seam?.[1]).toMatch(/border-left:\s*1px solid var\(--ce\)\s*;/);
+  });
 });
 
 describe("mobile develop bed", () => {

--- a/desktop/src/mobile/mobile.css.test.ts
+++ b/desktop/src/mobile/mobile.css.test.ts
@@ -318,14 +318,24 @@ describe("mobile safe areas", () => {
   it("renders Output as two flush segments instead of nested rounded pills", () => {
     const control = css.match(/\.mobile-output-mode \.ms-seg\s*\{([^}]*)\}/s);
     const button = css.match(/\.mobile-output-mode \.ms-seg \.ms-seg__btn\s*\{([^}]*)\}/s);
+    const first = css.match(
+      /\.mobile-output-mode \.ms-seg \.ms-seg__btn:first-child\s*\{([^}]*)\}/s,
+    );
+    const last = css.match(/\.mobile-output-mode \.ms-seg \.ms-seg__btn:last-child\s*\{([^}]*)\}/s);
     const seam = css.match(
       /\.mobile-output-mode \.ms-seg \.ms-seg__btn \+ \.ms-seg__btn\s*\{([^}]*)\}/s,
     );
 
     expect(control?.[1]).toMatch(/gap:\s*0\s*;/);
     expect(control?.[1]).toMatch(/padding:\s*0\s*;/);
-    expect(control?.[1]).toMatch(/overflow:\s*hidden\s*;/);
+    expect(control?.[1]).not.toMatch(/overflow:\s*hidden\s*;/);
     expect(button?.[1]).toMatch(/border-radius:\s*0\s*;/);
+    expect(first?.[1]).toMatch(
+      /border-radius:\s*calc\(var\(--radius-control\) - 1px\) 0 0 calc\(var\(--radius-control\) - 1px\)\s*;/,
+    );
+    expect(last?.[1]).toMatch(
+      /border-radius:\s*0 calc\(var\(--radius-control\) - 1px\) calc\(var\(--radius-control\) - 1px\) 0\s*;/,
+    );
     expect(seam?.[1]).toMatch(/border-left:\s*1px solid var\(--ce\)\s*;/);
   });
 });

--- a/ui/components/ClipPill.vue
+++ b/ui/components/ClipPill.vue
@@ -93,6 +93,10 @@ function onRemove(event: MouseEvent) {
     color var(--dur-quick) var(--ease);
 }
 
+.ms-clip:has(.ms-clip__remove) .ms-clip__body {
+  padding-right: 36px;
+}
+
 .ms-clip__body:hover {
   color: var(--rebate);
   border-color: var(--ink-3);
@@ -166,28 +170,36 @@ function onRemove(event: MouseEvent) {
 
 .ms-clip__remove {
   position: absolute;
-  top: -6px;
-  right: -6px;
+  top: 50%;
+  right: 7px;
   width: 18px;
   height: 18px;
-  display: none;
+  display: grid;
   place-items: center;
   padding: 0;
-  border: 1px solid var(--ce);
+  border: 0;
   border-radius: 50%;
-  background: var(--bench);
+  background: transparent;
   color: var(--ink-2);
   font-size: 10px;
   cursor: pointer;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-50%);
+  transition:
+    background var(--dur-quick) var(--ease),
+    color var(--dur-quick) var(--ease),
+    opacity var(--dur-quick) var(--ease);
 }
 
 .ms-clip:hover .ms-clip__remove,
 .ms-clip:focus-within .ms-clip__remove {
-  display: grid;
+  opacity: 1;
+  pointer-events: auto;
 }
 
 .ms-clip__remove:hover {
+  background: color-mix(in srgb, var(--stop) 10%, transparent);
   color: var(--stop);
-  border-color: var(--stop);
 }
 </style>

--- a/ui/components/ClipRail.test.ts
+++ b/ui/components/ClipRail.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { mount } from "@vue/test-utils";
 import ClipRail from "./ClipRail.vue";
+import railSource from "./ClipRail.vue?raw";
+import pillSource from "./ClipPill.vue?raw";
 import type { RailClip } from "./types";
 
 function clips(count: number): RailClip[] {
@@ -70,5 +72,25 @@ describe("ClipRail", () => {
     });
     expect(wrapper.find(".ms-clip__plan--cached").exists()).toBe(true);
     expect(wrapper.find(".ms-clip__plan--rerender").exists()).toBe(true);
+  });
+
+  it("keeps long rails scrollable without exposing a desktop scrollbar", () => {
+    expect(railSource).toMatch(/\.ms-rail__clips\s*\{[^}]*flex:\s*0 0 auto/s);
+    expect(railSource).toMatch(/\.ms-rail\s*\{[^}]*scrollbar-width:\s*none/s);
+    expect(railSource).toMatch(
+      /\.ms-rail::-webkit-scrollbar\s*\{[^}]*display:\s*none/s,
+    );
+  });
+
+  it("reserves an in-pill slot for remove so it cannot cover the frame count", () => {
+    expect(pillSource).toMatch(
+      /\.ms-clip:has\(\.ms-clip__remove\) \.ms-clip__body\s*\{[^}]*padding-right:\s*36px/s,
+    );
+    expect(pillSource).toMatch(
+      /\.ms-clip__remove\s*\{[^}]*top:\s*50%[^}]*right:\s*7px[^}]*opacity:\s*0/s,
+    );
+    expect(pillSource).toMatch(
+      /\.ms-clip:hover \.ms-clip__remove,[\s\S]*\.ms-clip:focus-within \.ms-clip__remove\s*\{[^}]*opacity:\s*1/s,
+    );
   });
 });

--- a/ui/components/ClipRail.vue
+++ b/ui/components/ClipRail.vue
@@ -131,12 +131,18 @@ const dragModel = computed({
   align-items: center;
   gap: 8px;
   overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.ms-rail::-webkit-scrollbar {
+  display: none;
 }
 
 .ms-rail__clips {
   display: flex;
   align-items: center;
   gap: 8px;
+  flex: 0 0 auto;
 }
 
 .ms-rail__item {


### PR DESCRIPTION
## Summary

- render the iPhone Output picker as two flush 44pt segments with a clean center seam
- keep desktop sequence clips, Add, and reorder guidance in separate non-overlapping layout space
- reserve an in-pill slot for the clip remove affordance and hide the native horizontal scrollbar

## Root cause

The mobile control inherited the shared segmented-control padding, gap, and inner radius, producing a rounded pill inside a rounded shell.

On desktop, the draggable clips flex item was allowed to shrink while its children overflowed visibly. At longer sequence lengths, the final clip painted underneath Add and the reorder hint. The focus-revealed remove button also sat directly over the frame count.

## Validation

- `bun run check:frontend`
  - studio: 168 tests
  - web: 915 tests
  - desktop: 2,346 tests
  - web and desktop production builds
- `bun run build:mobile`
- `./scripts/tests/ios-release-assets.sh`
- focused mobile/sequence suite: 143 tests
- Prettier and `git diff --check`
- rendered QA at 393×852 and 1440×900 with no relevant console warnings/errors
