### PR TITLE
feat(h3): stream Comfy INT8 transformer blocks

### DIFF
--- a/crates/mold-candle/examples/h3_comfy_int8_block_qualification.rs
+++ b/crates/mold-candle/examples/h3_comfy_int8_block_qualification.rs
@@ -1,0 +1,103 @@
+//! Private, release-unregistered qualification probe for one authenticated
+//! Comfy MiniMax H3 INT8 ConvRot block.
+
+#[cfg(feature = "cuda")]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use candle::{DType, Device, Tensor};
+    use mold_candle::minimax_h3::{
+        open_h3_comfy_published_int8_checkpoint, H3ComfyNeverCancel, H3ForwardInput,
+        H3PackedLayout, H3TransformerTask,
+    };
+
+    let mut arguments = std::env::args().skip(1);
+    let path = arguments.next().ok_or(
+        "usage: h3_comfy_int8_block_qualification <checkpoint> <fl2va|ref2va> [gpu] [block]",
+    )?;
+    let task = arguments.next().ok_or("missing task")?;
+    let gpu = arguments
+        .next()
+        .as_deref()
+        .unwrap_or("0")
+        .parse::<usize>()?;
+    let block_index = arguments
+        .next()
+        .as_deref()
+        .unwrap_or("0")
+        .parse::<usize>()?;
+    if block_index != 0 {
+        return Err("the isolated execution probe must start with exact block 0".into());
+    }
+    if arguments.next().is_some() {
+        return Err("unexpected extra qualification arguments".into());
+    }
+    let (task, artifact) = match task.as_str() {
+        "fl2va" => (
+            H3TransformerTask::T2VaFl2Va,
+            mold_candle::minimax_h3::H3ComfyPublishedArtifact::Fl2VaPrunedInt8ConvRot,
+        ),
+        "ref2va" => (
+            H3TransformerTask::Ref2Va,
+            mold_candle::minimax_h3::H3ComfyPublishedArtifact::Ref2VaPrunedInt8ConvRot,
+        ),
+        _ => return Err("task must be fl2va or ref2va".into()),
+    };
+    let opened = open_h3_comfy_published_int8_checkpoint(
+        std::path::Path::new(&path),
+        task,
+        artifact,
+        &H3ComfyNeverCancel,
+    )?;
+    let checkpoint_identity = opened.checkpoint_identity_sha256().to_owned();
+    let device = Device::new_cuda(gpu)?;
+    let (transformer, mut loader) = opened.load(&device)?;
+    let memory = loader.block_memory(block_index)?;
+    let config = transformer.config();
+    let layout = H3PackedLayout::new(
+        vec![[0.0, 0.0, 0.0], [0.0, -1.0, 0.5], [0.0, 0.0, -1.0]],
+        vec![0, 0, 0],
+        vec![1, 0, 2],
+        vec![1],
+        vec![2],
+        vec![0],
+    )?
+    .freeze(&device)?;
+    let video = Tensor::zeros((1, 1, config.video_patch_dim()), DType::F32, &device)?;
+    let audio = Tensor::zeros((1, 1, config.audio_latent_channels), DType::F32, &device)?;
+    let text = Tensor::zeros((1, 1, config.text_dim), DType::F32, &device)?;
+    let timesteps = Tensor::new(&[0.5f32], &device)?;
+    let mut step = transformer.begin_step(
+        H3ForwardInput {
+            video_rows: &video,
+            audio_rows: &audio,
+            text_states: &text,
+            timesteps: &timesteps,
+        },
+        &layout,
+    )?;
+    let block = loader.load_block(block_index)?;
+    step.forward_block(block_index, &block)?;
+    drop(block);
+    let report = serde_json::json!({
+        "schema": "mold.minimax-h3.comfy-int8-block-qualification.v1",
+        "task": format!("{task:?}"),
+        "block_index": block_index,
+        "checkpoint_identity_sha256": checkpoint_identity,
+        "content_sha256": loader.content_sha256(),
+        "runtime_bytes_read": loader.bytes_read(),
+        "encoded_host_bytes": memory.encoded_host_bytes,
+        "max_host_read_staging_bytes": memory.max_host_read_staging_bytes,
+        "max_device_weight_staging_bytes": memory.max_device_weight_staging_bytes,
+        "protected_device_bytes": memory.protected_device_bytes,
+        "live_blocks_after_drop": loader.live_block_count(),
+        "executed_block_count": 1,
+        "factory_activated": false,
+    });
+    println!("{}", serde_json::to_string_pretty(&report)?);
+    Ok(())
+}
+
+#[cfg(not(feature = "cuda"))]
+fn main() {
+    eprintln!("h3_comfy_int8_block_qualification requires --features cuda");
+    std::process::exit(2);
+}

--- a/crates/mold-candle/examples/h3_comfy_int8_block_qualification.rs
+++ b/crates/mold-candle/examples/h3_comfy_int8_block_qualification.rs
@@ -48,6 +48,25 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &H3ComfyNeverCancel,
     )?;
     let checkpoint_identity = opened.checkpoint_identity_sha256().to_owned();
+    let published_header_identity = opened.candidate().header_identity_sha256.clone();
+    let published_tensor_count = opened.candidate().tensor_count;
+    let quantization_policy_sha256 = opened
+        .candidate()
+        .strategy
+        .quantization_policy
+        .policy_sha256
+        .clone();
+    let validated_quantization_sidecars = opened
+        .candidate()
+        .strategy
+        .quantization_policy
+        .quantized_layers
+        .len();
+    if validated_quantization_sidecars != 200 {
+        return Err(
+            "published H3 INT8 qualification requires exactly 200 validated sidecars".into(),
+        );
+    }
     let device = Device::new_cuda(gpu)?;
     let (transformer, mut loader) = opened.load(&device)?;
     let memory = loader.block_memory(block_index)?;
@@ -77,17 +96,29 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let block = loader.load_block(block_index)?;
     step.forward_block(block_index, &block)?;
     drop(block);
