### PR TITLE
fix(mobile): center output segment labels

### DIFF
--- a/desktop/src/mobile/mobile.css
+++ b/desktop/src/mobile/mobile.css
@@ -180,11 +180,16 @@ button {
 
 .mobile-output-mode .ms-seg {
   gap: 0;
+  min-height: 44px;
   padding: 0;
+  border: 0;
+  box-shadow: inset 0 0 0 1px var(--ce);
 }
 
 .mobile-output-mode .ms-seg .ms-seg__btn {
   min-height: 44px;
+  justify-content: center;
+  padding-block: 0;
   border-radius: 0;
 }
 

--- a/desktop/src/mobile/mobile.css.test.ts
+++ b/desktop/src/mobile/mobile.css.test.ts
@@ -328,8 +328,13 @@ describe("mobile safe areas", () => {
 
     expect(control?.[1]).toMatch(/gap:\s*0\s*;/);
     expect(control?.[1]).toMatch(/padding:\s*0\s*;/);
+    expect(control?.[1]).toMatch(/min-height:\s*44px\s*;/);
+    expect(control?.[1]).toMatch(/border:\s*0\s*;/);
+    expect(control?.[1]).toMatch(/box-shadow:\s*inset 0 0 0 1px var\(--ce\)\s*;/);
     expect(control?.[1]).not.toMatch(/overflow:\s*hidden\s*;/);
     expect(button?.[1]).toMatch(/border-radius:\s*0\s*;/);
+    expect(button?.[1]).toMatch(/justify-content:\s*center\s*;/);
+    expect(button?.[1]).toMatch(/padding-block:\s*0\s*;/);
     expect(first?.[1]).toMatch(
       /border-radius:\s*calc\(var\(--radius-control\) - 1px\) 0 0 calc\(var\(--radius-control\) - 1px\)\s*;/,
     );


### PR DESCRIPTION
## Summary

- make the mobile Output segmented control exactly 44 points tall
- vertically center both labels without inherited block padding
- preserve the inset border and unclipped keyboard focus treatment
- lock the geometry into the mobile CSS regression test

## Root cause

The shared segmented-control shell added its own border around 44-point buttons, making the overall control taller than neighboring native controls. Its buttons also inherited vertical padding while using a column flex layout without vertical centering, which left the labels visually biased toward the top.

## Validation

- `bun run check:frontend`
- `bunx vitest run src/mobile/mobile.css.test.ts src/mobile/MobileApp.test.ts`
- `bun run build:mobile`
- `../scripts/tests/ios-release-assets.sh`
- rendered QA at a 393 × 852 viewport: 44px shell, 44px buttons, and label center delta under 0.01px
