### PR TITLE
refactor(studio): share generation capability policy

### DIFF
--- a/desktop/src/lib/capabilities.ts
+++ b/desktop/src/lib/capabilities.ts
@@ -1,9 +1,8 @@
 /**
  * Per-family generation capability matrix.
  *
- * Logic ported verbatim from the web SPA's `generateCapabilities.ts`
- * (families, scheduler options, CFG++ gate, negative-prompt gate, LoRA gate,
- * ControlNet gate, qwen-edit mode, batch-size lock). Two desktop additions:
+ * Shared family policy lives in `@studio/lib/generationCapabilities`. Two
+ * desktop additions:
  *   - `supportsImg2img` — whether the SourceImageWell should render at all.
  *     True for every non-video image family AND for LTX-2, whose engine
  *     stages `source_image` as frame-0 conditioning (image-to-video, with
@@ -12,106 +11,55 @@
  *   - `pruneRequestForFamily` — strips request fields the target family does
  *     not support, applied on model change so a leftover value never ships.
  *
- * Keep the LoRA-capable list in sync with the web `LORA_CAPABLE_FAMILIES`,
- * `mold-tui/src/model_info.rs::capabilities_for_family`, and the server-side
+ * Keep the shared LoRA-capable list in sync with
+ * `mold-tui/src/model_info.rs::capabilities_for_family` and the server-side
  * gate in `mold-core/src/validation.rs`.
  */
+import {
+  baseGenerationCapabilities,
+  isAdvancedVideoFamily,
+  isFlux2DevModel,
+  isQwenImageEditFamily,
+  MAX_LORA_STACK,
+  type BaseGenerationCapabilities,
+} from "@studio/lib/generationCapabilities";
 import type { GenerateRequest, OutputFormat, Scheduler } from "./api/types";
 
-export type SourceImageMode = "single" | "qwen-edit" | "references";
+export type { SourceImageMode } from "@studio/lib/generationCapabilities";
+export { isFlux2DevModel, isQwenImageEditFamily, MAX_LORA_STACK };
 
