### PR TITLE
perf(ci): route jobs by changed surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,13 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: "1"
 
+concurrency:
+  # A pushed commit makes every older run for that PR obsolete. Cancel it
+  # before it can keep scarce macOS/CUDA runners busy. Main runs are never
+  # canceled because they warm caches and provide the post-merge signal.
+  group: ci-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 # Cache strategy: jobs that compile the same features share a cache key.
 # Only main-branch pushes save caches; PRs read from main's cache.
 #
@@ -29,6 +36,7 @@ jobs:
       pull-requests: read
     outputs:
       rust: ${{ steps.filter.outputs.rust }}
+      gpu: ${{ steps.filter.outputs.gpu }}
       website: ${{ steps.filter.outputs.website }}
       web: ${{ steps.filter.outputs.web }}
       nix: ${{ steps.filter.outputs.nix }}
@@ -50,6 +58,18 @@ jobs:
               - 'docs/qualification/local-multi-gpu-report.schema.json'
               - 'docs/qualification/README.md'
               - '.github/workflows/ci.yml'
+            # Forced-local checks exist to compile backend-specific code that
+            # the ordinary workspace gate cannot see. Backend-neutral crates
+            # (catalog, DB, Discord, scheduler) are already covered by `rust`.
+            gpu:
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'crates/mold-cli/**'
+              - 'crates/mold-core/**'
+              - 'crates/mold-inference/**'
+              - 'crates/mold-server/**'
+              - 'crates/mold-tui/**'
+              - '.github/workflows/ci.yml'
             website:
               - 'website/**'
               - '.github/workflows/ci.yml'
@@ -63,7 +83,6 @@ jobs:
               - '.github/workflows/ci.yml'
             nix:
               - 'web/**'
-              - 'desktop/**'
               - 'studio/**'
               - 'ui/**'
               - 'package.json'
@@ -102,6 +121,7 @@ jobs:
               - 'scripts/validate-cuda-qualification-report.py'
               - 'scripts/verify-png-artifact.py'
               - 'scripts/tests/ci-coverage-disk-guard.sh'
+              - 'scripts/tests/ci-routing-contract.sh'
               - 'scripts/tests/cuda-distribution-contract.sh'
               - 'scripts/tests/cuda-ptx-parser-contract.py'
               - 'scripts/tests/install-cuda-arch.sh'
@@ -124,6 +144,8 @@ jobs:
         run: bash scripts/tests/release-sync-pr.sh
       - name: Test CI coverage disk guard
         run: bash scripts/tests/ci-coverage-disk-guard.sh
+      - name: Test CI job routing
+        run: bash scripts/tests/ci-routing-contract.sh
       - name: Test Docker web build context
         run: bash scripts/tests/docker-web-context.sh
       - name: Test desktop Candle lock synchronization
@@ -242,7 +264,7 @@ jobs:
   cuda-check:
     name: CUDA forced-local typecheck
     needs: changes
-    if: needs.changes.outputs.rust == 'true'
+    if: needs.changes.outputs.gpu == 'true'
     runs-on: ubuntu-22.04
     env:
       CUDA_COMPUTE_CAP: "89"
@@ -275,7 +297,7 @@ jobs:
   metal-check:
     name: Metal forced-local typecheck
     needs: changes
-    if: needs.changes.outputs.rust == 'true'
+    if: needs.changes.outputs.gpu == 'true'
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v6
@@ -289,7 +311,10 @@ jobs:
 
   coverage:
     needs: changes
-    if: needs.changes.outputs.rust == 'true'
+    # PRs already run the complete test suite in `rust`. Coverage is
+    # informational (Codecov failures are non-blocking), so collect it once
+    # after merge instead of recompiling the workspace on every PR revision.
+    if: github.event_name == 'push' && needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     env:
       RUSTC_WRAPPER: sccache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,8 @@ jobs:
               - 'website/deployment/nixos.md'
               - 'website/guide/installation.md'
               - '.github/workflows/desktop-distribution.yml'
+              - '.github/workflows/desktop.yml'
+              - '.github/workflows/ios.yml'
               - '.github/workflows/release.yml'
               - 'scripts/release/**'
               - 'scripts/verify-cuda-release-binary.sh'

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -10,7 +10,22 @@ on:
   push:
     branches: [main]
     paths:
-      - "desktop/**"
+      - "desktop/src/*.ts"
+      - "desktop/src/*.vue"
+      - "desktop/src/assets/**"
+      - "desktop/src/components/**"
+      - "desktop/src/lib/**"
+      - "desktop/src/stores/**"
+      - "desktop/src/styles/**"
+      - "desktop/src/views/**"
+      - "desktop/src-tauri/**"
+      - "desktop/.prettierignore"
+      - "desktop/icon-master.png"
+      - "desktop/index.html"
+      - "desktop/package.json"
+      - "desktop/tsconfig.json"
+      - "desktop/vite.config.ts"
+      - "desktop/vitest.config.ts"
       - "studio/**"
       - "ui/**"
       - "package.json"
