### PR TITLE
feat(h3): bridge private streamed runtime

### DIFF
--- a/crates/mold-candle/Cargo.toml
+++ b/crates/mold-candle/Cargo.toml
@@ -18,6 +18,9 @@ metal = ["candle/metal", "candle-nn/metal", "candle-transformers/metal"]
 # FlashAttention v2 primitive without making it reachable from the Mold CLI,
 # server factory, catalog, downloads, or any published artifact.
 h3-flash-attn-rc = ["dep:candle-flash-attn", "cuda"]
+# Development-only visibility for the authorization-bound H3 artifact runtime.
+# No Mold shipping surface forwards this feature.
+h3-private-uat = []
 # Mold's existing developer-only global attention benchmark remains a separate
 # switch. In particular, H3 qualification must not change Visual VAE Auto
 # dispatch or any other non-DiT attention path. Shipping builds omit both.

--- a/crates/mold-candle/src/minimax_h3/comfy_dit.rs
+++ b/crates/mold-candle/src/minimax_h3/comfy_dit.rs
@@ -1284,6 +1284,20 @@ impl H3ComfyInt8BlockLoader {
         &self.source.content_sha256
     }
 
+    /// Exact schema, policy, and authenticated-content identity shared with
+    /// the resident transformer created by the same opened checkpoint.
+    pub fn checkpoint_identity_sha256(&self) -> &str {
+        self.identity
+            .checkpoint_identity_sha256()
+            .expect("Comfy block loaders always carry a checkpoint identity")
+    }
+
+    /// True only when this loader and resident transformer came from the same
+    /// opened checkpoint authority, not merely equal artifact bytes.
+    pub fn is_exact_pair_for(&self, transformer: &H3StreamedTransformer) -> bool {
+        transformer.shares_streamed_identity(&self.identity)
+    }
+
     pub fn bytes_read(&self) -> u64 {
         self.source.runtime_bytes_read.load(Ordering::Relaxed)
     }
