### PR TITLE
fix(ci): verify Candle Nix source hash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,7 @@ jobs:
               - 'docs/qualification/**'
               - 'scripts/tests/docker-web-context.sh'
               - 'scripts/tests/desktop-candle-lock-sync.sh'
+              - 'scripts/tests/desktop-candle-nix-source-hash.sh'
               - 'scripts/tests/release-sync-pr.sh'
               - 'scripts/tests/crates-publish-contract.sh'
               - '.github/workflows/release-plz.yml'
@@ -161,6 +162,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - uses: DeterminateSystems/determinate-nix-action@v3
       - name: Test release PR synchronization
         run: bash scripts/tests/release-sync-pr.sh
       - name: Test crates.io publication contract
@@ -173,6 +175,8 @@ jobs:
         run: bash scripts/tests/docker-web-context.sh
       - name: Test desktop Candle lock synchronization
         run: bash scripts/tests/desktop-candle-lock-sync.sh
+      - name: Test desktop Candle Nix source hash
+        run: bash scripts/tests/desktop-candle-nix-source-hash.sh
       - name: Test CUDA distribution contract
         run: bash scripts/tests/cuda-distribution-contract.sh
       - name: Test embedded PTX parser contract

--- a/flake.nix
+++ b/flake.nix
@@ -478,7 +478,7 @@
               cargoLock = {
                 lockFile = ./desktop/src-tauri/Cargo.lock;
                 outputHashes = {
-                  "candle-core-0.11.0" = "sha256-eXlm3gYG1r+5rUcx2sFXy32ARsotfiOXPUbpnedrp6M=";
+                  "candle-core-0.11.0" = "sha256-OJw/evhFy+FlBcsko42EjwCUiG5HJRtxaat6lqMaGNk=";
                 };
               };
               buildFeatures = [ desktopFeature ];

--- a/scripts/tests/ci-routing-contract.sh
+++ b/scripts/tests/ci-routing-contract.sh
@@ -48,6 +48,9 @@ for manifest in Cargo.toml Cargo.lock desktop/src-tauri/Cargo.toml desktop/src-t
   grep -Fxq "              - '$manifest'" <<< "$release_filter" \
     || fail "release classifier does not run the desktop Candle lock guard for $manifest changes"
 done
+require_text "$ci" \
+  "run: bash scripts/tests/desktop-candle-nix-source-hash.sh" \
+  "release CI does not verify the Nix hash for the locked desktop Candle source"
 for workflow in desktop.yml ios.yml; do
   grep -Fq ".github/workflows/$workflow" <<< "$release_filter" \
     || fail "release classifier does not run the routing contract for $workflow changes"

--- a/scripts/tests/desktop-candle-nix-source-hash.sh
+++ b/scripts/tests/desktop-candle-nix-source-hash.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Verify the Nix fixed-output hash for the excluded desktop crate's Candle
+# git source against the exact revision selected by its Cargo lockfile.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+desktop_lock="$repo_root/desktop/src-tauri/Cargo.lock"
+flake="$repo_root/flake.nix"
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+command -v nix >/dev/null || fail "nix is required to verify the desktop Candle source hash"
+command -v jq >/dev/null || fail "jq is required to read nix prefetch output"
+
+read_lock_field() {
+  local field="$1"
+  awk -v field="$field" '
+    $0 == "name = \"candle-core\"" {
+      found = 1
+      next
+    }
+    found && $1 == field && $2 == "=" {
+      gsub(/"/, "", $3)
+      print $3
+      exit
+    }
+    found && /^\[\[package\]\]$/ {
+      exit
+    }
+  ' "$desktop_lock"
+}
+
+version="$(read_lock_field version)"
+source="$(read_lock_field source)"
+test -n "$version" || fail "desktop lockfile is missing the candle-core version"
+test -n "$source" || fail "desktop lockfile is missing the candle-core git source"
+
+case "$source" in
+  git+https://github.com/*\?*#*) ;;
+  *) fail "unsupported candle-core source: $source" ;;
+esac
+
+repository="${source#git+}"
+repository="${repository%%\?*}"
+revision="${source##*#}"
+archive_url="$repository/archive/$revision.tar.gz"
+expected="$(
+  sed -nE \
+    "s|^[[:space:]]*\"candle-core-${version}\" = \"([^\"]+)\";.*$|\\1|p" \
+    "$flake"
+)"
+test -n "$expected" || fail "flake.nix is missing the candle-core-${version} output hash"
+
+actual="$(nix store prefetch-file --unpack --json "$archive_url" | jq -r .hash)"
+test -n "$actual" && test "$actual" != "null" || fail "could not prefetch $archive_url"
+test "$actual" = "$expected" ||
+  fail "flake.nix has $expected for candle-core at $revision; expected $actual"
+
+echo "PASS: desktop Candle Nix source hash matches $revision"


### PR DESCRIPTION
## Summary
- update the desktop Nix Candle fixed-output hash for the locked `3a49a729` source
- verify the hash by prefetching the exact Cargo.lock revision in path-gated PR CI
- guard the new verification step in the CI routing contract

## Failure addressed
Main Release run 31143224941 failed because `build-nix-distribution` expected `sha256-eXlm...` but the locked Candle revision resolves to `sha256-OJw/...`.

## Validation
- `bash scripts/tests/desktop-candle-nix-source-hash.sh`
- `bash scripts/tests/desktop-candle-lock-sync.sh`
- `bash scripts/tests/ci-routing-contract.sh`
- `actionlint .github/workflows/ci.yml`
- `shellcheck scripts/tests/desktop-candle-nix-source-hash.sh`
- `git diff --check`