### PR TITLE
fix(mobile): open pairing QR codes in Mold

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -255,7 +255,10 @@ one-time-token `POST /api/pairing/claim`. The claim route is intentionally the
 only unauthenticated credential handoff: tokens are 256-bit random values,
 stored server-side only as an HMAC, capped, single-use, and expire after two
 minutes. Both responses are `no-store`; the QR must never contain the durable
-API key.
+API key. Pairing QR codes use the registered `mold://pair` scheme so the iOS
+Camera app offers to open them directly in Mold; cold-launch and already-open
+links share the same claim, instance-verification, and Keychain path as Mold's
+in-app scanner.
 
 Authenticated gallery media uses `POST /api/gallery/media-token` to exchange
 the normal `X-Api-Key` request for a short-lived, read-only URL scoped to one

--- a/apps/mobile/src-tauri/Cargo.lock
+++ b/apps/mobile/src-tauri/Cargo.lock
@@ -332,6 +332,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,6 +433,12 @@ name = "crossbeam-utils"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -613,6 +639,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -1177,6 +1212,12 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
@@ -1732,9 +1773,11 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "serde",
+ "serde_json",
  "tauri",
  "tauri-build",
  "tauri-plugin-barcode-scanner",
+ "tauri-plugin-deep-link",
 ]
 
 [[package]]
@@ -2031,6 +2074,16 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "pango"
@@ -2410,6 +2463,16 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
 ]
 
 [[package]]
@@ -3121,6 +3184,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-deep-link"
+version = "2.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ee75bc5627f77bfdf40c913255ebc258117b10ebe2b2239a1a1cf40b0b58aa"
+dependencies = [
+ "dunce",
+ "plist",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.19",
+ "tracing",
+ "url",
+ "windows-registry",
+ "windows-result 0.3.4",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3297,6 +3381,15 @@ checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -3523,7 +3616,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4054,6 +4159,17 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]

--- a/apps/mobile/src-tauri/Cargo.toml
+++ b/apps/mobile/src-tauri/Cargo.toml
@@ -22,7 +22,9 @@ tauri-build = { version = "2", features = [] }
 base64 = "0.22"
 libc = "0.2"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 tauri = { version = "2", features = [] }
+tauri-plugin-deep-link = "2.4.9"
 
 [target.'cfg(target_vendor = "apple")'.dependencies]
 security-framework = "3"

--- a/apps/mobile/src-tauri/capabilities/default.json
+++ b/apps/mobile/src-tauri/capabilities/default.json
@@ -6,6 +6,7 @@
   "platforms": ["iOS"],
   "permissions": [
     "core:default",
+    "deep-link:default",
     "barcode-scanner:allow-scan",
     "barcode-scanner:allow-cancel"
   ]

--- a/apps/mobile/src-tauri/gen/apple/mold-mobile_iOS/Info.plist
+++ b/apps/mobile/src-tauri/gen/apple/mold-mobile_iOS/Info.plist
@@ -56,5 +56,16 @@
 	</array>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>mold</string>
+			</array>
+			<key>CFBundleURLName</key>
+			<string>mold</string>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/apps/mobile/src-tauri/src/lib.rs
+++ b/apps/mobile/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@ fn app_context() -> tauri::Context<tauri::Wry> {
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
+        .plugin(tauri_plugin_deep_link::init())
         .setup(|_app| {
             #[cfg(target_os = "ios")]
             _app.handle().plugin(tauri_plugin_barcode_scanner::init())?;
@@ -82,5 +83,15 @@ mod tests {
         let plist = include_str!("../Info.ios.plist");
         assert!(plist.contains("<key>NSCameraUsageDescription</key>"));
         assert!(plist.contains("Scan a one-time Mold host pairing code."));
+    }
+
+    #[test]
+    fn ios_registers_mobile_pairing_deep_links() {
+        let config = include_str!("../tauri.conf.json");
+        let generated_plist = include_str!("../gen/apple/mold-mobile_iOS/Info.plist");
+        assert!(config.contains("\"deep-link\""));
+        assert!(config.contains("\"scheme\": [\"mold\"]"));
+        assert!(generated_plist.contains("<key>CFBundleURLTypes</key>"));
+        assert!(generated_plist.contains("<string>mold</string>"));
     }
 }

--- a/apps/mobile/src-tauri/tauri.conf.json
+++ b/apps/mobile/src-tauri/tauri.conf.json
@@ -21,12 +21,20 @@
       "csp": null
     }
   },
