### PR TITLE
feat(h3): add fail-closed FL2VA dispatch seam

### DIFF
--- a/crates/mold-inference/src/factory.rs
+++ b/crates/mold-inference/src/factory.rs
@@ -396,11 +396,7 @@ pub fn create_engine_with_frozen_config(
         gpu_ordinal,
         offload,
         shared_pool,
-        |_| {
-            bail!(
-                "MiniMax H3 typed factory authority is present but no runnable loader is registered"
-            )
-        },
+        |_| bail!(crate::minimax_h3::engine::H3_REAL_LOADER_DISABLED),
     )
 }
 
@@ -416,7 +412,9 @@ fn create_engine_with_frozen_config_and_h3_factory<F>(
     h3_factory: F,
 ) -> Result<Box<dyn InferenceEngine>>
 where
-    F: FnOnce(&crate::FrozenH3FactoryAuthority) -> Result<Box<dyn InferenceEngine>>,
+    F: FnOnce(
+        crate::minimax_h3::engine::H3RuntimeLoadRequest<'_>,
+    ) -> Result<Box<dyn InferenceEngine>>,
 {
     // The compliance gate is intentionally the first operation. No path,
     // runtime, device, authority, or future loader inspection may precede it.
@@ -725,7 +723,14 @@ where
                 frozen.attention_backend,
                 frozen.attention_chunk,
             )?;
