### PR TITLE
feat(h3): adapt private Comfy VAE runtime

### DIFF
--- a/crates/mold-candle/src/minimax_h3/audio.rs
+++ b/crates/mold-candle/src/minimax_h3/audio.rs
@@ -1063,14 +1063,42 @@ impl AudioVae {
         association: AudioSoundtrackAssociation,
         cancellation: &dyn AudioVaeCancellation,
     ) -> Result<StereoWaveform> {
-        cancellation_boundary(cancellation, AudioVaePhase::DecodeProjection)?;
+        self.decode_with_checkpoint(latents, association, &mut |phase| {
+            cancellation_boundary(cancellation, phase)
+        })
+    }
+
+    /// Decode with a fallible callback at each named audio safe point.
+    ///
+    /// This developer-only seam lets the private H3 pipeline preserve its
+    /// request-scoped cancellation and phase-accounting authority without
+    /// placing a non-`Send` pipeline checkpoint behind the public
+    /// [`AudioVaeCancellation`] trait.
+    #[cfg(feature = "h3-private-uat")]
+    #[doc(hidden)]
+    pub fn decode_with_phase_checkpoint(
+        &self,
+        latents: &StereoLatents,
+        association: AudioSoundtrackAssociation,
+        checkpoint: &mut dyn FnMut(AudioVaePhase) -> Result<()>,
+    ) -> Result<StereoWaveform> {
+        self.decode_with_checkpoint(latents, association, checkpoint)
+    }
+
+    fn decode_with_checkpoint(
+        &self,
+        latents: &StereoLatents,
+        association: AudioSoundtrackAssociation,
+        checkpoint: &mut dyn FnMut(AudioVaePhase) -> Result<()>,
+    ) -> Result<StereoWaveform> {
+        checkpoint(AudioVaePhase::DecodeProjection)?;
         let (batch, _, _, _) = latents.normalized().dims4()?;
         let packed = latents.pack_mono_batch()?;
         let denormalized = self.denormalize_mono_latents(&packed)?;
         let projected = self.dec_in_proj.forward(&denormalized)?;
-        cancellation_boundary(cancellation, AudioVaePhase::DecodeBigVgan)?;
+        checkpoint(AudioVaePhase::DecodeBigVgan)?;
         let decoded = self.decoder.forward(&projected)?;
-        cancellation_boundary(cancellation, AudioVaePhase::DecodeOutput)?;
+        checkpoint(AudioVaePhase::DecodeOutput)?;
         if self.config.sample_rate == SAMPLE_RATE {
             StereoWaveform::from_mono_batch(decoded, batch, self.config.sample_rate, association)
         } else {
@@ -1510,6 +1538,42 @@ mod tests {
                 )
                 .is_err());
             assert!(cancellation.seen.lock().unwrap().contains(&phase));
+        }
+        #[cfg(feature = "h3-private-uat")]
+        {
+            let mut phases = Vec::new();
+            vae.decode_with_phase_checkpoint(
+                &latents,
+                AudioSoundtrackAssociation::Generated,
+                &mut |phase| {
+                    phases.push(phase);
+                    Ok(())
+                },
+            )?;
+            assert_eq!(
+                phases,
+                [
+                    AudioVaePhase::DecodeProjection,
+                    AudioVaePhase::DecodeBigVgan,
+                    AudioVaePhase::DecodeOutput,
+                ]
+            );
+
+            let error = vae
+                .decode_with_phase_checkpoint(
+                    &latents,
+                    AudioSoundtrackAssociation::Generated,
+                    &mut |phase| {
+                        if phase == AudioVaePhase::DecodeBigVgan {
+                            bail!("synthetic pipeline cancellation")
+                        }
+                        Ok(())
+                    },
+                )
+                .unwrap_err();
+            assert!(error
+                .to_string()
+                .contains("synthetic pipeline cancellation"));
         }
         Ok(())
     }

--- a/crates/mold-inference/src/h3_factory.rs
+++ b/crates/mold-inference/src/h3_factory.rs
@@ -16,9 +16,10 @@ use crate::minimax_h3::backend::{
     H3ValidatedComponentSet,
 };
 use crate::minimax_h3::offload::FrozenH3BlockStreamingPlan;
+use crate::minimax_h3::vae_runtime::expected_h3_comfy_vae_artifact_plan_identity;
 use crate::minimax_h3::{FrozenH3ConditionerPlacement, H3ConditionerExecution};
 