-export interface GenerationCapabilities {
-  supportsNegativePrompt: boolean;
-  supportsScheduler: boolean;
+export interface GenerationCapabilities extends Omit<
+  BaseGenerationCapabilities,
+  "schedulerOptions"
+> {
   schedulerOptions: Scheduler[];
-  supportsCfgPlus: boolean;
-  supportsVideo: boolean;
-  supportsAudio: boolean;
-  supportsLora: boolean;
-  supportsControlNet: boolean;
   supportsImg2img: boolean;
-  sourceImageMode: SourceImageMode;
-  supportsMask: boolean;
-  forcesBatchSizeOne: boolean;
   /** LTX-2 only — the pipeline/keyframe/upscale/retake surface. `ltx-video`
    * is a plain video family and does NOT get these. */
   supportsAdvancedVideo: boolean;
 }
 
-const SCHEDULER_OPTIONS: Scheduler[] = ["default", "ddim", "euler-ancestral", "unipc"];
-
-const NO_NEGATIVE_PROMPT_FAMILIES = new Set([
-  "flux",
-  "flux2",
-  "flux.2",
-  "flux-2",
-  "z-image",
-  "qwen-image",
-  "qwen_image",
-  "qwen-image-edit",
-]);
-
-const SCHEDULER_FAMILIES = new Set(["sd15", "sd1.5", "stable-diffusion-1.5", "sdxl"]);
-
-const CFG_PLUS_FAMILIES = new Set(["sd3", "sd3.5"]);
-const VIDEO_FAMILIES = new Set(["ltx-video", "ltx2", "ltx-2"]);
-const AUDIO_FAMILIES = new Set(["ltx2", "ltx-2"]);
-/** LTX-2 only — the advanced pipeline/keyframe/upscale/retake surface. */
-const ADVANCED_VIDEO_FAMILIES = new Set(["ltx2", "ltx-2"]);
-const CONTROLNET_FAMILIES = new Set(["sd15", "sd1.5", "stable-diffusion-1.5"]);
-
-/** Mirrors web `LORA_CAPABLE_FAMILIES`. */
-const LORA_CAPABLE_FAMILIES = new Set([
-  "flux",
-  "flux2",
-  "ltx2",
-  "sd15",
-  "sd3",
-  "sdxl",
-  "qwen-image",
-  "qwen-image-edit",
-  "z-image",
-]);
-
-/** Soft ceiling on stacked LoRAs — matches web `MAX_LORA_STACK`. */
-export const MAX_LORA_STACK = 4;
-
 export function generationCapabilitiesForFamily(
   family: string,
   model = "",
 ): GenerationCapabilities {
-  const normalized = family.trim().toLowerCase();
-  const qwenEdit = isQwenImageEditFamily(normalized);
-  const referenceEdit = qwenEdit || isFlux2DevModel(model);
-  const supportsVideo = VIDEO_FAMILIES.has(normalized);
-  const schedulerOptions = SCHEDULER_FAMILIES.has(normalized) ? SCHEDULER_OPTIONS.slice() : [];
+  const shared = baseGenerationCapabilities(family, model);
+  const supportsAdvancedVideo = isAdvancedVideoFamily(family);
   return {
-    supportsNegativePrompt: !NO_NEGATIVE_PROMPT_FAMILIES.has(normalized),
-    supportsScheduler: schedulerOptions.length > 0,
-    schedulerOptions,
-    supportsCfgPlus: CFG_PLUS_FAMILIES.has(normalized),
-    supportsVideo,
-    supportsAudio: AUDIO_FAMILIES.has(normalized),
-    supportsLora: !isFlux2DevModel(model) && LORA_CAPABLE_FAMILIES.has(normalized),
-    supportsControlNet: CONTROLNET_FAMILIES.has(normalized),
+    ...shared,
     // LTX-2 accepts a still source_image as frame-0 conditioning (img2video);
     // ltx-video's engine has no img2vid path, so only the advanced-video
     // families get the well among video families.
-    supportsImg2img: !supportsVideo || ADVANCED_VIDEO_FAMILIES.has(normalized),
-    sourceImageMode: isFlux2DevModel(model) ? "references" : qwenEdit ? "qwen-edit" : "single",
-    supportsMask: !referenceEdit && !supportsVideo,
-    // Qwen edit always has a target image. FLUX.2 Dev only requires one
-    // output when references are actually attached; serializers and controls
-    // apply that request-sensitive lock.
-    forcesBatchSizeOne: qwenEdit,
-    supportsAdvancedVideo: ADVANCED_VIDEO_FAMILIES.has(normalized),
+    supportsImg2img: !shared.supportsVideo || supportsAdvancedVideo,
+    supportsMask: shared.supportsMask && !shared.supportsVideo,
+    supportsAdvancedVideo,
   };
 }
 
 /** LTX-2 advanced video gate: pipeline mode, keyframes, spatial/temporal
  * upscale, retake range, and source video. `ltx-video` returns false. */
 export function supportsAdvancedVideo(family: string): boolean {
-  return generationCapabilitiesForFamily(family).supportsAdvancedVideo;
+  return isAdvancedVideoFamily(family);
 }
 
 export function schedulerOptionsForFamily(family: string): Scheduler[] {
@@ -120,15 +68,6 @@ export function schedulerOptionsForFamily(family: string): Scheduler[] {
 
 export function isVideoFamily(family: string): boolean {
   return generationCapabilitiesForFamily(family).supportsVideo;
-}
-
-export function isQwenImageEditFamily(family: string): boolean {
-  return family === "qwen-image-edit";
-}
-
-export function isFlux2DevModel(model: string): boolean {
-  const normalized = model.trim().toLowerCase();
-  return normalized.includes("flux2-dev") || normalized.includes("flux.2-dev");
 }
 
 /** Output-format options for a family, most-preferred first (the UI default). */

--- a/studio/lib/generationCapabilities.test.ts
+++ b/studio/lib/generationCapabilities.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+  baseGenerationCapabilities,
+  isAdvancedVideoFamily,
+} from "./generationCapabilities";
+
+describe("baseGenerationCapabilities", () => {
+  it("keeps supported family aliases on the same capability policy", () => {
+    for (const family of ["sd15", "sd1.5", "stable-diffusion-1.5"]) {
+      expect(baseGenerationCapabilities(family)).toMatchObject({
+        supportsScheduler: true,
+        supportsControlNet: true,
+      });
+    }
+    for (const family of ["flux2", "flux.2", "flux-2"]) {
+      expect(baseGenerationCapabilities(family)).toMatchObject({
+        supportsNegativePrompt: false,
+        supportsLora: family === "flux2",
+      });
+    }
+    for (const family of ["ltx2", "ltx-2"]) {
+      expect(baseGenerationCapabilities(family)).toMatchObject({
+        supportsVideo: true,
+        supportsAudio: true,
+      });
+      expect(isAdvancedVideoFamily(family)).toBe(true);
+    }
+  });
+
+  it("returns independent scheduler option lists", () => {
+    const first = baseGenerationCapabilities("sdxl").schedulerOptions;
+    first.pop();
+    expect(baseGenerationCapabilities("sdxl").schedulerOptions).toEqual([
+      "default",
+      "ddim",
+      "euler-ancestral",
+      "unipc",
+    ]);
+  });
+});

--- a/studio/lib/generationCapabilities.ts
+++ b/studio/lib/generationCapabilities.ts
@@ -1,0 +1,107 @@
+export type GenerationScheduler =
+  "default" | "ddim" | "euler-ancestral" | "unipc";
+
+export type SourceImageMode = "single" | "qwen-edit" | "references";
+
+export interface BaseGenerationCapabilities {
+  supportsNegativePrompt: boolean;
+  supportsScheduler: boolean;
+  schedulerOptions: GenerationScheduler[];
+  supportsCfgPlus: boolean;
+  supportsVideo: boolean;
+  supportsAudio: boolean;
+  supportsLora: boolean;
+  supportsControlNet: boolean;
+  sourceImageMode: SourceImageMode;
+  supportsMask: boolean;
+  forcesBatchSizeOne: boolean;
+}
+
+const SCHEDULER_OPTIONS: GenerationScheduler[] = [
+  "default",
+  "ddim",
+  "euler-ancestral",
+  "unipc",
+];
+
+const NO_NEGATIVE_PROMPT_FAMILIES = new Set([
+  "flux",
+  "flux2",
+  "flux.2",
+  "flux-2",
+  "z-image",
+  "qwen-image",
+  "qwen_image",
+  "qwen-image-edit",
+]);
+
+const SCHEDULER_FAMILIES = new Set([
+  "sd15",
+  "sd1.5",
+  "stable-diffusion-1.5",
+  "sdxl",
+]);
+
+const CFG_PLUS_FAMILIES = new Set(["sd3", "sd3.5"]);
+const VIDEO_FAMILIES = new Set(["ltx-video", "ltx2", "ltx-2"]);
+const AUDIO_FAMILIES = new Set(["ltx2", "ltx-2"]);
+const ADVANCED_VIDEO_FAMILIES = new Set(["ltx2", "ltx-2"]);
+const CONTROLNET_FAMILIES = new Set(["sd15", "sd1.5", "stable-diffusion-1.5"]);
+
+export const MAX_LORA_STACK = 4;
+
+export const LORA_CAPABLE_FAMILIES = [
+  "flux",
+  "flux2",
+  "ltx2",
+  "sd15",
+  "sd3",
+  "sdxl",
+  "qwen-image",
+  "qwen-image-edit",
+  "z-image",
+] as const;
+
+export function baseGenerationCapabilities(
+  family: string,
+  model = "",
+): BaseGenerationCapabilities {
+  const normalized = family.trim().toLowerCase();
+  const qwenEdit = isQwenImageEditFamily(normalized);
+  const flux2Dev = isFlux2DevModel(model);
+  const schedulerOptions = SCHEDULER_FAMILIES.has(normalized)
+    ? SCHEDULER_OPTIONS.slice()
+    : [];
+  return {
+    supportsNegativePrompt: !NO_NEGATIVE_PROMPT_FAMILIES.has(normalized),
+    supportsScheduler: schedulerOptions.length > 0,
+    schedulerOptions,
+    supportsCfgPlus: CFG_PLUS_FAMILIES.has(normalized),
+    supportsVideo: VIDEO_FAMILIES.has(normalized),
+    supportsAudio: AUDIO_FAMILIES.has(normalized),
+    supportsLora:
+      !flux2Dev &&
+      (LORA_CAPABLE_FAMILIES as readonly string[]).includes(normalized),
+    supportsControlNet: CONTROLNET_FAMILIES.has(normalized),
+    sourceImageMode: flux2Dev
+      ? "references"
+      : qwenEdit
+        ? "qwen-edit"
+        : "single",
+    supportsMask: !qwenEdit && !flux2Dev,
+    forcesBatchSizeOne: qwenEdit,
+  };
+}
+
+export function isAdvancedVideoFamily(family: string): boolean {
+  return ADVANCED_VIDEO_FAMILIES.has(family.trim().toLowerCase());
+}
+
+export function isQwenImageEditFamily(family: string): boolean {
+  return family === "qwen-image-edit";
+}
+
+export function isFlux2DevModel(model: string): boolean {
+  const normalized = model.trim().toLowerCase();
+  return normalized.includes("flux2-dev") || normalized.includes("flux.2-dev");
+}

--- a/web/src/lib/generateCapabilities.ts
+++ b/web/src/lib/generateCapabilities.ts
@@ -1,84 +1,26 @@
+import {
+  baseGenerationCapabilities,
+  isFlux2DevModel,
+  isQwenImageEditFamily,
+  type BaseGenerationCapabilities,
+} from "@studio/lib/generationCapabilities";
 import type { Scheduler } from "../types";
-import { LORA_CAPABLE_FAMILIES } from "../types";
 
-export type SourceImageMode = "single" | "qwen-edit" | "references";
+export type { SourceImageMode } from "@studio/lib/generationCapabilities";
+export { isFlux2DevModel, isQwenImageEditFamily };
 
-export interface GenerationCapabilities {
-  supportsNegativePrompt: boolean;
-  supportsScheduler: boolean;
+export interface GenerationCapabilities extends Omit<
+  BaseGenerationCapabilities,
+  "schedulerOptions"
+> {
   schedulerOptions: Scheduler[];
-  supportsCfgPlus: boolean;
-  supportsVideo: boolean;
-  supportsAudio: boolean;
-  supportsLora: boolean;
-  supportsControlNet: boolean;
-  sourceImageMode: SourceImageMode;
-  supportsMask: boolean;
-  forcesBatchSizeOne: boolean;
 }
-
-const SCHEDULER_OPTIONS: Scheduler[] = [
-  "default",
-  "ddim",
-  "euler-ancestral",
-  "unipc",
-];
-
-const NO_NEGATIVE_PROMPT_FAMILIES = new Set([
-  "flux",
-  "flux2",
-  "flux.2",
-  "flux-2",
-  "z-image",
-  "qwen-image",
-  "qwen_image",
-  "qwen-image-edit",
-]);
-
-const SCHEDULER_FAMILIES = new Set([
-  "sd15",
-  "sd1.5",
-  "stable-diffusion-1.5",
-  "sdxl",
-]);
-
-const CFG_PLUS_FAMILIES = new Set(["sd3", "sd3.5"]);
-const VIDEO_FAMILIES = new Set(["ltx-video", "ltx2", "ltx-2"]);
-const AUDIO_FAMILIES = new Set(["ltx2", "ltx-2"]);
-const CONTROLNET_FAMILIES = new Set(["sd15", "sd1.5", "stable-diffusion-1.5"]);
 
 export function generationCapabilitiesForFamily(
   family: string,
   model = "",
 ): GenerationCapabilities {
-  const normalized = family.trim().toLowerCase();
-  const qwenEdit = isQwenImageEditFamily(normalized);
-  const referenceEdit = qwenEdit || isFlux2DevModel(model);
-  const schedulerOptions = SCHEDULER_FAMILIES.has(normalized)
-    ? SCHEDULER_OPTIONS
-    : [];
-  return {
-    supportsNegativePrompt: !NO_NEGATIVE_PROMPT_FAMILIES.has(normalized),
-    supportsScheduler: schedulerOptions.length > 0,
-    schedulerOptions,
-    supportsCfgPlus: CFG_PLUS_FAMILIES.has(normalized),
-    supportsVideo: VIDEO_FAMILIES.has(normalized),
-    supportsAudio: AUDIO_FAMILIES.has(normalized),
-    supportsLora:
-      !isFlux2DevModel(model) &&
-      (LORA_CAPABLE_FAMILIES as readonly string[]).includes(normalized),
-    supportsControlNet: CONTROLNET_FAMILIES.has(normalized),
-    sourceImageMode: isFlux2DevModel(model)
-      ? "references"
-      : qwenEdit
-        ? "qwen-edit"
-        : "single",
-    supportsMask: !referenceEdit,
-    // Qwen edit always has a target image. FLUX.2 Dev only requires one
-    // output when references are actually attached; serializers and controls
-    // apply that request-sensitive lock.
-    forcesBatchSizeOne: qwenEdit,
-  };
+  return baseGenerationCapabilities(family, model);
 }
 
 export function schedulerOptionsForFamily(family: string): Scheduler[] {
@@ -99,13 +41,4 @@ export function supportsScheduler(family: string): boolean {
 
 export function supportsLora(family: string): boolean {
   return generationCapabilitiesForFamily(family).supportsLora;
-}
-
-export function isQwenImageEditFamily(family: string): boolean {
-  return family === "qwen-image-edit";
-}
-
-export function isFlux2DevModel(model: string): boolean {
-  const normalized = model.trim().toLowerCase();
-  return normalized.includes("flux2-dev") || normalized.includes("flux.2-dev");
 }

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -691,24 +691,14 @@ export interface LoraSelection {
 /// Soft cap on stacked LoRAs in the web UI. The inference engine has no
 /// hard limit (the merge is `W' = W + Σ deltas`) but each adapter adds
 /// matmul work and disk I/O at build time, so 4 is a sane UX ceiling.
-export const MAX_LORA_STACK = 4;
+export { MAX_LORA_STACK } from "@studio/lib/generationCapabilities";
 
 /// Families whose engines actually merge LoRA adapters today. Mirrors
 /// `crates/mold-tui/src/model_info.rs::capabilities_for_family` and the
 /// server-side gate in `mold-core/src/validation.rs`. Keep all three in
 /// sync — divergence shows up as a UI that lets the user pick a LoRA the
 /// server then rejects.
-export const LORA_CAPABLE_FAMILIES = [
-  "flux",
-  "flux2",
-  "ltx2",
-  "sd15",
-  "sd3",
-  "sdxl",
-  "qwen-image",
-  "qwen-image-edit",
-  "z-image",
-] as const;
+export { LORA_CAPABLE_FAMILIES } from "@studio/lib/generationCapabilities";
 
 /** Advanced overrides for the LTX-2 multimodal guider, and their form-side
  * mirror. Both shapes and every parse/serialize rule live in `@studio` so


### PR DESCRIPTION
## Summary

- centralize the duplicated web and desktop generation-family capability matrix in `studio/lib/generationCapabilities.ts`
- keep the existing web facade and desktop-specific img2img, mask, advanced-video, output-format, and request-pruning behavior
- share the LoRA-capable family list and LoRA stack limit instead of maintaining separate copies
- characterize family aliases and scheduler-option isolation in the shared layer

## Production code reduction

`git diff --numstat origin/main...HEAD` reports:

```text
25   86   desktop/src/lib/capabilities.ts
107  0    studio/lib/generationCapabilities.ts
13   80   web/src/lib/generateCapabilities.ts
2    12   web/src/types.ts
```

Handwritten non-test production source: **147 additions, 178 removals, net -31 lines**. No generated, vendor, lock, or dependency files changed.

Reproducible total:

```bash
git diff --numstat origin/main...HEAD |
  awk '$3 !~ /\.test\.ts$/ { add += $1; del += $2 } END { printf "production additions=%d removals=%d net=%+d\n", add, del, add-del }'
```

Structural measurement: the two capability modules were 331 lines before (web 111 + desktop 220). The two adapters plus the shared authority are 310 lines after (web 44 + desktop 159 + shared 107), eliminating one duplicated policy matrix. Moving the shared constants out of `web/src/types.ts` accounts for the remaining 10-line net reduction.

Tests are separate: `studio/lib/generationCapabilities.test.ts` adds 40 lines and removes none.

## Behavior preservation

Before editing, the existing focused suites passed:

- web generation capabilities: 3/3
- desktop generation capabilities and request pruning: 23/23

After editing, those same suites pass unchanged. The new shared suite adds 2 assertions covering supported aliases and independent scheduler arrays.

## Validation

All applicable local CI-equivalent checks passed:

```bash
bun install --frozen-lockfile
bun run check:architecture
bun run check:dead-code
bun run test:studio
cd web && bun run fmt:check && bun run test && bun run build
cd ../desktop && ../scripts/tests/ios-release-assets.sh
../scripts/tests/ios-testflight-distribution.sh
../scripts/tests/ios-sim-pick.sh
bun run fmt:check
bun run test
bun run build
bun run build:mobile
```

Results:

- Studio: 38 files, 321 tests passed
- Web: 88 files, 1,128 tests passed; production build passed
- Desktop/mobile: 267 files, 2,780 tests passed; desktop and mobile builds passed
- Frontend architecture, Knip dead-code, iOS release assets, TestFlight distribution, and simulator selection contracts passed

Rust, native iOS Rust, GPU, release, and docs gates are not applicable because this PR changes only shared/web/desktop TypeScript source and tests.
