### PR TITLE
feat(h3): load Qwen NVFP4 runtime

### DIFF
--- a/crates/mold-candle/src/minimax_h3/mod.rs
+++ b/crates/mold-candle/src/minimax_h3/mod.rs
@@ -15,6 +15,10 @@ mod model;
 mod presentation;
 mod processor;
 mod qwen_nvfp4;
+// The private-artifact runtime is intentionally not wired into a public
+// factory until the separate compliance activation lands.
+#[allow(dead_code)]
+mod qwen_nvfp4_runtime;
 mod qwen_quant;
 mod text;
 mod vision;

--- a/crates/mold-candle/src/minimax_h3/model.rs
+++ b/crates/mold-candle/src/minimax_h3/model.rs
@@ -3,7 +3,7 @@ use candle_nn::VarBuilder;
 
 use super::artifacts::ConditionerWeightLayout;
 use super::config::{H3ConditionerConfig, H3_SELECTED_LANGUAGE_LAYERS};
-use super::text::{Qwen3VlTextDimensions, Qwen3VlTextEncoder};
+use super::text::{Qwen3VlNvfp4Weights, Qwen3VlTextDimensions, Qwen3VlTextEncoder};
 use super::vision::{Qwen3VlVisionDimensions, Qwen3VlVisionModel};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -104,89 +104,155 @@ impl H3Layer50Conditioner {
         input: &H3ConditionerInput,
         checkpoint: &mut dyn FnMut(ConditionerCheckpoint) -> Result<()>,
     ) -> Result<Tensor> {
-        let (input_batch, input_sequence) = input.input_ids.dims2()?;
-        if input_batch != 1 {
-            candle::bail!(
-                "H3 conditioner accepts one packed presentation, got batch {input_batch}"
-            );
-        }
-        if input_sequence == 0 {
-            candle::bail!(
-                "the raw H3 presentation tokenized to an empty sequence; no special token is inserted"
-            );
-        }
-        checkpoint(ConditionerCheckpoint::TokenEmbedding)?;
-        let mut embeddings = self.text.embed_tokens(&input.input_ids)?;
-        let (batch, sequence, hidden) = embeddings.dims3()?;
-        if input.position_ids.dims() != [3, batch, sequence] {
-            candle::bail!(
-                "H3 Qwen position ids have shape {:?}, expected ({}, {}, {})",
-                input.position_ids.dims(),
-                3,
-                batch,
-                sequence
-            );
-        }
-
-        let mut image_deepstack = None;
-        let mut video_deepstack = None;
-        let mut image_indices = Vec::new();
-        let mut video_indices = Vec::new();
-
-        if let Some(image) = &input.image {
-            let (features, deepstack) =
-                self.vision
-                    .forward(&image.pixel_values, &image.grid_thw, checkpoint)?;
-            image_indices = matching_token_indices(&input.input_ids, 151_655)?;
-            embeddings = replace_rows(
-                &embeddings,
-                &image_indices,
-                &features
-                    .to_device(embeddings.device())?
-                    .to_dtype(embeddings.dtype())?,
-                hidden,
-            )?;
-            image_deepstack = Some(deepstack);
-        }
-        if let Some(video) = &input.video {
-            let (features, deepstack) =
-                self.vision
-                    .forward(&video.pixel_values, &video.grid_thw, checkpoint)?;
-            video_indices = matching_token_indices(&input.input_ids, 151_656)?;
-            embeddings = replace_rows(
-                &embeddings,
-                &video_indices,
-                &features
-                    .to_device(embeddings.device())?
-                    .to_dtype(embeddings.dtype())?,
-                hidden,
-            )?;
-            video_deepstack = Some(deepstack);
-        }
-
-        if input.image.is_none() && !matching_token_indices(&input.input_ids, 151_655)?.is_empty() {
-            candle::bail!("H3 presentation contains image pads without image processor tensors");
-        }
-        if input.video.is_none() && !matching_token_indices(&input.input_ids, 151_656)?.is_empty() {
-            candle::bail!("H3 presentation contains video pads without video processor tensors");
-        }
-
-        let (visual_indices, deepstack) = merge_deepstack(
-            embeddings.device(),
-            embeddings.dtype(),
-            image_indices,
-            image_deepstack,
-            video_indices,
-            video_deepstack,
-        )?;
-        self.text.forward_embeds(
-            embeddings,
-            &input.position_ids,
-            &visual_indices,
-            deepstack.as_deref(),
-            checkpoint,
-        )
+        encode_conditioner(&self.text, &self.vision, input, checkpoint)
     }
