### PR TITLE
fix(gallery): dedupe prints across connected hosts

### DIFF
--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -3987,6 +3987,73 @@ describe("MobileApp gallery", () => {
     expect(wrapper.findAll("[data-test='gallery-item']")).toHaveLength(0);
   });
 
+  it("does not hide or delete a chained legacy copy outside the representative window", async () => {
+    const renderTarget = { baseUrl: "http://render.tailnet.ts.net:7680", apiKey: "secret" };
+    const archiveTarget = { baseUrl: "http://archive.tailnet.ts.net:7680", apiKey: "secret" };
+    const routes = [
+      { id: "studio-id", name: "Studio", baseUrl: target.baseUrl },
+      { id: "render-id", name: "Render", baseUrl: renderTarget.baseUrl },
+      { id: "archive-id", name: "Archive", baseUrl: archiveTarget.baseUrl },
+    ];
+    localStorage.setItem(
+      "mold.mobile.hosts.v1",
+      JSON.stringify(routes.map((host) => ({ ...host, online: false }))),
+    );
+    const copies = new Map([
+      [target.baseUrl, { filename: "newest.mp4", timestamp: 6_000 }],
+      [renderTarget.baseUrl, { filename: "middle.mp4", timestamp: 3_000 }],
+      [archiveTarget.baseUrl, { filename: "oldest.mp4", timestamp: 0 }],
+    ]);
+    apiJsonTo.mockImplementation((route: { baseUrl: string }, path: string) => {
+      const host = routes.find((candidate) => candidate.baseUrl === route.baseUrl)!;
+      if (path === "/api/status") {
+        return Promise.resolve({
+          ...status,
+          hostname: host.name.toLowerCase(),
+          instance_id: host.id,
+        });
+      }
+      if (path === "/api/models") return Promise.resolve([model]);
+      if (path === "/api/gallery") {
+        return Promise.resolve([
+          {
+            ...print,
+            ...copies.get(route.baseUrl),
+            size_bytes: 4_096,
+            metadata: { ...print.metadata, seed: 42, model: "flux-dev:q8" },
+          },
+        ]);
+      }
+      return Promise.reject(new Error(`Unexpected API path: ${path}`));
+    });
+    apiFetchTo.mockImplementation((_route, _path, init?: RequestInit) =>
+      Promise.resolve(
+        init?.method === "DELETE"
+          ? new Response(null, { status: 204 })
+          : ({ blob: () => Promise.resolve(new Blob(["thumbnail"])) } as Response),
+      ),
+    );
+
+    wrapper = mountMobileApp();
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-tab-gallery']").trigger("click");
+    await vi.waitFor(() => expect(wrapper?.findAll("[data-test='gallery-item']")).toHaveLength(2));
+
+    await wrapper.get("[data-test='mobile-gallery-select']").trigger("click");
+    await wrapper.findAll("[data-test='gallery-item']")[0]!.trigger("click");
+    const deleteButton = () =>
+      wrapper!.get("[data-test='mobile-gallery-actions']").find("button.danger");
+    await deleteButton().trigger("click");
+    await deleteButton().trigger("click");
+    await flushPromises();
+
+    const deletePaths = apiFetchTo.mock.calls
+      .filter(([, , init]) => init?.method === "DELETE")
+      .map(([, path]) => path);
+    expect(deletePaths).toEqual(["/api/gallery/image/newest.mp4", "/api/gallery/image/middle.mp4"]);
+    expect(wrapper.findAll("[data-test='gallery-item']")).toHaveLength(1);
+  });
+
   it("defers completion refreshes until an open viewer closes", async () => {
     wrapper = mountMobileApp();
     await flushPromises();

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -4040,7 +4040,7 @@ describe("MobileApp gallery", () => {
     await vi.waitFor(() => expect(wrapper?.findAll("[data-test='gallery-item']")).toHaveLength(2));
 
     await wrapper.get("[data-test='mobile-gallery-select']").trigger("click");
-    await wrapper.findAll("[data-test='gallery-item']")[0]!.trigger("click");
+    await wrapper.findAll("[data-test='gallery-item']")[1]!.trigger("click");
     const deleteButton = () =>
       wrapper!.get("[data-test='mobile-gallery-actions']").find("button.danger");
     await deleteButton().trigger("click");
@@ -4050,7 +4050,7 @@ describe("MobileApp gallery", () => {
     const deletePaths = apiFetchTo.mock.calls
       .filter(([, , init]) => init?.method === "DELETE")
       .map(([, path]) => path);
-    expect(deletePaths).toEqual(["/api/gallery/image/newest.mp4", "/api/gallery/image/middle.mp4"]);
+    expect(deletePaths).toEqual(["/api/gallery/image/oldest.mp4"]);
     expect(wrapper.findAll("[data-test='gallery-item']")).toHaveLength(1);
   });
 

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -3964,7 +3964,7 @@ describe("MobileApp gallery", () => {
     wrapper = mountMobileApp();
     await flushPromises();
     await wrapper.get("[data-test='mobile-tab-gallery']").trigger("click");
-    await vi.waitFor(() => expect(wrapper?.findAll("[data-test='gallery-item']")).toHaveLength(2));
+    await vi.waitFor(() => expect(wrapper?.findAll("[data-test='gallery-item']")).toHaveLength(1));
 
     await wrapper.get("[data-test='mobile-gallery-select']").trigger("click");
     await wrapper.findAll("[data-test='gallery-item']")[0]!.trigger("click");

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -26,7 +26,10 @@ import {
   resolveSourceResolution,
   type SourceResolutionResult,
 } from "@studio/lib/sourceResolution";
-import { sameLogicalGalleryPrint } from "@studio/lib/galleryPrintIdentity";
+import {
+  groupLogicalGalleryPrints,
+  sameLogicalGalleryPrint,
+} from "@studio/lib/galleryPrintIdentity";
 import {
   defaultClipFrames,
   modelsForOutput,
@@ -415,6 +418,8 @@ const resultMediaLoadKey = ref(0);
 const objectUrls = new Set<string>();
 const handledGenerationClientIds = new Set<number>();
 let pendingGallery: PendingGalleryPrint[] = [];
+/** Every concrete device copy behind the deduplicated Library tiles. */
+let galleryCopies: PendingGalleryPrint[] = [];
 let modelLoadEpoch = 0;
 let galleryRefreshRequested = false;
 let galleryRefreshDeferred = false;
@@ -2924,9 +2929,10 @@ async function performGalleryRefresh(): Promise<void> {
       }));
     }),
   );
-  pendingGallery = results
+  galleryCopies = results
     .flatMap((result) => (result.status === "fulfilled" ? result.value : []))
     .sort((a, b) => b.timestamp - a.timestamp);
+  pendingGallery = groupLogicalGalleryPrints(galleryCopies).map((group) => group.representative);
   const failed = results.filter((result) => result.status === "rejected").length;
   if (failed) galleryError.value = `${failed} host${failed === 1 ? "" : "s"} unavailable`;
   await loadMoreGalleryPage();
@@ -2952,7 +2958,7 @@ async function loadMoreGalleryPage(): Promise<void> {
       ...batch.flatMap((result) => (result.status === "fulfilled" ? [result.value] : [])),
     );
   }
-  markMobileLibrarySeen(gallery.value);
+  markMobileLibrarySeen(galleryCopies);
   galleryRemaining.value = pendingGallery.length;
   galleryLoadingMore.value = false;
 }
