### PR TITLE
refactor(web): consolidate durable sequence requests

### DIFF
--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  amendChainJob,
+  ApiHttpError,
   cancelChainJob,
   chainJobEventsUrl,
   chainJobStagePreviewUrl,
@@ -545,6 +547,20 @@ describe("chain job api helpers", () => {
       },
     );
 
+    const amendRequest = { stages: chainRequest().stages ?? [], steps: 12 };
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ ...summary, preserved_stages: 1 })),
+    );
+    await amendChainJob("job/1", amendRequest);
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      "/api/chain-jobs/job%2F1/amend",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(amendRequest),
+      },
+    );
+
     fetchMock.mockResolvedValueOnce(new Response(JSON.stringify(summary)));
     await cancelChainJob("job/1");
     expect(fetchMock).toHaveBeenLastCalledWith(
@@ -574,6 +590,21 @@ describe("chain job api helpers", () => {
     expect(fetchMock).toHaveBeenLastCalledWith("/api/chain-jobs/gc", {
       method: "POST",
       headers: {},
+    });
+  });
+
+  it("preserves typed HTTP errors from durable sequence requests", async () => {
+    installFetch({ error: "job moved on" }, 409);
+
+    const error = await amendChainJob("job/1", {
+      stages: chainRequest().stages ?? [],
+    }).catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(ApiHttpError);
+    expect(error).toMatchObject({
+      message:
+        'POST /api/chain-jobs/job/1/amend failed: 409 {"error":"job moved on"}',
+      status: 409,
     });
   });
 

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -408,50 +408,57 @@ async function requireJson<T>(res: Response, label: string): Promise<T> {
   return (await res.json()) as T;
 }
 
+async function chainJobJson<T>(
+  suffix: string,
+  target?: StreamTarget,
+  request: { method?: "POST"; body?: unknown } = {},
+): Promise<T> {
+  const path = `/api/chain-jobs${suffix}`;
+  const hasBody = request.body !== undefined;
+  const res = await fetch(`${targetBase(target)}${path}`, {
+    ...(request.method ? { method: request.method } : {}),
+    headers: {
+      ...(hasBody ? { "content-type": "application/json" } : {}),
+      ...targetHeaders(target),
+    },
+    ...(hasBody ? { body: JSON.stringify(request.body) } : {}),
+  });
+  return requireJson<T>(
+    res,
+    `${request.method ?? "GET"} ${decodeURIComponent(path)}`,
+  );
+}
+
 export async function createChainJob(
   req: ChainRequestWire,
   target?: StreamTarget,
 ): Promise<CreateChainJobResponse> {
-  const res = await fetch(`${targetBase(target)}/api/chain-jobs`, {
+  return chainJobJson("", target, {
     method: "POST",
-    headers: {
-      "content-type": "application/json",
-      ...targetHeaders(target),
-    },
-    body: JSON.stringify(req),
+    body: req,
   });
-  return requireJson<CreateChainJobResponse>(res, "POST /api/chain-jobs");
 }
 
 export async function listChainJobs(
   target?: StreamTarget,
 ): Promise<ChainJobListing> {
-  const res = await fetch(`${targetBase(target)}/api/chain-jobs`, {
-    headers: targetHeaders(target),
-  });
-  return requireJson<ChainJobListing>(res, "GET /api/chain-jobs");
+  return chainJobJson("", target);
 }
 
 export async function getChainJob(
   id: string,
   target?: StreamTarget,
 ): Promise<ChainJobDetail> {
-  const res = await fetch(
-    `${targetBase(target)}/api/chain-jobs/${encodeURIComponent(id)}`,
-    { headers: targetHeaders(target) },
-  );
-  return requireJson<ChainJobDetail>(res, `GET /api/chain-jobs/${id}`);
+  return chainJobJson(`/${encodeURIComponent(id)}`, target);
 }
 
 export async function resumeChainJob(
   id: string,
   target?: StreamTarget,
 ): Promise<ChainJobSummary> {
-  const res = await fetch(
-    `${targetBase(target)}/api/chain-jobs/${encodeURIComponent(id)}/resume`,
-    { method: "POST", headers: targetHeaders(target) },
-  );
-  return requireJson<ChainJobSummary>(res, `POST /api/chain-jobs/${id}/resume`);
+  return chainJobJson(`/${encodeURIComponent(id)}/resume`, target, {
+    method: "POST",
+  });
 }
 
 export async function retakeChainJob(
@@ -459,29 +466,19 @@ export async function retakeChainJob(
   req: RetakeRequest,
   target?: StreamTarget,
 ): Promise<ChainJobSummary> {
-  const res = await fetch(
-    `${targetBase(target)}/api/chain-jobs/${encodeURIComponent(id)}/retake`,
-    {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        ...targetHeaders(target),
-      },
-      body: JSON.stringify(req),
-    },
-  );
-  return requireJson<ChainJobSummary>(res, `POST /api/chain-jobs/${id}/retake`);
+  return chainJobJson(`/${encodeURIComponent(id)}/retake`, target, {
+    method: "POST",
+    body: req,
+  });
 }
 
 export async function cancelChainJob(
   id: string,
   target?: StreamTarget,
 ): Promise<ChainJobSummary> {
-  const res = await fetch(
-    `${targetBase(target)}/api/chain-jobs/${encodeURIComponent(id)}/cancel`,
-    { method: "POST", headers: targetHeaders(target) },
-  );
-  return requireJson<ChainJobSummary>(res, `POST /api/chain-jobs/${id}/cancel`);
+  return chainJobJson(`/${encodeURIComponent(id)}/cancel`, target, {
+    method: "POST",
+  });
 }
 
 export async function deleteChainJob(
@@ -509,32 +506,19 @@ export async function amendChainJob(
   req: AmendRequestWire,
   target?: StreamTarget,
 ): Promise<AmendResponseWire> {
-  const res = await fetch(
-    `${targetBase(target)}/api/chain-jobs/${encodeURIComponent(id)}/amend`,
-    {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        ...targetHeaders(target),
-      },
-      body: JSON.stringify(req),
-    },
-  );
-  return requireJson<AmendResponseWire>(
-    res,
-    `POST /api/chain-jobs/${id}/amend`,
-  );
+  return chainJobJson(`/${encodeURIComponent(id)}/amend`, target, {
+    method: "POST",
+    body: req,
+  });
 }
 
 export async function gcChainJobs(target?: StreamTarget): Promise<{
   swept_ephemeral_jobs: number;
   pruned_artifact_dirs: number;
 }> {
-  const res = await fetch(`${targetBase(target)}/api/chain-jobs/gc`, {
+  return chainJobJson("/gc", target, {
     method: "POST",
-    headers: targetHeaders(target),
   });
-  return requireJson(res, "POST /api/chain-jobs/gc");
 }
 
 export function chainJobEventsUrl(id: string, target?: StreamTarget): string {


### PR DESCRIPTION
## Summary

- consolidate the repeated durable-sequence JSON request plumbing behind one chain-job-specific helper
- preserve each endpoint's method, body shape, API-key header, encoded job ID, and typed HTTP error
- leave delete separate because its accepted `204` response differs from JSON endpoints

## Reduction

Reproducible production measurement:

```text
$ git diff --numstat origin/main...HEAD -- web/src/api.ts
40      56      web/src/api.ts
```

That is **16 fewer hand-written non-test production lines**. The production file fell from **849 to 833 lines**:

```text
$ git show origin/main:web/src/api.ts | wc -l
849
$ wc -l web/src/api.ts
833
```

The structural reduction replaces duplicated routing, authenticated headers, JSON serialization, fetch, and `ApiHttpError` handling across eight create/list/get/resume/retake/cancel/amend/GC helpers. Test changes are reported separately: `web/src/api.test.ts` is `+31/-0`. No generated, vendor, lock, dependency, or documentation files changed.

## Behavior preservation

- the existing focused API suite passed before editing (17 tests)
- the missing amend request shape and typed `409 ApiHttpError` contract were characterized on the pre-refactor code (18 tests)
- the same 18 focused tests pass after consolidation
- the full web suite covers local and authenticated remote request routing

## Validation

- `bun run --cwd web test -- src/api.test.ts` — 18 passed
- `bun run check:architecture` — passed
- `bun run check:dead-code` — passed
- `bun run test:studio` — 422 passed
- `bun run --cwd web fmt:check` — passed
- `bun run --cwd web test` — 1,174 passed
- `bun run --cwd web build` — passed (Vue typecheck + Vite build)
- `nix build .#mold-web --print-build-logs` — passed
- `git diff --check` — passed
