### PR TITLE
feat(inference): add H3 layer-50 Qwen conditioner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3139,8 +3139,6 @@ dependencies = [
  "candle-core",
  "candle-nn",
  "candle-transformers",
- "memmap2",
- "safetensors 0.4.5",
  "serde",
  "serde_json",
  "sha2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3139,8 +3139,13 @@ dependencies = [
  "candle-core",
  "candle-nn",
  "candle-transformers",
+ "memmap2",
+ "safetensors 0.4.5",
  "serde",
  "serde_json",
+ "sha2",
+ "thiserror 2.0.18",
+ "tokenizers 0.21.4",
  "tracing",
 ]
 

--- a/crates/mold-candle/Cargo.toml
+++ b/crates/mold-candle/Cargo.toml
@@ -19,8 +19,6 @@ metal = ["candle/metal", "candle-nn/metal", "candle-transformers/metal"]
 candle = { package = "candle-core", version = "0.11" }
 candle-nn = "0.11"
 candle-transformers = "0.11"
-memmap2 = "0.9"
-safetensors = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"

--- a/crates/mold-candle/Cargo.toml
+++ b/crates/mold-candle/Cargo.toml
@@ -19,6 +19,11 @@ metal = ["candle/metal", "candle-nn/metal", "candle-transformers/metal"]
 candle = { package = "candle-core", version = "0.11" }
 candle-nn = "0.11"
 candle-transformers = "0.11"
+memmap2 = "0.9"
+safetensors = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+sha2 = "0.10"
+thiserror = "2"
+tokenizers = { version = "0.21", default-features = false, features = ["fancy-regex"] }
 tracing = "0.1"

