### PR TITLE
test(h3): add revision-locked conformance harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,11 @@ jobs:
               - 'scripts/tests/local-multi-gpu-qualification-contract.sh'
               - 'scripts/tests/local_multi_gpu_qualification_test.py'
               - 'docs/qualification/local-multi-gpu-report.schema.json'
+              - 'scripts/minimax-h3-conformance.py'
+              - 'scripts/tests/minimax-h3-conformance-contract.py'
+              - 'tests/fixtures/minimax_h3/**'
+              - 'docs/qualification/minimax-h3-*.json'
+              - 'docs/qualification/minimax-h3-conformance.md'
               - 'docs/qualification/README.md'
               - '.github/workflows/ci.yml'
             # Forced-local checks exist to compile backend-specific code that
@@ -290,6 +295,8 @@ jobs:
         run: cargo test --workspace
       - name: Test local multi-GPU qualification contract
         run: bash scripts/tests/local-multi-gpu-qualification-contract.sh
+      - name: Test MiniMax H3 conformance contract
+        run: python3 scripts/tests/minimax-h3-conformance-contract.py
       - name: Check with all optional features
         run: cargo check -p mold-ai --features preview,discord,expand,tui,webp,mp4,mdns
 

--- a/docs/qualification/README.md
+++ b/docs/qualification/README.md
@@ -1,5 +1,10 @@
 # CUDA distribution qualification
 
+MiniMax H3 uses a separate, weight-free conformance contract before any CUDA
+qualification is allowed. Its pinned authorities, synthetic CI fixture, and
+external evidence boundary are documented in
+[MiniMax H3 conformance evidence](./minimax-h3-conformance.md).
+
 The schema and runner define the deferred real RTX 3090 acceptance gate. No
 passing hardware report is checked in, and the runner never provisions cloud
 hardware.

--- a/docs/qualification/minimax-h3-conformance-manifest.schema.json
+++ b/docs/qualification/minimax-h3-conformance-manifest.schema.json
@@ -31,7 +31,7 @@
         "precision": { "const": "official-bf16-fp32-mixed" },
         "excluded_accelerations": {
           "type": "array",
-          "minItems": 6,
+          "minItems": 7,
           "items": { "type": "string", "minLength": 1 }
         }
       }
@@ -43,7 +43,7 @@
     },
     "component_indexes": {
       "type": "array",
-      "minItems": 7,
+      "minItems": 8,
       "items": { "$ref": "#/$defs/component_index" }
     },
     "capture_policy": {

--- a/docs/qualification/minimax-h3-conformance-manifest.schema.json
+++ b/docs/qualification/minimax-h3-conformance-manifest.schema.json
@@ -1,0 +1,169 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://utensils.io/mold/schemas/minimax-h3-conformance-manifest-v1.json",
+  "title": "Mold MiniMax H3 conformance manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "family",
+    "numerical_authority",
+    "sources",
+    "component_indexes",
+    "capture_policy",
+    "fixture_layers",
+    "day_zero_contract",
+    "synthetic_fixture"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "mold.minimax-h3.conformance-manifest.v1"
+    },
+    "family": {
+      "const": "minimax-h3"
+    },
+    "numerical_authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source_id", "precision", "excluded_accelerations"],
+      "properties": {
+        "source_id": { "const": "diffusers" },
+        "precision": { "const": "official-bf16-fp32-mixed" },
+        "excluded_accelerations": {
+          "type": "array",
+          "minItems": 6,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "sources": {
+      "type": "array",
+      "minItems": 7,
+      "items": { "$ref": "#/$defs/source" }
+    },
+    "component_indexes": {
+      "type": "array",
+      "minItems": 7,
+      "items": { "$ref": "#/$defs/component_index" }
+    },
+    "capture_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "external_fixture_root_required",
+        "authorization_record_required",
+        "weights_in_repository_forbidden",
+        "generated_media_in_repository_forbidden",
+        "authorization_issue",
+        "fixture_root_environment",
+        "authorization_record_environment"
+      ],
+      "properties": {
+        "external_fixture_root_required": { "type": "boolean" },
+        "authorization_record_required": { "type": "boolean" },
+        "weights_in_repository_forbidden": { "type": "boolean" },
+        "generated_media_in_repository_forbidden": { "type": "boolean" },
+        "authorization_issue": {
+          "const": "https://github.com/utensils/mold/issues/831"
+        },
+        "fixture_root_environment": { "const": "MOLD_H3_FIXTURE_ROOT" },
+        "authorization_record_environment": {
+          "const": "MOLD_H3_AUTHORIZATION_RECORD"
+        }
+      }
+    },
+    "fixture_layers": {
+      "type": "array",
+      "minItems": 12,
+      "items": { "$ref": "#/$defs/fixture_layer" }
+    },
+    "day_zero_contract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "fps",
+        "frame_step",
+        "frame_offset",
+        "nominal_15_second_frames",
+        "nominal_15_second_actual_duration",
+        "mold_decision",
+        "diffusers_discrepancy"
+      ],
+      "properties": {
+        "fps": { "const": 24 },
+        "frame_step": { "const": 17 },
+        "frame_offset": { "const": 5 },
+        "nominal_15_second_frames": { "const": 362 },
+        "nominal_15_second_actual_duration": { "const": 15.083333333333334 },
+        "mold_decision": { "const": "accept-aligned-362" },
+        "diffusers_discrepancy": { "const": "aligns-to-362-then-rejects-over-15s" }
+      }
+    },
+    "synthetic_fixture": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["relative_path", "sha256", "weights_required"],
+      "properties": {
+        "relative_path": { "const": "synthetic-v1.json" },
+        "sha256": { "$ref": "#/$defs/sha256" },
+        "weights_required": { "const": false }
+      }
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "commit": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "repository", "revision", "role", "authority"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "repository": { "type": "string", "pattern": "^https://" },
+        "revision": { "$ref": "#/$defs/commit" },
+        "role": { "type": "string", "minLength": 1 },
+        "authority": {
+          "enum": ["numerical", "semantic", "deployment", "performance"]
+        }
+      }
+    },
+    "component_index": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "source_id", "relative_path", "sha256"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "source_id": { "const": "minimax-official-model" },
+        "relative_path": { "type": "string", "minLength": 1 },
+        "sha256": { "$ref": "#/$defs/sha256" }
+      }
+    },
+    "fixture_layer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "authority_tier", "required_provenance", "required_measurements"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "authority_tier": {
+          "enum": ["exact-full-bf16", "quantized-structural", "synthetic"]
+        },
+        "required_provenance": {
+          "type": "array",
+          "minItems": 5,
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "required_measurements": {
+          "type": "array",
+          "minItems": 2,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    }
+  }
+}

--- a/docs/qualification/minimax-h3-conformance.md
+++ b/docs/qualification/minimax-h3-conformance.md
@@ -51,6 +51,7 @@ The external authorization record has this exact shape:
   "family": "minimax-h3",
   "decision": "approved",
   "license_revision": "bfc8ed0353f5a9733be73e6b2c98ec0948195b86",
