### PR TITLE
fix(build): enforce the actual Rust 1.93 MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,6 +278,28 @@ jobs:
       - name: Check with all optional features
         run: cargo check -p mold-ai --features preview,discord,expand,tui,webp,mp4,mdns
 
+  msrv:
+    name: Declared MSRV
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Read workspace MSRV
+        id: msrv
+        shell: bash
+        run: |
+          msrv=$(sed -n 's/^rust-version = "\([^"]*\)"$/\1/p' Cargo.toml)
+          test -n "$msrv"
+          echo "toolchain=$msrv" >> "$GITHUB_OUTPUT"
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ steps.msrv.outputs.toolchain }}
+      - name: Install Rust build deps
+        run: sudo apt-get update && sudo apt-get install -y clang lld nasm libwebp-dev
+      - name: Check workspace on declared MSRV
+        run: cargo check --workspace --all-targets --locked
+
   cuda-check:
     name: CUDA forced-local typecheck
     needs: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,6 +265,15 @@ jobs:
         with:
           shared-key: workspace-default
           save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Check declared MSRV
+        shell: bash
+        run: |
+          msrv=$(sed -n 's/^rust-version = "\([^"]*\)"$/\1/p' Cargo.toml)
+          test -n "$msrv"
+          rustup toolchain install "$msrv" --profile minimal
+          cargo "+$msrv" check --workspace --all-targets --locked
+          cargo "+$msrv" check -p mold-ai --locked \
+            --features preview,discord,expand,tui,webp,mp4,mdns
       - name: Format
         run: cargo fmt --all -- --check
       - name: Check
@@ -277,28 +286,6 @@ jobs:
         run: bash scripts/tests/local-multi-gpu-qualification-contract.sh
       - name: Check with all optional features
         run: cargo check -p mold-ai --features preview,discord,expand,tui,webp,mp4,mdns
-
-  msrv:
-    name: Declared MSRV
-    needs: changes
-    if: needs.changes.outputs.rust == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - name: Read workspace MSRV
-        id: msrv
-        shell: bash
-        run: |
-          msrv=$(sed -n 's/^rust-version = "\([^"]*\)"$/\1/p' Cargo.toml)
-          test -n "$msrv"
-          echo "toolchain=$msrv" >> "$GITHUB_OUTPUT"
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ steps.msrv.outputs.toolchain }}
-      - name: Install Rust build deps
-        run: sudo apt-get update && sudo apt-get install -y clang lld nasm libwebp-dev
-      - name: Check workspace on declared MSRV
-        run: cargo check --workspace --all-targets --locked
 
   cuda-check:
     name: CUDA forced-local typecheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,10 +270,15 @@ jobs:
         run: |
           msrv=$(sed -n 's/^rust-version = "\([^"]*\)"$/\1/p' Cargo.toml)
           test -n "$msrv"
-          rustup toolchain install "$msrv" --profile minimal
-          cargo "+$msrv" check --workspace --all-targets --locked
-          cargo "+$msrv" check -p mold-ai --locked \
-            --features preview,discord,expand,tui,webp,mp4,mdns
+          case "$msrv" in
+            *.*.*) msrv_toolchain=$msrv ;;
+            *.*) msrv_toolchain=$msrv.0 ;;
+            *) echo "Invalid rust-version: $msrv" >&2; exit 1 ;;
+          esac
+          rustup toolchain install "$msrv_toolchain" --profile minimal
+          cargo "+$msrv_toolchain" check --workspace --all-targets --locked
+          cargo "+$msrv_toolchain" check -p mold-ai --locked \
+            --features preview,discord,expand,tui,metrics,webp,mp4,mdns
       - name: Format
         run: cargo fmt --all -- --check
       - name: Check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ crates/
 | `mold-discord/`   | `mold-ai-discord`          |
 | `mold-tui/`       | `mold-ai-tui`              |
 
