### PR TITLE
feat(h3): preprocess ordered references

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -39,3 +39,38 @@ INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
 LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
 OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
+
+## torchaudio sinc resampling algorithm
+
+The pure-Rust MiniMax H3 reference-audio resampler in
+`crates/mold-inference/src/reference_media.rs` independently expresses the
+numeric behavior of torchaudio's default Hann-windowed sinc resampler. The
+reference is torchaudio 2.8.0, commit
+`6e1c7fe9ff6d82b8665d0a46d859d3357d2ebaaa`,
+`src/torchaudio/functional/functional.py`. No torchaudio source file or Python
+implementation is vendored in Mold.
+
+torchaudio is licensed under the BSD 2-Clause License:
+
+    Copyright (c) 2017 Facebook Inc. (Soumith Chintala),
+    All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice,
+  this list of conditions and the following disclaimer.
+- Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/crates/mold-inference/src/engine.rs
+++ b/crates/mold-inference/src/engine.rs
@@ -42,6 +42,7 @@ pub struct BatchExecutionCapability {
 pub struct GenerationReferenceBinding {
     metadata: GenerationReferenceMetadata,
     file: File,
+    verified_bytes: u64,
 }
 
 impl GenerationReferenceBinding {
@@ -106,7 +107,11 @@ impl GenerationReferenceBinding {
             "generation reference binding digest differs from staged media"
         );
         file.seek(SeekFrom::Start(0))?;
-        Ok(Self { metadata, file })
+        Ok(Self {
+            metadata,
+            file,
+            verified_bytes: observed_bytes,
+        })
     }
 
     pub fn metadata(&self) -> &GenerationReferenceMetadata {
@@ -122,11 +127,21 @@ impl GenerationReferenceBinding {
         &self.file
     }
 
+    /// Exact byte length covered by the binding's digest verification.
+    ///
+    /// An opened descriptor preserves inode identity, but another writer can
+    /// still mutate that inode after admission. Decoders use this frozen bound
+    /// while copying and re-hash the bytes before parsing them.
+    pub(crate) fn verified_bytes(&self) -> u64 {
+        self.verified_bytes
+    }
+
     #[cfg(test)]
     pub(crate) fn synthetic(metadata: GenerationReferenceMetadata) -> Self {
         Self {
             metadata,
             file: tempfile::tempfile().expect("create synthetic reference handle"),
+            verified_bytes: 0,
         }
     }
 }

--- a/crates/mold-inference/src/lib.rs
+++ b/crates/mold-inference/src/lib.rs
@@ -36,6 +36,7 @@ pub mod model_registry;
 pub(crate) mod nvfp4;
 pub mod progress;
 pub mod qwen_image;
+pub(crate) mod reference_media;
 pub mod runtime_env;
 pub mod scheduler;
 pub mod sd15;

--- a/crates/mold-inference/src/ltx2/media.rs
+++ b/crates/mold-inference/src/ltx2/media.rs
@@ -311,6 +311,23 @@ fn decode_video_bounded(
     max_dimension: Option<u32>,
     max_rgb_bytes: Option<u64>,
 ) -> Result<DecodedVideo> {
+    decode_video_bounded_with_checkpoint(
+        input_video,
+        target_fps,
+        max_dimension,
+        max_rgb_bytes,
+        &mut || Ok(()),
+    )
+}
+
+fn decode_video_bounded_with_checkpoint(
+    input_video: &Path,
+    target_fps: Option<u32>,
+    max_dimension: Option<u32>,
+    max_rgb_bytes: Option<u64>,
+    checkpoint: &mut dyn FnMut() -> Result<()>,
+) -> Result<DecodedVideo> {
+    checkpoint()?;
     let mut reader = read_mp4(input_video)?;
     let video = find_video_track(&reader)?;
     let (has_audio, audio_sample_rate, audio_channels) = audio_metadata(&reader)?;
@@ -376,6 +393,7 @@ fn decode_video_bounded(
     let mut pps_seen = false;
 
     for sample_id in 1..=video.frames.unwrap_or_default() {
+        checkpoint()?;
         let Some(sample) = reader.read_sample(video.track_id, sample_id)? else {
             continue;
         };
@@ -397,6 +415,7 @@ fn decode_video_bounded(
             .decode(&converted)
             .context("failed to decode H.264 frame from MP4")?
         {
+            checkpoint()?;
             if should_sample_export_frame(decoded_index, video.fps, export_fps) {
                 let mut rgb = vec![0; image.rgb8_len()];
                 image.write_rgb8(&mut rgb);
@@ -423,6 +442,7 @@ fn decode_video_bounded(
         .flush_remaining()
         .context("failed to flush delayed H.264 frames")?
     {
+        checkpoint()?;
         if should_sample_export_frame(decoded_index, video.fps, export_fps) {
             let mut rgb = vec![0; image.rgb8_len()];
             image.write_rgb8(&mut rgb);
@@ -449,6 +469,8 @@ fn decode_video_bounded(
             input_video.display()
         );
     }
+
+    checkpoint()?;
 
     Ok(DecodedVideo {
         metadata: ProbeMetadata {
@@ -480,6 +502,16 @@ pub(crate) fn decode_video_frames(input_video: &Path) -> Result<(ProbeMetadata, 
 
 pub fn decode_video_frames_from_path(input: &Path) -> Result<(ProbeMetadata, Vec<RgbImage>)> {
     decode_video_frames(input)
+}
+
+/// Decode an H.264 MP4 while polling an attempt-scoped cancellation hook at
+/// container-sample and decoded-frame boundaries.
+pub(crate) fn decode_video_frames_from_path_with_checkpoint(
+    input: &Path,
+    checkpoint: &mut dyn FnMut() -> Result<()>,
+) -> Result<(ProbeMetadata, Vec<RgbImage>)> {
+    let video = decode_video_bounded_with_checkpoint(input, None, None, None, checkpoint)?;
+    Ok((video.metadata, video.frames))
 }
 
 #[allow(dead_code)]

--- a/crates/mold-inference/src/ltx2/media.rs
+++ b/crates/mold-inference/src/ltx2/media.rs
@@ -316,6 +316,8 @@ fn decode_video_bounded(
         target_fps,
         max_dimension,
         max_rgb_bytes,
+        None,
+        None,
         &mut || Ok(()),
     )
 }
@@ -325,6 +327,8 @@ fn decode_video_bounded_with_checkpoint(
     target_fps: Option<u32>,
     max_dimension: Option<u32>,
     max_rgb_bytes: Option<u64>,
+    selected_source_indices: Option<&[usize]>,
+    mut frame_transform: Option<&mut dyn FnMut(RgbImage) -> Result<RgbImage>>,
     checkpoint: &mut dyn FnMut() -> Result<()>,
 ) -> Result<DecodedVideo> {
     checkpoint()?;
@@ -332,6 +336,24 @@ fn decode_video_bounded_with_checkpoint(
     let video = find_video_track(&reader)?;
     let (has_audio, audio_sample_rate, audio_channels) = audio_metadata(&reader)?;
     let export_fps = target_fps.unwrap_or(video.fps).min(video.fps).max(1);
+    if let Some(indices) = selected_source_indices {
+        anyhow::ensure!(
+            !indices.is_empty()
+                && indices.windows(2).all(|pair| pair[0] < pair[1])
+                && video.frames.is_some_and(
+                    |frames| indices.last().copied().unwrap_or_default() < frames as usize
+                ),
+            "selected video-frame indices must be nonempty, strictly increasing, and in range"
+        );
+        anyhow::ensure!(
+            target_fps.is_none() && max_dimension.is_none(),
+            "selected video-frame decoding cannot also resample or resize frames"
+        );
+    }
+    anyhow::ensure!(
+        frame_transform.is_none() || selected_source_indices.is_some(),
+        "video-frame transforms require an explicit bounded selection"
+    );
     if let (Some(limit), Some(frame_count)) = (max_rgb_bytes, video.frames) {
         anyhow::ensure!(
             estimated_export_rgb_bytes(
@@ -380,13 +402,19 @@ fn decode_video_bounded_with_checkpoint(
     .context("failed to create H.264 decoder for LTX-2 media output")?;
 
     let mut converted = Vec::new();
-    let estimated_frames = video
-        .frames
-        .unwrap_or_default()
-        .saturating_mul(export_fps)
-        .div_ceil(video.fps.max(1)) as usize;
+    let estimated_frames = selected_source_indices.map_or_else(
+        || {
+            video
+                .frames
+                .unwrap_or_default()
+                .saturating_mul(export_fps)
+                .div_ceil(video.fps.max(1)) as usize
+        },
+        <[usize]>::len,
+    );
     let mut frames = Vec::with_capacity(estimated_frames);
     let mut decoded_index = 0_u32;
+    let mut selected_cursor = 0_usize;
     let mut retained_rgb_bytes = 0_u64;
     let mut new_idr = true;
     let mut sps_seen = false;
@@ -416,14 +444,23 @@ fn decode_video_bounded_with_checkpoint(
             .context("failed to decode H.264 frame from MP4")?
         {
             checkpoint()?;
-            if should_sample_export_frame(decoded_index, video.fps, export_fps) {
+            if should_retain_decoded_frame(
+                decoded_index,
+                video.fps,
+                export_fps,
+                selected_source_indices,
+                &mut selected_cursor,
+            )? {
                 let mut rgb = vec![0; image.rgb8_len()];
                 image.write_rgb8(&mut rgb);
                 let frame =
                     RgbImage::from_raw(video.width, video.height, rgb).ok_or_else(|| {
                         anyhow!("decoded H.264 frame size did not match track dimensions")
                     })?;
-                let frame = resize_export_frame(frame, max_dimension);
+                let frame = match frame_transform.as_deref_mut() {
+                    Some(transform) => transform(frame)?,
+                    None => resize_export_frame(frame, max_dimension),
+                };
                 retained_rgb_bytes = retained_rgb_bytes
                     .saturating_add(u64::from(frame.width()) * u64::from(frame.height()) * 3);
                 if let Some(limit) = max_rgb_bytes {
@@ -435,32 +472,58 @@ fn decode_video_bounded_with_checkpoint(
                 frames.push(frame);
             }
             decoded_index += 1;
+            if selected_source_indices.is_some_and(|indices| selected_cursor == indices.len()) {
+                break;
+            }
         }
     }
 
-    for image in decoder
-        .flush_remaining()
-        .context("failed to flush delayed H.264 frames")?
-    {
-        checkpoint()?;
-        if should_sample_export_frame(decoded_index, video.fps, export_fps) {
-            let mut rgb = vec![0; image.rgb8_len()];
-            image.write_rgb8(&mut rgb);
-            let frame = RgbImage::from_raw(video.width, video.height, rgb).ok_or_else(|| {
-                anyhow!("flushed H.264 frame size did not match track dimensions")
-            })?;
-            let frame = resize_export_frame(frame, max_dimension);
-            retained_rgb_bytes = retained_rgb_bytes
-                .saturating_add(u64::from(frame.width()) * u64::from(frame.height()) * 3);
-            if let Some(limit) = max_rgb_bytes {
-                anyhow::ensure!(
-                    retained_rgb_bytes <= limit,
-                    "animation export exceeds the safe decoded-frame budget; choose a smaller size or frame rate"
-                );
+    if selected_source_indices.is_none_or(|indices| selected_cursor != indices.len()) {
+        for image in decoder
+            .flush_remaining()
+            .context("failed to flush delayed H.264 frames")?
+        {
+            checkpoint()?;
+            if should_retain_decoded_frame(
+                decoded_index,
+                video.fps,
+                export_fps,
+                selected_source_indices,
+                &mut selected_cursor,
+            )? {
+                let mut rgb = vec![0; image.rgb8_len()];
+                image.write_rgb8(&mut rgb);
+                let frame =
+                    RgbImage::from_raw(video.width, video.height, rgb).ok_or_else(|| {
+                        anyhow!("flushed H.264 frame size did not match track dimensions")
+                    })?;
+                let frame = match frame_transform.as_deref_mut() {
+                    Some(transform) => transform(frame)?,
+                    None => resize_export_frame(frame, max_dimension),
+                };
+                retained_rgb_bytes = retained_rgb_bytes
+                    .saturating_add(u64::from(frame.width()) * u64::from(frame.height()) * 3);
+                if let Some(limit) = max_rgb_bytes {
+                    anyhow::ensure!(
+                        retained_rgb_bytes <= limit,
+                        "animation export exceeds the safe decoded-frame budget; choose a smaller size or frame rate"
+                    );
+                }
+                frames.push(frame);
             }
-            frames.push(frame);
+            decoded_index += 1;
+            if selected_source_indices.is_some_and(|indices| selected_cursor == indices.len()) {
+                break;
+            }
         }
-        decoded_index += 1;
+    }
+
+    if let Some(indices) = selected_source_indices {
+        anyhow::ensure!(
+            selected_cursor == indices.len(),
+            "video decoder produced only {decoded_index} frames before selected source frame {}",
+            indices[selected_cursor]
+        );
     }
 
     if frames.is_empty() {
@@ -474,10 +537,22 @@ fn decode_video_bounded_with_checkpoint(
 
     Ok(DecodedVideo {
         metadata: ProbeMetadata {
-            width: frames[0].width(),
-            height: frames[0].height(),
+            width: if selected_source_indices.is_some() {
+                video.width
+            } else {
+                frames[0].width()
+            },
+            height: if selected_source_indices.is_some() {
+                video.height
+            } else {
+                frames[0].height()
+            },
             fps: export_fps,
-            frames: Some(frames.len() as u32),
+            frames: if selected_source_indices.is_some() {
+                video.frames
+            } else {
+                Some(frames.len() as u32)
+            },
             duration_ms: video.duration_ms,
             has_audio,
             audio_sample_rate,
@@ -485,6 +560,36 @@ fn decode_video_bounded_with_checkpoint(
         },
         frames,
     })
+}
+
+fn should_retain_decoded_frame(
+    decoded_index: u32,
+    source_fps: u32,
+    export_fps: u32,
+    selected_source_indices: Option<&[usize]>,
+    selected_cursor: &mut usize,
+) -> Result<bool> {
+    let Some(indices) = selected_source_indices else {
+        return Ok(should_sample_export_frame(
+            decoded_index,
+            source_fps,
+            export_fps,
+        ));
+    };
+    if *selected_cursor == indices.len() {
+        return Ok(false);
+    }
+    let decoded_index = decoded_index as usize;
+    let expected = indices[*selected_cursor];
+    if decoded_index > expected {
+        bail!("video decoder skipped selected source frame {expected}");
+    }
+    if decoded_index == expected {
+        *selected_cursor += 1;
+        Ok(true)
+    } else {
+        Ok(false)
+    }
 }
 
 fn resize_export_frame(frame: RgbImage, max_dimension: Option<u32>) -> RgbImage {
@@ -504,13 +609,25 @@ pub fn decode_video_frames_from_path(input: &Path) -> Result<(ProbeMetadata, Vec
     decode_video_frames(input)
 }
 
-/// Decode an H.264 MP4 while polling an attempt-scoped cancellation hook at
-/// container-sample and decoded-frame boundaries.
-pub(crate) fn decode_video_frames_from_path_with_checkpoint(
+/// Decode only a strictly increasing set of source frames and transform each
+/// retained frame before it enters the output vector. This keeps H3 reference
+/// normalization bounded by its frozen canvas instead of retaining every
+/// full-resolution source frame.
+pub(crate) fn decode_video_frames_selected_from_path_with_checkpoint(
     input: &Path,
+    selected_source_indices: &[usize],
+    frame_transform: &mut dyn FnMut(RgbImage) -> Result<RgbImage>,
     checkpoint: &mut dyn FnMut() -> Result<()>,
 ) -> Result<(ProbeMetadata, Vec<RgbImage>)> {
-    let video = decode_video_bounded_with_checkpoint(input, None, None, None, checkpoint)?;
+    let video = decode_video_bounded_with_checkpoint(
+        input,
+        None,
+        None,
+        None,
+        Some(selected_source_indices),
+        Some(frame_transform),
+        checkpoint,
+    )?;
     Ok((video.metadata, video.frames))
 }
 

--- a/crates/mold-inference/src/ltx2/mod.rs
+++ b/crates/mold-inference/src/ltx2/mod.rs
@@ -21,6 +21,7 @@ mod text;
 mod tiling;
 
 pub use chain::{extract_tail_latents, tail_latent_frame_count};
+pub(crate) use model::DecodedAudio;
 pub use pipeline::Ltx2Engine;
 
 /// Whether the resolved checkpoint set contains both the audio VAE and

--- a/crates/mold-inference/src/ltx2/model/audio_vae.rs
+++ b/crates/mold-inference/src/ltx2/model/audio_vae.rs
@@ -303,8 +303,14 @@ impl DecodedAudio {
         let decoded = match Self::decode_with_probe_with_checkpoint(path, checkpoint) {
             Ok(Some(decoded)) => Some(decoded),
             Ok(None) => Self::decode_aac_from_mp4_with_checkpoint(path, checkpoint)?,
+            Err(probe_err) if crate::progress::is_inference_cancelled(&probe_err) => {
+                return Err(probe_err);
+            }
             Err(probe_err) => match Self::decode_aac_from_mp4_with_checkpoint(path, checkpoint) {
                 Ok(decoded) => decoded,
+                Err(fallback_err) if crate::progress::is_inference_cancelled(&fallback_err) => {
+                    return Err(fallback_err);
+                }
                 Err(fallback_err) => {
                     return Err(anyhow!(
                         "failed to decode source audio '{}' via probe ({probe_err:#}) or native MP4 fallback ({fallback_err:#})",

--- a/crates/mold-inference/src/ltx2/model/audio_vae.rs
+++ b/crates/mold-inference/src/ltx2/model/audio_vae.rs
@@ -269,11 +269,21 @@ pub struct DecodedAudio {
 
 impl DecodedAudio {
     pub fn from_file(path: &Path, max_duration_seconds: Option<f32>) -> Result<Option<Self>> {
+        Self::from_file_with_checkpoint(path, max_duration_seconds, &mut || Ok(()))
+    }
+
+    pub(crate) fn from_file_with_checkpoint(
+        path: &Path,
+        max_duration_seconds: Option<f32>,
+        checkpoint: &mut dyn FnMut() -> Result<()>,
+    ) -> Result<Option<Self>> {
+        checkpoint()?;
         let decoded = if is_mp4_audio_container(path) {
-            return Self::from_mp4_file(path, max_duration_seconds);
+            return Self::from_mp4_file_with_checkpoint(path, max_duration_seconds, checkpoint);
         } else {
-            Self::decode_with_probe(path)?
+            Self::decode_with_probe_with_checkpoint(path, checkpoint)?
         };
+        checkpoint()?;
         Ok(decoded.map(|decoded| decoded.trimmed(max_duration_seconds)))
     }
 
@@ -281,10 +291,19 @@ impl DecodedAudio {
     /// extension. Reference ingress uses this to bind exact decoded sample
     /// counts before Ref2VA placement can freeze a layout.
     pub fn from_mp4_file(path: &Path, max_duration_seconds: Option<f32>) -> Result<Option<Self>> {
-        let decoded = match Self::decode_with_probe(path) {
+        Self::from_mp4_file_with_checkpoint(path, max_duration_seconds, &mut || Ok(()))
+    }
+
+    pub(crate) fn from_mp4_file_with_checkpoint(
+        path: &Path,
+        max_duration_seconds: Option<f32>,
+        checkpoint: &mut dyn FnMut() -> Result<()>,
+    ) -> Result<Option<Self>> {
+        checkpoint()?;
+        let decoded = match Self::decode_with_probe_with_checkpoint(path, checkpoint) {
             Ok(Some(decoded)) => Some(decoded),
-            Ok(None) => Self::decode_aac_from_mp4(path)?,
-            Err(probe_err) => match Self::decode_aac_from_mp4(path) {
+            Ok(None) => Self::decode_aac_from_mp4_with_checkpoint(path, checkpoint)?,
+            Err(probe_err) => match Self::decode_aac_from_mp4_with_checkpoint(path, checkpoint) {
                 Ok(decoded) => decoded,
                 Err(fallback_err) => {
                     return Err(anyhow!(
@@ -294,10 +313,20 @@ impl DecodedAudio {
                 }
             },
         };
+        checkpoint()?;
         Ok(decoded.map(|decoded| decoded.trimmed(max_duration_seconds)))
     }
 
+    #[cfg(all(test, feature = "mp4"))]
     fn decode_with_probe(path: &Path) -> Result<Option<Self>> {
+        Self::decode_with_probe_with_checkpoint(path, &mut || Ok(()))
+    }
+
+    fn decode_with_probe_with_checkpoint(
+        path: &Path,
+        checkpoint: &mut dyn FnMut() -> Result<()>,
+    ) -> Result<Option<Self>> {
+        checkpoint()?;
         let file = File::open(path)
             .with_context(|| format!("failed to open source audio '{}'", path.display()))?;
         let mss = MediaSourceStream::new(Box::new(file), Default::default());
@@ -342,6 +371,7 @@ impl DecodedAudio {
         );
 
         loop {
+            checkpoint()?;
             let packet = match format.next_packet() {
                 Ok(packet) => packet,
                 Err(SymphoniaError::IoError(_)) => break,
@@ -353,10 +383,15 @@ impl DecodedAudio {
             accumulator.push_packet(path, decoder.as_mut(), &packet)?;
         }
 
+        checkpoint()?;
         Ok(accumulator.finish())
     }
 
-    fn decode_aac_from_mp4(path: &Path) -> Result<Option<Self>> {
+    fn decode_aac_from_mp4_with_checkpoint(
+        path: &Path,
+        checkpoint: &mut dyn FnMut() -> Result<()>,
+    ) -> Result<Option<Self>> {
+        checkpoint()?;
         let bytes = std::fs::read(path)
             .with_context(|| format!("failed to read source MP4 audio '{}'", path.display()))?;
         let mut reader = Mp4Reader::read_header(Cursor::new(bytes.clone()), bytes.len() as u64)
@@ -414,6 +449,7 @@ impl DecodedAudio {
         );
 
         for sample_id in 1..=track.sample_count() {
+            checkpoint()?;
             let Some(sample) = reader.read_sample(track_id, sample_id)? else {
                 continue;
             };
@@ -426,6 +462,7 @@ impl DecodedAudio {
             accumulator.push_packet(path, decoder.as_mut(), &packet)?;
         }
 
+        checkpoint()?;
         Ok(accumulator.finish())
     }
 

--- a/crates/mold-inference/src/minimax_h3/mod.rs
+++ b/crates/mold-inference/src/minimax_h3/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod backend;
 pub(crate) mod engine;
 pub(crate) mod offload;
 pub(crate) mod pipeline;
+pub(crate) mod reference_media;
 pub(crate) mod sampler;
 
 use anyhow::{anyhow, Result};

--- a/crates/mold-inference/src/minimax_h3/pipeline.rs
+++ b/crates/mold-inference/src/minimax_h3/pipeline.rs
@@ -1149,7 +1149,7 @@ fn pillow_resample_channel(samples: impl Iterator<Item = (u8, i32)>) -> u8 {
     (accumulator >> PILLOW_RESAMPLE_PRECISION_BITS).clamp(0, 255) as u8
 }
 
-fn pillow_lanczos_resize(
+pub(super) fn pillow_lanczos_resize(
     source: &RgbImage,
     width: u32,
     height: u32,

--- a/crates/mold-inference/src/minimax_h3/pipeline/ref2va.rs
+++ b/crates/mold-inference/src/minimax_h3/pipeline/ref2va.rs
@@ -9,6 +9,7 @@
 
 use super::*;
 use crate::engine::GenerationReferenceBinding;
+use crate::minimax_h3::reference_media::H3ReferenceMediaAdapter;
 use crate::minimax_h3::sampler::H3_VISUAL_CONDITION_TIMESTEP;
 use mold_candle::minimax_h3::{
     pack_h3_audio, sample_video_frames, AudioVaeConfig, RefPresentation, RefPresentationKind,
@@ -31,6 +32,7 @@ pub(crate) struct H3PreparedRef2VaRequest {
 pub(crate) struct H3PreparedReference {
     pub metadata: GenerationReferenceMetadata,
     pub shape: contract::GenerationReferencePreparedShape,
+    pub target_frames: u32,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -78,12 +80,24 @@ pub(crate) trait H3Ref2VaBackend {
     /// every reference block, and both generated suffixes.
     fn maximum_packed_rows(&self) -> usize;
 
+    /// Concrete, weight-free media preprocessing owned by a future Ref2VA
+    /// backend. Synthetic backends may override the two methods below; a
+    /// production backend exposes this adapter and cannot silently substitute
+    /// metadata-only preprocessing.
+    fn reference_media_adapter(&mut self) -> Option<&mut H3ReferenceMediaAdapter> {
+        None
+    }
+
     fn decode_reference(
         &mut self,
         reference: &H3PreparedReference,
         binding: &GenerationReferenceBinding,
         checkpoint: &mut dyn H3PipelineCheckpoint,
-    ) -> Result<H3DecodedReferenceFacts>;
+    ) -> Result<H3DecodedReferenceFacts> {
+        self.reference_media_adapter()
+            .ok_or_else(|| anyhow!("MiniMax H3 Ref2VA backend has no reference-media adapter"))?
+            .decode_reference(reference, binding, checkpoint)
+    }
 
     /// Normalize the already-decoded media and retain it internally for the
     /// two VAE encoders. The returned presentation is the exact Qwen vision
@@ -93,7 +107,11 @@ pub(crate) trait H3Ref2VaBackend {
         reference: &H3PreparedReference,
         decoded: &H3DecodedReferenceFacts,
         checkpoint: &mut dyn H3PipelineCheckpoint,
-    ) -> Result<H3ReferencePresentation>;
+    ) -> Result<H3ReferencePresentation> {
+        self.reference_media_adapter()
+            .ok_or_else(|| anyhow!("MiniMax H3 Ref2VA backend has no reference-media adapter"))?
+            .preprocess_reference(reference, decoded, checkpoint)
+    }
 
     fn encode_text(
         &mut self,
@@ -222,7 +240,11 @@ fn prepare_request_with_authority(
             bail!("MiniMax H3 Ref2VA reference {} lost its digest", index + 1);
         }
         metadata.prepared_shape = Some(shape.clone());
-        references.push(H3PreparedReference { metadata, shape });
+        references.push(H3PreparedReference {
+            metadata,
+            shape,
+            target_frames: frames,
+        });
     }
     let metadata = references
         .iter()

--- a/crates/mold-inference/src/minimax_h3/reference_media.rs
+++ b/crates/mold-inference/src/minimax_h3/reference_media.rs
@@ -1,0 +1,795 @@
+//! Concrete, weight-free media preprocessing for the dormant H3 Ref2VA path.
+//!
+//! This module deliberately contains no checkpoint discovery and activates no
+//! model family. It turns server-bound, digest-verified file descriptors into
+//! the exact media tensors a future legally admitted backend must encode.
+
+use std::collections::BTreeMap;
+
+use anyhow::{anyhow, bail, Context, Result};
+use image::RgbImage;
+use mold_candle::minimax_h3::{
+    sample_video_frames, RefPresentation, RefPresentationKind, VideoPresentationBlock,
+};
+use mold_core::minimax_h3::{AUDIO_SAMPLE_RATE_HZ, FIXED_FPS};
+use mold_core::GenerationReferenceKind;
+
+use super::pipeline::ref2va::{
+    H3DecodedAudioFacts, H3DecodedReferenceFacts, H3PreparedReference, H3ReferencePresentation,
+};
+use super::pipeline::{
+    pillow_lanczos_resize, H3PipelineCheckpoint, H3PipelineEvent, H3PipelinePhase,
+};
+use crate::engine::GenerationReferenceBinding;
+use crate::ltx2::DecodedAudio;
+use crate::reference_media::{
+    cfr_source_indices, decode_audio_from_open_file, decode_image_from_open_file,
+    decode_video_from_open_file, normalize_audio, NormalizedStereoAudio,
+};
+
+#[derive(Debug)]
+enum DecodedReference {
+    Image(RgbImage),
+    Video {
+        frames: Vec<RgbImage>,
+        fps: f64,
+        audio: Option<DecodedAudio>,
+    },
+    Audio(DecodedAudio),
+}
+
+#[derive(Debug)]
+struct DecodedSlot {
+    facts: H3DecodedReferenceFacts,
+    media: DecodedReference,
+}
+
+#[derive(Debug)]
+pub(crate) enum H3NormalizedReference {
+    Image {
+        image: RgbImage,
+        vision_tokens: usize,
+    },
+    Video {
+        /// Exact `17n+5` prefix consumed by the visual VAE.
+        vae_frames: Vec<RgbImage>,
+        /// Exact 2 fps cursor samples consumed by Qwen3-VL.
+        qwen_frames: Vec<RgbImage>,
+        qwen_source_indices: Vec<usize>,
+        audio: Option<NormalizedStereoAudio>,
+    },
+    Audio {
+        audio: NormalizedStereoAudio,
+    },
+}
+
+/// Attempt-local decoded/normalized media owned by one frozen backend.
+/// BTreeMap preserves the one-based request order for diagnostics and future
+/// encoder iteration; inserting a duplicate or preprocessing out of sequence
+/// fails closed.
+#[derive(Debug, Default)]
+pub(crate) struct H3ReferenceMediaAdapter {
+    decoded: BTreeMap<u32, DecodedSlot>,
+    normalized: BTreeMap<u32, H3NormalizedReference>,
+    decode_order: Vec<u32>,
+    normalized_order: Vec<u32>,
+}
+
+impl H3ReferenceMediaAdapter {
+    pub(crate) fn decode_reference(
+        &mut self,
+        reference: &H3PreparedReference,
+        binding: &GenerationReferenceBinding,
+        checkpoint: &mut dyn H3PipelineCheckpoint,
+    ) -> Result<H3DecodedReferenceFacts> {
+        let index = reference.metadata.index;
+        let expected_index = u32::try_from(self.decode_order.len() + 1)
+            .context("MiniMax H3 reference order exceeded u32")?;
+        if index != expected_index {
+            bail!(
+                "MiniMax H3 reference decode order changed: received {index}, expected {expected_index}"
+            );
+        }
+        if self.decoded.contains_key(&index) || self.normalized.contains_key(&index) {
+            bail!("MiniMax H3 reference {index} was decoded more than once");
+        }
+        let mut poll = || {
+            checkpoint.checkpoint(H3PipelineEvent {
+                phase: H3PipelinePhase::ReferenceDecodeChunk,
+                completed: 0,
+                total: 1,
+            })
+        };
+        let (facts, media) = match reference.metadata.kind {
+            GenerationReferenceKind::Image => {
+                let image = decode_image_from_open_file(binding.file(), &mut poll)?;
+                let facts = H3DecodedReferenceFacts {
+                    index,
+                    kind: GenerationReferenceKind::Image,
+                    width: Some(image.width()),
+                    height: Some(image.height()),
+                    frame_count: None,
+                    fps: None,
+                    audio: None,
+                };
+                (facts, DecodedReference::Image(image))
+            }
+            GenerationReferenceKind::Video => {
+                let decoded = decode_video_from_open_file(binding.file(), &mut poll)?;
+                let first = decoded
+                    .frames
+                    .first()
+                    .context("decoded H3 reference video did not contain a frame")?;
+                let audio_facts = decoded
+                    .audio
+                    .as_ref()
+                    .map(decoded_audio_facts)
+                    .transpose()?;
+                let facts = H3DecodedReferenceFacts {
+                    index,
+                    kind: GenerationReferenceKind::Video,
+                    width: Some(first.width()),
+                    height: Some(first.height()),
+                    frame_count: Some(
+                        u32::try_from(decoded.frames.len())
+                            .context("decoded H3 reference frame count exceeded u32")?,
+                    ),
+                    fps: Some(decoded.fps),
+                    audio: audio_facts,
+                };
+                (
+                    facts,
+                    DecodedReference::Video {
+                        frames: decoded.frames,
+                        fps: decoded.fps,
+                        audio: decoded.audio,
+                    },
+                )
+            }
+            GenerationReferenceKind::Audio => {
+                let decoded = decode_audio_from_open_file(
+                    binding.file(),
+                    &reference.metadata.mime_type,
+                    &mut poll,
+                )?;
+                let facts = H3DecodedReferenceFacts {
+                    index,
+                    kind: GenerationReferenceKind::Audio,
+                    width: None,
+                    height: None,
+                    frame_count: None,
+                    fps: None,
+                    audio: Some(decoded_audio_facts(&decoded)?),
+                };
+                (facts, DecodedReference::Audio(decoded))
+            }
+        };
+        self.decoded.insert(
+            index,
+            DecodedSlot {
+                facts: facts.clone(),
+                media,
+            },
+        );
+        self.decode_order.push(index);
+        Ok(facts)
+    }
+
+    pub(crate) fn preprocess_reference(
+        &mut self,
+        reference: &H3PreparedReference,
+        decoded: &H3DecodedReferenceFacts,
+        checkpoint: &mut dyn H3PipelineCheckpoint,
+    ) -> Result<H3ReferencePresentation> {
+        let index = reference.metadata.index;
+        let expected_index = self
+            .decode_order
+            .get(self.normalized_order.len())
+            .copied()
+            .ok_or_else(|| {
+                anyhow!("MiniMax H3 reference {index} was not decoded in this request")
+            })?;
+        if index != expected_index {
+            bail!(
+                "MiniMax H3 reference preprocess order changed: received {index}, expected {expected_index}"
+            );
+        }
+        if self.normalized.contains_key(&index) {
+            bail!("MiniMax H3 reference {index} was preprocessed more than once");
+        }
+        let slot = self.decoded.remove(&index).ok_or_else(|| {
+            anyhow!("MiniMax H3 reference {index} was preprocessed before decode")
+        })?;
+        if &slot.facts != decoded {
+            bail!("MiniMax H3 reference {index} decoded facts changed before preprocessing");
+        }
+        let mut poll = || {
+            checkpoint.checkpoint(H3PipelineEvent {
+                phase: H3PipelinePhase::ReferencePreprocessChunk,
+                completed: 0,
+                total: 1,
+            })
+        };
+        let (normalized, presentation) = match slot.media {
+            DecodedReference::Image(image) => {
+                let width = required_dimension(reference.shape.normalized_width, "width")?;
+                let height = required_dimension(reference.shape.normalized_height, "height")?;
+                let image = pillow_lanczos_resize(&image, width, height, &mut poll)?;
+                let vision_tokens = vision_tokens_per_temporal_block(width, height)?;
+                (
+                    H3NormalizedReference::Image {
+                        image,
+                        vision_tokens,
+                    },
+                    RefPresentation {
+                        kind: RefPresentationKind::Image { vision_tokens },
+                        has_audio: false,
+                    },
+                )
+            }
+            DecodedReference::Video { frames, fps, audio } => {
+                let width = required_dimension(reference.shape.normalized_width, "width")?;
+                let height = required_dimension(reference.shape.normalized_height, "height")?;
+                let normalized_count = required_count(
+                    reference.shape.normalized_video_frames,
+                    "normalized video frames",
+                )?;
+                let vae_count = required_count(reference.shape.video_frames, "video VAE frames")?;
+                let cfr_indices =
+                    cfr_source_indices(frames.len(), fps, FIXED_FPS, normalized_count, &mut poll)?;
+                if vae_count > cfr_indices.len() {
+                    bail!("MiniMax H3 visual-VAE frame prefix exceeds normalized video");
+                }
+                let mut vae_frames = Vec::with_capacity(vae_count);
+                for &source_index in &cfr_indices[..vae_count] {
+                    poll()?;
+                    vae_frames.push(pillow_lanczos_resize(
+                        &frames[source_index],
+                        width,
+                        height,
+                        &mut poll,
+                    )?);
+                }
+
+                let sampled = sample_video_frames(normalized_count, f64::from(FIXED_FPS))?;
+                let expected_qwen =
+                    required_count(reference.shape.qwen_video_frames, "Qwen video frames")?;
+                if sampled.frame_indices.len() != expected_qwen {
+                    bail!("MiniMax H3 Qwen 2 fps sampling changed the prepared frame count");
+                }
+                let mut qwen_frames = Vec::with_capacity(sampled.frame_indices.len());
+                let mut qwen_source_indices = Vec::with_capacity(sampled.frame_indices.len());
+                for &normalized_index in &sampled.frame_indices {
+                    poll()?;
+                    let source_index = cfr_indices[normalized_index];
+                    qwen_source_indices.push(source_index);
+                    if normalized_index < vae_frames.len() {
+                        qwen_frames.push(vae_frames[normalized_index].clone());
+                    } else {
+                        qwen_frames.push(pillow_lanczos_resize(
+                            &frames[source_index],
+                            width,
+                            height,
+                            &mut poll,
+                        )?);
+                    }
+                }
+                let audio = match audio {
+                    Some(audio) => Some(normalize_reference_audio(reference, &audio, &mut poll)?),
+                    None => None,
+                };
+                let vision_tokens = vision_tokens_per_temporal_block(width, height)?;
+                let blocks = sampled
+                    .block_timestamps_seconds
+                    .into_iter()
+                    .map(|timestamp_seconds| VideoPresentationBlock {
+                        timestamp_seconds,
+                        vision_tokens,
+                    })
+                    .collect();
+                (
+                    H3NormalizedReference::Video {
+                        vae_frames,
+                        qwen_frames,
+                        qwen_source_indices,
+                        audio,
+                    },
+                    RefPresentation {
+                        kind: RefPresentationKind::Video { blocks },
+                        has_audio: reference.metadata.has_audio,
+                    },
+                )
+            }
+            DecodedReference::Audio(audio) => {
+                let audio = normalize_reference_audio(reference, &audio, &mut poll)?;
+                (
+                    H3NormalizedReference::Audio { audio },
+                    RefPresentation {
+                        kind: RefPresentationKind::Audio,
+                        has_audio: true,
+                    },
+                )
+            }
+        };
+        self.normalized.insert(index, normalized);
+        self.normalized_order.push(index);
+        Ok(H3ReferencePresentation {
+            index,
+            presentation,
+        })
+    }
+
+    pub(crate) fn normalized(&self, index: u32) -> Option<&H3NormalizedReference> {
+        self.normalized.get(&index)
+    }
+
+    pub(crate) fn normalized_indices(&self) -> Vec<u32> {
+        self.normalized_order.clone()
+    }
+}
+
+fn decoded_audio_facts(decoded: &DecodedAudio) -> Result<H3DecodedAudioFacts> {
+    Ok(H3DecodedAudioFacts {
+        sample_rate: u32::try_from(decoded.sample_rate)
+            .context("decoded H3 reference sample rate exceeded u32")?,
+        channels: u16::try_from(decoded.channel_count())
+            .context("decoded H3 reference channel count exceeded u16")?,
+        samples_per_channel: u64::try_from(decoded.sample_count())
+            .context("decoded H3 reference sample count exceeded u64")?,
+    })
+}
+
+fn normalize_reference_audio(
+    reference: &H3PreparedReference,
+    decoded: &DecodedAudio,
+    checkpoint: &mut dyn FnMut() -> Result<()>,
+) -> Result<NormalizedStereoAudio> {
+    let maximum_native_samples = u64::from(reference.target_frames)
+        .checked_mul(u64::try_from(decoded.sample_rate)?)
+        .context("MiniMax H3 native audio truncation count overflowed")?
+        / u64::from(FIXED_FPS);
+    let maximum_native_samples = usize::try_from(maximum_native_samples)
+        .context("MiniMax H3 native audio truncation count exceeded usize")?;
+    let expected_samples = usize::try_from(
+        reference
+            .shape
+            .audio_samples_per_channel
+            .ok_or_else(|| anyhow!("MiniMax H3 audio reference lost prepared sample count"))?,
+    )
+    .context("MiniMax H3 prepared audio sample count exceeded usize")?;
+    let normalized = normalize_audio(
+        decoded,
+        maximum_native_samples,
+        AUDIO_SAMPLE_RATE_HZ,
+        expected_samples,
+        checkpoint,
+    )?;
+    if normalized.sample_rate != AUDIO_SAMPLE_RATE_HZ
+        || normalized.samples_per_channel() != expected_samples
+    {
+        bail!("MiniMax H3 audio normalization changed the prepared duration");
+    }
+    Ok(normalized)
+}
+
+fn required_dimension(value: Option<u32>, name: &str) -> Result<u32> {
+    value
+        .filter(|value| *value > 0)
+        .ok_or_else(|| anyhow!("MiniMax H3 reference lost normalized {name}"))
+}
+
+fn required_count(value: Option<u32>, name: &str) -> Result<usize> {
+    usize::try_from(
+        value
+            .filter(|value| *value > 0)
+            .ok_or_else(|| anyhow!("MiniMax H3 reference lost {name}"))?,
+    )
+    .with_context(|| format!("MiniMax H3 {name} exceeded usize"))
+}
+
+fn vision_tokens_per_temporal_block(width: u32, height: u32) -> Result<usize> {
+    if width == 0 || height == 0 || !width.is_multiple_of(32) || !height.is_multiple_of(32) {
+        bail!("MiniMax H3 Qwen canvas {width}x{height} is not divisible by 32");
+    }
+    usize::try_from(u64::from(width / 32) * u64::from(height / 32))
+        .context("MiniMax H3 Qwen vision-token count exceeded usize")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Cursor, Write};
+
+    use image::{DynamicImage, ImageFormat, Rgb};
+    use mold_core::minimax_h3::GenerationReferencePreparedShape;
+    use mold_core::{GenerationReferenceAuthority, GenerationReferenceMetadata};
+    use sha2::{Digest, Sha256};
+
+    use super::*;
+    use crate::progress::{is_inference_cancelled, InferenceCancelled};
+
+    #[derive(Default)]
+    struct TestCheckpoint {
+        polls: usize,
+        cancel_at: Option<usize>,
+        phases: Vec<H3PipelinePhase>,
+    }
+
+    impl H3PipelineCheckpoint for TestCheckpoint {
+        fn checkpoint(&mut self, event: H3PipelineEvent) -> Result<()> {
+            self.polls += 1;
+            self.phases.push(event.phase);
+            if self.cancel_at == Some(self.polls) {
+                return Err(InferenceCancelled.into());
+            }
+            Ok(())
+        }
+    }
+
+    fn metadata(
+        index: u32,
+        kind: GenerationReferenceKind,
+        mime_type: &str,
+    ) -> GenerationReferenceMetadata {
+        GenerationReferenceMetadata {
+            kind,
+            index,
+            name: Some(format!("reference-{index}")),
+            sha256: String::new(),
+            mime_type: mime_type.into(),
+            width: None,
+            height: None,
+            frame_count: None,
+            duration_ms: None,
+            fps: None,
+            has_audio: false,
+            audio_duration_ms: None,
+            audio_sample_count: None,
+            audio_sample_rate: None,
+            audio_channels: None,
+            sample_rate: None,
+            channels: None,
+            sample_count: None,
+            prepared_shape: None,
+        }
+    }
+
+    fn binding(
+        mut metadata: GenerationReferenceMetadata,
+        bytes: &[u8],
+    ) -> GenerationReferenceBinding {
+        metadata.sha256 = format!("{:x}", Sha256::digest(bytes));
+        let mut staged = tempfile::NamedTempFile::new().unwrap();
+        staged.write_all(bytes).unwrap();
+        staged.flush().unwrap();
+        GenerationReferenceBinding::from_opened_file(
+            metadata,
+            staged.reopen().unwrap(),
+            u64::try_from(bytes.len()).unwrap(),
+            None,
+        )
+        .unwrap()
+    }
+
+    fn prepared(
+        mut metadata: GenerationReferenceMetadata,
+        shape: GenerationReferencePreparedShape,
+        target_frames: u32,
+        bytes: &[u8],
+    ) -> (H3PreparedReference, GenerationReferenceBinding) {
+        metadata.sha256 = format!("{:x}", Sha256::digest(bytes));
+        metadata.prepared_shape = Some(shape.clone());
+        let binding = binding(metadata.clone(), bytes);
+        (
+            H3PreparedReference {
+                metadata,
+                shape,
+                target_frames,
+            },
+            binding,
+        )
+    }
+
+    fn png(width: u32, height: u32) -> Vec<u8> {
+        let image = RgbImage::from_fn(width, height, |x, y| {
+            Rgb([(x % 251) as u8, (y % 241) as u8, ((x + y) % 239) as u8])
+        });
+        let mut bytes = Cursor::new(Vec::new());
+        DynamicImage::ImageRgb8(image)
+            .write_to(&mut bytes, ImageFormat::Png)
+            .unwrap();
+        bytes.into_inner()
+    }
+
+    #[test]
+    fn image_preprocessing_uses_its_own_2048_short_edge_canvas() {
+        let bytes = png(64, 64);
+        let mut metadata = metadata(1, GenerationReferenceKind::Image, "image/png");
+        metadata.width = Some(64);
+        metadata.height = Some(64);
+        let shape = GenerationReferencePreparedShape {
+            version: mold_core::minimax_h3::REFERENCE_PREPROCESS_VERSION,
+            normalized_width: Some(2_048),
+            normalized_height: Some(2_048),
+            normalized_video_frames: None,
+            video_frames: None,
+            qwen_video_frames: None,
+            audio_samples_per_channel: None,
+            visual_rows: 4_096,
+            audio_rows: 0,
+        };
+        let (reference, binding) = prepared(metadata, shape, 124, &bytes);
+        let mut adapter = H3ReferenceMediaAdapter::default();
+        let mut checkpoint = TestCheckpoint::default();
+        let facts = adapter
+            .decode_reference(&reference, &binding, &mut checkpoint)
+            .unwrap();
+        let presentation = adapter
+            .preprocess_reference(&reference, &facts, &mut checkpoint)
+            .unwrap();
+
+        assert_eq!(adapter.normalized_indices(), vec![1]);
+        let H3NormalizedReference::Image {
+            image,
+            vision_tokens,
+        } = adapter.normalized(1).unwrap()
+        else {
+            panic!("expected normalized image")
+        };
+        assert_eq!(image.dimensions(), (2_048, 2_048));
+        assert_eq!(*vision_tokens, 4_096);
+        assert_eq!(
+            presentation.presentation.kind,
+            RefPresentationKind::Image {
+                vision_tokens: 4_096
+            }
+        );
+        assert!(!presentation.presentation.has_audio);
+    }
+
+    #[test]
+    fn preprocessing_cancellation_is_typed_and_does_not_publish_media() {
+        let bytes = png(64, 64);
+        let mut metadata = metadata(1, GenerationReferenceKind::Image, "image/png");
+        metadata.width = Some(64);
+        metadata.height = Some(64);
+        let shape = GenerationReferencePreparedShape {
+            version: mold_core::minimax_h3::REFERENCE_PREPROCESS_VERSION,
+            normalized_width: Some(2_048),
+            normalized_height: Some(2_048),
+            normalized_video_frames: None,
+            video_frames: None,
+            qwen_video_frames: None,
+            audio_samples_per_channel: None,
+            visual_rows: 4_096,
+            audio_rows: 0,
+        };
+        let (reference, binding) = prepared(metadata, shape, 124, &bytes);
+        let mut adapter = H3ReferenceMediaAdapter::default();
+        let facts = adapter
+            .decode_reference(&reference, &binding, &mut TestCheckpoint::default())
+            .unwrap();
+        let mut checkpoint = TestCheckpoint {
+            cancel_at: Some(4),
+            ..Default::default()
+        };
+        let error = adapter
+            .preprocess_reference(&reference, &facts, &mut checkpoint)
+            .unwrap_err();
+        assert!(is_inference_cancelled(&error));
+        assert!(adapter.normalized(1).is_none());
+        assert_eq!(checkpoint.polls, 4);
+    }
+
+    #[test]
+    fn prepared_rows_freeze_2048_images_768_videos_and_exact_audio_duration() {
+        let references = vec![
+            mold_core::GenerationReference::Image {
+                media: GenerationReferenceAuthority::Descriptor,
+                provenance: Default::default(),
+                mime_type: "image/png".into(),
+                width: 64,
+                height: 64,
+            },
+            mold_core::GenerationReference::Video {
+                media: GenerationReferenceAuthority::Descriptor,
+                provenance: Default::default(),
+                mime_type: "video/mp4".into(),
+                width: 64,
+                height: 64,
+                frame_count: Some(48),
+                duration_ms: 2_000,
+                fps: 24.0,
+                has_audio: false,
+                audio_duration_ms: None,
+                audio_sample_count: None,
+                audio_sample_rate: None,
+                audio_channels: None,
+            },
+            mold_core::GenerationReference::Audio {
+                media: GenerationReferenceAuthority::Descriptor,
+                provenance: Default::default(),
+                mime_type: "audio/wav".into(),
+                duration_ms: 1_000,
+                sample_rate: 16_000,
+                channels: 4,
+                sample_count: Some(16_000),
+            },
+        ];
+        let shapes =
+            mold_core::minimax_h3::reference_prepared_shapes_for_target(&references, 124).unwrap();
+        assert_eq!(
+            (shapes[0].normalized_width, shapes[0].normalized_height),
+            (Some(2_048), Some(2_048))
+        );
+        assert_eq!(shapes[0].visual_rows, 4_096);
+        assert_eq!(
+            (shapes[1].normalized_width, shapes[1].normalized_height),
+            (Some(768), Some(768))
+        );
+        assert_eq!(shapes[1].normalized_video_frames, Some(48));
+        assert_eq!(shapes[1].video_frames, Some(39));
+        assert_eq!(shapes[1].qwen_video_frames, Some(4));
+        assert_eq!(shapes[1].visual_rows, 6_912);
+        assert_eq!(shapes[2].audio_samples_per_channel, Some(32_000));
+        assert_eq!(shapes[2].audio_rows, 80);
+    }
+
+    #[cfg(feature = "mp4")]
+    #[test]
+    fn ordinary_media_fixtures_preserve_order_soundtrack_and_duration() {
+        use crate::av_media::attach_aac_track_to_mp4_bytes;
+        use crate::ltx2::media::{encode_wav_f32_interleaved, probe_decoded_mp4_audio_file};
+        use crate::ltx_video::video_enc;
+
+        let image_bytes = png(32, 32);
+        let frames = (0..24)
+            .map(|index| RgbImage::from_pixel(32, 32, Rgb([index as u8, 32, 96])))
+            .collect::<Vec<_>>();
+        let video_only = video_enc::encode_mp4(&frames, 24).unwrap();
+        let soundtrack = (0..32_000)
+            .flat_map(|sample| {
+                let value = ((sample as f32 / 32_000.0) * std::f32::consts::TAU * 220.0).sin();
+                [value * 0.1, value * 0.2]
+            })
+            .collect::<Vec<_>>();
+        let video_bytes =
+            attach_aac_track_to_mp4_bytes(&video_only, &soundtrack, 32_000, 2).unwrap();
+        let mut video_file = tempfile::NamedTempFile::new().unwrap();
+        video_file.write_all(&video_bytes).unwrap();
+        video_file.flush().unwrap();
+        let audio_probe = probe_decoded_mp4_audio_file(video_file.path())
+            .unwrap()
+            .unwrap();
+
+        let audio_samples = (0..8_000)
+            .flat_map(|sample| {
+                let value = sample as f32 / 8_000.0;
+                [value, value * 2.0, value * 3.0, value * 4.0]
+            })
+            .collect::<Vec<_>>();
+        let audio_bytes = encode_wav_f32_interleaved(&audio_samples, 16_000, 4).unwrap();
+
+        let mut image_metadata = metadata(1, GenerationReferenceKind::Image, "image/png");
+        image_metadata.width = Some(32);
+        image_metadata.height = Some(32);
+        let image_shape = GenerationReferencePreparedShape {
+            version: mold_core::minimax_h3::REFERENCE_PREPROCESS_VERSION,
+            normalized_width: Some(32),
+            normalized_height: Some(32),
+            normalized_video_frames: None,
+            video_frames: None,
+            qwen_video_frames: None,
+            audio_samples_per_channel: None,
+            visual_rows: 1,
+            audio_rows: 0,
+        };
+        let (image_reference, image_binding) =
+            prepared(image_metadata, image_shape, 24, &image_bytes);
+
+        let mut video_metadata = metadata(2, GenerationReferenceKind::Video, "video/mp4");
+        video_metadata.width = Some(32);
+        video_metadata.height = Some(32);
+        video_metadata.frame_count = Some(24);
+        video_metadata.duration_ms = Some(1_000);
+        video_metadata.fps = Some(24.0);
+        video_metadata.has_audio = true;
+        video_metadata.audio_duration_ms = Some(1_000);
+        video_metadata.audio_sample_count = Some(audio_probe.samples_per_channel);
+        video_metadata.audio_sample_rate = Some(audio_probe.sample_rate);
+        video_metadata.audio_channels = Some(audio_probe.channels);
+        let expected_video_audio = audio_probe
+            .samples_per_channel
+            .min(u64::from(audio_probe.sample_rate));
+        let expected_video_audio = expected_video_audio
+            .checked_mul(u64::from(AUDIO_SAMPLE_RATE_HZ))
+            .unwrap()
+            .div_ceil(u64::from(audio_probe.sample_rate));
+        let video_shape = GenerationReferencePreparedShape {
+            version: mold_core::minimax_h3::REFERENCE_PREPROCESS_VERSION,
+            normalized_width: Some(32),
+            normalized_height: Some(32),
+            normalized_video_frames: Some(24),
+            video_frames: Some(22),
+            qwen_video_frames: Some(2),
+            audio_samples_per_channel: Some(expected_video_audio),
+            visual_rows: 7,
+            audio_rows: expected_video_audio.div_ceil(800) * 2,
+        };
+        let (video_reference, video_binding) =
+            prepared(video_metadata, video_shape, 24, &video_bytes);
+
+        let mut audio_metadata = metadata(3, GenerationReferenceKind::Audio, "audio/wav");
+        audio_metadata.duration_ms = Some(500);
+        audio_metadata.sample_rate = Some(16_000);
+        audio_metadata.channels = Some(4);
+        audio_metadata.sample_count = Some(8_000);
+        let audio_shape = GenerationReferencePreparedShape {
+            version: mold_core::minimax_h3::REFERENCE_PREPROCESS_VERSION,
+            normalized_width: None,
+            normalized_height: None,
+            normalized_video_frames: None,
+            video_frames: None,
+            qwen_video_frames: None,
+            audio_samples_per_channel: Some(16_000),
+            visual_rows: 0,
+            audio_rows: 40,
+        };
+        let (audio_reference, audio_binding) =
+            prepared(audio_metadata, audio_shape, 24, &audio_bytes);
+
+        let references = [image_reference, video_reference, audio_reference];
+        let bindings = [image_binding, video_binding, audio_binding];
+        let mut adapter = H3ReferenceMediaAdapter::default();
+        let mut checkpoint = TestCheckpoint::default();
+        let decoded = references
+            .iter()
+            .zip(&bindings)
+            .map(|(reference, binding)| {
+                adapter.decode_reference(reference, binding, &mut checkpoint)
+            })
+            .collect::<Result<Vec<_>>>()
+            .unwrap();
+        let presentations = references
+            .iter()
+            .zip(&decoded)
+            .map(|(reference, decoded)| {
+                adapter.preprocess_reference(reference, decoded, &mut checkpoint)
+            })
+            .collect::<Result<Vec<_>>>()
+            .unwrap();
+
+        assert_eq!(adapter.normalized_indices(), vec![1, 2, 3]);
+        assert_eq!(
+            presentations
+                .iter()
+                .map(|presentation| presentation.index)
+                .collect::<Vec<_>>(),
+            vec![1, 2, 3]
+        );
+        let H3NormalizedReference::Video {
+            vae_frames,
+            qwen_frames,
+            qwen_source_indices,
+            audio: Some(video_audio),
+        } = adapter.normalized(2).unwrap()
+        else {
+            panic!("expected normalized video with soundtrack")
+        };
+        assert_eq!(vae_frames.len(), 22);
+        assert_eq!(qwen_frames.len(), 2);
+        assert_eq!(qwen_source_indices, &[0, 12]);
+        assert_eq!(video_audio.sample_rate, 32_000);
+        assert_eq!(
+            video_audio.samples_per_channel(),
+            usize::try_from(expected_video_audio).unwrap()
+        );
+        assert!(presentations[1].presentation.has_audio);
+        let H3NormalizedReference::Audio { audio } = adapter.normalized(3).unwrap() else {
+            panic!("expected normalized audio")
+        };
+        assert_eq!(audio.sample_rate, 32_000);
+        assert_eq!(audio.samples_per_channel(), 16_000);
+        assert_eq!(audio.channels[0][100], 0.0125);
+        assert_eq!(audio.channels[1][100], 0.01875);
+    }
+}

--- a/crates/mold-inference/src/minimax_h3/reference_media.rs
+++ b/crates/mold-inference/src/minimax_h3/reference_media.rs
@@ -4,7 +4,7 @@
 //! model family. It turns server-bound, digest-verified file descriptors into
 //! the exact media tensors a future legally admitted backend must encode.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use anyhow::{anyhow, bail, Context, Result};
 use image::RgbImage;
@@ -23,15 +23,16 @@ use super::pipeline::{
 use crate::engine::GenerationReferenceBinding;
 use crate::ltx2::DecodedAudio;
 use crate::reference_media::{
-    cfr_source_indices, decode_audio_from_open_file, decode_image_from_open_file,
-    decode_video_from_open_file, normalize_audio, NormalizedStereoAudio,
+    cfr_source_indices, decode_audio_from_binding, decode_image_from_binding,
+    decode_video_from_binding, normalize_audio, NormalizedStereoAudio,
 };
 
 #[derive(Debug)]
 enum DecodedReference {
     Image(RgbImage),
     Video {
-        frames: Vec<RgbImage>,
+        selected_frames: BTreeMap<usize, RgbImage>,
+        source_frame_count: u32,
         fps: f64,
         audio: Option<DecodedAudio>,
     },
@@ -102,7 +103,7 @@ impl H3ReferenceMediaAdapter {
         };
         let (facts, media) = match reference.metadata.kind {
             GenerationReferenceKind::Image => {
-                let image = decode_image_from_open_file(binding.file(), &mut poll)?;
+                let image = decode_image_from_binding(binding, &mut poll)?;
                 let facts = H3DecodedReferenceFacts {
                     index,
                     kind: GenerationReferenceKind::Image,
@@ -115,11 +116,35 @@ impl H3ReferenceMediaAdapter {
                 (facts, DecodedReference::Image(image))
             }
             GenerationReferenceKind::Video => {
-                let decoded = decode_video_from_open_file(binding.file(), &mut poll)?;
-                let first = decoded
+                let width = required_dimension(reference.shape.normalized_width, "width")?;
+                let height = required_dimension(reference.shape.normalized_height, "height")?;
+                let source_frame_count = required_count(
+                    reference.metadata.frame_count,
+                    "decoded source video frames",
+                )?;
+                let source_fps = reference
+                    .metadata
+                    .fps
+                    .filter(|fps| fps.is_finite() && *fps > 0.0)
+                    .ok_or_else(|| anyhow!("MiniMax H3 reference lost its decoded frame rate"))?;
+                let selected_source_indices = selected_video_source_indices(
+                    reference,
+                    source_frame_count,
+                    source_fps,
+                    &mut poll,
+                )?;
+                let mut resize =
+                    |frame: RgbImage| pillow_lanczos_resize(&frame, width, height, &mut || Ok(()));
+                let decoded = decode_video_from_binding(
+                    binding,
+                    &selected_source_indices,
+                    &mut resize,
+                    &mut poll,
+                )?;
+                decoded
                     .frames
                     .first()
-                    .context("decoded H3 reference video did not contain a frame")?;
+                    .context("decoded H3 reference video did not contain a selected frame")?;
                 let audio_facts = decoded
                     .audio
                     .as_ref()
@@ -128,30 +153,29 @@ impl H3ReferenceMediaAdapter {
                 let facts = H3DecodedReferenceFacts {
                     index,
                     kind: GenerationReferenceKind::Video,
-                    width: Some(first.width()),
-                    height: Some(first.height()),
-                    frame_count: Some(
-                        u32::try_from(decoded.frames.len())
-                            .context("decoded H3 reference frame count exceeded u32")?,
-                    ),
+                    width: Some(decoded.source_width),
+                    height: Some(decoded.source_height),
+                    frame_count: Some(decoded.source_frame_count),
                     fps: Some(decoded.fps),
                     audio: audio_facts,
                 };
+                let selected_frames = selected_source_indices
+                    .into_iter()
+                    .zip(decoded.frames)
+                    .collect();
                 (
                     facts,
                     DecodedReference::Video {
-                        frames: decoded.frames,
+                        selected_frames,
+                        source_frame_count: decoded.source_frame_count,
                         fps: decoded.fps,
                         audio: decoded.audio,
                     },
                 )
             }
             GenerationReferenceKind::Audio => {
-                let decoded = decode_audio_from_open_file(
-                    binding.file(),
-                    &reference.metadata.mime_type,
-                    &mut poll,
-                )?;
+                let decoded =
+                    decode_audio_from_binding(binding, &reference.metadata.mime_type, &mut poll)?;
                 let facts = H3DecodedReferenceFacts {
                     index,
                     kind: GenerationReferenceKind::Audio,
@@ -227,7 +251,12 @@ impl H3ReferenceMediaAdapter {
                     },
                 )
             }
-            DecodedReference::Video { frames, fps, audio } => {
+            DecodedReference::Video {
+                selected_frames,
+                source_frame_count,
+                fps,
+                audio,
+            } => {
                 let width = required_dimension(reference.shape.normalized_width, "width")?;
                 let height = required_dimension(reference.shape.normalized_height, "height")?;
                 let normalized_count = required_count(
@@ -235,20 +264,29 @@ impl H3ReferenceMediaAdapter {
                     "normalized video frames",
                 )?;
                 let vae_count = required_count(reference.shape.video_frames, "video VAE frames")?;
-                let cfr_indices =
-                    cfr_source_indices(frames.len(), fps, FIXED_FPS, normalized_count, &mut poll)?;
+                let cfr_indices = cfr_source_indices(
+                    usize::try_from(source_frame_count)?,
+                    fps,
+                    FIXED_FPS,
+                    normalized_count,
+                    &mut poll,
+                )?;
                 if vae_count > cfr_indices.len() {
                     bail!("MiniMax H3 visual-VAE frame prefix exceeds normalized video");
                 }
                 let mut vae_frames = Vec::with_capacity(vae_count);
                 for &source_index in &cfr_indices[..vae_count] {
                     poll()?;
-                    vae_frames.push(pillow_lanczos_resize(
-                        &frames[source_index],
-                        width,
-                        height,
-                        &mut poll,
-                    )?);
+                    vae_frames.push(
+                        selected_frames
+                            .get(&source_index)
+                            .with_context(|| {
+                                format!(
+                                    "MiniMax H3 decoder omitted selected source frame {source_index}"
+                                )
+                            })?
+                            .clone(),
+                    );
                 }
 
                 let sampled = sample_video_frames(normalized_count, f64::from(FIXED_FPS))?;
@@ -266,12 +304,16 @@ impl H3ReferenceMediaAdapter {
                     if normalized_index < vae_frames.len() {
                         qwen_frames.push(vae_frames[normalized_index].clone());
                     } else {
-                        qwen_frames.push(pillow_lanczos_resize(
-                            &frames[source_index],
-                            width,
-                            height,
-                            &mut poll,
-                        )?);
+                        qwen_frames.push(
+                            selected_frames
+                                .get(&source_index)
+                                .with_context(|| {
+                                    format!(
+                                        "MiniMax H3 decoder omitted Qwen source frame {source_index}"
+                                    )
+                                })?
+                                .clone(),
+                        );
                     }
                 }
                 let audio = match audio {
@@ -326,6 +368,43 @@ impl H3ReferenceMediaAdapter {
     pub(crate) fn normalized_indices(&self) -> Vec<u32> {
         self.normalized_order.clone()
     }
+}
+
+fn selected_video_source_indices(
+    reference: &H3PreparedReference,
+    source_frame_count: usize,
+    source_fps: f64,
+    checkpoint: &mut dyn FnMut() -> Result<()>,
+) -> Result<Vec<usize>> {
+    let normalized_count = required_count(
+        reference.shape.normalized_video_frames,
+        "normalized video frames",
+    )?;
+    let vae_count = required_count(reference.shape.video_frames, "video VAE frames")?;
+    let cfr_indices = cfr_source_indices(
+        source_frame_count,
+        source_fps,
+        FIXED_FPS,
+        normalized_count,
+        checkpoint,
+    )?;
+    if vae_count > cfr_indices.len() {
+        bail!("MiniMax H3 visual-VAE frame prefix exceeds normalized video");
+    }
+    let sampled = sample_video_frames(normalized_count, f64::from(FIXED_FPS))?;
+    let expected_qwen = required_count(reference.shape.qwen_video_frames, "Qwen video frames")?;
+    if sampled.frame_indices.len() != expected_qwen {
+        bail!("MiniMax H3 Qwen 2 fps sampling changed the prepared frame count");
+    }
+    let mut selected = BTreeSet::new();
+    selected.extend(cfr_indices[..vae_count].iter().copied());
+    selected.extend(
+        sampled
+            .frame_indices
+            .into_iter()
+            .map(|normalized_index| cfr_indices[normalized_index]),
+    );
+    Ok(selected.into_iter().collect())
 }
 
 fn decoded_audio_facts(decoded: &DecodedAudio) -> Result<H3DecodedAudioFacts> {
@@ -664,10 +743,10 @@ mod tests {
         let audio_samples = (0..8_000)
             .flat_map(|sample| {
                 let value = sample as f32 / 8_000.0;
-                [value, value * 2.0, value * 3.0, value * 4.0]
+                [value * 2.0, value * 3.0]
             })
             .collect::<Vec<_>>();
-        let audio_bytes = encode_wav_f32_interleaved(&audio_samples, 16_000, 4).unwrap();
+        let audio_bytes = encode_wav_f32_interleaved(&audio_samples, 16_000, 2).unwrap();
 
         let mut image_metadata = metadata(1, GenerationReferenceKind::Image, "image/png");
         image_metadata.width = Some(32);
@@ -721,7 +800,7 @@ mod tests {
         let mut audio_metadata = metadata(3, GenerationReferenceKind::Audio, "audio/wav");
         audio_metadata.duration_ms = Some(500);
         audio_metadata.sample_rate = Some(16_000);
-        audio_metadata.channels = Some(4);
+        audio_metadata.channels = Some(2);
         audio_metadata.sample_count = Some(8_000);
         let audio_shape = GenerationReferencePreparedShape {
             version: mold_core::minimax_h3::REFERENCE_PREPROCESS_VERSION,
@@ -789,7 +868,7 @@ mod tests {
         };
         assert_eq!(audio.sample_rate, 32_000);
         assert_eq!(audio.samples_per_channel(), 16_000);
-        assert_eq!(audio.channels[0][100], 0.0125);
-        assert_eq!(audio.channels[1][100], 0.01875);
+        assert!((audio.channels[0][100] - 0.0125).abs() < 1e-6);
+        assert!((audio.channels[1][100] - 0.01875).abs() < 1e-6);
     }
 }

--- a/crates/mold-inference/src/reference_media.rs
+++ b/crates/mold-inference/src/reference_media.rs
@@ -4,13 +4,14 @@
 //! file. These helpers preserve that authority by copying the open descriptor
 //! into private decoder storage; they never reopen a user-controlled path.
 
-use std::fs::File;
 use std::io::{Read, Seek, SeekFrom, Write};
 
 use anyhow::{anyhow, bail, Context, Result};
 use image::{ImageReader, RgbImage};
+use sha2::{Digest, Sha256};
 use tempfile::{Builder, NamedTempFile};
 
+use crate::engine::GenerationReferenceBinding;
 use crate::ltx2::{media, DecodedAudio};
 
 const COPY_CHUNK_BYTES: usize = 64 * 1024;
@@ -18,7 +19,10 @@ const COPY_CHUNK_BYTES: usize = 64 * 1024;
 #[derive(Debug)]
 pub(crate) struct DecodedReferenceVideo {
     pub frames: Vec<RgbImage>,
+    pub source_width: u32,
+    pub source_height: u32,
     pub fps: f64,
+    pub source_frame_count: u32,
     pub audio: Option<DecodedAudio>,
 }
 
@@ -34,11 +38,11 @@ impl NormalizedStereoAudio {
     }
 }
 
-pub(crate) fn decode_image_from_open_file(
-    file: &File,
+pub(crate) fn decode_image_from_binding(
+    binding: &GenerationReferenceBinding,
     checkpoint: &mut dyn FnMut() -> Result<()>,
 ) -> Result<RgbImage> {
-    let bytes = read_open_file(file, checkpoint)?;
+    let bytes = read_verified_binding(binding, checkpoint)?;
     checkpoint()?;
     let mut reader = ImageReader::new(std::io::Cursor::new(bytes))
         .with_guessed_format()
@@ -60,36 +64,47 @@ pub(crate) fn decode_image_from_open_file(
     Ok(image)
 }
 
-pub(crate) fn decode_video_from_open_file(
-    file: &File,
+pub(crate) fn decode_video_from_binding(
+    binding: &GenerationReferenceBinding,
+    selected_source_indices: &[usize],
+    frame_transform: &mut dyn FnMut(RgbImage) -> Result<RgbImage>,
     checkpoint: &mut dyn FnMut() -> Result<()>,
 ) -> Result<DecodedReferenceVideo> {
-    let staged = stage_open_file(file, ".mp4", checkpoint)?;
-    let (metadata, frames) =
-        media::decode_video_frames_from_path_with_checkpoint(staged.path(), checkpoint)?;
+    let staged = stage_verified_binding(binding, ".mp4", checkpoint)?;
+    let (metadata, frames) = media::decode_video_frames_selected_from_path_with_checkpoint(
+        staged.path(),
+        selected_source_indices,
+        frame_transform,
+        checkpoint,
+    )?;
     checkpoint()?;
     let audio = if metadata.has_audio {
-        DecodedAudio::from_mp4_file(staged.path(), None)?
+        DecodedAudio::from_mp4_file_with_checkpoint(staged.path(), None, checkpoint)?
     } else {
         None
     };
     checkpoint()?;
     Ok(DecodedReferenceVideo {
         frames,
+        source_width: metadata.width,
+        source_height: metadata.height,
         fps: f64::from(metadata.fps),
+        source_frame_count: metadata
+            .frames
+            .context("decoded reference video lost its source frame count")?,
         audio,
     })
 }
 
-pub(crate) fn decode_audio_from_open_file(
-    file: &File,
+pub(crate) fn decode_audio_from_binding(
+    binding: &GenerationReferenceBinding,
     mime_type: &str,
     checkpoint: &mut dyn FnMut() -> Result<()>,
 ) -> Result<DecodedAudio> {
     let suffix = audio_suffix(mime_type);
-    let staged = stage_open_file(file, suffix, checkpoint)?;
+    let staged = stage_verified_binding(binding, suffix, checkpoint)?;
     checkpoint()?;
-    let decoded = DecodedAudio::from_file(staged.path(), None)?
+    let decoded = DecodedAudio::from_file_with_checkpoint(staged.path(), None, checkpoint)?
         .ok_or_else(|| anyhow!("reference audio did not contain a decodable audio stream"))?;
     checkpoint()?;
     Ok(decoded)
@@ -168,8 +183,8 @@ pub(crate) fn cfr_source_indices(
     Ok(normalized)
 }
 
-/// Truncate in the native sample domain, remix every input channel to stereo,
-/// then resample exactly once to the frozen output rate and sample count.
+/// Truncate in the native sample domain, upmix mono to stereo, then resample
+/// exactly once to the frozen output rate and sample count.
 pub(crate) fn normalize_audio(
     decoded: &DecodedAudio,
     maximum_native_samples: usize,
@@ -177,8 +192,11 @@ pub(crate) fn normalize_audio(
     expected_samples: usize,
     checkpoint: &mut dyn FnMut() -> Result<()>,
 ) -> Result<NormalizedStereoAudio> {
-    if decoded.sample_rate == 0 || decoded.channels.is_empty() || target_sample_rate == 0 {
-        bail!("reference audio normalization requires positive rates and decoded channels");
+    if decoded.sample_rate == 0
+        || !matches!(decoded.channels.len(), 1 | 2)
+        || target_sample_rate == 0
+    {
+        bail!("reference audio normalization requires positive rates and mono/stereo audio");
     }
     let source_samples = decoded.sample_count();
     if source_samples == 0
@@ -194,21 +212,31 @@ pub(crate) fn normalize_audio(
         bail!("reference audio normalization resolved an empty duration");
     }
     checkpoint()?;
-    let stereo = remix_stereo(&decoded.channels, native_samples, checkpoint)?;
+    let stereo = match decoded.channels.as_slice() {
+        [mono] => {
+            let mono = mono[..native_samples].to_vec();
+            [mono.clone(), mono]
+        }
+        [left, right] => [
+            left[..native_samples].to_vec(),
+            right[..native_samples].to_vec(),
+        ],
+        _ => unreachable!("channel count was validated above"),
+    };
     let channels = if decoded.sample_rate == target_sample_rate as usize
         && native_samples == expected_samples
     {
         stereo
     } else {
         [
-            resample_channel(
+            torchaudio_hann_resample_channel(
                 &stereo[0],
                 decoded.sample_rate,
                 target_sample_rate as usize,
                 expected_samples,
                 checkpoint,
             )?,
-            resample_channel(
+            torchaudio_hann_resample_channel(
                 &stereo[1],
                 decoded.sample_rate,
                 target_sample_rate as usize,
@@ -224,79 +252,131 @@ pub(crate) fn normalize_audio(
     })
 }
 
-fn remix_stereo(
-    channels: &[Vec<f32>],
-    sample_count: usize,
-    checkpoint: &mut dyn FnMut() -> Result<()>,
-) -> Result<[Vec<f32>; 2]> {
-    if channels.len() == 1 {
-        let mono = channels[0][..sample_count].to_vec();
-        return Ok([mono.clone(), mono]);
-    }
-    if channels.len() == 2 {
-        return Ok([
-            channels[0][..sample_count].to_vec(),
-            channels[1][..sample_count].to_vec(),
-        ]);
-    }
-
-    // Preserve the established left/right pair and include every additional
-    // channel deterministically. Even-numbered channels feed left, odd feed
-    // right; each side is averaged to avoid gain growth for wide layouts.
-    let left_count = channels.len().div_ceil(2) as f32;
-    let right_count = (channels.len() / 2) as f32;
-    let mut left = Vec::with_capacity(sample_count);
-    let mut right = Vec::with_capacity(sample_count);
-    for sample in 0..sample_count {
-        if sample.is_multiple_of(4_096) {
-            checkpoint()?;
-        }
-        let mut left_sum = 0.0_f32;
-        let mut right_sum = 0.0_f32;
-        for (channel_index, channel) in channels.iter().enumerate() {
-            if channel_index.is_multiple_of(2) {
-                left_sum += channel[sample];
-            } else {
-                right_sum += channel[sample];
-            }
-        }
-        left.push(left_sum / left_count);
-        right.push(right_sum / right_count);
-    }
-    Ok([left, right])
-}
-
-fn resample_channel(
+/// Pure-Rust expression of torchaudio's default `sinc_interp_hann` resampler.
+///
+/// H3's pinned Diffusers setup calls `torchaudio.transforms.Resample` with its
+/// defaults. Keep the same reduced-rate polyphase kernel, six-zero-crossing
+/// Hann window, 0.99 rolloff, zero padding, and ceiling output length. The
+/// reference is torchaudio 2.8.0 `functional.py`; attribution is preserved in
+/// `THIRD_PARTY_NOTICES.md`.
+fn torchaudio_hann_resample_channel(
     source: &[f32],
     source_rate: usize,
     target_rate: usize,
     expected_samples: usize,
     checkpoint: &mut dyn FnMut() -> Result<()>,
 ) -> Result<Vec<f32>> {
+    const LOWPASS_FILTER_WIDTH: f64 = 6.0;
+    const ROLLOFF: f64 = 0.99;
+
+    if source.is_empty() || source_rate == 0 || target_rate == 0 {
+        bail!("reference audio resampling requires samples and positive rates");
+    }
+    let divisor = greatest_common_divisor(source_rate, target_rate);
+    let source_rate = source_rate / divisor;
+    let target_rate = target_rate / divisor;
+    let calculated_samples = source
+        .len()
+        .checked_mul(target_rate)
+        .context("reference audio resample length overflowed")?
+        .div_ceil(source_rate);
+    if calculated_samples != expected_samples {
+        bail!(
+            "reference audio resample length changed: calculated {calculated_samples}, expected {expected_samples}"
+        );
+    }
+
+    let base_rate = source_rate.min(target_rate) as f64 * ROLLOFF;
+    let width = (LOWPASS_FILTER_WIDTH * source_rate as f64 / base_rate).ceil() as usize;
+    let kernel_len = width
+        .checked_mul(2)
+        .and_then(|length| length.checked_add(source_rate))
+        .context("reference audio resample kernel length overflowed")?;
+    let scale = base_rate / source_rate as f64;
+    let mut kernels = Vec::with_capacity(target_rate);
+    for phase in 0..target_rate {
+        checkpoint()?;
+        let mut kernel = Vec::with_capacity(kernel_len);
+        for offset in 0..kernel_len {
+            let index = offset as f64 - width as f64;
+            let mut time =
+                (-(phase as f64) / target_rate as f64 + index / source_rate as f64) * base_rate;
+            time = time.clamp(-LOWPASS_FILTER_WIDTH, LOWPASS_FILTER_WIDTH);
+            let window = (time * std::f64::consts::PI / LOWPASS_FILTER_WIDTH / 2.0)
+                .cos()
+                .powi(2);
+            let angle = time * std::f64::consts::PI;
+            let sinc = if angle == 0.0 {
+                1.0
+            } else {
+                angle.sin() / angle
+            };
+            kernel.push((sinc * window * scale) as f32);
+        }
+        kernels.push(kernel);
+    }
+
     let mut output = Vec::with_capacity(expected_samples);
-    for target_index in 0..expected_samples {
-        if target_index.is_multiple_of(4_096) {
+    for output_index in 0..expected_samples {
+        if output_index.is_multiple_of(4_096) {
             checkpoint()?;
         }
-        let source_position = target_index as f64 * source_rate as f64 / target_rate as f64;
-        let left = (source_position.floor() as usize).min(source.len() - 1);
-        let right = (left + 1).min(source.len() - 1);
-        let fraction = (source_position - source_position.floor()) as f32;
-        output.push(source[left] + (source[right] - source[left]) * fraction);
+        let frame = output_index / target_rate;
+        let phase = output_index % target_rate;
+        let input_start = frame
+            .checked_mul(source_rate)
+            .context("reference audio resample cursor overflowed")?;
+        let mut sample = 0.0_f32;
+        for (kernel_index, &coefficient) in kernels[phase].iter().enumerate() {
+            let padded_index = input_start
+                .checked_add(kernel_index)
+                .context("reference audio resample index overflowed")?;
+            let Some(source_index) = padded_index.checked_sub(width) else {
+                continue;
+            };
+            if source_index >= source.len() {
+                continue;
+            }
+            sample += source[source_index] * coefficient;
+        }
+        output.push(sample);
     }
     Ok(output)
 }
 
-fn read_open_file(file: &File, checkpoint: &mut dyn FnMut() -> Result<()>) -> Result<Vec<u8>> {
-    let mut file = file
+fn greatest_common_divisor(mut left: usize, mut right: usize) -> usize {
+    while right != 0 {
+        (left, right) = (right, left % right);
+    }
+    left
+}
+
+fn read_verified_binding(
+    binding: &GenerationReferenceBinding,
+    checkpoint: &mut dyn FnMut() -> Result<()>,
+) -> Result<Vec<u8>> {
+    let expected_bytes = binding.verified_bytes();
+    let capacity = usize::try_from(expected_bytes).context("reference media is too large")?;
+    let mut bytes = Vec::with_capacity(capacity);
+    copy_and_verify_binding(binding, &mut bytes, checkpoint)?;
+    Ok(bytes)
+}
+
+fn copy_and_verify_binding(
+    binding: &GenerationReferenceBinding,
+    destination: &mut dyn Write,
+    checkpoint: &mut dyn FnMut() -> Result<()>,
+) -> Result<()> {
+    let expected_bytes = binding.verified_bytes();
+    let mut file = binding
+        .file()
         .try_clone()
         .context("failed to duplicate opened reference media")?;
     file.seek(SeekFrom::Start(0))
         .context("failed to rewind opened reference media")?;
-    let capacity =
-        usize::try_from(file.metadata()?.len()).context("reference media is too large")?;
-    let mut bytes = Vec::with_capacity(capacity);
     let mut chunk = [0_u8; COPY_CHUNK_BYTES];
+    let mut digest = Sha256::new();
+    let mut observed_bytes = 0_u64;
     loop {
         checkpoint()?;
         let read = file
@@ -305,41 +385,38 @@ fn read_open_file(file: &File, checkpoint: &mut dyn FnMut() -> Result<()>) -> Re
         if read == 0 {
             break;
         }
-        bytes.extend_from_slice(&chunk[..read]);
+        observed_bytes = observed_bytes
+            .checked_add(u64::try_from(read)?)
+            .context("reference media byte count overflowed")?;
+        if observed_bytes > expected_bytes {
+            bail!("opened reference media grew after digest verification");
+        }
+        digest.update(&chunk[..read]);
+        destination
+            .write_all(&chunk[..read])
+            .context("failed to copy opened reference media")?;
     }
-    Ok(bytes)
+    if observed_bytes != expected_bytes {
+        bail!("opened reference media changed size after digest verification");
+    }
+    let observed_digest = format!("{:x}", digest.finalize());
+    if !observed_digest.eq_ignore_ascii_case(&binding.metadata().sha256) {
+        bail!("opened reference media changed after digest verification");
+    }
+    Ok(())
 }
 
-fn stage_open_file(
-    file: &File,
+fn stage_verified_binding(
+    binding: &GenerationReferenceBinding,
     suffix: &str,
     checkpoint: &mut dyn FnMut() -> Result<()>,
 ) -> Result<NamedTempFile> {
-    let mut source = file
-        .try_clone()
-        .context("failed to duplicate opened reference media")?;
-    source
-        .seek(SeekFrom::Start(0))
-        .context("failed to rewind opened reference media")?;
     let mut staged = Builder::new()
         .prefix("mold-reference-")
         .suffix(suffix)
         .tempfile()
         .context("failed to create private reference decoder storage")?;
-    let mut chunk = [0_u8; COPY_CHUNK_BYTES];
-    loop {
-        checkpoint()?;
-        let read = source
-            .read(&mut chunk)
-            .context("failed to read opened reference media")?;
-        if read == 0 {
-            break;
-        }
-        staged
-            .as_file_mut()
-            .write_all(&chunk[..read])
-            .context("failed to stage opened reference media")?;
-    }
+    copy_and_verify_binding(binding, staged.as_file_mut(), checkpoint)?;
     staged
         .as_file_mut()
         .flush()
@@ -362,9 +439,68 @@ fn audio_suffix(mime_type: &str) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mold_core::{GenerationReferenceKind, GenerationReferenceMetadata};
+
+    fn binding(bytes: &[u8]) -> (NamedTempFile, GenerationReferenceBinding) {
+        let mut staged = NamedTempFile::new().unwrap();
+        staged.write_all(bytes).unwrap();
+        staged.flush().unwrap();
+        let metadata = GenerationReferenceMetadata {
+            kind: GenerationReferenceKind::Image,
+            index: 1,
+            name: Some("reference.png".into()),
+            sha256: format!("{:x}", Sha256::digest(bytes)),
+            mime_type: "image/png".into(),
+            width: Some(1),
+            height: Some(1),
+            frame_count: None,
+            duration_ms: None,
+            fps: None,
+            has_audio: false,
+            audio_duration_ms: None,
+            audio_sample_count: None,
+            audio_sample_rate: None,
+            audio_channels: None,
+            sample_rate: None,
+            channels: None,
+            sample_count: None,
+            prepared_shape: None,
+        };
+        let opened = staged.reopen().unwrap();
+        let binding = GenerationReferenceBinding::from_opened_file(
+            metadata,
+            opened,
+            u64::try_from(bytes.len()).unwrap(),
+            None,
+        )
+        .unwrap();
+        (staged, binding)
+    }
 
     fn frame(value: u8) -> RgbImage {
         RgbImage::from_pixel(2, 2, image::Rgb([value, 0, 0]))
+    }
+
+    #[test]
+    fn decoder_copy_rejects_same_length_inode_mutation_after_admission() {
+        let (mut staged, binding) = binding(b"original");
+        staged.as_file_mut().seek(SeekFrom::Start(0)).unwrap();
+        staged.as_file_mut().write_all(b"tampered").unwrap();
+        staged.as_file_mut().flush().unwrap();
+
+        let error = read_verified_binding(&binding, &mut || Ok(())).unwrap_err();
+        assert!(error.to_string().contains("changed after digest"));
+    }
+
+    #[test]
+    fn decoder_copy_rejects_inode_growth_after_admission() {
+        let (mut staged, binding) = binding(b"original");
+        staged.as_file_mut().seek(SeekFrom::End(0)).unwrap();
+        staged.as_file_mut().write_all(b"-growth").unwrap();
+        staged.as_file_mut().flush().unwrap();
+
+        let error = read_verified_binding(&binding, &mut || Ok(())).unwrap_err();
+        assert!(error.to_string().contains("grew after digest"));
     }
 
     #[test]
@@ -386,23 +522,45 @@ mod tests {
     }
 
     #[test]
-    fn arbitrary_channel_audio_is_truncated_remixed_and_resampled_exactly() {
+    fn mono_audio_is_truncated_upmixed_and_hann_resampled_exactly() {
+        let decoded = DecodedAudio {
+            sample_rate: 8_000,
+            channels: vec![vec![0.0, 1.0, 0.0, -1.0]],
+        };
+        let normalized = normalize_audio(&decoded, 4, 16_000, 8, &mut || Ok(())).unwrap();
+        assert_eq!(normalized.sample_rate, 16_000);
+        assert_eq!(normalized.samples_per_channel(), 8);
+        assert_eq!(normalized.channels[0], normalized.channels[1]);
+        let expected = [
+            0.004_270_599,
+            0.545_218_17,
+            0.997_540_24,
+            0.807_425_9,
+            0.0,
+            -0.807_425_9,
+            -0.997_540_24,
+            -0.545_218_17,
+        ];
+        for (actual, expected) in normalized.channels[0].iter().zip(expected) {
+            assert!((actual - expected).abs() < 1e-6, "{actual} != {expected}");
+        }
+    }
+
+    #[test]
+    fn audio_with_more_than_two_channels_fails_closed() {
         let decoded = DecodedAudio {
             sample_rate: 16_000,
-            channels: vec![vec![1.0; 8], vec![2.0; 8], vec![3.0; 8], vec![4.0; 8]],
+            channels: vec![vec![0.0; 8]; 3],
         };
-        let normalized = normalize_audio(&decoded, 4, 32_000, 8, &mut || Ok(())).unwrap();
-        assert_eq!(normalized.sample_rate, 32_000);
-        assert_eq!(normalized.samples_per_channel(), 8);
-        assert_eq!(normalized.channels[0], vec![2.0; 8]);
-        assert_eq!(normalized.channels[1], vec![3.0; 8]);
+        let error = normalize_audio(&decoded, 8, 32_000, 16, &mut || Ok(())).unwrap_err();
+        assert!(error.to_string().contains("mono/stereo"));
     }
 
     #[test]
     fn long_audio_work_polls_cancellation() {
         let decoded = DecodedAudio {
             sample_rate: 48_000,
-            channels: vec![vec![0.0; 20_000]; 6],
+            channels: vec![vec![0.0; 20_000]; 2],
         };
         let mut polls = 0;
         let error = normalize_audio(&decoded, 20_000, 32_000, 13_334, &mut || {

--- a/crates/mold-inference/src/reference_media.rs
+++ b/crates/mold-inference/src/reference_media.rs
@@ -268,6 +268,8 @@ fn torchaudio_hann_resample_channel(
 ) -> Result<Vec<f32>> {
     const LOWPASS_FILTER_WIDTH: f64 = 6.0;
     const ROLLOFF: f64 = 0.99;
+    const MAX_KERNEL_COEFFICIENTS: usize = 4 * 1024 * 1024;
+    const MAX_MULTIPLY_ADDS: usize = 512 * 1024 * 1024;
 
     if source.is_empty() || source_rate == 0 || target_rate == 0 {
         bail!("reference audio resampling requires samples and positive rates");
@@ -292,6 +294,17 @@ fn torchaudio_hann_resample_channel(
         .checked_mul(2)
         .and_then(|length| length.checked_add(source_rate))
         .context("reference audio resample kernel length overflowed")?;
+    let kernel_coefficients = kernel_len
+        .checked_mul(target_rate)
+        .context("reference audio resample kernel size overflowed")?;
+    let multiply_adds = kernel_len
+        .checked_mul(expected_samples)
+        .context("reference audio resample work estimate overflowed")?;
+    if kernel_coefficients > MAX_KERNEL_COEFFICIENTS || multiply_adds > MAX_MULTIPLY_ADDS {
+        bail!(
+            "reference audio sample-rate ratio requires an unsafe sinc-resample kernel; use a standard PCM rate"
+        );
+    }
     let scale = base_rate / source_rate as f64;
     let mut kernels = Vec::with_capacity(target_rate);
     for phase in 0..target_rate {
@@ -554,6 +567,17 @@ mod tests {
         };
         let error = normalize_audio(&decoded, 8, 32_000, 16, &mut || Ok(())).unwrap_err();
         assert!(error.to_string().contains("mono/stereo"));
+    }
+
+    #[test]
+    fn pathological_coprime_audio_rate_fails_before_kernel_allocation() {
+        let decoded = DecodedAudio {
+            sample_rate: 47_999,
+            channels: vec![vec![0.0; 48]],
+        };
+        let expected = 48_usize.checked_mul(32_000).unwrap().div_ceil(47_999);
+        let error = normalize_audio(&decoded, 48, 32_000, expected, &mut || Ok(())).unwrap_err();
+        assert!(error.to_string().contains("unsafe sinc-resample kernel"));
     }
 
     #[test]

--- a/crates/mold-inference/src/reference_media.rs
+++ b/crates/mold-inference/src/reference_media.rs
@@ -1,0 +1,420 @@
+//! Family-neutral reference-media decoding and normalization helpers.
+//!
+//! Reference ingress has already opened, bounded, and hashed each regular
+//! file. These helpers preserve that authority by copying the open descriptor
+//! into private decoder storage; they never reopen a user-controlled path.
+
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom, Write};
+
+use anyhow::{anyhow, bail, Context, Result};
+use image::{ImageReader, RgbImage};
+use tempfile::{Builder, NamedTempFile};
+
+use crate::ltx2::{media, DecodedAudio};
+
+const COPY_CHUNK_BYTES: usize = 64 * 1024;
+
+#[derive(Debug)]
+pub(crate) struct DecodedReferenceVideo {
+    pub frames: Vec<RgbImage>,
+    pub fps: f64,
+    pub audio: Option<DecodedAudio>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct NormalizedStereoAudio {
+    pub sample_rate: u32,
+    pub channels: [Vec<f32>; 2],
+}
+
+impl NormalizedStereoAudio {
+    pub fn samples_per_channel(&self) -> usize {
+        self.channels[0].len()
+    }
+}
+
+pub(crate) fn decode_image_from_open_file(
+    file: &File,
+    checkpoint: &mut dyn FnMut() -> Result<()>,
+) -> Result<RgbImage> {
+    let bytes = read_open_file(file, checkpoint)?;
+    checkpoint()?;
+    let mut reader = ImageReader::new(std::io::Cursor::new(bytes))
+        .with_guessed_format()
+        .context("unknown reference image format")?;
+    let mut limits = image::Limits::default();
+    limits.max_image_width = Some(mold_core::minimax_h3::MAX_REFERENCE_DIMENSION);
+    limits.max_image_height = Some(mold_core::minimax_h3::MAX_REFERENCE_DIMENSION);
+    limits.max_alloc = Some(
+        mold_core::minimax_h3::MAX_REFERENCE_IMAGE_PIXELS
+            .checked_mul(4)
+            .context("reference image decode limit overflowed")?,
+    );
+    reader.limits(limits);
+    let image = reader
+        .decode()
+        .context("reference image decode failed")?
+        .to_rgb8();
+    checkpoint()?;
+    Ok(image)
+}
+
+pub(crate) fn decode_video_from_open_file(
+    file: &File,
+    checkpoint: &mut dyn FnMut() -> Result<()>,
+) -> Result<DecodedReferenceVideo> {
+    let staged = stage_open_file(file, ".mp4", checkpoint)?;
+    let (metadata, frames) =
+        media::decode_video_frames_from_path_with_checkpoint(staged.path(), checkpoint)?;
+    checkpoint()?;
+    let audio = if metadata.has_audio {
+        DecodedAudio::from_mp4_file(staged.path(), None)?
+    } else {
+        None
+    };
+    checkpoint()?;
+    Ok(DecodedReferenceVideo {
+        frames,
+        fps: f64::from(metadata.fps),
+        audio,
+    })
+}
+
+pub(crate) fn decode_audio_from_open_file(
+    file: &File,
+    mime_type: &str,
+    checkpoint: &mut dyn FnMut() -> Result<()>,
+) -> Result<DecodedAudio> {
+    let suffix = audio_suffix(mime_type);
+    let staged = stage_open_file(file, suffix, checkpoint)?;
+    checkpoint()?;
+    let decoded = DecodedAudio::from_file(staged.path(), None)?
+        .ok_or_else(|| anyhow!("reference audio did not contain a decodable audio stream"))?;
+    checkpoint()?;
+    Ok(decoded)
+}
+
+/// Reproduce ffmpeg's CFR source-frame assignment at a fixed output rate.
+///
+/// Source frame `i` owns destination slots
+/// `floor(i * target/source + .5)..floor((i+1) * target/source + .5)`.
+/// The caller supplies the already-frozen (and possibly duration-truncated)
+/// output count, so preprocessing cannot silently change admission geometry.
+#[cfg(test)]
+pub(crate) fn normalize_cfr_frames(
+    source: &[RgbImage],
+    source_fps: f64,
+    target_fps: u32,
+    output_frames: usize,
+    checkpoint: &mut dyn FnMut() -> Result<()>,
+) -> Result<Vec<RgbImage>> {
+    let indices = cfr_source_indices(
+        source.len(),
+        source_fps,
+        target_fps,
+        output_frames,
+        checkpoint,
+    )?;
+    Ok(indices
+        .into_iter()
+        .map(|index| source[index].clone())
+        .collect())
+}
+
+pub(crate) fn cfr_source_indices(
+    source_frames: usize,
+    source_fps: f64,
+    target_fps: u32,
+    output_frames: usize,
+    checkpoint: &mut dyn FnMut() -> Result<()>,
+) -> Result<Vec<usize>> {
+    if source_frames == 0 || !source_fps.is_finite() || source_fps <= 0.0 || target_fps == 0 {
+        bail!("reference CFR normalization requires frames and positive finite rates");
+    }
+    if output_frames == 0 {
+        bail!("reference CFR normalization requires a nonzero output frame count");
+    }
+    let scale = f64::from(target_fps) / source_fps;
+    let terminal = ((source_frames as f64 * scale) + 0.5).floor() as usize;
+    if output_frames > terminal {
+        bail!(
+            "reference CFR normalization requested {output_frames} frames but the decoded timeline produces only {terminal}"
+        );
+    }
+
+    let mut normalized = Vec::with_capacity(output_frames);
+    for index in 0..source_frames {
+        checkpoint()?;
+        let start = ((index as f64 * scale) + 0.5).floor() as usize;
+        let end = ((((index + 1) as f64 * scale) + 0.5).floor() as usize).min(output_frames);
+        if end <= start {
+            continue;
+        }
+        for _ in start..end {
+            checkpoint()?;
+            normalized.push(index);
+        }
+        if normalized.len() == output_frames {
+            break;
+        }
+    }
+    if normalized.len() != output_frames {
+        bail!(
+            "reference CFR normalization produced {} frames, expected {output_frames}",
+            normalized.len()
+        );
+    }
+    Ok(normalized)
+}
+
+/// Truncate in the native sample domain, remix every input channel to stereo,
+/// then resample exactly once to the frozen output rate and sample count.
+pub(crate) fn normalize_audio(
+    decoded: &DecodedAudio,
+    maximum_native_samples: usize,
+    target_sample_rate: u32,
+    expected_samples: usize,
+    checkpoint: &mut dyn FnMut() -> Result<()>,
+) -> Result<NormalizedStereoAudio> {
+    if decoded.sample_rate == 0 || decoded.channels.is_empty() || target_sample_rate == 0 {
+        bail!("reference audio normalization requires positive rates and decoded channels");
+    }
+    let source_samples = decoded.sample_count();
+    if source_samples == 0
+        || decoded
+            .channels
+            .iter()
+            .any(|channel| channel.len() != source_samples)
+    {
+        bail!("reference audio channels must have one nonempty, shared sample count");
+    }
+    let native_samples = source_samples.min(maximum_native_samples);
+    if native_samples == 0 || expected_samples == 0 {
+        bail!("reference audio normalization resolved an empty duration");
+    }
+    checkpoint()?;
+    let stereo = remix_stereo(&decoded.channels, native_samples, checkpoint)?;
+    let channels = if decoded.sample_rate == target_sample_rate as usize
+        && native_samples == expected_samples
+    {
+        stereo
+    } else {
+        [
+            resample_channel(
+                &stereo[0],
+                decoded.sample_rate,
+                target_sample_rate as usize,
+                expected_samples,
+                checkpoint,
+            )?,
+            resample_channel(
+                &stereo[1],
+                decoded.sample_rate,
+                target_sample_rate as usize,
+                expected_samples,
+                checkpoint,
+            )?,
+        ]
+    };
+    checkpoint()?;
+    Ok(NormalizedStereoAudio {
+        sample_rate: target_sample_rate,
+        channels,
+    })
+}
+
+fn remix_stereo(
+    channels: &[Vec<f32>],
+    sample_count: usize,
+    checkpoint: &mut dyn FnMut() -> Result<()>,
+) -> Result<[Vec<f32>; 2]> {
+    if channels.len() == 1 {
+        let mono = channels[0][..sample_count].to_vec();
+        return Ok([mono.clone(), mono]);
+    }
+    if channels.len() == 2 {
+        return Ok([
+            channels[0][..sample_count].to_vec(),
+            channels[1][..sample_count].to_vec(),
+        ]);
+    }
+
+    // Preserve the established left/right pair and include every additional
+    // channel deterministically. Even-numbered channels feed left, odd feed
+    // right; each side is averaged to avoid gain growth for wide layouts.
+    let left_count = channels.len().div_ceil(2) as f32;
+    let right_count = (channels.len() / 2) as f32;
+    let mut left = Vec::with_capacity(sample_count);
+    let mut right = Vec::with_capacity(sample_count);
+    for sample in 0..sample_count {
+        if sample.is_multiple_of(4_096) {
+            checkpoint()?;
+        }
+        let mut left_sum = 0.0_f32;
+        let mut right_sum = 0.0_f32;
+        for (channel_index, channel) in channels.iter().enumerate() {
+            if channel_index.is_multiple_of(2) {
+                left_sum += channel[sample];
+            } else {
+                right_sum += channel[sample];
+            }
+        }
+        left.push(left_sum / left_count);
+        right.push(right_sum / right_count);
+    }
+    Ok([left, right])
+}
+
+fn resample_channel(
+    source: &[f32],
+    source_rate: usize,
+    target_rate: usize,
+    expected_samples: usize,
+    checkpoint: &mut dyn FnMut() -> Result<()>,
+) -> Result<Vec<f32>> {
+    let mut output = Vec::with_capacity(expected_samples);
+    for target_index in 0..expected_samples {
+        if target_index.is_multiple_of(4_096) {
+            checkpoint()?;
+        }
+        let source_position = target_index as f64 * source_rate as f64 / target_rate as f64;
+        let left = (source_position.floor() as usize).min(source.len() - 1);
+        let right = (left + 1).min(source.len() - 1);
+        let fraction = (source_position - source_position.floor()) as f32;
+        output.push(source[left] + (source[right] - source[left]) * fraction);
+    }
+    Ok(output)
+}
+
+fn read_open_file(file: &File, checkpoint: &mut dyn FnMut() -> Result<()>) -> Result<Vec<u8>> {
+    let mut file = file
+        .try_clone()
+        .context("failed to duplicate opened reference media")?;
+    file.seek(SeekFrom::Start(0))
+        .context("failed to rewind opened reference media")?;
+    let capacity =
+        usize::try_from(file.metadata()?.len()).context("reference media is too large")?;
+    let mut bytes = Vec::with_capacity(capacity);
+    let mut chunk = [0_u8; COPY_CHUNK_BYTES];
+    loop {
+        checkpoint()?;
+        let read = file
+            .read(&mut chunk)
+            .context("failed to read opened reference media")?;
+        if read == 0 {
+            break;
+        }
+        bytes.extend_from_slice(&chunk[..read]);
+    }
+    Ok(bytes)
+}
+
+fn stage_open_file(
+    file: &File,
+    suffix: &str,
+    checkpoint: &mut dyn FnMut() -> Result<()>,
+) -> Result<NamedTempFile> {
+    let mut source = file
+        .try_clone()
+        .context("failed to duplicate opened reference media")?;
+    source
+        .seek(SeekFrom::Start(0))
+        .context("failed to rewind opened reference media")?;
+    let mut staged = Builder::new()
+        .prefix("mold-reference-")
+        .suffix(suffix)
+        .tempfile()
+        .context("failed to create private reference decoder storage")?;
+    let mut chunk = [0_u8; COPY_CHUNK_BYTES];
+    loop {
+        checkpoint()?;
+        let read = source
+            .read(&mut chunk)
+            .context("failed to read opened reference media")?;
+        if read == 0 {
+            break;
+        }
+        staged
+            .as_file_mut()
+            .write_all(&chunk[..read])
+            .context("failed to stage opened reference media")?;
+    }
+    staged
+        .as_file_mut()
+        .flush()
+        .context("failed to flush private reference decoder storage")?;
+    checkpoint()?;
+    Ok(staged)
+}
+
+fn audio_suffix(mime_type: &str) -> &'static str {
+    match mime_type.to_ascii_lowercase().as_str() {
+        "audio/wav" | "audio/wave" | "audio/x-wav" => ".wav",
+        "audio/flac" | "audio/x-flac" => ".flac",
+        "audio/mpeg" | "audio/mp3" => ".mp3",
+        "audio/ogg" | "application/ogg" => ".ogg",
+        "audio/mp4" | "audio/x-m4a" | "video/mp4" => ".m4a",
+        _ => ".audio",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn frame(value: u8) -> RgbImage {
+        RgbImage::from_pixel(2, 2, image::Rgb([value, 0, 0]))
+    }
+
+    #[test]
+    fn cfr_normalization_downsamples_and_upsamples_by_source_assignment() {
+        let source = (0..5).map(frame).collect::<Vec<_>>();
+        let down = normalize_cfr_frames(&source, 30.0, 24, 4, &mut || Ok(())).unwrap();
+        assert_eq!(
+            down.iter()
+                .map(|frame| frame[(0, 0)][0])
+                .collect::<Vec<_>>(),
+            vec![0, 1, 3, 4]
+        );
+
+        let up = normalize_cfr_frames(&source[..2], 12.0, 24, 4, &mut || Ok(())).unwrap();
+        assert_eq!(
+            up.iter().map(|frame| frame[(0, 0)][0]).collect::<Vec<_>>(),
+            vec![0, 0, 1, 1]
+        );
+    }
+
+    #[test]
+    fn arbitrary_channel_audio_is_truncated_remixed_and_resampled_exactly() {
+        let decoded = DecodedAudio {
+            sample_rate: 16_000,
+            channels: vec![vec![1.0; 8], vec![2.0; 8], vec![3.0; 8], vec![4.0; 8]],
+        };
+        let normalized = normalize_audio(&decoded, 4, 32_000, 8, &mut || Ok(())).unwrap();
+        assert_eq!(normalized.sample_rate, 32_000);
+        assert_eq!(normalized.samples_per_channel(), 8);
+        assert_eq!(normalized.channels[0], vec![2.0; 8]);
+        assert_eq!(normalized.channels[1], vec![3.0; 8]);
+    }
+
+    #[test]
+    fn long_audio_work_polls_cancellation() {
+        let decoded = DecodedAudio {
+            sample_rate: 48_000,
+            channels: vec![vec![0.0; 20_000]; 6],
+        };
+        let mut polls = 0;
+        let error = normalize_audio(&decoded, 20_000, 32_000, 13_334, &mut || {
+            polls += 1;
+            if polls == 4 {
+                Err(anyhow::Error::new(crate::progress::InferenceCancelled))
+            } else {
+                Ok(())
+            }
+        })
+        .unwrap_err();
+        assert_eq!(polls, 4);
+        assert!(crate::progress::is_inference_cancelled(&error));
+    }
+}


### PR DESCRIPTION
## Summary

- add family-neutral, opened-file-bound image/video/audio decoding with cooperative cancellation
- re-enforce the admission-time byte bound and SHA-256 while copying each still-open descriptor into private decoder storage
- normalize H3 reference videos through exact 24 fps CFR assignment and frozen per-reference canvases, retaining and resizing only the source frames required by the visual VAE and 2 fps Qwen path
- normalize mono/stereo audio to stereo 32 kHz after source-domain duration truncation with the pinned torchaudio Hann-windowed sinc algorithm
- preprocess H3 reference images on their frozen 2048-short-edge canvases
- retain normalized media in one-based request order behind the dormant Ref2VA backend seam

## Safety boundary

- no model weights or private artifacts accessed
- no checkpoint discovery, catalog advertisement, capability activation, or public H3 runtime wiring
- decoders consume the existing opened descriptor and never reopen a user-controlled path
- descriptor mutation, growth, or digest drift between admission and decode fails before parsing
- video decode immediately transforms only the frozen source-frame selection, avoiding retention of every full-resolution source frame
- cancellation does not publish partially normalized media

## Validation

- `cargo fmt --all -- --check`
- `nix develop --command cargo test -p mold-ai-inference --lib --no-default-features reference_media -- --test-threads=1` (10 passed)
- `nix develop --command cargo test -p mold-ai-inference --lib --features mp4 ordinary_media_fixtures_preserve_order_soundtrack_and_duration -- --test-threads=1 --nocapture` (1 passed)
- `nix develop --command cargo clippy -p mold-ai-inference --all-targets --features mp4 -- -D warnings`

Generated PNG, H.264/AAC MP4, and stereo WAV fixtures cover exact prepared rows, order, soundtrack association, duration, 24 fps normalization, selected-frame decoding, 2 fps sampling, stereo resampling, and cancellation. Additional tests cover same-length inode mutation, post-admission growth, the torchaudio resampling oracle, unsupported channel layouts, and fail-closed pathological sample-rate ratios.

Refs #837