-            h3_factory(authority)
+            h3_factory(crate::minimax_h3::engine::H3RuntimeLoadRequest {
+                model_name: &model_name,
+                paths: &paths,
+                authority,
+                load_strategy,
+                gpu_ordinal,
+                block_offload: offload,
+            })
         }
         "wuerstchen" | "wuerstchen-v2" => Ok(boxed_inference_engine(WuerstchenEngine::new(
             model_name,

--- a/crates/mold-inference/src/h3_factory.rs
+++ b/crates/mold-inference/src/h3_factory.rs
@@ -348,6 +348,33 @@ impl FrozenH3FactoryAuthority {
         self.block_offload
     }
 
+    /// Validate the immutable authority carried into the legal-neutral engine
+    /// seam without claiming that H3 is runnable.
+    ///
+    /// Production factory dispatch must still call `validate_for_dispatch`,
+    /// which additionally requires the public runtime capability and family
+    /// registry. This narrower check exists only so an injected, weight-free
+    /// runtime can exercise the engine/worker transaction while those gates
+    /// remain closed.
+    pub(crate) fn validate_engine_seam(
+        &self,
+        model: &str,
+        gpu_ordinal: usize,
+        offload: bool,
+    ) -> Result<()> {
+        self.validate_frozen()?;
+        let request_contract = contract::capability_contract_for_model(model)
+            .ok_or_else(|| anyhow!("{model:?} has no MiniMax H3 capability contract"))?;
+        if request_contract.canonical_model != self.canonical_model()
+            || request_contract.task != Task::Fl2va
+            || gpu_ordinal != self.device_ordinal
+            || offload != self.block_offload
+        {
+            bail!("MiniMax H3 frozen engine authority changed before construction");
+        }
+        Ok(())
+    }
+
     pub fn quantization(&self) -> &H3FactoryQuantizationAuthority {
         &self.quantization
     }

--- a/crates/mold-inference/src/minimax_h3/engine.rs
+++ b/crates/mold-inference/src/minimax_h3/engine.rs
@@ -1,0 +1,1302 @@
+//! Legal-neutral MiniMax H3 FL2VA engine and streamed-dispatch seam.
+//!
+//! This module deliberately has no production loader registration. The public
+//! frozen factory still rejects H3 before paths or loader callbacks while the
+//! #831 authorization gate, runnable capability, attention qualification, and
+//! artifact identities are unavailable. Tests inject only in-memory runtimes.
+//!
+//! The streamed denoiser below consumes real [`H3BlockLoader`] objects one at a
+//! time. It does not adapt the current eager `H3Transformer`: doing so would
+//! falsely claim that its resident `Vec` satisfies block streaming. A future
+//! authorized loader must provide an executor over independently owned block
+//! objects before this seam can be registered by the production factory.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use anyhow::{bail, Context, Result};
+use candle_core::{Device, Tensor};
+use mold_candle::minimax_h3::{
+    H3ForwardInput, H3FrozenPackedLayout, H3TransformerOutput, StereoLatents, StereoWaveform,
+};
+use mold_core::minimax_h3::{self as contract, Mode, Task};
+use mold_core::{GenerateRequest, GenerateResponse, ModelPaths, OutputFormat, VideoData};
+
+use super::offload::{
+    FrozenH3BlockStreamingPlan, H3BlockLease, H3BlockLoader, H3BlockStreamEvent,
+    H3BlockStreamState, H3StreamCancellation, H3StreamCheckpoint,
+};
+#[cfg(feature = "mp4")]
+use super::pipeline;
+use super::pipeline::{
+    H3Fl2VaBackend, H3PipelineBackendIdentity, H3PipelineCheckpoint, H3PipelineEvent,
+    H3PipelineObserver, H3PipelinePhase, H3PreparedEndpoint, H3TextConditioning, H3VideoEncodeSink,
+};
+use crate::engine::{BatchExecutionCapability, InferenceEngine, LoadStrategy};
+use crate::progress::{
+    InferenceCancellationToken, ProgressCallback, ProgressEvent, ProgressPhase, ProgressReporter,
+};
+use crate::FrozenH3FactoryAuthority;
+
+/// Stable failure used by the shipping factory until a separately reviewed
+/// artifact locator/loader is registered. Keeping it here makes it impossible
+/// for a path, header, network client, or queue side effect to be mistaken for
+/// the legal-neutral runtime seam.
+pub(crate) const H3_REAL_LOADER_DISABLED: &str =
+    "MiniMax H3 real filesystem loader is runtime-disabled pending authorization and exact artifact identities";
+
+#[derive(Clone, Copy)]
+pub(crate) struct H3RuntimeLoadRequest<'a> {
+    pub(crate) model_name: &'a str,
+    pub(crate) paths: &'a ModelPaths,
+    pub(crate) authority: &'a FrozenH3FactoryAuthority,
+    pub(crate) load_strategy: LoadStrategy,
+    pub(crate) gpu_ordinal: usize,
+    pub(crate) block_offload: bool,
+}
+
+/// Injected component loader. No implementation is installed by the shipping
+/// factory; callers inside tests use in-memory components only.
+pub(crate) trait H3RuntimeLoader: Send + Sync {
+    fn load(
+        &mut self,
+        request: H3RuntimeLoadRequest<'_>,
+        progress: &ProgressReporter,
+    ) -> Result<Box<dyn H3RuntimeSession>>;
+}
+
+/// One already-loaded, single-route H3 runtime.
+pub(crate) trait H3RuntimeSession: Send + Sync {
+    fn device_id(&self) -> &str;
+    fn execution_fingerprint(&self) -> &str;
+    fn component_set_identity_sha256(&self) -> &str;
+    fn generate(
+        &mut self,
+        request: &GenerateRequest,
+        progress: &ProgressReporter,
+        observer: &mut dyn H3PipelineObserver,
+    ) -> Result<H3EngineOutput>;
+}
+
+#[derive(Debug)]
+pub(crate) struct H3EngineOutput {
+    pub(crate) mp4: Vec<u8>,
+    pub(crate) thumbnail_png: Vec<u8>,
+    pub(crate) mode: Mode,
+    pub(crate) seed: u64,
+    pub(crate) width: u32,
+    pub(crate) height: u32,
+    pub(crate) frames: u32,
+    pub(crate) fps: u32,
+    pub(crate) duration_ms: u64,
+    pub(crate) audio_sample_rate: u32,
+    pub(crate) audio_channels: u32,
+    pub(crate) device_id: String,
+    pub(crate) execution_fingerprint: String,
+    pub(crate) component_set_identity_sha256: String,
+}
+
+/// Concrete `InferenceEngine` adapter. It owns the exact server-frozen route,
+/// but can be constructed only with an injected loader; production factory
+/// dispatch deliberately has no such loader today.
+pub(crate) struct H3Fl2VaEngine {
+    model_name: String,
+    paths: ModelPaths,
+    authority: FrozenH3FactoryAuthority,
+    load_strategy: LoadStrategy,
+    block_offload: bool,
+    loader: Box<dyn H3RuntimeLoader>,
+    runtime: Option<Box<dyn H3RuntimeSession>>,
+    progress: ProgressReporter,
+}
+
+impl H3Fl2VaEngine {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new_injected(
+        model_name: String,
+        paths: ModelPaths,
+        authority: FrozenH3FactoryAuthority,
+        load_strategy: LoadStrategy,
+        gpu_ordinal: usize,
+        block_offload: bool,
+        loader: Box<dyn H3RuntimeLoader>,
+    ) -> Result<Self> {
+        authority.validate_engine_seam(&model_name, gpu_ordinal, block_offload)?;
+        Ok(Self {
+            model_name,
+            paths,
+            authority,
+            load_strategy,
+            block_offload,
+            loader,
+            runtime: None,
+            progress: ProgressReporter::default(),
+        })
+    }
+
+    pub(crate) fn from_factory_request(
+        request: H3RuntimeLoadRequest<'_>,
+        loader: Box<dyn H3RuntimeLoader>,
+    ) -> Result<Self> {
+        Self::new_injected(
+            request.model_name.to_string(),
+            request.paths.clone(),
+            request.authority.clone(),
+            request.load_strategy,
+            request.gpu_ordinal,
+            request.block_offload,
+            loader,
+        )
+    }
+
+    fn validate_loaded_runtime(&self, runtime: &dyn H3RuntimeSession) -> Result<()> {
+        if runtime.device_id() != self.authority.device_id()
+            || runtime.execution_fingerprint() != self.authority.execution_fingerprint()
+            || runtime.component_set_identity_sha256()
+                != self.authority.component_set_identity_sha256()
+        {
+            bail!("MiniMax H3 injected runtime differs from the frozen factory authority");
+        }
+        Ok(())
+    }
+
+    fn validate_output(
+        &self,
+        request: &GenerateRequest,
+        expected_mode: Mode,
+        output: &H3EngineOutput,
+    ) -> Result<()> {
+        if output.mode != expected_mode
+            || output.width != request.width
+            || output.height != request.height
+            || output.frames != request.frames.unwrap_or(contract::MIN_FRAMES)
+            || output.fps != contract::FIXED_FPS
+            || request.seed.is_some_and(|seed| seed != output.seed)
+            || output.audio_sample_rate != contract::AUDIO_SAMPLE_RATE_HZ
+            || output.audio_channels != contract::AUDIO_CHANNELS
+            || output.device_id != self.authority.device_id()
+            || output.execution_fingerprint != self.authority.execution_fingerprint()
+            || output.component_set_identity_sha256
+                != self.authority.component_set_identity_sha256()
+            || output.mp4.is_empty()
+            || output.thumbnail_png.is_empty()
+        {
+            bail!("MiniMax H3 runtime output differs from the frozen request or factory authority");
+        }
+        Ok(())
+    }
+}
+
+impl InferenceEngine for H3Fl2VaEngine {
+    fn generate(&mut self, request: &GenerateRequest) -> Result<GenerateResponse> {
+        let expected_mode = contract::validate_request_contract(request, Task::Fl2va)
+            .map_err(|error| anyhow::anyhow!("{}: {}", error.code, error.message))?;
+        if !self.is_loaded() {
+            self.load_for_request(request)?;
+        }
+        self.progress.checkpoint()?;
+        let started = Instant::now();
+        let mut observer = H3EngineProgressObserver::new(&self.progress);
+        let output = self
+            .runtime
+            .as_mut()
+            .context("MiniMax H3 runtime disappeared after load")?
+            .generate(request, &self.progress, &mut observer)?;
+        self.progress.checkpoint()?;
+        self.validate_output(request, expected_mode, &output)?;
+        Ok(GenerateResponse {
+            images: Vec::new(),
+            video: Some(VideoData {
+                data: output.mp4,
+                format: OutputFormat::Mp4,
+                width: output.width,
+                height: output.height,
+                frames: output.frames,
+                fps: output.fps,
+                pipeline: None,
+                thumbnail: output.thumbnail_png,
+                gif_preview: Vec::new(),
+                has_audio: true,
+                duration_ms: Some(output.duration_ms),
+                audio_sample_rate: Some(output.audio_sample_rate),
+                audio_channels: Some(output.audio_channels),
+            }),
+            audio: None,
+            generation_time_ms: started.elapsed().as_millis() as u64,
+            model: self.model_name.clone(),
+            seed_used: output.seed,
+            gpu: None,
+        })
+    }
+
+    fn model_name(&self) -> &str {
+        &self.model_name
+    }
+
+    fn is_loaded(&self) -> bool {
+        self.runtime.is_some()
+    }
+
+    fn load(&mut self) -> Result<()> {
+        if self.runtime.is_some() {
+            return Ok(());
+        }
+        self.progress.checkpoint()?;
+        self.progress
+            .stage_start("Loading MiniMax H3 frozen runtime");
+        let started = Instant::now();
+        let runtime = self.loader.load(
+            H3RuntimeLoadRequest {
+                model_name: &self.model_name,
+                paths: &self.paths,
+                authority: &self.authority,
+                load_strategy: self.load_strategy,
+                gpu_ordinal: self.authority.device_ordinal(),
+                block_offload: self.block_offload,
+            },
+            &self.progress,
+        )?;
+        self.validate_loaded_runtime(runtime.as_ref())?;
+        self.progress.checkpoint()?;
+        self.runtime = Some(runtime);
+        self.progress
+            .stage_done("Loading MiniMax H3 frozen runtime", started.elapsed());
+        Ok(())
+    }
+
+    fn unload(&mut self) {
+        self.runtime = None;
+    }
+
+    fn set_on_progress(&mut self, callback: ProgressCallback) {
+        self.progress.set_callback(callback);
+    }
+
+    fn clear_on_progress(&mut self) {
+        self.progress.clear_callback();
+    }
+
+    fn set_cancellation_token(&mut self, token: InferenceCancellationToken) {
+        self.progress.set_cancellation_token(token);
+    }
+
+    fn clear_cancellation_token(&mut self) {
+        self.progress.clear_cancellation_token();
+    }
+
+    fn batch_execution_capability(&self) -> BatchExecutionCapability {
+        BatchExecutionCapability::SINGLETON_COOPERATIVE
+    }
+
+    fn model_paths(&self) -> Option<&ModelPaths> {
+        Some(&self.paths)
+    }
+
+    fn configured_load_strategy(&self) -> Option<LoadStrategy> {
+        Some(self.load_strategy)
+    }
+
+    fn configured_block_offload(&self) -> Option<bool> {
+        Some(self.block_offload)
+    }
+
+    fn configured_execution_fingerprint(&self) -> Option<&str> {
+        Some(self.authority.execution_fingerprint())
+    }
+}
+
+struct H3EngineProgressObserver<'a> {
+    progress: &'a ProgressReporter,
+    started: HashMap<H3PipelinePhase, Instant>,
+    last_completed: HashMap<H3PipelinePhase, usize>,
+}
+
+impl<'a> H3EngineProgressObserver<'a> {
+    fn new(progress: &'a ProgressReporter) -> Self {
+        Self {
+            progress,
+            started: HashMap::new(),
+            last_completed: HashMap::new(),
+        }
+    }
+}
+
+impl H3PipelineObserver for H3EngineProgressObserver<'_> {
+    fn observe(&mut self, event: H3PipelineEvent) {
+        let previous = self.last_completed.get(&event.phase).copied();
+        if event.completed == 0 || previous.is_some_and(|value| event.completed < value) {
+            self.started.insert(event.phase, Instant::now());
+            self.progress.stage_start(pipeline_phase_name(event.phase));
+        }
+        if event.phase == H3PipelinePhase::Denoise && event.completed > 0 {
+            self.progress.emit(ProgressEvent::DenoiseStep {
+                step: event.completed,
+                total: event.total,
+                elapsed: Duration::ZERO,
+            });
+        }
+        if event.completed == event.total && previous != Some(event.completed) {
+            let elapsed = self
+                .started
+                .remove(&event.phase)
+                .map_or(Duration::ZERO, |started| started.elapsed());
+            match event.phase {
+                H3PipelinePhase::PromptEncode => self.progress.phase_done(
+                    ProgressPhase::PromptEncode,
+                    pipeline_phase_name(event.phase),
+                    elapsed,
+                ),
+                H3PipelinePhase::VisualConditionEncode
+                | H3PipelinePhase::VisualConditionEncodeChunk
+                | H3PipelinePhase::VisualDecode
+                | H3PipelinePhase::VisualDecodeChunk => self.progress.phase_done(
+                    ProgressPhase::Vae,
+                    pipeline_phase_name(event.phase),
+                    elapsed,
+                ),
+                _ => self
+                    .progress
+                    .stage_done(pipeline_phase_name(event.phase), elapsed),
+            }
+        }
+        self.last_completed.insert(event.phase, event.completed);
+    }
+}
+
+fn pipeline_phase_name(phase: H3PipelinePhase) -> &'static str {
+    match phase {
+        H3PipelinePhase::Validate => "Validating MiniMax H3 request",
+        H3PipelinePhase::EndpointPreprocess => "Preparing MiniMax H3 endpoints",
+        H3PipelinePhase::PromptEncode => "Encoding MiniMax H3 prompt",
+        H3PipelinePhase::VisualConditionEncode => "Encoding MiniMax H3 visual conditions",
+        H3PipelinePhase::VisualConditionEncodeChunk => "Encoding MiniMax H3 visual condition chunk",
+        H3PipelinePhase::NoiseAllocation => "Allocating MiniMax H3 synchronized noise",
+        H3PipelinePhase::Denoise => "Denoising MiniMax H3 audio-video latents",
+        H3PipelinePhase::TransformerBlock => "Streaming MiniMax H3 transformer blocks",
+        H3PipelinePhase::VisualDecode => "Decoding MiniMax H3 video",
+        H3PipelinePhase::VisualDecodeChunk => "Decoding MiniMax H3 video chunk",
+        H3PipelinePhase::AudioDecode => "Decoding MiniMax H3 audio",
+        H3PipelinePhase::AudioDecodeChunk => "Decoding MiniMax H3 audio chunk",
+        H3PipelinePhase::VideoEncode => "Encoding MiniMax H3 H.264 video",
+        H3PipelinePhase::Mux => "Muxing MiniMax H3 synchronized audio-video",
+        H3PipelinePhase::Staged => "Staging MiniMax H3 audio-video output",
+        H3PipelinePhase::Complete => "Completing MiniMax H3 generation",
+    }
+}
+
+/// Runtime adapter over the landed, runtime-neutral FL2VA pipeline.
+pub(crate) struct H3PipelineRuntime<B> {
+    backend: B,
+    identity: H3PipelineBackendIdentity,
+    component_set_identity_sha256: String,
+}
+
+/// Explicit marker for a component backend whose main DiT path is backed by
+/// `H3BlockStreamState`. The eager landed Candle transformer intentionally
+/// does not implement this marker.
+pub(crate) trait H3StreamedFl2VaBackend: H3Fl2VaBackend + Send + Sync {
+    fn component_set_identity_sha256(&self) -> &str;
+}
+
+impl<B> H3PipelineRuntime<B>
+where
+    B: H3StreamedFl2VaBackend,
+{
+    pub(crate) fn new(backend: B, authority: &FrozenH3FactoryAuthority) -> Result<Self> {
+        let identity = backend.identity();
+        if identity.device_id != authority.device_id()
+            || identity.execution_fingerprint != authority.execution_fingerprint()
+            || backend.component_set_identity_sha256() != authority.component_set_identity_sha256()
+        {
+            bail!("MiniMax H3 pipeline backend differs from frozen factory authority");
+        }
+        Ok(Self {
+            backend,
+            identity,
+            component_set_identity_sha256: authority.component_set_identity_sha256().to_string(),
+        })
+    }
+}
+
+impl<B> H3RuntimeSession for H3PipelineRuntime<B>
+where
+    B: H3StreamedFl2VaBackend,
+{
+    fn device_id(&self) -> &str {
+        &self.identity.device_id
+    }
+
+    fn execution_fingerprint(&self) -> &str {
+        &self.identity.execution_fingerprint
+    }
+
+    fn component_set_identity_sha256(&self) -> &str {
+        &self.component_set_identity_sha256
+    }
+
+    fn generate(
+        &mut self,
+        request: &GenerateRequest,
+        progress: &ProgressReporter,
+        observer: &mut dyn H3PipelineObserver,
+    ) -> Result<H3EngineOutput> {
+        #[cfg(not(feature = "mp4"))]
+        {
+            let _ = (request, progress, observer);
+            bail!("MiniMax H3 synchronized audio-video requires Mold's mp4 feature")
+        }
+        #[cfg(feature = "mp4")]
+        {
+            let prepared = pipeline::prepare_request(request, progress, observer)?;
+            let mode = prepared.geometry.mode;
+            let staged =
+                pipeline::execute_staged(&prepared, &mut self.backend, progress, observer)?;
+            let output = pipeline::finalize_av(staged, progress, observer)?;
+            let duration_ms = u64::from(1_000_u16)
+                .checked_mul(output.mux_report.video_duration_ticks)
+                .context("MiniMax H3 output duration overflow")?
+                / u64::from(output.mux_report.video_timescale);
+            Ok(H3EngineOutput {
+                mp4: output.mp4,
+                thumbnail_png: output.thumbnail_png,
+                mode,
+                seed: output.provenance.seed,
+                width: u32::try_from(output.provenance.width)
+                    .context("MiniMax H3 output width exceeds u32")?,
+                height: u32::try_from(output.provenance.height)
+                    .context("MiniMax H3 output height exceeds u32")?,
+                frames: u32::try_from(output.provenance.frames)
+                    .context("MiniMax H3 output frames exceed u32")?,
+                fps: output.provenance.fps,
+                duration_ms,
+                audio_sample_rate: output.mux_report.sample_rate,
+                audio_channels: u32::from(output.mux_report.channels),
+                device_id: output.provenance.device_id,
+                execution_fingerprint: output.provenance.execution_fingerprint,
+                component_set_identity_sha256: self.component_set_identity_sha256.clone(),
+            })
+        }
+    }
+}
+
+/// Main-block executor paired with a cancellation-safe block loader.
+/// Implementations own any per-step hidden state; every block object passed to
+/// `forward_block` is the exact object whose residency is managed by
+/// `H3BlockStreamState`.
+pub(crate) trait H3StreamedTransformerExecutor<Block>: Send + Sync {
+    fn begin_step(
+        &mut self,
+        input: H3ForwardInput<'_>,
+        layout: &H3FrozenPackedLayout,
+        checkpoint: &mut dyn H3PipelineCheckpoint,
+    ) -> Result<()>;
+
+    fn forward_block(
+        &mut self,
+        index: usize,
+        block: &Block,
+        checkpoint: &mut dyn H3PipelineCheckpoint,
+    ) -> Result<()>;
+
+    fn finish_step(
+        &mut self,
+        checkpoint: &mut dyn H3PipelineCheckpoint,
+    ) -> Result<H3TransformerOutput>;
+
+    fn abort_step(&mut self);
+}
+
+pub(crate) trait H3StreamedDenoiser: Send + Sync {
+    fn identity(&self) -> H3PipelineBackendIdentity;
+    fn denoise(
+        &mut self,
+        input: H3ForwardInput<'_>,
+        layout: &H3FrozenPackedLayout,
+        checkpoint: &mut dyn H3PipelineCheckpoint,
+    ) -> Result<H3TransformerOutput>;
+}
+
+pub(crate) struct H3BlockStreamedDenoiser<L, A, E>
+where
+    L: H3BlockLoader,
+    A: H3BlockLease,
+    E: H3StreamedTransformerExecutor<L::Block>,
+{
+    identity: H3PipelineBackendIdentity,
+    stream: H3BlockStreamState<L, A>,
+    executor: E,
+}
+
+impl<L, A, E> H3BlockStreamedDenoiser<L, A, E>
+where
+    L: H3BlockLoader,
+    A: H3BlockLease,
+    E: H3StreamedTransformerExecutor<L::Block>,
+{
+    pub(crate) fn new(
+        identity: H3PipelineBackendIdentity,
+        plan: FrozenH3BlockStreamingPlan,
+        lease: A,
+        loader: L,
+        executor: E,
+    ) -> Result<Self> {
+        if identity.device_id != plan.device_id
+            || identity.execution_fingerprint != plan.execution_fingerprint
+        {
+            bail!("MiniMax H3 streamed denoiser differs from the frozen backend route");
+        }
+        Ok(Self {
+            identity,
+            stream: H3BlockStreamState::new(plan, lease, loader)?,
+            executor,
+        })
+    }
+}
+
+impl<L, A, E> H3StreamedDenoiser for H3BlockStreamedDenoiser<L, A, E>
+where
+    L: H3BlockLoader + Send + Sync,
+    L::Block: Send + Sync,
+    A: H3BlockLease + Send + Sync,
+    E: H3StreamedTransformerExecutor<L::Block>,
+{
+    fn identity(&self) -> H3PipelineBackendIdentity {
+        self.identity.clone()
+    }
+
+    fn denoise(
+        &mut self,
+        input: H3ForwardInput<'_>,
+        layout: &H3FrozenPackedLayout,
+        checkpoint: &mut dyn H3PipelineCheckpoint,
+    ) -> Result<H3TransformerOutput> {
+        let control = H3StreamPipelineControl::new(checkpoint);
+        self.stream.prepare(&control, |_| {})?;
+        if let Err(error) = control
+            .with_checkpoint(|checkpoint| self.executor.begin_step(input, layout, checkpoint))
+        {
+            self.executor.abort_step();
+            return Err(error);
+        }
+        let run = self.stream.run_step(
+            &control,
+            |event| control.observe(event),
+            |index, block| {
+                control.with_checkpoint(|checkpoint| {
+                    self.executor.forward_block(index, block, checkpoint)
+                })
+            },
+        );
+        if let Err(error) = run {
+            self.executor.abort_step();
+            return Err(error);
+        }
+        match control.with_checkpoint(|checkpoint| self.executor.finish_step(checkpoint)) {
+            Ok(output) => Ok(output),
+            Err(error) => {
+                self.executor.abort_step();
+                Err(error)
+            }
+        }
+    }
+}
+
+struct H3StreamPipelineControl<'a> {
+    checkpoint: RefCell<&'a mut dyn H3PipelineCheckpoint>,
+}
+
+impl<'a> H3StreamPipelineControl<'a> {
+    fn new(checkpoint: &'a mut dyn H3PipelineCheckpoint) -> Self {
+        Self {
+            checkpoint: RefCell::new(checkpoint),
+        }
+    }
+
+    fn with_checkpoint<T>(
+        &self,
+        operation: impl FnOnce(&mut dyn H3PipelineCheckpoint) -> Result<T>,
+    ) -> Result<T> {
+        operation(&mut **self.checkpoint.borrow_mut())
+    }
+
+    fn observe(&self, _event: H3BlockStreamEvent) {
+        // Before/after checkpoints below are the fallible progress authority.
+        // The ownership observer remains side-effect free because the
+        // H3BlockStreamState callback cannot return an error.
+    }
+}
+
+impl H3StreamCancellation for H3StreamPipelineControl<'_> {
+    fn checkpoint(&self, point: H3StreamCheckpoint) -> Result<()> {
+        let index = match point {
+            H3StreamCheckpoint::BeforeResidentLoad(index)
+            | H3StreamCheckpoint::BeforePrefetch(index)
+            | H3StreamCheckpoint::BeforePrefetchWait(index)
+            | H3StreamCheckpoint::BeforeBlock(index) => index,
+            H3StreamCheckpoint::AfterResidentLoad(index)
+            | H3StreamCheckpoint::AfterPrefetch(index)
+            | H3StreamCheckpoint::AfterPrefetchWait(index)
+            | H3StreamCheckpoint::AfterBlock(index) => index.saturating_add(1),
+        };
+        self.checkpoint.borrow_mut().checkpoint(H3PipelineEvent {
+            phase: H3PipelinePhase::TransformerBlock,
+            completed: index.min(50),
+            total: 50,
+        })
+    }
+}
+
+/// Combines the landed component backend with a separately streamed main DiT.
+/// The eager backend's `denoise` method is deliberately never called.
+pub(crate) struct H3StreamedPipelineBackend<B, D> {
+    components: B,
+    denoiser: D,
+    component_set_identity_sha256: String,
+}
+
+impl<B, D> H3StreamedPipelineBackend<B, D>
+where
+    B: H3Fl2VaBackend,
+    D: H3StreamedDenoiser,
+{
+    pub(crate) fn new(
+        components: B,
+        denoiser: D,
+        component_set_identity_sha256: String,
+    ) -> Result<Self> {
+        if components.identity() != denoiser.identity() {
+            bail!("MiniMax H3 component and streamed-transformer routes disagree");
+        }
+        if component_set_identity_sha256.len() != 64
+            || !component_set_identity_sha256
+                .bytes()
+                .all(|byte| byte.is_ascii_hexdigit())
+        {
+            bail!("MiniMax H3 component-set identity must be one SHA-256 digest");
+        }
+        Ok(Self {
+            components,
+            denoiser,
+            component_set_identity_sha256,
+        })
+    }
+}
+
+impl<B, D> H3Fl2VaBackend for H3StreamedPipelineBackend<B, D>
+where
+    B: H3Fl2VaBackend,
+    D: H3StreamedDenoiser,
+{
+    fn identity(&self) -> H3PipelineBackendIdentity {
+        self.components.identity()
+    }
+
+    fn device(&self) -> &Device {
+        self.components.device()
+    }
+
+    fn encode_text(
+        &mut self,
+        prompt: &str,
+        endpoints: &[H3PreparedEndpoint],
+        checkpoint: &mut dyn H3PipelineCheckpoint,
+    ) -> Result<H3TextConditioning> {
+        self.components.encode_text(prompt, endpoints, checkpoint)
+    }
+
+    fn encode_visual_condition(
+        &mut self,
+        endpoint: &H3PreparedEndpoint,
+        mode: mold_candle::minimax_h3::ConditionEncodeMode,
+        checkpoint: &mut dyn H3PipelineCheckpoint,
+    ) -> Result<Tensor> {
+        self.components
+            .encode_visual_condition(endpoint, mode, checkpoint)
+    }
+
+    fn denoise(
+        &mut self,
+        input: H3ForwardInput<'_>,
+        layout: &H3FrozenPackedLayout,
+        checkpoint: &mut dyn H3PipelineCheckpoint,
+    ) -> Result<H3TransformerOutput> {
+        if self.components.identity() != self.denoiser.identity() {
+            bail!("MiniMax H3 streamed-transformer route changed during inference");
+        }
+        self.denoiser.denoise(input, layout, checkpoint)
+    }
+
+    fn decode_video(
+        &mut self,
+        latents: &Tensor,
+        sink: &mut H3VideoEncodeSink,
+        checkpoint: &mut dyn H3PipelineCheckpoint,
+    ) -> Result<()> {
+        self.components.decode_video(latents, sink, checkpoint)
+    }
+
+    fn decode_audio(
+        &mut self,
+        latents: &StereoLatents,
+        checkpoint: &mut dyn H3PipelineCheckpoint,
+    ) -> Result<StereoWaveform> {
+        self.components.decode_audio(latents, checkpoint)
+    }
+}
+
+impl<B, D> H3StreamedFl2VaBackend for H3StreamedPipelineBackend<B, D>
+where
+    B: H3Fl2VaBackend + Send + Sync,
+    D: H3StreamedDenoiser,
+{
+    fn component_set_identity_sha256(&self) -> &str {
+        &self.component_set_identity_sha256
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    use candle_core::DType;
+    use mold_candle::minimax_h3::{H3Modality, H3PackedLayout};
+    use serde_json::json;
+
+    use super::*;
+    use crate::progress::{is_inference_cancelled, InferenceCancelled};
+    use crate::{
+        H3FactoryAuthorityInput, H3FactoryComponentAuthority, H3FactoryComponentRole,
+        H3FactoryConditionerPlacement, H3FactoryQuantizationAuthority,
+    };
+
+    const EXECUTION: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    fn sha(byte: char) -> String {
+        std::iter::repeat_n(byte, 64).collect()
+    }
+
+    fn authority() -> FrozenH3FactoryAuthority {
+        let frozen = crate::FrozenEngineConfig::resolve(
+            contract::FL2VA_COMFY,
+            &mold_core::Config::default(),
+        );
+        FrozenH3FactoryAuthority::new_contract_only(H3FactoryAuthorityInput {
+            model: contract::FL2VA_COMFY.into(),
+            device_id: "gpu-0".into(),
+            device_ordinal: 0,
+            compute_capability: (8, 9),
+            execution_fingerprint: EXECUTION.into(),
+            conditioner_placement: H3FactoryConditionerPlacement::HostCpuThenDrop,
+            qwen_parameter_bytes: 2_048,
+            qwen_activation_workspace_bytes: 1_024,
+            resident_block_count: 2,
+            prefetch_depth: 1,
+            attention_backend: frozen.attention_backend,
+            attention_chunk: frozen.attention_chunk,
+            attention_kernel_identity: "synthetic-lossless-packed-attention-v1".into(),
+            attention_qualification_sha256: sha('b'),
+            attention_full_noncausal: true,
+            attention_lossless: true,
+            attention_head_count: 56,
+            attention_head_dim: 128,
+            block_offload: true,
+            quantization: H3FactoryQuantizationAuthority::ComfyPrunedInt8ConvrotNvfp4Awq {
+                transformer_policy_sha256: sha('c'),
+                qwen_policy_sha256: sha('d'),
+                pruned_adaln_table_sha256: sha('e'),
+            },
+            components: [
+                H3FactoryComponentRole::Conditioner,
+                H3FactoryComponentRole::Transformer,
+                H3FactoryComponentRole::VisualVae,
+                H3FactoryComponentRole::AudioVae,
+            ]
+            .into_iter()
+            .enumerate()
+            .map(|(index, role)| {
+                H3FactoryComponentAuthority::new(
+                    role,
+                    sha(char::from(b'1' + index as u8)),
+                    sha(char::from(b'5' + index as u8)),
+                )
+                .unwrap()
+            })
+            .collect(),
+        })
+        .unwrap()
+    }
+
+    fn paths() -> ModelPaths {
+        ModelPaths {
+            low_noise_transformer: None,
+            low_noise_distilled_lora: None,
+            transformer: PathBuf::from("/definitely/not/read/minimax-h3/transformer"),
+            transformer_shards: Vec::new(),
+            vae: PathBuf::from("/definitely/not/read/minimax-h3/vae"),
+            spatial_upscaler: None,
+            temporal_upscaler: None,
+            distilled_lora: None,
+            t5_encoder: None,
+            clip_encoder: None,
+            t5_tokenizer: None,
+            clip_tokenizer: None,
+            clip_encoder_2: None,
+            clip_tokenizer_2: None,
+            text_encoder_files: Vec::new(),
+            text_tokenizer: None,
+            decoder: None,
+        }
+    }
+
+    fn request() -> GenerateRequest {
+        serde_json::from_value(json!({
+            "prompt": "a lighthouse in a storm",
+            "model": contract::FL2VA_COMFY,
+            "width": 32,
+            "height": 32,
+            "steps": 4,
+            "guidance": 0.0,
+            "seed": 7,
+            "batch_size": 1,
+            "output_format": "mp4",
+            "strength": 1.0,
+            "frames": 124,
+            "fps": contract::FIXED_FPS
+        }))
+        .unwrap()
+    }
+
+    struct SyntheticRuntime {
+        device: String,
+        execution: String,
+        components: String,
+    }
+
+    impl H3RuntimeSession for SyntheticRuntime {
+        fn device_id(&self) -> &str {
+            &self.device
+        }
+
+        fn execution_fingerprint(&self) -> &str {
+            &self.execution
+        }
+
+        fn component_set_identity_sha256(&self) -> &str {
+            &self.components
+        }
+
+        fn generate(
+            &mut self,
+            request: &GenerateRequest,
+            progress: &ProgressReporter,
+            observer: &mut dyn H3PipelineObserver,
+        ) -> Result<H3EngineOutput> {
+            progress.checkpoint()?;
+            for event in [
+                H3PipelineEvent {
+                    phase: H3PipelinePhase::Validate,
+                    completed: 0,
+                    total: 1,
+                },
+                H3PipelineEvent {
+                    phase: H3PipelinePhase::Validate,
+                    completed: 1,
+                    total: 1,
+                },
+                H3PipelineEvent {
+                    phase: H3PipelinePhase::Denoise,
+                    completed: 0,
+                    total: 3,
+                },
+                H3PipelineEvent {
+                    phase: H3PipelinePhase::Denoise,
+                    completed: 1,
+                    total: 3,
+                },
+                H3PipelineEvent {
+                    phase: H3PipelinePhase::Denoise,
+                    completed: 2,
+                    total: 3,
+                },
+                H3PipelineEvent {
+                    phase: H3PipelinePhase::Denoise,
+                    completed: 3,
+                    total: 3,
+                },
+                H3PipelineEvent {
+                    phase: H3PipelinePhase::Complete,
+                    completed: 1,
+                    total: 1,
+                },
+            ] {
+                observer.observe(event);
+                progress.checkpoint()?;
+            }
+            Ok(H3EngineOutput {
+                mp4: vec![0, 0, 0, 1],
+                thumbnail_png: vec![137, 80, 78, 71],
+                mode: Mode::TextToAudioVideo,
+                seed: request.seed.unwrap(),
+                width: request.width,
+                height: request.height,
+                frames: request.frames.unwrap(),
+                fps: request.fps.unwrap(),
+                duration_ms: 5_166,
+                audio_sample_rate: contract::AUDIO_SAMPLE_RATE_HZ,
+                audio_channels: contract::AUDIO_CHANNELS,
+                device_id: self.device.clone(),
+                execution_fingerprint: self.execution.clone(),
+                component_set_identity_sha256: self.components.clone(),
+            })
+        }
+    }
+
+    struct SyntheticLoader {
+        loads: Arc<AtomicUsize>,
+        wrong_device: bool,
+    }
+
+    impl H3RuntimeLoader for SyntheticLoader {
+        fn load(
+            &mut self,
+            request: H3RuntimeLoadRequest<'_>,
+            progress: &ProgressReporter,
+        ) -> Result<Box<dyn H3RuntimeSession>> {
+            progress.checkpoint()?;
+            assert_eq!(request.model_name, contract::FL2VA_COMFY);
+            assert_eq!(request.load_strategy, LoadStrategy::Eager);
+            assert_eq!(request.gpu_ordinal, 0);
+            assert!(request.block_offload);
+            assert_eq!(
+                request.paths.transformer,
+                PathBuf::from("/definitely/not/read/minimax-h3/transformer")
+            );
+            self.loads.fetch_add(1, Ordering::SeqCst);
+            Ok(Box::new(SyntheticRuntime {
+                device: if self.wrong_device {
+                    "gpu-1".into()
+                } else {
+                    request.authority.device_id().into()
+                },
+                execution: request.authority.execution_fingerprint().into(),
+                components: request.authority.component_set_identity_sha256().into(),
+            }))
+        }
+    }
+
+    fn engine(loads: Arc<AtomicUsize>, wrong_device: bool) -> H3Fl2VaEngine {
+        H3Fl2VaEngine::new_injected(
+            contract::FL2VA_COMFY.into(),
+            paths(),
+            authority(),
+            LoadStrategy::Eager,
+            0,
+            true,
+            Box::new(SyntheticLoader {
+                loads,
+                wrong_device,
+            }),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn inference_adapter_preserves_frozen_route_and_publishes_video_contract() {
+        let loads = Arc::new(AtomicUsize::new(0));
+        let mut engine = engine(Arc::clone(&loads), false);
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let captured = Arc::clone(&events);
+        engine.set_on_progress(Box::new(move |event| {
+            captured.lock().unwrap().push(event);
+        }));
+
+        for _ in 0..2 {
+            let response = engine.generate(&request()).unwrap();
+            assert!(response.images.is_empty());
+            assert_eq!(response.seed_used, 7);
+            let video = response.video.unwrap();
+            assert_eq!((video.width, video.height), (32, 32));
+            assert_eq!((video.frames, video.fps), (124, contract::FIXED_FPS));
+            assert!(video.has_audio);
+            assert_eq!(
+                video.audio_sample_rate,
+                Some(contract::AUDIO_SAMPLE_RATE_HZ)
+            );
+            assert_eq!(video.audio_channels, Some(contract::AUDIO_CHANNELS));
+        }
+        assert_eq!(loads.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            engine.batch_execution_capability(),
+            BatchExecutionCapability::SINGLETON_COOPERATIVE
+        );
+        assert_eq!(engine.configured_execution_fingerprint(), Some(EXECUTION));
+        let events = events.lock().unwrap();
+        assert!(events.iter().any(|event| matches!(
+            event,
+            ProgressEvent::StageStart { name } if name.contains("frozen runtime")
+        )));
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| matches!(event, ProgressEvent::DenoiseStep { .. }))
+                .count(),
+            6
+        );
+    }
+
+    #[test]
+    fn cancellation_and_runtime_reroute_fail_without_publication_or_cache_state() {
+        let loads = Arc::new(AtomicUsize::new(0));
+        let mut cancelled = engine(Arc::clone(&loads), false);
+        let token = InferenceCancellationToken::default();
+        token.cancel();
+        cancelled.set_cancellation_token(token);
+        let error = cancelled.generate(&request()).unwrap_err();
+        assert!(is_inference_cancelled(&error));
+        assert_eq!(loads.load(Ordering::SeqCst), 0);
+        assert!(!cancelled.is_loaded());
+
+        let mut rerouted = engine(Arc::clone(&loads), true);
+        let error = rerouted.load().unwrap_err();
+        assert!(error.to_string().contains("frozen factory authority"));
+        assert_eq!(loads.load(Ordering::SeqCst), 1);
+        assert!(!rerouted.is_loaded());
+    }
+
+    #[derive(Clone)]
+    struct SyntheticBlock(usize);
+
+    struct SyntheticBlockLoader {
+        loaded: Arc<Mutex<Vec<usize>>>,
+    }
+
+    impl H3BlockLoader for SyntheticBlockLoader {
+        type Block = SyntheticBlock;
+
+        fn load_block(
+            &mut self,
+            index: usize,
+            device_id: &str,
+            execution_fingerprint: &str,
+        ) -> Result<Self::Block> {
+            assert_eq!(device_id, "synthetic-cpu-0");
+            assert_eq!(execution_fingerprint, EXECUTION);
+            self.loaded.lock().unwrap().push(index);
+            Ok(SyntheticBlock(index))
+        }
+    }
+
+    struct SyntheticLease;
+
+    impl H3BlockLease for SyntheticLease {
+        fn lease_id(&self) -> &str {
+            "synthetic-lease"
+        }
+
+        fn device_id(&self) -> &str {
+            "synthetic-cpu-0"
+        }
+
+        fn execution_fingerprint(&self) -> &str {
+            EXECUTION
+        }
+
+        fn is_active(&self) -> bool {
+            true
+        }
+    }
+
+    struct SyntheticExecutor {
+        forwarded: Arc<Mutex<Vec<usize>>>,
+        input: Option<(Tensor, Tensor)>,
+        aborted: Arc<AtomicUsize>,
+    }
+
+    impl H3StreamedTransformerExecutor<SyntheticBlock> for SyntheticExecutor {
+        fn begin_step(
+            &mut self,
+            input: H3ForwardInput<'_>,
+            _layout: &H3FrozenPackedLayout,
+            _checkpoint: &mut dyn H3PipelineCheckpoint,
+        ) -> Result<()> {
+            self.input = Some((input.video_rows.clone(), input.audio_rows.clone()));
+            Ok(())
+        }
+
+        fn forward_block(
+            &mut self,
+            index: usize,
+            block: &SyntheticBlock,
+            _checkpoint: &mut dyn H3PipelineCheckpoint,
+        ) -> Result<()> {
+            assert_eq!(index, block.0);
+            self.forwarded.lock().unwrap().push(index);
+            Ok(())
+        }
+
+        fn finish_step(
+            &mut self,
+            _checkpoint: &mut dyn H3PipelineCheckpoint,
+        ) -> Result<H3TransformerOutput> {
+            let (video, audio) = self.input.take().unwrap();
+            Ok(H3TransformerOutput {
+                video: Tensor::zeros_like(&video)?,
+                audio: Tensor::zeros_like(&audio)?,
+            })
+        }
+
+        fn abort_step(&mut self) {
+            self.input = None;
+            self.aborted.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingCheckpoint {
+        events: Vec<H3PipelineEvent>,
+        cancel_after_block: Option<usize>,
+    }
+
+    impl H3PipelineCheckpoint for RecordingCheckpoint {
+        fn checkpoint(&mut self, event: H3PipelineEvent) -> Result<()> {
+            self.events.push(event);
+            if self.cancel_after_block == Some(event.completed) {
+                Err(InferenceCancelled.into())
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    fn frozen_layout() -> H3FrozenPackedLayout {
+        H3PackedLayout::new(
+            vec![[0.0; 3]; 3],
+            vec![0, 1, 2],
+            vec![
+                H3Modality::Video as u32,
+                H3Modality::Audio as u32,
+                H3Modality::Text as u32,
+            ],
+            vec![0],
+            vec![1],
+            vec![2],
+        )
+        .unwrap()
+        .freeze(&Device::Cpu)
+        .unwrap()
+    }
+
+    fn forward_inputs() -> (Tensor, Tensor, Tensor, Tensor) {
+        (
+            Tensor::zeros((1, 1, 2), DType::F32, &Device::Cpu).unwrap(),
+            Tensor::zeros((1, 1, 3), DType::F32, &Device::Cpu).unwrap(),
+            Tensor::zeros((1, 1, 4), DType::F32, &Device::Cpu).unwrap(),
+            Tensor::zeros(3, DType::F32, &Device::Cpu).unwrap(),
+        )
+    }
+
+    #[test]
+    fn streamed_denoiser_executes_exact_blocks_and_reuses_only_resident_objects() {
+        let loaded = Arc::new(Mutex::new(Vec::new()));
+        let forwarded = Arc::new(Mutex::new(Vec::new()));
+        let aborted = Arc::new(AtomicUsize::new(0));
+        let identity = H3PipelineBackendIdentity {
+            kind: super::super::pipeline::H3PipelineBackendKind::SyntheticCpu,
+            device_id: "synthetic-cpu-0".into(),
+            execution_fingerprint: EXECUTION.into(),
+        };
+        let plan = FrozenH3BlockStreamingPlan::new("synthetic-cpu-0", EXECUTION, 2, 1).unwrap();
+        let mut denoiser = H3BlockStreamedDenoiser::new(
+            identity,
+            plan,
+            SyntheticLease,
+            SyntheticBlockLoader {
+                loaded: Arc::clone(&loaded),
+            },
+            SyntheticExecutor {
+                forwarded: Arc::clone(&forwarded),
+                input: None,
+                aborted: Arc::clone(&aborted),
+            },
+        )
+        .unwrap();
+        let layout = frozen_layout();
+        let mut checkpoint = RecordingCheckpoint::default();
+
+        for _ in 0..2 {
+            let (video, audio, text, timesteps) = forward_inputs();
+            let output = denoiser
+                .denoise(
+                    H3ForwardInput {
+                        video_rows: &video,
+                        audio_rows: &audio,
+                        text_states: &text,
+                        timesteps: &timesteps,
+                    },
+                    &layout,
+                    &mut checkpoint,
+                )
+                .unwrap();
+            assert_eq!(output.video.dims(), video.dims());
+            assert_eq!(output.audio.dims(), audio.dims());
+        }
+
+        assert_eq!(
+            *forwarded.lock().unwrap(),
+            (0..50).chain(0..50).collect::<Vec<_>>()
+        );
+        let loaded = loaded.lock().unwrap();
+        assert_eq!(loaded.iter().filter(|&&index| index < 2).count(), 2);
+        assert_eq!(loaded.iter().filter(|&&index| index >= 2).count(), 48 * 2);
+        drop(loaded);
+        assert_eq!(aborted.load(Ordering::SeqCst), 0);
+        assert!(checkpoint.events.iter().all(|event| {
+            event.phase == H3PipelinePhase::TransformerBlock && event.total == 50
+        }));
+
+        let forwarded_before_cancel = forwarded.lock().unwrap().len();
+        checkpoint.cancel_after_block = Some(3);
+        let (video, audio, text, timesteps) = forward_inputs();
+        let error = denoiser
+            .denoise(
+                H3ForwardInput {
+                    video_rows: &video,
+                    audio_rows: &audio,
+                    text_states: &text,
+                    timesteps: &timesteps,
+                },
+                &layout,
+                &mut checkpoint,
+            )
+            .unwrap_err();
+        assert!(is_inference_cancelled(&error));
+        assert_eq!(aborted.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            &forwarded.lock().unwrap()[forwarded_before_cancel..],
+            &[0, 1]
+        );
+
+        checkpoint.cancel_after_block = None;
+        let (video, audio, text, timesteps) = forward_inputs();
+        denoiser
+            .denoise(
+                H3ForwardInput {
+                    video_rows: &video,
+                    audio_rows: &audio,
+                    text_states: &text,
+                    timesteps: &timesteps,
+                },
+                &layout,
+                &mut checkpoint,
+            )
+            .expect("the streamed state must remain reusable after cooperative cancellation");
+        assert_eq!(aborted.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            &forwarded.lock().unwrap()[forwarded_before_cancel + 2..],
+            &(0..50).collect::<Vec<_>>()
+        );
+    }
+}

--- a/crates/mold-inference/src/minimax_h3/engine.rs
+++ b/crates/mold-inference/src/minimax_h3/engine.rs
@@ -342,13 +342,19 @@ impl H3PipelineObserver for H3EngineProgressObserver<'_> {
                 .remove(&event.phase)
                 .map_or(Duration::ZERO, |started| started.elapsed());
             match event.phase {
-                H3PipelinePhase::PromptEncode => self.progress.phase_done(
+                H3PipelinePhase::QwenEncode
+                | H3PipelinePhase::QwenEncodeChunk
+                | H3PipelinePhase::PromptEncode => self.progress.phase_done(
                     ProgressPhase::PromptEncode,
                     pipeline_phase_name(event.phase),
                     elapsed,
                 ),
                 H3PipelinePhase::VisualConditionEncode
                 | H3PipelinePhase::VisualConditionEncodeChunk
+                | H3PipelinePhase::ReferenceVisualEncode
+                | H3PipelinePhase::ReferenceVisualEncodeChunk
+                | H3PipelinePhase::ReferenceAudioEncode
+                | H3PipelinePhase::ReferenceAudioEncodeChunk
                 | H3PipelinePhase::VisualDecode
                 | H3PipelinePhase::VisualDecodeChunk => self.progress.phase_done(
                     ProgressPhase::Vae,
@@ -368,9 +374,19 @@ fn pipeline_phase_name(phase: H3PipelinePhase) -> &'static str {
     match phase {
         H3PipelinePhase::Validate => "Validating MiniMax H3 request",
         H3PipelinePhase::EndpointPreprocess => "Preparing MiniMax H3 endpoints",
+        H3PipelinePhase::ReferenceDecode => "Decoding MiniMax H3 references",
+        H3PipelinePhase::ReferenceDecodeChunk => "Decoding MiniMax H3 reference chunk",
+        H3PipelinePhase::ReferencePreprocess => "Preparing MiniMax H3 references",
+        H3PipelinePhase::ReferencePreprocessChunk => "Preparing MiniMax H3 reference chunk",
+        H3PipelinePhase::QwenEncode => "Encoding MiniMax H3 multimodal conditioning",
+        H3PipelinePhase::QwenEncodeChunk => "Encoding MiniMax H3 conditioning chunk",
         H3PipelinePhase::PromptEncode => "Encoding MiniMax H3 prompt",
         H3PipelinePhase::VisualConditionEncode => "Encoding MiniMax H3 visual conditions",
         H3PipelinePhase::VisualConditionEncodeChunk => "Encoding MiniMax H3 visual condition chunk",
+        H3PipelinePhase::ReferenceVisualEncode => "Encoding MiniMax H3 visual references",
+        H3PipelinePhase::ReferenceVisualEncodeChunk => "Encoding MiniMax H3 visual reference chunk",
+        H3PipelinePhase::ReferenceAudioEncode => "Encoding MiniMax H3 audio references",
+        H3PipelinePhase::ReferenceAudioEncodeChunk => "Encoding MiniMax H3 audio reference chunk",
         H3PipelinePhase::NoiseAllocation => "Allocating MiniMax H3 synchronized noise",
         H3PipelinePhase::Denoise => "Denoising MiniMax H3 audio-video latents",
         H3PipelinePhase::TransformerBlock => "Streaming MiniMax H3 transformer blocks",

--- a/crates/mold-inference/src/minimax_h3/mod.rs
+++ b/crates/mold-inference/src/minimax_h3/mod.rs
@@ -5,6 +5,7 @@
 //! frozen placement and issued component lease.
 
 pub(crate) mod backend;
+pub(crate) mod engine;
 pub(crate) mod offload;
 pub(crate) mod pipeline;
 pub(crate) mod sampler;

--- a/crates/mold-server/src/execution_plan.rs
+++ b/crates/mold-server/src/execution_plan.rs
@@ -950,6 +950,8 @@ fn prepared_config_overlay(
 
 #[derive(Clone, Debug, thiserror::Error, Eq, PartialEq)]
 pub enum ExecutionPlanError {
+    #[error("model activation rejected execution planning: {0}")]
+    ModelActivation(String),
     #[error("model '{model}' has no concrete local artifact paths")]
     MissingArtifacts { model: String },
     #[error("component {role:?} is pinned to CPU, but family '{family}' does not support that placement")]
@@ -1012,6 +1014,18 @@ pub fn capabilities_for_family(family: &str) -> PlacementCapabilities {
     }
 }
 
+fn require_execution_plan_activation(model: &str, family: &str) -> Result<(), ExecutionPlanError> {
+    if mold_core::minimax_h3::is_family(family)
+        || mold_core::minimax_h3::capability_contract_for_model(model).is_some()
+    {
+        return Err(ExecutionPlanError::ModelActivation(
+            crate::h3_admission::reject_normal_h3_admission(model, family).to_string(),
+        ));
+    }
+    mold_core::require_model_activation(model, Some(family))
+        .map_err(|error| ExecutionPlanError::ModelActivation(error.to_string()))
+}
+
 /// Resolve hard request/config placement before dependency preparation.
 ///
 /// This is intentionally artifact-only: it filters irrelevant sibling GPUs
@@ -1022,11 +1036,6 @@ pub fn eligible_devices_for_request(
     request: &GenerateRequest,
     devices: &[DeviceFact],
 ) -> Result<Vec<DeviceFact>, ExecutionPlanError> {
-    let paths = ModelPaths::resolve(&request.model, config).ok_or_else(|| {
-        ExecutionPlanError::MissingArtifacts {
-            model: request.model.clone(),
-        }
-    })?;
     let family = config
         .resolved_model_config(&request.model)
         .family
@@ -1035,6 +1044,12 @@ pub fn eligible_devices_for_request(
                 .map(|manifest| manifest.family.clone())
         })
         .unwrap_or_else(|| "unknown".to_string());
+    require_execution_plan_activation(&request.model, &family)?;
+    let paths = ModelPaths::resolve(&request.model, config).ok_or_else(|| {
+        ExecutionPlanError::MissingArtifacts {
+            model: request.model.clone(),
+        }
+    })?;
     let capabilities = capabilities_for_family(&family);
     let engine_config = mold_inference::FrozenEngineConfig::resolve(&request.model, config);
     if let Some(alias) = unresolvable_camera_control_alias(config, request) {
@@ -1137,11 +1152,6 @@ fn resolve_execution_plans_with_policy(
 ) -> Result<Vec<ResolvedExecutionPlan>, ExecutionPlanError> {
     let overlaid_config = prepared_config_overlay(config, request, prepared);
     let config = overlaid_config.as_ref().unwrap_or(config);
-    let paths = ModelPaths::resolve(&request.model, config).ok_or_else(|| {
-        ExecutionPlanError::MissingArtifacts {
-            model: request.model.clone(),
-        }
-    })?;
     let family = config
         .resolved_model_config(&request.model)
         .family
@@ -1150,6 +1160,12 @@ fn resolve_execution_plans_with_policy(
                 .map(|manifest| manifest.family.clone())
         })
         .unwrap_or_else(|| "unknown".to_string());
+    require_execution_plan_activation(&request.model, &family)?;
+    let paths = ModelPaths::resolve(&request.model, config).ok_or_else(|| {
+        ExecutionPlanError::MissingArtifacts {
+            model: request.model.clone(),
+        }
+    })?;
     let capabilities = capabilities_for_family(&family);
     if offload_requested && !capabilities.supports_block_offload {
         return Err(ExecutionPlanError::UnsupportedOffload { family });
@@ -1413,6 +1429,7 @@ pub fn validate_before_cuda(
     request: &GenerateRequest,
     prepared: Option<&PreparedExecutionInputs>,
 ) -> Result<(), ExecutionPlanError> {
+    require_execution_plan_activation(&request.model, &plan.model_family)?;
     if plan.device_id != worker_device_id || plan.device_ordinal != worker_ordinal {
         return Err(ExecutionPlanError::PlanInvalidated(format!(
             "lease targets {worker_device_id}/gpu:{worker_ordinal}, plan targets {}/gpu:{}",
@@ -3682,6 +3699,19 @@ mod tests {
         .unwrap();
         request.placement = placement;
         request
+    }
+
+    #[test]
+    fn h3_activation_gate_precedes_artifact_resolution_in_normal_planning() {
+        let root = TempDir::new().unwrap();
+        let config = config(root.path(), "minimax-h3", None);
+        let error = resolve_execution_plans(&config, &request(None), &devices(&[24 * GIB]), false)
+            .unwrap_err();
+
+        assert!(matches!(error, ExecutionPlanError::ModelActivation(_)));
+        assert!(error
+            .to_string()
+            .contains(mold_core::MINIMAX_H3_AUTHORIZATION_REQUIRED));
     }
 
     #[test]

--- a/crates/mold-server/src/h3_admission.rs
+++ b/crates/mold-server/src/h3_admission.rs
@@ -1348,6 +1348,98 @@ pub(crate) fn plan_h3_admission(
     Ok(plan)
 }
 
+/// Fully synthetic/injected inputs for the ordinary generation admission
+/// bridge. The shipping bridge has no source for these facts: authorization,
+/// a runnable capability, exact landed artifact identities, and qualified
+/// header/runtime evidence must all land before a real source is registered.
+pub(crate) struct H3NormalAdmissionInputs {
+    pub(crate) task: H3FrozenTask,
+    pub(crate) shape: H3PreparedRequestShape,
+    pub(crate) artifacts: H3ArtifactInventory,
+    pub(crate) checkpoint: H3CheckpointMemoryFacts,
+    pub(crate) runtime: H3QualifiedRuntimeFacts,
+    pub(crate) devices: Vec<H3AdmissionDevice>,
+    pub(crate) host: H3HostMemory,
+    pub(crate) policy: H3AdmissionPolicy,
+}
+
+#[derive(Debug, Error, Eq, PartialEq)]
+pub(crate) enum H3NormalAdmissionError {
+    #[error("{0}")]
+    Activation(String),
+    #[error("MiniMax H3 public runnable capability remains disabled")]
+    RuntimeUnavailable,
+    #[error("{H3_REAL_ADMISSION_SOURCE_DISABLED}")]
+    RealSourceDisabled,
+    #[error(transparent)]
+    Admission(#[from] H3AdmissionError),
+}
+
+pub(crate) const H3_REAL_ADMISSION_SOURCE_DISABLED: &str =
+    "MiniMax H3 real artifact/header admission source is runtime-disabled pending authorization and exact artifact identities";
+
+fn plan_normal_h3_admission_with_gates<G, S>(
+    model: &str,
+    family: &str,
+    activation_gate: G,
+    runtime_available: bool,
+    source: S,
+) -> Result<H3FrozenExecutionPlan, H3NormalAdmissionError>
+where
+    G: FnOnce() -> Result<(), mold_core::ModelActivationError>,
+    S: FnOnce() -> Result<H3NormalAdmissionInputs, H3NormalAdmissionError>,
+{
+    activation_gate().map_err(|error| H3NormalAdmissionError::Activation(error.to_string()))?;
+    if !runtime_available {
+        return Err(H3NormalAdmissionError::RuntimeUnavailable);
+    }
+    let inputs = source()?;
+    if inputs.artifacts.model
+        != minimax_h3::capability_contract_for_model(model)
+            .map(|contract| contract.canonical_model)
+            .unwrap_or_default()
+        || !minimax_h3::is_family(family)
+    {
+        return Err(H3NormalAdmissionError::Admission(
+            H3AdmissionError::InvalidArtifactFacts(
+                "normal H3 admission source differs from the requested model family".to_string(),
+            ),
+        ));
+    }
+    Ok(plan_h3_admission(
+        inputs.task,
+        inputs.shape,
+        &inputs.artifacts,
+        &inputs.checkpoint,
+        Some(&inputs.runtime),
+        &inputs.devices,
+        inputs.host,
+        inputs.policy,
+    )?)
+}
+
+/// Ordinary placement entry point while H3 is disabled.
+///
+/// Ordering is load-bearing: the #831 gate runs first, then the public runtime
+/// registry, and only then may a source gather paths, headers, or runtime
+/// facts. Today the source is an unconditional error, so even a future legal
+/// decision cannot accidentally start artifact work without a separate loader
+/// registration and exact identities.
+pub(crate) fn reject_normal_h3_admission(model: &str, family: &str) -> H3NormalAdmissionError {
+    let result = plan_normal_h3_admission_with_gates(
+        model,
+        family,
+        || mold_core::require_model_activation(model, Some(family)),
+        minimax_h3::runnable_capability_contract_for_model(model).is_some()
+            && mold_inference::production_family_capability_for_family(family).is_some(),
+        || Err(H3NormalAdmissionError::RealSourceDisabled),
+    );
+    match result {
+        Err(error) => error,
+        Ok(_) => H3NormalAdmissionError::RealSourceDisabled,
+    }
+}
+
 /// Bind a fully admitted server plan into the inference factory without
 /// exposing paths or bytes and without activating an H3 loader.
 ///
@@ -1862,6 +1954,74 @@ mod tests {
 
     fn prepared(model: &str, frames: u32) -> (H3FrozenTask, H3PreparedRequestShape) {
         H3PreparedRequestShape::from_prepared_request(&request(model, frames), 128, 0).unwrap()
+    }
+
+    #[test]
+    fn normal_admission_never_reads_facts_before_activation_and_runtime_gates() {
+        let source_calls = std::cell::Cell::new(0_u8);
+        let error = plan_normal_h3_admission_with_gates(
+            minimax_h3::FL2VA_COMFY,
+            minimax_h3::FAMILY,
+            || Err(mold_core::ModelActivationError),
+            true,
+            || {
+                source_calls.set(source_calls.get() + 1);
+                Err(H3NormalAdmissionError::RealSourceDisabled)
+            },
+        )
+        .unwrap_err();
+        assert!(matches!(error, H3NormalAdmissionError::Activation(_)));
+        assert_eq!(source_calls.get(), 0);
+
+        let error = plan_normal_h3_admission_with_gates(
+            minimax_h3::FL2VA_COMFY,
+            minimax_h3::FAMILY,
+            || Ok(()),
+            false,
+            || {
+                source_calls.set(source_calls.get() + 1);
+                Err(H3NormalAdmissionError::RealSourceDisabled)
+            },
+        )
+        .unwrap_err();
+        assert_eq!(error, H3NormalAdmissionError::RuntimeUnavailable);
+        assert_eq!(source_calls.get(), 0);
+    }
+
+    #[test]
+    fn normal_admission_bridge_delegates_to_the_canonical_h3_planner() {
+        let inventory = landed_inventory(minimax_h3::FL2VA_COMFY);
+        let checkpoint = checkpoint(&inventory);
+        let runtime = qualified_runtime();
+        let (task, shape) = prepared(minimax_h3::FL2VA_COMFY, 124);
+        let plan = plan_normal_h3_admission_with_gates(
+            minimax_h3::FL2VA_COMFY,
+            minimax_h3::FAMILY,
+            || Ok(()),
+            true,
+            || {
+                Ok(H3NormalAdmissionInputs {
+                    task,
+                    shape,
+                    artifacts: inventory,
+                    checkpoint,
+                    runtime,
+                    devices: vec![cuda(24 * GIB)],
+                    host: H3HostMemory {
+                        total_bytes: 96 * GIB,
+                        available_bytes: 96 * GIB,
+                    },
+                    policy: H3AdmissionPolicy::default(),
+                })
+            },
+        )
+        .unwrap();
+
+        assert_eq!(plan.canonical_model, minimax_h3::FL2VA_COMFY);
+        assert_eq!(plan.device_id, "gpu-0");
+        assert_eq!(plan.compute_capability, (8, 9));
+        assert_eq!(plan.execution_fingerprint.len(), 64);
+        plan.validate_execution_fingerprint().unwrap();
     }
 
     #[test]

--- a/crates/mold-server/src/queue.rs
+++ b/crates/mold-server/src/queue.rs
@@ -4111,6 +4111,114 @@ mod tests {
     }
 
     #[test]
+    fn synthetic_h3_video_publishes_synchronized_sse_and_gallery_metadata() {
+        let tmp = TempDir::new().unwrap();
+        let db = MetadataDb::open_in_memory().unwrap();
+        let mut request = fake_request(mold_core::minimax_h3::FL2VA_COMFY);
+        request.width = 1344;
+        request.height = 768;
+        request.frames = Some(124);
+        request.fps = Some(24);
+        request.output_format = Some(OutputFormat::Mp4);
+        request.enable_audio = Some(true);
+
+        let video = mold_core::VideoData {
+            data: b"synthetic-h3-mp4-with-synchronized-audio".to_vec(),
+            format: OutputFormat::Mp4,
+            width: 1344,
+            height: 768,
+            frames: 124,
+            fps: 24,
+            pipeline: None,
+            thumbnail: b"synthetic-h3-thumbnail".to_vec(),
+            gif_preview: Vec::new(),
+            has_audio: true,
+            duration_ms: Some(5_167),
+            audio_sample_rate: Some(mold_core::minimax_h3::AUDIO_SAMPLE_RATE_HZ),
+            audio_channels: Some(mold_core::minimax_h3::AUDIO_CHANNELS),
+        };
+        let response = mold_core::GenerateResponse {
+            images: Vec::new(),
+            video: Some(video.clone()),
+            audio: None,
+            generation_time_ms: 12_345,
+            model: mold_core::minimax_h3::FL2VA_COMFY.to_string(),
+            seed_used: 42,
+            gpu: Some(0),
+        };
+        let mut metadata =
+            OutputMetadata::from_generate_request(&request, response.seed_used, None, "test");
+        metadata.apply_video_output(&video);
+        let gallery_gate = crate::batch_transaction::GalleryPublicationGate::default();
+        let filename = save_video_to_dir(
+            tmp.path(),
+            &video.data,
+            &video.gif_preview,
+            video.format,
+            &request.model,
+            &metadata,
+            Some(response.generation_time_ms as i64),
+            Some(&db),
+            None,
+            &gallery_gate,
+        )
+        .expect("synthetic publication should allocate one gallery filename");
+        assert_eq!(
+            std::fs::read(tmp.path().join(&filename)).unwrap(),
+            video.data
+        );
+
+        let rows = db.list(Some(tmp.path())).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].metadata.model, mold_core::minimax_h3::FL2VA_COMFY);
+        assert_eq!(rows[0].metadata.seed, 42);
+        assert_eq!(rows[0].metadata.frames, Some(124));
+        assert_eq!(rows[0].metadata.fps, Some(24));
+        assert_eq!(rows[0].metadata.enable_audio, Some(true));
+
+        let thumbnail = ImageData {
+            data: video.thumbnail.clone(),
+            format: OutputFormat::Png,
+            width: video.width,
+            height: video.height,
+            index: 0,
+        };
+        let message = build_sse_completion_message(
+            &response,
+            &thumbnail,
+            None,
+            Some(&metadata),
+            &SavedOutputNames {
+                output: Some(filename.clone()),
+                original: None,
+            },
+            SseCompletionPayload::MetadataOnly,
+        );
+        let SseMessage::Complete(event) = message else {
+            panic!("saved synthetic H3 video must complete over SSE")
+        };
+        assert_eq!(event.filename.as_deref(), Some(filename.as_str()));
+        assert_eq!(event.model, mold_core::minimax_h3::FL2VA_COMFY);
+        assert_eq!(event.format, OutputFormat::Mp4);
+        assert_eq!(event.video_frames, Some(124));
+        assert_eq!(event.video_fps, Some(24));
+        assert!(event.video_has_audio);
+        assert_eq!(
+            event.video_audio_sample_rate,
+            Some(mold_core::minimax_h3::AUDIO_SAMPLE_RATE_HZ)
+        );
+        assert_eq!(
+            event.video_audio_channels,
+            Some(mold_core::minimax_h3::AUDIO_CHANNELS)
+        );
+        assert_eq!(event.metadata.as_ref().map(|value| value.seed), Some(42));
+        assert!(
+            event.image.is_empty(),
+            "metadata-only SSE must not duplicate MP4 bytes"
+        );
+    }
+
+    #[test]
     fn named_video_replay_keeps_one_gallery_file_and_row() {
         let tmp = TempDir::new().unwrap();
         let db = MetadataDb::open_in_memory().unwrap();


### PR DESCRIPTION
## Base

#863 is merged. This PR is rebased directly onto `main`; range-diff preserved both commits exactly.

## Summary

- add a concrete MiniMax H3 FL2VA `InferenceEngine` seam around the landed runtime-neutral pipeline and frozen factory authority
- enforce normal server ordering: compliance gate → static runtime/registry gate → frozen authority → future loader
- carry one admitted CUDA route through prompt/endpoint preparation, denoise orchestration, cancellation, and synchronized AV publication
- map all FL2VA and Ref2VA pipeline phases into stable progress events
- prove the existing worker transaction persists MP4 bytes, 32 kHz stereo metadata, model/seed/shape, filename-only SSE completion, and gallery/archive metadata consistently

## Safety boundary

- runtime, batch capability, catalogs, manifests, downloads, and public support remain unavailable
- the production adapter has no model locator or executable component bundle
- synthetic CPU backends are test-binary-only
- no artifact path, checkpoint/header byte, H3 weight, or generated H3 output was accessed
- authorization alone still cannot reach a loader

## Verification

- H3 engine tests: 3/3
- server H3 tests: 48/48
- focused inference/server Clippy with warnings denied
- Rustfmt and diff checks
- Nix-devshell inference check after Ref2VA phase integration
- stacked desktop rerun: Linux and macOS green on exact pre-rebase tree

Stable patch IDs remain `d5257001e454c8380fa3226176d6910bdd33ebe2` for the engine seam plus the focused Ref2VA-progress fix. Full main-target CI is now authoritative. Real-model UAT remains blocked by #831.

Refs #838, #827, #831.