### PR TITLE
fix(ci): lint GPU feature paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,6 +289,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
       - name: Free runner disk space
         run: |
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/.ghcup
@@ -308,8 +310,8 @@ jobs:
         with:
           shared-key: workspace-cuda-sm89
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      - name: Check CUDA forced-local and server paths
-        run: cargo check -p mold-ai --features cuda,preview,expand,tui,webp,mp4,mdns
+      - name: Clippy CUDA forced-local and server paths
+        run: cargo clippy -p mold-ai --features cuda,preview,expand,tui,webp,mp4,mdns --all-targets -- -D warnings
 
   # The `flash-attn` feature was decorative for months (issue #598) precisely
   # because nothing ever compiled it: the cfg-stripped fallback in
@@ -381,14 +383,8 @@ jobs:
       # `dev-bins` pulls in `attention_bench`, which no other gate compiles.
       - name: Clippy the flash-attn inference lib, tests and dev-bins
         run: cargo clippy -p mold-ai-inference --features flash-attn,dev-bins --all-targets -- -D warnings
-      # Deliberately `check`, not `clippy`. This step exists to prove the
-      # binary's feature wiring resolves; linting `-p mold-ai` with the feature
-      # additionally lints every `cuda`-gated crate, and mold-server carries
-      # pre-existing violations there that no gate has ever run (cuda-check is
-      # `cargo check` only, and the `rust` clippy job has no CUDA). Widening
-      # this gate to cover that debt belongs in its own change — see #738.
-      - name: Check the flash-attn binary wiring
-        run: cargo check -p mold-ai --features flash-attn
+      - name: Clippy the flash-attn binary wiring
+        run: cargo clippy -p mold-ai --features flash-attn -- -D warnings
 
   metal-check:
     name: Metal forced-local typecheck
@@ -398,12 +394,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: workspace-metal
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      - name: Check Metal forced-local and server paths
-        run: cargo check -p mold-ai --features metal,preview,expand,tui,webp,mp4,mdns
+      - name: Clippy Metal forced-local and server paths
+        run: cargo clippy -p mold-ai --features metal,preview,expand,tui,webp,mp4,mdns --all-targets -- -D warnings
 
   coverage:
     needs: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,6 @@ jobs:
               - 'crates/mold-inference/src/attention.rs'
               - 'crates/mold-inference/Cargo.toml'
               - 'crates/mold-cli/Cargo.toml'
-              - '.github/workflows/ci.yml'
             website:
               - 'website/**'
               - '.github/workflows/ci.yml'
@@ -320,7 +319,9 @@ jobs:
   #
   # It runs on main (keeping the kernel cache warm — GitHub evicts caches after
   # 7 idle days, and a cold run costs ~an hour) and on PRs that touch the
-  # attention dispatcher or the feature wiring.
+  # attention dispatcher or Cargo feature wiring. Workflow-only edits get
+  # their proof on the mandatory main run instead of blocking the PR for the
+  # 79-minute cold build.
   flash-attn-check:
     name: FlashAttention feature typecheck
     needs: changes

--- a/crates/mold-cli/src/commands/generate.rs
+++ b/crates/mold-cli/src/commands/generate.rs
@@ -1682,7 +1682,7 @@ async fn generate_local_batch(
 
     enum LocalOwnerEvent {
         Ready(usize),
-        Completed(usize, u32, GenerateResponse),
+        Completed(usize, u32, Box<GenerateResponse>),
         Failed(usize, u32, anyhow::Error),
         Crashed(usize, anyhow::Error),
     }
@@ -1735,8 +1735,11 @@ async fn generate_local_batch(
                     })();
                     match result {
                         Ok(response) => {
-                            let _ =
-                                event_tx.send(LocalOwnerEvent::Completed(ordinal, index, response));
+                            let _ = event_tx.send(LocalOwnerEvent::Completed(
+                                ordinal,
+                                index,
+                                Box::new(response),
+                            ));
                             let _ = event_tx.send(LocalOwnerEvent::Ready(ordinal));
                         }
                         Err(error) => {
@@ -1794,7 +1797,7 @@ async fn generate_local_batch(
                     )));
                     break 'events;
                 }