@@ -3120,9 +3126,8 @@ async function deleteSelectedGalleryPrints(): Promise<void> {
   const selected = allGalleryPrints().filter((print) =>
     gallerySelection.value.has(galleryPrintKey(print)),
   );
-  const all = allGalleryPrints();
   const groups = selected.map((print) =>
-    all.filter((candidate) => sameLogicalGalleryPrint(print, candidate)),
+    galleryCopies.filter((candidate) => sameLogicalGalleryPrint(print, candidate)),
   );
   const targets = new Map<string, GalleryPrint | PendingGalleryPrint>();
   for (const group of groups) {
@@ -3143,12 +3148,11 @@ async function deleteSelectedGalleryPrints(): Promise<void> {
     if (result.status === "fulfilled") deletedKeys.add(key);
     else failedKeys.add(key);
   });
-  for (const print of gallery.value) {
-    if (deletedKeys.has(galleryPrintKey(print))) revokeObjectUrl(print.thumbnailUrl);
-  }
-  gallery.value = gallery.value.filter((print) => !deletedKeys.has(galleryPrintKey(print)));
-  pendingGallery = pendingGallery.filter((print) => !deletedKeys.has(galleryPrintKey(print)));
-  galleryRemaining.value = pendingGallery.length;
+  for (const print of gallery.value) revokeObjectUrl(print.thumbnailUrl);
+  galleryCopies = galleryCopies.filter((print) => !deletedKeys.has(galleryPrintKey(print)));
+  gallery.value = [];
+  pendingGallery = groupLogicalGalleryPrints(galleryCopies).map((group) => group.representative);
+  await loadMoreGalleryPage();
 
   const failedPrints = groups.filter((group) =>
     group.some((print) => failedKeys.has(galleryPrintKey(print))),
@@ -3171,7 +3175,7 @@ function isFreshMobilePrint(print: GalleryPrint): boolean {
   return libraryPreviouslyVisited && seenAt != null && print.timestamp > seenAt;
 }
 
-function markMobileLibrarySeen(prints: GalleryPrint[]): void {
+function markMobileLibrarySeen(prints: Array<GalleryPrint | PendingGalleryPrint>): void {
   const seenAt = { ...librarySeenAtBaseline };
   for (const print of prints) {
     seenAt[print.hostId] = Math.max(seenAt[print.hostId] ?? 0, print.timestamp);

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -26,10 +26,7 @@ import {
   resolveSourceResolution,
   type SourceResolutionResult,
 } from "@studio/lib/sourceResolution";
-import {
-  groupLogicalGalleryPrints,
-  sameLogicalGalleryPrint,
-} from "@studio/lib/galleryPrintIdentity";
+import { groupLogicalGalleryPrints } from "@studio/lib/galleryPrintIdentity";
 import {
   defaultClipFrames,
   modelsForOutput,
@@ -3126,9 +3123,14 @@ async function deleteSelectedGalleryPrints(): Promise<void> {
   const selected = allGalleryPrints().filter((print) =>
     gallerySelection.value.has(galleryPrintKey(print)),
   );
-  const groups = selected.map((print) =>
-    galleryCopies.filter((candidate) => sameLogicalGalleryPrint(print, candidate)),
-  );
+  const logicalGroups = groupLogicalGalleryPrints(galleryCopies);
+  const groups = selected.map((print) => {
+    const key = galleryPrintKey(print);
+    return (
+      logicalGroups.find((group) => group.copies.some((copy) => galleryPrintKey(copy) === key))
+        ?.copies ?? [print]
+    );
+  });
   const targets = new Map<string, GalleryPrint | PendingGalleryPrint>();
   for (const group of groups) {
     for (const print of group) targets.set(galleryPrintKey(print), print);

--- a/desktop/src/stores/gallery.test.ts
+++ b/desktop/src/stores/gallery.test.ts
@@ -211,6 +211,30 @@ describe("merged grid", () => {
       availableOn: [{ key: "hal9000-7680", label: "hal9000" }],
     });
   });
+
+  it("dedupes matching copies across remote hosts without a local copy", async () => {
+    connectLocalPlusHal();
+    addExtra();
+    localSnapshot([]);
+    vi.mocked(apiJsonTo).mockImplementation((target) => {
+      const url = (target as { baseUrl: string }).baseUrl;
+      if (url.includes("hal9000")) return Promise.resolve([img("shared.png", 202)]) as never;
+      if (url.includes("okra")) return Promise.resolve([img("shared.png", 201)]) as never;
+      return Promise.resolve([]) as never;
+    });
+    const gallery = useGalleryStore();
+
+    await gallery.fetchAll();
+
+    expect(gallery.merged).toHaveLength(1);
+    expect(gallery.merged[0]).toMatchObject({
+      sourceKey: "hal9000-7680",
+      availableOn: [
+        { key: "hal9000-7680", label: "hal9000" },
+        { key: "okra-7680", label: "okra" },
+      ],
+    });
+  });
 });
 
 describe("identity dedupe", () => {

--- a/studio/lib/galleryPrintIdentity.test.ts
+++ b/studio/lib/galleryPrintIdentity.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   galleryIdentitySeed,
   galleryPrintIdentity,
+  groupLogicalGalleryPrints,
   sameLogicalGalleryPrint,
 } from "./galleryPrintIdentity";
 
@@ -52,5 +53,38 @@ describe("gallery print identity", () => {
         metadata: { seed: 0 },
       }),
     ).toBeNull();
+  });
+
+  it("groups the same logical print across multiple remote hosts", () => {
+    const items = [
+      {
+        hostId: "render-a",
+        filename: "origin.png",
+        timestamp: 1_002,
+        size_bytes: 4_096,
+        metadata: { seed: 42, model: "flux-dev:q8" },
+      },
+      {
+        hostId: "render-b",
+        filename: "legacy-copy.png",
+        timestamp: 1_001,
+        size_bytes: 4_096,
+        metadata: { seed: 42, model: "flux-dev:q8" },
+      },
+      {
+        hostId: "render-c",
+        filename: "origin.png",
+        timestamp: 1_000,
+      },
+    ];
+
+    const [group] = groupLogicalGalleryPrints(items);
+
+    expect(group?.representative.hostId).toBe("render-a");
+    expect(group?.copies.map((copy) => copy.hostId)).toEqual([
+      "render-a",
+      "render-b",
+      "render-c",
+    ]);
   });
 });

