### PR TITLE
feat(studio): add model-aware video duration controls

### DIFF
--- a/crates/mold-tui/src/app.rs
+++ b/crates/mold-tui/src/app.rs
@@ -394,6 +394,7 @@ pub enum ParamField {
     Guidance,
     Seed,
     Batch,
+    Duration,
     // Advanced — Sampling
     Scheduler,
     Expand,
@@ -424,6 +425,7 @@ impl ParamField {
             Self::Guidance => "Prompt strength",
             Self::Seed => "Seed",
             Self::Batch => "Batch",
+            Self::Duration => "Duration",
             Self::Format => "Format",
             Self::Scheduler => "Scheduler",
             Self::Lora => "LoRA",
@@ -667,6 +669,13 @@ impl GenerateParams {
                 ),
             },
             ParamField::Batch => self.batch.to_string(),
+            ParamField::Duration => {
+                format!(
+                    "{:.1}s · {}f",
+                    self.frames as f64 / self.fps.max(1) as f64,
+                    self.frames
+                )
+            }
             ParamField::Format => format!("{:?}", self.format).to_lowercase(),
             ParamField::Upscale => self.upscale_model.clone().unwrap_or_else(|| "off".into()),
             ParamField::Scheduler => self
@@ -732,6 +741,20 @@ impl GenerateParams {
             ParamField::ControlScale => format!("{:.1}", self.control_scale),
         }
     }
+}
+
+/// Mirror `/api/models`' requestable video grid for the TUI's keyboard sliders.
+/// Tuple fields are `(step, runtime_seconds, absolute_frames, fixed_frames)`.
+fn tui_max_video_frames(grid: (u32, Option<u32>, Option<u32>, u32), fps: u32) -> u32 {
+    let (step, runtime_seconds, absolute_frames, fixed_frames) = grid;
+    let cap = if let Some(seconds) = runtime_seconds {
+        let duration_cap = seconds.saturating_mul(fps.max(1)).saturating_add(4);
+        absolute_frames.map_or(duration_cap, |absolute| duration_cap.min(absolute))
+    } else {
+        fixed_frames
+    };
+    cap.saturating_sub(cap.saturating_sub(1) % step)
+        .max(step + 1)
 }
 
 /// State for the Generate view.
