### PR TITLE
test(h3): add per-layer conformance comparator

### DIFF
--- a/docs/qualification/minimax-h3-conformance.md
+++ b/docs/qualification/minimax-h3-conformance.md
@@ -21,6 +21,44 @@ python3 scripts/minimax-h3-conformance.py check-contract
 python3 scripts/tests/minimax-h3-conformance-contract.py
 ```
 
+Compare the checked-in, weight-free per-layer producer pair:
+
+```bash
+python3 scripts/minimax-h3-conformance.py compare \
+  --oracle tests/fixtures/minimax_h3/synthetic-oracle-v1.json \
+  --mold tests/fixtures/minimax_h3/synthetic-mold-v1.json
+```
+
+The two documents conform to
+`docs/qualification/minimax-h3-layer-output.schema.json`. Each document names
+one case and primitive layer, the producer role and exact source revision, the
+adapter command and tensor-hash encoding, the input/component fingerprints,
+the execution environment, and a keyed tensor set. Tensor records carry exact
+shape, dtype, content hash, min/max/mean/std, and coordinate-addressed stable
+samples. Only the oracle declares comparison policy, so a Mold producer cannot
+weaken its own acceptance threshold.
+
+The comparator requires the same case, layer, authority tier, input, output
+keys, sample coordinates, shapes, dtypes, and hash encoding. It rejects every
+NaN or infinity before schema comparison. Numeric statistics and samples pass
+only when
+`abs(mold - oracle) <= absolute + relative * abs(oracle)`. An `exact` hash
+policy makes a content-hash difference fatal; `record-only` retains both hashes
+as an explicit diagnostic while numerical tolerances remain authoritative.
+Failures aggregate the missing/extra keys and every comparable shape, dtype,
+hash, statistic, sample-coordinate, and tolerance discrepancy.
+
+The synthetic pair deliberately includes a small within-tolerance delta and a
+record-only hash difference. Contract mutation tests deterministically prove
+shape, dtype, output-key, sample-key, missing/extra, NaN, infinity, exact-hash,
+and tolerance failures without loading H3 artifacts. Recreate either checked
+document for review with:
+
+```bash
+python3 scripts/minimax-h3-conformance.py print-synthetic-output --role oracle
+python3 scripts/minimax-h3-conformance.py print-synthetic-output --role mold
+```
+
 Verify pinned local metadata/source clones without executing a checkpoint:
 
 ```bash