+  "license_sha256": "59b99642b95ea21630e311198ddbfffbfe05aadba0c2f5d884cbdf4efcc90f44",
   "approved_scopes": [
     "checkpoint-execution",
     "fixture-capture",

--- a/docs/qualification/minimax-h3-conformance.md
+++ b/docs/qualification/minimax-h3-conformance.md
@@ -1,0 +1,87 @@
+# MiniMax H3 conformance evidence
+
+Mold's H3 implementation is developed against one revision-locked numerical
+contract. The checked-in harness contains no MiniMax weights, generated media,
+or real-checkpoint activations. It gives ordinary CI a deterministic synthetic
+fixture while keeping real evidence outside the repository and behind the
+[authorization gate](https://github.com/utensils/mold/issues/831).
+
+The manifest at
+`tests/fixtures/minimax_h3/conformance-manifest.json` pins the official code and
+model, Diffusers numerical oracle, ComfyUI deployment layout, and the SGLang and
+vLLM-Omni performance references. It also content-addresses the official model
+and component index files. Diffusers BF16/FP32 mixed execution is authoritative
+for numerical comparisons; approximate or non-bit-stable acceleration is
+excluded from ground-truth capture.
+
+Validate the repository contract and weight-free fixture:
+
+```bash
+python3 scripts/minimax-h3-conformance.py check-contract
+python3 scripts/tests/minimax-h3-conformance-contract.py
+```
+
+Verify pinned local metadata/source clones without executing a checkpoint:
+
+```bash
+python3 scripts/minimax-h3-conformance.py verify-sources \
+  --source minimax-official-code=/absolute/path/to/MiniMax-H3-code \
+  --source minimax-official-model=/absolute/path/to/MiniMax-H3-model \
+  --source diffusers=/absolute/path/to/diffusers \
+  --source comfyui=/absolute/path/to/ComfyUI \
+  --source comfy-checkpoints=/absolute/path/to/Comfy-H3-model \
+  --source sglang=/absolute/path/to/sglang \
+  --source vllm-omni=/absolute/path/to/vllm-omni
+```
+
+## External real-checkpoint fixtures
+
+Real checkpoint execution and fixture capture remain unavailable until the
+license gate is cleared. After that decision, evidence must be stored under an
+absolute fixture root outside the Mold checkout. The authorization record must
+also live outside the repository and content-address the reviewed source
+document. The validator is an accidental-bypass guard: it does not authenticate
+the issuer or replace legal review.
+
+The external authorization record has this exact shape:
+
+```json
+{
+  "schema_version": "mold.minimax-h3.authorization.v1",
+  "family": "minimax-h3",
+  "decision": "approved",
+  "license_revision": "bfc8ed0353f5a9733be73e6b2c98ec0948195b86",
+  "approved_scopes": [
+    "checkpoint-execution",
+    "fixture-capture",
+    "generated-output-retention"
+  ],
+  "source_document_path": "/external/compliance/minimax-h3-authorization.pdf",
+  "source_document_sha256": "<sha256>",
+  "review_reference": "<external review identifier>"
+}
+```
+
+Validate a captured bundle and every referenced evidence hash:
+
+```bash
+python3 scripts/minimax-h3-conformance.py validate-bundle \
+  --fixture-root "$MOLD_H3_FIXTURE_ROOT" \
+  --bundle "$MOLD_H3_FIXTURE_ROOT/bundle.json" \
+  --authorization-record "$MOLD_H3_AUTHORIZATION_RECORD"
+```
+
+The bundle schema is
+`docs/qualification/minimax-h3-fixture-bundle.schema.json`. Every fixture names
+its primitive layer, authority tier, component-index hash, environment,
+shape/dtype/statistics/sampled values, evidence hash, and numerical tolerance.
+Quantized Comfy results use structural, temporal, and audio quality metrics;
+they are never mislabeled as bit-identical full-precision evidence.
+
+## Day-zero frame decision
+
+Mold intentionally accepts the advertised nominal 15-second result after H3
+alignment: 362 frames at 24 fps, or 15.0833 seconds. The pinned Diffusers path
+currently aligns 360 to 362 and then rejects it for exceeding 15 seconds. The
+synthetic fixture preserves both the discrepancy and Mold's explicit decision
+so later refactors cannot inherit the rejection accidentally.

--- a/docs/qualification/minimax-h3-fixture-bundle.schema.json
+++ b/docs/qualification/minimax-h3-fixture-bundle.schema.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://utensils.io/mold/schemas/minimax-h3-fixture-bundle-v1.json",
+  "title": "Mold MiniMax H3 external fixture bundle",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "manifest_sha256",
+    "authorization_document_sha256",
+    "capture_environment",
+    "fixtures"
+  ],
+  "properties": {
+    "schema_version": { "const": "mold.minimax-h3.fixture-bundle.v1" },
+    "manifest_sha256": { "$ref": "#/$defs/sha256" },
+    "authorization_document_sha256": { "$ref": "#/$defs/sha256" },
+    "capture_environment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "framework",
+        "framework_revision",
+        "device",
+        "dtype",
+        "attention_backend",
+        "command",
+        "forbidden_accelerations_disabled"
+      ],
+      "properties": {
+        "framework": { "type": "string", "minLength": 1 },
+        "framework_revision": { "$ref": "#/$defs/commit" },
+        "device": { "type": "string", "minLength": 1 },
+        "dtype": { "type": "string", "minLength": 1 },
+        "attention_backend": { "type": "string", "minLength": 1 },
+        "command": { "type": "string", "minLength": 1 },
+        "forbidden_accelerations_disabled": { "const": true }
+      }
+    },
+    "fixtures": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/fixture" }
+    }
+  },
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "commit": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "fixture": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "layer",
+        "authority_tier",
+        "relative_path",
+        "sha256",
+        "component_index_sha256",
+        "tensor",
+        "tolerance"
+      ],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "layer": { "type": "string", "minLength": 1 },
+        "authority_tier": {
+          "enum": ["exact-full-bf16", "quantized-structural", "synthetic"]
+        },
+        "relative_path": { "type": "string", "minLength": 1 },
+        "sha256": { "$ref": "#/$defs/sha256" },
+        "component_index_sha256": { "$ref": "#/$defs/sha256" },
+        "tensor": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["shape", "dtype", "min", "max", "mean", "std", "sampled_values"],
+          "properties": {
+            "shape": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "type": "integer", "minimum": 0 }
+            },
+            "dtype": { "type": "string", "minLength": 1 },
+            "min": { "type": "number" },
+            "max": { "type": "number" },
+            "mean": { "type": "number" },
+            "std": { "type": "number", "minimum": 0 },
+            "sampled_values": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "type": "number" }
+            }
+          }
+        },
+        "tolerance": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["absolute", "relative", "metric"],
+          "properties": {
+            "absolute": { "type": "number", "minimum": 0 },
+            "relative": { "type": "number", "minimum": 0 },
+            "metric": { "type": "string", "minLength": 1 }
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/minimax-h3-conformance.py
+++ b/scripts/minimax-h3-conformance.py
@@ -1,0 +1,555 @@
+#!/usr/bin/env python3
+"""Validate MiniMax H3 conformance pins and external fixture evidence.
+
+The checked-in contract is intentionally weight-free. Real checkpoint evidence
+must live outside the repository and is accepted only with a separately managed
+authorization record whose source document is content-addressed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import pathlib
+import struct
+import subprocess
+import sys
+from typing import Any
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+FIXTURE_DIR = REPO_ROOT / "tests" / "fixtures" / "minimax_h3"
+MANIFEST_PATH = FIXTURE_DIR / "conformance-manifest.json"
+SYNTHETIC_PATH = FIXTURE_DIR / "synthetic-v1.json"
+MANIFEST_SCHEMA_PATH = (
+    REPO_ROOT / "docs" / "qualification" / "minimax-h3-conformance-manifest.schema.json"
+)
+BUNDLE_SCHEMA_PATH = (
+    REPO_ROOT / "docs" / "qualification" / "minimax-h3-fixture-bundle.schema.json"
+)
+
+SCHEMA_VERSION = "mold.minimax-h3.conformance-manifest.v1"
+SYNTHETIC_SCHEMA_VERSION = "mold.minimax-h3.synthetic.v1"
+BUNDLE_SCHEMA_VERSION = "mold.minimax-h3.fixture-bundle.v1"
+AUTHORIZATION_SCHEMA_VERSION = "mold.minimax-h3.authorization.v1"
+
+EXPECTED_REVISIONS = {
+    "minimax-official-code": "8d8824efaf94586c0cc9ac7ad8d0723d4d6420ea",
+    "minimax-official-model": "bfc8ed0353f5a9733be73e6b2c98ec0948195b86",
+    "diffusers": "9c6a68c32b3b2a64db91800b624d33cec6e25ab8",
+    "comfyui": "a464ac33588ae182f81a090d910cfbf21e255b73",
+    "comfy-checkpoints": "eb8a16107c595128b3a578f82d2ce2f75920c355",
+    "sglang": "0c3a76fa0a5bfab410b645f4143e7e8e3cc25c77",
+    "vllm-omni": "3d7fc3b9ba3cac88d579d4dc35b78b0b641675fc",
+}
+
+EXPECTED_COMPONENT_INDEXES = {
+    "official-model-index": (
+        "model_index.json",
+        "5a587fe13b2371427415ac892463142683aefcd8d322e274a3a095eac37ac7d2",
+    ),
+    "official-modular-index": (
+        "modular_model_index.json",
+        "a2b6a210e482ffb78e613b553f570c44e101afce6741bd4ed91429d0559af031",
+    ),
+    "official-fl2va-transformer-index": (
+        "transformer/diffusion_pytorch_model.safetensors.index.json",
+        "ac30a3b58963f2e735d493475fbb81853a5735ec947619648b3e045acda6783e",
+    ),
+    "official-ref2va-transformer-index": (
+        "transformer_ref/diffusion_pytorch_model.safetensors.index.json",
+        "ac30a3b58963f2e735d493475fbb81853a5735ec947619648b3e045acda6783e",
+    ),
+    "official-text-encoder-index": (
+        "text_encoder/model.safetensors.index.json",
+        "06c952c569285870b811989b794b9766493e280fb77fbcb957fc4e5fcf25403a",
+    ),
+    "official-video-vae-index": (
+        "vae/diffusion_pytorch_model.safetensors.index.json",
+        "15f6d44553c3c616b0dc999920aa784f92ecee7e4201f1f99ac405cfbf3061ca",
+    ),
+    "official-audio-vae-config": (
+        "audio_vae/config.json",
+        "9a3c645ff892b376c6f5f4c8685964cd75474731af594ff058492a0000caabb6",
+    ),
+}
+
+EXPECTED_LAYERS = {
+    "tokenizer-processor",
+    "qwen-layer-50",
+    "visual-vae",
+    "audio-vae",
+    "token-refiner",
+    "transformer-block",
+    "packed-layout",
+    "dual-sampler",
+    "noise-allocation",
+    "end-to-end-t2va",
+    "end-to-end-fl2va",
+    "end-to-end-ref2va",
+}
+
+FORBIDDEN_FIXTURE_SUFFIXES = {
+    ".bin",
+    ".ckpt",
+    ".flac",
+    ".gguf",
+    ".jpeg",
+    ".jpg",
+    ".mp3",
+    ".mp4",
+    ".png",
+    ".pt",
+    ".pth",
+    ".safetensors",
+    ".wav",
+    ".webp",
+}
+
+
+class ConformanceFailure(Exception):
+    """A fail-closed conformance contract violation."""
+
+
+def fail(message: str) -> None:
+    raise ConformanceFailure(message)
+
+
+def load_json(path: pathlib.Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        fail(f"cannot read JSON {path}: {error}")
+
+
+def sha256_file(path: pathlib.Path) -> str:
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+    except OSError as error:
+        fail(f"cannot hash {path}: {error}")
+    return digest.hexdigest()
+
+
+def schema_helper() -> Any:
+    helper_path = REPO_ROOT / "scripts" / "validate-cuda-qualification-report.py"
+    spec = importlib.util.spec_from_file_location("mold_schema_helper", helper_path)
+    if spec is None or spec.loader is None:
+        fail(f"cannot load hermetic schema helper: {helper_path}")
+    helper = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(helper)
+    return helper
+
+
+def validate_schema(instance: Any, schema_path: pathlib.Path) -> None:
+    helper = schema_helper()
+    schema = load_json(schema_path)
+    try:
+        helper.audit_schema_keywords(schema)
+        helper.validate_schema(instance, schema, schema)
+    except helper.ValidationFailure as error:
+        fail(f"schema validation failed for {schema_path.name}: {error}")
+
+
+def f32(value: float) -> float:
+    return struct.unpack("!f", struct.pack("!f", value))[0]
+
+
+def shifted_schedule(grid_points: int, shift: float) -> list[float]:
+    values: list[float] = []
+    for index in range(grid_points):
+        base = f32(1.0 - index / (grid_points - 1))
+        numerator = f32(f32(shift) * base)
+        denominator = f32(1.0 + f32(f32(shift - 1.0) * base))
+        shifted = f32(numerator / denominator)
+        if not values or shifted != values[-1]:
+            values.append(shifted)
+    return values
+
+
+def euler_update(
+    sample: list[float], velocity: list[float], sigma: float, sigma_next: float
+) -> list[float]:
+    timestep = f32(1.0 - sigma)
+    sigma_from_timestep = f32(1.0 - timestep)
+    ratio = f32(sigma_next / sigma)
+    one_minus_ratio = f32(1.0 - ratio)
+    output = []
+    for sample_value, velocity_value in zip(sample, velocity, strict=True):
+        sample_value = f32(sample_value)
+        velocity_value = f32(velocity_value)
+        denoised = f32(sample_value + f32(sigma_from_timestep * velocity_value))
+        output.append(
+            f32(f32(ratio * sample_value) + f32(one_minus_ratio * denoised))
+        )
+    return output
+
+
+def align_frames(requested: int) -> int:
+    while requested % 17 != 5:
+        requested += 1
+    return requested
+
+
+def synthetic_fixture() -> dict[str, Any]:
+    frame_grid = []
+    for nominal_seconds in (5, 10, 15):
+        requested = nominal_seconds * 24
+        aligned = align_frames(requested)
+        frame_grid.append(
+            {
+                "nominal_seconds": nominal_seconds,
+                "requested_frames": requested,
+                "aligned_frames": aligned,
+                "video_latent_frames": ((aligned - 5) // 17) * 5 + 2,
+                "audio_latents_per_channel": round(aligned / 24 * 40),
+                "actual_duration_seconds": aligned / 24,
+            }
+        )
+
+    video_sigmas = shifted_schedule(4, 12.0)
+    audio_sigmas = shifted_schedule(4, 3.0)
+    sample = [0.25, -0.5, 1.0, -2.0]
+    video_velocity = [0.5, 0.25, -1.5, 2.0]
+    audio_velocity = [-0.25, 0.75, 0.5, -1.0]
+    step_index = 1
+
+    spans = [5.0 / 3.0 * value for value in (1, 4, 4, 4, 4, 1)]
+    temporal_positions = [3.0]
+    for span in spans:
+        temporal_positions.append(temporal_positions[-1] + span)
+
+    return {
+        "schema_version": SYNTHETIC_SCHEMA_VERSION,
+        "authority": {
+            "source": "diffusers-minimax-h3",
+            "revision": EXPECTED_REVISIONS["diffusers"],
+            "execution": "weight-free-python-float32-emulation",
+        },
+        "frame_grid": frame_grid,
+        "scheduler": {
+            "grid_points": 4,
+            "transformer_evaluations": 3,
+            "video_shift": 12.0,
+            "audio_shift": 3.0,
+            "video_sigmas": video_sigmas,
+            "audio_sigmas": audio_sigmas,
+            "video_timesteps": [f32(1.0 - value) for value in video_sigmas[:-1]],
+            "audio_timesteps": [f32(1.0 - value) for value in audio_sigmas[:-1]],
+            "terminal_zero_included": True,
+            "ancestral_noise_reinjected": False,
+        },
+        "coupled_update": {
+            "step_index": step_index,
+            "sample": sample,
+            "video_velocity": video_velocity,
+            "audio_velocity": audio_velocity,
+            "video_next": euler_update(
+                sample,
+                video_velocity,
+                video_sigmas[step_index],
+                video_sigmas[step_index + 1],
+            ),
+            "audio_next": euler_update(
+                sample,
+                audio_velocity,
+                audio_sigmas[step_index],
+                audio_sigmas[step_index + 1],
+            ),
+            "velocity_sign": "data-ward-plus",
+            "update_dtype": "float32",
+        },
+        "packed_layout": {
+            "order": [
+                "text",
+                "reference-audio",
+                "reference-video",
+                "target-audio",
+                "target-video",
+            ],
+            "row_counts": [3, 4, 6, 8, 10],
+            "row_offsets": [0, 3, 7, 13, 21, 31],
+            "modality_tags": {
+                "video": 0,
+                "text": 1,
+                "audio": 2,
+            },
+            "video_soundtrack_precedes_visual_rows": True,
+        },
+        "temporal_rope": {
+            "origin": 3.0,
+            "frame_rescale": 5.0 / 3.0,
+            "frames_per_latent_pattern": [1, 4, 4, 4, 4],
+            "positions_for_seven_latents": temporal_positions,
+        },
+        "noise_allocation_order": [
+            {"domain": "condition-posterior", "shape": [1, 24, 1, 2, 2]},
+            {"domain": "condition-noise", "shape": [1, 24, 1, 2, 2]},
+            {"domain": "target-video", "shape": [1, 24, 2, 2, 2]},
+            {"domain": "target-audio", "shape": [2, 3, 32]},
+        ],
+    }
+
+
+def canonical_bytes(value: Any) -> bytes:
+    return (json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n").encode()
+
+
+def validate_manifest() -> dict[str, Any]:
+    manifest = load_json(MANIFEST_PATH)
+    validate_schema(manifest, MANIFEST_SCHEMA_PATH)
+    if manifest.get("schema_version") != SCHEMA_VERSION:
+        fail("unexpected conformance manifest schema version")
+
+    revisions = {source["id"]: source["revision"] for source in manifest["sources"]}
+    if revisions != EXPECTED_REVISIONS:
+        fail("source revisions drifted from the reviewed H3 authority set")
+
+    indexes = {
+        item["id"]: (item["relative_path"], item["sha256"])
+        for item in manifest["component_indexes"]
+    }
+    if indexes != EXPECTED_COMPONENT_INDEXES:
+        fail("official component index fingerprints drifted")
+
+    layers = {layer["id"] for layer in manifest["fixture_layers"]}
+    if layers != EXPECTED_LAYERS:
+        fail("fixture layer coverage is incomplete or contains an unreviewed layer")
+
+    policy = manifest["capture_policy"]
+    if not all(
+        policy[field]
+        for field in (
+            "external_fixture_root_required",
+            "authorization_record_required",
+            "weights_in_repository_forbidden",
+            "generated_media_in_repository_forbidden",
+        )
+    ):
+        fail("real H3 capture policy is not fail closed")
+
+    expected_synthetic = synthetic_fixture()
+    checked_synthetic = load_json(SYNTHETIC_PATH)
+    if checked_synthetic != expected_synthetic:
+        fail("synthetic fixture does not match the deterministic generator")
+    synthetic = manifest["synthetic_fixture"]
+    if synthetic["relative_path"] != "synthetic-v1.json":
+        fail("synthetic fixture path is not repository-relative and fixed")
+    if synthetic["sha256"] != sha256_file(SYNTHETIC_PATH):
+        fail("synthetic fixture hash drifted")
+
+    tracked = []
+    try:
+        output = subprocess.run(
+            ["git", "ls-files", "-z", "--", str(FIXTURE_DIR.relative_to(REPO_ROOT))],
+            cwd=REPO_ROOT,
+            check=True,
+            capture_output=True,
+        ).stdout
+        tracked = [REPO_ROOT / path.decode() for path in output.split(b"\0") if path]
+    except (OSError, subprocess.CalledProcessError):
+        tracked = [path for path in FIXTURE_DIR.rglob("*") if path.is_file()]
+    forbidden = [path for path in tracked if path.suffix.lower() in FORBIDDEN_FIXTURE_SUFFIXES]
+    if forbidden:
+        fail(f"restricted model/media artifacts are present in the fixture tree: {forbidden}")
+    return manifest
+
+
+def canonical_external_directory(label: str, value: str) -> pathlib.Path:
+    path = pathlib.Path(value)
+    if not path.is_absolute():
+        fail(f"{label} must be an absolute path")
+    try:
+        resolved = path.resolve(strict=True)
+    except OSError as error:
+        fail(f"cannot resolve {label}: {error}")
+    if not resolved.is_dir():
+        fail(f"{label} is not a directory")
+    try:
+        resolved.relative_to(REPO_ROOT)
+    except ValueError:
+        pass
+    else:
+        fail(f"{label} must live outside the Mold repository")
+    return resolved
+
+
+def validate_authorization(record_path: pathlib.Path) -> dict[str, Any]:
+    if not record_path.is_absolute():
+        fail("authorization record path must be absolute")
+    record = load_json(record_path)
+    required = {
+        "schema_version",
+        "family",
+        "decision",
+        "license_revision",
+        "approved_scopes",
+        "source_document_path",
+        "source_document_sha256",
+        "review_reference",
+    }
+    if not isinstance(record, dict) or set(record) != required:
+        fail("authorization record fields are incomplete or unreviewed")
+    if record["schema_version"] != AUTHORIZATION_SCHEMA_VERSION:
+        fail("authorization record schema is unsupported")
+    if record["family"] != "minimax-h3" or record["decision"] != "approved":
+        fail("authorization record does not approve MiniMax H3")
+    if record["license_revision"] != EXPECTED_REVISIONS["minimax-official-model"]:
+        fail("authorization record covers a different H3 license revision")
+    scopes = record["approved_scopes"]
+    if not isinstance(scopes, list) or not {
+        "checkpoint-execution",
+        "fixture-capture",
+        "generated-output-retention",
+    }.issubset(scopes):
+        fail("authorization record does not cover every conformance activity")
+    source_document = pathlib.Path(record["source_document_path"])
+    if not source_document.is_absolute() or not source_document.is_file():
+        fail("authorization source document must be an existing absolute file")
+    try:
+        source_document.resolve().relative_to(REPO_ROOT)
+    except ValueError:
+        pass
+    else:
+        fail("authorization source document must not be committed to the repository")
+    if sha256_file(source_document) != record["source_document_sha256"]:
+        fail("authorization source document hash does not match its record")
+    if not isinstance(record["review_reference"], str) or not record["review_reference"].strip():
+        fail("authorization record lacks an external review reference")
+    return record
+
+
+def parse_sources(values: list[str]) -> dict[str, pathlib.Path]:
+    sources: dict[str, pathlib.Path] = {}
+    for value in values:
+        identifier, separator, raw_path = value.partition("=")
+        if not separator or identifier in sources:
+            fail(f"--source must be a unique id=/absolute/path pair, got {value!r}")
+        sources[identifier] = pathlib.Path(raw_path)
+    return sources
+
+
+def verify_source_checkouts(manifest: dict[str, Any], values: list[str]) -> None:
+    sources = parse_sources(values)
+    if set(sources) != set(EXPECTED_REVISIONS):
+        missing = sorted(set(EXPECTED_REVISIONS) - set(sources))
+        extra = sorted(set(sources) - set(EXPECTED_REVISIONS))
+        fail(f"source checkout set differs; missing={missing}, extra={extra}")
+    for identifier, expected_revision in EXPECTED_REVISIONS.items():
+        root = sources[identifier]
+        if not root.is_absolute() or not root.is_dir():
+            fail(f"source {identifier} is not an existing absolute directory")
+        try:
+            observed = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=root,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+        except (OSError, subprocess.CalledProcessError) as error:
+            fail(f"cannot read source revision for {identifier}: {error}")
+        if observed != expected_revision:
+            fail(f"source {identifier} is {observed}, expected {expected_revision}")
+
+    model_root = sources["minimax-official-model"]
+    for item in manifest["component_indexes"]:
+        path = model_root / item["relative_path"]
+        if not path.is_file() or sha256_file(path) != item["sha256"]:
+            fail(f"component metadata drifted: {item['id']} ({path})")
+
+
+def validate_bundle(
+    manifest: dict[str, Any], fixture_root_value: str, bundle_value: str, authorization_value: str
+) -> None:
+    fixture_root = canonical_external_directory("fixture root", fixture_root_value)
+    authorization_path = pathlib.Path(authorization_value)
+    authorization = validate_authorization(authorization_path)
+    bundle_path = pathlib.Path(bundle_value).resolve(strict=True)
+    try:
+        bundle_path.relative_to(fixture_root)
+    except ValueError:
+        fail("fixture bundle must be inside the approved external fixture root")
+    bundle = load_json(bundle_path)
+    validate_schema(bundle, BUNDLE_SCHEMA_PATH)
+    if bundle["schema_version"] != BUNDLE_SCHEMA_VERSION:
+        fail("external fixture bundle schema is unsupported")
+    if bundle["manifest_sha256"] != sha256_file(MANIFEST_PATH):
+        fail("external fixture bundle targets a different conformance manifest")
+    if bundle["authorization_document_sha256"] != authorization["source_document_sha256"]:
+        fail("external fixture bundle is not bound to the authorization evidence")
+    fixture_layers = {fixture["layer"] for fixture in bundle["fixtures"]}
+    unknown_layers = fixture_layers - EXPECTED_LAYERS
+    if unknown_layers:
+        fail(f"external fixture bundle contains unknown layers: {sorted(unknown_layers)}")
+    if not bundle["fixtures"]:
+        fail("external fixture bundle contains no evidence")
+    for fixture in bundle["fixtures"]:
+        evidence_path = (fixture_root / fixture["relative_path"]).resolve(strict=True)
+        try:
+            evidence_path.relative_to(fixture_root)
+        except ValueError:
+            fail(f"fixture evidence escapes its external root: {fixture['id']}")
+        if not evidence_path.is_file() or sha256_file(evidence_path) != fixture["sha256"]:
+            fail(f"fixture evidence hash mismatch: {fixture['id']}")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate the weight-free H3 contract, pinned checkouts, or a separately "
+            "authorized external fixture bundle."
+        )
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("check-contract", help="validate checked-in pins and synthetic fixtures")
+
+    verify = subparsers.add_parser("verify-sources", help="verify every pinned local source checkout")
+    verify.add_argument(
+        "--source",
+        action="append",
+        default=[],
+        metavar="ID=/ABSOLUTE/PATH",
+        help="repeat once for every source id in the conformance manifest",
+    )
+
+    bundle = subparsers.add_parser(
+        "validate-bundle", help="validate authorized evidence outside the repository"
+    )
+    bundle.add_argument("--fixture-root", required=True)
+    bundle.add_argument("--bundle", required=True)
+    bundle.add_argument("--authorization-record", required=True)
+
+    subparsers.add_parser("print-synthetic", help="print the deterministic synthetic fixture")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    try:
+        args = parse_args(argv)
+        if args.command == "print-synthetic":
+            sys.stdout.buffer.write(canonical_bytes(synthetic_fixture()))
+            return 0
+        manifest = validate_manifest()
+        if args.command == "verify-sources":
+            verify_source_checkouts(manifest, args.source)
+        elif args.command == "validate-bundle":
+            validate_bundle(
+                manifest,
+                args.fixture_root,
+                args.bundle,
+                args.authorization_record,
+            )
+        print(f"MiniMax H3 conformance {args.command} passed")
+        return 0
+    except (ConformanceFailure, OSError) as error:
+        print(f"invalid MiniMax H3 conformance evidence: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/minimax-h3-conformance.py
+++ b/scripts/minimax-h3-conformance.py
@@ -45,7 +45,23 @@ EXPECTED_REVISIONS = {
     "vllm-omni": "3d7fc3b9ba3cac88d579d4dc35b78b0b641675fc",
 }
 
+EXPECTED_LICENSE_SHA256 = "59b99642b95ea21630e311198ddbfffbfe05aadba0c2f5d884cbdf4efcc90f44"
+
+EXPECTED_EXCLUDED_ACCELERATIONS = {
+    "torch-compile",
+    "fp8",
+    "cache-dit",
+    "sageattention",
+    "stochastic-sampling",
+    "approximate-attention",
+    "tf32",
+}
+
 EXPECTED_COMPONENT_INDEXES = {
+    "official-license": (
+        "LICENSE",
+        EXPECTED_LICENSE_SHA256,
+    ),
     "official-model-index": (
         "model_index.json",
         "5a587fe13b2371427415ac892463142683aefcd8d322e274a3a095eac37ac7d2",
@@ -306,18 +322,29 @@ def validate_manifest() -> dict[str, Any]:
         fail("unexpected conformance manifest schema version")
 
     revisions = {source["id"]: source["revision"] for source in manifest["sources"]}
-    if revisions != EXPECTED_REVISIONS:
+    if len(manifest["sources"]) != len(EXPECTED_REVISIONS) or revisions != EXPECTED_REVISIONS:
         fail("source revisions drifted from the reviewed H3 authority set")
+
+    excluded = set(manifest["numerical_authority"]["excluded_accelerations"])
+    if (
+        len(manifest["numerical_authority"]["excluded_accelerations"])
+        != len(EXPECTED_EXCLUDED_ACCELERATIONS)
+        or excluded != EXPECTED_EXCLUDED_ACCELERATIONS
+    ):
+        fail("ground-truth acceleration exclusions drifted")
 
     indexes = {
         item["id"]: (item["relative_path"], item["sha256"])
         for item in manifest["component_indexes"]
     }
-    if indexes != EXPECTED_COMPONENT_INDEXES:
+    if (
+        len(manifest["component_indexes"]) != len(EXPECTED_COMPONENT_INDEXES)
+        or indexes != EXPECTED_COMPONENT_INDEXES
+    ):
         fail("official component index fingerprints drifted")
 
     layers = {layer["id"] for layer in manifest["fixture_layers"]}
-    if layers != EXPECTED_LAYERS:
+    if len(manifest["fixture_layers"]) != len(EXPECTED_LAYERS) or layers != EXPECTED_LAYERS:
         fail("fixture layer coverage is incomplete or contains an unreviewed layer")
 
     policy = manifest["capture_policy"]
@@ -387,6 +414,7 @@ def validate_authorization(record_path: pathlib.Path) -> dict[str, Any]:
         "family",
         "decision",
         "license_revision",
+        "license_sha256",
         "approved_scopes",
         "source_document_path",
         "source_document_sha256",
@@ -400,6 +428,8 @@ def validate_authorization(record_path: pathlib.Path) -> dict[str, Any]:
         fail("authorization record does not approve MiniMax H3")
     if record["license_revision"] != EXPECTED_REVISIONS["minimax-official-model"]:
         fail("authorization record covers a different H3 license revision")
+    if record["license_sha256"] != EXPECTED_LICENSE_SHA256:
+        fail("authorization record covers different H3 license bytes")
     scopes = record["approved_scopes"]
     if not isinstance(scopes, list) or not {
         "checkpoint-execution",

--- a/scripts/tests/minimax-h3-conformance-contract.py
+++ b/scripts/tests/minimax-h3-conformance-contract.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Mutation tests for the weight-free MiniMax H3 conformance boundary."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import pathlib
+import subprocess
+import sys
+import tempfile
+from collections.abc import Callable
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+TOOL_PATH = REPO_ROOT / "scripts" / "minimax-h3-conformance.py"
+
+
+def load_tool():
+    spec = importlib.util.spec_from_file_location("minimax_h3_conformance", TOOL_PATH)
+    if spec is None or spec.loader is None:
+        raise AssertionError(f"cannot load {TOOL_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def expect_failure(action: Callable[[], object], fragment: str) -> None:
+    try:
+        action()
+    except Exception as error:  # noqa: BLE001 - this is an adversarial contract test
+        assert fragment in str(error), (fragment, str(error))
+    else:
+        raise AssertionError(f"expected failure containing {fragment!r}")
+
+
+def sha256(path: pathlib.Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def write_json(path: pathlib.Path, value: object) -> None:
+    path.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
+
+
+def test_manifest_drift(tool, temporary: pathlib.Path) -> None:
+    original_path = tool.MANIFEST_PATH
+    manifest = json.loads(original_path.read_text(encoding="utf-8"))
+    manifest["sources"][0]["revision"] = "0" * 40
+    changed = temporary / "changed-manifest.json"
+    write_json(changed, manifest)
+    tool.MANIFEST_PATH = changed
+    try:
+        expect_failure(tool.validate_manifest, "source revisions drifted")
+    finally:
+        tool.MANIFEST_PATH = original_path
+
+
+def test_synthetic_drift(tool, temporary: pathlib.Path) -> None:
+    original_path = tool.SYNTHETIC_PATH
+    fixture = json.loads(original_path.read_text(encoding="utf-8"))
+    fixture["scheduler"]["video_shift"] = 11.0
+    changed = temporary / "changed-synthetic.json"
+    write_json(changed, fixture)
+    tool.SYNTHETIC_PATH = changed
+    try:
+        expect_failure(tool.validate_manifest, "synthetic fixture does not match")
+    finally:
+        tool.SYNTHETIC_PATH = original_path
+
+
+def valid_authorization(tool, temporary: pathlib.Path) -> tuple[pathlib.Path, dict[str, object]]:
+    source_document = temporary / "minimax-authorization.txt"
+    source_document.write_text("synthetic external authorization evidence\n", encoding="utf-8")
+    record = {
+        "schema_version": tool.AUTHORIZATION_SCHEMA_VERSION,
+        "family": "minimax-h3",
+        "decision": "approved",
+        "license_revision": tool.EXPECTED_REVISIONS["minimax-official-model"],
+        "approved_scopes": [
+            "checkpoint-execution",
+            "fixture-capture",
+            "generated-output-retention",
+        ],
+        "source_document_path": str(source_document),
+        "source_document_sha256": sha256(source_document),
+        "review_reference": "external-test-review",
+    }
+    record_path = temporary / "authorization-record.json"
+    write_json(record_path, record)
+    return record_path, record
+
+
+def test_authorization_and_external_root(tool, temporary: pathlib.Path) -> None:
+    expect_failure(
+        lambda: tool.canonical_external_directory("fixture root", str(REPO_ROOT)),
+        "must live outside",
+    )
+    record_path, record = valid_authorization(tool, temporary)
+    assert tool.validate_authorization(record_path) == record
+
+    missing_scope = dict(record)
+    missing_scope["approved_scopes"] = ["fixture-capture"]
+    missing_path = temporary / "missing-scope.json"
+    write_json(missing_path, missing_scope)
+    expect_failure(
+        lambda: tool.validate_authorization(missing_path),
+        "does not cover every conformance activity",
+    )
+
+    pathlib.Path(record["source_document_path"]).write_text("mutated\n", encoding="utf-8")
+    expect_failure(
+        lambda: tool.validate_authorization(record_path),
+        "hash does not match",
+    )
+
+
+def test_external_bundle_hashes(tool, temporary: pathlib.Path) -> None:
+    root = temporary / "fixtures"
+    root.mkdir()
+    evidence = root / "dual-sampler.json"
+    evidence.write_text('{"fixture":"synthetic"}\n', encoding="utf-8")
+    record_path, record = valid_authorization(tool, temporary)
+    bundle = {
+        "schema_version": tool.BUNDLE_SCHEMA_VERSION,
+        "manifest_sha256": sha256(tool.MANIFEST_PATH),
+        "authorization_document_sha256": record["source_document_sha256"],
+        "capture_environment": {
+            "framework": "diffusers",
+            "framework_revision": tool.EXPECTED_REVISIONS["diffusers"],
+            "device": "cpu-synthetic",
+            "dtype": "float32",
+            "attention_backend": "math",
+            "command": "weight-free synthetic fixture",
+            "forbidden_accelerations_disabled": True,
+        },
+        "fixtures": [
+            {
+                "id": "dual-sampler-synthetic",
+                "layer": "dual-sampler",
+                "authority_tier": "synthetic",
+                "relative_path": evidence.name,
+                "sha256": sha256(evidence),
+                "component_index_sha256": "0" * 64,
+                "tensor": {
+                    "shape": [4],
+                    "dtype": "float32",
+                    "min": 0.0,
+                    "max": 1.0,
+                    "mean": 0.5,
+                    "std": 0.5,
+                    "sampled_values": [1.0, 0.0],
+                },
+                "tolerance": {
+                    "absolute": 0.0,
+                    "relative": 0.0,
+                    "metric": "exact-float32",
+                },
+            }
+        ],
+    }
+    bundle_path = root / "bundle.json"
+    write_json(bundle_path, bundle)
+    manifest = tool.validate_manifest()
+    tool.validate_bundle(manifest, str(root), str(bundle_path), str(record_path))
+
+    evidence.write_text("mutated\n", encoding="utf-8")
+    expect_failure(
+        lambda: tool.validate_bundle(manifest, str(root), str(bundle_path), str(record_path)),
+        "fixture evidence hash mismatch",
+    )
+
+
+def main() -> int:
+    tool = load_tool()
+    tool.validate_manifest()
+    printed = subprocess.run(
+        [sys.executable, str(TOOL_PATH), "print-synthetic"],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+    ).stdout
+    assert json.loads(printed) == json.loads(tool.SYNTHETIC_PATH.read_bytes())
+
+    with tempfile.TemporaryDirectory(prefix="mold-h3-contract-") as value:
+        temporary = pathlib.Path(value).resolve()
+        test_manifest_drift(tool, temporary)
+        test_synthetic_drift(tool, temporary)
+        test_authorization_and_external_root(tool, temporary)
+        test_external_bundle_hashes(tool, temporary)
+
+    print("MiniMax H3 conformance contract tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/minimax-h3-conformance-contract.py
+++ b/scripts/tests/minimax-h3-conformance-contract.py
@@ -77,6 +77,7 @@ def valid_authorization(tool, temporary: pathlib.Path) -> tuple[pathlib.Path, di
         "family": "minimax-h3",
         "decision": "approved",
         "license_revision": tool.EXPECTED_REVISIONS["minimax-official-model"],
+        "license_sha256": tool.EXPECTED_LICENSE_SHA256,
         "approved_scopes": [
             "checkpoint-execution",
             "fixture-capture",

--- a/tests/fixtures/minimax_h3/conformance-manifest.json
+++ b/tests/fixtures/minimax_h3/conformance-manifest.json
@@ -67,6 +67,12 @@
   ],
   "component_indexes": [
     {
+      "id": "official-license",
+      "source_id": "minimax-official-model",
+      "relative_path": "LICENSE",
+      "sha256": "59b99642b95ea21630e311198ddbfffbfe05aadba0c2f5d884cbdf4efcc90f44"
+    },
+    {
       "id": "official-model-index",
       "source_id": "minimax-official-model",
       "relative_path": "model_index.json",

--- a/tests/fixtures/minimax_h3/conformance-manifest.json
+++ b/tests/fixtures/minimax_h3/conformance-manifest.json
@@ -1,0 +1,323 @@
+{
+  "schema_version": "mold.minimax-h3.conformance-manifest.v1",
+  "family": "minimax-h3",
+  "numerical_authority": {
+    "source_id": "diffusers",
+    "precision": "official-bf16-fp32-mixed",
+    "excluded_accelerations": [
+      "torch-compile",
+      "fp8",
+      "cache-dit",
+      "sageattention",
+      "stochastic-sampling",
+      "approximate-attention",
+      "tf32"
+    ]
+  },
+  "sources": [
+    {
+      "id": "minimax-official-code",
+      "repository": "https://github.com/MiniMax-AI/MiniMax-H3",
+      "revision": "8d8824efaf94586c0cc9ac7ad8d0723d4d6420ea",
+      "role": "official architecture and semantic contract",
+      "authority": "semantic"
+    },
+    {
+      "id": "minimax-official-model",
+      "repository": "https://huggingface.co/MiniMaxAI/MiniMax-H3",
+      "revision": "bfc8ed0353f5a9733be73e6b2c98ec0948195b86",
+      "role": "official checkpoint configuration and component indexes",
+      "authority": "numerical"
+    },
+    {
+      "id": "diffusers",
+      "repository": "https://github.com/huggingface/diffusers",
+      "revision": "9c6a68c32b3b2a64db91800b624d33cec6e25ab8",
+      "role": "official full-precision executable oracle",
+      "authority": "numerical"
+    },
+    {
+      "id": "comfyui",
+      "repository": "https://github.com/Comfy-Org/ComfyUI",
+      "revision": "a464ac33588ae182f81a090d910cfbf21e255b73",
+      "role": "pruned and quantized runtime reference",
+      "authority": "deployment"
+    },
+    {
+      "id": "comfy-checkpoints",
+      "repository": "https://huggingface.co/Comfy-Org/MiniMax-H3",
+      "revision": "eb8a16107c595128b3a578f82d2ce2f75920c355",
+      "role": "pruned and quantized checkpoint schema reference",
+      "authority": "deployment"
+    },
+    {
+      "id": "sglang",
+      "repository": "https://github.com/sgl-project/sglang",
+      "revision": "0c3a76fa0a5bfab410b645f4143e7e8e3cc25c77",
+      "role": "truncated conditioner and distributed performance reference",
+      "authority": "performance"
+    },
+    {
+      "id": "vllm-omni",
+      "repository": "https://github.com/vllm-project/vllm-omni",
+      "revision": "3d7fc3b9ba3cac88d579d4dc35b78b0b641675fc",
+      "role": "loader, offload, and CUDA kernel reference",
+      "authority": "performance"
+    }
+  ],
+  "component_indexes": [
+    {
+      "id": "official-model-index",
+      "source_id": "minimax-official-model",
+      "relative_path": "model_index.json",
+      "sha256": "5a587fe13b2371427415ac892463142683aefcd8d322e274a3a095eac37ac7d2"
+    },
+    {
+      "id": "official-modular-index",
+      "source_id": "minimax-official-model",
+      "relative_path": "modular_model_index.json",
+      "sha256": "a2b6a210e482ffb78e613b553f570c44e101afce6741bd4ed91429d0559af031"
+    },
+    {
+      "id": "official-fl2va-transformer-index",
+      "source_id": "minimax-official-model",
+      "relative_path": "transformer/diffusion_pytorch_model.safetensors.index.json",
+      "sha256": "ac30a3b58963f2e735d493475fbb81853a5735ec947619648b3e045acda6783e"
+    },
+    {
+      "id": "official-ref2va-transformer-index",
+      "source_id": "minimax-official-model",
+      "relative_path": "transformer_ref/diffusion_pytorch_model.safetensors.index.json",
+      "sha256": "ac30a3b58963f2e735d493475fbb81853a5735ec947619648b3e045acda6783e"
+    },
+    {
+      "id": "official-text-encoder-index",
+      "source_id": "minimax-official-model",
+      "relative_path": "text_encoder/model.safetensors.index.json",
+      "sha256": "06c952c569285870b811989b794b9766493e280fb77fbcb957fc4e5fcf25403a"
+    },
+    {
+      "id": "official-video-vae-index",
+      "source_id": "minimax-official-model",
+      "relative_path": "vae/diffusion_pytorch_model.safetensors.index.json",
+      "sha256": "15f6d44553c3c616b0dc999920aa784f92ecee7e4201f1f99ac405cfbf3061ca"
+    },
+    {
+      "id": "official-audio-vae-config",
+      "source_id": "minimax-official-model",
+      "relative_path": "audio_vae/config.json",
+      "sha256": "9a3c645ff892b376c6f5f4c8685964cd75474731af594ff058492a0000caabb6"
+    }
+  ],
+  "capture_policy": {
+    "external_fixture_root_required": true,
+    "authorization_record_required": true,
+    "weights_in_repository_forbidden": true,
+    "generated_media_in_repository_forbidden": true,
+    "authorization_issue": "https://github.com/utensils/mold/issues/831",
+    "fixture_root_environment": "MOLD_H3_FIXTURE_ROOT",
+    "authorization_record_environment": "MOLD_H3_AUTHORIZATION_RECORD"
+  },
+  "fixture_layers": [
+    {
+      "id": "tokenizer-processor",
+      "authority_tier": "exact-full-bf16",
+      "required_provenance": [
+        "source-revision",
+        "tokenizer-hash",
+        "processor-hash",
+        "device",
+        "capture-command"
+      ],
+      "required_measurements": [
+        "token-ids",
+        "special-token-presentation",
+        "processor-shapes",
+        "sampled-values"
+      ]
+    },
+    {
+      "id": "qwen-layer-50",
+      "authority_tier": "exact-full-bf16",
+      "required_provenance": [
+        "source-revision",
+        "component-index-hash",
+        "device",
+        "dtype",
+        "capture-command"
+      ],
+      "required_measurements": ["shape", "dtype", "statistics", "sampled-values", "tolerance"]
+    },
+    {
+      "id": "visual-vae",
+      "authority_tier": "exact-full-bf16",
+      "required_provenance": [
+        "source-revision",
+        "component-index-hash",
+        "device",
+        "dtype",
+        "capture-command"
+      ],
+      "required_measurements": [
+        "pixel-normalization",
+        "posterior-seed-42",
+        "latent-statistics",
+        "sampled-values",
+        "tile-seams"
+      ]
+    },
+    {
+      "id": "audio-vae",
+      "authority_tier": "exact-full-bf16",
+      "required_provenance": [
+        "source-revision",
+        "component-index-hash",
+        "device",
+        "dtype",
+        "capture-command"
+      ],
+      "required_measurements": [
+        "stereo-packing",
+        "latent-rate",
+        "waveform-statistics",
+        "phase-polarity",
+        "sampled-values"
+      ]
+    },
+    {
+      "id": "token-refiner",
+      "authority_tier": "exact-full-bf16",
+      "required_provenance": [
+        "source-revision",
+        "component-index-hash",
+        "device",
+        "dtype",
+        "capture-command"
+      ],
+      "required_measurements": ["shape", "statistics", "sampled-values", "tolerance"]
+    },
+    {
+      "id": "transformer-block",
+      "authority_tier": "exact-full-bf16",
+      "required_provenance": [
+        "source-revision",
+        "component-index-hash",
+        "device",
+        "dtype",
+        "attention-backend",
+        "capture-command"
+      ],
+      "required_measurements": [
+        "qk-rms",
+        "partial-mm-rope",
+        "adaln",
+        "video-head",
+        "audio-head",
+        "tolerance"
+      ]
+    },
+    {
+      "id": "packed-layout",
+      "authority_tier": "exact-full-bf16",
+      "required_provenance": [
+        "source-revision",
+        "workflow",
+        "reference-order",
+        "device",
+        "capture-command"
+      ],
+      "required_measurements": [
+        "row-order",
+        "modality-tags",
+        "rotary-coordinates",
+        "timestep-indices"
+      ]
+    },
+    {
+      "id": "dual-sampler",
+      "authority_tier": "synthetic",
+      "required_provenance": [
+        "source-revision",
+        "float-policy",
+        "video-shift",
+        "audio-shift",
+        "capture-command"
+      ],
+      "required_measurements": ["sigma-arrays", "timesteps", "coupled-update", "evaluation-count"]
+    },
+    {
+      "id": "noise-allocation",
+      "authority_tier": "exact-full-bf16",
+      "required_provenance": [
+        "source-revision",
+        "seed",
+        "generator-device",
+        "allocation-version",
+        "capture-command"
+      ],
+      "required_measurements": ["draw-order", "tensor-shapes", "sampled-values", "hash"]
+    },
+    {
+      "id": "end-to-end-t2va",
+      "authority_tier": "exact-full-bf16",
+      "required_provenance": [
+        "source-revision",
+        "component-index-hashes",
+        "device",
+        "dtype",
+        "capture-command"
+      ],
+      "required_measurements": ["latent-statistics", "av-timing", "video-metrics", "audio-metrics"]
+    },
+    {
+      "id": "end-to-end-fl2va",
+      "authority_tier": "exact-full-bf16",
+      "required_provenance": [
+        "source-revision",
+        "component-index-hashes",
+        "endpoint-signature",
+        "device",
+        "capture-command"
+      ],
+      "required_measurements": [
+        "condition-latents",
+        "latent-statistics",
+        "av-timing",
+        "video-metrics",
+        "audio-metrics"
+      ]
+    },
+    {
+      "id": "end-to-end-ref2va",
+      "authority_tier": "exact-full-bf16",
+      "required_provenance": [
+        "source-revision",
+        "component-index-hashes",
+        "reference-order",
+        "device",
+        "capture-command"
+      ],
+      "required_measurements": [
+        "packed-order",
+        "latent-statistics",
+        "av-timing",
+        "video-metrics",
+        "audio-metrics"
+      ]
+    }
+  ],
+  "day_zero_contract": {
+    "fps": 24,
+    "frame_step": 17,
+    "frame_offset": 5,
+    "nominal_15_second_frames": 362,
+    "nominal_15_second_actual_duration": 15.083333333333334,
+    "mold_decision": "accept-aligned-362",
+    "diffusers_discrepancy": "aligns-to-362-then-rejects-over-15s"
+  },
+  "synthetic_fixture": {
+    "relative_path": "synthetic-v1.json",
+    "sha256": "bddf9a6b821015094aedba95dd58a7634a783c9338dd6d488e66bd8d5fcd182a",
+    "weights_required": false
+  }
+}

--- a/tests/fixtures/minimax_h3/synthetic-v1.json
+++ b/tests/fixtures/minimax_h3/synthetic-v1.json
@@ -1,0 +1,133 @@
+{
+  "schema_version": "mold.minimax-h3.synthetic.v1",
+  "authority": {
+    "source": "diffusers-minimax-h3",
+    "revision": "9c6a68c32b3b2a64db91800b624d33cec6e25ab8",
+    "execution": "weight-free-python-float32-emulation"
+  },
+  "frame_grid": [
+    {
+      "nominal_seconds": 5,
+      "requested_frames": 120,
+      "aligned_frames": 124,
+      "video_latent_frames": 37,
+      "audio_latents_per_channel": 207,
+      "actual_duration_seconds": 5.166666666666667
+    },
+    {
+      "nominal_seconds": 10,
+      "requested_frames": 240,
+      "aligned_frames": 243,
+      "video_latent_frames": 72,
+      "audio_latents_per_channel": 405,
+      "actual_duration_seconds": 10.125
+    },
+    {
+      "nominal_seconds": 15,
+      "requested_frames": 360,
+      "aligned_frames": 362,
+      "video_latent_frames": 107,
+      "audio_latents_per_channel": 603,
+      "actual_duration_seconds": 15.083333333333334
+    }
+  ],
+  "scheduler": {
+    "grid_points": 4,
+    "transformer_evaluations": 3,
+    "video_shift": 12.0,
+    "audio_shift": 3.0,
+    "video_sigmas": [
+      1.0,
+      0.9599999189376831,
+      0.8571428060531616,
+      0.0
+    ],
+    "audio_sigmas": [
+      1.0,
+      0.8571428060531616,
+      0.5999999642372131,
+      0.0
+    ],
+    "video_timesteps": [
+      0.0,
+      0.040000081062316895,
+      0.14285719394683838
+    ],
+    "audio_timesteps": [
+      0.0,
+      0.14285719394683838,
+      0.40000003576278687
+    ],
+    "terminal_zero_included": true,
+    "ancestral_noise_reinjected": false
+  },
+  "coupled_update": {
+    "step_index": 1,
+    "sample": [0.25, -0.5, 1.0, -2.0],
+    "video_velocity": [0.5, 0.25, -1.5, 2.0],
+    "audio_velocity": [-0.25, 0.75, 0.5, -1.0],
+    "video_next": [
+      0.30142855644226074,
+      -0.47428572177886963,
+      0.8457143902778625,
+      -1.794285774230957
+    ],
+    "audio_next": [
+      0.18571428954601288,
+      -0.30714285373687744,
+      1.1285715103149414,
+      -2.257143020629883
+    ],
+    "velocity_sign": "data-ward-plus",
+    "update_dtype": "float32"
+  },
+  "packed_layout": {
+    "order": [
+      "text",
+      "reference-audio",
+      "reference-video",
+      "target-audio",
+      "target-video"
+    ],
+    "row_counts": [3, 4, 6, 8, 10],
+    "row_offsets": [0, 3, 7, 13, 21, 31],
+    "modality_tags": {
+      "video": 0,
+      "text": 1,
+      "audio": 2
+    },
+    "video_soundtrack_precedes_visual_rows": true
+  },
+  "temporal_rope": {
+    "origin": 3.0,
+    "frame_rescale": 1.6666666666666667,
+    "frames_per_latent_pattern": [1, 4, 4, 4, 4],
+    "positions_for_seven_latents": [
+      3.0,
+      4.666666666666667,
+      11.333333333333334,
+      18.0,
+      24.666666666666668,
+      31.333333333333336,
+      33.0
+    ]
+  },
+  "noise_allocation_order": [
+    {
+      "domain": "condition-posterior",
+      "shape": [1, 24, 1, 2, 2]
+    },
+    {
+      "domain": "condition-noise",
+      "shape": [1, 24, 1, 2, 2]
+    },
+    {
+      "domain": "target-video",
+      "shape": [1, 24, 2, 2, 2]
+    },
+    {
+      "domain": "target-audio",
+      "shape": [2, 3, 32]
+    }
+  ]
+}


### PR DESCRIPTION
## What changed

- pins the official MiniMax code/model, Diffusers oracle, Comfy deployment references, SGLang, and vLLM-Omni revisions in a machine-readable manifest
- content-addresses official component indexes and adds a hermetic external-fixture bundle schema
- adds deterministic weight-free frame-grid, dual-scheduler, coupled-update, packed-layout, RoPE, and noise-allocation fixtures
- rejects source/index drift, checked-in restricted payloads, in-repository real fixtures, incomplete authorization records, and mutated external evidence
- records Mold's explicit 362-frame nominal-15-second decision and the current Diffusers discrepancy
- wires mutation coverage into required CI

## Why

This establishes the #832 parity authority before model primitives and performance work can diverge. Real checkpoints and generated media remain outside the repository and impossible to validate without an external content-addressed authorization record; this PR does not bypass #831 or download model weights.

Refs #814
Refs #832

## Validation

- `python3 scripts/minimax-h3-conformance.py check-contract`
- `python3 scripts/minimax-h3-conformance.py verify-sources ...` against all seven pinned local checkouts
- `python3 scripts/tests/minimax-h3-conformance-contract.py`
- `ruff check scripts/minimax-h3-conformance.py scripts/tests/minimax-h3-conformance-contract.py`
- `bash scripts/tests/ci-routing-contract.sh`
- `git diff --check`
