### PR TITLE
fix(desktop): refine toasts and media controls

### DIFF
--- a/desktop/src/App.hosts.test.ts
+++ b/desktop/src/App.hosts.test.ts
@@ -15,4 +15,11 @@ describe("desktop host bootstrap", () => {
     expect(reconnect).toBeLessThan(waitForBoth);
     expect(local).toBeLessThan(waitForBoth);
   });
+
+  it("keeps offline hosts actionable from the compact toast", () => {
+    expect(source).toContain("It stays listed for reconnect.");
+    expect(source).toContain('label: "Open Machines"');
+    expect(source).toContain('router.push("/machines")');
+    expect(source).toContain("sticky: true");
+  });
 });

--- a/desktop/src/App.vue
+++ b/desktop/src/App.vue
@@ -91,7 +91,14 @@ watch(
   () => {
     const current = hostsStore.all.map((h) => ({ id: h.id, label: h.label, status: h.status }));
     for (const host of detectOfflineTransitions(hostStatusSnapshot, current)) {
-      toasts.push(`Can't reach ${host.label} — check Machines.`, "error", { sticky: true });
+      toasts.push(`Can't reach ${host.label}`, "error", {
+        description: "It stays listed for reconnect.",
+        action: {
+          label: "Open Machines",
+          run: () => void router.push("/machines"),
+        },
+        sticky: true,
+      });
     }
     hostStatusSnapshot = snapshotHostStatuses(current);
   },

--- a/desktop/src/components/gallery/AuthedMedia.test.ts
+++ b/desktop/src/components/gallery/AuthedMedia.test.ts
@@ -1,0 +1,22 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import AuthedMedia from "./AuthedMedia.vue";
+
+vi.mock("../../lib/gallery/media", () => ({
+  authedMediaUrl: vi.fn().mockResolvedValue("blob:video"),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("AuthedMedia", () => {
+  it("disables Picture-in-Picture for desktop video playback", async () => {
+    const wrapper = mount(AuthedMedia, {
+      props: { path: "/api/gallery/video/demo.mp4", video: true, controls: true },
+    });
+    await vi.waitFor(() => expect(wrapper.find("video").exists()).toBe(true));
+
+    expect(wrapper.get("video").attributes()).toHaveProperty("disablepictureinpicture");
+  });
+});

--- a/desktop/src/components/gallery/AuthedMedia.vue
+++ b/desktop/src/components/gallery/AuthedMedia.vue
@@ -45,6 +45,7 @@ onMounted(load);
     :controls="controls"
     loop
     playsinline
+    disablepictureinpicture
   />
   <img v-else-if="src" :src="src" :alt="alt" class="h-full w-full object-cover" draggable="false" />
   <div v-else-if="failed" class="flex h-full w-full items-center justify-center bg-bench">

--- a/desktop/src/components/shell/Toasts.test.ts
+++ b/desktop/src/components/shell/Toasts.test.ts
@@ -18,11 +18,11 @@ describe("Toasts a11y roles", () => {
     await wrapper.vm.$nextTick();
 
     const info = wrapper.get("[role='status']");
-    expect(info.text()).toBe("Saved to Gallery");
+    expect(info.get("[data-test='toast-title']").text()).toBe("Saved to Gallery");
     expect(info.attributes("aria-live")).toBe("polite");
 
     const error = wrapper.get("[role='alert']");
-    expect(error.text()).toBe("Something broke");
+    expect(error.get("[data-test='toast-title']").text()).toBe("Something broke");
     expect(error.attributes("aria-live")).toBe("assertive");
   });
 
@@ -41,7 +41,9 @@ describe("Toasts a11y roles", () => {
     toasts.push("Newer");
     await wrapper.vm.$nextTick();
 
-    const rendered = wrapper.findAll("[role='status']").map((row) => row.text());
+    const rendered = wrapper
+      .findAll("[role='status']")
+      .map((row) => row.get("[data-test='toast-title']").text());
     expect(rendered).toEqual(["Newer", "Older"]);
   });
 
@@ -54,5 +56,42 @@ describe("Toasts a11y roles", () => {
     expect(wrapper.find("[aria-label='Notifications']").exists()).toBe(true);
     await wrapper.get("[role='status']").trigger("click");
     expect(toasts.items.length).toBe(0);
+  });
+
+  it("renders an error as a compact action card with hierarchy and an explicit close control", async () => {
+    const wrapper = mount(Toasts);
+    const toasts = useToastStore();
+    const openMachines = vi.fn();
+    toasts.push("Can't reach bender-7680", "error", {
+      description: "It stays listed for reconnect.",
+      action: { label: "Open Machines", run: openMachines },
+      sticky: true,
+    });
+    await wrapper.vm.$nextTick();
+
+    const toast = wrapper.get("[role='alert']");
+    expect(toast.get("[data-test='toast-status-icon']").attributes("aria-hidden")).toBe("true");
+    expect(toast.get("[data-test='toast-title']").text()).toBe("Can't reach bender-7680");
+    expect(toast.get("[data-test='toast-description']").text()).toBe(
+      "It stays listed for reconnect.",
+    );
+    expect(toast.classes()).toContain("w-[min(25rem,calc(100vw-2rem))]");
+
+    await toast.get("[data-test='toast-action']").trigger("click");
+    expect(openMachines).toHaveBeenCalledOnce();
+    expect(toasts.items).toHaveLength(0);
+  });
+
+  it("dismisses from the explicit close control without running the body action", async () => {
+    const wrapper = mount(Toasts);
+    const toasts = useToastStore();
+    const onClick = vi.fn();
+    toasts.push("Generated", "info", { onClick });
+    await wrapper.vm.$nextTick();
+
+    await wrapper.get("[data-test='toast-dismiss']").trigger("click");
+
+    expect(onClick).not.toHaveBeenCalled();
+    expect(toasts.items).toHaveLength(0);
   });
 });

--- a/desktop/src/components/shell/Toasts.vue
+++ b/desktop/src/components/shell/Toasts.vue
@@ -24,25 +24,62 @@ const ordered = computed(() => [...toasts.items].reverse());
       <div
         v-for="toast in ordered"
         :key="toast.id"
-        class="border-edge pointer-events-auto flex items-center gap-2 rounded-chrome border bg-bench px-3 py-2 text-body shadow-raised"
-        :class="toast.kind === 'error' ? 'text-stop' : 'text-ink'"
+        class="border-edge pointer-events-auto grid w-[min(25rem,calc(100vw-2rem))] grid-cols-[auto_minmax(0,1fr)_auto] items-start gap-x-3 gap-y-2 rounded-[var(--radius-card)] border bg-bench px-4 py-3 text-body shadow-[0_10px_28px_rgba(0,0,0,0.28)]"
         :role="toast.kind === 'error' ? 'alert' : 'status'"
         :aria-live="toast.kind === 'error' ? 'assertive' : 'polite'"
         @click.self="toasts.click(toast.id)"
       >
+        <span
+          data-test="toast-status-icon"
+          aria-hidden="true"
+          class="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full font-semibold"
+          :class="
+            toast.kind === 'error'
+              ? 'bg-stop text-[var(--desk)]'
+              : 'bg-[color-mix(in_srgb,var(--halide)_18%,transparent)] text-halide'
+          "
+        >
+          {{ toast.kind === "error" ? "!" : "i" }}
+        </span>
         <button
           type="button"
-          class="min-w-0 flex-1 truncate text-left"
+          class="min-w-0 text-left"
           :title="toast.onClick ? undefined : 'Dismiss'"
           @click="toasts.click(toast.id)"
         >
-          {{ toast.message }}
+          <span data-test="toast-title" class="block font-semibold text-ink">
+            {{ toast.message }}
+          </span>
+          <span
+            v-if="toast.description"
+            data-test="toast-description"
+            class="mt-0.5 block text-caption leading-relaxed text-ink-2"
+          >
+            {{ toast.description }}
+          </span>
+        </button>
+        <button
+          type="button"
+          data-test="toast-dismiss"
+          class="-mt-1 -mr-1 flex h-7 w-7 items-center justify-center rounded-full text-ink-3 transition-colors duration-100 hover:bg-[color-mix(in_srgb,var(--rebate)_8%,transparent)] hover:text-ink"
+          aria-label="Dismiss notification"
+          @click="toasts.dismiss(toast.id)"
+        >
+          <svg viewBox="0 0 16 16" class="h-3.5 w-3.5" aria-hidden="true">
+            <path
+              d="m3.75 3.75 8.5 8.5m0-8.5-8.5 8.5"
+              fill="none"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-width="1.5"
+            />
+          </svg>
         </button>
         <button
           v-if="toast.action"
           type="button"
           data-test="toast-action"
-          class="shrink-0 rounded-control px-2 py-0.5 text-caption font-semibold text-safelight hover:brightness-110"
+          class="col-start-2 col-end-4 justify-self-end rounded-control px-2 py-1 text-caption font-semibold text-safelight transition-colors duration-100 hover:bg-[color-mix(in_srgb,var(--safelight)_10%,transparent)] hover:brightness-110"
           @click="toasts.runAction(toast.id)"
         >
           {{ toast.action.label }}

--- a/desktop/src/stores/toasts.ts
+++ b/desktop/src/stores/toasts.ts
@@ -10,6 +10,8 @@ export interface Toast {
   id: number;
   message: string;
   kind: "info" | "error";
+  /** Optional supporting copy rendered below the primary message. */
+  description?: string;
   /** Optional trailing action button (Undo, View…). Running it dismisses the toast. */
   action?: ToastAction;
   /** Optional body-click handler (e.g. navigate). Defaults to dismiss. */
@@ -19,6 +21,7 @@ export interface Toast {
 }
 
 export interface ToastOptions {
+  description?: string;
   action?: ToastAction;
   onClick?: () => void;
   sticky?: boolean;
@@ -45,6 +48,7 @@ export const useToastStore = defineStore("toasts", {
         id: nextId++,
         message,
         kind,
+        ...(options.description ? { description: options.description } : {}),
         ...(options.action ? { action: options.action } : {}),
         ...(options.onClick ? { onClick: options.onClick } : {}),
         ...(options.sticky ? { sticky: true } : {}),

--- a/desktop/src/styles/base.behavior.test.ts
+++ b/desktop/src/styles/base.behavior.test.ts
@@ -10,4 +10,11 @@ describe("desktop document behavior", () => {
     );
     expect(css).not.toMatch(/(?:^|\n)\s*\*\s*{\s*overscroll-behavior:\s*none;/s);
   });
+
+  it("hides WebKit's Picture-in-Picture control for desktop videos", () => {
+    expect(css).toContain("video::-webkit-media-controls-picture-in-picture-button");
+    expect(css).toMatch(
+      /video::\-webkit-media-controls-picture-in-picture-button\s*\{[^}]*display:\s*none/s,
+    );
+  });
 });

--- a/desktop/src/styles/base.css
+++ b/desktop/src/styles/base.css
@@ -80,6 +80,13 @@ textarea,
   background: transparent;
 }
 
+/* WKWebView may expose Picture in Picture in its native media controls even
+ * when the element opts out. Mold keeps video playback inside its own canvas
+ * and Library viewer, so hide that WebKit-only control as a fallback. */
+video::-webkit-media-controls-picture-in-picture-button {
+  display: none;
+}
+
 /* Utility type roles */
 .edge-code {
   font-family: var(--font-utility);

--- a/desktop/src/views/GenerateView.layout.test.ts
+++ b/desktop/src/views/GenerateView.layout.test.ts
@@ -42,4 +42,16 @@ describe("GenerateView layout", () => {
     expect(viewSource).toContain("Your print develops here");
     expect(viewSource).toContain("Describe an image below, pick a look, and press Generate.");
   });
+
+  it("dismisses the Templates popover on document-level Escape and restores trigger focus", () => {
+    expect(viewSource).toContain('document.addEventListener("keydown", onDocumentKeydown)');
+    expect(viewSource).toContain('document.removeEventListener("keydown", onDocumentKeydown)');
+    expect(viewSource).toContain('event.key !== "Escape"');
+    expect(viewSource).toContain("templatesToggleEl.value?.focus()");
+  });
+
+  it("disables Picture-in-Picture on the generated video preview", () => {
+    const previewVideo = viewSource.match(/<video\s+v-if="job\?\.resultUrl[^>]*>/s)?.[0] ?? "";
+    expect(previewVideo).toContain("disablepictureinpicture");
+  });
 });

--- a/desktop/src/views/GenerateView.vue
+++ b/desktop/src/views/GenerateView.vue
@@ -231,6 +231,7 @@ const form = formStore.form;
 const composerRef = ref<InstanceType<typeof ComposerCard> | null>(null);
 const templatesOpen = ref(false);
 const templatesEl = ref<HTMLDivElement | null>(null);
+const templatesToggleEl = ref<HTMLButtonElement | null>(null);
 /** Recent prompts for the composer's ↑/↓ history cycling. */
 const promptHistory = ref<string[]>([]);
 const nativeImageDragOver = ref(false);
@@ -310,6 +311,13 @@ async function listenForNativeImageDrops() {
 function onDocumentPointerDown(event: PointerEvent) {
   if (!templatesOpen.value || !templatesEl.value) return;
   if (!event.composedPath().includes(templatesEl.value)) templatesOpen.value = false;
+}
+
+function onDocumentKeydown(event: KeyboardEvent) {
+  if (!templatesOpen.value || event.defaultPrevented || event.key !== "Escape") return;
+  event.preventDefault();
+  templatesOpen.value = false;
+  void nextTick(() => templatesToggleEl.value?.focus());
 }
 
 const job = computed(() => generation.active);
@@ -1746,6 +1754,7 @@ watch(
 
 onMounted(() => {
   document.addEventListener("pointerdown", onDocumentPointerDown);
+  document.addEventListener("keydown", onDocumentKeydown);
   void listenForNativeImageDrops();
   // The persisted sequence draft wins on ordinary visits; a ?output=sequence
   // deep-link is consumed once and stripped.
@@ -1759,6 +1768,7 @@ onBeforeUnmount(() => {
   nativeImageDropUnmounted = true;
   stopNativeImageDrop?.();
   document.removeEventListener("pointerdown", onDocumentPointerDown);
+  document.removeEventListener("keydown", onDocumentKeydown);
 });
 </script>
 
@@ -1785,6 +1795,7 @@ onBeforeUnmount(() => {
         <!-- Templates popover (relocated from the inspector) -->
         <div ref="templatesEl" class="absolute right-3 top-3 z-20">
           <button
+            ref="templatesToggleEl"
             type="button"
             data-test="templates-toggle"
             class="border-edge rounded-control border bg-bench/80 px-2.5 py-1 text-caption text-ink-2 backdrop-blur transition-colors hover:text-ink"
@@ -1851,6 +1862,7 @@ onBeforeUnmount(() => {
                   autoplay
                   loop
                   controls
+                  disablepictureinpicture
                 />
                 <img
                   v-else-if="job?.resultUrl"


### PR DESCRIPTION
## Summary
- replace wide red desktop banners with compact hierarchical toast cards and an actionable host-offline recovery
- dismiss the Create Templates popover with Escape and restore focus to its trigger
- suppress Picture in Picture controls on desktop video previews and authenticated gallery media

## Validation
- `bun run --cwd desktop fmt:check`
- `bun run --cwd desktop test` (2,353 tests)
- `bun run --cwd desktop build`
- rendered Create/Templates and toast QA in light and dark themes with zero console warnings/errors