@@ -20,6 +35,7 @@ on:
       - "crates/mold-catalog/**"
       - "crates/mold-db/**"
       - "crates/mold-inference/**"
+      - "crates/mold-scheduler/**"
       - "crates/mold-server/**"
       - "flake.nix"
       - "Cargo.toml"
@@ -46,7 +62,22 @@ on:
       - "scripts/verify-desktop-updater-signature.sh"
   pull_request:
     paths:
-      - "desktop/**"
+      - "desktop/src/*.ts"
+      - "desktop/src/*.vue"
+      - "desktop/src/assets/**"
+      - "desktop/src/components/**"
+      - "desktop/src/lib/**"
+      - "desktop/src/stores/**"
+      - "desktop/src/styles/**"
+      - "desktop/src/views/**"
+      - "desktop/src-tauri/**"
+      - "desktop/.prettierignore"
+      - "desktop/icon-master.png"
+      - "desktop/index.html"
+      - "desktop/package.json"
+      - "desktop/tsconfig.json"
+      - "desktop/vite.config.ts"
+      - "desktop/vitest.config.ts"
       - "studio/**"
       - "ui/**"
       - "package.json"
@@ -56,6 +87,7 @@ on:
       - "crates/mold-catalog/**"
       - "crates/mold-db/**"
       - "crates/mold-inference/**"
+      - "crates/mold-scheduler/**"
       - "crates/mold-server/**"
       - "flake.nix"
       - "Cargo.toml"
