### PR TITLE
feat(inference): add H3 audio VAE primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3140,6 +3140,7 @@ dependencies = [
  "candle-nn",
  "candle-transformers",
  "serde",
+ "serde_json",
  "tracing",
 ]
 

--- a/crates/mold-candle/Cargo.toml
+++ b/crates/mold-candle/Cargo.toml
@@ -20,4 +20,5 @@ candle = { package = "candle-core", version = "0.11" }
 candle-nn = "0.11"
 candle-transformers = "0.11"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 tracing = "0.1"

--- a/crates/mold-candle/src/lib.rs
+++ b/crates/mold-candle/src/lib.rs
@@ -5,6 +5,7 @@
 //! universal tensor/backend semantics belong upstream.
 
 pub mod ltx_video;
+pub mod minimax_h3;
 pub mod quantized;
 pub mod quantized_nn;
 pub mod stable_diffusion;

--- a/crates/mold-candle/src/minimax_h3/audio.rs
+++ b/crates/mold-candle/src/minimax_h3/audio.rs
@@ -1,0 +1,1608 @@
+//! MiniMax H3 DAC/BigVGAN audio autoencoder primitives.
+//!
+//! This module is intentionally a model primitive, not an inference engine.
+//! It performs no downloads and is not reachable from Mold's model factory.
+
+use std::f64::consts::PI;
+
+use candle::{bail, DType, Device, Module, Result, Tensor, D};
+use candle_nn::{
+    Conv1d, Conv1dConfig, ConvTranspose1d, ConvTranspose1dConfig, LayerNorm, Linear, VarBuilder,
+};
+
+use super::audio_config::{AudioVaeConfig, SAMPLE_RATE};
+use super::audio_weights::AudioTensorLayout;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AudioVaePhase {
+    EncodePreprocess,
+    EncodeDac,
+    EncodeProjection,
+    EncodePosterior,
+    DecodeProjection,
+    DecodeBigVgan,
+    DecodeOutput,
+}
+
+pub trait AudioVaeCancellation: Send + Sync {
+    fn is_cancelled(&self, phase: AudioVaePhase) -> bool;
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct NeverCancel;
+
+impl AudioVaeCancellation for NeverCancel {
+    fn is_cancelled(&self, _phase: AudioVaePhase) -> bool {
+        false
+    }
+}
+
+fn cancellation_boundary(
+    cancellation: &dyn AudioVaeCancellation,
+    phase: AudioVaePhase,
+) -> Result<()> {
+    if cancellation.is_cancelled(phase) {
+        bail!("MiniMax H3 audio VAE cancelled at {phase:?}")
+    }
+    Ok(())
+}
+
+/// Association survives the audio boundary without introducing pipeline or
+/// packed-reference policy into this model crate.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AudioSoundtrackAssociation {
+    Generated,
+    StandaloneReference { reference_index: usize },
+    VideoSoundtrack { reference_index: usize },
+}
+
+/// Typed `[batch, stereo=2, samples]` FP32 waveform.
+#[derive(Clone, Debug)]
+pub struct StereoWaveform {
+    samples: Tensor,
+    association: AudioSoundtrackAssociation,
+}
+
+impl StereoWaveform {
+    pub fn new(
+        samples: Tensor,
+        sample_rate: usize,
+        association: AudioSoundtrackAssociation,
+    ) -> Result<Self> {
+        require_f32(&samples, "stereo waveform")?;
+        let (_batch, channels, samples_len) = samples.dims3()?;
+        if channels != 2 || samples_len == 0 {
+            bail!(
+                "MiniMax H3 stereo waveform must have shape [batch, 2, samples>0], got {:?}",
+                samples.dims()
+            )
+        }
+        if sample_rate != SAMPLE_RATE {
+            bail!("MiniMax H3 audio waveform must be {SAMPLE_RATE} Hz, got {sample_rate} Hz")
+        }
+        Ok(Self {
+            samples,
+            association,
+        })
+    }
+
+    #[doc(hidden)]
+    pub(super) fn new_for_config(
+        samples: Tensor,
+        _config: &AudioVaeConfig,
+        association: AudioSoundtrackAssociation,
+    ) -> Result<Self> {
+        require_f32(&samples, "stereo waveform")?;
+        let (_batch, channels, samples_len) = samples.dims3()?;
+        if channels != 2 || samples_len == 0 {
+            bail!("stereo waveform must have shape [batch, 2, samples>0]")
+        }
+        Ok(Self {
+            samples,
+            association,
+        })
+    }
+
+    pub fn samples(&self) -> &Tensor {
+        &self.samples
+    }
+
+    pub fn association(&self) -> AudioSoundtrackAssociation {
+        self.association
+    }
+
+    /// Channel-major batch packing used by all three pinned implementations:
+    /// `[B, 2, L] -> [B*2, 1, L]` with `B0-L, B0-R, B1-L, B1-R` order.
+    pub fn pack_mono_batch(&self) -> Result<Tensor> {
+        let (batch, channels, samples) = self.samples.dims3()?;
+        self.samples.reshape((batch * channels, 1, samples))
+    }
+
+    pub fn from_mono_batch(
+        mono: Tensor,
+        batch: usize,
+        sample_rate: usize,
+        association: AudioSoundtrackAssociation,
+    ) -> Result<Self> {
+        require_f32(&mono, "mono batch")?;
+        let (mono_batch, channels, samples) = mono.dims3()?;
+        if channels != 1 || mono_batch != batch * 2 || samples == 0 {
+            bail!(
+                "MiniMax H3 mono batch must have shape [{}, 1, samples>0], got {:?}",
+                batch * 2,
+                mono.dims()
+            )
+        }
+        Self::new(mono.reshape((batch, 2, samples))?, sample_rate, association)
+    }
+
+    fn from_mono_batch_for_config(
+        mono: Tensor,
+        batch: usize,
+        config: &AudioVaeConfig,
+        association: AudioSoundtrackAssociation,
+    ) -> Result<Self> {
+        require_f32(&mono, "mono batch")?;
+        let (mono_batch, channels, samples) = mono.dims3()?;
+        if channels != 1 || mono_batch != batch * 2 || samples == 0 {
+            bail!("mono batch does not match the MiniMax H3 stereo contract")
+        }
+        Self::new_for_config(mono.reshape((batch, 2, samples))?, config, association)
+    }
+}
+
+/// Typed normalized `[batch, latent_channels, stereo=2, rows]` tensor.
+#[derive(Clone, Debug)]
+pub struct StereoLatents {
+    normalized: Tensor,
+}
+
+impl StereoLatents {
+    pub fn new(normalized: Tensor, config: &AudioVaeConfig) -> Result<Self> {
+        require_f32(&normalized, "normalized stereo audio latents")?;
+        let (_batch, channels, stereo, rows) = normalized.dims4()?;
+        if channels != config.latent_channels || stereo != 2 || rows == 0 {
+            bail!(
+                "MiniMax H3 stereo latents must have shape [batch, {}, 2, rows>0], got {:?}",
+                config.latent_channels,
+                normalized.dims()
+            )
+        }
+        Ok(Self { normalized })
+    }
+
+    pub fn normalized(&self) -> &Tensor {
+        &self.normalized
+    }
+
+    pub fn pack_mono_batch(&self) -> Result<Tensor> {
+        let (batch, channels, stereo, rows) = self.normalized.dims4()?;
+        self.normalized
+            .permute((0, 2, 1, 3))?
+            .reshape((batch * stereo, channels, rows))
+    }
+
+    pub fn from_mono_batch(packed: Tensor, batch: usize, config: &AudioVaeConfig) -> Result<Self> {
+        require_f32(&packed, "packed normalized audio latents")?;
+        let (mono_batch, channels, rows) = packed.dims3()?;
+        if mono_batch != batch * 2 || channels != config.latent_channels || rows == 0 {
+            bail!("packed audio latents do not match the stereo/config contract")
+        }
+        let normalized = packed
+            .reshape((batch, 2, channels, rows))?
+            .permute((0, 2, 1, 3))?;
+        Self::new(normalized, config)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct AudioPosterior {
+    pub mean: Tensor,
+    pub logs: Tensor,
+}
+
+pub enum AudioPosteriorSelection<'a> {
+    Mode,
+    Sample { noise: &'a Tensor },
+}
+
+impl AudioPosterior {
+    pub fn new(mean: Tensor, logs: Tensor) -> Result<Self> {
+        require_f32(&mean, "audio posterior mean")?;
+        require_f32(&logs, "audio posterior log standard deviation")?;
+        if mean.dims() != logs.dims() {
+            bail!("MiniMax H3 audio posterior mean/logs shapes differ")
+        }
+        Ok(Self { mean, logs })
+    }
+
+    pub fn mode(&self) -> Tensor {
+        self.mean.clone()
+    }
+
+    pub fn select(&self, selection: AudioPosteriorSelection<'_>) -> Result<Tensor> {
+        match selection {
+            AudioPosteriorSelection::Mode => Ok(self.mode()),
+            AudioPosteriorSelection::Sample { noise } => {
+                require_f32(noise, "audio posterior noise")?;
+                if noise.dims() != self.mean.dims() {
+                    bail!("MiniMax H3 audio posterior noise shape differs from the posterior")
+                }
+                self.mean
+                    .broadcast_add(&self.logs.exp()?.broadcast_mul(noise)?)
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct Snake1d {
+    alpha: Tensor,
+}
+
+impl Snake1d {
+    fn load(channels: usize, vb: VarBuilder) -> Result<Self> {
+        Ok(Self {
+            alpha: vb.get((1, channels, 1), "alpha")?,
+        })
+    }
+
+    fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        require_f32(x, "Snake1d input")?;
+        let phase = x.broadcast_mul(&self.alpha)?;
+        let correction = phase
+            .sin()?
+            .sqr()?
+            .broadcast_div(&self.alpha.affine(1.0, 1e-9)?)?;
+        x.broadcast_add(&correction)
+    }
+}
+
+#[derive(Clone, Debug)]
+struct SnakeBeta {
+    alpha: Tensor,
+    beta: Tensor,
+}
+
+impl SnakeBeta {
+    fn load(channels: usize, vb: VarBuilder) -> Result<Self> {
+        Ok(Self {
+            alpha: vb.get(channels, "alpha")?,
+            beta: vb.get(channels, "beta")?,
+        })
+    }
+
+    fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        require_f32(x, "SnakeBeta input")?;
+        let alpha = self.alpha.exp()?.reshape((1, self.alpha.dims1()?, 1))?;
+        let beta = self.beta.exp()?.reshape((1, self.beta.dims1()?, 1))?;
+        let correction = x
+            .broadcast_mul(&alpha)?
+            .sin()?
+            .sqr()?
+            .broadcast_div(&beta.affine(1.0, 1e-9)?)?;
+        x.broadcast_add(&correction)
+    }
+}
+
+pub fn snake_value(x: f32, alpha: f32) -> f32 {
+    x + (alpha * x).sin().powi(2) / (alpha + 1e-9)
+}
+
+pub fn snake_beta_value(x: f32, log_alpha: f32, log_beta: f32) -> f32 {
+    let alpha = log_alpha.exp();
+    let beta = log_beta.exp();
+    x + (alpha * x).sin().powi(2) / (beta + 1e-9)
+}
+
+/// Exact alias-free-torch Kaiser-windowed sinc recipe used by BigVGAN.
+pub fn kaiser_sinc_coefficients(
+    cutoff: f64,
+    half_width: f64,
+    kernel_size: usize,
+) -> Result<Vec<f32>> {
+    if !(0.0..=0.5).contains(&cutoff) || half_width <= 0.0 || kernel_size < 2 {
+        bail!("invalid MiniMax H3 Kaiser-sinc filter parameters")
+    }
+    let half_size = kernel_size / 2;
+    let attenuation = 2.285 * (half_size - 1) as f64 * PI * (4.0 * half_width) + 7.95;
+    let beta = if attenuation > 50.0 {
+        0.1102 * (attenuation - 8.7)
+    } else if attenuation >= 21.0 {
+        0.5842 * (attenuation - 21.0).powf(0.4) + 0.07886 * (attenuation - 21.0)
+    } else {
+        0.0
+    };
+    let denom = bessel_i0(beta);
+    let mut filter = Vec::with_capacity(kernel_size);
+    for index in 0..kernel_size {
+        let window_position = 2.0 * index as f64 / (kernel_size - 1) as f64 - 1.0;
+        let window = bessel_i0(beta * (1.0 - window_position * window_position).sqrt()) / denom;
+        let time = if kernel_size.is_multiple_of(2) {
+            index as f64 - half_size as f64 + 0.5
+        } else {
+            index as f64 - half_size as f64
+        };
+        filter.push((2.0 * cutoff * window * sinc(2.0 * cutoff * time)) as f32);
+    }
+    let sum = filter.iter().map(|value| *value as f64).sum::<f64>();
+    if !sum.is_finite() || sum == 0.0 {
+        bail!("MiniMax H3 Kaiser-sinc filter has a non-finite/zero sum")
+    }
+    for value in &mut filter {
+        *value = (*value as f64 / sum) as f32;
+    }
+    Ok(filter)
+}
+
+fn sinc(value: f64) -> f64 {
+    if value == 0.0 {
+        1.0
+    } else {
+        (PI * value).sin() / (PI * value)
+    }
+}
+
+fn bessel_i0(value: f64) -> f64 {
+    // Convergent definition used at initialization only. The H3 kernel's beta
+    // needs fewer than 30 terms for f64 machine precision.
+    let y = value * value / 4.0;
+    let mut sum = 1.0;
+    let mut term = 1.0;
+    for k in 1..=64 {
+        term *= y / (k * k) as f64;
+        sum += term;
+        if term <= f64::EPSILON * sum {
+            break;
+        }
+    }
+    sum
+}
+
+#[derive(Clone, Debug)]
+struct UpSample1d {
+    ratio: usize,
+    pad: usize,
+    pad_left: usize,
+    pad_right: usize,
+    filter: Tensor,
+}
+
+impl UpSample1d {
+    fn load(ratio: usize, vb: VarBuilder) -> Result<Self> {
+        let kernel_size = 12usize;
+        let filter = vb.get((1, 1, kernel_size), "filter")?;
+        let pad = kernel_size / ratio - 1;
+        Ok(Self {
+            ratio,
+            pad,
+            pad_left: pad * ratio + (kernel_size - ratio) / 2,
+            pad_right: pad * ratio + (kernel_size - ratio).div_ceil(2),
+            filter,
+        })
+    }
+
+    fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        require_f32(x, "alias-free upsample input")?;
+        let (_, channels, _) = x.dims3()?;
+        let x = replicate_pad_1d(x, self.pad, self.pad)?.contiguous()?;
+        let filter = materialize_group_filter(&self.filter, channels, x.device())?;
+        let y = x
+            .conv_transpose1d(&filter, 0, 0, self.ratio, 1, channels)?
+            .affine(self.ratio as f64, 0.0)?;
+        let output_len = y.dim(2)?;
+        y.narrow(
+            2,
+            self.pad_left,
+            output_len.saturating_sub(self.pad_left + self.pad_right),
+        )
+    }
+}
+
+#[derive(Clone, Debug)]
+struct DownSample1d {
+    ratio: usize,
+    pad_left: usize,
+    pad_right: usize,
+    filter: Tensor,
+}
+
+impl DownSample1d {
+    fn load(ratio: usize, vb: VarBuilder) -> Result<Self> {
+        let kernel_size = 12usize;
+        Ok(Self {
+            ratio,
+            pad_left: kernel_size / 2 - usize::from(kernel_size.is_multiple_of(2)),
+            pad_right: kernel_size / 2,
+            filter: vb.pp("lowpass").get((1, 1, kernel_size), "filter")?,
+        })
+    }
+
+    fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        require_f32(x, "alias-free downsample input")?;
+        let (_, channels, _) = x.dims3()?;
+        let x = replicate_pad_1d(x, self.pad_left, self.pad_right)?.contiguous()?;
+        let filter = materialize_group_filter(&self.filter, channels, x.device())?;
+        x.conv1d(&filter, 0, self.ratio, 1, channels)
+    }
+}
+
+#[derive(Clone, Debug)]
+struct Activation1d {
+    activation: SnakeBeta,
+    upsample: UpSample1d,
+    downsample: DownSample1d,
+}
+
+impl Activation1d {
+    fn load(channels: usize, vb: VarBuilder) -> Result<Self> {
+        Ok(Self {
+            activation: SnakeBeta::load(channels, vb.pp("act"))?,
+            upsample: UpSample1d::load(2, vb.pp("upsample"))?,
+            downsample: DownSample1d::load(2, vb.pp("downsample"))?,
+        })
+    }
+
+    fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        self.downsample
+            .forward(&self.activation.forward(&self.upsample.forward(x)?)?)
+    }
+}
+
+#[derive(Clone, Debug)]
+struct ResidualUnit {
+    snake1: Snake1d,
+    conv1: Conv1d,
+    snake2: Snake1d,
+    conv2: Conv1d,
+}
+
+impl ResidualUnit {
+    fn load(
+        dim: usize,
+        dilation: usize,
+        layout: AudioTensorLayout,
+        vb: VarBuilder,
+    ) -> Result<Self> {
+        Ok(Self {
+            snake1: Snake1d::load(dim, vb.pp("block.0"))?,
+            conv1: load_conv1d(
+                dim,
+                dim,
+                7,
+                ((7 - 1) * dilation) / 2,
+                1,
+                dilation,
+                true,
+                layout,
+                vb.pp("block.1"),
+            )?,
+            snake2: Snake1d::load(dim, vb.pp("block.2"))?,
+            conv2: load_conv1d(dim, dim, 1, 0, 1, 1, true, layout, vb.pp("block.3"))?,
+        })
+    }
+
+    fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let residual = self.conv2.forward(
+            &self
+                .snake2
+                .forward(&self.conv1.forward(&self.snake1.forward(x)?)?)?,
+        )?;
+        let pad = (x.dim(2)? - residual.dim(2)?) / 2;
+        let shortcut = if pad > 0 {
+            x.narrow(2, pad, x.dim(2)? - 2 * pad)?
+        } else {
+            x.clone()
+        };
+        shortcut.add(&residual)
+    }
+}
+
+#[derive(Clone, Debug)]
+struct EncoderBlock {
+    residuals: Vec<ResidualUnit>,
+    snake: Snake1d,
+    downsample: Conv1d,
+}
+
+impl EncoderBlock {
+    fn load(dim: usize, stride: usize, layout: AudioTensorLayout, vb: VarBuilder) -> Result<Self> {
+        let half = dim / 2;
+        Ok(Self {
+            residuals: [1usize, 3, 9]
+                .iter()
+                .enumerate()
+                .map(|(index, dilation)| {
+                    ResidualUnit::load(half, *dilation, layout, vb.pp(format!("block.{index}")))
+                })
+                .collect::<Result<Vec<_>>>()?,
+            snake: Snake1d::load(half, vb.pp("block.3"))?,
+            downsample: load_conv1d(
+                half,
+                dim,
+                2 * stride,
+                stride.div_ceil(2),
+                stride,
+                1,
+                true,
+                layout,
+                vb.pp("block.4"),
+            )?,
+        })
+    }
+
+    fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let mut x = x.clone();
+        for residual in &self.residuals {
+            x = residual.forward(&x)?;
+        }
+        self.downsample.forward(&self.snake.forward(&x)?)
+    }
+}
+
+#[derive(Clone, Debug)]
+struct DacEncoder {
+    conv_in: Conv1d,
+    blocks: Vec<EncoderBlock>,
+    snake_out: Snake1d,
+    conv_out: Conv1d,
+}
+
+impl DacEncoder {
+    fn load(config: &AudioVaeConfig, layout: AudioTensorLayout, vb: VarBuilder) -> Result<Self> {
+        let conv_in = load_conv1d(
+            1,
+            config.encoder_dim,
+            7,
+            3,
+            1,
+            1,
+            true,
+            layout,
+            vb.pp("block.0"),
+        )?;
+        let mut dim = config.encoder_dim;
+        let mut blocks = Vec::with_capacity(config.encoder_rates.len());
+        for (index, stride) in config.encoder_rates.iter().copied().enumerate() {
+            dim *= 2;
+            blocks.push(EncoderBlock::load(
+                dim,
+                stride,
+                layout,
+                vb.pp(format!("block.{}", index + 1)),
+            )?);
+        }
+        let final_index = config.encoder_rates.len() + 1;
+        Ok(Self {
+            conv_in,
+            blocks,
+            snake_out: Snake1d::load(dim, vb.pp(format!("block.{final_index}")))?,
+            conv_out: load_conv1d(
+                dim,
+                config.latent_dim,
+                3,
+                1,
+                1,
+                1,
+                true,
+                layout,
+                vb.pp(format!("block.{}", final_index + 1)),
+            )?,
+        })
+    }
+
+    fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let mut x = self.conv_in.forward(x)?;
+        for block in &self.blocks {
+            x = block.forward(&x)?;
+        }
+        self.conv_out.forward(&self.snake_out.forward(&x)?)
+    }
+}
+
+#[derive(Clone, Debug)]
+struct GeGluMlp {
+    norm: LayerNorm,
+    w0: Linear,
+    w1: Linear,
+    w2: Linear,
+}
+
+impl GeGluMlp {
+    fn load(in_features: usize, hidden_features: usize, vb: VarBuilder) -> Result<Self> {
+        Ok(Self {
+            norm: candle_nn::layer_norm(in_features, 1e-5, vb.pp("norm"))?,
+            w0: candle_nn::linear(in_features, hidden_features, vb.pp("w0"))?,
+            w1: candle_nn::linear(in_features, hidden_features, vb.pp("w1"))?,
+            w2: candle_nn::linear(hidden_features, in_features, vb.pp("w2"))?,
+        })
+    }
+
+    fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let x = self.norm.forward(x)?;
+        let gate = candle_nn::Activation::GeluPytorchTanh.forward(&self.w0.forward(&x)?)?;
+        self.w2.forward(&gate.broadcast_mul(&self.w1.forward(&x)?)?)
+    }
+}
+
+#[derive(Clone, Debug)]
+struct CausalAttention {
+    qkv: Linear,
+    q_bias: Tensor,
+    zero_k_bias: Tensor,
+    v_bias: Tensor,
+    proj: Linear,
+    heads: usize,
+    head_dim: usize,
+    out_dim: usize,
+}
+
+impl CausalAttention {
+    fn load(in_dim: usize, out_dim: usize, heads: usize, vb: VarBuilder) -> Result<Self> {
+        Ok(Self {
+            qkv: candle_nn::linear_no_bias(in_dim, in_dim * 3, vb.pp("qkv"))?,
+            q_bias: vb.get(in_dim, "q_bias")?,
+            zero_k_bias: vb.get(in_dim, "zero_k_bias")?,
+            v_bias: vb.get(in_dim, "v_bias")?,
+            proj: candle_nn::linear(out_dim, out_dim, vb.pp("proj"))?,
+            heads,
+            head_dim: in_dim / heads,
+            out_dim,
+        })
+    }
+
+    fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        require_f32(x, "causal attention input")?;
+        let (batch, rows, in_dim) = x.dims3()?;
+        let bias = Tensor::cat(&[&self.q_bias, &self.zero_k_bias, &self.v_bias], 0)?;
+        let qkv = self.qkv.forward(x)?.broadcast_add(&bias)?;
+        let qkv = qkv
+            .reshape((batch, rows, 3, self.heads, self.head_dim))?
+            .permute((2, 0, 3, 1, 4))?;
+        let query = qkv.narrow(0, 0, 1)?.squeeze(0)?.contiguous()?;
+        let key = qkv.narrow(0, 1, 1)?.squeeze(0)?.contiguous()?;
+        let value = qkv.narrow(0, 2, 1)?.squeeze(0)?.contiguous()?;
+        let scores = query
+            .matmul(&key.transpose(2, 3)?.contiguous()?)?
+            .affine(1.0 / (self.head_dim as f64).sqrt(), 0.0)?;
+        let mask = causal_mask(rows, x.device())?;
+        let probabilities = candle_nn::ops::softmax_last_dim(&scores.broadcast_add(&mask)?)?;
+        let attended = probabilities.matmul(&value)?;
+        let mean_heads = attended.sum(1)?.affine(1.0 / self.heads as f64, 0.0)?;
+        let pool = self.head_dim / self.out_dim;
+        let pooled = mean_heads
+            .reshape((batch, rows, self.out_dim, pool))?
+            .sum(D::Minus1)?
+            .affine(1.0 / pool as f64, 0.0)?;
+        if in_dim != self.heads * self.head_dim {
+            bail!("MiniMax H3 audio causal attention dimensions drifted")
+        }
+        self.proj.forward(&pooled)
+    }
+}
+
+#[derive(Clone, Debug)]
+struct AttnProjection {
+    norm1: LayerNorm,
+    attention: CausalAttention,
+    proj: Linear,
+    norm3: LayerNorm,
+    norm2: LayerNorm,
+    mlp: GeGluMlp,
+}
+
+impl AttnProjection {
+    fn load(in_dim: usize, out_dim: usize, heads: usize, vb: VarBuilder) -> Result<Self> {
+        Ok(Self {
+            norm1: candle_nn::layer_norm(in_dim, 1e-5, vb.pp("norm1"))?,
+            attention: CausalAttention::load(in_dim, out_dim, heads, vb.pp("attn"))?,
+            proj: candle_nn::linear(in_dim, out_dim, vb.pp("proj"))?,
+            norm3: candle_nn::layer_norm(in_dim, 1e-5, vb.pp("norm3"))?,
+            norm2: candle_nn::layer_norm(out_dim, 1e-5, vb.pp("norm2"))?,
+            mlp: GeGluMlp::load(out_dim, out_dim * 2, vb.pp("mlp"))?,
+        })
+    }
+
+    fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let residual = self
+            .proj
+            .forward(&self.norm3.forward(x)?)?
+            .add(&self.attention.forward(&self.norm1.forward(x)?)?)?;
+        residual.add(&self.mlp.forward(&self.norm2.forward(&residual)?)?)
+    }
+}
+
+#[derive(Clone, Debug)]
+struct AmpBlock {
+    convs1: Vec<Conv1d>,
+    convs2: Vec<Conv1d>,
+    activations: Vec<Activation1d>,
+}
+
+impl AmpBlock {
+    fn load(
+        channels: usize,
+        kernel: usize,
+        dilations: &[usize],
+        layout: AudioTensorLayout,
+        vb: VarBuilder,
+    ) -> Result<Self> {
+        let mut convs1 = Vec::with_capacity(dilations.len());
+        let mut convs2 = Vec::with_capacity(dilations.len());
+        let mut activations = Vec::with_capacity(dilations.len() * 2);
+        for (index, dilation) in dilations.iter().copied().enumerate() {
+            convs1.push(load_conv1d(
+                channels,
+                channels,
+                kernel,
+                (kernel * dilation - dilation) / 2,
+                1,
+                dilation,
+                true,
+                layout,
+                vb.pp(format!("convs1.{index}")),
+            )?);
+            convs2.push(load_conv1d(
+                channels,
+                channels,
+                kernel,
+                (kernel - 1) / 2,
+                1,
+                1,
+                true,
+                layout,
+                vb.pp(format!("convs2.{index}")),
+            )?);
+        }
+        for index in 0..(dilations.len() * 2) {
+            activations.push(Activation1d::load(
+                channels,
+                vb.pp(format!("activations.{index}")),
+            )?);
+        }
+        Ok(Self {
+            convs1,
+            convs2,
+            activations,
+        })
+    }
+
+    fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let mut x = x.clone();
+        for index in 0..self.convs1.len() {
+            let residual =
+                self.convs2[index].forward(&self.activations[2 * index + 1].forward(
+                    &self.convs1[index].forward(&self.activations[2 * index].forward(&x)?)?,
+                )?)?;
+            x = x.add(&residual)?;
+        }
+        Ok(x)
+    }
+}
+
+#[derive(Clone, Debug)]
+struct BigVganDecoder {
+    conv_pre: Conv1d,
+    upsamplers: Vec<ConvTranspose1d>,
+    resblocks: Vec<AmpBlock>,
+    num_kernels: usize,
+    activation_post: Activation1d,
+    conv_post: Conv1d,
+}
+
+impl BigVganDecoder {
+    fn load(config: &AudioVaeConfig, layout: AudioTensorLayout, vb: VarBuilder) -> Result<Self> {
+        let conv_pre = load_conv1d(
+            config.latent_dim,
+            config.decoder_dim,
+            7,
+            3,
+            1,
+            1,
+            true,
+            layout,
+            vb.pp("conv_pre"),
+        )?;
+        let num_kernels = config.resblock_kernel_sizes.len();
+        let mut upsamplers = Vec::with_capacity(config.decoder_rates.len());
+        let mut resblocks = Vec::with_capacity(config.decoder_rates.len() * num_kernels);
+        for (stage, (rate, kernel)) in config
+            .decoder_rates
+            .iter()
+            .zip(&config.decoder_kernel_sizes)
+            .enumerate()
+        {
+            let in_channels = config.decoder_dim / (1usize << stage);
+            let out_channels = config.decoder_dim / (1usize << (stage + 1));
+            upsamplers.push(load_conv_transpose1d(
+                in_channels,
+                out_channels,
+                *kernel,
+                (kernel - rate) / 2,
+                *rate,
+                true,
+                layout,
+                vb.pp(format!("ups.{stage}.0")),
+            )?);
+            for (kernel_index, (res_kernel, dilations)) in config
+                .resblock_kernel_sizes
+                .iter()
+                .zip(&config.resblock_dilation_sizes)
+                .enumerate()
+            {
+                resblocks.push(AmpBlock::load(
+                    out_channels,
+                    *res_kernel,
+                    dilations,
+                    layout,
+                    vb.pp(format!("resblocks.{}", stage * num_kernels + kernel_index)),
+                )?);
+            }
+        }
+        let final_channels = config.decoder_dim / (1usize << config.decoder_rates.len());
+        Ok(Self {
+            conv_pre,
+            upsamplers,
+            resblocks,
+            num_kernels,
+            activation_post: Activation1d::load(final_channels, vb.pp("activation_post"))?,
+            conv_post: load_conv1d(
+                final_channels,
+                1,
+                7,
+                3,
+                1,
+                1,
+                false,
+                layout,
+                vb.pp("conv_post"),
+            )?,
+        })
+    }
+
+    fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let mut x = self.conv_pre.forward(x)?;
+        for (stage, upsampler) in self.upsamplers.iter().enumerate() {
+            x = upsampler.forward(&x)?;
+            let mut sum: Option<Tensor> = None;
+            for block in &self.resblocks[stage * self.num_kernels..(stage + 1) * self.num_kernels] {
+                let output = block.forward(&x)?;
+                sum = Some(match sum {
+                    Some(previous) => previous.add(&output)?,
+                    None => output,
+                });
+            }
+            x = sum
+                .ok_or_else(|| candle::Error::Msg("BigVGAN stage has no AMP blocks".into()))?
+                .affine(1.0 / self.num_kernels as f64, 0.0)?;
+        }
+        self.conv_post
+            .forward(&self.activation_post.forward(&x)?)?
+            .clamp(-1f32, 1f32)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct AudioVae {
+    config: AudioVaeConfig,
+    encoder: DacEncoder,
+    pre_block: AttnProjection,
+    mean_proj: Conv1d,
+    logs_proj: Conv1d,
+    dec_in_proj: Conv1d,
+    decoder: BigVganDecoder,
+    latent_mean: Tensor,
+    latent_std: Tensor,
+}
+
+impl AudioVae {
+    pub(super) fn load(
+        config: AudioVaeConfig,
+        layout: AudioTensorLayout,
+        requested_dtype: DType,
+        vb: VarBuilder,
+    ) -> Result<Self> {
+        config.validate()?;
+        config.validate_execution_dtype(requested_dtype)?;
+        if vb.dtype() != DType::F32 {
+            bail!("MiniMax H3 audio VarBuilder must expose F32 tensors")
+        }
+        let latent_mean = Tensor::from_vec(
+            config.latents_mean.clone(),
+            (1, config.latent_channels, 1),
+            vb.device(),
+        )?;
+        let latent_std = Tensor::from_vec(
+            config.latents_std.clone(),
+            (1, config.latent_channels, 1),
+            vb.device(),
+        )?;
+        let encoder = DacEncoder::load(&config, layout, vb.pp("encoder"))?;
+        let pre_block = AttnProjection::load(
+            config.latent_dim,
+            config.latent_channels,
+            config.attention_heads,
+            vb.pp("pre_block"),
+        )?;
+        let mean_proj = load_plain_conv1d(
+            config.latent_channels,
+            config.latent_channels,
+            1,
+            0,
+            1,
+            1,
+            true,
+            vb.pp("mean_proj"),
+        )?;
+        // Loaded even though H3 selects the posterior mode. This makes a
+        // truncated/missing stochastic head fail strict construction.
+        let logs_proj = load_plain_conv1d(
+            config.latent_channels,
+            config.latent_channels,
+            1,
+            0,
+            1,
+            1,
+            true,
+            vb.pp("logs_proj"),
+        )?;
+        let dec_in_proj = load_plain_conv1d(
+            config.latent_channels,
+            config.latent_dim,
+            1,
+            0,
+            1,
+            1,
+            true,
+            vb.pp("dec_in_proj"),
+        )?;
+        let decoder = BigVganDecoder::load(&config, layout, vb.pp("decoder"))?;
+        Ok(Self {
+            config,
+            encoder,
+            pre_block,
+            mean_proj,
+            logs_proj,
+            dec_in_proj,
+            decoder,
+            latent_mean,
+            latent_std,
+        })
+    }
+
+    pub fn config(&self) -> &AudioVaeConfig {
+        &self.config
+    }
+
+    pub fn normalize_mono_latents(&self, latents: &Tensor) -> Result<Tensor> {
+        require_f32(latents, "denormalized audio latents")?;
+        let (_batch, channels, _rows) = latents.dims3()?;
+        if channels != self.config.latent_channels {
+            bail!("audio latent channel count does not match the VAE")
+        }
+        latents
+            .broadcast_sub(&self.latent_mean)?
+            .broadcast_div(&self.latent_std)
+    }
+
+    pub fn denormalize_mono_latents(&self, normalized: &Tensor) -> Result<Tensor> {
+        require_f32(normalized, "normalized audio latents")?;
+        let (_batch, channels, _rows) = normalized.dims3()?;
+        if channels != self.config.latent_channels {
+            bail!("audio latent channel count does not match the VAE")
+        }
+        normalized
+            .broadcast_mul(&self.latent_std)?
+            .broadcast_add(&self.latent_mean)
+    }
+
+    pub fn encode_posterior(
+        &self,
+        waveform: &StereoWaveform,
+        cancellation: &dyn AudioVaeCancellation,
+    ) -> Result<(AudioPosterior, usize)> {
+        cancellation_boundary(cancellation, AudioVaePhase::EncodePreprocess)?;
+        let (batch, _, samples) = waveform.samples().dims3()?;
+        let padded = self.config.padded_samples(samples)?;
+        let mut mono = waveform.pack_mono_batch()?;
+        if padded > samples {
+            mono = mono.pad_with_zeros(2, 0, padded - samples)?;
+        }
+        cancellation_boundary(cancellation, AudioVaePhase::EncodeDac)?;
+        let encoded = self.encoder.forward(&mono)?;
+        cancellation_boundary(cancellation, AudioVaePhase::EncodeProjection)?;
+        let projected = self
+            .pre_block
+            .forward(&encoded.transpose(1, 2)?)?
+            .transpose(1, 2)?;
+        cancellation_boundary(cancellation, AudioVaePhase::EncodePosterior)?;
+        let mean = self.mean_proj.forward(&projected)?;
+        let logs = self.logs_proj.forward(&projected)?;
+        Ok((AudioPosterior::new(mean, logs)?, batch))
+    }
+
+    /// H3-authoritative encoding: posterior mode, then per-channel normalize.
+    pub fn encode(
+        &self,
+        waveform: &StereoWaveform,
+        cancellation: &dyn AudioVaeCancellation,
+    ) -> Result<StereoLatents> {
+        let (posterior, batch) = self.encode_posterior(waveform, cancellation)?;
+        let normalized = self.normalize_mono_latents(&posterior.mode())?;
+        StereoLatents::from_mono_batch(normalized, batch, &self.config)
+    }
+
+    pub fn decode(
+        &self,
+        latents: &StereoLatents,
+        association: AudioSoundtrackAssociation,
+        cancellation: &dyn AudioVaeCancellation,
+    ) -> Result<StereoWaveform> {
+        cancellation_boundary(cancellation, AudioVaePhase::DecodeProjection)?;
+        let (batch, _, _, _) = latents.normalized().dims4()?;
+        let packed = latents.pack_mono_batch()?;
+        let denormalized = self.denormalize_mono_latents(&packed)?;
+        let projected = self.dec_in_proj.forward(&denormalized)?;
+        cancellation_boundary(cancellation, AudioVaePhase::DecodeBigVgan)?;
+        let decoded = self.decoder.forward(&projected)?;
+        cancellation_boundary(cancellation, AudioVaePhase::DecodeOutput)?;
+        if self.config.sample_rate == SAMPLE_RATE {
+            StereoWaveform::from_mono_batch(decoded, batch, self.config.sample_rate, association)
+        } else {
+            StereoWaveform::from_mono_batch_for_config(decoded, batch, &self.config, association)
+        }
+    }
+}
+
+fn require_f32(tensor: &Tensor, label: &str) -> Result<()> {
+    if tensor.dtype() != DType::F32 {
+        bail!("MiniMax H3 {label} must be F32, got {:?}", tensor.dtype())
+    }
+    Ok(())
+}
+
+fn causal_mask(rows: usize, device: &Device) -> Result<Tensor> {
+    let values = (0..rows)
+        .flat_map(|query| {
+            (0..rows).map(move |key| {
+                if key <= query {
+                    0.0f32
+                } else {
+                    f32::NEG_INFINITY
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+    Tensor::from_vec(values, (1, 1, rows, rows), device)
+}
+
+fn replicate_pad_1d(x: &Tensor, left: usize, right: usize) -> Result<Tensor> {
+    let (_, _, length) = x.dims3()?;
+    if length == 0 {
+        bail!("cannot replicate-pad an empty audio tensor")
+    }
+    let mut parts = Vec::with_capacity(3);
+    if left > 0 {
+        parts.push(x.narrow(2, 0, 1)?.repeat((1, 1, left))?);
+    }
+    parts.push(x.clone());
+    if right > 0 {
+        parts.push(x.narrow(2, length - 1, 1)?.repeat((1, 1, right))?);
+    }
+    Tensor::cat(&parts.iter().collect::<Vec<_>>(), 2)
+}
+
+fn materialize_group_filter(filter: &Tensor, channels: usize, device: &Device) -> Result<Tensor> {
+    require_f32(filter, "alias-free filter")?;
+    let base = filter.to_device(device)?.contiguous()?;
+    Tensor::cat(&(0..channels).map(|_| &base).collect::<Vec<_>>(), 0)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn load_plain_conv1d(
+    in_channels: usize,
+    out_channels: usize,
+    kernel: usize,
+    padding: usize,
+    stride: usize,
+    dilation: usize,
+    bias: bool,
+    vb: VarBuilder,
+) -> Result<Conv1d> {
+    let weight = vb.get((out_channels, in_channels, kernel), "weight")?;
+    let bias = if bias {
+        Some(vb.get(out_channels, "bias")?)
+    } else {
+        None
+    };
+    Ok(Conv1d::new(
+        weight,
+        bias,
+        Conv1dConfig {
+            padding,
+            stride,
+            dilation,
+            ..Default::default()
+        },
+    ))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn load_conv1d(
+    in_channels: usize,
+    out_channels: usize,
+    kernel: usize,
+    padding: usize,
+    stride: usize,
+    dilation: usize,
+    bias: bool,
+    layout: AudioTensorLayout,
+    vb: VarBuilder,
+) -> Result<Conv1d> {
+    let weight = load_weight_norm(
+        (out_channels, in_channels, kernel),
+        out_channels,
+        layout,
+        vb.clone(),
+    )?;
+    let bias = if bias {
+        Some(vb.get(out_channels, "bias")?)
+    } else {
+        None
+    };
+    Ok(Conv1d::new(
+        weight,
+        bias,
+        Conv1dConfig {
+            padding,
+            stride,
+            dilation,
+            ..Default::default()
+        },
+    ))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn load_conv_transpose1d(
+    in_channels: usize,
+    out_channels: usize,
+    kernel: usize,
+    padding: usize,
+    stride: usize,
+    bias: bool,
+    layout: AudioTensorLayout,
+    vb: VarBuilder,
+) -> Result<ConvTranspose1d> {
+    let weight = load_weight_norm(
+        (in_channels, out_channels, kernel),
+        in_channels,
+        layout,
+        vb.clone(),
+    )?;
+    let bias = if bias {
+        Some(vb.get(out_channels, "bias")?)
+    } else {
+        None
+    };
+    Ok(ConvTranspose1d::new(
+        weight,
+        bias,
+        ConvTranspose1dConfig {
+            padding,
+            stride,
+            ..Default::default()
+        },
+    ))
+}
+
+fn load_weight_norm(
+    shape: (usize, usize, usize),
+    norm_channels: usize,
+    layout: AudioTensorLayout,
+    vb: VarBuilder,
+) -> Result<Tensor> {
+    match layout {
+        AudioTensorLayout::ComfyFolded => vb.get(shape, "weight"),
+        AudioTensorLayout::OfficialWeightNorm => {
+            let g = vb.get((norm_channels, 1, 1), "weight_g")?;
+            let v = vb.get(shape, "weight_v")?;
+            let norm = v.sqr()?.sum_keepdim(1)?.sum_keepdim(2)?.sqrt()?;
+            v.broadcast_mul(&g.broadcast_div(&norm)?)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    use candle::{Device, Tensor};
+
+    use super::*;
+
+    fn assert_close(left: &[f32], right: &[f32], tolerance: f32) {
+        assert_eq!(left.len(), right.len());
+        for (index, (left, right)) in left.iter().zip(right).enumerate() {
+            assert!(
+                (left - right).abs() <= tolerance,
+                "index {index}: {left} != {right} within {tolerance}"
+            );
+        }
+    }
+
+    #[test]
+    fn stereo_pack_order_round_trips() -> Result<()> {
+        let samples = Tensor::from_vec(
+            vec![1f32, 2., 3., 10., 20., 30., 4., 5., 6., 40., 50., 60.],
+            (2, 2, 3),
+            &Device::Cpu,
+        )?;
+        let waveform = StereoWaveform::new(
+            samples,
+            SAMPLE_RATE,
+            AudioSoundtrackAssociation::VideoSoundtrack { reference_index: 3 },
+        )?;
+        assert_eq!(
+            waveform
+                .pack_mono_batch()?
+                .flatten_all()?
+                .to_vec1::<f32>()?,
+            [1., 2., 3., 10., 20., 30., 4., 5., 6., 40., 50., 60.]
+        );
+        let round_trip = StereoWaveform::from_mono_batch(
+            waveform.pack_mono_batch()?,
+            2,
+            SAMPLE_RATE,
+            waveform.association(),
+        )?;
+        assert_eq!(
+            round_trip.samples().to_vec3::<f32>()?,
+            waveform.samples().to_vec3::<f32>()?
+        );
+        assert_eq!(round_trip.association(), waveform.association());
+        Ok(())
+    }
+
+    #[test]
+    fn posterior_mode_is_default_authority_and_sampling_is_explicit() -> Result<()> {
+        let mean = Tensor::from_vec(vec![1f32, -2.], (1, 1, 2), &Device::Cpu)?;
+        let logs = Tensor::zeros((1, 1, 2), DType::F32, &Device::Cpu)?;
+        let posterior = AudioPosterior::new(mean, logs)?;
+        assert_eq!(
+            posterior
+                .select(AudioPosteriorSelection::Mode)?
+                .to_vec3::<f32>()?,
+            vec![vec![vec![1., -2.]]]
+        );
+        let noise = Tensor::from_vec(vec![0.5f32, -0.25], (1, 1, 2), &Device::Cpu)?;
+        assert_eq!(
+            posterior
+                .select(AudioPosteriorSelection::Sample { noise: &noise })?
+                .to_vec3::<f32>()?,
+            vec![vec![vec![1.5, -2.25]]]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn snake_formulas_preserve_phase_polarity_and_amplitude_contract() {
+        assert!((snake_value(0.25, 2.0) - (0.25 + (0.5f32).sin().powi(2) / 2.0)).abs() < 1e-7);
+        assert!((snake_beta_value(-0.5, 0.0, 0.0) - (-0.5 + (-0.5f32).sin().powi(2))).abs() < 1e-7);
+        assert!(snake_beta_value(0.75, 0.0, 0.0) > 0.75);
+        assert!(snake_beta_value(-0.75, 0.0, 0.0) > -0.75);
+    }
+
+    #[test]
+    fn kaiser_filter_matches_pinned_coefficients_and_unity_sum() -> Result<()> {
+        let filter = kaiser_sinc_coefficients(0.25, 0.3, 12)?;
+        let expected = [
+            0.0020289664,
+            0.009389464,
+            -0.025543464,
+            -0.057657376,
+            0.12857261,
+            0.4432098,
+            0.4432098,
+            0.12857261,
+            -0.057657376,
+            -0.025543464,
+            0.009389464,
+            0.0020289664,
+        ];
+        assert_close(&filter, &expected, 2e-6);
+        assert!((filter.iter().sum::<f32>() - 1.0).abs() < 2e-6);
+        for index in 0..filter.len() {
+            assert!((filter[index] - filter[filter.len() - 1 - index]).abs() < 1e-7);
+        }
+        Ok(())
+    }
+
+    fn attention_builder(device: &Device) -> Result<VarBuilder<'static>> {
+        let mut tensors = HashMap::new();
+        let mut qkv = vec![0f32; 12 * 4];
+        for block in 0..3 {
+            for index in 0..4 {
+                qkv[(block * 4 + index) * 4 + index] = 1.0;
+            }
+        }
+        tensors.insert("qkv.weight".into(), Tensor::from_vec(qkv, (12, 4), device)?);
+        tensors.insert("q_bias".into(), Tensor::zeros(4, DType::F32, device)?);
+        tensors.insert("zero_k_bias".into(), Tensor::zeros(4, DType::F32, device)?);
+        tensors.insert("v_bias".into(), Tensor::zeros(4, DType::F32, device)?);
+        tensors.insert("proj.weight".into(), Tensor::eye(2, DType::F32, device)?);
+        tensors.insert("proj.bias".into(), Tensor::zeros(2, DType::F32, device)?);
+        Ok(VarBuilder::from_tensors(tensors, DType::F32, device))
+    }
+
+    #[test]
+    fn causal_attention_rejects_future_leakage() -> Result<()> {
+        let attention = CausalAttention::load(4, 2, 2, attention_builder(&Device::Cpu)?)?;
+        let base = Tensor::from_vec(
+            vec![1f32, 0., 0., 1., 0.5, 0.25, -0.5, 0.75, 1., 1., 1., 1.],
+            (1, 3, 4),
+            &Device::Cpu,
+        )?;
+        let perturbed = Tensor::from_vec(
+            vec![
+                1f32, 0., 0., 1., 0.5, 0.25, -0.5, 0.75, 100., -100., 80., -80.,
+            ],
+            (1, 3, 4),
+            &Device::Cpu,
+        )?;
+        let base_out = attention
+            .forward(&base)?
+            .narrow(1, 0, 2)?
+            .flatten_all()?
+            .to_vec1::<f32>()?;
+        let changed_out = attention
+            .forward(&perturbed)?
+            .narrow(1, 0, 2)?
+            .flatten_all()?
+            .to_vec1::<f32>()?;
+        assert_close(&base_out, &changed_out, 1e-6);
+        Ok(())
+    }
+
+    struct CancelAt {
+        phase: AudioVaePhase,
+        seen: Mutex<Vec<AudioVaePhase>>,
+    }
+
+    impl AudioVaeCancellation for CancelAt {
+        fn is_cancelled(&self, phase: AudioVaePhase) -> bool {
+            self.seen.lock().unwrap().push(phase);
+            phase == self.phase
+        }
+    }
+
+    fn tiny_vae(device: &Device) -> Result<AudioVae> {
+        let config = AudioVaeConfig::tiny();
+        AudioVae::load(
+            config,
+            AudioTensorLayout::ComfyFolded,
+            DType::F32,
+            VarBuilder::zeros(DType::F32, device),
+        )
+    }
+
+    #[test]
+    fn official_weight_norm_and_comfy_folded_weights_agree() -> Result<()> {
+        let device = Device::Cpu;
+        let v = Tensor::from_vec(vec![3f32, 4., 0., 0., 0., 12., 5., 0.], (2, 2, 2), &device)?;
+        let g = Tensor::from_vec(vec![10f32, 13.], (2, 1, 1), &device)?;
+        let expected = vec![6f32, 8., 0., 0., 0., 12., 5., 0.];
+        let mut official = HashMap::new();
+        official.insert("weight_g".into(), g);
+        official.insert("weight_v".into(), v);
+        let folded = load_weight_norm(
+            (2, 2, 2),
+            2,
+            AudioTensorLayout::OfficialWeightNorm,
+            VarBuilder::from_tensors(official, DType::F32, &device),
+        )?;
+        assert_close(&folded.flatten_all()?.to_vec1::<f32>()?, &expected, 1e-6);
+
+        let mut comfy = HashMap::new();
+        comfy.insert(
+            "weight".into(),
+            Tensor::from_vec(expected.clone(), (2, 2, 2), &device)?,
+        );
+        let direct = load_weight_norm(
+            (2, 2, 2),
+            2,
+            AudioTensorLayout::ComfyFolded,
+            VarBuilder::from_tensors(comfy, DType::F32, &device),
+        )?;
+        assert_close(&direct.flatten_all()?.to_vec1::<f32>()?, &expected, 0.0);
+        Ok(())
+    }
+
+    #[test]
+    fn tiny_encode_decode_shapes_normalization_and_cancellation() -> Result<()> {
+        let config = AudioVaeConfig::tiny();
+        let vae = tiny_vae(&Device::Cpu)?;
+        let waveform = StereoWaveform::new_for_config(
+            Tensor::from_vec(
+                (0..14).map(|v| v as f32 / 16.0).collect(),
+                (1, 2, 7),
+                &Device::Cpu,
+            )?,
+            &config,
+            AudioSoundtrackAssociation::StandaloneReference { reference_index: 1 },
+        )?;
+        let latents = vae.encode(&waveform, &NeverCancel)?;
+        assert_eq!(latents.normalized().dims4()?, (1, 2, 2, 2));
+        let decoded = vae.decode(
+            &latents,
+            AudioSoundtrackAssociation::Generated,
+            &NeverCancel,
+        )?;
+        assert_eq!(decoded.samples().dims3()?, (1, 2, 8));
+        assert!(decoded
+            .samples()
+            .flatten_all()?
+            .to_vec1::<f32>()?
+            .iter()
+            .all(|sample| (-1.0..=1.0).contains(sample)));
+
+        let raw = Tensor::from_vec(vec![0.25f32, 2.25, -0.5, 0.0], (1, 2, 2), &Device::Cpu)?;
+        let normalized = vae.normalize_mono_latents(&raw)?;
+        let round_trip = vae.denormalize_mono_latents(&normalized)?;
+        assert_close(
+            &raw.flatten_all()?.to_vec1::<f32>()?,
+            &round_trip.flatten_all()?.to_vec1::<f32>()?,
+            1e-6,
+        );
+
+        for phase in [
+            AudioVaePhase::EncodePreprocess,
+            AudioVaePhase::EncodeDac,
+            AudioVaePhase::EncodeProjection,
+            AudioVaePhase::EncodePosterior,
+        ] {
+            let cancellation = CancelAt {
+                phase,
+                seen: Mutex::new(Vec::new()),
+            };
+            assert!(vae.encode(&waveform, &cancellation).is_err());
+            assert!(cancellation.seen.lock().unwrap().contains(&phase));
+        }
+        for phase in [
+            AudioVaePhase::DecodeProjection,
+            AudioVaePhase::DecodeBigVgan,
+            AudioVaePhase::DecodeOutput,
+        ] {
+            let cancellation = CancelAt {
+                phase,
+                seen: Mutex::new(Vec::new()),
+            };
+            assert!(vae
+                .decode(
+                    &latents,
+                    AudioSoundtrackAssociation::Generated,
+                    &cancellation,
+                )
+                .is_err());
+            assert!(cancellation.seen.lock().unwrap().contains(&phase));
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn non_f32_inputs_fail_closed() -> Result<()> {
+        let config = AudioVaeConfig::tiny();
+        let bad = Tensor::zeros((1, 2, 8), DType::BF16, &Device::Cpu)?;
+        assert!(StereoWaveform::new_for_config(
+            bad,
+            &config,
+            AudioSoundtrackAssociation::Generated
+        )
+        .is_err());
+        Ok(())
+    }
+
+    #[cfg(feature = "cuda")]
+    #[test]
+    fn tiny_cpu_cuda_parity() -> Result<()> {
+        let cuda = Device::new_cuda(0)?;
+        let input = (0..16)
+            .map(|index| (index as f32 * 0.17).sin() * 0.5)
+            .collect::<Vec<_>>();
+        let cpu_vae = tiny_nonzero_vae(&Device::Cpu)?;
+        let cuda_vae = tiny_nonzero_vae(&cuda)?;
+        let cpu_wave = StereoWaveform::new_for_config(
+            Tensor::from_vec(input.clone(), (1, 2, 8), &Device::Cpu)?,
+            cpu_vae.config(),
+            AudioSoundtrackAssociation::Generated,
+        )?;
+        let cuda_wave = StereoWaveform::new_for_config(
+            Tensor::from_vec(input, (1, 2, 8), &cuda)?,
+            cuda_vae.config(),
+            AudioSoundtrackAssociation::Generated,
+        )?;
+        let cpu = cpu_vae
+            .encode(&cpu_wave, &NeverCancel)?
+            .normalized()
+            .flatten_all()?
+            .to_vec1::<f32>()?;
+        let gpu = cuda_vae
+            .encode(&cuda_wave, &NeverCancel)?
+            .normalized()
+            .to_device(&Device::Cpu)?
+            .flatten_all()?
+            .to_vec1::<f32>()?;
+        assert_close(&cpu, &gpu, 2e-4);
+
+        let cpu_latents = cpu_vae.encode(&cpu_wave, &NeverCancel)?;
+        let cuda_latents = cuda_vae.encode(&cuda_wave, &NeverCancel)?;
+        let cpu_decoded = cpu_vae
+            .decode(
+                &cpu_latents,
+                AudioSoundtrackAssociation::Generated,
+                &NeverCancel,
+            )?
+            .samples()
+            .flatten_all()?
+            .to_vec1::<f32>()?;
+        let gpu_decoded = cuda_vae
+            .decode(
+                &cuda_latents,
+                AudioSoundtrackAssociation::Generated,
+                &NeverCancel,
+            )?
+            .samples()
+            .to_device(&Device::Cpu)?
+            .flatten_all()?
+            .to_vec1::<f32>()?;
+        assert_close(&cpu_decoded, &gpu_decoded, 3e-4);
+        Ok(())
+    }
+
+    #[cfg(feature = "cuda")]
+    fn tiny_nonzero_vae(device: &Device) -> Result<AudioVae> {
+        use super::super::audio_weights::audio_tensor_specs;
+
+        let config = AudioVaeConfig::tiny();
+        let specs = audio_tensor_specs(&config, AudioTensorLayout::ComfyFolded)?;
+        let filter = kaiser_sinc_coefficients(0.25, 0.3, 12)?;
+        let mut tensors = HashMap::new();
+        for (name, spec) in specs {
+            let elements = spec.shape.iter().product::<usize>();
+            let values = if name.ends_with("upsample.filter")
+                || name.ends_with("downsample.lowpass.filter")
+            {
+                filter.clone()
+            } else if name.ends_with(".act.alpha") || name.ends_with(".act.beta") {
+                vec![0.0; elements]
+            } else if name.ends_with(".alpha")
+                || matches!(
+                    name.as_str(),
+                    "pre_block.norm1.weight"
+                        | "pre_block.norm2.weight"
+                        | "pre_block.norm3.weight"
+                        | "pre_block.mlp.norm.weight"
+                )
+            {
+                vec![1.0; elements]
+            } else if name == "latents_mean" {
+                config.latents_mean.clone()
+            } else if name == "latents_std" {
+                config.latents_std.clone()
+            } else if name.ends_with("weight") {
+                (0..elements)
+                    .map(|index| ((index % 11) as f32 - 5.0) * 0.002)
+                    .collect()
+            } else {
+                vec![0.0; elements]
+            };
+            tensors.insert(name, Tensor::from_vec(values, spec.shape, device)?);
+        }
+        AudioVae::load(
+            config,
+            AudioTensorLayout::ComfyFolded,
+            DType::F32,
+            VarBuilder::from_tensors(tensors, DType::F32, device),
+        )
+    }
+}

--- a/crates/mold-candle/src/minimax_h3/audio_config.rs
+++ b/crates/mold-candle/src/minimax_h3/audio_config.rs
@@ -1,0 +1,317 @@
+//! MiniMax H3 audio-VAE configuration and immutable media geometry.
+
+use candle::{bail, DType, Result};
+use serde::{Deserialize, Serialize};
+
+pub const SAMPLE_RATE: usize = 32_000;
+pub const SAMPLES_PER_LATENT: usize = 800;
+pub const LATENT_ROWS_PER_SECOND: usize = SAMPLE_RATE / SAMPLES_PER_LATENT;
+pub const LATENT_CHANNELS: usize = 32;
+
+pub const LATENTS_MEAN: [f32; LATENT_CHANNELS] = [
+    -0.020211687,
+    0.38764665,
+    -0.0439828,
+    -0.28591514,
+    0.08179686,
+    -0.3578264,
+    0.04062381,
+    -0.015525345,
+    -0.22336248,
+    0.18210068,
+    0.2941779,
+    -0.07901168,
+    -0.056815073,
+    -0.36990282,
+    -0.31616315,
+    0.5905951,
+    -0.05213957,
+    0.01367316,
+    -0.03691648,
+    0.09732661,
+    -0.33946624,
+    -0.30685678,
+    -0.24504599,
+    -0.034698524,
+    0.028680323,
+    -0.2121778,
+    -0.16782631,
+    0.3221288,
+    -0.12230559,
+    0.43566048,
+    -0.05025992,
+    0.39792582,
+];
+
+pub const LATENTS_STD: [f32; LATENT_CHANNELS] = [
+    1.6895524, 2.7626374, 1.7945344, 1.6801682, 1.6390227, 2.7788298, 1.765909, 1.6199758,
+    2.6336527, 1.8539357, 2.5056498, 1.8110192, 1.9579657, 1.6685498, 1.4922469, 3.2986703,
+    1.9491805, 1.8720003, 1.833408, 1.648807, 1.6176958, 1.913_145, 1.5695245, 1.694366, 1.8318421,
+    1.5540637, 1.9344931, 1.5991982, 1.718046, 1.6307219, 1.8661226, 1.5613768,
+];
+
+/// The immutable, user-visible media contract. This intentionally carries no
+/// model path or activation bit: capability registration remains fail-closed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MiniMaxH3AudioContract {
+    pub sample_rate: usize,
+    pub channels: usize,
+    pub samples_per_latent: usize,
+    pub latent_rows_per_second: usize,
+    pub latent_channels: usize,
+}
+
+impl Default for MiniMaxH3AudioContract {
+    fn default() -> Self {
+        Self {
+            sample_rate: SAMPLE_RATE,
+            channels: 2,
+            samples_per_latent: SAMPLES_PER_LATENT,
+            latent_rows_per_second: LATENT_ROWS_PER_SECOND,
+            latent_channels: LATENT_CHANNELS,
+        }
+    }
+}
+
+/// DAC encoder plus BigVGAN decoder topology.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct AudioVaeConfig {
+    pub encoder_dim: usize,
+    pub encoder_rates: Vec<usize>,
+    pub latent_dim: usize,
+    pub latent_channels: usize,
+    pub attention_heads: usize,
+    pub decoder_dim: usize,
+    pub decoder_rates: Vec<usize>,
+    pub decoder_kernel_sizes: Vec<usize>,
+    pub resblock_kernel_sizes: Vec<usize>,
+    pub resblock_dilation_sizes: Vec<Vec<usize>>,
+    pub sample_rate: usize,
+    pub latents_mean: Vec<f32>,
+    pub latents_std: Vec<f32>,
+}
+
+impl Default for AudioVaeConfig {
+    fn default() -> Self {
+        Self {
+            encoder_dim: 64,
+            encoder_rates: vec![2, 4, 4, 5, 5],
+            latent_dim: 2048,
+            latent_channels: LATENT_CHANNELS,
+            attention_heads: 8,
+            decoder_dim: 1024,
+            decoder_rates: vec![5, 5, 2, 2, 2, 2, 2],
+            decoder_kernel_sizes: vec![9, 9, 4, 4, 4, 4, 4],
+            resblock_kernel_sizes: vec![3, 7, 11],
+            resblock_dilation_sizes: vec![vec![1, 3, 5]; 3],
+            sample_rate: SAMPLE_RATE,
+            latents_mean: LATENTS_MEAN.to_vec(),
+            latents_std: LATENTS_STD.to_vec(),
+        }
+    }
+}
+
+impl AudioVaeConfig {
+    /// Small weight-free topology for backend and shape conformance tests.
+    /// Production never selects this configuration.
+    #[cfg(test)]
+    #[doc(hidden)]
+    pub(super) fn tiny() -> Self {
+        Self {
+            encoder_dim: 2,
+            encoder_rates: vec![2, 2],
+            latent_dim: 8,
+            latent_channels: 2,
+            attention_heads: 2,
+            decoder_dim: 8,
+            decoder_rates: vec![2, 2],
+            decoder_kernel_sizes: vec![4, 4],
+            resblock_kernel_sizes: vec![3],
+            resblock_dilation_sizes: vec![vec![1]],
+            sample_rate: 16,
+            latents_mean: vec![0.25, -0.5],
+            latents_std: vec![2.0, 0.5],
+        }
+    }
+
+    pub fn hop_length(&self) -> Result<usize> {
+        checked_product(&self.encoder_rates, "encoder rates")
+    }
+
+    pub fn latent_rows_per_second(&self) -> Result<usize> {
+        let hop = self.hop_length()?;
+        if !self.sample_rate.is_multiple_of(hop) {
+            bail!(
+                "audio sample rate {} is not divisible by hop length {hop}",
+                self.sample_rate
+            )
+        }
+        Ok(self.sample_rate / hop)
+    }
+
+    pub fn padded_samples(&self, samples: usize) -> Result<usize> {
+        if samples == 0 {
+            bail!("MiniMax H3 audio input must contain at least one sample")
+        }
+        let hop = self.hop_length()?;
+        samples
+            .checked_add(hop - 1)
+            .map(|value| value / hop * hop)
+            .ok_or_else(|| candle::Error::Msg("audio right-padding overflow".into()))
+    }
+
+    pub fn validate_execution_dtype(&self, dtype: DType) -> Result<()> {
+        if dtype != DType::F32 {
+            bail!("MiniMax H3 audio VAE is FP32-only; requested execution dtype {dtype:?}")
+        }
+        Ok(())
+    }
+
+    pub fn validate(&self) -> Result<()> {
+        if self.encoder_rates.is_empty() || self.decoder_rates.is_empty() {
+            bail!("MiniMax H3 audio encoder and decoder rates must be non-empty")
+        }
+        if self.encoder_rates.contains(&0) || self.decoder_rates.contains(&0) {
+            bail!("MiniMax H3 audio rates must be non-zero")
+        }
+        let hop = self.hop_length()?;
+        let decoder_hop = checked_product(&self.decoder_rates, "decoder rates")?;
+        if decoder_hop != hop {
+            bail!("MiniMax H3 audio decoder hop {decoder_hop} does not match encoder hop {hop}")
+        }
+        if self.decoder_rates.len() != self.decoder_kernel_sizes.len() {
+            bail!("MiniMax H3 audio decoder rates and kernels must have equal lengths")
+        }
+        if self.resblock_kernel_sizes.len() != self.resblock_dilation_sizes.len()
+            || self.resblock_kernel_sizes.is_empty()
+        {
+            bail!("MiniMax H3 audio resblock kernels and dilation tables must be non-empty and aligned")
+        }
+        if self
+            .resblock_dilation_sizes
+            .iter()
+            .any(|dilations| dilations.is_empty() || dilations.contains(&0))
+        {
+            bail!("MiniMax H3 audio resblock dilations must be non-empty and non-zero")
+        }
+        if self.latent_channels == 0
+            || self.latent_dim == 0
+            || self.attention_heads == 0
+            || !self.latent_dim.is_multiple_of(self.attention_heads)
+        {
+            bail!("MiniMax H3 audio latent and attention dimensions are invalid")
+        }
+        let head_dim = self.latent_dim / self.attention_heads;
+        if !head_dim.is_multiple_of(self.latent_channels) {
+            bail!(
+                "MiniMax H3 audio attention head width {head_dim} must pool exactly to {} latent channels",
+                self.latent_channels
+            )
+        }
+        let expected_latent_dim = self
+            .encoder_dim
+            .checked_mul(1usize << self.encoder_rates.len())
+            .ok_or_else(|| candle::Error::Msg("audio encoder width overflow".into()))?;
+        if expected_latent_dim != self.latent_dim {
+            bail!(
+                "MiniMax H3 audio encoder ends at width {expected_latent_dim}, expected latent_dim {}",
+                self.latent_dim
+            )
+        }
+        if !self
+            .decoder_dim
+            .is_multiple_of(1usize << self.decoder_rates.len())
+        {
+            bail!("MiniMax H3 audio decoder width cannot halve at every stage")
+        }
+        if self.latents_mean.len() != self.latent_channels
+            || self.latents_std.len() != self.latent_channels
+            || self
+                .latents_std
+                .iter()
+                .any(|std| !std.is_finite() || *std <= 0.0)
+            || self.latents_mean.iter().any(|mean| !mean.is_finite())
+        {
+            bail!("MiniMax H3 audio latent normalization vectors are invalid")
+        }
+        if self.sample_rate == 0 || !self.sample_rate.is_multiple_of(hop) {
+            bail!("MiniMax H3 audio sample rate must be a non-zero multiple of the hop")
+        }
+        Ok(())
+    }
+
+    /// Conservative boundary-tensor watermark used only by tiny synthetic
+    /// tests. It is intentionally not a production admission estimate.
+    #[doc(hidden)]
+    pub fn tiny_test_boundary_peak_bytes(&self, batch: usize, samples: usize) -> Result<usize> {
+        let padded = self.padded_samples(samples)?;
+        let rows = padded / self.hop_length()?;
+        let waveform = batch
+            .checked_mul(2)
+            .and_then(|v| v.checked_mul(padded))
+            .and_then(|v| v.checked_mul(4))
+            .ok_or_else(|| candle::Error::Msg("tiny audio memory accounting overflow".into()))?;
+        let encoder = batch
+            .checked_mul(2)
+            .and_then(|v| v.checked_mul(self.latent_dim))
+            .and_then(|v| v.checked_mul(rows))
+            .and_then(|v| v.checked_mul(4))
+            .ok_or_else(|| candle::Error::Msg("tiny audio memory accounting overflow".into()))?;
+        Ok(waveform.max(encoder))
+    }
+}
+
+fn checked_product(values: &[usize], label: &str) -> Result<usize> {
+    values.iter().try_fold(1usize, |product, value| {
+        product
+            .checked_mul(*value)
+            .ok_or_else(|| candle::Error::Msg(format!("MiniMax H3 audio {label} product overflow")))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn production_contract_is_exact() -> Result<()> {
+        let config = AudioVaeConfig::default();
+        config.validate()?;
+        assert_eq!(config.encoder_rates, [2, 4, 4, 5, 5]);
+        assert_eq!(config.decoder_rates, [5, 5, 2, 2, 2, 2, 2]);
+        assert_eq!(config.decoder_kernel_sizes, [9, 9, 4, 4, 4, 4, 4]);
+        assert_eq!(config.hop_length()?, SAMPLES_PER_LATENT);
+        assert_eq!(config.latent_rows_per_second()?, LATENT_ROWS_PER_SECOND);
+        assert_eq!(config.latent_channels, LATENT_CHANNELS);
+        assert_eq!(MiniMaxH3AudioContract::default().channels, 2);
+        Ok(())
+    }
+
+    #[test]
+    fn padding_is_right_only_and_rejects_empty_input() -> Result<()> {
+        let config = AudioVaeConfig::default();
+        assert_eq!(config.padded_samples(1)?, 800);
+        assert_eq!(config.padded_samples(800)?, 800);
+        assert_eq!(config.padded_samples(801)?, 1600);
+        assert!(config.padded_samples(0).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn execution_dtype_fails_closed() {
+        let config = AudioVaeConfig::default();
+        assert!(config.validate_execution_dtype(DType::F32).is_ok());
+        assert!(config.validate_execution_dtype(DType::BF16).is_err());
+        assert!(config.validate_execution_dtype(DType::F16).is_err());
+    }
+
+    #[test]
+    fn tiny_memory_watermark_is_scoped_and_bounded() -> Result<()> {
+        let config = AudioVaeConfig::tiny();
+        config.validate()?;
+        let peak = config.tiny_test_boundary_peak_bytes(1, 7)?;
+        assert_eq!(peak, 128);
+        assert!(peak < 1024);
+        Ok(())
+    }
+}

--- a/crates/mold-candle/src/minimax_h3/audio_weights.rs
+++ b/crates/mold-candle/src/minimax_h3/audio_weights.rs
@@ -290,7 +290,15 @@ pub fn validate_audio_safetensors(
     validate_header_and_file_len(&header, file_len, config, layout)
 }
 
-pub fn load_validated_audio_vae(
+/// Validate the exact audio-VAE tensor contract, then construct the FP32
+/// model from mmaped safetensors.
+///
+/// # Safety
+///
+/// The checkpoint path must remain immutable and valid for the complete
+/// lifetime of the returned [`AudioVae`]. Mutating, replacing, or truncating
+/// the file while Candle's mmap is live may cause undefined behavior.
+pub unsafe fn load_validated_audio_vae(
     path: impl AsRef<Path>,
     config: AudioVaeConfig,
     layout: AudioTensorLayout,
@@ -300,6 +308,8 @@ pub fn load_validated_audio_vae(
     config.validate_execution_dtype(requested_dtype)?;
     let path = path.as_ref();
     validate_audio_safetensors(path, &config, layout)?;
+    // SAFETY: forwarded from this function's caller after the header and file
+    // length were validated immediately above.
     let vb = unsafe { VarBuilder::from_mmaped_safetensors(&[path], DType::F32, device)? };
     if layout == AudioTensorLayout::ComfyFolded {
         validate_comfy_normalization_values(&vb, &config)?;
@@ -764,15 +774,21 @@ mod tests {
             std::process::id()
         ));
         candle::safetensors::save(&tensors, &path)?;
-        let loaded = load_validated_audio_vae(
-            &path,
-            config,
-            AudioTensorLayout::ComfyFolded,
-            DType::F32,
-            &Device::Cpu,
-        );
+        // SAFETY: this test owns the temporary file and does not mutate or
+        // remove it until after the returned model has been dropped below.
+        let loaded = unsafe {
+            load_validated_audio_vae(
+                &path,
+                config,
+                AudioTensorLayout::ComfyFolded,
+                DType::F32,
+                &Device::Cpu,
+            )
+        };
+        let passed = loaded.is_ok();
+        drop(loaded);
         let _ = std::fs::remove_file(&path);
-        assert!(loaded.is_ok());
+        assert!(passed);
         Ok(())
     }
 }

--- a/crates/mold-candle/src/minimax_h3/audio_weights.rs
+++ b/crates/mold-candle/src/minimax_h3/audio_weights.rs
@@ -1,0 +1,778 @@
+//! Strict MiniMax H3 audio-VAE safetensors contracts.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::Path;
+
+use candle::{bail, DType, Device, Result};
+use candle_nn::VarBuilder;
+use serde_json::Value;
+
+use super::audio::AudioVae;
+use super::audio_config::AudioVaeConfig;
+
+const MAX_HEADER_BYTES: usize = 100 * 1024 * 1024;
+
+/// Original/Diffusers H3 files retain PyTorch `weight_g`/`weight_v`.
+/// Comfy's pruned file folds weight normalization into a plain `weight`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AudioTensorLayout {
+    OfficialWeightNorm,
+    ComfyFolded,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AudioTensorSpec {
+    pub shape: Vec<usize>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ValidatedAudioWeights {
+    pub tensor_count: usize,
+    pub tensor_bytes: u64,
+    pub layout: AudioTensorLayout,
+}
+
+pub fn audio_tensor_specs(
+    config: &AudioVaeConfig,
+    layout: AudioTensorLayout,
+) -> Result<BTreeMap<String, AudioTensorSpec>> {
+    config.validate()?;
+    let mut specs = BTreeMap::new();
+
+    add_weight_norm_conv(
+        &mut specs,
+        "encoder.block.0",
+        config.encoder_dim,
+        1,
+        7,
+        true,
+        layout,
+    );
+    let mut dim = config.encoder_dim;
+    for (stage, stride) in config.encoder_rates.iter().copied().enumerate() {
+        dim *= 2;
+        let prefix = format!("encoder.block.{}.block", stage + 1);
+        let half = dim / 2;
+        for (residual, dilation) in [1usize, 3, 9].iter().copied().enumerate() {
+            let residual_prefix = format!("{prefix}.{residual}.block");
+            add(
+                &mut specs,
+                format!("{residual_prefix}.0.alpha"),
+                [1, half, 1],
+            );
+            add_weight_norm_conv(
+                &mut specs,
+                &format!("{residual_prefix}.1"),
+                half,
+                half,
+                7,
+                true,
+                layout,
+            );
+            add(
+                &mut specs,
+                format!("{residual_prefix}.2.alpha"),
+                [1, half, 1],
+            );
+            add_weight_norm_conv(
+                &mut specs,
+                &format!("{residual_prefix}.3"),
+                half,
+                half,
+                1,
+                true,
+                layout,
+            );
+            let _ = dilation;
+        }
+        add(&mut specs, format!("{prefix}.3.alpha"), [1, half, 1]);
+        add_weight_norm_conv(
+            &mut specs,
+            &format!("{prefix}.4"),
+            dim,
+            half,
+            2 * stride,
+            true,
+            layout,
+        );
+    }
+    let final_index = config.encoder_rates.len() + 1;
+    add(
+        &mut specs,
+        format!("encoder.block.{final_index}.alpha"),
+        [1, dim, 1],
+    );
+    add_weight_norm_conv(
+        &mut specs,
+        &format!("encoder.block.{}", final_index + 1),
+        config.latent_dim,
+        dim,
+        3,
+        true,
+        layout,
+    );
+
+    add_layer_norm(&mut specs, "pre_block.norm1", config.latent_dim);
+    add(
+        &mut specs,
+        "pre_block.attn.qkv.weight",
+        [config.latent_dim * 3, config.latent_dim],
+    );
+    add(&mut specs, "pre_block.attn.q_bias", [config.latent_dim]);
+    add(
+        &mut specs,
+        "pre_block.attn.zero_k_bias",
+        [config.latent_dim],
+    );
+    add(&mut specs, "pre_block.attn.v_bias", [config.latent_dim]);
+    add_linear(
+        &mut specs,
+        "pre_block.attn.proj",
+        config.latent_channels,
+        config.latent_channels,
+        true,
+    );
+    add_linear(
+        &mut specs,
+        "pre_block.proj",
+        config.latent_channels,
+        config.latent_dim,
+        true,
+    );
+    add_layer_norm(&mut specs, "pre_block.norm3", config.latent_dim);
+    add_layer_norm(&mut specs, "pre_block.norm2", config.latent_channels);
+    add_layer_norm(&mut specs, "pre_block.mlp.norm", config.latent_channels);
+    add_linear(
+        &mut specs,
+        "pre_block.mlp.w0",
+        config.latent_channels * 2,
+        config.latent_channels,
+        true,
+    );
+    add_linear(
+        &mut specs,
+        "pre_block.mlp.w1",
+        config.latent_channels * 2,
+        config.latent_channels,
+        true,
+    );
+    add_linear(
+        &mut specs,
+        "pre_block.mlp.w2",
+        config.latent_channels,
+        config.latent_channels * 2,
+        true,
+    );
+
+    for prefix in ["mean_proj", "logs_proj"] {
+        add_plain_conv(
+            &mut specs,
+            prefix,
+            config.latent_channels,
+            config.latent_channels,
+            1,
+            true,
+        );
+    }
+    add_plain_conv(
+        &mut specs,
+        "dec_in_proj",
+        config.latent_dim,
+        config.latent_channels,
+        1,
+        true,
+    );
+
+    add_weight_norm_conv(
+        &mut specs,
+        "decoder.conv_pre",
+        config.decoder_dim,
+        config.latent_dim,
+        7,
+        true,
+        layout,
+    );
+    let num_kernels = config.resblock_kernel_sizes.len();
+    for (stage, kernel) in config.decoder_kernel_sizes.iter().copied().enumerate() {
+        let in_channels = config.decoder_dim / (1usize << stage);
+        let out_channels = config.decoder_dim / (1usize << (stage + 1));
+        add_weight_norm_conv_transpose(
+            &mut specs,
+            &format!("decoder.ups.{stage}.0"),
+            in_channels,
+            out_channels,
+            kernel,
+            true,
+            layout,
+        );
+        for (kernel_index, (res_kernel, dilations)) in config
+            .resblock_kernel_sizes
+            .iter()
+            .zip(&config.resblock_dilation_sizes)
+            .enumerate()
+        {
+            let block = stage * num_kernels + kernel_index;
+            let prefix = format!("decoder.resblocks.{block}");
+            for index in 0..dilations.len() {
+                add_weight_norm_conv(
+                    &mut specs,
+                    &format!("{prefix}.convs1.{index}"),
+                    out_channels,
+                    out_channels,
+                    *res_kernel,
+                    true,
+                    layout,
+                );
+                add_weight_norm_conv(
+                    &mut specs,
+                    &format!("{prefix}.convs2.{index}"),
+                    out_channels,
+                    out_channels,
+                    *res_kernel,
+                    true,
+                    layout,
+                );
+            }
+            for index in 0..(dilations.len() * 2) {
+                add_alias_free_activation(
+                    &mut specs,
+                    &format!("{prefix}.activations.{index}"),
+                    out_channels,
+                );
+            }
+        }
+    }
+    let final_channels = config.decoder_dim / (1usize << config.decoder_rates.len());
+    add_alias_free_activation(&mut specs, "decoder.activation_post", final_channels);
+    add_weight_norm_conv(
+        &mut specs,
+        "decoder.conv_post",
+        1,
+        final_channels,
+        7,
+        false,
+        layout,
+    );
+
+    if layout == AudioTensorLayout::ComfyFolded {
+        add(&mut specs, "latents_mean", [config.latent_channels]);
+        add(&mut specs, "latents_std", [config.latent_channels]);
+    }
+    Ok(specs)
+}
+
+pub fn validate_audio_safetensors(
+    path: impl AsRef<Path>,
+    config: &AudioVaeConfig,
+    layout: AudioTensorLayout,
+) -> Result<ValidatedAudioWeights> {
+    let path = path.as_ref();
+    let mut file = File::open(path).map_err(|error| {
+        candle::Error::Msg(format!(
+            "failed to open MiniMax H3 audio weights {}: {error}",
+            path.display()
+        ))
+    })?;
+    let file_len = file.metadata().map_err(io_error)?.len();
+    let mut len = [0u8; 8];
+    file.read_exact(&mut len).map_err(io_error)?;
+    let header_len = usize::try_from(u64::from_le_bytes(len)).map_err(|_| {
+        candle::Error::Msg("audio safetensors header length overflows usize".into())
+    })?;
+    if header_len == 0 || header_len > MAX_HEADER_BYTES {
+        bail!("MiniMax H3 audio safetensors header length {header_len} is invalid")
+    }
+    let mut header = vec![0u8; header_len];
+    file.read_exact(&mut header).map_err(io_error)?;
+    file.seek(SeekFrom::Start(0)).map_err(io_error)?;
+    validate_header_and_file_len(&header, file_len, config, layout)
+}
+
+pub fn load_validated_audio_vae(
+    path: impl AsRef<Path>,
+    config: AudioVaeConfig,
+    layout: AudioTensorLayout,
+    requested_dtype: DType,
+    device: &Device,
+) -> Result<AudioVae> {
+    config.validate_execution_dtype(requested_dtype)?;
+    let path = path.as_ref();
+    validate_audio_safetensors(path, &config, layout)?;
+    let vb = unsafe { VarBuilder::from_mmaped_safetensors(&[path], DType::F32, device)? };
+    if layout == AudioTensorLayout::ComfyFolded {
+        validate_comfy_normalization_values(&vb, &config)?;
+    }
+    AudioVae::load(config, layout, requested_dtype, vb)
+}
+
+fn validate_header_and_file_len(
+    header: &[u8],
+    file_len: u64,
+    config: &AudioVaeConfig,
+    layout: AudioTensorLayout,
+) -> Result<ValidatedAudioWeights> {
+    let root: Value = serde_json::from_slice(header).map_err(|error| {
+        candle::Error::Msg(format!(
+            "invalid MiniMax H3 audio safetensors JSON header: {error}"
+        ))
+    })?;
+    let object = root
+        .as_object()
+        .ok_or_else(|| candle::Error::Msg("audio safetensors header must be an object".into()))?;
+    if let Some(metadata) = object.get("__metadata__") {
+        let metadata = metadata.as_object().ok_or_else(|| {
+            candle::Error::Msg("audio safetensors __metadata__ must be an object".into())
+        })?;
+        if let Some(format) = metadata.get("format") {
+            if format.as_str() != Some("pt") {
+                bail!("MiniMax H3 audio safetensors metadata format must be 'pt'")
+            }
+        }
+    }
+
+    let specs = audio_tensor_specs(config, layout)?;
+    let actual_names = object
+        .keys()
+        .filter(|name| name.as_str() != "__metadata__")
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let expected_names = specs.keys().cloned().collect::<BTreeSet<_>>();
+    let missing = expected_names
+        .difference(&actual_names)
+        .take(5)
+        .cloned()
+        .collect::<Vec<_>>();
+    let unexpected = actual_names
+        .difference(&expected_names)
+        .take(5)
+        .cloned()
+        .collect::<Vec<_>>();
+    if !missing.is_empty() || !unexpected.is_empty() {
+        bail!(
+            "MiniMax H3 audio tensor layout mismatch for {layout:?}: missing={missing:?}, unexpected={unexpected:?}"
+        )
+    }
+
+    let mut ranges = Vec::with_capacity(specs.len());
+    for (name, spec) in &specs {
+        let entry = object[name].as_object().ok_or_else(|| {
+            candle::Error::Msg(format!(
+                "MiniMax H3 audio tensor {name} header is not an object"
+            ))
+        })?;
+        let fields = entry.keys().map(String::as_str).collect::<BTreeSet<_>>();
+        if fields != BTreeSet::from(["data_offsets", "dtype", "shape"]) {
+            bail!("MiniMax H3 audio tensor {name} has unexpected header fields")
+        }
+        if entry.get("dtype").and_then(Value::as_str) != Some("F32") {
+            bail!("MiniMax H3 audio tensor {name} must be F32")
+        }
+        let shape = entry
+            .get("shape")
+            .and_then(Value::as_array)
+            .ok_or_else(|| candle::Error::Msg(format!("audio tensor {name} has no shape")))?
+            .iter()
+            .map(|value| {
+                value
+                    .as_u64()
+                    .and_then(|value| usize::try_from(value).ok())
+                    .ok_or_else(|| {
+                        candle::Error::Msg(format!("audio tensor {name} has invalid shape"))
+                    })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        if shape != spec.shape {
+            bail!(
+                "MiniMax H3 audio tensor {name} shape mismatch: expected {:?}, got {shape:?}",
+                spec.shape
+            )
+        }
+        let offsets = entry
+            .get("data_offsets")
+            .and_then(Value::as_array)
+            .filter(|offsets| offsets.len() == 2)
+            .ok_or_else(|| {
+                candle::Error::Msg(format!("audio tensor {name} has invalid data offsets"))
+            })?;
+        let start = offsets[0]
+            .as_u64()
+            .ok_or_else(|| candle::Error::Msg(format!("audio tensor {name} start is invalid")))?;
+        let end = offsets[1]
+            .as_u64()
+            .ok_or_else(|| candle::Error::Msg(format!("audio tensor {name} end is invalid")))?;
+        let elements = shape.iter().try_fold(1u64, |product, dim| {
+            product
+                .checked_mul(*dim as u64)
+                .ok_or_else(|| candle::Error::Msg(format!("audio tensor {name} size overflow")))
+        })?;
+        let expected_bytes = elements
+            .checked_mul(4)
+            .ok_or_else(|| candle::Error::Msg(format!("audio tensor {name} byte overflow")))?;
+        if end.checked_sub(start) != Some(expected_bytes) {
+            bail!("MiniMax H3 audio tensor {name} byte span does not match its F32 shape")
+        }
+        ranges.push((start, end, name));
+    }
+    ranges.sort_by_key(|(start, _, _)| *start);
+    let mut cursor = 0u64;
+    for (start, end, name) in &ranges {
+        if *start != cursor {
+            bail!(
+                "MiniMax H3 audio safetensors data is not contiguous at {name}: expected offset {cursor}, got {start}"
+            )
+        }
+        cursor = *end;
+    }
+    let header_bytes = 8u64
+        .checked_add(header.len() as u64)
+        .ok_or_else(|| candle::Error::Msg("audio header size overflow".into()))?;
+    if header_bytes.checked_add(cursor) != Some(file_len) {
+        bail!(
+            "MiniMax H3 audio safetensors file length mismatch: header {header_bytes} + tensors {cursor} != {file_len}"
+        )
+    }
+    Ok(ValidatedAudioWeights {
+        tensor_count: specs.len(),
+        tensor_bytes: cursor,
+        layout,
+    })
+}
+
+fn validate_comfy_normalization_values(vb: &VarBuilder, config: &AudioVaeConfig) -> Result<()> {
+    for (name, expected) in [
+        ("latents_mean", &config.latents_mean),
+        ("latents_std", &config.latents_std),
+    ] {
+        let actual = vb
+            .get(config.latent_channels, name)?
+            .to_device(&Device::Cpu)?
+            .to_vec1::<f32>()?;
+        if actual.len() != expected.len()
+            || actual
+                .iter()
+                .zip(expected.iter())
+                .any(|(actual, expected)| actual.to_bits() != expected.to_bits())
+        {
+            bail!("MiniMax H3 Comfy {name} does not match the pinned normalization config")
+        }
+    }
+    Ok(())
+}
+
+fn io_error(error: std::io::Error) -> candle::Error {
+    candle::Error::Msg(format!("MiniMax H3 audio safetensors I/O error: {error}"))
+}
+
+fn add<const N: usize>(
+    specs: &mut BTreeMap<String, AudioTensorSpec>,
+    name: impl Into<String>,
+    shape: [usize; N],
+) {
+    let previous = specs.insert(
+        name.into(),
+        AudioTensorSpec {
+            shape: shape.to_vec(),
+        },
+    );
+    debug_assert!(previous.is_none());
+}
+
+fn add_layer_norm(specs: &mut BTreeMap<String, AudioTensorSpec>, prefix: &str, size: usize) {
+    add(specs, format!("{prefix}.weight"), [size]);
+    add(specs, format!("{prefix}.bias"), [size]);
+}
+
+fn add_linear(
+    specs: &mut BTreeMap<String, AudioTensorSpec>,
+    prefix: &str,
+    out_features: usize,
+    in_features: usize,
+    bias: bool,
+) {
+    add(
+        specs,
+        format!("{prefix}.weight"),
+        [out_features, in_features],
+    );
+    if bias {
+        add(specs, format!("{prefix}.bias"), [out_features]);
+    }
+}
+
+fn add_plain_conv(
+    specs: &mut BTreeMap<String, AudioTensorSpec>,
+    prefix: &str,
+    out_channels: usize,
+    in_channels: usize,
+    kernel: usize,
+    bias: bool,
+) {
+    add(
+        specs,
+        format!("{prefix}.weight"),
+        [out_channels, in_channels, kernel],
+    );
+    if bias {
+        add(specs, format!("{prefix}.bias"), [out_channels]);
+    }
+}
+
+fn add_weight_norm_conv(
+    specs: &mut BTreeMap<String, AudioTensorSpec>,
+    prefix: &str,
+    out_channels: usize,
+    in_channels: usize,
+    kernel: usize,
+    bias: bool,
+    layout: AudioTensorLayout,
+) {
+    match layout {
+        AudioTensorLayout::OfficialWeightNorm => {
+            add(specs, format!("{prefix}.weight_g"), [out_channels, 1, 1]);
+            add(
+                specs,
+                format!("{prefix}.weight_v"),
+                [out_channels, in_channels, kernel],
+            );
+        }
+        AudioTensorLayout::ComfyFolded => add(
+            specs,
+            format!("{prefix}.weight"),
+            [out_channels, in_channels, kernel],
+        ),
+    }
+    if bias {
+        add(specs, format!("{prefix}.bias"), [out_channels]);
+    }
+}
+
+fn add_weight_norm_conv_transpose(
+    specs: &mut BTreeMap<String, AudioTensorSpec>,
+    prefix: &str,
+    in_channels: usize,
+    out_channels: usize,
+    kernel: usize,
+    bias: bool,
+    layout: AudioTensorLayout,
+) {
+    match layout {
+        AudioTensorLayout::OfficialWeightNorm => {
+            add(specs, format!("{prefix}.weight_g"), [in_channels, 1, 1]);
+            add(
+                specs,
+                format!("{prefix}.weight_v"),
+                [in_channels, out_channels, kernel],
+            );
+        }
+        AudioTensorLayout::ComfyFolded => add(
+            specs,
+            format!("{prefix}.weight"),
+            [in_channels, out_channels, kernel],
+        ),
+    }
+    if bias {
+        add(specs, format!("{prefix}.bias"), [out_channels]);
+    }
+}
+
+fn add_alias_free_activation(
+    specs: &mut BTreeMap<String, AudioTensorSpec>,
+    prefix: &str,
+    channels: usize,
+) {
+    add(specs, format!("{prefix}.act.alpha"), [channels]);
+    add(specs, format!("{prefix}.act.beta"), [channels]);
+    add(specs, format!("{prefix}.upsample.filter"), [1, 1, 12]);
+    add(
+        specs,
+        format!("{prefix}.downsample.lowpass.filter"),
+        [1, 1, 12],
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::*;
+
+    fn safetensors_bytes(
+        config: &AudioVaeConfig,
+        layout: AudioTensorLayout,
+        mutation: impl FnOnce(&mut serde_json::Map<String, Value>),
+    ) -> Result<Vec<u8>> {
+        let specs = audio_tensor_specs(config, layout)?;
+        let mut object = serde_json::Map::new();
+        object.insert("__metadata__".into(), serde_json::json!({"format": "pt"}));
+        let mut offset = 0usize;
+        for (name, spec) in specs {
+            let bytes = spec.shape.iter().product::<usize>() * 4;
+            object.insert(
+                name,
+                serde_json::json!({
+                    "dtype": "F32",
+                    "shape": spec.shape,
+                    "data_offsets": [offset, offset + bytes]
+                }),
+            );
+            offset += bytes;
+        }
+        mutation(&mut object);
+        let mut header = serde_json::to_vec(&object)
+            .map_err(|error| candle::Error::Msg(format!("test header encode failed: {error}")))?;
+        while header.len() % 8 != 0 {
+            header.push(b' ');
+        }
+        let mut bytes = (header.len() as u64).to_le_bytes().to_vec();
+        bytes.extend_from_slice(&header);
+        bytes.resize(bytes.len() + offset, 0);
+        Ok(bytes)
+    }
+
+    fn validate_bytes(
+        bytes: &[u8],
+        config: &AudioVaeConfig,
+        layout: AudioTensorLayout,
+    ) -> Result<ValidatedAudioWeights> {
+        let header_len = u64::from_le_bytes(bytes[..8].try_into().unwrap()) as usize;
+        validate_header_and_file_len(
+            &bytes[8..8 + header_len],
+            bytes.len() as u64,
+            config,
+            layout,
+        )
+    }
+
+    #[test]
+    fn both_exact_layouts_validate_and_are_distinct() -> Result<()> {
+        let config = AudioVaeConfig::tiny();
+        for layout in [
+            AudioTensorLayout::OfficialWeightNorm,
+            AudioTensorLayout::ComfyFolded,
+        ] {
+            let bytes = safetensors_bytes(&config, layout, |_| {})?;
+            let summary = validate_bytes(&bytes, &config, layout)?;
+            assert_eq!(summary.layout, layout);
+            assert!(summary.tensor_count > 100);
+            assert!(summary.tensor_bytes > 0);
+            let other = if layout == AudioTensorLayout::OfficialWeightNorm {
+                AudioTensorLayout::ComfyFolded
+            } else {
+                AudioTensorLayout::OfficialWeightNorm
+            };
+            assert!(validate_bytes(&bytes, &config, other).is_err());
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn production_tensor_payload_is_revision_locked() -> Result<()> {
+        let specs = audio_tensor_specs(
+            &AudioVaeConfig::default(),
+            AudioTensorLayout::OfficialWeightNorm,
+        )?;
+        let tensor_bytes = specs
+            .values()
+            .map(|spec| spec.shape.iter().product::<usize>() * 4)
+            .sum::<usize>();
+        // The pinned 605,429,340-byte official file has 605,306,340 bytes of
+        // F32 tensor payload and a 123,000-byte safetensors prefix/header.
+        assert_eq!(tensor_bytes, 605_306_340);
+        Ok(())
+    }
+
+    #[test]
+    fn header_rejects_missing_logs_wrong_dtype_shape_and_offsets() -> Result<()> {
+        let config = AudioVaeConfig::tiny();
+        let layout = AudioTensorLayout::ComfyFolded;
+        let missing = safetensors_bytes(&config, layout, |header| {
+            header.remove("logs_proj.weight");
+        })?;
+        assert!(validate_bytes(&missing, &config, layout).is_err());
+
+        let wrong_dtype = safetensors_bytes(&config, layout, |header| {
+            header["mean_proj.weight"]["dtype"] = Value::String("BF16".into());
+        })?;
+        assert!(validate_bytes(&wrong_dtype, &config, layout).is_err());
+
+        let wrong_shape = safetensors_bytes(&config, layout, |header| {
+            header["mean_proj.weight"]["shape"] = serde_json::json!([999, 1, 1]);
+        })?;
+        assert!(validate_bytes(&wrong_shape, &config, layout).is_err());
+
+        let wrong_offsets = safetensors_bytes(&config, layout, |header| {
+            header["mean_proj.weight"]["data_offsets"][1] = Value::from(1u64);
+        })?;
+        assert!(validate_bytes(&wrong_offsets, &config, layout).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn file_validator_checks_payload_length() -> Result<()> {
+        let config = AudioVaeConfig::tiny();
+        let bytes = safetensors_bytes(&config, AudioTensorLayout::ComfyFolded, |_| {})?;
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "mold-h3-audio-header-{}-{unique}.safetensors",
+            std::process::id()
+        ));
+        std::fs::write(&path, &bytes).map_err(io_error)?;
+        let result = validate_audio_safetensors(&path, &config, AudioTensorLayout::ComfyFolded);
+        let _ = std::fs::remove_file(&path);
+        assert!(result.is_ok());
+        Ok(())
+    }
+
+    #[test]
+    fn validated_comfy_loader_requires_exact_normalization_buffers() -> Result<()> {
+        let config = AudioVaeConfig::tiny();
+        let specs = audio_tensor_specs(&config, AudioTensorLayout::ComfyFolded)?;
+        let mut tensors = std::collections::HashMap::new();
+        for (name, spec) in specs {
+            tensors.insert(
+                name,
+                candle::Tensor::zeros(spec.shape, DType::F32, &Device::Cpu)?,
+            );
+        }
+        tensors.insert(
+            "latents_mean".into(),
+            candle::Tensor::from_vec(
+                config.latents_mean.clone(),
+                config.latent_channels,
+                &Device::Cpu,
+            )?,
+        );
+        tensors.insert(
+            "latents_std".into(),
+            candle::Tensor::from_vec(
+                config.latents_std.clone(),
+                config.latent_channels,
+                &Device::Cpu,
+            )?,
+        );
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "mold-h3-audio-load-{}-{unique}.safetensors",
+            std::process::id()
+        ));
+        candle::safetensors::save(&tensors, &path)?;
+        let loaded = load_validated_audio_vae(
+            &path,
+            config,
+            AudioTensorLayout::ComfyFolded,
+            DType::F32,
+            &Device::Cpu,
+        );
+        let _ = std::fs::remove_file(&path);
+        assert!(loaded.is_ok());
+        Ok(())
+    }
+}

--- a/crates/mold-candle/src/minimax_h3/mod.rs
+++ b/crates/mold-candle/src/minimax_h3/mod.rs
@@ -1,0 +1,21 @@
+//! Weight-free MiniMax H3 model primitives.
+//!
+//! Nothing in this module registers a runnable inference engine. The H3
+//! license gate and the family capability contract remain the authority for
+//! whether callers may construct these primitives with real weights.
+
+pub mod audio;
+pub mod audio_config;
+pub mod audio_weights;
+
+pub use audio::{
+    AudioPosterior, AudioPosteriorSelection, AudioSoundtrackAssociation, AudioVae,
+    AudioVaeCancellation, AudioVaePhase, NeverCancel, StereoLatents, StereoWaveform,
+};
+pub use audio_config::{
+    AudioVaeConfig, MiniMaxH3AudioContract, LATENT_CHANNELS, LATENT_ROWS_PER_SECOND,
+    SAMPLES_PER_LATENT, SAMPLE_RATE,
+};
+pub use audio_weights::{
+    load_validated_audio_vae, validate_audio_safetensors, AudioTensorLayout, AudioTensorSpec,
+};


### PR DESCRIPTION
## Summary

- Add a weight-free, FP32-only MiniMax H3 AudioVAE primitive with the production 32 kHz / 800-sample-hop contract, typed stereo packing, normalized latent geometry, posterior mode-by-default semantics, and explicit opt-in sampling.
- Implement the audited DAC encoder, causal attention/projection block, and BigVGAN decoder topology, including Snake/SnakeBeta activations and alias-free Kaiser-sinc resampling.
- Accept both audited upstream tensor layouts: official `weight_g` / `weight_v` weight normalization and ComfyUI folded `.weight` tensors.
- Preserve generated soundtrack association as a typed boundary and expose cancellation checkpoints around preprocess, DAC, projection, posterior, decode projection, BigVGAN, and output stages.

## Loader safety and parity boundaries

- Public construction goes through the validated safetensors loader; the raw model constructor remains crate-private.
- Validation fails closed on execution dtype, exact tensor key set, per-tensor dtype and shape, header fields, contiguous offsets, payload span, and full file length.
- ComfyUI normalization buffers must bit-match the pinned H3 configuration.
- The production tensor payload accounting is revision-locked at 605,306,340 bytes.
- This PR changes only `mold-candle` primitives and does not activate a catalog entry, engine factory, capability, scheduler path, or runtime download.

## Validation

- `cargo fmt --all -- --check`
- `cargo +1.93 clippy -p mold-ai-candle --all-targets -- -D warnings`
- `nix develop -c cargo test -p mold-ai-candle` — 24 passed
- `nix develop -c cargo check -p mold-ai-candle --features metal`
- Plato NVIDIA L40S: `cargo clippy -p mold-ai-candle --all-targets --features cuda -- -D warnings`
- Plato NVIDIA L40S: `cargo test -p mold-ai-candle --features cuda` — 25 passed, including nonzero CPU/CUDA encode+decode parity

## Gated follow-up

No H3 model weights were downloaded, the external UAT volume was not touched, and no media was generated. Legal authorization remains tracked in #831. Real-weight waveform/intermediate parity, 32 kHz AAC/native playback validation, pipeline integration, and end-to-end UAT remain explicitly gated follow-up work.

The synchronized A/V mux prerequisite landed in #846 before this branch was rebased onto `main`.

Refs #834
