### PR TITLE
fix(ui): confirm repair hosts and expand failures

### DIFF
--- a/desktop/src/components/models/CatalogTab.test.ts
+++ b/desktop/src/components/models/CatalogTab.test.ts
@@ -4,16 +4,23 @@ import { createPinia, setActivePinia } from "pinia";
 import type { CatalogEntry } from "../../lib/api/types";
 import type { CatalogSearchParams } from "../../lib/api/catalog";
 
-const { searchCatalog, fetchCatalogFamilies, startCatalogDownload } = vi.hoisted(() => ({
-  searchCatalog: vi.fn(),
-  fetchCatalogFamilies: vi.fn(),
-  startCatalogDownload: vi.fn(),
+const { searchCatalog, fetchCatalogDetail, fetchCatalogFamilies, startCatalogDownload } =
+  vi.hoisted(() => ({
+    searchCatalog: vi.fn(),
+    fetchCatalogDetail: vi.fn(),
+    fetchCatalogFamilies: vi.fn(),
+    startCatalogDownload: vi.fn(),
+  }));
+const { fetchModelComponents } = vi.hoisted(() => ({
+  fetchModelComponents: vi.fn(),
 }));
 vi.mock("../../lib/api/catalog", () => ({
   searchCatalog,
+  fetchCatalogDetail,
   fetchCatalogFamilies,
   startCatalogDownload,
 }));
+vi.mock("../../lib/api/models", () => ({ fetchModelComponents }));
 vi.mock("../../lib/catalogSizes", () => ({
   resolveEntrySize: vi.fn().mockResolvedValue(null),
 }));
@@ -21,6 +28,7 @@ vi.mock("../../lib/openExternal", () => ({ openExternal: vi.fn() }));
 
 import CatalogTab from "./CatalogTab.vue";
 import { useConnectionStore } from "../../stores/connection";
+import { useDownloadsStore } from "../../stores/downloads";
 import { useHostsStore } from "../../stores/hosts";
 import { useModelStore } from "../../stores/models";
 
@@ -94,6 +102,10 @@ beforeEach(() => {
   (globalThis as { IntersectionObserver?: unknown }).IntersectionObserver =
     FakeIntersectionObserver;
   fetchCatalogFamilies.mockResolvedValue([]);
+  fetchModelComponents.mockResolvedValue({ model: "", components: [] });
+  fetchCatalogDetail.mockImplementation((id: string) =>
+    Promise.resolve({ ...entry(id, "flux"), id, name: id, installed: true }),
+  );
   searchCatalog.mockResolvedValue({ entries: [], page: 1, page_size: PAGE_SIZE, total: 0 });
 });
 
@@ -617,6 +629,86 @@ describe("CatalogTab host fallback when the local engine is down", () => {
     ];
     expect(forward).toBe(false);
     expect(target).toBeUndefined();
+    wrapper.unmount();
+  });
+});
+
+describe("CatalogTab installed repair routing", () => {
+  it("confirms repair against owning hosts only", async () => {
+    setActivePinia(createPinia());
+    const connection = useConnectionStore();
+    connection.info = {
+      mode: "local",
+      baseUrl: "http://127.0.0.1:7680",
+      apiKey: "local-key",
+    };
+    connection.status = "ready";
+    vi.spyOn(useDownloadsStore(), "subscribe").mockResolvedValue(undefined);
+    useHostsStore().extras.push(
+      {
+        id: "studio-7680",
+        label: "Studio GPU",
+        url: "http://studio:7680",
+        apiKey: "studio-key",
+        status: "ready",
+        error: null,
+        instanceId: null,
+      },
+      {
+        id: "other-7680",
+        label: "Other GPU",
+        url: "http://other:7680",
+        apiKey: "other-key",
+        status: "ready",
+        error: null,
+        instanceId: null,
+      },
+    );
+    const installed = {
+      name: "flux-dev:q8",
+      family: "flux",
+      size_gb: 12,
+      is_loaded: false,
+      hf_repo: "org/flux-dev",
+      default_steps: 4,
+      default_guidance: 1,
+      default_width: 1024,
+      default_height: 1024,
+      description: "",
+      downloaded: true,
+      hostIds: ["local", "studio-7680"],
+    };
+    const wrapper = mount(CatalogTab, {
+      attachTo: document.body,
+      props: {
+        query: "",
+        layout: "grid" as const,
+        installedEntries: [installed],
+      },
+    });
+    await flushPromises();
+
+    await wrapper.get("[data-test='catalog-card']").trigger("click");
+    await flushPromises();
+    await document.body.querySelector<HTMLButtonElement>("[data-test='drawer-repair']")!.click();
+    await flushPromises();
+
+    const dialog = document.body.querySelector<HTMLElement>(
+      "[data-test='download-target-dialog']",
+    )!;
+    expect(dialog.textContent).toContain("Choose where to repair");
+    expect(dialog.textContent).toContain("This device");
+    expect(dialog.textContent).toContain("Studio GPU");
+    expect(dialog.textContent).not.toContain("Other GPU");
+    expect(startCatalogDownload).not.toHaveBeenCalled();
+
+    dialog.querySelector<HTMLButtonElement>("[data-test='download-target-studio-7680']")!.click();
+    await flushPromises();
+    expect(startCatalogDownload).toHaveBeenCalledWith(
+      "flux-dev:q8",
+      { baseUrl: "http://studio:7680", apiKey: "studio-key" },
+      true,
+    );
     wrapper.unmount();
   });
 });

