### PR TITLE
feat(h3): add fail-closed Ref2VA dispatch seam

### DIFF
--- a/crates/mold-core/src/minimax_h3.rs
+++ b/crates/mold-core/src/minimax_h3.rs
@@ -1315,6 +1315,27 @@ fn violation(code: &'static str, message: impl Into<String>) -> ContractError {
 /// helper is intentionally available for table tests and future engine work;
 /// it does not authorize H3 or bypass the compliance gate.
 pub fn validate_request_contract(req: &GenerateRequest, task: Task) -> Result<Mode, ContractError> {
+    validate_request_contract_with_reference_authority(req, task, false)
+}
+
+/// Validate the internal, payload-free request retained after authenticated
+/// Ref2VA ingress has resolved every media authority to a private binding.
+///
+/// This does not authorize H3 execution. It differs from
+/// [`validate_request_contract`] only by requiring descriptor authorities for
+/// Ref2VA, so a queued request never needs to carry server-local paths.
+pub fn validate_resolved_request_contract(
+    req: &GenerateRequest,
+    task: Task,
+) -> Result<Mode, ContractError> {
+    validate_request_contract_with_reference_authority(req, task, true)
+}
+
+fn validate_request_contract_with_reference_authority(
+    req: &GenerateRequest,
+    task: Task,
+    resolved_references: bool,
+) -> Result<Mode, ContractError> {
     let fps = req.fps.unwrap_or(FIXED_FPS);
     if fps != FIXED_FPS {
         return Err(violation(
@@ -1466,7 +1487,12 @@ pub fn validate_request_contract(req: &GenerateRequest, task: Task) -> Result<Mo
                     "Ref2VA requires at least one ordered reference",
                 )
             })?;
-            if let Err(error) = validate_references(references) {
+            let reference_validation = if resolved_references {
+                validate_reference_descriptors(references)
+            } else {
+                validate_references(references)
+            };
+            if let Err(error) = reference_validation {
                 return Err(violation(error.code, error.message));
             }
             Ok(Mode::ReferenceToAudioVideo)
@@ -2454,6 +2480,30 @@ mod tests {
         assert_eq!(
             validate_request_contract(&req, Task::Ref2va).unwrap(),
             Mode::ReferenceToAudioVideo
+        );
+        let mut resolved = req.clone();
+        if let GenerationReference::Image {
+            media, provenance, ..
+        } = &mut resolved.references.as_mut().unwrap()[0]
+        {
+            *media = GenerationReferenceAuthority::Descriptor;
+            provenance.sha256 = Some("A".repeat(64));
+        }
+        assert_eq!(
+            validate_request_contract(&resolved, Task::Ref2va)
+                .unwrap_err()
+                .code,
+            "MINIMAX_H3_REFERENCE_DESCRIPTOR_ONLY"
+        );
+        assert_eq!(
+            validate_resolved_request_contract(&resolved, Task::Ref2va).unwrap(),
+            Mode::ReferenceToAudioVideo
+        );
+        assert_eq!(
+            validate_resolved_request_contract(&req, Task::Ref2va)
+                .unwrap_err()
+                .code,
+            "MINIMAX_H3_REFERENCE_PREVIEW_MEDIA"
         );
         req.enable_audio = Some(false);
         assert_eq!(

--- a/crates/mold-core/src/types.rs
+++ b/crates/mold-core/src/types.rs
@@ -926,6 +926,21 @@ impl GenerationReference {
         })
     }
 
+    /// Redacted metadata for the exact generated duration that will consume
+    /// this reference. Long reference video/audio is truncated to the target
+    /// duration, so its prepared shape must not inherit the 362-frame planning
+    /// ceiling when a shorter request is queued or persisted.
+    pub fn redacted_metadata_for_target(
+        &self,
+        index: usize,
+        target_frames: u32,
+    ) -> Option<GenerationReferenceMetadata> {
+        let mut metadata = self.redacted_metadata(index)?;
+        metadata.prepared_shape =
+            Some(crate::minimax_h3::reference_prepared_shape_for_target(self, target_frames).ok()?);
+        Some(metadata)
+    }
+
     /// Preserve ordered reference metadata even if an internal caller bypassed
     /// request validation. Public ingress rejects a missing digest; this
     /// fallback keeps the offending entry visible instead of silently dropping
@@ -1030,6 +1045,20 @@ impl GenerationReference {
                 prepared_shape,
             },
         }
+    }
+
+    /// Lossless counterpart to [`Self::redacted_metadata_for_target`].
+    /// Invalid internal callers retain the reference entry, but never publish
+    /// a prepared shape for a different generated duration.
+    pub fn redacted_metadata_lossless_for_target(
+        &self,
+        index: usize,
+        target_frames: u32,
+    ) -> GenerationReferenceMetadata {
+        let mut metadata = self.redacted_metadata_lossless(index);
+        metadata.prepared_shape =
+            crate::minimax_h3::reference_prepared_shape_for_target(self, target_frames).ok();
+        metadata
     }
 }
 
@@ -1891,10 +1920,13 @@ impl OutputMetadata {
         };
         let references = req.references.as_ref().and_then(|references| {
             (!references.is_empty()).then(|| {
+                let target_frames = req.frames.unwrap_or(crate::minimax_h3::MIN_FRAMES);
                 references
                     .iter()
                     .enumerate()
-                    .map(|(index, reference)| reference.redacted_metadata_lossless(index))
+                    .map(|(index, reference)| {
+                        reference.redacted_metadata_lossless_for_target(index, target_frames)
+                    })
                     .collect::<Vec<_>>()
             })
         });
@@ -4470,6 +4502,58 @@ mod tests {
         assert_eq!(
             metadata.edit_image_sha256s.as_deref(),
             Some(expected.as_slice())
+        );
+    }
+
+    #[test]
+    fn h3_output_metadata_freezes_reference_shape_for_requested_frames() {
+        let mut req: GenerateRequest = serde_json::from_value(serde_json::json!({
+            "prompt": "short synchronized print",
+            "model": crate::minimax_h3::REF2VA_COMFY,
+            "width": crate::minimax_h3::DEFAULT_WIDTH,
+            "height": crate::minimax_h3::DEFAULT_HEIGHT,
+            "steps": crate::minimax_h3::DEFAULT_STEPS,
+            "guidance": 0.0,
+            "batch_size": 1,
+            "frames": crate::minimax_h3::MIN_FRAMES,
+            "fps": crate::minimax_h3::FIXED_FPS,
+            "output_format": "mp4"
+        }))
+        .unwrap();
+        let reference = GenerationReference::Audio {
+            media: GenerationReferenceAuthority::Descriptor,
+            provenance: GenerationReferenceProvenance {
+                name: Some("long.wav".to_string()),
+                sha256: Some("11".repeat(32)),
+            },
+            mime_type: "audio/wav".to_string(),
+            duration_ms: 15_000,
+            sample_rate: 32_000,
+            channels: 2,
+            sample_count: Some(480_000),
+        };
+        req.references = Some(vec![reference.clone()]);
+
+        let short = OutputMetadata::from_generate_request(&req, 7, None, "test");
+        let short_shape = short.references.unwrap()[0].prepared_shape.clone().unwrap();
+        assert_eq!(
+            short_shape,
+            crate::minimax_h3::reference_prepared_shape_for_target(
+                &reference,
+                crate::minimax_h3::MIN_FRAMES,
+            )
+            .unwrap()
+        );
+        assert_ne!(
+            short_shape,
+            crate::minimax_h3::reference_prepared_shape(&reference).unwrap()
+        );
+
+        req.frames = Some(crate::minimax_h3::MAX_FRAMES);
+        let long = OutputMetadata::from_generate_request(&req, 7, None, "test");
+        assert_eq!(
+            long.references.unwrap()[0].prepared_shape.as_ref(),
+            Some(&crate::minimax_h3::reference_prepared_shape(&reference).unwrap())
         );
     }
 

--- a/crates/mold-inference/src/engine.rs
+++ b/crates/mold-inference/src/engine.rs
@@ -1,6 +1,10 @@
 use anyhow::Result;
 use mold_core::GenerateRequest;
 use mold_core::GenerateResponse;
+use mold_core::GenerationReferenceMetadata;
+use sha2::{Digest, Sha256};
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
 use std::ops::{Deref, DerefMut};
 
 use crate::progress::{InferenceCancellationToken, ProgressCallback};
