### PR TITLE
feat(h3): bind admission to frozen factory authority

### DIFF
--- a/crates/mold-inference/src/factory.rs
+++ b/crates/mold-inference/src/factory.rs
@@ -72,6 +72,9 @@ pub struct FrozenEngineConfig {
     pub selected_qwen3_paths: Vec<PathBuf>,
     pub selected_qwen2_path: Option<PathBuf>,
     pub selected_gemma_paths: Vec<PathBuf>,
+    /// Exact contract-only MiniMax H3 admission/factory authority. This is
+    /// `None` for every runnable family and cannot activate H3 by itself.
+    pub h3_factory_authority: Option<crate::FrozenH3FactoryAuthority>,
     pub runtime_environment: crate::runtime_env::FrozenRuntimeEnvironment,
     pub attention_backend: crate::attention::AttentionBackend,
     pub attention_chunk: crate::attention::AttentionChunkPolicy,
@@ -114,6 +117,7 @@ impl FrozenEngineConfig {
             selected_qwen3_paths: Vec::new(),
             selected_qwen2_path: None,
             selected_gemma_paths: Vec::new(),
+            h3_factory_authority: None,
             runtime_environment,
             attention_backend: crate::attention::AttentionBackend::resolve(),
             attention_chunk: crate::attention::resolved_chunk_policy(),
@@ -384,7 +388,55 @@ pub fn create_engine_with_frozen_config(
     offload: bool,
     shared_pool: Option<Arc<Mutex<SharedPool>>>,
 ) -> Result<Box<dyn InferenceEngine>> {
+    create_engine_with_frozen_config_and_h3_factory(
+        model_name,
+        paths,
+        frozen,
+        load_strategy,
+        gpu_ordinal,
+        offload,
+        shared_pool,
+        |_| {
+            bail!(
+                "MiniMax H3 typed factory authority is present but no runnable loader is registered"
+            )
+        },
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn create_engine_with_frozen_config_and_h3_factory<F>(
+    model_name: String,
+    paths: ModelPaths,
+    frozen: &FrozenEngineConfig,
+    load_strategy: LoadStrategy,
+    gpu_ordinal: usize,
+    offload: bool,
+    shared_pool: Option<Arc<Mutex<SharedPool>>>,
+    h3_factory: F,
+) -> Result<Box<dyn InferenceEngine>>
+where
+    F: FnOnce(&crate::FrozenH3FactoryAuthority) -> Result<Box<dyn InferenceEngine>>,
+{
+    // The compliance gate is intentionally the first operation. No path,
+    // runtime, device, authority, or future loader inspection may precede it.
     mold_core::require_model_activation(&model_name, Some(&frozen.family))?;
+    if mold_core::minimax_h3::is_family(&frozen.family) {
+        let authority = frozen.h3_factory_authority.as_ref().ok_or_else(|| {
+            anyhow::anyhow!("MiniMax H3 factory dispatch requires an exact frozen server authority")
+        })?;
+        // The static runtime/registry gate deliberately precedes even path
+        // classification and local-existence checks. Legal authorization alone
+        // can therefore never make a contract-only build touch H3 artifacts.
+        authority.validate_for_dispatch(
+            &model_name,
+            &frozen.family,
+            gpu_ordinal,
+            offload,
+            frozen.attention_backend,
+            frozen.attention_chunk,
+        )?;
+    }
     for path in paths.all_file_paths() {
         mold_core::require_model_artifact_activation(
             path,
@@ -659,9 +711,22 @@ pub fn create_engine_with_frozen_config(
             gpu_ordinal,
             shared_pool,
         ))),
-        family if mold_core::minimax_h3::is_family(family) => bail!(
-            "MiniMax H3 has a static contract but no runnable inference engine in this build"
-        ),
+        family if mold_core::minimax_h3::is_family(family) => {
+            let authority = frozen.h3_factory_authority.as_ref().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "MiniMax H3 factory dispatch requires an exact frozen server authority"
+                )
+            })?;
+            authority.validate_for_dispatch(
+                &model_name,
+                family,
+                gpu_ordinal,
+                offload,
+                frozen.attention_backend,
+                frozen.attention_chunk,
+            )?;
+            h3_factory(authority)
+        }
         "wuerstchen" | "wuerstchen-v2" => Ok(boxed_inference_engine(WuerstchenEngine::new(
             model_name,
             paths,
@@ -684,6 +749,58 @@ pub fn create_engine_with_frozen_config(
 mod tests {
     use super::*;
     use std::path::PathBuf;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    fn sha(byte: char) -> String {
+        std::iter::repeat_n(byte, 64).collect()
+    }
+
+    fn h3_factory_authority(frozen: &FrozenEngineConfig) -> crate::FrozenH3FactoryAuthority {
+        crate::FrozenH3FactoryAuthority::new_contract_only(crate::H3FactoryAuthorityInput {
+            model: mold_core::minimax_h3::FL2VA_COMFY.into(),
+            device_id: "gpu-0".into(),
+            device_ordinal: 0,
+            compute_capability: (8, 9),
+            execution_fingerprint: sha('a'),
+            conditioner_placement: crate::H3FactoryConditionerPlacement::HostCpuThenDrop,
+            qwen_parameter_bytes: 2048,
+            qwen_activation_workspace_bytes: 1024,
+            resident_block_count: 8,
+            prefetch_depth: 1,
+            attention_backend: frozen.attention_backend,
+            attention_chunk: frozen.attention_chunk,
+            attention_kernel_identity: "synthetic-lossless-packed-attention-v1".into(),
+            attention_qualification_sha256: sha('b'),
+            attention_full_noncausal: true,
+            attention_lossless: true,
+            attention_head_count: 56,
+            attention_head_dim: 128,
+            block_offload: true,
+            quantization: crate::H3FactoryQuantizationAuthority::ComfyPrunedInt8ConvrotNvfp4Awq {
+                transformer_policy_sha256: sha('c'),
+                qwen_policy_sha256: sha('d'),
+                pruned_adaln_table_sha256: sha('e'),
+            },
+            components: [
+                crate::H3FactoryComponentRole::Conditioner,
+                crate::H3FactoryComponentRole::Transformer,
+                crate::H3FactoryComponentRole::VisualVae,
+                crate::H3FactoryComponentRole::AudioVae,
+            ]
+            .into_iter()
+            .enumerate()
+            .map(|(index, role)| {
+                crate::H3FactoryComponentAuthority::new(
+                    role,
+                    sha(char::from(b'1' + index as u8)),
+                    sha(char::from(b'5' + index as u8)),
+                )
+                .unwrap()
+            })
+            .collect(),
+        })
+        .unwrap()
+    }
 
     fn dummy_paths() -> ModelPaths {
         ModelPaths {
@@ -780,6 +897,37 @@ mod tests {
         assert!(error
             .to_string()
             .contains(mold_core::MINIMAX_H3_AUTHORIZATION_REQUIRED));
+    }
+
+    #[test]
+    fn frozen_factory_never_calls_h3_loader_before_the_legal_gate() {
+        let mut frozen =
+            FrozenEngineConfig::resolve(mold_core::minimax_h3::FL2VA_COMFY, &Config::default());
+        frozen.family = mold_core::minimax_h3::FAMILY.to_string();
+        frozen.h3_factory_authority = Some(h3_factory_authority(&frozen));
+        let called = Arc::new(AtomicBool::new(false));
+        let loader_called = Arc::clone(&called);
+
+        let error = create_engine_with_frozen_config_and_h3_factory(
+            mold_core::minimax_h3::FL2VA_COMFY.into(),
+            dummy_paths(),
+            &frozen,
+            LoadStrategy::Sequential,
+            0,
+            true,
+            None,
+            move |_| {
+                loader_called.store(true, Ordering::SeqCst);
+                unreachable!("the MiniMax H3 legal gate must precede the loader")
+            },
+        )
+        .err()
+        .expect("compliance-gated H3 must fail closed");
+
+        assert!(error
+            .to_string()
+            .contains(mold_core::MINIMAX_H3_AUTHORIZATION_REQUIRED));
+        assert!(!called.load(Ordering::SeqCst));
     }
 
     #[test]

--- a/crates/mold-inference/src/h3_factory.rs
+++ b/crates/mold-inference/src/h3_factory.rs
@@ -1,0 +1,608 @@
+//! Contract-only MiniMax H3 factory authority.
+//!
+//! This module is the typed seam between server admission and the private H3
+//! Candle backend. It carries only digests and immutable scheduling facts; it
+//! never receives artifact paths or bytes. Construction deliberately creates
+//! the backend's unavailable plan, so neither a qualified admission record nor
+//! this public type can activate the family by itself.
+
+use anyhow::{anyhow, bail, Result};
+use mold_core::minimax_h3::{self as contract, Layout, Task};
+use sha2::{Digest, Sha256};
+
+use crate::attention::{AttentionBackend, AttentionChunkPolicy};
+use crate::minimax_h3::backend::{
+    FrozenH3Fl2VaCandlePlan, H3CandleBackendDevice, H3ComponentRole, H3ValidatedComponentAuthority,
+    H3ValidatedComponentSet,
+};
+use crate::minimax_h3::offload::FrozenH3BlockStreamingPlan;
+use crate::minimax_h3::{FrozenH3ConditionerPlacement, H3ConditionerExecution};
+
+const H3_FACTORY_AUTHORITY_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub enum H3FactoryComponentRole {
+    Conditioner,
+    Transformer,
+    VisualVae,
+    AudioVae,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct H3FactoryComponentAuthority {
+    role: H3FactoryComponentRole,
+    content_sha256: String,
+    validation_sha256: String,
+}
+
+impl H3FactoryComponentAuthority {
+    pub fn new(
+        role: H3FactoryComponentRole,
+        content_sha256: impl Into<String>,
+        validation_sha256: impl Into<String>,
+    ) -> Result<Self> {
+        let authority = Self {
+            role,
+            content_sha256: content_sha256.into(),
+            validation_sha256: validation_sha256.into(),
+        };
+        authority.validate()?;
+        Ok(authority)
+    }
+
+    fn validate(&self) -> Result<()> {
+        require_sha256(&self.content_sha256, "H3 component content")?;
+        require_sha256(&self.validation_sha256, "H3 component validation")
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum H3FactoryConditionerPlacement {
+    AssignedCudaThenDrop,
+    HostCpuThenDrop,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum H3FactoryQuantizationAuthority {
+    OfficialBf16,
+    ComfyPrunedInt8ConvrotNvfp4Awq {
+        transformer_policy_sha256: String,
+        qwen_policy_sha256: String,
+        pruned_adaln_table_sha256: String,
+    },
+}
+
+impl H3FactoryQuantizationAuthority {
+    fn validate(&self, layout: Layout) -> Result<()> {
+        match (self, layout) {
+            (Self::OfficialBf16, Layout::OfficialBf16) => Ok(()),
+            (
+                Self::ComfyPrunedInt8ConvrotNvfp4Awq {
+                    transformer_policy_sha256,
+                    qwen_policy_sha256,
+                    pruned_adaln_table_sha256,
+                },
+                Layout::ComfyPrunedInt8ConvrotNvfp4Awq,
+            ) => {
+                require_sha256(transformer_policy_sha256, "H3 transformer quantization")?;
+                require_sha256(qwen_policy_sha256, "H3 Qwen quantization")?;
+                require_sha256(pruned_adaln_table_sha256, "H3 pruned AdaLN table")
+            }
+            _ => bail!("MiniMax H3 layout and quantization authorities disagree"),
+        }
+    }
+
+    fn update_identity(&self, hash: &mut Sha256) {
+        match self {
+            Self::OfficialBf16 => hash.update(b"official-bf16"),
+            Self::ComfyPrunedInt8ConvrotNvfp4Awq {
+                transformer_policy_sha256,
+                qwen_policy_sha256,
+                pruned_adaln_table_sha256,
+            } => {
+                hash.update(b"comfy-pruned-int8-convrot-nvfp4-awq\0");
+                hash.update(transformer_policy_sha256.as_bytes());
+                hash.update([0]);
+                hash.update(qwen_policy_sha256.as_bytes());
+                hash.update([0]);
+                hash.update(pruned_adaln_table_sha256.as_bytes());
+            }
+        }
+    }
+}
+
+/// Server-owned inputs that may cross into the H3 factory boundary.
+///
+/// The constructor validates and fingerprints every field before retaining
+/// it. In particular, component authorities are digests only; paths and model
+/// bytes remain on the compliance-gated side of the boundary.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct H3FactoryAuthorityInput {
+    pub model: String,
+    pub device_id: String,
+    pub device_ordinal: usize,
+    pub compute_capability: (u16, u16),
+    pub execution_fingerprint: String,
+    pub conditioner_placement: H3FactoryConditionerPlacement,
+    pub qwen_parameter_bytes: u64,
+    pub qwen_activation_workspace_bytes: u64,
+    pub resident_block_count: u32,
+    pub prefetch_depth: u32,
+    pub attention_backend: AttentionBackend,
+    pub attention_chunk: AttentionChunkPolicy,
+    pub attention_kernel_identity: String,
+    pub attention_qualification_sha256: String,
+    pub attention_full_noncausal: bool,
+    pub attention_lossless: bool,
+    pub attention_head_count: u32,
+    pub attention_head_dim: u32,
+    pub block_offload: bool,
+    pub quantization: H3FactoryQuantizationAuthority,
+    pub components: Vec<H3FactoryComponentAuthority>,
+}
+
+/// Immutable, contract-only authority carried by [`crate::FrozenEngineConfig`].
+///
+/// Its private backend plan always lacks executable attention/quantization
+/// authorities. `validate_for_dispatch` also requires both the public capability
+/// contract and production family registry before a future loader can be reached.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FrozenH3FactoryAuthority {
+    schema_version: u32,
+    backend_plan: FrozenH3Fl2VaCandlePlan,
+    device_ordinal: usize,
+    conditioner_placement: H3FactoryConditionerPlacement,
+    qwen_parameter_bytes: u64,
+    qwen_activation_workspace_bytes: u64,
+    attention_backend: AttentionBackend,
+    attention_chunk: AttentionChunkPolicy,
+    attention_kernel_identity: String,
+    attention_qualification_sha256: String,
+    attention_full_noncausal: bool,
+    attention_lossless: bool,
+    attention_head_count: u32,
+    attention_head_dim: u32,
+    block_offload: bool,
+    quantization: H3FactoryQuantizationAuthority,
+    identity_sha256: String,
+}
+
+impl FrozenH3FactoryAuthority {
+    pub fn new_contract_only(input: H3FactoryAuthorityInput) -> Result<Self> {
+        let model_contract = contract::capability_contract_for_model(&input.model)
+            .ok_or_else(|| anyhow!("{:?} has no MiniMax H3 capability contract", input.model))?;
+        if model_contract.task != Task::Fl2va {
+            bail!("the current MiniMax H3 Candle factory authority is FL2VA-only");
+        }
+        if model_contract.generation.runtime_available {
+            bail!(
+                "contract-only MiniMax H3 factory authority cannot be created for a runnable contract"
+            );
+        }
+        if input.device_id.trim().is_empty() || input.compute_capability.0 == 0 {
+            bail!("MiniMax H3 factory authority requires one concrete CUDA route");
+        }
+        require_sha256(&input.execution_fingerprint, "H3 scheduler execution")?;
+        if input.qwen_parameter_bytes == 0 || input.qwen_activation_workspace_bytes == 0 {
+            bail!("MiniMax H3 factory authority requires exact nonzero Qwen memory facts");
+        }
+        if input.attention_kernel_identity.trim().is_empty()
+            || !input.attention_full_noncausal
+            || !input.attention_lossless
+            || input.attention_head_count != 56
+            || input.attention_head_dim != 128
+        {
+            bail!("MiniMax H3 factory authority requires qualified lossless 56x128 full attention");
+        }
+        require_sha256(
+            &input.attention_qualification_sha256,
+            "H3 attention qualification",
+        )?;
+        if !input.block_offload {
+            bail!("MiniMax H3 factory authority requires admitted block streaming");
+        }
+        input.quantization.validate(model_contract.layout)?;
+
+        let components = H3ValidatedComponentSet::new(
+            input
+                .components
+                .into_iter()
+                .map(|component| {
+                    component.validate()?;
+                    let role = match component.role {
+                        H3FactoryComponentRole::Conditioner => H3ComponentRole::Conditioner,
+                        H3FactoryComponentRole::Transformer => H3ComponentRole::Transformer,
+                        H3FactoryComponentRole::VisualVae => H3ComponentRole::VisualVae,
+                        H3FactoryComponentRole::AudioVae => H3ComponentRole::AudioVae,
+                    };
+                    H3ValidatedComponentAuthority::new(
+                        role,
+                        component.content_sha256,
+                        component.validation_sha256,
+                    )
+                })
+                .collect::<Result<Vec<_>>>()?,
+        )?;
+        let conditioner_execution = match input.conditioner_placement {
+            H3FactoryConditionerPlacement::AssignedCudaThenDrop => {
+                H3ConditionerExecution::CudaResident
+            }
+            H3FactoryConditionerPlacement::HostCpuThenDrop => H3ConditionerExecution::CpuOffloaded,
+        };
+        let conditioner_device = match input.conditioner_placement {
+            H3FactoryConditionerPlacement::AssignedCudaThenDrop => input.device_id.clone(),
+            H3FactoryConditionerPlacement::HostCpuThenDrop => "cpu".to_string(),
+        };
+        let conditioner_placement = FrozenH3ConditionerPlacement::new(
+            conditioner_device,
+            conditioner_execution,
+            input.execution_fingerprint.clone(),
+            input.qwen_activation_workspace_bytes,
+        )?;
+        let block_streaming = FrozenH3BlockStreamingPlan::new(
+            input.device_id.clone(),
+            input.execution_fingerprint.clone(),
+            usize::try_from(input.resident_block_count)
+                .map_err(|_| anyhow!("MiniMax H3 resident block count exceeds usize"))?,
+            usize::try_from(input.prefetch_depth)
+                .map_err(|_| anyhow!("MiniMax H3 prefetch depth exceeds usize"))?,
+        )?;
+        let backend_plan = FrozenH3Fl2VaCandlePlan::new_unavailable(
+            model_contract.canonical_model,
+            input.device_id,
+            H3CandleBackendDevice::Cuda {
+                compute_capability: input.compute_capability,
+            },
+            input.execution_fingerprint,
+            conditioner_placement,
+            block_streaming,
+            components,
+        )?;
+        let mut frozen = Self {
+            schema_version: H3_FACTORY_AUTHORITY_SCHEMA_VERSION,
+            backend_plan,
+            device_ordinal: input.device_ordinal,
+            conditioner_placement: input.conditioner_placement,
+            qwen_parameter_bytes: input.qwen_parameter_bytes,
+            qwen_activation_workspace_bytes: input.qwen_activation_workspace_bytes,
+            attention_backend: input.attention_backend,
+            attention_chunk: input.attention_chunk,
+            attention_kernel_identity: input.attention_kernel_identity,
+            attention_qualification_sha256: input.attention_qualification_sha256,
+            attention_full_noncausal: input.attention_full_noncausal,
+            attention_lossless: input.attention_lossless,
+            attention_head_count: input.attention_head_count,
+            attention_head_dim: input.attention_head_dim,
+            block_offload: input.block_offload,
+            quantization: input.quantization,
+            identity_sha256: String::new(),
+        };
+        frozen.identity_sha256 = frozen_identity(&frozen);
+        frozen.validate_frozen()?;
+        Ok(frozen)
+    }
+
+    pub fn identity_sha256(&self) -> &str {
+        &self.identity_sha256
+    }
+
+    pub fn component_set_identity_sha256(&self) -> &str {
+        self.backend_plan.component_set_identity()
+    }
+
+    pub fn canonical_model(&self) -> &str {
+        self.backend_plan.canonical_model()
+    }
+
+    pub fn device_id(&self) -> &str {
+        self.backend_plan.device_id()
+    }
+
+    pub const fn device_ordinal(&self) -> usize {
+        self.device_ordinal
+    }
+
+    pub fn compute_capability(&self) -> (u16, u16) {
+        match self.backend_plan.backend() {
+            H3CandleBackendDevice::Cuda { compute_capability } => compute_capability,
+        }
+    }
+
+    pub fn execution_fingerprint(&self) -> &str {
+        self.backend_plan.execution_fingerprint()
+    }
+
+    pub fn attention_qualification_sha256(&self) -> &str {
+        &self.attention_qualification_sha256
+    }
+
+    pub const fn attention_backend(&self) -> AttentionBackend {
+        self.attention_backend
+    }
+
+    pub const fn attention_chunk(&self) -> AttentionChunkPolicy {
+        self.attention_chunk
+    }
+
+    pub const fn conditioner_placement(&self) -> H3FactoryConditionerPlacement {
+        self.conditioner_placement
+    }
+
+    pub const fn qwen_parameter_bytes(&self) -> u64 {
+        self.qwen_parameter_bytes
+    }
+
+    pub const fn qwen_activation_workspace_bytes(&self) -> u64 {
+        self.qwen_activation_workspace_bytes
+    }
+
+    pub fn resident_block_count(&self) -> usize {
+        self.backend_plan.block_streaming().resident_block_count
+    }
+
+    pub fn prefetch_depth(&self) -> usize {
+        self.backend_plan.block_streaming().prefetch_depth
+    }
+
+    pub const fn block_offload(&self) -> bool {
+        self.block_offload
+    }
+
+    pub fn quantization(&self) -> &H3FactoryQuantizationAuthority {
+        &self.quantization
+    }
+
+    fn validate_frozen(&self) -> Result<()> {
+        if self.schema_version != H3_FACTORY_AUTHORITY_SCHEMA_VERSION {
+            bail!("MiniMax H3 factory authority uses an unsupported schema version");
+        }
+        self.backend_plan.validate()?;
+        if self.backend_plan.task() != Task::Fl2va
+            || self.backend_plan.block_streaming().resident_block_count > 50
+            || self.backend_plan.block_streaming().prefetch_depth > 2
+        {
+            bail!("MiniMax H3 factory authority changed its task or streaming bounds");
+        }
+        if self.attention_kernel_identity.trim().is_empty()
+            || !self.attention_full_noncausal
+            || !self.attention_lossless
+            || self.attention_head_count != 56
+            || self.attention_head_dim != 128
+            || !self.block_offload
+            || self.qwen_parameter_bytes == 0
+            || self.qwen_activation_workspace_bytes == 0
+        {
+            bail!("MiniMax H3 factory attention or offload authority changed after admission");
+        }
+        require_sha256(
+            &self.attention_qualification_sha256,
+            "H3 attention qualification",
+        )?;
+        self.quantization.validate(self.backend_plan.layout())?;
+        require_sha256(&self.identity_sha256, "H3 factory authority")?;
+        if self.identity_sha256 != frozen_identity(self) {
+            bail!("MiniMax H3 factory authority changed after admission");
+        }
+        Ok(())
+    }
+
+    pub(crate) fn validate_for_dispatch(
+        &self,
+        model: &str,
+        family: &str,
+        gpu_ordinal: usize,
+        offload: bool,
+        attention_backend: AttentionBackend,
+        attention_chunk: AttentionChunkPolicy,
+    ) -> Result<()> {
+        self.validate_frozen()?;
+        let request_contract = contract::capability_contract_for_model(model)
+            .ok_or_else(|| anyhow!("{model:?} has no MiniMax H3 capability contract"))?;
+        if !contract::is_family(family)
+            || request_contract.canonical_model != self.canonical_model()
+            || gpu_ordinal != self.device_ordinal
+            || offload != self.block_offload
+            || attention_backend != self.attention_backend
+            || attention_chunk != self.attention_chunk
+        {
+            bail!(
+                "MiniMax H3 frozen route, attention, or offload authority changed before dispatch"
+            );
+        }
+        if contract::runnable_capability_contract_for_model(model).is_none()
+            || crate::production_family_capability_for_family(family).is_none()
+        {
+            bail!(
+                "MiniMax H3 public capability or production factory registry remains runtime unavailable"
+            );
+        }
+        Ok(())
+    }
+}
+
+fn frozen_identity(authority: &FrozenH3FactoryAuthority) -> String {
+    let mut hash = Sha256::new();
+    hash.update(b"mold.minimax-h3.factory-authority.v1\0");
+    hash.update(authority.schema_version.to_le_bytes());
+    hash.update(authority.backend_plan.identity_sha256().as_bytes());
+    hash.update(authority.device_ordinal.to_le_bytes());
+    hash.update(match authority.conditioner_placement {
+        H3FactoryConditionerPlacement::AssignedCudaThenDrop => b"qwen-cuda".as_slice(),
+        H3FactoryConditionerPlacement::HostCpuThenDrop => b"qwen-cpu".as_slice(),
+    });
+    hash.update(authority.qwen_parameter_bytes.to_le_bytes());
+    hash.update(authority.qwen_activation_workspace_bytes.to_le_bytes());
+    hash.update(match authority.attention_backend {
+        AttentionBackend::Math => b"math".as_slice(),
+        AttentionBackend::Flash => b"flash".as_slice(),
+    });
+    match authority.attention_chunk {
+        AttentionChunkPolicy::Auto => hash.update(b"chunk-auto"),
+        AttentionChunkPolicy::Off => hash.update(b"chunk-off"),
+        AttentionChunkPolicy::Size(size) => {
+            hash.update(b"chunk-size\0");
+            hash.update(size.to_le_bytes());
+        }
+    }
+    hash.update(authority.attention_kernel_identity.as_bytes());
+    hash.update([0]);
+    hash.update(authority.attention_qualification_sha256.as_bytes());
+    hash.update([
+        u8::from(authority.attention_full_noncausal),
+        u8::from(authority.attention_lossless),
+        u8::from(authority.block_offload),
+    ]);
+    hash.update(authority.attention_head_count.to_le_bytes());
+    hash.update(authority.attention_head_dim.to_le_bytes());
+    authority.quantization.update_identity(&mut hash);
+    format!("{:x}", hash.finalize())
+}
+
+fn require_sha256(value: &str, label: &str) -> Result<()> {
+    if value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        Ok(())
+    } else {
+        bail!("{label} fingerprint is not SHA-256")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sha(byte: char) -> String {
+        std::iter::repeat_n(byte, 64).collect()
+    }
+
+    fn authority() -> FrozenH3FactoryAuthority {
+        FrozenH3FactoryAuthority::new_contract_only(H3FactoryAuthorityInput {
+            model: contract::FL2VA_COMFY.into(),
+            device_id: "gpu-0".into(),
+            device_ordinal: 0,
+            compute_capability: (8, 9),
+            execution_fingerprint: sha('a'),
+            conditioner_placement: H3FactoryConditionerPlacement::HostCpuThenDrop,
+            qwen_parameter_bytes: 2048,
+            qwen_activation_workspace_bytes: 1024,
+            resident_block_count: 8,
+            prefetch_depth: 1,
+            attention_backend: AttentionBackend::Flash,
+            attention_chunk: AttentionChunkPolicy::Off,
+            attention_kernel_identity: "flash-attention-v2-sm89".into(),
+            attention_qualification_sha256: sha('b'),
+            attention_full_noncausal: true,
+            attention_lossless: true,
+            attention_head_count: 56,
+            attention_head_dim: 128,
+            block_offload: true,
+            quantization: H3FactoryQuantizationAuthority::ComfyPrunedInt8ConvrotNvfp4Awq {
+                transformer_policy_sha256: sha('c'),
+                qwen_policy_sha256: sha('d'),
+                pruned_adaln_table_sha256: sha('e'),
+            },
+            components: [
+                H3FactoryComponentRole::Conditioner,
+                H3FactoryComponentRole::Transformer,
+                H3FactoryComponentRole::VisualVae,
+                H3FactoryComponentRole::AudioVae,
+            ]
+            .into_iter()
+            .enumerate()
+            .map(|(index, role)| {
+                H3FactoryComponentAuthority::new(
+                    role,
+                    sha(char::from(b'1' + index as u8)),
+                    sha(char::from(b'5' + index as u8)),
+                )
+                .unwrap()
+            })
+            .collect(),
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn factory_authority_binds_backend_route_components_and_runtime_evidence() {
+        let authority = authority();
+        assert_eq!(authority.canonical_model(), contract::FL2VA_COMFY);
+        assert_eq!(authority.device_id(), "gpu-0");
+        assert_eq!(authority.device_ordinal(), 0);
+        assert_eq!(authority.execution_fingerprint(), sha('a'));
+        assert_eq!(authority.identity_sha256().len(), 64);
+        assert_eq!(authority.component_set_identity_sha256().len(), 64);
+        assert!(authority.block_offload());
+        assert!(matches!(
+            authority.quantization(),
+            H3FactoryQuantizationAuthority::ComfyPrunedInt8ConvrotNvfp4Awq { .. }
+        ));
+    }
+
+    #[test]
+    fn post_admission_mutations_are_rejected() {
+        for mutate in [
+            (|value: &mut FrozenH3FactoryAuthority| value.device_ordinal += 1)
+                as fn(&mut FrozenH3FactoryAuthority),
+            |value| value.attention_kernel_identity.push_str("-changed"),
+            |value| value.block_offload = false,
+            |value| {
+                value.quantization = H3FactoryQuantizationAuthority::OfficialBf16;
+            },
+        ] {
+            let mut changed = authority();
+            mutate(&mut changed);
+            assert!(changed.validate_frozen().is_err());
+        }
+    }
+
+    #[test]
+    fn exact_authority_still_rejects_while_runtime_and_factory_registry_are_closed() {
+        let authority = authority();
+        let error = authority
+            .validate_for_dispatch(
+                contract::FL2VA_COMFY,
+                contract::FAMILY,
+                0,
+                true,
+                AttentionBackend::Flash,
+                AttentionChunkPolicy::Off,
+            )
+            .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("registry remains runtime unavailable"));
+    }
+
+    #[test]
+    fn ref2va_and_missing_components_remain_unconstructable() {
+        let mut input = H3FactoryAuthorityInput {
+            model: contract::REF2VA_COMFY.into(),
+            device_id: "gpu-0".into(),
+            device_ordinal: 0,
+            compute_capability: (8, 9),
+            execution_fingerprint: sha('a'),
+            conditioner_placement: H3FactoryConditionerPlacement::HostCpuThenDrop,
+            qwen_parameter_bytes: 2048,
+            qwen_activation_workspace_bytes: 1024,
+            resident_block_count: 8,
+            prefetch_depth: 1,
+            attention_backend: AttentionBackend::Flash,
+            attention_chunk: AttentionChunkPolicy::Off,
+            attention_kernel_identity: "flash-attention-v2-sm89".into(),
+            attention_qualification_sha256: sha('b'),
+            attention_full_noncausal: true,
+            attention_lossless: true,
+            attention_head_count: 56,
+            attention_head_dim: 128,
+            block_offload: true,
+            quantization: H3FactoryQuantizationAuthority::ComfyPrunedInt8ConvrotNvfp4Awq {
+                transformer_policy_sha256: sha('c'),
+                qwen_policy_sha256: sha('d'),
+                pruned_adaln_table_sha256: sha('e'),
+            },
+            components: Vec::new(),
+        };
+        assert!(FrozenH3FactoryAuthority::new_contract_only(input.clone()).is_err());
+        input.model = contract::FL2VA_COMFY.into();
+        assert!(FrozenH3FactoryAuthority::new_contract_only(input).is_err());
+    }
+}

--- a/crates/mold-inference/src/lib.rs
+++ b/crates/mold-inference/src/lib.rs
@@ -18,6 +18,7 @@ pub mod expand;
 mod factory;
 pub mod flux;
 pub mod flux2;
+mod h3_factory;
 mod image;
 pub(crate) mod img2img;
 pub mod img_utils;
@@ -69,6 +70,10 @@ pub use factory::{
 };
 pub use flux::FluxEngine;
 pub use flux2::Flux2Engine;
+pub use h3_factory::{
+    FrozenH3FactoryAuthority, H3FactoryAuthorityInput, H3FactoryComponentAuthority,
+    H3FactoryComponentRole, H3FactoryConditionerPlacement, H3FactoryQuantizationAuthority,
+};
 pub use ltx2::Ltx2Engine;
 pub use ltx_video::LtxVideoEngine;
 pub use model_registry::known_models;

--- a/crates/mold-inference/src/minimax_h3/backend.rs
+++ b/crates/mold-inference/src/minimax_h3/backend.rs
@@ -297,6 +297,10 @@ impl FrozenH3Fl2VaCandlePlan {
         &self.device_id
     }
 
+    pub(crate) const fn backend(&self) -> H3CandleBackendDevice {
+        self.backend
+    }
+
     pub(crate) fn execution_fingerprint(&self) -> &str {
         &self.execution_fingerprint
     }
@@ -349,7 +353,7 @@ impl FrozenH3Fl2VaCandlePlan {
         self.runtime.validate()
     }
 
-    fn validate(&self) -> Result<()> {
+    pub(crate) fn validate(&self) -> Result<()> {
         self.validate_fields()?;
         require_sha256(&self.identity_sha256, "H3 backend plan")?;
         if self.identity_sha256 != backend_plan_identity(self) {
@@ -1115,6 +1119,14 @@ mod tests {
                 (|plan: &mut FrozenH3Fl2VaCandlePlan| plan.device_id = "gpu-1".into())
                     as fn(&mut FrozenH3Fl2VaCandlePlan),
                 "streaming and backend admission authorities disagree",
+            ),
+            (
+                |plan: &mut FrozenH3Fl2VaCandlePlan| {
+                    plan.backend = H3CandleBackendDevice::Cuda {
+                        compute_capability: (9, 0),
+                    }
+                },
+                "plan identity changed after admission",
             ),
             (
                 |plan: &mut FrozenH3Fl2VaCandlePlan| {

--- a/crates/mold-server/src/execution_plan.rs
+++ b/crates/mold-server/src/execution_plan.rs
@@ -332,6 +332,8 @@ pub struct ExecutionSemanticConfig {
     pub qwen2_variant: Option<String>,
     pub qwen2_text_encoder_mode: Option<String>,
     pub ltx2_gemma_variant: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub h3_factory_authority_sha256: Option<String>,
     pub attention_backend: SemanticAttentionBackend,
     pub attention_chunk: SemanticAttentionChunk,
     pub vae_tiling: SemanticVaeTiling,
@@ -497,6 +499,7 @@ impl ExecutionSemanticConfig {
             selected_qwen3_paths: _,
             selected_qwen2_path: _,
             selected_gemma_paths: _,
+            h3_factory_authority,
             runtime_environment,
             attention_backend,
             attention_chunk,
@@ -523,6 +526,9 @@ impl ExecutionSemanticConfig {
             qwen2_variant: qwen2_variant.clone(),
             qwen2_text_encoder_mode: qwen2_text_encoder_mode.clone(),
             ltx2_gemma_variant: ltx2_gemma_variant.clone(),
+            h3_factory_authority_sha256: h3_factory_authority
+                .as_ref()
+                .map(|authority| authority.identity_sha256().to_string()),
             attention_backend: match attention_backend {
                 mold_inference::attention::AttentionBackend::Math => SemanticAttentionBackend::Math,
                 mold_inference::attention::AttentionBackend::Flash => {
@@ -3556,6 +3562,7 @@ impl std::fmt::Debug for ExecutionFingerprintEngineConfig<'_> {
             selected_qwen3_paths,
             selected_qwen2_path,
             selected_gemma_paths,
+            h3_factory_authority,
             runtime_environment,
             attention_backend,
             attention_chunk,
@@ -3563,8 +3570,8 @@ impl std::fmt::Debug for ExecutionFingerprintEngineConfig<'_> {
             vae_dtype,
         } = self.0;
 
-        formatter
-            .debug_struct("FrozenEngineConfig")
+        let mut debug = formatter.debug_struct("FrozenEngineConfig");
+        debug
             .field("family", family)
             .field("is_schnell", is_schnell)
             .field("is_turbo", is_turbo)
@@ -3577,7 +3584,11 @@ impl std::fmt::Debug for ExecutionFingerprintEngineConfig<'_> {
             .field("selected_t5_path", selected_t5_path)
             .field("selected_qwen3_paths", selected_qwen3_paths)
             .field("selected_qwen2_path", selected_qwen2_path)
-            .field("selected_gemma_paths", selected_gemma_paths)
+            .field("selected_gemma_paths", selected_gemma_paths);
+        if let Some(authority) = h3_factory_authority {
+            debug.field("h3_factory_authority", &authority.identity_sha256());
+        }
+        debug
             .field("runtime_environment", runtime_environment)
             .field("attention_backend", attention_backend)
             .field("attention_chunk", attention_chunk)
@@ -5621,6 +5632,7 @@ mod tests {
             selected_qwen3_paths: Vec::new(),
             selected_qwen2_path: None,
             selected_gemma_paths: Vec::new(),
+            h3_factory_authority: None,
             runtime_environment: mold_inference::runtime_env::FrozenRuntimeEnvironment::default(),
             attention_backend: mold_inference::attention::AttentionBackend::Math,
             attention_chunk: mold_inference::attention::AttentionChunkPolicy::Auto,
@@ -5682,6 +5694,7 @@ mod tests {
                 qwen2_variant: None,
                 qwen2_text_encoder_mode: None,
                 ltx2_gemma_variant: None,
+                h3_factory_authority_sha256: None,
                 attention_backend: SemanticAttentionBackend::Math,
                 attention_chunk: SemanticAttentionChunk::Auto,
                 vae_tiling: SemanticVaeTiling::Auto,

--- a/crates/mold-server/src/h3_admission.rs
+++ b/crates/mold-server/src/h3_admission.rs
@@ -11,12 +11,12 @@ use mold_core::minimax_h3::{self, GenerationReferencePreparedShape};
 use mold_core::{GenerateRequest, GpuBackend};
 use serde::Serialize;
 use sha2::{Digest, Sha256};
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use thiserror::Error;
 
 const GIB: u64 = 1024 * 1024 * 1024;
 
-pub(crate) const H3_ADMISSION_SCHEMA_VERSION: u32 = 1;
+pub(crate) const H3_ADMISSION_SCHEMA_VERSION: u32 = 2;
 pub(crate) const H3_MAIN_BLOCK_COUNT: usize = 50;
 pub(crate) const H3_QWEN_SELECTED_LANGUAGE_LAYERS: u32 = 50;
 pub(crate) const H3_QWEN_MODEL_MAX_ROWS: u64 = 262_144;
@@ -825,6 +825,7 @@ impl H3QualifiedRuntimeFacts {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct H3AdmissionDevice {
     pub id: String,
+    pub ordinal: usize,
     pub backend: GpuBackend,
     pub compute_capability: Option<(u16, u16)>,
     pub available_vram_bytes: u64,
@@ -926,9 +927,12 @@ pub(crate) struct H3MemoryBreakdown {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub(crate) struct H3FrozenExecutionPlan {
     pub schema_version: u32,
+    pub canonical_model: String,
     pub task: H3FrozenTask,
     pub layout: H3PublishedLayout,
     pub device_id: String,
+    pub device_ordinal: usize,
+    pub compute_capability: (u16, u16),
     pub checkpoint_fingerprint: String,
     pub config_fingerprint: String,
     pub header_fingerprint: String,
@@ -1263,9 +1267,16 @@ pub(crate) fn plan_h3_admission(
     let artifact_fingerprint = fingerprint(artifacts)?;
     let mut plan = H3FrozenExecutionPlan {
         schema_version: H3_ADMISSION_SCHEMA_VERSION,
+        canonical_model: artifacts.model.clone(),
         task,
         layout: artifacts.layout,
         device_id: device.id.clone(),
+        device_ordinal: device.ordinal,
+        compute_capability: device.compute_capability.ok_or_else(|| {
+            H3AdmissionError::DeviceUnsupported(
+                "H3 CUDA admission requires an exact compute capability".to_string(),
+            )
+        })?,
         checkpoint_fingerprint: checkpoint.checkpoint_fingerprint.clone(),
         config_fingerprint: checkpoint.config_fingerprint.clone(),
         header_fingerprint: checkpoint.header_fingerprint.clone(),
@@ -1335,6 +1346,191 @@ pub(crate) fn plan_h3_admission(
     plan.execution_fingerprint = fingerprint(&plan)?;
     plan.validate_execution_fingerprint()?;
     Ok(plan)
+}
+
+/// Bind a fully admitted server plan into the inference factory without
+/// exposing paths or bytes and without activating an H3 loader.
+///
+/// Construction is transactional: `engine_config` is mutated only after the
+/// execution fingerprint, exact CUDA route, component set, attention evidence,
+/// streaming policy, and layout-specific quantization all agree.
+pub(crate) fn bind_h3_factory_authority(
+    plan: &H3FrozenExecutionPlan,
+    artifacts: &H3ArtifactInventory,
+    checkpoint: &H3CheckpointMemoryFacts,
+    device: &H3AdmissionDevice,
+    engine_config: &mut mold_inference::FrozenEngineConfig,
+) -> Result<(), H3AdmissionError> {
+    plan.validate_execution_fingerprint()?;
+    artifacts.validate_landed()?;
+    checkpoint.validate(artifacts)?;
+    let compute_capability = device.compute_capability.ok_or_else(|| {
+        H3AdmissionError::DeviceUnsupported(
+            "H3 factory binding requires an exact CUDA compute capability".to_string(),
+        )
+    })?;
+    if plan.schema_version != H3_ADMISSION_SCHEMA_VERSION
+        || plan.canonical_model != artifacts.model
+        || plan.task != artifacts.task
+        || plan.layout != artifacts.layout
+        || plan.device_id != device.id
+        || plan.device_ordinal != device.ordinal
+        || plan.compute_capability != compute_capability
+        || device.backend != GpuBackend::Cuda
+        || plan.checkpoint_fingerprint != checkpoint.checkpoint_fingerprint
+        || plan.config_fingerprint != checkpoint.config_fingerprint
+        || plan.header_fingerprint != checkpoint.header_fingerprint
+        || plan.adaln != checkpoint.adaln
+        || plan.quantization != checkpoint.quantization
+        || plan.artifact_fingerprint != fingerprint(artifacts)?
+    {
+        return Err(H3AdmissionError::InvalidRuntimeFacts(
+            "H3 server admission and factory authorities disagree".to_string(),
+        ));
+    }
+    if plan.task != H3FrozenTask::Fl2va {
+        return Err(H3AdmissionError::InvalidRuntimeFacts(
+            "the current H3 Candle factory authority is FL2VA-only".to_string(),
+        ));
+    }
+    if !minimax_h3::is_family(&engine_config.family) {
+        return Err(H3AdmissionError::InvalidRuntimeFacts(
+            "H3 admission cannot bind a non-H3 frozen engine family".to_string(),
+        ));
+    }
+    let conditioner_placement = match plan.qwen_placement {
+        H3QwenPlacement::AssignedGpuThenDrop => {
+            mold_inference::H3FactoryConditionerPlacement::AssignedCudaThenDrop
+        }
+        H3QwenPlacement::HostCpuThenDrop => {
+            mold_inference::H3FactoryConditionerPlacement::HostCpuThenDrop
+        }
+    };
+    let quantization = match (&plan.quantization, &plan.adaln) {
+        (H3QuantizationPolicy::None, H3AdaLnPolicy::FullProjection) => {
+            mold_inference::H3FactoryQuantizationAuthority::OfficialBf16
+        }
+        (
+            H3QuantizationPolicy::Int8ConvrotNvfp4Awq {
+                transformer_policy_fingerprint,
+                qwen_policy_fingerprint,
+            },
+            H3AdaLnPolicy::PrunedCurve {
+                table_fingerprint, ..
+            },
+        ) => mold_inference::H3FactoryQuantizationAuthority::ComfyPrunedInt8ConvrotNvfp4Awq {
+            transformer_policy_sha256: transformer_policy_fingerprint.clone(),
+            qwen_policy_sha256: qwen_policy_fingerprint.clone(),
+            pruned_adaln_table_sha256: table_fingerprint.clone(),
+        },
+        _ => {
+            return Err(H3AdmissionError::InvalidCheckpointFacts(
+                "H3 factory layout, AdaLN, and quantization authorities disagree".to_string(),
+            ));
+        }
+    };
+    let components = h3_factory_component_authorities(plan, artifacts, checkpoint)?;
+    let authority = mold_inference::FrozenH3FactoryAuthority::new_contract_only(
+        mold_inference::H3FactoryAuthorityInput {
+            model: artifacts.model.clone(),
+            device_id: plan.device_id.clone(),
+            device_ordinal: plan.device_ordinal,
+            compute_capability,
+            execution_fingerprint: plan.execution_fingerprint.clone(),
+            conditioner_placement,
+            qwen_parameter_bytes: checkpoint.qwen_device_bytes,
+            qwen_activation_workspace_bytes: plan.memory.qwen_activation_bytes,
+            resident_block_count: plan.resident_block_count,
+            prefetch_depth: plan.prefetch_depth,
+            attention_backend: engine_config.attention_backend,
+            attention_chunk: engine_config.attention_chunk,
+            attention_kernel_identity: plan.attention.kernel_identity.clone(),
+            attention_qualification_sha256: plan.attention.qualification_fingerprint.clone(),
+            attention_full_noncausal: plan.attention.full_noncausal,
+            attention_lossless: plan.attention.lossless,
+            attention_head_count: plan.attention.head_count,
+            attention_head_dim: plan.attention.head_dim,
+            block_offload: true,
+            quantization,
+            components,
+        },
+    )
+    .map_err(|error| H3AdmissionError::InvalidRuntimeFacts(error.to_string()))?;
+    engine_config.h3_factory_authority = Some(authority);
+    Ok(())
+}
+
+fn h3_factory_component_authorities(
+    plan: &H3FrozenExecutionPlan,
+    artifacts: &H3ArtifactInventory,
+    checkpoint: &H3CheckpointMemoryFacts,
+) -> Result<Vec<mold_inference::H3FactoryComponentAuthority>, H3AdmissionError> {
+    use mold_inference::H3FactoryComponentRole as FactoryRole;
+
+    let mut grouped = BTreeMap::<FactoryRole, Vec<&H3ArtifactFact>>::new();
+    for artifact in &artifacts.artifacts {
+        let role = match &artifact.role {
+            H3ArtifactRole::QwenShard(_) | H3ArtifactRole::ProcessorAsset(_) => {
+                FactoryRole::Conditioner
+            }
+            H3ArtifactRole::TransformerShard(_)
+            | H3ArtifactRole::TaskConfig(_)
+            | H3ArtifactRole::VideoScheduler
+            | H3ArtifactRole::AudioScheduler
+            | H3ArtifactRole::QuantizationSidecar
+            | H3ArtifactRole::PrunedAdaLnTable => FactoryRole::Transformer,
+            H3ArtifactRole::VideoVaeShard(_) => FactoryRole::VisualVae,
+            H3ArtifactRole::AudioVae => FactoryRole::AudioVae,
+            H3ArtifactRole::SharedConfig(_) => {
+                if artifact.source_path.starts_with("text_encoder/") {
+                    FactoryRole::Conditioner
+                } else if artifact.source_path.starts_with("vae/") {
+                    FactoryRole::VisualVae
+                } else if artifact.source_path.starts_with("audio_vae/") {
+                    FactoryRole::AudioVae
+                } else {
+                    FactoryRole::Transformer
+                }
+            }
+        };
+        grouped.entry(role).or_default().push(artifact);
+    }
+
+    [
+        FactoryRole::Conditioner,
+        FactoryRole::Transformer,
+        FactoryRole::VisualVae,
+        FactoryRole::AudioVae,
+    ]
+    .into_iter()
+    .map(|role| {
+        let members = grouped.get(&role).ok_or_else(|| {
+            H3AdmissionError::InvalidArtifactFacts(format!(
+                "H3 factory component {role:?} has no landed artifacts"
+            ))
+        })?;
+        let role_id = match role {
+            FactoryRole::Conditioner => "conditioner",
+            FactoryRole::Transformer => "transformer",
+            FactoryRole::VisualVae => "visual-vae",
+            FactoryRole::AudioVae => "audio-vae",
+        };
+        let content_sha256 = fingerprint(&(
+            "mold.minimax-h3.logical-component-content.v1",
+            role_id,
+            members,
+        ))?;
+        let validation_sha256 = fingerprint(&(
+            "mold.minimax-h3.logical-component-validation.v1",
+            role_id,
+            plan,
+            checkpoint,
+            members,
+        ))?;
+        mold_inference::H3FactoryComponentAuthority::new(role, content_sha256, validation_sha256)
+            .map_err(|error| H3AdmissionError::InvalidArtifactFacts(error.to_string()))
+    })
+    .collect()
 }
 
 fn choose_streaming(
@@ -1489,7 +1685,7 @@ fn fingerprint(value: &impl Serialize) -> Result<String, H3AdmissionError> {
     let bytes = serde_json::to_vec(value)
         .map_err(|error| H3AdmissionError::InvalidRuntimeFacts(error.to_string()))?;
     let mut hash = Sha256::new();
-    hash.update(b"mold.minimax-h3.admission.v1\0");
+    hash.update(b"mold.minimax-h3.admission.v2\0");
     hash.update(bytes);
     Ok(format!("{:x}", hash.finalize()))
 }
@@ -1657,6 +1853,7 @@ mod tests {
     fn cuda(vram: u64) -> H3AdmissionDevice {
         H3AdmissionDevice {
             id: "gpu-0".to_string(),
+            ordinal: 0,
             backend: GpuBackend::Cuda,
             compute_capability: Some((8, 9)),
             available_vram_bytes: vram,
@@ -2096,6 +2293,185 @@ mod tests {
         tampered.memory.predicted_vram_peak_bytes -= 1;
         let error = tampered.validate_execution_fingerprint().unwrap_err();
         assert!(matches!(error, H3AdmissionError::InvalidRuntimeFacts(_)));
+    }
+
+    #[test]
+    fn admitted_fl2va_plan_binds_exact_factory_route_and_component_authority() {
+        let inventory = landed_inventory(minimax_h3::FL2VA_COMFY);
+        let checkpoint = checkpoint(&inventory);
+        let runtime = qualified_runtime();
+        let device = cuda(24 * GIB);
+        let (task, shape) = prepared(minimax_h3::FL2VA_COMFY, 124);
+        let plan = plan_h3_admission(
+            task,
+            shape,
+            &inventory,
+            &checkpoint,
+            Some(&runtime),
+            std::slice::from_ref(&device),
+            H3HostMemory {
+                total_bytes: 96 * GIB,
+                available_bytes: 96 * GIB,
+            },
+            H3AdmissionPolicy::default(),
+        )
+        .unwrap();
+        let mut engine_config = mold_inference::FrozenEngineConfig::resolve(
+            minimax_h3::FL2VA_COMFY,
+            &mold_core::Config::default(),
+        );
+        engine_config.family = minimax_h3::FAMILY.to_string();
+
+        bind_h3_factory_authority(&plan, &inventory, &checkpoint, &device, &mut engine_config)
+            .unwrap();
+        let authority = engine_config.h3_factory_authority.as_ref().unwrap();
+        assert_eq!(plan.canonical_model, minimax_h3::FL2VA_COMFY);
+        assert_eq!(authority.canonical_model(), minimax_h3::FL2VA_COMFY);
+        assert_eq!(authority.device_id(), plan.device_id);
+        assert_eq!(authority.device_ordinal(), plan.device_ordinal);
+        assert_eq!(plan.compute_capability, (8, 9));
+        assert_eq!(authority.compute_capability(), (8, 9));
+        assert_eq!(
+            authority.execution_fingerprint(),
+            plan.execution_fingerprint
+        );
+        assert_eq!(
+            authority.attention_qualification_sha256(),
+            runtime.qualification_fingerprint
+        );
+        assert_eq!(
+            authority.attention_backend(),
+            engine_config.attention_backend
+        );
+        assert_eq!(authority.attention_chunk(), engine_config.attention_chunk);
+        assert_eq!(
+            authority.qwen_parameter_bytes(),
+            checkpoint.qwen_device_bytes
+        );
+        assert_eq!(
+            authority.qwen_activation_workspace_bytes(),
+            plan.memory.qwen_activation_bytes
+        );
+        assert_eq!(
+            authority.resident_block_count(),
+            plan.resident_block_count as usize
+        );
+        assert_eq!(authority.prefetch_depth(), plan.prefetch_depth as usize);
+        assert_eq!(authority.component_set_identity_sha256().len(), 64);
+        assert!(authority.block_offload());
+        assert!(matches!(
+            authority.quantization(),
+            mold_inference::H3FactoryQuantizationAuthority::ComfyPrunedInt8ConvrotNvfp4Awq { .. }
+        ));
+        let semantic =
+            crate::execution_plan::ExecutionSemanticConfig::from_frozen(&engine_config).unwrap();
+        assert_eq!(
+            semantic.h3_factory_authority_sha256.as_deref(),
+            Some(authority.identity_sha256())
+        );
+        assert!(!minimax_h3::capabilities(minimax_h3::Task::Fl2va).runtime_available);
+    }
+
+    #[test]
+    fn official_bf16_admission_binds_without_inheriting_comfy_quantization() {
+        let inventory = landed_inventory(minimax_h3::FL2VA_OFFICIAL);
+        let checkpoint = checkpoint(&inventory);
+        let runtime = qualified_runtime();
+        let device = cuda(160 * GIB);
+        let (task, shape) = prepared(minimax_h3::FL2VA_OFFICIAL, 124);
+        let plan = plan_h3_admission(
+            task,
+            shape,
+            &inventory,
+            &checkpoint,
+            Some(&runtime),
+            std::slice::from_ref(&device),
+            H3HostMemory {
+                total_bytes: 512 * GIB,
+                available_bytes: 512 * GIB,
+            },
+            H3AdmissionPolicy::default(),
+        )
+        .unwrap();
+        let mut engine_config = mold_inference::FrozenEngineConfig::resolve(
+            minimax_h3::FL2VA_OFFICIAL,
+            &mold_core::Config::default(),
+        );
+        engine_config.family = minimax_h3::FAMILY.to_string();
+
+        bind_h3_factory_authority(&plan, &inventory, &checkpoint, &device, &mut engine_config)
+            .unwrap();
+        let authority = engine_config.h3_factory_authority.as_ref().unwrap();
+        assert_eq!(authority.canonical_model(), minimax_h3::FL2VA_OFFICIAL);
+        assert_eq!(authority.compute_capability(), (8, 9));
+        assert!(matches!(
+            authority.quantization(),
+            mold_inference::H3FactoryQuantizationAuthority::OfficialBf16
+        ));
+    }
+
+    #[test]
+    fn mutated_admission_or_component_facts_never_partially_bind_the_factory() {
+        let inventory = landed_inventory(minimax_h3::FL2VA_COMFY);
+        let checkpoint = checkpoint(&inventory);
+        let runtime = qualified_runtime();
+        let device = cuda(24 * GIB);
+        let (task, shape) = prepared(minimax_h3::FL2VA_COMFY, 124);
+        let plan = plan_h3_admission(
+            task,
+            shape,
+            &inventory,
+            &checkpoint,
+            Some(&runtime),
+            std::slice::from_ref(&device),
+            H3HostMemory {
+                total_bytes: 96 * GIB,
+                available_bytes: 96 * GIB,
+            },
+            H3AdmissionPolicy::default(),
+        )
+        .unwrap();
+        let mut engine_config = mold_inference::FrozenEngineConfig::resolve(
+            minimax_h3::FL2VA_COMFY,
+            &mold_core::Config::default(),
+        );
+        engine_config.family = minimax_h3::FAMILY.to_string();
+
+        let mut rerouted = plan.clone();
+        rerouted.device_ordinal += 1;
+        assert!(bind_h3_factory_authority(
+            &rerouted,
+            &inventory,
+            &checkpoint,
+            &device,
+            &mut engine_config,
+        )
+        .is_err());
+        assert!(engine_config.h3_factory_authority.is_none());
+
+        let mut changed_device = device.clone();
+        changed_device.compute_capability = Some((9, 0));
+        assert!(bind_h3_factory_authority(
+            &plan,
+            &inventory,
+            &checkpoint,
+            &changed_device,
+            &mut engine_config,
+        )
+        .is_err());
+        assert!(engine_config.h3_factory_authority.is_none());
+
+        let mut changed_artifacts = inventory.clone();
+        changed_artifacts.artifacts[0].content_sha256 = sha(254);
+        assert!(bind_h3_factory_authority(
+            &plan,
+            &changed_artifacts,
+            &checkpoint,
+            &device,
+            &mut engine_config,
+        )
+        .is_err());
+        assert!(engine_config.h3_factory_authority.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- carry exact MiniMax H3 admission facts into a private frozen factory authority
- bind CUDA route/compute capability, Scheduler V2 fingerprint, Qwen memory, block residency/prefetch, qualified full-attention evidence, layout-specific quantization/AdaLN policy, and four logical component digests
- include the authority identity in execution semantics so post-admission mutation is rejected
- add a typed factory seam while keeping the production loader and family registry unavailable

## Safety boundary

- the compliance gate remains the first factory operation
- the static runtime/registry gate precedes path classification and existence checks
- the authority accepts only digests and immutable scheduling facts; no artifact path, checkpoint bytes, or safetensors header crosses it
- catalogs, manifests, downloads, public capabilities, and runtime activation remain unchanged and fail closed
- no H3 weights or generated artifacts were accessed

## Verification

The exact patch was validated before rebase with:

- H3 inference contract tests: 48/48
- H3 server admission/factory tests: 45/45
- H3 golden contract tests: 2/2
- focused Rustfmt and Clippy with warnings denied
- forced-local Metal typecheck
- synthetic CUDA typecheck/tests on Plato

The rebase onto `c1678411` preserved stable patch ID `eb758d124dbfd7cde0f68823974a5bb8abc8708c`; post-rebase `cargo fmt --all -- --check` and `git diff --check` pass.

Refs #838, #839, #840, #827, #831.