### PR TITLE
fix(desktop): preserve source fit across navigation

### DIFF
--- a/desktop/src/lib/desktopImageDrop.test.ts
+++ b/desktop/src/lib/desktopImageDrop.test.ts
@@ -58,6 +58,7 @@ describe("applyDesktopImageDrop", () => {
     });
     expect(form.sourceImage).toBe("IMAGE_BYTES");
     expect(form.sourceImageName).toBe("reference.png");
+    expect(form.sourceFit).toEqual({ mode: "lanczos-resize" });
     expect(form.sourceImageWidth).toBe(896);
     expect(form.sourceImageHeight).toBe(1152);
   });

--- a/desktop/src/lib/desktopImageDrop.ts
+++ b/desktop/src/lib/desktopImageDrop.ts
@@ -42,6 +42,7 @@ export function applyDesktopImageDrop(
     form.imageAttachments = [];
     form.sourceImage = image.base64;
     form.sourceImageName = image.filename;
+    form.sourceFit = { mode: "lanczos-resize" };
   } else {
     return { attached: false, metadataApplied };
   }

--- a/desktop/src/lib/generateForm.test.ts
+++ b/desktop/src/lib/generateForm.test.ts
@@ -984,6 +984,7 @@ describe("applyPrefillToForm", () => {
       outputFormat: "mp4",
       sourceImage: "SOURCE",
       sourceImageName: "frame.png",
+      sourceFit: { mode: "crop-fill", alignX: "center", alignY: "center" },
       controlModel: "",
       frames: 97,
       fps: 25,

--- a/desktop/src/lib/generateForm.ts
+++ b/desktop/src/lib/generateForm.ts
@@ -651,7 +651,6 @@ export function applyRequestToForm(
   form.strength = request.strength ?? form.strength;
   form.sourceImage = request.source_image ?? null;
   form.sourceImageName = request.source_image_name ?? null;
-  if (form.sourceImage) form.sourceFit = { mode: "lanczos-resize" };
   form.sourceImageWidth = null;
   form.sourceImageHeight = null;
   form.imageAttachments = [...(request.edit_images ?? [])];

--- a/desktop/src/lib/generateForm.ts
+++ b/desktop/src/lib/generateForm.ts
@@ -651,6 +651,7 @@ export function applyRequestToForm(
   form.strength = request.strength ?? form.strength;
   form.sourceImage = request.source_image ?? null;
   form.sourceImageName = request.source_image_name ?? null;
+  if (form.sourceImage) form.sourceFit = { mode: "lanczos-resize" };
   form.sourceImageWidth = null;
   form.sourceImageHeight = null;
   form.imageAttachments = [...(request.edit_images ?? [])];

--- a/desktop/src/views/GenerateView.sourcefit.test.ts
+++ b/desktop/src/views/GenerateView.sourcefit.test.ts
@@ -130,6 +130,23 @@ describe("GenerateView source-fit submit path", () => {
     document.body.innerHTML = "";
   });
 
+  it("preserves an attached source and its fit policy when Create remounts", async () => {
+    const form = primeForm();
+    form.sourceImageName = "camera.png";
+    form.sourceFit = { mode: "crop-fill", alignX: "right", alignY: "bottom" };
+
+    const first = mount(GenerateView, { shallow: true, attachTo: document.body });
+    await flushPromises();
+    first.unmount();
+
+    mount(GenerateView, { shallow: true, attachTo: document.body });
+    await flushPromises();
+
+    expect(form.sourceImage).toBe("SRC");
+    expect(form.sourceImageName).toBe("camera.png");
+    expect(form.sourceFit).toEqual({ mode: "crop-fill", alignX: "right", alignY: "bottom" });
+  });
+
   it("resolves the host before preprocessing and routes the upscale to it", async () => {
     const hosts = setupMultiHost();
     const resolveFeasible = vi.spyOn(hosts, "resolveFeasible");

--- a/desktop/src/views/GenerateView.sourcefit.test.ts
+++ b/desktop/src/views/GenerateView.sourcefit.test.ts
@@ -15,7 +15,8 @@ import { useConnectionStore } from "../stores/connection";
 import { useHostsStore } from "../stores/hosts";
 import { useToastStore } from "../stores/toasts";
 import { useUiStore } from "../stores/ui";
-import type { ModelEntry } from "../lib/api/types";
+import { useComposerStore } from "../stores/composer";
+import type { ModelEntry, OutputMetadata } from "../lib/api/types";
 import type { SourceFitInput } from "../lib/sourceFitPreprocess";
 
 vi.mock("vue-router", () => ({
@@ -54,7 +55,8 @@ vi.mock("@studio/api/generationPlacement", async (importOriginal) => {
     previewChainPlacement: planned,
   };
 });
-vi.mock("../lib/ipc", () => ({ ipc: {} }));
+const { sourceStashGet } = vi.hoisted(() => ({ sourceStashGet: vi.fn() }));
+vi.mock("../lib/ipc", () => ({ ipc: { sourceStashGet } }));
 vi.mock("../lib/api/history", () => ({ fetchHistory: vi.fn(() => Promise.resolve([])) }));
 
 const upscaleImage = vi.fn();
@@ -124,6 +126,7 @@ describe("GenerateView source-fit submit path", () => {
     upscaleImage.mockReset();
     upscaleImage.mockResolvedValue("UPSCALED");
     applySourceFitPreprocess.mockReset();
+    sourceStashGet.mockReset();
     useModelStore().all = [model];
   });
   afterEach(() => {
@@ -143,6 +146,34 @@ describe("GenerateView source-fit submit path", () => {
     await flushPromises();
 
     expect(form.sourceImage).toBe("SRC");
+    expect(form.sourceImageName).toBe("camera.png");
+    expect(form.sourceFit).toEqual({ mode: "crop-fill", alignX: "right", alignY: "bottom" });
+  });
+
+  it("preserves the fit policy while Reuse settings restores source bytes", async () => {
+    const form = useGenerateFormStore().form;
+    form.sourceFit = { mode: "crop-fill", alignX: "right", alignY: "bottom" };
+    sourceStashGet.mockResolvedValue("RESTORED");
+    useComposerStore().set({
+      metadata: {
+        prompt: "a camera",
+        model: model.name,
+        seed: 42,
+        steps: 20,
+        guidance: 7,
+        width: 512,
+        height: 512,
+        version: "test",
+        source_image_sha256: "a".repeat(64),
+        source_image_name: "camera.png",
+      } as OutputMetadata,
+    });
+
+    mount(GenerateView, { shallow: true, attachTo: document.body });
+    await flushPromises();
+
+    expect(sourceStashGet).toHaveBeenCalledWith("a".repeat(64));
+    expect(form.sourceImage).toBe("RESTORED");
     expect(form.sourceImageName).toBe("camera.png");
     expect(form.sourceFit).toEqual({ mode: "crop-fill", alignX: "right", alignY: "bottom" });
   });

--- a/desktop/src/views/GenerateView.vue
+++ b/desktop/src/views/GenerateView.vue
@@ -692,7 +692,9 @@ watch(
   ],
   ([base64]) => {
     if (isSequence.value) return;
-    const replaced = Boolean(base64 && base64 !== previousStillSource);
+    // This watcher also runs when Create remounts. Keep it limited to derived
+    // dimensions; source attachment boundaries own their one-time fit default
+    // so a route change cannot overwrite the user's selected policy.
     const next = applyDecodedSourceResolution(
       base64,
       {
@@ -706,9 +708,6 @@ watch(
     );
     previousStillSource = next.base64;
     previousStillResolution = next.resolution;
-    if (replaced && caps.value.sourceImageMode === "single") {
-      form.sourceFit = { mode: "lanczos-resize" };
-    }
   },
   { immediate: true },
 );
@@ -2501,6 +2500,7 @@ async function restorePrefillSource(metadata: OutputMetadata, epoch: number) {
   } else if (!attachmentMode && caps.value.sourceImageMode === "single" && restored) {
     form.sourceImage = restored.base64;
     form.sourceImageName = restored.filename;
+    form.sourceFit = { mode: "lanczos-resize" };
   } else {
     toasts.push(
       attachmentMode

--- a/desktop/src/views/GenerateView.vue
+++ b/desktop/src/views/GenerateView.vue
@@ -2500,7 +2500,6 @@ async function restorePrefillSource(metadata: OutputMetadata, epoch: number) {
   } else if (!attachmentMode && caps.value.sourceImageMode === "single" && restored) {
     form.sourceImage = restored.base64;
     form.sourceImageName = restored.filename;
-    form.sourceFit = { mode: "lanczos-resize" };
   } else {
     toasts.push(
       attachmentMode

--- a/desktop/src/views/LibraryView.test.ts
+++ b/desktop/src/views/LibraryView.test.ts
@@ -187,6 +187,7 @@ describe("LibraryView delete keyboard handling", () => {
     );
     expect(useGenerateFormStore().form.sourceImage).toBe("QUJD");
     expect(useGenerateFormStore().form.sourceImageName).toBe("remote-source.png");
+    expect(useGenerateFormStore().form.sourceFit).toEqual({ mode: "lanczos-resize" });
     expect(router.currentRoute.value.path).toBe("/create");
     expect(useToastStore().items.at(-1)?.message).toBe("Loaded as source");
     wrapper.unmount();

--- a/desktop/src/views/LibraryView.vue
+++ b/desktop/src/views/LibraryView.vue
@@ -708,6 +708,7 @@ async function useAsSource(entry: MergedPrint) {
     const base64 = await fetchItemBase64(entry);
     generateForm.form.sourceImage = base64;
     generateForm.form.sourceImageName = entry.item.filename;
+    generateForm.form.sourceFit = { mode: "lanczos-resize" };
     lightboxOpen.value = false;
     toasts.push("Loaded as source");
     void router.push("/create");


### PR DESCRIPTION
## Summary
- stop Create remounts from treating an existing source as a newly attached image
- preserve the selected source-fit policy across workspace navigation and template hydration
- keep Lanczos as the one-time default at actual desktop attachment boundaries

## Root cause
The desktop Create view cached the previous source image in component-local variables. Since route navigation unmounts the view, that cache restarted empty on return. The immediate source-resolution watcher then classified the already-persisted Pinia source as newly attached and overwrote its fit policy with Lanczos. Web and iPhone do not have this remount-time mutation.

## Validation
- `bun run --cwd desktop test` (2,900 tests)
- `bun run --cwd desktop build`
- `bun run --cwd desktop fmt:check`
- `bun run --cwd web test -- useGenerateForm.test.ts AdvancedDrawer.test.ts` (102 tests)
- `bun run --cwd desktop test -- MobileSourceControls.test.ts` (14 tests)
- in-app browser: `/create` → `/library` → `/create`, rendered successfully with no console warnings/errors