### PR TITLE
perf(ci): shorten pull request checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,10 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  CARGO_INCREMENTAL: "1"
+  # sccache rejects incremental rustc invocations. Keeping this disabled makes
+  # the shared compiler cache effective instead of tripping the fallback probe
+  # and recompiling every PR from scratch.
+  CARGO_INCREMENTAL: "0"
 
 concurrency:
   # A pushed commit makes every older run for that PR obsolete. Cancel it
@@ -37,12 +40,18 @@ jobs:
     outputs:
       rust: ${{ steps.filter.outputs.rust }}
       gpu: ${{ steps.filter.outputs.gpu }}
-      flash: ${{ steps.filter.outputs.flash }}
       website: ${{ steps.filter.outputs.website }}
       web: ${{ steps.filter.outputs.web }}
       nix: ${{ steps.filter.outputs.nix }}
       release: ${{ steps.filter.outputs.release }}
+      workflow: ${{ steps.filter.outputs.workflow }}
+      trusted_release_pr: ${{ steps.policy.outputs.trusted_release_pr }}
     steps:
+      - name: Detect the trusted release-plz PR
+        id: policy
+        env:
+          TRUSTED_RELEASE_PR: ${{ github.event_name == 'pull_request' && github.actor == 'release-plz-mold[bot]' && startsWith(github.head_ref, 'release-plz-') && github.event.pull_request.head.repo.full_name == github.repository }}
+        run: echo "trusted_release_pr=$TRUSTED_RELEASE_PR" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
         id: filter
@@ -64,7 +73,6 @@ jobs:
               - 'docs/qualification/minimax-h3-*.json'
               - 'docs/qualification/minimax-h3-conformance.md'
               - 'docs/qualification/README.md'
-              - '.github/workflows/ci.yml'
             # Forced-local checks exist to compile backend-specific code that
             # the ordinary workspace gate cannot see. Backend-neutral crates
             # (catalog, DB, Discord, scheduler) are already covered by `rust`.
@@ -72,31 +80,13 @@ jobs:
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'crates/mold-cli/**'
+              - 'crates/mold-candle/**'
               - 'crates/mold-core/**'
               - 'crates/mold-inference/**'
               - 'crates/mold-server/**'
               - 'crates/mold-tui/**'
-              - '.github/workflows/ci.yml'
-            # `flash-attn` compiles 53 FlashAttention v2 kernels through nvcc,
-            # so it gets a narrower filter than `gpu` rather than running on
-            # every GPU-adjacent change. Cargo.lock is deliberately absent: a
-            # lockfile bump would invalidate the kernel cache and cost ~an hour
-            # on the release PR, and the main-branch run below already covers
-            # dependency drift post-merge.
-            flash:
-              - 'crates/mold-candle/Cargo.toml'
-              - 'crates/mold-candle/src/minimax_h3/attention.rs'
-              - 'crates/mold-candle/src/minimax_h3/mod.rs'
-              - 'crates/mold-candle/src/minimax_h3/dit.rs'
-              - 'crates/mold-candle/src/minimax_h3/visual_vae.rs'
-              - 'crates/mold-inference/src/attention.rs'
-              - 'crates/mold-inference/src/lib.rs'
-              - 'crates/mold-inference/src/bin/h3_attention_qualification.rs'
-              - 'crates/mold-inference/Cargo.toml'
-              - 'crates/mold-cli/Cargo.toml'
             website:
               - 'website/**'
-              - '.github/workflows/ci.yml'
             web:
               - 'web/**'
               - 'studio/**'
@@ -104,7 +94,6 @@ jobs:
               - 'package.json'
               - 'bun.lock'
               - 'bun.nix'
-              - '.github/workflows/ci.yml'
             nix:
               - 'web/**'
               - 'studio/**'
@@ -115,7 +104,6 @@ jobs:
               - 'flake.nix'
               - 'flake.lock'
               - 'nix/**'
-              - '.github/workflows/ci.yml'
             release:
               - 'Cargo.toml'
               - 'Cargo.lock'
@@ -150,10 +138,6 @@ jobs:
               - 'website/deployment/docker.md'
               - 'website/deployment/nixos.md'
               - 'website/guide/installation.md'
-              - '.github/workflows/desktop-distribution.yml'
-              - '.github/workflows/desktop.yml'
-              - '.github/workflows/ios.yml'
-              - '.github/workflows/release.yml'
               - 'scripts/release/**'
               - 'scripts/verify-cuda-release-binary.sh'
               - 'scripts/verify-h3-release-exclusion.sh'
@@ -178,48 +162,28 @@ jobs:
               - 'scripts/tests/desktop-candle-nix-source-hash.sh'
               - 'scripts/tests/release-sync-pr.sh'
               - 'scripts/tests/crates-publish-contract.sh'
-              - '.github/workflows/release-plz.yml'
+              - '.github/workflows/**'
+            # Workflow-only PRs get static actionlint/routing-contract proof.
+            # After merge, exercise every dynamic path against the real runner
+            # environment without putting those expensive jobs on the PR.
+            workflow:
               - '.github/workflows/ci.yml'
-
-  release:
-    needs: changes
-    if: needs.changes.outputs.release == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: DeterminateSystems/determinate-nix-action@v3
-      - name: Test release PR synchronization
-        run: bash scripts/tests/release-sync-pr.sh
-      - name: Test crates.io publication contract
-        run: bash scripts/tests/crates-publish-contract.sh
-      - name: Test CI coverage disk guard
-        run: bash scripts/tests/ci-coverage-disk-guard.sh
-      - name: Test CI job routing
-        run: bash scripts/tests/ci-routing-contract.sh
-      - name: Test Docker web build context
-        run: bash scripts/tests/docker-web-context.sh
-      - name: Test desktop Candle lock synchronization
-        run: bash scripts/tests/desktop-candle-lock-sync.sh
-      - name: Test desktop Candle Nix source hash
-        run: bash scripts/tests/desktop-candle-nix-source-hash.sh
-      - name: Test CUDA distribution contract
-        run: bash scripts/tests/cuda-distribution-contract.sh
-      - name: Test embedded PTX parser contract
-        run: python3 scripts/tests/cuda-ptx-parser-contract.py
-      - name: Test installer CUDA architecture selection
-        run: bash scripts/tests/install-cuda-arch.sh
-      - name: Test deferred CUDA qualification contract
-        run: bash scripts/tests/cuda-qualification-contract.sh
-      - name: Test MiniMax H3 attention release-candidate contract
-        run: bash scripts/tests/minimax-h3-attention-release-contract.sh
-      - name: Test MiniMax H3 private-UAT release contract
-        run: bash scripts/tests/minimax-h3-private-uat-release-contract.sh
 
   docs:
     needs: changes
-    if: needs.changes.outputs.website == 'true'
+    if: >-
+      always() && !cancelled() &&
+      (needs.changes.result != 'success' ||
+       ((needs.changes.outputs.website == 'true' ||
+         (github.event_name == 'push' && needs.changes.outputs.workflow == 'true')) &&
+        needs.changes.outputs.trusted_release_pr != 'true'))
     runs-on: ubuntu-latest
     steps:
+      - name: Require successful change classification
+        if: needs.changes.result != 'success'
+        run: |
+          echo "::error::The required path classifier did not complete successfully."
+          exit 1
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
@@ -239,9 +203,19 @@ jobs:
 
   web:
     needs: changes
