### PR TITLE
fix(studio): expose camera controls in LoRA stacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Auto-download camera controls now appear in the LoRA stack as soon as they are selected.** Web, desktop, and iPhone Create expose the adapter's strength immediately, preserve that strength when switching motions, remove the picker selection with the row, and send the displayed value instead of silently forcing camera adapters back to 1.0 at submit time. The iPhone LoRA disclosure opens automatically when the camera row arrives, and not-yet-installed presets retain a readable label while they download on first use.
 - **LTX-2 19B camera controls now download and run through real distilled inference.** The hidden single-file camera adapters no longer enter checkpoint configuration and fail after their verified bytes land. Distilled image-to-video requests with a LoRA stay on the native LTX-2 path and load the ordered adapter stack in both denoising stages, matching upstream, instead of silently producing the synthetic rainbow fallback while preserving only the opening source frame.
 
 ### Added

--- a/desktop/src/components/create/AdvancedSettings.test.ts
+++ b/desktop/src/components/create/AdvancedSettings.test.ts
@@ -338,6 +338,14 @@ describe("AdvancedSettings — video (LTX-2)", () => {
     expect(options[1]?.attributes("disabled")).toBeUndefined();
     await wrapper.get("[data-test='camera-motion']").setValue("dolly-in");
     expect(form.cameraControl).toBe("dolly-in");
+    expect(form.loras).toEqual([
+      {
+        path: "camera-control:dolly-in",
+        name: "Dolly in camera control",
+        scale: 1,
+        trainedWords: [],
+      },
+    ]);
   });
 
   it("keeps custom camera motion available when the host reports no built-ins", async () => {
@@ -359,11 +367,46 @@ describe("AdvancedSettings — video (LTX-2)", () => {
 
   it("reveals a custom camera-motion path input", async () => {
     const form = formFor("ltx2");
+    form.cameraControl = "dolly-in";
+    form.loras = [
+      {
+        path: "camera-control:dolly-in",
+        name: "Dolly in camera control",
+        scale: 0.45,
+        trainedWords: [],
+      },
+    ];
     const wrapper = mountSettings(form);
     await openSection(wrapper, "Video");
     await wrapper.get("[data-test='camera-motion']").setValue("custom");
     await wrapper.get("[data-test='camera-motion-custom']").setValue("/loras/pan.safetensors");
     expect(form.cameraControl).toBe("/loras/pan.safetensors");
+    expect(form.loras).toEqual([
+      {
+        path: "/loras/pan.safetensors",
+        name: "/loras/pan.safetensors",
+        scale: 0.45,
+        trainedWords: [],
+      },
+    ]);
+  });
+
+  it("disables new camera choices when all four LoRA slots are occupied", async () => {
+    const form = formFor("ltx2");
+    form.loras = ["one", "two", "three", "four"].map((path) => ({
+      path,
+      name: path,
+      scale: 1,
+      trainedWords: [],
+    }));
+    const wrapper = mountSettings(form, {
+      cameraControls: [cameraControl("dolly-in", false)],
+      cameraControlsLoaded: true,
+    });
+    await openSection(wrapper, "Video");
+    const options = wrapper.get("[data-test='camera-motion']").findAll("option");
+    expect(options[1]?.attributes()).toHaveProperty("disabled");
+    expect(options[2]?.attributes()).toHaveProperty("disabled");
   });
 });
 

--- a/desktop/src/components/create/AdvancedSettings.vue
+++ b/desktop/src/components/create/AdvancedSettings.vue
@@ -20,7 +20,11 @@ import type {
   Ltx2ControlAdapterInfo,
   OutputFormat,
 } from "../../lib/api/types";
-import { generationCapabilitiesForFamily, outputFormatsForFamily } from "../../lib/capabilities";
+import {
+  generationCapabilitiesForFamily,
+  MAX_LORA_STACK,
+  outputFormatsForFamily,
+} from "../../lib/capabilities";
 import { frames8n1Error, snapFrames } from "../../lib/chain";
 import {
   decideGenerateRequestRouting,
@@ -35,7 +39,13 @@ import {
   fpsValidationError,
 } from "../../lib/generateValidation";
 import { advancedActiveCount } from "../../lib/advancedCount";
-import { cameraMotionMode } from "@studio/lib/cameraMotion";
+import {
+  cameraMotionLoraPath,
+  cameraMotionLoraSlotAvailable,
+  cameraMotionLoraLabel,
+  cameraMotionMode,
+  syncCameraMotionLora,
+} from "@studio/lib/cameraMotion";
 import {
   canOfferExtend,
   extendNewFrames,
@@ -163,11 +173,37 @@ watch(
 function setCameraMode(mode: string) {
   uiCameraMode.value = mode;
   if (mode === "custom") {
-    if (cameraMotionMode(props.form.cameraControl) !== "custom") props.form.cameraControl = "";
+    if (cameraMotionMode(props.form.cameraControl) !== "custom") setCameraControl("");
   } else {
-    props.form.cameraControl = mode === "" ? null : mode;
+    setCameraControl(mode === "" ? null : mode);
   }
 }
+
+function setCameraControl(next: string | null) {
+  if (
+    cameraMotionLoraPath(next) &&
+    !cameraMotionLoraSlotAvailable(props.form.loras, props.form.cameraControl, MAX_LORA_STACK)
+  ) {
+    return;
+  }
+  props.form.loras = syncCameraMotionLora(
+    props.form.loras,
+    props.form.cameraControl,
+    next,
+    (path, scale) => ({
+      path,
+      name: cameraMotionLoraLabel(path),
+      scale,
+      trainedWords: [],
+    }),
+    MAX_LORA_STACK,
+  );
+  props.form.cameraControl = next;
+}
+
+const cameraSlotAvailable = computed(() =>
+  cameraMotionLoraSlotAvailable(props.form.loras, props.form.cameraControl, MAX_LORA_STACK),
+);
 
 const keyframePickerOpen = ref(false);
 const pipelineOptions: Ltx2PipelineMode[] = [
@@ -546,10 +582,15 @@ function reset() {
             @change="setCameraMode(($event.target as HTMLSelectElement).value)"
           >
             <option value="">None</option>
-            <option v-for="p in cameraControls" :key="p.id" :value="p.id">
+            <option
+              v-for="p in cameraControls"
+              :key="p.id"
+              :value="p.id"
+              :disabled="!cameraSlotAvailable"
+            >
               {{ p.label }}{{ p.installed ? "" : " · downloads on first use" }}
             </option>
-            <option value="custom">Custom LoRA path…</option>
+            <option value="custom" :disabled="!cameraSlotAvailable">Custom LoRA path…</option>
           </select>
           <input
             v-if="uiCameraMode === 'custom'"
@@ -560,7 +601,7 @@ function reset() {
             aria-label="Camera motion LoRA path"
             class="ms-input data-mono ms-input--mt"
             :value="form.cameraControl ?? ''"
-            @input="form.cameraControl = ($event.target as HTMLInputElement).value"
+            @input="setCameraControl(($event.target as HTMLInputElement).value)"
           />
           <p
             v-if="cameraControlsLoaded && cameraControls.length === 0"

--- a/desktop/src/components/create/InspectorPanel.vue
+++ b/desktop/src/components/create/InspectorPanel.vue
@@ -17,7 +17,11 @@ import type {
   Ltx2ControlAdapterInfo,
   ModelEntry,
 } from "../../lib/api/types";
-import { isCameraMotionPreset, parseCameraControlAvailability } from "@studio/lib/cameraMotion";
+import {
+  isCameraMotionPreset,
+  parseCameraControlAvailability,
+  syncCameraMotionLora,
+} from "@studio/lib/cameraMotion";
 import { apiJsonTo } from "../../lib/api/client";
 import {
   filterModelsForTarget,
@@ -132,6 +136,12 @@ watch(
         const compatible = (value: string | null) =>
           !value || !isCameraMotionPreset(value) || cameras.some((camera) => camera.id === value);
         if (!compatible(props.form.cameraControl)) {
+          props.form.loras = syncCameraMotionLora(
+            props.form.loras,
+            props.form.cameraControl,
+            null,
+            (path, scale) => ({ path, name: path, scale, trainedWords: [] }),
+          );
           props.form.cameraControl = null;
         }
         for (const clip of draft.clips) {

--- a/desktop/src/components/generate/LoraStack.vue
+++ b/desktop/src/components/generate/LoraStack.vue
@@ -4,6 +4,7 @@ import type { GenerateForm } from "../../lib/generateForm";
 import { MAX_LORA_STACK } from "../../lib/capabilities";
 import { fetchLoras } from "../../lib/api/loras";
 import type { LoraInfo } from "../../lib/api/types";
+import { cameraMotionLoraPath } from "@studio/lib/cameraMotion";
 
 const props = defineProps<{ form: GenerateForm; model: string }>();
 const emit = defineEmits<{ (e: "append-word", word: string): void }>();
@@ -39,7 +40,11 @@ function addLora(l: LoraInfo) {
 }
 
 function removeLora(index: number) {
+  const removed = props.form.loras[index];
   props.form.loras.splice(index, 1);
+  if (removed?.path === cameraMotionLoraPath(props.form.cameraControl)) {
+    props.form.cameraControl = null;
+  }
 }
 
 // Close and reset the picker when the model changes — the family may differ.

--- a/desktop/src/lib/generateForm.test.ts
+++ b/desktop/src/lib/generateForm.test.ts
@@ -251,6 +251,20 @@ describe("buildRequest — camera control (LTX-2 motion LoRA presets)", () => {
     expect(buildRequest(form).loras).toEqual([{ path: "camera-control:dolly-in", scale: 1.0 }]);
   });
 
+  it("uses the camera adapter strength edited in the visible LoRA stack", () => {
+    const form = ltx2Form();
+    form.cameraControl = "dolly-in";
+    form.loras = [
+      {
+        path: "camera-control:dolly-in",
+        name: "Dolly in camera control",
+        scale: 0.5,
+        trainedWords: [],
+      },
+    ];
+    expect(buildRequest(form).loras).toEqual([{ path: "camera-control:dolly-in", scale: 0.5 }]);
+  });
+
   it("appends the camera-control entry after user loras, preserving order", () => {
     const form = ltx2Form();
     form.loras = [{ path: "my-style.safetensors", name: "my-style", scale: 0.8, trainedWords: [] }];
@@ -713,6 +727,34 @@ describe("applyMetadataToForm", () => {
       skipStep: 1,
     });
     expect(form.outputFormat).toBe("mp4");
+  });
+
+  it("restores a camera preset and its strength from the saved LoRA stack", () => {
+    const form = newGenerateForm();
+    applyMetadataToForm(
+      form,
+      {
+        prompt: "a tracking shot",
+        model: "ltx2:q8",
+        seed: 7,
+        width: 768,
+        height: 512,
+        steps: 20,
+        guidance: 3,
+        loras: [{ path: "camera-control:dolly-in", scale: 0.45 }],
+      },
+      [ltx2Model()],
+    );
+
+    expect(form.cameraControl).toBe("dolly-in");
+    expect(form.loras).toEqual([
+      expect.objectContaining({
+        path: "camera-control:dolly-in",
+        name: "Dolly in camera control",
+        scale: 0.45,
+      }),
+    ]);
+    expect(buildRequest(form).loras).toEqual([{ path: "camera-control:dolly-in", scale: 0.45 }]);
   });
 
   it("promotes a legacy single lora/lora_scale pair into the stack", () => {

--- a/desktop/src/lib/generateForm.ts
+++ b/desktop/src/lib/generateForm.ts
@@ -28,6 +28,11 @@ import { coerceSourceFitForMaskless, type SourceFitPolicy } from "@studio/lib/so
 import { defaultVideoFps } from "@studio/lib/sequence";
 import { findInstalledModel } from "./generateModels";
 import {
+  cameraMotionFromLoraPath,
+  cameraMotionLoraLabel,
+  syncCameraMotionLora,
+} from "@studio/lib/cameraMotion";
+import {
   emptyGuidanceOverrides,
   guidanceOverridesFromWire,
   guidanceOverridesToWire,
@@ -223,6 +228,9 @@ export function cloneGenerateForm(form: GenerateForm): GenerateForm {
  * target the new variant's tensor layout.
  */
 export function applyModelDefaults(form: GenerateForm, m: ModelEntry): void {
+  const cameraRows = form.loras.filter(
+    (lora) => lora.path.startsWith("camera-control:") || lora.path === form.cameraControl?.trim(),
+  );
   form.width = m.default_width;
   form.height = m.default_height;
   form.steps = m.default_steps;
@@ -233,6 +241,19 @@ export function applyModelDefaults(form: GenerateForm, m: ModelEntry): void {
   form.loras = [];
   form.icLoraControl = null;
   reconcileModelCapabilities(form, m);
+  if (form.cameraControl) {
+    form.loras = syncCameraMotionLora(
+      cameraRows,
+      form.cameraControl,
+      form.cameraControl,
+      (path, scale) => ({
+        path,
+        name: cameraMotionLoraLabel(path),
+        scale,
+        trainedWords: [],
+      }),
+    );
+  }
 }
 
 /**
@@ -301,6 +322,12 @@ export function reconcileModelCapabilities(form: GenerateForm, m: ModelEntry): v
     form.temporalUpscale = null;
     form.guidanceOverrides = emptyGuidanceOverrides();
     form.audioFile = null;
+    form.loras = syncCameraMotionLora(form.loras, form.cameraControl, null, (path, scale) => ({
+      path,
+      name: path,
+      scale,
+      trainedWords: [],
+    }));
     form.cameraControl = null;
   }
 }
@@ -342,7 +369,7 @@ export function resetFormToModelDefaults(
 export function buildRequest(form: GenerateForm): GenerateRequest {
   const caps = generationCapabilitiesForFamily(form.family, form.model);
   const parsedSeed = form.seed.trim() === "" ? undefined : Number(form.seed);
-  const loras: LoraWeight[] = form.loras.map((l) => ({ path: l.path, scale: l.scale }));
+  let loras: LoraWeight[] = form.loras.map((l) => ({ path: l.path, scale: l.scale }));
 
   // Camera motion rides the ordinary loras[] stack (mirrors the CLI's
   // --camera-control, run.rs): presets ship as the `camera-control:<preset>`
@@ -351,11 +378,16 @@ export function buildRequest(form: GenerateForm): GenerateRequest {
   // authority; the serializer never guesses from a public model id.
   const cameraControl = form.cameraControl?.trim();
   if (caps.supportsAdvancedVideo && cameraControl) {
-    if (cameraControl.endsWith(".safetensors")) {
-      loras.push({ path: cameraControl, scale: 1.0 });
-    } else {
-      loras.push({ path: `camera-control:${cameraControl}`, scale: 1.0 });
-    }
+    loras = syncCameraMotionLora(
+      loras,
+      cameraControl,
+      cameraControl,
+      (path, scale) => ({
+        path,
+        scale,
+      }),
+      MAX_LORA_STACK,
+    );
   }
 
   const req: GenerateRequest = {
@@ -475,6 +507,7 @@ function normalizeMetadataScheduler(s: OutputMetadata["scheduler"]): Scheduler {
 
 /** Display name for a LoRA restored from metadata — the path's basename. */
 function loraNameFromPath(path: string): string {
+  if (cameraMotionFromLoraPath(path)) return cameraMotionLoraLabel(path);
   const base = path.split("/").pop() ?? path;
   return base.replace(/\.safetensors$/i, "");
 }
@@ -493,9 +526,6 @@ export function applyMetadataToForm(
   metadata: OutputMetadata,
   models: ModelEntry[] = [],
 ): void {
-  // Camera motion serializes as an ordinary LoRA. The metadata mapper below
-  // restores that stack directly, so a separate live camera selection would
-  // duplicate or contaminate the reused print.
   form.cameraControl = null;
   const model = findInstalledModel(models, metadata.model);
   if (model) {
@@ -527,6 +557,10 @@ export function applyMetadataToForm(
     scale: l.scale,
     trainedWords: [],
   }));
+  form.cameraControl =
+    form.loras
+      .map((lora) => cameraMotionFromLoraPath(lora.path))
+      .find((value): value is string => value !== null) ?? null;
 
   form.controlModel = metadata.control_model ?? "";
   if (metadata.control_scale != null) form.controlScale = metadata.control_scale;
@@ -624,6 +658,10 @@ export function applyRequestToForm(
     scale: lora.scale,
     trainedWords: [],
   }));
+  form.cameraControl =
+    form.loras
+      .map((lora) => cameraMotionFromLoraPath(lora.path))
+      .find((value): value is string => value !== null) ?? null;
   form.frames = request.frames ?? form.frames;
   form.fps = request.fps ?? form.fps;
   form.enableAudio = request.enable_audio ?? false;

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -69,7 +69,11 @@ import type {
   ModelEntry,
   ServerStatus,
 } from "../lib/api/types";
-import { isCameraMotionPreset, parseCameraControlAvailability } from "@studio/lib/cameraMotion";
+import {
+  isCameraMotionPreset,
+  parseCameraControlAvailability,
+  syncCameraMotionLora,
+} from "@studio/lib/cameraMotion";
 import { emptyGuidanceOverrides, guidanceOverridesAreEmpty } from "@studio/lib/guidanceOverrides";
 import {
   buildAutoChainRequest,
@@ -554,7 +558,15 @@ watch(
         cameraControlsLoaded.value = true;
         const compatible = (value: string | null) =>
           !value || !isCameraMotionPreset(value) || cameras.some((camera) => camera.id === value);
-        if (!compatible(form.cameraControl)) form.cameraControl = null;
+        if (!compatible(form.cameraControl)) {
+          form.loras = syncCameraMotionLora(
+            form.loras,
+            form.cameraControl,
+            null,
+            (path, scale) => ({ path, name: path, scale, trainedWords: [] }),
+          );
+          form.cameraControl = null;
+        }
         for (const clip of draft.clips) {
           if (!compatible(clip.cameraControl)) clip.cameraControl = null;
         }

--- a/desktop/src/mobile/MobileGenerateParameters.test.ts
+++ b/desktop/src/mobile/MobileGenerateParameters.test.ts
@@ -359,11 +359,28 @@ describe("MobileGenerateParameters", () => {
     await wrapper.get("[data-test='mobile-camera-motion']").setValue("dolly-in");
     expect(form.enableAudio).toBe(true);
     expect(form.cameraControl).toBe("dolly-in");
+    expect(form.loras).toEqual([
+      {
+        path: "camera-control:dolly-in",
+        name: "Dolly in camera control",
+        scale: 1,
+        trainedWords: [],
+      },
+    ]);
+    form.loras[0]!.scale = 0.45;
     await wrapper.get("[data-test='mobile-camera-motion']").setValue("custom");
     await wrapper
       .get("[data-test='mobile-camera-motion-custom']")
       .setValue("/models/camera/custom.safetensors");
     expect(form.cameraControl).toBe("/models/camera/custom.safetensors");
+    expect(form.loras).toEqual([
+      {
+        path: "/models/camera/custom.safetensors",
+        name: "/models/camera/custom.safetensors",
+        scale: 0.45,
+        trainedWords: [],
+      },
+    ]);
 
     const disclosure = wrapper.get("[data-test='mobile-ltx2-disclosure']");
     expect(disclosure.attributes("aria-expanded")).toBe("false");
@@ -401,6 +418,20 @@ describe("MobileGenerateParameters", () => {
     expect(form.retakeRange).toBeNull();
     await attachFile(wrapper, "[data-test='mobile-ltx2-audio-file']", new File(["a"], "voice.wav"));
     expect(form.audioFile).toEqual({ filename: "voice.wav", base64: "b64:voice.wav" });
+  });
+
+  it("disables new camera choices when all four LoRA slots are occupied", () => {
+    const initial = formFor("ltx2", "ltx-2-19b-distilled:fp8");
+    initial.loras = ["one", "two", "three", "four"].map((path) => ({
+      path,
+      name: path,
+      scale: 1,
+      trainedWords: [],
+    }));
+    const { wrapper } = mountParameters(initial);
+    const options = wrapper.get("[data-test='mobile-camera-motion']").findAll("option");
+    expect(options[1]?.attributes()).toHaveProperty("disabled");
+    expect(options[2]?.attributes()).toHaveProperty("disabled");
   });
 
   it("edits guidance overrides and blocks invalid values before submission", async () => {

--- a/desktop/src/mobile/MobileGenerateParameters.vue
+++ b/desktop/src/mobile/MobileGenerateParameters.vue
@@ -8,7 +8,7 @@ import type {
   Ltx2TemporalUpscale,
   ModelEntry,
 } from "../lib/api/types";
-import { generationCapabilitiesForFamily } from "../lib/capabilities";
+import { generationCapabilitiesForFamily, MAX_LORA_STACK } from "../lib/capabilities";
 import { frames8n1Error, snapFrames } from "../lib/chain";
 import {
   decideGenerateRequestRouting,
@@ -28,7 +28,13 @@ import {
   type InlineGenerationMediaField,
 } from "../lib/generateValidation";
 import { fileToBase64, isStillImageFile } from "../lib/image";
-import { cameraMotionMode } from "@studio/lib/cameraMotion";
+import {
+  cameraMotionLoraPath,
+  cameraMotionLoraSlotAvailable,
+  cameraMotionLoraLabel,
+  cameraMotionMode,
+  syncCameraMotionLora,
+} from "@studio/lib/cameraMotion";
 import {
   canOfferExtend,
   extendNewFrames,
@@ -185,11 +191,37 @@ watch(
 function setCameraMode(mode: string): void {
   cameraMode.value = mode;
   if (mode === "custom") {
-    if (cameraMotionMode(props.form.cameraControl) !== "custom") props.form.cameraControl = "";
+    if (cameraMotionMode(props.form.cameraControl) !== "custom") setCameraControl("");
   } else {
-    props.form.cameraControl = mode || null;
+    setCameraControl(mode || null);
   }
 }
+
+function setCameraControl(next: string | null): void {
+  if (
+    cameraMotionLoraPath(next) &&
+    !cameraMotionLoraSlotAvailable(props.form.loras, props.form.cameraControl, MAX_LORA_STACK)
+  ) {
+    return;
+  }
+  props.form.loras = syncCameraMotionLora(
+    props.form.loras,
+    props.form.cameraControl,
+    next,
+    (path, scale) => ({
+      path,
+      name: cameraMotionLoraLabel(path),
+      scale,
+      trainedWords: [],
+    }),
+    MAX_LORA_STACK,
+  );
+  props.form.cameraControl = next;
+}
+
+const cameraSlotAvailable = computed(() =>
+  cameraMotionLoraSlotAvailable(props.form.loras, props.form.cameraControl, MAX_LORA_STACK),
+);
 
 function hasAdvancedVideoValue(): boolean {
   return !!(
@@ -668,10 +700,15 @@ const fpsErrorId = `mobile-fps-error-${useId()}`;
           @change="setCameraMode(($event.target as HTMLSelectElement).value)"
         >
           <option value="">None</option>
-          <option v-for="preset in cameraControls" :key="preset.id" :value="preset.id">
+          <option
+            v-for="preset in cameraControls"
+            :key="preset.id"
+            :value="preset.id"
+            :disabled="!cameraSlotAvailable"
+          >
             {{ preset.label }}{{ preset.installed ? "" : " · downloads on first use" }}
           </option>
-          <option value="custom">Custom LoRA path…</option>
+          <option value="custom" :disabled="!cameraSlotAvailable">Custom LoRA path…</option>
         </select>
       </label>
       <label
@@ -688,7 +725,7 @@ const fpsErrorId = `mobile-fps-error-${useId()}`;
           autocapitalize="none"
           placeholder="/path/to/lora.safetensors"
           :value="form.cameraControl ?? ''"
-          @input="form.cameraControl = ($event.target as HTMLInputElement).value"
+          @input="setCameraControl(($event.target as HTMLInputElement).value)"
         />
       </label>
       <p

--- a/desktop/src/mobile/MobileLoraControls.test.ts
+++ b/desktop/src/mobile/MobileLoraControls.test.ts
@@ -67,6 +67,55 @@ describe("MobileLoraControls", () => {
     expect(form.loras).toHaveLength(1);
   });
 
+  it("opens immediately when another control adds an auto-download LoRA", async () => {
+    const form = reactive(newGenerateForm());
+    form.model = "ltx-2-19b-distilled:fp8";
+    form.family = "ltx2";
+    const wrapper = mount(MobileLoraControls, { props: { form, target } });
+
+    form.loras.push({
+      path: "camera-control:dolly-in",
+      name: "Dolly in camera control",
+      scale: 1,
+      trainedWords: [],
+    });
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.get("[data-test='mobile-lora-disclosure']").attributes("aria-expanded")).toBe(
+      "true",
+    );
+    expect(wrapper.get("[data-test='mobile-lora-row']").text()).toContain(
+      "Dolly in camera control",
+    );
+  });
+
+  it("clears the camera picker when its LoRA row is removed", async () => {
+    const form = reactive(newGenerateForm());
+    form.model = "ltx-2-19b-distilled:fp8";
+    form.family = "ltx2";
+    form.cameraControl = "dolly-in";
+    form.loras = [
+      {
+        path: "camera-control:dolly-in",
+        name: "Dolly in camera control",
+        scale: 0.5,
+        trainedWords: [],
+      },
+    ];
+    const wrapper = mount(MobileLoraControls, { props: { form, target } });
+
+    await wrapper.vm.$nextTick();
+    if (
+      wrapper.get("[data-test='mobile-lora-disclosure']").attributes("aria-expanded") === "false"
+    ) {
+      await wrapper.get("[data-test='mobile-lora-disclosure']").trigger("click");
+    }
+    await wrapper.get("[data-test='mobile-lora-remove-0']").trigger("click");
+
+    expect(form.loras).toEqual([]);
+    expect(form.cameraControl).toBeNull();
+  });
+
   it("reloads the available adapters when generation moves to another host", async () => {
     const form = reactive(newGenerateForm());
     form.model = "flux:fp16";

--- a/desktop/src/mobile/MobileLoraControls.vue
+++ b/desktop/src/mobile/MobileLoraControls.vue
@@ -6,6 +6,7 @@ import { fetchLoras } from "../lib/api/loras";
 import type { LoraInfo } from "../lib/api/types";
 import { MAX_LORA_STACK, generationCapabilitiesForFamily } from "../lib/capabilities";
 import type { GenerateForm } from "../lib/generateForm";
+import { cameraMotionLoraPath } from "@studio/lib/cameraMotion";
 
 const props = defineProps<{
   form: GenerateForm;
@@ -65,7 +66,11 @@ function add(lora: LoraInfo): void {
 }
 
 function remove(index: number): void {
+  const removed = props.form.loras[index];
   props.form.loras.splice(index, 1);
+  if (removed?.path === cameraMotionLoraPath(props.form.cameraControl)) {
+    props.form.cameraControl = null;
+  }
 }
 
 watch(
@@ -76,6 +81,13 @@ watch(
     available.value = [];
     error.value = "";
     if (open.value) void load();
+  },
+);
+
+watch(
+  () => props.form.loras.length,
+  (length, previous) => {
+    if (length > previous) open.value = true;
   },
 );
 

--- a/studio/lib/cameraMotion.test.ts
+++ b/studio/lib/cameraMotion.test.ts
@@ -1,9 +1,15 @@
 import { describe, expect, it } from "vitest";
 import {
   CAMERA_MOTION_PRESETS,
+  cameraMotionFromLoraPath,
+  cameraMotionLoraLabel,
+  cameraMotionLoraPath,
+  cameraMotionLoraSlotAvailable,
   cameraMotionMode,
   isCameraMotionPreset,
+  normalizeCameraMotionLoraState,
   parseCameraControlAvailability,
+  syncCameraMotionLora,
 } from "./cameraMotion";
 
 describe("camera motion presets", () => {
@@ -27,6 +33,110 @@ describe("camera motion presets", () => {
     expect(cameraMotionMode("   ")).toBe("custom");
     expect(cameraMotionMode("jib-up")).toBe("jib-up");
     expect(cameraMotionMode("/models/camera.safetensors")).toBe("custom");
+  });
+
+  it("maps camera choices onto their visible LoRA rows", () => {
+    expect(cameraMotionLoraPath("dolly-in")).toBe("camera-control:dolly-in");
+    expect(cameraMotionLoraPath(" /models/pan.safetensors ")).toBe(
+      "/models/pan.safetensors",
+    );
+    expect(cameraMotionFromLoraPath("camera-control:dolly-in")).toBe(
+      "dolly-in",
+    );
+    expect(cameraMotionLoraLabel("camera-control:dolly-in")).toBe(
+      "Dolly in camera control",
+    );
+  });
+
+  it("inserts, replaces, and removes the camera row without losing its strength", () => {
+    const create = (path: string, scale: number) => ({ path, scale });
+    const selected = syncCameraMotionLora(
+      [{ path: "style.safetensors", scale: 0.7 }],
+      null,
+      "dolly-in",
+      create,
+    );
+    expect(selected).toEqual([
+      { path: "style.safetensors", scale: 0.7 },
+      { path: "camera-control:dolly-in", scale: 1 },
+    ]);
+
+    selected[1]!.scale = 0.45;
+    const switched = syncCameraMotionLora(
+      selected,
+      "dolly-in",
+      "dolly-right",
+      create,
+    );
+    expect(switched).toEqual([
+      { path: "style.safetensors", scale: 0.7 },
+      { path: "camera-control:dolly-right", scale: 0.45 },
+    ]);
+    expect(syncCameraMotionLora(switched, "dolly-right", null, create)).toEqual(
+      [{ path: "style.safetensors", scale: 0.7 }],
+    );
+  });
+
+  it("keeps the previous strength while a custom path is being entered", () => {
+    const create = (path: string, scale: number) => ({ path, scale });
+    const selected = [{ path: "camera-control:dolly-in", scale: 0.45 }];
+
+    const editing = syncCameraMotionLora(selected, "dolly-in", "", create);
+    expect(editing).toEqual(selected);
+    expect(
+      syncCameraMotionLora(editing, "", "/models/custom.safetensors", create),
+    ).toEqual([{ path: "/models/custom.safetensors", scale: 0.45 }]);
+  });
+
+  it("does not displace an existing LoRA when all stack slots are occupied", () => {
+    const full = ["one", "two", "three", "four"].map((path) => ({
+      path,
+      scale: 1,
+    }));
+    expect(cameraMotionLoraSlotAvailable(full, null, 4)).toBe(false);
+    expect(
+      syncCameraMotionLora(
+        full,
+        null,
+        "dolly-in",
+        (path, scale) => ({ path, scale }),
+        4,
+      ),
+    ).toEqual(full);
+  });
+
+  it("normalizes restored camera aliases and legacy picker-only state", () => {
+    const create = (path: string, scale: number) => ({ path, scale });
+    expect(
+      normalizeCameraMotionLoraState(
+        [{ path: "camera-control:dolly-in", scale: 0.45 }],
+        null,
+        create,
+        4,
+      ),
+    ).toEqual({
+      loras: [{ path: "camera-control:dolly-in", scale: 0.45 }],
+      cameraControl: "dolly-in",
+    });
+    expect(normalizeCameraMotionLoraState([], "jib-up", create, 4)).toEqual({
+      loras: [{ path: "camera-control:jib-up", scale: 1 }],
+      cameraControl: "jib-up",
+    });
+  });
+
+  it("clears an unrepresentable legacy camera selection from a full stack", () => {
+    const full = ["one", "two", "three", "four"].map((path) => ({
+      path,
+      scale: 1,
+    }));
+    expect(
+      normalizeCameraMotionLoraState(
+        full,
+        "dolly-in",
+        (path, scale) => ({ path, scale }),
+        4,
+      ),
+    ).toEqual({ loras: full, cameraControl: null });
   });
 
   it("reads a legacy bare-array response from an older host", () => {

--- a/studio/lib/cameraMotion.ts
+++ b/studio/lib/cameraMotion.ts
@@ -38,6 +38,138 @@ export function cameraMotionLabel(value: string): string {
   );
 }
 
+/** The ordinary LoRA-stack path used by the server for a camera choice. */
+export function cameraMotionLoraPath(value: string | null): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+  return trimmed.endsWith(".safetensors") || trimmed.includes("/")
+    ? trimmed
+    : `camera-control:${trimmed}`;
+}
+
+/** Recover a built-in camera choice from an ordinary LoRA-stack row. */
+export function cameraMotionFromLoraPath(path: string): string | null {
+  const preset = path.startsWith("camera-control:")
+    ? path.slice("camera-control:".length)
+    : null;
+  return preset && isCameraMotionPreset(preset) ? preset : null;
+}
+
+/** User-facing fallback for auto-download rows that are not installed yet. */
+export function cameraMotionLoraLabel(path: string): string {
+  const preset = cameraMotionFromLoraPath(path);
+  return preset ? `${cameraMotionLabel(preset)} camera control` : path;
+}
+
+export interface CameraMotionLoraRow {
+  path: string;
+  scale: number;
+}
+
+/** Whether the current stack can select/replace one camera adapter. */
+export function cameraMotionLoraSlotAvailable(
+  loras: readonly CameraMotionLoraRow[],
+  currentControl: string | null,
+  maxRows: number,
+): boolean {
+  const currentPath = cameraMotionLoraPath(currentControl);
+  return (
+    loras.length < maxRows ||
+    loras.some(
+      (row) =>
+        row.path === currentPath || row.path.startsWith("camera-control:"),
+    )
+  );
+}
+
+/**
+ * Keep the camera picker and the visible LoRA stack as one piece of state.
+ *
+ * A newly selected preset is inserted immediately, retaining the previous
+ * camera row's editable strength when the user switches motions. Existing
+ * ordinary LoRAs keep their order. The caller supplies display-only fields so
+ * web, desktop, and iPhone can share the state transition without sharing
+ * their surface-specific row types.
+ */
+export function syncCameraMotionLora<T extends CameraMotionLoraRow>(
+  loras: readonly T[],
+  previousControl: string | null,
+  nextControl: string | null,
+  create: (path: string, scale: number) => T,
+  maxRows = Number.POSITIVE_INFINITY,
+): T[] {
+  const previousPath = cameraMotionLoraPath(previousControl);
+  const nextPath = cameraMotionLoraPath(nextControl);
+  const presetIndex = loras.findIndex((row) =>
+    row.path.startsWith("camera-control:"),
+  );
+  const previousIndex = previousPath
+    ? loras.findIndex((row) => row.path === previousPath)
+    : -1;
+  const replaceIndex = previousIndex >= 0 ? previousIndex : presetIndex;
+  const existingNext = nextPath
+    ? loras.find((row) => row.path === nextPath)
+    : undefined;
+  const previous = replaceIndex >= 0 ? loras[replaceIndex] : undefined;
+  const scale = existingNext?.scale ?? previous?.scale ?? 1;
+  // Custom-path inputs pass through an intentional empty editing state. Keep
+  // the previous row alive so its user-edited strength can transfer to the
+  // completed path; `null` remains the explicit remove action.
+  if (nextControl !== null && !nextPath) return [...loras];
+  if (
+    nextPath &&
+    replaceIndex < 0 &&
+    !existingNext &&
+    loras.length >= maxRows
+  ) {
+    return [...loras];
+  }
+  const withoutCamera = loras.filter(
+    (row, index) =>
+      index !== replaceIndex &&
+      row.path !== nextPath &&
+      !row.path.startsWith("camera-control:"),
+  );
+
+  if (!nextPath) return withoutCamera;
+  const row = create(nextPath, scale);
+  const insertion =
+    replaceIndex < 0
+      ? withoutCamera.length
+      : Math.min(replaceIndex, withoutCamera.length);
+  return [
+    ...withoutCamera.slice(0, insertion),
+    row,
+    ...withoutCamera.slice(insertion),
+  ];
+}
+
+/** Normalize restored/persisted camera state without evicting user LoRAs. */
+export function normalizeCameraMotionLoraState<T extends CameraMotionLoraRow>(
+  loras: readonly T[],
+  cameraControl: string | null,
+  create: (path: string, scale: number) => T,
+  maxRows: number,
+): { loras: T[]; cameraControl: string | null } {
+  const inferred =
+    loras
+      .map((row) => cameraMotionFromLoraPath(row.path))
+      .find((value): value is string => value !== null) ?? null;
+  const control = cameraControl?.trim() || inferred;
+  if (!control) return { loras: [...loras], cameraControl: null };
+  if (!cameraMotionLoraSlotAvailable(loras, control, maxRows)) {
+    // A legacy snapshot can contain four ordinary LoRAs plus a camera picker
+    // value that was never represented in the stack. Preserve the four
+    // visible rows and clear the unrepresentable selection rather than
+    // silently evicting an adapter or dropping camera motion at submit time.
+    return { loras: [...loras], cameraControl: null };
+  }
+  return {
+    loras: syncCameraMotionLora(loras, control, control, create, maxRows),
+    cameraControl: control,
+  };
+}
+
 /** One camera-control preset as advertised by the selected host. */
 export interface CameraControlInfo {
   id: string;

--- a/web/src/components/LoraPicker.test.ts
+++ b/web/src/components/LoraPicker.test.ts
@@ -135,6 +135,16 @@ describe("LoraPicker — multi-LoRA stack", () => {
     expect(w.text()).toContain("moody lighting");
   });
 
+  it("renders an auto-download camera adapter before it is installed", async () => {
+    const w = mountPicker([{ path: "camera-control:dolly-in", scale: 0.5 }]);
+    await flushPromises();
+    const row = w.get("[data-test='lora-row']");
+    expect(row.get("select").text()).toContain("Dolly in camera control");
+    expect(
+      (row.get("input[type='range']").element as HTMLInputElement).value,
+    ).toBe("0.5");
+  });
+
   it("clicking a trigger-word chip emits append-prompt with the phrase", async () => {
     const w = mountPicker([
       {

--- a/web/src/components/LoraPicker.vue
+++ b/web/src/components/LoraPicker.vue
@@ -5,6 +5,7 @@ import Icon from "@ui/components/Icon.vue";
 import { fetchCatalogInstalled } from "../api";
 import type { CatalogEntryWire, LoraSelection } from "../types";
 import { MAX_LORA_STACK } from "../types";
+import { cameraMotionLoraLabel } from "@studio/lib/cameraMotion";
 
 defineOptions({ name: "LoraPicker" });
 
@@ -185,6 +186,9 @@ function addAnother() {
           @change="selectAt(index, $event)"
         >
           <option value="">— remove —</option>
+          <option v-if="!entryForPath(row.path)" :value="row.path">
+            {{ cameraMotionLoraLabel(row.path) }}
+          </option>
           <option
             v-for="e in filteredLoras"
             :key="e.id"

--- a/web/src/components/create/AdvancedDrawer.vue
+++ b/web/src/components/create/AdvancedDrawer.vue
@@ -52,6 +52,7 @@ import {
   type SourceFitMode,
 } from "@studio/lib/sourceFit";
 import {
+  cameraMotionLoraPath,
   cameraMotionMode,
   parseCameraControlAvailability,
   isCameraMotionPreset,
@@ -336,7 +337,14 @@ const seedModes = [
 
 // ── LoRA / placement passthrough ──────────────────────────────────────
 function setLoras(loras: LoraSelection[]) {
-  patch({ loras });
+  const cameraPath = cameraMotionLoraPath(props.modelValue.cameraControl);
+  patch({
+    loras,
+    cameraControl:
+      cameraPath && !loras.some((lora) => lora.path === cameraPath)
+        ? null
+        : props.modelValue.cameraControl,
+  });
 }
 function setPlacement(placement: DevicePlacement | null) {
   patch({ placement });

--- a/web/src/components/create/advanced/Ltx2VideoControls.test.ts
+++ b/web/src/components/create/advanced/Ltx2VideoControls.test.ts
@@ -194,6 +194,61 @@ describe("Ltx2VideoControls", () => {
     ]);
     await select.setValue("jib-up");
     expect(lastPatch(wrapper).cameraControl).toBe("jib-up");
+    expect(lastPatch(wrapper).loras).toEqual([
+      { path: "camera-control:jib-up", scale: 1, trainedWords: [] },
+    ]);
+
+    await wrapper.setProps({
+      modelValue: {
+        ...lastPatch(wrapper),
+        loras: [
+          { path: "camera-control:jib-up", scale: 0.45, trainedWords: [] },
+        ],
+      },
+    });
+    await select.setValue("custom");
+    await wrapper.setProps({ modelValue: lastPatch(wrapper) });
+    await wrapper
+      .get("[data-test='ltx2-camera-motion-custom']")
+      .setValue("/models/camera/custom.safetensors");
+    expect(lastPatch(wrapper).loras).toEqual([
+      {
+        path: "/models/camera/custom.safetensors",
+        scale: 0.45,
+        trainedWords: [],
+      },
+    ]);
+  });
+
+  it("disables camera choices when all four LoRA slots are occupied", async () => {
+    vi.mocked(fetch).mockImplementation(
+      async (input) =>
+        ({
+          ok: true,
+          json: async () =>
+            String(input).includes("ltx2-camera-controls")
+              ? [{ id: "dolly-in", label: "Dolly in", installed: false }]
+              : [],
+        }) as Response,
+    );
+    const wrapper = factory({
+      model: "ltx-2-19b-distilled:fp8",
+      loras: ["one", "two", "three", "four"].map((path) => ({
+        path,
+        scale: 1,
+        trainedWords: [],
+      })),
+    });
+    await vi.waitFor(() =>
+      expect(
+        wrapper.get("[data-test='ltx2-camera-motion']").findAll("option"),
+      ).toHaveLength(3),
+    );
+    const options = wrapper
+      .get("[data-test='ltx2-camera-motion']")
+      .findAll("option");
+    expect(options[1]?.attributes()).toHaveProperty("disabled");
+    expect(options[2]?.attributes()).toHaveProperty("disabled");
   });
 
   it("shows 19B guidance without disabled rows and accepts a custom camera LoRA", async () => {
@@ -219,6 +274,13 @@ describe("Ltx2VideoControls", () => {
     expect(lastPatch(wrapper).cameraControl).toBe(
       "/models/camera/pan.safetensors",
     );
+    expect(lastPatch(wrapper).loras).toEqual([
+      {
+        path: "/models/camera/pan.safetensors",
+        scale: 1,
+        trainedWords: [],
+      },
+    ]);
   });
 
   it("maps the spatial segmented control to the upscale field", async () => {

--- a/web/src/components/create/advanced/Ltx2VideoControls.vue
+++ b/web/src/components/create/advanced/Ltx2VideoControls.vue
@@ -23,11 +23,15 @@ import type {
   SourceImageState,
   SourceMediaState,
 } from "../../../types";
+import { MAX_LORA_STACK } from "../../../types";
 import { blobToBase64 } from "../../../lib/base64";
 import {
+  cameraMotionLoraPath,
+  cameraMotionLoraSlotAvailable,
   cameraMotionMode,
   isCameraMotionPreset,
   parseCameraControlAvailability,
+  syncCameraMotionLora,
 } from "@studio/lib/cameraMotion";
 import {
   DEFAULT_EXTEND_OVERLAP_FRAMES,
@@ -117,7 +121,7 @@ watch(
             (camera) => camera.id === props.modelValue.cameraControl,
           )
         ) {
-          patch({ cameraControl: null });
+          setCameraControl(null);
         }
       })
       .catch(() => {
@@ -134,6 +138,37 @@ watch(
 function patch(next: Partial<GenerateFormState>) {
   emit("update:modelValue", { ...props.modelValue, ...next });
 }
+
+function setCameraControl(next: string | null) {
+  if (
+    cameraMotionLoraPath(next) &&
+    !cameraMotionLoraSlotAvailable(
+      props.modelValue.loras,
+      props.modelValue.cameraControl,
+      MAX_LORA_STACK,
+    )
+  ) {
+    return;
+  }
+  patch({
+    cameraControl: next,
+    loras: syncCameraMotionLora(
+      props.modelValue.loras,
+      props.modelValue.cameraControl,
+      next,
+      (path, scale) => ({ path, scale, trainedWords: [] }),
+      MAX_LORA_STACK,
+    ),
+  });
+}
+
+const cameraSlotAvailable = computed(() =>
+  cameraMotionLoraSlotAvailable(
+    props.modelValue.loras,
+    props.modelValue.cameraControl,
+    MAX_LORA_STACK,
+  ),
+);
 
 // ── Audio decode toggle ───────────────────────────────────────────────
 // enableAudio is boolean | null; null lets the server default (on for MP4).
@@ -185,10 +220,10 @@ function setCameraMode(raw: string) {
   cameraMode.value = raw;
   if (raw === "custom") {
     if (cameraMotionMode(props.modelValue.cameraControl) !== "custom")
-      patch({ cameraControl: "" });
+      setCameraControl("");
     return;
   }
-  patch({ cameraControl: raw || null });
+  setCameraControl(raw || null);
 }
 
 // ── Spatial / temporal upscale (segmented; "" = native) ───────────────
@@ -441,11 +476,14 @@ function removeKeyframe(index: number) {
           v-for="preset in cameraControls"
           :key="preset.id"
           :value="preset.id"
+          :disabled="!cameraSlotAvailable"
         >
           {{ preset.label
           }}{{ preset.installed ? "" : " · downloads on first use" }}
         </option>
-        <option value="custom">Custom LoRA path…</option>
+        <option value="custom" :disabled="!cameraSlotAvailable">
+          Custom LoRA path…
+        </option>
       </select>
       <input
         v-if="cameraMode === 'custom'"
@@ -453,9 +491,7 @@ function removeKeyframe(index: number) {
         data-test="ltx2-camera-motion-custom"
         placeholder="/path/to/lora.safetensors"
         :value="modelValue.cameraControl ?? ''"
-        @input="
-          patch({ cameraControl: ($event.target as HTMLInputElement).value })
-        "
+        @input="setCameraControl(($event.target as HTMLInputElement).value)"
       />
       <p
         v-if="cameraControlsLoaded && cameraControls.length === 0"

--- a/web/src/composables/useGenerateForm.test.ts
+++ b/web/src/composables/useGenerateForm.test.ts
@@ -1267,4 +1267,44 @@ describe("generate form serialization helpers", () => {
       { path: "/loras/two.safetensors", scale: 1.1 },
     ]);
   });
+
+  it("does not infer camera motion from a metadata LoRA beyond the visible cap", () => {
+    const current = makeForm();
+    const next = applyMetadataToForm(
+      current,
+      {
+        prompt: "tracking shot",
+        model: "ltx-2-19b-distilled:fp8",
+        seed: 7,
+        steps: 8,
+        guidance: 3,
+        width: 768,
+        height: 512,
+        version: "0.1.0",
+        loras: [
+          { path: "one", scale: 1 },
+          { path: "two", scale: 1 },
+          { path: "three", scale: 1 },
+          { path: "four", scale: 1 },
+          { path: "camera-control:dolly-in", scale: 0.45 },
+        ],
+      },
+      {
+        models: [
+          makeModel({
+            name: "ltx-2-19b-distilled:fp8",
+            family: "ltx2",
+          }),
+        ],
+      },
+    );
+
+    expect(next.loras.map((lora) => lora.path)).toEqual([
+      "one",
+      "two",
+      "three",
+      "four",
+    ]);
+    expect(next.cameraControl).toBeNull();
+  });
 });

--- a/web/src/composables/useGenerateForm.test.ts
+++ b/web/src/composables/useGenerateForm.test.ts
@@ -142,6 +142,51 @@ describe("useGenerateForm", () => {
     expect(form.state.value.stylePreset).toBe("cinematic");
   });
 
+  it("upgrades a version 3 camera picker value into the visible LoRA stack", () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: 3,
+        model: "ltx-2-19b-distilled:fp8",
+        modelFamily: "ltx2",
+        cameraControl: "dolly-in",
+        loras: [],
+      }),
+    );
+
+    const form = useGenerateForm();
+    expect(form.state.value.cameraControl).toBe("dolly-in");
+    expect(form.state.value.loras).toEqual([
+      {
+        path: "camera-control:dolly-in",
+        scale: 1,
+        trainedWords: [],
+      },
+    ]);
+  });
+
+  it("clears a legacy picker-only camera value when all LoRA slots are occupied", () => {
+    const loras = ["one", "two", "three", "four"].map((path) => ({
+      path,
+      scale: 1,
+      trainedWords: [],
+    }));
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: 3,
+        model: "ltx-2-19b-distilled:fp8",
+        modelFamily: "ltx2",
+        cameraControl: "dolly-in",
+        loras,
+      }),
+    );
+
+    const form = useGenerateForm();
+    expect(form.state.value.cameraControl).toBeNull();
+    expect(form.state.value.loras).toEqual(loras);
+  });
+
   it("toRequest bakes the shared kit's style template without mutating the prompt", () => {
     const form = useGenerateForm();
     form.state.value.model = "flux2-klein:q4";
@@ -619,7 +664,18 @@ describe("useGenerateForm", () => {
     });
   });
 
-  it("reserves one LoRA slot for an LTX-2 camera control", () => {
+  it("uses the camera strength edited in the visible LoRA stack", () => {
+    const form = useGenerateForm();
+    form.state.value.model = "ltx-2-19b-distilled:fp8";
+    form.state.value.modelFamily = "ltx2";
+    form.state.value.cameraControl = "dolly-in";
+    form.state.value.loras = [{ path: "camera-control:dolly-in", scale: 0.45 }];
+    expect(form.toRequest().loras).toEqual([
+      { path: "camera-control:dolly-in", scale: 0.45 },
+    ]);
+  });
+
+  it("never evicts a user LoRA from a full stack to serialize camera control", () => {
     const form = useGenerateForm();
     form.state.value.model = "ltx-2-19b-distilled:fp8";
     form.state.value.modelFamily = "ltx2";
@@ -633,7 +689,7 @@ describe("useGenerateForm", () => {
       { path: "one", scale: 1 },
       { path: "two", scale: 1 },
       { path: "three", scale: 1 },
-      { path: "camera-control:dolly-in", scale: 1 },
+      { path: "four", scale: 1 },
     ]);
   });
 

--- a/web/src/composables/useGenerateForm.ts
+++ b/web/src/composables/useGenerateForm.ts
@@ -26,6 +26,12 @@ import {
 import { composeStyle } from "../lib/stylePresets";
 import { defaultVideoFps } from "@studio/lib/sequence";
 import {
+  cameraMotionFromLoraPath,
+  cameraMotionLoraPath,
+  normalizeCameraMotionLoraState,
+  syncCameraMotionLora,
+} from "@studio/lib/cameraMotion";
+import {
   emptyGuidanceOverrides,
   guidanceOverridesFromWire,
   guidanceOverridesToWire,
@@ -238,6 +244,19 @@ function modelDefaultsPatch(
     next.controlImage = null;
     next.controlModel = "";
   }
+  if (next.cameraControl) {
+    const cameraPath = cameraMotionLoraPath(next.cameraControl);
+    const cameraRows = current.loras.filter(
+      (lora) =>
+        lora.path === cameraPath || lora.path.startsWith("camera-control:"),
+    );
+    next.loras = syncCameraMotionLora(
+      cameraRows,
+      current.cameraControl,
+      next.cameraControl,
+      (path, scale) => ({ path, scale, trainedWords: [] }),
+    );
+  }
   return next;
 }
 
@@ -302,6 +321,9 @@ export function applyMetadataToForm(
         ]
       : []);
   const outputFormat = metadata.output_format ?? options.format ?? null;
+  const cameraControl =
+    loras.map((lora) => cameraMotionFromLoraPath(lora.path)).find(Boolean) ??
+    null;
   return {
     ...next,
     prompt: metadata.prompt ?? "",
@@ -322,6 +344,7 @@ export function applyMetadataToForm(
         ? metadata.strength
         : next.strength,
     loras: loras.slice(0, MAX_LORA_STACK),
+    cameraControl,
     controlModel: metadata.control_model ?? "",
     controlScale: metadata.control_scale ?? next.controlScale,
     upscaleModel: metadata.upscale_model ?? "",
@@ -464,13 +487,20 @@ function load(): GenerateFormState {
     if (parsed.version !== FORM_VERSION) {
       return defaultForm();
     }
-    return {
+    const restored = {
       ...defaultForm(),
       ...sanitizePersistedForm({
         ...defaultForm(),
         ...parsed,
       }),
     };
+    const camera = normalizeCameraMotionLoraState(
+      restored.loras,
+      restored.cameraControl,
+      (path, scale) => ({ path, scale, trainedWords: [] }),
+      MAX_LORA_STACK,
+    );
+    return { ...restored, ...camera };
   } catch {
     return defaultForm();
   }
@@ -614,13 +644,13 @@ export function useGenerateForm(): UseGenerateForm {
       const ltx2 = family === "ltx2" || family === "ltx-2";
       const cameraControl = s.cameraControl?.trim();
       if (ltx2 && cameraControl) {
-        loras = loras.slice(0, MAX_LORA_STACK - 1);
-        loras.push({
-          path: cameraControl.endsWith(".safetensors")
-            ? cameraControl
-            : `camera-control:${cameraControl}`,
-          scale: 1,
-        });
+        loras = syncCameraMotionLora(
+          loras,
+          cameraControl,
+          cameraControl,
+          (path, scale) => ({ path, scale }),
+          MAX_LORA_STACK,
+        );
       }
       // The style preset is baked into the OUTGOING request — prompt template
       // plus the preset's curated negative, merged after the user's own

--- a/web/src/composables/useGenerateForm.ts
+++ b/web/src/composables/useGenerateForm.ts
@@ -26,7 +26,6 @@ import {
 import { composeStyle } from "../lib/stylePresets";
 import { defaultVideoFps } from "@studio/lib/sequence";
 import {
-  cameraMotionFromLoraPath,
   cameraMotionLoraPath,
   normalizeCameraMotionLoraState,
   syncCameraMotionLora,
@@ -321,9 +320,12 @@ export function applyMetadataToForm(
         ]
       : []);
   const outputFormat = metadata.output_format ?? options.format ?? null;
-  const cameraControl =
-    loras.map((lora) => cameraMotionFromLoraPath(lora.path)).find(Boolean) ??
-    null;
+  const camera = normalizeCameraMotionLoraState(
+    loras.slice(0, MAX_LORA_STACK),
+    null,
+    (path, scale) => ({ path, scale }),
+    MAX_LORA_STACK,
+  );
   return {
     ...next,
     prompt: metadata.prompt ?? "",
@@ -343,8 +345,8 @@ export function applyMetadataToForm(
       metadata.strength !== undefined && metadata.strength !== null
         ? metadata.strength
         : next.strength,
-    loras: loras.slice(0, MAX_LORA_STACK),
-    cameraControl,
+    loras: camera.loras,
+    cameraControl: camera.cameraControl,
     controlModel: metadata.control_model ?? "",
     controlScale: metadata.control_scale ?? next.controlScale,
     upscaleModel: metadata.upscale_model ?? "",

--- a/web/src/pages/CreatePage.test.ts
+++ b/web/src/pages/CreatePage.test.ts
@@ -1872,6 +1872,56 @@ describe("CreatePage layout and behavior", () => {
     expect(form.state.value.imageAttachments).toEqual([]);
   });
 
+  it("restores a queued camera LoRA into both the picker and visible stack", async () => {
+    const job = {
+      id: "camera-print",
+      request: {
+        prompt: "a tracking shot",
+        model: "ltx-2-19b-distilled:fp8",
+        width: 768,
+        height: 512,
+        steps: 8,
+        guidance: 3,
+        loras: [{ path: "camera-control:dolly-in", scale: 0.45 }],
+      },
+      startedAt: 0,
+      controller: new AbortController(),
+      progress: {
+        stage: "Queued",
+        step: null,
+        totalSteps: null,
+        weightBytesLoaded: null,
+        weightBytesTotal: null,
+        queuePosition: null,
+        gpu: null,
+        elapsedMs: null,
+      },
+      result: null,
+      error: null,
+      state: "running",
+      chain: null,
+      lastProgressAt: 0,
+      workStarted: false,
+      serverId: null,
+    } as Job;
+    streamJobsRef.value = [job];
+    const form = useGenerateForm();
+    const wrapper = mount(CreatePage, { global: { stubs: pageStubs() } });
+    await flushPromises();
+
+    wrapper.getComponent({ name: "ActivityStrip" }).vm.$emit("open", job);
+    await nextTick();
+
+    expect(form.state.value.cameraControl).toBe("dolly-in");
+    expect(form.state.value.loras).toEqual([
+      {
+        path: "camera-control:dolly-in",
+        scale: 0.45,
+        trainedWords: [],
+      },
+    ]);
+  });
+
   it("deletes settled durable jobs through the strip's Delete action", async () => {
     listChainJobsMock.mockResolvedValue({
       jobs: [

--- a/web/src/pages/CreatePage.vue
+++ b/web/src/pages/CreatePage.vue
@@ -43,6 +43,7 @@ import {
   type SourceResolutionResult,
 } from "@studio/lib/sourceResolution";
 import { copyableError, describeTransportError } from "@studio/lib/errors";
+import { normalizeCameraMotionLoraState } from "@studio/lib/cameraMotion";
 import {
   guidanceOverrideCount,
   guidanceOverridesError,
@@ -148,6 +149,7 @@ import type {
   SourceFitPolicy,
   SourceImageState,
 } from "../types";
+import { MAX_LORA_STACK } from "../types";
 function loadMuted(): boolean {
   try {
     return localStorage.getItem("mold.gallery.muted") !== "false";
@@ -2738,6 +2740,14 @@ function openJob(job: Job) {
   form.state.value.loras = (
     request.loras ?? (request.lora ? [request.lora] : [])
   ).map((lora) => ({ ...lora, trainedWords: [] }));
+  const camera = normalizeCameraMotionLoraState(
+    form.state.value.loras,
+    null,
+    (path, scale) => ({ path, scale, trainedWords: [] }),
+    MAX_LORA_STACK,
+  );
+  form.state.value.loras = camera.loras;
+  form.state.value.cameraControl = camera.cameraControl;
   form.state.value.frames = request.frames ?? null;
   form.state.value.fps = request.fps ?? null;
   form.state.value.enableAudio = request.enable_audio ?? null;


### PR DESCRIPTION
## Summary

- add install-on-demand camera controls to the visible LoRA stack immediately across web, desktop, and iPhone Create
- keep camera selection, removal, strength edits, model changes, persistence, metadata reuse, and queued-job restore synchronized
- preserve the four-LoRA cap without evicting user adapters and retain readable labels before first-use downloads

## Verification

- `bun run check:architecture`
- `bun run check:dead-code`
- `bun run test:studio` (364 tests)
- `cd web && bun run test` (1,145 tests)
- `cd desktop && bun run test` (2,853 tests)
- web, desktop, and mobile production builds
- `scripts/tests/ios-release-assets.sh`
- rendered browser QA: selecting Dolly in immediately shows a labeled LoRA row and weight slider
- pre-push subagent peer review completed; all findings addressed, final pass clean

Plato/deployment diagnosis is intentionally out of scope per request.