### PR TITLE
feat(h3): validate Qwen NVFP4 AWQ artifact

### DIFF
--- a/crates/mold-candle/src/minimax_h3/comfy_quant.rs
+++ b/crates/mold-candle/src/minimax_h3/comfy_quant.rs
@@ -19,10 +19,10 @@
 //! - The Qwen3-VL INT8 ConvRot variant reconstructs bounded weight chunks and
 //!   runs an ordinary floating-point matmul; it does not quantize activations.
 //! - The Qwen3-VL NVFP4 variant stores high-nibble-first weights with
-//!   swizzled FP8-E4M3 block scales, an F32 tensor scale, and an AWQ-style
-//!   `pre_quant_scale`. Comfy deliberately selects full-precision matrix
-//!   multiplication for text encoders, so the portable forward dequantizes
-//!   weight chunks and applies the input scale before the linear operation.
+//!   swizzled FP8-E4M3 block scales and an F32 tensor scale. Its selective
+//!   AWQ-style `pre_quant_scale` is applied when present. Comfy deliberately
+//!   selects full-precision matrix multiplication for text encoders, so the
+//!   portable forward dequantizes weight chunks before the linear operation.
 //!
 //! These are reusable Candle operations, not runtime activation authority.
 //! H3 remains hidden behind Mold's compliance gate and unavailable factory.
@@ -628,13 +628,140 @@ fn unswizzle_nvfp4_scales(
     Ok(natural)
 }
 