--- a/studio/lib/galleryPrintIdentity.test.ts
+++ b/studio/lib/galleryPrintIdentity.test.ts
@@ -87,4 +87,28 @@ describe("gallery print identity", () => {
       "render-c",
     ]);
   });
+
+  it("does not transitively chain copies outside the representative's time window", () => {
+    const identified = (
+      hostId: string,
+      filename: string,
+      timestamp: number,
+    ) => ({
+      hostId,
+      filename,
+      timestamp,
+      size_bytes: 4_096,
+      metadata: { seed: 42, model: "flux-dev:q8" },
+    });
+
+    const groups = groupLogicalGalleryPrints([
+      identified("render-a", "newest.png", 6_000),
+      identified("render-b", "middle.png", 3_000),
+      identified("render-c", "oldest.png", 0),
+    ]);
+
+    expect(
+      groups.map((group) => group.copies.map((copy) => copy.hostId)),
+    ).toEqual([["render-a", "render-b"], ["render-c"]]);
+  });
 });

--- a/studio/lib/galleryPrintIdentity.ts
+++ b/studio/lib/galleryPrintIdentity.ts
@@ -90,11 +90,7 @@ export function groupLogicalGalleryPrints<T extends GalleryPrintIdentityInput>(
       group = byIdentity
         .get(identity)
         ?.find((candidate) =>
-          candidate.copies.some(
-            (copy) =>
-              Math.abs(copy.timestamp - item.timestamp) <=
-              GALLERY_IDENTITY_WINDOW_SECS,
-          ),
+          sameLogicalGalleryPrint(candidate.representative, item),
         );
     }
 

