### PR TITLE
fix(nix): expose CUDA runtime during binary checks

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -657,6 +657,21 @@
                 # check hermetic by running only binary unit tests; exec-based
                 # CLI smoke tests remain covered by non-sandbox CI.
                 cargoTestExtraArgs = "--bins";
+
+                # The H3 release-provenance marker deliberately keeps the
+                # CUDA/C++ dependency path live in the binary test harness.
+                # It runs before autoPatchelf, so expose the pinned toolkit
+                # libraries and inert driver stub only during checkPhase.
+                preCheck = ''
+                  export LD_LIBRARY_PATH=${
+                    lib.makeLibraryPath [
+                      pkgs.stdenv.cc.cc.lib
+                      pkgs.cudaPackages.cuda_cudart
+                      pkgs.cudaPackages.libcublas.lib
+                      pkgs.cudaPackages.libcurand.lib
+                    ]
+                  }:${pkgs.cudaPackages.cuda_cudart}/lib/stubs''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
+                '';
               }
               // {
                 passthru.moldCudaComputeCapability = computeCap;


### PR DESCRIPTION
## Summary

- expose the pinned GCC and CUDA runtime libraries while Nix executes binary tests
- provide only the CUDA toolkit inert driver stub during checkPhase
- leave final artifact patching, RUNPATH validation, and driver exclusion under the existing fixup pipeline

## Root cause

Release run 31246951801 failed only in build-nix-distribution. The CUDA-enabled binary test harness runs before autoPatchelf and retained its CUDA and C++ linkage, but checkPhase had no runtime search path. The harness therefore exited 127 while loading libstdc++.so.6; its remaining linked CUDA libraries and inert driver dependency require the same pre-fixup treatment.

## Validation

- nix fmt flake.nix
- cargo fmt --all -- --check
- bash scripts/tests/minimax-h3-attention-release-contract.sh
- Plato nix build .#mold-sm86 --print-build-logs --no-link
  - full derivation exited 0
  - 560 binary tests passed
  - MiniMax H3 release-exclusion verifier passed
  - final auto-patchelf and RUNPATH fixup completed
- Plato nix build .#checks.x86_64-linux.runpath-assertion --no-link --print-build-logs

No model artifacts were accessed.