--- a/crates/mold-candle/src/minimax_h3/artifacts.rs
+++ b/crates/mold-candle/src/minimax_h3/artifacts.rs
@@ -37,9 +37,42 @@ pub struct ArtifactFingerprint {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct FrozenArtifact {
+    role: ArtifactRole,
+    path: PathBuf,
+    fingerprint: ArtifactFingerprint,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ArtifactVerificationProgress {
     pub role: ArtifactRole,
-    pub path: PathBuf,
-    pub fingerprint: ArtifactFingerprint,
+    pub artifact_bytes_verified: u64,
+    pub artifact_bytes_total: u64,
+    pub total_bytes_verified: u64,
+    pub total_bytes: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct VerifiedArtifactMetadata {
+    identities: BTreeMap<ArtifactRole, FileMetadataIdentity>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct FileMetadataIdentity {
+    size_bytes: u64,
+    #[cfg(unix)]
+    device: u64,
+    #[cfg(unix)]
+    inode: u64,
+    #[cfg(unix)]
+    modified_seconds: i64,
+    #[cfg(unix)]
+    modified_nanoseconds: i64,
+    #[cfg(unix)]
+    changed_seconds: i64,
+    #[cfg(unix)]
+    changed_nanoseconds: i64,
+    #[cfg(not(unix))]
+    modified: Option<std::time::SystemTime>,
 }
 
 #[derive(Debug, Error)]
@@ -57,6 +90,26 @@ pub enum ArtifactError {
         expected: ArtifactFingerprint,
         found: ArtifactFingerprint,
     },
+    #[error("{role:?} artifact size changed: expected {expected} bytes, found {found} bytes")]
+    SizeChanged {
+        role: ArtifactRole,
+        expected: u64,
+        found: u64,
+    },
+    #[error("{role:?} artifact does not carry the released pinned identity: expected {expected:?}, found {found:?}")]
+    PinnedIdentityMismatch {
+        role: ArtifactRole,
+        expected: ArtifactFingerprint,
+        found: ArtifactFingerprint,
+    },
+    #[error("invalid pinned fingerprint for {role:?}: {message}")]
+    InvalidPinnedFingerprint { role: ArtifactRole, message: String },
+    #[error("MiniMax H3 artifact verification was cancelled")]
+    VerificationCancelled,
+    #[error("MiniMax H3 pinned artifact byte count overflow")]
+    ByteCountOverflow,
+    #[error("{role:?} artifact changed during or after content verification: {path}")]
+    MetadataChanged { role: ArtifactRole, path: PathBuf },
     #[error("duplicate MiniMax H3 artifact role {0:?}")]
     DuplicateRole(ArtifactRole),
     #[error("missing MiniMax H3 artifact role {0:?}")]
@@ -66,50 +119,167 @@ pub enum ArtifactError {
 }
 
 impl FrozenArtifact {
-    pub fn freeze(role: ArtifactRole, path: impl Into<PathBuf>) -> Result<Self, ArtifactError> {
-        let path = path.into();
-        let fingerprint = fingerprint_path(&role, &path)?;
+    /// Declare one exact expected artifact identity. Content is hashed once,
+    /// with cooperative cancellation and progress, when the complete artifact
+    /// set is prepared. Keeping construction free of file reads avoids hashing
+    /// 51.5-66.7 GB checkpoints once at planning and again at execution.
+    pub fn pinned(
+        role: ArtifactRole,
+        path: impl Into<PathBuf>,
+        fingerprint: ArtifactFingerprint,
+    ) -> Result<Self, ArtifactError> {
+        validate_fingerprint(&role, &fingerprint)?;
+        if let Some(expected) = released_support_fingerprint(&role) {
+            if fingerprint != expected {
+                return Err(ArtifactError::PinnedIdentityMismatch {
+                    role,
+                    expected,
+                    found: fingerprint,
+                });
+            }
+        }
         Ok(Self {
             role,
-            path,
+            path: path.into(),
             fingerprint,
         })
     }
 
-    /// Re-check identity immediately before mmap/load. A matching filename is
-    /// not sufficient authority for a 51.5 GB component.
-    pub fn verify(&self) -> Result<(), ArtifactError> {
-        let found = fingerprint_path(&self.role, &self.path)?;
-        if found != self.fingerprint {
-            return Err(ArtifactError::FingerprintChanged {
-                role: self.role.clone(),
-                expected: self.fingerprint.clone(),
-                found,
-            });
-        }
-        Ok(())
+    pub fn role(&self) -> &ArtifactRole {
+        &self.role
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn fingerprint(&self) -> &ArtifactFingerprint {
+        &self.fingerprint
     }
 }
 
-fn fingerprint_path(
+fn validate_fingerprint(
+    role: &ArtifactRole,
+    fingerprint: &ArtifactFingerprint,
+) -> Result<(), ArtifactError> {
+    if fingerprint.size_bytes == 0 {
+        return Err(ArtifactError::InvalidPinnedFingerprint {
+            role: role.clone(),
+            message: "size must be nonzero".into(),
+        });
+    }
+    if fingerprint.sha256.len() != 64
+        || !fingerprint
+            .sha256
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+    {
+        return Err(ArtifactError::InvalidPinnedFingerprint {
+            role: role.clone(),
+            message: "sha256 must be 64 lowercase hexadecimal characters".into(),
+        });
+    }
+    Ok(())
+}
+
+fn released_support_fingerprint(role: &ArtifactRole) -> Option<ArtifactFingerprint> {
+    // MiniMaxAI/MiniMax-H3 at the license-reviewed revision
+    // bfc8ed0353f5a9733be73e6b2c98ec0948195b86. These are, respectively,
+    // text_encoder/config.json, tokenizer/{tokenizer.json,tokenizer_config.json},
+    // and text_encoder/{preprocessor_config.json,video_preprocessor_config.json}.
+    // Content authentication is intentional: structural parsing alone cannot
+    // establish that the released tokenizer and processors are being used.
+    let (size_bytes, sha256) = match role {
+        ArtifactRole::ArchitectureConfig => (
+            1_474,
+            "d2dd0c60d01b9e195d9447c52da61c7302d28828524914c044d9c6e1b81d0427",
+        ),
+        ArtifactRole::Tokenizer => (
+            7_032_403,
+            "a5d85b6dcc535e6b93115a9ef287e6132fdbf30270da6218194ba742261173c7",
+        ),
+        ArtifactRole::TokenizerConfig => (
+            11_003,
+            "a07e942ac874baa13758de8d1fbdb186683cc03416b5589e1b6671c6b3057c68",
+        ),
+        ArtifactRole::ProcessorConfig => (
+            390,
+            "27225450ac9c6529872ee1924fcb0962ff5634834f817040f444118116f4e516",
+        ),
+        ArtifactRole::VideoProcessorConfig => (
+            385,
+            "7768af27c1fafa9cc9011c1dc20067e03f8915e03b63504550e11d5066986d13",
+        ),
+        ArtifactRole::CheckpointIndex | ArtifactRole::CheckpointShard(_) => return None,
+    };
+    Some(ArtifactFingerprint {
+        sha256: sha256.into(),
+        size_bytes,
+    })
+}
+
+fn metadata_identity(
     role: &ArtifactRole,
     path: &Path,
-) -> Result<ArtifactFingerprint, ArtifactError> {
+) -> Result<FileMetadataIdentity, ArtifactError> {
+    let metadata = std::fs::metadata(path).map_err(|source| ArtifactError::Io {
+        role: role.clone(),
+        path: path.to_path_buf(),
+        source,
+    })?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        Ok(FileMetadataIdentity {
+            size_bytes: metadata.len(),
+            device: metadata.dev(),
+            inode: metadata.ino(),
+            modified_seconds: metadata.mtime(),
+            modified_nanoseconds: metadata.mtime_nsec(),
+            changed_seconds: metadata.ctime(),
+            changed_nanoseconds: metadata.ctime_nsec(),
+        })
+    }
+    #[cfg(not(unix))]
+    {
+        Ok(FileMetadataIdentity {
+            size_bytes: metadata.len(),
+            modified: metadata.modified().ok(),
+        })
+    }
+}
+
+fn fingerprint_path_with_progress(
+    artifact: &FrozenArtifact,
+    verified_before: u64,
+    total_bytes: u64,
+    progress: &mut dyn FnMut(ArtifactVerificationProgress) -> Result<(), ArtifactError>,
+) -> Result<(ArtifactFingerprint, FileMetadataIdentity), ArtifactError> {
+    let role = &artifact.role;
+    let path = &artifact.path;
+    let before = metadata_identity(role, path)?;
+    if before.size_bytes != artifact.fingerprint.size_bytes {
+        return Err(ArtifactError::SizeChanged {
+            role: role.clone(),
+            expected: artifact.fingerprint.size_bytes,
+            found: before.size_bytes,
+        });
+    }
     let mut file = File::open(path).map_err(|source| ArtifactError::Io {
         role: role.clone(),
         path: path.to_path_buf(),
         source,
     })?;
-    let size_bytes = file
-        .metadata()
-        .map_err(|source| ArtifactError::Io {
-            role: role.clone(),
-            path: path.to_path_buf(),
-            source,
-        })?
-        .len();
     let mut hasher = Sha256::new();
-    let mut buffer = [0_u8; 1024 * 1024];
+    let mut buffer = vec![0_u8; 8 * 1024 * 1024];
+    let mut artifact_bytes_verified = 0_u64;
+    progress(ArtifactVerificationProgress {
+        role: role.clone(),
+        artifact_bytes_verified,
+        artifact_bytes_total: before.size_bytes,
+        total_bytes_verified: verified_before,
+        total_bytes,
+    })?;
     loop {
         let read = file.read(&mut buffer).map_err(|source| ArtifactError::Io {
             role: role.clone(),
@@ -120,13 +290,39 @@ fn fingerprint_path(
             break;
         }
         hasher.update(&buffer[..read]);
+        artifact_bytes_verified += read as u64;
+        progress(ArtifactVerificationProgress {
+            role: role.clone(),
+            artifact_bytes_verified,
+            artifact_bytes_total: before.size_bytes,
+            total_bytes_verified: verified_before + artifact_bytes_verified,
+            total_bytes,
+        })?;
     }
     let sha256 = hasher
         .finalize()
         .iter()
         .map(|byte| format!("{byte:02x}"))
         .collect();
-    Ok(ArtifactFingerprint { sha256, size_bytes })
+    let found = ArtifactFingerprint {
+        sha256,
+        size_bytes: before.size_bytes,
+    };
+    if found != artifact.fingerprint {
+        return Err(ArtifactError::FingerprintChanged {
+            role: role.clone(),
+            expected: artifact.fingerprint.clone(),
+            found,
+        });
+    }
+    let after = metadata_identity(role, path)?;
+    if after != before {
+        return Err(ArtifactError::MetadataChanged {
+            role: role.clone(),
+            path: path.clone(),
+        });
+    }
+    Ok((artifact.fingerprint.clone(), after))
 }
 
 #[derive(Clone, Debug)]
@@ -160,6 +356,17 @@ impl ConditionerArtifacts {
         {
             return Err(ArtifactError::MissingRole(ArtifactRole::CheckpointShard(0)));
         }
+        for artifact in by_role.values() {
+            if let Some(expected) = released_support_fingerprint(&artifact.role) {
+                if artifact.fingerprint != expected {
+                    return Err(ArtifactError::PinnedIdentityMismatch {
+                        role: artifact.role.clone(),
+                        expected,
+                        found: artifact.fingerprint.clone(),
+                    });
+                }
+            }
+        }
         Ok(Self { artifacts: by_role })
     }
 
@@ -173,8 +380,49 @@ impl ConditionerArtifacts {
         })
     }
 
-    pub fn verify_all(&self) -> Result<(), ArtifactError> {
-        self.artifacts.values().try_for_each(FrozenArtifact::verify)
+    pub fn expected_bytes(&self) -> Result<u64, ArtifactError> {
+        self.artifacts.values().try_fold(0_u64, |total, artifact| {
+            total
+                .checked_add(artifact.fingerprint.size_bytes)
+                .ok_or(ArtifactError::ByteCountOverflow)
+        })
+    }
+
+    pub(super) fn verify_all_with_progress(
+        &self,
+        progress: &mut dyn FnMut(ArtifactVerificationProgress) -> Result<(), ArtifactError>,
+    ) -> Result<VerifiedArtifactMetadata, ArtifactError> {
+        let total_bytes = self.expected_bytes()?;
+        let mut verified_before = 0_u64;
+        let mut identities = BTreeMap::new();
+        for artifact in self.artifacts.values() {
+            let (_, identity) =
+                fingerprint_path_with_progress(artifact, verified_before, total_bytes, progress)?;
+            verified_before = verified_before
+                .checked_add(artifact.fingerprint.size_bytes)
+                .ok_or(ArtifactError::ByteCountOverflow)?;
+            identities.insert(artifact.role.clone(), identity);
+        }
+        Ok(VerifiedArtifactMetadata { identities })
+    }
+
+    pub(super) fn verify_metadata(
+        &self,
+        verified: &VerifiedArtifactMetadata,
+    ) -> Result<(), ArtifactError> {
+        for artifact in self.artifacts.values() {
+            let expected = verified
+                .identities
+                .get(&artifact.role)
+                .ok_or_else(|| ArtifactError::MissingRole(artifact.role.clone()))?;
+            if &metadata_identity(&artifact.role, &artifact.path)? != expected {
+                return Err(ArtifactError::MetadataChanged {
+                    role: artifact.role.clone(),
+                    path: artifact.path.clone(),
+                });
+            }
+        }
+        Ok(())
     }
 }
 
@@ -205,6 +453,16 @@ pub(super) fn validate_checkpoint_keys_and_layout(
         .collect::<BTreeSet<_>>();
 
     let missing: Vec<_> = expected_materialized.difference(&actual).cloned().collect();
+    let missing_official_tail: Vec<_> = if layout == ConditionerWeightLayout::Official {
+        expected_skipped.difference(&actual).cloned().collect()
+    } else {
+        Vec::new()
+    };
+    let forbidden_comfy_tail: Vec<_> = if layout == ConditionerWeightLayout::ComfyLayer50 {
+        actual.intersection(&expected_skipped).cloned().collect()
+    } else {
+        Vec::new()
+    };
     let unexpected: Vec<_> = actual
         .difference(&expected_materialized)
         .filter(|name| !expected_skipped.contains(*name) && !is_regenerable_rotary_buffer(name))
@@ -220,11 +478,19 @@ pub(super) fn validate_checkpoint_keys_and_layout(
                 .cloned(),
         )
         .collect();
-    if !missing.is_empty() || !unexpected.is_empty() {
+    if !missing.is_empty()
+        || !missing_official_tail.is_empty()
+        || !forbidden_comfy_tail.is_empty()
+        || !unexpected.is_empty()
+    {
         return Err(ArtifactError::CheckpointKeys(format!(
-            "{} materialized keys missing (first: {:?}); {} unexpected keys (first: {:?})",
+            "{} materialized keys missing (first: {:?}); {} official tail keys missing (first: {:?}); {} tail keys forbidden in Comfy layer-50 layout (first: {:?}); {} unexpected keys (first: {:?})",
             missing.len(),
             missing.first(),
+            missing_official_tail.len(),
+            missing_official_tail.first(),
+            forbidden_comfy_tail.len(),
+            forbidden_comfy_tail.first(),
             unexpected.len(),
             unexpected.first()
         )));
@@ -495,6 +761,24 @@ mod tests {
     use super::*;
     use std::fs;
 
+    fn test_path(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "mold-h3-{label}-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ))
+    }
+
+    fn fingerprint(bytes: &[u8]) -> ArtifactFingerprint {
+        ArtifactFingerprint {
+            sha256: Sha256::digest(bytes)
+                .iter()
+                .map(|byte| format!("{byte:02x}"))
+                .collect(),
+            size_bytes: bytes.len() as u64,
+        }
+    }
+
     #[test]
     fn layer_tail_is_accounted_but_never_materialized() {
         let all = expected_materialized_keys()
@@ -532,6 +816,30 @@ mod tests {
     }
 
     #[test]
+    fn official_and_comfy_tail_key_sets_cannot_be_crossed() {
+        let truncated_official = expected_materialized_keys();
+        let error = validate_checkpoint_keys_and_layout(truncated_official).unwrap_err();
+        assert!(error.to_string().contains("156 official tail keys missing"));
+
+        let comfy_with_tail = expected_materialized_keys()
+            .into_iter()
+            .chain(expected_skipped_keys())
+            .map(|name| {
+                name.strip_prefix("model.language_model.")
+                    .map(|suffix| format!("model.{suffix}"))
+                    .or_else(|| {
+                        name.strip_prefix("model.visual.")
+                            .map(|suffix| format!("visual.{suffix}"))
+                    })
+                    .unwrap_or(name)
+            });
+        let error = validate_checkpoint_keys_and_layout(comfy_with_tail).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("156 tail keys forbidden in Comfy layer-50 layout"));
+    }
+
+    #[test]
     fn mixed_official_and_comfy_namespaces_are_rejected() {
         let names = expected_materialized_keys()
             .into_iter()
@@ -560,17 +868,91 @@ mod tests {
     }
 
     #[test]
-    fn frozen_fingerprint_detects_same_path_replacement() {
-        let path = std::env::temp_dir().join(format!(
-            "mold-h3-artifact-{}-{}",
-            std::process::id(),
-            std::thread::current().name().unwrap_or("test")
-        ));
-        fs::write(&path, b"original").unwrap();
-        let artifact = FrozenArtifact::freeze(ArtifactRole::Tokenizer, &path).unwrap();
-        fs::write(&path, b"replacement").unwrap();
+    fn verified_metadata_detects_same_path_replacement_without_rehashing() {
+        let path = test_path("metadata-replacement");
+        let original = b"original";
+        fs::write(&path, original).unwrap();
+        let artifact = FrozenArtifact::pinned(
+            ArtifactRole::CheckpointShard(0),
+            &path,
+            fingerprint(original),
+        )
+        .unwrap();
+        let (_, verified) =
+            fingerprint_path_with_progress(&artifact, 0, original.len() as u64, &mut |_| Ok(()))
+                .unwrap();
+        fs::remove_file(&path).unwrap();
+        fs::write(&path, b"replaced").unwrap();
         assert!(matches!(
-            artifact.verify(),
+            metadata_identity(artifact.role(), artifact.path()),
+            Ok(found) if found != verified
+        ));
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn large_artifact_hashing_is_cooperatively_cancellable() {
+        let path = test_path("cancel-hash");
+        let bytes = vec![7_u8; 17 * 1024 * 1024];
+        fs::write(&path, &bytes).unwrap();
+        let artifact =
+            FrozenArtifact::pinned(ArtifactRole::CheckpointShard(0), &path, fingerprint(&bytes))
+                .unwrap();
+        let mut observed = Vec::new();
+        let error =
+            fingerprint_path_with_progress(&artifact, 0, bytes.len() as u64, &mut |event| {
+                observed.push(event.total_bytes_verified);
+                if event.artifact_bytes_verified >= 8 * 1024 * 1024 {
+                    Err(ArtifactError::VerificationCancelled)
+                } else {
+                    Ok(())
+                }
+            })
+            .unwrap_err();
+        assert!(matches!(error, ArtifactError::VerificationCancelled));
+        assert!(observed.windows(2).all(|pair| pair[0] <= pair[1]));
+        assert!(observed
+            .last()
+            .is_some_and(|bytes| *bytes < 17 * 1024 * 1024));
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn every_tokenizer_and_processor_role_requires_the_released_digest() {
+        for role in [
+            ArtifactRole::ArchitectureConfig,
+            ArtifactRole::Tokenizer,
+            ArtifactRole::TokenizerConfig,
+            ArtifactRole::ProcessorConfig,
+            ArtifactRole::VideoProcessorConfig,
+        ] {
+            let expected = released_support_fingerprint(&role).unwrap();
+            assert!(FrozenArtifact::pinned(role.clone(), "/unused", expected.clone()).is_ok());
+            let wrong = ArtifactFingerprint {
+                sha256: "0".repeat(64),
+                size_bytes: expected.size_bytes,
+            };
+            assert!(matches!(
+                FrozenArtifact::pinned(role.clone(), "/unused", wrong),
+                Err(ArtifactError::PinnedIdentityMismatch { role: found, .. }) if found == role
+            ));
+        }
+    }
+
+    #[test]
+    fn same_size_corrupt_tokenizer_cannot_satisfy_the_pinned_identity() {
+        let role = ArtifactRole::Tokenizer;
+        let expected = released_support_fingerprint(&role).unwrap();
+        let path = test_path("corrupt-tokenizer");
+        fs::write(&path, vec![0_u8; expected.size_bytes as usize]).unwrap();
+        let artifact = FrozenArtifact::pinned(role, &path, expected).unwrap();
+        assert!(matches!(
+            fingerprint_path_with_progress(
+                &artifact,
+                0,
+                artifact.fingerprint().size_bytes,
+                &mut |_| Ok(())
+            ),
             Err(ArtifactError::FingerprintChanged { .. })
         ));
         let _ = fs::remove_file(path);

--- a/crates/mold-candle/src/minimax_h3/artifacts.rs
+++ b/crates/mold-candle/src/minimax_h3/artifacts.rs
@@ -1,0 +1,578 @@
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs::File;
+use std::io::{self, Read};
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+use super::config::{H3ConditionerConfig, H3_FULL_LANGUAGE_LAYERS, H3_SELECTED_LANGUAGE_LAYERS};
+
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum ArtifactRole {
+    ArchitectureConfig,
+    Tokenizer,
+    TokenizerConfig,
+    ProcessorConfig,
+    VideoProcessorConfig,
+    CheckpointIndex,
+    CheckpointShard(usize),
+}
+
+/// The two released BF16 conditioner namespaces are deliberately distinct.
+/// The official Transformers checkpoint retains the nested
+/// `model.language_model`/`model.visual` prefixes, while Comfy's layer-50
+/// checkpoint removes only those two wrapper components. A checkpoint must
+/// identify as exactly one layout; mixed namespaces are never repaired.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum ConditionerWeightLayout {
+    Official,
+    ComfyLayer50,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ArtifactFingerprint {
+    pub sha256: String,
+    pub size_bytes: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FrozenArtifact {
+    pub role: ArtifactRole,
+    pub path: PathBuf,
+    pub fingerprint: ArtifactFingerprint,
+}
+
+#[derive(Debug, Error)]
+pub enum ArtifactError {
+    #[error("failed to read {role:?} artifact {path}: {source}")]
+    Io {
+        role: ArtifactRole,
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    #[error("{role:?} artifact changed after planning: expected {expected:?}, found {found:?}")]
+    FingerprintChanged {
+        role: ArtifactRole,
+        expected: ArtifactFingerprint,
+        found: ArtifactFingerprint,
+    },
+    #[error("duplicate MiniMax H3 artifact role {0:?}")]
+    DuplicateRole(ArtifactRole),
+    #[error("missing MiniMax H3 artifact role {0:?}")]
+    MissingRole(ArtifactRole),
+    #[error("MiniMax H3 checkpoint key accounting failed: {0}")]
+    CheckpointKeys(String),
+}
+
+impl FrozenArtifact {
+    pub fn freeze(role: ArtifactRole, path: impl Into<PathBuf>) -> Result<Self, ArtifactError> {
+        let path = path.into();
+        let fingerprint = fingerprint_path(&role, &path)?;
+        Ok(Self {
+            role,
+            path,
+            fingerprint,
+        })
+    }
+
+    /// Re-check identity immediately before mmap/load. A matching filename is
+    /// not sufficient authority for a 51.5 GB component.
+    pub fn verify(&self) -> Result<(), ArtifactError> {
+        let found = fingerprint_path(&self.role, &self.path)?;
+        if found != self.fingerprint {
+            return Err(ArtifactError::FingerprintChanged {
+                role: self.role.clone(),
+                expected: self.fingerprint.clone(),
+                found,
+            });
+        }
+        Ok(())
+    }
+}
+
+fn fingerprint_path(
+    role: &ArtifactRole,
+    path: &Path,
+) -> Result<ArtifactFingerprint, ArtifactError> {
+    let mut file = File::open(path).map_err(|source| ArtifactError::Io {
+        role: role.clone(),
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let size_bytes = file
+        .metadata()
+        .map_err(|source| ArtifactError::Io {
+            role: role.clone(),
+            path: path.to_path_buf(),
+            source,
+        })?
+        .len();
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 1024 * 1024];
+    loop {
+        let read = file.read(&mut buffer).map_err(|source| ArtifactError::Io {
+            role: role.clone(),
+            path: path.to_path_buf(),
+            source,
+        })?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    let sha256 = hasher
+        .finalize()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect();
+    Ok(ArtifactFingerprint { sha256, size_bytes })
+}
+
+#[derive(Clone, Debug)]
+pub struct ConditionerArtifacts {
+    artifacts: BTreeMap<ArtifactRole, FrozenArtifact>,
+}
+
+impl ConditionerArtifacts {
+    pub fn new(artifacts: impl IntoIterator<Item = FrozenArtifact>) -> Result<Self, ArtifactError> {
+        let mut by_role = BTreeMap::new();
+        for artifact in artifacts {
+            let role = artifact.role.clone();
+            if by_role.insert(role.clone(), artifact).is_some() {
+                return Err(ArtifactError::DuplicateRole(role));
+            }
+        }
+        for role in [
+            ArtifactRole::ArchitectureConfig,
+            ArtifactRole::Tokenizer,
+            ArtifactRole::TokenizerConfig,
+            ArtifactRole::ProcessorConfig,
+            ArtifactRole::VideoProcessorConfig,
+        ] {
+            if !by_role.contains_key(&role) {
+                return Err(ArtifactError::MissingRole(role));
+            }
+        }
+        if !by_role
+            .keys()
+            .any(|role| matches!(role, ArtifactRole::CheckpointShard(_)))
+        {
+            return Err(ArtifactError::MissingRole(ArtifactRole::CheckpointShard(0)));
+        }
+        Ok(Self { artifacts: by_role })
+    }
+
+    pub fn get(&self, role: &ArtifactRole) -> Option<&FrozenArtifact> {
+        self.artifacts.get(role)
+    }
+
+    pub fn checkpoint_shards(&self) -> impl Iterator<Item = &FrozenArtifact> {
+        self.artifacts.iter().filter_map(|(role, artifact)| {
+            matches!(role, ArtifactRole::CheckpointShard(_)).then_some(artifact)
+        })
+    }
+
+    pub fn verify_all(&self) -> Result<(), ArtifactError> {
+        self.artifacts.values().try_for_each(FrozenArtifact::verify)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CheckpointKeyReport {
+    pub materialized: BTreeSet<String>,
+    pub intentionally_skipped: BTreeSet<String>,
+}
+
+/// Account for every released checkpoint key. Only the final norm, LM head,
+/// and decoder layers 50-63 are legal non-resident tensors.
+pub fn validate_checkpoint_keys(
+    names: impl IntoIterator<Item = impl Into<String>>,
+) -> Result<CheckpointKeyReport, ArtifactError> {
+    validate_checkpoint_keys_and_layout(names).map(|(report, _)| report)
+}
+
+pub(super) fn validate_checkpoint_keys_and_layout(
+    names: impl IntoIterator<Item = impl Into<String>>,
+) -> Result<(CheckpointKeyReport, ConditionerWeightLayout), ArtifactError> {
+    let expected_materialized = expected_materialized_keys();
+    let expected_skipped = expected_skipped_keys();
+    let raw: BTreeSet<String> = names.into_iter().map(Into::into).collect();
+    let layout = detect_checkpoint_layout(&raw)?;
+    let actual = raw
+        .iter()
+        .map(|name| canonical_checkpoint_name(name, layout))
+        .collect::<BTreeSet<_>>();
+
+    let missing: Vec<_> = expected_materialized.difference(&actual).cloned().collect();
+    let unexpected: Vec<_> = actual
+        .difference(&expected_materialized)
+        .filter(|name| !expected_skipped.contains(*name) && !is_regenerable_rotary_buffer(name))
+        .cloned()
+        .collect();
+    let skipped: BTreeSet<_> = actual
+        .intersection(&expected_skipped)
+        .cloned()
+        .chain(
+            actual
+                .iter()
+                .filter(|name| is_regenerable_rotary_buffer(name))
+                .cloned(),
+        )
+        .collect();
+    if !missing.is_empty() || !unexpected.is_empty() {
+        return Err(ArtifactError::CheckpointKeys(format!(
+            "{} materialized keys missing (first: {:?}); {} unexpected keys (first: {:?})",
+            missing.len(),
+            missing.first(),
+            unexpected.len(),
+            unexpected.first()
+        )));
+    }
+    Ok((
+        CheckpointKeyReport {
+            materialized: actual
+                .intersection(&expected_materialized)
+                .cloned()
+                .collect(),
+            intentionally_skipped: skipped,
+        },
+        layout,
+    ))
+}
+
+fn detect_checkpoint_layout(
+    names: &BTreeSet<String>,
+) -> Result<ConditionerWeightLayout, ArtifactError> {
+    let official = names.contains("model.language_model.embed_tokens.weight")
+        || names.iter().any(|name| name.starts_with("model.visual."));
+    let comfy = names.contains("model.embed_tokens.weight")
+        || names.iter().any(|name| name.starts_with("visual."));
+    match (official, comfy) {
+        (true, false) => Ok(ConditionerWeightLayout::Official),
+        (false, true) => Ok(ConditionerWeightLayout::ComfyLayer50),
+        (true, true) => Err(ArtifactError::CheckpointKeys(
+            "checkpoint mixes official and Comfy layer-50 namespaces".into(),
+        )),
+        (false, false) => Err(ArtifactError::CheckpointKeys(
+            "checkpoint has no exact official or Comfy layer-50 namespace marker".into(),
+        )),
+    }
+}
+
+pub(super) fn canonical_checkpoint_name(name: &str, layout: ConditionerWeightLayout) -> String {
+    match layout {
+        ConditionerWeightLayout::Official => name.to_string(),
+        ConditionerWeightLayout::ComfyLayer50 => {
+            if let Some(suffix) = name.strip_prefix("model.") {
+                format!("model.language_model.{suffix}")
+            } else if let Some(suffix) = name.strip_prefix("visual.") {
+                format!("model.visual.{suffix}")
+            } else {
+                name.to_string()
+            }
+        }
+    }
+}
+
+fn is_regenerable_rotary_buffer(name: &str) -> bool {
+    matches!(
+        name,
+        "model.language_model.rotary_emb.inv_freq" | "model.visual.rotary_pos_emb.inv_freq"
+    )
+}
+
+fn expected_materialized_keys() -> BTreeSet<String> {
+    let mut keys = BTreeSet::new();
+    keys.insert("model.language_model.embed_tokens.weight".into());
+    for layer in 0..H3_SELECTED_LANGUAGE_LAYERS {
+        let prefix = format!("model.language_model.layers.{layer}");
+        for suffix in [
+            "input_layernorm.weight",
+            "post_attention_layernorm.weight",
+            "self_attn.q_proj.weight",
+            "self_attn.k_proj.weight",
+            "self_attn.v_proj.weight",
+            "self_attn.o_proj.weight",
+            "self_attn.q_norm.weight",
+            "self_attn.k_norm.weight",
+            "mlp.gate_proj.weight",
+            "mlp.up_proj.weight",
+            "mlp.down_proj.weight",
+        ] {
+            keys.insert(format!("{prefix}.{suffix}"));
+        }
+    }
+    keys.insert("model.visual.patch_embed.proj.weight".into());
+    keys.insert("model.visual.patch_embed.proj.bias".into());
+    keys.insert("model.visual.pos_embed.weight".into());
+    for layer in 0..27 {
+        let prefix = format!("model.visual.blocks.{layer}");
+        for suffix in [
+            "attn.qkv.weight",
+            "attn.qkv.bias",
+            "attn.proj.weight",
+            "attn.proj.bias",
+            "mlp.linear_fc1.weight",
+            "mlp.linear_fc1.bias",
+            "mlp.linear_fc2.weight",
+            "mlp.linear_fc2.bias",
+            "norm1.weight",
+            "norm1.bias",
+            "norm2.weight",
+            "norm2.bias",
+        ] {
+            keys.insert(format!("{prefix}.{suffix}"));
+        }
+    }
+    for prefix in std::iter::once("model.visual.merger".to_string())
+        .chain((0..3).map(|index| format!("model.visual.deepstack_merger_list.{index}")))
+    {
+        for suffix in [
+            "linear_fc1.weight",
+            "linear_fc1.bias",
+            "linear_fc2.weight",
+            "linear_fc2.bias",
+            "norm.weight",
+            "norm.bias",
+        ] {
+            keys.insert(format!("{prefix}.{suffix}"));
+        }
+    }
+    keys
+}
+
+fn expected_skipped_keys() -> BTreeSet<String> {
+    let mut keys = BTreeSet::from([
+        "lm_head.weight".to_string(),
+        "model.language_model.norm.weight".to_string(),
+    ]);
+    for layer in H3_SELECTED_LANGUAGE_LAYERS..H3_FULL_LANGUAGE_LAYERS {
+        let prefix = format!("model.language_model.layers.{layer}");
+        for suffix in [
+            "input_layernorm.weight",
+            "post_attention_layernorm.weight",
+            "self_attn.q_proj.weight",
+            "self_attn.k_proj.weight",
+            "self_attn.v_proj.weight",
+            "self_attn.o_proj.weight",
+            "self_attn.q_norm.weight",
+            "self_attn.k_norm.weight",
+            "mlp.gate_proj.weight",
+            "mlp.up_proj.weight",
+            "mlp.down_proj.weight",
+        ] {
+            keys.insert(format!("{prefix}.{suffix}"));
+        }
+    }
+    keys
+}
+
+pub(super) fn expected_checkpoint_shapes(
+    config: &H3ConditionerConfig,
+) -> BTreeMap<String, Vec<usize>> {
+    let text = &config.text_config;
+    let vision = &config.vision_config;
+    let mut shapes = BTreeMap::new();
+    shapes.insert(
+        "model.language_model.embed_tokens.weight".into(),
+        vec![text.vocab_size, text.hidden_size],
+    );
+    shapes.insert(
+        "model.language_model.norm.weight".into(),
+        vec![text.hidden_size],
+    );
+    shapes.insert(
+        "lm_head.weight".into(),
+        vec![text.vocab_size, text.hidden_size],
+    );
+    let q_width = text.num_attention_heads * text.head_dim;
+    let kv_width = text.num_key_value_heads * text.head_dim;
+    for layer in 0..H3_FULL_LANGUAGE_LAYERS {
+        let prefix = format!("model.language_model.layers.{layer}");
+        for (suffix, shape) in [
+            ("input_layernorm.weight", vec![text.hidden_size]),
+            ("post_attention_layernorm.weight", vec![text.hidden_size]),
+            ("self_attn.q_proj.weight", vec![q_width, text.hidden_size]),
+            ("self_attn.k_proj.weight", vec![kv_width, text.hidden_size]),
+            ("self_attn.v_proj.weight", vec![kv_width, text.hidden_size]),
+            ("self_attn.o_proj.weight", vec![text.hidden_size, q_width]),
+            ("self_attn.q_norm.weight", vec![text.head_dim]),
+            ("self_attn.k_norm.weight", vec![text.head_dim]),
+            (
+                "mlp.gate_proj.weight",
+                vec![text.intermediate_size, text.hidden_size],
+            ),
+            (
+                "mlp.up_proj.weight",
+                vec![text.intermediate_size, text.hidden_size],
+            ),
+            (
+                "mlp.down_proj.weight",
+                vec![text.hidden_size, text.intermediate_size],
+            ),
+        ] {
+            shapes.insert(format!("{prefix}.{suffix}"), shape);
+        }
+    }
+
+    shapes.insert(
+        "model.visual.patch_embed.proj.weight".into(),
+        vec![
+            vision.hidden_size,
+            vision.in_channels,
+            vision.temporal_patch_size,
+            vision.patch_size,
+            vision.patch_size,
+        ],
+    );
+    shapes.insert(
+        "model.visual.patch_embed.proj.bias".into(),
+        vec![vision.hidden_size],
+    );
+    shapes.insert(
+        "model.visual.pos_embed.weight".into(),
+        vec![vision.num_position_embeddings, vision.hidden_size],
+    );
+    for layer in 0..vision.depth {
+        let prefix = format!("model.visual.blocks.{layer}");
+        for (suffix, shape) in [
+            (
+                "attn.qkv.weight",
+                vec![vision.hidden_size * 3, vision.hidden_size],
+            ),
+            ("attn.qkv.bias", vec![vision.hidden_size * 3]),
+            (
+                "attn.proj.weight",
+                vec![vision.hidden_size, vision.hidden_size],
+            ),
+            ("attn.proj.bias", vec![vision.hidden_size]),
+            (
+                "mlp.linear_fc1.weight",
+                vec![vision.intermediate_size, vision.hidden_size],
+            ),
+            ("mlp.linear_fc1.bias", vec![vision.intermediate_size]),
+            (
+                "mlp.linear_fc2.weight",
+                vec![vision.hidden_size, vision.intermediate_size],
+            ),
+            ("mlp.linear_fc2.bias", vec![vision.hidden_size]),
+            ("norm1.weight", vec![vision.hidden_size]),
+            ("norm1.bias", vec![vision.hidden_size]),
+            ("norm2.weight", vec![vision.hidden_size]),
+            ("norm2.bias", vec![vision.hidden_size]),
+        ] {
+            shapes.insert(format!("{prefix}.{suffix}"), shape);
+        }
+    }
+    let merged = vision.hidden_size * vision.spatial_merge_size.pow(2);
+    for (prefix, norm_width) in
+        std::iter::once(("model.visual.merger".to_string(), vision.hidden_size)).chain(
+            (0..vision.deepstack_visual_indexes.len()).map(|index| {
+                (
+                    format!("model.visual.deepstack_merger_list.{index}"),
+                    merged,
+                )
+            }),
+        )
+    {
+        for (suffix, shape) in [
+            ("norm.weight", vec![norm_width]),
+            ("norm.bias", vec![norm_width]),
+            ("linear_fc1.weight", vec![merged, merged]),
+            ("linear_fc1.bias", vec![merged]),
+            ("linear_fc2.weight", vec![vision.out_hidden_size, merged]),
+            ("linear_fc2.bias", vec![vision.out_hidden_size]),
+        ] {
+            shapes.insert(format!("{prefix}.{suffix}"), shape);
+        }
+    }
+    shapes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn layer_tail_is_accounted_but_never_materialized() {
+        let all = expected_materialized_keys()
+            .into_iter()
+            .chain(expected_skipped_keys())
+            .collect::<Vec<_>>();
+        let report = validate_checkpoint_keys(all).unwrap();
+        assert_eq!(report.materialized.len(), 902);
+        assert_eq!(report.intentionally_skipped.len(), 156);
+        assert!(!report.materialized.contains("lm_head.weight"));
+        assert!(!report
+            .materialized
+            .iter()
+            .any(|name| name.starts_with("model.language_model.layers.50.")));
+    }
+
+    #[test]
+    fn comfy_layer_50_namespace_is_exact_and_normalized() {
+        let comfy = expected_materialized_keys().into_iter().map(|name| {
+            name.strip_prefix("model.language_model.")
+                .map(|suffix| format!("model.{suffix}"))
+                .or_else(|| {
+                    name.strip_prefix("model.visual.")
+                        .map(|suffix| format!("visual.{suffix}"))
+                })
+                .unwrap_or(name)
+        });
+        let (report, layout) = validate_checkpoint_keys_and_layout(comfy).unwrap();
+        assert_eq!(layout, ConditionerWeightLayout::ComfyLayer50);
+        assert_eq!(report.materialized.len(), 902);
+        assert!(report.intentionally_skipped.is_empty());
+        assert!(report
+            .materialized
+            .contains("model.language_model.layers.49.self_attn.q_proj.weight"));
+    }
+
+    #[test]
+    fn mixed_official_and_comfy_namespaces_are_rejected() {
+        let names = expected_materialized_keys()
+            .into_iter()
+            .chain(["model.embed_tokens.weight".to_string()]);
+        let error = validate_checkpoint_keys(names).unwrap_err();
+        assert!(error.to_string().contains("mixes official and Comfy"));
+    }
+
+    #[test]
+    fn text_only_qwen_checkpoint_is_rejected() {
+        let text_only = expected_materialized_keys()
+            .into_iter()
+            .filter(|name| !name.starts_with("model.visual."));
+        let error = validate_checkpoint_keys(text_only).unwrap_err();
+        assert!(error.to_string().contains("351 materialized keys missing"));
+    }
+
+    #[test]
+    fn unknown_tail_key_is_not_silently_skipped() {
+        let all = expected_materialized_keys()
+            .into_iter()
+            .chain(expected_skipped_keys())
+            .chain(["model.language_model.layers.64.self_attn.q_proj.weight".into()]);
+        let error = validate_checkpoint_keys(all).unwrap_err();
+        assert!(error.to_string().contains("1 unexpected keys"));
+    }
+
+    #[test]
+    fn frozen_fingerprint_detects_same_path_replacement() {
+        let path = std::env::temp_dir().join(format!(
+            "mold-h3-artifact-{}-{}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("test")
+        ));
+        fs::write(&path, b"original").unwrap();
+        let artifact = FrozenArtifact::freeze(ArtifactRole::Tokenizer, &path).unwrap();
+        fs::write(&path, b"replacement").unwrap();
+        assert!(matches!(
+            artifact.verify(),
+            Err(ArtifactError::FingerprintChanged { .. })
+        ));
+        let _ = fs::remove_file(path);
+    }
+}

--- a/crates/mold-candle/src/minimax_h3/config.rs
+++ b/crates/mold-candle/src/minimax_h3/config.rs
@@ -1,0 +1,265 @@
+use serde::Deserialize;
+use thiserror::Error;
+
+pub const H3_SELECTED_LANGUAGE_LAYERS: usize = 50;
+pub const H3_FULL_LANGUAGE_LAYERS: usize = 64;
+
+/// Tensor payload of the full BF16 Qwen3-VL-32B checkpoint.
+pub const H3_FULL_CHECKPOINT_BYTES: u64 = 66_714_780_128;
+/// BF16 tensor payload materialized by the layer-50 H3 conditioner.
+pub const H3_BF16_PARAMETER_BYTES: u64 = 51_506_191_840;
+/// Size of Comfy's pruned single-file safetensors object, including its header.
+pub const H3_COMFY_SAFETENSORS_BYTES: u64 = 51_506_295_256;
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct H3ConditionerConfig {
+    pub architectures: Vec<String>,
+    pub image_token_id: u32,
+    pub video_token_id: u32,
+    pub vision_start_token_id: u32,
+    pub vision_end_token_id: u32,
+    pub text_config: H3TextConfig,
+    pub vision_config: H3VisionConfig,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct H3TextConfig {
+    pub model_type: String,
+    pub vocab_size: usize,
+    pub hidden_size: usize,
+    pub intermediate_size: usize,
+    pub num_hidden_layers: usize,
+    pub num_attention_heads: usize,
+    pub num_key_value_heads: usize,
+    pub head_dim: usize,
+    pub rms_norm_eps: f64,
+    pub rope_theta: f64,
+    pub max_position_embeddings: usize,
+    pub hidden_act: String,
+    pub attention_bias: bool,
+    pub rope_scaling: H3RopeScaling,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct H3RopeScaling {
+    pub rope_type: String,
+    pub mrope_interleaved: bool,
+    pub mrope_section: [usize; 3],
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct H3VisionConfig {
+    pub model_type: String,
+    pub depth: usize,
+    pub hidden_size: usize,
+    pub intermediate_size: usize,
+    pub num_heads: usize,
+    pub in_channels: usize,
+    pub patch_size: usize,
+    pub temporal_patch_size: usize,
+    pub spatial_merge_size: usize,
+    pub out_hidden_size: usize,
+    pub num_position_embeddings: usize,
+    pub deepstack_visual_indexes: Vec<usize>,
+    pub hidden_act: String,
+}
+
+#[derive(Debug, Error, PartialEq)]
+pub enum ConfigError {
+    #[error("invalid MiniMax H3 Qwen3-VL config JSON: {0}")]
+    Json(String),
+    #[error("wrong conditioner variant: {0}")]
+    WrongVariant(String),
+}
+
+impl H3ConditionerConfig {
+    pub fn from_json(bytes: &[u8]) -> Result<Self, ConfigError> {
+        let config: Self =
+            serde_json::from_slice(bytes).map_err(|error| ConfigError::Json(error.to_string()))?;
+        config.validate()?;
+        Ok(config)
+    }
+
+    /// Validate the exact released Qwen3-VL-32B architecture before any
+    /// checkpoint tensor is mapped or allocated.
+    pub fn validate(&self) -> Result<(), ConfigError> {
+        let wrong = |field: &str, found: String, expected: &str| {
+            ConfigError::WrongVariant(format!("{field} is {found}, expected {expected}"))
+        };
+        macro_rules! exact {
+            ($field:expr, $found:expr, $expected:expr) => {
+                if $found != $expected {
+                    return Err(wrong(
+                        $field,
+                        format!("{:?}", $found),
+                        &format!("{:?}", $expected),
+                    ));
+                }
+            };
+        }
+
+        exact!(
+            "architectures",
+            self.architectures.as_slice(),
+            ["Qwen3VLForConditionalGeneration"]
+        );
+        exact!("image_token_id", self.image_token_id, 151_655);
+        exact!("video_token_id", self.video_token_id, 151_656);
+        exact!("vision_start_token_id", self.vision_start_token_id, 151_652);
+        exact!("vision_end_token_id", self.vision_end_token_id, 151_653);
+
+        let text = &self.text_config;
+        exact!("text.model_type", text.model_type.as_str(), "qwen3_vl_text");
+        exact!("text.vocab_size", text.vocab_size, 151_936);
+        exact!("text.hidden_size", text.hidden_size, 5_120);
+        exact!("text.intermediate_size", text.intermediate_size, 25_600);
+        exact!(
+            "text.num_hidden_layers",
+            text.num_hidden_layers,
+            H3_FULL_LANGUAGE_LAYERS
+        );
+        exact!("text.num_attention_heads", text.num_attention_heads, 64);
+        exact!("text.num_key_value_heads", text.num_key_value_heads, 8);
+        exact!("text.head_dim", text.head_dim, 128);
+        exact!("text.rms_norm_eps", text.rms_norm_eps, 1e-6);
+        exact!("text.rope_theta", text.rope_theta, 5_000_000.0);
+        exact!(
+            "text.max_position_embeddings",
+            text.max_position_embeddings,
+            262_144
+        );
+        exact!("text.hidden_act", text.hidden_act.as_str(), "silu");
+        exact!("text.attention_bias", text.attention_bias, false);
+        exact!(
+            "text.rope_type",
+            text.rope_scaling.rope_type.as_str(),
+            "default"
+        );
+        exact!(
+            "text.mrope_interleaved",
+            text.rope_scaling.mrope_interleaved,
+            true
+        );
+        exact!(
+            "text.mrope_section",
+            text.rope_scaling.mrope_section,
+            [24, 20, 20]
+        );
+
+        let vision = &self.vision_config;
+        exact!("vision.model_type", vision.model_type.as_str(), "qwen3_vl");
+        exact!("vision.depth", vision.depth, 27);
+        exact!("vision.hidden_size", vision.hidden_size, 1_152);
+        exact!("vision.intermediate_size", vision.intermediate_size, 4_304);
+        exact!("vision.num_heads", vision.num_heads, 16);
+        exact!("vision.in_channels", vision.in_channels, 3);
+        exact!("vision.patch_size", vision.patch_size, 16);
+        exact!("vision.temporal_patch_size", vision.temporal_patch_size, 2);
+        exact!("vision.spatial_merge_size", vision.spatial_merge_size, 2);
+        exact!("vision.out_hidden_size", vision.out_hidden_size, 5_120);
+        exact!(
+            "vision.num_position_embeddings",
+            vision.num_position_embeddings,
+            2_304
+        );
+        exact!(
+            "vision.deepstack_visual_indexes",
+            vision.deepstack_visual_indexes.as_slice(),
+            [8, 16, 24]
+        );
+        exact!(
+            "vision.hidden_act",
+            vision.hidden_act.as_str(),
+            "gelu_pytorch_tanh"
+        );
+        Ok(())
+    }
+
+    pub fn materialized_parameter_count(&self) -> u64 {
+        let text = &self.text_config;
+        let vision = &self.vision_config;
+        let h = text.hidden_size as u64;
+        let q = (text.num_attention_heads * text.head_dim) as u64;
+        let kv = (text.num_key_value_heads * text.head_dim) as u64;
+        let intermediate = text.intermediate_size as u64;
+        let per_language_layer =
+            h * q + 2 * h * kv + q * h + 3 * h * intermediate + 2 * h + 2 * text.head_dim as u64;
+        let language =
+            text.vocab_size as u64 * h + H3_SELECTED_LANGUAGE_LAYERS as u64 * per_language_layer;
+
+        let vh = vision.hidden_size as u64;
+        let vi = vision.intermediate_size as u64;
+        let patch = vision.in_channels as u64
+            * vision.temporal_patch_size as u64
+            * vision.patch_size as u64
+            * vision.patch_size as u64
+            * vh
+            + vh;
+        let positions = vision.num_position_embeddings as u64 * vh;
+        let per_vision_block = 4 * vh * vh + 4 * vh + 2 * vh * vi + vi + vh + 4 * vh;
+        let merged = vh * vision.spatial_merge_size.pow(2) as u64;
+        let merger = 2 * vh
+            + merged * merged
+            + merged
+            + merged * vision.out_hidden_size as u64
+            + vision.out_hidden_size as u64;
+        let deepstack_merger = 2 * merged
+            + merged * merged
+            + merged
+            + merged * vision.out_hidden_size as u64
+            + vision.out_hidden_size as u64;
+        language
+            + patch
+            + positions
+            + vision.depth as u64 * per_vision_block
+            + merger
+            + vision.deepstack_visual_indexes.len() as u64 * deepstack_merger
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn released_config() -> String {
+        r#"{
+              "architectures":["Qwen3VLForConditionalGeneration"],
+              "image_token_id":151655,"video_token_id":151656,
+              "vision_start_token_id":151652,"vision_end_token_id":151653,
+              "text_config":{"model_type":"qwen3_vl_text","vocab_size":151936,
+                "hidden_size":5120,"intermediate_size":25600,"num_hidden_layers":64,
+                "num_attention_heads":64,"num_key_value_heads":8,"head_dim":128,
+                "rms_norm_eps":0.000001,"rope_theta":5000000.0,
+                "max_position_embeddings":262144,"hidden_act":"silu","attention_bias":false,
+                "rope_scaling":{"rope_type":"default","mrope_interleaved":true,
+                  "mrope_section":[24,20,20]}},
+              "vision_config":{"model_type":"qwen3_vl","depth":27,"hidden_size":1152,
+                "intermediate_size":4304,"num_heads":16,"in_channels":3,"patch_size":16,
+                "temporal_patch_size":2,"spatial_merge_size":2,"out_hidden_size":5120,
+                "num_position_embeddings":2304,"deepstack_visual_indexes":[8,16,24],
+                "hidden_act":"gelu_pytorch_tanh"}
+            }"#
+        .to_string()
+    }
+
+    #[test]
+    fn released_config_has_exact_layer_50_charge() {
+        let config = H3ConditionerConfig::from_json(released_config().as_bytes()).unwrap();
+        assert_eq!(config.materialized_parameter_count(), 25_753_095_920);
+        assert_eq!(
+            config.materialized_parameter_count() * 2,
+            H3_BF16_PARAMETER_BYTES
+        );
+        assert_eq!(
+            H3_COMFY_SAFETENSORS_BYTES - H3_BF16_PARAMETER_BYTES,
+            103_416
+        );
+    }
+
+    #[test]
+    fn rejects_ordinary_qwen_variant_before_loading() {
+        let wrong = released_config().replace("\"hidden_size\":5120", "\"hidden_size\":4096");
+        let error = H3ConditionerConfig::from_json(wrong.as_bytes()).unwrap_err();
+        assert!(error.to_string().contains("text.hidden_size"));
+    }
+}

--- a/crates/mold-candle/src/minimax_h3/loader.rs
+++ b/crates/mold-candle/src/minimax_h3/loader.rs
@@ -1,0 +1,467 @@
+use candle::{DType, Device};
+use candle_nn::VarBuilder;
+use memmap2::MmapOptions;
+use safetensors::{Dtype as SafeDtype, SafeTensors};
+use serde::Deserialize;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::fs::File;
+use std::path::PathBuf;
+use std::sync::Arc;
+use thiserror::Error;
+use tokenizers::Tokenizer;
+
+use super::artifacts::{
+    canonical_checkpoint_name, expected_checkpoint_shapes, validate_checkpoint_keys_and_layout,
+    ArtifactError, ArtifactRole, CheckpointKeyReport, ConditionerArtifacts,
+    ConditionerWeightLayout,
+};
+use super::config::{
+    ConfigError, H3ConditionerConfig, H3_BF16_PARAMETER_BYTES, H3_FULL_CHECKPOINT_BYTES,
+};
+use super::model::H3Layer50Conditioner;
+use super::presentation::{
+    H3_IMAGE_PAD_TOKEN_ID, H3_VIDEO_PAD_TOKEN_ID, H3_VISION_END_TOKEN_ID, H3_VISION_START_TOKEN_ID,
+};
+
+#[derive(Debug, Error)]
+pub enum H3LoadError {
+    #[error(transparent)]
+    Artifact(#[from] ArtifactError),
+    #[error(transparent)]
+    Config(#[from] ConfigError),
+    #[error("failed to read MiniMax H3 asset {path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("malformed MiniMax H3 processor assets: {0}")]
+    Processor(String),
+    #[error("wrong MiniMax H3 tokenizer assets: {0}")]
+    Tokenizer(String),
+    #[error("invalid MiniMax H3 checkpoint: {0}")]
+    Checkpoint(String),
+    #[error("failed to construct MiniMax H3 Qwen3-VL tensors: {0}")]
+    Candle(#[from] candle::Error),
+}
+
+pub struct LoadedH3Conditioner {
+    pub model: H3Layer50Conditioner,
+    pub tokenizer: Arc<Tokenizer>,
+    pub key_report: CheckpointKeyReport,
+}
+
+#[derive(Clone)]
+pub struct PreparedH3ConditionerAssets {
+    artifacts: ConditionerArtifacts,
+    config: H3ConditionerConfig,
+    tokenizer: Arc<Tokenizer>,
+    key_report: CheckpointKeyReport,
+    checkpoint_file_bytes: u64,
+    weight_layout: ConditionerWeightLayout,
+}
+
+impl PreparedH3ConditionerAssets {
+    pub fn tokenizer(&self) -> &Arc<Tokenizer> {
+        &self.tokenizer
+    }
+
+    pub fn key_report(&self) -> &CheckpointKeyReport {
+        &self.key_report
+    }
+
+    pub fn checkpoint_file_bytes(&self) -> u64 {
+        self.checkpoint_file_bytes
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ProcessorConfig {
+    size: ProcessorSize,
+    patch_size: usize,
+    temporal_patch_size: usize,
+    merge_size: usize,
+    image_mean: [f64; 3],
+    image_std: [f64; 3],
+    processor_class: String,
+    #[serde(default)]
+    image_processor_type: Option<String>,
+    #[serde(default)]
+    video_processor_type: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ProcessorSize {
+    longest_edge: usize,
+    shortest_edge: usize,
+}
+
+pub fn validate_processor_assets(image: &[u8], video: &[u8]) -> Result<(), H3LoadError> {
+    let image: ProcessorConfig = serde_json::from_slice(image)
+        .map_err(|error| H3LoadError::Processor(format!("image config JSON: {error}")))?;
+    let video: ProcessorConfig = serde_json::from_slice(video)
+        .map_err(|error| H3LoadError::Processor(format!("video config JSON: {error}")))?;
+    validate_processor(
+        &image,
+        (65_536, 16_777_216),
+        Some("Qwen2VLImageProcessorFast"),
+        None,
+        "image",
+    )?;
+    validate_processor(
+        &video,
+        (4_096, 25_165_824),
+        None,
+        Some("Qwen3VLVideoProcessor"),
+        "video",
+    )
+}
+
+fn validate_processor(
+    config: &ProcessorConfig,
+    edges: (usize, usize),
+    image_type: Option<&str>,
+    video_type: Option<&str>,
+    label: &str,
+) -> Result<(), H3LoadError> {
+    let exact = config.patch_size == 16
+        && config.temporal_patch_size == 2
+        && config.merge_size == 2
+        && config.image_mean == [0.5; 3]
+        && config.image_std == [0.5; 3]
+        && config.processor_class == "Qwen3VLProcessor"
+        && config.size.shortest_edge == edges.0
+        && config.size.longest_edge == edges.1
+        && config.image_processor_type.as_deref() == image_type
+        && config.video_processor_type.as_deref() == video_type;
+    if !exact {
+        return Err(H3LoadError::Processor(format!(
+            "{label} config does not match the released patch-16/temporal-2/merge-2 Qwen3-VL processor: {config:?}"
+        )));
+    }
+    Ok(())
+}
+
+/// Verify all frozen identities and checkpoint headers before mmaping tensors.
+/// The function is unsafe for the same reason as Candle's safetensors mmap
+/// loader: callers must not mutate or truncate checkpoint files while the
+/// returned model is alive.
+///
+/// # Safety
+///
+/// Every checkpoint path must remain immutable and valid for the complete
+/// lifetime of the returned conditioner.
+pub unsafe fn load_bf16_conditioner(
+    artifacts: &ConditionerArtifacts,
+    device: &Device,
+) -> Result<LoadedH3Conditioner, H3LoadError> {
+    let prepared = prepare_conditioner_assets(artifacts)?;
+    // SAFETY: forwarded from this function's caller.
+    let model = unsafe { load_prepared_bf16_conditioner(&prepared, device)? };
+    Ok(LoadedH3Conditioner {
+        model,
+        tokenizer: Arc::clone(&prepared.tokenizer),
+        key_report: prepared.key_report.clone(),
+    })
+}
+
+/// Validate and retain the lightweight Qwen tokenizer and processor state,
+/// plus the frozen checkpoint contract, without allocating model tensors.
+pub fn prepare_conditioner_assets(
+    artifacts: &ConditionerArtifacts,
+) -> Result<PreparedH3ConditionerAssets, H3LoadError> {
+    artifacts.verify_all()?;
+    let config_bytes = read_role(artifacts, ArtifactRole::ArchitectureConfig)?;
+    let config = H3ConditionerConfig::from_json(&config_bytes)?;
+    let tokenizer_config = read_role(artifacts, ArtifactRole::TokenizerConfig)?;
+    validate_tokenizer_config(&tokenizer_config)?;
+    validate_processor_assets(
+        &read_role(artifacts, ArtifactRole::ProcessorConfig)?,
+        &read_role(artifacts, ArtifactRole::VideoProcessorConfig)?,
+    )?;
+
+    let tokenizer_artifact = artifacts
+        .get(&ArtifactRole::Tokenizer)
+        .ok_or(ArtifactError::MissingRole(ArtifactRole::Tokenizer))?;
+    let tokenizer = Tokenizer::from_file(&tokenizer_artifact.path)
+        .map(Arc::new)
+        .map_err(|error| H3LoadError::Tokenizer(error.to_string()))?;
+    validate_tokenizer(&tokenizer)?;
+
+    let checkpoint_paths = artifacts
+        .checkpoint_shards()
+        .map(|artifact| artifact.path.clone())
+        .collect::<Vec<_>>();
+    let (header_names, payload_bytes, key_report, weight_layout) =
+        validate_safetensors_headers(&checkpoint_paths, &config)?;
+    if !matches!(
+        payload_bytes,
+        H3_BF16_PARAMETER_BYTES | H3_FULL_CHECKPOINT_BYTES
+    ) {
+        return Err(H3LoadError::Checkpoint(format!(
+            "BF16 tensor payload is {payload_bytes} bytes, expected truncated {H3_BF16_PARAMETER_BYTES} or full {H3_FULL_CHECKPOINT_BYTES}"
+        )));
+    }
+    if let Some(index) = artifacts.get(&ArtifactRole::CheckpointIndex) {
+        validate_index(
+            &fs::read(&index.path).map_err(|source| H3LoadError::Io {
+                path: index.path.clone(),
+                source,
+            })?,
+            &header_names,
+            weight_layout,
+        )?;
+    }
+    let checkpoint_file_bytes =
+        artifacts
+            .checkpoint_shards()
+            .try_fold(0_u64, |total, artifact| {
+                total
+                    .checked_add(artifact.fingerprint.size_bytes)
+                    .ok_or_else(|| {
+                        H3LoadError::Checkpoint("checkpoint file byte count overflow".into())
+                    })
+            })?;
+    Ok(PreparedH3ConditionerAssets {
+        artifacts: artifacts.clone(),
+        config,
+        tokenizer,
+        key_report,
+        checkpoint_file_bytes,
+        weight_layout,
+    })
+}
+
+/// Rebuild only dropped tensor state while retaining prepared tokenizer and
+/// processor assets.
+///
+/// # Safety
+///
+/// Every checkpoint path must remain immutable and valid for the complete
+/// lifetime of the returned conditioner.
+pub unsafe fn load_prepared_bf16_conditioner(
+    prepared: &PreparedH3ConditionerAssets,
+    device: &Device,
+) -> Result<H3Layer50Conditioner, H3LoadError> {
+    prepared.artifacts.verify_all()?;
+    let checkpoint_paths = prepared
+        .artifacts
+        .checkpoint_shards()
+        .map(|artifact| artifact.path.clone())
+        .collect::<Vec<_>>();
+    let references = checkpoint_paths.iter().collect::<Vec<_>>();
+    // SAFETY: upheld by this function's caller; identities were rechecked
+    // immediately above, before constructing the mmap.
+    let builder = unsafe { VarBuilder::from_mmaped_safetensors(&references, DType::BF16, device)? };
+    H3Layer50Conditioner::new_with_weight_layout(&prepared.config, builder, prepared.weight_layout)
+        .map_err(Into::into)
+}
+
+fn read_role(artifacts: &ConditionerArtifacts, role: ArtifactRole) -> Result<Vec<u8>, H3LoadError> {
+    let artifact = artifacts
+        .get(&role)
+        .ok_or_else(|| ArtifactError::MissingRole(role.clone()))?;
+    fs::read(&artifact.path).map_err(|source| H3LoadError::Io {
+        path: artifact.path.clone(),
+        source,
+    })
+}
+
+fn validate_tokenizer_config(bytes: &[u8]) -> Result<(), H3LoadError> {
+    let value: serde_json::Value = serde_json::from_slice(bytes)
+        .map_err(|error| H3LoadError::Tokenizer(format!("tokenizer config JSON: {error}")))?;
+    let exact = value
+        .get("tokenizer_class")
+        .and_then(|value| value.as_str())
+        == Some("Qwen2Tokenizer")
+        && value.get("add_bos_token").and_then(|value| value.as_bool()) == Some(false)
+        && value
+            .get("bos_token")
+            .is_some_and(serde_json::Value::is_null)
+        && value
+            .get("model_max_length")
+            .and_then(|value| value.as_u64())
+            == Some(262_144)
+        && value.get("pad_token").and_then(|value| value.as_str()) == Some("<|endoftext|>")
+        && value.get("eos_token").and_then(|value| value.as_str()) == Some("<|im_end|>");
+    if !exact {
+        return Err(H3LoadError::Tokenizer(
+            "config is not the released raw Qwen2 tokenizer contract".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_tokenizer(tokenizer: &Tokenizer) -> Result<(), H3LoadError> {
+    if tokenizer.get_vocab_size(true) != 151_936 {
+        return Err(H3LoadError::Tokenizer(format!(
+            "vocabulary has {} entries, expected 151936",
+            tokenizer.get_vocab_size(true)
+        )));
+    }
+    for (token, expected) in [
+        ("<|vision_start|>", H3_VISION_START_TOKEN_ID),
+        ("<|vision_end|>", H3_VISION_END_TOKEN_ID),
+        ("<|image_pad|>", H3_IMAGE_PAD_TOKEN_ID),
+        ("<|video_pad|>", H3_VIDEO_PAD_TOKEN_ID),
+    ] {
+        let found = tokenizer.token_to_id(token);
+        if found != Some(expected) {
+            return Err(H3LoadError::Tokenizer(format!(
+                "{token} resolves to {found:?}, expected {expected}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_safetensors_headers(
+    paths: &[PathBuf],
+    config: &H3ConditionerConfig,
+) -> Result<
+    (
+        BTreeSet<String>,
+        u64,
+        CheckpointKeyReport,
+        ConditionerWeightLayout,
+    ),
+    H3LoadError,
+> {
+    let expected_shapes = expected_checkpoint_shapes(config);
+    let mut names = BTreeSet::new();
+    let mut shapes = Vec::new();
+    let mut payload_bytes = 0_u64;
+    for path in paths {
+        let file = File::open(path).map_err(|source| H3LoadError::Io {
+            path: path.clone(),
+            source,
+        })?;
+        // SAFETY: this temporary read-only map is dropped before returning;
+        // artifact fingerprints were checked by the caller.
+        let map = unsafe { MmapOptions::new().map(&file) }.map_err(|source| H3LoadError::Io {
+            path: path.clone(),
+            source,
+        })?;
+        let tensors = SafeTensors::deserialize(&map).map_err(|error| {
+            H3LoadError::Checkpoint(format!(
+                "{} has an invalid safetensors header: {error}",
+                path.display()
+            ))
+        })?;
+        for name in tensors.names() {
+            if !names.insert(name.to_string()) {
+                return Err(H3LoadError::Checkpoint(format!(
+                    "tensor {name} occurs in more than one shard"
+                )));
+            }
+            let tensor = tensors.tensor(name).map_err(|error| {
+                H3LoadError::Checkpoint(format!("cannot inspect tensor {name}: {error}"))
+            })?;
+            if tensor.dtype() != SafeDtype::BF16 {
+                return Err(H3LoadError::Checkpoint(format!(
+                    "tensor {name} has {:?}, expected BF16",
+                    tensor.dtype()
+                )));
+            }
+            shapes.push((name.to_string(), tensor.shape().to_vec()));
+            payload_bytes = payload_bytes
+                .checked_add(tensor.data().len() as u64)
+                .ok_or_else(|| H3LoadError::Checkpoint("tensor byte count overflow".into()))?;
+        }
+    }
+    let (key_report, weight_layout) = validate_checkpoint_keys_and_layout(names.iter().cloned())?;
+    for (raw_name, shape) in shapes {
+        let canonical_name = canonical_checkpoint_name(&raw_name, weight_layout);
+        if let Some(expected) = expected_shapes.get(&canonical_name) {
+            if &shape != expected {
+                return Err(H3LoadError::Checkpoint(format!(
+                    "tensor {raw_name} has shape {shape:?}, expected {expected:?}"
+                )));
+            }
+        } else if !canonical_name.ends_with("rotary_emb.inv_freq") {
+            return Err(H3LoadError::Checkpoint(format!(
+                "tensor {raw_name} has no H3 Qwen3-VL shape contract"
+            )));
+        }
+    }
+    Ok((names, payload_bytes, key_report, weight_layout))
+}
+
+#[derive(Deserialize)]
+struct CheckpointIndex {
+    metadata: CheckpointIndexMetadata,
+    weight_map: BTreeMap<String, String>,
+}
+
+#[derive(Deserialize)]
+struct CheckpointIndexMetadata {
+    total_size: u64,
+}
+
+fn validate_index(
+    bytes: &[u8],
+    header_names: &BTreeSet<String>,
+    header_layout: ConditionerWeightLayout,
+) -> Result<(), H3LoadError> {
+    let index: CheckpointIndex = serde_json::from_slice(bytes)
+        .map_err(|error| H3LoadError::Checkpoint(format!("checkpoint index JSON: {error}")))?;
+    let index_names = index.weight_map.keys().cloned().collect::<BTreeSet<_>>();
+    let (_, index_layout) = validate_checkpoint_keys_and_layout(index_names.iter().cloned())?;
+    if index_layout != header_layout {
+        return Err(H3LoadError::Checkpoint(
+            "checkpoint index and shard headers use different weight namespaces".into(),
+        ));
+    }
+    if &index_names != header_names {
+        return Err(H3LoadError::Checkpoint(format!(
+            "checkpoint index names do not match shard headers ({} versus {})",
+            index_names.len(),
+            header_names.len()
+        )));
+    }
+    if !matches!(
+        index.metadata.total_size,
+        H3_BF16_PARAMETER_BYTES | H3_FULL_CHECKPOINT_BYTES
+    ) {
+        return Err(H3LoadError::Checkpoint(format!(
+            "checkpoint index total_size is {}, expected truncated {} or full {}",
+            index.metadata.total_size, H3_BF16_PARAMETER_BYTES, H3_FULL_CHECKPOINT_BYTES
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const IMAGE: &str = r#"{
+      "size":{"shortest_edge":65536,"longest_edge":16777216},
+      "patch_size":16,"temporal_patch_size":2,"merge_size":2,
+      "image_mean":[0.5,0.5,0.5],"image_std":[0.5,0.5,0.5],
+      "processor_class":"Qwen3VLProcessor",
+      "image_processor_type":"Qwen2VLImageProcessorFast"
+    }"#;
+    const VIDEO: &str = r#"{
+      "size":{"shortest_edge":4096,"longest_edge":25165824},
+      "patch_size":16,"temporal_patch_size":2,"merge_size":2,
+      "image_mean":[0.5,0.5,0.5],"image_std":[0.5,0.5,0.5],
+      "processor_class":"Qwen3VLProcessor",
+      "video_processor_type":"Qwen3VLVideoProcessor"
+    }"#;
+
+    #[test]
+    fn exact_processor_assets_validate() {
+        validate_processor_assets(IMAGE.as_bytes(), VIDEO.as_bytes()).unwrap();
+    }
+
+    #[test]
+    fn malformed_or_wrong_processor_assets_fail_closed() {
+        let malformed = validate_processor_assets(b"{", VIDEO.as_bytes()).unwrap_err();
+        assert!(malformed.to_string().contains("image config JSON"));
+        let wrong = IMAGE.replace("\"patch_size\":16", "\"patch_size\":14");
+        let error = validate_processor_assets(wrong.as_bytes(), VIDEO.as_bytes()).unwrap_err();
+        assert!(error.to_string().contains("patch-16"));
+    }
+}

--- a/crates/mold-candle/src/minimax_h3/loader.rs
+++ b/crates/mold-candle/src/minimax_h3/loader.rs
@@ -1,11 +1,10 @@
 use candle::{DType, Device};
 use candle_nn::VarBuilder;
-use memmap2::MmapOptions;
-use safetensors::{Dtype as SafeDtype, SafeTensors};
 use serde::Deserialize;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::fs::File;
+use std::io::Read;
 use std::path::PathBuf;
 use std::sync::Arc;
 use thiserror::Error;
@@ -13,8 +12,8 @@ use tokenizers::Tokenizer;
 
 use super::artifacts::{
     canonical_checkpoint_name, expected_checkpoint_shapes, validate_checkpoint_keys_and_layout,
-    ArtifactError, ArtifactRole, CheckpointKeyReport, ConditionerArtifacts,
-    ConditionerWeightLayout,
+    ArtifactError, ArtifactRole, ArtifactVerificationProgress, CheckpointKeyReport,
+    ConditionerArtifacts, ConditionerWeightLayout, VerifiedArtifactMetadata,
 };
 use super::config::{
     ConfigError, H3ConditionerConfig, H3_BF16_PARAMETER_BYTES, H3_FULL_CHECKPOINT_BYTES,
@@ -55,6 +54,7 @@ pub struct LoadedH3Conditioner {
 #[derive(Clone)]
 pub struct PreparedH3ConditionerAssets {
     artifacts: ConditionerArtifacts,
+    verified_metadata: VerifiedArtifactMetadata,
     config: H3ConditionerConfig,
     tokenizer: Arc<Tokenizer>,
     key_report: CheckpointKeyReport,
@@ -171,7 +171,14 @@ pub unsafe fn load_bf16_conditioner(
 pub fn prepare_conditioner_assets(
     artifacts: &ConditionerArtifacts,
 ) -> Result<PreparedH3ConditionerAssets, H3LoadError> {
-    artifacts.verify_all()?;
+    prepare_conditioner_assets_with_progress(artifacts, &mut |_| Ok(()))
+}
+
+pub fn prepare_conditioner_assets_with_progress(
+    artifacts: &ConditionerArtifacts,
+    progress: &mut dyn FnMut(ArtifactVerificationProgress) -> Result<(), ArtifactError>,
+) -> Result<PreparedH3ConditionerAssets, H3LoadError> {
+    let verified_metadata = artifacts.verify_all_with_progress(progress)?;
     let config_bytes = read_role(artifacts, ArtifactRole::ArchitectureConfig)?;
     let config = H3ConditionerConfig::from_json(&config_bytes)?;
     let tokenizer_config = read_role(artifacts, ArtifactRole::TokenizerConfig)?;
@@ -184,47 +191,45 @@ pub fn prepare_conditioner_assets(
     let tokenizer_artifact = artifacts
         .get(&ArtifactRole::Tokenizer)
         .ok_or(ArtifactError::MissingRole(ArtifactRole::Tokenizer))?;
-    let tokenizer = Tokenizer::from_file(&tokenizer_artifact.path)
+    let tokenizer = Tokenizer::from_file(tokenizer_artifact.path())
         .map(Arc::new)
         .map_err(|error| H3LoadError::Tokenizer(error.to_string()))?;
     validate_tokenizer(&tokenizer)?;
 
     let checkpoint_paths = artifacts
         .checkpoint_shards()
-        .map(|artifact| artifact.path.clone())
+        .map(|artifact| artifact.path().to_path_buf())
         .collect::<Vec<_>>();
     let (header_names, payload_bytes, key_report, weight_layout) =
         validate_safetensors_headers(&checkpoint_paths, &config)?;
-    if !matches!(
-        payload_bytes,
-        H3_BF16_PARAMETER_BYTES | H3_FULL_CHECKPOINT_BYTES
-    ) {
-        return Err(H3LoadError::Checkpoint(format!(
-            "BF16 tensor payload is {payload_bytes} bytes, expected truncated {H3_BF16_PARAMETER_BYTES} or full {H3_FULL_CHECKPOINT_BYTES}"
-        )));
-    }
+    validate_layout_payload_bytes(weight_layout, payload_bytes, "BF16 tensor payload")?;
     if let Some(index) = artifacts.get(&ArtifactRole::CheckpointIndex) {
         validate_index(
-            &fs::read(&index.path).map_err(|source| H3LoadError::Io {
-                path: index.path.clone(),
+            &fs::read(index.path()).map_err(|source| H3LoadError::Io {
+                path: index.path().to_path_buf(),
                 source,
             })?,
             &header_names,
             weight_layout,
         )?;
     }
+    // Authentication precedes parsing, but a path can still be replaced while
+    // the small support files and bounded checkpoint headers are read. Close
+    // that window before the prepared authority is returned.
+    artifacts.verify_metadata(&verified_metadata)?;
     let checkpoint_file_bytes =
         artifacts
             .checkpoint_shards()
             .try_fold(0_u64, |total, artifact| {
                 total
-                    .checked_add(artifact.fingerprint.size_bytes)
+                    .checked_add(artifact.fingerprint().size_bytes)
                     .ok_or_else(|| {
                         H3LoadError::Checkpoint("checkpoint file byte count overflow".into())
                     })
             })?;
     Ok(PreparedH3ConditionerAssets {
         artifacts: artifacts.clone(),
+        verified_metadata,
         config,
         tokenizer,
         key_report,
@@ -244,11 +249,18 @@ pub unsafe fn load_prepared_bf16_conditioner(
     prepared: &PreparedH3ConditionerAssets,
     device: &Device,
 ) -> Result<H3Layer50Conditioner, H3LoadError> {
-    prepared.artifacts.verify_all()?;
+    // Content was authenticated once during preparation. Re-reading 51.5-66.7
+    // GB here would make every warm reload another full-volume hash pass. The
+    // cheap file identity check catches replacement/size/timestamp changes;
+    // the unsafe caller still owns the stronger immutable-file lifetime that
+    // Candle's mmap requires.
+    prepared
+        .artifacts
+        .verify_metadata(&prepared.verified_metadata)?;
     let checkpoint_paths = prepared
         .artifacts
         .checkpoint_shards()
-        .map(|artifact| artifact.path.clone())
+        .map(|artifact| artifact.path().to_path_buf())
         .collect::<Vec<_>>();
     let references = checkpoint_paths.iter().collect::<Vec<_>>();
     // SAFETY: upheld by this function's caller; identities were rechecked
@@ -262,10 +274,31 @@ fn read_role(artifacts: &ConditionerArtifacts, role: ArtifactRole) -> Result<Vec
     let artifact = artifacts
         .get(&role)
         .ok_or_else(|| ArtifactError::MissingRole(role.clone()))?;
-    fs::read(&artifact.path).map_err(|source| H3LoadError::Io {
-        path: artifact.path.clone(),
+    fs::read(artifact.path()).map_err(|source| H3LoadError::Io {
+        path: artifact.path().to_path_buf(),
         source,
     })
+}
+
+const fn expected_payload_bytes(layout: ConditionerWeightLayout) -> u64 {
+    match layout {
+        ConditionerWeightLayout::Official => H3_FULL_CHECKPOINT_BYTES,
+        ConditionerWeightLayout::ComfyLayer50 => H3_BF16_PARAMETER_BYTES,
+    }
+}
+
+fn validate_layout_payload_bytes(
+    layout: ConditionerWeightLayout,
+    found: u64,
+    label: &str,
+) -> Result<(), H3LoadError> {
+    let expected = expected_payload_bytes(layout);
+    if found != expected {
+        return Err(H3LoadError::Checkpoint(format!(
+            "{layout:?} {label} is {found} bytes, expected exactly {expected}"
+        )));
+    }
+    Ok(())
 }
 
 fn validate_tokenizer_config(bytes: &[u8]) -> Result<(), H3LoadError> {
@@ -333,41 +366,18 @@ fn validate_safetensors_headers(
     let mut shapes = Vec::new();
     let mut payload_bytes = 0_u64;
     for path in paths {
-        let file = File::open(path).map_err(|source| H3LoadError::Io {
-            path: path.clone(),
-            source,
-        })?;
-        // SAFETY: this temporary read-only map is dropped before returning;
-        // artifact fingerprints were checked by the caller.
-        let map = unsafe { MmapOptions::new().map(&file) }.map_err(|source| H3LoadError::Io {
-            path: path.clone(),
-            source,
-        })?;
-        let tensors = SafeTensors::deserialize(&map).map_err(|error| {
-            H3LoadError::Checkpoint(format!(
-                "{} has an invalid safetensors header: {error}",
-                path.display()
-            ))
-        })?;
-        for name in tensors.names() {
-            if !names.insert(name.to_string()) {
+        let inspected = inspect_safetensors_header(path)?;
+        payload_bytes = payload_bytes
+            .checked_add(inspected.payload_bytes)
+            .ok_or_else(|| H3LoadError::Checkpoint("tensor byte count overflow".into()))?;
+        for tensor in inspected.tensors {
+            if !names.insert(tensor.name.clone()) {
                 return Err(H3LoadError::Checkpoint(format!(
-                    "tensor {name} occurs in more than one shard"
+                    "tensor {} occurs in more than one shard",
+                    tensor.name
                 )));
             }
-            let tensor = tensors.tensor(name).map_err(|error| {
-                H3LoadError::Checkpoint(format!("cannot inspect tensor {name}: {error}"))
-            })?;
-            if tensor.dtype() != SafeDtype::BF16 {
-                return Err(H3LoadError::Checkpoint(format!(
-                    "tensor {name} has {:?}, expected BF16",
-                    tensor.dtype()
-                )));
-            }
-            shapes.push((name.to_string(), tensor.shape().to_vec()));
-            payload_bytes = payload_bytes
-                .checked_add(tensor.data().len() as u64)
-                .ok_or_else(|| H3LoadError::Checkpoint("tensor byte count overflow".into()))?;
+            shapes.push((tensor.name, tensor.shape));
         }
     }
     let (key_report, weight_layout) = validate_checkpoint_keys_and_layout(names.iter().cloned())?;
@@ -386,6 +396,170 @@ fn validate_safetensors_headers(
         }
     }
     Ok((names, payload_bytes, key_report, weight_layout))
+}
+
+const MAX_SAFETENSORS_HEADER_BYTES: usize = 100_000_000;
+
+#[derive(Debug)]
+struct InspectedSafetensors {
+    tensors: Vec<InspectedTensor>,
+    payload_bytes: u64,
+}
+
+#[derive(Debug)]
+struct InspectedTensor {
+    name: String,
+    shape: Vec<usize>,
+}
+
+/// Read only the bounded safetensors header. Using a temporary mmap in this
+/// safe preparation API would inherit memmap2's external-file-mutation UB even
+/// though no model tensor is being loaded yet.
+fn inspect_safetensors_header(path: &PathBuf) -> Result<InspectedSafetensors, H3LoadError> {
+    let mut file = File::open(path).map_err(|source| H3LoadError::Io {
+        path: path.clone(),
+        source,
+    })?;
+    let file_len = file
+        .metadata()
+        .map_err(|source| H3LoadError::Io {
+            path: path.clone(),
+            source,
+        })?
+        .len();
+    let mut header_len_bytes = [0_u8; 8];
+    file.read_exact(&mut header_len_bytes)
+        .map_err(|source| H3LoadError::Io {
+            path: path.clone(),
+            source,
+        })?;
+    let header_len = usize::try_from(u64::from_le_bytes(header_len_bytes)).map_err(|_| {
+        H3LoadError::Checkpoint(format!(
+            "{} safetensors header length overflows usize",
+            path.display()
+        ))
+    })?;
+    if header_len == 0 || header_len > MAX_SAFETENSORS_HEADER_BYTES {
+        return Err(H3LoadError::Checkpoint(format!(
+            "{} safetensors header length {header_len} is invalid",
+            path.display()
+        )));
+    }
+    let mut header = vec![0_u8; header_len];
+    file.read_exact(&mut header)
+        .map_err(|source| H3LoadError::Io {
+            path: path.clone(),
+            source,
+        })?;
+    let root: serde_json::Map<String, serde_json::Value> = serde_json::from_slice(&header)
+        .map_err(|error| {
+            H3LoadError::Checkpoint(format!(
+                "{} has an invalid safetensors JSON header: {error}",
+                path.display()
+            ))
+        })?;
+    let mut tensors = Vec::with_capacity(root.len());
+    let mut intervals = Vec::with_capacity(root.len());
+    for (name, value) in root {
+        if name == "__metadata__" {
+            let valid = value
+                .as_object()
+                .is_some_and(|metadata| metadata.values().all(serde_json::Value::is_string));
+            if !valid {
+                return Err(H3LoadError::Checkpoint(
+                    "safetensors __metadata__ must map strings to strings".into(),
+                ));
+            }
+            continue;
+        }
+        let object = value.as_object().ok_or_else(|| {
+            H3LoadError::Checkpoint(format!("tensor {name} header entry is not an object"))
+        })?;
+        let dtype = object
+            .get("dtype")
+            .and_then(serde_json::Value::as_str)
+            .ok_or_else(|| H3LoadError::Checkpoint(format!("tensor {name} has no dtype")))?
+            .to_string();
+        if dtype != "BF16" {
+            return Err(H3LoadError::Checkpoint(format!(
+                "tensor {name} has {dtype}, expected BF16"
+            )));
+        }
+        let shape = object
+            .get("shape")
+            .and_then(serde_json::Value::as_array)
+            .ok_or_else(|| H3LoadError::Checkpoint(format!("tensor {name} has no shape")))?
+            .iter()
+            .map(|dimension| {
+                dimension
+                    .as_u64()
+                    .and_then(|value| usize::try_from(value).ok())
+                    .ok_or_else(|| {
+                        H3LoadError::Checkpoint(format!(
+                            "tensor {name} has a non-usize shape dimension"
+                        ))
+                    })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let offsets = object
+            .get("data_offsets")
+            .and_then(serde_json::Value::as_array)
+            .filter(|offsets| offsets.len() == 2)
+            .ok_or_else(|| {
+                H3LoadError::Checkpoint(format!("tensor {name} has invalid data_offsets"))
+            })?;
+        let start = offsets[0].as_u64().ok_or_else(|| {
+            H3LoadError::Checkpoint(format!("tensor {name} has invalid start offset"))
+        })?;
+        let end = offsets[1].as_u64().ok_or_else(|| {
+            H3LoadError::Checkpoint(format!("tensor {name} has invalid end offset"))
+        })?;
+        if end < start {
+            return Err(H3LoadError::Checkpoint(format!(
+                "tensor {name} has descending data offsets [{start}, {end}]"
+            )));
+        }
+        let element_count = shape.iter().try_fold(1_u64, |count, dimension| {
+            count.checked_mul(*dimension as u64).ok_or_else(|| {
+                H3LoadError::Checkpoint(format!("tensor {name} element count overflows"))
+            })
+        })?;
+        let expected_bytes = element_count.checked_mul(2).ok_or_else(|| {
+            H3LoadError::Checkpoint(format!("tensor {name} byte count overflows"))
+        })?;
+        if end - start != expected_bytes {
+            return Err(H3LoadError::Checkpoint(format!(
+                "tensor {name} data span is {} bytes, expected {expected_bytes} for {dtype} {shape:?}",
+                end - start
+            )));
+        }
+        intervals.push((start, end, name.clone()));
+        tensors.push(InspectedTensor { name, shape });
+    }
+    intervals.sort_unstable_by_key(|(start, _, _)| *start);
+    let mut payload_bytes = 0_u64;
+    for (start, end, name) in intervals {
+        if start != payload_bytes {
+            return Err(H3LoadError::Checkpoint(format!(
+                "tensor {name} starts at {start}, expected contiguous offset {payload_bytes}"
+            )));
+        }
+        payload_bytes = end;
+    }
+    let expected_file_len = 8_u64
+        .checked_add(header_len as u64)
+        .and_then(|bytes| bytes.checked_add(payload_bytes))
+        .ok_or_else(|| H3LoadError::Checkpoint("safetensors file length overflows".into()))?;
+    if file_len != expected_file_len {
+        return Err(H3LoadError::Checkpoint(format!(
+            "{} is {file_len} bytes, but its header accounts for {expected_file_len}",
+            path.display()
+        )));
+    }
+    Ok(InspectedSafetensors {
+        tensors,
+        payload_bytes,
+    })
 }
 
 #[derive(Deserialize)]
@@ -420,21 +594,38 @@ fn validate_index(
             header_names.len()
         )));
     }
-    if !matches!(
+    validate_layout_payload_bytes(
+        header_layout,
         index.metadata.total_size,
-        H3_BF16_PARAMETER_BYTES | H3_FULL_CHECKPOINT_BYTES
-    ) {
-        return Err(H3LoadError::Checkpoint(format!(
-            "checkpoint index total_size is {}, expected truncated {} or full {}",
-            index.metadata.total_size, H3_BF16_PARAMETER_BYTES, H3_FULL_CHECKPOINT_BYTES
-        )));
-    }
+        "checkpoint index total_size",
+    )?;
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn test_path(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "mold-h3-loader-{label}-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ))
+    }
+
+    fn safetensors_fixture(label: &str, header: serde_json::Value, payload: &[u8]) -> PathBuf {
+        let path = test_path(label);
+        let mut header = serde_json::to_vec(&header).unwrap();
+        while header.len() % 8 != 0 {
+            header.push(b' ');
+        }
+        let mut file = (header.len() as u64).to_le_bytes().to_vec();
+        file.extend_from_slice(&header);
+        file.extend_from_slice(payload);
+        fs::write(&path, file).unwrap();
+        path
+    }
 
     const IMAGE: &str = r#"{
       "size":{"shortest_edge":65536,"longest_edge":16777216},
@@ -463,5 +654,73 @@ mod tests {
         let wrong = IMAGE.replace("\"patch_size\":16", "\"patch_size\":14");
         let error = validate_processor_assets(wrong.as_bytes(), VIDEO.as_bytes()).unwrap_err();
         assert!(error.to_string().contains("patch-16"));
+    }
+
+    #[test]
+    fn checkpoint_payload_size_is_bound_to_the_detected_layout() {
+        assert!(validate_layout_payload_bytes(
+            ConditionerWeightLayout::Official,
+            H3_FULL_CHECKPOINT_BYTES,
+            "payload"
+        )
+        .is_ok());
+        assert!(validate_layout_payload_bytes(
+            ConditionerWeightLayout::ComfyLayer50,
+            H3_BF16_PARAMETER_BYTES,
+            "payload"
+        )
+        .is_ok());
+
+        let official_truncated = validate_layout_payload_bytes(
+            ConditionerWeightLayout::Official,
+            H3_BF16_PARAMETER_BYTES,
+            "payload",
+        )
+        .unwrap_err();
+        assert!(official_truncated.to_string().contains("Official payload"));
+        let comfy_full = validate_layout_payload_bytes(
+            ConditionerWeightLayout::ComfyLayer50,
+            H3_FULL_CHECKPOINT_BYTES,
+            "payload",
+        )
+        .unwrap_err();
+        assert!(comfy_full.to_string().contains("ComfyLayer50 payload"));
+    }
+
+    #[test]
+    fn bounded_header_reader_validates_dtype_offsets_and_file_length() {
+        let valid_path = safetensors_fixture(
+            "valid-header",
+            serde_json::json!({
+                "weight": {"dtype": "BF16", "shape": [2], "data_offsets": [0, 4]}
+            }),
+            &[0; 4],
+        );
+        let inspected = inspect_safetensors_header(&valid_path).unwrap();
+        assert_eq!(inspected.payload_bytes, 4);
+        assert_eq!(inspected.tensors[0].shape, [2]);
+        let _ = fs::remove_file(valid_path);
+
+        let wrong_dtype_path = safetensors_fixture(
+            "wrong-dtype",
+            serde_json::json!({
+                "weight": {"dtype": "F16", "shape": [2], "data_offsets": [0, 4]}
+            }),
+            &[0; 4],
+        );
+        let error = inspect_safetensors_header(&wrong_dtype_path).unwrap_err();
+        assert!(error.to_string().contains("F16, expected BF16"));
+        let _ = fs::remove_file(wrong_dtype_path);
+
+        let gap_path = safetensors_fixture(
+            "offset-gap",
+            serde_json::json!({
+                "weight": {"dtype": "BF16", "shape": [2], "data_offsets": [2, 6]}
+            }),
+            &[0; 6],
+        );
+        let error = inspect_safetensors_header(&gap_path).unwrap_err();
+        assert!(error.to_string().contains("expected contiguous offset 0"));
+        let _ = fs::remove_file(gap_path);
     }
 }

--- a/crates/mold-candle/src/minimax_h3/loader.rs
+++ b/crates/mold-candle/src/minimax_h3/loader.rs
@@ -617,7 +617,7 @@ mod tests {
     fn safetensors_fixture(label: &str, header: serde_json::Value, payload: &[u8]) -> PathBuf {
         let path = test_path(label);
         let mut header = serde_json::to_vec(&header).unwrap();
-        while header.len() % 8 != 0 {
+        while !header.len().is_multiple_of(8) {
             header.push(b' ');
         }
         let mut file = (header.len() as u64).to_le_bytes().to_vec();

--- a/crates/mold-candle/src/minimax_h3/mod.rs
+++ b/crates/mold-candle/src/minimax_h3/mod.rs
@@ -30,8 +30,8 @@ pub use audio_weights::{
 };
 
 pub use artifacts::{
-    validate_checkpoint_keys, ArtifactFingerprint, ArtifactRole, CheckpointKeyReport,
-    ConditionerArtifacts, FrozenArtifact,
+    validate_checkpoint_keys, ArtifactError, ArtifactFingerprint, ArtifactRole,
+    ArtifactVerificationProgress, CheckpointKeyReport, ConditionerArtifacts, FrozenArtifact,
 };
 pub use config::{
     H3ConditionerConfig, H3TextConfig, H3VisionConfig, H3_BF16_PARAMETER_BYTES,
@@ -40,7 +40,8 @@ pub use config::{
 };
 pub use loader::{
     load_bf16_conditioner, load_prepared_bf16_conditioner, prepare_conditioner_assets,
-    validate_processor_assets, H3LoadError, LoadedH3Conditioner, PreparedH3ConditionerAssets,
+    prepare_conditioner_assets_with_progress, validate_processor_assets, H3LoadError,
+    LoadedH3Conditioner, PreparedH3ConditionerAssets,
 };
 pub use model::{
     ConditionerCheckpoint, H3ConditionerInput, H3DTypeProfile, H3Layer50Conditioner, H3VisionInput,

--- a/crates/mold-candle/src/minimax_h3/mod.rs
+++ b/crates/mold-candle/src/minimax_h3/mod.rs
@@ -1,8 +1,17 @@
-//! Weight-free MiniMax H3 model primitives.
+//! Reusable MiniMax H3 model primitives.
 //!
 //! Nothing in this module registers a runnable inference engine. The H3
 //! license gate and the family capability contract remain the authority for
 //! whether callers may construct these primitives with real weights.
+
+mod artifacts;
+mod config;
+mod loader;
+mod model;
+mod presentation;
+mod processor;
+mod text;
+mod vision;
 
 pub mod audio;
 pub mod audio_config;
@@ -18,4 +27,29 @@ pub use audio_config::{
 };
 pub use audio_weights::{
     load_validated_audio_vae, validate_audio_safetensors, AudioTensorLayout, AudioTensorSpec,
+};
+
+pub use artifacts::{
+    validate_checkpoint_keys, ArtifactFingerprint, ArtifactRole, CheckpointKeyReport,
+    ConditionerArtifacts, FrozenArtifact,
+};
+pub use config::{
+    H3ConditionerConfig, H3TextConfig, H3VisionConfig, H3_BF16_PARAMETER_BYTES,
+    H3_COMFY_SAFETENSORS_BYTES, H3_FULL_CHECKPOINT_BYTES, H3_FULL_LANGUAGE_LAYERS,
+    H3_SELECTED_LANGUAGE_LAYERS,
+};
+pub use loader::{
+    load_bf16_conditioner, load_prepared_bf16_conditioner, prepare_conditioner_assets,
+    validate_processor_assets, H3LoadError, LoadedH3Conditioner, PreparedH3ConditionerAssets,
+};
+pub use model::{
+    ConditionerCheckpoint, H3ConditionerInput, H3DTypeProfile, H3Layer50Conditioner, H3VisionInput,
+};
+pub use presentation::{
+    build_fl2va_presentation, build_ref2va_presentation, build_text_presentation, H3ModalityTag,
+    H3Presentation, RefPresentation, RefPresentationKind,
+};
+pub use processor::{
+    create_mm_token_type_ids, pack_qwen_vision_u8, qwen_mrope_positions, sample_video_frames,
+    GridThw, PackedVisionPatches, QwenMmTokenType, SampledVideo,
 };

--- a/crates/mold-candle/src/minimax_h3/model.rs
+++ b/crates/mold-candle/src/minimax_h3/model.rs
@@ -1,0 +1,381 @@
+use candle::{DType, Result, Tensor};
+use candle_nn::VarBuilder;
+
+use super::artifacts::ConditionerWeightLayout;
+use super::config::{H3ConditionerConfig, H3_SELECTED_LANGUAGE_LAYERS};
+use super::text::{Qwen3VlTextDimensions, Qwen3VlTextEncoder};
+use super::vision::{Qwen3VlVisionDimensions, Qwen3VlVisionModel};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ConditionerCheckpoint {
+    TokenEmbedding,
+    VisionPatchEmbedding,
+    VisionLayer { completed: usize, total: usize },
+    LanguageLayer { completed: usize, total: usize },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct H3DTypeProfile {
+    pub parameter_dtype: DType,
+    pub vision_input_dtype: DType,
+    pub rotary_compute_dtype: DType,
+    pub vision_attention_dtype: DType,
+    pub language_attention_dtype: DType,
+    pub attention_softmax_dtype: DType,
+    pub output_dtype: DType,
+}
+
+#[derive(Clone, Debug)]
+pub struct H3VisionInput {
+    /// Flattened Qwen processor patches, `(patches, C*T*P*P)`.
+    pub pixel_values: Tensor,
+    /// One `(temporal, height, width)` row per image or video.
+    pub grid_thw: Tensor,
+}
+
+#[derive(Clone, Debug)]
+pub struct H3ConditionerInput {
+    pub input_ids: Tensor,
+    /// Qwen three-axis positions, `(3, batch, sequence)`.
+    pub position_ids: Tensor,
+    pub image: Option<H3VisionInput>,
+    pub video: Option<H3VisionInput>,
+}
+
+/// The exact Qwen3-VL feature extractor consumed by H3. Construction requests
+/// only decoder layers 0-49 and never asks the VarBuilder for a final norm or
+/// LM head.
+pub struct H3Layer50Conditioner {
+    text: Qwen3VlTextEncoder,
+    vision: Qwen3VlVisionModel,
+    dtype_profile: H3DTypeProfile,
+}
+
+impl H3Layer50Conditioner {
+    pub fn new(config: &H3ConditionerConfig, vb: VarBuilder) -> Result<Self> {
+        Self::new_with_weight_layout(config, vb, ConditionerWeightLayout::Official)
+    }
+
+    pub(super) fn new_with_weight_layout(
+        config: &H3ConditionerConfig,
+        vb: VarBuilder,
+        weight_layout: ConditionerWeightLayout,
+    ) -> Result<Self> {
+        config
+            .validate()
+            .map_err(|error| candle::Error::Msg(error.to_string()))?;
+        let vision_dimensions = Qwen3VlVisionDimensions::from_h3(config);
+        let text_dimensions = Qwen3VlTextDimensions::from_h3(config);
+        let (vision_vb, text_vb) = match weight_layout {
+            ConditionerWeightLayout::Official => (
+                vb.pp("model").pp("visual"),
+                vb.pp("model").pp("language_model"),
+            ),
+            ConditionerWeightLayout::ComfyLayer50 => (vb.pp("visual"), vb.pp("model")),
+        };
+        let vision = Qwen3VlVisionModel::new(&vision_dimensions, vision_vb)?;
+        let text = Qwen3VlTextEncoder::new(&text_dimensions, text_vb)?;
+        let parameter_dtype = vb.dtype();
+        Ok(Self {
+            text,
+            vision,
+            dtype_profile: H3DTypeProfile {
+                parameter_dtype,
+                vision_input_dtype: DType::F32,
+                rotary_compute_dtype: DType::F32,
+                vision_attention_dtype: parameter_dtype,
+                language_attention_dtype: parameter_dtype,
+                attention_softmax_dtype: DType::F32,
+                output_dtype: parameter_dtype,
+            },
+        })
+    }
+
+    pub fn dtype_profile(&self) -> H3DTypeProfile {
+        self.dtype_profile
+    }
+
+    pub fn resident_language_layers(&self) -> usize {
+        self.text.layer_count()
+    }
+
+    pub fn encode(
+        &self,
+        input: &H3ConditionerInput,
+        checkpoint: &mut dyn FnMut(ConditionerCheckpoint) -> Result<()>,
+    ) -> Result<Tensor> {
+        let (input_batch, input_sequence) = input.input_ids.dims2()?;
+        if input_batch != 1 {
+            candle::bail!(
+                "H3 conditioner accepts one packed presentation, got batch {input_batch}"
+            );
+        }
+        if input_sequence == 0 {
+            candle::bail!(
+                "the raw H3 presentation tokenized to an empty sequence; no special token is inserted"
+            );
+        }
+        checkpoint(ConditionerCheckpoint::TokenEmbedding)?;
+        let mut embeddings = self.text.embed_tokens(&input.input_ids)?;
+        let (batch, sequence, hidden) = embeddings.dims3()?;
+        if input.position_ids.dims() != [3, batch, sequence] {
+            candle::bail!(
+                "H3 Qwen position ids have shape {:?}, expected ({}, {}, {})",
+                input.position_ids.dims(),
+                3,
+                batch,
+                sequence
+            );
+        }
+
+        let mut image_deepstack = None;
+        let mut video_deepstack = None;
+        let mut image_indices = Vec::new();
+        let mut video_indices = Vec::new();
+
+        if let Some(image) = &input.image {
+            let (features, deepstack) =
+                self.vision
+                    .forward(&image.pixel_values, &image.grid_thw, checkpoint)?;
+            image_indices = matching_token_indices(&input.input_ids, 151_655)?;
+            embeddings = replace_rows(
+                &embeddings,
+                &image_indices,
+                &features
+                    .to_device(embeddings.device())?
+                    .to_dtype(embeddings.dtype())?,
+                hidden,
+            )?;
+            image_deepstack = Some(deepstack);
+        }
+        if let Some(video) = &input.video {
+            let (features, deepstack) =
+                self.vision
+                    .forward(&video.pixel_values, &video.grid_thw, checkpoint)?;
+            video_indices = matching_token_indices(&input.input_ids, 151_656)?;
+            embeddings = replace_rows(
+                &embeddings,
+                &video_indices,
+                &features
+                    .to_device(embeddings.device())?
+                    .to_dtype(embeddings.dtype())?,
+                hidden,
+            )?;
+            video_deepstack = Some(deepstack);
+        }
+
+        if input.image.is_none() && !matching_token_indices(&input.input_ids, 151_655)?.is_empty() {
+            candle::bail!("H3 presentation contains image pads without image processor tensors");
+        }
+        if input.video.is_none() && !matching_token_indices(&input.input_ids, 151_656)?.is_empty() {
+            candle::bail!("H3 presentation contains video pads without video processor tensors");
+        }
+
+        let (visual_indices, deepstack) = merge_deepstack(
+            embeddings.device(),
+            embeddings.dtype(),
+            image_indices,
+            image_deepstack,
+            video_indices,
+            video_deepstack,
+        )?;
+        self.text.forward_embeds(
+            embeddings,
+            &input.position_ids,
+            &visual_indices,
+            deepstack.as_deref(),
+            checkpoint,
+        )
+    }
+}
+
+fn matching_token_indices(input_ids: &Tensor, token_id: u32) -> Result<Vec<usize>> {
+    let (batch, sequence) = input_ids.dims2()?;
+    if batch != 1 {
+        candle::bail!("H3 conditioner accepts one packed presentation, got batch {batch}");
+    }
+    Ok(input_ids
+        .to_device(&candle::Device::Cpu)?
+        .to_dtype(DType::U32)?
+        .to_vec2::<u32>()?
+        .into_iter()
+        .next()
+        .unwrap_or_default()
+        .into_iter()
+        .take(sequence)
+        .enumerate()
+        .filter_map(|(index, id)| (id == token_id).then_some(index))
+        .collect())
+}
+
+fn replace_rows(
+    embeddings: &Tensor,
+    indices: &[usize],
+    features: &Tensor,
+    hidden: usize,
+) -> Result<Tensor> {
+    if features.dims() != [indices.len(), hidden] {
+        candle::bail!(
+            "H3 vision features have shape {:?}, expected ({}, {}) for the presentation pads",
+            features.dims(),
+            indices.len(),
+            hidden
+        );
+    }
+    let mut result = embeddings.clone();
+    for (feature_index, &sequence_index) in indices.iter().enumerate() {
+        result = result.slice_assign(
+            &[0..1, sequence_index..sequence_index + 1, 0..hidden],
+            &features.narrow(0, feature_index, 1)?.unsqueeze(0)?,
+        )?;
+    }
+    Ok(result)
+}
+
+#[allow(clippy::type_complexity)]
+fn merge_deepstack(
+    device: &candle::Device,
+    dtype: DType,
+    image_indices: Vec<usize>,
+    image: Option<Vec<Tensor>>,
+    video_indices: Vec<usize>,
+    video: Option<Vec<Tensor>>,
+) -> Result<(Vec<usize>, Option<Vec<Tensor>>)> {
+    let mut indexed_modalities = image_indices
+        .into_iter()
+        .map(|index| (index, true))
+        .chain(video_indices.into_iter().map(|index| (index, false)))
+        .collect::<Vec<_>>();
+    indexed_modalities.sort_unstable_by_key(|(index, _)| *index);
+    let visual_indices = indexed_modalities
+        .iter()
+        .map(|(index, _)| *index)
+        .collect::<Vec<_>>();
+    let layer_count = match (&image, &video) {
+        (Some(image), Some(video)) if image.len() != video.len() => {
+            candle::bail!(
+                "H3 image/video DeepStack layer counts differ: {} and {}",
+                image.len(),
+                video.len()
+            );
+        }
+        (Some(image), _) => image.len(),
+        (_, Some(video)) => video.len(),
+        _ => return Ok((visual_indices, None)),
+    };
+    let mut image_offset;
+    let mut video_offset;
+    let mut merged = Vec::with_capacity(layer_count);
+    for layer in 0..layer_count {
+        image_offset = 0;
+        video_offset = 0;
+        let mut rows = Vec::with_capacity(indexed_modalities.len());
+        for (_, is_image) in &indexed_modalities {
+            let row = if *is_image {
+                let tensor = image.as_ref().expect("an image index has image features");
+                let row = tensor[layer].narrow(0, image_offset, 1)?;
+                image_offset += 1;
+                row
+            } else {
+                let tensor = video.as_ref().expect("a video index has video features");
+                let row = tensor[layer].narrow(0, video_offset, 1)?;
+                video_offset += 1;
+                row
+            };
+            rows.push(row.to_device(device)?.to_dtype(dtype)?);
+        }
+        let refs = rows.iter().collect::<Vec<_>>();
+        merged.push(Tensor::cat(&refs, 0)?);
+    }
+    Ok((visual_indices, Some(merged)))
+}
+
+#[cfg(test)]
+impl H3Layer50Conditioner {
+    pub(super) fn new_tiny(
+        text_dimensions: &Qwen3VlTextDimensions,
+        vision_dimensions: &Qwen3VlVisionDimensions,
+        vb: VarBuilder,
+    ) -> Result<Self> {
+        Self::new_tiny_with_weight_layout(
+            text_dimensions,
+            vision_dimensions,
+            vb,
+            ConditionerWeightLayout::Official,
+        )
+    }
+
+    pub(super) fn new_tiny_with_weight_layout(
+        text_dimensions: &Qwen3VlTextDimensions,
+        vision_dimensions: &Qwen3VlVisionDimensions,
+        vb: VarBuilder,
+        weight_layout: ConditionerWeightLayout,
+    ) -> Result<Self> {
+        let (vision_vb, text_vb) = match weight_layout {
+            ConditionerWeightLayout::Official => (
+                vb.pp("model").pp("visual"),
+                vb.pp("model").pp("language_model"),
+            ),
+            ConditionerWeightLayout::ComfyLayer50 => (vb.pp("visual"), vb.pp("model")),
+        };
+        let text = Qwen3VlTextEncoder::new(text_dimensions, text_vb)?;
+        let vision = Qwen3VlVisionModel::new(vision_dimensions, vision_vb)?;
+        Ok(Self {
+            text,
+            vision,
+            dtype_profile: H3DTypeProfile {
+                parameter_dtype: vb.dtype(),
+                vision_input_dtype: DType::F32,
+                rotary_compute_dtype: DType::F32,
+                vision_attention_dtype: vb.dtype(),
+                language_attention_dtype: vb.dtype(),
+                attention_softmax_dtype: DType::F32,
+                output_dtype: vb.dtype(),
+            },
+        })
+    }
+}
+
+const _: () = assert!(H3_SELECTED_LANGUAGE_LAYERS == 50);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candle::Device;
+    use candle_nn::VarMap;
+
+    #[test]
+    fn tiny_combined_conditioner_constructs_only_requested_layers() {
+        let variables = VarMap::new();
+        let builder = VarBuilder::from_varmap(&variables, DType::F32, &Device::Cpu);
+        let conditioner = H3Layer50Conditioner::new_tiny(
+            &Qwen3VlTextDimensions::tiny(),
+            &Qwen3VlVisionDimensions::tiny(),
+            builder,
+        )
+        .unwrap();
+        assert_eq!(conditioner.resident_language_layers(), 3);
+        let keys = variables.data().lock().unwrap();
+        assert!(!keys.contains_key("model.language_model.norm.weight"));
+        assert!(!keys.contains_key("lm_head.weight"));
+    }
+
+    #[test]
+    fn tiny_comfy_layout_requests_only_pruned_namespace_keys() {
+        let variables = VarMap::new();
+        let builder = VarBuilder::from_varmap(&variables, DType::F32, &Device::Cpu);
+        H3Layer50Conditioner::new_tiny_with_weight_layout(
+            &Qwen3VlTextDimensions::tiny(),
+            &Qwen3VlVisionDimensions::tiny(),
+            builder,
+            ConditionerWeightLayout::ComfyLayer50,
+        )
+        .unwrap();
+        let keys = variables.data().lock().unwrap();
+        assert!(keys.contains_key("model.layers.0.self_attn.q_proj.weight"));
+        assert!(keys.contains_key("visual.deepstack_merger_list.0.norm.weight"));
+        assert!(!keys.keys().any(
+            |key| key.starts_with("model.language_model.") || key.starts_with("model.visual.")
+        ));
+    }
+}

--- a/crates/mold-candle/src/minimax_h3/presentation.rs
+++ b/crates/mold-candle/src/minimax_h3/presentation.rs
@@ -1,0 +1,373 @@
+use thiserror::Error;
+use tokenizers::Tokenizer;
+
+use super::processor::{create_mm_token_type_ids, QwenMmTokenType};
+
+pub const H3_IMAGE_PAD_TOKEN_ID: u32 = 151_655;
+pub const H3_VIDEO_PAD_TOKEN_ID: u32 = 151_656;
+pub const H3_VISION_START_TOKEN_ID: u32 = 151_652;
+pub const H3_VISION_END_TOKEN_ID: u32 = 151_653;
+
+/// MiniMax H3 transformer's row tag. This is intentionally a different type
+/// from Qwen's internal text/image/video token discriminator.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u8)]
+pub enum H3ModalityTag {
+    Vision = 0,
+    Text = 1,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct H3Presentation {
+    pub token_ids: Vec<u32>,
+    pub h3_tags: Vec<H3ModalityTag>,
+    pub qwen_mm_types: Vec<QwenMmTokenType>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct RefPresentation {
+    pub kind: RefPresentationKind,
+    /// A pure audio reference and a visual reference carrying a soundtrack
+    /// both emit an audio label before any visual label.
+    pub has_audio: bool,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum RefPresentationKind {
+    Audio,
+    Image { vision_tokens: usize },
+    Video { blocks: Vec<VideoPresentationBlock> },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct VideoPresentationBlock {
+    pub timestamp_seconds: f64,
+    pub vision_tokens: usize,
+}
+
+#[derive(Debug, Error, PartialEq)]
+pub enum PresentationError {
+    #[error("MiniMax H3 raw tokenization failed: {0}")]
+    Tokenizer(String),
+    #[error("MiniMax H3 processor token {token} resolved to {found:?}, expected {expected}")]
+    SpecialToken {
+        token: &'static str,
+        found: Option<u32>,
+        expected: u32,
+    },
+    #[error("MiniMax H3 presentation has {actual} tokens, exceeding the {maximum}-token conditioner context")]
+    ExcessContext { actual: usize, maximum: usize },
+    #[error("unsupported MiniMax H3 reference presentation: {0}")]
+    UnsupportedReference(String),
+}
+
+pub trait H3RawTokenizer {
+    fn encode_raw(&self, text: &str) -> Result<Vec<u32>, PresentationError>;
+    fn token_id(&self, token: &str) -> Option<u32>;
+}
+
+impl H3RawTokenizer for Tokenizer {
+    fn encode_raw(&self, text: &str) -> Result<Vec<u32>, PresentationError> {
+        self.encode(text, false)
+            .map(|encoding| encoding.get_ids().to_vec())
+            .map_err(|error| PresentationError::Tokenizer(error.to_string()))
+    }
+
+    fn token_id(&self, token: &str) -> Option<u32> {
+        self.token_to_id(token)
+    }
+}
+
+pub fn build_text_presentation(
+    tokenizer: &impl H3RawTokenizer,
+    prompt: &str,
+    maximum_tokens: usize,
+) -> Result<H3Presentation, PresentationError> {
+    let mut builder = PresentationBuilder::new(tokenizer, maximum_tokens)?;
+    builder.text(prompt)?;
+    builder.finish()
+}
+
+pub fn build_fl2va_presentation(
+    tokenizer: &impl H3RawTokenizer,
+    prompt: &str,
+    keyframe_vision_tokens: &[usize],
+    maximum_tokens: usize,
+) -> Result<H3Presentation, PresentationError> {
+    let mut builder = PresentationBuilder::new(tokenizer, maximum_tokens)?;
+    for (index, &vision_tokens) in keyframe_vision_tokens.iter().enumerate() {
+        if vision_tokens == 0 {
+            return Err(PresentationError::UnsupportedReference(format!(
+                "Picture {} has no merged vision tokens",
+                index + 1
+            )));
+        }
+        builder.text(&format!("<Picture {}>: ", index + 1))?;
+        builder.vision(H3_IMAGE_PAD_TOKEN_ID, vision_tokens);
+    }
+    builder.text(prompt)?;
+    builder.finish()
+}
+
+pub fn build_ref2va_presentation(
+    tokenizer: &impl H3RawTokenizer,
+    prompt: &str,
+    references: &[RefPresentation],
+    maximum_tokens: usize,
+) -> Result<H3Presentation, PresentationError> {
+    let mut builder = PresentationBuilder::new(tokenizer, maximum_tokens)?;
+    let (mut picture, mut video, mut audio) = (0, 0, 0);
+    for reference in references {
+        if reference.has_audio {
+            audio += 1;
+            builder.text(&format!("<Audio {audio}>: "))?;
+        }
+        match &reference.kind {
+            RefPresentationKind::Audio => {
+                if !reference.has_audio {
+                    return Err(PresentationError::UnsupportedReference(
+                        "an audio reference must set has_audio".into(),
+                    ));
+                }
+            }
+            RefPresentationKind::Image { vision_tokens } => {
+                if *vision_tokens == 0 {
+                    return Err(PresentationError::UnsupportedReference(
+                        "an image reference has no merged vision tokens".into(),
+                    ));
+                }
+                picture += 1;
+                builder.text(&format!("<Picture {picture}>: "))?;
+                builder.vision(H3_IMAGE_PAD_TOKEN_ID, *vision_tokens);
+            }
+            RefPresentationKind::Video { blocks } => {
+                if blocks.is_empty() {
+                    return Err(PresentationError::UnsupportedReference(
+                        "a video reference has no temporal vision blocks".into(),
+                    ));
+                }
+                video += 1;
+                builder.text(&format!("<Video {video}>: "))?;
+                for block in blocks {
+                    if !block.timestamp_seconds.is_finite() || block.timestamp_seconds < 0.0 {
+                        return Err(PresentationError::UnsupportedReference(
+                            "a video block timestamp is not finite and non-negative".into(),
+                        ));
+                    }
+                    if block.vision_tokens == 0 {
+                        return Err(PresentationError::UnsupportedReference(
+                            "a video block has no merged vision tokens".into(),
+                        ));
+                    }
+                    builder.text(&format!("<{:.1} seconds>", block.timestamp_seconds))?;
+                    builder.vision(H3_VIDEO_PAD_TOKEN_ID, block.vision_tokens);
+                }
+            }
+        }
+    }
+    builder.text(prompt)?;
+    builder.finish()
+}
+
+struct PresentationBuilder<'a, T> {
+    tokenizer: &'a T,
+    maximum_tokens: usize,
+    token_ids: Vec<u32>,
+    h3_tags: Vec<H3ModalityTag>,
+}
+
+impl<'a, T: H3RawTokenizer> PresentationBuilder<'a, T> {
+    fn new(tokenizer: &'a T, maximum_tokens: usize) -> Result<Self, PresentationError> {
+        for (token, expected) in [
+            ("<|vision_start|>", H3_VISION_START_TOKEN_ID),
+            ("<|vision_end|>", H3_VISION_END_TOKEN_ID),
+            ("<|image_pad|>", H3_IMAGE_PAD_TOKEN_ID),
+            ("<|video_pad|>", H3_VIDEO_PAD_TOKEN_ID),
+        ] {
+            let found = tokenizer.token_id(token);
+            if found != Some(expected) {
+                return Err(PresentationError::SpecialToken {
+                    token,
+                    found,
+                    expected,
+                });
+            }
+        }
+        Ok(Self {
+            tokenizer,
+            maximum_tokens,
+            token_ids: Vec::new(),
+            h3_tags: Vec::new(),
+        })
+    }
+
+    fn text(&mut self, text: &str) -> Result<(), PresentationError> {
+        let ids = self.tokenizer.encode_raw(text)?;
+        self.h3_tags
+            .extend(std::iter::repeat_n(H3ModalityTag::Text, ids.len()));
+        self.token_ids.extend(ids);
+        Ok(())
+    }
+
+    fn vision(&mut self, pad_token: u32, count: usize) {
+        self.token_ids.push(H3_VISION_START_TOKEN_ID);
+        self.token_ids.extend(std::iter::repeat_n(pad_token, count));
+        self.token_ids.push(H3_VISION_END_TOKEN_ID);
+        self.h3_tags
+            .extend(std::iter::repeat_n(H3ModalityTag::Vision, count + 2));
+    }
+
+    fn finish(self) -> Result<H3Presentation, PresentationError> {
+        if self.token_ids.len() > self.maximum_tokens {
+            return Err(PresentationError::ExcessContext {
+                actual: self.token_ids.len(),
+                maximum: self.maximum_tokens,
+            });
+        }
+        let qwen_mm_types = create_mm_token_type_ids(&self.token_ids);
+        debug_assert_eq!(self.token_ids.len(), self.h3_tags.len());
+        Ok(H3Presentation {
+            token_ids: self.token_ids,
+            h3_tags: self.h3_tags,
+            qwen_mm_types,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    struct RecordingTokenizer {
+        pieces: BTreeMap<String, u32>,
+    }
+
+    impl RecordingTokenizer {
+        fn new() -> Self {
+            Self {
+                pieces: BTreeMap::from([
+                    ("<|vision_start|>".into(), H3_VISION_START_TOKEN_ID),
+                    ("<|vision_end|>".into(), H3_VISION_END_TOKEN_ID),
+                    ("<|image_pad|>".into(), H3_IMAGE_PAD_TOKEN_ID),
+                    ("<|video_pad|>".into(), H3_VIDEO_PAD_TOKEN_ID),
+                ]),
+            }
+        }
+    }
+
+    impl H3RawTokenizer for RecordingTokenizer {
+        fn encode_raw(&self, text: &str) -> Result<Vec<u32>, PresentationError> {
+            // A stable one-token recording of each exact raw segment is enough
+            // to prove ordering without teaching the test a second BPE.
+            if text.is_empty() {
+                return Ok(Vec::new());
+            }
+            Ok(vec![text.bytes().fold(1_u32, |hash, byte| {
+                hash.wrapping_mul(16_777_619).wrapping_add(u32::from(byte))
+            })])
+        }
+
+        fn token_id(&self, token: &str) -> Option<u32> {
+            self.pieces.get(token).copied()
+        }
+    }
+
+    #[test]
+    fn text_prompt_is_raw_and_empty_stays_empty() {
+        let tokenizer = RecordingTokenizer::new();
+        let presentation = build_text_presentation(&tokenizer, "raw prompt", 20).unwrap();
+        assert_eq!(
+            presentation.token_ids,
+            tokenizer.encode_raw("raw prompt").unwrap()
+        );
+        let empty = build_text_presentation(&tokenizer, "", 20).unwrap();
+        assert!(empty.token_ids.is_empty());
+        assert!(!empty.token_ids.contains(&151_643));
+    }
+
+    #[test]
+    fn mixed_references_keep_authoritative_order_and_separate_tag_types() {
+        let tokenizer = RecordingTokenizer::new();
+        let references = vec![
+            RefPresentation {
+                kind: RefPresentationKind::Video {
+                    blocks: vec![VideoPresentationBlock {
+                        timestamp_seconds: 0.25,
+                        vision_tokens: 2,
+                    }],
+                },
+                has_audio: true,
+            },
+            RefPresentation {
+                kind: RefPresentationKind::Image { vision_tokens: 1 },
+                has_audio: false,
+            },
+            RefPresentation {
+                kind: RefPresentationKind::Audio,
+                has_audio: true,
+            },
+        ];
+        let result = build_ref2va_presentation(&tokenizer, "prompt", &references, 100).unwrap();
+        let expected_segments = [
+            "<Audio 1>: ",
+            "<Video 1>: ",
+            "<0.2 seconds>",
+            "<Picture 1>: ",
+            "<Audio 2>: ",
+            "prompt",
+        ];
+        let observed_text: Vec<_> = result
+            .token_ids
+            .iter()
+            .copied()
+            .filter(|id| {
+                ![
+                    H3_VISION_START_TOKEN_ID,
+                    H3_VISION_END_TOKEN_ID,
+                    H3_IMAGE_PAD_TOKEN_ID,
+                    H3_VIDEO_PAD_TOKEN_ID,
+                ]
+                .contains(id)
+            })
+            .collect();
+        assert_eq!(
+            observed_text,
+            expected_segments
+                .iter()
+                .flat_map(|segment| tokenizer.encode_raw(segment).unwrap())
+                .collect::<Vec<_>>()
+        );
+        let image_pad = result
+            .token_ids
+            .iter()
+            .position(|id| *id == H3_IMAGE_PAD_TOKEN_ID)
+            .unwrap();
+        assert_eq!(result.h3_tags[image_pad], H3ModalityTag::Vision);
+        assert_eq!(result.qwen_mm_types[image_pad], QwenMmTokenType::Image);
+        let image_start = image_pad - 1;
+        assert_eq!(result.h3_tags[image_start], H3ModalityTag::Vision);
+        assert_eq!(result.qwen_mm_types[image_start], QwenMmTokenType::Text);
+    }
+
+    #[test]
+    fn excess_context_and_unsupported_reference_fail_before_encoding() {
+        let tokenizer = RecordingTokenizer::new();
+        assert!(matches!(
+            build_fl2va_presentation(&tokenizer, "prompt", &[1], 3),
+            Err(PresentationError::ExcessContext { .. })
+        ));
+        assert!(matches!(
+            build_ref2va_presentation(
+                &tokenizer,
+                "prompt",
+                &[RefPresentation {
+                    kind: RefPresentationKind::Video { blocks: vec![] },
+                    has_audio: false,
+                }],
+                100,
+            ),
+            Err(PresentationError::UnsupportedReference(_))
+        ));
+    }
+}

--- a/crates/mold-candle/src/minimax_h3/processor.rs
+++ b/crates/mold-candle/src/minimax_h3/processor.rs
@@ -1,0 +1,398 @@
+use thiserror::Error;
+
+use super::presentation::{H3_IMAGE_PAD_TOKEN_ID, H3_VIDEO_PAD_TOKEN_ID};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u8)]
+pub enum QwenMmTokenType {
+    Text = 0,
+    Image = 1,
+    Video = 2,
+}
+
+pub fn create_mm_token_type_ids(token_ids: &[u32]) -> Vec<QwenMmTokenType> {
+    token_ids
+        .iter()
+        .map(|id| match *id {
+            H3_IMAGE_PAD_TOKEN_ID => QwenMmTokenType::Image,
+            H3_VIDEO_PAD_TOKEN_ID => QwenMmTokenType::Video,
+            _ => QwenMmTokenType::Text,
+        })
+        .collect()
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct GridThw {
+    pub temporal: usize,
+    pub height: usize,
+    pub width: usize,
+}
+
+impl GridThw {
+    pub fn merged_tokens(self, spatial_merge_size: usize) -> Result<usize, ProcessorError> {
+        if self.temporal == 0 || self.height == 0 || self.width == 0 {
+            return Err(ProcessorError::UnsupportedGrid(self));
+        }
+        if spatial_merge_size == 0
+            || !self.height.is_multiple_of(spatial_merge_size)
+            || !self.width.is_multiple_of(spatial_merge_size)
+        {
+            return Err(ProcessorError::UnsupportedGrid(self));
+        }
+        Ok(self.temporal * (self.height / spatial_merge_size) * (self.width / spatial_merge_size))
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct SampledVideo {
+    pub frame_indices: Vec<usize>,
+    pub block_timestamps_seconds: Vec<f64>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct PackedVisionPatches {
+    pub values: Vec<f32>,
+    pub patch_count: usize,
+    pub patch_width: usize,
+    pub grid: GridThw,
+}
+
+#[derive(Debug, Error, PartialEq)]
+pub enum ProcessorError {
+    #[error("source video fps must be finite and positive, got {0}")]
+    InvalidFps(f64),
+    #[error("a reference at {source_fps} fps needs at least {minimum_frames} frames for Qwen's 2 fps temporal-patch-2 input, got {actual_frames}")]
+    VideoTooShort {
+        source_fps: f64,
+        minimum_frames: usize,
+        actual_frames: usize,
+    },
+    #[error("unsupported Qwen3-VL processor grid {0:?}")]
+    UnsupportedGrid(GridThw),
+    #[error("Qwen3-VL multimodal run mismatch: {0}")]
+    MultimodalRun(String),
+    #[error("unsupported Qwen3-VL pixel tensor: {0}")]
+    UnsupportedPixels(String),
+}
+
+/// Normalize RGB bytes to `[-1, 1]` and reproduce Qwen's exact
+/// temporal/spatial patch permutation after the caller has resized frames to
+/// processor-authorized dimensions. A single image is repeated across the
+/// temporal pair; an odd video repeats its final frame.
+pub fn pack_qwen_vision_u8(
+    rgb_frames: &[u8],
+    frame_count: usize,
+    height: usize,
+    width: usize,
+) -> Result<PackedVisionPatches, ProcessorError> {
+    const CHANNELS: usize = 3;
+    const TEMPORAL_PATCH: usize = 2;
+    const PATCH: usize = 16;
+    const MERGE: usize = 2;
+    let expected = frame_count
+        .checked_mul(height)
+        .and_then(|value| value.checked_mul(width))
+        .and_then(|value| value.checked_mul(CHANNELS))
+        .ok_or_else(|| ProcessorError::UnsupportedPixels("shape byte count overflow".into()))?;
+    if frame_count == 0 || rgb_frames.len() != expected {
+        return Err(ProcessorError::UnsupportedPixels(format!(
+            "{frame_count}x{height}x{width}x3 requires {expected} bytes, got {}",
+            rgb_frames.len()
+        )));
+    }
+    let factor = PATCH * MERGE;
+    if height == 0 || width == 0 || !height.is_multiple_of(factor) || !width.is_multiple_of(factor)
+    {
+        return Err(ProcessorError::UnsupportedPixels(format!(
+            "resized dimensions {width}x{height} must be positive multiples of {factor}"
+        )));
+    }
+    let padded_frames = frame_count.next_multiple_of(TEMPORAL_PATCH);
+    let grid = GridThw {
+        temporal: padded_frames / TEMPORAL_PATCH,
+        height: height / PATCH,
+        width: width / PATCH,
+    };
+    let patch_count = grid.temporal * grid.height * grid.width;
+    let patch_width = CHANNELS * TEMPORAL_PATCH * PATCH * PATCH;
+    let mut values = Vec::with_capacity(patch_count * patch_width);
+    for temporal_block in 0..grid.temporal {
+        for outer_row in 0..grid.height / MERGE {
+            for outer_column in 0..grid.width / MERGE {
+                for inner_row in 0..MERGE {
+                    for inner_column in 0..MERGE {
+                        let patch_row = (outer_row * MERGE + inner_row) * PATCH;
+                        let patch_column = (outer_column * MERGE + inner_column) * PATCH;
+                        for channel in 0..CHANNELS {
+                            for temporal_inner in 0..TEMPORAL_PATCH {
+                                let frame = (temporal_block * TEMPORAL_PATCH + temporal_inner)
+                                    .min(frame_count - 1);
+                                for row in patch_row..patch_row + PATCH {
+                                    for column in patch_column..patch_column + PATCH {
+                                        let index = (((frame * height + row) * width + column)
+                                            * CHANNELS)
+                                            + channel;
+                                        values.push(f32::from(rgb_frames[index]) / 127.5 - 1.0);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    debug_assert_eq!(values.len(), patch_count * patch_width);
+    Ok(PackedVisionPatches {
+        values,
+        patch_count,
+        patch_width,
+        grid,
+    })
+}
+
+/// Reproduce the official 2 fps cursor sampling, including Python's ties-to-
+/// even `round`, deduplication, temporal-patch-2 padding, and mean labels.
+pub fn sample_video_frames(
+    frame_count: usize,
+    source_fps: f64,
+) -> Result<SampledVideo, ProcessorError> {
+    const SAMPLE_FPS: f64 = 2.0;
+    const TEMPORAL_PATCH: usize = 2;
+    if !source_fps.is_finite() || source_fps <= 0.0 {
+        return Err(ProcessorError::InvalidFps(source_fps));
+    }
+    let stride = source_fps / SAMPLE_FPS;
+    let mut cursor = 0.0_f64;
+    let mut frame_indices = Vec::new();
+    loop {
+        let index = cursor.round_ties_even() as usize;
+        if index >= frame_count {
+            break;
+        }
+        if frame_indices
+            .last()
+            .is_none_or(|previous| index > *previous)
+        {
+            frame_indices.push(index);
+        }
+        cursor += stride;
+    }
+    if frame_indices.len() < TEMPORAL_PATCH {
+        let minimum_frames = (((TEMPORAL_PATCH - 1) as f64 * stride).round_ties_even() as usize
+            + 1)
+        .max(TEMPORAL_PATCH);
+        return Err(ProcessorError::VideoTooShort {
+            source_fps,
+            minimum_frames,
+            actual_frames: frame_count,
+        });
+    }
+    let mut timestamps: Vec<_> = (0..frame_indices.len())
+        .map(|index| index as f64 / SAMPLE_FPS)
+        .collect();
+    while !timestamps.len().is_multiple_of(TEMPORAL_PATCH) {
+        timestamps.push(*timestamps.last().expect("at least two timestamps"));
+    }
+    let block_timestamps_seconds = timestamps
+        .chunks_exact(TEMPORAL_PATCH)
+        .map(|chunk| (chunk[0] + chunk[TEMPORAL_PATCH - 1]) / 2.0)
+        .collect();
+    Ok(SampledVideo {
+        frame_indices,
+        block_timestamps_seconds,
+    })
+}
+
+/// Qwen3-VL's three-axis position ids for one unpadded presentation.
+/// Video grids are split into one temporal block per contiguous video-pad run,
+/// matching the timestamped H3 presentation.
+pub fn qwen_mrope_positions(
+    token_types: &[QwenMmTokenType],
+    image_grids: &[GridThw],
+    video_grids: &[GridThw],
+    spatial_merge_size: usize,
+) -> Result<[Vec<u32>; 3], ProcessorError> {
+    let mut expanded_video_grids = Vec::new();
+    for grid in video_grids {
+        grid.merged_tokens(spatial_merge_size)?;
+        expanded_video_grids.extend(std::iter::repeat_n(
+            GridThw {
+                temporal: 1,
+                height: grid.height,
+                width: grid.width,
+            },
+            grid.temporal,
+        ));
+    }
+    let mut image_iter = image_grids.iter();
+    let mut video_iter = expanded_video_grids.iter();
+    let mut positions: [Vec<u32>; 3] =
+        std::array::from_fn(|_| Vec::with_capacity(token_types.len()));
+    let mut current = 0_u32;
+    let mut start = 0;
+    while start < token_types.len() {
+        let kind = token_types[start];
+        let mut end = start + 1;
+        while end < token_types.len() && token_types[end] == kind {
+            end += 1;
+        }
+        let run_len = end - start;
+        match kind {
+            QwenMmTokenType::Text => {
+                for offset in 0..run_len as u32 {
+                    for axis in &mut positions {
+                        axis.push(current + offset);
+                    }
+                }
+                current += run_len as u32;
+            }
+            QwenMmTokenType::Image | QwenMmTokenType::Video => {
+                let grid = match kind {
+                    QwenMmTokenType::Image => image_iter.next(),
+                    QwenMmTokenType::Video => video_iter.next(),
+                    QwenMmTokenType::Text => unreachable!(),
+                }
+                .ok_or_else(|| ProcessorError::MultimodalRun(format!("missing {kind:?} grid")))?;
+                let expected = grid.merged_tokens(spatial_merge_size)?;
+                if expected != run_len {
+                    return Err(ProcessorError::MultimodalRun(format!(
+                        "{kind:?} pad run has {run_len} tokens but grid {grid:?} yields {expected}"
+                    )));
+                }
+                let merged_h = grid.height / spatial_merge_size;
+                let merged_w = grid.width / spatial_merge_size;
+                for temporal in 0..grid.temporal {
+                    for height in 0..merged_h {
+                        for width in 0..merged_w {
+                            positions[0].push(current + temporal as u32);
+                            positions[1].push(current + height as u32);
+                            positions[2].push(current + width as u32);
+                        }
+                    }
+                }
+                current += grid.temporal.max(merged_h).max(merged_w) as u32;
+            }
+        }
+        start = end;
+    }
+    if image_iter.next().is_some() || video_iter.next().is_some() {
+        return Err(ProcessorError::MultimodalRun(
+            "processor returned more grids than the presentation contains".into(),
+        ));
+    }
+    Ok(positions)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn video_sampling_matches_official_two_fps_and_half_even_labels() {
+        let sampled = sample_video_frames(49, 24.0).unwrap();
+        assert_eq!(sampled.frame_indices, vec![0, 12, 24, 36, 48]);
+        assert_eq!(sampled.block_timestamps_seconds, vec![0.25, 1.25, 2.0]);
+        assert_eq!(format!("{:.1}", sampled.block_timestamps_seconds[0]), "0.2");
+    }
+
+    #[test]
+    fn video_sampling_reports_exact_minimum() {
+        assert_eq!(
+            sample_video_frames(12, 24.0).unwrap_err(),
+            ProcessorError::VideoTooShort {
+                source_fps: 24.0,
+                minimum_frames: 13,
+                actual_frames: 12,
+            }
+        );
+        assert_eq!(
+            sample_video_frames(1, 1.0).unwrap_err(),
+            ProcessorError::VideoTooShort {
+                source_fps: 1.0,
+                minimum_frames: 2,
+                actual_frames: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn mrope_uses_text_runs_and_visual_axes() {
+        let types = [
+            QwenMmTokenType::Text,
+            QwenMmTokenType::Text,
+            QwenMmTokenType::Image,
+            QwenMmTokenType::Image,
+            QwenMmTokenType::Image,
+            QwenMmTokenType::Image,
+            QwenMmTokenType::Text,
+        ];
+        let positions = qwen_mrope_positions(
+            &types,
+            &[GridThw {
+                temporal: 1,
+                height: 4,
+                width: 4,
+            }],
+            &[],
+            2,
+        )
+        .unwrap();
+        assert_eq!(positions[0], vec![0, 1, 2, 2, 2, 2, 4]);
+        assert_eq!(positions[1], vec![0, 1, 2, 2, 3, 3, 4]);
+        assert_eq!(positions[2], vec![0, 1, 2, 3, 2, 3, 4]);
+    }
+
+    #[test]
+    fn mismatched_vision_run_is_rejected() {
+        let error = qwen_mrope_positions(
+            &[QwenMmTokenType::Image],
+            &[GridThw {
+                temporal: 1,
+                height: 4,
+                width: 4,
+            }],
+            &[],
+            2,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("has 1 tokens"));
+    }
+
+    #[test]
+    fn vision_packing_duplicates_single_frame_and_uses_merge_block_order() {
+        let mut pixels = vec![0_u8; 32 * 32 * 3];
+        for row in 0..32 {
+            for column in 0..32 {
+                pixels[(row * 32 + column) * 3] = (row * 32 + column) as u8;
+            }
+        }
+        let packed = pack_qwen_vision_u8(&pixels, 1, 32, 32).unwrap();
+        assert_eq!(
+            packed.grid,
+            GridThw {
+                temporal: 1,
+                height: 2,
+                width: 2
+            }
+        );
+        assert_eq!(packed.patch_count, 4);
+        assert_eq!(packed.patch_width, 1_536);
+        // Channel 0, temporal frame 0 begins at (0, 0); frame 1 is the
+        // repeated image and starts after one 16x16 plane.
+        assert_eq!(packed.values[0], -1.0);
+        assert_eq!(packed.values[16 * 16], -1.0);
+        // The second emitted patch is the adjacent inner merge column and
+        // starts at source column 16.
+        assert_eq!(
+            packed.values[packed.patch_width],
+            f32::from(pixels[16 * 3]) / 127.5 - 1.0
+        );
+    }
+
+    #[test]
+    fn vision_packing_rejects_unresized_shapes() {
+        let error = pack_qwen_vision_u8(&vec![0; 31 * 32 * 3], 1, 31, 32).unwrap_err();
+        assert!(error.to_string().contains("multiples of 32"));
+    }
+}

--- a/crates/mold-candle/src/minimax_h3/text.rs
+++ b/crates/mold-candle/src/minimax_h3/text.rs
@@ -1,0 +1,532 @@
+use candle::{DType, IndexOp, Result, Tensor, D};
+use candle_nn::{
+    embedding, linear_b, rms_norm, Activation, Embedding, Linear, Module, RmsNorm, VarBuilder,
+};
+
+use super::config::{H3ConditionerConfig, H3_SELECTED_LANGUAGE_LAYERS};
+use super::model::ConditionerCheckpoint;
+
+#[derive(Clone, Debug)]
+pub(super) struct Qwen3VlTextDimensions {
+    vocab_size: usize,
+    hidden_size: usize,
+    intermediate_size: usize,
+    num_layers: usize,
+    num_attention_heads: usize,
+    num_key_value_heads: usize,
+    head_dim: usize,
+    rms_norm_eps: f64,
+    rope_theta: f64,
+    max_position_embeddings: usize,
+    mrope_section: [usize; 3],
+}
+
+impl Qwen3VlTextDimensions {
+    pub(super) fn from_h3(config: &H3ConditionerConfig) -> Self {
+        let text = &config.text_config;
+        Self {
+            vocab_size: text.vocab_size,
+            hidden_size: text.hidden_size,
+            intermediate_size: text.intermediate_size,
+            num_layers: H3_SELECTED_LANGUAGE_LAYERS,
+            num_attention_heads: text.num_attention_heads,
+            num_key_value_heads: text.num_key_value_heads,
+            head_dim: text.head_dim,
+            rms_norm_eps: text.rms_norm_eps,
+            rope_theta: text.rope_theta,
+            max_position_embeddings: text.max_position_embeddings,
+            mrope_section: text.rope_scaling.mrope_section,
+        }
+    }
+
+    fn validate(&self) -> Result<()> {
+        if self.num_layers == 0
+            || self.hidden_size == 0
+            || self.head_dim == 0
+            || self.num_attention_heads == 0
+            || self.num_key_value_heads == 0
+            || !self
+                .num_attention_heads
+                .is_multiple_of(self.num_key_value_heads)
+            || self.mrope_section.iter().sum::<usize>() != self.head_dim / 2
+        {
+            candle::bail!("invalid H3 Qwen3-VL text dimensions: {self:?}");
+        }
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub(super) fn tiny() -> Self {
+        Self {
+            vocab_size: 32,
+            hidden_size: 12,
+            intermediate_size: 24,
+            num_layers: 3,
+            num_attention_heads: 3,
+            num_key_value_heads: 1,
+            head_dim: 4,
+            rms_norm_eps: 1e-6,
+            rope_theta: 10_000.0,
+            max_position_embeddings: 64,
+            mrope_section: [1, 1, 0],
+        }
+    }
+}
+
+struct Mlp {
+    gate_proj: Linear,
+    up_proj: Linear,
+    down_proj: Linear,
+}
+
+impl Mlp {
+    fn new(config: &Qwen3VlTextDimensions, vb: VarBuilder) -> Result<Self> {
+        Ok(Self {
+            gate_proj: linear_b(
+                config.hidden_size,
+                config.intermediate_size,
+                false,
+                vb.pp("gate_proj"),
+            )?,
+            up_proj: linear_b(
+                config.hidden_size,
+                config.intermediate_size,
+                false,
+                vb.pp("up_proj"),
+            )?,
+            down_proj: linear_b(
+                config.intermediate_size,
+                config.hidden_size,
+                false,
+                vb.pp("down_proj"),
+            )?,
+        })
+    }
+
+    fn forward(&self, input: &Tensor) -> Result<Tensor> {
+        let gate = self.gate_proj.forward(input)?.apply(&Activation::Silu)?;
+        self.down_proj
+            .forward(&(gate * self.up_proj.forward(input)?)?)
+    }
+}
+
+struct MultimodalRotaryEmbedding {
+    inv_freq: Tensor,
+    sections: [usize; 3],
+    maximum_positions: usize,
+}
+
+impl MultimodalRotaryEmbedding {
+    fn new(config: &Qwen3VlTextDimensions, vb: &VarBuilder) -> Result<Self> {
+        let inv_freq = (0..config.head_dim)
+            .step_by(2)
+            .map(|index| {
+                1.0_f32 / (config.rope_theta as f32).powf(index as f32 / config.head_dim as f32)
+            })
+            .collect::<Vec<_>>();
+        let half = inv_freq.len();
+        Ok(Self {
+            inv_freq: Tensor::from_vec(inv_freq, (half,), vb.device())?,
+            sections: config.mrope_section,
+            maximum_positions: config.max_position_embeddings,
+        })
+    }
+
+    fn cos_sin(&self, position_ids: &Tensor) -> Result<(Tensor, Tensor)> {
+        let (axes, _batch, sequence) = position_ids.dims3()?;
+        if axes != 3 {
+            candle::bail!("Qwen multimodal RoPE needs three position axes, got {axes}");
+        }
+        let max_position = position_ids
+            .to_device(&candle::Device::Cpu)?
+            .flatten_all()?
+            .to_vec1::<u32>()?
+            .into_iter()
+            .max()
+            .unwrap_or(0) as usize;
+        if max_position >= self.maximum_positions {
+            candle::bail!(
+                "Qwen multimodal RoPE position {} exceeds configured maximum {}",
+                max_position,
+                self.maximum_positions
+            );
+        }
+        let positions = position_ids.to_dtype(DType::F32)?.unsqueeze(D::Minus1)?;
+        let frequencies = positions.broadcast_mul(&self.inv_freq.reshape((1, 1, 1, ()))?)?;
+        let axes = [frequencies.i(0)?, frequencies.i(1)?, frequencies.i(2)?];
+        let half = self.inv_freq.dim(0)?;
+        let mut columns = Vec::with_capacity(half);
+        for index in 0..half {
+            let axis = if index % 3 == 1 && index < self.sections[1] * 3 {
+                1
+            } else if index % 3 == 2 && index < self.sections[2] * 3 {
+                2
+            } else {
+                0
+            };
+            columns.push(axes[axis].narrow(D::Minus1, index, 1)?);
+        }
+        let refs = columns.iter().collect::<Vec<_>>();
+        let interleaved = Tensor::cat(&refs, D::Minus1)?;
+        debug_assert_eq!(interleaved.dim(1)?, sequence);
+        let doubled = Tensor::cat(&[&interleaved, &interleaved], D::Minus1)?;
+        Ok((doubled.cos()?, doubled.sin()?))
+    }
+}
+
+fn rotate_half(input: &Tensor) -> Result<Tensor> {
+    let hidden = input.dim(D::Minus1)?;
+    let first = input.narrow(D::Minus1, 0, hidden / 2)?;
+    let second = input.narrow(D::Minus1, hidden / 2, hidden / 2)?;
+    Tensor::cat(&[&second.neg()?, &first], D::Minus1)
+}
+
+fn apply_rotary(input: &Tensor, cos: &Tensor, sin: &Tensor) -> Result<Tensor> {
+    let dtype = input.dtype();
+    let input = input.to_dtype(DType::F32)?;
+    let cos = cos.unsqueeze(1)?;
+    let sin = sin.unsqueeze(1)?;
+    (input.broadcast_mul(&cos)? + rotate_half(&input)?.broadcast_mul(&sin)?)?.to_dtype(dtype)
+}
+
+struct Attention {
+    q_proj: Linear,
+    k_proj: Linear,
+    v_proj: Linear,
+    o_proj: Linear,
+    q_norm: RmsNorm,
+    k_norm: RmsNorm,
+    num_heads: usize,
+    num_key_value_heads: usize,
+    head_dim: usize,
+    kv_groups: usize,
+    scale: f64,
+}
+
+impl Attention {
+    fn new(config: &Qwen3VlTextDimensions, vb: VarBuilder) -> Result<Self> {
+        let q_width = config.num_attention_heads * config.head_dim;
+        let kv_width = config.num_key_value_heads * config.head_dim;
+        Ok(Self {
+            q_proj: linear_b(config.hidden_size, q_width, false, vb.pp("q_proj"))?,
+            k_proj: linear_b(config.hidden_size, kv_width, false, vb.pp("k_proj"))?,
+            v_proj: linear_b(config.hidden_size, kv_width, false, vb.pp("v_proj"))?,
+            o_proj: linear_b(q_width, config.hidden_size, false, vb.pp("o_proj"))?,
+            q_norm: rms_norm(config.head_dim, config.rms_norm_eps, vb.pp("q_norm"))?,
+            k_norm: rms_norm(config.head_dim, config.rms_norm_eps, vb.pp("k_norm"))?,
+            num_heads: config.num_attention_heads,
+            num_key_value_heads: config.num_key_value_heads,
+            head_dim: config.head_dim,
+            kv_groups: config.num_attention_heads / config.num_key_value_heads,
+            scale: 1.0 / (config.head_dim as f64).sqrt(),
+        })
+    }
+
+    fn forward(
+        &self,
+        input: &Tensor,
+        cos: &Tensor,
+        sin: &Tensor,
+        causal_mask: &Tensor,
+    ) -> Result<Tensor> {
+        let dtype = input.dtype();
+        let (batch, sequence, _) = input.dims3()?;
+        let q = self
+            .q_proj
+            .forward(input)?
+            .reshape((batch, sequence, self.num_heads, self.head_dim))?
+            .transpose(1, 2)?
+            .apply(&self.q_norm)?;
+        let k = self
+            .k_proj
+            .forward(input)?
+            .reshape((batch, sequence, self.num_key_value_heads, self.head_dim))?
+            .transpose(1, 2)?
+            .apply(&self.k_norm)?;
+        let v = self
+            .v_proj
+            .forward(input)?
+            .reshape((batch, sequence, self.num_key_value_heads, self.head_dim))?
+            .transpose(1, 2)?;
+        let q = apply_rotary(&q, cos, sin)?.contiguous()?;
+        let k = apply_rotary(&k, cos, sin)?.contiguous()?;
+        let k = candle_transformers::utils::repeat_kv(k, self.kv_groups)?.contiguous()?;
+        let v = candle_transformers::utils::repeat_kv(v, self.kv_groups)?.contiguous()?;
+        let scores = (q.matmul(&k.transpose(2, 3)?)? * self.scale)?.to_dtype(DType::F32)?;
+        let scores = scores.broadcast_add(causal_mask)?;
+        let probabilities = candle_nn::ops::softmax_last_dim(&scores)?.to_dtype(v.dtype())?;
+        let output = probabilities
+            .matmul(&v)?
+            .transpose(1, 2)?
+            .reshape((batch, sequence, self.num_heads * self.head_dim))?
+            .to_dtype(dtype)?;
+        self.o_proj.forward(&output)
+    }
+}
+
+struct DecoderLayer {
+    attention: Attention,
+    mlp: Mlp,
+    input_layernorm: RmsNorm,
+    post_attention_layernorm: RmsNorm,
+}
+
+impl DecoderLayer {
+    fn new(config: &Qwen3VlTextDimensions, vb: VarBuilder) -> Result<Self> {
+        Ok(Self {
+            attention: Attention::new(config, vb.pp("self_attn"))?,
+            mlp: Mlp::new(config, vb.pp("mlp"))?,
+            input_layernorm: rms_norm(
+                config.hidden_size,
+                config.rms_norm_eps,
+                vb.pp("input_layernorm"),
+            )?,
+            post_attention_layernorm: rms_norm(
+                config.hidden_size,
+                config.rms_norm_eps,
+                vb.pp("post_attention_layernorm"),
+            )?,
+        })
+    }
+
+    fn forward(
+        &self,
+        input: &Tensor,
+        cos: &Tensor,
+        sin: &Tensor,
+        causal_mask: &Tensor,
+    ) -> Result<Tensor> {
+        let attention =
+            self.attention
+                .forward(&input.apply(&self.input_layernorm)?, cos, sin, causal_mask)?;
+        let hidden = (input + attention)?;
+        let mlp = self
+            .mlp
+            .forward(&hidden.apply(&self.post_attention_layernorm)?)?;
+        hidden + mlp
+    }
+}
+
+pub(super) struct Qwen3VlTextEncoder {
+    embed_tokens: Embedding,
+    layers: Vec<DecoderLayer>,
+    rotary: MultimodalRotaryEmbedding,
+    hidden_size: usize,
+}
+
+impl Qwen3VlTextEncoder {
+    pub(super) fn new(config: &Qwen3VlTextDimensions, vb: VarBuilder) -> Result<Self> {
+        config.validate()?;
+        let embed_tokens = embedding(config.vocab_size, config.hidden_size, vb.pp("embed_tokens"))?;
+        let rotary = MultimodalRotaryEmbedding::new(config, &vb)?;
+        let mut layers = Vec::with_capacity(config.num_layers);
+        for index in 0..config.num_layers {
+            layers.push(DecoderLayer::new(config, vb.pp("layers").pp(index))?);
+        }
+        Ok(Self {
+            embed_tokens,
+            layers,
+            rotary,
+            hidden_size: config.hidden_size,
+        })
+    }
+
+    pub(super) fn layer_count(&self) -> usize {
+        self.layers.len()
+    }
+
+    pub(super) fn embed_tokens(&self, input_ids: &Tensor) -> Result<Tensor> {
+        self.embed_tokens.forward(input_ids)
+    }
+
+    pub(super) fn forward_embeds(
+        &self,
+        mut hidden: Tensor,
+        position_ids: &Tensor,
+        visual_indices: &[usize],
+        deepstack: Option<&[Tensor]>,
+        checkpoint: &mut dyn FnMut(ConditionerCheckpoint) -> Result<()>,
+    ) -> Result<Tensor> {
+        let (batch, sequence, width) = hidden.dims3()?;
+        if width != self.hidden_size || batch != 1 {
+            candle::bail!(
+                "H3 text embeddings have shape {:?}, expected (1, sequence, {})",
+                hidden.dims(),
+                self.hidden_size
+            );
+        }
+        if deepstack.is_some_and(|features| features.len() > self.layers.len()) {
+            candle::bail!("H3 DeepStack has more feature layers than language layers");
+        }
+        let (cos, sin) = self.rotary.cos_sin(position_ids)?;
+        let causal = causal_mask(sequence, hidden.device())?;
+        for (index, layer) in self.layers.iter().enumerate() {
+            hidden = layer.forward(&hidden, &cos, &sin, &causal)?;
+            if let Some(features) = deepstack.and_then(|features| features.get(index)) {
+                hidden = inject_deepstack(hidden, visual_indices, features, self.hidden_size)?;
+            }
+            checkpoint(ConditionerCheckpoint::LanguageLayer {
+                completed: index + 1,
+                total: self.layers.len(),
+            })?;
+        }
+        // Intentionally no final RMS norm: H3 consumes hidden_states[50], the
+        // unnormalized state immediately after decoder layer 49.
+        Ok(hidden)
+    }
+}
+
+fn causal_mask(sequence: usize, device: &candle::Device) -> Result<Tensor> {
+    let values = (0..sequence)
+        .flat_map(|row| {
+            (0..sequence).map(
+                move |column| {
+                    if column > row {
+                        f32::NEG_INFINITY
+                    } else {
+                        0.0
+                    }
+                },
+            )
+        })
+        .collect::<Vec<_>>();
+    Tensor::from_vec(values, (1, 1, sequence, sequence), device)
+}
+
+fn inject_deepstack(
+    mut hidden: Tensor,
+    visual_indices: &[usize],
+    features: &Tensor,
+    width: usize,
+) -> Result<Tensor> {
+    if features.dims() != [visual_indices.len(), width] {
+        candle::bail!(
+            "H3 DeepStack features have shape {:?}, expected ({}, {})",
+            features.dims(),
+            visual_indices.len(),
+            width
+        );
+    }
+    let features = features
+        .to_device(hidden.device())?
+        .to_dtype(hidden.dtype())?;
+    for (row, &sequence_index) in visual_indices.iter().enumerate() {
+        let current = hidden.narrow(1, sequence_index, 1)?;
+        let addition = features.narrow(0, row, 1)?.unsqueeze(0)?;
+        hidden = hidden.slice_assign(
+            &[0..1, sequence_index..sequence_index + 1, 0..width],
+            &(current + addition)?,
+        )?;
+    }
+    Ok(hidden)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candle::{DType, Device};
+    use candle_nn::VarMap;
+
+    #[test]
+    fn tiny_encoder_returns_full_unnormalized_sequence_without_tail_keys() {
+        let config = Qwen3VlTextDimensions::tiny();
+        let vars = VarMap::new();
+        let vb = VarBuilder::from_varmap(&vars, DType::F32, &Device::Cpu);
+        let encoder = Qwen3VlTextEncoder::new(&config, vb).unwrap();
+        let keys = vars
+            .data()
+            .lock()
+            .unwrap()
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        assert_eq!(encoder.layer_count(), 3);
+        assert!(!keys.iter().any(|key| key.ends_with(".norm.weight")));
+        assert!(!keys.iter().any(|key| key.starts_with("lm_head")));
+
+        let ids = Tensor::new(&[[1_u32, 2, 3]], &Device::Cpu).unwrap();
+        let positions = Tensor::new(
+            &[[[0_u32, 1, 2]], [[0_u32, 1, 2]], [[0_u32, 1, 2]]],
+            &Device::Cpu,
+        )
+        .unwrap();
+        let embeds = encoder.embed_tokens(&ids).unwrap();
+        let mut checkpoints = Vec::new();
+        let output = encoder
+            .forward_embeds(embeds, &positions, &[], None, &mut |checkpoint| {
+                checkpoints.push(checkpoint);
+                Ok(())
+            })
+            .unwrap();
+        assert_eq!(output.dims(), [1, 3, 12]);
+        assert_eq!(
+            checkpoints,
+            vec![
+                ConditionerCheckpoint::LanguageLayer {
+                    completed: 1,
+                    total: 3
+                },
+                ConditionerCheckpoint::LanguageLayer {
+                    completed: 2,
+                    total: 3
+                },
+                ConditionerCheckpoint::LanguageLayer {
+                    completed: 3,
+                    total: 3
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn multimodal_rope_interleaves_axes_in_fp32() {
+        let config = Qwen3VlTextDimensions::tiny();
+        let vb = VarBuilder::zeros(DType::F32, &Device::Cpu);
+        let rotary = MultimodalRotaryEmbedding::new(&config, &vb).unwrap();
+        let positions = Tensor::new(&[[[2_u32]], [[3_u32]], [[4_u32]]], &Device::Cpu).unwrap();
+        let (cos, sin) = rotary.cos_sin(&positions).unwrap();
+        assert_eq!(cos.dtype(), DType::F32);
+        assert_eq!(sin.dtype(), DType::F32);
+        assert_eq!(cos.dims(), [1, 1, 4]);
+        let values = cos.flatten_all().unwrap().to_vec1::<f32>().unwrap();
+        assert!((values[0] - 2.0_f32.cos()).abs() < 1e-6);
+        assert!((values[1] - (3.0_f32 / 100.0).cos()).abs() < 1e-6);
+    }
+
+    #[cfg(feature = "cuda")]
+    #[test]
+    fn tiny_bf16_text_stack_executes_on_cuda_with_fp32_rotary_and_softmax() {
+        let device = Device::new_cuda(0).unwrap();
+        let config = Qwen3VlTextDimensions::tiny();
+        let encoder =
+            Qwen3VlTextEncoder::new(&config, VarBuilder::zeros(DType::BF16, &device)).unwrap();
+        let ids = Tensor::new(&[[1_u32, 2, 3]], &device).unwrap();
+        let positions = Tensor::new(
+            &[[[0_u32, 1, 2]], [[0_u32, 1, 2]], [[0_u32, 1, 2]]],
+            &device,
+        )
+        .unwrap();
+        let output = encoder
+            .forward_embeds(
+                encoder.embed_tokens(&ids).unwrap(),
+                &positions,
+                &[],
+                None,
+                &mut |_| Ok(()),
+            )
+            .unwrap();
+        assert_eq!(output.dims(), [1, 3, 12]);
+        assert_eq!(output.dtype(), DType::BF16);
+        assert!(output
+            .to_device(&Device::Cpu)
+            .unwrap()
+            .to_dtype(DType::F32)
+            .unwrap()
+            .flatten_all()
+            .unwrap()
+            .to_vec1::<f32>()
+            .unwrap()
+            .iter()
+            .all(|value| value.is_finite()));
+    }
+}

--- a/crates/mold-candle/src/minimax_h3/vision.rs
+++ b/crates/mold-candle/src/minimax_h3/vision.rs
@@ -1,0 +1,757 @@
+// Tensor layout follows Qwen3-VL's released implementation. The learned
+// position interpolation and post-shuffle DeepStack mergers are not shared by
+// Mold's older Qwen2.5-VL paths and therefore live here.
+
+use candle::{DType, Device, IndexOp, Module, Result, Tensor, D};
+use candle_nn::{
+    embedding, layer_norm, linear, Activation, Conv2d, Conv2dConfig, Embedding, LayerNorm,
+    LayerNormConfig, Linear, VarBuilder,
+};
+
+use super::config::H3ConditionerConfig;
+use super::model::ConditionerCheckpoint;
+
+#[derive(Clone, Debug)]
+pub(super) struct Qwen3VlVisionDimensions {
+    depth: usize,
+    hidden_size: usize,
+    intermediate_size: usize,
+    num_heads: usize,
+    in_channels: usize,
+    patch_size: usize,
+    temporal_patch_size: usize,
+    spatial_merge_size: usize,
+    output_hidden_size: usize,
+    num_position_embeddings: usize,
+    deepstack_visual_indexes: Vec<usize>,
+    activation: Activation,
+}
+
+impl Qwen3VlVisionDimensions {
+    pub(super) fn from_h3(config: &H3ConditionerConfig) -> Self {
+        let vision = &config.vision_config;
+        Self {
+            depth: vision.depth,
+            hidden_size: vision.hidden_size,
+            intermediate_size: vision.intermediate_size,
+            num_heads: vision.num_heads,
+            in_channels: vision.in_channels,
+            patch_size: vision.patch_size,
+            temporal_patch_size: vision.temporal_patch_size,
+            spatial_merge_size: vision.spatial_merge_size,
+            output_hidden_size: vision.out_hidden_size,
+            num_position_embeddings: vision.num_position_embeddings,
+            deepstack_visual_indexes: vision.deepstack_visual_indexes.clone(),
+            activation: Activation::GeluPytorchTanh,
+        }
+    }
+
+    fn validate(&self) -> Result<()> {
+        if self.depth == 0
+            || self.hidden_size == 0
+            || self.num_heads == 0
+            || !self.hidden_size.is_multiple_of(self.num_heads)
+            || self.patch_size == 0
+            || self.temporal_patch_size != 2
+            || self.spatial_merge_size == 0
+            || self
+                .deepstack_visual_indexes
+                .iter()
+                .any(|index| *index >= self.depth)
+        {
+            candle::bail!("invalid H3 Qwen3-VL vision dimensions: {self:?}");
+        }
+        let side = (self.num_position_embeddings as f64).sqrt().round() as usize;
+        if side * side != self.num_position_embeddings {
+            candle::bail!(
+                "Qwen vision position count {} is not a square",
+                self.num_position_embeddings
+            );
+        }
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub(super) fn tiny() -> Self {
+        Self {
+            depth: 3,
+            hidden_size: 8,
+            intermediate_size: 16,
+            num_heads: 2,
+            in_channels: 3,
+            patch_size: 2,
+            temporal_patch_size: 2,
+            spatial_merge_size: 2,
+            output_hidden_size: 12,
+            num_position_embeddings: 4,
+            deepstack_visual_indexes: vec![0, 1, 2],
+            activation: Activation::GeluPytorchTanh,
+        }
+    }
+}
+
+struct TemporalTwoConv3d {
+    first: Conv2d,
+    second: Conv2d,
+}
+
+impl TemporalTwoConv3d {
+    fn new(
+        input_channels: usize,
+        output_channels: usize,
+        patch_size: usize,
+        vb: VarBuilder,
+    ) -> Result<Self> {
+        let weights = vb.get(
+            (output_channels, input_channels, 2, patch_size, patch_size),
+            "weight",
+        )?;
+        let config = Conv2dConfig {
+            stride: patch_size,
+            ..Default::default()
+        };
+        Ok(Self {
+            first: Conv2d::new(weights.i((.., .., 0, .., ..))?.contiguous()?, None, config),
+            second: Conv2d::new(weights.i((.., .., 1, .., ..))?.contiguous()?, None, config),
+        })
+    }
+
+    fn forward(&self, input: &Tensor) -> Result<Tensor> {
+        let first = self.first.forward(&input.i((.., .., 0, .., ..))?)?;
+        let second = self.second.forward(&input.i((.., .., 1, .., ..))?)?;
+        (first + second)?.unsqueeze(2)
+    }
+}
+
+struct PatchEmbed {
+    projection: TemporalTwoConv3d,
+    bias: Tensor,
+    input_channels: usize,
+    patch_size: usize,
+    temporal_patch_size: usize,
+    hidden_size: usize,
+}
+
+impl PatchEmbed {
+    fn new(config: &Qwen3VlVisionDimensions, vb: VarBuilder) -> Result<Self> {
+        let projection_vb = vb.pp("proj");
+        Ok(Self {
+            projection: TemporalTwoConv3d::new(
+                config.in_channels,
+                config.hidden_size,
+                config.patch_size,
+                projection_vb.clone(),
+            )?,
+            bias: projection_vb.get(config.hidden_size, "bias")?,
+            input_channels: config.in_channels,
+            patch_size: config.patch_size,
+            temporal_patch_size: config.temporal_patch_size,
+            hidden_size: config.hidden_size,
+        })
+    }
+
+    fn forward(&self, input: &Tensor) -> Result<Tensor> {
+        let expected_width =
+            self.input_channels * self.temporal_patch_size * self.patch_size * self.patch_size;
+        let (_, width) = input.dims2()?;
+        if width != expected_width {
+            candle::bail!(
+                "Qwen vision patches have width {width}, expected {expected_width} (C*T*P*P)"
+            );
+        }
+        let patches = input.reshape((
+            (),
+            self.input_channels,
+            self.temporal_patch_size,
+            self.patch_size,
+            self.patch_size,
+        ))?;
+        let projected = self
+            .projection
+            .forward(&patches)?
+            .reshape(((), self.hidden_size))?;
+        projected.broadcast_add(&self.bias.unsqueeze(0)?)
+    }
+}
+
+struct VisionMlp {
+    first: Linear,
+    second: Linear,
+    activation: Activation,
+}
+
+impl VisionMlp {
+    fn new(config: &Qwen3VlVisionDimensions, vb: VarBuilder) -> Result<Self> {
+        Ok(Self {
+            first: linear(
+                config.hidden_size,
+                config.intermediate_size,
+                vb.pp("linear_fc1"),
+            )?,
+            second: linear(
+                config.intermediate_size,
+                config.hidden_size,
+                vb.pp("linear_fc2"),
+            )?,
+            activation: config.activation,
+        })
+    }
+
+    fn forward(&self, input: &Tensor) -> Result<Tensor> {
+        self.second
+            .forward(&self.first.forward(input)?.apply(&self.activation)?)
+    }
+}
+
+fn rotate_half(input: &Tensor) -> Result<Tensor> {
+    let width = input.dim(D::Minus1)?;
+    let first = input.narrow(D::Minus1, 0, width / 2)?;
+    let second = input.narrow(D::Minus1, width / 2, width / 2)?;
+    Tensor::cat(&[&second.neg()?, &first], D::Minus1)
+}
+
+struct VisionAttention {
+    qkv: Linear,
+    projection: Linear,
+    num_heads: usize,
+    head_dimension: usize,
+}
+
+impl VisionAttention {
+    fn new(config: &Qwen3VlVisionDimensions, vb: VarBuilder) -> Result<Self> {
+        Ok(Self {
+            qkv: linear(config.hidden_size, config.hidden_size * 3, vb.pp("qkv"))?,
+            projection: linear(config.hidden_size, config.hidden_size, vb.pp("proj"))?,
+            num_heads: config.num_heads,
+            head_dimension: config.hidden_size / config.num_heads,
+        })
+    }
+
+    fn forward(
+        &self,
+        input: &Tensor,
+        cumulative_sequence_lengths: &[usize],
+        cos: &Tensor,
+        sin: &Tensor,
+    ) -> Result<Tensor> {
+        let sequence = input.dim(0)?;
+        let qkv = self
+            .qkv
+            .forward(input)?
+            .reshape((sequence, 3, self.num_heads, self.head_dimension))?
+            .permute((1, 0, 2, 3))?;
+        let cos = cos.unsqueeze(1)?;
+        let sin = sin.unsqueeze(1)?;
+        let apply_rotary = |value: Tensor| -> Result<Tensor> {
+            let dtype = value.dtype();
+            let value = value.to_dtype(DType::F32)?;
+            (value.broadcast_mul(&cos)? + rotate_half(&value)?.broadcast_mul(&sin)?)?
+                .to_dtype(dtype)
+        };
+        let query = apply_rotary(qkv.i(0)?)?;
+        let key = apply_rotary(qkv.i(1)?)?;
+        let value = qkv.i(2)?;
+        let mut outputs = Vec::new();
+        for bounds in cumulative_sequence_lengths.windows(2) {
+            let start = bounds[0];
+            let length = bounds[1].saturating_sub(start);
+            if length == 0 {
+                continue;
+            }
+            let query = query
+                .narrow(0, start, length)?
+                .transpose(0, 1)?
+                .unsqueeze(0)?
+                .contiguous()?;
+            let key = key
+                .narrow(0, start, length)?
+                .transpose(0, 1)?
+                .unsqueeze(0)?
+                .contiguous()?;
+            let value = value
+                .narrow(0, start, length)?
+                .transpose(0, 1)?
+                .unsqueeze(0)?
+                .contiguous()?;
+            let key_transposed = key.transpose(2, 3)?.contiguous()?;
+            let scores = (query.matmul(&key_transposed)? / (self.head_dimension as f64).sqrt())?;
+            let probabilities = candle_nn::ops::softmax_last_dim(&scores.to_dtype(DType::F32)?)?
+                .to_dtype(value.dtype())?;
+            outputs.push(
+                probabilities
+                    .matmul(&value)?
+                    .squeeze(0)?
+                    .transpose(0, 1)?
+                    .reshape((length, self.num_heads * self.head_dimension))?
+                    .to_dtype(input.dtype())?,
+            );
+        }
+        let refs = outputs.iter().collect::<Vec<_>>();
+        self.projection.forward(&Tensor::cat(&refs, 0)?)
+    }
+}
+
+struct VisionBlock {
+    norm1: LayerNorm,
+    norm2: LayerNorm,
+    attention: VisionAttention,
+    mlp: VisionMlp,
+}
+
+impl VisionBlock {
+    fn new(config: &Qwen3VlVisionDimensions, vb: VarBuilder) -> Result<Self> {
+        let norm_config = LayerNormConfig {
+            eps: 1e-6,
+            ..Default::default()
+        };
+        Ok(Self {
+            norm1: layer_norm(config.hidden_size, norm_config, vb.pp("norm1"))?,
+            norm2: layer_norm(config.hidden_size, norm_config, vb.pp("norm2"))?,
+            attention: VisionAttention::new(config, vb.pp("attn"))?,
+            mlp: VisionMlp::new(config, vb.pp("mlp"))?,
+        })
+    }
+
+    fn forward(
+        &self,
+        input: &Tensor,
+        cumulative_sequence_lengths: &[usize],
+        cos: &Tensor,
+        sin: &Tensor,
+    ) -> Result<Tensor> {
+        let attention = self.attention.forward(
+            &self.norm1.forward(input)?,
+            cumulative_sequence_lengths,
+            cos,
+            sin,
+        )?;
+        let hidden = (input + attention)?;
+        let mlp = self.mlp.forward(&self.norm2.forward(&hidden)?)?;
+        hidden + mlp
+    }
+}
+
+struct PatchMerger {
+    norm: LayerNorm,
+    postshuffle_norm: bool,
+    merge_unit: usize,
+    merged_hidden_size: usize,
+    first: Linear,
+    second: Linear,
+}
+
+impl PatchMerger {
+    fn new(
+        config: &Qwen3VlVisionDimensions,
+        postshuffle_norm: bool,
+        vb: VarBuilder,
+    ) -> Result<Self> {
+        let merge_unit = config.spatial_merge_size.pow(2);
+        let merged_hidden_size = config.hidden_size * merge_unit;
+        let norm_width = if postshuffle_norm {
+            merged_hidden_size
+        } else {
+            config.hidden_size
+        };
+        Ok(Self {
+            norm: layer_norm(
+                norm_width,
+                LayerNormConfig {
+                    eps: 1e-6,
+                    ..Default::default()
+                },
+                vb.pp("norm"),
+            )?,
+            postshuffle_norm,
+            merge_unit,
+            merged_hidden_size,
+            first: linear(merged_hidden_size, merged_hidden_size, vb.pp("linear_fc1"))?,
+            second: linear(
+                merged_hidden_size,
+                config.output_hidden_size,
+                vb.pp("linear_fc2"),
+            )?,
+        })
+    }
+
+    fn forward(&self, input: &Tensor) -> Result<Tensor> {
+        let sequence = input.dim(0)?;
+        if !sequence.is_multiple_of(self.merge_unit) {
+            candle::bail!(
+                "Qwen vision sequence {sequence} is not divisible by merge unit {}",
+                self.merge_unit
+            );
+        }
+        let groups = sequence / self.merge_unit;
+        let norm_input = if self.postshuffle_norm {
+            input.reshape((groups, self.merged_hidden_size))?
+        } else {
+            input.clone()
+        };
+        let normalized = self.norm.forward(&norm_input)?;
+        let merged = if self.postshuffle_norm {
+            normalized
+        } else {
+            normalized.reshape((groups, self.merged_hidden_size))?
+        };
+        self.second.forward(&self.first.forward(&merged)?.gelu()?)
+    }
+}
+
+struct VisionRotaryEmbedding {
+    inverse_frequency: Tensor,
+}
+
+impl VisionRotaryEmbedding {
+    fn new(dimension: usize, device: &Device) -> Result<Self> {
+        let inverse_frequency = (0..dimension)
+            .step_by(2)
+            .map(|index| 1.0_f32 / 10_000.0_f32.powf(index as f32 / dimension as f32))
+            .collect::<Vec<_>>();
+        let length = inverse_frequency.len();
+        Ok(Self {
+            inverse_frequency: Tensor::from_vec(inverse_frequency, (1, length), device)?,
+        })
+    }
+
+    fn frequencies(&self, sequence: usize) -> Result<Tensor> {
+        Tensor::arange(0.0_f32, sequence as f32, self.inverse_frequency.device())?
+            .unsqueeze(D::Minus1)?
+            .broadcast_matmul(&self.inverse_frequency)
+    }
+}
+
+pub(super) struct Qwen3VlVisionModel {
+    patch_embed: PatchEmbed,
+    position_embedding: Embedding,
+    blocks: Vec<VisionBlock>,
+    merger: PatchMerger,
+    deepstack_mergers: Vec<PatchMerger>,
+    deepstack_lookup: Vec<Option<usize>>,
+    rotary: VisionRotaryEmbedding,
+    spatial_merge_size: usize,
+    position_grid_side: usize,
+    hidden_size: usize,
+    parameter_dtype: DType,
+}
+
+impl Qwen3VlVisionModel {
+    pub(super) fn new(config: &Qwen3VlVisionDimensions, vb: VarBuilder) -> Result<Self> {
+        config.validate()?;
+        let patch_embed = PatchEmbed::new(config, vb.pp("patch_embed"))?;
+        let position_embedding = embedding(
+            config.num_position_embeddings,
+            config.hidden_size,
+            vb.pp("pos_embed"),
+        )?;
+        let blocks = (0..config.depth)
+            .map(|index| VisionBlock::new(config, vb.pp("blocks").pp(index)))
+            .collect::<Result<Vec<_>>>()?;
+        let merger = PatchMerger::new(config, false, vb.pp("merger"))?;
+        let deepstack_mergers = config
+            .deepstack_visual_indexes
+            .iter()
+            .enumerate()
+            .map(|(index, _)| {
+                PatchMerger::new(config, true, vb.pp("deepstack_merger_list").pp(index))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let mut deepstack_lookup = vec![None; config.depth];
+        for (merger, &layer) in config.deepstack_visual_indexes.iter().enumerate() {
+            deepstack_lookup[layer] = Some(merger);
+        }
+        Ok(Self {
+            patch_embed,
+            position_embedding,
+            blocks,
+            merger,
+            deepstack_mergers,
+            deepstack_lookup,
+            rotary: VisionRotaryEmbedding::new(
+                config.hidden_size / config.num_heads / 2,
+                vb.device(),
+            )?,
+            spatial_merge_size: config.spatial_merge_size,
+            position_grid_side: (config.num_position_embeddings as f64).sqrt().round() as usize,
+            hidden_size: config.hidden_size,
+            parameter_dtype: vb.dtype(),
+        })
+    }
+
+    pub(super) fn forward(
+        &self,
+        pixels: &Tensor,
+        grid_thw: &Tensor,
+        checkpoint: &mut dyn FnMut(ConditionerCheckpoint) -> Result<()>,
+    ) -> Result<(Tensor, Vec<Tensor>)> {
+        let grid = parse_grid(grid_thw, self.spatial_merge_size)?;
+        let expected_patches = grid
+            .iter()
+            .map(|grid| grid[0] * grid[1] * grid[2])
+            .sum::<usize>();
+        if pixels.dim(0)? != expected_patches {
+            candle::bail!(
+                "Qwen vision processor emitted {} patches but grid requires {expected_patches}",
+                pixels.dim(0)?
+            );
+        }
+        let embedded = self
+            .patch_embed
+            .forward(&pixels.to_dtype(self.parameter_dtype)?)?;
+        checkpoint(ConditionerCheckpoint::VisionPatchEmbedding)?;
+        let positions = self.interpolate_positions(&grid)?;
+        let mut hidden = embedded.add(&positions)?;
+        let rotary = self.rotary_positions(&grid)?;
+        let doubled = Tensor::cat(&[&rotary, &rotary], D::Minus1)?;
+        let cos = doubled.cos()?.to_dtype(DType::F32)?;
+        let sin = doubled.sin()?.to_dtype(DType::F32)?;
+        let cumulative = cumulative_sequence_lengths(&grid);
+        let mut deepstack = Vec::with_capacity(self.deepstack_mergers.len());
+        for (index, block) in self.blocks.iter().enumerate() {
+            hidden = block.forward(&hidden, &cumulative, &cos, &sin)?;
+            if let Some(merger) = self.deepstack_lookup[index] {
+                deepstack.push(self.deepstack_mergers[merger].forward(&hidden)?);
+            }
+            checkpoint(ConditionerCheckpoint::VisionLayer {
+                completed: index + 1,
+                total: self.blocks.len(),
+            })?;
+        }
+        Ok((self.merger.forward(&hidden)?, deepstack))
+    }
+
+    fn interpolate_positions(&self, grid: &[[usize; 3]]) -> Result<Tensor> {
+        let device = self.position_embedding.embeddings().device();
+        let dtype = self.position_embedding.embeddings().dtype();
+        let mut indices: [Vec<u32>; 4] = Default::default();
+        let mut weights: [Vec<f32>; 4] = Default::default();
+        let mut areas = Vec::with_capacity(grid.len());
+        for &[_, height, width] in grid {
+            areas.push(height * width);
+            let height_points = linspace(height, self.position_grid_side);
+            let width_points = linspace(width, self.position_grid_side);
+            for &height_point in &height_points {
+                let h0 = height_point.floor() as usize;
+                let h1 = (height_point.ceil() as usize).min(self.position_grid_side - 1);
+                let dh = height_point - h0 as f32;
+                for &width_point in &width_points {
+                    let w0 = width_point.floor() as usize;
+                    let w1 = (width_point.ceil() as usize).min(self.position_grid_side - 1);
+                    let dw = width_point - w0 as f32;
+                    for (slot, (row, column, weight)) in [
+                        (h0, w0, (1.0 - dh) * (1.0 - dw)),
+                        (h0, w1, (1.0 - dh) * dw),
+                        (h1, w0, dh * (1.0 - dw)),
+                        (h1, w1, dh * dw),
+                    ]
+                    .into_iter()
+                    .enumerate()
+                    {
+                        indices[slot].push((row * self.position_grid_side + column) as u32);
+                        weights[slot].push(weight);
+                    }
+                }
+            }
+        }
+        let index_tensors = indices
+            .into_iter()
+            .map(|values| Tensor::from_vec(values.clone(), (values.len(),), device))
+            .collect::<Result<Vec<_>>>()?;
+        let weight_tensors = weights
+            .into_iter()
+            .map(|values| Tensor::from_vec(values.clone(), (values.len(),), device))
+            .collect::<Result<Vec<_>>>()?;
+        let index_refs = index_tensors.iter().collect::<Vec<_>>();
+        let weight_refs = weight_tensors.iter().collect::<Vec<_>>();
+        let gathered = self
+            .position_embedding
+            .forward(&Tensor::stack(&index_refs, 0)?)?;
+        let interpolated = gathered
+            .broadcast_mul(
+                &Tensor::stack(&weight_refs, 0)?
+                    .to_dtype(dtype)?
+                    .unsqueeze(D::Minus1)?,
+            )?
+            .sum(0)?;
+        let mut outputs = Vec::with_capacity(grid.len());
+        let mut offset = 0;
+        for (&[temporal, height, width], area) in grid.iter().zip(areas) {
+            let positions = interpolated
+                .narrow(0, offset, area)?
+                .repeat((temporal, 1))?;
+            offset += area;
+            outputs.push(
+                positions
+                    .reshape((
+                        temporal,
+                        height / self.spatial_merge_size,
+                        self.spatial_merge_size,
+                        width / self.spatial_merge_size,
+                        self.spatial_merge_size,
+                        self.hidden_size,
+                    ))?
+                    .permute((0, 1, 3, 2, 4, 5))?
+                    .reshape((temporal * height * width, self.hidden_size))?,
+            );
+        }
+        let refs = outputs.iter().collect::<Vec<_>>();
+        Tensor::cat(&refs, 0)
+    }
+
+    fn rotary_positions(&self, grid: &[[usize; 3]]) -> Result<Tensor> {
+        let maximum = grid
+            .iter()
+            .flat_map(|grid| [grid[1], grid[2]])
+            .max()
+            .unwrap_or(0);
+        let frequency_table = self.rotary.frequencies(maximum)?;
+        let mut rows = Vec::new();
+        let mut columns = Vec::new();
+        for &[temporal, height, width] in grid {
+            let merged_height = height / self.spatial_merge_size;
+            let merged_width = width / self.spatial_merge_size;
+            let mut frame = Vec::with_capacity(height * width);
+            for block_row in 0..merged_height {
+                for block_column in 0..merged_width {
+                    for inner_row in 0..self.spatial_merge_size {
+                        for inner_column in 0..self.spatial_merge_size {
+                            frame.push((
+                                block_row * self.spatial_merge_size + inner_row,
+                                block_column * self.spatial_merge_size + inner_column,
+                            ));
+                        }
+                    }
+                }
+            }
+            for _ in 0..temporal {
+                for &(row, column) in &frame {
+                    rows.push(row as u32);
+                    columns.push(column as u32);
+                }
+            }
+        }
+        let row_ids = Tensor::from_vec(rows.clone(), (rows.len(),), frequency_table.device())?;
+        let column_ids =
+            Tensor::from_vec(columns.clone(), (columns.len(),), frequency_table.device())?;
+        let row = frequency_table.index_select(&row_ids, 0)?;
+        let column = frequency_table.index_select(&column_ids, 0)?;
+        Tensor::stack(&[&row, &column], D::Minus2)?.reshape((rows.len(), ()))
+    }
+}
+
+fn parse_grid(grid: &Tensor, merge: usize) -> Result<Vec<[usize; 3]>> {
+    let rows = grid
+        .to_device(&Device::Cpu)?
+        .to_dtype(DType::U32)?
+        .to_vec2::<u32>()?;
+    let mut parsed = Vec::with_capacity(rows.len());
+    for row in rows {
+        if row.len() != 3 {
+            candle::bail!("Qwen vision grid row has {} values, expected 3", row.len());
+        }
+        let value = [row[0] as usize, row[1] as usize, row[2] as usize];
+        if value[0] == 0
+            || value[1] == 0
+            || value[2] == 0
+            || !value[1].is_multiple_of(merge)
+            || !value[2].is_multiple_of(merge)
+        {
+            candle::bail!("unsupported Qwen vision grid {value:?} for merge size {merge}");
+        }
+        parsed.push(value);
+    }
+    if parsed.is_empty() {
+        candle::bail!("Qwen vision grid cannot be empty");
+    }
+    Ok(parsed)
+}
+
+fn linspace(steps: usize, position_grid_side: usize) -> Vec<f32> {
+    if steps == 1 {
+        return vec![0.0];
+    }
+    let stride = (position_grid_side - 1) as f32 / (steps - 1) as f32;
+    (0..steps).map(|index| index as f32 * stride).collect()
+}
+
+fn cumulative_sequence_lengths(grid: &[[usize; 3]]) -> Vec<usize> {
+    let mut cumulative = vec![0];
+    let mut total = 0;
+    for &[temporal, height, width] in grid {
+        for _ in 0..temporal {
+            total += height * width;
+            cumulative.push(total);
+        }
+    }
+    cumulative
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candle_nn::VarMap;
+
+    #[test]
+    fn tiny_vision_tower_returns_main_and_three_deepstack_rows() {
+        let config = Qwen3VlVisionDimensions::tiny();
+        let vars = VarMap::new();
+        let vb = VarBuilder::from_varmap(&vars, DType::F32, &Device::Cpu);
+        let model = Qwen3VlVisionModel::new(&config, vb).unwrap();
+        let pixels = Tensor::zeros((4, 24), DType::F32, &Device::Cpu).unwrap();
+        let grid = Tensor::new(&[[1_u32, 2, 2]], &Device::Cpu).unwrap();
+        let mut checkpoints = Vec::new();
+        let (main, deepstack) = model
+            .forward(&pixels, &grid, &mut |checkpoint| {
+                checkpoints.push(checkpoint);
+                Ok(())
+            })
+            .unwrap();
+        assert_eq!(main.dims(), [1, 12]);
+        assert_eq!(deepstack.len(), 3);
+        assert!(deepstack.iter().all(|tensor| tensor.dims() == [1, 12]));
+        assert_eq!(
+            checkpoints.last(),
+            Some(&ConditionerCheckpoint::VisionLayer {
+                completed: 3,
+                total: 3
+            })
+        );
+    }
+
+    #[test]
+    fn mismatched_patch_tensor_is_rejected() {
+        let config = Qwen3VlVisionDimensions::tiny();
+        let vb = VarBuilder::zeros(DType::F32, &Device::Cpu);
+        let model = Qwen3VlVisionModel::new(&config, vb).unwrap();
+        let pixels = Tensor::zeros((3, 24), DType::F32, &Device::Cpu).unwrap();
+        let grid = Tensor::new(&[[1_u32, 2, 2]], &Device::Cpu).unwrap();
+        let error = model.forward(&pixels, &grid, &mut |_| Ok(())).unwrap_err();
+        assert!(error.to_string().contains("emitted 3 patches"));
+    }
+
+    #[cfg(feature = "cuda")]
+    #[test]
+    fn tiny_bf16_vision_tower_executes_on_cuda_with_fp32_rotary_and_softmax() {
+        let device = Device::new_cuda(0).unwrap();
+        let config = Qwen3VlVisionDimensions::tiny();
+        let model =
+            Qwen3VlVisionModel::new(&config, VarBuilder::zeros(DType::BF16, &device)).unwrap();
+        let pixels = Tensor::zeros((4, 24), DType::F32, &device).unwrap();
+        let grid = Tensor::new(&[[1_u32, 2, 2]], &Device::Cpu).unwrap();
+        let (main, deepstack) = model.forward(&pixels, &grid, &mut |_| Ok(())).unwrap();
+        assert_eq!(main.dims(), [1, 12]);
+        assert_eq!(main.dtype(), DType::BF16);
+        assert_eq!(deepstack.len(), 3);
+        assert!(main
+            .to_device(&Device::Cpu)
+            .unwrap()
+            .to_dtype(DType::F32)
+            .unwrap()
+            .flatten_all()
+            .unwrap()
+            .to_vec1::<f32>()
+            .unwrap()
+            .iter()
+            .all(|value| value.is_finite()));
+    }
+}

--- a/crates/mold-inference/src/lib.rs
+++ b/crates/mold-inference/src/lib.rs
@@ -26,8 +26,9 @@ pub mod loader;
 pub mod ltx2;
 pub mod ltx_video;
 // The deterministic scheduler contract lands ahead of the license-gated H3
-// engine. Keeping it crate-private avoids advertising a runnable family while
-// leaving the exact math ready for the future pipeline to consume.
+// engine. Keeping these primitives crate-private avoids advertising a runnable
+// family while leaving exact math and conditioner lifecycle ready for the
+// future pipeline to consume.
 #[allow(dead_code)]
 pub(crate) mod minimax_h3;
 pub mod model_registry;

--- a/crates/mold-inference/src/minimax_h3/mod.rs
+++ b/crates/mold-inference/src/minimax_h3/mod.rs
@@ -9,9 +9,9 @@ pub(crate) mod sampler;
 use anyhow::{anyhow, Result};
 use candle_core::{Device, Tensor};
 use mold_candle::minimax_h3::{
-    load_prepared_bf16_conditioner, prepare_conditioner_assets, ConditionerArtifacts,
-    ConditionerCheckpoint, H3ConditionerInput, H3DTypeProfile, H3Layer50Conditioner,
-    PreparedH3ConditionerAssets, H3_BF16_PARAMETER_BYTES,
+    load_prepared_bf16_conditioner, prepare_conditioner_assets_with_progress, ArtifactError,
+    ConditionerArtifacts, ConditionerCheckpoint, H3ConditionerInput, H3DTypeProfile,
+    H3Layer50Conditioner, H3LoadError, PreparedH3ConditionerAssets, H3_BF16_PARAMETER_BYTES,
 };
 use std::time::Instant;
 use tokenizers::Tokenizer;
@@ -175,7 +175,30 @@ impl H3ConditionerLifecycle {
         progress.checkpoint()?;
         let started = Instant::now();
         progress.stage_start("Validating H3 Qwen3-VL tokenizer, processor, and checkpoint");
-        let prepared = prepare_conditioner_assets(artifacts)?;
+        let mut last_reported = None;
+        let prepared = prepare_conditioner_assets_with_progress(artifacts, &mut |verification| {
+            progress
+                .checkpoint()
+                .map_err(|_| ArtifactError::VerificationCancelled)?;
+            let should_report = last_reported.is_none_or(|previous| {
+                verification.total_bytes_verified.saturating_sub(previous) >= 64 * 1024 * 1024
+            }) || verification.total_bytes_verified == verification.total_bytes;
+            if should_report {
+                progress.weight_load(
+                    "Authenticating H3 Qwen3-VL artifacts",
+                    verification.total_bytes_verified,
+                    verification.total_bytes,
+                );
+                last_reported = Some(verification.total_bytes_verified);
+            }
+            Ok(())
+        });
+        let prepared = match prepared {
+            Err(H3LoadError::Artifact(ArtifactError::VerificationCancelled)) => {
+                return Err(InferenceCancelled.into());
+            }
+            result => result?,
+        };
         progress.checkpoint()?;
         progress.stage_done(
             "Validating H3 Qwen3-VL tokenizer, processor, and checkpoint",

--- a/crates/mold-inference/src/minimax_h3/mod.rs
+++ b/crates/mold-inference/src/minimax_h3/mod.rs
@@ -1,6 +1,427 @@
 //! MiniMax H3 inference primitives.
 //!
-//! H3 is not a runnable Mold family yet. This module contains only deterministic,
-//! non-weight contracts that can be verified before the model pipeline lands.
+//! H3 is not a runnable Mold family yet. This module contains deterministic
+//! sampler math plus a conditioner lifecycle that accepts only an already-
+//! frozen placement and issued component lease.
 
 pub(crate) mod sampler;
+
+use anyhow::{anyhow, Result};
+use candle_core::{Device, Tensor};
+use mold_candle::minimax_h3::{
+    load_prepared_bf16_conditioner, prepare_conditioner_assets, ConditionerArtifacts,
+    ConditionerCheckpoint, H3ConditionerInput, H3DTypeProfile, H3Layer50Conditioner,
+    PreparedH3ConditionerAssets, H3_BF16_PARAMETER_BYTES,
+};
+use std::time::Instant;
+use tokenizers::Tokenizer;
+
+use crate::progress::{InferenceCancelled, ProgressReporter};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum H3ConditionerExecution {
+    CudaResident,
+    CpuOffloaded,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct H3MemoryCharge {
+    pub resident_parameter_bytes: u64,
+    pub activation_workspace_bytes: u64,
+    pub charged_host_bytes: u64,
+    pub charged_vram_bytes: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FrozenH3ConditionerPlacement {
+    pub device_id: String,
+    pub execution: H3ConditionerExecution,
+    pub execution_fingerprint: String,
+    pub memory: H3MemoryCharge,
+}
+
+impl FrozenH3ConditionerPlacement {
+    pub fn new(
+        device_id: impl Into<String>,
+        execution: H3ConditionerExecution,
+        execution_fingerprint: impl Into<String>,
+        activation_workspace_bytes: u64,
+    ) -> Result<Self> {
+        if activation_workspace_bytes == 0 {
+            return Err(anyhow!(
+                "H3 conditioner placement must charge a nonzero activation workspace"
+            ));
+        }
+        let resident_parameter_bytes = H3_BF16_PARAMETER_BYTES;
+        let total = resident_parameter_bytes
+            .checked_add(activation_workspace_bytes)
+            .ok_or_else(|| anyhow!("H3 conditioner memory charge overflow"))?;
+        let (charged_host_bytes, charged_vram_bytes) = match execution {
+            H3ConditionerExecution::CudaResident => (0, total),
+            H3ConditionerExecution::CpuOffloaded => (total, 0),
+        };
+        let device_id = device_id.into();
+        let execution_fingerprint = execution_fingerprint.into();
+        if device_id.is_empty() || execution_fingerprint.is_empty() {
+            return Err(anyhow!(
+                "H3 conditioner placement requires device and execution identities"
+            ));
+        }
+        Ok(Self {
+            device_id,
+            execution,
+            execution_fingerprint,
+            memory: H3MemoryCharge {
+                resident_parameter_bytes,
+                activation_workspace_bytes,
+                charged_host_bytes,
+                charged_vram_bytes,
+            },
+        })
+    }
+
+    fn validate_lease(&self, lease: &impl H3ConditionerLease) -> Result<()> {
+        if lease.device_id() != self.device_id {
+            return Err(anyhow!(
+                "H3 conditioner lease is for {}, but the frozen plan requires {}; sibling-device borrowing is forbidden",
+                lease.device_id(),
+                self.device_id
+            ));
+        }
+        let backend_matches = match self.execution {
+            H3ConditionerExecution::CudaResident => lease.device().is_cuda(),
+            H3ConditionerExecution::CpuOffloaded => lease.device().is_cpu(),
+        };
+        if !backend_matches || lease.device().is_metal() {
+            return Err(anyhow!(
+                "H3 conditioner lease backend does not match frozen {:?} placement",
+                self.execution
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Scheduler-issued, attempt-scoped authority for exactly one device.
+pub trait H3ConditionerLease {
+    fn lease_id(&self) -> &str;
+    fn device_id(&self) -> &str;
+    fn device(&self) -> &Device;
+    fn release(&mut self);
+}
+
+struct LeaseReleaseGuard<'a, L: H3ConditionerLease> {
+    lease: &'a mut L,
+}
+
+impl<L: H3ConditionerLease> Drop for LeaseReleaseGuard<'_, L> {
+    fn drop(&mut self) {
+        self.lease.release();
+    }
+}
+
+fn validated_lease_guard<'a, L: H3ConditionerLease>(
+    placement: &FrozenH3ConditionerPlacement,
+    lease: &'a mut L,
+) -> Result<(LeaseReleaseGuard<'a, L>, Device, String, String)> {
+    let guard = LeaseReleaseGuard { lease };
+    placement.validate_lease(&*guard.lease)?;
+    let device = guard.lease.device().clone();
+    let device_id = guard.lease.device_id().to_string();
+    let lease_id = guard.lease.lease_id().to_string();
+    Ok((guard, device, device_id, lease_id))
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum H3LoadKind {
+    Cold,
+    WarmReload,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct H3LoadTelemetry {
+    pub kind: H3LoadKind,
+    pub device_id: String,
+    pub lease_id: String,
+    pub execution_fingerprint: String,
+    pub checkpoint_file_bytes: u64,
+    pub memory: H3MemoryCharge,
+    pub dtype_profile: H3DTypeProfile,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum H3LifecycleEvent {
+    Loaded(H3LoadTelemetry),
+    ReleasedBeforeDenoising {
+        device_id: String,
+        execution_fingerprint: String,
+    },
+    Cancelled {
+        device_id: String,
+        execution_fingerprint: String,
+    },
+}
+
+pub struct H3ConditionerLifecycle {
+    prepared: PreparedH3ConditionerAssets,
+    model: Option<H3Layer50Conditioner>,
+    loaded_route: Option<(String, String)>,
+    ever_loaded: bool,
+    telemetry: Vec<H3LifecycleEvent>,
+}
+
+impl H3ConditionerLifecycle {
+    pub fn prepare(artifacts: &ConditionerArtifacts, progress: &ProgressReporter) -> Result<Self> {
+        progress.checkpoint()?;
+        let started = Instant::now();
+        progress.stage_start("Validating H3 Qwen3-VL tokenizer, processor, and checkpoint");
+        let prepared = prepare_conditioner_assets(artifacts)?;
+        progress.checkpoint()?;
+        progress.stage_done(
+            "Validating H3 Qwen3-VL tokenizer, processor, and checkpoint",
+            started.elapsed(),
+        );
+        Ok(Self {
+            prepared,
+            model: None,
+            loaded_route: None,
+            ever_loaded: false,
+            telemetry: Vec::new(),
+        })
+    }
+
+    pub fn tokenizer(&self) -> &Tokenizer {
+        self.prepared.tokenizer()
+    }
+
+    pub fn telemetry(&self) -> &[H3LifecycleEvent] {
+        &self.telemetry
+    }
+
+    pub fn is_loaded(&self) -> bool {
+        self.model.is_some()
+    }
+
+    /// Load, encode on the exact leased route, then release all model weights
+    /// before returning the conditioning tensor to the denoising pipeline.
+    /// The retained tokenizer/processor state makes subsequent calls warm
+    /// reloads without retaining 51.5 GB of parameters.
+    ///
+    /// # Safety
+    ///
+    /// Frozen checkpoint files must remain immutable for the duration of this
+    /// call, matching Candle's mmaped-safetensors requirement.
+    pub unsafe fn encode_and_release_weights<L: H3ConditionerLease>(
+        &mut self,
+        input: &H3ConditionerInput,
+        placement: &FrozenH3ConditionerPlacement,
+        lease: &mut L,
+        progress: &ProgressReporter,
+    ) -> Result<Tensor> {
+        let (_release, device, device_id, lease_id) = validated_lease_guard(placement, lease)?;
+        progress.checkpoint()?;
+
+        let route = (
+            placement.execution_fingerprint.clone(),
+            placement.device_id.clone(),
+        );
+        if self.model.is_some() && self.loaded_route.as_ref() != Some(&route) {
+            return Err(anyhow!(
+                "loaded H3 conditioner route differs from the frozen placement; refusing implicit reroute"
+            ));
+        }
+        if self.model.is_none() {
+            let kind = if self.ever_loaded {
+                H3LoadKind::WarmReload
+            } else {
+                H3LoadKind::Cold
+            };
+            let stage = match kind {
+                H3LoadKind::Cold => "Cold loading H3 Qwen3-VL layer-50 conditioner",
+                H3LoadKind::WarmReload => "Warm reloading H3 Qwen3-VL layer-50 conditioner",
+            };
+            let started = Instant::now();
+            progress.stage_start(stage);
+            progress.weight_load(
+                "H3 Qwen3-VL layer-50 conditioner",
+                0,
+                self.prepared.checkpoint_file_bytes(),
+            );
+            // SAFETY: forwarded from this method's caller, on the exact leased
+            // device from the frozen placement.
+            let model = unsafe { load_prepared_bf16_conditioner(&self.prepared, &device)? };
+            progress.weight_load(
+                "H3 Qwen3-VL layer-50 conditioner",
+                self.prepared.checkpoint_file_bytes(),
+                self.prepared.checkpoint_file_bytes(),
+            );
+            progress.stage_done(stage, started.elapsed());
+            let dtype_profile = model.dtype_profile();
+            self.model = Some(model);
+            self.loaded_route = Some(route.clone());
+            self.ever_loaded = true;
+            self.telemetry
+                .push(H3LifecycleEvent::Loaded(H3LoadTelemetry {
+                    kind,
+                    device_id: device_id.clone(),
+                    lease_id,
+                    execution_fingerprint: placement.execution_fingerprint.clone(),
+                    checkpoint_file_bytes: self.prepared.checkpoint_file_bytes(),
+                    memory: placement.memory.clone(),
+                    dtype_profile,
+                }));
+        }
+
+        let vision_started = input.image.is_some() || input.video.is_some();
+        let vision_timer = vision_started.then(Instant::now);
+        if vision_started {
+            progress.stage_start("Encoding H3 Qwen3-VL vision references");
+        }
+        progress.stage_start("Running H3 Qwen3-VL language layers 0-49");
+        let language_timer = Instant::now();
+        let mut cancelled = false;
+        let encode_result =
+            self.model
+                .as_ref()
+                .expect("loaded above")
+                .encode(input, &mut |checkpoint| {
+                    if progress.checkpoint().is_err() {
+                        cancelled = true;
+                        return Err(candle_core::Error::Msg("H3 conditioner cancelled".into()));
+                    }
+                    match checkpoint {
+                        ConditionerCheckpoint::VisionLayer { completed, total }
+                            if completed == total || completed.is_multiple_of(5) =>
+                        {
+                            progress.info(&format!("H3 Qwen vision layer {completed}/{total}"));
+                        }
+                        ConditionerCheckpoint::LanguageLayer { completed, total }
+                            if completed == total || completed.is_multiple_of(5) =>
+                        {
+                            progress.info(&format!("H3 Qwen language layer {completed}/{total}"));
+                        }
+                        _ => {}
+                    }
+                    Ok(())
+                });
+
+        // Drop on success, cancellation, or any tensor error. No model or
+        // scheduler lease survives into denoising.
+        self.model = None;
+        self.loaded_route = None;
+        if cancelled {
+            self.telemetry.push(H3LifecycleEvent::Cancelled {
+                device_id,
+                execution_fingerprint: placement.execution_fingerprint.clone(),
+            });
+            return Err(InferenceCancelled.into());
+        }
+        let output = encode_result?;
+        if let Some(started) = vision_timer {
+            progress.stage_done("Encoding H3 Qwen3-VL vision references", started.elapsed());
+        }
+        progress.stage_done(
+            "Running H3 Qwen3-VL language layers 0-49",
+            language_timer.elapsed(),
+        );
+        self.telemetry
+            .push(H3LifecycleEvent::ReleasedBeforeDenoising {
+                device_id,
+                execution_fingerprint: placement.execution_fingerprint.clone(),
+            });
+        Ok(output)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    };
+
+    struct TestLease {
+        id: String,
+        device_id: String,
+        device: Device,
+        released: Arc<AtomicBool>,
+    }
+
+    impl H3ConditionerLease for TestLease {
+        fn lease_id(&self) -> &str {
+            &self.id
+        }
+
+        fn device_id(&self) -> &str {
+            &self.device_id
+        }
+
+        fn device(&self) -> &Device {
+            &self.device
+        }
+
+        fn release(&mut self) {
+            self.released.store(true, Ordering::Release);
+        }
+    }
+
+    #[test]
+    fn placement_charges_exact_parameters_and_workspace() {
+        let placement = FrozenH3ConditionerPlacement::new(
+            "cpu",
+            H3ConditionerExecution::CpuOffloaded,
+            "frozen",
+            2_000_000_000,
+        )
+        .unwrap();
+        assert_eq!(
+            placement.memory.resident_parameter_bytes,
+            H3_BF16_PARAMETER_BYTES
+        );
+        assert_eq!(placement.memory.charged_vram_bytes, 0);
+        assert_eq!(
+            placement.memory.charged_host_bytes,
+            H3_BF16_PARAMETER_BYTES + 2_000_000_000
+        );
+    }
+
+    #[test]
+    fn lease_guard_releases_on_error_and_rejects_sibling_route() {
+        let released = Arc::new(AtomicBool::new(false));
+        let mut lease = TestLease {
+            id: "lease".into(),
+            device_id: "cpu-b".into(),
+            device: Device::Cpu,
+            released: Arc::clone(&released),
+        };
+        let placement = FrozenH3ConditionerPlacement::new(
+            "cpu-a",
+            H3ConditionerExecution::CpuOffloaded,
+            "frozen",
+            1,
+        )
+        .unwrap();
+        assert!(validated_lease_guard(&placement, &mut lease).is_err());
+        assert!(released.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn metal_or_backend_mismatch_is_rejected_before_load() {
+        let released = Arc::new(AtomicBool::new(false));
+        let lease = TestLease {
+            id: "lease".into(),
+            device_id: "cpu".into(),
+            device: Device::Cpu,
+            released,
+        };
+        let placement = FrozenH3ConditionerPlacement::new(
+            "cpu",
+            H3ConditionerExecution::CudaResident,
+            "frozen",
+            1,
+        )
+        .unwrap();
+        assert!(placement.validate_lease(&lease).is_err());
+    }
+}


### PR DESCRIPTION
## Summary

- add the exact Qwen3-VL-32B vision tower, first 50 language layers, interleaved mRoPE, DeepStack injection, and unnormalized layer-50 output used by MiniMax H3
- reproduce raw text, FL2VA, and ordered heterogeneous Ref2VA presentations, including Qwen 2 fps video sampling, temporal-pair padding, vision patch packing, and separate Qwen/H3 modality tags
- validate exact config, tokenizer, processor, tensor shapes, BF16 payload, and all checkpoint keys under one explicit namespace: either official Transformers or Comfy's pruned layer-50 layout; mixed layouts fail closed
- add a frozen-placement conditioner lifecycle with exact 51,506,191,840-byte parameter charging, retained tokenizer/processor state, cold versus warm telemetry, progress/cancellation checkpoints, exact-device lease enforcement, and RAII release before denoising

## Audit hardening

- authenticate the exact license-reviewed H3 config, tokenizer, tokenizer config, image processor, and video processor by pinned byte size and SHA-256, including same-size corruption fixtures
- bind official namespace checkpoints to the complete 66,746,972,096-byte payload and complete tail key set, while binding Comfy's layer-50 namespace to the pruned 51,506,191,840-byte payload with no tail keys; cross-products fail closed
- hash every frozen artifact exactly once during preparation in cancellable 8 MiB chunks with aggregate progress; warm reloads use cheap file identity checks instead of re-reading 51.5-66.7 GB
- parse only bounded safetensors headers in the safe preparation API, avoiding a payload mmap until the explicitly unsafe Candle load boundary

## Safety boundary

- the H3 inference module remains crate-private and no factory, registry, manifest, catalog, capability, server route, or surface advertises a runnable H3 family
- Mold's existing MiniMax H3 authorization guard remains unchanged
- no H3 model weights were downloaded or executed; validation used code/metadata and tiny synthetic tensors only

## Validation

- `nix develop --command cargo fmt --all -- --check`
- `nix develop --command cargo test -p mold-ai-candle minimax_h3 --lib` — 31 passed
- `nix develop --command cargo test -p mold-ai-inference minimax_h3 --lib` — 13 passed, including the already-landed H3 sampler tests
- `nix develop --command cargo clippy -p mold-ai-candle -p mold-ai-inference --lib -- -D warnings`
- `nix develop --command cargo check -p mold-ai-inference --features metal`
- Plato L40S: `nix develop --command cargo test -p mold-ai-candle minimax_h3 --features cuda -- --nocapture` — 33 passed, including BF16 text and vision execution with FP32 RoPE/softmax boundaries
- Plato L40S: `nix develop --command cargo clippy -p mold-ai-candle -p mold-ai-inference --lib --features cuda -- -D warnings`

The first CUDA run caught a non-contiguous vision-attention matmul that CPU accepted. The fixed path makes Q/K/V and transposed K contiguous, and the BF16 CUDA fixture covers that regression.

## Deferred qualification

- real layer-50 hidden-state parity for text, image, video, image+audio, soundtrack, and mixed-order cases remains blocked on the authorized #832 golden corpus and MiniMax license resolution
- the processor currently consumes already-resized RGB tensors; exact end-to-end media resize/decode integration belongs with the core/runtime contracts in #816
- INT8/NVFP4 loading, memory-efficient attention, and block streaming are separate performance work; this PR is the exact BF16 correctness/lifecycle foundation
- public activation and real-weight UAT remain intentionally blocked

Refs #815
