### PR TITLE
fix(desktop): delete full gallery selection

### DIFF
--- a/desktop/src/views/LibraryView.test.ts
+++ b/desktop/src/views/LibraryView.test.ts
@@ -159,6 +159,46 @@ beforeEach(() => {
 });
 
 describe("LibraryView delete keyboard handling", () => {
+  it("routes a selected video's context-menu Delete through the full bulk selection", async () => {
+    const videos = prints.map((print, index) => ({
+      ...print,
+      filename: `${index + 1}.mp4`,
+    }));
+    localGalleryList.mockResolvedValueOnce({ images: videos, target: null });
+    const { wrapper, gallery } = await mountView(undefined, (g) => {
+      g.buckets.local!.items = videos;
+    });
+
+    await wrapper.get('[aria-label="Toggle select mode"]').trigger("click");
+    const tiles = wrapper.findAll(".ms-lib-tile");
+    await tiles[0]!.trigger("click");
+    await tiles[1]!.trigger("click", { metaKey: true });
+    expect(wrapper.get('[data-test="bulk-action-bar"]').text()).toContain("2 / 2 selected");
+
+    await tiles[0]!.trigger("contextmenu");
+    const menu = useContextMenuStore();
+    const deleteEntry = menu.entries.find(
+      (entry) => !("separator" in entry) && entry.label === "Delete 2 selected",
+    );
+    expect(deleteEntry).toBeDefined();
+    menu.activate(deleteEntry!);
+    await flushPromises();
+
+    const confirm = wrapper
+      .get('[data-test="bulk-action-bar"]')
+      .findAll("button")
+      .find((button) => button.text().includes("Delete 2 prints?"));
+    expect(confirm).toBeDefined();
+    await confirm!.trigger("click");
+    await flushPromises();
+
+    expect(localGalleryDelete).toHaveBeenCalledTimes(2);
+    expect(localGalleryDelete).toHaveBeenCalledWith("1.mp4");
+    expect(localGalleryDelete).toHaveBeenCalledWith("2.mp4");
+    expect(gallery.filtered).toHaveLength(0);
+    wrapper.unmount();
+  });
+
   it("loads a remote gallery image as the Create source from its context menu", async () => {
     const remotePrint: GalleryImage = {
       ...prints[0]!,

--- a/desktop/src/views/LibraryView.vue
+++ b/desktop/src/views/LibraryView.vue
@@ -287,6 +287,8 @@ async function editSequence(entry: MergedPrint) {
 function tileMenu(entry: MergedPrint): MenuEntry[] {
   const item = entry.item;
   const m = item.metadata;
+  const selectedForBulkDelete =
+    selectMode.value && bulkSelection.value.has(item.filename) && bulkSelection.value.size > 1;
   return [
     ...(isSequencePrint(entry)
       ? [
@@ -351,9 +353,12 @@ function tileMenu(entry: MergedPrint): MenuEntry[] {
     },
     { separator: true },
     {
-      label: "Delete",
+      label: selectedForBulkDelete ? `Delete ${bulkSelection.value.size} selected` : "Delete",
       danger: true,
-      action: () => deletePrint(entry),
+      action: () => {
+        if (selectedForBulkDelete) void deleteSelectedPrints();
+        else deletePrint(entry);
+      },
     },
   ];
 }


### PR DESCRIPTION
## Summary

- route desktop Library context-menu deletion through the active multi-selection
- preserve the existing two-step bulk confirmation and delete-everywhere failure recovery
- keep single-print context deletion unchanged for lone or unselected tiles

## Root cause

The desktop tile context menu always captured one `MergedPrint` and called the single-print delete path, even when the tile belonged to an active multi-selection. The bulk action bar and keyboard path already resolved every selected logical print correctly.

## Validation

- `bun run --cwd desktop test -- src/views/LibraryView.test.ts` (16 passed)
- `bun run --cwd desktop build`
- `bun run check:architecture`
- `bun run check:dead-code`
- `bun run --cwd desktop fmt:check`
- rendered Library QA at `http://127.0.0.1:1430/library` with selection toolbar interaction and zero console warnings/errors

Closes #707