-**MSRV**: 1.85.
+**MSRV**: 1.93.
 
 **iPhone app** (`apps/mobile/src-tauri`, frontend entry in `desktop/src/mobile/`): a standalone thin Tauri crate, excluded from the root workspace so the desktop GPU/server dependency tree is never cross-compiled for iOS. It is always remote-only (`HostView.kind = "remote"`, `primary = false`) and owns the five Mold Studio destinations as four tabs plus a push screen: **Create**, a merged remote **Library**, **Models**, **Machines**/host detail, and a header-pushed Settings screen; a full-screen Advanced sheet hosts the sampler/negative/source/LoRA/format controls with an active-count badge. Reuse `desktop/src/lib` API types, explicit-target HTTP/SSE helpers, capability/request form, source fitting, gallery media, catalog, and theme logic; never import a desktop store that assumes a local **This device** engine.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ authors = [
     "Jeffrey Dilley <jeff.dilley@gmail.com>",
 ]
 description = "CLI-native local AI image and video generation for people, scripts, and agents"
-rust-version = "1.85"
+rust-version = "1.93"
 homepage = "https://github.com/utensils/mold"
 repository = "https://github.com/utensils/mold"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/utensils/mold/actions/workflows/ci.yml/badge.svg)](https://github.com/utensils/mold/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/utensils/mold/graph/badge.svg)](https://codecov.io/gh/utensils/mold)
 [![FlakeHub](https://img.shields.io/endpoint?url=https://flakehub.com/f/utensils/mold/badge)](https://flakehub.com/flake/utensils/mold)
-[![Rust](https://img.shields.io/badge/rust-1.85%2B-orange.svg)](https://www.rust-lang.org)
+[![Rust](https://img.shields.io/badge/rust-1.93%2B-orange.svg)](https://www.rust-lang.org)
 [![Nix Flake](https://img.shields.io/badge/nix-flake-blue.svg)](https://nixos.wiki/wiki/Flakes)
 [![CLI native](https://img.shields.io/badge/CLI-native-7c3aed.svg)](https://utensils.io/mold/guide/cli-reference)
 [![Agent ready](https://img.shields.io/badge/agents-ready-0891b2.svg)](https://utensils.io/mold/guide/openclaw)

--- a/crates/mold-catalog/Cargo.toml
+++ b/crates/mold-catalog/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 readme.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/crates/mold-cli/Cargo.toml
+++ b/crates/mold-cli/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 readme.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/crates/mold-core/Cargo.toml
+++ b/crates/mold-core/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 readme.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/crates/mold-db/Cargo.toml
+++ b/crates/mold-db/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 readme.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/crates/mold-discord/Cargo.toml
+++ b/crates/mold-discord/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 description = "Discord bot for mold — AI image generation via slash commands"
 
 [lib]

--- a/crates/mold-inference/Cargo.toml
+++ b/crates/mold-inference/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 readme.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/crates/mold-scheduler/Cargo.toml
+++ b/crates/mold-scheduler/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 description = "Pure deterministic scheduler core for Mold"
 
 [lib]

--- a/crates/mold-server/Cargo.toml
+++ b/crates/mold-server/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 readme.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/crates/mold-tui/Cargo.toml
+++ b/crates/mold-tui/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 readme.workspace = true
 keywords.workspace = true
 categories.workspace = true

--- a/desktop/docs/architecture.md
+++ b/desktop/docs/architecture.md
@@ -99,7 +99,7 @@ resolver = "2"
 
 **Why (rejecting workspace membership):**
 
-- The root workspace is MSRV 1.85 / edition 2021 and every CI gate runs `--workspace` (`cargo check/clippy/test --workspace` with `-D warnings`). Joining would drag ~400 Tauri/objc2/wry crates into `clippy --workspace`, into crane's `buildDepsOnly` artifacts (invalidating the CUDA dep cache on every Tauri bump), and into `Cargo.lock` churn for a CUDA-heavy workspace. Exclusion means **zero risk to existing CI/builds** — the only main-tree edits are the one-line exclude, flake additions, and a new branch-gated workflow.
+- The root workspace is MSRV 1.93 / edition 2021 and every CI gate runs `--workspace` (`cargo check/clippy/test --workspace` with `-D warnings`). Joining would drag ~400 Tauri/objc2/wry crates into `clippy --workspace`, into crane's `buildDepsOnly` artifacts (invalidating the CUDA dep cache on every Tauri bump), and into `Cargo.lock` churn for a CUDA-heavy workspace. Exclusion means **zero risk to existing CI/builds** — the only main-tree edits are the one-line exclude, flake additions, and a new branch-gated workflow.
 - This is exactly the proven Aethon pattern (`cargoRoot = "src-tauri"`, separate `Cargo.lock`, `rustPlatform.buildRustPackage` + `cargo-tauri.hook`).
 - Path dependencies work fine across the boundary: `desktop/src-tauri` depends on `../../crates/mold-server` etc. by path; it compiles those crates under its own lock/profile.
 - **Deliberate choice: edition 2021 for the desktop crate** (Tauri 2 does not require 2024). This keeps treefmt's `rustfmt { edition = "2021" }` correct for the whole tree and lets the desktop crate build with the devshell's existing stable toolchain. (Aethon used 2024; we don't need it and it buys friction.)
@@ -334,7 +334,7 @@ desktop/
 name = "mold-desktop"
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.85"
+rust-version = "1.93"
 
 [lib]
 name = "mold_desktop_lib"

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
 license = "MIT"
 repository = "https://github.com/utensils/mold"
 edition = "2021"
-rust-version = "1.85"
+rust-version = "1.93"
 
 # This crate is deliberately its own cargo root (see the root Cargo.toml
 # [workspace] exclude): the Tauri dependency tree must not enter the CUDA

--- a/packaging/aur/mold-ai-git/PKGBUILD
+++ b/packaging/aur/mold-ai-git/PKGBUILD
@@ -23,7 +23,7 @@ optdepends=(
 
 makedepends=(
   'git'
-  'rust>=1.85'
+  'rust>=1.93'
   'cargo'
   'cuda'
   'clang'

--- a/packaging/aur/mold-ai/PKGBUILD
+++ b/packaging/aur/mold-ai/PKGBUILD
@@ -24,7 +24,7 @@ optdepends=(
 # `clang` + `lld` + `nasm` mirror the apt deps in .github/workflows/release.yml
 # build-linux-sm89 — candle-flash-attn and the H.264 decoder need them.
 makedepends=(
-  'rust>=1.85'
+  'rust>=1.93'
   'cargo'
   'cuda'
   'clang'

--- a/website/guide/installation.md
+++ b/website/guide/installation.md
@@ -187,7 +187,7 @@ cargo build --release -p mold-ai --features metal
 
 :::
 
-Requires Rust 1.85+ and CUDA toolkit (Linux) or Xcode (macOS).
+Requires Rust 1.93+ and CUDA toolkit (Linux) or Xcode (macOS).
 
 Optional features can be added to the same build, for example
 `--features cuda,preview,expand,discord,tui` or


### PR DESCRIPTION
## Summary

- raise the root and standalone desktop MSRV from Rust 1.85 to the empirically verified Rust 1.93 floor
- make every root workspace crate inherit the workspace rust-version so Clippy applies MSRV-aware lint gates consistently
- synchronize both AUR packages, public installation guidance, the README badge, and maintainer architecture documentation
- enforce the declared MSRV inside the already-required rust CI job, covering every workspace target and the supported optional-feature combination

## Root cause

The workspace declaration was stale and only mold-ai-candle inherited it. Rust 1.87 is already too old for the locked dependency graph, and Rust 1.92 still rejects the existing VecDeque::pop_front_if queue implementation. Rust 1.93 is the first candidate that checks the complete current workspace successfully.

## Validation

- confirmed Rust 1.87 fails dependency MSRV checks
- confirmed Rust 1.92 rejects VecDeque::pop_front_if
- cargo +1.93.0 check --workspace --all-targets --locked
- cargo +1.93.0 check -p mold-ai --locked --features preview,discord,expand,tui,webp,mp4,mdns
- cargo +1.93.0 check --manifest-path desktop/src-tauri/Cargo.toml --locked
- cargo +stable clippy --workspace --all-targets --locked -- -D warnings on Rust 1.95
- cargo fmt checks for both root and desktop manifests
- bash scripts/tests/ci-routing-contract.sh
- bash scripts/tests/release-sync-pr.sh
- website bun run fmt:check
- parsed .github/workflows/ci.yml successfully with Ruby Psych
- verified Cargo metadata reports Rust 1.93 for all ten workspace packages

Closes #737