### PR TITLE
Fix durable chains for installed catalog models

### DIFF
--- a/crates/mold-server/src/chain_job_runner.rs
+++ b/crates/mold-server/src/chain_job_runner.rs
@@ -2846,24 +2846,19 @@ impl ProductionStageExecutor {
     fn fresh_config(&self) -> mold_core::Config {
         self.config.blocking_read().clone()
     }
-}
 
-impl StageExecutor for ProductionStageExecutor {
-    fn freeze_model(&self, model: &str) -> anyhow::Result<mold_core::chain_job::FrozenChainModel> {
-        let config = self.fresh_config();
-        crate::execution_plan::freeze_chain_model(&config, model).map_err(anyhow::Error::new)
-    }
-
-    fn render_stage(
+    #[allow(clippy::too_many_arguments)]
+    fn render_stage_with_authority(
         &self,
+        cache_key: &str,
         model: &str,
+        config: &mold_core::Config,
         stage_req: &GenerateRequest,
         carry: Option<&ChainTail>,
         motion_tail_frames: u32,
         progress: &(dyn Fn(u32, u32) -> ControlFlow<()> + Send + Sync),
         cancelled: &(dyn Fn() -> bool + Send + Sync),
     ) -> anyhow::Result<StageRenderOutcome> {
-        let config = self.fresh_config();
         let Some(in_flight) = claim_worker_for_stage(
             &self.gpu_pool,
             model,
@@ -2876,7 +2871,7 @@ impl StageExecutor for ProductionStageExecutor {
         let worker = in_flight.worker().clone();
         let _in_flight = in_flight;
         let _active = WorkerActiveGenerationGuard::new(worker.clone(), model, &stage_req.prompt)?;
-        let hint = model_manager::family_for_model_sync(model, &config).map(|family| {
+        let hint = model_manager::family_for_model_sync(model, config).map(|family| {
             model_manager::ActivationHint {
                 width: stage_req.width,
                 height: stage_req.height,
@@ -2887,10 +2882,11 @@ impl StageExecutor for ProductionStageExecutor {
         });
         let carry_owned = carry.cloned();
         let stage_req = stage_req.clone();
-        let prep = gpu_worker::run_stage_blocking(
+        gpu_worker::run_stage_blocking_with_identity(
             &worker,
+            cache_key,
             model,
-            &config,
+            config,
             hint,
             move |engine| -> anyhow::Result<StageRenderOutcome> {
                 let renderer = engine.as_chain_renderer().ok_or_else(|| {
@@ -2919,8 +2915,47 @@ impl StageExecutor for ProductionStageExecutor {
                     Ok(StageRenderOutcome::Done(outcome))
                 }
             },
-        )?;
-        prep
+        )?
+    }
+}
+
+impl StageExecutor for ProductionStageExecutor {
+    fn freeze_model(&self, model: &str) -> anyhow::Result<mold_core::chain_job::FrozenChainModel> {
+        let config = self.fresh_config();
+        match model_manager::resolve_existing_model_authority(model, &config)
+            .map_err(|error| anyhow!(error.error))?
+        {
+            Some(authority) => crate::execution_plan::freeze_chain_model_with_paths(
+                &authority.config,
+                model,
+                authority.paths,
+            )
+            .map_err(anyhow::Error::new),
+            None => crate::execution_plan::freeze_chain_model(&config, model)
+                .map_err(anyhow::Error::new),
+        }
+    }
+
+    fn render_stage(
+        &self,
+        model: &str,
+        stage_req: &GenerateRequest,
+        carry: Option<&ChainTail>,
+        motion_tail_frames: u32,
+        progress: &(dyn Fn(u32, u32) -> ControlFlow<()> + Send + Sync),
+        cancelled: &(dyn Fn() -> bool + Send + Sync),
+    ) -> anyhow::Result<StageRenderOutcome> {
+        let config = self.fresh_config();
+        self.render_stage_with_authority(
+            model,
+            model,
+            &config,
+            stage_req,
+            carry,
+            motion_tail_frames,
+            progress,
+            cancelled,
+        )
     }
 
     fn render_stage_with_context(
@@ -2940,9 +2975,27 @@ impl StageExecutor for ProductionStageExecutor {
         cancelled: Arc<dyn Fn() -> bool + Send + Sync>,
     ) -> anyhow::Result<StageExecution> {
         if !self.dispatch_mode.owns_v2_workers() {
+            let mut config = self.fresh_config();
+            let cache_key = if let Some(frozen) = frozen_model {
+                let current =
+                    crate::execution_plan::frozen_model_fingerprint(model, &frozen.config)?;
+                if current != frozen.model_fingerprint {
+                    anyhow::bail!("frozen chain model inputs changed before CUDA");
+                }
+                config.install_frozen_model_config(model, frozen.config.clone());
+                if frozen.runtime_model_id.is_empty() {
+                    model
+                } else {
+                    frozen.runtime_model_id.as_str()
+                }
+            } else {
+                model
+            };
             return self
-                .render_stage(
+                .render_stage_with_authority(
+                    cache_key,
                     model,
+                    &config,
                     stage_req,
                     carry,
                     motion_tail_frames,
@@ -7853,6 +7906,55 @@ mod tests {
         let worker_method = &worker_source[worker_start..worker_end];
         assert!(worker_method.contains("run_stage_blocking_planned("));
         assert!(!worker_method.contains("run_stage_blocking(\n"));
+    }
+
+    #[test]
+    fn production_legacy_stage_path_keeps_persisted_frozen_model_authority() {
+        let source = include_str!("chain_job_runner.rs");
+        let implementation = source
+            .find("impl StageExecutor for ProductionStageExecutor")
+            .expect("production executor implementation");
+        let freeze_start = source[implementation..]
+            .find("fn freeze_model(")
+            .map(|offset| implementation + offset)
+            .expect("production freeze method");
+        let render_start = source[freeze_start..]
+            .find("\n    fn render_stage(")
+            .map(|offset| freeze_start + offset)
+            .expect("production render method");
+        let freeze_method = &source[freeze_start..render_start];
+        assert!(freeze_method.contains("resolve_existing_model_authority("));
+        assert!(freeze_method.contains("freeze_chain_model_with_paths("));
+
+        let contextual_start = source[render_start..]
+            .find("fn render_stage_with_context(")
+            .map(|offset| render_start + offset)
+            .expect("production contextual render method");
+        let v2_start = source[contextual_start..]
+            .find("\n        if cancelled()")
+            .map(|offset| contextual_start + offset)
+            .expect("V2 branch begins after legacy branch");
+        let legacy_branch = &source[contextual_start..v2_start];
+        let fingerprint = legacy_branch
+            .find("frozen_model_fingerprint(")
+            .expect("legacy replacement fence");
+        let install = legacy_branch
+            .find("install_frozen_model_config(")
+            .expect("legacy frozen config install");
+        let render = legacy_branch
+            .find("render_stage_with_authority(")
+            .expect("legacy frozen render");
+        assert!(fingerprint < install && install < render);
+        assert!(legacy_branch.contains("frozen.runtime_model_id"));
+
+        let helper_start = source
+            .find("fn render_stage_with_authority(")
+            .expect("authority-aware render helper");
+        let helper_end = source[helper_start..]
+            .find("\n}\n\nimpl StageExecutor for ProductionStageExecutor")
+            .map(|offset| helper_start + offset)
+            .expect("authority helper boundary");
+        assert!(source[helper_start..helper_end].contains("run_stage_blocking_with_identity("));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/mold-server/src/execution_plan.rs
+++ b/crates/mold-server/src/execution_plan.rs
@@ -3128,6 +3128,19 @@ pub fn freeze_chain_model(
         ModelPaths::resolve(model, config).ok_or_else(|| ExecutionPlanError::MissingArtifacts {
             model: model.to_string(),
         })?;
+    freeze_chain_model_with_paths(config, model, paths)
+}
+
+/// Freeze a model from the exact path resolution used at request admission.
+///
+/// Callers resolving opaque installed-catalog IDs must not repeat resolution
+/// from the base config: the effective overlay and these paths are one
+/// immutable authority snapshot.
+pub fn freeze_chain_model_with_paths(
+    config: &Config,
+    model: &str,
+    paths: ModelPaths,
+) -> Result<mold_core::chain_job::FrozenChainModel, ExecutionPlanError> {
     let canonical = |path: &std::path::Path| {
         std::fs::canonicalize(path)
             .map_err(|_| ExecutionPlanError::MissingArtifacts {

--- a/crates/mold-server/src/gpu_worker.rs
+++ b/crates/mold-server/src/gpu_worker.rs
@@ -3826,6 +3826,29 @@ pub fn run_stage_blocking<T, E: std::fmt::Display + std::fmt::Debug>(
     run_chain_blocking(worker, model_name, config, hint, with_engine)
 }
 
+/// Run a blocking chain stage with a cache identity separate from its semantic
+/// model name. Durable frozen models use their immutable runtime ID so a
+/// legacy/observe worker cannot reuse an engine loaded from mutable live
+/// config under the original catalog ID.
+pub fn run_stage_blocking_with_identity<T, E: std::fmt::Display + std::fmt::Debug>(
+    worker: &GpuWorker,
+    cache_key: &str,
+    model_name: &str,
+    config: &mold_core::Config,
+    hint: Option<crate::model_manager::ActivationHint>,
+    with_engine: impl FnOnce(&mut dyn mold_inference::InferenceEngine) -> Result<T, E>,
+) -> ChainPrep<T, E> {
+    run_chain_blocking_with_identity(
+        worker,
+        cache_key,
+        model_name,
+        config,
+        hint,
+        None,
+        with_engine,
+    )
+}
+
 struct PlannedStageLoad<'a> {
     cache_key: &'a str,
     model_name: &'a str,

--- a/crates/mold-server/src/model_manager.rs
+++ b/crates/mold-server/src/model_manager.rs
@@ -57,6 +57,12 @@ pub(crate) struct ExistingModelResolution {
     pub model_config_overlay: Option<mold_core::ModelConfig>,
 }
 
+#[derive(Clone, Debug)]
+pub(crate) struct ExistingModelAuthority {
+    pub paths: ModelPaths,
+    pub config: Config,
+}
+
 /// Resolve concrete model paths using only the supplied config and installed
 /// local sidecars.
 ///
@@ -109,6 +115,31 @@ pub(crate) fn resolve_existing_model_paths(
     }))
 }
 
+/// Resolve one immutable, local-only config snapshot for work that must keep
+/// an opaque catalog model stable beyond request admission.
+///
+/// The returned config owns the catalog overlay instead of mutating
+/// `AppState.config`, so inventory refreshes cannot erase or replace the
+/// authority carried by durable work.
+pub(crate) fn resolve_existing_model_authority(
+    model_name: &str,
+    config: &Config,
+) -> Result<Option<ExistingModelAuthority>, ApiError> {
+    let Some(resolved) = resolve_existing_model_paths(model_name, config)? else {
+        return Ok(None);
+    };
+    let mut effective = config.clone();
+    if let Some(model_config) = resolved.model_config_overlay {
+        effective
+            .models
+            .insert(model_name.to_string(), model_config);
+    }
+    Ok(Some(ExistingModelAuthority {
+        paths: resolved.paths,
+        config: effective,
+    }))
+}
+
 pub(crate) fn resolve_installed_catalog_paths_for_worker(
     model_name: &str,
     config: &Config,
@@ -116,17 +147,10 @@ pub(crate) fn resolve_installed_catalog_paths_for_worker(
     if !looks_like_catalog_id(model_name) {
         return Ok(None);
     }
-    let Some(resolved) = resolve_existing_model_paths(model_name, config)? else {
+    let Some(authority) = resolve_existing_model_authority(model_name, config)? else {
         return Ok(None);
     };
-    let Some(model_config) = resolved.model_config_overlay else {
-        return Ok(Some((resolved.paths, config.clone())));
-    };
-    let mut resolved_config = config.clone();
-    resolved_config
-        .models
-        .insert(model_name.to_string(), model_config);
-    Ok(Some((resolved.paths, resolved_config)))
+    Ok(Some((authority.paths, authority.config)))
 }
 
 pub(crate) type DownloadProgressCallback =

--- a/crates/mold-server/src/routes_chain.rs
+++ b/crates/mold-server/src/routes_chain.rs
@@ -24,20 +24,38 @@ use std::convert::Infallible;
 use tokio_stream::StreamExt as _;
 
 use crate::chain_job_runner::{ChainJobRunnerHandle, EphemeralClaimGuard};
+use crate::model_manager::ExistingModelAuthority;
 use crate::queue::save_video_to_dir;
 use crate::routes::{requested_sse_completion_payload, ApiError};
 use crate::state::{AppState, SseCompletionPayload};
 
-pub(crate) async fn freeze_chain_model(
+fn chain_freeze_error(model: &str, error: impl std::fmt::Display) -> ApiError {
+    ApiError::validation(format!(
+        "cannot freeze concrete chain model companions for '{model}': {error}"
+    ))
+}
+
+pub(crate) async fn resolve_chain_model_authority(
     state: &AppState,
     model: &str,
+) -> Result<ExistingModelAuthority, ApiError> {
+    let config = state.config.read().await.clone();
+    crate::model_manager::resolve_existing_model_authority(model, &config)
+        .map_err(|error| chain_freeze_error(model, error.error))?
+        .ok_or_else(|| {
+            chain_freeze_error(
+                model,
+                format!("model '{model}' has no concrete local artifact paths"),
+            )
+        })
+}
+
+pub(crate) fn freeze_chain_model(
+    authority: ExistingModelAuthority,
+    model: &str,
 ) -> Result<mold_core::chain_job::FrozenChainModel, ApiError> {
-    let config = state.config.read().await;
-    crate::execution_plan::freeze_chain_model(&config, model).map_err(|error| {
-        ApiError::validation(format!(
-            "cannot freeze concrete chain model companions for '{model}': {error}"
-        ))
-    })
+    crate::execution_plan::freeze_chain_model_with_paths(&authority.config, model, authority.paths)
+        .map_err(|error| chain_freeze_error(model, error))
 }
 
 /// Internal wire event used by the chain SSE stream before per-event
@@ -88,11 +106,13 @@ async fn shim_start_job(state: &AppState, req: ChainRequest) -> Result<ShimJob, 
     })?;
 
     let mut req = req;
-    validate_and_normalize_chain_family(state, &mut req).await?;
+    validate_chain_build_features(&req)?;
+    let authority = resolve_chain_model_authority(state, &req.model).await?;
+    validate_and_normalize_chain_family(&authority.config, &mut req)?;
     let mut req = req
         .normalise()
         .map_err(|e| ApiError::validation(e.to_string()))?;
-    validate_and_normalize_chain_family(state, &mut req).await?;
+    validate_and_normalize_chain_family(&authority.config, &mut req)?;
 
     let original_format = req.output_format;
     req.output_format = OutputFormat::Mp4;
@@ -105,7 +125,7 @@ async fn shim_start_job(state: &AppState, req: ChainRequest) -> Result<ShimJob, 
         crate::chain_job_runner::CreateJobParams {
             id: job_id.clone(),
             ephemeral: true,
-            frozen_model: Some(freeze_chain_model(state, &req.model).await?),
+            frozen_model: Some(freeze_chain_model(authority, &req.model)?),
             request: req,
         },
     ) {
@@ -539,18 +559,22 @@ fn build_sse_chain_complete_event(
 /// chain generation. Mutates `req.motion_tail_frames` for families that lack
 /// latent context handoff (currently `ltx-video`) so the stitch layer doesn't
 /// trim independent fresh frames at Smooth boundaries.
-pub(crate) async fn validate_and_normalize_chain_family(
-    state: &AppState,
-    req: &mut ChainRequest,
-) -> Result<(), ApiError> {
+pub(crate) fn validate_chain_build_features(_req: &ChainRequest) -> Result<(), ApiError> {
     #[cfg(not(feature = "mp4"))]
-    if req.enable_audio == Some(true) {
+    if _req.enable_audio == Some(true) {
         return Err(ApiError::validation(
             "chain audio requires a mold build with the mp4 feature; rebuild with `--features mp4` or remove `enable_audio: true`",
         ));
     }
+    Ok(())
+}
 
-    let config = state.config.read().await;
+pub(crate) fn validate_and_normalize_chain_family(
+    config: &mold_core::Config,
+    req: &mut ChainRequest,
+) -> Result<(), ApiError> {
+    validate_chain_build_features(req)?;
+
     let resolved_model = config.resolved_model_config(&req.model);
     let canonical_model = mold_core::manifest::resolve_model_name(&req.model);
     let manifest = mold_core::manifest::find_manifest(&canonical_model);
@@ -1269,8 +1293,8 @@ mod tests {
         let mut request = req(OutputFormat::Mp4);
         request.model = "ltx-2.3-22b-dev:fp8".into();
 
-        let error = validate_and_normalize_chain_family(&state, &mut request)
-            .await
+        let config = state.config.read().await;
+        let error = validate_and_normalize_chain_family(&config, &mut request)
             .expect_err("two-stage LTX-2 must be rejected at the API boundary");
 
         assert!(error.error.contains("two-stage"));

--- a/crates/mold-server/src/routes_chain_jobs.rs
+++ b/crates/mold-server/src/routes_chain_jobs.rs
@@ -76,7 +76,9 @@ pub async fn create_chain_job(
     crate::routes::ensure_generation_available(&state)?;
     let handle = chain_jobs_handle(&state)?;
     let db = metadata_db(&state)?;
-    crate::routes_chain::validate_and_normalize_chain_family(&state, &mut req).await?;
+    crate::routes_chain::validate_chain_build_features(&req)?;
+    let authority = crate::routes_chain::resolve_chain_model_authority(&state, &req.model).await?;
+    crate::routes_chain::validate_and_normalize_chain_family(&authority.config, &mut req)?;
     let req = req
         .normalise()
         .map_err(|e| ApiError::validation(e.to_string()))?;
@@ -95,7 +97,9 @@ pub async fn create_chain_job(
         crate::chain_job_runner::CreateJobParams {
             id: job_id.clone(),
             ephemeral: false,
-            frozen_model: Some(crate::routes_chain::freeze_chain_model(&state, &req.model).await?),
+            frozen_model: Some(crate::routes_chain::freeze_chain_model(
+                authority, &req.model,
+            )?),
             request: req,
         },
     )
@@ -151,8 +155,18 @@ pub async fn preview_chain_job_placement(
     if !(1..=64).contains(&copies) {
         return Json(unavailable("copies must be between 1 and 64".to_string()));
     }
+    if let Err(error) = crate::routes_chain::validate_chain_build_features(&req) {
+        return Json(unavailable(error.error));
+    }
+    let base_config = state.config.read().await.clone();
+    let validation_config =
+        match crate::model_manager::resolve_existing_model_authority(&req.model, &base_config) {
+            Ok(Some(authority)) => authority.config,
+            Ok(None) => base_config,
+            Err(error) => return Json(unavailable(error.error)),
+        };
     if let Err(error) =
-        crate::routes_chain::validate_and_normalize_chain_family(&state, &mut req).await
+        crate::routes_chain::validate_and_normalize_chain_family(&validation_config, &mut req)
     {
         return Json(unavailable(error.error));
     }
@@ -461,7 +475,20 @@ pub async fn amend_chain_job(
             .map_err(|e| ApiError::internal(format!("failed to load chain request: {e:#}")))?;
         let mut candidate = crate::chain_job_runner::amend_candidate_request(&effective, &req);
         let motion_tail_before = candidate.motion_tail_frames;
-        crate::routes_chain::validate_and_normalize_chain_family(&state, &mut candidate).await?;
+        crate::routes_chain::validate_chain_build_features(&candidate)?;
+        let validation_config = if let Some(frozen) = manifest.frozen_model.as_ref() {
+            let mut config = state.config.read().await.clone();
+            config.install_frozen_model_config(&candidate.model, frozen.config.clone());
+            config
+        } else {
+            crate::routes_chain::resolve_chain_model_authority(&state, &candidate.model)
+                .await?
+                .config
+        };
+        crate::routes_chain::validate_and_normalize_chain_family(
+            &validation_config,
+            &mut candidate,
+        )?;
         if candidate.motion_tail_frames != motion_tail_before {
             req.motion_tail_frames = Some(candidate.motion_tail_frames);
         }
@@ -1059,6 +1086,79 @@ mod tests {
         out
     }
 
+    fn materialize_manifest_companion(models_dir: &std::path::Path, companion: &str) {
+        let manifest = mold_core::manifest::find_manifest(companion).unwrap();
+        for file in &manifest.files {
+            let path = models_dir.join(mold_core::manifest::storage_path(manifest, file));
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(&path, b"test fixture").unwrap();
+            mold_core::download::write_sha256_marker(&path, "test").unwrap();
+        }
+    }
+
+    fn write_safetensors_with_keys(path: &std::path::Path, keys: &[&str]) {
+        use std::io::Write;
+
+        let mut header = serde_json::Map::new();
+        for key in keys {
+            header.insert(
+                (*key).to_string(),
+                serde_json::json!({
+                    "dtype": "F32",
+                    "shape": [1],
+                    "data_offsets": [0, 4],
+                }),
+            );
+        }
+        let header_json = serde_json::to_vec(&serde_json::Value::Object(header)).unwrap();
+        let mut file = std::fs::File::create(path).unwrap();
+        file.write_all(&(header_json.len() as u64).to_le_bytes())
+            .unwrap();
+        file.write_all(&header_json).unwrap();
+        file.write_all(&[0u8; 4]).unwrap();
+    }
+
+    fn materialize_ltx23_catalog_model(models_dir: &std::path::Path, model: &str) {
+        for companion in ["ltx2-te", "ltx2.3-vae", "ltx2.3-text-projection"] {
+            materialize_manifest_companion(models_dir, companion);
+        }
+        let install_dir = models_dir.join("cv-3143864");
+        std::fs::create_dir_all(&install_dir).unwrap();
+        let primary = install_dir.join("model.safetensors");
+        write_safetensors_with_keys(
+            &primary,
+            &["model.diffusion_model.transformer_blocks.0.attn1.to_q.weight"],
+        );
+        mold_catalog::sidecar::write_sidecar(
+            &install_dir.join(mold_catalog::sidecar::SIDECAR_FILENAME),
+            &mold_catalog::sidecar::CatalogSidecar {
+                schema: mold_catalog::sidecar::SIDECAR_SCHEMA,
+                id: model.to_string(),
+                source: "civitai".into(),
+                source_id: "3143864".into(),
+                name: "LTX 2.3 INT4 ConvRot".into(),
+                author: None,
+                family: "ltx2".into(),
+                family_role: "finetune".into(),
+                sub_family: Some("v2.3".into()),
+                kind: "checkpoint".into(),
+                modality: "video".into(),
+                nsfw: None,
+                description: None,
+                tags: vec![],
+                license: None,
+                page_url: None,
+                thumbnail_url: None,
+                size_bytes: Some(primary.metadata().unwrap().len()),
+                supported: true,
+                trained_words: vec![],
+                primary_filename_rel: "model.safetensors".into(),
+                written_at: 0,
+            },
+        )
+        .unwrap();
+    }
+
     struct NoopExecutor;
 
     impl crate::chain_job_runner::StageExecutor for NoopExecutor {
@@ -1169,11 +1269,81 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn web_sequence_freezes_installed_ltx23_catalog_model_without_mutating_live_config() {
+        const MODEL: &str = "cv:3143864";
+
+        let home = tempfile::tempdir().unwrap();
+        let models_dir = home.path().join("models");
+        std::fs::create_dir_all(&models_dir).unwrap();
+        materialize_ltx23_catalog_model(&models_dir, MODEL);
+        let db = Arc::new(Some(MetadataDb::open_in_memory().unwrap()));
+        let state = state_with(
+            db.clone(),
+            crate::chain_job_runner::ChainJobRunnerHandle::inert_for_tests(),
+        );
+        state.config.write().await.models_dir = models_dir.display().to_string();
+        let mut request = req(OutputFormat::Mp4);
+        request.model = MODEL.into();
+        request.stages.push(ChainStage {
+            prompt: "stage one".into(),
+            frames: 9,
+            source_image: None,
+            negative_prompt: None,
+            seed_offset: None,
+            transition: TransitionMode::Cut,
+            fade_frames: None,
+            model: None,
+            loras: vec![],
+            references: vec![],
+        });
+
+        let (status, Json(created)) = with_mold_home(home.path(), || {
+            futures::executor::block_on(create_chain_job(State(state.clone()), Json(request)))
+        })
+        .unwrap();
+
+        assert_eq!(status, StatusCode::ACCEPTED);
+        assert!(
+            !state.config.read().await.models.contains_key(MODEL),
+            "durable admission must not install a runtime catalog overlay into AppState"
+        );
+        let row = chain_jobs::get_job(db.as_ref().as_ref().unwrap(), &created.job_id)
+            .unwrap()
+            .unwrap();
+        let manifest = ChainJobManifest::read_from_dir(&row.job_dir).unwrap();
+        let effective = crate::chain_job_runner::effective_request(&manifest).unwrap();
+        assert_eq!(effective.model, MODEL);
+        assert_eq!(effective.stages.len(), 2);
+        let frozen = manifest.frozen_model.expect("catalog model frozen");
+        assert!(frozen.runtime_model_id.starts_with("mold-frozen-chain:"));
+        assert_eq!(frozen.config.family.as_deref(), Some("ltx2"));
+        let paths = mold_core::ModelPaths::resolve_from_model_config_exact(&frozen.config)
+            .expect("frozen paths remain exactly resolvable");
+        assert_eq!(
+            paths.transformer,
+            models_dir
+                .join("cv-3143864/model.safetensors")
+                .canonicalize()
+                .unwrap()
+        );
+        assert_ne!(paths.vae, paths.transformer);
+        assert!(
+            paths.text_encoder_files.len() > 1,
+            "Gemma weights and LTX-2.3 text projection must both be frozen"
+        );
+        for path in frozen.config.all_file_paths() {
+            let path = std::path::Path::new(&path);
+            assert!(path.is_absolute());
+            assert!(path.is_file(), "missing frozen path {}", path.display());
+        }
+    }
+
+    #[tokio::test]
     async fn create_chain_job_fails_closed_when_model_freeze_is_unresolvable() {
         let home = tempfile::tempdir().unwrap();
         let db = Arc::new(Some(MetadataDb::open_in_memory().unwrap()));
         let state = state_with(
-            db,
+            db.clone(),
             crate::chain_job_runner::ChainJobRunnerHandle::inert_for_tests(),
         );
         state.config.write().await.models.insert(
@@ -1197,10 +1367,16 @@ mod tests {
             futures::executor::block_on(create_chain_job(State(state), Json(request)))
         })
         .unwrap_err();
+        assert!(error
+            .error
+            .starts_with("cannot freeze concrete chain model companions for 'unfreezable-chain':"));
         assert_eq!(
             error.into_response().status(),
             StatusCode::UNPROCESSABLE_ENTITY
         );
+        assert!(chain_jobs::list_jobs(db.as_ref().as_ref().unwrap())
+            .unwrap()
+            .is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What changed

- Resolve one immutable local model authority for durable chain admission, so family and sequence validation and companion freezing use the same installed sidecar snapshot.
- Freeze canonical transformer, VAE, Gemma, text-projection, tokenizer, upscaler, LoRA, and decoder paths without mutating AppState config or consulting the live catalog.
- Reuse installed-sidecar resolution for legacy manifest migration.
- Make legacy and observe execution honor the persisted frozen config and synthetic runtime cache identity, with a replacement-fingerprint fence before CUDA.
- Keep V2 execution, non-authoritative chain placement previews, persisted amend authority, and existing 422 failure semantics intact.
- Add a Web-shaped cv:3143864 regression test plus legacy-authority coverage.

## Root cause

Ordinary generation had gained an existing-only resolver for opaque installed catalog IDs, but POST /api/chain-jobs still froze models directly from static Config. A cold installed model such as cv:3143864 therefore appeared in /api/models and could pass ordinary placement planning, while durable sequence admission failed with has no concrete local artifact paths before persisting its sidecar-derived companions.

## User impact

The Web UI can now submit and complete durable sequences with installed Civitai or Hugging Face model IDs while preserving exact local artifacts for resume, amend, retake, and legacy recovery.

## Validation

- cargo fmt --all -- --check
- git diff --check
- cargo clippy -p mold-ai-server --all-targets -- -D warnings
- cargo clippy -p mold-ai-server --features mp4 --all-targets -- -D warnings
- Full serial mold-ai-server suite: 1,147 library tests passed, 12 intentional ignores; 2 catalog-route tests passed; 13 execution-equivalence tests passed.
- Production mp4 chain-route group: 13 passed.
- Exact CUDA release build with CUDA_COMPUTE_CAP=86 and cuda,preview,discord,expand,tui,webp,mp4.
- Rebuilt local service binary SHA-256: bafd5fbe57dfd358a8646c9c06b62bcaef393663d7873ebc262321fa4bf829e0; running /proc executable matched exactly.
- Live Web endpoint proof: POST /api/chain-jobs accepted cv:3143864; job 5aef23fa-335d-4e57-8389-a6c1cfe45cfb completed both stages and published final/output-1.mp4 with frozen ConvRot transformer, LTX-2.3 VAE, Gemma assets, and text projection.

## Review provenance

- Fable 5 high plan review: PLAN CLEAN, session 3dd609b5-f9c8-4d40-b282-66923213493e.
- Independent exact-commit acceptance: gpt-5.6-sol high, task /root/sol_acceptance, verdict CLEAN at 5d7f7cd8b1df9ead1a815e85a08183b96f712454 from a fresh detached worktree.
- A requested post-change Fable invocation was rejected by the Claude Code account limit before reading the diff with zero tokens, session fca6959a-5fc2-4bcf-8e6f-525ead3538d9; it is not represented as an acceptance review.