### PR TITLE
fix(ci): enforce Candle lock synchronization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,8 @@ jobs:
               - 'nix/**'
               - '.github/workflows/ci.yml'
             release:
+              - 'Cargo.toml'
+              - 'Cargo.lock'
               - 'Dockerfile'
               - 'flake.nix'
               - 'install.sh'

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -706,7 +706,7 @@ dependencies = [
 [[package]]
 name = "candle-core"
 version = "0.11.0"
-source = "git+https://github.com/utensils/candle?branch=fix%2Fmold-compat-0.11#75ba835e2216903248bc92c6d88e8d591f17ab0c"
+source = "git+https://github.com/utensils/candle?branch=fix%2Fmold-compat-0.11#3a49a729638c9ed1510d9dae341677eb8bf2b6fd"
 dependencies = [
  "byteorder",
  "candle-kernels",
@@ -737,7 +737,7 @@ dependencies = [
 [[package]]
 name = "candle-kernels"
 version = "0.11.0"
-source = "git+https://github.com/utensils/candle?branch=fix%2Fmold-compat-0.11#75ba835e2216903248bc92c6d88e8d591f17ab0c"
+source = "git+https://github.com/utensils/candle?branch=fix%2Fmold-compat-0.11#3a49a729638c9ed1510d9dae341677eb8bf2b6fd"
 dependencies = [
  "cudaforge",
 ]
@@ -745,7 +745,7 @@ dependencies = [
 [[package]]
 name = "candle-metal-kernels"
 version = "0.11.0"
-source = "git+https://github.com/utensils/candle?branch=fix%2Fmold-compat-0.11#75ba835e2216903248bc92c6d88e8d591f17ab0c"
+source = "git+https://github.com/utensils/candle?branch=fix%2Fmold-compat-0.11#3a49a729638c9ed1510d9dae341677eb8bf2b6fd"
 dependencies = [
  "block2",
  "half",
@@ -760,7 +760,7 @@ dependencies = [
 [[package]]
 name = "candle-nn"
 version = "0.11.0"
-source = "git+https://github.com/utensils/candle?branch=fix%2Fmold-compat-0.11#75ba835e2216903248bc92c6d88e8d591f17ab0c"
+source = "git+https://github.com/utensils/candle?branch=fix%2Fmold-compat-0.11#3a49a729638c9ed1510d9dae341677eb8bf2b6fd"
 dependencies = [
  "candle-core",
  "candle-metal-kernels",
@@ -777,7 +777,7 @@ dependencies = [
 [[package]]
 name = "candle-transformers"
 version = "0.11.0"
-source = "git+https://github.com/utensils/candle?branch=fix%2Fmold-compat-0.11#75ba835e2216903248bc92c6d88e8d591f17ab0c"
+source = "git+https://github.com/utensils/candle?branch=fix%2Fmold-compat-0.11#3a49a729638c9ed1510d9dae341677eb8bf2b6fd"
 dependencies = [
  "byteorder",
  "candle-core",
@@ -795,7 +795,7 @@ dependencies = [
 [[package]]
 name = "candle-ug"
 version = "0.11.0"
-source = "git+https://github.com/utensils/candle?branch=fix%2Fmold-compat-0.11#75ba835e2216903248bc92c6d88e8d591f17ab0c"
+source = "git+https://github.com/utensils/candle?branch=fix%2Fmold-compat-0.11#3a49a729638c9ed1510d9dae341677eb8bf2b6fd"
 dependencies = [
  "ug",
  "ug-cuda",
@@ -1535,7 +1535,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1811,7 +1811,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4256,7 +4256,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5243,7 +5243,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5772,7 +5772,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5830,7 +5830,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7241,7 +7241,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8521,7 +8521,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/scripts/tests/ci-routing-contract.sh
+++ b/scripts/tests/ci-routing-contract.sh
@@ -44,6 +44,10 @@ require_text "$ci" \
   "if: github.event_name == 'push' && needs.changes.outputs.rust == 'true'" \
   "coverage is not deferred to the post-merge main run"
 release_filter="$(sed -n '/^            release:/,/^  release:/p' "$ci")"
+for manifest in Cargo.toml Cargo.lock desktop/src-tauri/Cargo.toml desktop/src-tauri/Cargo.lock; do
+  grep -Fxq "              - '$manifest'" <<< "$release_filter" \
+    || fail "release classifier does not run the desktop Candle lock guard for $manifest changes"
+done
 for workflow in desktop.yml ios.yml; do
   grep -Fq ".github/workflows/$workflow" <<< "$release_filter" \
     || fail "release classifier does not run the routing contract for $workflow changes"


### PR DESCRIPTION
## Summary

- repair the desktop Cargo lockfile to the root workspace's pinned Candle compatibility source
- run release contracts when either root Cargo manifest changes, not only when the desktop manifest changes
- regression-test all four root/desktop manifest and lockfile routing entries

## Root cause

PR #766 advanced only the root `Cargo.lock`. The release classifier did not include root `Cargo.toml` or `Cargo.lock`, so `desktop-candle-lock-sync.sh` was skipped on the PR and on `main`. The next release PR touched the desktop lockfile, finally activated the guard, and exposed the pre-existing mismatch.

## Validation

- `bash scripts/tests/ci-routing-contract.sh`
- `bash scripts/tests/desktop-candle-lock-sync.sh`
- `cargo metadata --manifest-path desktop/src-tauri/Cargo.toml --locked --no-deps --format-version 1`
- `actionlint .github/workflows/ci.yml`
- `shellcheck scripts/tests/ci-routing-contract.sh`
- `git diff --check`

The Linux-only embedded PTX contract remains delegated to Actions because its fixtures require ELF binaries and GNU `readelf`; running it on macOS correctly rejects Mach-O fixtures.
