### PR TITLE
fix(studio): align sequence transitions with clips

### DIFF
--- a/ui/components/ClipRail.test.ts
+++ b/ui/components/ClipRail.test.ts
@@ -271,7 +271,10 @@ describe("ClipRail", () => {
   it("keeps seams as compact connectors instead of thumbnail-height capsules", () => {
     expect(seamSource).toContain('class="ms-seam__caption"');
     expect(railSource).toMatch(
-      /\.ms-rail-frame :deep\(\.ms-seam\)\s*\{[^}]*grid-template-rows:\s*32px 16px[^}]*min-width:\s*44px[^}]*height:\s*54px[^}]*border:\s*0[^}]*background:\s*transparent/s,
+      /\.ms-rail__item\s*\{[^}]*align-items:\s*flex-start/s,
+    );
+    expect(railSource).toMatch(
+      /\.ms-rail-frame :deep\(\.ms-seam\)\s*\{[^}]*grid-template-rows:\s*32px 16px[^}]*margin-top:\s*calc\(\(var\(--filmstrip-thumb-height\) - 34px\) \/ 2\)[^}]*min-width:\s*44px[^}]*height:\s*54px[^}]*border:\s*0[^}]*background:\s*transparent/s,
     );
     expect(railSource).toMatch(
       /\.ms-rail-frame :deep\(\.ms-seam::before\)\s*\{[^}]*height:\s*1px/s,

--- a/ui/components/ClipRail.test.ts
+++ b/ui/components/ClipRail.test.ts
@@ -274,16 +274,19 @@ describe("ClipRail", () => {
       /\.ms-rail__item\s*\{[^}]*align-items:\s*flex-start/s,
     );
     expect(railSource).toMatch(
-      /\.ms-rail-frame :deep\(\.ms-seam\)\s*\{[^}]*grid-template-rows:\s*32px 16px[^}]*margin-top:\s*calc\(\(var\(--filmstrip-thumb-height\) - 34px\) \/ 2\)[^}]*min-width:\s*44px[^}]*height:\s*54px[^}]*border:\s*0[^}]*background:\s*transparent/s,
+      /\.ms-rail-frame :deep\(\.ms-seam\)\s*\{[^}]*grid-template-rows:\s*32px 16px[^}]*margin-top:\s*calc\(\s*var\(--filmstrip-thumb-height\) \/ 2 - var\(--filmstrip-seam-rule-y\)\s*\)[^}]*min-width:\s*44px[^}]*height:\s*54px[^}]*border:\s*0[^}]*background:\s*transparent/s,
     );
     expect(railSource).toMatch(
-      /\.ms-rail-frame :deep\(\.ms-seam::before\)\s*\{[^}]*height:\s*1px/s,
+      /\.ms-rail-frame :deep\(\.ms-seam::before\)\s*\{[^}]*top:\s*var\(--filmstrip-seam-rule-y\)[^}]*height:\s*1px/s,
     );
     expect(railSource).toMatch(
       /\.ms-rail-frame :deep\(\.ms-seam__diagram\)\s*\{[^}]*width:\s*30px[^}]*height:\s*30px[^}]*border-radius:\s*50%/s,
     );
     expect(railSource).toContain(
       ':deep(.ms-seam[data-transition="fade"] .ms-seam__diagram)',
+    );
+    expect(railSource).toMatch(
+      /@container create-bench \(max-height: 340px\)[\s\S]*?\.ms-rail-frame\s*\{[^}]*--filmstrip-thumb-height:\s*76px[^}]*--filmstrip-seam-rule-y:\s*15px/s,
     );
   });
 });

--- a/ui/components/ClipRail.test.ts
+++ b/ui/components/ClipRail.test.ts
@@ -282,6 +282,9 @@ describe("ClipRail", () => {
     expect(railSource).toMatch(
       /\.ms-rail-frame :deep\(\.ms-seam__diagram\)\s*\{[^}]*width:\s*30px[^}]*height:\s*30px[^}]*border-radius:\s*50%/s,
     );
+    expect(railSource).toMatch(
+      /\.ms-rail-frame :deep\(\.ms-seam__line-smooth\)\s*\{[^}]*top:\s*50%[^}]*transform:\s*translateY\(-50%\)/s,
+    );
     expect(railSource).toContain(
       ':deep(.ms-seam[data-transition="fade"] .ms-seam__diagram)',
     );