@@ -3257,6 +3271,7 @@ mod tests {
         assert_eq!(opened.checkpoint_identity_sha256().len(), 64);
         let expected_identity = opened.checkpoint_identity_sha256().to_owned();
         let (transformer, mut loader) = opened.load(&Device::Cpu)?;
+        assert!(loader.is_exact_pair_for(&transformer));
         assert_eq!(
             transformer.checkpoint_identity_sha256(),
             Some(expected_identity.as_str())
@@ -3283,6 +3298,42 @@ mod tests {
         assert_eq!(block1.index(), 1);
         drop(block1);
         assert_eq!(loader.live_block_count(), 0);
+        let _ = std::fs::remove_file(path);
+        Ok(())
+    }
+
+    #[test]
+    fn independently_opened_runtime_halves_are_not_an_exact_pair() -> candle::Result<()> {
+        let (config, header, data) = runtime_fixture();
+        let path = write_fixture(&header, &data, "opened-pair-identity");
+        let first = open_h3_comfy_int8_checkpoint(
+            &path,
+            config.clone(),
+            H3TransformerTask::T2VaFl2Va,
+            None,
+            None,
+            &H3ComfyNeverCancel,
+        )
+        .map_err(|error| candle::Error::Msg(error.to_string()))?;
+        let second = open_h3_comfy_int8_checkpoint(
+            &path,
+            config,
+            H3TransformerTask::T2VaFl2Va,
+            None,
+            None,
+            &H3ComfyNeverCancel,
+        )
+        .map_err(|error| candle::Error::Msg(error.to_string()))?;
+        let (first_transformer, first_loader) = first.load(&Device::Cpu)?;
+        let (second_transformer, second_loader) = second.load(&Device::Cpu)?;
+        assert_eq!(
+            first_loader.checkpoint_identity_sha256(),
+            second_loader.checkpoint_identity_sha256()
+        );
+        assert!(first_loader.is_exact_pair_for(&first_transformer));
+        assert!(second_loader.is_exact_pair_for(&second_transformer));
+        assert!(!first_loader.is_exact_pair_for(&second_transformer));
+        assert!(!second_loader.is_exact_pair_for(&first_transformer));
         let _ = std::fs::remove_file(path);
         Ok(())
     }

--- a/crates/mold-candle/src/minimax_h3/dit.rs
+++ b/crates/mold-candle/src/minimax_h3/dit.rs
@@ -1984,6 +1984,10 @@ impl H3StreamedTransformerIdentity {
     pub(super) fn live_block_count(&self) -> usize {
         self.live_blocks.load(Ordering::Relaxed)
     }
+
+    pub(super) fn checkpoint_identity_sha256(&self) -> Option<&str> {
+        self.checkpoint_identity_sha256.as_deref()
+    }
 }
 
 /// One independently owned main DiT block.
@@ -2402,6 +2406,13 @@ impl H3StreamedTransformer {
 
     pub(super) fn streamed_identity(&self) -> Arc<H3StreamedTransformerIdentity> {
         self.identity.clone()
+    }
+
+    pub(super) fn shares_streamed_identity(
+        &self,
+        other: &Arc<H3StreamedTransformerIdentity>,
+    ) -> bool {
+        Arc::ptr_eq(&self.identity, other)
     }
 
     pub fn task(&self) -> H3TransformerTask {

--- a/crates/mold-candle/src/minimax_h3/mod.rs
+++ b/crates/mold-candle/src/minimax_h3/mod.rs
@@ -122,6 +122,12 @@ pub use qwen_nvfp4::{
     H3_QWEN_NVFP4_AWQ_TENSOR_COUNT, H3_QWEN_NVFP4_LINEAR_COUNT,
     H3_QWEN_NVFP4_PRE_QUANT_SCALE_COUNT, H3_QWEN_QUANT_MARKER_COUNT,
 };
+#[cfg(feature = "h3-private-uat")]
+#[doc(hidden)]
+pub use qwen_nvfp4_runtime::{
+    load_h3_qwen_nvfp4_conditioner, H3QwenNvfp4LoadEvent, H3QwenNvfp4LoadObserver,
+    H3QwenNvfp4RuntimeError, LoadedH3QwenNvfp4Conditioner, NoopH3QwenNvfp4LoadObserver,
+};
 pub use qwen_quant::{
     expected_h3_qwen_int8_weight_only_schema, validate_h3_qwen_int8_weight_only_schema,
     H3QwenFp32Boundary, H3QwenInt8CheckpointMetadata, H3QwenInt8LayerMetadata,

--- a/crates/mold-candle/src/minimax_h3/qwen_nvfp4_runtime.rs
+++ b/crates/mold-candle/src/minimax_h3/qwen_nvfp4_runtime.rs
@@ -23,7 +23,7 @@ use super::qwen_nvfp4::{
 use super::text::{Qwen3VlNvfp4LayerWeights, Qwen3VlNvfp4Weights};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) enum H3QwenNvfp4LoadEvent {
+pub enum H3QwenNvfp4LoadEvent {
     Authenticating {
         completed_bytes: u64,
         total_bytes: u64,
@@ -37,13 +37,13 @@ pub(crate) enum H3QwenNvfp4LoadEvent {
     },
 }
 
-pub(crate) trait H3QwenNvfp4LoadObserver {
+pub trait H3QwenNvfp4LoadObserver {
     /// Return true to cancel at the next bounded read checkpoint.
     fn should_cancel(&mut self, event: &H3QwenNvfp4LoadEvent) -> bool;
 }
 
 #[derive(Default)]
-pub(crate) struct NoopH3QwenNvfp4LoadObserver;
+pub struct NoopH3QwenNvfp4LoadObserver;
 
 impl H3QwenNvfp4LoadObserver for NoopH3QwenNvfp4LoadObserver {
     fn should_cancel(&mut self, _event: &H3QwenNvfp4LoadEvent) -> bool {
@@ -52,7 +52,7 @@ impl H3QwenNvfp4LoadObserver for NoopH3QwenNvfp4LoadObserver {
 }
 
 #[derive(Debug, Error)]
-pub(crate) enum H3QwenNvfp4RuntimeError {
+pub enum H3QwenNvfp4RuntimeError {
     #[error(transparent)]
     Artifact(#[from] H3QwenNvfp4AwqError),
     #[error("invalid H3 Qwen NVFP4 runtime contract: {0}")]
@@ -61,14 +61,30 @@ pub(crate) enum H3QwenNvfp4RuntimeError {
     Candle(#[from] candle::Error),
 }
 
-pub(crate) struct LoadedH3QwenNvfp4Conditioner {
+pub struct LoadedH3QwenNvfp4Conditioner {
     model: H3QwenNvfp4Layer50Conditioner,
     artifact: OpenedH3QwenNvfp4AwqArtifact,
 }
 
 impl LoadedH3QwenNvfp4Conditioner {
-    pub(crate) fn model(&self) -> &H3QwenNvfp4Layer50Conditioner {
+    fn model(&self) -> &H3QwenNvfp4Layer50Conditioner {
         &self.model
+    }
+
+    pub fn encode(
+        &self,
+        input: &super::model::H3ConditionerInput,
+        checkpoint: &mut dyn FnMut(super::model::ConditionerCheckpoint) -> candle::Result<()>,
+    ) -> candle::Result<Tensor> {
+        self.model.encode(input, checkpoint)
+    }
+
+    pub fn dtype_profile(&self) -> super::model::H3DTypeProfile {
+        self.model.dtype_profile()
+    }
+
+    pub fn resident_language_layers(&self) -> usize {
+        self.model.resident_language_layers()
     }
 
     pub(crate) fn inspection(&self) -> &H3QwenNvfp4AwqInspection {
@@ -132,7 +148,7 @@ impl TensorLoadProgress<'_> {
     }
 }
 
-pub(crate) fn load_h3_qwen_nvfp4_conditioner(
+pub fn load_h3_qwen_nvfp4_conditioner(
     path: &Path,
     config: &H3ConditionerConfig,
     device: &Device,

--- a/crates/mold-inference/Cargo.toml
+++ b/crates/mold-inference/Cargo.toml
@@ -33,7 +33,7 @@ dev-bins = []
 # Development-only access to the authorization-bound MiniMax H3 artifact
 # qualifier. This feature is intentionally not forwarded by mold-ai or any
 # shipping surface; release verification rejects its embedded claim marker.
-h3-private-uat = []
+h3-private-uat = ["mold-candle/h3-private-uat"]
 
 [[bin]]
 name = "ltx2_checkpoint_probe"

--- a/crates/mold-inference/src/minimax_h3/mod.rs
+++ b/crates/mold-inference/src/minimax_h3/mod.rs
@@ -10,6 +10,8 @@ pub(crate) mod offload;
 pub(crate) mod pipeline;
 #[cfg(feature = "h3-private-uat")]
 pub mod private_qualification;
+#[cfg(feature = "h3-private-uat")]
+pub(crate) mod private_runtime;
 pub(crate) mod reference_media;
 pub(crate) mod sampler;
 pub(crate) mod vae_runtime;

--- a/crates/mold-inference/src/minimax_h3/private_runtime.rs
+++ b/crates/mold-inference/src/minimax_h3/private_runtime.rs
@@ -1,0 +1,310 @@
+//! Authorization-bound adapters for the private MiniMax H3 CUDA runtime.
+//!
+//! This module is compiled only by the developer-only `h3-private-uat`
+//! feature. It has no registry, capability, catalog, download, server, or CLI
+//! integration. The public family remains fail-closed; the adapters merely
+//! connect already-authenticated Candle objects to the runtime-neutral block
+//! streaming contract used by private qualification.
+
+use anyhow::{bail, Result};
+use mold_candle::minimax_h3::{
+    H3BlockProgress, H3BlockStack, H3ComfyInt8BlockLoader, H3ForwardInput, H3FrozenPackedLayout,
+    H3LoadedTransformerBlock, H3StreamedTransformer, H3TransformerOutput, H3TransformerStep,
+    H3TransformerTask,
+};
+
+use super::engine::H3StreamedTransformerExecutor;
+use super::offload::{FrozenH3BlockStreamingPlan, H3BlockLoader};
+use super::pipeline::{H3PipelineCheckpoint, H3PipelineEvent, H3PipelinePhase};
+
+const H3_MAIN_BLOCK_COUNT: usize = 50;
+
+/// Route-fenced adapter over the exact Comfy block loader returned alongside
+/// one resident streamed transformer.
+pub(crate) struct H3PrivateComfyBlockLoader {
+    inner: H3ComfyInt8BlockLoader,
+    device_id: String,
+    execution_fingerprint: String,
+}
+
+impl H3PrivateComfyBlockLoader {
+    fn new(inner: H3ComfyInt8BlockLoader, plan: &FrozenH3BlockStreamingPlan) -> Result<Self> {
+        plan.validate()?;
+        if plan.resident_block_count != 0 || plan.prefetch_depth != 0 {
+            bail!(
+                "private H3 Comfy streaming requires zero resident blocks and zero prefetch depth"
+            );
+        }
+        if inner.block_count() != H3_MAIN_BLOCK_COUNT {
+            bail!(
+                "private H3 Comfy loader exposes {} blocks, expected {H3_MAIN_BLOCK_COUNT}",
+                inner.block_count()
+            );
+        }
+        Ok(Self {
+            inner,
+            device_id: plan.device_id.clone(),
+            execution_fingerprint: plan.execution_fingerprint.clone(),
+        })
+    }
+
+    pub(crate) fn bytes_read(&self) -> u64 {
+        self.inner.bytes_read()
+    }
+
+    pub(crate) fn live_block_count(&self) -> usize {
+        self.inner.live_block_count()
+    }
+}
+
+impl H3BlockLoader for H3PrivateComfyBlockLoader {
+    type Block = H3LoadedTransformerBlock;
+
+    fn load_block(
+        &mut self,
+        index: usize,
+        device_id: &str,
+        execution_fingerprint: &str,
+    ) -> Result<Self::Block> {
+        if device_id != self.device_id || execution_fingerprint != self.execution_fingerprint {
+            bail!("private H3 Comfy block load differs from the frozen execution route");
+        }
+        Ok(self.inner.load_block(index)?)
+    }
+}
+
+/// Per-step executor over the resident projections, refiners, MM-RoPE, and
+/// output heads. Main blocks are supplied one at a time by the paired loader.
+pub(crate) struct H3PrivateComfyTransformerExecutor {
+    transformer: H3StreamedTransformer,
+    step: Option<H3TransformerStep>,
+}
+
+impl H3PrivateComfyTransformerExecutor {
+    fn new(transformer: H3StreamedTransformer) -> Self {
+        Self {
+            transformer,
+            step: None,
+        }
+    }
+}
+
+impl H3StreamedTransformerExecutor<H3LoadedTransformerBlock> for H3PrivateComfyTransformerExecutor {
+    fn begin_step(
+        &mut self,
+        input: H3ForwardInput<'_>,
+        layout: &H3FrozenPackedLayout,
+        checkpoint: &mut dyn H3PipelineCheckpoint,
+    ) -> Result<()> {
+        if self.step.is_some() {
+            bail!("private H3 streamed transformer already has an active denoise step");
+        }
+        let step = self
+            .transformer
+            .begin_step_with_observer(input, layout, |event| {
+                private_transformer_checkpoint(checkpoint, event)
+                    .map_err(|error| candle_core::Error::Msg(error.to_string()))
+            })?;
+        self.step = Some(step);
+        Ok(())
+    }
+
+    fn forward_block(
+        &mut self,
+        index: usize,
+        block: &H3LoadedTransformerBlock,
+        _checkpoint: &mut dyn H3PipelineCheckpoint,
+    ) -> Result<()> {
+        let step = self
+            .step
+            .as_mut()
+            .ok_or_else(|| anyhow::anyhow!("private H3 streamed step was not started"))?;
+        Ok(step.forward_block(index, block)?)
+    }
+
+    fn finish_step(
+        &mut self,
+        checkpoint: &mut dyn H3PipelineCheckpoint,
+    ) -> Result<H3TransformerOutput> {
+        let step = self
+            .step
+            .take()
+            .ok_or_else(|| anyhow::anyhow!("private H3 streamed step was not started"))?;
+        Ok(self.transformer.finish_step_with_observer(step, |event| {
+            private_transformer_checkpoint(checkpoint, event)
+                .map_err(|error| candle_core::Error::Msg(error.to_string()))
+        })?)
+    }
+
+    fn abort_step(&mut self) {
+        self.step = None;
+    }
+}
+
+/// Consume only a transformer/loader pair returned by the same authenticated
+/// checkpoint open. Pointer identity is still checked again by Candle for
+/// every streamed block.
+pub(crate) fn pair_private_comfy_stream(
+    transformer: H3StreamedTransformer,
+    loader: H3ComfyInt8BlockLoader,
+    plan: &FrozenH3BlockStreamingPlan,
+    expected_task: H3TransformerTask,
+) -> Result<(H3PrivateComfyBlockLoader, H3PrivateComfyTransformerExecutor)> {
+    let exact_open_pair = loader.is_exact_pair_for(&transformer);
+    validate_stream_pair(
+        plan,
+        expected_task,
+        transformer.task(),
+        transformer.block_count(),
+        transformer.checkpoint_identity_sha256(),
+        loader.task(),
+        loader.block_count(),
+        loader.checkpoint_identity_sha256(),
+        exact_open_pair,
+    )?;
+    Ok((
+        H3PrivateComfyBlockLoader::new(loader, plan)?,
+        H3PrivateComfyTransformerExecutor::new(transformer),
+    ))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn validate_stream_pair(
+    plan: &FrozenH3BlockStreamingPlan,
+    expected_task: H3TransformerTask,
+    transformer_task: H3TransformerTask,
+    transformer_blocks: usize,
+    transformer_checkpoint: Option<&str>,
+    loader_task: H3TransformerTask,
+    loader_blocks: usize,
+    loader_checkpoint: &str,
+    exact_open_pair: bool,
+) -> Result<()> {
+    plan.validate()?;
+    if plan.resident_block_count != 0 || plan.prefetch_depth != 0 {
+        bail!("private H3 Comfy streaming requires zero resident blocks and zero prefetch depth");
+    }
+    if transformer_task != expected_task || loader_task != expected_task {
+        bail!("private H3 Comfy transformer/loader task authority differs");
+    }
+    if transformer_blocks != H3_MAIN_BLOCK_COUNT || loader_blocks != H3_MAIN_BLOCK_COUNT {
+        bail!("private H3 Comfy transformer/loader block count differs from production");
+    }
+    if transformer_checkpoint != Some(loader_checkpoint) {
+        bail!("private H3 Comfy transformer and loader came from different checkpoints");
+    }
+    if !exact_open_pair {
+        bail!("private H3 Comfy transformer and loader came from different checkpoint opens");
+    }
+    Ok(())
+}
+
+fn private_transformer_checkpoint(
+    checkpoint: &mut dyn H3PipelineCheckpoint,
+    event: H3BlockProgress,
+) -> Result<()> {
+    let completed = match event.stack {
+        // The block stream owns 0..50. Refiners occur before block zero and
+        // output projection occurs after block fifty, so repeated boundary
+        // checkpoints preserve cancellation without inventing another scale.
+        H3BlockStack::TokenRefiner => 0,
+        H3BlockStack::Transformer => event.completed.min(H3_MAIN_BLOCK_COUNT),
+        H3BlockStack::Output => H3_MAIN_BLOCK_COUNT,
+    };
+    checkpoint.checkpoint(H3PipelineEvent {
+        phase: H3PipelinePhase::TransformerBlock,
+        completed,
+        total: H3_MAIN_BLOCK_COUNT,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FINGERPRINT: &str = "1111111111111111111111111111111111111111111111111111111111111111";
+    const CHECKPOINT: &str = "2222222222222222222222222222222222222222222222222222222222222222";
+
+    fn plan() -> FrozenH3BlockStreamingPlan {
+        FrozenH3BlockStreamingPlan::new("gpu-0", FINGERPRINT, 0, 0).unwrap()
+    }
+
+    #[test]
+    fn exact_comfy_stream_pair_is_accepted() {
+        validate_stream_pair(
+            &plan(),
+            H3TransformerTask::T2VaFl2Va,
+            H3TransformerTask::T2VaFl2Va,
+            50,
+            Some(CHECKPOINT),
+            H3TransformerTask::T2VaFl2Va,
+            50,
+            CHECKPOINT,
+            true,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn mixed_task_or_checkpoint_pair_is_rejected() {
+        let error = validate_stream_pair(
+            &plan(),
+            H3TransformerTask::T2VaFl2Va,
+            H3TransformerTask::Ref2Va,
+            50,
+            Some(CHECKPOINT),
+            H3TransformerTask::T2VaFl2Va,
+            50,
+            CHECKPOINT,
+            true,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("task authority"));
+
+        let error = validate_stream_pair(
+            &plan(),
+            H3TransformerTask::T2VaFl2Va,
+            H3TransformerTask::T2VaFl2Va,
+            50,
+            Some(CHECKPOINT),
+            H3TransformerTask::T2VaFl2Va,
+            50,
+            FINGERPRINT,
+            true,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("different checkpoints"));
+
+        let error = validate_stream_pair(
+            &plan(),
+            H3TransformerTask::T2VaFl2Va,
+            H3TransformerTask::T2VaFl2Va,
+            50,
+            Some(CHECKPOINT),
+            H3TransformerTask::T2VaFl2Va,
+            50,
+            CHECKPOINT,
+            false,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("different checkpoint opens"));
+    }
+
+    #[test]
+    fn multi_block_residency_is_rejected_for_single_live_loader() {
+        let plan = FrozenH3BlockStreamingPlan::new("gpu-0", FINGERPRINT, 1, 0).unwrap();
+        let error = validate_stream_pair(
+            &plan,
+            H3TransformerTask::T2VaFl2Va,
+            H3TransformerTask::T2VaFl2Va,
+            50,
+            Some(CHECKPOINT),
+            H3TransformerTask::T2VaFl2Va,
+            50,
+            CHECKPOINT,
+            true,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("zero resident blocks"));
+    }
+}

--- a/scripts/tests/minimax-h3-private-uat-release-contract.sh
+++ b/scripts/tests/minimax-h3-private-uat-release-contract.sh
@@ -16,9 +16,12 @@ require_text() {
   grep -Fq "$text" "$file" || fail "$message"
 }
 
-require_text crates/mold-inference/Cargo.toml \
+require_text crates/mold-candle/Cargo.toml \
   'h3-private-uat = []' \
-  "mold-inference does not expose the private H3 qualification feature"
+  "mold-candle does not keep the private H3 runtime behind its own feature"
+require_text crates/mold-inference/Cargo.toml \
+  'h3-private-uat = ["mold-candle/h3-private-uat"]' \
+  "mold-inference does not narrowly forward the private H3 runtime feature"
 require_text crates/mold-inference/Cargo.toml \
   'required-features = ["dev-bins", "h3-private-uat"]' \
   "the private H3 artifact qualifier is reachable without both development features"


### PR DESCRIPTION
## Summary

- add the developer-only `h3-private-uat` Candle feature and narrowly forward it from `mold-inference`
- expose the already-qualified Qwen NVFP4 conditioner only under that private feature
- adapt the Comfy INT8 opened-file block loader and resident streamed transformer to Mold's runtime-neutral loader/executor traits
- bind task, block count, checkpoint digest, exact opened-checkpoint identity, device route, and execution fingerprint before returning an executable pair
- require zero resident blocks and zero prefetch for the current single-live-block Comfy authority
- strengthen the private release contract so the new Candle forwarding is required while CLI and shipping feature sets remain rejected

## Safety boundary

This remains private qualification infrastructure only. No CLI, server, catalog, download, factory, capability, or release surface forwards `h3-private-uat`; ordinary public H3 activation remains fail-closed. The bridge does not yet construct an end-to-end runtime or generate media.

Part of #814. Advances #815, #830, #835, and #839.

## Verification

- `cargo fmt --all -- --check`
- `bash scripts/tests/minimax-h3-private-uat-release-contract.sh`
- `nix develop -c cargo clippy -p mold-ai-candle --lib --features h3-private-uat -- -D warnings`
- `nix develop -c cargo clippy -p mold-ai-inference --lib --features mp4,h3-private-uat -- -D warnings`
- `nix develop -c cargo test -p mold-ai-candle --lib --features h3-private-uat minimax_h3 -- --test-threads=1` (167 passed, 2 authorized-private tests ignored)
- `nix develop -c cargo test -p mold-ai-inference --lib --features h3-private-uat minimax_h3 -- --test-threads=1` (66 passed)
- independent peer review: no findings after adding a real same-path/same-digest mixed-reopen regression
