### PR TITLE
feat(templates): restore saved source images

### DIFF
--- a/desktop/src/components/generate/TemplatesPanel.vue
+++ b/desktop/src/components/generate/TemplatesPanel.vue
@@ -66,8 +66,7 @@ async function saveCurrent() {
     nameDraft.value = "";
     refresh();
   } catch (cause) {
-    error.value =
-      cause instanceof Error ? cause.message : "Couldn’t save the template and its source image.";
+    error.value = cause instanceof Error ? cause.message : "Couldn’t save the template media.";
   } finally {
     saving.value = false;
   }

--- a/desktop/src/components/generate/TemplatesPanel.vue
+++ b/desktop/src/components/generate/TemplatesPanel.vue
@@ -3,11 +3,11 @@ import { computed, ref } from "vue";
 import type { GenerateForm } from "../../lib/generateForm";
 import { modelDisplayNameForId, type DisplayableModel } from "../../lib/models";
 import {
-  deleteGenerationTemplate,
+  deleteGenerationTemplateWithMedia,
   fallbackTemplateName,
   loadGenerationTemplates,
   renameGenerationTemplate,
-  saveGenerationTemplate,
+  saveGenerationTemplateWithMedia,
   sortGenerationTemplates,
   type GenerationTemplate,
   type GenerationTemplateSort,
@@ -29,6 +29,8 @@ const templates = ref<GenerationTemplate[]>(loadGenerationTemplates(sort.value))
 const renamingId = ref<string | null>(null);
 const renameDraft = ref("");
 const confirmingDeleteId = ref<string | null>(null);
+const saving = ref(false);
+const error = ref("");
 
 const visibleTemplates = computed(() => {
   const q = search.value.trim().toLowerCase();
@@ -52,10 +54,23 @@ function refresh() {
   templates.value = loadGenerationTemplates(sort.value);
 }
 
-function saveCurrent() {
-  saveGenerationTemplate(nameDraft.value || fallbackTemplateName(props.form), props.form);
-  nameDraft.value = "";
-  refresh();
+async function saveCurrent() {
+  if (saving.value) return;
+  saving.value = true;
+  error.value = "";
+  try {
+    await saveGenerationTemplateWithMedia(
+      nameDraft.value || fallbackTemplateName(props.form),
+      props.form,
+    );
+    nameDraft.value = "";
+    refresh();
+  } catch (cause) {
+    error.value =
+      cause instanceof Error ? cause.message : "Couldn’t save the template and its source image.";
+  } finally {
+    saving.value = false;
+  }
 }
 
 function loadTemplate(template: GenerationTemplate) {
@@ -77,11 +92,12 @@ function cancelRename() {
   renamingId.value = null;
 }
 
-function requestDelete(template: GenerationTemplate) {
+async function requestDelete(template: GenerationTemplate) {
   if (confirmingDeleteId.value === template.id) {
-    deleteGenerationTemplate(template.id);
+    const deletion = deleteGenerationTemplateWithMedia(template);
     confirmingDeleteId.value = null;
     refresh();
+    await deletion;
   } else {
     renamingId.value = null;
     confirmingDeleteId.value = template.id;
@@ -111,12 +127,14 @@ function requestDelete(template: GenerationTemplate) {
       <button
         type="button"
         data-test="template-save"
+        :disabled="saving"
         class="h-8 rounded-control bg-safelight px-3 text-body font-semibold text-on-accent hover:brightness-105 active:translate-y-px"
         @click="saveCurrent"
       >
-        Save
+        {{ saving ? "Saving…" : "Save" }}
       </button>
     </div>
+    <p v-if="error" class="mt-1 text-caption text-stop" role="alert">{{ error }}</p>
 
     <!-- Search + sort -->
     <div class="mt-2 grid grid-cols-[1fr_auto] gap-2">

--- a/desktop/src/lib/generationTemplates.test.ts
+++ b/desktop/src/lib/generationTemplates.test.ts
@@ -10,12 +10,16 @@ import {
   deleteGenerationTemplate,
   formatTemplateMediaReferences,
   loadGenerationTemplates,
+  hydrateGenerationTemplate,
   renameGenerationTemplate,
   saveGenerationTemplate,
+  saveGenerationTemplateWithMedia,
+  deleteGenerationTemplateWithMedia,
   searchGenerationTemplates,
   sortGenerationTemplates,
   type GenerationTemplate,
 } from "./generationTemplates";
+import type { StoredTemplateMedia, TemplateMediaPersistence } from "@studio/lib/templateMediaStore";
 
 const B64 = "aGVsbG8td29ybGQtYmFzZTY0"; // "hello-world-base64"
 
@@ -23,11 +27,59 @@ function formWith(overrides: Partial<GenerateForm> = {}): GenerateForm {
   return { ...newGenerateForm(), ...overrides };
 }
 
+function memoryMedia(): TemplateMediaPersistence & { records: Map<string, StoredTemplateMedia> } {
+  const records = new Map<string, StoredTemplateMedia>();
+  return {
+    records,
+    async put(record) {
+      records.set(record.assetId, structuredClone(record));
+      return true;
+    },
+    async get(assetId) {
+      return records.get(assetId) ?? null;
+    },
+    async delete(assetId) {
+      records.delete(assetId);
+    },
+  };
+}
+
 beforeEach(() => {
   localStorage.clear();
 });
 
 describe("save / load round-trip", () => {
+  it("restores a saved source image independently of its original gallery host", async () => {
+    const persistence = memoryMedia();
+    const saved = await saveGenerationTemplateWithMedia(
+      "Portable source",
+      formWith({
+        sourceImage: B64,
+        sourceImageName: "remote-gallery.png",
+      }),
+      GENERATION_TEMPLATES_STORAGE_KEY,
+      "host-a",
+      persistence,
+    );
+
+    expect(saved.form.sourceImage).toBeNull();
+    expect(JSON.stringify(saved)).not.toContain(B64);
+    const hydrated = await hydrateGenerationTemplate(saved, persistence);
+    expect(hydrated.form.sourceImage).toBe(B64);
+    expect(hydrated.form.sourceImageName).toBe("remote-gallery.png");
+    expect(hydrated.missingMediaReferences).toEqual([]);
+
+    await deleteGenerationTemplateWithMedia(saved, GENERATION_TEMPLATES_STORAGE_KEY, persistence);
+    expect(persistence.records.size).toBe(0);
+  });
+
+  it("keeps the legacy re-add warning when no durable source asset exists", async () => {
+    const legacy = saveGenerationTemplate("Legacy", formWith({ sourceImage: B64 }));
+    const hydrated = await hydrateGenerationTemplate(legacy, memoryMedia());
+    expect(hydrated.form.sourceImage).toBeNull();
+    expect(hydrated.missingMediaReferences).toEqual(["source"]);
+  });
+
   it("strips base64 media and records references", () => {
     const form = formWith({
       prompt: "a lighthouse at dusk",

--- a/desktop/src/lib/generationTemplates.ts
+++ b/desktop/src/lib/generationTemplates.ts
@@ -4,21 +4,27 @@
  * recalled with one click. Ported from the web SPA's `generationTemplates.ts`,
  * but keyed on a desktop-only storage key so the two never share blobs.
  *
- * Media fields (`sourceImage` / `maskImage` / `controlImage`, plus video,
- * keyframe, and audio conditioning files) hold browser-local base64 that
- * we deliberately do NOT persist — a saved template records only a
- * human-facing `mediaReferences` hint so the user knows to re-select bytes.
+ * Large media bytes never enter localStorage. Source/edit images are stored
+ * durably in the shared IndexedDB media store and restored with the template;
+ * unsupported auxiliary media retains a human-facing re-selection hint.
  */
 import type { GenerateForm } from "./generateForm";
 import { createUuid } from "@studio/lib/id";
 import { emptyGuidanceOverrides } from "@studio/lib/guidanceOverrides";
+import {
+  deleteGenerationTemplateMedia,
+  hydrateGenerationTemplateMedia,
+  persistGenerationTemplateMedia,
+  type GenerationTemplateMediaAsset,
+  type TemplateMediaPersistence,
+} from "@studio/lib/templateMediaStore";
 
 /** Storage key — MUST differ from the web SPA's `mold.generation.templates.v1`. */
 export const GENERATION_TEMPLATES_STORAGE_KEY = "mold.desktop.generation.templates.v1";
 
 export type GenerationTemplateSort = "updated-desc" | "updated-asc" | "name-asc" | "name-desc";
 
-/** Human-facing labels for media that a template could not persist. */
+/** Human-facing labels for media present when the template was saved. */
 export type GenerationTemplateMediaField =
   "source" | "mask" | "control" | "sourceVideo" | "keyframes" | "editImages" | "audioFile";
 
@@ -29,8 +35,10 @@ export interface GenerationTemplate {
   updatedAt: number;
   /** The saved form with base64 media stripped to null / empty. */
   form: GenerateForm;
-  /** Which media slots were populated when saved — the user must re-select them. */
+  /** Which media slots were populated when saved. */
   mediaReferences: GenerationTemplateMediaField[];
+  /** Durable client-local source snapshots. Legacy templates omit this. */
+  mediaAssets?: GenerationTemplateMediaAsset[];
   /** Optional host scope for remote-only clients. Legacy/desktop templates omit it. */
   scopeId?: string;
 }
@@ -49,6 +57,19 @@ export function formatTemplateMediaReferences(
   references: readonly GenerationTemplateMediaField[],
 ): string {
   return references.map((reference) => MEDIA_REFERENCE_LABELS[reference]).join(", ");
+}
+
+/** Media that definitely has no durable snapshot and must be re-selected. */
+export function unsnapshottedTemplateMediaReferences(
+  template: GenerationTemplate,
+): GenerationTemplateMediaField[] {
+  const assets = template.mediaAssets ?? [];
+  const hasSource = assets.some((asset) => asset.field === "sourceImage");
+  const hasAttachments = assets.some((asset) => asset.field === "imageAttachments");
+  return template.mediaReferences.filter(
+    (reference) =>
+      !((reference === "source" && hasSource) || (reference === "editImages" && hasAttachments)),
+  );
 }
 
 function now(): number {
@@ -182,6 +203,91 @@ export function saveGenerationTemplate(
   return template;
 }
 
+/** Save the template only after its source bytes are durable in IndexedDB. */
+export async function saveGenerationTemplateWithMedia(
+  name: string,
+  form: GenerateForm,
+  storageKey = GENERATION_TEMPLATES_STORAGE_KEY,
+  scopeId?: string,
+  persistence?: TemplateMediaPersistence,
+): Promise<GenerationTemplate> {
+  const timestamp = now();
+  const id = templateId();
+  const inputs = [
+    ...(form.sourceImage
+      ? [
+          {
+            field: "sourceImage" as const,
+            filename: form.sourceImageName || "Source image",
+            base64: form.sourceImage,
+          },
+        ]
+      : []),
+    ...form.imageAttachments.map((base64, index) => ({
+      field: "imageAttachments" as const,
+      index,
+      filename: `Reference ${index + 1}`,
+      base64,
+    })),
+  ];
+  const mediaAssets = await persistGenerationTemplateMedia(id, inputs, persistence);
+  const template: GenerationTemplate = {
+    id,
+    name: normalizeName(name || fallbackTemplateName(form)),
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    form: stripTemplateForm(form),
+    mediaReferences: collectTemplateMediaReferences(form),
+    ...(mediaAssets.length ? { mediaAssets } : {}),
+    ...(scopeId ? { scopeId } : {}),
+  };
+  try {
+    writeTemplates([template, ...loadGenerationTemplates("updated-desc", storageKey)], storageKey);
+  } catch (error) {
+    await deleteGenerationTemplateMedia(mediaAssets, persistence);
+    throw error;
+  }
+  return template;
+}
+
+export async function hydrateGenerationTemplate(
+  template: GenerationTemplate,
+  persistence?: TemplateMediaPersistence,
+): Promise<{
+  form: GenerateForm;
+  missingMediaReferences: GenerationTemplateMediaField[];
+}> {
+  const form = JSON.parse(JSON.stringify(template.form)) as GenerateForm;
+  const assets = template.mediaAssets ?? [];
+  const { media, missing } = await hydrateGenerationTemplateMedia(assets, persistence);
+  const source = media.find((asset) => asset.field === "sourceImage");
+  if (source) {
+    form.sourceImage = source.base64;
+    form.sourceImageName = source.filename;
+  }
+  const attachments = media
+    .filter((asset) => asset.field === "imageAttachments")
+    .sort((left, right) => (left.index ?? 0) - (right.index ?? 0));
+  if (attachments.length) form.imageAttachments = attachments.map((asset) => asset.base64);
+
+  const restoredSource = Boolean(source) && !missing.some((asset) => asset.field === "sourceImage");
+  const expectedAttachments = assets.filter((asset) => asset.field === "imageAttachments").length;
+  const restoredAttachments =
+    expectedAttachments > 0 &&
+    attachments.length === expectedAttachments &&
+    !missing.some((asset) => asset.field === "imageAttachments");
+  return {
+    form,
+    missingMediaReferences: template.mediaReferences.filter(
+      (reference) =>
+        !(
+          (reference === "source" && restoredSource) ||
+          (reference === "editImages" && restoredAttachments)
+        ),
+    ),
+  };
+}
+
 export function renameGenerationTemplate(
   id: string,
   name: string,
@@ -205,6 +311,15 @@ export function deleteGenerationTemplate(
     loadGenerationTemplates("updated-desc", storageKey).filter((template) => template.id !== id),
     storageKey,
   );
+}
+
+export async function deleteGenerationTemplateWithMedia(
+  template: GenerationTemplate,
+  storageKey = GENERATION_TEMPLATES_STORAGE_KEY,
+  persistence?: TemplateMediaPersistence,
+): Promise<void> {
+  deleteGenerationTemplate(template.id, storageKey);
+  await deleteGenerationTemplateMedia(template.mediaAssets ?? [], persistence);
 }
 
 export function searchGenerationTemplates(

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -83,7 +83,11 @@ import {
   resetFormToModelDefaults,
   type GenerateForm,
 } from "../lib/generateForm";
-import { formatTemplateMediaReferences, type GenerationTemplate } from "../lib/generationTemplates";
+import {
+  formatTemplateMediaReferences,
+  hydrateGenerationTemplate,
+  type GenerationTemplate,
+} from "../lib/generationTemplates";
 import { galleryMediaPath, isVideoItem } from "../lib/gallery/media";
 import { isUpscaledImage } from "../lib/gallery/upscaled";
 import { percent } from "../lib/format";
@@ -1662,8 +1666,12 @@ function appendPromptWord(word: string): void {
   form.prompt = form.prompt.trim() ? `${form.prompt.trimEnd()}, ${trimmed}` : trimmed;
 }
 
-function loadTemplate(template: GenerationTemplate): void {
-  Object.assign(form, template.form);
+let templateLoadEpoch = 0;
+async function loadTemplate(template: GenerationTemplate): Promise<void> {
+  const epoch = ++templateLoadEpoch;
+  const hydrated = await hydrateGenerationTemplate(template);
+  if (epoch !== templateLoadEpoch) return;
+  Object.assign(form, hydrated.form);
   const sameHost = !!template.scopeId && template.scopeId === selectedHostId.value;
   if (!sameHost) clearHostScopedGenerationSelections();
   const selectedEntry = generationModels.value.find((model) => model.name === form.model);
@@ -1674,8 +1682,8 @@ function loadTemplate(template: GenerationTemplate): void {
       ? `Loaded ${template.name}`
       : `Loaded ${template.name}. Install ${form.model} from Catalog or choose another model.`,
   );
-  const mediaMessage = template.mediaReferences.length
-    ? ` Re-add ${formatTemplateMediaReferences(template.mediaReferences)}.`
+  const mediaMessage = hydrated.missingMediaReferences.length
+    ? ` Re-add ${formatTemplateMediaReferences(hydrated.missingMediaReferences)}.`
     : "";
   generationAnnouncement.value = sameHost
     ? `Template loaded.${mediaMessage}`

--- a/desktop/src/mobile/MobileTemplates.vue
+++ b/desktop/src/mobile/MobileTemplates.vue
@@ -72,8 +72,7 @@ async function save(): Promise<void> {
     name.value = "";
     refresh();
   } catch (cause) {
-    error.value =
-      cause instanceof Error ? cause.message : "Couldn’t save the template and its source image.";
+    error.value = cause instanceof Error ? cause.message : "Couldn’t save the template media.";
   } finally {
     saving.value = false;
   }

--- a/desktop/src/mobile/MobileTemplates.vue
+++ b/desktop/src/mobile/MobileTemplates.vue
@@ -8,14 +8,15 @@ export { MOBILE_GENERATION_TEMPLATES_STORAGE_KEY };
 import { computed, onMounted, ref } from "vue";
 import {
   formatTemplateMediaReferences,
-  deleteGenerationTemplate,
+  deleteGenerationTemplateWithMedia,
   fallbackTemplateName,
   loadGenerationTemplates,
   renameGenerationTemplate,
-  saveGenerationTemplate,
+  saveGenerationTemplateWithMedia,
   sortGenerationTemplates,
   type GenerationTemplate,
   type GenerationTemplateSort,
+  unsnapshottedTemplateMediaReferences,
 } from "../lib/generationTemplates";
 import type { GenerateForm } from "../lib/generateForm";
 import type { ModelEntry } from "../lib/api/types";
@@ -33,6 +34,8 @@ const templates = ref<GenerationTemplate[]>([]);
 const renamingId = ref<string | null>(null);
 const renameDraft = ref("");
 const confirmingDeleteId = ref<string | null>(null);
+const saving = ref(false);
+const error = ref("");
 
 const visible = computed(() => {
   const query = search.value.trim().toLowerCase();
@@ -55,20 +58,34 @@ function toggle(): void {
   if (open.value) refresh();
 }
 
-function save(): void {
-  saveGenerationTemplate(
-    name.value || fallbackTemplateName(props.form),
-    props.form,
-    MOBILE_GENERATION_TEMPLATES_STORAGE_KEY,
-    props.hostId,
-  );
-  name.value = "";
-  refresh();
+async function save(): Promise<void> {
+  if (saving.value) return;
+  saving.value = true;
+  error.value = "";
+  try {
+    await saveGenerationTemplateWithMedia(
+      name.value || fallbackTemplateName(props.form),
+      props.form,
+      MOBILE_GENERATION_TEMPLATES_STORAGE_KEY,
+      props.hostId,
+    );
+    name.value = "";
+    refresh();
+  } catch (cause) {
+    error.value =
+      cause instanceof Error ? cause.message : "Couldn’t save the template and its source image.";
+  } finally {
+    saving.value = false;
+  }
 }
 
 function load(template: GenerationTemplate): void {
   emit("load", template);
   open.value = false;
+}
+
+function mediaToReAdd(template: GenerationTemplate) {
+  return unsnapshottedTemplateMediaReferences(template);
 }
 
 function startRename(template: GenerationTemplate): void {
@@ -84,15 +101,19 @@ function commitRename(id: string): void {
   refresh();
 }
 
-function remove(template: GenerationTemplate): void {
+async function remove(template: GenerationTemplate): Promise<void> {
   if (confirmingDeleteId.value !== template.id) {
     confirmingDeleteId.value = template.id;
     renamingId.value = null;
     return;
   }
-  deleteGenerationTemplate(template.id, MOBILE_GENERATION_TEMPLATES_STORAGE_KEY);
+  const deletion = deleteGenerationTemplateWithMedia(
+    template,
+    MOBILE_GENERATION_TEMPLATES_STORAGE_KEY,
+  );
   confirmingDeleteId.value = null;
   refresh();
+  await deletion;
 }
 
 onMounted(refresh);
@@ -127,11 +148,15 @@ onMounted(refresh);
           type="button"
           class="secondary-button"
           data-test="mobile-template-save"
+          :disabled="saving"
           @click="save"
         >
-          Save
+          {{ saving ? "Saving…" : "Save" }}
         </button>
       </div>
+      <p v-if="error" class="mobile-helper-text mobile-inline-danger" role="alert">
+        {{ error }}
+      </p>
 
       <div class="mobile-inline-form mobile-template-filter">
         <input
@@ -189,8 +214,8 @@ onMounted(refresh);
               {{ confirmingDeleteId === template.id ? "Confirm" : "Delete" }}
             </button>
           </div>
-          <p v-if="template.mediaReferences.length" class="mobile-helper-text">
-            Re-add {{ formatTemplateMediaReferences(template.mediaReferences) }} after loading.
+          <p v-if="mediaToReAdd(template).length" class="mobile-helper-text">
+            Re-add {{ formatTemplateMediaReferences(mediaToReAdd(template)) }} after loading.
           </p>
         </article>
         <p v-if="visible.length === 0" class="mobile-helper-text">

--- a/desktop/src/views/GenerateView.vue
+++ b/desktop/src/views/GenerateView.vue
@@ -105,7 +105,11 @@ import { domCanvasOps } from "../lib/sourceFitCanvas";
 import { upscaleImage } from "../lib/api/upscale";
 import { expandPrompt } from "../lib/api/expand";
 import type { HostRoute } from "../stores/hosts";
-import { formatTemplateMediaReferences, type GenerationTemplate } from "../lib/generationTemplates";
+import {
+  formatTemplateMediaReferences,
+  hydrateGenerationTemplate,
+  type GenerationTemplate,
+} from "../lib/generationTemplates";
 import { fetchHistoryAll, type HistoryHostTarget } from "../lib/api/history";
 import { randomSeed } from "../stores/generation";
 import type { GenerateRequest, OutputMetadata } from "../lib/api/types";
@@ -1421,16 +1425,20 @@ const edgeCode = computed(() => {
   return [name, s, stepPart, size, time].filter(Boolean).join("  ");
 });
 
-function loadTemplate(template: GenerationTemplate) {
-  // Base64 media was stripped on save; buildRequest's pruneRequestForFamily
-  // still guards anything the (possibly different) family can't use.
-  Object.assign(form, template.form);
+let templateLoadEpoch = 0;
+async function loadTemplate(template: GenerationTemplate) {
+  const epoch = ++templateLoadEpoch;
   templatesOpen.value = false;
+  const hydrated = await hydrateGenerationTemplate(template);
+  if (epoch !== templateLoadEpoch) return;
+  // buildRequest's pruneRequestForFamily still guards anything the (possibly
+  // different) family can't use after the source snapshot is restored.
+  Object.assign(form, hydrated.form);
   if (form.model && !findInstalledModel(installedModels.value, form.model)) {
     toasts.push(`Model "${form.model}" isn't installed — settings applied anyway.`);
   }
-  if (template.mediaReferences.length > 0) {
-    toasts.push(`Re-add media: ${formatTemplateMediaReferences(template.mediaReferences)}.`);
+  if (hydrated.missingMediaReferences.length > 0) {
+    toasts.push(`Re-add media: ${formatTemplateMediaReferences(hydrated.missingMediaReferences)}.`);
   }
 }
 

--- a/studio/lib/draftMediaStore.ts
+++ b/studio/lib/draftMediaStore.ts
@@ -68,6 +68,28 @@ async function withStore<T>(
   });
 }
 
+async function writeStore(
+  fn: (store: IDBObjectStore) => IDBRequest,
+): Promise<boolean> {
+  const db = await openDb();
+  if (!db) return false;
+  return new Promise((resolve) => {
+    const tx = db.transaction(STORE_NAME, "readwrite");
+    const req = fn(tx.objectStore(STORE_NAME));
+    let settled = false;
+    const finish = (result: boolean) => {
+      if (settled) return;
+      settled = true;
+      db.close();
+      resolve(result);
+    };
+    req.onerror = () => finish(false);
+    tx.oncomplete = () => finish(true);
+    tx.onerror = () => finish(false);
+    tx.onabort = () => finish(false);
+  });
+}
+
 export async function putDraftMedia<T extends DraftMediaRecord>(
   media: T,
 ): Promise<void> {
@@ -77,6 +99,22 @@ export async function putDraftMedia<T extends DraftMediaRecord>(
   const saved = clone(media);
   memory.set(media.draftId, saved);
   await withStore("readwrite", (store) => store.put(saved));
+}
+
+/**
+ * Persist media durably, returning false when IndexedDB is unavailable or the
+ * transaction fails. Templates use this stricter contract because reporting a
+ * successful save and silently retaining bytes only in memory would create a
+ * broken template after the next launch.
+ */
+export async function putDurableMedia<T extends DraftMediaRecord>(
+  media: T,
+): Promise<boolean> {
+  if (!media.draftId || !media.base64) return false;
+  const saved = clone(media);
+  const persisted = await writeStore((store) => store.put(saved));
+  if (persisted) memory.set(media.draftId, saved);
+  return persisted;
 }
 
 export async function getDraftMedia<T extends DraftMediaRecord>(

--- a/studio/lib/templateMediaStore.test.ts
+++ b/studio/lib/templateMediaStore.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+import {
+  deleteGenerationTemplateMedia,
+  hydrateGenerationTemplateMedia,
+  persistGenerationTemplateMedia,
+  type StoredTemplateMedia,
+  type TemplateMediaPersistence,
+} from "./templateMediaStore";
+
+function memoryPersistence(failAt = -1): TemplateMediaPersistence & {
+  records: Map<string, StoredTemplateMedia>;
+} {
+  const records = new Map<string, StoredTemplateMedia>();
+  let writes = 0;
+  return {
+    records,
+    async put(record) {
+      if (writes++ === failAt) return false;
+      records.set(record.assetId, structuredClone(record));
+      return true;
+    },
+    async get(assetId) {
+      const record = records.get(assetId);
+      return record ? structuredClone(record) : null;
+    },
+    async delete(assetId) {
+      records.delete(assetId);
+    },
+  };
+}
+
+describe("template media store", () => {
+  it("round-trips local and gallery source bytes in stable order", async () => {
+    const persistence = memoryPersistence();
+    const assets = await persistGenerationTemplateMedia(
+      "template-a",
+      [
+        {
+          field: "imageAttachments",
+          index: 0,
+          filename: "local.png",
+          kind: "upload",
+          base64: "LOCAL_BYTES",
+        },
+        {
+          field: "imageAttachments",
+          index: 1,
+          filename: "remote-gallery.jpg",
+          kind: "gallery",
+          base64: "REMOTE_BYTES",
+        },
+      ],
+      persistence,
+    );
+
+    expect(assets.map((asset) => asset.assetId)).toEqual([
+      "template:template-a:attachment-0",
+      "template:template-a:attachment-1",
+    ]);
+    expect(JSON.stringify(assets)).not.toContain("_BYTES");
+    await expect(
+      hydrateGenerationTemplateMedia(assets, persistence),
+    ).resolves.toMatchObject({
+      media: [
+        { filename: "local.png", kind: "upload", base64: "LOCAL_BYTES" },
+        {
+          filename: "remote-gallery.jpg",
+          kind: "gallery",
+          base64: "REMOTE_BYTES",
+        },
+      ],
+      missing: [],
+    });
+  });
+
+  it("rolls back earlier assets when a durable write fails", async () => {
+    const persistence = memoryPersistence(1);
+    await expect(
+      persistGenerationTemplateMedia(
+        "template-b",
+        [
+          { field: "sourceImage", filename: "one.png", base64: "ONE" },
+          {
+            field: "imageAttachments",
+            index: 0,
+            filename: "two.png",
+            base64: "TWO",
+          },
+        ],
+        persistence,
+      ),
+    ).rejects.toThrow("storage is unavailable");
+    expect(persistence.records.size).toBe(0);
+  });
+
+  it("reports missing assets and removes owned media on deletion", async () => {
+    const persistence = memoryPersistence();
+    const assets = await persistGenerationTemplateMedia(
+      "template-c",
+      [{ field: "sourceImage", filename: "source.png", base64: "SOURCE" }],
+      persistence,
+    );
+    persistence.records.clear();
+    await expect(
+      hydrateGenerationTemplateMedia(assets, persistence),
+    ).resolves.toEqual({
+      media: [],
+      missing: assets,
+    });
+
+    await persistGenerationTemplateMedia(
+      "template-c",
+      [{ field: "sourceImage", filename: "source.png", base64: "SOURCE" }],
+      persistence,
+    );
+    await deleteGenerationTemplateMedia(assets, persistence);
+    expect(persistence.records.size).toBe(0);
+  });
+});

--- a/studio/lib/templateMediaStore.ts
+++ b/studio/lib/templateMediaStore.ts
@@ -67,7 +67,7 @@ export async function persistGenerationTemplateMedia(
   try {
     for (const record of stored) {
       if (!(await persistence.put(record))) {
-        throw new Error("Source image storage is unavailable.");
+        throw new Error("Template media storage is unavailable.");
       }
       written.push(record.assetId);
     }

--- a/studio/lib/templateMediaStore.ts
+++ b/studio/lib/templateMediaStore.ts
@@ -1,0 +1,113 @@
+import {
+  deleteDraftMedia,
+  getDraftMedia,
+  putDurableMedia,
+} from "./draftMediaStore";
+
+export type GenerationTemplateSourceField = "sourceImage" | "imageAttachments";
+
+export interface GenerationTemplateMediaAsset {
+  assetId: string;
+  field: GenerationTemplateSourceField;
+  index?: number;
+  filename: string;
+  kind?: "upload" | "gallery";
+  width?: number | null;
+  height?: number | null;
+  mime?: string | null;
+}
+
+export interface GenerationTemplateMediaInput extends Omit<
+  GenerationTemplateMediaAsset,
+  "assetId"
+> {
+  base64: string;
+}
+
+export interface StoredTemplateMedia extends GenerationTemplateMediaAsset {
+  draftId: string;
+  base64: string;
+}
+
+export interface HydratedGenerationTemplateMedia extends GenerationTemplateMediaAsset {
+  base64: string;
+}
+
+export interface TemplateMediaPersistence {
+  put(record: StoredTemplateMedia): Promise<boolean>;
+  get(assetId: string): Promise<StoredTemplateMedia | null>;
+  delete(assetId: string): Promise<void>;
+}
+
+const indexedDbPersistence: TemplateMediaPersistence = {
+  put: putDurableMedia,
+  get: (assetId) => getDraftMedia<StoredTemplateMedia>(assetId),
+  delete: deleteDraftMedia,
+};
+
+function assetIdFor(
+  templateId: string,
+  input: GenerationTemplateMediaInput,
+): string {
+  const suffix =
+    input.field === "sourceImage" ? "source" : `attachment-${input.index ?? 0}`;
+  return `template:${templateId}:${suffix}`;
+}
+
+export async function persistGenerationTemplateMedia(
+  templateId: string,
+  inputs: readonly GenerationTemplateMediaInput[],
+  persistence: TemplateMediaPersistence = indexedDbPersistence,
+): Promise<GenerationTemplateMediaAsset[]> {
+  const stored: StoredTemplateMedia[] = inputs.map((input) => {
+    const assetId = assetIdFor(templateId, input);
+    return { ...input, assetId, draftId: assetId };
+  });
+  const written: string[] = [];
+  try {
+    for (const record of stored) {
+      if (!(await persistence.put(record))) {
+        throw new Error("Source image storage is unavailable.");
+      }
+      written.push(record.assetId);
+    }
+  } catch (error) {
+    await Promise.allSettled(
+      written.map((assetId) => persistence.delete(assetId)),
+    );
+    throw error;
+  }
+  return stored.map(
+    ({ base64: _base64, draftId: _draftId, ...asset }) => asset,
+  );
+}
+
+export async function hydrateGenerationTemplateMedia(
+  assets: readonly GenerationTemplateMediaAsset[],
+  persistence: TemplateMediaPersistence = indexedDbPersistence,
+): Promise<{
+  media: HydratedGenerationTemplateMedia[];
+  missing: GenerationTemplateMediaAsset[];
+}> {
+  const resolved = await Promise.all(
+    assets.map(async (asset) => {
+      const stored = await persistence.get(asset.assetId).catch(() => null);
+      return stored?.base64 ? { ...asset, base64: stored.base64 } : null;
+    }),
+  );
+  return {
+    media: resolved.filter(
+      (entry): entry is HydratedGenerationTemplateMedia => entry !== null,
+    ),
+    missing: assets.filter((_, index) => resolved[index] === null),
+  };
+}
+
+export async function deleteGenerationTemplateMedia(
+  assets: readonly GenerationTemplateMediaAsset[],
+  persistence: TemplateMediaPersistence = indexedDbPersistence,
+): Promise<void> {
+  await Promise.allSettled(
+    assets.map((asset) => persistence.delete(asset.assetId)),
+  );
+}

--- a/web/src/components/GenerationTemplatesPanel.test.ts
+++ b/web/src/components/GenerationTemplatesPanel.test.ts
@@ -1,8 +1,9 @@
-import { mount } from "@vue/test-utils";
+import { flushPromises, mount } from "@vue/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import GenerationTemplatesPanel from "./GenerationTemplatesPanel.vue";
 import type { GenerateFormState } from "../types";
 import { saveGenerationTemplate } from "../lib/generationTemplates";
+import * as generationTemplates from "../lib/generationTemplates";
 import {
   resetNotifications,
   settleConfirm,
@@ -93,6 +94,51 @@ describe("GenerationTemplatesPanel", () => {
       .emitted("update:modelValue")
       ?.at(-1)?.[0] as GenerateFormState;
     expect(emitted.prompt).toBe("from template");
+  });
+
+  it("does not let a slower earlier template load overwrite the latest choice", async () => {
+    saveGenerationTemplate("First", makeForm({ prompt: "first" }));
+    saveGenerationTemplate("Second", makeForm({ prompt: "second" }));
+    const resolvers = new Map<
+      string,
+      (value: { form: GenerateFormState; sourceMissing: boolean }) => void
+    >();
+    vi.spyOn(
+      generationTemplates,
+      "hydrateGenerationTemplate",
+    ).mockImplementation(
+      (template) =>
+        new Promise((resolve) => {
+          resolvers.set(template.name, resolve);
+        }),
+    );
+    const w = mount(GenerationTemplatesPanel, {
+      props: { modelValue: makeForm({ prompt: "current" }) },
+    });
+    const buttons = w.findAll("[data-test='template-load']");
+    const secondButton = buttons.find((button) =>
+      button.text().includes("Second"),
+    );
+    const firstButton = buttons.find((button) =>
+      button.text().includes("First"),
+    );
+    await secondButton?.trigger("click");
+    await firstButton?.trigger("click");
+
+    resolvers.get("First")?.({
+      form: makeForm({ prompt: "first" }),
+      sourceMissing: false,
+    });
+    await flushPromises();
+    resolvers.get("Second")?.({
+      form: makeForm({ prompt: "second" }),
+      sourceMissing: false,
+    });
+    await flushPromises();
+
+    const loaded = w.emitted("update:modelValue") ?? [];
+    expect(loaded).toHaveLength(1);
+    expect((loaded[0]?.[0] as GenerateFormState).prompt).toBe("first");
   });
 
   it("searches, sorts, renames, and deletes templates", async () => {

--- a/web/src/components/GenerationTemplatesPanel.vue
+++ b/web/src/components/GenerationTemplatesPanel.vue
@@ -80,7 +80,7 @@ async function saveCurrent() {
     error.value =
       cause instanceof Error
         ? cause.message
-        : "Couldn’t save the template and its source image.";
+        : "Couldn’t save the template media.";
   } finally {
     saving.value = false;
   }
@@ -96,7 +96,7 @@ async function loadTemplate(template: GenerationTemplate) {
     emit("update:modelValue", hydrated.form);
     if (hydrated.sourceMissing) {
       error.value =
-        "The template loaded, but its source image is no longer available.";
+        "The template loaded, but some saved images are no longer available.";
     }
   } catch (cause) {
     if (epoch === loadEpoch) {

--- a/web/src/components/GenerationTemplatesPanel.vue
+++ b/web/src/components/GenerationTemplatesPanel.vue
@@ -5,10 +5,11 @@ import type { ModelInfoExtended } from "../types";
 import { modelDisplayNameForId } from "@studio/lib/modelDisplay";
 import { requestText } from "../lib/toasts";
 import {
-  deleteGenerationTemplate,
+  deleteGenerationTemplateWithMedia,
+  hydrateGenerationTemplate,
   loadGenerationTemplates,
   renameGenerationTemplate,
-  saveGenerationTemplate,
+  saveGenerationTemplateWithMedia,
   sortGenerationTemplates,
   type GenerationTemplate,
   type GenerationTemplateSort,
@@ -32,6 +33,10 @@ const sort = ref<GenerationTemplateSort>("updated-desc");
 const templates = ref<GenerationTemplate[]>(
   loadGenerationTemplates(sort.value),
 );
+const saving = ref(false);
+const loadingId = ref<string | null>(null);
+const error = ref("");
+let loadEpoch = 0;
 
 const visibleTemplates = computed(() => {
   const q = search.value.trim().toLowerCase();
@@ -56,18 +61,51 @@ function refreshTemplates() {
   templates.value = loadGenerationTemplates(sort.value);
 }
 
-function saveCurrent() {
+async function saveCurrent() {
+  if (saving.value) return;
   const fallback =
     props.modelValue.prompt.trim().slice(0, 48) ||
     props.modelValue.model ||
     "Untitled template";
-  saveGenerationTemplate(nameDraft.value || fallback, props.modelValue);
-  nameDraft.value = "";
-  refreshTemplates();
+  saving.value = true;
+  error.value = "";
+  try {
+    await saveGenerationTemplateWithMedia(
+      nameDraft.value || fallback,
+      props.modelValue,
+    );
+    nameDraft.value = "";
+    refreshTemplates();
+  } catch (cause) {
+    error.value =
+      cause instanceof Error
+        ? cause.message
+        : "Couldn’t save the template and its source image.";
+  } finally {
+    saving.value = false;
+  }
 }
 
-function loadTemplate(template: GenerationTemplate) {
-  emit("update:modelValue", template.form);
+async function loadTemplate(template: GenerationTemplate) {
+  const epoch = ++loadEpoch;
+  loadingId.value = template.id;
+  error.value = "";
+  try {
+    const hydrated = await hydrateGenerationTemplate(template);
+    if (epoch !== loadEpoch) return;
+    emit("update:modelValue", hydrated.form);
+    if (hydrated.sourceMissing) {
+      error.value =
+        "The template loaded, but its source image is no longer available.";
+    }
+  } catch (cause) {
+    if (epoch === loadEpoch) {
+      error.value =
+        cause instanceof Error ? cause.message : "Couldn’t load the template.";
+    }
+  } finally {
+    if (epoch === loadEpoch) loadingId.value = null;
+  }
 }
 
 async function renameTemplate(template: GenerationTemplate) {
@@ -81,9 +119,10 @@ async function renameTemplate(template: GenerationTemplate) {
   refreshTemplates();
 }
 
-function deleteTemplate(template: GenerationTemplate) {
-  deleteGenerationTemplate(template.id);
+async function deleteTemplate(template: GenerationTemplate) {
+  const deletion = deleteGenerationTemplateWithMedia(template);
   refreshTemplates();
+  await deletion;
 }
 </script>
 
@@ -111,11 +150,13 @@ function deleteTemplate(template: GenerationTemplate) {
         type="button"
         class="rounded-md bg-surface px-2 py-1 text-xs text-ink-2 hover:bg-surface"
         data-test="template-save"
+        :disabled="saving"
         @click="saveCurrent"
       >
-        Save
+        {{ saving ? "Saving…" : "Save" }}
       </button>
     </div>
+    <p v-if="error" class="mt-1 text-xs text-stop" role="alert">{{ error }}</p>
 
     <div class="mt-2 grid grid-cols-[1fr_auto] gap-2">
       <input
@@ -148,9 +189,11 @@ function deleteTemplate(template: GenerationTemplate) {
           type="button"
           class="min-w-0 truncate text-left text-xs text-ink-2 hover:text-rebate"
           data-test="template-load"
+          :disabled="loadingId === template.id"
           @click="loadTemplate(template)"
         >
           <span data-test="template-row-name">{{ template.name }}</span>
+          <span v-if="loadingId === template.id" class="ml-1">Restoring…</span>
           <span class="ml-1 text-ink-3">
             {{
               template.form.model ? modelLabel(template.form.model) : "no model"

--- a/web/src/lib/generationTemplates.test.ts
+++ b/web/src/lib/generationTemplates.test.ts
@@ -2,11 +2,18 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { GenerateFormState } from "../types";
 import {
   deleteGenerationTemplate,
+  deleteGenerationTemplateWithMedia,
+  hydrateGenerationTemplate,
   loadGenerationTemplates,
   renameGenerationTemplate,
   saveGenerationTemplate,
+  saveGenerationTemplateWithMedia,
   searchGenerationTemplates,
 } from "./generationTemplates";
+import type {
+  StoredTemplateMedia,
+  TemplateMediaPersistence,
+} from "@studio/lib/templateMediaStore";
 
 function makeForm(
   overrides: Partial<GenerateFormState> = {},
@@ -59,10 +66,71 @@ function makeForm(
   };
 }
 
+function memoryMedia(): TemplateMediaPersistence & {
+  records: Map<string, StoredTemplateMedia>;
+} {
+  const records = new Map<string, StoredTemplateMedia>();
+  return {
+    records,
+    async put(record) {
+      records.set(record.assetId, structuredClone(record));
+      return true;
+    },
+    async get(assetId) {
+      return records.get(assetId) ?? null;
+    },
+    async delete(assetId) {
+      records.delete(assetId);
+    },
+  };
+}
+
 describe("generation templates", () => {
   beforeEach(() => {
     localStorage.clear();
     vi.setSystemTime(new Date("2026-05-28T12:00:00Z"));
+  });
+
+  it("restores ordered local and gallery sources from durable template media", async () => {
+    const persistence = memoryMedia();
+    const saved = await saveGenerationTemplateWithMedia(
+      "Sources",
+      makeForm({
+        imageAttachments: [
+          { kind: "upload", filename: "local.png", base64: "LOCAL" },
+          { kind: "gallery", filename: "remote.jpg", base64: "REMOTE" },
+        ],
+      }),
+      persistence,
+    );
+
+    expect(saved.form.imageAttachments.every((image) => !image.base64)).toBe(
+      true,
+    );
+    expect(JSON.stringify(saved)).not.toContain('"LOCAL"');
+    const hydrated = await hydrateGenerationTemplate(saved, persistence);
+    expect(hydrated.sourceMissing).toBe(false);
+    expect(hydrated.form.imageAttachments).toEqual([
+      { kind: "upload", filename: "local.png", base64: "LOCAL" },
+      { kind: "gallery", filename: "remote.jpg", base64: "REMOTE" },
+    ]);
+
+    await deleteGenerationTemplateWithMedia(saved, persistence);
+    expect(persistence.records.size).toBe(0);
+  });
+
+  it("does not expose byte-free legacy source markers as usable images", async () => {
+    const legacy = saveGenerationTemplate(
+      "Legacy",
+      makeForm({
+        imageAttachments: [
+          { kind: "gallery", filename: "gone.png", base64: "GONE" },
+        ],
+      }),
+    );
+    const hydrated = await hydrateGenerationTemplate(legacy, memoryMedia());
+    expect(hydrated.form.imageAttachments).toEqual([]);
+    expect(hydrated.sourceMissing).toBe(true);
   });
 
   it("saves named templates with sanitized form config and media references", () => {

--- a/web/src/lib/generationTemplates.ts
+++ b/web/src/lib/generationTemplates.ts
@@ -1,6 +1,13 @@
 import type { GenerateFormState, SourceImageState } from "../types";
 import { cloneTemplateForm } from "../composables/useGenerateForm";
 import { createUuid } from "@studio/lib/id";
+import {
+  deleteGenerationTemplateMedia,
+  hydrateGenerationTemplateMedia,
+  persistGenerationTemplateMedia,
+  type GenerationTemplateMediaAsset,
+  type TemplateMediaPersistence,
+} from "@studio/lib/templateMediaStore";
 
 export const GENERATION_TEMPLATES_STORAGE_KEY = "mold.generation.templates.v1";
 
@@ -26,10 +33,12 @@ export interface GenerationTemplate {
   createdAt: number;
   updatedAt: number;
   form: GenerateFormState;
-  /** Human-facing references for media that could not be persisted without
-   * storing browser-local base64 blobs. Loading a template restores safe path
-   * fields from `form`, but upload/gallery bytes must be re-selected. */
+  /** Human-facing references for media present when the template was saved.
+   * Source images also have durable `mediaAssets`; unsupported auxiliary
+   * media keeps this metadata so the UI can request re-selection. */
   mediaReferences: GenerationTemplateMediaReference[];
+  /** Durable client-local source snapshots. Legacy templates omit this. */
+  mediaAssets?: GenerationTemplateMediaAsset[];
 }
 
 function now(): number {
@@ -165,6 +174,84 @@ export function saveGenerationTemplate(
   return template;
 }
 
+/** Save the template only after source bytes are durable in IndexedDB. */
+export async function saveGenerationTemplateWithMedia(
+  name: string,
+  form: GenerateFormState,
+  persistence?: TemplateMediaPersistence,
+): Promise<GenerationTemplate> {
+  const timestamp = now();
+  const id = templateId();
+  const mediaAssets = await persistGenerationTemplateMedia(
+    id,
+    form.imageAttachments.map((image, index) => ({
+      field: "imageAttachments",
+      index,
+      filename: image.filename,
+      kind: image.kind,
+      width: image.width,
+      height: image.height,
+      mime: image.mime,
+      base64: image.base64,
+    })),
+    persistence,
+  );
+  const template: GenerationTemplate = {
+    id,
+    name: normalizeName(name),
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    form: cloneTemplateForm(form),
+    mediaReferences: collectTemplateMediaReferences(form),
+    ...(mediaAssets.length ? { mediaAssets } : {}),
+  };
+  try {
+    writeTemplates([template, ...loadGenerationTemplates()]);
+  } catch (error) {
+    await deleteGenerationTemplateMedia(mediaAssets, persistence);
+    throw error;
+  }
+  return template;
+}
+
+export async function hydrateGenerationTemplate(
+  template: GenerationTemplate,
+  persistence?: TemplateMediaPersistence,
+): Promise<{ form: GenerateFormState; sourceMissing: boolean }> {
+  const form = JSON.parse(JSON.stringify(template.form)) as GenerateFormState;
+  // Legacy byte-free attachment markers must not masquerade as usable source
+  // images. New templates rebuild the ordered list from durable assets below.
+  form.imageAttachments = [];
+  const assets = template.mediaAssets ?? [];
+  const { media, missing } = await hydrateGenerationTemplateMedia(
+    assets,
+    persistence,
+  );
+  const attachments = media
+    .filter((asset) => asset.field === "imageAttachments")
+    .sort((left, right) => (left.index ?? 0) - (right.index ?? 0))
+    .map<SourceImageState>((asset) => ({
+      kind: asset.kind ?? "upload",
+      filename: asset.filename,
+      base64: asset.base64,
+      ...(asset.width != null ? { width: asset.width } : {}),
+      ...(asset.height != null ? { height: asset.height } : {}),
+      ...(asset.mime != null ? { mime: asset.mime } : {}),
+    }));
+  form.imageAttachments = attachments;
+  const expected = assets.filter(
+    (asset) => asset.field === "imageAttachments",
+  ).length;
+  return {
+    form,
+    sourceMissing:
+      template.mediaReferences.some(
+        (reference) => reference.field === "imageAttachments",
+      ) &&
+      (expected === 0 || attachments.length !== expected || missing.length > 0),
+  };
+}
+
 export function renameGenerationTemplate(
   id: string,
   name: string,
@@ -188,6 +275,14 @@ export function deleteGenerationTemplate(id: string): void {
   writeTemplates(
     loadGenerationTemplates().filter((template) => template.id !== id),
   );
+}
+
+export async function deleteGenerationTemplateWithMedia(
+  template: GenerationTemplate,
+  persistence?: TemplateMediaPersistence,
+): Promise<void> {
+  deleteGenerationTemplate(template.id);
+  await deleteGenerationTemplateMedia(template.mediaAssets ?? [], persistence);
 }
 
 export function searchGenerationTemplates(


### PR DESCRIPTION
## Summary

- persist exact template source and edit/reference image bytes in durable client-side IndexedDB storage
- restore saved local and gallery images across web, desktop, and iPhone, independent of the original local or remote generation host
- fail template saves cleanly when durable media storage is unavailable, clean up owned media on deletion, preserve legacy reattachment behavior, and fence async template loads against stale results

## User impact

Templates saved with source images now restore those images automatically instead of requiring users to choose them again. This works for local uploads and gallery images from local or remote machines on every Create surface.

## Validation

- `bun run check:frontend`
- `bun run build:mobile`
- `bun run fmt:check`
- `bun run check:dead-code`
- `git diff --check`

Post-rebase totals: 316 Studio tests, 1,128 web tests, and 2,772 desktop/iPhone tests passed.