--- a/desktop/src/components/models/CatalogTab.test.ts
+++ b/desktop/src/components/models/CatalogTab.test.ts
@@ -711,6 +711,59 @@ describe("CatalogTab installed repair routing", () => {
     );
     wrapper.unmount();
   });
+
+  it("does not reroute an offline owner's repair to the local primary", async () => {
+    setActivePinia(createPinia());
+    const connection = useConnectionStore();
+    connection.info = {
+      mode: "local",
+      baseUrl: "http://127.0.0.1:7680",
+      apiKey: "local-key",
+    };
+    connection.status = "ready";
+    vi.spyOn(useDownloadsStore(), "subscribe").mockResolvedValue(undefined);
+    useHostsStore().extras.push({
+      id: "offline-7680",
+      label: "Offline GPU",
+      url: "http://offline:7680",
+      apiKey: "offline-key",
+      status: "error",
+      error: "offline",
+      instanceId: null,
+    });
+    const wrapper = mount(CatalogTab, {
+      attachTo: document.body,
+      props: {
+        query: "",
+        layout: "grid" as const,
+        installedEntries: [
+          {
+            name: "flux-dev:q8",
+            family: "flux",
+            size_gb: 12,
+            is_loaded: false,
+            hf_repo: "org/flux-dev",
+            default_steps: 4,
+            default_guidance: 1,
+            default_width: 1024,
+            default_height: 1024,
+            description: "",
+            downloaded: true,
+            hostIds: ["offline-7680"],
+          },
+        ],
+      },
+    });
+    await flushPromises();
+    await wrapper.get("[data-test='catalog-card']").trigger("click");
+    await flushPromises();
+    document.body.querySelector<HTMLButtonElement>("[data-test='drawer-repair']")!.click();
+    await flushPromises();
+
+    expect(startCatalogDownload).not.toHaveBeenCalled();
+    expect(document.body.textContent).not.toContain("Choose where to repair");
+    wrapper.unmount();
+  });
 });
 
 describe("CatalogTab Discover source chips", () => {

--- a/desktop/src/components/models/CatalogTab.vue
+++ b/desktop/src/components/models/CatalogTab.vue
@@ -412,6 +412,10 @@ async function pullTo(entry: CatalogEntry, host: HostView | null) {
 
 function pull(entry: CatalogEntry) {
   const candidates = actionHosts(entry);
+  if (entry.installed && candidates.length === 0) {
+    toasts.push("No online owning host is available to repair this model.", "error");
+    return;
+  }
   if (candidates.length > 1) {
     pendingEntry.value = entry;
     return;

--- a/desktop/src/components/models/CatalogTab.vue
+++ b/desktop/src/components/models/CatalogTab.vue
@@ -254,6 +254,12 @@ const readyHosts = computed(() =>
   hosts.all.filter((host) => host.status === "ready" && host.baseUrl),
 );
 
+function actionHosts(entry: CatalogEntry & { hostIds?: string[] }): HostView[] {
+  if (!entry.installed) return readyHosts.value;
+  const ownerIds = new Set(entry.hostIds ?? []);
+  return readyHosts.value.filter((host) => ownerIds.has(host.id));
+}
+
 /**
  * Where catalog calls go: the local primary when it's ready (it reads its
  * own credentials), else the first ready host — with credentials forwarded
@@ -405,11 +411,12 @@ async function pullTo(entry: CatalogEntry, host: HostView | null) {
 }
 
 function pull(entry: CatalogEntry) {
-  if (readyHosts.value.length > 1) {
+  const candidates = actionHosts(entry);
+  if (candidates.length > 1) {
     pendingEntry.value = entry;
     return;
   }
-  void pullTo(entry, readyHosts.value[0] ?? null);
+  void pullTo(entry, candidates[0] ?? null);
 }
 
 /** The detail drawer fetches on the same host the catalog list came from. */
@@ -618,7 +625,8 @@ onMounted(async () => {
     <DownloadTargetDialog
       v-if="pendingEntry"
       :model-name="pendingEntry.display_name ?? pendingEntry.name"
-      :hosts="readyHosts"
+      :hosts="actionHosts(pendingEntry)"
+      :action="pendingEntry.installed ? 'repair' : 'download'"
       @close="pendingEntry = null"
       @select="(host) => pendingEntry && void pullTo(pendingEntry, host)"
     />

--- a/desktop/src/components/models/DownloadTargetDialog.test.ts
+++ b/desktop/src/components/models/DownloadTargetDialog.test.ts
@@ -71,4 +71,23 @@ describe("DownloadTargetDialog", () => {
     wrapper.unmount();
     expect(document.activeElement).toBe(opener);
   });
+
+  it("uses repair-specific confirmation copy", () => {
+    const wrapper = mount(DownloadTargetDialog, {
+      props: { modelName: "Flux Dev", hosts, action: "repair" },
+      attachTo: document.body,
+    });
+
+    const dialog = document.body.querySelector<HTMLElement>("[role='dialog']")!;
+    expect(dialog.textContent).toContain("Choose where to repair Flux Dev");
+    expect(dialog.textContent).toContain(
+      "Only missing or damaged files will be fetched on the selected host.",
+    );
+    expect(
+      document.body
+        .querySelector<HTMLButtonElement>("[aria-label='Close repair target picker']")
+        ?.getAttribute("aria-label"),
+    ).toBe("Close repair target picker");
+    wrapper.unmount();
+  });
 });

--- a/desktop/src/components/models/DownloadTargetDialog.vue
+++ b/desktop/src/components/models/DownloadTargetDialog.vue
@@ -1,13 +1,17 @@
 <script setup lang="ts">
-import { nextTick, onBeforeUnmount, onMounted, onUnmounted, ref } from "vue";
+import { computed, nextTick, onBeforeUnmount, onMounted, onUnmounted, ref } from "vue";
 import type { HostView } from "../../stores/hosts";
 
-defineProps<{ modelName: string; hosts: HostView[] }>();
+const props = withDefaults(
+  defineProps<{ modelName: string; hosts: HostView[]; action?: "download" | "repair" }>(),
+  { action: "download" },
+);
 const emit = defineEmits<{
   (e: "select", host: HostView): void;
   (e: "close"): void;
 }>();
 const closeBtn = ref<HTMLButtonElement | null>(null);
+const title = computed(() => `Choose where to ${props.action} ${props.modelName}`);
 let restoreFocusEl: HTMLElement | null = null;
 
 function onKeydown(event: KeyboardEvent) {
@@ -33,22 +37,28 @@ onBeforeUnmount(() => restoreFocusEl?.focus?.());
         role="dialog"
         aria-modal="true"
         aria-labelledby="download-target-title"
+        data-test="download-target-dialog"
         class="border-edge z-50 w-full max-w-md rounded-chrome border bg-bench p-4 shadow-raised"
       >
         <div class="mb-3 flex items-start justify-between gap-4">
           <div>
             <h2 id="download-target-title" class="text-body-lg font-semibold text-ink">
-              Choose where to download {{ modelName }}
+              {{ title }}
             </h2>
             <p class="mt-1 text-caption text-ink-2">
-              The model and its required components will be stored on the selected host.
+              <template v-if="action === 'repair'">
+                Only missing or damaged files will be fetched on the selected host.
+              </template>
+              <template v-else>
+                The model and its required components will be stored on the selected host.
+              </template>
             </p>
           </div>
           <button
             ref="closeBtn"
             type="button"
             class="h-7 rounded-control px-2 text-ink-2 hover:bg-bath hover:text-ink"
-            aria-label="Close download target picker"
+            :aria-label="`Close ${action} target picker`"
             @click="emit('close')"
           >
             ✕

--- a/desktop/src/components/models/InstalledTab.repair.test.ts
+++ b/desktop/src/components/models/InstalledTab.repair.test.ts
@@ -195,4 +195,31 @@ describe("InstalledTab model info drawer", () => {
     );
     wrapper.unmount();
   });
+
+  it("does not reroute repair when the only owning host is offline", async () => {
+    setActivePinia(createPinia());
+    useHostsStore().extras.push({
+      id: "offline-7680",
+      label: "Offline GPU",
+      url: "http://offline:7680",
+      apiKey: "offline-key",
+      status: "error",
+      error: "offline",
+      instanceId: null,
+    });
+    const wrapper = mount(InstalledTab, {
+      props: { entries: [{ ...model(), hostIds: ["offline-7680"] }] },
+    });
+    await wrapper.get("[data-test='row-title']").trigger("click");
+    await flushPromises();
+    await wrapper.get("[data-test='drawer-repair']").trigger("click");
+    await flushPromises();
+
+    expect(startCatalogDownload).not.toHaveBeenCalled();
+    expect(
+      useToastStore().items.some(
+        (toast) => toast.kind === "error" && toast.message.includes("online owning host"),
+      ),
+    ).toBe(true);
+  });
 });

--- a/desktop/src/components/models/InstalledTab.repair.test.ts
+++ b/desktop/src/components/models/InstalledTab.repair.test.ts
@@ -24,6 +24,8 @@ vi.mock("../../lib/api/catalog", () => ({ startCatalogDownload, fetchCatalogDeta
 vi.mock("../../lib/openExternal", () => ({ openExternal: vi.fn() }));
 
 import InstalledTab from "./InstalledTab.vue";
+import { useConnectionStore } from "../../stores/connection";
+import { useHostsStore } from "../../stores/hosts";
 import { useModelStore } from "../../stores/models";
 import { useToastStore } from "../../stores/toasts";
 
@@ -143,5 +145,54 @@ describe("InstalledTab model info drawer", () => {
     await flushPromises();
 
     expect(useToastStore().items.some((t) => t.kind === "error")).toBe(true);
+  });
+
+  it("confirms the owning host before repairing a model installed on multiple hosts", async () => {
+    setActivePinia(createPinia());
+    const connection = useConnectionStore();
+    connection.info = {
+      mode: "local",
+      baseUrl: "http://127.0.0.1:7680",
+      apiKey: "local-key",
+    };
+    connection.status = "ready";
+    useHostsStore().extras.push({
+      id: "studio-7680",
+      label: "Studio GPU",
+      url: "http://studio:7680",
+      apiKey: "studio-key",
+      status: "ready",
+      error: null,
+      instanceId: null,
+    });
+
+    const wrapper = mount(InstalledTab, {
+      attachTo: document.body,
+      props: { entries: [{ ...model(), hostIds: ["local", "studio-7680"] }] },
+    });
+    await wrapper.get("[data-test='row-title']").trigger("click");
+    await flushPromises();
+    await wrapper.get("[data-test='drawer-repair']").trigger("click");
+    await flushPromises();
+
+    const dialog = document.body.querySelector<HTMLElement>(
+      "[data-test='download-target-dialog']",
+    )!;
+    expect(dialog.textContent).toContain("Choose where to repair");
+    expect(dialog.textContent).toContain("This device");
+    expect(dialog.textContent).toContain("Studio GPU");
+    expect(startCatalogDownload).not.toHaveBeenCalled();
+
+    document.body
+      .querySelector<HTMLButtonElement>("[data-test='download-target-studio-7680']")!
+      .click();
+    await flushPromises();
+
+    expect(startCatalogDownload).toHaveBeenCalledWith(
+      "sdxl-base:fp16",
+      { baseUrl: "http://studio:7680", apiKey: "studio-key" },
+      true,
+    );
+    wrapper.unmount();
   });
 });

--- a/desktop/src/components/models/InstalledTab.vue
+++ b/desktop/src/components/models/InstalledTab.vue
@@ -5,6 +5,7 @@ import { useHostModelsStore } from "../../stores/hostModels";
 import { useHostsStore } from "../../stores/hosts";
 import { useToastStore } from "../../stores/toasts";
 import CatalogDetailDrawer from "./CatalogDetailDrawer.vue";
+import DownloadTargetDialog from "./DownloadTargetDialog.vue";
 import ModelTableRow from "./ModelTableRow.vue";
 import ModelMetadataBadges from "@studio/components/ModelMetadataBadges.vue";
 import { modelKindLabel, modelKindValue } from "@studio/lib/modelMetadata";
@@ -25,6 +26,7 @@ import { ApiError } from "../../lib/api/client";
 import { formatGB, percent } from "../../lib/format";
 import { type MediaType } from "../../lib/modelAvailability";
 import type { ModelEntry } from "../../lib/api/types";
+import type { HostView } from "../../stores/hosts";
 
 type LibraryModelEntry = ModelEntry & { hostIds?: string[] };
 
@@ -67,6 +69,7 @@ const sections = computed<[string, ModelEntry[]][]>(() => [
 
 // Info opens the shared model detail drawer (same layout as the catalog).
 const detailModel = ref<LibraryModelEntry | null>(null);
+const pendingRepair = ref<LibraryModelEntry | null>(null);
 const busy = ref<string | null>(null);
 const confirmingRemove = ref<string | null>(null);
 
@@ -78,9 +81,20 @@ function targetHost(m: LibraryModelEntry) {
 
 function targetFor(m: LibraryModelEntry) {
   const target = targetHost(m);
+  return targetForHost(target);
+}
+
+function targetForHost(target: HostView | null) {
   return target && !target.primary && target.baseUrl
     ? { baseUrl: target.baseUrl, apiKey: target.apiKey }
     : undefined;
+}
+
+function repairHosts(m: LibraryModelEntry): HostView[] {
+  const ownerIds = new Set(m.hostIds ?? ["local"]);
+  return hosts.all.filter(
+    (host) => ownerIds.has(host.id) && host.status === "ready" && Boolean(host.baseUrl),
+  );
 }
 
 function hostLabels(m: LibraryModelEntry): string[] {
@@ -131,11 +145,22 @@ async function remove(m: LibraryModelEntry) {
 /** Whole-model repair from the drawer: re-fetches only missing files. */
 const drawerRepairing = ref(false);
 
-async function repairFromDrawer(m: LibraryModelEntry) {
+function requestRepair(m: LibraryModelEntry) {
+  const candidates = repairHosts(m);
+  if (candidates.length > 1) {
+    pendingRepair.value = m;
+    return;
+  }
+  void repairOnHost(m, candidates[0] ?? targetHost(m));
+}
+
+async function repairOnHost(m: LibraryModelEntry, host: HostView | null) {
+  pendingRepair.value = null;
   drawerRepairing.value = true;
   try {
-    await startCatalogDownload(m.name, targetFor(m), !!targetFor(m));
-    toasts.push(`Repairing ${modelDisplayName(m)}`);
+    const target = targetForHost(host);
+    await startCatalogDownload(m.name, target, !!target);
+    toasts.push(`Repairing ${modelDisplayName(m)}${host ? ` on ${host.label}` : ""}`);
   } catch (err) {
     toasts.push(
       err instanceof ApiError && err.status === 409
@@ -279,6 +304,15 @@ async function unload(m: LibraryModelEntry) {
     :target="targetFor(detailModel)"
     :forward-credentials="!!targetFor(detailModel)"
     @close="detailModel = null"
-    @pull="detailModel && repairFromDrawer(detailModel)"
+    @pull="detailModel && requestRepair(detailModel)"
+  />
+
+  <DownloadTargetDialog
+    v-if="pendingRepair"
+    action="repair"
+    :model-name="modelDisplayName(pendingRepair)"
+    :hosts="repairHosts(pendingRepair)"
+    @close="pendingRepair = null"
+    @select="(host) => pendingRepair && void repairOnHost(pendingRepair, host)"
   />
 </template>

--- a/desktop/src/components/models/InstalledTab.vue
+++ b/desktop/src/components/models/InstalledTab.vue
@@ -147,11 +147,15 @@ const drawerRepairing = ref(false);
 
 function requestRepair(m: LibraryModelEntry) {
   const candidates = repairHosts(m);
+  if (candidates.length === 0) {
+    toasts.push("No online owning host is available to repair this model.", "error");
+    return;
+  }
   if (candidates.length > 1) {
     pendingRepair.value = m;
     return;
   }
-  void repairOnHost(m, candidates[0] ?? targetHost(m));
+  void repairOnHost(m, candidates[0]!);
 }
 
 async function repairOnHost(m: LibraryModelEntry, host: HostView | null) {

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -708,6 +708,7 @@ describe("MobileApp Output field", () => {
     expect(row.text()).toContain("needs more GPU memory");
     const failure = row.get("[data-test='mobile-sequence-error-disclosure']");
     expect(failure.attributes("aria-expanded")).toBe("false");
+    expect(failure.attributes("aria-label")).toBeUndefined();
     await failure.trigger("click");
     expect(failure.attributes("aria-expanded")).toBe("true");
     expect(failure.classes()).toContain("mobile-sequence-row-error--expanded");

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -706,6 +706,11 @@ describe("MobileApp Output field", () => {
 
     const row = wrapper.get("[data-test='mobile-sequence-job']");
     expect(row.text()).toContain("needs more GPU memory");
+    const failure = row.get("[data-test='mobile-sequence-error-disclosure']");
+    expect(failure.attributes("aria-expanded")).toBe("false");
+    await failure.trigger("click");
+    expect(failure.attributes("aria-expanded")).toBe("true");
+    expect(failure.classes()).toContain("mobile-sequence-row-error--expanded");
     expect(row.find("[data-test='mobile-sequence-cancel']").exists()).toBe(false);
     expect(row.find("[data-test='mobile-sequence-dismiss']").exists()).toBe(true);
     // The row survives for its actions, but a settled job is not active work.

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -3557,9 +3557,6 @@ onBeforeUnmount(() => {
                       }"
                       data-test="mobile-sequence-error-disclosure"
                       :aria-expanded="expandedQueueFailures.has(row.key)"
-                      :aria-label="`${
-                        expandedQueueFailures.has(row.key) ? 'Collapse' : 'Expand'
-                      } failure details`"
                       @click.stop="toggleQueueFailure(row.key)"
                     >
                       <span>{{ row.sequence.error }}</span>

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -620,6 +620,14 @@ const activityRows = computed<ActivityRow[]>(() =>
     return print ? [{ key: vm.key, sequence: null, print }] : [];
   }),
 );
+const expandedQueueFailures = ref(new Set<string>());
+
+function toggleQueueFailure(key: string): void {
+  const next = new Set(expandedQueueFailures.value);
+  if (next.has(key)) next.delete(key);
+  else next.add(key);
+  expandedQueueFailures.value = next;
+}
 
 async function selectMobilePrint(job: Job): Promise<void> {
   generation.select(job.clientId);
@@ -3540,9 +3548,25 @@ onBeforeUnmount(() => {
                         · {{ sequenceRowProgress }}%
                       </template>
                     </span>
-                    <span v-if="row.sequence.error" class="mobile-sequence-row-error" role="alert">
-                      {{ row.sequence.error }}
-                    </span>
+                    <button
+                      v-if="row.sequence.error"
+                      type="button"
+                      class="mobile-sequence-row-error"
+                      :class="{
+                        'mobile-sequence-row-error--expanded': expandedQueueFailures.has(row.key),
+                      }"
+                      data-test="mobile-sequence-error-disclosure"
+                      :aria-expanded="expandedQueueFailures.has(row.key)"
+                      :aria-label="`${
+                        expandedQueueFailures.has(row.key) ? 'Collapse' : 'Expand'
+                      } failure details`"
+                      @click.stop="toggleQueueFailure(row.key)"
+                    >
+                      <span>{{ row.sequence.error }}</span>
+                      <span aria-hidden="true">
+                        {{ expandedQueueFailures.has(row.key) ? "Less" : "Details" }}
+                      </span>
+                    </button>
                   </div>
                   <div class="mobile-generation-job-action">
                     <span data-test="mobile-sequence-status">{{ row.sequence.hostLabel }}</span>

--- a/desktop/src/mobile/MobileCatalogView.test.ts
+++ b/desktop/src/mobile/MobileCatalogView.test.ts
@@ -1037,7 +1037,7 @@ describe("MobileCatalogView", () => {
         { name: "text_encoder", kind: "companion", present: false },
       ],
     });
-    wrapper = mountCatalog();
+    wrapper = mountCatalog(studio.id, [studio]);
     await flushPromises();
 
     const installedCard = wrapper
@@ -1057,6 +1057,36 @@ describe("MobileCatalogView", () => {
 
     expect(document.querySelector("[data-test='mobile-catalog-target-sheet']")).toBeNull();
     expect(startCatalogDownload).toHaveBeenCalledWith("installed:q8", targets.studio, false);
+  });
+
+  it("asks which owning host to repair when an installed model exists on multiple hosts", async () => {
+    wrapper = mountCatalog();
+    await flushPromises();
+
+    const installedCard = wrapper
+      .findAll("[data-test='mobile-catalog-card']")
+      .find((candidate) => candidate.text().includes("installed:q8"))!;
+    expect(installedCard.text()).toContain("Studio");
+    expect(installedCard.text()).toContain("Render Box");
+
+    await installedCard.get(".mobile-catalog-card-open").trigger("click");
+    await flushPromises();
+    document.querySelector<HTMLButtonElement>(".mobile-catalog-detail-action button")!.click();
+    await flushPromises();
+
+    const picker = document.querySelector<HTMLElement>(
+      "[data-test='mobile-catalog-target-sheet']",
+    )!;
+    expect(picker).not.toBeNull();
+    expect(picker.textContent).toContain("Choose where to repair");
+    expect(picker.textContent).toContain("Studio");
+    expect(picker.textContent).toContain("Render Box");
+    expect(startCatalogDownload).not.toHaveBeenCalled();
+
+    picker.querySelectorAll<HTMLButtonElement>(".mobile-catalog-target-list button")[1]!.click();
+    await flushPromises();
+
+    expect(startCatalogDownload).toHaveBeenCalledWith("installed:q8", targets.render, false);
   });
 
   it("segmented control swaps shelves and remembers the Discover sub-source", async () => {

--- a/desktop/src/mobile/MobileCatalogView.vue
+++ b/desktop/src/mobile/MobileCatalogView.vue
@@ -757,6 +757,10 @@ async function cancelDownload(row: DownloadRow): Promise<void> {
 
 function requestPull(entry: MobileCatalogEntry): void {
   const candidates = entry.installed ? repairHosts(entry) : downloadHosts.value;
+  if (entry.installed && candidates.length === 0) {
+    announce("No online owning host is available to repair this model.", true);
+    return;
+  }
   if (candidates.length > 1) {
     targetRestoreFocus = document.activeElement as HTMLElement | null;
     targetEntry.value = entry;
@@ -767,7 +771,7 @@ function requestPull(entry: MobileCatalogEntry): void {
     });
     return;
   }
-  const host = candidates[0] ?? (entry.installed ? owningHost(entry) : selectedHost.value);
+  const host = candidates[0] ?? selectedHost.value;
   if (host) void pullTo(entry, host);
 }
 

--- a/desktop/src/mobile/MobileCatalogView.vue
+++ b/desktop/src/mobile/MobileCatalogView.vue
@@ -168,6 +168,19 @@ const downloadHosts = computed(() =>
   props.hosts.filter((host) => host.online || host.id === props.selectedHostId),
 );
 
+/** Repair is meaningful only on a host that already owns the collapsed
+ * installed row. Keep unreachable owners out of the action list, while the
+ * currently selected host remains eligible during its reachability probe. */
+function repairHosts(entry: MobileCatalogEntry): MobileHost[] {
+  const ownerIds = new Set(entry.hostIds ?? []);
+  return downloadHosts.value.filter((host) => ownerIds.has(host.id));
+}
+
+const targetHosts = computed(() => {
+  const entry = targetEntry.value;
+  return entry?.installed ? repairHosts(entry) : downloadHosts.value;
+});
+
 const installedEntries = computed<MobileCatalogEntry[]>(() => {
   const byName = new Map<string, { model: ModelEntry; hostIds: string[]; hostLabels: string[] }>();
   for (const host of props.hosts) {
@@ -743,12 +756,8 @@ async function cancelDownload(row: DownloadRow): Promise<void> {
 }
 
 function requestPull(entry: MobileCatalogEntry): void {
-  if (entry.installed) {
-    const host = owningHost(entry);
-    if (host) void pullTo(entry, host);
-    return;
-  }
-  if (downloadHosts.value.length > 1) {
+  const candidates = entry.installed ? repairHosts(entry) : downloadHosts.value;
+  if (candidates.length > 1) {
     targetRestoreFocus = document.activeElement as HTMLElement | null;
     targetEntry.value = entry;
     updateModalInert();
@@ -758,7 +767,7 @@ function requestPull(entry: MobileCatalogEntry): void {
     });
     return;
   }
-  const host = downloadHosts.value[0] ?? selectedHost.value;
+  const host = candidates[0] ?? (entry.installed ? owningHost(entry) : selectedHost.value);
   if (host) void pullTo(entry, host);
 }
 
@@ -1639,10 +1648,18 @@ onBeforeUnmount(() => {
         <div class="mobile-catalog-target-panel">
           <header>
             <div>
-              <h2 id="mobile-catalog-target-title">Choose a host</h2>
+              <h2 id="mobile-catalog-target-title">
+                {{ targetEntry.installed ? "Choose where to repair" : "Choose where to download" }}
+              </h2>
               <p>
-                {{ catalogActionLabel(targetEntry) }}
-                {{ targetEntry.display_name ?? targetEntry.name }}
+                <template v-if="targetEntry.installed">
+                  Only missing or damaged files for
+                  {{ targetEntry.display_name ?? targetEntry.name }} will be fetched.
+                </template>
+                <template v-else>
+                  {{ targetEntry.display_name ?? targetEntry.name }} and its required components
+                  will be stored on the selected host.
+                </template>
               </p>
             </div>
             <button
@@ -1656,7 +1673,7 @@ onBeforeUnmount(() => {
           </header>
           <div class="mobile-catalog-target-list">
             <button
-              v-for="host in downloadHosts"
+              v-for="host in targetHosts"
               :key="host.id"
               type="button"
               :disabled="Boolean(pullStatus(targetEntry, host.id))"

--- a/desktop/src/mobile/mobile.css
+++ b/desktop/src/mobile/mobile.css
@@ -240,7 +240,40 @@ button {
 }
 
 .mobile-sequence-row-error {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  width: 100%;
+  min-height: 44px;
+  border: 0;
+  padding: 4px 0;
+  background: transparent;
   color: var(--stop);
+  font: inherit;
+  text-align: left;
+}
+
+.mobile-sequence-row-error > span:first-child {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mobile-sequence-row-error > span:last-child {
+  flex: 0 0 auto;
+  margin-left: auto;
+  color: var(--ink-3);
+  font-family: var(--font-utility);
+  font-size: var(--text-edge-code);
+  text-transform: uppercase;
+}
+
+.mobile-sequence-row-error--expanded > span:first-child {
+  overflow: visible;
+  text-overflow: clip;
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 
 .mobile-sequence-resume {

--- a/ui/components/SequenceJobRow.test.ts
+++ b/ui/components/SequenceJobRow.test.ts
@@ -92,6 +92,7 @@ describe("SequenceJobRow", () => {
     const disclosure = wrapper.get("[data-test='seq-error-disclosure']");
 
     expect(disclosure.attributes("aria-expanded")).toBe("false");
+    expect(disclosure.attributes("aria-label")).toBeUndefined();
     expect(disclosure.text()).toContain(
       "plato ran out of memory. Try a smaller model, image size, or batch.",
     );

--- a/ui/components/SequenceJobRow.test.ts
+++ b/ui/components/SequenceJobRow.test.ts
@@ -83,6 +83,25 @@ describe("SequenceJobRow", () => {
     expect(wrapper.find("[data-test='seq-resume']").exists()).toBe(true);
   });
 
+  it("expands a failed job so its complete diagnostic can be inspected", async () => {
+    const diagnostic =
+      "CUDA allocation failed while reserving the transformer cache on device 1; requested 8.4 GiB with 3.1 GiB available";
+    const wrapper = mount(SequenceJobRow, {
+      props: { vm: vm({ state: "failed", error: diagnostic }) },
+    });
+    const disclosure = wrapper.get("[data-test='seq-error-disclosure']");
+
+    expect(disclosure.attributes("aria-expanded")).toBe("false");
+    expect(disclosure.text()).toContain(
+      "plato ran out of memory. Try a smaller model, image size, or batch.",
+    );
+    await disclosure.trigger("click");
+
+    expect(disclosure.attributes("aria-expanded")).toBe("true");
+    expect(disclosure.classes()).toContain("ms-seqrow__error--expanded");
+    expect(wrapper.emitted("select")).toBeUndefined();
+  });
+
   it("drops the progress region in the dense variant", () => {
     expect(
       mount(SequenceJobRow, { props: { vm: vm() } })

--- a/ui/components/SequenceJobRow.vue
+++ b/ui/components/SequenceJobRow.vue
@@ -107,7 +107,6 @@ const errorExpanded = ref(false);
         type="button"
         data-test="seq-error-disclosure"
         :aria-expanded="errorExpanded"
-        :aria-label="`${errorExpanded ? 'Collapse' : 'Expand'} failure details`"
         :title="errorExpanded ? undefined : vm.error"
         @click.stop="errorExpanded = !errorExpanded"
       >

--- a/ui/components/SequenceJobRow.vue
+++ b/ui/components/SequenceJobRow.vue
@@ -5,7 +5,7 @@
  * history drawer. Presentational only — props in, `action` out; the caller
  * owns routing, confirmation, and the destructive half of every verb.
  */
-import { computed } from "vue";
+import { computed, ref } from "vue";
 import ProgressBar from "./ProgressBar.vue";
 import {
   sequenceActionLabel,
@@ -68,6 +68,7 @@ const percent = computed(() => {
   return p && p.total > 0 ? Math.round((p.step / p.total) * 100) : 0;
 });
 const showProgress = computed(() => !props.dense && props.vm.progress !== null);
+const errorExpanded = ref(false);
 </script>
 
 <template>
@@ -99,12 +100,22 @@ const showProgress = computed(() => !props.dense && props.vm.progress !== null);
       >
         <ProgressBar :value="percent" :height="4" label="Sequence progress" />
       </span>
-      <span
+      <button
         v-if="showError && vm.error"
         class="ms-seqrow__error"
-        :title="vm.error"
-        >{{ vm.error }}</span
+        :class="{ 'ms-seqrow__error--expanded': errorExpanded }"
+        type="button"
+        data-test="seq-error-disclosure"
+        :aria-expanded="errorExpanded"
+        :aria-label="`${errorExpanded ? 'Collapse' : 'Expand'} failure details`"
+        :title="errorExpanded ? undefined : vm.error"
+        @click.stop="errorExpanded = !errorExpanded"
       >
+        <span>{{ vm.error }}</span>
+        <span class="ms-seqrow__error-toggle" aria-hidden="true">
+          {{ errorExpanded ? "Less" : "Details" }}
+        </span>
+      </button>
     </div>
     <div class="ms-seqrow__actions" data-test="sequence-job-actions">
       <button
@@ -204,12 +215,47 @@ const showProgress = computed(() => !props.dense && props.vm.progress !== null);
 }
 
 .ms-seqrow__error {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  min-width: 0;
+  border: 0;
+  padding: 0;
+  background: transparent;
   font-size: 10.5px;
   color: var(--stop);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 320px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.ms-seqrow__error > span:first-child {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.ms-seqrow__error-toggle {
+  flex: 0 0 auto;
+  color: var(--ink-3);
+  font-family: var(--f-mono);
+  font-size: 9px;
+  text-transform: uppercase;
+}
+
+.ms-seqrow__error--expanded {
+  align-items: flex-start;
+  white-space: normal;
+  overflow: visible;
+}
+
+.ms-seqrow__error--expanded > span:first-child {
+  overflow: visible;
+  text-overflow: clip;
+  overflow-wrap: anywhere;
 }
 
 .ms-seqrow--dense {


### PR DESCRIPTION
## Summary
- require an explicit owning-host choice before repairing multi-host model installs on iOS and desktop
- use repair-specific confirmation copy and keep Discover repairs scoped to hosts that actually own the model
- let failed sequence queue/history rows expand to show their complete diagnostic on iOS, desktop, and web

## Validation
- `cd desktop && bun run test` (2,580 tests)
- `cd web && bun run test` (1,019 tests)
- `cd desktop && bun run build:mobile`
- `cd desktop && bun run build`
- `cd web && bun run build`
- focused repair/disclosure suite after rebasing onto current `origin/main` (192 tests)
- Prettier check and `git diff --check`