-    if: needs.changes.outputs.web == 'true'
+    if: >-
+      always() && !cancelled() &&
+      (needs.changes.result != 'success' ||
+       ((needs.changes.outputs.web == 'true' ||
+         (github.event_name == 'push' && needs.changes.outputs.workflow == 'true')) &&
+        needs.changes.outputs.trusted_release_pr != 'true'))
     runs-on: ubuntu-latest
     steps:
+      - name: Require successful change classification
+        if: needs.changes.result != 'success'
+        run: |
+          echo "::error::The required path classifier did not complete successfully."
+          exit 1
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
@@ -264,7 +238,9 @@ jobs:
 
   nix-web:
     needs: changes
-    if: needs.changes.outputs.nix == 'true'
+    if: >-
+      needs.changes.outputs.nix == 'true' ||
+      (github.event_name == 'push' && needs.changes.outputs.workflow == 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -274,20 +250,113 @@ jobs:
 
   rust:
     needs: changes
-    if: needs.changes.outputs.rust == 'true'
+    if: >-
+      always() && !cancelled() &&
+      (needs.changes.result != 'success' ||
+       needs.changes.outputs.trusted_release_pr == 'true' ||
+       needs.changes.outputs.release == 'true' ||
+       needs.changes.outputs.rust == 'true' ||
+       (github.event_name == 'push' && needs.changes.outputs.workflow == 'true'))
     runs-on: ubuntu-latest
     env:
-      RUSTC_WRAPPER: sccache
+      RUN_RUST_SUITE: ${{ needs.changes.outputs.trusted_release_pr != 'true' && (needs.changes.outputs.rust == 'true' || (github.event_name == 'push' && needs.changes.outputs.workflow == 'true')) }}
       SCCACHE_GHA_ENABLED: "true"
     steps:
+      - name: Require successful change classification
+        if: needs.changes.result != 'success'
+        run: |
+          echo "::error::The required path classifier did not complete successfully."
+          exit 1
+      - name: Require trusted release routing
+        if: needs.changes.outputs.trusted_release_pr == 'true' && needs.changes.outputs.release != 'true'
+        run: |
+          echo "::error::The trusted release PR did not reach the release contract route."
+          exit 1
       - uses: actions/checkout@v6
+        if: needs.changes.outputs.trusted_release_pr != 'true'
+      - uses: actions/checkout@v6
+        if: needs.changes.outputs.trusted_release_pr == 'true'
+        with:
+          fetch-depth: 0
+      - name: Validate trusted release-plz file scope
+        if: needs.changes.outputs.trusted_release_pr == 'true'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          changed_count=0
+          while IFS= read -r -d '' status && IFS= read -r -d '' path; do
+            [[ "$status" == M ]] || {
+              echo "::error::Generated release PR may only modify tracked files, got $status for $path"
+              exit 1
+            }
+            ((changed_count += 1))
+            case "$path" in
+              CHANGELOG.md|Cargo.toml|Cargo.lock|desktop/package.json|desktop/src-tauri/Cargo.toml|desktop/src-tauri/Cargo.lock|apps/mobile/src-tauri/Cargo.toml|apps/mobile/src-tauri/Cargo.lock|apps/mobile/src-tauri/tauri.conf.json)
+                ;;
+              crates/*/Cargo.toml)
+                [[ "$path" =~ ^crates/[^/]+/Cargo\.toml$ ]] || {
+                  echo "::error::Unexpected generated release path: $path"
+                  exit 1
+                }
+                ;;
+              *)
+                echo "::error::Unexpected generated release path: $path"
+                exit 1
+                ;;
+            esac
+          done < <(git diff --name-status -z "$BASE_SHA...$HEAD_SHA")
+          ((changed_count > 0)) || {
+            echo "::error::Trusted release PR has no changed files."
+            exit 1
+          }
+      - name: Validate all locked Cargo graphs
+        if: needs.changes.outputs.release == 'true'
+        env:
+          RUSTC_WRAPPER: ""
+        run: |
+          cargo metadata --locked --no-deps --format-version 1 >/dev/null
+          cargo metadata --locked --no-deps --format-version 1 \
+            --manifest-path desktop/src-tauri/Cargo.toml >/dev/null
+          cargo metadata --locked --no-deps --format-version 1 \
+            --manifest-path apps/mobile/src-tauri/Cargo.toml >/dev/null
+      - uses: DeterminateSystems/determinate-nix-action@v3
+        if: needs.changes.outputs.release == 'true'
+      - name: Run protected release contracts
+        if: needs.changes.outputs.release == 'true'
+        run: |
+          nix run nixpkgs#actionlint -- .github/workflows/*.yml
+          bash scripts/tests/release-sync-pr.sh
+          bash scripts/tests/crates-publish-contract.sh
+          bash scripts/tests/ci-coverage-disk-guard.sh
+          bash scripts/tests/ci-routing-contract.sh
+          bash scripts/tests/docker-web-context.sh
+          bash scripts/tests/desktop-candle-lock-sync.sh
+          bash scripts/tests/desktop-candle-nix-source-hash.sh
+          bash scripts/tests/cuda-distribution-contract.sh
+          python3 scripts/tests/cuda-ptx-parser-contract.py
+          bash scripts/tests/install-cuda-arch.sh
+          bash scripts/tests/cuda-qualification-contract.sh
+          bash scripts/tests/minimax-h3-attention-release-contract.sh
+      - name: Test MiniMax H3 private-UAT release contract
+        if: needs.changes.outputs.release == 'true'
+        run: bash scripts/tests/minimax-h3-private-uat-release-contract.sh
       - uses: dtolnay/rust-toolchain@stable
+        if: env.RUN_RUST_SUITE == 'true'
         with:
           components: rustfmt,clippy
       - name: Install Rust build deps
+        if: env.RUN_RUST_SUITE == 'true'
         run: sudo apt-get update && sudo apt-get install -y clang lld nasm libwebp-dev
       - uses: mozilla-actions/sccache-action@v0.0.7
+        if: env.RUN_RUST_SUITE == 'true'
+      - name: Enable sccache
+        if: env.RUN_RUST_SUITE == 'true'
+        run: echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
       - name: Probe sccache (disable on cache outage)
+        if: env.RUN_RUST_SUITE == 'true'
         shell: bash
         run: |
           set +e
@@ -301,10 +370,12 @@ jobs:
             sccache --stop-server >/dev/null 2>&1 || true
           fi
       - uses: Swatinem/rust-cache@v2
+        if: env.RUN_RUST_SUITE == 'true'
         with:
           shared-key: workspace-default
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Check declared MSRV
+        if: env.RUN_RUST_SUITE == 'true'
         shell: bash
         run: |
           msrv=$(sed -n 's/^rust-version = "\([^"]*\)"$/\1/p' Cargo.toml)
@@ -319,28 +390,47 @@ jobs:
           cargo "+$msrv_toolchain" check -p mold-ai --locked \
             --features preview,discord,expand,tui,metrics,webp,mp4,mdns
       - name: Format
+        if: env.RUN_RUST_SUITE == 'true'
         run: cargo fmt --all -- --check
-      - name: Check
-        run: cargo check --workspace
       - name: Clippy
+        if: env.RUN_RUST_SUITE == 'true'
         run: cargo clippy --workspace --all-targets -- -D warnings
-      - name: Test
+      # The live Hugging Face search is an external-service monitor, not a
+      # deterministic change gate. It has repeatedly failed release PRs on 429
+      # responses, so keep that signal on main without forcing PR reruns.
+      - name: Test (PR suite)
+        if: env.RUN_RUST_SUITE == 'true' && github.event_name == 'pull_request'
+        run: >-
+          cargo test --workspace --
+          --skip catalog_api::catalog_live_test::live_search_free_text_can_find_manual_clip_components
+      - name: Test (full main suite)
+        if: env.RUN_RUST_SUITE == 'true' && github.event_name == 'push'
         run: cargo test --workspace
       - name: Test local multi-GPU qualification contract
+        if: env.RUN_RUST_SUITE == 'true'
         run: bash scripts/tests/local-multi-gpu-qualification-contract.sh
       - name: Test MiniMax H3 conformance contract
+        if: env.RUN_RUST_SUITE == 'true'
         run: python3 scripts/tests/minimax-h3-conformance-contract.py
       - name: Clippy the private MiniMax H3 artifact qualifier
+        if: env.RUN_RUST_SUITE == 'true'
         run: cargo clippy -p mold-ai-inference --features dev-bins,h3-private-uat --bin h3_artifact_qualification -- -D warnings
       - name: Test private MiniMax H3 foundations
+        if: env.RUN_RUST_SUITE == 'true'
         run: cargo test -p mold-ai-inference --lib --features h3-private-uat minimax_h3
       - name: Check with all optional features
+        if: env.RUN_RUST_SUITE == 'true'
         run: cargo check -p mold-ai --features preview,discord,expand,tui,webp,mp4,mdns
+      - name: Record protected gate success
+        run: echo "Required Rust and release routes completed successfully."
 
   cuda-check:
     name: CUDA forced-local typecheck
     needs: changes
-    if: needs.changes.outputs.gpu == 'true'
+    if: >-
+      needs.changes.outputs.trusted_release_pr != 'true' &&
+      (needs.changes.outputs.gpu == 'true' ||
+       (github.event_name == 'push' && needs.changes.outputs.workflow == 'true'))
     runs-on: ubuntu-22.04
     env:
       CUDA_COMPUTE_CAP: "89"
@@ -377,15 +467,14 @@ jobs:
   # `attention.rs` rotted into dead code that only a `--features flash-attn`
   # build can see. This job is the gate that keeps that from recurring.
   #
-  # It runs on main (keeping the kernel cache warm — GitHub evicts caches after
-  # 7 idle days, and a cold run costs ~an hour) and on PRs that touch the
-  # attention dispatcher or Cargo feature wiring. Workflow-only edits get
-  # their proof on the mandatory main run instead of blocking the PR for the
-  # 79-minute cold build.
+  # It runs after every main update so dependency and workflow drift remain
+  # covered. Cold builds can take more than an hour, and the feature is not
+  # included in any release artifact, so it never consumes the PR critical
+  # path or read-only PR cache generations.
   flash-attn-check:
     name: FlashAttention feature typecheck
     needs: changes
-    if: github.event_name == 'push' || needs.changes.outputs.flash == 'true'
+    if: github.event_name == 'push'
     runs-on: ubuntu-22.04
     timeout-minutes: 150
     env:
@@ -454,7 +543,10 @@ jobs:
   metal-check:
     name: Metal forced-local typecheck
     needs: changes
-    if: needs.changes.outputs.gpu == 'true'
+    if: >-
+      needs.changes.outputs.trusted_release_pr != 'true' &&
+      (needs.changes.outputs.gpu == 'true' ||
+       (github.event_name == 'push' && needs.changes.outputs.workflow == 'true'))
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v6
@@ -470,15 +562,25 @@ jobs:
 
   coverage:
     needs: changes
-    # PRs already run the complete test suite in `rust`. Coverage is
-    # informational (Codecov failures are non-blocking), so collect it once
-    # after merge instead of recompiling the workspace on every PR revision.
-    if: github.event_name == 'push' && needs.changes.outputs.rust == 'true'
+    # PRs already run the deterministic behavioral suite in `rust`; only the
+    # external-service catalog monitor is main-only. Coverage is informational,
+    # so collect it after merge instead of recompiling on every revision.
+    if: >-
+      always() && !cancelled() &&
+      (needs.changes.result != 'success' ||
+       (github.event_name == 'push' &&
+        (needs.changes.outputs.rust == 'true' ||
+         needs.changes.outputs.workflow == 'true')))
     runs-on: ubuntu-latest
     env:
       RUSTC_WRAPPER: sccache
       SCCACHE_GHA_ENABLED: "true"
     steps:
+      - name: Require successful change classification
+        if: needs.changes.result != 'success'
+        run: |
+          echo "::error::The required path classifier did not complete successfully."
+          exit 1
       - uses: actions/checkout@v6
 
       - name: Free runner disk space

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -133,6 +133,14 @@ env:
 jobs:
   changes:
     name: Classify desktop changes
+    # release-plz only promotes an already-tested main revision and version
+    # metadata. Trust the repository-owned app identity as well as its branch
+    # prefix so a user-created branch cannot bypass native PR checks.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.actor != 'release-plz-mold[bot]' ||
+      startsWith(github.head_ref, 'release-plz-') == false ||
+      github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -141,6 +149,7 @@ jobs:
       frontend: ${{ steps.filter.outputs.frontend }}
       rust: ${{ steps.filter.outputs.rust }}
       updater: ${{ steps.filter.outputs.updater }}
+      bundle: ${{ steps.filter.outputs.bundle }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
@@ -224,6 +233,22 @@ jobs:
               - 'scripts/tests/verify-desktop-updater-signature.sh'
               - 'scripts/verify-desktop-release.sh'
               - 'scripts/verify-desktop-updater-signature.sh'
+            # The debug bundle has caught macOS packaging/linkage regressions,
+            # but ordinary Rust/frontend changes are already covered by their
+            # focused gates. Run it only when bundle inputs actually change.
+            bundle:
+              - 'desktop/src-tauri/Cargo.toml'
+              - 'desktop/src-tauri/Cargo.lock'
+              - 'desktop/src-tauri/build.rs'
+              - 'desktop/src-tauri/tauri.conf.json'
+              - 'desktop/src-tauri/tauri.macos.conf.json'
+              - 'desktop/src-tauri/Entitlements.plist'
+              - 'desktop/src-tauri/Info.plist'
+              - 'desktop/src-tauri/capabilities/**'
+              - 'desktop/src-tauri/icons/**'
+              - 'desktop/package.json'
+              - 'desktop/vite.config.ts'
+              - 'scripts/fix-desktop-macos-linkage.sh'
 
   desktop-frontend:
     name: Frontend (typecheck, tests, format)
@@ -253,40 +278,49 @@ jobs:
       - run: bun install --frozen-lockfile
         working-directory: .
       - run: bun run fmt:check
-      - run: bunx vue-tsc -b
       - run: bun run test
+      # `build` already runs vue-tsc before Vite; a separate typecheck compiled
+      # the same project twice on every frontend PR.
       - run: bun run build
 
   desktop-rust:
     name: macOS Rust (fmt, clippy, test)
     needs: changes
-    if: github.event_name != 'pull_request' || needs.changes.outputs.rust == 'true'
+    if: >-
+      github.event_name != 'pull_request' ||
+      needs.changes.outputs.rust == 'true' ||
+      needs.changes.outputs.bundle == 'true'
     runs-on: macos-14
     defaults:
       run:
         working-directory: desktop
     steps:
       - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: desktop/src-tauri
-      - run: bun install --frozen-lockfile
-        working-directory: .
       - run: cargo fmt --manifest-path src-tauri/Cargo.toml -- --check
+        if: github.event_name != 'pull_request' || needs.changes.outputs.rust == 'true'
       - run: cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
+        if: github.event_name != 'pull_request' || needs.changes.outputs.rust == 'true'
       # CPU-only: the metal feature is deliberately off in CI.
       - run: cargo test --manifest-path src-tauri/Cargo.toml
-      # Reuse the test-profile artifacts for a fast PR packaging smoke test.
-      # Main immediately runs the real signed/notarized release build below.
-      - name: Fast bundle proof (debug .app)
-        if: github.event_name != 'push'
+        if: github.event_name != 'pull_request' || needs.changes.outputs.rust == 'true'
+      - uses: oven-sh/setup-bun@v2
+        if: github.event_name == 'pull_request' && needs.changes.outputs.bundle == 'true'
+      - run: bun install --frozen-lockfile
+        if: github.event_name == 'pull_request' && needs.changes.outputs.bundle == 'true'
+        working-directory: .
+      - name: Bundle macOS packaging inputs (debug .app)
+        if: github.event_name == 'pull_request' && needs.changes.outputs.bundle == 'true'
         run: bunx tauri build --debug --bundles app --ci
 
   desktop-linux:
     name: Linux (clippy, test; main AppImage)
     needs: changes
-    if: github.event_name != 'pull_request' || needs.changes.outputs.rust == 'true'
+    # macOS remains the single native PR gate. Every relevant main push repeats
+    # Linux clippy/tests and adds the stronger CUDA AppImage build + launch.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-22.04
     defaults:
       run:

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -78,6 +78,14 @@ concurrency:
 jobs:
   changes:
     name: Classify iOS changes
+    # Generated release-plz PRs promote an already-tested main revision. Match
+    # the repository-owned app as well as its branch prefix so this cannot be
+    # used as a user-controlled bypass.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.actor != 'release-plz-mold[bot]' ||
+      startsWith(github.head_ref, 'release-plz-') == false ||
+      github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -92,7 +100,9 @@ jobs:
         with:
           filters: |
             frontend:
-              - 'apps/mobile/**'
+              - 'apps/mobile/src-tauri/app-icon.png'
+              - 'apps/mobile/src-tauri/app-icon-source.sha256'
+              - 'apps/mobile/src-tauri/gen/apple/Assets.xcassets/**'
               - 'studio/**'
               - 'ui/**'
               - 'package.json'
@@ -140,12 +150,18 @@ jobs:
       - run: ../scripts/tests/ios-release-assets.sh
       - run: ../scripts/tests/ios-testflight-distribution.sh
       - run: ../scripts/tests/ios-sim-pick.sh
-      - run: bun run test
-      - run: bun run fmt:check
+      # The full desktop + Studio suite runs in Desktop CI. Keep iOS focused on
+      # its 29 mobile tests and mobile-only formatting; the release-assets
+      # contract above already performs the authoritative mobile typecheck/build.
+      - run: bunx vitest run src/mobile
+      - run: bunx prettier --check "src/mobile/**/*.{ts,vue,css}" vite.mobile.config.ts index.mobile.html
 
   simulator-rust:
     name: iOS simulator Rust
     needs: changes
