### PR TITLE
fix(desktop): compact dismissible error notices

### DIFF
--- a/desktop/src/components/generate/GenerateErrorNotice.test.ts
+++ b/desktop/src/components/generate/GenerateErrorNotice.test.ts
@@ -52,4 +52,19 @@ describe("GenerateErrorNotice", () => {
       "Copy error message",
     );
   });
+
+  it("dismisses the current error and reappears for a new message", async () => {
+    const wrapper = mount(GenerateErrorNotice, {
+      props: { message: "The first generation failed." },
+    });
+
+    expect(wrapper.get("[data-test='error-notice']").classes()).toContain("py-1.5");
+    await wrapper.get("[data-test='dismiss-error-notice']").trigger("click");
+    expect(wrapper.find("[data-test='error-notice']").exists()).toBe(false);
+
+    await wrapper.setProps({ message: "The retry failed differently." });
+    expect(wrapper.get("[data-test='error-notice-message']").text()).toBe(
+      "The retry failed differently.",
+    );
+  });
 });

--- a/desktop/src/components/generate/GenerateErrorNotice.vue
+++ b/desktop/src/components/generate/GenerateErrorNotice.vue
@@ -1,13 +1,34 @@
 <script setup lang="ts">
+import { ref, watch } from "vue";
 import ErrorNotice from "@ui/components/ErrorNotice.vue";
 
-withDefaults(defineProps<{ message: string; copyMessage?: string | null }>(), {
-  copyMessage: null,
-});
+const props = withDefaults(
+  defineProps<{ message: string; copyMessage?: string | null; dismissible?: boolean }>(),
+  {
+    copyMessage: null,
+    dismissible: true,
+  },
+);
+
+const dismissed = ref(false);
+
+watch(
+  () => props.message,
+  () => {
+    dismissed.value = false;
+  },
+);
 </script>
 
 <template>
-  <ErrorNotice :message="message" :copy-message="copyMessage">
+  <ErrorNotice
+    v-if="!dismissed"
+    compact
+    :dismissible="dismissible"
+    :message="message"
+    :copy-message="copyMessage"
+    @dismiss="dismissed = true"
+  >
     <template v-if="$slots.actions" #actions>
       <slot name="actions" />
     </template>

--- a/desktop/src/views/GenerateView.vue
+++ b/desktop/src/views/GenerateView.vue
@@ -3287,6 +3287,7 @@ onBeforeUnmount(() => {
           v-if="quickStaleReasons.length && !preparedBatch"
           data-test="quick-expansion-stale"
           class="mx-5 mb-2"
+          :dismissible="false"
           :message="quickStaleMessage"
         >
           <template #actions>

--- a/desktop/src/views/RunPodView.error.test.ts
+++ b/desktop/src/views/RunPodView.error.test.ts
@@ -6,6 +6,7 @@ describe("RunPodView operation errors", () => {
     expect(source).toContain('v-if="runpod.operationError"');
     expect(source).toContain('import ErrorNotice from "@ui/components/ErrorNotice.vue"');
     expect(source).toContain(':message="runpod.operationError"');
-    expect(source).toContain('@click="runpod.clearOperationError()"');
+    expect(source).toContain("dismissible");
+    expect(source).toContain('@dismiss="runpod.clearOperationError()"');
   });
 });

