### PR TITLE
fix(studio): preserve sequence inputs and model resolutions

### DIFF
--- a/crates/mold-core/src/catalog.rs
+++ b/crates/mold-core/src/catalog.rs
@@ -1,5 +1,20 @@
 use crate::manifest::{known_manifests, model_base_name, variant_quality_rank, visible_manifests};
-use crate::{Config, ModelDefaults, ModelInfo, ModelInfoExtended};
+use crate::{Config, ModelDefaults, ModelInfo, ModelInfoExtended, RecommendedDimensions};
+
+fn resolution_defaults(family: &str) -> (Option<u64>, Vec<RecommendedDimensions>, Option<u32>) {
+    (
+        Some(crate::validation::MAX_PIXELS),
+        crate::validation::recommended_dimensions(family)
+            .iter()
+            .map(|&(width, height)| RecommendedDimensions { width, height })
+            .collect(),
+        Some(if matches!(family, "ltx-video" | "ltx2") {
+            32
+        } else {
+            16
+        }),
+    )
+}
 
 /// Build the user-facing model catalog from the manifest registry plus local config.
 /// Hidden manifests are excluded from the catalog (CLI list, TUI model selector).
@@ -11,6 +26,8 @@ pub fn build_model_catalog(
     let mut models = Vec::with_capacity(known_manifests().len() + config.models.len());
 
     for manifest in visible_manifests() {
+        let (max_pixels, recommended_dimensions, dimension_alignment) =
+            resolution_defaults(&manifest.family);
         let model_cfg = config.resolved_model_config(&manifest.name);
         let downloaded = config.manifest_model_is_downloaded(&manifest.name);
         let (_, remaining_download_bytes) = crate::manifest::compute_download_size(manifest);
@@ -30,6 +47,9 @@ pub fn build_model_catalog(
                 default_fps: model_cfg.effective_fps(),
                 max_frames: crate::validation::max_frames_for_family(&manifest.family),
                 frame_step: crate::validation::frame_step_for_family(&manifest.family),
+                max_pixels,
+                recommended_dimensions,
+                dimension_alignment,
                 description: model_cfg
                     .description
                     .unwrap_or_else(|| manifest.name.clone()),
@@ -81,6 +101,8 @@ pub fn build_model_catalog(
             .family
             .clone()
             .unwrap_or_else(|| "flux".to_string());
+        let (max_pixels, recommended_dimensions, dimension_alignment) =
+            resolution_defaults(&family);
 
         models.push(ModelInfoExtended {
             downloaded: true,
@@ -93,6 +115,9 @@ pub fn build_model_catalog(
                 default_fps: model_cfg.effective_fps(),
                 max_frames: crate::validation::max_frames_for_family(&family),
                 frame_step: crate::validation::frame_step_for_family(&family),
+                max_pixels,
+                recommended_dimensions,
+                dimension_alignment,
                 description: model_cfg
                     .description
                     .clone()
@@ -190,9 +215,8 @@ mod tests {
         }
     }
 
-    /// Video models must advertise their manifest frame defaults and the
-    /// family frame constraints so clients stop hardcoding 25 frames; image
-    /// models must omit all four fields.
+    /// Models advertise both their family frame contract and the exact
+    /// runnable resolution buckets consumed by every Studio surface.
     #[test]
     fn build_model_catalog_emits_video_frame_defaults() {
         let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
@@ -211,6 +235,18 @@ mod tests {
             "no-temporal-upscale RoPE ceiling",
         );
         assert_eq!(ltx2.defaults.frame_step, Some(8));
+        assert_eq!(
+            ltx2.defaults.max_pixels,
+            Some(crate::validation::MAX_PIXELS)
+        );
+        assert_eq!(ltx2.defaults.dimension_alignment, Some(32));
+        assert!(
+            ltx2.defaults
+                .recommended_dimensions
+                .iter()
+                .any(|size| size.width == 1216 && size.height == 704),
+            "LTX-2's default landscape bucket must be advertised to every client",
+        );
 
         let ltx_video = catalog
             .iter()
@@ -229,6 +265,12 @@ mod tests {
         assert_eq!(flux.defaults.default_fps, None);
         assert_eq!(flux.defaults.max_frames, None);
         assert_eq!(flux.defaults.frame_step, None);
+        assert_eq!(
+            flux.defaults.max_pixels,
+            Some(crate::validation::MAX_PIXELS)
+        );
+        assert_eq!(flux.defaults.dimension_alignment, Some(16));
+        assert!(!flux.defaults.recommended_dimensions.is_empty());
     }
 
     #[test]

--- a/crates/mold-core/src/types.rs
+++ b/crates/mold-core/src/types.rs
@@ -910,6 +910,12 @@ pub struct ModelInfo {
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct RecommendedDimensions {
+    pub width: u32,
+    pub height: u32,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct ModelDefaults {
     #[schema(example = 4)]
     pub default_steps: u32,
@@ -941,6 +947,17 @@ pub struct ModelDefaults {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schema(example = 8)]
     pub frame_step: Option<u32>,
+    /// Server-authoritative total-pixel ceiling for generation requests.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schema(example = 1800000)]
+    pub max_pixels: Option<u64>,
+    /// Runnable, family-appropriate buckets used by every Studio surface.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub recommended_dimensions: Vec<RecommendedDimensions>,
+    /// Required dimension grid for this family.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schema(example = 16)]
+    pub dimension_alignment: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
@@ -1078,12 +1095,18 @@ mod model_defaults_frame_tests {
         assert_eq!(parsed.default_fps, None);
         assert_eq!(parsed.max_frames, None);
         assert_eq!(parsed.frame_step, None);
+        assert_eq!(parsed.max_pixels, None);
+        assert!(parsed.recommended_dimensions.is_empty());
+        assert_eq!(parsed.dimension_alignment, None);
 
         let out = serde_json::to_value(&parsed).unwrap();
         assert!(out.get("default_frames").is_none());
         assert!(out.get("default_fps").is_none());
         assert!(out.get("max_frames").is_none());
         assert!(out.get("frame_step").is_none());
+        assert!(out.get("max_pixels").is_none());
+        assert!(out.get("recommended_dimensions").is_none());
+        assert!(out.get("dimension_alignment").is_none());
 
         let video = ModelDefaults {
             default_frames: Some(97),

--- a/crates/mold-core/src/validation.rs
+++ b/crates/mold-core/src/validation.rs
@@ -705,9 +705,11 @@ const WUERSTCHEN_DIMS: &[(u32, u32)] = &[(1024, 1024)];
 /// Recommended dimensions for LTX Video models (native 768x512).
 /// LTX Video requires dimensions divisible by 32 (patchification).
 const LTX_VIDEO_DIMS: &[(u32, u32)] = &[
+    (704, 480),  // 22:15 (compact sample bucket)
     (768, 512),  // 3:2 (native)
     (512, 512),  // 1:1
     (1024, 576), // 16:9
+    (1216, 704), // 16:9 (LTX-2 19B/22B default)
     (576, 1024), // 9:16
     (768, 768),  // 1:1
     (512, 768),  // 2:3
@@ -728,7 +730,7 @@ pub fn recommended_dimensions(family: &str) -> &'static [(u32, u32)] {
         "qwen-image" => QWEN_IMAGE_DIMS,
         "qwen-image-edit" => QWEN_IMAGE_DIMS,
         "wuerstchen" => WUERSTCHEN_DIMS,
-        "ltx-video" => LTX_VIDEO_DIMS,
+        "ltx-video" | "ltx2" => LTX_VIDEO_DIMS,
         _ => &[],
     }
 }

--- a/crates/mold-server/src/model_manager.rs
+++ b/crates/mold-server/src/model_manager.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use mold_core::{
     build_model_catalog, Config, GenerateRequest, GenerationMemoryEstimate, ModelComponentOption,
     ModelComponentStatus, ModelComponentsResponse, ModelDefaults, ModelInfo, ModelInfoExtended,
-    ModelPaths,
+    ModelPaths, RecommendedDimensions,
 };
 #[cfg(test)]
 use mold_inference::device::ActivationFamily;
@@ -600,6 +600,20 @@ fn installed_catalog_models(
                 default_fps: fps,
                 max_frames: mold_core::validation::max_frames_for_family(&sidecar.family),
                 frame_step: mold_core::validation::frame_step_for_family(&sidecar.family),
+                max_pixels: Some(mold_core::validation::MAX_PIXELS),
+                recommended_dimensions: mold_core::validation::recommended_dimensions(
+                    &sidecar.family,
+                )
+                .iter()
+                .map(|&(width, height)| RecommendedDimensions { width, height })
+                .collect(),
+                dimension_alignment: Some(
+                    if matches!(sidecar.family.as_str(), "ltx-video" | "ltx2") {
+                        32
+                    } else {
+                        16
+                    },
+                ),
                 description,
             },
             info: ModelInfo {

--- a/desktop/src/components/create/InspectorPanel.test.ts
+++ b/desktop/src/components/create/InspectorPanel.test.ts
@@ -88,7 +88,9 @@ describe("InspectorPanel — shape + resolution projection", () => {
     form.width = 1024;
     form.height = 1024;
     const wrapper = mount(InspectorPanel, { props: { form } });
-    wrapper.findComponent(ResolutionSelector).vm.$emit("update:modelValue", 0.5);
+    wrapper
+      .findComponent(ResolutionSelector)
+      .vm.$emit("update:modelValue", (768 * 768) / 1_000_000);
     await flushPromises();
     expect(form.width * form.height).toBeLessThan(1024 * 1024);
     expect(form.width).toBe(form.height); // square ratio preserved
@@ -195,6 +197,39 @@ describe("InspectorPanel — advanced", () => {
 
     await wrapper.get('[data-test="open-advanced"]').trigger("click");
     expect(wrapper.get('[data-test="open-advanced"]').attributes("aria-expanded")).toBe("false");
+    expect(wrapper.find('[data-test="inline-advanced"]').exists()).toBe(false);
+  });
+
+  it("shows only sequence-specific Advanced controls in Sequence output", async () => {
+    const draft = useSequenceDraftStore();
+    draft.hydrate();
+    draft.output = "sequence";
+    draft.ensureClips(97);
+    const form = formFor("ltx2");
+    form.model = "ltx-2-19b-distilled:fp8";
+    const wrapper = mount(InspectorPanel, {
+      props: {
+        form,
+        chainLimits: {
+          model: form.model,
+          supports_sequence: true,
+          supports_audio: true,
+          max_stages: 16,
+          max_total_frames: 1552,
+          frames_per_clip_cap: 97,
+          frames_per_clip_recommended: 97,
+          fade_frames_max: 24,
+          transition_modes: ["smooth", "cut", "fade"],
+          quantization_family: "fp8",
+        },
+      },
+    });
+
+    await wrapper.get('[data-test="open-advanced"]').trigger("click");
+
+    expect(wrapper.find('[data-test="sequence-section-opening-image"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="sequence-section-negative"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="sequence-section-audio"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="inline-advanced"]').exists()).toBe(false);
   });
 });

--- a/desktop/src/components/create/InspectorPanel.test.ts
+++ b/desktop/src/components/create/InspectorPanel.test.ts
@@ -95,6 +95,15 @@ describe("InspectorPanel — shape + resolution projection", () => {
     expect(form.width * form.height).toBeLessThan(1024 * 1024);
     expect(form.width).toBe(form.height); // square ratio preserved
   });
+
+  it("labels a model's only runnable bucket as Native", () => {
+    const wrapper = mount(InspectorPanel, {
+      props: { form: formFor("wuerstchen") },
+    });
+    expect(wrapper.findComponent(ResolutionSelector).props("options")).toEqual([
+      expect.objectContaining({ sub: "Native" }),
+    ]);
+  });
 });
 
 describe("InspectorPanel — batch", () => {

--- a/desktop/src/components/create/InspectorPanel.vue
+++ b/desktop/src/components/create/InspectorPanel.vue
@@ -7,7 +7,6 @@ import SliderRow from "@ui/components/SliderRow.vue";
 import Stepper from "@ui/components/Stepper.vue";
 import BadgePill from "@ui/components/BadgePill.vue";
 import Icon from "@ui/components/Icon.vue";
-import { nearestMp } from "@ui/lib/resolution";
 import { useSequenceDraftStore } from "@studio/stores/sequenceDraft";
 import { defaultClipFrames, modelsForOutput, sequenceMotionTailFrames } from "@studio/lib/sequence";
 import type { ChainLimits } from "@studio/lib/api/chainTypes";
@@ -24,7 +23,14 @@ import { normalizeTargetHost } from "../../lib/hosts";
 import { modelDisplayName } from "../../lib/models";
 import { generationCapabilitiesForFamily } from "../../lib/capabilities";
 import { advancedActiveCount } from "../../lib/advancedCount";
-import { applyAspectId, applyMp, aspectIdFor } from "../../lib/resolutions";
+import { ASPECTS } from "@ui/lib/resolution";
+import {
+  aspectIdFor,
+  closestResolutionPreset,
+  megapixelLabel,
+  presetsForModel,
+  presetsNearRatio,
+} from "../../lib/resolutions";
 import { resolutionValidationError, stepsValidationError } from "../../lib/generateValidation";
 import { randomSeed } from "../../stores/generation";
 import { useGenerateFormStore } from "../../stores/generateForm";
@@ -35,6 +41,7 @@ import { useAppPrefsStore } from "../../stores/appPrefs";
 import { dragWidth } from "../../lib/panelResize";
 import ModelPicker from "./ModelPicker.vue";
 import AdvancedSettings from "./AdvancedSettings.vue";
+import SequenceAdvancedSettings from "./SequenceAdvancedSettings.vue";
 import { formatGB } from "../../lib/format";
 import PanelResizeHandle from "../shell/PanelResizeHandle.vue";
 
@@ -122,7 +129,13 @@ function onInspectorReset() {
 }
 
 const caps = computed(() => generationCapabilitiesForFamily(props.form.family));
-const advancedCount = computed(() => advancedActiveCount(props.form));
+const advancedCount = computed(() =>
+  isSequence.value
+    ? Number(Boolean(draft.openingImage)) +
+      Number(Boolean(draft.clips.some((clip) => clip.negativePrompt.trim()))) +
+      Number(draft.enableAudio)
+    : advancedActiveCount(props.form),
+);
 const advancedExpanded = ref(false);
 
 // ── Model picker (the shared ModelPicker; chains uses the same control) ──────
@@ -224,18 +237,60 @@ function pickModel(m: ModelEntry) {
 
 // ── Shape + resolution projection ────────────────────────────────────────────
 const shapeId = computed(() => aspectIdFor(props.form.width, props.form.height) ?? "");
-const resolutionMp = computed(() => nearestMp(props.form.width, props.form.height));
 const resolutionRatio = computed(() => props.form.width / props.form.height);
+const resolutionPresets = computed(() =>
+  presetsNearRatio(
+    presetsForModel(selectedModel.value ?? props.form.family),
+    resolutionRatio.value,
+  ),
+);
+const resolutionOptions = computed(() =>
+  resolutionPresets.value.map((preset, index, all) => ({
+    mp: (preset.width * preset.height) / 1_000_000,
+    label: megapixelLabel(preset.width, preset.height),
+    sub: index === 0 ? "Small" : index === all.length - 1 ? "Native" : "Standard",
+    width: preset.width,
+    height: preset.height,
+  })),
+);
+const resolutionMp = computed(() => {
+  const exact = resolutionOptions.value.find(
+    (option) => option.width === props.form.width && option.height === props.form.height,
+  );
+  if (exact) return exact.mp;
+  const current = (props.form.width * props.form.height) / 1_000_000;
+  return (
+    [...resolutionOptions.value].sort(
+      (a, b) => Math.abs(a.mp - current) - Math.abs(b.mp - current),
+    )[0]?.mp ?? current
+  );
+});
 const resolutionError = computed(() =>
   resolutionValidationError(props.form.width, props.form.height),
 );
 const stepsError = computed(() => stepsValidationError(props.form.steps));
 
 function onShape(id: string) {
-  applyAspectId(props.form, id);
+  const aspect = ASPECTS.find((option) => option.id === id);
+  if (!aspect) return;
+  const preset = closestResolutionPreset(
+    presetsNearRatio(presetsForModel(selectedModel.value ?? props.form.family), aspect.ratio),
+    props.form.width,
+    props.form.height,
+  );
+  if (preset) {
+    props.form.width = preset.width;
+    props.form.height = preset.height;
+  }
 }
 function onResolution(mp: number) {
-  applyMp(props.form, mp);
+  const preset = resolutionPresets.value.find(
+    (candidate) => (candidate.width * candidate.height) / 1_000_000 === mp,
+  );
+  if (preset) {
+    props.form.width = preset.width;
+    props.form.height = preset.height;
+  }
 }
 
 // ── Seed (mode is UI-owned to avoid focus loss — see the previous ParamPanel) ─
@@ -348,6 +403,7 @@ function resetSettings() {
         <ResolutionSelector
           :model-value="resolutionMp"
           :ratio="resolutionRatio"
+          :options="resolutionOptions"
           @update:model-value="onResolution"
         />
         <p v-if="resolutionError" class="ms-field__error" role="alert">{{ resolutionError }}</p>
@@ -495,8 +551,13 @@ function resetSettings() {
           <Icon :name="advancedExpanded ? 'chevron-up' : 'chevron-down'" :size="15" />
         </span>
       </button>
+      <SequenceAdvancedSettings
+        v-if="advancedExpanded && isSequence"
+        id="desktop-inline-advanced"
+        :chain-limits="chainLimits"
+      />
       <AdvancedSettings
-        v-if="advancedExpanded"
+        v-else-if="advancedExpanded"
         id="desktop-inline-advanced"
         :form="form"
         :selected-model="selectedModel"

--- a/desktop/src/components/create/InspectorPanel.vue
+++ b/desktop/src/components/create/InspectorPanel.vue
@@ -248,7 +248,14 @@ const resolutionOptions = computed(() =>
   resolutionPresets.value.map((preset, index, all) => ({
     mp: (preset.width * preset.height) / 1_000_000,
     label: megapixelLabel(preset.width, preset.height),
-    sub: index === 0 ? "Small" : index === all.length - 1 ? "Native" : "Standard",
+    sub:
+      all.length === 1
+        ? "Native"
+        : index === 0
+          ? "Small"
+          : index === all.length - 1
+            ? "Native"
+            : "Standard",
     width: preset.width,
     height: preset.height,
   })),

--- a/desktop/src/components/create/SequenceAdvancedSettings.vue
+++ b/desktop/src/components/create/SequenceAdvancedSettings.vue
@@ -1,0 +1,226 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import AccordionSection from "@ui/components/AccordionSection.vue";
+import Chip from "@ui/components/Chip.vue";
+import SwitchToggle from "@ui/components/SwitchToggle.vue";
+import { useSequenceDraftStore } from "@studio/stores/sequenceDraft";
+import type { ChainLimits } from "@studio/lib/api/chainTypes";
+import type { PickedImage } from "../../lib/generateForm";
+import ImagePickerModal from "../generate/ImagePickerModal.vue";
+
+const props = withDefaults(defineProps<{ chainLimits?: ChainLimits | null }>(), {
+  chainLimits: null,
+});
+
+const draft = useSequenceDraftStore();
+const pickerOpen = ref(false);
+const activeClip = computed(
+  () => draft.clips.find((clip) => clip.id === draft.activeClipId) ?? draft.clips[0] ?? null,
+);
+const activeIndex = computed(() =>
+  activeClip.value ? draft.clips.findIndex((clip) => clip.id === activeClip.value?.id) : -1,
+);
+const activeCount = computed(
+  () =>
+    Number(Boolean(draft.openingImage)) +
+    Number(Boolean(activeClip.value?.negativePrompt.trim())) +
+    Number(draft.enableAudio),
+);
+
+const NEGATIVE_QUICK_ADDS = [
+  "blurry",
+  "extra fingers",
+  "watermark",
+  "low quality",
+  "oversaturated",
+];
+
+function addNegative(word: string) {
+  const clip = activeClip.value;
+  if (!clip) return;
+  const current = clip.negativePrompt.trim();
+  clip.negativePrompt = current ? `${current}, ${word}` : word;
+}
+
+function onPickImage(images: PickedImage[]) {
+  const image = images[0];
+  pickerOpen.value = false;
+  if (!image) return;
+  draft.openingImage = { filename: image.filename, base64: image.base64 };
+}
+
+function reset() {
+  draft.openingImage = null;
+  draft.enableAudio = false;
+  for (const clip of draft.clips) clip.negativePrompt = "";
+}
+</script>
+
+<template>
+  <section class="ms-adv" data-test="sequence-inline-advanced">
+    <div class="ms-adv__toolbar">
+      <span class="ms-adv__summary">
+        {{ activeCount > 0 ? `${activeCount} active` : "Sequence controls" }}
+      </span>
+      <button
+        type="button"
+        class="ms-adv__reset"
+        data-test="sequence-advanced-reset"
+        @click="reset"
+      >
+        Reset
+      </button>
+    </div>
+
+    <div class="ms-adv__list">
+      <AccordionSection
+        icon="image"
+        title="Opening sequence image"
+        :summary="draft.openingImage?.filename ?? 'Optional original starting frame'"
+        :open="true"
+        :header-interactive="false"
+        data-test="sequence-section-opening-image"
+      >
+        <button
+          type="button"
+          class="ms-dropzone"
+          data-test="sequence-opening-image-pick"
+          @click="pickerOpen = true"
+        >
+          {{
+            draft.openingImage
+              ? `Replace ${draft.openingImage.filename}`
+              : "Drop an image or click to choose the original starting frame"
+          }}
+        </button>
+        <button
+          v-if="draft.openingImage"
+          type="button"
+          class="ms-remove"
+          data-test="sequence-opening-image-clear"
+          @click="draft.openingImage = null"
+        >
+          Remove opening image
+        </button>
+      </AccordionSection>
+
+      <AccordionSection
+        v-if="activeClip"
+        icon="negative"
+        :title="`Clip ${activeIndex + 1} negative prompt`"
+        summary="What to steer away from in this clip"
+        :open="true"
+        :header-interactive="false"
+        data-test="sequence-section-negative"
+      >
+        <textarea
+          v-model="activeClip.negativePrompt"
+          data-selectable
+          rows="2"
+          placeholder="blurry, low quality, deformed…"
+          class="ms-textarea"
+          aria-label="Active clip negative prompt"
+        />
+        <div class="ms-chips">
+          <Chip v-for="word in NEGATIVE_QUICK_ADDS" :key="word" @click="addNegative(word)"
+            >+ {{ word }}</Chip
+          >
+        </div>
+      </AccordionSection>
+
+      <AccordionSection
+        v-if="props.chainLimits?.supports_audio"
+        icon="video"
+        title="Sequence audio"
+        summary="Generate and mux audio for this timeline"
+        :open="true"
+        :header-interactive="false"
+        data-test="sequence-section-audio"
+      >
+        <div class="ms-switch-row">
+          <span>Generate audio</span>
+          <SwitchToggle
+            :model-value="draft.enableAudio"
+            label="Generate sequence audio"
+            @update:model-value="draft.enableAudio = $event"
+          />
+        </div>
+      </AccordionSection>
+    </div>
+
+    <ImagePickerModal
+      :open="pickerOpen"
+      title="Opening sequence image"
+      :multiple="false"
+      @pick="onPickImage"
+      @close="pickerOpen = false"
+    />
+  </section>
+</template>
+
+<style scoped>
+.ms-adv__toolbar,
+.ms-switch-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+.ms-adv__toolbar {
+  margin-bottom: 10px;
+}
+.ms-adv__summary {
+  color: var(--ink-3);
+  font-family: var(--f-mono);
+  font-size: 10px;
+}
+.ms-adv__reset,
+.ms-remove,
+.ms-dropzone {
+  border: 1px solid var(--ce);
+  background: transparent;
+  color: var(--ink-2);
+  border-radius: 8px;
+  cursor: pointer;
+}
+.ms-adv__reset,
+.ms-remove {
+  padding: 5px 9px;
+  font-size: 11px;
+}
+.ms-dropzone {
+  width: 100%;
+  border-style: dashed;
+  padding: 22px 12px;
+  font-size: 12px;
+}
+.ms-remove {
+  margin-top: 9px;
+  color: var(--stop);
+}
+.ms-adv__list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.ms-textarea {
+  width: 100%;
+  box-sizing: border-box;
+  resize: none;
+  border: 1px solid var(--ce);
+  border-radius: 8px;
+  background: var(--bath);
+  color: var(--rebate);
+  padding: 9px 10px;
+}
+.ms-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin-top: 9px;
+}
+.ms-switch-row {
+  color: var(--ink-2);
+  font-size: 12px;
+}
+</style>

--- a/desktop/src/components/create/SequenceComposer.test.ts
+++ b/desktop/src/components/create/SequenceComposer.test.ts
@@ -120,32 +120,20 @@ describe("SequenceComposer — active clip editor", () => {
     expect(wrapper.emitted("submit")).toHaveLength(1);
   });
 
-  it("offers the opening-image attach only on clip 1", async () => {
+  it("keeps opening-image controls out of the clip editor", async () => {
     const draft = seedDraft();
     draft.activeClipId = draft.clips[0]!.id;
     const wrapper = mountComposer();
-    expect(wrapper.find("[data-test='opening-image-attach']").exists()).toBe(true);
+    expect(wrapper.find("[data-test='opening-image-attach']").exists()).toBe(false);
     draft.activeClipId = draft.clips[1]!.id;
     await flushPromises();
     expect(wrapper.find("[data-test='opening-image-attach']").exists()).toBe(false);
   });
 
-  it("uses the shared file-or-gallery picker for the opening image", async () => {
-    const draft = seedDraft();
+  it("does not mount a duplicate opening-image picker", async () => {
+    seedDraft();
     const wrapper = mountComposer();
-
-    await wrapper.get("[data-test='opening-image-attach']").trigger("click");
-    const picker = wrapper.getComponent(ImagePickerModal);
-    expect(picker.props("open")).toBe(true);
-    expect(picker.props("multiple")).toBe(false);
-
-    picker.vm.$emit("pick", [{ filename: "gallery-still.jpg", base64: "picked-bytes" }]);
-    await flushPromises();
-    expect(draft.clips[0]!.sourceImage).toEqual({
-      filename: "gallery-still.jpg",
-      base64: "picked-bytes",
-    });
-    expect(picker.props("open")).toBe(false);
+    expect(wrapper.findComponent(ImagePickerModal).exists()).toBe(false);
   });
 });
 
@@ -179,12 +167,12 @@ describe("SequenceComposer — footer", () => {
     expect(wrapper.text()).toContain("Two-stage checkpoint");
   });
 
-  it("gates the audio toggle on chain-limits support", () => {
+  it("keeps audio out of the composer footer", () => {
     seedDraft();
     expect(mountComposer().find("[data-test='sequence-audio']").exists()).toBe(false);
     document.body.innerHTML = "";
     const withAudio = mountComposer({ chainLimits: { ...limits, supports_audio: true } });
-    expect(withAudio.find("[data-test='sequence-audio']").exists()).toBe(true);
+    expect(withAudio.find("[data-test='sequence-audio']").exists()).toBe(false);
   });
 });
 
@@ -222,14 +210,31 @@ describe("SequenceComposer — edit sessions", () => {
 
   it("Duplicate as new emits duplicate; Discard restores the baseline and stops editing", async () => {
     const draft = startEditing();
+    draft.openingImage = { filename: "original.png", base64: "ORIGINAL" };
+    draft.enableAudio = true;
+    draft.loadFromJob(
+      {
+        jobId: "abcdef1234567890",
+        hostId: "local",
+        baseline: draft.clips.map((clip) => ({ ...clip })),
+        completedStages: 2,
+      },
+      draft.clips.map((clip) => ({ ...clip })),
+      true,
+      draft.openingImage,
+    );
     const wrapper = mountComposer();
     await wrapper.get("[data-test='edit-duplicate']").trigger("click");
     expect(wrapper.emitted("duplicate")).toHaveLength(1);
 
     draft.clips[1]!.prompt = "changed beat";
+    draft.openingImage = { filename: "replacement.png", base64: "REPLACEMENT" };
+    draft.enableAudio = false;
     await wrapper.get("[data-test='edit-discard']").trigger("click");
     expect(draft.editing).toBeNull();
     expect(draft.clips[1]!.prompt).toBe("clip two");
+    expect(draft.openingImage?.filename).toBe("original.png");
+    expect(draft.enableAudio).toBe(true);
   });
 });
 

--- a/desktop/src/components/create/SequenceComposer.vue
+++ b/desktop/src/components/create/SequenceComposer.vue
@@ -10,7 +10,6 @@ import { computed, ref } from "vue";
 import ClipRail from "@ui/components/ClipRail.vue";
 import Popover from "@ui/components/Popover.vue";
 import SeamEditor from "@ui/components/SeamEditor.vue";
-import SwitchToggle from "@ui/components/SwitchToggle.vue";
 import ConfirmDialog from "../shell/ConfirmDialog.vue";
 import { useSequenceDraftStore } from "@studio/stores/sequenceDraft";
 import {
@@ -26,17 +25,17 @@ import {
 import {
   chainScriptToClips,
   clipsToChainScript,
+  sequenceOpeningImageError,
   stageInvalidation,
 } from "@studio/lib/sequenceForm";
 import { parseChainScript, serializeChainScript } from "@studio/lib/chainToml";
 import type { ChainLimits } from "@studio/lib/api/chainTypes";
 import { sequenceParams } from "../../lib/sequenceParams";
-import type { GenerateForm, PickedImage } from "../../lib/generateForm";
+import type { GenerateForm } from "../../lib/generateForm";
 import type { ModelEntry } from "../../lib/api/types";
 import { useHostsStore } from "../../stores/hosts";
 import { useToastStore } from "../../stores/toasts";
 import type { ClipRailMedia } from "@ui/components/types";
-import ImagePickerModal from "../generate/ImagePickerModal.vue";
 
 const props = withDefaults(
   defineProps<{
@@ -106,7 +105,6 @@ const activeMeta = computed(() => {
   }
   return parts.join(" · ");
 });
-const negativeOpen = ref(false);
 
 function onPromptKeydown(event: KeyboardEvent) {
   if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
@@ -150,17 +148,6 @@ function applySeamToAll(transition: "smooth" | "cut" | "fade") {
   openSeamId.value = null;
 }
 
-// ── Opening image (clip 1) ───────────────────────────────────────────────────
-const imagePickerOpen = ref(false);
-
-function onPickImage(images: PickedImage[]) {
-  const image = images[0];
-  const clip = draft.clips[0];
-  imagePickerOpen.value = false;
-  if (!image || !clip) return;
-  clip.sourceImage = { filename: image.filename, base64: image.base64 };
-}
-
 // ── Validation, duration, fit ────────────────────────────────────────────────
 const stages = computed<SequenceStage[]>(() =>
   draft.clips.map((clip) => ({
@@ -189,6 +176,8 @@ const disabledReason = computed(() => {
     );
   }
   if (!props.form.model) return "Pick a video model first.";
+  const openingError = sequenceOpeningImageError(draft.openingImage, draft.mediaRestoring);
+  if (openingError) return openingError;
   return validation.value[0] ?? null;
 });
 
@@ -218,6 +207,8 @@ function discardEdit() {
   const editing = draft.editing;
   if (!editing) return;
   draft.clips.splice(0, draft.clips.length, ...editing.baseline.map((clip) => ({ ...clip })));
+  draft.openingImage = editing.baselineOpeningImage ? { ...editing.baselineOpeningImage } : null;
+  draft.enableAudio = editing.baselineEnableAudio ?? false;
   draft.stopEditing();
 }
 
@@ -236,7 +227,6 @@ const clearMessage = computed(() => {
 function clearSequence() {
   clearConfirmOpen.value = false;
   openSeamId.value = null;
-  negativeOpen.value = false;
   draft.clearSequence(newClipFrames.value);
   toasts.push("Sequence cleared");
 }
@@ -249,6 +239,7 @@ function currentScript() {
   return clipsToChainScript(sequenceParams(props.form, props.selectedModel), draft.clips, {
     motionTailFrames: motionTail.value,
     enableAudio: draft.enableAudio,
+    openingImage: draft.openingImage,
   });
 }
 
@@ -266,6 +257,7 @@ async function onTomlFile(event: Event) {
     const script = parseChainScript(await file.text());
     const loaded = chainScriptToClips(script);
     draft.clips.splice(0, draft.clips.length, ...loaded.clips);
+    draft.openingImage = loaded.openingImage;
     draft.activeClipId = draft.clips[0]?.id ?? null;
     draft.enableAudio = loaded.enableAudio;
     // Shared params flow to the LIVE generate form — the one source of truth.
@@ -413,60 +405,7 @@ async function copyToml() {
         aria-label="Clip prompt"
         @keydown="onPromptKeydown"
       />
-      <div class="ms-seqbench__cliptools">
-        <template v-if="activeIndex === 0">
-          <button
-            type="button"
-            data-test="opening-image-attach"
-            class="ms-seqbench__tool"
-            @click="imagePickerOpen = true"
-          >
-            {{
-              activeClip.sourceImage
-                ? `Image: ${activeClip.sourceImage.filename}`
-                : "Attach opening image…"
-            }}
-          </button>
-          <button
-            v-if="activeClip.sourceImage"
-            type="button"
-            data-test="opening-image-clear"
-            class="ms-seqbench__tool ms-seqbench__tool--danger"
-            aria-label="Remove opening image"
-            @click="activeClip.sourceImage = null"
-          >
-            ✕
-          </button>
-        </template>
-        <button
-          type="button"
-          data-test="clip-negative-toggle"
-          class="ms-seqbench__tool"
-          :aria-expanded="negativeOpen"
-          @click="negativeOpen = !negativeOpen"
-        >
-          {{ negativeOpen ? "Hide negative prompt" : "Negative prompt…" }}
-        </button>
-      </div>
-      <textarea
-        v-if="negativeOpen"
-        v-model="activeClip.negativePrompt"
-        data-test="clip-negative"
-        data-selectable
-        rows="2"
-        class="ms-seqbench__prompt ms-seqbench__prompt--negative"
-        placeholder="What to avoid in this clip…"
-        aria-label="Clip negative prompt"
-      />
     </div>
-
-    <ImagePickerModal
-      :open="imagePickerOpen"
-      title="Opening image"
-      :multiple="false"
-      @pick="onPickImage"
-      @close="imagePickerOpen = false"
-    />
 
     <!-- Footer: file tools · audio · validation/fit · primary action -->
     <div class="ms-seqbench__footer" data-test="sequence-composer-footer">
@@ -531,19 +470,6 @@ async function copyToml() {
       >
         Clear sequence
       </button>
-
-      <label
-        v-if="chainLimits?.supports_audio"
-        class="ms-seqbench__audio"
-        data-test="sequence-audio"
-      >
-        <SwitchToggle
-          :model-value="draft.enableAudio"
-          label="Generate audio"
-          @update:model-value="draft.enableAudio = $event"
-        />
-        <span>Audio</span>
-      </label>
 
       <span
         v-if="disabledReason"

--- a/desktop/src/lib/api/types.ts
+++ b/desktop/src/lib/api/types.ts
@@ -115,6 +115,9 @@ export interface ModelEntry {
   default_guidance: number;
   default_width: number;
   default_height: number;
+  max_pixels?: number | null;
+  recommended_dimensions?: { width: number; height: number }[];
+  dimension_alignment?: number | null;
   description: string;
   downloaded: boolean;
   disk_usage_bytes?: number | null;

--- a/desktop/src/lib/resolutions.test.ts
+++ b/desktop/src/lib/resolutions.test.ts
@@ -118,7 +118,7 @@ describe("MP / aspect projection (Mold Studio inspector)", () => {
     expect(aspectIdFor(form.width, form.height)).toBe("wide");
     expect(form.width % 16).toBe(0);
     expect(form.height % 16).toBe(0);
-    expect(form.width * form.height).toBeGreaterThan(0.7e6);
+    expect(form.width * form.height).toBeGreaterThan(0.5e6);
     expect(form.width * form.height).toBeLessThan(1.3e6);
     applyAspectId(form, "unknown-shape"); // no-op for an id outside ASPECTS
     expect(aspectIdFor(form.width, form.height)).toBe("wide");

--- a/desktop/src/lib/resolutions.ts
+++ b/desktop/src/lib/resolutions.ts
@@ -1,149 +1,12 @@
-/**
- * Common, family-appropriate resolutions for the quick-select in the Size
- * block. Every entry is a multiple of 16 (the engines' latent stride — the
- * manual inputs snap to 16 for the same reason). The manual W/H inputs stay
- * for anything not listed.
- */
-import { ASPECTS, dimsForMp, nearestMp } from "@ui/lib/resolution";
+export * from "@studio/lib/resolutions";
 
-export interface ResolutionPreset {
-  label: string;
-  aspect: string;
-  width: number;
-  height: number;
-}
+import { ASPECTS } from "@ui/lib/resolution";
+import {
+  closestResolutionPreset,
+  presetsForFamily,
+  presetsNearRatio,
+} from "@studio/lib/resolutions";
 
-const p = (aspect: string, width: number, height: number): ResolutionPreset => ({
-  label: `${aspect} · ${width}×${height}`,
-  aspect,
-  width,
-  height,
-});
-
-/** SD 1.5 was trained at 512; going far beyond it doubles subjects. */
-const SD15: ResolutionPreset[] = [
-  p("1:1", 512, 512),
-  p("2:3", 512, 768),
-  p("3:2", 768, 512),
-  p("3:4", 640, 832),
-  p("4:3", 832, 640),
-];
-
-/** SDXL's official bucket list (all ~1 MP). */
-const SDXL: ResolutionPreset[] = [
-  p("1:1", 1024, 1024),
-  p("3:4", 896, 1152),
-  p("4:3", 1152, 896),
-  p("2:3", 832, 1216),
-  p("3:2", 1216, 832),
-  p("16:9", 1344, 768),
-  p("9:16", 768, 1344),
-];
-
-/** Modern ~1 MP transformers (FLUX, SD3.5, Z-Image, Qwen-Image, Flux.2). */
-const MODERN: ResolutionPreset[] = [
-  p("1:1", 1024, 1024),
-  p("3:4", 896, 1152),
-  p("4:3", 1152, 896),
-  p("2:3", 832, 1216),
-  p("3:2", 1216, 832),
-  p("16:9", 1344, 768),
-  p("9:16", 768, 1344),
-  p("21:9", 1536, 640),
-];
-
-/** Qwen's published buckets, kept in lockstep with mold-core validation. */
-const QWEN_IMAGE: ResolutionPreset[] = [
-  p("1:1", 1328, 1328),
-  p("1:1", 1024, 1024),
-  p("9:7", 1152, 896),
-  p("7:9", 896, 1152),
-  p("19:13", 1216, 832),
-  p("13:19", 832, 1216),
-  p("7:4", 1344, 768),
-  p("4:7", 768, 1344),
-  p("≈16:9", 1664, 928),
-  p("≈9:16", 928, 1664),
-  p("1:1", 768, 768),
-  p("1:1", 512, 512),
-];
-
-/** Video works in smaller frames; these match the LTX sample configs. */
-const VIDEO: ResolutionPreset[] = [
-  p("22:15", 704, 480),
-  p("3:2", 768, 512),
-  p("16:9", 1024, 576),
-  p("16:9", 1216, 704),
-];
-
-const BY_FAMILY: Record<string, ResolutionPreset[]> = {
-  sd15: SD15,
-  sdxl: SDXL,
-  flux: MODERN,
-  flux2: MODERN,
-  sd3: MODERN,
-  zimage: MODERN,
-  "z-image": MODERN,
-  "qwen-image": QWEN_IMAGE,
-  "qwen-image-edit": QWEN_IMAGE,
-  wuerstchen: SDXL,
-  "ltx-video": VIDEO,
-  ltx2: VIDEO,
-};
-
-export function presetsForFamily(family: string): ResolutionPreset[] {
-  return BY_FAMILY[family] ?? MODERN;
-}
-
-/** The preset matching the current W/H exactly, or null (= "Custom"). */
-export function matchPreset(
-  width: number,
-  height: number,
-  family: string,
-): ResolutionPreset | null {
-  return presetsForFamily(family).find((r) => r.width === width && r.height === height) ?? null;
-}
-
-function gcd(a: number, b: number): number {
-  let x = Math.max(1, Math.round(Math.abs(a)));
-  let y = Math.max(1, Math.round(Math.abs(b)));
-  while (y !== 0) [x, y] = [y, x % y];
-  return x;
-}
-
-/** Human-readable ratio, preferring a known model bucket over raw arithmetic. */
-export function aspectRatioLabel(width: number, height: number, family: string): string {
-  const preset = matchPreset(width, height, family);
-  if (preset) return preset.aspect;
-  const divisor = gcd(width, height);
-  return `${Math.round(width) / divisor}:${Math.round(height) / divisor}`;
-}
-
-export function orientationLabel(
-  width: number,
-  height: number,
-): "Landscape" | "Portrait" | "Square" {
-  if (width === height) return "Square";
-  return width > height ? "Landscape" : "Portrait";
-}
-
-// ── Mold Studio inspector: megapixel + shape projection ─────────────────────
-// The redesigned inspector drives Size with a five-swatch Shape picker (the
-// shared @ui ASPECTS set) and an MP-budget Resolution selector rather than raw
-// W/H. These helpers bridge that @ui vocabulary onto the desktop form, keeping
-// the engines' /16 latent-stride constraint the manual inputs already enforce.
-
-/** /16 latent-stride snap (floored at 64) shared with the manual W/H inputs. */
-function snap16(value: number): number {
-  return Math.max(64, Math.round(value / 16) * 16);
-}
-
-/**
- * The canonical shape id (from @ui `ASPECTS`) whose ratio matches width/height
- * within `tolerance` (relative), or null for a size the five swatches can't
- * represent (e.g. 2:3, 3:2, 21:9). Lets the Shape picker reflect the form's
- * live dimensions without forcing every bucket onto one of the five shapes.
- */
 export function aspectIdFor(width: number, height: number, tolerance = 0.075): string | null {
   if (!(width > 0) || !(height > 0)) return null;
   const ratio = width / height;
@@ -155,28 +18,38 @@ export function aspectIdFor(width: number, height: number, tolerance = 0.075): s
   return best && best.diff <= tolerance ? best.id : null;
 }
 
-/**
- * Reproject the form's dimensions onto a new megapixel budget at the CURRENT
- * aspect ratio. Uses @ui `dimsForMp` for the megapixel math, then snaps to the
- * /16 grid so the result is a runnable size (a no-op on `dimsForMp`'s /64
- * output, but the constraint the desktop engines actually require).
- */
-export function applyMp(form: { width: number; height: number }, mp: number): void {
-  if (!(form.width > 0) || !(form.height > 0)) return;
-  const { width, height } = dimsForMp(mp, form.width / form.height);
-  form.width = snap16(width);
-  form.height = snap16(height);
+export function applyMp(
+  form: { width: number; height: number; family?: string },
+  mp: number,
+): void {
+  const candidates = presetsNearRatio(
+    presetsForFamily(form.family ?? "flux"),
+    form.width / form.height,
+  );
+  const preset = [...candidates].sort(
+    (a, b) =>
+      Math.abs((a.width * a.height) / 1_000_000 - mp) -
+      Math.abs((b.width * b.height) / 1_000_000 - mp),
+  )[0];
+  if (preset) {
+    form.width = preset.width;
+    form.height = preset.height;
+  }
 }
 
-/**
- * Switch the form to a canonical shape (a swatch id from @ui `ASPECTS`) while
- * keeping the closest megapixel budget, snapped to /16. Unknown ids are a
- * no-op, so a custom size the picker can't select never gets clobbered.
- */
-export function applyAspectId(form: { width: number; height: number }, id: string): void {
+export function applyAspectId(
+  form: { width: number; height: number; family?: string },
+  id: string,
+): void {
   const aspect = ASPECTS.find((option) => option.id === id);
   if (!aspect) return;
-  const { width, height } = dimsForMp(nearestMp(form.width, form.height), aspect.ratio);
-  form.width = snap16(width);
-  form.height = snap16(height);
+  const preset = closestResolutionPreset(
+    presetsNearRatio(presetsForFamily(form.family ?? "flux"), aspect.ratio),
+    form.width,
+    form.height,
+  );
+  if (preset) {
+    form.width = preset.width;
+    form.height = preset.height;
+  }
 }

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -696,6 +696,7 @@ function selectCurrentMobileSequence(): void {
     draft.clips.splice(0, draft.clips.length, ...loaded.clips);
     draft.activeClipId = loaded.clips[0]?.id ?? null;
     draft.enableAudio = loaded.enableAudio;
+    draft.openingImage = loaded.openingImage;
   }
   tab.value = "generate";
 }
@@ -1251,6 +1252,7 @@ async function submitMobileSequence(): Promise<void> {
     const request = buildChainRequest(sequenceParams(form, entry), draft.clips, {
       motionTailFrames: sequenceMotionTail.value,
       enableAudio: draft.enableAudio,
+      openingImage: draft.openingImage,
     });
     let preview: GenerationPlacementPreview | null = null;
     let legacyUnsupported = false;
@@ -3260,6 +3262,7 @@ onBeforeUnmount(() => {
               <template #settings>
                 <MobileSharedParams
                   :form="form"
+                  :model="selectedGenerationModel"
                   :last-seed="generation.lastSeedUsed"
                   :disabled="loadingModels"
                   show-fps
@@ -3285,6 +3288,7 @@ onBeforeUnmount(() => {
             <MobilePromptTools
               v-if="selectedTarget"
               :form="form"
+              :model="selectedGenerationModel"
               :target="selectedTarget"
               :running="expansionRunning"
               :can-undo="quickExpansionOriginal !== null"

--- a/desktop/src/mobile/MobileResolutionPicker.test.ts
+++ b/desktop/src/mobile/MobileResolutionPicker.test.ts
@@ -47,17 +47,17 @@ describe("MobileResolutionPicker", () => {
     expect(wrapper.get("[data-aspect='1:1']").attributes("aria-pressed")).toBe("true");
     const active = wrapper.get("[data-test='mobile-resolution-tier'] [aria-checked='true']");
     expect(active.get(".ms-seg__label").text()).toBe("1 MP");
-    expect(active.get(".ms-seg__sub").text()).toBe("Recommended");
+    expect(active.get(".ms-seg__sub").text()).toBe("High");
 
     await wrapper.get("[data-orientation='portrait']").trigger("click");
-    expect(state).toMatchObject({ width: 896, height: 1152 });
+    expect(state).toMatchObject({ width: 768, height: 1024 });
     expect(wrapper.get("[data-test='mobile-resolution-announcement']").text()).toBe(
-      "Selected resolution: 896 by 1152 pixels, 3:4, Portrait.",
+      "Selected resolution: 768 by 1024 pixels, 3:4, Portrait.",
     );
     expect(wrapper.get("[data-aspect='3:4']").attributes("aria-pressed")).toBe("true");
 
     await wrapper.get("[data-aspect='9:16']").trigger("click");
-    expect(state).toMatchObject({ width: 768, height: 1344 });
+    expect(state).toMatchObject({ width: 576, height: 1024 });
   });
 
   it("offers named resolution tiers for repeated Qwen aspect buckets", async () => {
@@ -104,10 +104,12 @@ describe("MobileResolutionPicker", () => {
 
   it("renders however many tiers the family's aspect bucket provides", () => {
     const single = tierSegments(mountPicker(1024, 1024, "flux").wrapper);
-    expect(single).toHaveLength(1);
-    expect(single[0]?.get(".ms-seg__label").text()).toBe("1 MP");
-    expect(single[0]?.get(".ms-seg__sub").text()).toBe("Recommended");
-    expect(single[0]?.attributes("aria-checked")).toBe("true");
+    expect(single).toHaveLength(2);
+    expect(single.map((segment) => segment.get(".ms-seg__label").text())).toEqual([
+      "0.6 MP",
+      "1 MP",
+    ]);
+    expect(single[1]?.attributes("aria-checked")).toBe("true");
 
     const pair = tierSegments(mountPicker(1024, 576, "ltx2").wrapper);
     expect(pair.map((segment) => segment.get(".ms-seg__label").text())).toEqual([
@@ -194,11 +196,11 @@ describe("MobileResolutionPicker", () => {
     expect(picker.emitted("validity-change")?.at(-1)).toEqual([true]);
   });
 
-  it("disables orientations that the desktop family does not recommend", async () => {
+  it("exposes every orientation recommended by the shared video contract", async () => {
     const { wrapper, state } = mountPicker(1024, 576, "ltx2");
 
-    expect(wrapper.get("[data-orientation='square']").attributes()).toHaveProperty("disabled");
-    expect(wrapper.get("[data-orientation='portrait']").attributes()).toHaveProperty("disabled");
+    expect(wrapper.get("[data-orientation='square']").attributes("disabled")).toBeUndefined();
+    expect(wrapper.get("[data-orientation='portrait']").attributes("disabled")).toBeUndefined();
     expect(wrapper.get("[data-orientation='landscape']").attributes("aria-pressed")).toBe("true");
     expect(wrapper.findAll(".mobile-resolution-aspect").map((button) => button.text())).toEqual([
       "22:15",
@@ -208,7 +210,7 @@ describe("MobileResolutionPicker", () => {
 
     await wrapper.get("[data-orientation='portrait']").trigger("click");
     await flushPromises();
-    expect(state).toMatchObject({ width: 1024, height: 576 });
+    expect(state).toMatchObject({ width: 576, height: 1024 });
   });
 
   it("exposes controlled width and height update events", async () => {

--- a/desktop/src/mobile/MobileResolutionPicker.vue
+++ b/desktop/src/mobile/MobileResolutionPicker.vue
@@ -6,9 +6,10 @@ import {
   aspectRatioLabel,
   matchPreset,
   orientationLabel,
-  presetsForFamily,
+  presetsForModel,
   type ResolutionPreset,
 } from "../lib/resolutions";
+import type { ModelEntry } from "../lib/api/types";
 import {
   aspectsForOrientation,
   closestResolutionPreset,
@@ -23,9 +24,10 @@ import {
 const props = withDefaults(
   defineProps<{
     family: string;
+    model?: ModelEntry | null;
     disabled?: boolean;
   }>(),
-  { disabled: false },
+  { disabled: false, model: null },
 );
 
 const width = defineModel<number>("width", { required: true });
@@ -33,10 +35,14 @@ const height = defineModel<number>("height", { required: true });
 const emit = defineEmits<{ "validity-change": [valid: boolean] }>();
 
 const manualOpen = ref(false);
-const presets = computed(() => presetsForFamily(props.family));
-const currentPreset = computed(() => matchPreset(width.value, height.value, props.family));
+const presets = computed(() => presetsForModel(props.model ?? props.family));
+const currentPreset = computed(() =>
+  matchPreset(width.value, height.value, props.model ?? props.family),
+);
 const currentOrientation = computed(() => orientationLabel(width.value, height.value));
-const currentAspect = computed(() => aspectRatioLabel(width.value, height.value, props.family));
+const currentAspect = computed(() =>
+  aspectRatioLabel(width.value, height.value, props.model ?? props.family),
+);
 const customVisible = computed(() => manualOpen.value || !currentPreset.value);
 const resolutionError = computed(() => resolutionValidationError(width.value, height.value));
 watch(resolutionError, (next) => emit("validity-change", !next), { immediate: true });

--- a/desktop/src/mobile/MobileSequenceComposer.test.ts
+++ b/desktop/src/mobile/MobileSequenceComposer.test.ts
@@ -320,11 +320,10 @@ describe("MobileSequenceComposer guardrails", () => {
     picker.vm.$emit("pick", { filename: "opening.jpg", base64: "wire-bytes" });
     await wrapper!.vm.$nextTick();
 
-    expect(draft.clips[0]!.sourceImage).toEqual({
+    expect(draft.openingImage).toEqual({
       filename: "opening.jpg",
       base64: "wire-bytes",
     });
-    expect(draft.clips[1]!.sourceImage).toBeNull();
     expect(wrapper!.get("[data-test='mobile-sequence-source-preview']").attributes("src")).toBe(
       "data:image/jpeg;base64,wire-bytes",
     );

--- a/desktop/src/mobile/MobileSequenceComposer.vue
+++ b/desktop/src/mobile/MobileSequenceComposer.vue
@@ -25,11 +25,13 @@ import {
   type SequenceTransition,
 } from "@studio/lib/sequence";
 import { useSequenceDraftStore } from "@studio/stores/sequenceDraft";
+import { sequenceOpeningImageError } from "@studio/lib/sequenceForm";
 import type { ChainLimits } from "@studio/lib/api/chainTypes";
 import type { ApiTarget } from "../lib/api/client";
 import type { ModelEntry } from "../lib/api/types";
 import { base64ToDataUrl } from "../lib/image";
 import MobileImagePickerSheet, { type MobilePickedImage } from "./MobileImagePickerSheet.vue";
+import MobileAdvancedSheet from "./MobileAdvancedSheet.vue";
 import MobileSeamSheet from "./MobileSeamSheet.vue";
 
 const props = withDefaults(
@@ -62,6 +64,19 @@ const newClipFrames = computed(() =>
 );
 const locked = computed(() => props.submitting || props.busy);
 const imagePickerOpen = ref(false);
+const advancedOpen = ref(false);
+const activeClip = computed(
+  () => draft.clips.find((clip) => clip.id === draft.activeClipId) ?? draft.clips[0] ?? null,
+);
+const activeIndex = computed(() =>
+  activeClip.value ? draft.clips.findIndex((clip) => clip.id === activeClip.value?.id) : -1,
+);
+const advancedCount = computed(
+  () =>
+    Number(Boolean(draft.openingImage)) +
+    Number(Boolean(activeClip.value?.negativePrompt.trim())) +
+    Number(draft.enableAudio),
+);
 
 /** Durations are the 8n+1 grid up to the cap, strictly above the motion tail;
  *  an off-grid loaded value stays visible rather than silently re-snapping. */
@@ -97,7 +112,13 @@ const unsupportedReason = computed(() =>
     ? (props.chainLimits.sequence_unsupported_reason ?? "This model can't render a clip sequence.")
     : null,
 );
-const blockingReason = computed(() => unsupportedReason.value ?? validation.value[0] ?? null);
+const blockingReason = computed(
+  () =>
+    unsupportedReason.value ??
+    sequenceOpeningImageError(draft.openingImage, draft.mediaRestoring) ??
+    validation.value[0] ??
+    null,
+);
 const submitError = computed(() => (props.error ? friendlySequenceError(props.error) : ""));
 
 const clipLabel = (index: number) => (index === 0 ? "opening" : `clip ${index + 1}`);
@@ -136,9 +157,7 @@ function submit(): void {
 }
 
 function setOpeningImage(image: MobilePickedImage): void {
-  const opening = draft.clips[0];
-  if (!opening) return;
-  opening.sourceImage = { filename: image.filename, base64: image.base64 };
+  draft.openingImage = { filename: image.filename, base64: image.base64 };
   imagePickerOpen.value = false;
 }
 
@@ -185,38 +204,6 @@ function sourceImageMime(filename: string): string {
             :placeholder="index === 0 ? 'How does the sequence begin?' : 'What happens next?'"
             :disabled="locked"
           />
-          <div v-if="index === 0" class="mobile-sequence-source">
-            <img
-              v-if="clip.sourceImage?.base64"
-              :src="
-                base64ToDataUrl(
-                  clip.sourceImage.base64 ?? '',
-                  sourceImageMime(clip.sourceImage.filename),
-                )
-              "
-              :alt="clip.sourceImage.filename"
-              data-test="mobile-sequence-source-preview"
-            />
-            <button
-              type="button"
-              class="secondary-button"
-              data-test="mobile-sequence-source-pick"
-              :disabled="locked || !target"
-              @click="imagePickerOpen = true"
-            >
-              {{ clip.sourceImage ? "Replace opening image" : "Attach opening image" }}
-            </button>
-            <button
-              v-if="clip.sourceImage"
-              type="button"
-              class="secondary-button"
-              data-test="mobile-sequence-source-clear"
-              :disabled="locked"
-              @click="clip.sourceImage = null"
-            >
-              Remove
-            </button>
-          </div>
           <details class="mobile-native-disclosure">
             <summary>
               <span>Clip tools</span>
@@ -273,14 +260,15 @@ function sourceImageMime(filename: string): string {
       <slot name="settings" />
     </details>
 
-    <label
-      v-if="chainLimits?.supports_audio"
-      class="mobile-sequence-check"
-      data-test="mobile-sequence-audio"
+    <button
+      type="button"
+      class="secondary-button"
+      data-test="mobile-sequence-open-advanced"
+      @click="advancedOpen = true"
     >
-      <input v-model="draft.enableAudio" type="checkbox" :disabled="locked" />
-      Generate audio
-    </label>
+      Advanced sequence controls
+      <span v-if="advancedCount > 0">· {{ advancedCount }} on</span>
+    </button>
 
     <p
       v-if="blockingReason"
@@ -322,6 +310,65 @@ function sourceImageMime(filename: string): string {
       @update:fade-frames="setSeamFade"
       @close="openSeamId = null"
     />
+    <MobileAdvancedSheet
+      :open="advancedOpen"
+      :count="advancedCount"
+      @close="advancedOpen = false"
+      @reset="
+        draft.openingImage = null;
+        draft.enableAudio = false;
+        draft.clips.forEach((clip) => (clip.negativePrompt = ''));
+      "
+    >
+      <details class="mobile-native-disclosure" open data-test="mobile-sequence-advanced-opening">
+        <summary>
+          <span>Opening sequence image</span>
+          <small>{{ draft.openingImage?.filename ?? "Original starting frame" }}</small>
+        </summary>
+        <img
+          v-if="draft.openingImage?.base64"
+          :src="
+            base64ToDataUrl(
+              draft.openingImage.base64 ?? '',
+              sourceImageMime(draft.openingImage.filename),
+            )
+          "
+          :alt="draft.openingImage.filename"
+          data-test="mobile-sequence-source-preview"
+        />
+        <button
+          type="button"
+          class="secondary-button"
+          data-test="mobile-sequence-source-pick"
+          :disabled="locked || !target"
+          @click="imagePickerOpen = true"
+        >
+          {{ draft.openingImage ? "Replace opening image" : "Attach opening image" }}
+        </button>
+        <button
+          v-if="draft.openingImage"
+          type="button"
+          class="secondary-button"
+          data-test="mobile-sequence-source-clear"
+          :disabled="locked"
+          @click="draft.openingImage = null"
+        >
+          Remove
+        </button>
+      </details>
+      <label v-if="activeClip" class="field" data-test="mobile-sequence-advanced-negative">
+        <span>Clip {{ activeIndex + 1 }} negative prompt</span>
+        <input v-model="activeClip.negativePrompt" class="control" placeholder="Optional" />
+      </label>
+      <label
+        v-if="chainLimits?.supports_audio"
+        class="mobile-sequence-check"
+        data-test="mobile-sequence-audio"
+      >
+        <input v-model="draft.enableAudio" type="checkbox" :disabled="locked" />
+        Generate audio
+      </label>
+    </MobileAdvancedSheet>
     <MobileImagePickerSheet
       :open="imagePickerOpen"
       :target="target"

--- a/desktop/src/mobile/MobileSharedParams.vue
+++ b/desktop/src/mobile/MobileSharedParams.vue
@@ -9,12 +9,14 @@
 import { computed } from "vue";
 import { fpsValidationError } from "../lib/generateValidation";
 import type { GenerateForm } from "../lib/generateForm";
+import type { ModelEntry } from "../lib/api/types";
 import MobileResolutionPicker from "./MobileResolutionPicker.vue";
 import MobileSeedPicker from "./MobileSeedPicker.vue";
 
 const props = withDefaults(
   defineProps<{
     form: GenerateForm;
+    model?: ModelEntry | null;
     lastSeed: number | null;
     disabled?: boolean;
     /** Sequence output surfaces frame rate outside the Advanced sheet. */
@@ -22,7 +24,7 @@ const props = withDefaults(
     stepsError?: string | null;
     guidanceError?: string | null;
   }>(),
-  { disabled: false, showFps: false, stepsError: null, guidanceError: null },
+  { disabled: false, showFps: false, stepsError: null, guidanceError: null, model: null },
 );
 
 const emit = defineEmits<{
@@ -38,6 +40,7 @@ const fpsError = computed(() => (props.showFps ? fpsValidationError(props.form.f
     v-model:width="form.width"
     v-model:height="form.height"
     :family="form.family"
+    :model="model"
     :disabled="disabled"
     @validity-change="emit('resolution-validity', $event)"
   />

--- a/desktop/src/views/GenerateView.sequence.test.ts
+++ b/desktop/src/views/GenerateView.sequence.test.ts
@@ -423,6 +423,7 @@ describe("GenerateView — sequence output", () => {
     draft.ensureClips(25);
     draft.clips[0]!.prompt = "opening";
     draft.clips[1]!.prompt = "landing";
+    draft.openingImage = { filename: "opening.png", base64: "QUJD" };
     draft.enableAudio = false; // user turned audio OFF during the edit
     draft.loadFromJob(
       {
@@ -433,6 +434,7 @@ describe("GenerateView — sequence output", () => {
       },
       draft.clips.map((c) => ({ ...c })),
       false,
+      draft.openingImage,
     );
 
     const amendCalls: unknown[] = [];
@@ -463,6 +465,8 @@ describe("GenerateView — sequence output", () => {
     expect(amendCalls.length).toBe(1);
     const body = JSON.parse((amendCalls[0] as { body: string }).body);
     expect(body.enable_audio).toBe(false);
+    expect(body.stages[0].source_image).toBe("QUJD");
+    expect(body.stages[1].source_image).toBeUndefined();
   });
 
   it("guides to Discover when no chain-capable video model is installed", async () => {

--- a/desktop/src/views/GenerateView.vue
+++ b/desktop/src/views/GenerateView.vue
@@ -710,7 +710,9 @@ const chainLevelDirty = computed(
   () =>
     draft.editing !== null &&
     editSharedBaseline.value !== null &&
-    editSharedBaseline.value !== sharedSnapshot(),
+    (editSharedBaseline.value !== sharedSnapshot() ||
+      JSON.stringify(draft.editing.baselineOpeningImage ?? null) !==
+        JSON.stringify(draft.openingImage)),
 );
 
 /** `?output=sequence` deep-links (palette, menu, legacy /chains) are consumed
@@ -1121,6 +1123,7 @@ async function generateSequence() {
     const request = buildChainRequest(sequenceParams(form, entry), draft.clips, {
       motionTailFrames: sequenceMotionTail.value,
       enableAudio: draft.enableAudio,
+      openingImage: draft.openingImage,
     });
     if (draft.editing) {
       const editing = draft.editing;
@@ -1224,6 +1227,7 @@ async function loadSequence(payload: { hostId: string; jobId: string }, editing:
         },
         loaded.clips,
         loaded.enableAudio,
+        loaded.openingImage,
       );
       editSharedBaseline.value = sharedSnapshot();
     } else {
@@ -1233,6 +1237,7 @@ async function loadSequence(payload: { hostId: string; jobId: string }, editing:
       draft.clips.splice(0, draft.clips.length, ...loaded.clips);
       draft.activeClipId = loaded.clips[0]?.id ?? null;
       draft.enableAudio = loaded.enableAudio;
+      draft.openingImage = loaded.openingImage;
     }
     sequenceStageClipIdsByJob.set(
       `${payload.hostId}:${payload.jobId}`,

--- a/flake.nix
+++ b/flake.nix
@@ -746,20 +746,18 @@
               let
                 moduleWarnings =
                   cudaArch: package:
-                  (
-                    lib.nixosSystem {
-                      inherit system;
-                      modules = [
-                        ./nix/module.nix
-                        {
-                          services.mold = {
-                            enable = true;
-                            inherit cudaArch package;
-                          };
-                        }
-                      ];
-                    }
-                  ).config.warnings;
+                  (lib.nixosSystem {
+                    inherit system;
+                    modules = [
+                      ./nix/module.nix
+                      {
+                        services.mold = {
+                          enable = true;
+                          inherit cudaArch package;
+                        };
+                      }
+                    ];
+                  }).config.warnings;
                 correctPairs = [
                   {
                     cudaArch = "ampere";
@@ -778,14 +776,10 @@
                     package = mkMold "120";
                   }
                 ];
-                correct = builtins.all (
-                  pair: moduleWarnings pair.cudaArch pair.package == [ ]
-                ) correctPairs;
+                correct = builtins.all (pair: moduleWarnings pair.cudaArch pair.package == [ ]) correctPairs;
                 mismatch = builtins.length (moduleWarnings "ada" (mkMold "86")) == 1;
                 unknownPackage =
-                  builtins.length (
-                    moduleWarnings "ada" (pkgs.writeShellScriptBin "mold" "exit 0")
-                  ) == 1;
+                  builtins.length (moduleWarnings "ada" (pkgs.writeShellScriptBin "mold" "exit 0")) == 1;
               in
               assert correct;
               assert mismatch;

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -299,26 +299,28 @@ in
   };
 
   config = lib.mkIf cfg.enable {
-    warnings = lib.optionals (
-      cfg.cudaArch != null
-      && packageCudaComputeCapability
-      != expectedCudaComputeCapability.${cfg.cudaArch}
-    ) [
-      (
-        ''
-          services.mold.cudaArch is "${cfg.cudaArch}" (sm_${expectedCudaComputeCapability.${cfg.cudaArch}})
-          but services.mold.package declares ${
-            if packageCudaComputeCapability == null then
-              "no Mold CUDA capability metadata"
-            else
-              "sm_${packageCudaComputeCapability}"
-          }. Set package to the matching Mold flake output.
-        ''
-        + lib.optionalString (cfg.cudaArch == "blackwell-datacenter") ''
-          B200/B300 support is simulated, not hardware-qualified.
-        ''
-      )
-    ];
+    warnings =
+      lib.optionals
+        (
+          cfg.cudaArch != null
+          && packageCudaComputeCapability != expectedCudaComputeCapability.${cfg.cudaArch}
+        )
+        [
+          (
+            ''
+              services.mold.cudaArch is "${cfg.cudaArch}" (sm_${expectedCudaComputeCapability.${cfg.cudaArch}})
+              but services.mold.package declares ${
+                if packageCudaComputeCapability == null then
+                  "no Mold CUDA capability metadata"
+                else
+                  "sm_${packageCudaComputeCapability}"
+              }. Set package to the matching Mold flake output.
+            ''
+            + lib.optionalString (cfg.cudaArch == "blackwell-datacenter") ''
+              B200/B300 support is simulated, not hardware-qualified.
+            ''
+          )
+        ];
 
     services.mold.modelsDir = lib.mkDefault "${cfg.homeDir}/models";
 

--- a/studio/lib/draftMediaStore.ts
+++ b/studio/lib/draftMediaStore.ts
@@ -18,6 +18,26 @@ function clone<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
 }
 
+function recordsMatch(
+  left: DraftMediaRecord,
+  right: DraftMediaRecord,
+): boolean {
+  if (left.base64 !== right.base64) return false;
+  const leftRecord = left as Record<string, unknown>;
+  const rightRecord = right as Record<string, unknown>;
+  const keys = new Set([
+    ...Object.keys(leftRecord),
+    ...Object.keys(rightRecord),
+  ]);
+  for (const key of keys) {
+    if (key === "base64") continue;
+    if (JSON.stringify(leftRecord[key]) !== JSON.stringify(rightRecord[key])) {
+      return false;
+    }
+  }
+  return true;
+}
+
 function openDb(): Promise<IDBDatabase | null> {
   if (typeof indexedDB === "undefined") return Promise.resolve(null);
   return new Promise((resolve) => {
@@ -52,6 +72,8 @@ export async function putDraftMedia<T extends DraftMediaRecord>(
   media: T,
 ): Promise<void> {
   if (!media.draftId || !media.base64) return;
+  const existing = memory.get(media.draftId);
+  if (existing && recordsMatch(existing, media)) return;
   const saved = clone(media);
   memory.set(media.draftId, saved);
   await withStore("readwrite", (store) => store.put(saved));
@@ -61,7 +83,10 @@ export async function getDraftMedia<T extends DraftMediaRecord>(
   draftId: string,
 ): Promise<T | null> {
   const fromDb = await withStore<T>("readonly", (store) => store.get(draftId));
-  if (fromDb) return fromDb;
+  if (fromDb) {
+    memory.set(draftId, clone(fromDb));
+    return fromDb;
+  }
   const fromMemory = memory.get(draftId);
   return fromMemory ? (clone(fromMemory) as T) : null;
 }

--- a/studio/lib/draftMediaStore.ts
+++ b/studio/lib/draftMediaStore.ts
@@ -1,0 +1,76 @@
+/**
+ * Quota-safe media persistence for Create drafts.
+ *
+ * localStorage owns the small form metadata while IndexedDB owns base64 media.
+ * The structural type keeps this helper shared by web, desktop, and iPhone.
+ */
+export interface DraftMediaRecord {
+  draftId?: string;
+  base64?: string | null;
+}
+
+const DB_NAME = "mold-generate-drafts";
+const STORE_NAME = "media";
+const DB_VERSION = 1;
+const memory = new Map<string, DraftMediaRecord>();
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function openDb(): Promise<IDBDatabase | null> {
+  if (typeof indexedDB === "undefined") return Promise.resolve(null);
+  return new Promise((resolve) => {
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => {
+      if (!req.result.objectStoreNames.contains(STORE_NAME)) {
+        req.result.createObjectStore(STORE_NAME, { keyPath: "draftId" });
+      }
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => resolve(null);
+  });
+}
+
+async function withStore<T>(
+  mode: IDBTransactionMode,
+  fn: (store: IDBObjectStore) => IDBRequest<T>,
+): Promise<T | null> {
+  const db = await openDb();
+  if (!db) return null;
+  return new Promise((resolve) => {
+    const tx = db.transaction(STORE_NAME, mode);
+    const req = fn(tx.objectStore(STORE_NAME));
+    req.onsuccess = () => resolve(req.result ?? null);
+    req.onerror = () => resolve(null);
+    tx.oncomplete = () => db.close();
+    tx.onerror = () => db.close();
+  });
+}
+
+export async function putDraftMedia<T extends DraftMediaRecord>(
+  media: T,
+): Promise<void> {
+  if (!media.draftId || !media.base64) return;
+  const saved = clone(media);
+  memory.set(media.draftId, saved);
+  await withStore("readwrite", (store) => store.put(saved));
+}
+
+export async function getDraftMedia<T extends DraftMediaRecord>(
+  draftId: string,
+): Promise<T | null> {
+  const fromDb = await withStore<T>("readonly", (store) => store.get(draftId));
+  if (fromDb) return fromDb;
+  const fromMemory = memory.get(draftId);
+  return fromMemory ? (clone(fromMemory) as T) : null;
+}
+
+export async function deleteDraftMedia(draftId: string): Promise<void> {
+  memory.delete(draftId);
+  await withStore("readwrite", (store) => store.delete(draftId));
+}
+
+export function clearMemoryDraftsForTest() {
+  memory.clear();
+}

--- a/studio/lib/resolutions.test.ts
+++ b/studio/lib/resolutions.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_GENERATION_PIXELS,
+  megapixelLabel,
+  presetsForFamily,
+  presetsForModel,
+} from "./resolutions";
+
+describe("shared resolution contract", () => {
+  it("keeps every cross-surface fallback runnable under the server ceiling", () => {
+    for (const family of [
+      "sd15",
+      "sdxl",
+      "sd3",
+      "flux",
+      "flux2",
+      "z-image",
+      "qwen-image",
+      "qwen-image-edit",
+      "wuerstchen",
+      "ltx-video",
+      "ltx2",
+    ]) {
+      for (const preset of presetsForFamily(family)) {
+        expect(preset.width % 16, `${family} ${preset.label}`).toBe(0);
+        expect(preset.height % 16, `${family} ${preset.label}`).toBe(0);
+        expect(
+          preset.width * preset.height,
+          `${family} ${preset.label}`,
+        ).toBeLessThanOrEqual(MAX_GENERATION_PIXELS);
+      }
+    }
+  });
+
+  it("prefers exact server-advertised buckets and filters invalid rows", () => {
+    expect(
+      presetsForModel({
+        family: "flux2",
+        max_pixels: 1_800_000,
+        dimension_alignment: 16,
+        recommended_dimensions: [
+          { width: 1328, height: 1328 },
+          { width: 1408, height: 1408 },
+          { width: 1001, height: 1001 },
+        ],
+      }),
+    ).toEqual([
+      {
+        label: "1:1 · 1328×1328",
+        aspect: "1:1",
+        width: 1328,
+        height: 1328,
+      },
+    ]);
+    expect(megapixelLabel(1328, 1328)).toBe("1.8 MP");
+  });
+
+  it("keeps the runnable LTX-2 landscape bucket shared by every client", () => {
+    expect(presetsForFamily("ltx2")).toContainEqual({
+      label: "16:9 · 1216×704",
+      aspect: "16:9",
+      width: 1216,
+      height: 704,
+    });
+  });
+});

--- a/studio/lib/resolutions.ts
+++ b/studio/lib/resolutions.ts
@@ -1,0 +1,204 @@
+/** Shared, server-aligned resolution presets for web, desktop, and iPhone. */
+
+export interface ResolutionPreset {
+  label: string;
+  aspect: string;
+  width: number;
+  height: number;
+}
+
+export interface RecommendedDimensions {
+  width: number;
+  height: number;
+}
+
+export interface ModelResolutionContract {
+  family: string;
+  default_width?: number;
+  default_height?: number;
+  max_pixels?: number | null;
+  recommended_dimensions?: RecommendedDimensions[] | null;
+  dimension_alignment?: number | null;
+}
+
+export const MAX_GENERATION_PIXELS = 1_800_000;
+
+function gcd(a: number, b: number): number {
+  let x = Math.max(1, Math.round(Math.abs(a)));
+  let y = Math.max(1, Math.round(Math.abs(b)));
+  while (y !== 0) [x, y] = [y, x % y];
+  return x;
+}
+
+export function rawAspectRatioLabel(width: number, height: number): string {
+  const divisor = gcd(width, height);
+  return `${Math.round(width) / divisor}:${Math.round(height) / divisor}`;
+}
+
+const p = (
+  width: number,
+  height: number,
+  aspect = rawAspectRatioLabel(width, height),
+) => ({
+  label: `${aspect} · ${width}×${height}`,
+  aspect,
+  width,
+  height,
+});
+
+const SD15 = [p(512, 512), p(512, 768), p(768, 512), p(384, 512), p(512, 384)];
+const SDXL = [
+  p(1024, 1024),
+  p(1152, 896),
+  p(896, 1152),
+  p(1216, 832),
+  p(832, 1216),
+  p(1344, 768),
+  p(768, 1344),
+  p(1536, 640),
+  p(640, 1536),
+];
+const SD3 = SDXL.slice(0, 7);
+const FLUX = [
+  p(1024, 1024),
+  p(1024, 768),
+  p(768, 1024),
+  p(1024, 576),
+  p(576, 1024),
+  p(768, 768),
+];
+const ZIMAGE = [p(1024, 1024), p(1024, 768), p(768, 1024)];
+const QWEN_IMAGE = [
+  p(1328, 1328),
+  p(1024, 1024),
+  p(1152, 896),
+  p(896, 1152),
+  p(1216, 832),
+  p(832, 1216),
+  p(1344, 768),
+  p(768, 1344),
+  p(1664, 928, "≈16:9"),
+  p(928, 1664, "≈9:16"),
+  p(768, 768),
+  p(512, 512),
+];
+const VIDEO = [
+  p(704, 480, "22:15"),
+  p(768, 512),
+  p(512, 512),
+  p(1024, 576),
+  p(1216, 704, "16:9"),
+  p(576, 1024),
+  p(768, 768),
+  p(512, 768),
+];
+
+const BY_FAMILY: Record<string, ResolutionPreset[]> = {
+  sd15: SD15,
+  sdxl: SDXL,
+  sd3: SD3,
+  flux: FLUX,
+  flux2: FLUX,
+  zimage: ZIMAGE,
+  "z-image": ZIMAGE,
+  "qwen-image": QWEN_IMAGE,
+  "qwen-image-edit": QWEN_IMAGE,
+  wuerstchen: [p(1024, 1024)],
+  "ltx-video": VIDEO,
+  ltx2: VIDEO,
+};
+
+export function presetsForFamily(family: string): ResolutionPreset[] {
+  return BY_FAMILY[family] ?? FLUX;
+}
+
+export function presetsForModel(
+  model: ModelResolutionContract | string,
+): ResolutionPreset[] {
+  if (typeof model === "string") return presetsForFamily(model);
+  const advertised = model.recommended_dimensions ?? [];
+  if (advertised.length === 0) return presetsForFamily(model.family);
+  const maxPixels = model.max_pixels ?? MAX_GENERATION_PIXELS;
+  const alignment = model.dimension_alignment ?? 16;
+  return advertised
+    .filter(
+      ({ width, height }) =>
+        width > 0 &&
+        height > 0 &&
+        width % alignment === 0 &&
+        height % alignment === 0 &&
+        width * height <= maxPixels,
+    )
+    .map(({ width, height }) => p(width, height));
+}
+
+export function matchPreset(
+  width: number,
+  height: number,
+  model: ModelResolutionContract | string,
+): ResolutionPreset | null {
+  return (
+    presetsForModel(model).find(
+      (r) => r.width === width && r.height === height,
+    ) ?? null
+  );
+}
+
+export function aspectRatioLabel(
+  width: number,
+  height: number,
+  model: ModelResolutionContract | string,
+): string {
+  return (
+    matchPreset(width, height, model)?.aspect ??
+    rawAspectRatioLabel(width, height)
+  );
+}
+
+export function orientationLabel(
+  width: number,
+  height: number,
+): "Landscape" | "Portrait" | "Square" {
+  if (width === height) return "Square";
+  return width > height ? "Landscape" : "Portrait";
+}
+
+export function presetsNearRatio(
+  presets: readonly ResolutionPreset[],
+  ratio: number,
+  tolerance = 0.09,
+): ResolutionPreset[] {
+  if (!(ratio > 0) || presets.length === 0) return [];
+  const ranked = presets
+    .map((preset) => ({
+      preset,
+      diff: Math.abs(preset.width / preset.height - ratio) / ratio,
+    }))
+    .sort((a, b) => a.diff - b.diff);
+  const best = ranked[0]?.diff ?? Number.POSITIVE_INFINITY;
+  return ranked
+    .filter(({ diff }) => diff <= Math.max(best + Number.EPSILON, tolerance))
+    .map(({ preset }) => preset)
+    .sort((a, b) => a.width * a.height - b.width * b.height);
+}
+
+export function closestResolutionPreset(
+  presets: readonly ResolutionPreset[],
+  width: number,
+  height: number,
+): ResolutionPreset | null {
+  if (presets.length === 0) return null;
+  const area = width * height;
+  return (
+    [...presets].sort(
+      (a, b) =>
+        Math.abs(a.width * a.height - area) -
+        Math.abs(b.width * b.height - area),
+    )[0] ?? null
+  );
+}
+
+export function megapixelLabel(width: number, height: number): string {
+  const value = ((width * height) / 1_000_000).toFixed(1).replace(/\.0$/, "");
+  return `${value} MP`;
+}

--- a/studio/lib/sequenceForm.test.ts
+++ b/studio/lib/sequenceForm.test.ts
@@ -95,13 +95,13 @@ describe("buildChainRequest", () => {
     const clips = [
       clip({
         negativePrompt: "no rain",
-        sourceImage: { filename: "open.png", base64: "QUJD" },
       }),
       clip({ prompt: "b" }),
     ];
     const req = buildChainRequest(shared(), clips, {
       motionTailFrames: 17,
       enableAudio: false,
+      openingImage: { filename: "open.png", base64: "QUJD" },
     });
     expect(req.stages[0]?.negative_prompt).toBe("no rain");
     expect(req.stages[0]?.source_image).toBe("QUJD");
@@ -124,7 +124,7 @@ describe("script round-trip", () => {
         enable_audio: true,
       },
       stages: [
-        { prompt: "opening", frames: 97 },
+        { prompt: "opening", frames: 97, source_image_b64: "QUJD" },
         { prompt: "landing", frames: 33, transition: "fade", fade_frames: 8 },
       ],
     };
@@ -135,6 +135,7 @@ describe("script round-trip", () => {
     expect(loaded.clips[0]?.frames).toBe(97);
     expect(loaded.clips[1]?.transition).toBe("fade");
     expect(loaded.clips[1]?.fadeFrames).toBe(8);
+    expect(loaded.openingImage?.base64).toBe("QUJD");
     expect(loaded.enableAudio).toBe(true);
     expect(loaded.shared.model).toBe("ltx-2-19b-distilled:fp8");
     expect(loaded.shared.width).toBe(1216);
@@ -142,11 +143,23 @@ describe("script round-trip", () => {
     const back = clipsToChainScript(shared(), loaded.clips, {
       motionTailFrames: 17,
       enableAudio: true,
+      openingImage: loaded.openingImage,
     });
     expect(back.schema).toBe("mold.chain.v1");
     expect(back.stages).toHaveLength(2);
     expect(back.stages[1]?.transition).toBe("fade");
     expect(back.stages[1]?.fade_frames).toBe(8);
+    expect(back.stages[0]?.source_image_b64).toBe("QUJD");
+  });
+
+  it("refuses to silently drop an opening image whose payload is still restoring", () => {
+    expect(() =>
+      buildChainRequest(shared(), [clip(), clip()], {
+        motionTailFrames: 17,
+        enableAudio: false,
+        openingImage: { filename: "open.png", base64: null },
+      }),
+    ).toThrow("Reattach opening image open.png");
   });
 });
 

--- a/studio/lib/sequenceForm.ts
+++ b/studio/lib/sequenceForm.ts
@@ -19,6 +19,8 @@ import type { SequenceTransition } from "./sequence";
 
 export interface SequenceClipSourceImage {
   filename: string;
+  /** IndexedDB key used to restore the payload without localStorage quota risk. */
+  draftId?: string;
   /** Raw base64 payload; stripped before persistence (quota), kept in memory. */
   base64: string | null;
 }
@@ -62,7 +64,11 @@ export function newSequenceClip(frames: number): SequenceClipForm {
   };
 }
 
-function stageForWire(clip: SequenceClipForm, idx: number): ChainStageWire {
+function stageForWire(
+  clip: SequenceClipForm,
+  idx: number,
+  openingImage: SequenceClipSourceImage | null,
+): ChainStageWire {
   const transition: SequenceTransition = idx === 0 ? "smooth" : clip.transition;
   const stage: ChainStageWire = {
     prompt: clip.prompt,
@@ -71,20 +77,39 @@ function stageForWire(clip: SequenceClipForm, idx: number): ChainStageWire {
   };
   if (idx > 0 && transition === "fade") stage.fade_frames = clip.fadeFrames;
   if (clip.negativePrompt.trim()) stage.negative_prompt = clip.negativePrompt;
-  if (clip.sourceImage?.base64) stage.source_image = clip.sourceImage.base64;
+  const sourceImage = idx === 0 ? openingImage : clip.sourceImage;
+  if (sourceImage?.base64) stage.source_image = sourceImage.base64;
   return stage;
+}
+
+export function sequenceOpeningImageError(
+  openingImage: SequenceClipSourceImage | null,
+  restoring = false,
+): string | null {
+  if (!openingImage || openingImage.base64) return null;
+  return restoring
+    ? `Restoring opening image ${openingImage.filename}…`
+    : `Reattach opening image ${openingImage.filename} before generating.`;
 }
 
 /** Build the `POST /api/chain-jobs` request from the LIVE shared params. */
 export function buildChainRequest(
   shared: SequenceSharedParams,
   clips: readonly SequenceClipForm[],
-  opts: { motionTailFrames: number; enableAudio: boolean },
+  opts: {
+    motionTailFrames: number;
+    enableAudio: boolean;
+    openingImage?: SequenceClipSourceImage | null;
+  },
 ): ChainRequestWire {
+  const openingError = sequenceOpeningImageError(opts.openingImage ?? null);
+  if (openingError) throw new Error(openingError);
   const seed = shared.seed.trim() === "" ? undefined : Number(shared.seed);
   const req: ChainRequestWire = {
     model: shared.model,
-    stages: clips.map(stageForWire),
+    stages: clips.map((clip, idx) =>
+      stageForWire(clip, idx, opts.openingImage ?? null),
+    ),
     motion_tail_frames: opts.motionTailFrames,
     width: shared.width,
     height: shared.height,
@@ -105,7 +130,9 @@ export function chainScriptToClips(script: ChainScript): {
   shared: Partial<SequenceSharedParams>;
   enableAudio: boolean;
   motionTailFrames: number | null;
+  openingImage: SequenceClipSourceImage | null;
 } {
+  let openingImage: SequenceClipSourceImage | null = null;
   const clips = script.stages.map((stage, idx) => {
     const clip = newSequenceClip(stage.frames ?? 97);
     clip.prompt = stage.prompt;
@@ -113,10 +140,12 @@ export function chainScriptToClips(script: ChainScript): {
     clip.fadeFrames = stage.fade_frames ?? DEFAULT_FADE_FRAMES;
     clip.negativePrompt = stage.negative_prompt ?? "";
     if (stage.source_image_b64) {
-      clip.sourceImage = {
+      const sourceImage = {
         filename: stage.source_image_path ?? "opening image",
         base64: stage.source_image_b64,
       };
+      if (idx === 0) openingImage = sourceImage;
+      else clip.sourceImage = sourceImage;
     }
     return clip;
   });
@@ -133,6 +162,7 @@ export function chainScriptToClips(script: ChainScript): {
     shared,
     enableAudio: chain.enable_audio === true,
     motionTailFrames: chain.motion_tail_frames ?? null,
+    openingImage,
   };
 }
 
@@ -140,7 +170,11 @@ export function chainScriptToClips(script: ChainScript): {
 export function clipsToChainScript(
   shared: SequenceSharedParams,
   clips: readonly SequenceClipForm[],
-  opts: { motionTailFrames: number; enableAudio: boolean },
+  opts: {
+    motionTailFrames: number;
+    enableAudio: boolean;
+    openingImage?: SequenceClipSourceImage | null;
+  },
 ): ChainScript {
   return {
     schema: "mold.chain.v1",
@@ -165,8 +199,9 @@ export function clipsToChainScript(
         stage.fade_frames = clip.fadeFrames;
       if (clip.negativePrompt.trim())
         stage.negative_prompt = clip.negativePrompt;
-      if (clip.sourceImage?.base64)
-        stage.source_image_b64 = clip.sourceImage.base64;
+      const sourceImage =
+        idx === 0 ? (opts.openingImage ?? null) : clip.sourceImage;
+      if (sourceImage?.base64) stage.source_image_b64 = sourceImage.base64;
       return stage;
     }),
   };

--- a/studio/stores/sequenceDraft.test.ts
+++ b/studio/stores/sequenceDraft.test.ts
@@ -8,6 +8,7 @@ import {
   setSequenceDraftStorage,
   useSequenceDraftStore,
 } from "./sequenceDraft";
+import { clearMemoryDraftsForTest } from "../lib/draftMediaStore";
 
 function memoryStorage() {
   const values = new Map<string, string>();
@@ -29,6 +30,7 @@ describe("sequence draft store", () => {
   beforeEach(() => {
     localStorage = memoryStorage();
     setSequenceDraftStorage(localStorage);
+    clearMemoryDraftsForTest();
     vi.useFakeTimers();
   });
   afterEach(() => {
@@ -59,19 +61,22 @@ describe("sequence draft store", () => {
     expect(next.clips[0]?.prompt).toBe("a kingfisher waits");
   });
 
-  it("strips source-image payloads from persistence but keeps filenames", () => {
+  it("restores the sequence-level opening image from quota-safe media storage", async () => {
     const store = freshStore();
     store.hydrate();
     store.ensureClips(97);
-    const first = store.clips[0];
-    if (first) first.sourceImage = { filename: "open.png", base64: "QUJD" };
+    store.openingImage = { filename: "open.png", base64: "QUJD" };
     vi.advanceTimersByTime(1000);
 
     const saved = JSON.parse(localStorage.getItem(SEQUENCE_DRAFT_KEY)!);
-    expect(saved.clips[0].sourceImage.filename).toBe("open.png");
-    expect(saved.clips[0].sourceImage.base64).toBeNull();
+    expect(saved.openingImage.filename).toBe("open.png");
+    expect(saved.openingImage.base64).toBeNull();
     // In-memory payload stays intact.
-    expect(store.clips[0]?.sourceImage?.base64).toBe("QUJD");
+    expect(store.openingImage?.base64).toBe("QUJD");
+
+    const reloaded = freshStore();
+    reloaded.hydrate();
+    await vi.waitFor(() => expect(reloaded.openingImage?.base64).toBe("QUJD"));
   });
 
   it("parks clips while keeping one-shot and sequence prompts independent", () => {
@@ -104,6 +109,7 @@ describe("sequence draft store", () => {
     const store = freshStore();
     store.hydrate();
     store.ensureClips(97);
+    store.openingImage = { filename: "opening.png", base64: "AAAA" };
     const [a, b] = store.clips;
     store.removeClip(a!.id);
     expect(store.clips).toHaveLength(2);
@@ -114,6 +120,33 @@ describe("sequence draft store", () => {
     expect(store.clips[0]?.id).toBe(c!.id);
     expect(store.clips[1]?.id).toBe(a!.id);
     expect(store.clips[2]?.id).toBe(b!.id);
+    expect(store.openingImage).toEqual({
+      filename: "opening.png",
+      base64: "AAAA",
+    });
+  });
+
+  it("snapshots the opening image and audio with an edit session", () => {
+    const store = freshStore();
+    store.hydrate();
+    store.ensureClips(97);
+    store.loadFromJob(
+      {
+        jobId: "job-1",
+        hostId: "host-1",
+        baseline: store.clips.map((clip) => ({ ...clip })),
+        completedStages: 2,
+      },
+      store.clips,
+      true,
+      { filename: "original.png", base64: "ORIGINAL" },
+    );
+
+    expect(store.editing?.baselineOpeningImage).toEqual({
+      filename: "original.png",
+      base64: "ORIGINAL",
+    });
+    expect(store.editing?.baselineEnableAudio).toBe(true);
   });
 
   it("applies a transition to one seam or every seam", () => {

--- a/studio/stores/sequenceDraft.ts
+++ b/studio/stores/sequenceDraft.ts
@@ -24,6 +24,11 @@ import {
   type SequenceClipSourceImage,
 } from "../lib/sequenceForm";
 import { chainScriptToClips } from "../lib/sequenceForm";
+import {
+  deleteDraftMedia,
+  getDraftMedia,
+  putDraftMedia,
+} from "../lib/draftMediaStore";
 import type { OutputMode, SequenceTransition } from "../lib/sequence";
 import type { ChainScript } from "../lib/api/chainTypes";
 
@@ -63,6 +68,10 @@ export interface SequenceEditSession {
   hostId: string;
   /** The loaded job's clips at load time — `stageInvalidation`'s baseline. */
   baseline: SequenceClipForm[];
+  /** The durable job's opening frame, restored when edits are discarded. */
+  baselineOpeningImage?: SequenceClipSourceImage | null;
+  /** The durable job's audio choice, restored when edits are discarded. */
+  baselineEnableAudio?: boolean;
   /** Leading stages the job has actually completed (cache ceiling). */
   completedStages: number;
 }
@@ -76,6 +85,8 @@ interface PersistedDraftV1 {
   version: 1;
   output: OutputMode;
   clips: PersistedClip[];
+  openingImage?:
+    (Omit<SequenceClipSourceImage, "base64"> & { base64: null }) | null;
   enableAudio: boolean;
   lastSingleModel: string | null;
 }
@@ -89,6 +100,8 @@ function persistableClips(clips: readonly SequenceClipForm[]): PersistedClip[] {
   }));
 }
 
+const OPENING_MEDIA_ID = "sequence-opening-image";
+
 function readJson<T>(key: string): T | null {
   try {
     const raw = draftStorage()?.getItem(key) ?? null;
@@ -101,6 +114,8 @@ function readJson<T>(key: string): T | null {
 export const useSequenceDraftStore = defineStore("sequence-draft", () => {
   const output = ref<OutputMode>("single");
   const clips = reactive<SequenceClipForm[]>([]);
+  const openingImage = ref<SequenceClipSourceImage | null>(null);
+  const mediaRestoring = ref(false);
   const activeClipId = ref<string | null>(null);
   const enableAudio = ref(false);
   const editing = ref<SequenceEditSession | null>(null);
@@ -110,10 +125,36 @@ export const useSequenceDraftStore = defineStore("sequence-draft", () => {
   let persistTimer: ReturnType<typeof setTimeout> | null = null;
 
   function persistNow() {
+    if (openingImage.value?.base64) {
+      const draftId = openingImage.value.draftId ?? OPENING_MEDIA_ID;
+      openingImage.value.draftId = draftId;
+      void putDraftMedia({
+        ...openingImage.value,
+        draftId,
+        base64: openingImage.value.base64,
+      });
+    }
+    for (const clip of clips) {
+      if (!clip.sourceImage?.base64) continue;
+      const draftId = clip.sourceImage.draftId ?? `sequence-clip-${clip.id}`;
+      clip.sourceImage.draftId = draftId;
+      void putDraftMedia({
+        ...clip.sourceImage,
+        draftId,
+        base64: clip.sourceImage.base64,
+      });
+    }
     const draft: PersistedDraftV1 = {
       version: 1,
       output: output.value,
       clips: persistableClips(clips),
+      openingImage: openingImage.value
+        ? {
+            filename: openingImage.value.filename,
+            draftId: openingImage.value.draftId ?? OPENING_MEDIA_ID,
+            base64: null,
+          }
+        : null,
       enableAudio: enableAudio.value,
       lastSingleModel: lastSingleModel.value,
     };
@@ -133,8 +174,50 @@ export const useSequenceDraftStore = defineStore("sequence-draft", () => {
   function applyPersisted(saved: PersistedDraftV1) {
     output.value = saved.output;
     clips.splice(0, clips.length, ...saved.clips.map((clip) => ({ ...clip })));
+    openingImage.value = saved.openingImage ?? null;
     enableAudio.value = saved.enableAudio;
     lastSingleModel.value = saved.lastSingleModel ?? null;
+  }
+
+  async function restorePersistedMedia() {
+    const pending: Array<Promise<void>> = [];
+    if (openingImage.value && !openingImage.value.base64) {
+      const marker = openingImage.value;
+      pending.push(
+        getDraftMedia<SequenceClipSourceImage & { draftId: string }>(
+          marker.draftId ?? OPENING_MEDIA_ID,
+        ).then((stored) => {
+          if (stored?.base64 && openingImage.value === marker) {
+            openingImage.value = {
+              filename: stored.filename,
+              draftId: stored.draftId,
+              base64: stored.base64,
+            };
+          }
+        }),
+      );
+    }
+    for (const clip of clips) {
+      const marker = clip.sourceImage;
+      if (!marker || marker.base64) continue;
+      pending.push(
+        getDraftMedia<SequenceClipSourceImage & { draftId: string }>(
+          marker.draftId ?? `sequence-clip-${clip.id}`,
+        ).then((stored) => {
+          if (stored?.base64 && clip.sourceImage === marker) {
+            clip.sourceImage = {
+              filename: stored.filename,
+              draftId: stored.draftId,
+              base64: stored.base64,
+            };
+          }
+        }),
+      );
+    }
+    if (pending.length === 0) return;
+    mediaRestoring.value = true;
+    await Promise.all(pending);
+    mediaRestoring.value = false;
   }
 
   /** One-shot migrations from the pre-unification keys. */
@@ -152,6 +235,7 @@ export const useSequenceDraftStore = defineStore("sequence-draft", () => {
         stages: legacyStages,
       });
       clips.splice(0, clips.length, ...loaded.clips);
+      openingImage.value = loaded.openingImage;
       enableAudio.value = loaded.enableAudio;
       // Deliberately NOT importing the legacy chain-level width/steps/
       // guidance — those private copies were the stale-inspector bug.
@@ -180,6 +264,7 @@ export const useSequenceDraftStore = defineStore("sequence-draft", () => {
       activeClipId.value = clips[clips.length - 1]?.id ?? null;
     }
     hydrated.value = true;
+    void restorePersistedMedia();
     // migrateLegacy() consumed the legacy keys while `hydrated` was still
     // false (the watcher won't schedule persistence), so a reload before
     // any edit would lose the migrated draft — make it durable right away.
@@ -203,7 +288,9 @@ export const useSequenceDraftStore = defineStore("sequence-draft", () => {
     if (clips.length <= 2) return;
     const idx = clips.findIndex((clip) => clip.id === id);
     if (idx < 0) return;
-    clips.splice(idx, 1);
+    const [removed] = clips.splice(idx, 1);
+    if (removed?.sourceImage?.draftId)
+      void deleteDraftMedia(removed.sourceImage.draftId);
     if (activeClipId.value === id) {
       activeClipId.value = clips[Math.min(idx, clips.length - 1)]?.id ?? null;
     }
@@ -266,10 +353,18 @@ export const useSequenceDraftStore = defineStore("sequence-draft", () => {
     session: SequenceEditSession,
     loadedClips: SequenceClipForm[],
     loadedEnableAudio: boolean,
+    loadedOpeningImage: SequenceClipSourceImage | null = null,
   ) {
     clips.splice(0, clips.length, ...loadedClips);
     enableAudio.value = loadedEnableAudio;
-    editing.value = session;
+    openingImage.value = loadedOpeningImage;
+    editing.value = {
+      ...session,
+      baselineOpeningImage: loadedOpeningImage
+        ? { ...loadedOpeningImage }
+        : null,
+      baselineEnableAudio: loadedEnableAudio,
+    };
     output.value = "sequence";
     activeClipId.value = clips[0]?.id ?? null;
   }
@@ -284,6 +379,12 @@ export const useSequenceDraftStore = defineStore("sequence-draft", () => {
    * over", not "leave sequence mode" (that's the Output control's job).
    */
   function clearSequence(defaultFrames: number) {
+    if (openingImage.value?.draftId)
+      void deleteDraftMedia(openingImage.value.draftId);
+    for (const clip of clips) {
+      if (clip.sourceImage?.draftId)
+        void deleteDraftMedia(clip.sourceImage.draftId);
+    }
     clips.splice(
       0,
       clips.length,
@@ -292,13 +393,21 @@ export const useSequenceDraftStore = defineStore("sequence-draft", () => {
     );
     activeClipId.value = clips[0]?.id ?? null;
     enableAudio.value = false;
+    openingImage.value = null;
     editing.value = null;
   }
 
   function reset() {
+    if (openingImage.value?.draftId)
+      void deleteDraftMedia(openingImage.value.draftId);
+    for (const clip of clips) {
+      if (clip.sourceImage?.draftId)
+        void deleteDraftMedia(clip.sourceImage.draftId);
+    }
     clips.splice(0, clips.length);
     activeClipId.value = null;
     enableAudio.value = false;
+    openingImage.value = null;
     editing.value = null;
     output.value = "single";
   }
@@ -306,7 +415,7 @@ export const useSequenceDraftStore = defineStore("sequence-draft", () => {
   // Sync flush so the debounce timer arms on the mutation itself (the
   // callback only re-arms a setTimeout — cheap enough for every keystroke).
   watch(
-    [output, clips, enableAudio, lastSingleModel],
+    [output, clips, openingImage, enableAudio, lastSingleModel],
     () => schedulePersist(),
     { deep: true, flush: "sync" },
   );
@@ -314,6 +423,8 @@ export const useSequenceDraftStore = defineStore("sequence-draft", () => {
   return {
     output,
     clips,
+    openingImage,
+    mediaRestoring,
     activeClipId,
     enableAudio,
     editing,

--- a/ui/components/ResolutionSelector.test.ts
+++ b/ui/components/ResolutionSelector.test.ts
@@ -21,9 +21,9 @@ describe("ResolutionSelector", () => {
   });
 
   it("marks the active megapixel step checked", () => {
-    const wrapper = make(2);
+    const wrapper = make(1.8);
     const radios = wrapper.findAll("[role=radio]");
-    const index = RESOLUTIONS.findIndex((r) => r.mp === 2);
+    const index = RESOLUTIONS.findIndex((r) => r.mp === 1.8);
     expect(radios[index]!.attributes("aria-checked")).toBe("true");
     expect(radios[0]!.attributes("aria-checked")).toBe("false");
   });

--- a/ui/components/ResolutionSelector.vue
+++ b/ui/components/ResolutionSelector.vue
@@ -12,6 +12,8 @@ export interface ResolutionOption {
   mp: number;
   label: string;
   sub?: string;
+  width?: number;
+  height?: number;
 }
 
 const props = withDefaults(
@@ -34,9 +36,14 @@ const segments = computed(() =>
   props.options.map((o) => ({ value: o.mp, label: o.label, sub: o.sub })),
 );
 
-const resolved = computed(
-  () => `${dimsLabel(props.modelValue, props.ratio)} px`,
-);
+const resolved = computed(() => {
+  const selected = props.options.find(
+    (option) => option.mp === props.modelValue,
+  );
+  return selected?.width && selected.height
+    ? `${selected.width}×${selected.height} px`
+    : `${dimsLabel(props.modelValue, props.ratio)} px`;
+});
 </script>
 
 <template>

--- a/ui/lib/resolution.test.ts
+++ b/ui/lib/resolution.test.ts
@@ -13,12 +13,12 @@ describe("dimsForMp", () => {
     expect(dimsForMp(1, 1)).toEqual({ width: 1024, height: 1024 });
   });
 
-  it("snaps every canonical shape × step to the /64 grid", () => {
+  it("snaps every canonical shape × step to the server's /16 grid", () => {
     for (const aspect of ASPECTS) {
       for (const step of RESOLUTIONS) {
         const { width, height } = dimsForMp(step.mp, aspect.ratio);
-        expect(width % 64, `${step.label} ${aspect.label} width`).toBe(0);
-        expect(height % 64, `${step.label} ${aspect.label} height`).toBe(0);
+        expect(width % 16, `${step.label} ${aspect.label} width`).toBe(0);
+        expect(height % 16, `${step.label} ${aspect.label} height`).toBe(0);
         expect(width).toBeGreaterThanOrEqual(64);
         expect(height).toBeGreaterThanOrEqual(64);
       }
@@ -27,9 +27,9 @@ describe("dimsForMp", () => {
 
   it("tracks the megapixel budget within grid tolerance", () => {
     for (const aspect of ASPECTS) {
-      const { width, height } = dimsForMp(2, aspect.ratio);
+      const { width, height } = dimsForMp(1.8, aspect.ratio);
       expect((width * height) / 1e6).toBeGreaterThan(1.5);
-      expect((width * height) / 1e6).toBeLessThan(2.5);
+      expect((width * height) / 1e6).toBeLessThanOrEqual(1.8);
     }
   });
 
@@ -45,8 +45,8 @@ describe("nearestMp", () => {
   it("maps 704×704 to the 0.5 MP step", () => {
     expect(nearestMp(704, 704)).toBe(0.5);
   });
-  it("maps 1408×1408 to the 2 MP step", () => {
-    expect(nearestMp(1408, 1408)).toBe(2);
+  it("maps 1328×1328 to the 1.8 MP step", () => {
+    expect(nearestMp(1328, 1328)).toBe(1.8);
   });
 });
 

--- a/ui/lib/resolution.ts
+++ b/ui/lib/resolution.ts
@@ -1,7 +1,8 @@
 /*
  * Megapixel-based resolution math (spec §03 — Resolution selector).
  * Dimensions derive from a target megapixel budget and an aspect ratio,
- * rounded to the /64 grid diffusion models expect, floored at 64px.
+ * rounded to the legacy /64 grid, with a /16 under-ceiling correction for
+ * the 1.8 MP tier used by newer model contracts.
  */
 
 export interface AspectOption {
@@ -25,7 +26,7 @@ export const ASPECTS: readonly AspectOption[] = [
 export const RESOLUTIONS = [
   { mp: 0.5, label: "0.5 MP", sub: "Draft" },
   { mp: 1, label: "1 MP", sub: "Standard" },
-  { mp: 2, label: "2 MP", sub: "Large" },
+  { mp: 1.8, label: "1.8 MP", sub: "Large" },
 ] as const;
 
 function snap64(value: number): number {
@@ -38,7 +39,15 @@ export function dimsForMp(
   ratio: number,
 ): { width: number; height: number } {
   const width = Math.sqrt(mp * 1e6 * ratio);
-  return { width: snap64(width), height: snap64(width / ratio) };
+  let snappedWidth = snap64(width);
+  let snappedHeight = snap64(width / ratio);
+  const maxPixels = mp * 1e6;
+  if (snappedWidth * snappedHeight > maxPixels && mp >= 1.8) {
+    const scale = Math.sqrt(maxPixels / (snappedWidth * snappedHeight));
+    snappedWidth = Math.max(16, Math.floor((snappedWidth * scale) / 16) * 16);
+    snappedHeight = Math.max(16, Math.floor((snappedHeight * scale) / 16) * 16);
+  }
+  return { width: snappedWidth, height: snappedHeight };
 }
 
 /** "1024×1024" display form. */

--- a/web/src/components/SequenceComposer.test.ts
+++ b/web/src/components/SequenceComposer.test.ts
@@ -141,27 +141,12 @@ describe("SequenceComposer", () => {
     expect(store.clips[1]?.transition).toBe("cut");
   });
 
-  it("gates the audio toggle on chain-limits supports_audio", async () => {
+  it("keeps sequence audio out of the composer footer", async () => {
     const wrapper = mountComposer();
-    await flushPromises();
-    expect(wrapper.find("[data-test='sequence-enable-audio']").exists()).toBe(
-      true,
-    );
-
-    fetchChainLimitsMock.mockResolvedValue(
-      ltx2Limits({ supports_audio: false }),
-    );
-    const store = useSequenceDraftStore();
-    store.enableAudio = true;
-    await wrapper.setProps({
-      model: "ltx-video-distilled",
-      family: "ltx-video",
-    });
     await flushPromises();
     expect(wrapper.find("[data-test='sequence-enable-audio']").exists()).toBe(
       false,
     );
-    expect(store.enableAudio).toBe(false);
   });
 
   it("shows the sequence_unsupported_reason inline and disables Generate", async () => {
@@ -239,10 +224,9 @@ describe("SequenceComposer", () => {
     const store = useSequenceDraftStore();
     store.clips.forEach((clip, i) => {
       clip.prompt = `clip ${i + 1}`;
-      if (i === 0)
-        clip.sourceImage = { filename: "opening.png", base64: "AAAA" };
       if (i === 1) clip.negativePrompt = "camera shake";
     });
+    store.openingImage = { filename: "opening.png", base64: "AAAA" };
     await flushPromises();
 
     await wrapper.get("[data-test='sequence-validate']").trigger("click");
@@ -480,14 +464,8 @@ describe("SequenceComposer", () => {
     expect(Math.max(...options)).toBeLessThanOrEqual(97);
   });
 
-  it("attaches an opening image to clip 1 only", async () => {
+  it("keeps opening-image controls out of the clip editor", async () => {
     const wrapper = mountComposer();
-    await flushPromises();
-    const store = useSequenceDraftStore();
-    expect(wrapper.find("[data-test='opening-image-attach']").exists()).toBe(
-      true,
-    );
-    store.activeClipId = store.clips[1]?.id ?? null;
     await flushPromises();
     expect(wrapper.find("[data-test='opening-image-attach']").exists()).toBe(
       false,

--- a/web/src/components/SequenceComposer.vue
+++ b/web/src/components/SequenceComposer.vue
@@ -16,6 +16,7 @@ import {
   buildChainRequest,
   chainScriptToClips,
   clipsToChainScript,
+  sequenceOpeningImageError,
   stageInvalidation,
   type SequenceSharedParams,
 } from "@studio/lib/sequenceForm";
@@ -38,8 +39,6 @@ import {
   type StreamTarget,
 } from "../api";
 import { requestConfirm, toast } from "../lib/toasts";
-import ImagePickerModal from "./ImagePickerModal.vue";
-import type { SourceImageState } from "../types";
 import type { ClipRailMedia } from "@ui/components/types";
 
 const props = withDefaults(
@@ -103,7 +102,6 @@ async function clearSequence() {
   draft.clearSequence(defaultFrames.value);
   toast("info", "Sequence cleared");
 }
-const pickerOpen = ref(false);
 const importFileInput = ref<HTMLInputElement | null>(null);
 
 const motionTail = computed(() =>
@@ -231,6 +229,8 @@ const canGenerate = computed(
   () =>
     limits.value !== null &&
     !sequenceUnsupported.value &&
+    sequenceOpeningImageError(draft.openingImage, draft.mediaRestoring) ===
+      null &&
     validationErrors.value.length === 0,
 );
 
@@ -239,7 +239,10 @@ const canGenerate = computed(
 // payload references, so ordinary clip edits leave it dormant.
 const validationSourceRevision = ref(0);
 watch(
-  () => draft.clips.map((clip) => clip.sourceImage?.base64 ?? null),
+  () => [
+    draft.openingImage?.base64 ?? null,
+    ...draft.clips.map((clip) => clip.sourceImage?.base64 ?? null),
+  ],
   () => {
     validationSourceRevision.value += 1;
   },
@@ -253,6 +256,7 @@ const validationInputSignature = computed(() =>
     motionTail: motionTail.value,
     enableAudio: draft.enableAudio,
     sourceRevision: validationSourceRevision.value,
+    openingSourceFilename: draft.openingImage?.filename ?? null,
     clips: draft.clips.map((clip) => ({
       id: clip.id,
       prompt: clip.prompt,
@@ -281,6 +285,7 @@ async function validatePlan() {
     const request = buildChainRequest(props.shared, draft.clips, {
       motionTailFrames: motionTail.value,
       enableAudio: draft.enableAudio,
+      openingImage: draft.openingImage,
     });
     const plan = await validateChain(request, props.target);
     if (validationInputSignature.value === inputSignature) {
@@ -316,27 +321,13 @@ function onPromptKeydown(event: KeyboardEvent) {
   }
 }
 
-// ── Opening image (clip 1 only — later clips condition on the prior
-//    clip's motion tail) ───────────────────────────────────────────────
-function onPickImage(images: SourceImageState[]) {
-  const first = images[0];
-  const clip = draft.clips[0];
-  pickerOpen.value = false;
-  if (!first || !clip) return;
-  clip.sourceImage = { filename: first.filename, base64: first.base64 };
-}
-
-function clearOpeningImage() {
-  const clip = draft.clips[0];
-  if (clip) clip.sourceImage = null;
-}
-
 // ── File tools ────────────────────────────────────────────────────────
 function exportScript(): string {
   return serializeChainScript(
     clipsToChainScript(props.shared, draft.clips, {
       motionTailFrames: motionTail.value,
       enableAudio: draft.enableAudio,
+      openingImage: draft.openingImage,
     }),
   );
 }
@@ -362,6 +353,7 @@ function importTomlText(text: string) {
     const script = parseChainScript(text);
     const loaded = chainScriptToClips(script);
     draft.clips.splice(0, draft.clips.length, ...loaded.clips);
+    draft.openingImage = loaded.openingImage;
     draft.enableAudio = loaded.enableAudio;
     draft.activeClipId = draft.clips[0]?.id ?? null;
     emit("import-shared", loaded.shared);
@@ -521,8 +513,10 @@ defineExpose({ importTomlText });
           >
             <template #thumb="{ clip }">
               <img
-                v-if="clip.sourceImage?.base64"
-                :src="`data:image/png;base64,${clip.sourceImage.base64}`"
+                v-if="
+                  clip.id === draft.clips[0]?.id && draft.openingImage?.base64
+                "
+                :src="`data:image/png;base64,${draft.openingImage.base64}`"
                 alt=""
                 class="h-full w-full rounded object-cover"
               />
@@ -609,65 +603,8 @@ defineExpose({ importTomlText });
           <Icon name="star" :size="13" />
           Expand
         </button>
-        <template v-if="activeIndex === 0">
-          <button
-            type="button"
-            class="sq-tool"
-            data-test="opening-image-attach"
-            @click="pickerOpen = true"
-          >
-            <Icon name="image" :size="13" />
-            {{ activeClip.sourceImage?.filename ?? "Opening image" }}
-          </button>
-          <button
-            v-if="activeClip.sourceImage"
-            type="button"
-            class="sq-tool"
-            data-test="opening-image-clear"
-            aria-label="Clear opening image"
-            @click="clearOpeningImage"
-          >
-            <Icon name="close" :size="13" />
-          </button>
-        </template>
       </div>
-      <details class="text-xs text-ink-3">
-        <summary class="cursor-pointer select-none">
-          Negative prompt<span v-if="activeClip.negativePrompt.trim()">
-            · set</span
-          >
-        </summary>
-        <textarea
-          :value="activeClip.negativePrompt"
-          data-test="clip-negative"
-          rows="2"
-          class="mt-2 w-full resize-y rounded-control border border-ce bg-bath px-3 py-2 text-sm text-rebate outline-none focus:border-safelight"
-          placeholder="What to avoid in this clip"
-          @input="
-            activeClip.negativePrompt = (
-              $event.target as HTMLTextAreaElement
-            ).value
-          "
-        />
-      </details>
     </div>
-
-    <label
-      v-if="limits?.supports_audio"
-      class="flex cursor-pointer items-center gap-2 px-1 text-xs text-ink-2"
-      title="Generate per-stage audio and mux it into the stitched MP4."
-    >
-      <input
-        type="checkbox"
-        data-test="sequence-enable-audio"
-        class="h-4 w-4 rounded border-ce bg-bench text-safelight focus:ring-safelight"
-        :checked="draft.enableAudio"
-        @change="
-          draft.enableAudio = ($event.target as HTMLInputElement).checked
-        "
-      />
-      Generate audio
-    </label>
 
     <p
       v-if="validationErrors.length"
@@ -782,13 +719,6 @@ defineExpose({ importTomlText });
         {{ draft.editing ? "Update sequence" : "Generate sequence" }}
       </button>
     </div>
-
-    <ImagePickerModal
-      :open="pickerOpen"
-      title="Opening image"
-      @pick="onPickImage"
-      @close="pickerOpen = false"
-    />
   </section>
 </template>
 

--- a/web/src/components/create/AdvancedDrawer.test.ts
+++ b/web/src/components/create/AdvancedDrawer.test.ts
@@ -6,6 +6,8 @@ import {
   __testing__,
 } from "../../composables/useGenerateForm";
 import type { GenerateFormState, ModelInfoExtended } from "../../types";
+import { createPinia, setActivePinia } from "pinia";
+import { useSequenceDraftStore } from "@studio/stores/sequenceDraft";
 
 // The upscale section reads the host's model list. Only upscalers matter here.
 const UPSCALERS: ModelInfoExtended[] = [
@@ -47,9 +49,13 @@ function factory(
   overrides: Partial<GenerateFormState> = {},
   extra: Record<string, unknown> = {},
 ) {
+  const pinia = createPinia();
+  setActivePinia(pinia);
+  if (extra.output === "sequence") useSequenceDraftStore().ensureClips(97);
   return mount(AdvancedDrawer, {
     props: { open: true, modelValue: baseForm(overrides), family, ...extra },
     global: {
+      plugins: [pinia],
       stubs: {
         LoraPicker: { template: "<div data-test='lora-picker-stub' />" },
         RouterLink: { template: "<a><slot /></a>" },
@@ -57,6 +63,29 @@ function factory(
     },
   });
 }
+
+describe("AdvancedDrawer sequence contract", () => {
+  it("shows only sequence-owned controls", () => {
+    const wrapper = factory(
+      "ltx2",
+      {},
+      { output: "sequence", sequenceSupportsAudio: true },
+    );
+    expect(
+      wrapper.find("[data-test='sequence-section-opening-image']").exists(),
+    ).toBe(true);
+    expect(
+      wrapper.find("[data-test='sequence-section-negative']").exists(),
+    ).toBe(true);
+    expect(wrapper.find("[data-test='sequence-section-audio']").exists()).toBe(
+      true,
+    );
+    expect(wrapper.find("[data-test='section-source']").exists()).toBe(false);
+    expect(wrapper.find("[data-test='section-lora']").exists()).toBe(false);
+    expect(wrapper.find("[data-test='section-output']").exists()).toBe(false);
+    expect(wrapper.find("[data-test='section-video']").exists()).toBe(false);
+  });
+});
 
 function sections(family: string, extra: Record<string, unknown> = {}) {
   const wrapper = factory(family, {}, extra);

--- a/web/src/components/create/AdvancedDrawer.vue
+++ b/web/src/components/create/AdvancedDrawer.vue
@@ -38,6 +38,8 @@ import { generationCapabilitiesForFamily } from "../../lib/generateCapabilities"
 import { outputFormatsForFamily } from "../../composables/useGenerateForm";
 import { blobToBase64 } from "../../lib/base64";
 import { useOverlayFocus } from "../../composables/useOverlayFocus";
+import { useSequenceDraftStore } from "@studio/stores/sequenceDraft";
+import type { OutputMode } from "@studio/lib/sequence";
 
 const props = withDefaults(
   defineProps<{
@@ -54,6 +56,8 @@ const props = withDefaults(
     models?: ModelInfoExtended[];
     /** Selected model's resolved audio assets are available. */
     audioOutputSupported?: boolean;
+    output?: OutputMode;
+    sequenceSupportsAudio?: boolean;
   }>(),
   {
     open: false,
@@ -62,6 +66,8 @@ const props = withDefaults(
     placementGpus: () => [],
     models: () => [],
     audioOutputSupported: true,
+    output: "single",
+    sequenceSupportsAudio: false,
   },
 );
 
@@ -74,6 +80,19 @@ const emit = defineEmits<{
   "append-prompt": [phrase: string];
 }>();
 const host = ref<HTMLElement | { $el?: unknown } | null>(null);
+const draft = useSequenceDraftStore();
+const sequenceMode = computed(() => props.output === "sequence");
+const activeSequenceClip = computed(
+  () =>
+    draft.clips.find((clip) => clip.id === draft.activeClipId) ??
+    draft.clips[0] ??
+    null,
+);
+const activeSequenceIndex = computed(() =>
+  activeSequenceClip.value
+    ? draft.clips.findIndex((clip) => clip.id === activeSequenceClip.value?.id)
+    : -1,
+);
 const overlayOpen = computed(() => props.mobile && props.open);
 const { onKeydown } = useOverlayFocus(overlayOpen, host, () => emit("close"));
 
@@ -238,6 +257,12 @@ function clampFrames(n: number): number {
 
 // ── Reset (advanced fields only — prompt/model/shape/seed survive) ────
 function resetAdvanced() {
+  if (sequenceMode.value) {
+    draft.openingImage = null;
+    draft.enableAudio = false;
+    for (const clip of draft.clips) clip.negativePrompt = "";
+    return;
+  }
   patch({
     negativePrompt: "",
     scheduler: null,
@@ -312,399 +337,488 @@ function resetAdvanced() {
     </div>
 
     <div class="adv__sections">
-      <AccordionSection
-        v-if="showScheduler"
-        icon="scheduler"
-        title="Scheduler & sampling"
-        :summary="schedulerSummary"
-        :open="true"
-        :header-interactive="false"
-        data-test="section-scheduler"
-      >
-        <div v-if="caps.supportsScheduler" class="adv__field">
-          <label class="adv__label">Scheduler</label>
-          <select
-            class="adv__select"
-            data-test="scheduler-select"
-            :value="schedulerName"
-            @change="setScheduler(($event.target as HTMLSelectElement).value)"
-          >
-            <option v-for="s in schedulerChoices" :key="s" :value="s">
-              {{ s }}
-            </option>
-          </select>
-        </div>
-        <div v-if="caps.supportsCfgPlus" class="adv__row">
-          <span class="adv__label">CFG++</span>
-          <SwitchToggle
-            :model-value="modelValue.cfgPlus"
-            label="CFG++"
-            data-test="cfg-plus"
-            @update:model-value="patch({ cfgPlus: $event })"
-          />
-        </div>
-      </AccordionSection>
-
-      <AccordionSection
-        v-if="caps.supportsNegativePrompt"
-        icon="negative"
-        title="Negative prompt"
-        summary="What to steer away from"
-        :open="true"
-        :header-interactive="false"
-        data-test="section-negative"
-      >
-        <textarea
-          class="adv__textarea"
-          data-test="negative-input"
-          placeholder="blurry, low quality, deformed…"
-          :value="modelValue.negativePrompt"
-          @input="
-            patch({
-              negativePrompt: ($event.target as HTMLTextAreaElement).value,
-            })
+      <template v-if="sequenceMode">
+        <AccordionSection
+          icon="image"
+          title="Opening sequence image"
+          :summary="
+            draft.openingImage?.filename ?? 'Optional original starting frame'
           "
-        />
-        <div class="adv__chips">
-          <Chip
-            v-for="word in NEG_CHIPS"
-            :key="word"
-            :data-test="`neg-chip-${word.replace(/\s+/g, '-')}`"
-            @click="addNegative(word)"
-            >+ {{ word }}</Chip
-          >
-        </div>
-      </AccordionSection>
-
-      <AccordionSection
-        icon="image"
-        :title="
-          caps.sourceImageMode === 'qwen-edit' ? 'Edit images' : 'Source image'
-        "
-        :summary="
-          hasSource
-            ? caps.sourceImageMode === 'qwen-edit'
-              ? `${modelValue.imageAttachments.length} attached`
-              : `1 image · denoise ${modelValue.strength.toFixed(2)}`
-            : caps.sourceImageMode === 'qwen-edit'
-              ? 'Target and reference images'
-              : 'Image-to-image & inpainting'
-        "
-        :open="true"
-        :header-interactive="false"
-        data-test="section-source"
-      >
-        <button
-          v-if="!hasSource"
-          type="button"
-          class="adv__dropzone"
-          data-test="source-attach"
-          @click="emit('open-picker')"
+          :open="true"
+          :header-interactive="false"
+          data-test="sequence-section-opening-image"
         >
-          {{
-            caps.sourceImageMode === "qwen-edit"
-              ? "Attach images or "
-              : "Drop an image or "
-          }}<span class="adv__accent">browse</span>
-        </button>
-        <div v-else>
-          <div class="adv__source-row">
-            <span class="adv__source-name">{{
-              modelValue.imageAttachments[0]?.filename
-            }}</span>
-            <button
-              type="button"
-              class="adv__remove"
-              data-test="source-remove"
-              @click="emit('clear-source')"
-            >
-              Remove
-            </button>
-          </div>
-          <SliderRow
-            v-if="caps.sourceImageMode === 'single'"
-            label="Denoise strength"
-            :model-value="modelValue.strength"
-            :min="0"
-            :max="1"
-            :step="0.01"
-            :value-label="modelValue.strength.toFixed(2)"
-            @update:model-value="patch({ strength: $event })"
-          />
-          <div v-if="caps.sourceImageMode === 'single'" class="adv__field">
-            <label class="adv__label">Fit to canvas</label>
-            <SegmentedControl
-              :model-value="fitMode"
-              :options="fitOptions"
-              label="Fit to canvas"
-              @update:model-value="setFit"
-            />
-          </div>
           <button
-            v-if="caps.supportsMask"
             type="button"
-            class="adv__mask"
-            data-test="source-mask"
-            @click="emit('open-mask')"
+            class="adv__dropzone"
+            data-test="sequence-opening-image-pick"
+            @click="emit('open-picker')"
           >
             {{
-              modelValue.maskImage ? "Mask applied · edit" : "Edit inpaint mask"
+              draft.openingImage
+                ? `Replace ${draft.openingImage.filename}`
+                : "Drop an image or browse for the original starting frame"
             }}
           </button>
-        </div>
-
-        <div
-          v-if="showControlNet"
-          class="adv__controlnet"
-          data-test="controlnet-block"
-        >
-          <div class="adv__subhead">ControlNet</div>
-          <label
-            v-if="!hasControl"
-            class="adv__filezone"
-            data-test="control-attach"
+          <button
+            v-if="draft.openingImage"
+            type="button"
+            class="adv__remove"
+            data-test="sequence-opening-image-clear"
+            @click="draft.openingImage = null"
           >
-            <span
-              >Attach a control image or
-              <span class="adv__accent">browse</span></span
+            Remove opening image
+          </button>
+        </AccordionSection>
+
+        <AccordionSection
+          v-if="activeSequenceClip"
+          icon="negative"
+          :title="`Clip ${activeSequenceIndex + 1} negative prompt`"
+          summary="What to steer away from in this clip"
+          :open="true"
+          :header-interactive="false"
+          data-test="sequence-section-negative"
+        >
+          <textarea
+            v-model="activeSequenceClip.negativePrompt"
+            class="adv__textarea"
+            data-test="sequence-negative-input"
+            placeholder="blurry, low quality, deformed…"
+          />
+          <div class="adv__chips">
+            <Chip
+              v-for="word in NEG_CHIPS"
+              :key="word"
+              @click="
+                activeSequenceClip.negativePrompt =
+                  activeSequenceClip.negativePrompt.trim()
+                    ? `${activeSequenceClip.negativePrompt.trim()}, ${word}`
+                    : word
+              "
+              >+ {{ word }}</Chip
             >
-            <input
-              type="file"
-              accept="image/png,image/jpeg"
-              class="adv__file-input"
-              @change="onControlImage"
+          </div>
+        </AccordionSection>
+
+        <AccordionSection
+          v-if="sequenceSupportsAudio"
+          icon="video"
+          title="Sequence audio"
+          summary="Generate and mux audio for this timeline"
+          :open="true"
+          :header-interactive="false"
+          data-test="sequence-section-audio"
+        >
+          <div class="adv__row">
+            <span class="adv__label">Generate audio</span>
+            <SwitchToggle
+              :model-value="draft.enableAudio"
+              label="Generate sequence audio"
+              @update:model-value="draft.enableAudio = $event"
             />
-          </label>
-          <template v-else>
+          </div>
+        </AccordionSection>
+      </template>
+      <template v-else>
+        <AccordionSection
+          v-if="showScheduler"
+          icon="scheduler"
+          title="Scheduler & sampling"
+          :summary="schedulerSummary"
+          :open="true"
+          :header-interactive="false"
+          data-test="section-scheduler"
+        >
+          <div v-if="caps.supportsScheduler" class="adv__field">
+            <label class="adv__label">Scheduler</label>
+            <select
+              class="adv__select"
+              data-test="scheduler-select"
+              :value="schedulerName"
+              @change="setScheduler(($event.target as HTMLSelectElement).value)"
+            >
+              <option v-for="s in schedulerChoices" :key="s" :value="s">
+                {{ s }}
+              </option>
+            </select>
+          </div>
+          <div v-if="caps.supportsCfgPlus" class="adv__row">
+            <span class="adv__label">CFG++</span>
+            <SwitchToggle
+              :model-value="modelValue.cfgPlus"
+              label="CFG++"
+              data-test="cfg-plus"
+              @update:model-value="patch({ cfgPlus: $event })"
+            />
+          </div>
+        </AccordionSection>
+
+        <AccordionSection
+          v-if="caps.supportsNegativePrompt"
+          icon="negative"
+          title="Negative prompt"
+          summary="What to steer away from"
+          :open="true"
+          :header-interactive="false"
+          data-test="section-negative"
+        >
+          <textarea
+            class="adv__textarea"
+            data-test="negative-input"
+            placeholder="blurry, low quality, deformed…"
+            :value="modelValue.negativePrompt"
+            @input="
+              patch({
+                negativePrompt: ($event.target as HTMLTextAreaElement).value,
+              })
+            "
+          />
+          <div class="adv__chips">
+            <Chip
+              v-for="word in NEG_CHIPS"
+              :key="word"
+              :data-test="`neg-chip-${word.replace(/\s+/g, '-')}`"
+              @click="addNegative(word)"
+              >+ {{ word }}</Chip
+            >
+          </div>
+        </AccordionSection>
+
+        <AccordionSection
+          icon="image"
+          :title="
+            caps.sourceImageMode === 'qwen-edit'
+              ? 'Edit images'
+              : 'Source image'
+          "
+          :summary="
+            hasSource
+              ? caps.sourceImageMode === 'qwen-edit'
+                ? `${modelValue.imageAttachments.length} attached`
+                : `1 image · denoise ${modelValue.strength.toFixed(2)}`
+              : caps.sourceImageMode === 'qwen-edit'
+                ? 'Target and reference images'
+                : 'Image-to-image & inpainting'
+          "
+          :open="true"
+          :header-interactive="false"
+          data-test="section-source"
+        >
+          <button
+            v-if="!hasSource"
+            type="button"
+            class="adv__dropzone"
+            data-test="source-attach"
+            @click="emit('open-picker')"
+          >
+            {{
+              caps.sourceImageMode === "qwen-edit"
+                ? "Attach images or "
+                : "Drop an image or "
+            }}<span class="adv__accent">browse</span>
+          </button>
+          <div v-else>
             <div class="adv__source-row">
               <span class="adv__source-name">{{
-                modelValue.controlImage?.filename
+                modelValue.imageAttachments[0]?.filename
               }}</span>
               <button
                 type="button"
                 class="adv__remove"
-                data-test="control-remove"
-                @click="clearControl"
+                data-test="source-remove"
+                @click="emit('clear-source')"
               >
                 Remove
               </button>
             </div>
-            <div class="adv__field">
-              <label class="adv__label">Control model</label>
-              <input
-                class="adv__input"
-                data-test="control-model"
-                list="installed-controlnet-models"
-                placeholder="e.g. control_v11p_sd15_canny"
-                :value="modelValue.controlModel"
-                @input="
-                  patch({
-                    controlModel: ($event.target as HTMLInputElement).value,
-                  })
-                "
-              />
-              <datalist id="installed-controlnet-models">
-                <option
-                  v-for="model in controlModels"
-                  :key="model.name"
-                  :value="model.name"
-                />
-              </datalist>
-            </div>
             <SliderRow
-              label="Control scale"
-              data-test="control-scale"
-              :model-value="modelValue.controlScale"
+              v-if="caps.sourceImageMode === 'single'"
+              label="Denoise strength"
+              :model-value="modelValue.strength"
               :min="0"
-              :max="2"
-              :step="0.05"
-              :value-label="modelValue.controlScale.toFixed(2)"
-              @update:model-value="patch({ controlScale: $event })"
+              :max="1"
+              :step="0.01"
+              :value-label="modelValue.strength.toFixed(2)"
+              @update:model-value="patch({ strength: $event })"
             />
-          </template>
-        </div>
-      </AccordionSection>
-
-      <AccordionSection
-        v-if="caps.supportsLora"
-        icon="layers"
-        title="LoRA stack"
-        :summary="`${modelValue.loras.length} active · style adapters`"
-        :open="true"
-        :header-interactive="false"
-        data-test="section-lora"
-      >
-        <LoraPicker
-          :family="family"
-          :model-value="modelValue.loras"
-          @update:model-value="setLoras"
-          @append-prompt="emit('append-prompt', $event)"
-        />
-      </AccordionSection>
-
-      <UpscaleSection
-        v-if="showUpscale"
-        :model-value="modelValue.upscaleModel"
-        @update:model-value="patch({ upscaleModel: $event })"
-      />
-
-      <AccordionSection
-        icon="output"
-        title="Output & seed"
-        summary="Format and reproducibility"
-        :open="true"
-        :header-interactive="false"
-        data-test="section-output"
-      >
-        <div class="adv__field">
-          <label class="adv__label">File format</label>
-          <SegmentedControl
-            :model-value="modelValue.outputFormat"
-            :options="
-              formats.map((f) => ({ value: f, label: f.toUpperCase() }))
-            "
-            label="File format"
-            @update:model-value="
-              patch({ outputFormat: $event as OutputFormat })
-            "
-          />
-        </div>
-        <div class="adv__field">
-          <label class="adv__label">Exact size</label>
-          <div class="adv__size">
-            <input
-              class="adv__input"
-              type="number"
-              min="16"
-              step="16"
-              data-test="exact-width"
-              aria-label="Width in pixels"
-              :value="modelValue.width"
-              @change="setWidth(($event.target as HTMLInputElement).value)"
-            />
+            <div v-if="caps.sourceImageMode === 'single'" class="adv__field">
+              <label class="adv__label">Fit to canvas</label>
+              <SegmentedControl
+                :model-value="fitMode"
+                :options="fitOptions"
+                label="Fit to canvas"
+                @update:model-value="setFit"
+              />
+            </div>
             <button
+              v-if="caps.supportsMask"
               type="button"
-              class="adv__swap"
-              data-test="exact-swap"
-              aria-label="Swap width and height"
-              title="Swap width and height"
-              @click="swapDims"
+              class="adv__mask"
+              data-test="source-mask"
+              @click="emit('open-mask')"
             >
-              <Icon name="swap" :size="15" />
+              {{
+                modelValue.maskImage
+                  ? "Mask applied · edit"
+                  : "Edit inpaint mask"
+              }}
             </button>
-            <input
-              class="adv__input"
-              type="number"
-              min="16"
-              step="16"
-              data-test="exact-height"
-              aria-label="Height in pixels"
-              :value="modelValue.height"
-              @change="setHeight(($event.target as HTMLInputElement).value)"
+          </div>
+
+          <div
+            v-if="showControlNet"
+            class="adv__controlnet"
+            data-test="controlnet-block"
+          >
+            <div class="adv__subhead">ControlNet</div>
+            <label
+              v-if="!hasControl"
+              class="adv__filezone"
+              data-test="control-attach"
+            >
+              <span
+                >Attach a control image or
+                <span class="adv__accent">browse</span></span
+              >
+              <input
+                type="file"
+                accept="image/png,image/jpeg"
+                class="adv__file-input"
+                @change="onControlImage"
+              />
+            </label>
+            <template v-else>
+              <div class="adv__source-row">
+                <span class="adv__source-name">{{
+                  modelValue.controlImage?.filename
+                }}</span>
+                <button
+                  type="button"
+                  class="adv__remove"
+                  data-test="control-remove"
+                  @click="clearControl"
+                >
+                  Remove
+                </button>
+              </div>
+              <div class="adv__field">
+                <label class="adv__label">Control model</label>
+                <input
+                  class="adv__input"
+                  data-test="control-model"
+                  list="installed-controlnet-models"
+                  placeholder="e.g. control_v11p_sd15_canny"
+                  :value="modelValue.controlModel"
+                  @input="
+                    patch({
+                      controlModel: ($event.target as HTMLInputElement).value,
+                    })
+                  "
+                />
+                <datalist id="installed-controlnet-models">
+                  <option
+                    v-for="model in controlModels"
+                    :key="model.name"
+                    :value="model.name"
+                  />
+                </datalist>
+              </div>
+              <SliderRow
+                label="Control scale"
+                data-test="control-scale"
+                :model-value="modelValue.controlScale"
+                :min="0"
+                :max="2"
+                :step="0.05"
+                :value-label="modelValue.controlScale.toFixed(2)"
+                @update:model-value="patch({ controlScale: $event })"
+              />
+            </template>
+          </div>
+        </AccordionSection>
+
+        <AccordionSection
+          v-if="caps.supportsLora"
+          icon="layers"
+          title="LoRA stack"
+          :summary="`${modelValue.loras.length} active · style adapters`"
+          :open="true"
+          :header-interactive="false"
+          data-test="section-lora"
+        >
+          <LoraPicker
+            :family="family"
+            :model-value="modelValue.loras"
+            @update:model-value="setLoras"
+            @append-prompt="emit('append-prompt', $event)"
+          />
+        </AccordionSection>
+
+        <UpscaleSection
+          v-if="showUpscale"
+          :model-value="modelValue.upscaleModel"
+          @update:model-value="patch({ upscaleModel: $event })"
+        />
+
+        <AccordionSection
+          icon="output"
+          title="Output & seed"
+          summary="Format and reproducibility"
+          :open="true"
+          :header-interactive="false"
+          data-test="section-output"
+        >
+          <div class="adv__field">
+            <label class="adv__label">File format</label>
+            <SegmentedControl
+              :model-value="modelValue.outputFormat"
+              :options="
+                formats.map((f) => ({ value: f, label: f.toUpperCase() }))
+              "
+              label="File format"
+              @update:model-value="
+                patch({ outputFormat: $event as OutputFormat })
+              "
             />
           </div>
-          <p class="adv__hint">snaps to the nearest 16px.</p>
-        </div>
-        <div class="adv__field">
-          <label class="adv__label">Seed</label>
-          <SegmentedControl
-            :model-value="modelValue.seedMode"
-            :options="seedModes"
-            label="Seed mode"
-            @update:model-value="patch({ seedMode: $event })"
-          />
-        </div>
-        <input
-          v-if="modelValue.seedMode !== 'random'"
-          class="adv__input"
-          data-test="output-seed"
-          type="number"
-          min="0"
-          placeholder="Seed"
-          :value="modelValue.seed ?? ''"
-          @input="
-            patch({
-              seed: Number(($event.target as HTMLInputElement).value) || null,
-            })
-          "
-        />
-      </AccordionSection>
-
-      <AccordionSection
-        v-if="caps.supportsVideo"
-        icon="video"
-        title="Video"
-        :summary="`${modelValue.frames ?? 25} frames · ${modelValue.fps ?? 24} fps`"
-        :open="true"
-        :header-interactive="false"
-        data-test="section-video"
-      >
-        <div class="adv__field">
-          <label class="adv__label">Frames (8n+1)</label>
+          <div class="adv__field">
+            <label class="adv__label">Exact size</label>
+            <div class="adv__size">
+              <input
+                class="adv__input"
+                type="number"
+                min="16"
+                step="16"
+                data-test="exact-width"
+                aria-label="Width in pixels"
+                :value="modelValue.width"
+                @change="setWidth(($event.target as HTMLInputElement).value)"
+              />
+              <button
+                type="button"
+                class="adv__swap"
+                data-test="exact-swap"
+                aria-label="Swap width and height"
+                title="Swap width and height"
+                @click="swapDims"
+              >
+                <Icon name="swap" :size="15" />
+              </button>
+              <input
+                class="adv__input"
+                type="number"
+                min="16"
+                step="16"
+                data-test="exact-height"
+                aria-label="Height in pixels"
+                :value="modelValue.height"
+                @change="setHeight(($event.target as HTMLInputElement).value)"
+              />
+            </div>
+            <p class="adv__hint">snaps to the nearest 16px.</p>
+          </div>
+          <div class="adv__field">
+            <label class="adv__label">Seed</label>
+            <SegmentedControl
+              :model-value="modelValue.seedMode"
+              :options="seedModes"
+              label="Seed mode"
+              @update:model-value="patch({ seedMode: $event })"
+            />
+          </div>
           <input
+            v-if="modelValue.seedMode !== 'random'"
             class="adv__input"
-            data-test="video-frames"
+            data-test="output-seed"
             type="number"
-            :value="modelValue.frames ?? 25"
-            @change="
+            min="0"
+            placeholder="Seed"
+            :value="modelValue.seed ?? ''"
+            @input="
               patch({
-                frames: clampFrames(
-                  Number(($event.target as HTMLInputElement).value),
-                ),
+                seed: Number(($event.target as HTMLInputElement).value) || null,
               })
             "
           />
-          <p class="adv__hint">Frames must be 8n+1 — try 97.</p>
-        </div>
-        <div class="adv__field">
-          <label class="adv__label">Frames per second</label>
-          <input
-            class="adv__input"
-            data-test="video-fps"
-            type="number"
-            min="1"
-            :value="modelValue.fps ?? 24"
-            @change="
-              patch({
-                fps: Number(($event.target as HTMLInputElement).value) || 24,
-              })
-            "
-          />
-        </div>
-        <div class="adv__row">
-          <span class="adv__label">GIF preview</span>
-          <SwitchToggle
-            :model-value="modelValue.gifPreview"
-            label="Generate GIF preview"
-            data-test="video-gif-preview"
-            @update:model-value="patch({ gifPreview: $event })"
-          />
-        </div>
-        <Ltx2VideoControls
-          v-if="showLtx2"
-          :model-value="modelValue"
-          :audio-output-supported="audioOutputSupported"
-          @update:model-value="emit('update:modelValue', $event)"
-        />
-      </AccordionSection>
+        </AccordionSection>
 
-      <AccordionSection
-        v-if="showPlacement"
-        icon="machines"
-        title="GPU placement"
-        summary="Pin this job to a device"
-        :open="true"
-        :header-interactive="false"
-        data-test="section-placement"
-      >
-        <PlacementPanel
-          :model-value="modelValue.placement"
-          :family="family"
-          :model="modelValue.model"
-          :gpus="placementGpus"
-          @update:model-value="setPlacement"
-        />
-      </AccordionSection>
+        <AccordionSection
+          v-if="caps.supportsVideo"
+          icon="video"
+          title="Video"
+          :summary="`${modelValue.frames ?? 25} frames · ${modelValue.fps ?? 24} fps`"
+          :open="true"
+          :header-interactive="false"
+          data-test="section-video"
+        >
+          <div class="adv__field">
+            <label class="adv__label">Frames (8n+1)</label>
+            <input
+              class="adv__input"
+              data-test="video-frames"
+              type="number"
+              :value="modelValue.frames ?? 25"
+              @change="
+                patch({
+                  frames: clampFrames(
+                    Number(($event.target as HTMLInputElement).value),
+                  ),
+                })
+              "
+            />
+            <p class="adv__hint">Frames must be 8n+1 — try 97.</p>
+          </div>
+          <div class="adv__field">
+            <label class="adv__label">Frames per second</label>
+            <input
+              class="adv__input"
+              data-test="video-fps"
+              type="number"
+              min="1"
+              :value="modelValue.fps ?? 24"
+              @change="
+                patch({
+                  fps: Number(($event.target as HTMLInputElement).value) || 24,
+                })
+              "
+            />
+          </div>
+          <div class="adv__row">
+            <span class="adv__label">GIF preview</span>
+            <SwitchToggle
+              :model-value="modelValue.gifPreview"
+              label="Generate GIF preview"
+              data-test="video-gif-preview"
+              @update:model-value="patch({ gifPreview: $event })"
+            />
+          </div>
+          <Ltx2VideoControls
+            v-if="showLtx2"
+            :model-value="modelValue"
+            :audio-output-supported="audioOutputSupported"
+            @update:model-value="emit('update:modelValue', $event)"
+          />
+        </AccordionSection>
+
+        <AccordionSection
+          v-if="showPlacement"
+          icon="machines"
+          title="GPU placement"
+          summary="Pin this job to a device"
+          :open="true"
+          :header-interactive="false"
+          data-test="section-placement"
+        >
+          <PlacementPanel
+            :model-value="modelValue.placement"
+            :family="family"
+            :model="modelValue.model"
+            :gpus="placementGpus"
+            @update:model-value="setPlacement"
+          />
+        </AccordionSection>
+      </template>
     </div>
 
     <div v-if="mobile" class="adv__footer">

--- a/web/src/components/create/ControlsAside.test.ts
+++ b/web/src/components/create/ControlsAside.test.ts
@@ -5,7 +5,6 @@ import ShapePicker from "@ui/components/ShapePicker.vue";
 import ResolutionSelector from "@ui/components/ResolutionSelector.vue";
 import Stepper from "@ui/components/Stepper.vue";
 import SliderRow from "@ui/components/SliderRow.vue";
-import { dimsForMp } from "@ui/lib/resolution";
 import {
   useGenerateForm,
   __testing__,
@@ -62,7 +61,7 @@ describe("ControlsAside", () => {
       "square",
     );
     expect(wrapper.getComponent(ResolutionSelector).props("modelValue")).toBe(
-      1,
+      (1024 * 1024) / 1_000_000,
     );
   });
 
@@ -94,21 +93,21 @@ describe("ControlsAside", () => {
     const [next] = wrapper.emitted("update:modelValue")!.at(-1) as [
       GenerateFormState,
     ];
-    const expected = dimsForMp(1, 4 / 3);
-    expect(next.width).toBe(expected.width);
-    expect(next.height).toBe(expected.height);
+    expect(next.width).toBe(1024);
+    expect(next.height).toBe(768);
   });
 
   it("applies the projected dims when resolution changes", async () => {
-    const wrapper = factory({ width: 1024, height: 1024 });
-    wrapper.getComponent(ResolutionSelector).vm.$emit("update:modelValue", 2);
+    const wrapper = factory({ width: 1024, height: 1024 }, "qwen-image");
+    wrapper
+      .getComponent(ResolutionSelector)
+      .vm.$emit("update:modelValue", (1328 * 1328) / 1_000_000);
     await wrapper.vm.$nextTick();
     const [next] = wrapper.emitted("update:modelValue")!.at(-1) as [
       GenerateFormState,
     ];
-    const expected = dimsForMp(2, 1);
-    expect(next.width).toBe(expected.width);
-    expect(next.height).toBe(expected.height);
+    expect(next.width).toBe(1328);
+    expect(next.height).toBe(1328);
   });
 
   function seedButton(wrapper: ReturnType<typeof factory>, label: string) {

--- a/web/src/components/create/ControlsAside.test.ts
+++ b/web/src/components/create/ControlsAside.test.ts
@@ -110,6 +110,13 @@ describe("ControlsAside", () => {
     expect(next.height).toBe(1328);
   });
 
+  it("labels a model's only runnable bucket as Native", () => {
+    const wrapper = factory({ width: 1024, height: 1024 }, "wuerstchen");
+    expect(wrapper.getComponent(ResolutionSelector).props("options")).toEqual([
+      expect.objectContaining({ sub: "Native" }),
+    ]);
+  });
+
   function seedButton(wrapper: ReturnType<typeof factory>, label: string) {
     return wrapper
       .findAll("[data-test='seed-seg'] button")

--- a/web/src/components/create/ControlsAside.vue
+++ b/web/src/components/create/ControlsAside.vue
@@ -16,8 +16,14 @@ import SegmentedControl from "@ui/components/SegmentedControl.vue";
 import Stepper from "@ui/components/Stepper.vue";
 import BadgePill from "@ui/components/BadgePill.vue";
 import Icon from "@ui/components/Icon.vue";
-import { ASPECTS, dimsForMp } from "@ui/lib/resolution";
-import type { GenerateFormState } from "../../types";
+import { ASPECTS } from "@ui/lib/resolution";
+import type { GenerateFormState, ModelInfoExtended } from "../../types";
+import {
+  closestResolutionPreset,
+  megapixelLabel,
+  presetsForModel,
+  presetsNearRatio,
+} from "@studio/lib/resolutions";
 import type { OutputMode } from "@studio/lib/sequence";
 import { generationCapabilitiesForFamily } from "../../lib/generateCapabilities";
 import { projectResolution } from "./resolutionProjection";
@@ -28,6 +34,7 @@ const props = withDefaults(
   defineProps<{
     modelValue: GenerateFormState;
     family: string;
+    model?: ModelInfoExtended | null;
     /** Count of active advanced fields (drives the badge). */
     advCount?: number;
     /** Phone surface: the Advanced sheet button shows here; on tablet+ the
@@ -48,6 +55,7 @@ const props = withDefaults(
     lastSeed: null,
     output: "single",
     clipCount: 0,
+    model: null,
   },
 );
 
@@ -110,16 +118,54 @@ function patch(patch: Partial<GenerateFormState>) {
   emit("update:modelValue", { ...props.modelValue, ...patch });
 }
 
+const resolutionPresets = computed(() =>
+  presetsNearRatio(
+    presetsForModel(props.model ?? props.family),
+    currentRatio.value,
+  ),
+);
+const resolutionOptions = computed(() =>
+  resolutionPresets.value.map((preset, index, all) => ({
+    mp: (preset.width * preset.height) / 1_000_000,
+    label: megapixelLabel(preset.width, preset.height),
+    sub:
+      index === 0 ? "Small" : index === all.length - 1 ? "Native" : "Standard",
+    width: preset.width,
+    height: preset.height,
+  })),
+);
+const selectedMp = computed(() => {
+  const exact = resolutionOptions.value.find(
+    (option) =>
+      option.width === props.modelValue.width &&
+      option.height === props.modelValue.height,
+  );
+  if (exact) return exact.mp;
+  const current =
+    (props.modelValue.width * props.modelValue.height) / 1_000_000;
+  return (
+    [...resolutionOptions.value].sort(
+      (a, b) => Math.abs(a.mp - current) - Math.abs(b.mp - current),
+    )[0]?.mp ?? mp.value
+  );
+});
+
 function setAspect(id: string) {
   const a = ASPECTS.find((x) => x.id === id);
   if (!a) return;
-  const dims = dimsForMp(mp.value, a.ratio);
-  patch({ width: dims.width, height: dims.height });
+  const preset = closestResolutionPreset(
+    presetsNearRatio(presetsForModel(props.model ?? props.family), a.ratio),
+    props.modelValue.width,
+    props.modelValue.height,
+  );
+  if (preset) patch({ width: preset.width, height: preset.height });
 }
 
 function setMp(nextMp: number) {
-  const dims = dimsForMp(nextMp, currentRatio.value);
-  patch({ width: dims.width, height: dims.height });
+  const preset = resolutionPresets.value.find(
+    (candidate) => (candidate.width * candidate.height) / 1_000_000 === nextMp,
+  );
+  if (preset) patch({ width: preset.width, height: preset.height });
 }
 
 // Seed: Random / Fixed segments. "Fixed" covers the persisted static and
@@ -192,8 +238,9 @@ function lockLastSeed() {
     <div class="controls__group">
       <div class="controls__label">Resolution</div>
       <ResolutionSelector
-        :model-value="mp"
+        :model-value="selectedMp"
         :ratio="currentRatio"
+        :options="resolutionOptions"
         @update:model-value="setMp"
       />
     </div>

--- a/web/src/components/create/ControlsAside.vue
+++ b/web/src/components/create/ControlsAside.vue
@@ -129,7 +129,13 @@ const resolutionOptions = computed(() =>
     mp: (preset.width * preset.height) / 1_000_000,
     label: megapixelLabel(preset.width, preset.height),
     sub:
-      index === 0 ? "Small" : index === all.length - 1 ? "Native" : "Standard",
+      all.length === 1
+        ? "Native"
+        : index === 0
+          ? "Small"
+          : index === all.length - 1
+            ? "Native"
+            : "Standard",
     width: preset.width,
     height: preset.height,
   })),

--- a/web/src/components/create/resolutionProjection.test.ts
+++ b/web/src/components/create/resolutionProjection.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { dimsForMp } from "@ui/lib/resolution";
+import { dimsForMp, RESOLUTIONS } from "@ui/lib/resolution";
 import { aspectIdForDims, projectResolution } from "./resolutionProjection";
 
 describe("aspectIdForDims", () => {
@@ -22,7 +22,7 @@ describe("aspectIdForDims", () => {
 
 describe("projectResolution", () => {
   it("round-trips the canonical grid without flagging custom", () => {
-    for (const mp of [0.5, 1, 2]) {
+    for (const { mp } of RESOLUTIONS) {
       const { width, height } = dimsForMp(mp, 1);
       const proj = projectResolution(width, height);
       expect(proj.aspectId).toBe("square");

--- a/web/src/lib/draftMediaStore.ts
+++ b/web/src/lib/draftMediaStore.ts
@@ -1,65 +1,12 @@
-import type { SourceImageState, SourceMediaState } from "../types";
 import { createUuid } from "@studio/lib/id";
-
-type DraftMedia = SourceImageState | SourceMediaState;
-
-const DB_NAME = "mold-generate-drafts";
-const STORE_NAME = "media";
-const DB_VERSION = 1;
-const memory = new Map<string, DraftMedia>();
-
-function clone<T>(value: T): T {
-  return JSON.parse(JSON.stringify(value)) as T;
-}
-
-function openDb(): Promise<IDBDatabase | null> {
-  if (typeof indexedDB === "undefined") return Promise.resolve(null);
-  return new Promise((resolve) => {
-    const req = indexedDB.open(DB_NAME, DB_VERSION);
-    req.onupgradeneeded = () => {
-      req.result.createObjectStore(STORE_NAME, { keyPath: "draftId" });
-    };
-    req.onsuccess = () => resolve(req.result);
-    req.onerror = () => resolve(null);
-  });
-}
-
-async function withStore<T>(
-  mode: IDBTransactionMode,
-  fn: (store: IDBObjectStore) => IDBRequest<T>,
-): Promise<T | null> {
-  const db = await openDb();
-  if (!db) return null;
-  return new Promise((resolve) => {
-    const tx = db.transaction(STORE_NAME, mode);
-    const req = fn(tx.objectStore(STORE_NAME));
-    req.onsuccess = () => resolve(req.result ?? null);
-    req.onerror = () => resolve(null);
-    tx.oncomplete = () => db.close();
-    tx.onerror = () => db.close();
-  });
-}
+import {
+  clearMemoryDraftsForTest,
+  getDraftMedia,
+  putDraftMedia,
+} from "@studio/lib/draftMediaStore";
 
 export function newDraftId(): string {
   return createUuid();
 }
 
-export async function putDraftMedia(media: DraftMedia): Promise<void> {
-  if (!media.draftId || !media.base64) return;
-  const saved = clone(media);
-  memory.set(media.draftId, saved);
-  await withStore("readwrite", (store) => store.put(saved));
-}
-
-export async function getDraftMedia<T extends DraftMedia>(
-  draftId: string,
-): Promise<T | null> {
-  const fromDb = await withStore<T>("readonly", (store) => store.get(draftId));
-  if (fromDb) return fromDb;
-  const fromMemory = memory.get(draftId);
-  return fromMemory ? (clone(fromMemory) as T) : null;
-}
-
-export function clearMemoryDraftsForTest() {
-  memory.clear();
-}
+export { clearMemoryDraftsForTest, getDraftMedia, putDraftMedia };

--- a/web/src/pages/CreatePage.test.ts
+++ b/web/src/pages/CreatePage.test.ts
@@ -1926,7 +1926,12 @@ describe("CreatePage layout and behavior", () => {
           output_format: "mp4",
         },
         stages: [
-          { prompt: "one", frames: 97 },
+          {
+            prompt: "one",
+            frames: 97,
+            source_image_b64: "QUJD",
+            source_image_path: "opening.png",
+          },
           { prompt: "two", frames: 97, transition: "cut" },
         ],
       },
@@ -1950,6 +1955,10 @@ describe("CreatePage layout and behavior", () => {
       completedStages: 2,
     });
     expect(draft.clips.map((c) => c.prompt)).toEqual(["one", "two"]);
+    expect(draft.openingImage).toEqual({
+      filename: "opening image",
+      base64: "QUJD",
+    });
     expect(draft.clips[1]?.transition).toBe("cut");
     // The job's shared params landed on the LIVE form.
     const form = useGenerateForm();
@@ -1977,7 +1986,10 @@ describe("CreatePage layout and behavior", () => {
       "job-9",
       expect.objectContaining({
         stages: [
-          expect.objectContaining({ prompt: "one" }),
+          expect.objectContaining({
+            prompt: "one",
+            source_image: "QUJD",
+          }),
           expect.objectContaining({ prompt: "two, but stormier" }),
         ],
       }),

--- a/web/src/pages/CreatePage.vue
+++ b/web/src/pages/CreatePage.vue
@@ -31,6 +31,7 @@ import { blobToBase64 } from "../lib/base64";
 import Icon from "@ui/components/Icon.vue";
 import ErrorNotice from "@ui/components/ErrorNotice.vue";
 import { ASPECTS } from "@ui/lib/resolution";
+import { MAX_GENERATION_PIXELS } from "@studio/lib/resolutions";
 import type { DevelopPhase } from "@ui/lib/grain";
 import type { ClipRailMedia } from "@ui/components/types";
 import { SourceFitPreprocessCache } from "@ui/lib/sourceFitPreprocessCache";
@@ -1084,7 +1085,9 @@ const sequenceReuseNotice = ref<string | null>(null);
 const chainLevelDirty = computed(
   () =>
     editBaselineShared.value !== null &&
-    editBaselineShared.value !== JSON.stringify(sharedParams.value),
+    (editBaselineShared.value !== JSON.stringify(sharedParams.value) ||
+      JSON.stringify(draft.editing?.baselineOpeningImage ?? null) !==
+        JSON.stringify(draft.openingImage)),
 );
 
 /** Apply a script's chain-level params onto the LIVE form (edit + import). */
@@ -1130,6 +1133,7 @@ async function onSubmitSequence() {
   const req = buildChainRequest(sharedParams.value, draft.clips, {
     motionTailFrames: sequenceMotionTail.value,
     enableAudio: draft.enableAudio,
+    openingImage: draft.openingImage,
   });
 
   const editing = draft.editing;
@@ -1222,6 +1226,7 @@ async function loadSequence(hostId: string, jobId: string, editing: boolean) {
         },
         loaded.clips,
         loaded.enableAudio,
+        loaded.openingImage,
       );
       editBaselineShared.value = JSON.stringify(
         sequenceSharedParams(form.state.value, currentFamily.value),
@@ -1233,6 +1238,7 @@ async function loadSequence(hostId: string, jobId: string, editing: boolean) {
       draft.clips.splice(0, draft.clips.length, ...loaded.clips);
       draft.activeClipId = loaded.clips[0]?.id ?? null;
       draft.enableAudio = loaded.enableAudio;
+      draft.openingImage = loaded.openingImage;
     }
     sequenceStageClipIdsByJob.set(
       `${hostId}:${jobId}`,
@@ -1251,12 +1257,20 @@ function onDuplicateAsNew() {
 }
 
 function onDiscardEdit() {
+  const editing = draft.editing;
+  if (!editing) return;
+  draft.clips.splice(
+    0,
+    draft.clips.length,
+    ...editing.baseline.map((clip) => ({ ...clip })),
+  );
+  draft.openingImage = editing.baselineOpeningImage
+    ? { ...editing.baselineOpeningImage }
+    : null;
+  draft.enableAudio = editing.baselineEnableAudio ?? false;
   draft.stopEditing();
   editBaselineShared.value = null;
-  draft.clips.splice(0, draft.clips.length);
-  draft.activeClipId = null;
-  draft.enableAudio = false;
-  draft.ensureClips(sequenceDefaultFrames.value);
+  draft.activeClipId = draft.clips[0]?.id ?? null;
 }
 
 function onImportShared(shared: Partial<SequenceSharedParams>) {
@@ -1405,39 +1419,43 @@ const aspectLabel = computed(
 );
 
 const advCount = computed(() =>
-  advancedActiveCount({
-    negativePrompt: capabilities.value.supportsNegativePrompt
-      ? form.state.value.negativePrompt
-      : "",
-    hasSource: form.state.value.imageAttachments.length > 0,
-    loraCount: form.state.value.loras.length,
-    upscaleOn: form.state.value.upscaleModel.trim() !== "",
-    scheduler: capabilities.value.supportsScheduler
-      ? form.state.value.scheduler
-      : null,
-    customSize: projection.value.isCustom,
-    videoNonDefault:
-      capabilities.value.supportsVideo &&
-      form.state.value.frames != null &&
-      form.state.value.frames !== 25,
-    controlNet:
-      capabilities.value.supportsControlNet &&
-      form.state.value.controlImage != null,
-    videoSuite:
-      capabilities.value.supportsVideo &&
-      (form.state.value.gifPreview ||
-        form.state.value.enableAudio === false ||
-        form.state.value.pipeline != null ||
-        form.state.value.icLoraControl != null ||
-        form.state.value.audioFile != null ||
-        form.state.value.audioFilePath.trim() !== "" ||
-        form.state.value.sourceVideo != null ||
-        form.state.value.sourceVideoPath.trim() !== "" ||
-        form.state.value.keyframes.length > 0 ||
-        form.state.value.retakeRange != null ||
-        form.state.value.spatialUpscale != null ||
-        form.state.value.temporalUpscale != null),
-  }),
+  sequenceMode.value
+    ? Number(Boolean(draft.openingImage)) +
+      Number(Boolean(draft.clips.some((clip) => clip.negativePrompt.trim()))) +
+      Number(draft.enableAudio)
+    : advancedActiveCount({
+        negativePrompt: capabilities.value.supportsNegativePrompt
+          ? form.state.value.negativePrompt
+          : "",
+        hasSource: form.state.value.imageAttachments.length > 0,
+        loraCount: form.state.value.loras.length,
+        upscaleOn: form.state.value.upscaleModel.trim() !== "",
+        scheduler: capabilities.value.supportsScheduler
+          ? form.state.value.scheduler
+          : null,
+        customSize: projection.value.isCustom,
+        videoNonDefault:
+          capabilities.value.supportsVideo &&
+          form.state.value.frames != null &&
+          form.state.value.frames !== 25,
+        controlNet:
+          capabilities.value.supportsControlNet &&
+          form.state.value.controlImage != null,
+        videoSuite:
+          capabilities.value.supportsVideo &&
+          (form.state.value.gifPreview ||
+            form.state.value.enableAudio === false ||
+            form.state.value.pipeline != null ||
+            form.state.value.icLoraControl != null ||
+            form.state.value.audioFile != null ||
+            form.state.value.audioFilePath.trim() !== "" ||
+            form.state.value.sourceVideo != null ||
+            form.state.value.sourceVideoPath.trim() !== "" ||
+            form.state.value.keyframes.length > 0 ||
+            form.state.value.retakeRange != null ||
+            form.state.value.spatialUpscale != null ||
+            form.state.value.temporalUpscale != null),
+      }),
 );
 
 // ── Canvas state ──────────────────────────────────────────────────────
@@ -1713,6 +1731,14 @@ function validateSubmit(): boolean {
   if (!form.state.value.model) {
     showAdvanced.value = false;
     composerError.value = "Pick a model to start.";
+    return false;
+  }
+  const pixels = form.state.value.width * form.state.value.height;
+  const maxPixels = currentModel.value?.max_pixels ?? MAX_GENERATION_PIXELS;
+  if (pixels > maxPixels) {
+    composerError.value = `${form.state.value.width} × ${form.state.value.height} exceeds this model's ${(
+      maxPixels / 1_000_000
+    ).toFixed(1)} MP limit.`;
     return false;
   }
   const qwenImageEdit =
@@ -2267,6 +2293,18 @@ async function onClearSource() {
 }
 
 async function onPickSource(v: SourceImageState[]) {
+  if (sequenceMode.value) {
+    const first = v[0];
+    if (first) {
+      draft.openingImage = {
+        filename: first.filename,
+        base64: first.base64,
+        draftId: first.draftId,
+      };
+    }
+    composerError.value = null;
+    return;
+  }
   const qwenEdit =
     isQwenImageEditFamily(
       currentModel.value?.family ?? form.state.value.modelFamily,
@@ -2631,6 +2669,7 @@ onBeforeUnmount(() => {
             <ControlsAside
               v-model="form.state.value"
               :family="currentFamily"
+              :model="currentModel"
               :adv-count="advCount"
               :mobile="true"
               :last-seed="lastSeedUsed"
@@ -2820,6 +2859,7 @@ onBeforeUnmount(() => {
                 <ControlsAside
                   v-model="form.state.value"
                   :family="currentFamily"
+                  :model="currentModel"
                   :adv-count="advCount"
                   :mobile="true"
                   :last-seed="lastSeedUsed"
@@ -2971,6 +3011,7 @@ onBeforeUnmount(() => {
         <ControlsAside
           v-model="form.state.value"
           :family="currentFamily"
+          :model="currentModel"
           :adv-count="advCount"
           :mobile="false"
           :last-seed="lastSeedUsed"
@@ -2989,6 +3030,10 @@ onBeforeUnmount(() => {
           :placement-gpus="gpuListForPlacement"
           :models="models"
           :audio-output-supported="currentModel?.supports_audio !== false"
+          :output="sequenceMode ? 'sequence' : 'single'"
+          :sequence-supports-audio="
+            currentFamily === 'ltx2' && currentModel?.supports_audio !== false
+          "
           @open-picker="showPicker = true"
           @clear-source="onClearSource"
           @open-mask="showMask = true"
@@ -3010,6 +3055,10 @@ onBeforeUnmount(() => {
         :placement-gpus="gpuListForPlacement"
         :models="models"
         :audio-output-supported="currentModel?.supports_audio !== false"
+        :output="sequenceMode ? 'sequence' : 'single'"
+        :sequence-supports-audio="
+          currentFamily === 'ltx2' && currentModel?.supports_audio !== false
+        "
         @close="showAdvanced = false"
         @open-picker="showPicker = true"
         @clear-source="onClearSource"
@@ -3038,9 +3087,13 @@ onBeforeUnmount(() => {
     <ImagePickerModal
       :open="showPicker"
       :title="
-        currentFamily === 'qwen-image-edit' ? 'Edit images' : 'Source image'
+        sequenceMode
+          ? 'Opening sequence image'
+          : currentFamily === 'qwen-image-edit'
+            ? 'Edit images'
+            : 'Source image'
       "
-      :multiple="currentFamily === 'qwen-image-edit'"
+      :multiple="!sequenceMode && currentFamily === 'qwen-image-edit'"
       @pick="onPickSource"
       @close="showPicker = false"
     />

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -242,6 +242,9 @@ export interface ModelDefaults {
   default_guidance: number;
   default_width: number;
   default_height: number;
+  max_pixels?: number | null;
+  recommended_dimensions?: { width: number; height: number }[];
+  dimension_alignment?: number | null;
   description: string;
 }
 


### PR DESCRIPTION
## Summary
- preserve the opening sequence image through draft reloads, durable-job edits, reorder, discard, and resubmission
- give sequence mode its own Advanced controls on web, desktop, and iPhone, removing one-shot-only leftovers and the duplicate bottom image controls
- advertise the server resolution contract per model and share exact presets across web, desktop, and iPhone, including the runnable 1.8 MP and LTX-2 buckets

## Verification
- bun run check:frontend
- bun run build:mobile
- bun run fmt:check (root, web, desktop)
- nix develop -c cargo clippy --workspace --all-targets -- -D warnings
- nix develop -c cargo test --workspace
- nix develop -c cargo check -p mold-ai --features preview,discord,expand,tui,webp,mp4
- nix flake check
- rendered web and desktop sequence UAT: dedicated Advanced sections, one opening-image control, no one-shot LoRA/scheduler/upscale controls, no duplicate bottom image field
- iPhone 17 Pro simulator build/install/launch and Sequence-mode UAT; component tests cover the offline-only Advanced sheet path