### PR TITLE
feat(studio): improve sequence source and timeline controls

### DIFF
--- a/crates/mold-core/src/chain_job.rs
+++ b/crates/mold-core/src/chain_job.rs
@@ -680,7 +680,7 @@ pub struct RetakeRequest {
 /// canonical order) replaces the job's stages, plus optional chain-level
 /// overlays (omitted = keep current). NOT amendable — the client must create
 /// a fresh job instead: model, width, height, output_format, placement,
-/// strength, and batch provenance.
+/// and batch provenance.
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct AmendRequest {
     pub stages: Vec<crate::chain::ChainStage>,
@@ -695,6 +695,8 @@ pub struct AmendRequest {
     pub steps: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub guidance: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub strength: Option<f64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub enable_audio: Option<bool>,
 }
@@ -1027,6 +1029,7 @@ mod tests {
         assert_eq!(req.motion_tail_frames, None);
         assert_eq!(req.fps, None);
         assert_eq!(req.guidance, None);
+        assert_eq!(req.strength, None);
         assert_eq!(req.enable_audio, None);
         assert_eq!(req.stages.len(), 1);
         assert_eq!(req.stages[0].prompt, "edited clip");

--- a/crates/mold-server/src/chain_job_runner.rs
+++ b/crates/mold-server/src/chain_job_runner.rs
@@ -2488,6 +2488,9 @@ pub(crate) fn amend_candidate_request(
     if let Some(guidance) = req.guidance {
         candidate.guidance = guidance;
     }
+    if let Some(strength) = req.strength {
+        candidate.strength = strength;
+    }
     if let Some(enable_audio) = req.enable_audio {
         candidate.enable_audio = Some(enable_audio);
     }
@@ -2497,7 +2500,7 @@ pub(crate) fn amend_candidate_request(
 /// Longest preserved prefix of per-stage render identity between the old
 /// effective request and the amended candidate (both normalised).
 ///
-/// Chain-level invalidation first: a changed seed/steps/guidance/fps/
+/// Chain-level invalidation first: a changed seed/steps/guidance/strength/fps/
 /// motion_tail_frames, or enable_audio flipping OFF→ON, dirties everything
 /// (ON→OFF preserves — finalize just ignores sidecars). Otherwise the prefix
 /// compares `(prompt, frames, negative_prompt, source_image bytes, LoRA stack,
@@ -2519,6 +2522,17 @@ pub(crate) fn preserved_stage_prefix(old: &ChainRequest, new: &ChainRequest) -> 
     if old.seed != new.seed
         || old.steps != new.steps
         || old.guidance != new.guidance
+        || (old.strength != new.strength
+            && (old
+                .stages
+                .first()
+                .and_then(|stage| stage.source_image.as_ref())
+                .is_some()
+                || new
+                    .stages
+                    .first()
+                    .and_then(|stage| stage.source_image.as_ref())
+                    .is_some()))
         || old.fps != new.fps
         || old.motion_tail_frames != new.motion_tail_frames
         || (!old_audio && new_audio)
@@ -5717,6 +5731,7 @@ mod tests {
             seed: None,
             steps: None,
             guidance: None,
+            strength: None,
             enable_audio: None,
         }
     }
@@ -5798,6 +5813,16 @@ mod tests {
             mutate(&mut new);
             assert_eq!(preserved_stage_prefix(&base, &new), 0, "chain-level edit");
         }
+
+        let mut source_backed = base.clone();
+        source_backed.stages[0].source_image = Some("source".into());
+        let mut changed_strength = source_backed.clone();
+        changed_strength.strength = 0.55;
+        assert_eq!(preserved_stage_prefix(&source_backed, &changed_strength), 0);
+
+        let mut source_less_strength = base.clone();
+        source_less_strength.strength = 0.55;
+        assert_eq!(preserved_stage_prefix(&base, &source_less_strength), 3);
 
         // enable_audio ON→OFF preserves (finalize ignores sidecars)…
         let mut old = base.clone();

--- a/crates/mold-server/src/routes_chain_jobs.rs
+++ b/crates/mold-server/src/routes_chain_jobs.rs
@@ -1527,6 +1527,7 @@ mod tests {
             seed: None,
             steps: None,
             guidance: None,
+            strength: None,
             enable_audio: None,
         }
     }

--- a/desktop/src/components/create/InspectorPanel.vue
+++ b/desktop/src/components/create/InspectorPanel.vue
@@ -696,6 +696,8 @@ function resetSettings() {
         v-if="advancedExpanded && isSequence"
         id="desktop-inline-advanced"
         :chain-limits="chainLimits"
+        :form="form"
+        :upscalers="models.upscalers"
         :camera-controls-enabled="form.family === 'ltx2'"
         :camera-controls="cameraControls"
         :camera-controls-loaded="cameraControlsLoaded"

--- a/desktop/src/components/create/SequenceAdvancedSettings.test.ts
+++ b/desktop/src/components/create/SequenceAdvancedSettings.test.ts
@@ -3,6 +3,7 @@ import { createPinia, setActivePinia } from "pinia";
 import { beforeEach, describe, expect, it } from "vitest";
 import { useSequenceDraftStore } from "@studio/stores/sequenceDraft";
 import SequenceAdvancedSettings from "./SequenceAdvancedSettings.vue";
+import { newGenerateForm } from "../../lib/generateForm";
 
 const cameraControls = [
   {
@@ -26,12 +27,27 @@ describe("SequenceAdvancedSettings camera motion", () => {
   it("edits the active clip and labels a first-use download", async () => {
     const draft = useSequenceDraftStore();
     const wrapper = mount(SequenceAdvancedSettings, {
-      props: { cameraControls, cameraControlsEnabled: true },
+      props: { form: newGenerateForm(), cameraControls, cameraControlsEnabled: true },
     });
+
     const select = wrapper.get("[data-test='sequence-camera-motion']");
     expect(select.text()).toContain("downloads on first use");
     await select.setValue("dolly-in");
     expect(draft.clips[0]?.cameraControl).toBe("dolly-in");
+  });
+
+  it("disables upscale fit when no upscaler is available", () => {
+    const draft = useSequenceDraftStore();
+    draft.openingImage = { filename: "opening.png", base64: "QUJD" };
+    const wrapper = mount(SequenceAdvancedSettings, {
+      props: { form: newGenerateForm() },
+    });
+    const upscale = wrapper
+      .get("[data-test='sequence-source-fit']")
+      .findAll("option")
+      .find((option) => option.attributes("value") === "upscale-then-fit");
+    expect(upscale?.attributes("disabled")).toBeDefined();
+    expect(wrapper.text()).toContain("Install an upscaler");
   });
 
   it("resets camera motion across the sequence", async () => {
@@ -39,7 +55,7 @@ describe("SequenceAdvancedSettings camera motion", () => {
     draft.clips[0]!.cameraControl = "dolly-in";
     draft.clips[1]!.cameraControl = "/models/camera/custom.safetensors";
     const wrapper = mount(SequenceAdvancedSettings, {
-      props: { cameraControls, cameraControlsEnabled: true },
+      props: { form: newGenerateForm(), cameraControls, cameraControlsEnabled: true },
     });
     await wrapper.get("[data-test='sequence-advanced-reset']").trigger("click");
     expect(draft.clips.map((clip) => clip.cameraControl)).toEqual([null, null]);
@@ -47,8 +63,32 @@ describe("SequenceAdvancedSettings camera motion", () => {
 
   it("hides camera motion outside the LTX-2 family", () => {
     const wrapper = mount(SequenceAdvancedSettings, {
-      props: { cameraControls, cameraControlsEnabled: false },
+      props: { form: newGenerateForm(), cameraControls, cameraControlsEnabled: false },
     });
     expect(wrapper.find("[data-test='sequence-section-camera']").exists()).toBe(false);
+  });
+
+  it("edits opening-image strength and fit with the same live form as one shot", async () => {
+    const draft = useSequenceDraftStore();
+    draft.openingImage = { filename: "opening.png", base64: "QUJD" };
+    const form = newGenerateForm();
+    const wrapper = mount(SequenceAdvancedSettings, {
+      props: {
+        form,
+        upscalers: [{ name: "real-esrgan-x4plus:fp16" } as never],
+      },
+    });
+
+    expect(
+      (wrapper.get("[data-test='sequence-source-fit']").element as HTMLSelectElement).value,
+    ).toBe("crop-fill");
+    await wrapper.get("[data-test='sequence-source-strength']").setValue("0.55");
+    expect(form.strength).toBe(0.55);
+    await wrapper.get("[data-test='sequence-source-fit']").setValue("upscale-then-fit");
+    expect(form.sourceFit).toEqual({
+      mode: "upscale-then-fit",
+      upscalerModel: "real-esrgan-x4plus:fp16",
+      fit: { mode: "crop-fill", alignX: "center", alignY: "center" },
+    });
   });
 });

--- a/desktop/src/components/create/SequenceAdvancedSettings.vue
+++ b/desktop/src/components/create/SequenceAdvancedSettings.vue
@@ -6,22 +6,31 @@ import SwitchToggle from "@ui/components/SwitchToggle.vue";
 import { useSequenceDraftStore } from "@studio/stores/sequenceDraft";
 import type { ChainLimits } from "@studio/lib/api/chainTypes";
 import { cameraMotionMode } from "@studio/lib/cameraMotion";
-import type { PickedImage } from "../../lib/generateForm";
-import type { Ltx2CameraControlInfo } from "../../lib/api/types";
+import type { GenerateForm, PickedImage } from "../../lib/generateForm";
+import type { Ltx2CameraControlInfo, ModelEntry } from "../../lib/api/types";
+import {
+  SOURCE_FIT_OPTIONS,
+  coerceSourceFitForMaskless,
+  sourceFitPolicyForMode,
+  type SourceFitMode,
+} from "@studio/lib/sourceFit";
 import ImagePickerModal from "../generate/ImagePickerModal.vue";
 
 const props = withDefaults(
   defineProps<{
+    form: GenerateForm;
     chainLimits?: ChainLimits | null;
     cameraControlsEnabled?: boolean;
     cameraControls?: Ltx2CameraControlInfo[];
     cameraControlsLoaded?: boolean;
+    upscalers?: ModelEntry[];
   }>(),
   {
     chainLimits: null,
     cameraControlsEnabled: false,
     cameraControls: () => [],
     cameraControlsLoaded: false,
+    upscalers: () => [],
   },
 );
 
@@ -40,6 +49,18 @@ const activeCount = computed(
     Number(props.cameraControlsEnabled && Boolean(activeClip.value?.cameraControl)) +
     Number(draft.enableAudio),
 );
+const fitOptions = SOURCE_FIT_OPTIONS.filter((option) => option.value !== "pad-repaint");
+const fitMode = computed(() => coerceSourceFitForMaskless(props.form.sourceFit).mode);
+const upscalerAvailable = computed(() =>
+  Boolean(props.form.upscaleModel || props.upscalers[0]?.name),
+);
+
+function setSourceFit(mode: SourceFitMode) {
+  props.form.sourceFit = sourceFitPolicyForMode(mode, {
+    supportsMask: false,
+    upscalerModel: props.form.upscaleModel || props.upscalers[0]?.name || "",
+  });
+}
 
 const NEGATIVE_QUICK_ADDS = [
   "blurry",
@@ -71,11 +92,14 @@ function onPickImage(images: PickedImage[]) {
   pickerOpen.value = false;
   if (!image) return;
   draft.openingImage = { filename: image.filename, base64: image.base64 };
+  props.form.sourceFit = coerceSourceFitForMaskless(props.form.sourceFit);
 }
 
 function reset() {
   draft.openingImage = null;
   draft.enableAudio = false;
+  props.form.strength = 0.75;
+  props.form.sourceFit = { mode: "crop-fill", alignX: "center", alignY: "center" };
   for (const clip of draft.clips) {
     clip.negativePrompt = "";
     clip.cameraControl = null;
@@ -129,6 +153,44 @@ function reset() {
         >
           Remove opening image
         </button>
+        <div v-if="draft.openingImage" class="ms-source-controls">
+          <label class="ms-range">
+            <span>
+              Source strength
+              <output class="data-mono">{{ form.strength.toFixed(2) }}</output>
+            </span>
+            <input
+              v-model.number="form.strength"
+              type="range"
+              min="0"
+              max="1"
+              step="0.01"
+              data-test="sequence-source-strength"
+            />
+          </label>
+          <label class="ms-field">
+            <span>Fit to video frame</span>
+            <select
+              class="ms-input"
+              :value="fitMode"
+              data-test="sequence-source-fit"
+              @change="setSourceFit(($event.target as HTMLSelectElement).value as SourceFitMode)"
+            >
+              <option
+                v-for="option in fitOptions"
+                :key="option.value"
+                :value="option.value"
+                :disabled="option.value === 'upscale-then-fit' && !upscalerAvailable"
+              >
+                {{ option.label }}
+              </option>
+            </select>
+          </label>
+          <p v-if="!upscalerAvailable" class="ms-hint">
+            Install an upscaler to enable Upscale + crop.
+          </p>
+          <p class="ms-hint">Applied to the opening image before clip 1 renders.</p>
+        </div>
       </AccordionSection>
 
       <AccordionSection
@@ -257,6 +319,29 @@ function reset() {
 .ms-remove {
   padding: 5px 9px;
   font-size: 11px;
+}
+.ms-source-controls {
+  display: grid;
+  gap: 10px;
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--ce);
+}
+.ms-range,
+.ms-field {
+  display: grid;
+  gap: 6px;
+  color: var(--ink-2);
+  font-size: 11px;
+}
+.ms-range > span {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+}
+.ms-range input {
+  width: 100%;
+  accent-color: var(--safelight);
 }
 .ms-dropzone {
   width: 100%;

--- a/desktop/src/components/create/SequenceComposer.test.ts
+++ b/desktop/src/components/create/SequenceComposer.test.ts
@@ -405,3 +405,36 @@ describe("SequenceComposer — clear sequence", () => {
     expect(wrapper.emitted("duplicate")).toBeUndefined();
   });
 });
+
+describe("SequenceComposer — TOML import", () => {
+  it("restores opening-image strength and clears stale maskless fit state", async () => {
+    seedDraft();
+    const liveForm = form();
+    liveForm.strength = 0.75;
+    liveForm.sourceFit = {
+      mode: "upscale-then-fit",
+      upscalerModel: "upscaler",
+      fit: { mode: "crop-fill" },
+    };
+    const wrapper = mountComposer({ form: liveForm });
+    const toml = [
+      'schema = "mold.chain.v1"',
+      "[chain]",
+      'model = "ltx-video"',
+      "strength = 0.4",
+      "[[stage]]",
+      'prompt = "opening"',
+      "frames = 25",
+      'source_image_b64 = "aGk="',
+      "[[stage]]",
+      'prompt = "ending"',
+      "frames = 25",
+    ].join("\n");
+    await wrapper.vm.importTomlText(toml);
+    await flushPromises();
+
+    expect(liveForm.strength).toBe(0.4);
+    expect(liveForm.sourceFit).toEqual({ mode: "crop-fill" });
+    expect(useSequenceDraftStore().openingImage?.base64).toBe("aGk=");
+  });
+});

--- a/desktop/src/components/create/SequenceComposer.vue
+++ b/desktop/src/components/create/SequenceComposer.vue
@@ -338,11 +338,20 @@ async function onTomlFile(event: Event) {
   const file = input.files?.[0];
   input.value = ""; // allow re-picking the same file
   if (!file) return;
+  await importTomlText(await file.text(), file.name);
+}
+
+async function importTomlText(text: string, filename = "sequence.toml") {
   try {
-    const script = parseChainScript(await file.text());
+    const script = parseChainScript(text);
     const loaded = chainScriptToClips(script);
     draft.clips.splice(0, draft.clips.length, ...loaded.clips);
     draft.openingImage = loaded.openingImage;
+    if (loaded.openingImage) {
+      // Imported opening-image bytes are already the script's prepared source;
+      // never inherit a stale client-only upscale policy from the prior draft.
+      props.form.sourceFit = { mode: "crop-fill" };
+    }
     draft.activeClipId = draft.clips[0]?.id ?? null;
     draft.enableAudio = loaded.enableAudio;
     // Shared params flow to the LIVE generate form — the one source of truth.
@@ -353,6 +362,7 @@ async function onTomlFile(event: Event) {
     if (shared.fps != null) props.form.fps = shared.fps;
     if (shared.steps != null) props.form.steps = shared.steps;
     if (shared.guidance != null) props.form.guidance = shared.guidance;
+    if (shared.strength != null) props.form.strength = shared.strength;
     if (shared.seed != null) props.form.seed = shared.seed;
     if (
       shared.model &&
@@ -361,11 +371,13 @@ async function onTomlFile(event: Event) {
     ) {
       toasts.push(`Pull ${shared.model} first`);
     }
-    toasts.push(`Loaded ${file.name}`);
+    toasts.push(`Loaded ${filename}`);
   } catch (err) {
     toasts.push(err instanceof Error ? err.message : String(err), "error");
   }
 }
+
+defineExpose({ importTomlText });
 
 function exportToml() {
   const blob = new Blob([serializeChainScript(currentScript())], { type: "application/toml" });

--- a/desktop/src/lib/sequenceParams.test.ts
+++ b/desktop/src/lib/sequenceParams.test.ts
@@ -25,6 +25,8 @@ describe("sequenceParams", () => {
       steps: 8,
       guidance: 3,
       strength: 0.9,
+      sourceFitPolicy: { mode: "pad-repaint" },
+      upscalerModel: "",
       seed: "42",
     });
 

--- a/desktop/src/lib/sequenceParams.ts
+++ b/desktop/src/lib/sequenceParams.ts
@@ -21,6 +21,8 @@ export function sequenceParams(
     steps: form.steps,
     guidance: form.guidance,
     strength: form.strength,
+    sourceFitPolicy: form.sourceFit,
+    upscalerModel: form.upscaleModel,
     seed: form.seed,
   };
 }

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -328,20 +328,31 @@ describe("MobileApp sequence generation", () => {
       return Promise.reject(new Error(`Unexpected API path: ${path}`));
     });
 
-    previewChainPlacement.mockResolvedValueOnce({
-      version: 1,
-      authoritative: false,
-      state_version: 1,
-      plan_version: 1,
-      outcome: "unsupported",
-      candidate: null,
-    });
+    let finishPreview!: (value: Awaited<ReturnType<typeof previewChainPlacement>>) => void;
+    previewChainPlacement.mockReturnValueOnce(
+      new Promise((resolve) => {
+        finishPreview = resolve;
+      }),
+    );
     wrapper = mountMobileApp();
     await flushPromises();
     const prompts = wrapper.findAll("[data-test='mobile-sequence-clip'] textarea");
     await prompts[0]!.setValue("A paper boat crosses a moonlit pond");
     await prompts[1]!.setValue("Fireflies gather as the sky brightens");
+    const sequenceForm = wrapper.getComponent({ name: "MobileSequenceComposer" }).props("form") as {
+      strength: number;
+    };
+    const tappedStrength = sequenceForm.strength;
     await wrapper.get("[data-test='mobile-generate-sequence']").trigger("click");
+    await flushPromises();
+    sequenceForm.strength = 0.12;
+    await prompts[0]!.setValue("A later edit that belongs to the next submission");
+    finishPreview({
+      ...plannedPlacement(),
+      authoritative: false,
+      outcome: "unsupported",
+      candidate: null,
+    });
     await flushPromises();
 
     expect(previewChainPlacement).toHaveBeenCalledWith(target, expect.anything());
@@ -353,6 +364,12 @@ describe("MobileApp sequence generation", () => {
         body: expect.stringContaining("A paper boat crosses a moonlit pond"),
       }),
     );
+    const createCall = apiJsonTo.mock.calls.find(
+      (call) => call[1] === "/api/chain-jobs" && (call[2] as RequestInit)?.method === "POST",
+    );
+    const request = JSON.parse(String((createCall?.[2] as RequestInit)?.body));
+    expect(request.strength).toBe(tappedStrength);
+    expect(request.stages[0].prompt).toBe("A paper boat crosses a moonlit pond");
     const recovery = localStorage.getItem("mold.mobile.sequence-job.v1");
     expect(JSON.parse(recovery ?? "null")).toEqual({
       hostId: "studio-id",

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -1509,13 +1509,20 @@ async function submitMobileSequence(): Promise<void> {
     target,
     instanceId: host.instanceId ?? null,
   };
+  // Freeze all request-affecting values at the tap boundary. Source fitting
+  // and placement preview are asynchronous; edits during either await belong
+  // to the next submission.
+  const requestForm = cloneGenerateForm(form);
+  const clips = JSON.parse(JSON.stringify(draft.clips)) as typeof draft.clips;
+  const openingSnapshot = draft.openingImage ? { ...draft.openingImage } : null;
+  const enableAudio = draft.enableAudio;
+  const motionTailFrames = sequenceMotionTail.value;
   sequenceStarting.value = true;
   sequenceError.value = "";
   try {
     // Stale limits would mis-gate audio and frame caps for the routed host.
     if (!chainLimits.value || chainLimits.value.model !== entry.name) await loadChainLimits();
-    const requestForm = cloneGenerateForm(form);
-    requestForm.sourceImage = draft.openingImage?.base64 ?? null;
+    requestForm.sourceImage = openingSnapshot?.base64 ?? null;
     requestForm.maskImage = null;
     if (requestForm.sourceImage) {
       const result = await applySourceFitPreprocess(
@@ -1534,12 +1541,12 @@ async function submitMobileSequence(): Promise<void> {
       );
       requestForm.sourceImage = result.source;
     }
-    const openingImage = draft.openingImage
-      ? { ...draft.openingImage, base64: requestForm.sourceImage }
+    const openingImage = openingSnapshot
+      ? { ...openingSnapshot, base64: requestForm.sourceImage }
       : null;
-    const request = buildChainRequest(sequenceParams(form, entry), draft.clips, {
-      motionTailFrames: sequenceMotionTail.value,
-      enableAudio: draft.enableAudio,
+    const request = buildChainRequest(sequenceParams(requestForm, entry), clips, {
+      motionTailFrames,
+      enableAudio,
       openingImage,
     });
     let preview: GenerationPlacementPreview | null = null;
@@ -1568,7 +1575,7 @@ async function submitMobileSequence(): Promise<void> {
     persistSequenceRecovery(host, response.job_id);
     watchSequenceJob(host.id, target, response.job_id, {
       model: entry.name,
-      stageCount: draft.clips.length,
+      stageCount: clips.length,
     });
   } catch (error) {
     sequenceError.value = describeTransportError(error, host.name);

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -878,6 +878,8 @@ function selectCurrentMobileSequence(): void {
     if (shared.fps != null) form.fps = shared.fps;
     if (shared.steps != null) form.steps = shared.steps;
     if (shared.guidance != null) form.guidance = shared.guidance;
+    if (shared.strength != null) form.strength = shared.strength;
+    form.sourceFit = { mode: "crop-fill", alignX: "center", alignY: "center" };
     form.seed = shared.seed ?? "";
     draft.stopEditing();
     draft.output = "sequence";
@@ -1512,10 +1514,33 @@ async function submitMobileSequence(): Promise<void> {
   try {
     // Stale limits would mis-gate audio and frame caps for the routed host.
     if (!chainLimits.value || chainLimits.value.model !== entry.name) await loadChainLimits();
+    const requestForm = cloneGenerateForm(form);
+    requestForm.sourceImage = draft.openingImage?.base64 ?? null;
+    requestForm.maskImage = null;
+    if (requestForm.sourceImage) {
+      const result = await applySourceFitPreprocess(
+        {
+          source: requestForm.sourceImage,
+          mask: null,
+          policy: coerceSourceFitForMaskless(requestForm.sourceFit),
+          target: { width: requestForm.width, height: requestForm.height },
+        },
+        {
+          ops: domCanvasOps,
+          cache: sourceFitCache,
+          upscale: (image, model) => upscaleImage({ image, model, target }),
+          onStatus: setGenerationStatus,
+        },
+      );
+      requestForm.sourceImage = result.source;
+    }
+    const openingImage = draft.openingImage
+      ? { ...draft.openingImage, base64: requestForm.sourceImage }
+      : null;
     const request = buildChainRequest(sequenceParams(form, entry), draft.clips, {
       motionTailFrames: sequenceMotionTail.value,
       enableAudio: draft.enableAudio,
-      openingImage: draft.openingImage,
+      openingImage,
     });
     let preview: GenerationPlacementPreview | null = null;
     let legacyUnsupported = false;
@@ -3539,6 +3564,8 @@ onBeforeUnmount(() => {
             <MobileSequenceComposer
               v-else
               :selected-model="selectedGenerationModel"
+              :form="form"
+              :upscalers="upscalers"
               :chain-limits="chainLimits"
               :target="selectedTarget"
               :shared="sequenceParams(form, selectedGenerationModel)"

--- a/desktop/src/mobile/MobileSequenceComposer.test.ts
+++ b/desktop/src/mobile/MobileSequenceComposer.test.ts
@@ -10,6 +10,7 @@ import MobileSeamSheet from "./MobileSeamSheet.vue";
 import MobileAdvancedSheet from "./MobileAdvancedSheet.vue";
 import MobileSequenceComposer from "./MobileSequenceComposer.vue";
 import { validateChain } from "@studio/api/chains";
+import { newGenerateForm } from "../lib/generateForm";
 
 vi.mock("@studio/api/chains", () => ({
   validateChain: vi.fn(),
@@ -79,6 +80,7 @@ function mountComposer(props: Record<string, unknown> = {}): VueWrapper {
   wrapper = mount(MobileSequenceComposer, {
     props: {
       selectedModel: ltx2,
+      form: newGenerateForm(),
       chainLimits: limits,
       target: { baseUrl: "http://studio:7680", apiKey: "secret" },
       shared,
@@ -116,12 +118,28 @@ describe("MobileSequenceComposer clips", () => {
     const draft = useSequenceDraftStore();
     mountComposer();
     await wrapper!.get("[data-test='mobile-sequence-open-advanced']").trigger("click");
+
     const select = wrapper!.get("[data-test='mobile-sequence-camera-motion']");
     expect(select.text()).toContain("downloads on first use");
     await select.setValue("dolly-in");
     expect(draft.clips[0]?.cameraControl).toBe("dolly-in");
     wrapper!.getComponent(MobileAdvancedSheet).vm.$emit("reset");
     expect(draft.clips[0]?.cameraControl).toBeNull();
+  });
+
+  it("locks source controls while a sequence is submitting", async () => {
+    const draft = useSequenceDraftStore();
+    draft.openingImage = { filename: "opening.png", base64: "QUJD" };
+    mountComposer({ submitting: true });
+    await wrapper!.get("[data-test='mobile-sequence-open-advanced']").trigger("click");
+    expect(
+      (wrapper!.get("[data-test='mobile-sequence-source-strength']").element as HTMLInputElement)
+        .disabled,
+    ).toBe(true);
+    expect(
+      (wrapper!.get("[data-test='mobile-sequence-source-fit']").element as HTMLSelectElement)
+        .disabled,
+    ).toBe(true);
   });
 
   it("renders the shared draft's clips instead of private component state", async () => {
@@ -442,6 +460,7 @@ describe("MobileSequenceComposer guardrails", () => {
     wrapper = mount(MobileSequenceComposer, {
       props: {
         selectedModel: ltx2,
+        form: newGenerateForm(),
         chainLimits: limits,
         target: { baseUrl: "http://studio:7680", apiKey: "secret" },
         shared,
@@ -480,6 +499,29 @@ describe("MobileSequenceComposer guardrails", () => {
     expect(wrapper!.get("[data-test='mobile-sequence-source-preview']").attributes("src")).toBe(
       "data:image/jpeg;base64,wire-bytes",
     );
+  });
+
+  it("exposes strength and fit controls after an opening image is attached", async () => {
+    const form = newGenerateForm();
+    const draft = useSequenceDraftStore();
+    draft.openingImage = { filename: "opening.png", base64: "QUJD" };
+    mountComposer({
+      form,
+      upscalers: [{ ...ltx2, name: "real-esrgan-x4plus:fp16", family: "upscaler" }],
+    });
+    await wrapper!.get("[data-test='mobile-sequence-open-advanced']").trigger("click");
+
+    expect(
+      (wrapper!.get("[data-test='mobile-sequence-source-fit']").element as HTMLSelectElement).value,
+    ).toBe("crop-fill");
+    await wrapper!.get("[data-test='mobile-sequence-source-strength']").setValue("0.6");
+    expect(form.strength).toBe(0.6);
+    await wrapper!.get("[data-test='mobile-sequence-source-fit']").setValue("upscale-then-fit");
+    expect(form.sourceFit).toEqual({
+      mode: "upscale-then-fit",
+      upscalerModel: "real-esrgan-x4plus:fp16",
+      fit: { mode: "crop-fill", alignX: "center", alignY: "center" },
+    });
   });
 
   it("summarizes the timeline at the form's own frame rate", () => {

--- a/desktop/src/mobile/MobileSequenceComposer.vue
+++ b/desktop/src/mobile/MobileSequenceComposer.vue
@@ -33,9 +33,16 @@ import {
 } from "@studio/lib/sequenceForm";
 import { promptOptional } from "@studio/lib/promptRequirement";
 import { cameraMotionMode } from "@studio/lib/cameraMotion";
+import {
+  SOURCE_FIT_OPTIONS,
+  coerceSourceFitForMaskless,
+  sourceFitPolicyForMode,
+  type SourceFitMode,
+} from "@studio/lib/sourceFit";
 import type { ChainLimits } from "@studio/lib/api/chainTypes";
 import type { ApiTarget } from "../lib/api/client";
 import type { Ltx2CameraControlInfo, ModelEntry } from "../lib/api/types";
+import type { GenerateForm } from "../lib/generateForm";
 import { base64ToDataUrl } from "../lib/image";
 import MobileImagePickerSheet, { type MobilePickedImage } from "./MobileImagePickerSheet.vue";
 import MobileAdvancedSheet from "./MobileAdvancedSheet.vue";
@@ -45,6 +52,7 @@ import type { ChainValidationResponse } from "@studio/lib/api/chainTypes";
 
 const props = withDefaults(
   defineProps<{
+    form: GenerateForm;
     selectedModel: ModelEntry | null;
     chainLimits: ChainLimits | null;
     target: ApiTarget | null;
@@ -61,6 +69,7 @@ const props = withDefaults(
     settingsSummary?: string;
     cameraControls?: Ltx2CameraControlInfo[];
     cameraControlsLoaded?: boolean;
+    upscalers?: ModelEntry[];
   }>(),
   {
     target: null,
@@ -70,6 +79,7 @@ const props = withDefaults(
     settingsSummary: "",
     cameraControls: () => [],
     cameraControlsLoaded: false,
+    upscalers: () => [],
   },
 );
 
@@ -99,6 +109,18 @@ const advancedCount = computed(
     Number(Boolean(activeClip.value?.cameraControl)) +
     Number(draft.enableAudio),
 );
+const fitOptions = SOURCE_FIT_OPTIONS.filter((option) => option.value !== "pad-repaint");
+const fitMode = computed(() => coerceSourceFitForMaskless(props.form.sourceFit).mode);
+const upscalerAvailable = computed(() =>
+  Boolean(props.form.upscaleModel || props.upscalers[0]?.name),
+);
+
+function setSourceFit(mode: SourceFitMode): void {
+  props.form.sourceFit = sourceFitPolicyForMode(mode, {
+    supportsMask: false,
+    upscalerModel: props.form.upscaleModel || props.upscalers[0]?.name || "",
+  });
+}
 
 function setCameraMode(mode: string) {
   const clip = activeClip.value;
@@ -265,6 +287,7 @@ function submit(): void {
 
 function setOpeningImage(image: MobilePickedImage): void {
   draft.openingImage = { filename: image.filename, base64: image.base64 };
+  props.form.sourceFit = coerceSourceFitForMaskless(props.form.sourceFit);
   imagePickerOpen.value = false;
 }
 
@@ -472,6 +495,8 @@ function sourceImageMime(filename: string): string {
       @reset="
         draft.openingImage = null;
         draft.enableAudio = false;
+        form.strength = 0.75;
+        form.sourceFit = { mode: 'crop-fill', alignX: 'center', alignY: 'center' };
         draft.clips.forEach((clip) => {
           clip.negativePrompt = '';
           clip.cameraControl = null;
@@ -513,6 +538,47 @@ function sourceImageMime(filename: string): string {
         >
           Remove
         </button>
+        <template v-if="draft.openingImage">
+          <label class="mobile-range-field">
+            <span>
+              Source strength
+              <output>{{ form.strength.toFixed(2) }}</output>
+            </span>
+            <input
+              v-model.number="form.strength"
+              type="range"
+              min="0"
+              max="1"
+              step="0.01"
+              aria-label="Sequence source strength"
+              data-test="mobile-sequence-source-strength"
+              :disabled="locked"
+            />
+          </label>
+          <label class="field">
+            <span>Fit to video frame</span>
+            <select
+              class="control"
+              :value="fitMode"
+              data-test="mobile-sequence-source-fit"
+              :disabled="locked"
+              @change="setSourceFit(($event.target as HTMLSelectElement).value as SourceFitMode)"
+            >
+              <option
+                v-for="option in fitOptions"
+                :key="option.value"
+                :value="option.value"
+                :disabled="option.value === 'upscale-then-fit' && !upscalerAvailable"
+              >
+                {{ option.label }}
+              </option>
+            </select>
+          </label>
+          <p v-if="!upscalerAvailable" class="mobile-source-note">
+            Install an upscaler to enable Upscale + crop.
+          </p>
+          <p class="mobile-source-note">Applied to the opening image before clip 1 renders.</p>
+        </template>
       </details>
       <label v-if="activeClip" class="field" data-test="mobile-sequence-advanced-negative">
         <span>Clip {{ activeIndex + 1 }} negative prompt</span>

--- a/desktop/src/stores/chainJobs.ts
+++ b/desktop/src/stores/chainJobs.ts
@@ -112,8 +112,8 @@ export const useChainJobsStore = defineStore("chainJobs", {
         this.pollTimer = null;
       }
     },
-    async create(hostId: string, req: ChainRequestWire): Promise<string> {
-      const target = this.targetFor(hostId);
+    async create(hostId: string, req: ChainRequestWire, frozenTarget?: ApiTarget): Promise<string> {
+      const target = frozenTarget ?? this.targetFor(hostId);
       const res = await apiJsonTo<CreateChainJobResponse>(target, "/api/chain-jobs", jsonInit(req));
       await this.fetchHost(hostId);
       this.watch(hostId, res.job_id);
@@ -202,8 +202,13 @@ export const useChainJobsStore = defineStore("chainJobs", {
       this.watch(hostId, jobId);
     },
     /** Edit a durable job in place: the server re-renders only dirty stages. */
-    async amend(hostId: string, jobId: string, req: AmendRequest): Promise<AmendResponse> {
-      const target = this.targetFor(hostId);
+    async amend(
+      hostId: string,
+      jobId: string,
+      req: AmendRequest,
+      frozenTarget?: ApiTarget,
+    ): Promise<AmendResponse> {
+      const target = frozenTarget ?? this.targetFor(hostId);
       const outcome = await apiJsonTo<AmendResponse>(
         target,
         `/api/chain-jobs/${encodeURIComponent(jobId)}/amend`,

--- a/desktop/src/views/GenerateView.sequence.test.ts
+++ b/desktop/src/views/GenerateView.sequence.test.ts
@@ -14,6 +14,7 @@ vi.mock("vue-router", () => ({
 const apiJson = vi.fn();
 const apiJsonTo = vi.fn();
 const apiFetchTo = vi.fn();
+const applySourceFitPreprocess = vi.fn();
 vi.mock("../lib/api/client", () => ({
   apiJson: (...args: unknown[]) => apiJson(...args),
   apiJsonTo: (...args: unknown[]) => apiJsonTo(...args),
@@ -31,6 +32,9 @@ vi.mock("../lib/ipc", () => ({
   },
 }));
 vi.mock("../lib/api/sse", () => ({ sseStream: vi.fn().mockResolvedValue(undefined) }));
+vi.mock("../lib/sourceFitPreprocess", () => ({
+  applySourceFitPreprocess: (...args: unknown[]) => applySourceFitPreprocess(...args),
+}));
 
 import GenerateView from "./GenerateView.vue";
 import { useSequenceDraftStore } from "@studio/stores/sequenceDraft";
@@ -99,6 +103,11 @@ beforeEach(() => {
   );
   apiJsonTo.mockReset();
   apiFetchTo.mockReset();
+  applySourceFitPreprocess
+    .mockReset()
+    .mockImplementation((input) =>
+      Promise.resolve({ source: input.source, mask: input.mask, changed: false }),
+    );
   apiJsonTo.mockImplementation((_target: unknown, path: unknown) => {
     if (path === "/api/chain-jobs") return Promise.resolve({ jobs: [] });
     if (path === "/api/models") return Promise.resolve(installedPayload);
@@ -465,8 +474,90 @@ describe("GenerateView — sequence output", () => {
     expect(amendCalls.length).toBe(1);
     const body = JSON.parse((amendCalls[0] as { body: string }).body);
     expect(body.enable_audio).toBe(false);
+    expect(body.strength).toBe(0.75);
     expect(body.stages[0].source_image).toBe("QUJD");
     expect(body.stages[1].source_image).toBeUndefined();
+  });
+
+  it("fits the opening image before a sequence request is submitted", async () => {
+    readyLocal();
+    installedPayload = [videoModel];
+    useModelStore().all = [videoModel];
+    const formStore = useGenerateFormStore();
+    formStore.form.model = "ltx-video";
+    formStore.form.sourceFit = { mode: "lanczos-resize" };
+    formStore.form.strength = 0.55;
+    const draft = useSequenceDraftStore();
+    draft.hydrate();
+    draft.output = "sequence";
+    draft.ensureClips(25);
+    draft.clips[0]!.prompt = "opening";
+    draft.clips[1]!.prompt = "landing";
+    draft.openingImage = { filename: "opening.png", base64: "ORIGINAL" };
+    applySourceFitPreprocess.mockResolvedValue({
+      source: "FITTED",
+      mask: null,
+      changed: true,
+    });
+    const create = vi.spyOn(useChainJobsStore(), "create").mockResolvedValue("job-1");
+
+    const wrapper = mountView();
+    await flushPromises();
+    wrapper.findComponent({ name: "SequenceComposer" }).vm.$emit("submit");
+    await flushPromises();
+
+    expect(applySourceFitPreprocess).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "ORIGINAL",
+        mask: null,
+        policy: { mode: "lanczos-resize" },
+      }),
+      expect.any(Object),
+    );
+    expect(create.mock.calls[0]?.[1]).toMatchObject({
+      strength: 0.55,
+      stages: [{ source_image: "FITTED" }, expect.any(Object)],
+    });
+  });
+
+  it("aborts when the sequence route changes during source preprocessing", async () => {
+    readyLocal();
+    installedPayload = [videoModel];
+    useModelStore().all = [videoModel];
+    const formStore = useGenerateFormStore();
+    formStore.form.model = "ltx-video";
+    formStore.form.sourceFit = { mode: "lanczos-resize" };
+    const draft = useSequenceDraftStore();
+    draft.hydrate();
+    draft.output = "sequence";
+    draft.ensureClips(25);
+    draft.clips[0]!.prompt = "opening";
+    draft.clips[1]!.prompt = "landing";
+    draft.openingImage = { filename: "opening.png", base64: "ORIGINAL" };
+    let finishPreprocessing!: (value: { source: string; mask: null; changed: boolean }) => void;
+    applySourceFitPreprocess.mockReturnValue(
+      new Promise((resolve) => {
+        finishPreprocessing = resolve;
+      }),
+    );
+    const create = vi.spyOn(useChainJobsStore(), "create").mockResolvedValue("job-1");
+
+    const wrapper = mountView();
+    await flushPromises();
+    wrapper.findComponent({ name: "SequenceComposer" }).vm.$emit("submit");
+    await flushPromises();
+    useConnectionStore().info = {
+      mode: "local",
+      baseUrl: "http://127.0.0.1:8765",
+      apiKey: "replacement-key",
+    };
+    finishPreprocessing({ source: "FITTED", mask: null, changed: true });
+    await flushPromises();
+
+    expect(create).not.toHaveBeenCalled();
+    expect(useToastStore().items.at(-1)?.message).toContain(
+      "machine changed during source preparation",
+    );
   });
 
   it("guides to Discover when no chain-capable video model is installed", async () => {

--- a/desktop/src/views/GenerateView.vue
+++ b/desktop/src/views/GenerateView.vue
@@ -1239,9 +1239,15 @@ async function generateSequence() {
     toasts.push("Choose an installed sequence-capable video model first.", "error");
     return;
   }
-  const hostRoute = draft.editing
-    ? hosts.resolveRoute(draft.editing.hostId, entry.name)
-    : routeForModel(entry);
+  // Freeze the complete request at the click boundary. Preprocessing can be
+  // slow, and edits made while it runs belong to the next submission.
+  const editing = draft.editing ? { ...draft.editing } : null;
+  const requestForm = cloneGenerateForm(form);
+  const clips = JSON.parse(JSON.stringify(draft.clips)) as typeof draft.clips;
+  const openingSnapshot = draft.openingImage ? { ...draft.openingImage } : null;
+  const enableAudio = draft.enableAudio;
+  const motionTailFrames = sequenceMotionTail.value;
+  const hostRoute = editing ? hosts.resolveRoute(editing.hostId, entry.name) : routeForModel(entry);
   if (!hostRoute) {
     toasts.push("The selected host isn't reachable. Pick another host.", "error");
     return;
@@ -1252,30 +1258,50 @@ async function generateSequence() {
     if (!chainLimits.value || chainLimits.value.model !== entry.name) {
       await loadChainLimits();
     }
-    const request = buildChainRequest(sequenceParams(form, entry), draft.clips, {
-      motionTailFrames: sequenceMotionTail.value,
-      enableAudio: draft.enableAudio,
-      openingImage: draft.openingImage,
+    requestForm.sourceImage = openingSnapshot?.base64 ?? null;
+    requestForm.maskImage = null;
+    if (!(await preprocessSourceFit(hostRoute, requestForm))) return;
+    const openingImage = openingSnapshot
+      ? { ...openingSnapshot, base64: requestForm.sourceImage }
+      : null;
+    const request = buildChainRequest(sequenceParams(requestForm, entry), clips, {
+      motionTailFrames,
+      enableAudio,
+      openingImage,
     });
-    if (draft.editing) {
-      const editing = draft.editing;
+    const currentRoute = hosts.resolveRoute(hostRoute.hostId, entry.name);
+    if (
+      !currentRoute ||
+      currentRoute.hostId !== hostRoute.hostId ||
+      currentRoute.target.baseUrl !== hostRoute.target.baseUrl ||
+      currentRoute.target.apiKey !== hostRoute.target.apiKey ||
+      (currentRoute.instanceId ?? null) !== (hostRoute.instanceId ?? null)
+    ) {
+      toasts.push(
+        "The sequence machine changed during source preparation. Review the machine and Generate again.",
+        "error",
+      );
+      return;
+    }
+    if (editing) {
       const amend: AmendRequest = {
         stages: request.stages,
         motion_tail_frames: request.motion_tail_frames ?? null,
         fps: request.fps ?? null,
-        seed: form.seed.trim() === "" ? null : form.seed.trim(),
+        seed: requestForm.seed.trim() === "" ? null : requestForm.seed.trim(),
         steps: request.steps,
         guidance: request.guidance,
+        strength: request.strength ?? null,
         // Always explicit: null means "keep current" server-side, which
         // would make turning audio OFF impossible through an edit.
-        enable_audio: draft.enableAudio,
+        enable_audio: enableAudio,
       };
       try {
         sequenceStageClipIdsByJob.set(
           `${editing.hostId}:${editing.jobId}`,
-          draft.clips.map((clip) => clip.id),
+          clips.map((clip) => clip.id),
         );
-        const outcome = await chains.amend(editing.hostId, editing.jobId, amend);
+        const outcome = await chains.amend(editing.hostId, editing.jobId, amend, hostRoute.target);
         toasts.push(
           `Sequence updated · ${outcome.preserved_stages} clip${outcome.preserved_stages === 1 ? "" : "s"} kept from cache`,
         );
@@ -1292,10 +1318,10 @@ async function generateSequence() {
         throw err;
       }
     } else {
-      const jobId = await chains.create(hostRoute.hostId, request);
+      const jobId = await chains.create(hostRoute.hostId, request, hostRoute.target);
       sequenceStageClipIdsByJob.set(
         `${hostRoute.hostId}:${jobId}`,
-        draft.clips.map((clip) => clip.id),
+        clips.map((clip) => clip.id),
       );
       toasts.push("Sequence queued");
     }
@@ -1348,6 +1374,10 @@ async function loadSequence(payload: { hostId: string; jobId: string }, editing:
     if (shared.fps != null) form.fps = shared.fps;
     if (shared.steps != null) form.steps = shared.steps;
     if (shared.guidance != null) form.guidance = shared.guidance;
+    if (shared.strength != null) form.strength = shared.strength;
+    if (loaded.openingImage) {
+      form.sourceFit = { mode: "crop-fill", alignX: "center", alignY: "center" };
+    }
     form.seed = shared.seed ?? "";
     if (editing) {
       draft.loadFromJob(

--- a/studio/lib/api/chainTypes.ts
+++ b/studio/lib/api/chainTypes.ts
@@ -106,6 +106,7 @@ export interface ChainScriptChain {
   seed?: string | null;
   steps?: number;
   guidance?: number;
+  strength?: number;
   enable_audio?: boolean | null;
 }
 
@@ -187,6 +188,7 @@ export interface AmendRequest {
   seed?: string | null;
   steps?: number | null;
   guidance?: number | null;
+  strength?: number | null;
   enable_audio?: boolean | null;
 }
 

--- a/studio/lib/chainScriptWire.test.ts
+++ b/studio/lib/chainScriptWire.test.ts
@@ -48,6 +48,7 @@ describe("normalizeServerChainScript", () => {
       fps: 24,
       steps: 8,
       guidance: 3,
+      strength: 1,
       motion_tail_frames: 0,
       seed: "42",
     });
@@ -117,12 +118,12 @@ describe("normalizeServerChainScript", () => {
     expect(off?.chain.enable_audio).toBeUndefined();
   });
 
-  it("drops unknown chain fields and unrecognized transitions", () => {
+  it("keeps supported source strength while dropping unknown chain fields", () => {
     const script = normalizeServerChainScript({
       chain: { model: "m", strength: 1, output_format: "mp4", nonsense: "x" },
       stage: [{ prompt: "a", transition: "sparkle" }],
     });
-    expect(script?.chain).toEqual({ model: "m" });
+    expect(script?.chain).toEqual({ model: "m", strength: 1 });
     expect(script?.stages[0]?.transition).toBeUndefined();
   });
 

--- a/studio/lib/chainScriptWire.ts
+++ b/studio/lib/chainScriptWire.ts
@@ -111,6 +111,8 @@ export function normalizeServerChainScript(raw: unknown): ChainScript | null {
   if (steps !== undefined) script.chain.steps = steps;
   const guidance = num(c.guidance);
   if (guidance !== undefined) script.chain.guidance = guidance;
+  const strength = num(c.strength);
+  if (strength !== undefined) script.chain.strength = strength;
   const motionTail = num(c.motion_tail_frames);
   if (motionTail !== undefined) script.chain.motion_tail_frames = motionTail;
   const seed = seedString(c.seed);

--- a/studio/lib/chainToml.test.ts
+++ b/studio/lib/chainToml.test.ts
@@ -72,6 +72,7 @@ describe("serializeChainScript", () => {
     const toml = serializeChainScript(s);
     expect(toml).toContain("strength = 0.75");
     expect(toml).toContain('output_format = "webm"');
+    expect(parseChainScript(toml).chain.strength).toBe(0.75);
   });
 
   it("emits the seed as a bare TOML integer, u64-precise", () => {

--- a/studio/lib/chainToml.ts
+++ b/studio/lib/chainToml.ts
@@ -232,6 +232,8 @@ export function parseChainScript(text: string): ChainScript {
   if (steps !== undefined) script.chain.steps = steps;
   const guidance = num(c.guidance);
   if (guidance !== undefined) script.chain.guidance = guidance;
+  const strength = num(c.strength);
+  if (strength !== undefined) script.chain.strength = strength;
   const motionTail = num(c.motion_tail_frames);
   if (motionTail !== undefined) script.chain.motion_tail_frames = motionTail;
   const seed = seedString(c.seed);

--- a/studio/lib/sequenceForm.test.ts
+++ b/studio/lib/sequenceForm.test.ts
@@ -179,6 +179,7 @@ describe("script round-trip", () => {
         fps: 24,
         steps: 8,
         guidance: 3,
+        strength: 0.6,
         enable_audio: true,
       },
       stages: [
@@ -209,6 +210,7 @@ describe("script round-trip", () => {
     expect(loaded.enableAudio).toBe(true);
     expect(loaded.shared.model).toBe("ltx-2-19b-distilled:fp8");
     expect(loaded.shared.width).toBe(1216);
+    expect(loaded.shared.strength).toBe(0.6);
 
     const back = clipsToChainScript(shared(), loaded.clips, {
       motionTailFrames: 17,
@@ -221,6 +223,7 @@ describe("script round-trip", () => {
     expect(back.stages[1]?.fade_frames).toBe(8);
     expect(back.stages[0]?.source_image_b64).toBe("QUJD");
     expect(back.stages[0]?.loras?.[0]?.path).toBe("camera-control:dolly-left");
+    expect(back.chain.strength).toBe(1);
   });
 
   it("recovers source dimensions from script media without adding wire fields", () => {

--- a/studio/lib/sequenceForm.ts
+++ b/studio/lib/sequenceForm.ts
@@ -17,6 +17,7 @@ import type {
 } from "./api/chainTypes";
 import { imageDimensionsFromBase64 } from "./imageDimensions";
 import type { SequenceTransition } from "./sequence";
+import type { SourceFitPolicy } from "./sourceFit";
 import {
   CAMERA_MOTION_PRESETS,
   cameraMotionLabel,
@@ -57,6 +58,10 @@ export interface SequenceSharedParams {
   steps: number;
   guidance: number;
   strength: number;
+  /** Client-side preprocessing policy for an opening image. */
+  sourceFitPolicy?: SourceFitPolicy;
+  /** Preferred source pre-upscaler when the policy requests one. */
+  upscalerModel?: string;
   /** Decimal string; "" means random (matches the generate forms). */
   seed: string;
 }
@@ -200,6 +205,7 @@ export function chainScriptToClips(script: ChainScript): {
   if (chain.fps != null) shared.fps = chain.fps;
   if (chain.steps != null) shared.steps = chain.steps;
   if (chain.guidance != null) shared.guidance = chain.guidance;
+  if (chain.strength != null) shared.strength = chain.strength;
   if (chain.seed != null) shared.seed = String(chain.seed);
   return {
     clips,
@@ -231,6 +237,7 @@ export function clipsToChainScript(
       seed: shared.seed.trim() === "" ? null : shared.seed,
       steps: shared.steps,
       guidance: shared.guidance,
+      strength: shared.strength,
       enable_audio: opts.enableAudio ? true : null,
     },
     stages: clips.map((clip, idx) =>

--- a/studio/lib/sourceFit.test.ts
+++ b/studio/lib/sourceFit.test.ts
@@ -4,7 +4,26 @@ import {
   describeSourceFit,
   maskPaddingRectangles,
   resolveSourceFitTransform,
+  sourceFitPolicyForMode,
 } from "./sourceFit";
+
+describe("sourceFitPolicyForMode", () => {
+  it("builds maskless sequence policies without unrepaintable padding", () => {
+    expect(
+      sourceFitPolicyForMode("upscale-then-fit", {
+        supportsMask: false,
+        upscalerModel: "real-esrgan-x4plus:fp16",
+      }),
+    ).toEqual({
+      mode: "upscale-then-fit",
+      upscalerModel: "real-esrgan-x4plus:fp16",
+      fit: { mode: "crop-fill", alignX: "center", alignY: "center" },
+    });
+    expect(
+      sourceFitPolicyForMode("pad-repaint", { supportsMask: false }),
+    ).toEqual({ mode: "crop-fill", alignX: "center", alignY: "center" });
+  });
+});
 
 describe("source fit policies", () => {
   it("defaults to pad repaint, preserving requested dimensions and repainting added pixels", () => {

--- a/studio/lib/sourceFit.ts
+++ b/studio/lib/sourceFit.ts
@@ -21,6 +21,46 @@ export type SourceFitPolicy =
       fit: Exclude<SourceFitPolicy, { mode: "upscale-then-fit" }>;
     };
 
+export type SourceFitMode = SourceFitPolicy["mode"];
+
+/**
+ * Source-fit choices shared by every source-image surface. Sequence video is
+ * maskless, so callers omit Pad + repaint and use the remaining four modes.
+ */
+export const SOURCE_FIT_OPTIONS: readonly {
+  value: SourceFitMode;
+  label: string;
+}[] = [
+  { value: "pad-repaint", label: "Pad + repaint" },
+  { value: "crop-fill", label: "Crop fill" },
+  { value: "pad-fit", label: "Scale to fit" },
+  { value: "lanczos-resize", label: "Resize to fill" },
+  { value: "upscale-then-fit", label: "Upscale + crop" },
+];
+
+/** Build the complete policy represented by a compact mode control. */
+export function sourceFitPolicyForMode(
+  mode: SourceFitMode,
+  options: { supportsMask: boolean; upscalerModel?: string },
+): SourceFitPolicy {
+  if (mode === "crop-fill") {
+    return { mode, alignX: "center", alignY: "center" };
+  }
+  if (mode === "upscale-then-fit") {
+    return {
+      mode,
+      upscalerModel: options.upscalerModel ?? "",
+      fit: options.supportsMask
+        ? { mode: "pad-repaint" }
+        : { mode: "crop-fill", alignX: "center", alignY: "center" },
+    };
+  }
+  if (mode === "pad-repaint" && !options.supportsMask) {
+    return { mode: "crop-fill", alignX: "center", alignY: "center" };
+  }
+  return { mode };
+}
+
 export interface Size {
   width: number;
   height: number;

--- a/ui/components/ClipPill.vue
+++ b/ui/components/ClipPill.vue
@@ -39,16 +39,19 @@ const emit = defineEmits<{
 let resizeStartX = 0;
 let resizeStartFrames = 0;
 
+/** A stable timeline zoom: equal playback time gets equal visual width. */
+const TIMELINE_PIXELS_PER_SECOND = 48;
+const MIN_CLIP_WIDTH = 148;
+
 const sortedFrameOptions = computed(() =>
   [...(props.frameOptions ?? [])].sort((a, b) => a - b),
 );
 const clipWidth = computed(() => {
-  const options = sortedFrameOptions.value;
-  if (options.length < 2) return 196;
-  const min = options[0]!;
-  const max = options.at(-1)!;
-  const progress = (props.frames - min) / Math.max(1, max - min);
-  return Math.round(148 + Math.min(1, Math.max(0, progress)) * 112);
+  const fps = Math.max(1, props.fps);
+  return Math.max(
+    MIN_CLIP_WIDTH,
+    Math.round((props.frames / fps) * TIMELINE_PIXELS_PER_SECOND),
+  );
 });
 
 function stopResize() {
@@ -59,15 +62,36 @@ function stopResize() {
 function onResizeMove(event: PointerEvent) {
   const options = sortedFrameOptions.value;
   if (!options.length) return;
-  const min = options[0]!;
-  const max = options.at(-1)!;
+  const pixelsPerFrame = TIMELINE_PIXELS_PER_SECOND / Math.max(1, props.fps);
   const target =
-    resizeStartFrames +
-    ((event.clientX - resizeStartX) * Math.max(8, max - min)) / 112;
+    resizeStartFrames + (event.clientX - resizeStartX) / pixelsPerFrame;
   const frames = options.reduce((nearest, option) =>
     Math.abs(option - target) < Math.abs(nearest - target) ? option : nearest,
   );
   if (frames !== props.frames) emit("resize", frames);
+}
+
+function onResizeKeydown(event: KeyboardEvent) {
+  const options = sortedFrameOptions.value;
+  if (options.length < 2) return;
+  const currentIndex = options.reduce(
+    (nearest, option, index) =>
+      Math.abs(option - props.frames) <
+      Math.abs(options[nearest]! - props.frames)
+        ? index
+        : nearest,
+    0,
+  );
+  let nextIndex = currentIndex;
+  if (event.key === "ArrowLeft") nextIndex = Math.max(0, currentIndex - 1);
+  else if (event.key === "ArrowRight")
+    nextIndex = Math.min(options.length - 1, currentIndex + 1);
+  else if (event.key === "Home") nextIndex = 0;
+  else if (event.key === "End") nextIndex = options.length - 1;
+  else return;
+  event.preventDefault();
+  const frames = options[nextIndex];
+  if (frames !== undefined && frames !== props.frames) emit("resize", frames);
 }
 
 function startResize(event: PointerEvent) {
@@ -119,6 +143,7 @@ const statusLabel = computed(() => {
     :data-playing="playing ? 'true' : undefined"
     :data-status="media?.status ?? undefined"
     :data-plan="plan ?? undefined"
+    :data-frames="frames"
     :style="{ '--clip-width': `${clipWidth}px` }"
   >
     <button
@@ -221,6 +246,7 @@ const statusLabel = computed(() => {
       :aria-label="`Resize ${label}; currently ${durationLabel}`"
       title="Drag to change scene length"
       @pointerdown="startResize"
+      @keydown="onResizeKeydown"
     >
       <span aria-hidden="true" />
     </button>
@@ -232,7 +258,7 @@ const statusLabel = computed(() => {
   position: relative;
   display: block;
   flex: 0 0 auto;
-  width: min(var(--clip-width), var(--filmstrip-tile-max, 196px));
+  width: var(--clip-width);
 }
 
 .ms-clip__resize {

--- a/ui/components/ClipRail.test.ts
+++ b/ui/components/ClipRail.test.ts
@@ -223,13 +223,8 @@ describe("ClipRail", () => {
     expect(railSource).toMatch(
       /--filmstrip-thumb-height:\s*calc\(\s*var\(--filmstrip-scene-height\) - var\(--filmstrip-footer-height\)\s*\)/,
     );
-    expect(railSource).toMatch(
-      /--filmstrip-tile-max:\s*calc\(var\(--filmstrip-thumb-height\) \* 16 \/ 9\)/,
-    );
     expect(railSource).not.toContain("@container create-bench");
-    expect(pillSource).toContain(
-      "width: min(var(--clip-width), var(--filmstrip-tile-max, 196px))",
-    );
+    expect(pillSource).toContain("width: var(--clip-width)");
   });
 
   it("changes duration on the x axis while every tile keeps the track height", () => {
@@ -253,6 +248,30 @@ describe("ClipRail", () => {
     expect(pillSource).toMatch(
       /\.ms-clip__thumb :deep\(img\),[\s\S]*object-fit:\s*cover/s,
     );
+  });
+
+  it("scales long clips by actual playback duration instead of a fixed frame cap", () => {
+    const wrapper = make({
+      fps: 24,
+      clips: [
+        { ...clips(2)[0]!, frames: 97 },
+        { ...clips(2)[1]!, frames: 481 },
+      ],
+      frameOptions: [97, 193, 289, 385, 481],
+    });
+    const tiles = wrapper.findAll(".ms-clip");
+    expect(tiles[0]!.attributes("style")).toContain("--clip-width: 194px");
+    expect(tiles[1]!.attributes("style")).toContain("--clip-width: 962px");
+    expect(Number(tiles[1]!.attributes("data-frames"))).toBe(481);
+  });
+
+  it("steps clip duration from the resize handle with the keyboard", async () => {
+    const wrapper = make({ frameOptions: [97, 193, 289, 385, 481] });
+    const handles = wrapper.findAll(".ms-clip__resize");
+    await handles[0]!.trigger("keydown", { key: "ArrowRight" });
+    expect(wrapper.emitted("resize")?.at(-1)).toEqual(["c0", 193]);
+    await handles[0]!.trigger("keydown", { key: "End" });
+    expect(wrapper.emitted("resize")?.at(-1)).toEqual(["c0", 481]);
   });
 
   it("keeps playback and removal as separate, keyboard-focusable controls", () => {

--- a/ui/components/ClipRail.vue
+++ b/ui/components/ClipRail.vue
@@ -290,7 +290,7 @@ const dragModel = computed({
 .ms-rail-frame {
   /*
    * Fluid filmstrip geometry: the frame is its own size container, so every
-   * internal measure (paddings, scene, thumb, tile cap) derives from the
+   * internal vertical measure (paddings, scene, thumb) derives from the
    * frame's actual height. Surfaces only ever set the frame height — the
    * desktop bench resizer shrinks it via flex — and the strip re-proportions
    * continuously instead of stepping through fixed density tiers or growing
@@ -306,7 +306,6 @@ const dragModel = computed({
   --filmstrip-thumb-height: calc(
     var(--filmstrip-scene-height) - var(--filmstrip-footer-height)
   );
-  --filmstrip-tile-max: calc(var(--filmstrip-thumb-height) * 16 / 9);
   --filmstrip-seam-width: 46px;
   position: relative;
   height: 188px;

--- a/web/src/components/create/AdvancedDrawer.test.ts
+++ b/web/src/components/create/AdvancedDrawer.test.ts
@@ -97,6 +97,35 @@ describe("AdvancedDrawer sequence contract", () => {
     expect(wrapper.find("[data-test='section-video']").exists()).toBe(false);
   });
 
+  it("exposes strength and maskless fit controls for an opening image", async () => {
+    const wrapper = factory(
+      "ltx2",
+      { strength: 0.8, sourceFitPolicy: { mode: "crop-fill" } },
+      { output: "sequence" },
+    );
+    useSequenceDraftStore().openingImage = {
+      filename: "opening.png",
+      base64: "QUJD",
+    };
+    await wrapper.vm.$nextTick();
+
+    expect(
+      wrapper.get("[data-test='sequence-source-strength']").text(),
+    ).toContain("0.80");
+    const fit = wrapper.get("[data-test='sequence-source-fit']");
+    expect((fit.element as HTMLSelectElement).value).toBe("crop-fill");
+    expect(fit.findAll("option").map((option) => option.text())).toEqual([
+      "Crop fill",
+      "Scale to fit",
+      "Resize to fill",
+      "Upscale + crop",
+    ]);
+    await fit.setValue("lanczos-resize");
+    expect(wrapper.emitted("update:modelValue")?.at(-1)?.[0]).toMatchObject({
+      sourceFitPolicy: { mode: "lanczos-resize" },
+    });
+  });
+
   it("edits and resets camera motion on the active clip", async () => {
     vi.mocked(fetch).mockResolvedValue({
       ok: true,

--- a/web/src/components/create/AdvancedDrawer.vue
+++ b/web/src/components/create/AdvancedDrawer.vue
@@ -46,6 +46,12 @@ import { useOverlayFocus } from "../../composables/useOverlayFocus";
 import { useSequenceDraftStore } from "@studio/stores/sequenceDraft";
 import type { OutputMode } from "@studio/lib/sequence";
 import {
+  SOURCE_FIT_OPTIONS,
+  coerceSourceFitForMaskless,
+  sourceFitPolicyForMode,
+  type SourceFitMode,
+} from "@studio/lib/sourceFit";
+import {
   cameraMotionMode,
   isCameraMotionPreset,
 } from "@studio/lib/cameraMotion";
@@ -224,6 +230,23 @@ const fitOptions = [
 const fitMode = computed(
   () => props.modelValue.sourceFitPolicy?.mode ?? "pad-repaint",
 );
+const sequenceFitOptions = SOURCE_FIT_OPTIONS.filter(
+  (option) => option.value !== "pad-repaint",
+);
+const sequenceFitMode = computed(
+  () =>
+    coerceSourceFitForMaskless(
+      props.modelValue.sourceFitPolicy ?? { mode: "crop-fill" },
+    ).mode,
+);
+function setSequenceFit(mode: SourceFitMode) {
+  patch({
+    sourceFitPolicy: sourceFitPolicyForMode(mode, {
+      supportsMask: false,
+      upscalerModel: props.modelValue.upscaleModel || "real-esrgan-x4plus:fp16",
+    }),
+  });
+}
 function setFit(mode: string) {
   if (mode === "upscale-then-fit") {
     patch({
@@ -324,6 +347,7 @@ function resetAdvanced() {
       clip.negativePrompt = "";
       clip.cameraControl = null;
     }
+    patch({ strength: 0.75, sourceFitPolicy: { mode: "crop-fill" } });
     return;
   }
   patch({
@@ -443,6 +467,45 @@ function setSequenceCameraMode(mode: string) {
           >
             Remove opening image
           </button>
+          <template v-if="draft.openingImage">
+            <SliderRow
+              label="Source strength"
+              :model-value="modelValue.strength"
+              :min="0"
+              :max="1"
+              :step="0.01"
+              :value-label="modelValue.strength.toFixed(2)"
+              data-test="sequence-source-strength"
+              @update:model-value="patch({ strength: $event })"
+            />
+            <div class="adv__field">
+              <label class="adv__label" for="sequence-source-fit"
+                >Fit to video frame</label
+              >
+              <select
+                id="sequence-source-fit"
+                class="adv__input"
+                data-test="sequence-source-fit"
+                :value="sequenceFitMode"
+                @change="
+                  setSequenceFit(
+                    ($event.target as HTMLSelectElement).value as SourceFitMode,
+                  )
+                "
+              >
+                <option
+                  v-for="option in sequenceFitOptions"
+                  :key="option.value"
+                  :value="option.value"
+                >
+                  {{ option.label }}
+                </option>
+              </select>
+              <p class="adv__hint">
+                Applied to the opening image before the first clip renders.
+              </p>
+            </div>
+          </template>
         </AccordionSection>
 
         <AccordionSection

--- a/web/src/composables/useChainJobs.ts
+++ b/web/src/composables/useChainJobs.ts
@@ -338,8 +338,9 @@ async function amend(
   hostId: string,
   jobId: string,
   req: AmendRequest,
+  frozenTarget?: StreamTarget,
 ): Promise<AmendResponse> {
-  const target = targetFor(hostId) ?? undefined;
+  const target = frozenTarget ?? targetFor(hostId) ?? undefined;
   const response = await amendChainJob(jobId, req, target);
   track(hostId, jobId);
   void fetchHost(hostId);
@@ -430,6 +431,7 @@ export interface UseChainJobs {
     hostId: string,
     jobId: string,
     req: AmendRequest,
+    frozenTarget?: StreamTarget,
   ) => Promise<AmendResponse>;
   clearInactive: () => Promise<{ cleared: number; failed: number }>;
   gc: () => Promise<{

--- a/web/src/lib/sequenceParams.test.ts
+++ b/web/src/lib/sequenceParams.test.ts
@@ -30,6 +30,7 @@ function formState(): GenerateFormState {
     controlModel: "",
     controlScale: 1,
     upscaleModel: "",
+    sourceFitPolicy: { mode: "crop-fill" },
     gifPreview: false,
     audioFile: null,
     audioFilePath: "",
@@ -63,6 +64,8 @@ describe("sequenceSharedParams", () => {
       steps: 8,
       guidance: 3.5,
       strength: 0.9,
+      sourceFitPolicy: { mode: "crop-fill" },
+      upscalerModel: "",
       seed: "",
     });
   });

--- a/web/src/lib/sequenceParams.ts
+++ b/web/src/lib/sequenceParams.ts
@@ -27,6 +27,8 @@ export function sequenceSharedParams(
     steps: state.steps,
     guidance: state.guidance,
     strength: state.strength,
+    sourceFitPolicy: state.sourceFitPolicy,
+    upscalerModel: state.upscaleModel,
     seed:
       state.seedMode === "random" || state.seed === null
         ? ""

--- a/web/src/pages/CreatePage.test.ts
+++ b/web/src/pages/CreatePage.test.ts
@@ -1981,7 +1981,7 @@ describe("CreatePage layout and behavior", () => {
           {
             prompt: "one",
             frames: 97,
-            source_image_b64: "QUJD",
+            source_image_b64: "iVBORw0KGgoAAAANSUhEUgAAAoAAAAGA",
             source_image_path: "opening.png",
           },
           { prompt: "two", frames: 97, transition: "cut" },
@@ -2009,7 +2009,9 @@ describe("CreatePage layout and behavior", () => {
     expect(draft.clips.map((c) => c.prompt)).toEqual(["one", "two"]);
     expect(draft.openingImage).toEqual({
       filename: "opening image",
-      base64: "QUJD",
+      base64: "iVBORw0KGgoAAAANSUhEUgAAAoAAAAGA",
+      width: 640,
+      height: 384,
     });
     expect(draft.clips[1]?.transition).toBe("cut");
     // The job's shared params landed on the LIVE form.
@@ -2040,12 +2042,15 @@ describe("CreatePage layout and behavior", () => {
         stages: [
           expect.objectContaining({
             prompt: "one",
-            source_image: "QUJD",
+            source_image: "iVBORw0KGgoAAAANSUhEUgAAAoAAAAGA",
           }),
           expect.objectContaining({ prompt: "two, but stormier" }),
         ],
       }),
       expect.objectContaining({ baseUrl: expect.any(String) }),
+    );
+    expect(amendChainJobMock.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({ strength: 1 }),
     );
     expect(createChainJobMock).not.toHaveBeenCalled();
     expect(draft.editing).toBeNull();

--- a/web/src/pages/CreatePage.vue
+++ b/web/src/pages/CreatePage.vue
@@ -122,6 +122,7 @@ import { useQueue } from "../composables/useQueue";
 import { decideGenerateRequestRouting } from "../lib/chainRouting";
 import { isStandaloneGenerationModel } from "../lib/modelFilters";
 import {
+  coerceSourceFitForMaskless,
   maskPaddingRectangles,
   resolveSourceFitTransform,
 } from "@studio/lib/sourceFit";
@@ -389,9 +390,8 @@ function canvasToSourceImage(
 function drawableFitPolicy(
   policy: SourceFitPolicy | undefined,
 ): SourceFitPolicy {
-  if (!policy || policy.mode === "upscale-then-fit") {
-    return { mode: "pad-repaint" };
-  }
+  if (!policy) return { mode: "pad-repaint" };
+  if (policy.mode === "upscale-then-fit") return policy.fit;
   return policy;
 }
 
@@ -486,6 +486,20 @@ function hostTargetFor(hostId: string): StreamTarget | undefined {
   const host = routing.hosts.value.find((h) => h.id === hostId);
   if (!host) return undefined;
   return { baseUrl: host.url, ...(host.apiKey ? { apiKey: host.apiKey } : {}) };
+}
+
+function hostRouteFor(hostId: string): HostRoute | null {
+  const host = routing.hosts.value.find((candidate) => candidate.id === hostId);
+  if (!host) return null;
+  return {
+    hostId: host.id,
+    label: host.label,
+    target: {
+      baseUrl: host.url,
+      ...(host.apiKey ? { apiKey: host.apiKey } : {}),
+    },
+    instanceId: host.instanceId ?? null,
+  };
 }
 
 const watchedProgress = computed(() => {
@@ -1244,6 +1258,7 @@ function applySharedToForm(shared: Partial<SequenceSharedParams>) {
   if (shared.fps != null) s.fps = shared.fps;
   if (shared.steps != null) s.steps = shared.steps;
   if (shared.guidance != null) s.guidance = shared.guidance;
+  if (shared.strength != null) s.strength = shared.strength;
   if (shared.seed != null && shared.seed !== "") {
     s.seedMode = "static";
     s.seed = Number(shared.seed);
@@ -1260,40 +1275,111 @@ async function onSubmitSequence() {
       "Choose an installed sequence-capable video model on the selected machine.";
     return;
   }
-  const initialRoute = routing.resolve(form.state.value.model || null);
+  // Freeze every request-affecting value at the click boundary. Source
+  // preprocessing may take minutes; edits during that await belong to the
+  // next submission and must not create a hybrid request.
+  const editing = draft.editing ? { ...draft.editing } : null;
+  const shared = {
+    ...sharedParams.value,
+    sourceFitPolicy: sharedParams.value.sourceFitPolicy
+      ? JSON.parse(JSON.stringify(sharedParams.value.sourceFitPolicy))
+      : undefined,
+  } satisfies SequenceSharedParams;
+  const clips = JSON.parse(JSON.stringify(draft.clips)) as typeof draft.clips;
+  const openingSnapshot = draft.openingImage ? { ...draft.openingImage } : null;
+  const enableAudio = draft.enableAudio;
+  const motionTailFrames = sequenceMotionTail.value;
+  const initialRoute = editing
+    ? hostRouteFor(editing.hostId)
+    : routing.resolve(shared.model || null);
   if (!initialRoute) {
     composerError.value = "The selected sequence host is unavailable.";
     return;
   }
   // Refresh chain limits when stale (30 s cache) — the server still remains
   // the final authority at submission.
-  await fetchChainLimits(form.state.value.model, initialRoute.target).catch(
-    () => {},
-  );
-  const req = buildChainRequest(sharedParams.value, draft.clips, {
-    motionTailFrames: sequenceMotionTail.value,
-    enableAudio: draft.enableAudio,
-    openingImage: draft.openingImage,
+  await fetchChainLimits(shared.model, initialRoute.target).catch(() => {});
+  const preliminaryRequest = buildChainRequest(shared, clips, {
+    motionTailFrames,
+    enableAudio,
+    openingImage: openingSnapshot,
+  });
+  let route = initialRoute;
+  if (!editing) {
+    const feasibility = await routing.resolveFeasibleChain(preliminaryRequest);
+    if (feasibility.kind !== "route") {
+      composerError.value = feasibilityMessage(feasibility, "this sequence");
+      return;
+    }
+    route = feasibility.route;
+  }
+  let openingImage = openingSnapshot;
+  if (openingImage?.base64) {
+    const prepared = await prepareStillSourceToRequest(route, {
+      source: {
+        kind: "upload",
+        filename: openingImage.filename,
+        base64: openingImage.base64,
+        width: openingImage.width,
+        height: openingImage.height,
+        mime: /\.jpe?g$/i.test(openingImage.filename)
+          ? "image/jpeg"
+          : "image/png",
+      },
+      mask: null,
+      maskless: true,
+      settings: {
+        policy: shared.sourceFitPolicy,
+        upscalerModel: shared.upscalerModel,
+        family: shared.family,
+        frames: null,
+        width: shared.width,
+        height: shared.height,
+      },
+    });
+    if (prepared === false) return;
+    openingImage = prepared.source
+      ? {
+          ...openingImage,
+          base64: prepared.source.base64,
+          width: prepared.source.width ?? undefined,
+          height: prepared.source.height ?? undefined,
+        }
+      : openingImage;
+  }
+  const req = buildChainRequest(shared, clips, {
+    motionTailFrames,
+    enableAudio,
+    openingImage,
   });
 
-  const editing = draft.editing;
   if (editing) {
     const amendReq: AmendRequest = {
       stages: req.stages,
       motion_tail_frames: req.motion_tail_frames ?? null,
       fps: req.fps ?? null,
-      seed:
-        sharedParams.value.seed.trim() === "" ? null : sharedParams.value.seed,
+      seed: shared.seed.trim() === "" ? null : shared.seed,
       steps: req.steps,
       guidance: req.guidance,
-      enable_audio: draft.enableAudio ? true : null,
+      strength: req.strength ?? null,
+      enable_audio: enableAudio ? true : null,
     };
     try {
+      if (!sameRoute(route, hostRouteFor(editing.hostId))) {
+        composerError.value =
+          "The sequence machine changed during source preparation. Review the machine and Update again.";
+        return;
+      }
       sequenceStageClipIdsByJob.set(
         `${editing.hostId}:${editing.jobId}`,
-        draft.clips.map((clip) => clip.id),
+        clips.map((clip) => clip.id),
       );
-      await chainJobs.amend(editing.hostId, editing.jobId, amendReq);
+      await chainJobs.amend(
+        editing.hostId,
+        editing.jobId,
+        amendReq,
+        route.target,
+      );
       draft.stopEditing();
       editBaselineShared.value = null;
       toast("info", "Sequence updated — unchanged clips stay cached.");
@@ -1316,14 +1402,17 @@ async function onSubmitSequence() {
   }
 
   try {
-    const feasibility = await routing.resolveFeasibleChain(req);
-    if (feasibility.kind !== "route")
-      throw new Error(feasibilityMessage(feasibility, "this sequence"));
-    const route = feasibility.route;
+    const feasibility = await routing.revalidateFeasibleChain(route, req);
+    if (feasibility.kind !== "route") {
+      throw new Error(
+        feasibilityMessage(feasibility, "this finalized sequence"),
+      );
+    }
+    route = feasibility.route;
     const jobId = await chainJobs.create(route.hostId, req);
     sequenceStageClipIdsByJob.set(
       `${route.hostId}:${jobId}`,
-      draft.clips.map((clip) => clip.id),
+      clips.map((clip) => clip.id),
     );
     if (editing) {
       draft.stopEditing();
@@ -1356,6 +1445,13 @@ async function loadSequence(hostId: string, jobId: string, editing: boolean) {
     if (!script) throw new Error("This sequence job has no editable script.");
     const loaded = chainScriptToClips(script);
     applySharedToForm(loaded.shared);
+    if (loaded.openingImage) {
+      form.state.value.sourceFitPolicy = {
+        mode: "crop-fill",
+        alignX: "center",
+        alignY: "center",
+      };
+    }
     if (editing) {
       draft.loadFromJob(
         {
@@ -1415,6 +1511,11 @@ function onDiscardEdit() {
 
 function onImportShared(shared: Partial<SequenceSharedParams>) {
   applySharedToForm(shared);
+  if (draft.openingImage) {
+    // Imported opening-image bytes are already the script's prepared source;
+    // never inherit a stale client-only upscale policy from the prior draft.
+    form.state.value.sourceFitPolicy = { mode: "crop-fill" };
+  }
 }
 
 function onSequenceAction(action: ActivityAction, vm: ActivityJobVM) {
@@ -1725,14 +1826,38 @@ const sourceFitCache = new SourceFitPreprocessCache();
 /** Prepare request-only source bytes while preserving the user's editable source. */
 async function prepareStillSourceToRequest(
   route: HostRoute | null,
+  override?: {
+    source: SourceImageState | null;
+    mask: SourceImageState | null;
+    maskless?: boolean;
+    settings?: {
+      policy?: SourceFitPolicy;
+      upscalerModel?: string;
+      family: string;
+      frames: number | null;
+      width: number;
+      height: number;
+    };
+  },
 ): Promise<PreparedStillSource | false> {
-  let source = form.state.value.imageAttachments[0] ?? null;
-  const mask = form.state.value.maskImage;
+  let source = override
+    ? override.source
+    : (form.state.value.imageAttachments[0] ?? null);
+  const mask = override ? override.mask : form.state.value.maskImage;
   if (!source) return { source, mask };
 
-  const outerPolicy = form.state.value.sourceFitPolicy;
+  const configuredPolicy =
+    override?.settings?.policy ??
+    form.state.value.sourceFitPolicy ??
+    ({ mode: "pad-repaint" } as const);
+  const outerPolicy = override?.maskless
+    ? coerceSourceFitForMaskless(configuredPolicy)
+    : configuredPolicy;
   if (outerPolicy?.mode === "upscale-then-fit") {
-    const model = outerPolicy.upscalerModel || form.state.value.upscaleModel;
+    const model =
+      outerPolicy.upscalerModel ||
+      override?.settings?.upscalerModel ||
+      form.state.value.upscaleModel;
     if (model) {
       try {
         const original = source;
@@ -1790,13 +1915,23 @@ async function prepareStillSourceToRequest(
     }
   }
 
-  const family = currentModel.value?.family ?? form.state.value.modelFamily;
-  if (isQwenImageEditFamily(family) || form.state.value.frames)
+  const family =
+    override?.settings?.family ??
+    currentModel.value?.family ??
+    form.state.value.modelFamily;
+  if (
+    isQwenImageEditFamily(family) ||
+    ((override?.settings?.frames ?? form.state.value.frames) &&
+      !override?.maskless)
+  )
     return { source, mask };
   const target = {
-    width: form.state.value.width,
-    height: form.state.value.height,
+    width: override?.settings?.width ?? form.state.value.width,
+    height: override?.settings?.height ?? form.state.value.height,
   };
+  if (source.width === target.width && source.height === target.height) {
+    return { source, mask };
+  }
   const policy = drawableFitPolicy(outerPolicy);
   return sourceFitCache.fit(
     source.base64,
@@ -2463,6 +2598,9 @@ async function onPickSource(v: SourceImageState[]) {
         width: first.width ?? undefined,
         height: first.height ?? undefined,
       };
+      form.state.value.sourceFitPolicy = coerceSourceFitForMaskless(
+        form.state.value.sourceFitPolicy ?? { mode: "crop-fill" },
+      );
     }
     composerError.value = null;
     return;


### PR DESCRIPTION
## Summary

- add sequence opening-image strength and fit controls across web, desktop, and iPhone
- preprocess sequence sources on the frozen target with coherent request and route snapshots
- scale filmstrip clips dynamically from their real frame duration, including accessible keyboard resizing
- preserve strength through scripts, edits, imports, and amend cache invalidation

## Verification

- `bun run check:frontend`
- `bun run build:mobile`
- focused desktop route-drift/source preprocessing tests
- focused web sequence create/amend tests
- focused Rust core/server chain tests under `nix develop`
- rendered web and desktop sequence-mode UAT
- three subagent peer-review tracks, all closed with no findings