--- a/desktop/src/views/RunPodView.vue
+++ b/desktop/src/views/RunPodView.vue
@@ -544,17 +544,14 @@ onBeforeUnmount(() => {
       </aside>
 
       <main class="min-h-0 overflow-y-auto p-4">
-        <ErrorNotice v-if="runpod.operationError" class="mb-4" :message="runpod.operationError">
-          <template #actions>
-            <button
-              type="button"
-              class="text-caption text-ink-2 hover:text-ink"
-              @click="runpod.clearOperationError()"
-            >
-              Dismiss
-            </button>
-          </template>
-        </ErrorNotice>
+        <ErrorNotice
+          v-if="runpod.operationError"
+          compact
+          dismissible
+          class="mb-4"
+          :message="runpod.operationError"
+          @dismiss="runpod.clearOperationError()"
+        />
         <section class="border-edge mb-5 rounded-chrome border bg-bath">
           <div class="flex items-center justify-between px-3 py-2.5">
             <div>

--- a/ui/components/ErrorNotice.test.ts
+++ b/ui/components/ErrorNotice.test.ts
@@ -28,4 +28,22 @@ describe("ErrorNotice", () => {
       wrapper.get("[data-test='copy-error-notice']").attributes("aria-label"),
     ).toBe("Error copied");
   });
+
+  it("renders compact spacing and emits from an accessible dismiss button", async () => {
+    const wrapper = mount(ErrorNotice, {
+      props: { message: "Expansion failed.", compact: true, dismissible: true },
+    });
+
+    expect(wrapper.get("[data-test='error-notice']").classes()).toContain(
+      "py-1.5",
+    );
+    expect(
+      wrapper.get("[data-test='error-notice-message']").classes(),
+    ).toContain("leading-snug");
+
+    const dismiss = wrapper.get("[data-test='dismiss-error-notice']");
+    expect(dismiss.attributes("aria-label")).toBe("Dismiss error message");
+    await dismiss.trigger("click");
+    expect(wrapper.emitted("dismiss")).toEqual([[]]);
+  });
 });

--- a/ui/components/ErrorNotice.vue
+++ b/ui/components/ErrorNotice.vue
@@ -7,9 +7,13 @@ const props = withDefaults(
     message: string;
     /** Optional diagnostic payload; visible copy remains human-readable. */
     copyMessage?: string | null;
+    compact?: boolean;
+    dismissible?: boolean;
   }>(),
-  { copyMessage: null },
+  { copyMessage: null, compact: false, dismissible: false },
 );
+
+const emit = defineEmits<{ dismiss: [] }>();
 
 const copied = ref(false);
 const copyFailed = ref(false);
@@ -38,12 +42,14 @@ async function copyError() {
   <div
     role="alert"
     data-test="error-notice"
-    class="flex flex-wrap items-start gap-3 rounded-control border border-stop/45 bg-stop/10 px-3 py-2.5 text-stop"
+    class="flex flex-wrap rounded-control border border-stop/45 bg-stop/10 px-3 text-stop"
+    :class="compact ? 'items-center gap-2 py-1.5' : 'items-start gap-3 py-2.5'"
   >
     <p
       data-test="error-notice-message"
       data-selectable
-      class="min-w-0 flex-1 text-body leading-relaxed"
+      class="min-w-0 flex-1 text-body"
+      :class="compact ? 'leading-snug' : 'leading-relaxed'"
     >
       {{ message }}
     </p>
@@ -65,6 +71,17 @@ async function copyError() {
     >
       <Icon v-if="!copied" name="copy" :size="16" />
       <Icon v-else name="check" :size="16" />
+    </button>
+    <button
+      v-if="dismissible"
+      type="button"
+      data-test="dismiss-error-notice"
+      class="flex h-9 w-9 shrink-0 items-center justify-center rounded-control text-stop transition-colors hover:bg-stop/10 hover:text-ink active:translate-y-px"
+      aria-label="Dismiss error message"
+      title="Dismiss"
+      @click="emit('dismiss')"
+    >
+      <Icon name="close" :size="16" />
     </button>
     <div v-if="$slots.actions" class="flex w-full flex-wrap items-center gap-2">
       <slot name="actions" />


### PR DESCRIPTION
## Summary
- tighten desktop error notice vertical padding and line-height
- add an accessible X control while preserving copy-error behavior
- keep recovery-required stale expansion notices non-dismissible

## Testing
- `nix develop -c desktop-test` (2,988 frontend tests; 111 native/package tests)
- `nix develop -c desktop-check`
- rendered desktop QA at 1280×720: long expansion error stayed on one compact row; X removed the alert from the DOM
- `git diff --check`