+  "plugins": {
+    "deep-link": {
+      "mobile": [
+        {
+          "scheme": ["mold"],
+          "appLink": false
+        }
+      ]
+    }
+  },
   "bundle": {
     "active": true,
     "targets": "all",
-    "icon": [
-      "../../../desktop/src-tauri/icons/icon.png"
-    ],
+    "icon": ["../../../desktop/src-tauri/icons/icon.png"],
     "publisher": "James Brink and Jeffrey Dilley",
     "copyright": "Copyright \u00a9 2026 James Brink and Jeffrey Dilley. MIT License.",
     "category": "GraphicsAndDesign",

--- a/bun.lock
+++ b/bun.lock
@@ -38,6 +38,7 @@
         "@mold/ui": "workspace:*",
         "@tauri-apps/api": "2.11.1",
         "@tauri-apps/plugin-barcode-scanner": "2.4.5",
+        "@tauri-apps/plugin-deep-link": "2.4.9",
         "@tauri-apps/plugin-dialog": "2.7.1",
         "@tauri-apps/plugin-notification": "2.3.3",
         "@tauri-apps/plugin-opener": "2.5.4",
@@ -315,6 +316,8 @@
     "@tauri-apps/cli-win32-x64-msvc": ["@tauri-apps/cli-win32-x64-msvc@2.11.4", "", { "os": "win32", "cpu": "x64" }, "sha512-+vDiqBIU5dMISg/wNvX3sF+ZHfgJGJ5T0AcO+EHNXV9GGAG+P5fzodlDXD3QdKCRgZxMoCm5PPvj3BqLNjBthw=="],
 
     "@tauri-apps/plugin-barcode-scanner": ["@tauri-apps/plugin-barcode-scanner@2.4.5", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" } }, "sha512-sIPRYEfxww8/y8skZ2LcAp/h5bwvlHkQiq+3w6QEl+2BHs13xnpn7hP+pv4fkBs8DyDfpUbOBIYS5YBwP7x1QQ=="],
+
+    "@tauri-apps/plugin-deep-link": ["@tauri-apps/plugin-deep-link@2.4.9", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" } }, "sha512-u0SKOUHnJ1wqeqXsDFq2+kASCBj9xxbG0g9XZWPy9SOmU4wXtp6b/wiYpm6oH6/5fBTQsLqnLhIvqLBRpgHJlA=="],
 
     "@tauri-apps/plugin-dialog": ["@tauri-apps/plugin-dialog@2.7.1", "", { "dependencies": { "@tauri-apps/api": "^2.11.0" } }, "sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ=="],
 

--- a/bun.nix
+++ b/bun.nix
@@ -511,6 +511,10 @@
     url = "https://registry.npmjs.org/@tauri-apps/plugin-barcode-scanner/-/plugin-barcode-scanner-2.4.5.tgz";
     hash = "sha512-sIPRYEfxww8/y8skZ2LcAp/h5bwvlHkQiq+3w6QEl+2BHs13xnpn7hP+pv4fkBs8DyDfpUbOBIYS5YBwP7x1QQ==";
   };
+  "@tauri-apps/plugin-deep-link@2.4.9" = fetchurl {
+    url = "https://registry.npmjs.org/@tauri-apps/plugin-deep-link/-/plugin-deep-link-2.4.9.tgz";
+    hash = "sha512-u0SKOUHnJ1wqeqXsDFq2+kASCBj9xxbG0g9XZWPy9SOmU4wXtp6b/wiYpm6oH6/5fBTQsLqnLhIvqLBRpgHJlA==";
+  };
   "@tauri-apps/plugin-dialog@2.7.1" = fetchurl {
     url = "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.7.1.tgz";
     hash = "sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==";

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -21,6 +21,7 @@
     "@mold/ui": "workspace:*",
     "@tauri-apps/api": "2.11.1",
     "@tauri-apps/plugin-dialog": "2.7.1",
+    "@tauri-apps/plugin-deep-link": "2.4.9",
     "@tauri-apps/plugin-notification": "2.3.3",
     "@tauri-apps/plugin-barcode-scanner": "2.4.5",
     "@tauri-apps/plugin-opener": "2.5.4"

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -19,6 +19,9 @@ const {
   previewGenerationPlacement,
   scanPairingQr,
   claimPairingSession,
+  getCurrentDeepLinks,
+  onOpenDeepLinks,
+  unlistenDeepLinks,
 } = vi.hoisted(() => ({
   invoke: vi.fn(),
   apiFetchTo: vi.fn(),
@@ -33,12 +36,19 @@ const {
   previewGenerationPlacement: vi.fn(),
   scanPairingQr: vi.fn(),
   claimPairingSession: vi.fn(),
+  getCurrentDeepLinks: vi.fn(),
+  onOpenDeepLinks: vi.fn(),
+  unlistenDeepLinks: vi.fn(),
 }));
 
 vi.mock("@tauri-apps/api/core", () => ({ invoke }));
 vi.mock("@tauri-apps/plugin-barcode-scanner", () => ({
   Format: { QRCode: "QRCode" },
   scan: scanPairingQr,
+}));
+vi.mock("@tauri-apps/plugin-deep-link", () => ({
+  getCurrent: getCurrentDeepLinks,
+  onOpenUrl: onOpenDeepLinks,
 }));
 vi.mock("@studio/api/pairing", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@studio/api/pairing")>()),
@@ -265,6 +275,9 @@ beforeEach(() => {
   previewGenerationPlacement.mockReset().mockResolvedValue(plannedPlacement());
   scanPairingQr.mockReset();
   claimPairingSession.mockReset();
+  getCurrentDeepLinks.mockReset().mockResolvedValue(null);
+  unlistenDeepLinks.mockReset();
+  onOpenDeepLinks.mockReset().mockResolvedValue(unlistenDeepLinks);
   objectUrlSequence = 0;
   URL.createObjectURL = vi.fn(() => `blob:thumbnail-${++objectUrlSequence}`);
   URL.revokeObjectURL = vi.fn();
@@ -276,6 +289,7 @@ afterEach(() => {
   document.body.innerHTML = "";
   delete document.documentElement.dataset.theme;
   delete document.documentElement.dataset.themeFamily;
+  delete (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
 });
 
 describe("MobileApp sequence generation", () => {
@@ -4407,6 +4421,15 @@ describe("MobileApp host and catalog coordination", () => {
     });
   }
 
+  function pairingUrl(overrides: Record<string, unknown> = {}): string {
+    const payload = JSON.parse(pairingPayload(overrides)) as Record<string, string>;
+    const url = new URL("mold://pair");
+    for (const [key, value] of Object.entries(payload)) {
+      if (key !== "type" && value !== null) url.searchParams.set(key, String(value));
+    }
+    return url.toString();
+  }
+
   async function scanFromMachines(): Promise<void> {
     wrapper = mountMobileApp();
     await flushPromises();
@@ -4640,6 +4663,54 @@ describe("MobileApp host and catalog coordination", () => {
       .findAll("option")
       .map((option) => option.text());
     expect(options).toContain(pulledModel.name);
+  });
+
+  it("claims a cold-launch iOS Camera pairing link through the existing Keychain path", async () => {
+    Object.defineProperty(window, "__TAURI_INTERNALS__", {
+      value: {},
+      configurable: true,
+    });
+    getCurrentDeepLinks.mockResolvedValue([pairingUrl()]);
+    claimPairingSession.mockResolvedValue({
+      api_key: "paired-key",
+      instance_id: "pair-id",
+      hostname: "pair-host",
+    });
+    apiJsonTo.mockImplementation((requestTarget: unknown, path: string) => {
+      const baseUrl = (requestTarget as { baseUrl: string }).baseUrl;
+      if (path === "/api/status" && baseUrl === "http://pair.local:7680") {
+        return Promise.resolve({ ...status, instance_id: "pair-id", hostname: "pair-host" });
+      }
+      if (path === "/api/status") return Promise.resolve(status);
+      if (path === "/api/models") return Promise.resolve([model]);
+      if (path === "/api/gallery") return Promise.resolve([print]);
+      return Promise.reject(new Error(`Unexpected API path: ${path}`));
+    });
+
+    wrapper = mountMobileApp();
+    await vi.waitFor(() =>
+      expect(invoke).toHaveBeenCalledWith("keychain_set_api_key", {
+        hostId: "pair-local-7680",
+        apiKey: "paired-key",
+      }),
+    );
+
+    expect(onOpenDeepLinks).toHaveBeenCalledOnce();
+    expect(claimPairingSession).toHaveBeenCalledWith("http://pair.local:7680", "one-time-token");
+  });
+
+  it("stops listening for iOS pairing links when the mobile shell unmounts", async () => {
+    Object.defineProperty(window, "__TAURI_INTERNALS__", {
+      value: {},
+      configurable: true,
+    });
+    wrapper = mountMobileApp();
+    await vi.waitFor(() => expect(onOpenDeepLinks).toHaveBeenCalledOnce());
+
+    wrapper.unmount();
+    wrapper = null;
+
+    expect(unlistenDeepLinks).toHaveBeenCalledOnce();
   });
 });
 

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -11,6 +11,7 @@ import {
 } from "vue";
 import { invoke } from "@tauri-apps/api/core";
 import { Format, scan } from "@tauri-apps/plugin-barcode-scanner";
+import { getCurrent, onOpenUrl } from "@tauri-apps/plugin-deep-link";
 import EstimateBadge from "../components/generate/EstimateBadge.vue";
 import { ApiError, apiFetchTo, apiJsonTo, type ApiTarget } from "../lib/api/client";
 import { describeTransportError } from "../lib/api/errors";
@@ -285,6 +286,7 @@ const hostInput = reactive({ name: "", address: "", apiKey: "" });
 const discovered = ref<DiscoveredHost[]>([]);
 const discovering = ref(false);
 const pairing = ref(false);
+let stopPairingDeepLinks: (() => void) | null = null;
 const hostError = ref("");
 const models = ref<ModelEntry[]>([]);
 const modelsHostId = ref("");
@@ -1161,13 +1163,12 @@ async function discoverHosts(): Promise<void> {
   }
 }
 
-async function scanPairingCode(): Promise<void> {
+async function pairFromCode(code: () => Promise<string>): Promise<void> {
   if (pairing.value) return;
   pairing.value = true;
   hostError.value = "";
   try {
-    const result = await scan({ cameraDirection: "back", formats: [Format.QRCode] });
-    const payload = parseMobilePairingPayload(result.content);
+    const payload = parseMobilePairingPayload(await code());
     if (payload.expires_at !== null && payload.expires_at <= Math.floor(Date.now() / 1000)) {
       throw new Error("That pairing code expired. Create a new one in the host's Settings.");
     }
@@ -1185,6 +1186,24 @@ async function scanPairingCode(): Promise<void> {
   } finally {
     pairing.value = false;
   }
+}
+
+function scanPairingCode(): Promise<void> {
+  return pairFromCode(async () => {
+    const result = await scan({ cameraDirection: "back", formats: [Format.QRCode] });
+    return result.content;
+  });
+}
+
+async function openPairingUrls(urls: string[]): Promise<void> {
+  const pairingUrl = urls.find((url) => url.startsWith("mold://pair?"));
+  if (pairingUrl) await pairFromCode(() => Promise.resolve(pairingUrl));
+}
+
+async function listenForPairingDeepLinks(): Promise<void> {
+  stopPairingDeepLinks = await onOpenUrl((urls) => void openPairingUrls(urls));
+  const current = await getCurrent();
+  if (current) await openPairingUrls(current);
 }
 
 async function selectHost(id: string): Promise<void> {
@@ -3311,6 +3330,14 @@ onMounted(async () => {
   }
   await hydrateApiKeys();
   if (unmounted) return;
+  if ("__TAURI_INTERNALS__" in window) {
+    try {
+      await listenForPairingDeepLinks();
+    } catch (error) {
+      hostError.value = describeTransportError(error, "Mobile pairing");
+    }
+  }
+  if (unmounted) return;
   recoverMobileSequence();
   // Start the cadence before awaiting individual tailnet hosts. One slow host
   // must not prevent every other saved host from being probed on schedule.
@@ -3339,6 +3366,8 @@ onBeforeUnmount(() => {
   clearExpansionRecovery();
   document.removeEventListener("visibilitychange", handleForegroundResume);
   window.removeEventListener("pageshow", handleForegroundResume);
+  stopPairingDeepLinks?.();
+  stopPairingDeepLinks = null;
   if (hostProbeTimer) clearInterval(hostProbeTimer);
   hostProbeTimer = null;
   stopSequenceTransport();

--- a/studio/api/pairing.test.ts
+++ b/studio/api/pairing.test.ts
@@ -1,23 +1,39 @@
 import { describe, expect, it } from "vitest";
-import { parseMobilePairingPayload } from "./pairing";
+import { mobilePairingUrl, parseMobilePairingPayload } from "./pairing";
+
+const payload = {
+  type: "mold.mobile-pairing" as const,
+  version: 1 as const,
+  base_url: "http://studio.local:7680",
+  token: "one-time",
+  expires_at: 1_900_000_000,
+  instance_id: "server-id",
+  name: "Studio Mac",
+};
 
 describe("parseMobilePairingPayload", () => {
   it("accepts the versioned one-time pairing envelope", () => {
-    expect(
-      parseMobilePairingPayload(
-        JSON.stringify({
-          type: "mold.mobile-pairing",
-          version: 1,
-          base_url: "http://studio.local:7680",
-          token: "one-time",
-          expires_at: 1_900_000_000,
-          instance_id: "server-id",
-          name: "Studio Mac",
-        }),
-      ),
-    ).toMatchObject({
+    expect(parseMobilePairingPayload(JSON.stringify(payload))).toMatchObject({
       base_url: "http://studio.local:7680",
       token: "one-time",
+    });
+  });
+
+  it("round-trips an app-opening mobile pairing URL", () => {
+    const url = mobilePairingUrl(payload);
+
+    expect(url).toMatch(/^mold:\/\/pair\?/);
+    expect(url).not.toContain("api_key");
+    expect(parseMobilePairingPayload(url)).toEqual(payload);
+  });
+
+  it("preserves credential-free pairing in an app-opening URL", () => {
+    const url = mobilePairingUrl({ ...payload, token: null, expires_at: null });
+
+    expect(parseMobilePairingPayload(url)).toEqual({
+      ...payload,
+      token: null,
+      expires_at: null,
     });
   });
 

--- a/studio/api/pairing.ts
+++ b/studio/api/pairing.ts
@@ -25,6 +25,18 @@ export interface MobilePairingPayload {
   name: string;
 }
 
+export function mobilePairingUrl(payload: MobilePairingPayload): string {
+  const url = new URL("mold://pair");
+  url.searchParams.set("version", String(payload.version));
+  url.searchParams.set("base_url", payload.base_url);
+  if (payload.token !== null) url.searchParams.set("token", payload.token);
+  if (payload.expires_at !== null)
+    url.searchParams.set("expires_at", String(payload.expires_at));
+  url.searchParams.set("instance_id", payload.instance_id);
+  url.searchParams.set("name", payload.name);
+  return url.toString();
+}
+
 export function createPairingSession(
   target: ApiTarget,
 ): Promise<PairingSession> {
@@ -53,7 +65,30 @@ export function parseMobilePairingPayload(raw: string): MobilePairingPayload {
   try {
     value = JSON.parse(raw);
   } catch {
-    throw new Error("That QR code is not a Mold pairing code.");
+    try {
+      const url = new URL(raw);
+      if (
+        url.protocol !== "mold:" ||
+        url.hostname !== "pair" ||
+        url.username ||
+        url.password ||
+        url.hash
+      ) {
+        throw new Error();
+      }
+      const expiresAt = url.searchParams.get("expires_at");
+      value = {
+        type: "mold.mobile-pairing",
+        version: Number(url.searchParams.get("version")),
+        base_url: url.searchParams.get("base_url"),
+        token: url.searchParams.get("token"),
+        expires_at: expiresAt === null ? null : Number(expiresAt),
+        instance_id: url.searchParams.get("instance_id"),
+        name: url.searchParams.get("name"),
+      };
+    } catch {
+      throw new Error("That QR code is not a Mold pairing code.");
+    }
   }
   if (!value || typeof value !== "object")
     throw new Error("That QR code is not a Mold pairing code.");
@@ -64,7 +99,9 @@ export function parseMobilePairingPayload(raw: string): MobilePairingPayload {
     typeof payload.base_url !== "string" ||
     !/^https?:\/\//i.test(payload.base_url) ||
     (payload.token !== null && typeof payload.token !== "string") ||
-    (payload.expires_at !== null && typeof payload.expires_at !== "number") ||
+    (payload.expires_at !== null &&
+      (typeof payload.expires_at !== "number" ||
+        !Number.isFinite(payload.expires_at))) ||
     typeof payload.instance_id !== "string" ||
     typeof payload.name !== "string"
   ) {

--- a/studio/components/MobilePairingCard.test.ts
+++ b/studio/components/MobilePairingCard.test.ts
@@ -55,13 +55,21 @@ describe("MobilePairingCard", () => {
     const headers = request[1].headers as Headers;
     expect(headers.get("x-api-key")).toBe("durable-secret");
     expect(qrPayloads[0]).not.toContain("durable-secret");
-    expect(JSON.parse(qrPayloads[0]!)).toMatchObject({
+    const qrUrl = new URL(qrPayloads[0]!);
+    expect(qrUrl.protocol).toBe("mold:");
+    expect(qrUrl.host).toBe("pair");
+    expect(Object.fromEntries(qrUrl.searchParams)).toMatchObject({
       base_url: "http://studio-mac.local:7680",
       token: "one-time-token",
       instance_id: "server-id",
     });
     expect(wrapper.get("img").attributes("src")).toBe(
       "data:image/png;base64,pairing",
+    );
+    expect(wrapper.text()).toContain("Mobile pairing");
+    expect(wrapper.text()).not.toContain("iPhone");
+    expect(wrapper.get("img").attributes("alt")).toBe(
+      "Mold mobile pairing QR code",
     );
   });
 });

--- a/studio/components/MobilePairingCard.vue
+++ b/studio/components/MobilePairingCard.vue
@@ -4,6 +4,7 @@ import QRCode from "qrcode";
 import type { ApiTarget } from "../api/client";
 import {
   createPairingSession,
+  mobilePairingUrl,
   type MobilePairingPayload,
   type PairingSession,
 } from "../api/pairing";
@@ -39,7 +40,7 @@ const expired = computed(() => secondsLeft.value === 0);
 const buttonLabel = computed(() => {
   if (busy.value) return "Creating secure code…";
   if (session.value) return "New pairing code";
-  return "Pair an iPhone";
+  return "Create pairing code";
 });
 
 function reachableBaseUrl(input: string, hostname: string | null): string {
@@ -49,7 +50,7 @@ function reachableBaseUrl(input: string, hostname: string | null): string {
     url = new URL(candidate);
   } catch {
     throw new Error(
-      "Enter the http:// or https:// address your iPhone uses for this host.",
+      "Enter the http:// or https:// address your mobile device uses for this host.",
     );
   }
   if (!["http:", "https:"].includes(url.protocol))
@@ -92,7 +93,7 @@ async function startPairing(): Promise<void> {
       instance_id: next.instance_id,
       name: props.hostLabel || next.hostname || new URL(baseUrl).hostname,
     };
-    qrDataUrl.value = await QRCode.toDataURL(JSON.stringify(payload), {
+    qrDataUrl.value = await QRCode.toDataURL(mobilePairingUrl(payload), {
       width: 320,
       margin: 2,
       errorCorrectionLevel: "M",
@@ -124,7 +125,7 @@ onBeforeUnmount(() => {
       <div class="pairing-heading">
         <span class="pairing-icon" aria-hidden="true">▦</span>
         <div>
-          <h3>Pair Mold for iPhone</h3>
+          <h3>Mobile pairing</h3>
           <p>
             Scan once to add this host. The code expires quickly and never
             contains your API key.
@@ -132,7 +133,7 @@ onBeforeUnmount(() => {
         </div>
       </div>
       <label class="pairing-address">
-        <span>Address your iPhone can reach</span>
+        <span>Address your mobile device can reach</span>
         <input
           v-model="address"
           data-selectable
@@ -160,7 +161,7 @@ onBeforeUnmount(() => {
       class="pairing-code"
       :class="{ 'pairing-code--expired': expired }"
     >
-      <img :src="qrDataUrl" alt="Mold iPhone pairing QR code" />
+      <img :src="qrDataUrl" alt="Mold mobile pairing QR code" />
       <div class="pairing-status">
         <span v-if="session?.auth_required === false">No key required</span>
         <span v-else-if="expired">Expired</span>


### PR DESCRIPTION
## Summary

- rename pairing UI copy from iPhone-specific wording to Mobile pairing
- encode the existing short-lived one-use ticket as a registered mold://pair URL
- handle cold-launch and already-running iOS deep links through the existing instance verification and Keychain enrollment path
- register the scheme in Tauri/iOS configuration and add regression coverage

## Root cause

The QR encoded plain JSON, so the iOS Camera app saw data rather than a URL owned by Mold. The mobile bundle also had no registered URL scheme or deep-link listener.

## Validation

- bun run test:studio — 339 tests passed
- cd desktop && bun run test — 2,805 tests passed
- bun run check:architecture
- bash scripts/tests/ios-release-assets.sh
- nix develop -c ios-check
- focused mobile Rust registration test
- signed iOS simulator bundle build via ./scripts/ios.sh simulator
- installed bundle verified with CFBundleURLSchemes = mold
- iOS simulator displayed Open in “Mold”? for a mold://pair URL and launched Mold