### PR TITLE
fix(desktop): type sequence import test exposure

### DIFF
--- a/desktop/src/components/create/SequenceComposer.test.ts
+++ b/desktop/src/components/create/SequenceComposer.test.ts
@@ -430,7 +430,11 @@ describe("SequenceComposer — TOML import", () => {
       'prompt = "ending"',
       "frames = 25",
     ].join("\n");
-    await wrapper.vm.importTomlText(toml);
+    const { importTomlText } = wrapper.vm as unknown as {
+      importTomlText?: (text: string, filename?: string) => Promise<void>;
+    };
+    if (!importTomlText) throw new Error("SequenceComposer did not expose importTomlText");
+    await importTomlText(toml);
     await flushPromises();
 
     expect(liveForm.strength).toBe(0.4);


### PR DESCRIPTION
## Summary

- declare the SequenceComposer exposed test method at the Vue wrapper boundary
- retain a runtime guard if the component stops exposing importTomlText
- restore cold-sandbox vue-tsc compatibility without excluding tests from type-checking

## Root cause

Cold Nix builds resolve the SFC through the generic .vue shim, which cannot infer defineExpose. The test therefore saw wrapper.vm.importTomlText as undefined, even though warm local TypeScript state could infer the runtime exposure.

## Verification

- nix develop -c bunx prettier --check desktop/src/components/create/SequenceComposer.test.ts
- focused SequenceComposer.test.ts: 18 passed
- nix build .#mold-desktop-web --no-link

Closes #670