### PR TITLE
feat(h3): add visual VAE primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3137,6 +3137,7 @@ name = "mold-ai-candle"
 version = "0.21.0"
 dependencies = [
  "candle-core",
+ "candle-flash-attn",
  "candle-nn",
  "candle-transformers",
  "serde",

--- a/crates/mold-candle/Cargo.toml
+++ b/crates/mold-candle/Cargo.toml
@@ -14,11 +14,13 @@ name = "mold_candle"
 default = []
 cuda = ["candle/cuda", "candle-nn/cuda", "candle-transformers/cuda"]
 metal = ["candle/metal", "candle-nn/metal", "candle-transformers/metal"]
+flash-attn = ["dep:candle-flash-attn", "cuda"]
 
 [dependencies]
 candle = { package = "candle-core", version = "0.11" }
 candle-nn = "0.11"
 candle-transformers = "0.11"
+candle-flash-attn = { version = "0.11", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"

--- a/crates/mold-candle/src/minimax_h3/mod.rs
+++ b/crates/mold-candle/src/minimax_h3/mod.rs
@@ -11,6 +11,10 @@ mod model;
 mod presentation;
 mod processor;
 mod text;
+mod visual_condition;
+mod visual_geometry;
+mod visual_vae;
+mod visual_weights;
 mod vision;
 
 pub mod audio;
@@ -53,4 +57,22 @@ pub use presentation::{
 pub use processor::{
     create_mm_token_type_ids, pack_qwen_vision_u8, qwen_mrope_positions, sample_video_frames,
     GridThw, PackedVisionPatches, QwenMmTokenType, SampledVideo,
+};
+pub use visual_condition::{
+    ConditionEncodeMode, SignedRgbPixels, Uint8RgbPixels, UnitRgbPixels, H3_IMAGENET_MEAN,
+    H3_IMAGENET_STD, H3_LATENTS_MEAN, H3_LATENTS_STD,
+};
+pub use visual_geometry::{
+    EndpointResizePlan, ReferenceImageResizePlan, SpatialTilePlan, TemporalDecodeChunk,
+    TemporalDecodePlan, TemporalEncodeChunk, TemporalEncodePlan, VisualTemporalGeometry,
+};
+pub use visual_vae::{
+    DecodeComputePolicy, DecodeSink, MiniMaxH3VisualVae, MiniMaxH3VisualVaeConfig,
+    NoopVisualVaeObserver, VisualVaeEvent, VisualVaeObserver, VisualVaePhase, WeightLayout,
+};
+pub use visual_weights::{
+    comfy_tensor_transforms, component_fingerprint, expected_diffusers_weight_shapes,
+    inspect_safetensors_header, inspect_visual_vae_config, validate_diffusers_weight_index,
+    ComfyTensorTransform, DiffusersWeightIndex, SafetensorsHeader, SafetensorsTensorHeader,
+    VisualVaeComponentRole, VisualVaeWeightInspection,
 };

--- a/crates/mold-candle/src/minimax_h3/mod.rs
+++ b/crates/mold-candle/src/minimax_h3/mod.rs
@@ -11,11 +11,11 @@ mod model;
 mod presentation;
 mod processor;
 mod text;
+mod vision;
 mod visual_condition;
 mod visual_geometry;
 mod visual_vae;
 mod visual_weights;
-mod vision;
 
 pub mod audio;
 pub mod audio_config;
@@ -68,11 +68,14 @@ pub use visual_geometry::{
 };
 pub use visual_vae::{
     DecodeComputePolicy, DecodeSink, MiniMaxH3VisualVae, MiniMaxH3VisualVaeConfig,
-    NoopVisualVaeObserver, VisualVaeEvent, VisualVaeObserver, VisualVaePhase, WeightLayout,
+    NoopVisualVaeObserver, VisualAttentionBackend, VisualVaeEvent, VisualVaeObserver,
+    VisualVaePhase, WeightLayout,
 };
 pub use visual_weights::{
-    comfy_tensor_transforms, component_fingerprint, expected_diffusers_weight_shapes,
-    inspect_safetensors_header, inspect_visual_vae_config, validate_diffusers_weight_index,
-    ComfyTensorTransform, DiffusersWeightIndex, SafetensorsHeader, SafetensorsTensorHeader,
-    VisualVaeComponentRole, VisualVaeWeightInspection,
+    comfy_tensor_transforms, component_fingerprint, component_fingerprint_with_observer,
+    expected_comfy_weight_shapes, expected_diffusers_weight_shapes, inspect_safetensors_header,
+    inspect_visual_vae_config, validate_comfy_weight_file, validate_diffusers_weight_index,
+    ComfyTensorTransform, DiffusersWeightIndex, NoopVisualWeightReadObserver, SafetensorsHeader,
+    SafetensorsTensorHeader, ValidatedVisualVaeWeights, VisualVaeComponentRole,
+    VisualVaeWeightInspection, VisualWeightReadObserver, COMFY_VISUAL_VAE_FILENAME,
 };

--- a/crates/mold-candle/src/minimax_h3/visual_condition.rs
+++ b/crates/mold-candle/src/minimax_h3/visual_condition.rs
@@ -1,0 +1,535 @@
+use candle::{bail, DType, Device, IndexOp, Result, Tensor};
+
+pub const H3_IMAGENET_MEAN: [f32; 3] = [0.485, 0.456, 0.406];
+pub const H3_IMAGENET_STD: [f32; 3] = [0.229, 0.224, 0.225];
+
+pub const H3_LATENTS_MEAN: [f32; 24] = [
+    0.85809034,
+    -0.96065915,
+    1.066164,
+    -0.50903255,
+    -0.2727582,
+    -1.3675414,
+    -0.2553255,
+    -0.26907554,
+    -0.5376841,
+    -0.04640973,
+    0.66573703,
+    0.19690128,
+    -0.5460608,
+    -0.4035342,
+    -0.23683025,
+    0.25928453,
+    -0.30133945,
+    0.21134199,
+    -1.1206849,
+    0.35819334,
+    -0.042251438,
+    0.260483,
+    0.22864093,
+    0.7056032,
+];
+
+pub const H3_LATENTS_STD: [f32; 24] = [
+    1.2223774, 1.2767264, 1.6831775, 1.7549455, 1.5636216, 2.1941435, 0.9653138, 1.0569886,
+    0.8419489, 0.7729953, 1.8955938, 0.94684184, 0.79968095, 0.449889, 0.71974, 0.6936293,
+    2.961095, 2.76942, 3.0496185, 2.1088054, 3.2762263, 3.1627357, 2.2816813, 2.6127844,
+];
+
+/// The released conditioning contract is stochastic and is the default.
+/// ComfyUI's mean-only shortcut is exposed only under an explicit name.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ConditionEncodeMode {
+    #[default]
+    OfficialFreshSeed42,
+    ComfyMeanOnly,
+}
+
+/// One RGB condition in the official uint8 input domain.
+#[derive(Clone, Debug)]
+pub struct Uint8RgbPixels(Tensor);
+
+impl Uint8RgbPixels {
+    pub fn new(tensor: Tensor) -> Result<Self> {
+        validate_rgb_condition_shape(&tensor)?;
+        if tensor.dtype() != DType::U8 {
+            bail!(
+                "H3 uint8 condition requires U8 pixels, got {:?}; use UnitRgbPixels for [0,1] float input",
+                tensor.dtype()
+            )
+        }
+        Ok(Self(tensor))
+    }
+
+    pub(crate) fn into_imagenet(self) -> Result<ImageNetPixels> {
+        let unit = self.0.to_dtype(DType::F32)?.affine(1.0 / 255.0, 0.0)?;
+        normalize_imagenet(unit)
+    }
+}
+
+/// One RGB condition in an explicitly typed floating-point `[0,1]` domain.
+#[derive(Clone, Debug)]
+pub struct UnitRgbPixels(Tensor);
+
+impl UnitRgbPixels {
+    pub fn new(tensor: Tensor) -> Result<Self> {
+        validate_rgb_condition_shape(&tensor)?;
+        if !matches!(
+            tensor.dtype(),
+            DType::F16 | DType::BF16 | DType::F32 | DType::F64
+        ) {
+            bail!("H3 unit RGB condition requires a floating-point tensor")
+        }
+        let f32_tensor = tensor.to_dtype(DType::F32)?;
+        let min = f32_tensor.min_all()?.to_scalar::<f32>()?;
+        let max = f32_tensor.max_all()?.to_scalar::<f32>()?;
+        if min < 0.0 || max > 1.0 || !min.is_finite() || !max.is_finite() {
+            bail!("H3 unit RGB condition must be finite and within [0,1], got [{min},{max}]")
+        }
+        Ok(Self(f32_tensor))
+    }
+
+    pub(crate) fn into_imagenet(self) -> Result<ImageNetPixels> {
+        normalize_imagenet(self.0)
+    }
+}
+
+/// One RGB condition in ComfyUI's public floating-point `[-1,1]` domain.
+/// Keeping this distinct from [`UnitRgbPixels`] prevents a silent 0.5 offset.
+#[derive(Clone, Debug)]
+pub struct SignedRgbPixels(Tensor);
+
+impl SignedRgbPixels {
+    pub fn new(tensor: Tensor) -> Result<Self> {
+        validate_rgb_condition_shape(&tensor)?;
+        if !matches!(
+            tensor.dtype(),
+            DType::F16 | DType::BF16 | DType::F32 | DType::F64
+        ) {
+            bail!("H3 signed RGB condition requires a floating-point tensor")
+        }
+        let f32_tensor = tensor.to_dtype(DType::F32)?;
+        let min = f32_tensor.min_all()?.to_scalar::<f32>()?;
+        let max = f32_tensor.max_all()?.to_scalar::<f32>()?;
+        if min < -1.0 || max > 1.0 || !min.is_finite() || !max.is_finite() {
+            bail!("H3 signed RGB condition must be finite and within [-1,1], got [{min},{max}]")
+        }
+        Ok(Self(f32_tensor))
+    }
+
+    pub(crate) fn into_imagenet(self) -> Result<ImageNetPixels> {
+        normalize_imagenet(self.0.affine(0.5, 0.5)?)
+    }
+}
+
+/// RGB already transformed into the VAE's ImageNet-normalized pixel domain.
+#[derive(Clone, Debug)]
+pub struct ImageNetPixels(Tensor);
+
+impl ImageNetPixels {
+    pub(crate) fn into_tensor(self) -> Tensor {
+        self.0
+    }
+}
+
+fn validate_rgb_condition_shape(tensor: &Tensor) -> Result<()> {
+    let (batch, channels, frames, height, width) = tensor.dims5()?;
+    if batch != 1 || channels != 3 || frames == 0 || height == 0 || width == 0 {
+        bail!(
+            "H3 visual condition must be [1,3,T,H,W] with positive dimensions, got {:?}",
+            tensor.dims()
+        )
+    }
+    Ok(())
+}
+
+fn normalize_imagenet(unit: Tensor) -> Result<ImageNetPixels> {
+    let device = unit.device();
+    let mean = Tensor::from_slice(&H3_IMAGENET_MEAN, (1, 3, 1, 1, 1), device)?;
+    let std = Tensor::from_slice(&H3_IMAGENET_STD, (1, 3, 1, 1, 1), device)?;
+    Ok(ImageNetPixels(
+        unit.broadcast_sub(&mean)?.broadcast_div(&std)?,
+    ))
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct DiagonalGaussianDistribution {
+    mean: Tensor,
+    logvar: Tensor,
+}
+
+impl DiagonalGaussianDistribution {
+    pub(crate) fn from_moments(moments: &Tensor) -> Result<Self> {
+        let (_, channels, _, _, _) = moments.dims5()?;
+        if channels == 0 || channels % 2 != 0 {
+            bail!("H3 posterior moments require an even nonzero channel count, got {channels}")
+        }
+        let latent_channels = channels / 2;
+        let moments = moments.to_dtype(DType::F32)?;
+        Ok(Self {
+            mean: moments
+                .i((.., ..latent_channels, .., .., ..))?
+                .contiguous()?,
+            logvar: moments
+                .i((.., latent_channels.., .., .., ..))?
+                .clamp(-30.0, 20.0)?
+                .contiguous()?,
+        })
+    }
+
+    pub(crate) fn condition_latents(
+        &self,
+        mode: ConditionEncodeMode,
+        latents_mean: &[f32],
+        latents_std: &[f32],
+    ) -> Result<Tensor> {
+        let latent = match mode {
+            ConditionEncodeMode::OfficialFreshSeed42 => {
+                let std = self.logvar.affine(0.5, 0.0)?.exp()?;
+                let noise = fresh_seed42_noise(self.mean.shape())?.to_device(self.mean.device())?;
+                // The official generator is CPU-owned and independent from
+                // request/denoiser noise. The sampled latent is then rounded
+                // through FP16 before normalization.
+                self.mean
+                    .add(&std.mul(&noise)?)?
+                    .to_dtype(DType::F16)?
+                    .to_dtype(DType::F32)?
+                    .to_device(&Device::Cpu)?
+            }
+            ConditionEncodeMode::ComfyMeanOnly => self.mean.to_device(&Device::Cpu)?,
+        };
+        normalize_latents(&latent, latents_mean, latents_std)
+    }
+}
+
+/// A fresh local generator per condition is the authority boundary. Using a
+/// process/global Candle RNG here would couple posterior samples to unrelated
+/// model noise and violate the official recipe.
+fn fresh_seed42_noise(shape: &candle::Shape) -> Result<Tensor> {
+    let values = pytorch_cpu_randn_f32(shape.elem_count(), 42);
+    Tensor::from_vec(values, shape.clone(), &Device::Cpu)
+}
+
+/// PyTorch's CPU `torch.randn(..., generator=torch.Generator().manual_seed(seed))`
+/// recipe for a contiguous FP32 tensor. H3 creates that CPU generator afresh
+/// for every condition, even when the VAE itself is on a GPU.
+fn pytorch_cpu_randn_f32(size: usize, seed: u64) -> Vec<f32> {
+    let mut generator = TorchMt19937::new(seed);
+    if size < 16 {
+        let mut output = Vec::with_capacity(size);
+        let mut cached = None;
+        while output.len() < size {
+            if let Some(value) = cached.take() {
+                output.push(value as f32);
+                continue;
+            }
+            let u1 = generator.uniform_f64();
+            let u2 = generator.uniform_f64();
+            let radius = (-2.0 * (-u2).ln_1p()).sqrt();
+            let theta = 2.0 * std::f64::consts::PI * u1;
+            cached = Some(radius * theta.sin());
+            output.push((radius * theta.cos()) as f32);
+        }
+        return output;
+    }
+
+    let mut output = (0..size)
+        .map(|_| generator.uniform_f32())
+        .collect::<Vec<_>>();
+    let mut offset = 0;
+    while offset + 16 <= size {
+        torch_normal_fill_16(&mut output[offset..offset + 16]);
+        offset += 16;
+    }
+    // PyTorch deliberately regenerates and recomputes the final 16 values for
+    // a non-multiple length rather than transforming a partial block.
+    if !size.is_multiple_of(16) {
+        let offset = size - 16;
+        for value in &mut output[offset..] {
+            *value = generator.uniform_f32();
+        }
+        torch_normal_fill_16(&mut output[offset..]);
+    }
+    output
+}
+
+fn torch_normal_fill_16(data: &mut [f32]) {
+    debug_assert_eq!(data.len(), 16);
+    for pair in 0..8 {
+        let u1 = 1.0 - data[pair];
+        let u2 = data[pair + 8];
+        let radius = (-2.0 * u1.ln()).sqrt();
+        let theta = 2.0 * std::f32::consts::PI * u2;
+        data[pair] = radius * theta.cos();
+        data[pair + 8] = radius * theta.sin();
+    }
+}
+
+/// PyTorch's `at::mt19937_engine`; this is intentionally not Rust's
+/// `StdRng`, whose seed-42 stream differs from the released conditioner.
+struct TorchMt19937 {
+    state: [u32; 624],
+    left: usize,
+    next: usize,
+}
+
+impl TorchMt19937 {
+    fn new(seed: u64) -> Self {
+        let mut state = [0u32; 624];
+        state[0] = seed as u32;
+        for index in 1..state.len() {
+            state[index] = 1_812_433_253u32
+                .wrapping_mul(state[index - 1] ^ (state[index - 1] >> 30))
+                .wrapping_add(index as u32);
+        }
+        Self {
+            state,
+            left: 1,
+            next: 0,
+        }
+    }
+
+    fn random_u32(&mut self) -> u32 {
+        self.left -= 1;
+        if self.left == 0 {
+            self.next_state();
+        }
+        let mut value = self.state[self.next];
+        self.next += 1;
+        value ^= value >> 11;
+        value ^= (value << 7) & 0x9d2c_5680;
+        value ^= (value << 15) & 0xefc6_0000;
+        value ^ (value >> 18)
+    }
+
+    fn random_u64(&mut self) -> u64 {
+        (u64::from(self.random_u32()) << 32) | u64::from(self.random_u32())
+    }
+
+    fn uniform_f32(&mut self) -> f32 {
+        const MASK: u32 = (1 << 24) - 1;
+        (self.random_u32() & MASK) as f32 * (1.0 / (1u32 << 24) as f32)
+    }
+
+    fn uniform_f64(&mut self) -> f64 {
+        const MASK: u64 = (1 << 53) - 1;
+        (self.random_u64() & MASK) as f64 * (1.0 / (1u64 << 53) as f64)
+    }
+
+    fn next_state(&mut self) {
+        const N: usize = 624;
+        const M: usize = 397;
+        for index in 0..(N - M) {
+            self.state[index] =
+                self.state[index + M] ^ Self::twist(self.state[index], self.state[index + 1]);
+        }
+        for index in (N - M)..(N - 1) {
+            self.state[index] =
+                self.state[index + M - N] ^ Self::twist(self.state[index], self.state[index + 1]);
+        }
+        self.state[N - 1] = self.state[M - 1] ^ Self::twist(self.state[N - 1], self.state[0]);
+        self.left = N;
+        self.next = 0;
+    }
+
+    fn twist(first: u32, second: u32) -> u32 {
+        let mixed = (first & 0x8000_0000) | (second & 0x7fff_ffff);
+        (mixed >> 1) ^ if second & 1 == 1 { 0x9908_b0df } else { 0 }
+    }
+}
+
+pub(crate) fn normalize_latents(
+    latent: &Tensor,
+    latents_mean: &[f32],
+    latents_std: &[f32],
+) -> Result<Tensor> {
+    let (_, channels, _, _, _) = latent.dims5()?;
+    if latents_mean.len() != channels || latents_std.len() != channels {
+        bail!(
+            "H3 latent statistics require {channels} channels, got mean={} std={}",
+            latents_mean.len(),
+            latents_std.len()
+        )
+    }
+    if latents_std
+        .iter()
+        .any(|value| !value.is_finite() || *value <= 0.0)
+    {
+        bail!("H3 latent standard deviations must be finite and positive")
+    }
+    let mean = Tensor::from_slice(latents_mean, (1, channels, 1, 1, 1), latent.device())?;
+    let std = Tensor::from_slice(latents_std, (1, channels, 1, 1, 1), latent.device())?;
+    latent.broadcast_sub(&mean)?.broadcast_div(&std)
+}
+
+pub(crate) fn denormalize_latents(
+    latent: &Tensor,
+    latents_mean: &[f32],
+    latents_std: &[f32],
+) -> Result<Tensor> {
+    let (_, channels, _, _, _) = latent.dims5()?;
+    if latents_mean.len() != channels || latents_std.len() != channels {
+        bail!("H3 latent statistics do not match the decode tensor")
+    }
+    let mean = Tensor::from_slice(latents_mean, (1, channels, 1, 1, 1), latent.device())?;
+    let std = Tensor::from_slice(latents_std, (1, channels, 1, 1, 1), latent.device())?;
+    latent.broadcast_mul(&std)?.broadcast_add(&mean)
+}
+
+pub(crate) fn denormalize_imagenet(pixels: &Tensor) -> Result<Tensor> {
+    let device = pixels.device();
+    let mean = Tensor::from_slice(&H3_IMAGENET_MEAN, (1, 3, 1, 1, 1), device)?;
+    let std = Tensor::from_slice(&H3_IMAGENET_STD, (1, 3, 1, 1, 1), device)?;
+    pixels
+        .to_dtype(DType::F32)?
+        .broadcast_mul(&std)?
+        .broadcast_add(&mean)?
+        .clamp(0.0, 1.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn typed_pixel_domains_are_distinct_but_normalize_identically() {
+        let u8_pixels =
+            Tensor::from_vec(vec![0u8, 128, 255], (1, 3, 1, 1, 1), &Device::Cpu).unwrap();
+        let unit_pixels = Tensor::from_vec(
+            vec![0.0f32, 128.0 / 255.0, 1.0],
+            (1, 3, 1, 1, 1),
+            &Device::Cpu,
+        )
+        .unwrap();
+        let signed_pixels = Tensor::from_vec(
+            vec![-1.0f32, 2.0 * (128.0 / 255.0) - 1.0, 1.0],
+            (1, 3, 1, 1, 1),
+            &Device::Cpu,
+        )
+        .unwrap();
+        let from_u8 = Uint8RgbPixels::new(u8_pixels)
+            .unwrap()
+            .into_imagenet()
+            .unwrap()
+            .into_tensor();
+        let from_unit = UnitRgbPixels::new(unit_pixels)
+            .unwrap()
+            .into_imagenet()
+            .unwrap()
+            .into_tensor();
+        let from_signed = SignedRgbPixels::new(signed_pixels)
+            .unwrap()
+            .into_imagenet()
+            .unwrap()
+            .into_tensor();
+        let delta = from_u8
+            .sub(&from_unit)
+            .unwrap()
+            .abs()
+            .unwrap()
+            .max_all()
+            .unwrap();
+        assert!(delta.to_scalar::<f32>().unwrap() < 1e-6);
+        let signed_delta = from_u8
+            .sub(&from_signed)
+            .unwrap()
+            .abs()
+            .unwrap()
+            .max_all()
+            .unwrap();
+        assert!(signed_delta.to_scalar::<f32>().unwrap() < 1e-6);
+        assert!(Uint8RgbPixels::new(
+            Tensor::zeros((1, 3, 1, 1, 1), DType::F32, &Device::Cpu).unwrap()
+        )
+        .is_err());
+        assert!(
+            UnitRgbPixels::new(Tensor::full(1.1f32, (1, 3, 1, 1, 1), &Device::Cpu).unwrap())
+                .is_err()
+        );
+        assert!(SignedRgbPixels::new(
+            Tensor::full(-1.1f32, (1, 3, 1, 1, 1), &Device::Cpu).unwrap()
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn official_posterior_is_fresh_seed42_and_domain_independent() {
+        let means = Tensor::zeros((1, 2, 1, 1, 3), DType::F32, &Device::Cpu).unwrap();
+        let logvars = Tensor::zeros((1, 2, 1, 1, 3), DType::F32, &Device::Cpu).unwrap();
+        let posterior = DiagonalGaussianDistribution::from_moments(
+            &Tensor::cat(&[&means, &logvars], 1).unwrap(),
+        )
+        .unwrap();
+        let first = posterior
+            .condition_latents(
+                ConditionEncodeMode::OfficialFreshSeed42,
+                &[0.0, 0.0],
+                &[1.0, 1.0],
+            )
+            .unwrap();
+        // Consume unrelated random values. The next condition must still use
+        // its own seed-42 stream rather than global/request RNG state.
+        let _ = Tensor::randn(0.0f32, 1.0f32, (4096,), &Device::Cpu).unwrap();
+        let second = posterior
+            .condition_latents(
+                ConditionEncodeMode::OfficialFreshSeed42,
+                &[0.0, 0.0],
+                &[1.0, 1.0],
+            )
+            .unwrap();
+        assert_eq!(
+            first.flatten_all().unwrap().to_vec1::<f32>().unwrap(),
+            second.flatten_all().unwrap().to_vec1::<f32>().unwrap()
+        );
+        assert_ne!(
+            first.flatten_all().unwrap().to_vec1::<f32>().unwrap(),
+            posterior
+                .condition_latents(ConditionEncodeMode::ComfyMeanOnly, &[0.0, 0.0], &[1.0, 1.0])
+                .unwrap()
+                .flatten_all()
+                .unwrap()
+                .to_vec1::<f32>()
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn seed42_noise_matches_pytorch_cpu_reference_stream() {
+        // `torch.randn(16, generator=torch.Generator().manual_seed(42))`.
+        // The scalar math can differ by a few ULP from PyTorch's AVX2
+        // approximation, which is immaterial after the required FP16 round trip.
+        let expected = [
+            1.9269, 1.4873, 0.9007, -2.1055, 0.6784, -1.2345, -0.0431, -1.6047, -0.7521, 1.6487,
+            -0.3925, -1.4036, -0.7279, -0.5594, -0.7688, 0.7624,
+        ];
+        let actual = pytorch_cpu_randn_f32(16, 42);
+        for (actual, expected) in actual.iter().zip(expected) {
+            assert!((actual - expected).abs() < 5e-4, "{actual} != {expected}");
+        }
+    }
+
+    #[test]
+    fn fp16_round_trip_happens_before_latent_normalization() {
+        let mean = Tensor::from_vec(vec![0.33333334f32], (1, 1, 1, 1, 1), &Device::Cpu).unwrap();
+        let logvar = Tensor::full(-30.0f32, (1, 1, 1, 1, 1), &Device::Cpu).unwrap();
+        let posterior =
+            DiagonalGaussianDistribution::from_moments(&Tensor::cat(&[&mean, &logvar], 1).unwrap())
+                .unwrap();
+        let actual = posterior
+            .condition_latents(ConditionEncodeMode::OfficialFreshSeed42, &[0.1], &[0.2])
+            .unwrap()
+            .flatten_all()
+            .unwrap()
+            .to_vec1::<f32>()
+            .unwrap()[0];
+        let rounded = Tensor::from_slice(&[0.33333334f32], 1, &Device::Cpu)
+            .unwrap()
+            .to_dtype(DType::F16)
+            .unwrap()
+            .to_dtype(DType::F32)
+            .unwrap()
+            .to_vec1::<f32>()
+            .unwrap()[0];
+        assert!((actual - (rounded - 0.1) / 0.2).abs() < 1e-3);
+    }
+}

--- a/crates/mold-candle/src/minimax_h3/visual_geometry.rs
+++ b/crates/mold-candle/src/minimax_h3/visual_geometry.rs
@@ -1,0 +1,564 @@
+use candle::{bail, Result};
+
+/// The released H3 visual VAE's temporal chunk contract.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct VisualTemporalGeometry {
+    pub clip_length: usize,
+    pub token_drop: usize,
+    pub temporal_compression: usize,
+}
+
+impl Default for VisualTemporalGeometry {
+    fn default() -> Self {
+        Self {
+            clip_length: 17,
+            token_drop: 3,
+            temporal_compression: 4,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TemporalEncodeChunk {
+    pub input_start: usize,
+    pub valid_frames: usize,
+    pub repeated_tail_frames: usize,
+}
+
+/// A bounded-memory encode plan. Chunks are independent causal evaluations;
+/// no activation from one 17-frame chunk is carried into the next.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TemporalEncodePlan {
+    pub chunks: Vec<TemporalEncodeChunk>,
+    pub latent_frames_before_drop: usize,
+    pub latent_frames: usize,
+    pub trailing_latents_to_drop: usize,
+    pub single_frame: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TemporalDecodeChunk {
+    pub latent_start: usize,
+    pub latent_frames: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TemporalDecodePlan {
+    pub chunks: Vec<TemporalDecodeChunk>,
+    pub repeated_tail_tokens: usize,
+    pub output_frames: usize,
+    pub tokens_per_chunk: usize,
+    pub token_overlap: usize,
+    pub frame_pre_padding: usize,
+    pub frame_overlap: usize,
+}
+
+impl VisualTemporalGeometry {
+    pub fn validate(self) -> Result<()> {
+        if self.clip_length == 0 || self.temporal_compression == 0 {
+            bail!("H3 visual VAE clip length and temporal compression must be positive")
+        }
+        let tokens = self.tokens_per_chunk();
+        if self.token_drop >= tokens {
+            bail!(
+                "H3 visual VAE token_drop {} must be smaller than tokens_per_chunk {}",
+                self.token_drop,
+                tokens
+            )
+        }
+        Ok(())
+    }
+
+    pub const fn tokens_per_chunk(self) -> usize {
+        self.clip_length.div_ceil(self.temporal_compression)
+    }
+
+    pub const fn frame_pre_padding(self) -> usize {
+        (self.temporal_compression - self.clip_length % self.temporal_compression)
+            % self.temporal_compression
+    }
+
+    pub const fn token_overlap(self) -> usize {
+        (self.tokens_per_chunk() - self.token_drop % self.tokens_per_chunk())
+            % self.tokens_per_chunk()
+    }
+
+    pub const fn frame_overlap(self) -> usize {
+        self.token_overlap()
+            .saturating_mul(self.temporal_compression)
+            .saturating_sub(self.frame_pre_padding())
+    }
+
+    pub fn encode_plan(self, pixel_frames: usize) -> Result<TemporalEncodePlan> {
+        self.validate()?;
+        if pixel_frames == 0 {
+            bail!("H3 visual VAE cannot encode an empty frame sequence")
+        }
+        if pixel_frames == 1 {
+            return Ok(TemporalEncodePlan {
+                chunks: vec![TemporalEncodeChunk {
+                    input_start: 0,
+                    valid_frames: 1,
+                    repeated_tail_frames: 0,
+                }],
+                latent_frames_before_drop: 1,
+                latent_frames: 1,
+                trailing_latents_to_drop: 0,
+                single_frame: true,
+            });
+        }
+
+        let num_chunks = pixel_frames.div_ceil(self.clip_length);
+        let mut chunks = Vec::with_capacity(num_chunks);
+        for index in 0..num_chunks {
+            let input_start = index * self.clip_length;
+            let valid_frames = (pixel_frames - input_start).min(self.clip_length);
+            chunks.push(TemporalEncodeChunk {
+                input_start,
+                valid_frames,
+                repeated_tail_frames: self.clip_length - valid_frames,
+            });
+        }
+        let before_drop = num_chunks
+            .checked_mul(self.tokens_per_chunk())
+            .ok_or_else(|| candle::Error::Msg("H3 encoded frame count overflow".into()))?;
+        Ok(TemporalEncodePlan {
+            chunks,
+            latent_frames_before_drop: before_drop,
+            latent_frames: before_drop - self.token_drop,
+            trailing_latents_to_drop: self.token_drop,
+            single_frame: false,
+        })
+    }
+
+    pub fn encoded_frames(self, pixel_frames: usize) -> Result<usize> {
+        Ok(self.encode_plan(pixel_frames)?.latent_frames)
+    }
+
+    pub fn decode_plan(self, latent_frames: usize) -> Result<TemporalDecodePlan> {
+        self.validate()?;
+        if latent_frames == 0 {
+            bail!("H3 visual VAE cannot decode an empty latent sequence")
+        }
+        if latent_frames == 1 {
+            return Ok(TemporalDecodePlan {
+                chunks: vec![TemporalDecodeChunk {
+                    latent_start: 0,
+                    latent_frames: 1,
+                }],
+                repeated_tail_tokens: 0,
+                output_frames: 1,
+                tokens_per_chunk: self.tokens_per_chunk(),
+                token_overlap: self.token_overlap(),
+                frame_pre_padding: self.frame_pre_padding(),
+                frame_overlap: self.frame_overlap(),
+            });
+        }
+
+        let tokens_per_chunk = self.tokens_per_chunk();
+        let mut pseudo_total_tokens = latent_frames
+            .checked_add(self.token_drop)
+            .ok_or_else(|| candle::Error::Msg("H3 decoded token count overflow".into()))?;
+        let mut pad_tokens = 0;
+        let remainder = pseudo_total_tokens % tokens_per_chunk;
+        if remainder != 0 {
+            pad_tokens = tokens_per_chunk - remainder;
+            pseudo_total_tokens = pseudo_total_tokens
+                .checked_add(pad_tokens)
+                .ok_or_else(|| candle::Error::Msg("H3 padded token count overflow".into()))?;
+        }
+        let mut num_chunks =
+            pseudo_total_tokens / tokens_per_chunk - usize::from(self.token_drop > 0);
+        if num_chunks < 1 {
+            // The released decoder pads a two-token single-image-style latent
+            // by a whole extra chunk so it still has a real decode window.
+            pad_tokens = pad_tokens
+                .checked_add(tokens_per_chunk)
+                .ok_or_else(|| candle::Error::Msg("H3 padded token count overflow".into()))?;
+            num_chunks += 1;
+        }
+        let padded_len = latent_frames
+            .checked_add(pad_tokens)
+            .ok_or_else(|| candle::Error::Msg("H3 padded latent length overflow".into()))?;
+        let token_overlap = self.token_overlap();
+        let mut chunks = Vec::with_capacity(num_chunks);
+        for index in 0..num_chunks {
+            let start = index
+                .checked_mul(tokens_per_chunk)
+                .ok_or_else(|| candle::Error::Msg("H3 decode chunk offset overflow".into()))?;
+            chunks.push(TemporalDecodeChunk {
+                latent_start: start,
+                latent_frames: (tokens_per_chunk + token_overlap).min(padded_len - start),
+            });
+        }
+
+        let chunk_decoded_frames = tokens_per_chunk
+            .checked_mul(self.temporal_compression)
+            .ok_or_else(|| candle::Error::Msg("H3 decoded chunk length overflow".into()))?;
+        let split_count = usize::from(self.token_drop > 0) + 1;
+        let mut total_frames = 0usize;
+        let mut final_overlap_frames = 0usize;
+        for chunk in &chunks {
+            let clip_frames = chunk
+                .latent_frames
+                .checked_mul(self.temporal_compression)
+                .ok_or_else(|| candle::Error::Msg("H3 decoded clip length overflow".into()))?;
+            for split in 0..split_count {
+                let start = split
+                    .checked_mul(chunk_decoded_frames)
+                    .ok_or_else(|| candle::Error::Msg("H3 decoded split offset overflow".into()))?;
+                let end = start.saturating_add(chunk_decoded_frames).min(clip_frames);
+                let content_start =
+                    start.checked_add(self.frame_pre_padding()).ok_or_else(|| {
+                        candle::Error::Msg("H3 decoded content offset overflow".into())
+                    })?;
+                let frames = end.saturating_sub(content_start);
+                if split == 0 {
+                    total_frames = total_frames.checked_add(frames).ok_or_else(|| {
+                        candle::Error::Msg("H3 decoded output length overflow".into())
+                    })?;
+                } else {
+                    final_overlap_frames = frames;
+                }
+            }
+        }
+        total_frames = total_frames
+            .checked_add(final_overlap_frames)
+            .ok_or_else(|| candle::Error::Msg("H3 decoded output length overflow".into()))?;
+        let pad_frames = self.decode_pad_frames(padded_len, pad_tokens)?;
+        total_frames = total_frames.checked_sub(pad_frames).ok_or_else(|| {
+            candle::Error::Msg("H3 decode padding exceeds the planned output".into())
+        })?;
+
+        Ok(TemporalDecodePlan {
+            chunks,
+            repeated_tail_tokens: pad_tokens,
+            output_frames: total_frames,
+            tokens_per_chunk,
+            token_overlap,
+            frame_pre_padding: self.frame_pre_padding(),
+            frame_overlap: self.frame_overlap(),
+        })
+    }
+
+    fn decode_pad_frames(self, padded_len: usize, pad_tokens: usize) -> Result<usize> {
+        if pad_tokens == 0 {
+            return Ok(0);
+        }
+        let intra_tail = self.clip_length % self.temporal_compression;
+        if intra_tail == 0 {
+            return pad_tokens
+                .checked_mul(self.temporal_compression)
+                .ok_or_else(|| candle::Error::Msg("H3 decode padding overflow".into()));
+        }
+        let before_pad = padded_len - pad_tokens;
+        (0..pad_tokens).try_fold(0usize, |total, offset| {
+            let frames = if (before_pad + offset).is_multiple_of(self.tokens_per_chunk()) {
+                intra_tail
+            } else {
+                self.temporal_compression
+            };
+            total
+                .checked_add(frames)
+                .ok_or_else(|| candle::Error::Msg("H3 decode padding overflow".into()))
+        })
+    }
+}
+
+/// Exact spatial tile layout used by the released 256px/64px overlap path.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SpatialTilePlan {
+    pub starts: Vec<usize>,
+    pub lengths: Vec<usize>,
+    pub overlaps: Vec<usize>,
+}
+
+impl SpatialTilePlan {
+    pub fn new(
+        input_len: usize,
+        tile_size: usize,
+        minimum_overlap: usize,
+        spatial_compression: usize,
+    ) -> Result<Self> {
+        if input_len == 0 || tile_size == 0 || spatial_compression == 0 {
+            bail!("H3 visual VAE tile dimensions and compression must be positive")
+        }
+        if !input_len.is_multiple_of(spatial_compression)
+            || !tile_size.is_multiple_of(spatial_compression)
+        {
+            bail!(
+                "H3 visual VAE tile input {} and tile size {} must be divisible by spatial compression {}",
+                input_len,
+                tile_size,
+                spatial_compression
+            )
+        }
+        if minimum_overlap >= tile_size || !minimum_overlap.is_multiple_of(spatial_compression) {
+            bail!(
+                "H3 visual VAE overlap {} must be smaller than tile size {} and latent-aligned to {}",
+                minimum_overlap,
+                tile_size,
+                spatial_compression
+            )
+        }
+        if tile_size >= input_len {
+            return Ok(Self {
+                starts: vec![0],
+                lengths: vec![input_len],
+                overlaps: vec![],
+            });
+        }
+
+        let covered = |count: usize| -> Result<usize> {
+            tile_size
+                .checked_mul(count)
+                .and_then(|total| {
+                    minimum_overlap
+                        .checked_mul(count - 1)
+                        .and_then(|overlap| total.checked_sub(overlap))
+                })
+                .ok_or_else(|| candle::Error::Msg("H3 tile coverage overflow".into()))
+        };
+        let mut num_tiles = input_len.div_ceil(tile_size);
+        while covered(num_tiles)? < input_len {
+            num_tiles += 1;
+        }
+        let mut overlaps = vec![minimum_overlap; num_tiles - 1];
+        let remaining = covered(num_tiles)? - input_len;
+        if !remaining.is_multiple_of(spatial_compression) {
+            bail!("H3 visual VAE tile slack is not latent aligned")
+        }
+        for index in 0..remaining / spatial_compression {
+            overlaps[index % (num_tiles - 1)] += spatial_compression;
+        }
+        let mut starts: Vec<usize> = Vec::with_capacity(num_tiles);
+        starts.push(0);
+        for overlap in &overlaps {
+            let previous = starts
+                .last()
+                .copied()
+                .ok_or_else(|| candle::Error::Msg("H3 tile plan lost its initial offset".into()))?;
+            starts.push(
+                previous
+                    .checked_add(tile_size - overlap)
+                    .ok_or_else(|| candle::Error::Msg("H3 tile offset overflow".into()))?,
+            );
+        }
+        Ok(Self {
+            starts,
+            lengths: vec![tile_size; num_tiles],
+            overlaps,
+        })
+    }
+}
+
+/// Geometry-only plan. The caller must execute the resize with LANCZOS.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EndpointResizePlan {
+    /// The first/geometry-anchor image is stretched directly onto the canvas.
+    Stretch { width: usize, height: usize },
+    /// The follower preserves aspect ratio, covers the canvas, then uses the
+    /// released centered integer crop arithmetic.
+    CoverCrop {
+        resized_width: usize,
+        resized_height: usize,
+        left: usize,
+        top: usize,
+        width: usize,
+        height: usize,
+    },
+}
+
+impl EndpointResizePlan {
+    pub fn geometry_anchor(target_width: usize, target_height: usize) -> Result<Self> {
+        positive_dims(target_width, target_height)?;
+        Ok(Self::Stretch {
+            width: target_width,
+            height: target_height,
+        })
+    }
+
+    pub fn follower(
+        source_width: usize,
+        source_height: usize,
+        target_width: usize,
+        target_height: usize,
+    ) -> Result<Self> {
+        positive_dims(source_width, source_height)?;
+        positive_dims(target_width, target_height)?;
+        let scale = (target_width as f64 / source_width as f64)
+            .max(target_height as f64 / source_height as f64);
+        // Python's round() uses ties-to-even; this is intentionally not
+        // Rust's ties-away-from-zero f64::round().
+        let resized_width =
+            target_width.max((source_width as f64 * scale).round_ties_even() as usize);
+        let resized_height =
+            target_height.max((source_height as f64 * scale).round_ties_even() as usize);
+        Ok(Self::CoverCrop {
+            resized_width,
+            resized_height,
+            left: (resized_width - target_width) / 2,
+            top: (resized_height - target_height) / 2,
+            width: target_width,
+            height: target_height,
+        })
+    }
+}
+
+/// Geometry-only reference-image plan. Official Ref2VA always targets a 2048
+/// short edge (including upscaling); Comfy's optional deployment shortcut is
+/// represented separately so it cannot silently replace the model contract.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReferenceImageResizePlan {
+    pub width: usize,
+    pub height: usize,
+    pub upscaled: bool,
+}
+
+impl ReferenceImageResizePlan {
+    pub fn official_2048(
+        source_width: usize,
+        source_height: usize,
+        multiple: usize,
+    ) -> Result<Self> {
+        reference_short_edge_plan(source_width, source_height, 2048, multiple, true)
+    }
+
+    pub fn comfy_max_2048_down_only(
+        source_width: usize,
+        source_height: usize,
+        multiple: usize,
+    ) -> Result<Self> {
+        reference_short_edge_plan(source_width, source_height, 2048, multiple, false)
+    }
+}
+
+fn reference_short_edge_plan(
+    width: usize,
+    height: usize,
+    short_edge: usize,
+    multiple: usize,
+    upscale: bool,
+) -> Result<ReferenceImageResizePlan> {
+    positive_dims(width, height)?;
+    if multiple == 0 || short_edge == 0 {
+        bail!("H3 reference-image short edge and alignment must be positive")
+    }
+    if width > height.saturating_mul(4) || height > width.saturating_mul(4) {
+        bail!("H3 reference image must be within 1:4 and 4:1, got {width}x{height}")
+    }
+    let mut scale = short_edge as f64 / width.min(height) as f64;
+    if !upscale {
+        scale = scale.min(1.0);
+    }
+    let round_aligned = |value: usize| {
+        multiple.max((value as f64 * scale / multiple as f64).round_ties_even() as usize * multiple)
+    };
+    let target_width = round_aligned(width);
+    let target_height = round_aligned(height);
+    Ok(ReferenceImageResizePlan {
+        width: target_width,
+        height: target_height,
+        upscaled: target_width > width || target_height > height,
+    })
+}
+
+fn positive_dims(width: usize, height: usize) -> Result<()> {
+    if width == 0 || height == 0 {
+        bail!("H3 visual dimensions must be positive, got {width}x{height}")
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn official_frame_grid_is_exact_across_chunk_seams() {
+        let geometry = VisualTemporalGeometry::default();
+        for (pixels, latents) in [
+            (1, 1),
+            (5, 2),
+            (17, 2),
+            (22, 7),
+            (39, 12),
+            (124, 37),
+            (362, 107),
+        ] {
+            assert_eq!(
+                geometry.encoded_frames(pixels).unwrap(),
+                latents,
+                "{pixels}"
+            );
+        }
+        assert_eq!(geometry.decode_plan(2).unwrap().output_frames, 5);
+        assert_eq!(geometry.decode_plan(7).unwrap().output_frames, 22);
+        assert_eq!(geometry.decode_plan(12).unwrap().output_frames, 39);
+        assert_eq!(geometry.decode_plan(37).unwrap().output_frames, 124);
+        assert_eq!(geometry.decode_plan(107).unwrap().output_frames, 362);
+    }
+
+    #[test]
+    fn chunks_repeat_only_the_final_input_and_drop_once_globally() {
+        let plan = VisualTemporalGeometry::default().encode_plan(22).unwrap();
+        assert_eq!(
+            plan.chunks,
+            vec![
+                TemporalEncodeChunk {
+                    input_start: 0,
+                    valid_frames: 17,
+                    repeated_tail_frames: 0,
+                },
+                TemporalEncodeChunk {
+                    input_start: 17,
+                    valid_frames: 5,
+                    repeated_tail_frames: 12,
+                },
+            ]
+        );
+        assert_eq!(plan.latent_frames_before_drop, 10);
+        assert_eq!(plan.trailing_latents_to_drop, 3);
+    }
+
+    #[test]
+    fn released_tile_slack_is_distributed_in_latent_units() {
+        let plan = SpatialTilePlan::new(544, 256, 64, 16).unwrap();
+        assert_eq!(plan.starts, vec![0, 144, 288]);
+        assert_eq!(plan.overlaps, vec![112, 112]);
+        assert_eq!(plan.starts[2] + plan.lengths[2], 544);
+        assert!(SpatialTilePlan::new(545, 256, 64, 16).is_err());
+    }
+
+    #[test]
+    fn endpoint_plans_keep_the_asymmetric_reference_arithmetic() {
+        assert_eq!(
+            EndpointResizePlan::geometry_anchor(1344, 768).unwrap(),
+            EndpointResizePlan::Stretch {
+                width: 1344,
+                height: 768
+            }
+        );
+        assert_eq!(
+            EndpointResizePlan::follower(1000, 1000, 1344, 768).unwrap(),
+            EndpointResizePlan::CoverCrop {
+                resized_width: 1344,
+                resized_height: 1344,
+                left: 0,
+                top: 288,
+                width: 1344,
+                height: 768,
+            }
+        );
+    }
+
+    #[test]
+    fn official_and_comfy_reference_image_policies_are_not_conflated() {
+        let official = ReferenceImageResizePlan::official_2048(640, 480, 16).unwrap();
+        let comfy = ReferenceImageResizePlan::comfy_max_2048_down_only(640, 480, 16).unwrap();
+        assert_eq!((official.width, official.height), (2736, 2048));
+        assert!(official.upscaled);
+        assert_eq!((comfy.width, comfy.height), (640, 480));
+        assert!(!comfy.upscaled);
+    }
+}

--- a/crates/mold-candle/src/minimax_h3/visual_vae.rs
+++ b/crates/mold-candle/src/minimax_h3/visual_vae.rs
@@ -6,6 +6,7 @@ use super::visual_condition::{
     H3_LATENTS_STD,
 };
 use super::visual_geometry::{SpatialTilePlan, VisualTemporalGeometry};
+use super::visual_weights::ValidatedVisualVaeWeights;
 use candle::{bail, DType, Device, IndexOp, Result, Tensor, D};
 use candle_nn::{ops, Conv2d, Conv2dConfig, GroupNorm, Init, VarBuilder};
 use serde::{Deserialize, Serialize};
@@ -14,6 +15,14 @@ const TEST_WEIGHT_INIT: Init = Init::Randn {
     mean: 0.0,
     stdev: 0.02,
 };
+
+fn detach_mmap_storage(tensor: Tensor) -> Result<Tensor> {
+    if tensor.device().is_cpu() {
+        tensor.copy()
+    } else {
+        Ok(tensor)
+    }
+}
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(default)]
@@ -260,9 +269,18 @@ pub enum WeightLayout {
     OfficialComfySource,
 }
 
-/// FP32 parameter storage is invariant. The released CUDA decode executes
-/// autocast-eligible projections/convolutions in FP16 while norms and rotary
-/// construction stay FP32. CPU and Metal remain FP32.
+impl WeightLayout {
+    pub(crate) const fn artifact_dtype(self) -> DType {
+        match self {
+            Self::Diffusers => DType::F32,
+            Self::OfficialComfySource => DType::F16,
+        }
+    }
+}
+
+/// The artifact dtype remains the sole resident parameter dtype. The released
+/// CUDA decode executes autocast-eligible projections/convolutions in FP16
+/// while norms and rotary construction stay FP32. CPU and Metal remain FP32.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum DecodeComputePolicy {
     #[default]
@@ -279,13 +297,26 @@ impl DecodeComputePolicy {
     }
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum VisualAttentionBackend {
+    /// Fused FlashAttention v2 on eligible CUDA builds, fused SDPA on Metal,
+    /// and bounded exact math everywhere else.
+    #[default]
+    Auto,
+    /// Exact bounded math attention, useful for parity and deterministic UAT.
+    Math,
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum VisualVaePhase {
+    LoadWeights,
     EncodeChunk,
     EncodeTile,
     DecodeChunk,
     DecodeTile,
+    DecodeAssembly,
     DecoderBlock,
+    AttentionChunk,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -318,38 +349,24 @@ pub trait DecodeSink {
 
 #[derive(Clone, Debug)]
 struct MixedLinear {
-    stored_weight: Tensor,
-    stored_bias: Option<Tensor>,
-    compute_weight: Option<Tensor>,
-    compute_bias: Option<Tensor>,
+    resident_weight: Tensor,
+    resident_bias: Option<Tensor>,
     compute_dtype: DType,
 }
 
 impl MixedLinear {
     fn new(weight: Tensor, bias: Option<Tensor>, compute_dtype: DType) -> Result<Self> {
-        let stored_weight = weight.to_dtype(DType::F32)?;
-        let stored_bias = match bias {
-            Some(bias) => Some(bias.to_dtype(DType::F32)?),
-            None => None,
-        };
-        let compute_weight = if compute_dtype == DType::F32 {
-            None
-        } else {
-            Some(stored_weight.to_dtype(compute_dtype)?)
-        };
-        let compute_bias = if compute_dtype == DType::F32 {
-            None
-        } else {
-            stored_bias
-                .as_ref()
-                .map(|bias| bias.to_dtype(compute_dtype))
-                .transpose()?
-        };
+        if bias
+            .as_ref()
+            .is_some_and(|bias| bias.dtype() != weight.dtype())
+        {
+            bail!("H3 resident linear weight and bias dtypes must match")
+        }
+        let weight = detach_mmap_storage(weight)?;
+        let bias = bias.map(detach_mmap_storage).transpose()?;
         Ok(Self {
-            stored_weight,
-            stored_bias,
-            compute_weight,
-            compute_bias,
+            resident_weight: weight,
+            resident_bias: bias,
             compute_dtype,
         })
     }
@@ -361,10 +378,15 @@ impl MixedLinear {
     }
 
     fn forward(&self, input: &Tensor) -> Result<Tensor> {
-        let (weight, bias) = match &self.compute_weight {
-            Some(weight) => (weight, self.compute_bias.as_ref()),
-            None => (&self.stored_weight, self.stored_bias.as_ref()),
-        };
+        // Official Diffusers files remain resident F32 and are autocast at
+        // each eligible operation. Comfy files remain resident F16. Never
+        // retain a second full decoder copy merely to change compute dtype.
+        let weight = self.resident_weight.to_dtype(self.compute_dtype)?;
+        let bias = self
+            .resident_bias
+            .as_ref()
+            .map(|bias| bias.to_dtype(self.compute_dtype))
+            .transpose()?;
         let input = input.to_dtype(self.compute_dtype)?;
         let mut output_shape = input.dims().to_vec();
         let input_dim = output_shape
@@ -382,31 +404,31 @@ impl MixedLinear {
         output_shape.pop();
         output_shape.push(weight.dim(0)?);
         let output = output.reshape(output_shape.as_slice())?;
-        match bias {
+        match &bias {
             Some(bias) => output.broadcast_add(bias),
             None => Ok(output),
         }
     }
 
     fn stored_dtype(&self) -> DType {
-        self.stored_weight.dtype()
+        self.resident_weight.dtype()
     }
 }
 
 #[derive(Clone, Debug)]
-struct Fp32Vector {
-    stored: Tensor,
+struct ResidentVector {
+    resident: Tensor,
 }
 
-impl Fp32Vector {
-    fn new(stored: Tensor) -> Result<Self> {
+impl ResidentVector {
+    fn new(resident: Tensor) -> Result<Self> {
         Ok(Self {
-            stored: stored.to_dtype(DType::F32)?,
+            resident: detach_mmap_storage(resident)?,
         })
     }
 
-    fn value(&self) -> &Tensor {
-        &self.stored
+    fn value(&self, dtype: DType) -> Result<Tensor> {
+        self.resident.to_dtype(dtype)
     }
 }
 
@@ -428,7 +450,7 @@ impl PointwiseConv3d {
 
     fn forward(&self, input: &Tensor) -> Result<Tensor> {
         let (batch, channels, frames, height, width) = input.dims5()?;
-        let output_channels = self.linear.stored_weight.dim(0)?;
+        let output_channels = self.linear.resident_weight.dim(0)?;
         self.linear
             .forward(
                 &input
@@ -462,8 +484,9 @@ where
 struct H3CausalConv3d {
     temporal_kernel: usize,
     temporal_stride: usize,
+    spatial_stride: usize,
     spatial_padding: usize,
-    slices: Vec<Conv2d>,
+    slices: Vec<Tensor>,
     bias: Tensor,
 }
 
@@ -485,28 +508,27 @@ impl H3CausalConv3d {
         let bias = vb.get_with_hints(output_channels, "bias", Init::Const(0.0))?;
         let mut slices = Vec::with_capacity(kernel);
         for temporal in 0..kernel {
-            slices.push(Conv2d::new(
+            slices.push(detach_mmap_storage(
                 weight.i((.., .., temporal, .., ..))?.contiguous()?,
-                None,
-                Conv2dConfig {
-                    stride: spatial_stride,
-                    ..Default::default()
-                },
-            ));
+            )?);
         }
         Ok(Self {
             temporal_kernel: kernel,
             temporal_stride,
+            spatial_stride,
             spatial_padding,
             slices,
-            bias,
+            bias: detach_mmap_storage(bias)?,
         })
     }
 
     fn forward(&self, input: &Tensor) -> Result<Tensor> {
         let (batch, channels, _frames, height, width) = input.dims5()?;
-        if input.dtype() != DType::F32 {
-            bail!("H3 causal encoder convolutions require FP32 activations")
+        if !matches!(
+            input.dtype(),
+            DType::F16 | DType::BF16 | DType::F32 | DType::F64
+        ) {
+            bail!("H3 causal encoder convolutions require floating-point activations")
         }
         let front = self.temporal_kernel.saturating_sub(1);
         let input = if front == 0 {
@@ -516,7 +538,7 @@ impl H3CausalConv3d {
                 &[
                     &Tensor::zeros(
                         (batch, channels, front, height, width),
-                        DType::F32,
+                        input.dtype(),
                         input.device(),
                     )?,
                     input,
@@ -539,7 +561,15 @@ impl H3CausalConv3d {
                     .squeeze(2)?
                     .contiguous()?;
                 let frame = reflect_pad_4d(&frame, self.spatial_padding, self.spatial_padding)?;
-                let projected = frame.apply(&self.slices[kernel_frame])?;
+                let conv = Conv2d::new(
+                    self.slices[kernel_frame].to_dtype(frame.dtype())?,
+                    None,
+                    Conv2dConfig {
+                        stride: self.spatial_stride,
+                        ..Default::default()
+                    },
+                );
+                let projected = frame.apply(&conv)?;
                 accumulated = Some(match accumulated {
                     Some(previous) => previous.add(&projected)?,
                     None => projected,
@@ -554,7 +584,13 @@ impl H3CausalConv3d {
             );
         }
         let output = cat_tensors(&outputs, 2)?;
-        output.broadcast_add(&self.bias.reshape((1, self.bias.dim(0)?, 1, 1, 1))?)
+        output.broadcast_add(&self.bias.to_dtype(output.dtype())?.reshape((
+            1,
+            self.bias.dim(0)?,
+            1,
+            1,
+            1,
+        ))?)
     }
 }
 
@@ -598,20 +634,38 @@ fn pad_bottom_right_reflect(input: &Tensor) -> Result<Tensor> {
 
 #[derive(Clone, Debug)]
 struct TemporalIsolatedGroupNorm {
-    norm: GroupNorm,
+    weight: Tensor,
+    bias: Tensor,
+    channels: usize,
+    groups: usize,
+    eps: f64,
 }
 
 impl TemporalIsolatedGroupNorm {
     fn load(vb: VarBuilder, groups: usize, channels: usize, eps: f64) -> Result<Self> {
-        let weight = vb.get_with_hints(channels, "weight", Init::Const(1.0))?;
-        let bias = vb.get_with_hints(channels, "bias", Init::Const(0.0))?;
         Ok(Self {
-            norm: GroupNorm::new(weight, bias, channels, groups, eps)?,
+            weight: detach_mmap_storage(vb.get_with_hints(
+                channels,
+                "weight",
+                Init::Const(1.0),
+            )?)?,
+            bias: detach_mmap_storage(vb.get_with_hints(channels, "bias", Init::Const(0.0))?)?,
+            channels,
+            groups,
+            eps,
         })
     }
 
     fn forward(&self, input: &Tensor) -> Result<Tensor> {
-        map_frames(input, |frame| frame.apply(&self.norm))
+        let dtype = input.dtype();
+        let norm = GroupNorm::new(
+            self.weight.to_dtype(dtype)?,
+            self.bias.to_dtype(dtype)?,
+            self.channels,
+            self.groups,
+            self.eps,
+        )?;
+        map_frames(input, |frame| frame.apply(&norm))
     }
 }
 
@@ -858,10 +912,11 @@ struct Fp32RmsNorm {
 impl Fp32RmsNorm {
     fn load_affine(vb: VarBuilder, dim: usize, eps: f64) -> Result<Self> {
         Ok(Self {
-            weight: Some(
-                vb.get_with_hints(dim, "weight", Init::Const(1.0))?
-                    .to_dtype(DType::F32)?,
-            ),
+            weight: Some(detach_mmap_storage(vb.get_with_hints(
+                dim,
+                "weight",
+                Init::Const(1.0),
+            )?)?),
             eps,
         })
     }
@@ -875,7 +930,7 @@ impl Fp32RmsNorm {
         let variance = input32.sqr()?.mean_keepdim(D::Minus1)?;
         let normalized = input32.broadcast_div(&variance.affine(1.0, self.eps)?.sqrt()?)?;
         let normalized = match &self.weight {
-            Some(weight) => normalized.broadcast_mul(weight)?,
+            Some(weight) => normalized.broadcast_mul(&weight.to_dtype(DType::F32)?)?,
             None => normalized,
         };
         normalized.to_dtype(output_dtype)
@@ -892,12 +947,8 @@ struct Fp32LayerNorm {
 impl Fp32LayerNorm {
     fn load(vb: VarBuilder, dim: usize, eps: f64) -> Result<Self> {
         Ok(Self {
-            weight: vb
-                .get_with_hints(dim, "weight", Init::Const(1.0))?
-                .to_dtype(DType::F32)?,
-            bias: vb
-                .get_with_hints(dim, "bias", Init::Const(0.0))?
-                .to_dtype(DType::F32)?,
+            weight: detach_mmap_storage(vb.get_with_hints(dim, "weight", Init::Const(1.0))?)?,
+            bias: detach_mmap_storage(vb.get_with_hints(dim, "bias", Init::Const(0.0))?)?,
             eps,
         })
     }
@@ -909,8 +960,8 @@ impl Fp32LayerNorm {
         let variance = centered.sqr()?.mean_keepdim(D::Minus1)?;
         centered
             .broadcast_div(&variance.affine(1.0, self.eps)?.sqrt()?)?
-            .broadcast_mul(&self.weight)?
-            .broadcast_add(&self.bias)?
+            .broadcast_mul(&self.weight.to_dtype(DType::F32)?)?
+            .broadcast_add(&self.bias.to_dtype(DType::F32)?)?
             .to_dtype(output_dtype)
     }
 }
@@ -987,6 +1038,7 @@ struct H3Attention {
     heads: usize,
     head_dim: usize,
     compute_dtype: DType,
+    backend: VisualAttentionBackend,
 }
 
 impl H3Attention {
@@ -998,6 +1050,7 @@ impl H3Attention {
         head_dim: usize,
         eps: f64,
         compute_dtype: DType,
+        backend: VisualAttentionBackend,
     ) -> Result<Self> {
         let qkv = match layout {
             WeightLayout::Diffusers => {
@@ -1037,10 +1090,17 @@ impl H3Attention {
             heads,
             head_dim,
             compute_dtype,
+            backend,
         })
     }
 
-    fn forward(&self, input: &Tensor, cos: &Tensor, sin: &Tensor) -> Result<Tensor> {
+    fn forward(
+        &self,
+        input: &Tensor,
+        cos: &Tensor,
+        sin: &Tensor,
+        observer: &mut dyn VisualVaeObserver,
+    ) -> Result<Tensor> {
         let (batch, sequence, dim) = input.dims3()?;
         let qkv = self.qkv.forward(input)?;
         let (query, key, value) =
@@ -1051,17 +1111,175 @@ impl H3Attention {
         let rotary_dim = cos.dim(D::Minus1)?;
         query = apply_rope(&query, cos, sin, rotary_dim)?;
         key = apply_rope(&key, cos, sin, rotary_dim)?;
-        let scores = query
-            .matmul(&key.transpose(2, 3)?)?
-            .affine(1.0 / (self.head_dim as f64).sqrt(), 0.0)?;
-        let attention = ops::softmax_last_dim(&scores)?;
-        let hidden = attention
-            .matmul(&value)?
-            .permute((0, 2, 1, 3))?
-            .contiguous()?
-            .reshape((batch, sequence, dim))?;
+        let hidden = visual_attention(
+            &query,
+            &key,
+            &value,
+            1.0 / (self.head_dim as f64).sqrt() as f32,
+            self.backend,
+            observer,
+        )?
+        .permute((0, 2, 1, 3))?
+        .contiguous()?
+        .reshape((batch, sequence, dim))?;
         self.output.forward(&hidden)
     }
+}
+
+const DEFAULT_ATTENTION_QUERY_CHUNK: usize = 256;
+
+fn visual_attention(
+    query: &Tensor,
+    key: &Tensor,
+    value: &Tensor,
+    scale: f32,
+    backend: VisualAttentionBackend,
+    observer: &mut dyn VisualVaeObserver,
+) -> Result<Tensor> {
+    if backend == VisualAttentionBackend::Auto && query.device().is_metal() {
+        observer.checkpoint(VisualVaeEvent {
+            phase: VisualVaePhase::AttentionChunk,
+            completed: 0,
+            total: 1,
+        })?;
+        let output = ops::sdpa(query, key, value, None, false, scale, 1.0)?;
+        observer.checkpoint(VisualVaeEvent {
+            phase: VisualVaePhase::AttentionChunk,
+            completed: 1,
+            total: 1,
+        })?;
+        return Ok(output);
+    }
+    if backend == VisualAttentionBackend::Auto && flash_attention_eligible(query) {
+        observer.checkpoint(VisualVaeEvent {
+            phase: VisualVaePhase::AttentionChunk,
+            completed: 0,
+            total: 1,
+        })?;
+        if let Some(output) = try_flash_attention(query, key, value, scale)? {
+            observer.checkpoint(VisualVaeEvent {
+                phase: VisualVaePhase::AttentionChunk,
+                completed: 1,
+                total: 1,
+            })?;
+            return Ok(output);
+        }
+    }
+    bounded_math_attention(
+        query,
+        key,
+        value,
+        scale,
+        DEFAULT_ATTENTION_QUERY_CHUNK,
+        observer,
+    )
+}
+
+fn bounded_math_attention(
+    query: &Tensor,
+    key: &Tensor,
+    value: &Tensor,
+    scale: f32,
+    chunk_size: usize,
+    observer: &mut dyn VisualVaeObserver,
+) -> Result<Tensor> {
+    if chunk_size == 0 {
+        bail!("H3 attention query chunk must be positive")
+    }
+    let (batch, heads, query_len, head_dim) = query.dims4()?;
+    let (key_batch, key_heads, key_len, key_dim) = key.dims4()?;
+    let (value_batch, value_heads, value_len, value_dim) = value.dims4()?;
+    if (batch, heads, head_dim) != (key_batch, key_heads, key_dim)
+        || (batch, heads, key_len) != (value_batch, value_heads, value_len)
+    {
+        bail!("H3 attention QKV shapes do not agree")
+    }
+    attention_score_element_bound(batch, heads, query_len, key_len, chunk_size)?;
+    let query = query.reshape((batch * heads, query_len, head_dim))?;
+    let key_t = key
+        .reshape((batch * heads, key_len, key_dim))?
+        .transpose(1, 2)?;
+    let value = value.reshape((batch * heads, value_len, value_dim))?;
+    let total = query_len.div_ceil(chunk_size);
+    let mut chunks = Vec::with_capacity(total);
+    for chunk in 0..total {
+        observer.checkpoint(VisualVaeEvent {
+            phase: VisualVaePhase::AttentionChunk,
+            completed: chunk,
+            total,
+        })?;
+        let start = chunk * chunk_size;
+        let len = (query_len - start).min(chunk_size);
+        let scores = query
+            .narrow(1, start, len)?
+            .matmul(&key_t)?
+            .affine(scale as f64, 0.0)?;
+        chunks.push(ops::softmax_last_dim(&scores)?.matmul(&value)?);
+    }
+    observer.checkpoint(VisualVaeEvent {
+        phase: VisualVaePhase::AttentionChunk,
+        completed: total,
+        total,
+    })?;
+    cat_tensors(&chunks, 1)?.reshape((batch, heads, query_len, value_dim))
+}
+
+fn attention_score_element_bound(
+    batch: usize,
+    heads: usize,
+    query_len: usize,
+    key_len: usize,
+    chunk_size: usize,
+) -> Result<usize> {
+    [batch, heads, query_len.min(chunk_size), key_len]
+        .into_iter()
+        .try_fold(1usize, |total, value| {
+            total.checked_mul(value).ok_or_else(|| {
+                candle::Error::Msg("H3 attention workspace element count overflow".into())
+            })
+        })
+}
+
+fn flash_attention_eligible(query: &Tensor) -> bool {
+    query.device().is_cuda()
+        && matches!(query.dtype(), DType::F16 | DType::BF16)
+        && query
+            .dim(D::Minus1)
+            .is_ok_and(|dim| dim > 0 && dim.is_multiple_of(8) && dim <= 512)
+}
+
+#[cfg(feature = "flash-attn")]
+fn try_flash_attention(
+    query: &Tensor,
+    key: &Tensor,
+    value: &Tensor,
+    scale: f32,
+) -> Result<Option<Tensor>> {
+    let query = to_flash_layout(query)?;
+    let key = to_flash_layout(key)?;
+    let value = to_flash_layout(value)?;
+    let output = candle_flash_attn::flash_attn(&query, &key, &value, scale, false)?;
+    Ok(Some(output.transpose(1, 2)?.contiguous()?))
+}
+
+#[cfg(feature = "flash-attn")]
+fn to_flash_layout(tensor: &Tensor) -> Result<Tensor> {
+    let tensor = tensor.transpose(1, 2)?;
+    if tensor.stride().last() == Some(&1) {
+        Ok(tensor)
+    } else {
+        tensor.contiguous()
+    }
+}
+
+#[cfg(not(feature = "flash-attn"))]
+fn try_flash_attention(
+    _query: &Tensor,
+    _key: &Tensor,
+    _value: &Tensor,
+    _scale: f32,
+) -> Result<Option<Tensor>> {
+    Ok(None)
 }
 
 fn split_qkv_layout(
@@ -1203,10 +1421,11 @@ fn split_gate_value(
 struct H3TransformerBlock {
     norm1: Fp32RmsNorm,
     attention: H3Attention,
-    scale1: Fp32Vector,
+    scale1: ResidentVector,
     norm2: Fp32RmsNorm,
     feed_forward: H3FeedForward,
-    scale2: Fp32Vector,
+    scale2: ResidentVector,
+    residual_dtype: DType,
 }
 
 impl H3TransformerBlock {
@@ -1219,6 +1438,8 @@ impl H3TransformerBlock {
         ffn_mult: usize,
         eps: f64,
         compute_dtype: DType,
+        residual_dtype: DType,
+        attention_backend: VisualAttentionBackend,
     ) -> Result<Self> {
         Ok(Self {
             norm1: Fp32RmsNorm::load_affine(vb.pp("norm1"), dim, eps)?,
@@ -1230,32 +1451,37 @@ impl H3TransformerBlock {
                 head_dim,
                 eps,
                 compute_dtype,
+                attention_backend,
             )?,
-            scale1: Fp32Vector::new(vb.get_with_hints(dim, "scale1", Init::Const(0.0))?)?,
+            scale1: ResidentVector::new(vb.get_with_hints(dim, "scale1", Init::Const(0.0))?)?,
             norm2: Fp32RmsNorm::load_affine(vb.pp("norm2"), dim, eps)?,
             feed_forward: H3FeedForward::load(vb.pp("ff"), layout, dim, ffn_mult, compute_dtype)?,
-            scale2: Fp32Vector::new(vb.get_with_hints(dim, "scale2", Init::Const(0.0))?)?,
+            scale2: ResidentVector::new(vb.get_with_hints(dim, "scale2", Init::Const(0.0))?)?,
+            residual_dtype,
         })
     }
 
-    fn forward(&self, input: &Tensor, cos: &Tensor, sin: &Tensor) -> Result<Tensor> {
-        // Autocast lowers the projection sites, but the released learned
-        // scales are FP32. Their pointwise products promote the residual
-        // stream back to FP32 after every branch.
-        let norm = self.norm1.forward(input, DType::F32)?;
+    fn forward(
+        &self,
+        input: &Tensor,
+        cos: &Tensor,
+        sin: &Tensor,
+        observer: &mut dyn VisualVaeObserver,
+    ) -> Result<Tensor> {
+        let norm = self.norm1.forward(input, self.residual_dtype)?;
         let attention = self
             .attention
-            .forward(&norm, cos, sin)?
-            .to_dtype(DType::F32)?
-            .broadcast_mul(self.scale1.value())?;
-        let hidden = input.to_dtype(DType::F32)?.add(&attention)?;
-        let norm = self.norm2.forward(&hidden, DType::F32)?;
+            .forward(&norm, cos, sin, observer)?
+            .to_dtype(self.residual_dtype)?
+            .broadcast_mul(&self.scale1.value(self.residual_dtype)?)?;
+        let hidden = input.to_dtype(self.residual_dtype)?.add(&attention)?;
+        let norm = self.norm2.forward(&hidden, self.residual_dtype)?;
         hidden.add(
             &self
                 .feed_forward
                 .forward(&norm)?
-                .to_dtype(DType::F32)?
-                .broadcast_mul(self.scale2.value())?,
+                .to_dtype(self.residual_dtype)?
+                .broadcast_mul(&self.scale2.value(self.residual_dtype)?)?,
         )
     }
 }
@@ -1263,7 +1489,7 @@ impl H3TransformerBlock {
 #[derive(Clone, Debug)]
 struct H3VitDecoder3d {
     projection_in: MixedLinear,
-    register_tokens: Fp32Vector,
+    register_tokens: ResidentVector,
     blocks: Vec<H3TransformerBlock>,
     norm_out: Fp32LayerNorm,
     projection_out: MixedLinear,
@@ -1275,6 +1501,7 @@ struct H3VitDecoder3d {
     patch_size_t: usize,
     out_channels: usize,
     compute_dtype: DType,
+    residual_dtype: DType,
 }
 
 impl H3VitDecoder3d {
@@ -1283,14 +1510,26 @@ impl H3VitDecoder3d {
         vb: VarBuilder,
         layout: WeightLayout,
         compute_dtype: DType,
+        attention_backend: VisualAttentionBackend,
+        observer: &mut dyn VisualVaeObserver,
     ) -> Result<Self> {
         let dim = config.decoder_num_attention_heads * config.decoder_attention_head_dim;
+        let residual_dtype = match layout {
+            WeightLayout::Diffusers => DType::F32,
+            WeightLayout::OfficialComfySource => compute_dtype,
+        };
         let projection_in_name = match layout {
             WeightLayout::Diffusers => "proj_in",
             WeightLayout::OfficialComfySource => "x_embedder",
         };
         let mut blocks = Vec::with_capacity(config.decoder_num_layers);
+        let load_total = config.decoder_num_layers + 1;
         for block in 0..config.decoder_num_layers {
+            observer.checkpoint(VisualVaeEvent {
+                phase: VisualVaePhase::LoadWeights,
+                completed: block + 1,
+                total: load_total,
+            })?;
             blocks.push(H3TransformerBlock::load(
                 vb.pp(format!("transformer_blocks.{block}")),
                 layout,
@@ -1300,8 +1539,15 @@ impl H3VitDecoder3d {
                 config.decoder_ffn_mult,
                 config.decoder_norm_eps,
                 compute_dtype,
+                residual_dtype,
+                attention_backend,
             )?);
         }
+        observer.checkpoint(VisualVaeEvent {
+            phase: VisualVaePhase::LoadWeights,
+            completed: load_total,
+            total: load_total,
+        })?;
         let patch_size = config.spatial_compression_ratio();
         let patch_size_t = config.temporal_compression_ratio();
         let output = config.out_channels * patch_size_t * patch_size * patch_size;
@@ -1312,7 +1558,7 @@ impl H3VitDecoder3d {
                 dim,
                 compute_dtype,
             )?,
-            register_tokens: Fp32Vector::new(vb.get_with_hints(
+            register_tokens: ResidentVector::new(vb.get_with_hints(
                 (1, config.decoder_num_register_tokens, dim),
                 "register_tokens",
                 TEST_WEIGHT_INIT,
@@ -1331,6 +1577,7 @@ impl H3VitDecoder3d {
             patch_size_t,
             out_channels: config.out_channels,
             compute_dtype,
+            residual_dtype,
         })
     }
 
@@ -1343,13 +1590,14 @@ impl H3VitDecoder3d {
                 .contiguous()?
                 .reshape((batch, patches, channels))?,
         )?;
-        // `proj_in` is autocast-eligible, then concatenation with the released
-        // FP32 register parameters promotes the decoder residual stream.
-        hidden = hidden.to_dtype(DType::F32)?;
-        let registers = self.register_tokens.value().repeat((batch, 1, 1))?;
+        hidden = hidden.to_dtype(self.residual_dtype)?;
+        let registers = self
+            .register_tokens
+            .value(self.residual_dtype)?
+            .repeat((batch, 1, 1))?;
         let zero = Tensor::zeros(
             (batch, 1, self.heads * self.head_dim),
-            DType::F32,
+            self.residual_dtype,
             input.device(),
         )?;
         hidden = Tensor::cat(&[&hidden, &registers, &zero], 1)?;
@@ -1368,7 +1616,7 @@ impl H3VitDecoder3d {
                 completed: index,
                 total: self.blocks.len(),
             })?;
-            hidden = block.forward(&hidden, &cos, &sin)?;
+            hidden = block.forward(&hidden, &cos, &sin, observer)?;
         }
         observer.checkpoint(VisualVaeEvent {
             phase: VisualVaePhase::DecoderBlock,
@@ -1410,45 +1658,117 @@ pub struct MiniMaxH3VisualVae {
     quant_conv: PointwiseConv3d,
     post_quant_conv: PointwiseConv3d,
     decoder: H3VitDecoder3d,
+    encoder_compute_dtype: DType,
     compute_dtype: DType,
+    attention_backend: VisualAttentionBackend,
 }
 
 impl MiniMaxH3VisualVae {
-    pub fn new(
+    /// Construct from an opaque artifact proof. This is the only public model
+    /// loader: callers cannot validate one path and mmap an unrelated builder.
+    /// Authorization must precede creation of `validated`.
+    pub fn from_validated(
+        config: MiniMaxH3VisualVaeConfig,
+        validated: &ValidatedVisualVaeWeights,
+        device: &Device,
+        decode_policy: DecodeComputePolicy,
+        attention_backend: VisualAttentionBackend,
+        observer: &mut dyn VisualVaeObserver,
+    ) -> Result<Self> {
+        config.validate_production_contract()?;
+        validated.revalidate_files()?;
+        let vb = validated.mmap_var_builder(device)?;
+        let model = Self::load(
+            config,
+            vb,
+            validated.layout(),
+            decode_policy,
+            attention_backend,
+            observer,
+        )?;
+        validated.revalidate_files()?;
+        Ok(model)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new(
         config: MiniMaxH3VisualVaeConfig,
         vb: VarBuilder,
         layout: WeightLayout,
         decode_policy: DecodeComputePolicy,
     ) -> Result<Self> {
+        Self::load(
+            config,
+            vb,
+            layout,
+            decode_policy,
+            VisualAttentionBackend::Auto,
+            &mut NoopVisualVaeObserver,
+        )
+    }
+
+    fn load(
+        config: MiniMaxH3VisualVaeConfig,
+        vb: VarBuilder,
+        layout: WeightLayout,
+        decode_policy: DecodeComputePolicy,
+        attention_backend: VisualAttentionBackend,
+        observer: &mut dyn VisualVaeObserver,
+    ) -> Result<Self> {
         config.validate()?;
-        if vb.dtype() != DType::F32 {
+        if vb.dtype() != layout.artifact_dtype() {
             bail!(
-                "H3 visual VAE VarBuilder must expose FP32 stored weights, got {:?}",
-                vb.dtype()
+                "H3 visual VAE {:?} VarBuilder must preserve {:?} artifact weights, got {:?}",
+                layout,
+                layout.artifact_dtype(),
+                vb.dtype(),
             )
         }
         let compute_dtype = decode_policy.effective_dtype(vb.device());
+        let encoder_compute_dtype = match layout {
+            WeightLayout::Diffusers => DType::F32,
+            WeightLayout::OfficialComfySource => compute_dtype,
+        };
+        observer.checkpoint(VisualVaeEvent {
+            phase: VisualVaePhase::LoadWeights,
+            completed: 0,
+            total: config.decoder_num_layers + 1,
+        })?;
         let encoder = H3Encoder3d::load(&config, vb.clone(), layout)?;
         let quant_conv = PointwiseConv3d::load(
             vb.pp("quant_conv"),
             config.latent_channels * 2,
             config.latent_channels * 2,
-            DType::F32,
+            encoder_compute_dtype,
         )?;
+        observer.checkpoint(VisualVaeEvent {
+            phase: VisualVaePhase::LoadWeights,
+            completed: 1,
+            total: config.decoder_num_layers + 1,
+        })?;
         let post_quant_conv = PointwiseConv3d::load(
             vb.pp("post_quant_conv"),
             config.latent_channels,
             config.latent_channels,
             compute_dtype,
         )?;
-        let decoder = H3VitDecoder3d::load(&config, vb.pp("decoder"), layout, compute_dtype)?;
+        let decoder = H3VitDecoder3d::load(
+            &config,
+            vb.pp("decoder"),
+            layout,
+            compute_dtype,
+            attention_backend,
+            observer,
+        )?;
         Ok(Self {
             config,
             encoder,
             quant_conv,
             post_quant_conv,
             decoder,
+            encoder_compute_dtype,
             compute_dtype,
+            attention_backend,
         })
     }
 
@@ -1462,6 +1782,10 @@ impl MiniMaxH3VisualVae {
 
     pub fn decode_compute_dtype(&self) -> DType {
         self.compute_dtype
+    }
+
+    pub fn attention_backend(&self) -> VisualAttentionBackend {
+        self.attention_backend
     }
 
     pub fn encode_condition_u8(
@@ -1557,7 +1881,11 @@ impl MiniMaxH3VisualVae {
         if !self.config.tiling {
             return self
                 .quant_conv
-                .forward(&self.encoder.forward(pixels)?)
+                .forward(
+                    &self
+                        .encoder
+                        .forward(&pixels.to_dtype(self.encoder_compute_dtype)?)?,
+                )
                 .and_then(|tensor| tensor.to_dtype(DType::F32));
         }
         let height_plan = SpatialTilePlan::new(
@@ -1583,7 +1911,10 @@ impl MiniMaxH3VisualVae {
                     completed,
                     total,
                 })?;
-                let tile = pixels.narrow(3, y, tile_height)?.narrow(4, x, tile_width)?;
+                let tile = pixels
+                    .narrow(3, y, tile_height)?
+                    .narrow(4, x, tile_width)?
+                    .to_dtype(self.encoder_compute_dtype)?;
                 row.push(self.quant_conv.forward(&self.encoder.forward(&tile)?)?);
                 completed += 1;
             }
@@ -1607,7 +1938,8 @@ impl MiniMaxH3VisualVae {
                 .iter()
                 .map(|overlap| overlap / ratio)
                 .collect::<Vec<_>>(),
-        )
+        )?
+        .to_dtype(DType::F32)
     }
 
     pub fn decode_normalized(
@@ -1764,9 +2096,10 @@ impl MiniMaxH3VisualVae {
             .enumerate()
         {
             let mut new_row_tails = Vec::with_capacity(width_plan.starts.len());
+            let mut row_bodies = Vec::with_capacity(width_plan.starts.len());
             let mut left_tail: Option<Tensor> = None;
             let mut output_x = 0;
-            let mut written_height = 0;
+            let mut written_height: Option<usize> = None;
             for (column_index, (&x, &tile_width)) in width_plan
                 .starts
                 .iter()
@@ -1788,8 +2121,8 @@ impl MiniMaxH3VisualVae {
                     .forward(&self.post_quant_conv.forward(&tile)?, observer)?;
 
                 // Preserve raw tails before blending, exactly as ComfyUI's
-                // preallocated tiled decoder does. No full decoded tile row is
-                // retained after its cropped body is copied into the canvas.
+                // preallocated tiled decoder does. Cropped bodies retain only
+                // one bounded output row before one strided canvas insertion.
                 if row_index < height_plan.starts.len() - 1 {
                     let overlap = height_plan.overlaps[row_index];
                     new_row_tails.push(
@@ -1832,31 +2165,49 @@ impl MiniMaxH3VisualVae {
                     tile = tile.narrow(4, 0, tile.dim(4)? - width_plan.overlaps[column_index])?;
                 }
                 let tile = tile.contiguous()?;
-                written_height = tile.dim(3)?;
-                let output = match &canvas {
-                    Some(canvas) => canvas,
-                    None => canvas.insert(Tensor::zeros(
-                        (
-                            tile.dim(0)?,
-                            tile.dim(1)?,
-                            tile.dim(2)?,
-                            pixel_height,
-                            pixel_width,
-                        ),
-                        tile.dtype(),
-                        tile.device(),
-                    )?),
-                };
-                copy_spatial_tile(output, &tile, output_y, output_x)?;
+                let tile_height = tile.dim(3)?;
+                if written_height.is_some_and(|height| height != tile_height) {
+                    bail!("H3 tiled decode row produced inconsistent tile heights")
+                }
+                written_height = Some(tile_height);
                 output_x += tile.dim(4)?;
+                row_bodies.push(tile);
                 completed += 1;
             }
             if output_x != pixel_width {
                 bail!("H3 tiled decode row wrote {output_x}px, expected {pixel_width}px")
             }
+            observer.checkpoint(VisualVaeEvent {
+                phase: VisualVaePhase::DecodeAssembly,
+                completed: row_index,
+                total: height_plan.starts.len(),
+            })?;
+            let row = cat_tensors(&row_bodies, 4)?.contiguous()?;
+            let output = match &canvas {
+                Some(canvas) => canvas,
+                None => canvas.insert(Tensor::zeros(
+                    (
+                        row.dim(0)?,
+                        row.dim(1)?,
+                        row.dim(2)?,
+                        pixel_height,
+                        pixel_width,
+                    ),
+                    row.dtype(),
+                    row.device(),
+                )?),
+            };
+            copy_spatial_row(output, &row, output_y)?;
             row_tails = new_row_tails;
-            output_y += written_height;
+            output_y += written_height.ok_or_else(|| {
+                candle::Error::Msg("H3 tiled decode produced an empty tile row".into())
+            })?;
         }
+        observer.checkpoint(VisualVaeEvent {
+            phase: VisualVaePhase::DecodeAssembly,
+            completed: height_plan.starts.len(),
+            total: height_plan.starts.len(),
+        })?;
         observer.checkpoint(VisualVaeEvent {
             phase: VisualVaePhase::DecodeTile,
             completed,
@@ -1869,36 +2220,16 @@ impl MiniMaxH3VisualVae {
     }
 }
 
-fn copy_spatial_tile(canvas: &Tensor, tile: &Tensor, y: usize, x: usize) -> Result<()> {
+fn copy_spatial_row(canvas: &Tensor, row: &Tensor, y: usize) -> Result<()> {
     let (batch, channels, frames, canvas_height, canvas_width) = canvas.dims5()?;
-    let (tile_batch, tile_channels, tile_frames, tile_height, tile_width) = tile.dims5()?;
-    if (batch, channels, frames) != (tile_batch, tile_channels, tile_frames)
-        || y + tile_height > canvas_height
-        || x + tile_width > canvas_width
+    let (row_batch, row_channels, row_frames, row_height, row_width) = row.dims5()?;
+    if (batch, channels, frames) != (row_batch, row_channels, row_frames)
+        || y + row_height > canvas_height
+        || row_width != canvas_width
     {
-        bail!("H3 decoded tile does not fit its output canvas")
+        bail!("H3 decoded tile row does not fit its output canvas")
     }
-    let flat_canvas = canvas.flatten_all()?;
-    for batch_index in 0..batch {
-        for channel in 0..channels {
-            for frame in 0..frames {
-                for row in 0..tile_height {
-                    let destination = (((batch_index * channels + channel) * frames + frame)
-                        * canvas_height
-                        + y
-                        + row)
-                        * canvas_width
-                        + x;
-                    let source = tile
-                        .i((batch_index, channel, frame, row, ..))?
-                        .contiguous()?
-                        .flatten_all()?;
-                    flat_canvas.slice_set(&source, 0, destination)?;
-                }
-            }
-        }
-    }
-    Ok(())
+    canvas.slice_set(row, 3, y)
 }
 
 fn blend(a: &Tensor, b: &Tensor, extent: usize, dim: usize) -> Result<Tensor> {
@@ -2088,6 +2419,69 @@ mod tests {
     }
 
     #[test]
+    fn bounded_math_attention_matches_dense_reference() {
+        #[derive(Default)]
+        struct CountChunks(usize);
+        impl VisualVaeObserver for CountChunks {
+            fn checkpoint(&mut self, event: VisualVaeEvent) -> Result<()> {
+                if event.phase == VisualVaePhase::AttentionChunk && event.completed < event.total {
+                    self.0 += 1;
+                }
+                Ok(())
+            }
+        }
+
+        let query = Tensor::arange(0u32, 40, &Device::Cpu)
+            .unwrap()
+            .to_dtype(DType::F32)
+            .unwrap()
+            .affine(0.01, -0.2)
+            .unwrap()
+            .reshape((1, 2, 5, 4))
+            .unwrap();
+        let key = query.affine(0.7, 0.1).unwrap();
+        let value = query.affine(-0.3, 0.4).unwrap();
+        let scale = 0.5f32;
+        let dense = ops::softmax_last_dim(
+            &query
+                .matmul(&key.transpose(2, 3).unwrap())
+                .unwrap()
+                .affine(scale as f64, 0.0)
+                .unwrap(),
+        )
+        .unwrap()
+        .matmul(&value)
+        .unwrap();
+        let mut observer = CountChunks::default();
+        let bounded =
+            bounded_math_attention(&query, &key, &value, scale, 2, &mut observer).unwrap();
+        let max_error = dense
+            .sub(&bounded)
+            .unwrap()
+            .abs()
+            .unwrap()
+            .max_all()
+            .unwrap()
+            .to_scalar::<f32>()
+            .unwrap();
+        assert!(max_error < 1e-6, "bounded attention error {max_error}");
+        assert_eq!(observer.0, 3);
+    }
+
+    #[test]
+    fn production_attention_workspace_is_bounded_below_dense_scores() {
+        let sequence = 7 * 16 * 16 + 5;
+        assert_eq!(sequence, 1797);
+        let bounded =
+            attention_score_element_bound(1, 32, sequence, sequence, DEFAULT_ATTENTION_QUERY_CHUNK)
+                .unwrap();
+        let dense = 32 * sequence * sequence;
+        assert_eq!(bounded, 14_721_024);
+        assert_eq!(dense, 103_334_688);
+        assert!(bounded * 7 < dense);
+    }
+
+    #[test]
     fn tiny_decoder_executes_released_temporal_frame_counts() {
         let mut config = MiniMaxH3VisualVaeConfig::tiny_for_tests();
         config.tiling = false;
@@ -2109,11 +2503,17 @@ mod tests {
     #[test]
     fn comfy_style_tiled_decode_streams_into_the_exact_canvas() {
         #[derive(Default)]
-        struct CountTiles(usize);
+        struct CountTiles {
+            tiles: usize,
+            assembly_rows: usize,
+        }
         impl VisualVaeObserver for CountTiles {
             fn checkpoint(&mut self, event: VisualVaeEvent) -> Result<()> {
                 if event.phase == VisualVaePhase::DecodeTile && event.completed < event.total {
-                    self.0 += 1;
+                    self.tiles += 1;
+                }
+                if event.phase == VisualVaePhase::DecodeAssembly && event.completed < event.total {
+                    self.assembly_rows += 1;
                 }
                 Ok(())
             }
@@ -2124,7 +2524,18 @@ mod tests {
         let mut observer = CountTiles::default();
         let decoded = model.decode_normalized(&latents, &mut observer).unwrap();
         assert_eq!(decoded.dims5().unwrap(), (1, 3, 5, 36, 36));
-        assert_eq!(observer.0, 4);
+        assert_eq!(observer.tiles, 4);
+        assert_eq!(observer.assembly_rows, 2);
+    }
+
+    #[test]
+    fn production_canvas_assembly_uses_one_copy_per_bounded_row() {
+        let plan = SpatialTilePlan::new(2048, 256, 64, 16).unwrap();
+        assert_eq!(plan.starts.len(), 11);
+        let canvas_copy_operations = plan.starts.len();
+        let former_row_copy_operations = 3 * 28 * 2048 * 11;
+        assert_eq!(canvas_copy_operations, 11);
+        assert_eq!(former_row_copy_operations, 1_892_352);
     }
 
     #[test]
@@ -2174,6 +2585,11 @@ mod tests {
 
     #[test]
     fn dtype_policy_separates_storage_from_backend_compute() {
+        assert_eq!(WeightLayout::Diffusers.artifact_dtype(), DType::F32);
+        assert_eq!(
+            WeightLayout::OfficialComfySource.artifact_dtype(),
+            DType::F16
+        );
         assert_eq!(
             DecodeComputePolicy::Reference.effective_dtype(&Device::Cpu),
             DType::F32
@@ -2182,6 +2598,43 @@ mod tests {
             DecodeComputePolicy::FullF32.effective_dtype(&Device::Cpu),
             DType::F32
         );
+
+        let weight = Tensor::ones((2, 2), DType::F16, &Device::Cpu).unwrap();
+        let bias = Tensor::zeros(2, DType::F16, &Device::Cpu).unwrap();
+        let linear = MixedLinear::new(weight, Some(bias), DType::F32).unwrap();
+        assert_eq!(linear.resident_weight.dtype(), DType::F16);
+        assert_eq!(linear.resident_bias.as_ref().unwrap().dtype(), DType::F16);
+        let output = linear
+            .forward(&Tensor::ones((1, 2), DType::F32, &Device::Cpu).unwrap())
+            .unwrap();
+        assert_eq!(output.dtype(), DType::F32);
+    }
+
+    #[test]
+    fn model_load_is_cancellable_between_weight_components() {
+        struct Cancel;
+        impl VisualVaeObserver for Cancel {
+            fn checkpoint(&mut self, event: VisualVaeEvent) -> Result<()> {
+                if event.phase == VisualVaePhase::LoadWeights {
+                    bail!("synthetic load cancellation")
+                }
+                Ok(())
+            }
+        }
+        let config = MiniMaxH3VisualVaeConfig::tiny_for_tests();
+        let varmap = VarMap::new();
+        let vb = VarBuilder::from_varmap(&varmap, DType::F32, &Device::Cpu);
+        let error = MiniMaxH3VisualVae::load(
+            config,
+            vb,
+            WeightLayout::Diffusers,
+            DecodeComputePolicy::Reference,
+            VisualAttentionBackend::Math,
+            &mut Cancel,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("synthetic load cancellation"));
     }
 
     #[cfg(feature = "cuda")]
@@ -2209,22 +2662,30 @@ mod tests {
         .unwrap();
         assert_eq!(cuda_model.decode_compute_dtype(), DType::F16);
         assert_eq!(
-            cuda_model.decoder.register_tokens.value().dtype(),
+            cuda_model
+                .decoder
+                .register_tokens
+                .value(DType::F32)
+                .unwrap()
+                .dtype(),
             DType::F32
         );
         assert_eq!(
-            cuda_model.decoder.blocks[0].scale1.value().dtype(),
+            cuda_model.decoder.blocks[0]
+                .scale1
+                .value(DType::F32)
+                .unwrap()
+                .dtype(),
             DType::F32
         );
         assert_eq!(
             cuda_model.decoder.blocks[0]
                 .attention
                 .qkv
-                .compute_weight
-                .as_ref()
-                .expect("CUDA reference policy keeps an FP16 compute copy")
+                .resident_weight
                 .dtype(),
-            DType::F16
+            DType::F32,
+            "official weights remain one resident F32 copy"
         );
         // 9x9 latents map to 36x36 pixels, forcing the 32px/8px-overlap
         // synthetic configuration through four streamed decode tiles.

--- a/crates/mold-candle/src/minimax_h3/visual_vae.rs
+++ b/crates/mold-candle/src/minimax_h3/visual_vae.rs
@@ -1,0 +1,2255 @@
+#![allow(clippy::too_many_arguments)]
+
+use super::visual_condition::{
+    denormalize_imagenet, denormalize_latents, ConditionEncodeMode, DiagonalGaussianDistribution,
+    ImageNetPixels, SignedRgbPixels, Uint8RgbPixels, UnitRgbPixels, H3_LATENTS_MEAN,
+    H3_LATENTS_STD,
+};
+use super::visual_geometry::{SpatialTilePlan, VisualTemporalGeometry};
+use candle::{bail, DType, Device, IndexOp, Result, Tensor, D};
+use candle_nn::{ops, Conv2d, Conv2dConfig, GroupNorm, Init, VarBuilder};
+use serde::{Deserialize, Serialize};
+
+const TEST_WEIGHT_INIT: Init = Init::Randn {
+    mean: 0.0,
+    stdev: 0.02,
+};
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct MiniMaxH3VisualVaeConfig {
+    pub in_channels: usize,
+    pub out_channels: usize,
+    pub latent_channels: usize,
+    pub block_out_channels: Vec<usize>,
+    pub layers_per_block: usize,
+    pub spatial_downsample_factors: Vec<usize>,
+    pub temporal_downsample_factors: Vec<usize>,
+    pub norm_num_groups: usize,
+    pub norm_eps: f64,
+    pub spatial_padding_mode: String,
+    pub decoder_num_layers: usize,
+    pub decoder_num_attention_heads: usize,
+    pub decoder_attention_head_dim: usize,
+    pub decoder_num_register_tokens: usize,
+    pub decoder_ffn_mult: usize,
+    pub decoder_rope_theta: f64,
+    pub decoder_rope_dim_ratio: f64,
+    pub decoder_norm_eps: f64,
+    pub clip_length: usize,
+    pub token_drop: usize,
+    pub latents_mean: Vec<f32>,
+    pub latents_std: Vec<f32>,
+    pub tile_size: usize,
+    pub tile_overlap_min: usize,
+    pub tiling: bool,
+}
+
+impl Default for MiniMaxH3VisualVaeConfig {
+    fn default() -> Self {
+        Self::production()
+    }
+}
+
+impl MiniMaxH3VisualVaeConfig {
+    pub fn production() -> Self {
+        Self {
+            in_channels: 3,
+            out_channels: 3,
+            latent_channels: 24,
+            block_out_channels: vec![128, 256, 256, 512, 512, 1024],
+            layers_per_block: 2,
+            spatial_downsample_factors: vec![2, 2, 2, 2, 1, 1],
+            temporal_downsample_factors: vec![1, 2, 2, 1, 1, 1],
+            norm_num_groups: 32,
+            norm_eps: 1e-6,
+            spatial_padding_mode: "reflect".into(),
+            decoder_num_layers: 36,
+            decoder_num_attention_heads: 32,
+            decoder_attention_head_dim: 64,
+            decoder_num_register_tokens: 4,
+            decoder_ffn_mult: 4,
+            decoder_rope_theta: 100.0,
+            decoder_rope_dim_ratio: 0.75,
+            decoder_norm_eps: 1e-5,
+            clip_length: 17,
+            token_drop: 3,
+            latents_mean: H3_LATENTS_MEAN.to_vec(),
+            latents_std: H3_LATENTS_STD.to_vec(),
+            tile_size: 256,
+            tile_overlap_min: 64,
+            tiling: true,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn tiny_for_tests() -> Self {
+        Self {
+            in_channels: 3,
+            out_channels: 3,
+            latent_channels: 2,
+            block_out_channels: vec![4, 8],
+            layers_per_block: 1,
+            spatial_downsample_factors: vec![2, 2],
+            temporal_downsample_factors: vec![2, 2],
+            norm_num_groups: 2,
+            norm_eps: 1e-6,
+            spatial_padding_mode: "reflect".into(),
+            decoder_num_layers: 1,
+            decoder_num_attention_heads: 1,
+            decoder_attention_head_dim: 8,
+            decoder_num_register_tokens: 2,
+            decoder_ffn_mult: 2,
+            decoder_rope_theta: 100.0,
+            decoder_rope_dim_ratio: 0.75,
+            decoder_norm_eps: 1e-5,
+            clip_length: 17,
+            token_drop: 3,
+            latents_mean: vec![0.25, -0.5],
+            latents_std: vec![1.5, 0.75],
+            tile_size: 32,
+            tile_overlap_min: 8,
+            tiling: true,
+        }
+    }
+
+    pub fn spatial_compression_ratio(&self) -> usize {
+        self.spatial_downsample_factors
+            .iter()
+            .fold(1usize, |ratio, factor| ratio.saturating_mul(*factor))
+    }
+
+    pub fn temporal_compression_ratio(&self) -> usize {
+        self.temporal_downsample_factors
+            .iter()
+            .fold(1usize, |ratio, factor| ratio.saturating_mul(*factor))
+    }
+
+    pub fn temporal_geometry(&self) -> VisualTemporalGeometry {
+        VisualTemporalGeometry {
+            clip_length: self.clip_length,
+            token_drop: self.token_drop,
+            temporal_compression: self.temporal_compression_ratio(),
+        }
+    }
+
+    pub fn validate(&self) -> Result<()> {
+        let levels = self.block_out_channels.len();
+        if levels == 0
+            || self.spatial_downsample_factors.len() != levels
+            || self.temporal_downsample_factors.len() != levels
+        {
+            bail!(
+                "H3 visual VAE channel and downsample schedules must be nonempty and equal length"
+            )
+        }
+        if self.in_channels != 3 || self.out_channels != 3 || self.latent_channels == 0 {
+            bail!("H3 visual VAE requires RGB input/output and nonzero latent channels")
+        }
+        if self.layers_per_block == 0 || self.norm_num_groups == 0 {
+            bail!("H3 visual VAE residual depth and norm groups must be positive")
+        }
+        if !self.norm_eps.is_finite()
+            || self.norm_eps <= 0.0
+            || !self.decoder_norm_eps.is_finite()
+            || self.decoder_norm_eps <= 0.0
+        {
+            bail!("H3 visual VAE normalization epsilons must be finite and positive")
+        }
+        if self.spatial_padding_mode != "reflect" {
+            bail!(
+                "H3 f16t4d24 requires reflect spatial padding, got {:?}",
+                self.spatial_padding_mode
+            )
+        }
+        if self
+            .block_out_channels
+            .iter()
+            .any(|channels| *channels == 0 || *channels % self.norm_num_groups != 0)
+        {
+            bail!("H3 visual VAE channels must be nonzero and divisible by norm groups")
+        }
+        if self
+            .spatial_downsample_factors
+            .iter()
+            .chain(self.temporal_downsample_factors.iter())
+            .any(|factor| !matches!(*factor, 1 | 2))
+        {
+            bail!("H3 visual VAE downsample factors must be 1 or 2")
+        }
+        checked_compression_ratio(&self.spatial_downsample_factors, "spatial")?;
+        checked_compression_ratio(&self.temporal_downsample_factors, "temporal")?;
+        self.temporal_geometry().validate()?;
+        if self.decoder_num_layers == 0
+            || self.decoder_num_attention_heads == 0
+            || self.decoder_attention_head_dim == 0
+            || self.decoder_ffn_mult == 0
+        {
+            bail!("H3 visual VAE decoder dimensions must be positive")
+        }
+        let decoder_dim = self
+            .decoder_num_attention_heads
+            .checked_mul(self.decoder_attention_head_dim)
+            .ok_or_else(|| candle::Error::Msg("H3 decoder width overflow".into()))?;
+        let decoder_inner = decoder_dim
+            .checked_mul(self.decoder_ffn_mult)
+            .ok_or_else(|| candle::Error::Msg("H3 decoder feed-forward width overflow".into()))?;
+        decoder_inner
+            .checked_mul(2)
+            .ok_or_else(|| candle::Error::Msg("H3 decoder gated width overflow".into()))?;
+        self.latent_channels
+            .checked_mul(2)
+            .ok_or_else(|| candle::Error::Msg("H3 posterior width overflow".into()))?;
+        self.out_channels
+            .checked_mul(self.temporal_compression_ratio())
+            .and_then(|volume| volume.checked_mul(self.spatial_compression_ratio()))
+            .and_then(|volume| volume.checked_mul(self.spatial_compression_ratio()))
+            .ok_or_else(|| candle::Error::Msg("H3 decoder patch volume overflow".into()))?;
+        let rope_dim =
+            (self.decoder_attention_head_dim as f64 * self.decoder_rope_dim_ratio) as usize;
+        if rope_dim == 0
+            || rope_dim > self.decoder_attention_head_dim
+            || !rope_dim.is_multiple_of(6)
+            || !self.decoder_rope_dim_ratio.is_finite()
+            || self.decoder_rope_dim_ratio <= 0.0
+            || !self.decoder_rope_theta.is_finite()
+            || self.decoder_rope_theta <= 0.0
+        {
+            bail!("H3 visual VAE rotary dimension must be positive, head-bounded, and divisible by six")
+        }
+        if self.latents_mean.len() != self.latent_channels
+            || self.latents_std.len() != self.latent_channels
+            || self.latents_mean.iter().any(|value| !value.is_finite())
+            || self
+                .latents_std
+                .iter()
+                .any(|value| !value.is_finite() || *value <= 0.0)
+        {
+            bail!("H3 visual VAE latent statistics do not match latent_channels")
+        }
+        SpatialTilePlan::new(
+            self.tile_size,
+            self.tile_size,
+            self.tile_overlap_min,
+            self.spatial_compression_ratio(),
+        )?;
+        Ok(())
+    }
+
+    pub fn validate_production_contract(&self) -> Result<()> {
+        self.validate()?;
+        if self != &Self::production() {
+            bail!("H3 f16t4d24 artifact metadata does not match the released production contract")
+        }
+        Ok(())
+    }
+}
+
+fn checked_compression_ratio(factors: &[usize], label: &str) -> Result<usize> {
+    factors.iter().try_fold(1usize, |ratio, factor| {
+        ratio
+            .checked_mul(*factor)
+            .ok_or_else(|| candle::Error::Msg(format!("H3 {label} compression ratio overflow")))
+    })
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum WeightLayout {
+    #[default]
+    Diffusers,
+    OfficialComfySource,
+}
+
+/// FP32 parameter storage is invariant. The released CUDA decode executes
+/// autocast-eligible projections/convolutions in FP16 while norms and rotary
+/// construction stay FP32. CPU and Metal remain FP32.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum DecodeComputePolicy {
+    #[default]
+    Reference,
+    FullF32,
+}
+
+impl DecodeComputePolicy {
+    pub fn effective_dtype(self, device: &Device) -> DType {
+        match self {
+            Self::Reference if device.is_cuda() => DType::F16,
+            Self::Reference | Self::FullF32 => DType::F32,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VisualVaePhase {
+    EncodeChunk,
+    EncodeTile,
+    DecodeChunk,
+    DecodeTile,
+    DecoderBlock,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct VisualVaeEvent {
+    pub phase: VisualVaePhase,
+    pub completed: usize,
+    pub total: usize,
+}
+
+pub trait VisualVaeObserver {
+    /// Returning an error cancels immediately at the named safe point.
+    fn checkpoint(&mut self, event: VisualVaeEvent) -> Result<()>;
+}
+
+#[derive(Default)]
+pub struct NoopVisualVaeObserver;
+
+impl VisualVaeObserver for NoopVisualVaeObserver {
+    fn checkpoint(&mut self, _event: VisualVaeEvent) -> Result<()> {
+        Ok(())
+    }
+}
+
+pub trait DecodeSink {
+    /// Receives contiguous `[B,3,T,H,W]` unit-range FP32 chunks in temporal
+    /// order. A runtime can encode/mux them immediately without retaining a
+    /// second full decoded video.
+    fn write(&mut self, frame_offset: usize, frames: &Tensor) -> Result<()>;
+}
+
+#[derive(Clone, Debug)]
+struct MixedLinear {
+    stored_weight: Tensor,
+    stored_bias: Option<Tensor>,
+    compute_weight: Option<Tensor>,
+    compute_bias: Option<Tensor>,
+    compute_dtype: DType,
+}
+
+impl MixedLinear {
+    fn new(weight: Tensor, bias: Option<Tensor>, compute_dtype: DType) -> Result<Self> {
+        let stored_weight = weight.to_dtype(DType::F32)?;
+        let stored_bias = match bias {
+            Some(bias) => Some(bias.to_dtype(DType::F32)?),
+            None => None,
+        };
+        let compute_weight = if compute_dtype == DType::F32 {
+            None
+        } else {
+            Some(stored_weight.to_dtype(compute_dtype)?)
+        };
+        let compute_bias = if compute_dtype == DType::F32 {
+            None
+        } else {
+            stored_bias
+                .as_ref()
+                .map(|bias| bias.to_dtype(compute_dtype))
+                .transpose()?
+        };
+        Ok(Self {
+            stored_weight,
+            stored_bias,
+            compute_weight,
+            compute_bias,
+            compute_dtype,
+        })
+    }
+
+    fn load(vb: VarBuilder, input: usize, output: usize, compute_dtype: DType) -> Result<Self> {
+        let weight = vb.get_with_hints((output, input), "weight", TEST_WEIGHT_INIT)?;
+        let bias = vb.get_with_hints(output, "bias", Init::Const(0.0))?;
+        Self::new(weight, Some(bias), compute_dtype)
+    }
+
+    fn forward(&self, input: &Tensor) -> Result<Tensor> {
+        let (weight, bias) = match &self.compute_weight {
+            Some(weight) => (weight, self.compute_bias.as_ref()),
+            None => (&self.stored_weight, self.stored_bias.as_ref()),
+        };
+        let input = input.to_dtype(self.compute_dtype)?;
+        let mut output_shape = input.dims().to_vec();
+        let input_dim = output_shape
+            .last()
+            .copied()
+            .ok_or_else(|| candle::Error::Msg("H3 linear input must have rank >= 1".into()))?;
+        if input_dim != weight.dim(1)? {
+            bail!(
+                "H3 linear input width {input_dim} does not match weight width {}",
+                weight.dim(1)?
+            )
+        }
+        let rows = input.elem_count() / input_dim;
+        let output = input.reshape((rows, input_dim))?.matmul(&weight.t()?)?;
+        output_shape.pop();
+        output_shape.push(weight.dim(0)?);
+        let output = output.reshape(output_shape.as_slice())?;
+        match bias {
+            Some(bias) => output.broadcast_add(bias),
+            None => Ok(output),
+        }
+    }
+
+    fn stored_dtype(&self) -> DType {
+        self.stored_weight.dtype()
+    }
+}
+
+#[derive(Clone, Debug)]
+struct Fp32Vector {
+    stored: Tensor,
+}
+
+impl Fp32Vector {
+    fn new(stored: Tensor) -> Result<Self> {
+        Ok(Self {
+            stored: stored.to_dtype(DType::F32)?,
+        })
+    }
+
+    fn value(&self) -> &Tensor {
+        &self.stored
+    }
+}
+
+#[derive(Clone, Debug)]
+struct PointwiseConv3d {
+    linear: MixedLinear,
+}
+
+impl PointwiseConv3d {
+    fn load(vb: VarBuilder, input: usize, output: usize, compute_dtype: DType) -> Result<Self> {
+        let weight = vb
+            .get_with_hints((output, input, 1, 1, 1), "weight", TEST_WEIGHT_INIT)?
+            .reshape((output, input))?;
+        let bias = vb.get_with_hints(output, "bias", Init::Const(0.0))?;
+        Ok(Self {
+            linear: MixedLinear::new(weight, Some(bias), compute_dtype)?,
+        })
+    }
+
+    fn forward(&self, input: &Tensor) -> Result<Tensor> {
+        let (batch, channels, frames, height, width) = input.dims5()?;
+        let output_channels = self.linear.stored_weight.dim(0)?;
+        self.linear
+            .forward(
+                &input
+                    .permute((0, 2, 3, 4, 1))?
+                    .contiguous()?
+                    .reshape((batch * frames * height * width, channels))?,
+            )?
+            .reshape((batch, frames, height, width, output_channels))?
+            .permute((0, 4, 1, 2, 3))
+    }
+}
+
+fn cat_tensors(tensors: &[Tensor], dim: usize) -> Result<Tensor> {
+    let refs = tensors.iter().collect::<Vec<_>>();
+    Tensor::cat(&refs, dim)
+}
+
+fn map_frames<F>(input: &Tensor, mut function: F) -> Result<Tensor>
+where
+    F: FnMut(&Tensor) -> Result<Tensor>,
+{
+    let frames = input.dim(2)?;
+    let mut output = Vec::with_capacity(frames);
+    for frame in 0..frames {
+        output.push(function(&input.narrow(2, frame, 1)?.squeeze(2)?.contiguous()?)?.unsqueeze(2)?);
+    }
+    cat_tensors(&output, 2)
+}
+
+#[derive(Clone, Debug)]
+struct H3CausalConv3d {
+    temporal_kernel: usize,
+    temporal_stride: usize,
+    spatial_padding: usize,
+    slices: Vec<Conv2d>,
+    bias: Tensor,
+}
+
+impl H3CausalConv3d {
+    fn load(
+        vb: VarBuilder,
+        input_channels: usize,
+        output_channels: usize,
+        kernel: usize,
+        temporal_stride: usize,
+        spatial_stride: usize,
+        spatial_padding: usize,
+    ) -> Result<Self> {
+        let weight = vb.get_with_hints(
+            (output_channels, input_channels, kernel, kernel, kernel),
+            "weight",
+            TEST_WEIGHT_INIT,
+        )?;
+        let bias = vb.get_with_hints(output_channels, "bias", Init::Const(0.0))?;
+        let mut slices = Vec::with_capacity(kernel);
+        for temporal in 0..kernel {
+            slices.push(Conv2d::new(
+                weight.i((.., .., temporal, .., ..))?.contiguous()?,
+                None,
+                Conv2dConfig {
+                    stride: spatial_stride,
+                    ..Default::default()
+                },
+            ));
+        }
+        Ok(Self {
+            temporal_kernel: kernel,
+            temporal_stride,
+            spatial_padding,
+            slices,
+            bias,
+        })
+    }
+
+    fn forward(&self, input: &Tensor) -> Result<Tensor> {
+        let (batch, channels, _frames, height, width) = input.dims5()?;
+        if input.dtype() != DType::F32 {
+            bail!("H3 causal encoder convolutions require FP32 activations")
+        }
+        let front = self.temporal_kernel.saturating_sub(1);
+        let input = if front == 0 {
+            input.clone()
+        } else {
+            Tensor::cat(
+                &[
+                    &Tensor::zeros(
+                        (batch, channels, front, height, width),
+                        DType::F32,
+                        input.device(),
+                    )?,
+                    input,
+                ],
+                2,
+            )?
+        };
+        let padded_frames = input.dim(2)?;
+        if padded_frames < self.temporal_kernel {
+            bail!("H3 causal convolution received too few temporal frames")
+        }
+        let output_frames = (padded_frames - self.temporal_kernel) / self.temporal_stride + 1;
+        let mut outputs = Vec::with_capacity(output_frames);
+        for output_frame in 0..output_frames {
+            let base = output_frame * self.temporal_stride;
+            let mut accumulated: Option<Tensor> = None;
+            for kernel_frame in 0..self.temporal_kernel {
+                let frame = input
+                    .narrow(2, base + kernel_frame, 1)?
+                    .squeeze(2)?
+                    .contiguous()?;
+                let frame = reflect_pad_4d(&frame, self.spatial_padding, self.spatial_padding)?;
+                let projected = frame.apply(&self.slices[kernel_frame])?;
+                accumulated = Some(match accumulated {
+                    Some(previous) => previous.add(&projected)?,
+                    None => projected,
+                });
+            }
+            outputs.push(
+                accumulated
+                    .ok_or_else(|| {
+                        candle::Error::Msg("H3 causal convolution has no kernel slices".into())
+                    })?
+                    .unsqueeze(2)?,
+            );
+        }
+        let output = cat_tensors(&outputs, 2)?;
+        output.broadcast_add(&self.bias.reshape((1, self.bias.dim(0)?, 1, 1, 1))?)
+    }
+}
+
+fn reflect_pad_4d(input: &Tensor, pad_h: usize, pad_w: usize) -> Result<Tensor> {
+    let (_, _, height, width) = input.dims4()?;
+    if (pad_h > 0 && height <= pad_h) || (pad_w > 0 && width <= pad_w) {
+        bail!(
+            "H3 reflect padding requires spatial dimensions larger than padding, got {height}x{width} pad={pad_h}x{pad_w}"
+        )
+    }
+    let mut output = input.clone();
+    if pad_w > 0 {
+        let left = output.narrow(3, 1, pad_w)?.contiguous()?.flip(&[3])?;
+        let right = output
+            .narrow(3, width - pad_w - 1, pad_w)?
+            .contiguous()?
+            .flip(&[3])?;
+        output = Tensor::cat(&[&left, &output, &right], 3)?;
+    }
+    if pad_h > 0 {
+        let top = output.narrow(2, 1, pad_h)?.contiguous()?.flip(&[2])?;
+        let bottom = output
+            .narrow(2, height - pad_h - 1, pad_h)?
+            .contiguous()?
+            .flip(&[2])?;
+        output = Tensor::cat(&[&top, &output, &bottom], 2)?;
+    }
+    Ok(output)
+}
+
+fn pad_bottom_right_reflect(input: &Tensor) -> Result<Tensor> {
+    let (_, _, _, height, width) = input.dims5()?;
+    if height < 2 || width < 2 {
+        bail!("H3 stride-2 reflect padding requires at least 2x2 input")
+    }
+    let right = input.narrow(4, width - 2, 1)?.contiguous()?;
+    let with_right = Tensor::cat(&[input, &right], 4)?;
+    let bottom = with_right.narrow(3, height - 2, 1)?.contiguous()?;
+    Tensor::cat(&[&with_right, &bottom], 3)
+}
+
+#[derive(Clone, Debug)]
+struct TemporalIsolatedGroupNorm {
+    norm: GroupNorm,
+}
+
+impl TemporalIsolatedGroupNorm {
+    fn load(vb: VarBuilder, groups: usize, channels: usize, eps: f64) -> Result<Self> {
+        let weight = vb.get_with_hints(channels, "weight", Init::Const(1.0))?;
+        let bias = vb.get_with_hints(channels, "bias", Init::Const(0.0))?;
+        Ok(Self {
+            norm: GroupNorm::new(weight, bias, channels, groups, eps)?,
+        })
+    }
+
+    fn forward(&self, input: &Tensor) -> Result<Tensor> {
+        map_frames(input, |frame| frame.apply(&self.norm))
+    }
+}
+
+#[derive(Clone, Debug)]
+struct H3ResnetBlock3d {
+    norm1: TemporalIsolatedGroupNorm,
+    conv1: H3CausalConv3d,
+    norm2: TemporalIsolatedGroupNorm,
+    conv2: H3CausalConv3d,
+    shortcut: Option<H3CausalConv3d>,
+}
+
+impl H3ResnetBlock3d {
+    fn load(
+        vb: VarBuilder,
+        input_channels: usize,
+        output_channels: usize,
+        groups: usize,
+        eps: f64,
+        shortcut_name: &str,
+    ) -> Result<Self> {
+        Ok(Self {
+            norm1: TemporalIsolatedGroupNorm::load(vb.pp("norm1"), groups, input_channels, eps)?,
+            conv1: H3CausalConv3d::load(
+                vb.pp("conv1"),
+                input_channels,
+                output_channels,
+                3,
+                1,
+                1,
+                1,
+            )?,
+            norm2: TemporalIsolatedGroupNorm::load(vb.pp("norm2"), groups, output_channels, eps)?,
+            conv2: H3CausalConv3d::load(
+                vb.pp("conv2"),
+                output_channels,
+                output_channels,
+                3,
+                1,
+                1,
+                1,
+            )?,
+            shortcut: if input_channels == output_channels {
+                None
+            } else {
+                Some(H3CausalConv3d::load(
+                    vb.pp(shortcut_name),
+                    input_channels,
+                    output_channels,
+                    1,
+                    1,
+                    1,
+                    0,
+                )?)
+            },
+        })
+    }
+
+    fn forward(&self, input: &Tensor) -> Result<Tensor> {
+        let hidden = self
+            .conv1
+            .forward(&ops::silu(&self.norm1.forward(input)?)?)?;
+        let hidden = self
+            .conv2
+            .forward(&ops::silu(&self.norm2.forward(&hidden)?)?)?;
+        let residual = match &self.shortcut {
+            Some(shortcut) => shortcut.forward(input)?,
+            None => input.clone(),
+        };
+        hidden.add(&residual)
+    }
+}
+
+#[derive(Clone, Debug)]
+struct H3Downsample3d {
+    spatial_stride: usize,
+    conv: H3CausalConv3d,
+}
+
+impl H3Downsample3d {
+    fn load(
+        vb: VarBuilder,
+        channels: usize,
+        temporal_stride: usize,
+        spatial_stride: usize,
+    ) -> Result<Self> {
+        Ok(Self {
+            spatial_stride,
+            conv: H3CausalConv3d::load(
+                vb,
+                channels,
+                channels,
+                3,
+                temporal_stride,
+                spatial_stride,
+                0,
+            )?,
+        })
+    }
+
+    fn forward(&self, input: &Tensor) -> Result<Tensor> {
+        let input = if self.spatial_stride == 2 {
+            pad_bottom_right_reflect(input)?
+        } else {
+            input.clone()
+        };
+        self.conv.forward(&input)
+    }
+}
+
+#[derive(Clone, Debug)]
+struct H3EncoderLevel {
+    blocks: Vec<H3ResnetBlock3d>,
+    downsample: Option<H3Downsample3d>,
+}
+
+#[derive(Clone, Debug)]
+struct H3Encoder3d {
+    conv_in: H3CausalConv3d,
+    levels: Vec<H3EncoderLevel>,
+    norm_out: TemporalIsolatedGroupNorm,
+    conv_out: H3CausalConv3d,
+}
+
+impl H3Encoder3d {
+    fn load(
+        config: &MiniMaxH3VisualVaeConfig,
+        vb: VarBuilder,
+        layout: WeightLayout,
+    ) -> Result<Self> {
+        let conv_in = H3CausalConv3d::load(
+            vb.pp("encoder.conv_in"),
+            config.in_channels,
+            config.block_out_channels[0],
+            3,
+            1,
+            1,
+            1,
+        )?;
+        let mut levels = Vec::with_capacity(config.block_out_channels.len());
+        for level in 0..config.block_out_channels.len() {
+            let output_channels = config.block_out_channels[level];
+            let input_channels = if level == 0 {
+                output_channels
+            } else {
+                config.block_out_channels[level - 1]
+            };
+            let mut blocks = Vec::with_capacity(config.layers_per_block);
+            for block in 0..config.layers_per_block {
+                let block_input = if block == 0 {
+                    input_channels
+                } else {
+                    output_channels
+                };
+                let prefix = match layout {
+                    WeightLayout::Diffusers => {
+                        format!("encoder.down_blocks.{level}.resnets.{block}")
+                    }
+                    WeightLayout::OfficialComfySource => {
+                        format!("encoder.down.{level}.block.{block}")
+                    }
+                };
+                blocks.push(H3ResnetBlock3d::load(
+                    vb.pp(prefix),
+                    block_input,
+                    output_channels,
+                    config.norm_num_groups,
+                    config.norm_eps,
+                    match layout {
+                        WeightLayout::Diffusers => "conv_shortcut",
+                        WeightLayout::OfficialComfySource => "nin_shortcut",
+                    },
+                )?);
+            }
+            let downsample = if config.spatial_downsample_factors[level]
+                * config.temporal_downsample_factors[level]
+                > 1
+            {
+                let prefix = match layout {
+                    WeightLayout::Diffusers => {
+                        format!("encoder.down_blocks.{level}.downsamplers.0.conv")
+                    }
+                    WeightLayout::OfficialComfySource => {
+                        format!("encoder.down.{level}.downsample.conv")
+                    }
+                };
+                Some(H3Downsample3d::load(
+                    vb.pp(prefix),
+                    output_channels,
+                    config.temporal_downsample_factors[level],
+                    config.spatial_downsample_factors[level],
+                )?)
+            } else {
+                None
+            };
+            levels.push(H3EncoderLevel { blocks, downsample });
+        }
+        let final_channels =
+            config.block_out_channels.last().copied().ok_or_else(|| {
+                candle::Error::Msg("H3 visual VAE channel schedule is empty".into())
+            })?;
+        Ok(Self {
+            conv_in,
+            levels,
+            norm_out: TemporalIsolatedGroupNorm::load(
+                vb.pp("encoder.norm_out"),
+                config.norm_num_groups,
+                final_channels,
+                config.norm_eps,
+            )?,
+            conv_out: H3CausalConv3d::load(
+                vb.pp("encoder.conv_out"),
+                final_channels,
+                config.latent_channels * 2,
+                3,
+                1,
+                1,
+                1,
+            )?,
+        })
+    }
+
+    fn forward(&self, input: &Tensor) -> Result<Tensor> {
+        let mut hidden = self.conv_in.forward(input)?;
+        for level in &self.levels {
+            for block in &level.blocks {
+                hidden = block.forward(&hidden)?;
+            }
+            if let Some(downsample) = &level.downsample {
+                hidden = downsample.forward(&hidden)?;
+            }
+        }
+        self.conv_out
+            .forward(&ops::silu(&self.norm_out.forward(&hidden)?)?)
+    }
+}
+
+#[derive(Clone, Debug)]
+struct Fp32RmsNorm {
+    weight: Option<Tensor>,
+    eps: f64,
+}
+
+impl Fp32RmsNorm {
+    fn load_affine(vb: VarBuilder, dim: usize, eps: f64) -> Result<Self> {
+        Ok(Self {
+            weight: Some(
+                vb.get_with_hints(dim, "weight", Init::Const(1.0))?
+                    .to_dtype(DType::F32)?,
+            ),
+            eps,
+        })
+    }
+
+    fn no_affine(eps: f64) -> Self {
+        Self { weight: None, eps }
+    }
+
+    fn forward(&self, input: &Tensor, output_dtype: DType) -> Result<Tensor> {
+        let input32 = input.to_dtype(DType::F32)?;
+        let variance = input32.sqr()?.mean_keepdim(D::Minus1)?;
+        let normalized = input32.broadcast_div(&variance.affine(1.0, self.eps)?.sqrt()?)?;
+        let normalized = match &self.weight {
+            Some(weight) => normalized.broadcast_mul(weight)?,
+            None => normalized,
+        };
+        normalized.to_dtype(output_dtype)
+    }
+}
+
+#[derive(Clone, Debug)]
+struct Fp32LayerNorm {
+    weight: Tensor,
+    bias: Tensor,
+    eps: f64,
+}
+
+impl Fp32LayerNorm {
+    fn load(vb: VarBuilder, dim: usize, eps: f64) -> Result<Self> {
+        Ok(Self {
+            weight: vb
+                .get_with_hints(dim, "weight", Init::Const(1.0))?
+                .to_dtype(DType::F32)?,
+            bias: vb
+                .get_with_hints(dim, "bias", Init::Const(0.0))?
+                .to_dtype(DType::F32)?,
+            eps,
+        })
+    }
+
+    fn forward(&self, input: &Tensor, output_dtype: DType) -> Result<Tensor> {
+        let input = input.to_dtype(DType::F32)?;
+        let mean = input.mean_keepdim(D::Minus1)?;
+        let centered = input.broadcast_sub(&mean)?;
+        let variance = centered.sqr()?.mean_keepdim(D::Minus1)?;
+        centered
+            .broadcast_div(&variance.affine(1.0, self.eps)?.sqrt()?)?
+            .broadcast_mul(&self.weight)?
+            .broadcast_add(&self.bias)?
+            .to_dtype(output_dtype)
+    }
+}
+
+#[derive(Clone, Debug)]
+struct H3RotaryEmbedding {
+    inv_freq: Vec<f32>,
+}
+
+impl H3RotaryEmbedding {
+    fn new(dim: usize, theta: f64) -> Result<Self> {
+        if !dim.is_multiple_of(6) {
+            bail!("H3 decoder rotary dimension {dim} must be divisible by six")
+        }
+        let pairs_per_axis = dim / 6;
+        let inv_freq = (0..pairs_per_axis)
+            .map(|index| {
+                let exponent = index as f64 * 6.0 / dim as f64;
+                theta.powf(-exponent) as f32
+            })
+            .collect();
+        Ok(Self { inv_freq })
+    }
+
+    fn cos_sin(
+        &self,
+        batch: usize,
+        frames: usize,
+        height: usize,
+        width: usize,
+        suffix: usize,
+        device: &Device,
+        dtype: DType,
+    ) -> Result<(Tensor, Tensor)> {
+        let mut positions = Vec::with_capacity((frames * height * width + suffix) * 3);
+        for temporal in 0..frames {
+            let t = 2.0 * ((temporal as f32 + 0.5) / frames as f32) - 1.0;
+            for y in 0..height {
+                let h = 2.0 * ((y as f32 + 0.5) / height as f32) - 1.0;
+                for x in 0..width {
+                    let w = 2.0 * ((x as f32 + 0.5) / width as f32) - 1.0;
+                    positions.extend_from_slice(&[t, h, w]);
+                }
+            }
+        }
+        positions.resize(positions.len() + suffix * 3, 0.0);
+        let sequence = frames * height * width + suffix;
+        let mut angles = Vec::with_capacity(sequence * 3 * self.inv_freq.len() * 2);
+        for token in 0..sequence {
+            let coordinates = &positions[token * 3..token * 3 + 3];
+            let mut half = Vec::with_capacity(3 * self.inv_freq.len());
+            for coordinate in coordinates {
+                for frequency in &self.inv_freq {
+                    half.push(2.0 * std::f32::consts::PI * coordinate * frequency);
+                }
+            }
+            angles.extend_from_slice(&half);
+            angles.extend_from_slice(&half);
+        }
+        let angle = Tensor::from_vec(angles, (1, 1, sequence, 6 * self.inv_freq.len()), device)?;
+        let cos = angle.cos()?.to_dtype(dtype)?.repeat((batch, 1, 1, 1))?;
+        let sin = angle.sin()?.to_dtype(dtype)?.repeat((batch, 1, 1, 1))?;
+        Ok((cos, sin))
+    }
+}
+
+#[derive(Clone, Debug)]
+struct H3Attention {
+    qkv: MixedLinear,
+    qkv_layout: WeightLayout,
+    output: MixedLinear,
+    q_norm: Fp32RmsNorm,
+    k_norm: Fp32RmsNorm,
+    heads: usize,
+    head_dim: usize,
+    compute_dtype: DType,
+}
+
+impl H3Attention {
+    fn load(
+        vb: VarBuilder,
+        layout: WeightLayout,
+        dim: usize,
+        heads: usize,
+        head_dim: usize,
+        eps: f64,
+        compute_dtype: DType,
+    ) -> Result<Self> {
+        let qkv = match layout {
+            WeightLayout::Diffusers => {
+                let mut weights = Vec::with_capacity(3);
+                let mut biases = Vec::with_capacity(3);
+                for projection in ["to_q", "to_k", "to_v"] {
+                    weights.push(vb.pp(projection).get_with_hints(
+                        (dim, dim),
+                        "weight",
+                        TEST_WEIGHT_INIT,
+                    )?);
+                    biases.push(
+                        vb.pp(projection)
+                            .get_with_hints(dim, "bias", Init::Const(0.0))?,
+                    );
+                }
+                MixedLinear::new(
+                    cat_tensors(&weights, 0)?,
+                    Some(cat_tensors(&biases, 0)?),
+                    compute_dtype,
+                )?
+            }
+            WeightLayout::OfficialComfySource => {
+                MixedLinear::load(vb.pp("to_qkv"), dim, dim * 3, compute_dtype)?
+            }
+        };
+        let output_prefix = match layout {
+            WeightLayout::Diffusers => "to_out.0",
+            WeightLayout::OfficialComfySource => "to_out",
+        };
+        Ok(Self {
+            qkv,
+            qkv_layout: layout,
+            output: MixedLinear::load(vb.pp(output_prefix), dim, dim, compute_dtype)?,
+            q_norm: Fp32RmsNorm::no_affine(eps),
+            k_norm: Fp32RmsNorm::no_affine(eps),
+            heads,
+            head_dim,
+            compute_dtype,
+        })
+    }
+
+    fn forward(&self, input: &Tensor, cos: &Tensor, sin: &Tensor) -> Result<Tensor> {
+        let (batch, sequence, dim) = input.dims3()?;
+        let qkv = self.qkv.forward(input)?;
+        let (query, key, value) =
+            split_qkv_layout(&qkv, self.qkv_layout, self.heads, self.head_dim)?;
+        let mut query = self.q_norm.forward(&query, self.compute_dtype)?;
+        let mut key = self.k_norm.forward(&key, self.compute_dtype)?;
+        let value = value.to_dtype(self.compute_dtype)?;
+        let rotary_dim = cos.dim(D::Minus1)?;
+        query = apply_rope(&query, cos, sin, rotary_dim)?;
+        key = apply_rope(&key, cos, sin, rotary_dim)?;
+        let scores = query
+            .matmul(&key.transpose(2, 3)?)?
+            .affine(1.0 / (self.head_dim as f64).sqrt(), 0.0)?;
+        let attention = ops::softmax_last_dim(&scores)?;
+        let hidden = attention
+            .matmul(&value)?
+            .permute((0, 2, 1, 3))?
+            .contiguous()?
+            .reshape((batch, sequence, dim))?;
+        self.output.forward(&hidden)
+    }
+}
+
+fn split_qkv_layout(
+    qkv: &Tensor,
+    layout: WeightLayout,
+    heads: usize,
+    head_dim: usize,
+) -> Result<(Tensor, Tensor, Tensor)> {
+    let (batch, sequence, width) = qkv.dims3()?;
+    let dim = heads
+        .checked_mul(head_dim)
+        .ok_or_else(|| candle::Error::Msg("H3 attention width overflow".into()))?;
+    let fused_dim = dim
+        .checked_mul(3)
+        .ok_or_else(|| candle::Error::Msg("H3 fused QKV width overflow".into()))?;
+    if width != fused_dim {
+        bail!("H3 fused QKV width {width} does not match 3 * {dim}")
+    }
+    let project = |tensor: Tensor| -> Result<Tensor> {
+        tensor
+            .reshape((batch, sequence, heads, head_dim))?
+            .permute((0, 2, 1, 3))?
+            .contiguous()
+    };
+    match layout {
+        WeightLayout::Diffusers => Ok((
+            project(qkv.narrow(2, 0, dim)?)?,
+            project(qkv.narrow(2, dim, dim)?)?,
+            project(qkv.narrow(2, 2 * dim, dim)?)?,
+        )),
+        WeightLayout::OfficialComfySource => {
+            let fused_head_dim = head_dim
+                .checked_mul(3)
+                .ok_or_else(|| candle::Error::Msg("H3 fused head width overflow".into()))?;
+            let qkv = qkv.reshape((batch, sequence, heads, fused_head_dim))?;
+            Ok((
+                qkv.narrow(3, 0, head_dim)?
+                    .permute((0, 2, 1, 3))?
+                    .contiguous()?,
+                qkv.narrow(3, head_dim, head_dim)?
+                    .permute((0, 2, 1, 3))?
+                    .contiguous()?,
+                qkv.narrow(3, 2 * head_dim, head_dim)?
+                    .permute((0, 2, 1, 3))?
+                    .contiguous()?,
+            ))
+        }
+    }
+}
+
+fn apply_rope(input: &Tensor, cos: &Tensor, sin: &Tensor, rotary_dim: usize) -> Result<Tensor> {
+    let head_dim = input.dim(D::Minus1)?;
+    if rotary_dim > head_dim || !rotary_dim.is_multiple_of(2) {
+        bail!("H3 rotary width is invalid for attention head")
+    }
+    let rotary = input.narrow(D::Minus1, 0, rotary_dim)?;
+    let half = rotary_dim / 2;
+    let first = rotary.narrow(D::Minus1, 0, half)?;
+    let second = rotary.narrow(D::Minus1, half, half)?;
+    let rotated = Tensor::cat(&[&second.neg()?, &first], D::Minus1)?;
+    let rotary = rotary
+        .broadcast_mul(cos)?
+        .add(&rotated.broadcast_mul(sin)?)?;
+    if rotary_dim == head_dim {
+        Ok(rotary)
+    } else {
+        Tensor::cat(
+            &[
+                &rotary,
+                &input.narrow(D::Minus1, rotary_dim, head_dim - rotary_dim)?,
+            ],
+            D::Minus1,
+        )
+    }
+}
+
+#[derive(Clone, Debug)]
+struct H3FeedForward {
+    input: MixedLinear,
+    output: MixedLinear,
+    inner: usize,
+    gate_first: bool,
+}
+
+impl H3FeedForward {
+    fn load(
+        vb: VarBuilder,
+        layout: WeightLayout,
+        dim: usize,
+        mult: usize,
+        compute_dtype: DType,
+    ) -> Result<Self> {
+        let inner = dim
+            .checked_mul(mult)
+            .ok_or_else(|| candle::Error::Msg("H3 feed-forward width overflow".into()))?;
+        let gated_inner = inner
+            .checked_mul(2)
+            .ok_or_else(|| candle::Error::Msg("H3 gated feed-forward width overflow".into()))?;
+        let (input_name, output_name) = match layout {
+            WeightLayout::Diffusers => ("net.0.proj", "net.2"),
+            WeightLayout::OfficialComfySource => ("w1", "w2"),
+        };
+        Ok(Self {
+            input: MixedLinear::load(vb.pp(input_name), dim, gated_inner, compute_dtype)?,
+            output: MixedLinear::load(vb.pp(output_name), inner, dim, compute_dtype)?,
+            inner,
+            gate_first: layout == WeightLayout::OfficialComfySource,
+        })
+    }
+
+    fn forward(&self, input: &Tensor) -> Result<Tensor> {
+        let projected = self.input.forward(input)?;
+        let (gate, value) = split_gate_value(&projected, self.inner, self.gate_first)?;
+        self.output.forward(&ops::silu(&gate)?.mul(&value)?)
+    }
+}
+
+fn split_gate_value(
+    projected: &Tensor,
+    inner: usize,
+    gate_first: bool,
+) -> Result<(Tensor, Tensor)> {
+    let expected = inner
+        .checked_mul(2)
+        .ok_or_else(|| candle::Error::Msg("H3 gated feed-forward width overflow".into()))?;
+    if projected.dim(D::Minus1)? != expected {
+        bail!("H3 feed-forward projection width does not match its inner dimension")
+    }
+    let first = projected.narrow(D::Minus1, 0, inner)?;
+    let second = projected.narrow(D::Minus1, inner, inner)?;
+    Ok(if gate_first {
+        (first, second)
+    } else {
+        (second, first)
+    })
+}
+
+#[derive(Clone, Debug)]
+struct H3TransformerBlock {
+    norm1: Fp32RmsNorm,
+    attention: H3Attention,
+    scale1: Fp32Vector,
+    norm2: Fp32RmsNorm,
+    feed_forward: H3FeedForward,
+    scale2: Fp32Vector,
+}
+
+impl H3TransformerBlock {
+    fn load(
+        vb: VarBuilder,
+        layout: WeightLayout,
+        dim: usize,
+        heads: usize,
+        head_dim: usize,
+        ffn_mult: usize,
+        eps: f64,
+        compute_dtype: DType,
+    ) -> Result<Self> {
+        Ok(Self {
+            norm1: Fp32RmsNorm::load_affine(vb.pp("norm1"), dim, eps)?,
+            attention: H3Attention::load(
+                vb.pp("attn"),
+                layout,
+                dim,
+                heads,
+                head_dim,
+                eps,
+                compute_dtype,
+            )?,
+            scale1: Fp32Vector::new(vb.get_with_hints(dim, "scale1", Init::Const(0.0))?)?,
+            norm2: Fp32RmsNorm::load_affine(vb.pp("norm2"), dim, eps)?,
+            feed_forward: H3FeedForward::load(vb.pp("ff"), layout, dim, ffn_mult, compute_dtype)?,
+            scale2: Fp32Vector::new(vb.get_with_hints(dim, "scale2", Init::Const(0.0))?)?,
+        })
+    }
+
+    fn forward(&self, input: &Tensor, cos: &Tensor, sin: &Tensor) -> Result<Tensor> {
+        // Autocast lowers the projection sites, but the released learned
+        // scales are FP32. Their pointwise products promote the residual
+        // stream back to FP32 after every branch.
+        let norm = self.norm1.forward(input, DType::F32)?;
+        let attention = self
+            .attention
+            .forward(&norm, cos, sin)?
+            .to_dtype(DType::F32)?
+            .broadcast_mul(self.scale1.value())?;
+        let hidden = input.to_dtype(DType::F32)?.add(&attention)?;
+        let norm = self.norm2.forward(&hidden, DType::F32)?;
+        hidden.add(
+            &self
+                .feed_forward
+                .forward(&norm)?
+                .to_dtype(DType::F32)?
+                .broadcast_mul(self.scale2.value())?,
+        )
+    }
+}
+
+#[derive(Clone, Debug)]
+struct H3VitDecoder3d {
+    projection_in: MixedLinear,
+    register_tokens: Fp32Vector,
+    blocks: Vec<H3TransformerBlock>,
+    norm_out: Fp32LayerNorm,
+    projection_out: MixedLinear,
+    rope: H3RotaryEmbedding,
+    num_register_tokens: usize,
+    heads: usize,
+    head_dim: usize,
+    patch_size: usize,
+    patch_size_t: usize,
+    out_channels: usize,
+    compute_dtype: DType,
+}
+
+impl H3VitDecoder3d {
+    fn load(
+        config: &MiniMaxH3VisualVaeConfig,
+        vb: VarBuilder,
+        layout: WeightLayout,
+        compute_dtype: DType,
+    ) -> Result<Self> {
+        let dim = config.decoder_num_attention_heads * config.decoder_attention_head_dim;
+        let projection_in_name = match layout {
+            WeightLayout::Diffusers => "proj_in",
+            WeightLayout::OfficialComfySource => "x_embedder",
+        };
+        let mut blocks = Vec::with_capacity(config.decoder_num_layers);
+        for block in 0..config.decoder_num_layers {
+            blocks.push(H3TransformerBlock::load(
+                vb.pp(format!("transformer_blocks.{block}")),
+                layout,
+                dim,
+                config.decoder_num_attention_heads,
+                config.decoder_attention_head_dim,
+                config.decoder_ffn_mult,
+                config.decoder_norm_eps,
+                compute_dtype,
+            )?);
+        }
+        let patch_size = config.spatial_compression_ratio();
+        let patch_size_t = config.temporal_compression_ratio();
+        let output = config.out_channels * patch_size_t * patch_size * patch_size;
+        Ok(Self {
+            projection_in: MixedLinear::load(
+                vb.pp(projection_in_name),
+                config.latent_channels,
+                dim,
+                compute_dtype,
+            )?,
+            register_tokens: Fp32Vector::new(vb.get_with_hints(
+                (1, config.decoder_num_register_tokens, dim),
+                "register_tokens",
+                TEST_WEIGHT_INIT,
+            )?)?,
+            blocks,
+            norm_out: Fp32LayerNorm::load(vb.pp("norm_out"), dim, config.decoder_norm_eps)?,
+            projection_out: MixedLinear::load(vb.pp("proj_out"), dim, output, compute_dtype)?,
+            rope: H3RotaryEmbedding::new(
+                (config.decoder_attention_head_dim as f64 * config.decoder_rope_dim_ratio) as usize,
+                config.decoder_rope_theta,
+            )?,
+            num_register_tokens: config.decoder_num_register_tokens,
+            heads: config.decoder_num_attention_heads,
+            head_dim: config.decoder_attention_head_dim,
+            patch_size,
+            patch_size_t,
+            out_channels: config.out_channels,
+            compute_dtype,
+        })
+    }
+
+    fn forward(&self, input: &Tensor, observer: &mut dyn VisualVaeObserver) -> Result<Tensor> {
+        let (batch, channels, frames, height, width) = input.dims5()?;
+        let patches = frames * height * width;
+        let mut hidden = self.projection_in.forward(
+            &input
+                .permute((0, 2, 3, 4, 1))?
+                .contiguous()?
+                .reshape((batch, patches, channels))?,
+        )?;
+        // `proj_in` is autocast-eligible, then concatenation with the released
+        // FP32 register parameters promotes the decoder residual stream.
+        hidden = hidden.to_dtype(DType::F32)?;
+        let registers = self.register_tokens.value().repeat((batch, 1, 1))?;
+        let zero = Tensor::zeros(
+            (batch, 1, self.heads * self.head_dim),
+            DType::F32,
+            input.device(),
+        )?;
+        hidden = Tensor::cat(&[&hidden, &registers, &zero], 1)?;
+        let (cos, sin) = self.rope.cos_sin(
+            batch,
+            frames,
+            height,
+            width,
+            self.num_register_tokens + 1,
+            input.device(),
+            self.compute_dtype,
+        )?;
+        for (index, block) in self.blocks.iter().enumerate() {
+            observer.checkpoint(VisualVaeEvent {
+                phase: VisualVaePhase::DecoderBlock,
+                completed: index,
+                total: self.blocks.len(),
+            })?;
+            hidden = block.forward(&hidden, &cos, &sin)?;
+        }
+        observer.checkpoint(VisualVaeEvent {
+            phase: VisualVaePhase::DecoderBlock,
+            completed: self.blocks.len(),
+            total: self.blocks.len(),
+        })?;
+        let hidden = self
+            .projection_out
+            .forward(&self.norm_out.forward(&hidden, DType::F32)?)?
+            .narrow(1, 0, patches)?;
+        let output_order: &[usize] = &[0, 4, 1, 5, 2, 6, 3, 7];
+        hidden
+            .reshape(&[
+                batch,
+                frames,
+                height,
+                width,
+                self.out_channels,
+                self.patch_size_t,
+                self.patch_size,
+                self.patch_size,
+            ])?
+            .permute(output_order)?
+            .contiguous()?
+            .reshape((
+                batch,
+                self.out_channels,
+                frames * self.patch_size_t,
+                height * self.patch_size,
+                width * self.patch_size,
+            ))
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct MiniMaxH3VisualVae {
+    config: MiniMaxH3VisualVaeConfig,
+    encoder: H3Encoder3d,
+    quant_conv: PointwiseConv3d,
+    post_quant_conv: PointwiseConv3d,
+    decoder: H3VitDecoder3d,
+    compute_dtype: DType,
+}
+
+impl MiniMaxH3VisualVae {
+    pub fn new(
+        config: MiniMaxH3VisualVaeConfig,
+        vb: VarBuilder,
+        layout: WeightLayout,
+        decode_policy: DecodeComputePolicy,
+    ) -> Result<Self> {
+        config.validate()?;
+        if vb.dtype() != DType::F32 {
+            bail!(
+                "H3 visual VAE VarBuilder must expose FP32 stored weights, got {:?}",
+                vb.dtype()
+            )
+        }
+        let compute_dtype = decode_policy.effective_dtype(vb.device());
+        let encoder = H3Encoder3d::load(&config, vb.clone(), layout)?;
+        let quant_conv = PointwiseConv3d::load(
+            vb.pp("quant_conv"),
+            config.latent_channels * 2,
+            config.latent_channels * 2,
+            DType::F32,
+        )?;
+        let post_quant_conv = PointwiseConv3d::load(
+            vb.pp("post_quant_conv"),
+            config.latent_channels,
+            config.latent_channels,
+            compute_dtype,
+        )?;
+        let decoder = H3VitDecoder3d::load(&config, vb.pp("decoder"), layout, compute_dtype)?;
+        Ok(Self {
+            config,
+            encoder,
+            quant_conv,
+            post_quant_conv,
+            decoder,
+            compute_dtype,
+        })
+    }
+
+    pub fn config(&self) -> &MiniMaxH3VisualVaeConfig {
+        &self.config
+    }
+
+    pub fn stored_weight_dtype(&self) -> DType {
+        self.decoder.projection_in.stored_dtype()
+    }
+
+    pub fn decode_compute_dtype(&self) -> DType {
+        self.compute_dtype
+    }
+
+    pub fn encode_condition_u8(
+        &self,
+        pixels: Uint8RgbPixels,
+        mode: ConditionEncodeMode,
+        observer: &mut dyn VisualVaeObserver,
+    ) -> Result<Tensor> {
+        self.encode_condition_imagenet(pixels.into_imagenet()?, mode, observer)
+    }
+
+    pub fn encode_condition_unit(
+        &self,
+        pixels: UnitRgbPixels,
+        mode: ConditionEncodeMode,
+        observer: &mut dyn VisualVaeObserver,
+    ) -> Result<Tensor> {
+        self.encode_condition_imagenet(pixels.into_imagenet()?, mode, observer)
+    }
+
+    pub fn encode_condition_signed(
+        &self,
+        pixels: SignedRgbPixels,
+        mode: ConditionEncodeMode,
+        observer: &mut dyn VisualVaeObserver,
+    ) -> Result<Tensor> {
+        self.encode_condition_imagenet(pixels.into_imagenet()?, mode, observer)
+    }
+
+    fn encode_condition_imagenet(
+        &self,
+        pixels: ImageNetPixels,
+        mode: ConditionEncodeMode,
+        observer: &mut dyn VisualVaeObserver,
+    ) -> Result<Tensor> {
+        let moments = self.encode_moments(&pixels.into_tensor(), observer)?;
+        DiagonalGaussianDistribution::from_moments(&moments)?.condition_latents(
+            mode,
+            &self.config.latents_mean,
+            &self.config.latents_std,
+        )
+    }
+
+    fn encode_moments(
+        &self,
+        pixels: &Tensor,
+        observer: &mut dyn VisualVaeObserver,
+    ) -> Result<Tensor> {
+        let (batch, channels, frames, height, width) = pixels.dims5()?;
+        if batch != 1 || channels != 3 || pixels.dtype() != DType::F32 {
+            bail!("H3 encoder expects ImageNet-normalized FP32 [1,3,T,H,W]")
+        }
+        let spatial_ratio = self.config.spatial_compression_ratio();
+        if height % spatial_ratio != 0 || width % spatial_ratio != 0 {
+            bail!(
+                "H3 encoder dimensions {width}x{height} must be divisible by spatial compression {spatial_ratio}"
+            )
+        }
+        let plan = self.config.temporal_geometry().encode_plan(frames)?;
+        if plan.single_frame {
+            return self.encode_clip(pixels, observer);
+        }
+        let mut chunks = Vec::with_capacity(plan.chunks.len());
+        for (index, chunk) in plan.chunks.iter().enumerate() {
+            observer.checkpoint(VisualVaeEvent {
+                phase: VisualVaePhase::EncodeChunk,
+                completed: index,
+                total: plan.chunks.len(),
+            })?;
+            let mut clip = pixels.narrow(2, chunk.input_start, chunk.valid_frames)?;
+            if chunk.repeated_tail_frames > 0 {
+                let tail = clip.narrow(2, chunk.valid_frames - 1, 1)?.repeat((
+                    1,
+                    1,
+                    chunk.repeated_tail_frames,
+                    1,
+                    1,
+                ))?;
+                clip = Tensor::cat(&[&clip, &tail], 2)?;
+            }
+            chunks.push(self.encode_clip(&clip, observer)?);
+        }
+        observer.checkpoint(VisualVaeEvent {
+            phase: VisualVaePhase::EncodeChunk,
+            completed: plan.chunks.len(),
+            total: plan.chunks.len(),
+        })?;
+        let moments = cat_tensors(&chunks, 2)?;
+        moments.narrow(2, 0, plan.latent_frames)
+    }
+
+    fn encode_clip(&self, pixels: &Tensor, observer: &mut dyn VisualVaeObserver) -> Result<Tensor> {
+        if !self.config.tiling {
+            return self
+                .quant_conv
+                .forward(&self.encoder.forward(pixels)?)
+                .and_then(|tensor| tensor.to_dtype(DType::F32));
+        }
+        let height_plan = SpatialTilePlan::new(
+            pixels.dim(3)?,
+            self.config.tile_size,
+            self.config.tile_overlap_min,
+            self.config.spatial_compression_ratio(),
+        )?;
+        let width_plan = SpatialTilePlan::new(
+            pixels.dim(4)?,
+            self.config.tile_size,
+            self.config.tile_overlap_min,
+            self.config.spatial_compression_ratio(),
+        )?;
+        let total = height_plan.starts.len() * width_plan.starts.len();
+        let mut rows = Vec::with_capacity(height_plan.starts.len());
+        let mut completed = 0;
+        for (&y, &tile_height) in height_plan.starts.iter().zip(&height_plan.lengths) {
+            let mut row = Vec::with_capacity(width_plan.starts.len());
+            for (&x, &tile_width) in width_plan.starts.iter().zip(&width_plan.lengths) {
+                observer.checkpoint(VisualVaeEvent {
+                    phase: VisualVaePhase::EncodeTile,
+                    completed,
+                    total,
+                })?;
+                let tile = pixels.narrow(3, y, tile_height)?.narrow(4, x, tile_width)?;
+                row.push(self.quant_conv.forward(&self.encoder.forward(&tile)?)?);
+                completed += 1;
+            }
+            rows.push(row);
+        }
+        observer.checkpoint(VisualVaeEvent {
+            phase: VisualVaePhase::EncodeTile,
+            completed,
+            total,
+        })?;
+        let ratio = self.config.spatial_compression_ratio();
+        stitch_tiles(
+            rows,
+            &height_plan
+                .overlaps
+                .iter()
+                .map(|overlap| overlap / ratio)
+                .collect::<Vec<_>>(),
+            &width_plan
+                .overlaps
+                .iter()
+                .map(|overlap| overlap / ratio)
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    pub fn decode_normalized(
+        &self,
+        latents: &Tensor,
+        observer: &mut dyn VisualVaeObserver,
+    ) -> Result<Tensor> {
+        let mut sink = CollectDecodeSink::default();
+        self.decode_normalized_to_sink(latents, &mut sink, observer)?;
+        sink.finish()
+    }
+
+    pub fn decode_normalized_to_sink(
+        &self,
+        normalized_latents: &Tensor,
+        sink: &mut dyn DecodeSink,
+        observer: &mut dyn VisualVaeObserver,
+    ) -> Result<()> {
+        let (batch, channels, latent_frames, height, width) = normalized_latents.dims5()?;
+        if batch == 0 || channels != self.config.latent_channels || height == 0 || width == 0 {
+            bail!("H3 decoder latent shape does not match the visual VAE contract")
+        }
+        if !matches!(
+            normalized_latents.dtype(),
+            DType::F16 | DType::BF16 | DType::F32 | DType::F64
+        ) {
+            bail!("H3 decoder latents must use a floating-point dtype")
+        }
+        let latents = denormalize_latents(
+            normalized_latents,
+            &self.config.latents_mean,
+            &self.config.latents_std,
+        )?
+        .to_dtype(self.compute_dtype)?;
+        let plan = self.config.temporal_geometry().decode_plan(latent_frames)?;
+        if latent_frames == 1 {
+            let decoded = self.decode_clip(&latents, observer)?;
+            let last = decoded.narrow(2, decoded.dim(2)? - 1, 1)?;
+            sink.write(0, &denormalize_imagenet(&last)?)?;
+            return Ok(());
+        }
+        let padded = if plan.repeated_tail_tokens > 0 {
+            let tail = latents.narrow(2, latent_frames - 1, 1)?.repeat((
+                1,
+                1,
+                plan.repeated_tail_tokens,
+                1,
+                1,
+            ))?;
+            Tensor::cat(&[&latents, &tail], 2)?
+        } else {
+            latents
+        };
+        let chunk_decoded_frames = plan.tokens_per_chunk * self.config.temporal_compression_ratio();
+        let split_count = usize::from(self.config.token_drop > 0) + 1;
+        let mut overlap: Option<Tensor> = None;
+        let mut written = 0;
+        for (index, chunk) in plan.chunks.iter().enumerate() {
+            observer.checkpoint(VisualVaeEvent {
+                phase: VisualVaePhase::DecodeChunk,
+                completed: index,
+                total: plan.chunks.len(),
+            })?;
+            let clip = padded.narrow(2, chunk.latent_start, chunk.latent_frames)?;
+            let decoded = self.decode_clip(&clip, observer)?;
+            for split in 0..split_count {
+                let start = split * chunk_decoded_frames;
+                let end = (start + chunk_decoded_frames).min(decoded.dim(2)?);
+                if end <= start + plan.frame_pre_padding {
+                    continue;
+                }
+                let mut part = decoded.narrow(2, start, end - start)?.narrow(
+                    2,
+                    plan.frame_pre_padding,
+                    end - start - plan.frame_pre_padding,
+                )?;
+                if split == 0 {
+                    if let Some(previous) = overlap.take() {
+                        part = blend(&previous, &part, plan.frame_overlap, 2)?;
+                    }
+                    write_limited(
+                        sink,
+                        &denormalize_imagenet(&part)?,
+                        &mut written,
+                        plan.output_frames,
+                    )?;
+                } else {
+                    overlap = Some(part.contiguous()?);
+                }
+            }
+        }
+        if let Some(overlap) = overlap {
+            write_limited(
+                sink,
+                &denormalize_imagenet(&overlap)?,
+                &mut written,
+                plan.output_frames,
+            )?;
+        }
+        observer.checkpoint(VisualVaeEvent {
+            phase: VisualVaePhase::DecodeChunk,
+            completed: plan.chunks.len(),
+            total: plan.chunks.len(),
+        })?;
+        if written != plan.output_frames {
+            bail!(
+                "H3 streamed decode wrote {written} frames but planned {}",
+                plan.output_frames
+            )
+        }
+        Ok(())
+    }
+
+    fn decode_clip(
+        &self,
+        latents: &Tensor,
+        observer: &mut dyn VisualVaeObserver,
+    ) -> Result<Tensor> {
+        if !self.config.tiling {
+            return self
+                .decoder
+                .forward(&self.post_quant_conv.forward(latents)?, observer);
+        }
+        let ratio = self.config.spatial_compression_ratio();
+        let pixel_height = latents
+            .dim(3)?
+            .checked_mul(ratio)
+            .ok_or_else(|| candle::Error::Msg("H3 decoded height overflow".into()))?;
+        let pixel_width = latents
+            .dim(4)?
+            .checked_mul(ratio)
+            .ok_or_else(|| candle::Error::Msg("H3 decoded width overflow".into()))?;
+        let height_plan = SpatialTilePlan::new(
+            pixel_height,
+            self.config.tile_size,
+            self.config.tile_overlap_min,
+            ratio,
+        )?;
+        let width_plan = SpatialTilePlan::new(
+            pixel_width,
+            self.config.tile_size,
+            self.config.tile_overlap_min,
+            ratio,
+        )?;
+        let total = height_plan.starts.len() * width_plan.starts.len();
+        let mut canvas: Option<Tensor> = None;
+        let mut row_tails: Vec<Tensor> = Vec::new();
+        let mut output_y = 0;
+        let mut completed = 0;
+        for (row_index, (&y, &tile_height)) in height_plan
+            .starts
+            .iter()
+            .zip(&height_plan.lengths)
+            .enumerate()
+        {
+            let mut new_row_tails = Vec::with_capacity(width_plan.starts.len());
+            let mut left_tail: Option<Tensor> = None;
+            let mut output_x = 0;
+            let mut written_height = 0;
+            for (column_index, (&x, &tile_width)) in width_plan
+                .starts
+                .iter()
+                .zip(&width_plan.lengths)
+                .enumerate()
+            {
+                observer.checkpoint(VisualVaeEvent {
+                    phase: VisualVaePhase::DecodeTile,
+                    completed,
+                    total,
+                })?;
+                let tile = latents.narrow(3, y / ratio, tile_height / ratio)?.narrow(
+                    4,
+                    x / ratio,
+                    tile_width / ratio,
+                )?;
+                let mut tile = self
+                    .decoder
+                    .forward(&self.post_quant_conv.forward(&tile)?, observer)?;
+
+                // Preserve raw tails before blending, exactly as ComfyUI's
+                // preallocated tiled decoder does. No full decoded tile row is
+                // retained after its cropped body is copied into the canvas.
+                if row_index < height_plan.starts.len() - 1 {
+                    let overlap = height_plan.overlaps[row_index];
+                    new_row_tails.push(
+                        tile.narrow(3, tile.dim(3)? - overlap, overlap)?
+                            .contiguous()?,
+                    );
+                }
+                let next_left_tail = if column_index < width_plan.starts.len() - 1 {
+                    let overlap = width_plan.overlaps[column_index];
+                    Some(
+                        tile.narrow(4, tile.dim(4)? - overlap, overlap)?
+                            .contiguous()?,
+                    )
+                } else {
+                    None
+                };
+                if row_index > 0 {
+                    tile = blend(
+                        &row_tails[column_index],
+                        &tile,
+                        height_plan.overlaps[row_index - 1],
+                        3,
+                    )?;
+                }
+                if column_index > 0 {
+                    tile = blend(
+                        left_tail.as_ref().ok_or_else(|| {
+                            candle::Error::Msg("H3 decode left-tail state is missing".into())
+                        })?,
+                        &tile,
+                        width_plan.overlaps[column_index - 1],
+                        4,
+                    )?;
+                }
+                left_tail = next_left_tail;
+                if row_index < height_plan.starts.len() - 1 {
+                    tile = tile.narrow(3, 0, tile.dim(3)? - height_plan.overlaps[row_index])?;
+                }
+                if column_index < width_plan.starts.len() - 1 {
+                    tile = tile.narrow(4, 0, tile.dim(4)? - width_plan.overlaps[column_index])?;
+                }
+                let tile = tile.contiguous()?;
+                written_height = tile.dim(3)?;
+                let output = match &canvas {
+                    Some(canvas) => canvas,
+                    None => canvas.insert(Tensor::zeros(
+                        (
+                            tile.dim(0)?,
+                            tile.dim(1)?,
+                            tile.dim(2)?,
+                            pixel_height,
+                            pixel_width,
+                        ),
+                        tile.dtype(),
+                        tile.device(),
+                    )?),
+                };
+                copy_spatial_tile(output, &tile, output_y, output_x)?;
+                output_x += tile.dim(4)?;
+                completed += 1;
+            }
+            if output_x != pixel_width {
+                bail!("H3 tiled decode row wrote {output_x}px, expected {pixel_width}px")
+            }
+            row_tails = new_row_tails;
+            output_y += written_height;
+        }
+        observer.checkpoint(VisualVaeEvent {
+            phase: VisualVaePhase::DecodeTile,
+            completed,
+            total,
+        })?;
+        if output_y != pixel_height {
+            bail!("H3 tiled decode wrote {output_y}px, expected {pixel_height}px")
+        }
+        canvas.ok_or_else(|| candle::Error::Msg("H3 tiled decode produced no tiles".into()))
+    }
+}
+
+fn copy_spatial_tile(canvas: &Tensor, tile: &Tensor, y: usize, x: usize) -> Result<()> {
+    let (batch, channels, frames, canvas_height, canvas_width) = canvas.dims5()?;
+    let (tile_batch, tile_channels, tile_frames, tile_height, tile_width) = tile.dims5()?;
+    if (batch, channels, frames) != (tile_batch, tile_channels, tile_frames)
+        || y + tile_height > canvas_height
+        || x + tile_width > canvas_width
+    {
+        bail!("H3 decoded tile does not fit its output canvas")
+    }
+    let flat_canvas = canvas.flatten_all()?;
+    for batch_index in 0..batch {
+        for channel in 0..channels {
+            for frame in 0..frames {
+                for row in 0..tile_height {
+                    let destination = (((batch_index * channels + channel) * frames + frame)
+                        * canvas_height
+                        + y
+                        + row)
+                        * canvas_width
+                        + x;
+                    let source = tile
+                        .i((batch_index, channel, frame, row, ..))?
+                        .contiguous()?
+                        .flatten_all()?;
+                    flat_canvas.slice_set(&source, 0, destination)?;
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn blend(a: &Tensor, b: &Tensor, extent: usize, dim: usize) -> Result<Tensor> {
+    if extent == 0 {
+        return Ok(b.clone());
+    }
+    let extent = extent.min(a.dim(dim)?).min(b.dim(dim)?);
+    let positions = Tensor::arange(0u32, extent as u32, b.device())?.to_dtype(b.dtype())?;
+    let mut shape = vec![1usize; b.rank()];
+    shape[dim] = extent;
+    let weight_a = positions
+        .affine(-1.0 / extent as f64, 1.0)?
+        .reshape(shape.clone())?;
+    let weight_b = positions.affine(1.0 / extent as f64, 0.0)?.reshape(shape)?;
+    let blended = a
+        .narrow(dim, a.dim(dim)? - extent, extent)?
+        .broadcast_mul(&weight_a)?
+        .add(&b.narrow(dim, 0, extent)?.broadcast_mul(&weight_b)?)?;
+    if extent == b.dim(dim)? {
+        Ok(blended)
+    } else {
+        Tensor::cat(
+            &[&blended, &b.narrow(dim, extent, b.dim(dim)? - extent)?],
+            dim,
+        )
+    }
+}
+
+fn stitch_tiles(
+    rows: Vec<Vec<Tensor>>,
+    height_overlaps: &[usize],
+    width_overlaps: &[usize],
+) -> Result<Tensor> {
+    if rows.is_empty() || rows[0].is_empty() {
+        bail!("H3 tile stitch requires at least one tile")
+    }
+    let mut result_rows = Vec::with_capacity(rows.len());
+    for (row_index, row) in rows.iter().enumerate() {
+        let mut result_row = Vec::with_capacity(row.len());
+        for (column_index, raw_tile) in row.iter().enumerate() {
+            let mut tile = raw_tile.clone();
+            if row_index > 0 {
+                tile = blend(
+                    &rows[row_index - 1][column_index],
+                    &tile,
+                    height_overlaps[row_index - 1],
+                    3,
+                )?;
+            }
+            if column_index > 0 {
+                tile = blend(
+                    &row[column_index - 1],
+                    &tile,
+                    width_overlaps[column_index - 1],
+                    4,
+                )?;
+            }
+            if row_index < rows.len() - 1 {
+                tile = tile.narrow(3, 0, tile.dim(3)? - height_overlaps[row_index])?;
+            }
+            if column_index < row.len() - 1 {
+                tile = tile.narrow(4, 0, tile.dim(4)? - width_overlaps[column_index])?;
+            }
+            result_row.push(tile);
+        }
+        result_rows.push(cat_tensors(&result_row, 4)?);
+    }
+    cat_tensors(&result_rows, 3)
+}
+
+fn write_limited(
+    sink: &mut dyn DecodeSink,
+    frames: &Tensor,
+    written: &mut usize,
+    total: usize,
+) -> Result<()> {
+    let count = frames.dim(2)?.min(total.saturating_sub(*written));
+    if count > 0 {
+        sink.write(*written, &frames.narrow(2, 0, count)?)?;
+        *written += count;
+    }
+    Ok(())
+}
+
+#[derive(Default)]
+struct CollectDecodeSink {
+    parts: Vec<Tensor>,
+    next_offset: usize,
+}
+
+impl DecodeSink for CollectDecodeSink {
+    fn write(&mut self, frame_offset: usize, frames: &Tensor) -> Result<()> {
+        if frame_offset != self.next_offset {
+            bail!(
+                "H3 decode sink expected frame offset {}, got {frame_offset}",
+                self.next_offset
+            )
+        }
+        self.next_offset += frames.dim(2)?;
+        self.parts.push(frames.clone());
+        Ok(())
+    }
+}
+
+impl CollectDecodeSink {
+    fn finish(self) -> Result<Tensor> {
+        if self.parts.is_empty() {
+            bail!("H3 decode produced no frames")
+        }
+        cat_tensors(&self.parts, 2)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candle_nn::VarMap;
+
+    fn build(config: MiniMaxH3VisualVaeConfig) -> (MiniMaxH3VisualVae, VarMap) {
+        let varmap = VarMap::new();
+        let vb = VarBuilder::from_varmap(&varmap, DType::F32, &Device::Cpu);
+        let model = MiniMaxH3VisualVae::new(
+            config,
+            vb,
+            WeightLayout::Diffusers,
+            DecodeComputePolicy::Reference,
+        )
+        .unwrap();
+        (model, varmap)
+    }
+
+    #[test]
+    fn tiny_encoder_executes_the_causal_shape_contract() {
+        let config = MiniMaxH3VisualVaeConfig::tiny_for_tests();
+        let (model, _) = build(config.clone());
+        let pixels = Tensor::zeros((1, 3, 22, 32, 32), DType::F32, &Device::Cpu).unwrap();
+        let moments = model
+            .encode_moments(&pixels, &mut NoopVisualVaeObserver)
+            .unwrap();
+        assert_eq!(moments.dims5().unwrap(), (1, 4, 7, 8, 8));
+        assert_eq!(model.stored_weight_dtype(), DType::F32);
+        assert_eq!(model.decode_compute_dtype(), DType::F32);
+    }
+
+    #[test]
+    fn converted_and_original_qkv_and_ff_layouts_resolve_identically() {
+        let diffusers_qkv = Tensor::from_vec(
+            vec![1f32, 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12.],
+            (1, 1, 12),
+            &Device::Cpu,
+        )
+        .unwrap();
+        let original_qkv = Tensor::from_vec(
+            vec![1f32, 2., 5., 6., 9., 10., 3., 4., 7., 8., 11., 12.],
+            (1, 1, 12),
+            &Device::Cpu,
+        )
+        .unwrap();
+        let diffusers = split_qkv_layout(&diffusers_qkv, WeightLayout::Diffusers, 2, 2).unwrap();
+        let original =
+            split_qkv_layout(&original_qkv, WeightLayout::OfficialComfySource, 2, 2).unwrap();
+        for (converted, source) in [
+            (&diffusers.0, &original.0),
+            (&diffusers.1, &original.1),
+            (&diffusers.2, &original.2),
+        ] {
+            assert_eq!(
+                converted.flatten_all().unwrap().to_vec1::<f32>().unwrap(),
+                source.flatten_all().unwrap().to_vec1::<f32>().unwrap()
+            );
+        }
+
+        let original_ff =
+            Tensor::from_vec(vec![1f32, 2., 3., 4.], (1, 1, 4), &Device::Cpu).unwrap();
+        let diffusers_ff =
+            Tensor::from_vec(vec![3f32, 4., 1., 2.], (1, 1, 4), &Device::Cpu).unwrap();
+        let original = split_gate_value(&original_ff, 2, true).unwrap();
+        let converted = split_gate_value(&diffusers_ff, 2, false).unwrap();
+        assert_eq!(
+            original.0.flatten_all().unwrap().to_vec1::<f32>().unwrap(),
+            converted.0.flatten_all().unwrap().to_vec1::<f32>().unwrap()
+        );
+        assert_eq!(
+            original.1.flatten_all().unwrap().to_vec1::<f32>().unwrap(),
+            converted.1.flatten_all().unwrap().to_vec1::<f32>().unwrap()
+        );
+    }
+
+    #[test]
+    fn tiny_decoder_executes_released_temporal_frame_counts() {
+        let mut config = MiniMaxH3VisualVaeConfig::tiny_for_tests();
+        config.tiling = false;
+        let (model, _) = build(config);
+        for (latent_frames, pixel_frames) in [(1, 1), (2, 5), (7, 22), (12, 39)] {
+            let latents =
+                Tensor::zeros((1, 2, latent_frames, 2, 2), DType::F32, &Device::Cpu).unwrap();
+            let decoded = model
+                .decode_normalized(&latents, &mut NoopVisualVaeObserver)
+                .unwrap();
+            assert_eq!(
+                decoded.dims5().unwrap(),
+                (1, 3, pixel_frames, 8, 8),
+                "latent frame count {latent_frames}"
+            );
+        }
+    }
+
+    #[test]
+    fn comfy_style_tiled_decode_streams_into_the_exact_canvas() {
+        #[derive(Default)]
+        struct CountTiles(usize);
+        impl VisualVaeObserver for CountTiles {
+            fn checkpoint(&mut self, event: VisualVaeEvent) -> Result<()> {
+                if event.phase == VisualVaePhase::DecodeTile && event.completed < event.total {
+                    self.0 += 1;
+                }
+                Ok(())
+            }
+        }
+
+        let (model, _) = build(MiniMaxH3VisualVaeConfig::tiny_for_tests());
+        let latents = Tensor::zeros((1, 2, 2, 9, 9), DType::F32, &Device::Cpu).unwrap();
+        let mut observer = CountTiles::default();
+        let decoded = model.decode_normalized(&latents, &mut observer).unwrap();
+        assert_eq!(decoded.dims5().unwrap(), (1, 3, 5, 36, 36));
+        assert_eq!(observer.0, 4);
+    }
+
+    #[test]
+    fn tiled_stitch_reconstructs_identical_overlap_samples_without_seams() {
+        let global = Tensor::arange(0u32, 36, &Device::Cpu)
+            .unwrap()
+            .to_dtype(DType::F32)
+            .unwrap()
+            .reshape((1, 1, 1, 6, 6))
+            .unwrap();
+        let rows = vec![
+            vec![
+                global.narrow(3, 0, 4).unwrap().narrow(4, 0, 4).unwrap(),
+                global.narrow(3, 0, 4).unwrap().narrow(4, 2, 4).unwrap(),
+            ],
+            vec![
+                global.narrow(3, 2, 4).unwrap().narrow(4, 0, 4).unwrap(),
+                global.narrow(3, 2, 4).unwrap().narrow(4, 2, 4).unwrap(),
+            ],
+        ];
+        let stitched = stitch_tiles(rows, &[2], &[2]).unwrap();
+        assert_eq!(
+            stitched.flatten_all().unwrap().to_vec1::<f32>().unwrap(),
+            global.flatten_all().unwrap().to_vec1::<f32>().unwrap()
+        );
+    }
+
+    #[test]
+    fn decode_stream_is_cancellable_at_a_named_safe_point() {
+        struct Cancel;
+        impl VisualVaeObserver for Cancel {
+            fn checkpoint(&mut self, event: VisualVaeEvent) -> Result<()> {
+                if event.phase == VisualVaePhase::DecodeChunk {
+                    bail!("synthetic cancellation")
+                }
+                Ok(())
+            }
+        }
+        let (model, _) = build(MiniMaxH3VisualVaeConfig::tiny_for_tests());
+        let latents = Tensor::zeros((1, 2, 7, 2, 2), DType::F32, &Device::Cpu).unwrap();
+        let error = model
+            .decode_normalized(&latents, &mut Cancel)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("synthetic cancellation"));
+    }
+
+    #[test]
+    fn dtype_policy_separates_storage_from_backend_compute() {
+        assert_eq!(
+            DecodeComputePolicy::Reference.effective_dtype(&Device::Cpu),
+            DType::F32
+        );
+        assert_eq!(
+            DecodeComputePolicy::FullF32.effective_dtype(&Device::Cpu),
+            DType::F32
+        );
+    }
+
+    #[cfg(feature = "cuda")]
+    #[test]
+    fn tiny_decoder_cpu_cuda_consistency() {
+        use std::collections::HashMap;
+
+        let config = MiniMaxH3VisualVaeConfig::tiny_for_tests();
+        let (cpu_model, varmap) = build(config.clone());
+        let cuda = Device::new_cuda(0).expect("CUDA test requires a device");
+        let tensors = varmap
+            .data()
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|(name, var)| Ok((name.clone(), var.as_tensor().to_device(&cuda)?)))
+            .collect::<Result<HashMap<_, _>>>()
+            .unwrap();
+        let cuda_model = MiniMaxH3VisualVae::new(
+            config,
+            VarBuilder::from_tensors(tensors, DType::F32, &cuda),
+            WeightLayout::Diffusers,
+            DecodeComputePolicy::Reference,
+        )
+        .unwrap();
+        assert_eq!(cuda_model.decode_compute_dtype(), DType::F16);
+        assert_eq!(
+            cuda_model.decoder.register_tokens.value().dtype(),
+            DType::F32
+        );
+        assert_eq!(
+            cuda_model.decoder.blocks[0].scale1.value().dtype(),
+            DType::F32
+        );
+        assert_eq!(
+            cuda_model.decoder.blocks[0]
+                .attention
+                .qkv
+                .compute_weight
+                .as_ref()
+                .expect("CUDA reference policy keeps an FP16 compute copy")
+                .dtype(),
+            DType::F16
+        );
+        // 9x9 latents map to 36x36 pixels, forcing the 32px/8px-overlap
+        // synthetic configuration through four streamed decode tiles.
+        let latents = Tensor::zeros((1, 2, 2, 9, 9), DType::F32, &Device::Cpu).unwrap();
+        let cpu = cpu_model
+            .decode_normalized(&latents, &mut NoopVisualVaeObserver)
+            .unwrap();
+        let gpu = cuda_model
+            .decode_normalized(
+                &latents.to_device(&cuda).unwrap(),
+                &mut NoopVisualVaeObserver,
+            )
+            .unwrap()
+            .to_device(&Device::Cpu)
+            .unwrap();
+        let max_error = cpu
+            .sub(&gpu)
+            .unwrap()
+            .abs()
+            .unwrap()
+            .max_all()
+            .unwrap()
+            .to_scalar::<f32>()
+            .unwrap();
+        assert_eq!(gpu.dims5().unwrap(), (1, 3, 5, 36, 36));
+        assert!(max_error < 0.08, "CPU/CUDA max error {max_error}");
+    }
+}

--- a/crates/mold-candle/src/minimax_h3/visual_weights.rs
+++ b/crates/mold-candle/src/minimax_h3/visual_weights.rs
@@ -1,0 +1,878 @@
+use super::visual_vae::MiniMaxH3VisualVaeConfig;
+use candle::{bail, Result};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VisualVaeComponentRole {
+    F16T4D24,
+}
+
+impl VisualVaeComponentRole {
+    pub const fn stable_id(self) -> &'static str {
+        match self {
+            Self::F16T4D24 => "minimax-h3.visual-vae.f16t4d24",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct DiffusersWeightIndex {
+    #[serde(default)]
+    pub metadata: BTreeMap<String, serde_json::Value>,
+    pub weight_map: BTreeMap<String, String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SafetensorsTensorHeader {
+    pub dtype: String,
+    pub shape: Vec<usize>,
+    pub data_offsets: [u64; 2],
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SafetensorsHeader {
+    pub tensors: BTreeMap<String, SafetensorsTensorHeader>,
+    pub header_len: u64,
+    pub file_len: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VisualVaeWeightInspection {
+    pub role: &'static str,
+    pub shard_count: usize,
+    pub tensor_count: usize,
+    pub total_size: u64,
+    /// Header/index identity only. Use [`component_fingerprint`] when a full
+    /// content fingerprint is required after authorization.
+    pub header_identity_sha256: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ComfyTensorTransform {
+    Direct {
+        source: String,
+        target: String,
+    },
+    /// Reorder the source checkpoint's per-head `[q,k,v]` rows into
+    /// contiguous `[q_all,k_all,v_all]`, then split the first axis.
+    ReorderAndSplitQkv {
+        source: String,
+        query: String,
+        key: String,
+        value: String,
+        num_attention_heads: usize,
+        attention_head_dim: usize,
+    },
+    /// Swap the source `[gate,up]` halves into Diffusers' `[up,gate]`.
+    SwapFeedForwardHalves {
+        source: String,
+        target: String,
+        split_axis: usize,
+    },
+    /// Checkpoint-only training state intentionally omitted at inference.
+    Drop {
+        source: String,
+    },
+}
+
+/// Build the complete Diffusers checkpoint key/shape contract without opening
+/// model data. Tiny configs use the same naming arithmetic in unit tests.
+pub fn expected_diffusers_weight_shapes(
+    config: &MiniMaxH3VisualVaeConfig,
+) -> Result<BTreeMap<String, Vec<usize>>> {
+    config.validate()?;
+    let mut shapes = BTreeMap::new();
+    let mut add = |name: String, shape: Vec<usize>| -> Result<()> {
+        if shapes.insert(name.clone(), shape).is_some() {
+            bail!("duplicate H3 visual VAE weight key {name}")
+        }
+        Ok(())
+    };
+    let add_conv = |add: &mut dyn FnMut(String, Vec<usize>) -> Result<()>,
+                    prefix: String,
+                    out_channels: usize,
+                    in_channels: usize,
+                    kernel: usize| {
+        add(
+            format!("{prefix}.weight"),
+            vec![out_channels, in_channels, kernel, kernel, kernel],
+        )?;
+        add(format!("{prefix}.bias"), vec![out_channels])
+    };
+    let add_norm =
+        |add: &mut dyn FnMut(String, Vec<usize>) -> Result<()>, prefix: String, channels: usize| {
+            add(format!("{prefix}.weight"), vec![channels])?;
+            add(format!("{prefix}.bias"), vec![channels])
+        };
+
+    add_conv(
+        &mut add,
+        "encoder.conv_in".into(),
+        config.block_out_channels[0],
+        config.in_channels,
+        3,
+    )?;
+    for level in 0..config.block_out_channels.len() {
+        let output_channels = config.block_out_channels[level];
+        let input_channels = if level == 0 {
+            output_channels
+        } else {
+            config.block_out_channels[level - 1]
+        };
+        for block in 0..config.layers_per_block {
+            let block_input = if block == 0 {
+                input_channels
+            } else {
+                output_channels
+            };
+            let prefix = format!("encoder.down_blocks.{level}.resnets.{block}");
+            add_norm(&mut add, format!("{prefix}.norm1"), block_input)?;
+            add_conv(
+                &mut add,
+                format!("{prefix}.conv1"),
+                output_channels,
+                block_input,
+                3,
+            )?;
+            add_norm(&mut add, format!("{prefix}.norm2"), output_channels)?;
+            add_conv(
+                &mut add,
+                format!("{prefix}.conv2"),
+                output_channels,
+                output_channels,
+                3,
+            )?;
+            if block_input != output_channels {
+                add_conv(
+                    &mut add,
+                    format!("{prefix}.conv_shortcut"),
+                    output_channels,
+                    block_input,
+                    1,
+                )?;
+            }
+        }
+        if config.spatial_downsample_factors[level] * config.temporal_downsample_factors[level] > 1
+        {
+            add_conv(
+                &mut add,
+                format!("encoder.down_blocks.{level}.downsamplers.0.conv"),
+                output_channels,
+                output_channels,
+                3,
+            )?;
+        }
+    }
+    let final_channels = config
+        .block_out_channels
+        .last()
+        .copied()
+        .ok_or_else(|| candle::Error::Msg("H3 visual VAE channel schedule is empty".into()))?;
+    add_norm(&mut add, "encoder.norm_out".into(), final_channels)?;
+    add_conv(
+        &mut add,
+        "encoder.conv_out".into(),
+        config.latent_channels * 2,
+        final_channels,
+        3,
+    )?;
+    add_conv(
+        &mut add,
+        "quant_conv".into(),
+        config.latent_channels * 2,
+        config.latent_channels * 2,
+        1,
+    )?;
+    add_conv(
+        &mut add,
+        "post_quant_conv".into(),
+        config.latent_channels,
+        config.latent_channels,
+        1,
+    )?;
+
+    let dim = config.decoder_num_attention_heads * config.decoder_attention_head_dim;
+    let inner = dim * config.decoder_ffn_mult;
+    add(
+        "decoder.proj_in.weight".into(),
+        vec![dim, config.latent_channels],
+    )?;
+    add("decoder.proj_in.bias".into(), vec![dim])?;
+    add(
+        "decoder.register_tokens".into(),
+        vec![1, config.decoder_num_register_tokens, dim],
+    )?;
+    for block in 0..config.decoder_num_layers {
+        let prefix = format!("decoder.transformer_blocks.{block}");
+        add(format!("{prefix}.norm1.weight"), vec![dim])?;
+        for projection in ["to_q", "to_k", "to_v"] {
+            add(format!("{prefix}.attn.{projection}.weight"), vec![dim, dim])?;
+            add(format!("{prefix}.attn.{projection}.bias"), vec![dim])?;
+        }
+        add(format!("{prefix}.attn.to_out.0.weight"), vec![dim, dim])?;
+        add(format!("{prefix}.attn.to_out.0.bias"), vec![dim])?;
+        add(format!("{prefix}.scale1"), vec![dim])?;
+        add(format!("{prefix}.norm2.weight"), vec![dim])?;
+        add(
+            format!("{prefix}.ff.net.0.proj.weight"),
+            vec![inner * 2, dim],
+        )?;
+        add(format!("{prefix}.ff.net.0.proj.bias"), vec![inner * 2])?;
+        add(format!("{prefix}.ff.net.2.weight"), vec![dim, inner])?;
+        add(format!("{prefix}.ff.net.2.bias"), vec![dim])?;
+        add(format!("{prefix}.scale2"), vec![dim])?;
+    }
+    add("decoder.norm_out.weight".into(), vec![dim])?;
+    add("decoder.norm_out.bias".into(), vec![dim])?;
+    let patch_volume = config.out_channels
+        * config.temporal_compression_ratio()
+        * config.spatial_compression_ratio()
+        * config.spatial_compression_ratio();
+    add("decoder.proj_out.weight".into(), vec![patch_volume, dim])?;
+    add("decoder.proj_out.bias".into(), vec![patch_volume])?;
+    Ok(shapes)
+}
+
+/// Map old bundled/Comfy source names to the converted Diffusers layout. The
+/// fused QKV transform is returned separately because it is a split, not a
+/// rename. `decoder.mask_token` is deliberately absent: it is checkpoint-only
+/// training state and unused at inference.
+pub fn comfy_tensor_transforms(
+    config: &MiniMaxH3VisualVaeConfig,
+) -> Result<Vec<ComfyTensorTransform>> {
+    let expected = expected_diffusers_weight_shapes(config)?;
+    let mut transforms = Vec::new();
+    for target in expected.keys() {
+        if target.contains(".attn.to_q.")
+            || target.contains(".attn.to_k.")
+            || target.contains(".attn.to_v.")
+            || target.contains(".ff.net.0.proj.")
+        {
+            continue;
+        }
+        let source = diffusers_to_comfy_direct_key(target);
+        transforms.push(ComfyTensorTransform::Direct {
+            source,
+            target: target.clone(),
+        });
+    }
+    for block in 0..config.decoder_num_layers {
+        for suffix in ["weight", "bias"] {
+            let prefix = format!("decoder.transformer_blocks.{block}.attn");
+            transforms.push(ComfyTensorTransform::ReorderAndSplitQkv {
+                source: format!("{prefix}.to_qkv.{suffix}"),
+                query: format!("{prefix}.to_q.{suffix}"),
+                key: format!("{prefix}.to_k.{suffix}"),
+                value: format!("{prefix}.to_v.{suffix}"),
+                num_attention_heads: config.decoder_num_attention_heads,
+                attention_head_dim: config.decoder_attention_head_dim,
+            });
+            transforms.push(ComfyTensorTransform::SwapFeedForwardHalves {
+                source: format!("decoder.transformer_blocks.{block}.ff.w1.{suffix}"),
+                target: format!("decoder.transformer_blocks.{block}.ff.net.0.proj.{suffix}"),
+                split_axis: 0,
+            });
+        }
+    }
+    transforms.push(ComfyTensorTransform::Drop {
+        source: "decoder.mask_token".into(),
+    });
+    Ok(transforms)
+}
+
+fn diffusers_to_comfy_direct_key(target: &str) -> String {
+    let mut source = target
+        .replace("encoder.down_blocks.", "encoder.down.")
+        .replace(".resnets.", ".block.")
+        .replace(".conv_shortcut.", ".nin_shortcut.")
+        .replace(".downsamplers.0.conv.", ".downsample.conv.")
+        .replace("decoder.proj_in.", "decoder.x_embedder.")
+        .replace(".attn.to_out.0.", ".attn.to_out.")
+        .replace(".ff.net.0.proj.", ".ff.w1.")
+        .replace(".ff.net.2.", ".ff.w2.");
+    // The source Downsample3D owns `downsample.conv`; some repacks flatten it
+    // to `downsample`. The loader accepts both, but the canonical source path
+    // is the nested form above.
+    if source == "decoder.proj_in" {
+        source = "decoder.x_embedder".into();
+    }
+    source
+}
+
+pub fn inspect_safetensors_header(path: &Path) -> Result<SafetensorsHeader> {
+    const MAX_HEADER: u64 = 100_000_000;
+    let mut file = File::open(path)?;
+    let file_len = file.metadata()?.len();
+    let mut len_bytes = [0u8; 8];
+    file.read_exact(&mut len_bytes)?;
+    let header_len = u64::from_le_bytes(len_bytes);
+    if header_len == 0 || header_len > MAX_HEADER || header_len + 8 > file_len {
+        bail!(
+            "invalid safetensors header length {header_len} for {}",
+            path.display()
+        )
+    }
+    let mut header_bytes = vec![0u8; header_len as usize];
+    file.read_exact(&mut header_bytes)?;
+    let raw: BTreeMap<String, serde_json::Value> =
+        serde_json::from_slice(&header_bytes).map_err(candle::Error::wrap)?;
+    let data_len = file_len - header_len - 8;
+    let mut tensors = BTreeMap::new();
+    for (name, value) in raw {
+        if name == "__metadata__" {
+            continue;
+        }
+        #[derive(Deserialize)]
+        struct Entry {
+            dtype: String,
+            shape: Vec<usize>,
+            data_offsets: [u64; 2],
+        }
+        let entry: Entry = serde_json::from_value(value).map_err(candle::Error::wrap)?;
+        if entry.data_offsets[0] > entry.data_offsets[1] || entry.data_offsets[1] > data_len {
+            bail!(
+                "invalid safetensors offsets for {name} in {}",
+                path.display()
+            )
+        }
+        let elements = entry
+            .shape
+            .iter()
+            .try_fold(1u64, |total, dim| total.checked_mul(*dim as u64))
+            .ok_or_else(|| candle::Error::Msg(format!("shape overflow for {name}")))?;
+        let element_size = dtype_size(&entry.dtype)?;
+        let expected_bytes = elements
+            .checked_mul(element_size)
+            .ok_or_else(|| candle::Error::Msg(format!("byte-size overflow for {name}")))?;
+        if entry.data_offsets[1] - entry.data_offsets[0] != expected_bytes {
+            bail!("safetensors byte range does not match dtype/shape for {name}")
+        }
+        if tensors
+            .insert(
+                name.clone(),
+                SafetensorsTensorHeader {
+                    dtype: entry.dtype,
+                    shape: entry.shape,
+                    data_offsets: entry.data_offsets,
+                },
+            )
+            .is_some()
+        {
+            bail!("duplicate safetensors tensor {name}")
+        }
+    }
+    let mut cursor = 0u64;
+    let mut ranges = tensors
+        .iter()
+        .map(|(name, tensor)| (tensor.data_offsets, name.as_str()))
+        .collect::<Vec<_>>();
+    ranges.sort_by_key(|(offsets, _)| offsets[0]);
+    for (offsets, name) in ranges {
+        if offsets[0] != cursor {
+            bail!(
+                "non-contiguous or overlapping safetensors data before {name} in {}",
+                path.display()
+            )
+        }
+        cursor = offsets[1];
+    }
+    if cursor != data_len {
+        bail!(
+            "safetensors data section has {} unclaimed bytes in {}",
+            data_len - cursor,
+            path.display()
+        )
+    }
+    Ok(SafetensorsHeader {
+        tensors,
+        header_len,
+        file_len,
+    })
+}
+
+/// Read and validate Diffusers component metadata without opening any weight
+/// shard. Unknown framework bookkeeping fields are intentionally ignored;
+/// every inference-relevant field must equal the released f16t4d24 contract.
+pub fn inspect_visual_vae_config(path: &Path) -> Result<MiniMaxH3VisualVaeConfig> {
+    let bytes = std::fs::read(path)?;
+    parse_visual_vae_config(&bytes)
+}
+
+fn parse_visual_vae_config(bytes: &[u8]) -> Result<MiniMaxH3VisualVaeConfig> {
+    let raw: serde_json::Value = serde_json::from_slice(bytes).map_err(candle::Error::wrap)?;
+    let object = raw
+        .as_object()
+        .ok_or_else(|| candle::Error::Msg("H3 visual VAE config must be a JSON object".into()))?;
+    const REQUIRED: &[&str] = &[
+        "in_channels",
+        "out_channels",
+        "latent_channels",
+        "block_out_channels",
+        "layers_per_block",
+        "spatial_downsample_factors",
+        "temporal_downsample_factors",
+        "norm_num_groups",
+        "norm_eps",
+        "spatial_padding_mode",
+        "decoder_num_layers",
+        "decoder_num_attention_heads",
+        "decoder_attention_head_dim",
+        "decoder_num_register_tokens",
+        "decoder_ffn_mult",
+        "decoder_rope_theta",
+        "decoder_rope_dim_ratio",
+        "decoder_norm_eps",
+        "clip_length",
+        "token_drop",
+        "latents_mean",
+        "latents_std",
+    ];
+    let missing = REQUIRED
+        .iter()
+        .filter(|key| !object.contains_key(**key))
+        .copied()
+        .collect::<Vec<_>>();
+    if !missing.is_empty() {
+        bail!("H3 visual VAE config is missing required fields {missing:?}")
+    }
+    let config: MiniMaxH3VisualVaeConfig =
+        serde_json::from_value(raw).map_err(candle::Error::wrap)?;
+    config.validate_production_contract()?;
+    Ok(config)
+}
+
+pub fn validate_diffusers_weight_index(
+    config: &MiniMaxH3VisualVaeConfig,
+    index_path: &Path,
+    component_dir: &Path,
+) -> Result<VisualVaeWeightInspection> {
+    config.validate_production_contract()?;
+    let index_bytes = std::fs::read(index_path)?;
+    let index: DiffusersWeightIndex =
+        serde_json::from_slice(&index_bytes).map_err(candle::Error::wrap)?;
+    let expected = expected_diffusers_weight_shapes(config)?;
+    validate_weight_map_keys(expected.keys(), index.weight_map.keys())?;
+    let expected_data_size = expected_f32_data_size(&expected)?;
+    let indexed_data_size = index
+        .metadata
+        .get("total_size")
+        .and_then(serde_json::Value::as_u64)
+        .ok_or_else(|| {
+            candle::Error::Msg(
+                "H3 visual VAE weight index is missing numeric metadata.total_size".into(),
+            )
+        })?;
+    if indexed_data_size != expected_data_size {
+        bail!(
+            "H3 visual VAE index total_size {indexed_data_size} does not match expected {expected_data_size}"
+        )
+    }
+
+    let actual_keys = index.weight_map.keys().cloned().collect::<BTreeSet<_>>();
+    let expected_keys = expected.keys().cloned().collect::<BTreeSet<_>>();
+    debug_assert_eq!(actual_keys, expected_keys);
+
+    let mut by_shard: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    for (tensor, shard) in &index.weight_map {
+        validate_shard_basename(shard)?;
+        by_shard
+            .entry(shard.clone())
+            .or_default()
+            .insert(tensor.clone());
+    }
+    let indexed_shards = by_shard.keys().cloned().collect::<BTreeSet<_>>();
+    validate_canonical_shard_names(&indexed_shards)?;
+    let present_shards = safetensors_files(component_dir)?;
+    if present_shards != indexed_shards {
+        let missing = indexed_shards
+            .difference(&present_shards)
+            .cloned()
+            .collect::<Vec<_>>();
+        let unexpected = present_shards
+            .difference(&indexed_shards)
+            .cloned()
+            .collect::<Vec<_>>();
+        bail!("H3 visual VAE shard set mismatch: missing={missing:?} unexpected={unexpected:?}")
+    }
+    let mut total_size = 0u64;
+    let mut identity = Sha256::new();
+    identity.update(VisualVaeComponentRole::F16T4D24.stable_id().as_bytes());
+    identity.update(&index_bytes);
+    for (shard, assigned) in &by_shard {
+        let path = component_dir.join(shard);
+        let header = inspect_safetensors_header(&path)?;
+        let present = header.tensors.keys().cloned().collect::<BTreeSet<_>>();
+        if &present != assigned {
+            bail!("H3 visual VAE shard {shard} contents do not match the weight index")
+        }
+        for name in assigned {
+            let tensor = &header.tensors[name];
+            if tensor.dtype != "F32" {
+                bail!(
+                    "H3 released visual VAE tensor {name} must be stored F32, got {}",
+                    tensor.dtype
+                )
+            }
+            if tensor.shape != expected[name] {
+                bail!(
+                    "H3 visual VAE tensor {name} shape mismatch: {:?} != {:?}",
+                    tensor.shape,
+                    expected[name]
+                )
+            }
+        }
+        total_size = total_size
+            .checked_add(header.file_len)
+            .ok_or_else(|| candle::Error::Msg("H3 shard size overflow".into()))?;
+        identity.update(shard.as_bytes());
+        identity.update(header.header_len.to_le_bytes());
+        identity.update(header.file_len.to_le_bytes());
+        let mut file = File::open(&path)?;
+        let mut bytes = vec![0u8; (header.header_len + 8) as usize];
+        file.read_exact(&mut bytes)?;
+        identity.update(bytes);
+    }
+    Ok(VisualVaeWeightInspection {
+        role: VisualVaeComponentRole::F16T4D24.stable_id(),
+        shard_count: by_shard.len(),
+        tensor_count: expected.len(),
+        total_size,
+        header_identity_sha256: hex_digest(identity.finalize()),
+    })
+}
+
+fn validate_weight_map_keys<'a>(
+    expected: impl Iterator<Item = &'a String>,
+    actual: impl Iterator<Item = &'a String>,
+) -> Result<()> {
+    let actual_keys = actual.cloned().collect::<BTreeSet<_>>();
+    let expected_keys = expected.cloned().collect::<BTreeSet<_>>();
+    if actual_keys != expected_keys {
+        let missing = expected_keys
+            .difference(&actual_keys)
+            .take(8)
+            .cloned()
+            .collect::<Vec<_>>();
+        let unexpected = actual_keys
+            .difference(&expected_keys)
+            .take(8)
+            .cloned()
+            .collect::<Vec<_>>();
+        bail!("H3 visual VAE weight index mismatch: missing={missing:?} unexpected={unexpected:?}")
+    }
+    Ok(())
+}
+
+/// Full content fingerprint. This intentionally reads every byte and must only
+/// be called after Mold's H3 authorization gate permits artifact access.
+pub fn component_fingerprint(paths: &[PathBuf]) -> Result<String> {
+    if paths.is_empty() {
+        bail!("cannot fingerprint an empty H3 visual VAE component")
+    }
+    let mut sorted = paths
+        .iter()
+        .map(|path| {
+            let name = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .ok_or_else(|| {
+                    candle::Error::Msg("H3 fingerprint path has no UTF-8 basename".into())
+                })?;
+            validate_shard_basename(name)?;
+            Ok((name.to_owned(), path.clone()))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    sorted.sort_by(|(left, _), (right, _)| left.cmp(right));
+    if sorted
+        .windows(2)
+        .any(|pair| pair[0].0.as_str() == pair[1].0.as_str())
+    {
+        bail!("H3 fingerprint paths contain duplicate shard basenames")
+    }
+    let mut digest = Sha256::new();
+    digest.update(VisualVaeComponentRole::F16T4D24.stable_id().as_bytes());
+    let mut buffer = vec![0u8; 1024 * 1024];
+    for (name, path) in sorted {
+        let file_len = std::fs::metadata(&path)?.len();
+        digest.update((name.len() as u64).to_le_bytes());
+        digest.update(name.as_bytes());
+        digest.update(file_len.to_le_bytes());
+        let mut file = File::open(&path)?;
+        file.seek(SeekFrom::Start(0))?;
+        loop {
+            let read = file.read(&mut buffer)?;
+            if read == 0 {
+                break;
+            }
+            digest.update(&buffer[..read]);
+        }
+    }
+    Ok(hex_digest(digest.finalize()))
+}
+
+fn expected_f32_data_size(expected: &BTreeMap<String, Vec<usize>>) -> Result<u64> {
+    expected.values().try_fold(0u64, |total, shape| {
+        let elements = shape.iter().try_fold(1u64, |elements, dimension| {
+            elements
+                .checked_mul(*dimension as u64)
+                .ok_or_else(|| candle::Error::Msg("H3 visual VAE expected shape overflow".into()))
+        })?;
+        let bytes = elements.checked_mul(4).ok_or_else(|| {
+            candle::Error::Msg("H3 visual VAE expected byte-size overflow".into())
+        })?;
+        total
+            .checked_add(bytes)
+            .ok_or_else(|| candle::Error::Msg("H3 visual VAE total byte-size overflow".into()))
+    })
+}
+
+fn validate_canonical_shard_names(shards: &BTreeSet<String>) -> Result<()> {
+    if shards.is_empty() {
+        bail!("H3 visual VAE weight index does not name any shards")
+    }
+    let count = shards.len();
+    let expected = (1..=count)
+        .map(|index| format!("diffusion_pytorch_model-{index:05}-of-{count:05}.safetensors"))
+        .collect::<BTreeSet<_>>();
+    if shards != &expected {
+        bail!("H3 visual VAE index uses a non-canonical shard sequence")
+    }
+    Ok(())
+}
+
+fn safetensors_files(component_dir: &Path) -> Result<BTreeSet<String>> {
+    let mut files = BTreeSet::new();
+    for entry in std::fs::read_dir(component_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|extension| extension.to_str()) != Some("safetensors") {
+            continue;
+        }
+        if !entry.file_type()?.is_file() {
+            bail!(
+                "H3 visual VAE shard {} must be a regular file",
+                path.display()
+            )
+        }
+        let name = entry.file_name().into_string().map_err(|_| {
+            candle::Error::Msg("H3 visual VAE shard name is not valid UTF-8".into())
+        })?;
+        if !files.insert(name.clone()) {
+            bail!("duplicate H3 visual VAE shard name {name}")
+        }
+    }
+    Ok(files)
+}
+
+fn validate_shard_basename(shard: &str) -> Result<()> {
+    let path = Path::new(shard);
+    if path.components().count() != 1
+        || path.extension().and_then(|extension| extension.to_str()) != Some("safetensors")
+    {
+        bail!("unsafe or invalid H3 visual VAE shard name {shard:?}")
+    }
+    Ok(())
+}
+
+fn dtype_size(dtype: &str) -> Result<u64> {
+    match dtype {
+        "BOOL" | "U8" | "I8" | "F8_E4M3" | "F8_E5M2" => Ok(1),
+        "I16" | "U16" | "F16" | "BF16" => Ok(2),
+        "I32" | "U32" | "F32" => Ok(4),
+        "I64" | "U64" | "F64" => Ok(8),
+        other => bail!("unsupported safetensors dtype {other}"),
+    }
+}
+
+fn hex_digest(bytes: impl AsRef<[u8]>) -> String {
+    bytes
+        .as_ref()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn production_key_contract_has_the_pinned_703_tensors() {
+        let shapes =
+            expected_diffusers_weight_shapes(&MiniMaxH3VisualVaeConfig::production()).unwrap();
+        assert_eq!(shapes.len(), 703);
+        assert_eq!(shapes["encoder.conv_in.weight"], vec![128, 3, 3, 3, 3]);
+        assert_eq!(
+            shapes["decoder.transformer_blocks.35.ff.net.0.proj.weight"],
+            vec![16384, 2048]
+        );
+        assert_eq!(shapes["decoder.proj_out.weight"], vec![3072, 2048]);
+    }
+
+    #[test]
+    fn config_inspection_accepts_only_the_released_contract() {
+        let config = MiniMaxH3VisualVaeConfig::production();
+        let bytes = serde_json::to_vec(&config).unwrap();
+        assert_eq!(parse_visual_vae_config(&bytes).unwrap(), config);
+        assert!(parse_visual_vae_config(b"{}").is_err());
+
+        let mut value = serde_json::to_value(config).unwrap();
+        value["latent_channels"] = serde_json::Value::from(16);
+        assert!(parse_visual_vae_config(&serde_json::to_vec(&value).unwrap()).is_err());
+
+        let mut value = serde_json::to_value(MiniMaxH3VisualVaeConfig::production()).unwrap();
+        value["spatial_padding_mode"] = serde_json::Value::from("zeros");
+        assert!(parse_visual_vae_config(&serde_json::to_vec(&value).unwrap()).is_err());
+    }
+
+    #[test]
+    fn comfy_mapping_names_old_encoder_and_fused_qkv_without_guessing() {
+        let config = MiniMaxH3VisualVaeConfig::tiny_for_tests();
+        let transforms = comfy_tensor_transforms(&config).unwrap();
+        assert!(transforms.contains(&ComfyTensorTransform::Direct {
+            source: "encoder.down.1.block.0.nin_shortcut.weight".into(),
+            target: "encoder.down_blocks.1.resnets.0.conv_shortcut.weight".into(),
+        }));
+        assert!(
+            transforms.contains(&ComfyTensorTransform::ReorderAndSplitQkv {
+                source: "decoder.transformer_blocks.0.attn.to_qkv.weight".into(),
+                query: "decoder.transformer_blocks.0.attn.to_q.weight".into(),
+                key: "decoder.transformer_blocks.0.attn.to_k.weight".into(),
+                value: "decoder.transformer_blocks.0.attn.to_v.weight".into(),
+                num_attention_heads: 1,
+                attention_head_dim: 8,
+            })
+        );
+        assert!(
+            transforms.contains(&ComfyTensorTransform::SwapFeedForwardHalves {
+                source: "decoder.transformer_blocks.0.ff.w1.weight".into(),
+                target: "decoder.transformer_blocks.0.ff.net.0.proj.weight".into(),
+                split_axis: 0,
+            })
+        );
+        assert!(transforms.contains(&ComfyTensorTransform::Drop {
+            source: "decoder.mask_token".into(),
+        }));
+    }
+
+    #[test]
+    fn comfy_source_plan_covers_every_source_and_target_exactly_once() {
+        let config = MiniMaxH3VisualVaeConfig::production();
+        let transforms = comfy_tensor_transforms(&config).unwrap();
+        let mut sources = BTreeSet::new();
+        let mut targets = BTreeSet::new();
+        for transform in transforms {
+            let (source, outputs): (&str, Vec<&str>) = match &transform {
+                ComfyTensorTransform::Direct { source, target }
+                | ComfyTensorTransform::SwapFeedForwardHalves { source, target, .. } => {
+                    (source, vec![target])
+                }
+                ComfyTensorTransform::ReorderAndSplitQkv {
+                    source,
+                    query,
+                    key,
+                    value,
+                    ..
+                } => (source, vec![query, key, value]),
+                ComfyTensorTransform::Drop { source } => (source, vec![]),
+            };
+            assert!(
+                sources.insert(source.to_owned()),
+                "duplicate source {source}"
+            );
+            for target in outputs {
+                assert!(
+                    targets.insert(target.to_owned()),
+                    "duplicate target {target}"
+                );
+            }
+        }
+        assert_eq!(sources.len(), 560);
+        assert_eq!(
+            targets,
+            expected_diffusers_weight_shapes(&config)
+                .unwrap()
+                .into_keys()
+                .collect()
+        );
+    }
+
+    #[test]
+    fn weight_map_drift_fails_closed_for_missing_and_unexpected_keys() {
+        let expected =
+            expected_diffusers_weight_shapes(&MiniMaxH3VisualVaeConfig::production()).unwrap();
+        let mut actual = expected.keys().cloned().collect::<BTreeSet<_>>();
+        actual.remove("encoder.conv_in.weight");
+        actual.insert("encoder.unplanned.weight".into());
+        let error = validate_weight_map_keys(expected.keys(), actual.iter())
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("encoder.conv_in.weight"));
+        assert!(error.contains("encoder.unplanned.weight"));
+    }
+
+    #[test]
+    fn header_inspection_reads_metadata_and_rejects_bad_byte_spans() {
+        let dir = std::env::temp_dir().join(format!(
+            "mold-h3-header-{}-{}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("test")
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("tiny.safetensors");
+        let header = br#"{"x":{"dtype":"F32","shape":[2],"data_offsets":[0,8]}}"#;
+        let mut bytes = (header.len() as u64).to_le_bytes().to_vec();
+        bytes.extend_from_slice(header);
+        bytes.extend_from_slice(&[0u8; 8]);
+        std::fs::write(&path, bytes).unwrap();
+        let inspected = inspect_safetensors_header(&path).unwrap();
+        assert_eq!(inspected.tensors["x"].shape, vec![2]);
+
+        let bad = br#"{"x":{"dtype":"F32","shape":[2],"data_offsets":[0,4]}}"#;
+        let mut bytes = (bad.len() as u64).to_le_bytes().to_vec();
+        bytes.extend_from_slice(bad);
+        bytes.extend_from_slice(&[0u8; 4]);
+        std::fs::write(&path, bytes).unwrap();
+        assert!(inspect_safetensors_header(&path).is_err());
+
+        let overlapping = br#"{"x":{"dtype":"F32","shape":[2],"data_offsets":[0,8]},"y":{"dtype":"F32","shape":[1],"data_offsets":[4,8]}}"#;
+        let mut bytes = (overlapping.len() as u64).to_le_bytes().to_vec();
+        bytes.extend_from_slice(overlapping);
+        bytes.extend_from_slice(&[0u8; 8]);
+        std::fs::write(&path, bytes).unwrap();
+        assert!(inspect_safetensors_header(&path).is_err());
+
+        let gap = br#"{"x":{"dtype":"F32","shape":[1],"data_offsets":[0,4]},"y":{"dtype":"F32","shape":[1],"data_offsets":[8,12]}}"#;
+        let mut bytes = (gap.len() as u64).to_le_bytes().to_vec();
+        bytes.extend_from_slice(gap);
+        bytes.extend_from_slice(&[0u8; 12]);
+        std::fs::write(&path, bytes).unwrap();
+        assert!(inspect_safetensors_header(&path).is_err());
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn shard_sequence_is_canonical_and_complete() {
+        let canonical = [
+            "diffusion_pytorch_model-00001-of-00003.safetensors".to_owned(),
+            "diffusion_pytorch_model-00002-of-00003.safetensors".to_owned(),
+            "diffusion_pytorch_model-00003-of-00003.safetensors".to_owned(),
+        ]
+        .into_iter()
+        .collect();
+        assert!(validate_canonical_shard_names(&canonical).is_ok());
+
+        let incomplete = [
+            "diffusion_pytorch_model-00001-of-00003.safetensors".to_owned(),
+            "diffusion_pytorch_model-00003-of-00003.safetensors".to_owned(),
+        ]
+        .into_iter()
+        .collect();
+        assert!(validate_canonical_shard_names(&incomplete).is_err());
+    }
+}

--- a/crates/mold-candle/src/minimax_h3/visual_weights.rs
+++ b/crates/mold-candle/src/minimax_h3/visual_weights.rs
@@ -1,11 +1,16 @@
-use super::visual_vae::MiniMaxH3VisualVaeConfig;
-use candle::{bail, Result};
+use super::visual_vae::{MiniMaxH3VisualVaeConfig, WeightLayout};
+use candle::{bail, DType, Device, Result};
+use candle_nn::VarBuilder;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs::File;
-use std::io::{Read, Seek, SeekFrom};
+use std::io::Read;
 use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum VisualVaeComponentRole {
@@ -41,6 +46,45 @@ pub struct SafetensorsHeader {
     pub file_len: u64,
 }
 
+struct UniqueSafetensorsHeader(BTreeMap<String, serde_json::Value>);
+
+impl<'de> Deserialize<'de> for UniqueSafetensorsHeader {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct UniqueHeaderVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for UniqueHeaderVisitor {
+            type Value = UniqueSafetensorsHeader;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("a safetensors header with unique tensor names")
+            }
+
+            fn visit_map<A>(
+                self,
+                mut map: A,
+            ) -> std::result::Result<UniqueSafetensorsHeader, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                let mut entries = BTreeMap::new();
+                while let Some((name, value)) = map.next_entry::<String, serde_json::Value>()? {
+                    if entries.insert(name.clone(), value).is_some() {
+                        return Err(serde::de::Error::custom(format!(
+                            "duplicate safetensors tensor {name}"
+                        )));
+                    }
+                }
+                Ok(UniqueSafetensorsHeader(entries))
+            }
+        }
+
+        deserializer.deserialize_map(UniqueHeaderVisitor)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct VisualVaeWeightInspection {
     pub role: &'static str,
@@ -50,6 +94,103 @@ pub struct VisualVaeWeightInspection {
     /// Header/index identity only. Use [`component_fingerprint`] when a full
     /// content fingerprint is required after authorization.
     pub header_identity_sha256: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct VisualWeightFileIdentity {
+    canonical_path: PathBuf,
+    len: u64,
+    #[cfg(unix)]
+    device: u64,
+    #[cfg(unix)]
+    inode: u64,
+    #[cfg(unix)]
+    modified_seconds: i64,
+    #[cfg(unix)]
+    modified_nanoseconds: i64,
+    #[cfg(unix)]
+    changed_seconds: i64,
+    #[cfg(unix)]
+    changed_nanoseconds: i64,
+    #[cfg(not(unix))]
+    modified: Option<std::time::SystemTime>,
+}
+
+/// Opaque proof that one exact visual-VAE artifact set passed its complete
+/// layout, dtype, key, shape, and immutable-file inspection. Creating this
+/// token opens model artifacts, so callers must cross Mold's authorization
+/// gate before invoking either validator that returns it.
+#[derive(Clone, Debug)]
+pub struct ValidatedVisualVaeWeights {
+    layout: WeightLayout,
+    inspection: VisualVaeWeightInspection,
+    files: Vec<VisualWeightFileIdentity>,
+}
+
+impl ValidatedVisualVaeWeights {
+    pub fn layout(&self) -> WeightLayout {
+        self.layout
+    }
+
+    pub fn artifact_dtype(&self) -> DType {
+        self.layout.artifact_dtype()
+    }
+
+    pub fn inspection(&self) -> &VisualVaeWeightInspection {
+        &self.inspection
+    }
+
+    pub fn component_fingerprint(
+        &self,
+        observer: &mut dyn VisualWeightReadObserver,
+    ) -> Result<String> {
+        self.revalidate_files()?;
+        fingerprint_identities(&self.files, observer)
+    }
+
+    pub(crate) fn revalidate_files(&self) -> Result<()> {
+        for expected in &self.files {
+            let current = visual_weight_file_identity(&expected.canonical_path)?;
+            if &current != expected {
+                bail!(
+                    "validated H3 visual VAE artifact changed after inspection: {}",
+                    expected.canonical_path.display()
+                )
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn mmap_var_builder<'a>(&self, device: &Device) -> Result<VarBuilder<'a>> {
+        self.revalidate_files()?;
+        let paths = self
+            .files
+            .iter()
+            .map(|identity| identity.canonical_path.as_path())
+            .collect::<Vec<_>>();
+        // SAFETY: every canonical regular file was fully schema-validated and
+        // its immutable file identity was rechecked immediately before mmap.
+        // The returned backend owns its mappings; a second identity check
+        // below rejects replacement or mutation racing the open operation.
+        let builder =
+            unsafe { VarBuilder::from_mmaped_safetensors(&paths, self.artifact_dtype(), device)? };
+        self.revalidate_files()?;
+        Ok(builder)
+    }
+}
+
+pub trait VisualWeightReadObserver {
+    /// Returning an error cancels hashing at the next 1 MiB read boundary.
+    fn checkpoint(&mut self, bytes_read: u64, total_bytes: u64) -> Result<()>;
+}
+
+#[derive(Default)]
+pub struct NoopVisualWeightReadObserver;
+
+impl VisualWeightReadObserver for NoopVisualWeightReadObserver {
+    fn checkpoint(&mut self, _bytes_read: u64, _total_bytes: u64) -> Result<()> {
+        Ok(())
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -285,6 +426,64 @@ pub fn comfy_tensor_transforms(
     Ok(transforms)
 }
 
+/// Exact tensor contract of Mold's pinned single-file Comfy checkpoint. The
+/// source keeps attention QKV fused per head, stores the feed-forward gate
+/// half first, and includes one unused decoder mask token.
+pub fn expected_comfy_weight_shapes(
+    config: &MiniMaxH3VisualVaeConfig,
+) -> Result<BTreeMap<String, Vec<usize>>> {
+    let diffusers = expected_diffusers_weight_shapes(config)?;
+    let mut source = BTreeMap::new();
+    let mut insert = |name: String, shape: Vec<usize>| -> Result<()> {
+        if source.insert(name.clone(), shape).is_some() {
+            bail!("duplicate H3 Comfy source weight key {name}")
+        }
+        Ok(())
+    };
+    for transform in comfy_tensor_transforms(config)? {
+        match transform {
+            ComfyTensorTransform::Direct {
+                source: source_name,
+                target,
+            }
+            | ComfyTensorTransform::SwapFeedForwardHalves {
+                source: source_name,
+                target,
+                ..
+            } => insert(source_name, diffusers[&target].clone())?,
+            ComfyTensorTransform::ReorderAndSplitQkv {
+                source: source_name,
+                query,
+                key,
+                value,
+                ..
+            } => {
+                let query_shape = &diffusers[&query];
+                if diffusers[&key] != *query_shape || diffusers[&value] != *query_shape {
+                    bail!("H3 Diffusers QKV target shapes disagree")
+                }
+                let mut fused_shape = query_shape.clone();
+                fused_shape[0] = fused_shape[0]
+                    .checked_mul(3)
+                    .ok_or_else(|| candle::Error::Msg("H3 fused QKV shape overflow".into()))?;
+                insert(source_name, fused_shape)?;
+            }
+            ComfyTensorTransform::Drop {
+                source: source_name,
+            } => {
+                let dim = config
+                    .decoder_num_attention_heads
+                    .checked_mul(config.decoder_attention_head_dim)
+                    .ok_or_else(|| {
+                        candle::Error::Msg("H3 decoder width overflow for mask token".into())
+                    })?;
+                insert(source_name, vec![1, 1, dim])?;
+            }
+        }
+    }
+    Ok(source)
+}
+
 fn diffusers_to_comfy_direct_key(target: &str) -> String {
     let mut source = target
         .replace("encoder.down_blocks.", "encoder.down.")
@@ -305,21 +504,28 @@ fn diffusers_to_comfy_direct_key(target: &str) -> String {
 }
 
 pub fn inspect_safetensors_header(path: &Path) -> Result<SafetensorsHeader> {
+    let identity = visual_weight_file_identity(path)?;
+    inspect_safetensors_header_for_identity(&identity)
+}
+
+fn inspect_safetensors_header_for_identity(
+    identity: &VisualWeightFileIdentity,
+) -> Result<SafetensorsHeader> {
     const MAX_HEADER: u64 = 100_000_000;
-    let mut file = File::open(path)?;
-    let file_len = file.metadata()?.len();
+    let mut file = open_expected_file(identity, "before header inspection")?;
+    let file_len = identity.len;
     let mut len_bytes = [0u8; 8];
     file.read_exact(&mut len_bytes)?;
     let header_len = u64::from_le_bytes(len_bytes);
     if header_len == 0 || header_len > MAX_HEADER || header_len + 8 > file_len {
         bail!(
             "invalid safetensors header length {header_len} for {}",
-            path.display()
+            identity.canonical_path.display()
         )
     }
     let mut header_bytes = vec![0u8; header_len as usize];
     file.read_exact(&mut header_bytes)?;
-    let raw: BTreeMap<String, serde_json::Value> =
+    let UniqueSafetensorsHeader(raw) =
         serde_json::from_slice(&header_bytes).map_err(candle::Error::wrap)?;
     let data_len = file_len - header_len - 8;
     let mut tensors = BTreeMap::new();
@@ -337,7 +543,7 @@ pub fn inspect_safetensors_header(path: &Path) -> Result<SafetensorsHeader> {
         if entry.data_offsets[0] > entry.data_offsets[1] || entry.data_offsets[1] > data_len {
             bail!(
                 "invalid safetensors offsets for {name} in {}",
-                path.display()
+                identity.canonical_path.display()
             )
         }
         let elements = entry
@@ -376,7 +582,7 @@ pub fn inspect_safetensors_header(path: &Path) -> Result<SafetensorsHeader> {
         if offsets[0] != cursor {
             bail!(
                 "non-contiguous or overlapping safetensors data before {name} in {}",
-                path.display()
+                identity.canonical_path.display()
             )
         }
         cursor = offsets[1];
@@ -385,9 +591,11 @@ pub fn inspect_safetensors_header(path: &Path) -> Result<SafetensorsHeader> {
         bail!(
             "safetensors data section has {} unclaimed bytes in {}",
             data_len - cursor,
-            path.display()
+            identity.canonical_path.display()
         )
     }
+    ensure_open_file_unchanged(&file, identity, "during header inspection")?;
+    ensure_identity_unchanged(identity, "during header inspection")?;
     Ok(SafetensorsHeader {
         tensors,
         header_len,
@@ -450,7 +658,7 @@ pub fn validate_diffusers_weight_index(
     config: &MiniMaxH3VisualVaeConfig,
     index_path: &Path,
     component_dir: &Path,
-) -> Result<VisualVaeWeightInspection> {
+) -> Result<ValidatedVisualVaeWeights> {
     config.validate_production_contract()?;
     let index_bytes = std::fs::read(index_path)?;
     let index: DiffusersWeightIndex =
@@ -501,11 +709,14 @@ pub fn validate_diffusers_weight_index(
     }
     let mut total_size = 0u64;
     let mut identity = Sha256::new();
+    let mut files = Vec::with_capacity(by_shard.len());
     identity.update(VisualVaeComponentRole::F16T4D24.stable_id().as_bytes());
+    identity.update(b"diffusers-f32");
     identity.update(&index_bytes);
     for (shard, assigned) in &by_shard {
         let path = component_dir.join(shard);
-        let header = inspect_safetensors_header(&path)?;
+        let file_identity = visual_weight_file_identity(&path)?;
+        let header = inspect_safetensors_header_for_identity(&file_identity)?;
         let present = header.tensors.keys().cloned().collect::<BTreeSet<_>>();
         if &present != assigned {
             bail!("H3 visual VAE shard {shard} contents do not match the weight index")
@@ -532,18 +743,113 @@ pub fn validate_diffusers_weight_index(
         identity.update(shard.as_bytes());
         identity.update(header.header_len.to_le_bytes());
         identity.update(header.file_len.to_le_bytes());
-        let mut file = File::open(&path)?;
+        let mut file = open_expected_file(&file_identity, "before header identity read")?;
         let mut bytes = vec![0u8; (header.header_len + 8) as usize];
         file.read_exact(&mut bytes)?;
         identity.update(bytes);
+        ensure_open_file_unchanged(&file, &file_identity, "during header identity read")?;
+        ensure_identity_unchanged(&file_identity, "during validation")?;
+        files.push(file_identity);
     }
-    Ok(VisualVaeWeightInspection {
-        role: VisualVaeComponentRole::F16T4D24.stable_id(),
-        shard_count: by_shard.len(),
-        tensor_count: expected.len(),
-        total_size,
-        header_identity_sha256: hex_digest(identity.finalize()),
+    Ok(ValidatedVisualVaeWeights {
+        layout: WeightLayout::Diffusers,
+        inspection: VisualVaeWeightInspection {
+            role: VisualVaeComponentRole::F16T4D24.stable_id(),
+            shard_count: by_shard.len(),
+            tensor_count: expected.len(),
+            total_size,
+            header_identity_sha256: hex_digest(identity.finalize()),
+        },
+        files,
     })
+}
+
+pub const COMFY_VISUAL_VAE_FILENAME: &str = "minimax_h3_video_vae_fp16.safetensors";
+
+/// Validate the exact pinned Comfy single-file source layout. Unlike the
+/// Diffusers conversion, this artifact is genuinely FP16 and must remain FP16
+/// in resident storage.
+pub fn validate_comfy_weight_file(
+    config: &MiniMaxH3VisualVaeConfig,
+    weight_path: &Path,
+) -> Result<ValidatedVisualVaeWeights> {
+    config.validate_production_contract()?;
+    let basename = weight_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| candle::Error::Msg("H3 Comfy VAE path has no UTF-8 basename".into()))?;
+    if basename != COMFY_VISUAL_VAE_FILENAME {
+        bail!(
+            "H3 Comfy visual VAE must use canonical filename {COMFY_VISUAL_VAE_FILENAME}, got {basename}"
+        )
+    }
+    let file_identity = visual_weight_file_identity(weight_path)?;
+    let canonical_basename = file_identity
+        .canonical_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+            candle::Error::Msg("H3 Comfy VAE canonical path has no UTF-8 basename".into())
+        })?;
+    if canonical_basename != COMFY_VISUAL_VAE_FILENAME {
+        bail!(
+            "H3 Comfy visual VAE canonical file must be named {COMFY_VISUAL_VAE_FILENAME}, got {canonical_basename}"
+        )
+    }
+    let expected = expected_comfy_weight_shapes(config)?;
+    let header = inspect_safetensors_header_for_identity(&file_identity)?;
+    validate_tensor_headers(&header, &expected, "F16", "Comfy")?;
+
+    let mut identity = Sha256::new();
+    identity.update(VisualVaeComponentRole::F16T4D24.stable_id().as_bytes());
+    identity.update(b"comfy-source-f16");
+    identity.update(basename.as_bytes());
+    identity.update(header.header_len.to_le_bytes());
+    identity.update(header.file_len.to_le_bytes());
+    let mut file = open_expected_file(&file_identity, "before header identity read")?;
+    let mut bytes = vec![0u8; (header.header_len + 8) as usize];
+    file.read_exact(&mut bytes)?;
+    identity.update(bytes);
+    ensure_open_file_unchanged(&file, &file_identity, "during header identity read")?;
+    ensure_identity_unchanged(&file_identity, "during validation")?;
+
+    Ok(ValidatedVisualVaeWeights {
+        layout: WeightLayout::OfficialComfySource,
+        inspection: VisualVaeWeightInspection {
+            role: VisualVaeComponentRole::F16T4D24.stable_id(),
+            shard_count: 1,
+            tensor_count: expected.len(),
+            total_size: header.file_len,
+            header_identity_sha256: hex_digest(identity.finalize()),
+        },
+        files: vec![file_identity],
+    })
+}
+
+fn validate_tensor_headers(
+    header: &SafetensorsHeader,
+    expected: &BTreeMap<String, Vec<usize>>,
+    expected_dtype: &str,
+    label: &str,
+) -> Result<()> {
+    validate_weight_map_keys(expected.keys(), header.tensors.keys())?;
+    for (name, shape) in expected {
+        let tensor = &header.tensors[name];
+        if tensor.dtype != expected_dtype {
+            bail!(
+                "H3 {label} visual VAE tensor {name} must be stored {expected_dtype}, got {}",
+                tensor.dtype
+            )
+        }
+        if tensor.shape != *shape {
+            bail!(
+                "H3 {label} visual VAE tensor {name} shape mismatch: {:?} != {:?}",
+                tensor.shape,
+                shape
+            )
+        }
+    }
+    Ok(())
 }
 
 fn validate_weight_map_keys<'a>(
@@ -568,51 +874,207 @@ fn validate_weight_map_keys<'a>(
     Ok(())
 }
 
-/// Full content fingerprint. This intentionally reads every byte and must only
-/// be called after Mold's H3 authorization gate permits artifact access.
+/// Full content fingerprint. This intentionally reads every byte on the first
+/// immutable file identity and must only be called after Mold's H3
+/// authorization gate permits artifact access.
 pub fn component_fingerprint(paths: &[PathBuf]) -> Result<String> {
+    component_fingerprint_with_observer(paths, &mut NoopVisualWeightReadObserver)
+}
+
+pub fn component_fingerprint_with_observer(
+    paths: &[PathBuf],
+    observer: &mut dyn VisualWeightReadObserver,
+) -> Result<String> {
     if paths.is_empty() {
         bail!("cannot fingerprint an empty H3 visual VAE component")
     }
-    let mut sorted = paths
+    let identities = paths
         .iter()
-        .map(|path| {
-            let name = path
-                .file_name()
-                .and_then(|name| name.to_str())
-                .ok_or_else(|| {
-                    candle::Error::Msg("H3 fingerprint path has no UTF-8 basename".into())
-                })?;
-            validate_shard_basename(name)?;
-            Ok((name.to_owned(), path.clone()))
-        })
+        .map(|path| visual_weight_file_identity(path))
         .collect::<Result<Vec<_>>>()?;
-    sorted.sort_by(|(left, _), (right, _)| left.cmp(right));
+    fingerprint_identities(&identities, observer)
+}
+
+fn fingerprint_identities(
+    identities: &[VisualWeightFileIdentity],
+    observer: &mut dyn VisualWeightReadObserver,
+) -> Result<String> {
+    let mut sorted = identities.to_vec();
+    sorted.sort_by(|left, right| left.canonical_path.cmp(&right.canonical_path));
     if sorted
         .windows(2)
-        .any(|pair| pair[0].0.as_str() == pair[1].0.as_str())
+        .any(|pair| pair[0].canonical_path == pair[1].canonical_path)
     {
-        bail!("H3 fingerprint paths contain duplicate shard basenames")
+        bail!("H3 fingerprint paths contain duplicate canonical files")
     }
+    let total_bytes = sorted.iter().try_fold(0u64, |total, identity| {
+        total
+            .checked_add(identity.len)
+            .ok_or_else(|| candle::Error::Msg("H3 fingerprint byte count overflow".into()))
+    })?;
+    observer.checkpoint(0, total_bytes)?;
     let mut digest = Sha256::new();
     digest.update(VisualVaeComponentRole::F16T4D24.stable_id().as_bytes());
-    let mut buffer = vec![0u8; 1024 * 1024];
-    for (name, path) in sorted {
-        let file_len = std::fs::metadata(&path)?.len();
+    let mut completed = 0u64;
+    for identity in sorted {
+        let name = identity
+            .canonical_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .ok_or_else(|| {
+                candle::Error::Msg("H3 fingerprint path has no UTF-8 basename".into())
+            })?;
+        validate_shard_basename(name)?;
         digest.update((name.len() as u64).to_le_bytes());
         digest.update(name.as_bytes());
-        digest.update(file_len.to_le_bytes());
-        let mut file = File::open(&path)?;
-        file.seek(SeekFrom::Start(0))?;
-        loop {
-            let read = file.read(&mut buffer)?;
-            if read == 0 {
-                break;
-            }
-            digest.update(&buffer[..read]);
-        }
+        digest.update(identity.len.to_le_bytes());
+        let file_digest = fingerprint_file(&identity, completed, total_bytes, observer)?;
+        digest.update(file_digest);
+        completed = completed
+            .checked_add(identity.len)
+            .ok_or_else(|| candle::Error::Msg("H3 fingerprint progress overflow".into()))?;
+        observer.checkpoint(completed, total_bytes)?;
     }
     Ok(hex_digest(digest.finalize()))
+}
+
+fn fingerprint_file(
+    identity: &VisualWeightFileIdentity,
+    completed_before: u64,
+    total_bytes: u64,
+    observer: &mut dyn VisualWeightReadObserver,
+) -> Result<[u8; 32]> {
+    static CACHE: OnceLock<Mutex<BTreeMap<VisualWeightFileIdentity, [u8; 32]>>> = OnceLock::new();
+    let cache = CACHE.get_or_init(|| Mutex::new(BTreeMap::new()));
+    if let Some(digest) = cache
+        .lock()
+        .map_err(|_| candle::Error::Msg("H3 fingerprint cache mutex is poisoned".into()))?
+        .get(identity)
+        .copied()
+    {
+        observer.checkpoint(completed_before, total_bytes)?;
+        return Ok(digest);
+    }
+
+    let mut file = File::open(&identity.canonical_path)?;
+    let opened = visual_weight_file_identity_from_metadata(
+        identity.canonical_path.clone(),
+        &file.metadata()?,
+    )?;
+    if &opened != identity {
+        bail!(
+            "H3 visual VAE artifact changed before fingerprinting: {}",
+            identity.canonical_path.display()
+        )
+    }
+    let mut digest = Sha256::new();
+    let mut buffer = vec![0u8; 1024 * 1024];
+    let mut read_total = 0u64;
+    loop {
+        observer.checkpoint(completed_before + read_total, total_bytes)?;
+        let read = file.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        read_total = read_total
+            .checked_add(read as u64)
+            .ok_or_else(|| candle::Error::Msg("H3 fingerprint progress overflow".into()))?;
+        digest.update(&buffer[..read]);
+    }
+    if read_total != identity.len {
+        bail!(
+            "H3 visual VAE artifact length changed while fingerprinting: {}",
+            identity.canonical_path.display()
+        )
+    }
+    let closed_identity = visual_weight_file_identity_from_metadata(
+        identity.canonical_path.clone(),
+        &file.metadata()?,
+    )?;
+    if &closed_identity != identity
+        || visual_weight_file_identity(&identity.canonical_path)? != *identity
+    {
+        bail!(
+            "H3 visual VAE artifact changed while fingerprinting: {}",
+            identity.canonical_path.display()
+        )
+    }
+    let digest: [u8; 32] = digest.finalize().into();
+    cache
+        .lock()
+        .map_err(|_| candle::Error::Msg("H3 fingerprint cache mutex is poisoned".into()))?
+        .insert(identity.clone(), digest);
+    Ok(digest)
+}
+
+fn visual_weight_file_identity(path: &Path) -> Result<VisualWeightFileIdentity> {
+    let canonical_path = std::fs::canonicalize(path)?;
+    let metadata = std::fs::metadata(&canonical_path)?;
+    visual_weight_file_identity_from_metadata(canonical_path, &metadata)
+}
+
+fn ensure_identity_unchanged(expected: &VisualWeightFileIdentity, operation: &str) -> Result<()> {
+    if visual_weight_file_identity(&expected.canonical_path)? != *expected {
+        bail!(
+            "H3 visual VAE artifact changed {operation}: {}",
+            expected.canonical_path.display()
+        )
+    }
+    Ok(())
+}
+
+fn open_expected_file(expected: &VisualWeightFileIdentity, operation: &str) -> Result<File> {
+    let file = File::open(&expected.canonical_path)?;
+    ensure_open_file_unchanged(&file, expected, operation)?;
+    Ok(file)
+}
+
+fn ensure_open_file_unchanged(
+    file: &File,
+    expected: &VisualWeightFileIdentity,
+    operation: &str,
+) -> Result<()> {
+    let opened = visual_weight_file_identity_from_metadata(
+        expected.canonical_path.clone(),
+        &file.metadata()?,
+    )?;
+    if &opened != expected {
+        bail!(
+            "H3 visual VAE artifact changed {operation}: {}",
+            expected.canonical_path.display()
+        )
+    }
+    Ok(())
+}
+
+fn visual_weight_file_identity_from_metadata(
+    canonical_path: PathBuf,
+    metadata: &std::fs::Metadata,
+) -> Result<VisualWeightFileIdentity> {
+    if !metadata.is_file() {
+        bail!(
+            "H3 visual VAE artifact must be a regular file: {}",
+            canonical_path.display()
+        )
+    }
+    Ok(VisualWeightFileIdentity {
+        canonical_path,
+        len: metadata.len(),
+        #[cfg(unix)]
+        device: metadata.dev(),
+        #[cfg(unix)]
+        inode: metadata.ino(),
+        #[cfg(unix)]
+        modified_seconds: metadata.mtime(),
+        #[cfg(unix)]
+        modified_nanoseconds: metadata.mtime_nsec(),
+        #[cfg(unix)]
+        changed_seconds: metadata.ctime(),
+        #[cfg(unix)]
+        changed_nanoseconds: metadata.ctime_nsec(),
+        #[cfg(not(unix))]
+        modified: metadata.modified().ok(),
+    })
 }
 
 fn expected_f32_data_size(expected: &BTreeMap<String, Vec<usize>>) -> Result<u64> {
@@ -712,6 +1174,79 @@ mod tests {
             vec![16384, 2048]
         );
         assert_eq!(shapes["decoder.proj_out.weight"], vec![3072, 2048]);
+    }
+
+    #[test]
+    fn comfy_contract_has_exact_560_source_tensors_and_fp16_payload() {
+        let shapes = expected_comfy_weight_shapes(&MiniMaxH3VisualVaeConfig::production()).unwrap();
+        assert_eq!(shapes.len(), 560);
+        assert_eq!(
+            shapes["decoder.transformer_blocks.35.attn.to_qkv.weight"],
+            vec![6144, 2048]
+        );
+        assert_eq!(
+            shapes["decoder.transformer_blocks.35.ff.w1.weight"],
+            vec![16384, 2048]
+        );
+        assert_eq!(shapes["decoder.mask_token"], vec![1, 1, 2048]);
+        let elements = shapes
+            .values()
+            .map(|shape| shape.iter().product::<usize>() as u64)
+            .sum::<u64>();
+        assert_eq!(elements * 2, 5_207_742_064);
+    }
+
+    #[test]
+    fn comfy_header_contract_rejects_key_dtype_and_shape_drift() {
+        let expected =
+            expected_comfy_weight_shapes(&MiniMaxH3VisualVaeConfig::tiny_for_tests()).unwrap();
+        let mut offset = 0u64;
+        let tensors = expected
+            .iter()
+            .map(|(name, shape)| {
+                let bytes = shape.iter().product::<usize>() as u64 * 2;
+                let tensor = SafetensorsTensorHeader {
+                    dtype: "F16".into(),
+                    shape: shape.clone(),
+                    data_offsets: [offset, offset + bytes],
+                };
+                offset += bytes;
+                (name.clone(), tensor)
+            })
+            .collect::<BTreeMap<_, _>>();
+        let header = SafetensorsHeader {
+            tensors,
+            header_len: 1,
+            file_len: offset + 9,
+        };
+        validate_tensor_headers(&header, &expected, "F16", "Comfy").unwrap();
+
+        let mut bad_dtype = header.clone();
+        bad_dtype
+            .tensors
+            .get_mut("decoder.mask_token")
+            .unwrap()
+            .dtype = "F32".into();
+        assert!(validate_tensor_headers(&bad_dtype, &expected, "F16", "Comfy").is_err());
+
+        let mut bad_shape = header.clone();
+        bad_shape
+            .tensors
+            .get_mut("decoder.mask_token")
+            .unwrap()
+            .shape = vec![1, 2, 8];
+        assert!(validate_tensor_headers(&bad_shape, &expected, "F16", "Comfy").is_err());
+
+        let mut unexpected = header;
+        unexpected.tensors.insert(
+            "decoder.unplanned".into(),
+            SafetensorsTensorHeader {
+                dtype: "F16".into(),
+                shape: vec![1],
+                data_offsets: [offset, offset + 2],
+            },
+        );
+        assert!(validate_tensor_headers(&unexpected, &expected, "F16", "Comfy").is_err());
     }
 
     #[test]
@@ -840,6 +1375,16 @@ mod tests {
         std::fs::write(&path, bytes).unwrap();
         assert!(inspect_safetensors_header(&path).is_err());
 
+        let duplicate = br#"{"x":{"dtype":"F32","shape":[1],"data_offsets":[0,4]},"x":{"dtype":"F32","shape":[1],"data_offsets":[0,4]}}"#;
+        let mut bytes = (duplicate.len() as u64).to_le_bytes().to_vec();
+        bytes.extend_from_slice(duplicate);
+        bytes.extend_from_slice(&[0u8; 4]);
+        std::fs::write(&path, bytes).unwrap();
+        assert!(inspect_safetensors_header(&path)
+            .unwrap_err()
+            .to_string()
+            .contains("duplicate safetensors tensor x"));
+
         let overlapping = br#"{"x":{"dtype":"F32","shape":[2],"data_offsets":[0,8]},"y":{"dtype":"F32","shape":[1],"data_offsets":[4,8]}}"#;
         let mut bytes = (overlapping.len() as u64).to_le_bytes().to_vec();
         bytes.extend_from_slice(overlapping);
@@ -874,5 +1419,72 @@ mod tests {
         .into_iter()
         .collect();
         assert!(validate_canonical_shard_names(&incomplete).is_err());
+    }
+
+    #[test]
+    fn fingerprint_is_cancellable_cached_and_invalidates_on_file_change() {
+        struct CancelAfter {
+            limit: u64,
+            calls: Vec<u64>,
+        }
+        impl VisualWeightReadObserver for CancelAfter {
+            fn checkpoint(&mut self, bytes_read: u64, _total_bytes: u64) -> Result<()> {
+                self.calls.push(bytes_read);
+                if bytes_read >= self.limit {
+                    bail!("synthetic fingerprint cancellation")
+                }
+                Ok(())
+            }
+        }
+
+        let dir = std::env::temp_dir().join(format!(
+            "mold-h3-fingerprint-{}-{}",
+            std::process::id(),
+            std::thread::current().name().unwrap_or("test")
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("weights.safetensors");
+        std::fs::write(&path, vec![7u8; 2 * 1024 * 1024 + 17]).unwrap();
+
+        let mut cancel = CancelAfter {
+            limit: 1024 * 1024,
+            calls: Vec::new(),
+        };
+        let error = component_fingerprint_with_observer(std::slice::from_ref(&path), &mut cancel)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("synthetic fingerprint cancellation"));
+        assert!(cancel.calls.contains(&(1024 * 1024)));
+
+        let fingerprint = component_fingerprint(std::slice::from_ref(&path)).unwrap();
+        let mut cached = CancelAfter {
+            limit: u64::MAX,
+            calls: Vec::new(),
+        };
+        assert_eq!(
+            component_fingerprint_with_observer(std::slice::from_ref(&path), &mut cached).unwrap(),
+            fingerprint
+        );
+        assert!(
+            cached.calls.len() <= 3,
+            "cached fingerprint reread the file"
+        );
+
+        let token = ValidatedVisualVaeWeights {
+            layout: WeightLayout::OfficialComfySource,
+            inspection: VisualVaeWeightInspection {
+                role: VisualVaeComponentRole::F16T4D24.stable_id(),
+                shard_count: 1,
+                tensor_count: 0,
+                total_size: std::fs::metadata(&path).unwrap().len(),
+                header_identity_sha256: "test".into(),
+            },
+            files: vec![visual_weight_file_identity(&path).unwrap()],
+        };
+        let mut bytes = std::fs::read(&path).unwrap();
+        bytes.push(9);
+        std::fs::write(&path, bytes).unwrap();
+        assert!(token.revalidate_files().is_err());
+        let _ = std::fs::remove_dir_all(dir);
     }
 }

--- a/crates/mold-inference/Cargo.toml
+++ b/crates/mold-inference/Cargo.toml
@@ -22,7 +22,7 @@ metal = ["candle-core/metal", "candle-nn/metal", "candle-transformers/metal", "m
 # Off by default — pulls in the candle-flash-attn build, which requires the
 # CUDA toolkit. Tensors that aren't CUDA + fp16/bf16 transparently fall back
 # to the math path inside `crate::attention`.
-flash-attn = ["dep:candle-flash-attn", "cuda"]
+flash-attn = ["dep:candle-flash-attn", "cuda", "mold-candle/flash-attn"]
 expand = []
 webp = ["webp-animation"]
 mp4 = ["dep:fdk-aac"]


### PR DESCRIPTION
## Summary

- add the MiniMax H3 f16t4d24 visual VAE as isolated Candle model primitives
- preserve the released causal temporal geometry, conditioning domains, latent statistics, decoder transformer layout, RoPE, and Comfy-style bounded spatial tiling
- validate the exact released config and strict safetensors shard/key/shape contract, including original/Comfy fused-QKV and FF conversion
- keep activation license-gated: this PR does not register a runtime engine, factory, catalog entry, capability, or download path

## Research basis

Implementation was independently checked against these pinned code revisions:

- MiniMax official implementation: 8d8824efaf94586c0cc9ac7ad8d0723d4d6420ea
- Hugging Face Diffusers: 9c6a68c32b3b2a64db91800b624d33cec6e25ab8
- ComfyUI: a464ac33588ae182f81a090d910cfbf21e255b73

The independent transform audit covers all 560 original source tensors and all 703 unique Diffusers targets. It verifies direct mappings, per-head interleaved fused-QKV reordering/splitting, FF gate/up reordering, and the one intentionally dropped decoder mask token.

## Validation

- cargo fmt --all -- --check
- cargo test -p mold-ai-candle: 30 passed
- cargo clippy -p mold-ai-candle --all-targets -- -D warnings
- cargo test -p mold-ai-candle --features cuda on Plato L40S: 31 passed
- cargo clippy -p mold-ai-candle --features cuda --all-targets -- -D warnings
- tiny four-tile CPU/CUDA output-parity test passes with the released mixed-precision boundary
- fresh tiled synthetic CUDA sample on GPU0: 3 MiB baseline, 485 MiB peak, 482 MiB delta
- negative loader coverage rejects missing plus unexpected keys, malformed spans, noncanonical shards, dtype/shape drift, and config drift

## Deliberately deferred

No model weights or other license-gated artifacts were downloaded or accessed. Real-weight output parity, perceptual tiled-vs-untiled metrics, representative 960x544 and 1344x768 throughput/peak measurements, cold/warm runtime telemetry, engine integration, and end-to-end UAT remain blocked until authorized artifact access and the later activation slices.

Refs #833
