### PR TITLE
feat(surfaces): add MiniMax H3 CLI, TUI, and Discord authoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3174,6 +3174,7 @@ dependencies = [
  "dirs 6.0.0",
  "hf-hub",
  "indicatif 0.17.11",
+ "libc",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3182,6 +3182,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "toml",
  "tracing",
  "ureq",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3224,6 +3224,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "symphonia",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3216,11 +3216,14 @@ name = "mold-ai-discord"
 version = "0.21.0"
 dependencies = [
  "anyhow",
+ "image",
  "mold-ai-core",
  "mold-ai-db",
+ "mp4",
  "poise",
  "serde",
  "serde_json",
+ "sha2",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -3340,6 +3343,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "sha2",
  "sysinfo",
  "tachyonfx",
  "tempfile",

--- a/crates/mold-cli/src/commands/generate.rs
+++ b/crates/mold-cli/src/commands/generate.rs
@@ -1,13 +1,14 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 #[cfg(any(feature = "preview", test))]
 use base64::{engine::general_purpose, Engine as _};
 use colored::Colorize;
 use indicatif::{ProgressBar, ProgressStyle};
 use mold_core::{
     classify_generate_error, fit_to_model_dimensions_aligned, fit_to_target_area, manifest, Config,
-    DevicePlacement, GenerateRequest, GenerateResponse, GenerateServerAction, ImageData,
-    KeyframeCondition, LoraWeight, Ltx2GuidanceOverrides, Ltx2PipelineMode, Ltx2SpatialUpscale,
-    Ltx2TemporalUpscale, MoldClient, OutputFormat, Scheduler, TimeRange,
+    DevicePlacement, GenerateRequest, GenerateResponse, GenerateServerAction, GenerationReference,
+    GenerationReferenceAuthority, ImageData, KeyframeCondition, LoraWeight, Ltx2GuidanceOverrides,
+    Ltx2PipelineMode, Ltx2SpatialUpscale, Ltx2TemporalUpscale, MoldClient, OutputFormat,
+    ReferenceUploadSessionRequest, Scheduler, TimeRange,
 };
 use rand::Rng;
 #[cfg(feature = "preview")]
@@ -15,6 +16,7 @@ use std::io::IsTerminal;
 use std::io::Write;
 use std::time::Duration;
 
+use crate::commands::h3::ReferenceUpload;
 use crate::control::{stream_server_pull, CliContext};
 use crate::errors::RemoteInferenceError;
 use crate::output::{is_piped, status};
@@ -140,6 +142,25 @@ fn effective_dimensions(
     source_image: Option<&[u8]>,
     edit_images: Option<&[Vec<u8>]>,
 ) -> Result<(u32, u32)> {
+    if family.is_some_and(mold_core::minimax_h3::is_family) {
+        return match (width, height, source_image) {
+            (Some(width), Some(height), _) => Ok((width, height)),
+            (Some(width), None, _) => Ok((width, model_cfg.effective_height(config))),
+            (None, Some(height), _) => Ok((model_cfg.effective_width(config), height)),
+            (None, None, Some(source_image)) => {
+                let image = image::load_from_memory(source_image)
+                    .map_err(|error| anyhow::anyhow!("failed to decode H3 first frame: {error}"))?;
+                Ok(mold_core::minimax_h3::recommended_dimensions(
+                    image.width(),
+                    image.height(),
+                ))
+            }
+            (None, None, None) => Ok((
+                mold_core::minimax_h3::DEFAULT_WIDTH,
+                mold_core::minimax_h3::DEFAULT_HEIGHT,
+            )),
+        };
+    }
     match (width, height, source_image) {
         (Some(width), Some(height), _) => Ok((width, height)),
         (Some(width), None, _) => Ok((width, model_cfg.effective_height(config))),
@@ -278,6 +299,13 @@ pub struct Ltx2Options {
     /// Advanced multimodal-guider overrides. `None` keeps every pipeline
     /// constant, which is what makes existing seeds reproducible.
     pub guidance_overrides: Option<Ltx2GuidanceOverrides>,
+    /// Display-safe first-frame provenance. Never a client path.
+    pub source_image_name: Option<String>,
+    /// Payload-free ordered H3 Ref2VA descriptors.
+    pub references: Option<Vec<GenerationReference>>,
+    /// Local files corresponding one-for-one with `references`. They are
+    /// streamed only after an authenticated request-bound session is created.
+    pub reference_uploads: Vec<ReferenceUpload>,
 }
 
 fn require_local_hdr_exr_dir(hdr_exr_dir: Option<String>, local: bool) -> Result<Option<String>> {
@@ -350,6 +378,9 @@ pub async fn run(
         spatial_upscale,
         temporal_upscale,
         guidance_overrides,
+        source_image_name,
+        references,
+        reference_uploads,
     } = ltx2;
     // Keep the filesystem path out of every remote request shape. Local
     // generation retains the exact user path so export metadata remains
@@ -372,8 +403,36 @@ pub async fn run(
     let embed_metadata = config.effective_embed_metadata(no_metadata.then_some(false));
     let model_cfg = config.resolved_model_config(model);
     let family = resolve_family(model, &config);
-    let effective_frames = frames.or_else(|| model_cfg.effective_frames());
-    let effective_fps = fps.or_else(|| model_cfg.effective_fps());
+    let is_h3 = family
+        .as_deref()
+        .is_some_and(mold_core::minimax_h3::is_family);
+    if is_h3 && !reference_uploads.is_empty() && batch != 1 {
+        anyhow::bail!(
+            "MiniMax H3 ordered references require batch 1 because upload handles are one-use and request-bound"
+        );
+    }
+    if is_h3
+        && references.as_ref().is_some_and(|references| {
+            references.iter().any(|reference| {
+                matches!(reference.media(), GenerationReferenceAuthority::Descriptor)
+            })
+        })
+        && reference_uploads.is_empty()
+    {
+        anyhow::bail!(
+            "MiniMax H3 reference descriptors require authenticated streaming upload sources"
+        );
+    }
+    let effective_frames = if is_h3 {
+        Some(frames.unwrap_or(mold_core::minimax_h3::MIN_FRAMES))
+    } else {
+        frames.or_else(|| model_cfg.effective_frames())
+    };
+    let effective_fps = if is_h3 {
+        Some(mold_core::minimax_h3::FIXED_FPS)
+    } else {
+        fps.or_else(|| model_cfg.effective_fps())
+    };
     let is_ltx2 = family.as_deref() == Some("ltx2");
     validate_cli_batch_for_family(family.as_deref(), batch)?;
 
@@ -383,7 +442,9 @@ pub async fn run(
     let audio_only_pipeline = ltx2
         .pipeline
         .is_some_and(mold_core::Ltx2PipelineMode::is_audio_only);
-    let output_format = if audio_only_pipeline && format == OutputFormat::Png {
+    let output_format = if is_h3 {
+        OutputFormat::Mp4
+    } else if audio_only_pipeline && format == OutputFormat::Png {
         OutputFormat::Wav
     } else if format == OutputFormat::Png && effective_frames.is_some() {
         if is_ltx2 {
@@ -645,13 +706,25 @@ pub async fn run(
         source_image.as_deref(),
         edit_images.as_deref(),
     )?;
-    let effective_steps = steps.unwrap_or_else(|| model_cfg.effective_steps(&config));
-    let effective_guidance = guidance.unwrap_or_else(|| model_cfg.effective_guidance());
-    let effective_negative_prompt = effective_negative_prompt(
-        family.as_deref(),
-        effective_guidance,
-        negative_prompt.clone(),
-    );
+    let effective_steps = if is_h3 {
+        steps.unwrap_or(mold_core::minimax_h3::DEFAULT_STEPS)
+    } else {
+        steps.unwrap_or_else(|| model_cfg.effective_steps(&config))
+    };
+    let effective_guidance = if is_h3 {
+        0.0
+    } else {
+        guidance.unwrap_or_else(|| model_cfg.effective_guidance())
+    };
+    let effective_negative_prompt = if is_h3 {
+        None
+    } else {
+        effective_negative_prompt(
+            family.as_deref(),
+            effective_guidance,
+            negative_prompt.clone(),
+        )
+    };
 
     let mut req = GenerateRequest {
         hdr_exr_dir,
@@ -668,13 +741,13 @@ pub async fn run(
         batch_size: batch,
         output_format: Some(output_format),
         embed_metadata: Some(embed_metadata),
-        scheduler,
-        cfg_plus,
+        scheduler: (!is_h3).then_some(scheduler).flatten(),
+        cfg_plus: (!is_h3).then_some(cfg_plus).flatten(),
         edit_images: edit_images.clone(),
-        references: None,
+        references,
         source_image: source_image.clone(),
-        source_image_name: None,
-        strength,
+        source_image_name,
+        strength: if is_h3 { 1.0 } else { strength },
         mask_image: mask_image.clone(),
         control_image: control_image.clone(),
         control_model: control_model.clone(),
@@ -690,7 +763,7 @@ pub async fn run(
         fps: effective_fps,
         upscale_model: None,
         gif_preview: preview,
-        enable_audio,
+        enable_audio: if is_h3 { Some(true) } else { enable_audio },
         audio_file,
         audio_file_path: None,
         source_video,
@@ -707,10 +780,18 @@ pub async fn run(
         temporal_upscale,
         placement,
     };
+    let base_seed = req.seed.unwrap_or_else(|| rand::thread_rng().gen());
+    let mut reference_session = None;
     if local {
         require_local_request_model_activation(&req, &config)?;
         materialize_local_builtin_control(&mut req, &config).await?;
         materialize_local_builtin_camera_controls(&mut req, &config).await?;
+    } else if !reference_uploads.is_empty() {
+        // Upload sessions bind the complete request. Freeze a random seed now
+        // rather than changing it between session creation and generation.
+        req.seed = Some(base_seed);
+        reference_session =
+            bind_remote_reference_uploads(ctx.client(), &mut req, &reference_uploads).await?;
     }
 
     // Warn if user-provided dimensions don't match model recommendations.
@@ -775,7 +856,34 @@ pub async fn run(
             );
         }
     }
-    if mask_image.is_some() {
+    if is_h3 {
+        let mode = match mold_core::minimax_h3::task_for_model(&req.model) {
+            Some(mold_core::minimax_h3::Task::Ref2va) => format!(
+                "Ref2VA with {} ordered reference{}",
+                req.references.as_ref().map_or(0, Vec::len),
+                if req.references.as_ref().map_or(0, Vec::len) == 1 {
+                    ""
+                } else {
+                    "s"
+                }
+            ),
+            Some(mold_core::minimax_h3::Task::Fl2va) => {
+                let first = req.source_image.is_some();
+                let last = req
+                    .keyframes
+                    .as_ref()
+                    .is_some_and(|items| !items.is_empty());
+                match (first, last) {
+                    (false, false) => "T2VA".to_string(),
+                    (true, false) => "FL2VA with first frame".to_string(),
+                    (false, true) => "FL2VA with last frame".to_string(),
+                    (true, true) => "FL2VA with first and last frames".to_string(),
+                }
+            }
+            None => "unknown task".to_string(),
+        };
+        status!("{} MiniMax H3 {mode}", theme::icon_mode());
+    } else if mask_image.is_some() {
         status!(
             "{} inpainting mode (strength: {:.2})",
             theme::icon_mode(),
@@ -809,7 +917,15 @@ pub async fn run(
     let is_video = effective_frames.is_some() && !audio_only_pipeline;
     if let Some(f) = effective_frames {
         let effective_fps = effective_fps.unwrap_or(24);
-        if audio_only_pipeline {
+        if is_h3 {
+            status!(
+                "{} Synchronized AV: {} frames @ {} fps ({:.2}s), 32 kHz stereo",
+                theme::icon_mode(),
+                f,
+                effective_fps,
+                f64::from(f) / f64::from(effective_fps.max(1)),
+            );
+        } else if audio_only_pipeline {
             status!(
                 "{} Audio mode: {:.2}s ({} frames @ {} fps)",
                 theme::icon_mode(),
@@ -835,7 +951,16 @@ pub async fn run(
         }
     }
     let displayed_guidance = guidance_caps.fixed_scale.unwrap_or(effective_guidance);
-    if audio_only_pipeline {
+    if is_h3 {
+        status!(
+            "{} Generating {}x{} ({} sigma points / {} model evaluations, no CFG)",
+            theme::icon_info(),
+            effective_width,
+            effective_height,
+            effective_steps,
+            effective_steps.saturating_sub(1),
+        );
+    } else if audio_only_pipeline {
         // No raster to report. Printing the request's width and height here
         // would describe a frame this pipeline never renders.
         status!(
@@ -856,7 +981,6 @@ pub async fn run(
     }
     status!("{}", "─".repeat(40).dimmed());
 
-    let base_seed = req.seed.unwrap_or_else(|| rand::thread_rng().gen());
     let response = if local {
         print_using_local_inference();
         generate_local_batch(
@@ -934,7 +1058,16 @@ pub async fn run(
                 steps,
                 guidance,
             )
-            .await?;
+            .await;
+            let response = match response {
+                Ok(response) => response,
+                Err(error) => {
+                    if let Some(session) = reference_session.as_deref() {
+                        let _ = ctx.client().cancel_reference_upload_session(session).await;
+                    }
+                    return Err(error);
+                }
+            };
 
             // Persist every successful artifact before the next batch item can
             // fail. The aggregate retains the last clip or track only for the
@@ -1219,6 +1352,191 @@ fn local_control_artifact_is_complete(
     })
 }
 
+async fn bind_remote_reference_uploads(
+    client: &MoldClient,
+    request: &mut GenerateRequest,
+    uploads: &[ReferenceUpload],
+) -> Result<Option<String>> {
+    let descriptors = request
+        .references
+        .clone()
+        .ok_or_else(|| anyhow::anyhow!("reference uploads require ordered H3 descriptors"))?;
+    if descriptors.len() != uploads.len() || descriptors.is_empty() {
+        anyhow::bail!(
+            "reference descriptor/file count mismatch: {} descriptors for {} files",
+            descriptors.len(),
+            uploads.len()
+        );
+    }
+    mold_core::minimax_h3::validate_reference_descriptors(&descriptors)
+        .map_err(anyhow::Error::new)?;
+    let upload_references = (1..=descriptors.len())
+        .map(|index| u32::try_from(index).context("too many reference uploads"))
+        .collect::<Result<Vec<_>>>()?;
+    let session = client
+        .create_reference_upload_session(&ReferenceUploadSessionRequest {
+            request: request.clone(),
+            upload_references,
+        })
+        .await?;
+    if session.instance_id.trim().is_empty()
+        || session.expires_at_ms == 0
+        || !is_sha256_hex(&session.request_scope_sha256)
+        || !is_reference_upload_handle(&session.session_handle)
+        || session.uploads.len() != descriptors.len()
+    {
+        let _ = client
+            .cancel_reference_upload_session(&session.session_handle)
+            .await;
+        anyhow::bail!("server returned an incomplete reference upload session");
+    }
+
+    let upload_result: Result<Vec<GenerationReference>> = async {
+        let mut bound = Vec::with_capacity(descriptors.len());
+        let mut seen_handles = std::collections::HashSet::new();
+        for (index, (descriptor, source)) in descriptors.iter().zip(uploads).enumerate() {
+            let reference = u32::try_from(index)
+                .context("too many reference uploads")?
+                .saturating_add(1);
+            let slot = session
+                .uploads
+                .iter()
+                .find(|slot| slot.reference == reference)
+                .ok_or_else(|| {
+                    anyhow::anyhow!("server omitted reference upload slot {reference}")
+                })?;
+            if !is_reference_upload_handle(&slot.handle) {
+                anyhow::bail!("server returned an invalid reference upload handle");
+            }
+            if !seen_handles.insert(slot.handle.as_str()) {
+                anyhow::bail!("server reused a one-use reference upload handle");
+            }
+            let completed = client
+                .upload_reference_file(&slot.handle, &source.path, &source.mime_type)
+                .await
+                .with_context(|| format!("reference {reference} upload failed"))?;
+            if completed.instance_id != session.instance_id || completed.reference != reference {
+                anyhow::bail!(
+                    "reference {reference} upload response did not match its bound server session"
+                );
+            }
+            let expected = descriptor
+                .redacted_metadata(index)
+                .ok_or_else(|| anyhow::anyhow!("reference {reference} lost digest provenance"))?;
+            if completed.metadata != expected {
+                anyhow::bail!(
+                    "reference {reference} upload response drifted from the client-probed descriptor"
+                );
+            }
+            bound.push(reference_with_authority(
+                descriptor,
+                GenerationReferenceAuthority::Upload {
+                    handle: slot.handle.clone(),
+                },
+            ));
+        }
+        Ok(bound)
+    }
+    .await;
+
+    match upload_result {
+        Ok(bound) => {
+            request.references = Some(bound);
+            Ok(Some(session.session_handle))
+        }
+        Err(error) => {
+            let _ = client
+                .cancel_reference_upload_session(&session.session_handle)
+                .await;
+            Err(error)
+        }
+    }
+}
+
+fn is_sha256_hex(value: &str) -> bool {
+    value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn is_reference_upload_handle(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= mold_core::minimax_h3::MAX_REFERENCE_UPLOAD_HANDLE_BYTES
+        && value.bytes().all(|byte| byte.is_ascii_graphic())
+}
+
+fn reference_with_authority(
+    reference: &GenerationReference,
+    media: GenerationReferenceAuthority,
+) -> GenerationReference {
+    match reference {
+        GenerationReference::Image {
+            provenance,
+            mime_type,
+            width,
+            height,
+            ..
+        } => GenerationReference::Image {
+            media,
+            provenance: provenance.clone(),
+            mime_type: mime_type.clone(),
+            width: *width,
+            height: *height,
+        },
+        GenerationReference::Video {
+            provenance,
+            mime_type,
+            width,
+            height,
+            duration_ms,
+            fps,
+            has_audio,
+            audio_duration_ms,
+            ..
+        } => GenerationReference::Video {
+            media,
+            provenance: provenance.clone(),
+            mime_type: mime_type.clone(),
+            width: *width,
+            height: *height,
+            duration_ms: *duration_ms,
+            fps: *fps,
+            has_audio: *has_audio,
+            audio_duration_ms: *audio_duration_ms,
+        },
+        GenerationReference::Audio {
+            provenance,
+            mime_type,
+            duration_ms,
+            sample_rate,
+            channels,
+            ..
+        } => GenerationReference::Audio {
+            media,
+            provenance: provenance.clone(),
+            mime_type: mime_type.clone(),
+            duration_ms: *duration_ms,
+            sample_rate: *sample_rate,
+            channels: *channels,
+        },
+    }
+}
+
+fn has_remote_reference_handles(request: &GenerateRequest) -> bool {
+    request.references.as_ref().is_some_and(|references| {
+        references.iter().any(|reference| {
+            matches!(
+                reference.media(),
+                GenerationReferenceAuthority::Upload { .. }
+            )
+        })
+    })
+}
+
+fn require_remote_auto_pull_activation(request: &GenerateRequest, config: &Config) -> Result<()> {
+    let family = resolve_family(&request.model, config);
+    mold_core::require_model_activation(&request.model, family.as_deref())
+        .map_err(anyhow::Error::new)
+}
+
 /// Remote generation: try SSE streaming first, fall back to blocking API.
 #[allow(clippy::too_many_arguments)]
 async fn generate_remote(
@@ -1281,6 +1599,8 @@ async fn generate_remote(
             let _ = render.await;
             match classify_generate_error(&e) {
                 GenerateServerAction::PullModelAndRetry => {
+                    require_remote_auto_pull_activation(req, config)
+                        .map_err(|error| tag_remote(client, error))?;
                     print_server_pull_missing_model(model);
                     stream_server_pull(client, model)
                         .await
@@ -1311,6 +1631,14 @@ async fn generate_remote(
                     }
                 }
                 GenerateServerAction::FallbackLocal => {
+                    if has_remote_reference_handles(req) {
+                        return Err(tag_remote(
+                            client,
+                            anyhow::anyhow!(
+                                "server connection failed after H3 references were bound; secure upload handles cannot fall back to local inference"
+                            ),
+                        ));
+                    }
                     print_using_local_inference();
                     let mut local_request = req.clone();
                     materialize_local_builtin_control(&mut local_request, config).await?;
@@ -1385,6 +1713,8 @@ async fn generate_remote_blocking(
             pb.finish_and_clear();
             match classify_generate_error(&e) {
                 GenerateServerAction::PullModelAndRetry => {
+                    require_remote_auto_pull_activation(req, config)
+                        .map_err(|error| tag_remote(client, error))?;
                     print_server_pull_missing_model(model);
                     stream_server_pull(client, model)
                         .await
@@ -1396,6 +1726,14 @@ async fn generate_remote_blocking(
                         .map_err(|e| tag_remote(client, e))
                 }
                 GenerateServerAction::FallbackLocal => {
+                    if has_remote_reference_handles(req) {
+                        return Err(tag_remote(
+                            client,
+                            anyhow::anyhow!(
+                                "server connection failed after H3 references were bound; secure upload handles cannot fall back to local inference"
+                            ),
+                        ));
+                    }
                     print_using_local_inference();
                     let mut local_request = req.clone();
                     materialize_local_builtin_control(&mut local_request, config).await?;
@@ -2643,6 +2981,243 @@ fn default_filename(model: &str, timestamp: u64, ext: &str, batch: u32, index: u
 mod tests {
     use super::*;
     use mold_core::ModelConfig;
+
+    fn h3_request(model: &str) -> GenerateRequest {
+        serde_json::from_value(serde_json::json!({
+            "prompt": "a synchronized scene",
+            "model": model,
+            "width": mold_core::minimax_h3::DEFAULT_WIDTH,
+            "height": mold_core::minimax_h3::DEFAULT_HEIGHT,
+            "steps": mold_core::minimax_h3::DEFAULT_STEPS,
+            "guidance": 0.0,
+            "seed": 42,
+            "batch_size": 1,
+            "output_format": "mp4",
+            "strength": 1.0,
+            "frames": mold_core::minimax_h3::MIN_FRAMES,
+            "fps": mold_core::minimax_h3::FIXED_FPS,
+            "enable_audio": true
+        }))
+        .unwrap()
+    }
+
+    fn descriptor(name: &str, sha256: &str) -> GenerationReference {
+        GenerationReference::Image {
+            media: GenerationReferenceAuthority::Descriptor,
+            provenance: mold_core::GenerationReferenceProvenance {
+                name: Some(name.to_string()),
+                sha256: Some(sha256.to_string()),
+            },
+            mime_type: "image/png".to_string(),
+            width: 32,
+            height: 32,
+        }
+    }
+
+    #[tokio::test]
+    async fn h3_reference_binding_preserves_order_and_uses_one_use_handles() {
+        use sha2::{Digest as _, Sha256};
+        use wiremock::matchers::{body_string, header, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let dir = tempfile::tempdir().unwrap();
+        let first_path = dir.path().join("first.png");
+        let second_path = dir.path().join("second.png");
+        std::fs::write(&first_path, b"first").unwrap();
+        std::fs::write(&second_path, b"second").unwrap();
+        let first_sha = format!("{:x}", Sha256::digest(b"first"));
+        let second_sha = format!("{:x}", Sha256::digest(b"second"));
+        let descriptors = vec![
+            descriptor("first.png", &first_sha),
+            descriptor("second.png", &second_sha),
+        ];
+        let first_metadata = descriptors[0].redacted_metadata(0).unwrap();
+        let second_metadata = descriptors[1].redacted_metadata(1).unwrap();
+
+        Mock::given(method("POST"))
+            .and(path("/api/generate/reference-upload-sessions"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                mold_core::ReferenceUploadSessionResponse {
+                    instance_id: "server-1".to_string(),
+                    expires_at_ms: u64::MAX,
+                    request_scope_sha256: "a".repeat(64),
+                    session_handle: "mrs_secret".to_string(),
+                    uploads: vec![
+                        mold_core::ReferenceUploadSlot {
+                            reference: 1,
+                            handle: "mru_first".to_string(),
+                        },
+                        mold_core::ReferenceUploadSlot {
+                            reference: 2,
+                            handle: "mru_second".to_string(),
+                        },
+                    ],
+                },
+            ))
+            .expect(1)
+            .mount(&server)
+            .await;
+        for (handle, body, metadata) in [
+            ("mru_first", "first", first_metadata),
+            ("mru_second", "second", second_metadata),
+        ] {
+            let reference = metadata.index;
+            Mock::given(method("PUT"))
+                .and(path("/api/generate/reference-upload"))
+                .and(header("x-mold-reference-upload", handle))
+                .and(body_string(body))
+                .respond_with(ResponseTemplate::new(200).set_body_json(
+                    mold_core::ReferenceUploadCompleteResponse {
+                        instance_id: "server-1".to_string(),
+                        reference,
+                        metadata,
+                    },
+                ))
+                .expect(1)
+                .mount(&server)
+                .await;
+        }
+
+        let mut request = h3_request(mold_core::minimax_h3::REF2VA_COMFY);
+        request.references = Some(descriptors);
+        let session = bind_remote_reference_uploads(
+            &MoldClient::new(&server.uri()),
+            &mut request,
+            &[
+                ReferenceUpload {
+                    path: first_path,
+                    mime_type: "image/png".to_string(),
+                },
+                ReferenceUpload {
+                    path: second_path,
+                    mime_type: "image/png".to_string(),
+                },
+            ],
+        )
+        .await
+        .unwrap();
+        assert_eq!(session.as_deref(), Some("mrs_secret"));
+        let references = request.references.unwrap();
+        assert!(matches!(
+            references[0].media(),
+            GenerationReferenceAuthority::Upload { handle } if handle == "mru_first"
+        ));
+        assert!(matches!(
+            references[1].media(),
+            GenerationReferenceAuthority::Upload { handle } if handle == "mru_second"
+        ));
+    }
+
+    #[tokio::test]
+    async fn h3_remote_builder_freezes_exact_av_contract_before_http_451() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/generate/stream"))
+            .respond_with(ResponseTemplate::new(451).set_body_json(serde_json::json!({
+                "error": "MiniMax H3 legal activation is unavailable",
+                "code": mold_core::MINIMAX_H3_AUTHORIZATION_REQUIRED
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let error = run(
+            "a synchronized scene",
+            mold_core::minimax_h3::FL2VA_COMFY,
+            None,
+            None,
+            None,
+            None,
+            Some(7.5),
+            Some(42),
+            1,
+            Ltx2Options {
+                frames: None,
+                fps: None,
+                clip_frames: None,
+                motion_tail: 17,
+                enable_audio: None,
+                audio_file: None,
+                source_video: None,
+                extend_video: None,
+                extend_overlap_frames: None,
+                keyframes: None,
+                pipeline: None,
+                ic_lora_control: None,
+                hdr_exr_dir: None,
+                hdr_exr_full_float: false,
+                loras: None,
+                retake_range: None,
+                spatial_upscale: None,
+                temporal_upscale: None,
+                guidance_overrides: None,
+                source_image_name: None,
+                references: None,
+                reference_uploads: Vec::new(),
+            },
+            Some(server.uri()),
+            OutputFormat::Png,
+            false,
+            false,
+            false,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(Scheduler::UniPc),
+            Some(true),
+            false,
+            false,
+            None,
+            None,
+            None,
+            0.75,
+            None,
+            None,
+            None,
+            1.0,
+            Some("bad negative".to_string()),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains(mold_core::MINIMAX_H3_AUTHORIZATION_REQUIRED));
+
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 1);
+        let body: serde_json::Value = serde_json::from_slice(&requests[0].body).unwrap();
+        assert_eq!(body["output_format"], "mp4");
+        assert_eq!(body["width"], mold_core::minimax_h3::DEFAULT_WIDTH);
+        assert_eq!(body["height"], mold_core::minimax_h3::DEFAULT_HEIGHT);
+        assert_eq!(body["steps"], mold_core::minimax_h3::DEFAULT_STEPS);
+        assert_eq!(body["guidance"], 0.0);
+        assert_eq!(body["strength"], 1.0);
+        assert_eq!(body["frames"], mold_core::minimax_h3::MIN_FRAMES);
+        assert_eq!(body["fps"], mold_core::minimax_h3::FIXED_FPS);
+        assert_eq!(body["enable_audio"], true);
+        assert!(body["negative_prompt"].is_null());
+        assert!(body["scheduler"].is_null());
+        assert!(body["cfg_plus"].is_null());
+    }
+
+    #[test]
+    fn h3_remote_missing_model_cannot_enter_auto_pull() {
+        let request = h3_request(mold_core::minimax_h3::FL2VA_COMFY);
+        let error = require_remote_auto_pull_activation(&request, &Config::default()).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains(mold_core::MINIMAX_H3_AUTHORIZATION_REQUIRED));
+    }
 
     #[tokio::test]
     async fn local_control_materialization_preserves_built_in_first_ordering() {

--- a/crates/mold-cli/src/commands/generate.rs
+++ b/crates/mold-cli/src/commands/generate.rs
@@ -1486,10 +1486,14 @@ fn reference_with_authority(
             mime_type,
             width,
             height,
+            frame_count,
             duration_ms,
             fps,
             has_audio,
             audio_duration_ms,
+            audio_sample_count,
+            audio_sample_rate,
+            audio_channels,
             ..
         } => GenerationReference::Video {
             media,
@@ -1497,10 +1501,14 @@ fn reference_with_authority(
             mime_type: mime_type.clone(),
             width: *width,
             height: *height,
+            frame_count: *frame_count,
             duration_ms: *duration_ms,
             fps: *fps,
             has_audio: *has_audio,
             audio_duration_ms: *audio_duration_ms,
+            audio_sample_count: *audio_sample_count,
+            audio_sample_rate: *audio_sample_rate,
+            audio_channels: *audio_channels,
         },
         GenerationReference::Audio {
             provenance,
@@ -1508,6 +1516,7 @@ fn reference_with_authority(
             duration_ms,
             sample_rate,
             channels,
+            sample_count,
             ..
         } => GenerationReference::Audio {
             media,
@@ -1516,6 +1525,7 @@ fn reference_with_authority(
             duration_ms: *duration_ms,
             sample_rate: *sample_rate,
             channels: *channels,
+            sample_count: *sample_count,
         },
     }
 }

--- a/crates/mold-cli/src/commands/generate.rs
+++ b/crates/mold-cli/src/commands/generate.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
 #[cfg(any(feature = "preview", test))]
 use base64::{engine::general_purpose, Engine as _};
 use colored::Colorize;
@@ -8,7 +8,7 @@ use mold_core::{
     DevicePlacement, GenerateRequest, GenerateResponse, GenerateServerAction, GenerationReference,
     GenerationReferenceAuthority, ImageData, KeyframeCondition, LoraWeight, Ltx2GuidanceOverrides,
     Ltx2PipelineMode, Ltx2SpatialUpscale, Ltx2TemporalUpscale, MoldClient, OutputFormat,
-    ReferenceUploadSessionRequest, Scheduler, TimeRange,
+    ReferenceUploadLease, ReferenceUploadSource, Scheduler, TimeRange,
 };
 use rand::Rng;
 #[cfg(feature = "preview")]
@@ -791,7 +791,7 @@ pub async fn run(
         // rather than changing it between session creation and generation.
         req.seed = Some(base_seed);
         reference_session =
-            bind_remote_reference_uploads(ctx.client(), &mut req, &reference_uploads).await?;
+            bind_remote_reference_uploads(ctx.client(), &mut req, reference_uploads).await?;
     }
 
     // Warn if user-provided dimensions don't match model recommendations.
@@ -1017,13 +1017,15 @@ pub async fn run(
 
         for i in 0..batch {
             let mut iter_req = req.clone();
-            iter_req.seed = Some(base_seed.wrapping_add(i as u64));
-            iter_req.batch_size = 1;
+            if reference_session.is_none() {
+                iter_req.seed = Some(base_seed.wrapping_add(i as u64));
+                iter_req.batch_size = 1;
 
-            // Use per-batch expanded prompt if available
-            if let Some(ref prompts) = batch_prompts {
-                if let Some(p) = prompts.get(i as usize) {
-                    iter_req.prompt = p.clone();
+                // Use per-batch expanded prompt if available
+                if let Some(ref prompts) = batch_prompts {
+                    if let Some(p) = prompts.get(i as usize) {
+                        iter_req.prompt = p.clone();
+                    }
                 }
             }
 
@@ -1062,12 +1064,15 @@ pub async fn run(
             let response = match response {
                 Ok(response) => response,
                 Err(error) => {
-                    if let Some(session) = reference_session.as_deref() {
-                        let _ = ctx.client().cancel_reference_upload_session(session).await;
+                    if let Some(lease) = reference_session.as_mut() {
+                        let _ = lease.cancel().await;
                     }
                     return Err(error);
                 }
             };
+            if let Some(lease) = reference_session.as_mut() {
+                lease.mark_consumed();
+            }
 
             // Persist every successful artifact before the next batch item can
             // fail. The aggregate retains the last clip or track only for the
@@ -1355,8 +1360,8 @@ fn local_control_artifact_is_complete(
 async fn bind_remote_reference_uploads(
     client: &MoldClient,
     request: &mut GenerateRequest,
-    uploads: &[ReferenceUpload],
-) -> Result<Option<String>> {
+    uploads: Vec<ReferenceUpload>,
+) -> Result<Option<ReferenceUploadLease>> {
     let descriptors = request
         .references
         .clone()
@@ -1370,164 +1375,13 @@ async fn bind_remote_reference_uploads(
     }
     mold_core::minimax_h3::validate_reference_descriptors(&descriptors)
         .map_err(anyhow::Error::new)?;
-    let upload_references = (1..=descriptors.len())
-        .map(|index| u32::try_from(index).context("too many reference uploads"))
+    let sources = uploads
+        .into_iter()
+        .map(|upload| ReferenceUploadSource::open_file(upload.file))
         .collect::<Result<Vec<_>>>()?;
-    let session = client
-        .create_reference_upload_session(&ReferenceUploadSessionRequest {
-            request: request.clone(),
-            upload_references,
-        })
-        .await?;
-    if session.instance_id.trim().is_empty()
-        || session.expires_at_ms == 0
-        || !is_sha256_hex(&session.request_scope_sha256)
-        || !is_reference_upload_handle(&session.session_handle)
-        || session.uploads.len() != descriptors.len()
-    {
-        let _ = client
-            .cancel_reference_upload_session(&session.session_handle)
-            .await;
-        anyhow::bail!("server returned an incomplete reference upload session");
-    }
-
-    let upload_result: Result<Vec<GenerationReference>> = async {
-        let mut bound = Vec::with_capacity(descriptors.len());
-        let mut seen_handles = std::collections::HashSet::new();
-        for (index, (descriptor, source)) in descriptors.iter().zip(uploads).enumerate() {
-            let reference = u32::try_from(index)
-                .context("too many reference uploads")?
-                .saturating_add(1);
-            let slot = session
-                .uploads
-                .iter()
-                .find(|slot| slot.reference == reference)
-                .ok_or_else(|| {
-                    anyhow::anyhow!("server omitted reference upload slot {reference}")
-                })?;
-            if !is_reference_upload_handle(&slot.handle) {
-                anyhow::bail!("server returned an invalid reference upload handle");
-            }
-            if !seen_handles.insert(slot.handle.as_str()) {
-                anyhow::bail!("server reused a one-use reference upload handle");
-            }
-            let completed = client
-                .upload_reference_file(&slot.handle, &source.path, &source.mime_type)
-                .await
-                .with_context(|| format!("reference {reference} upload failed"))?;
-            if completed.instance_id != session.instance_id || completed.reference != reference {
-                anyhow::bail!(
-                    "reference {reference} upload response did not match its bound server session"
-                );
-            }
-            let expected = descriptor
-                .redacted_metadata(index)
-                .ok_or_else(|| anyhow::anyhow!("reference {reference} lost digest provenance"))?;
-            if completed.metadata != expected {
-                anyhow::bail!(
-                    "reference {reference} upload response drifted from the client-probed descriptor"
-                );
-            }
-            bound.push(reference_with_authority(
-                descriptor,
-                GenerationReferenceAuthority::Upload {
-                    handle: slot.handle.clone(),
-                },
-            ));
-        }
-        Ok(bound)
-    }
-    .await;
-
-    match upload_result {
-        Ok(bound) => {
-            request.references = Some(bound);
-            Ok(Some(session.session_handle))
-        }
-        Err(error) => {
-            let _ = client
-                .cancel_reference_upload_session(&session.session_handle)
-                .await;
-            Err(error)
-        }
-    }
-}
-
-fn is_sha256_hex(value: &str) -> bool {
-    value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
-}
-
-fn is_reference_upload_handle(value: &str) -> bool {
-    !value.is_empty()
-        && value.len() <= mold_core::minimax_h3::MAX_REFERENCE_UPLOAD_HANDLE_BYTES
-        && value.bytes().all(|byte| byte.is_ascii_graphic())
-}
-
-fn reference_with_authority(
-    reference: &GenerationReference,
-    media: GenerationReferenceAuthority,
-) -> GenerationReference {
-    match reference {
-        GenerationReference::Image {
-            provenance,
-            mime_type,
-            width,
-            height,
-            ..
-        } => GenerationReference::Image {
-            media,
-            provenance: provenance.clone(),
-            mime_type: mime_type.clone(),
-            width: *width,
-            height: *height,
-        },
-        GenerationReference::Video {
-            provenance,
-            mime_type,
-            width,
-            height,
-            frame_count,
-            duration_ms,
-            fps,
-            has_audio,
-            audio_duration_ms,
-            audio_sample_count,
-            audio_sample_rate,
-            audio_channels,
-            ..
-        } => GenerationReference::Video {
-            media,
-            provenance: provenance.clone(),
-            mime_type: mime_type.clone(),
-            width: *width,
-            height: *height,
-            frame_count: *frame_count,
-            duration_ms: *duration_ms,
-            fps: *fps,
-            has_audio: *has_audio,
-            audio_duration_ms: *audio_duration_ms,
-            audio_sample_count: *audio_sample_count,
-            audio_sample_rate: *audio_sample_rate,
-            audio_channels: *audio_channels,
-        },
-        GenerationReference::Audio {
-            provenance,
-            mime_type,
-            duration_ms,
-            sample_rate,
-            channels,
-            sample_count,
-            ..
-        } => GenerationReference::Audio {
-            media,
-            provenance: provenance.clone(),
-            mime_type: mime_type.clone(),
-            duration_ms: *duration_ms,
-            sample_rate: *sample_rate,
-            channels: *channels,
-            sample_count: *sample_count,
-        },
-    }
+    let lease = client.bind_reference_uploads_v2(request, sources).await?;
+    *request = lease.request().clone();
+    Ok(Some(lease))
 }
 
 fn has_remote_reference_handles(request: &GenerateRequest) -> bool {
@@ -1573,11 +1427,21 @@ async fn generate_remote(
     // Try SSE streaming first
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
     let render = tokio::spawn(render_progress(rx));
+    let one_use_references = has_remote_reference_handles(req);
 
     match client.generate_stream(req, tx).await {
         Ok(Some(response)) => {
             let _ = render.await;
             Ok(response)
+        }
+        Ok(None) if one_use_references => {
+            let _ = render.await;
+            Err(tag_remote(
+                client,
+                anyhow::anyhow!(
+                    "server lacks secure streaming generation required for one-use MiniMax H3 references; create a fresh upload attempt after updating the server"
+                ),
+            ))
         }
         Ok(None) => {
             // Server doesn't support SSE — fall back to blocking API with spinner
@@ -1607,6 +1471,14 @@ async fn generate_remote(
         }
         Err(e) => {
             let _ = render.await;
+            if one_use_references {
+                return Err(tag_remote(
+                    client,
+                    e.context(
+                        "one-use MiniMax H3 reference handles cannot be retried, pulled, or replayed through another generation endpoint",
+                    ),
+                ));
+            }
             match classify_generate_error(&e) {
                 GenerateServerAction::PullModelAndRetry => {
                     require_remote_auto_pull_activation(req, config)
@@ -1699,6 +1571,11 @@ async fn generate_remote_blocking(
     cli_steps: Option<u32>,
     cli_guidance: Option<f64>,
 ) -> Result<GenerateResponse> {
+    if has_remote_reference_handles(req) {
+        anyhow::bail!(
+            "one-use MiniMax H3 reference handles require streaming generation and cannot use the blocking fallback"
+        );
+    }
     let pb = ProgressBar::new_spinner();
     if piped {
         pb.set_draw_target(indicatif::ProgressDrawTarget::stderr());
@@ -3024,6 +2901,74 @@ mod tests {
         }
     }
 
+    async fn generate_remote_for_test(
+        client: &MoldClient,
+        request: &GenerateRequest,
+    ) -> Result<GenerateResponse> {
+        generate_remote(
+            client,
+            request,
+            &Config::default(),
+            &request.model,
+            false,
+            request.width,
+            request.height,
+            request.steps,
+            None,
+            None,
+            None,
+            None,
+            None,
+            false,
+            false,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+    }
+
+    async fn mount_reference_v2_authority(server: &wiremock::MockServer) {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let capabilities = mold_core::ServerCapabilities {
+            reference_uploads: mold_core::ReferenceUploadCapabilities {
+                available: true,
+                protocol_version: 2,
+                requires_api_key: true,
+                session_path: mold_core::reference_upload::SESSION_PATH.into(),
+                upload_path: mold_core::reference_upload::UPLOAD_PATH.into(),
+                session_handle_header: mold_core::reference_upload::SESSION_HANDLE_HEADER.into(),
+                upload_handle_header: mold_core::reference_upload::UPLOAD_HANDLE_HEADER.into(),
+                max_file_bytes: 256 * 1024 * 1024,
+                max_session_bytes: 1024 * 1024 * 1024,
+                session_ttl_ms: 120_000,
+            },
+            ..Default::default()
+        };
+        Mock::given(method("GET"))
+            .and(path("/api/capabilities"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(capabilities))
+            .expect(1)
+            .mount(server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/api/status"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "version": "test",
+                "models_loaded": [],
+                "busy": false,
+                "gpu_info": null,
+                "uptime_secs": 1,
+                "instance_id": "server-1"
+            })))
+            .expect(1)
+            .mount(server)
+            .await;
+    }
+
     #[tokio::test]
     async fn h3_reference_binding_preserves_order_and_uses_one_use_handles() {
         use sha2::{Digest as _, Sha256};
@@ -3031,6 +2976,7 @@ mod tests {
         use wiremock::{Mock, MockServer, ResponseTemplate};
 
         let server = MockServer::start().await;
+        mount_reference_v2_authority(&server).await;
         let dir = tempfile::tempdir().unwrap();
         let first_path = dir.path().join("first.png");
         let second_path = dir.path().join("second.png");
@@ -3068,9 +3014,15 @@ mod tests {
             .expect(1)
             .mount(&server)
             .await;
-        for (handle, body, metadata) in [
-            ("mru_first", "first", first_metadata),
-            ("mru_second", "second", second_metadata),
+        for (handle, body, metadata, session_complete, scope) in [
+            ("mru_first", "first", first_metadata, false, "b".repeat(64)),
+            (
+                "mru_second",
+                "second",
+                second_metadata,
+                true,
+                "c".repeat(64),
+            ),
         ] {
             let reference = metadata.index;
             Mock::given(method("PUT"))
@@ -3082,6 +3034,8 @@ mod tests {
                         instance_id: "server-1".to_string(),
                         reference,
                         metadata,
+                        request_scope_sha256: scope,
+                        session_complete,
                     },
                 ))
                 .expect(1)
@@ -3091,23 +3045,22 @@ mod tests {
 
         let mut request = h3_request(mold_core::minimax_h3::REF2VA_COMFY);
         request.references = Some(descriptors);
-        let session = bind_remote_reference_uploads(
-            &MoldClient::new(&server.uri()),
+        let mut lease = bind_remote_reference_uploads(
+            &MoldClient::with_api_key(&server.uri(), "sekrit".into()),
             &mut request,
-            &[
+            vec![
                 ReferenceUpload {
-                    path: first_path,
-                    mime_type: "image/png".to_string(),
+                    file: mold_core::secure_file::open_regular_file_no_follow(&first_path).unwrap(),
                 },
                 ReferenceUpload {
-                    path: second_path,
-                    mime_type: "image/png".to_string(),
+                    file: mold_core::secure_file::open_regular_file_no_follow(&second_path)
+                        .unwrap(),
                 },
             ],
         )
         .await
         .unwrap();
-        assert_eq!(session.as_deref(), Some("mrs_secret"));
+        assert!(lease.is_some());
         let references = request.references.unwrap();
         assert!(matches!(
             references[0].media(),
@@ -3117,6 +3070,125 @@ mod tests {
             references[1].media(),
             GenerationReferenceAuthority::Upload { handle } if handle == "mru_second"
         ));
+        lease.as_mut().unwrap().mark_consumed();
+    }
+
+    #[tokio::test]
+    async fn h3_reference_http_451_sends_no_upload_or_generation() {
+        use sha2::{Digest as _, Sha256};
+        use wiremock::matchers::{header, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        mount_reference_v2_authority(&server).await;
+        Mock::given(method("POST"))
+            .and(path("/api/generate/reference-upload-sessions"))
+            .and(header("x-api-key", "sekrit"))
+            .respond_with(ResponseTemplate::new(451).set_body_json(serde_json::json!({
+                "error": "MiniMax H3 legal activation is unavailable",
+                "code": mold_core::MINIMAX_H3_AUTHORIZATION_REQUIRED
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("reference.png");
+        std::fs::write(&path, b"reference").unwrap();
+        let digest = format!("{:x}", Sha256::digest(b"reference"));
+        let mut request = h3_request(mold_core::minimax_h3::REF2VA_COMFY);
+        request.references = Some(vec![descriptor("reference.png", &digest)]);
+        let error = bind_remote_reference_uploads(
+            &MoldClient::with_api_key(&server.uri(), "sekrit".into()),
+            &mut request,
+            vec![ReferenceUpload {
+                file: mold_core::secure_file::open_regular_file_no_follow(&path).unwrap(),
+            }],
+        )
+        .await
+        .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains(mold_core::MINIMAX_H3_AUTHORIZATION_REQUIRED));
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(
+            requests
+                .iter()
+                .filter(|request| request.method.as_str() == "PUT")
+                .count(),
+            0
+        );
+        assert!(!requests.iter().any(|request| {
+            matches!(request.url.path(), "/api/generate" | "/api/generate/stream")
+        }));
+    }
+
+    #[tokio::test]
+    async fn one_use_reference_handles_never_use_blocking_fallback() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/generate/stream"))
+            .respond_with(ResponseTemplate::new(404))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let mut request = h3_request(mold_core::minimax_h3::REF2VA_COMFY);
+        request.references = Some(vec![GenerationReference::Image {
+            media: GenerationReferenceAuthority::Upload {
+                handle: "mru_one_use".into(),
+            },
+            provenance: mold_core::GenerationReferenceProvenance {
+                name: Some("reference.png".into()),
+                sha256: Some("a".repeat(64)),
+            },
+            mime_type: "image/png".into(),
+            width: 32,
+            height: 32,
+        }]);
+        let error = generate_remote_for_test(&MoldClient::new(&server.uri()), &request)
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("secure streaming generation"));
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].url.path(), "/api/generate/stream");
+    }
+
+    #[tokio::test]
+    async fn one_use_reference_handles_never_pull_and_retry() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/generate/stream"))
+            .respond_with(ResponseTemplate::new(404).set_body_string("model is not downloaded"))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let mut request = h3_request(mold_core::minimax_h3::REF2VA_COMFY);
+        request.references = Some(vec![GenerationReference::Image {
+            media: GenerationReferenceAuthority::Upload {
+                handle: "mru_one_use".into(),
+            },
+            provenance: mold_core::GenerationReferenceProvenance {
+                name: Some("reference.png".into()),
+                sha256: Some("a".repeat(64)),
+            },
+            mime_type: "image/png".into(),
+            width: 32,
+            height: 32,
+        }]);
+        let error = generate_remote_for_test(&MoldClient::new(&server.uri()), &request)
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("cannot be retried"));
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].url.path(), "/api/generate/stream");
     }
 
     #[tokio::test]

--- a/crates/mold-cli/src/commands/h3.rs
+++ b/crates/mold-cli/src/commands/h3.rs
@@ -10,7 +10,6 @@ use mold_core::{
     minimax_h3, GenerationReference, GenerationReferenceAuthority, GenerationReferenceProvenance,
     KeyframeCondition, OutputFormat,
 };
-use sha2::{Digest, Sha256};
 use std::{
     fs::File,
     io::{BufReader, Cursor, Read, Seek, SeekFrom},
@@ -19,6 +18,7 @@ use std::{
 };
 
 const MAX_REFERENCE_FILE_BYTES: u64 = 256 * 1024 * 1024;
+const MAX_REFERENCE_TOTAL_BYTES: u64 = 1024 * 1024 * 1024;
 const MAX_BOUNDARY_IMAGE_BYTES: u64 = minimax_h3::MAX_INLINE_REFERENCE_BYTES as u64;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -28,10 +28,20 @@ pub(crate) enum ReferenceKind {
     Audio,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub(crate) struct ReferenceArg {
     pub kind: ReferenceKind,
     pub path: PathBuf,
+}
+
+impl std::fmt::Debug for ReferenceArg {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ReferenceArg")
+            .field("kind", &self.kind)
+            .field("path", &"<redacted>")
+            .finish()
+    }
 }
 
 impl FromStr for ReferenceArg {
@@ -67,13 +77,20 @@ impl FromStr for ReferenceArg {
     }
 }
 
-#[derive(Debug, Clone)]
 pub(crate) struct ReferenceUpload {
-    pub path: PathBuf,
-    pub mime_type: String,
+    pub file: File,
 }
 
-#[derive(Debug, Default)]
+impl std::fmt::Debug for ReferenceUpload {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ReferenceUpload")
+            .field("file", &"<redacted>")
+            .finish()
+    }
+}
+
+#[derive(Default)]
 pub(crate) struct PreparedAuthoring {
     pub frames: Option<u32>,
     pub fps: Option<u32>,
@@ -84,6 +101,29 @@ pub(crate) struct PreparedAuthoring {
     pub keyframes: Option<Vec<KeyframeCondition>>,
     pub references: Option<Vec<GenerationReference>>,
     pub uploads: Vec<ReferenceUpload>,
+}
+
+impl std::fmt::Debug for PreparedAuthoring {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("PreparedAuthoring")
+            .field("frames", &self.frames)
+            .field("fps", &self.fps)
+            .field("width", &self.width)
+            .field("height", &self.height)
+            .field(
+                "source_image",
+                &self
+                    .source_image
+                    .as_ref()
+                    .map(|bytes| format!("<redacted {} bytes>", bytes.len())),
+            )
+            .field("source_image_name", &self.source_image_name)
+            .field("keyframes", &self.keyframes.as_ref().map(Vec::len))
+            .field("references", &self.references)
+            .field("uploads", &self.uploads)
+            .finish()
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -99,6 +139,7 @@ pub(crate) fn prepare_authoring(
     legacy_image: Option<&str>,
     last_frame: Option<&Path>,
     references: &[ReferenceArg],
+    reference_client: Option<&mold_core::MoldClient>,
 ) -> Result<PreparedAuthoring> {
     let is_h3 = minimax_h3::is_family(family);
     let has_h3_authoring = duration_seconds.is_some()
@@ -169,6 +210,10 @@ pub(crate) fn prepare_authoring(
                     "MiniMax H3 Ref2VA requires at least one ordered --reference KIND=PATH"
                 );
             }
+            anyhow::ensure!(
+                reference_client.is_some_and(mold_core::MoldClient::has_api_key),
+                "MiniMax H3 reference preparation requires a configured, valid MOLD_API_KEY"
+            );
         }
     }
 
@@ -348,13 +393,16 @@ fn validate_dimensions(width: u32, height: u32) -> Result<()> {
 }
 
 fn read_boundary_image(path: &Path, boundary: &str) -> Result<(Vec<u8>, (u32, u32))> {
-    ensure_regular_file(
-        path,
-        &format!("--{boundary}-frame"),
-        MAX_BOUNDARY_IMAGE_BYTES,
-    )?;
-    let bytes = std::fs::read(path)
-        .with_context(|| format!("failed to read {boundary} frame '{}'", path.display()))?;
+    let mut file = mold_core::secure_file::open_regular_file_no_follow(path)
+        .with_context(|| format!("failed to open {boundary} frame"))?;
+    let length = file.metadata()?.len();
+    anyhow::ensure!(
+        length > 0 && length <= MAX_BOUNDARY_IMAGE_BYTES,
+        "MiniMax H3 {boundary} frame must contain 1..={MAX_BOUNDARY_IMAGE_BYTES} bytes"
+    );
+    let mut bytes = Vec::with_capacity(usize::try_from(length)?);
+    file.read_to_end(&mut bytes)
+        .with_context(|| format!("failed to read {boundary} frame"))?;
     let dimensions = validate_boundary_image_bytes(&bytes, boundary).map_err(|error| {
         anyhow::anyhow!("invalid {boundary} frame '{}': {error}", path.display())
     })?;
@@ -387,30 +435,42 @@ fn prepare_references(
 ) -> Result<(Vec<GenerationReference>, Vec<ReferenceUpload>)> {
     let mut descriptors = Vec::with_capacity(inputs.len());
     let mut uploads = Vec::with_capacity(inputs.len());
+    let mut total_bytes = 0_u64;
     for (index, input) in inputs.iter().enumerate() {
-        ensure_regular_file(
-            &input.path,
-            &format!("reference {}", index + 1),
-            MAX_REFERENCE_FILE_BYTES,
-        )?;
-        let sha256 = sha256_file(&input.path)
+        let mut file = mold_core::secure_file::open_regular_file_no_follow(&input.path)
+            .with_context(|| format!("reference {} could not be opened no-follow", index + 1))?;
+        let length = file.metadata()?.len();
+        anyhow::ensure!(
+            length > 0 && length <= MAX_REFERENCE_FILE_BYTES,
+            "reference {} must be a non-empty regular file no larger than {} MiB",
+            index + 1,
+            MAX_REFERENCE_FILE_BYTES / (1024 * 1024)
+        );
+        total_bytes = total_bytes
+            .checked_add(length)
+            .context("combined reference size overflowed")?;
+        anyhow::ensure!(
+            total_bytes <= MAX_REFERENCE_TOTAL_BYTES,
+            "combined references must stay under {} MiB",
+            MAX_REFERENCE_TOTAL_BYTES / (1024 * 1024)
+        );
+        let sha256 = mold_core::secure_file::sha256_open_file(&file)
             .with_context(|| format!("failed to hash reference {}", index + 1))?;
+        file.seek(SeekFrom::Start(0))?;
         let provenance = GenerationReferenceProvenance {
             name: display_name(&input.path),
             sha256: Some(sha256),
         };
         let descriptor = match input.kind {
-            ReferenceKind::Image => probe_image(&input.path, provenance)
+            ReferenceKind::Image => probe_image(file.try_clone()?, provenance)
                 .with_context(|| format!("reference {} image probe failed", index + 1))?,
-            ReferenceKind::Video => probe_video(&input.path, provenance)
+            ReferenceKind::Video => probe_video(file.try_clone()?, provenance)
                 .with_context(|| format!("reference {} video probe failed", index + 1))?,
-            ReferenceKind::Audio => probe_audio(&input.path, provenance)
+            ReferenceKind::Audio => probe_audio(file.try_clone()?, provenance)
                 .with_context(|| format!("reference {} audio probe failed", index + 1))?,
         };
-        uploads.push(ReferenceUpload {
-            path: input.path.clone(),
-            mime_type: reference_mime_type(&descriptor).to_string(),
-        });
+        file.seek(SeekFrom::Start(0))?;
+        uploads.push(ReferenceUpload { file });
         descriptors.push(descriptor);
     }
     if !descriptors.is_empty() {
@@ -419,48 +479,26 @@ fn prepare_references(
     Ok((descriptors, uploads))
 }
 
-fn ensure_regular_file(path: &Path, label: &str, max_bytes: u64) -> Result<()> {
-    let metadata = path
-        .metadata()
-        .with_context(|| format!("{label} file not found: {}", path.display()))?;
-    if !metadata.is_file() {
-        anyhow::bail!("{label} path is not a regular file: {}", path.display());
-    }
-    if metadata.len() == 0 || metadata.len() > max_bytes {
-        anyhow::bail!(
-            "{label} must contain 1..={max_bytes} bytes: {}",
-            path.display()
-        );
-    }
-    Ok(())
-}
-
 fn display_name(path: &Path) -> Option<String> {
     path.file_name()
         .and_then(|name| name.to_str())
-        .filter(|name| !name.is_empty())
+        .map(str::trim)
+        .filter(|name| {
+            !name.is_empty()
+                && name.len() <= minimax_h3::MAX_REFERENCE_NAME_BYTES
+                && *name != "."
+                && *name != ".."
+                && !name.contains(['/', '\\'])
+                && !name.chars().any(char::is_control)
+        })
         .map(str::to_string)
 }
 
-fn sha256_file(path: &Path) -> Result<String> {
-    let mut file = File::open(path)?;
-    let mut digest = Sha256::new();
-    let mut buffer = [0_u8; 64 * 1024];
-    loop {
-        let read = file.read(&mut buffer)?;
-        if read == 0 {
-            break;
-        }
-        digest.update(&buffer[..read]);
-    }
-    Ok(format!("{:x}", digest.finalize()))
-}
-
 fn probe_image(
-    path: &Path,
+    file: File,
     provenance: GenerationReferenceProvenance,
 ) -> Result<GenerationReference> {
-    let reader = image::ImageReader::open(path)?.with_guessed_format()?;
+    let reader = image::ImageReader::new(BufReader::new(file)).with_guessed_format()?;
     let format = reader
         .format()
         .ok_or_else(|| anyhow::anyhow!("unknown image format"))?;
@@ -482,16 +520,16 @@ fn probe_image(
 }
 
 fn probe_video(
-    path: &Path,
+    file: File,
     provenance: GenerationReferenceProvenance,
 ) -> Result<GenerationReference> {
-    let probe = mold_inference::ltx2::media::probe_video(path)?;
+    let probe = mold_inference::ltx2::media::probe_video_file(file.try_clone()?)?;
     let duration_ms = probe
         .duration_ms
         .ok_or_else(|| anyhow::anyhow!("MP4 video duration is unavailable"))?;
     let decoded_audio = if probe.has_audio {
         Some(
-            mold_inference::ltx2::media::probe_decoded_mp4_audio_file(path)?
+            mold_inference::ltx2::media::probe_decoded_mp4_audio_open_file(file)?
                 .context("MP4 audio track could not be decoded exactly")?,
         )
     } else {
@@ -527,10 +565,10 @@ fn probe_video(
 }
 
 fn probe_audio(
-    path: &Path,
+    file: File,
     provenance: GenerationReferenceProvenance,
 ) -> Result<GenerationReference> {
-    let wav = probe_wav(File::open(path)?)?;
+    let wav = probe_wav(file)?;
     Ok(GenerationReference::Audio {
         media: GenerationReferenceAuthority::Descriptor,
         provenance,
@@ -662,14 +700,6 @@ fn probe_wav(file: File) -> Result<WavProbe> {
     })
 }
 
-fn reference_mime_type(reference: &GenerationReference) -> &str {
-    match reference {
-        GenerationReference::Image { mime_type, .. }
-        | GenerationReference::Video { mime_type, .. }
-        | GenerationReference::Audio { mime_type, .. } => mime_type,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -680,6 +710,7 @@ mod tests {
         let parsed: ReferenceArg = "video=/tmp/clip=final.mp4".parse().unwrap();
         assert_eq!(parsed.kind, ReferenceKind::Video);
         assert_eq!(parsed.path, PathBuf::from("/tmp/clip=final.mp4"));
+        assert!(!format!("{parsed:?}").contains("clip=final"));
     }
 
     #[test]
@@ -727,6 +758,7 @@ mod tests {
             None,
             Some(&last),
             &[],
+            None,
         )
         .unwrap();
         assert_eq!(prepared.frames, Some(124));
@@ -759,6 +791,7 @@ mod tests {
             None,
             Some(&last),
             &[],
+            None,
         )
         .unwrap_err();
         assert!(error.to_string().contains("must be PNG or JPEG"));
@@ -787,5 +820,49 @@ mod tests {
         })
         .unwrap_err();
         assert!(error.to_string().contains("--format mp4"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn reference_preparation_rejects_symlink_input() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("anchor.png");
+        image::DynamicImage::new_rgb8(32, 16).save(&target).unwrap();
+        let link = dir.path().join("linked.png");
+        symlink(target, &link).unwrap();
+        let error = prepare_references(&[ReferenceArg {
+            kind: ReferenceKind::Image,
+            path: link,
+        }])
+        .expect_err("symlink references must fail no-follow");
+        assert!(error.to_string().contains("no-follow"));
+    }
+
+    #[test]
+    fn ref2va_auth_preflight_wins_before_reference_file_access() {
+        let missing = PathBuf::from("/definitely/not/opened/reference.png");
+        let client = mold_core::MoldClient::new("http://127.0.0.1:9");
+        let error = prepare_authoring(
+            minimax_h3::REF2VA_COMFY,
+            minimax_h3::FAMILY,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            &[ReferenceArg {
+                kind: ReferenceKind::Image,
+                path: missing,
+            }],
+            Some(&client),
+        )
+        .expect_err("a missing API key must fail before touching the path");
+        assert!(error.to_string().contains("MOLD_API_KEY"));
+        assert!(!error.to_string().contains("opened no-follow"));
     }
 }

--- a/crates/mold-cli/src/commands/h3.rs
+++ b/crates/mold-cli/src/commands/h3.rs
@@ -191,6 +191,7 @@ pub(crate) fn prepare_authoring(
                 Some(vec![KeyframeCondition {
                     frame: frames - 1,
                     image,
+                    name: display_name(path),
                 }]),
                 Some(dimensions),
             )
@@ -488,16 +489,40 @@ fn probe_video(
     let duration_ms = probe
         .duration_ms
         .ok_or_else(|| anyhow::anyhow!("MP4 video duration is unavailable"))?;
+    let decoded_audio = if probe.has_audio {
+        Some(
+            mold_inference::ltx2::media::probe_decoded_mp4_audio_file(path)?
+                .context("MP4 audio track could not be decoded exactly")?,
+        )
+    } else {
+        None
+    };
+    let audio_duration_ms = decoded_audio
+        .as_ref()
+        .map(|audio| {
+            audio
+                .samples_per_channel
+                .checked_mul(1_000)
+                .context("MP4 soundtrack duration overflowed")
+                .map(|samples| samples.div_ceil(u64::from(audio.sample_rate)))
+        })
+        .transpose()?;
     Ok(GenerationReference::Video {
         media: GenerationReferenceAuthority::Descriptor,
         provenance,
         mime_type: "video/mp4".to_string(),
         width: probe.width,
         height: probe.height,
+        frame_count: probe.frames,
         duration_ms,
         fps: f64::from(probe.fps),
         has_audio: probe.has_audio,
-        audio_duration_ms: probe.has_audio.then_some(duration_ms),
+        audio_duration_ms,
+        audio_sample_count: decoded_audio
+            .as_ref()
+            .map(|audio| audio.samples_per_channel),
+        audio_sample_rate: decoded_audio.as_ref().map(|audio| audio.sample_rate),
+        audio_channels: decoded_audio.as_ref().map(|audio| audio.channels),
     })
 }
 
@@ -513,6 +538,7 @@ fn probe_audio(
         duration_ms: wav.duration_ms,
         sample_rate: wav.sample_rate,
         channels: wav.channels,
+        sample_count: Some(wav.sample_count),
     })
 }
 
@@ -521,6 +547,7 @@ struct WavProbe {
     duration_ms: u64,
     sample_rate: u32,
     channels: u16,
+    sample_count: u64,
 }
 
 fn probe_wav(file: File) -> Result<WavProbe> {
@@ -631,6 +658,7 @@ fn probe_wav(file: File) -> Result<WavProbe> {
         duration_ms: data_bytes.saturating_mul(1_000).div_ceil(byte_rate),
         sample_rate,
         channels,
+        sample_count: data_bytes / block_align,
     })
 }
 
@@ -706,6 +734,7 @@ mod tests {
         assert_eq!(prepared.width.zip(prepared.height), Some((1344, 768)));
         let keyframe = &prepared.keyframes.unwrap()[0];
         assert_eq!(keyframe.frame, 123);
+        assert_eq!(keyframe.name.as_deref(), Some("closing.png"));
     }
 
     #[test]

--- a/crates/mold-cli/src/commands/h3.rs
+++ b/crates/mold-cli/src/commands/h3.rs
@@ -1,0 +1,762 @@
+//! MiniMax H3 command-line authoring.
+//!
+//! This module deliberately owns only payload-free request construction and
+//! local user-media inspection. It does not activate, advertise, resolve, or
+//! download the compliance-gated H3 model family. Runtime activation remains
+//! authoritative in `mold-core` and the server.
+
+use anyhow::{Context, Result};
+use mold_core::{
+    minimax_h3, GenerationReference, GenerationReferenceAuthority, GenerationReferenceProvenance,
+    KeyframeCondition, OutputFormat,
+};
+use sha2::{Digest, Sha256};
+use std::{
+    fs::File,
+    io::{BufReader, Cursor, Read, Seek, SeekFrom},
+    path::{Path, PathBuf},
+    str::FromStr,
+};
+
+const MAX_REFERENCE_FILE_BYTES: u64 = 256 * 1024 * 1024;
+const MAX_BOUNDARY_IMAGE_BYTES: u64 = minimax_h3::MAX_INLINE_REFERENCE_BYTES as u64;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ReferenceKind {
+    Image,
+    Video,
+    Audio,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ReferenceArg {
+    pub kind: ReferenceKind,
+    pub path: PathBuf,
+}
+
+impl FromStr for ReferenceArg {
+    type Err = String;
+
+    fn from_str(value: &str) -> std::result::Result<Self, Self::Err> {
+        let (kind, path) = value.split_once('=').ok_or_else(|| {
+            "reference must use KIND=PATH (image=..., video=..., or audio=...)".to_string()
+        })?;
+        let kind = match kind.trim().to_ascii_lowercase().as_str() {
+            "image" => ReferenceKind::Image,
+            "video" => ReferenceKind::Video,
+            "audio" => ReferenceKind::Audio,
+            other => {
+                return Err(format!(
+                    "unknown reference kind '{other}'; expected image, video, or audio"
+                ));
+            }
+        };
+        if path.trim().is_empty() {
+            return Err("reference path must not be empty".to_string());
+        }
+        if path == "-" {
+            return Err(
+                "H3 references require file paths so they can use authenticated streaming upload"
+                    .to_string(),
+            );
+        }
+        Ok(Self {
+            kind,
+            path: PathBuf::from(path),
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ReferenceUpload {
+    pub path: PathBuf,
+    pub mime_type: String,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct PreparedAuthoring {
+    pub frames: Option<u32>,
+    pub fps: Option<u32>,
+    pub width: Option<u32>,
+    pub height: Option<u32>,
+    pub source_image: Option<Vec<u8>>,
+    pub source_image_name: Option<String>,
+    pub keyframes: Option<Vec<KeyframeCondition>>,
+    pub references: Option<Vec<GenerationReference>>,
+    pub uploads: Vec<ReferenceUpload>,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn prepare_authoring(
+    model: &str,
+    family: &str,
+    duration_seconds: Option<f64>,
+    frames: Option<u32>,
+    fps: Option<u32>,
+    width: Option<u32>,
+    height: Option<u32>,
+    first_frame: Option<&Path>,
+    legacy_image: Option<&str>,
+    last_frame: Option<&Path>,
+    references: &[ReferenceArg],
+) -> Result<PreparedAuthoring> {
+    let is_h3 = minimax_h3::is_family(family);
+    let has_h3_authoring = duration_seconds.is_some()
+        || first_frame.is_some()
+        || last_frame.is_some()
+        || !references.is_empty();
+    if !is_h3 {
+        if has_h3_authoring {
+            anyhow::bail!(
+                "--duration, --first-frame, --last-frame, and --reference are MiniMax H3-only options"
+            );
+        }
+        return Ok(PreparedAuthoring::default());
+    }
+
+    let task = minimax_h3::task_for_model(model)
+        .ok_or_else(|| anyhow::anyhow!("unknown MiniMax H3 task for model '{model}'"))?;
+    if frames.is_some() && duration_seconds.is_some() {
+        anyhow::bail!("use either --duration or --frames for MiniMax H3, not both");
+    }
+    if fps.is_some_and(|value| value != minimax_h3::FIXED_FPS) {
+        anyhow::bail!(
+            "MiniMax H3 requires --fps {}; received {}",
+            minimax_h3::FIXED_FPS,
+            fps.unwrap_or_default()
+        );
+    }
+    let frames = match duration_seconds {
+        Some(seconds) => frames_for_duration(seconds)?,
+        None => frames.unwrap_or(minimax_h3::MIN_FRAMES),
+    };
+    if !minimax_h3::valid_frame_count(frames) {
+        anyhow::bail!(
+            "MiniMax H3 --frames must be {}n+{} from {} through {}; received {} (nearest valid value: {})",
+            minimax_h3::FRAME_STEP,
+            minimax_h3::FRAME_OFFSET,
+            minimax_h3::MIN_FRAMES,
+            minimax_h3::MAX_FRAMES,
+            frames,
+            minimax_h3::recommended_frames(frames),
+        );
+    }
+    if width.is_some() != height.is_some() {
+        anyhow::bail!("MiniMax H3 requires --width and --height to be supplied together");
+    }
+    if let (Some(width), Some(height)) = (width, height) {
+        validate_dimensions(width, height)?;
+    }
+
+    let first_path =
+        first_frame.or_else(|| legacy_image.filter(|path| *path != "-").map(Path::new));
+    match task {
+        minimax_h3::Task::Fl2va => {
+            if !references.is_empty() {
+                anyhow::bail!(
+                    "MiniMax H3 FL2VA accepts boundary frames, not --reference; select a minimax-h3-ref2va model for ordered references"
+                );
+            }
+        }
+        minimax_h3::Task::Ref2va => {
+            if first_path.is_some() || legacy_image == Some("-") || last_frame.is_some() {
+                anyhow::bail!(
+                    "MiniMax H3 Ref2VA accepts ordered --reference inputs, not --image/--first-frame/--last-frame"
+                );
+            }
+            if references.is_empty() {
+                anyhow::bail!(
+                    "MiniMax H3 Ref2VA requires at least one ordered --reference KIND=PATH"
+                );
+            }
+        }
+    }
+
+    let (source_image, source_image_name, first_dimensions) = match first_path {
+        Some(path) => {
+            let (bytes, dimensions) = read_boundary_image(path, "first")?;
+            (Some(bytes), display_name(path), Some(dimensions))
+        }
+        None if legacy_image == Some("-") => {
+            // Stdin is read by the ordinary image path. It has no safe filename
+            // provenance, and dimensions are resolved after that read.
+            (None, None, None)
+        }
+        None => (None, None, None),
+    };
+    let (keyframes, last_dimensions) = match last_frame {
+        Some(path) => {
+            let (image, dimensions) = read_boundary_image(path, "last")?;
+            (
+                Some(vec![KeyframeCondition {
+                    frame: frames - 1,
+                    image,
+                }]),
+                Some(dimensions),
+            )
+        }
+        None => (None, None),
+    };
+
+    let inferred_dimensions = first_dimensions.or(last_dimensions);
+    let (width, height) = match (width, height, inferred_dimensions) {
+        (Some(width), Some(height), _) => (Some(width), Some(height)),
+        (None, None, Some((source_width, source_height))) => {
+            let (width, height) = minimax_h3::recommended_dimensions(source_width, source_height);
+            (Some(width), Some(height))
+        }
+        (None, None, None) => (None, None),
+        _ => unreachable!("partial MiniMax H3 dimensions were rejected above"),
+    };
+
+    let (reference_descriptors, uploads) = prepare_references(references)?;
+    Ok(PreparedAuthoring {
+        frames: Some(frames),
+        fps: Some(minimax_h3::FIXED_FPS),
+        width,
+        height,
+        source_image,
+        source_image_name,
+        keyframes,
+        references: (!reference_descriptors.is_empty()).then_some(reference_descriptors),
+        uploads,
+    })
+}
+
+pub(crate) struct FlagValidation<'a> {
+    pub family: &'a str,
+    pub format: Option<OutputFormat>,
+    pub guidance: Option<f64>,
+    pub strength: Option<f64>,
+    pub no_audio: bool,
+    pub negative_prompt: Option<&'a str>,
+    pub scheduler_set: bool,
+    pub cfg_plus: bool,
+    pub has_lora: bool,
+    pub has_mask: bool,
+    pub has_control: bool,
+    pub has_audio_file: bool,
+    pub has_video: bool,
+    pub has_extend: bool,
+    pub has_generic_keyframes: bool,
+    pub has_ltx_pipeline_fields: bool,
+    pub clip_frames: Option<u32>,
+}
+
+pub(crate) fn validate_h3_flags(flags: FlagValidation<'_>) -> Result<()> {
+    if !minimax_h3::is_family(flags.family) {
+        return Ok(());
+    }
+    if flags.format.is_some_and(|value| value != OutputFormat::Mp4) {
+        anyhow::bail!("MiniMax H3 requires --format mp4 for synchronized audio-video output");
+    }
+    if flags.guidance.is_some_and(|value| value != 0.0) {
+        anyhow::bail!("MiniMax H3 has no CFG path; omit --guidance or use --guidance 0");
+    }
+    if flags.strength.is_some_and(|value| value != 1.0) {
+        anyhow::bail!("MiniMax H3 has no denoise-strength control; omit --strength or use 1");
+    }
+    if flags.no_audio {
+        anyhow::bail!("MiniMax H3 always generates synchronized audio; --no-audio is unsupported");
+    }
+    if flags
+        .negative_prompt
+        .is_some_and(|value| !value.trim().is_empty())
+    {
+        anyhow::bail!("MiniMax H3 has no negative-prompt branch; remove --negative-prompt");
+    }
+    if flags.scheduler_set {
+        anyhow::bail!(
+            "MiniMax H3 uses fixed video/audio flow schedules; --scheduler is unsupported"
+        );
+    }
+    if flags.cfg_plus {
+        anyhow::bail!("MiniMax H3 has no CFG path; --cfg-plus is unsupported");
+    }
+    if flags.has_lora || flags.has_mask || flags.has_control {
+        anyhow::bail!("MiniMax H3 does not accept LoRA, mask, or ControlNet options");
+    }
+    if flags.has_audio_file || flags.has_video || flags.has_extend {
+        anyhow::bail!(
+            "MiniMax H3 uses FL2VA boundary frames or Ref2VA --reference inputs; --audio-file, --video, and --extend are unsupported"
+        );
+    }
+    if flags.has_generic_keyframes {
+        anyhow::bail!(
+            "MiniMax H3 accepts only endpoint frames; use --first-frame and/or --last-frame instead of --keyframe"
+        );
+    }
+    if flags.has_ltx_pipeline_fields {
+        anyhow::bail!(
+            "MiniMax H3 does not accept LTX-2 pipeline, HDR, upscale, or guidance controls"
+        );
+    }
+    if flags.clip_frames.is_some() {
+        anyhow::bail!("MiniMax H3 is a single-clip request; --clip-frames is unsupported");
+    }
+    Ok(())
+}
+
+fn frames_for_duration(seconds: f64) -> Result<u32> {
+    if !seconds.is_finite() {
+        anyhow::bail!("MiniMax H3 --duration must be a finite number of seconds");
+    }
+    if seconds < f64::from(minimax_h3::MIN_DURATION_SECONDS)
+        || seconds > f64::from(minimax_h3::MAX_DURATION_SECONDS)
+    {
+        anyhow::bail!(
+            "MiniMax H3 --duration must be between {} and {} seconds",
+            minimax_h3::MIN_DURATION_SECONDS,
+            minimax_h3::MAX_DURATION_SECONDS
+        );
+    }
+    let requested = seconds * f64::from(minimax_h3::FIXED_FPS);
+    let offset = f64::from(minimax_h3::FRAME_OFFSET);
+    let step = f64::from(minimax_h3::FRAME_STEP);
+    let lower = minimax_h3::FRAME_OFFSET
+        + (((requested - offset) / step).floor() as u32) * minimax_h3::FRAME_STEP;
+    let upper = lower.saturating_add(minimax_h3::FRAME_STEP);
+    let rounded = if requested - f64::from(lower) <= f64::from(upper) - requested {
+        lower
+    } else {
+        upper
+    };
+    Ok(rounded.clamp(minimax_h3::MIN_FRAMES, minimax_h3::MAX_FRAMES))
+}
+
+fn validate_dimensions(width: u32, height: u32) -> Result<()> {
+    let valid = width > 0
+        && height > 0
+        && width.is_multiple_of(minimax_h3::DIMENSION_ALIGNMENT)
+        && height.is_multiple_of(minimax_h3::DIMENSION_ALIGNMENT)
+        && u64::from(width) * u64::from(height) <= minimax_h3::MAX_PIXELS
+        && (minimax_h3::MIN_ASPECT_RATIO..=minimax_h3::MAX_ASPECT_RATIO)
+            .contains(&(f64::from(width) / f64::from(height)));
+    if !valid {
+        let (recommended_width, recommended_height) =
+            minimax_h3::recommended_dimensions(width, height);
+        anyhow::bail!(
+            "MiniMax H3 dimensions must be positive multiples of {}, at most {} pixels, with aspect ratio 1:4 through 4:1; nearest official canvas is {}x{}",
+            minimax_h3::DIMENSION_ALIGNMENT,
+            minimax_h3::MAX_PIXELS,
+            recommended_width,
+            recommended_height,
+        );
+    }
+    Ok(())
+}
+
+fn read_boundary_image(path: &Path, boundary: &str) -> Result<(Vec<u8>, (u32, u32))> {
+    ensure_regular_file(
+        path,
+        &format!("--{boundary}-frame"),
+        MAX_BOUNDARY_IMAGE_BYTES,
+    )?;
+    let bytes = std::fs::read(path)
+        .with_context(|| format!("failed to read {boundary} frame '{}'", path.display()))?;
+    let dimensions = validate_boundary_image_bytes(&bytes, boundary).map_err(|error| {
+        anyhow::anyhow!("invalid {boundary} frame '{}': {error}", path.display())
+    })?;
+    Ok((bytes, dimensions))
+}
+
+pub(crate) fn validate_boundary_image_bytes(bytes: &[u8], boundary: &str) -> Result<(u32, u32)> {
+    if bytes.is_empty() || bytes.len() as u64 > MAX_BOUNDARY_IMAGE_BYTES {
+        anyhow::bail!(
+            "MiniMax H3 {boundary} frame must contain 1..={MAX_BOUNDARY_IMAGE_BYTES} bytes"
+        );
+    }
+    let reader = image::ImageReader::new(Cursor::new(bytes))
+        .with_guessed_format()
+        .with_context(|| format!("failed to identify MiniMax H3 {boundary} frame"))?;
+    let format = reader
+        .format()
+        .ok_or_else(|| anyhow::anyhow!("unknown MiniMax H3 {boundary} frame format"))?;
+    if !matches!(format, image::ImageFormat::Png | image::ImageFormat::Jpeg) {
+        anyhow::bail!("MiniMax H3 {boundary} frame must be PNG or JPEG; received {format:?}");
+    }
+    let dimensions = reader
+        .into_dimensions()
+        .with_context(|| format!("failed to decode MiniMax H3 {boundary} frame"))?;
+    Ok(dimensions)
+}
+
+fn prepare_references(
+    inputs: &[ReferenceArg],
+) -> Result<(Vec<GenerationReference>, Vec<ReferenceUpload>)> {
+    let mut descriptors = Vec::with_capacity(inputs.len());
+    let mut uploads = Vec::with_capacity(inputs.len());
+    for (index, input) in inputs.iter().enumerate() {
+        ensure_regular_file(
+            &input.path,
+            &format!("reference {}", index + 1),
+            MAX_REFERENCE_FILE_BYTES,
+        )?;
+        let sha256 = sha256_file(&input.path)
+            .with_context(|| format!("failed to hash reference {}", index + 1))?;
+        let provenance = GenerationReferenceProvenance {
+            name: display_name(&input.path),
+            sha256: Some(sha256),
+        };
+        let descriptor = match input.kind {
+            ReferenceKind::Image => probe_image(&input.path, provenance)
+                .with_context(|| format!("reference {} image probe failed", index + 1))?,
+            ReferenceKind::Video => probe_video(&input.path, provenance)
+                .with_context(|| format!("reference {} video probe failed", index + 1))?,
+            ReferenceKind::Audio => probe_audio(&input.path, provenance)
+                .with_context(|| format!("reference {} audio probe failed", index + 1))?,
+        };
+        uploads.push(ReferenceUpload {
+            path: input.path.clone(),
+            mime_type: reference_mime_type(&descriptor).to_string(),
+        });
+        descriptors.push(descriptor);
+    }
+    if !descriptors.is_empty() {
+        minimax_h3::validate_reference_descriptors(&descriptors).map_err(anyhow::Error::new)?;
+    }
+    Ok((descriptors, uploads))
+}
+
+fn ensure_regular_file(path: &Path, label: &str, max_bytes: u64) -> Result<()> {
+    let metadata = path
+        .metadata()
+        .with_context(|| format!("{label} file not found: {}", path.display()))?;
+    if !metadata.is_file() {
+        anyhow::bail!("{label} path is not a regular file: {}", path.display());
+    }
+    if metadata.len() == 0 || metadata.len() > max_bytes {
+        anyhow::bail!(
+            "{label} must contain 1..={max_bytes} bytes: {}",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
+fn display_name(path: &Path) -> Option<String> {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .map(str::to_string)
+}
+
+fn sha256_file(path: &Path) -> Result<String> {
+    let mut file = File::open(path)?;
+    let mut digest = Sha256::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let read = file.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        digest.update(&buffer[..read]);
+    }
+    Ok(format!("{:x}", digest.finalize()))
+}
+
+fn probe_image(
+    path: &Path,
+    provenance: GenerationReferenceProvenance,
+) -> Result<GenerationReference> {
+    let reader = image::ImageReader::open(path)?.with_guessed_format()?;
+    let format = reader
+        .format()
+        .ok_or_else(|| anyhow::anyhow!("unknown image format"))?;
+    let mime_type = match format {
+        image::ImageFormat::Png => "image/png",
+        image::ImageFormat::Jpeg => "image/jpeg",
+        image::ImageFormat::WebP => "image/webp",
+        image::ImageFormat::Gif => "image/gif",
+        _ => anyhow::bail!("unsupported image format; use PNG, JPEG, WebP, or GIF"),
+    };
+    let (width, height) = reader.into_dimensions()?;
+    Ok(GenerationReference::Image {
+        media: GenerationReferenceAuthority::Descriptor,
+        provenance,
+        mime_type: mime_type.to_string(),
+        width,
+        height,
+    })
+}
+
+fn probe_video(
+    path: &Path,
+    provenance: GenerationReferenceProvenance,
+) -> Result<GenerationReference> {
+    let probe = mold_inference::ltx2::media::probe_video(path)?;
+    let duration_ms = probe
+        .duration_ms
+        .ok_or_else(|| anyhow::anyhow!("MP4 video duration is unavailable"))?;
+    Ok(GenerationReference::Video {
+        media: GenerationReferenceAuthority::Descriptor,
+        provenance,
+        mime_type: "video/mp4".to_string(),
+        width: probe.width,
+        height: probe.height,
+        duration_ms,
+        fps: f64::from(probe.fps),
+        has_audio: probe.has_audio,
+        audio_duration_ms: probe.has_audio.then_some(duration_ms),
+    })
+}
+
+fn probe_audio(
+    path: &Path,
+    provenance: GenerationReferenceProvenance,
+) -> Result<GenerationReference> {
+    let wav = probe_wav(File::open(path)?)?;
+    Ok(GenerationReference::Audio {
+        media: GenerationReferenceAuthority::Descriptor,
+        provenance,
+        mime_type: "audio/wav".to_string(),
+        duration_ms: wav.duration_ms,
+        sample_rate: wav.sample_rate,
+        channels: wav.channels,
+    })
+}
+
+#[derive(Debug)]
+struct WavProbe {
+    duration_ms: u64,
+    sample_rate: u32,
+    channels: u16,
+}
+
+fn probe_wav(file: File) -> Result<WavProbe> {
+    let file_len = file.metadata()?.len();
+    anyhow::ensure!(file_len <= MAX_REFERENCE_FILE_BYTES);
+    let mut reader = BufReader::new(file);
+    let mut header = [0_u8; 12];
+    reader.read_exact(&mut header)?;
+    anyhow::ensure!(
+        &header[..4] == b"RIFF" && &header[8..] == b"WAVE",
+        "not a RIFF/WAVE file"
+    );
+    let riff_end = 8_u64
+        .checked_add(u64::from(u32::from_le_bytes(header[4..8].try_into()?)))
+        .context("WAVE container length overflowed")?;
+    anyhow::ensure!(
+        riff_end >= 12 && riff_end <= file_len,
+        "WAVE container is truncated"
+    );
+    let mut sample_rate = None;
+    let mut channels = None;
+    let mut byte_rate = None;
+    let mut block_align = None;
+    let mut data_bytes = None;
+    while reader.stream_position()?.saturating_add(8) <= riff_end {
+        let mut chunk = [0_u8; 8];
+        reader.read_exact(&mut chunk)?;
+        let length = u64::from(u32::from_le_bytes(chunk[4..].try_into()?));
+        let data_start = reader.stream_position()?;
+        let padded_length = length
+            .checked_add(length % 2)
+            .context("WAVE chunk length overflowed")?;
+        let next_chunk = data_start
+            .checked_add(padded_length)
+            .context("WAVE chunk offset overflowed")?;
+        anyhow::ensure!(
+            next_chunk <= riff_end && next_chunk <= file_len,
+            "WAVE chunk is truncated"
+        );
+        match &chunk[..4] {
+            b"fmt " => {
+                anyhow::ensure!(length >= 16, "WAVE fmt chunk is truncated");
+                let mut format = [0_u8; 16];
+                reader.read_exact(&mut format)?;
+                let encoding = u16::from_le_bytes(format[..2].try_into()?);
+                anyhow::ensure!(
+                    matches!(encoding, 1 | 3),
+                    "unsupported WAVE sample encoding"
+                );
+                let observed_channels = u16::from_le_bytes(format[2..4].try_into()?);
+                let observed_sample_rate = u32::from_le_bytes(format[4..8].try_into()?);
+                let observed_byte_rate = u32::from_le_bytes(format[8..12].try_into()?);
+                let observed_block_align = u16::from_le_bytes(format[12..14].try_into()?);
+                let bits_per_sample = u16::from_le_bytes(format[14..16].try_into()?);
+                anyhow::ensure!(
+                    observed_channels > 0
+                        && observed_sample_rate > 0
+                        && observed_block_align > 0
+                        && bits_per_sample > 0
+                        && bits_per_sample % 8 == 0,
+                    "WAVE format fields are invalid"
+                );
+                let expected_align = observed_channels
+                    .checked_mul(bits_per_sample / 8)
+                    .context("WAVE block alignment overflowed")?;
+                anyhow::ensure!(
+                    observed_block_align == expected_align,
+                    "WAVE block alignment is inconsistent"
+                );
+                anyhow::ensure!(
+                    observed_byte_rate
+                        == observed_sample_rate.saturating_mul(u32::from(observed_block_align)),
+                    "WAVE byte rate is inconsistent"
+                );
+                channels = Some(observed_channels);
+                sample_rate = Some(observed_sample_rate);
+                byte_rate = Some(observed_byte_rate);
+                block_align = Some(observed_block_align);
+            }
+            b"data" => data_bytes = Some(length),
+            _ => {}
+        }
+        reader.seek(SeekFrom::Start(next_chunk))?;
+        if sample_rate.is_some() && data_bytes.is_some() {
+            break;
+        }
+    }
+    let sample_rate = sample_rate
+        .filter(|rate| *rate > 0)
+        .context("WAVE sample rate is missing")?;
+    let channels = channels
+        .filter(|channels| *channels > 0)
+        .context("WAVE channel count is missing")?;
+    let byte_rate = u64::from(
+        byte_rate
+            .filter(|rate| *rate > 0)
+            .context("WAVE byte rate is missing")?,
+    );
+    let block_align = u64::from(block_align.context("WAVE block alignment is missing")?);
+    let data_bytes = data_bytes
+        .filter(|bytes| *bytes > 0)
+        .context("WAVE data chunk is missing or empty")?;
+    anyhow::ensure!(
+        data_bytes % block_align == 0,
+        "WAVE data is not frame-aligned"
+    );
+    Ok(WavProbe {
+        duration_ms: data_bytes.saturating_mul(1_000).div_ceil(byte_rate),
+        sample_rate,
+        channels,
+    })
+}
+
+fn reference_mime_type(reference: &GenerationReference) -> &str {
+    match reference {
+        GenerationReference::Image { mime_type, .. }
+        | GenerationReference::Video { mime_type, .. }
+        | GenerationReference::Audio { mime_type, .. } => mime_type,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use image::ImageEncoder as _;
+
+    #[test]
+    fn reference_arg_preserves_kind_and_paths_containing_equals() {
+        let parsed: ReferenceArg = "video=/tmp/clip=final.mp4".parse().unwrap();
+        assert_eq!(parsed.kind, ReferenceKind::Video);
+        assert_eq!(parsed.path, PathBuf::from("/tmp/clip=final.mp4"));
+    }
+
+    #[test]
+    fn reference_arg_rejects_implicit_or_stdin_media() {
+        assert!("/tmp/a.png".parse::<ReferenceArg>().is_err());
+        assert!("audio=-".parse::<ReferenceArg>().is_err());
+        assert!("document=/tmp/a.pdf".parse::<ReferenceArg>().is_err());
+    }
+
+    #[test]
+    fn duration_resolves_onto_exact_h3_grid() {
+        assert_eq!(frames_for_duration(5.0).unwrap(), 124);
+        assert_eq!(frames_for_duration(10.0).unwrap(), 243);
+        assert_eq!(frames_for_duration(15.0).unwrap(), 362);
+        assert_eq!(frames_for_duration(200.5 / 24.0).unwrap(), 192);
+        assert!(frames_for_duration(4.99).is_err());
+        assert!(frames_for_duration(15.01).is_err());
+        assert!(frames_for_duration(f64::NAN).is_err());
+    }
+
+    #[test]
+    fn fl2va_last_frame_uses_resolved_final_index_and_source_canvas() {
+        let dir = tempfile::tempdir().unwrap();
+        let last = dir.path().join("closing.png");
+        let mut png = Vec::new();
+        image::codecs::png::PngEncoder::new(&mut png)
+            .write_image(
+                &[0_u8; 640 * 360 * 3],
+                640,
+                360,
+                image::ExtendedColorType::Rgb8,
+            )
+            .unwrap();
+        std::fs::write(&last, png).unwrap();
+
+        let prepared = prepare_authoring(
+            minimax_h3::FL2VA_COMFY,
+            minimax_h3::FAMILY,
+            Some(5.0),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(&last),
+            &[],
+        )
+        .unwrap();
+        assert_eq!(prepared.frames, Some(124));
+        assert_eq!(prepared.fps, Some(24));
+        assert_eq!(prepared.width.zip(prepared.height), Some((1344, 768)));
+        let keyframe = &prepared.keyframes.unwrap()[0];
+        assert_eq!(keyframe.frame, 123);
+    }
+
+    #[test]
+    fn fl2va_boundary_rejects_reference_only_image_formats() {
+        let dir = tempfile::tempdir().unwrap();
+        let last = dir.path().join("closing.webp");
+        let mut webp = std::io::Cursor::new(Vec::new());
+        image::DynamicImage::new_rgb8(32, 32)
+            .write_to(&mut webp, image::ImageFormat::WebP)
+            .unwrap();
+        std::fs::write(&last, webp.into_inner()).unwrap();
+
+        let error = prepare_authoring(
+            minimax_h3::FL2VA_COMFY,
+            minimax_h3::FAMILY,
+            Some(5.0),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(&last),
+            &[],
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("must be PNG or JPEG"));
+    }
+
+    #[test]
+    fn h3_explicit_incompatible_shared_flags_fail_clearly() {
+        let error = validate_h3_flags(FlagValidation {
+            family: minimax_h3::FAMILY,
+            format: Some(OutputFormat::Png),
+            guidance: None,
+            strength: None,
+            no_audio: false,
+            negative_prompt: None,
+            scheduler_set: false,
+            cfg_plus: false,
+            has_lora: false,
+            has_mask: false,
+            has_control: false,
+            has_audio_file: false,
+            has_video: false,
+            has_extend: false,
+            has_generic_keyframes: false,
+            has_ltx_pipeline_fields: false,
+            clip_frames: None,
+        })
+        .unwrap_err();
+        assert!(error.to_string().contains("--format mp4"));
+    }
+}

--- a/crates/mold-cli/src/commands/mod.rs
+++ b/crates/mold-cli/src/commands/mod.rs
@@ -9,6 +9,7 @@ pub mod discord;
 pub mod expand;
 pub(crate) mod generate;
 pub mod gpu;
+pub(crate) mod h3;
 pub mod info;
 pub mod jobs;
 pub mod lambda;

--- a/crates/mold-cli/src/commands/run.rs
+++ b/crates/mold-cli/src/commands/run.rs
@@ -735,6 +735,8 @@ pub async fn run(
         );
     }
 
+    let reference_client =
+        (is_h3 && !references.is_empty()).then(|| crate::control::client_for_host(host.as_deref()));
     let mut h3_authoring = h3::prepare_authoring(
         &model,
         &family,
@@ -747,6 +749,7 @@ pub async fn run(
         image.first().map(String::as_str),
         last_frame.as_deref(),
         &references,
+        reference_client.as_ref(),
     )?;
     let frames = h3_authoring.frames.or(frames);
     let fps = h3_authoring.fps.or(fps);

--- a/crates/mold-cli/src/commands/run.rs
+++ b/crates/mold-cli/src/commands/run.rs
@@ -10,11 +10,12 @@ use mold_core::{
     OutputFormat, Scheduler, TimeRange,
 };
 use std::io::{IsTerminal, Read};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::{Ltx2PipelineArg, Ltx2SpatialUpscaleArg, Ltx2TemporalUpscaleArg};
 
 use super::generate;
+use super::h3::{self, ReferenceArg};
 
 /// Provide model name completions for shell tab-completion.
 pub fn complete_model_name() -> Vec<CompletionCandidate> {
@@ -626,6 +627,7 @@ pub async fn run(
     batch: u32,
     frames: Option<u32>,
     fps: Option<u32>,
+    duration: Option<f64>,
     clip_frames: Option<u32>,
     motion_tail: u32,
     audio: bool,
@@ -635,6 +637,9 @@ pub async fn run(
     extend: Option<String>,
     extend_overlap: Option<u32>,
     keyframe: Vec<String>,
+    first_frame: Option<PathBuf>,
+    last_frame: Option<PathBuf>,
+    references: Vec<ReferenceArg>,
     pipeline: Option<Ltx2PipelineArg>,
     ic_lora_control: Option<String>,
     hdr_exr_dir: Option<String>,
@@ -645,7 +650,7 @@ pub async fn run(
     guidance_flags: GuidanceFlags,
     camera_control: Option<String>,
     host: Option<String>,
-    format: OutputFormat,
+    format: Option<OutputFormat>,
     no_metadata: bool,
     preview: bool,
     local: bool,
@@ -662,7 +667,7 @@ pub async fn run(
     lora: Vec<String>,
     lora_scale: f64,
     image: Vec<String>,
-    strength: f64,
+    strength: Option<f64>,
     mask: Option<String>,
     control: Option<String>,
     control_model: Option<String>,
@@ -686,6 +691,83 @@ pub async fn run(
 
     let (model, prompt) = resolve_run_args(model_or_prompt.as_deref(), &prompt_rest, &mut config)?;
     let family = resolve_family(&model, &config);
+    let is_h3 = mold_core::minimax_h3::is_family(&family);
+
+    h3::validate_h3_flags(h3::FlagValidation {
+        family: &family,
+        format,
+        guidance,
+        strength,
+        no_audio,
+        negative_prompt: negative_prompt.as_deref(),
+        scheduler_set: scheduler.is_some(),
+        cfg_plus,
+        has_lora: !lora.is_empty(),
+        has_mask: mask.is_some(),
+        has_control: control.is_some() || control_model.is_some() || control_scale != 1.0,
+        has_audio_file: audio_file.is_some(),
+        has_video: video.is_some(),
+        has_extend: extend.is_some() || extend_overlap.is_some(),
+        has_generic_keyframes: !keyframe.is_empty(),
+        has_ltx_pipeline_fields: pipeline.is_some()
+            || ic_lora_control.is_some()
+            || hdr_exr_dir.is_some()
+            || hdr_exr_full_float
+            || retake.is_some()
+            || spatial_upscale.is_some()
+            || temporal_upscale.is_some()
+            || guidance_flags.stg_scale.is_some()
+            || guidance_flags.stg_blocks.is_some()
+            || guidance_flags.rescale_scale.is_some()
+            || guidance_flags.modality_scale.is_some()
+            || guidance_flags.skip_step.is_some()
+            || camera_control.is_some(),
+        clip_frames,
+    })?;
+    if is_h3 && !references.is_empty() && batch > 1 {
+        anyhow::bail!(
+            "MiniMax H3 ordered references currently require --batch 1 because upload handles are one-use and request-bound"
+        );
+    }
+    if is_h3 && steps.is_some_and(|value| value < 2) {
+        anyhow::bail!(
+            "MiniMax H3 --steps counts terminal-inclusive sigma grid points and must be at least 2"
+        );
+    }
+
+    let mut h3_authoring = h3::prepare_authoring(
+        &model,
+        &family,
+        duration,
+        frames,
+        fps,
+        width,
+        height,
+        first_frame.as_deref(),
+        image.first().map(String::as_str),
+        last_frame.as_deref(),
+        &references,
+    )?;
+    let frames = h3_authoring.frames.or(frames);
+    let fps = h3_authoring.fps.or(fps);
+    let width = h3_authoring.width.or(width);
+    let height = h3_authoring.height.or(height);
+    let format = if is_h3 {
+        OutputFormat::Mp4
+    } else {
+        format.unwrap_or(OutputFormat::Png)
+    };
+    let strength = if is_h3 { 1.0 } else { strength.unwrap_or(0.75) };
+    if is_h3 {
+        if let Some(path) = output.as_deref().filter(|path| *path != "-") {
+            let extension = Path::new(path).extension().and_then(|value| value.to_str());
+            if !extension.is_some_and(|value| value.eq_ignore_ascii_case("mp4")) {
+                anyhow::bail!(
+                    "MiniMax H3 output is always MP4; use --output <name>.mp4 or stdout (-)"
+                );
+            }
+        }
+    }
 
     // Validate file-based arguments early — before expansion or inference.
     validate_file_args_full(FileArgRefs {
@@ -713,19 +795,26 @@ pub async fn run(
 
     validate_image_args_for_model(&family, &model, &image)?;
 
-    let loaded_images = image
-        .iter()
-        .map(|img_path| {
-            if img_path == "-" {
-                let mut buf = Vec::new();
-                std::io::stdin().read_to_end(&mut buf)?;
-                Ok(buf)
-            } else {
-                std::fs::read(img_path)
-                    .map_err(|e| anyhow::anyhow!("failed to read image '{}': {e}", img_path))
-            }
-        })
-        .collect::<Result<Vec<_>>>()?;
+    let loaded_images = if let Some(source) = h3_authoring.source_image.take() {
+        vec![source]
+    } else {
+        image
+            .iter()
+            .map(|img_path| {
+                if img_path == "-" {
+                    let mut buf = Vec::new();
+                    std::io::stdin().read_to_end(&mut buf)?;
+                    if is_h3 {
+                        h3::validate_boundary_image_bytes(&buf, "first")?;
+                    }
+                    Ok(buf)
+                } else {
+                    std::fs::read(img_path)
+                        .map_err(|e| anyhow::anyhow!("failed to read image '{}': {e}", img_path))
+                }
+            })
+            .collect::<Result<Vec<_>>>()?
+    };
     let ordered_images = family == "qwen-image-edit" || is_flux2_dev_model(&model);
     let source_image = if ordered_images {
         None
@@ -758,7 +847,11 @@ pub async fn run(
     let audio_file_bytes = audio_file.as_deref().map(std::fs::read).transpose()?;
     let source_video_bytes = video.as_deref().map(std::fs::read).transpose()?;
     let extend_video_bytes = extend.as_deref().map(std::fs::read).transpose()?;
-    let keyframes = parse_keyframes(&keyframe)?;
+    let keyframes = if is_h3 {
+        h3_authoring.keyframes.take()
+    } else {
+        parse_keyframes(&keyframe)?
+    };
     let pipeline = resolve_ic_lora_pipeline(
         parse_pipeline(pipeline),
         ic_lora_control.as_deref(),
@@ -806,15 +899,23 @@ pub async fn run(
     if should_expand {
         mold_core::expand::validate_expansion_variation_count(batch.max(1) as usize)?;
     }
-    let expansion_task = mold_core::ExpandTask::for_conditioning(
-        &family,
-        pipeline,
-        source_image.is_some(),
-        source_video_bytes.is_some() || extend_video_bytes.is_some(),
-        audio_file_bytes.is_some(),
-        keyframes.as_ref().map_or(0, Vec::len),
-        retake_range.is_some(),
-    );
+    let expansion_task = if h3_authoring
+        .references
+        .as_ref()
+        .is_some_and(|references| !references.is_empty())
+    {
+        mold_core::ExpandTask::ReferenceToAudioVideo
+    } else {
+        mold_core::ExpandTask::for_conditioning(
+            &family,
+            pipeline,
+            source_image.is_some(),
+            source_video_bytes.is_some() || extend_video_bytes.is_some(),
+            audio_file_bytes.is_some(),
+            keyframes.as_ref().map_or(0, Vec::len),
+            retake_range.is_some(),
+        )
+    };
 
     // Expansion strategy:
     // - If --local or server unreachable: expand client-side (existing path)
@@ -900,10 +1001,8 @@ pub async fn run(
 
         let variations = batch.max(1) as usize;
         let model_family = super::expand::resolve_family_from_config(&model, &config);
-        let client = match host.as_deref() {
-            Some(h) => mold_core::MoldClient::new(h),
-            None => mold_core::MoldClient::from_env(),
-        };
+        let expand_context = crate::control::CliContext::new(host.as_deref());
+        let client = expand_context.client();
         let expand_req = mold_core::ExpandRequest {
             prompt: prompt.clone(),
             model_family,
@@ -995,7 +1094,7 @@ pub async fn run(
 
     // Resolve effective negative prompt: CLI flag > per-model config > global config > None.
     // --no-negative suppresses all defaults (forces empty unconditional).
-    let effective_negative_prompt = if no_negative {
+    let effective_negative_prompt = if is_h3 || no_negative {
         None
     } else if negative_prompt.is_some() {
         negative_prompt
@@ -1006,8 +1105,9 @@ pub async fn run(
 
     // Resolve LoRA: explicit CLI values override config defaults.
     let model_cfg = config.resolved_model_config(&model);
-    let default_lora = model_cfg
-        .effective_lora()
+    let default_lora = (!is_h3)
+        .then(|| model_cfg.effective_lora())
+        .flatten()
         .map(|(path, scale)| LoraWeight { path, scale });
     let (effective_lora, loras) = resolve_effective_loras_for_family(
         &family,
@@ -1055,6 +1155,20 @@ pub async fn run(
             spatial_upscale,
             temporal_upscale,
             guidance_overrides,
+            source_image_name: if is_h3 {
+                h3_authoring.source_image_name.or_else(|| {
+                    image
+                        .first()
+                        .filter(|path| path.as_str() != "-")
+                        .and_then(|path| Path::new(path).file_name())
+                        .and_then(|name| name.to_str())
+                        .map(str::to_string)
+                })
+            } else {
+                None
+            },
+            references: h3_authoring.references,
+            reference_uploads: h3_authoring.uploads,
         },
         host,
         format,

--- a/crates/mold-cli/src/control.rs
+++ b/crates/mold-cli/src/control.rs
@@ -19,7 +19,13 @@ pub(crate) struct CliContext {
 impl CliContext {
     pub(crate) fn new(host: Option<&str>) -> Self {
         let client = match host {
-            Some(host) => MoldClient::new(host),
+            Some(host) => std::env::var("MOLD_API_KEY")
+                .ok()
+                .filter(|key| !key.is_empty())
+                .map_or_else(
+                    || MoldClient::new(host),
+                    |key| MoldClient::with_api_key(host, key),
+                ),
             None => MoldClient::from_env(),
         };
         let config = Config::load_or_default();

--- a/crates/mold-cli/src/control.rs
+++ b/crates/mold-cli/src/control.rs
@@ -18,16 +18,7 @@ pub(crate) struct CliContext {
 
 impl CliContext {
     pub(crate) fn new(host: Option<&str>) -> Self {
-        let client = match host {
-            Some(host) => std::env::var("MOLD_API_KEY")
-                .ok()
-                .filter(|key| !key.is_empty())
-                .map_or_else(
-                    || MoldClient::new(host),
-                    |key| MoldClient::with_api_key(host, key),
-                ),
-            None => MoldClient::from_env(),
-        };
+        let client = client_for_host(host);
         let config = Config::load_or_default();
         Self { client, config }
     }
@@ -54,6 +45,23 @@ impl CliContext {
 
     pub(crate) async fn stream_server_pull(&self, model: &str) -> Result<()> {
         stream_server_pull(&self.client, model).await
+    }
+}
+
+/// Build the exact CLI target client without contacting the host.
+///
+/// H3 authoring uses this before opening reference media so a missing or
+/// invalid API-key header fails before local bytes are read.
+pub(crate) fn client_for_host(host: Option<&str>) -> MoldClient {
+    match host {
+        Some(host) => std::env::var("MOLD_API_KEY")
+            .ok()
+            .filter(|key| !key.is_empty())
+            .map_or_else(
+                || MoldClient::new(host),
+                |key| MoldClient::with_api_key(host, key),
+            ),
+        None => MoldClient::from_env(),
     }
 }
 

--- a/crates/mold-cli/src/main.rs
+++ b/crates/mold-cli/src/main.rs
@@ -625,10 +625,10 @@ Examples:
         #[arg(short, long, help_heading = "Output", value_hint = ValueHint::FilePath)]
         output: Option<String>,
 
-        /// Output format
-        #[arg(long, default_value_t = OutputFormat::Png, help_heading = "Output",
+        /// Output format (default: PNG; MiniMax H3 always emits MP4)
+        #[arg(long, help_heading = "Output",
               value_parser = output_format_parser(&["png", "jpeg", "jpg", "gif", "apng", "webp", "mp4", "wav"]))]
-        format: OutputFormat,
+        format: Option<OutputFormat>,
 
         /// Disable embedded generation metadata in PNG output for this run
         #[arg(long, help_heading = "Output")]
@@ -674,6 +674,11 @@ Examples:
         /// Only used with --frames or video model families.
         #[arg(long, help_heading = "Video")]
         fps: Option<u32>,
+
+        /// MiniMax H3 duration in seconds (5 through 15). Resolves to the
+        /// nearest exact 17n+5 frame count on H3's fixed 24 FPS clock.
+        #[arg(long, conflicts_with = "frames", help_heading = "Video")]
+        duration: Option<f64>,
 
         /// Per-clip frame cap for chained video. When --frames exceeds this,
         /// the CLI splits into multiple chained clips stitched at render time.
@@ -726,6 +731,26 @@ Examples:
         /// Keyframe conditioning in the form <frame:path>. Repeat for multiple keyframes.
         #[arg(long, help_heading = "Video")]
         keyframe: Vec<String>,
+
+        /// MiniMax H3 FL2VA opening-frame condition.
+        #[arg(
+            long,
+            conflicts_with = "image",
+            help_heading = "MiniMax H3",
+            value_hint = ValueHint::FilePath
+        )]
+        first_frame: Option<std::path::PathBuf>,
+
+        /// MiniMax H3 FL2VA closing-frame condition. It is bound to the final
+        /// frame after --duration/--frames resolves onto H3's exact frame grid.
+        #[arg(long, help_heading = "MiniMax H3", value_hint = ValueHint::FilePath)]
+        last_frame: Option<std::path::PathBuf>,
+
+        /// Ordered MiniMax H3 Ref2VA input as KIND=PATH, where KIND is image,
+        /// video, or audio. Repeat in semantic order. Files use authenticated,
+        /// request-bound streaming upload and are never placed inline in JSON.
+        #[arg(long, value_name = "KIND=PATH", help_heading = "MiniMax H3")]
+        reference: Vec<commands::h3::ReferenceArg>,
 
         /// LTX-2 pipeline mode.
         #[arg(long, help_heading = "Video", value_enum)]
@@ -947,9 +972,10 @@ Examples:
         #[arg(short = 'i', long, help_heading = "img2img", value_hint = ValueHint::FilePath)]
         image: Vec<String>,
 
-        /// Denoising strength for img2img (0.0 = no change, 1.0 = full noise)
-        #[arg(long, default_value = "0.75", help_heading = "img2img")]
-        strength: f64,
+        /// Denoising strength for img2img (default: 0.75; 0.0 = no change,
+        /// 1.0 = full noise)
+        #[arg(long, help_heading = "img2img")]
+        strength: Option<f64>,
 
         /// Mask image for inpainting (file path; white = repaint, black = preserve)
         #[arg(long, requires = "image", help_heading = "img2img", value_hint = ValueHint::FilePath)]
@@ -1700,6 +1726,7 @@ async fn run() -> anyhow::Result<()> {
             batch,
             frames,
             fps,
+            duration,
             clip_frames,
             motion_tail,
             audio,
@@ -1709,6 +1736,9 @@ async fn run() -> anyhow::Result<()> {
             extend,
             extend_overlap,
             keyframe,
+            first_frame,
+            last_frame,
+            reference,
             pipeline,
             ic_lora_control,
             hdr_exr_dir,
@@ -1803,6 +1833,20 @@ async fn run() -> anyhow::Result<()> {
                 }
             }
 
+            if prompt.len() > 1
+                && (model_or_prompt
+                    .as_deref()
+                    .and_then(mold_core::minimax_h3::resolve_model_name)
+                    .is_some()
+                    || duration.is_some()
+                    || first_frame.is_some()
+                    || last_frame.is_some()
+                    || !reference.is_empty())
+            {
+                anyhow::bail!(
+                    "MiniMax H3 endpoint/reference authoring is single-clip; use one prompt"
+                );
+            }
             if prompt.len() > 1 {
                 return commands::chain::run_from_sugar(
                     model_or_prompt.clone(),
@@ -1850,6 +1894,7 @@ async fn run() -> anyhow::Result<()> {
                 batch,
                 frames,
                 fps,
+                duration,
                 clip_frames,
                 motion_tail,
                 audio,
@@ -1859,6 +1904,9 @@ async fn run() -> anyhow::Result<()> {
                 extend,
                 extend_overlap,
                 keyframe,
+                first_frame,
+                last_frame,
+                reference,
                 pipeline,
                 ic_lora_control,
                 hdr_exr_dir,
@@ -2628,7 +2676,7 @@ mod tests {
     fn run_format_jpeg() {
         let cli = parse(&["run", "model", "test", "--format", "jpeg"]);
         match cli.command {
-            Commands::Run { format, .. } => assert_eq!(format, OutputFormat::Jpeg),
+            Commands::Run { format, .. } => assert_eq!(format, Some(OutputFormat::Jpeg)),
             _ => panic!("expected Run"),
         }
     }
@@ -2741,7 +2789,7 @@ mod tests {
                 assert_eq!(width, Some(512));
                 assert_eq!(height, Some(768));
                 assert_eq!(guidance, Some(4.0));
-                assert_eq!(format, OutputFormat::Jpeg);
+                assert_eq!(format, Some(OutputFormat::Jpeg));
                 assert!(!no_metadata);
                 assert_eq!(batch, 2);
                 assert_eq!(output.as_deref(), Some("/tmp/test.jpg"));
@@ -2775,7 +2823,7 @@ mod tests {
                 assert_eq!(width, None);
                 assert_eq!(height, None);
                 assert_eq!(guidance, None);
-                assert_eq!(format, OutputFormat::Png);
+                assert_eq!(format, None);
                 assert!(!no_metadata);
                 assert_eq!(batch, 1);
                 assert_eq!(output, None);
@@ -2812,7 +2860,7 @@ mod tests {
         // "gif" is in the new format list [png, jpeg, gif, apng, webp, mp4]
         let cli = parse(&["run", "model", "test", "--format", "gif"]);
         match cli.command {
-            Commands::Run { format, .. } => assert_eq!(format, OutputFormat::Gif),
+            Commands::Run { format, .. } => assert_eq!(format, Some(OutputFormat::Gif)),
             _ => panic!("expected Run"),
         }
     }
@@ -2875,7 +2923,7 @@ mod tests {
     fn run_strength_flag() {
         let cli = parse(&["run", "model", "test", "--strength", "0.5"]);
         match cli.command {
-            Commands::Run { strength, .. } => assert_eq!(strength, 0.5),
+            Commands::Run { strength, .. } => assert_eq!(strength, Some(0.5)),
             _ => panic!("expected Run"),
         }
     }
@@ -2884,7 +2932,7 @@ mod tests {
     fn run_strength_default() {
         let cli = parse(&["run", "model", "test"]);
         match cli.command {
-            Commands::Run { strength, .. } => assert_eq!(strength, 0.75),
+            Commands::Run { strength, .. } => assert_eq!(strength, None),
             _ => panic!("expected Run"),
         }
     }
@@ -3071,6 +3119,73 @@ mod tests {
             }
             _ => panic!("expected Run"),
         }
+    }
+
+    #[test]
+    fn run_h3_authoring_flags_preserve_reference_order() {
+        let cli = parse(&[
+            "run",
+            "minimax-h3-ref2va",
+            "match the cast",
+            "--duration",
+            "8.5",
+            "--reference",
+            "image=/tmp/cast.png",
+            "--reference",
+            "video=/tmp/motion.mp4",
+            "--reference",
+            "audio=/tmp/voice.wav",
+        ]);
+        match cli.command {
+            Commands::Run {
+                duration,
+                reference,
+                format,
+                strength,
+                ..
+            } => {
+                assert_eq!(duration, Some(8.5));
+                assert_eq!(reference.len(), 3);
+                assert_eq!(reference[0].kind, commands::h3::ReferenceKind::Image);
+                assert_eq!(reference[1].kind, commands::h3::ReferenceKind::Video);
+                assert_eq!(reference[2].kind, commands::h3::ReferenceKind::Audio);
+                assert_eq!(format, None);
+                assert_eq!(strength, None);
+            }
+            _ => panic!("expected Run command"),
+        }
+    }
+
+    #[test]
+    fn run_h3_duration_conflicts_with_explicit_frames() {
+        let error = try_parse(&[
+            "run",
+            "minimax-h3",
+            "a synchronized shot",
+            "--duration",
+            "5",
+            "--frames",
+            "124",
+        ])
+        .err()
+        .expect("duration and frames must conflict");
+        assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn run_h3_first_frame_conflicts_with_legacy_image_flag() {
+        let error = try_parse(&[
+            "run",
+            "minimax-h3",
+            "animate",
+            "--first-frame",
+            "/tmp/first.png",
+            "--image",
+            "/tmp/other.png",
+        ])
+        .err()
+        .expect("first-frame and image must conflict");
+        assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
     }
 
     #[test]

--- a/crates/mold-core/Cargo.toml
+++ b/crates/mold-core/Cargo.toml
@@ -19,6 +19,7 @@ console = "0.15"
 dirs = "6"
 hf-hub = { version = "0.5", default-features = false, features = ["tokio", "ureq", "rustls-tls"] }
 indicatif = "0.17"
+libc = "0.2"
 reqwest = { version = "0.12", features = ["json", "rustls-tls", "stream"], default-features = false }
 serde = { version = "1", features = ["derive"] }
 sha2 = "0.10"

--- a/crates/mold-core/Cargo.toml
+++ b/crates/mold-core/Cargo.toml
@@ -19,13 +19,14 @@ console = "0.15"
 dirs = "6"
 hf-hub = { version = "0.5", default-features = false, features = ["tokio", "ureq", "rustls-tls"] }
 indicatif = "0.17"
-reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
+reqwest = { version = "0.12", features = ["json", "rustls-tls", "stream"], default-features = false }
 serde = { version = "1", features = ["derive"] }
 sha2 = "0.10"
 serde_json = "1"
 thiserror = "2"
 tracing = "0.1"
 tokio = { version = "1", features = ["full"] }
+tokio-util = { version = "0.7", features = ["io"] }
 toml = "0.8"
 base64 = "0.22"
 strsim = "0.11"

--- a/crates/mold-core/src/client.rs
+++ b/crates/mold-core/src/client.rs
@@ -25,23 +25,26 @@ const REFERENCE_UPLOAD_SESSION_HEADER: &str = "x-mold-reference-upload-session";
 pub struct MoldClient {
     base_url: String,
     client: Client,
+    api_key_configured: bool,
 }
 
 impl MoldClient {
     pub fn new(base_url: &str) -> Self {
-        let client = build_client(None);
+        let (client, api_key_configured) = build_client(None);
         Self {
             base_url: normalize_host(base_url),
             client,
+            api_key_configured,
         }
     }
 
     /// Create a client with an explicit API key for authentication.
     pub fn with_api_key(base_url: &str, api_key: String) -> Self {
-        let client = build_client(Some(&api_key));
+        let (client, api_key_configured) = build_client(Some(&api_key));
         Self {
             base_url: normalize_host(base_url),
             client,
+            api_key_configured,
         }
     }
 
@@ -49,11 +52,17 @@ impl MoldClient {
         let base_url =
             std::env::var("MOLD_HOST").unwrap_or_else(|_| "http://localhost:7680".to_string());
         let api_key = std::env::var("MOLD_API_KEY").ok().filter(|k| !k.is_empty());
-        let client = build_client(api_key.as_deref());
+        let (client, api_key_configured) = build_client(api_key.as_deref());
         Self {
             base_url: normalize_host(&base_url),
             client,
+            api_key_configured,
         }
+    }
+
+    /// Whether this client actually installed a non-empty API-key header.
+    pub fn has_api_key(&self) -> bool {
+        self.api_key_configured
     }
 
     /// Create a request-bound MiniMax H3 reference upload session.
@@ -1497,15 +1506,17 @@ fn parse_sse_event(event_text: &str) -> (String, String) {
 }
 
 /// Build a reqwest Client, optionally with a default `X-Api-Key` header.
-fn build_client(api_key: Option<&str>) -> Client {
+fn build_client(api_key: Option<&str>) -> (Client, bool) {
     let mut builder = Client::builder();
+    let mut api_key_configured = false;
     if let Some(key) = api_key {
         let mut headers = reqwest::header::HeaderMap::new();
         match reqwest::header::HeaderValue::from_str(key) {
-            Ok(val) => {
+            Ok(val) if !key.trim().is_empty() => {
                 headers.insert("x-api-key", val);
+                api_key_configured = true;
             }
-            Err(_) => {
+            _ => {
                 eprintln!(
                     "warning: MOLD_API_KEY contains characters invalid for an HTTP header; \
                      authentication header will not be sent"
@@ -1514,7 +1525,10 @@ fn build_client(api_key: Option<&str>) -> Client {
         }
         builder = builder.default_headers(headers);
     }
-    builder.build().unwrap_or_else(|_| Client::new())
+    match builder.build() {
+        Ok(client) => (client, api_key_configured),
+        Err(_) => (Client::new(), false),
+    }
 }
 
 /// Normalize a host string into a full URL.
@@ -1604,6 +1618,19 @@ mod tests {
     fn test_new_trims_trailing_slash() {
         let client = MoldClient::new("http://localhost:7680/");
         assert_eq!(client.host(), "http://localhost:7680");
+    }
+
+    #[test]
+    fn api_key_state_tracks_only_an_installed_header() {
+        assert!(!MoldClient::new("http://localhost:7680").has_api_key());
+        assert!(
+            MoldClient::with_api_key("http://localhost:7680", "sekrit".to_string()).has_api_key()
+        );
+        assert!(!MoldClient::with_api_key("http://localhost:7680", "".to_string()).has_api_key());
+        assert!(
+            !MoldClient::with_api_key("http://localhost:7680", "bad\nkey".to_string())
+                .has_api_key()
+        );
     }
 
     #[test]
@@ -1770,7 +1797,9 @@ mod tests {
                     "mime_type": "image/png",
                     "width": 1,
                     "height": 1
-                }
+                },
+                "request_scope_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "session_complete": true
             })))
             .expect(1)
             .mount(&server)
@@ -1793,7 +1822,9 @@ mod tests {
                     "mime_type": "image/png",
                     "width": 16,
                     "height": 16
-                }
+                },
+                "request_scope_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                "session_complete": true
             })))
             .expect(1)
             .mount(&server)
@@ -1817,7 +1848,9 @@ mod tests {
                     "duration_ms": 2000,
                     "sample_rate": 32000,
                     "channels": 2
-                }
+                },
+                "request_scope_sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+                "session_complete": true
             })))
             .expect(1)
             .mount(&server)

--- a/crates/mold-core/src/client.rs
+++ b/crates/mold-core/src/client.rs
@@ -7,11 +7,18 @@ use crate::error::MoldError;
 use crate::types::{
     AudioData, DeviceState, ExpandRequest, ExpandResponse, GalleryImage, GenerateRequest,
     GenerateResponse, ImageData, LoraInfo, ModelInfo, ModelInfoExtended, OutputFormat,
-    QueueListingWire, ServerStatus, SseCompleteEvent, SseErrorEvent, SseProgressEvent, VideoData,
+    QueueListingWire, ReferenceUploadCompleteResponse, ReferenceUploadSessionRequest,
+    ReferenceUploadSessionResponse, ServerStatus, SseCompleteEvent, SseErrorEvent,
+    SseProgressEvent, VideoData,
 };
 use anyhow::{Context, Result};
 use base64::Engine as _;
 use reqwest::{Client, StatusCode};
+use std::path::Path;
+use tokio_util::io::ReaderStream;
+
+const REFERENCE_UPLOAD_HANDLE_HEADER: &str = "x-mold-reference-upload";
+const REFERENCE_UPLOAD_SESSION_HEADER: &str = "x-mold-reference-upload-session";
 
 #[derive(Clone)]
 pub struct MoldClient {
@@ -46,6 +53,86 @@ impl MoldClient {
             base_url: normalize_host(&base_url),
             client,
         }
+    }
+
+    /// Create a request-bound MiniMax H3 reference upload session.
+    ///
+    /// The server applies authentication and legal activation before it
+    /// allocates staging. Error bodies (including HTTP 451 policy details) are
+    /// retained verbatim for callers instead of being collapsed to a generic
+    /// reqwest status error.
+    pub async fn create_reference_upload_session(
+        &self,
+        request: &ReferenceUploadSessionRequest,
+    ) -> Result<ReferenceUploadSessionResponse> {
+        let response = self
+            .client
+            .post(format!(
+                "{}/api/generate/reference-upload-sessions",
+                self.base_url
+            ))
+            .json(request)
+            .send()
+            .await?;
+        Ok(error_for_status_with_body(response)
+            .await?
+            .json::<ReferenceUploadSessionResponse>()
+            .await?)
+    }
+
+    /// Stream one local reference file through a one-use bearer handle.
+    ///
+    /// The handle stays in a header, while the opened file's exact length is
+    /// sent as `Content-Length`. `ReaderStream` keeps large video references
+    /// out of process-sized buffers; the server independently hashes, probes,
+    /// and checks the declared descriptor before admission.
+    pub async fn upload_reference_file(
+        &self,
+        handle: &str,
+        path: &Path,
+        mime_type: &str,
+    ) -> Result<ReferenceUploadCompleteResponse> {
+        let file = tokio::fs::File::open(path)
+            .await
+            .with_context(|| format!("failed to open reference '{}'", path.display()))?;
+        let metadata = file
+            .metadata()
+            .await
+            .with_context(|| format!("failed to inspect reference '{}'", path.display()))?;
+        anyhow::ensure!(
+            metadata.is_file() && metadata.len() > 0,
+            "reference upload source is not a non-empty regular file: {}",
+            path.display()
+        );
+        let body = reqwest::Body::wrap_stream(ReaderStream::new(file));
+        let response = self
+            .client
+            .put(format!("{}/api/generate/reference-upload", self.base_url))
+            .header(REFERENCE_UPLOAD_HANDLE_HEADER, handle)
+            .header(reqwest::header::CONTENT_TYPE, mime_type)
+            .header(reqwest::header::CONTENT_LENGTH, metadata.len())
+            .body(body)
+            .send()
+            .await?;
+        Ok(error_for_status_with_body(response)
+            .await?
+            .json::<ReferenceUploadCompleteResponse>()
+            .await?)
+    }
+
+    /// Best-effort cleanup for an unconsumed reference upload session.
+    pub async fn cancel_reference_upload_session(&self, handle: &str) -> Result<()> {
+        let response = self
+            .client
+            .delete(format!(
+                "{}/api/generate/reference-upload-sessions",
+                self.base_url
+            ))
+            .header(REFERENCE_UPLOAD_SESSION_HEADER, handle)
+            .send()
+            .await?;
+        error_for_status_with_body(response).await?;
+        Ok(())
     }
 
     /// Generate an image. Returns raw image bytes (PNG or JPEG).
@@ -1417,6 +1504,40 @@ mod tests {
     use super::*;
     use crate::test_support::ENV_LOCK;
 
+    fn reference_session_request() -> ReferenceUploadSessionRequest {
+        let request = serde_json::from_value(serde_json::json!({
+            "prompt": "match the reference",
+            "model": crate::minimax_h3::REF2VA_COMFY,
+            "width": crate::minimax_h3::DEFAULT_WIDTH,
+            "height": crate::minimax_h3::DEFAULT_HEIGHT,
+            "steps": crate::minimax_h3::DEFAULT_STEPS,
+            "guidance": 0.0,
+            "seed": 7,
+            "batch_size": 1,
+            "output_format": "mp4",
+            "strength": 1.0,
+            "frames": crate::minimax_h3::MIN_FRAMES,
+            "fps": crate::minimax_h3::FIXED_FPS,
+            "enable_audio": true,
+            "references": [{
+                "kind": "image",
+                "media": { "authority": "descriptor" },
+                "provenance": {
+                    "name": "reference.png",
+                    "sha256": "0000000000000000000000000000000000000000000000000000000000000000"
+                },
+                "mime_type": "image/png",
+                "width": 1,
+                "height": 1
+            }]
+        }))
+        .unwrap();
+        ReferenceUploadSessionRequest {
+            request,
+            upload_references: vec![1],
+        }
+    }
+
     #[test]
     fn test_new_trims_trailing_slash() {
         let client = MoldClient::new("http://localhost:7680/");
@@ -1535,6 +1656,89 @@ mod tests {
     fn test_is_connection_error_via_mold_error() {
         let err: anyhow::Error = MoldError::Client("connection refused".to_string()).into();
         assert!(MoldClient::is_connection_error(&err));
+    }
+
+    #[tokio::test]
+    async fn reference_session_preserves_authenticated_http_451_body() {
+        use wiremock::matchers::{header, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/generate/reference-upload-sessions"))
+            .and(header("x-api-key", "sekrit"))
+            .respond_with(ResponseTemplate::new(451).set_body_json(serde_json::json!({
+                "error": "MiniMax H3 legal activation is unavailable",
+                "code": crate::MINIMAX_H3_AUTHORIZATION_REQUIRED
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let error = MoldClient::with_api_key(&server.uri(), "sekrit".to_string())
+            .create_reference_upload_session(&reference_session_request())
+            .await
+            .unwrap_err();
+        let message = error.to_string();
+        assert!(message.contains("451 Unavailable For Legal Reasons"));
+        assert!(message.contains(crate::MINIMAX_H3_AUTHORIZATION_REQUIRED));
+    }
+
+    #[tokio::test]
+    async fn reference_file_streams_with_secret_headers_and_cancels_by_session_header() {
+        use wiremock::matchers::{body_string, header, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path("/api/generate/reference-upload"))
+            .and(header("x-api-key", "sekrit"))
+            .and(header(REFERENCE_UPLOAD_HANDLE_HEADER, "mru_secret"))
+            .and(header("content-type", "image/png"))
+            .and(header("content-length", "5"))
+            .and(body_string("bytes"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "instance_id": "server-1",
+                "reference": 1,
+                "metadata": {
+                    "kind": "image",
+                    "index": 1,
+                    "name": "reference.png",
+                    "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "mime_type": "image/png",
+                    "width": 1,
+                    "height": 1
+                }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("DELETE"))
+            .and(path("/api/generate/reference-upload-sessions"))
+            .and(header("x-api-key", "sekrit"))
+            .and(header(
+                REFERENCE_UPLOAD_SESSION_HEADER,
+                "mrs_session_secret",
+            ))
+            .respond_with(ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("reference.png");
+        std::fs::write(&path, b"bytes").unwrap();
+        let client = MoldClient::with_api_key(&server.uri(), "sekrit".to_string());
+        let completed = client
+            .upload_reference_file("mru_secret", &path, "image/png")
+            .await
+            .unwrap();
+        assert_eq!(completed.instance_id, "server-1");
+        assert_eq!(completed.reference, 1);
+        client
+            .cancel_reference_upload_session("mrs_session_secret")
+            .await
+            .unwrap();
     }
 
     #[tokio::test]

--- a/crates/mold-core/src/client.rs
+++ b/crates/mold-core/src/client.rs
@@ -14,6 +14,7 @@ use crate::types::{
 use anyhow::{Context, Result};
 use base64::Engine as _;
 use reqwest::{Client, StatusCode};
+use std::io::{Seek, SeekFrom};
 use std::path::Path;
 use tokio_util::io::ReaderStream;
 
@@ -104,13 +105,74 @@ impl MoldClient {
             "reference upload source is not a non-empty regular file: {}",
             path.display()
         );
-        let body = reqwest::Body::wrap_stream(ReaderStream::new(file));
+        self.upload_reference_body(
+            handle,
+            mime_type,
+            metadata.len(),
+            reqwest::Body::wrap_stream(ReaderStream::new(file)),
+        )
+        .await
+    }
+
+    /// Stream an already-open reference file through a one-use bearer handle.
+    ///
+    /// Keeping the descriptor probe and upload tied to clones of the same file
+    /// descriptor prevents a path or symlink replacement between inspection and
+    /// upload. The local pathname never enters the request or this method's
+    /// errors.
+    pub async fn upload_reference_open_file(
+        &self,
+        handle: &str,
+        mut file: std::fs::File,
+        mime_type: &str,
+    ) -> Result<ReferenceUploadCompleteResponse> {
+        let metadata = file.metadata().context("failed to inspect reference")?;
+        anyhow::ensure!(
+            metadata.is_file() && metadata.len() > 0,
+            "reference upload source is not a non-empty regular file"
+        );
+        file.seek(SeekFrom::Start(0))
+            .context("failed to rewind reference")?;
+        let file = tokio::fs::File::from_std(file);
+        self.upload_reference_body(
+            handle,
+            mime_type,
+            metadata.len(),
+            reqwest::Body::wrap_stream(ReaderStream::new(file)),
+        )
+        .await
+    }
+
+    /// Upload one bounded in-memory attachment through a one-use bearer handle.
+    ///
+    /// Discord already owns attachment bytes in memory after its download-size
+    /// gate. Taking ownership here guarantees the uploaded body is exactly the
+    /// body that was hashed and probed, without a second URL fetch.
+    pub async fn upload_reference_bytes(
+        &self,
+        handle: &str,
+        bytes: Vec<u8>,
+        mime_type: &str,
+    ) -> Result<ReferenceUploadCompleteResponse> {
+        anyhow::ensure!(!bytes.is_empty(), "reference upload source is empty");
+        let length = u64::try_from(bytes.len()).context("reference upload is too large")?;
+        self.upload_reference_body(handle, mime_type, length, reqwest::Body::from(bytes))
+            .await
+    }
+
+    async fn upload_reference_body(
+        &self,
+        handle: &str,
+        mime_type: &str,
+        content_length: u64,
+        body: reqwest::Body,
+    ) -> Result<ReferenceUploadCompleteResponse> {
         let response = self
             .client
             .put(format!("{}/api/generate/reference-upload", self.base_url))
             .header(REFERENCE_UPLOAD_HANDLE_HEADER, handle)
             .header(reqwest::header::CONTENT_TYPE, mime_type)
-            .header(reqwest::header::CONTENT_LENGTH, metadata.len())
+            .header(reqwest::header::CONTENT_LENGTH, content_length)
             .body(body)
             .send()
             .await?;
@@ -1713,6 +1775,53 @@ mod tests {
             .expect(1)
             .mount(&server)
             .await;
+        Mock::given(method("PUT"))
+            .and(path("/api/generate/reference-upload"))
+            .and(header("x-api-key", "sekrit"))
+            .and(header(REFERENCE_UPLOAD_HANDLE_HEADER, "mru_open"))
+            .and(header("content-type", "image/png"))
+            .and(header("content-length", "15"))
+            .and(body_string("reference-bytes"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "instance_id": "server-1",
+                "reference": 1,
+                "metadata": {
+                    "kind": "image",
+                    "index": 1,
+                    "name": "reference.png",
+                    "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "mime_type": "image/png",
+                    "width": 16,
+                    "height": 16
+                }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("PUT"))
+            .and(path("/api/generate/reference-upload"))
+            .and(header("x-api-key", "sekrit"))
+            .and(header(REFERENCE_UPLOAD_HANDLE_HEADER, "mru_bytes"))
+            .and(header("content-type", "audio/wav"))
+            .and(header("content-length", "5"))
+            .and(body_string("bytes"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "instance_id": "server-1",
+                "reference": 2,
+                "metadata": {
+                    "kind": "audio",
+                    "index": 2,
+                    "name": "reference.wav",
+                    "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+                    "mime_type": "audio/wav",
+                    "duration_ms": 2000,
+                    "sample_rate": 32000,
+                    "channels": 2
+                }
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
         Mock::given(method("DELETE"))
             .and(path("/api/generate/reference-upload-sessions"))
             .and(header("x-api-key", "sekrit"))
@@ -1727,7 +1836,9 @@ mod tests {
 
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("reference.png");
+        let open_path = dir.path().join("reference-open.png");
         std::fs::write(&path, b"bytes").unwrap();
+        std::fs::write(&open_path, b"reference-bytes").unwrap();
         let client = MoldClient::with_api_key(&server.uri(), "sekrit".to_string());
         let completed = client
             .upload_reference_file("mru_secret", &path, "image/png")
@@ -1735,6 +1846,22 @@ mod tests {
             .unwrap();
         assert_eq!(completed.instance_id, "server-1");
         assert_eq!(completed.reference, 1);
+        let completed = client
+            .upload_reference_open_file(
+                "mru_open",
+                std::fs::File::open(&open_path).unwrap(),
+                "image/png",
+            )
+            .await
+            .unwrap();
+        assert_eq!(completed.instance_id, "server-1");
+        assert_eq!(completed.reference, 1);
+        let completed = client
+            .upload_reference_bytes("mru_bytes", b"bytes".to_vec(), "audio/wav")
+            .await
+            .unwrap();
+        assert_eq!(completed.instance_id, "server-1");
+        assert_eq!(completed.reference, 2);
         client
             .cancel_reference_upload_session("mrs_session_secret")
             .await

--- a/crates/mold-core/src/lib.rs
+++ b/crates/mold-core/src/lib.rs
@@ -24,9 +24,11 @@ pub mod manifest;
 pub mod media_paths;
 pub mod minimax_h3;
 pub mod model_policy;
+pub mod reference_upload;
 pub mod removal;
 pub mod runpod;
 pub mod safetensors_probe;
+pub mod secure_file;
 pub mod time;
 pub mod types;
 pub mod validation;
@@ -60,6 +62,7 @@ pub use model_policy::{
     MINIMAX_H3_AUTHORIZATION_ISSUE_URL, MINIMAX_H3_AUTHORIZATION_REQUIRED,
     MINIMAX_H3_LICENSE_SHA256, MINIMAX_H3_LICENSE_URL,
 };
+pub use reference_upload::{ReferenceUploadLease, ReferenceUploadSource};
 pub use types::GenerateRequest;
 pub use types::Scheduler;
 pub use types::*;

--- a/crates/mold-core/src/reference_upload.rs
+++ b/crates/mold-core/src/reference_upload.rs
@@ -1,0 +1,889 @@
+//! Shared authenticated MiniMax H3 reference-upload V2 client authority.
+//!
+//! Every surface uses this module so canonical media probing, request-scope
+//! rebinding, one-use completion order, and cleanup cannot drift independently.
+
+use crate::{
+    GenerateRequest, GenerationReference, GenerationReferenceAuthority, GenerationReferenceKind,
+    GenerationReferenceProvenance, MoldClient, ReferenceUploadCapabilities,
+    ReferenceUploadCompleteResponse, ReferenceUploadSessionRequest, ReferenceUploadSessionResponse,
+};
+use anyhow::{ensure, Context, Result};
+use sha2::{Digest, Sha256};
+use std::{
+    collections::HashSet,
+    fs::File,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+pub const PROTOCOL_VERSION: u32 = 2;
+pub const SESSION_PATH: &str = "/api/generate/reference-upload-sessions";
+pub const UPLOAD_PATH: &str = "/api/generate/reference-upload";
+pub const SESSION_HANDLE_HEADER: &str = "x-mold-reference-upload-session";
+pub const UPLOAD_HANDLE_HEADER: &str = "x-mold-reference-upload";
+
+enum ReferenceUploadBody {
+    OpenFile(File),
+    Bytes(Vec<u8>),
+}
+
+/// One exact upload body. Debug output never reveals bytes or a local path.
+pub struct ReferenceUploadSource {
+    body: ReferenceUploadBody,
+    length: u64,
+}
+
+impl std::fmt::Debug for ReferenceUploadSource {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ReferenceUploadSource")
+            .field("body", &"<redacted>")
+            .field("length", &self.length)
+            .finish()
+    }
+}
+
+impl ReferenceUploadSource {
+    pub fn open_file(file: File) -> Result<Self> {
+        let metadata = file
+            .metadata()
+            .context("failed to inspect reference file")?;
+        ensure!(
+            metadata.is_file() && metadata.len() > 0,
+            "reference upload source is not a non-empty regular file"
+        );
+        Ok(Self {
+            body: ReferenceUploadBody::OpenFile(file),
+            length: metadata.len(),
+        })
+    }
+
+    pub fn bytes(bytes: Vec<u8>) -> Result<Self> {
+        ensure!(!bytes.is_empty(), "reference upload source is empty");
+        let length = u64::try_from(bytes.len()).context("reference upload is too large")?;
+        Ok(Self {
+            body: ReferenceUploadBody::Bytes(bytes),
+            length,
+        })
+    }
+
+    fn sha256(&self) -> Result<String> {
+        match &self.body {
+            ReferenceUploadBody::OpenFile(file) => crate::secure_file::sha256_open_file(file),
+            ReferenceUploadBody::Bytes(bytes) => Ok(format!("{:x}", Sha256::digest(bytes))),
+        }
+    }
+}
+
+/// Fresh one-attempt authority returned after every upload is canonicalized.
+pub struct ReferenceUploadLease {
+    request: GenerateRequest,
+    pub expires_at_ms: u64,
+    pub request_scope_sha256: String,
+    cancellation: SessionCancellationGuard,
+}
+
+impl std::fmt::Debug for ReferenceUploadLease {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ReferenceUploadLease")
+            .field("request", &"<redacted frozen request>")
+            .field("session_handle", &"<redacted>")
+            .field("expires_at_ms", &self.expires_at_ms)
+            .field("request_scope_sha256", &self.request_scope_sha256)
+            .finish()
+    }
+}
+
+impl ReferenceUploadLease {
+    /// Exact request frozen at session creation with only server-canonical
+    /// descriptors and their one-use handles rebound afterward.
+    pub fn request(&self) -> &GenerateRequest {
+        &self.request
+    }
+
+    /// Stop best-effort cleanup after the server has accepted/consumed the
+    /// request. Calling this before generation would leak the session.
+    pub fn mark_consumed(&mut self) {
+        self.cancellation.disarm();
+    }
+
+    /// Explicitly release an unused lease. Drop remains armed when transport
+    /// cancellation interrupts this await, so it can schedule one final try.
+    pub async fn cancel(&mut self) -> Result<()> {
+        self.cancellation.cancel().await
+    }
+}
+
+struct SessionCancellationGuard {
+    client: MoldClient,
+    session_handle: Option<String>,
+}
+
+impl SessionCancellationGuard {
+    fn new(client: MoldClient, session_handle: &str) -> Self {
+        Self {
+            client,
+            session_handle: valid_handle(session_handle).then(|| session_handle.to_string()),
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.session_handle = None;
+    }
+
+    async fn cancel(&mut self) -> Result<()> {
+        let Some(session_handle) = self.session_handle.clone() else {
+            return Ok(());
+        };
+        self.client
+            .cancel_reference_upload_session(&session_handle)
+            .await?;
+        self.disarm();
+        Ok(())
+    }
+}
+
+impl Drop for SessionCancellationGuard {
+    fn drop(&mut self) {
+        let Some(session_handle) = self.session_handle.take() else {
+            return;
+        };
+        let Ok(runtime) = tokio::runtime::Handle::try_current() else {
+            // A server-enforced TTL remains the last bound during runtime
+            // teardown, when spawning cleanup is no longer possible.
+            return;
+        };
+        let client = self.client.clone();
+        runtime.spawn(async move {
+            let _ = client
+                .cancel_reference_upload_session(&session_handle)
+                .await;
+        });
+    }
+}
+
+fn valid_sha256(value: &str) -> bool {
+    value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn valid_handle(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= crate::minimax_h3::MAX_REFERENCE_UPLOAD_HANDLE_BYTES
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b':' | b'.'))
+}
+
+fn now_ms() -> Result<u64> {
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("system clock is before the Unix epoch")?
+        .as_millis();
+    u64::try_from(millis).context("system clock is outside the supported range")
+}
+
+fn ensure_session_live(expires_at_ms: u64, observed_at_ms: u64) -> Result<()> {
+    ensure!(
+        expires_at_ms > observed_at_ms,
+        "host returned an expired reference-upload session"
+    );
+    Ok(())
+}
+
+fn validate_capabilities(capabilities: &ReferenceUploadCapabilities) -> Result<()> {
+    ensure!(
+        capabilities.available
+            && capabilities.protocol_version == PROTOCOL_VERSION
+            && capabilities.requires_api_key,
+        "host does not advertise authenticated reference-upload protocol V2"
+    );
+    ensure!(
+        capabilities.session_path == SESSION_PATH
+            && capabilities.upload_path == UPLOAD_PATH
+            && capabilities
+                .session_handle_header
+                .eq_ignore_ascii_case(SESSION_HANDLE_HEADER)
+            && capabilities
+                .upload_handle_header
+                .eq_ignore_ascii_case(UPLOAD_HANDLE_HEADER),
+        "host advertised an incompatible reference-upload V2 wire contract"
+    );
+    ensure!(
+        capabilities.max_file_bytes > 0
+            && capabilities.max_session_bytes >= capabilities.max_file_bytes
+            && capabilities.session_ttl_ms > 0,
+        "host advertised invalid reference-upload V2 limits"
+    );
+    Ok(())
+}
+
+fn validate_session(
+    session: &ReferenceUploadSessionResponse,
+    expected_instance_id: &str,
+    expected_count: usize,
+    now_ms: u64,
+) -> Result<Vec<String>> {
+    ensure!(
+        session.instance_id == expected_instance_id,
+        "reference-upload session came from a different Mold instance"
+    );
+    ensure_session_live(session.expires_at_ms, now_ms)?;
+    ensure!(
+        valid_sha256(&session.request_scope_sha256)
+            && valid_handle(&session.session_handle)
+            && session.uploads.len() == expected_count,
+        "host returned an incomplete reference-upload session"
+    );
+    let mut ordered = vec![None; expected_count];
+    let mut handles = HashSet::new();
+    for slot in &session.uploads {
+        let index = usize::try_from(slot.reference)
+            .ok()
+            .and_then(|reference| reference.checked_sub(1))
+            .filter(|index| *index < expected_count)
+            .context("host returned an out-of-range reference-upload slot")?;
+        ensure!(
+            valid_handle(&slot.handle)
+                && handles.insert(slot.handle.as_str())
+                && ordered[index].replace(slot.handle.clone()).is_none(),
+            "host returned an invalid or duplicate reference-upload slot"
+        );
+    }
+    ordered
+        .into_iter()
+        .enumerate()
+        .map(|(index, handle)| {
+            handle.with_context(|| format!("host omitted reference-upload slot {}", index + 1))
+        })
+        .collect()
+}
+
+fn canonical_reference(
+    provisional: &GenerationReference,
+    complete: &ReferenceUploadCompleteResponse,
+    expected_instance_id: &str,
+    expected_reference: u32,
+    expected_session_complete: bool,
+    upload_handle: String,
+) -> Result<GenerationReference> {
+    ensure!(
+        complete.instance_id == expected_instance_id
+            && complete.reference == expected_reference
+            && complete.metadata.index == expected_reference
+            && complete.metadata.kind == provisional.kind()
+            && valid_sha256(&complete.request_scope_sha256)
+            && complete.session_complete == expected_session_complete,
+        "reference {expected_reference} upload response did not match its bound V2 session"
+    );
+    let expected = provisional
+        .redacted_metadata(usize::try_from(expected_reference.saturating_sub(1))?)
+        .with_context(|| format!("reference {expected_reference} lost digest provenance"))?;
+    ensure!(
+        complete
+            .metadata
+            .sha256
+            .eq_ignore_ascii_case(&expected.sha256)
+            && complete.metadata.name == expected.name,
+        "reference {expected_reference} upload response changed immutable provenance"
+    );
+    let provenance = GenerationReferenceProvenance {
+        name: complete.metadata.name.clone(),
+        sha256: Some(complete.metadata.sha256.to_ascii_lowercase()),
+    };
+    let descriptor = match provisional {
+        GenerationReference::Image { mime_type, .. } => {
+            ensure!(
+                complete.metadata.kind == GenerationReferenceKind::Image
+                    && complete.metadata.mime_type == *mime_type,
+                "reference {expected_reference} upload response changed its image type"
+            );
+            GenerationReference::Image {
+                media: GenerationReferenceAuthority::Descriptor,
+                provenance,
+                mime_type: complete.metadata.mime_type.clone(),
+                width: complete
+                    .metadata
+                    .width
+                    .filter(|value| *value > 0)
+                    .context("canonical image width is missing")?,
+                height: complete
+                    .metadata
+                    .height
+                    .filter(|value| *value > 0)
+                    .context("canonical image height is missing")?,
+            }
+        }
+        GenerationReference::Video { mime_type, .. } => {
+            ensure!(
+                mime_type == "video/mp4"
+                    && complete.metadata.kind == GenerationReferenceKind::Video
+                    && complete.metadata.mime_type == "video/mp4",
+                "reference {expected_reference} upload response changed its video type"
+            );
+            let fps = complete
+                .metadata
+                .fps
+                .filter(|value| value.is_finite() && *value > 0.0)
+                .context("canonical video fps is missing")?;
+            let (audio_duration_ms, audio_sample_count, audio_sample_rate, audio_channels) =
+                if complete.metadata.has_audio {
+                    let channels = complete
+                        .metadata
+                        .audio_channels
+                        .filter(|value| matches!(value, 1 | 2))
+                        .context("canonical video audio channel count is missing")?;
+                    (
+                        Some(
+                            complete
+                                .metadata
+                                .audio_duration_ms
+                                .filter(|value| *value > 0)
+                                .context("canonical video audio duration is missing")?,
+                        ),
+                        Some(
+                            complete
+                                .metadata
+                                .audio_sample_count
+                                .filter(|value| *value > 0)
+                                .context("canonical video audio sample count is missing")?,
+                        ),
+                        Some(
+                            complete
+                                .metadata
+                                .audio_sample_rate
+                                .filter(|value| *value > 0)
+                                .context("canonical video audio sample rate is missing")?,
+                        ),
+                        Some(channels),
+                    )
+                } else {
+                    ensure!(
+                        complete.metadata.audio_duration_ms.is_none()
+                            && complete.metadata.audio_sample_count.is_none()
+                            && complete.metadata.audio_sample_rate.is_none()
+                            && complete.metadata.audio_channels.is_none(),
+                        "canonical silent video unexpectedly contains audio facts"
+                    );
+                    (None, None, None, None)
+                };
+            GenerationReference::Video {
+                media: GenerationReferenceAuthority::Descriptor,
+                provenance,
+                mime_type: "video/mp4".to_string(),
+                width: complete
+                    .metadata
+                    .width
+                    .filter(|value| *value > 0)
+                    .context("canonical video width is missing")?,
+                height: complete
+                    .metadata
+                    .height
+                    .filter(|value| *value > 0)
+                    .context("canonical video height is missing")?,
+                frame_count: Some(
+                    complete
+                        .metadata
+                        .frame_count
+                        .filter(|value| *value > 0)
+                        .context("canonical video frame count is missing")?,
+                ),
+                duration_ms: complete
+                    .metadata
+                    .duration_ms
+                    .filter(|value| *value > 0)
+                    .context("canonical video duration is missing")?,
+                fps,
+                has_audio: complete.metadata.has_audio,
+                audio_duration_ms,
+                audio_sample_count,
+                audio_sample_rate,
+                audio_channels,
+            }
+        }
+        GenerationReference::Audio { mime_type, .. } => {
+            let declared = mime_type.trim().to_ascii_lowercase();
+            ensure!(
+                matches!(
+                    declared.as_str(),
+                    "audio/wav" | "audio/x-wav" | "audio/wave"
+                ) && complete.metadata.kind == GenerationReferenceKind::Audio
+                    && complete.metadata.mime_type == "audio/wav",
+                "reference {expected_reference} upload response changed its audio type"
+            );
+            GenerationReference::Audio {
+                media: GenerationReferenceAuthority::Descriptor,
+                provenance,
+                mime_type: "audio/wav".to_string(),
+                duration_ms: complete
+                    .metadata
+                    .duration_ms
+                    .filter(|value| *value > 0)
+                    .context("canonical audio duration is missing")?,
+                sample_rate: complete
+                    .metadata
+                    .sample_rate
+                    .filter(|value| *value > 0)
+                    .context("canonical audio sample rate is missing")?,
+                channels: complete
+                    .metadata
+                    .channels
+                    .filter(|value| matches!(value, 1 | 2))
+                    .context("canonical audio channel count is missing")?,
+                sample_count: Some(
+                    complete
+                        .metadata
+                        .sample_count
+                        .filter(|value| *value > 0)
+                        .context("canonical audio sample count is missing")?,
+                ),
+            }
+        }
+    };
+    crate::minimax_h3::reference_prepared_shape(&descriptor).map_err(anyhow::Error::new)?;
+    Ok(with_authority(
+        descriptor,
+        GenerationReferenceAuthority::Upload {
+            handle: upload_handle,
+        },
+    ))
+}
+
+fn with_authority(
+    reference: GenerationReference,
+    media: GenerationReferenceAuthority,
+) -> GenerationReference {
+    match reference {
+        GenerationReference::Image {
+            provenance,
+            mime_type,
+            width,
+            height,
+            ..
+        } => GenerationReference::Image {
+            media,
+            provenance,
+            mime_type,
+            width,
+            height,
+        },
+        GenerationReference::Video {
+            provenance,
+            mime_type,
+            width,
+            height,
+            frame_count,
+            duration_ms,
+            fps,
+            has_audio,
+            audio_duration_ms,
+            audio_sample_count,
+            audio_sample_rate,
+            audio_channels,
+            ..
+        } => GenerationReference::Video {
+            media,
+            provenance,
+            mime_type,
+            width,
+            height,
+            frame_count,
+            duration_ms,
+            fps,
+            has_audio,
+            audio_duration_ms,
+            audio_sample_count,
+            audio_sample_rate,
+            audio_channels,
+        },
+        GenerationReference::Audio {
+            provenance,
+            mime_type,
+            duration_ms,
+            sample_rate,
+            channels,
+            sample_count,
+            ..
+        } => GenerationReference::Audio {
+            media,
+            provenance,
+            mime_type,
+            duration_ms,
+            sample_rate,
+            channels,
+            sample_count,
+        },
+    }
+}
+
+fn mime_type(reference: &GenerationReference) -> &str {
+    match reference {
+        GenerationReference::Image { mime_type, .. }
+        | GenerationReference::Video { mime_type, .. }
+        | GenerationReference::Audio { mime_type, .. } => mime_type,
+    }
+}
+
+fn rebind_canonical_request(
+    mut scoped_request: GenerateRequest,
+    references: Vec<GenerationReference>,
+) -> GenerateRequest {
+    scoped_request.references = Some(references);
+    scoped_request
+}
+
+impl MoldClient {
+    /// Create and fill one canonical upload-V2 lease. A returned request may be
+    /// submitted exactly once; callers must re-open/re-download original media
+    /// to retry after any generation attempt.
+    pub async fn bind_reference_uploads_v2(
+        &self,
+        request: &GenerateRequest,
+        sources: Vec<ReferenceUploadSource>,
+    ) -> Result<ReferenceUploadLease> {
+        ensure!(
+            self.has_api_key(),
+            "reference uploads require a client configured with a valid API key"
+        );
+        let (capabilities, status) =
+            tokio::try_join!(self.server_capabilities(), self.server_status())?;
+        let capabilities = capabilities.reference_uploads;
+        validate_capabilities(&capabilities)?;
+        let expected_instance_id = status
+            .instance_id
+            .filter(|value| !value.trim().is_empty())
+            .context("host status does not expose an exact Mold instance identity")?;
+        let scoped_request = request.clone();
+        let descriptors = scoped_request
+            .references
+            .clone()
+            .context("reference uploads require ordered H3 descriptors")?;
+        ensure!(
+            !descriptors.is_empty() && descriptors.len() == sources.len(),
+            "reference descriptor/body count mismatch"
+        );
+        crate::minimax_h3::validate_reference_descriptors(&descriptors)
+            .map_err(anyhow::Error::new)?;
+
+        let mut total_bytes = 0_u64;
+        for (index, (descriptor, source)) in descriptors.iter().zip(&sources).enumerate() {
+            ensure!(
+                source.length <= capabilities.max_file_bytes,
+                "reference {} exceeds this host's per-file upload limit",
+                index + 1
+            );
+            total_bytes = total_bytes
+                .checked_add(source.length)
+                .context("combined reference size overflowed")?;
+            ensure!(
+                total_bytes <= capabilities.max_session_bytes,
+                "ordered references exceed this host's upload-session limit"
+            );
+            let expected_digest = descriptor
+                .content_sha256()
+                .with_context(|| format!("reference {} has no content digest", index + 1))?;
+            ensure!(
+                source.sha256()?.eq_ignore_ascii_case(&expected_digest),
+                "reference {} changed after it was probed",
+                index + 1
+            );
+        }
+
+        let upload_references = (1..=descriptors.len())
+            .map(|index| u32::try_from(index).context("too many reference uploads"))
+            .collect::<Result<Vec<_>>>()?;
+        let session = self
+            .create_reference_upload_session(&ReferenceUploadSessionRequest {
+                request: scoped_request.clone(),
+                upload_references,
+            })
+            .await?;
+        // Arm cleanup before the next await. Dropping this future during any
+        // upload schedules a best-effort DELETE instead of waiting for TTL.
+        let mut cancellation = SessionCancellationGuard::new(self.clone(), &session.session_handle);
+        let handles = match validate_session(
+            &session,
+            &expected_instance_id,
+            descriptors.len(),
+            now_ms()?,
+        ) {
+            Ok(handles) => handles,
+            Err(error) => {
+                let _ = cancellation.cancel().await;
+                return Err(error);
+            }
+        };
+
+        let result: Result<(Vec<GenerationReference>, String)> = async {
+            let upload_count = sources.len();
+            let mut canonical = Vec::with_capacity(upload_count);
+            let mut canonical_scope = session.request_scope_sha256.to_ascii_lowercase();
+            for (index, ((descriptor, source), handle)) in
+                descriptors.iter().zip(sources).zip(handles).enumerate()
+            {
+                let reference = u32::try_from(index + 1).context("too many references")?;
+                let content_type = mime_type(descriptor);
+                let completed = match source.body {
+                    ReferenceUploadBody::OpenFile(file) => {
+                        self.upload_reference_open_file(&handle, file, content_type)
+                            .await
+                    }
+                    ReferenceUploadBody::Bytes(bytes) => {
+                        self.upload_reference_bytes(&handle, bytes, content_type)
+                            .await
+                    }
+                }
+                .with_context(|| format!("reference {reference} upload failed"))?;
+                let bound = canonical_reference(
+                    descriptor,
+                    &completed,
+                    &expected_instance_id,
+                    reference,
+                    index + 1 == upload_count,
+                    handle,
+                )?;
+                canonical_scope = completed.request_scope_sha256.to_ascii_lowercase();
+                canonical.push(bound);
+            }
+            crate::minimax_h3::validate_references(&canonical).map_err(anyhow::Error::new)?;
+            ensure_session_live(session.expires_at_ms, now_ms()?).context(
+                "reference-upload session expired before its canonical request could be returned",
+            )?;
+            Ok((canonical, canonical_scope))
+        }
+        .await;
+
+        match result {
+            Ok((references, request_scope_sha256)) => {
+                let request = rebind_canonical_request(scoped_request, references);
+                Ok(ReferenceUploadLease {
+                    request,
+                    expires_at_ms: session.expires_at_ms,
+                    request_scope_sha256,
+                    cancellation,
+                })
+            }
+            Err(error) => {
+                let _ = cancellation.cancel().await;
+                Err(error)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn request_with_references(references: Vec<GenerationReference>) -> GenerateRequest {
+        let mut request: GenerateRequest = serde_json::from_value(serde_json::json!({
+            "prompt": "keep this request frozen",
+            "model": crate::minimax_h3::REF2VA_COMFY,
+            "width": crate::minimax_h3::DEFAULT_WIDTH,
+            "height": crate::minimax_h3::DEFAULT_HEIGHT,
+            "steps": crate::minimax_h3::DEFAULT_STEPS,
+            "guidance": 0.0,
+            "seed": 77,
+            "batch_size": 1,
+            "output_format": "mp4",
+            "strength": 1.0,
+            "frames": crate::minimax_h3::MIN_FRAMES,
+            "fps": crate::minimax_h3::FIXED_FPS,
+            "enable_audio": true
+        }))
+        .unwrap();
+        request.references = Some(references);
+        request
+    }
+
+    fn audio_descriptor() -> GenerationReference {
+        GenerationReference::Audio {
+            media: GenerationReferenceAuthority::Descriptor,
+            provenance: GenerationReferenceProvenance {
+                name: Some("voice.wav".into()),
+                sha256: Some("a".repeat(64)),
+            },
+            mime_type: "audio/x-wav".into(),
+            duration_ms: 1_000,
+            sample_rate: 44_100,
+            channels: 2,
+            sample_count: Some(44_100),
+        }
+    }
+
+    #[test]
+    fn canonical_audio_response_rebinds_provisional_facts() {
+        let completed = ReferenceUploadCompleteResponse {
+            instance_id: "instance".into(),
+            reference: 1,
+            metadata: crate::GenerationReferenceMetadata {
+                kind: GenerationReferenceKind::Audio,
+                index: 1,
+                name: Some("voice.wav".into()),
+                sha256: "a".repeat(64),
+                mime_type: "audio/wav".into(),
+                width: None,
+                height: None,
+                frame_count: None,
+                duration_ms: Some(998),
+                fps: None,
+                has_audio: false,
+                audio_duration_ms: None,
+                audio_sample_count: None,
+                audio_sample_rate: None,
+                audio_channels: None,
+                sample_rate: Some(48_000),
+                channels: Some(2),
+                sample_count: Some(47_904),
+                prepared_shape: None,
+            },
+            request_scope_sha256: "b".repeat(64),
+            session_complete: true,
+        };
+        let bound = canonical_reference(
+            &audio_descriptor(),
+            &completed,
+            "instance",
+            1,
+            true,
+            "mru_handle".into(),
+        )
+        .unwrap();
+        assert!(matches!(
+            bound,
+            GenerationReference::Audio {
+                media: GenerationReferenceAuthority::Upload { .. },
+                duration_ms: 998,
+                sample_rate: 48_000,
+                sample_count: Some(47_904),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn lease_debug_redacts_frozen_request_and_session_authority() {
+        let mut request = request_with_references(vec![with_authority(
+            audio_descriptor(),
+            GenerationReferenceAuthority::Upload {
+                handle: "mru_private_upload".into(),
+            },
+        )]);
+        request.prompt = "private prompt".into();
+        request.source_image = Some(vec![17, 42, 99]);
+        let lease = ReferenceUploadLease {
+            request,
+            expires_at_ms: u64::MAX,
+            request_scope_sha256: "c".repeat(64),
+            cancellation: SessionCancellationGuard::new(
+                MoldClient::new("http://127.0.0.1:9"),
+                "mrs_private_session",
+            ),
+        };
+
+        let debug = format!("{lease:?}");
+        assert!(debug.contains("<redacted frozen request>"));
+        assert!(!debug.contains("private prompt"));
+        assert!(!debug.contains("mru_private_upload"));
+        assert!(!debug.contains("mrs_private_session"));
+        assert!(!debug.contains("17, 42, 99"));
+    }
+
+    #[test]
+    fn completion_order_and_scope_fail_closed() {
+        let mut completed = ReferenceUploadCompleteResponse {
+            instance_id: "instance".into(),
+            reference: 1,
+            metadata: audio_descriptor().redacted_metadata(0).unwrap(),
+            request_scope_sha256: "b".repeat(64),
+            session_complete: true,
+        };
+        assert!(canonical_reference(
+            &audio_descriptor(),
+            &completed,
+            "instance",
+            1,
+            false,
+            "mru_handle".into(),
+        )
+        .is_err());
+        completed.session_complete = false;
+        completed.request_scope_sha256 = "bad".into();
+        assert!(canonical_reference(
+            &audio_descriptor(),
+            &completed,
+            "instance",
+            1,
+            false,
+            "mru_handle".into(),
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn canonical_rebind_changes_only_the_reference_authority() {
+        let original = request_with_references(vec![audio_descriptor()]);
+        let bound_reference = with_authority(
+            audio_descriptor(),
+            GenerationReferenceAuthority::Upload {
+                handle: "mru_handle".into(),
+            },
+        );
+        let rebound = rebind_canonical_request(original.clone(), vec![bound_reference.clone()]);
+        let mut expected = original;
+        expected.references = Some(vec![bound_reference]);
+        assert_eq!(
+            serde_json::to_value(rebound).unwrap(),
+            serde_json::to_value(expected).unwrap()
+        );
+    }
+
+    #[test]
+    fn final_expiry_check_rejects_a_session_that_elapsed_during_upload() {
+        assert!(ensure_session_live(101, 100).is_ok());
+        assert!(ensure_session_live(100, 100).is_err());
+        assert!(ensure_session_live(99, 100).is_err());
+    }
+
+    #[tokio::test]
+    async fn unauthenticated_client_fails_before_any_host_or_media_work() {
+        let server = wiremock::MockServer::start().await;
+        let request = request_with_references(vec![audio_descriptor()]);
+        let error = MoldClient::new(&server.uri())
+            .bind_reference_uploads_v2(
+                &request,
+                vec![ReferenceUploadSource::bytes(b"unread media".to_vec()).unwrap()],
+            )
+            .await
+            .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("configured with a valid API key"));
+        assert!(server.received_requests().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn dropping_armed_session_guard_schedules_cancellation() {
+        use wiremock::matchers::{header, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path(SESSION_PATH))
+            .and(header("x-api-key", "sekrit"))
+            .and(header(SESSION_HANDLE_HEADER, "mrs_abort"))
+            .respond_with(ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let client = MoldClient::with_api_key(&server.uri(), "sekrit".into());
+        drop(SessionCancellationGuard::new(client, "mrs_abort"));
+        for _ in 0..20 {
+            if !server.received_requests().await.unwrap().is_empty() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        assert_eq!(server.received_requests().await.unwrap().len(), 1);
+    }
+}

--- a/crates/mold-core/src/secure_file.rs
+++ b/crates/mold-core/src/secure_file.rs
@@ -1,0 +1,219 @@
+//! Race-resistant local file reads for user-selected conditioning media.
+//!
+//! Callers retain the returned descriptor for hashing, probing, and upload so
+//! a later path or symlink replacement cannot substitute different bytes.
+
+use anyhow::{ensure, Context, Result};
+use sha2::{Digest, Sha256};
+use std::{
+    fs::File,
+    io::{Read, Seek, SeekFrom},
+    path::{Component, Path, PathBuf},
+};
+
+fn absolute_lexical_path(path: &Path) -> Result<PathBuf> {
+    let candidate = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .context("failed to resolve the current directory")?
+            .join(path)
+    };
+    let mut normalized = PathBuf::new();
+    for component in candidate.components() {
+        match component {
+            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            Component::RootDir => normalized.push(Path::new(std::path::MAIN_SEPARATOR_STR)),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                ensure!(
+                    normalized.pop(),
+                    "reference path escapes the filesystem root"
+                );
+            }
+            Component::Normal(value) => normalized.push(value),
+        }
+    }
+    ensure!(
+        normalized.is_absolute(),
+        "reference path did not resolve absolutely"
+    );
+    Ok(normalized)
+}
+
+#[cfg(unix)]
+fn open_directory_without_symlinks(path: &Path) -> Result<File> {
+    #[cfg(target_os = "macos")]
+    let resolved_system_alias;
+    #[cfg(target_os = "macos")]
+    let path = {
+        // macOS exposes these immutable root entries as aliases into /private.
+        // Resolve only those fixed aliases; every user-controlled component
+        // below them is still opened with O_NOFOLLOW | O_DIRECTORY.
+        let alias = ["var", "tmp", "etc"].into_iter().find_map(|name| {
+            path.strip_prefix(Path::new("/").join(name))
+                .ok()
+                .map(|suffix| (name, suffix))
+        });
+        if let Some((name, suffix)) = alias {
+            resolved_system_alias = Path::new("/private").join(name).join(suffix);
+            resolved_system_alias.as_path()
+        } else {
+            path
+        }
+    };
+
+    use std::ffi::CString;
+    use std::os::fd::{AsRawFd, FromRawFd};
+    use std::os::unix::ffi::OsStrExt;
+
+    ensure!(path.is_absolute(), "reference parent is not absolute");
+    let mut current = File::open("/")?;
+    for component in path.components() {
+        let Component::Normal(name) = component else {
+            ensure!(
+                matches!(component, Component::RootDir),
+                "reference parent contains an invalid component"
+            );
+            continue;
+        };
+        let name = CString::new(name.as_bytes()).context("reference parent contains NUL")?;
+        // SAFETY: `current` owns a valid directory descriptor, `name` is
+        // NUL-terminated, and a successful descriptor is transferred once.
+        let fd = unsafe {
+            libc::openat(
+                current.as_raw_fd(),
+                name.as_ptr(),
+                libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+            )
+        };
+        if fd < 0 {
+            return Err(std::io::Error::last_os_error())
+                .context("failed to open a no-follow reference parent");
+        }
+        // SAFETY: `fd` is a fresh owned descriptor returned by `openat`.
+        current = unsafe { File::from_raw_fd(fd) };
+    }
+    Ok(current)
+}
+
+/// Open an existing regular file without following a symlink in the filename
+/// or any parent component.
+#[cfg(unix)]
+pub fn open_regular_file_no_follow(path: &Path) -> Result<File> {
+    use std::ffi::CString;
+    use std::os::fd::{AsRawFd, FromRawFd};
+    use std::os::unix::ffi::OsStrExt;
+
+    let path = absolute_lexical_path(path)?;
+    let parent_path = path.parent().context("reference path has no parent")?;
+    let name = path.file_name().context("reference path has no filename")?;
+    let name = CString::new(name.as_bytes()).context("reference filename contains NUL")?;
+    let parent = open_directory_without_symlinks(parent_path)?;
+    // SAFETY: `parent` owns a valid directory descriptor, `name` is
+    // NUL-terminated, and a successful descriptor is transferred once.
+    let fd = unsafe {
+        libc::openat(
+            parent.as_raw_fd(),
+            name.as_ptr(),
+            libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+        )
+    };
+    if fd < 0 {
+        return Err(std::io::Error::last_os_error()).context("failed to open reference no-follow");
+    }
+    // SAFETY: `fd` is a fresh owned descriptor returned by `openat`.
+    let file = unsafe { File::from_raw_fd(fd) };
+    ensure!(
+        file.metadata()?.is_file(),
+        "reference is not a regular file"
+    );
+    Ok(file)
+}
+
+#[cfg(not(unix))]
+pub fn open_regular_file_no_follow(path: &Path) -> Result<File> {
+    let path = absolute_lexical_path(path)?;
+    let mut current = PathBuf::new();
+    for component in path.components() {
+        current.push(component.as_os_str());
+        let metadata = std::fs::symlink_metadata(&current)?;
+        ensure!(
+            !metadata.file_type().is_symlink(),
+            "reference path contains a symlink"
+        );
+    }
+    let file = File::open(path)?;
+    ensure!(
+        file.metadata()?.is_file(),
+        "reference is not a regular file"
+    );
+    Ok(file)
+}
+
+/// Hash an already-open file without changing the caller's cursor.
+pub fn sha256_open_file(file: &File) -> Result<String> {
+    let mut file = file.try_clone().context("failed to clone reference file")?;
+    let original_position = file
+        .stream_position()
+        .context("failed to read reference cursor")?;
+    file.seek(SeekFrom::Start(0))
+        .context("failed to rewind reference file")?;
+    let hash_result = (|| -> std::io::Result<String> {
+        let mut digest = Sha256::new();
+        let mut buffer = [0_u8; 64 * 1024];
+        loop {
+            let read = file.read(&mut buffer)?;
+            if read == 0 {
+                break;
+            }
+            digest.update(&buffer[..read]);
+        }
+        Ok(format!("{:x}", digest.finalize()))
+    })();
+    let restore_result = file.seek(SeekFrom::Start(original_position));
+    match (hash_result, restore_result) {
+        (Ok(digest), Ok(_)) => Ok(digest),
+        (Err(error), _) => Err(error).context("failed to hash reference file"),
+        (Ok(_), Err(error)) => Err(error).context("failed to restore reference cursor"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn opened_file_hash_stays_bound_after_path_replacement() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("reference.bin");
+        std::fs::write(&path, b"original").unwrap();
+        let mut file = open_regular_file_no_follow(&path).unwrap();
+        file.seek(SeekFrom::Start(3)).unwrap();
+        std::fs::rename(&path, dir.path().join("original.bin")).unwrap();
+        std::fs::write(&path, b"replacement").unwrap();
+        assert_eq!(
+            sha256_open_file(&file).unwrap(),
+            format!("{:x}", Sha256::digest(b"original"))
+        );
+        assert_eq!(file.stream_position().unwrap(), 3);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn no_follow_open_rejects_symlink_filename_and_parent() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("real");
+        std::fs::create_dir(&real).unwrap();
+        let target = real.join("reference.bin");
+        std::fs::write(&target, b"bytes").unwrap();
+        let file_link = dir.path().join("file-link");
+        symlink(&target, &file_link).unwrap();
+        assert!(open_regular_file_no_follow(&file_link).is_err());
+        let parent_link = dir.path().join("parent-link");
+        symlink(&real, &parent_link).unwrap();
+        assert!(open_regular_file_no_follow(&parent_link.join("reference.bin")).is_err());
+    }
+}

--- a/crates/mold-core/src/validation.rs
+++ b/crates/mold-core/src/validation.rs
@@ -316,12 +316,22 @@ pub fn fixed_fps_for_family(family: &str) -> Option<u32> {
 /// Single-request runtime ceiling in seconds for families whose real limit is
 /// a duration. `None` means the family's ceiling is a plain frame count.
 pub fn max_runtime_seconds_for_family(family: &str) -> Option<u32> {
-    (family == "ltx2").then_some(LTX2_MAX_RUNTIME_SECONDS)
+    match family {
+        "ltx2" => Some(LTX2_MAX_RUNTIME_SECONDS),
+        family if crate::minimax_h3::is_family(family) => {
+            Some(crate::minimax_h3::MAX_DURATION_SECONDS)
+        }
+        _ => None,
+    }
 }
 
 /// fps-independent frame guard, paired with `max_runtime_seconds_for_family`.
 pub fn max_frames_absolute_for_family(family: &str) -> Option<u32> {
-    (family == "ltx2").then_some(LTX2_MAX_FRAMES_ABSOLUTE)
+    match family {
+        "ltx2" => Some(LTX2_MAX_FRAMES_ABSOLUTE),
+        family if crate::minimax_h3::is_family(family) => Some(crate::minimax_h3::MAX_FRAMES),
+        _ => None,
+    }
 }
 
 /// Step of the frame-count grid for a family. Pair with
@@ -4341,6 +4351,14 @@ mod tests {
         );
         assert_eq!(
             max_frames_for_family(crate::minimax_h3::FAMILY),
+            Some(crate::minimax_h3::MAX_FRAMES)
+        );
+        assert_eq!(
+            max_runtime_seconds_for_family(crate::minimax_h3::FAMILY),
+            Some(crate::minimax_h3::MAX_DURATION_SECONDS)
+        );
+        assert_eq!(
+            max_frames_absolute_for_family(crate::minimax_h3::FAMILY),
             Some(crate::minimax_h3::MAX_FRAMES)
         );
 

--- a/crates/mold-discord/Cargo.toml
+++ b/crates/mold-discord/Cargo.toml
@@ -24,3 +24,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "webp"] }
+mp4-rs = { package = "mp4", version = "0.14" }
+sha2 = "0.10"

--- a/crates/mold-discord/Cargo.toml
+++ b/crates/mold-discord/Cargo.toml
@@ -27,3 +27,4 @@ serde_json = "1"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "webp"] }
 mp4-rs = { package = "mp4", version = "0.14" }
 sha2 = "0.10"
+symphonia = { version = "0.5", default-features = false, features = ["aac", "isomp4"] }

--- a/crates/mold-discord/src/commands/generate.rs
+++ b/crates/mold-discord/src/commands/generate.rs
@@ -206,6 +206,7 @@ pub struct BuildParams<'a> {
     pub negative_prompt: Option<&'a str>,
     pub defaults: Option<&'a mold_core::ModelDefaults>,
     pub source_image: Option<Vec<u8>>,
+    pub references: Option<Vec<mold_core::GenerationReference>>,
     pub frames: Option<u32>,
     pub fps: Option<u32>,
     pub strength: Option<f64>,
@@ -458,7 +459,14 @@ pub fn build_generate_request(params: BuildParams<'_>) -> GenerateRequest {
         scheduler: None,
         cfg_plus: None,
         edit_images: None,
-        references: None,
+        references: if is_h3
+            && mold_core::minimax_h3::task_for_model(params.model)
+                == Some(mold_core::minimax_h3::Task::Ref2va)
+        {
+            params.references
+        } else {
+            None
+        },
         source_image: params.source_image,
         source_image_name: None,
         strength: if is_h3 {
@@ -774,7 +782,22 @@ pub async fn generate(
     #[description = "Optional third image for LTX-2 keyframe interpolation"] keyframe_3: Option<
         serenity::Attachment,
     >,
+    #[description = "First ordered H3 reference (image, H.264 MP4, or WAV)"] reference_1: Option<
+        serenity::Attachment,
+    >,
+    #[description = "Second ordered H3 reference (image, H.264 MP4, or WAV)"] reference_2: Option<
+        serenity::Attachment,
+    >,
 ) -> Result<()> {
+    if reference_1.is_none() && reference_2.is_some() {
+        ctx.send(
+            poise::CreateReply::default()
+                .content("Add reference_1 before reference_2 so H3 ordering is unambiguous.")
+                .ephemeral(true),
+        )
+        .await?;
+        return Ok(());
+    }
     let keyframe_attachments = [
         keyframe_1.as_ref(),
         keyframe_2.as_ref(),
@@ -783,6 +806,29 @@ pub async fn generate(
     .into_iter()
     .flatten()
     .collect::<Vec<_>>();
+    let reference_attachments = [reference_1.as_ref(), reference_2.as_ref()]
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+    if !reference_attachments.is_empty()
+        && (source_image.is_some()
+            || audio_file.is_some()
+            || source_video.is_some()
+            || !keyframe_attachments.is_empty()
+            || retake_start.is_some()
+            || retake_end.is_some()
+            || pipeline.is_some())
+    {
+        ctx.send(
+            poise::CreateReply::default()
+                .content(
+                    "Ordered H3 references cannot be combined with source, retake, keyframe, audio, or pipeline inputs.",
+                )
+                .ephemeral(true),
+        )
+        .await?;
+        return Ok(());
+    }
     let specialized = match specialized_pipeline(
         source_image.is_some(),
         audio_file.is_some(),
@@ -815,7 +861,8 @@ pub async fn generate(
         .iter()
         .chain(audio_file.iter())
         .chain(source_video.iter())
-        .chain(keyframe_attachments.iter().copied());
+        .chain(keyframe_attachments.iter().copied())
+        .chain(reference_attachments.iter().copied());
     if let Err(message) = validate_inline_media_size(inline_attachments) {
         ctx.send(
             poise::CreateReply::default()
@@ -874,7 +921,30 @@ pub async fn generate(
         .or(fallback_defaults.as_ref());
     let family = model_entry
         .map(|m| m.info.family.as_str())
-        .or_else(|| fallback_manifest.map(|manifest| manifest.family.as_str()));
+        .or_else(|| fallback_manifest.map(|manifest| manifest.family.as_str()))
+        .or_else(|| {
+            mold_core::minimax_h3::task_for_model(&model_name)
+                .map(|_| mold_core::minimax_h3::FAMILY)
+        });
+    let h3_task = mold_core::minimax_h3::task_for_model(&model_name);
+    if !reference_attachments.is_empty() && h3_task != Some(mold_core::minimax_h3::Task::Ref2va) {
+        ctx.data().quotas.refund(user_id);
+        handler::send_error(
+            ctx,
+            "Ordered references require an explicitly authorized MiniMax H3 Ref2VA model.",
+        )
+        .await?;
+        return Ok(());
+    }
+    if h3_task == Some(mold_core::minimax_h3::Task::Ref2va) && reference_attachments.is_empty() {
+        ctx.data().quotas.refund(user_id);
+        handler::send_error(
+            ctx,
+            "MiniMax H3 Ref2VA requires at least one ordered reference.",
+        )
+        .await?;
+        return Ok(());
+    }
     let (resolved_frames, resolved_fps) =
         match resolve_video_timing(family, model_defaults, frames, fps, duration) {
             Ok(timing) => timing,
@@ -884,6 +954,23 @@ pub async fn generate(
                 return Ok(());
             }
         };
+
+    let prepared_references = if reference_attachments.is_empty() {
+        None
+    } else {
+        match crate::h3_references::prepare_attachments(&reference_attachments).await {
+            Ok(prepared) => Some(prepared),
+            Err(error) => {
+                ctx.data().quotas.refund(user_id);
+                handler::send_error(
+                    ctx,
+                    &format!("MiniMax H3 reference preparation failed: {error}"),
+                )
+                .await?;
+                return Ok(());
+            }
+        }
+    };
 
     // Fetch source image bytes if an attachment was supplied. This also covers
     // the LTX-2 image-to-video path — the server forwards a source_image to
@@ -966,7 +1053,7 @@ pub async fn generate(
         }),
         _ => None,
     };
-    let req = build_generate_request(BuildParams {
+    let mut req = build_generate_request(BuildParams {
         prompt: &prompt,
         model: &model_name,
         family,
@@ -978,6 +1065,9 @@ pub async fn generate(
         negative_prompt: negative_prompt.as_deref(),
         defaults: model_defaults,
         source_image: source_bytes,
+        references: prepared_references
+            .as_ref()
+            .map(|prepared| prepared.descriptors.clone()),
         frames: resolved_frames,
         fps: resolved_fps,
         strength,
@@ -990,15 +1080,46 @@ pub async fn generate(
         retake_range,
     });
 
+    let reference_session = if let Some(prepared) = prepared_references {
+        match crate::h3_references::bind_remote_references(&ctx.data().client, &mut req, prepared)
+            .await
+        {
+            Ok(session) => Some(session),
+            Err(error) => {
+                ctx.data().quotas.refund(user_id);
+                handler::send_error(
+                    ctx,
+                    &format!("MiniMax H3 reference authorization/upload failed: {error}"),
+                )
+                .await?;
+                return Ok(());
+            }
+        }
+    } else {
+        None
+    };
+
     match handler::run_generation(ctx, req).await {
         Ok(()) => {
             // Quota slot was already consumed atomically in check_generate_auth
             ctx.data().cooldowns.record(user_id);
         }
         Err(e) => {
+            if let Some(session) = reference_session {
+                let _ = ctx
+                    .data()
+                    .client
+                    .cancel_reference_upload_session(&session)
+                    .await;
+            }
             // Refund the quota slot consumed during auth check
             ctx.data().quotas.refund(user_id);
-            let msg = if mold_core::MoldClient::is_connection_error(&e) {
+            let msg = if h3_task.is_some() {
+                format!(
+                    "MiniMax H3 runtime/authorization is unavailable: {e} ({})",
+                    mold_core::MINIMAX_H3_AUTHORIZATION_REQUIRED
+                )
+            } else if mold_core::MoldClient::is_connection_error(&e) {
                 "Could not connect to the mold server. Is it running?".to_string()
             } else if mold_core::MoldClient::is_model_not_found(&e) {
                 format!("Model '{model_name}' is not downloaded. Use `/models` to see available models.")
@@ -1301,6 +1422,34 @@ mod tests {
     }
 
     #[test]
+    fn h3_builder_preserves_ordered_descriptor_authority_for_session_binding() {
+        let references = vec![mold_core::GenerationReference::Image {
+            media: mold_core::GenerationReferenceAuthority::Descriptor,
+            provenance: mold_core::GenerationReferenceProvenance {
+                name: Some("anchor.png".to_string()),
+                sha256: Some("0".repeat(64)),
+            },
+            mime_type: "image/png".to_string(),
+            width: 24,
+            height: 16,
+        }];
+        let req = build_generate_request(BuildParams {
+            family: Some(mold_core::minimax_h3::FAMILY),
+            references: Some(references),
+            ..base_params("animate the anchor", mold_core::minimax_h3::REF2VA_COMFY)
+        });
+        assert!(matches!(
+            req.references.as_deref(),
+            Some([mold_core::GenerationReference::Image {
+                provenance,
+                width: 24,
+                height: 16,
+                ..
+            }]) if provenance.name.as_deref() == Some("anchor.png")
+        ));
+    }
+
+    #[test]
     fn duration_rejects_ambiguous_or_unsupported_requests() {
         assert!(resolve_video_timing(Some("ltx2"), None, Some(97), None, Some(4.0)).is_err());
         assert!(resolve_video_timing(Some("ltx2"), None, None, None, Some(20.1)).is_err());
@@ -1502,12 +1651,14 @@ mod tests {
     #[test]
     fn generate_stays_within_discords_option_limit() {
         let command = generate();
-        assert_eq!(command.parameters.len(), 23);
+        assert_eq!(command.parameters.len(), 25);
         assert!(command.parameters.len() <= 25);
         assert!(command
             .parameters
             .iter()
             .any(|parameter| parameter.name == "duration"));
+        assert_eq!(command.parameters[23].name, "reference_1");
+        assert_eq!(command.parameters[24].name, "reference_2");
     }
 
     #[test]

--- a/crates/mold-discord/src/commands/generate.rs
+++ b/crates/mold-discord/src/commands/generate.rs
@@ -165,12 +165,20 @@ impl PipelineChoice {
     }
 }
 
-/// Classify a model family: returns `Some("ltx-video")`, `Some("ltx2")`, or
-/// `None` for anything that isn't a recognized video-producing family.
+/// Classify a model family without making it discoverable or runnable.
+///
+/// H3 remains absent from the visible model catalog while its runtime and
+/// compliance gates are closed. Keeping its timing/container semantics here
+/// means an authorized future server can advertise it without Discord falling
+/// back to still-image defaults.
 pub fn video_family(family: &str) -> Option<&str> {
-    match family {
-        "ltx-video" | "ltx2" | "wan" => Some(family),
-        _ => None,
+    if mold_core::minimax_h3::is_family(family) {
+        Some(mold_core::minimax_h3::FAMILY)
+    } else {
+        match family {
+            "ltx-video" | "ltx2" | "wan" => Some(family),
+            _ => None,
+        }
     }
 }
 
@@ -232,9 +240,20 @@ fn resolve_video_timing(
         return Ok((frames, fps));
     };
 
-    let resolved_fps = fps
-        .or_else(|| defaults.and_then(|value| value.default_fps))
-        .unwrap_or(24);
+    let is_h3 = mold_core::minimax_h3::is_family(family);
+    if is_h3 && fps.is_some_and(|value| value != mold_core::minimax_h3::FIXED_FPS) {
+        return Err(format!(
+            "MiniMax H3 requires {} FPS.",
+            mold_core::minimax_h3::FIXED_FPS
+        ));
+    }
+
+    let resolved_fps = if is_h3 {
+        mold_core::minimax_h3::FIXED_FPS
+    } else {
+        fps.or_else(|| defaults.and_then(|value| value.default_fps))
+            .unwrap_or(24)
+    };
     if resolved_fps == 0 {
         return Err("Video FPS must be at least 1.".to_string());
     }
@@ -247,6 +266,12 @@ fn resolve_video_timing(
     };
     if !seconds.is_finite() || seconds <= 0.0 {
         return Err("Duration must be a positive number of seconds.".to_string());
+    }
+    if is_h3 && seconds < f64::from(mold_core::minimax_h3::MIN_DURATION_SECONDS) {
+        return Err(format!(
+            "MiniMax H3 duration must be at least {} seconds.",
+            mold_core::minimax_h3::MIN_DURATION_SECONDS
+        ));
     }
 
     let max_runtime_seconds = defaults
@@ -264,13 +289,29 @@ fn resolve_video_timing(
         .or_else(|| mold_core::validation::frame_step_for_family(family))
         .unwrap_or(1)
         .max(1);
+    let offset = defaults
+        .and_then(|value| value.frame_offset)
+        .or_else(|| mold_core::validation::frame_offset_for_family(family))
+        .unwrap_or(1)
+        .max(1);
     let requested_frames = seconds * f64::from(resolved_fps);
     if requested_frames > f64::from(u32::MAX) {
         return Err("Duration is too large.".to_string());
     }
-    let frames_on_grid = ((((requested_frames.max(1.0) - 1.0) / f64::from(step)).round() as u32)
-        .saturating_mul(step))
-    .saturating_add(1);
+    let frames_on_grid = if requested_frames <= f64::from(offset) {
+        offset
+    } else {
+        (((requested_frames - f64::from(offset)) / f64::from(step)).round() as u32)
+            .saturating_mul(step)
+            .saturating_add(offset)
+    };
+    let min_frames = mold_core::validation::min_frames_for_family(family).unwrap_or(offset);
+    if frames_on_grid < min_frames {
+        return Err(format!(
+            "Duration for this model must be at least {:.1} seconds.",
+            f64::from(min_frames) / f64::from(resolved_fps)
+        ));
+    }
 
     let max_frames = if let Some(runtime_seconds) = max_runtime_seconds {
         let raw = runtime_seconds
@@ -288,10 +329,12 @@ fn resolve_video_timing(
             .or_else(|| mold_core::validation::max_frames_for_family_at_fps(family, resolved_fps))
             .unwrap_or(u32::MAX)
     };
-    let max_frames_on_grid = if max_frames <= 1 {
-        1
+    let max_frames_on_grid = if max_frames < offset {
+        max_frames
+    } else if max_frames == offset {
+        offset
     } else {
-        max_frames - ((max_frames - 1) % step)
+        max_frames - ((max_frames - offset) % step)
     };
     if frames_on_grid > max_frames_on_grid {
         return Err(format!(
@@ -318,9 +361,15 @@ pub fn build_generate_request(params: BuildParams<'_>) -> GenerateRequest {
 
     let is_video_family = params.family.and_then(video_family).is_some();
     let is_ltx2 = params.family == Some("ltx2");
+    let is_h3 = params.family.is_some_and(mold_core::minimax_h3::is_family);
 
     // Video families always deliver MP4 or GIF. Image models stay PNG.
-    let output_format = if is_video_family {
+    let output_format = if is_h3 {
+        // H3 always emits synchronized audio and its contract requires an MP4
+        // container. This does not activate the hidden family; it only keeps
+        // the request builder from manufacturing an invalid future request.
+        OutputFormat::Mp4
+    } else if is_video_family {
         params
             .video_format
             .map(VideoFormat::to_output_format)
@@ -336,12 +385,20 @@ pub fn build_generate_request(params: BuildParams<'_>) -> GenerateRequest {
             params
                 .frames
                 .or_else(|| params.defaults.and_then(|value| value.default_frames))
-                .unwrap_or(25),
+                .unwrap_or(if is_h3 {
+                    mold_core::minimax_h3::MIN_FRAMES
+                } else {
+                    25
+                }),
         )
     } else {
         params.frames
     };
-    let fps = if is_video_family {
+    let fps = if is_h3 {
+        // This is a final defense for callers that bypass the slash-command
+        // timing resolver. H3's audio/video clock is fixed at 24 FPS.
+        Some(mold_core::minimax_h3::FIXED_FPS)
+    } else if is_video_family {
         Some(
             params
                 .fps
@@ -352,20 +409,48 @@ pub fn build_generate_request(params: BuildParams<'_>) -> GenerateRequest {
         params.fps
     };
 
-    // LTX-2 audio only flows through MP4 container.
-    let enable_audio = if is_ltx2 { params.audio } else { None };
+    // Optional LTX-2 audio follows the user override; H3 audio is inherent.
+    let enable_audio = if is_h3 {
+        Some(true)
+    } else if is_ltx2 {
+        params.audio
+    } else {
+        None
+    };
 
     GenerateRequest {
         hdr_exr_dir: None,
         hdr_exr_full_float: false,
         guidance_overrides: None,
         prompt: params.prompt.to_string(),
-        negative_prompt: params.negative_prompt.map(|s| s.to_string()),
+        negative_prompt: if is_h3 {
+            None
+        } else {
+            params.negative_prompt.map(|s| s.to_string())
+        },
         model: params.model.to_string(),
-        width: params.width.unwrap_or(def_w),
-        height: params.height.unwrap_or(def_h),
-        steps: params.steps.unwrap_or(def_steps),
-        guidance: params.guidance.unwrap_or(def_guidance),
+        width: params.width.unwrap_or(if is_h3 {
+            mold_core::minimax_h3::DEFAULT_WIDTH
+        } else {
+            def_w
+        }),
+        height: params.height.unwrap_or(if is_h3 {
+            mold_core::minimax_h3::DEFAULT_HEIGHT
+        } else {
+            def_h
+        }),
+        steps: params.steps.unwrap_or(if is_h3 {
+            mold_core::minimax_h3::DEFAULT_STEPS
+        } else {
+            def_steps
+        }),
+        // H3 has no CFG path; an explicit Discord override cannot weaken the
+        // model contract even when this builder is called independently.
+        guidance: if is_h3 {
+            0.0
+        } else {
+            params.guidance.unwrap_or(def_guidance)
+        },
         seed: params.seed,
         batch_size: 1,
         output_format: Some(output_format),
@@ -376,7 +461,11 @@ pub fn build_generate_request(params: BuildParams<'_>) -> GenerateRequest {
         references: None,
         source_image: params.source_image,
         source_image_name: None,
-        strength: params.strength.unwrap_or(0.75),
+        strength: if is_h3 {
+            1.0
+        } else {
+            params.strength.unwrap_or(0.75)
+        },
         mask_image: None,
         control_image: None,
         control_model: None,
@@ -483,10 +572,19 @@ fn validate_inline_media_lengths(sizes: impl IntoIterator<Item = u64>) -> Result
 /// width/height when the user didn't supply explicit values — otherwise the
 /// server would `resize_exact` a landscape photo into a square default.
 /// Fits the source into the model's default canvas via the shared
-/// aspect-preserving helper used by the CLI and server, on the grid the
-/// server advertises for the model (`dimension_alignment` — 32 for
-/// `wan22-ti2v-5b`, 16 elsewhere; older servers omit it and keep 16).
-fn fit_attachment_dims(w: u32, h: u32, defaults: Option<&mold_core::ModelDefaults>) -> (u32, u32) {
+/// aspect-preserving helper used by the CLI and server. H3 owns a stricter
+/// 32px canvas contract and its official short-edge/area rounding authority;
+/// other models use the grid advertised by the server (`dimension_alignment`
+/// is 32 for `wan22-ti2v-5b`, 16 elsewhere, and omitted by older servers).
+fn fit_attachment_dims(
+    w: u32,
+    h: u32,
+    defaults: Option<&mold_core::ModelDefaults>,
+    family: Option<&str>,
+) -> (u32, u32) {
+    if family.is_some_and(mold_core::minimax_h3::is_family) {
+        return mold_core::minimax_h3::recommended_dimensions(w, h);
+    }
     let (model_w, model_h) = defaults
         .map(|d| (d.default_width, d.default_height))
         .unwrap_or((1024, 1024));
@@ -849,7 +947,7 @@ pub async fn generate(
                 source_image.as_ref().and_then(|a| a.height),
             ) {
                 (Some(w), Some(h)) => {
-                    let (sw, sh) = fit_attachment_dims(w, h, model_defaults);
+                    let (sw, sh) = fit_attachment_dims(w, h, model_defaults, family);
                     (Some(sw), Some(sh))
                 }
                 _ => (width, height),
@@ -1079,6 +1177,127 @@ mod tests {
             resolve_video_timing(Some("ltx2"), Some(&defs), None, Some(30), Some(10.0)).unwrap(),
             (Some(297), Some(30))
         );
+    }
+
+    #[test]
+    fn h3_duration_uses_its_five_offset_frame_grid() {
+        let defs = mold_core::ModelDefaults {
+            default_frames: Some(mold_core::minimax_h3::MIN_FRAMES),
+            default_fps: Some(mold_core::minimax_h3::FIXED_FPS),
+            max_runtime_seconds: Some(mold_core::minimax_h3::MAX_DURATION_SECONDS),
+            max_frames_absolute: Some(mold_core::minimax_h3::MAX_FRAMES),
+            frame_step: Some(mold_core::minimax_h3::FRAME_STEP),
+            frame_offset: Some(mold_core::minimax_h3::FRAME_OFFSET),
+            ..defaults()
+        };
+
+        assert_eq!(
+            resolve_video_timing(
+                Some(mold_core::minimax_h3::FAMILY),
+                Some(&defs),
+                None,
+                None,
+                Some(5.0),
+            )
+            .unwrap(),
+            (Some(124), Some(24))
+        );
+        assert_eq!(
+            resolve_video_timing(
+                Some(mold_core::minimax_h3::FAMILY),
+                Some(&defs),
+                None,
+                None,
+                Some(15.0),
+            )
+            .unwrap(),
+            (Some(362), Some(24))
+        );
+        assert_eq!(
+            resolve_video_timing(
+                Some(mold_core::minimax_h3::FAMILY),
+                Some(&defs),
+                None,
+                None,
+                Some(4.9),
+            )
+            .unwrap_err(),
+            "MiniMax H3 duration must be at least 5 seconds."
+        );
+    }
+
+    #[test]
+    fn h3_rejects_explicit_non_fixed_fps_on_both_timing_paths() {
+        let duration_error = resolve_video_timing(
+            Some(mold_core::minimax_h3::FAMILY),
+            None,
+            None,
+            Some(30),
+            Some(5.0),
+        )
+        .unwrap_err();
+        let frames_error = resolve_video_timing(
+            Some("minimax_h3"),
+            None,
+            Some(mold_core::minimax_h3::MIN_FRAMES),
+            Some(30),
+            None,
+        )
+        .unwrap_err();
+
+        assert_eq!(duration_error, "MiniMax H3 requires 24 FPS.");
+        assert_eq!(frames_error, "MiniMax H3 requires 24 FPS.");
+    }
+
+    #[test]
+    fn h3_request_builder_preserves_mandatory_av_contract() {
+        let defs = mold_core::ModelDefaults {
+            default_frames: Some(mold_core::minimax_h3::MIN_FRAMES),
+            default_fps: Some(mold_core::minimax_h3::FIXED_FPS),
+            default_width: mold_core::minimax_h3::DEFAULT_WIDTH,
+            default_height: mold_core::minimax_h3::DEFAULT_HEIGHT,
+            default_steps: mold_core::minimax_h3::DEFAULT_STEPS,
+            default_guidance: 0.0,
+            frame_step: Some(mold_core::minimax_h3::FRAME_STEP),
+            frame_offset: Some(mold_core::minimax_h3::FRAME_OFFSET),
+            ..defaults()
+        };
+        let req = build_generate_request(BuildParams {
+            family: Some("minimax_h3"),
+            defaults: Some(&defs),
+            // Neither a user-selected GIF nor a false audio flag may weaken
+            // H3's synchronized MP4 contract.
+            video_format: Some(VideoFormat::Gif),
+            audio: Some(false),
+            strength: Some(0.25),
+            fps: Some(30),
+            guidance: Some(7.5),
+            negative_prompt: Some("stale negative"),
+            ..base_params("a quiet shoreline", mold_core::minimax_h3::FL2VA_COMFY)
+        });
+
+        assert_eq!(req.output_format, Some(OutputFormat::Mp4));
+        assert_eq!(req.enable_audio, Some(true));
+        assert_eq!(req.frames, Some(124));
+        assert_eq!(req.fps, Some(24));
+        assert_eq!(req.steps, 50);
+        assert_eq!(req.guidance, 0.0);
+        assert_eq!(req.strength, 1.0);
+        assert_eq!(req.negative_prompt, None);
+
+        let without_server_defaults = build_generate_request(BuildParams {
+            family: Some(mold_core::minimax_h3::FAMILY),
+            ..base_params("a quiet shoreline", mold_core::minimax_h3::FL2VA_COMFY)
+        });
+        assert_eq!(
+            (
+                without_server_defaults.width,
+                without_server_defaults.height
+            ),
+            (1344, 768)
+        );
+        assert_eq!(without_server_defaults.frames, Some(124));
+        assert_eq!(without_server_defaults.fps, Some(24));
     }
 
     #[test]
@@ -1351,15 +1570,27 @@ mod tests {
     fn fit_attachment_dims_preserves_aspect_ratio() {
         let d = defaults_1024();
         // Landscape photo is no longer squashed to a square.
-        assert_eq!(fit_attachment_dims(1920, 1080, Some(&d)), (1024, 576));
+        assert_eq!(
+            fit_attachment_dims(1920, 1080, Some(&d), Some("flux")),
+            (1024, 576)
+        );
         // Portrait keeps its orientation.
-        assert_eq!(fit_attachment_dims(1080, 1920, Some(&d)), (576, 1024));
+        assert_eq!(
+            fit_attachment_dims(1080, 1920, Some(&d), Some("flux")),
+            (576, 1024)
+        );
         // Square source fills the model's native square.
-        assert_eq!(fit_attachment_dims(1000, 1000, Some(&d)), (1024, 1024));
+        assert_eq!(
+            fit_attachment_dims(1000, 1000, Some(&d), Some("flux")),
+            (1024, 1024)
+        );
         // Missing defaults fall back to a 1024x1024 canvas.
-        assert_eq!(fit_attachment_dims(1920, 1080, None), (1024, 576));
+        assert_eq!(
+            fit_attachment_dims(1920, 1080, None, Some("flux")),
+            (1024, 576)
+        );
         // Output always lands on the 16px grid.
-        let (w, h) = fit_attachment_dims(777, 513, Some(&d));
+        let (w, h) = fit_attachment_dims(777, 513, Some(&d), Some("flux"));
         assert_eq!((w % 16, h % 16), (0, 0));
     }
 
@@ -1377,7 +1608,10 @@ mod tests {
             dimension_alignment: Some(32),
             ..defaults_1024()
         };
-        assert_eq!(fit_attachment_dims(1617, 1000, Some(&five_b)), (1120, 704));
+        assert_eq!(
+            fit_attachment_dims(1617, 1000, Some(&five_b), Some("wan")),
+            (1120, 704)
+        );
 
         let fourteen_b = mold_core::ModelDefaults {
             default_width: 1280,
@@ -1386,7 +1620,7 @@ mod tests {
             ..defaults_1024()
         };
         assert_eq!(
-            fit_attachment_dims(1617, 1000, Some(&fourteen_b)),
+            fit_attachment_dims(1617, 1000, Some(&fourteen_b), Some("wan")),
             (1136, 704)
         );
 
@@ -1397,7 +1631,7 @@ mod tests {
             ..defaults_1024()
         };
         assert_eq!(
-            fit_attachment_dims(1617, 1000, Some(&unadvertised)),
+            fit_attachment_dims(1617, 1000, Some(&unadvertised), Some("wan")),
             (1136, 704)
         );
     }
@@ -1418,6 +1652,22 @@ mod tests {
         );
     }
 
+    #[test]
+    fn h3_attachment_dims_use_the_official_32px_canvas_authority() {
+        for (source_width, source_height) in [(1920, 1080), (1080, 1920)] {
+            let (width, height) = fit_attachment_dims(
+                source_width,
+                source_height,
+                Some(&defaults_1024()),
+                Some("minimax_h3"),
+            );
+            assert_eq!((width % 32, height % 32), (0, 0));
+            assert_eq!(
+                (width, height),
+                mold_core::minimax_h3::recommended_dimensions(source_width, source_height)
+            );
+        }
+    }
     // --- autocomplete ranking ---
 
     fn mk_model(name: &str, family: &str, downloaded: bool) -> ModelInfoExtended {
@@ -1544,6 +1794,13 @@ mod tests {
         assert_eq!(video_family("ltx-video"), Some("ltx-video"));
         assert_eq!(video_family("ltx2"), Some("ltx2"));
         assert_eq!(video_family("wan"), Some("wan"));
+        for alias in mold_core::minimax_h3::FAMILY_ALIASES {
+            assert_eq!(
+                video_family(alias),
+                Some(mold_core::minimax_h3::FAMILY),
+                "alias {alias}"
+            );
+        }
         assert!(video_family("flux").is_none());
         assert!(video_family("sdxl").is_none());
     }

--- a/crates/mold-discord/src/commands/generate.rs
+++ b/crates/mold-discord/src/commands/generate.rs
@@ -206,6 +206,8 @@ pub struct BuildParams<'a> {
     pub negative_prompt: Option<&'a str>,
     pub defaults: Option<&'a mold_core::ModelDefaults>,
     pub source_image: Option<Vec<u8>>,
+    /// Display-safe source attachment basename; never a Discord URL or path.
+    pub source_image_name: Option<String>,
     pub references: Option<Vec<mold_core::GenerationReference>>,
     pub frames: Option<u32>,
     pub fps: Option<u32>,
@@ -468,7 +470,7 @@ pub fn build_generate_request(params: BuildParams<'_>) -> GenerateRequest {
             None
         },
         source_image: params.source_image,
-        source_image_name: None,
+        source_image_name: params.source_image_name,
         strength: if is_h3 {
             1.0
         } else {
@@ -958,7 +960,9 @@ pub async fn generate(
     let prepared_references = if reference_attachments.is_empty() {
         None
     } else {
-        match crate::h3_references::prepare_attachments(&reference_attachments).await {
+        match crate::h3_references::prepare_attachments(&ctx.data().client, &reference_attachments)
+            .await
+        {
             Ok(prepared) => Some(prepared),
             Err(error) => {
                 ctx.data().quotas.refund(user_id);
@@ -1065,6 +1069,9 @@ pub async fn generate(
         negative_prompt: negative_prompt.as_deref(),
         defaults: model_defaults,
         source_image: source_bytes,
+        source_image_name: source_image
+            .as_ref()
+            .and_then(|attachment| crate::h3_references::safe_name(&attachment.filename)),
         references: prepared_references
             .as_ref()
             .map(|prepared| prepared.descriptors.clone()),
@@ -1080,7 +1087,7 @@ pub async fn generate(
         retake_range,
     });
 
-    let reference_session = if let Some(prepared) = prepared_references {
+    let mut reference_session = if let Some(prepared) = prepared_references {
         match crate::h3_references::bind_remote_references(&ctx.data().client, &mut req, prepared)
             .await
         {
@@ -1101,16 +1108,15 @@ pub async fn generate(
 
     match handler::run_generation(ctx, req).await {
         Ok(()) => {
+            if let Some(lease) = reference_session.as_mut() {
+                lease.mark_consumed();
+            }
             // Quota slot was already consumed atomically in check_generate_auth
             ctx.data().cooldowns.record(user_id);
         }
         Err(e) => {
-            if let Some(session) = reference_session {
-                let _ = ctx
-                    .data()
-                    .client
-                    .cancel_reference_upload_session(&session)
-                    .await;
+            if let Some(lease) = reference_session.as_mut() {
+                let _ = lease.cancel().await;
             }
             // Refund the quota slot consumed during auth check
             ctx.data().quotas.refund(user_id);
@@ -1447,6 +1453,20 @@ mod tests {
                 ..
             }]) if provenance.name.as_deref() == Some("anchor.png")
         ));
+    }
+
+    #[test]
+    fn h3_builder_preserves_only_sanitized_source_name() {
+        let name = crate::h3_references::safe_name("../../closing-frame.png\nignored");
+        assert!(name.is_none());
+        let req = build_generate_request(BuildParams {
+            family: Some(mold_core::minimax_h3::FAMILY),
+            source_image: Some(vec![1, 2, 3]),
+            source_image_name: crate::h3_references::safe_name("C:\\uploads\\opening-frame.png"),
+            ..base_params("animate the frame", mold_core::minimax_h3::FL2VA_COMFY)
+        });
+        assert_eq!(req.source_image_name.as_deref(), Some("opening-frame.png"));
+        assert!(!format!("{req:?}").contains("C:\\uploads"));
     }
 
     #[test]

--- a/crates/mold-discord/src/h3_references.rs
+++ b/crates/mold-discord/src/h3_references.rs
@@ -18,6 +18,13 @@ use std::{
     collections::HashSet,
     io::{Cursor, Read, Seek, SeekFrom},
 };
+use symphonia::{
+    core::{
+        audio::SampleBuffer, codecs::DecoderOptions, errors::Error as SymphoniaError,
+        formats::FormatOptions, io::MediaSourceStream, meta::MetadataOptions, probe::Hint,
+    },
+    default::{get_codecs, get_probe},
+};
 
 pub(crate) const MAX_DISCORD_REFERENCES: usize = 2;
 const MAX_REFERENCE_IMAGE_BYTES: usize = 10 * 1024 * 1024;
@@ -254,6 +261,7 @@ fn probe_reference(
             duration_ms: wav.duration_ms,
             sample_rate: wav.sample_rate,
             channels: wav.channels,
+            sample_count: Some(wav.sample_count),
         });
     }
     probe_video(bytes, provenance)
@@ -276,6 +284,7 @@ fn probe_video(
     );
     let width = track.width() as u32;
     let height = track.height() as u32;
+    let frame_count = track.sample_count();
     let fps = track.frame_rate().round() as u32;
     let duration_ms = track.duration().as_millis() as u64;
     anyhow::ensure!(
@@ -286,23 +295,146 @@ fn probe_video(
         .tracks()
         .values()
         .any(|track| matches!(track.track_type(), Ok(TrackType::Audio)));
+    let decoded_audio = if has_audio {
+        Some(
+            probe_decoded_mp4_audio(bytes)?
+                .context("MP4 audio track could not be decoded exactly")?,
+        )
+    } else {
+        None
+    };
+    let audio_duration_ms = decoded_audio
+        .as_ref()
+        .map(|audio| {
+            audio
+                .samples_per_channel
+                .checked_mul(1_000)
+                .context("MP4 soundtrack duration overflowed")
+                .map(|samples| samples.div_ceil(u64::from(audio.sample_rate)))
+        })
+        .transpose()?;
     Ok(GenerationReference::Video {
         media: GenerationReferenceAuthority::Descriptor,
         provenance,
         mime_type: "video/mp4".to_string(),
         width,
         height,
+        frame_count: Some(frame_count),
         duration_ms,
         fps: f64::from(fps),
         has_audio,
-        audio_duration_ms: has_audio.then_some(duration_ms),
+        audio_duration_ms,
+        audio_sample_count: decoded_audio
+            .as_ref()
+            .map(|audio| audio.samples_per_channel),
+        audio_sample_rate: decoded_audio.as_ref().map(|audio| audio.sample_rate),
+        audio_channels: decoded_audio.as_ref().map(|audio| audio.channels),
     })
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ExactAudioProbe {
+    sample_rate: u32,
+    channels: u16,
+    samples_per_channel: u64,
+}
+
+/// Decode attachment audio instead of estimating it from MP4 duration or AAC
+/// packet count. Codec delay and the final packet make either estimate unsafe
+/// for H3's frozen Ref2VA row calculation.
+fn probe_decoded_mp4_audio(bytes: &[u8]) -> Result<Option<ExactAudioProbe>> {
+    let source = MediaSourceStream::new(Box::new(Cursor::new(bytes.to_vec())), Default::default());
+    let mut hint = Hint::new();
+    hint.with_extension("mp4");
+    let probed = get_probe()
+        .format(
+            &hint,
+            source,
+            &FormatOptions::default(),
+            &MetadataOptions::default(),
+        )
+        .context("failed to probe MP4 attachment audio")?;
+    let mut format = probed.format;
+    let Some(track) = format
+        .tracks()
+        .iter()
+        .find(|track| track.codec_params.sample_rate.is_some())
+        .cloned()
+    else {
+        return Ok(None);
+    };
+    let track_id = track.id;
+    let mut decoder = get_codecs()
+        .make(&track.codec_params, &DecoderOptions::default())
+        .context("failed to create MP4 attachment audio decoder")?;
+    let mut sample_rate = None;
+    let mut channels = None;
+    let mut samples_per_channel = 0_u64;
+
+    loop {
+        let packet = match format.next_packet() {
+            Ok(packet) => packet,
+            Err(SymphoniaError::IoError(_)) => break,
+            Err(error) => return Err(error.into()),
+        };
+        if packet.track_id() != track_id {
+            continue;
+        }
+        let decoded = match decoder.decode(&packet) {
+            Ok(decoded) => decoded,
+            Err(SymphoniaError::DecodeError(_)) | Err(SymphoniaError::IoError(_)) => continue,
+            Err(SymphoniaError::ResetRequired) => {
+                anyhow::bail!("MP4 attachment audio decoder requested a reset")
+            }
+            Err(error) => return Err(error.into()),
+        };
+        let observed_rate = decoded.spec().rate;
+        let observed_channels = decoded.spec().channels.count();
+        anyhow::ensure!(
+            observed_rate > 0 && matches!(observed_channels, 1 | 2),
+            "MP4 attachment audio must be mono or stereo with a positive sample rate"
+        );
+        if let Some(expected) = sample_rate {
+            anyhow::ensure!(
+                expected == observed_rate,
+                "MP4 attachment audio changed sample rate mid-stream"
+            );
+        }
+        if let Some(expected) = channels {
+            anyhow::ensure!(
+                expected == observed_channels,
+                "MP4 attachment audio changed channel count mid-stream"
+            );
+        }
+        sample_rate = Some(observed_rate);
+        channels = Some(observed_channels);
+        let mut samples = SampleBuffer::<f32>::new(decoded.capacity() as u64, *decoded.spec());
+        samples.copy_interleaved_ref(decoded);
+        anyhow::ensure!(
+            samples.samples().len().is_multiple_of(observed_channels),
+            "MP4 attachment audio decoder returned a partial frame"
+        );
+        samples_per_channel = samples_per_channel
+            .checked_add((samples.samples().len() / observed_channels) as u64)
+            .context("MP4 attachment decoded sample count overflowed")?;
+    }
+
+    let (Some(sample_rate), Some(channels)) = (sample_rate, channels) else {
+        return Ok(None);
+    };
+    anyhow::ensure!(samples_per_channel > 0, "MP4 attachment audio was empty");
+    Ok(Some(ExactAudioProbe {
+        sample_rate,
+        channels: u16::try_from(channels).context("MP4 audio channel count exceeded u16")?,
+        samples_per_channel,
+    }))
 }
 
 struct WavProbe {
     duration_ms: u64,
     sample_rate: u32,
     channels: u16,
+    sample_count: u64,
 }
 
 fn probe_wav(bytes: &[u8]) -> Result<WavProbe> {
@@ -399,6 +531,7 @@ fn probe_wav(bytes: &[u8]) -> Result<WavProbe> {
         duration_ms: data_bytes.saturating_mul(1_000).div_ceil(byte_rate),
         sample_rate,
         channels,
+        sample_count: data_bytes / block_align,
     })
 }
 
@@ -460,10 +593,14 @@ fn with_authority(
             mime_type,
             width,
             height,
+            frame_count,
             duration_ms,
             fps,
             has_audio,
             audio_duration_ms,
+            audio_sample_count,
+            audio_sample_rate,
+            audio_channels,
             ..
         } => GenerationReference::Video {
             media,
@@ -471,10 +608,14 @@ fn with_authority(
             mime_type: mime_type.clone(),
             width: *width,
             height: *height,
+            frame_count: *frame_count,
             duration_ms: *duration_ms,
             fps: *fps,
             has_audio: *has_audio,
             audio_duration_ms: *audio_duration_ms,
+            audio_sample_count: *audio_sample_count,
+            audio_sample_rate: *audio_sample_rate,
+            audio_channels: *audio_channels,
         },
         GenerationReference::Audio {
             provenance,
@@ -482,6 +623,7 @@ fn with_authority(
             duration_ms,
             sample_rate,
             channels,
+            sample_count,
             ..
         } => GenerationReference::Audio {
             media,
@@ -490,6 +632,7 @@ fn with_authority(
             duration_ms: *duration_ms,
             sample_rate: *sample_rate,
             channels: *channels,
+            sample_count: *sample_count,
         },
     }
 }
@@ -537,7 +680,12 @@ mod tests {
         ));
         assert!(matches!(
             &prepared.descriptors[1],
-            GenerationReference::Audio { provenance, duration_ms: 2_000, .. }
+            GenerationReference::Audio {
+                provenance,
+                duration_ms: 2_000,
+                sample_count: Some(16_000),
+                ..
+            }
                 if provenance.name.as_deref() == Some("voice.wav")
         ));
         assert!(!format!("{prepared:?}").contains("89504e47"));

--- a/crates/mold-discord/src/h3_references.rs
+++ b/crates/mold-discord/src/h3_references.rs
@@ -1,0 +1,552 @@
+//! Exact, payload-free MiniMax H3 reference descriptors for Discord.
+//!
+//! Discord exposes two ordered generic attachment options because `/generate`
+//! already uses 23 of Discord's 25 option slots. Bytes are downloaded once,
+//! probed locally, and retained only long enough to upload through a fresh,
+//! authenticated server session. Debug output redacts both bytes and handles.
+
+use anyhow::{Context, Result};
+use image::ImageReader;
+use mold_core::{
+    minimax_h3, GenerateRequest, GenerationReference, GenerationReferenceAuthority,
+    GenerationReferenceProvenance, MoldClient, ReferenceUploadSessionRequest,
+};
+use mp4_rs::{MediaType, Mp4Reader, TrackType};
+use poise::serenity_prelude as serenity;
+use sha2::{Digest, Sha256};
+use std::{
+    collections::HashSet,
+    io::{Cursor, Read, Seek, SeekFrom},
+};
+
+pub(crate) const MAX_DISCORD_REFERENCES: usize = 2;
+const MAX_REFERENCE_IMAGE_BYTES: usize = 10 * 1024 * 1024;
+const MAX_REFERENCE_TOTAL_BYTES: usize = 47 * 1024 * 1024;
+
+pub(crate) struct PreparedReferences {
+    pub descriptors: Vec<GenerationReference>,
+    uploads: Vec<ReferenceUpload>,
+}
+
+impl std::fmt::Debug for PreparedReferences {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("PreparedReferences")
+            .field("descriptors", &self.descriptors)
+            .field(
+                "uploads",
+                &format_args!("<{} redacted bodies>", self.uploads.len()),
+            )
+            .finish()
+    }
+}
+
+struct ReferenceUpload {
+    bytes: Vec<u8>,
+    mime_type: String,
+}
+
+pub(crate) async fn prepare_attachments(
+    attachments: &[&serenity::Attachment],
+) -> Result<PreparedReferences> {
+    anyhow::ensure!(
+        !attachments.is_empty() && attachments.len() <= MAX_DISCORD_REFERENCES,
+        "Discord accepts one or two ordered MiniMax H3 references"
+    );
+    let declared_total = attachments
+        .iter()
+        .try_fold(0_usize, |total, attachment| {
+            total.checked_add(attachment.size as usize)
+        })
+        .context("combined reference attachment size overflowed")?;
+    anyhow::ensure!(
+        declared_total <= MAX_REFERENCE_TOTAL_BYTES,
+        "combined reference attachments must stay under 47 MiB"
+    );
+
+    let mut bodies = Vec::with_capacity(attachments.len());
+    for (index, attachment) in attachments.iter().enumerate() {
+        let bytes = attachment
+            .download()
+            .await
+            .map_err(|_| anyhow::anyhow!("reference {} download failed", index + 1))?;
+        anyhow::ensure!(!bytes.is_empty(), "reference {} is empty", index + 1);
+        bodies.push((attachment.filename.as_str(), bytes));
+    }
+    prepare_named_bytes(bodies)
+}
+
+fn prepare_named_bytes<'a>(
+    bodies: impl IntoIterator<Item = (&'a str, Vec<u8>)>,
+) -> Result<PreparedReferences> {
+    let bodies = bodies.into_iter().collect::<Vec<_>>();
+    anyhow::ensure!(
+        !bodies.is_empty() && bodies.len() <= MAX_DISCORD_REFERENCES,
+        "Discord accepts one or two ordered MiniMax H3 references"
+    );
+    let actual_total = bodies
+        .iter()
+        .try_fold(0_usize, |total, (_, bytes)| total.checked_add(bytes.len()))
+        .context("combined reference body size overflowed")?;
+    anyhow::ensure!(
+        actual_total <= MAX_REFERENCE_TOTAL_BYTES,
+        "combined reference attachments must stay under 47 MiB"
+    );
+
+    let mut descriptors = Vec::with_capacity(bodies.len());
+    let mut uploads = Vec::with_capacity(bodies.len());
+    for (index, (name, bytes)) in bodies.into_iter().enumerate() {
+        let provenance = GenerationReferenceProvenance {
+            name: Some(
+                safe_name(name)
+                    .with_context(|| format!("reference {} filename is invalid", index + 1))?,
+            ),
+            sha256: Some(format!("{:x}", Sha256::digest(&bytes))),
+        };
+        let descriptor = probe_reference(&bytes, provenance)
+            .with_context(|| format!("reference {} media probe failed", index + 1))?;
+        if matches!(descriptor, GenerationReference::Image { .. }) {
+            anyhow::ensure!(
+                bytes.len() <= MAX_REFERENCE_IMAGE_BYTES,
+                "reference {} image must stay under 10 MiB",
+                index + 1
+            );
+        }
+        uploads.push(ReferenceUpload {
+            mime_type: reference_mime_type(&descriptor).to_string(),
+            bytes,
+        });
+        descriptors.push(descriptor);
+    }
+    minimax_h3::validate_reference_descriptors(&descriptors).map_err(anyhow::Error::new)?;
+    Ok(PreparedReferences {
+        descriptors,
+        uploads,
+    })
+}
+
+pub(crate) async fn bind_remote_references(
+    client: &MoldClient,
+    request: &mut GenerateRequest,
+    prepared: PreparedReferences,
+) -> Result<String> {
+    anyhow::ensure!(
+        prepared.descriptors.len() == prepared.uploads.len(),
+        "reference descriptor/body count mismatch"
+    );
+    minimax_h3::validate_reference_descriptors(&prepared.descriptors)
+        .map_err(anyhow::Error::new)?;
+    request.references = Some(prepared.descriptors.clone());
+    let upload_references = (1..=prepared.descriptors.len())
+        .map(|index| u32::try_from(index).context("too many reference uploads"))
+        .collect::<Result<Vec<_>>>()?;
+    let session = client
+        .create_reference_upload_session(&ReferenceUploadSessionRequest {
+            request: request.clone(),
+            upload_references,
+        })
+        .await?;
+    if session.instance_id.trim().is_empty()
+        || session.expires_at_ms == 0
+        || !is_sha256_hex(&session.request_scope_sha256)
+        || !is_upload_handle(&session.session_handle)
+        || session.uploads.len() != prepared.descriptors.len()
+    {
+        let _ = client
+            .cancel_reference_upload_session(&session.session_handle)
+            .await;
+        anyhow::bail!("server returned an incomplete reference upload session");
+    }
+
+    let result: Result<Vec<GenerationReference>> = async {
+        let mut bound = Vec::with_capacity(prepared.descriptors.len());
+        let mut seen = HashSet::new();
+        for (index, (descriptor, upload)) in prepared
+            .descriptors
+            .iter()
+            .zip(prepared.uploads)
+            .enumerate()
+        {
+            let reference = u32::try_from(index)
+                .context("too many reference uploads")?
+                .saturating_add(1);
+            let slot = session
+                .uploads
+                .iter()
+                .find(|slot| slot.reference == reference)
+                .ok_or_else(|| anyhow::anyhow!("server omitted reference upload slot {reference}"))?;
+            if !is_upload_handle(&slot.handle) || !seen.insert(slot.handle.as_str()) {
+                anyhow::bail!("server returned an invalid or reused reference upload handle");
+            }
+            let completed = client
+                .upload_reference_bytes(&slot.handle, upload.bytes, &upload.mime_type)
+                .await
+                .with_context(|| format!("reference {reference} upload failed"))?;
+            if completed.instance_id != session.instance_id || completed.reference != reference {
+                anyhow::bail!(
+                    "reference {reference} upload response did not match its bound server session"
+                );
+            }
+            let expected = descriptor
+                .redacted_metadata(index)
+                .ok_or_else(|| anyhow::anyhow!("reference {reference} lost digest provenance"))?;
+            if completed.metadata != expected {
+                anyhow::bail!(
+                    "reference {reference} upload response drifted from the client-probed descriptor"
+                );
+            }
+            bound.push(with_authority(
+                descriptor,
+                GenerationReferenceAuthority::Upload {
+                    handle: slot.handle.clone(),
+                },
+            ));
+        }
+        Ok(bound)
+    }
+    .await;
+
+    match result {
+        Ok(bound) => {
+            request.references = Some(bound);
+            Ok(session.session_handle)
+        }
+        Err(error) => {
+            let _ = client
+                .cancel_reference_upload_session(&session.session_handle)
+                .await;
+            Err(error)
+        }
+    }
+}
+
+fn probe_reference(
+    bytes: &[u8],
+    provenance: GenerationReferenceProvenance,
+) -> Result<GenerationReference> {
+    if let Ok(reader) = ImageReader::new(Cursor::new(bytes)).with_guessed_format() {
+        if let Some(format) = reader.format() {
+            let mime_type = match format {
+                image::ImageFormat::Png => Some("image/png"),
+                image::ImageFormat::Jpeg => Some("image/jpeg"),
+                image::ImageFormat::WebP => Some("image/webp"),
+                image::ImageFormat::Gif => Some("image/gif"),
+                _ => None,
+            };
+            if let Some(mime_type) = mime_type {
+                let (width, height) = reader.into_dimensions()?;
+                return Ok(GenerationReference::Image {
+                    media: GenerationReferenceAuthority::Descriptor,
+                    provenance,
+                    mime_type: mime_type.to_string(),
+                    width,
+                    height,
+                });
+            }
+        }
+    }
+    if bytes.starts_with(b"RIFF") && bytes.get(8..12) == Some(b"WAVE") {
+        let wav = probe_wav(bytes)?;
+        return Ok(GenerationReference::Audio {
+            media: GenerationReferenceAuthority::Descriptor,
+            provenance,
+            mime_type: "audio/wav".to_string(),
+            duration_ms: wav.duration_ms,
+            sample_rate: wav.sample_rate,
+            channels: wav.channels,
+        });
+    }
+    probe_video(bytes, provenance)
+}
+
+fn probe_video(
+    bytes: &[u8],
+    provenance: GenerationReferenceProvenance,
+) -> Result<GenerationReference> {
+    let reader = Mp4Reader::read_header(Cursor::new(bytes), bytes.len() as u64)
+        .context("unsupported reference; use PNG, JPEG, WebP, GIF, H.264 MP4, or RIFF/WAVE")?;
+    let track = reader
+        .tracks()
+        .values()
+        .find(|track| matches!(track.track_type(), Ok(TrackType::Video)))
+        .context("MP4 did not contain a video track")?;
+    anyhow::ensure!(
+        track.media_type()? == MediaType::H264,
+        "MP4 video must use H.264/AVC"
+    );
+    let width = track.width() as u32;
+    let height = track.height() as u32;
+    let fps = track.frame_rate().round() as u32;
+    let duration_ms = track.duration().as_millis() as u64;
+    anyhow::ensure!(
+        width > 0 && height > 0 && fps > 0 && duration_ms > 0,
+        "MP4 video metadata is incomplete"
+    );
+    let has_audio = reader
+        .tracks()
+        .values()
+        .any(|track| matches!(track.track_type(), Ok(TrackType::Audio)));
+    Ok(GenerationReference::Video {
+        media: GenerationReferenceAuthority::Descriptor,
+        provenance,
+        mime_type: "video/mp4".to_string(),
+        width,
+        height,
+        duration_ms,
+        fps: f64::from(fps),
+        has_audio,
+        audio_duration_ms: has_audio.then_some(duration_ms),
+    })
+}
+
+struct WavProbe {
+    duration_ms: u64,
+    sample_rate: u32,
+    channels: u16,
+}
+
+fn probe_wav(bytes: &[u8]) -> Result<WavProbe> {
+    let file_len = bytes.len() as u64;
+    let mut reader = Cursor::new(bytes);
+    let mut header = [0_u8; 12];
+    reader.read_exact(&mut header)?;
+    anyhow::ensure!(
+        &header[..4] == b"RIFF" && &header[8..] == b"WAVE",
+        "not RIFF/WAVE"
+    );
+    let riff_end = 8_u64
+        .checked_add(u64::from(u32::from_le_bytes(header[4..8].try_into()?)))
+        .context("WAVE container length overflowed")?;
+    anyhow::ensure!(
+        riff_end >= 12 && riff_end <= file_len,
+        "WAVE container is truncated"
+    );
+    let mut sample_rate = None;
+    let mut channels = None;
+    let mut byte_rate = None;
+    let mut block_align = None;
+    let mut data_bytes = None;
+    while reader.stream_position()?.saturating_add(8) <= riff_end {
+        let mut chunk = [0_u8; 8];
+        reader.read_exact(&mut chunk)?;
+        let length = u64::from(u32::from_le_bytes(chunk[4..].try_into()?));
+        let start = reader.stream_position()?;
+        let next = start
+            .checked_add(
+                length
+                    .checked_add(length % 2)
+                    .context("WAVE chunk overflowed")?,
+            )
+            .context("WAVE chunk offset overflowed")?;
+        anyhow::ensure!(
+            next <= riff_end && next <= file_len,
+            "WAVE chunk is truncated"
+        );
+        match &chunk[..4] {
+            b"fmt " => {
+                anyhow::ensure!(length >= 16, "WAVE fmt chunk is truncated");
+                let mut format = [0_u8; 16];
+                reader.read_exact(&mut format)?;
+                let encoding = u16::from_le_bytes(format[..2].try_into()?);
+                let observed_channels = u16::from_le_bytes(format[2..4].try_into()?);
+                let observed_rate = u32::from_le_bytes(format[4..8].try_into()?);
+                let observed_byte_rate = u32::from_le_bytes(format[8..12].try_into()?);
+                let observed_align = u16::from_le_bytes(format[12..14].try_into()?);
+                let bits = u16::from_le_bytes(format[14..16].try_into()?);
+                anyhow::ensure!(matches!(encoding, 1 | 3), "unsupported WAVE encoding");
+                anyhow::ensure!(
+                    observed_channels > 0
+                        && observed_rate > 0
+                        && observed_align > 0
+                        && bits > 0
+                        && bits % 8 == 0,
+                    "invalid WAVE fields"
+                );
+                anyhow::ensure!(
+                    observed_align
+                        == observed_channels
+                            .checked_mul(bits / 8)
+                            .context("WAVE alignment overflowed")?,
+                    "inconsistent WAVE alignment"
+                );
+                anyhow::ensure!(
+                    observed_byte_rate == observed_rate.saturating_mul(u32::from(observed_align)),
+                    "inconsistent WAVE byte rate"
+                );
+                sample_rate = Some(observed_rate);
+                channels = Some(observed_channels);
+                byte_rate = Some(observed_byte_rate);
+                block_align = Some(observed_align);
+            }
+            b"data" => data_bytes = Some(length),
+            _ => {}
+        }
+        reader.seek(SeekFrom::Start(next))?;
+        if sample_rate.is_some() && data_bytes.is_some() {
+            break;
+        }
+    }
+    let sample_rate = sample_rate.context("WAVE has no sample rate")?;
+    let channels = channels.context("WAVE has no channels")?;
+    let byte_rate = u64::from(byte_rate.context("WAVE has no byte rate")?);
+    let block_align = u64::from(block_align.context("WAVE has no block alignment")?);
+    let data_bytes = data_bytes.context("WAVE has no data chunk")?;
+    anyhow::ensure!(
+        data_bytes > 0 && data_bytes % block_align == 0,
+        "WAVE data is empty or unaligned"
+    );
+    Ok(WavProbe {
+        duration_ms: data_bytes.saturating_mul(1_000).div_ceil(byte_rate),
+        sample_rate,
+        channels,
+    })
+}
+
+fn safe_name(value: &str) -> Option<String> {
+    value
+        .rsplit(['/', '\\'])
+        .next()
+        .map(str::trim)
+        .filter(|name| {
+            !name.is_empty()
+                && name.len() <= minimax_h3::MAX_REFERENCE_NAME_BYTES
+                && *name != "."
+                && *name != ".."
+                && !name.chars().any(char::is_control)
+        })
+        .map(str::to_string)
+}
+
+fn reference_mime_type(reference: &GenerationReference) -> &str {
+    match reference {
+        GenerationReference::Image { mime_type, .. }
+        | GenerationReference::Video { mime_type, .. }
+        | GenerationReference::Audio { mime_type, .. } => mime_type,
+    }
+}
+
+fn is_sha256_hex(value: &str) -> bool {
+    value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn is_upload_handle(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= minimax_h3::MAX_REFERENCE_UPLOAD_HANDLE_BYTES
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b':' | b'.'))
+}
+
+fn with_authority(
+    reference: &GenerationReference,
+    media: GenerationReferenceAuthority,
+) -> GenerationReference {
+    match reference {
+        GenerationReference::Image {
+            provenance,
+            mime_type,
+            width,
+            height,
+            ..
+        } => GenerationReference::Image {
+            media,
+            provenance: provenance.clone(),
+            mime_type: mime_type.clone(),
+            width: *width,
+            height: *height,
+        },
+        GenerationReference::Video {
+            provenance,
+            mime_type,
+            width,
+            height,
+            duration_ms,
+            fps,
+            has_audio,
+            audio_duration_ms,
+            ..
+        } => GenerationReference::Video {
+            media,
+            provenance: provenance.clone(),
+            mime_type: mime_type.clone(),
+            width: *width,
+            height: *height,
+            duration_ms: *duration_ms,
+            fps: *fps,
+            has_audio: *has_audio,
+            audio_duration_ms: *audio_duration_ms,
+        },
+        GenerationReference::Audio {
+            provenance,
+            mime_type,
+            duration_ms,
+            sample_rate,
+            channels,
+            ..
+        } => GenerationReference::Audio {
+            media,
+            provenance: provenance.clone(),
+            mime_type: mime_type.clone(),
+            duration_ms: *duration_ms,
+            sample_rate: *sample_rate,
+            channels: *channels,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn wav_bytes(seconds: u32) -> Vec<u8> {
+        let sample_rate = 8_000_u32;
+        let data_len = sample_rate * seconds * 2;
+        let mut bytes = Vec::with_capacity(44 + data_len as usize);
+        bytes.extend_from_slice(b"RIFF");
+        bytes.extend_from_slice(&(36 + data_len).to_le_bytes());
+        bytes.extend_from_slice(b"WAVEfmt ");
+        bytes.extend_from_slice(&16_u32.to_le_bytes());
+        bytes.extend_from_slice(&1_u16.to_le_bytes());
+        bytes.extend_from_slice(&1_u16.to_le_bytes());
+        bytes.extend_from_slice(&sample_rate.to_le_bytes());
+        bytes.extend_from_slice(&(sample_rate * 2).to_le_bytes());
+        bytes.extend_from_slice(&2_u16.to_le_bytes());
+        bytes.extend_from_slice(&16_u16.to_le_bytes());
+        bytes.extend_from_slice(b"data");
+        bytes.extend_from_slice(&data_len.to_le_bytes());
+        bytes.resize(44 + data_len as usize, 0);
+        bytes
+    }
+
+    #[test]
+    fn mixed_image_audio_order_and_provenance_are_exact() {
+        let mut png = Cursor::new(Vec::new());
+        image::DynamicImage::new_rgb8(24, 16)
+            .write_to(&mut png, image::ImageFormat::Png)
+            .unwrap();
+        let prepared = prepare_named_bytes([
+            ("../../anchor.png", png.into_inner()),
+            ("voice.wav", wav_bytes(2)),
+        ])
+        .unwrap();
+        assert!(matches!(
+            &prepared.descriptors[0],
+            GenerationReference::Image { provenance, width: 24, height: 16, .. }
+                if provenance.name.as_deref() == Some("anchor.png")
+                    && provenance.sha256.as_ref().is_some_and(|digest| digest.len() == 64)
+        ));
+        assert!(matches!(
+            &prepared.descriptors[1],
+            GenerationReference::Audio { provenance, duration_ms: 2_000, .. }
+                if provenance.name.as_deref() == Some("voice.wav")
+        ));
+        assert!(!format!("{prepared:?}").contains("89504e47"));
+    }
+
+    #[test]
+    fn audio_only_fails_closed() {
+        let error = prepare_named_bytes([("voice.wav", wav_bytes(2))])
+            .expect_err("audio-only input must fail");
+        assert!(error.to_string().contains("audio references require"));
+    }
+}

--- a/crates/mold-discord/src/h3_references.rs
+++ b/crates/mold-discord/src/h3_references.rs
@@ -9,15 +9,12 @@ use anyhow::{Context, Result};
 use image::ImageReader;
 use mold_core::{
     minimax_h3, GenerateRequest, GenerationReference, GenerationReferenceAuthority,
-    GenerationReferenceProvenance, MoldClient, ReferenceUploadSessionRequest,
+    GenerationReferenceProvenance, MoldClient, ReferenceUploadLease, ReferenceUploadSource,
 };
 use mp4_rs::{MediaType, Mp4Reader, TrackType};
 use poise::serenity_prelude as serenity;
 use sha2::{Digest, Sha256};
-use std::{
-    collections::HashSet,
-    io::{Cursor, Read, Seek, SeekFrom},
-};
+use std::io::{Cursor, Read, Seek, SeekFrom};
 use symphonia::{
     core::{
         audio::SampleBuffer, codecs::DecoderOptions, errors::Error as SymphoniaError,
@@ -50,12 +47,16 @@ impl std::fmt::Debug for PreparedReferences {
 
 struct ReferenceUpload {
     bytes: Vec<u8>,
-    mime_type: String,
 }
 
 pub(crate) async fn prepare_attachments(
+    client: &MoldClient,
     attachments: &[&serenity::Attachment],
 ) -> Result<PreparedReferences> {
+    anyhow::ensure!(
+        client.has_api_key(),
+        "MiniMax H3 reference preparation requires a configured, valid server API key"
+    );
     anyhow::ensure!(
         !attachments.is_empty() && attachments.len() <= MAX_DISCORD_REFERENCES,
         "Discord accepts one or two ordered MiniMax H3 references"
@@ -119,10 +120,7 @@ fn prepare_named_bytes<'a>(
                 index + 1
             );
         }
-        uploads.push(ReferenceUpload {
-            mime_type: reference_mime_type(&descriptor).to_string(),
-            bytes,
-        });
+        uploads.push(ReferenceUpload { bytes });
         descriptors.push(descriptor);
     }
     minimax_h3::validate_reference_descriptors(&descriptors).map_err(anyhow::Error::new)?;
@@ -136,95 +134,22 @@ pub(crate) async fn bind_remote_references(
     client: &MoldClient,
     request: &mut GenerateRequest,
     prepared: PreparedReferences,
-) -> Result<String> {
+) -> Result<ReferenceUploadLease> {
     anyhow::ensure!(
         prepared.descriptors.len() == prepared.uploads.len(),
         "reference descriptor/body count mismatch"
     );
     minimax_h3::validate_reference_descriptors(&prepared.descriptors)
         .map_err(anyhow::Error::new)?;
-    request.references = Some(prepared.descriptors.clone());
-    let upload_references = (1..=prepared.descriptors.len())
-        .map(|index| u32::try_from(index).context("too many reference uploads"))
+    request.references = Some(prepared.descriptors);
+    let sources = prepared
+        .uploads
+        .into_iter()
+        .map(|upload| ReferenceUploadSource::bytes(upload.bytes))
         .collect::<Result<Vec<_>>>()?;
-    let session = client
-        .create_reference_upload_session(&ReferenceUploadSessionRequest {
-            request: request.clone(),
-            upload_references,
-        })
-        .await?;
-    if session.instance_id.trim().is_empty()
-        || session.expires_at_ms == 0
-        || !is_sha256_hex(&session.request_scope_sha256)
-        || !is_upload_handle(&session.session_handle)
-        || session.uploads.len() != prepared.descriptors.len()
-    {
-        let _ = client
-            .cancel_reference_upload_session(&session.session_handle)
-            .await;
-        anyhow::bail!("server returned an incomplete reference upload session");
-    }
-
-    let result: Result<Vec<GenerationReference>> = async {
-        let mut bound = Vec::with_capacity(prepared.descriptors.len());
-        let mut seen = HashSet::new();
-        for (index, (descriptor, upload)) in prepared
-            .descriptors
-            .iter()
-            .zip(prepared.uploads)
-            .enumerate()
-        {
-            let reference = u32::try_from(index)
-                .context("too many reference uploads")?
-                .saturating_add(1);
-            let slot = session
-                .uploads
-                .iter()
-                .find(|slot| slot.reference == reference)
-                .ok_or_else(|| anyhow::anyhow!("server omitted reference upload slot {reference}"))?;
-            if !is_upload_handle(&slot.handle) || !seen.insert(slot.handle.as_str()) {
-                anyhow::bail!("server returned an invalid or reused reference upload handle");
-            }
-            let completed = client
-                .upload_reference_bytes(&slot.handle, upload.bytes, &upload.mime_type)
-                .await
-                .with_context(|| format!("reference {reference} upload failed"))?;
-            if completed.instance_id != session.instance_id || completed.reference != reference {
-                anyhow::bail!(
-                    "reference {reference} upload response did not match its bound server session"
-                );
-            }
-            let expected = descriptor
-                .redacted_metadata(index)
-                .ok_or_else(|| anyhow::anyhow!("reference {reference} lost digest provenance"))?;
-            if completed.metadata != expected {
-                anyhow::bail!(
-                    "reference {reference} upload response drifted from the client-probed descriptor"
-                );
-            }
-            bound.push(with_authority(
-                descriptor,
-                GenerationReferenceAuthority::Upload {
-                    handle: slot.handle.clone(),
-                },
-            ));
-        }
-        Ok(bound)
-    }
-    .await;
-
-    match result {
-        Ok(bound) => {
-            request.references = Some(bound);
-            Ok(session.session_handle)
-        }
-        Err(error) => {
-            let _ = client
-                .cancel_reference_upload_session(&session.session_handle)
-                .await;
-            Err(error)
-        }
-    }
+    let lease = client.bind_reference_uploads_v2(request, sources).await?;
+    *request = lease.request().clone();
+    Ok(lease)
 }
 
 fn probe_reference(
@@ -535,7 +460,7 @@ fn probe_wav(bytes: &[u8]) -> Result<WavProbe> {
     })
 }
 
-fn safe_name(value: &str) -> Option<String> {
+pub(crate) fn safe_name(value: &str) -> Option<String> {
     value
         .rsplit(['/', '\\'])
         .next()
@@ -548,93 +473,6 @@ fn safe_name(value: &str) -> Option<String> {
                 && !name.chars().any(char::is_control)
         })
         .map(str::to_string)
-}
-
-fn reference_mime_type(reference: &GenerationReference) -> &str {
-    match reference {
-        GenerationReference::Image { mime_type, .. }
-        | GenerationReference::Video { mime_type, .. }
-        | GenerationReference::Audio { mime_type, .. } => mime_type,
-    }
-}
-
-fn is_sha256_hex(value: &str) -> bool {
-    value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
-}
-
-fn is_upload_handle(value: &str) -> bool {
-    !value.is_empty()
-        && value.len() <= minimax_h3::MAX_REFERENCE_UPLOAD_HANDLE_BYTES
-        && value
-            .bytes()
-            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b':' | b'.'))
-}
-
-fn with_authority(
-    reference: &GenerationReference,
-    media: GenerationReferenceAuthority,
-) -> GenerationReference {
-    match reference {
-        GenerationReference::Image {
-            provenance,
-            mime_type,
-            width,
-            height,
-            ..
-        } => GenerationReference::Image {
-            media,
-            provenance: provenance.clone(),
-            mime_type: mime_type.clone(),
-            width: *width,
-            height: *height,
-        },
-        GenerationReference::Video {
-            provenance,
-            mime_type,
-            width,
-            height,
-            frame_count,
-            duration_ms,
-            fps,
-            has_audio,
-            audio_duration_ms,
-            audio_sample_count,
-            audio_sample_rate,
-            audio_channels,
-            ..
-        } => GenerationReference::Video {
-            media,
-            provenance: provenance.clone(),
-            mime_type: mime_type.clone(),
-            width: *width,
-            height: *height,
-            frame_count: *frame_count,
-            duration_ms: *duration_ms,
-            fps: *fps,
-            has_audio: *has_audio,
-            audio_duration_ms: *audio_duration_ms,
-            audio_sample_count: *audio_sample_count,
-            audio_sample_rate: *audio_sample_rate,
-            audio_channels: *audio_channels,
-        },
-        GenerationReference::Audio {
-            provenance,
-            mime_type,
-            duration_ms,
-            sample_rate,
-            channels,
-            sample_count,
-            ..
-        } => GenerationReference::Audio {
-            media,
-            provenance: provenance.clone(),
-            mime_type: mime_type.clone(),
-            duration_ms: *duration_ms,
-            sample_rate: *sample_rate,
-            channels: *channels,
-            sample_count: *sample_count,
-        },
-    }
 }
 
 #[cfg(test)]
@@ -696,5 +534,41 @@ mod tests {
         let error = prepare_named_bytes([("voice.wav", wav_bytes(2))])
             .expect_err("audio-only input must fail");
         assert!(error.to_string().contains("audio references require"));
+    }
+
+    #[tokio::test]
+    async fn auth_preflight_prevents_attachment_download() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let url = format!("http://{}/reference.png", listener.local_addr().unwrap());
+        let attachment: serenity::Attachment = serde_json::from_value(serde_json::json!({
+            "id": "1",
+            "filename": "reference.png",
+            "description": null,
+            "height": 1,
+            "proxy_url": url,
+            "size": 1,
+            "url": url,
+            "width": 1,
+            "content_type": "image/png",
+            "ephemeral": false,
+            "duration_secs": null,
+            "waveform": null
+        }))
+        .unwrap();
+        let client = MoldClient::new("http://127.0.0.1:9");
+        let error = tokio::time::timeout(
+            std::time::Duration::from_millis(250),
+            prepare_attachments(&client, &[&attachment]),
+        )
+        .await
+        .expect("auth preflight must return without waiting on attachment I/O")
+        .unwrap_err();
+        assert!(error.to_string().contains("API key"));
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(50), listener.accept())
+                .await
+                .is_err(),
+            "missing-key preparation must not contact the attachment URL"
+        );
     }
 }

--- a/crates/mold-discord/src/handler.rs
+++ b/crates/mold-discord/src/handler.rs
@@ -13,6 +13,11 @@ const EDIT_THROTTLE: std::time::Duration = std::time::Duration::from_secs(3);
 /// payload exceeds this we fall back to the always-generated gif_preview.
 const MAX_ATTACHMENT_BYTES: usize = 24 * 1024 * 1024;
 
+fn requires_secure_generation_stream(req: &GenerateRequest) -> bool {
+    mold_core::minimax_h3::task_for_model(&req.model).is_some()
+        || req.references.as_ref().is_some_and(|refs| !refs.is_empty())
+}
+
 /// Convert our format::EmbedData into a serenity CreateEmbed.
 pub fn embed_data_to_create_embed(data: &EmbedData) -> CreateEmbed {
     let mut embed = CreateEmbed::new().title(&data.title).color(data.color);
@@ -80,6 +85,11 @@ pub async fn run_generation(ctx: Context<'_>, req: GenerateRequest) -> Result<()
             send_result_edit(&reply_handle, ctx, &resp, &prompt).await?;
         }
         None => {
+            if requires_secure_generation_stream(&req) {
+                anyhow::bail!(
+                    "server lacks secure streaming generation required for one-use MiniMax H3 references; update the server"
+                );
+            }
             // Server doesn't support SSE — fall back to non-streaming
             let resp = client.generate(req).await?;
             send_result_edit(&reply_handle, ctx, &resp, &prompt).await?;
@@ -232,6 +242,29 @@ mod tests {
             seed_used: 7,
             gpu: None,
         }
+    }
+
+    #[test]
+    fn h3_generation_never_reuses_one_use_authority_on_the_blocking_fallback() {
+        let req = crate::commands::generate::build_generate_request(
+            crate::commands::generate::BuildParams {
+                prompt: "animate",
+                model: mold_core::minimax_h3::REF2VA_COMFY,
+                family: Some(mold_core::minimax_h3::FAMILY),
+                ..Default::default()
+            },
+        );
+        assert!(requires_secure_generation_stream(&req));
+
+        let ordinary = crate::commands::generate::build_generate_request(
+            crate::commands::generate::BuildParams {
+                prompt: "cat",
+                model: "flux-schnell:q8",
+                family: Some("flux"),
+                ..Default::default()
+            },
+        );
+        assert!(!requires_secure_generation_stream(&ordinary));
     }
 
     #[test]

--- a/crates/mold-discord/src/lib.rs
+++ b/crates/mold-discord/src/lib.rs
@@ -3,6 +3,7 @@ pub mod checks;
 pub mod commands;
 pub mod cooldown;
 pub mod format;
+mod h3_references;
 pub mod handler;
 pub mod quota;
 pub mod state;

--- a/crates/mold-inference/src/ltx2/media.rs
+++ b/crates/mold-inference/src/ltx2/media.rs
@@ -4,7 +4,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use image::{GenericImage, Rgb, RgbImage};
 use mold_core::OutputFormat;
 use std::fs;
-use std::io::{BufReader, Cursor, Read, Seek};
+use std::io::{BufReader, Cursor, Read, Seek, SeekFrom, Write};
 use std::path::Path;
 
 use mp4_rs::{
@@ -54,6 +54,25 @@ pub fn probe_decoded_mp4_audio_file(path: &Path) -> Result<Option<DecodedAudioPr
         samples_per_channel: u64::try_from(decoded.sample_count())
             .context("decoded reference audio sample count exceeded u64")?,
     }))
+}
+
+/// Decode the exact soundtrack authority from an already-open regular file.
+///
+/// TUI reference ingestion opens with no-follow semantics before probing. Keep
+/// that file descriptor authoritative by copying its bytes into private
+/// temporary storage instead of reopening the user-controlled pathname.
+pub fn probe_decoded_mp4_audio_open_file(mut file: fs::File) -> Result<Option<DecodedAudioProbe>> {
+    file.seek(SeekFrom::Start(0))
+        .context("failed to rewind the open MP4 reference")?;
+    let mut staged = tempfile::NamedTempFile::new()
+        .context("failed to create private MP4 audio-probe storage")?;
+    std::io::copy(&mut file, staged.as_file_mut())
+        .context("failed to stage the open MP4 reference for audio probing")?;
+    staged
+        .as_file_mut()
+        .flush()
+        .context("failed to flush the staged MP4 reference")?;
+    probe_decoded_mp4_audio_file(staged.path())
 }
 
 #[derive(Debug)]

--- a/crates/mold-tui/Cargo.toml
+++ b/crates/mold-tui/Cargo.toml
@@ -29,6 +29,7 @@ image = "0.25"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+sha2 = "0.10"
 anyhow = "1"
 tracing = "0.1"
 rand = "0.8"

--- a/crates/mold-tui/src/app.rs
+++ b/crates/mold-tui/src/app.rs
@@ -6269,10 +6269,24 @@ impl App {
             }
             self.target.clone()
         } else {
-            let Some(snapshot) = self.generate.params.prepared_transform_snapshot.as_ref() else {
+            let Some(snapshot) = self.generate.params.prepared_transform_snapshot.clone() else {
                 self.generate.error_message =
                     Some("Prepared Remix lost its frozen route; remix again".into());
                 return;
+            };
+            let current_reference_fingerprint = if self.generate.params.model == snapshot.model
+                && self.target == snapshot.target
+                && self.prompt_transform_task() == snapshot.task
+            {
+                match self.reference_fingerprint_for_target(&self.target) {
+                    Ok(fingerprint) => Some(fingerprint),
+                    Err(error) => {
+                        self.generate.error_message = Some(error);
+                        return;
+                    }
+                }
+            } else {
+                None
             };
             let stale_reason = if self.generate.params.model != snapshot.model {
                 Some("model changed")
@@ -6280,9 +6294,8 @@ impl App {
                 Some("generation target changed")
             } else if self.prompt_transform_task() != snapshot.task {
                 Some("conditioning task changed")
-            } else if crate::h3_references::authority_fingerprint(
-                &self.generate.params.reference_paths,
-            ) != snapshot.reference_fingerprint
+            } else if current_reference_fingerprint.as_deref()
+                != Some(snapshot.reference_fingerprint.as_str())
             {
                 Some("ordered references changed")
             } else if self.generate.params.prepared_prompts.len()
@@ -6310,7 +6323,7 @@ impl App {
                 ));
                 return;
             }
-            snapshot.target.clone()
+            snapshot.target
         };
 
         // Route by the frozen prepared target or the current sticky Machines target. Auto keeps
@@ -6324,7 +6337,11 @@ impl App {
         let mut route_name = None;
         let mut api_key = None;
         match &generation_target {
-            GenTarget::Auto => {}
+            GenTarget::Auto => {
+                api_key = std::env::var("MOLD_API_KEY")
+                    .ok()
+                    .filter(|key| !key.is_empty());
+            }
             GenTarget::Local if h3_task.is_some() => {
                 self.generate.error_message = Some(format!(
                     "MiniMax H3 has no in-process TUI runtime. Select an authorized mold server. {}",
@@ -6434,6 +6451,48 @@ impl App {
         )
     }
 
+    /// Hash ordered reference content only after the selected route proves it
+    /// has a syntactically valid API-key header. This keeps transform
+    /// staleness exact without letting UI snapshotting read media before the
+    /// same authentication precondition used by upload binding.
+    fn reference_fingerprint_for_target(
+        &self,
+        target: &crate::hosts::GenTarget,
+    ) -> std::result::Result<String, String> {
+        let references = &self.generate.params.reference_paths;
+        if references.is_empty() {
+            return crate::h3_references::authority_fingerprint(None, references)
+                .map_err(|error| error.to_string());
+        }
+
+        use crate::hosts::GenTarget;
+        let (url, api_key) = match target {
+            GenTarget::Host(id) => {
+                let entry = self.machines.registry.get(id).ok_or_else(|| {
+                    format!("Machine '{id}' is no longer saved. Pick a target in Machines (4).")
+                })?;
+                (entry.url.clone(), crate::hosts::api_key_for(id))
+            }
+            GenTarget::Auto => {
+                let url = self.server_url.clone().ok_or_else(|| {
+                    "MiniMax H3 references require an authorized remote Mold target".to_string()
+                })?;
+                let api_key = std::env::var("MOLD_API_KEY")
+                    .ok()
+                    .filter(|key| !key.is_empty());
+                (url, api_key)
+            }
+            GenTarget::Local => {
+                return Err(
+                    "MiniMax H3 references require an authorized remote Mold target".to_string(),
+                );
+            }
+        };
+        let client = crate::hosts::client_for(&url, api_key.as_deref());
+        crate::h3_references::authority_fingerprint(Some(&client), references)
+            .map_err(|error| error.to_string())
+    }
+
     fn start_prompt_transform(&mut self, operation: PromptTransformOperation) {
         if !self.generate.params.reference_paths.is_empty()
             && operation == PromptTransformOperation::Remix
@@ -6494,14 +6553,19 @@ impl App {
             .filter(|root| !root.trim().is_empty());
         let family = family_for_model(&self.generate.params.model, &self.config);
         let task = self.prompt_transform_task();
+        let reference_fingerprint = match self.reference_fingerprint_for_target(&self.target) {
+            Ok(fingerprint) => fingerprint,
+            Err(error) => {
+                self.generate.error_message = Some(error);
+                return;
+            }
+        };
         let snapshot = PromptTransformSnapshot {
             operation,
             model: self.generate.params.model.clone(),
             target: self.target.clone(),
             task,
-            reference_fingerprint: crate::h3_references::authority_fingerprint(
-                &self.generate.params.reference_paths,
-            ),
+            reference_fingerprint,
             source_prompt: source_prompt.clone(),
             current_prompt,
             root_prompt: root.clone(),
@@ -6534,7 +6598,12 @@ impl App {
                 }
             },
             GenTarget::Local => (None, None),
-            GenTarget::Auto => (self.server_url.clone(), None),
+            GenTarget::Auto => (
+                self.server_url.clone(),
+                std::env::var("MOLD_API_KEY")
+                    .ok()
+                    .filter(|key| !key.is_empty()),
+            ),
         };
         self.generate.prompt_transform_token = self.generate.prompt_transform_token.wrapping_add(1);
         let token = self.generate.prompt_transform_token;
@@ -6576,9 +6645,11 @@ impl App {
                 "Remix is stale because the conditioning task changed; remix again".into(),
             );
         }
-        if crate::h3_references::authority_fingerprint(&self.generate.params.reference_paths)
-            != snapshot.reference_fingerprint
-        {
+        let reference_fingerprint = match self.reference_fingerprint_for_target(&self.target) {
+            Ok(fingerprint) => fingerprint,
+            Err(error) => return Some(error),
+        };
+        if reference_fingerprint != snapshot.reference_fingerprint {
             return Some(
                 "Remix is stale because the ordered references changed; remix again".into(),
             );
@@ -6596,27 +6667,26 @@ impl App {
     /// Validate reviewed Batch-1 semantics while deliberately ignoring the
     /// snapshotted host. Quick work may be submitted on the current target;
     /// prepared Batch N remains route-frozen in `start_generation`.
-    fn quick_transform_staleness(
-        &self,
-        snapshot: &PromptTransformSnapshot,
-    ) -> Option<&'static str> {
+    fn quick_transform_staleness(&self, snapshot: &PromptTransformSnapshot) -> Option<String> {
         if self.generate.params.model != snapshot.model {
-            return Some("model changed");
+            return Some("model changed".into());
         }
         if self.prompt_transform_task() != snapshot.task {
-            return Some("conditioning task changed");
+            return Some("conditioning task changed".into());
         }
-        if crate::h3_references::authority_fingerprint(&self.generate.params.reference_paths)
-            != snapshot.reference_fingerprint
-        {
-            return Some("ordered references changed");
+        let reference_fingerprint = match self.reference_fingerprint_for_target(&self.target) {
+            Ok(fingerprint) => fingerprint,
+            Err(error) => return Some(error),
+        };
+        if reference_fingerprint != snapshot.reference_fingerprint {
+            return Some("ordered references changed".into());
         }
         let current = self.generate.prompt.lines().join("\n").trim().to_string();
         if current != snapshot.current_prompt {
-            return Some("reviewed prompt changed");
+            return Some("reviewed prompt changed".into());
         }
         let Some(provenance) = self.generate.params.prompt_transform.as_ref() else {
-            return Some("transform provenance changed");
+            return Some("transform provenance changed".into());
         };
         if provenance.operation != snapshot.operation
             || provenance.source_prompt != snapshot.source_prompt
@@ -6624,7 +6694,7 @@ impl App {
             || provenance.source_kind != snapshot.source_kind
             || provenance.task != snapshot.task
         {
-            return Some("transform provenance changed");
+            return Some("transform provenance changed".into());
         }
         None
     }
@@ -14680,8 +14750,10 @@ mod tests {
             target: crate::hosts::GenTarget::Auto,
             task: app.prompt_transform_task(),
             reference_fingerprint: crate::h3_references::authority_fingerprint(
+                None,
                 &app.generate.params.reference_paths,
-            ),
+            )
+            .unwrap(),
             source_prompt: "source idea".into(),
             current_prompt: "source idea".into(),
             root_prompt: None,
@@ -14714,45 +14786,52 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial(mold_env)]
     async fn transform_snapshot_names_model_prompt_and_reference_staleness() {
-        let mut app = make_settings_test_app();
-        app.set_prompt_text("frozen prompt");
-        app.generate
-            .params
-            .reference_paths
-            .push(crate::h3_references::ReferencePath {
-                kind: crate::h3_references::ReferenceKind::Image,
-                path: "/tmp/first.png".into(),
-            });
-        let snapshot = PromptTransformSnapshot {
-            operation: PromptTransformOperation::Remix,
-            model: app.generate.params.model.clone(),
-            target: app.target.clone(),
-            task: app.prompt_transform_task(),
-            reference_fingerprint: crate::h3_references::authority_fingerprint(
-                &app.generate.params.reference_paths,
-            ),
-            source_prompt: "frozen prompt".into(),
-            current_prompt: "frozen prompt".into(),
-            root_prompt: None,
-            source_kind: mold_core::RemixSourceKind::Direct,
-        };
-        app.generate.params.model = "different-model".into();
-        assert!(app
-            .prompt_transform_staleness(&snapshot)
-            .is_some_and(|message| message.contains("model changed")));
+        crate::test_env::with_isolated_env(|_home| {
+            let mut app = make_settings_test_app();
+            app.machines
+                .registry
+                .add(machines_test_host("reference-host"))
+                .unwrap();
+            crate::hosts::save_api_key("reference-host", "sekrit");
+            app.target = crate::hosts::GenTarget::Host("reference-host".into());
+            app.set_prompt_text("frozen prompt");
+            app.generate
+                .params
+                .reference_paths
+                .push(crate::h3_references::ReferencePath {
+                    kind: crate::h3_references::ReferenceKind::Image,
+                    path: "/tmp/first.png".into(),
+                });
+            let snapshot = PromptTransformSnapshot {
+                operation: PromptTransformOperation::Remix,
+                model: app.generate.params.model.clone(),
+                target: app.target.clone(),
+                task: app.prompt_transform_task(),
+                reference_fingerprint: app.reference_fingerprint_for_target(&app.target).unwrap(),
+                source_prompt: "frozen prompt".into(),
+                current_prompt: "frozen prompt".into(),
+                root_prompt: None,
+                source_kind: mold_core::RemixSourceKind::Direct,
+            };
+            app.generate.params.model = "different-model".into();
+            assert!(app
+                .prompt_transform_staleness(&snapshot)
+                .is_some_and(|message| message.contains("model changed")));
 
-        app.generate.params.model = snapshot.model.clone();
-        app.set_prompt_text("edited prompt");
-        assert!(app
-            .prompt_transform_staleness(&snapshot)
-            .is_some_and(|message| message.contains("current prompt changed")));
+            app.generate.params.model = snapshot.model.clone();
+            app.set_prompt_text("edited prompt");
+            assert!(app
+                .prompt_transform_staleness(&snapshot)
+                .is_some_and(|message| message.contains("current prompt changed")));
 
-        app.set_prompt_text("frozen prompt");
-        app.generate.params.reference_paths[0].path = "/tmp/replacement.png".into();
-        assert!(app
-            .prompt_transform_staleness(&snapshot)
-            .is_some_and(|message| message.contains("ordered references changed")));
+            app.set_prompt_text("frozen prompt");
+            app.generate.params.reference_paths[0].path = "/tmp/replacement.png".into();
+            assert!(app
+                .prompt_transform_staleness(&snapshot)
+                .is_some_and(|message| message.contains("ordered references changed")));
+        });
     }
 
     #[tokio::test]
@@ -14787,8 +14866,10 @@ mod tests {
             target: crate::hosts::GenTarget::Auto,
             task: app.prompt_transform_task(),
             reference_fingerprint: crate::h3_references::authority_fingerprint(
+                None,
                 &app.generate.params.reference_paths,
-            ),
+            )
+            .unwrap(),
             source_prompt: "source idea".into(),
             current_prompt: "source idea".into(),
             root_prompt: None,

--- a/crates/mold-tui/src/app.rs
+++ b/crates/mold-tui/src/app.rs
@@ -966,16 +966,73 @@ fn parse_stg_blocks_input(input: &str) -> std::result::Result<Option<Vec<u32>>, 
 }
 
 /// Mirror `/api/models`' requestable video grid for the TUI's keyboard sliders.
-/// Tuple fields are `(step, runtime_seconds, absolute_frames, fixed_frames)`.
-fn tui_max_video_frames(grid: (u32, Option<u32>, Option<u32>, u32), fps: u32) -> u32 {
-    let (step, runtime_seconds, absolute_frames, fixed_frames) = grid;
-    let cap = if let Some(seconds) = runtime_seconds {
+#[derive(Debug, Clone, Copy)]
+struct TuiVideoGrid {
+    step: u32,
+    offset: u32,
+    min_frames: u32,
+    fixed_fps: Option<u32>,
+    runtime_seconds: Option<u32>,
+    absolute_frames: Option<u32>,
+    fixed_frames: u32,
+}
+
+impl TuiVideoGrid {
+    fn snap_nearest(self, target: u32) -> u32 {
+        if target <= self.offset {
+            return self.offset;
+        }
+        ((target - self.offset + self.step / 2) / self.step)
+            .saturating_mul(self.step)
+            .saturating_add(self.offset)
+    }
+}
+
+fn tui_max_video_frames(grid: TuiVideoGrid, fps: u32) -> u32 {
+    let cap = if let Some(seconds) = grid.runtime_seconds {
         let duration_cap = seconds.saturating_mul(fps.max(1)).saturating_add(4);
-        absolute_frames.map_or(duration_cap, |absolute| duration_cap.min(absolute))
+        grid.absolute_frames
+            .map_or(duration_cap, |absolute| duration_cap.min(absolute))
     } else {
-        fixed_frames
+        grid.fixed_frames
     };
-    cap.saturating_sub(cap.saturating_sub(1) % step).max(1)
+    if cap < grid.offset {
+        return cap;
+    }
+    cap - (cap - grid.offset) % grid.step
+}
+
+/// Repair every legacy/shared TUI field that H3 fixes or does not consume.
+///
+/// This is deliberately applied after persistence/default overlays and again
+/// at submit time. Hidden controls are presentation only; this function is the
+/// request-authority boundary that prevents stale state from weakening H3's
+/// synchronized AV contract. It does not activate the compliance-gated family.
+pub(crate) fn normalize_generate_params_for_family(params: &mut GenerateParams, family: &str) {
+    if !mold_core::minimax_h3::is_family(family) {
+        return;
+    }
+
+    params.frames = mold_core::minimax_h3::recommended_frames(params.frames);
+    params.fps = mold_core::minimax_h3::FIXED_FPS;
+    params.format = OutputFormat::Mp4;
+    params.enable_audio = Some(true);
+    params.guidance = 0.0;
+    params.strength = 1.0;
+
+    params.scheduler = None;
+    params.lora_path = None;
+    params.lora_scale = 1.0;
+    params.source_image_path = None;
+    params.mask_image_path = None;
+    params.control_image_path = None;
+    params.control_model = None;
+    params.control_scale = 1.0;
+    params.pipeline = None;
+    params.spatial_upscale = None;
+    params.temporal_upscale = None;
+    params.guidance_overrides = Ltx2GuidanceOverrides::default();
+    params.upscale_model = None;
 }
 
 /// State for the Generate view.
@@ -1786,6 +1843,7 @@ impl App {
         }
 
         let family = family_for_model(&params.model, &config);
+        normalize_generate_params_for_family(&mut params, &family);
         let capabilities = capabilities_for_model(
             &family,
             &params.model,
@@ -2098,30 +2156,35 @@ impl App {
     /// model clears stale audio plus LTX-2 pipeline and latent-upscale overrides
     /// before they can leak into another family.
     fn sync_generate_capabilities(&mut self) {
-        let model = &self.generate.params.model;
-        let family = family_for_model(model, &self.config);
+        let model = self.generate.params.model.clone();
+        let family = family_for_model(&model, &self.config);
         let advertised_audio_support = self
             .models
             .catalog
             .iter()
-            .find(|entry| entry.name == *model)
+            .find(|entry| entry.name == model)
             .and_then(|entry| entry.supports_audio);
         let advertised_guidance = self
             .models
             .catalog
             .iter()
-            .find(|entry| entry.name == *model)
+            .find(|entry| entry.name == model)
             .and_then(|entry| entry.guidance_capabilities);
         let effective_guidance = self
             .generate
             .params
             .pipeline
             .map(|pipeline| {
-                mold_core::GuidanceCapabilities::for_recipe(&family, model, Some(pipeline))
+                mold_core::GuidanceCapabilities::for_recipe(&family, &model, Some(pipeline))
             })
             .or(advertised_guidance);
-        self.generate.capabilities =
-            capabilities_for_model(&family, model, advertised_audio_support, effective_guidance);
+        self.generate.capabilities = capabilities_for_model(
+            &family,
+            &model,
+            advertised_audio_support,
+            effective_guidance,
+        );
+        normalize_generate_params_for_family(&mut self.generate.params, &family);
         if !self.generate.capabilities.supports_audio {
             self.generate.params.enable_audio = None;
         }
@@ -2523,14 +2586,16 @@ impl App {
                 }
             }
         }
-        self.sync_generate_capabilities();
-        self.generate.param_index = 0;
-
         // Apply saved per-model prefs last, so a user's explicit choices
         // override the manifest/catalog defaults we just restored. Only
         // generation params move — the prompt textareas stay as-is so a
         // model flip mid-typing doesn't wipe what the user is writing.
         self.apply_prefs_for_model(&model_name);
+        // Capabilities and family-fixed request fields are authoritative over
+        // persistence. In particular, an old H3 preference row may not
+        // restore PNG, CFG guidance, strength, or an off-grid frame count.
+        self.sync_generate_capabilities();
+        self.generate.param_index = 0;
     }
 
     /// Persist the *currently-displayed* generation params under `model`.
@@ -2614,10 +2679,7 @@ impl App {
             p.batch = b;
         }
         if let Some(ref f) = prefs.format {
-            p.format = match f.as_str() {
-                "jpeg" => mold_core::OutputFormat::Jpeg,
-                _ => mold_core::OutputFormat::Png,
-            };
+            p.format = f.parse().unwrap_or(mold_core::OutputFormat::Png);
         }
         if prefs.lora_path.is_some() {
             p.lora_path = prefs.lora_path.clone();
@@ -4357,23 +4419,32 @@ impl App {
                 .or_else(|| mold_core::validation::frame_step_for_family(&family))
                 .unwrap_or(8)
                 .max(1);
-            Some((
+            let offset = entry
+                .and_then(|entry| entry.defaults.frame_offset)
+                .or_else(|| mold_core::validation::frame_offset_for_family(&family))
+                .unwrap_or(1)
+                .max(1);
+            Some(TuiVideoGrid {
                 step,
-                entry
+                offset,
+                min_frames: mold_core::validation::min_frames_for_family(&family).unwrap_or(offset),
+                fixed_fps: mold_core::validation::fixed_fps_for_family(&family),
+                runtime_seconds: entry
                     .and_then(|entry| entry.defaults.max_runtime_seconds)
                     .or_else(|| mold_core::validation::max_runtime_seconds_for_family(&family)),
-                entry
+                absolute_frames: entry
                     .and_then(|entry| entry.defaults.max_frames_absolute)
                     .or_else(|| mold_core::validation::max_frames_absolute_for_family(&family)),
-                entry
+                fixed_frames: entry
                     .and_then(|entry| entry.defaults.max_frames)
                     .or_else(|| mold_core::validation::max_frames_for_family(&family))
                     .unwrap_or(257),
-            ))
+            })
         } else {
             None
         };
         let guidance_adjustable = self.generate.guidance_adjustable();
+        let audio_required = self.generate.capabilities.audio_required;
         let p = &mut self.generate.params;
         match field {
             ParamField::Size => {
@@ -4416,26 +4487,33 @@ impl App {
             }
             ParamField::Duration => {
                 let grid = video_grid.expect("duration has video grid");
-                let step = grid.0;
                 let fps = p.fps.max(1);
                 let seconds = (p.frames as f64 / fps as f64 + delta as f64).max(0.1);
                 let target = (seconds * fps as f64).round() as u32;
-                let snapped = ((target.saturating_sub(1) + step / 2) / step) * step + 1;
-                p.frames = snapped.min(tui_max_video_frames(grid, fps));
+                p.frames = grid
+                    .snap_nearest(target)
+                    .clamp(grid.min_frames, tui_max_video_frames(grid, fps));
             }
             ParamField::Strength => {
                 p.strength = (p.strength + delta as f64 * 0.05).clamp(0.0, 1.0);
             }
             ParamField::Frames => {
                 let grid = video_grid.expect("frames has video grid");
-                let step = grid.0;
-                p.frames = (p.frames as i64 + delta as i64 * step as i64)
-                    .clamp(1, tui_max_video_frames(grid, p.fps) as i64)
-                    as u32;
+                let current = grid
+                    .snap_nearest(p.frames)
+                    .clamp(grid.min_frames, tui_max_video_frames(grid, p.fps));
+                p.frames = (current as i64 + delta as i64 * grid.step as i64).clamp(
+                    i64::from(grid.min_frames),
+                    i64::from(tui_max_video_frames(grid, p.fps)),
+                ) as u32;
             }
             ParamField::Fps => {
-                p.fps = (p.fps as i32 + delta).clamp(1, 60) as u32;
                 let grid = video_grid.expect("fps has video grid");
+                if let Some(fixed_fps) = grid.fixed_fps {
+                    p.fps = fixed_fps;
+                    return;
+                }
+                p.fps = (p.fps as i32 + delta).clamp(1, 60) as u32;
                 p.frames = p.frames.min(tui_max_video_frames(grid, p.fps));
             }
             ParamField::Pipeline => {
@@ -4521,21 +4599,26 @@ impl App {
                 p.control_scale = (p.control_scale + delta as f64 * 0.1).clamp(0.0, 2.0);
             }
             ParamField::Format => {
-                p.format = match p.format {
-                    OutputFormat::Png => OutputFormat::Jpeg,
-                    OutputFormat::Jpeg => OutputFormat::Gif,
-                    OutputFormat::Gif => OutputFormat::Apng,
-                    OutputFormat::Apng => OutputFormat::Webp,
-                    OutputFormat::Webp => OutputFormat::Mp4,
-                    OutputFormat::Mp4 => OutputFormat::Png,
-                    // `wav` is not in the cycle: it is only valid for the
-                    // LTX-2 text-to-audio pipeline, which the Create form has
-                    // no control for. Cycling exits back to the raster start
-                    // rather than offering a format that would 422.
-                    OutputFormat::Wav => OutputFormat::Png,
-                };
-                if p.enable_audio == Some(true) && p.format != OutputFormat::Mp4 {
-                    p.enable_audio = None;
+                if audio_required {
+                    p.format = OutputFormat::Mp4;
+                    p.enable_audio = Some(true);
+                } else {
+                    p.format = match p.format {
+                        OutputFormat::Png => OutputFormat::Jpeg,
+                        OutputFormat::Jpeg => OutputFormat::Gif,
+                        OutputFormat::Gif => OutputFormat::Apng,
+                        OutputFormat::Apng => OutputFormat::Webp,
+                        OutputFormat::Webp => OutputFormat::Mp4,
+                        OutputFormat::Mp4 => OutputFormat::Png,
+                        // `wav` is not in the cycle: it is only valid for the
+                        // LTX-2 text-to-audio pipeline, which the Create form has
+                        // no control for. Cycling exits back to the raster start
+                        // rather than offering a format that would 422.
+                        OutputFormat::Wav => OutputFormat::Png,
+                    };
+                    if p.enable_audio == Some(true) && p.format != OutputFormat::Mp4 {
+                        p.enable_audio = None;
+                    }
                 }
             }
             ParamField::Expand => {
@@ -4743,6 +4826,7 @@ impl App {
         } else {
             self.generate.params.lora_path = None;
         }
+        self.sync_generate_capabilities();
 
         // Switch to Generate view
         self.active_view = View::Create;
@@ -6088,6 +6172,10 @@ impl App {
     }
 
     fn start_generation(&mut self) {
+        // Persistence, gallery reuse, and future call sites may all mutate the
+        // shared parameter bag without touching the visible rows. Reassert the
+        // selected family's request authority immediately before freezing it.
+        self.sync_generate_capabilities();
         let prompt_text = self.generate.prompt.lines().join("\n").trim().to_string();
         if prompt_text.is_empty() && prompt_required_for_params(&self.generate.params, &self.config)
         {
@@ -6190,7 +6278,12 @@ impl App {
             .join("\n")
             .trim()
             .to_string();
-        let negative_prompt = if neg.is_empty() { None } else { Some(neg) };
+        let negative_prompt =
+            if neg.is_empty() || !self.generate.capabilities.supports_negative_prompt {
+                None
+            } else {
+                Some(neg)
+            };
 
         // Resolve seed based on seed mode
         let resolved_seed = self
@@ -10868,11 +10961,48 @@ mod tests {
 
     #[test]
     fn video_duration_ceiling_tracks_fps_and_the_absolute_guard() {
-        let ltx2_grid = (8, Some(20), Some(604), 481);
+        let ltx2_grid = TuiVideoGrid {
+            step: 8,
+            offset: 1,
+            min_frames: 1,
+            fixed_fps: None,
+            runtime_seconds: Some(20),
+            absolute_frames: Some(604),
+            fixed_frames: 481,
+        };
         assert_eq!(tui_max_video_frames(ltx2_grid, 12), 241);
         assert_eq!(tui_max_video_frames(ltx2_grid, 24), 481);
         assert_eq!(tui_max_video_frames(ltx2_grid, 48), 601);
-        assert_eq!(tui_max_video_frames((8, None, None, 1), 24), 1);
+        assert_eq!(
+            tui_max_video_frames(
+                TuiVideoGrid {
+                    runtime_seconds: None,
+                    absolute_frames: None,
+                    fixed_frames: 1,
+                    ..ltx2_grid
+                },
+                24,
+            ),
+            1
+        );
+    }
+
+    #[test]
+    fn h3_video_grid_keeps_the_five_offset_and_fixed_fps() {
+        let h3_grid = TuiVideoGrid {
+            step: mold_core::minimax_h3::FRAME_STEP,
+            offset: mold_core::minimax_h3::FRAME_OFFSET,
+            min_frames: mold_core::minimax_h3::MIN_FRAMES,
+            fixed_fps: Some(mold_core::minimax_h3::FIXED_FPS),
+            runtime_seconds: Some(mold_core::minimax_h3::MAX_DURATION_SECONDS),
+            absolute_frames: Some(mold_core::minimax_h3::MAX_FRAMES),
+            fixed_frames: mold_core::minimax_h3::MAX_FRAMES,
+        };
+
+        assert_eq!(h3_grid.snap_nearest(120), 124);
+        assert_eq!(h3_grid.snap_nearest(240), 243);
+        assert_eq!(h3_grid.snap_nearest(360), 362);
+        assert_eq!(tui_max_video_frames(h3_grid, 24), 362);
     }
 
     #[tokio::test]
@@ -10937,6 +11067,154 @@ mod tests {
 
         app.dispatch_action(Action::Confirm);
         assert_eq!(app.generate.params.enable_audio, Some(true));
+    }
+
+    #[tokio::test]
+    async fn h3_capability_sync_freezes_mandatory_av_wire_defaults() {
+        use crate::ui::create_form::CreateRow;
+
+        let mut app = make_settings_test_app();
+        app.generate.params.model = mold_core::minimax_h3::FL2VA_COMFY.into();
+        app.generate.params.enable_audio = Some(false);
+        app.generate.params.format = OutputFormat::Gif;
+        app.generate.params.guidance = 7.5;
+        app.generate.params.strength = 0.25;
+        app.generate.params.frames = 25;
+        app.generate.params.fps = 30;
+        app.generate.params.scheduler = Some(Scheduler::Ddim);
+        app.generate.params.lora_path = Some("stale.safetensors".into());
+        app.generate.params.source_image_path = Some("stale.png".into());
+        app.generate.params.mask_image_path = Some("stale-mask.png".into());
+        app.generate.params.control_image_path = Some("stale-control.png".into());
+        app.generate.params.control_model = Some("stale-control".into());
+        app.config.models.insert(
+            app.generate.params.model.clone(),
+            mold_core::ModelConfig {
+                family: Some(mold_core::minimax_h3::FAMILY.into()),
+                ..Default::default()
+            },
+        );
+
+        app.sync_generate_capabilities();
+
+        assert!(app.generate.capabilities.audio_required);
+        assert_eq!(app.generate.params.enable_audio, Some(true));
+        assert_eq!(app.generate.params.format, OutputFormat::Mp4);
+        assert_eq!(app.generate.params.guidance, 0.0);
+        assert_eq!(app.generate.params.strength, 1.0);
+        assert_eq!(
+            app.generate.params.frames,
+            mold_core::minimax_h3::MIN_FRAMES
+        );
+        assert_eq!(app.generate.params.fps, mold_core::minimax_h3::FIXED_FPS);
+        assert_eq!(app.generate.params.scheduler, None);
+        assert_eq!(app.generate.params.lora_path, None);
+        assert_eq!(app.generate.params.source_image_path, None);
+        assert_eq!(app.generate.params.mask_image_path, None);
+        assert_eq!(app.generate.params.control_image_path, None);
+        assert_eq!(app.generate.params.control_model, None);
+        assert!(!app.generate.rows.iter().any(|row| matches!(
+            row,
+            CreateRow::Field(ParamField::Audio) | CreateRow::SectionField(_, ParamField::Audio)
+        )));
+
+        app.adjust_field(ParamField::Format, 1);
+        assert_eq!(app.generate.params.format, OutputFormat::Mp4);
+        assert_eq!(app.generate.params.enable_audio, Some(true));
+
+        app.generate.params.frames = mold_core::minimax_h3::MIN_FRAMES;
+        app.adjust_field(ParamField::Frames, -1);
+        assert_eq!(
+            app.generate.params.frames,
+            mold_core::minimax_h3::MIN_FRAMES
+        );
+        app.generate.params.fps = 12;
+        app.adjust_field(ParamField::Fps, 1);
+        assert_eq!(app.generate.params.fps, mold_core::minimax_h3::FIXED_FPS);
+
+        app.generate.params.frames = 25;
+        app.adjust_field(ParamField::Frames, 1);
+        assert_eq!(
+            app.generate.params.frames,
+            mold_core::minimax_h3::MIN_FRAMES + mold_core::minimax_h3::FRAME_STEP
+        );
+    }
+
+    #[test]
+    fn h3_boot_session_overlay_is_repaired_before_form_construction() {
+        let mut params = GenerateParams::from_config(&Config::default());
+        params.model = mold_core::minimax_h3::FL2VA_COMFY.into();
+        params.frames = 25;
+        params.fps = 30;
+        params.source_image_path = Some("stale.png".into());
+        let session = crate::session::TuiSession {
+            guidance: Some(7.5),
+            format: Some("png".into()),
+            scheduler: Some("ddim".into()),
+            lora_path: Some("stale.safetensors".into()),
+            strength: Some(0.25),
+            ..Default::default()
+        };
+
+        session.apply_to_params(&mut params);
+        normalize_generate_params_for_family(&mut params, "minimax_h3");
+
+        assert_eq!(params.frames, mold_core::minimax_h3::MIN_FRAMES);
+        assert_eq!(params.fps, mold_core::minimax_h3::FIXED_FPS);
+        assert_eq!(params.format, OutputFormat::Mp4);
+        assert_eq!(params.enable_audio, Some(true));
+        assert_eq!(params.guidance, 0.0);
+        assert_eq!(params.strength, 1.0);
+        assert_eq!(params.scheduler, None);
+        assert_eq!(params.lora_path, None);
+        assert_eq!(params.source_image_path, None);
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(mold_env)]
+    async fn h3_switch_away_and_back_cannot_restore_invalid_preferences() {
+        crate::test_env::with_isolated_env(|_home| {
+            let mut app = make_settings_test_app();
+            app.config.models.insert(
+                mold_core::minimax_h3::FL2VA_COMFY.into(),
+                mold_core::ModelConfig {
+                    family: Some("minimax_h3".into()),
+                    default_frames: Some(25),
+                    default_fps: Some(30),
+                    ..Default::default()
+                },
+            );
+            app.config.models.insert(
+                "flux-dev:q4".into(),
+                mold_core::ModelConfig {
+                    family: Some("flux".into()),
+                    ..Default::default()
+                },
+            );
+
+            app.update_model(mold_core::minimax_h3::FL2VA_COMFY);
+            app.generate.params.format = OutputFormat::Png;
+            app.generate.params.guidance = 7.5;
+            app.generate.params.strength = 0.25;
+            app.generate.params.scheduler = Some(Scheduler::Ddim);
+            app.generate.params.lora_path = Some("stale.safetensors".into());
+            app.generate.params.source_image_path = Some("stale.png".into());
+            app.update_model("flux-dev:q4");
+            app.update_model(mold_core::minimax_h3::FL2VA_COMFY);
+
+            assert_eq!(
+                app.generate.params.frames,
+                mold_core::minimax_h3::MIN_FRAMES
+            );
+            assert_eq!(app.generate.params.fps, mold_core::minimax_h3::FIXED_FPS);
+            assert_eq!(app.generate.params.format, OutputFormat::Mp4);
+            assert_eq!(app.generate.params.enable_audio, Some(true));
+            assert_eq!(app.generate.params.guidance, 0.0);
+            assert_eq!(app.generate.params.strength, 1.0);
+            assert_eq!(app.generate.params.scheduler, None);
+            assert_eq!(app.generate.params.lora_path, None);
+            assert_eq!(app.generate.params.source_image_path, None);
+        });
     }
 
     #[tokio::test]

--- a/crates/mold-tui/src/app.rs
+++ b/crates/mold-tui/src/app.rs
@@ -29,6 +29,8 @@ pub(crate) struct PromptTransformSnapshot {
     pub model: String,
     pub target: crate::hosts::GenTarget,
     pub task: mold_core::ExpandTask,
+    /// Ordered reference identity without retaining any filesystem path.
+    pub reference_fingerprint: String,
     pub source_prompt: String,
     pub current_prompt: String,
     pub root_prompt: Option<String>,
@@ -435,6 +437,7 @@ pub enum ParamField {
     Offload,
     // Advanced — Source
     SourceImage,
+    References,
     Strength,
     MaskImage,
     ControlImage,
@@ -475,6 +478,7 @@ impl ParamField {
             Self::Expand => "Expand prompt",
             Self::Offload => "Offload",
             Self::SourceImage => "Source",
+            Self::References => "References",
             Self::Strength => "Strength",
             Self::MaskImage => "Mask",
             Self::ControlImage => "Control",
@@ -619,6 +623,9 @@ pub struct GenerateParams {
     pub upscale_model: Option<String>,
     // img2img
     pub source_image_path: Option<String>,
+    /// Ordered H3 reference paths. This transient state is deliberately not
+    /// serialized; only basename + digest provenance crosses the wire.
+    pub reference_paths: Vec<crate::h3_references::ReferencePath>,
     pub strength: f64,
     pub mask_image_path: Option<String>,
     // Video
@@ -746,6 +753,7 @@ impl GenerateParams {
             offload: false,
             upscale_model: None,
             source_image_path: None,
+            reference_paths: Vec::new(),
             strength: 0.75,
             mask_image_path: None,
             frames: 25,
@@ -818,6 +826,11 @@ impl GenerateParams {
                         .unwrap_or_else(|| p.to_string())
                 })
                 .unwrap_or_else(|| "\u{27e8}none\u{27e9}".to_string()),
+            ParamField::References => match self.reference_paths.len() {
+                0 => "\u{27e8}none\u{27e9}".to_string(),
+                1 => "1 ordered file".to_string(),
+                count => format!("{count} ordered files"),
+            },
             ParamField::Strength => format!("{:.2}", self.strength),
             ParamField::MaskImage => self
                 .mask_image_path
@@ -1534,6 +1547,11 @@ pub enum Popup {
         input: String,
         error: Option<String>,
     },
+    /// Ordered `kind=path` MiniMax H3 reference input. Paths remain transient.
+    ReferencesInput {
+        input: String,
+        error: Option<String>,
+    },
     HistorySearch {
         filter: String,
         selected: usize,
@@ -2187,6 +2205,9 @@ impl App {
         normalize_generate_params_for_family(&mut self.generate.params, &family);
         if !self.generate.capabilities.supports_audio {
             self.generate.params.enable_audio = None;
+        }
+        if !self.generate.capabilities.supports_references {
+            self.generate.params.reference_paths.clear();
         }
         if !self.generate.capabilities.supports_video_upscale {
             self.generate.params.pipeline = None;
@@ -3244,6 +3265,28 @@ impl App {
                         Err(message) => *error = Some(message),
                     },
                     KeyCode::Char(c) if c.is_ascii_digit() || matches!(c, ',' | ' ') => {
+                        input.push(c);
+                        *error = None;
+                    }
+                    KeyCode::Backspace => {
+                        input.pop();
+                        *error = None;
+                    }
+                    _ => {}
+                },
+                Some(Popup::ReferencesInput { input, error }) => match key.code {
+                    KeyCode::Esc => self.close_popup(),
+                    KeyCode::Enter => match crate::h3_references::parse_reference_input(input) {
+                        Ok(references) => {
+                            self.generate.params.reference_paths = references;
+                            self.close_popup();
+                        }
+                        Err(message) => *error = Some(message),
+                    },
+                    KeyCode::Char(c)
+                        if input.len() + c.len_utf8()
+                            <= crate::h3_references::MAX_REFERENCE_INPUT_BYTES =>
+                    {
                         input.push(c);
                         *error = None;
                     }
@@ -4636,6 +4679,7 @@ impl App {
             | ParamField::Lora
             | ParamField::StgBlocks
             | ParamField::SourceImage
+            | ParamField::References
             | ParamField::MaskImage
             | ParamField::ControlImage
             | ParamField::ControlModel => {}
@@ -5210,6 +5254,12 @@ impl App {
                     .unwrap_or_default();
                 self.popup = Some(Popup::StgBlocksInput { input, error: None });
             }
+            ParamField::References => {
+                let input = crate::h3_references::format_reference_input(
+                    &self.generate.params.reference_paths,
+                );
+                self.popup = Some(Popup::ReferencesInput { input, error: None });
+            }
             // Cycle format
             ParamField::Format => self.adjust_field(ParamField::Format, 1),
             // Cycle scheduler
@@ -5302,6 +5352,7 @@ impl App {
         self.generate.params.guidance_overrides = Ltx2GuidanceOverrides::default();
         self.generate.params.strength = 0.75;
         self.generate.params.source_image_path = None;
+        self.generate.params.reference_paths.clear();
         self.generate.params.mask_image_path = None;
         self.generate.params.control_image_path = None;
         self.generate.params.control_model = None;
@@ -6182,6 +6233,30 @@ impl App {
             self.generate.error_message = Some("Prompt is empty".to_string());
             return;
         }
+        let h3_task = mold_core::minimax_h3::task_for_model(&self.generate.params.model);
+        if h3_task == Some(mold_core::minimax_h3::Task::Ref2va) {
+            if self.generate.params.reference_paths.is_empty() {
+                self.generate.error_message = Some(
+                    "MiniMax H3 Ref2VA requires at least one ordered image or video reference"
+                        .to_string(),
+                );
+                return;
+            }
+            if self.generate.params.batch != 1 || !self.generate.params.prepared_prompts.is_empty()
+            {
+                self.generate.error_message = Some(
+                    "MiniMax H3 ordered references require Batch 1; submit each attempt separately"
+                        .to_string(),
+                );
+                return;
+            }
+        } else if !self.generate.params.reference_paths.is_empty() {
+            self.generate.error_message = Some(
+                "Ordered references require an explicitly authorized MiniMax H3 Ref2VA model"
+                    .to_string(),
+            );
+            return;
+        }
 
         let generation_target = if self.generate.params.prepared_prompts.is_empty() {
             if let Some(snapshot) = self.generate.params.quick_transform_snapshot.as_ref() {
@@ -6205,6 +6280,11 @@ impl App {
                 Some("generation target changed")
             } else if self.prompt_transform_task() != snapshot.task {
                 Some("conditioning task changed")
+            } else if crate::h3_references::authority_fingerprint(
+                &self.generate.params.reference_paths,
+            ) != snapshot.reference_fingerprint
+            {
+                Some("ordered references changed")
             } else if self.generate.params.prepared_prompts.len()
                 != self.generate.params.prepared_prompt_transforms.len()
                 || self
@@ -6245,6 +6325,13 @@ impl App {
         let mut api_key = None;
         match &generation_target {
             GenTarget::Auto => {}
+            GenTarget::Local if h3_task.is_some() => {
+                self.generate.error_message = Some(format!(
+                    "MiniMax H3 has no in-process TUI runtime. Select an authorized mold server. {}",
+                    mold_core::MINIMAX_H3_AUTHORIZATION_REQUIRED
+                ));
+                return;
+            }
             GenTarget::Local => route_mode = Some(InferenceMode::Local),
             GenTarget::Host(id) => match self.machines.registry.get(id) {
                 Some(entry) => {
@@ -6332,6 +6419,9 @@ impl App {
     }
 
     fn prompt_transform_task(&self) -> mold_core::ExpandTask {
+        if !self.generate.params.reference_paths.is_empty() {
+            return mold_core::ExpandTask::ReferenceToAudioVideo;
+        }
         let family = family_for_model(&self.generate.params.model, &self.config);
         mold_core::ExpandTask::for_conditioning(
             &family,
@@ -6345,6 +6435,15 @@ impl App {
     }
 
     fn start_prompt_transform(&mut self, operation: PromptTransformOperation) {
+        if !self.generate.params.reference_paths.is_empty()
+            && operation == PromptTransformOperation::Remix
+        {
+            self.generate.error_message = Some(
+                "MiniMax H3 ordered references are Batch 1 only; use Expand for one reviewed prompt"
+                    .to_string(),
+            );
+            return;
+        }
         let current = self.generate.prompt.lines().join("\n").trim().to_string();
         if current.is_empty() {
             self.generate.error_message = Some("Prompt is empty".to_string());
@@ -6400,6 +6499,9 @@ impl App {
             model: self.generate.params.model.clone(),
             target: self.target.clone(),
             task,
+            reference_fingerprint: crate::h3_references::authority_fingerprint(
+                &self.generate.params.reference_paths,
+            ),
             source_prompt: source_prompt.clone(),
             current_prompt,
             root_prompt: root.clone(),
@@ -6474,6 +6576,13 @@ impl App {
                 "Remix is stale because the conditioning task changed; remix again".into(),
             );
         }
+        if crate::h3_references::authority_fingerprint(&self.generate.params.reference_paths)
+            != snapshot.reference_fingerprint
+        {
+            return Some(
+                "Remix is stale because the ordered references changed; remix again".into(),
+            );
+        }
         let current = self.generate.prompt.lines().join("\n").trim().to_string();
         if current != snapshot.current_prompt {
             return Some("Remix is stale because the current prompt changed; remix again".into());
@@ -6496,6 +6605,11 @@ impl App {
         }
         if self.prompt_transform_task() != snapshot.task {
             return Some("conditioning task changed");
+        }
+        if crate::h3_references::authority_fingerprint(&self.generate.params.reference_paths)
+            != snapshot.reference_fingerprint
+        {
+            return Some("ordered references changed");
         }
         let current = self.generate.prompt.lines().join("\n").trim().to_string();
         if current != snapshot.current_prompt {
@@ -14565,6 +14679,9 @@ mod tests {
             model: app.generate.params.model.clone(),
             target: crate::hosts::GenTarget::Auto,
             task: app.prompt_transform_task(),
+            reference_fingerprint: crate::h3_references::authority_fingerprint(
+                &app.generate.params.reference_paths,
+            ),
             source_prompt: "source idea".into(),
             current_prompt: "source idea".into(),
             root_prompt: None,
@@ -14597,14 +14714,24 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn transform_snapshot_names_model_and_prompt_staleness() {
+    async fn transform_snapshot_names_model_prompt_and_reference_staleness() {
         let mut app = make_settings_test_app();
         app.set_prompt_text("frozen prompt");
+        app.generate
+            .params
+            .reference_paths
+            .push(crate::h3_references::ReferencePath {
+                kind: crate::h3_references::ReferenceKind::Image,
+                path: "/tmp/first.png".into(),
+            });
         let snapshot = PromptTransformSnapshot {
             operation: PromptTransformOperation::Remix,
             model: app.generate.params.model.clone(),
             target: app.target.clone(),
             task: app.prompt_transform_task(),
+            reference_fingerprint: crate::h3_references::authority_fingerprint(
+                &app.generate.params.reference_paths,
+            ),
             source_prompt: "frozen prompt".into(),
             current_prompt: "frozen prompt".into(),
             root_prompt: None,
@@ -14620,6 +14747,34 @@ mod tests {
         assert!(app
             .prompt_transform_staleness(&snapshot)
             .is_some_and(|message| message.contains("current prompt changed")));
+
+        app.set_prompt_text("frozen prompt");
+        app.generate.params.reference_paths[0].path = "/tmp/replacement.png".into();
+        assert!(app
+            .prompt_transform_staleness(&snapshot)
+            .is_some_and(|message| message.contains("ordered references changed")));
+    }
+
+    #[tokio::test]
+    async fn h3_reference_remix_fails_before_creating_an_unusable_batch() {
+        let mut app = make_settings_test_app();
+        app.set_prompt_text("animate the anchor");
+        app.generate
+            .params
+            .reference_paths
+            .push(crate::h3_references::ReferencePath {
+                kind: crate::h3_references::ReferenceKind::Image,
+                path: "/tmp/anchor.png".into(),
+            });
+
+        app.start_prompt_transform(PromptTransformOperation::Remix);
+
+        assert!(app.popup.is_none());
+        assert!(app
+            .generate
+            .error_message
+            .as_deref()
+            .is_some_and(|message| message.contains("Batch 1")));
     }
 
     #[tokio::test]
@@ -14631,6 +14786,9 @@ mod tests {
             model: app.generate.params.model.clone(),
             target: crate::hosts::GenTarget::Auto,
             task: app.prompt_transform_task(),
+            reference_fingerprint: crate::h3_references::authority_fingerprint(
+                &app.generate.params.reference_paths,
+            ),
             source_prompt: "source idea".into(),
             current_prompt: "source idea".into(),
             root_prompt: None,

--- a/crates/mold-tui/src/backend.rs
+++ b/crates/mold-tui/src/backend.rs
@@ -167,6 +167,11 @@ pub async fn run_generation(
     api_key: Option<String>,
     tx: mpsc::UnboundedSender<BackgroundEvent>,
 ) {
+    // Canonicalize before batching and provenance capture so metadata/history
+    // describe the exact request that was sent, not hidden stale UI state.
+    let config = mold_core::Config::load_or_default();
+    let (params, negative_prompt) =
+        canonicalize_generation_authority(params, negative_prompt, &config);
     let prepared_prompts = params.prepared_prompts.clone();
     let prepared_transforms = params.prepared_prompt_transforms.clone();
     let batch = if prepared_prompts.is_empty() {
@@ -640,11 +645,30 @@ async fn run_local_generation(
     }
 }
 
+fn canonicalize_generation_authority(
+    mut params: GenerateParams,
+    mut negative_prompt: Option<String>,
+    config: &mold_core::Config,
+) -> (GenerateParams, Option<String>) {
+    let family = crate::model_info::family_for_model(&params.model, config);
+    crate::app::normalize_generate_params_for_family(&mut params, &family);
+    if mold_core::minimax_h3::is_family(&family) {
+        negative_prompt = None;
+    }
+    (params, negative_prompt)
+}
+
 fn build_request(
     params: &GenerateParams,
     prompt: &str,
     negative_prompt: &Option<String>,
 ) -> GenerateRequest {
+    let config = mold_core::Config::load_or_default();
+    let (normalized_params, normalized_negative_prompt) =
+        canonicalize_generation_authority(params.clone(), negative_prompt.clone(), &config);
+    let params = &normalized_params;
+    let family = crate::model_info::family_for_model(&params.model, &config);
+
     let lora = params.lora_path.as_ref().map(|path| LoraWeight {
         path: path.clone(),
         scale: params.lora_scale,
@@ -665,9 +689,6 @@ fn build_request(
         .as_ref()
         .and_then(|p| std::fs::read(p).ok());
 
-    let family = mold_core::manifest::find_manifest(&params.model)
-        .map(|m| m.family.as_str().to_string())
-        .unwrap_or_default();
     let (edit_images, source_image, strength, mask_image) = if family == "qwen-image-edit" {
         (
             source_image.clone().map(|image| vec![image]),
@@ -695,7 +716,7 @@ fn build_request(
         hdr_exr_full_float: false,
         guidance_overrides: params.guidance_overrides.clone().into_option(),
         prompt: prompt.to_string(),
-        negative_prompt: negative_prompt.clone(),
+        negative_prompt: normalized_negative_prompt,
         model: params.model.clone(),
         width: params.width,
         height: params.height,
@@ -704,7 +725,7 @@ fn build_request(
         seed: params.seed,
         batch_size: params.batch,
         output_format: Some(params.format),
-        embed_metadata: Some(mold_core::Config::load_or_default().effective_embed_metadata(None)),
+        embed_metadata: Some(config.effective_embed_metadata(None)),
         scheduler: params.scheduler,
         cfg_plus: None,
         edit_images,
@@ -1068,6 +1089,75 @@ mod tests {
             build_request(&params, "p", &None).guidance_overrides,
             Some(params.guidance_overrides.clone())
         );
+    }
+
+    #[test]
+    fn build_request_reasserts_h3_authority_over_stale_shared_fields() {
+        let config = mold_core::Config::load_or_default();
+        let mut params = GenerateParams::from_config(&config);
+        let readable_path = std::env::current_exe()
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+        params.model = mold_core::minimax_h3::FL2VA_COMFY.into();
+        params.frames = 25;
+        params.fps = 30;
+        params.format = mold_core::OutputFormat::Png;
+        params.enable_audio = Some(false);
+        params.guidance = 7.5;
+        params.strength = 0.25;
+        params.scheduler = Some(mold_core::Scheduler::Ddim);
+        params.lora_path = Some("stale.safetensors".into());
+        params.source_image_path = Some(readable_path.clone());
+        params.mask_image_path = Some(readable_path.clone());
+        params.control_image_path = Some(readable_path);
+        params.control_model = Some("stale-control".into());
+        params.pipeline = Some(mold_core::Ltx2PipelineMode::TwoStage);
+        params.spatial_upscale = Some(mold_core::Ltx2SpatialUpscale::X1_5);
+        params.temporal_upscale = Some(mold_core::Ltx2TemporalUpscale::X2);
+        params.guidance_overrides = mold_core::Ltx2GuidanceOverrides {
+            stg_scale: Some(1.5),
+            ..Default::default()
+        };
+        params.upscale_model = Some("stale-upscaler".into());
+
+        let (canonical_params, canonical_negative) = canonicalize_generation_authority(
+            params.clone(),
+            Some("stale negative".into()),
+            &config,
+        );
+        let snapshot = GenerationMetadataSnapshot::new(
+            canonical_params.clone(),
+            "p".into(),
+            canonical_negative.clone(),
+        );
+        let request = build_request(&canonical_params, "p", &canonical_negative);
+
+        assert_eq!(request.frames, Some(mold_core::minimax_h3::MIN_FRAMES));
+        assert_eq!(request.fps, Some(mold_core::minimax_h3::FIXED_FPS));
+        assert_eq!(request.output_format, Some(mold_core::OutputFormat::Mp4));
+        assert_eq!(request.enable_audio, Some(true));
+        assert_eq!(request.guidance, 0.0);
+        assert_eq!(request.strength, 1.0);
+        assert_eq!(request.negative_prompt, None);
+        assert_eq!(request.scheduler, None);
+        assert_eq!(request.lora, None);
+        assert_eq!(request.source_image, None);
+        assert_eq!(request.mask_image, None);
+        assert_eq!(request.control_image, None);
+        assert_eq!(request.control_model, None);
+        assert_eq!(request.pipeline, None);
+        assert_eq!(request.spatial_upscale, None);
+        assert_eq!(request.temporal_upscale, None);
+        assert_eq!(request.guidance_overrides, None);
+        assert_eq!(request.upscale_model, None);
+        assert_eq!(snapshot.negative_prompt, request.negative_prompt);
+        assert_eq!(snapshot.params.frames, request.frames.unwrap());
+        assert_eq!(snapshot.params.fps, request.fps.unwrap());
+        assert_eq!(Some(snapshot.params.format), request.output_format);
+        assert_eq!(snapshot.params.enable_audio, request.enable_audio);
+        assert_eq!(snapshot.params.guidance, request.guidance);
+        assert_eq!(snapshot.params.strength, request.strength);
     }
 
     #[test]

--- a/crates/mold-tui/src/backend.rs
+++ b/crates/mold-tui/src/backend.rs
@@ -255,12 +255,16 @@ pub async fn run_generation(
             if let Some(ref url) = effective_url {
                 let client = crate::hosts::client_for(url, api_key.as_deref());
                 let mut req = build_request(&iter_params, &iter_prompt, &negative_prompt);
-                let reference_session = if iter_params.reference_paths.is_empty() {
+                let mut reference_session = if iter_params.reference_paths.is_empty() {
                     None
                 } else {
                     let reference_paths = iter_params.reference_paths.clone();
+                    let reference_client = client.clone();
                     let prepared = match tokio::task::spawn_blocking(move || {
-                        crate::h3_references::prepare_references(&reference_paths)
+                        crate::h3_references::prepare_references(
+                            &reference_client,
+                            &reference_paths,
+                        )
                     })
                     .await
                     {
@@ -292,10 +296,12 @@ pub async fn run_generation(
                 };
 
                 let result = try_server_generate(&client, &req, &metadata_snapshot, &tx).await;
-                if !matches!(&result, ServerResult::Done) {
-                    if let Some(session) = reference_session {
-                        let _ = client.cancel_reference_upload_session(&session).await;
+                if matches!(&result, ServerResult::Done) {
+                    if let Some(lease) = reference_session.as_mut() {
+                        lease.mark_consumed();
                     }
+                } else if let Some(lease) = reference_session.as_mut() {
+                    let _ = lease.cancel().await;
                 }
                 match result {
                     ServerResult::Done => {}

--- a/crates/mold-tui/src/backend.rs
+++ b/crates/mold-tui/src/backend.rs
@@ -172,6 +172,24 @@ pub async fn run_generation(
     let config = mold_core::Config::load_or_default();
     let (params, negative_prompt) =
         canonicalize_generation_authority(params, negative_prompt, &config);
+    let h3_task = mold_core::minimax_h3::task_for_model(&params.model);
+    if h3_task == Some(mold_core::minimax_h3::Task::Ref2va)
+        && (params.reference_paths.is_empty()
+            || params.batch != 1
+            || !params.prepared_prompts.is_empty())
+    {
+        let _ = tx.send(BackgroundEvent::Error(
+            "MiniMax H3 ordered references require at least one reference and Batch 1".to_string(),
+        ));
+        return;
+    }
+    if h3_task != Some(mold_core::minimax_h3::Task::Ref2va) && !params.reference_paths.is_empty() {
+        let _ = tx.send(BackgroundEvent::Error(
+            "Ordered references require an explicitly authorized MiniMax H3 Ref2VA model"
+                .to_string(),
+        ));
+        return;
+    }
     let prepared_prompts = params.prepared_prompts.clone();
     let prepared_transforms = params.prepared_prompt_transforms.clone();
     let batch = if prepared_prompts.is_empty() {
@@ -218,7 +236,10 @@ pub async fn run_generation(
             negative_prompt.clone(),
         );
 
-        if iter_params.inference_mode == InferenceMode::Local {
+        if iter_params.inference_mode == InferenceMode::Local && h3_task.is_some() {
+            let _ = tx.send(BackgroundEvent::Error(h3_runtime_unavailable_message(None)));
+            return;
+        } else if iter_params.inference_mode == InferenceMode::Local {
             run_local_generation_single(
                 iter_params,
                 iter_prompt.clone(),
@@ -233,9 +254,50 @@ pub async fn run_generation(
             let mut fell_through = false;
             if let Some(ref url) = effective_url {
                 let client = crate::hosts::client_for(url, api_key.as_deref());
-                let req = build_request(&iter_params, &iter_prompt, &negative_prompt);
+                let mut req = build_request(&iter_params, &iter_prompt, &negative_prompt);
+                let reference_session = if iter_params.reference_paths.is_empty() {
+                    None
+                } else {
+                    let reference_paths = iter_params.reference_paths.clone();
+                    let prepared = match tokio::task::spawn_blocking(move || {
+                        crate::h3_references::prepare_references(&reference_paths)
+                    })
+                    .await
+                    {
+                        Ok(Ok(prepared)) => prepared,
+                        Ok(Err(error)) => {
+                            let _ = tx.send(BackgroundEvent::Error(format!(
+                                "MiniMax H3 reference preparation failed: {error}"
+                            )));
+                            return;
+                        }
+                        Err(error) => {
+                            let _ = tx.send(BackgroundEvent::Error(format!(
+                                "MiniMax H3 reference preparation task failed: {error}"
+                            )));
+                            return;
+                        }
+                    };
+                    match crate::h3_references::bind_remote_references(&client, &mut req, prepared)
+                        .await
+                    {
+                        Ok(session) => Some(session),
+                        Err(error) => {
+                            let _ = tx.send(BackgroundEvent::Error(format!(
+                                "MiniMax H3 reference authorization/upload failed: {error}"
+                            )));
+                            return;
+                        }
+                    }
+                };
 
-                match try_server_generate(&client, &req, &metadata_snapshot, &tx).await {
+                let result = try_server_generate(&client, &req, &metadata_snapshot, &tx).await;
+                if !matches!(&result, ServerResult::Done) {
+                    if let Some(session) = reference_session {
+                        let _ = client.cancel_reference_upload_session(&session).await;
+                    }
+                }
+                match result {
                     ServerResult::Done => {}
                     ServerResult::FallbackLocal => {
                         fell_through = true;
@@ -250,6 +312,12 @@ pub async fn run_generation(
             }
 
             if fell_through {
+                if h3_task.is_some() {
+                    let _ = tx.send(BackgroundEvent::Error(h3_runtime_unavailable_message(
+                        effective_url.as_deref(),
+                    )));
+                    return;
+                }
                 if iter_params.inference_mode == InferenceMode::Remote {
                     // An explicit target that's down is an error naming the
                     // host + a concrete fix — never a silent local fallback.
@@ -457,6 +525,21 @@ enum ServerResult {
     Error(String),
 }
 
+fn requires_secure_generation_stream(req: &GenerateRequest) -> bool {
+    mold_core::minimax_h3::task_for_model(&req.model).is_some()
+        || req.references.as_ref().is_some_and(|refs| !refs.is_empty())
+}
+
+fn h3_runtime_unavailable_message(url: Option<&str>) -> String {
+    let target = url
+        .map(|url| format!(" on {url}"))
+        .unwrap_or_else(|| " in the local TUI runtime".to_string());
+    format!(
+        "MiniMax H3 runtime is unavailable{target}; select a reachable, authorized mold server. {}",
+        mold_core::MINIMAX_H3_AUTHORIZATION_REQUIRED
+    )
+}
+
 /// Try generating via the server. If the server says the model isn't downloaded,
 /// auto-pull it and retry once.
 async fn try_server_generate(
@@ -465,6 +548,7 @@ async fn try_server_generate(
     metadata_snapshot: &GenerationMetadataSnapshot,
     tx: &mpsc::UnboundedSender<BackgroundEvent>,
 ) -> ServerResult {
+    let is_h3 = mold_core::minimax_h3::task_for_model(&req.model).is_some();
     let (progress_tx, mut progress_rx) = mpsc::unbounded_channel::<SseProgressEvent>();
 
     let tx_progress = tx.clone();
@@ -483,6 +567,10 @@ async fn try_server_generate(
             });
             ServerResult::Done
         }
+        Err(e) if is_h3 => ServerResult::Error(format!(
+            "MiniMax H3 runtime/authorization unavailable: {e} ({})",
+            mold_core::MINIMAX_H3_AUTHORIZATION_REQUIRED
+        )),
         Err(e) => match classify_generate_error(&e) {
             GenerateServerAction::FallbackLocal => ServerResult::FallbackLocal,
             GenerateServerAction::PullModelAndRetry => {
@@ -548,6 +636,11 @@ async fn try_server_generate_once(
 ) -> Result<GenerateResponse, anyhow::Error> {
     match client.generate_stream(req, progress_tx).await {
         Ok(Some(response)) => Ok(response),
+        Ok(None) if requires_secure_generation_stream(req) => {
+            anyhow::bail!(
+                "server lacks secure streaming generation required for one-use MiniMax H3 references; update the server"
+            )
+        }
         Ok(None) => {
             // Server doesn't support SSE — try blocking API
             client.generate(req.clone()).await
@@ -569,6 +662,10 @@ async fn run_local_generation(
 
     let mut config = Config::load_or_default();
     let model_name = params.model.clone();
+    if mold_core::minimax_h3::task_for_model(&model_name).is_some() {
+        let _ = tx.send(BackgroundEvent::Error(h3_runtime_unavailable_message(None)));
+        return;
+    }
 
     // Resolve model paths — auto-pull if not downloaded
     let model_paths = match ModelPaths::resolve(&model_name, &config) {
@@ -1158,6 +1255,7 @@ mod tests {
         assert_eq!(snapshot.params.enable_audio, request.enable_audio);
         assert_eq!(snapshot.params.guidance, request.guidance);
         assert_eq!(snapshot.params.strength, request.strength);
+        assert!(requires_secure_generation_stream(&request));
     }
 
     #[test]

--- a/crates/mold-tui/src/h3_references.rs
+++ b/crates/mold-tui/src/h3_references.rs
@@ -8,11 +8,10 @@
 use anyhow::{Context, Result};
 use mold_core::{
     minimax_h3, GenerateRequest, GenerationReference, GenerationReferenceAuthority,
-    GenerationReferenceProvenance, MoldClient, ReferenceUploadSessionRequest,
+    GenerationReferenceProvenance, MoldClient, ReferenceUploadLease, ReferenceUploadSource,
 };
 use sha2::{Digest, Sha256};
 use std::{
-    collections::HashSet,
     fs::File,
     io::{BufReader, Read, Seek, SeekFrom},
     path::{Path, PathBuf},
@@ -130,16 +129,38 @@ pub(crate) fn format_reference_input(references: &[ReferencePath]) -> String {
 
 /// Safe identity for conditioning staleness checks. The digest retains order
 /// and kind without putting local paths into prompt-transform snapshots/logs.
-pub(crate) fn authority_fingerprint(references: &[ReferencePath]) -> String {
+pub(crate) fn authority_fingerprint(
+    client: Option<&MoldClient>,
+    references: &[ReferencePath],
+) -> Result<String> {
+    if !references.is_empty() {
+        anyhow::ensure!(
+            client.is_some_and(MoldClient::has_api_key),
+            "MiniMax H3 reference inspection requires a configured, valid server API key"
+        );
+    }
     let mut digest = Sha256::new();
-    digest.update(b"mold.tui.minimax-h3.reference-paths.v1\0");
+    digest.update(b"mold.tui.minimax-h3.reference-content.v2\0");
     for reference in references {
         digest.update(reference.kind.label().as_bytes());
         digest.update(b"\0");
-        digest.update(reference.path.as_os_str().as_encoded_bytes());
+        match mold_core::secure_file::open_regular_file_no_follow(&reference.path)
+            .and_then(|file| mold_core::secure_file::sha256_open_file(&file))
+        {
+            Ok(content_sha256) => {
+                digest.update(b"content\0");
+                digest.update(content_sha256.as_bytes());
+            }
+            Err(_) => {
+                // An unavailable/no-follow-invalid path must still remain
+                // distinct without retaining it in the snapshot.
+                digest.update(b"unavailable\0");
+                digest.update(reference.path.as_os_str().as_encoded_bytes());
+            }
+        }
         digest.update(b"\0");
     }
-    format!("{:x}", digest.finalize())
+    Ok(format!("{:x}", digest.finalize()))
 }
 
 pub(crate) struct PreparedReferences {
@@ -162,19 +183,25 @@ impl std::fmt::Debug for PreparedReferences {
 
 struct ReferenceUpload {
     file: File,
-    mime_type: String,
 }
 
 /// Probe exact payload-free descriptors while retaining an already-open file
 /// descriptor for the subsequent upload. Server ingress probes the staged bytes
 /// independently and rejects any drift.
-pub(crate) fn prepare_references(inputs: &[ReferencePath]) -> Result<PreparedReferences> {
+pub(crate) fn prepare_references(
+    client: &MoldClient,
+    inputs: &[ReferencePath],
+) -> Result<PreparedReferences> {
+    anyhow::ensure!(
+        client.has_api_key(),
+        "MiniMax H3 reference preparation requires a configured, valid server API key"
+    );
     let mut descriptors = Vec::with_capacity(inputs.len());
     let mut uploads = Vec::with_capacity(inputs.len());
     let mut total_bytes = 0_u64;
     for (index, input) in inputs.iter().enumerate() {
-        let mut file = File::open(&input.path)
-            .with_context(|| format!("reference {} could not be opened", index + 1))?;
+        let mut file = mold_core::secure_file::open_regular_file_no_follow(&input.path)
+            .with_context(|| format!("reference {} could not be opened no-follow", index + 1))?;
         let metadata = file
             .metadata()
             .with_context(|| format!("reference {} could not be inspected", index + 1))?;
@@ -217,10 +244,7 @@ pub(crate) fn prepare_references(inputs: &[ReferencePath]) -> Result<PreparedRef
         .with_context(|| format!("reference {} media probe failed", index + 1))?;
         file.seek(SeekFrom::Start(0))
             .with_context(|| format!("reference {} could not be rewound", index + 1))?;
-        uploads.push(ReferenceUpload {
-            file,
-            mime_type: reference_mime_type(&descriptor).to_string(),
-        });
+        uploads.push(ReferenceUpload { file });
         descriptors.push(descriptor);
     }
     minimax_h3::validate_reference_descriptors(&descriptors).map_err(anyhow::Error::new)?;
@@ -236,7 +260,7 @@ pub(crate) async fn bind_remote_references(
     client: &MoldClient,
     request: &mut GenerateRequest,
     prepared: PreparedReferences,
-) -> Result<String> {
+) -> Result<ReferenceUploadLease> {
     let PreparedReferences {
         descriptors,
         uploads,
@@ -246,85 +270,14 @@ pub(crate) async fn bind_remote_references(
         "reference descriptor/file count mismatch"
     );
     minimax_h3::validate_reference_descriptors(&descriptors).map_err(anyhow::Error::new)?;
-    request.references = Some(descriptors.clone());
-    let upload_references = (1..=descriptors.len())
-        .map(|index| u32::try_from(index).context("too many reference uploads"))
+    request.references = Some(descriptors);
+    let sources = uploads
+        .into_iter()
+        .map(|upload| ReferenceUploadSource::open_file(upload.file))
         .collect::<Result<Vec<_>>>()?;
-    let session = client
-        .create_reference_upload_session(&ReferenceUploadSessionRequest {
-            request: request.clone(),
-            upload_references,
-        })
-        .await?;
-    if session.instance_id.trim().is_empty()
-        || session.expires_at_ms == 0
-        || !is_sha256_hex(&session.request_scope_sha256)
-        || !is_upload_handle(&session.session_handle)
-        || session.uploads.len() != descriptors.len()
-    {
-        let _ = client
-            .cancel_reference_upload_session(&session.session_handle)
-            .await;
-        anyhow::bail!("server returned an incomplete reference upload session");
-    }
-
-    let upload_result: Result<Vec<GenerationReference>> = async {
-        let mut bound = Vec::with_capacity(descriptors.len());
-        let mut seen_handles = HashSet::new();
-        for (index, (descriptor, upload)) in
-            descriptors.iter().zip(uploads).enumerate()
-        {
-            let reference = u32::try_from(index)
-                .context("too many reference uploads")?
-                .saturating_add(1);
-            let slot = session
-                .uploads
-                .iter()
-                .find(|slot| slot.reference == reference)
-                .ok_or_else(|| anyhow::anyhow!("server omitted reference upload slot {reference}"))?;
-            if !is_upload_handle(&slot.handle) || !seen_handles.insert(slot.handle.as_str()) {
-                anyhow::bail!("server returned an invalid or reused reference upload handle");
-            }
-            let completed = client
-                .upload_reference_open_file(&slot.handle, upload.file, &upload.mime_type)
-                .await
-                .with_context(|| format!("reference {reference} upload failed"))?;
-            if completed.instance_id != session.instance_id || completed.reference != reference {
-                anyhow::bail!(
-                    "reference {reference} upload response did not match its bound server session"
-                );
-            }
-            let expected = descriptor
-                .redacted_metadata(index)
-                .ok_or_else(|| anyhow::anyhow!("reference {reference} lost digest provenance"))?;
-            if completed.metadata != expected {
-                anyhow::bail!(
-                    "reference {reference} upload response drifted from the client-probed descriptor"
-                );
-            }
-            bound.push(with_authority(
-                descriptor,
-                GenerationReferenceAuthority::Upload {
-                    handle: slot.handle.clone(),
-                },
-            ));
-        }
-        Ok(bound)
-    }
-    .await;
-
-    match upload_result {
-        Ok(bound) => {
-            request.references = Some(bound);
-            Ok(session.session_handle)
-        }
-        Err(error) => {
-            let _ = client
-                .cancel_reference_upload_session(&session.session_handle)
-                .await;
-            Err(error)
-        }
-    }
+    let lease = client.bind_reference_uploads_v2(request, sources).await?;
+    *request = lease.request().clone();
+    Ok(lease)
 }
 
 fn sha256_file(mut file: File) -> Result<String> {
@@ -557,96 +510,13 @@ fn probe_wav(file: File) -> Result<WavProbe> {
     })
 }
 
-fn reference_mime_type(reference: &GenerationReference) -> &str {
-    match reference {
-        GenerationReference::Image { mime_type, .. }
-        | GenerationReference::Video { mime_type, .. }
-        | GenerationReference::Audio { mime_type, .. } => mime_type,
-    }
-}
-
-fn is_sha256_hex(value: &str) -> bool {
-    value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
-}
-
-fn is_upload_handle(value: &str) -> bool {
-    !value.is_empty()
-        && value.len() <= minimax_h3::MAX_REFERENCE_UPLOAD_HANDLE_BYTES
-        && value
-            .bytes()
-            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b':' | b'.'))
-}
-
-fn with_authority(
-    reference: &GenerationReference,
-    media: GenerationReferenceAuthority,
-) -> GenerationReference {
-    match reference {
-        GenerationReference::Image {
-            provenance,
-            mime_type,
-            width,
-            height,
-            ..
-        } => GenerationReference::Image {
-            media,
-            provenance: provenance.clone(),
-            mime_type: mime_type.clone(),
-            width: *width,
-            height: *height,
-        },
-        GenerationReference::Video {
-            provenance,
-            mime_type,
-            width,
-            height,
-            frame_count,
-            duration_ms,
-            fps,
-            has_audio,
-            audio_duration_ms,
-            audio_sample_count,
-            audio_sample_rate,
-            audio_channels,
-            ..
-        } => GenerationReference::Video {
-            media,
-            provenance: provenance.clone(),
-            mime_type: mime_type.clone(),
-            width: *width,
-            height: *height,
-            frame_count: *frame_count,
-            duration_ms: *duration_ms,
-            fps: *fps,
-            has_audio: *has_audio,
-            audio_duration_ms: *audio_duration_ms,
-            audio_sample_count: *audio_sample_count,
-            audio_sample_rate: *audio_sample_rate,
-            audio_channels: *audio_channels,
-        },
-        GenerationReference::Audio {
-            provenance,
-            mime_type,
-            duration_ms,
-            sample_rate,
-            channels,
-            sample_count,
-            ..
-        } => GenerationReference::Audio {
-            media,
-            provenance: provenance.clone(),
-            mime_type: mime_type.clone(),
-            duration_ms: *duration_ms,
-            sample_rate: *sample_rate,
-            channels: *channels,
-            sample_count: *sample_count,
-        },
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn authenticated_client() -> MoldClient {
+        MoldClient::with_api_key("http://127.0.0.1:9", "sekrit".into())
+    }
 
     fn wav_bytes(seconds: u32) -> Vec<u8> {
         let sample_rate = 8_000_u32;
@@ -684,7 +554,8 @@ mod tests {
             format_reference_input(&references),
             "video=/tmp/a=b.mp4; image=/tmp/frame.png; audio=/tmp/voice.wav"
         );
-        let fingerprint = authority_fingerprint(&references);
+        let client = authenticated_client();
+        let fingerprint = authority_fingerprint(Some(&client), &references).unwrap();
         assert_eq!(fingerprint.len(), 64);
         assert!(!fingerprint.contains("tmp"));
         assert!(!format!("{references:?}").contains("/tmp"));
@@ -710,7 +581,8 @@ mod tests {
                 path: audio_path.clone(),
             },
         ];
-        let prepared = prepare_references(&inputs).unwrap();
+        let client = authenticated_client();
+        let prepared = prepare_references(&client, &inputs).unwrap();
         assert_eq!(prepared.descriptors.len(), 2);
         assert!(matches!(
             &prepared.descriptors[0],
@@ -730,10 +602,13 @@ mod tests {
                     && provenance.sha256.as_ref().is_some_and(|value| value.len() == 64)
         ));
 
-        let error = prepare_references(&[ReferencePath {
-            kind: ReferenceKind::Audio,
-            path: audio_path,
-        }])
+        let error = prepare_references(
+            &client,
+            &[ReferencePath {
+                kind: ReferenceKind::Audio,
+                path: audio_path,
+            }],
+        )
         .expect_err("audio-only references must fail");
         assert!(error.to_string().contains("audio references require"));
     }
@@ -747,5 +622,60 @@ mod tests {
         assert!(parse_reference_input(&input)
             .unwrap_err()
             .contains("at most 12"));
+    }
+
+    #[test]
+    fn authority_fingerprint_detects_same_path_content_changes() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("reference.bin");
+        std::fs::write(&path, b"first").unwrap();
+        let references = vec![ReferencePath {
+            kind: ReferenceKind::Image,
+            path: path.clone(),
+        }];
+        let client = authenticated_client();
+        let frozen = authority_fingerprint(Some(&client), &references).unwrap();
+        std::fs::write(path, b"other").unwrap();
+        assert_ne!(
+            frozen,
+            authority_fingerprint(Some(&client), &references).unwrap()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn reference_preparation_rejects_symlink_input() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("anchor.png");
+        image::DynamicImage::new_rgb8(32, 16).save(&target).unwrap();
+        let link = dir.path().join("linked.png");
+        symlink(target, &link).unwrap();
+        let client = authenticated_client();
+        let error = prepare_references(
+            &client,
+            &[ReferencePath {
+                kind: ReferenceKind::Image,
+                path: link,
+            }],
+        )
+        .expect_err("symlink references must fail no-follow");
+        assert!(error.to_string().contains("no-follow"));
+    }
+
+    #[test]
+    fn auth_preflight_wins_before_reference_file_access() {
+        let client = MoldClient::new("http://127.0.0.1:9");
+        let references = [ReferencePath {
+            kind: ReferenceKind::Image,
+            path: "/definitely/not/opened/reference.png".into(),
+        }];
+
+        let fingerprint_error = authority_fingerprint(Some(&client), &references).unwrap_err();
+        assert!(fingerprint_error.to_string().contains("API key"));
+        let preparation_error = prepare_references(&client, &references).unwrap_err();
+        assert!(preparation_error.to_string().contains("API key"));
+        assert!(!preparation_error.to_string().contains("opened no-follow"));
     }
 }

--- a/crates/mold-tui/src/h3_references.rs
+++ b/crates/mold-tui/src/h3_references.rs
@@ -385,20 +385,44 @@ fn probe_video(
     file: File,
     provenance: GenerationReferenceProvenance,
 ) -> Result<GenerationReference> {
-    let probe = mold_inference::ltx2::media::probe_video_file(file)?;
+    let probe = mold_inference::ltx2::media::probe_video_file(file.try_clone()?)?;
     let duration_ms = probe
         .duration_ms
         .ok_or_else(|| anyhow::anyhow!("MP4 video duration is unavailable"))?;
+    let decoded_audio = if probe.has_audio {
+        Some(
+            mold_inference::ltx2::media::probe_decoded_mp4_audio_open_file(file)?
+                .context("MP4 audio track could not be decoded exactly")?,
+        )
+    } else {
+        None
+    };
+    let audio_duration_ms = decoded_audio
+        .as_ref()
+        .map(|audio| {
+            audio
+                .samples_per_channel
+                .checked_mul(1_000)
+                .context("MP4 soundtrack duration overflowed")
+                .map(|samples| samples.div_ceil(u64::from(audio.sample_rate)))
+        })
+        .transpose()?;
     Ok(GenerationReference::Video {
         media: GenerationReferenceAuthority::Descriptor,
         provenance,
         mime_type: "video/mp4".to_string(),
         width: probe.width,
         height: probe.height,
+        frame_count: probe.frames,
         duration_ms,
         fps: f64::from(probe.fps),
         has_audio: probe.has_audio,
-        audio_duration_ms: probe.has_audio.then_some(duration_ms),
+        audio_duration_ms,
+        audio_sample_count: decoded_audio
+            .as_ref()
+            .map(|audio| audio.samples_per_channel),
+        audio_sample_rate: decoded_audio.as_ref().map(|audio| audio.sample_rate),
+        audio_channels: decoded_audio.as_ref().map(|audio| audio.channels),
     })
 }
 
@@ -414,6 +438,7 @@ fn probe_audio(
         duration_ms: wav.duration_ms,
         sample_rate: wav.sample_rate,
         channels: wav.channels,
+        sample_count: Some(wav.sample_count),
     })
 }
 
@@ -421,6 +446,7 @@ struct WavProbe {
     duration_ms: u64,
     sample_rate: u32,
     channels: u16,
+    sample_count: u64,
 }
 
 fn probe_wav(file: File) -> Result<WavProbe> {
@@ -527,6 +553,7 @@ fn probe_wav(file: File) -> Result<WavProbe> {
         duration_ms,
         sample_rate,
         channels,
+        sample_count: data_bytes / u64::from(block_align),
     })
 }
 
@@ -573,10 +600,14 @@ fn with_authority(
             mime_type,
             width,
             height,
+            frame_count,
             duration_ms,
             fps,
             has_audio,
             audio_duration_ms,
+            audio_sample_count,
+            audio_sample_rate,
+            audio_channels,
             ..
         } => GenerationReference::Video {
             media,
@@ -584,10 +615,14 @@ fn with_authority(
             mime_type: mime_type.clone(),
             width: *width,
             height: *height,
+            frame_count: *frame_count,
             duration_ms: *duration_ms,
             fps: *fps,
             has_audio: *has_audio,
             audio_duration_ms: *audio_duration_ms,
+            audio_sample_count: *audio_sample_count,
+            audio_sample_rate: *audio_sample_rate,
+            audio_channels: *audio_channels,
         },
         GenerationReference::Audio {
             provenance,
@@ -595,6 +630,7 @@ fn with_authority(
             duration_ms,
             sample_rate,
             channels,
+            sample_count,
             ..
         } => GenerationReference::Audio {
             media,
@@ -603,6 +639,7 @@ fn with_authority(
             duration_ms: *duration_ms,
             sample_rate: *sample_rate,
             channels: *channels,
+            sample_count: *sample_count,
         },
     }
 }
@@ -683,7 +720,12 @@ mod tests {
         ));
         assert!(matches!(
             &prepared.descriptors[1],
-            GenerationReference::Audio { provenance, duration_ms: 2_000, .. }
+            GenerationReference::Audio {
+                provenance,
+                duration_ms: 2_000,
+                sample_count: Some(16_000),
+                ..
+            }
                 if provenance.name.as_deref() == Some("voice.wav")
                     && provenance.sha256.as_ref().is_some_and(|value| value.len() == 64)
         ));

--- a/crates/mold-tui/src/h3_references.rs
+++ b/crates/mold-tui/src/h3_references.rs
@@ -1,0 +1,709 @@
+//! Legal-safe MiniMax H3 Ref2VA authoring for the terminal surface.
+//!
+//! Paths stay in transient TUI state. Before any request is sent, each path is
+//! opened once, cloned for hashing/probing, and the original file descriptor is
+//! streamed through an authenticated, request-bound upload session. Neither the
+//! local path nor the one-use handles are persisted or logged.
+
+use anyhow::{Context, Result};
+use mold_core::{
+    minimax_h3, GenerateRequest, GenerationReference, GenerationReferenceAuthority,
+    GenerationReferenceProvenance, MoldClient, ReferenceUploadSessionRequest,
+};
+use sha2::{Digest, Sha256};
+use std::{
+    collections::HashSet,
+    fs::File,
+    io::{BufReader, Read, Seek, SeekFrom},
+    path::{Path, PathBuf},
+};
+
+const MAX_REFERENCE_FILE_BYTES: u64 = 256 * 1024 * 1024;
+const MAX_REFERENCE_TOTAL_BYTES: u64 = 1024 * 1024 * 1024;
+pub(crate) const MAX_REFERENCE_INPUT_BYTES: usize = 16 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ReferenceKind {
+    Image,
+    Video,
+    Audio,
+}
+
+impl ReferenceKind {
+    fn parse(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "image" => Some(Self::Image),
+            "video" => Some(Self::Video),
+            "audio" => Some(Self::Audio),
+            _ => None,
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::Image => "image",
+            Self::Video => "video",
+            Self::Audio => "audio",
+        }
+    }
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) struct ReferencePath {
+    pub kind: ReferenceKind,
+    pub path: PathBuf,
+}
+
+impl std::fmt::Debug for ReferencePath {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ReferencePath")
+            .field("kind", &self.kind.label())
+            .field("path", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Parse the one-line TUI syntax `image=/a.png; video=/b.mp4; audio=/c.wav`.
+/// Semicolon order is semantic. `split_once` deliberately permits `=` inside a
+/// pathname; newlines are accepted too for tests and future multiline widgets.
+pub(crate) fn parse_reference_input(
+    value: &str,
+) -> std::result::Result<Vec<ReferencePath>, String> {
+    if value.len() > MAX_REFERENCE_INPUT_BYTES {
+        return Err("Ordered reference input is too long.".to_string());
+    }
+    let mut references = Vec::new();
+    for (index, item) in value
+        .split([';', '\n'])
+        .map(str::trim)
+        .filter(|item| !item.is_empty())
+        .enumerate()
+    {
+        let (kind, path) = item.split_once('=').ok_or_else(|| {
+            format!(
+                "Reference {} must use KIND=PATH (image, video, or audio).",
+                index + 1
+            )
+        })?;
+        let kind = ReferenceKind::parse(kind).ok_or_else(|| {
+            format!(
+                "Reference {} has unknown kind '{}'; use image, video, or audio.",
+                index + 1,
+                kind.trim()
+            )
+        })?;
+        let path = path.trim();
+        if path.is_empty() || path == "-" {
+            return Err(format!(
+                "Reference {} requires a file path for authenticated streaming upload.",
+                index + 1
+            ));
+        }
+        references.push(ReferencePath {
+            kind,
+            path: PathBuf::from(path),
+        });
+    }
+    if references.len() > minimax_h3::MAX_REFERENCE_FILES {
+        return Err(format!(
+            "MiniMax H3 accepts at most {} ordered references.",
+            minimax_h3::MAX_REFERENCE_FILES
+        ));
+    }
+    Ok(references)
+}
+
+pub(crate) fn format_reference_input(references: &[ReferencePath]) -> String {
+    references
+        .iter()
+        .map(|reference| {
+            format!(
+                "{}={}",
+                reference.kind.label(),
+                reference.path.to_string_lossy()
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
+/// Safe identity for conditioning staleness checks. The digest retains order
+/// and kind without putting local paths into prompt-transform snapshots/logs.
+pub(crate) fn authority_fingerprint(references: &[ReferencePath]) -> String {
+    let mut digest = Sha256::new();
+    digest.update(b"mold.tui.minimax-h3.reference-paths.v1\0");
+    for reference in references {
+        digest.update(reference.kind.label().as_bytes());
+        digest.update(b"\0");
+        digest.update(reference.path.as_os_str().as_encoded_bytes());
+        digest.update(b"\0");
+    }
+    format!("{:x}", digest.finalize())
+}
+
+pub(crate) struct PreparedReferences {
+    pub descriptors: Vec<GenerationReference>,
+    uploads: Vec<ReferenceUpload>,
+}
+
+impl std::fmt::Debug for PreparedReferences {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("PreparedReferences")
+            .field("descriptors", &self.descriptors)
+            .field(
+                "uploads",
+                &format_args!("<{} redacted file descriptors>", self.uploads.len()),
+            )
+            .finish()
+    }
+}
+
+struct ReferenceUpload {
+    file: File,
+    mime_type: String,
+}
+
+/// Probe exact payload-free descriptors while retaining an already-open file
+/// descriptor for the subsequent upload. Server ingress probes the staged bytes
+/// independently and rejects any drift.
+pub(crate) fn prepare_references(inputs: &[ReferencePath]) -> Result<PreparedReferences> {
+    let mut descriptors = Vec::with_capacity(inputs.len());
+    let mut uploads = Vec::with_capacity(inputs.len());
+    let mut total_bytes = 0_u64;
+    for (index, input) in inputs.iter().enumerate() {
+        let mut file = File::open(&input.path)
+            .with_context(|| format!("reference {} could not be opened", index + 1))?;
+        let metadata = file
+            .metadata()
+            .with_context(|| format!("reference {} could not be inspected", index + 1))?;
+        anyhow::ensure!(
+            metadata.is_file() && metadata.len() > 0 && metadata.len() <= MAX_REFERENCE_FILE_BYTES,
+            "reference {} must be a non-empty regular file no larger than {} MiB",
+            index + 1,
+            MAX_REFERENCE_FILE_BYTES / (1024 * 1024)
+        );
+        total_bytes = total_bytes
+            .checked_add(metadata.len())
+            .context("combined reference size overflowed")?;
+        anyhow::ensure!(
+            total_bytes <= MAX_REFERENCE_TOTAL_BYTES,
+            "combined references must stay under {} MiB",
+            MAX_REFERENCE_TOTAL_BYTES / (1024 * 1024)
+        );
+        let sha256 = sha256_file(
+            file.try_clone()
+                .with_context(|| format!("reference {} could not be cloned", index + 1))?,
+        )
+        .with_context(|| format!("reference {} could not be hashed", index + 1))?;
+        file.seek(SeekFrom::Start(0))
+            .with_context(|| format!("reference {} could not be rewound", index + 1))?;
+        let provenance = GenerationReferenceProvenance {
+            name: Some(
+                display_name(&input.path)
+                    .with_context(|| format!("reference {} filename is invalid", index + 1))?,
+            ),
+            sha256: Some(sha256),
+        };
+        let probe_file = file
+            .try_clone()
+            .with_context(|| format!("reference {} could not be cloned", index + 1))?;
+        let descriptor = match input.kind {
+            ReferenceKind::Image => probe_image(probe_file, provenance),
+            ReferenceKind::Video => probe_video(probe_file, provenance),
+            ReferenceKind::Audio => probe_audio(probe_file, provenance),
+        }
+        .with_context(|| format!("reference {} media probe failed", index + 1))?;
+        file.seek(SeekFrom::Start(0))
+            .with_context(|| format!("reference {} could not be rewound", index + 1))?;
+        uploads.push(ReferenceUpload {
+            file,
+            mime_type: reference_mime_type(&descriptor).to_string(),
+        });
+        descriptors.push(descriptor);
+    }
+    minimax_h3::validate_reference_descriptors(&descriptors).map_err(anyhow::Error::new)?;
+    Ok(PreparedReferences {
+        descriptors,
+        uploads,
+    })
+}
+
+/// Bind and upload one exact attempt. Callers must invoke this again from the
+/// original paths/bytes for any retry; handles are one-use and request-scoped.
+pub(crate) async fn bind_remote_references(
+    client: &MoldClient,
+    request: &mut GenerateRequest,
+    prepared: PreparedReferences,
+) -> Result<String> {
+    let PreparedReferences {
+        descriptors,
+        uploads,
+    } = prepared;
+    anyhow::ensure!(
+        !descriptors.is_empty() && descriptors.len() == uploads.len(),
+        "reference descriptor/file count mismatch"
+    );
+    minimax_h3::validate_reference_descriptors(&descriptors).map_err(anyhow::Error::new)?;
+    request.references = Some(descriptors.clone());
+    let upload_references = (1..=descriptors.len())
+        .map(|index| u32::try_from(index).context("too many reference uploads"))
+        .collect::<Result<Vec<_>>>()?;
+    let session = client
+        .create_reference_upload_session(&ReferenceUploadSessionRequest {
+            request: request.clone(),
+            upload_references,
+        })
+        .await?;
+    if session.instance_id.trim().is_empty()
+        || session.expires_at_ms == 0
+        || !is_sha256_hex(&session.request_scope_sha256)
+        || !is_upload_handle(&session.session_handle)
+        || session.uploads.len() != descriptors.len()
+    {
+        let _ = client
+            .cancel_reference_upload_session(&session.session_handle)
+            .await;
+        anyhow::bail!("server returned an incomplete reference upload session");
+    }
+
+    let upload_result: Result<Vec<GenerationReference>> = async {
+        let mut bound = Vec::with_capacity(descriptors.len());
+        let mut seen_handles = HashSet::new();
+        for (index, (descriptor, upload)) in
+            descriptors.iter().zip(uploads).enumerate()
+        {
+            let reference = u32::try_from(index)
+                .context("too many reference uploads")?
+                .saturating_add(1);
+            let slot = session
+                .uploads
+                .iter()
+                .find(|slot| slot.reference == reference)
+                .ok_or_else(|| anyhow::anyhow!("server omitted reference upload slot {reference}"))?;
+            if !is_upload_handle(&slot.handle) || !seen_handles.insert(slot.handle.as_str()) {
+                anyhow::bail!("server returned an invalid or reused reference upload handle");
+            }
+            let completed = client
+                .upload_reference_open_file(&slot.handle, upload.file, &upload.mime_type)
+                .await
+                .with_context(|| format!("reference {reference} upload failed"))?;
+            if completed.instance_id != session.instance_id || completed.reference != reference {
+                anyhow::bail!(
+                    "reference {reference} upload response did not match its bound server session"
+                );
+            }
+            let expected = descriptor
+                .redacted_metadata(index)
+                .ok_or_else(|| anyhow::anyhow!("reference {reference} lost digest provenance"))?;
+            if completed.metadata != expected {
+                anyhow::bail!(
+                    "reference {reference} upload response drifted from the client-probed descriptor"
+                );
+            }
+            bound.push(with_authority(
+                descriptor,
+                GenerationReferenceAuthority::Upload {
+                    handle: slot.handle.clone(),
+                },
+            ));
+        }
+        Ok(bound)
+    }
+    .await;
+
+    match upload_result {
+        Ok(bound) => {
+            request.references = Some(bound);
+            Ok(session.session_handle)
+        }
+        Err(error) => {
+            let _ = client
+                .cancel_reference_upload_session(&session.session_handle)
+                .await;
+            Err(error)
+        }
+    }
+}
+
+fn sha256_file(mut file: File) -> Result<String> {
+    file.seek(SeekFrom::Start(0))?;
+    let mut digest = Sha256::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let read = file.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        digest.update(&buffer[..read]);
+    }
+    Ok(format!("{:x}", digest.finalize()))
+}
+
+fn display_name(path: &Path) -> Option<String> {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .map(str::trim)
+        .filter(|name| {
+            !name.is_empty()
+                && name.len() <= minimax_h3::MAX_REFERENCE_NAME_BYTES
+                && *name != "."
+                && *name != ".."
+                && !name.contains(['/', '\\'])
+                && !name.chars().any(char::is_control)
+        })
+        .map(str::to_string)
+}
+
+fn probe_image(
+    file: File,
+    provenance: GenerationReferenceProvenance,
+) -> Result<GenerationReference> {
+    let reader = image::ImageReader::new(BufReader::new(file)).with_guessed_format()?;
+    let format = reader
+        .format()
+        .ok_or_else(|| anyhow::anyhow!("unknown image format"))?;
+    let mime_type = match format {
+        image::ImageFormat::Png => "image/png",
+        image::ImageFormat::Jpeg => "image/jpeg",
+        image::ImageFormat::WebP => "image/webp",
+        image::ImageFormat::Gif => "image/gif",
+        _ => anyhow::bail!("unsupported image format; use PNG, JPEG, WebP, or GIF"),
+    };
+    let (width, height) = reader.into_dimensions()?;
+    Ok(GenerationReference::Image {
+        media: GenerationReferenceAuthority::Descriptor,
+        provenance,
+        mime_type: mime_type.to_string(),
+        width,
+        height,
+    })
+}
+
+fn probe_video(
+    file: File,
+    provenance: GenerationReferenceProvenance,
+) -> Result<GenerationReference> {
+    let probe = mold_inference::ltx2::media::probe_video_file(file)?;
+    let duration_ms = probe
+        .duration_ms
+        .ok_or_else(|| anyhow::anyhow!("MP4 video duration is unavailable"))?;
+    Ok(GenerationReference::Video {
+        media: GenerationReferenceAuthority::Descriptor,
+        provenance,
+        mime_type: "video/mp4".to_string(),
+        width: probe.width,
+        height: probe.height,
+        duration_ms,
+        fps: f64::from(probe.fps),
+        has_audio: probe.has_audio,
+        audio_duration_ms: probe.has_audio.then_some(duration_ms),
+    })
+}
+
+fn probe_audio(
+    file: File,
+    provenance: GenerationReferenceProvenance,
+) -> Result<GenerationReference> {
+    let wav = probe_wav(file)?;
+    Ok(GenerationReference::Audio {
+        media: GenerationReferenceAuthority::Descriptor,
+        provenance,
+        mime_type: "audio/wav".to_string(),
+        duration_ms: wav.duration_ms,
+        sample_rate: wav.sample_rate,
+        channels: wav.channels,
+    })
+}
+
+struct WavProbe {
+    duration_ms: u64,
+    sample_rate: u32,
+    channels: u16,
+}
+
+fn probe_wav(file: File) -> Result<WavProbe> {
+    let file_len = file.metadata()?.len();
+    anyhow::ensure!(file_len <= MAX_REFERENCE_FILE_BYTES);
+    let mut reader = BufReader::new(file);
+    let mut header = [0_u8; 12];
+    reader.read_exact(&mut header)?;
+    anyhow::ensure!(
+        &header[..4] == b"RIFF" && &header[8..] == b"WAVE",
+        "not a RIFF/WAVE file"
+    );
+    let riff_end = 8_u64
+        .checked_add(u64::from(u32::from_le_bytes(header[4..8].try_into()?)))
+        .context("WAVE container length overflowed")?;
+    anyhow::ensure!(
+        riff_end >= 12 && riff_end <= file_len,
+        "WAVE container is truncated"
+    );
+    let mut sample_rate = None;
+    let mut channels = None;
+    let mut byte_rate = None;
+    let mut block_align = None;
+    let mut data_bytes = None;
+    while reader.stream_position()?.saturating_add(8) <= riff_end {
+        let mut chunk = [0_u8; 8];
+        reader.read_exact(&mut chunk)?;
+        let length = u64::from(u32::from_le_bytes(chunk[4..].try_into()?));
+        let data_start = reader.stream_position()?;
+        let padded_length = length
+            .checked_add(length % 2)
+            .context("WAVE chunk length overflowed")?;
+        let next_chunk = data_start
+            .checked_add(padded_length)
+            .context("WAVE chunk offset overflowed")?;
+        anyhow::ensure!(
+            next_chunk <= riff_end && next_chunk <= file_len,
+            "WAVE chunk is truncated"
+        );
+        match &chunk[..4] {
+            b"fmt " => {
+                anyhow::ensure!(length >= 16, "WAVE fmt chunk is truncated");
+                let mut format = [0_u8; 16];
+                reader.read_exact(&mut format)?;
+                let encoding = u16::from_le_bytes(format[..2].try_into()?);
+                anyhow::ensure!(
+                    matches!(encoding, 1 | 3),
+                    "unsupported WAVE sample encoding"
+                );
+                let observed_channels = u16::from_le_bytes(format[2..4].try_into()?);
+                let observed_sample_rate = u32::from_le_bytes(format[4..8].try_into()?);
+                let observed_byte_rate = u32::from_le_bytes(format[8..12].try_into()?);
+                let observed_block_align = u16::from_le_bytes(format[12..14].try_into()?);
+                let bits_per_sample = u16::from_le_bytes(format[14..16].try_into()?);
+                anyhow::ensure!(
+                    observed_channels > 0
+                        && observed_sample_rate > 0
+                        && observed_block_align > 0
+                        && bits_per_sample > 0
+                        && bits_per_sample % 8 == 0,
+                    "WAVE format fields are invalid"
+                );
+                let expected_align = observed_channels
+                    .checked_mul(bits_per_sample / 8)
+                    .context("WAVE block alignment overflowed")?;
+                anyhow::ensure!(
+                    observed_block_align == expected_align,
+                    "WAVE block alignment is inconsistent"
+                );
+                anyhow::ensure!(
+                    observed_byte_rate
+                        == observed_sample_rate.saturating_mul(u32::from(observed_block_align)),
+                    "WAVE byte rate is inconsistent"
+                );
+                sample_rate = Some(observed_sample_rate);
+                channels = Some(observed_channels);
+                byte_rate = Some(observed_byte_rate);
+                block_align = Some(observed_block_align);
+            }
+            b"data" => data_bytes = Some(length),
+            _ => {}
+        }
+        reader.seek(SeekFrom::Start(next_chunk))?;
+        if sample_rate.is_some() && data_bytes.is_some() {
+            break;
+        }
+    }
+    let sample_rate = sample_rate.context("WAVE file has no fmt chunk")?;
+    let channels = channels.context("WAVE file has no channel count")?;
+    let byte_rate = byte_rate.context("WAVE file has no byte rate")?;
+    let block_align = block_align.context("WAVE file has no block alignment")?;
+    let data_bytes = data_bytes.context("WAVE file has no data chunk")?;
+    anyhow::ensure!(data_bytes > 0, "WAVE data chunk is empty");
+    anyhow::ensure!(
+        data_bytes % u64::from(block_align) == 0,
+        "WAVE data is not block aligned"
+    );
+    let duration_ms = data_bytes
+        .checked_mul(1_000)
+        .context("WAVE duration overflowed")?
+        .div_ceil(u64::from(byte_rate));
+    anyhow::ensure!(duration_ms > 0, "WAVE duration is zero");
+    Ok(WavProbe {
+        duration_ms,
+        sample_rate,
+        channels,
+    })
+}
+
+fn reference_mime_type(reference: &GenerationReference) -> &str {
+    match reference {
+        GenerationReference::Image { mime_type, .. }
+        | GenerationReference::Video { mime_type, .. }
+        | GenerationReference::Audio { mime_type, .. } => mime_type,
+    }
+}
+
+fn is_sha256_hex(value: &str) -> bool {
+    value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn is_upload_handle(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= minimax_h3::MAX_REFERENCE_UPLOAD_HANDLE_BYTES
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b':' | b'.'))
+}
+
+fn with_authority(
+    reference: &GenerationReference,
+    media: GenerationReferenceAuthority,
+) -> GenerationReference {
+    match reference {
+        GenerationReference::Image {
+            provenance,
+            mime_type,
+            width,
+            height,
+            ..
+        } => GenerationReference::Image {
+            media,
+            provenance: provenance.clone(),
+            mime_type: mime_type.clone(),
+            width: *width,
+            height: *height,
+        },
+        GenerationReference::Video {
+            provenance,
+            mime_type,
+            width,
+            height,
+            duration_ms,
+            fps,
+            has_audio,
+            audio_duration_ms,
+            ..
+        } => GenerationReference::Video {
+            media,
+            provenance: provenance.clone(),
+            mime_type: mime_type.clone(),
+            width: *width,
+            height: *height,
+            duration_ms: *duration_ms,
+            fps: *fps,
+            has_audio: *has_audio,
+            audio_duration_ms: *audio_duration_ms,
+        },
+        GenerationReference::Audio {
+            provenance,
+            mime_type,
+            duration_ms,
+            sample_rate,
+            channels,
+            ..
+        } => GenerationReference::Audio {
+            media,
+            provenance: provenance.clone(),
+            mime_type: mime_type.clone(),
+            duration_ms: *duration_ms,
+            sample_rate: *sample_rate,
+            channels: *channels,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn wav_bytes(seconds: u32) -> Vec<u8> {
+        let sample_rate = 8_000_u32;
+        let channels = 1_u16;
+        let samples = sample_rate * seconds;
+        let data_len = samples * u32::from(channels) * 2;
+        let mut bytes = Vec::with_capacity(44 + data_len as usize);
+        bytes.extend_from_slice(b"RIFF");
+        bytes.extend_from_slice(&(36 + data_len).to_le_bytes());
+        bytes.extend_from_slice(b"WAVEfmt ");
+        bytes.extend_from_slice(&16_u32.to_le_bytes());
+        bytes.extend_from_slice(&1_u16.to_le_bytes());
+        bytes.extend_from_slice(&channels.to_le_bytes());
+        bytes.extend_from_slice(&sample_rate.to_le_bytes());
+        bytes.extend_from_slice(&(sample_rate * 2).to_le_bytes());
+        bytes.extend_from_slice(&2_u16.to_le_bytes());
+        bytes.extend_from_slice(&16_u16.to_le_bytes());
+        bytes.extend_from_slice(b"data");
+        bytes.extend_from_slice(&data_len.to_le_bytes());
+        bytes.resize(44 + data_len as usize, 0);
+        bytes
+    }
+
+    #[test]
+    fn parser_preserves_mixed_order_and_equals_inside_paths() {
+        let references =
+            parse_reference_input("video=/tmp/a=b.mp4; image=/tmp/frame.png; audio=/tmp/voice.wav")
+                .unwrap();
+        assert_eq!(references.len(), 3);
+        assert_eq!(references[0].kind, ReferenceKind::Video);
+        assert_eq!(references[0].path, PathBuf::from("/tmp/a=b.mp4"));
+        assert_eq!(references[1].kind, ReferenceKind::Image);
+        assert_eq!(references[2].kind, ReferenceKind::Audio);
+        assert_eq!(
+            format_reference_input(&references),
+            "video=/tmp/a=b.mp4; image=/tmp/frame.png; audio=/tmp/voice.wav"
+        );
+        let fingerprint = authority_fingerprint(&references);
+        assert_eq!(fingerprint.len(), 64);
+        assert!(!fingerprint.contains("tmp"));
+        assert!(!format!("{references:?}").contains("/tmp"));
+    }
+
+    #[test]
+    fn preparation_keeps_image_then_audio_provenance_and_rejects_audio_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let image_path = dir.path().join("anchor.png");
+        let audio_path = dir.path().join("voice.wav");
+        image::DynamicImage::new_rgb8(32, 16)
+            .save(&image_path)
+            .unwrap();
+        std::fs::write(&audio_path, wav_bytes(2)).unwrap();
+
+        let inputs = vec![
+            ReferencePath {
+                kind: ReferenceKind::Image,
+                path: image_path,
+            },
+            ReferencePath {
+                kind: ReferenceKind::Audio,
+                path: audio_path.clone(),
+            },
+        ];
+        let prepared = prepare_references(&inputs).unwrap();
+        assert_eq!(prepared.descriptors.len(), 2);
+        assert!(matches!(
+            &prepared.descriptors[0],
+            GenerationReference::Image { provenance, width: 32, height: 16, .. }
+                if provenance.name.as_deref() == Some("anchor.png")
+                    && provenance.sha256.as_ref().is_some_and(|value| value.len() == 64)
+        ));
+        assert!(matches!(
+            &prepared.descriptors[1],
+            GenerationReference::Audio { provenance, duration_ms: 2_000, .. }
+                if provenance.name.as_deref() == Some("voice.wav")
+                    && provenance.sha256.as_ref().is_some_and(|value| value.len() == 64)
+        ));
+
+        let error = prepare_references(&[ReferencePath {
+            kind: ReferenceKind::Audio,
+            path: audio_path,
+        }])
+        .expect_err("audio-only references must fail");
+        assert!(error.to_string().contains("audio references require"));
+    }
+
+    #[test]
+    fn parser_enforces_twelve_file_ceiling_before_io() {
+        let input = (0..13)
+            .map(|index| format!("image=/tmp/{index}.png"))
+            .collect::<Vec<_>>()
+            .join("; ");
+        assert!(parse_reference_input(&input)
+            .unwrap_err()
+            .contains("at most 12"));
+    }
+}

--- a/crates/mold-tui/src/lib.rs
+++ b/crates/mold-tui/src/lib.rs
@@ -7,6 +7,7 @@ mod app;
 mod backend;
 mod event;
 mod gallery_scan;
+mod h3_references;
 mod history;
 mod hosts;
 mod model_info;

--- a/crates/mold-tui/src/model_info.rs
+++ b/crates/mold-tui/src/model_info.rs
@@ -11,6 +11,8 @@ pub struct ModelCapabilities {
     pub supports_img2img: bool,
     /// Whether the model accepts a source/reference image.
     pub supports_source_image: bool,
+    /// Whether this exact model accepts ordered MiniMax H3 references.
+    pub supports_references: bool,
     /// Whether the model uses a denoising strength control.
     pub supports_strength: bool,
     /// Whether the model supports a mask image.
@@ -42,6 +44,7 @@ pub fn capabilities_for_family(family: &str) -> ModelCapabilities {
             supports_scheduler: false,
             supports_img2img: false,
             supports_source_image: false,
+            supports_references: false,
             supports_strength: false,
             supports_mask: false,
             supports_controlnet: false,
@@ -59,6 +62,7 @@ pub fn capabilities_for_family(family: &str) -> ModelCapabilities {
             supports_scheduler: true,
             supports_img2img: true,
             supports_source_image: true,
+            supports_references: false,
             supports_strength: true,
             supports_mask: true,
             supports_controlnet: true,
@@ -74,6 +78,7 @@ pub fn capabilities_for_family(family: &str) -> ModelCapabilities {
             supports_scheduler: true,
             supports_img2img: true,
             supports_source_image: true,
+            supports_references: false,
             supports_strength: true,
             supports_mask: true,
             supports_controlnet: false,
@@ -89,6 +94,7 @@ pub fn capabilities_for_family(family: &str) -> ModelCapabilities {
             supports_scheduler: false,
             supports_img2img: false,
             supports_source_image: false,
+            supports_references: false,
             supports_strength: false,
             supports_mask: false,
             supports_controlnet: false,
@@ -104,6 +110,7 @@ pub fn capabilities_for_family(family: &str) -> ModelCapabilities {
             supports_scheduler: false,
             supports_img2img: false,
             supports_source_image: false,
+            supports_references: false,
             supports_strength: false,
             supports_mask: false,
             supports_controlnet: false,
@@ -119,6 +126,7 @@ pub fn capabilities_for_family(family: &str) -> ModelCapabilities {
             supports_scheduler: false,
             supports_img2img: true,
             supports_source_image: true,
+            supports_references: false,
             supports_strength: true,
             supports_mask: true,
             supports_controlnet: false, // ControlNet only supported on SD1.5
@@ -134,6 +142,7 @@ pub fn capabilities_for_family(family: &str) -> ModelCapabilities {
             supports_scheduler: false,
             supports_img2img: false,
             supports_source_image: false,
+            supports_references: false,
             supports_strength: false,
             supports_mask: false,
             supports_controlnet: false,
@@ -149,6 +158,7 @@ pub fn capabilities_for_family(family: &str) -> ModelCapabilities {
             supports_scheduler: false,
             supports_img2img: false,
             supports_source_image: false,
+            supports_references: false,
             supports_strength: false,
             supports_mask: false,
             supports_controlnet: false,
@@ -164,6 +174,7 @@ pub fn capabilities_for_family(family: &str) -> ModelCapabilities {
             supports_scheduler: false,
             supports_img2img: false,
             supports_source_image: false,
+            supports_references: false,
             supports_strength: false,
             supports_mask: false,
             supports_controlnet: false,
@@ -179,6 +190,7 @@ pub fn capabilities_for_family(family: &str) -> ModelCapabilities {
             supports_scheduler: false,
             supports_img2img: false,
             supports_source_image: true,
+            supports_references: false,
             supports_strength: false,
             supports_mask: false,
             supports_controlnet: false,
@@ -194,6 +206,7 @@ pub fn capabilities_for_family(family: &str) -> ModelCapabilities {
             supports_scheduler: false,
             supports_img2img: false,
             supports_source_image: false,
+            supports_references: false,
             supports_strength: false,
             supports_mask: false,
             supports_controlnet: false,
@@ -209,6 +222,7 @@ pub fn capabilities_for_family(family: &str) -> ModelCapabilities {
             supports_scheduler: false,
             supports_img2img: false,
             supports_source_image: false,
+            supports_references: false,
             supports_strength: false,
             supports_mask: false,
             supports_controlnet: false,
@@ -229,6 +243,7 @@ pub fn capabilities_for_family(family: &str) -> ModelCapabilities {
             supports_scheduler: false,
             supports_img2img: false,
             supports_source_image: true,
+            supports_references: false,
             // Wan's image conditioning is a first-frame anchor, not a
             // strength-weighted blend, so a strength slider would imply a
             // control the engine does not read.
@@ -247,6 +262,7 @@ pub fn capabilities_for_family(family: &str) -> ModelCapabilities {
             supports_scheduler: false,
             supports_img2img: false,
             supports_source_image: false,
+            supports_references: false,
             supports_strength: false,
             supports_mask: false,
             supports_controlnet: false,
@@ -271,6 +287,9 @@ pub fn capabilities_for_model(
     advertised_guidance: Option<mold_core::GuidanceCapabilities>,
 ) -> ModelCapabilities {
     let mut caps = capabilities_for_family(family);
+    caps.supports_references = mold_core::minimax_h3::is_family(family)
+        && mold_core::minimax_h3::task_for_model(model)
+            == Some(mold_core::minimax_h3::Task::Ref2va);
     // H3 has no unconditional/CFG branch. Contradictory checkpoint metadata
     // may not expose an editor for conditioning the model cannot consume.
     if !mold_core::minimax_h3::is_family(family) {
@@ -309,6 +328,9 @@ fn wan_model_takes_source_image(model: &str) -> bool {
 
 /// Resolve the family string for a given model name using the config and manifest.
 pub fn family_for_model(model_name: &str, config: &Config) -> String {
+    if mold_core::minimax_h3::task_for_model(model_name).is_some() {
+        return mold_core::minimax_h3::FAMILY.to_string();
+    }
     let model_cfg = config.resolved_model_config(model_name);
     model_cfg
         .family
@@ -325,6 +347,29 @@ mod tests {
     fn flux_does_not_support_controlnet() {
         let caps = capabilities_for_family("flux");
         assert!(!caps.supports_controlnet);
+    }
+
+    #[test]
+    fn h3_references_are_exposed_only_for_an_explicit_ref2va_identity() {
+        let ref2va = capabilities_for_model(
+            mold_core::minimax_h3::FAMILY,
+            mold_core::minimax_h3::REF2VA_COMFY,
+            None,
+            None,
+        );
+        let fl2va = capabilities_for_model(
+            mold_core::minimax_h3::FAMILY,
+            mold_core::minimax_h3::FL2VA_COMFY,
+            None,
+            None,
+        );
+        assert!(ref2va.supports_references);
+        assert!(!fl2va.supports_references);
+        assert_eq!(
+            family_for_model(mold_core::minimax_h3::REF2VA_COMFY, &Config::default()),
+            mold_core::minimax_h3::FAMILY
+        );
+        assert!(!capabilities_for_family("flux").supports_references);
     }
 
     #[test]

--- a/crates/mold-tui/src/model_info.rs
+++ b/crates/mold-tui/src/model_info.rs
@@ -23,6 +23,8 @@ pub struct ModelCapabilities {
     pub supports_video: bool,
     /// Whether the model can emit synchronized audio with video.
     pub supports_audio: bool,
+    /// Whether synchronized audio is inherent and cannot be disabled.
+    pub audio_required: bool,
     /// Whether the model supports LTX-2 latent spatial/temporal upscaling.
     pub supports_video_upscale: bool,
     /// Default scheduler for UNet-based models.
@@ -31,6 +33,26 @@ pub struct ModelCapabilities {
 
 /// Determine model capabilities from family name.
 pub fn capabilities_for_family(family: &str) -> ModelCapabilities {
+    if mold_core::minimax_h3::is_family(family) {
+        // Static form-shape knowledge only. H3 remains hidden and every H3
+        // identity remains server-gated, so recognizing aliases here cannot
+        // make the family selectable or runnable.
+        return ModelCapabilities {
+            supports_negative_prompt: false,
+            supports_scheduler: false,
+            supports_img2img: false,
+            supports_source_image: false,
+            supports_strength: false,
+            supports_mask: false,
+            supports_controlnet: false,
+            supports_lora: false,
+            supports_video: true,
+            supports_audio: true,
+            audio_required: true,
+            supports_video_upscale: false,
+            default_scheduler: None,
+        };
+    }
     match family {
         "sd15" | "sd1.5" | "stable-diffusion-1.5" => ModelCapabilities {
             supports_negative_prompt: true,
@@ -43,6 +65,7 @@ pub fn capabilities_for_family(family: &str) -> ModelCapabilities {
             supports_lora: true,
             supports_video: false,
             supports_audio: false,
+            audio_required: false,
             supports_video_upscale: false,
             default_scheduler: Some(Scheduler::Ddim),
         },
@@ -57,6 +80,7 @@ pub fn capabilities_for_family(family: &str) -> ModelCapabilities {
             supports_lora: true,
             supports_video: false,
             supports_audio: false,
+            audio_required: false,
             supports_video_upscale: false,
             default_scheduler: Some(Scheduler::Ddim),
         },
@@ -71,6 +95,7 @@ pub fn capabilities_for_family(family: &str) -> ModelCapabilities {
             supports_lora: true,
             supports_video: false,
             supports_audio: false,
+            audio_required: false,
             supports_video_upscale: false,
             default_scheduler: None,
         },
@@ -85,6 +110,7 @@ pub fn capabilities_for_family(family: &str) -> ModelCapabilities {
             supports_lora: false,
             supports_video: false,
             supports_audio: false,
+            audio_required: false,
             supports_video_upscale: false,
             default_scheduler: None,
         },
@@ -99,6 +125,7 @@ pub fn capabilities_for_family(family: &str) -> ModelCapabilities {
             supports_lora: true,
             supports_video: false,
             supports_audio: false,
+            audio_required: false,
             supports_video_upscale: false,
             default_scheduler: None,
         },
@@ -113,6 +140,7 @@ pub fn capabilities_for_family(family: &str) -> ModelCapabilities {
             supports_lora: true,
             supports_video: false,
             supports_audio: false,
+            audio_required: false,
             supports_video_upscale: false,
             default_scheduler: None,
         },
@@ -127,6 +155,7 @@ pub fn capabilities_for_family(family: &str) -> ModelCapabilities {
             supports_lora: true,
             supports_video: false,
             supports_audio: false,
+            audio_required: false,
             supports_video_upscale: false,
             default_scheduler: None,
         },
@@ -141,6 +170,7 @@ pub fn capabilities_for_family(family: &str) -> ModelCapabilities {
             supports_lora: true,
             supports_video: false,
             supports_audio: false,
+            audio_required: false,
             supports_video_upscale: false,
             default_scheduler: None,
         },
@@ -155,6 +185,7 @@ pub fn capabilities_for_family(family: &str) -> ModelCapabilities {
             supports_lora: true,
             supports_video: false,
             supports_audio: false,
+            audio_required: false,
             supports_video_upscale: false,
             default_scheduler: None,
         },
@@ -169,6 +200,7 @@ pub fn capabilities_for_family(family: &str) -> ModelCapabilities {
             supports_lora: false,
             supports_video: true,
             supports_audio: false,
+            audio_required: false,
             supports_video_upscale: false,
             default_scheduler: None,
         },
@@ -183,6 +215,7 @@ pub fn capabilities_for_family(family: &str) -> ModelCapabilities {
             supports_lora: true,
             supports_video: true,
             supports_audio: true,
+            audio_required: false,
             supports_video_upscale: true,
             default_scheduler: None,
         },
@@ -205,6 +238,7 @@ pub fn capabilities_for_family(family: &str) -> ModelCapabilities {
             supports_lora: true,
             supports_video: true,
             supports_audio: false,
+            audio_required: false,
             supports_video_upscale: false,
             default_scheduler: None,
         },
@@ -219,6 +253,7 @@ pub fn capabilities_for_family(family: &str) -> ModelCapabilities {
             supports_lora: false,
             supports_video: false,
             supports_audio: false,
+            audio_required: false,
             supports_video_upscale: false,
             default_scheduler: None,
         },
@@ -236,10 +271,16 @@ pub fn capabilities_for_model(
     advertised_guidance: Option<mold_core::GuidanceCapabilities>,
 ) -> ModelCapabilities {
     let mut caps = capabilities_for_family(family);
-    caps.supports_negative_prompt = advertised_guidance
-        .unwrap_or_else(|| mold_core::GuidanceCapabilities::for_recipe(family, model, None))
-        .supports_negative_prompt;
-    if advertised_audio_support == Some(false) {
+    // H3 has no unconditional/CFG branch. Contradictory checkpoint metadata
+    // may not expose an editor for conditioning the model cannot consume.
+    if !mold_core::minimax_h3::is_family(family) {
+        caps.supports_negative_prompt = advertised_guidance
+            .unwrap_or_else(|| mold_core::GuidanceCapabilities::for_recipe(family, model, None))
+            .supports_negative_prompt;
+    }
+    // Checkpoint metadata can narrow optional audio (LTX-2), but may never
+    // weaken H3's inherent synchronized-audio contract.
+    if advertised_audio_support == Some(false) && !caps.audio_required {
         caps.supports_audio = false;
     }
     if family == "wan" {
@@ -417,13 +458,21 @@ mod tests {
     }
 
     #[test]
-    fn checkpoint_audio_fact_can_disable_ltx2_audio_without_enabling_other_families() {
+    fn checkpoint_audio_fact_narrows_optional_audio_but_not_mandatory_h3_audio() {
         assert!(capabilities_for_model("ltx2", "ltx-2-dev", None, None).supports_audio);
         assert!(capabilities_for_model("ltx2", "ltx-2-dev", Some(true), None).supports_audio);
         assert!(!capabilities_for_model("ltx2", "ltx-2-dev", Some(false), None).supports_audio);
         assert!(
             !capabilities_for_model("ltx-video", "ltx-video-dev", Some(true), None).supports_audio
         );
+        let mandatory_h3 = capabilities_for_model(
+            mold_core::minimax_h3::FAMILY,
+            mold_core::minimax_h3::FL2VA_COMFY,
+            Some(false),
+            None,
+        );
+        assert!(mandatory_h3.supports_audio);
+        assert!(mandatory_h3.audio_required);
     }
 
     #[test]
@@ -497,5 +546,34 @@ mod tests {
         let caps = capabilities_for_family("ltx2");
         assert!(caps.supports_video);
         assert!(!caps.supports_negative_prompt);
+    }
+
+    #[test]
+    fn h3_exposes_only_its_static_synchronized_av_fields() {
+        for family in [mold_core::minimax_h3::FAMILY, "minimax_h3", "minimaxh3"] {
+            let caps = capabilities_for_family(family);
+            assert!(caps.supports_video);
+            assert!(caps.supports_audio);
+            assert!(caps.audio_required);
+            assert!(!caps.supports_negative_prompt);
+            assert!(!caps.supports_scheduler);
+            assert!(!caps.supports_img2img);
+            assert!(!caps.supports_source_image);
+            assert!(!caps.supports_strength);
+            assert!(!caps.supports_mask);
+            assert!(!caps.supports_controlnet);
+            assert!(!caps.supports_lora);
+            assert!(!caps.supports_video_upscale);
+        }
+
+        let contradictory = capabilities_for_model(
+            "minimax_h3",
+            mold_core::minimax_h3::FL2VA_COMFY,
+            Some(false),
+            Some(mold_core::GuidanceCapabilities::ADJUSTABLE_CFG),
+        );
+        assert!(contradictory.audio_required);
+        assert!(contradictory.supports_audio);
+        assert!(!contradictory.supports_negative_prompt);
     }
 }

--- a/crates/mold-tui/src/session.rs
+++ b/crates/mold-tui/src/session.rs
@@ -171,10 +171,7 @@ impl TuiSession {
             params.batch = b;
         }
         if let Some(ref f) = self.format {
-            params.format = match f.as_str() {
-                "jpeg" => mold_core::OutputFormat::Jpeg,
-                _ => mold_core::OutputFormat::Png,
-            };
+            params.format = f.parse().unwrap_or(mold_core::OutputFormat::Png);
         }
         if let Some(ref s) = self.scheduler {
             params.scheduler = match s.as_str() {
@@ -219,10 +216,7 @@ impl TuiSession {
             params.batch = b;
         }
         if let Some(ref f) = self.format {
-            params.format = match f.as_str() {
-                "jpeg" => mold_core::OutputFormat::Jpeg,
-                _ => mold_core::OutputFormat::Png,
-            };
+            params.format = f.parse().unwrap_or(mold_core::OutputFormat::Png);
         }
         if let Some(ref lp) = self.lora_path {
             params.lora_path = Some(lp.clone());
@@ -722,6 +716,25 @@ mod tests {
         assert!(!params.offload);
         assert_eq!(params.strength, 0.3);
         assert_eq!(params.control_scale, 1.5);
+    }
+
+    #[test]
+    fn persisted_video_formats_do_not_fall_back_to_png() {
+        use crate::app::GenerateParams;
+
+        for format in ["gif", "webp", "mp4"] {
+            let session = TuiSession {
+                format: Some(format.into()),
+                ..Default::default()
+            };
+            let mut params = GenerateParams::from_config(&mold_core::Config::default());
+            session.apply_to_params(&mut params);
+            assert_eq!(params.format.to_string(), format);
+
+            params.format = mold_core::OutputFormat::Png;
+            session.apply_non_model_params(&mut params);
+            assert_eq!(params.format.to_string(), format);
+        }
     }
 
     #[test]

--- a/crates/mold-tui/src/session.rs
+++ b/crates/mold-tui/src/session.rs
@@ -637,6 +637,7 @@ mod tests {
             offload: true,
             upscale_model: None,
             source_image_path: None,
+            reference_paths: Vec::new(),
             strength: 0.6,
             mask_image_path: None,
             frames: 25,

--- a/crates/mold-tui/src/ui/create_form.rs
+++ b/crates/mold-tui/src/ui/create_form.rs
@@ -143,6 +143,7 @@ pub fn advanced_sections(caps: &ModelCapabilities) -> Vec<AdvSection> {
         sections.push(AdvSection::Negative);
     }
     if caps.supports_source_image
+        || caps.supports_references
         || caps.supports_strength
         || caps.supports_mask
         || caps.supports_controlnet
@@ -176,6 +177,9 @@ pub fn section_fields(sec: AdvSection, caps: &ModelCapabilities) -> Vec<ParamFie
         AdvSection::Negative => Vec::new(),
         AdvSection::Source => {
             let mut fields = Vec::new();
+            if caps.supports_references {
+                fields.push(ParamField::References);
+            }
             if caps.supports_source_image {
                 fields.push(ParamField::SourceImage);
             }
@@ -289,6 +293,9 @@ pub fn section_summary(sec: AdvSection, params: &GenerateParams, negative_empty:
                 "on".into()
             }
         }
+        AdvSection::Source if !params.reference_paths.is_empty() => {
+            format!("{} ordered", params.reference_paths.len())
+        }
         AdvSection::Source => params
             .source_image_path
             .as_deref()
@@ -352,7 +359,8 @@ pub fn advanced_active_count(params: &GenerateParams, negative_empty: bool) -> u
     if !negative_empty {
         count += 1;
     }
-    if params.source_image_path.is_some()
+    if !params.reference_paths.is_empty()
+        || params.source_image_path.is_some()
         || params.mask_image_path.is_some()
         || params.control_image_path.is_some()
     {
@@ -485,6 +493,20 @@ mod tests {
                 CreateRow::AdvancedHeader,
                 CreateRow::ResetDefaults,
             ]
+        );
+    }
+
+    #[test]
+    fn h3_ref2va_source_section_exposes_only_the_ordered_reference_editor() {
+        let caps = crate::model_info::capabilities_for_model(
+            mold_core::minimax_h3::FAMILY,
+            mold_core::minimax_h3::REF2VA_COMFY,
+            None,
+            None,
+        );
+        assert_eq!(
+            section_fields(AdvSection::Source, &caps),
+            vec![ParamField::References]
         );
     }
 

--- a/crates/mold-tui/src/ui/create_form.rs
+++ b/crates/mold-tui/src/ui/create_form.rs
@@ -200,7 +200,7 @@ pub fn section_fields(sec: AdvSection, caps: &ModelCapabilities) -> Vec<ParamFie
             if caps.supports_video_upscale {
                 fields.push(ParamField::Pipeline);
             }
-            if caps.supports_audio {
+            if caps.supports_audio && !caps.audio_required {
                 fields.push(ParamField::Audio);
             }
             if caps.supports_video_upscale {
@@ -573,6 +573,19 @@ mod tests {
         assert!(!legacy_fields.contains(&ParamField::RescaleScale));
         assert!(!legacy_fields.contains(&ParamField::ModalityScale));
         assert!(!legacy_fields.contains(&ParamField::GuidanceSkip));
+    }
+
+    #[test]
+    fn h3_video_section_does_not_offer_an_audio_disable_control() {
+        let h3 = capabilities_for_family(mold_core::minimax_h3::FAMILY);
+        let fields = section_fields(AdvSection::Video, &h3);
+
+        assert!(fields.contains(&ParamField::Frames));
+        assert!(fields.contains(&ParamField::Fps));
+        assert!(!fields.contains(&ParamField::Audio));
+        assert!(!fields.contains(&ParamField::Pipeline));
+        assert!(!fields.contains(&ParamField::SpatialUpscale));
+        assert!(!fields.contains(&ParamField::TemporalUpscale));
     }
 
     #[test]

--- a/crates/mold-tui/src/ui/param_form.rs
+++ b/crates/mold-tui/src/ui/param_form.rs
@@ -191,6 +191,7 @@ fn adjustable(field: ParamField) -> bool {
             | ParamField::Lora
             | ParamField::StgBlocks
             | ParamField::SourceImage
+            | ParamField::References
             | ParamField::MaskImage
             | ParamField::ControlImage
             | ParamField::ControlModel

--- a/crates/mold-tui/src/ui/popup.rs
+++ b/crates/mold-tui/src/ui/popup.rs
@@ -14,6 +14,7 @@ pub fn render(frame: &mut Frame, app: &mut App) {
         Some(Popup::SeedInput { .. }) => render_seed_input(frame, app),
         Some(Popup::SizeInput { .. }) => render_size_input(frame, app),
         Some(Popup::StgBlocksInput { .. }) => render_stg_blocks_input(frame, app),
+        Some(Popup::ReferencesInput { .. }) => render_references_input(frame, app),
         Some(Popup::HistorySearch { .. }) => render_history_search(frame, app),
         Some(Popup::CommandPalette { .. }) => render_command_palette(frame, app),
         Some(Popup::Confirm { message, .. }) => render_confirm(frame, app, message.clone()),
@@ -627,6 +628,60 @@ fn render_stg_blocks_input(frame: &mut Frame, app: &mut App) {
             },
         );
     }
+}
+
+fn render_references_input(frame: &mut Frame, app: &mut App) {
+    let theme = &app.theme;
+    let area = centered_rect(frame.area(), 72, 24);
+    frame.render_widget(Clear, area);
+
+    let Some(Popup::ReferencesInput { input, error }) = &app.popup else {
+        return;
+    };
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(theme.popup_border())
+        .title(" Ordered H3 References ")
+        .title_style(theme.title_focused())
+        .style(theme.popup_bg());
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    if inner.height < 5 {
+        return;
+    }
+    frame.render_widget(
+        Paragraph::new("Semicolon order is semantic: image=/a.png; video=/b.mp4; audio=/c.wav")
+            .style(theme.dim()),
+        Rect { height: 1, ..inner },
+    );
+    frame.render_widget(
+        Paragraph::new(format!("{input}\u{2588}"))
+            .style(Style::default().fg(theme.text))
+            .wrap(Wrap { trim: false }),
+        Rect {
+            y: inner.y + 2,
+            height: inner.height.saturating_sub(4),
+            ..inner
+        },
+    );
+    if let Some(error) = error {
+        frame.render_widget(
+            Paragraph::new(error.as_str()).style(theme.error()),
+            Rect {
+                y: inner.y + inner.height.saturating_sub(2),
+                height: 1,
+                ..inner
+            },
+        );
+    }
+    frame.render_widget(
+        action_hints(theme, &[("Enter", "Confirm"), ("Esc", "Cancel")]),
+        Rect {
+            y: inner.y + inner.height.saturating_sub(1),
+            height: 1,
+            ..inner
+        },
+    );
 }
 
 /// Render the stepped connect-a-machine flow (Machines workspace).


### PR DESCRIPTION
## Summary

- add MiniMax H3 FL2VA and ordered Ref2VA authoring to CLI, TUI, and Discord
- centralize protocol-V2 canonical reference uploads in mold-core so non-browser surfaces share one strict implementation
- fail before path reads, hashes, probes, or URL downloads when the exact target lacks API-key authority
- preserve ordered media provenance and staleness identity without storing raw bytes or secrets
- retain fail-closed legal and runtime boundaries; this stack does not expose H3 in the catalog or activate local inference

## Stack

PR #867 is merged; this branch is rebased directly onto `main`.

- base: main at #867 squash commit `8dc9ade909498cb1454f636cb80215fc14cd9ef9`
- head: `4afcac4e3539a7cb334412dd437748e93dddd231`
- six surface commits rebased onto the #867 squash merge; range-diff marks all six patches equivalent
- the current-main WAN dimension-grid fixes are preserved alongside H3 canvas authority in CLI and Discord

Fresh exact-head CI on the final main base is required before merge.

## Reference-ingress security

- client-owned authenticated preflight runs before all local or remote reference-media I/O
- upload sessions bind the exact request scope, server instance, ordered slots, MIME, digest, decoded metadata, total byte cap, and TTL
- local files use no-follow single-descriptor reads and verify size plus digest from the opened object
- one-use handles have no retry or path fallback
- an armed cleanup guard cancels abandoned, invalid, expired, failed, or aborted sessions
- expiry is rechecked after final canonical validation and before lease return
- logs and Debug output redact API keys, upload handles, paths, and media bytes

## Legal and activation boundary

- no MiniMax H3 model artifacts, checkpoint payloads, or weight headers were accessed or downloaded
- no catalog, manifest, factory, worker, queue, or download activation is included
- local H3 execution remains rejected
- remote authoring remains subject to the server authorization policy, including HTTP 451
- real-weight validation and UAT remain blocked on #831

## Exact-tree validation

- mold-core reference-upload tests: 6
- mold-core secure-file tests: 2
- API-key state and redacted-Debug regressions: 2
- CLI request binding and 451 tests: 2; replay tests: 2; H3 authoring tests: 8
- TUI H3 authoring tests: 7 plus focused staleness coverage
- Discord H3 authoring tests: 10
- selected cargo checks for mold-ai-core, mold-ai, mold-ai-tui, and mold-ai-discord
- all-target clippy with warnings denied for mold-ai-core, mold-ai, mold-ai-tui, and mold-ai-discord
- rustfmt and git diff check
- post-rebase Discord WAN 16/32px and H3 official 32px canvas regressions: 3 passed
- post-rebase `cargo check -p mold-ai --no-default-features` passed

Fresh post-rebase no-default-features validation covers the complete mold-core, CLI, TUI, and Discord suites under the Rust 1.93 Nix shell, including 548 CLI tests and 627 TUI tests; all pass.

Part of #841. Legal authorization remains tracked by #831.