### PR TITLE
perf(h3): qualify memory-efficient full attention

### DIFF
--- a/crates/mold-candle/Cargo.toml
+++ b/crates/mold-candle/Cargo.toml
@@ -22,7 +22,9 @@ flash-attn = ["dep:candle-flash-attn", "cuda"]
 candle = { package = "candle-core", version = "0.11" }
 candle-nn = "0.11"
 candle-transformers = "0.11"
-candle-flash-attn = { version = "0.11", optional = true }
+# The H3 runtime fingerprint qualifies this exact crates.io payload, not
+# an arbitrary semver-compatible 0.11.x implementation.
+candle-flash-attn = { version = "=0.11.0", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"

--- a/crates/mold-candle/Cargo.toml
+++ b/crates/mold-candle/Cargo.toml
@@ -14,6 +14,8 @@ name = "mold_candle"
 default = []
 cuda = ["candle/cuda", "candle-nn/cuda", "candle-transformers/cuda"]
 metal = ["candle/metal", "candle-nn/metal", "candle-transformers/metal"]
+# Developer-only H3 FlashAttention v2 primitive. Mold release artifacts do not
+# enable this feature; the H3 authority remains a separate fail-closed gate.
 flash-attn = ["dep:candle-flash-attn", "cuda"]
 
 [dependencies]

--- a/crates/mold-candle/src/minimax_h3/attention.rs
+++ b/crates/mold-candle/src/minimax_h3/attention.rs
@@ -1,0 +1,1483 @@
+//! Lossless, fail-closed attention authority for MiniMax H3.
+//!
+//! H3 packs every text, reference, generated-video, and generated-audio row
+//! into one full non-causal self-attention document. Released shapes make an
+//! `N x N` score tensor non-viable. This module therefore keeps dense F32
+//! attention behind a small synthetic bound and gives the optional Candle
+//! FlashAttention v2 primitive a separate, source- and hardware-qualified
+//! authority.
+//!
+//! The optional kernel is deliberately not a shipping claim. Mold's release,
+//! Nix, Docker, desktop, and AUR builds do not compile `flash-attn`, and doing
+//! so would require an explicit reproducibility-policy decision. The runtime
+//! authority below records that state and always fails its release-activation
+//! gate even in a developer build.
+
+use std::error::Error as StdError;
+use std::fmt;
+
+use candle::{DType, Device, Tensor, D};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+pub const H3_DENSE_SYNTHETIC_MAX_SCORE_ELEMENTS: u64 = 4 * 1024 * 1024;
+pub const H3_FLASH_ATTN_PACKAGE_VERSION: &str = "0.11.0";
+pub const H3_FLASH_ATTN_CRATE_SHA256: &str =
+    "e5f1e2f29f5123d7a627171209fdaeb4ee91d076aefeac588922aa9842e30c2c";
+pub const H3_FLASH_ATTN_QUALIFIED_COMPUTE_CAPABILITY: (u16, u16) = (8, 9);
+
+const H3_RELEASE_HEADS: usize = 56;
+const H3_RELEASE_HEAD_DIM: usize = 128;
+const PLAN_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum H3AttentionDType {
+    Bf16,
+    F16,
+    F32,
+}
+
+impl H3AttentionDType {
+    const fn stable_id(self) -> &'static str {
+        match self {
+            Self::Bf16 => "bf16",
+            Self::F16 => "f16",
+            Self::F32 => "f32",
+        }
+    }
+
+    const fn byte_width(self) -> u64 {
+        match self {
+            Self::Bf16 | Self::F16 => 2,
+            Self::F32 => 4,
+        }
+    }
+
+    pub(crate) fn from_candle(dtype: DType) -> InspectionResult<Self> {
+        match dtype {
+            DType::BF16 => Ok(Self::Bf16),
+            DType::F16 => Ok(Self::F16),
+            DType::F32 => Ok(Self::F32),
+            other => Err(failure(
+                H3AttentionErrorCode::UnsupportedDType,
+                format!("MiniMax H3 attention does not support {other:?}"),
+                vec![H3AttentionRequirement::Bf16OrBoundedSyntheticF32],
+            )),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum H3AttentionDevice {
+    Cpu,
+    Metal,
+    Cuda {
+        compute_capability: Option<(u16, u16)>,
+    },
+}
+
+impl H3AttentionDevice {
+    pub fn from_candle(device: &Device) -> Self {
+        match device {
+            Device::Cpu => Self::Cpu,
+            Device::Metal(_) => Self::Metal,
+            Device::Cuda(cuda) => {
+                #[cfg(feature = "cuda")]
+                let compute_capability = cuda
+                    .cuda_stream()
+                    .context()
+                    .compute_capability()
+                    .ok()
+                    .and_then(|(major, minor)| {
+                        Some((u16::try_from(major).ok()?, u16::try_from(minor).ok()?))
+                    });
+                #[cfg(not(feature = "cuda"))]
+                let compute_capability = {
+                    let _ = cuda;
+                    None
+                };
+                Self::Cuda { compute_capability }
+            }
+        }
+    }
+
+    fn stable_id(self) -> String {
+        match self {
+            Self::Cpu => "cpu".into(),
+            Self::Metal => "metal".into(),
+            Self::Cuda {
+                compute_capability: Some((major, minor)),
+            } => format!("cuda-sm{major}{minor}"),
+            Self::Cuda {
+                compute_capability: None,
+            } => "cuda-unknown".into(),
+        }
+    }
+
+    fn matches_candle(self, device: &Device) -> bool {
+        match (self, device) {
+            (Self::Cpu, Device::Cpu) | (Self::Metal, Device::Metal(_)) => true,
+            (
+                Self::Cuda {
+                    compute_capability: expected,
+                },
+                Device::Cuda(_),
+            ) => {
+                expected.is_none()
+                    || Self::from_candle(device)
+                        == (Self::Cuda {
+                            compute_capability: expected,
+                        })
+            }
+            _ => false,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum H3AttentionScope {
+    TokenRefiner,
+    PackedTransformer,
+}
+
+impl H3AttentionScope {
+    const fn stable_id(self) -> &'static str {
+        match self {
+            Self::TokenRefiner => "token-refiner",
+            Self::PackedTransformer => "packed-transformer",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum H3AttentionMask {
+    FullNonCausalPacked,
+}
+
+impl H3AttentionMask {
+    const fn stable_id(self) -> &'static str {
+        match self {
+            Self::FullNonCausalPacked => "full-noncausal-packed",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum H3AttentionBackend {
+    BoundedDenseMath,
+    FlashAttentionV2,
+}
+
+impl H3AttentionBackend {
+    const fn stable_id(self) -> &'static str {
+        match self {
+            Self::BoundedDenseMath => "bounded-dense-math",
+            Self::FlashAttentionV2 => "flash-attention-v2",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum H3AttentionKernel {
+    CandleDenseF32V011,
+    CandleFlashFwdHdim128Bf16Sm80V011,
+}
+
+impl H3AttentionKernel {
+    const fn stable_id(self) -> &'static str {
+        match self {
+            Self::CandleDenseF32V011 => "candle-0.11.dense-f32",
+            Self::CandleFlashFwdHdim128Bf16Sm80V011 => {
+                "candle-flash-attn-0.11.0.flash-fwd-hdim128-bf16-sm80"
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum H3AttentionActivation {
+    SyntheticCorrectnessOnly,
+    DeveloperFeatureOnly,
+}
+
+impl H3AttentionActivation {
+    const fn stable_id(self) -> &'static str {
+        match self {
+            Self::SyntheticCorrectnessOnly => "synthetic-correctness-only",
+            Self::DeveloperFeatureOnly => "developer-feature-only",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct H3AttentionModelContract {
+    pub heads: usize,
+    pub head_dim: usize,
+    pub dtype: H3AttentionDType,
+}
+
+impl H3AttentionModelContract {
+    pub const fn released_bf16() -> Self {
+        Self {
+            heads: H3_RELEASE_HEADS,
+            head_dim: H3_RELEASE_HEAD_DIM,
+            dtype: H3AttentionDType::Bf16,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct H3AttentionWorkspace {
+    pub input_output_tensor_bytes: u64,
+    pub qkv_compute_bytes: u64,
+    pub score_matrix_bytes: u64,
+    pub probability_matrix_bytes: u64,
+    pub output_compute_bytes: u64,
+    pub softmax_lse_bytes: u64,
+    pub peak_auxiliary_bytes_upper_bound: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct H3FrozenAttentionPlan {
+    schema_version: u32,
+    identity_sha256: String,
+    scope: H3AttentionScope,
+    backend: H3AttentionBackend,
+    kernel: H3AttentionKernel,
+    activation: H3AttentionActivation,
+    device: H3AttentionDevice,
+    dtype: H3AttentionDType,
+    mask: H3AttentionMask,
+    batch_size: usize,
+    query_rows: usize,
+    key_value_rows: usize,
+    heads: usize,
+    head_dim: usize,
+    softmax_scale_f32_bits: u32,
+    workspace: H3AttentionWorkspace,
+}
+
+impl H3FrozenAttentionPlan {
+    pub fn identity_sha256(&self) -> &str {
+        &self.identity_sha256
+    }
+
+    pub const fn scope(&self) -> H3AttentionScope {
+        self.scope
+    }
+
+    pub const fn backend(&self) -> H3AttentionBackend {
+        self.backend
+    }
+
+    pub const fn kernel(&self) -> H3AttentionKernel {
+        self.kernel
+    }
+
+    pub const fn activation(&self) -> H3AttentionActivation {
+        self.activation
+    }
+
+    pub const fn device(&self) -> H3AttentionDevice {
+        self.device
+    }
+
+    pub const fn dtype(&self) -> H3AttentionDType {
+        self.dtype
+    }
+
+    pub const fn batch_size(&self) -> usize {
+        self.batch_size
+    }
+
+    pub const fn rows(&self) -> usize {
+        self.query_rows
+    }
+
+    pub const fn heads(&self) -> usize {
+        self.heads
+    }
+
+    pub const fn head_dim(&self) -> usize {
+        self.head_dim
+    }
+
+    pub const fn workspace(&self) -> &H3AttentionWorkspace {
+        &self.workspace
+    }
+
+    fn validate_identity(&self) -> InspectionResult<()> {
+        let expected = plan_identity(self);
+        if self.schema_version != PLAN_SCHEMA_VERSION || self.identity_sha256 != expected {
+            return Err(failure(
+                H3AttentionErrorCode::FrozenIdentityMismatch,
+                "MiniMax H3 attention plan identity does not match its frozen fields",
+                vec![H3AttentionRequirement::UntamperedFrozenPlan],
+            ));
+        }
+        if self.batch_size == 0
+            || self.query_rows == 0
+            || self.query_rows != self.key_value_rows
+            || self.mask != H3AttentionMask::FullNonCausalPacked
+        {
+            return Err(failure(
+                H3AttentionErrorCode::UnsupportedSemantics,
+                "MiniMax H3 frozen attention must be non-empty full packed self-attention",
+                vec![H3AttentionRequirement::FullNonCausalPackedSelfAttention],
+            ));
+        }
+        let contract = H3AttentionModelContract {
+            heads: self.heads,
+            head_dim: self.head_dim,
+            dtype: self.dtype,
+        };
+        validate_backend_contract(
+            self.backend,
+            self.kernel,
+            self.activation,
+            self.device,
+            contract,
+        )?;
+        let expected_scale = (1.0f32 / (self.head_dim as f32).sqrt()).to_bits();
+        if self.softmax_scale_f32_bits != expected_scale {
+            return Err(failure(
+                H3AttentionErrorCode::RuntimePlanMismatch,
+                "MiniMax H3 frozen softmax scale does not match its head dimension",
+                vec![H3AttentionRequirement::UntamperedFrozenPlan],
+            ));
+        }
+        let score_elements = checked_product(
+            "attention score elements",
+            &[
+                self.batch_size,
+                self.heads,
+                self.query_rows,
+                self.key_value_rows,
+            ],
+        )?;
+        if self.backend == H3AttentionBackend::BoundedDenseMath
+            && score_elements > H3_DENSE_SYNTHETIC_MAX_SCORE_ELEMENTS
+        {
+            return Err(failure(
+                H3AttentionErrorCode::DenseMathLimitExceeded,
+                "MiniMax H3 frozen dense attention exceeds the synthetic score bound",
+                vec![H3AttentionRequirement::CompiledH3FlashAttentionV2],
+            ));
+        }
+        validate_flash_launch_shape(
+            self.backend,
+            self.batch_size,
+            self.query_rows,
+            self.heads,
+            self.head_dim,
+        )?;
+        let expected_workspace = workspace_for(
+            self.backend,
+            self.dtype,
+            self.batch_size,
+            self.heads,
+            self.query_rows,
+            self.head_dim,
+        )?;
+        if self.workspace != expected_workspace {
+            return Err(failure(
+                H3AttentionErrorCode::RuntimePlanMismatch,
+                "MiniMax H3 frozen workspace does not match its backend and shape",
+                vec![H3AttentionRequirement::UntamperedFrozenPlan],
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct H3FrozenAttentionExecution {
+    pub token_refiner: H3FrozenAttentionPlan,
+    pub packed_transformer: H3FrozenAttentionPlan,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct H3AttentionRuntimeAuthority {
+    identity_sha256: String,
+    backend: H3AttentionBackend,
+    kernel: H3AttentionKernel,
+    activation: H3AttentionActivation,
+    device: H3AttentionDevice,
+    contract: H3AttentionModelContract,
+}
+
+impl H3AttentionRuntimeAuthority {
+    pub fn bounded_synthetic_math(
+        device: H3AttentionDevice,
+        contract: H3AttentionModelContract,
+    ) -> InspectionResult<Self> {
+        validate_model_contract_shape(contract)?;
+        if !matches!(
+            contract.dtype,
+            H3AttentionDType::Bf16 | H3AttentionDType::F32
+        ) {
+            return Err(failure(
+                H3AttentionErrorCode::UnsupportedDType,
+                "MiniMax H3 bounded math accepts BF16 or synthetic F32 inputs",
+                vec![H3AttentionRequirement::Bf16OrBoundedSyntheticF32],
+            ));
+        }
+        Ok(Self::new(
+            H3AttentionBackend::BoundedDenseMath,
+            H3AttentionKernel::CandleDenseF32V011,
+            H3AttentionActivation::SyntheticCorrectnessOnly,
+            device,
+            contract,
+        ))
+    }
+
+    /// Qualify the only currently measured H3 FlashAttention primitive.
+    ///
+    /// This is deliberately exact: BF16, 56 heads, head dimension 128, and
+    /// SM89. Other Candle-supported shapes or architectures are not H3
+    /// qualification evidence and are rejected until separately measured.
+    pub fn qualify_flash_attention_v2(
+        device: H3AttentionDevice,
+        contract: H3AttentionModelContract,
+    ) -> InspectionResult<Self> {
+        qualify_flash_attention_v2_with_availability(device, contract, cfg!(feature = "flash-attn"))
+    }
+
+    fn new(
+        backend: H3AttentionBackend,
+        kernel: H3AttentionKernel,
+        activation: H3AttentionActivation,
+        device: H3AttentionDevice,
+        contract: H3AttentionModelContract,
+    ) -> Self {
+        let mut authority = Self {
+            identity_sha256: String::new(),
+            backend,
+            kernel,
+            activation,
+            device,
+            contract,
+        };
+        authority.identity_sha256 = runtime_identity(&authority);
+        authority
+    }
+
+    pub fn identity_sha256(&self) -> &str {
+        &self.identity_sha256
+    }
+
+    pub const fn backend(&self) -> H3AttentionBackend {
+        self.backend
+    }
+
+    pub const fn kernel(&self) -> H3AttentionKernel {
+        self.kernel
+    }
+
+    pub const fn activation(&self) -> H3AttentionActivation {
+        self.activation
+    }
+
+    pub const fn device(&self) -> H3AttentionDevice {
+        self.device
+    }
+
+    pub const fn contract(&self) -> H3AttentionModelContract {
+        self.contract
+    }
+
+    pub fn verify_model(
+        &self,
+        contract: H3AttentionModelContract,
+        device: &Device,
+    ) -> InspectionResult<()> {
+        self.validate_identity()?;
+        if self.contract != contract {
+            return Err(failure(
+                H3AttentionErrorCode::RuntimePlanMismatch,
+                format!(
+                    "MiniMax H3 attention authority {:?} does not match model {:?}",
+                    self.contract, contract
+                ),
+                vec![H3AttentionRequirement::ExactModelContract],
+            ));
+        }
+        if !self.device.matches_candle(device) {
+            return Err(failure(
+                H3AttentionErrorCode::RuntimePlanMismatch,
+                "MiniMax H3 attention authority targets a different device backend",
+                vec![H3AttentionRequirement::ExactDeviceBackend],
+            ));
+        }
+        Ok(())
+    }
+
+    pub fn freeze_execution(
+        &self,
+        batch_size: usize,
+        token_refiner_rows: usize,
+        packed_rows: usize,
+    ) -> InspectionResult<H3FrozenAttentionExecution> {
+        self.validate_identity()?;
+        Ok(H3FrozenAttentionExecution {
+            token_refiner: self.freeze_scope(
+                H3AttentionScope::TokenRefiner,
+                batch_size,
+                token_refiner_rows,
+            )?,
+            packed_transformer: self.freeze_scope(
+                H3AttentionScope::PackedTransformer,
+                batch_size,
+                packed_rows,
+            )?,
+        })
+    }
+
+    fn freeze_scope(
+        &self,
+        scope: H3AttentionScope,
+        batch_size: usize,
+        rows: usize,
+    ) -> InspectionResult<H3FrozenAttentionPlan> {
+        if batch_size == 0 || rows == 0 {
+            return Err(failure(
+                H3AttentionErrorCode::InvalidShape,
+                "MiniMax H3 attention batch and row counts must be positive",
+                vec![H3AttentionRequirement::NonEmptySelfAttention],
+            ));
+        }
+        let score_elements = checked_product(
+            "attention score elements",
+            &[batch_size, self.contract.heads, rows, rows],
+        )?;
+        if self.backend == H3AttentionBackend::BoundedDenseMath
+            && score_elements > H3_DENSE_SYNTHETIC_MAX_SCORE_ELEMENTS
+        {
+            return Err(failure(
+                H3AttentionErrorCode::DenseMathLimitExceeded,
+                format!(
+                    "MiniMax H3 dense attention would materialize {score_elements} score elements; the synthetic bound is {H3_DENSE_SYNTHETIC_MAX_SCORE_ELEMENTS}"
+                ),
+                vec![
+                    H3AttentionRequirement::CompiledH3FlashAttentionV2,
+                    H3AttentionRequirement::QualifiedCudaSm89,
+                    H3AttentionRequirement::ReleasedBf16HeadGeometry,
+                ],
+            ));
+        }
+        validate_flash_launch_shape(
+            self.backend,
+            batch_size,
+            rows,
+            self.contract.heads,
+            self.contract.head_dim,
+        )?;
+
+        let workspace = workspace_for(
+            self.backend,
+            self.contract.dtype,
+            batch_size,
+            self.contract.heads,
+            rows,
+            self.contract.head_dim,
+        )?;
+        let mut plan = H3FrozenAttentionPlan {
+            schema_version: PLAN_SCHEMA_VERSION,
+            identity_sha256: String::new(),
+            scope,
+            backend: self.backend,
+            kernel: self.kernel,
+            activation: self.activation,
+            device: self.device,
+            dtype: self.contract.dtype,
+            mask: H3AttentionMask::FullNonCausalPacked,
+            batch_size,
+            query_rows: rows,
+            key_value_rows: rows,
+            heads: self.contract.heads,
+            head_dim: self.contract.head_dim,
+            softmax_scale_f32_bits: (1.0f32 / (self.contract.head_dim as f32).sqrt()).to_bits(),
+            workspace,
+        };
+        plan.identity_sha256 = plan_identity(&plan);
+        Ok(plan)
+    }
+
+    pub fn require_release_activation(&self) -> Result<(), H3AttentionReleaseRejection> {
+        Err(H3AttentionReleaseRejection {
+            requirements: vec![
+                H3AttentionReleaseRequirement::MiniMaxH3Authorization,
+                H3AttentionReleaseRequirement::ReleaseArtifactIncludesKernel,
+                H3AttentionReleaseRequirement::CrossBackendReproducibilityDecision,
+                H3AttentionReleaseRequirement::RemainingCudaArchitectureQualification,
+            ],
+        })
+    }
+
+    fn validate_identity(&self) -> InspectionResult<()> {
+        if self.identity_sha256 != runtime_identity(self) {
+            return Err(failure(
+                H3AttentionErrorCode::FrozenIdentityMismatch,
+                "MiniMax H3 attention runtime identity does not match its frozen fields",
+                vec![H3AttentionRequirement::UntamperedFrozenPlan],
+            ));
+        }
+        validate_backend_contract(
+            self.backend,
+            self.kernel,
+            self.activation,
+            self.device,
+            self.contract,
+        )
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum H3AttentionRequirement {
+    NonEmptySelfAttention,
+    Bf16OrBoundedSyntheticF32,
+    ReleasedBf16HeadGeometry,
+    ExactModelContract,
+    ExactDeviceBackend,
+    FullNonCausalPackedSelfAttention,
+    QualifiedCudaSm89,
+    CompiledH3FlashAttentionV2,
+    FlashAttentionU32LaunchShape,
+    UntamperedFrozenPlan,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum H3AttentionErrorCode {
+    InvalidShape,
+    UnsupportedDType,
+    UnsupportedSemantics,
+    UnqualifiedArchitecture,
+    KernelNotCompiled,
+    DenseMathLimitExceeded,
+    RuntimePlanMismatch,
+    FrozenIdentityMismatch,
+    ArithmeticOverflow,
+    KernelExecution,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct H3AttentionError {
+    pub code: H3AttentionErrorCode,
+    pub message: String,
+    pub requirements: Vec<H3AttentionRequirement>,
+}
+
+impl fmt::Display for H3AttentionError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}", self.message)?;
+        if !self.requirements.is_empty() {
+            write!(formatter, "; requirements: {:?}", self.requirements)?;
+        }
+        Ok(())
+    }
+}
+
+impl StdError for H3AttentionError {}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum H3AttentionReleaseRequirement {
+    MiniMaxH3Authorization,
+    ReleaseArtifactIncludesKernel,
+    CrossBackendReproducibilityDecision,
+    RemainingCudaArchitectureQualification,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct H3AttentionReleaseRejection {
+    pub requirements: Vec<H3AttentionReleaseRequirement>,
+}
+
+impl fmt::Display for H3AttentionReleaseRejection {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "MiniMax H3 attention is not release-activated; requirements: {:?}",
+            self.requirements
+        )
+    }
+}
+
+impl StdError for H3AttentionReleaseRejection {}
+
+type InspectionResult<T> = std::result::Result<T, H3AttentionError>;
+
+fn failure(
+    code: H3AttentionErrorCode,
+    message: impl Into<String>,
+    requirements: Vec<H3AttentionRequirement>,
+) -> H3AttentionError {
+    H3AttentionError {
+        code,
+        message: message.into(),
+        requirements,
+    }
+}
+
+fn validate_model_contract_shape(contract: H3AttentionModelContract) -> InspectionResult<()> {
+    if contract.heads == 0 || contract.head_dim == 0 {
+        return Err(failure(
+            H3AttentionErrorCode::InvalidShape,
+            "MiniMax H3 attention heads and head dimension must be positive",
+            vec![H3AttentionRequirement::NonEmptySelfAttention],
+        ));
+    }
+    Ok(())
+}
+
+fn validate_backend_contract(
+    backend: H3AttentionBackend,
+    kernel: H3AttentionKernel,
+    activation: H3AttentionActivation,
+    device: H3AttentionDevice,
+    contract: H3AttentionModelContract,
+) -> InspectionResult<()> {
+    validate_model_contract_shape(contract)?;
+    match backend {
+        H3AttentionBackend::BoundedDenseMath => {
+            if kernel != H3AttentionKernel::CandleDenseF32V011
+                || activation != H3AttentionActivation::SyntheticCorrectnessOnly
+            {
+                return Err(failure(
+                    H3AttentionErrorCode::RuntimePlanMismatch,
+                    "MiniMax H3 bounded math has an unqualified kernel/activation tuple",
+                    vec![H3AttentionRequirement::UntamperedFrozenPlan],
+                ));
+            }
+            if !matches!(
+                contract.dtype,
+                H3AttentionDType::Bf16 | H3AttentionDType::F32
+            ) {
+                return Err(failure(
+                    H3AttentionErrorCode::UnsupportedDType,
+                    "MiniMax H3 bounded math accepts BF16 or synthetic F32 inputs",
+                    vec![H3AttentionRequirement::Bf16OrBoundedSyntheticF32],
+                ));
+            }
+        }
+        H3AttentionBackend::FlashAttentionV2 => {
+            if kernel != H3AttentionKernel::CandleFlashFwdHdim128Bf16Sm80V011
+                || activation != H3AttentionActivation::DeveloperFeatureOnly
+            {
+                return Err(failure(
+                    H3AttentionErrorCode::RuntimePlanMismatch,
+                    "MiniMax H3 FlashAttention has an unqualified kernel/activation tuple",
+                    vec![H3AttentionRequirement::UntamperedFrozenPlan],
+                ));
+            }
+            if contract != H3AttentionModelContract::released_bf16() {
+                return Err(failure(
+                    if contract.dtype != H3AttentionDType::Bf16 {
+                        H3AttentionErrorCode::UnsupportedDType
+                    } else {
+                        H3AttentionErrorCode::InvalidShape
+                    },
+                    format!(
+                        "MiniMax H3 FlashAttention qualification requires {:?}, got {contract:?}",
+                        H3AttentionModelContract::released_bf16()
+                    ),
+                    vec![H3AttentionRequirement::ReleasedBf16HeadGeometry],
+                ));
+            }
+            if device
+                != (H3AttentionDevice::Cuda {
+                    compute_capability: Some(H3_FLASH_ATTN_QUALIFIED_COMPUTE_CAPABILITY),
+                })
+            {
+                return Err(failure(
+                    H3AttentionErrorCode::UnqualifiedArchitecture,
+                    format!(
+                        "MiniMax H3 FlashAttention is qualified only for CUDA SM89, got {}",
+                        device.stable_id()
+                    ),
+                    vec![H3AttentionRequirement::QualifiedCudaSm89],
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn qualify_flash_attention_v2_with_availability(
+    device: H3AttentionDevice,
+    contract: H3AttentionModelContract,
+    kernel_compiled: bool,
+) -> InspectionResult<H3AttentionRuntimeAuthority> {
+    validate_backend_contract(
+        H3AttentionBackend::FlashAttentionV2,
+        H3AttentionKernel::CandleFlashFwdHdim128Bf16Sm80V011,
+        H3AttentionActivation::DeveloperFeatureOnly,
+        device,
+        contract,
+    )?;
+    if !kernel_compiled {
+        return Err(failure(
+            H3AttentionErrorCode::KernelNotCompiled,
+            "MiniMax H3 FlashAttention kernel is not compiled into this binary",
+            vec![H3AttentionRequirement::CompiledH3FlashAttentionV2],
+        ));
+    }
+    Ok(H3AttentionRuntimeAuthority::new(
+        H3AttentionBackend::FlashAttentionV2,
+        H3AttentionKernel::CandleFlashFwdHdim128Bf16Sm80V011,
+        H3AttentionActivation::DeveloperFeatureOnly,
+        device,
+        contract,
+    ))
+}
+
+fn validate_flash_launch_shape(
+    backend: H3AttentionBackend,
+    batch_size: usize,
+    rows: usize,
+    heads: usize,
+    head_dim: usize,
+) -> InspectionResult<()> {
+    if backend != H3AttentionBackend::FlashAttentionV2 {
+        return Ok(());
+    }
+    let batch_stride = checked_product("FlashAttention batch stride", &[rows, heads, head_dim])?;
+    let total_rows = checked_product("FlashAttention total rows", &[batch_size, rows])?;
+    if batch_stride > u32::MAX as u64 || total_rows > u32::MAX as u64 {
+        return Err(failure(
+            H3AttentionErrorCode::InvalidShape,
+            "MiniMax H3 attention shape exceeds Candle FlashAttention's u32 launch contract",
+            vec![H3AttentionRequirement::FlashAttentionU32LaunchShape],
+        ));
+    }
+    Ok(())
+}
+
+fn checked_product(label: &str, values: &[usize]) -> InspectionResult<u64> {
+    values.iter().try_fold(1u64, |product, value| {
+        product.checked_mul(*value as u64).ok_or_else(|| {
+            failure(
+                H3AttentionErrorCode::ArithmeticOverflow,
+                format!("MiniMax H3 {label} overflows"),
+                Vec::new(),
+            )
+        })
+    })
+}
+
+fn checked_sum(label: &str, values: &[u64]) -> InspectionResult<u64> {
+    values.iter().try_fold(0u64, |sum, value| {
+        sum.checked_add(*value).ok_or_else(|| {
+            failure(
+                H3AttentionErrorCode::ArithmeticOverflow,
+                format!("MiniMax H3 {label} overflows"),
+                Vec::new(),
+            )
+        })
+    })
+}
+
+fn workspace_for(
+    backend: H3AttentionBackend,
+    dtype: H3AttentionDType,
+    batch: usize,
+    heads: usize,
+    rows: usize,
+    head_dim: usize,
+) -> InspectionResult<H3AttentionWorkspace> {
+    let vector_elements =
+        checked_product("attention vector elements", &[batch, heads, rows, head_dim])?;
+    let score_elements = checked_product("attention score elements", &[batch, heads, rows, rows])?;
+    let input_output_tensor_bytes = vector_elements
+        .checked_mul(dtype.byte_width())
+        .and_then(|value| value.checked_mul(4))
+        .ok_or_else(|| {
+            failure(
+                H3AttentionErrorCode::ArithmeticOverflow,
+                "MiniMax H3 attention input/output byte accounting overflows",
+                Vec::new(),
+            )
+        })?;
+    match backend {
+        H3AttentionBackend::BoundedDenseMath => {
+            let one_vector_f32 = vector_elements.checked_mul(4).ok_or_else(|| {
+                failure(
+                    H3AttentionErrorCode::ArithmeticOverflow,
+                    "MiniMax H3 dense vector byte accounting overflows",
+                    Vec::new(),
+                )
+            })?;
+            let qkv_compute_bytes = one_vector_f32.checked_mul(3).ok_or_else(|| {
+                failure(
+                    H3AttentionErrorCode::ArithmeticOverflow,
+                    "MiniMax H3 dense QKV byte accounting overflows",
+                    Vec::new(),
+                )
+            })?;
+            let score_matrix_bytes = score_elements.checked_mul(4).ok_or_else(|| {
+                failure(
+                    H3AttentionErrorCode::ArithmeticOverflow,
+                    "MiniMax H3 dense score byte accounting overflows",
+                    Vec::new(),
+                )
+            })?;
+            let probability_matrix_bytes = score_matrix_bytes;
+            let output_compute_bytes = one_vector_f32;
+            Ok(H3AttentionWorkspace {
+                input_output_tensor_bytes,
+                qkv_compute_bytes,
+                score_matrix_bytes,
+                probability_matrix_bytes,
+                output_compute_bytes,
+                softmax_lse_bytes: 0,
+                peak_auxiliary_bytes_upper_bound: checked_sum(
+                    "dense attention workspace",
+                    &[
+                        qkv_compute_bytes,
+                        score_matrix_bytes,
+                        probability_matrix_bytes,
+                        output_compute_bytes,
+                    ],
+                )?,
+            })
+        }
+        H3AttentionBackend::FlashAttentionV2 => {
+            let softmax_lse_bytes =
+                checked_product("FlashAttention LSE elements", &[batch, heads, rows])?
+                    .checked_mul(4)
+                    .ok_or_else(|| {
+                        failure(
+                            H3AttentionErrorCode::ArithmeticOverflow,
+                            "MiniMax H3 FlashAttention LSE byte accounting overflows",
+                            Vec::new(),
+                        )
+                    })?;
+            Ok(H3AttentionWorkspace {
+                input_output_tensor_bytes,
+                qkv_compute_bytes: 0,
+                score_matrix_bytes: 0,
+                probability_matrix_bytes: 0,
+                output_compute_bytes: 0,
+                softmax_lse_bytes,
+                peak_auxiliary_bytes_upper_bound: softmax_lse_bytes,
+            })
+        }
+    }
+}
+
+fn runtime_identity(authority: &H3AttentionRuntimeAuthority) -> String {
+    let mut digest = Sha256::new();
+    digest.update(b"minimax-h3-attention-runtime-v1");
+    digest.update(authority.backend.stable_id().as_bytes());
+    digest.update(authority.kernel.stable_id().as_bytes());
+    digest.update(authority.activation.stable_id().as_bytes());
+    digest.update(authority.device.stable_id().as_bytes());
+    digest.update((authority.contract.heads as u64).to_le_bytes());
+    digest.update((authority.contract.head_dim as u64).to_le_bytes());
+    digest.update(authority.contract.dtype.stable_id().as_bytes());
+    digest.update(H3_FLASH_ATTN_PACKAGE_VERSION.as_bytes());
+    digest.update(H3_FLASH_ATTN_CRATE_SHA256.as_bytes());
+    hex_digest(digest.finalize())
+}
+
+fn plan_identity(plan: &H3FrozenAttentionPlan) -> String {
+    let mut digest = Sha256::new();
+    digest.update(b"minimax-h3-attention-plan-v1");
+    digest.update(plan.scope.stable_id().as_bytes());
+    digest.update(plan.backend.stable_id().as_bytes());
+    digest.update(plan.kernel.stable_id().as_bytes());
+    digest.update(plan.activation.stable_id().as_bytes());
+    digest.update(plan.device.stable_id().as_bytes());
+    digest.update(plan.dtype.stable_id().as_bytes());
+    digest.update(plan.mask.stable_id().as_bytes());
+    for value in [
+        plan.batch_size,
+        plan.query_rows,
+        plan.key_value_rows,
+        plan.heads,
+        plan.head_dim,
+    ] {
+        digest.update((value as u64).to_le_bytes());
+    }
+    digest.update(plan.softmax_scale_f32_bits.to_le_bytes());
+    for value in [
+        plan.workspace.input_output_tensor_bytes,
+        plan.workspace.qkv_compute_bytes,
+        plan.workspace.score_matrix_bytes,
+        plan.workspace.probability_matrix_bytes,
+        plan.workspace.output_compute_bytes,
+        plan.workspace.softmax_lse_bytes,
+        plan.workspace.peak_auxiliary_bytes_upper_bound,
+    ] {
+        digest.update(value.to_le_bytes());
+    }
+    digest.update(H3_FLASH_ATTN_PACKAGE_VERSION.as_bytes());
+    digest.update(H3_FLASH_ATTN_CRATE_SHA256.as_bytes());
+    hex_digest(digest.finalize())
+}
+
+fn hex_digest(bytes: impl AsRef<[u8]>) -> String {
+    bytes
+        .as_ref()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+/// Execute one already-frozen H3 attention plan over BNHD tensors.
+///
+/// The function revalidates every serialized field and tensor property before
+/// dispatch. It never silently substitutes dense attention for a missing or
+/// ineligible FlashAttention kernel.
+pub fn execute_h3_attention(
+    plan: &H3FrozenAttentionPlan,
+    q: &Tensor,
+    k: &Tensor,
+    v: &Tensor,
+) -> InspectionResult<Tensor> {
+    plan.validate_identity()?;
+    let q_shape = q
+        .dims4()
+        .map_err(|error| kernel_shape_error("query", error))?;
+    let k_shape = k
+        .dims4()
+        .map_err(|error| kernel_shape_error("key", error))?;
+    let v_shape = v
+        .dims4()
+        .map_err(|error| kernel_shape_error("value", error))?;
+    let expected_q = (plan.batch_size, plan.query_rows, plan.heads, plan.head_dim);
+    let expected_kv = (
+        plan.batch_size,
+        plan.key_value_rows,
+        plan.heads,
+        plan.head_dim,
+    );
+    if q_shape != expected_q || k_shape != expected_kv || v_shape != expected_kv {
+        return Err(failure(
+            H3AttentionErrorCode::RuntimePlanMismatch,
+            format!(
+                "MiniMax H3 attention tensor shapes q={q_shape:?} k={k_shape:?} v={v_shape:?} do not match q={expected_q:?} kv={expected_kv:?}"
+            ),
+            vec![H3AttentionRequirement::UntamperedFrozenPlan],
+        ));
+    }
+    let actual_dtype = H3AttentionDType::from_candle(q.dtype())?;
+    if actual_dtype != plan.dtype || k.dtype() != q.dtype() || v.dtype() != q.dtype() {
+        return Err(failure(
+            H3AttentionErrorCode::RuntimePlanMismatch,
+            "MiniMax H3 Q/K/V dtype does not match the frozen attention plan",
+            vec![H3AttentionRequirement::ExactModelContract],
+        ));
+    }
+    if !q.device().same_device(k.device())
+        || !q.device().same_device(v.device())
+        || !plan.device.matches_candle(q.device())
+    {
+        return Err(failure(
+            H3AttentionErrorCode::RuntimePlanMismatch,
+            "MiniMax H3 Q/K/V device does not match the frozen attention plan",
+            vec![H3AttentionRequirement::ExactDeviceBackend],
+        ));
+    }
+    if plan.mask != H3AttentionMask::FullNonCausalPacked {
+        return Err(failure(
+            H3AttentionErrorCode::UnsupportedSemantics,
+            "MiniMax H3 requires full non-causal packed self-attention",
+            vec![H3AttentionRequirement::FullNonCausalPackedSelfAttention],
+        ));
+    }
+    let scale = f32::from_bits(plan.softmax_scale_f32_bits);
+    match plan.kernel {
+        H3AttentionKernel::CandleDenseF32V011 => dense_attention(q, k, v, scale),
+        H3AttentionKernel::CandleFlashFwdHdim128Bf16Sm80V011 => {
+            if q.stride().last() != Some(&1)
+                || k.stride().last() != Some(&1)
+                || v.stride().last() != Some(&1)
+            {
+                return Err(failure(
+                    H3AttentionErrorCode::RuntimePlanMismatch,
+                    "MiniMax H3 FlashAttention Q/K/V must have unit head-dimension stride",
+                    vec![H3AttentionRequirement::ExactModelContract],
+                ));
+            }
+            flash_attention(q, k, v, scale)
+        }
+    }
+}
+
+fn kernel_shape_error(name: &str, error: candle::Error) -> H3AttentionError {
+    failure(
+        H3AttentionErrorCode::RuntimePlanMismatch,
+        format!("MiniMax H3 {name} tensor must be rank 4 BNHD: {error}"),
+        vec![H3AttentionRequirement::ExactModelContract],
+    )
+}
+
+fn kernel_error(context: &str, error: candle::Error) -> H3AttentionError {
+    failure(
+        H3AttentionErrorCode::KernelExecution,
+        format!("MiniMax H3 {context} failed: {error}"),
+        Vec::new(),
+    )
+}
+
+fn dense_attention(q: &Tensor, k: &Tensor, v: &Tensor, scale: f32) -> InspectionResult<Tensor> {
+    let output_dtype = q.dtype();
+    let q = q
+        .transpose(1, 2)
+        .and_then(|tensor| tensor.contiguous())
+        .and_then(|tensor| tensor.to_dtype(DType::F32))
+        .map_err(|error| kernel_error("dense query preparation", error))?;
+    let k = k
+        .transpose(1, 2)
+        .and_then(|tensor| tensor.contiguous())
+        .and_then(|tensor| tensor.to_dtype(DType::F32))
+        .map_err(|error| kernel_error("dense key preparation", error))?;
+    let v = v
+        .transpose(1, 2)
+        .and_then(|tensor| tensor.contiguous())
+        .and_then(|tensor| tensor.to_dtype(DType::F32))
+        .map_err(|error| kernel_error("dense value preparation", error))?;
+    let scores = q
+        .matmul(
+            &k.transpose(2, 3)
+                .and_then(|tensor| tensor.contiguous())
+                .map_err(|error| kernel_error("dense key transpose", error))?,
+        )
+        .and_then(|tensor| tensor.affine(f64::from(scale), 0.0))
+        .map_err(|error| kernel_error("dense score", error))?;
+    let probabilities = candle_nn::ops::softmax(&scores, D::Minus1)
+        .map_err(|error| kernel_error("dense softmax", error))?;
+    probabilities
+        .matmul(&v)
+        .and_then(|tensor| tensor.to_dtype(output_dtype))
+        .and_then(|tensor| tensor.transpose(1, 2))
+        .and_then(|tensor| tensor.contiguous())
+        .map_err(|error| kernel_error("dense output", error))
+}
+
+#[cfg(feature = "flash-attn")]
+fn flash_attention(q: &Tensor, k: &Tensor, v: &Tensor, scale: f32) -> InspectionResult<Tensor> {
+    candle_flash_attn::flash_attn(q, k, v, scale, false)
+        .map_err(|error| kernel_error("FlashAttention v2 forward", error))
+}
+
+#[cfg(not(feature = "flash-attn"))]
+fn flash_attention(_: &Tensor, _: &Tensor, _: &Tensor, _: f32) -> InspectionResult<Tensor> {
+    Err(failure(
+        H3AttentionErrorCode::KernelNotCompiled,
+        "MiniMax H3 frozen plan references FlashAttention, but this binary omitted the kernel",
+        vec![H3AttentionRequirement::CompiledH3FlashAttentionV2],
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn exact_flash_candidate() -> H3AttentionRuntimeAuthority {
+        qualify_flash_attention_v2_with_availability(
+            H3AttentionDevice::Cuda {
+                compute_capability: Some((8, 9)),
+            },
+            H3AttentionModelContract::released_bf16(),
+            true,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn released_flash_authority_is_exact_and_never_release_activated() {
+        let authority = exact_flash_candidate();
+        assert_eq!(authority.backend(), H3AttentionBackend::FlashAttentionV2);
+        assert_eq!(
+            authority.kernel(),
+            H3AttentionKernel::CandleFlashFwdHdim128Bf16Sm80V011
+        );
+        assert_eq!(
+            authority.activation(),
+            H3AttentionActivation::DeveloperFeatureOnly
+        );
+        assert_eq!(authority.identity_sha256().len(), 64);
+        assert_eq!(H3_FLASH_ATTN_PACKAGE_VERSION, "0.11.0");
+        assert_eq!(H3_FLASH_ATTN_CRATE_SHA256.len(), 64);
+        let rejection = authority.require_release_activation().unwrap_err();
+        assert!(rejection
+            .requirements
+            .contains(&H3AttentionReleaseRequirement::MiniMaxH3Authorization));
+        assert!(rejection
+            .requirements
+            .contains(&H3AttentionReleaseRequirement::CrossBackendReproducibilityDecision));
+    }
+
+    #[test]
+    fn flash_contract_mutations_fail_closed_before_tensor_execution() {
+        let device = H3AttentionDevice::Cuda {
+            compute_capability: Some((8, 9)),
+        };
+        for contract in [
+            H3AttentionModelContract {
+                heads: 55,
+                ..H3AttentionModelContract::released_bf16()
+            },
+            H3AttentionModelContract {
+                head_dim: 64,
+                ..H3AttentionModelContract::released_bf16()
+            },
+            H3AttentionModelContract {
+                dtype: H3AttentionDType::F16,
+                ..H3AttentionModelContract::released_bf16()
+            },
+        ] {
+            assert!(qualify_flash_attention_v2_with_availability(device, contract, true).is_err());
+        }
+        for wrong_device in [
+            H3AttentionDevice::Cpu,
+            H3AttentionDevice::Metal,
+            H3AttentionDevice::Cuda {
+                compute_capability: None,
+            },
+            H3AttentionDevice::Cuda {
+                compute_capability: Some((8, 6)),
+            },
+            H3AttentionDevice::Cuda {
+                compute_capability: Some((9, 0)),
+            },
+        ] {
+            assert_eq!(
+                qualify_flash_attention_v2_with_availability(
+                    wrong_device,
+                    H3AttentionModelContract::released_bf16(),
+                    true,
+                )
+                .unwrap_err()
+                .code,
+                H3AttentionErrorCode::UnqualifiedArchitecture
+            );
+        }
+        assert_eq!(
+            qualify_flash_attention_v2_with_availability(
+                device,
+                H3AttentionModelContract::released_bf16(),
+                false,
+            )
+            .unwrap_err()
+            .code,
+            H3AttentionErrorCode::KernelNotCompiled
+        );
+    }
+
+    #[test]
+    fn dense_math_is_bounded_to_synthetic_score_shapes() {
+        let authority = H3AttentionRuntimeAuthority::bounded_synthetic_math(
+            H3AttentionDevice::Cpu,
+            H3AttentionModelContract::released_bf16(),
+        )
+        .unwrap();
+        let small = authority.freeze_execution(1, 32, 64).unwrap();
+        assert_eq!(
+            small.packed_transformer.backend(),
+            H3AttentionBackend::BoundedDenseMath
+        );
+        assert!(small.packed_transformer.workspace().score_matrix_bytes > 0);
+        let error = authority.freeze_execution(1, 256, 37_296).unwrap_err();
+        assert_eq!(error.code, H3AttentionErrorCode::DenseMathLimitExceeded);
+        assert!(error
+            .requirements
+            .contains(&H3AttentionRequirement::CompiledH3FlashAttentionV2));
+    }
+
+    #[test]
+    fn flash_workspace_is_linear_for_released_row_counts() {
+        let authority = exact_flash_candidate();
+        let short = authority.freeze_execution(1, 256, 37_296).unwrap();
+        let long = authority.freeze_execution(1, 256, 107_856).unwrap();
+        for plan in [&short.packed_transformer, &long.packed_transformer] {
+            assert_eq!(plan.workspace().score_matrix_bytes, 0);
+            assert_eq!(plan.workspace().probability_matrix_bytes, 0);
+            assert_eq!(
+                plan.workspace().softmax_lse_bytes,
+                (plan.heads() * plan.rows() * 4) as u64
+            );
+            assert_eq!(
+                plan.workspace().peak_auxiliary_bytes_upper_bound,
+                plan.workspace().softmax_lse_bytes
+            );
+        }
+        assert_eq!(
+            short.packed_transformer.workspace().softmax_lse_bytes,
+            8_354_304
+        );
+        assert_eq!(
+            long.packed_transformer.workspace().softmax_lse_bytes,
+            24_159_744
+        );
+        assert_ne!(
+            short.packed_transformer.identity_sha256(),
+            long.packed_transformer.identity_sha256()
+        );
+    }
+
+    #[test]
+    fn frozen_plan_mutation_and_tensor_shape_mismatch_are_rejected() {
+        let authority = H3AttentionRuntimeAuthority::bounded_synthetic_math(
+            H3AttentionDevice::Cpu,
+            H3AttentionModelContract {
+                heads: 2,
+                head_dim: 8,
+                dtype: H3AttentionDType::F32,
+            },
+        )
+        .unwrap();
+        let plan = authority
+            .freeze_execution(1, 3, 4)
+            .unwrap()
+            .packed_transformer;
+        let mut shape_mutation = plan.clone();
+        shape_mutation.query_rows += 1;
+        let mut backend_mutation = plan.clone();
+        backend_mutation.backend = H3AttentionBackend::FlashAttentionV2;
+        let mut kernel_mutation = plan.clone();
+        kernel_mutation.kernel = H3AttentionKernel::CandleFlashFwdHdim128Bf16Sm80V011;
+        let mut dtype_mutation = plan.clone();
+        dtype_mutation.dtype = H3AttentionDType::Bf16;
+        let mut workspace_mutation = plan.clone();
+        workspace_mutation.workspace.softmax_lse_bytes = 1;
+        for mutation in [
+            shape_mutation,
+            backend_mutation,
+            kernel_mutation,
+            dtype_mutation,
+            workspace_mutation,
+        ] {
+            assert_eq!(
+                mutation.validate_identity().unwrap_err().code,
+                H3AttentionErrorCode::FrozenIdentityMismatch
+            );
+        }
+
+        let mut semantically_forged = plan.clone();
+        semantically_forged.backend = H3AttentionBackend::FlashAttentionV2;
+        semantically_forged.identity_sha256 = plan_identity(&semantically_forged);
+        assert_eq!(
+            semantically_forged.validate_identity().unwrap_err().code,
+            H3AttentionErrorCode::RuntimePlanMismatch
+        );
+
+        let q = Tensor::zeros((1, 4, 2, 8), DType::F32, &Device::Cpu).unwrap();
+        let k = Tensor::zeros((1, 3, 2, 8), DType::F32, &Device::Cpu).unwrap();
+        assert_eq!(
+            execute_h3_attention(&plan, &q, &k, &k).unwrap_err().code,
+            H3AttentionErrorCode::RuntimePlanMismatch
+        );
+    }
+
+    #[test]
+    fn bounded_dense_execution_matches_direct_f32_reference() {
+        let authority = H3AttentionRuntimeAuthority::bounded_synthetic_math(
+            H3AttentionDevice::Cpu,
+            H3AttentionModelContract {
+                heads: 2,
+                head_dim: 8,
+                dtype: H3AttentionDType::F32,
+            },
+        )
+        .unwrap();
+        let plan = authority
+            .freeze_execution(1, 3, 5)
+            .unwrap()
+            .packed_transformer;
+        let values = (0..80)
+            .map(|index| index as f32 / 41.0 - 0.8)
+            .collect::<Vec<_>>();
+        let q = Tensor::from_vec(values.clone(), (1, 5, 2, 8), &Device::Cpu).unwrap();
+        let k = (&q / 3.0).unwrap();
+        let v = Tensor::from_vec(
+            values.into_iter().rev().collect::<Vec<_>>(),
+            (1, 5, 2, 8),
+            &Device::Cpu,
+        )
+        .unwrap();
+        let actual = execute_h3_attention(&plan, &q, &k, &v).unwrap();
+        let scale = 1.0 / (8f64).sqrt();
+        let qh = q.transpose(1, 2).unwrap().contiguous().unwrap();
+        let kh = k.transpose(1, 2).unwrap().contiguous().unwrap();
+        let vh = v.transpose(1, 2).unwrap().contiguous().unwrap();
+        let expected = candle_nn::ops::softmax(
+            &qh.matmul(&kh.transpose(2, 3).unwrap().contiguous().unwrap())
+                .unwrap()
+                .affine(scale, 0.0)
+                .unwrap(),
+            D::Minus1,
+        )
+        .unwrap()
+        .matmul(&vh)
+        .unwrap()
+        .transpose(1, 2)
+        .unwrap()
+        .contiguous()
+        .unwrap();
+        let max = (actual - expected)
+            .unwrap()
+            .abs()
+            .unwrap()
+            .flatten_all()
+            .unwrap()
+            .max(0)
+            .unwrap()
+            .to_scalar::<f32>()
+            .unwrap();
+        assert!(max <= 1e-6, "dense max difference {max}");
+    }
+
+    #[cfg(feature = "flash-attn")]
+    #[test]
+    fn flash_bf16_cpu_reference_cuda_parity() -> candle::Result<()> {
+        let Ok(cuda) = Device::new_cuda(0) else {
+            return Ok(());
+        };
+        let flash = H3AttentionRuntimeAuthority::qualify_flash_attention_v2(
+            H3AttentionDevice::Cuda {
+                compute_capability: Some((8, 9)),
+            },
+            H3AttentionModelContract::released_bf16(),
+        )
+        .unwrap();
+        let dense = H3AttentionRuntimeAuthority::bounded_synthetic_math(
+            H3AttentionDevice::Cpu,
+            H3AttentionModelContract::released_bf16(),
+        )
+        .unwrap();
+        let flash_plan = flash.freeze_execution(1, 7, 37).unwrap().packed_transformer;
+        let dense_plan = dense.freeze_execution(1, 7, 37).unwrap().packed_transformer;
+        let count = 37 * H3_RELEASE_HEADS * H3_RELEASE_HEAD_DIM;
+        let values = (0..count)
+            .map(|index| ((index % 251) as f32 - 125.0) / 211.0)
+            .collect::<Vec<_>>();
+        let cpu = Tensor::from_vec(
+            values.clone(),
+            (1, 37, H3_RELEASE_HEADS, H3_RELEASE_HEAD_DIM),
+            &Device::Cpu,
+        )?
+        .to_dtype(DType::BF16)?;
+        let gpu = Tensor::from_vec(
+            values,
+            (1, 37, H3_RELEASE_HEADS, H3_RELEASE_HEAD_DIM),
+            &cuda,
+        )?
+        .to_dtype(DType::BF16)?;
+        let cpu_out = execute_h3_attention(&dense_plan, &cpu, &(&cpu / 3.0)?, &(&cpu / 5.0)?)
+            .unwrap()
+            .to_dtype(DType::F32)?;
+        let gpu_out = execute_h3_attention(&flash_plan, &gpu, &(&gpu / 3.0)?, &(&gpu / 5.0)?)
+            .unwrap()
+            .to_device(&Device::Cpu)?
+            .to_dtype(DType::F32)?;
+        let max = (cpu_out - gpu_out)?
+            .abs()?
+            .flatten_all()?
+            .max(0)?
+            .to_scalar::<f32>()?;
+        assert!(max <= 0.02, "FlashAttention BF16 max difference {max}");
+        Ok(())
+    }
+}

--- a/crates/mold-candle/src/minimax_h3/attention.rs
+++ b/crates/mold-candle/src/minimax_h3/attention.rs
@@ -1429,6 +1429,46 @@ mod tests {
         assert!(max <= 1e-6, "dense max difference {max}");
     }
 
+    #[cfg(feature = "metal")]
+    #[test]
+    fn metal_keeps_only_the_bounded_synthetic_dense_path() -> candle::Result<()> {
+        let metal = Device::new_metal(0)?;
+        let authority = H3AttentionRuntimeAuthority::bounded_synthetic_math(
+            H3AttentionDevice::from_candle(&metal),
+            H3AttentionModelContract {
+                heads: 2,
+                head_dim: 8,
+                dtype: H3AttentionDType::F32,
+            },
+        )
+        .unwrap();
+        let plan = authority
+            .freeze_execution(1, 3, 5)
+            .unwrap()
+            .packed_transformer;
+        let q = Tensor::zeros((1, 5, 2, 8), DType::F32, &metal)?;
+        let output = execute_h3_attention(&plan, &q, &q, &q).unwrap();
+        assert_eq!(output.dims4()?, (1, 5, 2, 8));
+        assert!(output.device().same_device(&metal));
+
+        let product_error = authority.freeze_execution(1, 3, 37_296).unwrap_err();
+        assert_eq!(
+            product_error.code,
+            H3AttentionErrorCode::DenseMathLimitExceeded
+        );
+        assert_eq!(
+            qualify_flash_attention_v2_with_availability(
+                H3AttentionDevice::Metal,
+                H3AttentionModelContract::released_bf16(),
+                true,
+            )
+            .unwrap_err()
+            .code,
+            H3AttentionErrorCode::UnqualifiedArchitecture
+        );
+        Ok(())
+    }
+
     #[cfg(feature = "flash-attn")]
     #[test]
     fn flash_bf16_cpu_reference_cuda_parity() -> candle::Result<()> {

--- a/crates/mold-candle/src/minimax_h3/dit.rs
+++ b/crates/mold-candle/src/minimax_h3/dit.rs
@@ -17,6 +17,13 @@ use candle_nn as nn;
 use nn::{Module, VarBuilder};
 use serde::{Deserialize, Serialize};
 
+#[cfg(test)]
+use super::attention::H3AttentionBackend;
+use super::attention::{
+    execute_h3_attention, H3AttentionDType, H3AttentionDevice, H3AttentionModelContract,
+    H3AttentionRuntimeAuthority, H3FrozenAttentionExecution, H3FrozenAttentionPlan,
+};
+
 pub const H3_MODALITY_COUNT: usize = 3;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -1251,6 +1258,7 @@ impl H3Attention {
         &self,
         hidden: &Tensor,
         rotary: Option<(&Tensor, &Tensor, usize)>,
+        attention_plan: &H3FrozenAttentionPlan,
     ) -> Result<Tensor> {
         let (batch, seq_len, _) = hidden.dims3()?;
         let qkv = self.qkv.forward(hidden)?;
@@ -1274,21 +1282,8 @@ impl H3Attention {
             k = apply_h3_rotary(&k, cos, sin, rotary_dim)?;
         }
 
-        // Full, non-causal attention over one packed document. The F32 score
-        // path is the correctness backend; fused/chunked policies live above
-        // this primitive and must be selected explicitly.
-        let q = q.transpose(1, 2)?.contiguous()?.to_dtype(DType::F32)?;
-        let k = k.transpose(1, 2)?.contiguous()?.to_dtype(DType::F32)?;
-        let v = v.transpose(1, 2)?.contiguous()?.to_dtype(DType::F32)?;
-        let scores = q
-            .matmul(&k.transpose(2, 3)?.contiguous()?)?
-            .affine(1.0 / (self.head_dim as f64).sqrt(), 0.0)?;
-        let probabilities = nn::ops::softmax(&scores, D::Minus1)?;
-        let output = probabilities
-            .matmul(&v)?
-            .to_dtype(hidden.dtype())?
-            .transpose(1, 2)?
-            .contiguous()?
+        let output = execute_h3_attention(attention_plan, &q, &k, &v)
+            .map_err(|error| candle::Error::Msg(error.to_string()))?
             .reshape((batch, seq_len, self.inner_dim))?;
         self.out.forward(&output)
     }
@@ -1353,8 +1348,10 @@ impl H3TokenRefinerBlock {
         })
     }
 
-    fn forward(&self, hidden: &Tensor) -> Result<Tensor> {
-        let attention = self.attention.forward(&self.norm1.forward(hidden)?, None)?;
+    fn forward(&self, hidden: &Tensor, attention_plan: &H3FrozenAttentionPlan) -> Result<Tensor> {
+        let attention =
+            self.attention
+                .forward(&self.norm1.forward(hidden)?, None, attention_plan)?;
         let hidden = hidden.broadcast_add(&attention)?;
         let mlp = self.mlp.forward(&self.norm2.forward(&hidden)?)?;
         hidden.broadcast_add(&mlp)
@@ -1480,6 +1477,7 @@ impl H3TransformerBlock {
         adaln_input: &Tensor,
         adaln_indices: &Tensor,
         rotary: (&Tensor, &Tensor, usize),
+        attention_plan: &H3FrozenAttentionPlan,
     ) -> Result<Tensor> {
         let parameters = self.adaln.forward(adaln_input)?;
         let [shift_attention, scale_attention, gate_attention, shift_mlp, scale_mlp, gate_mlp]:
@@ -1492,7 +1490,9 @@ impl H3TransformerBlock {
             &scale_attention,
             adaln_indices,
         )?;
-        let update = self.attention.forward(&normalized, Some(rotary))?;
+        let update = self
+            .attention
+            .forward(&normalized, Some(rotary), attention_plan)?;
         let hidden = gated_residual(hidden, &update, &gate_attention, adaln_indices)?;
         let normalized = modulate(
             &self.norm2.forward(&hidden)?,
@@ -1728,6 +1728,7 @@ pub struct H3Transformer {
     task: H3TransformerTask,
     mode: H3AdaLnMode,
     precision: H3PrecisionProfile,
+    attention_runtime: H3AttentionRuntimeAuthority,
     video_projection: nn::Linear,
     audio_projection: nn::Linear,
     text_projection: nn::Linear,
@@ -1741,6 +1742,30 @@ pub struct H3Transformer {
 
 impl H3Transformer {
     pub fn load(checkpoint: H3AuditedCheckpoint<'_>) -> Result<Self> {
+        let contract = H3AttentionModelContract {
+            heads: checkpoint.config.num_attention_heads,
+            head_dim: checkpoint.config.attention_head_dim,
+            dtype: H3AttentionDType::from_candle(checkpoint.plan.precision.compute_dtype())
+                .map_err(|error| candle::Error::Msg(error.to_string()))?,
+        };
+        let attention_runtime = H3AttentionRuntimeAuthority::bounded_synthetic_math(
+            H3AttentionDevice::from_candle(checkpoint.source.vb.device()),
+            contract,
+        )
+        .map_err(|error| candle::Error::Msg(error.to_string()))?;
+        Self::load_with_attention(checkpoint, attention_runtime)
+    }
+
+    /// Load with one explicit attention authority.
+    ///
+    /// This does not activate H3 in any engine or release artifact. It exists
+    /// so a scheduler can eventually bind a qualified kernel/device identity
+    /// before model construction and so developer qualification can exercise
+    /// the exact DiT dispatch without environment-driven fallback.
+    pub fn load_with_attention(
+        checkpoint: H3AuditedCheckpoint<'_>,
+        attention_runtime: H3AttentionRuntimeAuthority,
+    ) -> Result<Self> {
         let H3AuditedCheckpoint {
             config,
             plan,
@@ -1748,12 +1773,23 @@ impl H3Transformer {
         } = checkpoint;
         debug_assert_eq!(source.inventory.component, plan.component);
         let vb = source.vb;
+        let compute_dtype = plan.precision.compute_dtype();
+        attention_runtime
+            .verify_model(
+                H3AttentionModelContract {
+                    heads: config.num_attention_heads,
+                    head_dim: config.attention_head_dim,
+                    dtype: H3AttentionDType::from_candle(compute_dtype)
+                        .map_err(|error| candle::Error::Msg(error.to_string()))?,
+                },
+                vb.device(),
+            )
+            .map_err(|error| candle::Error::Msg(error.to_string()))?;
         for key in plan.expected.keys() {
             if !vb.contains_tensor(key) {
                 candle::bail!("MiniMax H3 audited tensor {key:?} is absent from the loader")
             }
         }
-        let compute_dtype = plan.precision.compute_dtype();
         let mut token_refiner = Vec::with_capacity(config.token_refiner_num_layers);
         for index in 0..config.token_refiner_num_layers {
             token_refiner.push(H3TokenRefinerBlock::load(
@@ -1776,6 +1812,7 @@ impl H3Transformer {
             task: plan.task,
             mode: plan.mode,
             precision: plan.precision,
+            attention_runtime,
             video_projection: linear_with_dtype(
                 config.video_patch_dim(),
                 config.hidden_size,
@@ -1829,6 +1866,23 @@ impl H3Transformer {
         self.precision
     }
 
+    pub const fn attention_runtime(&self) -> &H3AttentionRuntimeAuthority {
+        &self.attention_runtime
+    }
+
+    /// Freeze both token-refiner and packed-transformer attention identities
+    /// before any projection or model block runs.
+    pub fn freeze_attention_execution(
+        &self,
+        batch_size: usize,
+        token_refiner_rows: usize,
+        packed_rows: usize,
+    ) -> Result<H3FrozenAttentionExecution> {
+        self.attention_runtime
+            .freeze_execution(batch_size, token_refiner_rows, packed_rows)
+            .map_err(|error| candle::Error::Msg(error.to_string()))
+    }
+
     pub fn forward(
         &self,
         input: H3ForwardInput<'_>,
@@ -1873,6 +1927,12 @@ impl H3Transformer {
             candle::bail!("MiniMax H3 inputs and frozen layout must share one device")
         }
 
+        // This is intentionally before any projection or block execution: a
+        // product-size N² math fallback is rejected without spending model
+        // compute or waiting for a late CUDA allocation failure.
+        let attention_execution =
+            self.freeze_attention_execution(batch, text_rows, layout.seq_len)?;
+
         let compute_dtype = self.precision.compute_dtype();
         let video = self
             .video_projection
@@ -1892,7 +1952,7 @@ impl H3Transformer {
             total: self.token_refiner.len(),
         })?;
         for (index, block) in self.token_refiner.iter().enumerate() {
-            text = block.forward(&text)?;
+            text = block.forward(&text, &attention_execution.token_refiner)?;
             observer(H3BlockProgress {
                 stack: H3BlockStack::TokenRefiner,
                 completed: index + 1,
@@ -1928,6 +1988,7 @@ impl H3Transformer {
                 &adaln_input,
                 &layout.adaln_indices,
                 (&cos, &sin, rotary_dim),
+                &attention_execution.packed_transformer,
             )?;
             observer(H3BlockProgress {
                 stack: H3BlockStack::Transformer,
@@ -2040,6 +2101,21 @@ mod tests {
         let checkpoint = audit_h3_checkpoint(config, task, precision, source)
             .map_err(|error| candle::Error::Msg(error.to_string()))?;
         H3Transformer::load(checkpoint)
+    }
+
+    fn load_with_attention(
+        device: &Device,
+        config: H3TransformerConfig,
+        mode: H3AdaLnMode,
+        precision: H3PrecisionProfile,
+        task: H3TransformerTask,
+        attention: H3AttentionRuntimeAuthority,
+    ) -> Result<H3Transformer> {
+        let inventory = inventory(&config, mode, precision, task.checkpoint_component());
+        let source = source_from_inventory(inventory, device)?;
+        let checkpoint = audit_h3_checkpoint(config, task, precision, source)
+            .map_err(|error| candle::Error::Msg(error.to_string()))?;
+        H3Transformer::load_with_attention(checkpoint, attention)
     }
 
     fn tiny_layout() -> H3PackedLayout {
@@ -2569,6 +2645,51 @@ mod tests {
     }
 
     #[test]
+    fn default_attention_authority_is_bounded_and_rejects_product_rows_early() -> Result<()> {
+        let model = load_tiny(
+            &Device::Cpu,
+            H3AdaLnMode::Full,
+            H3PrecisionProfile::SyntheticF32,
+            H3TransformerTask::T2VaFl2Va,
+        )?;
+        assert_eq!(
+            model.attention_runtime().backend(),
+            H3AttentionBackend::BoundedDenseMath
+        );
+        let tiny = model.freeze_attention_execution(1, 2, 6)?;
+        assert_eq!(tiny.packed_transformer.rows(), 6);
+        let error = model
+            .freeze_attention_execution(1, 256, 37_296)
+            .unwrap_err();
+        assert!(error.to_string().contains("synthetic bound"));
+        Ok(())
+    }
+
+    #[test]
+    fn explicit_attention_authority_must_match_model_before_loading() -> Result<()> {
+        let attention = H3AttentionRuntimeAuthority::bounded_synthetic_math(
+            H3AttentionDevice::Cpu,
+            H3AttentionModelContract {
+                heads: 3,
+                head_dim: 8,
+                dtype: H3AttentionDType::F32,
+            },
+        )
+        .unwrap();
+        let error = load_with_attention(
+            &Device::Cpu,
+            H3TransformerConfig::tiny(),
+            H3AdaLnMode::Full,
+            H3PrecisionProfile::SyntheticF32,
+            H3TransformerTask::T2VaFl2Va,
+            attention,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("does not match model"));
+        Ok(())
+    }
+
+    #[test]
     fn pruned_curve_stack_interpolates_dual_timesteps() -> Result<()> {
         let device = Device::Cpu;
         let mode = H3AdaLnMode::Curve {
@@ -2758,6 +2879,55 @@ mod tests {
         let output = model.forward(input.borrowed(), &tiny_layout().freeze(&cuda)?)?;
         assert_eq!(output.video.dtype(), DType::F32);
         assert_eq!(output.audio.dtype(), DType::F32);
+        assert!(output
+            .video
+            .flatten_all()?
+            .to_vec1::<f32>()?
+            .iter()
+            .all(|value| value.is_finite()));
+        assert!(output
+            .audio
+            .flatten_all()?
+            .to_vec1::<f32>()?
+            .iter()
+            .all(|value| value.is_finite()));
+        Ok(())
+    }
+
+    #[cfg(feature = "flash-attn")]
+    #[test]
+    fn h3_stack_dispatches_through_qualified_flash_attention_on_cuda() -> Result<()> {
+        let Ok(cuda) = Device::new_cuda(0) else {
+            return Ok(());
+        };
+        let mut config = H3TransformerConfig::tiny();
+        config.num_attention_heads = 56;
+        config.attention_head_dim = 128;
+        let attention = H3AttentionRuntimeAuthority::qualify_flash_attention_v2(
+            H3AttentionDevice::Cuda {
+                compute_capability: Some((8, 9)),
+            },
+            H3AttentionModelContract::released_bf16(),
+        )
+        .unwrap();
+        let model = load_with_attention(
+            &cuda,
+            config,
+            H3AdaLnMode::Curve {
+                grid: 9,
+                basis_dim: 3,
+            },
+            H3PrecisionProfile::OfficialMixedBf16F32,
+            H3TransformerTask::Ref2Va,
+            attention,
+        )?;
+        let execution = model.freeze_attention_execution(1, 2, 6)?;
+        assert_eq!(
+            execution.packed_transformer.backend(),
+            H3AttentionBackend::FlashAttentionV2
+        );
+        let input = OwnedInput::new(&cuda)?;
+        let output = model.forward(input.borrowed(), &tiny_layout().freeze(&cuda)?)?;
         assert!(output
             .video
             .flatten_all()?

--- a/crates/mold-candle/src/minimax_h3/mod.rs
+++ b/crates/mold-candle/src/minimax_h3/mod.rs
@@ -5,6 +5,7 @@
 //! whether callers may construct these primitives with real weights.
 
 mod artifacts;
+mod attention;
 mod comfy_dit;
 mod config;
 mod dit;
@@ -38,6 +39,15 @@ pub use audio_weights::{
 pub use artifacts::{
     validate_checkpoint_keys, ArtifactError, ArtifactFingerprint, ArtifactRole,
     ArtifactVerificationProgress, CheckpointKeyReport, ConditionerArtifacts, FrozenArtifact,
+};
+pub use attention::{
+    execute_h3_attention, H3AttentionActivation, H3AttentionBackend, H3AttentionDType,
+    H3AttentionDevice, H3AttentionError, H3AttentionErrorCode, H3AttentionKernel, H3AttentionMask,
+    H3AttentionModelContract, H3AttentionReleaseRejection, H3AttentionReleaseRequirement,
+    H3AttentionRequirement, H3AttentionRuntimeAuthority, H3AttentionScope, H3AttentionWorkspace,
+    H3FrozenAttentionExecution, H3FrozenAttentionPlan, H3_DENSE_SYNTHETIC_MAX_SCORE_ELEMENTS,
+    H3_FLASH_ATTN_CRATE_SHA256, H3_FLASH_ATTN_PACKAGE_VERSION,
+    H3_FLASH_ATTN_QUALIFIED_COMPUTE_CAPABILITY,
 };
 pub use comfy_dit::{
     inspect_h3_comfy_published_header, H3ComfyAccuracyTier, H3ComfyCheckpointCandidate,


### PR DESCRIPTION
## Summary

- add a MiniMax H3-specific attention authority for full, non-causal packed self-attention
- qualify Candle FlashAttention v2 only for the measured H3 contract: BF16, 56 heads, head dimension 128, and CUDA SM89
- freeze backend, kernel source identity, activation class, device capability, dtype, shape, scale, and workspace before DiT projection/block execution
- route both token-refiner and packed-transformer attention through the frozen plan with no silent dense fallback
- keep F32-accumulating dense attention behind a 4,194,304-score-element synthetic bound and reject released 37k/108k-row plans before model compute

## Qualification boundary

This pins `candle-flash-attn` 0.11.0 and its crates.io checksum `e5f1e2f29f5123d7a627171209fdaeb4ee91d076aefeac588922aa9842e30c2c`. The qualified kernel is the BF16, head-dimension-128, non-causal FA2 forward path compiled for SM89. SageAttention, INT8 QK, and other approximate paths are not accepted.

The frozen workspace records no materialized score or probability matrix. Its global auxiliary LSE allocation is linear:

- 37,296 packed rows: 8,354,304 bytes
- 107,856 packed rows: 24,159,744 bytes

This is deliberately a fail-closed implementation slice, not release activation. `require_release_activation()` always rejects and names the remaining authorities: MiniMax H3 authorization, inclusion of the kernel in release artifacts, an explicit cross-backend seed-reproducibility decision, and qualification of the remaining shipped CUDA architectures. Existing release artifacts remain unchanged.

## Verification

Local, on the exact stacked parent:

- `cargo fmt --all -- --check`
- `cargo test -p mold-ai-candle minimax_h3 --locked` — 111 passed
- `cargo clippy -p mold-ai-candle --all-targets --locked -- -D warnings`
- `rustup run 1.93.0 cargo check -p mold-ai-candle --all-targets --locked`
- `cargo check -p mold-ai-inference --locked`

Plato, NVIDIA L40S / SM89 / CUDA 12.8, with no H3 weights or model artifacts:

- `cargo test -p mold-ai-candle --features flash-attn minimax_h3 --locked` — 121 passed
  - direct CPU BF16 dense-reference to CUDA FA2 parity passed
  - full H3 DiT dispatch through the qualified kernel passed
- `cargo clippy -p mold-ai-candle --all-targets --features flash-attn --locked -- -D warnings`
- `cargo clippy -p mold-ai-inference --all-targets --features flash-attn --locked -- -D warnings`

## Remaining work in #840

- legally authorize H3 work and distribution under #831
- include and test the selected kernel in actual release artifacts without silently changing other families' seed behavior
- qualify additional shipped CUDA architectures and driver/toolkit combinations
- add production telemetry, packed-reference benchmarks, fusion evaluation, and denoise-loop/placement UAT once real-H3 execution is authorized

Refs #840.
