### PR TITLE
fix(server): isolate mock generation output

### DIFF
--- a/crates/mold-server/src/lib.rs
+++ b/crates/mold-server/src/lib.rs
@@ -603,7 +603,7 @@ pub async fn run_server(
     // until every durable attempt is either rolled back or rolled forward.
     {
         let config = state.config.read().await;
-        if !config.is_output_disabled() {
+        if !state.is_output_disabled(&config) {
             let output_dir = config.effective_output_dir();
             drop(config);
             std::fs::create_dir_all(&output_dir)?;
@@ -687,7 +687,7 @@ pub async fn run_server(
         );
 
         let config_snapshot = state.config.read().await.clone();
-        let output_dir = if config_snapshot.is_output_disabled() {
+        let output_dir = if state.is_output_disabled(&config_snapshot) {
             None
         } else {
             Some(config_snapshot.effective_output_dir())
@@ -833,7 +833,7 @@ pub async fn run_server(
     // Ensure output directory exists and pre-generate thumbnails.
     {
         let config = state.config.read().await;
-        if config.is_output_disabled() {
+        if state.is_output_disabled(&config) {
             tracing::warn!(
                 "image output is disabled (output_dir is empty) — \
                  generated images will not be saved and the TUI gallery will be empty"

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -644,7 +644,7 @@ async fn prepare_generation(
 
     let (output_dir, dim_warning) = {
         let config = state.config.read().await;
-        let output_dir = if config.is_output_disabled() {
+        let output_dir = if state.is_output_disabled(&config) {
             None
         } else {
             Some(config.effective_output_dir())
@@ -3471,7 +3471,8 @@ async fn server_capabilities(State(state): State<AppState>) -> Json<mold_core::S
         expand_settings.is_local() && config.manifest_model_is_downloaded(&expand_settings.model);
     let expand = expand_capabilities(&expand_settings, expand_model_present);
 
-    let server_batch = state.scheduled_work.v2_authoritative() && !config.is_output_disabled();
+    let server_batch =
+        state.scheduled_work.v2_authoritative() && !state.is_output_disabled(&config);
     Json(mold_core::ServerCapabilities {
         gallery: mold_core::GalleryCapabilities { can_delete: true },
         catalog: mold_core::CatalogCapabilities {
@@ -3973,7 +3974,7 @@ async fn import_gallery_file(
 ) -> Result<(StatusCode, Json<GalleryImportResponse>), ApiError> {
     validate_gallery_filename(&filename)?;
     let config = state.config.read().await;
-    if config.is_output_disabled() {
+    if state.is_output_disabled(&config) {
         return Err(ApiError::not_found("image output is disabled"));
     }
     let output_dir = config.effective_output_dir();
@@ -4377,7 +4378,7 @@ async fn list_gallery(
     // needlessly serializing ordinary listings and media reads.
     let _gallery_reader = state.gallery_publication_gate.read().await;
     let config = state.config.read().await;
-    if config.is_output_disabled() {
+    if state.is_output_disabled(&config) {
         return Ok(Json(Vec::new()));
     }
     let output_dir = config.effective_output_dir();
@@ -4439,7 +4440,7 @@ async fn get_gallery_image(
 ) -> Result<axum::response::Response, ApiError> {
     let _gallery_reader = state.gallery_publication_gate.read().await;
     let config = state.config.read().await;
-    if config.is_output_disabled() {
+    if state.is_output_disabled(&config) {
         return Err(ApiError::not_found("image output is disabled"));
     }
     let output_dir = config.effective_output_dir();
@@ -4611,7 +4612,7 @@ async fn delete_gallery_image(
 ) -> Result<impl IntoResponse, ApiError> {
     let _gallery_writer = state.gallery_publication_gate.write().await;
     let config = state.config.read().await;
-    if config.is_output_disabled() {
+    if state.is_output_disabled(&config) {
         return Err(ApiError::not_found("image output is disabled"));
     }
     let output_dir = config.effective_output_dir();
@@ -4734,7 +4735,7 @@ async fn get_gallery_thumbnail(
 ) -> Result<impl IntoResponse, ApiError> {
     let _gallery_reader = state.gallery_publication_gate.read().await;
     let config = state.config.read().await;
-    if config.is_output_disabled() {
+    if state.is_output_disabled(&config) {
         return Err(ApiError::not_found("image output is disabled"));
     }
     let output_dir = config.effective_output_dir();
@@ -4851,7 +4852,7 @@ async fn get_gallery_preview(
 ) -> Result<axum::response::Response, ApiError> {
     let _gallery_reader = state.gallery_publication_gate.read().await;
     let config = state.config.read().await;
-    if config.is_output_disabled() {
+    if state.is_output_disabled(&config) {
         return Err(ApiError::not_found("image output is disabled"));
     }
     let output_dir = config.effective_output_dir();

--- a/crates/mold-server/src/routes_chain.rs
+++ b/crates/mold-server/src/routes_chain.rs
@@ -329,7 +329,7 @@ fn shim_build_response_and_cleanup(
 
     let output_dir = {
         let config = state.config.blocking_read();
-        if config.is_output_disabled() {
+        if state.is_output_disabled(&config) {
             None
         } else {
             Some(config.effective_output_dir())
@@ -750,9 +750,11 @@ pub async fn generate_chain_stream(
         return Err(ApiError::generation_unavailable(reason));
     }
     let completion_payload = requested_sse_completion_payload(&headers)?;
-    if completion_payload == SseCompletionPayload::MetadataOnly
-        && state.config.read().await.is_output_disabled()
-    {
+    let output_disabled = {
+        let config = state.config.read().await;
+        state.is_output_disabled(&config)
+    };
+    if completion_payload == SseCompletionPayload::MetadataOnly && output_disabled {
         return Err(ApiError::validation(
             "metadata-only SSE completions require server gallery output to be enabled",
         ));

--- a/crates/mold-server/src/routes_test.rs
+++ b/crates/mold-server/src/routes_test.rs
@@ -283,6 +283,43 @@ mod tests {
         create_router(state)
     }
 
+    #[tokio::test]
+    async fn generation_fixture_disables_real_gallery_output_by_default() {
+        let (state, _rx) = AppState::with_engine_and_queue(MockEngine::ready());
+        let config = state.config.read().await;
+
+        assert!(
+            state.is_output_disabled(&config),
+            "mock generation tests must opt into an isolated output directory"
+        );
+    }
+
+    #[test]
+    fn generation_fixture_ignores_process_output_override() {
+        let _env = env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let previous = std::env::var_os("MOLD_OUTPUT_DIR");
+        unsafe { std::env::set_var("MOLD_OUTPUT_DIR", "/tmp/mold-test-must-not-write") };
+
+        let (state, _rx) = AppState::with_engine_and_queue(MockEngine::ready());
+        let config = state.config.try_read().unwrap();
+        let environment_would_enable_output = !config.is_output_disabled();
+        let fixture_disables_output = state.is_output_disabled(&config);
+        drop(config);
+
+        match previous {
+            Some(value) => unsafe { std::env::set_var("MOLD_OUTPUT_DIR", value) },
+            None => unsafe { std::env::remove_var("MOLD_OUTPUT_DIR") },
+        }
+
+        assert!(environment_would_enable_output);
+        assert!(
+            fixture_disables_output,
+            "mock generation tests must ignore process-level output overrides"
+        );
+    }
+
     /// Create an app from pre-built state. Caller must ensure queue worker is
     /// running if generate endpoints will be tested.
     fn app_with_state(state: AppState) -> axum::Router {
@@ -5149,7 +5186,8 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn stream_metadata_only_returns_saved_filename_without_base64_media() {
         let output_dir = tempfile::tempdir().unwrap();
-        let (state, rx) = AppState::with_engine_and_queue(MockEngine::ready());
+        let (mut state, rx) = AppState::with_engine_and_queue(MockEngine::ready());
+        state.output_disabled_override = false;
         state.config.write().await.output_dir =
             Some(output_dir.path().to_string_lossy().into_owned());
         let worker_state = state.clone();
@@ -5481,7 +5519,8 @@ mod tests {
             queue_capacity: 200,
             model_cache: Arc::new(tokio::sync::Mutex::new(cache)),
             active_generation: Arc::new(std::sync::RwLock::new(None)),
-            config: Arc::new(tokio::sync::RwLock::new(mold_core::Config::default())),
+            config: Arc::new(tokio::sync::RwLock::new(AppState::test_config())),
+            output_disabled_override: true,
             start_time: std::time::Instant::now(),
             model_load_lock: Arc::new(tokio::sync::Mutex::new(())),
             pull_lock: Arc::new(tokio::sync::Mutex::new(())),
@@ -5551,7 +5590,8 @@ mod tests {
             queue_capacity: 200,
             model_cache: Arc::new(tokio::sync::Mutex::new(cache)),
             active_generation: Arc::new(std::sync::RwLock::new(None)),
-            config: Arc::new(tokio::sync::RwLock::new(mold_core::Config::default())),
+            config: Arc::new(tokio::sync::RwLock::new(AppState::test_config())),
+            output_disabled_override: true,
             start_time: std::time::Instant::now(),
             model_load_lock: Arc::new(tokio::sync::Mutex::new(())),
             pull_lock: Arc::new(tokio::sync::Mutex::new(())),
@@ -5824,7 +5864,8 @@ mod tests {
             queue_capacity: 200,
             model_cache: Arc::new(tokio::sync::Mutex::new(cache)),
             active_generation: Arc::new(std::sync::RwLock::new(None)),
-            config: Arc::new(tokio::sync::RwLock::new(mold_core::Config::default())),
+            config: Arc::new(tokio::sync::RwLock::new(AppState::test_config())),
+            output_disabled_override: true,
             start_time: std::time::Instant::now(),
             model_load_lock: Arc::new(tokio::sync::Mutex::new(())),
             pull_lock: Arc::new(tokio::sync::Mutex::new(())),

--- a/crates/mold-server/src/state.rs
+++ b/crates/mold-server/src/state.rs
@@ -277,6 +277,12 @@ pub struct AppState {
     /// Must never be held across an .await point.
     pub active_generation: Arc<RwLock<Option<ActiveGenerationSnapshot>>>,
     pub config: Arc<tokio::sync::RwLock<Config>>,
+    /// Hard output kill switch used by isolated server test fixtures.
+    ///
+    /// This is intentionally separate from `Config`: environment overrides
+    /// remain authoritative in production, while mock-generation fixtures
+    /// must never inherit any process-level `MOLD_OUTPUT_DIR`.
+    pub output_disabled_override: bool,
     pub start_time: Instant,
     /// Guards concurrent model loads and hot-swaps.
     pub model_load_lock: Arc<Mutex<()>>,
@@ -516,6 +522,24 @@ pub fn resolve_max_cached_models() -> usize {
 }
 
 impl AppState {
+    /// Test states must never inherit the production gallery fallback.
+    ///
+    /// `Config::default()` intentionally resolves output to
+    /// `~/.mold/output`, which means a successful mock generation can write
+    /// into a developer's real Library unless output is explicitly disabled.
+    /// Persistence tests opt back in with their own temporary output dir.
+    #[cfg(test)]
+    pub(crate) fn test_config() -> Config {
+        Config {
+            output_dir: Some(String::new()),
+            ..Config::default()
+        }
+    }
+
+    pub(crate) fn is_output_disabled(&self, config: &Config) -> bool {
+        self.output_disabled_override || config.is_output_disabled()
+    }
+
     /// Create state with a pre-loaded engine (server starts with a configured model).
     pub fn new(
         engine: Box<dyn InferenceEngine>,
@@ -537,6 +561,7 @@ impl AppState {
             model_cache: Arc::new(Mutex::new(cache)),
             active_generation: Arc::new(RwLock::new(None)),
             config: Arc::new(tokio::sync::RwLock::new(config)),
+            output_disabled_override: false,
             start_time: Instant::now(),
             model_load_lock: Arc::new(Mutex::new(())),
             pull_lock: Arc::new(Mutex::new(())),
@@ -604,6 +629,7 @@ impl AppState {
             model_cache: Arc::new(Mutex::new(ModelCache::new(resolve_max_cached_models()))),
             active_generation: Arc::new(RwLock::new(None)),
             config: Arc::new(tokio::sync::RwLock::new(config)),
+            output_disabled_override: false,
             start_time: Instant::now(),
             model_load_lock: Arc::new(Mutex::new(())),
             pull_lock: Arc::new(Mutex::new(())),
@@ -680,7 +706,8 @@ impl AppState {
             queue_capacity: 200,
             model_cache: Arc::new(Mutex::new(cache)),
             active_generation: Arc::new(RwLock::new(None)),
-            config: Arc::new(tokio::sync::RwLock::new(Config::default())),
+            config: Arc::new(tokio::sync::RwLock::new(Self::test_config())),
+            output_disabled_override: true,
             start_time: Instant::now(),
             model_load_lock: Arc::new(Mutex::new(())),
             pull_lock: Arc::new(Mutex::new(())),
@@ -724,7 +751,8 @@ impl AppState {
             queue_capacity: 200,
             model_cache: Arc::new(Mutex::new(cache)),
             active_generation: Arc::new(RwLock::new(None)),
-            config: Arc::new(tokio::sync::RwLock::new(Config::default())),
+            config: Arc::new(tokio::sync::RwLock::new(Self::test_config())),
+            output_disabled_override: true,
             start_time: Instant::now(),
             model_load_lock: Arc::new(Mutex::new(())),
             pull_lock: Arc::new(Mutex::new(())),
@@ -769,6 +797,7 @@ impl AppState {
             model_cache: Arc::new(Mutex::new(ModelCache::new(resolve_max_cached_models()))),
             active_generation: Arc::new(RwLock::new(None)),
             config: Arc::new(tokio::sync::RwLock::new(Config::default())),
+            output_disabled_override: false,
             start_time: Instant::now(),
             model_load_lock: Arc::new(Mutex::new(())),
             pull_lock: Arc::new(Mutex::new(())),


### PR DESCRIPTION
## Summary

- make server generation test fixtures disable real gallery output by default
- route hand-built load-test fixtures through the same isolated test configuration
- add a regression guard preventing mock generations from reaching the user library

## Root cause

Successful mock generation tests inherited the production default output directory, allowing test artifacts and gallery metadata to leak into the local Mold library.

## Verification

- `cargo fmt --all -- --check`
- `nix develop -c cargo test -p mold-ai-server` (1,163 passed; 12 ignored)
- live local library: 280 entries, 0 mock entries, 0 unreadable entries
- local gallery database/files/authority: 0 mock records