+    # This is the only compiler for the standalone mobile crate and has caught
+    # native-only PR failures. Keep Clippy, but drop the redundant cargo check
+    # because Clippy compiles the same target before linting it.
     if: github.event_name != 'pull_request' || needs.changes.outputs.rust == 'true'
     runs-on: macos-14
     defaults:
@@ -161,5 +177,4 @@ jobs:
         with:
           workspaces: apps/mobile/src-tauri
       - run: cargo fmt -- --check
-      - run: cargo check --target aarch64-apple-ios-sim
       - run: cargo clippy --target aarch64-apple-ios-sim -- -D warnings

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,8 @@ jobs:
   build-macos:
     runs-on: macos-14
     env:
-      CARGO_INCREMENTAL: "1"
+      # sccache rejects incremental rustc invocations.
+      CARGO_INCREMENTAL: "0"
       RUSTC_WRAPPER: sccache
       SCCACHE_GHA_ENABLED: "true"
     steps:
@@ -76,7 +77,7 @@ jobs:
   build-linux-sm86:
     runs-on: ubuntu-latest
     env:
-      CARGO_INCREMENTAL: "1"
+      CARGO_INCREMENTAL: "0"
       RUSTC_WRAPPER: sccache
       SCCACHE_GHA_ENABLED: "true"
     steps:
