### PR TITLE
fix(desktop): show selected host status

### DIFF
--- a/desktop/src/components/shell/StatusPopover.test.ts
+++ b/desktop/src/components/shell/StatusPopover.test.ts
@@ -127,6 +127,19 @@ describe("StatusPopover host-aware display", () => {
     expect(streamCalls.at(-1)?.target ?? null).toBeNull();
   });
 
+  it("describes a local engine failure as an engine lifecycle state", async () => {
+    const wrapper = mountPopover();
+    useConnectionStore().status = "error";
+
+    await flushPromises();
+    await openPopover(wrapper);
+
+    expect(wrapper.get("[role='dialog']").text()).toContain("engine error");
+    expect(wrapper.get("[role='dialog']").text()).toContain("Engine error");
+    expect(wrapper.get("[role='dialog']").text()).not.toContain("Machine is offline");
+    expect(wrapper.get("[data-test='status-trigger']").text()).toContain("error");
+  });
+
   it("keeps showing a concrete Create host selection while another host has a live job", async () => {
     const wrapper = mountPopover();
     addRemoteHost();

--- a/desktop/src/components/shell/StatusPopover.test.ts
+++ b/desktop/src/components/shell/StatusPopover.test.ts
@@ -104,6 +104,29 @@ describe("StatusPopover host-aware display", () => {
     expect(streamCalls.at(-1)?.target?.baseUrl).toBe("http://hal9000:7680");
   });
 
+  it("reports an offline selected host instead of presenting missing telemetry as status", async () => {
+    const wrapper = mountPopover();
+    const hosts = addRemoteHost();
+    const remote = hosts.extras.find((host) => host.id === "hal9000-7680")!;
+    remote.label = "Parity Fixture";
+    remote.status = "error";
+    remote.error = "connection refused";
+    delete hosts.telemetry[remote.id];
+    useAppPrefsStore().settings = { generateTargetHost: remote.id } as never;
+
+    await flushPromises();
+    await openPopover(wrapper);
+
+    const trigger = wrapper.get("[data-test='status-trigger']");
+    expect(wrapper.get("[role='dialog']").text()).toContain("Parity Fixture · offline");
+    expect(wrapper.get("[role='dialog']").text()).toContain("Machine is offline");
+    expect(wrapper.get("[role='dialog']").text()).not.toContain("no gpu telemetry");
+    expect(trigger.text()).toContain("offline");
+    expect(trigger.text()).toContain("—");
+    expect(trigger.get("span").classes()).toContain("bg-stop");
+    expect(streamCalls.at(-1)?.target ?? null).toBeNull();
+  });
+
   it("keeps showing a concrete Create host selection while another host has a live job", async () => {
     const wrapper = mountPopover();
     addRemoteHost();

--- a/desktop/src/components/shell/StatusPopover.vue
+++ b/desktop/src/components/shell/StatusPopover.vue
@@ -150,15 +150,22 @@ const dotClass = computed(() => {
 });
 
 const unavailableTelemetryLabel = computed(() => {
-  if (displayConnectionStatus.value === "error") return "Machine is offline";
-  if (displayConnectionStatus.value === "connecting") return "Connecting to machine…";
+  if (displayConnectionStatus.value === "error") {
+    return displayingRemote.value ? "Machine is offline" : "Engine error";
+  }
+  if (displayConnectionStatus.value === "connecting") {
+    return displayingRemote.value ? "Connecting to machine…" : "Starting engine…";
+  }
   if (displayConnectionStatus.value === "idle") return "Engine is off";
   return "No GPU telemetry";
 });
 
 const triggerStatusLabel = computed(() => {
-  if (displayConnectionStatus.value === "error") return "offline";
-  if (displayConnectionStatus.value === "connecting") return "connecting";
+  if (displayConnectionStatus.value === "error")
+    return displayingRemote.value ? "offline" : "error";
+  if (displayConnectionStatus.value === "connecting") {
+    return displayingRemote.value ? "connecting" : "starting";
+  }
   if (displayConnectionStatus.value === "idle") return "off";
   return "ready";
 });

--- a/desktop/src/components/shell/StatusPopover.vue
+++ b/desktop/src/components/shell/StatusPopover.vue
@@ -50,6 +50,10 @@ const displayHost = computed(() => {
   return hosts.all.find((h) => h.id === id) ?? hosts.primaryHost;
 });
 const displayingRemote = computed(() => !!displayHost.value && !displayHost.value.primary);
+const displayConnectionStatus = computed<"idle" | "connecting" | "ready" | "error">(() => {
+  if (displayingRemote.value) return displayHost.value!.status;
+  return conn.status === "starting" ? "connecting" : conn.status;
+});
 const anyJobRunning = computed(() =>
   generation.jobs.some((j) => j.status !== "complete" && j.status !== "error"),
 );
@@ -116,9 +120,17 @@ function gpuTone(used: number, total: number) {
 }
 
 const engineChip = computed(() => {
+  if (displayingRemote.value) {
+    const suffix =
+      displayConnectionStatus.value === "error"
+        ? " · offline"
+        : displayConnectionStatus.value === "connecting"
+          ? " · connecting"
+          : "";
+    return `⇄ ${displayHost.value!.label}${suffix}`;
+  }
   if (conn.status === "starting") return "⌁ starting…";
   if (conn.status === "error") return "⌁ engine error";
-  if (displayingRemote.value) return `⇄ ${displayHost.value!.label}`;
   switch (conn.mode) {
     case "local":
       return "⌁ local";
@@ -131,10 +143,24 @@ const engineChip = computed(() => {
 
 /** Trigger dot color mirrors the engine/host status. */
 const dotClass = computed(() => {
-  if (conn.status === "error") return "bg-stop";
-  if (conn.status === "starting") return "bg-halide animate-pulse";
+  if (displayConnectionStatus.value === "error") return "bg-stop";
+  if (displayConnectionStatus.value === "connecting") return "bg-halide animate-pulse";
   if (displayingRemote.value) return "bg-halide";
   return conn.ready ? "bg-success" : "bg-ink-3";
+});
+
+const unavailableTelemetryLabel = computed(() => {
+  if (displayConnectionStatus.value === "error") return "Machine is offline";
+  if (displayConnectionStatus.value === "connecting") return "Connecting to machine…";
+  if (displayConnectionStatus.value === "idle") return "Engine is off";
+  return "No GPU telemetry";
+});
+
+const triggerStatusLabel = computed(() => {
+  if (displayConnectionStatus.value === "error") return "offline";
+  if (displayConnectionStatus.value === "connecting") return "connecting";
+  if (displayConnectionStatus.value === "idle") return "off";
+  return "ready";
 });
 
 /** Queue + loaded models for whichever host the status is displaying. */
@@ -183,6 +209,7 @@ function startResourceStream() {
   resourceAbort = new AbortController();
   snapshot.value = null;
   const host = displayHost.value;
+  if (displayingRemote.value && host?.status !== "ready") return;
   void sseStream("/api/resources/stream", {
     signal: resourceAbort.signal,
     ...(displayingRemote.value && host?.baseUrl
@@ -223,7 +250,7 @@ watch(
 // Only the resources stream follows the display host; the status poll stays
 // on the primary (recovery invariant).
 watch(
-  () => displayHost.value?.id,
+  () => `${displayHost.value?.id ?? "none"}:${displayConnectionStatus.value}`,
   () => {
     if (conn.ready) startResourceStream();
   },
@@ -264,9 +291,9 @@ onUnmounted(() => {
         <span
           class="data-mono"
           :class="
-            conn.status === 'error'
+            displayConnectionStatus === 'error'
               ? 'text-stop'
-              : displayingRemote
+              : displayingRemote || displayConnectionStatus === 'connecting'
                 ? 'text-halide'
                 : conn.ready
                   ? 'text-ink-2'
@@ -324,7 +351,7 @@ onUnmounted(() => {
           </div>
         </div>
       </template>
-      <p v-else class="text-caption text-ink-3">no gpu telemetry</p>
+      <p v-else class="text-caption text-ink-3">{{ unavailableTelemetryLabel }}</p>
 
       <div v-if="snapshot" class="mt-2 flex items-center justify-between">
         <span class="edge-code">ram</span>
@@ -360,9 +387,11 @@ onUnmounted(() => {
         <span v-if="gpus.length" class="min-w-0 flex-1">
           <ProgressBar :value="vramPct" :tone="vramTone" :height="4" label="VRAM in use" />
         </span>
-        <span v-else class="flex-1 text-left text-caption text-ink-3">status</span>
+        <span v-else class="flex-1 text-left text-caption text-ink-3">{{
+          triggerStatusLabel
+        }}</span>
         <span class="shrink-0 font-utility text-[9.5px] text-ink-3">
-          {{ displayStatus.queueDepth ?? 0 }}
+          {{ displayStatus.queueDepth ?? "—" }}
         </span>
       </template>
     </button>


### PR DESCRIPTION
## Summary

- derive the sidebar status popover health from the host it is actually displaying
- show explicit offline, connecting, ready, and engine-off copy instead of a generic status fallback
- preserve unknown queue depth as an em dash and avoid opening telemetry streams for unavailable remotes
- add a regression for the reported offline “Parity Fixture” state

## Root cause

The popover correctly followed the selected generation host for identity and telemetry, but its health color and labels still came from the local primary connection. Consequently, any selected remote was painted as active even when its own status was `error`, while missing queue and GPU data rendered as `0` and “no gpu telemetry.”

## Validation

- `nix develop -c bun run --cwd desktop test src/components/shell/StatusPopover.test.ts` (15 passed)
- `nix develop -c bun run test:desktop` (2,802 passed)
- `nix develop -c bun run build:desktop`
- `nix develop -c bun run check:architecture`
- rendered desktop preview at `http://127.0.0.1:4178/create`: status popover opened, meaningful content rendered, no framework overlay, no console warnings/errors
