### PR TITLE
feat(studio): add gallery and host context actions

### DIFF
--- a/desktop/src/views/LibraryView.test.ts
+++ b/desktop/src/views/LibraryView.test.ts
@@ -52,6 +52,7 @@ import { useConnectionStore } from "../stores/connection";
 import { useContextMenuStore, type MenuEntry } from "../stores/contextMenu";
 import { useGalleryStore } from "../stores/gallery";
 import { useHostsStore } from "../stores/hosts";
+import { useGenerateFormStore } from "../stores/generateForm";
 import { useToastStore } from "../stores/toasts";
 import type { GalleryImage } from "../lib/api/types";
 import { installMemoryLocalStorage } from "../lib/testSupport/memoryLocalStorage";
@@ -158,6 +159,39 @@ beforeEach(() => {
 });
 
 describe("LibraryView delete keyboard handling", () => {
+  it("loads a remote gallery image as the Create source from its context menu", async () => {
+    const remotePrint: GalleryImage = {
+      ...prints[0]!,
+      filename: "remote-source.png",
+      timestamp: 3,
+      metadata: { ...prints[0]!.metadata, seed: 9 },
+    };
+    apiFetchTo.mockResolvedValueOnce(new Response(new Uint8Array([65, 66, 67])));
+    const { wrapper, router } = await mountView(remotePrint);
+
+    const tile = wrapper.findAll("button").find((button) => button.text().includes("S 9"));
+    expect(tile).toBeDefined();
+    await tile!.trigger("contextmenu");
+
+    const menu = useContextMenuStore();
+    const sourceEntry = menu.entries.find(
+      (entry) => !("separator" in entry) && entry.label === "Use as source",
+    )!;
+    expect(sourceEntry).toMatchObject({ disabled: false });
+    menu.activate(sourceEntry);
+    await flushPromises();
+
+    expect(apiFetchTo).toHaveBeenCalledWith(
+      { baseUrl: "http://plato:7680", apiKey: "secret" },
+      "/api/gallery/image/remote-source.png",
+    );
+    expect(useGenerateFormStore().form.sourceImage).toBe("QUJD");
+    expect(useGenerateFormStore().form.sourceImageName).toBe("remote-source.png");
+    expect(router.currentRoute.value.path).toBe("/create");
+    expect(useToastStore().items.at(-1)?.message).toBe("Loaded as source");
+    wrapper.unmount();
+  });
+
   it.each(["Delete", "Backspace"])(
     "prevents %s navigation and only DELETEs after the undo window",
     async (key) => {

--- a/desktop/src/views/LibraryView.vue
+++ b/desktop/src/views/LibraryView.vue
@@ -314,6 +314,11 @@ function tileMenu(entry: MergedPrint): MenuEntry[] {
       action: () => void copyImage(entry),
     },
     {
+      label: "Use as source",
+      disabled: isVideo(item),
+      action: () => void useAsSource(entry),
+    },
+    {
       label: "Copy file path",
       action: () =>
         void copyLocalOutputPath(item.filename)
@@ -691,14 +696,12 @@ function removeSelected() {
 }
 
 /**
- * "Use as source" from the lightbox — load this print's bytes into the Create
+ * "Use as source" from the gallery — load this print's bytes into the Create
  * composer as the img2img source (raw base64, the form's contract) and open
  * Create. Deliberately does NOT touch `composer.prefill`, so GenerateView's
  * prefill watcher can't clobber the source we just attached.
  */
-async function useSelectedAsSource() {
-  const entry = selectedEntry.value;
-  if (!entry) return;
+async function useAsSource(entry: MergedPrint) {
   try {
     const base64 = await fetchItemBase64(entry);
     generateForm.form.sourceImage = base64;
@@ -709,6 +712,11 @@ async function useSelectedAsSource() {
   } catch (error) {
     toasts.push(error instanceof Error ? error.message : String(error), "error");
   }
+}
+
+async function useSelectedAsSource() {
+  const entry = selectedEntry.value;
+  if (entry) await useAsSource(entry);
 }
 
 // Deep link: /library?host=<bucket key> pre-picks a chip ("local" = This

--- a/desktop/src/views/MachinesView.test.ts
+++ b/desktop/src/views/MachinesView.test.ts
@@ -32,6 +32,7 @@ vi.mock("../lib/notify", () => ({ notifyGenerated: vi.fn(), notifyGenerationFail
 import MachinesView from "./MachinesView.vue";
 import { useConnectionStore } from "../stores/connection";
 import { useHostsStore } from "../stores/hosts";
+import { useContextMenuStore } from "../stores/contextMenu";
 
 const stub = { template: "<div />" };
 let router: Router;
@@ -130,6 +131,33 @@ beforeEach(() => {
 });
 
 describe("MachinesView overview", () => {
+  it("offers common context-menu actions for connected, remembered, and discovered hosts", async () => {
+    const wrapper = await mountView();
+
+    await wrapper.get("[data-test='host-card']").trigger("contextmenu");
+    expect(
+      useContextMenuStore().entries.flatMap((entry) => ("separator" in entry ? [] : [entry.label])),
+    ).toEqual([
+      "Open details",
+      "Set as generation target",
+      "Copy address",
+      "Open web UI",
+      "Disconnect",
+      "Forget…",
+    ]);
+
+    await wrapper.get("[data-test='remembered-host']").trigger("contextmenu");
+    expect(
+      useContextMenuStore().entries.flatMap((entry) => ("separator" in entry ? [] : [entry.label])),
+    ).toEqual(["Connect", "Copy address", "Forget…"]);
+
+    await wrapper.get("[data-test='discovered-host']").trigger("contextmenu");
+    expect(
+      useContextMenuStore().entries.flatMap((entry) => ("separator" in entry ? [] : [entry.label])),
+    ).toEqual(["Connect", "Copy address"]);
+    wrapper.unmount();
+  });
+
   it("renders This device first, then connected remote cards", async () => {
     const wrapper = await mountView();
     expect(wrapper.find("[data-test='this-device-card']").exists()).toBe(true);

--- a/desktop/src/views/MachinesView.vue
+++ b/desktop/src/views/MachinesView.vue
@@ -15,6 +15,7 @@ import Icon from "@ui/components/Icon.vue";
 import ConnectMachineModal from "../components/machines/ConnectMachineModal.vue";
 import QueueColumn from "../components/machines/QueueColumn.vue";
 import PodCostMeter from "../components/machines/PodCostMeter.vue";
+import ConfirmDialog from "../components/shell/ConfirmDialog.vue";
 import { ipc, type DiscoveredHost, type SavedHost } from "../lib/ipc";
 import { gpuFleetLabel, gpuSnapshotsFromWorkers } from "../lib/api/gpuStatus";
 import { addressLabel, prepareHosts, versionLabel } from "../lib/discovery";
@@ -22,12 +23,16 @@ import { formatGB } from "../lib/format";
 import { hostIdFromUrl, inferBackendFromGpuName } from "../lib/hosts";
 import { podGpuName, type RunPodPod } from "../lib/runpod";
 import { useHostsStore, type HostView } from "../stores/hosts";
+import { useAppPrefsStore } from "../stores/appPrefs";
+import { useContextMenuStore, type MenuEntry } from "../stores/contextMenu";
 import { useJobsStore } from "../stores/jobs";
 import { useRunPodStore } from "../stores/runpod";
 import { useToastStore } from "../stores/toasts";
 
 const router = useRouter();
 const hosts = useHostsStore();
+const appPrefs = useAppPrefsStore();
+const contextMenu = useContextMenuStore();
 const jobs = useJobsStore();
 const runpod = useRunPodStore();
 const toasts = useToastStore();
@@ -55,6 +60,110 @@ const connectOpen = ref(false);
 
 function openDetail(host: HostView) {
   void router.push(`/machines/${host.id}`);
+}
+
+async function copyAddress(address: string) {
+  try {
+    await navigator.clipboard.writeText(address);
+    toasts.push("Address copied");
+  } catch (err) {
+    toasts.push(err instanceof Error ? err.message : String(err), "error");
+  }
+}
+
+async function openHostUrl(url: string) {
+  try {
+    const { openUrl } = await import("@tauri-apps/plugin-opener");
+    await openUrl(url);
+  } catch {
+    window.open(url, "_blank", "noopener");
+  }
+}
+
+async function disconnectHost(host: HostView) {
+  await hosts.disconnect(host.id);
+  await refreshSaved();
+  toasts.push(`Disconnected from ${host.label}`);
+}
+
+const forgetCandidate = ref<{ id: string; label: string; connected: boolean } | null>(null);
+
+async function forgetHost() {
+  const candidate = forgetCandidate.value;
+  forgetCandidate.value = null;
+  if (!candidate) return;
+  try {
+    if (candidate.connected) await hosts.disconnect(candidate.id);
+    await ipc.forgetRemoteHost(candidate.id);
+    await refreshSaved();
+    toasts.push(`Forgot ${candidate.label}`);
+  } catch (err) {
+    toasts.push(err instanceof Error ? err.message : String(err), "error");
+  }
+}
+
+function connectedHostMenu(host: HostView): MenuEntry[] {
+  const isTarget = (appPrefs.settings?.generateTargetHost ?? null) === host.id;
+  return [
+    { label: "Open details", action: () => openDetail(host) },
+    {
+      label: isTarget ? "Generation target" : "Set as generation target",
+      disabled: isTarget || host.status !== "ready",
+      action: () => void appPrefs.update({ generateTargetHost: host.id }),
+    },
+    {
+      label: "Copy address",
+      disabled: !host.baseUrl,
+      action: () => void copyAddress(host.baseUrl ?? ""),
+    },
+    {
+      label: "Open web UI",
+      disabled: !host.baseUrl,
+      action: () => void openHostUrl(host.baseUrl ?? ""),
+    },
+    ...(host.kind === "remote"
+      ? [
+          { separator: true } as const,
+          ...(host.status === "error"
+            ? [{ label: "Retry connection", action: () => void hosts.reconnect(host.id) }]
+            : []),
+          { label: "Disconnect", action: () => void disconnectHost(host) },
+          {
+            label: "Forget…",
+            danger: true,
+            action: () => {
+              forgetCandidate.value = { id: host.id, label: host.label, connected: true };
+            },
+          },
+        ]
+      : []),
+  ];
+}
+
+function rememberedHostMenu(host: SavedHost): MenuEntry[] {
+  return [
+    { label: "Connect", disabled: adding.value, action: () => void connectSaved(host) },
+    { label: "Copy address", action: () => void copyAddress(host.url) },
+    { separator: true },
+    {
+      label: "Forget…",
+      danger: true,
+      action: () => {
+        forgetCandidate.value = { id: host.id, label: savedHostLabel(host), connected: false };
+      },
+    },
+  ];
+}
+
+function discoveredHostMenu(host: DiscoveredHost): MenuEntry[] {
+  return [
+    {
+      label: "Connect",
+      disabled: adding.value || isThisMachine(host),
+      action: () => void addDiscovered(host),
+    },
+    { label: "Copy address", action: () => void copyAddress(host.url) },
+  ];
 }
 
 // ── Card telemetry (from the app-wide status poll) ────────────────────────
@@ -239,6 +348,7 @@ async function onConnected() {
             :data-test="host.primary ? 'this-device-card' : 'host-card'"
             class="border-edge rounded-chrome border bg-bench p-4 text-left shadow-[inset_0_1px_0_var(--card-hi)] transition-colors hover:border-ink-3"
             @click="openDetail(host)"
+            @contextmenu="contextMenu.open($event, connectedHostMenu(host))"
           >
             <div class="flex items-center gap-2.5">
               <span class="h-2 w-2 shrink-0 rounded-full" :class="statusDot(host.status)" />
@@ -317,6 +427,7 @@ async function onConnected() {
               :key="saved.id"
               data-test="remembered-host"
               class="border-edge flex items-center gap-3 rounded-chrome border bg-bench px-4 py-3 opacity-70"
+              @contextmenu="contextMenu.open($event, rememberedHostMenu(saved))"
             >
               <span class="h-2 w-2 shrink-0 rounded-full bg-ink-3" />
               <div class="min-w-0 flex-1">
@@ -353,6 +464,7 @@ async function onConnected() {
             :key="host.url"
             data-test="discovered-host"
             class="border-edge flex items-center gap-3 rounded-chrome border bg-bench px-4 py-3"
+            @contextmenu="contextMenu.open($event, discoveredHostMenu(host))"
           >
             <span class="h-2 w-2 shrink-0 rounded-full bg-halide" />
             <div class="min-w-0 flex-1">
@@ -394,6 +506,15 @@ async function onConnected() {
       :open="connectOpen"
       @close="connectOpen = false"
       @connected="onConnected"
+    />
+    <ConfirmDialog
+      :open="forgetCandidate !== null"
+      title="Forget this machine?"
+      :message="`${forgetCandidate?.label ?? 'This machine'} and its saved API key will be removed.`"
+      confirm-label="Forget machine"
+      danger
+      @confirm="forgetHost"
+      @cancel="forgetCandidate = null"
     />
   </div>
 </template>

--- a/web/src/components/machines/HostCard.vue
+++ b/web/src/components/machines/HostCard.vue
@@ -16,7 +16,11 @@ import { deriveHostCardGpu, formatGb } from "./machineTelemetry";
 import type { HostEntry } from "../../lib/hostRegistry";
 
 const props = defineProps<{ host: HostEntry; primary?: boolean }>();
-const emit = defineEmits<{ open: [id: string]; reconnect: [id: string] }>();
+const emit = defineEmits<{
+  open: [id: string];
+  reconnect: [id: string];
+  contextMenu: [payload: { host: HostEntry; x: number; y: number }];
+}>();
 
 const disconnected = computed(() => props.host.connected === false);
 const poll = useHostPoll(
@@ -101,6 +105,10 @@ function reconnect(event: Event) {
   event.stopPropagation();
   emit("reconnect", props.host.id);
 }
+
+function openContextMenu(event: MouseEvent) {
+  emit("contextMenu", { host: props.host, x: event.clientX, y: event.clientY });
+}
 </script>
 
 <template>
@@ -119,6 +127,7 @@ function reconnect(event: Event) {
       :aria-label="disconnected ? undefined : `Open ${host.name}`"
       @click="open"
       @keydown="onKey"
+      @contextmenu.prevent.stop="openContextMenu"
     >
       <div class="hc__head">
         <StatusDot :state="dotState" />

--- a/web/src/pages/MachinesPage.test.ts
+++ b/web/src/pages/MachinesPage.test.ts
@@ -92,6 +92,25 @@ describe("MachinesPage", () => {
     expect(w.get('[data-test="host-mem"]').text()).toContain("/ 48.0 GB");
   });
 
+  it("opens a common-actions context menu for a connected host", async () => {
+    poll.loading.value = false;
+    poll.online.value = true;
+    poll.status.value = makeStatus();
+    const w = mountPage();
+    await nextTick();
+
+    await w.get('[data-test="host-card"]').trigger("contextmenu", {
+      clientX: 24,
+      clientY: 32,
+    });
+    const menu = w.get('[data-test="machine-context-menu"]');
+    expect(menu.text()).toContain("Open details");
+    expect(menu.text()).toContain("Generation target");
+    expect(menu.text()).toContain("Copy address");
+    expect(menu.text()).not.toContain("Disconnect");
+    expect(menu.text()).not.toContain("Forget");
+  });
+
   it("shows an offline card with a retry that forces a poll", async () => {
     poll.loading.value = false;
     poll.online.value = false;
@@ -132,6 +151,32 @@ describe("MachinesPage", () => {
       connected: true,
       apiKey: "secret",
     });
+  });
+
+  it("offers reconnect and forget for a remembered host context menu", async () => {
+    localStorage.setItem(
+      "mold.web.hosts.v1",
+      JSON.stringify([
+        {
+          id: "studio-7680",
+          name: "Studio",
+          url: "http://studio:7680",
+          apiKey: "secret",
+          connected: false,
+        },
+      ]),
+    );
+    poll.loading.value = false;
+    const w = mountPage();
+    const cards = w.findAll('[data-test="host-card"]');
+    expect(cards).toHaveLength(2);
+    await cards[1]!.trigger("contextmenu", { clientX: 24, clientY: 32 });
+
+    const menu = w.get('[data-test="machine-context-menu"]');
+    expect(menu.text()).toContain("Connect");
+    expect(menu.text()).toContain("Copy address");
+    expect(menu.text()).toContain("Forget…");
+    expect(menu.text()).not.toContain("Disconnect");
   });
 
   it("opens the connect modal from the header button", async () => {

--- a/web/src/pages/MachinesPage.test.ts
+++ b/web/src/pages/MachinesPage.test.ts
@@ -6,6 +6,13 @@ import type { ResourceSnapshot } from "../types";
 import MachinesPage from "./MachinesPage.vue";
 import ConnectModal from "../components/machines/ConnectModal.vue";
 
+const { toastMock } = vi.hoisted(() => ({ toastMock: vi.fn() }));
+
+vi.mock("../lib/toasts", () => ({
+  toast: toastMock,
+  requestConfirm: vi.fn().mockResolvedValue(false),
+}));
+
 // Shared, mutable poll stub returned by the mocked useHostPoll (every HostCard
 // shares it — the page renders one card here, the primary origin).
 let poll: {
@@ -55,6 +62,7 @@ const mountPage = () =>
 
 beforeEach(() => {
   localStorage.clear();
+  toastMock.mockClear();
   poll = {
     status: ref<HostStatus | null>(null),
     resources: ref<ResourceSnapshot | null>(null),
@@ -109,6 +117,12 @@ describe("MachinesPage", () => {
     expect(menu.text()).toContain("Copy address");
     expect(menu.text()).not.toContain("Disconnect");
     expect(menu.text()).not.toContain("Forget");
+
+    document.body.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true }),
+    );
+    await nextTick();
+    expect(w.find('[data-test="machine-context-menu"]').exists()).toBe(false);
   });
 
   it("shows an offline card with a retry that forces a poll", async () => {
@@ -177,6 +191,15 @@ describe("MachinesPage", () => {
     expect(menu.text()).toContain("Copy address");
     expect(menu.text()).toContain("Forget…");
     expect(menu.text()).not.toContain("Disconnect");
+
+    await menu
+      .findAll("button")
+      .find((button) => button.text() === "Connect")!
+      .trigger("click");
+    expect(
+      JSON.parse(localStorage.getItem("mold.web.hosts.v1") ?? "[]")[0],
+    ).toMatchObject({ connected: true });
+    expect(toastMock).toHaveBeenCalledWith("success", "Studio connected.");
   });
 
   it("opens the connect modal from the header button", async () => {

--- a/web/src/pages/MachinesPage.vue
+++ b/web/src/pages/MachinesPage.vue
@@ -17,16 +17,20 @@ import {
   HOSTS_CHANGED_EVENT,
   HOSTS_STORAGE_KEY,
   ORIGIN_HOST_ID,
+  getGenerateTargetId,
   listKnownHosts,
+  removeHost,
   setHostConnected,
+  setGenerateTargetId,
   type HostEntry,
 } from "../lib/hostRegistry";
-import { toast } from "../lib/toasts";
+import { requestConfirm, toast } from "../lib/toasts";
 
 const router = useRouter();
 const route = useRoute();
 const hosts = ref<HostEntry[]>(listKnownHosts());
 const connectOpen = ref(false);
+const contextMenu = ref<{ host: HostEntry; x: number; y: number } | null>(null);
 watch(
   () => route.query.add,
   (add) => {
@@ -43,14 +47,32 @@ function onStorage(event: StorageEvent) {
   if (event.key === HOSTS_STORAGE_KEY) refreshHosts();
 }
 
+function closeContextMenu() {
+  contextMenu.value = null;
+}
+
+function onWindowPointer(event: MouseEvent) {
+  const target = event.target as HTMLElement | null;
+  if (!target?.closest("[data-test='machine-context-menu']"))
+    closeContextMenu();
+}
+
+function onWindowKey(event: KeyboardEvent) {
+  if (event.key === "Escape") closeContextMenu();
+}
+
 onMounted(() => {
   window.addEventListener(HOSTS_CHANGED_EVENT, refreshHosts);
   window.addEventListener("storage", onStorage);
+  window.addEventListener("mousedown", onWindowPointer);
+  window.addEventListener("keydown", onWindowKey);
 });
 
 onBeforeUnmount(() => {
   window.removeEventListener(HOSTS_CHANGED_EVENT, refreshHosts);
   window.removeEventListener("storage", onStorage);
+  window.removeEventListener("mousedown", onWindowPointer);
+  window.removeEventListener("keydown", onWindowKey);
 });
 
 function openDetail(id: string) {
@@ -65,6 +87,69 @@ function onAdded(host: HostEntry) {
 function reconnect(id: string) {
   const host = setHostConnected(id, true);
   if (host) toast("success", `${host.name} reconnected.`);
+}
+
+function openHostContext(payload: { host: HostEntry; x: number; y: number }) {
+  contextMenu.value = payload;
+}
+
+function contextOpen() {
+  const host = contextMenu.value?.host;
+  closeContextMenu();
+  if (host && host.connected !== false) openDetail(host.id);
+}
+
+function contextTarget() {
+  const host = contextMenu.value?.host;
+  closeContextMenu();
+  if (!host || host.connected === false) return;
+  setGenerateTargetId(host.id);
+  toast("success", `${host.name} is now the generation target.`);
+}
+
+async function contextCopyAddress() {
+  const host = contextMenu.value?.host;
+  closeContextMenu();
+  if (!host) return;
+  try {
+    await navigator.clipboard.writeText(host.url);
+    toast("success", "Address copied.");
+  } catch (error) {
+    toast("error", error instanceof Error ? error.message : String(error));
+  }
+}
+
+function contextConnect() {
+  const host = contextMenu.value?.host;
+  closeContextMenu();
+  if (host) reconnect(host.id);
+}
+
+function contextDisconnect() {
+  const host = contextMenu.value?.host;
+  closeContextMenu();
+  if (!host || host.id === ORIGIN_HOST_ID) return;
+  setHostConnected(host.id, false);
+  if (getGenerateTargetId() === host.id) setGenerateTargetId(ORIGIN_HOST_ID);
+  refreshHosts();
+  toast("success", `${host.name} disconnected.`);
+}
+
+async function contextForget() {
+  const host = contextMenu.value?.host;
+  closeContextMenu();
+  if (!host || host.id === ORIGIN_HOST_ID) return;
+  const accepted = await requestConfirm({
+    title: "Forget this machine?",
+    body: `${host.name} and its saved API key will be removed from this browser.`,
+    confirmLabel: "Forget machine",
+    danger: true,
+  });
+  if (!accepted) return;
+  removeHost(host.id);
+  if (getGenerateTargetId() === host.id) setGenerateTargetId(ORIGIN_HOST_ID);
+  refreshHosts();
+  toast("success", `${host.name} forgotten.`);
 }
 </script>
 
@@ -96,6 +181,7 @@ function reconnect(id: string) {
         :primary="host.id === ORIGIN_HOST_ID"
         @open="openDetail"
         @reconnect="reconnect"
+        @context-menu="openHostContext"
       />
 
       <CardSurface dashed>
@@ -119,6 +205,76 @@ function reconnect(id: string) {
       @close="connectOpen = false"
       @added="onAdded"
     />
+
+    <div
+      v-if="contextMenu"
+      class="machine-context"
+      data-test="machine-context-menu"
+      role="menu"
+      :style="{ left: `${contextMenu.x}px`, top: `${contextMenu.y}px` }"
+    >
+      <button
+        type="button"
+        role="menuitem"
+        :disabled="contextMenu.host.connected === false"
+        @click="contextOpen"
+      >
+        Open details
+      </button>
+      <button
+        type="button"
+        role="menuitem"
+        :disabled="
+          contextMenu.host.connected === false ||
+          getGenerateTargetId() === contextMenu.host.id
+        "
+        @click="contextTarget"
+      >
+        {{
+          getGenerateTargetId() === contextMenu.host.id
+            ? "Generation target"
+            : "Set as generation target"
+        }}
+      </button>
+      <button type="button" role="menuitem" @click="contextCopyAddress">
+        Copy address
+      </button>
+      <div
+        v-if="contextMenu.host.id !== ORIGIN_HOST_ID"
+        class="machine-context__separator"
+      />
+      <button
+        v-if="
+          contextMenu.host.id !== ORIGIN_HOST_ID &&
+          contextMenu.host.connected === false
+        "
+        type="button"
+        role="menuitem"
+        @click="contextConnect"
+      >
+        Connect
+      </button>
+      <button
+        v-if="
+          contextMenu.host.id !== ORIGIN_HOST_ID &&
+          contextMenu.host.connected !== false
+        "
+        type="button"
+        role="menuitem"
+        @click="contextDisconnect"
+      >
+        Disconnect
+      </button>
+      <button
+        v-if="contextMenu.host.id !== ORIGIN_HOST_ID"
+        type="button"
+        role="menuitem"
+        class="machine-context__danger"
+        @click="contextForget"
+      >
+        Forget…
+      </button>
+    </div>
   </div>
 </template>
 
@@ -166,5 +322,49 @@ function reconnect(id: string) {
 .ms-addcard__sub {
   font-size: 11.5px;
   color: var(--ink-3);
+}
+
+.machine-context {
+  position: fixed;
+  z-index: 80;
+  min-width: 210px;
+  padding: 5px;
+  border: 1px solid var(--ce);
+  border-radius: 9px;
+  background: var(--bench);
+  box-shadow: 0 14px 36px color-mix(in srgb, var(--bath) 50%, transparent);
+}
+
+.machine-context button {
+  display: block;
+  width: 100%;
+  min-height: 32px;
+  padding: 0 10px;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--rebate);
+  text-align: left;
+  font-size: 12.5px;
+  cursor: pointer;
+}
+
+.machine-context button:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--safelight) 14%, transparent);
+}
+
+.machine-context button:disabled {
+  color: var(--ink-3);
+  cursor: default;
+}
+
+.machine-context__separator {
+  height: 1px;
+  margin: 4px 6px;
+  background: var(--ce);
+}
+
+.machine-context .machine-context__danger {
+  color: var(--stop);
 }
 </style>

--- a/web/src/pages/MachinesPage.vue
+++ b/web/src/pages/MachinesPage.vue
@@ -51,7 +51,7 @@ function closeContextMenu() {
   contextMenu.value = null;
 }
 
-function onWindowPointer(event: MouseEvent) {
+function onDocumentPointer(event: PointerEvent) {
   const target = event.target as HTMLElement | null;
   if (!target?.closest("[data-test='machine-context-menu']"))
     closeContextMenu();
@@ -64,14 +64,14 @@ function onWindowKey(event: KeyboardEvent) {
 onMounted(() => {
   window.addEventListener(HOSTS_CHANGED_EVENT, refreshHosts);
   window.addEventListener("storage", onStorage);
-  window.addEventListener("mousedown", onWindowPointer);
+  document.addEventListener("pointerdown", onDocumentPointer);
   window.addEventListener("keydown", onWindowKey);
 });
 
 onBeforeUnmount(() => {
   window.removeEventListener(HOSTS_CHANGED_EVENT, refreshHosts);
   window.removeEventListener("storage", onStorage);
-  window.removeEventListener("mousedown", onWindowPointer);
+  document.removeEventListener("pointerdown", onDocumentPointer);
   window.removeEventListener("keydown", onWindowKey);
 });
 
@@ -122,7 +122,9 @@ async function contextCopyAddress() {
 function contextConnect() {
   const host = contextMenu.value?.host;
   closeContextMenu();
-  if (host) reconnect(host.id);
+  if (!host) return;
+  const connected = setHostConnected(host.id, true);
+  if (connected) toast("success", `${connected.name} connected.`);
 }
 
 function contextDisconnect() {


### PR DESCRIPTION
## Summary
- add **Use as source** to the desktop Library tile context menu and route origin-owned bytes into Create
- add state-aware host context menus across desktop and web Machines views
- expose open/details, generation target, address, connect/disconnect, web UI, and confirmed forget actions where applicable

## Validation
- `cd desktop && bun run test` (2767 tests)
- `cd web && bun run test` (1125 tests)
- `cd desktop && bun run build`
- `cd web && bun run build`
- `bun run check:architecture`
- rendered desktop and web context-menu QA with clean consoles and host-detail navigation