+}
+
+/// Internal mixed-storage conditioner for the authenticated Comfy Qwen
+/// NVFP4-AWQ object. It is not registered with any Mold engine or capability.
+#[allow(dead_code)]
+pub(super) struct H3QwenNvfp4Layer50Conditioner {
+    text: Qwen3VlTextEncoder,
+    vision: Qwen3VlVisionModel,
+    dtype_profile: H3DTypeProfile,
+}
+
+#[allow(dead_code)]
+impl H3QwenNvfp4Layer50Conditioner {
+    pub(super) fn new(
+        config: &H3ConditionerConfig,
+        dense_vb: VarBuilder,
+        text_weights: Qwen3VlNvfp4Weights,
+    ) -> Result<Self> {
+        config
+            .validate()
+            .map_err(|error| candle::Error::Msg(error.to_string()))?;
+        let vision_dimensions = Qwen3VlVisionDimensions::from_h3(config);
+        let text_dimensions = Qwen3VlTextDimensions::from_h3(config);
+        let parameter_dtype = dense_vb.dtype();
+        let vision = Qwen3VlVisionModel::new(&vision_dimensions, dense_vb.pp("visual"))?;
+        let text =
+            Qwen3VlTextEncoder::new_nvfp4(&text_dimensions, dense_vb.pp("model"), text_weights)?;
+        Ok(Self {
+            text,
+            vision,
+            dtype_profile: H3DTypeProfile {
+                parameter_dtype,
+                vision_input_dtype: DType::F32,
+                rotary_compute_dtype: DType::F32,
+                vision_attention_dtype: parameter_dtype,
+                language_attention_dtype: parameter_dtype,
+                attention_softmax_dtype: DType::F32,
+                output_dtype: parameter_dtype,
+            },
+        })
+    }
+
+    pub fn dtype_profile(&self) -> H3DTypeProfile {
+        self.dtype_profile
+    }
+
+    pub fn resident_language_layers(&self) -> usize {
+        self.text.layer_count()
+    }
+
+    pub fn encode(
+        &self,
+        input: &H3ConditionerInput,
+        checkpoint: &mut dyn FnMut(ConditionerCheckpoint) -> Result<()>,
+    ) -> Result<Tensor> {
+        encode_conditioner(&self.text, &self.vision, input, checkpoint)
+    }
+
+    pub(crate) fn embed_tokens(&self, input_ids: &Tensor) -> Result<Tensor> {
+        self.text.embed_tokens(input_ids)
+    }
+}
+
+fn encode_conditioner(
+    text: &Qwen3VlTextEncoder,
+    vision: &Qwen3VlVisionModel,
+    input: &H3ConditionerInput,
+    checkpoint: &mut dyn FnMut(ConditionerCheckpoint) -> Result<()>,
+) -> Result<Tensor> {
+    let (input_batch, input_sequence) = input.input_ids.dims2()?;
+    if input_batch != 1 {
+        candle::bail!("H3 conditioner accepts one packed presentation, got batch {input_batch}");
+    }
+    if input_sequence == 0 {
+        candle::bail!(
+            "the raw H3 presentation tokenized to an empty sequence; no special token is inserted"
+        );
+    }
+    checkpoint(ConditionerCheckpoint::TokenEmbedding)?;
+    let mut embeddings = text.embed_tokens(&input.input_ids)?;
+    let (batch, sequence, hidden) = embeddings.dims3()?;
+    if input.position_ids.dims() != [3, batch, sequence] {
+        candle::bail!(
+            "H3 Qwen position ids have shape {:?}, expected ({}, {}, {})",
+            input.position_ids.dims(),
+            3,
+            batch,
+            sequence
+        );
+    }
+
+    let mut image_deepstack = None;
+    let mut video_deepstack = None;
+    let mut image_indices = Vec::new();
+    let mut video_indices = Vec::new();
+
+    if let Some(image) = &input.image {
+        let (features, deepstack) =
+            vision.forward(&image.pixel_values, &image.grid_thw, checkpoint)?;
+        image_indices = matching_token_indices(&input.input_ids, 151_655)?;
+        embeddings = replace_rows(
+            &embeddings,
+            &image_indices,
+            &features
+                .to_device(embeddings.device())?
+                .to_dtype(embeddings.dtype())?,
+            hidden,
+        )?;
+        image_deepstack = Some(deepstack);
+    }
+    if let Some(video) = &input.video {
+        let (features, deepstack) =
+            vision.forward(&video.pixel_values, &video.grid_thw, checkpoint)?;
+        video_indices = matching_token_indices(&input.input_ids, 151_656)?;
+        embeddings = replace_rows(
+            &embeddings,
+            &video_indices,
+            &features
+                .to_device(embeddings.device())?
+                .to_dtype(embeddings.dtype())?,
+            hidden,
+        )?;
+        video_deepstack = Some(deepstack);
+    }
+
+    if input.image.is_none() && !matching_token_indices(&input.input_ids, 151_655)?.is_empty() {
+        candle::bail!("H3 presentation contains image pads without image processor tensors");
+    }
+    if input.video.is_none() && !matching_token_indices(&input.input_ids, 151_656)?.is_empty() {
+        candle::bail!("H3 presentation contains video pads without video processor tensors");
+    }
+
+    let (visual_indices, deepstack) = merge_deepstack(
+        embeddings.device(),
+        embeddings.dtype(),
+        image_indices,
+        image_deepstack,
+        video_indices,
+        video_deepstack,
+    )?;
+    text.forward_embeds(
+        embeddings,
+        &input.position_ids,
+        &visual_indices,
+        deepstack.as_deref(),
+        checkpoint,
+    )
 }
 
 fn matching_token_indices(input_ids: &Tensor, token_id: u32) -> Result<Vec<usize>> {

--- a/crates/mold-candle/src/minimax_h3/qwen_nvfp4.rs
+++ b/crates/mold-candle/src/minimax_h3/qwen_nvfp4.rs
@@ -20,7 +20,7 @@ use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs::{File, Metadata};
 use std::io::{Read, Seek, SeekFrom};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use thiserror::Error;
 
 use super::artifacts::{expected_checkpoint_shapes, expected_materialized_keys};
@@ -222,7 +222,7 @@ pub enum H3QwenNvfp4AwqError {
     Io(String),
 }
 
-fn released_config() -> Result<H3ConditionerConfig, H3QwenNvfp4AwqError> {
+pub(crate) fn released_config() -> Result<H3ConditionerConfig, H3QwenNvfp4AwqError> {
     H3ConditionerConfig::from_json(
         br#"{
           "architectures":["Qwen3VLForConditionalGeneration"],
@@ -660,19 +660,126 @@ fn file_identity(metadata: &Metadata) -> FileIdentity {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-struct H3SafetensorsTensorHeader {
-    dtype: String,
-    shape: Vec<usize>,
-    data_offsets: [u64; 2],
+pub(crate) struct H3SafetensorsTensorHeader {
+    pub(crate) dtype: String,
+    pub(crate) shape: Vec<usize>,
+    pub(crate) data_offsets: [u64; 2],
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct H3SafetensorsHeader {
-    tensors: BTreeMap<String, H3SafetensorsTensorHeader>,
-    header_len: u64,
-    file_len: u64,
+    pub(crate) tensors: BTreeMap<String, H3SafetensorsTensorHeader>,
+    pub(crate) header_len: u64,
+    pub(crate) file_len: u64,
     bytes: Vec<u8>,
     has_metadata: bool,
+}
+
+/// One exact regular-file descriptor bound to a successfully inspected H3
+/// Qwen object. This is crate-internal so schema inspection cannot be mistaken
+/// for public model activation authority.
+pub(crate) struct OpenedH3QwenNvfp4AwqArtifact {
+    file: File,
+    path: PathBuf,
+    identity: FileIdentity,
+    header: H3SafetensorsHeader,
+    policy: H3QwenNvfp4AwqPolicy,
+    inspection: H3QwenNvfp4AwqInspection,
+}
+
+impl OpenedH3QwenNvfp4AwqArtifact {
+    pub(crate) fn inspection(&self) -> &H3QwenNvfp4AwqInspection {
+        &self.inspection
+    }
+
+    pub(crate) fn policy(&self) -> &H3QwenNvfp4AwqPolicy {
+        &self.policy
+    }
+
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub(crate) fn tensors(&self) -> &BTreeMap<String, H3SafetensorsTensorHeader> {
+        &self.header.tensors
+    }
+
+    pub(crate) fn revalidate(&self, operation: &str) -> Result<(), H3QwenNvfp4AwqError> {
+        checked_open_identity(&self.file, &self.identity, operation)?;
+        checked_path_identity(&self.path, Some(&self.identity), operation)?;
+        Ok(())
+    }
+
+    pub(crate) fn authenticate_full_sha256(
+        &mut self,
+        checkpoint: &mut dyn FnMut(u64, u64) -> Result<(), H3QwenNvfp4AwqError>,
+    ) -> Result<(), H3QwenNvfp4AwqError> {
+        const READ_CHUNK_BYTES: usize = 1024 * 1024;
+        self.revalidate("before full artifact authentication")?;
+        self.file
+            .seek(SeekFrom::Start(0))
+            .map_err(|error| H3QwenNvfp4AwqError::Io(error.to_string()))?;
+        let mut digest = Sha256::new();
+        let mut buffer = vec![0_u8; READ_CHUNK_BYTES];
+        let mut completed = 0_u64;
+        while completed < self.identity.len {
+            let remaining = self.identity.len - completed;
+            let length = usize::try_from(remaining.min(READ_CHUNK_BYTES as u64))
+                .expect("the read length is bounded to one MiB");
+            self.file
+                .read_exact(&mut buffer[..length])
+                .map_err(|error| H3QwenNvfp4AwqError::Io(error.to_string()))?;
+            digest.update(&buffer[..length]);
+            completed += length as u64;
+            checkpoint(completed, self.identity.len)?;
+        }
+        self.revalidate("after full artifact authentication")?;
+        let actual = hex_digest(digest.finalize());
+        if actual != H3_QWEN_NVFP4_AWQ_SHA256 {
+            return Err(H3QwenNvfp4AwqError::Accounting(format!(
+                "artifact SHA-256 {actual}, expected {H3_QWEN_NVFP4_AWQ_SHA256}"
+            )));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn read_tensor_bytes(
+        &mut self,
+        name: &str,
+        checkpoint: &mut dyn FnMut(u64, u64) -> Result<(), H3QwenNvfp4AwqError>,
+    ) -> Result<Vec<u8>, H3QwenNvfp4AwqError> {
+        const READ_CHUNK_BYTES: usize = 1024 * 1024;
+        let tensor =
+            self.header.tensors.get(name).cloned().ok_or_else(|| {
+                H3QwenNvfp4AwqError::TensorSchema(format!("missing tensor {name:?}"))
+            })?;
+        let length_u64 = tensor.data_offsets[1] - tensor.data_offsets[0];
+        let length = usize::try_from(length_u64).map_err(|_| {
+            H3QwenNvfp4AwqError::Io(format!("tensor {name:?} byte length overflows usize"))
+        })?;
+        let offset = 8_u64
+            .checked_add(self.header.header_len)
+            .and_then(|offset| offset.checked_add(tensor.data_offsets[0]))
+            .ok_or_else(|| {
+                H3QwenNvfp4AwqError::Io(format!("tensor {name:?} file offset overflows"))
+            })?;
+        self.revalidate(&format!("before reading tensor {name:?}"))?;
+        self.file
+            .seek(SeekFrom::Start(offset))
+            .map_err(|error| H3QwenNvfp4AwqError::Io(error.to_string()))?;
+        let mut bytes = vec![0_u8; length];
+        let mut completed = 0_usize;
+        while completed < length {
+            let end = completed.saturating_add(READ_CHUNK_BYTES).min(length);
+            self.file
+                .read_exact(&mut bytes[completed..end])
+                .map_err(|error| H3QwenNvfp4AwqError::Io(error.to_string()))?;
+            completed = end;
+            checkpoint(completed as u64, length_u64)?;
+        }
+        self.revalidate(&format!("after reading tensor {name:?}"))?;
+        Ok(bytes)
+    }
 }
 
 struct UniqueH3SafetensorsHeader(BTreeMap<String, serde_json::Value>);
@@ -867,13 +974,22 @@ fn read_h3_safetensors_header(
 pub fn inspect_h3_qwen_nvfp4_awq_header(
     path: &Path,
 ) -> Result<H3QwenNvfp4AwqInspection, H3QwenNvfp4AwqError> {
+    open_h3_qwen_nvfp4_awq_artifact(path).map(|artifact| artifact.inspection)
+}
+
+pub(crate) fn open_h3_qwen_nvfp4_awq_artifact(
+    path: &Path,
+) -> Result<OpenedH3QwenNvfp4AwqArtifact, H3QwenNvfp4AwqError> {
     let before = checked_path_identity(path, None, "before bounded inspection")?;
-    let mut file = File::open(path).map_err(|error| H3QwenNvfp4AwqError::Io(error.to_string()))?;
+    let path =
+        std::fs::canonicalize(path).map_err(|error| H3QwenNvfp4AwqError::Io(error.to_string()))?;
+    checked_path_identity(&path, Some(&before), "after resolving artifact path")?;
+    let mut file = File::open(&path).map_err(|error| H3QwenNvfp4AwqError::Io(error.to_string()))?;
     checked_open_identity(&file, &before, "after opening artifact")?;
-    checked_path_identity(path, Some(&before), "after opening artifact")?;
+    checked_path_identity(&path, Some(&before), "after opening artifact")?;
     let header = read_h3_safetensors_header(&mut file, before.len)?;
     checked_open_identity(&file, &before, "after header inspection")?;
-    checked_path_identity(path, Some(&before), "after header inspection")?;
+    checked_path_identity(&path, Some(&before), "after header inspection")?;
     if header.file_len != H3_QWEN_NVFP4_AWQ_FILE_BYTES
         || header.header_len != H3_QWEN_NVFP4_AWQ_HEADER_BYTES
         || header.tensors.len() != H3_QWEN_NVFP4_AWQ_TENSOR_COUNT
@@ -939,8 +1055,8 @@ pub fn inspect_h3_qwen_nvfp4_awq_header(
         ));
     }
     checked_open_identity(&file, &before, "after marker inspection")?;
-    checked_path_identity(path, Some(&before), "after marker inspection")?;
-    Ok(H3QwenNvfp4AwqInspection {
+    checked_path_identity(&path, Some(&before), "after marker inspection")?;
+    let inspection = H3QwenNvfp4AwqInspection {
         stable_id: H3_QWEN_NVFP4_AWQ_STABLE_ID.into(),
         expected_artifact_sha256: H3_QWEN_NVFP4_AWQ_SHA256.into(),
         artifact_file_bytes: header.file_len,
@@ -955,6 +1071,14 @@ pub fn inspect_h3_qwen_nvfp4_awq_header(
             .count(),
         header_identity_sha256: hex_digest(Sha256::digest(&header.bytes)),
         policy_sha256: policy.policy_sha256().into(),
+    };
+    Ok(OpenedH3QwenNvfp4AwqArtifact {
+        file,
+        path,
+        identity: before,
+        header,
+        policy,
+        inspection,
     })
 }
 
@@ -967,7 +1091,7 @@ fn hex_digest(bytes: impl AsRef<[u8]>) -> String {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use serde_json::json;
     use std::fs::OpenOptions;
@@ -1074,7 +1198,7 @@ mod tests {
         path
     }
 
-    fn sparse_published_fixture() -> PathBuf {
+    pub(crate) fn sparse_published_fixture() -> PathBuf {
         sparse_published_fixture_with_metadata(false)
     }
 

--- a/crates/mold-candle/src/minimax_h3/qwen_nvfp4_runtime.rs
+++ b/crates/mold-candle/src/minimax_h3/qwen_nvfp4_runtime.rs
@@ -1,0 +1,531 @@
+//! Internal runtime for the authenticated H3 Qwen NVFP4-AWQ artifact.
+//!
+//! This module deliberately has no engine, factory, catalog, download, or
+//! capability registration. The caller must cross the external authorization
+//! boundary before opening the private object. One retained regular-file
+//! descriptor supplies schema inspection, complete SHA-256 authentication,
+//! and every tensor payload read.
+
+use candle::{DType, Device, Tensor};
+use candle_nn::VarBuilder;
+use std::collections::HashMap;
+use std::path::Path;
+use thiserror::Error;
+
+use super::comfy_quant::{H3ComfyInt8TensorwiseEmbedding, H3ComfyNvfp4AwqLinear};
+use super::config::{H3ConditionerConfig, H3_SELECTED_LANGUAGE_LAYERS};
+use super::model::H3QwenNvfp4Layer50Conditioner;
+use super::qwen_nvfp4::{
+    open_h3_qwen_nvfp4_awq_artifact, released_config, H3QwenNvfp4AwqError, H3QwenNvfp4AwqExecution,
+    H3QwenNvfp4AwqInspection, H3SafetensorsTensorHeader, OpenedH3QwenNvfp4AwqArtifact,
+    H3_QWEN_NVFP4_AWQ_PAYLOAD_BYTES,
+};
+use super::text::{Qwen3VlNvfp4LayerWeights, Qwen3VlNvfp4Weights};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum H3QwenNvfp4LoadEvent {
+    Authenticating {
+        completed_bytes: u64,
+        total_bytes: u64,
+    },
+    LoadingTensor {
+        name: String,
+        tensor_index: usize,
+        tensor_count: usize,
+        completed_bytes: u64,
+        total_bytes: u64,
+    },
+}
+
+pub(crate) trait H3QwenNvfp4LoadObserver {
+    /// Return true to cancel at the next bounded read checkpoint.
+    fn should_cancel(&mut self, event: &H3QwenNvfp4LoadEvent) -> bool;
+}
+
+#[derive(Default)]
+pub(crate) struct NoopH3QwenNvfp4LoadObserver;
+
+impl H3QwenNvfp4LoadObserver for NoopH3QwenNvfp4LoadObserver {
+    fn should_cancel(&mut self, _event: &H3QwenNvfp4LoadEvent) -> bool {
+        false
+    }
+}
+
+#[derive(Debug, Error)]
+pub(crate) enum H3QwenNvfp4RuntimeError {
+    #[error(transparent)]
+    Artifact(#[from] H3QwenNvfp4AwqError),
+    #[error("invalid H3 Qwen NVFP4 runtime contract: {0}")]
+    Contract(String),
+    #[error("failed to construct H3 Qwen NVFP4 runtime: {0}")]
+    Candle(#[from] candle::Error),
+}
+
+pub(crate) struct LoadedH3QwenNvfp4Conditioner {
+    model: H3QwenNvfp4Layer50Conditioner,
+    artifact: OpenedH3QwenNvfp4AwqArtifact,
+}
+
+impl LoadedH3QwenNvfp4Conditioner {
+    pub(crate) fn model(&self) -> &H3QwenNvfp4Layer50Conditioner {
+        &self.model
+    }
+
+    pub(crate) fn inspection(&self) -> &H3QwenNvfp4AwqInspection {
+        self.artifact.inspection()
+    }
+
+    pub(crate) fn artifact_path(&self) -> &Path {
+        self.artifact.path()
+    }
+
+    pub(crate) fn revalidate_artifact(&self) -> Result<(), H3QwenNvfp4RuntimeError> {
+        self.artifact
+            .revalidate("while retaining loaded H3 Qwen runtime")?;
+        Ok(())
+    }
+}
+
+struct TensorLoadProgress<'a> {
+    observer: &'a mut dyn H3QwenNvfp4LoadObserver,
+    tensor_index: usize,
+    tensor_count: usize,
+    completed_before: u64,
+    total_bytes: u64,
+}
+
+impl TensorLoadProgress<'_> {
+    fn read(
+        &mut self,
+        artifact: &mut OpenedH3QwenNvfp4AwqArtifact,
+        name: &str,
+    ) -> Result<Vec<u8>, H3QwenNvfp4RuntimeError> {
+        let event_name = name.to_string();
+        let observer = &mut self.observer;
+        let tensor_index = self.tensor_index;
+        let tensor_count = self.tensor_count;
+        let completed_before = self.completed_before;
+        let total_bytes = self.total_bytes;
+        let bytes = artifact.read_tensor_bytes(name, &mut |completed, _| {
+            let event = H3QwenNvfp4LoadEvent::LoadingTensor {
+                name: event_name.clone(),
+                tensor_index,
+                tensor_count,
+                completed_bytes: completed_before.saturating_add(completed),
+                total_bytes,
+            };
+            if observer.should_cancel(&event) {
+                return Err(H3QwenNvfp4AwqError::Io(
+                    "H3 Qwen NVFP4 load cancelled".into(),
+                ));
+            }
+            Ok(())
+        })?;
+        self.completed_before = self
+            .completed_before
+            .checked_add(bytes.len() as u64)
+            .ok_or_else(|| {
+                H3QwenNvfp4RuntimeError::Contract("loaded byte count overflows".into())
+            })?;
+        self.tensor_index += 1;
+        Ok(bytes)
+    }
+}
+
+pub(crate) fn load_h3_qwen_nvfp4_conditioner(
+    path: &Path,
+    config: &H3ConditionerConfig,
+    device: &Device,
+    observer: &mut dyn H3QwenNvfp4LoadObserver,
+) -> Result<LoadedH3QwenNvfp4Conditioner, H3QwenNvfp4RuntimeError> {
+    config
+        .validate()
+        .map_err(|error| H3QwenNvfp4RuntimeError::Contract(error.to_string()))?;
+    if config != &released_config()? {
+        return Err(H3QwenNvfp4RuntimeError::Contract(
+            "runtime config differs from the frozen published layer-50 Qwen contract".into(),
+        ));
+    }
+
+    let mut artifact = open_h3_qwen_nvfp4_awq_artifact(path)?;
+    artifact.authenticate_full_sha256(&mut |completed_bytes, total_bytes| {
+        let event = H3QwenNvfp4LoadEvent::Authenticating {
+            completed_bytes,
+            total_bytes,
+        };
+        if observer.should_cancel(&event) {
+            return Err(H3QwenNvfp4AwqError::Io(
+                "H3 Qwen NVFP4 authentication cancelled".into(),
+            ));
+        }
+        Ok(())
+    })?;
+
+    let loadable_names = artifact
+        .tensors()
+        .iter()
+        .filter(|(name, _)| !name.ends_with(".comfy_quant"))
+        .map(|(name, _)| name.clone())
+        .collect::<Vec<_>>();
+    let loadable_bytes = loadable_names.iter().try_fold(0_u64, |total, name| {
+        let header = &artifact.tensors()[name];
+        total.checked_add(header.data_offsets[1] - header.data_offsets[0])
+    });
+    let loadable_bytes = loadable_bytes.ok_or_else(|| {
+        H3QwenNvfp4RuntimeError::Contract("loadable tensor bytes overflow".into())
+    })?;
+    if loadable_bytes > H3_QWEN_NVFP4_AWQ_PAYLOAD_BYTES {
+        return Err(H3QwenNvfp4RuntimeError::Contract(
+            "loadable tensor bytes exceed authenticated payload".into(),
+        ));
+    }
+    let mut progress = TensorLoadProgress {
+        observer,
+        tensor_index: 1,
+        tensor_count: loadable_names.len(),
+        completed_before: 0,
+        total_bytes: loadable_bytes,
+    };
+
+    let embed_weight = load_tensor(
+        &mut artifact,
+        "model.embed_tokens.weight",
+        &Device::Cpu,
+        &mut progress,
+    )?;
+    let embed_scale = load_tensor(
+        &mut artifact,
+        "model.embed_tokens.weight_scale",
+        &Device::Cpu,
+        &mut progress,
+    )?;
+    let embed_tokens = H3ComfyInt8TensorwiseEmbedding::new(embed_weight, embed_scale)?;
+
+    let mut layers = Vec::with_capacity(H3_SELECTED_LANGUAGE_LAYERS);
+    for layer in 0..H3_SELECTED_LANGUAGE_LAYERS {
+        layers.push(Qwen3VlNvfp4LayerWeights {
+            q_proj: load_linear(
+                &mut artifact,
+                config,
+                layer,
+                "self_attn.q_proj",
+                &mut progress,
+            )?,
+            k_proj: load_linear(
+                &mut artifact,
+                config,
+                layer,
+                "self_attn.k_proj",
+                &mut progress,
+            )?,
+            v_proj: load_linear(
+                &mut artifact,
+                config,
+                layer,
+                "self_attn.v_proj",
+                &mut progress,
+            )?,
+            o_proj: load_linear(
+                &mut artifact,
+                config,
+                layer,
+                "self_attn.o_proj",
+                &mut progress,
+            )?,
+            gate_proj: load_linear(&mut artifact, config, layer, "mlp.gate_proj", &mut progress)?,
+            up_proj: load_linear(&mut artifact, config, layer, "mlp.up_proj", &mut progress)?,
+            down_proj: load_linear(&mut artifact, config, layer, "mlp.down_proj", &mut progress)?,
+        });
+    }
+
+    let dense_names = artifact
+        .tensors()
+        .iter()
+        .filter(|(name, header)| header.dtype == "BF16" && !name.ends_with(".pre_quant_scale"))
+        .map(|(name, _)| name.clone())
+        .collect::<Vec<_>>();
+    let mut dense = HashMap::with_capacity(dense_names.len());
+    for name in dense_names {
+        let tensor = load_tensor(&mut artifact, &name, device, &mut progress)?;
+        if dense.insert(name.clone(), tensor).is_some() {
+            return Err(H3QwenNvfp4RuntimeError::Contract(format!(
+                "duplicate dense tensor {name:?}"
+            )));
+        }
+    }
+    if progress.tensor_index - 1 != progress.tensor_count
+        || progress.completed_before != progress.total_bytes
+    {
+        return Err(H3QwenNvfp4RuntimeError::Contract(format!(
+            "runtime loaded {} of {} tensors and {} of {} bytes",
+            progress.tensor_index - 1,
+            progress.tensor_count,
+            progress.completed_before,
+            progress.total_bytes
+        )));
+    }
+    artifact.revalidate("after constructing H3 Qwen tensor storage")?;
+    let builder = VarBuilder::from_tensors(dense, DType::BF16, device);
+    let model = H3QwenNvfp4Layer50Conditioner::new(
+        config,
+        builder,
+        Qwen3VlNvfp4Weights {
+            embed_tokens,
+            layers,
+        },
+    )?;
+    if model.resident_language_layers() != H3_SELECTED_LANGUAGE_LAYERS {
+        return Err(H3QwenNvfp4RuntimeError::Contract(format!(
+            "runtime constructed {} language layers, expected exactly {H3_SELECTED_LANGUAGE_LAYERS}",
+            model.resident_language_layers()
+        )));
+    }
+    artifact.revalidate("after constructing H3 Qwen layer-50 model")?;
+    Ok(LoadedH3QwenNvfp4Conditioner { model, artifact })
+}
+
+fn load_linear(
+    artifact: &mut OpenedH3QwenNvfp4AwqArtifact,
+    config: &H3ConditionerConfig,
+    layer: usize,
+    suffix: &str,
+    progress: &mut TensorLoadProgress<'_>,
+) -> Result<H3ComfyNvfp4AwqLinear, H3QwenNvfp4RuntimeError> {
+    let canonical = format!("model.language_model.layers.{layer}.{suffix}.weight");
+    let execution = artifact.policy().execution_for_weight(&canonical)?;
+    let H3QwenNvfp4AwqExecution::Nvfp4FullPrecision {
+        packed_weight_tensor,
+        block_scale_tensor,
+        tensor_scale_tensor,
+        pre_quant_scale_tensor,
+    } = execution
+    else {
+        return Err(H3QwenNvfp4RuntimeError::Contract(format!(
+            "projection {canonical:?} did not resolve to NVFP4 execution"
+        )));
+    };
+    let (out_features, in_features) = linear_dimensions(config, suffix)?;
+    let packed_weight = load_tensor(artifact, &packed_weight_tensor, &Device::Cpu, progress)?;
+    let block_scales = load_tensor(artifact, &block_scale_tensor, &Device::Cpu, progress)?;
+    let tensor_scale = load_tensor(artifact, &tensor_scale_tensor, &Device::Cpu, progress)?;
+    let pre_quant_scale = pre_quant_scale_tensor
+        .as_deref()
+        .map(|name| load_tensor(artifact, name, &Device::Cpu, progress))
+        .transpose()?;
+    H3ComfyNvfp4AwqLinear::new_with_optional_awq(
+        packed_weight,
+        block_scales,
+        tensor_scale,
+        pre_quant_scale,
+        out_features,
+        in_features,
+    )
+    .map_err(Into::into)
+}
+
+fn linear_dimensions(
+    config: &H3ConditionerConfig,
+    suffix: &str,
+) -> Result<(usize, usize), H3QwenNvfp4RuntimeError> {
+    let text = &config.text_config;
+    let query_width = text
+        .num_attention_heads
+        .checked_mul(text.head_dim)
+        .ok_or_else(|| H3QwenNvfp4RuntimeError::Contract("query width overflows".into()))?;
+    let key_value_width = text
+        .num_key_value_heads
+        .checked_mul(text.head_dim)
+        .ok_or_else(|| H3QwenNvfp4RuntimeError::Contract("key/value width overflows".into()))?;
+    match suffix {
+        "self_attn.q_proj" => Ok((query_width, text.hidden_size)),
+        "self_attn.k_proj" | "self_attn.v_proj" => Ok((key_value_width, text.hidden_size)),
+        "self_attn.o_proj" => Ok((text.hidden_size, query_width)),
+        "mlp.gate_proj" | "mlp.up_proj" => Ok((text.intermediate_size, text.hidden_size)),
+        "mlp.down_proj" => Ok((text.hidden_size, text.intermediate_size)),
+        other => Err(H3QwenNvfp4RuntimeError::Contract(format!(
+            "unsupported Qwen projection {other:?}"
+        ))),
+    }
+}
+
+fn load_tensor(
+    artifact: &mut OpenedH3QwenNvfp4AwqArtifact,
+    name: &str,
+    device: &Device,
+    progress: &mut TensorLoadProgress<'_>,
+) -> Result<Tensor, H3QwenNvfp4RuntimeError> {
+    let header = artifact.tensors().get(name).cloned().ok_or_else(|| {
+        H3QwenNvfp4RuntimeError::Contract(format!("missing authenticated tensor {name:?}"))
+    })?;
+    let bytes = progress.read(artifact, name)?;
+    tensor_from_bytes(&bytes, &header, device).map_err(Into::into)
+}
+
+fn tensor_from_bytes(
+    bytes: &[u8],
+    header: &H3SafetensorsTensorHeader,
+    device: &Device,
+) -> candle::Result<Tensor> {
+    let dtype = match header.dtype.as_str() {
+        "BF16" => DType::BF16,
+        "F8_E4M3" => DType::F8E4M3,
+        "F32" => DType::F32,
+        // Candle has no signed I8 storage. Preserve exact two's-complement
+        // bytes and let the embedding primitive widen them explicitly.
+        "I8" | "U8" => DType::U8,
+        other => candle::bail!("unsupported authenticated Qwen dtype {other:?}"),
+    };
+    Tensor::from_raw_buffer(bytes, dtype, &header.shape, device)
+}
+
+const _: () = assert!(H3_SELECTED_LANGUAGE_LAYERS == 50);
+
+#[cfg(test)]
+mod tests {
+    use super::super::qwen_nvfp4::tests::sparse_published_fixture;
+    use super::*;
+
+    struct CancelAuthentication {
+        events: Vec<H3QwenNvfp4LoadEvent>,
+    }
+
+    impl H3QwenNvfp4LoadObserver for CancelAuthentication {
+        fn should_cancel(&mut self, event: &H3QwenNvfp4LoadEvent) -> bool {
+            self.events.push(event.clone());
+            matches!(
+                event,
+                H3QwenNvfp4LoadEvent::Authenticating {
+                    completed_bytes,
+                    ..
+                } if *completed_bytes > 0
+            )
+        }
+    }
+
+    struct CancelTensorRead {
+        events: Vec<H3QwenNvfp4LoadEvent>,
+    }
+
+    impl H3QwenNvfp4LoadObserver for CancelTensorRead {
+        fn should_cancel(&mut self, event: &H3QwenNvfp4LoadEvent) -> bool {
+            self.events.push(event.clone());
+            matches!(
+                event,
+                H3QwenNvfp4LoadEvent::LoadingTensor {
+                    completed_bytes,
+                    ..
+                } if *completed_bytes > 0
+            )
+        }
+    }
+
+    #[test]
+    fn authentication_is_cancellable_at_a_bounded_read_checkpoint() {
+        let path = sparse_published_fixture();
+        let mut observer = CancelAuthentication { events: Vec::new() };
+        let error = load_h3_qwen_nvfp4_conditioner(
+            &path,
+            &released_config().unwrap(),
+            &Device::Cpu,
+            &mut observer,
+        )
+        .err()
+        .expect("the observer must cancel authentication");
+        assert!(error.to_string().contains("authentication cancelled"));
+        assert_eq!(observer.events.len(), 1);
+        assert!(matches!(
+            observer.events[0],
+            H3QwenNvfp4LoadEvent::Authenticating {
+                completed_bytes: 1_048_576,
+                total_bytes: super::super::qwen_nvfp4::H3_QWEN_NVFP4_AWQ_FILE_BYTES,
+            }
+        ));
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn tensor_staging_is_cancellable_at_a_bounded_read_checkpoint() {
+        let path = sparse_published_fixture();
+        let mut artifact = open_h3_qwen_nvfp4_awq_artifact(&path).unwrap();
+        let mut observer = CancelTensorRead { events: Vec::new() };
+        let mut progress = TensorLoadProgress {
+            observer: &mut observer,
+            tensor_index: 1,
+            tensor_count: 1,
+            completed_before: 0,
+            total_bytes: 777_912_320,
+        };
+        let error = progress
+            .read(&mut artifact, "model.embed_tokens.weight")
+            .expect_err("the observer must cancel tensor staging");
+        assert!(error.to_string().contains("load cancelled"));
+        assert_eq!(observer.events.len(), 1);
+        assert!(matches!(
+            observer.events[0],
+            H3QwenNvfp4LoadEvent::LoadingTensor {
+                ref name,
+                tensor_index: 1,
+                tensor_count: 1,
+                completed_bytes: 1_048_576,
+                total_bytes: 777_912_320,
+            } if name == "model.embed_tokens.weight"
+        ));
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn runtime_rejects_config_drift_before_opening_the_artifact() {
+        let missing = std::env::temp_dir().join("mold-h3-qwen-deliberately-missing.safetensors");
+        let mut config = released_config().unwrap();
+        config.text_config.max_position_embeddings -= 1;
+        let error = load_h3_qwen_nvfp4_conditioner(
+            &missing,
+            &config,
+            &Device::Cpu,
+            &mut NoopH3QwenNvfp4LoadObserver,
+        )
+        .err()
+        .expect("frozen config drift must fail");
+        assert!(matches!(error, H3QwenNvfp4RuntimeError::Contract(_)));
+        assert!(!missing.exists());
+    }
+
+    #[test]
+    #[ignore = "requires the authorized 15.7 GB private H3 Qwen artifact"]
+    fn authorized_real_artifact_constructs_exact_layer_50_runtime() {
+        let path = std::env::var_os("MOLD_H3_QWEN_NVFP4_PATH")
+            .map(std::path::PathBuf::from)
+            .expect("set MOLD_H3_QWEN_NVFP4_PATH to the authorized artifact");
+        let loaded = load_h3_qwen_nvfp4_conditioner(
+            &path,
+            &released_config().unwrap(),
+            &Device::Cpu,
+            &mut NoopH3QwenNvfp4LoadObserver,
+        )
+        .unwrap();
+        assert_eq!(
+            loaded.model().resident_language_layers(),
+            H3_SELECTED_LANGUAGE_LAYERS
+        );
+        assert_eq!(
+            loaded.inspection().expected_artifact_sha256,
+            super::super::qwen_nvfp4::H3_QWEN_NVFP4_AWQ_SHA256
+        );
+        assert_eq!(loaded.artifact_path(), path);
+        loaded.revalidate_artifact().unwrap();
+
+        let ids = Tensor::new(&[[0_u32, 1, 151_935]], &Device::Cpu).unwrap();
+        let embeddings = loaded
+            .model()
+            .embed_tokens(&ids)
+            .unwrap()
+            .to_dtype(DType::F32)
+            .unwrap()
+            .flatten_all()
+            .unwrap()
+            .to_vec1::<f32>()
+            .unwrap();
+        assert_eq!(embeddings.len(), 3 * 5_120);
+        assert!(embeddings.iter().all(|value| value.is_finite()));
+    }
+}

--- a/crates/mold-candle/src/minimax_h3/text.rs
+++ b/crates/mold-candle/src/minimax_h3/text.rs
@@ -1,10 +1,12 @@
-use candle::{DType, IndexOp, Result, Tensor, D};
+use candle::{DType, Device, IndexOp, Result, Tensor, D};
 use candle_nn::{
     embedding, linear_b, rms_norm, Activation, Embedding, Linear, Module, RmsNorm, VarBuilder,
 };
 
+use super::comfy_quant::{H3ComfyInt8TensorwiseEmbedding, H3ComfyNvfp4AwqLinear};
 use super::config::{H3ConditionerConfig, H3_SELECTED_LANGUAGE_LAYERS};
 use super::model::ConditionerCheckpoint;
+use super::H3_COMFY_PORTABLE_ROW_CHUNK;
 
 #[derive(Clone, Debug)]
 pub(super) struct Qwen3VlTextDimensions {
@@ -73,34 +75,99 @@ impl Qwen3VlTextDimensions {
     }
 }
 
+enum Qwen3VlEmbedding {
+    Dense(Embedding),
+    Int8Tensorwise {
+        embedding: H3ComfyInt8TensorwiseEmbedding,
+        output_dtype: DType,
+        device: Device,
+    },
+}
+
+impl Qwen3VlEmbedding {
+    fn forward(&self, input_ids: &Tensor) -> Result<Tensor> {
+        match self {
+            Self::Dense(embedding) => embedding.forward(input_ids),
+            Self::Int8Tensorwise {
+                embedding,
+                output_dtype,
+                device,
+            } => embedding.forward(input_ids, *output_dtype, device),
+        }
+    }
+}
+
+enum Qwen3VlLinear {
+    Dense(Linear),
+    Nvfp4(H3ComfyNvfp4AwqLinear),
+}
+
+impl Qwen3VlLinear {
+    fn forward(&self, input: &Tensor) -> Result<Tensor> {
+        match self {
+            Self::Dense(linear) => linear.forward(input),
+            Self::Nvfp4(linear) => {
+                linear.forward_dequantized(input, None, input.dtype(), H3_COMFY_PORTABLE_ROW_CHUNK)
+            }
+        }
+    }
+}
+
+pub(super) struct Qwen3VlNvfp4LayerWeights {
+    pub(super) q_proj: H3ComfyNvfp4AwqLinear,
+    pub(super) k_proj: H3ComfyNvfp4AwqLinear,
+    pub(super) v_proj: H3ComfyNvfp4AwqLinear,
+    pub(super) o_proj: H3ComfyNvfp4AwqLinear,
+    pub(super) gate_proj: H3ComfyNvfp4AwqLinear,
+    pub(super) up_proj: H3ComfyNvfp4AwqLinear,
+    pub(super) down_proj: H3ComfyNvfp4AwqLinear,
+}
+
+pub(super) struct Qwen3VlNvfp4Weights {
+    pub(super) embed_tokens: H3ComfyInt8TensorwiseEmbedding,
+    pub(super) layers: Vec<Qwen3VlNvfp4LayerWeights>,
+}
+
 struct Mlp {
-    gate_proj: Linear,
-    up_proj: Linear,
-    down_proj: Linear,
+    gate_proj: Qwen3VlLinear,
+    up_proj: Qwen3VlLinear,
+    down_proj: Qwen3VlLinear,
 }
 
 impl Mlp {
     fn new(config: &Qwen3VlTextDimensions, vb: VarBuilder) -> Result<Self> {
         Ok(Self {
-            gate_proj: linear_b(
+            gate_proj: Qwen3VlLinear::Dense(linear_b(
                 config.hidden_size,
                 config.intermediate_size,
                 false,
                 vb.pp("gate_proj"),
-            )?,
-            up_proj: linear_b(
+            )?),
+            up_proj: Qwen3VlLinear::Dense(linear_b(
                 config.hidden_size,
                 config.intermediate_size,
                 false,
                 vb.pp("up_proj"),
-            )?,
-            down_proj: linear_b(
+            )?),
+            down_proj: Qwen3VlLinear::Dense(linear_b(
                 config.intermediate_size,
                 config.hidden_size,
                 false,
                 vb.pp("down_proj"),
-            )?,
+            )?),
         })
+    }
+
+    fn new_nvfp4(
+        gate_proj: H3ComfyNvfp4AwqLinear,
+        up_proj: H3ComfyNvfp4AwqLinear,
+        down_proj: H3ComfyNvfp4AwqLinear,
+    ) -> Self {
+        Self {
+            gate_proj: Qwen3VlLinear::Nvfp4(gate_proj),
+            up_proj: Qwen3VlLinear::Nvfp4(up_proj),
+            down_proj: Qwen3VlLinear::Nvfp4(down_proj),
+        }
     }
 
     fn forward(&self, input: &Tensor) -> Result<Tensor> {
@@ -190,10 +257,10 @@ fn apply_rotary(input: &Tensor, cos: &Tensor, sin: &Tensor) -> Result<Tensor> {
 }
 
 struct Attention {
-    q_proj: Linear,
-    k_proj: Linear,
-    v_proj: Linear,
-    o_proj: Linear,
+    q_proj: Qwen3VlLinear,
+    k_proj: Qwen3VlLinear,
+    v_proj: Qwen3VlLinear,
+    o_proj: Qwen3VlLinear,
     q_norm: RmsNorm,
     k_norm: RmsNorm,
     num_heads: usize,
@@ -208,10 +275,53 @@ impl Attention {
         let q_width = config.num_attention_heads * config.head_dim;
         let kv_width = config.num_key_value_heads * config.head_dim;
         Ok(Self {
-            q_proj: linear_b(config.hidden_size, q_width, false, vb.pp("q_proj"))?,
-            k_proj: linear_b(config.hidden_size, kv_width, false, vb.pp("k_proj"))?,
-            v_proj: linear_b(config.hidden_size, kv_width, false, vb.pp("v_proj"))?,
-            o_proj: linear_b(q_width, config.hidden_size, false, vb.pp("o_proj"))?,
+            q_proj: Qwen3VlLinear::Dense(linear_b(
+                config.hidden_size,
+                q_width,
+                false,
+                vb.pp("q_proj"),
+            )?),
+            k_proj: Qwen3VlLinear::Dense(linear_b(
+                config.hidden_size,
+                kv_width,
+                false,
+                vb.pp("k_proj"),
+            )?),
+            v_proj: Qwen3VlLinear::Dense(linear_b(
+                config.hidden_size,
+                kv_width,
+                false,
+                vb.pp("v_proj"),
+            )?),
+            o_proj: Qwen3VlLinear::Dense(linear_b(
+                q_width,
+                config.hidden_size,
+                false,
+                vb.pp("o_proj"),
+            )?),
+            q_norm: rms_norm(config.head_dim, config.rms_norm_eps, vb.pp("q_norm"))?,
+            k_norm: rms_norm(config.head_dim, config.rms_norm_eps, vb.pp("k_norm"))?,
+            num_heads: config.num_attention_heads,
+            num_key_value_heads: config.num_key_value_heads,
+            head_dim: config.head_dim,
+            kv_groups: config.num_attention_heads / config.num_key_value_heads,
+            scale: 1.0 / (config.head_dim as f64).sqrt(),
+        })
+    }
+
+    fn new_nvfp4(
+        config: &Qwen3VlTextDimensions,
+        vb: VarBuilder,
+        q_proj: H3ComfyNvfp4AwqLinear,
+        k_proj: H3ComfyNvfp4AwqLinear,
+        v_proj: H3ComfyNvfp4AwqLinear,
+        o_proj: H3ComfyNvfp4AwqLinear,
+    ) -> Result<Self> {
+        Ok(Self {
+            q_proj: Qwen3VlLinear::Nvfp4(q_proj),
+            k_proj: Qwen3VlLinear::Nvfp4(k_proj),
+            v_proj: Qwen3VlLinear::Nvfp4(v_proj),
+            o_proj: Qwen3VlLinear::Nvfp4(o_proj),
             q_norm: rms_norm(config.head_dim, config.rms_norm_eps, vb.pp("q_norm"))?,
             k_norm: rms_norm(config.head_dim, config.rms_norm_eps, vb.pp("k_norm"))?,
             num_heads: config.num_attention_heads,
@@ -289,6 +399,43 @@ impl DecoderLayer {
         })
     }
 
+    fn new_nvfp4(
+        config: &Qwen3VlTextDimensions,
+        vb: VarBuilder,
+        weights: Qwen3VlNvfp4LayerWeights,
+    ) -> Result<Self> {
+        let Qwen3VlNvfp4LayerWeights {
+            q_proj,
+            k_proj,
+            v_proj,
+            o_proj,
+            gate_proj,
+            up_proj,
+            down_proj,
+        } = weights;
+        Ok(Self {
+            attention: Attention::new_nvfp4(
+                config,
+                vb.pp("self_attn"),
+                q_proj,
+                k_proj,
+                v_proj,
+                o_proj,
+            )?,
+            mlp: Mlp::new_nvfp4(gate_proj, up_proj, down_proj),
+            input_layernorm: rms_norm(
+                config.hidden_size,
+                config.rms_norm_eps,
+                vb.pp("input_layernorm"),
+            )?,
+            post_attention_layernorm: rms_norm(
+                config.hidden_size,
+                config.rms_norm_eps,
+                vb.pp("post_attention_layernorm"),
+            )?,
+        })
+    }
+
     fn forward(
         &self,
         input: &Tensor,
@@ -308,7 +455,7 @@ impl DecoderLayer {
 }
 
 pub(super) struct Qwen3VlTextEncoder {
-    embed_tokens: Embedding,
+    embed_tokens: Qwen3VlEmbedding,
     layers: Vec<DecoderLayer>,
     rotary: MultimodalRotaryEmbedding,
     hidden_size: usize,
@@ -324,7 +471,52 @@ impl Qwen3VlTextEncoder {
             layers.push(DecoderLayer::new(config, vb.pp("layers").pp(index))?);
         }
         Ok(Self {
-            embed_tokens,
+            embed_tokens: Qwen3VlEmbedding::Dense(embed_tokens),
+            layers,
+            rotary,
+            hidden_size: config.hidden_size,
+        })
+    }
+
+    pub(super) fn new_nvfp4(
+        config: &Qwen3VlTextDimensions,
+        vb: VarBuilder,
+        weights: Qwen3VlNvfp4Weights,
+    ) -> Result<Self> {
+        config.validate()?;
+        if weights.layers.len() != config.num_layers {
+            candle::bail!(
+                "H3 NVFP4 Qwen supplied {} layers, expected exactly {}",
+                weights.layers.len(),
+                config.num_layers
+            );
+        }
+        if weights.embed_tokens.vocabulary() != config.vocab_size
+            || weights.embed_tokens.hidden_size() != config.hidden_size
+        {
+            candle::bail!(
+                "H3 NVFP4 Qwen embedding is {}x{}, expected {}x{}",
+                weights.embed_tokens.vocabulary(),
+                weights.embed_tokens.hidden_size(),
+                config.vocab_size,
+                config.hidden_size
+            );
+        }
+        let rotary = MultimodalRotaryEmbedding::new(config, &vb)?;
+        let mut layers = Vec::with_capacity(config.num_layers);
+        for (index, weights) in weights.layers.into_iter().enumerate() {
+            layers.push(DecoderLayer::new_nvfp4(
+                config,
+                vb.pp("layers").pp(index),
+                weights,
+            )?);
+        }
+        Ok(Self {
+            embed_tokens: Qwen3VlEmbedding::Int8Tensorwise {
+                embedding: weights.embed_tokens,
+                output_dtype: vb.dtype(),
+                device: vb.device().clone(),
+            },
             layers,
             rotary,
             hidden_size: config.hidden_size,
@@ -426,6 +618,144 @@ mod tests {
     use super::*;
     use candle::{DType, Device};
     use candle_nn::VarMap;
+    use std::collections::HashMap;
+
+    fn round_up(value: usize, multiple: usize) -> usize {
+        value.div_ceil(multiple) * multiple
+    }
+
+    fn synthetic_nvfp4(
+        out_features: usize,
+        in_features: usize,
+        with_awq: bool,
+    ) -> H3ComfyNvfp4AwqLinear {
+        let padded_out = round_up(out_features, 16);
+        let padded_in = round_up(in_features, 16);
+        let scale_rows = round_up(padded_out, 128);
+        let scale_columns = round_up(padded_in / 16, 4);
+        // 0x11 is two +0.5 E2M1 values. With unit block scales and a
+        // 1/16 tensor scale this represents a dense 1/32 matrix exactly.
+        let packed = Tensor::from_vec(
+            vec![0x11_u8; padded_out * padded_in / 2],
+            (padded_out, padded_in / 2),
+            &Device::Cpu,
+        )
+        .unwrap();
+        let block_scales = Tensor::ones((scale_rows, scale_columns), DType::F32, &Device::Cpu)
+            .unwrap()
+            .to_dtype(DType::F8E4M3)
+            .unwrap();
+        let tensor_scale = Tensor::new(0.0625_f32, &Device::Cpu).unwrap();
+        let awq = with_awq.then(|| Tensor::ones((in_features,), DType::F32, &Device::Cpu).unwrap());
+        H3ComfyNvfp4AwqLinear::new_with_optional_awq(
+            packed,
+            block_scales,
+            tensor_scale,
+            awq,
+            out_features,
+            in_features,
+        )
+        .unwrap()
+    }
+
+    fn synthetic_nvfp4_weights(config: &Qwen3VlTextDimensions) -> Qwen3VlNvfp4Weights {
+        let mut raw_embedding = Vec::with_capacity(config.vocab_size * config.hidden_size);
+        for row in 0..config.vocab_size {
+            for column in 0..config.hidden_size {
+                let value = ((row * config.hidden_size + column) % 7) as i8 - 3;
+                raw_embedding.push(value as u8);
+            }
+        }
+        let embed_tokens = H3ComfyInt8TensorwiseEmbedding::new(
+            Tensor::from_vec(
+                raw_embedding,
+                (config.vocab_size, config.hidden_size),
+                &Device::Cpu,
+            )
+            .unwrap(),
+            Tensor::ones((config.vocab_size, 1), DType::F32, &Device::Cpu).unwrap(),
+        )
+        .unwrap();
+        let q_width = config.num_attention_heads * config.head_dim;
+        let kv_width = config.num_key_value_heads * config.head_dim;
+        let layers = (0..config.num_layers)
+            .map(|_| Qwen3VlNvfp4LayerWeights {
+                q_proj: synthetic_nvfp4(q_width, config.hidden_size, false),
+                k_proj: synthetic_nvfp4(kv_width, config.hidden_size, false),
+                v_proj: synthetic_nvfp4(kv_width, config.hidden_size, false),
+                o_proj: synthetic_nvfp4(config.hidden_size, q_width, true),
+                gate_proj: synthetic_nvfp4(config.intermediate_size, config.hidden_size, false),
+                up_proj: synthetic_nvfp4(config.intermediate_size, config.hidden_size, false),
+                down_proj: synthetic_nvfp4(config.hidden_size, config.intermediate_size, true),
+            })
+            .collect();
+        Qwen3VlNvfp4Weights {
+            embed_tokens,
+            layers,
+        }
+    }
+
+    fn synthetic_dense_weights(config: &Qwen3VlTextDimensions) -> HashMap<String, Tensor> {
+        let mut tensors = HashMap::new();
+        let embedding = (0..config.vocab_size * config.hidden_size)
+            .map(|index| (index % 7) as f32 - 3.0)
+            .collect::<Vec<_>>();
+        tensors.insert(
+            "embed_tokens.weight".into(),
+            Tensor::from_vec(
+                embedding,
+                (config.vocab_size, config.hidden_size),
+                &Device::Cpu,
+            )
+            .unwrap(),
+        );
+        let q_width = config.num_attention_heads * config.head_dim;
+        let kv_width = config.num_key_value_heads * config.head_dim;
+        for layer in 0..config.num_layers {
+            let prefix = format!("layers.{layer}");
+            for (suffix, out_features, in_features) in [
+                ("self_attn.q_proj.weight", q_width, config.hidden_size),
+                ("self_attn.k_proj.weight", kv_width, config.hidden_size),
+                ("self_attn.v_proj.weight", kv_width, config.hidden_size),
+                ("self_attn.o_proj.weight", config.hidden_size, q_width),
+                (
+                    "mlp.gate_proj.weight",
+                    config.intermediate_size,
+                    config.hidden_size,
+                ),
+                (
+                    "mlp.up_proj.weight",
+                    config.intermediate_size,
+                    config.hidden_size,
+                ),
+                (
+                    "mlp.down_proj.weight",
+                    config.hidden_size,
+                    config.intermediate_size,
+                ),
+            ] {
+                tensors.insert(
+                    format!("{prefix}.{suffix}"),
+                    Tensor::ones((out_features, in_features), DType::F32, &Device::Cpu)
+                        .unwrap()
+                        .affine(0.03125, 0.0)
+                        .unwrap(),
+                );
+            }
+            for (suffix, width) in [
+                ("self_attn.q_norm.weight", config.head_dim),
+                ("self_attn.k_norm.weight", config.head_dim),
+                ("input_layernorm.weight", config.hidden_size),
+                ("post_attention_layernorm.weight", config.hidden_size),
+            ] {
+                tensors.insert(
+                    format!("{prefix}.{suffix}"),
+                    Tensor::ones((width,), DType::F32, &Device::Cpu).unwrap(),
+                );
+            }
+        }
+        tensors
+    }
 
     #[test]
     fn tiny_encoder_returns_full_unnormalized_sequence_without_tail_keys() {
@@ -491,6 +821,86 @@ mod tests {
         let values = cos.flatten_all().unwrap().to_vec1::<f32>().unwrap();
         assert!((values[0] - 2.0_f32.cos()).abs() < 1e-6);
         assert!((values[1] - (3.0_f32 / 100.0).cos()).abs() < 1e-6);
+    }
+
+    #[test]
+    fn mixed_int8_nvfp4_stack_matches_dense_numerical_oracle() {
+        let config = Qwen3VlTextDimensions::tiny();
+        let dense_weights = synthetic_dense_weights(&config);
+        let dense = Qwen3VlTextEncoder::new(
+            &config,
+            VarBuilder::from_tensors(dense_weights.clone(), DType::F32, &Device::Cpu),
+        )
+        .unwrap();
+        let quantized = Qwen3VlTextEncoder::new_nvfp4(
+            &config,
+            VarBuilder::from_tensors(dense_weights, DType::F32, &Device::Cpu),
+            synthetic_nvfp4_weights(&config),
+        )
+        .unwrap();
+        let ids = Tensor::new(&[[1_u32, 7, 19]], &Device::Cpu).unwrap();
+        let positions = Tensor::new(
+            &[[[0_u32, 1, 2]], [[0_u32, 1, 2]], [[0_u32, 1, 2]]],
+            &Device::Cpu,
+        )
+        .unwrap();
+
+        let dense_embeds = dense.embed_tokens(&ids).unwrap();
+        let quantized_embeds = quantized.embed_tokens(&ids).unwrap();
+        let dense_output = dense
+            .forward_embeds(dense_embeds.clone(), &positions, &[], None, &mut |_| Ok(()))
+            .unwrap();
+        let quantized_output = quantized
+            .forward_embeds(quantized_embeds.clone(), &positions, &[], None, &mut |_| {
+                Ok(())
+            })
+            .unwrap();
+
+        for (role, dense, quantized) in [
+            ("embedding", dense_embeds, quantized_embeds),
+            (
+                "unnormalized hidden-state contract",
+                dense_output,
+                quantized_output,
+            ),
+        ] {
+            let dense = dense.flatten_all().unwrap().to_vec1::<f32>().unwrap();
+            let quantized = quantized.flatten_all().unwrap().to_vec1::<f32>().unwrap();
+            let max_difference = dense
+                .iter()
+                .zip(&quantized)
+                .map(|(left, right)| (left - right).abs())
+                .fold(0_f32, f32::max);
+            assert!(max_difference <= 2e-5, "{role} drifted by {max_difference}");
+        }
+    }
+
+    #[test]
+    fn mixed_stack_rejects_any_layer_tail_or_truncation() {
+        let config = Qwen3VlTextDimensions::tiny();
+        for supplied in [config.num_layers - 1, config.num_layers + 1] {
+            let mut weights = synthetic_nvfp4_weights(&config);
+            weights.layers.truncate(supplied.min(config.num_layers));
+            if supplied > config.num_layers {
+                weights.layers.push(Qwen3VlNvfp4LayerWeights {
+                    q_proj: synthetic_nvfp4(12, 12, false),
+                    k_proj: synthetic_nvfp4(4, 12, false),
+                    v_proj: synthetic_nvfp4(4, 12, false),
+                    o_proj: synthetic_nvfp4(12, 12, true),
+                    gate_proj: synthetic_nvfp4(24, 12, false),
+                    up_proj: synthetic_nvfp4(24, 12, false),
+                    down_proj: synthetic_nvfp4(12, 24, true),
+                });
+            }
+            let error = Qwen3VlTextEncoder::new_nvfp4(
+                &config,
+                VarBuilder::zeros(DType::F32, &Device::Cpu),
+                weights,
+            )
+            .err()
+            .expect("mismatched layer count must fail");
+            assert!(error.to_string().contains("expected exactly 3"));
+        }
     }
 
     #[cfg(feature = "cuda")]


### PR DESCRIPTION
## Summary

- retain one canonical regular-file descriptor from strict header inspection through complete SHA-256 authentication and every tensor payload read
- construct the released layer-50 Qwen3-VL conditioner from its exact mixed storage: raw signed-I8 tensorwise embedding, 350 CPU-packed NVFP4 projections with the published selective AWQ vectors, and dense BF16 vision/norm tensors on the selected device
- share the existing H3 presentation/vision/DeepStack encode path while excluding every language layer after 49, the final norm, and the LM head
- make authentication and per-tensor staging cancellable at bounded 1 MiB read checkpoints, with exact tensor/byte accounting and retained file-identity fences
- add a nonzero dense-vs-quantized numerical oracle, layer-tail/truncation rejection, cancellation coverage, and an authorization-gated real-artifact construction probe

## Why

#879 froze and authenticated the published MiniMax H3 Qwen NVFP4-AWQ artifact contract, but intentionally stopped at inspection and primitive execution policy. This change adds the internal runtime that consumes that authority without inventing a second schema or relaxing the file-identity boundary.

## Authorization boundary

This remains crate-internal and is not registered with any Mold engine, factory, catalog, downloader, capability response, or release artifact. The caller must cross the separate private authorization boundary before supplying the pinned object. Public H3 activation and distribution remain rejected.

## Verification

- `cargo test -p mold-ai-candle --no-default-features --lib -- --test-threads=1` — 159 passed, 2 authorization-gated tests ignored
- `cargo clippy -p mold-ai-candle --no-default-features --all-targets -- -D warnings`
- `cargo clippy -p mold-ai-candle --no-default-features --features metal --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- exact rebased head `5d5a290874cd70437c807599f00a7efafee1ad07` privately qualified on private UAT host against the authorized 15,687,142,551-byte artifact: complete SHA authentication, all 2,054 tensors loaded, exactly 50 language layers constructed, retained lease revalidated, and real token embeddings finite; 1 passed in 358.64s

Refs #815 and #839.

