### PR TITLE
fix(release): sync desktop Candle lockfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
               - 'crates/mold-core/src/cuda_distribution.rs'
               - 'crates/mold-server/Cargo.toml'
               - 'desktop/src-tauri/Cargo.toml'
+              - 'desktop/src-tauri/Cargo.lock'
               - 'desktop/src-tauri/src/runpod.rs'
               - 'release-plz.toml'
               - 'website/deployment/docker.md'
@@ -108,6 +109,7 @@ jobs:
               - 'scripts/qualify-cuda-sm86.sh'
               - 'docs/qualification/**'
               - 'scripts/tests/docker-web-context.sh'
+              - 'scripts/tests/desktop-candle-lock-sync.sh'
               - 'scripts/tests/release-sync-pr.sh'
               - '.github/workflows/release-plz.yml'
               - '.github/workflows/ci.yml'
@@ -124,6 +126,8 @@ jobs:
         run: bash scripts/tests/ci-coverage-disk-guard.sh
       - name: Test Docker web build context
         run: bash scripts/tests/docker-web-context.sh
+      - name: Test desktop Candle lock synchronization
+        run: bash scripts/tests/desktop-candle-lock-sync.sh
       - name: Test CUDA distribution contract
         run: bash scripts/tests/cuda-distribution-contract.sh
       - name: Test embedded PTX parser contract

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -716,9 +716,9 @@ dependencies = [
 
 [[package]]
 name = "candle-core-mold"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48586739054543b6a1e9f9c0cb99b95966f663365df9dbf0871c9354e7c05237"
+checksum = "7c8fb900f10525efe6d276d4834095100dbc9e4898f5f8a9849d27fcfef82618"
 dependencies = [
  "byteorder",
  "candle-kernels",
@@ -770,9 +770,9 @@ dependencies = [
 
 [[package]]
 name = "candle-nn-mold"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "444ec65690c63c933550c0c20119ee51737bf735cb68abc9944b181fb28c1c70"
+checksum = "e97b9062d469eab7d82978ee62ff91aea853051b7739d5f16b1c5e5cd9e8b450"
 dependencies = [
  "candle-core-mold",
  "candle-metal-kernels-mold",
@@ -788,9 +788,9 @@ dependencies = [
 
 [[package]]
 name = "candle-transformers-mold"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589960fc3a18e813f3d12446351db1fb973f4b405b47baf1e40b9b7c92e915e5"
+checksum = "f4bf49698799015758a3a5e1db1d928edeb76e3104dce2e4bfff286a9def247c"
 dependencies = [
  "byteorder",
  "candle-core-mold",

--- a/scripts/tests/desktop-candle-lock-sync.sh
+++ b/scripts/tests/desktop-candle-lock-sync.sh
@@ -40,7 +40,7 @@ for dependency in candle-core candle-nn candle-transformers; do
   test -n "$required" || fail "could not read $dependency requirement from mold-inference"
   test -n "$locked" || fail "desktop lockfile is missing ${dependency}-mold"
   test "$locked" = "$required" ||
-    fail "desktop lockfile has ${dependency}-mold $locked, but mold-inference requires $required; run: cargo update --manifest-path desktop/src-tauri/Cargo.toml -p candle-core-mold --precise $required"
+    fail "desktop lockfile has ${dependency}-mold $locked, but mold-inference requires $required; run: cargo update --manifest-path desktop/src-tauri/Cargo.toml -p ${dependency}-mold --precise $required"
 done
 
 echo "PASS: desktop Candle lockfile matches mold-inference"

--- a/scripts/tests/desktop-candle-lock-sync.sh
+++ b/scripts/tests/desktop-candle-lock-sync.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Keep the excluded Tauri crate's lockfile aligned with the Candle fork
+# requirements inherited through mold-inference.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+manifest="$repo_root/crates/mold-inference/Cargo.toml"
+desktop_lock="$repo_root/desktop/src-tauri/Cargo.lock"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+manifest_version() {
+  local dependency="$1"
+  sed -nE \
+    "s/^${dependency} = \\{ package = \"${dependency}-mold\", version = \"([^\"]+)\".*$/\\1/p" \
+    "$manifest"
+}
+
+lock_version() {
+  local package="$1"
+  awk -v package="$package" '
+    $0 == "name = \"" package "\"" {
+      getline
+      if ($1 == "version" && $2 == "=") {
+        gsub(/"/, "", $3)
+        print $3
+        exit
+      }
+    }
+  ' "$desktop_lock"
+}
+
+for dependency in candle-core candle-nn candle-transformers; do
+  required="$(manifest_version "$dependency")"
+  locked="$(lock_version "${dependency}-mold")"
+
+  test -n "$required" || fail "could not read $dependency requirement from mold-inference"
+  test -n "$locked" || fail "desktop lockfile is missing ${dependency}-mold"
+  test "$locked" = "$required" ||
+    fail "desktop lockfile has ${dependency}-mold $locked, but mold-inference requires $required; run: cargo update --manifest-path desktop/src-tauri/Cargo.toml -p candle-core-mold --precise $required"
+done
+
+echo "PASS: desktop Candle lockfile matches mold-inference"


### PR DESCRIPTION
## Summary
- refresh the excluded desktop Tauri lockfile to Candle fork 0.9.13
- run the release contract when the desktop lockfile changes
- guard the desktop lockfile against future Candle requirement drift

## Root cause
The workspace manifests moved `candle-*-mold` to 0.9.13, but `desktop/src-tauri/Cargo.lock` remained on 0.9.12. The Nix desktop derivation vendors from that separate lockfile, so the main Release workflow failed offline dependency resolution before compilation.

## Verification
- `bash scripts/tests/desktop-candle-lock-sync.sh`
- `cargo metadata --manifest-path desktop/src-tauri/Cargo.toml --locked --no-deps`
- `bash scripts/tests/release-sync-pr.sh`
- `git diff --check`
- `nix build .#mold-desktop --no-link` passed vendoring and full release compilation against Candle 0.9.13; the local macOS bundle hook then encountered the unrelated existing `src-tauri/target/release/mold-desktop` path assumption after compilation

Fixes the failure in main Release run 30581411123.