### PR TITLE
feat(h3): add gate-safe core contracts

### DIFF
--- a/crates/mold-catalog/src/civitai_map.rs
+++ b/crates/mold-catalog/src/civitai_map.rs
@@ -181,6 +181,11 @@ pub const CIVITAI_BASE_MODELS: &[&str] = &[
 pub fn supported_for(family: Family, bundling: Bundling, kind: Kind) -> bool {
     use Family::*;
     use Kind::*;
+    if family == MinimaxH3 {
+        // Family taxonomy is registered for exact classification and policy
+        // enforcement, but there is no runnable H3 engine in this build.
+        return false;
+    }
     match kind {
         // Supporting assets and adapters are installable when the family has
         // a compatible runtime. They are not standalone generation models, so

--- a/crates/mold-catalog/src/companions.rs
+++ b/crates/mold-catalog/src/companions.rs
@@ -408,6 +408,10 @@ pub fn companions_for(
                 _ => push(&mut out, "wan21-vae"),
             }
         }
+        // H3 catalog installs remain policy-gated and have no independently
+        // runnable companion graph. Its hidden core manifests own the exact
+        // FL2VA/Ref2VA component layouts.
+        Family::MinimaxH3 => {}
         Family::QwenImage => {
             push(&mut out, "qwen-image-runtime");
         }

--- a/crates/mold-catalog/src/defaults.rs
+++ b/crates/mold-catalog/src/defaults.rs
@@ -112,6 +112,15 @@ pub fn runtime_defaults_for_family(
                 fps: Some(16),
             },
         },
+        "minimax-h3" | "minimax_h3" | "minimaxh3" => CatalogRuntimeDefaults {
+            width: mold_core::minimax_h3::DEFAULT_WIDTH,
+            height: mold_core::minimax_h3::DEFAULT_HEIGHT,
+            steps: mold_core::minimax_h3::DEFAULT_STEPS,
+            guidance: 0.0,
+            is_schnell: None,
+            frames: Some(mold_core::minimax_h3::MIN_FRAMES),
+            fps: Some(mold_core::minimax_h3::FIXED_FPS),
+        },
         "sdxl" => CatalogRuntimeDefaults {
             width: 1024,
             height: 1024,
@@ -166,6 +175,12 @@ mod tests {
         let ltx_video = runtime_defaults_for_family("ltx-video", None);
         assert_eq!(ltx_video.frames, Some(25));
         assert_eq!(ltx_video.fps, Some(30));
+
+        let h3 = runtime_defaults_for_family("minimax-h3", None);
+        assert_eq!(h3.frames, Some(mold_core::minimax_h3::MIN_FRAMES));
+        assert_eq!(h3.fps, Some(mold_core::minimax_h3::FIXED_FPS));
+        assert_eq!((h3.width, h3.height), (1344, 768));
+        assert_eq!(h3.guidance, 0.0);
 
         let flux = runtime_defaults_for_family("flux", None);
         assert_eq!(flux.frames, None);

--- a/crates/mold-catalog/src/families.rs
+++ b/crates/mold-catalog/src/families.rs
@@ -16,6 +16,7 @@ pub enum Family {
     LtxVideo,
     Ltx2,
     Wan,
+    MinimaxH3,
     QwenImage,
     Wuerstchen,
 }
@@ -29,9 +30,22 @@ pub const ALL_FAMILIES: &[Family] = &[
     Family::LtxVideo,
     Family::Ltx2,
     Family::Wan,
+    Family::MinimaxH3,
     Family::QwenImage,
     Family::Wuerstchen,
 ];
+
+/// Families permitted in ordinary discovery surfaces for this build.
+///
+/// `ALL_FAMILIES` remains the exhaustive internal taxonomy so classification
+/// and exhaustive matches know about contract-only families. Public catalog
+/// endpoints must consume this filtered iterator instead: its predicate is a
+/// direct view of mold-core's single activation authority.
+pub fn active_families() -> impl Iterator<Item = Family> {
+    ALL_FAMILIES.iter().copied().filter(|family| {
+        mold_core::model_activation_available(family.as_str(), Some(family.as_str()))
+    })
+}
 
 #[derive(Debug, thiserror::Error)]
 #[error("unknown family: {0:?}")]
@@ -51,6 +65,7 @@ impl Family {
             Family::LtxVideo => "ltx-video",
             Family::Ltx2 => "ltx2",
             Family::Wan => "wan",
+            Family::MinimaxH3 => "minimax-h3",
             Family::QwenImage => "qwen-image",
             Family::Wuerstchen => "wuerstchen",
         }
@@ -68,7 +83,7 @@ impl Family {
     /// count. One predicate is what keeps the four in step.
     pub fn is_video(&self) -> bool {
         match self {
-            Family::LtxVideo | Family::Ltx2 | Family::Wan => true,
+            Family::LtxVideo | Family::Ltx2 | Family::Wan | Family::MinimaxH3 => true,
             Family::Flux
             | Family::Flux2
             | Family::Sd15
@@ -90,6 +105,7 @@ impl Family {
             "ltx-video" => Family::LtxVideo,
             "ltx2" => Family::Ltx2,
             "wan" => Family::Wan,
+            "minimax-h3" | "minimax_h3" | "minimaxh3" => Family::MinimaxH3,
             "qwen-image" => Family::QwenImage,
             "wuerstchen" => Family::Wuerstchen,
             other => return Err(UnknownFamily(other.to_string())),
@@ -100,5 +116,27 @@ impl Family {
 impl fmt::Display for Family {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn minimax_h3_aliases_are_canonical_video_taxonomy() {
+        for alias in ["minimax-h3", "minimax_h3", "minimaxh3"] {
+            let family = Family::from_str(alias).unwrap();
+            assert_eq!(family, Family::MinimaxH3);
+            assert_eq!(family.as_str(), "minimax-h3");
+            assert!(family.is_video());
+        }
+    }
+
+    #[test]
+    fn compliance_gated_families_stay_out_of_public_discovery() {
+        let families = active_families().collect::<Vec<_>>();
+        assert!(!families.contains(&Family::MinimaxH3));
+        assert!(families.contains(&Family::Flux));
     }
 }

--- a/crates/mold-catalog/src/hf_seeds.rs
+++ b/crates/mold-catalog/src/hf_seeds.rs
@@ -38,6 +38,7 @@ pub fn seeds_for(family: Family) -> &'static [&'static str] {
             "QuantStack/Wan2.2-T2V-A14B-GGUF",
             "QuantStack/Wan2.2-I2V-A14B-GGUF",
         ],
+        MinimaxH3 => &["MiniMaxAI/MiniMax-H3", "Comfy-Org/MiniMax-H3"],
         QwenImage => &["Qwen/Qwen-Image"],
         Wuerstchen => &["warp-ai/wuerstchen"],
     }

--- a/crates/mold-catalog/src/live.rs
+++ b/crates/mold-catalog/src/live.rs
@@ -1216,6 +1216,22 @@ fn looks_like_wan(id_lower: &str) -> bool {
     ANCHORED.iter().any(|needle| id_lower.contains(needle))
 }
 
+/// Match an H3 family token without swallowing adjacent words or versions.
+/// Repository names such as `MiniMax-H3-FL2VA` are valid, while
+/// `notminimax-h3` and `minimax-h30` are unrelated lookalikes.
+fn looks_like_minimax_h3(id_lower: &str) -> bool {
+    ["minimax-h3", "minimax_h3", "minimaxh3"]
+        .into_iter()
+        .any(|needle| {
+            id_lower.match_indices(needle).any(|(start, matched)| {
+                let before = id_lower[..start].chars().next_back();
+                let after = id_lower[start + matched.len()..].chars().next();
+                before.is_none_or(|ch| !ch.is_ascii_alphanumeric())
+                    && after.is_none_or(|ch| !ch.is_ascii_alphanumeric())
+            })
+        })
+}
+
 /// Wan's sub-family, inferred from a repo id.
 ///
 /// The HF normalizers pass `sub_family: None` on the grounds that single-file
@@ -1258,7 +1274,9 @@ pub fn family_from_hf(
     // Repo-id substring match — the load-bearing path. HF doesn't
     // expose a canonical "model family" tag, so id-substring + curated
     // seed list is the cleanest signal.
-    let family = if id_lower.contains("flux.2") || id_lower.contains("flux-2") {
+    let family = if looks_like_minimax_h3(&id_lower) {
+        Family::MinimaxH3
+    } else if id_lower.contains("flux.2") || id_lower.contains("flux-2") {
         Family::Flux2
     } else if id_lower.contains("flux.1")
         || id_lower.contains("flux-1")
@@ -1300,6 +1318,7 @@ pub fn family_from_hf(
                 // Safe as an exact tag where it is unsafe as a substring:
                 // a repo that tags itself `wan` is claiming the family.
                 "wan" => Some(Family::Wan),
+                "minimax-h3" | "minimax_h3" | "minimaxh3" => Some(Family::MinimaxH3),
                 _ => continue,
             };
             break;

--- a/crates/mold-catalog/src/synthesis.rs
+++ b/crates/mold-catalog/src/synthesis.rs
@@ -233,7 +233,9 @@ pub fn family_bundles_vae_unconditionally(family: Family) -> bool {
         // the VAE in its own file, and the GGUF experts could not bundle one
         // even in principle. So there is nothing to probe for and the resolver
         // routes straight to the VAE companion.
-        Family::Flux2 | Family::ZImage | Family::LtxVideo | Family::Wan => false,
+        Family::Flux2 | Family::ZImage | Family::LtxVideo | Family::Wan | Family::MinimaxH3 => {
+            false
+        }
         Family::QwenImage | Family::Wuerstchen => false,
     }
 }

--- a/crates/mold-catalog/tests/live_search.rs
+++ b/crates/mold-catalog/tests/live_search.rs
@@ -885,6 +885,8 @@ fn family_from_hf_id_substring() {
         ("black-forest-labs/FLUX.2-dev", Family::Flux2),
         ("Lightricks/LTX-Video-2.3", Family::Ltx2),
         ("Lightricks/LTX-Video", Family::LtxVideo),
+        ("MiniMaxAI/MiniMax-H3", Family::MinimaxH3),
+        ("someone/MiniMax-H3-FL2VA-finetune", Family::MinimaxH3),
         ("stabilityai/stable-diffusion-xl-base-1.0", Family::Sdxl),
         ("Tongyi-MAI/Z-Image-Turbo", Family::ZImage),
     ];
@@ -897,6 +899,12 @@ fn family_from_hf_id_substring() {
         family_from_hf("some-org/llama-3-instruct", &[], None).is_none(),
         "non-mold repos must return None"
     );
+    for id in ["someone/notminimax-h3", "someone/minimax-h30"] {
+        assert!(
+            family_from_hf(id, &[], None).is_none(),
+            "H3 lookalike {id} must not be classified"
+        );
+    }
 }
 
 /// Every spelling of Wan that the ecosystem actually ships must land on the

--- a/crates/mold-cli/src/commands/info.rs
+++ b/crates/mold-cli/src/commands/info.rs
@@ -47,7 +47,14 @@ fn resolve_file_path(
         ModelComponent::ClipTokenizer2 => mcfg.clip_tokenizer_2.clone(),
         ModelComponent::TextTokenizer => mcfg.text_tokenizer.clone(),
         ModelComponent::Decoder => mcfg.decoder.clone(),
-        ModelComponent::TransformerShard | ModelComponent::TextEncoder => None,
+        ModelComponent::TransformerShard
+        | ModelComponent::TextEncoder
+        | ModelComponent::AudioVae
+        | ModelComponent::Processor
+        | ModelComponent::VideoScheduler
+        | ModelComponent::AudioScheduler
+        | ModelComponent::ModelConfig
+        | ModelComponent::TaskConfig => None,
         ModelComponent::Upscaler => mcfg.transformer.clone(),
     }
 }
@@ -79,6 +86,12 @@ fn resolve_verify_path(
             // Shards, text encoder files, and upscaler weights; fall through to config
             ModelComponent::TransformerShard
             | ModelComponent::TextEncoder
+            | ModelComponent::AudioVae
+            | ModelComponent::Processor
+            | ModelComponent::VideoScheduler
+            | ModelComponent::AudioScheduler
+            | ModelComponent::ModelConfig
+            | ModelComponent::TaskConfig
             | ModelComponent::Upscaler => None,
         };
         if let Some(p) = path {
@@ -95,6 +108,12 @@ fn component_label(component: &ModelComponent) -> &'static str {
         ModelComponent::TransformerShard => "Transformer Shard",
         ModelComponent::LowNoiseTransformer => "Low-Noise Transformer",
         ModelComponent::Vae => "VAE",
+        ModelComponent::AudioVae => "Audio VAE",
+        ModelComponent::Processor => "Processor",
+        ModelComponent::VideoScheduler => "Video Scheduler",
+        ModelComponent::AudioScheduler => "Audio Scheduler",
+        ModelComponent::ModelConfig => "Model Config",
+        ModelComponent::TaskConfig => "Task Config",
         ModelComponent::SpatialUpscaler => "Spatial Upscaler",
         ModelComponent::TemporalUpscaler => "Temporal Upscaler",
         ModelComponent::DistilledLora => "Distilled LoRA",

--- a/crates/mold-cli/src/ui.rs
+++ b/crates/mold-cli/src/ui.rs
@@ -20,6 +20,7 @@ pub(crate) fn family_label(family: &str) -> &str {
         "wuerstchen" | "wuerstchen-v2" => "Wuerstchen",
         "ltx-video" | "ltx_video" => "LTX Video",
         "ltx2" => "LTX-2",
+        "minimax-h3" | "minimax_h3" | "minimaxh3" => "MiniMax H3",
         "controlnet" => "ControlNet",
         "qwen3-expand" => "Expand",
         "upscaler" => "Upscaler",
@@ -40,6 +41,7 @@ pub(crate) fn format_family_padded(family: &str, width: usize) -> String {
         "wuerstchen" | "wuerstchen-v2" => padded.bright_yellow().to_string(),
         "ltx-video" | "ltx_video" => padded.red().to_string(),
         "ltx2" => padded.truecolor(255, 140, 80).to_string(),
+        "minimax-h3" | "minimax_h3" | "minimaxh3" => padded.truecolor(80, 190, 255).to_string(),
         "controlnet" => padded.bright_red().to_string(),
         "qwen3-expand" => padded.bright_cyan().to_string(),
         "upscaler" => padded.bright_purple().to_string(),
@@ -65,6 +67,9 @@ pub(crate) fn format_family(family: &str) -> String {
             | "ltx-video"
             | "ltx_video"
             | "ltx2"
+            | "minimax-h3"
+            | "minimax_h3"
+            | "minimaxh3"
             | "controlnet"
             | "qwen3-expand"
             | "upscaler"

--- a/crates/mold-core/src/catalog.rs
+++ b/crates/mold-core/src/catalog.rs
@@ -96,6 +96,7 @@ pub fn build_model_catalog(
                 default_height: model_cfg.effective_height(config),
                 default_frames: model_cfg.effective_frames(),
                 default_fps: model_cfg.effective_fps(),
+                min_frames: crate::validation::min_frames_for_family(&manifest.family),
                 max_frames: crate::validation::max_frames_for_family_at_fps(
                     &manifest.family,
                     model_cfg
@@ -109,6 +110,7 @@ pub fn build_model_catalog(
                     &manifest.family,
                 ),
                 frame_step: crate::validation::frame_step_for_family(&manifest.family),
+                frame_offset: crate::validation::frame_offset_for_family(&manifest.family),
                 max_pixels: resolution.max_pixels,
                 max_axis_pixels: resolution.max_axis_pixels,
                 recommended_dimensions: resolution.recommended_dimensions,
@@ -201,6 +203,7 @@ pub fn build_model_catalog(
                 default_height: model_cfg.effective_height(config),
                 default_frames: model_cfg.effective_frames(),
                 default_fps: model_cfg.effective_fps(),
+                min_frames: crate::validation::min_frames_for_family(&family),
                 max_frames: crate::validation::max_frames_for_family_at_fps(
                     &family,
                     model_cfg
@@ -210,6 +213,7 @@ pub fn build_model_catalog(
                 max_runtime_seconds: crate::validation::max_runtime_seconds_for_family(&family),
                 max_frames_absolute: crate::validation::max_frames_absolute_for_family(&family),
                 frame_step: crate::validation::frame_step_for_family(&family),
+                frame_offset: crate::validation::frame_offset_for_family(&family),
                 max_pixels: resolution.max_pixels,
                 max_axis_pixels: resolution.max_axis_pixels,
                 recommended_dimensions: resolution.recommended_dimensions,

--- a/crates/mold-core/src/config.rs
+++ b/crates/mold-core/src/config.rs
@@ -1777,6 +1777,15 @@ fn resolved_manifest_paths_exist(
             .text_tokenizer
             .as_ref()
             .is_some_and(|path| path.exists()),
+        // H3 remains contract-only. ModelPaths does not yet carry these
+        // components, so a manifest can never be mistaken for runnable merely
+        // because the legacy transformer/VAE subset exists.
+        ModelComponent::AudioVae
+        | ModelComponent::Processor
+        | ModelComponent::VideoScheduler
+        | ModelComponent::AudioScheduler
+        | ModelComponent::ModelConfig
+        | ModelComponent::TaskConfig => false,
         ModelComponent::Decoder => paths.decoder.as_ref().is_some_and(|path| path.exists()),
         ModelComponent::Upscaler => paths.transformer.exists(),
     })

--- a/crates/mold-core/src/download.rs
+++ b/crates/mold-core/src/download.rs
@@ -11,6 +11,14 @@ use thiserror::Error;
 use crate::manifest::{paths_from_downloads, ModelComponent, ModelFile, ModelManifest};
 use crate::ModelPaths;
 
+fn hf_model_repo(repo_id: &str) -> Repo {
+    if let Some(revision) = crate::minimax_h3::repo_revision(repo_id) {
+        Repo::with_revision(repo_id.to_string(), RepoType::Model, revision.to_string())
+    } else {
+        Repo::new(repo_id.to_string(), RepoType::Model)
+    }
+}
+
 /// Callback-based download progress event.
 #[derive(Debug, Clone)]
 pub enum DownloadProgressEvent {
@@ -1263,7 +1271,7 @@ async fn download_file<P: Progress + Clone + Send + Sync + 'static>(
     progress: P,
     model_name: &str,
 ) -> Result<PathBuf, DownloadError> {
-    let repo = api.repo(Repo::new(file.hf_repo.clone(), RepoType::Model));
+    let repo = api.repo(hf_model_repo(&file.hf_repo));
 
     match repo
         .download_with_progress(&file.hf_filename, progress)
@@ -1436,7 +1444,7 @@ where
     let api = builder
         .build()
         .map_err(|e| DownloadError::SyncApiSetup(e.to_string()))?;
-    let repo = api.repo(Repo::new(hf_repo.to_string(), RepoType::Model));
+    let repo = api.repo(hf_model_repo(hf_repo));
     let hf_path = repo
         .download_with_progress(hf_filename, progress)
         .map_err(|e| {
@@ -1487,7 +1495,7 @@ where
 /// `MOLD_MODELS_DIR`, not the user's home HF cache.
 pub fn cached_file_path_in_mold_cache(hf_repo: &str, hf_filename: &str) -> Option<PathBuf> {
     let cache = Cache::new(hf_cache_dir());
-    let repo = cache.repo(Repo::new(hf_repo.to_string(), RepoType::Model));
+    let repo = cache.repo(hf_model_repo(hf_repo));
     repo.get(hf_filename)
 }
 
@@ -1523,21 +1531,21 @@ pub fn cached_file_path_in(
 
     // 2. Check new hf-cache location (~/.mold/models/.hf-cache/)
     let new_cache = Cache::new(models_root.join(".hf-cache"));
-    let new_repo = new_cache.repo(Repo::new(hf_repo.to_string(), RepoType::Model));
+    let new_repo = new_cache.repo(hf_model_repo(hf_repo));
     if let Some(path) = new_repo.get(hf_filename) {
         return Some(path);
     }
 
     // 3. Check old mold models dir (backward compat — HF cached here before .hf-cache/)
     let old_cache = Cache::new(models_root.to_path_buf());
-    let old_repo = old_cache.repo(Repo::new(hf_repo.to_string(), RepoType::Model));
+    let old_repo = old_cache.repo(hf_model_repo(hf_repo));
     if let Some(path) = old_repo.get(hf_filename) {
         return Some(path);
     }
 
     // 4. Check default HF cache (~/.cache/huggingface/hub/)
     let default_cache = Cache::from_env();
-    let default_repo = default_cache.repo(Repo::new(hf_repo.to_string(), RepoType::Model));
+    let default_repo = default_cache.repo(hf_model_repo(hf_repo));
     default_repo.get(hf_filename)
 }
 
@@ -1563,7 +1571,7 @@ pub fn cached_file_path_existing_only(
     let lookup = |root: &Path| {
         root.is_dir().then(|| {
             Cache::new(root.to_path_buf())
-                .repo(Repo::new(hf_repo.to_string(), RepoType::Model))
+                .repo(hf_model_repo(hf_repo))
                 .get(hf_filename)
         })?
     };
@@ -1571,11 +1579,10 @@ pub fn cached_file_path_existing_only(
         .or_else(|| lookup(models_root))
         .or_else(|| {
             let cache = Cache::from_env();
-            cache.path().is_dir().then(|| {
-                cache
-                    .repo(Repo::new(hf_repo.to_string(), RepoType::Model))
-                    .get(hf_filename)
-            })?
+            cache
+                .path()
+                .is_dir()
+                .then(|| cache.repo(hf_model_repo(hf_repo)).get(hf_filename))?
         })
 }
 

--- a/crates/mold-core/src/lib.rs
+++ b/crates/mold-core/src/lib.rs
@@ -22,6 +22,7 @@ pub mod ltx2_control;
 pub use ltx2_control::Ltx2ControlAdapterInfo;
 pub mod manifest;
 pub mod media_paths;
+pub mod minimax_h3;
 pub mod model_policy;
 pub mod removal;
 pub mod runpod;
@@ -53,10 +54,11 @@ pub use error::{MoldError, Result as MoldResult};
 pub use install_error::InstallError;
 pub use media_paths::{configured_media_roots, parse_media_roots_env, resolve_server_media_path};
 pub use model_policy::{
-    model_access_capabilities, model_activation, model_artifact_activation,
-    require_model_activation, require_model_artifact_activation, ModelAccessCapabilities,
-    ModelAccessRestriction, ModelActivation, ModelActivationError,
-    MINIMAX_H3_AUTHORIZATION_ISSUE_URL, MINIMAX_H3_AUTHORIZATION_REQUIRED, MINIMAX_H3_LICENSE_URL,
+    model_access_capabilities, model_activation, model_activation_available,
+    model_artifact_activation, require_model_activation, require_model_artifact_activation,
+    ModelAccessCapabilities, ModelAccessRestriction, ModelActivation, ModelActivationError,
+    MINIMAX_H3_AUTHORIZATION_ISSUE_URL, MINIMAX_H3_AUTHORIZATION_REQUIRED,
+    MINIMAX_H3_LICENSE_SHA256, MINIMAX_H3_LICENSE_URL,
 };
 pub use types::GenerateRequest;
 pub use types::Scheduler;
@@ -64,7 +66,8 @@ pub use types::*;
 pub use validation::{
     clamp_to_megapixel_limit, dimension_alignment_for_family, dimension_warning,
     dimension_warning_composed, family_supports_lora, fit_to_model_dimensions, fit_to_target_area,
-    largest_ltx2_rung_within, ltx2_output_rung, ltx2_spatial_composition, prompt_required_for,
+    fixed_fps_for_family, frame_offset_for_family, largest_ltx2_rung_within, ltx2_output_rung,
+    ltx2_spatial_composition, min_frames_for_family, prompt_required_for,
     prompt_required_with_conditioning, recommended_dimensions, recommended_dimensions_composed,
     require_generate_request_model_activation, validate_generate_request,
     validate_generate_request_with_family, validate_generation_dimensions,

--- a/crates/mold-core/src/manifest.rs
+++ b/crates/mold-core/src/manifest.rs
@@ -47,8 +47,21 @@ pub enum ModelComponent {
     ClipTokenizer2, // CLIP-G tokenizer (SDXL)
     TextEncoder,    // Generic text encoder shard (Qwen3 for Z-Image)
     TextTokenizer,  // Generic text encoder tokenizer
-    Decoder,        // Stage B decoder weights (Wuerstchen)
-    Upscaler,       // Upscaler model weights (Real-ESRGAN, etc.)
+    /// MiniMax H3 synchronized-audio VAE. Kept distinct from the video VAE.
+    AudioVae,
+    /// Tokenizer / multimodal processor data owned by a model family.
+    Processor,
+    /// Video-side scheduler configuration for a dual-modality model.
+    VideoScheduler,
+    /// Audio-side scheduler configuration for a dual-modality model.
+    AudioScheduler,
+    /// Shared architecture/configuration metadata.
+    ModelConfig,
+    /// Task-transformer configuration. Never shared across tasks; compatible
+    /// layouts of the same task may reuse one pinned config identity.
+    TaskConfig,
+    Decoder,  // Stage B decoder weights (Wuerstchen)
+    Upscaler, // Upscaler model weights (Real-ESRGAN, etc.)
 }
 
 #[derive(Debug, Clone)]
@@ -296,6 +309,7 @@ fn is_model_specific_component(component: ModelComponent) -> bool {
             | ModelComponent::LowNoiseTransformer
             | ModelComponent::DistilledLora
             | ModelComponent::LowNoiseDistilledLora
+            | ModelComponent::TaskConfig
             | ModelComponent::Upscaler
     )
 }
@@ -310,6 +324,20 @@ fn is_model_specific_component(component: ModelComponent) -> bool {
 /// creating subdirectories under the target directory.
 pub fn storage_path(manifest: &ModelManifest, file: &ModelFile) -> PathBuf {
     let sanitized_name = manifest.name.replace(':', "-");
+
+    // H3's official and Comfy transformers use the same task architecture
+    // config. Keep one copy per task across layouts while the task-specific
+    // source path (`transformer` vs `transformer_ref`) prevents cross-task
+    // substitution. The Comfy manifests intentionally omit official sharded
+    // weight indexes because those do not describe their single-file weights.
+    if manifest.family == crate::minimax_h3::FAMILY
+        && file.component == ModelComponent::TaskConfig
+        && file.hf_repo == crate::minimax_h3::OFFICIAL_REPO
+    {
+        return PathBuf::from("shared")
+            .join(crate::minimax_h3::FAMILY)
+            .join(&file.hf_filename);
+    }
 
     if is_model_specific_component(file.component) {
         PathBuf::from(&sanitized_name).join(&file.hf_filename)
@@ -1249,6 +1277,7 @@ fn build_known_manifests() -> Vec<ModelManifest> {
     manifests.extend(ltx_video_manifests());
     manifests.extend(ltx2_manifests());
     manifests.extend(wan_manifests());
+    manifests.extend(crate::minimax_h3::manifests());
     manifests.extend(ltx2_control_manifests());
     manifests.extend(ltx2_camera_control_manifests());
     manifests.extend(controlnet_manifests());
@@ -3497,6 +3526,9 @@ fn wuerstchen_manifests() -> Vec<ModelManifest> {
 /// - `flux-dev:q4` → `flux-dev:q4` (unchanged)
 /// - `flux-dev-q4` → `flux-dev:q4` (legacy format)
 pub fn resolve_model_name(input: &str) -> String {
+    if let Some(name) = crate::minimax_h3::resolve_model_name(input) {
+        return name.to_string();
+    }
     // Already has a tag
     if input.contains(':') {
         return input.to_string();
@@ -6447,7 +6479,7 @@ mod tests {
 
     #[test]
     fn known_manifests_count() {
-        // 24 FLUX + 3 SD1.5 + 4 SD3 + 8 SDXL + 4 Z-Image + 9 Flux.2 + 24 Qwen-Image/Qwen-Image-Edit + 1 Wuerstchen + 5 LTX Video + 6 LTX-2 + 6 Wan + 7 LTX-2 controls + 7 LTX-2 camera controls + 3 ControlNet + 2 Qwen3-Expand + 7 Upscaler + 20 Companion = 140
+        // 24 FLUX + 3 SD1.5 + 4 SD3 + 8 SDXL + 4 Z-Image + 9 Flux.2 + 24 Qwen-Image/Qwen-Image-Edit + 1 Wuerstchen + 5 LTX Video + 6 LTX-2 + 6 Wan + 4 compliance-hidden MiniMax H3 contracts + 7 LTX-2 controls + 7 LTX-2 camera controls + 3 ControlNet + 2 Qwen3-Expand + 7 Upscaler + 20 Companion = 144
         // Wan bump: +wan22-{t2v,i2v}-a14b:{q5,q8} — the two-expert A14B tiers.
         // Companion bump: +flux2-te, +flux2-te-9b, +flux2-vae for the
         // catalog bridge (single-file Civitai Flux.2 fine-tunes); +z-image-te
@@ -6455,7 +6487,7 @@ mod tests {
         // catalog bridge (single-file Civitai LTX-2 / LTX-2.3 fine-tunes —
         // Gemma 3 12B text encoder); +wan-umt5, +wan21-vae, +wan22-vae for
         // single-file Wan checkpoints.
-        assert_eq!(known_manifests().len(), 140);
+        assert_eq!(known_manifests().len(), 144);
     }
 
     #[test]

--- a/crates/mold-core/src/minimax_h3.rs
+++ b/crates/mold-core/src/minimax_h3.rs
@@ -1,0 +1,1997 @@
+//! Static MiniMax H3 contracts.
+//!
+//! H3 is intentionally *not* a runnable Mold family yet.  The compliance gate
+//! in `model_policy` remains the first authority for every public ingress.  This
+//! module records the immutable model/layout/request facts needed by the later
+//! engine work without weakening that gate or claiming that weights can run.
+
+use crate::manifest::{ManifestDefaults, ModelComponent, ModelFile, ModelManifest};
+use crate::{GenerateRequest, OutputFormat, MINIMAX_H3_LICENSE_SHA256, MINIMAX_H3_LICENSE_URL};
+
+pub const FAMILY: &str = "minimax-h3";
+pub const FAMILY_ALIASES: &[&str] = &["minimax-h3", "minimax_h3", "minimaxh3"];
+
+pub const OFFICIAL_REPO: &str = "MiniMaxAI/MiniMax-H3";
+pub const OFFICIAL_REVISION: &str = "bfc8ed0353f5a9733be73e6b2c98ec0948195b86";
+pub const COMFY_REPO: &str = "Comfy-Org/MiniMax-H3";
+pub const COMFY_REVISION: &str = "eb8a16107c595128b3a578f82d2ce2f75920c355";
+pub const COMFY_IMPLEMENTATION_REPO: &str = "Comfy-Org/ComfyUI";
+pub const COMFY_IMPLEMENTATION_REVISION: &str = "a464ac33588ae182f81a090d910cfbf21e255b73";
+pub const OFFICIAL_IMPLEMENTATION_REPO: &str = "MiniMax-AI/MiniMax-H3";
+pub const OFFICIAL_IMPLEMENTATION_REVISION: &str = "8d8824efaf94586c0cc9ac7ad8d0723d4d6420ea";
+pub const DIFFUSERS_REFERENCE_REPO: &str = "huggingface/diffusers";
+pub const DIFFUSERS_REFERENCE_REVISION: &str = "9c6a68c32b3b2a64db91800b624d33cec6e25ab8";
+pub const LICENSE_SHA256: &str = MINIMAX_H3_LICENSE_SHA256;
+
+pub const FL2VA_OFFICIAL: &str = "minimax-h3-fl2va:official-bf16";
+pub const REF2VA_OFFICIAL: &str = "minimax-h3-ref2va:official-bf16";
+pub const FL2VA_COMFY: &str = "minimax-h3-fl2va:comfy-pruned-int8";
+pub const REF2VA_COMFY: &str = "minimax-h3-ref2va:comfy-pruned-int8";
+
+pub const DEFAULT_WIDTH: u32 = 1344;
+pub const DEFAULT_HEIGHT: u32 = 768;
+pub const DEFAULT_STEPS: u32 = 50;
+pub const FIXED_FPS: u32 = 24;
+pub const MIN_DURATION_SECONDS: u32 = 5;
+pub const MAX_DURATION_SECONDS: u32 = 15;
+pub const MIN_FRAMES: u32 = 124;
+pub const MAX_FRAMES: u32 = 362;
+pub const FRAME_STEP: u32 = 17;
+pub const FRAME_OFFSET: u32 = 5;
+pub const DIMENSION_ALIGNMENT: u32 = 32;
+/// Short edge used by the released checkpoint's aspect-ratio resolver.
+pub const CANVAS_SHORT_EDGE: u32 = 768;
+/// Pre-rounding area budget used by the released checkpoint.
+pub const CANVAS_MAX_PIXELS: u64 = 768 * 1344;
+/// Largest post-rounding canvas produced by the official resolver over the
+/// supported 1:4 through 4:1 aspect range.
+///
+/// The official algorithm applies the area budget first, then rounds both axes
+/// independently to 32 pixels. That final rounding is explicitly allowed to
+/// exceed [`CANVAS_MAX_PIXELS`]; the 576x1856 (and transposed) canvas is the
+/// largest result at 1,069,056 pixels. Advertising the pre-rounding budget as a
+/// hard request ceiling would reject a canvas produced by the oracle itself.
+pub const MAX_PIXELS: u64 = 576 * 1856;
+pub const MIN_ASPECT_RATIO: f64 = 0.25;
+pub const MAX_ASPECT_RATIO: f64 = 4.0;
+pub const NATIVE_BATCH_SIZES: &[u32] = &[1];
+pub const CONDITION_POSTERIOR_SEED: u64 = 42;
+pub const AUDIO_SAMPLE_RATE_HZ: u32 = 32_000;
+pub const AUDIO_CHANNELS: u32 = 2;
+
+/// Seed-domain version. Changing stream names/order or seed derivation must
+/// mint a new version rather than silently changing seeded outputs.
+pub const NOISE_DOMAIN_VERSION: &str = "mold.minimax-h3.noise.v1";
+pub const NOISE_STREAMS: &[&str] = &[
+    "condition-posterior",
+    "condition-noise",
+    "target-video",
+    "target-audio",
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NoiseSeedSource {
+    /// A fresh generator is recreated for each visual condition.
+    FixedFreshPerVisualCondition(u64),
+    /// The generator seeded from the request, shared in the declared draw order.
+    RequestSeed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NoiseDrawCardinality {
+    PerVisualCondition,
+    Once,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NoiseDrawContract {
+    pub name: &'static str,
+    pub seed_source: NoiseSeedSource,
+    pub cardinality: NoiseDrawCardinality,
+}
+
+/// Ordering is part of the seeded-output contract. The condition posterior is
+/// deliberately outside the request generator: official preprocessing creates
+/// a fresh seed-42 generator for every visual condition. Condition noise then
+/// consumes the request generator in packed-condition order, followed by target
+/// video and target audio noise.
+pub const NOISE_DRAWS: &[NoiseDrawContract] = &[
+    NoiseDrawContract {
+        name: NOISE_STREAMS[0],
+        seed_source: NoiseSeedSource::FixedFreshPerVisualCondition(CONDITION_POSTERIOR_SEED),
+        cardinality: NoiseDrawCardinality::PerVisualCondition,
+    },
+    NoiseDrawContract {
+        name: NOISE_STREAMS[1],
+        seed_source: NoiseSeedSource::RequestSeed,
+        cardinality: NoiseDrawCardinality::PerVisualCondition,
+    },
+    NoiseDrawContract {
+        name: NOISE_STREAMS[2],
+        seed_source: NoiseSeedSource::RequestSeed,
+        cardinality: NoiseDrawCardinality::Once,
+    },
+    NoiseDrawContract {
+        name: NOISE_STREAMS[3],
+        seed_source: NoiseSeedSource::RequestSeed,
+        cardinality: NoiseDrawCardinality::Once,
+    },
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Task {
+    Fl2va,
+    Ref2va,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Layout {
+    OfficialBf16,
+    ComfyPrunedInt8ConvrotNvfp4Awq,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mode {
+    TextToAudioVideo,
+    FirstFrameToAudioVideo,
+    LastFrameToAudioVideo,
+    FirstAndLastFrameToAudioVideo,
+    ReferenceToAudioVideo,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BackendQualification {
+    /// The implementation target is CUDA, but no runnable engine is registered.
+    ContractTarget,
+    Unsupported,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BackendApplicability {
+    pub cuda: BackendQualification,
+    pub metal: BackendQualification,
+    pub cpu: BackendQualification,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Capabilities {
+    pub runtime_available: bool,
+    pub backends: BackendApplicability,
+    pub native_batch_sizes: &'static [u32],
+    pub modes: &'static [Mode],
+    pub synchronized_audio: bool,
+    pub audio_disable_supported: bool,
+    pub audio_sample_rate_hz: u32,
+    pub audio_channels: u32,
+    pub fixed_fps: u32,
+    pub min_duration_seconds: u32,
+    pub max_duration_seconds: u32,
+    pub frame_step: u32,
+    pub frame_offset: u32,
+    pub min_frames: u32,
+    pub max_frames: u32,
+    pub dimension_alignment: u32,
+    pub default_dimensions: (u32, u32),
+    pub min_aspect_ratio: (u32, u32),
+    pub max_aspect_ratio: (u32, u32),
+    pub max_pixels: u64,
+    pub noise_domain_version: &'static str,
+    pub noise_streams: &'static [&'static str],
+    pub noise_draws: &'static [NoiseDrawContract],
+}
+
+const FL2VA_MODES: &[Mode] = &[
+    Mode::TextToAudioVideo,
+    Mode::FirstFrameToAudioVideo,
+    Mode::LastFrameToAudioVideo,
+    Mode::FirstAndLastFrameToAudioVideo,
+];
+const REF2VA_MODES: &[Mode] = &[Mode::ReferenceToAudioVideo];
+pub const ALL_MODES: &[Mode] = &[
+    Mode::TextToAudioVideo,
+    Mode::FirstFrameToAudioVideo,
+    Mode::LastFrameToAudioVideo,
+    Mode::FirstAndLastFrameToAudioVideo,
+    Mode::ReferenceToAudioVideo,
+];
+
+pub const fn capabilities(task: Task) -> Capabilities {
+    Capabilities {
+        runtime_available: false,
+        backends: BackendApplicability {
+            cuda: BackendQualification::ContractTarget,
+            metal: BackendQualification::Unsupported,
+            cpu: BackendQualification::Unsupported,
+        },
+        native_batch_sizes: NATIVE_BATCH_SIZES,
+        modes: match task {
+            Task::Fl2va => FL2VA_MODES,
+            Task::Ref2va => REF2VA_MODES,
+        },
+        synchronized_audio: true,
+        audio_disable_supported: false,
+        audio_sample_rate_hz: AUDIO_SAMPLE_RATE_HZ,
+        audio_channels: AUDIO_CHANNELS,
+        fixed_fps: FIXED_FPS,
+        min_duration_seconds: MIN_DURATION_SECONDS,
+        max_duration_seconds: MAX_DURATION_SECONDS,
+        frame_step: FRAME_STEP,
+        frame_offset: FRAME_OFFSET,
+        min_frames: MIN_FRAMES,
+        max_frames: MAX_FRAMES,
+        dimension_alignment: DIMENSION_ALIGNMENT,
+        default_dimensions: (DEFAULT_WIDTH, DEFAULT_HEIGHT),
+        min_aspect_ratio: (1, 4),
+        max_aspect_ratio: (4, 1),
+        max_pixels: MAX_PIXELS,
+        noise_domain_version: NOISE_DOMAIN_VERSION,
+        noise_streams: NOISE_STREAMS,
+        noise_draws: NOISE_DRAWS,
+    }
+}
+
+/// Exact per-model capability authority for later server/surface advertising.
+///
+/// This contract is intentionally not serialized while H3 is policy-hidden.
+/// Callers that advertise *runnable* models must use
+/// [`runnable_capability_contract_for_model`], which returns `None` until an
+/// engine is registered and qualified. Keeping task and layout in this typed
+/// value prevents UI/server code from guessing modes from family strings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ModelCapabilityContract {
+    pub canonical_model: &'static str,
+    pub task: Task,
+    pub layout: Layout,
+    pub generation: Capabilities,
+}
+
+pub fn capability_contract_for_model(model: &str) -> Option<ModelCapabilityContract> {
+    let canonical_model = resolve_model_name(model)?;
+    let task = task_for_model(canonical_model)?;
+    let layout = layout_for_model(canonical_model)?;
+    Some(ModelCapabilityContract {
+        canonical_model,
+        task,
+        layout,
+        generation: capabilities(task),
+    })
+}
+
+/// Runtime-advertising boundary. This stays `None` for every H3 identity until
+/// the engine, device qualification, and shipping policy are all real.
+pub fn runnable_capability_contract_for_model(model: &str) -> Option<ModelCapabilityContract> {
+    let contract = capability_contract_for_model(model)?;
+    contract.generation.runtime_available.then_some(contract)
+}
+
+pub fn canonical_family(value: &str) -> Option<&'static str> {
+    let normalized = value.trim().to_ascii_lowercase();
+    FAMILY_ALIASES
+        .contains(&normalized.as_str())
+        .then_some(FAMILY)
+}
+
+pub fn is_family(value: &str) -> bool {
+    canonical_family(value).is_some()
+}
+
+pub fn repo_revision(repo: &str) -> Option<&'static str> {
+    match repo {
+        OFFICIAL_REPO => Some(OFFICIAL_REVISION),
+        COMFY_REPO => Some(COMFY_REVISION),
+        _ => None,
+    }
+}
+
+pub fn task_for_model(model: &str) -> Option<Task> {
+    let canonical = resolve_model_name(model)?;
+    if canonical.starts_with("minimax-h3-ref2va:") {
+        Some(Task::Ref2va)
+    } else if canonical.starts_with("minimax-h3-fl2va:") {
+        Some(Task::Fl2va)
+    } else {
+        None
+    }
+}
+
+pub fn layout_for_model(model: &str) -> Option<Layout> {
+    let canonical = resolve_model_name(model)?;
+    if canonical.ends_with(":official-bf16") {
+        Some(Layout::OfficialBf16)
+    } else if canonical.ends_with(":comfy-pruned-int8") {
+        Some(Layout::ComfyPrunedInt8ConvrotNvfp4Awq)
+    } else {
+        None
+    }
+}
+
+pub fn resolve_model_name(input: &str) -> Option<&'static str> {
+    let normalized = input.trim().to_ascii_lowercase().replace('_', "-");
+    match normalized.as_str() {
+        "minimax-h3" | "minimaxh3" | "minimax-h3-fl2va" => Some(FL2VA_COMFY),
+        "minimax-h3-ref2va" => Some(REF2VA_COMFY),
+        value if value == FL2VA_OFFICIAL => Some(FL2VA_OFFICIAL),
+        value if value == REF2VA_OFFICIAL => Some(REF2VA_OFFICIAL),
+        value if value == FL2VA_COMFY => Some(FL2VA_COMFY),
+        value if value == REF2VA_COMFY => Some(REF2VA_COMFY),
+        _ => None,
+    }
+}
+
+pub const fn valid_frame_count(frames: u32) -> bool {
+    frames >= MIN_FRAMES
+        && frames <= MAX_FRAMES
+        && frames >= FRAME_OFFSET
+        && (frames - FRAME_OFFSET).is_multiple_of(FRAME_STEP)
+}
+
+pub fn recommended_frames(frames: u32) -> u32 {
+    if frames <= MIN_FRAMES {
+        return MIN_FRAMES;
+    }
+    if frames >= MAX_FRAMES {
+        return MAX_FRAMES;
+    }
+    let lower = FRAME_OFFSET + ((frames - FRAME_OFFSET) / FRAME_STEP) * FRAME_STEP;
+    let upper = (lower + FRAME_STEP).min(MAX_FRAMES);
+    if frames - lower <= upper - frames {
+        lower.max(MIN_FRAMES)
+    } else {
+        upper
+    }
+}
+
+pub fn recommended_dimensions(width: u32, height: u32) -> (u32, u32) {
+    if width == 0 || height == 0 {
+        return (DEFAULT_WIDTH, DEFAULT_HEIGHT);
+    }
+    let aspect = (width as f64 / height as f64).clamp(MIN_ASPECT_RATIO, MAX_ASPECT_RATIO);
+    let short_edge = f64::from(CANVAS_SHORT_EDGE);
+    let (mut target_width, mut target_height) = if aspect >= 1.0 {
+        (short_edge * aspect, short_edge)
+    } else {
+        (short_edge, short_edge / aspect)
+    };
+    let area = target_width * target_height;
+    if area > CANVAS_MAX_PIXELS as f64 {
+        let scale = (CANVAS_MAX_PIXELS as f64 / area).sqrt();
+        target_width *= scale;
+        target_height *= scale;
+    }
+    let round_axis = |axis: f64| {
+        ((axis / f64::from(DIMENSION_ALIGNMENT))
+            .round_ties_even()
+            .max(1.0) as u32)
+            * DIMENSION_ALIGNMENT
+    };
+    (round_axis(target_width), round_axis(target_height))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContractError {
+    pub code: &'static str,
+    pub message: String,
+    pub recommended_frames: Option<u32>,
+    pub recommended_dimensions: Option<(u32, u32)>,
+}
+
+impl std::fmt::Display for ContractError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for ContractError {}
+
+fn violation(code: &'static str, message: impl Into<String>) -> ContractError {
+    ContractError {
+        code,
+        message: message.into(),
+        recommended_frames: None,
+        recommended_dimensions: None,
+    }
+}
+
+/// Validate the H3-specific part of a normalized generation request.
+///
+/// Public generation paths must call `require_model_activation` first.  This
+/// helper is intentionally available for table tests and future engine work;
+/// it does not authorize H3 or bypass the compliance gate.
+pub fn validate_request_contract(req: &GenerateRequest, task: Task) -> Result<Mode, ContractError> {
+    let fps = req.fps.unwrap_or(FIXED_FPS);
+    if fps != FIXED_FPS {
+        return Err(violation(
+            "MINIMAX_H3_FIXED_FPS",
+            format!("MiniMax H3 requires {FIXED_FPS} fps; received {fps}"),
+        ));
+    }
+
+    let frames = req.frames.unwrap_or(MIN_FRAMES);
+    if !valid_frame_count(frames) {
+        let mut error = violation(
+            "MINIMAX_H3_FRAME_GRID",
+            format!(
+                "MiniMax H3 frames must be {FRAME_STEP}n+{FRAME_OFFSET} from {MIN_FRAMES} through {MAX_FRAMES}; received {frames}"
+            ),
+        );
+        error.recommended_frames = Some(recommended_frames(frames));
+        return Err(error);
+    }
+
+    if req.width == 0
+        || req.height == 0
+        || !req.width.is_multiple_of(DIMENSION_ALIGNMENT)
+        || !req.height.is_multiple_of(DIMENSION_ALIGNMENT)
+        || u64::from(req.width) * u64::from(req.height) > MAX_PIXELS
+        || !(MIN_ASPECT_RATIO..=MAX_ASPECT_RATIO).contains(&(req.width as f64 / req.height as f64))
+    {
+        let mut error = violation(
+            "MINIMAX_H3_DIMENSIONS",
+            format!(
+                "MiniMax H3 dimensions must be positive multiples of {DIMENSION_ALIGNMENT}, at most {MAX_PIXELS} pixels, with aspect ratio in [{MIN_ASPECT_RATIO}, {MAX_ASPECT_RATIO}]"
+            ),
+        );
+        error.recommended_dimensions = Some(recommended_dimensions(req.width, req.height));
+        return Err(error);
+    }
+
+    if req.enable_audio == Some(false) {
+        return Err(violation(
+            "MINIMAX_H3_SYNCHRONIZED_AUDIO_REQUIRED",
+            "MiniMax H3 always generates synchronized audio; enable_audio=false is unsupported",
+        ));
+    }
+    if req
+        .output_format
+        .is_some_and(|format| format != OutputFormat::Mp4)
+    {
+        return Err(violation(
+            "MINIMAX_H3_MP4_REQUIRED",
+            "MiniMax H3 synchronized audio-video output requires mp4",
+        ));
+    }
+    if req.guidance != 0.0 {
+        return Err(violation(
+            "MINIMAX_H3_NO_CFG",
+            "MiniMax H3 does not use classifier-free guidance; guidance must be 0",
+        ));
+    }
+    if req
+        .negative_prompt
+        .as_deref()
+        .is_some_and(|value| !value.trim().is_empty())
+    {
+        return Err(violation(
+            "MINIMAX_H3_NO_NEGATIVE_PROMPT",
+            "MiniMax H3 has no negative-prompt branch",
+        ));
+    }
+    if req.source_video.is_some()
+        || req.source_video_path.is_some()
+        || req.audio_file.is_some()
+        || req.audio_file_path.is_some()
+        || req.retake_range.is_some()
+        || req.is_extend()
+    {
+        return Err(violation(
+            "MINIMAX_H3_CONDITIONING_UNSUPPORTED",
+            "MiniMax H3 supports text, FL2VA boundary frames, or Ref2VA references; source video/audio, retake, and extend are unsupported",
+        ));
+    }
+
+    match task {
+        Task::Ref2va => {
+            if req.source_image.is_some() || req.keyframes.as_ref().is_some_and(|v| !v.is_empty()) {
+                return Err(violation(
+                    "MINIMAX_H3_TASK_MISMATCH",
+                    "Ref2VA accepts reference inputs, not FL2VA boundary frames",
+                ));
+            }
+            if req
+                .edit_images
+                .as_ref()
+                .is_none_or(|items| items.is_empty())
+            {
+                return Err(violation(
+                    "MINIMAX_H3_REFERENCE_REQUIRED",
+                    "Ref2VA requires at least one reference image",
+                ));
+            }
+            Ok(Mode::ReferenceToAudioVideo)
+        }
+        Task::Fl2va => {
+            if req
+                .edit_images
+                .as_ref()
+                .is_some_and(|items| !items.is_empty())
+            {
+                return Err(violation(
+                    "MINIMAX_H3_TASK_MISMATCH",
+                    "FL2VA does not accept Ref2VA reference inputs",
+                ));
+            }
+            let last = frames - 1;
+            let mut first = req.source_image.is_some();
+            let mut end = false;
+            for keyframe in req.keyframes.as_deref().unwrap_or_default() {
+                match keyframe.frame {
+                    0 if !first => first = true,
+                    0 => {
+                        return Err(violation(
+                            "MINIMAX_H3_DUPLICATE_BOUNDARY",
+                            "FL2VA received more than one first-frame condition",
+                        ))
+                    }
+                    frame if frame == last && !end => end = true,
+                    frame if frame == last => {
+                        return Err(violation(
+                            "MINIMAX_H3_DUPLICATE_BOUNDARY",
+                            "FL2VA received more than one last-frame condition",
+                        ))
+                    }
+                    frame => {
+                        return Err(violation(
+                            "MINIMAX_H3_BOUNDARY_FRAME_REQUIRED",
+                            format!(
+                                "FL2VA keyframes may target only frame 0 or final frame {last}; received {frame}"
+                            ),
+                        ))
+                    }
+                }
+            }
+            Ok(match (first, end) {
+                (false, false) => Mode::TextToAudioVideo,
+                (true, false) => Mode::FirstFrameToAudioVideo,
+                (false, true) => Mode::LastFrameToAudioVideo,
+                (true, true) => Mode::FirstAndLastFrameToAudioVideo,
+            })
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArtifactRole {
+    TaskTransformer,
+    Qwen3VlConditioner,
+    VideoVae,
+    AudioVae,
+    Processor,
+    VideoScheduler,
+    AudioScheduler,
+    SharedConfig,
+    TaskConfig,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ManifestContract<'a> {
+    pub manifest_name: &'a str,
+    pub task: Task,
+    pub layout: Layout,
+    pub source_repo: &'static str,
+    pub source_revision: &'static str,
+    pub license_url: &'static str,
+    pub license_sha256: &'static str,
+    pub implementation_repo: &'static str,
+    pub implementation_revision: &'static str,
+    pub diffusers_reference_repo: &'static str,
+    pub diffusers_reference_revision: &'static str,
+    pub shared_identity_scheme: &'static str,
+    pub runtime_available: bool,
+}
+
+pub fn manifest_contract(manifest: &ModelManifest) -> Option<ManifestContract<'_>> {
+    if manifest.family != FAMILY {
+        return None;
+    }
+    let task = task_for_model(&manifest.name)?;
+    let layout = layout_for_model(&manifest.name)?;
+    let (source_repo, source_revision, implementation_repo, implementation_revision) = match layout
+    {
+        Layout::OfficialBf16 => (
+            OFFICIAL_REPO,
+            OFFICIAL_REVISION,
+            OFFICIAL_IMPLEMENTATION_REPO,
+            OFFICIAL_IMPLEMENTATION_REVISION,
+        ),
+        Layout::ComfyPrunedInt8ConvrotNvfp4Awq => (
+            COMFY_REPO,
+            COMFY_REVISION,
+            COMFY_IMPLEMENTATION_REPO,
+            COMFY_IMPLEMENTATION_REVISION,
+        ),
+    };
+    Some(ManifestContract {
+        manifest_name: &manifest.name,
+        task,
+        layout,
+        source_repo,
+        source_revision,
+        license_url: MINIMAX_H3_LICENSE_URL,
+        license_sha256: LICENSE_SHA256,
+        implementation_repo,
+        implementation_revision,
+        diffusers_reference_repo: DIFFUSERS_REFERENCE_REPO,
+        diffusers_reference_revision: DIFFUSERS_REFERENCE_REVISION,
+        shared_identity_scheme: "hf-repo+revision+path+sha256",
+        runtime_available: capabilities(task).runtime_available,
+    })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ArtifactIdentity<'a> {
+    pub source_repo: &'a str,
+    pub source_revision: &'static str,
+    pub source_path: &'a str,
+    pub sha256: &'static str,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ArtifactContract<'a> {
+    pub identity: ArtifactIdentity<'a>,
+    pub role: ArtifactRole,
+    pub license_url: &'static str,
+    pub license_sha256: &'static str,
+    pub dtype: &'static str,
+    pub shape: &'static str,
+    pub compatible_tasks: &'static [Task],
+}
+
+const BOTH_TASKS: &[Task] = &[Task::Fl2va, Task::Ref2va];
+const FL2VA_ONLY: &[Task] = &[Task::Fl2va];
+const REF2VA_ONLY: &[Task] = &[Task::Ref2va];
+
+pub fn artifact_contract<'a>(
+    manifest: &'a ModelManifest,
+    file: &'a ModelFile,
+) -> Option<ArtifactContract<'a>> {
+    if manifest.family != FAMILY {
+        return None;
+    }
+    if !manifest.files.iter().any(|candidate| {
+        candidate.hf_repo == file.hf_repo
+            && candidate.hf_filename == file.hf_filename
+            && candidate.component == file.component
+            && candidate.size_bytes == file.size_bytes
+            && candidate.gated == file.gated
+            && candidate.sha256 == file.sha256
+    }) {
+        return None;
+    }
+    let task = task_for_model(&manifest.name)?;
+    let layout = layout_for_model(&manifest.name)?;
+    let compatible_tasks = if matches!(
+        file.component,
+        ModelComponent::Transformer | ModelComponent::TransformerShard | ModelComponent::TaskConfig
+    ) {
+        match task {
+            Task::Fl2va => FL2VA_ONLY,
+            Task::Ref2va => REF2VA_ONLY,
+        }
+    } else {
+        BOTH_TASKS
+    };
+    let (role, dtype, shape) = match file.component {
+        ModelComponent::Transformer | ModelComponent::TransformerShard => (
+            ArtifactRole::TaskTransformer,
+            match layout {
+                Layout::OfficialBf16 => "bf16",
+                Layout::ComfyPrunedInt8ConvrotNvfp4Awq => "int8-convrot-pruned",
+            },
+            "50 blocks; hidden=5376; 56 heads x 128",
+        ),
+        ModelComponent::TextEncoder => (
+            ArtifactRole::Qwen3VlConditioner,
+            match layout {
+                Layout::OfficialBf16 => "bf16",
+                Layout::ComfyPrunedInt8ConvrotNvfp4Awq => "nvfp4-awq",
+            },
+            "Qwen3-VL-32B; H3 hidden-state contract",
+        ),
+        ModelComponent::Vae => (
+            ArtifactRole::VideoVae,
+            match layout {
+                Layout::OfficialBf16 => "fp32",
+                Layout::ComfyPrunedInt8ConvrotNvfp4Awq => "fp16",
+            },
+            "24 latent channels; spatial /16; temporal 17->5 (+2)",
+        ),
+        ModelComponent::AudioVae => (
+            ArtifactRole::AudioVae,
+            "fp32",
+            "32 kHz stereo; 40 latent rows/second",
+        ),
+        ModelComponent::Processor => (
+            ArtifactRole::Processor,
+            "data",
+            "Qwen3-VL tokenizer/processor",
+        ),
+        ModelComponent::VideoScheduler => (
+            ArtifactRole::VideoScheduler,
+            "config",
+            "rectified-flow Euler; video shift=12",
+        ),
+        ModelComponent::AudioScheduler => (
+            ArtifactRole::AudioScheduler,
+            "config",
+            "rectified-flow Euler; audio shift=3",
+        ),
+        ModelComponent::ModelConfig => (
+            ArtifactRole::SharedConfig,
+            "config",
+            "official module config",
+        ),
+        ModelComponent::TaskConfig => (
+            ArtifactRole::TaskConfig,
+            "config",
+            "task transformer config/index",
+        ),
+        _ => return None,
+    };
+    Some(ArtifactContract {
+        identity: ArtifactIdentity {
+            source_repo: &file.hf_repo,
+            source_revision: repo_revision(&file.hf_repo)?,
+            source_path: &file.hf_filename,
+            sha256: file.sha256?,
+        },
+        role,
+        license_url: MINIMAX_H3_LICENSE_URL,
+        license_sha256: LICENSE_SHA256,
+        dtype,
+        shape,
+        compatible_tasks,
+    })
+}
+
+fn file(
+    repo: &str,
+    filename: &str,
+    component: ModelComponent,
+    size_bytes: u64,
+    sha256: &'static str,
+) -> ModelFile {
+    ModelFile {
+        hf_repo: repo.to_string(),
+        hf_filename: filename.to_string(),
+        component,
+        size_bytes,
+        gated: false,
+        sha256: Some(sha256),
+    }
+}
+
+const FL2VA_TRANSFORMER: &[(u64, &str)] = &[
+    (
+        4_825_958_704,
+        "2d847200c45c09dd7f973c1b096663068408ef851ee0b3711d059b6dc5dcd028",
+    ),
+    (
+        4_702_158_032,
+        "2c4d362eddd2802180ac9c744849eb9ba8d9c8b984bdf9822cb02ed004b29184",
+    ),
+    (
+        4_933_368_192,
+        "949c5aafbbfa5654da730a6a7fafd75adb164d0857b095a30e8bb6d390887d69",
+    ),
+    (
+        4_567_069_608,
+        "eef7616790105ee839766bb2027203bf2c0d87c6aa038dca84145a8675f5ce28",
+    ),
+    (
+        4_702_158_080,
+        "43fdf42d638e8bc6745f713fae80c93bb301807a1a5ae7249344ce28e202a494",
+    ),
+    (
+        4_933_368_232,
+        "6442510b34d173653f0cce5c964b935395a8f7accf0b9cc0aa31aec59805239d",
+    ),
+    (
+        4_567_069_608,
+        "29f48f535c91dac76496ca821eeb16ca24bc4caf3f0cae8b920a89b1f966da6d",
+    ),
+    (
+        4_702_158_080,
+        "c711b096c764bd60f0b8b6ad49518bfab6d614fb788c725add8741c0674a4cd8",
+    ),
+    (
+        4_933_368_232,
+        "44428defe3976cbb87635ad200b958199e739986697cd29fdf27aeb7294b5944",
+    ),
+    (
+        4_567_069_608,
+        "3d44939c374c9da382e9c6877e1946adf7b84e08c7a881c068f228d6849411c9",
+    ),
+    (
+        4_702_158_080,
+        "224d24430b58127a5577721084e0e704a0e74ec96dd7c35bc6fc0994ebd87c33",
+    ),
+    (
+        4_933_368_232,
+        "48fa2bd8fe134eef565ab2464f1c2589a6657cba0d14283dfc06b532f8961f3c",
+    ),
+    (
+        4_567_069_608,
+        "be5b4b1809f9d546ffd4b3fcf41e5c1e02b819125caa6bc105c109b04c051bd3",
+    ),
+    (
+        4_644_161_920,
+        "8fbd5e6c1fb1df7ce988ca90f3d59e7610e465c7517e4b344eda4a214ba4b97d",
+    ),
+];
+
+const REF2VA_TRANSFORMER: &[(u64, &str)] = &[
+    (
+        4_825_958_704,
+        "7a3fcad885f51560e550b2e84c9a8d8b35e62996cfd9076937e992bd23478df9",
+    ),
+    (
+        4_702_158_032,
+        "1638ae1dc8ae26c4ba43ad28a6d851ad8983847324bb2b468719c7c81f219706",
+    ),
+    (
+        4_933_368_192,
+        "1ef3c4954ffe5a664c2e3028e2a3241190d9c159dce6ba1136002c6af1db5353",
+    ),
+    (
+        4_567_069_608,
+        "12d92f2975cfd5c5b786126385c52e5bf64884d4b4d6e60c3ef5d857c3f7469f",
+    ),
+    (
+        4_702_158_080,
+        "304d41ce03d59ac94bceb055935bf4e034df0badf8b0df4ded327c08a288a4cc",
+    ),
+    (
+        4_933_368_232,
+        "12a134b7c76d86edbe8fa2dc315f6cdaf4e1aca1b6ea4dfe4cad92df03d42eeb",
+    ),
+    (
+        4_567_069_608,
+        "b96395261359937c00fb42f4eb29306dc59b1a3368eeba52af4fb66e3e142c69",
+    ),
+    (
+        4_702_158_080,
+        "1897a6bf3b4fc834bb82d73ca02a7afc7d38c07f50ec5382cd54cd2f91b604d1",
+    ),
+    (
+        4_933_368_232,
+        "edfb38235adc96b99f55a401849befce59075a745e99c2d8c63ff358dd36443d",
+    ),
+    (
+        4_567_069_608,
+        "f8710775cf3413670edd7e23861b650a3431a71a6cc14cb1080623ab6b052385",
+    ),
+    (
+        4_702_158_080,
+        "9e18acc09f84edb5b34df9628efa15cfcab8bb76e8e20c1c2e979a107a0f7215",
+    ),
+    (
+        4_933_368_232,
+        "ea2e18228f8bdba1a4e0f32b155e4586df055997c45356213d05b971ba13e2f4",
+    ),
+    (
+        4_567_069_608,
+        "1e12083b1875678f7414ff55b09cd8bb1c30b861243f9bb7ff1e75b6ad3f1bdc",
+    ),
+    (
+        4_644_161_920,
+        "b340f44b5690cc745d48ae399381ec15b26a4fe25d483f677ccb4960dadb50d4",
+    ),
+];
+
+const TEXT_ENCODER: &[(u64, &str)] = &[
+    (
+        4_932_328_944,
+        "6b9dfbc930e505402ae9d7e5091a9d7d656cda5f34614f01cfe70bfb0cca27cb",
+    ),
+    (
+        4_875_990_528,
+        "d8bb44b4ff303fe76fe9e894022fb3dc71b15a2e716592790fe0e3c3e60478fa",
+    ),
+    (
+        4_875_990_552,
+        "54f22e8b3168f8dc962fac0d313607ebf52a12b433d4cf3098a0d82d9f042940",
+    ),
+    (
+        4_875_990_584,
+        "ad09c74d3c13ee29b5d0d84548fd8a3424a651564eaccd519946c296e59c557f",
+    ),
+    (
+        4_875_990_584,
+        "fc993c8a0e2a5b0570f383e1a95dc3a1281d1b224b6f3ee908f4827941e1dfc2",
+    ),
+    (
+        4_875_990_584,
+        "82f05620d1f718a90c362b221d6a184ff1a0f53301d706882d3df49695fa1974",
+    ),
+    (
+        4_875_990_584,
+        "fb91da8cb01ff4de3eef0eab1c3e769a734b3a1aafc61734068638a0d6c86934",
+    ),
+    (
+        4_875_990_584,
+        "431ca56535c8781944ce3801f5eb61c45531e853ecc5846d936ebaf4761b764f",
+    ),
+    (
+        4_875_990_584,
+        "3825e3f4302f4d2f7d76aa7430d2ce0864fde6b9e540a5806bf0d8e38e4d9f47",
+    ),
+    (
+        4_875_990_584,
+        "aded5a4d1d5e22dbd8b6f79266b6eb88c840411b09527c53917a1419ace22e2f",
+    ),
+    (
+        4_875_990_584,
+        "3820ffe8d8d6477f6fe8d614ef3c87abb264ee39accebf43a1507b970d80946f",
+    ),
+    (
+        4_875_990_584,
+        "05ad2d08ce71963121c9b03f1d9ec5d7641052f4b23c6c12b80d71065eb8e98e",
+    ),
+    (
+        4_875_990_584,
+        "b64f2289871261fdd1abbd3b78bcd66011b341de3dc8eeb2ed1a473ee7c8d95c",
+    ),
+    (
+        3_270_697_008,
+        "e45b6c9998c77ee5a6577f9f47bc76416c1d4d387169e50c4c9d3134ea51b13b",
+    ),
+];
+
+fn official_shared_files() -> Vec<ModelFile> {
+    let mut files: Vec<_> = TEXT_ENCODER
+        .iter()
+        .enumerate()
+        .map(|(index, (size, sha))| {
+            file(
+                OFFICIAL_REPO,
+                &format!("text_encoder/model-{:05}-of-00014.safetensors", index + 1),
+                ModelComponent::TextEncoder,
+                *size,
+                sha,
+            )
+        })
+        .collect();
+    files.extend([
+        file(
+            OFFICIAL_REPO,
+            "vae/diffusion_pytorch_model-00001-of-00003.safetensors",
+            ModelComponent::Vae,
+            5_061_033_024,
+            "72f4c6be84ac0674f27398cde991dd9d719762f3952c4921aa66b2ce542f6374",
+        ),
+        file(
+            OFFICIAL_REPO,
+            "vae/diffusion_pytorch_model-00002-of-00003.safetensors",
+            ModelComponent::Vae,
+            4_955_986_528,
+            "2e05e8bc23fa4071043e17fd242be8acd0685e781a43987432b2eae925be4198",
+        ),
+        file(
+            OFFICIAL_REPO,
+            "vae/diffusion_pytorch_model-00003-of-00003.safetensors",
+            ModelComponent::Vae,
+            398_539_336,
+            "c05d6ac4b1a33de372799d708531da6320f6a3ce6d1ce6d895e770988e004a39",
+        ),
+        file(
+            OFFICIAL_REPO,
+            "audio_vae/diffusion_pytorch_model.safetensors",
+            ModelComponent::AudioVae,
+            605_429_340,
+            "52c59e67ba8de5477c81bfbced0327aabf500f1bfdeefd5ee754529241cb26cb",
+        ),
+        file(
+            OFFICIAL_REPO,
+            "model_index.json",
+            ModelComponent::ModelConfig,
+            2_936,
+            "5a587fe13b2371427415ac892463142683aefcd8d322e274a3a095eac37ac7d2",
+        ),
+        file(
+            OFFICIAL_REPO,
+            "modular_model_index.json",
+            ModelComponent::ModelConfig,
+            2_935,
+            "a2b6a210e482ffb78e613b553f570c44e101afce6741bd4ed91429d0559af031",
+        ),
+        file(
+            OFFICIAL_REPO,
+            "text_encoder/config.json",
+            ModelComponent::ModelConfig,
+            1_474,
+            "d2dd0c60d01b9e195d9447c52da61c7302d28828524914c044d9c6e1b81d0427",
+        ),
+        file(
+            OFFICIAL_REPO,
+            "text_encoder/model.safetensors.index.json",
+            ModelComponent::ModelConfig,
+            97_831,
+            "06c952c569285870b811989b794b9766493e280fb77fbcb957fc4e5fcf25403a",
+        ),
+        file(
+            OFFICIAL_REPO,
+            "vae/config.json",
+            ModelComponent::ModelConfig,
+            2_011,
+            "78f67deec3d63aae807f2bfe7154bc1e26f6372cb20b63265fcbae1b62bb5745",
+        ),
+        file(
+            OFFICIAL_REPO,
+            "vae/diffusion_pytorch_model.safetensors.index.json",
+            ModelComponent::ModelConfig,
+            74_228,
+            "15f6d44553c3c616b0dc999920aa784f92ecee7e4201f1f99ac405cfbf3061ca",
+        ),
+        file(
+            OFFICIAL_REPO,
+            "audio_vae/config.json",
+            ModelComponent::ModelConfig,
+            2_271,
+            "9a3c645ff892b376c6f5f4c8685964cd75474731af594ff058492a0000caabb6",
+        ),
+        file(
+            OFFICIAL_REPO,
+            "scheduler/scheduler_config.json",
+            ModelComponent::VideoScheduler,
+            97,
+            "8fa6c3aa70dc9e691e1a6df899fd1b6f75f70481a27cee6e18a303817075c304",
+        ),
+        file(
+            OFFICIAL_REPO,
+            "audio_scheduler/scheduler_config.json",
+            ModelComponent::AudioScheduler,
+            96,
+            "804780f7133477067bd6bbfbc02dc8b3cf9feeb400f97c08f5b1d5f6cbab3840",
+        ),
+        file(
+            OFFICIAL_REPO,
+            "processor/chat_template.json",
+            ModelComponent::Processor,
+            5_499,
+            "5c72a170d2a4a1a3bc5adad2e689ae28138a9700e5b8c96c0266331e86c0acce",
+        ),
+        file(
+            OFFICIAL_REPO,
+            "processor/merges.txt",
+            ModelComponent::Processor,
+            1_671_839,
+            "599bab54075088774b1733fde865d5bd747cbcc7a547c5bc12610e874e26f5e3",
+        ),
+        file(
+            OFFICIAL_REPO,
+            "processor/preprocessor_config.json",
+            ModelComponent::Processor,
+            390,
+            "27225450ac9c6529872ee1924fcb0962ff5634834f817040f444118116f4e516",
+        ),
+        file(
+            OFFICIAL_REPO,
+            "processor/tokenizer.json",
+            ModelComponent::Processor,
+            7_032_403,
+            "a5d85b6dcc535e6b93115a9ef287e6132fdbf30270da6218194ba742261173c7",
+        ),
+        file(
+            OFFICIAL_REPO,
+            "processor/tokenizer_config.json",
+            ModelComponent::Processor,
+            11_003,
+            "a07e942ac874baa13758de8d1fbdb186683cc03416b5589e1b6671c6b3057c68",
+        ),
+        file(
+            OFFICIAL_REPO,
+            "processor/video_preprocessor_config.json",
+            ModelComponent::Processor,
+            385,
+            "7768af27c1fafa9cc9011c1dc20067e03f8915e03b63504550e11d5066986d13",
+        ),
+        file(
+            OFFICIAL_REPO,
+            "processor/vocab.json",
+            ModelComponent::Processor,
+            2_776_833,
+            "ca10d7e9fb3ed18575dd1e277a2579c16d108e32f27439684afa0e10b1440910",
+        ),
+    ]);
+    files
+}
+
+fn official_files(task: Task) -> Vec<ModelFile> {
+    let (directory, shards) = match task {
+        Task::Fl2va => ("transformer", FL2VA_TRANSFORMER),
+        Task::Ref2va => ("transformer_ref", REF2VA_TRANSFORMER),
+    };
+    let mut files: Vec<_> = shards
+        .iter()
+        .enumerate()
+        .map(|(index, (size, sha))| {
+            file(
+                OFFICIAL_REPO,
+                &format!(
+                    "{directory}/diffusion_pytorch_model-{:05}-of-00014.safetensors",
+                    index + 1
+                ),
+                ModelComponent::TransformerShard,
+                *size,
+                sha,
+            )
+        })
+        .collect();
+    files.push(official_task_config(task));
+    files.push(file(
+        OFFICIAL_REPO,
+        &format!("{directory}/diffusion_pytorch_model.safetensors.index.json"),
+        ModelComponent::TaskConfig,
+        64_488,
+        "ac30a3b58963f2e735d493475fbb81853a5735ec947619648b3e045acda6783e",
+    ));
+    files.extend(official_shared_files());
+    files
+}
+
+/// The task architecture config is valid for both the official and Comfy
+/// weight layouts. It is deliberately separate from each task's sharded
+/// weight index: the latter describes only the official BF16 files and must
+/// never be attached to a Comfy single-file transformer.
+fn official_task_config(task: Task) -> ModelFile {
+    let directory = match task {
+        Task::Fl2va => "transformer",
+        Task::Ref2va => "transformer_ref",
+    };
+    file(
+        OFFICIAL_REPO,
+        &format!("{directory}/config.json"),
+        ModelComponent::TaskConfig,
+        546,
+        "74c11bff524336576096993cbfcdcdc2ef4fa2fa4409df693bdcbc6c666282ae",
+    )
+}
+
+/// Pinned non-weight runtime assets reused by the Comfy layouts.
+///
+/// ComfyUI supplies equivalent tokenizer code/data from its Python package,
+/// but Mold is a standalone binary and cannot assume that package exists.
+/// Reuse the official model's exact processor and architecture/scheduler
+/// files. Root model indexes and sharded-weight indexes are excluded because
+/// they describe the official BF16 weight graph, not the Comfy layout.
+fn official_runtime_support_files() -> Vec<ModelFile> {
+    official_shared_files()
+        .into_iter()
+        .filter(|file| match file.component {
+            ModelComponent::Processor
+            | ModelComponent::VideoScheduler
+            | ModelComponent::AudioScheduler => true,
+            ModelComponent::ModelConfig => matches!(
+                file.hf_filename.as_str(),
+                "text_encoder/config.json" | "vae/config.json" | "audio_vae/config.json"
+            ),
+            _ => false,
+        })
+        .collect()
+}
+
+fn comfy_files(task: Task) -> Vec<ModelFile> {
+    let (filename, transformer_sha) = match task {
+        Task::Fl2va => (
+            "diffusion_models/minimax_h3_fl2va_pruned_int8_convrot.safetensors",
+            "e889202c41dafb67b10d67b97f0d8541508036a6090af23425a5c2615d03c47a",
+        ),
+        Task::Ref2va => (
+            "diffusion_models/minimax_h3_ref2va_pruned_int8_convrot.safetensors",
+            "9255f52b6677845ad238f20dfaafa94727053694127ab7f255c048f0f9365779",
+        ),
+    };
+    let mut files = vec![
+        file(
+            COMFY_REPO,
+            filename,
+            ModelComponent::Transformer,
+            20_970_379_616,
+            transformer_sha,
+        ),
+        file(
+            COMFY_REPO,
+            "text_encoders/qwen3vl_32b_minimax_h3_nvfp4_awq.safetensors",
+            ModelComponent::TextEncoder,
+            15_687_142_551,
+            "35a88d51044231fe332301d7a62aa81e3f2cba62febeb446e2c1e3e0ef76f2c6",
+        ),
+        file(
+            COMFY_REPO,
+            "vae/minimax_h3_video_vae_fp16.safetensors",
+            ModelComponent::Vae,
+            5_207_808_496,
+            "7c1f131492e7eddacaac9069a61b81bdd39de5cc96561e677c5eab1cdce5e522",
+        ),
+        file(
+            COMFY_REPO,
+            "vae/minimax_h3_audio_vae_fp32.safetensors",
+            ModelComponent::AudioVae,
+            605_254_808,
+            "8e505d95dd1561d47abd43d4238fd40d9bb1ae9e147ed0a4cba778d76ae4db48",
+        ),
+    ];
+    files.push(official_task_config(task));
+    files.extend(official_runtime_support_files());
+    files
+}
+
+fn defaults() -> ManifestDefaults {
+    ManifestDefaults {
+        steps: DEFAULT_STEPS,
+        guidance: 0.0,
+        width: DEFAULT_WIDTH,
+        height: DEFAULT_HEIGHT,
+        is_schnell: false,
+        scheduler: None,
+        negative_prompt: None,
+        frames: Some(MIN_FRAMES),
+        fps: Some(FIXED_FPS),
+    }
+}
+
+/// Hidden manifests used for exact identity, storage, and future engine work.
+/// They must remain hidden while `capabilities(...).runtime_available` is false.
+pub(crate) fn manifests() -> Vec<ModelManifest> {
+    [
+        (FL2VA_OFFICIAL, Task::Fl2va, Layout::OfficialBf16),
+        (REF2VA_OFFICIAL, Task::Ref2va, Layout::OfficialBf16),
+        (
+            FL2VA_COMFY,
+            Task::Fl2va,
+            Layout::ComfyPrunedInt8ConvrotNvfp4Awq,
+        ),
+        (
+            REF2VA_COMFY,
+            Task::Ref2va,
+            Layout::ComfyPrunedInt8ConvrotNvfp4Awq,
+        ),
+    ]
+    .into_iter()
+    .map(|(name, task, layout)| ModelManifest {
+        name: name.to_string(),
+        family: FAMILY.to_string(),
+        description: match (task, layout) {
+            (Task::Fl2va, Layout::OfficialBf16) => "MiniMax H3 FL2VA official BF16 transformer/conditioner + FP32 VAEs (compliance-gated; runtime unavailable)",
+            (Task::Ref2va, Layout::OfficialBf16) => "MiniMax H3 Ref2VA official BF16 transformer/conditioner + FP32 VAEs (compliance-gated; runtime unavailable)",
+            (Task::Fl2va, Layout::ComfyPrunedInt8ConvrotNvfp4Awq) => "MiniMax H3 FL2VA Comfy pruned INT8-convrot + NVFP4-AWQ (compliance-gated; runtime unavailable)",
+            (Task::Ref2va, Layout::ComfyPrunedInt8ConvrotNvfp4Awq) => "MiniMax H3 Ref2VA Comfy pruned INT8-convrot + NVFP4-AWQ (compliance-gated; runtime unavailable)",
+        }
+        .to_string(),
+        files: match layout {
+            Layout::OfficialBf16 => official_files(task),
+            Layout::ComfyPrunedInt8ConvrotNvfp4Awq => comfy_files(task),
+        },
+        defaults: defaults(),
+        hidden: true,
+    })
+    .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::manifest::{find_manifest, storage_path};
+
+    fn request() -> GenerateRequest {
+        GenerateRequest {
+            prompt: "a lighthouse in a storm".into(),
+            negative_prompt: None,
+            model: FL2VA_COMFY.into(),
+            width: DEFAULT_WIDTH,
+            height: DEFAULT_HEIGHT,
+            steps: DEFAULT_STEPS,
+            guidance: 0.0,
+            seed: Some(42),
+            batch_size: 1,
+            output_format: Some(OutputFormat::Mp4),
+            embed_metadata: None,
+            scheduler: None,
+            cfg_plus: None,
+            source_image: None,
+            source_image_name: None,
+            edit_images: None,
+            strength: 1.0,
+            mask_image: None,
+            control_image: None,
+            control_model: None,
+            control_scale: 1.0,
+            expand: None,
+            original_prompt: None,
+            prompt_transform: None,
+            batch_id: None,
+            batch_index: None,
+            batch_count: None,
+            lora: None,
+            frames: Some(MIN_FRAMES),
+            fps: Some(FIXED_FPS),
+            upscale_model: None,
+            gif_preview: false,
+            enable_audio: None,
+            audio_file: None,
+            audio_file_path: None,
+            source_video: None,
+            source_video_path: None,
+            extend_video: None,
+            extend_video_path: None,
+            extend_overlap_frames: None,
+            keyframes: None,
+            hdr_exr_dir: None,
+            hdr_exr_full_float: false,
+            pipeline: None,
+            ic_lora_control: None,
+            loras: None,
+            retake_range: None,
+            spatial_upscale: None,
+            temporal_upscale: None,
+            guidance_overrides: None,
+            placement: None,
+        }
+    }
+
+    #[test]
+    fn aliases_resolve_to_explicit_practical_variants() {
+        assert_eq!(resolve_model_name("minimax-h3"), Some(FL2VA_COMFY));
+        assert_eq!(resolve_model_name("minimax_h3_ref2va"), Some(REF2VA_COMFY));
+        assert_eq!(canonical_family("MiniMax_H3"), Some(FAMILY));
+        assert_eq!(canonical_family("h3"), None);
+        for alias in FAMILY_ALIASES {
+            assert_eq!(
+                crate::ExpandTask::for_family(alias),
+                crate::ExpandTask::TextToVideo
+            );
+        }
+        for lookalike in [
+            "notminimax-h3",
+            "minimax-h30",
+            "minimax-h3-ref2va-extra",
+            "other:minimax-h3-fl2va:official-bf16",
+        ] {
+            assert_eq!(resolve_model_name(lookalike), None, "{lookalike}");
+            assert_eq!(task_for_model(lookalike), None, "{lookalike}");
+            assert_eq!(layout_for_model(lookalike), None, "{lookalike}");
+        }
+    }
+
+    #[test]
+    fn timing_grid_accepts_the_three_documented_nominal_durations() {
+        for frames in [124, 243, 362] {
+            assert!(valid_frame_count(frames), "{frames}");
+        }
+        for frames in [123, 125, 361, 363] {
+            assert!(!valid_frame_count(frames), "{frames}");
+        }
+        assert_eq!(recommended_frames(125), 124);
+        assert_eq!(recommended_frames(350), 345);
+        assert_eq!(recommended_frames(u32::MAX), MAX_FRAMES);
+    }
+
+    #[test]
+    fn fl2va_modes_are_derived_only_from_boundary_frames() {
+        let mut req = request();
+        assert_eq!(
+            validate_request_contract(&req, Task::Fl2va).unwrap(),
+            Mode::TextToAudioVideo
+        );
+
+        req.source_image = Some(vec![1]);
+        assert_eq!(
+            validate_request_contract(&req, Task::Fl2va).unwrap(),
+            Mode::FirstFrameToAudioVideo
+        );
+        req.keyframes = Some(vec![crate::KeyframeCondition {
+            frame: MIN_FRAMES - 1,
+            image: vec![2],
+        }]);
+        assert_eq!(
+            validate_request_contract(&req, Task::Fl2va).unwrap(),
+            Mode::FirstAndLastFrameToAudioVideo
+        );
+
+        req.source_image = None;
+        assert_eq!(
+            validate_request_contract(&req, Task::Fl2va).unwrap(),
+            Mode::LastFrameToAudioVideo
+        );
+        req.keyframes.as_mut().unwrap()[0].frame = 17;
+        assert_eq!(
+            validate_request_contract(&req, Task::Fl2va)
+                .unwrap_err()
+                .code,
+            "MINIMAX_H3_BOUNDARY_FRAME_REQUIRED"
+        );
+    }
+
+    #[test]
+    fn ref2va_and_synchronized_audio_fail_closed() {
+        let mut req = request();
+        assert_eq!(
+            validate_request_contract(&req, Task::Ref2va)
+                .unwrap_err()
+                .code,
+            "MINIMAX_H3_REFERENCE_REQUIRED"
+        );
+        req.edit_images = Some(vec![vec![1]]);
+        assert_eq!(
+            validate_request_contract(&req, Task::Ref2va).unwrap(),
+            Mode::ReferenceToAudioVideo
+        );
+        req.enable_audio = Some(false);
+        assert_eq!(
+            validate_request_contract(&req, Task::Ref2va)
+                .unwrap_err()
+                .code,
+            "MINIMAX_H3_SYNCHRONIZED_AUDIO_REQUIRED"
+        );
+    }
+
+    #[test]
+    fn invalid_timing_and_canvas_errors_include_recommendations() {
+        let mut req = request();
+        req.frames = Some(125);
+        let error = validate_request_contract(&req, Task::Fl2va).unwrap_err();
+        assert_eq!(error.code, "MINIMAX_H3_FRAME_GRID");
+        assert_eq!(error.recommended_frames, Some(124));
+
+        req.frames = Some(MAX_FRAMES);
+        req.width = 1056;
+        req.height = 1056;
+        let error = validate_request_contract(&req, Task::Fl2va).unwrap_err();
+        assert_eq!(error.code, "MINIMAX_H3_DIMENSIONS");
+        let (width, height) = error.recommended_dimensions.unwrap();
+        assert!(width.is_multiple_of(DIMENSION_ALIGNMENT));
+        assert!(height.is_multiple_of(DIMENSION_ALIGNMENT));
+        assert!(u64::from(width) * u64::from(height) <= MAX_PIXELS);
+        assert_eq!((width, height), (768, 768));
+    }
+
+    #[test]
+    fn fixed_fps_frame_bounds_and_every_canvas_rule_fail_explicitly() {
+        for fps in [1, 23, 25, 120] {
+            let mut req = request();
+            req.fps = Some(fps);
+            assert_eq!(
+                validate_request_contract(&req, Task::Fl2va)
+                    .unwrap_err()
+                    .code,
+                "MINIMAX_H3_FIXED_FPS",
+                "fps={fps}"
+            );
+        }
+
+        for frames in [107, 125, 379] {
+            let mut req = request();
+            req.frames = Some(frames);
+            assert_eq!(
+                validate_request_contract(&req, Task::Fl2va)
+                    .unwrap_err()
+                    .code,
+                "MINIMAX_H3_FRAME_GRID",
+                "frames={frames}"
+            );
+        }
+
+        for (width, height, rule) in [
+            (0, DEFAULT_HEIGHT, "positive"),
+            (DEFAULT_WIDTH - 1, DEFAULT_HEIGHT, "alignment"),
+            (1056, 1056, "area"),
+            (160, 768, "minimum aspect"),
+            (1344, 256, "maximum aspect"),
+        ] {
+            let mut req = request();
+            req.width = width;
+            req.height = height;
+            assert_eq!(
+                validate_request_contract(&req, Task::Fl2va)
+                    .unwrap_err()
+                    .code,
+                "MINIMAX_H3_DIMENSIONS",
+                "{rule}: {width}x{height}"
+            );
+        }
+
+        for (width, height) in [
+            (DEFAULT_WIDTH, DEFAULT_HEIGHT),
+            (DEFAULT_HEIGHT, DEFAULT_WIDTH),
+            (1024, 1024),
+            (256, 1024),
+            (1024, 256),
+        ] {
+            let mut req = request();
+            req.width = width;
+            req.height = height;
+            assert!(
+                validate_request_contract(&req, Task::Fl2va).is_ok(),
+                "valid canvas {width}x{height}"
+            );
+        }
+    }
+
+    #[test]
+    fn canvas_recommendations_match_the_official_short_edge_area_then_round_order() {
+        for ((aspect_width, aspect_height), expected) in [
+            ((21, 9), (1536, 672)),
+            ((16, 9), (1344, 768)),
+            ((4, 3), (1024, 768)),
+            ((1, 1), (768, 768)),
+            ((3, 4), (768, 1024)),
+            ((9, 16), (768, 1344)),
+            ((4, 1), (2016, 512)),
+            ((1, 4), (512, 2016)),
+        ] {
+            assert_eq!(
+                recommended_dimensions(aspect_width, aspect_height),
+                expected,
+                "aspect {aspect_width}:{aspect_height}"
+            );
+        }
+
+        // The oracle's independent post-budget rounding may exceed the
+        // pre-rounding area. 7:23 is one ratio that reaches the exact envelope.
+        let rounded = recommended_dimensions(7, 23);
+        assert_eq!(rounded, (576, 1856));
+        assert_eq!(u64::from(rounded.0) * u64::from(rounded.1), MAX_PIXELS);
+    }
+
+    #[test]
+    fn capabilities_are_truthful_before_runtime_exists() {
+        for task in [Task::Fl2va, Task::Ref2va] {
+            let caps = capabilities(task);
+            assert!(!caps.runtime_available);
+            assert_eq!(caps.native_batch_sizes, &[1]);
+            assert_eq!(caps.backends.cuda, BackendQualification::ContractTarget);
+            assert_eq!(caps.backends.metal, BackendQualification::Unsupported);
+            assert_eq!(caps.backends.cpu, BackendQualification::Unsupported);
+            assert!(caps.synchronized_audio);
+            assert!(!caps.audio_disable_supported);
+            assert_eq!(caps.audio_sample_rate_hz, 32_000);
+            assert_eq!(caps.audio_channels, 2);
+            assert_eq!(
+                (caps.min_duration_seconds, caps.max_duration_seconds),
+                (5, 15)
+            );
+            assert_eq!(caps.default_dimensions, (1344, 768));
+            assert_eq!(caps.min_aspect_ratio, (1, 4));
+            assert_eq!(caps.max_aspect_ratio, (4, 1));
+            assert_eq!(caps.noise_domain_version, NOISE_DOMAIN_VERSION);
+            assert_eq!(caps.noise_streams, NOISE_STREAMS);
+            assert_eq!(
+                caps.noise_draws,
+                &[
+                    NoiseDrawContract {
+                        name: NOISE_STREAMS[0],
+                        seed_source: NoiseSeedSource::FixedFreshPerVisualCondition(42),
+                        cardinality: NoiseDrawCardinality::PerVisualCondition,
+                    },
+                    NoiseDrawContract {
+                        name: NOISE_STREAMS[1],
+                        seed_source: NoiseSeedSource::RequestSeed,
+                        cardinality: NoiseDrawCardinality::PerVisualCondition,
+                    },
+                    NoiseDrawContract {
+                        name: NOISE_STREAMS[2],
+                        seed_source: NoiseSeedSource::RequestSeed,
+                        cardinality: NoiseDrawCardinality::Once,
+                    },
+                    NoiseDrawContract {
+                        name: NOISE_STREAMS[3],
+                        seed_source: NoiseSeedSource::RequestSeed,
+                        cardinality: NoiseDrawCardinality::Once,
+                    },
+                ]
+            );
+        }
+    }
+
+    #[test]
+    fn per_model_capability_authority_covers_five_modes_without_advertising_runtime() {
+        let cases = [
+            (
+                FL2VA_OFFICIAL,
+                Task::Fl2va,
+                Layout::OfficialBf16,
+                FL2VA_MODES,
+            ),
+            (
+                REF2VA_OFFICIAL,
+                Task::Ref2va,
+                Layout::OfficialBf16,
+                REF2VA_MODES,
+            ),
+            (
+                FL2VA_COMFY,
+                Task::Fl2va,
+                Layout::ComfyPrunedInt8ConvrotNvfp4Awq,
+                FL2VA_MODES,
+            ),
+            (
+                REF2VA_COMFY,
+                Task::Ref2va,
+                Layout::ComfyPrunedInt8ConvrotNvfp4Awq,
+                REF2VA_MODES,
+            ),
+        ];
+        let mut observed_modes = Vec::new();
+        for (model, task, layout, modes) in cases {
+            let contract = capability_contract_for_model(model).unwrap();
+            assert_eq!(contract.canonical_model, model);
+            assert_eq!(contract.task, task);
+            assert_eq!(contract.layout, layout);
+            assert_eq!(contract.generation.modes, modes);
+            assert!(!contract.generation.runtime_available);
+            assert_eq!(contract.generation.native_batch_sizes, &[1]);
+            assert_eq!(
+                contract.generation.backends,
+                BackendApplicability {
+                    cuda: BackendQualification::ContractTarget,
+                    metal: BackendQualification::Unsupported,
+                    cpu: BackendQualification::Unsupported,
+                }
+            );
+            assert!(contract.generation.synchronized_audio);
+            assert!(runnable_capability_contract_for_model(model).is_none());
+            observed_modes.extend_from_slice(modes);
+        }
+        observed_modes.sort_by_key(|mode| *mode as u8);
+        observed_modes.dedup();
+        assert_eq!(observed_modes, ALL_MODES);
+
+        for alias in FAMILY_ALIASES {
+            assert!(capability_contract_for_model(alias).is_some());
+            assert!(runnable_capability_contract_for_model(alias).is_none());
+        }
+
+        let advertised = crate::build_model_catalog(&crate::Config::default(), None, false);
+        assert!(advertised.iter().all(|model| model.family != FAMILY));
+    }
+
+    #[test]
+    fn manifests_are_hidden_pinned_and_cannot_mix_task_transformers() {
+        let fl_official = find_manifest(FL2VA_OFFICIAL).unwrap();
+        let ref_official = find_manifest(REF2VA_OFFICIAL).unwrap();
+        let fl_comfy = find_manifest(FL2VA_COMFY).unwrap();
+        let ref_comfy = find_manifest(REF2VA_COMFY).unwrap();
+        for manifest in [fl_official, ref_official, fl_comfy, ref_comfy] {
+            assert!(manifest.hidden);
+            let contract = manifest_contract(manifest).unwrap();
+            assert!(!contract.runtime_available);
+            assert_eq!(contract.license_url, MINIMAX_H3_LICENSE_URL);
+            assert_eq!(contract.license_sha256, LICENSE_SHA256);
+            assert_eq!(
+                contract.source_revision,
+                repo_revision(contract.source_repo).unwrap()
+            );
+            assert_eq!(
+                contract.shared_identity_scheme,
+                "hf-repo+revision+path+sha256"
+            );
+            assert!(!contract.implementation_revision.is_empty());
+            assert_eq!(contract.diffusers_reference_repo, DIFFUSERS_REFERENCE_REPO);
+            assert_eq!(
+                contract.diffusers_reference_revision,
+                DIFFUSERS_REFERENCE_REVISION
+            );
+            for artifact in &manifest.files {
+                let metadata = artifact_contract(manifest, artifact).unwrap();
+                assert_eq!(
+                    Some(metadata.identity.source_revision),
+                    repo_revision(metadata.identity.source_repo)
+                );
+                assert_eq!(metadata.identity.source_path, artifact.hf_filename);
+                assert_eq!(Some(metadata.identity.sha256), artifact.sha256);
+                assert_eq!(metadata.license_url, MINIMAX_H3_LICENSE_URL);
+                assert_eq!(metadata.license_sha256, LICENSE_SHA256);
+            }
+            let task_transformer = manifest
+                .files
+                .iter()
+                .find(|artifact| {
+                    matches!(
+                        artifact.component,
+                        ModelComponent::Transformer | ModelComponent::TransformerShard
+                    )
+                })
+                .unwrap();
+            assert_eq!(
+                artifact_contract(manifest, task_transformer)
+                    .unwrap()
+                    .identity
+                    .source_repo,
+                contract.source_repo
+            );
+        }
+
+        let task_files = |manifest: &ModelManifest| {
+            manifest
+                .files
+                .iter()
+                .filter(|file| {
+                    matches!(
+                        artifact_contract(manifest, file).map(|metadata| metadata.role),
+                        Some(ArtifactRole::TaskTransformer | ArtifactRole::TaskConfig)
+                    )
+                })
+                .map(|file| file.hf_filename.clone())
+                .collect::<std::collections::BTreeSet<_>>()
+        };
+        assert!(task_files(fl_official).is_disjoint(&task_files(ref_official)));
+        assert!(task_files(fl_comfy).is_disjoint(&task_files(ref_comfy)));
+
+        let ref_transformer = ref_comfy
+            .files
+            .iter()
+            .find(|file| file.component == ModelComponent::Transformer)
+            .unwrap();
+        assert!(artifact_contract(fl_comfy, ref_transformer).is_none());
+    }
+
+    #[test]
+    fn every_variant_has_a_complete_standalone_component_graph() {
+        let required_roles = [
+            ArtifactRole::TaskTransformer,
+            ArtifactRole::Qwen3VlConditioner,
+            ArtifactRole::VideoVae,
+            ArtifactRole::AudioVae,
+            ArtifactRole::Processor,
+            ArtifactRole::VideoScheduler,
+            ArtifactRole::AudioScheduler,
+            ArtifactRole::SharedConfig,
+            ArtifactRole::TaskConfig,
+        ];
+        for manifest_name in [FL2VA_OFFICIAL, REF2VA_OFFICIAL, FL2VA_COMFY, REF2VA_COMFY] {
+            let manifest = find_manifest(manifest_name).unwrap();
+            for role in required_roles {
+                assert!(
+                    manifest.files.iter().any(|file| {
+                        artifact_contract(manifest, file)
+                            .is_some_and(|contract| contract.role == role)
+                    }),
+                    "{manifest_name} is missing {role:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn comfy_reuses_exact_official_runtime_assets_without_official_weight_indexes() {
+        for (official_name, comfy_name) in [
+            (FL2VA_OFFICIAL, FL2VA_COMFY),
+            (REF2VA_OFFICIAL, REF2VA_COMFY),
+        ] {
+            let official = find_manifest(official_name).unwrap();
+            let comfy = find_manifest(comfy_name).unwrap();
+            let reused = comfy
+                .files
+                .iter()
+                .filter(|file| file.hf_repo == OFFICIAL_REPO)
+                .collect::<Vec<_>>();
+            assert_eq!(reused.len(), 13);
+            for file in reused {
+                assert!(!matches!(
+                    file.hf_filename.as_str(),
+                    "model_index.json" | "modular_model_index.json"
+                ));
+                assert!(!file.hf_filename.ends_with("safetensors.index.json"));
+                let same = official
+                    .files
+                    .iter()
+                    .find(|candidate| {
+                        candidate.hf_repo == file.hf_repo
+                            && candidate.hf_filename == file.hf_filename
+                            && candidate.component == file.component
+                            && candidate.size_bytes == file.size_bytes
+                            && candidate.gated == file.gated
+                            && candidate.sha256 == file.sha256
+                    })
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "{comfy_name} reused asset is not exact in {official_name}: {}",
+                            file.hf_filename
+                        )
+                    });
+                assert_eq!(
+                    artifact_contract(comfy, file).unwrap().identity,
+                    artifact_contract(official, same).unwrap().identity
+                );
+                assert_eq!(storage_path(comfy, file), storage_path(official, same));
+            }
+        }
+    }
+
+    #[test]
+    fn artifact_metadata_requires_exact_pinned_file_membership() {
+        let manifest = find_manifest(FL2VA_COMFY).unwrap();
+        let original = manifest.files.first().unwrap();
+
+        let mut wrong_size = original.clone();
+        wrong_size.size_bytes += 1;
+        assert!(artifact_contract(manifest, &wrong_size).is_none());
+
+        let mut wrong_gate = original.clone();
+        wrong_gate.gated = !wrong_gate.gated;
+        assert!(artifact_contract(manifest, &wrong_gate).is_none());
+    }
+
+    #[test]
+    fn shared_components_have_one_storage_identity_per_layout() {
+        for (fl_name, ref_name) in [
+            (FL2VA_OFFICIAL, REF2VA_OFFICIAL),
+            (FL2VA_COMFY, REF2VA_COMFY),
+        ] {
+            let fl = find_manifest(fl_name).unwrap();
+            let reference = find_manifest(ref_name).unwrap();
+            let shared = |manifest: &ModelManifest| {
+                manifest
+                    .files
+                    .iter()
+                    .filter(|file| {
+                        artifact_contract(manifest, file)
+                            .is_some_and(|metadata| metadata.compatible_tasks == BOTH_TASKS)
+                    })
+                    .map(|file| {
+                        let identity = artifact_contract(manifest, file).unwrap().identity;
+                        (
+                            identity.source_repo.to_string(),
+                            identity.source_revision.to_string(),
+                            identity.source_path.to_string(),
+                            identity.sha256.to_string(),
+                            storage_path(manifest, file),
+                        )
+                    })
+                    .collect::<std::collections::BTreeSet<_>>()
+            };
+            assert_eq!(shared(fl), shared(reference));
+        }
+    }
+
+    #[test]
+    fn artifact_dtypes_are_exact_per_concrete_layout() {
+        let assert_dtype = |manifest_name: &str, component: ModelComponent, expected: &str| {
+            let manifest = find_manifest(manifest_name).unwrap();
+            let matches = manifest
+                .files
+                .iter()
+                .filter(|file| file.component == component)
+                .map(|file| artifact_contract(manifest, file).unwrap().dtype)
+                .collect::<std::collections::BTreeSet<_>>();
+            assert_eq!(matches, std::collections::BTreeSet::from([expected]));
+        };
+
+        for manifest in [FL2VA_OFFICIAL, REF2VA_OFFICIAL] {
+            assert_dtype(manifest, ModelComponent::TransformerShard, "bf16");
+            assert_dtype(manifest, ModelComponent::TextEncoder, "bf16");
+            assert_dtype(manifest, ModelComponent::Vae, "fp32");
+            assert_dtype(manifest, ModelComponent::AudioVae, "fp32");
+        }
+        for manifest in [FL2VA_COMFY, REF2VA_COMFY] {
+            assert_dtype(manifest, ModelComponent::Transformer, "int8-convrot-pruned");
+            assert_dtype(manifest, ModelComponent::TextEncoder, "nvfp4-awq");
+            assert_dtype(manifest, ModelComponent::Vae, "fp16");
+            assert_dtype(manifest, ModelComponent::AudioVae, "fp32");
+        }
+    }
+
+    #[test]
+    fn request_wire_round_trip_preserves_contract_then_public_admission_stays_gated() {
+        let mut req = request();
+        req.output_format = None;
+        req.normalise_output_format(Some(FAMILY));
+        assert_eq!(req.output_format, Some(OutputFormat::Mp4));
+
+        let wire = serde_json::to_value(&req).unwrap();
+        let parsed: GenerateRequest = serde_json::from_value(wire.clone()).unwrap();
+        assert_eq!(serde_json::to_value(&parsed).unwrap(), wire);
+        assert_eq!(
+            validate_request_contract(&parsed, Task::Fl2va).unwrap(),
+            Mode::TextToAudioVideo
+        );
+
+        let error = crate::validate_generate_request_with_family(&parsed, Some(FAMILY))
+            .expect_err("public admission must remain compliance-gated");
+        assert!(error.contains(crate::MINIMAX_H3_AUTHORIZATION_REQUIRED));
+    }
+
+    #[test]
+    fn rust_contract_pins_match_the_revision_locked_conformance_authority() {
+        let conformance: serde_json::Value = serde_json::from_str(include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../tests/fixtures/minimax_h3/conformance-manifest.json"
+        )))
+        .unwrap();
+        let source_revision = |id: &str| {
+            conformance["sources"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .find(|source| source["id"] == id)
+                .and_then(|source| source["revision"].as_str())
+                .unwrap()
+        };
+        assert_eq!(source_revision("minimax-official-model"), OFFICIAL_REVISION);
+        assert_eq!(source_revision("comfy-checkpoints"), COMFY_REVISION);
+        assert_eq!(
+            source_revision("minimax-official-code"),
+            OFFICIAL_IMPLEMENTATION_REVISION
+        );
+        assert_eq!(source_revision("comfyui"), COMFY_IMPLEMENTATION_REVISION);
+        assert_eq!(source_revision("diffusers"), DIFFUSERS_REFERENCE_REVISION);
+        assert_eq!(
+            conformance["numerical_authority"]["precision"],
+            "official-bf16-fp32-mixed"
+        );
+        assert_eq!(conformance["day_zero_contract"]["fps"], FIXED_FPS);
+        assert_eq!(conformance["day_zero_contract"]["frame_step"], FRAME_STEP);
+        assert_eq!(
+            conformance["day_zero_contract"]["frame_offset"],
+            FRAME_OFFSET
+        );
+        assert_eq!(
+            conformance["day_zero_contract"]["nominal_15_second_frames"],
+            MAX_FRAMES
+        );
+        let synthetic: serde_json::Value = serde_json::from_str(include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../tests/fixtures/minimax_h3/synthetic-v1.json"
+        )))
+        .unwrap();
+        let noise_order = synthetic["noise_allocation_order"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|draw| draw["domain"].as_str().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(noise_order, NOISE_STREAMS);
+
+        let pin = |id: &str| {
+            conformance["component_indexes"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .find(|item| item["id"] == id)
+                .unwrap()
+        };
+        assert_eq!(pin("official-license")["sha256"], LICENSE_SHA256);
+        for (id, manifest_name, path) in [
+            ("official-model-index", FL2VA_OFFICIAL, "model_index.json"),
+            (
+                "official-modular-index",
+                FL2VA_OFFICIAL,
+                "modular_model_index.json",
+            ),
+            (
+                "official-fl2va-transformer-index",
+                FL2VA_OFFICIAL,
+                "transformer/diffusion_pytorch_model.safetensors.index.json",
+            ),
+            (
+                "official-ref2va-transformer-index",
+                REF2VA_OFFICIAL,
+                "transformer_ref/diffusion_pytorch_model.safetensors.index.json",
+            ),
+            (
+                "official-text-encoder-index",
+                FL2VA_OFFICIAL,
+                "text_encoder/model.safetensors.index.json",
+            ),
+            (
+                "official-video-vae-index",
+                FL2VA_OFFICIAL,
+                "vae/diffusion_pytorch_model.safetensors.index.json",
+            ),
+            (
+                "official-audio-vae-config",
+                FL2VA_OFFICIAL,
+                "audio_vae/config.json",
+            ),
+        ] {
+            let manifest = find_manifest(manifest_name).unwrap();
+            let artifact = manifest
+                .files
+                .iter()
+                .find(|file| file.hf_filename == path)
+                .unwrap_or_else(|| panic!("missing {path} in {manifest_name}"));
+            assert_eq!(pin(id)["relative_path"], path);
+            assert_eq!(pin(id)["sha256"].as_str(), artifact.sha256);
+        }
+    }
+}

--- a/crates/mold-core/src/model_policy.rs
+++ b/crates/mold-core/src/model_policy.rs
@@ -13,6 +13,11 @@ pub const MINIMAX_H3_AUTHORIZATION_ISSUE_URL: &str = "https://github.com/utensil
 pub const MINIMAX_H3_LICENSE_URL: &str = "https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/\
 bfc8ed0353f5a9733be73e6b2c98ec0948195b86/LICENSE";
 
+/// Content identity of the reviewed license bytes, pinned by the H3
+/// conformance manifest and required by any future authorization record.
+pub const MINIMAX_H3_LICENSE_SHA256: &str =
+    "59b99642b95ea21630e311198ddbfffbfe05aadba0c2f5d884cbdf4efcc90f44";
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ModelActivation {
     Available,
@@ -81,6 +86,16 @@ pub fn model_activation(identifier: &str, family: Option<&str>) -> ModelActivati
     } else {
         ModelActivation::Available
     }
+}
+
+/// Whether an identity may appear in ordinary model-discovery surfaces.
+///
+/// This is a convenience view over [`model_activation`], not a second policy
+/// table. Catalog-family lists and other non-error-producing discovery paths
+/// use it so a compliance-gated family cannot leak through static taxonomy
+/// while mutating ingress paths continue to use [`require_model_activation`].
+pub fn model_activation_available(identifier: &str, family: Option<&str>) -> bool {
+    model_activation(identifier, family) == ModelActivation::Available
 }
 
 pub fn require_model_activation(
@@ -217,6 +232,15 @@ mod tests {
                 "{identifier}"
             );
         }
+    }
+
+    #[test]
+    fn discovery_availability_is_a_view_of_the_activation_authority() {
+        assert!(!model_activation_available(
+            "minimax-h3",
+            Some("minimax-h3")
+        ));
+        assert!(model_activation_available("flux", Some("flux")));
     }
 
     #[test]

--- a/crates/mold-core/src/types.rs
+++ b/crates/mold-core/src/types.rs
@@ -196,7 +196,8 @@ impl ExpandTask {
     /// Backward-compatible policy for callers that only send a family.
     pub fn for_family(family: &str) -> Self {
         match family.trim().to_ascii_lowercase().as_str() {
-            "ltx2" | "ltx-2" | "ltx-video" | "wan" | "wan2.1" | "wan2.2" => Self::TextToVideo,
+            "ltx2" | "ltx-2" | "ltx-video" | "wan" | "wan2.1" | "wan2.2" | "minimax-h3"
+            | "minimax_h3" | "minimaxh3" => Self::TextToVideo,
             _ => Self::TextToImage,
         }
     }
@@ -242,7 +243,15 @@ impl ExpandTask {
     ) -> Self {
         if !matches!(
             family.trim().to_ascii_lowercase().as_str(),
-            "ltx2" | "ltx-2" | "ltx-video" | "wan" | "wan2.1" | "wan2.2"
+            "ltx2"
+                | "ltx-2"
+                | "ltx-video"
+                | "wan"
+                | "wan2.1"
+                | "wan2.2"
+                | "minimax-h3"
+                | "minimax_h3"
+                | "minimaxh3"
         ) {
             return Self::TextToImage;
         }
@@ -797,7 +806,8 @@ impl GenerateRequest {
             return self;
         }
         self.output_format = Some(match family {
-            Some("ltx2") | Some("ltx-video") | Some("wan") => OutputFormat::Mp4,
+            Some("ltx2") | Some("ltx-video") | Some("wan") | Some("minimax-h3")
+            | Some("minimax_h3") | Some("minimaxh3") => OutputFormat::Mp4,
             _ => OutputFormat::Png,
         });
         self
@@ -1577,6 +1587,11 @@ pub struct ModelDefaults {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schema(example = 24)]
     pub default_fps: Option<u32>,
+    /// Minimum requestable video frame count (additive; absent when the
+    /// historical one-frame floor applies).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schema(example = 124)]
+    pub min_frames: Option<u32>,
     /// Maximum frames a single request may ask for at `default_fps`
     /// (additive; absent for image models). For families whose ceiling is a
     /// duration — see `max_runtime_seconds` — this scalar moves with fps, so
@@ -1599,11 +1614,17 @@ pub struct ModelDefaults {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schema(example = 604)]
     pub max_frames_absolute: Option<u32>,
-    /// Valid frame counts are `k * frame_step + 1` (additive; absent for
-    /// image models). 8 for the LTX families.
+    /// Step of the valid frame grid (additive; absent for image models).
+    /// Combine with `frame_offset`, whose backward-compatible default is 1:
+    /// valid counts are `k * frame_step + frame_offset`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schema(example = 8)]
     pub frame_step: Option<u32>,
+    /// Offset of the valid frame grid. Omitted by older servers and families
+    /// whose grid is `k * frame_step + 1`; MiniMax H3 advertises 5.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schema(example = 5)]
+    pub frame_offset: Option<u32>,
     /// Server-authoritative total-pixel ceiling for generation requests.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schema(example = 1800000)]
@@ -1781,8 +1802,10 @@ mod model_defaults_frame_tests {
         let parsed: ModelDefaults = serde_json::from_str(legacy).unwrap();
         assert_eq!(parsed.default_frames, None);
         assert_eq!(parsed.default_fps, None);
+        assert_eq!(parsed.min_frames, None);
         assert_eq!(parsed.max_frames, None);
         assert_eq!(parsed.frame_step, None);
+        assert_eq!(parsed.frame_offset, None);
         assert_eq!(parsed.max_pixels, None);
         assert!(parsed.recommended_dimensions.is_empty());
         assert_eq!(parsed.dimension_alignment, None);
@@ -1790,8 +1813,10 @@ mod model_defaults_frame_tests {
         let out = serde_json::to_value(&parsed).unwrap();
         assert!(out.get("default_frames").is_none());
         assert!(out.get("default_fps").is_none());
+        assert!(out.get("min_frames").is_none());
         assert!(out.get("max_frames").is_none());
         assert!(out.get("frame_step").is_none());
+        assert!(out.get("frame_offset").is_none());
         assert!(out.get("max_pixels").is_none());
         assert!(out.get("recommended_dimensions").is_none());
         assert!(out.get("dimension_alignment").is_none());
@@ -1799,23 +1824,29 @@ mod model_defaults_frame_tests {
         let video = ModelDefaults {
             default_frames: Some(97),
             default_fps: Some(24),
+            min_frames: Some(1),
             max_frames: Some(484),
             max_runtime_seconds: Some(20),
             frame_step: Some(8),
+            frame_offset: Some(1),
             ..parsed
         };
         let out = serde_json::to_value(&video).unwrap();
         assert_eq!(out["default_frames"], 97);
         assert_eq!(out["default_fps"], 24);
+        assert_eq!(out["min_frames"], 1);
         assert_eq!(out["max_frames"], 484);
         assert_eq!(out["max_runtime_seconds"], 20);
         assert_eq!(out["frame_step"], 8);
+        assert_eq!(out["frame_offset"], 1);
 
         let back: ModelDefaults = serde_json::from_value(out).unwrap();
         assert_eq!(back.default_frames, Some(97));
         assert_eq!(back.default_fps, Some(24));
+        assert_eq!(back.min_frames, Some(1));
         assert_eq!(back.max_frames, Some(484));
         assert_eq!(back.max_runtime_seconds, Some(20));
+        assert_eq!(back.frame_offset, Some(1));
         assert_eq!(back.frame_step, Some(8));
     }
 }

--- a/crates/mold-core/src/validation.rs
+++ b/crates/mold-core/src/validation.rs
@@ -290,6 +290,7 @@ pub fn max_frames_for_family_at_fps(family: &str, fps: u32) -> Option<u32> {
         // The flat global ceiling is the resource guard, and 257 sits on the
         // `4k+1` grid, so the advertised maximum is itself submittable.
         "wan" => Some(MAX_FRAMES_GLOBAL),
+        family if crate::minimax_h3::is_family(family) => Some(crate::minimax_h3::MAX_FRAMES),
         _ => None,
     }
 }
@@ -298,6 +299,18 @@ pub fn max_frames_for_family_at_fps(family: &str, fps: u32) -> Option<u32> {
 /// that have no per-model fps to hand.
 pub fn max_frames_for_family(family: &str) -> Option<u32> {
     max_frames_for_family_at_fps(family, LTX2_DEFAULT_FPS)
+}
+
+/// Minimum requestable frame count for families that impose one above the
+/// generic single-frame floor. `None` retains the historical minimum of one.
+pub fn min_frames_for_family(family: &str) -> Option<u32> {
+    crate::minimax_h3::is_family(family).then_some(crate::minimax_h3::MIN_FRAMES)
+}
+
+/// A family's mandatory frame rate, when the checkpoint does not support
+/// arbitrary FPS. `None` means callers may choose any otherwise-valid rate.
+pub fn fixed_fps_for_family(family: &str) -> Option<u32> {
+    crate::minimax_h3::is_family(family).then_some(crate::minimax_h3::FIXED_FPS)
 }
 
 /// Single-request runtime ceiling in seconds for families whose real limit is
@@ -311,14 +324,55 @@ pub fn max_frames_absolute_for_family(family: &str) -> Option<u32> {
     (family == "ltx2").then_some(LTX2_MAX_FRAMES_ABSOLUTE)
 }
 
-/// Frame-count grid for a family: valid counts are `k * step + 1`. The value
-/// `/api/models` advertises as `frame_step`; the validator consumes it.
+/// Step of the frame-count grid for a family. Pair with
+/// [`frame_offset_for_family`]; valid counts are `k * step + offset`.
 pub fn frame_step_for_family(family: &str) -> Option<u32> {
     match family {
         "ltx2" | "ltx-video" => Some(LTX2_TEMPORAL_SCALE),
         "wan" => Some(WAN_TEMPORAL_SCALE),
+        family if crate::minimax_h3::is_family(family) => Some(crate::minimax_h3::FRAME_STEP),
         _ => None,
     }
+}
+
+/// Offset of the frame-count grid. Existing video families use 1; MiniMax H3
+/// uses 5 (`17n+5`). `None` means the family has no temporal grid.
+pub fn frame_offset_for_family(family: &str) -> Option<u32> {
+    frame_step_for_family(family).map(|_| {
+        if crate::minimax_h3::is_family(family) {
+            crate::minimax_h3::FRAME_OFFSET
+        } else {
+            1
+        }
+    })
+}
+
+/// Validate family-specific temporal constraints that sit above the generic
+/// non-zero FPS/frame checks. Public admission calls this only after the model
+/// activation gate; keeping it factored lets the authority be tested without
+/// introducing a test-only authorization bypass.
+fn validate_family_video_timing_constraints(
+    frames: Option<u32>,
+    fps: Option<u32>,
+    family: Option<&str>,
+) -> Result<(), String> {
+    if let (Some(family), Some(fps)) = (family, fps) {
+        if let Some(fixed_fps) = fixed_fps_for_family(family) {
+            if fps != fixed_fps {
+                return Err(format!("{family} requires {fixed_fps} fps; received {fps}"));
+            }
+        }
+    }
+    if let (Some(family), Some(frames)) = (family, frames) {
+        if let Some(min_frames) = min_frames_for_family(family) {
+            if frames < min_frames {
+                return Err(format!(
+                    "frames ({frames}) must be >= {min_frames} for {family}"
+                ));
+            }
+        }
+    }
+    Ok(())
 }
 
 fn megapixel_limit_label_for(limit: u64) -> String {
@@ -444,6 +498,7 @@ pub fn max_pixels_for_family_composed(
     match (family, composition) {
         (Some("ltx2"), Ltx2SpatialComposition::TiledTwoStage) => LTX2_COMPOSED_MAX_PIXELS,
         (Some("ltx2"), Ltx2SpatialComposition::SinglePass) => LTX2_MAX_PIXELS,
+        (Some(family), _) if crate::minimax_h3::is_family(family) => crate::minimax_h3::MAX_PIXELS,
         _ => MAX_PIXELS,
     }
 }
@@ -472,7 +527,9 @@ pub fn max_axis_pixels_for_family_composed(
 /// LTX video VAEs compress spatial dimensions by 32. Every other current
 /// family uses the shared 16px generation grid.
 pub fn dimension_alignment_for_family(family: Option<&str>) -> u32 {
-    if matches!(family, Some("ltx-video" | "ltx2")) {
+    if matches!(family, Some("ltx-video" | "ltx2"))
+        || family.is_some_and(crate::minimax_h3::is_family)
+    {
         32
     } else {
         16
@@ -1314,6 +1371,7 @@ pub fn validate_generate_request_with_family(
         Ltx2SpatialComposition::SinglePass
     };
     validate_generation_dimensions_composed(req.width, req.height, family, composition)?;
+    validate_family_video_timing_constraints(req.frames, req.fps, family)?;
     if composition == Ltx2SpatialComposition::TiledTwoStage {
         // The composed ceiling above is the x2 rung's. A request that names a
         // different rung reaches a different stage-1 shape, and only stage 1's
@@ -1486,12 +1544,13 @@ pub fn validate_generate_request_with_family(
             return Err("frames must be >= 1".to_string());
         }
         if let Some(step) = family.and_then(frame_step_for_family) {
-            if frames > 1 && (frames - 1) % step != 0 {
+            let offset = family.and_then(frame_offset_for_family).unwrap_or(1);
+            if frames < offset || !(frames - offset).is_multiple_of(step) {
                 return Err(format!(
-                    "frames ({frames}) must be {step}n+1 for this model family (e.g. {}, {}, {}, …)",
-                    step + 1,
-                    2 * step + 1,
-                    3 * step + 1,
+                    "frames ({frames}) must be {step}n+{offset} for this model family (e.g. {}, {}, {}, …)",
+                    step + offset,
+                    2 * step + offset,
+                    3 * step + offset,
                 ));
             }
         }
@@ -1529,8 +1588,15 @@ pub fn validate_generate_request_with_family(
                      Raise --fps, lower --frames, or render the shot as a multi-clip sequence"
                 ));
             }
-        } else if frames > MAX_FRAMES_GLOBAL {
-            return Err(format!("frames ({frames}) must be <= {MAX_FRAMES_GLOBAL}"));
+        } else {
+            let max_frames = family
+                .and_then(|family| {
+                    max_frames_for_family_at_fps(family, req.fps.unwrap_or(LTX2_DEFAULT_FPS).max(1))
+                })
+                .unwrap_or(MAX_FRAMES_GLOBAL);
+            if frames > max_frames {
+                return Err(format!("frames ({frames}) must be <= {max_frames}"));
+            }
         }
     }
     if let Some(keyframes) = &req.keyframes {
@@ -2034,6 +2100,14 @@ pub fn recommended_dimensions(family: &str) -> &'static [(u32, u32)] {
         "ltx-video" => LTX_VIDEO_DIMS,
         "ltx2" => LTX2_DIMS,
         "wan" => WAN_DIMS,
+        family if crate::minimax_h3::is_family(family) => &[
+            (1536, 672),
+            (1344, 768),
+            (1024, 768),
+            (768, 768),
+            (768, 1024),
+            (768, 1344),
+        ],
         _ => &[],
     }
 }
@@ -3874,6 +3948,8 @@ mod tests {
         assert_eq!(frame_step_for_family("ltx2"), Some(8));
         assert_eq!(frame_step_for_family("ltx-video"), Some(8));
         assert_eq!(frame_step_for_family("flux"), None);
+        assert_eq!(min_frames_for_family("flux"), None);
+        assert_eq!(fixed_fps_for_family("flux"), None);
 
         // One grid step past the advertised ltx-video cap must be rejected,
         // and the rejection must quote the same cap the wire advertises.
@@ -3895,6 +3971,45 @@ mod tests {
         req.frames = Some(249); // first 8n+1 value past the 244-frame cap
         let err = validate_generate_request(&req).unwrap_err();
         assert!(err.contains(&cap.to_string()), "got: {err}");
+    }
+
+    #[test]
+    fn h3_post_activation_timing_authority_rejects_short_or_retimed_requests() {
+        assert_eq!(
+            min_frames_for_family(crate::minimax_h3::FAMILY),
+            Some(crate::minimax_h3::MIN_FRAMES)
+        );
+        assert_eq!(
+            fixed_fps_for_family(crate::minimax_h3::FAMILY),
+            Some(crate::minimax_h3::FIXED_FPS)
+        );
+        assert_eq!(
+            max_frames_for_family(crate::minimax_h3::FAMILY),
+            Some(crate::minimax_h3::MAX_FRAMES)
+        );
+
+        let short = validate_family_video_timing_constraints(
+            Some(crate::minimax_h3::FRAME_OFFSET),
+            Some(crate::minimax_h3::FIXED_FPS),
+            Some(crate::minimax_h3::FAMILY),
+        )
+        .unwrap_err();
+        assert!(short.contains("124"), "got: {short}");
+
+        let retimed = validate_family_video_timing_constraints(
+            Some(crate::minimax_h3::MIN_FRAMES),
+            Some(23),
+            Some(crate::minimax_h3::FAMILY),
+        )
+        .unwrap_err();
+        assert!(retimed.contains("24 fps"), "got: {retimed}");
+
+        assert!(validate_family_video_timing_constraints(
+            Some(crate::minimax_h3::MIN_FRAMES),
+            Some(crate::minimax_h3::FIXED_FPS),
+            Some(crate::minimax_h3::FAMILY),
+        )
+        .is_ok());
     }
 
     /// Wan advertises a flat frame guard on the `4k+1` grid; the advertised
@@ -5285,6 +5400,7 @@ mod tests {
             ("qwen-image-edit", 1024, 1024),
             ("wuerstchen", 1024, 1024),
             ("ltx-video", 768, 512),
+            ("minimax-h3", 1344, 768),
         ];
         for (family, w, h) in families {
             let dims = recommended_dimensions(family);
@@ -5293,6 +5409,21 @@ mod tests {
                 "{family} native {w}x{h} missing from recommended list"
             );
         }
+    }
+
+    #[test]
+    fn h3_recommendations_are_the_official_product_ratios_on_the_oracle_canvas() {
+        assert_eq!(
+            recommended_dimensions(crate::minimax_h3::FAMILY),
+            &[
+                (1536, 672),
+                (1344, 768),
+                (1024, 768),
+                (768, 768),
+                (768, 1024),
+                (768, 1344),
+            ]
+        );
     }
 
     #[test]

--- a/crates/mold-discord/src/commands/generate.rs
+++ b/crates/mold-discord/src/commands/generate.rs
@@ -88,6 +88,7 @@ fn defaults_from_manifest(
             &manifest.family,
         ),
         frame_step: mold_core::validation::frame_step_for_family(&manifest.family),
+        frame_offset: mold_core::validation::frame_offset_for_family(&manifest.family),
         ..Default::default()
     }
 }

--- a/crates/mold-inference/src/factory.rs
+++ b/crates/mold-inference/src/factory.rs
@@ -17,6 +17,34 @@ use crate::wan::pipeline::WanEngine;
 use crate::wuerstchen::WuerstchenEngine;
 use crate::zimage::ZImageEngine;
 
+/// Whether the frozen factory can construct a family today.
+///
+/// Contract-only families are explicit so static metadata work cannot be
+/// mistaken for a runnable engine registration.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FactoryFamilyAvailability {
+    Runnable,
+    ContractOnly,
+}
+
+pub fn factory_family_availability(family: &str) -> Option<FactoryFamilyAvailability> {
+    if let Some(contract) = mold_core::minimax_h3::capability_contract_for_model(family) {
+        Some(
+            if contract.generation.runtime_available
+                && crate::production_family_capability_for_family(family).is_some()
+            {
+                FactoryFamilyAvailability::Runnable
+            } else {
+                FactoryFamilyAvailability::ContractOnly
+            },
+        )
+    } else if crate::production_family_capability_for_family(family).is_some() {
+        Some(FactoryFamilyAvailability::Runnable)
+    } else {
+        None
+    }
+}
+
 /// Immutable inputs that may change the concrete engine constructed for a
 /// model. Scheduler-owned execution plans capture this once and pass it to
 /// [`create_engine_with_frozen_config`], so worker dispatch never consults a
@@ -631,6 +659,9 @@ pub fn create_engine_with_frozen_config(
             gpu_ordinal,
             shared_pool,
         ))),
+        family if mold_core::minimax_h3::is_family(family) => bail!(
+            "MiniMax H3 has a static contract but no runnable inference engine in this build"
+        ),
         "wuerstchen" | "wuerstchen-v2" => Ok(boxed_inference_engine(WuerstchenEngine::new(
             model_name,
             paths,
@@ -749,6 +780,21 @@ mod tests {
         assert!(error
             .to_string()
             .contains(mold_core::MINIMAX_H3_AUTHORIZATION_REQUIRED));
+    }
+
+    #[test]
+    fn h3_aliases_are_factory_contract_only_not_production_capabilities() {
+        for alias in mold_core::minimax_h3::FAMILY_ALIASES {
+            assert_eq!(
+                factory_family_availability(alias),
+                Some(FactoryFamilyAvailability::ContractOnly)
+            );
+            assert!(crate::production_family_capability_for_family(alias).is_none());
+        }
+        assert_eq!(
+            factory_family_availability("flux"),
+            Some(FactoryFamilyAvailability::Runnable)
+        );
     }
 
     #[test]

--- a/crates/mold-inference/src/lib.rs
+++ b/crates/mold-inference/src/lib.rs
@@ -63,7 +63,8 @@ pub use engine::{
 };
 pub use error::InferenceError;
 pub use factory::{
-    create_engine, create_engine_with_frozen_config, create_engine_with_pool, FrozenEngineConfig,
+    create_engine, create_engine_with_frozen_config, create_engine_with_pool,
+    factory_family_availability, FactoryFamilyAvailability, FrozenEngineConfig,
 };
 pub use flux::FluxEngine;
 pub use flux2::Flux2Engine;

--- a/crates/mold-server/src/catalog_api.rs
+++ b/crates/mold-server/src/catalog_api.rs
@@ -384,10 +384,8 @@ pub async fn list_families(State(_state): State<crate::state::AppState>) -> impl
     // Live search hits one family per request, so the sidebar just gets
     // the static taxonomy. No per-family counts — that line is gone from
     // the SPA too.
-    use mold_catalog::families::{Family, ALL_FAMILIES};
-    let merged: Vec<serde_json::Value> = ALL_FAMILIES
-        .iter()
-        .map(|f: &Family| serde_json::json!({ "family": f.as_str() }))
+    let merged: Vec<serde_json::Value> = mold_catalog::families::active_families()
+        .map(|family| serde_json::json!({ "family": family.as_str() }))
         .collect();
     Json(serde_json::json!({ "families": merged })).into_response()
 }
@@ -778,6 +776,22 @@ pub async fn live_search_catalog(
         },
         None => None,
     };
+    if let Some(family) = family {
+        if let Err(error) =
+            mold_core::require_model_activation(family.as_str(), Some(family.as_str()))
+        {
+            return model_activation_response(error);
+        }
+    }
+    if let Some(query) =
+        q.q.as_deref()
+            .map(str::trim)
+            .filter(|query| !query.is_empty())
+    {
+        if let Err(error) = mold_core::require_model_activation(query, None) {
+            return model_activation_response(error);
+        }
+    }
     let kind = match q.kind.as_deref().filter(|s| !s.is_empty()) {
         Some(s) => match parse_kind(s) {
             Some(k) => Some(k),

--- a/crates/mold-server/src/catalog_live_test.rs
+++ b/crates/mold-server/src/catalog_live_test.rs
@@ -189,6 +189,35 @@ async fn raw_h3_catalog_routes_fail_before_upstream_lookup_or_download() {
     assert!(post_body.contains(mold_core::MINIMAX_H3_AUTHORIZATION_REQUIRED));
 }
 
+#[tokio::test]
+async fn h3_search_identity_fails_before_any_upstream_request() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(wm_path("/api/v1/models"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(0)
+        .mount(&server)
+        .await;
+    let state = AppState::for_tests().with_civitai_base(server.uri());
+    let router = create_router(state);
+
+    for uri in [
+        "/api/catalog/search?family=minimax-h3&source=civitai",
+        "/api/catalog/search?q=MiniMax-H3&source=civitai",
+    ] {
+        let (status, body) = get(router.clone(), uri).await;
+        assert_eq!(status, StatusCode::UNAVAILABLE_FOR_LEGAL_REASONS, "{body}");
+        assert!(body.contains(mold_core::MINIMAX_H3_AUTHORIZATION_REQUIRED));
+    }
+
+    assert!(server
+        .received_requests()
+        .await
+        .expect("recorded requests")
+        .is_empty());
+    server.verify().await;
+}
+
 #[test]
 fn resolved_catalog_metadata_cannot_hide_h3_behind_an_opaque_id() {
     let mut entry = hf_checkpoint("ordinary/repo");

--- a/crates/mold-server/src/model_manager.rs
+++ b/crates/mold-server/src/model_manager.rs
@@ -655,6 +655,7 @@ fn installed_catalog_models(
                 default_guidance: guidance,
                 default_frames: frames,
                 default_fps: fps,
+                min_frames: mold_core::validation::min_frames_for_family(&sidecar.family),
                 max_frames: mold_core::validation::max_frames_for_family_at_fps(
                     &sidecar.family,
                     fps.unwrap_or(mold_core::validation::LTX2_DEFAULT_FPS),
@@ -666,6 +667,7 @@ fn installed_catalog_models(
                     &sidecar.family,
                 ),
                 frame_step: mold_core::validation::frame_step_for_family(&sidecar.family),
+                frame_offset: mold_core::validation::frame_offset_for_family(&sidecar.family),
                 // Per model, through the same helper the manifest catalog
                 // uses. An installed `cv:` / `hf:` checkpoint has no spatial
                 // upsampler, so it advertises the single-pass ceiling and
@@ -1233,6 +1235,7 @@ fn manifest_component_kind(component: mold_core::manifest::ModelComponent) -> &'
         | ModelComponent::TransformerShard
         | ModelComponent::LowNoiseTransformer => "transformer",
         ModelComponent::Vae => "vae",
+        ModelComponent::AudioVae => "audio_vae",
         ModelComponent::SpatialUpscaler => "spatial_upscaler",
         ModelComponent::TemporalUpscaler => "temporal_upscaler",
         ModelComponent::DistilledLora | ModelComponent::LowNoiseDistilledLora => "distilled_lora",
@@ -1241,7 +1244,12 @@ fn manifest_component_kind(component: mold_core::manifest::ModelComponent) -> &'
         ModelComponent::T5Tokenizer
         | ModelComponent::ClipTokenizer
         | ModelComponent::ClipTokenizer2
-        | ModelComponent::TextTokenizer => "tokenizer",
+        | ModelComponent::TextTokenizer
+        | ModelComponent::Processor => "tokenizer",
+        ModelComponent::VideoScheduler
+        | ModelComponent::AudioScheduler
+        | ModelComponent::ModelConfig
+        | ModelComponent::TaskConfig => "config",
         ModelComponent::Decoder => "decoder",
         ModelComponent::Upscaler => "upscaler",
     }
@@ -1254,6 +1262,7 @@ fn manifest_component_name(component: mold_core::manifest::ModelComponent, filen
         ModelComponent::TransformerShard => "transformer shard",
         ModelComponent::LowNoiseTransformer => "low-noise transformer",
         ModelComponent::Vae => "vae",
+        ModelComponent::AudioVae => "audio vae",
         ModelComponent::SpatialUpscaler => "spatial upscaler",
         ModelComponent::TemporalUpscaler => "temporal upscaler",
         ModelComponent::DistilledLora => "distilled lora",
@@ -1266,6 +1275,11 @@ fn manifest_component_name(component: mold_core::manifest::ModelComponent, filen
         ModelComponent::ClipTokenizer2 => "clip-g tokenizer",
         ModelComponent::TextEncoder => "text encoder",
         ModelComponent::TextTokenizer => "text tokenizer",
+        ModelComponent::Processor => "processor",
+        ModelComponent::VideoScheduler => "video scheduler",
+        ModelComponent::AudioScheduler => "audio scheduler",
+        ModelComponent::ModelConfig => "model config",
+        ModelComponent::TaskConfig => "task config",
         ModelComponent::Decoder => "decoder",
         ModelComponent::Upscaler => filename,
     }

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -4427,9 +4427,8 @@ async fn server_capabilities(State(state): State<AppState>) -> Json<mold_core::S
         gallery: mold_core::GalleryCapabilities { can_delete: true },
         catalog: mold_core::CatalogCapabilities {
             available: catalog_available,
-            families: mold_catalog::families::ALL_FAMILIES
-                .iter()
-                .map(|f| f.as_str().to_string())
+            families: mold_catalog::families::active_families()
+                .map(|family| family.as_str().to_string())
                 .collect::<Vec<_>>(),
             sort: mold_catalog::live::CatalogSort::WIRE_VALUES
                 .iter()

--- a/crates/mold-server/src/routes_test.rs
+++ b/crates/mold-server/src/routes_test.rs
@@ -3901,6 +3901,9 @@ mod tests {
             body["catalog"]["sort"],
             serde_json::json!(["downloads", "recent", "rating"])
         );
+        assert!(body["catalog"]["families"]
+            .as_array()
+            .is_some_and(|families| families.iter().all(|family| family != "minimax-h3")));
         assert_eq!(
             body["model_access"]["restrictions"][0]["code"],
             mold_core::MINIMAX_H3_AUTHORIZATION_REQUIRED

--- a/crates/mold-server/tests/catalog_routes.rs
+++ b/crates/mold-server/tests/catalog_routes.rs
@@ -28,6 +28,10 @@ async fn families_endpoint_returns_static_taxonomy() {
             "family {expected:?} missing from sidebar list, got {names:?}",
         );
     }
+    assert!(
+        !names.contains(&"minimax-h3"),
+        "compliance-gated H3 must stay out of ordinary taxonomy: {names:?}"
+    );
     // Per-family counts are gone from the wire — live search hits one
     // family at a time, so the SPA's sidebar shows just the family name.
     let flux = families
@@ -46,4 +50,17 @@ async fn capabilities_includes_catalog_block() {
     let v: serde_json::Value = serde_json::from_str(&resp.body).unwrap();
     assert_eq!(v["catalog"]["available"], serde_json::Value::Bool(true));
     assert!(v["catalog"]["families"].is_array());
+    assert!(!v["catalog"]["families"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|family| family == "minimax-h3"));
+    assert!(v["model_access"]["restrictions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|restriction| {
+            restriction["family"] == "minimax-h3"
+                && restriction["code"] == mold_core::MINIMAX_H3_AUTHORIZATION_REQUIRED
+        }));
 }

--- a/desktop/src/lib/api/types.ts
+++ b/desktop/src/lib/api/types.ts
@@ -176,14 +176,18 @@ export interface ModelEntry {
   /** Server-advertised frame rate (LTX-Video ships 30, LTX-2 24); absent on
    * older servers and image models. Applied like steps/guidance. */
   default_fps?: number | null;
+  /** Minimum requestable frame count; omitted means the legacy floor of one. */
+  min_frames?: number | null;
   /** Requestable single-shot frame ceiling at `default_fps`. */
   max_frames?: number | null;
   /** Duration-based ceiling; clients recompute max frames when FPS changes. */
   max_runtime_seconds?: number | null;
   /** FPS-independent resource guard paired with `max_runtime_seconds`. */
   max_frames_absolute?: number | null;
-  /** Valid frame counts are `k * frame_step + 1`. */
+  /** Valid frame counts are `k * frame_step + frame_offset` (offset defaults to 1). */
   frame_step?: number | null;
+  /** Frame-grid offset; omitted means 1. MiniMax H3 advertises 5. */
+  frame_offset?: number | null;
 }
 
 // ── Generation ───────────────────────────────────────────────────────────

--- a/studio/lib/videoDuration.test.ts
+++ b/studio/lib/videoDuration.test.ts
@@ -4,8 +4,10 @@ import {
   formatVideoDuration,
   framesForVideoDuration,
   maxVideoFrames,
+  minVideoFrames,
   snapVideoFrames,
   videoFrameStep,
+  videoFrameOffset,
 } from "./videoDuration";
 
 const ltx2 = {
@@ -64,6 +66,30 @@ describe("video duration controls", () => {
     expect(videoFrameStep({ family: "wan", frame_step: 8 })).toBe(8);
     expect(videoFrameStep({ family: "flux" })).toBe(8);
     expect(videoFrameStep(null)).toBe(8);
+  });
+
+  it("supports MiniMax H3's 17n+5 frame grid", () => {
+    const h3 = {
+      family: "minimax-h3",
+      frame_step: 17,
+      frame_offset: 5,
+      min_frames: 124,
+      max_frames: 362,
+    };
+    expect(videoFrameStep(h3)).toBe(17);
+    expect(videoFrameOffset(h3)).toBe(5);
+    expect(minVideoFrames(h3)).toBe(124);
+    expect(snapVideoFrames(124, h3)).toBe(124);
+    expect(snapVideoFrames(243, h3)).toBe(243);
+    expect(maxVideoFrames(h3, 24)).toBe(362);
+    expect(clampVideoFrames(5, 24, h3)).toBe(124);
+    expect(framesForVideoDuration(1, 24, h3)).toBe(124);
+  });
+
+  it("prefers the server-advertised minimum over the family fallback", () => {
+    expect(minVideoFrames({ family: "minimax-h3", min_frames: 141 })).toBe(141);
+    expect(minVideoFrames({ family: "flux", min_frames: 9 })).toBe(9);
+    expect(minVideoFrames({ family: "flux" })).toBe(1);
   });
 
   it("gives wan the flat 257 ceiling on a host that advertises no max", () => {

--- a/studio/lib/videoDuration.ts
+++ b/studio/lib/videoDuration.ts
@@ -5,10 +5,12 @@ export interface VideoFrameContract {
   family?: string | null;
   default_frames?: number | null;
   default_fps?: number | null;
+  min_frames?: number | null;
   max_frames?: number | null;
   max_runtime_seconds?: number | null;
   max_frames_absolute?: number | null;
   frame_step?: number | null;
+  frame_offset?: number | null;
 }
 
 const LEGACY_FRAME_STEP = 8;
@@ -16,7 +18,8 @@ const LEGACY_MAX_FRAMES = 257;
 
 /**
  * Frame grid per family, mirroring `frame_step_for_family` in
- * `crates/mold-core/src/validation.rs`. Valid counts are `k * step + 1`.
+ * `crates/mold-core/src/validation.rs`. Valid counts are
+ * `k * step + videoFrameOffset(model)`.
  *
  * This is the fallback for a model row that names its family but not its
  * `frame_step`. It matters because the legacy default is 8 and Wan's grid is
@@ -29,6 +32,21 @@ const FAMILY_FRAME_STEP: ReadonlyMap<string, number> = new Map([
   ["ltx-2", 8],
   ["ltx-video", 8],
   ["wan", 4],
+  ["minimax-h3", 17],
+  ["minimax_h3", 17],
+  ["minimaxh3", 17],
+]);
+
+const FAMILY_FRAME_OFFSET: ReadonlyMap<string, number> = new Map([
+  ["minimax-h3", 5],
+  ["minimax_h3", 5],
+  ["minimaxh3", 5],
+]);
+
+const FAMILY_MIN_FRAMES: ReadonlyMap<string, number> = new Map([
+  ["minimax-h3", 124],
+  ["minimax_h3", 124],
+  ["minimaxh3", 124],
 ]);
 
 export function videoFrameStep(model?: VideoFrameContract | null): number {
@@ -41,16 +59,27 @@ export function videoFrameStep(model?: VideoFrameContract | null): number {
   return FAMILY_FRAME_STEP.get(family) ?? LEGACY_FRAME_STEP;
 }
 
-/** Snap a frame count onto the server's `k * step + 1` request grid. */
+export function videoFrameOffset(model?: VideoFrameContract | null): number {
+  const advertised = model?.frame_offset;
+  if (advertised != null) {
+    const offset = Math.round(advertised);
+    if (offset > 0) return offset;
+  }
+  const family = (model?.family ?? "").trim().toLowerCase();
+  return FAMILY_FRAME_OFFSET.get(family) ?? 1;
+}
+
+/** Snap a frame count onto the server's `k * step + offset` request grid. */
 export function snapVideoFrames(
   frames: number,
   model?: VideoFrameContract | null,
   direction: "nearest" | "down" = "nearest",
 ): number {
   const step = videoFrameStep(model);
-  const scaled = (Math.max(1, frames) - 1) / step;
+  const offset = videoFrameOffset(model);
+  const scaled = (Math.max(offset, frames) - offset) / step;
   const grid = direction === "down" ? Math.floor(scaled) : Math.round(scaled);
-  return Math.max(1, grid * step + 1);
+  return Math.max(offset, grid * step + offset);
 }
 
 /**
@@ -79,8 +108,14 @@ export function maxVideoFrames(
   return snapVideoFrames(cap, model, "down");
 }
 
-export function minVideoFrames(): number {
-  return 1;
+export function minVideoFrames(model?: VideoFrameContract | null): number {
+  const advertised = model?.min_frames;
+  if (advertised != null) {
+    const minimum = Math.round(advertised);
+    if (minimum > 0) return minimum;
+  }
+  const family = (model?.family ?? "").trim().toLowerCase();
+  return FAMILY_MIN_FRAMES.get(family) ?? 1;
 }
 
 export function clampVideoFrames(
@@ -90,7 +125,7 @@ export function clampVideoFrames(
 ): number {
   return Math.min(
     maxVideoFrames(model, fps),
-    Math.max(minVideoFrames(), snapVideoFrames(frames, model)),
+    Math.max(minVideoFrames(model), snapVideoFrames(frames, model)),
   );
 }
 

--- a/ui/components/VideoDurationSlider.test.ts
+++ b/ui/components/VideoDurationSlider.test.ts
@@ -51,6 +51,27 @@ describe("VideoDurationSlider", () => {
     expect(wrapper.emitted("update:frames")).toBeUndefined();
   });
 
+  it("uses the advertised minimum and offset for H3's frame grid", () => {
+    const wrapper = mount(VideoDurationSlider, {
+      props: {
+        frames: 124,
+        fps: 24,
+        model: {
+          family: "minimax-h3",
+          min_frames: 124,
+          max_frames: 362,
+          frame_step: 17,
+          frame_offset: 5,
+        },
+      },
+    });
+
+    const slider = wrapper.get('input[type="range"]');
+    expect(slider.attributes("min")).toBe("124");
+    expect(slider.attributes("max")).toBe("362");
+    expect(slider.attributes("step")).toBe("17");
+  });
+
   it("reports an intentional long-chain duration without rewriting it", () => {
     const wrapper = mount(VideoDurationSlider, {
       props: {

--- a/ui/components/VideoDurationSlider.vue
+++ b/ui/components/VideoDurationSlider.vue
@@ -61,7 +61,7 @@ function update(frames: number): void {
   >
     <SliderRow
       :model-value="sliderValue"
-      :min="minVideoFrames()"
+      :min="minVideoFrames(model)"
       :max="maximum"
       :step="videoFrameStep(model)"
       :label="label"

--- a/web/src/lib/modelFilters.ts
+++ b/web/src/lib/modelFilters.ts
@@ -57,6 +57,9 @@ const FAMILY_ORDER = [
   "ltx2",
   "ltx-2",
   "wan",
+  "minimax-h3",
+  "minimax_h3",
+  "minimaxh3",
 ];
 
 const FAMILY_LABELS: Record<string, string> = {
@@ -76,6 +79,9 @@ const FAMILY_LABELS: Record<string, string> = {
   ltx2: "LTX-2",
   "ltx-2": "LTX-2",
   wan: "Wan Video",
+  "minimax-h3": "MiniMax H3",
+  minimax_h3: "MiniMax H3",
+  minimaxh3: "MiniMax H3",
 };
 
 const VARIANT_RANKS: Record<string, number> = {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -339,14 +339,18 @@ export interface ModelInfoExtended extends ModelDefaults {
   /** Model's own default frame rate (`/api/models`, additive) — LTX-Video
    * ships 30, LTX-2 24; absent on older servers and image models. */
   default_fps?: number | null;
+  /** Minimum requestable frame count; omitted means the legacy floor of one. */
+  min_frames?: number | null;
   /** Requestable single-shot frame ceiling at `default_fps`. */
   max_frames?: number | null;
   /** Duration-based ceiling; clients recompute max frames when FPS changes. */
   max_runtime_seconds?: number | null;
   /** FPS-independent resource guard paired with `max_runtime_seconds`. */
   max_frames_absolute?: number | null;
-  /** Valid frame counts are `k * frame_step + 1`. */
+  /** Valid frame counts are `k * frame_step + frame_offset` (offset defaults to 1). */
   frame_step?: number | null;
+  /** Frame-grid offset; omitted means 1. MiniMax H3 advertises 5. */
+  frame_offset?: number | null;
 }
 
 export interface GpuInfo {


### PR DESCRIPTION
## Summary

- register four explicit, revision- and digest-pinned H3 FL2VA/Ref2VA manifest layouts for official BF16 and Comfy pruned/quantized artifacts
- add fail-closed family/capability/factory/catalog contracts without activating runtime, public discovery, or downloads
- add exact 24 fps, 17n+5 frame-grid, synchronized stereo audio, deterministic noise-domain, and official canvas-oracle validation contracts
- propagate additive min_frames/frame_offset support through Rust and shared Studio clients, including the actual duration slider boundary

This PR is stacked on #846 so its shared A/V boundary is present while the H3 component graph is introduced. It remains authorization-gated: no H3 weights are downloaded, no runtime engine is registered, and public catalog/search/download ingress returns HTTP 451.

## Verification

- nix develop -c cargo test -p mold-ai-core
- nix develop -c cargo clippy -p mold-ai-core --all-targets -- -D warnings
- nix develop -c cargo fmt --all -- --check
- bunx vitest run --config studio/vitest.config.ts studio/lib/videoDuration.test.ts
- cd desktop && bunx vitest run ../ui/components/VideoDurationSlider.test.ts
- full affected workspace, feature, server/catalog, web/desktop/mobile, and conformance gates passed on Plato before final review

Closes #816