### PR TITLE
fix(ui): place render status below previews

### DIFF
--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -3152,6 +3152,14 @@ describe("MobileApp generation queue", () => {
     expect(preview.attributes("style")).toContain("blur(11px)");
     // The develop grain layers over the preview and thins with progress.
     expect(wrapper.find("develop-canvas-stub").exists()).toBe(true);
+    // iPhone already keeps the changing status outside and below the noisy
+    // preview, matching the desktop/web placement invariant.
+    const summary = wrapper.get("[data-test='mobile-generation-summary']");
+    expect(summary.text()).toBe("Developing 2 / 8");
+    expect(bed.find("[data-test='mobile-generation-summary']").exists()).toBe(false);
+    expect(
+      bed.element.compareDocumentPosition(summary.element) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
 
     openStreams[0]?.options.onEvent(
       "complete",

--- a/desktop/src/views/GenerateView.prepared.test.ts
+++ b/desktop/src/views/GenerateView.prepared.test.ts
@@ -842,6 +842,35 @@ describe("GenerateView prepared expansion batches", () => {
     expect(chrome.text()).not.toContain("cv:1759168");
   });
 
+  it("keeps the live generation status below the developing image", async () => {
+    const job = newJob({
+      model: catalogModel.name,
+      prompt: "a camera",
+      width: 1024,
+      height: 1024,
+      steps: 25,
+      guidance: 7,
+      batch_size: 1,
+      output_format: "png",
+    });
+    job.status = "denoising";
+    job.step = 20;
+    job.total = 25;
+    job.previewUrl = "blob:latent-preview";
+    useGenerationStore().jobs = [job];
+
+    const wrapper = mountView();
+    await flushPromises();
+
+    const frame = wrapper.get("[data-test='preview-frame']");
+    const status = wrapper.get("[data-test='generation-live-status']");
+    expect(status.text()).toBe("Developing 20/25");
+    expect(frame.find("[data-test='generation-live-status']").exists()).toBe(false);
+    expect(
+      frame.element.compareDocumentPosition(status.element) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
   it("cancels a deferred Batch 1 submission when the expansion is restored", async () => {
     const form = useGenerateFormStore().form;
     form.batchSize = 1;

--- a/desktop/src/views/GenerateView.vue
+++ b/desktop/src/views/GenerateView.vue
@@ -1510,6 +1510,15 @@ const previewFrameStyle = computed(() => ({
   width: `min(100cqw, ${(100 * previewWidth.value) / previewHeight.value}cqh)`,
 }));
 
+const liveGenerationStatus = computed(() => {
+  const j = job.value;
+  if (!j || j.status === "complete" || j.status === "error") return "";
+  if (j.status === "queued") return "Queued";
+  if (j.status === "loading") return `${j.stage ?? "Preparing"}…`;
+  if (j.status === "finishing") return `Fixing — ${j.stage ?? "finishing"}…`;
+  return `Developing ${j.step}/${j.total}`;
+});
+
 const edgeCode = computed(() => {
   const j = job.value;
   if (!j) return "";
@@ -3085,35 +3094,26 @@ onBeforeUnmount(() => {
                       : '1',
                   }"
                 />
-                <!-- Grain is the signature; the ring overlays it with the
-                     percent + stage until the first latent preview arrives,
-                     after which the forming print itself takes over. -->
+                <!-- Grain is the signature; the ring overlays it until the
+                     first latent preview arrives, after which the forming
+                     print itself takes over. The status stays below the frame
+                     where the grain cannot obscure it. -->
                 <div
                   v-if="job && job.status !== 'complete' && !job.previewUrl"
                   data-test="develop-progress"
-                  class="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-3"
+                  class="pointer-events-none absolute inset-0 flex items-center justify-center"
                 >
                   <ProgressRing :value="jobProgress(job) * 100" :size="96" show-label />
-                  <span class="edge-code text-safelight">
-                    {{
-                      job.status === "finishing"
-                        ? `fixing — ${job.stage ?? "finishing"}…`
-                        : job.status === "loading"
-                          ? `${job.stage ?? "Preparing"}…`
-                          : "developing…"
-                    }}
-                  </span>
-                </div>
-                <div
-                  v-if="job && (job.status === 'denoising' || job.status === 'finishing')"
-                  class="edge-code absolute bottom-2 left-3"
-                >
-                  <template v-if="job.status === 'denoising'">
-                    {{ job.step }}/{{ job.total }}
-                  </template>
-                  <template v-else>Fixing — {{ job.stage ?? "finishing" }}…</template>
                 </div>
               </div>
+            </div>
+
+            <div
+              v-if="liveGenerationStatus"
+              data-test="generation-live-status"
+              class="edge-code mt-2 max-w-full text-center text-safelight"
+            >
+              {{ liveGenerationStatus }}
             </div>
 
             <div

--- a/web/src/components/create/ResultCanvas.test.ts
+++ b/web/src/components/create/ResultCanvas.test.ts
@@ -79,9 +79,18 @@ describe("ResultCanvas", () => {
     expect(wrapper.findComponent(DevelopCanvas).attributes("style")).toContain(
       "opacity: 0.55",
     );
-    // The forming print replaces the ring + stage overlay.
+    // The forming print replaces the ring, while the status stays legible
+    // below the noisy preview instead of disappearing or overlaying it.
     expect(wrapper.findComponent(ProgressRing).exists()).toBe(false);
-    expect(wrapper.find("[data-test='canvas-stage']").exists()).toBe(false);
+    expect(wrapper.get("[data-test='canvas-stage']").text()).toBe(
+      "Developing 4 / 8",
+    );
+    expect(
+      wrapper
+        .get("[data-test='canvas-bed']")
+        .find("[data-test='canvas-stage']")
+        .exists(),
+    ).toBe(false);
     expect(wrapper.find("[data-test='canvas-generating']").exists()).toBe(true);
   });
 

--- a/web/src/components/create/ResultCanvas.vue
+++ b/web/src/components/create/ResultCanvas.vue
@@ -3,8 +3,8 @@
  * Result canvas (Mold Studio Create) — the develop bed. Four states:
  *  - empty: brand headline + what-to-do guidance.
  *  - generating: the develop bed — live latent preview under the thinning
- *    Develop grain (desktop parity), with a progress ring + stage line until
- *    the first preview arrives.
+ *    Develop grain (desktop parity), with a progress ring until the first
+ *    preview arrives and an always-visible stage line below the bed.
  *  - result: the finished print with a mono provenance caption.
  *  - variations: batch>1 expansion review — editable prompts with per-row Use,
  *    plus Discard / Queue N.
@@ -160,7 +160,11 @@ watch(
       class="canvas__generating"
       data-test="canvas-generating"
     >
-      <div class="canvas__bed ms-shimmer" :style="bedStyle">
+      <div
+        class="canvas__bed ms-shimmer"
+        data-test="canvas-bed"
+        :style="bedStyle"
+      >
         <!-- Live latent preview: a tiny PNG upscaled by CSS; the blur tightens
              as denoising progresses so the print develops on the canvas. -->
         <img
@@ -180,13 +184,13 @@ watch(
           class="canvas__develop"
           :style="{ opacity: grainOpacity }"
         />
-        <!-- Ring + stage overlay the grain only until the first latent
-             preview arrives; then the forming print takes over. -->
+        <!-- The ring overlays the grain only until the first latent preview
+             arrives; the stage line remains legible below the bed. -->
         <div v-if="!previewSrc" class="canvas__ring">
           <ProgressRing :value="progress" :size="104" show-label />
         </div>
       </div>
-      <div v-if="!previewSrc" class="canvas__stage" data-test="canvas-stage">
+      <div class="canvas__stage" data-test="canvas-stage">
         {{ stage }}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- move desktop generation progress out of the noisy developing image and into a dedicated status line below it
- keep the equivalent web stage line visible below live latent previews
- lock in the already-correct iPhone placement with a cross-surface regression assertion

## Validation
- peer review by a separate agent (no functional, layout, accessibility, or regression blockers)
- desktop full suite: 2,998 tests passed
- web full suite: 1,176 tests passed
- focused post-rebase: desktop/iPhone 183 tests and web 16 tests passed
- desktop, web, and mobile production builds
- frontend architecture check
- Prettier and git diff checks
- rendered desktop QA in the Create view, including bench resize: status remained 8px below the preview frame with no console warnings/errors