@@ -162,7 +163,7 @@ jobs:
   build-linux-sm89:
     runs-on: ubuntu-latest
     env:
-      CARGO_INCREMENTAL: "1"
+      CARGO_INCREMENTAL: "0"
       RUSTC_WRAPPER: sccache
       SCCACHE_GHA_ENABLED: "true"
     steps:
@@ -252,7 +253,7 @@ jobs:
   build-linux-sm100:
     runs-on: ubuntu-latest
     env:
-      CARGO_INCREMENTAL: "1"
+      CARGO_INCREMENTAL: "0"
       RUSTC_WRAPPER: sccache
       SCCACHE_GHA_ENABLED: "true"
     steps:
@@ -338,7 +339,7 @@ jobs:
   build-linux-sm120:
     runs-on: ubuntu-latest
     env:
-      CARGO_INCREMENTAL: "1"
+      CARGO_INCREMENTAL: "0"
       RUSTC_WRAPPER: sccache
       SCCACHE_GHA_ENABLED: "true"
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ cargo check -p mold-ai --features preview,discord,expand,tui,webp,mp4         # 
 
 Inside `nix develop` the devshell exposes shortcuts (`build`, `build-release`, `serve`, `mold`, `clippy`, `run-tests`, `coverage`, `fmt`). Run `type <cmd>` to see the underlying invocation.
 
-**CI gates** (`.github/workflows/ci.yml`): `rust` (fmt + check + clippy-deny-warnings + test + feature-combo check), `cuda-check` and `metal-check` (forced-local + server typechecks for their respective GPU backends), `coverage` (cargo-llvm-cov → Codecov), `web` (architecture + dead-code + Studio/web tests, formatting, and build), `docs` (`bun run fmt:check && bun run verify && bun run build` in `website/`), and a path-gated `release` check for release-plz synchronization scripts. All triggered gates must pass.
+**CI gates** (`.github/workflows/ci.yml`): PRs keep the required `rust` MSRV/fmt/Clippy/deterministic-test/feature gate, relevant CUDA/Metal forced-local checks, the Nix web sandbox, `web`, `docs`, and path-gated release contracts. The live external-catalog monitor and coverage run after relevant changes land on `main`; non-shipping FlashAttention runs on every `main` update. Repository-owned release-plz PRs take an allowlisted fast path through locked-manifest and release-contract validation, bridged into the protected `rust` status. Workflow-only PRs get static routing validation, then exercise every dynamic route after merge. Required jobs fail closed if path classification fails. All triggered gates must pass.
 
 ## Crates
 

