### PR TITLE
refactor(studio): share sequence stage serialization

### DIFF
--- a/studio/lib/sequenceForm.test.ts
+++ b/studio/lib/sequenceForm.test.ts
@@ -140,6 +140,34 @@ describe("buildChainRequest", () => {
 });
 
 describe("script round-trip", () => {
+  it("keeps request and script stage projections equivalent", () => {
+    const clips = [
+      clip({ negativePrompt: "no rain", cameraControl: "dolly-in" }),
+      clip({
+        prompt: "landing",
+        transition: "fade",
+        fadeFrames: 12,
+        cameraControl: "/models/camera/custom.safetensors",
+        sourceImage: { filename: "landing.png", base64: "REVG" },
+      }),
+    ];
+    const options = {
+      motionTailFrames: 17,
+      enableAudio: true,
+      openingImage: { filename: "opening.png", base64: "QUJD" },
+    };
+
+    const requestStages = buildChainRequest(shared(), clips, options).stages;
+    const scriptStages = clipsToChainScript(shared(), clips, options).stages;
+
+    expect(scriptStages).toEqual(
+      requestStages.map(({ source_image, ...stage }) => ({
+        ...stage,
+        ...(source_image ? { source_image_b64: source_image } : {}),
+      })),
+    );
+  });
+
   it("converts a job's effective script into editable clips and back", () => {
     const script: ChainScript = {
       schema: "mold.chain.v1",

--- a/studio/lib/sequenceForm.ts
+++ b/studio/lib/sequenceForm.ts
@@ -76,13 +76,14 @@ export function newSequenceClip(frames: number): SequenceClipForm {
   };
 }
 
-function stageForWire(
+function serializeStage(
   clip: SequenceClipForm,
   idx: number,
   openingImage: SequenceClipSourceImage | null,
-): ChainStageWire {
+  sourceField: "source_image" | "source_image_b64",
+): ChainStageWire & ChainScript["stages"][number] {
   const transition: SequenceTransition = idx === 0 ? "smooth" : clip.transition;
-  const stage: ChainStageWire = {
+  const stage: ChainStageWire & ChainScript["stages"][number] = {
     prompt: clip.prompt,
     frames: clip.frames,
     transition,
@@ -101,7 +102,7 @@ function stageForWire(
     ];
   }
   const sourceImage = idx === 0 ? openingImage : clip.sourceImage;
-  if (sourceImage?.base64) stage.source_image = sourceImage.base64;
+  if (sourceImage?.base64) stage[sourceField] = sourceImage.base64;
   return stage;
 }
 
@@ -131,7 +132,7 @@ export function buildChainRequest(
   const req: ChainRequestWire = {
     model: shared.model,
     stages: clips.map((clip, idx) =>
-      stageForWire(clip, idx, opts.openingImage ?? null),
+      serializeStage(clip, idx, opts.openingImage ?? null, "source_image"),
     ),
     motion_tail_frames: opts.motionTailFrames,
     width: shared.width,
@@ -232,32 +233,9 @@ export function clipsToChainScript(
       guidance: shared.guidance,
       enable_audio: opts.enableAudio ? true : null,
     },
-    stages: clips.map((clip, idx) => {
-      const stage: ChainScript["stages"][number] = {
-        prompt: clip.prompt,
-        frames: clip.frames,
-        transition: idx === 0 ? "smooth" : clip.transition,
-      };
-      if (idx > 0 && clip.transition === "fade")
-        stage.fade_frames = clip.fadeFrames;
-      if (clip.negativePrompt.trim())
-        stage.negative_prompt = clip.negativePrompt;
-      const cameraControl = clip.cameraControl?.trim();
-      if (cameraControl) {
-        const preset = isCameraMotionPreset(cameraControl);
-        stage.loras = [
-          {
-            path: preset ? `camera-control:${cameraControl}` : cameraControl,
-            scale: 1,
-            name: preset ? cameraMotionLabel(cameraControl) : "Camera motion",
-          },
-        ];
-      }
-      const sourceImage =
-        idx === 0 ? (opts.openingImage ?? null) : clip.sourceImage;
-      if (sourceImage?.base64) stage.source_image_b64 = sourceImage.base64;
-      return stage;
-    }),
+    stages: clips.map((clip, idx) =>
+      serializeStage(clip, idx, opts.openingImage ?? null, "source_image_b64"),
+    ),
   };
 }
 


### PR DESCRIPTION
## Summary

- replace the duplicated JSON/TOML chain-stage serializers with one shared projection
- preserve the intentional `source_image` versus `source_image_b64` wire-field distinction
- add a characterization test covering transitions, fades, negative prompts, camera-control LoRAs, and per-stage source images

## Reduction proof

Hand-written non-test production source only (generated, vendor, lock, and test files excluded):

```text
$ git diff --numstat origin/main -- studio/lib/sequenceForm.ts
9       31      studio/lib/sequenceForm.ts
```

That is **22 fewer production lines**. The production file shrinks from **334 to 312 lines**.

Tests are reported separately:

```text
$ git diff --numstat origin/main -- studio/lib/sequenceForm.test.ts
28      0       studio/lib/sequenceForm.test.ts
```

The structural reduction is one serialization authority instead of two parallel implementations that could drift between durable JSON submission and TOML/amend projection. This is not a move, rename, generated-file change, or formatting compression.

## Behavior preservation

The new parity test proves both outputs carry identical stage semantics after accounting for the intentional source-field rename. Existing sequence-form coverage remains green, including seed/audio handling, first-stage transition coercion, fade gating, camera motion, source restoration, and round trips.

## Validation

```text
bunx vitest run --config studio/vitest.config.ts studio/lib/sequenceForm.test.ts
bunx prettier --check studio/lib/sequenceForm.ts studio/lib/sequenceForm.test.ts
bun run check:architecture
bun run check:dead-code
bun run test:studio
(cd web && bun run fmt:check && bun run test && bun run build)
(cd desktop && bun run fmt:check && bunx vue-tsc -b && bun run test && bun run build && bun run build:mobile)
(cd desktop && ../scripts/tests/ios-release-assets.sh && ../scripts/tests/ios-testflight-distribution.sh && ../scripts/tests/ios-sim-pick.sh)
nix build .#mold-web --print-build-logs
git diff --check
test -z "$(git ls-files -ci --exclude-standard)"
```

All commands passed locally. Path routing skips Rust/GPU, desktop Rust, iOS Rust, and docs gates for this Studio-only change.
