### PR TITLE
fix(release): advance rolling latest tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -632,6 +632,9 @@ jobs:
       - name: Generate checksums
         run: cd artifacts && sha256sum ./*.tar.gz > SHA256SUMS
 
+      - name: Verify rolling release source is current main
+        run: scripts/check-desktop-nightly-main-head.sh "$GITHUB_SHA"
+
       - name: Create/update release
         uses: softprops/action-gh-release@v2
         with:
@@ -683,6 +686,33 @@ jobs:
             tar xzf mold-x86_64-unknown-linux-gnu-cuda-sm120.tar.gz  # RTX 50-series
             ./mold version
             ```
+
+      # action-gh-release updates an existing release's body and assets, but it
+      # does not move the already-created tag. Keep the mutable rolling tag as
+      # exact as the commit recorded in the release body and shipped binaries.
+      - name: Pin rolling tag to this release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          scripts/check-desktop-nightly-main-head.sh "$GITHUB_SHA"
+
+          gh api \
+            --method PATCH \
+            "repos/${GITHUB_REPOSITORY}/git/refs/tags/latest" \
+            -f "sha=${GITHUB_SHA}" \
+            -F force=true >/dev/null
+
+          tag_sha="$(
+            gh api \
+              "repos/${GITHUB_REPOSITORY}/git/ref/tags/latest" \
+              --jq '.object.sha'
+          )"
+          if [[ "$tag_sha" != "$GITHUB_SHA" ]]; then
+            echo "::error::latest resolved to $tag_sha instead of $GITHUB_SHA"
+            exit 1
+          fi
 
   # Versioned release + crates.io publish on v* tags
   release-version:

--- a/scripts/tests/cuda-distribution-contract.sh
+++ b/scripts/tests/cuda-distribution-contract.sh
@@ -154,6 +154,60 @@ for release_job in release-latest release-version; do
   require_release_job_need "$release_job" "docker"
   require_release_job_need "$release_job" "build-nix-distribution"
 done
+require_release_job_text "release-latest" \
+  "Pin rolling tag to this release"
+require_release_job_text "release-latest" \
+  'contents: write'
+require_release_job_text "release-latest" \
+  'prerelease: true'
+require_release_job_text "release-latest" \
+  'make_latest: false'
+require_release_job_text "release-latest" \
+  'GH_TOKEN: ${{ github.token }}'
+require_release_job_text "release-latest" \
+  '"repos/${GITHUB_REPOSITORY}/git/refs/tags/latest"'
+require_release_job_text "release-latest" \
+  '"repos/${GITHUB_REPOSITORY}/git/ref/tags/latest"'
+require_release_job_text "release-latest" \
+  '--method PATCH'
+require_release_job_text "release-latest" \
+  '-f "sha=${GITHUB_SHA}"'
+require_release_job_text "release-latest" \
+  '-F force=true'
+require_release_job_text "release-latest" \
+  'if [[ "$tag_sha" != "$GITHUB_SHA" ]]; then'
+main_freshness_guard_count="$(
+  awk '
+    $0 == "  release-latest:" { in_job = 1 }
+    in_job && /^  [[:alnum:]_-]+:$/ && $0 != "  release-latest:" { exit }
+    in_job { print }
+  ' "$repo_root/$release" |
+    grep -Fc 'scripts/check-desktop-nightly-main-head.sh "$GITHUB_SHA"'
+)"
+[[ "$main_freshness_guard_count" -eq 2 ]] \
+  || fail "release-latest must reject stale main before release and tag mutation"
+
+release_guard_lines="$(
+  grep -nF 'scripts/check-desktop-nightly-main-head.sh "$GITHUB_SHA"' \
+    "$repo_root/$release" |
+    cut -d: -f1
+)"
+first_release_guard_line="$(sed -n '1p' <<<"$release_guard_lines")"
+second_release_guard_line="$(sed -n '2p' <<<"$release_guard_lines")"
+release_upload_line="$(
+  grep -n -m1 'uses: softprops/action-gh-release@v2' "$repo_root/$release" |
+    cut -d: -f1
+)"
+rolling_tag_patch_line="$(
+  grep -n -m1 '"repos/${GITHUB_REPOSITORY}/git/refs/tags/latest"' \
+    "$repo_root/$release" |
+    cut -d: -f1
+)"
+[[ "$first_release_guard_line" -lt "$release_upload_line" \
+  && "$second_release_guard_line" -gt "$release_upload_line" \
+  && "$second_release_guard_line" -lt "$rolling_tag_patch_line" ]] \
+  || fail "fresh-main guards must surround release mutation and tag movement"
+require_text "$release" 'tags: ["v*"]'
 require_release_job_text "docker" \
   'type=raw,value=latest${{ matrix.suffix }},enable={{is_default_branch}}'
 require_release_job_text "docker" \


### PR DESCRIPTION
## Summary

- reject stale rolling-release runs before they mutate the public release
- move `refs/tags/latest` to the exact published `GITHUB_SHA` only after the release body and assets succeed
- read the ref back and fail loudly if permissions, rulesets, or API behavior prevent the move
- extend the release contract with ordering, freshness, permission, endpoint, and payload assertions

## Root cause

`softprops/action-gh-release` refreshes an existing release and clobbers its assets, but it does not update an already-created Git tag. The public release body and binaries were current while `refs/tags/latest` remained anchored to a March commit. GitHub also ignores `target_commitish` when the tag already exists, so an explicit Git refs API update is required.

## Validation

- `nix fmt`
- `actionlint .github/workflows/release.yml`
- `bash scripts/tests/check-desktop-nightly-main-head.sh`
- Plato Linux/Nix: `bash scripts/tests/cuda-distribution-contract.sh` — 36 PTX fixtures passed and contract reported `ok`
- independent race/permissions review: no findings

No model files or MiniMax H3 payloads were accessed.
