### PR TITLE
feat(inference): add H3 dual-shift flow sampler

### DIFF
--- a/crates/mold-inference/src/lib.rs
+++ b/crates/mold-inference/src/lib.rs
@@ -24,6 +24,11 @@ pub mod latent_preview;
 pub mod loader;
 pub mod ltx2;
 pub mod ltx_video;
+// The deterministic scheduler contract lands ahead of the license-gated H3
+// engine. Keeping it crate-private avoids advertising a runnable family while
+// leaving the exact math ready for the future pipeline to consume.
+#[allow(dead_code)]
+pub(crate) mod minimax_h3;
 pub mod model_registry;
 pub(crate) mod nvfp4;
 pub mod progress;

--- a/crates/mold-inference/src/minimax_h3/mod.rs
+++ b/crates/mold-inference/src/minimax_h3/mod.rs
@@ -1,0 +1,6 @@
+//! MiniMax H3 inference primitives.
+//!
+//! H3 is not a runnable Mold family yet. This module contains only deterministic,
+//! non-weight contracts that can be verified before the model pipeline lands.
+
+pub(crate) mod sampler;

--- a/crates/mold-inference/src/minimax_h3/sampler.rs
+++ b/crates/mold-inference/src/minimax_h3/sampler.rs
@@ -317,6 +317,13 @@ pub(crate) fn euler_step(sample: &Tensor, velocity: &Tensor, step: H3FlowStep) -
             output_dtype.as_str()
         );
     }
+    let velocity_dtype = velocity.dtype();
+    if !matches!(velocity_dtype, DType::F16 | DType::BF16 | DType::F32) {
+        bail!(
+            "MiniMax H3 velocity must use f16, bf16, or f32, got {}",
+            velocity_dtype.as_str()
+        );
+    }
 
     // Match `1 - timestep.to(dtype=sample.dtype)` before the model output
     // promotes the x0 expression to FP32.