--- a/studio/lib/galleryPrintIdentity.ts
+++ b/studio/lib/galleryPrintIdentity.ts
@@ -64,3 +64,52 @@ export function sameLogicalGalleryPrint(
     Math.abs(a.timestamp - b.timestamp) <= GALLERY_IDENTITY_WINDOW_SECS
   );
 }
+
+export interface LogicalGalleryPrintGroup<T> {
+  /** The first copy in the input order, used as the rendered print. */
+  representative: T;
+  /** Every physical copy, including the representative. */
+  copies: T[];
+}
+
+/**
+ * Collapse physical copies from any number of hosts into logical prints.
+ * Callers control which copy represents a group by ordering the input first.
+ */
+export function groupLogicalGalleryPrints<T extends GalleryPrintIdentityInput>(
+  items: readonly T[],
+): LogicalGalleryPrintGroup<T>[] {
+  const groups: LogicalGalleryPrintGroup<T>[] = [];
+  const byFilename = new Map<string, LogicalGalleryPrintGroup<T>>();
+  const byIdentity = new Map<string, LogicalGalleryPrintGroup<T>[]>();
+
+  for (const item of items) {
+    const identity = galleryPrintIdentity(item);
+    let group = byFilename.get(item.filename);
+    if (!group && identity) {
+      group = byIdentity
+        .get(identity)
+        ?.find((candidate) =>
+          candidate.copies.some(
+            (copy) =>
+              Math.abs(copy.timestamp - item.timestamp) <=
+              GALLERY_IDENTITY_WINDOW_SECS,
+          ),
+        );
+    }
+
+    if (!group) {
+      group = { representative: item, copies: [] };
+      groups.push(group);
+    }
+    group.copies.push(item);
+    byFilename.set(item.filename, group);
+    if (identity) {
+      const candidates = byIdentity.get(identity) ?? [];
+      if (!candidates.includes(group)) candidates.push(group);
+      byIdentity.set(identity, candidates);
+    }
+  }
+
+  return groups;
+}

--- a/web/src/lib/multiHostGallery.test.ts
+++ b/web/src/lib/multiHostGallery.test.ts
@@ -105,6 +105,33 @@ describe("fetchMergedGallery", () => {
       "render-b",
     ]);
   });