+    let f16_curve_projection_upcast_loads = loader.f16_curve_projection_upcast_loads();
+    if f16_curve_projection_upcast_loads != 4 {
+        return Err(format!(
+            "isolated block-0 qualification expected four F16-to-F32 curve projection loads, got {f16_curve_projection_upcast_loads}"
+        )
+        .into());
+    }
     let report = serde_json::json!({
         "schema": "mold.minimax-h3.comfy-int8-block-qualification.v1",
         "task": format!("{task:?}"),
         "block_index": block_index,
         "checkpoint_identity_sha256": checkpoint_identity,
+        "published_header_identity_sha256": published_header_identity,
+        "published_tensor_count": published_tensor_count,
+        "validated_quantization_sidecars": validated_quantization_sidecars,
+        "quantization_policy_sha256": quantization_policy_sha256,
         "content_sha256": loader.content_sha256(),
         "runtime_bytes_read": loader.bytes_read(),
         "encoded_host_bytes": memory.encoded_host_bytes,
         "max_host_read_staging_bytes": memory.max_host_read_staging_bytes,
         "max_device_weight_staging_bytes": memory.max_device_weight_staging_bytes,
         "protected_device_bytes": memory.protected_device_bytes,
+        "f16_curve_projection_upcast_loads": f16_curve_projection_upcast_loads,
         "live_blocks_after_drop": loader.live_block_count(),
         "executed_block_count": 1,
         "factory_activated": false,

--- a/crates/mold-candle/src/minimax_h3/comfy_dit.rs
+++ b/crates/mold-candle/src/minimax_h3/comfy_dit.rs
@@ -67,6 +67,9 @@ const CONVROT_GROUP_SIZE: usize = 256;
 const PUBLISHED_INT8_CURVE_GRID: usize = 1_025;
 const PUBLISHED_INT8_CURVE_BASIS: usize = 8;
 const PUBLISHED_INT8_COMFY_QUANT_BYTES: usize = 72;
+const PUBLISHED_INT8_COMFY_QUANT_COUNT: usize = 200;
+const PUBLISHED_INT8_COMFY_QUANT_PAYLOAD: &[u8; PUBLISHED_INT8_COMFY_QUANT_BYTES] =
+    br#"{"format": "int8_tensorwise", "convrot": true, "convrot_groupsize": 256}"#;
 const FILE_READ_CHUNK_BYTES: usize = 8 * 1024 * 1024;
 const QUANTIZED_BLOCK_WEIGHT_SUFFIXES: &[&str] = &[
     "attn.qkv_proj.weight",
@@ -529,7 +532,7 @@ pub fn open_h3_comfy_published_int8_checkpoint(
         path,
         H3TransformerConfig::default(),
         requested_task,
-        artifact,
+        Some(artifact),
         Some((artifact.file_bytes(), artifact.content_sha256())),
         cancellation,
     )
@@ -539,18 +542,26 @@ fn open_h3_comfy_int8_checkpoint(
     path: &Path,
     config: H3TransformerConfig,
     requested_task: H3TransformerTask,
-    artifact: H3ComfyPublishedArtifact,
+    published_artifact: Option<H3ComfyPublishedArtifact>,
     expected_content: Option<(u64, &str)>,
     cancellation: &dyn H3ComfyInt8Cancellation,
 ) -> InspectionResult<H3ComfyOpenedInt8Checkpoint> {
-    if requested_task != artifact.task() {
-        return Err(failure(
-            H3ComfyCheckpointErrorCode::TaskAuthorityMismatch,
-            format!(
-                "H3 requested task {requested_task:?} does not match source authority {:?}",
-                artifact.task()
-            ),
-        ));
+    if let Some(artifact) = published_artifact {
+        if artifact.format() != H3ComfyPrunedFormat::Int8ConvRot {
+            return Err(failure(
+                H3ComfyCheckpointErrorCode::FormatMismatch,
+                "H3 opened INT8 runtime requires an INT8 ConvRot published authority",
+            ));
+        }
+        if requested_task != artifact.task() {
+            return Err(failure(
+                H3ComfyCheckpointErrorCode::TaskAuthorityMismatch,
+                format!(
+                    "H3 requested task {requested_task:?} does not match source authority {:?}",
+                    artifact.task()
+                ),
+            ));
+        }
     }
     cancellation_boundary_inspection(cancellation)?;
     let symlink_metadata = std::fs::symlink_metadata(path).map_err(|error| {
@@ -599,8 +610,16 @@ fn open_h3_comfy_int8_checkpoint(
         config.clone(),
         requested_task,
         H3ComfyPrunedFormat::Int8ConvRot,
-        Some(artifact),
+        published_artifact,
     )?;
+    if published_artifact.is_some() {
+        validate_published_int8_quantization_sidecars(
+            &mut file,
+            &parsed,
+            &candidate.strategy.quantization_policy,
+            cancellation,
+        )?;
+    }
     let content_sha256 = hash_open_file(&mut file, parsed.file_len, cancellation)?;
     if let Some((_, expected_sha256)) = expected_content {
         if content_sha256 != expected_sha256 {
@@ -624,6 +643,9 @@ fn open_h3_comfy_int8_checkpoint(
         ));
     }
     let checkpoint_identity_sha256 = comfy_checkpoint_identity(&candidate, &content_sha256);
+    let f16_curve_projection_tensors = published_artifact
+        .map(|_| published_int8_curve_projection_tensors(&config))
+        .unwrap_or_default();
     Ok(H3ComfyOpenedInt8Checkpoint {
         candidate,
         config,
@@ -633,6 +655,8 @@ fn open_h3_comfy_int8_checkpoint(
             identity,
             content_sha256,
             runtime_bytes_read: AtomicU64::new(0),
+            f16_curve_projection_tensors,
+            f16_curve_projection_upcast_loads: AtomicU64::new(0),
         }),
         checkpoint_identity_sha256,
     })
@@ -704,6 +728,8 @@ struct H3ComfyOpenedSource {
     identity: H3OpenedFileIdentity,
     content_sha256: String,
     runtime_bytes_read: AtomicU64,
+    f16_curve_projection_tensors: BTreeSet<String>,
+    f16_curve_projection_upcast_loads: AtomicU64,
 }
 
 impl fmt::Debug for H3ComfyOpenedSource {
@@ -935,6 +961,75 @@ fn cancellation_boundary_inspection(
     Ok(())
 }
 
+fn validate_published_int8_quantization_sidecars(
+    file: &mut File,
+    parsed: &ParsedHeader,
+    policy: &H3ComfyQuantizationPolicy,
+    cancellation: &dyn H3ComfyInt8Cancellation,
+) -> InspectionResult<()> {
+    if policy.quantized_layers.len() != PUBLISHED_INT8_COMFY_QUANT_COUNT {
+        return Err(failure(
+            H3ComfyCheckpointErrorCode::InvalidMetadata,
+            format!(
+                "published H3 INT8 authority requires exactly {PUBLISHED_INT8_COMFY_QUANT_COUNT} quantized layers"
+            ),
+        ));
+    }
+    for layer in &policy.quantized_layers {
+        cancellation_boundary_inspection(cancellation)?;
+        let name = format!("{layer}.comfy_quant");
+        let tensor = parsed.tensors.get(&name).ok_or_else(|| {
+            failure(
+                H3ComfyCheckpointErrorCode::InvalidMetadata,
+                format!("published H3 INT8 quantization sidecar {name:?} is missing"),
+            )
+        })?;
+        if tensor.dtype != "U8"
+            || tensor.shape != [PUBLISHED_INT8_COMFY_QUANT_BYTES]
+            || tensor.data_offsets[1] - tensor.data_offsets[0]
+                != PUBLISHED_INT8_COMFY_QUANT_BYTES as u64
+        {
+            return Err(failure(
+                H3ComfyCheckpointErrorCode::InvalidMetadata,
+                format!(
+                    "published H3 INT8 quantization sidecar {name:?} does not have the authenticated U8[72] storage"
+                ),
+            ));
+        }
+        let data_start = 8u64
+            .checked_add(parsed.header_len)
+            .and_then(|value| value.checked_add(tensor.data_offsets[0]))
+            .ok_or_else(|| {
+                failure(
+                    H3ComfyCheckpointErrorCode::InvalidHeader,
+                    format!("published H3 INT8 quantization sidecar {name:?} offset overflows"),
+                )
+            })?;
+        file.seek(SeekFrom::Start(data_start)).map_err(|error| {
+            failure(
+                H3ComfyCheckpointErrorCode::Io,
+                format!("failed to seek H3 Comfy quantization sidecar {name:?}: {error}"),
+            )
+        })?;
+        let mut payload = [0u8; PUBLISHED_INT8_COMFY_QUANT_BYTES];
+        file.read_exact(&mut payload).map_err(|error| {
+            failure(
+                H3ComfyCheckpointErrorCode::Io,
+                format!("failed to read H3 Comfy quantization sidecar {name:?}: {error}"),
+            )
+        })?;
+        if payload != *PUBLISHED_INT8_COMFY_QUANT_PAYLOAD {
+            return Err(failure(
+                H3ComfyCheckpointErrorCode::InvalidMetadata,
+                format!(
+                    "published H3 INT8 quantization sidecar {name:?} differs from the authenticated Comfy payload"
+                ),
+            ));
+        }
+    }
+    cancellation_boundary_inspection(cancellation)
+}
+
 fn hash_open_file(
     file: &mut File,
     file_len: u64,
@@ -1058,9 +1153,19 @@ impl H3ComfyOpenedSource {
         cancellation: &dyn H3ComfyInt8Cancellation,
     ) -> candle::Result<Tensor> {
         let header = self.tensor_header(name)?;
+        let f16_curve_projection_upcast = header.dtype == "F16";
         let source_dtype = match header.dtype.as_str() {
             "BF16" => DType::BF16,
             "F32" => DType::F32,
+            "F16"
+                if requested_dtype == DType::F32
+                    && self.f16_curve_projection_tensors.contains(name) =>
+            {
+                DType::F16
+            }
+            "F16" => candle::bail!(
+                "H3 Comfy F16 storage is authorized only for published curve projections loaded as logical F32; refused tensor {name:?} as {requested_dtype:?}"
+            ),
             dtype => candle::bail!(
                 "H3 Comfy dense backend refuses encoded dtype {dtype:?} for tensor {name:?}"
             ),
@@ -1072,7 +1177,12 @@ impl H3ComfyOpenedSource {
         } else {
             tensor.to_dtype(requested_dtype)?
         };
-        tensor.to_device(device)
+        let tensor = tensor.to_device(device)?;
+        if f16_curve_projection_upcast {
+            self.f16_curve_projection_upcast_loads
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        Ok(tensor)
     }
 
     fn load_raw_int8(
@@ -1178,58 +1288,19 @@ impl H3ComfyInt8BlockLoader {
         self.source.runtime_bytes_read.load(Ordering::Relaxed)
     }
 
+    pub fn f16_curve_projection_upcast_loads(&self) -> u64 {
+        self.source
+            .f16_curve_projection_upcast_loads
+            .load(Ordering::Relaxed)
+    }
+
     pub fn block_memory(&self, index: usize) -> candle::Result<H3ComfyInt8BlockMemory> {
-        if index >= self.block_count() {
-            candle::bail!(
-                "MiniMax H3 block index {index} is outside the exact block count {}",
-                self.block_count()
-            )
-        }
-        let prefix = format!("blocks.{index}.");
-        let mut encoded_host_bytes = 0u64;
-        let mut max_host_read_staging_bytes = 0u64;
-        let mut max_device_weight_staging_bytes = 0u64;
-        let mut protected_device_bytes = 0u64;
-        for (name, tensor) in self
-            .source
-            .header
-            .tensors
-            .range(prefix.clone()..)
-            .take_while(|(name, _)| name.starts_with(&prefix))
-        {
-            let bytes = tensor.data_offsets[1] - tensor.data_offsets[0];
-            max_host_read_staging_bytes = max_host_read_staging_bytes.max(bytes);
-            let quantized = QUANTIZED_BLOCK_WEIGHT_SUFFIXES
-                .iter()
-                .any(|suffix| name == &format!("{prefix}{suffix}"));
-            let scale = name.ends_with(".weight_scale");
-            if quantized || scale {
-                encoded_host_bytes = encoded_host_bytes.checked_add(bytes).ok_or_else(|| {
-                    candle::Error::Msg("H3 Comfy block host byte count overflows".into())
-                })?;
-                if quantized {
-                    let rows = tensor.shape[0].min(H3_COMFY_PORTABLE_ROW_CHUNK);
-                    let staging = rows
-                        .checked_mul(tensor.shape[1])
-                        .and_then(|elements| elements.checked_mul(std::mem::size_of::<f32>()))
-                        .ok_or_else(|| {
-                            candle::Error::Msg("H3 Comfy device staging bytes overflow".into())
-                        })? as u64;
-                    max_device_weight_staging_bytes = max_device_weight_staging_bytes.max(staging);
-                }
-            } else {
-                protected_device_bytes =
-                    protected_device_bytes.checked_add(bytes).ok_or_else(|| {
-                        candle::Error::Msg("H3 Comfy protected block bytes overflow".into())
-                    })?;
-            }
-        }
-        Ok(H3ComfyInt8BlockMemory {
-            encoded_host_bytes,
-            max_host_read_staging_bytes,
-            max_device_weight_staging_bytes,
-            protected_device_bytes,
-        })
+        calculate_block_memory(
+            &self.source.header,
+            &self.source.f16_curve_projection_tensors,
+            index,
+            self.block_count(),
+        )
     }
 
     /// Load exactly one indexed main block. A second live block is rejected so
@@ -1273,6 +1344,84 @@ impl H3ComfyInt8BlockLoader {
             self.vb.pp(prefix),
         )
     }
+}
+
+fn calculate_block_memory(
+    header: &ParsedHeader,
+    f16_curve_projection_tensors: &BTreeSet<String>,
+    index: usize,
+    block_count: usize,
+) -> candle::Result<H3ComfyInt8BlockMemory> {
+    if index >= block_count {
+        candle::bail!(
+            "MiniMax H3 block index {index} is outside the exact block count {block_count}"
+        )
+    }
+    let prefix = format!("blocks.{index}.");
+    let mut encoded_host_bytes = 0u64;
+    let mut max_host_read_staging_bytes = 0u64;
+    let mut max_device_weight_staging_bytes = 0u64;
+    let mut protected_device_bytes = 0u64;
+    for (name, tensor) in header
+        .tensors
+        .range(prefix.clone()..)
+        .take_while(|(name, _)| name.starts_with(&prefix))
+    {
+        if name.ends_with(".comfy_quant") {
+            continue;
+        }
+        let bytes = tensor.data_offsets[1] - tensor.data_offsets[0];
+        max_host_read_staging_bytes = max_host_read_staging_bytes.max(bytes);
+        let quantized = QUANTIZED_BLOCK_WEIGHT_SUFFIXES
+            .iter()
+            .any(|suffix| name == &format!("{prefix}{suffix}"));
+        let scale = name.ends_with(".weight_scale");
+        if quantized || scale {
+            encoded_host_bytes = encoded_host_bytes.checked_add(bytes).ok_or_else(|| {
+                candle::Error::Msg("H3 Comfy block host byte count overflows".into())
+            })?;
+            if quantized {
+                let rows = tensor.shape[0].min(H3_COMFY_PORTABLE_ROW_CHUNK);
+                let staging = rows
+                    .checked_mul(tensor.shape[1])
+                    .and_then(|elements| elements.checked_mul(std::mem::size_of::<f32>()))
+                    .ok_or_else(|| {
+                        candle::Error::Msg("H3 Comfy device staging bytes overflow".into())
+                    })? as u64;
+                max_device_weight_staging_bytes = max_device_weight_staging_bytes.max(staging);
+            }
+        } else {
+            let device_bytes = if tensor.dtype == "F16"
+                && f16_curve_projection_tensors.contains(name)
+            {
+                tensor
+                    .shape
+                    .iter()
+                    .try_fold(1u64, |elements, dimension| {
+                        elements.checked_mul(*dimension as u64)
+                    })
+                    .and_then(|elements| elements.checked_mul(std::mem::size_of::<f32>() as u64))
+                    .ok_or_else(|| {
+                        candle::Error::Msg(
+                            "H3 Comfy protected F32 device byte count overflows".into(),
+                        )
+                    })?
+            } else {
+                bytes
+            };
+            protected_device_bytes = protected_device_bytes
+                .checked_add(device_bytes)
+                .ok_or_else(|| {
+                    candle::Error::Msg("H3 Comfy protected block bytes overflow".into())
+                })?;
+        }
+    }
+    Ok(H3ComfyInt8BlockMemory {
+        encoded_host_bytes,
+        max_host_read_staging_bytes,
+        max_device_weight_staging_bytes,
+        protected_device_bytes,
+    })
 }
 
 #[derive(Deserialize)]
@@ -1627,17 +1776,7 @@ fn apply_published_int8_storage_overrides(
     expected: &mut BTreeMap<String, ExpectedTensor>,
     config: &H3TransformerConfig,
 ) -> InspectionResult<()> {
-    let block_tensors = (0..config.num_layers).flat_map(|index| {
-        [
-            format!("blocks.{index}.adaln_proj.linear.weight"),
-            format!("blocks.{index}.adaln_proj.linear.bias"),
-        ]
-    });
-    let final_tensors = [
-        "final_layer.adaln_proj.linear.weight".to_owned(),
-        "final_layer.adaln_proj.linear.bias".to_owned(),
-    ];
-    for name in block_tensors.chain(final_tensors) {
+    for name in published_int8_curve_projection_tensors(config) {
         let tensor = expected.get_mut(&name).ok_or_else(|| {
             failure(
                 H3ComfyCheckpointErrorCode::ConfigMismatch,
@@ -1657,6 +1796,21 @@ fn apply_published_int8_storage_overrides(
         tensor.dtype = "F16";
     }
     Ok(())
+}
+
+fn published_int8_curve_projection_tensors(config: &H3TransformerConfig) -> BTreeSet<String> {
+    (0..config.num_layers)
+        .flat_map(|index| {
+            [
+                format!("blocks.{index}.adaln_proj.linear.weight"),
+                format!("blocks.{index}.adaln_proj.linear.bias"),
+            ]
+        })
+        .chain([
+            "final_layer.adaln_proj.linear.weight".to_owned(),
+            "final_layer.adaln_proj.linear.bias".to_owned(),
+        ])
+        .collect()
 }
 
 fn detect_format(
@@ -2883,6 +3037,206 @@ mod tests {
     }
 
     #[test]
+    fn published_int8_sidecar_payloads_are_exact_and_cancellable() {
+        let config = H3TransformerConfig::default();
+        let mode = H3AdaLnMode::Curve {
+            grid: PUBLISHED_INT8_CURVE_GRID,
+            basis_dim: PUBLISHED_INT8_CURVE_BASIS,
+        };
+        let quantization = published_int8_quantization(&config, mode).unwrap();
+        let (_, policy) = expected_schema(
+            &config,
+            mode,
+            H3ComfyPrunedFormat::Int8ConvRot,
+            Some(&quantization),
+        )
+        .unwrap();
+        assert_eq!(
+            policy.quantized_layers.len(),
+            PUBLISHED_INT8_COMFY_QUANT_COUNT
+        );
+
+        let mut tensors = BTreeMap::new();
+        let mut data = Vec::new();
+        for layer in &policy.quantized_layers {
+            let start = data.len() as u64;
+            data.extend_from_slice(PUBLISHED_INT8_COMFY_QUANT_PAYLOAD);
+            tensors.insert(
+                format!("{layer}.comfy_quant"),
+                HeaderTensor {
+                    dtype: "U8".into(),
+                    shape: vec![PUBLISHED_INT8_COMFY_QUANT_BYTES],
+                    data_offsets: [start, data.len() as u64],
+                },
+            );
+        }
+        let path = std::env::temp_dir().join(format!(
+            "mold-h3-comfy-sidecars-{}-{}.safetensors",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let mut created = File::create(&path).unwrap();
+        created.write_all(&0u64.to_le_bytes()).unwrap();
+        created.write_all(&data).unwrap();
+        drop(created);
+        let parsed = ParsedHeader {
+            metadata: BTreeMap::new(),
+            tensors,
+            header_len: 0,
+            file_len: 8 + data.len() as u64,
+            header_identity_sha256: String::new(),
+        };
+        let mut file = File::open(&path).unwrap();
+        validate_published_int8_quantization_sidecars(
+            &mut file,
+            &parsed,
+            &policy,
+            &H3ComfyNeverCancel,
+        )
+        .unwrap();
+
+        let mut mutable = std::fs::OpenOptions::new().write(true).open(&path).unwrap();
+        mutable.seek(SeekFrom::Start(8 + 17)).unwrap();
+        mutable.write_all(b"X").unwrap();
+        mutable.sync_all().unwrap();
+        drop(mutable);
+        let mut file = File::open(&path).unwrap();
+        assert_eq!(
+            validate_published_int8_quantization_sidecars(
+                &mut file,
+                &parsed,
+                &policy,
+                &H3ComfyNeverCancel,
+            )
+            .unwrap_err()
+            .code,
+            H3ComfyCheckpointErrorCode::InvalidMetadata
+        );
+
+        let cancelled = ToggleCancellation(AtomicBool::new(true));
+        let mut file = File::open(&path).unwrap();
+        assert_eq!(
+            validate_published_int8_quantization_sidecars(&mut file, &parsed, &policy, &cancelled,)
+                .unwrap_err()
+                .code,
+            H3ComfyCheckpointErrorCode::Cancelled
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn published_f16_curve_storage_upcasts_only_authorized_logical_f32() {
+        let name = "blocks.0.adaln_proj.linear.bias";
+        let header = serde_json::json!({
+            (name): {
+                "dtype": "F16",
+                "shape": [2],
+                "data_offsets": [0, 4]
+            }
+        });
+        let path = write_fixture(&header, &[0x00, 0x3c, 0x00, 0xc0], "f16-upcast");
+        let parsed = read_safetensors_header(&path).unwrap();
+        let make_source = |allowed: BTreeSet<String>| {
+            let file = File::open(&path).unwrap();
+            let identity = H3OpenedFileIdentity::from_metadata(&file.metadata().unwrap());
+            H3ComfyOpenedSource {
+                file: Mutex::new(file),
+                header: parsed.clone(),
+                identity,
+                content_sha256: "fixture".into(),
+                runtime_bytes_read: AtomicU64::new(0),
+                f16_curve_projection_tensors: allowed,
+                f16_curve_projection_upcast_loads: AtomicU64::new(0),
+            }
+        };
+        let source = make_source(BTreeSet::from([name.to_owned()]));
+        let tensor = source
+            .load_dense_tensor(name, DType::F32, &Device::Cpu, &H3ComfyNeverCancel)
+            .unwrap();
+        assert_eq!(tensor.to_vec1::<f32>().unwrap(), vec![1.0, -2.0]);
+        assert_eq!(
+            source
+                .f16_curve_projection_upcast_loads
+                .load(Ordering::Relaxed),
+            1
+        );
+        assert!(source
+            .load_dense_tensor(name, DType::BF16, &Device::Cpu, &H3ComfyNeverCancel)
+            .unwrap_err()
+            .to_string()
+            .contains("loaded as logical F32"));
+        let unauthorized = make_source(BTreeSet::new());
+        assert!(unauthorized
+            .load_dense_tensor(name, DType::F32, &Device::Cpu, &H3ComfyNeverCancel)
+            .unwrap_err()
+            .to_string()
+            .contains("authorized only for published curve projections"));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn published_block_memory_excludes_sidecars_and_counts_logical_f32() {
+        let tensors = BTreeMap::from([
+            (
+                "blocks.0.attn.qkv_proj.weight".into(),
+                HeaderTensor {
+                    dtype: "I8".into(),
+                    shape: vec![1, 4],
+                    data_offsets: [0, 4],
+                },
+            ),
+            (
+                "blocks.0.attn.qkv_proj.weight_scale".into(),
+                HeaderTensor {
+                    dtype: "F32".into(),
+                    shape: vec![1, 1],
+                    data_offsets: [4, 8],
+                },
+            ),
+            (
+                "blocks.0.attn.qkv_proj.comfy_quant".into(),
+                HeaderTensor {
+                    dtype: "U8".into(),
+                    shape: vec![PUBLISHED_INT8_COMFY_QUANT_BYTES],
+                    data_offsets: [8, 80],
+                },
+            ),
+            (
+                "blocks.0.adaln_proj.linear.weight".into(),
+                HeaderTensor {
+                    dtype: "F16".into(),
+                    shape: vec![2],
+                    data_offsets: [80, 84],
+                },
+            ),
+            (
+                "blocks.0.norm1.weight".into(),
+                HeaderTensor {
+                    dtype: "F32".into(),
+                    shape: vec![1],
+                    data_offsets: [84, 88],
+                },
+            ),
+        ]);
+        let parsed = ParsedHeader {
+            metadata: BTreeMap::new(),
+            tensors,
+            header_len: 0,
+            file_len: 96,
+            header_identity_sha256: String::new(),
+        };
+        let allowed = BTreeSet::from(["blocks.0.adaln_proj.linear.weight".to_owned()]);
+        let memory = calculate_block_memory(&parsed, &allowed, 0, 1).unwrap();
+        assert_eq!(memory.encoded_host_bytes, 8);
+        assert_eq!(memory.max_host_read_staging_bytes, 4);
+        assert_eq!(memory.max_device_weight_staging_bytes, 16);
+        assert_eq!(memory.protected_device_bytes, 12);
+    }
+
+    #[test]
     fn opened_int8_runtime_streams_exactly_one_cpu_packed_block() -> candle::Result<()> {
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<H3ComfyOpenedInt8Checkpoint>();
@@ -2894,7 +3248,7 @@ mod tests {
             &path,
             config,
             H3TransformerTask::T2VaFl2Va,
-            H3ComfyPublishedArtifact::Fl2VaPrunedInt8ConvRot,
+            None,
             None,
             &H3ComfyNeverCancel,
         )
@@ -2941,7 +3295,7 @@ mod tests {
             &path,
             config.clone(),
             H3TransformerTask::T2VaFl2Va,
-            H3ComfyPublishedArtifact::Fl2VaPrunedInt8ConvRot,
+            None,
             None,
             &H3ComfyNeverCancel,
         )
@@ -2950,7 +3304,7 @@ mod tests {
             &path,
             config.clone(),
             H3TransformerTask::T2VaFl2Va,
-            H3ComfyPublishedArtifact::Fl2VaPrunedInt8ConvRot,
+            None,
             None,
             &H3ComfyNeverCancel,
         )
@@ -2959,7 +3313,7 @@ mod tests {
             &path,
             config,
             H3TransformerTask::Ref2Va,
-            H3ComfyPublishedArtifact::Ref2VaPrunedInt8ConvRot,
+            None,
             None,
             &H3ComfyNeverCancel,
         )
@@ -2997,7 +3351,7 @@ mod tests {
             &path,
             config.clone(),
             H3TransformerTask::T2VaFl2Va,
-            H3ComfyPublishedArtifact::Fl2VaPrunedInt8ConvRot,
+            None,
             Some((bytes, &wrong_digest)),
             &H3ComfyNeverCancel,
         )
@@ -3012,7 +3366,7 @@ mod tests {
             &path,
             config.clone(),
             H3TransformerTask::T2VaFl2Va,
-            H3ComfyPublishedArtifact::Fl2VaPrunedInt8ConvRot,
+            None,
             None,
             &cancelled,
         )
@@ -3023,7 +3377,7 @@ mod tests {
             &path,
             config,
             H3TransformerTask::T2VaFl2Va,
-            H3ComfyPublishedArtifact::Fl2VaPrunedInt8ConvRot,
+            None,
             None,
             &H3ComfyNeverCancel,
         )
@@ -3045,7 +3399,7 @@ mod tests {
             &path,
             config.clone(),
             H3TransformerTask::T2VaFl2Va,
-            H3ComfyPublishedArtifact::Fl2VaPrunedInt8ConvRot,
+            None,
             None,
             &H3ComfyNeverCancel,
         )

--- a/crates/mold-candle/src/minimax_h3/comfy_dit.rs
+++ b/crates/mold-candle/src/minimax_h3/comfy_dit.rs
@@ -1,34 +1,45 @@
-//! Header-only contracts for ComfyUI's pruned MiniMax H3 DiT checkpoints.
+//! Source-pinned inspection and opened-file streaming primitives for ComfyUI's
+//! pruned MiniMax H3 DiT checkpoints.
 //!
 //! The schema is derived from ComfyUI `a464ac33588ae182f81a090d910cfbf21e255b73`:
 //! `comfy/ldm/minimax/model.py`, `comfy/model_detection.py`,
 //! `comfy/quant_ops.py`, `comfy/ops.py`, and `comfy/utils.py`, plus its exact
 //! comfy-kitchen 0.2.26 dependency for ConvRot scale semantics. Public artifact
 //! sizes and content digests are pinned to the Comfy-Org repository revision
-//! below. No model tensor data is needed by this inspector.
+//! below. Header inspection remains payload-free; the additive INT8 primitive
+//! fully authenticates and retains one opened descriptor before loading
+//! protected resident tensors or one CPU-packed main block at a time.
 //!
-//! This module deliberately produces a *candidate* strategy, not a runnable
-//! checkpoint. Private integration authorization allowed Mold to authenticate
-//! the curated INT8 artifacts and pin their shared released header identity.
-//! Public discovery, execution, and distribution remain independently gated;
-//! a header candidate is never an execution authority by itself.
+//! Neither path registers an inference engine, capability, catalog entry, or
+//! download. Header candidates therefore remain non-executable, and the
+//! opened-file primitive remains a private implementation prerequisite until
+//! the separate runtime/release qualification and activation work lands.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error as StdError;
 use std::fmt;
-use std::fs::File;
-use std::io::Read;
+use std::fs::{File, Metadata};
+use std::io::{Read, Seek, SeekFrom};
 use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 
-use candle::DType;
+use candle::{DType, Device, Shape, Tensor};
+use candle_nn::var_builder::SimpleBackend;
+use candle_nn::VarBuilder;
 use serde::de::{DeserializeOwned, Error as _, MapAccess, SeqAccess, Visitor};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::{Map, Number, Value};
 use sha2::{Digest, Sha256};
 
+use super::attention::{
+    H3AttentionDType, H3AttentionDevice, H3AttentionModelContract, H3AttentionRuntimeAuthority,
+};
+use super::comfy_quant::{H3ComfyInt8ConvRotLinear, H3_COMFY_PORTABLE_ROW_CHUNK};
 use super::dit::{
-    expected_h3_weight_specs, H3AdaLnMode, H3PrecisionProfile, H3QkvLayout, H3TransformerConfig,
-    H3TransformerTask,
+    expected_h3_weight_specs, H3AdaLnMode, H3ComfyInt8BlockMatrices, H3LoadedTransformerBlock,
+    H3PrecisionProfile, H3QkvLayout, H3StreamedTransformer, H3StreamedTransformerIdentity,
+    H3TransformerConfig, H3TransformerTask,
 };
 
 pub const H3_COMFYUI_SOURCE_REVISION: &str = "a464ac33588ae182f81a090d910cfbf21e255b73";
@@ -56,6 +67,7 @@ const CONVROT_GROUP_SIZE: usize = 256;
 const PUBLISHED_INT8_CURVE_GRID: usize = 1_025;
 const PUBLISHED_INT8_CURVE_BASIS: usize = 8;
 const PUBLISHED_INT8_COMFY_QUANT_BYTES: usize = 72;
+const FILE_READ_CHUNK_BYTES: usize = 8 * 1024 * 1024;
 const QUANTIZED_BLOCK_WEIGHT_SUFFIXES: &[&str] = &[
     "attn.qkv_proj.weight",
     "attn.out_proj.weight",
@@ -282,11 +294,14 @@ impl H3ComfyCheckpointCandidate {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum H3ComfyCheckpointErrorCode {
     Io,
+    Cancelled,
     InvalidHeader,
     InvalidMetadata,
     ConfigMismatch,
     TaskAuthorityMismatch,
     SourceSizeMismatch,
+    ContentDigestMismatch,
+    FileIdentityChanged,
     FormatMismatch,
     TensorSchemaMismatch,
 }
@@ -311,6 +326,147 @@ fn failure(code: H3ComfyCheckpointErrorCode, message: impl Into<String>) -> H3Co
     H3ComfyCheckpointError {
         code,
         message: message.into(),
+    }
+}
+
+/// Cooperative cancellation checked before every bounded file read and every
+/// main-block construction boundary.
+pub trait H3ComfyInt8Cancellation: Send + Sync {
+    fn is_cancelled(&self) -> bool;
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct H3ComfyNeverCancel;
+
+impl H3ComfyInt8Cancellation for H3ComfyNeverCancel {
+    fn is_cancelled(&self) -> bool {
+        false
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct H3ComfyInt8BlockMemory {
+    /// Quantized weights and F32 scale sidecars retained on CPU for one block.
+    pub encoded_host_bytes: u64,
+    /// Largest temporary host buffer used by one exact tensor read.
+    pub max_host_read_staging_bytes: u64,
+    /// Largest dense F32 row chunk staged on the execution device.
+    pub max_device_weight_staging_bytes: u64,
+    /// Protected norms and FP32 Curve-AdaLN tensors resident for this block.
+    pub protected_device_bytes: u64,
+}
+
+/// An exact, already-opened Comfy INT8 artifact authority.
+///
+/// Header parsing, schema/policy validation, full-content hashing, resident
+/// loads, and every streamed block read all use the same retained file
+/// descriptor. This primitive is deliberately not registered with Mold's
+/// factory or catalog.
+pub struct H3ComfyOpenedInt8Checkpoint {
+    candidate: H3ComfyCheckpointCandidate,
+    config: H3TransformerConfig,
+    source: Arc<H3ComfyOpenedSource>,
+    checkpoint_identity_sha256: String,
+}
+
+impl fmt::Debug for H3ComfyOpenedInt8Checkpoint {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("H3ComfyOpenedInt8Checkpoint")
+            .field("artifact", &self.candidate.artifact)
+            .field("task", &self.candidate.strategy.task)
+            .field(
+                "checkpoint_identity_sha256",
+                &self.checkpoint_identity_sha256,
+            )
+            .finish_non_exhaustive()
+    }
+}
+
+impl H3ComfyOpenedInt8Checkpoint {
+    pub fn candidate(&self) -> &H3ComfyCheckpointCandidate {
+        &self.candidate
+    }
+
+    pub fn checkpoint_identity_sha256(&self) -> &str {
+        &self.checkpoint_identity_sha256
+    }
+
+    pub fn verified_file_bytes(&self) -> u64 {
+        self.source.identity.len
+    }
+
+    pub fn bytes_read_after_verification(&self) -> u64 {
+        self.source.runtime_bytes_read.load(Ordering::Relaxed)
+    }
+
+    /// Load resident stages and retain only the opened file plus an opaque
+    /// exact-block loader for the fifty main blocks.
+    pub fn load(
+        self,
+        device: &Device,
+    ) -> candle::Result<(H3StreamedTransformer, H3ComfyInt8BlockLoader)> {
+        let contract = H3AttentionModelContract {
+            heads: self.config.num_attention_heads,
+            head_dim: self.config.attention_head_dim,
+            dtype: H3AttentionDType::from_candle(
+                self.candidate
+                    .strategy
+                    .dense_compute_precision
+                    .compute_dtype(),
+            )
+            .map_err(|error| candle::Error::Msg(error.to_string()))?,
+        };
+        let attention = H3AttentionRuntimeAuthority::bounded_synthetic_math(
+            H3AttentionDevice::from_candle(device),
+            contract,
+        )
+        .map_err(|error| candle::Error::Msg(error.to_string()))?;
+        self.load_with_attention_and_cancellation(device, attention, Arc::new(H3ComfyNeverCancel))
+    }
+
+    pub fn load_with_attention_and_cancellation(
+        self,
+        device: &Device,
+        attention: H3AttentionRuntimeAuthority,
+        cancellation: Arc<dyn H3ComfyInt8Cancellation>,
+    ) -> candle::Result<(H3StreamedTransformer, H3ComfyInt8BlockLoader)> {
+        cancellation_boundary(cancellation.as_ref())?;
+        let backend = H3ComfyOpenedBackend {
+            source: self.source.clone(),
+            cancellation: cancellation.clone(),
+        };
+        let vb = VarBuilder::from_backend(
+            Box::new(backend),
+            self.candidate
+                .strategy
+                .dense_compute_precision
+                .compute_dtype(),
+            device.clone(),
+        );
+        let mode = self.candidate.strategy.adaln_mode;
+        let precision = self.candidate.strategy.dense_compute_precision;
+        let task = self.candidate.strategy.task;
+        let transformer = H3StreamedTransformer::load_comfy_int8_resident(
+            self.config.clone(),
+            task,
+            mode,
+            precision,
+            vb.clone(),
+            attention,
+            self.checkpoint_identity_sha256.clone(),
+        )?;
+        cancellation_boundary(cancellation.as_ref())?;
+        let loader = H3ComfyInt8BlockLoader {
+            config: self.config,
+            mode,
+            precision,
+            source: self.source,
+            vb,
+            identity: transformer.streamed_identity(),
+            cancellation,
+        };
+        Ok((transformer, loader))
     }
 }
 
@@ -351,6 +507,137 @@ pub fn inspect_h3_comfy_published_header(
     )
 }
 
+/// Open and fully authenticate one published Comfy INT8 ConvRot checkpoint.
+///
+/// Unlike [`inspect_h3_comfy_published_header`], this reads the complete file
+/// and returns the retained opened-file authority needed by the private model
+/// primitive. It still does not make the model reachable from any Mold runtime
+/// factory, capability, catalog, or download route.
+pub fn open_h3_comfy_published_int8_checkpoint(
+    path: &Path,
+    requested_task: H3TransformerTask,
+    artifact: H3ComfyPublishedArtifact,
+    cancellation: &dyn H3ComfyInt8Cancellation,
+) -> InspectionResult<H3ComfyOpenedInt8Checkpoint> {
+    if artifact.format() != H3ComfyPrunedFormat::Int8ConvRot {
+        return Err(failure(
+            H3ComfyCheckpointErrorCode::FormatMismatch,
+            "H3 opened INT8 runtime requires a published INT8 ConvRot artifact",
+        ));
+    }
+    open_h3_comfy_int8_checkpoint(
+        path,
+        H3TransformerConfig::default(),
+        requested_task,
+        artifact,
+        Some((artifact.file_bytes(), artifact.content_sha256())),
+        cancellation,
+    )
+}
+
+fn open_h3_comfy_int8_checkpoint(
+    path: &Path,
+    config: H3TransformerConfig,
+    requested_task: H3TransformerTask,
+    artifact: H3ComfyPublishedArtifact,
+    expected_content: Option<(u64, &str)>,
+    cancellation: &dyn H3ComfyInt8Cancellation,
+) -> InspectionResult<H3ComfyOpenedInt8Checkpoint> {
+    if requested_task != artifact.task() {
+        return Err(failure(
+            H3ComfyCheckpointErrorCode::TaskAuthorityMismatch,
+            format!(
+                "H3 requested task {requested_task:?} does not match source authority {:?}",
+                artifact.task()
+            ),
+        ));
+    }
+    cancellation_boundary_inspection(cancellation)?;
+    let symlink_metadata = std::fs::symlink_metadata(path).map_err(|error| {
+        failure(
+            H3ComfyCheckpointErrorCode::Io,
+            format!("failed to inspect H3 Comfy checkpoint: {error}"),
+        )
+    })?;
+    if symlink_metadata.file_type().is_symlink() || !symlink_metadata.is_file() {
+        return Err(failure(
+            H3ComfyCheckpointErrorCode::FileIdentityChanged,
+            "H3 Comfy execution authority must be opened from a regular non-symlink file",
+        ));
+    }
+    let mut file = File::open(path).map_err(|error| {
+        failure(
+            H3ComfyCheckpointErrorCode::Io,
+            format!("failed to open H3 Comfy checkpoint: {error}"),
+        )
+    })?;
+    let identity = H3OpenedFileIdentity::from_metadata(
+        &file
+            .metadata()
+            .map_err(|error| failure(H3ComfyCheckpointErrorCode::Io, error.to_string()))?,
+    );
+    if identity.len != symlink_metadata.len() {
+        return Err(failure(
+            H3ComfyCheckpointErrorCode::FileIdentityChanged,
+            "H3 Comfy checkpoint changed while its descriptor was opened",
+        ));
+    }
+    let parsed = read_safetensors_header_from_file(&mut file)?;
+    if let Some((expected_bytes, _)) = expected_content {
+        if parsed.file_len != expected_bytes {
+            return Err(failure(
+                H3ComfyCheckpointErrorCode::SourceSizeMismatch,
+                format!(
+                    "H3 Comfy artifact size {} does not match source-pinned {expected_bytes}",
+                    parsed.file_len
+                ),
+            ));
+        }
+    }
+    let candidate = inspect_parsed_header(
+        parsed.clone(),
+        config.clone(),
+        requested_task,
+        H3ComfyPrunedFormat::Int8ConvRot,
+        Some(artifact),
+    )?;
+    let content_sha256 = hash_open_file(&mut file, parsed.file_len, cancellation)?;
+    if let Some((_, expected_sha256)) = expected_content {
+        if content_sha256 != expected_sha256 {
+            return Err(failure(
+                H3ComfyCheckpointErrorCode::ContentDigestMismatch,
+                format!(
+                    "H3 Comfy content digest {content_sha256} does not match source-pinned {expected_sha256}"
+                ),
+            ));
+        }
+    }
+    let final_identity = H3OpenedFileIdentity::from_metadata(
+        &file
+            .metadata()
+            .map_err(|error| failure(H3ComfyCheckpointErrorCode::Io, error.to_string()))?,
+    );
+    if final_identity != identity {
+        return Err(failure(
+            H3ComfyCheckpointErrorCode::FileIdentityChanged,
+            "H3 Comfy checkpoint changed during content verification",
+        ));
+    }
+    let checkpoint_identity_sha256 = comfy_checkpoint_identity(&candidate, &content_sha256);
+    Ok(H3ComfyOpenedInt8Checkpoint {
+        candidate,
+        config,
+        source: Arc::new(H3ComfyOpenedSource {
+            file: Mutex::new(file),
+            header: parsed,
+            identity,
+            content_sha256,
+            runtime_bytes_read: AtomicU64::new(0),
+        }),
+        checkpoint_identity_sha256,
+    })
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct HeaderTensor {
     dtype: String,
@@ -367,6 +654,69 @@ struct ParsedHeader {
     header_identity_sha256: String,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct H3OpenedFileIdentity {
+    len: u64,
+    #[cfg(unix)]
+    device: u64,
+    #[cfg(unix)]
+    inode: u64,
+    #[cfg(unix)]
+    modified_seconds: i64,
+    #[cfg(unix)]
+    modified_nanoseconds: i64,
+    #[cfg(unix)]
+    changed_seconds: i64,
+    #[cfg(unix)]
+    changed_nanoseconds: i64,
+    #[cfg(not(unix))]
+    modified: Option<std::time::SystemTime>,
+}
+
+impl H3OpenedFileIdentity {
+    fn from_metadata(metadata: &Metadata) -> Self {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            Self {
+                len: metadata.len(),
+                device: metadata.dev(),
+                inode: metadata.ino(),
+                modified_seconds: metadata.mtime(),
+                modified_nanoseconds: metadata.mtime_nsec(),
+                changed_seconds: metadata.ctime(),
+                changed_nanoseconds: metadata.ctime_nsec(),
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            Self {
+                len: metadata.len(),
+                modified: metadata.modified().ok(),
+            }
+        }
+    }
+}
+
+struct H3ComfyOpenedSource {
+    file: Mutex<File>,
+    header: ParsedHeader,
+    identity: H3OpenedFileIdentity,
+    content_sha256: String,
+    runtime_bytes_read: AtomicU64,
+}
+
+impl fmt::Debug for H3ComfyOpenedSource {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("H3ComfyOpenedSource")
+            .field("file_bytes", &self.identity.len)
+            .field("content_sha256", &self.content_sha256)
+            .field("tensor_count", &self.header.tensors.len())
+            .finish_non_exhaustive()
+    }
+}
+
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 struct RawTensorHeader {
@@ -380,6 +730,16 @@ fn read_safetensors_header(path: &Path) -> InspectionResult<ParsedHeader> {
         failure(
             H3ComfyCheckpointErrorCode::Io,
             format!("failed to open H3 Comfy checkpoint: {error}"),
+        )
+    })?;
+    read_safetensors_header_from_file(&mut file)
+}
+
+fn read_safetensors_header_from_file(file: &mut File) -> InspectionResult<ParsedHeader> {
+    file.seek(SeekFrom::Start(0)).map_err(|error| {
+        failure(
+            H3ComfyCheckpointErrorCode::Io,
+            format!("failed to seek H3 Comfy checkpoint: {error}"),
         )
     })?;
     let file_len = file
@@ -553,6 +913,365 @@ fn dtype_size(dtype: &str) -> InspectionResult<u64> {
             H3ComfyCheckpointErrorCode::InvalidHeader,
             format!("unsupported H3 Comfy safetensors dtype {other:?}"),
         )),
+    }
+}
+
+fn cancellation_boundary(cancellation: &dyn H3ComfyInt8Cancellation) -> candle::Result<()> {
+    if cancellation.is_cancelled() {
+        candle::bail!("MiniMax H3 Comfy INT8 checkpoint read was cancelled")
+    }
+    Ok(())
+}
+
+fn cancellation_boundary_inspection(
+    cancellation: &dyn H3ComfyInt8Cancellation,
+) -> InspectionResult<()> {
+    if cancellation.is_cancelled() {
+        return Err(failure(
+            H3ComfyCheckpointErrorCode::Cancelled,
+            "MiniMax H3 Comfy INT8 checkpoint read was cancelled",
+        ));
+    }
+    Ok(())
+}
+
+fn hash_open_file(
+    file: &mut File,
+    file_len: u64,
+    cancellation: &dyn H3ComfyInt8Cancellation,
+) -> InspectionResult<String> {
+    file.seek(SeekFrom::Start(0)).map_err(|error| {
+        failure(
+            H3ComfyCheckpointErrorCode::Io,
+            format!("failed to seek H3 Comfy checkpoint for hashing: {error}"),
+        )
+    })?;
+    let mut digest = Sha256::new();
+    let mut verified = 0u64;
+    let mut buffer = vec![0u8; FILE_READ_CHUNK_BYTES];
+    while verified < file_len {
+        cancellation_boundary_inspection(cancellation)?;
+        let remaining = usize::try_from((file_len - verified).min(FILE_READ_CHUNK_BYTES as u64))
+            .map_err(|_| {
+                failure(
+                    H3ComfyCheckpointErrorCode::Io,
+                    "H3 Comfy hash read size does not fit this platform",
+                )
+            })?;
+        file.read_exact(&mut buffer[..remaining]).map_err(|error| {
+            failure(
+                H3ComfyCheckpointErrorCode::Io,
+                format!("failed to hash H3 Comfy checkpoint: {error}"),
+            )
+        })?;
+        digest.update(&buffer[..remaining]);
+        verified += remaining as u64;
+    }
+    cancellation_boundary_inspection(cancellation)?;
+    Ok(hex_digest(digest.finalize()))
+}
+
+fn comfy_checkpoint_identity(
+    candidate: &H3ComfyCheckpointCandidate,
+    content_sha256: &str,
+) -> String {
+    let mut digest = Sha256::new();
+    digest.update(b"mold.minimax-h3.comfy-int8-opened-checkpoint.v1\0");
+    digest.update(candidate.strategy.stable_id.as_bytes());
+    digest.update([candidate.strategy.task as u8]);
+    digest.update(candidate.header_identity_sha256.as_bytes());
+    digest.update(content_sha256.as_bytes());
+    digest.update(
+        candidate
+            .strategy
+            .quantization_policy
+            .policy_sha256
+            .as_bytes(),
+    );
+    hex_digest(digest.finalize())
+}
+
+impl H3ComfyOpenedSource {
+    fn verify_identity(&self, file: &File) -> candle::Result<()> {
+        let current = file.metadata().map_err(|error| {
+            candle::Error::Msg(format!(
+                "failed to stat opened H3 Comfy checkpoint: {error}"
+            ))
+        })?;
+        if H3OpenedFileIdentity::from_metadata(&current) != self.identity {
+            candle::bail!("opened H3 Comfy checkpoint changed after full verification")
+        }
+        Ok(())
+    }
+
+    fn tensor_header(&self, name: &str) -> candle::Result<&HeaderTensor> {
+        self.header.tensors.get(name).ok_or_else(|| {
+            candle::Error::Msg(format!(
+                "verified H3 Comfy checkpoint does not contain tensor {name:?}"
+            ))
+        })
+    }
+
+    fn read_tensor_bytes(
+        &self,
+        name: &str,
+        cancellation: &dyn H3ComfyInt8Cancellation,
+    ) -> candle::Result<Vec<u8>> {
+        cancellation_boundary(cancellation)?;
+        let tensor = self.tensor_header(name)?;
+        let len = usize::try_from(tensor.data_offsets[1] - tensor.data_offsets[0])
+            .map_err(|_| candle::Error::Msg(format!("H3 Comfy tensor {name:?} is too large")))?;
+        let data_start = 8u64
+            .checked_add(self.header.header_len)
+            .and_then(|value| value.checked_add(tensor.data_offsets[0]))
+            .ok_or_else(|| candle::Error::Msg("H3 Comfy tensor offset overflows".into()))?;
+        let mut bytes = vec![0u8; len];
+        let mut file = self
+            .file
+            .lock()
+            .map_err(|_| candle::Error::Msg("H3 Comfy file lock was poisoned".into()))?;
+        self.verify_identity(&file)?;
+        file.seek(SeekFrom::Start(data_start)).map_err(|error| {
+            candle::Error::Msg(format!("failed to seek H3 Comfy tensor {name:?}: {error}"))
+        })?;
+        let mut offset = 0usize;
+        while offset < bytes.len() {
+            cancellation_boundary(cancellation)?;
+            let end = (offset + FILE_READ_CHUNK_BYTES).min(bytes.len());
+            file.read_exact(&mut bytes[offset..end]).map_err(|error| {
+                candle::Error::Msg(format!("failed to read H3 Comfy tensor {name:?}: {error}"))
+            })?;
+            self.runtime_bytes_read
+                .fetch_add((end - offset) as u64, Ordering::Relaxed);
+            offset = end;
+        }
+        self.verify_identity(&file)?;
+        cancellation_boundary(cancellation)?;
+        Ok(bytes)
+    }
+
+    fn load_dense_tensor(
+        &self,
+        name: &str,
+        requested_dtype: DType,
+        device: &Device,
+        cancellation: &dyn H3ComfyInt8Cancellation,
+    ) -> candle::Result<Tensor> {
+        let header = self.tensor_header(name)?;
+        let source_dtype = match header.dtype.as_str() {
+            "BF16" => DType::BF16,
+            "F32" => DType::F32,
+            dtype => candle::bail!(
+                "H3 Comfy dense backend refuses encoded dtype {dtype:?} for tensor {name:?}"
+            ),
+        };
+        let bytes = self.read_tensor_bytes(name, cancellation)?;
+        let tensor = Tensor::from_raw_buffer(&bytes, source_dtype, &header.shape, &Device::Cpu)?;
+        let tensor = if tensor.dtype() == requested_dtype {
+            tensor
+        } else {
+            tensor.to_dtype(requested_dtype)?
+        };
+        tensor.to_device(device)
+    }
+
+    fn load_raw_int8(
+        &self,
+        name: &str,
+        cancellation: &dyn H3ComfyInt8Cancellation,
+    ) -> candle::Result<Tensor> {
+        let header = self.tensor_header(name)?;
+        if header.dtype != "I8" {
+            candle::bail!("H3 Comfy tensor {name:?} is not exact I8 storage")
+        }
+        let bytes = self.read_tensor_bytes(name, cancellation)?;
+        Tensor::from_raw_buffer(&bytes, DType::U8, &header.shape, &Device::Cpu)
+    }
+
+    fn load_f32_cpu(
+        &self,
+        name: &str,
+        cancellation: &dyn H3ComfyInt8Cancellation,
+    ) -> candle::Result<Tensor> {
+        self.load_dense_tensor(name, DType::F32, &Device::Cpu, cancellation)
+    }
+}
+
+struct H3ComfyOpenedBackend {
+    source: Arc<H3ComfyOpenedSource>,
+    cancellation: Arc<dyn H3ComfyInt8Cancellation>,
+}
+
+impl SimpleBackend for H3ComfyOpenedBackend {
+    fn get(
+        &self,
+        shape: Shape,
+        name: &str,
+        _hints: candle_nn::Init,
+        dtype: DType,
+        device: &Device,
+    ) -> candle::Result<Tensor> {
+        let tensor =
+            self.source
+                .load_dense_tensor(name, dtype, device, self.cancellation.as_ref())?;
+        if tensor.shape() != &shape {
+            return Err(candle::Error::UnexpectedShape {
+                msg: format!("H3 Comfy opened-file backend shape mismatch for {name}"),
+                expected: shape,
+                got: tensor.shape().clone(),
+            }
+            .bt());
+        }
+        Ok(tensor)
+    }
+
+    fn get_unchecked(&self, name: &str, dtype: DType, device: &Device) -> candle::Result<Tensor> {
+        self.source
+            .load_dense_tensor(name, dtype, device, self.cancellation.as_ref())
+    }
+
+    fn contains_tensor(&self, name: &str) -> bool {
+        self.source.header.tensors.contains_key(name)
+    }
+}
+
+pub struct H3ComfyInt8BlockLoader {
+    config: H3TransformerConfig,
+    mode: H3AdaLnMode,
+    precision: H3PrecisionProfile,
+    source: Arc<H3ComfyOpenedSource>,
+    vb: VarBuilder<'static>,
+    identity: Arc<H3StreamedTransformerIdentity>,
+    cancellation: Arc<dyn H3ComfyInt8Cancellation>,
+}
+
+impl fmt::Debug for H3ComfyInt8BlockLoader {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("H3ComfyInt8BlockLoader")
+            .field("task", &self.identity.task())
+            .field("block_count", &self.identity.block_count())
+            .field("live_blocks", &self.identity.live_block_count())
+            .field("content_sha256", &self.source.content_sha256)
+            .finish_non_exhaustive()
+    }
+}
+
+impl H3ComfyInt8BlockLoader {
+    pub fn task(&self) -> H3TransformerTask {
+        self.identity.task()
+    }
+
+    pub fn block_count(&self) -> usize {
+        self.identity.block_count()
+    }
+
+    pub fn live_block_count(&self) -> usize {
+        self.identity.live_block_count()
+    }
+
+    pub fn content_sha256(&self) -> &str {
+        &self.source.content_sha256
+    }
+
+    pub fn bytes_read(&self) -> u64 {
+        self.source.runtime_bytes_read.load(Ordering::Relaxed)
+    }
+
+    pub fn block_memory(&self, index: usize) -> candle::Result<H3ComfyInt8BlockMemory> {
+        if index >= self.block_count() {
+            candle::bail!(
+                "MiniMax H3 block index {index} is outside the exact block count {}",
+                self.block_count()
+            )
+        }
+        let prefix = format!("blocks.{index}.");
+        let mut encoded_host_bytes = 0u64;
+        let mut max_host_read_staging_bytes = 0u64;
+        let mut max_device_weight_staging_bytes = 0u64;
+        let mut protected_device_bytes = 0u64;
+        for (name, tensor) in self
+            .source
+            .header
+            .tensors
+            .range(prefix.clone()..)
+            .take_while(|(name, _)| name.starts_with(&prefix))
+        {
+            let bytes = tensor.data_offsets[1] - tensor.data_offsets[0];
+            max_host_read_staging_bytes = max_host_read_staging_bytes.max(bytes);
+            let quantized = QUANTIZED_BLOCK_WEIGHT_SUFFIXES
+                .iter()
+                .any(|suffix| name == &format!("{prefix}{suffix}"));
+            let scale = name.ends_with(".weight_scale");
+            if quantized || scale {
+                encoded_host_bytes = encoded_host_bytes.checked_add(bytes).ok_or_else(|| {
+                    candle::Error::Msg("H3 Comfy block host byte count overflows".into())
+                })?;
+                if quantized {
+                    let rows = tensor.shape[0].min(H3_COMFY_PORTABLE_ROW_CHUNK);
+                    let staging = rows
+                        .checked_mul(tensor.shape[1])
+                        .and_then(|elements| elements.checked_mul(std::mem::size_of::<f32>()))
+                        .ok_or_else(|| {
+                            candle::Error::Msg("H3 Comfy device staging bytes overflow".into())
+                        })? as u64;
+                    max_device_weight_staging_bytes = max_device_weight_staging_bytes.max(staging);
+                }
+            } else {
+                protected_device_bytes =
+                    protected_device_bytes.checked_add(bytes).ok_or_else(|| {
+                        candle::Error::Msg("H3 Comfy protected block bytes overflow".into())
+                    })?;
+            }
+        }
+        Ok(H3ComfyInt8BlockMemory {
+            encoded_host_bytes,
+            max_host_read_staging_bytes,
+            max_device_weight_staging_bytes,
+            protected_device_bytes,
+        })
+    }
+
+    /// Load exactly one indexed main block. A second live block is rejected so
+    /// neither compressed host weights nor protected device tensors can grow
+    /// with the fifty-block stack.
+    pub fn load_block(&mut self, index: usize) -> candle::Result<H3LoadedTransformerBlock> {
+        cancellation_boundary(self.cancellation.as_ref())?;
+        if index >= self.block_count() {
+            candle::bail!(
+                "MiniMax H3 block index {index} is outside the exact block count {}",
+                self.block_count()
+            )
+        }
+        if self.live_block_count() != 0 {
+            candle::bail!("MiniMax H3 Comfy INT8 loader permits exactly one live main block")
+        }
+        let prefix = format!("blocks.{index}");
+        let linear = |suffix: &str| -> candle::Result<H3ComfyInt8ConvRotLinear> {
+            let layer = format!("{prefix}.{suffix}");
+            H3ComfyInt8ConvRotLinear::new(
+                self.source
+                    .load_raw_int8(&format!("{layer}.weight"), self.cancellation.as_ref())?,
+                self.source
+                    .load_f32_cpu(&format!("{layer}.weight_scale"), self.cancellation.as_ref())?,
+            )
+        };
+        let matrices = H3ComfyInt8BlockMatrices {
+            qkv: linear("attn.qkv_proj")?,
+            out: linear("attn.out_proj")?,
+            fc1: linear("mlp.fc1")?,
+            fc2: linear("mlp.fc2")?,
+        };
+        cancellation_boundary(self.cancellation.as_ref())?;
+        H3LoadedTransformerBlock::new_comfy_int8(
+            index,
+            self.identity.clone(),
+            &self.config,
+            self.mode,
+            self.precision,
+            matrices,
+            self.vb.pp(prefix),
+        )
     }
 }
 
@@ -1338,6 +2057,7 @@ fn hex_digest(bytes: impl AsRef<[u8]>) -> String {
 #[cfg(test)]
 mod tests {
     use std::io::Write;
+    use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
 
     use candle::{Device, Tensor};
 
@@ -1360,6 +2080,28 @@ mod tests {
             time_embed_hidden_size: 8,
             time_embed_dim: 4,
             rope_inv_freq_len: 1,
+            norm_eps: 1e-5,
+            qk_norm_eps: 1e-5,
+            final_norm_eps: 1e-5,
+        }
+    }
+
+    fn runtime_config() -> H3TransformerConfig {
+        H3TransformerConfig {
+            hidden_size: 256,
+            num_layers: 2,
+            token_refiner_num_layers: 1,
+            num_attention_heads: 2,
+            attention_head_dim: 128,
+            ffn_hidden_size: 256,
+            video_latent_channels: 64,
+            audio_latent_channels: 256,
+            patch_size: [1, 2, 2],
+            text_dim: 256,
+            timestep_input_dim: 64,
+            time_embed_hidden_size: 256,
+            time_embed_dim: 128,
+            rope_inv_freq_len: 16,
             norm_eps: 1e-5,
             qk_norm_eps: 1e-5,
             final_norm_eps: 1e-5,
@@ -1530,6 +2272,44 @@ mod tests {
         file.write_all(&encoded).unwrap();
         file.write_all(data).unwrap();
         path
+    }
+
+    fn fill_f32_tensor(header: &Value, data: &mut [u8], name: &str, value: f32) {
+        let tensor = &header[name];
+        let start = tensor["data_offsets"][0].as_u64().unwrap() as usize;
+        let end = tensor["data_offsets"][1].as_u64().unwrap() as usize;
+        for bytes in data[start..end].chunks_exact_mut(4) {
+            bytes.copy_from_slice(&value.to_le_bytes());
+        }
+    }
+
+    fn runtime_fixture() -> (H3TransformerConfig, Value, Vec<u8>) {
+        let config = runtime_config();
+        let mode = H3AdaLnMode::Curve {
+            grid: 5,
+            basis_dim: 64,
+        };
+        let (header, mut data) = fixture_header(&config, mode, H3ComfyPrunedFormat::Int8ConvRot);
+        let scales = header
+            .as_object()
+            .unwrap()
+            .keys()
+            .filter(|name| name.ends_with(".weight_scale"))
+            .cloned()
+            .collect::<Vec<_>>();
+        for scale in scales {
+            fill_f32_tensor(&header, &mut data, &scale, 1.0);
+        }
+        (config, header, data)
+    }
+
+    #[derive(Default)]
+    struct ToggleCancellation(AtomicBool);
+
+    impl H3ComfyInt8Cancellation for ToggleCancellation {
+        fn is_cancelled(&self) -> bool {
+            self.0.load(AtomicOrdering::Relaxed)
+        }
     }
 
     fn inspect_fixture(
@@ -2100,6 +2880,199 @@ mod tests {
             H3ComfyCheckpointErrorCode::InvalidHeader
         );
         let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn opened_int8_runtime_streams_exactly_one_cpu_packed_block() -> candle::Result<()> {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<H3ComfyOpenedInt8Checkpoint>();
+        assert_send_sync::<H3ComfyInt8BlockLoader>();
+        assert_send_sync::<H3ComfyInt8BlockMemory>();
+        let (config, header, data) = runtime_fixture();
+        let path = write_fixture(&header, &data, "opened-runtime");
+        let opened = open_h3_comfy_int8_checkpoint(
+            &path,
+            config,
+            H3TransformerTask::T2VaFl2Va,
+            H3ComfyPublishedArtifact::Fl2VaPrunedInt8ConvRot,
+            None,
+            &H3ComfyNeverCancel,
+        )
+        .map_err(|error| candle::Error::Msg(error.to_string()))?;
+        assert_eq!(opened.bytes_read_after_verification(), 0);
+        assert_eq!(opened.checkpoint_identity_sha256().len(), 64);
+        let expected_identity = opened.checkpoint_identity_sha256().to_owned();
+        let (transformer, mut loader) = opened.load(&Device::Cpu)?;
+        assert_eq!(
+            transformer.checkpoint_identity_sha256(),
+            Some(expected_identity.as_str())
+        );
+        assert_eq!(loader.block_count(), 2);
+        assert_eq!(loader.live_block_count(), 0);
+        assert!(
+            loader.bytes_read() > 0,
+            "resident weights must be file-backed"
+        );
+        let memory = loader.block_memory(0)?;
+        assert!(memory.encoded_host_bytes > 0);
+        assert!(memory.max_host_read_staging_bytes > 0);
+        assert_eq!(memory.max_device_weight_staging_bytes, 256 * 256 * 4);
+        assert!(memory.protected_device_bytes > 0);
+
+        let block0 = loader.load_block(0)?;
+        assert_eq!(block0.index(), 0);
+        assert_eq!(loader.live_block_count(), 1);
+        assert!(loader.load_block(1).is_err());
+        drop(block0);
+        assert_eq!(loader.live_block_count(), 0);
+        let block1 = loader.load_block(1)?;
+        assert_eq!(block1.index(), 1);
+        drop(block1);
+        assert_eq!(loader.live_block_count(), 0);
+        let _ = std::fs::remove_file(path);
+        Ok(())
+    }
+
+    #[test]
+    fn opened_identity_freezes_task_header_content_and_quantization_policy() {
+        let (config, header, data) = runtime_fixture();
+        let path = write_fixture(&header, &data, "opened-task-identity");
+        let fl = open_h3_comfy_int8_checkpoint(
+            &path,
+            config.clone(),
+            H3TransformerTask::T2VaFl2Va,
+            H3ComfyPublishedArtifact::Fl2VaPrunedInt8ConvRot,
+            None,
+            &H3ComfyNeverCancel,
+        )
+        .unwrap();
+        let same = open_h3_comfy_int8_checkpoint(
+            &path,
+            config.clone(),
+            H3TransformerTask::T2VaFl2Va,
+            H3ComfyPublishedArtifact::Fl2VaPrunedInt8ConvRot,
+            None,
+            &H3ComfyNeverCancel,
+        )
+        .unwrap();
+        let reference = open_h3_comfy_int8_checkpoint(
+            &path,
+            config,
+            H3TransformerTask::Ref2Va,
+            H3ComfyPublishedArtifact::Ref2VaPrunedInt8ConvRot,
+            None,
+            &H3ComfyNeverCancel,
+        )
+        .unwrap();
+        assert_eq!(
+            fl.checkpoint_identity_sha256(),
+            same.checkpoint_identity_sha256()
+        );
+        assert_ne!(
+            fl.checkpoint_identity_sha256(),
+            reference.checkpoint_identity_sha256()
+        );
+        assert_eq!(
+            fl.candidate().header_identity_sha256,
+            reference.candidate().header_identity_sha256
+        );
+        assert_eq!(
+            fl.candidate().strategy.quantization_policy.policy_sha256,
+            reference
+                .candidate()
+                .strategy
+                .quantization_policy
+                .policy_sha256
+        );
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn opened_int8_runtime_rejects_digest_drift_cancellation_and_post_open_mutation() {
+        let (config, header, data) = runtime_fixture();
+        let path = write_fixture(&header, &data, "opened-authority");
+        let bytes = std::fs::metadata(&path).unwrap().len();
+        let wrong_digest = "00".repeat(32);
+        let digest_error = open_h3_comfy_int8_checkpoint(
+            &path,
+            config.clone(),
+            H3TransformerTask::T2VaFl2Va,
+            H3ComfyPublishedArtifact::Fl2VaPrunedInt8ConvRot,
+            Some((bytes, &wrong_digest)),
+            &H3ComfyNeverCancel,
+        )
+        .unwrap_err();
+        assert_eq!(
+            digest_error.code,
+            H3ComfyCheckpointErrorCode::ContentDigestMismatch
+        );
+
+        let cancelled = ToggleCancellation(AtomicBool::new(true));
+        let cancel_error = open_h3_comfy_int8_checkpoint(
+            &path,
+            config.clone(),
+            H3TransformerTask::T2VaFl2Va,
+            H3ComfyPublishedArtifact::Fl2VaPrunedInt8ConvRot,
+            None,
+            &cancelled,
+        )
+        .unwrap_err();
+        assert_eq!(cancel_error.code, H3ComfyCheckpointErrorCode::Cancelled);
+
+        let opened = open_h3_comfy_int8_checkpoint(
+            &path,
+            config,
+            H3TransformerTask::T2VaFl2Va,
+            H3ComfyPublishedArtifact::Fl2VaPrunedInt8ConvRot,
+            None,
+            &H3ComfyNeverCancel,
+        )
+        .unwrap();
+        let mut mutable = std::fs::OpenOptions::new().write(true).open(&path).unwrap();
+        mutable.seek(SeekFrom::End(-1)).unwrap();
+        mutable.write_all(&[1]).unwrap();
+        mutable.sync_all().unwrap();
+        let error = opened.load(&Device::Cpu).unwrap_err().to_string();
+        assert!(error.contains("changed after full verification"), "{error}");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn runtime_cancellation_is_polled_before_block_tensor_reads() -> candle::Result<()> {
+        let (config, header, data) = runtime_fixture();
+        let path = write_fixture(&header, &data, "block-cancellation");
+        let opened = open_h3_comfy_int8_checkpoint(
+            &path,
+            config.clone(),
+            H3TransformerTask::T2VaFl2Va,
+            H3ComfyPublishedArtifact::Fl2VaPrunedInt8ConvRot,
+            None,
+            &H3ComfyNeverCancel,
+        )
+        .map_err(|error| candle::Error::Msg(error.to_string()))?;
+        let cancellation = Arc::new(ToggleCancellation::default());
+        let attention = H3AttentionRuntimeAuthority::bounded_synthetic_math(
+            H3AttentionDevice::Cpu,
+            H3AttentionModelContract {
+                heads: config.num_attention_heads,
+                head_dim: config.attention_head_dim,
+                dtype: H3AttentionDType::Bf16,
+            },
+        )
+        .map_err(|error| candle::Error::Msg(error.to_string()))?;
+        let (_transformer, mut loader) = opened.load_with_attention_and_cancellation(
+            &Device::Cpu,
+            attention,
+            cancellation.clone(),
+        )?;
+        cancellation.0.store(true, AtomicOrdering::Relaxed);
+        let before = loader.bytes_read();
+        let error = loader.load_block(0).unwrap_err().to_string();
+        assert!(error.contains("cancelled"), "{error}");
+        assert_eq!(loader.bytes_read(), before);
+        assert_eq!(loader.live_block_count(), 0);
+        let _ = std::fs::remove_file(path);
+        Ok(())
     }
 
     #[test]

--- a/crates/mold-candle/src/minimax_h3/comfy_quant.rs
+++ b/crates/mold-candle/src/minimax_h3/comfy_quant.rs
@@ -166,6 +166,23 @@ fn regular_hadamard(device: &Device) -> Result<Tensor> {
     )
 }
 
+/// Match `torch.round`: nearest integer with half-way values rounded to even.
+///
+/// Candle's built-in `round` follows Rust/C `round` and sends half-way values
+/// away from zero. Comfy's dynamic INT8 QDQ uses PyTorch's ties-to-even rule,
+/// so that primitive is not source-equivalent at exact half steps.
+fn round_ties_even(input: &Tensor) -> Result<Tensor> {
+    ensure_floating(input.dtype(), "ties-to-even input")?;
+    let lower = input.floor()?;
+    let fraction = input.broadcast_sub(&lower)?;
+    let greater_than_half = fraction.gt(0.5)?.to_dtype(input.dtype())?;
+    let exactly_half = fraction.eq(0.5)?.to_dtype(input.dtype())?;
+    let even_below = lower.affine(0.5, 0.0)?.floor()?.affine(2.0, 0.0)?;
+    let odd_lower = lower.broadcast_sub(&even_below)?;
+    let increment = greater_than_half.broadcast_add(&exactly_half.broadcast_mul(&odd_lower)?)?;
+    lower.broadcast_add(&increment)
+}
+
 /// CPU-backed per-tensor FP8-E4M3 linear used by Comfy's scaled H3 DiT.
 ///
 /// Both scales use the source convention, not its reciprocal:
@@ -627,11 +644,10 @@ impl H3ComfyInt8ConvRotLinear {
             .affine(1.0 / 127.0, 0.0)?
             .clamp(1e-30f32, f32::MAX)?;
         // comfy-kitchen casts the F32 scale back to the activation dtype for
-        // the division before rounding to nearest (ties-to-even in both
-        // PyTorch and Candle) and clamping to the signed-I8 interval.
-        let quantized_input = rotated
-            .broadcast_div(&input_scale.to_dtype(input_dtype)?)?
-            .round_to(0)?
+        // the division before PyTorch's ties-to-even rounding and clamping to
+        // the signed-I8 interval.
+        let scaled_input = rotated.broadcast_div(&input_scale.to_dtype(input_dtype)?)?;
+        let quantized_input = round_ties_even(&scaled_input)?
             .clamp(-128.0f32, 127.0f32)?
             .to_dtype(DType::F32)?;
         let mut chunks = Vec::new();
@@ -1351,6 +1367,30 @@ mod tests {
     }
 
     #[test]
+    fn ties_to_even_rounding_matches_pytorch_half_step_contract() -> Result<()> {
+        let input = Tensor::new(
+            &[-3.5f32, -2.5, -1.5, -0.5, 0.5, 1.5, 2.5, 3.5],
+            &Device::Cpu,
+        )?;
+        let expected = vec![-4.0, -2.0, -2.0, 0.0, 0.0, 2.0, 2.0, 4.0];
+        for dtype in [DType::F32, DType::F16, DType::BF16] {
+            assert_eq!(
+                round_ties_even(&input.to_dtype(dtype)?)?
+                    .to_dtype(DType::F32)?
+                    .to_vec1::<f32>()?,
+                expected,
+                "ties-to-even mismatch for {dtype:?}"
+            );
+        }
+        assert_ne!(
+            input.round()?.to_vec1::<f32>()?,
+            round_ties_even(&input)?.to_vec1::<f32>()?,
+            "the regression must distinguish Candle's half-away-from-zero primitive"
+        );
+        Ok(())
+    }
+
+    #[test]
     fn int8_convrot_forward_matches_explicit_dequantized_weight() -> Result<()> {
         let device = Device::Cpu;
         let rows = 3;
@@ -1417,10 +1457,8 @@ mod tests {
             .max_keepdim(1)?
             .affine(1.0 / 127.0, 0.0)?
             .clamp(1e-30f32, f32::MAX)?;
-        let quantized = rotated
-            .broadcast_div(&input_scale)?
-            .round_to(0)?
-            .clamp(-128.0f32, 127.0f32)?;
+        let scaled = rotated.broadcast_div(&input_scale)?;
+        let quantized = round_ties_even(&scaled)?.clamp(-128.0f32, 127.0f32)?;
         let signed = linear.signed_rows(0, rows, &device)?;
         let expected = quantized
             .matmul(&signed.t()?.contiguous()?)?

--- a/crates/mold-candle/src/minimax_h3/comfy_quant.rs
+++ b/crates/mold-candle/src/minimax_h3/comfy_quant.rs
@@ -10,9 +10,10 @@
 //! Four representations/execution policies intentionally remain distinct:
 //!
 //! - The pruned DiT stores INT8 weights after a regular, normalized, 256-wide
-//!   ConvRot transform and carries one F32 scale per output row. A portable
-//!   forward rotates the activation in F32, streams output-row chunks, and
-//!   multiplies by the stored row scale without retaining a dense weight.
+//!   ConvRot transform and carries one F32 scale per output row. Its source
+//!   reference rotates activations in the input dtype, performs dynamic
+//!   per-row INT8 QDQ, streams output-row chunks, and applies both F32 scales
+//!   without retaining a dense weight.
 //! - The pruned DiT's scaled FP8 matrices retain E4M3 weights plus scalar F32
 //!   weight/input scales. Their reference path preserves the source QDQ order
 //!   and accumulates against bounded, reconstructed F32 weight chunks.
@@ -572,6 +573,82 @@ impl H3ComfyInt8ConvRotLinear {
                 rotated
                     .matmul(&quantized.t()?.contiguous()?)?
                     .broadcast_mul(&scales)?,
+            );
+        }
+        finish_linear(
+            chunks,
+            bias,
+            output_dtype,
+            output_shape,
+            self.out_features,
+            device,
+        )
+    }
+
+    /// Execute Comfy's source-defined INT8 ConvRot W8A8 reference order.
+    ///
+    /// Activations are rotated in their input dtype, dynamically quantized
+    /// per row with `absmax / 127`, rounded and clamped to signed INT8, then
+    /// accumulated against the checkpoint's packed signed bytes. Scales are
+    /// applied in F32 before each bounded output-row chunk is converted to the
+    /// requested output dtype. This mirrors comfy-kitchen's eager fallback
+    /// while retaining neither a dense block weight nor the full output-width
+    /// accumulator.
+    pub fn forward_reference(
+        &self,
+        input: &Tensor,
+        bias: Option<&Tensor>,
+        output_dtype: DType,
+        rows_per_chunk: usize,
+    ) -> Result<Tensor> {
+        ensure_output_dtype(output_dtype)?;
+        if rows_per_chunk == 0 {
+            candle::bail!("MiniMax H3 INT8 row chunk must be positive")
+        }
+        let device = input.device();
+        let input_dtype = input.dtype();
+        ensure_floating(input_dtype, "INT8 ConvRot activation")?;
+        let (flat, output_shape) = flattened_input(input, self.in_features)?;
+        let rows = flat.dim(0)?;
+        let groups = self.in_features / H3_COMFY_CONVROT_GROUP_SIZE;
+        let grouped_rows = rows.checked_mul(groups).ok_or_else(|| {
+            candle::Error::Msg("MiniMax H3 INT8 grouped activation rows overflow".into())
+        })?;
+        let hadamard = regular_hadamard(device)?.to_dtype(input_dtype)?;
+        let rotated = flat
+            .to_dtype(input_dtype)?
+            .reshape((grouped_rows, H3_COMFY_CONVROT_GROUP_SIZE))?
+            .matmul(&hadamard)?
+            .reshape((rows, self.in_features))?;
+        let input_scale = rotated
+            .abs()?
+            .max_keepdim(1)?
+            .to_dtype(DType::F32)?
+            .affine(1.0 / 127.0, 0.0)?
+            .clamp(1e-30f32, f32::MAX)?;
+        // comfy-kitchen casts the F32 scale back to the activation dtype for
+        // the division before rounding to nearest (ties-to-even in both
+        // PyTorch and Candle) and clamping to the signed-I8 interval.
+        let quantized_input = rotated
+            .broadcast_div(&input_scale.to_dtype(input_dtype)?)?
+            .round_to(0)?
+            .clamp(-128.0f32, 127.0f32)?
+            .to_dtype(DType::F32)?;
+        let mut chunks = Vec::new();
+        for start in (0..self.out_features).step_by(rows_per_chunk) {
+            let width = rows_per_chunk.min(self.out_features - start);
+            let quantized_weight = self.signed_rows(start, width, device)?;
+            let weight_scale = self
+                .weight_scale
+                .narrow(0, start, width)?
+                .to_device(device)?
+                .reshape((1, width))?;
+            let scale = input_scale.broadcast_mul(&weight_scale)?;
+            chunks.push(
+                quantized_input
+                    .matmul(&quantized_weight.t()?.contiguous()?)?
+                    .broadcast_mul(&scale)?
+                    .to_dtype(output_dtype)?,
             );
         }
         finish_linear(
@@ -1189,7 +1266,7 @@ mod tests {
             .map(|index| (index as f32 % 17.0 - 8.0) / 5.0)
             .collect::<Vec<_>>();
         linear
-            .forward_dequantized(
+            .forward_reference(
                 &Tensor::from_vec(input_values, (2, columns), device)?,
                 None,
                 DType::F32,
@@ -1306,6 +1383,56 @@ mod tests {
         assert!(linear
             .forward_dequantized(&input, Some(&bias), DType::F32, 0)
             .is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn int8_convrot_reference_matches_comfy_dynamic_row_qdq_order() -> Result<()> {
+        let device = Device::Cpu;
+        let rows = 3;
+        let columns = H3_COMFY_CONVROT_GROUP_SIZE;
+        let raw = (0..rows * columns)
+            .map(|index| (((index * 29 + 5) % 37) as i8 - 18).to_ne_bytes()[0])
+            .collect::<Vec<_>>();
+        let scales = Tensor::from_vec(vec![0.015625f32, 0.03125, 0.0625], (rows, 1), &device)?;
+        let linear = H3ComfyInt8ConvRotLinear::new(
+            Tensor::from_vec(raw, (rows, columns), &device)?,
+            scales.clone(),
+        )?;
+        let input = Tensor::from_vec(
+            (0..2 * columns)
+                .map(|index| ((index * 13 % 97) as f32 - 48.0) / 31.0)
+                .collect::<Vec<_>>(),
+            (2, columns),
+            &device,
+        )?;
+        let actual = linear.forward_reference(&input, None, DType::F32, 2)?;
+
+        let rotated = input
+            .reshape((2, columns))?
+            .matmul(&regular_hadamard(&device)?)?
+            .reshape((2, columns))?;
+        let input_scale = rotated
+            .abs()?
+            .max_keepdim(1)?
+            .affine(1.0 / 127.0, 0.0)?
+            .clamp(1e-30f32, f32::MAX)?;
+        let quantized = rotated
+            .broadcast_div(&input_scale)?
+            .round_to(0)?
+            .clamp(-128.0f32, 127.0f32)?;
+        let signed = linear.signed_rows(0, rows, &device)?;
+        let expected = quantized
+            .matmul(&signed.t()?.contiguous()?)?
+            .broadcast_mul(&input_scale.broadcast_mul(&scales.t()?)?)?;
+        assert_eq!(max_error(&actual, &expected)?, 0.0);
+        assert!(
+            max_error(
+                &actual,
+                &linear.forward_dequantized(&input, None, DType::F32, 2)?
+            )? > 0.0,
+            "dynamic activation quantization must remain distinct from dense dequantization"
+        );
         Ok(())
     }
 

--- a/crates/mold-candle/src/minimax_h3/dit.rs
+++ b/crates/mold-candle/src/minimax_h3/dit.rs
@@ -25,6 +25,7 @@ use super::attention::{
     execute_h3_attention, H3AttentionDType, H3AttentionDevice, H3AttentionModelContract,
     H3AttentionRuntimeAuthority, H3FrozenAttentionExecution, H3FrozenAttentionPlan,
 };
+use super::comfy_quant::{H3ComfyInt8ConvRotLinear, H3_COMFY_PORTABLE_ROW_CHUNK};
 
 pub const H3_MODALITY_COUNT: usize = 3;
 
@@ -1436,6 +1437,211 @@ struct H3TransformerBlockWeights {
     adaln: H3AdaLnProjection,
 }
 
+#[derive(Clone, Debug)]
+struct H3ComfyInt8Attention {
+    heads: usize,
+    head_dim: usize,
+    inner_dim: usize,
+    qkv: H3ComfyInt8ConvRotLinear,
+    q_norm: nn::RmsNorm,
+    k_norm: nn::RmsNorm,
+    out: H3ComfyInt8ConvRotLinear,
+}
+
+impl H3ComfyInt8Attention {
+    fn forward(
+        &self,
+        hidden: &Tensor,
+        rotary: (&Tensor, &Tensor, usize),
+        attention_plan: &H3FrozenAttentionPlan,
+    ) -> Result<Tensor> {
+        let (batch, seq_len, _) = hidden.dims3()?;
+        let qkv = self.qkv.forward_reference(
+            hidden,
+            None,
+            hidden.dtype(),
+            H3_COMFY_PORTABLE_ROW_CHUNK,
+        )?;
+        let q = qkv.narrow(2, 0, self.inner_dim)?;
+        let k = qkv.narrow(2, self.inner_dim, self.inner_dim)?;
+        let v = qkv.narrow(2, 2 * self.inner_dim, self.inner_dim)?;
+        let mut q = q
+            .reshape((batch, seq_len, self.heads, self.head_dim))?
+            .contiguous()?;
+        let mut k = k
+            .reshape((batch, seq_len, self.heads, self.head_dim))?
+            .contiguous()?;
+        let v = v
+            .reshape((batch, seq_len, self.heads, self.head_dim))?
+            .contiguous()?;
+        q = self.q_norm.forward(&q)?;
+        k = self.k_norm.forward(&k)?;
+        q = apply_h3_rotary(&q, rotary.0, rotary.1, rotary.2)?;
+        k = apply_h3_rotary(&k, rotary.0, rotary.1, rotary.2)?;
+        let output = execute_h3_attention(attention_plan, &q, &k, &v)
+            .map_err(|error| candle::Error::Msg(error.to_string()))?
+            .reshape((batch, seq_len, self.inner_dim))?;
+        self.out
+            .forward_reference(&output, None, hidden.dtype(), H3_COMFY_PORTABLE_ROW_CHUNK)
+    }
+}
+
+#[derive(Clone, Debug)]
+struct H3ComfyInt8Mlp {
+    width: usize,
+    fc1: H3ComfyInt8ConvRotLinear,
+    fc2: H3ComfyInt8ConvRotLinear,
+}
+
+impl H3ComfyInt8Mlp {
+    fn forward(&self, hidden: &Tensor) -> Result<Tensor> {
+        let projected = self.fc1.forward_reference(
+            hidden,
+            None,
+            hidden.dtype(),
+            H3_COMFY_PORTABLE_ROW_CHUNK,
+        )?;
+        let gate = projected.narrow(D::Minus1, 0, self.width)?;
+        let up = projected.narrow(D::Minus1, self.width, self.width)?;
+        self.fc2.forward_reference(
+            &silu(&gate)?.broadcast_mul(&up)?,
+            None,
+            hidden.dtype(),
+            H3_COMFY_PORTABLE_ROW_CHUNK,
+        )
+    }
+}
+
+#[derive(Clone, Debug)]
+struct H3ComfyInt8TransformerBlockWeights {
+    norm1: nn::RmsNorm,
+    attention: H3ComfyInt8Attention,
+    norm2: nn::RmsNorm,
+    mlp: H3ComfyInt8Mlp,
+    adaln: H3AdaLnProjection,
+}
+
+/// Exact CPU-packed matrices for one Comfy INT8 ConvRot main block.
+///
+/// This stays crate-private so the public streamed block handle remains the
+/// only execution representation exposed to inference consumers.
+pub(super) struct H3ComfyInt8BlockMatrices {
+    pub qkv: H3ComfyInt8ConvRotLinear,
+    pub out: H3ComfyInt8ConvRotLinear,
+    pub fc1: H3ComfyInt8ConvRotLinear,
+    pub fc2: H3ComfyInt8ConvRotLinear,
+}
+
+impl H3ComfyInt8TransformerBlockWeights {
+    fn load(
+        config: &H3TransformerConfig,
+        mode: H3AdaLnMode,
+        precision: H3PrecisionProfile,
+        matrices: H3ComfyInt8BlockMatrices,
+        vb: VarBuilder,
+    ) -> Result<Self> {
+        let compute_dtype = precision.compute_dtype();
+        if !matches!(mode, H3AdaLnMode::Curve { .. }) || mode.qkv_layout() != H3QkvLayout::QkvMajor
+        {
+            candle::bail!("MiniMax H3 Comfy INT8 blocks require pruned Curve AdaLN/QKV-major mode")
+        }
+        let inner_dim = config.attention_inner_dim();
+        if matrices.qkv.in_features() != config.hidden_size
+            || matrices.qkv.out_features() != 3 * inner_dim
+            || matrices.out.in_features() != inner_dim
+            || matrices.out.out_features() != config.hidden_size
+            || matrices.fc1.in_features() != config.hidden_size
+            || matrices.fc1.out_features() != 2 * config.ffn_hidden_size
+            || matrices.fc2.in_features() != config.ffn_hidden_size
+            || matrices.fc2.out_features() != config.hidden_size
+        {
+            candle::bail!(
+                "MiniMax H3 Comfy INT8 block matrix shapes do not match the frozen config"
+            )
+        }
+        Ok(Self {
+            norm1: rms_norm_with_dtype(
+                config.hidden_size,
+                config.norm_eps,
+                compute_dtype,
+                vb.pp("norm1"),
+            )?,
+            attention: H3ComfyInt8Attention {
+                heads: config.num_attention_heads,
+                head_dim: config.attention_head_dim,
+                inner_dim,
+                qkv: matrices.qkv,
+                q_norm: rms_norm_with_dtype(
+                    config.attention_head_dim,
+                    config.qk_norm_eps,
+                    compute_dtype,
+                    vb.pp("attn.q_norm"),
+                )?,
+                k_norm: rms_norm_with_dtype(
+                    config.attention_head_dim,
+                    config.qk_norm_eps,
+                    compute_dtype,
+                    vb.pp("attn.k_norm"),
+                )?,
+                out: matrices.out,
+            },
+            norm2: rms_norm_with_dtype(
+                config.hidden_size,
+                config.norm_eps,
+                compute_dtype,
+                vb.pp("norm2"),
+            )?,
+            mlp: H3ComfyInt8Mlp {
+                width: config.ffn_hidden_size,
+                fc1: matrices.fc1,
+                fc2: matrices.fc2,
+            },
+            // Curve projections are a source-defined FP32-sensitive island.
+            adaln: H3AdaLnProjection::load(
+                mode.input_dim(config),
+                config.hidden_size,
+                6,
+                H3_MODALITY_COUNT,
+                DType::F32,
+                vb.pp("adaln_proj"),
+            )?,
+        })
+    }
+
+    fn forward(
+        &self,
+        hidden: &Tensor,
+        adaln_input: &Tensor,
+        adaln_indices: &Tensor,
+        rotary: (&Tensor, &Tensor, usize),
+        attention_plan: &H3FrozenAttentionPlan,
+    ) -> Result<Tensor> {
+        let parameters = self.adaln.forward(adaln_input)?;
+        let [shift_attention, scale_attention, gate_attention, shift_mlp, scale_mlp, gate_mlp]:
+            [Tensor; 6] = parameters.try_into().map_err(|_| {
+                candle::Error::Msg("MiniMax H3 block AdaLN must produce six tensors".into())
+            })?;
+        let normalized = modulate(
+            &self.norm1.forward(hidden)?,
+            &shift_attention,
+            &scale_attention,
+            adaln_indices,
+        )?;
+        let update = self
+            .attention
+            .forward(&normalized, rotary, attention_plan)?;
+        let hidden = gated_residual(hidden, &update, &gate_attention, adaln_indices)?;
+        let normalized = modulate(
+            &self.norm2.forward(&hidden)?,
+            &shift_mlp,
+            &scale_mlp,
+            adaln_indices,
+        )?;
+        let update = self.mlp.forward(&normalized)?;
+        gated_residual(&hidden, &update, &gate_mlp, adaln_indices)
+    }
+}
+
 impl H3TransformerBlockWeights {
     fn load(
         config: &H3TransformerConfig,
@@ -1517,6 +1723,7 @@ impl H3TransformerBlockWeights {
 #[derive(Clone, Debug)]
 enum H3TransformerBlockRepresentation {
     Dense(H3TransformerBlockWeights),
+    ComfyInt8ConvRot(H3ComfyInt8TransformerBlockWeights),
 }
 
 impl H3TransformerBlockRepresentation {
@@ -1530,6 +1737,9 @@ impl H3TransformerBlockRepresentation {
     ) -> Result<Tensor> {
         match self {
             Self::Dense(block) => {
+                block.forward(hidden, adaln_input, adaln_indices, rotary, attention_plan)
+            }
+            Self::ComfyInt8ConvRot(block) => {
                 block.forward(hidden, adaln_input, adaln_indices, rotary, attention_plan)
             }
         }
@@ -1754,11 +1964,26 @@ pub struct H3TransformerOutput {
 }
 
 #[derive(Debug)]
-struct H3StreamedTransformerIdentity {
+pub(super) struct H3StreamedTransformerIdentity {
     task: H3TransformerTask,
     attention_identity_sha256: String,
+    checkpoint_identity_sha256: Option<String>,
     block_count: usize,
     live_blocks: AtomicUsize,
+}
+
+impl H3StreamedTransformerIdentity {
+    pub(super) fn task(&self) -> H3TransformerTask {
+        self.task
+    }
+
+    pub(super) fn block_count(&self) -> usize {
+        self.block_count
+    }
+
+    pub(super) fn live_block_count(&self) -> usize {
+        self.live_blocks.load(Ordering::Relaxed)
+    }
 }
 
 /// One independently owned main DiT block.
@@ -1795,6 +2020,25 @@ impl H3LoadedTransformerBlock {
             identity,
             representation: H3TransformerBlockRepresentation::Dense(block),
         }
+    }
+
+    pub(super) fn new_comfy_int8(
+        index: usize,
+        identity: Arc<H3StreamedTransformerIdentity>,
+        config: &H3TransformerConfig,
+        mode: H3AdaLnMode,
+        precision: H3PrecisionProfile,
+        matrices: H3ComfyInt8BlockMatrices,
+        vb: VarBuilder,
+    ) -> Result<Self> {
+        let block =
+            H3ComfyInt8TransformerBlockWeights::load(config, mode, precision, matrices, vb)?;
+        identity.live_blocks.fetch_add(1, Ordering::Relaxed);
+        Ok(Self {
+            index,
+            identity,
+            representation: H3TransformerBlockRepresentation::ComfyInt8ConvRot(block),
+        })
     }
 
     fn clone_for_eager(&self) -> Self {
@@ -1951,6 +2195,9 @@ impl H3TransformerStep {
         if block.identity.attention_identity_sha256 != self.identity.attention_identity_sha256 {
             candle::bail!("MiniMax H3 streamed block attention authority does not match the step")
         }
+        if block.identity.checkpoint_identity_sha256 != self.identity.checkpoint_identity_sha256 {
+            candle::bail!("MiniMax H3 streamed block checkpoint authority does not match the step")
+        }
         if !Arc::ptr_eq(&block.identity, &self.identity) {
             candle::bail!(
                 "MiniMax H3 streamed block belongs to a different audited checkpoint load"
@@ -2023,7 +2270,41 @@ impl H3StreamedTransformer {
         } = checkpoint;
         debug_assert_eq!(source.inventory.component, plan.component);
         let vb = source.vb;
-        let compute_dtype = plan.precision.compute_dtype();
+        for key in plan.expected.keys() {
+            if !vb.contains_tensor(key) {
+                candle::bail!("MiniMax H3 audited tensor {key:?} is absent from the loader")
+            }
+        }
+        let transformer = Self::load_resident(
+            config.clone(),
+            plan.task,
+            plan.mode,
+            plan.precision,
+            vb.clone(),
+            attention_runtime,
+            None,
+        )?;
+        let loader = H3TransformerBlockLoader {
+            config,
+            mode: plan.mode,
+            precision: plan.precision,
+            vb,
+            identity: transformer.identity.clone(),
+        };
+        Ok((transformer, loader))
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn load_resident(
+        config: H3TransformerConfig,
+        task: H3TransformerTask,
+        mode: H3AdaLnMode,
+        precision: H3PrecisionProfile,
+        vb: VarBuilder,
+        attention_runtime: H3AttentionRuntimeAuthority,
+        checkpoint_identity_sha256: Option<String>,
+    ) -> Result<Self> {
+        let compute_dtype = precision.compute_dtype();
         attention_runtime
             .verify_model(
                 H3AttentionModelContract {
@@ -2035,15 +2316,10 @@ impl H3StreamedTransformer {
                 vb.device(),
             )
             .map_err(|error| candle::Error::Msg(error.to_string()))?;
-        for key in plan.expected.keys() {
-            if !vb.contains_tensor(key) {
-                candle::bail!("MiniMax H3 audited tensor {key:?} is absent from the loader")
-            }
-        }
-
         let identity = Arc::new(H3StreamedTransformerIdentity {
-            task: plan.task,
+            task,
             attention_identity_sha256: attention_runtime.identity_sha256().to_owned(),
+            checkpoint_identity_sha256,
             block_count: config.num_layers,
             live_blocks: AtomicUsize::new(0),
         });
@@ -2051,21 +2327,14 @@ impl H3StreamedTransformer {
         for index in 0..config.token_refiner_num_layers {
             token_refiner.push(H3TokenRefinerBlock::load(
                 &config,
-                plan.qkv_layout(),
+                mode.qkv_layout(),
                 compute_dtype,
                 vb.pp(format!("token_refiner.blocks.{index}")),
             )?);
         }
-        let loader = H3TransformerBlockLoader {
-            config: config.clone(),
-            mode: plan.mode,
-            precision: plan.precision,
-            vb: vb.clone(),
-            identity: identity.clone(),
-        };
-        let transformer = Self {
-            mode: plan.mode,
-            precision: plan.precision,
+        Ok(Self {
+            mode,
+            precision,
             attention_runtime,
             video_projection: linear_with_dtype(
                 config.video_patch_dim(),
@@ -2088,7 +2357,7 @@ impl H3StreamedTransformer {
                 compute_dtype,
                 vb.pp("condition_proj"),
             )?,
-            time: H3TimeConditioner::load(&config, plan.mode, vb.clone())?,
+            time: H3TimeConditioner::load(&config, mode, vb.clone())?,
             rope: H3Rope::load(&config, vb.pp("rope"))?,
             token_refiner,
             token_refiner_norm: rms_norm_with_dtype(
@@ -2097,16 +2366,42 @@ impl H3StreamedTransformer {
                 compute_dtype,
                 vb.pp("token_refiner.final_norm"),
             )?,
-            final_layer: H3FinalLayer::load(
-                &config,
-                plan.mode,
-                plan.precision,
-                vb.pp("final_layer"),
-            )?,
+            final_layer: H3FinalLayer::load(&config, mode, precision, vb.pp("final_layer"))?,
             config,
             identity,
-        };
-        Ok((transformer, loader))
+        })
+    }
+
+    /// Internal constructor for the source-pinned Comfy INT8 checkpoint
+    /// primitive. It is intentionally not a factory registration or public
+    /// runtime activation path.
+    pub(super) fn load_comfy_int8_resident(
+        config: H3TransformerConfig,
+        task: H3TransformerTask,
+        mode: H3AdaLnMode,
+        precision: H3PrecisionProfile,
+        vb: VarBuilder<'static>,
+        attention_runtime: H3AttentionRuntimeAuthority,
+        checkpoint_identity_sha256: String,
+    ) -> Result<Self> {
+        if !matches!(mode, H3AdaLnMode::Curve { .. })
+            || precision != H3PrecisionProfile::OfficialMixedBf16F32
+        {
+            candle::bail!("MiniMax H3 Comfy INT8 resident core requires the official pruned mixed-precision profile")
+        }
+        Self::load_resident(
+            config,
+            task,
+            mode,
+            precision,
+            vb,
+            attention_runtime,
+            Some(checkpoint_identity_sha256),
+        )
+    }
+
+    pub(super) fn streamed_identity(&self) -> Arc<H3StreamedTransformerIdentity> {
+        self.identity.clone()
     }
 
     pub fn task(&self) -> H3TransformerTask {
@@ -2131,6 +2426,12 @@ impl H3StreamedTransformer {
 
     pub fn block_count(&self) -> usize {
         self.identity.block_count
+    }
+
+    /// Exact schema/policy/content identity when this resident core came from
+    /// an opened Comfy INT8 authority. Dense audited sources remain `None`.
+    pub fn checkpoint_identity_sha256(&self) -> Option<&str> {
+        self.identity.checkpoint_identity_sha256.as_deref()
     }
 
     pub fn live_block_count(&self) -> usize {
@@ -3178,6 +3479,123 @@ mod tests {
     }
 
     #[test]
+    fn comfy_int8_block_matches_its_exact_dense_dequantized_oracle() -> Result<()> {
+        let device = Device::Cpu;
+        let config = H3TransformerConfig {
+            hidden_size: 256,
+            num_layers: 1,
+            token_refiner_num_layers: 1,
+            num_attention_heads: 2,
+            attention_head_dim: 128,
+            ffn_hidden_size: 256,
+            video_latent_channels: 64,
+            audio_latent_channels: 256,
+            patch_size: [1, 2, 2],
+            text_dim: 256,
+            timestep_input_dim: 64,
+            time_embed_hidden_size: 256,
+            time_embed_dim: 128,
+            rope_inv_freq_len: 16,
+            norm_eps: 1e-5,
+            qk_norm_eps: 1e-5,
+            final_norm_eps: 1e-5,
+        };
+        let mode = H3AdaLnMode::Curve {
+            grid: 5,
+            basis_dim: 64,
+        };
+        let precision = H3PrecisionProfile::SyntheticF32;
+        let specs = expected_h3_weight_specs(&config, mode, precision)?;
+        let mut tensors = tensor_map(&specs, &device)?;
+
+        let quantized = |out_features: usize,
+                         in_features: usize,
+                         seed: usize|
+         -> Result<(H3ComfyInt8ConvRotLinear, Tensor)> {
+            let raw = (0..out_features * in_features)
+                .map(|index| {
+                    let signed = ((index.wrapping_mul(17).wrapping_add(seed)) % 7) as i8 - 3;
+                    signed.to_ne_bytes()[0]
+                })
+                .collect::<Vec<_>>();
+            let scales = (0..out_features)
+                .map(|row| 0.003 + ((row + seed) % 11) as f32 * 0.0001)
+                .collect::<Vec<_>>();
+            let linear = H3ComfyInt8ConvRotLinear::new(
+                Tensor::from_vec(raw, (out_features, in_features), &device)?,
+                Tensor::from_vec(scales, (out_features, 1), &device)?,
+            )?;
+            let dense = linear.dequantize_weight(DType::F32, &device, 256)?;
+            Ok((linear, dense))
+        };
+        let inner = config.attention_inner_dim();
+        let (qkv, qkv_dense) = quantized(3 * inner, config.hidden_size, 1)?;
+        let (out, out_dense) = quantized(config.hidden_size, inner, 2)?;
+        let (fc1, fc1_dense) = quantized(2 * config.ffn_hidden_size, config.hidden_size, 3)?;
+        let (fc2, fc2_dense) = quantized(config.hidden_size, config.ffn_hidden_size, 4)?;
+        tensors.insert("blocks.0.attn.qkv_proj.weight".into(), qkv_dense);
+        tensors.insert("blocks.0.attn.out_proj.weight".into(), out_dense);
+        tensors.insert("blocks.0.mlp.fc1.weight".into(), fc1_dense);
+        tensors.insert("blocks.0.mlp.fc2.weight".into(), fc2_dense);
+        let vb = VarBuilder::from_tensors(tensors, DType::F32, &device);
+        let dense = H3TransformerBlockWeights::load(&config, mode, precision, vb.pp("blocks.0"))?;
+        let quant = H3ComfyInt8TransformerBlockWeights::load(
+            &config,
+            mode,
+            precision,
+            H3ComfyInt8BlockMatrices { qkv, out, fc1, fc2 },
+            vb.pp("blocks.0"),
+        )?;
+
+        let hidden = Tensor::from_vec(
+            (0..3 * config.hidden_size)
+                .map(|index| index as f32 / 997.0 - 0.35)
+                .collect::<Vec<_>>(),
+            (1, 3, config.hidden_size),
+            &device,
+        )?;
+        let adaln_input = Tensor::from_vec(
+            (0..64)
+                .map(|index| index as f32 / 211.0 - 0.1)
+                .collect::<Vec<_>>(),
+            (1, 64),
+            &device,
+        )?;
+        let adaln_indices = Tensor::new(&[0u32, 1, 2], &device)?;
+        let rotary_dim = 6 * config.rope_inv_freq_len;
+        let cos = Tensor::ones((3, rotary_dim), DType::F32, &device)?;
+        let sin = Tensor::zeros((3, rotary_dim), DType::F32, &device)?;
+        let authority = H3AttentionRuntimeAuthority::bounded_synthetic_math(
+            H3AttentionDevice::Cpu,
+            H3AttentionModelContract {
+                heads: config.num_attention_heads,
+                head_dim: config.attention_head_dim,
+                dtype: H3AttentionDType::F32,
+            },
+        )
+        .map_err(|error| candle::Error::Msg(error.to_string()))?;
+        let plan = authority
+            .freeze_execution(1, 3, 3)
+            .map_err(|error| candle::Error::Msg(error.to_string()))?
+            .packed_transformer;
+        let expected = dense.forward(
+            &hidden,
+            &adaln_input,
+            &adaln_indices,
+            (&cos, &sin, rotary_dim),
+            &plan,
+        )?;
+        let actual = quant.forward(
+            &hidden,
+            &adaln_input,
+            &adaln_indices,
+            (&cos, &sin, rotary_dim),
+            &plan,
+        )?;
+        assert_close(&expected, &actual, 2e-4)
+    }
+
+    #[test]
     fn full_tiny_stack_runs_both_heads_deterministically() -> Result<()> {
         let device = Device::Cpu;
         let model = load_tiny(
@@ -3389,7 +3807,9 @@ mod tests {
         )?;
         assert_eq!(model.streamed.video_projection.weight().dtype(), DType::F32);
         assert_eq!(model.streamed.text_projection.weight().dtype(), DType::BF16);
-        let H3TransformerBlockRepresentation::Dense(first) = &model.blocks[0].representation;
+        let H3TransformerBlockRepresentation::Dense(first) = &model.blocks[0].representation else {
+            panic!("eager audited checkpoint must retain dense blocks")
+        };
         assert_eq!(first.attention.qkv.weight().dtype(), DType::BF16);
         assert_eq!(first.adaln.linear.weight().dtype(), DType::BF16);
         assert_eq!(

--- a/crates/mold-candle/src/minimax_h3/mod.rs
+++ b/crates/mold-candle/src/minimax_h3/mod.rs
@@ -57,9 +57,11 @@ pub use attention::{
     H3_FLASH_ATTN_QUALIFIED_COMPUTE_CAPABILITY,
 };
 pub use comfy_dit::{
-    inspect_h3_comfy_published_header, H3ComfyAccuracyTier, H3ComfyCheckpointCandidate,
-    H3ComfyCheckpointError, H3ComfyCheckpointErrorCode, H3ComfyCurveInterpolation,
-    H3ComfyFrozenStrategyMetadata, H3ComfyMemoryAccounting, H3ComfyPrunedFormat,
+    inspect_h3_comfy_published_header, open_h3_comfy_published_int8_checkpoint,
+    H3ComfyAccuracyTier, H3ComfyCheckpointCandidate, H3ComfyCheckpointError,
+    H3ComfyCheckpointErrorCode, H3ComfyCurveInterpolation, H3ComfyFrozenStrategyMetadata,
+    H3ComfyInt8BlockLoader, H3ComfyInt8BlockMemory, H3ComfyInt8Cancellation,
+    H3ComfyMemoryAccounting, H3ComfyNeverCancel, H3ComfyOpenedInt8Checkpoint, H3ComfyPrunedFormat,
     H3ComfyPublishedArtifact, H3ComfyQuantizationPolicy, H3ComfyRuntimeBackend,
     H3ComfyRuntimeRejection, H3ComfyRuntimeRequirement, H3_COMFYUI_SOURCE_REVISION,
     H3_COMFY_KITCHEN_REPOSITORY, H3_COMFY_KITCHEN_SOURCE_REVISION, H3_COMFY_KITCHEN_VERSION,


### PR DESCRIPTION
## Summary

- authenticate the exact released FL2VA/Ref2VA INT8 ConvRot artifacts from one retained file descriptor, including their metadata-free shared header, full-content digest, 932-tensor schema, and all 200 exact 72-byte `.comfy_quant` payloads
- keep resident projections, token refiner, Curve AdaLN table, and output heads while loading exactly one CPU-packed main block at a time behind the opaque streamed-block authority
- execute Comfy dynamic row QDQ with explicit PyTorch-compatible ties-to-even rounding, signed INT8 widening, F32 scales, bounded row staging, and strict block-drop/cancellation accounting
- authorize only the 102 released F16 Curve-AdaLN storage tensors to upcast into logical F32 computation and charge the logical device bytes
- add a release-unregistered CUDA qualification example plus dense-dequant, source-QDQ, mutation, sidecar, F16, cancellation, memory, and identity tests

## Safety boundary

- no engine factory, capability, catalog, download, CLI, server, or release activation
- public candidates remain rejected by the existing runtime gate; both real qualification reports record `factory_activated: false`
- no artifact or model data is committed or distributed

## Exact-head validation

Current head `f070f95f849cda3ff9e0943967025591f0363177` on `d7bdbe8a10c5a9abb4f5ba8a1ef2876992b44852`:

- `nix develop --no-write-lock-file -c cargo test -p mold-ai-candle` (167 passed, 1 separately authorized-artifact test ignored)
- `nix develop --no-write-lock-file -c cargo clippy -p mold-ai-candle --all-targets -- -D warnings`
- `nix develop --no-write-lock-file -c cargo check -p mold-ai-inference`
- `nix develop --no-write-lock-file -c cargo fmt --all -- --check`
- child-range stable patch id `c6fb57f67cd9f84b818b9f84b5fcdbee4bb41820`, identical to the L40S-qualified rehearsal range
- each replayed child commit also retains its stable patch id (`c6feafd2...`, `130d64fb...`, `8d8ef699...`)
- zero PR comments, reviews, or unresolved threads

## Authorized L40S qualification

Both released 20.97 GB checkpoints passed full retained-descriptor authentication and isolated CUDA block-0 execution:

- FL2VA content SHA-256 `e889202c41dafb67b10d67b97f0d8541508036a6090af23425a5c2615d03c47a`; checkpoint identity `9c9041bf4801a736d44f4d7ac8814846c40a65774ace13307f32ccf675166824`
- Ref2VA content SHA-256 `9255f52b6677845ad238f20dfaafa94727053694127ab7f255c048f0f9365779`; checkpoint identity `a949053ecbdc5c49a14dab6671926e59fefa5c679a5b2cf9941f9c490514f51e`
- shared header identity `8232b3c428e54591c286b5eee3eaba840f03d2cd2cb359ec09dd2558974ddc74`, 932 tensors, 200 validated sidecars, policy `1505033d21cf4e2eafbc1bee47faf25050df7ee880d511920fa22772e8b97871`
- each run performed exactly 4 authorized F16-to-F32 loads for resident final-layer plus block-0 Curve-AdaLN, executed one block, and returned to 0 live blocks
- measured block accounting: 385,595,392 encoded host bytes; 154,140,672 max host read staging; 14,680,064 max device staging; 3,505,664 protected device bytes

Advances #839.