### PR TITLE
refactor(ui): share overlay root focus lifecycle

### DIFF
--- a/ui/components/DrawerPanel.vue
+++ b/ui/components/DrawerPanel.vue
@@ -5,7 +5,8 @@
  * ancestor, never Teleport or position:fixed. Backdrop click and Esc close;
  * clicks inside the panel do not.
  */
-import { nextTick, onMounted, ref, useSlots, watch } from "vue";
+import { ref, useSlots } from "vue";
+import { useRootFocusOnOpen } from "../lib/useRootFocusOnOpen";
 import Icon from "./Icon.vue";
 
 const props = withDefaults(
@@ -23,22 +24,7 @@ const emit = defineEmits<{ close: [] }>();
 
 const slots = useSlots();
 const root = ref<HTMLElement | null>(null);
-
-async function focusRoot() {
-  await nextTick();
-  root.value?.focus();
-}
-
-onMounted(() => {
-  if (props.open) focusRoot();
-});
-
-watch(
-  () => props.open,
-  (open) => {
-    if (open) focusRoot();
-  },
-);
+useRootFocusOnOpen(root, () => props.open);
 </script>
 
 <template>

--- a/ui/components/ModalPanel.vue
+++ b/ui/components/ModalPanel.vue
@@ -5,7 +5,8 @@
  * absolute overlay, never Teleport or position:fixed. Backdrop click and
  * Esc close; clicks inside the panel do not.
  */
-import { nextTick, onMounted, ref, useSlots, watch } from "vue";
+import { ref, useSlots } from "vue";
+import { useRootFocusOnOpen } from "../lib/useRootFocusOnOpen";
 
 const props = withDefaults(
   defineProps<{
@@ -26,22 +27,7 @@ const emit = defineEmits<{ close: [] }>();
 
 const slots = useSlots();
 const root = ref<HTMLElement | null>(null);
-
-async function focusRoot() {
-  await nextTick();
-  root.value?.focus();
-}
-
-onMounted(() => {
-  if (props.open) focusRoot();
-});
-
-watch(
-  () => props.open,
-  (open) => {
-    if (open) focusRoot();
-  },
-);
+useRootFocusOnOpen(root, () => props.open);
 </script>
 
 <template>

--- a/ui/components/SheetPanel.vue
+++ b/ui/components/SheetPanel.vue
@@ -5,7 +5,8 @@
  * frame: absolute overlay, never Teleport or position:fixed. Backdrop
  * click and Esc close; clicks inside the panel do not.
  */
-import { nextTick, onMounted, ref, watch } from "vue";
+import { ref } from "vue";
+import { useRootFocusOnOpen } from "../lib/useRootFocusOnOpen";
 import Icon from "./Icon.vue";
 
 const props = withDefaults(
@@ -21,22 +22,7 @@ const props = withDefaults(
 const emit = defineEmits<{ close: [] }>();
 
 const root = ref<HTMLElement | null>(null);
-
-async function focusRoot() {
-  await nextTick();
-  root.value?.focus();
-}
-
-onMounted(() => {
-  if (props.open) focusRoot();
-});
-
-watch(
-  () => props.open,
-  (open) => {
-    if (open) focusRoot();
-  },
-);
+useRootFocusOnOpen(root, () => props.open);
 </script>
 
 <template>

--- a/ui/lib/useRootFocusOnOpen.ts
+++ b/ui/lib/useRootFocusOnOpen.ts
@@ -1,0 +1,19 @@
+import { nextTick, onMounted, watch, type Ref } from "vue";
+
+/** Focus an overlay root after it is initially rendered or reopened. */
+export function useRootFocusOnOpen(
+  root: Ref<HTMLElement | null>,
+  open: () => boolean,
+) {
+  async function focusRoot() {
+    await nextTick();
+    root.value?.focus();
+  }
+
+  onMounted(() => {
+    if (open()) void focusRoot();
+  });
+  watch(open, (isOpen) => {
+    if (isOpen) void focusRoot();
+  });
+}


### PR DESCRIPTION
## Summary

- replace three identical overlay-root focus lifecycle implementations with one shared `useRootFocusOnOpen` helper
- preserve each component's existing root ref, mount-time focus, reopen focus, and `nextTick` timing
- keep the cleanup limited to hand-written UI production source

## Reduction evidence

Reproduce from this branch with:

```bash
git diff origin/main...HEAD --numstat -- \
  ui/components/DrawerPanel.vue \
  ui/components/ModalPanel.vue \
  ui/components/SheetPanel.vue \
  ui/lib/useRootFocusOnOpen.ts
```

Result:

```text
3  17  ui/components/DrawerPanel.vue
3  17  ui/components/ModalPanel.vue
3  17  ui/components/SheetPanel.vue
19 0   ui/lib/useRootFocusOnOpen.ts
```

Hand-written non-test production source changes by **28 additions / 51 deletions, net -23 lines**. The affected production files shrink from **525 to 502 lines**. No tests, generated files, vendor files, lockfiles, or dependencies changed.

Structurally, three copies of the `nextTick` + mount watcher + reopen watcher sequence become one typed helper. This removes duplicated lifecycle policy instead of moving or formatting the same amount of code.

## Behavior preservation

The existing overlay component tests directly characterize focus on open. The same focused command passed before and after the refactor: **3 files, 31 tests**.

```bash
bunx vitest run --config studio/vitest.config.ts --root . \
  ui/components/DrawerPanel.test.ts \
  ui/components/SheetPanel.test.ts \
  ui/components/ModalPanel.test.ts
```

## Validation

All applicable path-triggered CI-equivalent checks passed locally:

```bash
bun install --frozen-lockfile
bun run check:architecture
bun run check:dead-code
bun run test:studio                         # 369 passed
cd web && bun run fmt:check
cd web && bun run test                      # 1,149 passed
cd web && bun run build
cd desktop && bun run fmt:check
cd desktop && bunx vue-tsc -b
cd desktop && bun run test                  # 2,870 passed
cd desktop && bun run build
cd desktop && bun run build:mobile
bash scripts/tests/ios-release-assets.sh
bash scripts/tests/ios-testflight-distribution.sh
bash scripts/tests/ios-sim-pick.sh
nix build .#mold-web --print-build-logs
git diff --check
```

The production builds retain their existing Vite chunk-size warnings; all commands exited successfully.
