### PR TITLE
refactor(models): share catalog scroll sentinel

### DIFF
--- a/desktop/src/components/models/CatalogTab.vue
+++ b/desktop/src/components/models/CatalogTab.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { computed, onMounted, ref, watch } from "vue";
 import CatalogLayoutToggle, {
   type CatalogLayoutChoice,
 } from "@ui/components/CatalogLayoutToggle.vue";
@@ -22,6 +22,7 @@ import {
 } from "../../lib/catalogFilters";
 import { isCatalogModelId, modelDisplayName } from "../../lib/models";
 import { type MediaType } from "../../lib/modelAvailability";
+import { useInfiniteScrollSentinel } from "../../lib/useInfiniteScrollSentinel";
 import CatalogCard from "./CatalogCard.vue";
 import CatalogTableRow from "./CatalogTableRow.vue";
 import CatalogDetailDrawer, { type DrawerVariant } from "./CatalogDetailDrawer.vue";
@@ -378,48 +379,8 @@ function loadMore() {
   void runSearch(false);
 }
 
-/** End-of-list sentinel: scrolling near it fetches the next page — the
- *  old Load more button read as a dead end and (worse) looked broken
- *  whenever upstream paging returned duplicate rows the dedup swallowed. */
 const sentinel = ref<HTMLElement | null>(null);
-const sentinelVisible = ref(false);
-/** Fetches chained since the last real intersection event — bounded like
- *  the media-filter auto-fetch so a dedup-swallowed page can't loop. */
-let chainedFetches = 0;
-let observer: IntersectionObserver | null = null;
-
-watch(sentinel, (el) => {
-  observer?.disconnect();
-  observer = null;
-  sentinelVisible.value = false;
-  if (!el) return;
-  observer = new IntersectionObserver(
-    (hits) => {
-      for (const hit of hits) sentinelVisible.value = hit.isIntersecting;
-      if (sentinelVisible.value) {
-        chainedFetches = 0;
-        loadMore();
-      }
-    },
-    { rootMargin: "600px 0px" },
-  );
-  observer.observe(el);
-});
-
-// A page that lands without pushing the sentinel out of view (dedup or the
-// media filter swallowed its rows) emits no new intersection event, so the
-// observer alone would stall. Chain the next fetch while the sentinel is
-// still visible, up to the auto-fetch bound.
-watch(loading, (isLoading) => {
-  if (isLoading || !sentinelVisible.value || !hasMore.value) return;
-  if (chainedFetches >= MAX_AUTO_PAGES) return;
-  chainedFetches += 1;
-  loadMore();
-});
-
-onBeforeUnmount(() => {
-  observer?.disconnect();
-});
+useInfiniteScrollSentinel(sentinel, loading, hasMore, loadMore, MAX_AUTO_PAGES);
 
 async function pullTo(entry: CatalogEntry, host: HostView | null) {
   pulling.value.add(entry.id);

--- a/desktop/src/lib/useInfiniteScrollSentinel.ts
+++ b/desktop/src/lib/useInfiniteScrollSentinel.ts
@@ -1,0 +1,45 @@
+import { onBeforeUnmount, ref, watch, type Ref } from "vue";
+
+/**
+ * Loads more results while an end-of-list sentinel is visible. A bounded
+ * follow-up loop handles pages that do not move the sentinel because every
+ * returned row was filtered out or deduplicated.
+ */
+export function useInfiniteScrollSentinel(
+  sentinel: Ref<HTMLElement | null>,
+  loading: Ref<boolean>,
+  hasMore: Ref<boolean>,
+  loadMore: () => void,
+  maxChainedFetches: number,
+) {
+  const sentinelVisible = ref(false);
+  let chainedFetches = 0;
+  let observer: IntersectionObserver | null = null;
+
+  watch(sentinel, (element) => {
+    observer?.disconnect();
+    observer = null;
+    sentinelVisible.value = false;
+    if (!element) return;
+    observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) sentinelVisible.value = entry.isIntersecting;
+        if (sentinelVisible.value) {
+          chainedFetches = 0;
+          loadMore();
+        }
+      },
+      { rootMargin: "600px 0px" },
+    );
+    observer.observe(element);
+  });
+
+  watch(loading, (isLoading) => {
+    if (isLoading || !sentinelVisible.value || !hasMore.value) return;
+    if (chainedFetches >= maxChainedFetches) return;
+    chainedFetches += 1;
+    loadMore();
+  });
+
+  onBeforeUnmount(() => observer?.disconnect());
+}

--- a/desktop/src/mobile/MobileCatalogView.vue
+++ b/desktop/src/mobile/MobileCatalogView.vue
@@ -42,6 +42,7 @@ import {
 } from "@studio/lib/modelInstallTargets";
 import { catalogThumbnailUrl } from "../lib/catalogThumbnails";
 import { isVideoFamily } from "../lib/capabilities";
