### PR TITLE
fix(mobile): isolate offline gallery hosts

### DIFF
--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -3975,6 +3975,51 @@ describe("MobileApp primary navigation", () => {
 });
 
 describe("MobileApp gallery", () => {
+  it("loads reachable hosts without waiting for a host already known to be offline", async () => {
+    const offlineTarget = { baseUrl: "http://halcyon.tailnet.ts.net:7680", apiKey: "secret" };
+    localStorage.setItem(
+      "mold.mobile.hosts.v1",
+      JSON.stringify([
+        {
+          id: "studio-id",
+          name: "Plato",
+          baseUrl: target.baseUrl,
+          hostname: "plato",
+          version: "0.18.0",
+          online: false,
+        },
+        {
+          id: "halcyon-id",
+          name: "Halcyon",
+          baseUrl: offlineTarget.baseUrl,
+          hostname: "halcyon",
+          version: "0.18.0",
+          online: false,
+        },
+      ]),
+    );
+    apiJsonTo.mockImplementation((requestTarget: unknown, path: string) => {
+      const baseUrl = (requestTarget as { baseUrl: string }).baseUrl;
+      if (baseUrl === offlineTarget.baseUrl) {
+        if (path === "/api/status") return Promise.reject(new Error("offline"));
+        if (path === "/api/gallery") return new Promise(() => {});
+      }
+      if (path === "/api/status") return Promise.resolve({ ...status, hostname: "plato" });
+      if (path === "/api/models") return Promise.resolve([model]);
+      if (path === "/api/capabilities") return Promise.resolve({});
+      if (path === "/api/gallery") return Promise.resolve([print]);
+      return Promise.reject(new Error(`Unexpected API path: ${path}`));
+    });
+
+    wrapper = mountMobileApp();
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-tab-gallery']").trigger("click");
+
+    await vi.waitFor(() => expect(wrapper?.find("[data-test='gallery-item']").exists()).toBe(true));
+    expect(wrapper.find(".empty-state").exists()).toBe(false);
+    expect(wrapper.text()).toContain("1 host unavailable");
+  });
+
   it("keeps the native image context menu and enters multi-select from Select", async () => {
     wrapper = mountMobileApp();
     await flushPromises();
@@ -4386,7 +4431,10 @@ describe("MobileApp gallery", () => {
       if (path === "/api/gallery") {
         return Promise.resolve(baseUrl === remoteTarget.baseUrl ? [print] : []);
       }
-      if (baseUrl === remoteTarget.baseUrl) return Promise.reject(new Error("offline"));
+      if (baseUrl === remoteTarget.baseUrl && path === "/api/status") {
+        return Promise.resolve({ ...status, hostname: "remote", instance_id: "remote-id" });
+      }
+      if (baseUrl === remoteTarget.baseUrl) return Promise.reject(new Error("models offline"));
       if (path === "/api/status") return Promise.resolve(status);
       if (path === "/api/models") return Promise.resolve([model]);
       return Promise.reject(new Error(`Unexpected API path: ${path}`));

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -4020,6 +4020,62 @@ describe("MobileApp gallery", () => {
     expect(wrapper.text()).toContain("1 host unavailable");
   });
 
+  it("refreshes the Library when a previously offline host recovers", async () => {
+    const recoveredTarget = { baseUrl: "http://halcyon.tailnet.ts.net:7680", apiKey: "secret" };
+    localStorage.setItem(
+      "mold.mobile.hosts.v1",
+      JSON.stringify([
+        {
+          id: "studio-id",
+          name: "Plato",
+          baseUrl: target.baseUrl,
+          hostname: "plato",
+          version: "0.18.0",
+          online: false,
+        },
+        {
+          id: "halcyon-id",
+          name: "Halcyon",
+          baseUrl: recoveredTarget.baseUrl,
+          hostname: "halcyon",
+          version: "0.18.0",
+          online: false,
+        },
+      ]),
+    );
+    const recoveredProbe = deferred<ServerStatus>();
+    let halcyonProbeCount = 0;
+    apiJsonTo.mockImplementation((requestTarget: unknown, path: string) => {
+      const baseUrl = (requestTarget as { baseUrl: string }).baseUrl;
+      if (baseUrl === recoveredTarget.baseUrl && path === "/api/status") {
+        halcyonProbeCount += 1;
+        return halcyonProbeCount === 1
+          ? Promise.reject(new Error("offline"))
+          : recoveredProbe.promise;
+      }
+      if (path === "/api/status") return Promise.resolve({ ...status, hostname: "plato" });
+      if (path === "/api/models") return Promise.resolve([model]);
+      if (path === "/api/capabilities") return Promise.resolve({});
+      if (path === "/api/gallery") {
+        return Promise.resolve(baseUrl === recoveredTarget.baseUrl ? [print] : []);
+      }
+      return Promise.reject(new Error(`Unexpected API path: ${path}`));
+    });
+
+    wrapper = mountMobileApp();
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-tab-gallery']").trigger("click");
+    await flushPromises();
+    expect(wrapper.find("[data-test='gallery-item']").exists()).toBe(false);
+
+    window.dispatchEvent(new Event("pageshow"));
+    await vi.waitFor(() => expect(halcyonProbeCount).toBe(2));
+    recoveredProbe.resolve({ ...status, hostname: "halcyon", instance_id: "halcyon-id" });
+
+    await vi.waitFor(() => expect(wrapper?.find("[data-test='gallery-item']").exists()).toBe(true));
+    expect(wrapper.text()).not.toContain("host unavailable");
+  });
+
   it("keeps the native image context menu and enters multi-select from Select", async () => {
     wrapper = mountMobileApp();
     await flushPromises();

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -263,6 +263,7 @@ const LEGACY_LIBRARY_SEEN_KEY = "mold.mobile.library-seen.v1";
 const LIBRARY_VISITED_KEY = "mold.mobile.library-visited.v1";
 const SEQUENCE_RECOVERY_KEY = "mold.mobile.sequence-job.v1";
 const HOST_PROBE_TIMEOUT_MS = 9_000;
+const GALLERY_HOST_TIMEOUT_MS = 9_000;
 const OUTPUT_OPTIONS = [
   { value: "single" as const, label: "One shot" },
   { value: "sequence" as const, label: "Sequence" },
@@ -440,6 +441,7 @@ const hostProbes = new Map<
   string,
   { epoch: number; controller: AbortController; timeout: ReturnType<typeof setTimeout> }
 >();
+const knownHostReachability = new Set<string>();
 const generation = useGenerationStore();
 const mobileDownloads = useMobileDownloadsStore();
 function loadLibrarySeenAt(): Record<string, number> {
@@ -1162,6 +1164,7 @@ async function connectHost(address?: string, discoveredName?: string): Promise<v
     };
     if (existing) Object.assign(existing, saved);
     else hosts.value.push(saved);
+    knownHostReachability.add(saved.id);
     if (saved.apiKey) {
       await invoke("keychain_set_api_key", { hostId: saved.id, apiKey: saved.apiKey });
     } else {
@@ -1293,9 +1296,11 @@ async function probeHost(host: MobileHost): Promise<void> {
       signal: controller.signal,
     });
     if (hostProbes.get(host.id)?.epoch !== epoch) return;
+    knownHostReachability.add(host.id);
     updateHostStatus({ id: host.id, status });
   } catch {
     if (hostProbes.get(host.id)?.epoch !== epoch) return;
+    knownHostReachability.add(host.id);
     updateHostStatus({ id: host.id, status: null });
   } finally {
     if (hostProbes.get(host.id)?.epoch === epoch) hostProbes.delete(host.id);
@@ -1328,12 +1333,14 @@ function reconnectHost(id: string): void {
   const host = hosts.value.find((candidate) => candidate.id === id);
   if (!host) return;
   host.connected = true;
+  knownHostReachability.delete(id);
   persistHosts();
   void probeHost(host);
 }
 
 function removeHost(id: string): void {
   cancelHostProbe(id);
+  knownHostReachability.delete(id);
   const removedSelectedHost = selectedHostId.value === id;
   const removedCatalogHost = catalogHostId.value === id;
   if (hostDetailId.value === id) hostDetailId.value = "";
@@ -1398,6 +1405,7 @@ async function refreshModels(): Promise<boolean> {
       ),
     ]);
     if (unmounted || epoch !== modelLoadEpoch || selectedHostId.value !== hostId) return false;
+    knownHostReachability.add(hostId);
     host.online = true;
     host.version = status.version;
     host.hostname = status.hostname ?? undefined;
@@ -1418,6 +1426,7 @@ async function refreshModels(): Promise<boolean> {
     return true;
   } catch (error) {
     if (unmounted || epoch !== modelLoadEpoch || selectedHostId.value !== hostId) return false;
+    knownHostReachability.add(hostId);
     host.online = false;
     // The banner above the model select owns this failure; the generation
     // status line keeps showing generation state, not background loads.
@@ -2938,10 +2947,23 @@ async function performGalleryRefresh(): Promise<void> {
   const prior = gallery.value;
   gallery.value = [];
   for (const item of prior) revokeObjectUrl(item.thumbnailUrl);
+  const galleryHosts = connectedHosts.value.filter(
+    (host) => host.online || !knownHostReachability.has(host.id),
+  );
+  const knownOffline = connectedHosts.value.length - galleryHosts.length;
   const results = await Promise.allSettled(
-    connectedHosts.value.map(async (host) => {
+    galleryHosts.map(async (host) => {
       const target = { baseUrl: host.baseUrl, apiKey: host.apiKey || null };
-      const prints = await apiJsonTo<GalleryImage[]>(target, "/api/gallery");
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), GALLERY_HOST_TIMEOUT_MS);
+      let prints: GalleryImage[];
+      try {
+        prints = await apiJsonTo<GalleryImage[]>(target, "/api/gallery", {
+          signal: controller.signal,
+        });
+      } finally {
+        clearTimeout(timeout);
+      }
       return prints.map((print) => ({
         ...print,
         hostId: host.id,
@@ -2954,7 +2976,7 @@ async function performGalleryRefresh(): Promise<void> {
     .flatMap((result) => (result.status === "fulfilled" ? result.value : []))
     .sort((a, b) => b.timestamp - a.timestamp);
   pendingGallery = groupLogicalGalleryPrints(galleryCopies).map((group) => group.representative);
-  const failed = results.filter((result) => result.status === "rejected").length;
+  const failed = knownOffline + results.filter((result) => result.status === "rejected").length;
   if (failed) galleryError.value = `${failed} host${failed === 1 ? "" : "s"} unavailable`;
   await loadMoreGalleryPage();
   galleryLoading.value = false;

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -1288,6 +1288,7 @@ async function probeHost(host: MobileHost): Promise<void> {
   cancelHostProbe(host.id);
   const controller = new AbortController();
   const epoch = ++hostProbeEpoch;
+  const wasKnownOffline = knownHostReachability.has(host.id) && !host.online;
   const timeout = setTimeout(() => controller.abort(), HOST_PROBE_TIMEOUT_MS);
   const probe = { epoch, controller, timeout };
   hostProbes.set(host.id, probe);
@@ -1298,6 +1299,7 @@ async function probeHost(host: MobileHost): Promise<void> {
     if (hostProbes.get(host.id)?.epoch !== epoch) return;
     knownHostReachability.add(host.id);
     updateHostStatus({ id: host.id, status });
+    if (wasKnownOffline && tab.value === "gallery") void refreshGallery();
   } catch {
     if (hostProbes.get(host.id)?.epoch !== epoch) return;
     knownHostReachability.add(host.id);


### PR DESCRIPTION
## Summary

- keep the iPhone Library loading healthy connected hosts when another saved host is offline
- skip gallery inventory calls for hosts whose reachability probe has already settled offline
- bound gallery inventory requests so a host that drops after probing cannot leave the Library spinner pending forever
- continue reporting unavailable host counts while rendering reachable prints

## Root cause

The mobile Library used `Promise.allSettled` across every connected host, including hosts already known to be offline. A transport request to an unreachable host can remain pending, which prevented the aggregate promise from settling and withheld results from healthy hosts.

## Validation

- `bun run test` — 2,898 tests passed across 276 files
- `bunx vitest run src/mobile/MobileApp.test.ts src/mobile/MobileGalleryViewer.test.ts` — 142 tests passed
- `bun run build:mobile`
- `bunx prettier --check src/mobile/MobileApp.vue src/mobile/MobileApp.test.ts`
- `git diff --check`

Simulator UI UAT was not run because no iOS simulator was booted.