@@ -71,6 +109,24 @@ python3 scripts/minimax-h3-conformance.py validate-bundle \
   --bundle "$MOLD_H3_FIXTURE_ROOT/bundle.json" \
   --authorization-record "$MOLD_H3_AUTHORIZATION_RECORD"
 ```
+
+After authorization and capture, compare any external per-layer pair under the
+same approved root:
+
+```bash
+python3 scripts/minimax-h3-conformance.py compare \
+  --oracle "$MOLD_H3_FIXTURE_ROOT/layers/<case>/oracle.json" \
+  --mold "$MOLD_H3_FIXTURE_ROOT/layers/<case>/mold.json" \
+  --fixture-root "$MOLD_H3_FIXTURE_ROOT" \
+  --authorization-record "$MOLD_H3_AUTHORIZATION_RECORD"
+```
+
+Without those last two arguments, `compare` accepts only the exact checked-in
+synthetic pair. Any other paths—even files labeled synthetic—must be inside the
+external root and pass the existing authorization gate. Non-synthetic producer
+documents must additionally bind the authorization source-document hash. The
+comparison command consumes adapter JSON only; it never opens checkpoints or
+media itself.
 
 The bundle schema is
 `docs/qualification/minimax-h3-fixture-bundle.schema.json`. Every fixture names

--- a/docs/qualification/minimax-h3-layer-output.schema.json
+++ b/docs/qualification/minimax-h3-layer-output.schema.json
@@ -1,0 +1,174 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://utensils.io/mold/schemas/minimax-h3-layer-output-v1.json",
+  "title": "Mold MiniMax H3 per-layer producer and adapter output",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "family",
+    "case_id",
+    "layer",
+    "authority_tier",
+    "authorization_document_sha256",
+    "input",
+    "producer",
+    "adapter",
+    "environment",
+    "outputs"
+  ],
+  "properties": {
+    "schema_version": { "const": "mold.minimax-h3.layer-output.v1" },
+    "family": { "const": "minimax-h3" },
+    "case_id": { "$ref": "#/$defs/key" },
+    "layer": { "$ref": "#/$defs/key" },
+    "authority_tier": {
+      "enum": ["exact-full-bf16", "quantized-structural", "synthetic"]
+    },
+    "authorization_document_sha256": {
+      "type": ["string", "null"],
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "input": { "$ref": "#/$defs/input" },
+    "producer": { "$ref": "#/$defs/producer" },
+    "adapter": { "$ref": "#/$defs/adapter" },
+    "environment": { "$ref": "#/$defs/environment" },
+    "outputs": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/tensor" }
+    },
+    "comparison": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/comparison" }
+    }
+  },
+  "$defs": {
+    "key": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._/-]*$"
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "commit": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$"
+    },
+    "input": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "sha256", "component_index_sha256"],
+      "properties": {
+        "id": { "$ref": "#/$defs/key" },
+        "sha256": { "$ref": "#/$defs/sha256" },
+        "component_index_sha256": { "$ref": "#/$defs/sha256" }
+      }
+    },
+    "producer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["role", "implementation", "source_id", "revision"],
+      "properties": {
+        "role": { "enum": ["oracle", "mold"] },
+        "implementation": { "$ref": "#/$defs/key" },
+        "source_id": { "$ref": "#/$defs/key" },
+        "revision": { "$ref": "#/$defs/commit" }
+      }
+    },
+    "adapter": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema_version", "id", "command", "tensor_hash_encoding"],
+      "properties": {
+        "schema_version": { "const": "mold.minimax-h3.layer-adapter.v1" },
+        "id": { "$ref": "#/$defs/key" },
+        "command": { "type": "string", "minLength": 1 },
+        "tensor_hash_encoding": { "$ref": "#/$defs/key" }
+      }
+    },
+    "environment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "device",
+        "dtype",
+        "attention_backend",
+        "forbidden_accelerations_disabled"
+      ],
+      "properties": {
+        "device": { "type": "string", "minLength": 1 },
+        "dtype": { "type": "string", "minLength": 1 },
+        "attention_backend": { "type": "string", "minLength": 1 },
+        "forbidden_accelerations_disabled": { "const": true }
+      }
+    },
+    "statistics": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["min", "max", "mean", "std"],
+      "properties": {
+        "min": { "type": "number" },
+        "max": { "type": "number" },
+        "mean": { "type": "number" },
+        "std": { "type": "number", "minimum": 0 }
+      }
+    },
+    "sample": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["index", "value"],
+      "properties": {
+        "index": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "integer", "minimum": 0 }
+        },
+        "value": { "type": "number" }
+      }
+    },
+    "tensor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "key",
+        "shape",
+        "dtype",
+        "content_sha256",
+        "statistics",
+        "samples"
+      ],
+      "properties": {
+        "key": { "$ref": "#/$defs/key" },
+        "shape": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "integer", "minimum": 1 }
+        },
+        "dtype": { "type": "string", "minLength": 1 },
+        "content_sha256": { "$ref": "#/$defs/sha256" },
+        "statistics": { "$ref": "#/$defs/statistics" },
+        "samples": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/sample" }
+        }
+      }
+    },
+    "comparison": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["key", "absolute", "relative", "metric", "hash_policy"],
+      "properties": {
+        "key": { "$ref": "#/$defs/key" },
+        "absolute": { "type": "number", "minimum": 0 },
+        "relative": { "type": "number", "minimum": 0 },
+        "metric": { "const": "elementwise-atol-plus-rtol" },
+        "hash_policy": { "enum": ["exact", "record-only"] }
+      }
+    }
+  }
+}

--- a/scripts/minimax-h3-conformance.py
+++ b/scripts/minimax-h3-conformance.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Validate MiniMax H3 conformance pins and external fixture evidence.
+"""Validate MiniMax H3 pins and compare per-layer conformance evidence.
 
 The checked-in contract is intentionally weight-free. Real checkpoint evidence
 must live outside the repository and is accepted only with a separately managed
@@ -12,6 +12,7 @@ import argparse
 import hashlib
 import importlib.util
 import json
+import math
 import pathlib
 import struct
 import subprocess
@@ -29,11 +30,22 @@ MANIFEST_SCHEMA_PATH = (
 BUNDLE_SCHEMA_PATH = (
     REPO_ROOT / "docs" / "qualification" / "minimax-h3-fixture-bundle.schema.json"
 )
+LAYER_OUTPUT_SCHEMA_PATH = (
+    REPO_ROOT / "docs" / "qualification" / "minimax-h3-layer-output.schema.json"
+)
+SYNTHETIC_ORACLE_PATH = FIXTURE_DIR / "synthetic-oracle-v1.json"
+SYNTHETIC_MOLD_PATH = FIXTURE_DIR / "synthetic-mold-v1.json"
 
 SCHEMA_VERSION = "mold.minimax-h3.conformance-manifest.v1"
 SYNTHETIC_SCHEMA_VERSION = "mold.minimax-h3.synthetic.v1"
 BUNDLE_SCHEMA_VERSION = "mold.minimax-h3.fixture-bundle.v1"
 AUTHORIZATION_SCHEMA_VERSION = "mold.minimax-h3.authorization.v1"
+LAYER_OUTPUT_SCHEMA_VERSION = "mold.minimax-h3.layer-output.v1"
+LAYER_ADAPTER_SCHEMA_VERSION = "mold.minimax-h3.layer-adapter.v1"
+
+# The checked synthetic candidate records the Mold tree from which the original
+# H3 contract was extended. Real captures record their exact candidate commit.
+SYNTHETIC_MOLD_REVISION = "ea3d1d86fbd09eb6d47848649168c70392db9c63"
 
 EXPECTED_REVISIONS = {
     "minimax-official-code": "8d8824efaf94586c0cc9ac7ad8d0723d4d6420ea",
@@ -45,7 +57,9 @@ EXPECTED_REVISIONS = {
     "vllm-omni": "3d7fc3b9ba3cac88d579d4dc35b78b0b641675fc",
 }
 
-EXPECTED_LICENSE_SHA256 = "59b99642b95ea21630e311198ddbfffbfe05aadba0c2f5d884cbdf4efcc90f44"
+EXPECTED_LICENSE_SHA256 = (
+    "59b99642b95ea21630e311198ddbfffbfe05aadba0c2f5d884cbdf4efcc90f44"
+)
 
 EXPECTED_EXCLUDED_ACCELERATIONS = {
     "torch-compile",
@@ -199,9 +213,7 @@ def euler_update(
         sample_value = f32(sample_value)
         velocity_value = f32(velocity_value)
         denoised = f32(sample_value + f32(sigma_from_timestep * velocity_value))
-        output.append(
-            f32(f32(ratio * sample_value) + f32(one_minus_ratio * denoised))
-        )
+        output.append(f32(f32(ratio * sample_value) + f32(one_minus_ratio * denoised)))
     return output
 
 
@@ -315,6 +327,357 @@ def canonical_bytes(value: Any) -> bytes:
     return (json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n").encode()
 
 
+def tensor_content_sha256(dtype: str, shape: list[int], values: list[float]) -> str:
+    """Hash the checked synthetic tensor's canonical numeric representation."""
+    payload = {"dtype": dtype, "shape": shape, "values": values}
+    return hashlib.sha256(canonical_bytes(payload)).hexdigest()
+
+
+def tensor_statistics(values: list[float]) -> dict[str, float]:
+    mean = sum(values) / len(values)
+    variance = sum((value - mean) ** 2 for value in values) / len(values)
+    return {
+        "min": min(values),
+        "max": max(values),
+        "mean": mean,
+        "std": math.sqrt(variance),
+    }
+
+
+def synthetic_tensor(key: str, values: list[float]) -> dict[str, Any]:
+    shape = [len(values)]
+    return {
+        "key": key,
+        "shape": shape,
+        "dtype": "float32",
+        "content_sha256": tensor_content_sha256("float32", shape, values),
+        "statistics": tensor_statistics(values),
+        "samples": [
+            {"index": [index], "value": value} for index, value in enumerate(values)
+        ],
+    }
+
+
+def synthetic_layer_outputs() -> tuple[dict[str, Any], dict[str, Any]]:
+    """Build the checked weight-free producer/adaptor comparison pair."""
+    video_values = [0.25, -0.5, 1.0, -2.0]
+    oracle_audio_values = [0.125, -0.25, 0.5, -1.0]
+    mold_audio_values = [f32(value + 0.000001) for value in oracle_audio_values]
+    input_record = {
+        "id": "synthetic-v1",
+        "sha256": sha256_file(SYNTHETIC_PATH),
+        "component_index_sha256": EXPECTED_COMPONENT_INDEXES["official-modular-index"][
+            1
+        ],
+    }
+    environment = {
+        "device": "cpu-synthetic",
+        "dtype": "float32",
+        "attention_backend": "scalar-python",
+        "forbidden_accelerations_disabled": True,
+    }
+
+    def document(
+        role: str,
+        implementation: str,
+        source_id: str,
+        revision: str,
+        outputs: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        return {
+            "schema_version": LAYER_OUTPUT_SCHEMA_VERSION,
+            "family": "minimax-h3",
+            "case_id": "synthetic-coupled-update-v1",
+            "layer": "dual-sampler",
+            "authority_tier": "synthetic",
+            "authorization_document_sha256": None,
+            "input": dict(input_record),
+            "producer": {
+                "role": role,
+                "implementation": implementation,
+                "source_id": source_id,
+                "revision": revision,
+            },
+            "adapter": {
+                "schema_version": LAYER_ADAPTER_SCHEMA_VERSION,
+                "id": f"{implementation}-synthetic-dual-sampler-v1",
+                "command": (
+                    "python3 scripts/minimax-h3-conformance.py "
+                    f"print-synthetic-output --role {role}"
+                ),
+                "tensor_hash_encoding": "canonical-json-numeric-v1",
+            },
+            "environment": dict(environment),
+            "outputs": outputs,
+        }
+
+    oracle = document(
+        "oracle",
+        "diffusers",
+        "diffusers",
+        EXPECTED_REVISIONS["diffusers"],
+        [
+            synthetic_tensor("video_next", video_values),
+            synthetic_tensor("audio_next", oracle_audio_values),
+        ],
+    )
+    oracle["comparison"] = [
+        {
+            "key": "video_next",
+            "absolute": 0.0,
+            "relative": 0.0,
+            "metric": "elementwise-atol-plus-rtol",
+            "hash_policy": "exact",
+        },
+        {
+            "key": "audio_next",
+            "absolute": 0.000002,
+            "relative": 0.000001,
+            "metric": "elementwise-atol-plus-rtol",
+            "hash_policy": "record-only",
+        },
+    ]
+    mold = document(
+        "mold",
+        "mold-synthetic-adapter",
+        "mold",
+        SYNTHETIC_MOLD_REVISION,
+        [
+            synthetic_tensor("video_next", video_values),
+            synthetic_tensor("audio_next", mold_audio_values),
+        ],
+    )
+    return oracle, mold
+
+
+def non_finite_name(value: float) -> str:
+    if math.isnan(value):
+        return "NaN"
+    return "Inf" if value > 0 else "-Inf"
+
+
+def reject_non_finite(value: Any, label: str, location: str = "$") -> None:
+    if isinstance(value, float) and not math.isfinite(value):
+        fail(f"{label} {location} is {non_finite_name(value)}")
+    if isinstance(value, dict):
+        for key, child in value.items():
+            reject_non_finite(child, label, f"{location}.{key}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            reject_non_finite(child, label, f"{location}[{index}]")
+
+
+def keyed_records(
+    records: list[dict[str, Any]], label: str
+) -> dict[str, dict[str, Any]]:
+    keyed: dict[str, dict[str, Any]] = {}
+    for record in records:
+        key = record["key"]
+        if key in keyed:
+            fail(f"{label} contains duplicate key {key!r}")
+        keyed[key] = record
+    return keyed
+
+
+def sample_records(
+    output: dict[str, Any], label: str
+) -> dict[tuple[int, ...], dict[str, Any]]:
+    samples: dict[tuple[int, ...], dict[str, Any]] = {}
+    shape = output["shape"]
+    for sample in output["samples"]:
+        index = tuple(sample["index"])
+        if len(index) != len(shape):
+            fail(
+                f"{label} sample index {list(index)} has rank {len(index)}, "
+                f"expected {len(shape)}"
+            )
+        if any(offset >= extent for offset, extent in zip(index, shape, strict=True)):
+            fail(f"{label} sample index {list(index)} is outside shape {shape}")
+        if index in samples:
+            fail(f"{label} contains duplicate sample index {list(index)}")
+        samples[index] = sample
+    return samples
+
+
+def validate_layer_output(value: Any, label: str) -> dict[str, Any]:
+    reject_non_finite(value, label)
+    validate_schema(value, LAYER_OUTPUT_SCHEMA_PATH)
+    if value["schema_version"] != LAYER_OUTPUT_SCHEMA_VERSION:
+        fail(f"{label} uses an unsupported layer-output schema")
+    if value["family"] != "minimax-h3":
+        fail(f"{label} targets a different model family")
+    if value["layer"] not in EXPECTED_LAYERS:
+        fail(f"{label} names unknown layer {value['layer']!r}")
+
+    component_hashes = {
+        component_sha for _, component_sha in EXPECTED_COMPONENT_INDEXES.values()
+    }
+    if value["input"]["component_index_sha256"] not in component_hashes:
+        fail(f"{label} component index hash is not in the pinned authority set")
+
+    producer = value["producer"]
+    if producer["role"] == "oracle":
+        source_id = producer["source_id"]
+        expected_revision = EXPECTED_REVISIONS.get(source_id)
+        if expected_revision is None or producer["revision"] != expected_revision:
+            fail(f"{label} oracle source revision is not pinned")
+    elif producer["source_id"] != "mold":
+        fail(f"{label} Mold producer source_id must be 'mold'")
+
+    authorization_hash = value["authorization_document_sha256"]
+    if value["authority_tier"] == "synthetic":
+        if authorization_hash is not None:
+            fail(f"{label} synthetic evidence must not claim real authorization")
+    elif authorization_hash is None:
+        fail(f"{label} real evidence lacks its authorization document hash")
+
+    outputs = keyed_records(value["outputs"], f"{label} outputs")
+    for key, output in outputs.items():
+        sample_records(output, f"{label} output {key!r}")
+        statistics = output["statistics"]
+        if statistics["min"] > statistics["max"]:
+            fail(f"{label} output {key!r} has min greater than max")
+        if not statistics["min"] <= statistics["mean"] <= statistics["max"]:
+            fail(f"{label} output {key!r} mean lies outside min/max")
+
+    comparison = value.get("comparison")
+    if producer["role"] == "oracle":
+        if comparison is None:
+            fail(f"{label} oracle lacks comparison policies")
+        policies = keyed_records(comparison, f"{label} comparison policies")
+        missing = sorted(set(outputs) - set(policies))
+        extra = sorted(set(policies) - set(outputs))
+        if missing or extra:
+            fail(
+                f"{label} comparison policy key mismatch: "
+                f"missing={missing}, extra={extra}"
+            )
+    elif comparison is not None:
+        fail(f"{label} Mold producer must not declare oracle comparison policies")
+    return value
+
+
+def tolerance_issue(
+    context: str,
+    oracle_value: float,
+    mold_value: float,
+    policy: dict[str, Any],
+) -> str | None:
+    absolute = policy["absolute"]
+    relative = policy["relative"]
+    error = abs(mold_value - oracle_value)
+    allowed = absolute + relative * abs(oracle_value)
+    if error <= allowed:
+        return None
+    return (
+        f"{context} tolerance exceeded: oracle={oracle_value!r}, mold={mold_value!r}, "
+        f"abs_error={error!r}, allowed={allowed!r}, atol={absolute!r}, "
+        f"rtol={relative!r}"
+    )
+
+
+def compare_layer_outputs(oracle: Any, mold: Any) -> list[str]:
+    """Compare one Mold producer document with its numerical oracle."""
+    oracle = validate_layer_output(oracle, "oracle")
+    mold = validate_layer_output(mold, "Mold")
+    if oracle["producer"]["role"] != "oracle":
+        fail("--oracle document producer role is not oracle")
+    if mold["producer"]["role"] != "mold":
+        fail("--mold document producer role is not mold")
+
+    issues: list[str] = []
+    for field in ("case_id", "layer", "authority_tier", "input"):
+        if oracle[field] != mold[field]:
+            issues.append(
+                f"comparison {field} mismatch: oracle={oracle[field]!r}, "
+                f"mold={mold[field]!r}"
+            )
+    if (
+        oracle["adapter"]["tensor_hash_encoding"]
+        != mold["adapter"]["tensor_hash_encoding"]
+    ):
+        issues.append(
+            "tensor hash encoding mismatch: "
+            f"oracle={oracle['adapter']['tensor_hash_encoding']!r}, "
+            f"mold={mold['adapter']['tensor_hash_encoding']!r}"
+        )
+    if oracle["authorization_document_sha256"] != mold["authorization_document_sha256"]:
+        issues.append("authorization document hash mismatch between producers")
+
+    layer = oracle["layer"]
+    case_id = oracle["case_id"]
+    oracle_outputs = keyed_records(oracle["outputs"], "oracle outputs")
+    mold_outputs = keyed_records(mold["outputs"], "Mold outputs")
+    missing_outputs = sorted(set(oracle_outputs) - set(mold_outputs))
+    extra_outputs = sorted(set(mold_outputs) - set(oracle_outputs))
+    if missing_outputs or extra_outputs:
+        issues.append(
+            f"layer={layer} case={case_id} output key mismatch: "
+            f"missing Mold outputs={missing_outputs}, extra Mold outputs={extra_outputs}"
+        )
+
+    policies = keyed_records(oracle["comparison"], "oracle comparison policies")
+    notes: list[str] = []
+    for key in sorted(set(oracle_outputs) & set(mold_outputs)):
+        expected = oracle_outputs[key]
+        actual = mold_outputs[key]
+        policy = policies[key]
+        context = f"layer={layer} case={case_id} output={key}"
+        if expected["shape"] != actual["shape"]:
+            issues.append(
+                f"{context} shape mismatch: oracle={expected['shape']}, "
+                f"mold={actual['shape']}"
+            )
+        if expected["dtype"] != actual["dtype"]:
+            issues.append(
+                f"{context} dtype mismatch: oracle={expected['dtype']!r}, "
+                f"mold={actual['dtype']!r}"
+            )
+        if expected["content_sha256"] != actual["content_sha256"]:
+            hash_message = (
+                f"{context} hash mismatch: oracle={expected['content_sha256']}, "
+                f"mold={actual['content_sha256']}, policy={policy['hash_policy']}"
+            )
+            if policy["hash_policy"] == "exact":
+                issues.append(hash_message)
+            else:
+                notes.append(hash_message)
+
+        for statistic in ("min", "max", "mean", "std"):
+            issue = tolerance_issue(
+                f"{context} statistic={statistic}",
+                expected["statistics"][statistic],
+                actual["statistics"][statistic],
+                policy,
+            )
+            if issue is not None:
+                issues.append(issue)
+
+        expected_samples = sample_records(expected, f"oracle output {key!r}")
+        actual_samples = sample_records(actual, f"Mold output {key!r}")
+        missing_samples = sorted(set(expected_samples) - set(actual_samples))
+        extra_samples = sorted(set(actual_samples) - set(expected_samples))
+        if missing_samples or extra_samples:
+            issues.append(
+                f"{context} sample key mismatch: missing Mold indexes="
+                f"{[list(index) for index in missing_samples]}, extra Mold indexes="
+                f"{[list(index) for index in extra_samples]}"
+            )
+        for index in sorted(set(expected_samples) & set(actual_samples)):
+            issue = tolerance_issue(
+                f"{context} sample={list(index)}",
+                expected_samples[index]["value"],
+                actual_samples[index]["value"],
+                policy,
+            )
+            if issue is not None:
+                issues.append(issue)
+
+    if issues:
+        fail("Mold-vs-oracle comparison failed:\n- " + "\n- ".join(issues))
+    return notes
+
+
 def validate_manifest() -> dict[str, Any]:
     manifest = load_json(MANIFEST_PATH)
     validate_schema(manifest, MANIFEST_SCHEMA_PATH)
@@ -322,7 +685,10 @@ def validate_manifest() -> dict[str, Any]:
         fail("unexpected conformance manifest schema version")
 
     revisions = {source["id"]: source["revision"] for source in manifest["sources"]}
-    if len(manifest["sources"]) != len(EXPECTED_REVISIONS) or revisions != EXPECTED_REVISIONS:
+    if (
+        len(manifest["sources"]) != len(EXPECTED_REVISIONS)
+        or revisions != EXPECTED_REVISIONS
+    ):
         fail("source revisions drifted from the reviewed H3 authority set")
 
     excluded = set(manifest["numerical_authority"]["excluded_accelerations"])
@@ -344,7 +710,10 @@ def validate_manifest() -> dict[str, Any]:
         fail("official component index fingerprints drifted")
 
     layers = {layer["id"] for layer in manifest["fixture_layers"]}
-    if len(manifest["fixture_layers"]) != len(EXPECTED_LAYERS) or layers != EXPECTED_LAYERS:
+    if (
+        len(manifest["fixture_layers"]) != len(EXPECTED_LAYERS)
+        or layers != EXPECTED_LAYERS
+    ):
         fail("fixture layer coverage is incomplete or contains an unreviewed layer")
 
     policy = manifest["capture_policy"]
@@ -369,6 +738,15 @@ def validate_manifest() -> dict[str, Any]:
     if synthetic["sha256"] != sha256_file(SYNTHETIC_PATH):
         fail("synthetic fixture hash drifted")
 
+    expected_oracle, expected_mold = synthetic_layer_outputs()
+    checked_oracle = load_json(SYNTHETIC_ORACLE_PATH)
+    checked_mold = load_json(SYNTHETIC_MOLD_PATH)
+    if checked_oracle != expected_oracle:
+        fail("synthetic oracle layer output does not match the deterministic generator")
+    if checked_mold != expected_mold:
+        fail("synthetic Mold layer output does not match the deterministic generator")
+    compare_layer_outputs(checked_oracle, checked_mold)
+
     tracked = []
     try:
         output = subprocess.run(
@@ -380,9 +758,13 @@ def validate_manifest() -> dict[str, Any]:
         tracked = [REPO_ROOT / path.decode() for path in output.split(b"\0") if path]
     except (OSError, subprocess.CalledProcessError):
         tracked = [path for path in FIXTURE_DIR.rglob("*") if path.is_file()]
-    forbidden = [path for path in tracked if path.suffix.lower() in FORBIDDEN_FIXTURE_SUFFIXES]
+    forbidden = [
+        path for path in tracked if path.suffix.lower() in FORBIDDEN_FIXTURE_SUFFIXES
+    ]
     if forbidden:
-        fail(f"restricted model/media artifacts are present in the fixture tree: {forbidden}")
+        fail(
+            f"restricted model/media artifacts are present in the fixture tree: {forbidden}"
+        )
     return manifest
 
 
@@ -448,9 +830,73 @@ def validate_authorization(record_path: pathlib.Path) -> dict[str, Any]:
         fail("authorization source document must not be committed to the repository")
     if sha256_file(source_document) != record["source_document_sha256"]:
         fail("authorization source document hash does not match its record")
-    if not isinstance(record["review_reference"], str) or not record["review_reference"].strip():
+    if (
+        not isinstance(record["review_reference"], str)
+        or not record["review_reference"].strip()
+    ):
         fail("authorization record lacks an external review reference")
     return record
+
+
+def resolve_comparison_path(label: str, value: str) -> pathlib.Path:
+    path = pathlib.Path(value)
+    try:
+        resolved = path.resolve(strict=True)
+    except OSError as error:
+        fail(f"cannot resolve {label}: {error}")
+    if not resolved.is_file():
+        fail(f"{label} is not a file")
+    return resolved
+
+
+def compare_output_files(
+    oracle_value: str,
+    mold_value: str,
+    fixture_root_value: str | None = None,
+    authorization_value: str | None = None,
+) -> list[str]:
+    oracle_path = resolve_comparison_path("oracle output", oracle_value)
+    mold_path = resolve_comparison_path("Mold output", mold_value)
+    checked_pair = (
+        oracle_path == SYNTHETIC_ORACLE_PATH.resolve()
+        and mold_path == SYNTHETIC_MOLD_PATH.resolve()
+    )
+
+    authorization: dict[str, Any] | None = None
+    if not checked_pair:
+        if fixture_root_value is None or authorization_value is None:
+            fail(
+                "non-checked-in comparison requires an approved external fixture root "
+                "and authorization record"
+            )
+        fixture_root = canonical_external_directory("fixture root", fixture_root_value)
+        for label, path in (("oracle output", oracle_path), ("Mold output", mold_path)):
+            try:
+                path.relative_to(fixture_root)
+            except ValueError:
+                fail(f"{label} must be inside the approved external fixture root")
+        authorization = validate_authorization(pathlib.Path(authorization_value))
+    elif fixture_root_value is not None or authorization_value is not None:
+        if fixture_root_value is None or authorization_value is None:
+            fail("--fixture-root and --authorization-record must be supplied together")
+        fail(
+            "checked-in synthetic comparison does not accept real authorization evidence"
+        )
+
+    oracle = load_json(oracle_path)
+    mold = load_json(mold_path)
+    validate_layer_output(oracle, "oracle")
+    validate_layer_output(mold, "Mold")
+    if authorization is not None:
+        authorization_hash = authorization["source_document_sha256"]
+        for label, document in (("oracle", oracle), ("Mold", mold)):
+            recorded = document["authorization_document_sha256"]
+            if (
+                document["authority_tier"] != "synthetic"
+                and recorded != authorization_hash
+            ):
+                fail(f"{label} output is not bound to the authorization evidence")
+    return compare_layer_outputs(oracle, mold)
 
 
 def parse_sources(values: list[str]) -> dict[str, pathlib.Path]:
@@ -494,7 +940,10 @@ def verify_source_checkouts(manifest: dict[str, Any], values: list[str]) -> None
 
 
 def validate_bundle(
-    manifest: dict[str, Any], fixture_root_value: str, bundle_value: str, authorization_value: str
+    manifest: dict[str, Any],
+    fixture_root_value: str,
+    bundle_value: str,
+    authorization_value: str,
 ) -> None:
     fixture_root = canonical_external_directory("fixture root", fixture_root_value)
     authorization_path = pathlib.Path(authorization_value)
@@ -510,12 +959,17 @@ def validate_bundle(
         fail("external fixture bundle schema is unsupported")
     if bundle["manifest_sha256"] != sha256_file(MANIFEST_PATH):
         fail("external fixture bundle targets a different conformance manifest")
-    if bundle["authorization_document_sha256"] != authorization["source_document_sha256"]:
+    if (
+        bundle["authorization_document_sha256"]
+        != authorization["source_document_sha256"]
+    ):
         fail("external fixture bundle is not bound to the authorization evidence")
     fixture_layers = {fixture["layer"] for fixture in bundle["fixtures"]}
     unknown_layers = fixture_layers - EXPECTED_LAYERS
     if unknown_layers:
-        fail(f"external fixture bundle contains unknown layers: {sorted(unknown_layers)}")
+        fail(
+            f"external fixture bundle contains unknown layers: {sorted(unknown_layers)}"
+        )
     if not bundle["fixtures"]:
         fail("external fixture bundle contains no evidence")
     for fixture in bundle["fixtures"]:
@@ -524,7 +978,10 @@ def validate_bundle(
             evidence_path.relative_to(fixture_root)
         except ValueError:
             fail(f"fixture evidence escapes its external root: {fixture['id']}")
-        if not evidence_path.is_file() or sha256_file(evidence_path) != fixture["sha256"]:
+        if (
+            not evidence_path.is_file()
+            or sha256_file(evidence_path) != fixture["sha256"]
+        ):
             fail(f"fixture evidence hash mismatch: {fixture['id']}")
 
 
@@ -536,9 +993,13 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         )
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
-    subparsers.add_parser("check-contract", help="validate checked-in pins and synthetic fixtures")
+    subparsers.add_parser(
+        "check-contract", help="validate checked-in pins and synthetic fixtures"
+    )
 
-    verify = subparsers.add_parser("verify-sources", help="verify every pinned local source checkout")
+    verify = subparsers.add_parser(
+        "verify-sources", help="verify every pinned local source checkout"
+    )
     verify.add_argument(
         "--source",
         action="append",
@@ -554,7 +1015,28 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     bundle.add_argument("--bundle", required=True)
     bundle.add_argument("--authorization-record", required=True)
 
-    subparsers.add_parser("print-synthetic", help="print the deterministic synthetic fixture")
+    compare = subparsers.add_parser(
+        "compare", help="compare one Mold per-layer output with its oracle"
+    )
+    compare.add_argument("--oracle", required=True, help="oracle layer-output JSON")
+    compare.add_argument("--mold", required=True, help="Mold layer-output JSON")
+    compare.add_argument(
+        "--fixture-root",
+        help="approved external root; required except for the checked synthetic pair",
+    )
+    compare.add_argument(
+        "--authorization-record",
+        help="external authorization record; required with --fixture-root",
+    )
+
+    subparsers.add_parser(
+        "print-synthetic", help="print the deterministic synthetic fixture"
+    )
+    synthetic_output = subparsers.add_parser(
+        "print-synthetic-output",
+        help="print one deterministic synthetic producer/adaptor document",
+    )
+    synthetic_output.add_argument("--role", choices=("oracle", "mold"), required=True)
     return parser.parse_args(argv)
 
 
@@ -563,6 +1045,12 @@ def main(argv: list[str]) -> int:
         args = parse_args(argv)
         if args.command == "print-synthetic":
             sys.stdout.buffer.write(canonical_bytes(synthetic_fixture()))
+            return 0
+        if args.command == "print-synthetic-output":
+            oracle, mold = synthetic_layer_outputs()
+            sys.stdout.buffer.write(
+                canonical_bytes(oracle if args.role == "oracle" else mold)
+            )
             return 0
         manifest = validate_manifest()
         if args.command == "verify-sources":
@@ -574,6 +1062,15 @@ def main(argv: list[str]) -> int:
                 args.bundle,
                 args.authorization_record,
             )
+        elif args.command == "compare":
+            notes = compare_output_files(
+                args.oracle,
+                args.mold,
+                args.fixture_root,
+                args.authorization_record,
+            )
+            for note in notes:
+                print(f"MiniMax H3 conformance note: {note}")
         print(f"MiniMax H3 conformance {args.command} passed")
         return 0
     except (ConformanceFailure, OSError) as error:

--- a/scripts/tests/minimax-h3-conformance-contract.py
+++ b/scripts/tests/minimax-h3-conformance-contract.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import copy
 import hashlib
 import importlib.util
 import json
@@ -69,9 +70,107 @@ def test_synthetic_drift(tool, temporary: pathlib.Path) -> None:
         tool.SYNTHETIC_PATH = original_path
 
 
-def valid_authorization(tool, temporary: pathlib.Path) -> tuple[pathlib.Path, dict[str, object]]:
+def checked_comparison_pair(tool) -> tuple[dict[str, object], dict[str, object]]:
+    return (
+        json.loads(tool.SYNTHETIC_ORACLE_PATH.read_text(encoding="utf-8")),
+        json.loads(tool.SYNTHETIC_MOLD_PATH.read_text(encoding="utf-8")),
+    )
+
+
+def output_with_key(document: dict[str, object], key: str) -> dict[str, object]:
+    outputs = document["outputs"]
+    assert isinstance(outputs, list)
+    return next(output for output in outputs if output["key"] == key)
+
+
+def test_comparison_diagnostics(tool) -> None:
+    oracle, mold = checked_comparison_pair(tool)
+    notes = tool.compare_layer_outputs(oracle, mold)
+    assert len(notes) == 1
+    assert "hash mismatch" in notes[0]
+    assert "policy=record-only" in notes[0]
+
+    shape_mold = copy.deepcopy(mold)
+    output_with_key(shape_mold, "audio_next")["shape"] = [5]
+    expect_failure(
+        lambda: tool.compare_layer_outputs(oracle, shape_mold),
+        "shape mismatch: oracle=[4], mold=[5]",
+    )
+
+    dtype_mold = copy.deepcopy(mold)
+    output_with_key(dtype_mold, "audio_next")["dtype"] = "float16"
+    expect_failure(
+        lambda: tool.compare_layer_outputs(oracle, dtype_mold),
+        "dtype mismatch: oracle='float32', mold='float16'",
+    )
+
+    keys_mold = copy.deepcopy(mold)
+    renamed = output_with_key(keys_mold, "audio_next")
+    renamed["key"] = "unexpected_output"
+    expect_failure(
+        lambda: tool.compare_layer_outputs(oracle, keys_mold),
+        "missing Mold outputs=['audio_next'], extra Mold outputs=['unexpected_output']",
+    )
+
+    samples_mold = copy.deepcopy(mold)
+    sampled_output = output_with_key(samples_mold, "audio_next")
+    sampled_output["shape"] = [5]
+    sampled_output["samples"][0]["index"] = [4]
+    expect_failure(
+        lambda: tool.compare_layer_outputs(oracle, samples_mold),
+        "sample key mismatch: missing Mold indexes=[[0]], extra Mold indexes=[[4]]",
+    )
+
+    hash_mold = copy.deepcopy(mold)
+    output_with_key(hash_mold, "video_next")["content_sha256"] = "f" * 64
+    expect_failure(
+        lambda: tool.compare_layer_outputs(oracle, hash_mold),
+        "hash mismatch: oracle=cfff2f665b33397e84a33853fc786e9597ebead599161a3e00d7d2a6761fbf9e",
+    )
+
+    tolerance_mold = copy.deepcopy(mold)
+    output_with_key(tolerance_mold, "audio_next")["samples"][0]["value"] = 0.25
+    expect_failure(
+        lambda: tool.compare_layer_outputs(oracle, tolerance_mold),
+        "sample=[0] tolerance exceeded",
+    )
+
+    nan_mold = copy.deepcopy(mold)
+    output_with_key(nan_mold, "audio_next")["statistics"]["mean"] = float("nan")
+    expect_failure(
+        lambda: tool.compare_layer_outputs(oracle, nan_mold),
+        "is NaN",
+    )
+
+    infinity_mold = copy.deepcopy(mold)
+    output_with_key(infinity_mold, "audio_next")["samples"][0]["value"] = float("inf")
+    expect_failure(
+        lambda: tool.compare_layer_outputs(oracle, infinity_mold),
+        "is Inf",
+    )
+
+    missing_field = copy.deepcopy(mold)
+    del missing_field["producer"]["revision"]
+    expect_failure(
+        lambda: tool.compare_layer_outputs(oracle, missing_field),
+        "missing required keys ['revision']",
+    )
+
+    drifted_oracle = copy.deepcopy(oracle)
+    drifted_oracle["producer"]["revision"] = "0" * 40
+    expect_failure(
+        lambda: tool.compare_layer_outputs(drifted_oracle, mold),
+        "oracle source revision is not pinned",
+    )
+
+
+def valid_authorization(
+    tool, temporary: pathlib.Path
+) -> tuple[pathlib.Path, dict[str, object]]:
     source_document = temporary / "minimax-authorization.txt"
-    source_document.write_text("synthetic external authorization evidence\n", encoding="utf-8")
+    source_document.write_text(
+        "synthetic external authorization evidence\n", encoding="utf-8"
+    )
     record = {
         "schema_version": tool.AUTHORIZATION_SCHEMA_VERSION,
         "family": "minimax-h3",
@@ -109,7 +208,9 @@ def test_authorization_and_external_root(tool, temporary: pathlib.Path) -> None:
         "does not cover every conformance activity",
     )
 
-    pathlib.Path(record["source_document_path"]).write_text("mutated\n", encoding="utf-8")
+    pathlib.Path(record["source_document_path"]).write_text(
+        "mutated\n", encoding="utf-8"
+    )
     expect_failure(
         lambda: tool.validate_authorization(record_path),
         "hash does not match",
@@ -167,9 +268,73 @@ def test_external_bundle_hashes(tool, temporary: pathlib.Path) -> None:
 
     evidence.write_text("mutated\n", encoding="utf-8")
     expect_failure(
-        lambda: tool.validate_bundle(manifest, str(root), str(bundle_path), str(record_path)),
+        lambda: tool.validate_bundle(
+            manifest, str(root), str(bundle_path), str(record_path)
+        ),
         "fixture evidence hash mismatch",
     )
+
+
+def test_comparison_authorization_boundary(tool, temporary: pathlib.Path) -> None:
+    root = temporary / "comparison-fixtures"
+    root.mkdir()
+    oracle, mold = checked_comparison_pair(tool)
+    oracle_path = root / "oracle.json"
+    mold_path = root / "mold.json"
+    write_json(oracle_path, oracle)
+    write_json(mold_path, mold)
+
+    expect_failure(
+        lambda: tool.compare_output_files(str(oracle_path), str(mold_path)),
+        "requires an approved external fixture root and authorization record",
+    )
+    authorization_path, _ = valid_authorization(tool, temporary)
+    notes = tool.compare_output_files(
+        str(oracle_path),
+        str(mold_path),
+        str(root),
+        str(authorization_path),
+    )
+    assert len(notes) == 1
+
+    expect_failure(
+        lambda: tool.compare_output_files(
+            str(tool.SYNTHETIC_ORACLE_PATH),
+            str(tool.SYNTHETIC_MOLD_PATH),
+            str(root),
+        ),
+        "must be supplied together",
+    )
+
+    authorization = tool.validate_authorization(authorization_path)
+    unauthorized_oracle = copy.deepcopy(oracle)
+    unauthorized_mold = copy.deepcopy(mold)
+    for document in (unauthorized_oracle, unauthorized_mold):
+        document["authority_tier"] = "exact-full-bf16"
+        document["authorization_document_sha256"] = "0" * 64
+    write_json(oracle_path, unauthorized_oracle)
+    write_json(mold_path, unauthorized_mold)
+    expect_failure(
+        lambda: tool.compare_output_files(
+            str(oracle_path),
+            str(mold_path),
+            str(root),
+            str(authorization_path),
+        ),
+        "oracle output is not bound to the authorization evidence",
+    )
+    assert authorization["source_document_sha256"] != "0" * 64
+
+
+def test_ci_routing() -> None:
+    workflow = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text(
+        encoding="utf-8"
+    )
+    assert "'scripts/minimax-h3-conformance.py'" in workflow
+    assert "'scripts/tests/minimax-h3-conformance-contract.py'" in workflow
+    assert "'tests/fixtures/minimax_h3/**'" in workflow
+    assert "'docs/qualification/minimax-h3-*.json'" in workflow
+    assert "python3 scripts/tests/minimax-h3-conformance-contract.py" in workflow
 
 
 def main() -> int:
@@ -182,11 +347,31 @@ def main() -> int:
         capture_output=True,
     ).stdout
     assert json.loads(printed) == json.loads(tool.SYNTHETIC_PATH.read_bytes())
+    compared = subprocess.run(
+        [
+            sys.executable,
+            str(TOOL_PATH),
+            "compare",
+            "--oracle",
+            str(tool.SYNTHETIC_ORACLE_PATH),
+            "--mold",
+            str(tool.SYNTHETIC_MOLD_PATH),
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    assert "policy=record-only" in compared
+    assert "MiniMax H3 conformance compare passed" in compared
+    test_ci_routing()
 
     with tempfile.TemporaryDirectory(prefix="mold-h3-contract-") as value:
         temporary = pathlib.Path(value).resolve()
         test_manifest_drift(tool, temporary)
         test_synthetic_drift(tool, temporary)
+        test_comparison_diagnostics(tool)
+        test_comparison_authorization_boundary(tool, temporary)
         test_authorization_and_external_root(tool, temporary)
         test_external_bundle_hashes(tool, temporary)
 

--- a/tests/fixtures/minimax_h3/synthetic-mold-v1.json
+++ b/tests/fixtures/minimax_h3/synthetic-mold-v1.json
@@ -1,0 +1,69 @@
+{
+  "schema_version": "mold.minimax-h3.layer-output.v1",
+  "family": "minimax-h3",
+  "case_id": "synthetic-coupled-update-v1",
+  "layer": "dual-sampler",
+  "authority_tier": "synthetic",
+  "authorization_document_sha256": null,
+  "input": {
+    "id": "synthetic-v1",
+    "sha256": "bddf9a6b821015094aedba95dd58a7634a783c9338dd6d488e66bd8d5fcd182a",
+    "component_index_sha256": "a2b6a210e482ffb78e613b553f570c44e101afce6741bd4ed91429d0559af031"
+  },
+  "producer": {
+    "role": "mold",
+    "implementation": "mold-synthetic-adapter",
+    "source_id": "mold",
+    "revision": "ea3d1d86fbd09eb6d47848649168c70392db9c63"
+  },
+  "adapter": {
+    "schema_version": "mold.minimax-h3.layer-adapter.v1",
+    "id": "mold-synthetic-adapter-synthetic-dual-sampler-v1",
+    "command": "python3 scripts/minimax-h3-conformance.py print-synthetic-output --role mold",
+    "tensor_hash_encoding": "canonical-json-numeric-v1"
+  },
+  "environment": {
+    "device": "cpu-synthetic",
+    "dtype": "float32",
+    "attention_backend": "scalar-python",
+    "forbidden_accelerations_disabled": true
+  },
+  "outputs": [
+    {
+      "key": "video_next",
+      "shape": [4],
+      "dtype": "float32",
+      "content_sha256": "cfff2f665b33397e84a33853fc786e9597ebead599161a3e00d7d2a6761fbf9e",
+      "statistics": {
+        "min": -2.0,
+        "max": 1.0,
+        "mean": -0.3125,
+        "std": 1.109264959331178
+      },
+      "samples": [
+        { "index": [0], "value": 0.25 },
+        { "index": [1], "value": -0.5 },
+        { "index": [2], "value": 1.0 },
+        { "index": [3], "value": -2.0 }
+      ]
+    },
+    {
+      "key": "audio_next",
+      "shape": [4],
+      "dtype": "float32",
+      "content_sha256": "e091f212d9dd00366d753c47505ad04485c98c29e961168366f29eff25a13d6e",
+      "statistics": {
+        "min": -0.9999989867210388,
+        "max": 0.5000010132789612,
+        "mean": -0.15624899417161942,
+        "std": 0.5546324784062111
+      },
+      "samples": [
+        { "index": [0], "value": 0.1250009983778 },
+        { "index": [1], "value": -0.2499990016222 },
+        { "index": [2], "value": 0.5000010132789612 },
+        { "index": [3], "value": -0.9999989867210388 }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/minimax_h3/synthetic-oracle-v1.json
+++ b/tests/fixtures/minimax_h3/synthetic-oracle-v1.json
@@ -1,0 +1,85 @@
+{
+  "schema_version": "mold.minimax-h3.layer-output.v1",
+  "family": "minimax-h3",
+  "case_id": "synthetic-coupled-update-v1",
+  "layer": "dual-sampler",
+  "authority_tier": "synthetic",
+  "authorization_document_sha256": null,
+  "input": {
+    "id": "synthetic-v1",
+    "sha256": "bddf9a6b821015094aedba95dd58a7634a783c9338dd6d488e66bd8d5fcd182a",
+    "component_index_sha256": "a2b6a210e482ffb78e613b553f570c44e101afce6741bd4ed91429d0559af031"
+  },
+  "producer": {
+    "role": "oracle",
+    "implementation": "diffusers",
+    "source_id": "diffusers",
+    "revision": "9c6a68c32b3b2a64db91800b624d33cec6e25ab8"
+  },
+  "adapter": {
+    "schema_version": "mold.minimax-h3.layer-adapter.v1",
+    "id": "diffusers-synthetic-dual-sampler-v1",
+    "command": "python3 scripts/minimax-h3-conformance.py print-synthetic-output --role oracle",
+    "tensor_hash_encoding": "canonical-json-numeric-v1"
+  },
+  "environment": {
+    "device": "cpu-synthetic",
+    "dtype": "float32",
+    "attention_backend": "scalar-python",
+    "forbidden_accelerations_disabled": true
+  },
+  "outputs": [
+    {
+      "key": "video_next",
+      "shape": [4],
+      "dtype": "float32",
+      "content_sha256": "cfff2f665b33397e84a33853fc786e9597ebead599161a3e00d7d2a6761fbf9e",
+      "statistics": {
+        "min": -2.0,
+        "max": 1.0,
+        "mean": -0.3125,
+        "std": 1.109264959331178
+      },
+      "samples": [
+        { "index": [0], "value": 0.25 },
+        { "index": [1], "value": -0.5 },
+        { "index": [2], "value": 1.0 },
+        { "index": [3], "value": -2.0 }
+      ]
+    },
+    {
+      "key": "audio_next",
+      "shape": [4],
+      "dtype": "float32",
+      "content_sha256": "75880588de85c782b29eb21d3b780110fcf5f0e0ab364a4174cdedd77722b024",
+      "statistics": {
+        "min": -1.0,
+        "max": 0.5,
+        "mean": -0.15625,
+        "std": 0.554632479665589
+      },
+      "samples": [
+        { "index": [0], "value": 0.125 },
+        { "index": [1], "value": -0.25 },
+        { "index": [2], "value": 0.5 },
+        { "index": [3], "value": -1.0 }
+      ]
+    }
+  ],
+  "comparison": [
+    {
+      "key": "video_next",
+      "absolute": 0.0,
+      "relative": 0.0,
+      "metric": "elementwise-atol-plus-rtol",
+      "hash_policy": "exact"
+    },
+    {
+      "key": "audio_next",
+      "absolute": 0.000002,
+      "relative": 0.000001,
+      "metric": "elementwise-atol-plus-rtol",
+      "hash_policy": "record-only"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- add a strict per-layer producer/adapter schema for H3 conformance records
- compare Mold and oracle tensors with exact shape, dtype, key, hash, finite-value, absolute-tolerance, and relative-tolerance diagnostics
- enforce authorization and approved external fixture roots for every non-synthetic comparison while retaining one exact checked synthetic pair
- add deterministic fixture generation, mutation coverage, documentation, and CI-routing assertions

## Safety boundary

This PR uses only checked synthetic records and pinned source metadata. It does not access MiniMax H3 model payloads, safetensors headers, generated outputs, or restricted artifacts. Real checkpoint goldens remain blocked by the MiniMax authorization issue and must bind their source-document hash to an approved authorization record.

## Verification

- H3 conformance contract test
- checked synthetic Mold-vs-oracle comparison
- Ruff validation
- JSON schema and fixture parsing
- CI path-routing contract
- git diff whitespace audit

Refs #832 and #831.