### PR TITLE
fix(ltx2): price the checkpoint's own AdaLN width (19B/22B parity)

### DIFF
--- a/crates/mold-inference/src/device.rs
+++ b/crates/mold-inference/src/device.rs
@@ -827,9 +827,15 @@ const LTX2_PIXELS_PER_TOKEN_AXIS: u64 = 32;
 const LTX2_INNER_DIM: u64 = 4096;
 /// Feed-forward hidden width (`ff.net.0.proj` output) — 4× the inner dim.
 const LTX2_FF_HIDDEN_DIM: u64 = 16_384;
-/// Per-token AdaLN width (`adaln_single.linear` output) — 6 × inner dim, only
+/// Per-token AdaLN width (`adaln_single.linear` output) when the checkpoint's
+/// own width is not known — 6 × inner dim, the LTX-2 19B layout. Only
 /// materialized per token when the run is conditioned.
-const LTX2_ADALN_DIM: u64 = 24_576;
+///
+/// This is a fallback, not the truth: LTX-2.3's 22B checkpoint ships nine
+/// components (`[36864, 4096]`), so callers that have read the checkpoint
+/// header pass its real width to
+/// [`ltx2_activation_budget_bytes`].
+pub const LTX2_ADALN_DEFAULT_DIM: u64 = 24_576;
 const BF16_BYTES: u64 = 2;
 const F32_BYTES: u64 = 4;
 