-                completed.push((index, response));
+                completed.push((index, *response));
                 terminal_items += 1;
             }
             LocalOwnerEvent::Failed(ordinal, index, error) => {

--- a/crates/mold-server/src/memory_preflight.rs
+++ b/crates/mold-server/src/memory_preflight.rs
@@ -725,13 +725,13 @@ pub(crate) fn preflight_planned_memory_guard(
         let free = authoritative_cuda_available(
             mold_inference::device::usable_free_vram_bytes_result(gpu_ordinal),
         )?;
-        return check_planned_memory_budget_with_resident(
+        check_planned_memory_budget_with_resident(
             model_name,
             predicted_peak_bytes,
             free,
             active_vram_bytes,
             rejection_suggestion(hint),
-        );
+        )
     }
 
     #[cfg(not(feature = "cuda"))]
@@ -818,12 +818,12 @@ pub(crate) fn preflight_planned_memory_guard_after_drop(
         let available = authoritative_cuda_available(
             mold_inference::device::post_drop_free_vram_bytes(gpu_ordinal),
         )?;
-        return check_planned_memory_budget(
+        check_planned_memory_budget(
             model_name,
             predicted_peak_bytes,
             available,
             rejection_suggestion(hint),
-        );
+        )
     }
 
     #[cfg(not(feature = "cuda"))]

--- a/scripts/tests/ci-routing-contract.sh
+++ b/scripts/tests/ci-routing-contract.sh
@@ -25,6 +25,15 @@ require_text "$ci" \
   "if: needs.changes.outputs.gpu == 'true'" \
   "backend checks are not routed through the GPU-specific classifier"
 require_text "$ci" \
+  "cargo clippy -p mold-ai --features cuda,preview,expand,tui,webp,mp4,mdns --all-targets -- -D warnings" \
+  "CUDA-gated production code is not linted"
+require_text "$ci" \
+  "cargo clippy -p mold-ai --features metal,preview,expand,tui,webp,mp4,mdns --all-targets -- -D warnings" \
+  "Metal-gated production code is not linted"
+require_text "$ci" \
+  "cargo clippy -p mold-ai --features flash-attn -- -D warnings" \
+  "the flash-attn binary wiring is only typechecked"
+require_text "$ci" \
   "if: github.event_name == 'push' && needs.changes.outputs.rust == 'true'" \
   "coverage is not deferred to the post-merge main run"
 release_filter="$(sed -n '/^            release:/,/^  release:/p' "$ci")"

--- a/scripts/tests/ci-routing-contract.sh
+++ b/scripts/tests/ci-routing-contract.sh
@@ -33,6 +33,13 @@ require_text "$ci" \
 require_text "$ci" \
   "cargo clippy -p mold-ai --features flash-attn -- -D warnings" \
   "the flash-attn binary wiring is only typechecked"
+flash_filter="$(sed -n '/^            flash:/,/^            website:/p' "$ci")"
+if grep -Fq ".github/workflows/ci.yml" <<< "$flash_filter"; then
+  fail "unrelated root CI edits still trigger the hour-long FlashAttention kernel build on PRs"
+fi
+require_text "$ci" \
+  "if: github.event_name == 'push' || needs.changes.outputs.flash == 'true'" \
+  "FlashAttention is not covered by every main push after narrowing its PR paths"
 require_text "$ci" \
   "if: github.event_name == 'push' && needs.changes.outputs.rust == 'true'" \
   "coverage is not deferred to the post-merge main run"


### PR DESCRIPTION
Closes #738.

## What changed

- run Clippy with warnings denied for CUDA and Metal forced-local feature paths, including all mold CLI targets
- restore Clippy for the flash-attn binary wiring now that CUDA-gated debt is clean
- remove the two CUDA-only needless returns
- box completed local batch responses to eliminate the backend-only large enum variant
- extend the CI routing contract so these GPU lint gates cannot silently regress to cargo check

## Validation

- full Metal forced-local Clippy with all targets
- 16 memory-preflight tests
- 2 local-batch tests
- CI routing contract
- cargo fmt and git diff checks

The CUDA command cannot run locally on macOS because nvcc is unavailable; this PR intentionally makes the Linux CUDA job the authoritative validation for that backend.