-/// CPU-backed NVFP4 weight with the mandatory H3 AWQ input transform.
+/// CPU-backed tensorwise-INT8 embedding used by the selected H3 conditioner.
+///
+/// Candle has no signed-I8 tensor dtype, so an authenticated loader preserves
+/// the safetensors payload byte-for-byte in U8 storage. Lookup widens each
+/// selected byte through two's-complement `i8` interpretation and applies the
+/// corresponding F32 row scale. Only requested token rows are materialized in
+/// floating point; the complete 151,936 x 5,120 table is never dequantized.
+#[derive(Clone, Debug)]
+pub struct H3ComfyInt8TensorwiseEmbedding {
+    weight_bytes: Tensor,
+    row_scales: Tensor,
+    vocabulary: usize,
+    hidden_size: usize,
+}
+
+impl H3ComfyInt8TensorwiseEmbedding {
+    pub fn new(weight_bytes: Tensor, row_scales: Tensor) -> Result<Self> {
+        if !weight_bytes.device().is_cpu() || !row_scales.device().is_cpu() {
+            candle::bail!("MiniMax H3 portable INT8 embedding storage must remain on CPU")
+        }
+        if weight_bytes.dtype() != DType::U8 {
+            candle::bail!(
+                "MiniMax H3 INT8 embedding payload must retain raw U8 bytes, got {:?}",
+                weight_bytes.dtype()
+            )
+        }
+        if row_scales.dtype() != DType::F32 {
+            candle::bail!(
+                "MiniMax H3 INT8 embedding row scales must be F32, got {:?}",
+                row_scales.dtype()
+            )
+        }
+        let (vocabulary, hidden_size) = weight_bytes.dims2()?;
+        if vocabulary == 0 || hidden_size == 0 {
+            candle::bail!("MiniMax H3 INT8 embedding dimensions must be positive")
+        }
+        if row_scales.dims() != [vocabulary, 1] {
+            candle::bail!(
+                "MiniMax H3 INT8 embedding scales must have shape [{vocabulary}, 1], got {:?}",
+                row_scales.dims()
+            )
+        }
+        let scales = row_scales.flatten_all()?.to_vec1::<f32>()?;
+        if scales
+            .iter()
+            .any(|scale| !scale.is_finite() || *scale <= 0.0)
+        {
+            candle::bail!("MiniMax H3 INT8 embedding scales must be finite and positive")
+        }
+        Ok(Self {
+            weight_bytes,
+            row_scales,
+            vocabulary,
+            hidden_size,
+        })
+    }
+
+    pub const fn vocabulary(&self) -> usize {
+        self.vocabulary
+    }
+
+    pub const fn hidden_size(&self) -> usize {
+        self.hidden_size
+    }
+
+    pub fn encoded_weight_bytes(&self) -> Result<usize> {
+        self.vocabulary
+            .checked_mul(self.hidden_size)
+            .and_then(|bytes| {
+                self.vocabulary
+                    .checked_mul(std::mem::size_of::<f32>())
+                    .and_then(|scales| bytes.checked_add(scales))
+            })
+            .ok_or_else(|| candle::Error::Msg("MiniMax H3 INT8 embedding bytes overflow".into()))
+    }
+
+    pub fn forward(
+        &self,
+        input_ids: &Tensor,
+        output_dtype: DType,
+        device: &Device,
+    ) -> Result<Tensor> {
+        ensure_output_dtype(output_dtype)?;
+        if input_ids.dtype() != DType::U32 {
+            candle::bail!(
+                "MiniMax H3 INT8 embedding input ids must be U32, got {:?}",
+                input_ids.dtype()
+            )
+        }
+        let input_shape = input_ids.dims().to_vec();
+        if input_shape.is_empty() {
+            candle::bail!("MiniMax H3 INT8 embedding input ids must have rank at least one")
+        }
+        let ids = input_ids
+            .to_device(&Device::Cpu)?
+            .flatten_all()?
+            .to_vec1::<u32>()?;
+        if ids.is_empty() {
+            candle::bail!("MiniMax H3 INT8 embedding input ids cannot be empty")
+        }
+        let scales = self.row_scales.flatten_all()?.to_vec1::<f32>()?;
+        let mut rows =
+            Vec::with_capacity(ids.len().checked_mul(self.hidden_size).ok_or_else(|| {
+                candle::Error::Msg("MiniMax H3 INT8 embedding output size overflows".into())
+            })?);
+        for id in ids {
+            let row = id as usize;
+            if row >= self.vocabulary {
+                candle::bail!(
+                    "MiniMax H3 INT8 embedding token id {row} exceeds vocabulary {}",
+                    self.vocabulary
+                )
+            }
+            let bytes = self
+                .weight_bytes
+                .narrow(0, row, 1)?
+                .flatten_all()?
+                .to_vec1::<u8>()?;
+            let scale = scales[row];
+            rows.extend(bytes.into_iter().map(|byte| (byte as i8) as f32 * scale));
+        }
+        let mut output_shape = input_shape;
+        output_shape.push(self.hidden_size);
+        Tensor::from_vec(rows, output_shape.as_slice(), device)?.to_dtype(output_dtype)
+    }
+}
+
+/// CPU-backed NVFP4 weight with H3's selective AWQ input transform.
 #[derive(Clone, Debug)]
 pub struct H3ComfyNvfp4AwqLinear {
     packed_weight: Tensor,
     natural_block_scales: Vec<f32>,
     tensor_scale: f32,
-    pre_quant_scale: Tensor,
+    pre_quant_scale: Option<Tensor>,
     out_features: usize,
     in_features: usize,
     padded_out_features: usize,
@@ -651,10 +778,36 @@ impl H3ComfyNvfp4AwqLinear {
         out_features: usize,
         in_features: usize,
     ) -> Result<Self> {
+        Self::new_with_optional_awq(
+            packed_weight,
+            block_scales,
+            tensor_scale,
+            Some(pre_quant_scale),
+            out_features,
+            in_features,
+        )
+    }
+
+    /// Construct one published NVFP4 projection. ModelOpt AWQ smoothing is
+    /// selective in the H3 Qwen artifact: `None` is the exact identity input
+    /// transform used by 250 projections, while the attention output and MLP
+    /// down projections provide a mandatory vector validated by the artifact
+    /// loading policy.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_with_optional_awq(
+        packed_weight: Tensor,
+        block_scales: Tensor,
+        tensor_scale: Tensor,
+        pre_quant_scale: Option<Tensor>,
+        out_features: usize,
+        in_features: usize,
+    ) -> Result<Self> {
         if !packed_weight.device().is_cpu()
             || !block_scales.device().is_cpu()
             || !tensor_scale.device().is_cpu()
-            || !pre_quant_scale.device().is_cpu()
+            || pre_quant_scale
+                .as_ref()
+                .is_some_and(|scale| !scale.device().is_cpu())
         {
             candle::bail!("MiniMax H3 portable NVFP4-AWQ storage must remain on CPU")
         }
@@ -678,12 +831,14 @@ impl H3ComfyNvfp4AwqLinear {
         {
             candle::bail!("MiniMax H3 NVFP4 tensor scale must be F32 with source shape [] or [1]")
         }
-        ensure_floating(pre_quant_scale.dtype(), "NVFP4 AWQ pre_quant_scale")?;
-        if pre_quant_scale.dims() != [in_features] {
-            candle::bail!(
-                "MiniMax H3 NVFP4 AWQ pre_quant_scale must have shape [{in_features}], got {:?}",
-                pre_quant_scale.dims()
-            )
+        if let Some(pre_quant_scale) = &pre_quant_scale {
+            ensure_floating(pre_quant_scale.dtype(), "NVFP4 AWQ pre_quant_scale")?;
+            if pre_quant_scale.dims() != [in_features] {
+                candle::bail!(
+                    "MiniMax H3 NVFP4 AWQ pre_quant_scale must have shape [{in_features}], got {:?}",
+                    pre_quant_scale.dims()
+                )
+            }
         }
 
         let padded_out_features = checked_round_up(out_features, 16, "NVFP4 output")?;
@@ -708,9 +863,11 @@ impl H3ComfyNvfp4AwqLinear {
         if !tensor_scale.is_finite() || tensor_scale <= 0.0 {
             candle::bail!("MiniMax H3 NVFP4 tensor scale must be finite and positive")
         }
-        let awq = pre_quant_scale.to_dtype(DType::F32)?.to_vec1::<f32>()?;
-        if awq.iter().any(|scale| !scale.is_finite() || *scale <= 0.0) {
-            candle::bail!("MiniMax H3 AWQ input scales must be finite and positive")
+        if let Some(pre_quant_scale) = &pre_quant_scale {
+            let awq = pre_quant_scale.to_dtype(DType::F32)?.to_vec1::<f32>()?;
+            if awq.iter().any(|scale| !scale.is_finite() || *scale <= 0.0) {
+                candle::bail!("MiniMax H3 AWQ input scales must be finite and positive")
+            }
         }
         let swizzled = block_scales
             .to_dtype(DType::F32)?
@@ -766,12 +923,13 @@ impl H3ComfyNvfp4AwqLinear {
         let scales = scale_rows
             .checked_mul(scale_columns)
             .ok_or_else(|| candle::Error::Msg("MiniMax H3 NVFP4 scale count overflows".into()))?;
-        let awq_scale = self
-            .in_features
-            .checked_mul(self.pre_quant_scale.dtype().size_in_bytes())
-            .ok_or_else(|| {
-                candle::Error::Msg("MiniMax H3 NVFP4 AWQ byte count overflows".into())
-            })?;
+        let awq_scale = self.pre_quant_scale.as_ref().map_or(Ok(0), |scale| {
+            self.in_features
+                .checked_mul(scale.dtype().size_in_bytes())
+                .ok_or_else(|| {
+                    candle::Error::Msg("MiniMax H3 NVFP4 AWQ byte count overflows".into())
+                })
+        })?;
         packed
             .checked_add(scales)
             .and_then(|bytes| bytes.checked_add(std::mem::size_of::<f32>()))
@@ -859,15 +1017,18 @@ impl H3ComfyNvfp4AwqLinear {
         let device = input.device();
         let (flat, output_shape) = flattened_input(input, self.in_features)?;
         let rows = flat.dim(0)?;
-        let awq = self
-            .pre_quant_scale
-            .to_device(device)?
-            .to_dtype(DType::F32)?
-            .reshape((1, self.in_features))?;
         let scaled = flat
             .to_dtype(DType::F32)?
-            .reshape((rows, self.in_features))?
-            .broadcast_mul(&awq)?;
+            .reshape((rows, self.in_features))?;
+        let scaled = if let Some(pre_quant_scale) = &self.pre_quant_scale {
+            let awq = pre_quant_scale
+                .to_device(device)?
+                .to_dtype(DType::F32)?
+                .reshape((1, self.in_features))?;
+            scaled.broadcast_mul(&awq)?
+        } else {
+            scaled
+        };
         let mut chunks = Vec::new();
         for start in (0..self.out_features).step_by(rows_per_chunk) {
             let width = rows_per_chunk.min(self.out_features - start);
@@ -1378,6 +1539,64 @@ mod tests {
             .collect::<Vec<_>>();
         let swizzled = swizzle_scales(&natural, rows, columns);
         assert_eq!(unswizzle_nvfp4_scales(&swizzled, rows, columns)?, natural);
+        Ok(())
+    }
+
+    #[test]
+    fn nvfp4_without_selective_awq_scale_uses_identity_input_transform() -> Result<()> {
+        let device = Device::Cpu;
+        let out_features = 1;
+        let in_features = 16;
+        let padded_rows = 16;
+        let mut packed = vec![0_u8; padded_rows * in_features / 2];
+        packed[0] = 0x22;
+        let block_scales = Tensor::from_vec(
+            swizzle_scales(&vec![1.0; padded_rows], padded_rows, 1),
+            (128, 4),
+            &device,
+        )?
+        .to_dtype(DType::F8E4M3)?;
+        let linear = H3ComfyNvfp4AwqLinear::new_with_optional_awq(
+            Tensor::from_vec(packed, (padded_rows, in_features / 2), &device)?,
+            block_scales,
+            Tensor::new(1.0_f32, &device)?,
+            None,
+            out_features,
+            in_features,
+        )?;
+        let output = linear.forward_dequantized(
+            &Tensor::from_vec(vec![1.0_f32; in_features], (1, in_features), &device)?,
+            None,
+            DType::F32,
+            1,
+        )?;
+        assert_eq!(output.to_vec2::<f32>()?, vec![vec![2.0]]);
+        assert_eq!(linear.encoded_weight_bytes()?, 16 * 8 + 128 * 4 + 4);
+        Ok(())
+    }
+
+    #[test]
+    fn int8_embedding_widens_signed_bytes_and_only_materializes_selected_rows() -> Result<()> {
+        let device = Device::Cpu;
+        let embedding = H3ComfyInt8TensorwiseEmbedding::new(
+            Tensor::from_vec(vec![0_u8, 1, 127, 128, 255, 2, 254, 64], (2, 4), &device)?,
+            Tensor::from_vec(vec![0.5_f32, 2.0], (2, 1), &device)?,
+        )?;
+        let output = embedding.forward(
+            &Tensor::from_vec(vec![1_u32, 0], (1, 2), &device)?,
+            DType::F32,
+            &device,
+        )?;
+        assert_eq!(
+            output.to_vec3::<f32>()?,
+            vec![vec![
+                vec![-2.0, 4.0, -4.0, 128.0],
+                vec![0.0, 0.5, 63.5, -64.0],
+            ]]
+        );
+        assert_eq!(embedding.vocabulary(), 2);
+        assert_eq!(embedding.hidden_size(), 4);
+        assert_eq!(embedding.encoded_weight_bytes()?, 16);
         Ok(())
     }
 

--- a/crates/mold-candle/src/minimax_h3/mod.rs
+++ b/crates/mold-candle/src/minimax_h3/mod.rs
@@ -14,6 +14,7 @@ mod loader;
 mod model;
 mod presentation;
 mod processor;
+mod qwen_nvfp4;
 mod qwen_quant;
 mod text;
 mod vision;
@@ -65,8 +66,9 @@ pub use comfy_dit::{
     H3_COMFY_ORG_SOURCE_REVISION,
 };
 pub use comfy_quant::{
-    H3ComfyFp8ScaledLinear, H3ComfyInt8ConvRotLinear, H3ComfyNvfp4AwqLinear,
-    H3_COMFY_CONVROT_GROUP_SIZE, H3_COMFY_NVFP4_BLOCK_SIZE, H3_COMFY_PORTABLE_ROW_CHUNK,
+    H3ComfyFp8ScaledLinear, H3ComfyInt8ConvRotLinear, H3ComfyInt8TensorwiseEmbedding,
+    H3ComfyNvfp4AwqLinear, H3_COMFY_CONVROT_GROUP_SIZE, H3_COMFY_NVFP4_BLOCK_SIZE,
+    H3_COMFY_PORTABLE_ROW_CHUNK,
 };
 pub use config::{
     H3ConditionerConfig, H3TextConfig, H3VisionConfig, H3_BF16_PARAMETER_BYTES,
@@ -99,6 +101,16 @@ pub use presentation::{
 pub use processor::{
     create_mm_token_type_ids, pack_qwen_vision_u8, qwen_mrope_positions, sample_video_frames,
     GridThw, PackedVisionPatches, QwenMmTokenType, SampledVideo,
+};
+pub use qwen_nvfp4::{
+    expected_h3_qwen_nvfp4_awq_schema, inspect_h3_qwen_nvfp4_awq_header,
+    validate_h3_qwen_nvfp4_awq_schema, H3QwenNvfp4AwqError, H3QwenNvfp4AwqExecution,
+    H3QwenNvfp4AwqInspection, H3QwenNvfp4AwqMemoryAccounting, H3QwenNvfp4AwqPolicy,
+    H3QwenNvfp4AwqSchema, H3QwenQuantMarker, H3_QWEN_NVFP4_AWQ_FILENAME,
+    H3_QWEN_NVFP4_AWQ_FILE_BYTES, H3_QWEN_NVFP4_AWQ_HEADER_BYTES, H3_QWEN_NVFP4_AWQ_PAYLOAD_BYTES,
+    H3_QWEN_NVFP4_AWQ_POLICY_SHA256, H3_QWEN_NVFP4_AWQ_SHA256, H3_QWEN_NVFP4_AWQ_STABLE_ID,
+    H3_QWEN_NVFP4_AWQ_TENSOR_COUNT, H3_QWEN_NVFP4_LINEAR_COUNT,
+    H3_QWEN_NVFP4_PRE_QUANT_SCALE_COUNT, H3_QWEN_QUANT_MARKER_COUNT,
 };
 pub use qwen_quant::{
     expected_h3_qwen_int8_weight_only_schema, validate_h3_qwen_int8_weight_only_schema,

--- a/crates/mold-candle/src/minimax_h3/qwen_nvfp4.rs
+++ b/crates/mold-candle/src/minimax_h3/qwen_nvfp4.rs
@@ -744,6 +744,18 @@ pub fn inspect_h3_qwen_nvfp4_awq_header(
     file.seek(SeekFrom::Start(0))
         .and_then(|_| file.read_exact(&mut header_bytes))
         .map_err(|error| H3QwenNvfp4AwqError::Io(error.to_string()))?;
+    let raw_header: serde_json::Value =
+        serde_json::from_slice(&header_bytes[8..]).map_err(|error| {
+            H3QwenNvfp4AwqError::Header(format!("failed to reparse bounded header: {error}"))
+        })?;
+    if raw_header
+        .as_object()
+        .is_some_and(|object| object.contains_key("__metadata__"))
+    {
+        return Err(H3QwenNvfp4AwqError::Metadata(
+            "published Qwen NVFP4-AWQ object must not add safetensors __metadata__".into(),
+        ));
+    }
     let after_open = file
         .metadata()
         .map(|metadata| file_identity(&metadata))
@@ -821,7 +833,7 @@ mod tests {
         }
     }
 
-    fn sparse_published_fixture() -> PathBuf {
+    fn sparse_published_fixture_with_metadata(include_metadata: bool) -> PathBuf {
         let (_, tensors, markers) = fixture();
         // Safetensors payload order is independent of JSON key order. Put the
         // numerous small tensors first, like the published converter does, so
@@ -839,6 +851,9 @@ mod tests {
         assert_eq!(cursor, H3_QWEN_NVFP4_AWQ_PAYLOAD_BYTES);
 
         let mut root = serde_json::Map::new();
+        if include_metadata {
+            root.insert("__metadata__".into(), json!({"format": "pt"}));
+        }
         let mut marker_ranges = Vec::new();
         for (name, spec) in &tensors {
             let offsets = ranges[name];
@@ -885,6 +900,10 @@ mod tests {
         }
         file.sync_all().unwrap();
         path
+    }
+
+    fn sparse_published_fixture() -> PathBuf {
+        sparse_published_fixture_with_metadata(false)
     }
 
     #[test]
@@ -1037,6 +1056,13 @@ mod tests {
             Err(H3QwenNvfp4AwqError::Metadata(_))
         ));
         std::fs::remove_file(path).unwrap();
+
+        let metadata_path = sparse_published_fixture_with_metadata(true);
+        assert!(matches!(
+            inspect_h3_qwen_nvfp4_awq_header(&metadata_path),
+            Err(H3QwenNvfp4AwqError::Metadata(_))
+        ));
+        std::fs::remove_file(metadata_path).unwrap();
     }
 
     #[test]

--- a/crates/mold-candle/src/minimax_h3/qwen_nvfp4.rs
+++ b/crates/mold-candle/src/minimax_h3/qwen_nvfp4.rs
@@ -1,0 +1,1063 @@
+//! Published Qwen3-VL NVFP4-AWQ artifact contract for MiniMax H3.
+//!
+//! The selected Comfy H3 conditioner is not the older INT8 ConvRot object.
+//! It has one INT8 tensorwise token embedding, 350 NVFP4 language projection
+//! matrices, and otherwise BF16 tensors. Every NVFP4 projection carries
+//! `weight_scale`, `weight_scale_2`, and a `comfy_quant` marker which requires
+//! full-precision matrix multiplication. ModelOpt AWQ smoothing is selective:
+//! only the attention output and MLP down projections carry
+//! `pre_quant_scale`; its absence on the other 250 projections means identity,
+//! not an incomplete checkpoint.
+//!
+//! This module reads only the bounded safetensors header and the small
+//! `comfy_quant` marker tensors. It neither hashes the full artifact nor grants
+//! download, license, factory, or runtime authority. Callers must separately
+//! authenticate the complete pinned object before mapping tensor payloads.
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs::{File, Metadata};
+use std::io::{Read, Seek, SeekFrom};
+use std::path::Path;
+use thiserror::Error;
+
+use super::artifacts::{expected_checkpoint_shapes, expected_materialized_keys};
+use super::config::{H3ConditionerConfig, H3_SELECTED_LANGUAGE_LAYERS};
+use super::qwen_quant::{H3QwenTensorDType, H3QwenTensorSpec};
+use super::visual_weights::inspect_safetensors_header;
+use super::H3_COMFY_NVFP4_BLOCK_SIZE;
+
+pub const H3_QWEN_NVFP4_AWQ_STABLE_ID: &str = "minimax-h3.qwen3-vl.layer50.nvfp4-awq.v1";
+pub const H3_QWEN_NVFP4_AWQ_FILENAME: &str = "qwen3vl_32b_minimax_h3_nvfp4_awq.safetensors";
+pub const H3_QWEN_NVFP4_AWQ_SHA256: &str =
+    "35a88d51044231fe332301d7a62aa81e3f2cba62febeb446e2c1e3e0ef76f2c6";
+pub const H3_QWEN_NVFP4_AWQ_POLICY_SHA256: &str =
+    "b36894e044a993d114a37db743f9aec8cf1492073d1cb9e82f4b04ac92cb25b9";
+pub const H3_QWEN_NVFP4_AWQ_FILE_BYTES: u64 = 15_687_142_551;
+pub const H3_QWEN_NVFP4_AWQ_HEADER_BYTES: u64 = 231_400;
+pub const H3_QWEN_NVFP4_AWQ_PAYLOAD_BYTES: u64 = 15_686_911_143;
+pub const H3_QWEN_NVFP4_AWQ_TENSOR_COUNT: usize = 2_054;
+pub const H3_QWEN_NVFP4_LINEAR_COUNT: usize = 350;
+pub const H3_QWEN_NVFP4_PRE_QUANT_SCALE_COUNT: usize = 100;
+pub const H3_QWEN_QUANT_MARKER_COUNT: usize = 351;
+
+const INT8_MARKER_JSON: &[u8] = br#"{"format": "int8_tensorwise"}"#;
+const NVFP4_MARKER_JSON: &[u8] = br#"{"format": "nvfp4", "full_precision_matrix_mult": true}"#;
+
+const LANGUAGE_LINEAR_SUFFIXES: &[&str] = &[
+    "self_attn.q_proj",
+    "self_attn.k_proj",
+    "self_attn.v_proj",
+    "self_attn.o_proj",
+    "mlp.gate_proj",
+    "mlp.up_proj",
+    "mlp.down_proj",
+];
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct H3QwenQuantMarker {
+    pub format: String,
+    #[serde(default)]
+    pub full_precision_matrix_mult: bool,
+}
+
+pub type H3QwenNvfp4AwqSchema = (
+    BTreeMap<String, H3QwenTensorSpec>,
+    BTreeMap<String, H3QwenQuantMarker>,
+);
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct H3QwenNvfp4AwqMemoryAccounting {
+    pub artifact_file_bytes: u64,
+    pub header_bytes: u64,
+    pub tensor_payload_bytes: u64,
+    pub nvfp4_packed_weight_bytes: u64,
+    pub nvfp4_block_scale_bytes: u64,
+    pub nvfp4_tensor_scale_bytes: u64,
+    pub awq_pre_quant_scale_bytes: u64,
+    pub int8_embedding_weight_bytes: u64,
+    pub int8_embedding_scale_bytes: u64,
+    pub dense_bf16_bytes: u64,
+    pub quant_marker_bytes: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum H3QwenNvfp4AwqExecution {
+    DenseBf16 {
+        source_tensor: String,
+    },
+    Int8TensorwiseEmbedding {
+        weight_tensor: String,
+        weight_scale_tensor: String,
+    },
+    Nvfp4FullPrecision {
+        packed_weight_tensor: String,
+        block_scale_tensor: String,
+        tensor_scale_tensor: String,
+        pre_quant_scale_tensor: Option<String>,
+    },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct H3QwenNvfp4AwqPolicy {
+    stable_id: String,
+    quantized_layers: Vec<String>,
+    awq_smoothed_layers: Vec<String>,
+    protected_tensors: Vec<String>,
+    memory: H3QwenNvfp4AwqMemoryAccounting,
+    policy_sha256: String,
+}
+
+impl H3QwenNvfp4AwqPolicy {
+    pub fn stable_id(&self) -> &str {
+        &self.stable_id
+    }
+
+    pub fn quantized_layers(&self) -> &[String] {
+        &self.quantized_layers
+    }
+
+    pub fn awq_smoothed_layers(&self) -> &[String] {
+        &self.awq_smoothed_layers
+    }
+
+    pub fn protected_tensors(&self) -> &[String] {
+        &self.protected_tensors
+    }
+
+    pub const fn memory(&self) -> &H3QwenNvfp4AwqMemoryAccounting {
+        &self.memory
+    }
+
+    pub fn policy_sha256(&self) -> &str {
+        &self.policy_sha256
+    }
+
+    /// Resolve one canonical H3 model weight to its exact published source
+    /// tensors. Names returned here use the Comfy `model.*` / `visual.*`
+    /// namespace and are loading instructions, not runtime activation.
+    pub fn execution_for_weight(
+        &self,
+        canonical_weight: &str,
+    ) -> Result<H3QwenNvfp4AwqExecution, H3QwenNvfp4AwqError> {
+        if canonical_weight == "model.language_model.embed_tokens.weight" {
+            return Ok(H3QwenNvfp4AwqExecution::Int8TensorwiseEmbedding {
+                weight_tensor: "model.embed_tokens.weight".into(),
+                weight_scale_tensor: "model.embed_tokens.weight_scale".into(),
+            });
+        }
+        let Some(canonical_layer) = canonical_weight.strip_suffix(".weight") else {
+            return Err(H3QwenNvfp4AwqError::Execution(format!(
+                "Qwen execution lookup requires a canonical .weight tensor, got {canonical_weight:?}"
+            )));
+        };
+        if self
+            .quantized_layers
+            .binary_search_by(|candidate| candidate.as_str().cmp(canonical_layer))
+            .is_ok()
+        {
+            let source_layer = comfy_name(canonical_layer);
+            let pre_quant_scale_tensor = self
+                .awq_smoothed_layers
+                .binary_search_by(|candidate| candidate.as_str().cmp(canonical_layer))
+                .is_ok()
+                .then(|| format!("{source_layer}.pre_quant_scale"));
+            return Ok(H3QwenNvfp4AwqExecution::Nvfp4FullPrecision {
+                packed_weight_tensor: format!("{source_layer}.weight"),
+                block_scale_tensor: format!("{source_layer}.weight_scale"),
+                tensor_scale_tensor: format!("{source_layer}.weight_scale_2"),
+                pre_quant_scale_tensor,
+            });
+        }
+        if self
+            .protected_tensors
+            .binary_search_by(|candidate| candidate.as_str().cmp(canonical_weight))
+            .is_ok()
+        {
+            return Ok(H3QwenNvfp4AwqExecution::DenseBf16 {
+                source_tensor: comfy_name(canonical_weight),
+            });
+        }
+        Err(H3QwenNvfp4AwqError::Execution(format!(
+            "Qwen tensor {canonical_weight:?} is outside the frozen layer-50 NVFP4-AWQ policy"
+        )))
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct H3QwenNvfp4AwqInspection {
+    pub stable_id: String,
+    pub expected_artifact_sha256: String,
+    pub artifact_file_bytes: u64,
+    pub header_bytes: u64,
+    pub tensor_payload_bytes: u64,
+    pub tensor_count: usize,
+    pub nvfp4_linear_count: usize,
+    pub awq_pre_quant_scale_count: usize,
+    pub int8_tensorwise_count: usize,
+    pub header_identity_sha256: String,
+    pub policy_sha256: String,
+}
+
+#[derive(Debug, Error, Eq, PartialEq)]
+pub enum H3QwenNvfp4AwqError {
+    #[error("invalid MiniMax H3 Qwen NVFP4-AWQ config: {0}")]
+    Config(String),
+    #[error("invalid MiniMax H3 Qwen NVFP4-AWQ header: {0}")]
+    Header(String),
+    #[error("invalid MiniMax H3 Qwen NVFP4-AWQ tensor schema: {0}")]
+    TensorSchema(String),
+    #[error("invalid MiniMax H3 Qwen NVFP4-AWQ metadata: {0}")]
+    Metadata(String),
+    #[error("invalid MiniMax H3 Qwen NVFP4-AWQ accounting: {0}")]
+    Accounting(String),
+    #[error("invalid MiniMax H3 Qwen NVFP4-AWQ execution lookup: {0}")]
+    Execution(String),
+    #[error("failed to read MiniMax H3 Qwen NVFP4-AWQ artifact: {0}")]
+    Io(String),
+}
+
+fn released_config() -> Result<H3ConditionerConfig, H3QwenNvfp4AwqError> {
+    H3ConditionerConfig::from_json(
+        br#"{
+          "architectures":["Qwen3VLForConditionalGeneration"],
+          "image_token_id":151655,"video_token_id":151656,
+          "vision_start_token_id":151652,"vision_end_token_id":151653,
+          "text_config":{"model_type":"qwen3_vl_text","vocab_size":151936,
+            "hidden_size":5120,"intermediate_size":25600,"num_hidden_layers":64,
+            "num_attention_heads":64,"num_key_value_heads":8,"head_dim":128,
+            "rms_norm_eps":0.000001,"rope_theta":5000000.0,
+            "max_position_embeddings":262144,"hidden_act":"silu","attention_bias":false,
+            "rope_scaling":{"rope_type":"default","mrope_interleaved":true,
+              "mrope_section":[24,20,20]}},
+          "vision_config":{"model_type":"qwen3_vl","depth":27,"hidden_size":1152,
+            "intermediate_size":4304,"num_heads":16,"in_channels":3,"patch_size":16,
+            "temporal_patch_size":2,"spatial_merge_size":2,"out_hidden_size":5120,
+            "num_position_embeddings":2304,"deepstack_visual_indexes":[8,16,24],
+            "hidden_act":"gelu_pytorch_tanh"}
+        }"#,
+    )
+    .map_err(|error| H3QwenNvfp4AwqError::Config(error.to_string()))
+}
+
+fn canonical_quantized_layers() -> BTreeSet<String> {
+    (0..H3_SELECTED_LANGUAGE_LAYERS)
+        .flat_map(|layer| {
+            LANGUAGE_LINEAR_SUFFIXES
+                .iter()
+                .map(move |suffix| format!("model.language_model.layers.{layer}.{suffix}"))
+        })
+        .collect()
+}
+
+fn canonical_awq_smoothed_layers() -> BTreeSet<String> {
+    (0..H3_SELECTED_LANGUAGE_LAYERS)
+        .flat_map(|layer| {
+            ["self_attn.o_proj", "mlp.down_proj"]
+                .into_iter()
+                .map(move |suffix| format!("model.language_model.layers.{layer}.{suffix}"))
+        })
+        .collect()
+}
+
+fn comfy_name(canonical: &str) -> String {
+    canonical
+        .strip_prefix("model.language_model.")
+        .map(|suffix| format!("model.{suffix}"))
+        .or_else(|| {
+            canonical
+                .strip_prefix("model.visual.")
+                .map(|suffix| format!("visual.{suffix}"))
+        })
+        .unwrap_or_else(|| canonical.to_owned())
+}
+
+fn round_up(value: usize, multiple: usize, role: &str) -> Result<usize, H3QwenNvfp4AwqError> {
+    value
+        .checked_add(multiple - 1)
+        .map(|value| value / multiple * multiple)
+        .ok_or_else(|| H3QwenNvfp4AwqError::Accounting(format!("{role} overflows")))
+}
+
+fn nvfp4_specs(
+    logical_shape: &[usize],
+) -> Result<(H3QwenTensorSpec, H3QwenTensorSpec), H3QwenNvfp4AwqError> {
+    let [out_features, in_features] = logical_shape else {
+        return Err(H3QwenNvfp4AwqError::TensorSchema(format!(
+            "NVFP4 projection must have rank two, got {logical_shape:?}"
+        )));
+    };
+    let padded_out = round_up(*out_features, 16, "NVFP4 output shape")?;
+    let padded_in = round_up(*in_features, 16, "NVFP4 input shape")?;
+    let scale_rows = round_up(padded_out, 128, "NVFP4 scale output shape")?;
+    let scale_columns = round_up(
+        padded_in / H3_COMFY_NVFP4_BLOCK_SIZE,
+        4,
+        "NVFP4 scale input shape",
+    )?;
+    Ok((
+        H3QwenTensorSpec {
+            dtype: H3QwenTensorDType::U8,
+            shape: vec![padded_out, padded_in / 2],
+        },
+        H3QwenTensorSpec {
+            dtype: H3QwenTensorDType::F8E4M3,
+            shape: vec![scale_rows, scale_columns],
+        },
+    ))
+}
+
+/// Construct the exact published schema without opening a checkpoint.
+/// Returned tensor names use the Comfy `model.*` / `visual.*` namespace.
+pub fn expected_h3_qwen_nvfp4_awq_schema(
+    config: &H3ConditionerConfig,
+) -> Result<H3QwenNvfp4AwqSchema, H3QwenNvfp4AwqError> {
+    config
+        .validate()
+        .map_err(|error| H3QwenNvfp4AwqError::Config(error.to_string()))?;
+    let shapes = expected_checkpoint_shapes(config);
+    let quantized = canonical_quantized_layers();
+    let smoothed = canonical_awq_smoothed_layers();
+    let mut tensors = BTreeMap::new();
+    let mut markers = BTreeMap::new();
+    for canonical in expected_materialized_keys() {
+        let logical_shape = shapes.get(&canonical).ok_or_else(|| {
+            H3QwenNvfp4AwqError::TensorSchema(format!("missing production shape for {canonical:?}"))
+        })?;
+        let source = comfy_name(&canonical);
+        if canonical == "model.language_model.embed_tokens.weight" {
+            tensors.insert(
+                source.clone(),
+                H3QwenTensorSpec {
+                    dtype: H3QwenTensorDType::I8,
+                    shape: logical_shape.clone(),
+                },
+            );
+            let base = source.strip_suffix(".weight").expect("embedding weight");
+            tensors.insert(
+                format!("{base}.weight_scale"),
+                H3QwenTensorSpec {
+                    dtype: H3QwenTensorDType::F32,
+                    shape: vec![logical_shape[0], 1],
+                },
+            );
+            tensors.insert(
+                format!("{base}.comfy_quant"),
+                H3QwenTensorSpec {
+                    dtype: H3QwenTensorDType::U8,
+                    shape: vec![INT8_MARKER_JSON.len()],
+                },
+            );
+            markers.insert(
+                base.into(),
+                H3QwenQuantMarker {
+                    format: "int8_tensorwise".into(),
+                    full_precision_matrix_mult: false,
+                },
+            );
+            continue;
+        }
+        let Some(canonical_layer) = canonical.strip_suffix(".weight") else {
+            tensors.insert(
+                source,
+                H3QwenTensorSpec {
+                    dtype: H3QwenTensorDType::Bf16,
+                    shape: logical_shape.clone(),
+                },
+            );
+            continue;
+        };
+        if !quantized.contains(canonical_layer) {
+            tensors.insert(
+                source,
+                H3QwenTensorSpec {
+                    dtype: H3QwenTensorDType::Bf16,
+                    shape: logical_shape.clone(),
+                },
+            );
+            continue;
+        }
+        let source_layer = source
+            .strip_suffix(".weight")
+            .expect("projection weight")
+            .to_owned();
+        let (packed, block_scale) = nvfp4_specs(logical_shape)?;
+        tensors.insert(source, packed);
+        tensors.insert(format!("{source_layer}.weight_scale"), block_scale);
+        tensors.insert(
+            format!("{source_layer}.weight_scale_2"),
+            H3QwenTensorSpec {
+                dtype: H3QwenTensorDType::F32,
+                shape: Vec::new(),
+            },
+        );
+        tensors.insert(
+            format!("{source_layer}.comfy_quant"),
+            H3QwenTensorSpec {
+                dtype: H3QwenTensorDType::U8,
+                shape: vec![NVFP4_MARKER_JSON.len()],
+            },
+        );
+        if smoothed.contains(canonical_layer) {
+            tensors.insert(
+                format!("{source_layer}.pre_quant_scale"),
+                H3QwenTensorSpec {
+                    dtype: H3QwenTensorDType::Bf16,
+                    shape: vec![logical_shape[1]],
+                },
+            );
+        }
+        markers.insert(
+            source_layer,
+            H3QwenQuantMarker {
+                format: "nvfp4".into(),
+                full_precision_matrix_mult: true,
+            },
+        );
+    }
+    Ok((tensors, markers))
+}
+
+fn checked_tensor_bytes(spec: &H3QwenTensorSpec) -> Result<u64, H3QwenNvfp4AwqError> {
+    spec.shape
+        .iter()
+        .try_fold(1_u64, |elements, dimension| {
+            elements.checked_mul(*dimension as u64)
+        })
+        .and_then(|elements| elements.checked_mul(spec.dtype.byte_width()))
+        .ok_or_else(|| H3QwenNvfp4AwqError::Accounting("tensor byte count overflows".into()))
+}
+
+/// Validate an already parsed schema and freeze the only supported loading
+/// policy. This function is artifact-neutral and grants no filesystem or
+/// runtime authority.
+pub fn validate_h3_qwen_nvfp4_awq_schema(
+    config: &H3ConditionerConfig,
+    tensors: &BTreeMap<String, H3QwenTensorSpec>,
+    markers: &BTreeMap<String, H3QwenQuantMarker>,
+) -> Result<H3QwenNvfp4AwqPolicy, H3QwenNvfp4AwqError> {
+    let (expected_tensors, expected_markers) = expected_h3_qwen_nvfp4_awq_schema(config)?;
+    if tensors != &expected_tensors {
+        let expected_keys = expected_tensors.keys().collect::<BTreeSet<_>>();
+        let actual_keys = tensors.keys().collect::<BTreeSet<_>>();
+        let missing = expected_keys
+            .difference(&actual_keys)
+            .take(4)
+            .map(|name| (*name).clone())
+            .collect::<Vec<_>>();
+        let unexpected = actual_keys
+            .difference(&expected_keys)
+            .take(4)
+            .map(|name| (*name).clone())
+            .collect::<Vec<_>>();
+        if !missing.is_empty() || !unexpected.is_empty() {
+            return Err(H3QwenNvfp4AwqError::TensorSchema(format!(
+                "tensor set mismatch: missing={missing:?} unexpected={unexpected:?}"
+            )));
+        }
+        let (name, expected) = expected_tensors
+            .iter()
+            .find(|(name, expected)| tensors.get(*name) != Some(*expected))
+            .expect("unequal maps have one unequal tensor");
+        let actual = &tensors[name];
+        return Err(H3QwenNvfp4AwqError::TensorSchema(format!(
+            "tensor {name:?} expected {:?} {:?}, got {:?} {:?}",
+            expected.dtype, expected.shape, actual.dtype, actual.shape
+        )));
+    }
+    if markers != &expected_markers {
+        let expected_keys = expected_markers.keys().collect::<BTreeSet<_>>();
+        let actual_keys = markers.keys().collect::<BTreeSet<_>>();
+        if expected_keys != actual_keys {
+            return Err(H3QwenNvfp4AwqError::Metadata(format!(
+                "quantized layer set mismatch: expected {} layers, got {}",
+                expected_keys.len(),
+                actual_keys.len()
+            )));
+        }
+        let (name, expected) = expected_markers
+            .iter()
+            .find(|(name, expected)| markers.get(*name) != Some(*expected))
+            .expect("unequal maps have one unequal marker");
+        return Err(H3QwenNvfp4AwqError::Metadata(format!(
+            "layer {name:?} expected marker {expected:?}, got {:?}",
+            markers[name]
+        )));
+    }
+
+    let quantized = canonical_quantized_layers();
+    let smoothed = canonical_awq_smoothed_layers();
+    if quantized.len() != H3_QWEN_NVFP4_LINEAR_COUNT
+        || smoothed.len() != H3_QWEN_NVFP4_PRE_QUANT_SCALE_COUNT
+    {
+        return Err(H3QwenNvfp4AwqError::Accounting(format!(
+            "derived {} NVFP4 layers and {} AWQ scales",
+            quantized.len(),
+            smoothed.len()
+        )));
+    }
+
+    let mut memory = H3QwenNvfp4AwqMemoryAccounting {
+        artifact_file_bytes: H3_QWEN_NVFP4_AWQ_FILE_BYTES,
+        header_bytes: H3_QWEN_NVFP4_AWQ_HEADER_BYTES,
+        tensor_payload_bytes: 0,
+        nvfp4_packed_weight_bytes: 0,
+        nvfp4_block_scale_bytes: 0,
+        nvfp4_tensor_scale_bytes: 0,
+        awq_pre_quant_scale_bytes: 0,
+        int8_embedding_weight_bytes: 0,
+        int8_embedding_scale_bytes: 0,
+        dense_bf16_bytes: 0,
+        quant_marker_bytes: 0,
+    };
+    for (name, spec) in &expected_tensors {
+        let bytes = checked_tensor_bytes(spec)?;
+        memory.tensor_payload_bytes = memory
+            .tensor_payload_bytes
+            .checked_add(bytes)
+            .ok_or_else(|| H3QwenNvfp4AwqError::Accounting("payload bytes overflow".into()))?;
+        if name == "model.embed_tokens.weight" {
+            memory.int8_embedding_weight_bytes = bytes;
+        } else if name == "model.embed_tokens.weight_scale" {
+            memory.int8_embedding_scale_bytes = bytes;
+        } else if name.ends_with(".comfy_quant") {
+            memory.quant_marker_bytes = memory
+                .quant_marker_bytes
+                .checked_add(bytes)
+                .ok_or_else(|| H3QwenNvfp4AwqError::Accounting("marker bytes overflow".into()))?;
+        } else if name.ends_with(".pre_quant_scale") {
+            memory.awq_pre_quant_scale_bytes = memory
+                .awq_pre_quant_scale_bytes
+                .checked_add(bytes)
+                .ok_or_else(|| H3QwenNvfp4AwqError::Accounting("AWQ bytes overflow".into()))?;
+        } else if name.ends_with(".weight_scale_2") {
+            memory.nvfp4_tensor_scale_bytes = memory
+                .nvfp4_tensor_scale_bytes
+                .checked_add(bytes)
+                .ok_or_else(|| {
+                    H3QwenNvfp4AwqError::Accounting("tensor-scale bytes overflow".into())
+                })?;
+        } else if name.ends_with(".weight_scale") {
+            memory.nvfp4_block_scale_bytes = memory
+                .nvfp4_block_scale_bytes
+                .checked_add(bytes)
+                .ok_or_else(|| {
+                    H3QwenNvfp4AwqError::Accounting("block-scale bytes overflow".into())
+                })?;
+        } else if spec.dtype == H3QwenTensorDType::U8 && name.ends_with(".weight") {
+            memory.nvfp4_packed_weight_bytes = memory
+                .nvfp4_packed_weight_bytes
+                .checked_add(bytes)
+                .ok_or_else(|| {
+                    H3QwenNvfp4AwqError::Accounting("packed-weight bytes overflow".into())
+                })?;
+        } else if spec.dtype == H3QwenTensorDType::Bf16 {
+            memory.dense_bf16_bytes = memory
+                .dense_bf16_bytes
+                .checked_add(bytes)
+                .ok_or_else(|| H3QwenNvfp4AwqError::Accounting("dense bytes overflow".into()))?;
+        } else {
+            return Err(H3QwenNvfp4AwqError::Accounting(format!(
+                "tensor {name:?} is not assigned to a memory category"
+            )));
+        }
+    }
+    if memory.tensor_payload_bytes != H3_QWEN_NVFP4_AWQ_PAYLOAD_BYTES {
+        return Err(H3QwenNvfp4AwqError::Accounting(format!(
+            "derived {} payload bytes, expected {H3_QWEN_NVFP4_AWQ_PAYLOAD_BYTES}",
+            memory.tensor_payload_bytes
+        )));
+    }
+    let protected_tensors = expected_materialized_keys()
+        .into_iter()
+        .filter(|name| {
+            name != "model.language_model.embed_tokens.weight"
+                && !name
+                    .strip_suffix(".weight")
+                    .is_some_and(|layer| quantized.contains(layer))
+        })
+        .collect::<Vec<_>>();
+
+    let mut digest = Sha256::new();
+    digest.update(H3_QWEN_NVFP4_AWQ_STABLE_ID.as_bytes());
+    for (name, spec) in &expected_tensors {
+        digest.update((name.len() as u64).to_le_bytes());
+        digest.update(name.as_bytes());
+        digest.update(spec.dtype.stable_id().as_bytes());
+        for dimension in &spec.shape {
+            digest.update((*dimension as u64).to_le_bytes());
+        }
+    }
+    for (name, marker) in &expected_markers {
+        digest.update((name.len() as u64).to_le_bytes());
+        digest.update(name.as_bytes());
+        digest.update(marker.format.as_bytes());
+        digest.update([u8::from(marker.full_precision_matrix_mult)]);
+    }
+    let policy_sha256 = hex_digest(digest.finalize());
+    if policy_sha256 != H3_QWEN_NVFP4_AWQ_POLICY_SHA256 {
+        return Err(H3QwenNvfp4AwqError::Accounting(format!(
+            "derived policy identity {policy_sha256}, expected {H3_QWEN_NVFP4_AWQ_POLICY_SHA256}"
+        )));
+    }
+    Ok(H3QwenNvfp4AwqPolicy {
+        stable_id: H3_QWEN_NVFP4_AWQ_STABLE_ID.into(),
+        quantized_layers: quantized.into_iter().collect(),
+        awq_smoothed_layers: smoothed.into_iter().collect(),
+        protected_tensors,
+        memory,
+        policy_sha256,
+    })
+}
+
+fn parse_dtype(dtype: &str) -> Result<H3QwenTensorDType, H3QwenNvfp4AwqError> {
+    match dtype {
+        "BF16" => Ok(H3QwenTensorDType::Bf16),
+        "F8_E4M3" => Ok(H3QwenTensorDType::F8E4M3),
+        "F32" => Ok(H3QwenTensorDType::F32),
+        "I8" => Ok(H3QwenTensorDType::I8),
+        "U8" => Ok(H3QwenTensorDType::U8),
+        other => Err(H3QwenNvfp4AwqError::TensorSchema(format!(
+            "unsupported published dtype {other:?}"
+        ))),
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct FileIdentity {
+    len: u64,
+    modified: Option<std::time::SystemTime>,
+    #[cfg(unix)]
+    device: u64,
+    #[cfg(unix)]
+    inode: u64,
+    #[cfg(unix)]
+    changed_seconds: i64,
+    #[cfg(unix)]
+    changed_nanoseconds: i64,
+}
+
+fn file_identity(metadata: &Metadata) -> FileIdentity {
+    #[cfg(unix)]
+    use std::os::unix::fs::MetadataExt;
+    FileIdentity {
+        len: metadata.len(),
+        modified: metadata.modified().ok(),
+        #[cfg(unix)]
+        device: metadata.dev(),
+        #[cfg(unix)]
+        inode: metadata.ino(),
+        #[cfg(unix)]
+        changed_seconds: metadata.ctime(),
+        #[cfg(unix)]
+        changed_nanoseconds: metadata.ctime_nsec(),
+    }
+}
+
+/// Inspect the exact selected H3 Qwen object using bounded reads.
+///
+/// This validates file/header size, every tensor dtype/shape/range, all 351
+/// small quantization marker payloads, and the frozen policy identity. It does
+/// **not** hash the 15.7 GB tensor payload; compare a separately computed full
+/// digest with [`H3_QWEN_NVFP4_AWQ_SHA256`] before treating weights as
+/// authenticated.
+pub fn inspect_h3_qwen_nvfp4_awq_header(
+    path: &Path,
+) -> Result<H3QwenNvfp4AwqInspection, H3QwenNvfp4AwqError> {
+    let before = std::fs::metadata(path)
+        .map(|metadata| file_identity(&metadata))
+        .map_err(|error| H3QwenNvfp4AwqError::Io(error.to_string()))?;
+    let header = inspect_safetensors_header(path)
+        .map_err(|error| H3QwenNvfp4AwqError::Header(error.to_string()))?;
+    if header.file_len != H3_QWEN_NVFP4_AWQ_FILE_BYTES
+        || header.header_len != H3_QWEN_NVFP4_AWQ_HEADER_BYTES
+        || header.tensors.len() != H3_QWEN_NVFP4_AWQ_TENSOR_COUNT
+    {
+        return Err(H3QwenNvfp4AwqError::Header(format!(
+            "expected {H3_QWEN_NVFP4_AWQ_FILE_BYTES} file bytes, {H3_QWEN_NVFP4_AWQ_HEADER_BYTES} header bytes, and {H3_QWEN_NVFP4_AWQ_TENSOR_COUNT} tensors; got {}, {}, and {}",
+            header.file_len,
+            header.header_len,
+            header.tensors.len()
+        )));
+    }
+    let tensors = header
+        .tensors
+        .iter()
+        .map(|(name, tensor)| {
+            Ok((
+                name.clone(),
+                H3QwenTensorSpec {
+                    dtype: parse_dtype(&tensor.dtype)?,
+                    shape: tensor.shape.clone(),
+                },
+            ))
+        })
+        .collect::<Result<BTreeMap<_, _>, H3QwenNvfp4AwqError>>()?;
+
+    let mut file = File::open(path).map_err(|error| H3QwenNvfp4AwqError::Io(error.to_string()))?;
+    let opened = file
+        .metadata()
+        .map(|metadata| file_identity(&metadata))
+        .map_err(|error| H3QwenNvfp4AwqError::Io(error.to_string()))?;
+    if opened != before {
+        return Err(H3QwenNvfp4AwqError::Io(
+            "artifact changed between header and marker inspection".into(),
+        ));
+    }
+    let data_start = 8_u64
+        .checked_add(header.header_len)
+        .ok_or_else(|| H3QwenNvfp4AwqError::Header("data offset overflows".into()))?;
+    let mut markers = BTreeMap::new();
+    for (name, tensor) in &header.tensors {
+        let Some(base) = name.strip_suffix(".comfy_quant") else {
+            continue;
+        };
+        if tensor.dtype != "U8" || tensor.shape.len() != 1 || tensor.shape[0] > 128 {
+            return Err(H3QwenNvfp4AwqError::Metadata(format!(
+                "quant marker {name:?} must be bounded rank-one U8"
+            )));
+        }
+        let length = usize::try_from(tensor.data_offsets[1] - tensor.data_offsets[0])
+            .map_err(|_| H3QwenNvfp4AwqError::Metadata("marker length overflows".into()))?;
+        let mut bytes = vec![0_u8; length];
+        file.seek(SeekFrom::Start(
+            data_start
+                .checked_add(tensor.data_offsets[0])
+                .ok_or_else(|| H3QwenNvfp4AwqError::Metadata("marker offset overflows".into()))?,
+        ))
+        .and_then(|_| file.read_exact(&mut bytes))
+        .map_err(|error| H3QwenNvfp4AwqError::Io(error.to_string()))?;
+        let marker: H3QwenQuantMarker = serde_json::from_slice(&bytes).map_err(|error| {
+            H3QwenNvfp4AwqError::Metadata(format!("invalid marker {name:?}: {error}"))
+        })?;
+        if markers.insert(base.into(), marker).is_some() {
+            return Err(H3QwenNvfp4AwqError::Metadata(format!(
+                "duplicate marker base {base:?}"
+            )));
+        }
+    }
+    let policy = validate_h3_qwen_nvfp4_awq_schema(&released_config()?, &tensors, &markers)?;
+
+    let mut header_bytes = vec![0_u8; (8 + header.header_len) as usize];
+    file.seek(SeekFrom::Start(0))
+        .and_then(|_| file.read_exact(&mut header_bytes))
+        .map_err(|error| H3QwenNvfp4AwqError::Io(error.to_string()))?;
+    let after_open = file
+        .metadata()
+        .map(|metadata| file_identity(&metadata))
+        .map_err(|error| H3QwenNvfp4AwqError::Io(error.to_string()))?;
+    let after_path = std::fs::metadata(path)
+        .map(|metadata| file_identity(&metadata))
+        .map_err(|error| H3QwenNvfp4AwqError::Io(error.to_string()))?;
+    if before != after_open || before != after_path {
+        return Err(H3QwenNvfp4AwqError::Io(
+            "artifact changed during bounded inspection".into(),
+        ));
+    }
+    Ok(H3QwenNvfp4AwqInspection {
+        stable_id: H3_QWEN_NVFP4_AWQ_STABLE_ID.into(),
+        expected_artifact_sha256: H3_QWEN_NVFP4_AWQ_SHA256.into(),
+        artifact_file_bytes: header.file_len,
+        header_bytes: header.header_len,
+        tensor_payload_bytes: policy.memory().tensor_payload_bytes,
+        tensor_count: header.tensors.len(),
+        nvfp4_linear_count: policy.quantized_layers().len(),
+        awq_pre_quant_scale_count: policy.awq_smoothed_layers().len(),
+        int8_tensorwise_count: markers
+            .values()
+            .filter(|marker| marker.format == "int8_tensorwise")
+            .count(),
+        header_identity_sha256: hex_digest(Sha256::digest(&header_bytes)),
+        policy_sha256: policy.policy_sha256().into(),
+    })
+}
+
+fn hex_digest(bytes: impl AsRef<[u8]>) -> String {
+    bytes
+        .as_ref()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::fs::OpenOptions;
+    use std::io::Write;
+    use std::path::PathBuf;
+
+    fn fixture() -> (
+        H3ConditionerConfig,
+        BTreeMap<String, H3QwenTensorSpec>,
+        BTreeMap<String, H3QwenQuantMarker>,
+    ) {
+        let config = released_config().unwrap();
+        let (tensors, markers) = expected_h3_qwen_nvfp4_awq_schema(&config).unwrap();
+        (config, tensors, markers)
+    }
+
+    fn temp_path(tag: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "mold-h3-qwen-nvfp4-{tag}-{}-{}.safetensors",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+    }
+
+    fn dtype_name(dtype: H3QwenTensorDType) -> &'static str {
+        match dtype {
+            H3QwenTensorDType::Bf16 => "BF16",
+            H3QwenTensorDType::F8E4M3 => "F8_E4M3",
+            H3QwenTensorDType::F32 => "F32",
+            H3QwenTensorDType::I8 => "I8",
+            H3QwenTensorDType::U8 => "U8",
+        }
+    }
+
+    fn sparse_published_fixture() -> PathBuf {
+        let (_, tensors, markers) = fixture();
+        // Safetensors payload order is independent of JSON key order. Put the
+        // numerous small tensors first, like the published converter does, so
+        // their decimal offsets keep the synthetic header below the frozen
+        // published header size; the remaining bytes are legal JSON padding.
+        let mut payload_order = tensors.iter().collect::<Vec<_>>();
+        payload_order.sort_by_key(|(name, spec)| (checked_tensor_bytes(spec).unwrap(), *name));
+        let mut ranges = BTreeMap::new();
+        let mut cursor = 0_u64;
+        for (name, spec) in payload_order {
+            let bytes = checked_tensor_bytes(spec).unwrap();
+            ranges.insert(name.clone(), [cursor, cursor + bytes]);
+            cursor += bytes;
+        }
+        assert_eq!(cursor, H3_QWEN_NVFP4_AWQ_PAYLOAD_BYTES);
+
+        let mut root = serde_json::Map::new();
+        let mut marker_ranges = Vec::new();
+        for (name, spec) in &tensors {
+            let offsets = ranges[name];
+            root.insert(
+                name.clone(),
+                json!({
+                    "dtype": dtype_name(spec.dtype),
+                    "shape": spec.shape,
+                    "data_offsets": offsets
+                }),
+            );
+            if let Some(base) = name.strip_suffix(".comfy_quant") {
+                let marker = &markers[base];
+                let bytes = if marker.format == "int8_tensorwise" {
+                    INT8_MARKER_JSON
+                } else {
+                    NVFP4_MARKER_JSON
+                };
+                marker_ranges.push((offsets[0], bytes));
+            }
+        }
+        let mut header = serde_json::to_vec(&root).unwrap();
+        assert!(
+            header.len() <= H3_QWEN_NVFP4_AWQ_HEADER_BYTES as usize,
+            "synthetic header is {} bytes",
+            header.len()
+        );
+        header.resize(H3_QWEN_NVFP4_AWQ_HEADER_BYTES as usize, b' ');
+        let path = temp_path("published");
+        let mut file = OpenOptions::new()
+            .create_new(true)
+            .read(true)
+            .write(true)
+            .open(&path)
+            .unwrap();
+        file.set_len(H3_QWEN_NVFP4_AWQ_FILE_BYTES).unwrap();
+        file.write_all(&H3_QWEN_NVFP4_AWQ_HEADER_BYTES.to_le_bytes())
+            .unwrap();
+        file.write_all(&header).unwrap();
+        let data_start = 8 + H3_QWEN_NVFP4_AWQ_HEADER_BYTES;
+        for (offset, bytes) in marker_ranges {
+            file.seek(SeekFrom::Start(data_start + offset)).unwrap();
+            file.write_all(bytes).unwrap();
+        }
+        file.sync_all().unwrap();
+        path
+    }
+
+    #[test]
+    fn published_schema_and_byte_accounting_are_frozen() {
+        let (config, tensors, markers) = fixture();
+        let policy = validate_h3_qwen_nvfp4_awq_schema(&config, &tensors, &markers).unwrap();
+        assert_eq!(tensors.len(), H3_QWEN_NVFP4_AWQ_TENSOR_COUNT);
+        assert_eq!(markers.len(), H3_QWEN_QUANT_MARKER_COUNT);
+        assert_eq!(policy.quantized_layers().len(), H3_QWEN_NVFP4_LINEAR_COUNT);
+        assert_eq!(
+            policy.awq_smoothed_layers().len(),
+            H3_QWEN_NVFP4_PRE_QUANT_SCALE_COUNT
+        );
+        assert_eq!(policy.memory().tensor_payload_bytes, 15_686_911_143);
+        assert_eq!(policy.memory().nvfp4_packed_weight_bytes, 12_189_696_000);
+        assert_eq!(policy.memory().nvfp4_block_scale_bytes, 1_523_712_000);
+        assert_eq!(policy.memory().nvfp4_tensor_scale_bytes, 1_400);
+        assert_eq!(policy.memory().awq_pre_quant_scale_bytes, 3_379_200);
+        assert_eq!(policy.memory().int8_embedding_weight_bytes, 777_912_320);
+        assert_eq!(policy.memory().int8_embedding_scale_bytes, 607_744);
+        assert_eq!(policy.memory().dense_bf16_bytes, 1_191_583_200);
+        assert_eq!(policy.memory().quant_marker_bytes, 19_279);
+        assert_eq!(policy.policy_sha256(), H3_QWEN_NVFP4_AWQ_POLICY_SHA256);
+    }
+
+    #[test]
+    fn selective_awq_and_int8_embedding_loading_contract_is_exact() {
+        let (config, tensors, markers) = fixture();
+        let policy = validate_h3_qwen_nvfp4_awq_schema(&config, &tensors, &markers).unwrap();
+        assert_eq!(
+            policy
+                .execution_for_weight("model.language_model.embed_tokens.weight")
+                .unwrap(),
+            H3QwenNvfp4AwqExecution::Int8TensorwiseEmbedding {
+                weight_tensor: "model.embed_tokens.weight".into(),
+                weight_scale_tensor: "model.embed_tokens.weight_scale".into()
+            }
+        );
+        assert_eq!(
+            policy
+                .execution_for_weight("model.language_model.layers.0.mlp.down_proj.weight")
+                .unwrap(),
+            H3QwenNvfp4AwqExecution::Nvfp4FullPrecision {
+                packed_weight_tensor: "model.layers.0.mlp.down_proj.weight".into(),
+                block_scale_tensor: "model.layers.0.mlp.down_proj.weight_scale".into(),
+                tensor_scale_tensor: "model.layers.0.mlp.down_proj.weight_scale_2".into(),
+                pre_quant_scale_tensor: Some("model.layers.0.mlp.down_proj.pre_quant_scale".into()),
+            }
+        );
+        assert_eq!(
+            policy
+                .execution_for_weight("model.language_model.layers.0.mlp.gate_proj.weight")
+                .unwrap(),
+            H3QwenNvfp4AwqExecution::Nvfp4FullPrecision {
+                packed_weight_tensor: "model.layers.0.mlp.gate_proj.weight".into(),
+                block_scale_tensor: "model.layers.0.mlp.gate_proj.weight_scale".into(),
+                tensor_scale_tensor: "model.layers.0.mlp.gate_proj.weight_scale_2".into(),
+                pre_quant_scale_tensor: None,
+            }
+        );
+        assert_eq!(
+            policy
+                .execution_for_weight("model.visual.blocks.0.attn.qkv.weight")
+                .unwrap(),
+            H3QwenNvfp4AwqExecution::DenseBf16 {
+                source_tensor: "visual.blocks.0.attn.qkv.weight".into()
+            }
+        );
+    }
+
+    #[test]
+    fn dtype_shape_sidecar_and_marker_mutations_fail_closed() {
+        let (config, tensors, markers) = fixture();
+        let base = "model.layers.0.mlp.down_proj";
+
+        let mut missing = tensors.clone();
+        missing.remove(&format!("{base}.weight_scale_2"));
+        assert!(matches!(
+            validate_h3_qwen_nvfp4_awq_schema(&config, &missing, &markers),
+            Err(H3QwenNvfp4AwqError::TensorSchema(_))
+        ));
+
+        let mut wrong_dtype = tensors.clone();
+        wrong_dtype
+            .get_mut(&format!("{base}.weight_scale"))
+            .unwrap()
+            .dtype = H3QwenTensorDType::F32;
+        assert!(matches!(
+            validate_h3_qwen_nvfp4_awq_schema(&config, &wrong_dtype, &markers),
+            Err(H3QwenNvfp4AwqError::TensorSchema(_))
+        ));
+
+        let mut missing_awq = tensors.clone();
+        missing_awq.remove(&format!("{base}.pre_quant_scale"));
+        assert!(validate_h3_qwen_nvfp4_awq_schema(&config, &missing_awq, &markers).is_err());
+
+        let mut unexpected_awq = tensors.clone();
+        unexpected_awq.insert(
+            "model.layers.0.mlp.gate_proj.pre_quant_scale".into(),
+            H3QwenTensorSpec {
+                dtype: H3QwenTensorDType::Bf16,
+                shape: vec![5120],
+            },
+        );
+        assert!(validate_h3_qwen_nvfp4_awq_schema(&config, &unexpected_awq, &markers).is_err());
+
+        let mut kernel_marker = markers.clone();
+        kernel_marker
+            .get_mut(base)
+            .unwrap()
+            .full_precision_matrix_mult = false;
+        assert!(matches!(
+            validate_h3_qwen_nvfp4_awq_schema(&config, &tensors, &kernel_marker),
+            Err(H3QwenNvfp4AwqError::Metadata(_))
+        ));
+    }
+
+    #[test]
+    fn serialized_markers_reject_unknown_execution_fields() {
+        let marker = br#"{"format":"nvfp4","full_precision_matrix_mult":true,"native":true}"#;
+        assert!(serde_json::from_slice::<H3QwenQuantMarker>(marker).is_err());
+    }
+
+    #[test]
+    fn bounded_inspector_accepts_exact_sparse_artifact_and_rejects_marker_corruption() {
+        let path = sparse_published_fixture();
+        let inspection = inspect_h3_qwen_nvfp4_awq_header(&path).unwrap();
+        assert_eq!(inspection.tensor_count, H3_QWEN_NVFP4_AWQ_TENSOR_COUNT);
+        assert_eq!(inspection.nvfp4_linear_count, H3_QWEN_NVFP4_LINEAR_COUNT);
+        assert_eq!(inspection.awq_pre_quant_scale_count, 100);
+        assert_eq!(inspection.int8_tensorwise_count, 1);
+        assert_eq!(inspection.header_identity_sha256.len(), 64);
+        assert_eq!(
+            inspection.expected_artifact_sha256,
+            H3_QWEN_NVFP4_AWQ_SHA256
+        );
+
+        let header = inspect_safetensors_header(&path).unwrap();
+        let marker = &header.tensors["model.layers.0.mlp.down_proj.comfy_quant"];
+        let mut file = OpenOptions::new().write(true).open(&path).unwrap();
+        file.seek(SeekFrom::Start(
+            8 + header.header_len + marker.data_offsets[0],
+        ))
+        .unwrap();
+        file.write_all(br#"{"format": "nvfp5", "full_precision_matrix_mult": true}"#)
+            .unwrap();
+        file.sync_all().unwrap();
+        assert!(matches!(
+            inspect_h3_qwen_nvfp4_awq_header(&path),
+            Err(H3QwenNvfp4AwqError::Metadata(_))
+        ));
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    #[ignore = "requires the authorized, separately authenticated private H3 artifact"]
+    fn authorized_published_artifact_matches_bounded_contract() {
+        let path = std::env::var_os("MOLD_H3_QWEN_NVFP4_PATH")
+            .map(PathBuf::from)
+            .expect("set MOLD_H3_QWEN_NVFP4_PATH to the private pinned artifact");
+        let inspection = inspect_h3_qwen_nvfp4_awq_header(&path).unwrap();
+        assert_eq!(inspection.artifact_file_bytes, H3_QWEN_NVFP4_AWQ_FILE_BYTES);
+        assert_eq!(inspection.header_bytes, H3_QWEN_NVFP4_AWQ_HEADER_BYTES);
+        assert_eq!(
+            inspection.tensor_payload_bytes,
+            H3_QWEN_NVFP4_AWQ_PAYLOAD_BYTES
+        );
+        assert_eq!(inspection.tensor_count, H3_QWEN_NVFP4_AWQ_TENSOR_COUNT);
+        assert_eq!(inspection.nvfp4_linear_count, H3_QWEN_NVFP4_LINEAR_COUNT);
+        assert_eq!(
+            inspection.awq_pre_quant_scale_count,
+            H3_QWEN_NVFP4_PRE_QUANT_SCALE_COUNT
+        );
+        assert_eq!(inspection.int8_tensorwise_count, 1);
+    }
+}

--- a/crates/mold-candle/src/minimax_h3/qwen_nvfp4.rs
+++ b/crates/mold-candle/src/minimax_h3/qwen_nvfp4.rs
@@ -10,9 +10,10 @@
 //! not an incomplete checkpoint.
 //!
 //! This module reads only the bounded safetensors header and the small
-//! `comfy_quant` marker tensors. It neither hashes the full artifact nor grants
-//! download, license, factory, or runtime authority. Callers must separately
-//! authenticate the complete pinned object before mapping tensor payloads.
+//! `comfy_quant` marker tensors through one identity-fenced regular-file
+//! descriptor. It neither hashes the full artifact nor grants download,
+//! license, factory, or runtime authority. Callers must separately authenticate
+//! the complete pinned object before mapping tensor payloads.
 
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -25,8 +26,10 @@ use thiserror::Error;
 use super::artifacts::{expected_checkpoint_shapes, expected_materialized_keys};
 use super::config::{H3ConditionerConfig, H3_SELECTED_LANGUAGE_LAYERS};
 use super::qwen_quant::{H3QwenTensorDType, H3QwenTensorSpec};
-use super::visual_weights::inspect_safetensors_header;
 use super::H3_COMFY_NVFP4_BLOCK_SIZE;
+
+#[cfg(test)]
+use super::visual_weights::inspect_safetensors_header;
 
 pub const H3_QWEN_NVFP4_AWQ_STABLE_ID: &str = "minimax-h3.qwen3-vl.layer50.nvfp4-awq.v1";
 pub const H3_QWEN_NVFP4_AWQ_FILENAME: &str = "qwen3vl_32b_minimax_h3_nvfp4_awq.safetensors";
@@ -656,21 +659,221 @@ fn file_identity(metadata: &Metadata) -> FileIdentity {
     }
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct H3SafetensorsTensorHeader {
+    dtype: String,
+    shape: Vec<usize>,
+    data_offsets: [u64; 2],
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct H3SafetensorsHeader {
+    tensors: BTreeMap<String, H3SafetensorsTensorHeader>,
+    header_len: u64,
+    file_len: u64,
+    bytes: Vec<u8>,
+    has_metadata: bool,
+}
+
+struct UniqueH3SafetensorsHeader(BTreeMap<String, serde_json::Value>);
+
+impl<'de> Deserialize<'de> for UniqueH3SafetensorsHeader {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct UniqueHeaderVisitor;
+
+        impl<'de> serde::de::Visitor<'de> for UniqueHeaderVisitor {
+            type Value = UniqueH3SafetensorsHeader;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("a safetensors header with unique tensor names")
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                let mut entries = BTreeMap::new();
+                while let Some((name, value)) = map.next_entry::<String, serde_json::Value>()? {
+                    if entries.insert(name.clone(), value).is_some() {
+                        return Err(serde::de::Error::custom(format!(
+                            "duplicate safetensors tensor {name}"
+                        )));
+                    }
+                }
+                Ok(UniqueH3SafetensorsHeader(entries))
+            }
+        }
+
+        deserializer.deserialize_map(UniqueHeaderVisitor)
+    }
+}
+
+fn checked_path_identity(
+    path: &Path,
+    expected: Option<&FileIdentity>,
+    operation: &str,
+) -> Result<FileIdentity, H3QwenNvfp4AwqError> {
+    let metadata = std::fs::symlink_metadata(path)
+        .map_err(|error| H3QwenNvfp4AwqError::Io(format!("{operation}: {error}")))?;
+    if metadata.file_type().is_symlink() {
+        return Err(H3QwenNvfp4AwqError::Io(format!(
+            "{operation}: artifact path must not be a symlink"
+        )));
+    }
+    if !metadata.file_type().is_file() {
+        return Err(H3QwenNvfp4AwqError::Io(format!(
+            "{operation}: artifact path must be a regular file"
+        )));
+    }
+    let identity = file_identity(&metadata);
+    if expected.is_some_and(|expected| *expected != identity) {
+        return Err(H3QwenNvfp4AwqError::Io(format!(
+            "{operation}: artifact path identity changed"
+        )));
+    }
+    Ok(identity)
+}
+
+fn checked_open_identity(
+    file: &File,
+    expected: &FileIdentity,
+    operation: &str,
+) -> Result<(), H3QwenNvfp4AwqError> {
+    let metadata = file
+        .metadata()
+        .map_err(|error| H3QwenNvfp4AwqError::Io(format!("{operation}: {error}")))?;
+    if !metadata.file_type().is_file() || file_identity(&metadata) != *expected {
+        return Err(H3QwenNvfp4AwqError::Io(format!(
+            "{operation}: opened artifact identity changed"
+        )));
+    }
+    Ok(())
+}
+
+fn read_h3_safetensors_header(
+    file: &mut File,
+    file_len: u64,
+) -> Result<H3SafetensorsHeader, H3QwenNvfp4AwqError> {
+    file.seek(SeekFrom::Start(0))
+        .map_err(|error| H3QwenNvfp4AwqError::Io(error.to_string()))?;
+    let mut len_bytes = [0_u8; 8];
+    file.read_exact(&mut len_bytes)
+        .map_err(|error| H3QwenNvfp4AwqError::Io(error.to_string()))?;
+    let header_len = u64::from_le_bytes(len_bytes);
+    if header_len != H3_QWEN_NVFP4_AWQ_HEADER_BYTES
+        || header_len.checked_add(8).is_none_or(|end| end > file_len)
+    {
+        return Err(H3QwenNvfp4AwqError::Header(format!(
+            "expected {H3_QWEN_NVFP4_AWQ_HEADER_BYTES} header bytes, got {header_len}"
+        )));
+    }
+    let header_size = usize::try_from(header_len)
+        .map_err(|_| H3QwenNvfp4AwqError::Header("header length overflows usize".into()))?;
+    let mut json_bytes = vec![0_u8; header_size];
+    file.read_exact(&mut json_bytes)
+        .map_err(|error| H3QwenNvfp4AwqError::Io(error.to_string()))?;
+    let UniqueH3SafetensorsHeader(mut raw) = serde_json::from_slice(&json_bytes)
+        .map_err(|error| H3QwenNvfp4AwqError::Header(error.to_string()))?;
+    let has_metadata = raw.remove("__metadata__").is_some();
+    let data_len = file_len - header_len - 8;
+    let mut tensors = BTreeMap::new();
+    for (name, value) in raw {
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct Entry {
+            dtype: String,
+            shape: Vec<usize>,
+            data_offsets: [u64; 2],
+        }
+
+        let entry: Entry = serde_json::from_value(value).map_err(|error| {
+            H3QwenNvfp4AwqError::Header(format!("invalid tensor {name:?}: {error}"))
+        })?;
+        if entry.data_offsets[0] > entry.data_offsets[1] || entry.data_offsets[1] > data_len {
+            return Err(H3QwenNvfp4AwqError::Header(format!(
+                "invalid safetensors offsets for {name:?}"
+            )));
+        }
+        let dtype = parse_dtype(&entry.dtype)?;
+        let elements = entry.shape.iter().try_fold(1_u64, |total, &dimension| {
+            total.checked_mul(dimension as u64)
+        });
+        let expected_bytes = elements
+            .and_then(|elements| elements.checked_mul(dtype.byte_width()))
+            .ok_or_else(|| {
+                H3QwenNvfp4AwqError::Header(format!("byte-size overflow for {name:?}"))
+            })?;
+        if entry.data_offsets[1] - entry.data_offsets[0] != expected_bytes {
+            return Err(H3QwenNvfp4AwqError::Header(format!(
+                "safetensors byte range does not match dtype/shape for {name:?}"
+            )));
+        }
+        tensors.insert(
+            name,
+            H3SafetensorsTensorHeader {
+                dtype: entry.dtype,
+                shape: entry.shape,
+                data_offsets: entry.data_offsets,
+            },
+        );
+    }
+
+    let mut cursor = 0_u64;
+    let mut ranges = tensors
+        .iter()
+        .map(|(name, tensor)| (tensor.data_offsets, name.as_str()))
+        .collect::<Vec<_>>();
+    ranges.sort_by_key(|(offsets, _)| offsets[0]);
+    for (offsets, name) in ranges {
+        if offsets[0] != cursor {
+            return Err(H3QwenNvfp4AwqError::Header(format!(
+                "non-contiguous or overlapping safetensors data before {name:?}"
+            )));
+        }
+        cursor = offsets[1];
+    }
+    if cursor != data_len {
+        return Err(H3QwenNvfp4AwqError::Header(format!(
+            "safetensors data section has {} unclaimed bytes",
+            data_len - cursor
+        )));
+    }
+
+    let mut bytes = Vec::with_capacity(8 + header_size);
+    bytes.extend_from_slice(&len_bytes);
+    bytes.extend_from_slice(&json_bytes);
+    Ok(H3SafetensorsHeader {
+        tensors,
+        header_len,
+        file_len,
+        bytes,
+        has_metadata,
+    })
+}
+
 /// Inspect the exact selected H3 Qwen object using bounded reads.
 ///
-/// This validates file/header size, every tensor dtype/shape/range, all 351
-/// small quantization marker payloads, and the frozen policy identity. It does
+/// Symlinks and non-regular files are rejected. One opened descriptor supplies
+/// the prefix, header, header identity, and all marker bytes while descriptor
+/// and path identities are fenced before and after bounded inspection. This
+/// validates file/header size, every tensor dtype/shape/range, all 351 small
+/// quantization marker payloads, and the frozen policy identity. It does
 /// **not** hash the 15.7 GB tensor payload; compare a separately computed full
 /// digest with [`H3_QWEN_NVFP4_AWQ_SHA256`] before treating weights as
 /// authenticated.
 pub fn inspect_h3_qwen_nvfp4_awq_header(
     path: &Path,
 ) -> Result<H3QwenNvfp4AwqInspection, H3QwenNvfp4AwqError> {
-    let before = std::fs::metadata(path)
-        .map(|metadata| file_identity(&metadata))
-        .map_err(|error| H3QwenNvfp4AwqError::Io(error.to_string()))?;
-    let header = inspect_safetensors_header(path)
-        .map_err(|error| H3QwenNvfp4AwqError::Header(error.to_string()))?;
+    let before = checked_path_identity(path, None, "before bounded inspection")?;
+    let mut file = File::open(path).map_err(|error| H3QwenNvfp4AwqError::Io(error.to_string()))?;
+    checked_open_identity(&file, &before, "after opening artifact")?;
+    checked_path_identity(path, Some(&before), "after opening artifact")?;
+    let header = read_h3_safetensors_header(&mut file, before.len)?;
+    checked_open_identity(&file, &before, "after header inspection")?;
+    checked_path_identity(path, Some(&before), "after header inspection")?;
     if header.file_len != H3_QWEN_NVFP4_AWQ_FILE_BYTES
         || header.header_len != H3_QWEN_NVFP4_AWQ_HEADER_BYTES
         || header.tensors.len() != H3_QWEN_NVFP4_AWQ_TENSOR_COUNT
@@ -696,16 +899,6 @@ pub fn inspect_h3_qwen_nvfp4_awq_header(
         })
         .collect::<Result<BTreeMap<_, _>, H3QwenNvfp4AwqError>>()?;
 
-    let mut file = File::open(path).map_err(|error| H3QwenNvfp4AwqError::Io(error.to_string()))?;
-    let opened = file
-        .metadata()
-        .map(|metadata| file_identity(&metadata))
-        .map_err(|error| H3QwenNvfp4AwqError::Io(error.to_string()))?;
-    if opened != before {
-        return Err(H3QwenNvfp4AwqError::Io(
-            "artifact changed between header and marker inspection".into(),
-        ));
-    }
     let data_start = 8_u64
         .checked_add(header.header_len)
         .ok_or_else(|| H3QwenNvfp4AwqError::Header("data offset overflows".into()))?;
@@ -740,34 +933,13 @@ pub fn inspect_h3_qwen_nvfp4_awq_header(
     }
     let policy = validate_h3_qwen_nvfp4_awq_schema(&released_config()?, &tensors, &markers)?;
 
-    let mut header_bytes = vec![0_u8; (8 + header.header_len) as usize];
-    file.seek(SeekFrom::Start(0))
-        .and_then(|_| file.read_exact(&mut header_bytes))
-        .map_err(|error| H3QwenNvfp4AwqError::Io(error.to_string()))?;
-    let raw_header: serde_json::Value =
-        serde_json::from_slice(&header_bytes[8..]).map_err(|error| {
-            H3QwenNvfp4AwqError::Header(format!("failed to reparse bounded header: {error}"))
-        })?;
-    if raw_header
-        .as_object()
-        .is_some_and(|object| object.contains_key("__metadata__"))
-    {
+    if header.has_metadata {
         return Err(H3QwenNvfp4AwqError::Metadata(
             "published Qwen NVFP4-AWQ object must not add safetensors __metadata__".into(),
         ));
     }
-    let after_open = file
-        .metadata()
-        .map(|metadata| file_identity(&metadata))
-        .map_err(|error| H3QwenNvfp4AwqError::Io(error.to_string()))?;
-    let after_path = std::fs::metadata(path)
-        .map(|metadata| file_identity(&metadata))
-        .map_err(|error| H3QwenNvfp4AwqError::Io(error.to_string()))?;
-    if before != after_open || before != after_path {
-        return Err(H3QwenNvfp4AwqError::Io(
-            "artifact changed during bounded inspection".into(),
-        ));
-    }
+    checked_open_identity(&file, &before, "after marker inspection")?;
+    checked_path_identity(path, Some(&before), "after marker inspection")?;
     Ok(H3QwenNvfp4AwqInspection {
         stable_id: H3_QWEN_NVFP4_AWQ_STABLE_ID.into(),
         expected_artifact_sha256: H3_QWEN_NVFP4_AWQ_SHA256.into(),
@@ -781,7 +953,7 @@ pub fn inspect_h3_qwen_nvfp4_awq_header(
             .values()
             .filter(|marker| marker.format == "int8_tensorwise")
             .count(),
-        header_identity_sha256: hex_digest(Sha256::digest(&header_bytes)),
+        header_identity_sha256: hex_digest(Sha256::digest(&header.bytes)),
         policy_sha256: policy.policy_sha256().into(),
     })
 }
@@ -1025,6 +1197,47 @@ mod tests {
     fn serialized_markers_reject_unknown_execution_fields() {
         let marker = br#"{"format":"nvfp4","full_precision_matrix_mult":true,"native":true}"#;
         assert!(serde_json::from_slice::<H3QwenQuantMarker>(marker).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bounded_inspector_rejects_symlinks_before_opening_weights() {
+        use std::os::unix::fs::symlink;
+
+        let target = temp_path("symlink-target");
+        let link = temp_path("symlink");
+        std::fs::write(&target, b"not opened through the link").unwrap();
+        symlink(&target, &link).unwrap();
+        let error = inspect_h3_qwen_nvfp4_awq_header(&link).unwrap_err();
+        assert!(
+            matches!(error, H3QwenNvfp4AwqError::Io(message) if message.contains("must not be a symlink"))
+        );
+        std::fs::remove_file(link).unwrap();
+        std::fs::remove_file(target).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn fd_and_path_identity_fences_detect_replacement() {
+        let path = temp_path("identity-original");
+        let replacement = temp_path("identity-replacement");
+        std::fs::write(&path, b"original").unwrap();
+        std::fs::write(&replacement, b"replacement").unwrap();
+        let expected = checked_path_identity(&path, None, "test setup").unwrap();
+        let file = File::open(&path).unwrap();
+        checked_open_identity(&file, &expected, "test setup").unwrap();
+
+        std::fs::rename(&replacement, &path).unwrap();
+
+        assert!(matches!(
+            checked_open_identity(&file, &expected, "after replacement"),
+            Err(H3QwenNvfp4AwqError::Io(message)) if message.contains("identity changed")
+        ));
+        assert!(matches!(
+            checked_path_identity(&path, Some(&expected), "after replacement"),
+            Err(H3QwenNvfp4AwqError::Io(message)) if message.contains("identity changed")
+        ));
+        std::fs::remove_file(path).unwrap();
     }
 
     #[test]

--- a/crates/mold-candle/src/minimax_h3/qwen_quant.rs
+++ b/crates/mold-candle/src/minimax_h3/qwen_quant.rs
@@ -35,24 +35,28 @@ const LANGUAGE_LINEAR_SUFFIXES: &[&str] = &[
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub enum H3QwenTensorDType {
     Bf16,
+    F8E4M3,
     F32,
     I8,
+    U8,
 }
 
 impl H3QwenTensorDType {
-    const fn byte_width(self) -> u64 {
+    pub(super) const fn byte_width(self) -> u64 {
         match self {
-            Self::I8 => 1,
+            Self::F8E4M3 | Self::I8 | Self::U8 => 1,
             Self::Bf16 => 2,
             Self::F32 => 4,
         }
     }
 
-    const fn stable_id(self) -> &'static str {
+    pub(super) const fn stable_id(self) -> &'static str {
         match self {
             Self::Bf16 => "bf16",
+            Self::F8E4M3 => "f8-e4m3",
             Self::F32 => "f32",
             Self::I8 => "i8",
+            Self::U8 => "u8",
         }
     }
 }

--- a/docs/qualification/minimax-h3-comfy-quantization.md
+++ b/docs/qualification/minimax-h3-comfy-quantization.md
@@ -1,13 +1,18 @@
 # MiniMax H3 Comfy quantization source audit
 
-Status: source-only portable primitives; runtime activation remains blocked.
+Status: authorized bounded artifact contract plus portable primitives; runtime
+activation remains blocked.
 
-This audit did not access MiniMax H3 binary model payloads, safetensors headers,
-or generated outputs. It used only public implementation source and textual
-repository metadata. The model's license gate in `mold-core` remains
-authoritative. Frozen H3 factory authority and FL2VA/Ref2VA dispatch seams now
-exist, but `runtime_available` remains false and the Comfy checkpoint candidate
-continues to reject every production runtime backend.
+The source-derived quantization math remains pinned to public implementation
+source. After the project received authorization for private qualification,
+Mold additionally performed bounded inspection of the exact selected Qwen
+safetensors header and its small per-layer `comfy_quant` marker tensors. The
+complete artifact digest was verified independently against the pinned
+manifest identity; no weight payload or generated output is committed. The
+model's public-product license gate in `mold-core` remains authoritative.
+Frozen H3 factory authority and FL2VA/Ref2VA dispatch seams exist, but
+`runtime_available` remains false and the Comfy checkpoint candidate continues
+to reject every production runtime backend.
 
 ## Pinned implementation sources
 
@@ -125,26 +130,46 @@ Comfy's NVFP4 storage consists of:
   rank-0 `[]` or one-element `[1]`; and
 - an optional ModelOpt AWQ-style `pre_quant_scale` applied to the input.
 
-The H3 Comfy conditioner contract is the AWQ variant, so Mold requires an
-explicit input-scale vector with exactly `in_features` entries. It applies that
-vector before the linear operation. Comfy constructs text encoders with
-`full_precision_mm=true`, so their NVFP4 representation is a storage and
-streaming optimization: weights dequantize before matrix multiplication even
-on hardware that offers native NVFP4 compute. Mold follows that ordering and
-does not substitute an unqualified Blackwell kernel.
+The selected H3 Comfy conditioner is a mixed layout, not the older INT8 ConvRot
+conditioner. Its token embedding is INT8 tensorwise with a per-row F32 scale.
+Exactly 350 language projections are NVFP4, and every one carries an explicit
+`comfy_quant` marker with `full_precision_matrix_mult=true`. ModelOpt AWQ
+smoothing is selective: the attention output and MLP down projections in each
+of layers 0-49 carry a BF16 `pre_quant_scale` vector, for 100 vectors total;
+absence on the other 250 projections is the source-defined identity transform.
+When present, Mold applies that vector before the linear operation. The NVFP4
+representation is therefore a storage and streaming optimization: weights
+dequantize before matrix multiplication even on hardware that offers native
+NVFP4 compute. Mold follows that ordering and does not substitute an
+unqualified Blackwell kernel.
 
 For packed byte `b`, logical even column `2i` uses `b >> 4` and odd column
 `2i+1` uses `b & 0x0f`. Reconstruction is
 
 ```text
 W[row, col] = E2M1[nibble] * E4M3[block] * tensor_scale
-y = (x * pre_quant_scale) * W^T + bias
+y = (x * optional_pre_quant_scale) * W^T + bias
 ```
+
+The pinned object is 15,687,142,551 bytes: an 8-byte safetensors length prefix,
+an exact 231,400-byte JSON header, and 15,686,911,143 payload bytes across 2,054
+tensors. That payload contains 12,189,696,000 packed NVFP4 weight bytes,
+1,523,712,000 FP8 block-scale bytes, 1,400 F32 tensor-scale bytes, 3,379,200
+selective AWQ bytes, a
+777,912,320-byte INT8 embedding with 607,744 scale bytes, 1,191,583,200 dense
+BF16 bytes, and 19,279 bounded quant-marker bytes. The validator rejects any
+extra/missing tensor, dtype or shape drift, missing mandatory sidecar, AWQ
+vector on the wrong projection, marker extension, or native-MM substitution.
 
 Mold unswizzles the block scales once, retains compressed U8 weights on the
 host, and stages only a bounded number of output rows for each F32 Candle
-matrix multiplication. The same portable path is typed for CPU, Metal, and
-CUDA execution devices; native quantized kernels remain out of scope.
+matrix multiplication. The INT8 embedding similarly widens only requested
+token rows through signed two's-complement interpretation. The same portable
+path is typed for CPU, Metal, and CUDA execution devices; native quantized
+kernels remain out of scope. Bounded header validation reports the expected
+full-object SHA-256 but deliberately does not pretend to authenticate the
+tensor payload; private qualification must verify that digest separately
+before any mmap authority is constructed.
 
 ## Synthetic qualification and remaining gates
 
@@ -159,7 +184,10 @@ The committed tests use tiny deterministic synthetic tensors only. They prove:
   execution, FP32 compute boundaries, and public-size-derived byte accounting;
 - high-nibble-first E2M1 decoding, tensor/block scale application, and
   multi-tile scale unswizzling against a fixed comfy-kitchen layout oracle;
-- AWQ input scaling occurs before the dequantized linear operation; and
+- selective AWQ input scaling occurs before the dequantized linear operation,
+  while an absent scale is an explicit identity transform;
+- the exact 2,054-tensor published Qwen schema and bounded marker values match
+  the pinned 15.7 GB object, including the separately scaled INT8 embedding;
 - source-dtype-aware encoded byte accounting, CPU/Metal forward parity, and
   fail-closed invalid dtypes, shapes, scales, and zero-sized staging plans.
 


### PR DESCRIPTION
## Summary

- replace filename-level assumptions with a strict, bounded contract for the selected MiniMax H3 Qwen3-VL NVFP4-AWQ artifact
- validate all 2,054 tensor dtypes/shapes/ranges plus the 351 bounded `comfy_quant` marker payloads, with exact published size, digest, and frozen policy identities
- model the actual mixed layout: one tensorwise-INT8 embedding, 350 full-precision-MM NVFP4 projections, 100 selective AWQ input scales, and dense BF16 protected tensors
- expose canonical-to-source loading plans and portable signed-INT8 embedding / optional-AWQ execution primitives without activating H3 in the catalog, factory, server, or release artifacts
- update qualification documentation with observed byte accounting and the separate full-content authentication boundary

Advances #815 and #832. Public product activation remains blocked by #831.

## Verification

- `cargo fmt --all -- --check`
- `nix develop --command env CARGO_TARGET_DIR=/tmp/mold-h3-qwen-target cargo clippy -p mold-ai-candle --all-targets --no-default-features -- -D warnings`
- `nix develop --command env CARGO_TARGET_DIR=/tmp/mold-h3-qwen-target cargo test -p mold-ai-candle --no-default-features` (149 passed, 1 private-artifact test ignored by default)
- authorized private Plato run of `authorized_published_artifact_matches_bounded_contract` against the independently SHA-256-verified pinned artifact (passed)
