### PR TITLE
feat(h3): add scaled FP8 and Qwen INT8 execution

### DIFF
--- a/crates/mold-candle/src/minimax_h3/artifacts.rs
+++ b/crates/mold-candle/src/minimax_h3/artifacts.rs
@@ -548,7 +548,7 @@ fn is_regenerable_rotary_buffer(name: &str) -> bool {
     )
 }
 
-fn expected_materialized_keys() -> BTreeSet<String> {
+pub(super) fn expected_materialized_keys() -> BTreeSet<String> {
     let mut keys = BTreeSet::new();
     keys.insert("model.language_model.embed_tokens.weight".into());
     for layer in 0..H3_SELECTED_LANGUAGE_LAYERS {

--- a/crates/mold-candle/src/minimax_h3/comfy_quant.rs
+++ b/crates/mold-candle/src/minimax_h3/comfy_quant.rs
@@ -7,13 +7,18 @@
 //! supplied by the caller and do not discover, open, download, or register H3
 //! artifacts.
 //!
-//! Two representations intentionally remain distinct:
+//! Four representations/execution policies intentionally remain distinct:
 //!
 //! - The pruned DiT stores INT8 weights after a regular, normalized, 256-wide
 //!   ConvRot transform and carries one F32 scale per output row. A portable
 //!   forward rotates the activation in F32, streams output-row chunks, and
 //!   multiplies by the stored row scale without retaining a dense weight.
-//! - The Qwen3-VL conditioner stores high-nibble-first NVFP4 weights with
+//! - The pruned DiT's scaled FP8 matrices retain E4M3 weights plus scalar F32
+//!   weight/input scales. Their reference path preserves the source QDQ order
+//!   and accumulates against bounded, reconstructed F32 weight chunks.
+//! - The Qwen3-VL INT8 ConvRot variant reconstructs bounded weight chunks and
+//!   runs an ordinary floating-point matmul; it does not quantize activations.
+//! - The Qwen3-VL NVFP4 variant stores high-nibble-first weights with
 //!   swizzled FP8-E4M3 block scales, an F32 tensor scale, and an AWQ-style
 //!   `pre_quant_scale`. Comfy deliberately selects full-precision matrix
 //!   multiplication for text encoders, so the portable forward dequantizes
@@ -160,7 +165,160 @@ fn regular_hadamard(device: &Device) -> Result<Tensor> {
     )
 }
 
-/// CPU-backed INT8 ConvRot weight for the Comfy pruned H3 DiT.
+/// CPU-backed per-tensor FP8-E4M3 linear used by Comfy's scaled H3 DiT.
+///
+/// Both scales use the source convention, not its reciprocal:
+///
+/// ```text
+/// q(x) = fp8(clamp(x / input_scale, -448, 448))
+/// y = (f32(q(x)) * input_scale)
+///     @ (f32(weight) * weight_scale)^T + bias
+/// ```
+///
+/// The portable reference path deliberately executes the reconstructed
+/// multiplication in F32. It establishes the exact quantize/dequantize and
+/// scale ordering without claiming a qualified native FP8 kernel. Construction
+/// accepts only caller-supplied tensors and never discovers or reads an H3
+/// artifact.
+#[derive(Clone, Debug)]
+pub struct H3ComfyFp8ScaledLinear {
+    weight: Tensor,
+    weight_scale: f32,
+    input_scale: f32,
+    out_features: usize,
+    in_features: usize,
+}
+
+impl H3ComfyFp8ScaledLinear {
+    pub fn new(weight: Tensor, weight_scale: Tensor, input_scale: Tensor) -> Result<Self> {
+        if !weight.device().is_cpu()
+            || !weight_scale.device().is_cpu()
+            || !input_scale.device().is_cpu()
+        {
+            candle::bail!("MiniMax H3 portable scaled FP8 storage must remain on CPU")
+        }
+        if weight.dtype() != DType::F8E4M3 {
+            candle::bail!(
+                "MiniMax H3 scaled FP8 weight must use F8E4M3 storage, got {:?}",
+                weight.dtype()
+            )
+        }
+        let (out_features, in_features) = weight.dims2()?;
+        if out_features == 0 || in_features == 0 {
+            candle::bail!("MiniMax H3 scaled FP8 weight dimensions must be positive")
+        }
+        let scalar = |value: &Tensor, role: &str| -> Result<f32> {
+            if value.dtype() != DType::F32 || value.rank() != 0 {
+                candle::bail!(
+                    "MiniMax H3 scaled FP8 {role} must use an exact rank-0 F32 source tensor"
+                )
+            }
+            let value = value.to_scalar::<f32>()?;
+            if !value.is_finite() || value <= 0.0 {
+                candle::bail!("MiniMax H3 scaled FP8 {role} must be finite and positive")
+            }
+            Ok(value)
+        };
+        Ok(Self {
+            weight,
+            weight_scale: scalar(&weight_scale, "weight scale")?,
+            input_scale: scalar(&input_scale, "input scale")?,
+            out_features,
+            in_features,
+        })
+    }
+
+    pub const fn in_features(&self) -> usize {
+        self.in_features
+    }
+
+    pub const fn out_features(&self) -> usize {
+        self.out_features
+    }
+
+    pub const fn weight_scale(&self) -> f32 {
+        self.weight_scale
+    }
+
+    pub const fn input_scale(&self) -> f32 {
+        self.input_scale
+    }
+
+    /// Source-encoded weight and its two mandatory F32 scalar sidecars.
+    pub fn encoded_weight_bytes(&self) -> Result<usize> {
+        self.out_features
+            .checked_mul(self.in_features)
+            .and_then(|bytes| bytes.checked_add(2 * std::mem::size_of::<f32>()))
+            .ok_or_else(|| candle::Error::Msg("MiniMax H3 scaled FP8 byte count overflows".into()))
+    }
+
+    /// Dense F32 device-weight bytes staged for one output-row chunk.
+    pub fn portable_weight_staging_bytes(&self, rows_per_chunk: usize) -> Result<usize> {
+        if rows_per_chunk == 0 {
+            candle::bail!("MiniMax H3 scaled FP8 row chunk must be positive")
+        }
+        rows_per_chunk
+            .min(self.out_features)
+            .checked_mul(self.in_features)
+            .and_then(|elements| elements.checked_mul(std::mem::size_of::<f32>()))
+            .ok_or_else(|| {
+                candle::Error::Msg("MiniMax H3 scaled FP8 staging size overflows".into())
+            })
+    }
+
+    fn quantize_dequantize_input(&self, input: &Tensor) -> Result<Tensor> {
+        let input = input.to_dtype(DType::F32)?;
+        let scale = Tensor::new(self.input_scale, input.device())?;
+        input
+            .broadcast_div(&scale)?
+            .clamp(-448.0f32, 448.0f32)?
+            .to_dtype(DType::F8E4M3)?
+            .to_dtype(DType::F32)?
+            .broadcast_mul(&scale)
+    }
+
+    fn dequantize_rows(&self, start: usize, rows: usize, device: &Device) -> Result<Tensor> {
+        self.weight
+            .narrow(0, start, rows)?
+            .to_dtype(DType::F32)?
+            .affine(self.weight_scale as f64, 0.0)?
+            .to_device(device)
+    }
+
+    /// Execute the source-defined scaled FP8 reference operation with bounded
+    /// output-row weight staging and F32 accumulation.
+    pub fn forward_reference(
+        &self,
+        input: &Tensor,
+        bias: Option<&Tensor>,
+        output_dtype: DType,
+        rows_per_chunk: usize,
+    ) -> Result<Tensor> {
+        if rows_per_chunk == 0 {
+            candle::bail!("MiniMax H3 scaled FP8 row chunk must be positive")
+        }
+        let device = input.device();
+        let (flat, output_shape) = flattened_input(input, self.in_features)?;
+        let quantized_input = self.quantize_dequantize_input(&flat)?;
+        let mut chunks = Vec::new();
+        for start in (0..self.out_features).step_by(rows_per_chunk) {
+            let rows = rows_per_chunk.min(self.out_features - start);
+            let weight = self.dequantize_rows(start, rows, device)?;
+            chunks.push(quantized_input.matmul(&weight.t()?.contiguous()?)?);
+        }
+        finish_linear(
+            chunks,
+            bias,
+            output_dtype,
+            output_shape,
+            self.out_features,
+            device,
+        )
+    }
+}
+
+/// CPU-backed INT8 ConvRot weight for the Comfy pruned H3 DiT or Qwen
+/// conditioner.
 ///
 /// Candle does not expose a signed-I8 tensor dtype, so the checkpoint's exact
 /// two's-complement bytes are retained in a U8 tensor and widened explicitly
@@ -275,6 +433,36 @@ impl H3ComfyInt8ConvRotLinear {
         Tensor::from_vec(values, (rows, self.in_features), device)
     }
 
+    fn dequantize_rows(
+        &self,
+        start: usize,
+        rows: usize,
+        output_dtype: DType,
+        device: &Device,
+        hadamard: &Tensor,
+    ) -> Result<Tensor> {
+        let groups = self.in_features / H3_COMFY_CONVROT_GROUP_SIZE;
+        let grouped_rows = rows.checked_mul(groups).ok_or_else(|| {
+            candle::Error::Msg("MiniMax H3 INT8 grouped weight rows overflow".into())
+        })?;
+        let quantized = self.signed_rows(start, rows, device)?;
+        let scales = self
+            .weight_scale
+            .narrow(0, start, rows)?
+            .to_device(device)?
+            .reshape((rows, 1))?;
+        quantized
+            .broadcast_mul(&scales)?
+            // Candle 0.11 materializes the broadcasted RHS for
+            // `broadcast_matmul`. Flatten groups into the row dimension so the
+            // fixed 256x256 Hadamard stays singular and the bounded staging
+            // calculation remains authoritative.
+            .reshape((grouped_rows, H3_COMFY_CONVROT_GROUP_SIZE))?
+            .matmul(hadamard)?
+            .reshape((rows, self.in_features))?
+            .to_dtype(output_dtype)
+    }
+
     /// Reconstruct the dense weight in the original, unrotated basis.
     pub fn dequantize_weight(
         &self,
@@ -287,28 +475,62 @@ impl H3ComfyInt8ConvRotLinear {
             candle::bail!("MiniMax H3 INT8 row chunk must be positive")
         }
         let hadamard = regular_hadamard(device)?;
-        let groups = self.in_features / H3_COMFY_CONVROT_GROUP_SIZE;
         let mut chunks = Vec::new();
         for start in (0..self.out_features).step_by(rows_per_chunk) {
             let rows = rows_per_chunk.min(self.out_features - start);
-            let quantized = self.signed_rows(start, rows, device)?;
-            let scales = self
-                .weight_scale
-                .narrow(0, start, rows)?
-                .to_device(device)?
-                .reshape((rows, 1))?;
-            let rotated = quantized.broadcast_mul(&scales)?.reshape((
-                rows,
-                groups,
-                H3_COMFY_CONVROT_GROUP_SIZE,
-            ))?;
-            chunks.push(
-                rotated
-                    .broadcast_matmul(&hadamard)?
-                    .reshape((rows, self.in_features))?,
-            );
+            chunks.push(self.dequantize_rows(start, rows, output_dtype, device, &hadamard)?);
         }
-        Tensor::cat(&chunks, 0)?.to_dtype(output_dtype)
+        Tensor::cat(&chunks, 0)
+    }
+
+    /// Comfy's Qwen INT8 layout is weight-only: each ConvRot row chunk is
+    /// reconstructed in the input dtype, then a normal floating-point linear
+    /// operation runs without dynamically quantizing the activation. This is
+    /// intentionally distinct from the DiT's optional fused W8A8 execution.
+    pub fn forward_weight_only(
+        &self,
+        input: &Tensor,
+        bias: Option<&Tensor>,
+        output_dtype: DType,
+        rows_per_chunk: usize,
+    ) -> Result<Tensor> {
+        ensure_output_dtype(output_dtype)?;
+        if rows_per_chunk == 0 {
+            candle::bail!("MiniMax H3 INT8 row chunk must be positive")
+        }
+        let compute_dtype = input.dtype();
+        ensure_floating(compute_dtype, "Qwen INT8 weight-only compute")?;
+        let device = input.device();
+        let (flat, mut output_shape) = flattened_input(input, self.in_features)?;
+        let flat = flat.to_dtype(compute_dtype)?;
+        let hadamard = regular_hadamard(device)?;
+        let mut chunks = Vec::new();
+        for start in (0..self.out_features).step_by(rows_per_chunk) {
+            let rows = rows_per_chunk.min(self.out_features - start);
+            let weight = self.dequantize_rows(start, rows, compute_dtype, device, &hadamard)?;
+            chunks.push(flat.matmul(&weight.t()?.contiguous()?)?);
+        }
+        let mut output = Tensor::cat(&chunks, 1)?;
+        if let Some(bias) = bias {
+            ensure_floating(bias.dtype(), "Qwen INT8 weight-only bias")?;
+            if bias.dims() != [self.out_features] {
+                candle::bail!(
+                    "MiniMax H3 Qwen INT8 weight-only bias must have shape [{}], got {:?}",
+                    self.out_features,
+                    bias.dims()
+                )
+            }
+            output = output.broadcast_add(
+                &bias
+                    .to_device(device)?
+                    .to_dtype(compute_dtype)?
+                    .reshape((1, self.out_features))?,
+            )?;
+        }
+        *output_shape
+            .last_mut()
+            .expect("flattened_input established a nonempty shape") = self.out_features;
+        output.to_dtype(output_dtype)?.reshape(&*output_shape)
     }
 
     /// Portable low-memory forward equivalent to multiplying by the exact
@@ -328,11 +550,14 @@ impl H3ComfyInt8ConvRotLinear {
         let (flat, output_shape) = flattened_input(input, self.in_features)?;
         let rows = flat.dim(0)?;
         let groups = self.in_features / H3_COMFY_CONVROT_GROUP_SIZE;
+        let grouped_rows = rows.checked_mul(groups).ok_or_else(|| {
+            candle::Error::Msg("MiniMax H3 INT8 grouped activation rows overflow".into())
+        })?;
         let hadamard = regular_hadamard(device)?;
         let rotated = flat
             .to_dtype(DType::F32)?
-            .reshape((rows, groups, H3_COMFY_CONVROT_GROUP_SIZE))?
-            .broadcast_matmul(&hadamard)?
+            .reshape((grouped_rows, H3_COMFY_CONVROT_GROUP_SIZE))?
+            .matmul(&hadamard)?
             .reshape((rows, self.in_features))?;
         let mut chunks = Vec::new();
         for start in (0..self.out_features).step_by(rows_per_chunk) {
@@ -698,6 +923,97 @@ mod tests {
         swizzled
     }
 
+    #[test]
+    fn scaled_fp8_reference_applies_exact_source_scale_order() -> Result<()> {
+        let device = Device::Cpu;
+        let weight = Tensor::from_vec(
+            vec![1.0f32, 2.0, -1.0, 0.5, -2.0, 0.5, 1.0, 4.0],
+            (2, 4),
+            &device,
+        )?
+        .to_dtype(DType::F8E4M3)?;
+        let linear = H3ComfyFp8ScaledLinear::new(
+            weight,
+            Tensor::new(0.25f32, &device)?,
+            Tensor::new(0.5f32, &device)?,
+        )?;
+        let input = Tensor::from_vec(vec![0.5f32, 1.0, -0.5, 0.25], (1, 4), &device)?;
+        let bias = Tensor::from_vec(vec![0.125f32, -0.25], 2, &device)?;
+        let output = linear.forward_reference(&input, Some(&bias), DType::F32, 1)?;
+        assert_eq!(output.to_vec2::<f32>()?, vec![vec![0.90625, -0.25]]);
+        assert_eq!(linear.weight_scale(), 0.25);
+        assert_eq!(linear.input_scale(), 0.5);
+        assert_eq!(linear.encoded_weight_bytes()?, 16);
+        assert_eq!(linear.portable_weight_staging_bytes(1)?, 16);
+        Ok(())
+    }
+
+    #[test]
+    fn scaled_fp8_reference_clamps_before_cast_and_reapplies_input_scale() -> Result<()> {
+        let device = Device::Cpu;
+        let weight =
+            Tensor::from_vec(vec![1.0f32, 0.0], (1, 2), &device)?.to_dtype(DType::F8E4M3)?;
+        let linear = H3ComfyFp8ScaledLinear::new(
+            weight,
+            Tensor::new(1.0f32, &device)?,
+            Tensor::new(0.5f32, &device)?,
+        )?;
+        let input = Tensor::from_vec(vec![250.0f32, -250.0], (1, 2), &device)?;
+        assert_eq!(
+            linear
+                .forward_reference(&input, None, DType::F32, 1)?
+                .to_vec2::<f32>()?,
+            vec![vec![224.0]]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn scaled_fp8_rejects_implicit_or_invalid_dtype_and_scale_contracts() -> Result<()> {
+        let device = Device::Cpu;
+        let weight = Tensor::ones((2, 4), DType::F32, &device)?.to_dtype(DType::F8E4M3)?;
+        let scalar = Tensor::new(0.5f32, &device)?;
+        let rank_one = Tensor::from_vec(vec![0.5f32], 1, &device)?;
+        assert!(
+            H3ComfyFp8ScaledLinear::new(weight.clone(), rank_one, scalar.clone())
+                .unwrap_err()
+                .to_string()
+                .contains("rank-0 F32")
+        );
+        let zero = Tensor::new(0.0f32, &device)?;
+        assert!(
+            H3ComfyFp8ScaledLinear::new(weight.clone(), scalar.clone(), zero)
+                .unwrap_err()
+                .to_string()
+                .contains("finite and positive")
+        );
+        for invalid in [-1.0f32, f32::INFINITY, f32::NAN] {
+            assert!(H3ComfyFp8ScaledLinear::new(
+                weight.clone(),
+                scalar.clone(),
+                Tensor::new(invalid, &device)?,
+            )
+            .unwrap_err()
+            .to_string()
+            .contains("finite and positive"));
+        }
+        let half_scale = scalar.to_dtype(DType::F16)?;
+        assert!(H3ComfyFp8ScaledLinear::new(weight, half_scale, scalar)
+            .unwrap_err()
+            .to_string()
+            .contains("rank-0 F32"));
+        let dense = Tensor::ones((2, 4), DType::F32, &device)?;
+        assert!(H3ComfyFp8ScaledLinear::new(
+            dense,
+            Tensor::new(1.0f32, &device)?,
+            Tensor::new(1.0f32, &device)?,
+        )
+        .unwrap_err()
+        .to_string()
+        .contains("F8E4M3"));
+        Ok(())
+    }
+
     #[cfg(any(feature = "metal", feature = "cuda"))]
     fn synthetic_int8_forward(device: &Device) -> Result<Tensor> {
         let columns = H3_COMFY_CONVROT_GROUP_SIZE;
@@ -829,6 +1145,43 @@ mod tests {
         assert!(linear
             .forward_dequantized(&input, Some(&bias), DType::F32, 0)
             .is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn qwen_int8_weight_only_forward_dequantizes_before_float_matmul() -> Result<()> {
+        let device = Device::Cpu;
+        let rows = 3;
+        let columns = H3_COMFY_CONVROT_GROUP_SIZE;
+        let quantized = (0..rows * columns)
+            .map(|index| (((index * 17 + 3) % 23) as i8 - 11) as u8)
+            .collect::<Vec<_>>();
+        let linear = H3ComfyInt8ConvRotLinear::new(
+            Tensor::from_vec(quantized, (rows, columns), &device)?,
+            Tensor::from_vec(vec![0.03125f32, 0.0625, 0.125], (rows, 1), &device)?,
+        )?;
+        let input = Tensor::from_vec(
+            (0..2 * columns)
+                .map(|index| (index as f32 % 19.0 - 9.0) / 16.0)
+                .collect(),
+            (1, 2, columns),
+            &device,
+        )?;
+        let bias = Tensor::from_vec(vec![0.125f32, -0.25, 0.5], rows, &device)?;
+        let actual = linear.forward_weight_only(&input, Some(&bias), DType::F32, 2)?;
+        let dense = linear.dequantize_weight(DType::F32, &device, 1)?;
+        let expected = input
+            .reshape((2, columns))?
+            .matmul(&dense.t()?.contiguous()?)?
+            .broadcast_add(&bias.reshape((1, rows))?)?
+            .reshape((1, 2, rows))?;
+        assert!(max_error(&actual, &expected)? <= 2e-5);
+
+        let mut perturbed = input.flatten_all()?.to_vec1::<f32>()?;
+        perturbed[0] += 1.0 / 65_536.0;
+        let perturbed = Tensor::from_vec(perturbed, (1, 2, columns), &device)?;
+        let changed = linear.forward_weight_only(&perturbed, Some(&bias), DType::F32, 2)?;
+        assert!(max_error(&actual, &changed)? > 0.0);
         Ok(())
     }
 

--- a/crates/mold-candle/src/minimax_h3/config.rs
+++ b/crates/mold-candle/src/minimax_h3/config.rs
@@ -10,6 +10,15 @@ pub const H3_FULL_CHECKPOINT_BYTES: u64 = 66_714_780_128;
 pub const H3_BF16_PARAMETER_BYTES: u64 = 51_506_191_840;
 /// Size of Comfy's pruned single-file safetensors object, including its header.
 pub const H3_COMFY_SAFETENSORS_BYTES: u64 = 51_506_295_256;
+/// Tensor payload of Comfy's layer-50 Qwen3-VL INT8 ConvRot checkpoint.
+///
+/// This is derived without reading the published checkpoint: the 350 language
+/// projection matrices use one signed byte per parameter plus one F32 scale per
+/// output row; every other materialized tensor retains its BF16 source dtype.
+pub const H3_COMFY_INT8_CONVROT_PARAMETER_BYTES: u64 = 27_141_135_840;
+/// Public object size of Comfy's layer-50 Qwen3-VL INT8 ConvRot checkpoint,
+/// including its safetensors header.
+pub const H3_COMFY_INT8_CONVROT_SAFETENSORS_BYTES: u64 = 27_141_342_152;
 
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 pub struct H3ConditionerConfig {

--- a/crates/mold-candle/src/minimax_h3/mod.rs
+++ b/crates/mold-candle/src/minimax_h3/mod.rs
@@ -14,6 +14,7 @@ mod loader;
 mod model;
 mod presentation;
 mod processor;
+mod qwen_quant;
 mod text;
 mod vision;
 mod visual_condition;
@@ -60,11 +61,12 @@ pub use comfy_dit::{
     H3_COMFY_ORG_SOURCE_REVISION,
 };
 pub use comfy_quant::{
-    H3ComfyInt8ConvRotLinear, H3ComfyNvfp4AwqLinear, H3_COMFY_CONVROT_GROUP_SIZE,
-    H3_COMFY_NVFP4_BLOCK_SIZE, H3_COMFY_PORTABLE_ROW_CHUNK,
+    H3ComfyFp8ScaledLinear, H3ComfyInt8ConvRotLinear, H3ComfyNvfp4AwqLinear,
+    H3_COMFY_CONVROT_GROUP_SIZE, H3_COMFY_NVFP4_BLOCK_SIZE, H3_COMFY_PORTABLE_ROW_CHUNK,
 };
 pub use config::{
     H3ConditionerConfig, H3TextConfig, H3VisionConfig, H3_BF16_PARAMETER_BYTES,
+    H3_COMFY_INT8_CONVROT_PARAMETER_BYTES, H3_COMFY_INT8_CONVROT_SAFETENSORS_BYTES,
     H3_COMFY_SAFETENSORS_BYTES, H3_FULL_CHECKPOINT_BYTES, H3_FULL_LANGUAGE_LAYERS,
     H3_SELECTED_LANGUAGE_LAYERS,
 };
@@ -93,6 +95,13 @@ pub use presentation::{
 pub use processor::{
     create_mm_token_type_ids, pack_qwen_vision_u8, qwen_mrope_positions, sample_video_frames,
     GridThw, PackedVisionPatches, QwenMmTokenType, SampledVideo,
+};
+pub use qwen_quant::{
+    expected_h3_qwen_int8_weight_only_schema, validate_h3_qwen_int8_weight_only_schema,
+    H3QwenFp32Boundary, H3QwenInt8CheckpointMetadata, H3QwenInt8LayerMetadata,
+    H3QwenInt8MemoryAccounting, H3QwenInt8PolicyError, H3QwenInt8WeightOnlyPolicy,
+    H3QwenLinearExecution, H3QwenTensorDType, H3QwenTensorSpec,
+    H3_QWEN_INT8_QUANTIZED_LINEAR_COUNT, H3_QWEN_INT8_WEIGHT_ONLY_STABLE_ID,
 };
 pub use visual_condition::{
     ConditionEncodeMode, SignedRgbPixels, Uint8RgbPixels, UnitRgbPixels, H3_IMAGENET_MEAN,

--- a/crates/mold-candle/src/minimax_h3/qwen_quant.rs
+++ b/crates/mold-candle/src/minimax_h3/qwen_quant.rs
@@ -1,0 +1,759 @@
+//! Artifact-free Qwen3-VL INT8 ConvRot loader and execution policy for H3.
+//!
+//! The policy is derived from ComfyUI
+//! `a464ac33588ae182f81a090d910cfbf21e255b73` and comfy-kitchen 0.2.26
+//! (`255a43879fe57bbcbecfdb273b46d772b00c5a90`). It validates caller-supplied
+//! header/metadata descriptions only. It does not open, discover, download, or
+//! register an H3 checkpoint, and it is not runtime activation authority.
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, BTreeSet};
+use thiserror::Error;
+
+use super::artifacts::{expected_checkpoint_shapes, expected_materialized_keys};
+use super::config::{
+    H3ConditionerConfig, H3_COMFY_INT8_CONVROT_PARAMETER_BYTES,
+    H3_COMFY_INT8_CONVROT_SAFETENSORS_BYTES, H3_SELECTED_LANGUAGE_LAYERS,
+};
+use super::{H3_COMFY_CONVROT_GROUP_SIZE, H3_COMFY_PORTABLE_ROW_CHUNK};
+
+pub const H3_QWEN_INT8_WEIGHT_ONLY_STABLE_ID: &str =
+    "minimax-h3.qwen3-vl.layer50.int8-convrot-weight-only.v1";
+pub const H3_QWEN_INT8_QUANTIZED_LINEAR_COUNT: usize = 350;
+
+const LANGUAGE_LINEAR_SUFFIXES: &[&str] = &[
+    "self_attn.q_proj",
+    "self_attn.k_proj",
+    "self_attn.v_proj",
+    "self_attn.o_proj",
+    "mlp.gate_proj",
+    "mlp.up_proj",
+    "mlp.down_proj",
+];
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+pub enum H3QwenTensorDType {
+    Bf16,
+    F32,
+    I8,
+}
+
+impl H3QwenTensorDType {
+    const fn byte_width(self) -> u64 {
+        match self {
+            Self::I8 => 1,
+            Self::Bf16 => 2,
+            Self::F32 => 4,
+        }
+    }
+
+    const fn stable_id(self) -> &'static str {
+        match self {
+            Self::Bf16 => "bf16",
+            Self::F32 => "f32",
+            Self::I8 => "i8",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct H3QwenTensorSpec {
+    pub dtype: H3QwenTensorDType,
+    pub shape: Vec<usize>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct H3QwenInt8LayerMetadata {
+    pub format: String,
+    pub full_precision_matrix_mult: Option<bool>,
+    pub convrot: Option<bool>,
+    pub convrot_groupsize: Option<usize>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct H3QwenInt8CheckpointMetadata {
+    pub format_version: String,
+    pub layers: BTreeMap<String, H3QwenInt8LayerMetadata>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+pub enum H3QwenFp32Boundary {
+    TextMultimodalRotary,
+    TextAttentionScoresAndSoftmax,
+    VisionRotary,
+    VisionAttentionScoresAndSoftmax,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct H3QwenInt8MemoryAccounting {
+    pub artifact_file_bytes: u64,
+    pub header_bytes: u64,
+    pub encoded_tensor_bytes: u64,
+    pub quantized_weight_bytes: u64,
+    pub quantization_scale_bytes: u64,
+    pub protected_bf16_bytes: u64,
+    /// Exact peak scratch for default-chunk weight reconstruction: the signed
+    /// F32 source rows, scaled rows, reconstructed rows, the concurrently live
+    /// BF16/F16 conversion, per-row F32 scales, and one 256x256 F32 Hadamard
+    /// matrix. Caller-owned activation and linear output workspaces remain
+    /// request-shaped and are not hidden here.
+    pub default_dequantization_workspace_bytes: u64,
+    /// A future mmap loader would map the complete object, but mapped bytes are
+    /// not claimed as resident RAM.
+    pub host_mapped_file_bytes: u64,
+    pub host_resident_bytes: Option<u64>,
+    pub resident_device_weight_bytes: Option<u64>,
+    pub streamed_weight_bytes: Option<u64>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub enum H3QwenLinearExecution {
+    DenseBf16,
+    Int8ConvRotWeightOnly {
+        weight_scale_tensor: String,
+        group_size: usize,
+    },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct H3QwenInt8WeightOnlyPolicy {
+    stable_id: String,
+    /// Canonical official-namespace layer names without `.weight`.
+    quantized_layers: Vec<String>,
+    /// Canonical tensors that must remain dense BF16.
+    protected_tensors: Vec<String>,
+    fp32_compute_boundaries: Vec<H3QwenFp32Boundary>,
+    memory: H3QwenInt8MemoryAccounting,
+    policy_sha256: String,
+    quantized_linear_shapes: Vec<[usize; 2]>,
+}
+
+impl H3QwenInt8WeightOnlyPolicy {
+    pub fn stable_id(&self) -> &str {
+        &self.stable_id
+    }
+
+    pub fn quantized_layers(&self) -> &[String] {
+        &self.quantized_layers
+    }
+
+    pub fn protected_tensors(&self) -> &[String] {
+        &self.protected_tensors
+    }
+
+    pub fn fp32_compute_boundaries(&self) -> &[H3QwenFp32Boundary] {
+        &self.fp32_compute_boundaries
+    }
+
+    pub const fn memory(&self) -> &H3QwenInt8MemoryAccounting {
+        &self.memory
+    }
+
+    pub fn policy_sha256(&self) -> &str {
+        &self.policy_sha256
+    }
+
+    pub fn execution_for_weight(
+        &self,
+        canonical_weight: &str,
+    ) -> Result<H3QwenLinearExecution, H3QwenInt8PolicyError> {
+        let Some(layer) = canonical_weight.strip_suffix(".weight") else {
+            return Err(H3QwenInt8PolicyError::Execution(format!(
+                "Qwen execution lookup requires a canonical .weight tensor, got {canonical_weight:?}"
+            )));
+        };
+        if self
+            .quantized_layers
+            .binary_search_by(|candidate| candidate.as_str().cmp(layer))
+            .is_ok()
+        {
+            return Ok(H3QwenLinearExecution::Int8ConvRotWeightOnly {
+                weight_scale_tensor: format!("{layer}.weight_scale"),
+                group_size: H3_COMFY_CONVROT_GROUP_SIZE,
+            });
+        }
+        if self
+            .protected_tensors
+            .binary_search_by(|candidate| candidate.as_str().cmp(canonical_weight))
+            .is_ok()
+        {
+            return Ok(H3QwenLinearExecution::DenseBf16);
+        }
+        Err(H3QwenInt8PolicyError::Execution(format!(
+            "Qwen tensor {canonical_weight:?} is outside the frozen layer-50 policy"
+        )))
+    }
+
+    /// Maximum peak reconstruction scratch for any one quantized Qwen linear
+    /// at the requested output-row chunk. The portable ConvRot path holds the
+    /// signed F32 rows, scaled rows, and reconstructed rows concurrently. A
+    /// BF16/F16 compute path also allocates its converted reconstructed rows
+    /// before those temporaries leave scope. Per-row scales and the shared F32
+    /// Hadamard matrix are included; caller-owned activations and the final
+    /// linear output are excluded.
+    pub fn max_dequantization_workspace_bytes(
+        &self,
+        rows_per_chunk: usize,
+    ) -> Result<u64, H3QwenInt8PolicyError> {
+        if rows_per_chunk == 0 {
+            return Err(H3QwenInt8PolicyError::Accounting(
+                "Qwen INT8 row chunk must be positive".into(),
+            ));
+        }
+        let mut peak_reconstruction = 0_u64;
+        for [out_features, in_features] in &self.quantized_linear_shapes {
+            let rows = rows_per_chunk.min(*out_features) as u64;
+            let elements = rows.checked_mul(*in_features as u64).ok_or_else(|| {
+                H3QwenInt8PolicyError::Accounting("Qwen INT8 weight workspace overflows".into())
+            })?;
+            let row_bytes = elements.checked_mul(4).ok_or_else(|| {
+                H3QwenInt8PolicyError::Accounting("Qwen INT8 weight workspace overflows".into())
+            })?;
+            let converted_row_bytes = elements.checked_mul(2).ok_or_else(|| {
+                H3QwenInt8PolicyError::Accounting("Qwen INT8 converted workspace overflows".into())
+            })?;
+            let scale_bytes = rows.checked_mul(4).ok_or_else(|| {
+                H3QwenInt8PolicyError::Accounting("Qwen INT8 scale workspace overflows".into())
+            })?;
+            let bytes = row_bytes
+                .checked_mul(3)
+                .and_then(|bytes| bytes.checked_add(converted_row_bytes))
+                .and_then(|bytes| bytes.checked_add(scale_bytes))
+                .ok_or_else(|| {
+                    H3QwenInt8PolicyError::Accounting(
+                        "Qwen INT8 reconstruction workspace overflows".into(),
+                    )
+                })?;
+            peak_reconstruction = peak_reconstruction.max(bytes);
+        }
+        let hadamard = (H3_COMFY_CONVROT_GROUP_SIZE as u64)
+            .checked_mul(H3_COMFY_CONVROT_GROUP_SIZE as u64)
+            .and_then(|elements| elements.checked_mul(4))
+            .ok_or_else(|| {
+                H3QwenInt8PolicyError::Accounting("Qwen INT8 Hadamard workspace overflows".into())
+            })?;
+        peak_reconstruction.checked_add(hadamard).ok_or_else(|| {
+            H3QwenInt8PolicyError::Accounting("Qwen INT8 workspace overflows".into())
+        })
+    }
+}
+
+#[derive(Debug, Error, Eq, PartialEq)]
+pub enum H3QwenInt8PolicyError {
+    #[error("invalid MiniMax H3 Qwen config: {0}")]
+    Config(String),
+    #[error("invalid MiniMax H3 Qwen INT8 namespace: {0}")]
+    Namespace(String),
+    #[error("invalid MiniMax H3 Qwen INT8 metadata: {0}")]
+    Metadata(String),
+    #[error("invalid MiniMax H3 Qwen INT8 tensor schema: {0}")]
+    TensorSchema(String),
+    #[error("invalid MiniMax H3 Qwen INT8 execution lookup: {0}")]
+    Execution(String),
+    #[error("invalid MiniMax H3 Qwen INT8 accounting: {0}")]
+    Accounting(String),
+}
+
+fn canonical_quantized_layers() -> BTreeSet<String> {
+    (0..H3_SELECTED_LANGUAGE_LAYERS)
+        .flat_map(|layer| {
+            LANGUAGE_LINEAR_SUFFIXES
+                .iter()
+                .map(move |suffix| format!("model.language_model.layers.{layer}.{suffix}"))
+        })
+        .collect()
+}
+
+fn comfy_name(canonical: &str) -> String {
+    canonical
+        .strip_prefix("model.language_model.")
+        .map(|suffix| format!("model.{suffix}"))
+        .or_else(|| {
+            canonical
+                .strip_prefix("model.visual.")
+                .map(|suffix| format!("visual.{suffix}"))
+        })
+        .unwrap_or_else(|| canonical.to_owned())
+}
+
+fn checked_tensor_bytes(spec: &H3QwenTensorSpec) -> Result<u64, H3QwenInt8PolicyError> {
+    spec.shape
+        .iter()
+        .try_fold(1_u64, |elements, dimension| {
+            elements.checked_mul(*dimension as u64)
+        })
+        .and_then(|elements| elements.checked_mul(spec.dtype.byte_width()))
+        .ok_or_else(|| H3QwenInt8PolicyError::Accounting("Qwen tensor byte count overflows".into()))
+}
+
+/// Build the exact expected Comfy layer-50 schema without reading a checkpoint.
+/// The returned names use the published `model.*`/`visual.*` namespace.
+pub fn expected_h3_qwen_int8_weight_only_schema(
+    config: &H3ConditionerConfig,
+) -> Result<
+    (
+        BTreeMap<String, H3QwenTensorSpec>,
+        H3QwenInt8CheckpointMetadata,
+    ),
+    H3QwenInt8PolicyError,
+> {
+    config
+        .validate()
+        .map_err(|error| H3QwenInt8PolicyError::Config(error.to_string()))?;
+    let shapes = expected_checkpoint_shapes(config);
+    let quantized = canonical_quantized_layers();
+    let mut tensors = BTreeMap::new();
+    let mut layers = BTreeMap::new();
+    for canonical in expected_materialized_keys() {
+        let shape = shapes.get(&canonical).cloned().ok_or_else(|| {
+            H3QwenInt8PolicyError::TensorSchema(format!(
+                "missing production shape for {canonical:?}"
+            ))
+        })?;
+        let layer = canonical.strip_suffix(".weight");
+        let is_quantized = layer.is_some_and(|layer| quantized.contains(layer));
+        let raw = comfy_name(&canonical);
+        tensors.insert(
+            raw.clone(),
+            H3QwenTensorSpec {
+                dtype: if is_quantized {
+                    H3QwenTensorDType::I8
+                } else {
+                    H3QwenTensorDType::Bf16
+                },
+                shape: shape.clone(),
+            },
+        );
+        if is_quantized {
+            let layer = layer.expect("is_quantized requires a weight tensor");
+            let raw_layer = comfy_name(layer);
+            tensors.insert(
+                format!("{raw_layer}.weight_scale"),
+                H3QwenTensorSpec {
+                    dtype: H3QwenTensorDType::F32,
+                    shape: vec![shape[0], 1],
+                },
+            );
+            layers.insert(
+                raw_layer,
+                H3QwenInt8LayerMetadata {
+                    format: "int8_tensorwise".into(),
+                    full_precision_matrix_mult: None,
+                    convrot: Some(true),
+                    convrot_groupsize: Some(H3_COMFY_CONVROT_GROUP_SIZE),
+                },
+            );
+        }
+    }
+    Ok((
+        tensors,
+        H3QwenInt8CheckpointMetadata {
+            format_version: "1.0".into(),
+            layers,
+        },
+    ))
+}
+
+/// Validate a caller-supplied, header-derived schema and freeze the only
+/// supported Qwen INT8 execution policy. Successful validation still grants no
+/// filesystem, license, download, or runtime authority.
+pub fn validate_h3_qwen_int8_weight_only_schema(
+    config: &H3ConditionerConfig,
+    tensors: &BTreeMap<String, H3QwenTensorSpec>,
+    metadata: &H3QwenInt8CheckpointMetadata,
+) -> Result<H3QwenInt8WeightOnlyPolicy, H3QwenInt8PolicyError> {
+    let (expected_tensors, expected_metadata) = expected_h3_qwen_int8_weight_only_schema(config)?;
+    if tensors.contains_key("model.language_model.embed_tokens.weight")
+        || tensors.keys().any(|name| name.starts_with("model.visual."))
+        || !tensors.contains_key("model.embed_tokens.weight")
+        || !tensors.keys().any(|name| name.starts_with("visual."))
+    {
+        return Err(H3QwenInt8PolicyError::Namespace(
+            "INT8 layer-50 checkpoints must use exactly the Comfy model.* and visual.* namespaces"
+                .into(),
+        ));
+    }
+    let expected_keys = expected_tensors.keys().collect::<BTreeSet<_>>();
+    let actual_keys = tensors.keys().collect::<BTreeSet<_>>();
+    if expected_keys != actual_keys {
+        let missing = expected_keys
+            .difference(&actual_keys)
+            .take(4)
+            .map(|name| (*name).clone())
+            .collect::<Vec<_>>();
+        let unexpected = actual_keys
+            .difference(&expected_keys)
+            .take(4)
+            .map(|name| (*name).clone())
+            .collect::<Vec<_>>();
+        return Err(H3QwenInt8PolicyError::TensorSchema(format!(
+            "tensor set mismatch: missing={missing:?} unexpected={unexpected:?}"
+        )));
+    }
+    for (name, expected) in &expected_tensors {
+        let actual = &tensors[name];
+        if actual != expected {
+            return Err(H3QwenInt8PolicyError::TensorSchema(format!(
+                "tensor {name:?} expected {:?} {:?}, got {:?} {:?}",
+                expected.dtype, expected.shape, actual.dtype, actual.shape
+            )));
+        }
+    }
+    if metadata.format_version != "1.0" {
+        return Err(H3QwenInt8PolicyError::Metadata(format!(
+            "format_version must be 1.0, got {:?}",
+            metadata.format_version
+        )));
+    }
+    let expected_layers = expected_metadata.layers.keys().collect::<BTreeSet<_>>();
+    let actual_layers = metadata.layers.keys().collect::<BTreeSet<_>>();
+    if expected_layers != actual_layers {
+        return Err(H3QwenInt8PolicyError::Metadata(format!(
+            "quantized layer set mismatch: expected {} layers, got {}",
+            expected_layers.len(),
+            actual_layers.len()
+        )));
+    }
+    for (name, layer) in &metadata.layers {
+        if layer.format != "int8_tensorwise"
+            || layer.full_precision_matrix_mult == Some(true)
+            || layer.convrot != Some(true)
+            || layer.convrot_groupsize != Some(H3_COMFY_CONVROT_GROUP_SIZE)
+        {
+            return Err(H3QwenInt8PolicyError::Metadata(format!(
+                "layer {name:?} must be INT8 tensorwise ConvRot group {} with weight-only activation policy",
+                H3_COMFY_CONVROT_GROUP_SIZE
+            )));
+        }
+    }
+
+    let quantized_layers = canonical_quantized_layers().into_iter().collect::<Vec<_>>();
+    if quantized_layers.len() != H3_QWEN_INT8_QUANTIZED_LINEAR_COUNT {
+        return Err(H3QwenInt8PolicyError::Accounting(format!(
+            "expected {H3_QWEN_INT8_QUANTIZED_LINEAR_COUNT} Qwen linears, derived {}",
+            quantized_layers.len()
+        )));
+    }
+    let materialized = expected_materialized_keys();
+    let protected_tensors = materialized
+        .iter()
+        .filter(|tensor| {
+            !tensor.strip_suffix(".weight").is_some_and(|layer| {
+                quantized_layers
+                    .binary_search_by(|candidate| candidate.as_str().cmp(layer))
+                    .is_ok()
+            })
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    let fp32_compute_boundaries = vec![
+        H3QwenFp32Boundary::TextMultimodalRotary,
+        H3QwenFp32Boundary::TextAttentionScoresAndSoftmax,
+        H3QwenFp32Boundary::VisionRotary,
+        H3QwenFp32Boundary::VisionAttentionScoresAndSoftmax,
+    ];
+
+    let mut encoded_tensor_bytes = 0_u64;
+    let mut quantized_weight_bytes = 0_u64;
+    let mut quantization_scale_bytes = 0_u64;
+    let mut quantized_linear_shapes = Vec::new();
+    for (name, spec) in &expected_tensors {
+        let bytes = checked_tensor_bytes(spec)?;
+        encoded_tensor_bytes = encoded_tensor_bytes.checked_add(bytes).ok_or_else(|| {
+            H3QwenInt8PolicyError::Accounting("Qwen encoded bytes overflow".into())
+        })?;
+        if spec.dtype == H3QwenTensorDType::I8 {
+            quantized_weight_bytes =
+                quantized_weight_bytes.checked_add(bytes).ok_or_else(|| {
+                    H3QwenInt8PolicyError::Accounting("Qwen quantized bytes overflow".into())
+                })?;
+            quantized_linear_shapes.push([spec.shape[0], spec.shape[1]]);
+        } else if name.ends_with(".weight_scale") {
+            quantization_scale_bytes =
+                quantization_scale_bytes.checked_add(bytes).ok_or_else(|| {
+                    H3QwenInt8PolicyError::Accounting("Qwen scale bytes overflow".into())
+                })?;
+        }
+    }
+    if encoded_tensor_bytes != H3_COMFY_INT8_CONVROT_PARAMETER_BYTES {
+        return Err(H3QwenInt8PolicyError::Accounting(format!(
+            "derived {encoded_tensor_bytes} encoded bytes, expected {H3_COMFY_INT8_CONVROT_PARAMETER_BYTES}"
+        )));
+    }
+    let protected_bf16_bytes = encoded_tensor_bytes
+        .checked_sub(quantized_weight_bytes)
+        .and_then(|bytes| bytes.checked_sub(quantization_scale_bytes))
+        .ok_or_else(|| {
+            H3QwenInt8PolicyError::Accounting("Qwen protected byte count underflows".into())
+        })?;
+    let header_bytes = H3_COMFY_INT8_CONVROT_SAFETENSORS_BYTES
+        .checked_sub(encoded_tensor_bytes)
+        .ok_or_else(|| {
+            H3QwenInt8PolicyError::Accounting("Qwen artifact header bytes underflow".into())
+        })?;
+
+    let mut policy = H3QwenInt8WeightOnlyPolicy {
+        stable_id: H3_QWEN_INT8_WEIGHT_ONLY_STABLE_ID.into(),
+        quantized_layers,
+        protected_tensors,
+        fp32_compute_boundaries,
+        memory: H3QwenInt8MemoryAccounting {
+            artifact_file_bytes: H3_COMFY_INT8_CONVROT_SAFETENSORS_BYTES,
+            header_bytes,
+            encoded_tensor_bytes,
+            quantized_weight_bytes,
+            quantization_scale_bytes,
+            protected_bf16_bytes,
+            default_dequantization_workspace_bytes: 0,
+            host_mapped_file_bytes: H3_COMFY_INT8_CONVROT_SAFETENSORS_BYTES,
+            host_resident_bytes: None,
+            resident_device_weight_bytes: None,
+            streamed_weight_bytes: None,
+        },
+        policy_sha256: String::new(),
+        quantized_linear_shapes,
+    };
+    policy.memory.default_dequantization_workspace_bytes =
+        policy.max_dequantization_workspace_bytes(H3_COMFY_PORTABLE_ROW_CHUNK)?;
+
+    let mut digest = Sha256::new();
+    digest.update(policy.stable_id.as_bytes());
+    for (name, spec) in &expected_tensors {
+        digest.update((name.len() as u64).to_le_bytes());
+        digest.update(name.as_bytes());
+        digest.update(spec.dtype.stable_id().as_bytes());
+        for dimension in &spec.shape {
+            digest.update((*dimension as u64).to_le_bytes());
+        }
+    }
+    for boundary in &policy.fp32_compute_boundaries {
+        digest.update(format!("{boundary:?}").as_bytes());
+    }
+    policy.policy_sha256 = digest
+        .finalize()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect();
+    Ok(policy)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn released_config() -> H3ConditionerConfig {
+        H3ConditionerConfig::from_json(
+            br#"{
+              "architectures":["Qwen3VLForConditionalGeneration"],
+              "image_token_id":151655,"video_token_id":151656,
+              "vision_start_token_id":151652,"vision_end_token_id":151653,
+              "text_config":{"model_type":"qwen3_vl_text","vocab_size":151936,
+                "hidden_size":5120,"intermediate_size":25600,"num_hidden_layers":64,
+                "num_attention_heads":64,"num_key_value_heads":8,"head_dim":128,
+                "rms_norm_eps":0.000001,"rope_theta":5000000.0,
+                "max_position_embeddings":262144,"hidden_act":"silu","attention_bias":false,
+                "rope_scaling":{"rope_type":"default","mrope_interleaved":true,
+                  "mrope_section":[24,20,20]}},
+              "vision_config":{"model_type":"qwen3_vl","depth":27,"hidden_size":1152,
+                "intermediate_size":4304,"num_heads":16,"in_channels":3,"patch_size":16,
+                "temporal_patch_size":2,"spatial_merge_size":2,"out_hidden_size":5120,
+                "num_position_embeddings":2304,"deepstack_visual_indexes":[8,16,24],
+                "hidden_act":"gelu_pytorch_tanh"}
+            }"#,
+        )
+        .unwrap()
+    }
+
+    fn valid_fixture() -> (
+        H3ConditionerConfig,
+        BTreeMap<String, H3QwenTensorSpec>,
+        H3QwenInt8CheckpointMetadata,
+    ) {
+        let config = released_config();
+        let (tensors, metadata) = expected_h3_qwen_int8_weight_only_schema(&config).unwrap();
+        (config, tensors, metadata)
+    }
+
+    #[test]
+    fn exact_layer_50_policy_and_memory_are_frozen_without_artifacts() {
+        let (config, tensors, metadata) = valid_fixture();
+        let policy =
+            validate_h3_qwen_int8_weight_only_schema(&config, &tensors, &metadata).unwrap();
+        assert_eq!(policy.stable_id(), H3_QWEN_INT8_WEIGHT_ONLY_STABLE_ID);
+        assert_eq!(policy.quantized_layers().len(), 350);
+        assert!(!policy.protected_tensors().is_empty());
+        assert_eq!(policy.fp32_compute_boundaries().len(), 4);
+        assert_eq!(metadata.layers.len(), 350);
+        assert_eq!(policy.memory().encoded_tensor_bytes, 27_141_135_840);
+        assert_eq!(policy.memory().artifact_file_bytes, 27_141_342_152);
+        assert_eq!(policy.memory().header_bytes, 206_312);
+        assert_eq!(policy.memory().quantized_weight_bytes, 24_379_392_000);
+        assert_eq!(policy.memory().quantization_scale_bytes, 14_336_000);
+        assert_eq!(policy.memory().protected_bf16_bytes, 2_747_407_840);
+        assert_eq!(
+            policy.memory().default_dequantization_workspace_bytes,
+            92_013_568
+        );
+        assert_eq!(policy.policy_sha256().len(), 64);
+        assert_eq!(
+            policy
+                .execution_for_weight("model.language_model.layers.49.mlp.down_proj.weight")
+                .unwrap(),
+            H3QwenLinearExecution::Int8ConvRotWeightOnly {
+                weight_scale_tensor: "model.language_model.layers.49.mlp.down_proj.weight_scale"
+                    .into(),
+                group_size: 256,
+            }
+        );
+        assert_eq!(
+            policy
+                .execution_for_weight("model.language_model.embed_tokens.weight")
+                .unwrap(),
+            H3QwenLinearExecution::DenseBf16
+        );
+        assert_eq!(
+            policy
+                .execution_for_weight("model.visual.blocks.0.attn.qkv.weight")
+                .unwrap(),
+            H3QwenLinearExecution::DenseBf16
+        );
+        assert!(policy
+            .execution_for_weight("model.language_model.layers.50.mlp.down_proj.weight")
+            .is_err());
+    }
+
+    #[test]
+    fn only_language_projection_weights_are_int8() {
+        let (config, tensors, metadata) = valid_fixture();
+        validate_h3_qwen_int8_weight_only_schema(&config, &tensors, &metadata).unwrap();
+        assert_eq!(
+            tensors["model.layers.0.self_attn.q_proj.weight"].dtype,
+            H3QwenTensorDType::I8
+        );
+        assert_eq!(
+            tensors["model.layers.0.self_attn.q_proj.weight_scale"],
+            H3QwenTensorSpec {
+                dtype: H3QwenTensorDType::F32,
+                shape: vec![8192, 1],
+            }
+        );
+        for protected in [
+            "model.embed_tokens.weight",
+            "model.layers.0.input_layernorm.weight",
+            "model.layers.0.self_attn.q_norm.weight",
+            "visual.blocks.0.attn.qkv.weight",
+            "visual.merger.linear_fc2.weight",
+        ] {
+            assert_eq!(tensors[protected].dtype, H3QwenTensorDType::Bf16);
+        }
+        assert!(!tensors.keys().any(|name| name.ends_with(".input_scale")));
+    }
+
+    #[test]
+    fn dtype_shape_and_metadata_mutations_fail_closed() {
+        let (config, tensors, metadata) = valid_fixture();
+        let scale = "model.layers.0.self_attn.q_proj.weight_scale";
+
+        let mut wrong_dtype = tensors.clone();
+        wrong_dtype.get_mut(scale).unwrap().dtype = H3QwenTensorDType::Bf16;
+        assert!(matches!(
+            validate_h3_qwen_int8_weight_only_schema(&config, &wrong_dtype, &metadata),
+            Err(H3QwenInt8PolicyError::TensorSchema(_))
+        ));
+
+        let mut wrong_shape = tensors.clone();
+        wrong_shape.get_mut(scale).unwrap().shape = Vec::new();
+        assert!(matches!(
+            validate_h3_qwen_int8_weight_only_schema(&config, &wrong_shape, &metadata),
+            Err(H3QwenInt8PolicyError::TensorSchema(_))
+        ));
+
+        let mut missing = tensors.clone();
+        missing.remove(scale);
+        assert!(matches!(
+            validate_h3_qwen_int8_weight_only_schema(&config, &missing, &metadata),
+            Err(H3QwenInt8PolicyError::TensorSchema(_))
+        ));
+
+        let mut dynamic_activation = metadata.clone();
+        dynamic_activation
+            .layers
+            .get_mut("model.layers.0.self_attn.q_proj")
+            .unwrap()
+            .convrot = Some(false);
+        assert!(matches!(
+            validate_h3_qwen_int8_weight_only_schema(&config, &tensors, &dynamic_activation),
+            Err(H3QwenInt8PolicyError::Metadata(_))
+        ));
+
+        let mut fused_activation = metadata.clone();
+        fused_activation
+            .layers
+            .get_mut("model.layers.0.self_attn.q_proj")
+            .unwrap()
+            .full_precision_matrix_mult = Some(true);
+        assert!(matches!(
+            validate_h3_qwen_int8_weight_only_schema(&config, &tensors, &fused_activation),
+            Err(H3QwenInt8PolicyError::Metadata(_))
+        ));
+
+        let mut explicit_weight_only = metadata.clone();
+        explicit_weight_only
+            .layers
+            .values_mut()
+            .for_each(|layer| layer.full_precision_matrix_mult = Some(false));
+        validate_h3_qwen_int8_weight_only_schema(&config, &tensors, &explicit_weight_only).unwrap();
+    }
+
+    #[test]
+    fn serialized_checkpoint_descriptions_reject_unknown_fields() {
+        let (_, tensors, metadata) = valid_fixture();
+
+        let mut checkpoint = serde_json::to_value(&metadata).unwrap();
+        checkpoint["future_execution_policy"] = serde_json::json!("fused-w8a8");
+        assert!(
+            serde_json::from_value::<H3QwenInt8CheckpointMetadata>(checkpoint).is_err(),
+            "unknown checkpoint policy must not be silently discarded"
+        );
+
+        let mut layer = serde_json::to_value(
+            metadata
+                .layers
+                .get("model.layers.0.self_attn.q_proj")
+                .unwrap(),
+        )
+        .unwrap();
+        layer["activation_quantization"] = serde_json::json!("dynamic");
+        assert!(
+            serde_json::from_value::<H3QwenInt8LayerMetadata>(layer).is_err(),
+            "unknown per-layer execution policy must fail closed"
+        );
+
+        let mut tensor = serde_json::to_value(
+            tensors
+                .get("model.layers.0.self_attn.q_proj.weight")
+                .unwrap(),
+        )
+        .unwrap();
+        tensor["compression"] = serde_json::json!("opaque");
+        assert!(
+            serde_json::from_value::<H3QwenTensorSpec>(tensor).is_err(),
+            "unknown tensor storage authority must fail closed"
+        );
+    }
+
+    #[test]
+    fn official_or_mixed_namespace_cannot_enter_the_comfy_policy() {
+        let (config, mut tensors, metadata) = valid_fixture();
+        let embed = tensors.remove("model.embed_tokens.weight").unwrap();
+        tensors.insert("model.language_model.embed_tokens.weight".into(), embed);
+        assert!(matches!(
+            validate_h3_qwen_int8_weight_only_schema(&config, &tensors, &metadata),
+            Err(H3QwenInt8PolicyError::Namespace(_))
+        ));
+    }
+}

--- a/docs/qualification/minimax-h3-comfy-quantization.md
+++ b/docs/qualification/minimax-h3-comfy-quantization.md
@@ -59,6 +59,54 @@ unaltered two's-complement bytes in CPU U8 storage and widens each byte through
 signed interpretation when staging a chunk. A numeric U8 cast would corrupt
 negative weights and is never used.
 
+## Pruned DiT scaled FP8
+
+The published pruned FP8 transformer uses E4M3 weights plus two exact rank-0
+F32 sidecars for every one of the 200 quantized block matrices:
+`weight_scale` and calibrated `input_scale`. The source convention stores the
+decode scale, not its reciprocal. The legal-neutral reference operation is:
+
+```text
+qx = fp8_e4m3(clamp(x / input_scale, -448, 448))
+qw = stored fp8_e4m3 weight
+y = (f32(qx) * input_scale) @ (f32(qw) * weight_scale)^T + bias
+```
+
+Mold rejects missing, rank-one, non-F32, zero, negative, or non-finite scale
+sidecars. Its F32 reference multiplication stages bounded output-row chunks;
+it establishes scale/QDQ semantics but does not claim a native FP8 kernel or
+production runtime qualification.
+
+## Qwen3-VL layer-50 INT8 ConvRot
+
+The Comfy repository also publishes a 27,141,342,152-byte layer-50 Qwen3-VL
+INT8 ConvRot object. Its size independently corroborates the source policy:
+exactly seven language projection matrices across each of layers 0-49 are
+INT8, for 350 matrices and 24,379,392,000 signed weight bytes. Their per-output
+F32 scales add 14,336,000 bytes. Embeddings, RMS norms, all vision weights and
+biases, and every other materialized tensor retain BF16, adding 2,747,407,840
+bytes. The total tensor payload is therefore 27,141,135,840 bytes and the
+safetensors header is 206,312 bytes.
+
+Comfy's `int8_tensorwise` registration sets `quantize_input=false`. The Qwen
+path is consequently weight-only: reconstruct each ConvRot weight chunk in the
+activation dtype, then execute an ordinary floating-point linear operation.
+Mold freezes that distinction in a named loader policy rather than inferring it
+from an I8 dtype or filename. Text/vision rotary math and attention score/
+softmax boundaries remain explicitly F32; language norms, embeddings, and the
+complete vision tower are protected from quantization. The policy accepts only
+the Comfy layer-50 namespace, the exact 350-layer metadata set, I8 matrix
+shapes, `[out_features, 1]` F32 scales, and ConvRot group 256.
+
+At the default 256-row portable chunk, the largest reconstruction peak is
+92,013,568 bytes: signed F32 source rows, scaled F32 rows, reconstructed F32
+rows, the concurrently live BF16/F16 conversion, per-row F32 scales, and the
+shared F32 Hadamard matrix. This excludes
+request-shaped activations and outputs and therefore is not presented as a
+complete peak-memory estimate. Mapped object bytes likewise are not claimed as
+resident host RAM, and streamed/device-resident totals stay unset until an
+authorized loader is bound to admission.
+
 ## Qwen3-VL NVFP4-AWQ
 
 Comfy's NVFP4 storage consists of:
@@ -98,6 +146,10 @@ The committed tests use tiny deterministic synthetic tensors only. They prove:
 - regular Hadamard symmetry and orthonormality;
 - ConvRot forward equivalence to explicit dequantization;
 - strict `[out_features, 1]` INT8 scale authority and signed-byte handling;
+- scaled FP8 clamp/cast/decode order, mandatory rank-0 F32 scales, and bounded
+  staging accounting;
+- exact Qwen layer-50 INT8 allow/deny policy, weight-only dequant-before-matmul
+  execution, FP32 compute boundaries, and public-size-derived byte accounting;
 - high-nibble-first E2M1 decoding, tensor/block scale application, and
   multi-tile scale unswizzling against a fixed comfy-kitchen layout oracle;
 - AWQ input scaling occurs before the dequantized linear operation; and


### PR DESCRIPTION
## Summary

- add strict scaled-E4M3 QDQ/F32 reference execution for the Comfy pruned FP8 transformer layout
- add the exact Qwen3-VL layer-50 INT8 ConvRot weight-only schema and execution policy for 350 quantized matrices
- freeze BF16-protected tensors and F32-sensitive rotary/attention boundaries
- reject unknown checkpoint, per-layer, and tensor-description fields instead of silently accepting future execution policy
- account the actual 92,013,568-byte default reconstruction peak and use flattened ordinary ConvRot matmul so Candle never materializes a broadcast Hadamard RHS
- document the pinned ComfyUI/comfy-kitchen semantics and remaining native-kernel/qualification gates

## Safety boundary

- accepts caller-supplied synthetic tensor/metadata descriptions only
- does not discover, open, mmap, download, or register H3 checkpoints
- does not read safetensors headers or payload bytes
- does not change factory, server, catalog, manifest, download, or public runtime capability code
- resident/streamed totals remain unknown rather than guessed until an authorized loader is bound
- no H3 weights or generated outputs were accessed

## Verification

- preliminary full mold-ai-candle MiniMax H3 suite: 129 passed
- post-review focused Qwen policy tests: 5 passed
- post-review Comfy quant execution tests: 13 passed
- strict mold-ai-candle Clippy, Rustfmt, and diff checks passed in the Nix devshell
- independent audit: no remaining blockers
- stable patch ID: f02bcc13a54e66b2536833066787602efbdacfd4

Native GPU quant kernels, real-checkpoint parity, factory/admission wiring, and rendered hardware qualification remain separately gated by #831.

Refs #839, #827, #831.