--- a/ui/components/ClipRail.vue
+++ b/ui/components/ClipRail.vue
@@ -555,6 +555,11 @@ const dragModel = computed({
   box-shadow: none;
 }
 
+.ms-rail-frame :deep(.ms-seam__line-smooth) {
+  top: 50%;
+  transform: translateY(-50%);
+}
+
 .ms-rail-frame :deep(.ms-seam:hover:not(:disabled) .ms-seam__diagram) {
   border-color: rgba(255, 255, 255, 0.7);
   transform: scale(1.04);

--- a/ui/components/ClipRail.vue
+++ b/ui/components/ClipRail.vue
@@ -341,7 +341,7 @@ const dragModel = computed({
 
 .ms-rail__item {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 10px;
   flex: 0 0 auto;
   scroll-snap-align: start;
@@ -473,6 +473,12 @@ const dragModel = computed({
   grid-template-rows: 32px 16px;
   place-items: center;
   width: var(--filmstrip-seam-width);
+  /*
+   * Keep the connector's rule centered on the picture, not the combined
+   * picture + metadata card. This also keeps every seam on one visual edit
+   * axis when the responsive rail changes scene and footer heights.
+   */
+  margin-top: calc((var(--filmstrip-thumb-height) - 34px) / 2);
   min-width: 44px;
   height: 54px;
   min-height: 44px;

--- a/ui/components/ClipRail.vue
+++ b/ui/components/ClipRail.vue
@@ -293,6 +293,7 @@ const dragModel = computed({
   --filmstrip-footer-height: 36px;
   --filmstrip-scene-height: 140px;
   --filmstrip-seam-width: 46px;
+  --filmstrip-seam-rule-y: 17px;
   position: relative;
   height: 188px;
   min-width: 0;
@@ -478,7 +479,9 @@ const dragModel = computed({
    * picture + metadata card. This also keeps every seam on one visual edit
    * axis when the responsive rail changes scene and footer heights.
    */
-  margin-top: calc((var(--filmstrip-thumb-height) - 34px) / 2);
+  margin-top: calc(
+    var(--filmstrip-thumb-height) / 2 - var(--filmstrip-seam-rule-y)
+  );
   min-width: 44px;
   height: 54px;
   min-height: 44px;
@@ -496,7 +499,7 @@ const dragModel = computed({
   content: "";
   position: absolute;
   z-index: 0;
-  top: 17px;
+  top: var(--filmstrip-seam-rule-y);
   right: -10px;
   left: -10px;
   height: 1px;
@@ -643,6 +646,7 @@ const dragModel = computed({
     --filmstrip-footer-height: 32px;
     --filmstrip-scene-height: 108px;
     --filmstrip-seam-width: 44px;
+    --filmstrip-seam-rule-y: 15px;
     height: 138px;
   }
 
@@ -661,10 +665,6 @@ const dragModel = computed({
   .ms-rail-frame :deep(.ms-seam__diagram) {
     width: 26px;
     height: 26px;
-  }
-
-  .ms-rail-frame :deep(.ms-seam::before) {
-    top: 15px;
   }
 
   .ms-rail-frame :deep(.ms-seam__caption) {


### PR DESCRIPTION
## Summary

- align filmstrip transition connectors to the footage thumbnail centerline instead of the combined thumbnail-and-metadata card
- center the Smooth transition glyph inside its circular seam control on both normal and compact rails
- keep the edit axis stable across responsive rail sizes shared by desktop and web
- add focused regression assertions for the shared rail geometry

## Validation

- `bun run --cwd web test` (87 files, 1,015 tests)
- `bun run --cwd desktop test` (251 files, 2,563 tests)
- `bunx vitest run --config /tmp/mold-ui-vitest.config.ts ui/components/ClipRail.test.ts` (17 tests)
- `bun run --cwd web test src/components/SequenceComposer.test.ts` (13 tests)
- `bun run --cwd desktop test src/components/create/SequenceComposer.test.ts` (11 tests)
- `bunx prettier --check ui/components/ClipRail.vue ui/components/ClipRail.test.ts`
- `bun run build:web`
- `bun run build:desktop`
- `nix develop -c desktop-dev` (native Tauri cold build and launch)

## UAT

- Web Create sequence with a fixture LTX-2 host: opened the seam editor, changed Fade → Smooth, and measured the 30px circular diagram and 2px Smooth line at the same center Y (`0px` delta). No console warnings/errors or framework overlay.
- Native desktop: rebuilt and launched the Tauri application from this worktree; the shared component and desktop production frontend build both passed.
