### PR TITLE
fix(studio): preserve long-video advanced settings

### DIFF
--- a/desktop/src/components/create/AdvancedSettings.test.ts
+++ b/desktop/src/components/create/AdvancedSettings.test.ts
@@ -355,6 +355,20 @@ describe("AdvancedSettings — video (LTX-2)", () => {
     expect(wrapper.get("[data-test='chain-cue']").text()).toContain("chained clips of 97 frames");
   });
 
+  it("explains when advanced settings keep a long request single-shot", async () => {
+    const form = formFor("ltx2");
+    form.model = "ltx-2.3-22b-distilled:fp8";
+    form.frames = 153;
+    form.negativePrompt = "flicker";
+    const wrapper = mountSettings(form);
+    await openSection(wrapper, "Video");
+
+    expect(wrapper.get("[data-test='single-shot-preservation-cue']").text()).toContain(
+      "one 153-frame clip to preserve negative prompt",
+    );
+    expect(wrapper.find("[data-test='chain-compatibility-error']").exists()).toBe(false);
+  });
+
   it("shows the reject message when a chain would exceed the stage ceiling", async () => {
     const form = formFor("ltx2");
     form.model = "ltx-2-19b:fp8";

--- a/desktop/src/components/create/AdvancedSettings.vue
+++ b/desktop/src/components/create/AdvancedSettings.vue
@@ -28,8 +28,8 @@ import {
 } from "../../lib/capabilities";
 import { frames8n1Error, snapFrames } from "../../lib/chain";
 import {
+  autoChainFieldList,
   decideGenerateRequestRouting,
-  unsupportedAutoChainFields,
   type ChainRoutingDecision,
 } from "../../lib/chainRouting";
 import { fileToBase64 } from "../../lib/image";
@@ -148,11 +148,10 @@ const chainDecision = computed<ChainRoutingDecision>(() =>
     ? decideGenerateRequestRouting(generationRequest.value, props.form.family)
     : { kind: "single" },
 );
-const chainCompatibilityError = computed(() => {
-  if (chainDecision.value.kind !== "chain") return null;
-  return unsupportedAutoChainFields(generationRequest.value).length > 0
-    ? "Long-video chaining can’t preserve the selected advanced options. Remove them or reduce Frames to 97 or fewer."
-    : null;
+const singleShotPreservationNote = computed(() => {
+  const decision = chainDecision.value;
+  if (decision.kind !== "single" || !decision.preservedAutoChainFields?.length) return null;
+  return `Will render as one ${props.form.frames}-frame clip to preserve ${autoChainFieldList(decision.preservedAutoChainFields)}. This may use more GPU memory than automatic chaining.`;
 });
 const fpsError = computed(() =>
   caps.value.supportsVideo ? fpsValidationError(props.form.fps) : null,
@@ -550,16 +549,19 @@ function reset() {
         />
         <p v-if="framesError" class="ms-error">{{ framesError }}</p>
 
-        <div
-          v-if="chainDecision.kind === 'chain' && !chainCompatibilityError"
-          data-test="chain-cue"
-          class="ms-cue"
-        >
+        <div v-if="chainDecision.kind === 'chain'" data-test="chain-cue" class="ms-cue">
           Will render as
           <span class="data-mono font-semibold text-ink">{{ chainDecision.stageCount }}</span>
           chained clips of {{ chainDecision.clipFrames }} frames (motion-tail
           {{ chainDecision.motionTail }}) — expect this to take substantially longer than a single
           clip.
+        </div>
+        <div
+          v-else-if="singleShotPreservationNote"
+          data-test="single-shot-preservation-cue"
+          class="ms-cue"
+        >
+          {{ singleShotPreservationNote }}
         </div>
         <p
           v-else-if="chainDecision.kind === 'reject'"
@@ -567,13 +569,6 @@ function reset() {
           class="ms-error ms-error--mt"
         >
           {{ chainDecision.reason }}
-        </p>
-        <p
-          v-else-if="chainCompatibilityError"
-          data-test="chain-compatibility-error"
-          class="ms-error ms-error--mt"
-        >
-          {{ chainCompatibilityError }}
         </p>
 
         <label class="ms-label ms-label--mt">FPS</label>

--- a/desktop/src/lib/chainRouting.test.ts
+++ b/desktop/src/lib/chainRouting.test.ts
@@ -231,8 +231,8 @@ describe("request-aware generation routing", () => {
     });
   });
 
-  it("estimates one concrete batch sibling and one chain clip", () => {
-    const chained = {
+  it("estimates one sibling using the concrete render selected by safe routing", () => {
+    const advancedSingle = {
       ...request,
       model: "ltx-2-19b-distilled:fp8",
       frames: 241,
@@ -243,18 +243,26 @@ describe("request-aware generation routing", () => {
       control_model: "controlnet-canny-sd15",
       control_scale: 0.8,
     };
-    delete chained.temporal_upscale;
-    expect(buildGenerationEstimateRequest(chained, "ltx2")).toMatchObject({
+    delete advancedSingle.temporal_upscale;
+    expect(buildGenerationEstimateRequest(advancedSingle, "ltx2")).toMatchObject({
       batch_size: 1,
-      frames: 97,
+      frames: 241,
     });
-    const estimate = buildGenerationEstimateRequest(chained, "ltx2");
+    const estimate = buildGenerationEstimateRequest(advancedSingle, "ltx2");
     expect(estimate).not.toHaveProperty("source_video");
     expect(estimate).not.toHaveProperty("keyframes");
     expect(estimate).not.toHaveProperty("audio_file");
     expect(estimate).not.toHaveProperty("control_image");
     expect(estimate).not.toHaveProperty("control_model");
     expect(estimate).not.toHaveProperty("control_scale");
+    const compatibleChain: GenerateRequest = { ...advancedSingle };
+    delete compatibleChain.source_video;
+    delete compatibleChain.keyframes;
+    delete compatibleChain.audio_file;
+    expect(buildGenerationEstimateRequest(compatibleChain, "ltx2")).toMatchObject({
+      batch_size: 1,
+      frames: 97,
+    });
     expect(buildGenerationEstimateRequest(request, "ltx2")).toMatchObject({
       batch_size: 1,
       frames: 257,
@@ -346,6 +354,33 @@ describe("automatic chain request projection", () => {
       "temporal_upscale",
       "guidance_overrides",
     ]);
+  });
+
+  it("keeps an in-budget long request single-shot when chaining would lose settings", () => {
+    const decision = decideGenerateRequestRouting(
+      {
+        ...request,
+        frames: 153,
+        negative_prompt: "text",
+        loras: [{ path: "/models/style.safetensors", scale: 0.8 }],
+      },
+      "ltx2",
+    );
+
+    expect(decision).toEqual({
+      kind: "single",
+      preservedAutoChainFields: ["negative_prompt", "loras"],
+    });
+  });
+
+  it("rejects incompatible chaining only past the single-shot cap", () => {
+    expect(
+      decideGenerateRequestRouting({ ...request, frames: 489, negative_prompt: "text" }, "ltx2"),
+    ).toEqual({
+      kind: "reject",
+      reason:
+        "489 frames exceeds the 481-frame single-shot limit at 24 fps, and automatic chaining can’t preserve negative prompt. Reduce Frames, remove that option, or author a Sequence with compatible per-clip settings.",
+    });
   });
 
   it("ignores empty optional values and reports singular LoRA compatibility", () => {

--- a/desktop/src/lib/chainRouting.ts
+++ b/desktop/src/lib/chainRouting.ts
@@ -7,57 +7,22 @@ import { decideGenerateRequestRouting, type ChainRoutingDecision } from "@studio
 import type { AutoChainRequest, GenerateRequest } from "./api/types";
 
 export {
+  AUTO_CHAIN_FIELD_LABELS,
   DEFAULT_MOTION_TAIL,
   LTX2_DEFAULT_CLIP_FRAMES,
   MAX_CHAIN_STAGES,
+  autoChainFieldList,
   decideChainRouting,
   decideGenerateRequestRouting,
+  unsupportedAutoChainFields,
 } from "@studio/lib/chainRouting";
-export type { ChainRoutingDecision } from "@studio/lib/chainRouting";
+export type { AutoChainUnsupportedField, ChainRoutingDecision } from "@studio/lib/chainRouting";
 
 export type AutoChainRoutingDecision = Extract<ChainRoutingDecision, { kind: "chain" }>;
 
-/** GenerateRequest features the server's auto-expand chain form cannot carry. */
-export type AutoChainUnsupportedField =
-  | "negative_prompt"
-  | "loras"
-  | "audio_file"
-  | "source_video"
-  | "keyframes"
-  | "pipeline"
-  | "ic_lora_control"
-  | "retake_range"
-  | "spatial_upscale"
-  | "temporal_upscale"
-  | "guidance_overrides";
-
-/** Report meaningful fields that would be lost when a normal generation is
- * routed through the auto-expand chain endpoint. Camera control rides the
- * LoRA wire fields, so it is intentionally reported as `loras` too. */
-export function unsupportedAutoChainFields(req: GenerateRequest): AutoChainUnsupportedField[] {
-  const unsupported: AutoChainUnsupportedField[] = [];
-  if (req.negative_prompt?.trim()) unsupported.push("negative_prompt");
-  if ((req.loras?.length ?? 0) > 0 || req.lora) unsupported.push("loras");
-  if (req.audio_file) unsupported.push("audio_file");
-  if (req.source_video) unsupported.push("source_video");
-  if ((req.keyframes?.length ?? 0) > 0) unsupported.push("keyframes");
-  if (req.pipeline) unsupported.push("pipeline");
-  if (req.ic_lora_control) unsupported.push("ic_lora_control");
-  if (req.retake_range) unsupported.push("retake_range");
-  if (req.spatial_upscale) unsupported.push("spatial_upscale");
-  if (req.temporal_upscale) unsupported.push("temporal_upscale");
-  const hasGuidanceOverride = Object.values(req.guidance_overrides ?? {}).some((value) =>
-    Array.isArray(value) ? value.length > 0 : value !== null && value !== undefined,
-  );
-  if (hasGuidanceOverride) {
-    unsupported.push("guidance_overrides");
-  }
-  return unsupported;
-}
-
 /** Project a normal GenerateRequest onto the chain endpoint's auto-expand
- * wire contract. Call `unsupportedAutoChainFields` first so the UI can reject
- * an incompatible request instead of silently dropping it. */
+ * wire contract. Only call this after `decideGenerateRequestRouting` returns a
+ * chain decision; incompatible requests stay single-shot or are rejected. */
 export function buildAutoChainRequest(
   req: GenerateRequest,
   decision: AutoChainRoutingDecision,

--- a/desktop/src/mobile/MobileGenerateParameters.test.ts
+++ b/desktop/src/mobile/MobileGenerateParameters.test.ts
@@ -232,7 +232,7 @@ describe("MobileGenerateParameters", () => {
     );
   });
 
-  it("blocks long-video chaining when selected settings cannot survive the chain wire", async () => {
+  it("keeps a long request single-shot when chaining would lose selected settings", async () => {
     const form = formFor("ltx2", "ltx-2-19b-distilled:fp8");
     form.frames = 177;
     form.negativePrompt = "flicker";
@@ -240,10 +240,10 @@ describe("MobileGenerateParameters", () => {
     const child = chain.wrapper.getComponent(MobileGenerateParameters);
 
     expect(chain.wrapper.find("[data-test='mobile-chain-cue']").exists()).toBe(false);
-    expect(chain.wrapper.get("[data-test='mobile-chain-compatibility-error']").text()).toContain(
-      "negative prompt",
+    expect(chain.wrapper.get("[data-test='mobile-single-shot-preservation-cue']").text()).toContain(
+      "one 177-frame clip to preserve negative prompt",
     );
-    expect(child.emitted("validity-change")?.at(-1)).toEqual([false]);
+    expect(child.emitted("validity-change")?.at(-1)).toEqual([true]);
 
     chain.form.negativePrompt = "";
     await flushPromises();

--- a/desktop/src/mobile/MobileGenerateParameters.vue
+++ b/desktop/src/mobile/MobileGenerateParameters.vue
@@ -12,9 +12,8 @@ import type {
 import { generationCapabilitiesForFamily, MAX_LORA_STACK } from "../lib/capabilities";
 import { frames8n1Error, snapFrames } from "../lib/chain";
 import {
+  autoChainFieldList,
   decideGenerateRequestRouting,
-  unsupportedAutoChainFields,
-  type AutoChainUnsupportedField,
   type ChainRoutingDecision,
 } from "../lib/chainRouting";
 import { buildRequest, type GenerateForm, type PickedImage } from "../lib/generateForm";
@@ -104,26 +103,10 @@ const chainDecision = computed<ChainRoutingDecision>(() =>
     : { kind: "single" },
 );
 
-const AUTO_CHAIN_FIELD_LABELS: Record<AutoChainUnsupportedField, string> = {
-  negative_prompt: "negative prompt",
-  loras: "LoRAs or camera motion",
-  audio_file: "conditioning audio",
-  source_video: "source video",
-  keyframes: "keyframes",
-  pipeline: "pipeline",
-  ic_lora_control: "reference control",
-  retake_range: "retake range",
-  spatial_upscale: "spatial upscale",
-  temporal_upscale: "temporal upscale",
-  guidance_overrides: "guidance overrides",
-};
-
-const chainCompatibilityError = computed(() => {
-  if (chainDecision.value.kind !== "chain") return null;
-  const unsupported = unsupportedAutoChainFields(generationRequest.value);
-  if (unsupported.length === 0) return null;
-  const labels = unsupported.map((field) => AUTO_CHAIN_FIELD_LABELS[field]);
-  return `Long-video chaining can’t preserve ${labels.join(", ")}. Remove those options or reduce Frames to 97 or fewer.`;
+const singleShotPreservationNote = computed(() => {
+  const decision = chainDecision.value;
+  if (decision.kind !== "single" || !decision.preservedAutoChainFields?.length) return null;
+  return `Rendering one ${props.form.frames}-frame clip to preserve ${autoChainFieldList(decision.preservedAutoChainFields)}. This may use more GPU memory than automatic chaining.`;
 });
 
 const audioFormatError = computed(() => audioOutputValidationError(props.form));
@@ -141,7 +124,6 @@ const valid = computed(
     !frameError.value &&
     !fpsError.value &&
     chainDecision.value.kind !== "reject" &&
-    !chainCompatibilityError.value &&
     !audioFormatError.value &&
     !advancedVideoError.value &&
     !cameraError.value,
@@ -658,7 +640,7 @@ const fpsErrorId = `mobile-fps-error-${useId()}`;
         {{ fpsError }}
       </p>
       <p
-        v-if="chainDecision.kind === 'chain' && !chainCompatibilityError"
+        v-if="chainDecision.kind === 'chain'"
         class="mobile-generate-callout"
         data-test="mobile-chain-cue"
       >
@@ -667,20 +649,19 @@ const fpsErrorId = `mobile-fps-error-${useId()}`;
         tail.
       </p>
       <p
+        v-else-if="singleShotPreservationNote"
+        class="mobile-generate-callout"
+        data-test="mobile-single-shot-preservation-cue"
+      >
+        {{ singleShotPreservationNote }}
+      </p>
+      <p
         v-else-if="chainDecision.kind === 'reject'"
         class="mobile-generate-validation"
         role="alert"
         data-test="mobile-chain-reject"
       >
         {{ chainDecision.reason }}
-      </p>
-      <p
-        v-else-if="chainCompatibilityError"
-        class="mobile-generate-validation"
-        role="alert"
-        data-test="mobile-chain-compatibility-error"
-      >
-        {{ chainCompatibilityError }}
       </p>
 
       <label v-if="caps.supportsAudio" class="mobile-generate-toggle-row">

--- a/studio/lib/chainRouting.ts
+++ b/studio/lib/chainRouting.ts
@@ -20,7 +20,12 @@ export const MAX_CHAIN_STAGES = 16;
 export const DEFAULT_MOTION_TAIL = 17;
 
 export type ChainRoutingDecision =
-  | { kind: "single" }
+  | {
+      kind: "single";
+      /** Options that forced an otherwise automatic chain to remain one
+       * render so their request semantics are preserved. */
+      preservedAutoChainFields?: AutoChainUnsupportedField[];
+    }
   | {
       kind: "chain";
       clipFrames: number;
@@ -33,8 +38,98 @@ type GenerateRoutingRequest = {
   frames?: number | null;
   fps?: number | null;
   model: string;
+  negative_prompt?: string | null;
+  loras?: readonly unknown[] | null;
+  lora?: unknown;
+  audio_file?: string | null;
+  audio_file_path?: string | null;
+  source_video?: string | null;
+  source_video_path?: string | null;
+  extend_video?: string | null;
+  extend_video_path?: string | null;
+  extend_overlap_frames?: number | null;
+  keyframes?: readonly unknown[] | null;
+  pipeline?: unknown;
+  ic_lora_control?: string | null;
+  retake_range?: unknown;
+  spatial_upscale?: unknown;
   temporal_upscale?: string | null;
+  guidance_overrides?: object | null;
 };
+
+export type AutoChainUnsupportedField =
+  | "negative_prompt"
+  | "loras"
+  | "audio_file"
+  | "source_video"
+  | "extend_video"
+  | "keyframes"
+  | "pipeline"
+  | "ic_lora_control"
+  | "retake_range"
+  | "spatial_upscale"
+  | "temporal_upscale"
+  | "guidance_overrides";
+
+export const AUTO_CHAIN_FIELD_LABELS: Readonly<
+  Record<AutoChainUnsupportedField, string>
+> = {
+  negative_prompt: "negative prompt",
+  loras: "LoRAs or camera motion",
+  audio_file: "conditioning audio",
+  source_video: "source video",
+  extend_video: "video continuation",
+  keyframes: "keyframes",
+  pipeline: "pipeline selection",
+  ic_lora_control: "reference control",
+  retake_range: "retake range",
+  spatial_upscale: "spatial upscale",
+  temporal_upscale: "temporal upscale",
+  guidance_overrides: "guidance overrides",
+};
+
+/** Fields the auto-expand chain form cannot carry without silently changing
+ * the request. Canonical authored Sequences support a wider per-clip schema. */
+export function unsupportedAutoChainFields(
+  req: GenerateRoutingRequest,
+): AutoChainUnsupportedField[] {
+  const unsupported: AutoChainUnsupportedField[] = [];
+  if (req.negative_prompt?.trim()) unsupported.push("negative_prompt");
+  if ((req.loras?.length ?? 0) > 0 || req.lora) unsupported.push("loras");
+  if (req.audio_file || req.audio_file_path) unsupported.push("audio_file");
+  if (req.source_video || req.source_video_path)
+    unsupported.push("source_video");
+  if (
+    req.extend_video ||
+    req.extend_video_path ||
+    req.extend_overlap_frames != null
+  ) {
+    unsupported.push("extend_video");
+  }
+  if ((req.keyframes?.length ?? 0) > 0) unsupported.push("keyframes");
+  if (req.pipeline) unsupported.push("pipeline");
+  if (req.ic_lora_control) unsupported.push("ic_lora_control");
+  if (req.retake_range) unsupported.push("retake_range");
+  if (req.spatial_upscale) unsupported.push("spatial_upscale");
+  if (req.temporal_upscale) unsupported.push("temporal_upscale");
+  const hasGuidanceOverride = Object.values(req.guidance_overrides ?? {}).some(
+    (value) =>
+      Array.isArray(value)
+        ? value.length > 0
+        : value !== null && value !== undefined,
+  );
+  if (hasGuidanceOverride) unsupported.push("guidance_overrides");
+  return unsupported;
+}
+
+export function autoChainFieldList(
+  fields: readonly AutoChainUnsupportedField[],
+): string {
+  const labels = fields.map((field) => AUTO_CHAIN_FIELD_LABELS[field]);
+  if (labels.length <= 1) return labels[0] ?? "selected options";
+  if (labels.length === 2) return `${labels[0]} and ${labels[1]}`;
+  return `${labels.slice(0, -1).join(", ")}, and ${labels.at(-1)}`;
+}
 
 /** Families accepted by the server's `chain_limits::family_cap` whitelist. */
 const CHAIN_CAPABLE_FAMILIES: ReadonlySet<string> = new Set([
@@ -74,7 +169,34 @@ export function decideGenerateRequestRouting(
           reason: `Temporal x2 renders the same duration as a plain request, so it is still capped at ${cap} frames at ${req.fps ?? 24} fps. Reduce the frame count or raise fps.`,
         };
   }
-  return decideChainRouting(frames, family, req.model, motionTail, req.fps);
+  const decision = decideChainRouting(
+    frames,
+    family,
+    req.model,
+    motionTail,
+    req.fps,
+  );
+  if (decision.kind !== "chain") return decision;
+
+  const unsupported = unsupportedAutoChainFields(req);
+  if (unsupported.length === 0) return decision;
+
+  const singleShotCap = maxFramesForFamilyAtFps(
+    canonicalizeFamily(family),
+    req.fps,
+  );
+  const frameCount = frames ?? 0;
+  if (singleShotCap !== null && frameCount <= singleShotCap) {
+    return { kind: "single", preservedAutoChainFields: unsupported };
+  }
+
+  const fps = Math.max(1, Math.floor(req.fps ?? 24));
+  const options = autoChainFieldList(unsupported);
+  const determiner = unsupported.length === 1 ? "that option" : "those options";
+  return {
+    kind: "reject",
+    reason: `${frameCount} frames exceeds the ${singleShotCap ?? 97}-frame single-shot limit at ${fps} fps, and automatic chaining can’t preserve ${options}. Reduce Frames, remove ${determiner}, or author a Sequence with compatible per-clip settings.`,
+  };
 }
 
 export function decideChainRouting(

--- a/web/src/lib/chainRouting.test.ts
+++ b/web/src/lib/chainRouting.test.ts
@@ -179,6 +179,42 @@ describe("decideChainRouting", () => {
     });
   });
 
+  it("preserves advanced LTX-2 inputs by staying single-shot inside the model budget", () => {
+    expect(
+      decideGenerateRequestRouting(
+        {
+          frames: 153,
+          fps: 24,
+          model: "ltx-2.3-22b-distilled:fp8",
+          negative_prompt: "blurry",
+          guidance_overrides: { stg_scale: 1.5 },
+        },
+        "ltx2",
+      ),
+    ).toEqual({
+      kind: "single",
+      preservedAutoChainFields: ["negative_prompt", "guidance_overrides"],
+    });
+  });
+
+  it("treats video continuation as single-shot instead of dropping it during chaining", () => {
+    expect(
+      decideGenerateRequestRouting(
+        {
+          frames: 153,
+          fps: 24,
+          model: "ltx-2.3-22b-distilled:fp8",
+          extend_video: "base64-video",
+          extend_overlap_frames: 17,
+        },
+        "ltx2",
+      ),
+    ).toEqual({
+      kind: "single",
+      preservedAutoChainFields: ["extend_video"],
+    });
+  });
+
   it("returns single when family is missing", () => {
     expect(decideChainRouting(50, null, "anything")).toEqual({
       kind: "single",

--- a/web/src/lib/chainRouting.ts
+++ b/web/src/lib/chainRouting.ts
@@ -3,10 +3,16 @@
  * Existing imports stay surface-local while web and desktop use one policy.
  */
 export {
+  AUTO_CHAIN_FIELD_LABELS,
   DEFAULT_MOTION_TAIL,
   LTX2_DEFAULT_CLIP_FRAMES,
   MAX_CHAIN_STAGES,
+  autoChainFieldList,
   decideChainRouting,
   decideGenerateRequestRouting,
+  unsupportedAutoChainFields,
 } from "@studio/lib/chainRouting";
-export type { ChainRoutingDecision } from "@studio/lib/chainRouting";
+export type {
+  AutoChainUnsupportedField,
+  ChainRoutingDecision,
+} from "@studio/lib/chainRouting";

--- a/web/src/pages/CreatePage.test.ts
+++ b/web/src/pages/CreatePage.test.ts
@@ -811,6 +811,36 @@ describe("CreatePage layout and behavior", () => {
     expect(req.source_image).toBeUndefined();
   });
 
+  it("keeps a long advanced video request single-shot and preserves its settings", async () => {
+    hostModelsMock.mockResolvedValue([installedSequenceModel()]);
+    const wrapper = mount(CreatePage, { global: { stubs: pageStubs() } });
+    await flushPromises();
+    const form = useGenerateForm();
+    form.state.value.model = "ltx-2-19b-distilled:fp8";
+    form.state.value.modelFamily = "ltx2";
+    form.state.value.frames = 153;
+    form.state.value.fps = 24;
+    form.state.value.negativePrompt = "flicker";
+    await nextTick();
+
+    expect(
+      wrapper.get("[data-test='single-shot-preservation-cue']").text(),
+    ).toContain("one 153-frame clip to preserve negative prompt");
+
+    await wrapper.get("[data-test='composer-submit']").trigger("click");
+    await flushPromises();
+
+    expect(submitMock).toHaveBeenCalledTimes(1);
+    expect(submitMock.mock.calls[0]?.[0]).toMatchObject({
+      frames: 153,
+      negative_prompt: "flicker",
+    });
+    expect(submitMock.mock.calls[0]?.[1]).toEqual({
+      kind: "single",
+      preservedAutoChainFields: ["negative_prompt"],
+    });
+  });
+
   it("reuses source preprocessing without replacing the editable source", async () => {
     upscaleStreamMock.mockImplementation(async (_request, handlers) => {
       handlers.onComplete({ image: "UPSCALED" });

--- a/web/src/pages/CreatePage.vue
+++ b/web/src/pages/CreatePage.vue
@@ -120,7 +120,10 @@ import {
   storeLastSeed,
 } from "../lib/lastSeed";
 import { useQueue } from "../composables/useQueue";
-import { decideGenerateRequestRouting } from "../lib/chainRouting";
+import {
+  autoChainFieldList,
+  decideGenerateRequestRouting,
+} from "../lib/chainRouting";
 import { isStandaloneGenerationModel } from "../lib/modelFilters";
 import {
   coerceSourceFitForMaskless,
@@ -1099,14 +1102,16 @@ const gpuListForPlacement = computed(
 
 const chainDecision = computed(() =>
   decideGenerateRequestRouting(
-    {
-      frames: form.state.value.frames,
-      model: form.state.value.model,
-      temporal_upscale: form.state.value.temporalUpscale,
-    },
+    form.toRequest(currentModel.value),
     currentModel.value?.family ?? null,
   ),
 );
+const singleShotPreservationNote = computed(() => {
+  const decision = chainDecision.value;
+  if (decision.kind !== "single" || !decision.preservedAutoChainFields?.length)
+    return null;
+  return `Will render as one ${form.state.value.frames}-frame clip to preserve ${autoChainFieldList(decision.preservedAutoChainFields)}. This may use more GPU memory than automatic chaining.`;
+});
 
 // Keep the preflight small: source/control media do not change the model's
 // static peak estimate enough to justify serializing their base64 payloads on
@@ -3283,6 +3288,13 @@ onBeforeUnmount(() => {
             <span class="font-semibold">{{ chainDecision.stageCount }}</span>
             chained clips of {{ chainDecision.clipFrames }} frames — expect this
             to take substantially longer than a single clip.
+          </div>
+          <div
+            v-else-if="singleShotPreservationNote"
+            class="rounded-control bg-halide/10 px-3 py-1.5 text-xs text-halide"
+            data-test="single-shot-preservation-cue"
+          >
+            {{ singleShotPreservationNote }}
           </div>
 
           <div


### PR DESCRIPTION
## Summary
- keep long LTX video requests single-shot when automatic chaining would discard advanced settings and the request fits the model budget
- share the request-aware routing policy across web, desktop, and iPhone
- explain the single-shot GPU-memory tradeoff and reject incompatible requests only beyond the true single-shot limit

## Verification
- `bun run fmt:check`
- `bun run check:architecture`
- `bun run check:dead-code`
- `bun run test:studio`
- `bun run test:web`
- `bun run test:desktop`
- `bun run build:web`
- `bun run build:desktop`
- `bun run build:mobile`