+import { useInfiniteScrollSentinel } from "../lib/useInfiniteScrollSentinel";
 import { formatCount, formatGB, percent } from "../lib/format";
 import {
   isCatalogModelId,
@@ -640,44 +641,8 @@ function loadMore(): void {
   void runSearch(false);
 }
 
-/** End-of-list sentinel: scrolling near it fetches the next page — the
- *  old Load more button read as a dead end and (worse) looked broken
- *  whenever upstream paging returned duplicate rows the dedup swallowed. */
 const sentinel = ref<HTMLElement | null>(null);
-const sentinelVisible = ref(false);
-/** Fetches chained since the last real intersection event — bounded like
- *  the media-filter auto-fetch so a dedup-swallowed page can't loop. */
-let chainedFetches = 0;
-let sentinelObserver: IntersectionObserver | null = null;
-
-watch(sentinel, (el) => {
-  sentinelObserver?.disconnect();
-  sentinelObserver = null;
-  sentinelVisible.value = false;
-  if (!el) return;
-  sentinelObserver = new IntersectionObserver(
-    (hits) => {
-      for (const hit of hits) sentinelVisible.value = hit.isIntersecting;
-      if (sentinelVisible.value) {
-        chainedFetches = 0;
-        loadMore();
-      }
-    },
-    { rootMargin: "600px 0px" },
-  );
-  sentinelObserver.observe(el);
-});
-
-// A page that lands without pushing the sentinel out of view (dedup or the
-// media filter swallowed its rows) emits no new intersection event, so the
-// observer alone would stall. Chain the next fetch while the sentinel is
-// still visible, up to the auto-fetch bound.
-watch(loading, (isLoading) => {
-  if (isLoading || !sentinelVisible.value || !hasMore.value) return;
-  if (chainedFetches >= MAX_AUTO_PAGES) return;
-  chainedFetches += 1;
-  loadMore();
-});
+useInfiniteScrollSentinel(sentinel, loading, hasMore, loadMore, MAX_AUTO_PAGES);
 
 async function loadFamilies(): Promise<void> {
   const target = selectedTarget.value;
@@ -1132,7 +1097,6 @@ onBeforeUnmount(() => {
   ++modelsEpoch;
   ++detailEpoch;
   if (debounce) clearTimeout(debounce);
-  sentinelObserver?.disconnect();
   deactivateInteractions();
   mobileDownloads.unregisterConsumer(DOWNLOAD_CONSUMER_ID);
 });


### PR DESCRIPTION
## Summary

- extract the duplicated catalog infinite-scroll observer lifecycle into one shared composable
- keep desktop Discover and iPhone Discover responsible for their existing search, paging, and UI policy
- preserve observer replacement, 600 px prefetch margin, bounded chained fetches, and unmount cleanup

## Code reduction

Reproducible command:

```console
git diff --numstat origin/main...HEAD -- \
  desktop/src/components/models/CatalogTab.vue \
  desktop/src/lib/useInfiniteScrollSentinel.ts \
  desktop/src/mobile/MobileCatalogView.vue
```

Result:

```text
3       42      desktop/src/components/models/CatalogTab.vue
45      0       desktop/src/lib/useInfiniteScrollSentinel.ts
2       38      desktop/src/mobile/MobileCatalogView.vue
```

Hand-written non-test production source: **50 additions / 80 deletions, net -30 lines**. Aggregate size for the affected production files fell from **2,453 to 2,423 lines**. Structurally, two independent copies of the same observer/visibility/chained-fetch lifecycle are now one implementation with two callers.

Tests changed: **0 additions / 0 deletions**. Generated, vendor, lock, dependency, and documentation files are unchanged.

## Behavior preservation

Before editing, the two existing catalog characterization suites passed **70/70 tests**. The same suites pass after extraction and cover:

- loading the next page when the sentinel enters view
- stopping at server-reported exhaustion
- leaving and re-entering the viewport
- continuing across filtered or deduplicated pages that do not move the sentinel
- bounding chained fetches at the existing five-page limit

The full desktop/mobile suite also passes **2,877/2,877 tests**.

## Validation

- `bun install --frozen-lockfile`
- `bun run check:architecture`
- `bun run check:dead-code`
- `cd desktop && bun run fmt:check`
- `cd desktop && bunx vue-tsc -b --pretty false`
- `cd desktop && bunx vitest run --config vitest.config.ts src/components/models/CatalogTab.test.ts src/mobile/MobileCatalogView.test.ts` — 70 passed
- `cd desktop && bun run test` — 2,877 passed
- `cd desktop && bun run build`
- `cd desktop && ../scripts/tests/ios-release-assets.sh` — includes mobile build; passed
- `cd desktop && ../scripts/tests/ios-testflight-distribution.sh`
- `cd desktop && ../scripts/tests/ios-sim-pick.sh`

Vite emitted its existing chunk-size/dynamic-import warnings; all commands exited successfully. Rust and docs gates are not path-applicable because this PR changes only desktop/mobile TypeScript and Vue production source.
