### PR TITLE
fix(activity): restore recovered work across clients

### DIFF
--- a/desktop/src/components/create/ActivityStrip.test.ts
+++ b/desktop/src/components/create/ActivityStrip.test.ts
@@ -33,7 +33,7 @@ function baseJob(): Job {
 }
 
 describe("ActivityStrip", () => {
-  it("shows shared work from another client with explicit host and stale state", () => {
+  it("keeps recovered shared work visible and actionable", async () => {
     useLiveActivityStore().hosts = {
       render: {
         hostId: "render",
@@ -46,12 +46,14 @@ describe("ActivityStrip", () => {
         error: "offline",
         items: [
           {
-            id: "foreign",
-            kind: "generation",
-            phase: "running",
-            model: "flux-dev",
+            id: "pull-1",
+            kind: "download",
+            phase: "downloading",
+            model: "ltx-2",
             created_at_unix_ms: 1,
             updated_at_unix_ms: 2,
+            current: 50,
+            total: 100,
             can_cancel: false,
           },
         ],
@@ -61,6 +63,8 @@ describe("ActivityStrip", () => {
     const wrapper = mount(ActivityStrip);
     expect(wrapper.get("[data-test='shared-live-activity']").text()).toContain("Render box");
     expect(wrapper.text()).toContain("Last seen active · offline");
+    await wrapper.get("[data-test^='live-activity-select-']").trigger("click");
+    expect(routerPush).toHaveBeenCalledWith("/models");
   });
 
   it("is hidden when nothing is in flight", () => {

--- a/desktop/src/components/create/ActivityStrip.vue
+++ b/desktop/src/components/create/ActivityStrip.vue
@@ -25,6 +25,7 @@ import { useToastStore } from "../../stores/toasts";
 import { useComposerStore } from "../../stores/composer";
 import { useSequenceDraftStore } from "@studio/stores/sequenceDraft";
 import { useLiveActivityStore } from "../../stores/liveActivity";
+import { useOpenLiveWork } from "../../composables/useOpenLiveWork";
 
 /**
  * Create activity strip (Mold Studio) — present tense only.
@@ -48,6 +49,7 @@ const toasts = useToastStore();
 const composer = useComposerStore();
 const draft = useSequenceDraftStore();
 const liveActivity = useLiveActivityStore();
+const openLiveWork = useOpenLiveWork();
 
 function selectPrint(job: Job) {
   generation.select(job.clientId);
@@ -313,7 +315,7 @@ function deleteConfirmed() {
       </button>
     </div>
 
-    <LiveActivityList :rows="sharedRows" />
+    <LiveActivityList :rows="sharedRows" interactive @select="openLiveWork" />
 
     <!-- In-flight sequence rows (merged jobs surface) -->
     <SequenceJobRow

--- a/desktop/src/components/generate/ExpandControl.vue
+++ b/desktop/src/components/generate/ExpandControl.vue
@@ -63,7 +63,11 @@ defineExpose({ expand });
       data-test="remix-action"
       class="border-edge min-h-7 rounded-control border px-2 text-body text-ink-2 transition-colors duration-100 hover:border-safelight hover:text-ink active:translate-y-px disabled:opacity-50"
       :disabled="blocked || running || !prompt.trim()"
-      title="Create three subject-preserving prompt remixes"
+      :title="
+        isPreparedBatch
+          ? `Prepare ${batchSize} subject-preserving prompt remixes`
+          : 'Remix this prompt in place'
+      "
       @click="emit('remix')"
     >
       Remix

--- a/desktop/src/components/generate/PreparedExpansionBatch.test.ts
+++ b/desktop/src/components/generate/PreparedExpansionBatch.test.ts
@@ -211,6 +211,33 @@ describe("PreparedExpansionBatch", () => {
     expect(wrapper.get('[data-test="discard-prepared"]').attributes("disabled")).toBeUndefined();
   });
 
+  it("cancels the review from the explicit action or Escape", async () => {
+    const buttonWrapper = mountBatch();
+    expect(buttonWrapper.get('[data-test="discard-prepared"]').text()).toBe("Cancel");
+    await buttonWrapper.get('[data-test="discard-prepared"]').trigger("click");
+    expect(buttonWrapper.emitted("discard")).toHaveLength(1);
+
+    const escapeWrapper = mountBatch();
+    await flushPromises();
+    expect(document.activeElement).toBe(escapeWrapper.findAll("textarea")[0]!.element);
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    await flushPromises();
+    expect(escapeWrapper.emitted("discard")).toHaveLength(1);
+  });
+
+  it("does not discard the review when Escape belongs to another surface", async () => {
+    const wrapper = mountBatch();
+    const outside = document.createElement("button");
+    document.body.append(outside);
+    outside.focus();
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    await flushPromises();
+
+    expect(wrapper.emitted("discard")).toBeUndefined();
+    outside.remove();
+  });
+
   it("preserves stale work, names the reasons, and blocks generation", () => {
     const wrapper = mountBatch({
       staleReasons: [

--- a/desktop/src/components/generate/PreparedExpansionBatch.vue
+++ b/desktop/src/components/generate/PreparedExpansionBatch.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, ref, watch } from "vue";
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import { hostSelectionLabel, type PreparedExpansionBatch } from "../../lib/preparedExpansion";
 import type { ExpansionPullView } from "../../lib/expansionPull";
 import ExpansionPullStatus from "./ExpansionPullStatus.vue";
@@ -138,6 +138,21 @@ function confirmCollapse() {
   confirmingRemovalId.value = null;
   emit("collapse", id);
 }
+
+function dismissOnEscape(event: KeyboardEvent) {
+  if (event.key !== "Escape" || event.defaultPrevented || confirmingRemovalId.value) return;
+  const active = document.activeElement;
+  if (active && active !== document.body && !sectionEl.value?.contains(active)) return;
+  event.preventDefault();
+  emit("discard");
+}
+
+onMounted(async () => {
+  window.addEventListener("keydown", dismissOnEscape);
+  await nextTick();
+  sectionEl.value?.querySelector<HTMLTextAreaElement>('[data-test="prepared-prompt"]')?.focus();
+});
+onBeforeUnmount(() => window.removeEventListener("keydown", dismissOnEscape));
 </script>
 
 <template>
@@ -340,7 +355,7 @@ function confirmCollapse() {
       aria-modal="false"
       aria-labelledby="collapse-title"
       class="border-safelight/45 mt-3 rounded-control border bg-[color-mix(in_srgb,var(--safelight)_8%,transparent)] p-3"
-      @keydown.esc="keepPreparedBatch"
+      @keydown.esc.stop.prevent="keepPreparedBatch"
     >
       <p id="collapse-title" class="text-body font-semibold text-ink">Continue with one prompt?</p>
       <p class="mt-1 max-w-[65ch] text-caption text-ink-2">
@@ -376,7 +391,7 @@ function confirmCollapse() {
         class="min-h-8 rounded-control px-2 text-caption text-ink-3 transition-colors duration-100 hover:bg-stop/10 hover:text-stop"
         @click="emit('discard')"
       >
-        Discard prepared batch
+        Cancel
       </button>
       <div class="flex min-w-0 flex-wrap items-center justify-end gap-2">
         <span class="text-caption text-ink-3">

--- a/desktop/src/components/shell/NavRail.test.ts
+++ b/desktop/src/components/shell/NavRail.test.ts
@@ -10,6 +10,8 @@ import { useGalleryStore } from "../../stores/gallery";
 import { useGenerationStore } from "../../stores/generation";
 import { useChainJobsStore } from "../../stores/chainJobs";
 import { useHostModelsStore } from "../../stores/hostModels";
+import { useLiveActivityStore } from "../../stores/liveActivity";
+import { useComposerStore } from "../../stores/composer";
 
 const stub = { template: "<div />" };
 
@@ -100,6 +102,84 @@ describe("NavRail collapse", () => {
 });
 
 describe("NavRail developing jobs", () => {
+  it("shows recovered work and reloads its submitted settings", async () => {
+    const wrapper = await mountAt("/create");
+    useHostsStore().extras.push({
+      id: "render",
+      label: "Render box",
+      url: "http://render:7680",
+      apiKey: "secret",
+      status: "ready",
+      error: null,
+      instanceId: "render-instance",
+    });
+    useLiveActivityStore().hosts = {
+      render: {
+        hostId: "render",
+        hostLabel: "Render box",
+        target: { baseUrl: "http://render:7680", apiKey: null },
+        routeUrl: "http://render:7680",
+        instanceId: "render-instance",
+        observedAtUnixMs: 2,
+        stale: false,
+        error: null,
+        unavailableKinds: [],
+        items: [
+          {
+            id: "foreign",
+            kind: "generation",
+            phase: "running",
+            model: "flux-dev",
+            created_at_unix_ms: 1,
+            updated_at_unix_ms: 2,
+            can_cancel: false,
+          },
+        ],
+      },
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            entries: [
+              {
+                id: "foreign",
+                model: "flux-dev",
+                state: "running",
+                started_at_unix_ms: 1,
+                position: 0,
+                seed_pinned: true,
+                metadata: {
+                  model: "flux-dev",
+                  prompt: "restore me",
+                  width: 1024,
+                  height: 1024,
+                  steps: 20,
+                  guidance: 3.5,
+                  seed: 42,
+                },
+              },
+            ],
+            plan: null,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      ),
+    );
+    await flushPromises();
+
+    expect(wrapper.get("[data-test='developing-region']").text()).toContain("Render box");
+    expect(wrapper.text()).not.toContain("nothing developing");
+    await wrapper.get("[data-test^='live-activity-select-']").trigger("click");
+    await flushPromises();
+
+    expect(useComposerStore().prefill).toMatchObject({
+      metadata: { prompt: "restore me", seed: 42 },
+    });
+    vi.unstubAllGlobals();
+  });
+
   it("uses the remaining rail height before scrolling queued jobs", async () => {
     const wrapper = await mountAt("/create");
     const generation = useGenerationStore();

--- a/desktop/src/components/shell/NavRail.vue
+++ b/desktop/src/components/shell/NavRail.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed, onBeforeUnmount, onMounted, ref } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import NavItem from "@ui/components/NavItem.vue";
 import Keycap from "@ui/components/Keycap.vue";
+import LiveActivityList from "@ui/components/LiveActivityList.vue";
 import type { IconName } from "@ui/icons";
 import logoUrl from "../../assets/logo.png";
 import StatusPopover from "./StatusPopover.vue";
@@ -28,11 +29,13 @@ import { useContextMenuStore, type MenuEntry } from "../../stores/contextMenu";
 import { useGalleryStore } from "../../stores/gallery";
 import { useHostsStore } from "../../stores/hosts";
 import { useHostModelsStore } from "../../stores/hostModels";
+import { useLiveActivityStore } from "../../stores/liveActivity";
 import { useToastStore } from "../../stores/toasts";
 import { badgeCount } from "../../lib/notifications";
 import { shortcutLabel } from "../../lib/platform";
 import { modelDisplayNameForId } from "../../lib/models";
 import { useSequenceDraftStore } from "@studio/stores/sequenceDraft";
+import { useOpenLiveWork } from "../../composables/useOpenLiveWork";
 
 const route = useRoute();
 const router = useRouter();
@@ -43,9 +46,11 @@ const composer = useComposerStore();
 const contextMenu = useContextMenuStore();
 const hosts = useHostsStore();
 const hostModels = useHostModelsStore();
+const liveActivity = useLiveActivityStore();
 const gallery = useGalleryStore();
 const toasts = useToastStore();
 const draft = useSequenceDraftStore();
+const openLiveWork = useOpenLiveWork();
 
 // Workspace badges (§08 G11): Library counts prints developed since the last
 // visit; Machines shows a stop dot when any connected host is offline.
@@ -138,7 +143,31 @@ const railSequences = computed(() =>
   ).active.filter((vm): vm is ActivityJobVM & { kind: "sequence" } => vm.kind === "sequence"),
 );
 
-const developingCount = computed(() => generation.pending.length + railSequences.value.length);
+/** Server-owned work survives this client's restart. Keep it in the global
+ * Now developing rail, not the current session's Create activity strip. Rows
+ * already represented by local print/sequence state stay on their richer,
+ * actionable rail cards instead of rendering twice. */
+const sharedRows = computed(() => {
+  const primaryId = hosts.primaryHost?.id ?? "local";
+  const local = new Set(
+    generation.jobs.flatMap((job) =>
+      job.id ? [`${job.hostId ?? primaryId}:generation:${job.id}`] : [],
+    ),
+  );
+  for (const { hostId, job } of chains.allJobs) local.add(`${hostId}:sequence:${job.id}`);
+  return liveActivity.rows.filter((row) => !local.has(row.key));
+});
+
+const developingCount = computed(
+  () => generation.pending.length + railSequences.value.length + sharedRows.value.length,
+);
+
+onMounted(() => {
+  if (!import.meta.env.TEST) liveActivity.start();
+});
+onBeforeUnmount(() => {
+  if (!import.meta.env.TEST) liveActivity.stop();
+});
 
 /** `clip 3/5 · developing…` — the sequence's answer to developingLabel. */
 function sequenceLine(vm: ActivityJobVM & { kind: "sequence" }): string {
@@ -275,10 +304,11 @@ function selectSequence(vm: ActivityJobVM & { kind: "sequence" }) {
         </span>
       </div>
       <div
-        v-if="railJobs.length > 0 || railSequences.length > 0"
+        v-if="railJobs.length > 0 || railSequences.length > 0 || sharedRows.length > 0"
         data-test="developing-jobs"
         class="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto px-2"
       >
+        <LiveActivityList :rows="sharedRows" compact interactive @select="openLiveWork" />
         <a
           v-for="vm in railSequences"
           :key="vm.key"

--- a/desktop/src/composables/useOpenLiveWork.ts
+++ b/desktop/src/composables/useOpenLiveWork.ts
@@ -1,0 +1,50 @@
+import { useRouter } from "vue-router";
+import type { FleetActiveWork } from "@studio/api/activity";
+import { listQueue } from "@studio/api/queuePlan";
+import type { OutputMetadata } from "../lib/api/types";
+import { useComposerStore } from "../stores/composer";
+import { useHostsStore } from "../stores/hosts";
+import { useToastStore } from "../stores/toasts";
+
+/** Opens server-owned work in the surface that can inspect or resume it. */
+export function useOpenLiveWork() {
+  const router = useRouter();
+  const hosts = useHostsStore();
+  const composer = useComposerStore();
+  const toasts = useToastStore();
+
+  return async (row: FleetActiveWork) => {
+    if (row.kind === "sequence") {
+      composer.setSequence({ kind: "inspect", hostId: row.hostId, jobId: row.id });
+      await router.push("/create");
+      return;
+    }
+    if (row.kind === "generation") {
+      const host = hosts.all.find((candidate) => candidate.id === row.hostId);
+      if (!host?.baseUrl) {
+        toasts.push("That machine is no longer connected", "error");
+        return;
+      }
+      try {
+        const queue = await listQueue({ baseUrl: host.baseUrl, apiKey: host.apiKey });
+        const entry = queue.entries.find((candidate) => candidate.id === row.id);
+        if (!entry?.metadata) {
+          toasts.push("This host cannot restore settings for that generation", "error");
+          return;
+        }
+        const metadata = entry.metadata as OutputMetadata;
+        composer.set({
+          metadata:
+            entry.seed_pinned === false
+              ? ({ ...metadata, seed: null } as unknown as OutputMetadata)
+              : metadata,
+        });
+        await router.push("/create");
+      } catch (error) {
+        toasts.push(error instanceof Error ? error.message : String(error), "error");
+      }
+      return;
+    }
+    await router.push(row.kind === "download" ? "/models" : `/machines/${row.hostId}`);
+  };
+}

--- a/desktop/src/views/GenerateView.prepared.test.ts
+++ b/desktop/src/views/GenerateView.prepared.test.ts
@@ -639,7 +639,7 @@ describe("GenerateView prepared expansion batches", () => {
     });
   });
 
-  it("applies a Remix with the style snapshotted before the request", async () => {
+  it("remixes Batch 1 in place with the style snapshotted before the request", async () => {
     const form = useGenerateFormStore().form;
     form.batchSize = 1;
     form.stylePreset = "cinematic";
@@ -657,17 +657,20 @@ describe("GenerateView prepared expansion batches", () => {
     pending.resolve({
       source_prompt: "a lighthouse at dusk",
       source_kind: "direct",
-      variants: ["one", "two", "three"].map((prompt) => ({
+      variants: ["one"].map((prompt) => ({
         prompt,
         dimensions: ["camera"],
       })),
     });
     await flushPromises();
 
-    const prepared = wrapper.findComponent(PreparedExpansionBatch);
-    expect(prepared.props("batch").stylePreset).toBe("cinematic");
-    prepared.vm.$emit("apply", prepared.props("batch").prompts[0]!.id);
-    await nextTick();
+    expect(vi.mocked(remixPrompt)).toHaveBeenCalledWith(
+      expect.objectContaining({ variations: 1 }),
+      expect.anything(),
+    );
+    expect(wrapper.findComponent(PreparedExpansionBatch).exists()).toBe(false);
+    expect(form.prompt).toBe("one");
+    expect(form.batchSize).toBe(1);
     expect(form.stylePreset).toBe("");
 
     await wrapper.get('[data-test="generate-button"]').trigger("click");
@@ -680,6 +683,31 @@ describe("GenerateView prepared expansion batches", () => {
         dimensions: ["camera"],
       },
     });
+  });
+
+  it("prepares the explicitly selected number of Remix variants", async () => {
+    const form = useGenerateFormStore().form;
+    form.batchSize = 3;
+    vi.mocked(remixPrompt).mockResolvedValue({
+      source_prompt: "a lighthouse at dusk",
+      source_kind: "direct",
+      variants: ["one", "two", "three"].map((prompt) => ({
+        prompt,
+        dimensions: ["camera"],
+      })),
+    });
+    const wrapper = mountView();
+    await flushPromises();
+
+    wrapper.findComponent(ExpandControl).vm.$emit("remix");
+    await flushPromises();
+
+    expect(vi.mocked(remixPrompt)).toHaveBeenCalledWith(
+      expect.objectContaining({ variations: 3 }),
+      expect.anything(),
+    );
+    expect(wrapper.findComponent(PreparedExpansionBatch).props("batch").prompts).toHaveLength(3);
+    expect(form.batchSize).toBe(3);
   });
 
   it("offers immediate human-readable recovery when a quick expansion changes models", async () => {

--- a/desktop/src/views/GenerateView.vue
+++ b/desktop/src/views/GenerateView.vue
@@ -1711,6 +1711,10 @@ async function remixForCurrentPrompt(replacePrepared = false) {
   const source = promptSource(form.prompt, form.originalPrompt, remixSource.value);
   const stylePreset = form.stylePreset || null;
   const dimensions = defaultRemixDimensions(task, Boolean(stylePreset));
+  // Match the Batch value the composer actually presents. Capability/source
+  // constraints can force the effective value to one while preserving the
+  // user's saved raw preference for a later compatible model.
+  const requestedCount = effectiveBatchSize.value;
   const token = preparationGuard.begin();
   expansionRunning.value = true;
   expansionError.value = null;
@@ -1723,7 +1727,7 @@ async function remixForCurrentPrompt(replacePrepared = false) {
         ...(source.rootPrompt ? { root_prompt: source.rootPrompt } : {}),
         source_kind: source.kind,
         model_family: form.family,
-        variations: 3,
+        variations: requestedCount,
         task,
         ...(style ? { style } : {}),
         dimensions,
@@ -1731,7 +1735,7 @@ async function remixForCurrentPrompt(replacePrepared = false) {
       route.target,
     );
     if (!preparationGuard.isCurrent(token)) return;
-    const variants = validateRemixVariants(response.variants, 3);
+    const variants = validateRemixVariants(response.variants, requestedCount);
     const currentRequest = buildRequest(form);
     if (
       form.model !== request.model ||
@@ -1742,7 +1746,37 @@ async function remixForCurrentPrompt(replacePrepared = false) {
         "The model or conditioning changed while Remix was running. Remix again.";
       return;
     }
-    form.batchSize = 3;
+    if (requestedCount === 1) {
+      const selected = variants[0]!;
+      form.prompt = selected.prompt;
+      form.originalPrompt = response.root_prompt ?? response.source_prompt;
+      quickExpansionOriginal.value = response.source_prompt;
+      bakeStyleNegative(stylePreset ?? "", form.family);
+      form.stylePreset = "";
+      quickExpansionSnapshot.value = {
+        requestToken: token,
+        originalPrompt: response.root_prompt ?? response.source_prompt,
+        expandedPrompt: selected.prompt,
+        model: form.model,
+        family: form.family,
+        task,
+        stylePreset,
+        selectedHostPolicy: stickyTarget.value,
+        route: { ...route, target: { ...route.target } },
+        promptTransform: {
+          operation: "remix",
+          ...(response.root_prompt ? { root_prompt: response.root_prompt } : {}),
+          source_prompt: response.source_prompt,
+          source_kind: response.source_kind,
+          task,
+          dimensions: [...selected.dimensions],
+        },
+      };
+      preparedBatch.value = null;
+      void nextTick(() => composerRef.value?.focus?.());
+      return;
+    }
+    form.batchSize = requestedCount;
     const batch = createPreparedExpansionBatch(
       {
         kind: "remix",
@@ -1754,7 +1788,7 @@ async function remixForCurrentPrompt(replacePrepared = false) {
         model: form.model,
         family: form.family,
         task,
-        requestedCount: 3,
+        requestedCount,
         stylePreset,
         selectedHostPolicy: stickyTarget.value,
       },

--- a/studio/api/queuePlan.ts
+++ b/studio/api/queuePlan.ts
@@ -16,6 +16,10 @@ export interface QueueEntry {
   position: number;
   gpu?: number;
   target_gpu?: number | null;
+  /** Additive request settings exposed by current servers. Kept unknown in
+   * studio because desktop and web own structurally compatible metadata types. */
+  metadata?: unknown;
+  seed_pinned?: boolean | null;
 }
 
 export interface QueueWorkItem {

--- a/ui/components/LiveActivityList.vue
+++ b/ui/components/LiveActivityList.vue
@@ -1,7 +1,19 @@
 <script setup lang="ts">
 import type { FleetActiveWork } from "@studio/api/activity";
 
-defineProps<{ rows: FleetActiveWork[] }>();
+withDefaults(
+  defineProps<{
+    rows: FleetActiveWork[];
+    compact?: boolean;
+    interactive?: boolean;
+  }>(),
+  {
+    compact: false,
+    interactive: false,
+  },
+);
+
+const emit = defineEmits<{ select: [row: FleetActiveWork] }>();
 
 function title(row: FleetActiveWork): string {
   if (row.kind === "download")
@@ -25,6 +37,7 @@ function progress(row: FleetActiveWork): number | null {
   <ol
     v-if="rows.length"
     class="live-activity-list"
+    :class="{ 'live-activity-list--compact': compact }"
     data-test="shared-live-activity"
   >
     <li
@@ -33,24 +46,32 @@ function progress(row: FleetActiveWork): number | null {
       class="live-activity-row"
       :data-stale="row.stale"
     >
-      <span
-        class="live-activity-dot"
-        :data-phase="row.phase"
-        aria-hidden="true"
-      />
-      <span class="live-activity-copy">
-        <strong>{{ title(row) }}</strong>
-        <span>
-          {{ row.hostLabel }} · {{ row.phase.replaceAll("_", " ") }}
-          <template v-if="progress(row) !== null">
-            · {{ progress(row) }}%</template
-          >
-          <template v-if="row.stale">
-            · Last seen active ·
-            {{ row.hostError ?? "Waiting to reconnect" }}</template
-          >
+      <component
+        :is="interactive ? 'button' : 'div'"
+        :type="interactive ? 'button' : undefined"
+        class="live-activity-surface"
+        :data-test="interactive ? `live-activity-select-${row.key}` : undefined"
+        @click="interactive && emit('select', row)"
+      >
+        <span
+          class="live-activity-dot"
+          :data-phase="row.phase"
+          aria-hidden="true"
+        />
+        <span class="live-activity-copy">
+          <strong>{{ title(row) }}</strong>
+          <span>
+            {{ row.hostLabel }} · {{ row.phase.replaceAll("_", " ") }}
+            <template v-if="progress(row) !== null">
+              · {{ progress(row) }}%</template
+            >
+            <template v-if="row.stale">
+              · Last seen active ·
+              {{ row.hostError ?? "Waiting to reconnect" }}</template
+            >
+          </span>
         </span>
-      </span>
+      </component>
     </li>
   </ol>
 </template>
@@ -64,18 +85,32 @@ function progress(row: FleetActiveWork): number | null {
   list-style: none;
 }
 .live-activity-row {
+  min-width: 0;
+}
+.live-activity-surface {
   display: flex;
+  width: 100%;
   align-items: center;
+  text-align: left;
   gap: 9px;
   min-height: 44px;
   padding: 7px 10px;
   border: 1px solid var(--edge);
   border-radius: 9px;
   background: var(--surface);
+  color: inherit;
+  font: inherit;
 }
 .live-activity-row[data-stale="true"] {
   opacity: 0.72;
   border-style: dashed;
+}
+.live-activity-surface:is(button) {
+  cursor: pointer;
+}
+.live-activity-surface:is(button):hover {
+  border-color: color-mix(in srgb, var(--safelight) 36%, var(--edge));
+  background: color-mix(in srgb, var(--safelight) 7%, var(--surface));
 }
 .live-activity-dot {
   width: 7px;
@@ -106,5 +141,16 @@ function progress(row: FleetActiveWork): number | null {
   color: var(--ink-3);
   font-size: 11px;
   text-transform: capitalize;
+}
+.live-activity-list--compact .live-activity-surface {
+  min-height: 38px;
+  padding: 5px 7px;
+  background: transparent;
+}
+.live-activity-list--compact .live-activity-copy strong {
+  font-size: 11.5px;
+}
+.live-activity-list--compact .live-activity-copy span {
+  font-size: 9.5px;
 }
 </style>

--- a/web/src/components/create/ActivityStrip.test.ts
+++ b/web/src/components/create/ActivityStrip.test.ts
@@ -66,28 +66,27 @@ function makeSequenceVM(
 }
 
 describe("ActivityStrip", () => {
-  it("shows host-attributed shared work without importing it into session jobs", () => {
+  it("keeps recovered shared work visible and actionable", async () => {
+    const shared = {
+      key: "render:download:pull-1",
+      id: "pull-1",
+      kind: "download" as const,
+      phase: "downloading",
+      model: "ltx-2",
+      hostId: "render",
+      hostLabel: "Render box",
+      stale: true,
+      hostError: "offline",
+      created_at_unix_ms: 1,
+      updated_at_unix_ms: 2,
+      current: 50,
+      total: 100,
+      can_cancel: false,
+    };
     const wrapper = mount(ActivityStrip, {
       props: {
         jobs: [],
-        shared: [
-          {
-            key: "render:download:pull-1",
-            id: "pull-1",
-            kind: "download",
-            phase: "downloading",
-            model: "ltx-2",
-            hostId: "render",
-            hostLabel: "Render box",
-            stale: true,
-            hostError: "offline",
-            created_at_unix_ms: 1,
-            updated_at_unix_ms: 2,
-            current: 50,
-            total: 100,
-            can_cancel: false,
-          },
-        ],
+        shared: [shared],
       },
     });
     expect(wrapper.get("[data-test='shared-live-activity']").text()).toContain(
@@ -95,6 +94,8 @@ describe("ActivityStrip", () => {
     );
     expect(wrapper.text()).toContain("Last seen active · offline");
     expect(wrapper.text()).toContain("50%");
+    await wrapper.get("[data-test^='live-activity-select-']").trigger("click");
+    expect(wrapper.emitted("shared-open")?.[0]).toEqual([shared]);
   });
 
   it("is hidden when nothing is in flight", () => {
@@ -107,7 +108,7 @@ describe("ActivityStrip", () => {
   it("keeps initiating-client history after the shared terminal snapshot disappears", () => {
     const completed = makeSequenceVM({ state: "completed" });
     const wrapper = mount(ActivityStrip, {
-      props: { jobs: [], sequences: [completed], shared: [] },
+      props: { jobs: [], sequences: [completed] },
     });
     expect(wrapper.find("[data-test='shared-live-activity']").exists()).toBe(
       false,

--- a/web/src/components/create/ActivityStrip.vue
+++ b/web/src/components/create/ActivityStrip.vue
@@ -30,6 +30,7 @@ const props = withDefaults(
     /** Durable sequence jobs merged into the same strip (mockup 1c: the
      * chain Jobs list merges with the activity strip). */
     sequences?: ActivityJobVM[];
+    /** Server-owned work discovered after a reload or in another client. */
     shared?: FleetActiveWork[];
   }>(),
   { sequences: () => [], shared: () => [] },
@@ -48,6 +49,7 @@ const emit = defineEmits<{
   open: [job: Job];
   "sequence-action": [action: ActivityAction, vm: ActivityJobVM];
   "show-history": [];
+  "shared-open": [row: FleetActiveWork];
 }>();
 
 /** Session-only sequence dismissals, keyed by VM key. Deliberately not
@@ -160,8 +162,8 @@ const active = computed(
     running.value.length > 0 ||
     queued.value.length > 0 ||
     partition.value.active.length > 0 ||
-    props.shared.length > 0 ||
     partition.value.attention.length > 0 ||
+    props.shared.length > 0 ||
     digest.value !== null,
 );
 </script>
@@ -182,7 +184,11 @@ const active = computed(
       </button>
     </div>
 
-    <LiveActivityList :rows="shared" />
+    <LiveActivityList
+      :rows="shared"
+      interactive
+      @select="emit('shared-open', $event)"
+    />
 
     <div v-for="job in running" :key="job.id" class="activity__running">
       <button

--- a/web/src/components/shell/AppNav.test.ts
+++ b/web/src/components/shell/AppNav.test.ts
@@ -2,6 +2,7 @@ import { mount } from "@vue/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import AppNav from "./AppNav.vue";
 import MobileNavSheet from "./MobileNavSheet.vue";
+import { takeGenerationHandoff } from "../../composables/useGenerationHandoff";
 
 const routeState = vi.hoisted(() => ({
   name: "library" as string,
@@ -12,6 +13,19 @@ const dlState = vi.hoisted(() => ({
   activeJobs: [] as unknown[],
   queued: [] as unknown[],
 }));
+const liveState = vi.hoisted(() => ({ rows: [] as Record<string, unknown>[] }));
+const routingState = vi.hoisted(() => ({
+  hosts: [
+    {
+      id: "render",
+      label: "Render box",
+      url: "http://render:7680",
+      apiKey: "secret",
+      status: "ready",
+    },
+  ],
+}));
+const listQueueMock = vi.hoisted(() => vi.fn());
 
 vi.mock("vue-router", () => ({
   useRoute: () => routeState,
@@ -25,6 +39,21 @@ vi.mock("../../composables/useDownloads", () => ({
     active: { value: null },
   }),
 }));
+vi.mock("../../composables/useHostRouting", () => ({
+  useHostRouting: () => ({
+    hosts: { value: routingState.hosts },
+    start: vi.fn(),
+    stop: vi.fn(),
+  }),
+}));
+vi.mock("../../composables/useLiveActivity", () => ({
+  useLiveActivity: () => ({
+    rows: { value: liveState.rows },
+    start: vi.fn(),
+    stop: vi.fn(),
+  }),
+}));
+vi.mock("@studio/api/queuePlan", () => ({ listQueue: listQueueMock }));
 
 const notifState = vi.hoisted(() => ({ fresh: 0, offline: false }));
 const statusState = vi.hoisted(() => ({ error: null as string | null }));
@@ -59,6 +88,9 @@ describe("AppNav", () => {
     notifState.fresh = 0;
     notifState.offline = false;
     statusState.error = null;
+    liveState.rows = [];
+    takeGenerationHandoff();
+    listQueueMock.mockReset();
     markGalleryVisitedMock.mockClear();
     pushMock.mockClear();
   });
@@ -125,6 +157,52 @@ describe("AppNav", () => {
     window.removeEventListener("mold:open-downloads", listener);
 
     expect(listener).toHaveBeenCalled();
+  });
+
+  it("opens recovered work from Now developing and restores its settings", async () => {
+    liveState.rows = [
+      {
+        key: "render:generation:foreign",
+        id: "foreign",
+        kind: "generation",
+        phase: "running",
+        model: "flux-dev",
+        hostId: "render",
+        hostLabel: "Render box",
+        stale: false,
+        hostError: null,
+        created_at_unix_ms: 1,
+        updated_at_unix_ms: 2,
+        can_cancel: false,
+      },
+    ];
+    listQueueMock.mockResolvedValue({
+      entries: [
+        {
+          id: "foreign",
+          seed_pinned: true,
+          metadata: { model: "flux-dev", prompt: "restore me", seed: 42 },
+        },
+      ],
+      plan: null,
+    });
+    const wrapper = mountNav();
+    await wrapper
+      .findAll("[data-test='now-developing-trigger']")[0]!
+      .trigger("click");
+    await wrapper
+      .findAll("[data-test^='live-activity-select-']")[0]!
+      .trigger("click");
+
+    expect(listQueueMock).toHaveBeenCalledWith({
+      baseUrl: "http://render:7680",
+      apiKey: "secret",
+    });
+    expect(takeGenerationHandoff()).toMatchObject({
+      metadata: { prompt: "restore me", seed: 42 },
+      seedPinned: true,
+    });
+    expect(pushMock).toHaveBeenCalledWith("/create");
   });
 
   it("toggles the mobile nav sheet from the hamburger", async () => {

--- a/web/src/components/shell/AppNav.vue
+++ b/web/src/components/shell/AppNav.vue
@@ -8,11 +8,12 @@
  * Downloads opens the existing drawer via the shared `mold:open-downloads`
  * window event (App listens); the ⌘K palette uses the same channel.
  */
-import { computed, ref, watch } from "vue";
+import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import Icon from "@ui/components/Icon.vue";
 import BadgePill from "@ui/components/BadgePill.vue";
 import MobileNavSheet from "./MobileNavSheet.vue";
+import NowDevelopingPopover from "./NowDevelopingPopover.vue";
 import { useDownloads } from "../../composables/useDownloads";
 import {
   markGalleryVisited,
@@ -20,11 +21,28 @@ import {
 } from "../../lib/notifications";
 import type { IconName } from "@ui/icons";
 import { useStatusPoll } from "../../composables/useStatusPoll";
+import { useHostRouting } from "../../composables/useHostRouting";
+import { useLiveActivity } from "../../composables/useLiveActivity";
+import { useOpenLiveWork } from "../../composables/useOpenLiveWork";
 
 const route = useRoute();
 const router = useRouter();
 const downloads = useDownloads();
 const { error: engineError } = useStatusPoll();
+const routing = useHostRouting();
+const liveActivity = useLiveActivity(routing);
+const openLiveWork = useOpenLiveWork(routing);
+
+onMounted(() => {
+  if (import.meta.env.TEST) return;
+  routing.start();
+  liveActivity.start();
+});
+onBeforeUnmount(() => {
+  if (import.meta.env.TEST) return;
+  liveActivity.stop();
+  routing.stop();
+});
 
 // Cross-workspace badge signals (spec §08 G11): a fresh-prints accent dot on
 // the Library pill (cleared on entering the Library) and a stop-tinted dot on
@@ -167,6 +185,11 @@ const menuOpen = ref(false);
 
       <div class="spacer" />
 
+      <NowDevelopingPopover
+        :rows="liveActivity.rows.value"
+        @select="openLiveWork"
+      />
+
       <form class="search-box" role="search" @submit.prevent="submitSearch">
         <Icon name="search" :size="14" class="search-icon" />
         <input
@@ -212,6 +235,11 @@ const menuOpen = ref(false);
       </router-link>
 
       <div class="spacer" />
+
+      <NowDevelopingPopover
+        :rows="liveActivity.rows.value"
+        @select="openLiveWork"
+      />
 
       <button
         type="button"

--- a/web/src/components/shell/NowDevelopingPopover.vue
+++ b/web/src/components/shell/NowDevelopingPopover.vue
@@ -1,0 +1,109 @@
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref } from "vue";
+import BadgePill from "@ui/components/BadgePill.vue";
+import Icon from "@ui/components/Icon.vue";
+import LiveActivityList from "@ui/components/LiveActivityList.vue";
+import type { FleetActiveWork } from "@studio/api/activity";
+
+defineProps<{ rows: FleetActiveWork[] }>();
+const emit = defineEmits<{ select: [row: FleetActiveWork] }>();
+
+const open = ref(false);
+
+function closeOnEscape(event: KeyboardEvent) {
+  if (event.key === "Escape") open.value = false;
+}
+
+onMounted(() => window.addEventListener("keydown", closeOnEscape));
+onBeforeUnmount(() => window.removeEventListener("keydown", closeOnEscape));
+</script>
+
+<template>
+  <div v-if="rows.length" class="now-developing">
+    <button
+      type="button"
+      class="now-developing__trigger"
+      data-test="now-developing-trigger"
+      :aria-expanded="open"
+      aria-controls="now-developing-panel"
+      @click="open = !open"
+    >
+      <Icon name="create" :size="15" />
+      <span class="now-developing__label">Now developing</span>
+      <BadgePill tone="accent">{{ rows.length }}</BadgePill>
+    </button>
+    <section
+      v-if="open"
+      id="now-developing-panel"
+      class="now-developing__panel"
+      data-test="now-developing-panel"
+      aria-label="Now developing"
+    >
+      <div class="now-developing__heading">Now developing</div>
+      <LiveActivityList
+        :rows="rows"
+        interactive
+        @select="
+          (row) => {
+            open = false;
+            emit('select', row);
+          }
+        "
+      />
+    </section>
+  </div>
+</template>
+
+<style scoped>
+.now-developing {
+  position: relative;
+  flex: 0 0 auto;
+}
+.now-developing__trigger {
+  display: flex;
+  min-height: 36px;
+  align-items: center;
+  gap: 7px;
+  padding: 5px 9px;
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-control);
+  background: var(--surface);
+  color: var(--ink-2);
+  font-family: var(--f-body);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.now-developing__trigger:hover,
+.now-developing__trigger[aria-expanded="true"] {
+  border-color: color-mix(in srgb, var(--safelight) 36%, var(--edge));
+  background: color-mix(in srgb, var(--safelight) 7%, var(--surface));
+}
+.now-developing__panel {
+  position: absolute;
+  z-index: 40;
+  top: calc(100% + 10px);
+  right: 0;
+  width: min(360px, calc(100vw - 28px));
+  max-height: min(520px, calc(100svh - 80px));
+  overflow-y: auto;
+  padding: 12px;
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-card);
+  background: var(--bench);
+  box-shadow: var(--shadow-raised);
+}
+.now-developing__heading {
+  margin: 1px 2px 9px;
+  color: var(--ink-3);
+  font-family: var(--f-mono);
+  font-size: 9px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+@media (max-width: 799px) {
+  .now-developing__label {
+    display: none;
+  }
+}
+</style>

--- a/web/src/composables/useGenerationHandoff.ts
+++ b/web/src/composables/useGenerationHandoff.ts
@@ -1,0 +1,23 @@
+import { ref, type Ref } from "vue";
+import type { OutputMetadata } from "../types";
+
+export interface GenerationHandoff {
+  metadata: OutputMetadata;
+  seedPinned: boolean | null;
+}
+
+const pending = ref<GenerationHandoff | null>(null);
+
+export function setGenerationHandoff(handoff: GenerationHandoff): void {
+  pending.value = handoff;
+}
+
+export function takeGenerationHandoff(): GenerationHandoff | null {
+  const handoff = pending.value;
+  pending.value = null;
+  return handoff;
+}
+
+export function pendingGenerationHandoff(): Ref<GenerationHandoff | null> {
+  return pending;
+}

--- a/web/src/composables/useOpenLiveWork.ts
+++ b/web/src/composables/useOpenLiveWork.ts
@@ -1,0 +1,63 @@
+import { useRouter } from "vue-router";
+import type { FleetActiveWork } from "@studio/api/activity";
+import { listQueue } from "@studio/api/queuePlan";
+import type { OutputMetadata } from "../types";
+import type { HostRouting } from "./useHostRouting";
+import { setGenerationHandoff } from "./useGenerationHandoff";
+import { setSequenceHandoff } from "./useSequenceHandoff";
+import { toast } from "../lib/toasts";
+
+/** Opens server-owned work in the web surface that can inspect or resume it. */
+export function useOpenLiveWork(routing: HostRouting) {
+  const router = useRouter();
+
+  return async (row: FleetActiveWork) => {
+    if (row.kind === "sequence") {
+      setSequenceHandoff({
+        kind: "inspect",
+        hostId: row.hostId,
+        jobId: row.id,
+      });
+      await router.push("/create");
+      return;
+    }
+    if (row.kind === "generation") {
+      const host = routing.hosts.value.find(
+        (candidate) => candidate.id === row.hostId,
+      );
+      if (!host) {
+        toast("error", "That machine is no longer connected.");
+        return;
+      }
+      try {
+        const queue = await listQueue({
+          baseUrl: host.url,
+          apiKey: host.apiKey ?? null,
+        });
+        const entry = queue.entries.find(
+          (candidate) => candidate.id === row.id,
+        );
+        if (!entry?.metadata) {
+          toast(
+            "error",
+            "This host cannot restore settings for that generation.",
+          );
+          return;
+        }
+        setGenerationHandoff({
+          metadata: entry.metadata as OutputMetadata,
+          seedPinned: entry.seed_pinned ?? null,
+        });
+        await router.push("/create");
+      } catch (error) {
+        toast("error", error instanceof Error ? error.message : String(error));
+      }
+      return;
+    }
+    if (row.kind === "download") {
+      window.dispatchEvent(new CustomEvent("mold:open-downloads"));
+      return;
+    }
+    await router.push(`/machines/${row.hostId}`);
+  };
+}

--- a/web/src/pages/CreatePage.test.ts
+++ b/web/src/pages/CreatePage.test.ts
@@ -26,6 +26,10 @@ import {
   setSequenceHandoff,
   takeSequenceHandoff,
 } from "../composables/useSequenceHandoff";
+import {
+  setGenerationHandoff,
+  takeGenerationHandoff,
+} from "../composables/useGenerationHandoff";
 import { ApiHttpError } from "../api";
 import { ApiError } from "@studio/api/client";
 import { addHost, ORIGIN_HOST_ID } from "../lib/hostRegistry";
@@ -277,6 +281,7 @@ describe("CreatePage layout and behavior", () => {
     setActivePinia(createPinia());
     chainJobsTesting.reset();
     takeSequenceHandoff();
+    takeGenerationHandoff();
     generateFormTesting.resetForTest();
     resetNotifications();
     submitMock.mockClear();
@@ -341,6 +346,36 @@ describe("CreatePage layout and behavior", () => {
     expect(wrapper.get("[data-test='generate-workspace']").classes()).toContain(
       "md:grid-cols-[minmax(0,1fr)_340px]",
     );
+  });
+
+  it("applies settings selected from recovered Now developing work", async () => {
+    enterSequenceMode();
+    setGenerationHandoff({
+      seedPinned: true,
+      metadata: {
+        version: "1",
+        model: "flux-dev",
+        prompt: "recovered lighthouse",
+        seed: 42,
+        steps: 20,
+        guidance: 3.5,
+        width: 1024,
+        height: 1024,
+      } as OutputMetadata,
+    });
+
+    mount(CreatePage, { global: { stubs: pageStubs() } });
+    await flushPromises();
+
+    expect(useSequenceDraftStore().output).toBe("single");
+    expect(useGenerateForm().state.value).toMatchObject({
+      prompt: "recovered lighthouse",
+      seedMode: "static",
+      seed: 42,
+      steps: 20,
+      guidance: 3.5,
+    });
+    expect(takeGenerationHandoff()).toBeNull();
   });
 
   it("uses a human-readable catalog model in the completed generation caption", async () => {

--- a/web/src/pages/CreatePage.vue
+++ b/web/src/pages/CreatePage.vue
@@ -15,8 +15,6 @@ import ControlsAside from "../components/create/ControlsAside.vue";
 import CreateModelPicker from "../components/create/CreateModelPicker.vue";
 import AdvancedDrawer from "../components/create/AdvancedDrawer.vue";
 import ActivityStrip from "../components/create/ActivityStrip.vue";
-import { useLiveActivity } from "../composables/useLiveActivity";
-import { ORIGIN_HOST_ID } from "../lib/hostRegistry";
 import EstimateBadge from "../components/create/EstimateBadge.vue";
 import { advancedActiveCount } from "../components/create/advancedCount";
 import { projectResolution } from "../components/create/resolutionProjection";
@@ -88,6 +86,10 @@ import {
   pendingSequenceHandoff,
   takeSequenceHandoff,
 } from "../composables/useSequenceHandoff";
+import {
+  pendingGenerationHandoff,
+  takeGenerationHandoff,
+} from "../composables/useGenerationHandoff";
 import { useSequenceDraftStore } from "@studio/stores/sequenceDraft";
 import {
   sequenceToVM,
@@ -140,6 +142,9 @@ import {
   storeLastSeed,
 } from "../lib/lastSeed";
 import { useQueue } from "../composables/useQueue";
+import { useLiveActivity } from "../composables/useLiveActivity";
+import { useOpenLiveWork } from "../composables/useOpenLiveWork";
+import { ORIGIN_HOST_ID } from "../lib/hostRegistry";
 import {
   autoChainFieldList,
   decideGenerateRequestRouting,
@@ -188,6 +193,7 @@ const { status } = useStatusPoll();
 const queue = useQueue();
 const routing = useHostRouting();
 const liveActivity = useLiveActivity(routing);
+const openLiveWork = useOpenLiveWork(routing);
 // The model list follows the routing target: a pinned machine shows its own
 // models, Auto / Most capable show the union across ready machines. Single-host
 // installs collapse to exactly the origin's `/api/models`, as before.
@@ -610,6 +616,8 @@ const sequenceVMs = computed<ActivityJobVM[]>(() => {
   return out;
 });
 
+/** Server-owned rows survive this tab and client. Avoid duplicating work that
+ * the current Create session already renders with its richer local controls. */
 const sharedActivityRows = computed(() =>
   liveActivity.rows.value.filter((row) => {
     if (row.kind === "generation") {
@@ -1703,6 +1711,22 @@ function applySequenceHandoff() {
   }
 }
 watch(pendingSequenceHandoff(), applySequenceHandoff, { immediate: true });
+
+function applyGenerationHandoff() {
+  const handoff = takeGenerationHandoff();
+  if (!handoff) return;
+  setOutput("single");
+  draft.stopEditing();
+  editBaselineShared.value = null;
+  const metadata =
+    handoff.seedPinned === false
+      ? ({ ...handoff.metadata, seed: null } as unknown as OutputMetadata)
+      : handoff.metadata;
+  form.state.value = applyMetadataToForm(form.state.value, metadata, {
+    models: models.value,
+  });
+}
+watch(pendingGenerationHandoff(), applyGenerationHandoff, { immediate: true });
 
 /** The digest chip's one hop. `Clear inactive` and `Clean up disk` moved with
  *  it: they are destructive, host-scoped, and live in the History drawer now. */
@@ -3141,7 +3165,6 @@ function openAdvanced() {
 }
 
 onMounted(async () => {
-  liveActivity.start();
   if (phoneQuery) {
     phoneQuery.addEventListener?.("change", syncPhone);
   }
@@ -3167,7 +3190,6 @@ onMounted(async () => {
 });
 
 onBeforeUnmount(() => {
-  liveActivity.stop();
   stopAutoRefresh();
   clearSequencePreviews();
   phoneQuery?.removeEventListener?.("change", syncPhone);
@@ -3205,6 +3227,7 @@ onBeforeUnmount(() => {
           @open="openJob"
           @sequence-action="onSequenceAction"
           @show-history="onShowSequenceHistory"
+          @shared-open="openLiveWork"
         />
 
         <div class="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- keep recovered host work in both Desktop Now developing and the Create Activity strip, with clickable rows that restore queued generation settings or open the owning sequence/download/machine surface
- add the equivalent global Now developing popover and retained Activity rows to the web interface, including cross-route generation handoff and progress visibility
- make Batch 1 Remix rewrite the prompt in place, while explicit Batch N prepares exactly N reviewed remixes
- add an explicit Cancel action to remix review and make Escape dismiss it with focus-safe ownership

## Verification
- desktop full suite: 283 files, 2,985 tests passed
- web full suite: 89 files, 1,175 tests passed
- desktop and web production builds passed
- desktop and web formatting checks passed
- post-rebase focused suites: 82 desktop tests and 112 web tests passed
- peer agent review completed; its Escape focus finding was fixed and re-verified with no remaining blockers

## Notes
- rebased onto current origin/main before publication
- the existing web bundle-size warning remains unchanged