-const H3_FACTORY_AUTHORITY_SCHEMA_VERSION: u32 = 1;
+const H3_FACTORY_AUTHORITY_SCHEMA_VERSION: u32 = 2;
 
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub enum H3FactoryComponentRole {
@@ -150,6 +151,7 @@ pub struct H3FactoryAuthorityInput {
 pub struct FrozenH3FactoryAuthority {
     schema_version: u32,
     backend_plan: FrozenH3Fl2VaCandlePlan,
+    comfy_vae_artifact_plan_identity_sha256: Option<String>,
     device_ordinal: usize,
     conditioner_placement: H3FactoryConditionerPlacement,
     qwen_parameter_bytes: u64,
@@ -165,6 +167,21 @@ pub struct FrozenH3FactoryAuthority {
     block_offload: bool,
     quantization: H3FactoryQuantizationAuthority,
     identity_sha256: String,
+}
+
+/// Private-only projection of the exact admission record needed to compose
+/// the opened-file Comfy VAEs with one already-authorized component backend.
+#[cfg(feature = "h3-private-uat")]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct H3PrivateVaeFactoryAuthority {
+    pub(crate) factory_identity_sha256: String,
+    pub(crate) backend_plan_identity_sha256: String,
+    pub(crate) vae_artifact_plan_identity_sha256: String,
+    pub(crate) component_set_identity_sha256: String,
+    pub(crate) canonical_model: String,
+    pub(crate) task: Task,
+    pub(crate) device_id: String,
+    pub(crate) execution_fingerprint: String,
 }
 
 impl FrozenH3FactoryAuthority {
@@ -255,9 +272,19 @@ impl FrozenH3FactoryAuthority {
             block_streaming,
             components,
         )?;
+        let comfy_vae_artifact_plan_identity_sha256 =
+            if model_contract.layout == Layout::ComfyPrunedInt8ConvrotNvfp4Awq {
+                Some(
+                    expected_h3_comfy_vae_artifact_plan_identity(model_contract.canonical_model)
+                        .map_err(|error| anyhow!(error.to_string()))?,
+                )
+            } else {
+                None
+            };
         let mut frozen = Self {
             schema_version: H3_FACTORY_AUTHORITY_SCHEMA_VERSION,
             backend_plan,
+            comfy_vae_artifact_plan_identity_sha256,
             device_ordinal: input.device_ordinal,
             conditioner_placement: input.conditioner_placement,
             qwen_parameter_bytes: input.qwen_parameter_bytes,
@@ -285,6 +312,33 @@ impl FrozenH3FactoryAuthority {
 
     pub fn component_set_identity_sha256(&self) -> &str {
         self.backend_plan.component_set_identity()
+    }
+
+    #[cfg(feature = "h3-private-uat")]
+    pub(crate) fn backend_plan_identity_sha256(&self) -> &str {
+        self.backend_plan.identity_sha256()
+    }
+
+    #[cfg(feature = "h3-private-uat")]
+    pub(crate) fn private_vae_adapter_authority(&self) -> Result<H3PrivateVaeFactoryAuthority> {
+        self.validate_frozen()?;
+        let vae_artifact_plan_identity_sha256 = self
+            .comfy_vae_artifact_plan_identity_sha256
+            .as_deref()
+            .ok_or_else(|| anyhow!("MiniMax H3 factory authority has no private Comfy VAE plan"))?;
+        if self.task() != Task::Fl2va {
+            bail!("private MiniMax H3 VAE adapter currently requires the FL2VA task authority");
+        }
+        Ok(H3PrivateVaeFactoryAuthority {
+            factory_identity_sha256: self.identity_sha256.clone(),
+            backend_plan_identity_sha256: self.backend_plan_identity_sha256().into(),
+            vae_artifact_plan_identity_sha256: vae_artifact_plan_identity_sha256.into(),
+            component_set_identity_sha256: self.component_set_identity_sha256().into(),
+            canonical_model: self.canonical_model().into(),
+            task: self.task(),
+            device_id: self.device_id().into(),
+            execution_fingerprint: self.execution_fingerprint().into(),
+        })
     }
 
     pub fn canonical_model(&self) -> &str {
@@ -385,6 +439,18 @@ impl FrozenH3FactoryAuthority {
             bail!("MiniMax H3 factory authority uses an unsupported schema version");
         }
         self.backend_plan.validate()?;
+        let expected_vae_plan =
+            if self.backend_plan.layout() == Layout::ComfyPrunedInt8ConvrotNvfp4Awq {
+                Some(
+                    expected_h3_comfy_vae_artifact_plan_identity(self.canonical_model())
+                        .map_err(|error| anyhow!(error.to_string()))?,
+                )
+            } else {
+                None
+            };
+        if self.comfy_vae_artifact_plan_identity_sha256 != expected_vae_plan {
+            bail!("MiniMax H3 factory VAE artifact plan changed after admission");
+        }
         if self.backend_plan.block_streaming().resident_block_count > 50
             || self.backend_plan.block_streaming().prefetch_depth > 2
         {
@@ -450,9 +516,17 @@ impl FrozenH3FactoryAuthority {
 
 fn frozen_identity(authority: &FrozenH3FactoryAuthority) -> String {
     let mut hash = Sha256::new();
-    hash.update(b"mold.minimax-h3.factory-authority.v1\0");
+    hash.update(b"mold.minimax-h3.factory-authority.v2\0");
     hash.update(authority.schema_version.to_le_bytes());
     hash.update(authority.backend_plan.identity_sha256().as_bytes());
+    hash.update([0]);
+    hash.update(
+        authority
+            .comfy_vae_artifact_plan_identity_sha256
+            .as_deref()
+            .unwrap_or("no-comfy-vae-plan")
+            .as_bytes(),
+    );
     hash.update(authority.device_ordinal.to_le_bytes());
     hash.update(match authority.conditioner_placement {
         H3FactoryConditionerPlacement::AssignedCudaThenDrop => b"qwen-cuda".as_slice(),
@@ -562,6 +636,23 @@ mod tests {
         assert_eq!(authority.execution_fingerprint(), sha('a'));
         assert_eq!(authority.identity_sha256().len(), 64);
         assert_eq!(authority.component_set_identity_sha256().len(), 64);
+        #[cfg(feature = "h3-private-uat")]
+        {
+            let vae = authority.private_vae_adapter_authority().unwrap();
+            assert_eq!(vae.factory_identity_sha256, authority.identity_sha256());
+            assert_eq!(
+                vae.backend_plan_identity_sha256,
+                authority.backend_plan_identity_sha256()
+            );
+            assert_eq!(
+                vae.component_set_identity_sha256,
+                authority.component_set_identity_sha256()
+            );
+            assert_eq!(
+                vae.vae_artifact_plan_identity_sha256,
+                expected_h3_comfy_vae_artifact_plan_identity(contract::FL2VA_COMFY).unwrap()
+            );
+        }
         assert!(authority.block_offload());
         assert!(matches!(
             authority.quantization(),
@@ -578,6 +669,9 @@ mod tests {
             |value| value.block_offload = false,
             |value| {
                 value.quantization = H3FactoryQuantizationAuthority::OfficialBf16;
+            },
+            |value| {
+                value.comfy_vae_artifact_plan_identity_sha256 = Some(sha('f'));
             },
         ] {
             let mut changed = authority();

--- a/crates/mold-inference/src/minimax_h3/mod.rs
+++ b/crates/mold-inference/src/minimax_h3/mod.rs
@@ -14,6 +14,8 @@ pub mod private_qualification;
 pub(crate) mod private_qwen_support;
 #[cfg(feature = "h3-private-uat")]
 pub(crate) mod private_runtime;
+#[cfg(feature = "h3-private-uat")]
+pub(crate) mod private_vae_adapter;
 pub(crate) mod reference_media;
 pub(crate) mod sampler;
 pub(crate) mod vae_runtime;

--- a/crates/mold-inference/src/minimax_h3/pipeline.rs
+++ b/crates/mold-inference/src/minimax_h3/pipeline.rs
@@ -903,7 +903,11 @@ impl H3VideoEncodeSink {
         Self::new_dimensions(geometry.width, geometry.height, geometry.frames)
     }
 
-    fn new_dimensions(width: usize, height: usize, expected_frames: usize) -> Result<Self> {
+    pub(super) fn new_dimensions(
+        width: usize,
+        height: usize,
+        expected_frames: usize,
+    ) -> Result<Self> {
         let width = u32::try_from(width).context("H3 width does not fit u32")?;
         let height = u32::try_from(height).context("H3 height does not fit u32")?;
         Ok(H3VideoEncodeSink {

--- a/crates/mold-inference/src/minimax_h3/private_vae_adapter.rs
+++ b/crates/mold-inference/src/minimax_h3/private_vae_adapter.rs
@@ -1,0 +1,1249 @@
+//! Authorization-bound VAE adapter for the private MiniMax H3 CUDA runtime.
+//!
+//! This module is compiled only by the developer-only `h3-private-uat`
+//! feature. It decorates an already-frozen, explicitly VAE-free FL2VA
+//! component backend with the opened-file-bound Comfy visual and audio VAE
+//! bundle. It has no registry, factory, capability, catalog, download, server,
+//! or CLI integration.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use anyhow::{bail, Result};
+use candle_core::{DType, Device, Tensor};
+use image::RgbImage;
+use mold_candle::minimax_h3::{
+    AudioSoundtrackAssociation, AudioVaePhase, DecodeSink, H3ForwardInput, H3FrozenPackedLayout,
+    H3TransformerOutput, StereoLatents, StereoWaveform, Uint8RgbPixels, VisualVaeEvent,
+    VisualVaeObserver,
+};
+use mold_core::minimax_h3::{self as contract, Task};
+
+use crate::h3_factory::H3PrivateVaeFactoryAuthority;
+use crate::FrozenH3FactoryAuthority;
+
+use super::pipeline::{
+    H3Fl2VaBackend, H3PipelineBackendIdentity, H3PipelineBackendKind, H3PipelineCheckpoint,
+    H3PipelineEvent, H3PipelinePhase, H3PreparedEndpoint, H3TextConditioning, H3VideoEncodeSink,
+};
+use super::vae_runtime::{H3ComfyVaeRuntimeBundle, H3ComfyVaeRuntimeMemory};
+
+pub(crate) trait H3PrivateVaeRuntime: Send + Sync {
+    fn task(&self) -> Task;
+    fn canonical_model(&self) -> &str;
+    fn plan_identity_sha256(&self) -> &str;
+    fn artifact_plan_identity_sha256(&self) -> &str;
+    fn authority_identity_sha256(&self) -> &str;
+    fn device(&self) -> &Device;
+    fn validate_authority(&self) -> Result<()>;
+
+    fn encode_visual_condition(
+        &self,
+        endpoint: &H3PreparedEndpoint,
+        mode: mold_candle::minimax_h3::ConditionEncodeMode,
+        checkpoint: &mut dyn H3PipelineCheckpoint,
+    ) -> Result<Tensor>;
+
+    fn decode_video(
+        &self,
+        latents: &Tensor,
+        sink: &mut H3VideoEncodeSink,
+        checkpoint: &mut dyn H3PipelineCheckpoint,
+    ) -> Result<()>;
+
+    fn decode_audio(
+        &self,
+        latents: &StereoLatents,
+        checkpoint: &mut dyn H3PipelineCheckpoint,
+    ) -> Result<StereoWaveform>;
+}
+
+impl H3PrivateVaeRuntime for H3ComfyVaeRuntimeBundle {
+    fn task(&self) -> Task {
+        self.task()
+    }
+
+    fn canonical_model(&self) -> &str {
+        self.canonical_model()
+    }
+
+    fn plan_identity_sha256(&self) -> &str {
+        self.plan_identity_sha256()
+    }
+
+    fn artifact_plan_identity_sha256(&self) -> &str {
+        self.artifact_plan_identity_sha256()
+    }
+
+    fn authority_identity_sha256(&self) -> &str {
+        self.authority_identity_sha256()
+    }
+
+    fn device(&self) -> &Device {
+        self.device()
+    }
+
+    fn validate_authority(&self) -> Result<()> {
+        Ok(self.validate_authority()?)
+    }
+
+    fn encode_visual_condition(
+        &self,
+        endpoint: &H3PreparedEndpoint,
+        mode: mold_candle::minimax_h3::ConditionEncodeMode,
+        checkpoint: &mut dyn H3PipelineCheckpoint,
+    ) -> Result<Tensor> {
+        let pixels = Uint8RgbPixels::new(endpoint.pixels.to_device(self.device())?)?;
+        let error_bridge = H3CallbackErrorBridge::default();
+        let mut observer = H3PrivateVisualObserver {
+            checkpoint,
+            phase: H3PipelinePhase::VisualConditionEncodeChunk,
+            error_bridge: error_bridge.clone(),
+        };
+        let result = self
+            .visual_vae
+            .encode_condition_u8(pixels, mode, &mut observer);
+        error_bridge.finish(result)
+    }
+
+    fn decode_video(
+        &self,
+        latents: &Tensor,
+        sink: &mut H3VideoEncodeSink,
+        checkpoint: &mut dyn H3PipelineCheckpoint,
+    ) -> Result<()> {
+        let checkpoint = Rc::new(RefCell::new(checkpoint));
+        let error_bridge = H3CallbackErrorBridge::default();
+        let mut decode_sink = H3PrivatePipelineDecodeSink {
+            sink,
+            checkpoint: Rc::clone(&checkpoint),
+            next_frame: 0,
+            error_bridge: error_bridge.clone(),
+        };
+        let mut observer = H3PrivateSharedVisualObserver {
+            checkpoint,
+            phase: H3PipelinePhase::VisualDecodeChunk,
+            error_bridge: error_bridge.clone(),
+        };
+        let result =
+            self.visual_vae
+                .decode_normalized_to_sink(latents, &mut decode_sink, &mut observer);
+        error_bridge.finish(result)
+    }
+
+    fn decode_audio(
+        &self,
+        latents: &StereoLatents,
+        checkpoint: &mut dyn H3PipelineCheckpoint,
+    ) -> Result<StereoWaveform> {
+        let error_bridge = H3CallbackErrorBridge::default();
+        let mut phase_checkpoint =
+            |phase| checkpoint_audio_decode_phase(checkpoint, phase, &error_bridge);
+        let result = self.audio_vae.decode_with_phase_checkpoint(
+            latents,
+            AudioSoundtrackAssociation::Generated,
+            &mut phase_checkpoint,
+        );
+        let waveform = error_bridge.finish(result)?;
+        checkpoint.checkpoint(H3PipelineEvent {
+            phase: H3PipelinePhase::AudioDecodeChunk,
+            completed: 3,
+            total: 3,
+        })?;
+        Ok(waveform)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct H3PrivateInnerAuthority {
+    factory_identity_sha256: String,
+    backend_plan_identity_sha256: String,
+    component_set_identity_sha256: String,
+}
+
+impl H3PrivateInnerAuthority {
+    pub(crate) fn new(
+        factory_identity_sha256: impl Into<String>,
+        backend_plan_identity_sha256: impl Into<String>,
+        component_set_identity_sha256: impl Into<String>,
+    ) -> Result<Self> {
+        let authority = Self {
+            factory_identity_sha256: factory_identity_sha256.into(),
+            backend_plan_identity_sha256: backend_plan_identity_sha256.into(),
+            component_set_identity_sha256: component_set_identity_sha256.into(),
+        };
+        if !valid_sha256(&authority.factory_identity_sha256)
+            || !valid_sha256(&authority.backend_plan_identity_sha256)
+            || !valid_sha256(&authority.component_set_identity_sha256)
+        {
+            bail!("private MiniMax H3 VAE-free inner authority is not exact SHA-256 evidence");
+        }
+        Ok(authority)
+    }
+
+    fn matches(&self, admitted: &H3PrivateVaeFactoryAuthority) -> bool {
+        self.factory_identity_sha256 == admitted.factory_identity_sha256
+            && self.backend_plan_identity_sha256 == admitted.backend_plan_identity_sha256
+            && self.component_set_identity_sha256 == admitted.component_set_identity_sha256
+    }
+}
+
+mod vae_free_inner_seal {
+    pub trait Sealed {}
+}
+
+/// Active-authority hook required of a decorated VAE-free component backend.
+///
+/// # Safety
+///
+/// An implementer must own no visual or audio VAE weights. Every call must
+/// revalidate its active execution lease and the artifact lease covering its
+/// complete admitted component set, then return the exact full-factory,
+/// backend-plan, and component-set identities from that live admission. The
+/// private seal deliberately prevents eager or otherwise VAE-owning backends
+/// from opting into this contract outside this module.
+#[allow(private_bounds)]
+pub(crate) unsafe trait H3PrivateVaeFreeInnerAuthority:
+    H3Fl2VaBackend + vae_free_inner_seal::Sealed
+{
+    fn validate_private_vae_free_inner_authority(&self) -> Result<H3PrivateInnerAuthority>;
+}
+
+/// VAE-only decorator for the existing FL2VA/T2VA component contract.
+///
+/// Field order is load-bearing. The visual/audio models and their source-file
+/// lease drop before the delegated backend, which may own the CUDA execution
+/// lease. Inside the runtime bundle, both models drop before the opened source
+/// descriptors.
+pub(crate) struct H3PrivateComfyVaeAdapter<B, R = H3ComfyVaeRuntimeBundle> {
+    vae: R,
+    inner: B,
+    frozen_identity: H3PipelineBackendIdentity,
+    admitted: H3PrivateVaeFactoryAuthority,
+    plan_identity_sha256: String,
+    authority_identity_sha256: String,
+}
+
+impl<B> H3PrivateComfyVaeAdapter<B>
+where
+    B: H3PrivateVaeFreeInnerAuthority,
+{
+    pub(crate) fn new(
+        inner: B,
+        vae: H3ComfyVaeRuntimeBundle,
+        authority: &FrozenH3FactoryAuthority,
+    ) -> Result<Self> {
+        Self::new_with_runtime(inner, vae, authority)
+    }
+
+    pub(crate) fn plan_identity_sha256(&self) -> &str {
+        &self.plan_identity_sha256
+    }
+
+    pub(crate) fn authority_identity_sha256(&self) -> &str {
+        &self.authority_identity_sha256
+    }
+
+    pub(crate) fn factory_identity_sha256(&self) -> &str {
+        &self.admitted.factory_identity_sha256
+    }
+
+    pub(crate) fn backend_plan_identity_sha256(&self) -> &str {
+        &self.admitted.backend_plan_identity_sha256
+    }
+
+    pub(crate) fn component_set_identity_sha256(&self) -> &str {
+        &self.admitted.component_set_identity_sha256
+    }
+
+    pub(crate) fn memory(&self) -> &H3ComfyVaeRuntimeMemory {
+        self.vae.memory()
+    }
+}
+
+impl<B, R> H3PrivateComfyVaeAdapter<B, R>
+where
+    B: H3PrivateVaeFreeInnerAuthority,
+    R: H3PrivateVaeRuntime,
+{
+    fn new_with_runtime(inner: B, vae: R, authority: &FrozenH3FactoryAuthority) -> Result<Self> {
+        let frozen_identity = inner.identity();
+        let admitted = authority.private_vae_adapter_authority()?;
+        validate_initial_authority(&inner, &vae, &frozen_identity, &admitted)?;
+        Ok(Self {
+            plan_identity_sha256: vae.plan_identity_sha256().into(),
+            authority_identity_sha256: vae.authority_identity_sha256().into(),
+            vae,
+            inner,
+            frozen_identity,
+            admitted,
+        })
+    }
+
+    fn validate_authority(&self) -> Result<()> {
+        self.vae.validate_authority()?;
+        let inner_authority = self.inner.validate_private_vae_free_inner_authority()?;
+        if self.inner.identity() != self.frozen_identity
+            || !self.inner.device().same_device(self.vae.device())
+            || self.vae.task() != Task::Fl2va
+            || self.vae.canonical_model() != contract::FL2VA_COMFY
+            || self.vae.artifact_plan_identity_sha256()
+                != self.admitted.vae_artifact_plan_identity_sha256
+            || !inner_authority.matches(&self.admitted)
+            || self.vae.plan_identity_sha256() != self.plan_identity_sha256
+            || self.vae.authority_identity_sha256() != self.authority_identity_sha256
+        {
+            bail!("private MiniMax H3 VAE authority changed after composition");
+        }
+        Ok(())
+    }
+
+    fn checked<T>(&self, operation: impl FnOnce(&R) -> Result<T>) -> Result<T> {
+        self.validate_authority()?;
+        let result = operation(&self.vae);
+        self.validate_authority()?;
+        result
+    }
+}
+
+impl<B, R> H3Fl2VaBackend for H3PrivateComfyVaeAdapter<B, R>
+where
+    B: H3PrivateVaeFreeInnerAuthority,
+    R: H3PrivateVaeRuntime,
+{
+    fn identity(&self) -> H3PipelineBackendIdentity {
+        self.frozen_identity.clone()
+    }
+
+    fn device(&self) -> &Device {
+        self.inner.device()
+    }
+
+    fn encode_text(
+        &mut self,
+        prompt: &str,
+        endpoints: &[H3PreparedEndpoint],
+        checkpoint: &mut dyn H3PipelineCheckpoint,
+    ) -> Result<H3TextConditioning> {
+        self.validate_authority()?;
+        let result = self.inner.encode_text(prompt, endpoints, checkpoint);
+        self.validate_authority()?;
+        result
+    }
+
+    fn encode_visual_condition(
+        &mut self,
+        endpoint: &H3PreparedEndpoint,
+        mode: mold_candle::minimax_h3::ConditionEncodeMode,
+        checkpoint: &mut dyn H3PipelineCheckpoint,
+    ) -> Result<Tensor> {
+        self.checked(|vae| vae.encode_visual_condition(endpoint, mode, checkpoint))
+    }
+
+    fn denoise(
+        &mut self,
+        input: H3ForwardInput<'_>,
+        layout: &H3FrozenPackedLayout,
+        checkpoint: &mut dyn H3PipelineCheckpoint,
+    ) -> Result<H3TransformerOutput> {
+        self.validate_authority()?;
+        let result = self.inner.denoise(input, layout, checkpoint);
+        self.validate_authority()?;
+        result
+    }
+
+    fn decode_video(
+        &mut self,
+        latents: &Tensor,
+        sink: &mut H3VideoEncodeSink,
+        checkpoint: &mut dyn H3PipelineCheckpoint,
+    ) -> Result<()> {
+        self.checked(|vae| vae.decode_video(latents, sink, checkpoint))
+    }
+
+    fn decode_audio(
+        &mut self,
+        latents: &StereoLatents,
+        checkpoint: &mut dyn H3PipelineCheckpoint,
+    ) -> Result<StereoWaveform> {
+        self.checked(|vae| vae.decode_audio(latents, checkpoint))
+    }
+}
+
+fn validate_initial_authority<B, R>(
+    inner: &B,
+    vae: &R,
+    identity: &H3PipelineBackendIdentity,
+    admitted: &H3PrivateVaeFactoryAuthority,
+) -> Result<()>
+where
+    B: H3PrivateVaeFreeInnerAuthority,
+    R: H3PrivateVaeRuntime,
+{
+    vae.validate_authority()?;
+    let inner_authority = inner.validate_private_vae_free_inner_authority()?;
+    let supported_route = matches!(identity.kind, H3PipelineBackendKind::Cuda)
+        || cfg!(test) && matches!(identity.kind, H3PipelineBackendKind::SyntheticCpu);
+    if !supported_route
+        || identity.device_id.trim().is_empty()
+        || identity.execution_fingerprint.trim().is_empty()
+        || identity.device_id != admitted.device_id
+        || identity.execution_fingerprint != admitted.execution_fingerprint
+        || !inner.device().same_device(vae.device())
+        || admitted.task != Task::Fl2va
+        || admitted.canonical_model != contract::FL2VA_COMFY
+        || vae.task() != admitted.task
+        || vae.canonical_model() != admitted.canonical_model
+        || vae.artifact_plan_identity_sha256() != admitted.vae_artifact_plan_identity_sha256
+        || !inner_authority.matches(admitted)
+        || !valid_sha256(vae.plan_identity_sha256())
+        || !valid_sha256(vae.authority_identity_sha256())
+    {
+        bail!("private MiniMax H3 VAE runtime does not match the frozen FL2VA route");
+    }
+    Ok(())
+}
+
+fn valid_sha256(value: &str) -> bool {
+    value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn audio_decode_phase_progress(phase: AudioVaePhase) -> candle_core::Result<usize> {
+    match phase {
+        AudioVaePhase::DecodeProjection => Ok(0),
+        AudioVaePhase::DecodeBigVgan => Ok(1),
+        AudioVaePhase::DecodeOutput => Ok(2),
+        _ => candle_core::bail!("MiniMax H3 audio decoder reported an encode-only phase"),
+    }
+}
+
+fn checkpoint_audio_decode_phase(
+    checkpoint: &mut dyn H3PipelineCheckpoint,
+    phase: AudioVaePhase,
+    error_bridge: &H3CallbackErrorBridge,
+) -> candle_core::Result<()> {
+    let completed = audio_decode_phase_progress(phase)?;
+    checkpoint
+        .checkpoint(H3PipelineEvent {
+            phase: H3PipelinePhase::AudioDecodeChunk,
+            completed,
+            total: 3,
+        })
+        .map_err(|error| error_bridge.capture(error))
+}
+
+/// Candle callbacks can return only `candle_core::Error`. Keep the original
+/// `anyhow::Error` beside that transport error so `InferenceCancelled` and any
+/// future typed pipeline error survive the model boundary unchanged.
+#[derive(Clone, Default)]
+struct H3CallbackErrorBridge {
+    original: Rc<RefCell<Option<anyhow::Error>>>,
+}
+
+impl H3CallbackErrorBridge {
+    fn capture(&self, error: anyhow::Error) -> candle_core::Error {
+        let message = error.to_string();
+        let mut original = self.original.borrow_mut();
+        if original.is_none() {
+            *original = Some(error);
+        }
+        candle_core::Error::Msg(message)
+    }
+
+    fn finish<T>(&self, result: candle_core::Result<T>) -> Result<T> {
+        let original = self.original.borrow_mut().take();
+        match (result, original) {
+            (Ok(value), None) => Ok(value),
+            (Ok(_), Some(error)) | (Err(_), Some(error)) => Err(error),
+            (Err(error), None) => Err(error.into()),
+        }
+    }
+}
+
+struct H3PrivateVisualObserver<'a> {
+    checkpoint: &'a mut dyn H3PipelineCheckpoint,
+    phase: H3PipelinePhase,
+    error_bridge: H3CallbackErrorBridge,
+}
+
+impl VisualVaeObserver for H3PrivateVisualObserver<'_> {
+    fn checkpoint(&mut self, event: VisualVaeEvent) -> candle_core::Result<()> {
+        self.checkpoint
+            .checkpoint(H3PipelineEvent {
+                phase: self.phase,
+                completed: event.completed,
+                total: event.total.max(1),
+            })
+            .map_err(|error| self.error_bridge.capture(error))
+    }
+}
+
+struct H3PrivatePipelineDecodeSink<'sink, 'checkpoint> {
+    sink: &'sink mut H3VideoEncodeSink,
+    checkpoint: Rc<RefCell<&'checkpoint mut dyn H3PipelineCheckpoint>>,
+    next_frame: usize,
+    error_bridge: H3CallbackErrorBridge,
+}
+
+impl DecodeSink for H3PrivatePipelineDecodeSink<'_, '_> {
+    fn write(&mut self, frame_offset: usize, frames: &Tensor) -> candle_core::Result<()> {
+        if frame_offset != self.next_frame {
+            candle_core::bail!(
+                "MiniMax H3 decoder emitted frame offset {frame_offset}, expected {}",
+                self.next_frame
+            );
+        }
+        let (batch, channels, count, height, width) = frames.dims5()?;
+        if batch != 1 || channels != 3 || frames.dtype() != DType::F32 {
+            candle_core::bail!("MiniMax H3 decoded frames must be FP32 [1,3,T,H,W]");
+        }
+        let values = frames
+            .to_device(&Device::Cpu)?
+            .flatten_all()?
+            .to_vec1::<f32>()?;
+        for frame_index in 0..count {
+            let rgb_bytes = height
+                .checked_mul(width)
+                .and_then(|pixels| pixels.checked_mul(3))
+                .ok_or_else(|| candle_core::Error::Msg("H3 RGB frame size overflow".into()))?;
+            let mut rgb = Vec::with_capacity(rgb_bytes);
+            for row in 0..height {
+                for column in 0..width {
+                    for channel in 0..3 {
+                        let value = values
+                            [((channel * count + frame_index) * height + row) * width + column];
+                        rgb.push((value.clamp(0.0, 1.0) * 255.0).round() as u8);
+                    }
+                }
+            }
+            let width = u32::try_from(width)
+                .map_err(|_| candle_core::Error::Msg("H3 RGB frame width exceeds U32".into()))?;
+            let height = u32::try_from(height)
+                .map_err(|_| candle_core::Error::Msg("H3 RGB frame height exceeds U32".into()))?;
+            let image = RgbImage::from_raw(width, height, rgb)
+                .ok_or_else(|| candle_core::Error::Msg("H3 RGB frame shape overflow".into()))?;
+            let mut checkpoint = self.checkpoint.borrow_mut();
+            self.sink
+                .push(&image, &mut **checkpoint)
+                .map_err(|error| self.error_bridge.capture(error))?;
+            self.next_frame += 1;
+        }
+        Ok(())
+    }
+}
+
+struct H3PrivateSharedVisualObserver<'a> {
+    checkpoint: Rc<RefCell<&'a mut dyn H3PipelineCheckpoint>>,
+    phase: H3PipelinePhase,
+    error_bridge: H3CallbackErrorBridge,
+}
+
+impl VisualVaeObserver for H3PrivateSharedVisualObserver<'_> {
+    fn checkpoint(&mut self, event: VisualVaeEvent) -> candle_core::Result<()> {
+        self.checkpoint
+            .borrow_mut()
+            .checkpoint(H3PipelineEvent {
+                phase: self.phase,
+                completed: event.completed,
+                total: event.total.max(1),
+            })
+            .map_err(|error| self.error_bridge.capture(error))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    use anyhow::anyhow;
+    use mold_candle::minimax_h3::{
+        AudioVaeConfig, ConditionEncodeMode, H3Modality, H3PackedLayout, LATENT_CHANNELS,
+    };
+
+    use super::*;
+    use crate::attention::{AttentionBackend, AttentionChunkPolicy};
+    use crate::minimax_h3::backend::{
+        H3BackendArtifactLease, H3BackendExecutionLease, H3CandleBackend,
+    };
+    use crate::minimax_h3::H3ConditionerLease;
+    use crate::progress::{is_inference_cancelled, InferenceCancelled};
+    use crate::{
+        H3FactoryAuthorityInput, H3FactoryComponentAuthority, H3FactoryComponentRole,
+        H3FactoryConditionerPlacement, H3FactoryQuantizationAuthority,
+    };
+
+    const PLAN: &str = "1111111111111111111111111111111111111111111111111111111111111111";
+    const AUTHORITY: &str = "2222222222222222222222222222222222222222222222222222222222222222";
+    const EXECUTION: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    // Compile-time negative assertion: if the eager backend ever implements
+    // the VAE-free marker, inference of `_` becomes ambiguous and this test
+    // module stops compiling. The private seal prevents accidental opt-in;
+    // this assertion also guards an intentional attempt to open that seal.
+    #[allow(dead_code)]
+    fn assert_eager_h3_candle_backend_is_not_vae_free<C, E, A>()
+    where
+        C: H3ConditionerLease,
+        E: H3BackendExecutionLease,
+        A: H3BackendArtifactLease,
+    {
+        trait AmbiguousIfVaeFree<Marker> {
+            fn assert_not_implemented() {}
+        }
+        impl<T: ?Sized> AmbiguousIfVaeFree<()> for T {}
+        struct ImplementsVaeFree;
+        impl<T: ?Sized + H3PrivateVaeFreeInnerAuthority> AmbiguousIfVaeFree<ImplementsVaeFree> for T {}
+
+        <H3CandleBackend<'static, C, E, A> as AmbiguousIfVaeFree<_>>::assert_not_implemented();
+    }
+
+    fn sha(byte: char) -> String {
+        std::iter::repeat_n(byte, 64).collect()
+    }
+
+    fn authority_with_qwen_parameter_bytes(qwen_parameter_bytes: u64) -> FrozenH3FactoryAuthority {
+        FrozenH3FactoryAuthority::new_contract_only(H3FactoryAuthorityInput {
+            model: contract::FL2VA_COMFY.into(),
+            device_id: "test-cpu".into(),
+            device_ordinal: 0,
+            compute_capability: (8, 9),
+            execution_fingerprint: EXECUTION.into(),
+            conditioner_placement: H3FactoryConditionerPlacement::HostCpuThenDrop,
+            qwen_parameter_bytes,
+            qwen_activation_workspace_bytes: 1_024,
+            resident_block_count: 0,
+            prefetch_depth: 0,
+            attention_backend: AttentionBackend::Flash,
+            attention_chunk: AttentionChunkPolicy::Off,
+            attention_kernel_identity: "synthetic-lossless-packed-attention-v1".into(),
+            attention_qualification_sha256: sha('b'),
+            attention_full_noncausal: true,
+            attention_lossless: true,
+            attention_head_count: 56,
+            attention_head_dim: 128,
+            block_offload: true,
+            quantization: H3FactoryQuantizationAuthority::ComfyPrunedInt8ConvrotNvfp4Awq {
+                transformer_policy_sha256: sha('c'),
+                qwen_policy_sha256: sha('d'),
+                pruned_adaln_table_sha256: sha('e'),
+            },
+            components: [
+                H3FactoryComponentRole::Conditioner,
+                H3FactoryComponentRole::Transformer,
+                H3FactoryComponentRole::VisualVae,
+                H3FactoryComponentRole::AudioVae,
+            ]
+            .into_iter()
+            .enumerate()
+            .map(|(index, role)| {
+                H3FactoryComponentAuthority::new(
+                    role,
+                    sha(char::from(b'1' + index as u8)),
+                    sha(char::from(b'5' + index as u8)),
+                )
+                .unwrap()
+            })
+            .collect(),
+        })
+        .unwrap()
+    }
+
+    fn authority() -> FrozenH3FactoryAuthority {
+        authority_with_qwen_parameter_bytes(2_048)
+    }
+
+    #[derive(Default)]
+    struct RecordingCheckpoint {
+        events: Vec<H3PipelineEvent>,
+        fail_at: Option<usize>,
+    }
+
+    impl H3PipelineCheckpoint for RecordingCheckpoint {
+        fn checkpoint(&mut self, event: H3PipelineEvent) -> Result<()> {
+            self.events.push(event);
+            if self.fail_at == Some(self.events.len()) {
+                bail!("cancelled by synthetic checkpoint");
+            }
+            Ok(())
+        }
+    }
+
+    struct CancelCheckpoint;
+
+    impl H3PipelineCheckpoint for CancelCheckpoint {
+        fn checkpoint(&mut self, _event: H3PipelineEvent) -> Result<()> {
+            Err(InferenceCancelled.into())
+        }
+    }
+
+    struct FakeBackend {
+        device: Device,
+        identity: H3PipelineBackendIdentity,
+        inner_authority: H3PrivateInnerAuthority,
+        inner_authority_after_text: Option<H3PrivateInnerAuthority>,
+        execution_active: Arc<AtomicBool>,
+        artifact_active: Arc<AtomicBool>,
+        delegated_text: Arc<Mutex<usize>>,
+        denoise_calls: Arc<AtomicUsize>,
+        drops: Arc<Mutex<Vec<&'static str>>>,
+    }
+
+    impl Drop for FakeBackend {
+        fn drop(&mut self) {
+            self.drops.lock().unwrap().push("backend");
+        }
+    }
+
+    impl super::vae_free_inner_seal::Sealed for FakeBackend {}
+
+    // SAFETY: this synthetic backend owns no visual or audio VAE model. Its
+    // only artifact/execution state is represented by the two active flags,
+    // and it returns the exact frozen factory, backend-plan, and component-set
+    // identities after revalidating both flags on every authority query.
+    unsafe impl H3PrivateVaeFreeInnerAuthority for FakeBackend {
+        fn validate_private_vae_free_inner_authority(&self) -> Result<H3PrivateInnerAuthority> {
+            if !self.execution_active.load(Ordering::SeqCst) {
+                bail!("synthetic execution lease revoked");
+            }
+            if !self.artifact_active.load(Ordering::SeqCst) {
+                bail!("synthetic artifact lease revoked");
+            }
+            Ok(self.inner_authority.clone())
+        }
+    }
+
+    impl H3Fl2VaBackend for FakeBackend {
+        fn identity(&self) -> H3PipelineBackendIdentity {
+            self.identity.clone()
+        }
+
+        fn device(&self) -> &Device {
+            &self.device
+        }
+
+        fn encode_text(
+            &mut self,
+            _prompt: &str,
+            _endpoints: &[H3PreparedEndpoint],
+            _checkpoint: &mut dyn H3PipelineCheckpoint,
+        ) -> Result<H3TextConditioning> {
+            *self.delegated_text.lock().unwrap() += 1;
+            if let Some(authority) = self.inner_authority_after_text.take() {
+                self.inner_authority = authority;
+            }
+            Err(anyhow!("synthetic delegated text stop"))
+        }
+
+        fn encode_visual_condition(
+            &mut self,
+            _endpoint: &H3PreparedEndpoint,
+            _mode: ConditionEncodeMode,
+            _checkpoint: &mut dyn H3PipelineCheckpoint,
+        ) -> Result<Tensor> {
+            bail!("inner VAE must not be used")
+        }
+
+        fn denoise(
+            &mut self,
+            input: H3ForwardInput<'_>,
+            _layout: &H3FrozenPackedLayout,
+            _checkpoint: &mut dyn H3PipelineCheckpoint,
+        ) -> Result<H3TransformerOutput> {
+            self.denoise_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(H3TransformerOutput {
+                video: input.video_rows.clone(),
+                audio: input.audio_rows.clone(),
+            })
+        }
+
+        fn decode_video(
+            &mut self,
+            _latents: &Tensor,
+            _sink: &mut H3VideoEncodeSink,
+            _checkpoint: &mut dyn H3PipelineCheckpoint,
+        ) -> Result<()> {
+            bail!("inner VAE must not be used")
+        }
+
+        fn decode_audio(
+            &mut self,
+            _latents: &StereoLatents,
+            _checkpoint: &mut dyn H3PipelineCheckpoint,
+        ) -> Result<StereoWaveform> {
+            bail!("inner VAE must not be used")
+        }
+    }
+
+    struct FakeVaeRuntime {
+        device: Device,
+        task: Task,
+        model: &'static str,
+        plan: &'static str,
+        artifact_plan: String,
+        authority: &'static str,
+        active: Arc<AtomicBool>,
+        visual_calls: Arc<Mutex<usize>>,
+        audio_calls: Arc<AtomicUsize>,
+        drops: Arc<Mutex<Vec<&'static str>>>,
+    }
+
+    impl Drop for FakeVaeRuntime {
+        fn drop(&mut self) {
+            self.drops.lock().unwrap().push("vae");
+        }
+    }
+
+    impl H3PrivateVaeRuntime for FakeVaeRuntime {
+        fn task(&self) -> Task {
+            self.task
+        }
+
+        fn canonical_model(&self) -> &str {
+            self.model
+        }
+
+        fn plan_identity_sha256(&self) -> &str {
+            self.plan
+        }
+
+        fn artifact_plan_identity_sha256(&self) -> &str {
+            &self.artifact_plan
+        }
+
+        fn authority_identity_sha256(&self) -> &str {
+            self.authority
+        }
+
+        fn device(&self) -> &Device {
+            &self.device
+        }
+
+        fn validate_authority(&self) -> Result<()> {
+            if self.active.load(Ordering::SeqCst) {
+                Ok(())
+            } else {
+                bail!("synthetic VAE lease is inactive")
+            }
+        }
+
+        fn encode_visual_condition(
+            &self,
+            _endpoint: &H3PreparedEndpoint,
+            _mode: ConditionEncodeMode,
+            checkpoint: &mut dyn H3PipelineCheckpoint,
+        ) -> Result<Tensor> {
+            *self.visual_calls.lock().unwrap() += 1;
+            checkpoint.checkpoint(H3PipelineEvent {
+                phase: H3PipelinePhase::VisualConditionEncodeChunk,
+                completed: 1,
+                total: 1,
+            })?;
+            Ok(Tensor::zeros((1, 16, 1, 1, 1), DType::F32, &self.device)?)
+        }
+
+        fn decode_video(
+            &self,
+            _latents: &Tensor,
+            _sink: &mut H3VideoEncodeSink,
+            _checkpoint: &mut dyn H3PipelineCheckpoint,
+        ) -> Result<()> {
+            Ok(())
+        }
+
+        fn decode_audio(
+            &self,
+            _latents: &StereoLatents,
+            _checkpoint: &mut dyn H3PipelineCheckpoint,
+        ) -> Result<StereoWaveform> {
+            self.audio_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(StereoWaveform::new(
+                Tensor::zeros((1, 2, 1), DType::F32, &self.device)?,
+                32_000,
+                AudioSoundtrackAssociation::Generated,
+            )?)
+        }
+    }
+
+    fn inner_authority(authority: &FrozenH3FactoryAuthority) -> H3PrivateInnerAuthority {
+        let admitted = authority.private_vae_adapter_authority().unwrap();
+        H3PrivateInnerAuthority::new(
+            admitted.factory_identity_sha256,
+            admitted.backend_plan_identity_sha256,
+            admitted.component_set_identity_sha256,
+        )
+        .unwrap()
+    }
+
+    fn backend(
+        drops: Arc<Mutex<Vec<&'static str>>>,
+        authority: &FrozenH3FactoryAuthority,
+    ) -> FakeBackend {
+        FakeBackend {
+            device: Device::Cpu,
+            identity: H3PipelineBackendIdentity {
+                kind: H3PipelineBackendKind::SyntheticCpu,
+                device_id: "test-cpu".into(),
+                execution_fingerprint: EXECUTION.into(),
+            },
+            inner_authority: inner_authority(authority),
+            inner_authority_after_text: None,
+            execution_active: Arc::new(AtomicBool::new(true)),
+            artifact_active: Arc::new(AtomicBool::new(true)),
+            delegated_text: Arc::new(Mutex::new(0)),
+            denoise_calls: Arc::new(AtomicUsize::new(0)),
+            drops,
+        }
+    }
+
+    fn runtime(
+        drops: Arc<Mutex<Vec<&'static str>>>,
+        authority: &FrozenH3FactoryAuthority,
+    ) -> FakeVaeRuntime {
+        FakeVaeRuntime {
+            device: Device::Cpu,
+            task: Task::Fl2va,
+            model: contract::FL2VA_COMFY,
+            plan: PLAN,
+            artifact_plan: authority
+                .private_vae_adapter_authority()
+                .unwrap()
+                .vae_artifact_plan_identity_sha256,
+            authority: AUTHORITY,
+            active: Arc::new(AtomicBool::new(true)),
+            visual_calls: Arc::new(Mutex::new(0)),
+            audio_calls: Arc::new(AtomicUsize::new(0)),
+            drops,
+        }
+    }
+
+    fn frozen_layout() -> H3FrozenPackedLayout {
+        H3PackedLayout::new(
+            vec![[0.0; 3]; 3],
+            vec![0, 1, 2],
+            vec![
+                H3Modality::Video as u32,
+                H3Modality::Audio as u32,
+                H3Modality::Text as u32,
+            ],
+            vec![0],
+            vec![1],
+            vec![2],
+        )
+        .unwrap()
+        .freeze(&Device::Cpu)
+        .unwrap()
+    }
+
+    fn forward_inputs() -> (Tensor, Tensor, Tensor, Tensor) {
+        (
+            Tensor::zeros((1, 1, 2), DType::F32, &Device::Cpu).unwrap(),
+            Tensor::zeros((1, 1, 3), DType::F32, &Device::Cpu).unwrap(),
+            Tensor::zeros((1, 1, 4), DType::F32, &Device::Cpu).unwrap(),
+            Tensor::zeros(3, DType::F32, &Device::Cpu).unwrap(),
+        )
+    }
+
+    #[test]
+    fn exact_private_vae_decorates_only_vae_operations() {
+        let authority = authority();
+        let drops = Arc::new(Mutex::new(Vec::new()));
+        let delegated_text = Arc::new(Mutex::new(0));
+        let visual_calls = Arc::new(Mutex::new(0));
+        let mut inner = backend(Arc::clone(&drops), &authority);
+        inner.delegated_text = Arc::clone(&delegated_text);
+        let mut vae = runtime(Arc::clone(&drops), &authority);
+        vae.visual_calls = Arc::clone(&visual_calls);
+        let mut adapter =
+            H3PrivateComfyVaeAdapter::new_with_runtime(inner, vae, &authority).unwrap();
+        let mut checkpoint = RecordingCheckpoint::default();
+
+        let text_error = adapter
+            .encode_text("prompt", &[], &mut checkpoint)
+            .unwrap_err();
+        assert!(text_error.to_string().contains("delegated text"));
+        assert_eq!(*delegated_text.lock().unwrap(), 1);
+
+        let endpoint = H3PreparedEndpoint {
+            anchor: super::super::pipeline::H3EndpointAnchor::First,
+            source_width: 1,
+            source_height: 1,
+            resize: super::super::pipeline::H3EndpointResize::Identity,
+            pixels: Tensor::zeros((1, 3, 1, 1, 1), DType::U8, &Device::Cpu).unwrap(),
+        };
+        adapter
+            .encode_visual_condition(
+                &endpoint,
+                ConditionEncodeMode::OfficialFreshSeed42,
+                &mut checkpoint,
+            )
+            .unwrap();
+        assert_eq!(*visual_calls.lock().unwrap(), 1);
+        assert_eq!(
+            checkpoint.events.last().unwrap().phase,
+            H3PipelinePhase::VisualConditionEncodeChunk
+        );
+    }
+
+    #[test]
+    fn mixed_task_artifact_or_inactive_lease_is_rejected() {
+        let authority = authority();
+        let drops = Arc::new(Mutex::new(Vec::new()));
+        let mut wrong_task = runtime(Arc::clone(&drops), &authority);
+        wrong_task.task = Task::Ref2va;
+        assert!(H3PrivateComfyVaeAdapter::new_with_runtime(
+            backend(Arc::clone(&drops), &authority),
+            wrong_task,
+            &authority,
+        )
+        .err()
+        .unwrap()
+        .to_string()
+        .contains("frozen FL2VA route"));
+
+        let mut wrong_artifact = runtime(Arc::clone(&drops), &authority);
+        wrong_artifact.plan = "not-a-digest";
+        assert!(H3PrivateComfyVaeAdapter::new_with_runtime(
+            backend(Arc::clone(&drops), &authority),
+            wrong_artifact,
+            &authority,
+        )
+        .err()
+        .unwrap()
+        .to_string()
+        .contains("frozen FL2VA route"));
+
+        let inactive = runtime(Arc::clone(&drops), &authority);
+        inactive.active.store(false, Ordering::SeqCst);
+        assert!(H3PrivateComfyVaeAdapter::new_with_runtime(
+            backend(Arc::clone(&drops), &authority),
+            inactive,
+            &authority,
+        )
+        .err()
+        .unwrap()
+        .to_string()
+        .contains("inactive"));
+    }
+
+    #[test]
+    fn cross_plan_and_cross_component_composition_fail_before_work() {
+        let authority = authority();
+        let drops = Arc::new(Mutex::new(Vec::new()));
+        let visual_calls = Arc::new(Mutex::new(0));
+
+        let mut wrong_plan = runtime(Arc::clone(&drops), &authority);
+        wrong_plan.artifact_plan = sha('f');
+        wrong_plan.visual_calls = Arc::clone(&visual_calls);
+        let error = H3PrivateComfyVaeAdapter::new_with_runtime(
+            backend(Arc::clone(&drops), &authority),
+            wrong_plan,
+            &authority,
+        )
+        .err()
+        .unwrap();
+        assert!(error.to_string().contains("frozen FL2VA route"));
+        assert_eq!(*visual_calls.lock().unwrap(), 0);
+
+        let mut wrong_components = backend(Arc::clone(&drops), &authority);
+        wrong_components
+            .inner_authority
+            .component_set_identity_sha256 = sha('f');
+        let error = H3PrivateComfyVaeAdapter::new_with_runtime(
+            wrong_components,
+            runtime(Arc::clone(&drops), &authority),
+            &authority,
+        )
+        .err()
+        .unwrap();
+        assert!(error.to_string().contains("frozen FL2VA route"));
+        assert_eq!(*visual_calls.lock().unwrap(), 0);
+    }
+
+    #[test]
+    fn outer_factory_admission_must_match_initial_before_and_after_work() {
+        let authority = authority();
+        let changed_outer_authority = authority_with_qwen_parameter_bytes(2_049);
+        let exact = authority.private_vae_adapter_authority().unwrap();
+        let changed = changed_outer_authority
+            .private_vae_adapter_authority()
+            .unwrap();
+        assert_ne!(
+            exact.factory_identity_sha256,
+            changed.factory_identity_sha256
+        );
+        assert_eq!(
+            exact.backend_plan_identity_sha256,
+            changed.backend_plan_identity_sha256
+        );
+        assert_eq!(
+            exact.component_set_identity_sha256,
+            changed.component_set_identity_sha256
+        );
+        assert_eq!(exact.device_id, changed.device_id);
+        assert_eq!(exact.execution_fingerprint, changed.execution_fingerprint);
+
+        let drops = Arc::new(Mutex::new(Vec::new()));
+        let error = H3PrivateComfyVaeAdapter::new_with_runtime(
+            backend(Arc::clone(&drops), &authority),
+            runtime(Arc::clone(&drops), &changed_outer_authority),
+            &changed_outer_authority,
+        )
+        .err()
+        .unwrap();
+        assert!(error.to_string().contains("frozen FL2VA route"));
+
+        let audio_calls = Arc::new(AtomicUsize::new(0));
+        let mut vae = runtime(Arc::clone(&drops), &authority);
+        vae.audio_calls = Arc::clone(&audio_calls);
+        let mut adapter = H3PrivateComfyVaeAdapter::new_with_runtime(
+            backend(Arc::clone(&drops), &authority),
+            vae,
+            &authority,
+        )
+        .unwrap();
+        adapter.inner.inner_authority.factory_identity_sha256 =
+            changed.factory_identity_sha256.clone();
+        let latents = StereoLatents::new(
+            Tensor::zeros((1, LATENT_CHANNELS, 2, 1), DType::F32, &Device::Cpu).unwrap(),
+            &AudioVaeConfig::default(),
+        )
+        .unwrap();
+        let error = adapter
+            .decode_audio(&latents, &mut RecordingCheckpoint::default())
+            .unwrap_err();
+        assert!(error.to_string().contains("authority changed"));
+        assert_eq!(audio_calls.load(Ordering::SeqCst), 0);
+
+        let delegated_text = Arc::new(Mutex::new(0));
+        let mut inner = backend(Arc::clone(&drops), &authority);
+        inner.delegated_text = Arc::clone(&delegated_text);
+        inner.inner_authority_after_text = Some(inner_authority(&changed_outer_authority));
+        let mut adapter = H3PrivateComfyVaeAdapter::new_with_runtime(
+            inner,
+            runtime(Arc::clone(&drops), &authority),
+            &authority,
+        )
+        .unwrap();
+        let error = adapter
+            .encode_text("prompt", &[], &mut RecordingCheckpoint::default())
+            .unwrap_err();
+        assert!(error.to_string().contains("authority changed"));
+        assert_eq!(*delegated_text.lock().unwrap(), 1);
+    }
+
+    #[test]
+    fn revoked_inner_lease_after_denoise_blocks_vae_decode() {
+        let authority = authority();
+        let drops = Arc::new(Mutex::new(Vec::new()));
+        let artifact_active = Arc::new(AtomicBool::new(true));
+        let denoise_calls = Arc::new(AtomicUsize::new(0));
+        let audio_calls = Arc::new(AtomicUsize::new(0));
+        let mut inner = backend(Arc::clone(&drops), &authority);
+        inner.artifact_active = Arc::clone(&artifact_active);
+        inner.denoise_calls = Arc::clone(&denoise_calls);
+        let mut vae = runtime(Arc::clone(&drops), &authority);
+        vae.audio_calls = Arc::clone(&audio_calls);
+        let mut adapter =
+            H3PrivateComfyVaeAdapter::new_with_runtime(inner, vae, &authority).unwrap();
+
+        let (video, audio, text, timesteps) = forward_inputs();
+        adapter
+            .denoise(
+                H3ForwardInput {
+                    video_rows: &video,
+                    audio_rows: &audio,
+                    text_states: &text,
+                    timesteps: &timesteps,
+                },
+                &frozen_layout(),
+                &mut RecordingCheckpoint::default(),
+            )
+            .unwrap();
+        assert_eq!(denoise_calls.load(Ordering::SeqCst), 1);
+
+        artifact_active.store(false, Ordering::SeqCst);
+        let latents = StereoLatents::new(
+            Tensor::zeros((1, LATENT_CHANNELS, 2, 1), DType::F32, &Device::Cpu).unwrap(),
+            &AudioVaeConfig::default(),
+        )
+        .unwrap();
+        let error = adapter
+            .decode_audio(&latents, &mut RecordingCheckpoint::default())
+            .unwrap_err();
+        assert!(error.to_string().contains("artifact lease revoked"));
+        assert_eq!(audio_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn callback_bridge_preserves_typed_visual_video_and_audio_cancellation() {
+        let bridge = H3CallbackErrorBridge::default();
+        let mut visual_checkpoint = CancelCheckpoint;
+        let mut observer = H3PrivateVisualObserver {
+            checkpoint: &mut visual_checkpoint,
+            phase: H3PipelinePhase::VisualConditionEncodeChunk,
+            error_bridge: bridge.clone(),
+        };
+        let transport = observer
+            .checkpoint(VisualVaeEvent {
+                phase: mold_candle::minimax_h3::VisualVaePhase::EncodeChunk,
+                completed: 0,
+                total: 1,
+            })
+            .unwrap_err();
+        let error = bridge.finish::<()>(Err(transport)).unwrap_err();
+        assert!(is_inference_cancelled(&error));
+
+        let bridge = H3CallbackErrorBridge::default();
+        let mut video_checkpoint = CancelCheckpoint;
+        let checkpoint: Rc<RefCell<&mut dyn H3PipelineCheckpoint>> =
+            Rc::new(RefCell::new(&mut video_checkpoint));
+        let mut sink = H3VideoEncodeSink::new_dimensions(1, 1, 1).unwrap();
+        let mut decode_sink = H3PrivatePipelineDecodeSink {
+            sink: &mut sink,
+            checkpoint,
+            next_frame: 0,
+            error_bridge: bridge.clone(),
+        };
+        let transport = decode_sink
+            .write(
+                0,
+                &Tensor::zeros((1, 3, 1, 1, 1), DType::F32, &Device::Cpu).unwrap(),
+            )
+            .unwrap_err();
+        let error = bridge.finish::<()>(Err(transport)).unwrap_err();
+        assert!(is_inference_cancelled(&error));
+
+        for (phase, expected_completed) in [
+            (AudioVaePhase::DecodeProjection, 0),
+            (AudioVaePhase::DecodeBigVgan, 1),
+            (AudioVaePhase::DecodeOutput, 2),
+        ] {
+            assert_eq!(
+                audio_decode_phase_progress(phase).unwrap(),
+                expected_completed
+            );
+            let bridge = H3CallbackErrorBridge::default();
+            let mut checkpoint = CancelCheckpoint;
+            let transport =
+                checkpoint_audio_decode_phase(&mut checkpoint, phase, &bridge).unwrap_err();
+            let error = bridge.finish::<()>(Err(transport)).unwrap_err();
+            assert!(is_inference_cancelled(&error), "phase {phase:?}");
+        }
+        assert!(audio_decode_phase_progress(AudioVaePhase::EncodeDac).is_err());
+    }
+
+    #[test]
+    fn vae_models_and_artifact_lease_drop_before_execution_backend() {
+        let authority = authority();
+        let drops = Arc::new(Mutex::new(Vec::new()));
+        let adapter = H3PrivateComfyVaeAdapter::new_with_runtime(
+            backend(Arc::clone(&drops), &authority),
+            runtime(Arc::clone(&drops), &authority),
+            &authority,
+        )
+        .unwrap();
+        drop(adapter);
+        assert_eq!(*drops.lock().unwrap(), ["vae", "backend"]);
+    }
+}

--- a/crates/mold-inference/src/minimax_h3/vae_runtime.rs
+++ b/crates/mold-inference/src/minimax_h3/vae_runtime.rs
@@ -215,6 +215,7 @@ pub(crate) struct FrozenH3ComfyVaeLoadPlan {
     paths: H3ComfyVaeArtifactPaths,
     staging_root: PathBuf,
     artifacts: Vec<ExpectedArtifact>,
+    artifact_plan_identity_sha256: String,
     identity_sha256: String,
     #[cfg(test)]
     synthetic: bool,
@@ -253,11 +254,18 @@ impl FrozenH3ComfyVaeLoadPlan {
             paths,
             staging_root: staging_root.into(),
             artifacts,
+            artifact_plan_identity_sha256: String::new(),
             identity_sha256: String::new(),
             #[cfg(test)]
             synthetic: false,
         };
         plan.validate_fields()?;
+        plan.artifact_plan_identity_sha256 = artifact_plan_identity(
+            &plan.canonical_model,
+            plan.task,
+            plan.layout,
+            &plan.artifacts,
+        );
         plan.identity_sha256 = load_plan_identity(&plan);
         plan.validate()?;
         Ok(plan)
@@ -265,6 +273,10 @@ impl FrozenH3ComfyVaeLoadPlan {
 
     pub(crate) fn identity_sha256(&self) -> &str {
         &self.identity_sha256
+    }
+
+    pub(crate) fn artifact_plan_identity_sha256(&self) -> &str {
+        &self.artifact_plan_identity_sha256
     }
 
     pub(crate) const fn task(&self) -> Task {
@@ -325,7 +337,16 @@ impl FrozenH3ComfyVaeLoadPlan {
 
     fn validate(&self) -> LoadResult<()> {
         self.validate_fields()?;
-        if !valid_sha256(&self.identity_sha256) || self.identity_sha256 != load_plan_identity(self)
+        if !valid_sha256(&self.artifact_plan_identity_sha256)
+            || self.artifact_plan_identity_sha256
+                != artifact_plan_identity(
+                    &self.canonical_model,
+                    self.task,
+                    self.layout,
+                    &self.artifacts,
+                )
+            || !valid_sha256(&self.identity_sha256)
+            || self.identity_sha256 != load_plan_identity(self)
         {
             return Err(H3ComfyVaeLoadError::InvalidPlan(
                 "load-plan identity changed after freezing".into(),
@@ -366,10 +387,17 @@ impl FrozenH3ComfyVaeLoadPlan {
             paths,
             staging_root,
             artifacts,
+            artifact_plan_identity_sha256: String::new(),
             identity_sha256: String::new(),
             synthetic: true,
         };
         plan.validate_fields()?;
+        plan.artifact_plan_identity_sha256 = artifact_plan_identity(
+            &plan.canonical_model,
+            plan.task,
+            plan.layout,
+            &plan.artifacts,
+        );
         plan.identity_sha256 = load_plan_identity(&plan);
         plan.validate()?;
         Ok(plan)
@@ -496,7 +524,10 @@ pub(crate) struct H3ComfyVaeRuntimeBundle<V = MiniMaxH3VisualVae, A = AudioVae> 
     memory: H3ComfyVaeRuntimeMemory,
     task: Task,
     canonical_model: String,
+    artifact_plan_identity_sha256: String,
     plan_identity_sha256: String,
+    #[cfg(feature = "h3-private-uat")]
+    device: Device,
     pub(crate) artifact_lease: H3ComfyVaeArtifactLease,
 }
 
@@ -515,6 +546,21 @@ impl<V, A> H3ComfyVaeRuntimeBundle<V, A> {
 
     pub(crate) fn plan_identity_sha256(&self) -> &str {
         &self.plan_identity_sha256
+    }
+
+    #[cfg(feature = "h3-private-uat")]
+    pub(crate) fn artifact_plan_identity_sha256(&self) -> &str {
+        &self.artifact_plan_identity_sha256
+    }
+
+    #[cfg(feature = "h3-private-uat")]
+    pub(crate) fn authority_identity_sha256(&self) -> &str {
+        self.artifact_lease.authority_identity_sha256()
+    }
+
+    #[cfg(feature = "h3-private-uat")]
+    pub(crate) fn device(&self) -> &Device {
+        &self.device
     }
 
     pub(crate) fn validate_authority(&self) -> LoadResult<()> {
@@ -1003,7 +1049,10 @@ fn load_with_factory<F: VaeFactory>(
         memory,
         task: plan.task,
         canonical_model: plan.canonical_model.clone(),
+        artifact_plan_identity_sha256: plan.artifact_plan_identity_sha256.clone(),
         plan_identity_sha256: plan.identity_sha256.clone(),
+        #[cfg(feature = "h3-private-uat")]
+        device: device.clone(),
         artifact_lease,
     })
 }
@@ -1502,6 +1551,69 @@ fn production_artifacts(manifest: &ModelManifest) -> LoadResult<Vec<ExpectedArti
     .collect()
 }
 
+/// Path-independent authority for the exact four-artifact Comfy VAE plan.
+/// Admission and the opened-file runtime derive this independently from the
+/// pinned manifest; local source/staging paths remain confined to the
+/// attempt-specific load-plan identity below.
+pub(crate) fn expected_h3_comfy_vae_artifact_plan_identity(model: &str) -> LoadResult<String> {
+    let manifest = find_manifest(model)
+        .ok_or_else(|| H3ComfyVaeLoadError::InvalidPlan(format!("missing manifest {model:?}")))?;
+    let manifest_contract = contract::manifest_contract(manifest).ok_or_else(|| {
+        H3ComfyVaeLoadError::InvalidPlan(format!("{model:?} lost its H3 manifest contract"))
+    })?;
+    if manifest_contract.manifest_name != model
+        || manifest_contract.layout != Layout::ComfyPrunedInt8ConvrotNvfp4Awq
+    {
+        return Err(H3ComfyVaeLoadError::InvalidPlan(format!(
+            "{model:?} is not an exact canonical Comfy MiniMax H3 task"
+        )));
+    }
+    let artifacts = production_artifacts(manifest)?;
+    Ok(artifact_plan_identity(
+        model,
+        manifest_contract.task,
+        manifest_contract.layout,
+        &artifacts,
+    ))
+}
+
+fn artifact_plan_identity(
+    canonical_model: &str,
+    task: Task,
+    layout: Layout,
+    artifacts: &[ExpectedArtifact],
+) -> String {
+    let mut digest = Sha256::new();
+    digest.update(b"mold.minimax-h3.comfy-vae-artifact-plan.v1\0");
+    digest.update(canonical_model.as_bytes());
+    digest.update([0]);
+    digest.update(match task {
+        Task::Fl2va => b"fl2va".as_slice(),
+        Task::Ref2va => b"ref2va".as_slice(),
+    });
+    digest.update([0]);
+    digest.update(match layout {
+        Layout::OfficialBf16 => b"official-bf16".as_slice(),
+        Layout::ComfyPrunedInt8ConvrotNvfp4Awq => b"comfy-pruned-int8".as_slice(),
+    });
+    for artifact in artifacts {
+        digest.update([0]);
+        digest.update(artifact.role.stable_id().as_bytes());
+        digest.update([0]);
+        digest.update(artifact.source_repository.as_bytes());
+        digest.update([0]);
+        digest.update(artifact.source_revision.as_bytes());
+        digest.update([0]);
+        digest.update(artifact.source_path.as_bytes());
+        digest.update([0]);
+        digest.update(artifact.content_sha256.as_bytes());
+        digest.update(artifact.file_bytes.to_le_bytes());
+    }
+    digest.update(b"visual-resident-fp16\0visual-reference-compute-fp16\0");
+    digest.update(b"audio-resident-fp32\0audio-compute-fp32\0");
+    format!("{:x}", digest.finalize())
+}
+
 fn artifact_error(role: H3ComfyVaeArtifactRole, message: impl Into<String>) -> H3ComfyVaeLoadError {
     H3ComfyVaeLoadError::Artifact {
         role,
@@ -1762,6 +1874,14 @@ mod tests {
         assert_eq!(fl.task(), Task::Fl2va);
         assert_eq!(reference.task(), Task::Ref2va);
         assert_ne!(fl.identity_sha256(), reference.identity_sha256());
+        assert_ne!(
+            fl.artifact_plan_identity_sha256(),
+            reference.artifact_plan_identity_sha256()
+        );
+        assert_eq!(
+            fl.artifact_plan_identity_sha256(),
+            expected_h3_comfy_vae_artifact_plan_identity(contract::FL2VA_COMFY).unwrap()
+        );
         let visual = fl.artifact(H3ComfyVaeArtifactRole::VisualWeights).unwrap();
         assert_eq!(visual.file_bytes, 5_207_808_496);
         assert_eq!(


### PR DESCRIPTION
## Summary

- add a private-only adapter that replaces visual encode, visual decode, and audio decode with the opened-file-bound Comfy VAE runtime
- bind the adapter to the exact frozen full-factory, backend-plan, component-set, task, model, device, and four-artifact VAE plan identities
- revalidate the live VAE-free inner execution/artifact authority and VAE descriptor authority before and after every operation
- preserve typed cancellation across Candle visual/video/audio callbacks
- drop VAE models and their opened-source guard before the delegated execution backend
- seal the unsafe VAE-free inner contract and compile-time reject the eager backend, preventing duplicate visual/audio VAE residency

## Safety boundary

This is compiled only under `h3-private-uat`. No real eager backend is eligible to implement the VAE-free marker yet; the later streamed core must provide that singular authority. This PR adds no engine registration, capability, catalog, download, CLI, server, or shipping route. Public H3 remains fail-closed.

Part of #814. Advances #830, #833, #834, and #835.

## Verification

- exact merge candidate `a3ec5903`, rebased onto main `43165fbe`
- adapter 7/7, factory 4/4, VAE runtime 4/4, backend 6/6, and Candle audio 8/8 focused tests
- ordinary and private feature checks
- private release and CI-routing contracts
- ordinary inference plus private inference/Candle clippy with warnings denied
- tests-enabled private inference clippy with warnings denied
- formatting, diff, and changed-file private-name scans clean
- independent review confirmed the full-factory authority and duplicate-residency defects are closed; the only later finding was the tests-enabled Clippy lifetime lint fixed in this head