@@ -95,8 +127,102 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  changes:
+    name: Classify desktop changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      frontend: ${{ steps.filter.outputs.frontend }}
+      rust: ${{ steps.filter.outputs.rust }}
+      updater: ${{ steps.filter.outputs.updater }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            frontend:
+              - 'desktop/src/*.ts'
+              - 'desktop/src/*.vue'
+              - 'desktop/src/assets/**'
+              - 'desktop/src/components/**'
+              - 'desktop/src/lib/**'
+              - 'desktop/src/stores/**'
+              - 'desktop/src/styles/**'
+              - 'desktop/src/views/**'
+              - 'desktop/.prettierignore'
+              - 'desktop/icon-master.png'
+              - 'desktop/index.html'
+              - 'desktop/package.json'
+              - 'desktop/tsconfig.json'
+              - 'desktop/vite.config.ts'
+              - 'desktop/vitest.config.ts'
+              - 'studio/**'
+              - 'ui/**'
+              - 'package.json'
+              - 'bun.lock'
+              - 'bun.nix'
+              - '.github/workflows/desktop.yml'
+              - '.github/workflows/desktop-distribution.yml'
+              - 'scripts/check-desktop-nightly-main-head.sh'
+              - 'scripts/create-desktop-bundle-version.sh'
+              - 'scripts/create-desktop-nightly-version.sh'
+              - 'scripts/create-desktop-update-manifest.sh'
+              - 'scripts/fix-desktop-macos-linkage.sh'
+              - 'scripts/notarize-desktop-dmg.sh'
+              - 'scripts/prepare-desktop-linuxdeploy.sh'
+              - 'scripts/prune-desktop-nightly-assets.sh'
+              - 'scripts/select-desktop-stable-latest.sh'
+              - 'scripts/tests/check-desktop-nightly-main-head.sh'
+              - 'scripts/tests/create-desktop-bundle-version.sh'
+              - 'scripts/tests/create-desktop-nightly-version.sh'
+              - 'scripts/tests/create-desktop-update-manifest.sh'
+              - 'scripts/tests/desktop-nightly-race-guards.sh'
+              - 'scripts/tests/prune-desktop-nightly-assets.sh'
+              - 'scripts/tests/select-desktop-stable-latest.sh'
+              - 'scripts/tests/verify-desktop-updater-signature.sh'
+              - 'scripts/verify-desktop-release.sh'
+              - 'scripts/verify-desktop-updater-signature.sh'
+            rust:
+              - 'desktop/src-tauri/**'
+              - 'crates/mold-core/**'
+              - 'crates/mold-catalog/**'
+              - 'crates/mold-db/**'
+              - 'crates/mold-inference/**'
+              - 'crates/mold-scheduler/**'
+              - 'crates/mold-server/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'flake.nix'
+              - '.github/workflows/desktop.yml'
+              - '.github/workflows/desktop-distribution.yml'
+            updater:
+              - '.github/workflows/desktop.yml'
+              - '.github/workflows/desktop-distribution.yml'
+              - 'scripts/check-desktop-nightly-main-head.sh'
+              - 'scripts/create-desktop-bundle-version.sh'
+              - 'scripts/create-desktop-nightly-version.sh'
+              - 'scripts/create-desktop-update-manifest.sh'
+              - 'scripts/notarize-desktop-dmg.sh'
+              - 'scripts/prune-desktop-nightly-assets.sh'
+              - 'scripts/select-desktop-stable-latest.sh'
+              - 'scripts/tests/check-desktop-nightly-main-head.sh'
+              - 'scripts/tests/create-desktop-bundle-version.sh'
+              - 'scripts/tests/create-desktop-nightly-version.sh'
+              - 'scripts/tests/create-desktop-update-manifest.sh'
+              - 'scripts/tests/desktop-nightly-race-guards.sh'
+              - 'scripts/tests/prune-desktop-nightly-assets.sh'
+              - 'scripts/tests/select-desktop-stable-latest.sh'
+              - 'scripts/tests/verify-desktop-updater-signature.sh'
+              - 'scripts/verify-desktop-release.sh'
+              - 'scripts/verify-desktop-updater-signature.sh'
+
   desktop-frontend:
     name: Frontend (typecheck, tests, format)
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -105,8 +231,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
       - name: Install updater verification tooling
+        if: github.event_name != 'pull_request' || needs.changes.outputs.updater == 'true'
         run: sudo apt-get update && sudo apt-get install -y minisign
       - name: Test updater release scripts
+        if: github.event_name != 'pull_request' || needs.changes.outputs.updater == 'true'
         run: |
           bash ../scripts/tests/check-desktop-nightly-main-head.sh
           bash ../scripts/tests/create-desktop-bundle-version.sh
@@ -125,6 +253,8 @@ jobs:
 
   desktop-rust:
     name: macOS Rust (fmt, clippy, test)
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.rust == 'true'
     runs-on: macos-14
     defaults:
       run:
@@ -149,6 +279,8 @@ jobs:
 
   desktop-linux:
     name: Linux (clippy, test; main AppImage)
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-22.04
     defaults:
       run:

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -69,9 +69,65 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  # Do not let an obsolete PR revision hold a macOS runner while its
+  # replacement waits. Main and manual runs always finish.
+  group: ios-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
+  changes:
+    name: Classify iOS changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      frontend: ${{ steps.filter.outputs.frontend }}
+      rust: ${{ steps.filter.outputs.rust }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            frontend:
+              - 'apps/mobile/**'
+              - 'studio/**'
+              - 'ui/**'
+              - 'package.json'
+              - 'bun.lock'
+              - 'bun.nix'
+              - 'desktop/src/mobile/**'
+              - 'desktop/src/components/**'
+              - 'desktop/src/lib/**'
+              - 'desktop/src/stores/**'
+              - 'desktop/src/styles/**'
+              - 'desktop/src/assets/**'
+              - 'desktop/package.json'
+              - 'desktop/icon-master.png'
+              - 'desktop/vite.mobile.config.ts'
+              - 'desktop/index.mobile.html'
+              - 'scripts/ios.sh'
+              - 'scripts/generate-ios-icons.sh'
+              - 'scripts/tests/ios-release-assets.sh'
+              - 'scripts/tests/ios-testflight-distribution.sh'
+              - 'scripts/ios-sim.sh'
+              - 'scripts/tests/ios-sim-pick.sh'
+              - 'scripts/ensure-testflight-tester.rb'
+              - 'scripts/wait-for-testflight.rb'
+              - '.github/workflows/ios.yml'
+              - '.github/workflows/testflight-ios.yml'
+            rust:
+              - 'apps/mobile/src-tauri/**'
+              - 'flake.nix'
+              - '.github/workflows/ios.yml'
+              - '.github/workflows/testflight-ios.yml'
+
   frontend:
     name: Mobile frontend
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -89,6 +145,8 @@ jobs:
 
   simulator-rust:
     name: iOS simulator Rust
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.rust == 'true'
     runs-on: macos-14
     defaults:
       run:

--- a/scripts/tests/ci-routing-contract.sh
+++ b/scripts/tests/ci-routing-contract.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ci="$repo_root/.github/workflows/ci.yml"
+desktop="$repo_root/.github/workflows/desktop.yml"
+ios="$repo_root/.github/workflows/ios.yml"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+require_text() {
+  local file=$1
+  local text=$2
+  local message=$3
+  grep -Fq "$text" "$file" || fail "$message"
+}
+
+require_text "$ci" \
+  "cancel-in-progress: \${{ github.event_name == 'pull_request' }}" \
+  "root CI does not cancel superseded PR runs"
+require_text "$ci" \
+  "if: needs.changes.outputs.gpu == 'true'" \
+  "backend checks are not routed through the GPU-specific classifier"
+require_text "$ci" \
+  "if: github.event_name == 'push' && needs.changes.outputs.rust == 'true'" \
+  "coverage is not deferred to the post-merge main run"
+
+nix_filter="$(sed -n '/^            nix:/,/^            release:/p' "$ci")"
+if grep -Fq "desktop/**" <<< "$nix_filter"; then
+  fail "desktop-only changes still start the mold-web Nix build"
+fi
+
+desktop_classifier="$(sed -n '/^  changes:/,/^  desktop-frontend:/p' "$desktop")"
+require_text "$desktop" "name: Classify desktop changes" \
+  "desktop workflow has no path classifier"
+require_text "$desktop" \
+  "if: github.event_name != 'pull_request' || needs.changes.outputs.frontend == 'true'" \
+  "desktop frontend job is not path-gated on PRs"
+require_text "$desktop" \
+  "if: github.event_name != 'pull_request' || needs.changes.outputs.rust == 'true'" \
+  "desktop native jobs are not path-gated on PRs"
+[[ "$(grep -Fc "if: github.event_name != 'pull_request' || needs.changes.outputs.updater == 'true'" "$desktop")" -eq 2 ]] \
+  || fail "updater tooling and contract tests are not restricted to updater changes on PRs"
+if grep -Fq "desktop/**" <<< "$desktop_classifier"; then
+  fail "desktop frontend classifier is broad enough to include native/mobile files"
+fi
+[[ "$(grep -Fc 'desktop/src/components/**' "$desktop")" -eq 3 ]] \
+  || fail "desktop frontend trigger/classifier does not track desktop components"
+[[ "$(grep -Fc 'desktop/src-tauri/**' "$desktop")" -eq 3 ]] \
+  || fail "desktop native trigger/classifier does not track the Tauri crate"
+if grep -Fq "desktop/src/mobile/**" "$desktop"; then
+  fail "mobile-only changes are not owned exclusively by the iOS workflow"
+fi
+[[ "$(grep -Fc 'crates/mold-scheduler/**' "$desktop")" -eq 3 ]] \
+  || fail "desktop trigger/classifier does not track its scheduler dependency"
+
+require_text "$ios" \
+  "cancel-in-progress: \${{ github.event_name == 'pull_request' }}" \
+  "iOS workflow does not cancel superseded PR runs"
+require_text "$ios" "name: Classify iOS changes" \
+  "iOS workflow has no path classifier"
+require_text "$ios" \
+  "if: github.event_name != 'pull_request' || needs.changes.outputs.rust == 'true'" \
+  "iOS simulator job is not restricted to native changes on PRs"
+require_text "$ios" "run: ../scripts/tests/ios-release-assets.sh" \
+  "iOS frontend job does not validate the built mobile entry"
+
+echo "PASS: CI routing contract"

--- a/scripts/tests/ci-routing-contract.sh
+++ b/scripts/tests/ci-routing-contract.sh
@@ -27,6 +27,11 @@ require_text "$ci" \
 require_text "$ci" \
   "if: github.event_name == 'push' && needs.changes.outputs.rust == 'true'" \
   "coverage is not deferred to the post-merge main run"
+release_filter="$(sed -n '/^            release:/,/^  release:/p' "$ci")"
+for workflow in desktop.yml ios.yml; do
+  grep -Fq ".github/workflows/$workflow" <<< "$release_filter" \
+    || fail "release classifier does not run the routing contract for $workflow changes"
+done
 
 nix_filter="$(sed -n '/^            nix:/,/^            release:/p' "$ci")"
 if grep -Fq "desktop/**" <<< "$nix_filter"; then


### PR DESCRIPTION
## Summary

- cancel superseded root CI and iOS PR runs before they consume constrained runners
- classify root, desktop, and iOS changes so backend, native, frontend, updater, Nix, and coverage work only runs when relevant
- make mobile-only changes exclusively use the iOS workflow and defer informational coverage collection to post-merge main
- add a CI routing contract that protects the scheduling policy

## History-driven impact

The current mobile-only PR #638 executes seven real jobs. With this routing it executes three: root classification plus iOS classification/frontend. This removes the unrelated Nix web build, all Desktop jobs, and iOS simulator Rust. Superseded CI runs for recent multi-revision PRs will now cancel instead of continuing alongside their replacement.

## Validation

- `actionlint` on all changed workflows
- `shellcheck scripts/tests/ci-routing-contract.sh`
- `bash scripts/tests/ci-routing-contract.sh`
- `bash scripts/tests/desktop-nightly-race-guards.sh`
- `bash scripts/tests/ci-coverage-disk-guard.sh`
- `bash scripts/tests/release-sync-pr.sh`
- `bash scripts/tests/ios-release-assets.sh`
- `git diff --check`