### PR TITLE
refactor(studio): share blob base64 encoding

### DIFF
--- a/desktop/src/lib/image.ts
+++ b/desktop/src/lib/image.ts
@@ -1,3 +1,7 @@
+import { blobToBase64 } from "@studio/lib/base64";
+
+export { blobToBase64 };
+
 /**
  * Read a `File` (drag-drop or <input type=file>) to base64 with no data-URI
  * prefix — the shape mold-core expects for `source_image` / `mask_image` /
@@ -8,19 +12,6 @@
  */
 export function fileToBase64(file: File): Promise<string> {
   return blobToBase64(file);
-}
-
-/** Read any `Blob` (e.g. a `fetch().blob()` of an authed gallery image) to
- * base64 with no data-URI prefix — the shape mold-core expects on the wire. */
-export function blobToBase64(blob: Blob): Promise<string> {
-  return blob.arrayBuffer().then((buffer) => {
-    const bytes = new Uint8Array(buffer);
-    let binary = "";
-    for (let offset = 0; offset < bytes.length; offset += 0x8000) {
-      binary += String.fromCharCode(...bytes.subarray(offset, offset + 0x8000));
-    }
-    return btoa(binary);
-  });
 }
 
 /** Object URL for a base64 payload so a `<img>` can preview it. */

--- a/desktop/src/views/LibraryView.vue
+++ b/desktop/src/views/LibraryView.vue
@@ -12,6 +12,7 @@ import {
   loadGalleryThumbnailSize,
   saveGalleryThumbnailSize,
 } from "@studio/lib/galleryThumbnailSize";
+import { blobToBase64 } from "@studio/lib/base64";
 import AuthedMedia from "../components/gallery/AuthedMedia.vue";
 import Lightbox from "../components/gallery/Lightbox.vue";
 import HistoryDrawer from "../components/library/HistoryDrawer.vue";
@@ -108,15 +109,6 @@ const canReveal = (entry: MergedPrint) =>
  *  once a local copy exists. */
 const canSaveLocally = (entry: MergedPrint) =>
   inTauri() && gallery.hostFor(entry.sourceKey)?.kind === "remote" && !gallery.existsLocally(entry);
-
-async function blobToBase64(blob: Blob): Promise<string> {
-  const bytes = new Uint8Array(await blob.arrayBuffer());
-  let binary = "";
-  for (let i = 0; i < bytes.length; i += 0x8000) {
-    binary += String.fromCharCode(...bytes.subarray(i, i + 0x8000));
-  }
-  return btoa(binary);
-}
 
 /** Authed source bytes for a host-gallery item, as base64 (origin-aware). */
 async function fetchItemBase64(entry: MergedPrint): Promise<string> {

--- a/studio/index.ts
+++ b/studio/index.ts
@@ -7,3 +7,4 @@ export * from "./lib/sourceFit";
 export * from "./lib/chainRouting";
 export * from "./lib/modelDisplay";
 export * from "./lib/sequence";
+export * from "./lib/base64";

--- a/studio/lib/base64.ts
+++ b/studio/lib/base64.ts
@@ -1,0 +1,9 @@
+/** Encode a Blob as raw base64 without a data-URI prefix. */
+export async function blobToBase64(blob: Blob): Promise<string> {
+  const bytes = new Uint8Array(await blob.arrayBuffer());
+  let binary = "";
+  for (let offset = 0; offset < bytes.length; offset += 0x8000) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + 0x8000));
+  }
+  return btoa(binary);
+}

--- a/web/src/lib/base64.ts
+++ b/web/src/lib/base64.ts
@@ -1,19 +1,4 @@
-/**
- * Encode a Blob / File / ArrayBuffer as raw base64 (no data-URI prefix).
- * The server expects bare base64 in GenerateRequest.source_image.
- */
-export async function blobToBase64(input: Blob): Promise<string> {
-  const buffer = await input.arrayBuffer();
-  const bytes = new Uint8Array(buffer);
-  let binary = "";
-  const chunk = 0x8000;
-  for (let i = 0; i < bytes.length; i += chunk) {
-    binary += String.fromCharCode(
-      ...bytes.subarray(i, Math.min(i + chunk, bytes.length)),
-    );
-  }
-  return btoa(binary);
-}
+export { blobToBase64 } from "@studio/lib/base64";
 
 /** Inverse — base64 → Blob, used by the image picker's gallery tab. */
 export function base64ToBlob(b64: string, mime: string): Blob {


### PR DESCRIPTION
## Summary

- add one browser-safe Studio authority for chunked Blob-to-base64 encoding
- keep the existing web and desktop utility APIs while delegating them to the shared implementation
- remove the third inline encoder from the desktop Library save path

This preserves the existing raw-base64 wire shape and 32 KiB chunking while replacing three equivalent production implementations with one.

## Reduction

Reproducible hand-written non-test production measurement:

```text
$ git diff --numstat origin/main...HEAD -- '*.ts' '*.vue' ':!**/*.test.ts' ':!**/*.spec.ts'
4       13      desktop/src/lib/image.ts
1       9       desktop/src/views/LibraryView.vue
1       0       studio/index.ts
9       0       studio/lib/base64.ts
1       16      web/src/lib/base64.ts
```

- production source: 16 additions / 38 deletions, net **-22 lines**
- aggregate changed production files: **1,194 lines before → 1,172 after**
- test source: **0 additions / 0 deletions**
- generated, vendor, lock, and dependency files: unchanged

This is a structural reduction: three encoder bodies become one shared implementation; no code was renamed, minified, or moved without removing duplication.

## Behavior preservation

The existing encoder characterization ran before and after the refactor. It covers ASCII round-tripping, payloads spanning multiple 32 KiB chunks, empty blobs, and the required bare-base64 output. Existing desktop and mobile image-picker/viewer consumers also passed before and after, so no new test file was needed.

## Validation

All commands passed locally:

```text
(cd web && bun run test -- src/lib/base64.test.ts)  # 4 tests
(cd desktop && bun run test -- src/components/generate/ImagePickerModal.test.ts src/mobile/MobileGalleryViewer.test.ts)  # 33 tests
bun run check:architecture
bun run check:dead-code
bun run test:studio  # 387 tests
(cd web && bun run fmt:check && bun run test && bun run build)  # 1,161 tests + typecheck/build
(cd desktop && bun run fmt:check && bunx vue-tsc -b && bun run test && bun run build && bun run build:mobile)  # 2,911 tests + desktop/mobile builds
scripts/tests/ios-release-assets.sh
scripts/tests/ios-testflight-distribution.sh
scripts/tests/ios-sim-pick.sh
nix build .#mold-web --print-build-logs
git diff --check
```

The Vite builds emitted only the repository's existing chunk-size/dynamic-import warnings.