--- a/scripts/tests/ci-routing-contract.sh
+++ b/scripts/tests/ci-routing-contract.sh
@@ -5,6 +5,7 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 ci="$repo_root/.github/workflows/ci.yml"
 desktop="$repo_root/.github/workflows/desktop.yml"
 ios="$repo_root/.github/workflows/ios.yml"
+release_workflow="$repo_root/.github/workflows/release.yml"
 
 fail() {
   echo "FAIL: $1" >&2
@@ -15,15 +16,210 @@ require_text() {
   local file=$1
   local text=$2
   local message=$3
-  grep -Fq "$text" "$file" || fail "$message"
+  grep -Fq -- "$text" "$file" || fail "$message"
+}
+
+extract_job() {
+  local file=$1
+  local job=$2
+  awk -v key="  $job:" '
+    $0 == key { selected = 1 }
+    selected && $0 ~ /^  [[:alnum:]_-][[:alnum:]_-]*:$/ && $0 != key { exit }
+    selected { print }
+  ' "$file"
+}
+
+extract_filter() {
+  local file=$1
+  local filter=$2
+  awk -v key="            $filter:" '
+    $0 == key { selected = 1 }
+    selected && $0 ~ /^            [[:alnum:]_-][[:alnum:]_-]*:$/ && $0 != key { exit }
+    selected { print }
+  ' "$file"
 }
 
 require_text "$ci" \
   "cancel-in-progress: \${{ github.event_name == 'pull_request' }}" \
   "root CI does not cancel superseded PR runs"
-require_text "$ci" \
-  "if: needs.changes.outputs.gpu == 'true'" \
-  "backend checks are not routed through the GPU-specific classifier"
+require_text "$ci" 'CARGO_INCREMENTAL: "0"' \
+  "root CI enables incremental compilation even though sccache rejects it"
+if grep -Fq 'CARGO_INCREMENTAL: "1"' "$release_workflow"; then
+  fail "release builds enable incremental compilation while using sccache"
+fi
+[[ "$(grep -Fc 'CARGO_INCREMENTAL: "0"' "$release_workflow")" -eq 5 ]] \
+  || fail "not every sccache-backed release build disables incremental compilation"
+
+# Assert the complete trusted-app predicates, then exercise the security truth
+# table. Fragment checks would pass if an operator were accidentally inverted.
+python3 - "$ci" "$desktop" "$ios" <<'PY' || exit 1
+import re
+import sys
+from pathlib import Path
+
+
+def normalize(value: str) -> str:
+    return " ".join(value.split())
+
+
+ci_text, desktop_text, ios_text = (Path(path).read_text() for path in sys.argv[1:])
+trusted = (
+    "github.event_name == 'pull_request' && "
+    "github.actor == 'release-plz-mold[bot]' && "
+    "startsWith(github.head_ref, 'release-plz-') && "
+    "github.event.pull_request.head.repo.full_name == github.repository"
+)
+match = re.search(r"TRUSTED_RELEASE_PR:\s*\$\{\{\s*(.*?)\s*\}\}", ci_text, re.S)
+if match is None or normalize(match.group(1)) != trusted:
+    raise SystemExit("FAIL: root trusted release predicate does not match the complete policy")
+
+untrusted = (
+    "github.event_name != 'pull_request' || "
+    "github.actor != 'release-plz-mold[bot]' || "
+    "startsWith(github.head_ref, 'release-plz-') == false || "
+    "github.event.pull_request.head.repo.full_name != github.repository"
+)
+for label, text in (("desktop", desktop_text), ("iOS", ios_text)):
+    block = re.search(r"(?ms)^  changes:\n(.*?)(?=^  [A-Za-z0-9_-]+:\n)", text)
+    condition = re.search(r"(?ms)^    if: >-\n(.*?)(?=^    [A-Za-z0-9_-]+:)", block.group(1) if block else "")
+    if condition is None or normalize(condition.group(1)) != untrusted:
+        raise SystemExit(f"FAIL: {label} trusted release predicate does not match the complete policy")
+
+
+def is_trusted(event: str, actor: str, branch: str, head_repo: str, repo: str) -> bool:
+    return (
+        event == "pull_request"
+        and actor == "release-plz-mold[bot]"
+        and branch.startswith("release-plz-")
+        and head_repo == repo
+    )
+
+
+cases = [
+    (True, "pull_request", "release-plz-mold[bot]", "release-plz-2026", "utensils/mold", "utensils/mold"),
+    (False, "push", "release-plz-mold[bot]", "release-plz-2026", "utensils/mold", "utensils/mold"),
+    (False, "pull_request", "someone", "release-plz-2026", "utensils/mold", "utensils/mold"),
+    (False, "pull_request", "release-plz-mold[bot]", "feat/release-plz-2026", "utensils/mold", "utensils/mold"),
+    (False, "pull_request", "release-plz-mold[bot]", "release-plz-2026", "fork/mold", "utensils/mold"),
+]
+for expected, *inputs in cases:
+    if is_trusted(*inputs) is not expected:
+        raise SystemExit(f"FAIL: trusted release truth table mismatch for {inputs!r}")
+
+rust = re.search(r"(?ms)^  rust:\n(.*?)(?=^  [A-Za-z0-9_-]+:\n)", ci_text)
+if rust is None:
+    raise SystemExit("FAIL: protected Rust job is missing")
+rust_text = rust.group(1)
+
+run_suite = (
+    "needs.changes.outputs.trusted_release_pr != 'true' && "
+    "(needs.changes.outputs.rust == 'true' || "
+    "(github.event_name == 'push' && needs.changes.outputs.workflow == 'true'))"
+)
+match = re.search(r"RUN_RUST_SUITE:\s*\$\{\{\s*(.*?)\s*\}\}", rust_text, re.S)
+if match is None or normalize(match.group(1)) != run_suite:
+    raise SystemExit("FAIL: protected Rust suite selector does not match the complete policy")
+
+
+def step_condition(name: str) -> str:
+    step = re.search(
+        rf"(?ms)^      - name: {re.escape(name)}\n(.*?)(?=^      - (?:name:|uses:))",
+        rust_text,
+    )
+    condition = re.search(r"(?m)^        if:\s*(.+)$", step.group(1) if step else "")
+    if condition is None:
+        raise SystemExit(f"FAIL: protected step has no simple condition: {name}")
+    return normalize(condition.group(1))
+
+
+expected_step_conditions = {
+    "Require trusted release routing": (
+        "needs.changes.outputs.trusted_release_pr == 'true' && "
+        "needs.changes.outputs.release != 'true'"
+    ),
+    "Validate trusted release-plz file scope": (
+        "needs.changes.outputs.trusted_release_pr == 'true'"
+    ),
+    "Validate all locked Cargo graphs": "needs.changes.outputs.release == 'true'",
+    "Run protected release contracts": "needs.changes.outputs.release == 'true'",
+    "Test MiniMax H3 private-UAT release contract": (
+        "needs.changes.outputs.release == 'true'"
+    ),
+    "Clippy the private MiniMax H3 artifact qualifier": (
+        "env.RUN_RUST_SUITE == 'true'"
+    ),
+    "Test private MiniMax H3 foundations": "env.RUN_RUST_SUITE == 'true'",
+}
+for name, expected in expected_step_conditions.items():
+    actual = step_condition(name)
+    if actual != expected:
+        raise SystemExit(f"FAIL: protected step condition mismatch for {name}: {actual}")
+
+heavy_start = rust_text.find("      - uses: dtolnay/rust-toolchain@stable")
+heavy_end = rust_text.find("      - name: Record protected gate success")
+if heavy_start < 0 or heavy_end <= heavy_start:
+    raise SystemExit("FAIL: protected Rust heavy-step boundary is missing")
+heavy_steps = re.split(
+    r"(?m)(?=^      - (?:name:|uses:))",
+    rust_text[heavy_start:heavy_end],
+)
+for step in (candidate for candidate in heavy_steps if candidate.strip()):
+    label = step.splitlines()[0].strip()
+    condition = re.search(r"(?m)^        if:\s*(.+)$", step)
+    if condition is None:
+        raise SystemExit(f"FAIL: heavy Rust step is not suite-gated: {label}")
+    actual = normalize(condition.group(1))
+    if not (
+        actual == "env.RUN_RUST_SUITE == 'true'"
+        or actual.startswith("env.RUN_RUST_SUITE == 'true' && ")
+    ):
+        raise SystemExit(f"FAIL: heavy Rust step bypasses suite routing: {label}: {actual}")
+PY
+
+release_job="$(extract_job "$ci" rust)"
+# The dollar-prefixed names are literal workflow source under test.
+# shellcheck disable=SC2016
+for contract in \
+  'Validate trusted release-plz file scope' \
+  'Unexpected generated release path' \
+  'git diff --name-status -z "$BASE_SHA...$HEAD_SHA"' \
+  '[[ "$status" == M ]]' \
+  'cargo metadata --locked --no-deps --format-version 1' \
+  '--manifest-path desktop/src-tauri/Cargo.toml' \
+  '--manifest-path apps/mobile/src-tauri/Cargo.toml'; do
+  grep -Fq -- "$contract" <<< "$release_job" \
+    || fail "release gate is missing: $contract"
+done
+
+release_change_allowed() {
+  local status=$1
+  local path=$2
+  [[ "$status" == M ]] || return 1
+  case "$path" in
+    CHANGELOG.md|Cargo.toml|Cargo.lock|desktop/package.json|desktop/src-tauri/Cargo.toml|desktop/src-tauri/Cargo.lock|apps/mobile/src-tauri/Cargo.toml|apps/mobile/src-tauri/Cargo.lock|apps/mobile/src-tauri/tauri.conf.json)
+      return 0
+      ;;
+    crates/*/Cargo.toml)
+      [[ "$path" =~ ^crates/[^/]+/Cargo\.toml$ ]]
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+release_change_allowed M Cargo.toml \
+  || fail "trusted release policy rejects a normal metadata modification"
+release_change_allowed M crates/new/Cargo.toml \
+  || fail "trusted release policy rejects a normal crate-manifest modification"
+for forbidden_status in A D R100 C100; do
+  if release_change_allowed "$forbidden_status" crates/new/Cargo.toml; then
+    fail "trusted release policy accepts $forbidden_status changes"
+  fi
+done
+if release_change_allowed M src/production.rs; then
+  fail "trusted release policy accepts a production-source modification"
+fi
+
 require_text "$ci" \
   "cargo clippy -p mold-ai --features cuda,preview,expand,tui,webp,mp4,mdns --all-targets -- -D warnings" \
   "CUDA-gated production code is not linted"
@@ -31,55 +227,130 @@ require_text "$ci" \
   "cargo clippy -p mold-ai --features metal,preview,expand,tui,webp,mp4,mdns --all-targets -- -D warnings" \
   "Metal-gated production code is not linted"
 require_text "$ci" \
+  "nix run nixpkgs#actionlint -- .github/workflows/*.yml" \
+  "workflow-only PRs have no protected actionlint proof"
+[[ "$(grep -Fc "needs.changes.outputs.gpu == 'true' ||" "$ci")" -eq 2 ]] \
+  || fail "CUDA and Metal are not retained for relevant PRs with workflow-only main proof"
+for backend_job in cuda-check metal-check; do
+  backend_block="$(extract_job "$ci" "$backend_job")"
+  grep -Fq "needs.changes.outputs.trusted_release_pr != 'true'" <<< "$backend_block" \
+    || fail "$backend_job still runs on generated release PRs"
+done
+
+require_text "$ci" \
   "cargo clippy -p mold-ai --features flash-attn -- -D warnings" \
   "the flash-attn binary wiring is only typechecked"
-flash_filter="$(sed -n '/^            flash:/,/^            website:/p' "$ci")"
-if grep -Fq ".github/workflows/ci.yml" <<< "$flash_filter"; then
-  fail "unrelated root CI edits still trigger the hour-long FlashAttention kernel build on PRs"
+flash_job="$(extract_job "$ci" flash-attn-check)"
+grep -Fq "if: github.event_name == 'push'" <<< "$flash_job" \
+  || fail "FlashAttention still consumes the PR critical path"
+
+for required_job in rust coverage docs web; do
+  required_block="$(extract_job "$ci" "$required_job")"
+  grep -Fq 'always() && !cancelled() &&' <<< "$required_block" \
+    || fail "required $required_job job does not fail closed without reviving canceled runs"
+  grep -Fq "needs.changes.result != 'success'" <<< "$required_block" \
+    || fail "required $required_job job does not propagate classifier failures"
+  grep -Fq 'Require successful change classification' <<< "$required_block" \
+    || fail "required $required_job job has no classifier-failure sentinel"
+  grep -Fq 'exit 1' <<< "$required_block" \
+    || fail "required $required_job classifier sentinel does not fail"
+done
+
+rust_gate="$(extract_job "$ci" rust)"
+grep -Fq 'RUN_RUST_SUITE:' <<< "$rust_gate" \
+  || fail "protected Rust status does not select its full suite"
+grep -Fq 'Require trusted release routing' <<< "$rust_gate" \
+  || fail "protected Rust status does not fail closed for trusted release routing"
+grep -Fq 'Run protected release contracts' <<< "$rust_gate" \
+  || fail "protected Rust status does not own release-contract failures"
+
+grep -Fq 'Check declared MSRV' <<< "$rust_gate" \
+  || fail "PR Rust suite no longer checks the declared MSRV"
+grep -Fq 'Clippy the private MiniMax H3 artifact qualifier' <<< "$rust_gate" \
+  || fail "PR Rust suite no longer checks the private qualifier"
+grep -Fq 'Check with all optional features' <<< "$rust_gate" \
+  || fail "PR Rust suite no longer checks the optional feature combination"
+grep -Fq -- '--skip catalog_api::catalog_live_test::live_search_free_text_can_find_manual_clip_components' <<< "$rust_gate" \
+  || fail "PR Rust suite still runs the flaky external catalog monitor"
+grep -Fq 'name: Test (full main suite)' <<< "$rust_gate" \
+  || fail "main Rust suite does not retain the complete workspace tests"
+if grep -Fq -- '--skip batch_transaction::tests::' <<< "$rust_gate"; then
+  fail "PR Rust suite skips the high-signal gallery scale regression"
 fi
-require_text "$ci" \
-  "if: github.event_name == 'push' || needs.changes.outputs.flash == 'true'" \
-  "FlashAttention is not covered by every main push after narrowing its PR paths"
-require_text "$ci" \
-  "if: github.event_name == 'push' && needs.changes.outputs.rust == 'true'" \
-  "coverage is not deferred to the post-merge main run"
-release_filter="$(sed -n '/^            release:/,/^  release:/p' "$ci")"
+if grep -Fq 'run: cargo check --workspace' "$ci"; then
+  fail "root Rust CI still runs cargo check immediately before all-target Clippy"
+fi
+
+gpu_filter="$(extract_filter "$ci" gpu)"
+grep -Fq 'crates/mold-candle/**' <<< "$gpu_filter" \
+  || fail "GPU routing omits backend-conditional mold-candle sources"
+for classifier in rust gpu website web nix; do
+  classifier_block="$(extract_filter "$ci" "$classifier")"
+  if grep -Fq '.github/workflows/ci.yml' <<< "$classifier_block"; then
+    fail "workflow-only edits still force the $classifier dynamic build on PRs"
+  fi
+done
+workflow_filter="$(extract_filter "$ci" workflow)"
+grep -Fxq "              - '.github/workflows/ci.yml'" <<< "$workflow_filter" \
+  || fail "workflow-only changes have no dedicated post-merge classifier"
+
+release_filter="$(extract_filter "$ci" release)"
 for manifest in Cargo.toml Cargo.lock desktop/src-tauri/Cargo.toml desktop/src-tauri/Cargo.lock; do
   grep -Fxq "              - '$manifest'" <<< "$release_filter" \
     || fail "release classifier does not run the desktop Candle lock guard for $manifest changes"
 done
 require_text "$ci" \
-  "run: bash scripts/tests/desktop-candle-nix-source-hash.sh" \
+  "bash scripts/tests/desktop-candle-nix-source-hash.sh" \
   "release CI does not verify the Nix hash for the locked desktop Candle source"
-for workflow in desktop.yml ios.yml; do
-  grep -Fq ".github/workflows/$workflow" <<< "$release_filter" \
-    || fail "release classifier does not run the routing contract for $workflow changes"
-done
+grep -Fq "'.github/workflows/**'" <<< "$release_filter" \
+  || fail "workflow changes do not reach protected actionlint and routing contracts"
 
-nix_filter="$(sed -n '/^            nix:/,/^            release:/p' "$ci")"
-if grep -Fq "desktop/**" <<< "$nix_filter"; then
+nix_filter="$(extract_filter "$ci" nix)"
+if grep -Fq 'desktop/**' <<< "$nix_filter"; then
   fail "desktop-only changes still start the mold-web Nix build"
 fi
+nix_job="$(extract_job "$ci" nix-web)"
+grep -Fq "needs.changes.outputs.nix == 'true' ||" <<< "$nix_job" \
+  || fail "the sandboxed Nix web build no longer protects relevant PRs"
+grep -Fq "github.event_name == 'push' && needs.changes.outputs.workflow == 'true'" <<< "$nix_job" \
+  || fail "workflow-only changes do not exercise the Nix build after merge"
 
-desktop_classifier="$(sed -n '/^  changes:/,/^  desktop-frontend:/p' "$desktop")"
-require_text "$desktop" "name: Classify desktop changes" \
+desktop_classifier="$(extract_job "$desktop" changes)"
+require_text "$desktop" 'name: Classify desktop changes' \
   "desktop workflow has no path classifier"
 require_text "$desktop" \
   "if: github.event_name != 'pull_request' || needs.changes.outputs.frontend == 'true'" \
   "desktop frontend job is not path-gated on PRs"
-require_text "$desktop" \
-  "if: github.event_name != 'pull_request' || needs.changes.outputs.rust == 'true'" \
-  "desktop native jobs are not path-gated on PRs"
+desktop_rust="$(extract_job "$desktop" desktop-rust)"
+grep -Fq "needs.changes.outputs.rust == 'true' ||" <<< "$desktop_rust" \
+  || fail "the macOS native job is not path-gated on PRs"
+grep -Fq "needs.changes.outputs.bundle == 'true'" <<< "$desktop_rust" \
+  || fail "macOS bundle-sensitive changes do not reach the native job"
+grep -Fq 'name: Bundle macOS packaging inputs (debug .app)' <<< "$desktop_rust" \
+  || fail "macOS packaging inputs have no focused bundle proof"
+grep -Fq "github.event_name == 'pull_request' && needs.changes.outputs.bundle == 'true'" <<< "$desktop_rust" \
+  || fail "macOS debug bundle is not restricted to bundle-sensitive PRs"
+bundle_filter="$(extract_filter "$desktop" bundle)"
+for path in desktop/src-tauri/tauri.macos.conf.json scripts/fix-desktop-macos-linkage.sh; do
+  grep -Fq "$path" <<< "$bundle_filter" \
+    || fail "desktop bundle classifier omits $path"
+done
+desktop_linux="$(extract_job "$desktop" desktop-linux)"
+grep -Fq "if: github.event_name != 'pull_request'" <<< "$desktop_linux" \
+  || fail "Desktop Linux still runs on pull requests"
+if grep -Fq 'bunx vue-tsc -b' "$desktop"; then
+  fail "desktop frontend still typechecks once explicitly and again during build"
+fi
 [[ "$(grep -Fc "if: github.event_name != 'pull_request' || needs.changes.outputs.updater == 'true'" "$desktop")" -eq 2 ]] \
   || fail "updater tooling and contract tests are not restricted to updater changes on PRs"
-if grep -Fq "desktop/**" <<< "$desktop_classifier"; then
+if grep -Fq 'desktop/**' <<< "$desktop_classifier"; then
   fail "desktop frontend classifier is broad enough to include native/mobile files"
 fi
 [[ "$(grep -Fc 'desktop/src/components/**' "$desktop")" -eq 3 ]] \
   || fail "desktop frontend trigger/classifier does not track desktop components"
 [[ "$(grep -Fc 'desktop/src-tauri/**' "$desktop")" -eq 3 ]] \
   || fail "desktop native trigger/classifier does not track the Tauri crate"
-if grep -Fq "desktop/src/mobile/**" "$desktop"; then
+if grep -Fq 'desktop/src/mobile/**' "$desktop"; then
   fail "mobile-only changes are not owned exclusively by the iOS workflow"
 fi
 [[ "$(grep -Fc 'crates/mold-scheduler/**' "$desktop")" -eq 3 ]] \
@@ -88,12 +359,23 @@ fi
 require_text "$ios" \
   "cancel-in-progress: \${{ github.event_name == 'pull_request' }}" \
   "iOS workflow does not cancel superseded PR runs"
-require_text "$ios" "name: Classify iOS changes" \
+require_text "$ios" 'name: Classify iOS changes' \
   "iOS workflow has no path classifier"
+ios_frontend_filter="$(extract_filter "$ios" frontend)"
+if grep -Fq "'apps/mobile/**'" <<< "$ios_frontend_filter"; then
+  fail "native-only iOS changes still run the mobile frontend suite"
+fi
+grep -Fq "apps/mobile/src-tauri/gen/apple/Assets.xcassets/**" <<< "$ios_frontend_filter" \
+  || fail "iOS frontend classifier omits release icon assets"
 require_text "$ios" \
   "if: github.event_name != 'pull_request' || needs.changes.outputs.rust == 'true'" \
-  "iOS simulator job is not restricted to native changes on PRs"
-require_text "$ios" "run: ../scripts/tests/ios-release-assets.sh" \
+  "iOS simulator Clippy is not retained for native PR changes"
+require_text "$ios" 'run: ../scripts/tests/ios-release-assets.sh' \
   "iOS frontend job does not validate the built mobile entry"
+require_text "$ios" 'run: bunx vitest run src/mobile' \
+  "iOS frontend job does not retain its mobile-specific tests"
+if grep -Fq 'run: cargo check --target aarch64-apple-ios-sim' "$ios"; then
+  fail "iOS simulator still runs cargo check immediately before Clippy"
+fi
 
 echo "PASS: CI routing contract"

--- a/scripts/tests/cuda-distribution-contract.sh
+++ b/scripts/tests/cuda-distribution-contract.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC1003,SC2016 # Literal workflow/Docker/Nix source is asserted below.
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -27,6 +28,10 @@ require_ci_release_path() {
     ' "$repo_root/.github/workflows/ci.yml"
   )"
   [[ -n "$block" ]] || fail ".github/workflows/ci.yml has no release path classifier"
+  if [[ "$path" == .github/workflows/* ]] \
+    && grep -Fq -- "- '.github/workflows/**'" <<<"$block"; then
+    return 0
+  fi
   grep -Fq -- "- '${path}'" <<<"$block" \
     || fail ".github/workflows/ci.yml release classifier is missing: $path"
 }

--- a/scripts/tests/desktop-nightly-race-guards.sh
+++ b/scripts/tests/desktop-nightly-race-guards.sh
@@ -19,12 +19,12 @@ grep -Fq "cancel-in-progress: \${{ github.event_name == 'pull_request' }}" <<< "
   || fail "workflow-level concurrency does not cancel only superseded PR runs"
 
 rust_job="$(sed -n '/^  desktop-rust:/,/^  desktop-nightly:/p' "$workflow")"
-grep -Fq 'name: Fast bundle proof (debug .app)' <<< "$rust_job" \
-  || fail "PR bundle proof is not clearly marked as a fast debug build"
-grep -Fq "if: github.event_name != 'push'" <<< "$rust_job" \
-  || fail "redundant unsigned bundle proof still runs before main Nightly distribution"
 grep -Fq 'run: bunx tauri build --debug --bundles app --ci' <<< "$rust_job" \
-  || fail "PR bundle proof does not reuse debug test artifacts"
+  || fail "bundle-sensitive macOS PRs have no packaging proof"
+grep -Fq "if: github.event_name == 'pull_request' && needs.changes.outputs.bundle == 'true'" <<< "$rust_job" \
+  || fail "debug bundle is not restricted to bundle-sensitive PRs"
+grep -Fq 'run: cargo test --manifest-path src-tauri/Cargo.toml' <<< "$rust_job" \
+  || fail "macOS PR gate no longer runs the native test suite"
 
 nightly_header="$(sed -n '/^  desktop-nightly:/,/^  publish-desktop-nightly:/p' "$workflow")"
 grep -Fq 'needs: [desktop-frontend, desktop-rust]' <<< "$nightly_header" \

--- a/scripts/tests/minimax-h3-attention-release-contract.sh
+++ b/scripts/tests/minimax-h3-attention-release-contract.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2016 # Literal workflow/Nix source is asserted below.
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -98,21 +99,21 @@ require_text .github/workflows/ci.yml \
 require_text .github/workflows/ci.yml \
   'cargo clippy -p mold-ai-inference --features h3-attention-rc,dev-bins --bin h3_attention_qualification -- -D warnings' \
   "CI does not compile the synthetic H3 qualification executable"
-flash_filter="$(sed -n '/^            flash:/,/^            website:/p' .github/workflows/ci.yml)"
-for path in \
-  crates/mold-candle/Cargo.toml \
-  crates/mold-candle/src/minimax_h3/attention.rs \
-  crates/mold-candle/src/minimax_h3/mod.rs \
-  crates/mold-candle/src/minimax_h3/dit.rs \
-  crates/mold-candle/src/minimax_h3/visual_vae.rs \
-  crates/mold-inference/src/lib.rs \
-  crates/mold-inference/Cargo.toml \
-  crates/mold-inference/src/bin/h3_attention_qualification.rs; do
-  grep -Fq "'$path'" <<< "$flash_filter" \
-    || fail "FlashAttention CI classifier omits $path"
-done
+flash_job="$(awk '
+  $0 == "  flash-attn-check:" { selected = 1 }
+  selected && $0 ~ /^  [[:alnum:]_-][[:alnum:]_-]*:$/ &&
+    $0 != "  flash-attn-check:" { exit }
+  selected { print }
+' .github/workflows/ci.yml)"
+grep -Fq "if: github.event_name == 'push'" <<< "$flash_job" \
+  || fail "FlashAttention proof is not deferred from PRs to every main update"
 
-release_filter="$(sed -n '/^            release:/,/^[[:space:]]*release:/p' .github/workflows/ci.yml)"
+release_filter="$(awk '
+  $0 == "            release:" { selected = 1 }
+  selected && $0 ~ /^            [[:alnum:]_-][[:alnum:]_-]*:$/ &&
+    $0 != "            release:" { exit }
+  selected { print }
+' .github/workflows/ci.yml)"
 for path in \
   crates/mold-candle/src/minimax_h3/mod.rs \
   crates/mold-candle/src/minimax_h3/dit.rs \


### PR DESCRIPTION
## Summary

- make the existing Rust sccache path effective by disabling incompatible incremental compilation, and remove redundant `cargo check` / duplicate Vue typecheck work
- move the non-shipping FlashAttention proof off PRs and run it on every `main` update; keep MSRV, full deterministic Rust tests, CUDA/Metal, native iOS Clippy, and bundle-sensitive macOS packaging checks pre-merge
- stop generic PRs from duplicating Desktop Linux, macOS bundle, and full desktop tests in iOS; keep each signal on a narrower path or the existing main/nightly pipeline
- give repository-owned release-plz PRs a protected fast path with exact actor/repo/branch checks, an M-only generated-file allowlist, three locked Cargo graph validations, actionlint, and the full release contract suite
- make required jobs fail closed on classifier errors without reviving canceled runs, and exercise workflow-only changes dynamically after merge

## Expected impact

Based on recent successful and failed runs:

- root CI p90: **68.9m → ~25.9m**; observed max: **108.4m → ~38.7m**, before any sccache upside
- Desktop native median: **12.6m → ~8.5m**
- iOS frontend median: **4.8m → ~3.1m**
- generated release PRs: about **51 runner-minutes saved per revision**, and about **132 runner-minutes** on the observed cold-Flash revision

The intentional tradeoff is that FlashAttention caught one unique wiring defect recently. It is a non-shipping feature, so this change preserves the signal on every `main` push instead of allowing its 80+ minute cold build onto the PR critical path.

## Validation

- rebased on current `origin/main` immediately before opening this PR
- actionlint: all workflows
- ShellCheck: all modified contract scripts
- CI routing, Desktop nightly race, MiniMax H3 release/private-UAT, release sync/body, crates publish, coverage disk, Docker context, and Desktop Candle lock/hash contracts
- locked Cargo metadata: root, Desktop, and mobile
- `cargo fmt --all -- --check`
- mobile: 29 files / 513 tests; targeted Prettier check
- full Desktop frontend suite: 294 files / 3,109 tests; production build

The CUDA distribution contract reaches its ELF/PTX fixture stage locally but requires Linux `readelf`; the protected Ubuntu release-contract route in this PR is the authoritative execution for that unchanged platform-specific portion.
