### PR TITLE
fix: resolve open server bug backlog

### DIFF
--- a/crates/mold-cli/src/commands/default.rs
+++ b/crates/mold-cli/src/commands/default.rs
@@ -119,6 +119,29 @@ mod tests {
     use crate::test_support::ENV_LOCK;
     use std::collections::HashMap;
 
+    /// Run an assertion that depends on config-based default-model resolution
+    /// without observing either the caller's environment or another test's
+    /// temporary `MOLD_DEFAULT_MODEL` override.
+    fn without_default_model_override<T>(f: impl FnOnce() -> T) -> T {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let previous = std::env::var_os("MOLD_DEFAULT_MODEL");
+        std::env::remove_var("MOLD_DEFAULT_MODEL");
+
+        struct RestoreEnv(Option<std::ffi::OsString>);
+
+        impl Drop for RestoreEnv {
+            fn drop(&mut self) {
+                match self.0.take() {
+                    Some(value) => std::env::set_var("MOLD_DEFAULT_MODEL", value),
+                    None => std::env::remove_var("MOLD_DEFAULT_MODEL"),
+                }
+            }
+        }
+
+        let _restore = RestoreEnv(previous);
+        f()
+    }
+
     fn empty_config() -> Config {
         Config {
             config_version: 1,
@@ -178,30 +201,36 @@ mod tests {
 
     #[test]
     fn show_default_returns_ok() {
-        let config = empty_config();
-        let result = show_default(&config);
-        assert!(result.is_ok());
+        without_default_model_override(|| {
+            let config = empty_config();
+            let result = show_default(&config);
+            assert!(result.is_ok());
+        });
     }
 
     #[test]
     fn resolve_source_default_config() {
-        let mut config = empty_config();
-        // Use a model name that won't be downloaded locally, so resolution
-        // falls through to the ConfigDefault step.
-        config.default_model = "wuerstchen:bf16".to_string();
-        let resolution = config.resolve_default_model();
-        assert_eq!(resolution.source, DefaultModelSource::ConfigDefault);
+        without_default_model_override(|| {
+            let mut config = empty_config();
+            // Use a model name that won't be downloaded locally, so resolution
+            // falls through to the ConfigDefault step.
+            config.default_model = "wuerstchen:bf16".to_string();
+            let resolution = config.resolve_default_model();
+            assert_eq!(resolution.source, DefaultModelSource::ConfigDefault);
+        });
     }
 
     #[test]
     fn resolve_source_custom_model_entry() {
-        let mut config = empty_config();
-        config.models.insert(
-            "flux2-klein".to_string(),
-            mold_core::config::ModelConfig::default(),
-        );
-        let resolution = config.resolve_default_model();
-        assert_eq!(resolution.source, DefaultModelSource::ConfigCustomEntry);
+        without_default_model_override(|| {
+            let mut config = empty_config();
+            config.models.insert(
+                "flux2-klein".to_string(),
+                mold_core::config::ModelConfig::default(),
+            );
+            let resolution = config.resolve_default_model();
+            assert_eq!(resolution.source, DefaultModelSource::ConfigCustomEntry);
+        });
     }
 
     #[test]

--- a/crates/mold-cli/src/commands/generate.rs
+++ b/crates/mold-cli/src/commands/generate.rs
@@ -248,6 +248,16 @@ pub struct Ltx2Options {
     pub guidance_overrides: Option<Ltx2GuidanceOverrides>,
 }
 
+fn require_local_hdr_exr_dir(hdr_exr_dir: Option<String>, local: bool) -> Result<Option<String>> {
+    if hdr_exr_dir.is_some() && !local {
+        anyhow::bail!(
+            "--hdr-exr-dir renders locally; re-run with --local — a remote server cannot write \
+             the EXR sidecar to your machine"
+        );
+    }
+    Ok(hdr_exr_dir)
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn run(
     prompt: &str,
@@ -309,6 +319,10 @@ pub async fn run(
         temporal_upscale,
         guidance_overrides,
     } = ltx2;
+    // Keep the filesystem path out of every remote request shape. Local
+    // generation retains the exact user path so export metadata remains
+    // faithful to the sidecar written on this machine.
+    let hdr_exr_dir = require_local_hdr_exr_dir(hdr_exr_dir, local)?;
 
     // Load config and pull model-specific defaults.
     let ctx = CliContext::new(host.as_deref());
@@ -377,21 +391,11 @@ pub async fn run(
                 clip_frames: cf,
                 motion_tail: mt,
             } => {
-                // Chained EXR export is local-only: the ChainRequest wire
-                // carries no HDR fields, so a remote server could only
-                // silently drop the sidecar — the empty-directory failure
-                // #681 refused. The forced-local orchestrator carries the
-                // whole HDR authority instead (control id, adapter LoRAs,
-                // per-stage reference windows), so every stage renders a
-                // true regrade of its own slice of the reference (#688).
-                if hdr_exr_dir.is_some() && !local {
-                    anyhow::bail!(
-                        "--hdr-exr-dir with auto-chaining renders locally; re-run with --local \
-                         — a remote server cannot write the EXR sidecar to your machine \
-                         ({} frames auto-chains at {cf} frames per clip)",
-                        effective_frames.unwrap_or_default()
-                    );
-                }
+                // Chained EXR export reaches this arm only after the shared
+                // local-only gate above. The forced-local orchestrator carries
+                // the whole HDR authority (control id, adapter LoRAs, and
+                // per-stage reference windows), so every stage renders a true
+                // regrade of its own slice of the reference (#688).
                 warn_if_clamped(
                     clip_frames,
                     family
@@ -3329,15 +3333,37 @@ mod tests {
 
 #[cfg(test)]
 mod hdr_chain_guard_tests {
-    /// Chained EXR export renders locally: the ChainRequest wire carries no
-    /// HDR fields, so a remote submission could only silently drop the
-    /// sidecar — the empty-directory-beside-`✓ Saved` failure #681 refused.
-    /// The Chain arm must therefore reject hdr+remote with an error naming
-    /// `--local`, and must NOT reject hdr+local (that path builds the
-    /// ChainHdrInputs authority and hands it to the orchestrator).
-    ///
-    /// Asserted against the source because the guard sits inside the routing
-    /// match in a long function, the way the other CLI routing contracts are.
+    #[test]
+    fn remote_hdr_exr_is_rejected_before_request_construction() {
+        let path = "/tmp/client-side-exr".to_string();
+        let error = super::require_local_hdr_exr_dir(Some(path.clone()), false).unwrap_err();
+        assert!(error.to_string().contains("--local"), "got: {error:#}");
+        assert!(
+            error.to_string().contains("remote server"),
+            "got: {error:#}"
+        );
+
+        assert_eq!(
+            super::require_local_hdr_exr_dir(Some(path.clone()), true).unwrap(),
+            Some(path)
+        );
+        assert_eq!(super::require_local_hdr_exr_dir(None, false).unwrap(), None);
+
+        let source = include_str!("generate.rs");
+        let gate = source
+            .find("require_local_hdr_exr_dir(hdr_exr_dir, local)?")
+            .expect("run must apply the local-only HDR gate");
+        let request = source
+            .find("let mut req = GenerateRequest")
+            .expect("run must construct the generation request");
+        assert!(
+            gate < request,
+            "the local-only gate must run before a normal remote GenerateRequest can be built"
+        );
+    }
+
+    /// Forced-local chaining must retain the sidecar authority after the
+    /// shared local-only gate rather than dropping its export metadata.
     #[test]
     fn auto_chaining_routes_the_exr_sidecar_to_the_local_orchestrator() {
         let source = include_str!("generate.rs");
@@ -3345,20 +3371,6 @@ mod hdr_chain_guard_tests {
             .split("ChainRoutingDecision::Chain {")
             .nth(1)
             .expect("the Chain routing arm must exist");
-        let guard = chain_arm
-            .split("warn_if_clamped")
-            .next()
-            .expect("the guard must precede any other chain work");
-
-        assert!(
-            guard.contains("hdr_exr_dir.is_some() && !local"),
-            "the Chain arm must reject an EXR sidecar only for remote submission; \
-             forced-local chains carry the sidecar for real now"
-        );
-        assert!(
-            guard.contains("anyhow::bail!") && guard.contains("--local"),
-            "the hdr+remote combination must be an error that names --local"
-        );
         assert!(
             chain_arm.contains("ChainHdrInputs"),
             "the local branch must build the ChainHdrInputs authority"

--- a/crates/mold-server/src/chain_job_runner.rs
+++ b/crates/mold-server/src/chain_job_runner.rs
@@ -132,6 +132,7 @@ pub(crate) struct CreateJobParams {
 
 pub enum RunnerCmd {
     Kick,
+    Shutdown,
     Gc {
         reply: tokio::sync::oneshot::Sender<std::result::Result<GcOutcome, String>>,
     },
@@ -293,6 +294,20 @@ impl CancelRegistry {
         } else {
             false
         }
+    }
+
+    fn request_all(&self) -> usize {
+        let tokens = self
+            .tokens
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        for token in &tokens {
+            token.cancel();
+        }
+        tokens.len()
     }
 
     fn is_cancelled(&self, job_id: &str) -> bool {
@@ -505,6 +520,14 @@ impl ChainJobRunnerHandle {
     /// Mark cancel-requested; false when the job is unknown to the registry.
     pub fn request_cancel(&self, job_id: &str) -> bool {
         self.cancel.request(job_id)
+    }
+
+    /// Fence every active chain attempt before the HTTP server starts
+    /// draining long-lived SSE responses, then stop the orchestration loop.
+    pub fn request_shutdown(&self) -> usize {
+        let cancelled = self.cancel.request_all();
+        let _ = self.kick_tx.send(RunnerCmd::Shutdown);
+        cancelled
     }
 
     pub fn is_cancelling(&self, job_id: &str) -> bool {
@@ -1232,6 +1255,7 @@ async fn claim_for_execution_async(deps: &RunnerDeps, job: &ChainJobRow) -> anyh
 async fn handle_runner_cmd(deps: Arc<RunnerDeps>, cmd: RunnerCmd) -> bool {
     match cmd {
         RunnerCmd::Kick => true,
+        RunnerCmd::Shutdown => false,
         RunnerCmd::Gc { reply } => {
             let result = run_gc_for_runner(deps, true).await;
             let _ = reply.send(result);

--- a/crates/mold-server/src/chain_job_runner.rs
+++ b/crates/mold-server/src/chain_job_runner.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::io::Cursor;
 use std::ops::ControlFlow;
 use std::path::{Component, Path, PathBuf};
-use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -49,6 +49,7 @@ pub struct ChainJobRunnerHandle {
 
 pub struct CancelRegistry {
     tokens: Mutex<HashMap<String, mold_inference::InferenceCancellationToken>>,
+    shutting_down: AtomicBool,
 }
 
 struct ActiveChainAttemptGuard {
@@ -263,15 +264,22 @@ impl CancelRegistry {
     pub fn new() -> Self {
         Self {
             tokens: Mutex::new(HashMap::new()),
+            shutting_down: AtomicBool::new(false),
         }
     }
 
     fn register(&self, job_id: &str) {
-        self.tokens
+        let mut tokens = self
+            .tokens
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .entry(job_id.to_string())
-            .or_default();
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let token = tokens.entry(job_id.to_string()).or_default();
+        // The load happens while the token map is locked. If shutdown races
+        // after this load, request_all() must acquire the same lock and will
+        // observe/cancel this token; if shutdown won first, cancel it here.
+        if self.shutting_down.load(Ordering::Acquire) {
+            token.cancel();
+        }
     }
 
     fn unregister(&self, job_id: &str) {
@@ -297,6 +305,10 @@ impl CancelRegistry {
     }
 
     fn request_all(&self) -> usize {
+        // Fence future registrations before snapshotting current attempts.
+        // register() checks this flag while holding the token-map lock, making
+        // a claim racing shutdown either visible here or cancelled on insert.
+        self.shutting_down.store(true, Ordering::Release);
         let tokens = self
             .tokens
             .lock()
@@ -319,12 +331,15 @@ impl CancelRegistry {
     }
 
     fn token(&self, job_id: &str) -> mold_inference::InferenceCancellationToken {
-        self.tokens
+        let mut tokens = self
+            .tokens
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-            .entry(job_id.to_string())
-            .or_default()
-            .clone()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let token = tokens.entry(job_id.to_string()).or_default();
+        if self.shutting_down.load(Ordering::Acquire) {
+            token.cancel();
+        }
+        token.clone()
     }
 }
 

--- a/crates/mold-server/src/gpu_worker.rs
+++ b/crates/mold-server/src/gpu_worker.rs
@@ -1314,6 +1314,15 @@ fn process_scheduled_chain_stage(
         "chain stage reached execution without an exact execution plan".to_string()
     })?;
     job.stage_req.placement = Some(crate::execution_plan::materialized_placement(&plan));
+    tracing::info!(
+        gpu = worker.gpu.ordinal,
+        model = %job.model,
+        work_id = %job.id,
+        work_kind = "chain_stage",
+        "dispatched job"
+    );
+    let memory_watchdog =
+        ChainStageMemoryWatchdog::start(worker.gpu.ordinal, job.model.clone(), job.id.clone());
     struct ActiveGuard<'a>(&'a GpuWorker);
     impl Drop for ActiveGuard<'_> {
         fn drop(&mut self) {
@@ -1397,10 +1406,90 @@ fn process_scheduled_chain_stage(
     )
     .map_err(|error| format!("{error:#}"))?
     .map_err(|error| format!("{error:#}"))?;
+    drop(memory_watchdog);
     Ok(crate::chain_job_runner::StageExecution {
         outcome: result,
         device_ordinal: Some(worker.gpu.ordinal),
     })
+}
+
+/// Scheduled chain stages bypass `process_job`, so they need their own memory
+/// heartbeat around model readiness and rendering. A channel-backed stop wakes
+/// the thread immediately for short stages instead of making completion wait
+/// for the one-second sampling interval.
+struct ChainStageMemoryWatchdog {
+    stop: Option<std::sync::mpsc::Sender<()>>,
+    handle: Option<std::thread::JoinHandle<()>>,
+    rss_before: u64,
+    ordinal: usize,
+    model: String,
+    work_id: String,
+}
+
+impl ChainStageMemoryWatchdog {
+    fn start(ordinal: usize, model: String, work_id: String) -> Self {
+        let rss_before = crate::resources::ram_snapshot().used_by_mold;
+        let (stop, stopped) = std::sync::mpsc::channel();
+        let thread_model = model.clone();
+        let thread_work_id = work_id.clone();
+        let handle = std::thread::Builder::new()
+            .name(format!("chain-rss-watchdog-{ordinal}"))
+            .spawn(move || {
+                let start = Instant::now();
+                while let Err(std::sync::mpsc::RecvTimeoutError::Timeout) =
+                    stopped.recv_timeout(Duration::from_secs(1))
+                {
+                    let rss = crate::resources::ram_snapshot().used_by_mold;
+                    tracing::info!(
+                        gpu = ordinal,
+                        model = %thread_model,
+                        work_id = %thread_work_id,
+                        elapsed_s = start.elapsed().as_secs(),
+                        rss_mb = rss / 1_000_000,
+                        "chain stage rss watchdog"
+                    );
+                }
+            })
+            .map_err(|error| {
+                tracing::warn!(
+                    gpu = ordinal,
+                    model = %model,
+                    work_id = %work_id,
+                    %error,
+                    "could not start chain stage RSS watchdog"
+                );
+            })
+            .ok();
+        Self {
+            stop: Some(stop),
+            handle,
+            rss_before,
+            ordinal,
+            model,
+            work_id,
+        }
+    }
+}
+
+impl Drop for ChainStageMemoryWatchdog {
+    fn drop(&mut self) {
+        if let Some(stop) = self.stop.take() {
+            let _ = stop.send(());
+        }
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+        let rss_after = crate::resources::ram_snapshot().used_by_mold;
+        tracing::info!(
+            gpu = self.ordinal,
+            model = %self.model,
+            work_id = %self.work_id,
+            rss_before_mb = self.rss_before / 1_000_000,
+            rss_after_mb = rss_after / 1_000_000,
+            rss_delta_mb = (rss_after as i64 - self.rss_before as i64) / 1_000_000,
+            "chain stage memory delta"
+        );
+    }
 }
 
 fn fence_chain_stage_render(
@@ -4438,6 +4527,30 @@ mod tests {
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex, RwLock};
     use std::time::Duration;
+
+    #[test]
+    fn scheduled_chain_stage_wraps_render_with_dispatch_and_memory_observability() {
+        let source = include_str!("gpu_worker.rs");
+        let start = source
+            .find("fn process_scheduled_chain_stage(")
+            .expect("scheduled chain stage handler");
+        let end = source[start..]
+            .find("\nfn fence_chain_stage_render(")
+            .map(|offset| start + offset)
+            .expect("scheduled chain stage handler boundary");
+        let method = &source[start..end];
+        let dispatch = method.find("\"dispatched job\"").expect("dispatch log");
+        let watchdog = method
+            .find("ChainStageMemoryWatchdog::start(")
+            .expect("memory watchdog start");
+        let render = method
+            .find("run_stage_blocking_planned(")
+            .expect("planned stage render");
+        let stop = method
+            .find("drop(memory_watchdog)")
+            .expect("memory watchdog stop");
+        assert!(dispatch < watchdog && watchdog < render && render < stop);
+    }
 
     /// Weight-free engine that sleeps in `load()` to widen the critical-section
     /// window during concurrency tests.

--- a/crates/mold-server/src/lib.rs
+++ b/crates/mold-server/src/lib.rs
@@ -905,8 +905,20 @@ pub async fn run_server(
     // All inject + enforce layers use .layer() (not .route_layer()) so they run on
     // ALL requests, including unmatched 404 paths — preventing auth/rate-limit bypass.
     // Set up graceful shutdown: fires on SIGTERM or POST /api/shutdown.
-    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+    // The public trigger feeds an arbiter that fences GPU scheduling and
+    // active chain attempts *before* Axum starts draining long-lived SSE
+    // responses. Waiting until `serve` returned could wedge forever on the
+    // very chain stream whose inference still needed cancellation (#586).
+    let (shutdown_tx, shutdown_request_rx) = tokio::sync::oneshot::channel::<()>();
+    let (http_shutdown_tx, http_shutdown_rx) = tokio::sync::oneshot::channel::<()>();
     *state.shutdown_tx.lock().await = Some(shutdown_tx);
+    let shutdown_scheduler = scheduler_shutdown.clone();
+    let shutdown_chain_jobs = state.chain_jobs.clone();
+    tokio::spawn(async move {
+        let _ = shutdown_request_rx.await;
+        begin_runtime_shutdown(shutdown_chain_jobs.as_deref(), &shutdown_scheduler);
+        let _ = http_shutdown_tx.send(());
+    });
 
     #[cfg(unix)]
     {
@@ -1043,7 +1055,7 @@ pub async fn run_server(
             app.into_make_service_with_connect_info::<SocketAddr>(),
         )
         .with_graceful_shutdown(async move {
-            let _ = shutdown_rx.await;
+            let _ = http_shutdown_rx.await;
             tracing::info!("shutting down");
         }),
     );
@@ -1124,6 +1136,17 @@ pub async fn run_server(
     Ok(())
 }
 
+fn begin_runtime_shutdown(
+    chain_jobs: Option<&chain_job_runner::ChainJobRunnerHandle>,
+    scheduler_shutdown: &tokio_util::sync::CancellationToken,
+) {
+    if let Some(chain_jobs) = chain_jobs {
+        let active_chains = chain_jobs.request_shutdown();
+        tracing::info!(active_chains, "cancelled chain work before HTTP drain");
+    }
+    scheduler_shutdown.cancel();
+}
+
 /// Spawn a tokio task that wakes every 60s and drops any cache entry whose
 /// `last_used` is older than `ttl` (and that isn't actively GPU-resident).
 /// Sweeps the legacy cache. Per-GPU caches are evicted by their dedicated
@@ -1201,8 +1224,8 @@ fn build_cors_layer() -> Result<CorsLayer> {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_cors_layer, classify_startup_mode, startup_plan, trace_request_path, GpuOwnerThreads,
-        StartupMode,
+        begin_runtime_shutdown, build_cors_layer, classify_startup_mode, startup_plan,
+        trace_request_path, GpuOwnerThreads, StartupMode,
     };
     use crate::auth::{inject_auth_state, require_api_key, ApiKeySet};
     use crate::device_registry::DeviceRegistry;
@@ -1221,6 +1244,18 @@ mod tests {
     use tower::ServiceExt;
 
     static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn runtime_shutdown_cancels_chains_and_scheduler_before_http_drain() {
+        let chains = crate::chain_job_runner::ChainJobRunnerHandle::inert_for_tests();
+        chains.register_cancel_for_tests("chain-in-flight");
+        let scheduler = tokio_util::sync::CancellationToken::new();
+
+        begin_runtime_shutdown(Some(&chains), &scheduler);
+
+        assert!(chains.is_cancelling("chain-in-flight"));
+        assert!(scheduler.is_cancelled());
+    }
 
     #[test]
     fn invalid_cors_origin_returns_error() {

--- a/crates/mold-server/src/lib.rs
+++ b/crates/mold-server/src/lib.rs
@@ -1254,6 +1254,8 @@ mod tests {
         begin_runtime_shutdown(Some(&chains), &scheduler);
 
         assert!(chains.is_cancelling("chain-in-flight"));
+        chains.register_cancel_for_tests("chain-claimed-during-shutdown");
+        assert!(chains.is_cancelling("chain-claimed-during-shutdown"));
         assert!(scheduler.is_cancelled());
     }
 

--- a/crates/mold-server/src/queue.rs
+++ b/crates/mold-server/src/queue.rs
@@ -1816,6 +1816,49 @@ pub async fn run_queue_dispatcher_until_cancelled(
     run_queue_dispatcher_with_tuning(job_rx, state, buffer_size, max_deferrals, shutdown).await;
 }
 
+const LEGACY_UNAVAILABLE_INITIAL_WAIT: std::time::Duration = std::time::Duration::from_millis(250);
+const LEGACY_UNAVAILABLE_MAX_WAIT: std::time::Duration = std::time::Duration::from_secs(2);
+
+struct LegacyUnavailableBackoff {
+    next_wait: std::time::Duration,
+    warning_emitted: bool,
+}
+
+impl LegacyUnavailableBackoff {
+    fn new() -> Self {
+        Self {
+            next_wait: LEGACY_UNAVAILABLE_INITIAL_WAIT,
+            warning_emitted: false,
+        }
+    }
+
+    /// Return whether this is the transition into unavailable state. The
+    /// caller logs only on that transition instead of once per retry tick.
+    fn enter_unavailable(&mut self) -> bool {
+        !std::mem::replace(&mut self.warning_emitted, true)
+    }
+
+    fn take_wait(&mut self) -> std::time::Duration {
+        let wait = self.next_wait;
+        self.next_wait = self
+            .next_wait
+            .saturating_mul(2)
+            .min(LEGACY_UNAVAILABLE_MAX_WAIT);
+        wait
+    }
+}
+
+async fn wait_for_legacy_worker_retry(
+    shutdown: &tokio_util::sync::CancellationToken,
+    wait: std::time::Duration,
+) -> bool {
+    tokio::select! {
+        biased;
+        _ = shutdown.cancelled() => false,
+        _ = tokio::time::sleep(wait) => true,
+    }
+}
+
 pub async fn run_legacy_scheduled_work_dispatcher(
     mut scheduled_work_rx: tokio::sync::mpsc::Receiver<crate::scheduler::ScheduledOwnerWork>,
     mut owner_event_rx: tokio::sync::mpsc::UnboundedReceiver<crate::gpu_worker::LegacyOwnerEvent>,
@@ -1883,6 +1926,7 @@ async fn dispatch_legacy_scheduled_work(
     }
     let mut pending = Some(work);
     let mut skip = Vec::new();
+    let mut unavailable = LegacyUnavailableBackoff::new();
     loop {
         if !wait_for_legacy_dispatch(state, shutdown).await {
             pending
@@ -1930,7 +1974,14 @@ async fn dispatch_legacy_scheduled_work(
                 return true;
             }
             skip.clear();
-            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            if !wait_for_legacy_worker_retry(shutdown, unavailable.take_wait()).await {
+                pending
+                    .take()
+                    .expect("legacy scheduled work remains pending")
+                    .work
+                    .reject(legacy_dispatch_stop_message(state));
+                return false;
+            }
             continue;
         };
 
@@ -2283,6 +2334,7 @@ async fn run_queue_dispatcher_with_tuning(
             Vec::new()
         };
         let mut dispatched = false;
+        let mut unavailable = LegacyUnavailableBackoff::new();
 
         while !dispatched {
             if shutdown.is_cancelled()
@@ -2321,11 +2373,19 @@ async fn run_queue_dispatcher_with_tuning(
 
             let Some(worker) = worker else {
                 if preferred_gpu.is_none() && state.gpu_pool.worker_count() > 0 {
-                    tracing::warn!(
-                        model = %model_name,
-                        "all GPU workers are temporarily unavailable; keeping job queued"
-                    );
-                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                    if unavailable.enter_unavailable() {
+                        tracing::warn!(
+                            model = %model_name,
+                            "all GPU workers are temporarily unavailable; keeping job queued"
+                        );
+                    }
+                    if !wait_for_legacy_worker_retry(&shutdown, unavailable.take_wait()).await {
+                        if let Some(job) = gpu_job.take() {
+                            crate::gpu_pool::OwnerWork::Generation(Box::new(job))
+                                .reject(legacy_dispatch_stop_message(&state));
+                        }
+                        break 'dispatcher;
+                    }
                     continue;
                 }
                 let rejected = gpu_job
@@ -2834,6 +2894,25 @@ mod tests {
     use std::sync::atomic::AtomicUsize;
     use std::sync::{Arc, Mutex, RwLock};
     use tempfile::TempDir;
+
+    #[test]
+    fn legacy_unavailable_backoff_warns_once_and_caps_retry_frequency() {
+        let mut backoff = LegacyUnavailableBackoff::new();
+        assert!(backoff.enter_unavailable());
+        assert!(!backoff.enter_unavailable());
+        assert_eq!(backoff.take_wait(), std::time::Duration::from_millis(250));
+        assert_eq!(backoff.take_wait(), std::time::Duration::from_millis(500));
+        assert_eq!(backoff.take_wait(), std::time::Duration::from_secs(1));
+        assert_eq!(backoff.take_wait(), std::time::Duration::from_secs(2));
+        assert_eq!(backoff.take_wait(), std::time::Duration::from_secs(2));
+    }
+
+    #[tokio::test]
+    async fn legacy_unavailable_wait_is_immediately_shutdown_cancellable() {
+        let shutdown = tokio_util::sync::CancellationToken::new();
+        shutdown.cancel();
+        assert!(!wait_for_legacy_worker_retry(&shutdown, std::time::Duration::from_secs(60)).await);
+    }
 
     /// A `GenerateRequest` with the bare minimum fields populated — enough to
     /// hand to `OutputMetadata::from_generate_request` in tests.

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -651,6 +651,17 @@ async fn prepare_generation(
     state: &AppState,
     request: &mut mold_core::GenerateRequest,
 ) -> Result<(Option<std::path::PathBuf>, RequestWarnings, Option<usize>), ApiError> {
+    // `hdr_exr_dir` names an output directory on the machine doing inference.
+    // An HTTP client must never choose that server-local path: unlike media
+    // inputs there is no useful remote artifact to return and no safe root to
+    // resolve it beneath. Forced-local CLI generation bypasses this boundary
+    // and continues to own EXR export and metadata recording.
+    if request.hdr_exr_dir.is_some() {
+        return Err(ApiError::validation(
+            "hdr_exr_dir is local-only and cannot be set through the server API; \
+             re-run the CLI with --local so the EXR sidecar is written on your machine",
+        ));
+    }
     ensure_schedulable_device(state)?;
     // NOTE: the capacity check is enforced inside `state.queue.submit(...)` so
     // that a burst of concurrent callers can't all slip past an open check

--- a/crates/mold-server/src/routes_test.rs
+++ b/crates/mold-server/src/routes_test.rs
@@ -5230,6 +5230,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn generate_rejects_client_supplied_hdr_exr_directory() {
+        let app = app_with(MockEngine::ready());
+        let body = serde_json::json!({
+            "prompt": "an HDR sunset",
+            "model": "mock-model",
+            "width": 768,
+            "height": 768,
+            "steps": 4,
+            "batch_size": 1,
+            "output_format": "mp4",
+            "hdr_exr_dir": "/tmp/client-chosen-server-path"
+        });
+        let resp = app
+            .oneshot(
+                Request::post("/api/generate")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body = json_body(resp).await;
+        assert_eq!(body["code"], "VALIDATION_ERROR");
+        assert!(
+            body["error"]
+                .as_str()
+                .is_some_and(|error| error.contains("hdr_exr_dir") && error.contains("--local")),
+            "got: {body}"
+        );
+    }
+
+    #[tokio::test]
     async fn server_local_media_paths_require_configured_roots() {
         let state = AppState::with_engine(MockEngine::ready());
         let mut req: GenerateRequest = serde_json::from_value(serde_json::json!({


### PR DESCRIPTION
## Summary

- make default-model resolution tests deterministic across process-wide environment mutation
- reject remote HDR EXR output paths at both CLI and server authority boundaries
- replace degraded-worker WARN polling with cancellation-aware bounded backoff
- give scheduled chain stages dispatch/RSS observability and cancel chain work before HTTP shutdown drain

## Root causes

- default-model tests read `MOLD_DEFAULT_MODEL` without joining the shared environment lock
- `hdr_exr_dir` crossed the HTTP boundary as an unconstrained server-local output path
- legacy dispatch retried unavailable workers every 100 ms and logged every retry
- chain stages used their own scheduled execution path, missing ordinary dispatch telemetry, while shutdown cancellation happened only after Axum drained active SSE requests

## Validation

- `nix develop -c cargo fmt --all -- --check`
- `nix develop -c cargo clippy -p mold-ai-server -p mold-ai --all-targets -- -D warnings`
- default-command tests, including an ambient `MOLD_DEFAULT_MODEL` override
- remote HDR CLI and direct server API rejection regressions
- legacy unavailable-worker backoff, cancellation, recovery, and capacity regressions
- chain-stage dispatch/memory observability and pre-drain shutdown cancellation regressions
- full `mold-ai-server` library suite: 1264 passed; two unrelated wall-clock tests exceeded local budgets under concurrent worktree compilation; the affected post-upscale test passed alone after narrowing transport behavior

Closes #562
Closes #581
Closes #586
Closes #703