@@ -350,12 +357,52 @@ pub(crate) fn euler_step_pair(
 #[cfg(test)]
 mod tests {
     use candle_core::{DType, Device, Tensor};
+    use serde::Deserialize;
 
     use super::{
         euler_step, euler_step_pair, unique_consecutive, H3DualSchedule, H3FlowStep, H3StepCount,
         H3_AUDIO_SHIFT, H3_CLEAN_TIMESTEP, H3_DEFAULT_GRID_POINTS, H3_VIDEO_SHIFT,
         H3_VISUAL_CONDITION_TIMESTEP,
     };
+
+    #[derive(Debug, Deserialize)]
+    struct SyntheticFixture {
+        scheduler: SyntheticScheduler,
+        coupled_update: SyntheticCoupledUpdate,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct SyntheticScheduler {
+        grid_points: usize,
+        transformer_evaluations: usize,
+        video_shift: f32,
+        audio_shift: f32,
+        video_sigmas: Vec<f32>,
+        audio_sigmas: Vec<f32>,
+        video_timesteps: Vec<f32>,
+        audio_timesteps: Vec<f32>,
+        terminal_zero_included: bool,
+        ancestral_noise_reinjected: bool,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct SyntheticCoupledUpdate {
+        step_index: usize,
+        sample: Vec<f32>,
+        video_velocity: Vec<f32>,
+        audio_velocity: Vec<f32>,
+        video_next: Vec<f32>,
+        audio_next: Vec<f32>,
+        velocity_sign: String,
+        update_dtype: String,
+    }
+
+    fn synthetic_fixture() -> SyntheticFixture {
+        serde_json::from_str(include_str!(
+            "../../../../tests/fixtures/minimax_h3/synthetic-v1.json"
+        ))
+        .expect("the checked-in MiniMax H3 synthetic fixture must be valid")
+    }
 
     fn assert_close(actual: &[f32], expected: &[f32], tolerance: f32) {
         assert_eq!(actual.len(), expected.len());
@@ -391,18 +438,20 @@ mod tests {
 
     #[test]
     fn weight_free_synthetic_v1_matches_the_pinned_oracle() {
-        // The exact float32 values in
-        // tests/fixtures/minimax_h3/synthetic-v1.json, captured from
-        // diffusers-minimax-h3@9c6a68c without model weights.
-        let schedule = H3DualSchedule::new(4).unwrap();
+        let fixture = synthetic_fixture();
+        let authority = &fixture.scheduler;
+        assert_eq!(authority.video_shift, H3_VIDEO_SHIFT);
+        assert_eq!(authority.audio_shift, H3_AUDIO_SHIFT);
+        assert!(authority.terminal_zero_included);
+        assert!(!authority.ancestral_noise_reinjected);
+
+        let schedule = H3DualSchedule::new(authority.grid_points).unwrap();
         assert_eq!(
-            schedule.video_sigmas(),
-            &[1.0, 0.959_999_9, 0.857_142_8, 0.0]
+            schedule.counts().transformer_evaluations,
+            authority.transformer_evaluations
         );
-        assert_eq!(
-            schedule.audio_sigmas(),
-            &[1.0, 0.857_142_8, 0.599_999_96, 0.0]
-        );
+        assert_eq!(schedule.video_sigmas(), authority.video_sigmas);
+        assert_eq!(schedule.audio_sigmas(), authority.audio_sigmas);
 
         let steps: Vec<_> = schedule.steps().collect();
         assert_eq!(
@@ -410,32 +459,38 @@ mod tests {
                 .iter()
                 .map(|step| step.video.timestep)
                 .collect::<Vec<_>>(),
-            vec![0.0, 0.040_000_08, 0.142_857_2]
+            authority.video_timesteps
         );
         assert_eq!(
             steps
                 .iter()
                 .map(|step| step.audio.timestep)
                 .collect::<Vec<_>>(),
-            vec![0.0, 0.142_857_2, 0.400_000_04]
+            authority.audio_timesteps
         );
 
+        let update = &fixture.coupled_update;
+        assert_eq!(update.velocity_sign, "data-ward-plus");
+        assert_eq!(update.update_dtype, "float32");
         let device = Device::Cpu;
-        let sample_values = [0.25f32, -0.5, 1.0, -2.0];
-        let video = Tensor::new(&sample_values, &device).unwrap();
-        let audio = Tensor::new(&sample_values, &device).unwrap();
-        let video_velocity = Tensor::new(&[0.5f32, 0.25, -1.5, 2.0], &device).unwrap();
-        let audio_velocity = Tensor::new(&[-0.25f32, 0.75, 0.5, -1.0], &device).unwrap();
+        let video = Tensor::new(update.sample.as_slice(), &device).unwrap();
+        let audio = Tensor::new(update.sample.as_slice(), &device).unwrap();
+        let video_velocity = Tensor::new(update.video_velocity.as_slice(), &device).unwrap();
+        let audio_velocity = Tensor::new(update.audio_velocity.as_slice(), &device).unwrap();
+        let step = steps
+            .get(update.step_index)
+            .copied()
+            .expect("fixture step must exist in its schedule");
         let (video, audio) =
-            euler_step_pair(&video, &audio, &video_velocity, &audio_velocity, steps[1]).unwrap();
+            euler_step_pair(&video, &audio, &video_velocity, &audio_velocity, step).unwrap();
         assert_close(
             &video.to_vec1::<f32>().unwrap(),
-            &[0.301_428_56, -0.474_285_72, 0.845_714_4, -1.794_285_8],
+            &update.video_next,
             f32::EPSILON,
         );
         assert_close(
             &audio.to_vec1::<f32>().unwrap(),
-            &[0.185_714_29, -0.307_142_85, 1.128_571_5, -2.257_143],
+            &update.audio_next,
             f32::EPSILON,
         );
     }
@@ -633,6 +688,10 @@ mod tests {
             timestep: 0.25,
         };
         assert!(euler_step(&sample, &velocity, inconsistent_timestep).is_err());
+
+        let integer_velocity = Tensor::new(&[1u8], &device).unwrap();
+        let valid = H3DualSchedule::new(2).unwrap().steps().next().unwrap();
+        assert!(euler_step(&sample, &integer_velocity, valid.video).is_err());
     }
 
     #[cfg(feature = "cuda")]

--- a/crates/mold-inference/src/minimax_h3/sampler.rs
+++ b/crates/mold-inference/src/minimax_h3/sampler.rs
@@ -1,0 +1,678 @@
+//! Exact dual-modality rectified-flow schedule used by MiniMax H3.
+//!
+//! H3 advances generated video and audio rows through one transformer forward,
+//! but the two modalities use different shifted sigma grids. The iterator in
+//! this module therefore yields one immutable descriptor per *coupled* forward;
+//! callers can check cancellation before requesting the next descriptor and
+//! only replace their two latent tensors after [`euler_step_pair`] succeeds.
+//!
+//! `grid_points` deliberately includes the terminal zero. The official default
+//! is 50 grid points and thus 49 transformer evaluations, not 50 evaluations.
+
+use std::iter::FusedIterator;
+
+use anyhow::{bail, Result};
+use candle_core::{DType, Tensor};
+
+pub(crate) const H3_DEFAULT_GRID_POINTS: usize = 50;
+pub(crate) const H3_VIDEO_SHIFT: f32 = 12.0;
+pub(crate) const H3_AUDIO_SHIFT: f32 = 3.0;
+pub(crate) const H3_VISUAL_CONDITION_TIMESTEP: f32 = 0.999;
+pub(crate) const H3_CLEAN_TIMESTEP: f32 = 1.0;
+
+/// One modality's authority for a coupled transformer evaluation.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct H3FlowStep {
+    /// Current noise level.
+    pub sigma: f32,
+    /// Noise level after this deterministic Euler update.
+    pub next_sigma: f32,
+    /// AdaLN timestep supplied to the transformer: `1 - sigma`.
+    pub timestep: f32,
+}
+
+/// Timestep values assigned to the five packed-row roles during one forward.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct H3RowTimesteps {
+    /// Text rows do not have an output head and inherit generated video time.
+    pub text: f32,
+    pub generated_video: f32,
+    /// Visual anchors use at least the official near-clean value; this is a
+    /// `max(generated_video, 0.999)` in the pinned reference implementation.
+    pub visual_condition: f32,
+    pub generated_audio: f32,
+    /// Audio references are fully clean and never denoised.
+    pub audio_reference: f32,
+}
+
+/// Unambiguous user/API and execution counts for one schedule.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct H3StepCount {
+    /// Requested sigma grid points, including terminal zero.
+    pub requested_grid_points: usize,
+    /// Grid points after consecutive float32 collisions are collapsed.
+    pub effective_grid_points: usize,
+    /// Coupled DiT forwards, always `effective_grid_points - 1`.
+    pub transformer_evaluations: usize,
+}
+
+/// Progress before or after a coupled transformer evaluation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct H3DenoiseProgress {
+    pub completed_evaluations: usize,
+    pub total_evaluations: usize,
+}
+
+impl H3DenoiseProgress {
+    pub fn is_complete(self) -> bool {
+        self.completed_evaluations == self.total_evaluations
+    }
+}
+
+/// One cancellation-safe unit of H3 denoising work.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(crate) struct H3DualScheduleStep {
+    /// Zero-based index of the coupled transformer forward.
+    pub evaluation_index: usize,
+    pub video: H3FlowStep,
+    pub audio: H3FlowStep,
+    pub row_timesteps: H3RowTimesteps,
+    total_evaluations: usize,
+}
+
+impl H3DualScheduleStep {
+    /// Progress to report immediately before the forward (and cancellation
+    /// boundary) represented by this descriptor.
+    pub fn progress_before_forward(self) -> H3DenoiseProgress {
+        H3DenoiseProgress {
+            completed_evaluations: self.evaluation_index,
+            total_evaluations: self.total_evaluations,
+        }
+    }
+
+    /// Progress to report only after both video and audio updates commit.
+    pub fn progress_after_update(self) -> H3DenoiseProgress {
+        H3DenoiseProgress {
+            completed_evaluations: self.evaluation_index + 1,
+            total_evaluations: self.total_evaluations,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct H3ModalitySchedule {
+    sigmas: Vec<f32>,
+}
+
+fn unique_consecutive(values: impl IntoIterator<Item = f32>) -> Vec<f32> {
+    let mut unique = Vec::new();
+    for value in values {
+        if unique.last().copied() != Some(value) {
+            unique.push(value);
+        }
+    }
+    unique
+}
+
+impl H3ModalitySchedule {
+    fn new(grid_points: usize, shift: f32) -> Result<Self> {
+        if grid_points < 2 {
+            bail!("MiniMax H3 schedule needs at least two grid points, got {grid_points}");
+        }
+        if !shift.is_finite() || shift <= 0.0 {
+            bail!("MiniMax H3 schedule shift must be finite and positive, got {shift}");
+        }
+
+        let denominator = (grid_points - 1) as f64;
+        let shifted = (0..grid_points).map(|index| {
+            // Spell out both endpoints so terminal zero and initial one remain
+            // exact. The pinned float32 linspace rounds the result of the
+            // double-precision index division, rather than dividing two f32
+            // values; the distinction is one ulp for some short grids.
+            let base = match index {
+                0 => 1.0,
+                index if index + 1 == grid_points => 0.0,
+                _ => (1.0 - index as f64 / denominator) as f32,
+            };
+            let numerator = shift * base;
+            let denominator = 1.0 + (shift - 1.0) * base;
+            numerator / denominator
+        });
+        let sigmas = unique_consecutive(shifted);
+
+        if sigmas.len() < 2
+            || sigmas.first().copied() != Some(1.0)
+            || sigmas.last().copied() != Some(0.0)
+            || !sigmas.windows(2).all(|pair| pair[1] < pair[0])
+        {
+            bail!("MiniMax H3 shift {shift} produced an invalid sigma grid");
+        }
+
+        Ok(Self { sigmas })
+    }
+
+    fn evaluations(&self) -> usize {
+        self.sigmas.len() - 1
+    }
+
+    fn step(&self, index: usize) -> H3FlowStep {
+        let sigma = self.sigmas[index];
+        H3FlowStep {
+            sigma,
+            next_sigma: self.sigmas[index + 1],
+            timestep: 1.0 - sigma,
+        }
+    }
+}
+
+/// H3's synchronized video/audio schedule.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct H3DualSchedule {
+    requested_grid_points: usize,
+    video: H3ModalitySchedule,
+    audio: H3ModalitySchedule,
+}
+
+impl H3DualSchedule {
+    /// Build the exact released-checkpoint schedule: shift 12 for video and 3
+    /// for audio, both derived from the same terminal-inclusive base grid.
+    pub fn new(grid_points: usize) -> Result<Self> {
+        let video = H3ModalitySchedule::new(grid_points, H3_VIDEO_SHIFT)?;
+        let audio = H3ModalitySchedule::new(grid_points, H3_AUDIO_SHIFT)?;
+        if video.evaluations() != audio.evaluations() {
+            bail!(
+                "MiniMax H3 shifted grids collapsed to different lengths (video {}, audio {}); cannot synchronize one-forward updates",
+                video.evaluations(),
+                audio.evaluations()
+            );
+        }
+        Ok(Self {
+            requested_grid_points: grid_points,
+            video,
+            audio,
+        })
+    }
+
+    pub fn official_default() -> Self {
+        Self::new(H3_DEFAULT_GRID_POINTS).expect("the official H3 schedule is valid")
+    }
+
+    pub fn counts(&self) -> H3StepCount {
+        H3StepCount {
+            requested_grid_points: self.requested_grid_points,
+            effective_grid_points: self.video.sigmas.len(),
+            transformer_evaluations: self.video.evaluations(),
+        }
+    }
+
+    pub fn video_sigmas(&self) -> &[f32] {
+        &self.video.sigmas
+    }
+
+    pub fn audio_sigmas(&self) -> &[f32] {
+        &self.audio.sigmas
+    }
+
+    /// Iterate one descriptor per coupled transformer forward. A caller checks
+    /// cancellation before each `next()`/forward and never stores a partial AV
+    /// result: [`euler_step_pair`] returns both next tensors or an error.
+    pub fn steps(&self) -> H3DualScheduleIter<'_> {
+        H3DualScheduleIter {
+            schedule: self,
+            next_index: 0,
+        }
+    }
+
+    fn step(&self, index: usize) -> H3DualScheduleStep {
+        let video = self.video.step(index);
+        let audio = self.audio.step(index);
+        H3DualScheduleStep {
+            evaluation_index: index,
+            video,
+            audio,
+            row_timesteps: H3RowTimesteps {
+                text: video.timestep,
+                generated_video: video.timestep,
+                visual_condition: video.timestep.max(H3_VISUAL_CONDITION_TIMESTEP),
+                generated_audio: audio.timestep,
+                audio_reference: H3_CLEAN_TIMESTEP,
+            },
+            total_evaluations: self.video.evaluations(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct H3DualScheduleIter<'a> {
+    schedule: &'a H3DualSchedule,
+    next_index: usize,
+}
+
+impl Iterator for H3DualScheduleIter<'_> {
+    type Item = H3DualScheduleStep;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.next_index >= self.schedule.video.evaluations() {
+            return None;
+        }
+        let step = self.schedule.step(self.next_index);
+        self.next_index += 1;
+        Some(step)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.schedule.video.evaluations() - self.next_index;
+        (remaining, Some(remaining))
+    }
+}
+
+impl ExactSizeIterator for H3DualScheduleIter<'_> {}
+impl FusedIterator for H3DualScheduleIter<'_> {}
+
+/// Apply one data-ward H3 Euler update, then restore the latent dtype.
+///
+/// The transformer predicts `v` toward clean data, so `x0 = x + sigma * v`.
+/// H3 then interpolates exactly to the next sigma without ancestral noise:
+/// `x_next = ratio*x + (1-ratio)*x0`, `ratio = next_sigma/sigma`.
+///
+/// The pinned scheduler first casts `t` to the latent dtype and recovers
+/// `sigma = 1 - t` there. The H3 pipeline supplies an FP32 model output, so
+/// that recovered value and the latent are promoted for `x0`; the ratio blend
+/// also stays FP32 for half-precision latents. Reproducing that ordering is
+/// important near the terminal end of the schedule, where the half-precision
+/// `1 - (1 - sigma)` round trip is observably different from `sigma`.
+pub(crate) fn euler_step(sample: &Tensor, velocity: &Tensor, step: H3FlowStep) -> Result<Tensor> {
+    if sample.dims() != velocity.dims() {
+        bail!(
+            "MiniMax H3 sample/velocity shape mismatch: {:?} versus {:?}",
+            sample.dims(),
+            velocity.dims()
+        );
+    }
+    if step.sigma <= 0.0
+        || step.next_sigma < 0.0
+        || step.next_sigma >= step.sigma
+        || !step.sigma.is_finite()
+        || !step.next_sigma.is_finite()
+    {
+        bail!(
+            "MiniMax H3 Euler step needs finite decreasing sigmas, got {} -> {}",
+            step.sigma,
+            step.next_sigma
+        );
+    }
+    let expected_timestep = 1.0 - step.sigma;
+    if step.timestep.to_bits() != expected_timestep.to_bits() {
+        bail!(
+            "MiniMax H3 timestep must be exactly 1 - sigma, got {} for sigma {}",
+            step.timestep,
+            step.sigma
+        );
+    }
+
+    let output_dtype = sample.dtype();
+    if !matches!(output_dtype, DType::F16 | DType::BF16 | DType::F32) {
+        bail!(
+            "MiniMax H3 latents must use f16, bf16, or f32, got {}",
+            output_dtype.as_str()
+        );
+    }
+
+    // Match `1 - timestep.to(dtype=sample.dtype)` before the model output
+    // promotes the x0 expression to FP32.
+    let one = Tensor::new(1.0f32, sample.device())?.to_dtype(output_dtype)?;
+    let timestep = Tensor::new(step.timestep, sample.device())?.to_dtype(output_dtype)?;
+    let sigma_from_timestep = one.sub(&timestep)?.to_dtype(DType::F32)?;
+    let sample = sample.to_dtype(DType::F32)?;
+    let velocity = velocity.to_dtype(DType::F32)?;
+    let x0 = sample.add(&velocity.broadcast_mul(&sigma_from_timestep)?)?;
+    let ratio = (step.next_sigma / step.sigma) as f64;
+    sample
+        .affine(ratio, 0.0)?
+        .add(&x0.affine(1.0 - ratio, 0.0)?)?
+        .to_dtype(output_dtype)
+        .map_err(Into::into)
+}
+
+/// Compute both modality updates before the caller replaces either latent.
+pub(crate) fn euler_step_pair(
+    video_sample: &Tensor,
+    audio_sample: &Tensor,
+    video_velocity: &Tensor,
+    audio_velocity: &Tensor,
+    step: H3DualScheduleStep,
+) -> Result<(Tensor, Tensor)> {
+    let next_video = euler_step(video_sample, video_velocity, step.video)?;
+    let next_audio = euler_step(audio_sample, audio_velocity, step.audio)?;
+    Ok((next_video, next_audio))
+}
+
+#[cfg(test)]
+mod tests {
+    use candle_core::{DType, Device, Tensor};
+
+    use super::{
+        euler_step, euler_step_pair, unique_consecutive, H3DualSchedule, H3FlowStep, H3StepCount,
+        H3_AUDIO_SHIFT, H3_CLEAN_TIMESTEP, H3_DEFAULT_GRID_POINTS, H3_VIDEO_SHIFT,
+        H3_VISUAL_CONDITION_TIMESTEP,
+    };
+
+    fn assert_close(actual: &[f32], expected: &[f32], tolerance: f32) {
+        assert_eq!(actual.len(), expected.len());
+        for (index, (actual, expected)) in actual.iter().zip(expected).enumerate() {
+            assert!(
+                (actual - expected).abs() <= tolerance,
+                "value {index}: expected {expected}, got {actual}"
+            );
+        }
+    }
+
+    #[test]
+    fn exact_dual_shifts_apply_to_one_terminal_inclusive_grid() {
+        assert_eq!(H3_VIDEO_SHIFT, 12.0);
+        assert_eq!(H3_AUDIO_SHIFT, 3.0);
+
+        let schedule = H3DualSchedule::new(5).unwrap();
+        assert_close(
+            schedule.video_sigmas(),
+            &[1.0, 0.972_972_9, 0.923_076_9, 0.8, 0.0],
+            f32::EPSILON,
+        );
+        assert_close(
+            schedule.audio_sigmas(),
+            &[1.0, 0.9, 0.75, 0.5, 0.0],
+            f32::EPSILON,
+        );
+
+        // Swapping the official modality shifts must fail this explicit middle
+        // comparison even though both arrays still look like valid schedules.
+        assert_ne!(schedule.video_sigmas()[2], schedule.audio_sigmas()[2]);
+    }
+
+    #[test]
+    fn weight_free_synthetic_v1_matches_the_pinned_oracle() {
+        // The exact float32 values in
+        // tests/fixtures/minimax_h3/synthetic-v1.json, captured from
+        // diffusers-minimax-h3@9c6a68c without model weights.
+        let schedule = H3DualSchedule::new(4).unwrap();
+        assert_eq!(
+            schedule.video_sigmas(),
+            &[1.0, 0.959_999_9, 0.857_142_8, 0.0]
+        );
+        assert_eq!(
+            schedule.audio_sigmas(),
+            &[1.0, 0.857_142_8, 0.599_999_96, 0.0]
+        );
+
+        let steps: Vec<_> = schedule.steps().collect();
+        assert_eq!(
+            steps
+                .iter()
+                .map(|step| step.video.timestep)
+                .collect::<Vec<_>>(),
+            vec![0.0, 0.040_000_08, 0.142_857_2]
+        );
+        assert_eq!(
+            steps
+                .iter()
+                .map(|step| step.audio.timestep)
+                .collect::<Vec<_>>(),
+            vec![0.0, 0.142_857_2, 0.400_000_04]
+        );
+
+        let device = Device::Cpu;
+        let sample_values = [0.25f32, -0.5, 1.0, -2.0];
+        let video = Tensor::new(&sample_values, &device).unwrap();
+        let audio = Tensor::new(&sample_values, &device).unwrap();
+        let video_velocity = Tensor::new(&[0.5f32, 0.25, -1.5, 2.0], &device).unwrap();
+        let audio_velocity = Tensor::new(&[-0.25f32, 0.75, 0.5, -1.0], &device).unwrap();
+        let (video, audio) =
+            euler_step_pair(&video, &audio, &video_velocity, &audio_velocity, steps[1]).unwrap();
+        assert_close(
+            &video.to_vec1::<f32>().unwrap(),
+            &[0.301_428_56, -0.474_285_72, 0.845_714_4, -1.794_285_8],
+            f32::EPSILON,
+        );
+        assert_close(
+            &audio.to_vec1::<f32>().unwrap(),
+            &[0.185_714_29, -0.307_142_85, 1.128_571_5, -2.257_143],
+            f32::EPSILON,
+        );
+    }
+
+    #[test]
+    fn official_steps_mean_fifty_grid_points_and_forty_nine_forwards() {
+        let schedule = H3DualSchedule::official_default();
+        assert_eq!(
+            schedule.counts(),
+            H3StepCount {
+                requested_grid_points: H3_DEFAULT_GRID_POINTS,
+                effective_grid_points: H3_DEFAULT_GRID_POINTS,
+                transformer_evaluations: H3_DEFAULT_GRID_POINTS - 1,
+            }
+        );
+        assert_eq!(schedule.video_sigmas().first(), Some(&1.0));
+        assert_eq!(schedule.audio_sigmas().first(), Some(&1.0));
+        assert_eq!(schedule.video_sigmas().last(), Some(&0.0));
+        assert_eq!(schedule.audio_sigmas().last(), Some(&0.0));
+        assert_eq!(schedule.steps().len(), 49);
+    }
+
+    #[test]
+    fn float32_collisions_collapse_without_losing_terminal_zero() {
+        assert_eq!(
+            unique_consecutive([1.0, 1.0, 0.75, 0.75, 0.25, 0.0, 0.0]),
+            vec![1.0, 0.75, 0.25, 0.0]
+        );
+        let shortest = H3DualSchedule::new(2).unwrap();
+        assert_eq!(shortest.video_sigmas(), &[1.0, 0.0]);
+        assert_eq!(shortest.audio_sigmas(), &[1.0, 0.0]);
+        assert_eq!(shortest.steps().len(), 1);
+    }
+
+    #[test]
+    fn timesteps_and_condition_rows_keep_their_authority() {
+        let schedule = H3DualSchedule::new(5).unwrap();
+        let steps: Vec<_> = schedule.steps().collect();
+
+        assert_eq!(steps[0].video.timestep, 0.0);
+        assert_eq!(steps[0].audio.timestep, 0.0);
+        assert_eq!(steps[2].video.timestep, 1.0 - 0.923_076_9);
+        assert_eq!(steps[2].audio.timestep, 0.25);
+        for step in steps {
+            assert_eq!(step.row_timesteps.text, step.video.timestep);
+            assert_eq!(step.row_timesteps.generated_video, step.video.timestep);
+            assert_eq!(
+                step.row_timesteps.visual_condition,
+                step.video.timestep.max(H3_VISUAL_CONDITION_TIMESTEP)
+            );
+            assert_eq!(step.row_timesteps.generated_audio, step.audio.timestep);
+            assert_eq!(step.row_timesteps.audio_reference, H3_CLEAN_TIMESTEP);
+        }
+    }
+
+    #[test]
+    fn iterator_has_one_cancellation_boundary_per_coupled_forward() {
+        let schedule = H3DualSchedule::official_default();
+        let mut steps = schedule.steps();
+        assert_eq!(steps.len(), 49);
+
+        let first = steps.next().unwrap();
+        assert_eq!(first.progress_before_forward().completed_evaluations, 0);
+        assert_eq!(first.progress_after_update().completed_evaluations, 1);
+        assert!(!first.progress_after_update().is_complete());
+        assert_eq!(steps.len(), 48);
+
+        let last = steps.last().unwrap();
+        assert_eq!(last.evaluation_index, 48);
+        assert_eq!(last.video.next_sigma, 0.0);
+        assert_eq!(last.audio.next_sigma, 0.0);
+        assert_eq!(last.progress_after_update().completed_evaluations, 49);
+        assert_eq!(last.progress_after_update().total_evaluations, 49);
+        assert!(last.progress_after_update().is_complete());
+    }
+
+    #[test]
+    fn data_ward_velocity_uses_the_positive_sign_and_reaches_x0() {
+        let device = Device::Cpu;
+        let sample = Tensor::new(&[1.0f32, -2.0], &device).unwrap();
+        let velocity = Tensor::new(&[0.5f32, 1.0], &device).unwrap();
+        let final_step = H3DualSchedule::new(5).unwrap().steps().last().unwrap();
+        let output = euler_step(&sample, &velocity, final_step.video)
+            .unwrap()
+            .to_vec1::<f32>()
+            .unwrap();
+
+        // Final video sigma is 0.8: x0 = x + 0.8*v. Reversing the sign would
+        // produce [0.6, -2.8] and is intentionally caught here.
+        assert_close(&output, &[1.4, -1.2], 1e-6);
+    }
+
+    #[test]
+    fn coupled_update_uses_distinct_sigmas_without_partial_mutation() {
+        let device = Device::Cpu;
+        let video = Tensor::new(&[1.0f32], &device).unwrap();
+        let audio = Tensor::new(&[1.0f32], &device).unwrap();
+        let video_velocity = Tensor::new(&[1.0f32], &device).unwrap();
+        let audio_velocity = Tensor::new(&[1.0f32], &device).unwrap();
+        let step = H3DualSchedule::new(5).unwrap().steps().nth(2).unwrap();
+
+        let (next_video, next_audio) =
+            euler_step_pair(&video, &audio, &video_velocity, &audio_velocity, step).unwrap();
+        let next_video = next_video.to_vec1::<f32>().unwrap()[0];
+        let next_audio = next_audio.to_vec1::<f32>().unwrap()[0];
+        assert_close(&[next_video], &[1.123_076_9], 1e-6);
+        assert_close(&[next_audio], &[1.25], 1e-6);
+
+        // Inputs are immutable; a later audio error cannot leave a stored video
+        // update pretending the pair is synchronized.
+        assert_eq!(video.to_vec1::<f32>().unwrap(), vec![1.0]);
+        assert_eq!(audio.to_vec1::<f32>().unwrap(), vec![1.0]);
+    }
+
+    #[test]
+    fn half_latents_quantize_timestep_before_float32_x0_and_blend() {
+        let device = Device::Cpu;
+        let sample = Tensor::new(&[-80.0f32, 40.0], &device)
+            .unwrap()
+            .to_dtype(DType::BF16)
+            .unwrap();
+        // The official denoise block explicitly passes its prediction as
+        // float32 even while the latent is bf16/f16.
+        let velocity = Tensor::new(&[100.0f32, -50.0], &device).unwrap();
+        let step = H3DualSchedule::new(5)
+            .unwrap()
+            .steps()
+            .last()
+            .unwrap()
+            .video;
+
+        let output = euler_step(&sample, &velocity, step).unwrap();
+        assert_eq!(output.dtype(), DType::BF16);
+
+        // Oracle ordering: cast t to the latent dtype, subtract there, then
+        // promote the mixed latent/model-output expression and blend in f32.
+        let one = Tensor::new(1.0f32, &device)
+            .unwrap()
+            .to_dtype(DType::BF16)
+            .unwrap();
+        let timestep = Tensor::new(step.timestep, &device)
+            .unwrap()
+            .to_dtype(DType::BF16)
+            .unwrap();
+        let sigma_from_timestep = one.sub(&timestep).unwrap().to_dtype(DType::F32).unwrap();
+        let sample32 = sample.to_dtype(DType::F32).unwrap();
+        let expected = sample32
+            .add(&velocity.broadcast_mul(&sigma_from_timestep).unwrap())
+            .unwrap()
+            .to_dtype(DType::BF16)
+            .unwrap()
+            .to_dtype(DType::F32)
+            .unwrap()
+            .to_vec1::<f32>()
+            .unwrap();
+        let actual = output
+            .to_dtype(DType::F32)
+            .unwrap()
+            .to_vec1::<f32>()
+            .unwrap();
+        assert_eq!(actual, expected);
+
+        // Reusing the f32 grid sigma directly is close numerically but is not
+        // the pinned scheduler's half-precision timestep round trip.
+        let unquantized = sample32
+            .add(&velocity.affine((1.0 - step.timestep) as f64, 0.0).unwrap())
+            .unwrap()
+            .to_dtype(DType::BF16)
+            .unwrap()
+            .to_dtype(DType::F32)
+            .unwrap()
+            .to_vec1::<f32>()
+            .unwrap();
+        assert_ne!(actual, unquantized);
+    }
+
+    #[test]
+    fn malformed_schedule_inputs_and_steps_fail_closed() {
+        assert!(H3DualSchedule::new(0).is_err());
+        assert!(H3DualSchedule::new(1).is_err());
+
+        let device = Device::Cpu;
+        let sample = Tensor::new(&[1.0f32], &device).unwrap();
+        let velocity = Tensor::new(&[1.0f32], &device).unwrap();
+        let invalid = H3FlowStep {
+            sigma: 0.5,
+            next_sigma: 0.5,
+            timestep: 0.5,
+        };
+        assert!(euler_step(&sample, &velocity, invalid).is_err());
+
+        let inconsistent_timestep = H3FlowStep {
+            sigma: 0.5,
+            next_sigma: 0.0,
+            timestep: 0.25,
+        };
+        assert!(euler_step(&sample, &velocity, inconsistent_timestep).is_err());
+    }
+
+    #[cfg(feature = "cuda")]
+    #[test]
+    #[cfg_attr(not(target_os = "linux"), ignore)]
+    fn tiny_coupled_update_matches_cpu_and_cuda() {
+        let Ok(cuda) = Device::new_cuda(0) else {
+            return;
+        };
+        let cpu = Device::Cpu;
+        let video_values = [0.125f32, -1.75, 3.5, 0.03125];
+        let audio_values = [-0.5f32, 2.25, -4.0, 0.75];
+        let video_velocity_values = [0.75f32, -0.125, 1.25, -3.0];
+        let audio_velocity_values = [1.5f32, -2.0, 0.0625, 0.25];
+        let step = H3DualSchedule::official_default().steps().nth(24).unwrap();
+
+        let run = |device: &Device| {
+            let video = Tensor::new(&video_values, device).unwrap();
+            let audio = Tensor::new(&audio_values, device).unwrap();
+            let video_velocity = Tensor::new(&video_velocity_values, device).unwrap();
+            let audio_velocity = Tensor::new(&audio_velocity_values, device).unwrap();
+            let (video, audio) =
+                euler_step_pair(&video, &audio, &video_velocity, &audio_velocity, step).unwrap();
+            (
+                video
+                    .to_device(&Device::Cpu)
+                    .unwrap()
+                    .to_vec1::<f32>()
+                    .unwrap(),
+                audio
+                    .to_device(&Device::Cpu)
+                    .unwrap()
+                    .to_vec1::<f32>()
+                    .unwrap(),
+            )
+        };
+
+        let (cpu_video, cpu_audio) = run(&cpu);
+        let (cuda_video, cuda_audio) = run(&cuda);
+        assert_close(&cuda_video, &cpu_video, 1e-6);
+        assert_close(&cuda_audio, &cpu_audio, 1e-6);
+    }
+}


### PR DESCRIPTION
## Summary

- add a crate-private MiniMax H3 dual-modality scheduler contract without registering or advertising a runnable H3 family
- reproduce the pinned terminal-inclusive float32 linspace, video shift 12, audio shift 3, duplicate collapse, and 50-grid-point / 49-forward semantics
- emit immutable coupled-forward descriptors with authoritative text, generated AV, visual-condition, and clean audio-reference timesteps plus unambiguous progress counts
- implement atomic paired data-ward Euler updates with the positive H3 velocity sign, no ancestral noise, and the pinned BF16/FP16-to-FP32 operation order
- keep cancellation safe at forward boundaries by returning both next modality tensors before either stored latent is replaced

## Conformance

The Rust regression uses the exact schedule, timestep, and coupled-update values from `tests/fixtures/minimax_h3/synthetic-v1.json` at pinned Diffusers revision `9c6a68c32b3b2a64db91800b624d33cec6e25ab8`. It catches the one-ULP difference between the oracle's float32 linspace and an all-f32 index division, swapped modality shifts, reversed velocity sign, missing terminal zero, off-by-one progress, and bypassing the half-precision timestep round trip.

## Validation

- `cargo fmt --all -- --check`
- `python3 scripts/tests/minimax-h3-conformance-contract.py`
- `cargo test -p mold-ai-inference minimax_h3::sampler::tests --lib` (10 passed)
- `cargo test -p mold-ai-inference --features cuda minimax_h3::sampler::tests --lib` on NVIDIA L40S (11 passed, including CPU/CUDA parity)
- `cargo clippy -p mold-ai-inference --lib --tests -- -D warnings`

This intentionally contains no model weights, downloads, manifest/catalog entry, factory dispatch, capability advertising, or authorization bypass. The future H3 DiT/pipeline consumes these descriptors to perform the actual single-forward AV execution and wire generation-facing validation, metadata, and phase telemetry.

Refs #836