@@ -25,6 +29,116 @@ pub enum LoadStrategy {
 pub struct BatchExecutionCapability {
     pub native_batch_sizes: &'static [usize],
     pub cooperative_cancellation: bool,
+}
+
+/// One request-scoped, server-resolved media authority for generation.
+///
+/// This value is deliberately not serializable and its `Debug` implementation
+/// exposes no private staging path. Public requests and durable metadata keep
+/// only [`GenerationReferenceMetadata`]; the server opens the staged regular
+/// file without following symlinks, then this binding hashes and retains that
+/// exact handle for as long as the queued job is alive. Decoders must consume
+/// [`Self::file`] and never reopen a pathname.
+pub struct GenerationReferenceBinding {
+    metadata: GenerationReferenceMetadata,
+    file: File,
+}
+
+impl GenerationReferenceBinding {
+    pub fn from_opened_file(
+        metadata: GenerationReferenceMetadata,
+        mut file: File,
+        maximum_bytes: u64,
+        cancellation: Option<&InferenceCancellationToken>,
+    ) -> Result<Self> {
+        anyhow::ensure!(
+            metadata.index > 0,
+            "generation reference index must be one-based"
+        );
+        anyhow::ensure!(
+            metadata.sha256.len() == 64
+                && metadata.sha256.bytes().all(|byte| byte.is_ascii_hexdigit()),
+            "generation reference digest must be SHA-256"
+        );
+        let file_metadata = file.metadata()?;
+        anyhow::ensure!(
+            file_metadata.is_file(),
+            "generation reference binding requires an opened regular file"
+        );
+        anyhow::ensure!(
+            maximum_bytes > 0 && file_metadata.len() > 0 && file_metadata.len() <= maximum_bytes,
+            "generation reference binding exceeds its frozen byte limit"
+        );
+        if let Some(cancellation) = cancellation {
+            cancellation.checkpoint()?;
+        }
+        file.seek(SeekFrom::Start(0))?;
+        let mut digest = Sha256::new();
+        let mut buffer = [0_u8; 64 * 1024];
+        let mut observed_bytes = 0_u64;
+        loop {
+            if let Some(cancellation) = cancellation {
+                cancellation.checkpoint()?;
+            }
+            let read = file.read(&mut buffer)?;
+            if read == 0 {
+                break;
+            }
+            observed_bytes = observed_bytes
+                .checked_add(u64::try_from(read)?)
+                .ok_or_else(|| anyhow::anyhow!("generation reference byte count overflowed"))?;
+            anyhow::ensure!(
+                observed_bytes <= maximum_bytes,
+                "generation reference binding exceeds its frozen byte limit"
+            );
+            digest.update(&buffer[..read]);
+        }
+        anyhow::ensure!(
+            observed_bytes == file_metadata.len(),
+            "generation reference binding changed size during verification"
+        );
+        if let Some(cancellation) = cancellation {
+            cancellation.checkpoint()?;
+        }
+        let observed = format!("{:x}", digest.finalize());
+        anyhow::ensure!(
+            observed.eq_ignore_ascii_case(&metadata.sha256),
+            "generation reference binding digest differs from staged media"
+        );
+        file.seek(SeekFrom::Start(0))?;
+        Ok(Self { metadata, file })
+    }
+
+    pub fn metadata(&self) -> &GenerationReferenceMetadata {
+        &self.metadata
+    }
+
+    /// The already-opened, content-verified media authority.
+    ///
+    /// Implementations may seek/read this handle directly or duplicate its
+    /// descriptor for a decoder. Reopening the former staging pathname would
+    /// discard the content identity proved by this binding.
+    pub fn file(&self) -> &File {
+        &self.file
+    }
+
+    #[cfg(test)]
+    pub(crate) fn synthetic(metadata: GenerationReferenceMetadata) -> Self {
+        Self {
+            metadata,
+            file: tempfile::tempfile().expect("create synthetic reference handle"),
+        }
+    }
+}
+
+impl std::fmt::Debug for GenerationReferenceBinding {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("GenerationReferenceBinding")
+            .field("metadata", &self.metadata)
+            .field("file", &"<opened regular file>")
+            .finish()
+    }
 }
 
 impl BatchExecutionCapability {
@@ -61,6 +175,22 @@ impl BatchExecutionCapability {
 /// Trait for inference backends.
 pub trait InferenceEngine: Send + Sync {
     fn generate(&mut self, req: &GenerateRequest) -> Result<GenerateResponse>;
+    /// Generate with private, request-scoped reference media bound by the
+    /// authenticated server ingress path. Engines fail closed by default so a
+    /// reference-bearing request can never silently degrade into text-only
+    /// generation.
+    fn generate_with_reference_bindings(
+        &mut self,
+        req: &GenerateRequest,
+        bindings: &[GenerationReferenceBinding],
+    ) -> Result<GenerateResponse> {
+        anyhow::ensure!(
+            bindings.is_empty(),
+            "model '{}' does not consume resolved generation references",
+            self.model_name()
+        );
+        self.generate(req)
+    }
     fn model_name(&self) -> &str;
     fn is_loaded(&self) -> bool;
     /// Load model weights. Called automatically on first generate if not yet loaded.
@@ -271,7 +401,75 @@ pub(crate) fn seeded_randn(
 
 #[cfg(test)]
 mod tests {
+    use std::io::Write as _;
+
     use super::*;
+
+    fn reference_binding_metadata(bytes: &[u8]) -> GenerationReferenceMetadata {
+        let mut digest = Sha256::new();
+        digest.update(bytes);
+        GenerationReferenceMetadata {
+            kind: mold_core::GenerationReferenceKind::Image,
+            index: 1,
+            name: Some("reference.png".to_string()),
+            sha256: format!("{:x}", digest.finalize()),
+            mime_type: "image/png".to_string(),
+            width: Some(1),
+            height: Some(1),
+            frame_count: None,
+            duration_ms: None,
+            fps: None,
+            has_audio: false,
+            audio_duration_ms: None,
+            audio_sample_count: None,
+            audio_sample_rate: None,
+            audio_channels: None,
+            sample_rate: None,
+            channels: None,
+            sample_count: None,
+            prepared_shape: None,
+        }
+    }
+
+    fn reference_binding_file(bytes: &[u8]) -> File {
+        let mut file = tempfile::tempfile().unwrap();
+        file.write_all(bytes).unwrap();
+        file
+    }
+
+    #[test]
+    fn reference_binding_is_bounded_and_cooperatively_cancellable() {
+        let bytes = b"bounded reference bytes";
+        let metadata = reference_binding_metadata(bytes);
+        let binding = GenerationReferenceBinding::from_opened_file(
+            metadata.clone(),
+            reference_binding_file(bytes),
+            bytes.len() as u64,
+            None,
+        )
+        .unwrap();
+        assert_eq!(binding.metadata(), &metadata);
+
+        let oversized = GenerationReferenceBinding::from_opened_file(
+            metadata.clone(),
+            reference_binding_file(bytes),
+            bytes.len() as u64 - 1,
+            None,
+        )
+        .unwrap_err();
+        assert!(oversized.to_string().contains("frozen byte limit"));
+
+        let cancellation = InferenceCancellationToken::default();
+        cancellation.cancel();
+        let cancelled = GenerationReferenceBinding::from_opened_file(
+            metadata,
+            reference_binding_file(bytes),
+            bytes.len() as u64,
+            Some(&cancellation),
+        )
+        .unwrap_err();
+        assert!(crate::progress::is_inference_cancelled(&cancelled));
+    }
 
     #[test]
     fn batch_execution_capability_rejects_invalid_native_sizes() {

--- a/crates/mold-inference/src/factory.rs
+++ b/crates/mold-inference/src/factory.rs
@@ -760,9 +760,12 @@ mod tests {
         std::iter::repeat_n(byte, 64).collect()
     }
 
-    fn h3_factory_authority(frozen: &FrozenEngineConfig) -> crate::FrozenH3FactoryAuthority {
+    fn h3_factory_authority(
+        frozen: &FrozenEngineConfig,
+        model: &str,
+    ) -> crate::FrozenH3FactoryAuthority {
         crate::FrozenH3FactoryAuthority::new_contract_only(crate::H3FactoryAuthorityInput {
-            model: mold_core::minimax_h3::FL2VA_COMFY.into(),
+            model: model.into(),
             device_id: "gpu-0".into(),
             device_ordinal: 0,
             compute_capability: (8, 9),
@@ -906,33 +909,37 @@ mod tests {
 
     #[test]
     fn frozen_factory_never_calls_h3_loader_before_the_legal_gate() {
-        let mut frozen =
-            FrozenEngineConfig::resolve(mold_core::minimax_h3::FL2VA_COMFY, &Config::default());
-        frozen.family = mold_core::minimax_h3::FAMILY.to_string();
-        frozen.h3_factory_authority = Some(h3_factory_authority(&frozen));
-        let called = Arc::new(AtomicBool::new(false));
-        let loader_called = Arc::clone(&called);
+        for model in [
+            mold_core::minimax_h3::FL2VA_COMFY,
+            mold_core::minimax_h3::REF2VA_COMFY,
+        ] {
+            let mut frozen = FrozenEngineConfig::resolve(model, &Config::default());
+            frozen.family = mold_core::minimax_h3::FAMILY.to_string();
+            frozen.h3_factory_authority = Some(h3_factory_authority(&frozen, model));
+            let called = Arc::new(AtomicBool::new(false));
+            let loader_called = Arc::clone(&called);
 
-        let error = create_engine_with_frozen_config_and_h3_factory(
-            mold_core::minimax_h3::FL2VA_COMFY.into(),
-            dummy_paths(),
-            &frozen,
-            LoadStrategy::Sequential,
-            0,
-            true,
-            None,
-            move |_| {
-                loader_called.store(true, Ordering::SeqCst);
-                unreachable!("the MiniMax H3 legal gate must precede the loader")
-            },
-        )
-        .err()
-        .expect("compliance-gated H3 must fail closed");
+            let error = create_engine_with_frozen_config_and_h3_factory(
+                model.into(),
+                dummy_paths(),
+                &frozen,
+                LoadStrategy::Sequential,
+                0,
+                true,
+                None,
+                move |_| {
+                    loader_called.store(true, Ordering::SeqCst);
+                    unreachable!("the MiniMax H3 legal gate must precede the loader")
+                },
+            )
+            .err()
+            .expect("compliance-gated H3 must fail closed");
 
-        assert!(error
-            .to_string()
-            .contains(mold_core::MINIMAX_H3_AUTHORIZATION_REQUIRED));
-        assert!(!called.load(Ordering::SeqCst));
+            assert!(error
+                .to_string()
+                .contains(mold_core::MINIMAX_H3_AUTHORIZATION_REQUIRED));
+            assert!(!called.load(Ordering::SeqCst));
+        }
     }
 
     #[test]

--- a/crates/mold-inference/src/h3_factory.rs
+++ b/crates/mold-inference/src/h3_factory.rs
@@ -171,9 +171,6 @@ impl FrozenH3FactoryAuthority {
     pub fn new_contract_only(input: H3FactoryAuthorityInput) -> Result<Self> {
         let model_contract = contract::capability_contract_for_model(&input.model)
             .ok_or_else(|| anyhow!("{:?} has no MiniMax H3 capability contract", input.model))?;
-        if model_contract.task != Task::Fl2va {
-            bail!("the current MiniMax H3 Candle factory authority is FL2VA-only");
-        }
         if model_contract.generation.runtime_available {
             bail!(
                 "contract-only MiniMax H3 factory authority cannot be created for a runnable contract"
@@ -294,6 +291,10 @@ impl FrozenH3FactoryAuthority {
         self.backend_plan.canonical_model()
     }
 
+    pub const fn task(&self) -> Task {
+        self.backend_plan.task()
+    }
+
     pub fn device_id(&self) -> &str {
         self.backend_plan.device_id()
     }
@@ -366,7 +367,7 @@ impl FrozenH3FactoryAuthority {
         let request_contract = contract::capability_contract_for_model(model)
             .ok_or_else(|| anyhow!("{model:?} has no MiniMax H3 capability contract"))?;
         if request_contract.canonical_model != self.canonical_model()
-            || request_contract.task != Task::Fl2va
+            || request_contract.task != self.task()
             || gpu_ordinal != self.device_ordinal
             || offload != self.block_offload
         {
@@ -384,11 +385,10 @@ impl FrozenH3FactoryAuthority {
             bail!("MiniMax H3 factory authority uses an unsupported schema version");
         }
         self.backend_plan.validate()?;
-        if self.backend_plan.task() != Task::Fl2va
-            || self.backend_plan.block_streaming().resident_block_count > 50
+        if self.backend_plan.block_streaming().resident_block_count > 50
             || self.backend_plan.block_streaming().prefetch_depth > 2
         {
-            bail!("MiniMax H3 factory authority changed its task or streaming bounds");
+            bail!("MiniMax H3 factory authority changed its streaming bounds");
         }
         if self.attention_kernel_identity.trim().is_empty()
             || !self.attention_full_noncausal
@@ -427,6 +427,7 @@ impl FrozenH3FactoryAuthority {
             .ok_or_else(|| anyhow!("{model:?} has no MiniMax H3 capability contract"))?;
         if !contract::is_family(family)
             || request_contract.canonical_model != self.canonical_model()
+            || request_contract.task != self.task()
             || gpu_ordinal != self.device_ordinal
             || offload != self.block_offload
             || attention_backend != self.attention_backend
@@ -501,9 +502,9 @@ mod tests {
         std::iter::repeat_n(byte, 64).collect()
     }
 
-    fn authority() -> FrozenH3FactoryAuthority {
+    fn authority_for(model: &str) -> FrozenH3FactoryAuthority {
         FrozenH3FactoryAuthority::new_contract_only(H3FactoryAuthorityInput {
-            model: contract::FL2VA_COMFY.into(),
+            model: model.into(),
             device_id: "gpu-0".into(),
             device_ordinal: 0,
             compute_capability: (8, 9),
@@ -546,6 +547,10 @@ mod tests {
             .collect(),
         })
         .unwrap()
+    }
+
+    fn authority() -> FrozenH3FactoryAuthority {
+        authority_for(contract::FL2VA_COMFY)
     }
 
     #[test]
@@ -600,8 +605,26 @@ mod tests {
     }
 
     #[test]
-    fn ref2va_and_missing_components_remain_unconstructable() {
-        let mut input = H3FactoryAuthorityInput {
+    fn ref2va_contract_authority_is_distinct_while_missing_components_fail_closed() {
+        let ref2va = authority_for(contract::REF2VA_COMFY);
+        assert_eq!(ref2va.task(), Task::Ref2va);
+        assert_eq!(ref2va.canonical_model(), contract::REF2VA_COMFY);
+        assert_ne!(ref2va.identity_sha256(), authority().identity_sha256());
+        let error = ref2va
+            .validate_for_dispatch(
+                contract::REF2VA_COMFY,
+                contract::FAMILY,
+                0,
+                true,
+                AttentionBackend::Flash,
+                AttentionChunkPolicy::Off,
+            )
+            .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("registry remains runtime unavailable"));
+
+        let input = H3FactoryAuthorityInput {
             model: contract::REF2VA_COMFY.into(),
             device_id: "gpu-0".into(),
             device_ordinal: 0,
@@ -628,8 +651,6 @@ mod tests {
             },
             components: Vec::new(),
         };
-        assert!(FrozenH3FactoryAuthority::new_contract_only(input.clone()).is_err());
-        input.model = contract::FL2VA_COMFY.into();
         assert!(FrozenH3FactoryAuthority::new_contract_only(input).is_err());
     }
 }

--- a/crates/mold-inference/src/lib.rs
+++ b/crates/mold-inference/src/lib.rs
@@ -61,7 +61,8 @@ pub use batch::{
     QualificationReference, SeedContract, TiledVaeCapability, WorkflowCapabilities,
 };
 pub use engine::{
-    with_inference_cancellation, BatchExecutionCapability, InferenceEngine, LoadStrategy,
+    with_inference_cancellation, BatchExecutionCapability, GenerationReferenceBinding,
+    InferenceEngine, LoadStrategy,
 };
 pub use error::InferenceError;
 pub use factory::{

--- a/crates/mold-inference/src/minimax_h3/backend.rs
+++ b/crates/mold-inference/src/minimax_h3/backend.rs
@@ -248,9 +248,6 @@ impl FrozenH3Fl2VaCandlePlan {
     ) -> Result<Self> {
         let contract = contract::capability_contract_for_model(model)
             .ok_or_else(|| anyhow!("{model:?} has no MiniMax H3 capability contract"))?;
-        if contract.task != Task::Fl2va {
-            bail!("MiniMax H3 FL2VA backend cannot load a Ref2VA transformer");
-        }
         let device_id = device_id.into();
         let execution_fingerprint = execution_fingerprint.into();
         let mut plan = Self {
@@ -324,7 +321,6 @@ impl FrozenH3Fl2VaCandlePlan {
         let contract = contract::capability_contract_for_model(&self.canonical_model)
             .ok_or_else(|| anyhow!("H3 backend plan lost its canonical model"))?;
         if self.canonical_model != contract.canonical_model
-            || self.task != Task::Fl2va
             || self.task != contract.task
             || self.layout != contract.layout
         {
@@ -509,6 +505,11 @@ where
     let requirements = plan.missing_requirements();
     if !requirements.is_empty() {
         return Err(H3BackendActivationError::Unavailable { requirements });
+    }
+    if plan.task() != Task::Fl2va {
+        return Err(H3BackendActivationError::InvalidPlan(
+            "the eager MiniMax H3 Candle backend remains FL2VA-only".to_string(),
+        ));
     }
     let components = loader
         .load(&plan)
@@ -1185,8 +1186,8 @@ mod tests {
     }
 
     #[test]
-    fn ref2va_conditioner_and_streaming_reroutes_fail_before_activation() {
-        assert!(FrozenH3Fl2VaCandlePlan::new_unavailable(
+    fn ref2va_plan_is_contract_only_and_route_mutations_fail_before_activation() {
+        let ref2va = FrozenH3Fl2VaCandlePlan::new_unavailable(
             contract::REF2VA_OFFICIAL,
             "gpu-0",
             H3CandleBackendDevice::Cuda {
@@ -1203,7 +1204,9 @@ mod tests {
             FrozenH3BlockStreamingPlan::new("gpu-0", EXECUTION, 8, 1).unwrap(),
             authorities(),
         )
-        .is_err());
+        .unwrap();
+        assert_eq!(ref2va.task(), Task::Ref2va);
+        ref2va.validate().unwrap();
 
         assert!(FrozenH3Fl2VaCandlePlan::new_unavailable(
             contract::FL2VA_OFFICIAL,
@@ -1358,6 +1361,7 @@ mod tests {
         for (model, quantized) in [
             (contract::FL2VA_OFFICIAL, false),
             (contract::FL2VA_COMFY, true),
+            (contract::REF2VA_OFFICIAL, false),
         ] {
             let called = Arc::new(AtomicBool::new(false));
             let error = try_activate_h3_candle_backend(

--- a/crates/mold-inference/src/minimax_h3/engine.rs
+++ b/crates/mold-inference/src/minimax_h3/engine.rs
@@ -1,4 +1,4 @@
-//! Legal-neutral MiniMax H3 FL2VA engine and streamed-dispatch seam.
+//! Legal-neutral MiniMax H3 FL2VA/Ref2VA engine and streamed-dispatch seam.
 //!
 //! This module deliberately has no production loader registration. The public
 //! frozen factory still rejects H3 before paths or loader callbacks while the
@@ -29,11 +29,19 @@ use super::offload::{
 };
 #[cfg(feature = "mp4")]
 use super::pipeline;
+#[cfg(feature = "mp4")]
+use super::pipeline::ref2va as ref2va_pipeline;
+use super::pipeline::ref2va::{
+    H3AudioConditionEncodeMode, H3DecodedReferenceFacts, H3PreparedReference, H3Ref2VaBackend,
+    H3ReferencePresentation,
+};
 use super::pipeline::{
     H3Fl2VaBackend, H3PipelineBackendIdentity, H3PipelineCheckpoint, H3PipelineEvent,
     H3PipelineObserver, H3PipelinePhase, H3PreparedEndpoint, H3TextConditioning, H3VideoEncodeSink,
 };
-use crate::engine::{BatchExecutionCapability, InferenceEngine, LoadStrategy};
+use crate::engine::{
+    BatchExecutionCapability, GenerationReferenceBinding, InferenceEngine, LoadStrategy,
+};
 use crate::progress::{
     InferenceCancellationToken, ProgressCallback, ProgressEvent, ProgressPhase, ProgressReporter,
 };
@@ -74,6 +82,7 @@ pub(crate) trait H3RuntimeSession: Send + Sync {
     fn generate(
         &mut self,
         request: &GenerateRequest,
+        bindings: &[GenerationReferenceBinding],
         progress: &ProgressReporter,
         observer: &mut dyn H3PipelineObserver,
     ) -> Result<H3EngineOutput>;
@@ -95,12 +104,14 @@ pub(crate) struct H3EngineOutput {
     pub(crate) device_id: String,
     pub(crate) execution_fingerprint: String,
     pub(crate) component_set_identity_sha256: String,
+    pub(crate) reference_fingerprint: Option<String>,
 }
 
-/// Concrete `InferenceEngine` adapter. It owns the exact server-frozen route,
-/// but can be constructed only with an injected loader; production factory
-/// dispatch deliberately has no such loader today.
+/// Concrete task-bound `InferenceEngine` adapter. It owns the exact
+/// server-frozen route, but can be constructed only with an injected loader;
+/// production factory dispatch deliberately has no such loader today.
 pub(crate) struct H3Fl2VaEngine {
+    task: Task,
     model_name: String,
     paths: ModelPaths,
     authority: FrozenH3FactoryAuthority,
@@ -122,8 +133,59 @@ impl H3Fl2VaEngine {
         block_offload: bool,
         loader: Box<dyn H3RuntimeLoader>,
     ) -> Result<Self> {
+        Self::new_task_injected(
+            Task::Fl2va,
+            model_name,
+            paths,
+            authority,
+            load_strategy,
+            gpu_ordinal,
+            block_offload,
+            loader,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new_ref2va_injected(
+        model_name: String,
+        paths: ModelPaths,
+        authority: FrozenH3FactoryAuthority,
+        load_strategy: LoadStrategy,
+        gpu_ordinal: usize,
+        block_offload: bool,
+        loader: Box<dyn H3RuntimeLoader>,
+    ) -> Result<Self> {
+        Self::new_task_injected(
+            Task::Ref2va,
+            model_name,
+            paths,
+            authority,
+            load_strategy,
+            gpu_ordinal,
+            block_offload,
+            loader,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn new_task_injected(
+        task: Task,
+        model_name: String,
+        paths: ModelPaths,
+        authority: FrozenH3FactoryAuthority,
+        load_strategy: LoadStrategy,
+        gpu_ordinal: usize,
+        block_offload: bool,
+        loader: Box<dyn H3RuntimeLoader>,
+    ) -> Result<Self> {
         authority.validate_engine_seam(&model_name, gpu_ordinal, block_offload)?;
+        let model_task = contract::task_for_model(&model_name)
+            .context("MiniMax H3 engine model has no task contract")?;
+        if model_task != task {
+            bail!("MiniMax H3 engine constructor and model task disagree");
+        }
         Ok(Self {
+            task,
             model_name,
             paths,
             authority,
@@ -139,7 +201,10 @@ impl H3Fl2VaEngine {
         request: H3RuntimeLoadRequest<'_>,
         loader: Box<dyn H3RuntimeLoader>,
     ) -> Result<Self> {
-        Self::new_injected(
+        let task = contract::task_for_model(request.model_name)
+            .context("MiniMax H3 factory request has no task contract")?;
+        Self::new_task_injected(
+            task,
             request.model_name.to_string(),
             request.paths.clone(),
             request.authority.clone(),
@@ -165,6 +230,7 @@ impl H3Fl2VaEngine {
         &self,
         request: &GenerateRequest,
         expected_mode: Mode,
+        expected_reference_fingerprint: Option<&str>,
         output: &H3EngineOutput,
     ) -> Result<()> {
         if output.mode != expected_mode
@@ -179,6 +245,7 @@ impl H3Fl2VaEngine {
             || output.execution_fingerprint != self.authority.execution_fingerprint()
             || output.component_set_identity_sha256
                 != self.authority.component_set_identity_sha256()
+            || output.reference_fingerprint.as_deref() != expected_reference_fingerprint
             || output.mp4.is_empty()
             || output.thumbnail_png.is_empty()
         {
@@ -186,12 +253,30 @@ impl H3Fl2VaEngine {
         }
         Ok(())
     }
-}
 
-impl InferenceEngine for H3Fl2VaEngine {
-    fn generate(&mut self, request: &GenerateRequest) -> Result<GenerateResponse> {
-        let expected_mode = contract::validate_request_contract(request, Task::Fl2va)
+    fn generate_bound(
+        &mut self,
+        request: &GenerateRequest,
+        bindings: &[GenerationReferenceBinding],
+    ) -> Result<GenerateResponse> {
+        let request_contract = match self.task {
+            Task::Fl2va => contract::validate_request_contract(request, self.task),
+            Task::Ref2va => contract::validate_resolved_request_contract(request, self.task),
+        };
+        let expected_mode = request_contract
             .map_err(|error| anyhow::anyhow!("{}: {}", error.code, error.message))?;
+        let expected_reference_fingerprint = match self.task {
+            Task::Fl2va => {
+                if !bindings.is_empty() {
+                    bail!("MiniMax H3 FL2VA cannot consume Ref2VA media bindings");
+                }
+                None
+            }
+            Task::Ref2va => {
+                validate_ref2va_bindings(request, bindings)?;
+                Some(ref2va_reference_fingerprint(request)?)
+            }
+        };
         if !self.is_loaded() {
             self.load_for_request(request)?;
         }
@@ -202,9 +287,14 @@ impl InferenceEngine for H3Fl2VaEngine {
             .runtime
             .as_mut()
             .context("MiniMax H3 runtime disappeared after load")?
-            .generate(request, &self.progress, &mut observer)?;
+            .generate(request, bindings, &self.progress, &mut observer)?;
         self.progress.checkpoint()?;
-        self.validate_output(request, expected_mode, &output)?;
+        self.validate_output(
+            request,
+            expected_mode,
+            expected_reference_fingerprint.as_deref(),
+            &output,
+        )?;
         Ok(GenerateResponse {
             images: Vec::new(),
             video: Some(VideoData {
@@ -228,6 +318,81 @@ impl InferenceEngine for H3Fl2VaEngine {
             seed_used: output.seed,
             gpu: None,
         })
+    }
+}
+
+pub(crate) type H3Ref2VaEngine = H3Fl2VaEngine;
+
+fn ref2va_reference_fingerprint(request: &GenerateRequest) -> Result<String> {
+    let references = request
+        .references
+        .as_deref()
+        .context("MiniMax H3 Ref2VA request lost ordered references")?;
+    let shapes = contract::reference_prepared_shapes_for_target(
+        references,
+        request.frames.unwrap_or(contract::MIN_FRAMES),
+    )
+    .map_err(|error| anyhow::anyhow!("{}: {}", error.code, error.message))?;
+    let metadata = references
+        .iter()
+        .zip(shapes)
+        .enumerate()
+        .map(|(index, (reference, shape))| {
+            let mut metadata = reference.redacted_metadata_lossless(index);
+            metadata.prepared_shape = Some(shape);
+            metadata
+        })
+        .collect::<Vec<_>>();
+    Ok(mold_core::generation_reference_fingerprint(&metadata))
+}
+
+fn validate_ref2va_bindings(
+    request: &GenerateRequest,
+    bindings: &[GenerationReferenceBinding],
+) -> Result<()> {
+    let references = request
+        .references
+        .as_deref()
+        .context("MiniMax H3 Ref2VA request lost ordered reference descriptors")?;
+    if references.len() != bindings.len() {
+        bail!(
+            "MiniMax H3 Ref2VA received {} private media bindings for {} ordered references",
+            bindings.len(),
+            references.len()
+        );
+    }
+    let request_metadata = references
+        .iter()
+        .enumerate()
+        .map(|(index, reference)| reference.redacted_metadata_lossless(index))
+        .collect::<Vec<_>>();
+    let binding_metadata = bindings
+        .iter()
+        .map(|binding| binding.metadata().clone())
+        .collect::<Vec<_>>();
+    if binding_metadata != request_metadata
+        || mold_core::generation_reference_fingerprint(&binding_metadata)
+            != mold_core::generation_reference_fingerprint(&request_metadata)
+    {
+        bail!("MiniMax H3 Ref2VA private media bindings changed order or provenance");
+    }
+    Ok(())
+}
+
+impl InferenceEngine for H3Fl2VaEngine {
+    fn generate(&mut self, request: &GenerateRequest) -> Result<GenerateResponse> {
+        if self.task == Task::Ref2va {
+            bail!("MiniMax H3 Ref2VA requires authenticated server-resolved media bindings");
+        }
+        self.generate_bound(request, &[])
+    }
+
+    fn generate_with_reference_bindings(
+        &mut self,
+        request: &GenerateRequest,
+        bindings: &[GenerationReferenceBinding],
+    ) -> Result<GenerateResponse> {
+        self.generate_bound(request, bindings)
     }
 
     fn model_name(&self) -> &str {
@@ -454,9 +619,13 @@ where
     fn generate(
         &mut self,
         request: &GenerateRequest,
+        bindings: &[GenerationReferenceBinding],
         progress: &ProgressReporter,
         observer: &mut dyn H3PipelineObserver,
     ) -> Result<H3EngineOutput> {
+        if !bindings.is_empty() {
+            bail!("MiniMax H3 FL2VA runtime received Ref2VA media bindings");
+        }
         #[cfg(not(feature = "mp4"))]
         {
             let _ = (request, progress, observer);
@@ -491,9 +660,123 @@ where
                 device_id: output.provenance.device_id,
                 execution_fingerprint: output.provenance.execution_fingerprint,
                 component_set_identity_sha256: self.component_set_identity_sha256.clone(),
+                reference_fingerprint: output.provenance.reference_fingerprint,
             })
         }
     }
+}
+
+/// Runtime adapter over the landed ordered Ref2VA pipeline. Like the FL2VA
+/// adapter, it is constructable only from an injected, block-streamed backend.
+pub(crate) struct H3Ref2VaPipelineRuntime<B> {
+    backend: B,
+    identity: H3PipelineBackendIdentity,
+    component_set_identity_sha256: String,
+}
+
+pub(crate) trait H3StreamedRef2VaBackend: H3Ref2VaBackend + Send + Sync {
+    fn component_set_identity_sha256(&self) -> &str;
+}
+
+impl<B> H3Ref2VaPipelineRuntime<B>
+where
+    B: H3StreamedRef2VaBackend,
+{
+    pub(crate) fn new(backend: B, authority: &FrozenH3FactoryAuthority) -> Result<Self> {
+        let identity = backend.identity();
+        if authority.task() != Task::Ref2va
+            || identity.device_id != authority.device_id()
+            || identity.execution_fingerprint != authority.execution_fingerprint()
+            || backend.component_set_identity_sha256() != authority.component_set_identity_sha256()
+        {
+            bail!("MiniMax H3 Ref2VA backend differs from frozen factory authority");
+        }
+        Ok(Self {
+            backend,
+            identity,
+            component_set_identity_sha256: authority.component_set_identity_sha256().to_string(),
+        })
+    }
+}
+
+impl<B> H3RuntimeSession for H3Ref2VaPipelineRuntime<B>
+where
+    B: H3StreamedRef2VaBackend,
+{
+    fn device_id(&self) -> &str {
+        &self.identity.device_id
+    }
+
+    fn execution_fingerprint(&self) -> &str {
+        &self.identity.execution_fingerprint
+    }
+
+    fn component_set_identity_sha256(&self) -> &str {
+        &self.component_set_identity_sha256
+    }
+
+    fn generate(
+        &mut self,
+        request: &GenerateRequest,
+        bindings: &[GenerationReferenceBinding],
+        progress: &ProgressReporter,
+        observer: &mut dyn H3PipelineObserver,
+    ) -> Result<H3EngineOutput> {
+        #[cfg(not(feature = "mp4"))]
+        {
+            let _ = (request, bindings, progress, observer);
+            bail!("MiniMax H3 synchronized audio-video requires Mold's mp4 feature")
+        }
+        #[cfg(feature = "mp4")]
+        {
+            let prepared = ref2va_pipeline::prepare_resolved_request(request, progress, observer)?;
+            let staged = ref2va_pipeline::execute_staged(
+                &prepared,
+                bindings,
+                &mut self.backend,
+                progress,
+                observer,
+            )?;
+            let output = pipeline::finalize_av(staged, progress, observer)?;
+            h3_engine_output_from_pipeline(
+                output,
+                Mode::ReferenceToAudioVideo,
+                &self.component_set_identity_sha256,
+            )
+        }
+    }
+}
+
+#[cfg(feature = "mp4")]
+fn h3_engine_output_from_pipeline(
+    output: super::pipeline::H3PipelineOutput,
+    mode: Mode,
+    component_set_identity_sha256: &str,
+) -> Result<H3EngineOutput> {
+    let duration_ms = u64::from(1_000_u16)
+        .checked_mul(output.mux_report.video_duration_ticks)
+        .context("MiniMax H3 output duration overflow")?
+        / u64::from(output.mux_report.video_timescale);
+    Ok(H3EngineOutput {
+        mp4: output.mp4,
+        thumbnail_png: output.thumbnail_png,
+        mode,
+        seed: output.provenance.seed,
+        width: u32::try_from(output.provenance.width)
+            .context("MiniMax H3 output width exceeds u32")?,
+        height: u32::try_from(output.provenance.height)
+            .context("MiniMax H3 output height exceeds u32")?,
+        frames: u32::try_from(output.provenance.frames)
+            .context("MiniMax H3 output frames exceed u32")?,
+        fps: output.provenance.fps,
+        duration_ms,
+        audio_sample_rate: output.mux_report.sample_rate,
+        audio_channels: u32::from(output.mux_report.channels),
+        device_id: output.provenance.device_id,
+        execution_fingerprint: output.provenance.execution_fingerprint,
+        component_set_identity_sha256: component_set_identity_sha256.to_string(),
+        reference_fingerprint: output.provenance.reference_fingerprint,
+    })
 }
 
 /// Main-block executor paired with a cancellation-safe block loader.
@@ -771,6 +1054,149 @@ where
     }
 }
 
+/// Combines ordered-reference component operations with the same audited
+/// block-streamed main DiT used by FL2VA. Each decode receives the exact
+/// request-scoped private binding alongside its frozen payload-free metadata.
+pub(crate) struct H3StreamedRef2VaPipelineBackend<B, D> {
+    components: B,
+    denoiser: D,
+    component_set_identity_sha256: String,
+}
+
+impl<B, D> H3StreamedRef2VaPipelineBackend<B, D>
+where
+    B: H3Ref2VaBackend,
+    D: H3StreamedDenoiser,
+{
+    pub(crate) fn new(
+        components: B,
+        denoiser: D,
+        component_set_identity_sha256: String,
+    ) -> Result<Self> {
+        if components.identity() != denoiser.identity() {
+            bail!("MiniMax H3 Ref2VA component and streamed-transformer routes disagree");
+        }
+        if component_set_identity_sha256.len() != 64
+            || !component_set_identity_sha256
+                .bytes()
+                .all(|byte| byte.is_ascii_hexdigit())
+        {
+            bail!("MiniMax H3 component-set identity must be one SHA-256 digest");
+        }
+        Ok(Self {
+            components,
+            denoiser,
+            component_set_identity_sha256,
+        })
+    }
+}
+
+impl<B, D> H3Ref2VaBackend for H3StreamedRef2VaPipelineBackend<B, D>
+where
+    B: H3Ref2VaBackend,
+    D: H3StreamedDenoiser,
+{
+    fn identity(&self) -> H3PipelineBackendIdentity {
+        self.components.identity()
+    }
+
+    fn device(&self) -> &Device {
+        self.components.device()
+    }
+
+    fn maximum_packed_rows(&self) -> usize {
+        self.components.maximum_packed_rows()
+    }
+
+    fn decode_reference(
+        &mut self,
+        reference: &H3PreparedReference,
+        binding: &GenerationReferenceBinding,
+        checkpoint: &mut dyn H3PipelineCheckpoint,
+    ) -> Result<H3DecodedReferenceFacts> {
+        self.components
+            .decode_reference(reference, binding, checkpoint)
+    }
+
+    fn preprocess_reference(
+        &mut self,
+        reference: &H3PreparedReference,
+        decoded: &H3DecodedReferenceFacts,
+        checkpoint: &mut dyn H3PipelineCheckpoint,
+    ) -> Result<H3ReferencePresentation> {
+        self.components
+            .preprocess_reference(reference, decoded, checkpoint)
+    }
+
+    fn encode_text(
+        &mut self,
+        prompt: &str,
+        references: &[H3ReferencePresentation],
+        checkpoint: &mut dyn H3PipelineCheckpoint,
+    ) -> Result<H3TextConditioning> {
+        self.components.encode_text(prompt, references, checkpoint)
+    }
+
+    fn encode_visual_reference(
+        &mut self,
+        reference: &H3PreparedReference,
+        mode: mold_candle::minimax_h3::ConditionEncodeMode,
+        checkpoint: &mut dyn H3PipelineCheckpoint,
+    ) -> Result<Tensor> {
+        self.components
+            .encode_visual_reference(reference, mode, checkpoint)
+    }
+
+    fn encode_audio_reference(
+        &mut self,
+        reference: &H3PreparedReference,
+        mode: H3AudioConditionEncodeMode,
+        checkpoint: &mut dyn H3PipelineCheckpoint,
+    ) -> Result<StereoLatents> {
+        self.components
+            .encode_audio_reference(reference, mode, checkpoint)
+    }
+
+    fn denoise(
+        &mut self,
+        input: H3ForwardInput<'_>,
+        layout: &H3FrozenPackedLayout,
+        checkpoint: &mut dyn H3PipelineCheckpoint,
+    ) -> Result<H3TransformerOutput> {
+        if self.components.identity() != self.denoiser.identity() {
+            bail!("MiniMax H3 Ref2VA streamed-transformer route changed during inference");
+        }
+        self.denoiser.denoise(input, layout, checkpoint)
+    }
+
+    fn decode_video(
+        &mut self,
+        latents: &Tensor,
+        sink: &mut H3VideoEncodeSink,
+        checkpoint: &mut dyn H3PipelineCheckpoint,
+    ) -> Result<()> {
+        self.components.decode_video(latents, sink, checkpoint)
+    }
+
+    fn decode_audio(
+        &mut self,
+        latents: &StereoLatents,
+        checkpoint: &mut dyn H3PipelineCheckpoint,
+    ) -> Result<StereoWaveform> {
+        self.components.decode_audio(latents, checkpoint)
+    }
+}
+
+impl<B, D> H3StreamedRef2VaBackend for H3StreamedRef2VaPipelineBackend<B, D>
+where
+    B: H3Ref2VaBackend + Send + Sync,
+    D: H3StreamedDenoiser,
+{
+    fn component_set_identity_sha256(&self) -> &str {
+        &self.component_set_identity_sha256
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
@@ -778,7 +1204,11 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     use candle_core::DType;
-    use mold_candle::minimax_h3::{H3Modality, H3PackedLayout};
+    use image::{Rgb, RgbImage};
+    use mold_candle::minimax_h3::{
+        AudioSoundtrackAssociation, ConditionEncodeMode, H3Modality, H3ModalityTag, H3PackedLayout,
+        RefPresentation, RefPresentationKind,
+    };
     use serde_json::json;
 
     use super::*;
@@ -794,13 +1224,10 @@ mod tests {
         std::iter::repeat_n(byte, 64).collect()
     }
 
-    fn authority() -> FrozenH3FactoryAuthority {
-        let frozen = crate::FrozenEngineConfig::resolve(
-            contract::FL2VA_COMFY,
-            &mold_core::Config::default(),
-        );
+    fn authority_for(model: &str) -> FrozenH3FactoryAuthority {
+        let frozen = crate::FrozenEngineConfig::resolve(model, &mold_core::Config::default());
         FrozenH3FactoryAuthority::new_contract_only(H3FactoryAuthorityInput {
-            model: contract::FL2VA_COMFY.into(),
+            model: model.into(),
             device_id: "gpu-0".into(),
             device_ordinal: 0,
             compute_capability: (8, 9),
@@ -845,6 +1272,10 @@ mod tests {
         .unwrap()
     }
 
+    fn authority() -> FrozenH3FactoryAuthority {
+        authority_for(contract::FL2VA_COMFY)
+    }
+
     fn paths() -> ModelPaths {
         ModelPaths {
             low_noise_transformer: None,
@@ -885,6 +1316,86 @@ mod tests {
         .unwrap()
     }
 
+    fn ref2va_request() -> GenerateRequest {
+        use mold_core::{
+            GenerationReference, GenerationReferenceAuthority, GenerationReferenceProvenance,
+        };
+
+        let provenance = |name: &str, digest: char| GenerationReferenceProvenance {
+            name: Some(name.to_string()),
+            sha256: Some(sha(digest)),
+        };
+        let mut request = request();
+        request.model = contract::REF2VA_COMFY.into();
+        request.references = Some(vec![
+            GenerationReference::Video {
+                media: GenerationReferenceAuthority::Descriptor,
+                provenance: provenance("motion.mp4", '1'),
+                mime_type: "video/mp4".into(),
+                width: 64,
+                height: 64,
+                frame_count: Some(48),
+                duration_ms: 2_000,
+                fps: 24.0,
+                has_audio: true,
+                audio_duration_ms: Some(2_000),
+                audio_sample_count: Some(96_000),
+                audio_sample_rate: Some(48_000),
+                audio_channels: Some(2),
+            },
+            GenerationReference::Image {
+                media: GenerationReferenceAuthority::Descriptor,
+                provenance: provenance("portrait.png", '2'),
+                mime_type: "image/png".into(),
+                width: 48,
+                height: 48,
+            },
+            GenerationReference::Audio {
+                media: GenerationReferenceAuthority::Descriptor,
+                provenance: provenance("voice.wav", '3'),
+                mime_type: "audio/wav".into(),
+                duration_ms: 2_000,
+                sample_rate: 48_000,
+                channels: 1,
+                sample_count: Some(96_000),
+            },
+        ]);
+        request
+    }
+
+    fn image_ref2va_request() -> GenerateRequest {
+        use mold_core::{
+            GenerationReference, GenerationReferenceAuthority, GenerationReferenceProvenance,
+        };
+
+        let mut request = request();
+        request.model = contract::REF2VA_COMFY.into();
+        request.references = Some(vec![GenerationReference::Image {
+            media: GenerationReferenceAuthority::Descriptor,
+            provenance: GenerationReferenceProvenance {
+                name: Some("portrait.png".to_string()),
+                sha256: Some(sha('2')),
+            },
+            mime_type: "image/png".into(),
+            width: 48,
+            height: 48,
+        }]);
+        request
+    }
+
+    fn ref2va_bindings(request: &GenerateRequest) -> Vec<GenerationReferenceBinding> {
+        request
+            .references
+            .as_deref()
+            .unwrap()
+            .iter()
+            .enumerate()
+            .map(|(index, reference)| {
+                GenerationReferenceBinding::synthetic(reference.redacted_metadata_lossless(index))
+            })
+            .collect()
+    }
+
     struct SyntheticRuntime {
         device: String,
         execution: String,
@@ -907,9 +1418,11 @@ mod tests {
         fn generate(
             &mut self,
             request: &GenerateRequest,
+            bindings: &[GenerationReferenceBinding],
             progress: &ProgressReporter,
             observer: &mut dyn H3PipelineObserver,
         ) -> Result<H3EngineOutput> {
+            assert!(bindings.is_empty());
             progress.checkpoint()?;
             for event in [
                 H3PipelineEvent {
@@ -966,6 +1479,7 @@ mod tests {
                 device_id: self.device.clone(),
                 execution_fingerprint: self.execution.clone(),
                 component_set_identity_sha256: self.components.clone(),
+                reference_fingerprint: None,
             })
         }
     }
@@ -973,6 +1487,107 @@ mod tests {
     struct SyntheticLoader {
         loads: Arc<AtomicUsize>,
         wrong_device: bool,
+    }
+
+    struct SyntheticRefRuntime {
+        device: String,
+        execution: String,
+        components: String,
+        observed: Arc<Mutex<Vec<(u32, mold_core::GenerationReferenceKind)>>>,
+        wrong_reference_fingerprint: bool,
+    }
+
+    impl H3RuntimeSession for SyntheticRefRuntime {
+        fn device_id(&self) -> &str {
+            &self.device
+        }
+
+        fn execution_fingerprint(&self) -> &str {
+            &self.execution
+        }
+
+        fn component_set_identity_sha256(&self) -> &str {
+            &self.components
+        }
+
+        fn generate(
+            &mut self,
+            request: &GenerateRequest,
+            bindings: &[GenerationReferenceBinding],
+            progress: &ProgressReporter,
+            observer: &mut dyn H3PipelineObserver,
+        ) -> Result<H3EngineOutput> {
+            progress.checkpoint()?;
+            let observed = bindings
+                .iter()
+                .map(|binding| {
+                    assert!(binding.file().metadata().unwrap().is_file());
+                    (binding.metadata().index, binding.metadata().kind)
+                })
+                .collect::<Vec<_>>();
+            *self.observed.lock().unwrap() = observed;
+            observer.observe(H3PipelineEvent {
+                phase: H3PipelinePhase::QwenEncode,
+                completed: 0,
+                total: 1,
+            });
+            progress.checkpoint()?;
+            observer.observe(H3PipelineEvent {
+                phase: H3PipelinePhase::QwenEncode,
+                completed: 1,
+                total: 1,
+            });
+            progress.checkpoint()?;
+            Ok(H3EngineOutput {
+                mp4: vec![0, 0, 0, 1],
+                thumbnail_png: vec![137, 80, 78, 71],
+                mode: Mode::ReferenceToAudioVideo,
+                seed: request.seed.unwrap(),
+                width: request.width,
+                height: request.height,
+                frames: request.frames.unwrap(),
+                fps: request.fps.unwrap(),
+                duration_ms: 5_166,
+                audio_sample_rate: contract::AUDIO_SAMPLE_RATE_HZ,
+                audio_channels: contract::AUDIO_CHANNELS,
+                device_id: self.device.clone(),
+                execution_fingerprint: self.execution.clone(),
+                component_set_identity_sha256: self.components.clone(),
+                reference_fingerprint: Some(if self.wrong_reference_fingerprint {
+                    sha('f')
+                } else {
+                    ref2va_reference_fingerprint(request)?
+                }),
+            })
+        }
+    }
+
+    struct SyntheticRefLoader {
+        loads: Arc<AtomicUsize>,
+        observed: Arc<Mutex<Vec<(u32, mold_core::GenerationReferenceKind)>>>,
+        wrong_reference_fingerprint: bool,
+    }
+
+    impl H3RuntimeLoader for SyntheticRefLoader {
+        fn load(
+            &mut self,
+            request: H3RuntimeLoadRequest<'_>,
+            progress: &ProgressReporter,
+        ) -> Result<Box<dyn H3RuntimeSession>> {
+            progress.checkpoint()?;
+            assert_eq!(request.model_name, contract::REF2VA_COMFY);
+            assert_eq!(request.authority.task(), Task::Ref2va);
+            assert_eq!(request.gpu_ordinal, 0);
+            assert!(request.block_offload);
+            self.loads.fetch_add(1, Ordering::SeqCst);
+            Ok(Box::new(SyntheticRefRuntime {
+                device: request.authority.device_id().into(),
+                execution: request.authority.execution_fingerprint().into(),
+                components: request.authority.component_set_identity_sha256().into(),
+                observed: Arc::clone(&self.observed),
+                wrong_reference_fingerprint: self.wrong_reference_fingerprint,
+            }))
+        }
     }
 
     impl H3RuntimeLoader for SyntheticLoader {
@@ -1014,6 +1629,34 @@ mod tests {
             Box::new(SyntheticLoader {
                 loads,
                 wrong_device,
+            }),
+        )
+        .unwrap()
+    }
+
+    fn ref2va_engine(
+        loads: Arc<AtomicUsize>,
+        observed: Arc<Mutex<Vec<(u32, mold_core::GenerationReferenceKind)>>>,
+    ) -> H3Ref2VaEngine {
+        ref2va_engine_with_output_fingerprint(loads, observed, false)
+    }
+
+    fn ref2va_engine_with_output_fingerprint(
+        loads: Arc<AtomicUsize>,
+        observed: Arc<Mutex<Vec<(u32, mold_core::GenerationReferenceKind)>>>,
+        wrong_reference_fingerprint: bool,
+    ) -> H3Ref2VaEngine {
+        H3Ref2VaEngine::new_ref2va_injected(
+            contract::REF2VA_COMFY.into(),
+            paths(),
+            authority_for(contract::REF2VA_COMFY),
+            LoadStrategy::Eager,
+            0,
+            true,
+            Box::new(SyntheticRefLoader {
+                loads,
+                observed,
+                wrong_reference_fingerprint,
             }),
         )
         .unwrap()
@@ -1073,6 +1716,7 @@ mod tests {
         let error = cancelled.generate(&request()).unwrap_err();
         assert!(is_inference_cancelled(&error));
         assert_eq!(loads.load(Ordering::SeqCst), 0);
+
         assert!(!cancelled.is_loaded());
 
         let mut rerouted = engine(Arc::clone(&loads), true);
@@ -1080,6 +1724,89 @@ mod tests {
         assert!(error.to_string().contains("frozen factory authority"));
         assert_eq!(loads.load(Ordering::SeqCst), 1);
         assert!(!rerouted.is_loaded());
+    }
+
+    #[test]
+    fn ref2va_adapter_requires_exact_private_bindings_and_preserves_ordered_av_contract() {
+        let request = ref2va_request();
+        let bindings = ref2va_bindings(&request);
+        assert!(!format!("{:?}", bindings[0]).contains("/synthetic/not-read"));
+        let loads = Arc::new(AtomicUsize::new(0));
+        let observed = Arc::new(Mutex::new(Vec::new()));
+        let mut engine = ref2va_engine(Arc::clone(&loads), Arc::clone(&observed));
+
+        let error = engine.generate(&request).unwrap_err();
+        assert!(error.to_string().contains("server-resolved media bindings"));
+        assert_eq!(loads.load(Ordering::SeqCst), 0);
+
+        let response = engine
+            .generate_with_reference_bindings(&request, &bindings)
+            .unwrap();
+        let video = response.video.unwrap();
+        assert!(video.has_audio);
+        assert_eq!(
+            video.audio_sample_rate,
+            Some(contract::AUDIO_SAMPLE_RATE_HZ)
+        );
+        assert_eq!(video.audio_channels, Some(contract::AUDIO_CHANNELS));
+        assert_eq!(loads.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            *observed.lock().unwrap(),
+            vec![
+                (1, mold_core::GenerationReferenceKind::Video),
+                (2, mold_core::GenerationReferenceKind::Image),
+                (3, mold_core::GenerationReferenceKind::Audio),
+            ]
+        );
+    }
+
+    #[test]
+    fn ref2va_binding_mutation_and_cancellation_fail_before_runtime_load() {
+        let request = ref2va_request();
+        let loads = Arc::new(AtomicUsize::new(0));
+        let observed = Arc::new(Mutex::new(Vec::new()));
+
+        let mut missing = ref2va_bindings(&request);
+        missing.pop();
+        let mut engine = ref2va_engine(Arc::clone(&loads), Arc::clone(&observed));
+        let error = engine
+            .generate_with_reference_bindings(&request, &missing)
+            .unwrap_err();
+        assert!(error.to_string().contains("private media bindings"));
+        assert_eq!(loads.load(Ordering::SeqCst), 0);
+
+        let mut reordered = ref2va_bindings(&request);
+        reordered.swap(0, 1);
+        let mut engine = ref2va_engine(Arc::clone(&loads), Arc::clone(&observed));
+        let error = engine
+            .generate_with_reference_bindings(&request, &reordered)
+            .unwrap_err();
+        assert!(error.to_string().contains("changed order or provenance"));
+        assert_eq!(loads.load(Ordering::SeqCst), 0);
+
+        let mut cancelled = ref2va_engine(Arc::clone(&loads), observed);
+        let token = InferenceCancellationToken::default();
+        token.cancel();
+        cancelled.set_cancellation_token(token);
+        let error = cancelled
+            .generate_with_reference_bindings(&request, &ref2va_bindings(&request))
+            .unwrap_err();
+        assert!(is_inference_cancelled(&error));
+        assert_eq!(loads.load(Ordering::SeqCst), 0);
+
+        let wrong_loads = Arc::new(AtomicUsize::new(0));
+        let mut wrong_output = ref2va_engine_with_output_fingerprint(
+            Arc::clone(&wrong_loads),
+            Arc::new(Mutex::new(Vec::new())),
+            true,
+        );
+        let error = wrong_output
+            .generate_with_reference_bindings(&request, &ref2va_bindings(&request))
+            .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("differs from the frozen request or factory authority"));
+        assert_eq!(wrong_loads.load(Ordering::SeqCst), 1);
     }
 
     #[derive(Clone)]
@@ -1185,6 +1912,240 @@ mod tests {
                 Ok(())
             }
         }
+    }
+
+    struct StructuralRefComponents {
+        device: Device,
+        identity: H3PipelineBackendIdentity,
+        trace: Arc<Mutex<Vec<&'static str>>>,
+    }
+
+    impl H3Ref2VaBackend for StructuralRefComponents {
+        fn identity(&self) -> H3PipelineBackendIdentity {
+            self.identity.clone()
+        }
+
+        fn device(&self) -> &Device {
+            &self.device
+        }
+
+        fn maximum_packed_rows(&self) -> usize {
+            100_000
+        }
+
+        fn decode_reference(
+            &mut self,
+            reference: &H3PreparedReference,
+            binding: &GenerationReferenceBinding,
+            _checkpoint: &mut dyn H3PipelineCheckpoint,
+        ) -> Result<H3DecodedReferenceFacts> {
+            self.trace.lock().unwrap().push("decode-reference");
+            let mut bound = binding.metadata().clone();
+            bound.prepared_shape = Some(reference.shape.clone());
+            assert_eq!(bound, reference.metadata);
+            assert!(binding.file().metadata()?.is_file());
+            Ok(H3DecodedReferenceFacts {
+                index: reference.metadata.index,
+                kind: reference.metadata.kind,
+                width: reference.metadata.width,
+                height: reference.metadata.height,
+                frame_count: None,
+                fps: None,
+                audio: None,
+            })
+        }
+
+        fn preprocess_reference(
+            &mut self,
+            reference: &H3PreparedReference,
+            decoded: &H3DecodedReferenceFacts,
+            _checkpoint: &mut dyn H3PipelineCheckpoint,
+        ) -> Result<H3ReferencePresentation> {
+            self.trace.lock().unwrap().push("preprocess-reference");
+            assert_eq!(decoded.index, reference.metadata.index);
+            Ok(H3ReferencePresentation {
+                index: reference.metadata.index,
+                presentation: RefPresentation {
+                    kind: RefPresentationKind::Image { vision_tokens: 2 },
+                    has_audio: false,
+                },
+            })
+        }
+
+        fn encode_text(
+            &mut self,
+            prompt: &str,
+            references: &[H3ReferencePresentation],
+            _checkpoint: &mut dyn H3PipelineCheckpoint,
+        ) -> Result<H3TextConditioning> {
+            self.trace.lock().unwrap().push("encode-text");
+            assert!(!prompt.is_empty());
+            assert_eq!(references.len(), 1);
+            let tags = vec![
+                H3ModalityTag::Text,
+                H3ModalityTag::Text,
+                H3ModalityTag::Vision,
+                H3ModalityTag::Vision,
+            ];
+            Ok(H3TextConditioning {
+                states: Tensor::zeros((1, tags.len(), 5_120), DType::F32, &self.device)?,
+                tags,
+            })
+        }
+
+        fn encode_visual_reference(
+            &mut self,
+            reference: &H3PreparedReference,
+            mode: ConditionEncodeMode,
+            _checkpoint: &mut dyn H3PipelineCheckpoint,
+        ) -> Result<Tensor> {
+            self.trace.lock().unwrap().push("encode-visual");
+            assert_eq!(mode, ConditionEncodeMode::OfficialFreshSeed42);
+            let height = usize::try_from(reference.shape.normalized_height.unwrap())? / 16;
+            let width = usize::try_from(reference.shape.normalized_width.unwrap())? / 16;
+            Tensor::zeros((1, 24, 1, height, width), DType::F32, &self.device).map_err(Into::into)
+        }
+
+        fn encode_audio_reference(
+            &mut self,
+            _reference: &H3PreparedReference,
+            _mode: H3AudioConditionEncodeMode,
+            _checkpoint: &mut dyn H3PipelineCheckpoint,
+        ) -> Result<StereoLatents> {
+            unreachable!("structural composition test does not encode audio")
+        }
+
+        fn denoise(
+            &mut self,
+            _input: H3ForwardInput<'_>,
+            _layout: &H3FrozenPackedLayout,
+            _checkpoint: &mut dyn H3PipelineCheckpoint,
+        ) -> Result<H3TransformerOutput> {
+            unreachable!("the composed backend must route denoise to its streamed authority")
+        }
+
+        fn decode_video(
+            &mut self,
+            latents: &Tensor,
+            sink: &mut H3VideoEncodeSink,
+            _checkpoint: &mut dyn H3PipelineCheckpoint,
+        ) -> Result<()> {
+            self.trace.lock().unwrap().push("decode-video");
+            assert_eq!(latents.dims(), [1, 24, 37, 2, 2]);
+            for frame in 0..124 {
+                sink.push(
+                    &RgbImage::from_pixel(32, 32, Rgb([frame as u8, 2, 3])),
+                    _checkpoint,
+                )?;
+            }
+            Ok(())
+        }
+
+        fn decode_audio(
+            &mut self,
+            latents: &StereoLatents,
+            _checkpoint: &mut dyn H3PipelineCheckpoint,
+        ) -> Result<StereoWaveform> {
+            self.trace.lock().unwrap().push("decode-audio");
+            assert_eq!(latents.normalized().dims(), [1, 32, 2, 207]);
+            StereoWaveform::new(
+                Tensor::zeros((1, 2, 207 * 800), DType::F32, &self.device)?,
+                contract::AUDIO_SAMPLE_RATE_HZ as usize,
+                AudioSoundtrackAssociation::Generated,
+            )
+            .map_err(Into::into)
+        }
+    }
+
+    struct StructuralDenoiser {
+        identity: H3PipelineBackendIdentity,
+        trace: Arc<Mutex<Vec<&'static str>>>,
+    }
+
+    impl H3StreamedDenoiser for StructuralDenoiser {
+        fn identity(&self) -> H3PipelineBackendIdentity {
+            self.identity.clone()
+        }
+
+        fn denoise(
+            &mut self,
+            input: H3ForwardInput<'_>,
+            _layout: &H3FrozenPackedLayout,
+            _checkpoint: &mut dyn H3PipelineCheckpoint,
+        ) -> Result<H3TransformerOutput> {
+            self.trace.lock().unwrap().push("streamed-denoise");
+            Ok(H3TransformerOutput {
+                video: Tensor::zeros_like(input.video_rows)?,
+                audio: Tensor::zeros_like(input.audio_rows)?,
+            })
+        }
+    }
+
+    #[cfg(feature = "mp4")]
+    #[test]
+    fn ref2va_runtime_executes_exact_composed_streamed_backend_authority() {
+        let authority = authority_for(contract::REF2VA_COMFY);
+        let identity = H3PipelineBackendIdentity {
+            kind: crate::minimax_h3::pipeline::H3PipelineBackendKind::SyntheticCpu,
+            device_id: authority.device_id().to_string(),
+            execution_fingerprint: authority.execution_fingerprint().to_string(),
+        };
+        let trace = Arc::new(Mutex::new(Vec::new()));
+        let composed = H3StreamedRef2VaPipelineBackend::new(
+            StructuralRefComponents {
+                device: Device::Cpu,
+                identity: identity.clone(),
+                trace: Arc::clone(&trace),
+            },
+            StructuralDenoiser {
+                identity,
+                trace: Arc::clone(&trace),
+            },
+            authority.component_set_identity_sha256().to_string(),
+        )
+        .unwrap();
+        let mut runtime = H3Ref2VaPipelineRuntime::new(composed, &authority).unwrap();
+        assert_eq!(runtime.device_id(), authority.device_id());
+        assert_eq!(
+            runtime.execution_fingerprint(),
+            authority.execution_fingerprint()
+        );
+        assert_eq!(
+            runtime.component_set_identity_sha256(),
+            authority.component_set_identity_sha256()
+        );
+
+        let request = image_ref2va_request();
+        let bindings = ref2va_bindings(&request);
+        let output = runtime
+            .generate(
+                &request,
+                &bindings,
+                &ProgressReporter::default(),
+                &mut pipeline::NoopH3PipelineObserver,
+            )
+            .unwrap();
+        assert!(!output.mp4.is_empty());
+        assert!(!output.thumbnail_png.is_empty());
+        assert_eq!(output.mode, Mode::ReferenceToAudioVideo);
+        assert_eq!(
+            output.reference_fingerprint,
+            Some(ref2va_reference_fingerprint(&request).unwrap())
+        );
+        assert_eq!(
+            *trace.lock().unwrap(),
+            vec![
+                "decode-reference",
+                "preprocess-reference",
+                "encode-text",
+                "encode-visual",
+                "streamed-denoise",
+                "streamed-denoise",
+                "streamed-denoise",
+                "decode-video",
+                "decode-audio",
+            ]
+        );
     }
 
     fn frozen_layout() -> H3FrozenPackedLayout {

--- a/crates/mold-inference/src/minimax_h3/pipeline/ref2va.rs
+++ b/crates/mold-inference/src/minimax_h3/pipeline/ref2va.rs
@@ -8,6 +8,7 @@
 //! synthetic unit-test backend.
 
 use super::*;
+use crate::engine::GenerationReferenceBinding;
 use crate::minimax_h3::sampler::H3_VISUAL_CONDITION_TIMESTEP;
 use mold_candle::minimax_h3::{
     pack_h3_audio, sample_video_frames, AudioVaeConfig, RefPresentation, RefPresentationKind,
@@ -80,6 +81,7 @@ pub(crate) trait H3Ref2VaBackend {
     fn decode_reference(
         &mut self,
         reference: &H3PreparedReference,
+        binding: &GenerationReferenceBinding,
         checkpoint: &mut dyn H3PipelineCheckpoint,
     ) -> Result<H3DecodedReferenceFacts>;
 
@@ -172,10 +174,31 @@ pub(crate) fn prepare_request(
     progress: &ProgressReporter,
     observer: &mut dyn H3PipelineObserver,
 ) -> Result<H3PreparedRef2VaRequest> {
+    prepare_request_with_authority(req, false, progress, observer)
+}
+
+pub(crate) fn prepare_resolved_request(
+    req: &GenerateRequest,
+    progress: &ProgressReporter,
+    observer: &mut dyn H3PipelineObserver,
+) -> Result<H3PreparedRef2VaRequest> {
+    prepare_request_with_authority(req, true, progress, observer)
+}
+
+fn prepare_request_with_authority(
+    req: &GenerateRequest,
+    resolved_references: bool,
+    progress: &ProgressReporter,
+    observer: &mut dyn H3PipelineObserver,
+) -> Result<H3PreparedRef2VaRequest> {
     let mut control = PipelineControl { progress, observer };
     phase_boundary(&mut control, H3PipelinePhase::Validate, false)?;
-    let mode = contract::validate_request_contract(req, Task::Ref2va)
-        .map_err(|error| anyhow!("{}: {}", error.code, error.message))?;
+    let mode = if resolved_references {
+        contract::validate_resolved_request_contract(req, Task::Ref2va)
+    } else {
+        contract::validate_request_contract(req, Task::Ref2va)
+    }
+    .map_err(|error| anyhow!("{}: {}", error.code, error.message))?;
     if mode != Mode::ReferenceToAudioVideo {
         bail!("MiniMax H3 Ref2VA preparation resolved the wrong mode {mode:?}");
     }
@@ -220,10 +243,12 @@ pub(crate) fn prepare_request(
 
 pub(crate) fn execute_staged(
     prepared: &H3PreparedRef2VaRequest,
+    bindings: &[GenerationReferenceBinding],
     backend: &mut dyn H3Ref2VaBackend,
     progress: &ProgressReporter,
     observer: &mut dyn H3PipelineObserver,
 ) -> Result<H3StagedAvOutput> {
+    validate_reference_bindings(prepared, bindings)?;
     let frozen_identity = backend.identity();
     frozen_identity.validate(backend.device())?;
     let device = backend.device().clone();
@@ -236,9 +261,9 @@ pub(crate) fn execute_staged(
         total,
     })?;
     let mut decoded = Vec::with_capacity(total);
-    for (offset, reference) in prepared.references.iter().enumerate() {
+    for (offset, (reference, binding)) in prepared.references.iter().zip(bindings).enumerate() {
         ensure_ref_identity(backend, &frozen_identity, &device)?;
-        let facts = backend.decode_reference(reference, &mut control)?;
+        let facts = backend.decode_reference(reference, binding, &mut control)?;
         ensure_ref_identity(backend, &frozen_identity, &device)?;
         validate_decoded_reference(reference, &facts)?;
         decoded.push(facts);
@@ -576,6 +601,42 @@ pub(crate) fn execute_staged(
             execution_fingerprint: frozen_identity.execution_fingerprint,
         },
     })
+}
+
+fn validate_reference_bindings(
+    prepared: &H3PreparedRef2VaRequest,
+    bindings: &[GenerationReferenceBinding],
+) -> Result<()> {
+    if bindings.len() != prepared.references.len() {
+        bail!(
+            "MiniMax H3 Ref2VA received {} private media bindings for {} ordered references",
+            bindings.len(),
+            prepared.references.len()
+        );
+    }
+    for (reference, binding) in prepared.references.iter().zip(bindings) {
+        let mut bound_metadata = binding.metadata().clone();
+        bound_metadata.prepared_shape = Some(reference.shape.clone());
+        if bound_metadata != reference.metadata {
+            bail!(
+                "MiniMax H3 Ref2VA private media binding {} differs from frozen reference provenance",
+                reference.metadata.index
+            );
+        }
+    }
+    let metadata = bindings
+        .iter()
+        .zip(&prepared.references)
+        .map(|(binding, reference)| {
+            let mut metadata = binding.metadata().clone();
+            metadata.prepared_shape = Some(reference.shape.clone());
+            metadata
+        })
+        .collect::<Vec<_>>();
+    if generation_reference_fingerprint(&metadata) != prepared.reference_fingerprint {
+        bail!("MiniMax H3 Ref2VA private media binding order changed after admission");
+    }
+    Ok(())
 }
 
 fn validate_decoded_reference(
@@ -1287,6 +1348,18 @@ mod tests {
         .unwrap()
     }
 
+    fn bindings(prepared: &H3PreparedRef2VaRequest) -> Vec<GenerationReferenceBinding> {
+        prepared
+            .references
+            .iter()
+            .map(|reference| {
+                let mut metadata = reference.metadata.clone();
+                metadata.prepared_shape = None;
+                GenerationReferenceBinding::synthetic(metadata)
+            })
+            .collect()
+    }
+
     #[derive(Default)]
     struct RecordingObserver {
         events: Vec<H3PipelineEvent>,
@@ -1361,6 +1434,7 @@ mod tests {
         fn decode_reference(
             &mut self,
             reference: &H3PreparedReference,
+            binding: &GenerationReferenceBinding,
             checkpoint: &mut dyn H3PipelineCheckpoint,
         ) -> Result<H3DecodedReferenceFacts> {
             checkpoint.checkpoint(H3PipelineEvent {
@@ -1369,6 +1443,10 @@ mod tests {
                 total: 1,
             })?;
             let metadata = &reference.metadata;
+            let mut bound_metadata = binding.metadata().clone();
+            bound_metadata.prepared_shape = Some(reference.shape.clone());
+            assert_eq!(&bound_metadata, metadata);
+            assert!(binding.file().metadata().unwrap().is_file());
             self.decoded_order.push(metadata.index);
             let audio = match metadata.kind {
                 GenerationReferenceKind::Image => None,
@@ -1734,6 +1812,7 @@ mod tests {
         let mut backend = SyntheticBackend::new();
         let staged = execute_staged(
             &prepared,
+            &bindings(&prepared),
             &mut backend,
             &ProgressReporter::default(),
             &mut NoopH3PipelineObserver,
@@ -1793,6 +1872,40 @@ mod tests {
     }
 
     #[test]
+    fn private_reference_bindings_require_exact_count_order_and_provenance() {
+        let prepared = prepare(&request());
+        let mut missing = bindings(&prepared);
+        missing.pop();
+        let mut backend = SyntheticBackend::new();
+        let error = execute_staged(
+            &prepared,
+            &missing,
+            &mut backend,
+            &ProgressReporter::default(),
+            &mut NoopH3PipelineObserver,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("private media bindings"));
+        assert!(backend.decoded_order.is_empty());
+
+        let mut reordered = bindings(&prepared);
+        reordered.swap(0, 1);
+        let mut backend = SyntheticBackend::new();
+        let error = execute_staged(
+            &prepared,
+            &reordered,
+            &mut backend,
+            &ProgressReporter::default(),
+            &mut NoopH3PipelineObserver,
+        )
+        .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("differs from frozen reference provenance"));
+        assert!(backend.decoded_order.is_empty());
+    }
+
+    #[test]
     fn every_long_ref2va_phase_has_a_cancellation_checkpoint() {
         let prepared = prepare(&request());
         for phase in [
@@ -1819,6 +1932,7 @@ mod tests {
             };
             let error = execute_staged(
                 &prepared,
+                &bindings(&prepared),
                 &mut SyntheticBackend::new(),
                 &progress,
                 &mut observer,
@@ -1835,6 +1949,7 @@ mod tests {
         rerouted.reroute_after_decode = true;
         let error = execute_staged(
             &prepared,
+            &bindings(&prepared),
             &mut rerouted,
             &ProgressReporter::default(),
             &mut NoopH3PipelineObserver,
@@ -1846,6 +1961,7 @@ mod tests {
         denoise_reroute.reroute_after_denoise = true;
         let error = execute_staged(
             &prepared,
+            &bindings(&prepared),
             &mut denoise_reroute,
             &ProgressReporter::default(),
             &mut NoopH3PipelineObserver,
@@ -1857,6 +1973,7 @@ mod tests {
         too_small.maximum_rows = 1;
         let error = execute_staged(
             &prepared,
+            &bindings(&prepared),
             &mut too_small,
             &ProgressReporter::default(),
             &mut NoopH3PipelineObserver,
@@ -1873,6 +1990,7 @@ mod tests {
         let prepared = prepare(&request());
         let staged = execute_staged(
             &prepared,
+            &bindings(&prepared),
             &mut SyntheticBackend::new(),
             &ProgressReporter::default(),
             &mut NoopH3PipelineObserver,

--- a/crates/mold-server/src/gpu_worker.rs
+++ b/crates/mold-server/src/gpu_worker.rs
@@ -168,6 +168,14 @@ impl mold_inference::InferenceEngine for PlannedInferenceEngine {
         self.inner.generate(req)
     }
 
+    fn generate_with_reference_bindings(
+        &mut self,
+        req: &mold_core::GenerateRequest,
+        bindings: &[mold_inference::GenerationReferenceBinding],
+    ) -> anyhow::Result<mold_core::GenerateResponse> {
+        self.inner.generate_with_reference_bindings(req, bindings)
+    }
+
     fn model_name(&self) -> &str {
         self.inner.model_name()
     }
@@ -2646,6 +2654,31 @@ fn process_job_with_sink(
         return false;
     }
 
+    // The durable parent owns an attempt-scoped token. Reference hashing runs
+    // on this dedicated worker thread and polls the same token before any
+    // model or CUDA work begins.
+    let batch_cancellation = job
+        .batch_child
+        .as_ref()
+        .map(|child| child.cancellation.clone());
+    let reference_bindings = match crate::reference_uploads::inference_bindings_for_request(
+        &job.request,
+        job.resolved_references.as_ref(),
+        batch_cancellation.as_ref(),
+    ) {
+        Ok(bindings) => bindings,
+        Err(error) => {
+            let err_msg = format!("generation reference binding error: {error:#}");
+            if let Some(ref tx) = job.progress_tx {
+                let _ = tx.send(SseMessage::Error(SseErrorEvent {
+                    message: err_msg.clone(),
+                }));
+            }
+            let _ = job.result_tx.send(Err(err_msg));
+            return false;
+        }
+    };
+
     // Mark the registry entry as running on this specific GPU. The /api/queue
     // listing now shows this row as `state: "running"` with `gpu: <ordinal>`.
     // The V2 coordinator claims the row atomically before transport. Legacy
@@ -2858,14 +2891,6 @@ fn process_job_with_sink(
             .expect("failed to spawn RSS watchdog")
     };
 
-    // The durable parent owns an attempt-scoped token. Installing that exact
-    // token lets cancellation stop expensive inference at family-defined safe
-    // checkpoints instead of merely fencing publication after work completes.
-    let batch_cancellation = job
-        .batch_child
-        .as_ref()
-        .map(|child| child.cancellation.clone());
-
     // Run inference — cache mutex is FREE during this.
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         ensure_worker_not_poisoned(worker, &model_name)?;
@@ -2873,9 +2898,11 @@ fn process_job_with_sink(
             Some(cancellation) => mold_inference::with_inference_cancellation(
                 &mut *cached_engine.engine,
                 cancellation.clone(),
-                |engine| engine.generate(&job.request),
+                |engine| engine.generate_with_reference_bindings(&job.request, &reference_bindings),
             ),
-            None => cached_engine.engine.generate(&job.request),
+            None => cached_engine
+                .engine
+                .generate_with_reference_bindings(&job.request, &reference_bindings),
         }
     }));
 

--- a/crates/mold-server/src/h3_admission.rs
+++ b/crates/mold-server/src/h3_admission.rs
@@ -448,6 +448,36 @@ impl H3PreparedRequestShape {
         qwen_output_text_rows: u64,
         qwen_vision_rows: u64,
     ) -> Result<(H3FrozenTask, Self), H3AdmissionError> {
+        Self::from_request_with_reference_authority(
+            request,
+            qwen_output_text_rows,
+            qwen_vision_rows,
+            false,
+        )
+    }
+
+    /// Build admission authority from the payload-free descriptor request
+    /// retained after authenticated Ref2VA ingress. Descriptor authorities are
+    /// invalid at the public boundary but are the only valid queue/worker form.
+    pub(crate) fn from_resolved_prepared_request(
+        request: &GenerateRequest,
+        qwen_output_text_rows: u64,
+        qwen_vision_rows: u64,
+    ) -> Result<(H3FrozenTask, Self), H3AdmissionError> {
+        Self::from_request_with_reference_authority(
+            request,
+            qwen_output_text_rows,
+            qwen_vision_rows,
+            true,
+        )
+    }
+
+    fn from_request_with_reference_authority(
+        request: &GenerateRequest,
+        qwen_output_text_rows: u64,
+        qwen_vision_rows: u64,
+        resolved_references: bool,
+    ) -> Result<(H3FrozenTask, Self), H3AdmissionError> {
         let contract =
             minimax_h3::capability_contract_for_model(&request.model).ok_or_else(|| {
                 H3AdmissionError::RequestContract(format!(
@@ -455,8 +485,12 @@ impl H3PreparedRequestShape {
                     request.model
                 ))
             })?;
-        minimax_h3::validate_request_contract(request, contract.task)
-            .map_err(|error| H3AdmissionError::RequestContract(error.to_string()))?;
+        if resolved_references {
+            minimax_h3::validate_resolved_request_contract(request, contract.task)
+        } else {
+            minimax_h3::validate_request_contract(request, contract.task)
+        }
+        .map_err(|error| H3AdmissionError::RequestContract(error.to_string()))?;
         if qwen_output_text_rows == 0 || qwen_output_text_rows > H3_QWEN_MODEL_MAX_ROWS {
             return Err(H3AdmissionError::RequestContract(format!(
                 "H3 Qwen output rows must be 1..={H3_QWEN_MODEL_MAX_ROWS}, got {qwen_output_text_rows}"
@@ -464,7 +498,8 @@ impl H3PreparedRequestShape {
         }
         let width = u64::from(request.width);
         let height = u64::from(request.height);
-        let frames = u64::from(request.frames.unwrap_or(minimax_h3::MIN_FRAMES));
+        let target_frames = request.frames.unwrap_or(minimax_h3::MIN_FRAMES);
+        let frames = u64::from(target_frames);
         let video_latent_frames = frames
             .checked_sub(u64::from(minimax_h3::FRAME_OFFSET))
             .ok_or(H3AdmissionError::ArithmeticOverflow("video latent frames"))?
@@ -496,26 +531,23 @@ impl H3PreparedRequestShape {
             .ok_or(H3AdmissionError::ArithmeticOverflow("target audio samples"))?
             / 3;
 
-        let reference_shapes = request
-            .references
-            .as_deref()
-            .map(minimax_h3::reference_prepared_shapes)
-            .transpose()
-            .map_err(|error| H3AdmissionError::RequestContract(error.to_string()))?
-            .unwrap_or_default();
-        let reference_metadata = request
-            .references
-            .as_deref()
-            .unwrap_or_default()
+        let references = request.references.as_deref().unwrap_or_default();
+        let reference_shapes =
+            minimax_h3::reference_prepared_shapes_for_target(references, target_frames)
+                .map_err(|error| H3AdmissionError::RequestContract(error.to_string()))?;
+        let reference_metadata = references
             .iter()
+            .zip(&reference_shapes)
             .enumerate()
-            .map(|(index, reference)| {
-                reference.redacted_metadata(index).ok_or_else(|| {
+            .map(|(index, (reference, shape))| {
+                let mut metadata = reference.redacted_metadata(index).ok_or_else(|| {
                     H3AdmissionError::RequestContract(format!(
                         "reference {} lacks a validated digest or prepared shape",
                         index + 1
                     ))
-                })
+                })?;
+                metadata.prepared_shape = Some(shape.clone());
+                Ok(metadata)
             })
             .collect::<Result<Vec<_>, _>>()?;
         let reference_fingerprint =
@@ -1480,11 +1512,6 @@ pub(crate) fn bind_h3_factory_authority(
             "H3 server admission and factory authorities disagree".to_string(),
         ));
     }
-    if plan.task != H3FrozenTask::Fl2va {
-        return Err(H3AdmissionError::InvalidRuntimeFacts(
-            "the current H3 Candle factory authority is FL2VA-only".to_string(),
-        ));
-    }
     if !minimax_h3::is_family(&engine_config.family) {
         return Err(H3AdmissionError::InvalidRuntimeFacts(
             "H3 admission cannot bind a non-H3 frozen engine family".to_string(),
@@ -1548,6 +1575,11 @@ pub(crate) fn bind_h3_factory_authority(
         },
     )
     .map_err(|error| H3AdmissionError::InvalidRuntimeFacts(error.to_string()))?;
+    if H3FrozenTask::from(authority.task()) != plan.task {
+        return Err(H3AdmissionError::InvalidRuntimeFacts(
+            "H3 factory task authority changed during binding".to_string(),
+        ));
+    }
     engine_config.h3_factory_authority = Some(authority);
     Ok(())
 }
@@ -2133,6 +2165,46 @@ mod tests {
     }
 
     #[test]
+    fn ref2va_admission_fingerprint_and_rows_use_the_frozen_target_duration() {
+        let reference = GenerationReference::Video {
+            media: GenerationReferenceAuthority::ServerPath {
+                path: "/synthetic/not-read/long-reference.mp4".to_string(),
+            },
+            provenance: GenerationReferenceProvenance {
+                name: Some("long-reference.mp4".to_string()),
+                sha256: Some(sha(19)),
+            },
+            mime_type: "video/mp4".to_string(),
+            width: 1280,
+            height: 720,
+            frame_count: Some(360),
+            duration_ms: 15_000,
+            fps: 24.0,
+            has_audio: true,
+            audio_duration_ms: Some(15_000),
+            audio_sample_count: Some(480_000),
+            audio_sample_rate: Some(32_000),
+            audio_channels: Some(2),
+        };
+        let mut short_request = request(minimax_h3::REF2VA_COMFY, 124);
+        short_request.references = Some(vec![reference.clone()]);
+        let (_, short) =
+            H3PreparedRequestShape::from_prepared_request(&short_request, 128, 512).unwrap();
+        let mut long_request = request(minimax_h3::REF2VA_COMFY, 362);
+        long_request.references = Some(vec![reference]);
+        let (_, long) =
+            H3PreparedRequestShape::from_prepared_request(&long_request, 128, 512).unwrap();
+
+        assert_eq!(short.reference_shapes[0].normalized_video_frames, Some(124));
+        assert_eq!(long.reference_shapes[0].normalized_video_frames, Some(360));
+        assert!(short.rows.condition_visual_rows < long.rows.condition_visual_rows);
+        assert!(short.rows.condition_audio_rows < long.rows.condition_audio_rows);
+        assert_ne!(short.reference_fingerprint, long.reference_fingerprint);
+        assert_eq!(short.conditioning_fingerprint, short.reference_fingerprint);
+        assert_eq!(long.conditioning_fingerprint, long.reference_fingerprint);
+    }
+
+    #[test]
     fn pinned_full_and_curated_stacks_charge_every_physical_artifact() {
         let official =
             H3ArtifactInventory::pending_from_manifest(minimax_h3::FL2VA_OFFICIAL).unwrap();
@@ -2530,6 +2602,65 @@ mod tests {
             Some(authority.identity_sha256())
         );
         assert!(!minimax_h3::capabilities(minimax_h3::Task::Fl2va).runtime_available);
+    }
+
+    #[test]
+    fn admitted_ref2va_plan_binds_exact_task_route_and_reference_authority() {
+        let inventory = landed_inventory(minimax_h3::REF2VA_COMFY);
+        let checkpoint = checkpoint(&inventory);
+        let runtime = qualified_runtime();
+        let device = cuda(24 * GIB);
+        let mut request = request(minimax_h3::REF2VA_COMFY, 124);
+        request.references = Some(vec![GenerationReference::Image {
+            media: GenerationReferenceAuthority::Descriptor,
+            provenance: GenerationReferenceProvenance {
+                name: Some("reference.png".to_string()),
+                sha256: Some(sha(17)),
+            },
+            mime_type: "image/png".to_string(),
+            width: 1024,
+            height: 768,
+        }]);
+        assert!(H3PreparedRequestShape::from_prepared_request(&request, 128, 1_024).is_err());
+        let (task, shape) =
+            H3PreparedRequestShape::from_resolved_prepared_request(&request, 128, 1_024).unwrap();
+        let reference_fingerprint = shape.reference_fingerprint.clone();
+        let plan = plan_h3_admission(
+            task,
+            shape,
+            &inventory,
+            &checkpoint,
+            Some(&runtime),
+            std::slice::from_ref(&device),
+            H3HostMemory {
+                total_bytes: 96 * GIB,
+                available_bytes: 96 * GIB,
+            },
+            H3AdmissionPolicy::default(),
+        )
+        .unwrap();
+        let mut engine_config = mold_inference::FrozenEngineConfig::resolve(
+            minimax_h3::REF2VA_COMFY,
+            &mold_core::Config::default(),
+        );
+        engine_config.family = minimax_h3::FAMILY.to_string();
+
+        bind_h3_factory_authority(&plan, &inventory, &checkpoint, &device, &mut engine_config)
+            .unwrap();
+        let authority = engine_config.h3_factory_authority.as_ref().unwrap();
+        assert_eq!(plan.task, H3FrozenTask::Ref2va);
+        assert_eq!(authority.task(), minimax_h3::Task::Ref2va);
+        assert_eq!(authority.canonical_model(), minimax_h3::REF2VA_COMFY);
+        assert_eq!(authority.device_id(), plan.device_id);
+        assert_eq!(
+            authority.execution_fingerprint(),
+            plan.execution_fingerprint
+        );
+        assert_eq!(plan.shape.reference_fingerprint, reference_fingerprint);
+        assert!(!minimax_h3::capabilities(minimax_h3::Task::Ref2va).runtime_available);
+        assert!(
+            minimax_h3::runnable_capability_contract_for_model(minimax_h3::REF2VA_COMFY).is_none()
+        );
     }
 
     #[test]

--- a/crates/mold-server/src/queue.rs
+++ b/crates/mold-server/src/queue.rs
@@ -1404,7 +1404,7 @@ pub(crate) fn resolve_max_deferrals() -> usize {
     }
 }
 
-async fn process_job(state: &AppState, job: GenerationJob) {
+async fn process_job(state: &AppState, mut job: GenerationJob) {
     // Check if client already disconnected before doing any work
     if job.result_tx.is_closed() {
         tracing::debug!("skipping queued job — client disconnected");
@@ -1424,6 +1424,48 @@ async fn process_job(state: &AppState, job: GenerationJob) {
             id: job.id.clone(),
         }));
     }
+
+    // Reference binding verifies up to one GiB of staged media. Keep that I/O
+    // off Tokio's async worker and return the staging owner alongside the
+    // opened handles so it remains alive for the whole generation attempt.
+    let reference_binding_result =
+        if job.request.references.is_none() && job.resolved_references.is_none() {
+            Ok(Vec::new())
+        } else {
+            let request = job.request.clone();
+            let resolved = job.resolved_references.take();
+            match tokio::task::spawn_blocking(move || {
+                let result = crate::reference_uploads::inference_bindings_for_request(
+                    &request,
+                    resolved.as_ref(),
+                    None,
+                );
+                (resolved, result)
+            })
+            .await
+            {
+                Ok((resolved, result)) => {
+                    job.resolved_references = resolved;
+                    result
+                }
+                Err(_) => Err(anyhow::anyhow!(
+                    "reference binding worker did not complete safely"
+                )),
+            }
+        };
+    let reference_bindings = match reference_binding_result {
+        Ok(bindings) => bindings,
+        Err(error) => {
+            let err_msg = format!("generation reference binding error: {error:#}");
+            if let Some(ref tx) = job.progress_tx {
+                let _ = tx.send(SseMessage::Error(SseErrorEvent {
+                    message: err_msg.clone(),
+                }));
+            }
+            let _ = job.result_tx.send(Err(err_msg));
+            return;
+        }
+    };
 
     // 1. Ensure model is ready (with progress forwarding)
     let progress_callback = job.progress_tx.as_ref().map(|tx| {
@@ -1515,7 +1557,9 @@ async fn process_job(state: &AppState, job: GenerationJob) {
     // the cache in async context regardless of outcome.
     let join_result = tokio::task::spawn_blocking(move || {
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            cached_engine.engine.generate(&gen_req)
+            cached_engine
+                .engine
+                .generate_with_reference_bindings(&gen_req, &reference_bindings)
         }));
         if was_streaming {
             cached_engine.engine.clear_on_progress();
@@ -4216,6 +4260,160 @@ mod tests {
             event.image.is_empty(),
             "metadata-only SSE must not duplicate MP4 bytes"
         );
+    }
+
+    #[test]
+    fn synthetic_h3_ref2va_publication_preserves_ordered_redacted_provenance() {
+        use mold_core::{
+            GenerationReference, GenerationReferenceAuthority, GenerationReferenceKind,
+            GenerationReferenceProvenance,
+        };
+
+        let tmp = TempDir::new().unwrap();
+        let db = MetadataDb::open_in_memory().unwrap();
+        let provenance = |name: &str, byte: u8| GenerationReferenceProvenance {
+            name: Some(name.to_string()),
+            sha256: Some(format!("{byte:02x}").repeat(32)),
+        };
+        let mut request = fake_request(mold_core::minimax_h3::REF2VA_COMFY);
+        request.width = 1344;
+        request.height = 768;
+        request.frames = Some(124);
+        request.fps = Some(24);
+        request.output_format = Some(OutputFormat::Mp4);
+        request.enable_audio = Some(true);
+        request.guidance = 0.0;
+        request.strength = 1.0;
+        request.references = Some(vec![
+            GenerationReference::Video {
+                media: GenerationReferenceAuthority::Descriptor,
+                provenance: provenance("motion.mp4", 1),
+                mime_type: "video/mp4".to_string(),
+                width: 1280,
+                height: 720,
+                frame_count: Some(48),
+                duration_ms: 2_000,
+                fps: 24.0,
+                has_audio: true,
+                audio_duration_ms: Some(2_000),
+                audio_sample_count: Some(96_000),
+                audio_sample_rate: Some(48_000),
+                audio_channels: Some(2),
+            },
+            GenerationReference::Image {
+                media: GenerationReferenceAuthority::Descriptor,
+                provenance: provenance("portrait.png", 2),
+                mime_type: "image/png".to_string(),
+                width: 1024,
+                height: 768,
+            },
+            GenerationReference::Audio {
+                media: GenerationReferenceAuthority::Descriptor,
+                provenance: provenance("voice.wav", 3),
+                mime_type: "audio/wav".to_string(),
+                duration_ms: 2_000,
+                sample_rate: 48_000,
+                channels: 1,
+                sample_count: Some(96_000),
+            },
+        ]);
+        let video = mold_core::VideoData {
+            data: b"synthetic-ref2va-mp4-with-synchronized-audio".to_vec(),
+            format: OutputFormat::Mp4,
+            width: request.width,
+            height: request.height,
+            frames: request.frames.unwrap(),
+            fps: request.fps.unwrap(),
+            pipeline: None,
+            thumbnail: b"synthetic-ref2va-thumbnail".to_vec(),
+            gif_preview: Vec::new(),
+            has_audio: true,
+            duration_ms: Some(5_167),
+            audio_sample_rate: Some(mold_core::minimax_h3::AUDIO_SAMPLE_RATE_HZ),
+            audio_channels: Some(mold_core::minimax_h3::AUDIO_CHANNELS),
+        };
+        let response = mold_core::GenerateResponse {
+            images: Vec::new(),
+            video: Some(video.clone()),
+            audio: None,
+            generation_time_ms: 12_345,
+            model: request.model.clone(),
+            seed_used: 42,
+            gpu: Some(0),
+        };
+        let mut metadata = OutputMetadata::from_generate_request(&request, 42, None, "test");
+        metadata.apply_video_output(&video);
+        let gallery_gate = crate::batch_transaction::GalleryPublicationGate::default();
+        let filename = save_video_to_dir(
+            tmp.path(),
+            &video.data,
+            &video.gif_preview,
+            video.format,
+            &request.model,
+            &metadata,
+            Some(response.generation_time_ms as i64),
+            Some(&db),
+            None,
+            &gallery_gate,
+        )
+        .unwrap();
+
+        let rows = db.list(Some(tmp.path())).unwrap();
+        let references = rows[0].metadata.references.as_deref().unwrap();
+        assert_eq!(
+            references.iter().map(|item| item.kind).collect::<Vec<_>>(),
+            [
+                GenerationReferenceKind::Video,
+                GenerationReferenceKind::Image,
+                GenerationReferenceKind::Audio,
+            ]
+        );
+        assert_eq!(references[0].index, 1);
+        assert!(references[0].has_audio);
+        assert_eq!(references[0].audio_sample_rate, Some(48_000));
+        assert_eq!(references[2].index, 3);
+        let durable_json = serde_json::to_string(&rows[0].metadata).unwrap();
+        for secret in ["authority", "handle", "server_path", "/synthetic/"] {
+            assert!(!durable_json.contains(secret));
+        }
+
+        let thumbnail = ImageData {
+            data: video.thumbnail.clone(),
+            format: OutputFormat::Png,
+            width: video.width,
+            height: video.height,
+            index: 0,
+        };
+        let SseMessage::Complete(event) = build_sse_completion_message(
+            &response,
+            &thumbnail,
+            None,
+            Some(&metadata),
+            &SavedOutputNames {
+                output: Some(filename),
+                original: None,
+            },
+            SseCompletionPayload::MetadataOnly,
+        ) else {
+            panic!("saved synthetic Ref2VA output must complete over SSE")
+        };
+        assert_eq!(
+            event.video_audio_sample_rate,
+            Some(mold_core::minimax_h3::AUDIO_SAMPLE_RATE_HZ)
+        );
+        assert_eq!(
+            event.video_audio_channels,
+            Some(mold_core::minimax_h3::AUDIO_CHANNELS)
+        );
+        assert_eq!(
+            event
+                .metadata
+                .as_ref()
+                .and_then(|value| value.references.as_ref())
+                .map(|items| items.iter().map(|item| item.index).collect::<Vec<_>>()),
+            Some(vec![1, 2, 3])
+        );
+        assert!(event.image.is_empty());
     }
 
     #[test]

--- a/crates/mold-server/src/reference_uploads.rs
+++ b/crates/mold-server/src/reference_uploads.rs
@@ -178,6 +178,68 @@ impl ResolvedReferenceSet {
     pub fn fingerprint(&self) -> &str {
         &self.fingerprint
     }
+
+    /// Bind the payload-free queued request back to the private staged files
+    /// immediately before inference. The order, complete probed metadata, and
+    /// aggregate fingerprint must all still match; paths never enter the
+    /// request, scheduler plan, logs, SSE, or gallery metadata.
+    pub fn inference_bindings(
+        &self,
+        request: &mold_core::GenerateRequest,
+        cancellation: Option<&mold_inference::InferenceCancellationToken>,
+    ) -> anyhow::Result<Vec<mold_inference::GenerationReferenceBinding>> {
+        let references = request
+            .references
+            .as_deref()
+            .ok_or_else(|| anyhow::anyhow!("resolved references lost their queued descriptors"))?;
+        anyhow::ensure!(
+            references.len() == self.entries.len(),
+            "resolved reference count changed before inference"
+        );
+        let queued_metadata = references
+            .iter()
+            .enumerate()
+            .map(|(index, reference)| reference.redacted_metadata_lossless(index))
+            .collect::<Vec<_>>();
+        anyhow::ensure!(
+            mold_core::generation_reference_fingerprint(&queued_metadata) == self.fingerprint,
+            "resolved reference fingerprint changed before inference"
+        );
+        self.entries
+            .iter()
+            .zip(queued_metadata)
+            .map(|(entry, queued)| {
+                anyhow::ensure!(
+                    entry.metadata == queued,
+                    "resolved reference {} changed before inference",
+                    entry.metadata.index
+                );
+                let file = crate::batch_transaction::open_regular_file_no_follow(&entry.path)
+                    .map_err(|_| {
+                        anyhow::anyhow!(
+                            "failed to safely open resolved reference {}",
+                            entry.metadata.index
+                        )
+                    })?;
+                mold_inference::GenerationReferenceBinding::from_opened_file(
+                    entry.metadata.clone(),
+                    file,
+                    MAX_REFERENCE_UPLOAD_FILE_BYTES,
+                    cancellation,
+                )
+                .map_err(|error| {
+                    if mold_inference::is_inference_cancelled(&error) {
+                        error
+                    } else {
+                        anyhow::anyhow!(
+                            "failed to verify resolved reference {}",
+                            entry.metadata.index
+                        )
+                    }
+                })
+            })
+            .collect()
+    }
 }
 
 impl Drop for ResolvedReferenceSet {
@@ -187,6 +249,23 @@ impl Drop for ResolvedReferenceSet {
                 tracing::warn!("failed to remove private reference staging: {error}");
             }
         }
+    }
+}
+
+pub(crate) fn inference_bindings_for_request(
+    request: &mold_core::GenerateRequest,
+    resolved: Option<&ResolvedReferenceSet>,
+    cancellation: Option<&mold_inference::InferenceCancellationToken>,
+) -> anyhow::Result<Vec<mold_inference::GenerationReferenceBinding>> {
+    match (request.references.is_some(), resolved) {
+        (false, None) => Ok(Vec::new()),
+        (true, Some(resolved)) => resolved.inference_bindings(request, cancellation),
+        (true, None) => anyhow::bail!(
+            "reference-bearing generation reached inference without private resolved media"
+        ),
+        (false, Some(_)) => anyhow::bail!(
+            "private resolved media reached inference without queued reference descriptors"
+        ),
     }
 }
 
@@ -1797,6 +1876,7 @@ mod tests {
             "steps": minimax_h3::DEFAULT_STEPS,
             "guidance": 0.0,
             "batch_size": 1,
+            "strength": 1.0,
             "frames": minimax_h3::MIN_FRAMES,
             "fps": minimax_h3::FIXED_FPS,
             "output_format": "mp4"
@@ -1811,6 +1891,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let store = ReferenceUploadStore::at(dir.path().join("cache"));
         let bytes = png_bytes();
+        let expected_bytes = bytes.clone();
         let byte_count = bytes.len() as u64;
         let digest = format!("{:x}", Sha256::digest(&bytes));
         let descriptor = png_reference(GenerationReferenceAuthority::Descriptor, Some(digest));
@@ -1842,7 +1923,9 @@ mod tests {
         assert!(complete.metadata.prepared_shape.is_some());
 
         let mut final_request = request(png_reference(
-            GenerationReferenceAuthority::Upload { handle },
+            GenerationReferenceAuthority::Upload {
+                handle: handle.clone(),
+            },
             Some(complete.metadata.sha256.clone()),
         ));
         let resolved = store
@@ -1857,9 +1940,92 @@ mod tests {
             final_request.references.as_ref().unwrap()[0].media(),
             GenerationReferenceAuthority::Descriptor
         ));
+        let (task, prepared) =
+            crate::h3_admission::H3PreparedRequestShape::from_resolved_prepared_request(
+                &final_request,
+                128,
+                1_024,
+            )
+            .unwrap();
+        assert_eq!(task, crate::h3_admission::H3FrozenTask::Ref2va);
+        assert_eq!(prepared.reference_fingerprint, resolved.fingerprint());
         assert!(!format!("{resolved:?}").contains(dir.path().to_string_lossy().as_ref()));
+        let bindings = resolved.inference_bindings(&final_request, None).unwrap();
+        assert_eq!(bindings.len(), 1);
+        assert_eq!(bindings[0].metadata(), &complete.metadata);
+        let debug = format!("{bindings:?}");
+        assert!(!debug.contains(dir.path().to_string_lossy().as_ref()));
+        assert!(!debug.contains(&handle));
+        let cancellation = mold_inference::InferenceCancellationToken::default();
+        cancellation.cancel();
+        let cancelled = resolved
+            .inference_bindings(&final_request, Some(&cancellation))
+            .unwrap_err();
+        assert!(mold_inference::is_inference_cancelled(&cancelled));
+
+        // Binding hashes and retains the exact no-follow handle. Replacing the
+        // staged pathname after dispatch cannot alter the bytes decoded under
+        // the frozen digest, and a later bind fails closed on the replacement.
+        let staged = resolved.entries()[0].path.clone();
+        let displaced = staged.with_extension("displaced");
+        std::fs::rename(&staged, &displaced).unwrap();
+        std::fs::write(&staged, b"different replacement bytes").unwrap();
+        let mut bound = bindings[0].file();
+        bound.seek(SeekFrom::Start(0)).unwrap();
+        let mut observed = Vec::new();
+        bound.read_to_end(&mut observed).unwrap();
+        assert_eq!(observed, expected_bytes);
+        let replacement_error = resolved
+            .inference_bindings(&final_request, None)
+            .unwrap_err();
+        let replacement_message = format!("{replacement_error:#}");
+        assert!(!replacement_message.contains(dir.path().to_string_lossy().as_ref()));
+        assert!(!replacement_message.contains(&handle));
+
+        // Even the lower-level safe-open error includes the private path.
+        // A non-regular replacement must remain client-safe at this boundary.
+        std::fs::remove_file(&staged).unwrap();
+        std::fs::create_dir(&staged).unwrap();
+        let open_error = resolved
+            .inference_bindings(&final_request, None)
+            .unwrap_err();
+        let open_message = format!("{open_error:#}");
+        assert!(!open_message.contains(dir.path().to_string_lossy().as_ref()));
+        assert!(!open_message.contains(&handle));
+
+        let mut changed = final_request.clone();
+        if let GenerationReference::Image { provenance, .. } =
+            &mut changed.references.as_mut().unwrap()[0]
+        {
+            provenance.name = Some("changed.png".to_string());
+        }
+        assert!(resolved.inference_bindings(&changed, None).is_err());
+        drop(bindings);
         drop(resolved);
         assert_eq!(store.resolved_bytes.load(Ordering::Acquire), 0);
+    }
+
+    #[test]
+    fn inference_binding_presence_must_match_payload_free_request() {
+        let plain: mold_core::GenerateRequest = serde_json::from_value(serde_json::json!({
+            "prompt": "plain",
+            "model": minimax_h3::FL2VA_COMFY,
+            "width": 32,
+            "height": 32,
+            "steps": 4,
+            "guidance": 0.0,
+            "batch_size": 1
+        }))
+        .unwrap();
+        assert!(inference_bindings_for_request(&plain, None, None)
+            .unwrap()
+            .is_empty());
+
+        let reference_request = request(png_reference(
+            GenerationReferenceAuthority::Descriptor,
+            Some("11".repeat(32)),
+        ));
+        assert!(inference_bindings_for_request(&reference_request, None, None).is_err());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- carry private, non-serializable ordered-reference bindings from authenticated upload resolution through legacy and GPU-worker dispatch
- validate exact reference order, provenance, bindings, and frozen fingerprints before backend work
- add task-neutral frozen factory/admission authority plus synthetic Ref2VA engine, streamed backend, cancellation, progress, and synchronized AV publication contracts
- preserve 32 kHz stereo MP4 facts in redacted SSE/gallery metadata

## Safety boundary

This PR does not add a production loader, manifest, catalog entry, runtime capability, server-batch capability, or model download. The MiniMax H3 legal/runtime gates remain fail-closed, and no H3 weight, header, model artifact, or generated output was accessed.

## Stack

Stacked on #865 (feat/h3-fp8-int8-execution). Once #865 merges, this PR will be retargeted to main and its exact current head will be revalidated before merge.

## Verification

- mold-ai-core H3 validation and resolved-reference contracts
- inference H3 factory/backend/engine/Ref2VA pipeline tests, including MP4 cancellation
- server reference-upload, H3 admission, Ref2VA publication, and existing FL2VA publication tests
- strict Clippy for core/inference/server
- formatting and diff checks
- stable patch-id de33617237630eaa2d677b48ff9660d2e3ebf2f0

Real-weight parity and rendered hardware UAT remain blocked by #831.