@@ -1797,7 +1820,7 @@ impl App {
 
     /// Apply model defaults from the server's catalog to the current model.
     /// When connected remotely, the server's config is authoritative for steps,
-    /// guidance, width, and height.
+    /// guidance, size, and video timing.
     fn apply_remote_model_defaults(&mut self, catalog: &[ModelInfoExtended]) {
         let model_name = &self.generate.params.model;
         if let Some(entry) = catalog.iter().find(|m| &m.name == model_name) {
@@ -1805,6 +1828,12 @@ impl App {
             self.generate.params.guidance = entry.defaults.default_guidance;
             self.generate.params.width = entry.defaults.default_width;
             self.generate.params.height = entry.defaults.default_height;
+            if let Some(frames) = entry.defaults.default_frames {
+                self.generate.params.frames = frames;
+            }
+            if let Some(fps) = entry.defaults.default_fps {
+                self.generate.params.fps = fps;
+            }
             if !entry.defaults.description.is_empty() {
                 self.generate.model_description = entry.defaults.description.clone();
             }
@@ -2150,6 +2179,12 @@ impl App {
                 self.generate.params.guidance = entry.defaults.default_guidance;
                 self.generate.params.width = entry.defaults.default_width;
                 self.generate.params.height = entry.defaults.default_height;
+                if let Some(frames) = entry.defaults.default_frames {
+                    self.generate.params.frames = frames;
+                }
+                if let Some(fps) = entry.defaults.default_fps {
+                    self.generate.params.fps = fps;
+                }
                 if !entry.defaults.description.is_empty() {
                     self.generate.model_description = entry.defaults.description.clone();
                 }
@@ -2167,6 +2202,12 @@ impl App {
             self.generate.params.guidance = model_cfg.effective_guidance();
             self.generate.params.width = model_cfg.effective_width(&self.config);
             self.generate.params.height = model_cfg.effective_height(&self.config);
+            if let Some(frames) = model_cfg.effective_frames() {
+                self.generate.params.frames = frames;
+            }
+            if let Some(fps) = model_cfg.effective_fps() {
+                self.generate.params.fps = fps;
+            }
 
             self.generate.model_description = mold_core::manifest::find_manifest(&model_name)
                 .and_then(|m| {
@@ -3807,6 +3848,38 @@ impl App {
         } else {
             None
         };
+        let video_grid = if matches!(
+            field,
+            ParamField::Duration | ParamField::Frames | ParamField::Fps
+        ) {
+            let entry = self
+                .models
+                .catalog
+                .iter()
+                .find(|entry| entry.name == self.generate.params.model);
+            let family =
+                crate::model_info::family_for_model(&self.generate.params.model, &self.config);
+            let step = entry
+                .and_then(|entry| entry.defaults.frame_step)
+                .or_else(|| mold_core::validation::frame_step_for_family(&family))
+                .unwrap_or(8)
+                .max(1);
+            Some((
+                step,
+                entry
+                    .and_then(|entry| entry.defaults.max_runtime_seconds)
+                    .or_else(|| mold_core::validation::max_runtime_seconds_for_family(&family)),
+                entry
+                    .and_then(|entry| entry.defaults.max_frames_absolute)
+                    .or_else(|| mold_core::validation::max_frames_absolute_for_family(&family)),
+                entry
+                    .and_then(|entry| entry.defaults.max_frames)
+                    .or_else(|| mold_core::validation::max_frames_for_family(&family))
+                    .unwrap_or(257),
+            ))
+        } else {
+            None
+        };
         let p = &mut self.generate.params;
         match field {
             ParamField::Size => {
@@ -3844,14 +3917,30 @@ impl App {
             ParamField::Batch => {
                 p.batch = (p.batch as i32 + delta).max(1) as u32;
             }
+            ParamField::Duration => {
+                let grid = video_grid.expect("duration has video grid");
+                let step = grid.0;
+                let fps = p.fps.max(1);
+                let seconds = (p.frames as f64 / fps as f64 + delta as f64).max(0.1);
+                let target = (seconds * fps as f64).round() as u32;
+                let snapped =
+                    (((target.saturating_sub(1) + step / 2) / step) * step + 1).max(step + 1);
+                p.frames = snapped.min(tui_max_video_frames(grid, fps));
+            }
             ParamField::Strength => {
                 p.strength = (p.strength + delta as f64 * 0.05).clamp(0.0, 1.0);
             }
             ParamField::Frames => {
-                p.frames = (p.frames as i32 + delta * 8).clamp(9, 257) as u32;
+                let grid = video_grid.expect("frames has video grid");
+                let step = grid.0;
+                p.frames = (p.frames as i64 + delta as i64 * step as i64)
+                    .clamp((step + 1) as i64, tui_max_video_frames(grid, p.fps) as i64)
+                    as u32;
             }
             ParamField::Fps => {
                 p.fps = (p.fps as i32 + delta).clamp(1, 60) as u32;
+                let grid = video_grid.expect("fps has video grid");
+                p.frames = p.frames.min(tui_max_video_frames(grid, p.fps));
             }
             ParamField::Audio => {
                 p.enable_audio = match (p.enable_audio, delta >= 0) {
@@ -4483,6 +4572,8 @@ impl App {
     /// Restore the selected model's defaults (keeps model and prompt).
     fn reset_params_to_model_defaults(&mut self) {
         let model = self.generate.params.model.clone();
+        let mut default_frames = 25;
+        let mut default_fps = 24;
 
         // Use server catalog defaults when connected (and not in local mode),
         // local config otherwise
@@ -4493,12 +4584,24 @@ impl App {
         } {
             self.generate.params.width = entry.defaults.default_width;
             self.generate.params.height = entry.defaults.default_height;
+            if let Some(frames) = entry.defaults.default_frames {
+                default_frames = frames;
+            }
+            if let Some(fps) = entry.defaults.default_fps {
+                default_fps = fps;
+            }
             self.generate.params.steps = entry.defaults.default_steps;
             self.generate.params.guidance = entry.defaults.default_guidance;
         } else {
             let mc = self.config.resolved_model_config(&model);
             self.generate.params.width = mc.effective_width(&self.config);
             self.generate.params.height = mc.effective_height(&self.config);
+            if let Some(frames) = mc.effective_frames() {
+                default_frames = frames;
+            }
+            if let Some(fps) = mc.effective_fps() {
+                default_fps = fps;
+            }
             self.generate.params.steps = mc.effective_steps(&self.config);
             self.generate.params.guidance = mc.effective_guidance();
         }
@@ -4512,8 +4615,8 @@ impl App {
         self.generate.params.expand = false;
         self.generate.params.offload = false;
         self.generate.params.upscale_model = None;
-        self.generate.params.frames = 25;
-        self.generate.params.fps = 24;
+        self.generate.params.frames = default_frames;
+        self.generate.params.fps = default_fps;
         self.generate.params.enable_audio = None;
         self.generate.params.strength = 0.75;
         self.generate.params.source_image_path = None;
@@ -9606,6 +9709,14 @@ mod tests {
         );
     }
 
+    #[test]
+    fn video_duration_ceiling_tracks_fps_and_the_absolute_guard() {
+        let ltx2_grid = (8, Some(20), Some(604), 481);
+        assert_eq!(tui_max_video_frames(ltx2_grid, 12), 241);
+        assert_eq!(tui_max_video_frames(ltx2_grid, 24), 481);
+        assert_eq!(tui_max_video_frames(ltx2_grid, 48), 601);
+    }
+
     #[tokio::test]
     async fn seed_row_cycles_mode_with_arrows_and_enter_edits_value() {
         use crate::ui::create_form::CreateRow;
@@ -10579,14 +10690,11 @@ mod tests {
         crate::test_env::with_isolated_env(|_home| {
             let mut app = make_settings_test_app();
             app.server_url = Some("http://hal9000:7680".to_string());
-            app.models.catalog = vec![make_test_catalog_entry(
-                "flux-dev:q4",
-                28,
-                4.0,
-                768,
-                768,
-                "Server FLUX Dev Q4",
-            )];
+            let mut entry =
+                make_test_catalog_entry("flux-dev:q4", 28, 4.0, 768, 768, "Server FLUX Dev Q4");
+            entry.defaults.default_frames = Some(97);
+            entry.defaults.default_fps = Some(24);
+            app.models.catalog = vec![entry];
 
             app.update_model("flux-dev:q4");
 
@@ -10594,6 +10702,8 @@ mod tests {
             assert!((app.generate.params.guidance - 4.0).abs() < f64::EPSILON);
             assert_eq!(app.generate.params.width, 768);
             assert_eq!(app.generate.params.height, 768);
+            assert_eq!(app.generate.params.frames, 97);
+            assert_eq!(app.generate.params.fps, 24);
             assert_eq!(app.generate.model_description, "Server FLUX Dev Q4");
         });
     }
@@ -11522,11 +11632,21 @@ mod tests {
         crate::test_env::with_isolated_env(|_home| {
             let mut app = make_settings_test_app();
             app.server_url = None;
-            let model = app.config.resolved_default_model();
+            let model = "local-video:test".to_string();
+            app.config.models.insert(
+                model.clone(),
+                mold_core::config::ModelConfig {
+                    default_frames: Some(97),
+                    default_fps: Some(30),
+                    ..Default::default()
+                },
+            );
             app.update_model(&model);
             // Should succeed without panic and use local config defaults
             assert!(app.generate.params.steps > 0);
             assert!(app.generate.params.width > 0);
+            assert_eq!(app.generate.params.frames, 97);
+            assert_eq!(app.generate.params.fps, 30);
         });
     }
 
@@ -11652,6 +11772,14 @@ mod tests {
     async fn reset_defaults_uses_local_config_when_no_server() {
         let mut app = make_settings_test_app();
         app.server_url = None;
+        app.config.models.insert(
+            app.generate.params.model.clone(),
+            mold_core::config::ModelConfig {
+                default_frames: Some(97),
+                default_fps: Some(30),
+                ..Default::default()
+            },
+        );
 
         // Mutate params
         app.generate.params.steps = 999;
@@ -11671,6 +11799,8 @@ mod tests {
         // Should use local config defaults (steps won't be 999)
         assert_ne!(app.generate.params.steps, 999);
         assert_eq!(app.generate.params.batch, 1);
+        assert_eq!(app.generate.params.frames, 97);
+        assert_eq!(app.generate.params.fps, 30);
     }
 
     // ── sync_resource_info_mode() ─────────────────────────────

--- a/crates/mold-tui/src/app.rs
+++ b/crates/mold-tui/src/app.rs
@@ -753,8 +753,7 @@ fn tui_max_video_frames(grid: (u32, Option<u32>, Option<u32>, u32), fps: u32) ->
     } else {
         fixed_frames
     };
-    cap.saturating_sub(cap.saturating_sub(1) % step)
-        .max(step + 1)
+    cap.saturating_sub(cap.saturating_sub(1) % step).max(1)
 }
 
 /// State for the Generate view.
@@ -3923,8 +3922,7 @@ impl App {
                 let fps = p.fps.max(1);
                 let seconds = (p.frames as f64 / fps as f64 + delta as f64).max(0.1);
                 let target = (seconds * fps as f64).round() as u32;
-                let snapped =
-                    (((target.saturating_sub(1) + step / 2) / step) * step + 1).max(step + 1);
+                let snapped = ((target.saturating_sub(1) + step / 2) / step) * step + 1;
                 p.frames = snapped.min(tui_max_video_frames(grid, fps));
             }
             ParamField::Strength => {
@@ -3934,7 +3932,7 @@ impl App {
                 let grid = video_grid.expect("frames has video grid");
                 let step = grid.0;
                 p.frames = (p.frames as i64 + delta as i64 * step as i64)
-                    .clamp((step + 1) as i64, tui_max_video_frames(grid, p.fps) as i64)
+                    .clamp(1, tui_max_video_frames(grid, p.fps) as i64)
                     as u32;
             }
             ParamField::Fps => {
@@ -9715,6 +9713,7 @@ mod tests {
         assert_eq!(tui_max_video_frames(ltx2_grid, 12), 241);
         assert_eq!(tui_max_video_frames(ltx2_grid, 24), 481);
         assert_eq!(tui_max_video_frames(ltx2_grid, 48), 601);
+        assert_eq!(tui_max_video_frames((8, None, None, 1), 24), 1);
     }
 
     #[tokio::test]

--- a/crates/mold-tui/src/ui/create_form.rs
+++ b/crates/mold-tui/src/ui/create_form.rs
@@ -215,10 +215,15 @@ pub fn visible_rows(caps: &ModelCapabilities, adv: &AdvancedState) -> Vec<Create
         CreateRow::Field(ParamField::Size),
         CreateRow::Field(ParamField::Steps),
         CreateRow::Field(ParamField::Guidance),
+    ];
+    if caps.supports_video {
+        rows.push(CreateRow::Field(ParamField::Duration));
+    }
+    rows.extend([
         CreateRow::Field(ParamField::Seed),
         CreateRow::Field(ParamField::Batch),
         CreateRow::AdvancedHeader,
-    ];
+    ]);
     if adv.open {
         for sec in advanced_sections(caps) {
             rows.push(CreateRow::Section(sec));
@@ -487,11 +492,13 @@ mod tests {
         assert!(video_caps.supports_video);
         let rows = visible_rows(&video_caps, &open_state(None));
         assert!(rows.contains(&CreateRow::Section(AdvSection::Video)));
+        assert!(rows.contains(&CreateRow::Field(ParamField::Duration)));
 
         let image_caps = capabilities_for_family("flux");
         assert!(!image_caps.supports_video);
         let rows = visible_rows(&image_caps, &open_state(None));
         assert!(!rows.contains(&CreateRow::Section(AdvSection::Video)));
+        assert!(!rows.contains(&CreateRow::Field(ParamField::Duration)));
     }
 
     #[test]

--- a/desktop/src/components/create/AdvancedSettings.vue
+++ b/desktop/src/components/create/AdvancedSettings.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
 import AccordionSection from "@ui/components/AccordionSection.vue";
+import VideoDurationSlider from "@ui/components/VideoDurationSlider.vue";
 import SegmentedControl, { type SegmentOption } from "@ui/components/SegmentedControl.vue";
 import SwitchToggle from "@ui/components/SwitchToggle.vue";
 import Chip from "@ui/components/Chip.vue";
@@ -521,6 +522,13 @@ function reset() {
         :header-interactive="false"
         data-test="section-video"
       >
+        <VideoDurationSlider
+          :frames="form.frames"
+          :fps="form.fps"
+          :model="selectedModel"
+          @update:frames="form.frames = $event"
+        />
+
         <label class="ms-label">Frames</label>
         <input
           v-model.number="form.frames"

--- a/desktop/src/components/create/InspectorPanel.test.ts
+++ b/desktop/src/components/create/InspectorPanel.test.ts
@@ -6,6 +6,7 @@ import InspectorPanel from "./InspectorPanel.vue";
 import ShapePicker from "@ui/components/ShapePicker.vue";
 import ResolutionSelector from "@ui/components/ResolutionSelector.vue";
 import SliderRow from "@ui/components/SliderRow.vue";
+import VideoDurationSlider from "@ui/components/VideoDurationSlider.vue";
 import Stepper from "@ui/components/Stepper.vue";
 import BadgePill from "@ui/components/BadgePill.vue";
 import PanelResizeHandle from "../shell/PanelResizeHandle.vue";
@@ -43,6 +44,29 @@ describe("InspectorPanel — layout", () => {
     expect(wrapper.findComponent(Stepper).exists()).toBe(true);
     expect(wrapper.find('[data-test="seed-mode-random"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="open-advanced"]').exists()).toBe(true);
+  });
+
+  it("shows duration in seconds for the selected one-shot video model", async () => {
+    const model = {
+      name: "ltx-2-19b-distilled:fp8",
+      family: "ltx2",
+      default_frames: 97,
+      default_fps: 24,
+      max_runtime_seconds: 20,
+      max_frames_absolute: 604,
+      frame_step: 8,
+    } as ModelEntry;
+    useModelStore().all = [model];
+    const form = formFor("ltx2");
+    form.model = model.name;
+    form.frames = 97;
+    form.fps = 24;
+    const wrapper = mount(InspectorPanel, { props: { form } });
+    const duration = wrapper.getComponent(VideoDurationSlider);
+    expect(duration.text()).toContain("4.0s");
+    duration.vm.$emit("update:frames", 241);
+    await flushPromises();
+    expect(form.frames).toBe(241);
   });
 
   it("defaults wide enough for one ratio row and persists left-edge resizing", async () => {

--- a/desktop/src/components/create/InspectorPanel.vue
+++ b/desktop/src/components/create/InspectorPanel.vue
@@ -4,6 +4,7 @@ import ShapePicker from "@ui/components/ShapePicker.vue";
 import ResolutionSelector from "@ui/components/ResolutionSelector.vue";
 import SegmentedControl from "@ui/components/SegmentedControl.vue";
 import SliderRow from "@ui/components/SliderRow.vue";
+import VideoDurationSlider from "@ui/components/VideoDurationSlider.vue";
 import Stepper from "@ui/components/Stepper.vue";
 import BadgePill from "@ui/components/BadgePill.vue";
 import Icon from "@ui/components/Icon.vue";
@@ -591,6 +592,16 @@ function resetSettings() {
           label="Prompt strength"
           :value-label="form.guidance.toFixed(1)"
           @update:model-value="form.guidance = $event"
+        />
+      </div>
+
+      <!-- Duration is the human-facing video control; exact frames/FPS stay in Advanced. -->
+      <div v-if="caps.supportsVideo && !isSequence" class="ms-field">
+        <VideoDurationSlider
+          :frames="form.frames"
+          :fps="form.fps"
+          :model="selectedModel"
+          @update:frames="form.frames = $event"
         />
       </div>
 

--- a/desktop/src/components/shell/NavRail.test.ts
+++ b/desktop/src/components/shell/NavRail.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { flushPromises, mount } from "@vue/test-utils";
 import { createPinia, setActivePinia } from "pinia";
 import { createMemoryHistory, createRouter, type Router } from "vue-router";
@@ -120,6 +120,42 @@ describe("NavRail developing jobs", () => {
       expect.arrayContaining(["min-h-0", "flex-1", "overflow-y-auto"]),
     );
     expect(jobs.classes()).not.toContain("max-h-44");
+  });
+
+  it("uses the available rail space for a longer finished-print history", async () => {
+    const wrapper = await mountAt("/create");
+    const generation = useGenerationStore();
+    generation.jobs = Array.from({ length: 12 }, (_, index) => ({
+      clientId: index + 1,
+      model: "flux-dev:q8",
+      prompt: `finished print ${index + 1}`,
+      status: "complete",
+    })) as never;
+    await flushPromises();
+
+    expect(wrapper.findAll("[data-test='developing-print']")).toHaveLength(12);
+    expect(wrapper.get("[data-test='developing-jobs']").classes()).toContain("overflow-y-auto");
+  });
+
+  it("reacquires a compacted print when its history row is opened", async () => {
+    const wrapper = await mountAt("/create");
+    const generation = useGenerationStore();
+    const refresh = vi.spyOn(generation, "refreshRemoteResultUrl").mockResolvedValue();
+    generation.jobs = [
+      {
+        clientId: 13,
+        model: "flux-dev:q8",
+        prompt: "older compacted print",
+        status: "complete",
+        resultUrl: null,
+        result: { filename: "older.png", image: "" },
+        request: { prompt: "older compacted print", model: "flux-dev:q8" },
+      } as never,
+    ];
+    await flushPromises();
+
+    await wrapper.get("[data-test='developing-print']").trigger("click");
+    expect(refresh).toHaveBeenCalledWith(13);
   });
 
   // G14 hole: the rail only ever read `generation.jobs`, so a running sequence

--- a/desktop/src/components/shell/NavRail.vue
+++ b/desktop/src/components/shell/NavRail.vue
@@ -14,7 +14,13 @@ import {
   sequenceToVM,
   type ActivityJobVM,
 } from "@studio/lib/activity";
-import { useGenerationStore, jobStatusCode, railOrder, type Job } from "../../stores/generation";
+import {
+  GENERATION_HISTORY_LIMIT,
+  useGenerationStore,
+  jobStatusCode,
+  railOrder,
+  type Job,
+} from "../../stores/generation";
 import { useAppPrefsStore } from "../../stores/appPrefs";
 import { useChainJobsStore } from "../../stores/chainJobs";
 import { useComposerStore } from "../../stores/composer";
@@ -99,15 +105,16 @@ function isActive(path: string): boolean {
   return route.path === path;
 }
 
-/** Queue order: every live job first (submission order), then the freshest
- *  finished prints — the rail is a working queue, not a full history. */
+/** Queue order: every live job first (submission order), then enough recent
+ * finished prints to use the rail's available height. The flex child scrolls,
+ * so a tall window becomes useful history without displacing status/settings. */
 const railJobs = computed<Job[]>(() => {
   const live = railOrder(
     generation.jobs.filter((j) => j.status !== "complete" && j.status !== "error"),
   );
   const done = generation.jobs
     .filter((j) => j.status === "complete" || j.status === "error")
-    .slice(-3)
+    .slice(-GENERATION_HISTORY_LIMIT)
     .reverse();
   return [...live, ...done];
 });
@@ -197,6 +204,18 @@ function selectPrint(job: Job) {
   draft.output = "single";
   const request = job.request;
   if (request) composer.set({ request });
+  if (job.status === "complete" && !job.resultUrl) {
+    if (job.result?.filename) {
+      void generation.refreshRemoteResultUrl(job.clientId).catch(() => {
+        toasts.push("Open this older print in Library");
+        void router.push("/library");
+      });
+    } else {
+      toasts.push("Open this older print in Library");
+      void router.push("/library");
+      return;
+    }
+  }
   void router.push("/create");
 }
 
@@ -291,6 +310,7 @@ function selectSequence(vm: ActivityJobVM & { kind: "sequence" }) {
           v-for="job in railJobs"
           :key="job.clientId"
           href="#"
+          data-test="developing-print"
           class="flex items-center gap-2.5 rounded-[8px] px-1 py-1 hover:bg-[color-mix(in_srgb,var(--rebate)_6%,transparent)]"
           @click.prevent="selectPrint(job)"
           @contextmenu.prevent="contextMenu.open($event, jobMenu(job))"

--- a/desktop/src/lib/api/types.ts
+++ b/desktop/src/lib/api/types.ts
@@ -154,6 +154,14 @@ export interface ModelEntry {
   /** Server-advertised frame rate (LTX-Video ships 30, LTX-2 24); absent on
    * older servers and image models. Applied like steps/guidance. */
   default_fps?: number | null;
+  /** Requestable single-shot frame ceiling at `default_fps`. */
+  max_frames?: number | null;
+  /** Duration-based ceiling; clients recompute max frames when FPS changes. */
+  max_runtime_seconds?: number | null;
+  /** FPS-independent resource guard paired with `max_runtime_seconds`. */
+  max_frames_absolute?: number | null;
+  /** Valid frame counts are `k * frame_step + 1`. */
+  frame_step?: number | null;
 }
 
 // ── Generation ───────────────────────────────────────────────────────────

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -3833,6 +3833,7 @@ onBeforeUnmount(() => {
 
             <MobileSharedParams
               :form="form"
+              :duration-model="selectedGenerationModel"
               :last-seed="generation.lastSeedUsed"
               :disabled="loadingModels"
               :steps-error="stepsError"

--- a/desktop/src/mobile/MobileGenerateParameters.test.ts
+++ b/desktop/src/mobile/MobileGenerateParameters.test.ts
@@ -72,6 +72,31 @@ async function attachFile(wrapper: VueWrapper, selector: string, file: File): Pr
 }
 
 describe("MobileGenerateParameters", () => {
+  it("offers a duration slider while retaining exact video fields", async () => {
+    const model = {
+      name: "ltx-2-19b-distilled:fp8",
+      family: "ltx2",
+      default_frames: 97,
+      default_fps: 24,
+      max_runtime_seconds: 20,
+      max_frames_absolute: 604,
+      frame_step: 8,
+    } as ModelEntry;
+    const { wrapper, form } = mountParameters(
+      { ...formFor("ltx2", model.name), frames: 97, fps: 24 },
+      [],
+      true,
+      [],
+      [cameraControl],
+      model,
+    );
+    expect(wrapper.get("[data-test='mobile-advanced-duration']").text()).toContain("4.0s");
+    await wrapper.get("[data-test='mobile-advanced-duration'] input[type='range']").setValue("241");
+    expect(form.frames).toBe(241);
+    expect(wrapper.find("[data-test='mobile-frames']").exists()).toBe(true);
+    expect(wrapper.find("[data-test='mobile-fps']").exists()).toBe(true);
+  });
+
   it("renders host-provided reference controls and guide copy", async () => {
     const adapters: Ltx2ControlAdapterInfo[] = [
       {

--- a/desktop/src/mobile/MobileGenerateParameters.vue
+++ b/desktop/src/mobile/MobileGenerateParameters.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, useId, watch } from "vue";
+import VideoDurationSlider from "@ui/components/VideoDurationSlider.vue";
 import type {
   Ltx2PipelineMode,
   Ltx2CameraControlInfo,
@@ -568,6 +569,15 @@ const fpsErrorId = `mobile-fps-error-${useId()}`;
       class="mobile-generate-section mobile-generate-video-options"
     >
       <legend class="mobile-generate-legend">Video</legend>
+
+      <VideoDurationSlider
+        :frames="form.frames"
+        :fps="form.fps"
+        :model="selectedModel"
+        touch-friendly
+        data-test="mobile-advanced-duration"
+        @update:frames="form.frames = $event"
+      />
 
       <div class="mobile-generate-field-grid">
         <label class="field mobile-generate-field">

--- a/desktop/src/mobile/MobileSharedParams.test.ts
+++ b/desktop/src/mobile/MobileSharedParams.test.ts
@@ -1,0 +1,56 @@
+import { mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { reactive } from "vue";
+import { beforeEach, describe, expect, it } from "vitest";
+import { newGenerateForm } from "../lib/generateForm";
+import type { ModelEntry } from "../lib/api/types";
+import MobileSharedParams from "./MobileSharedParams.vue";
+
+describe("MobileSharedParams video duration", () => {
+  beforeEach(() => setActivePinia(createPinia()));
+
+  it("shows the model-aware seconds slider for one-shot video", async () => {
+    const form = reactive({
+      ...newGenerateForm(),
+      model: "ltx-2-19b-distilled:fp8",
+      family: "ltx2",
+      frames: 97,
+      fps: 24,
+    });
+    const model = {
+      name: form.model,
+      family: form.family,
+      max_runtime_seconds: 20,
+      max_frames_absolute: 604,
+      frame_step: 8,
+    } as ModelEntry;
+    const wrapper = mount(MobileSharedParams, {
+      props: { form, durationModel: model, lastSeed: null },
+      global: {
+        stubs: { MobileResolutionPicker: true, MobileSeedPicker: true },
+      },
+    });
+
+    const slider = wrapper.get("[data-test='mobile-duration'] input[type='range']");
+    expect(wrapper.get("[data-test='mobile-duration']").text()).toContain("4.0s");
+    await slider.setValue("241");
+    expect(form.frames).toBe(241);
+  });
+
+  it("keeps sequence FPS visible without duplicating the duration control", () => {
+    const form = reactive({
+      ...newGenerateForm(),
+      model: "ltx-2-19b-distilled:fp8",
+      family: "ltx2",
+    });
+    const wrapper = mount(MobileSharedParams, {
+      props: { form, lastSeed: null, showFps: true },
+      global: {
+        stubs: { MobileResolutionPicker: true, MobileSeedPicker: true },
+      },
+    });
+
+    expect(wrapper.find("[data-test='mobile-duration']").exists()).toBe(false);
+    expect(wrapper.find("[data-test='mobile-sequence-fps']").exists()).toBe(true);
+  });
+});

--- a/desktop/src/mobile/MobileSharedParams.vue
+++ b/desktop/src/mobile/MobileSharedParams.vue
@@ -12,12 +12,16 @@ import type { GenerateForm } from "../lib/generateForm";
 import type { ModelEntry } from "../lib/api/types";
 import MobileResolutionPicker from "./MobileResolutionPicker.vue";
 import MobileSeedPicker from "./MobileSeedPicker.vue";
+import VideoDurationSlider from "@ui/components/VideoDurationSlider.vue";
+import { generationCapabilitiesForFamily } from "../lib/capabilities";
 import { useSequenceDraftStore } from "@studio/stores/sequenceDraft";
 
 const props = withDefaults(
   defineProps<{
     form: GenerateForm;
     model?: ModelEntry | null;
+    /** Timing metadata without changing legacy resolution projection behavior. */
+    durationModel?: ModelEntry | null;
     lastSeed: number | null;
     disabled?: boolean;
     /** Sequence output surfaces frame rate outside the Advanced sheet. */
@@ -25,7 +29,14 @@ const props = withDefaults(
     stepsError?: string | null;
     guidanceError?: string | null;
   }>(),
-  { disabled: false, showFps: false, stepsError: null, guidanceError: null, model: null },
+  {
+    disabled: false,
+    showFps: false,
+    stepsError: null,
+    guidanceError: null,
+    model: null,
+    durationModel: null,
+  },
 );
 
 const emit = defineEmits<{
@@ -34,6 +45,9 @@ const emit = defineEmits<{
 }>();
 
 const fpsError = computed(() => (props.showFps ? fpsValidationError(props.form.fps) : null));
+const supportsVideo = computed(
+  () => generationCapabilitiesForFamily(props.form.family, props.form.model).supportsVideo,
+);
 const draft = useSequenceDraftStore();
 const sourceDimensions = computed(() => {
   if (props.showFps) {
@@ -58,6 +72,15 @@ const sourceDimensions = computed(() => {
     :source-dimensions="sourceDimensions"
     :disabled="disabled"
     @validity-change="emit('resolution-validity', $event)"
+  />
+  <VideoDurationSlider
+    v-if="supportsVideo && !showFps"
+    :frames="form.frames"
+    :fps="form.fps"
+    :model="durationModel ?? model"
+    touch-friendly
+    data-test="mobile-duration"
+    @update:frames="form.frames = $event"
   />
   <label v-if="showFps" class="field" data-test="mobile-sequence-fps">
     <span>FPS</span>

--- a/desktop/src/stores/generation.ts
+++ b/desktop/src/stores/generation.ts
@@ -48,6 +48,11 @@ export {
   type JobStatus,
 } from "../lib/generationJob";
 
+/** Settled prints retained for the activity rail's scrollable history. */
+export const GENERATION_HISTORY_LIMIT = 50;
+/** Only the freshest jobs retain decoded/encoded media in Create memory. */
+export const GENERATION_RICH_HISTORY_LIMIT = 12;
+
 /** Where a batch runs — mirrors `HostRoute` from the hosts store. */
 export interface JobRoute {
   hostId: string;
@@ -452,7 +457,7 @@ export const useGenerationStore = defineStore("generation", {
           );
           const pendingBatches = new Set(this.pendingConsumerBatchIds);
           this.prune(
-            12,
+            GENERATION_HISTORY_LIMIT,
             jobs.map((job) => job.clientId),
             this.jobs.filter((job) => !pendingBatches.has(job.batchId)).map((job) => job.clientId),
           );
@@ -536,6 +541,23 @@ export const useGenerationStore = defineStore("generation", {
           (job.status === "complete" || job.status === "error") &&
           (!eligible || eligible.has(job.clientId)),
       );
+      const rich = new Set(
+        finished.slice(-Math.min(keep, GENERATION_RICH_HISTORY_LIMIT)).map((job) => job.clientId),
+      );
+      for (const clientId of preserve) rich.add(clientId);
+      for (const job of finished) {
+        if (rich.has(job.clientId)) continue;
+        if (job.result) job.result = metadataOnlyResult(job.result);
+        if (job.resultUrlIsObjectUrl && job.resultUrl) {
+          URL.revokeObjectURL(job.resultUrl);
+          job.resultUrl = null;
+          job.resultUrlIsObjectUrl = false;
+        }
+        if (job.previewUrl) {
+          URL.revokeObjectURL(job.previewUrl);
+          job.previewUrl = null;
+        }
+      }
       const excess = finished.length - keep;
       if (excess <= 0) return;
       const drop = new Set(

--- a/desktop/src/stores/generationQueue.test.ts
+++ b/desktop/src/stores/generationQueue.test.ts
@@ -442,6 +442,32 @@ describe("generation queueing", () => {
     expect(store.jobs).not.toContain(jobs[1]);
   });
 
+  it("keeps long rail history lightweight beyond the freshest media window", () => {
+    const store = useGenerationStore();
+    for (let index = 0; index < 13; index += 1) {
+      const job = store.startJob({ ...req, prompt: `history ${index}` });
+      job.status = "complete";
+      job.result = {
+        image: "large-encoded-output",
+        format: "png",
+        width: 1024,
+        height: 1024,
+        seed_used: index,
+        generation_time_ms: 1,
+        model: req.model,
+      } as never;
+      job.resultUrl = `blob:history-${index}`;
+      job.resultUrlIsObjectUrl = true;
+    }
+
+    store.prune(50);
+
+    expect(store.jobs).toHaveLength(13);
+    expect(store.jobs[0]?.result?.image).toBe("");
+    expect(store.jobs[0]?.resultUrl).toBeNull();
+    expect(store.jobs[1]?.result?.image).toBe("large-encoded-output");
+  });
+
   it("prunes only terminal jobs whose consumer callbacks have run", () => {
     const store = useGenerationStore();
     const jobs = Array.from({ length: 3 }, (_, index) =>
@@ -460,7 +486,7 @@ describe("generation queueing", () => {
     const store = useGenerationStore();
     const { jobs, settled } = store.submitBatch({ ...req, prompt: "slow oldest" }, 1);
     await flushPromises();
-    for (let index = 0; index < 12; index += 1) {
+    for (let index = 0; index < 50; index += 1) {
       const newer = store.startJob({ ...req, prompt: `newer ${index}` });
       newer.status = "complete";
     }
@@ -483,7 +509,7 @@ describe("generation queueing", () => {
     expect(store.jobs).toContain(jobs[0]);
     await new Promise((resolve) => setTimeout(resolve, 1));
     expect(store.jobs).toContain(jobs[0]);
-    expect(store.jobs).toHaveLength(12);
+    expect(store.jobs).toHaveLength(50);
   });
 
   it("does not auto-prune a terminal job from another batch whose consumer is pending", async () => {
@@ -529,7 +555,7 @@ describe("generation queueing", () => {
     // Force the finishing batch's automatic housekeeping over the retention
     // threshold. The older terminal job is first in store order, so it would
     // be the first casualty without the cross-batch consumer guard.
-    for (let index = 0; index < 12; index += 1) {
+    for (let index = 0; index < 50; index += 1) {
       const filler = store.startJob({ ...req, prompt: `finished filler ${index}` });
       filler.status = "complete";
     }
@@ -540,7 +566,7 @@ describe("generation queueing", () => {
     expect(pendingConsumerObserved).toBe(false);
     expect(store.pendingConsumerBatchIds).toEqual([pendingBatch.jobs[0]!.batchId]);
     expect(store.jobs).toContain(pendingBatch.jobs[0]);
-    expect(store.jobs).toHaveLength(13);
+    expect(store.jobs).toHaveLength(51);
 
     openStreams[0]!.resolve();
     await pendingBatch.settled;

--- a/studio/lib/videoDuration.test.ts
+++ b/studio/lib/videoDuration.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+  clampVideoFrames,
+  formatVideoDuration,
+  framesForVideoDuration,
+  maxVideoFrames,
+} from "./videoDuration";
+
+const ltx2 = {
+  default_frames: 97,
+  default_fps: 24,
+  max_frames: 481,
+  max_runtime_seconds: 20,
+  max_frames_absolute: 604,
+  frame_step: 8,
+};
+
+describe("video duration controls", () => {
+  it("maps seconds onto the selected model's valid frame grid", () => {
+    expect(framesForVideoDuration(10, 24, ltx2)).toBe(241);
+    expect(formatVideoDuration(241, 24)).toBe("10s");
+  });
+
+  it("recomputes duration-based model ceilings at the selected fps", () => {
+    expect(maxVideoFrames(ltx2, 12)).toBe(241);
+    expect(maxVideoFrames(ltx2, 24)).toBe(481);
+    expect(maxVideoFrames(ltx2, 48)).toBe(601);
+  });
+
+  it("uses fixed per-model caps for frame-limited video models", () => {
+    const ltxVideo = { max_frames: 257, frame_step: 8 };
+    expect(maxVideoFrames(ltxVideo, 24)).toBe(257);
+    expect(maxVideoFrames(ltxVideo, 60)).toBe(257);
+  });
+
+  it("retains the LTX-2 duration budget for older hosts", () => {
+    expect(maxVideoFrames({ family: "ltx2" }, 24)).toBe(481);
+  });
+
+  it("clamps manual values to the requestable model grid", () => {
+    expect(clampVideoFrames(999, 24, ltx2)).toBe(481);
+    expect(clampVideoFrames(1, 24, ltx2)).toBe(1);
+  });
+});

--- a/studio/lib/videoDuration.test.ts
+++ b/studio/lib/videoDuration.test.ts
@@ -40,5 +40,6 @@ describe("video duration controls", () => {
   it("clamps manual values to the requestable model grid", () => {
     expect(clampVideoFrames(999, 24, ltx2)).toBe(481);
     expect(clampVideoFrames(1, 24, ltx2)).toBe(1);
+    expect(formatVideoDuration(1, 24)).toBe("0.04s");
   });
 });

--- a/studio/lib/videoDuration.ts
+++ b/studio/lib/videoDuration.ts
@@ -1,0 +1,93 @@
+import { maxFramesForFamilyAtFps } from "./videoBudget";
+
+/** Additive `/api/models` fields that describe a model's requestable video grid. */
+export interface VideoFrameContract {
+  family?: string | null;
+  default_frames?: number | null;
+  default_fps?: number | null;
+  max_frames?: number | null;
+  max_runtime_seconds?: number | null;
+  max_frames_absolute?: number | null;
+  frame_step?: number | null;
+}
+
+const LEGACY_FRAME_STEP = 8;
+const LEGACY_MAX_FRAMES = 257;
+
+export function videoFrameStep(model?: VideoFrameContract | null): number {
+  const step = Math.round(model?.frame_step ?? LEGACY_FRAME_STEP);
+  return step > 0 ? step : LEGACY_FRAME_STEP;
+}
+
+/** Snap a frame count onto the server's `k * step + 1` request grid. */
+export function snapVideoFrames(
+  frames: number,
+  model?: VideoFrameContract | null,
+  direction: "nearest" | "down" = "nearest",
+): number {
+  const step = videoFrameStep(model);
+  const scaled = (Math.max(1, frames) - 1) / step;
+  const grid = direction === "down" ? Math.floor(scaled) : Math.round(scaled);
+  return Math.max(1, grid * step + 1);
+}
+
+/**
+ * Requestable single-shot ceiling at the currently selected FPS.
+ *
+ * LTX-2 advertises a duration ceiling, so its frame limit moves with FPS.
+ * Older servers only advertise `max_frames`; the conservative legacy fallback
+ * keeps those clients useful without inventing a larger model limit.
+ */
+export function maxVideoFrames(
+  model: VideoFrameContract | null | undefined,
+  fps: number,
+): number {
+  const rate = Math.max(1, Math.round(fps) || model?.default_fps || 24);
+  let cap: number;
+  if (model?.max_runtime_seconds) {
+    cap = model.max_runtime_seconds * rate + 4;
+    if (model.max_frames_absolute)
+      cap = Math.min(cap, model.max_frames_absolute);
+  } else {
+    cap =
+      model?.max_frames ??
+      maxFramesForFamilyAtFps(model?.family, rate) ??
+      LEGACY_MAX_FRAMES;
+  }
+  return snapVideoFrames(cap, model, "down");
+}
+
+export function minVideoFrames(): number {
+  return 1;
+}
+
+export function clampVideoFrames(
+  frames: number,
+  fps: number,
+  model?: VideoFrameContract | null,
+): number {
+  return Math.min(
+    maxVideoFrames(model, fps),
+    Math.max(minVideoFrames(), snapVideoFrames(frames, model)),
+  );
+}
+
+export function videoDurationSeconds(frames: number, fps: number): number {
+  return Math.max(1, frames) / Math.max(1, fps);
+}
+
+export function framesForVideoDuration(
+  seconds: number,
+  fps: number,
+  model?: VideoFrameContract | null,
+): number {
+  return clampVideoFrames(seconds * Math.max(1, fps), fps, model);
+}
+
+export function formatVideoDuration(frames: number, fps: number): string {
+  const seconds = videoDurationSeconds(frames, fps);
+  if (seconds >= 10 && Math.abs(seconds - Math.round(seconds)) < 0.05) {
+    return `${Math.round(seconds)}s`;
+  }
+  return `${seconds.toFixed(1)}s`;
+}

--- a/studio/lib/videoDuration.ts
+++ b/studio/lib/videoDuration.ts
@@ -89,5 +89,6 @@ export function formatVideoDuration(frames: number, fps: number): string {
   if (seconds >= 10 && Math.abs(seconds - Math.round(seconds)) < 0.05) {
     return `${Math.round(seconds)}s`;
   }
+  if (seconds < 0.1) return `${seconds.toFixed(2)}s`;
   return `${seconds.toFixed(1)}s`;
 }

--- a/ui/components/VideoDurationSlider.test.ts
+++ b/ui/components/VideoDurationSlider.test.ts
@@ -1,0 +1,67 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+import VideoDurationSlider from "./VideoDurationSlider.vue";
+
+describe("VideoDurationSlider", () => {
+  it("shows seconds and emits model-valid frames", async () => {
+    const wrapper = mount(VideoDurationSlider, {
+      props: {
+        frames: 97,
+        fps: 24,
+        model: {
+          max_runtime_seconds: 20,
+          max_frames_absolute: 604,
+          frame_step: 8,
+        },
+      },
+    });
+
+    expect(wrapper.text()).toContain("4.0s");
+    const range = wrapper.get('input[type="range"]');
+    expect(range.attributes("max")).toBe("481");
+    await range.setValue("241");
+    expect(wrapper.emitted("update:frames")?.[0]).toEqual([241]);
+  });
+
+  it("updates the request value when FPS lowers the model ceiling", async () => {
+    const wrapper = mount(VideoDurationSlider, {
+      props: {
+        frames: 481,
+        fps: 24,
+        model: {
+          max_runtime_seconds: 20,
+          max_frames_absolute: 604,
+          frame_step: 8,
+        },
+      },
+    });
+
+    await wrapper.setProps({ fps: 12 });
+    expect(wrapper.emitted("update:frames")?.at(-1)).toEqual([241]);
+    await wrapper.setProps({ frames: 241 });
+    expect(wrapper.text()).toContain("241 frames");
+  });
+
+  it("preserves the exact one-frame value accepted by the server", () => {
+    const wrapper = mount(VideoDurationSlider, {
+      props: { frames: 1, fps: 24, model: { frame_step: 8 } },
+    });
+
+    expect(wrapper.get('input[type="range"]').attributes("min")).toBe("1");
+    expect(wrapper.emitted("update:frames")).toBeUndefined();
+  });
+
+  it("reports an intentional long-chain duration without rewriting it", () => {
+    const wrapper = mount(VideoDurationSlider, {
+      props: {
+        frames: 500,
+        fps: 12,
+        model: { family: "ltx2", frame_step: 8 },
+      },
+    });
+
+    expect(wrapper.text()).toContain("500 frames · 12 fps · 41.7s");
+    expect(wrapper.text()).toContain("automatic sequence");
+    expect(wrapper.emitted("update:frames")).toBeUndefined();
+  });
+});

--- a/ui/components/VideoDurationSlider.vue
+++ b/ui/components/VideoDurationSlider.vue
@@ -1,0 +1,98 @@
+<script setup lang="ts">
+import { computed, watch } from "vue";
+import {
+  clampVideoFrames,
+  formatVideoDuration,
+  maxVideoFrames,
+  minVideoFrames,
+  videoFrameStep,
+  type VideoFrameContract,
+} from "@studio/lib/videoDuration";
+import SliderRow from "./SliderRow.vue";
+
+const props = withDefaults(
+  defineProps<{
+    frames: number;
+    fps: number;
+    model?: VideoFrameContract | null;
+    label?: string;
+    touchFriendly?: boolean;
+  }>(),
+  { model: null, label: "Duration" },
+);
+
+const emit = defineEmits<{ "update:frames": [frames: number] }>();
+
+const rate = computed(() => Math.max(1, Math.round(props.fps) || 24));
+const sliderValue = computed(() =>
+  clampVideoFrames(props.frames, rate.value, props.model),
+);
+const maximum = computed(() => maxVideoFrames(props.model, rate.value));
+const isLongVideo = computed(() => props.frames > maximum.value);
+const displayedFrames = computed(() =>
+  isLongVideo.value ? props.frames : sliderValue.value,
+);
+const readout = computed(() =>
+  formatVideoDuration(displayedFrames.value, rate.value),
+);
+
+// FPS/model changes can lower a previously legal single-shot value. Clamp that
+// transition, but preserve an intentional above-ceiling exact frame count: the
+// advanced fields use those to request automatic long-video chaining.
+watch(maximum, (next, previous) => {
+  if (props.frames <= previous && props.frames > next) {
+    emit(
+      "update:frames",
+      clampVideoFrames(props.frames, rate.value, props.model),
+    );
+  }
+});
+
+function update(frames: number): void {
+  emit("update:frames", clampVideoFrames(frames, rate.value, props.model));
+}
+</script>
+
+<template>
+  <div
+    class="video-duration"
+    :class="{ 'video-duration--touch': touchFriendly }"
+    data-test="video-duration"
+  >
+    <SliderRow
+      :model-value="sliderValue"
+      :min="minVideoFrames()"
+      :max="maximum"
+      :step="videoFrameStep(model)"
+      :label="label"
+      :value-label="readout"
+      @update:model-value="update"
+    />
+    <p class="video-duration__hint" data-test="video-duration-detail">
+      {{ displayedFrames }} frames · {{ rate }} fps · {{ readout }}
+      <template v-if="isLongVideo"> · automatic sequence</template>
+    </p>
+  </div>
+</template>
+
+<style scoped>
+.video-duration__hint {
+  margin: 7px 0 0;
+  color: var(--ink-3);
+  font-family: var(--f-mono);
+  font-size: 10px;
+  line-height: 1.4;
+}
+
+.video-duration--touch :deep(.ms-slider__input) {
+  box-sizing: border-box;
+  height: 44px;
+  background: linear-gradient(
+    to bottom,
+    transparent 20px,
+    var(--ce) 20px,
+    var(--ce) 24px,
+    transparent 24px
+  );
+}
+</style>

--- a/web/src/components/create/AdvancedDrawer.test.ts
+++ b/web/src/components/create/AdvancedDrawer.test.ts
@@ -167,6 +167,36 @@ describe("AdvancedDrawer sequence contract", () => {
   });
 });
 
+describe("AdvancedDrawer video duration", () => {
+  it("keeps the seconds slider beside exact frames and FPS", async () => {
+    const model = {
+      name: "ltx-2-19b-distilled:fp8",
+      family: "ltx2",
+      default_frames: 97,
+      default_fps: 24,
+      max_runtime_seconds: 20,
+      max_frames_absolute: 604,
+      frame_step: 8,
+    } as ModelInfoExtended;
+    const wrapper = factory(
+      "ltx2",
+      { model: model.name, frames: 97, fps: 24 },
+      { models: [model] },
+    );
+    expect(wrapper.get("[data-test='video-duration']").text()).toContain(
+      "4.0s",
+    );
+    await wrapper
+      .get("[data-test='video-duration'] input[type='range']")
+      .setValue("241");
+    expect(wrapper.emitted("update:modelValue")?.at(-1)?.[0]).toMatchObject({
+      frames: 241,
+    });
+    expect(wrapper.find("[data-test='video-frames']").exists()).toBe(true);
+    expect(wrapper.find("[data-test='video-fps']").exists()).toBe(true);
+  });
+});
+
 function sections(family: string, extra: Record<string, unknown> = {}) {
   const wrapper = factory(family, {}, extra);
   const has = (key: string) =>

--- a/web/src/components/create/AdvancedDrawer.vue
+++ b/web/src/components/create/AdvancedDrawer.vue
@@ -45,6 +45,7 @@ import { blobToBase64 } from "../../lib/base64";
 import { useOverlayFocus } from "../../composables/useOverlayFocus";
 import { useSequenceDraftStore } from "@studio/stores/sequenceDraft";
 import type { OutputMode } from "@studio/lib/sequence";
+import VideoDurationSlider from "@ui/components/VideoDurationSlider.vue";
 import {
   SOURCE_FIT_OPTIONS,
   coerceSourceFitForMaskless,
@@ -104,6 +105,10 @@ const emit = defineEmits<{
 const host = ref<HTMLElement | { $el?: unknown } | null>(null);
 const draft = useSequenceDraftStore();
 const sequenceMode = computed(() => props.output === "sequence");
+const selectedModel = computed(
+  () =>
+    props.models.find((model) => model.name === props.modelValue.model) ?? null,
+);
 const activeSequenceClip = computed(
   () =>
     draft.clips.find((clip) => clip.id === draft.activeClipId) ??
@@ -973,6 +978,15 @@ function setSequenceCameraMode(mode: string) {
           :header-interactive="false"
           data-test="section-video"
         >
+          <div class="adv__field">
+            <VideoDurationSlider
+              :frames="modelValue.frames ?? selectedModel?.default_frames ?? 25"
+              :fps="modelValue.fps ?? selectedModel?.default_fps ?? 24"
+              :model="selectedModel"
+              label="Duration"
+              @update:frames="patch({ frames: $event })"
+            />
+          </div>
           <div class="adv__field">
             <label class="adv__label">Frames (8n+1)</label>
             <input

--- a/web/src/components/create/ControlsAside.test.ts
+++ b/web/src/components/create/ControlsAside.test.ts
@@ -5,6 +5,7 @@ import ShapePicker from "@ui/components/ShapePicker.vue";
 import ResolutionSelector from "@ui/components/ResolutionSelector.vue";
 import Stepper from "@ui/components/Stepper.vue";
 import SliderRow from "@ui/components/SliderRow.vue";
+import VideoDurationSlider from "@ui/components/VideoDurationSlider.vue";
 import {
   useGenerateForm,
   __testing__,
@@ -119,6 +120,31 @@ describe("ControlsAside", () => {
     expect(strength?.props("min")).toBe(0);
     expect(strength?.props("max")).toBe(12);
     expect(strength?.props("step")).toBe(0.1);
+  });
+
+  it("shows a per-model duration slider for one-shot video", async () => {
+    const wrapper = mount(ControlsAside, {
+      props: {
+        modelValue: baseForm({ frames: 97, fps: 24 }),
+        family: "ltx2",
+        model: {
+          name: "ltx-2-19b-distilled:fp8",
+          family: "ltx2",
+          default_frames: 97,
+          default_fps: 24,
+          max_runtime_seconds: 20,
+          max_frames_absolute: 604,
+          frame_step: 8,
+        } as never,
+      },
+    });
+    const duration = wrapper.getComponent(VideoDurationSlider);
+    expect(duration.text()).toContain("4.0s");
+    duration.vm.$emit("update:frames", 241);
+    await wrapper.vm.$nextTick();
+    expect(wrapper.emitted("update:modelValue")?.at(-1)?.[0]).toMatchObject({
+      frames: 241,
+    });
   });
 
   it("applies the projected dims when a shape is picked", async () => {

--- a/web/src/components/create/ControlsAside.vue
+++ b/web/src/components/create/ControlsAside.vue
@@ -12,6 +12,7 @@ import { useRouter } from "vue-router";
 import ShapePicker from "@ui/components/ShapePicker.vue";
 import ResolutionSelector from "@ui/components/ResolutionSelector.vue";
 import SliderRow from "@ui/components/SliderRow.vue";
+import VideoDurationSlider from "@ui/components/VideoDurationSlider.vue";
 import SegmentedControl from "@ui/components/SegmentedControl.vue";
 import Stepper from "@ui/components/Stepper.vue";
 import BadgePill from "@ui/components/BadgePill.vue";
@@ -365,6 +366,18 @@ function lockLastSeed() {
         :max="60"
         :value-label="`${modelValue.steps} steps`"
         @update:model-value="patch({ steps: $event })"
+      />
+    </div>
+
+    <div
+      v-if="capabilities.supportsVideo && !sequenceMode"
+      class="controls__group"
+    >
+      <VideoDurationSlider
+        :frames="modelValue.frames ?? model?.default_frames ?? 25"
+        :fps="modelValue.fps ?? model?.default_fps ?? 24"
+        :model="model"
+        @update:frames="patch({ frames: $event })"
       />
     </div>
 

--- a/web/src/components/create/RecentGrid.test.ts
+++ b/web/src/components/create/RecentGrid.test.ts
@@ -52,6 +52,12 @@ describe("RecentGrid", () => {
     expect(more.text()).toContain("30");
   });
 
+  it("fills large web workspaces when given the desktop history limit", () => {
+    const entries = Array.from({ length: 60 }, (_, i) => entry(`p${i}.png`));
+    const w = mountGrid(entries, 50);
+    expect(w.findAll("[data-test='recent-tile']")).toHaveLength(50);
+  });
+
   it("does not render a view-all link when everything fits", () => {
     const w = mountGrid([entry("a.png")], 12);
     expect(w.find("[data-test='recent-view-all']").exists()).toBe(false);

--- a/web/src/components/create/RecentGrid.vue
+++ b/web/src/components/create/RecentGrid.vue
@@ -6,8 +6,8 @@
  * narrow, and the format/type/time badges stacked on top of each other. The
  * prototype's Recent block is a plain fixed grid of square tiles, so this
  * component renders one `MediaTile` per print — square, aspect-fit (cover)
- * thumbnails, a single non-overlapping video badge — capped to a handful with
- * a "view all" link into the gallery for the rest.
+ * thumbnails, a single non-overlapping video badge — long enough to fill a
+ * large Create workspace, with a "view all" link into the gallery for the rest.
  */
 import { computed } from "vue";
 import { RouterLink } from "vue-router";

--- a/web/src/pages/CreatePage.test.ts
+++ b/web/src/pages/CreatePage.test.ts
@@ -550,6 +550,7 @@ describe("CreatePage layout and behavior", () => {
           Node.DOCUMENT_POSITION_FOLLOWING,
       ).toBeTruthy();
     }
+    expect(wrapper.findComponent(RecentGridStub).props("limit")).toBe(18);
     wrapper.unmount();
     vi.unstubAllGlobals();
     vi.stubGlobal("prompt", vi.fn());
@@ -560,6 +561,7 @@ describe("CreatePage layout and behavior", () => {
     await flushPromises();
     const feed = wrapper.findComponent(RecentGridStub);
     expect(feed.props("entries")).toEqual([entry]);
+    expect(feed.props("limit")).toBe(50);
   });
 
   it("dismisses the Templates popover with Escape and outside click", async () => {

--- a/web/src/pages/CreatePage.vue
+++ b/web/src/pages/CreatePage.vue
@@ -3316,7 +3316,11 @@ onBeforeUnmount(() => {
               >{{ galleryEntries.length }} prints</span
             >
           </div>
-          <RecentGrid :entries="galleryEntries" @open="openItem" />
+          <RecentGrid
+            :entries="galleryEntries"
+            :limit="isPhone ? 18 : 50"
+            @open="openItem"
+          />
         </section>
       </main>
 

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -311,6 +311,14 @@ export interface ModelInfoExtended extends ModelDefaults {
   /** Model's own default frame rate (`/api/models`, additive) — LTX-Video
    * ships 30, LTX-2 24; absent on older servers and image models. */
   default_fps?: number | null;
+  /** Requestable single-shot frame ceiling at `default_fps`. */
+  max_frames?: number | null;
+  /** Duration-based ceiling; clients recompute max frames when FPS changes. */
+  max_runtime_seconds?: number | null;
+  /** FPS-independent resource guard paired with `max_runtime_seconds`. */
+  max_frames_absolute?: number | null;
+  /** Valid frame counts are `k * frame_step + 1`. */
+  frame_step?: number | null;
 }
 
 export interface GpuInfo {


### PR DESCRIPTION
## Summary
- add per-model video duration sliders in general and advanced Create controls across web, desktop, iPhone, and TUI
- keep exact frame/FPS editing and automatic long-video sequence behavior while honoring model frame grids and legacy LTX-2 limits
- extend desktop Now Developing and web Recent history to use larger workspaces without retaining heavy media payloads

## Verification
- focused Studio, shared UI, web, desktop, mobile, generation-store, and TUI tests
- web, desktop, and mobile production builds
- frontend architecture, dead-code, formatting, Rust fmt, TUI clippy, and diff checks
- rendered desktop and phone browser QA
- independent subagent peer review with all findings resolved