@@ -872,19 +878,26 @@ pub fn ltx2_token_count(width: u32, height: u32, frames: u32) -> u64 {
 /// * feed-forward — the BF16 `[1, T, 16384]` projection. The F32 GELU work is
 ///   chunked (two `[chunk, 16384]` buffers) and therefore priced in
 ///   [`LTX2_FIXED_WORKSPACE_BYTES`], not per token
-/// * AdaLN — the per-token `[1, T, 24576]` BF16 modulation, materialized only
-///   when `conditioned` (source image, keyframes, or extend carryover) makes
-///   the modulation token-varying rather than a single broadcast row
+/// * AdaLN — the per-token `[1, T, adaln_dim]` BF16 modulation, materialized
+///   only when `conditioned` (source image, keyframes, or extend carryover)
+///   makes the modulation token-varying rather than a single broadcast row
 ///
-/// That is 112 KiB/token unconditioned and 160 KiB/token conditioned, plus the
-/// flat workspace. Anchors: 1024² × 97 frames (13,312 tokens) → 2.60 GB
-/// unconditioned / 3.25 GB conditioned; the 512² stage-1 render of the same
-/// job (3,328 tokens) → 1.46 GB.
+/// `adaln_dim` is the checkpoint's own `adaln_single.linear` output width. It
+/// is **not** a constant across LTX-2: the 19B ships six components
+/// (`[24576, 4096]`) and LTX-2.3's 22B ships nine (`[36864, 4096]`), a 327 MB
+/// difference at the stage-2 shape. Pass `None` only when the header has not
+/// been read; it falls back to [`LTX2_ADALN_DEFAULT_DIM`].
+///
+/// That is 112 KiB/token unconditioned and 160 KiB/token conditioned at the
+/// six-component width, plus the flat workspace. Anchors: 1024² × 97 frames
+/// (13,312 tokens) → 2.60 GB unconditioned / 3.25 GB conditioned; the 512²
+/// stage-1 render of the same job (3,328 tokens) → 1.46 GB.
 pub fn ltx2_activation_budget_bytes(
     width: u32,
     height: u32,
     frames: u32,
     conditioned: bool,
+    adaln_dim: Option<u64>,
 ) -> u64 {
     let residual = LTX2_RESIDUAL_LIVE_BUFFERS * LTX2_INNER_DIM * BF16_BYTES;
     // `chunked_attention` narrows q/k/v and upcasts per tile, so the only
@@ -894,7 +907,7 @@ pub fn ltx2_activation_budget_bytes(
     let attention = 3 * LTX2_INNER_DIM * BF16_BYTES + LTX2_INNER_DIM * F32_BYTES;
     let feed_forward = LTX2_FF_HIDDEN_DIM * BF16_BYTES;
     let adaln = if conditioned {
-        LTX2_ADALN_DIM * BF16_BYTES
+        adaln_dim.unwrap_or(LTX2_ADALN_DEFAULT_DIM) * BF16_BYTES
     } else {
         0
     };
@@ -3172,13 +3185,44 @@ mod tests {
     /// flat 1 GiB workspace.
     #[test]
     fn ltx2_activation_budget_models_ff_and_adaln() {
-        let uncond = ltx2_activation_budget_bytes(1024, 1024, 97, false);
-        let cond = ltx2_activation_budget_bytes(1024, 1024, 97, true);
+        let uncond = ltx2_activation_budget_bytes(1024, 1024, 97, false, None);
+        let cond = ltx2_activation_budget_bytes(1024, 1024, 97, true, None);
         assert_eq!(uncond, 13_312 * 114_688 + 1_073_741_824);
         assert_eq!(cond, 13_312 * 163_840 + 1_073_741_824);
         assert_eq!(uncond, 2_600_468_480);
         assert_eq!(cond, 3_254_779_904);
-        assert_eq!(cond - uncond, 13_312 * LTX2_ADALN_DIM * BF16_BYTES);
+        assert_eq!(cond - uncond, 13_312 * LTX2_ADALN_DEFAULT_DIM * BF16_BYTES);
+    }
+
+    /// LTX-2.3's 22B checkpoint ships `adaln_single.linear.weight` at
+    /// `[36864, 4096]` — **nine** AdaLN components, not the 19B's six. Measured
+    /// from the two checkpoints' safetensors headers. Assuming the 19B width
+    /// under-reserved a conditioned 22B render by 327 MB at the stage-2 shape,
+    /// in the exact budget this estimator exists to keep honest.
+    #[test]
+    fn ltx2_activation_budget_follows_the_checkpoints_adaln_width() {
+        const NINE_COMPONENT_ADALN: u64 = 36_864;
+        let six = ltx2_activation_budget_bytes(1024, 1024, 97, true, Some(LTX2_ADALN_DEFAULT_DIM));
+        let nine = ltx2_activation_budget_bytes(1024, 1024, 97, true, Some(NINE_COMPONENT_ADALN));
+
+        assert_eq!(
+            six,
+            ltx2_activation_budget_bytes(1024, 1024, 97, true, None),
+            "an unknown width must fall back to the 19B/6-component default"
+        );
+        assert_eq!(
+            nine - six,
+            13_312 * (NINE_COMPONENT_ADALN - LTX2_ADALN_DEFAULT_DIM) * BF16_BYTES,
+            "the extra three components must be priced per token"
+        );
+        assert_eq!(nine - six, 327_155_712);
+
+        // An unconditioned render never materializes the per-token modulation,
+        // so the width cannot matter there.
+        assert_eq!(
+            ltx2_activation_budget_bytes(1024, 1024, 97, false, Some(NINE_COMPONENT_ADALN)),
+            ltx2_activation_budget_bytes(1024, 1024, 97, false, None),
+        );
     }
 
     /// A half-resolution stage-1 render costs a quarter of the tokens, so it
@@ -3186,8 +3230,8 @@ mod tests {
     /// charged it the full-resolution budget.
     #[test]
     fn ltx2_activation_budget_scales_with_tokens_not_pixels() {
-        let stage1 = ltx2_activation_budget_bytes(512, 512, 97, false);
-        let stage2 = ltx2_activation_budget_bytes(1024, 1024, 97, false);
+        let stage1 = ltx2_activation_budget_bytes(512, 512, 97, false, None);
+        let stage2 = ltx2_activation_budget_bytes(1024, 1024, 97, false, None);
         assert_eq!(stage1, 3_328 * 114_688 + 1_073_741_824);
         let stage1_tokens = stage1 - 1_073_741_824;
         let stage2_tokens = stage2 - 1_073_741_824;
@@ -3197,7 +3241,7 @@ mod tests {
     /// Even a degenerate shape reserves the flat workspace.
     #[test]
     fn ltx2_activation_budget_floors_at_fixed_workspace() {
-        let tiny = ltx2_activation_budget_bytes(0, 0, 0, false);
+        let tiny = ltx2_activation_budget_bytes(0, 0, 0, false, None);
         assert!(tiny >= 1_073_741_824, "got {tiny}");
     }
 

--- a/crates/mold-inference/src/ltx2/runtime.rs
+++ b/crates/mold-inference/src/ltx2/runtime.rs
@@ -5002,8 +5002,14 @@ fn plan_is_conditioned(plan: &Ltx2GeneratePlan) -> bool {
         || plan.conditioning.video_path.is_some()
 }
 
-fn ltx2_video_activation_budget(stage: Ltx2StageShape) -> u64 {
-    ltx2_activation_budget_bytes(stage.width, stage.height, stage.frames, stage.conditioned)
+fn ltx2_video_activation_budget(stage: Ltx2StageShape, adaln_dim: Option<u64>) -> u64 {
+    ltx2_activation_budget_bytes(
+        stage.width,
+        stage.height,
+        stage.frames,
+        stage.conditioned,
+        adaln_dim,
+    )
 }
 
 /// The VRAM the adaptive planner may spend on this transformer.
@@ -5029,7 +5035,7 @@ fn ltx2_adaptive_transformer_plan(
         &weights.blocks,
         ltx2_transformer_vram_budget(plan.vram_grant_bytes, free_vram),
         weights.non_block_bytes,
-        ltx2_video_activation_budget(stage),
+        ltx2_video_activation_budget(stage, weights.adaln_dim),
         ADAPTIVE_OFFLOAD_RUNTIME_HEADROOM,
     )
 }
@@ -5481,6 +5487,11 @@ struct Ltx2TransformerWeightSizes {
     /// the GPU *after* every resident block, so they are unconditionally
     /// resident and must be reserved, not discovered.
     non_block_bytes: u64,
+    /// The checkpoint's `adaln_single.linear` output width, which sets the
+    /// per-token AdaLN cost of a conditioned render. Not a constant across
+    /// LTX-2: the 19B ships six components (24,576) and LTX-2.3's 22B ships
+    /// nine (36,864). `None` when the tensor is absent from the header.
+    adaln_dim: Option<u64>,
 }
 
 /// The parsed safetensors header of an LTX-2 checkpoint.
@@ -5577,12 +5588,22 @@ impl Ltx2CheckpointHeader {
     fn transformer_weight_sizes(&self, num_layers: usize) -> Result<Ltx2TransformerWeightSizes> {
         let mut blocks = vec![0usize; num_layers];
         let mut non_block_bytes = 0u64;
+        let mut adaln_dim = None;
         for (name, tensor) in &self.tensors {
             if ltx2_tensor_is_non_transformer(name) {
                 continue;
             }
             let tensor_bytes = Self::tensor_bytes(name, tensor)?;
             let remapped = remap_ltx2_transformer_key(name);
+            // The video branch's own modulation table. `audio_adaln_single`
+            // and the `av_ca_*` gates share the suffix, so match the exact key
+            // rather than a contains().
+            if remapped.ends_with("adaln_single.linear.weight")
+                && !remapped.contains("audio")
+                && !remapped.contains("av_ca_")
+            {
+                adaln_dim = tensor.shape.first().map(|dim| *dim as u64);
+            }
             match ltx2_transformer_block_index(&remapped) {
                 Some(index) => {
                     if let Some(size) = blocks.get_mut(index) {
@@ -5595,6 +5616,7 @@ impl Ltx2CheckpointHeader {
         Ok(Ltx2TransformerWeightSizes {
             blocks,
             non_block_bytes,
+            adaln_dim,
         })
     }
 }
@@ -7508,6 +7530,7 @@ mod tests {
         let weights = super::Ltx2TransformerWeightSizes {
             blocks: ltx2_19b_fp8_blocks(),
             non_block_bytes: 2_107_091_456,
+            adaln_dim: Some(24_576),
         };
         const FREE_VRAM: u64 = 25_339_395_072;
 
@@ -7516,7 +7539,7 @@ mod tests {
         assert_eq!(residency.fixed_resident_bytes, weights.non_block_bytes);
         let true_demand = residency.resident_bytes
             + weights.non_block_bytes
-            + super::ltx2_video_activation_budget(stage)
+            + super::ltx2_video_activation_budget(stage, weights.adaln_dim)
             + super::ADAPTIVE_OFFLOAD_RUNTIME_HEADROOM
             + residency.largest_streamed_block;
         assert!(
@@ -7533,12 +7556,12 @@ mod tests {
         let stage1 = stage_shape(&plan, 512, 512, 97);
         let stage2 = stage_shape(&plan, 1024, 1024, 97);
 
-        let stage1_budget = super::ltx2_video_activation_budget(stage1);
-        let stage2_budget = super::ltx2_video_activation_budget(stage2);
+        let stage1_budget = super::ltx2_video_activation_budget(stage1, None);
+        let stage2_budget = super::ltx2_video_activation_budget(stage2, None);
 
         assert_eq!(
             stage1_budget,
-            super::ltx2_activation_budget_bytes(512, 512, 97, stage1.conditioned)
+            super::ltx2_activation_budget_bytes(512, 512, 97, stage1.conditioned, None)
         );
         assert!(
             stage1_budget < stage2_budget,
@@ -7569,6 +7592,7 @@ mod tests {
         let weights = super::Ltx2TransformerWeightSizes {
             blocks: ltx2_19b_fp8_blocks(),
             non_block_bytes: 2_107_091_456,
+            adaln_dim: Some(24_576),
         };
         let ungranted = ltx2_plan_at(1024, 1024, 97);
         let stage = stage_shape(&ungranted, 1024, 1024, 97);
@@ -7640,8 +7664,9 @@ mod tests {
     #[test]
     fn ltx2_adaptive_residency_reserves_every_live_latent_frame() {
         let plan = ltx2_plan_at(1024, 1024, 97);
-        let budget =
-            |frames| super::ltx2_video_activation_budget(stage_shape(&plan, 1024, 1024, frames));
+        let budget = |frames| {
+            super::ltx2_video_activation_budget(stage_shape(&plan, 1024, 1024, frames), None)
+        };
 
         // 1 pixel frame → 1 latent frame; 9 → 2; 97 → 13.
         let one_latent_frame = budget(9) - budget(1);

--- a/crates/mold-server/src/ltx2_admission.rs
+++ b/crates/mold-server/src/ltx2_admission.rs
@@ -50,13 +50,27 @@ pub(crate) fn ltx2_activation_budget_bytes(
     height: u32,
     frames: u32,
     conditioned: bool,
+    adaln_dim: Option<u64>,
 ) -> u64 {
-    mold_inference::device::ltx2_activation_budget_bytes(width, height, frames, conditioned)
+    mold_inference::device::ltx2_activation_budget_bytes(
+        width,
+        height,
+        frames,
+        conditioned,
+        adaln_dim,
+    )
 }
 
-/// Activation budget for a request shape.
-pub(crate) fn ltx2_activation_bytes(shape: Ltx2ShapeHint) -> u64 {
-    ltx2_activation_budget_bytes(shape.width, shape.height, shape.frames, shape.conditioned)
+/// Activation budget for a request shape, priced against the checkpoint's own
+/// AdaLN width when its header has been read.
+pub(crate) fn ltx2_activation_bytes(shape: Ltx2ShapeHint, adaln_dim: Option<u64>) -> u64 {
+    ltx2_activation_budget_bytes(
+        shape.width,
+        shape.height,
+        shape.frames,
+        shape.conditioned,
+        adaln_dim,
+    )
 }
 
 /// Request shape that drives the LTX-2 activation budget. `ActivationHint`
@@ -103,6 +117,10 @@ pub(crate) struct Ltx2CheckpointFacts {
     /// Bundled video VAE weights, resident for encode and decode while the
     /// transformer's resident blocks are still held.
     pub(crate) vae_bytes: u64,
+    /// The checkpoint's `adaln_single.linear` output width, which sets the
+    /// per-token AdaLN cost of a conditioned render. The 19B ships six
+    /// components (24,576); LTX-2.3's 22B ships nine (36,864).
+    pub(crate) adaln_dim: Option<u64>,
 }
 
 impl Ltx2CheckpointFacts {
@@ -184,6 +202,8 @@ pub(crate) fn warm_checkpoint_facts(path: &Path) -> Option<Arc<Ltx2CheckpointFac
 #[derive(serde::Deserialize)]
 struct HeaderTensor {
     data_offsets: (u64, u64),
+    #[serde(default)]
+    shape: Vec<u64>,
 }
 
 /// Read the safetensors metadata header and classify every tensor into
@@ -205,6 +225,7 @@ pub(crate) fn parse_checkpoint_facts(path: &Path) -> anyhow::Result<Ltx2Checkpoi
     let mut blocks: BTreeMap<usize, u64> = BTreeMap::new();
     let mut fixed_resident_bytes = 0u64;
     let mut vae_bytes = 0u64;
+    let mut adaln_dim = None;
     for (name, value) in tensors {
         if name == "__metadata__" {
             continue;
@@ -213,6 +234,14 @@ pub(crate) fn parse_checkpoint_facts(path: &Path) -> anyhow::Result<Ltx2Checkpoi
             continue;
         };
         let bytes = tensor.data_offsets.1.saturating_sub(tensor.data_offsets.0);
+        // The video branch's own modulation table — `audio_adaln_single` and
+        // the `av_ca_*` gates share the suffix.
+        if name.ends_with("adaln_single.linear.weight")
+            && !name.contains("audio")
+            && !name.contains("av_ca_")
+        {
+            adaln_dim = tensor.shape.first().copied();
+        }
         match classify_tensor(&name) {
             TensorRole::Block(index) => {
                 let entry = blocks.entry(index).or_default();
@@ -231,6 +260,7 @@ pub(crate) fn parse_checkpoint_facts(path: &Path) -> anyhow::Result<Ltx2Checkpoi
         block_sizes,
         fixed_resident_bytes,
         vae_bytes,
+        adaln_dim,
     })
 }
 
@@ -382,7 +412,11 @@ pub(crate) fn ltx2_shape_fits(
     shape: Ltx2ShapeHint,
     available_bytes: u64,
 ) -> bool {
-    let estimate = ltx2_peak_estimate(facts, ltx2_activation_bytes(shape), available_bytes);
+    let estimate = ltx2_peak_estimate(
+        facts,
+        ltx2_activation_bytes(shape, facts.adaln_dim),
+        available_bytes,
+    );
     estimate.viable && estimate.peak_bytes <= available_bytes / 100 * LTX2_ADMISSION_BUDGET_PERCENT
 }
 
@@ -495,7 +529,11 @@ pub(crate) fn supported_shape_advice(
     requested: Ltx2ShapeHint,
     available_bytes: u64,
 ) -> Option<String> {
-    let estimate = ltx2_peak_estimate(facts, ltx2_activation_bytes(requested), available_bytes);
+    let estimate = ltx2_peak_estimate(
+        facts,
+        ltx2_activation_bytes(requested, facts.adaln_dim),
+        available_bytes,
+    );
     let shapes = supported_shapes(facts, requested, available_bytes);
     if shapes.is_empty() {
         return None;
@@ -528,6 +566,7 @@ pub(crate) mod test_support {
             block_sizes,
             fixed_resident_bytes: 2_107_091_456,
             vae_bytes: 2_444_960_482,
+            adaln_dim: Some(24_576),
         }
     }
 
@@ -559,10 +598,14 @@ pub(crate) mod test_support {
                 &mut offset,
             );
         }
+        // The AdaLN table is itself a fixed-resident tensor, so the stub
+        // carries the remainder — parsing this file must reproduce exactly the
+        // `fixed_resident_bytes` the fixture declares.
+        let adaln_bytes = facts.adaln_dim.map_or(0, |dim| dim * 4096 * 2);
         push(
             &mut tensors,
             "model.patchify_proj.weight".to_string(),
-            facts.fixed_resident_bytes,
+            facts.fixed_resident_bytes.saturating_sub(adaln_bytes),
             &mut offset,
         );
         push(
@@ -571,6 +614,20 @@ pub(crate) mod test_support {
             facts.vae_bytes,
             &mut offset,
         );
+        if let Some(adaln_dim) = facts.adaln_dim {
+            // Shape carries the real `[out, in]`, unlike the byte-sized stubs
+            // above — the parser reads this width, not the tensor's size.
+            let start = offset;
+            offset += adaln_bytes;
+            tensors.insert(
+                "model.adaln_single.linear.weight".to_string(),
+                serde_json::json!({
+                    "dtype": "BF16",
+                    "shape": [adaln_dim, 4096],
+                    "data_offsets": [start, offset],
+                }),
+            );
+        }
 
         let header = serde_json::to_vec(&serde_json::Value::Object(tensors)).unwrap();
         let mut file = File::create(path).unwrap();
@@ -595,6 +652,34 @@ mod tests {
             frames: 97,
             conditioned: true,
         }
+    }
+
+    /// LTX-2.3's 22B ships nine AdaLN components (`[36864, 4096]`) where the
+    /// 19B ships six (`[24576, 4096]`) — measured from both checkpoints'
+    /// headers. Admission must price a conditioned render against the
+    /// checkpoint it is actually going to run, not the 19B's width.
+    #[test]
+    fn checkpoint_facts_read_the_adaln_width_and_price_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut wide = ltx2_19b_fp8_facts();
+        wide.adaln_dim = Some(36_864);
+        let path = dir.path().join("ltx-2.3-22b-distilled-fp8.safetensors");
+        write_header_only_checkpoint(&path, &wide);
+
+        let parsed = parse_checkpoint_facts(&path).unwrap();
+        assert_eq!(
+            parsed.adaln_dim,
+            Some(36_864),
+            "the parser must read the checkpoint's own AdaLN width"
+        );
+
+        let six = ltx2_activation_bytes(incident_shape(), Some(24_576));
+        let nine = ltx2_activation_bytes(incident_shape(), parsed.adaln_dim);
+        assert_eq!(
+            nine - six,
+            327_155_712,
+            "the three extra components must be reserved, not assumed away"
+        );
     }
 
     /// The two-stage Distilled pipeline renders stage 1 at 512² (3,328 tokens)
@@ -642,7 +727,7 @@ mod tests {
         let facts = ltx2_19b_fp8_facts();
         let estimate = ltx2_peak_estimate(
             &facts,
-            ltx2_activation_bytes(incident_shape()),
+            ltx2_activation_bytes(incident_shape(), facts.adaln_dim),
             RTX_4090_AVAILABLE,
         );
 
@@ -668,7 +753,7 @@ mod tests {
         let facts = ltx2_19b_fp8_facts();
         let estimate = ltx2_peak_estimate(
             &facts,
-            ltx2_activation_bytes(incident_shape()),
+            ltx2_activation_bytes(incident_shape(), facts.adaln_dim),
             RTX_4090_AVAILABLE,
         );
 
@@ -729,7 +814,7 @@ mod tests {
         let facts = ltx2_19b_fp8_facts();
         let estimate = ltx2_peak_estimate(
             &facts,
-            ltx2_activation_bytes(incident_shape()),
+            ltx2_activation_bytes(incident_shape(), facts.adaln_dim),
             80_000_000_000,
         );
         assert!(estimate.viable);

--- a/crates/mold-server/src/memory_preflight.rs
+++ b/crates/mold-server/src/memory_preflight.rs
@@ -1161,7 +1161,7 @@ pub(crate) fn estimate_generation_memory_for_request(
         });
     let (peak, activation) = match &ltx2 {
         Some((facts, shape, available)) => {
-            let activation = crate::ltx2_admission::ltx2_activation_bytes(*shape);
+            let activation = crate::ltx2_admission::ltx2_activation_bytes(*shape, facts.adaln_dim);
             let estimate = crate::ltx2_admission::ltx2_peak_estimate(facts, activation, *available);
             (estimate.peak_bytes, activation)
         }
@@ -1227,8 +1227,13 @@ fn request_sensitive_activation_memory(
     // under-counted the 1024x1024 x 97 frame stage-2 shape by several GB
     // (#641). Price it from the same token model admission uses.
     let base = if hint.is_some_and(|h| h.family.streaming_transformer()) {
+        // Cold-cache fallback: no checkpoint header has been read here, so the
+        // AdaLN width is unknown and falls back to the six-component default.
+        // The authoritative path in `estimate_generation_memory_for_request`
+        // passes the checkpoint's real width.
         crate::ltx2_admission::ltx2_activation_bytes(
             crate::ltx2_admission::Ltx2ShapeHint::from_request(req),
+            None,
         )
     } else {
         activation_memory_for_estimate(hint, qwen_quantized)
@@ -1696,7 +1701,7 @@ mod fail_closed_tests {
         let source_frame_bytes = 1024u64 * 1024 * 4;
         assert_eq!(
             request_sensitive_activation_memory(&request, Some(hint), false),
-            crate::ltx2_admission::ltx2_activation_budget_bytes(1024, 1024, 97, true)
+            crate::ltx2_admission::ltx2_activation_budget_bytes(1024, 1024, 97, true, None)
                 + source_frame_bytes,
         );
         // 97 frames produce 13 live latent frames; a 49-frame clip produces 7.


### PR DESCRIPTION
Follow-up parity check on #653/#641: do those fixes hold for the LTX-2.3 **22B**
checkpoint, not just the 19B they were measured against?

Mostly yes — one real gap, fixed here.

## Already model-agnostic (verified, no change needed)

The kernel work is shape-derived, and both checkpoints share the same transformer
geometry — inner dim 4096, FF hidden 16384, attention 4096×4096, 48 blocks — so fused
GELU, FF token chunking, per-tile attention staging, RoPE scoping and lazy
`value_passthrough` apply identically.

The accounting is read from each checkpoint's own safetensors header, so it adapts.
Measured from the two shipped files:

| | 19B | 22B |
|---|---|---|
| block bytes | 20.86 GB | 20.51 GB |
| **non-block `model.*`** | 3.55 GB | **7.20 GB** |
| VAE / other | 2.66 GB | 1.82 GB |

The 22B carries roughly double the non-block weights — the exact category #641 had
priced at zero — so that fix matters *more* there, not less.

## The gap

`LTX2_ADALN_DIM` was a constant at 24,576. Measured:

```
19B  adaln_single.linear.weight  [24576, 4096]   6 components
22B  adaln_single.linear.weight  [36864, 4096]   9 components
```

A conditioned (image-to-video) 22B render under-reserved `12,288 × 2` bytes per token
— **327 MB** at the 13,312-token stage-2 shape — in the exact budget this estimator
exists to keep honest. The engine renders correctly either way, since `ada_component`
derives its width from the tensor; it was the *estimate* that was short.

Both header parsers (engine `Ltx2TransformerWeightSizes`, admission
`Ltx2CheckpointFacts`) now read the video branch's own `adaln_single.linear` width and
thread it into `ltx2_activation_budget_bytes`. The constant becomes
`LTX2_ADALN_DEFAULT_DIM`, used only when no header has been read. The match excludes
`audio_adaln_single` and the `av_ca_*` gates, which share the suffix.

## Verified on an RTX 4090

`ltx-2.3-22b-distilled:fp8` image-to-video, 1024×1024 × 97 frames → complete MP4 in
296.5 s, `ffprobe`-clean at 97 frames / 24 fps.

```
transformer_load[1024x1024x97]  peak=12.5 GB predicted=24.0 GB  resident_blocks=25 fixed_resident=7.2 GB
distilled.stage2.denoise        peak=16.1 GB predicted=24.0 GB  free 12.2 GB->11.9 GB
```

Note the plan differs from the 19B's (25 resident blocks vs 32, 7.2 GB fixed vs 3.6 GB)
— the residency planner is responding to the measured checkpoint, which is the point.

## Tests

- `ltx2_activation_budget_follows_the_checkpoints_adaln_width` — nine components cost
  327,155,712 B more than six at the stage-2 shape; an unconditioned render is
  unaffected by the width; `None` falls back to the 19B default.
- `checkpoint_facts_read_the_adaln_width_and_price_it` — round-trips a synthetic 22B
  header and asserts the parsed width is priced.
- The test checkpoint writer now emits a real `[out, in]`-shaped AdaLN tensor and
  subtracts its bytes from the stub, so parsing a fixture reproduces exactly the
  `fixed_resident_bytes` it declares.

Pre-existing and unrelated: three `execution_plan::tests` mtime-granularity flakes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