+
+  it("keeps a chained legacy identity outside the representative window visible", async () => {
+    const hosts = [
+      host("render-a", "render a"),
+      host("render-b", "render b"),
+      host("render-c", "render c"),
+    ];
+    const timestamps = new Map([
+      ["render-a", 6_000],
+      ["render-b", 3_000],
+      ["render-c", 0],
+    ]);
+    const fetcher = vi.fn(async (h: HostEntry) => [
+      {
+        ...img(`${h.id}.png`, timestamps.get(h.id)!),
+        size_bytes: 4_096,
+        metadata: { prompt: "shared", model: "flux", seed: 42 } as never,
+      },
+    ]);
+
+    const res = await fetchMergedGallery(hosts, fetcher);
+
+    expect(res.entries.map((entry) => entry.hostId)).toEqual([
+      "render-a",
+      "render-c",
+    ]);
+  });
 });
 
 describe("printKey", () => {

--- a/web/src/lib/multiHostGallery.test.ts
+++ b/web/src/lib/multiHostGallery.test.ts
@@ -78,6 +78,33 @@ describe("fetchMergedGallery", () => {
     const multi = await fetchMergedGallery([origin, a, b], fetcher);
     expect(multi.remoteHostCount).toBe(2);
   });
+
+  it("deduplicates the same logical print across remote hosts without a local copy", async () => {
+    const a = host("render-a", "render a");
+    const b = host("render-b", "render b");
+    const shared = {
+      ...img("shared.png", 200),
+      size_bytes: 4_096,
+      metadata: { prompt: "shared", model: "flux", seed: 42 } as never,
+    };
+    const fetcher = vi.fn(async (h: HostEntry) => [
+      h.id === "render-a"
+        ? shared
+        : { ...shared, filename: "legacy-shared.png", timestamp: 199 },
+    ]);
+
+    const res = await fetchMergedGallery([a, b], fetcher);
+
+    expect(res.entries).toHaveLength(1);
+    expect(res.entries[0]).toMatchObject({
+      hostId: "render-a",
+      filename: "shared.png",
+    });
+    expect(res.rawEntries.map((entry) => entry.hostId)).toEqual([
+      "render-a",
+      "render-b",
+    ]);
+  });
 });
 
 describe("printKey", () => {

--- a/web/src/lib/multiHostGallery.ts
+++ b/web/src/lib/multiHostGallery.ts
@@ -5,13 +5,11 @@
  * with its owning host, and merges newest-first. A per-host failure degrades
  * to an "unreachable" note — the grid never blanks because one box is down.
  *
- * Dedupe is intentionally minimal: the host registry already collapses one
- * box reached by several addresses to a single entry (instance-UUID dedupe),
- * so we don't double-count instances here. The desktop app additionally
- * collapses cross-host copies of the same print by filename / seed+byte-size,
- * but that only exists because desktop auto-saves remote outputs locally; web
- * doesn't, so that heavier collapse is deliberately deferred.
+ * Physical copies are retained for host filters and delete-everywhere, while
+ * the All view receives one representative per logical print regardless of
+ * which pair of hosts contains the copies.
  */
+import { groupLogicalGalleryPrints } from "@studio/lib/galleryPrintIdentity";
 import { ORIGIN_HOST_ID, type HostEntry } from "./hostRegistry";
 import { hostGallery } from "../components/machines/hostClient";
 import type { GalleryImage } from "../types";
@@ -24,8 +22,10 @@ export interface HostGalleryImage extends GalleryImage {
 }
 
 export interface MergedGallery {
-  /** Every reachable host's prints, merged newest-first, host-tagged. */
+  /** Logical prints for the All view, merged newest-first and deduplicated. */
   entries: HostGalleryImage[];
+  /** Every physical copy for host filters and device-routed actions. */
+  rawEntries: HostGalleryImage[];
   /** Hosts whose /api/gallery succeeded. */
   reachableHostIds: string[];
   /** Hosts that failed (network, authentication, or incompatible API) — surfaced as an
@@ -76,11 +76,18 @@ export async function fetchMergedGallery(
     }
   });
 
-  // Newest first across all hosts.
+  // Newest first across all hosts. The first copy becomes the representative,
+  // so a newer reachable copy supplies media/actions when no local preference
+  // exists (web has no special local filesystem bucket).
   entries.sort((a, b) => b.timestamp - a.timestamp);
+  const rawEntries = entries;
+  const deduplicated = groupLogicalGalleryPrints(rawEntries).map(
+    (group) => group.representative,
+  );
 
   return {
-    entries,
+    entries: deduplicated,
+    rawEntries,
     reachableHostIds,
     unreachableHostIds,
     remoteHostCount: hosts.filter((h) => h.id !== ORIGIN_HOST_ID).length,

--- a/web/src/pages/LibraryPage.sequence.test.ts
+++ b/web/src/pages/LibraryPage.sequence.test.ts
@@ -69,6 +69,11 @@ vi.mock("../lib/multiHostGallery", async () => {
           hostLabel: "this server",
           ...e,
         })),
+        rawEntries: list.map((e) => ({
+          hostId: "origin",
+          hostLabel: "this server",
+          ...e,
+        })),
         reachableHostIds: ["origin"],
         unreachableHostIds: [],
         remoteHostCount: 0,

--- a/web/src/pages/LibraryPage.test.ts
+++ b/web/src/pages/LibraryPage.test.ts
@@ -555,6 +555,61 @@ describe("LibraryPage multi-host identity", () => {
     );
   });
 
+  it("uses representative groups when deleting a chained host-filter copy", async () => {
+    vi.useFakeTimers();
+    const archive = {
+      id: "archive-7680",
+      name: "archive",
+      url: "http://archive:7680",
+      apiKey: "archive-key",
+    };
+    localStorage.setItem(
+      "mold.web.hosts.v1",
+      JSON.stringify([STUDIO, archive]),
+    );
+    const identified = (
+      hostId: string,
+      hostLabel: string,
+      filename: string,
+      timestamp: number,
+    ) => ({
+      ...makeEntry(filename, "shared", "flux-dev:q8", 42),
+      hostId,
+      hostLabel,
+      timestamp,
+      size_bytes: 4_096,
+    });
+    listGalleryMock.mockResolvedValue([
+      identified("origin", "this server", "newest.png", 6_000),
+      identified("studio-7680", "studio", "middle.png", 3_000),
+      identified("archive-7680", "archive", "oldest.png", 0),
+    ]);
+    const wrapper = mountPage();
+    await flushPromises();
+    const studio = wrapper
+      .findAll("[data-test='gallery-host-filter']")
+      .find((button) => button.text() === "studio");
+    await studio!.trigger("click");
+    await wrapper.find("[data-test='grid-open']").trigger("click");
+    await wrapper.find("[data-test='lb-delete']").trigger("click");
+    await flushPromises();
+    vi.advanceTimersByTime(6_000);
+    await flushPromises();
+
+    expect(deleteMock).toHaveBeenCalledWith("newest.png");
+    expect(hostDeleteMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "studio-7680" }),
+      "middle.png",
+    );
+    expect(hostDeleteMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ id: "archive-7680" }),
+      "oldest.png",
+    );
+    expect(wrapper.find("[data-test='grid-keys']").text()).toBe(
+      "archive-7680|oldest.png",
+    );
+  });
+
   it("bulk delete routes each selected twin to its own host", async () => {
     const wrapper = mountPage();
     await flushPromises();

--- a/web/src/pages/LibraryPage.test.ts
+++ b/web/src/pages/LibraryPage.test.ts
@@ -63,6 +63,11 @@ vi.mock("../lib/multiHostGallery", async () => {
           hostLabel: "this server",
           ...e,
         })),
+        rawEntries: list.map((e) => ({
+          hostId: "origin",
+          hostLabel: "this server",
+          ...e,
+        })),
         reachableHostIds: ["origin"],
         unreachableHostIds: [],
         remoteHostCount: 0,
@@ -340,7 +345,7 @@ describe("LibraryPage", () => {
 
   it("reuse writes the form and routes to Create", async () => {
     const wrapper = await mounted();
-    await wrapper.find("[data-test='grid-open']").trigger("click");
+    await wrapper.find("[data-test='grid-open-last']").trigger("click");
     await wrapper.vm.$nextTick();
     await wrapper.find("[data-test='lb-reuse']").trigger("click");
     await flushPromises();
@@ -351,7 +356,7 @@ describe("LibraryPage", () => {
 
   it("reuse restores the selected model's family defaults", async () => {
     const wrapper = await mounted();
-    await wrapper.find("[data-test='grid-open-last']").trigger("click");
+    await wrapper.find("[data-test='grid-open']").trigger("click");
     await wrapper.vm.$nextTick();
     await wrapper.find("[data-test='lb-reuse']").trigger("click");
     await flushPromises();
@@ -365,7 +370,7 @@ describe("LibraryPage", () => {
     const wrapper = mountPage();
     await flushPromises();
 
-    await wrapper.find("[data-test='grid-open']").trigger("click");
+    await wrapper.find("[data-test='grid-open-last']").trigger("click");
     await wrapper.vm.$nextTick();
     await wrapper.find("[data-test='lb-delete']").trigger("click");
     await flushPromises();
@@ -474,11 +479,11 @@ describe("LibraryPage multi-host identity", () => {
     localStorage.clear();
   });
 
-  it("deletes a selected remote twin from every host that contains the print", async () => {
+  it("renders one logical twin and deletes it from every host", async () => {
     vi.useFakeTimers();
     const wrapper = mountPage();
     await flushPromises();
-    expect(wrapper.find("[data-test='grid-count']").text()).toBe("2");
+    expect(wrapper.find("[data-test='grid-count']").text()).toBe("1");
 
     // entries[0] is the studio copy.
     await wrapper.find("[data-test='grid-open']").trigger("click");
@@ -497,18 +502,50 @@ describe("LibraryPage multi-host identity", () => {
     expect(deleteMock).toHaveBeenCalledWith("twin.png");
   });
 
-  it("deletes a selected local twin from every host that contains the print", async () => {
+  it("keeps each physical twin visible in its owning host filter", async () => {
     vi.useFakeTimers();
     const wrapper = mountPage();
     await flushPromises();
 
-    await wrapper.find("[data-test='grid-open-last']").trigger("click");
+    const studio = wrapper
+      .findAll("[data-test='gallery-host-filter']")
+      .find((button) => button.text() === "studio");
+    expect(studio).toBeTruthy();
+    await studio!.trigger("click");
+    expect(wrapper.find("[data-test='grid-count']").text()).toBe("1");
+    expect(wrapper.find("[data-test='grid-keys']").text()).toBe(
+      "studio-7680|twin.png",
+    );
+
+    await wrapper.find("[data-test='grid-open']").trigger("click");
     await wrapper.vm.$nextTick();
     await wrapper.find("[data-test='lb-delete']").trigger("click");
     await flushPromises();
 
     expect(wrapper.text()).toContain("No prints yet");
 
+    vi.advanceTimersByTime(6000);
+    await flushPromises();
+    expect(deleteMock).toHaveBeenCalledWith("twin.png");
+    expect(hostDeleteMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "studio-7680" }),
+      "twin.png",
+    );
+  });
+
+  it("deletes everywhere from a non-representative host-filter copy", async () => {
+    vi.useFakeTimers();
+    const wrapper = mountPage();
+    await flushPromises();
+    const local = wrapper
+      .findAll("[data-test='gallery-host-filter']")
+      .find((button) => button.text() === "this server");
+    await local!.trigger("click");
+    await wrapper.find("[data-test='grid-open']").trigger("click");
+    await wrapper.find("[data-test='lb-delete']").trigger("click");
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("No prints yet");
     vi.advanceTimersByTime(6000);
     await flushPromises();
     expect(deleteMock).toHaveBeenCalledWith("twin.png");
@@ -564,7 +601,12 @@ describe("LibraryPage multi-host identity", () => {
     const wrapper = mountPage();
     await flushPromises();
 
-    await wrapper.find("[data-test='grid-open-last']").trigger("click");
+    const local = wrapper
+      .findAll("[data-test='gallery-host-filter']")
+      .find((button) => button.text() === "this server");
+    expect(local).toBeTruthy();
+    await local!.trigger("click");
+    await wrapper.find("[data-test='grid-open']").trigger("click");
     await wrapper.vm.$nextTick();
     await wrapper.find("[data-test='lb-source']").trigger("click");
     await flushPromises();

--- a/web/src/pages/LibraryPage.vue
+++ b/web/src/pages/LibraryPage.vue
@@ -62,7 +62,10 @@ import HistoryDrawer from "../components/library/HistoryDrawer.vue";
 import Lightbox from "../components/gallery/Lightbox.vue";
 import { setSequenceHandoff } from "../composables/useSequenceHandoff";
 import { useSequenceDraftStore } from "@studio/stores/sequenceDraft";
-import { sameLogicalGalleryPrint } from "@studio/lib/galleryPrintIdentity";
+import {
+  groupLogicalGalleryPrints,
+  sameLogicalGalleryPrint,
+} from "@studio/lib/galleryPrintIdentity";
 
 type FilterKind = "all" | "images" | "video";
 type ViewMode = "feed" | "grid";
@@ -81,6 +84,8 @@ function loadViewMode(): ViewMode {
 }
 
 const entries = ref<HostGalleryImage[]>([]);
+/** Concrete device copies retained behind the deduplicated All view. */
+const rawEntries = ref<HostGalleryImage[]>([]);
 const models = ref<ModelInfoExtended[]>([]);
 // Hosts whose /api/gallery failed this refresh (surfaced, not hidden), and
 // how many non-origin hosts were attempted (drives the honest count line).
@@ -212,7 +217,7 @@ const keyOf = (entry: GalleryImage) =>
   printKey(entry as { hostId?: string; filename: string });
 
 function entryForKey(key: string): HostGalleryImage | null {
-  return entries.value.find((e) => keyOf(e) === key) ?? null;
+  return rawEntries.value.find((e) => keyOf(e) === key) ?? null;
 }
 
 /*
@@ -334,8 +339,15 @@ function deleteRouted(entry: GalleryImage): Promise<void> {
 }
 
 function copiesOf(entry: GalleryImage): HostGalleryImage[] {
-  return entries.value.filter((candidate) =>
+  return rawEntries.value.filter((candidate) =>
     sameLogicalGalleryPrint(entry, candidate),
+  );
+}
+
+function syncLogicalEntries(): void {
+  rawEntries.value.sort((a, b) => b.timestamp - a.timestamp);
+  entries.value = groupLogicalGalleryPrints(rawEntries.value).map(
+    (group) => group.representative,
   );
 }
 
@@ -361,7 +373,8 @@ async function handleDeleteMany(keys: string[]): Promise<number> {
     if (results[i]?.status === "fulfilled") deleted.add(t.key);
     else failed++;
   });
-  entries.value = entries.value.filter((e) => !deleted.has(keyOf(e)));
+  rawEntries.value = rawEntries.value.filter((e) => !deleted.has(keyOf(e)));
+  syncLogicalEntries();
   if (deleted.size > 0) {
     const next = new Set(selection.value);
     for (const key of deleted) next.delete(key);
@@ -426,7 +439,7 @@ async function deleteAllFiltered() {
 // ── Filtering ────────────────────────────────────────────────────────────────
 const hostOptions = computed(() => {
   const options = new Map<string, string>();
-  for (const entry of entries.value) {
+  for (const entry of rawEntries.value) {
     const id = entry.hostId ?? ORIGIN_HOST_ID;
     options.set(id, entry.hostLabel ?? getHost(id)?.name ?? id);
   }
@@ -436,7 +449,7 @@ const hostOptions = computed(() => {
 const hostFiltered = computed(() =>
   hostFilter.value === "all"
     ? entries.value
-    : entries.value.filter(
+    : rawEntries.value.filter(
         (entry) => (entry.hostId ?? ORIGIN_HOST_ID) === hostFilter.value,
       ),
 );
@@ -492,10 +505,11 @@ async function performRefresh() {
   errorMessage.value = null;
   try {
     const merged = await fetchMergedGallery(listHosts());
-    entries.value = merged.entries;
+    rawEntries.value = merged.rawEntries;
+    syncLogicalEntries();
     unreachableHostIds.value = merged.unreachableHostIds;
     remoteHostCount.value = merged.remoteHostCount;
-    reconcileFresh(merged.entries);
+    reconcileFresh(entries.value);
     // Only a total wipe-out (no host answered) is an error; one box down just
     // shows an "unreachable" note while the rest render.
     if (
@@ -682,13 +696,14 @@ async function onLightboxDelete(item: GalleryImage) {
   });
   if (!accepted) return;
   const key = keyOf(item);
-  const entryIdx = entries.value.findIndex((e) => keyOf(e) === key);
+  const entryIdx = rawEntries.value.findIndex((e) => keyOf(e) === key);
   if (entryIdx === -1) return;
   const removed = copiesOf(item);
   const removedKeys = new Set(removed.map((entry) => keyOf(entry)));
 
   // Optimistic removal; commit the DELETE only once the undo window elapses.
-  entries.value = entries.value.filter((e) => !removedKeys.has(keyOf(e)));
+  rawEntries.value = rawEntries.value.filter((e) => !removedKeys.has(keyOf(e)));
+  syncLogicalEntries();
   if (filtered.value.length === 0) {
     closeLightbox();
   } else {
@@ -703,9 +718,8 @@ async function onLightboxDelete(item: GalleryImage) {
   undoableAction({
     text: "Print deleted everywhere",
     undo: () => {
-      entries.value = [...entries.value, ...removed].sort(
-        (a, b) => b.timestamp - a.timestamp,
-      );
+      rawEntries.value = [...rawEntries.value, ...removed];
+      syncLogicalEntries();
     },
     commit: async () => {
       const results = await Promise.allSettled(
@@ -715,9 +729,8 @@ async function onLightboxDelete(item: GalleryImage) {
         (_, index) => results[index]?.status === "rejected",
       );
       if (failed.length > 0) {
-        entries.value = [...entries.value, ...failed].sort(
-          (a, b) => b.timestamp - a.timestamp,
-        );
+        rawEntries.value = [...rawEntries.value, ...failed];
+        syncLogicalEntries();
         toast(
           "error",
           `${failed.length} device ${failed.length === 1 ? "copy remains" : "copies remain"} because a delete failed.`,

--- a/web/src/pages/LibraryPage.vue
+++ b/web/src/pages/LibraryPage.vue
@@ -62,10 +62,7 @@ import HistoryDrawer from "../components/library/HistoryDrawer.vue";
 import Lightbox from "../components/gallery/Lightbox.vue";
 import { setSequenceHandoff } from "../composables/useSequenceHandoff";
 import { useSequenceDraftStore } from "@studio/stores/sequenceDraft";
-import {
-  groupLogicalGalleryPrints,
-  sameLogicalGalleryPrint,
-} from "@studio/lib/galleryPrintIdentity";
+import { groupLogicalGalleryPrints } from "@studio/lib/galleryPrintIdentity";
 
 type FilterKind = "all" | "images" | "video";
 type ViewMode = "feed" | "grid";
@@ -339,8 +336,11 @@ function deleteRouted(entry: GalleryImage): Promise<void> {
 }
 
 function copiesOf(entry: GalleryImage): HostGalleryImage[] {
-  return rawEntries.value.filter((candidate) =>
-    sameLogicalGalleryPrint(entry, candidate),
+  const key = keyOf(entry);
+  return (
+    groupLogicalGalleryPrints(rawEntries.value).find((group) =>
+      group.copies.some((copy) => keyOf(copy) === key),
+    )?.copies ?? []
   );
 }
 


### PR DESCRIPTION
## Summary

- deduplicate logical gallery prints across every connected-host combination on web and iPhone
- retain concrete per-host copies for host filters, media actions, and delete-everywhere behavior
- add desktop remote-to-remote coverage and shared representative-bounded legacy identity grouping
- address peer review feedback preventing transitive time-window grouping from hiding undeleted copies

## Validation

- `bunx vitest run ../studio/lib/galleryPrintIdentity.test.ts src/stores/gallery.test.ts src/mobile/MobileApp.test.ts` (177 passed)
- `bunx vue-tsc -b --pretty false` in `desktop/`
- `bunx vitest run src/lib/multiHostGallery.test.ts src/pages/LibraryPage.test.ts src/pages/LibraryPage.sequence.test.ts` (41 passed)
- `bun run build` in `web/`
- desktop and iPhone production frontend builds passed before the peer-review-only shared grouping correction
- rendered web QA with identical origin + remote copies: All showed one print; host filter retained the physical copy; no console errors or framework overlay