### PR TITLE
refactor(desktop): share expansion pull presentation

### DIFF
--- a/desktop/src/components/generate/ExpansionPullStatus.vue
+++ b/desktop/src/components/generate/ExpansionPullStatus.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
 import { computed } from "vue";
-import type { ExpansionPullView } from "../../lib/expansionPull";
-import { formatBytes, formatEta, percent } from "../../lib/format";
-import { modelDisplayNameForId, type DisplayableModel } from "../../lib/models";
+import { expansionPullPresentation, type ExpansionPullView } from "../../lib/expansionPull";
+import type { DisplayableModel } from "../../lib/models";
 
 const props = defineProps<{
   model: string;
@@ -12,20 +11,21 @@ const props = defineProps<{
   etaSeconds: number | null;
   models?: DisplayableModel[] | undefined;
 }>();
-const modelLabel = computed(() => modelDisplayNameForId(props.model, props.models ?? []));
 
 defineEmits<{
   (e: "pull"): void;
   (e: "retry-expansion"): void;
 }>();
 
-const pullPercent = computed(() =>
-  props.status.job
-    ? Math.round(percent(props.status.job.bytes_done, props.status.job.bytes_total))
-    : 0,
-);
-const busy = computed(() =>
-  ["connecting", "starting", "queued", "pulling"].includes(props.status.kind),
+const presentation = computed(() =>
+  expansionPullPresentation(
+    props.status,
+    props.model,
+    props.hostLabel,
+    props.error,
+    props.etaSeconds,
+    props.models ?? [],
+  ),
 );
 const toneClass = computed(() => {
   if (props.status.kind === "ready")
@@ -34,33 +34,13 @@ const toneClass = computed(() => {
     return "border-stop/45 bg-stop/10";
   return "border-edge bg-bench";
 });
-const stateLabel = computed(() => {
-  switch (props.status.kind) {
-    case "missing":
-      return props.error;
-    case "connecting":
-      return `Connecting to ${props.hostLabel} to pull ${modelLabel.value}…`;
-    case "starting":
-      return `Starting ${modelLabel.value} on ${props.hostLabel}…`;
-    case "queued":
-      return `${modelLabel.value} queued on ${props.hostLabel}`;
-    case "pulling":
-      return `Pulling ${modelLabel.value} on ${props.hostLabel}`;
-    case "ready":
-      return `${modelLabel.value} ready on ${props.hostLabel}`;
-    case "failed":
-      return `${modelLabel.value} pull failed on ${props.hostLabel}`;
-    case "cancelled":
-      return `${props.model} pull cancelled on ${props.hostLabel}`;
-  }
-});
 </script>
 
 <template>
   <section
     class="mt-3 rounded-control border px-2.5 py-2"
     :class="toneClass"
-    :aria-busy="busy || undefined"
+    :aria-busy="presentation.busy || undefined"
     role="status"
     aria-live="polite"
     aria-atomic="true"
@@ -68,7 +48,7 @@ const stateLabel = computed(() => {
   >
     <div class="flex min-w-0 flex-wrap items-center justify-between gap-2">
       <div class="min-w-0">
-        <p class="text-caption font-semibold text-ink">{{ stateLabel }}</p>
+        <p class="text-caption font-semibold text-ink">{{ presentation.label }}</p>
         <p
           v-if="status.kind === 'failed' && status.message"
           class="mt-0.5 truncate text-caption text-stop"
@@ -93,7 +73,7 @@ const stateLabel = computed(() => {
         v-else-if="status.kind === 'ready'"
         type="button"
         data-test="retry-expansion"
-        :aria-label="`Retry expansion with ${modelLabel} on ${hostLabel}`"
+        :aria-label="`Retry expansion with ${presentation.modelLabel} on ${hostLabel}`"
         class="min-h-8 rounded-control bg-safelight px-2.5 text-caption font-semibold text-on-accent transition-[filter] duration-100 hover:brightness-105"
         @click="$emit('retry-expansion')"
       >
@@ -106,7 +86,7 @@ const stateLabel = computed(() => {
         class="border-stop/60 min-h-8 rounded-control border px-2.5 text-caption font-semibold text-ink transition-colors duration-100 hover:border-stop"
         @click="$emit('pull')"
       >
-        Retry {{ modelLabel }} pull on {{ hostLabel }}
+        Retry {{ presentation.modelLabel }} pull on {{ hostLabel }}
       </button>
     </div>
 
@@ -116,24 +96,20 @@ const stateLabel = computed(() => {
         role="progressbar"
         aria-valuemin="0"
         aria-valuemax="100"
-        :aria-valuenow="pullPercent"
-        :aria-label="`Pulling ${modelLabel} on ${hostLabel}`"
+        :aria-valuenow="presentation.percent"
+        :aria-label="`Pulling ${presentation.modelLabel} on ${hostLabel}`"
       >
         <div
           class="h-full bg-safelight transition-[width] duration-300 motion-reduce:transition-none"
-          :style="{ width: `${pullPercent}%` }"
+          :style="{ width: `${presentation.percent}%` }"
         />
       </div>
       <div
         class="mt-1 flex min-w-0 flex-wrap items-center gap-x-3 gap-y-0.5 text-caption text-ink-3"
       >
-        <span class="data-mono text-safelight">{{ pullPercent }}%</span>
-        <span class="data-mono">
-          {{ formatBytes(status.job.bytes_done) }} / {{ formatBytes(status.job.bytes_total) }}
-        </span>
-        <span v-if="status.job.files_total > 0">
-          {{ status.job.files_done }}/{{ status.job.files_total }} files
-        </span>
+        <span class="data-mono text-safelight">{{ presentation.percent }}%</span>
+        <span class="data-mono">{{ presentation.bytes }}</span>
+        <span v-if="presentation.files">{{ presentation.files }}</span>
         <span
           v-if="status.job.current_file"
           class="data-mono min-w-0 truncate"
@@ -141,7 +117,7 @@ const stateLabel = computed(() => {
         >
           {{ status.job.current_file }}
         </span>
-        <span>ETA {{ formatEta(etaSeconds) }}</span>
+        <span>ETA {{ presentation.eta }}</span>
       </div>
     </div>
   </section>

--- a/desktop/src/lib/expansionPull.ts
+++ b/desktop/src/lib/expansionPull.ts
@@ -1,4 +1,6 @@
 import type { DownloadJob } from "./api/types";
+import { formatBytes, formatEta, percent } from "./format";
+import { modelDisplayNameForId, type DisplayableModel } from "./models";
 
 export type ExpansionPullPhase = "missing" | "connecting" | "starting";
 export type ExpansionPullKind =
@@ -64,6 +66,42 @@ export function resolveExpansionPullStatus(input: ExpansionPullResolutionInput):
 
   if (!job) return { kind: input.phase, job: null };
   return viewForJob(job);
+}
+
+/** Shared desktop/iPhone copy and progress semantics for the pull lifecycle. */
+export function expansionPullPresentation(
+  status: ExpansionPullView,
+  model: string,
+  hostLabel: string,
+  missingError: string,
+  etaSeconds: number | null,
+  models: DisplayableModel[] = [],
+) {
+  const modelLabel = modelDisplayNameForId(model, models);
+  const labels: Record<ExpansionPullKind, string> = {
+    missing: missingError,
+    connecting: `Connecting to ${hostLabel} to pull ${modelLabel}…`,
+    starting: `Starting ${modelLabel} on ${hostLabel}…`,
+    queued: `${modelLabel} queued on ${hostLabel}`,
+    pulling: `Pulling ${modelLabel} on ${hostLabel}`,
+    ready: `${modelLabel} ready on ${hostLabel}`,
+    failed: `${modelLabel} pull failed on ${hostLabel}`,
+    cancelled: `${model} pull cancelled on ${hostLabel}`,
+  };
+  return {
+    label: labels[status.kind],
+    modelLabel,
+    busy: ["connecting", "starting", "queued", "pulling"].includes(status.kind),
+    percent: status.job ? Math.round(percent(status.job.bytes_done, status.job.bytes_total)) : 0,
+    bytes: status.job
+      ? `${formatBytes(status.job.bytes_done)} / ${formatBytes(status.job.bytes_total)}`
+      : "",
+    files:
+      status.job && status.job.files_total > 0
+        ? `${status.job.files_done}/${status.job.files_total} files`
+        : null,
+    eta: formatEta(etaSeconds),
+  };
 }
 
 function viewForJob(job: DownloadJob): ExpansionPullView {

--- a/desktop/src/mobile/MobileExpansionPullStatus.vue
+++ b/desktop/src/mobile/MobileExpansionPullStatus.vue
@@ -1,9 +1,7 @@
 <script setup lang="ts">
 import { computed } from "vue";
-import type { ExpansionPullView } from "../lib/expansionPull";
+import { expansionPullPresentation, type ExpansionPullView } from "../lib/expansionPull";
 import type { ModelEntry } from "../lib/api/types";
-import { formatBytes, formatEta, percent } from "../lib/format";
-import { modelDisplayNameForId } from "../lib/models";
 
 const props = defineProps<{
   model: string;
@@ -13,37 +11,18 @@ const props = defineProps<{
   etaSeconds: number | null;
   models?: ModelEntry[] | undefined;
 }>();
-const modelLabel = computed(() => modelDisplayNameForId(props.model, props.models ?? []));
 defineEmits<{ pull: []; "retry-expansion": [] }>();
 
-const amount = computed(() =>
-  props.status.job
-    ? Math.round(percent(props.status.job.bytes_done, props.status.job.bytes_total))
-    : 0,
+const presentation = computed(() =>
+  expansionPullPresentation(
+    props.status,
+    props.model,
+    props.hostLabel,
+    props.error,
+    props.etaSeconds,
+    props.models ?? [],
+  ),
 );
-const busy = computed(() =>
-  ["connecting", "starting", "queued", "pulling"].includes(props.status.kind),
-);
-const label = computed(() => {
-  switch (props.status.kind) {
-    case "missing":
-      return props.error;
-    case "connecting":
-      return `Connecting to ${props.hostLabel} to pull ${modelLabel.value}…`;
-    case "starting":
-      return `Starting ${modelLabel.value} on ${props.hostLabel}…`;
-    case "queued":
-      return `${modelLabel.value} queued on ${props.hostLabel}`;
-    case "pulling":
-      return `Pulling ${modelLabel.value} on ${props.hostLabel}`;
-    case "ready":
-      return `${modelLabel.value} ready on ${props.hostLabel}`;
-    case "failed":
-      return `${modelLabel.value} pull failed on ${props.hostLabel}`;
-    case "cancelled":
-      return `${props.model} pull cancelled on ${props.hostLabel}`;
-  }
-});
 </script>
 
 <template>
@@ -52,9 +31,9 @@ const label = computed(() => {
     role="status"
     aria-live="polite"
     aria-atomic="true"
-    :aria-busy="busy || undefined"
+    :aria-busy="presentation.busy || undefined"
   >
-    <strong>{{ label }}</strong>
+    <strong>{{ presentation.label }}</strong>
     <span v-if="error && status.kind !== 'missing'" class="error-text" role="alert">{{
       error
     }}</span>
@@ -66,22 +45,17 @@ const label = computed(() => {
         role="progressbar"
         aria-valuemin="0"
         aria-valuemax="100"
-        :aria-valuenow="amount"
-        :aria-label="label"
+        :aria-valuenow="presentation.percent"
+        :aria-label="presentation.label"
       >
-        <span :style="{ width: `${amount}%` }" />
+        <span :style="{ width: `${presentation.percent}%` }" />
       </div>
       <p>
-        <span>{{ amount }}%</span>
-        <span
-          >{{ formatBytes(status.job.bytes_done) }} /
-          {{ formatBytes(status.job.bytes_total) }}</span
-        >
-        <span v-if="status.job.files_total"
-          >{{ status.job.files_done }}/{{ status.job.files_total }} files</span
-        >
+        <span>{{ presentation.percent }}%</span>
+        <span>{{ presentation.bytes }}</span>
+        <span v-if="presentation.files">{{ presentation.files }}</span>
         <span v-if="status.job.current_file">{{ status.job.current_file }}</span>
-        <span>ETA {{ formatEta(etaSeconds) }}</span>
+        <span>ETA {{ presentation.eta }}</span>
       </p>
     </div>
     <button
@@ -109,7 +83,7 @@ const label = computed(() => {
       data-test="mobile-retry-expansion-pull"
       @click="$emit('pull')"
     >
-      Retry {{ modelLabel }} pull on {{ hostLabel }}
+      Retry {{ presentation.modelLabel }} pull on {{ hostLabel }}
     </button>
   </section>
 </template>


### PR DESCRIPTION
## Summary

- centralize desktop and iPhone expansion-model pull presentation in `expansionPullPresentation`
- keep each surface's markup, styling, recovery controls, and host/model identity behavior unchanged
- remove duplicate lifecycle labels, busy-state policy, progress calculation, byte/file totals, ETA formatting, and model display-name resolution

## Production code reduction

Reproducible command (hand-written non-test TypeScript/Vue only; generated, vendor, lock, and test files excluded):

```sh
git diff --numstat origin/main...HEAD -- '*.ts' '*.vue' ':!**/*.test.ts' ':!**/*.spec.ts'
```

```text
22  46  desktop/src/components/generate/ExpansionPullStatus.vue
38   0  desktop/src/lib/expansionPull.ts
20  46  desktop/src/mobile/MobileExpansionPullStatus.vue
```

Total: 80 additions, 92 deletions, net **-12 production lines**. The three changed production files fell from 391 to 379 lines. Tests are unchanged (`0/0`) and reported separately from production.

## Behavior preservation

The existing focused characterization covered every pull lifecycle state (`missing`, `connecting`, `starting`, `queued`, `pulling`, `ready`, `failed`, and `cancelled`) plus progress percentage, byte/file detail, ETA, accessible status semantics, and recovery actions. It passed before the refactor and after it: 3 files, 32 tests.

## Validation

```sh
bun install --frozen-lockfile
bun run --cwd desktop test --run src/lib/expansionPull.test.ts src/components/generate/ExpansionPullStatus.test.ts src/mobile/MobileExpansionPullStatus.test.ts
bun run check:architecture
bun run check:dead-code
bun run --cwd desktop fmt:check
bun run --cwd desktop test
bun run --cwd desktop build
bun run build:mobile
scripts/tests/ios-release-assets.sh
scripts/tests/ios-testflight-distribution.sh
scripts/tests/ios-sim-pick.sh
git diff --check
```

Results: all passed. The complete desktop/mobile suite passed 3,108 tests across 294 files. Desktop and mobile production builds typechecked and completed. The iOS asset, TestFlight distribution, and simulator-picker contracts passed.

Rust, web, docs, updater, and native iOS Rust gates are not applicable to these frontend-only paths and are expected to be path-skipped in CI.
