### PR TITLE
fix(ios): satisfy animation cache clippy

### DIFF
--- a/apps/mobile/src-tauri/src/media.rs
+++ b/apps/mobile/src-tauri/src/media.rs
@@ -87,10 +87,10 @@ fn take_cached_animation(reuse_key: &str) -> Option<std::path::PathBuf> {
 
 #[cfg(target_os = "ios")]
 fn cache_animation(reuse_key: String, path: std::path::PathBuf) {
-    if let Ok(mut cache) = animation_export_cache().lock() {
-        if let Some(replaced) = cache.replace(CachedAnimationExport { reuse_key, path }) {
-            let _ = std::fs::remove_file(replaced.path);
-        }
+    if let Ok(mut cache) = animation_export_cache().lock()
+        && let Some(replaced) = cache.replace(CachedAnimationExport { reuse_key, path })
+    {
+        let _ = std::fs::remove_file(replaced.path);
     }
 }
 


### PR DESCRIPTION
## Summary
- collapse the nested animation export cache condition flagged by Clippy
- preserve replacement cleanup behavior
- restore the iOS simulator Rust gate on main

## Verification
- `cargo fmt -- --check`
- `cargo check --target aarch64-apple-ios-sim`
- `cargo clippy --target aarch64-apple-ios-sim -- -D warnings`

Fixes the current-main iOS failure from run 31131676686.