### PR TITLE
fix(studio): keep auto-chained videos in one-shot mode

### DIFF
--- a/crates/mold-core/src/client.rs
+++ b/crates/mold-core/src/client.rs
@@ -537,10 +537,15 @@ impl MoldClient {
             .get(format!("{}/api/chain-jobs", self.base_url))
             .send()
             .await?;
-        Ok(error_for_status_with_body(resp)
+        let mut listing = error_for_status_with_body(resp)
             .await?
             .json::<ChainJobListing>()
-            .await?)
+            .await?;
+        // Older servers exposed the ephemeral runner records used by
+        // automatic long one-shot videos. They are not authored sequences and
+        // must stay out of `mold jobs list` even across a mixed-version pair.
+        listing.jobs.retain(|job| !job.ephemeral);
+        Ok(listing)
     }
 
     pub async fn get_chain_job(&self, id: &str) -> Result<ChainJobDetail> {

--- a/crates/mold-core/tests/chain_client.rs
+++ b/crates/mold-core/tests/chain_client.rs
@@ -89,6 +89,40 @@ fn minimal_chain_response_json() -> serde_json::Value {
     })
 }
 
+#[tokio::test]
+async fn list_chain_jobs_hides_legacy_server_one_shot_shims() {
+    let server = MockServer::start().await;
+    let summary = |id: &str, ephemeral: bool| {
+        serde_json::json!({
+            "id": id,
+            "state": "running",
+            "model": "ltx-2-19b-distilled:fp8",
+            "stage_count": 3,
+            "current_stage": 1,
+            "created_at_unix_ms": 100,
+            "updated_at_unix_ms": 101,
+            "error": null,
+            "ephemeral": ephemeral
+        })
+    };
+    Mock::given(method("GET"))
+        .and(path("/api/chain-jobs"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "jobs": [summary("authored", false), summary("one-shot", true)]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let jobs = MoldClient::new(&server.uri())
+        .list_chain_jobs()
+        .await
+        .expect("chain-job listing should parse");
+
+    assert_eq!(jobs.jobs.len(), 1);
+    assert_eq!(jobs.jobs[0].id, "authored");
+}
+
 // ── /api/generate/chain (non-streaming) ────────────────────────────────
 
 #[tokio::test]

--- a/crates/mold-server/src/routes_chain_jobs.rs
+++ b/crates/mold-server/src/routes_chain_jobs.rs
@@ -3,7 +3,7 @@ use std::path::Path as FsPath;
 use std::pin::Pin;
 
 use axum::{
-    extract::{Extension, Path, State},
+    extract::{Extension, Path, Query, State},
     http::{header, HeaderMap, HeaderValue, StatusCode},
     response::{sse, IntoResponse, Response, Sse},
     Json,
@@ -47,6 +47,16 @@ fn default_preview_copies() -> u32 {
 pub enum ChainPlacementPreviewBody {
     Wrapped(ChainPlacementPreviewRequest),
     Legacy(ChainRequest),
+}
+
+#[derive(Debug, Clone, Copy, Default, serde::Deserialize, utoipa::IntoParams)]
+#[into_params(parameter_in = Query)]
+pub struct ListChainJobsQuery {
+    /// Include internal one-shot long-video shim records. This exists only so
+    /// an iPhone can recover an id lost during suspension; sequence surfaces
+    /// use the default durable-only listing.
+    #[serde(default)]
+    include_ephemeral: bool,
 }
 
 impl ChainPlacementPreviewBody {
@@ -195,10 +205,12 @@ pub async fn preview_chain_job_placement(
     get,
     path = "/api/chain-jobs",
     tag = "chain-jobs",
+    params(ListChainJobsQuery),
     responses((status = 200, description = "Chain jobs", body = mold_core::chain_job::ChainJobListing))
 )]
 pub async fn list_chain_jobs(
     State(state): State<AppState>,
+    Query(query): Query<ListChainJobsQuery>,
 ) -> Result<Json<ChainJobListing>, ApiError> {
     let handle = chain_jobs_handle(&state)?;
     let db = metadata_db(&state)?;
@@ -207,11 +219,17 @@ pub async fn list_chain_jobs(
         .map_err(|e| ApiError::internal(format!("failed to list chain jobs: {e:#}")))?;
     let jobs = rows
         .into_iter()
-        .map(|row| {
-            let mut summary = summary_for_row(&row, read_manifest_optional(&row, &root).as_ref());
+        .filter_map(|row| {
+            let manifest = read_manifest_optional(&row, &root);
+            if manifest.as_ref().is_some_and(|manifest| manifest.ephemeral)
+                && !query.include_ephemeral
+            {
+                return None;
+            }
+            let mut summary = summary_for_row(&row, manifest.as_ref());
             summary.cancelling =
                 row.state == ChainJobState::Running && handle.is_cancelling(&row.id);
-            summary
+            Some(summary)
         })
         .collect();
     Ok(Json(ChainJobListing { jobs }))

--- a/crates/mold-server/src/routes_test.rs
+++ b/crates/mold-server/src/routes_test.rs
@@ -6438,6 +6438,57 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn chain_jobs_listing_hides_one_shot_shims_unless_recovery_requests_them() {
+        let home = tempfile::tempdir().unwrap();
+        let _home = MoldHomeGuard::set(home.path());
+        let db = mold_db::MetadataDb::open_in_memory().unwrap();
+        seed_chain_job(
+            &db,
+            home.path(),
+            "authored-sequence",
+            ChainJobState::Running,
+        );
+        let shim_dir = seed_chain_job(&db, home.path(), "one-shot-shim", ChainJobState::Running);
+        let mut shim = ChainJobManifest::read_from_dir(&shim_dir).unwrap();
+        shim.ephemeral = true;
+        shim.write_atomic(&shim_dir).unwrap();
+        let app = app_with_chain_db(db);
+
+        let public = app
+            .clone()
+            .oneshot(Request::get("/api/chain-jobs").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(public.status(), StatusCode::OK);
+        let public_body = json_body(public).await;
+        let public_ids = public_body["jobs"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|job| job["id"].as_str().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(public_ids, ["authored-sequence"]);
+
+        let recovery = app
+            .oneshot(
+                Request::get("/api/chain-jobs?include_ephemeral=true")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(recovery.status(), StatusCode::OK);
+        let recovery_body = json_body(recovery).await;
+        let recovery_ids = recovery_body["jobs"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|job| job["id"].as_str().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(recovery_ids, ["authored-sequence", "one-shot-shim"]);
+    }
+
+    #[tokio::test]
     async fn chain_job_detail_returns_404_for_unknown_job() {
         let home = tempfile::tempdir().unwrap();
         let _home = MoldHomeGuard::set(home.path());

--- a/desktop/src/mobile/mobileGenerationRecovery.test.ts
+++ b/desktop/src/mobile/mobileGenerationRecovery.test.ts
@@ -402,23 +402,32 @@ describe("reconcileInterruptedGenerationJobs", () => {
     expect(opts.refreshResultUrl).toHaveBeenCalledWith(7);
   });
 
-  it("finds an id-less durable chain created with the interrupted submission", async () => {
+  it("finds only the id-less one-shot shim created with the interrupted submission", async () => {
     const submittedAtUnixMs = 1_700_000_000_000;
     apiJsonTo.mockImplementation((_target: unknown, path: string) => {
-      if (path === "/api/chain-jobs") {
+      if (path === "/api/chain-jobs?include_ephemeral=true") {
         return Promise.resolve({
           jobs: [
+            {
+              id: "authored-sequence",
+              state: "running",
+              model: "ltx2:q8",
+              created_at_unix_ms: submittedAtUnixMs + 50,
+              ephemeral: false,
+            },
             {
               id: "chain-later",
               state: "running",
               model: "ltx2:q8",
               created_at_unix_ms: submittedAtUnixMs + 200,
+              ephemeral: true,
             },
             {
               id: "chain-mine",
               state: "running",
               model: "ltx2:q8",
               created_at_unix_ms: submittedAtUnixMs + 100,
+              ephemeral: true,
             },
           ],
         });
@@ -440,6 +449,7 @@ describe("reconcileInterruptedGenerationJobs", () => {
     expect(job.id).toBe("chain-mine");
     expect(job.status).toBe("complete");
     expect(job.result?.filename).toBe("recovered.mp4");
+    expect(apiJsonTo).toHaveBeenCalledWith(target, "/api/chain-jobs?include_ephemeral=true");
   });
 
   it("surfaces a chain failure with the host's own error copy", async () => {

--- a/desktop/src/mobile/mobileGenerationRecovery.ts
+++ b/desktop/src/mobile/mobileGenerationRecovery.ts
@@ -215,13 +215,20 @@ function findQueueEntry(
 }
 
 async function findPreIdChain(job: Job, opts: GenerationRecoveryOptions): Promise<string | null> {
-  const listing = await apiJsonTo<ChainJobListing>(opts.target, "/api/chain-jobs");
+  // Public sequence lists intentionally hide the ephemeral chain-runner shim
+  // behind a one-shot long video. Recovery is the one consumer that needs to
+  // find that internal record when iOS suspended before receiving its id.
+  const listing = await apiJsonTo<ChainJobListing>(
+    opts.target,
+    "/api/chain-jobs?include_ephemeral=true",
+  );
   const earliest = job.submittedAtUnixMs - PRE_ID_CLOCK_SKEW_MS;
   const latest = job.submittedAtUnixMs + PRE_ID_JOIN_WINDOW_MS;
   return (
     listing.jobs
       .filter(
         (candidate) =>
+          candidate.ephemeral === true &&
           candidate.model === job.model &&
           (candidate.state === "queued" || candidate.state === "running") &&
           candidate.created_at_unix_ms >= earliest &&

--- a/desktop/src/stores/chainJobs.test.ts
+++ b/desktop/src/stores/chainJobs.test.ts
@@ -85,6 +85,19 @@ describe("per-host listing", () => {
     expect(store.byHost[REMOTE_ID]?.jobs.map((j) => j.id)).toEqual(["r-new", "r-old"]);
   });
 
+  it("keeps automatic long-video shim jobs out of sequence surfaces", async () => {
+    apiJsonTo.mockResolvedValue({
+      jobs: [
+        { id: "authored", state: "running", created_at_unix_ms: 1, ephemeral: false },
+        { id: "one-shot", state: "running", created_at_unix_ms: 2, ephemeral: true },
+      ],
+    });
+    const store = useChainJobsStore();
+    await store.fetchHost("local");
+
+    expect(store.byHost.local?.jobs.map((job) => job.id)).toEqual(["authored"]);
+  });
+
   it("a failed host keeps its last jobs and records the error", async () => {
     const store = useChainJobsStore();
     store.byHost[REMOTE_ID] = {

--- a/desktop/src/stores/chainJobs.ts
+++ b/desktop/src/stores/chainJobs.ts
@@ -4,6 +4,7 @@ import {
   emptyChainJobLive,
   type ChainJobLive,
 } from "@studio/lib/chainJobEvents";
+import { isAuthoredSequenceJob } from "@studio/lib/api/chainTypes";
 import type {
   AmendRequest,
   AmendResponse,
@@ -81,7 +82,9 @@ export const useChainJobsStore = defineStore("chainJobs", {
         const listing = await apiJsonTo<ChainJobListing>(target, "/api/chain-jobs");
         if (version !== this.fetchVersions[hostId]) return;
         this.byHost[hostId] = {
-          jobs: listing.jobs.sort((a, b) => b.created_at_unix_ms - a.created_at_unix_ms),
+          jobs: listing.jobs
+            .filter(isAuthoredSequenceJob)
+            .sort((a, b) => b.created_at_unix_ms - a.created_at_unix_ms),
           error: null,
         };
       } catch (err) {

--- a/studio/lib/api/chainTypes.ts
+++ b/studio/lib/api/chainTypes.ts
@@ -145,6 +145,14 @@ export interface ChainJobSummary {
   ephemeral?: boolean;
 }
 
+/** Internal long-video compatibility shims share the chain runner but are
+ * still one-shot prints. Older servers listed those temporary records beside
+ * authored sequences, so every client filters defensively at its list
+ * boundary instead of letting a shim switch Create into Sequence mode. */
+export function isAuthoredSequenceJob(job: ChainJobSummary): boolean {
+  return job.ephemeral !== true;
+}
+
 export interface ChainJobStageDetail {
   idx: number;
   state: ChainStageState;

--- a/web/src/composables/useChainJobs.test.ts
+++ b/web/src/composables/useChainJobs.test.ts
@@ -155,6 +155,22 @@ describe("useChainJobs", () => {
     expect(jobs.state.byHost[host.id]?.error).toBeNull();
   });
 
+  it("keeps automatic long-video shim jobs out of sequence surfaces", async () => {
+    const host = addHost({ url: "http://plato:7680", name: "plato" });
+    listChainJobsMock.mockResolvedValue({
+      jobs: [
+        summary({ id: "authored", ephemeral: false }),
+        summary({ id: "one-shot", ephemeral: true }),
+      ],
+    });
+    const jobs = useChainJobs();
+    await jobs.fetchHost(host.id);
+
+    expect(jobs.state.byHost[host.id]?.jobs.map((job) => job.id)).toEqual([
+      "authored",
+    ]);
+  });
+
   it("keeps the last good list and records the error when a host fetch fails", async () => {
     const host = addHost({ url: "http://plato:7680", name: "plato" });
     listChainJobsMock.mockResolvedValue({ jobs: [summary({ id: "kept" })] });

--- a/web/src/composables/useChainJobs.ts
+++ b/web/src/composables/useChainJobs.ts
@@ -31,6 +31,7 @@ import {
   emptyChainJobLive,
   type ChainJobLive,
 } from "@studio/lib/chainJobEvents";
+import { isAuthoredSequenceJob } from "@studio/lib/api/chainTypes";
 import type {
   AmendRequest,
   AmendResponse,
@@ -180,9 +181,9 @@ async function fetchHost(hostId: string): Promise<void> {
   }
   try {
     const listing = await listChainJobs(target);
-    const jobs = [...listing.jobs].sort(
-      (a, b) => b.created_at_unix_ms - a.created_at_unix_ms,
-    );
+    const jobs = listing.jobs
+      .filter(isAuthoredSequenceJob)
+      .sort((a, b) => b.created_at_unix_ms - a.created_at_unix_ms);
     state.byHost[hostId] = { jobs, error: null };
     // Server-side deletions release our tracked interest.
     const known = new Set(jobs.map((j) => j.id));


### PR DESCRIPTION
## Summary

- hide ephemeral automatic long-video chain shims from authored Sequence listings
- keep desktop, web, CLI, and older-server combinations on the original one-shot print path
- preserve exact iPhone suspension recovery through an explicit ephemeral-only lookup

## Root cause

Automatic long videos use an ephemeral durable-chain runner record internally. The public chain-job listing exposed that record, and sequence activity consumers treated every listed chain as user-authored. Clicking the resulting Developing row therefore switched Create into Sequence inspection.

## Validation

- sub-agent peer review completed; both findings addressed
- 373 Studio tests passed
- 1,151 web tests passed
- affected desktop/mobile/store tests passed
- full desktop flakes reproduced only in unrelated tests and passed in isolated reruns
- web, desktop, and mobile production builds passed
- server and Rust-client regression tests passed
- cargo fmt, cargo check, and mold-ai-server clippy with warnings denied passed

Copilot review intentionally skipped per request.