### PR TITLE
fix(h3): bind qualification to authorization record

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3246,6 +3246,7 @@ dependencies = [
  "fs2",
  "gif 0.13.3",
  "image",
+ "libc",
  "mold-ai-candle",
  "mold-ai-catalog",
  "mold-ai-core",

--- a/crates/mold-inference/Cargo.toml
+++ b/crates/mold-inference/Cargo.toml
@@ -88,6 +88,7 @@ candle-flash-attn = { version = "0.11", optional = true }
 gif = "0.13"
 webp-animation = { version = "0.10", features = ["static"], optional = true }
 image = "0.25"
+libc = "0.2"
 # Already vendored transitively via image's default features, so a direct
 # dependency adds no new crates to the Nix vendor set. Pure Rust: no system
 # OpenEXR, no cmake, nothing to cross-compile for the sm86/89/100/120 matrix.

--- a/crates/mold-inference/src/bin/h3_artifact_qualification.rs
+++ b/crates/mold-inference/src/bin/h3_artifact_qualification.rs
@@ -1,27 +1,24 @@
-//! Private MiniMax H3 artifact qualification on the authorized private host.
+//! Private MiniMax H3 artifact qualification under a reviewed campaign record.
 //!
 //! The binary is unreachable without `dev-bins,h3-private-uat`, refuses every
-//! host/root outside the authorization record, never constructs an engine, and
-//! embeds a marker that release verification rejects.
+//! root outside the authorization record's owner-only campaign, never
+//! constructs an engine, and embeds a marker that release verification rejects.
 
 use std::collections::BTreeMap;
 use std::env;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use anyhow::{bail, Context, Result};
-use mold_inference::private_qualification::{
-    qualify_private_artifacts, H3ArtifactHashProgress, H3_PRIVATE_AUTHORIZATION_SCOPE,
-    H3_PRIVATE_MODELS_ROOT,
-};
+use mold_inference::private_qualification::{qualify_private_artifacts, H3ArtifactHashProgress};
 
 fn usage() -> &'static str {
     "usage: h3_artifact_qualification --models-root \
-     /storage/jamesbrink/mold-uat/minimax-h3/models --model \
+     <absolute-campaign-root>/mold-home/models --model \
      <minimax-h3-fl2va:comfy-pruned-int8|minimax-h3-ref2va:comfy-pruned-int8> \
-     --authorization-scope private-h3-uat"
+     --authorization-record <absolute-campaign-root>/compliance/<record>.json"
 }
 
-fn parse_args() -> Result<(PathBuf, String, String)> {
+fn parse_args() -> Result<(PathBuf, String, PathBuf)> {
     let mut values = BTreeMap::new();
     let mut args = env::args().skip(1);
     while let Some(argument) = args.next() {
@@ -47,25 +44,23 @@ fn parse_args() -> Result<(PathBuf, String, String)> {
         .map(PathBuf::from)
         .with_context(usage)?;
     let model = values.remove("--model").with_context(usage)?;
-    let authorization_scope = values.remove("--authorization-scope").with_context(usage)?;
+    let authorization_record = values
+        .remove("--authorization-record")
+        .map(PathBuf::from)
+        .with_context(usage)?;
     if !values.is_empty() {
         bail!("unknown qualification argument; {}", usage())
     }
-    Ok((models_root, model, authorization_scope))
+    Ok((models_root, model, authorization_record))
 }
 
 fn main() -> Result<()> {
-    let (models_root, model, authorization_scope) = parse_args()?;
-    if models_root != Path::new(H3_PRIVATE_MODELS_ROOT)
-        || authorization_scope != H3_PRIVATE_AUTHORIZATION_SCOPE
-    {
-        bail!("the requested host scope differs from the reviewed private authorization")
-    }
+    let (models_root, model, authorization_record) = parse_args()?;
     let mut reported = BTreeMap::<String, u64>::new();
     let report = qualify_private_artifacts(
         &models_root,
         &model,
-        &authorization_scope,
+        &authorization_record,
         |progress: H3ArtifactHashProgress| {
             let previous = reported
                 .get(&progress.relative_path)

--- a/crates/mold-inference/src/minimax_h3/private_qualification.rs
+++ b/crates/mold-inference/src/minimax_h3/private_qualification.rs
@@ -6,7 +6,7 @@
 //! ordinary product policy. Its claim marker is forbidden in published Mold
 //! binaries by `scripts/verify-h3-release-exclusion.sh`.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs::{self, File, Metadata};
 use std::io::Read;
 use std::path::{Component, Path, PathBuf};
@@ -31,12 +31,19 @@ use std::os::unix::fs::{MetadataExt, PermissionsExt};
 
 pub const H3_PRIVATE_UAT_CLAIM_MARKER: &str = "mold.minimax-h3.private-uat-artifact-reader.v1";
 pub const H3_PRIVATE_AUTHORIZATION_SCOPE: &str = "private-h3-uat";
-pub const H3_PRIVATE_HOST_AUTHORITY_SHA256: &str =
-    "87e4571bc7b47363d74a65592c50a1eccb5afdc5bd3036d119f8c84c934b37da";
-pub const H3_PRIVATE_MODELS_ROOT: &str = "/storage/jamesbrink/mold-uat/minimax-h3/models";
 
 const MAX_PRIVATE_HEADER_BYTES: u64 = 8 * 1024 * 1024;
+const MAX_AUTHORIZATION_RECORD_BYTES: u64 = 64 * 1024;
 const HASH_BUFFER_BYTES: usize = 8 * 1024 * 1024;
+const AUTHORIZATION_SCHEMA: &str = "mold.minimax-h3.authorization.v1";
+const REVIEWED_AUTHORIZATION_EVIDENCE_SHA256: &str =
+    "8cd4d6e52cff34d7d39721ebab13b8c1187aa87aafc1c4ae2a16609186f22f1d";
+const QUALIFICATION_SCHEMA: &str = "mold.minimax-h3.private-artifact-qualification.v2";
+const REQUIRED_AUTHORIZATION_SCOPES: [&str; 3] = [
+    "checkpoint-execution",
+    "fixture-capture",
+    "generated-output-retention",
+];
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize)]
 pub struct H3ArtifactHashProgress {
@@ -69,7 +76,10 @@ pub struct H3PrivateArtifactQualificationReport {
     pub claim_marker: &'static str,
     pub decision: &'static str,
     pub authorization_scope: &'static str,
-    pub host_authority_sha256: &'static str,
+    pub authorization_schema: &'static str,
+    pub authorization_record_sha256: String,
+    pub authorization_source_document_sha256: String,
+    pub authorization_review_reference: String,
     pub canonical_model: String,
     pub task: &'static str,
     pub layout: &'static str,
@@ -99,6 +109,42 @@ struct ResolvedArtifact<'a> {
     file: &'a ModelFile,
     relative_path: PathBuf,
     canonical_path: PathBuf,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct H3PrivateAuthorizationRecord {
+    schema_version: String,
+    family: String,
+    decision: String,
+    license_revision: String,
+    license_sha256: String,
+    approved_scopes: Vec<String>,
+    source_document_path: PathBuf,
+    source_document_sha256: String,
+    review_reference: String,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ProtectedPathKind {
+    Directory,
+    File,
+}
+
+#[derive(Clone, Debug)]
+struct ProtectedPath {
+    path: PathBuf,
+    kind: ProtectedPathKind,
+    identity: FileIdentity,
+}
+
+#[derive(Debug)]
+struct ValidatedPrivateScope {
+    models_root: PathBuf,
+    authorization_record_sha256: String,
+    authorization_source_document_sha256: String,
+    authorization_review_reference: String,
+    protected_paths: Vec<ProtectedPath>,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]
@@ -146,6 +192,10 @@ struct FileIdentity {
     #[cfg(unix)]
     inode: u64,
     #[cfg(unix)]
+    mode: u32,
+    #[cfg(unix)]
+    owner: u32,
+    #[cfg(unix)]
     modified_seconds: i64,
     #[cfg(unix)]
     modified_nanoseconds: i64,
@@ -166,6 +216,10 @@ impl FileIdentity {
             #[cfg(unix)]
             inode: metadata.ino(),
             #[cfg(unix)]
+            mode: metadata.mode(),
+            #[cfg(unix)]
+            owner: metadata.uid(),
+            #[cfg(unix)]
             modified_seconds: metadata.mtime(),
             #[cfg(unix)]
             modified_nanoseconds: metadata.mtime_nsec(),
@@ -181,20 +235,19 @@ impl FileIdentity {
 
 /// Authenticate and structurally inspect the exact Comfy deployment set.
 ///
-/// The host, models root, authorization scope, hidden manifest, file sizes,
-/// full SHA-256 digests, and bounded headers are all mandatory. This function
-/// never builds an inference engine and cannot change `runtime_available`.
+/// The owner-only campaign layout, external authorization record, hidden
+/// manifest, file sizes, full SHA-256 digests, and bounded headers are all
+/// mandatory. This function never builds an inference engine and cannot change
+/// `runtime_available`.
 pub fn qualify_private_artifacts(
     models_root: &Path,
     model: &str,
-    authorization_scope: &str,
+    authorization_record: &Path,
     mut progress: impl FnMut(H3ArtifactHashProgress),
 ) -> Result<H3PrivateArtifactQualificationReport> {
-    validate_private_scope(models_root, authorization_scope)?;
+    let private_scope = validate_private_scope(models_root, authorization_record)?;
     let (manifest, task, published_transformer) = qualification_manifest(model)?;
-    let root = models_root
-        .canonicalize()
-        .context("failed to canonicalize the private H3 models root")?;
+    let root = private_scope.models_root.clone();
     let artifacts = manifest
         .files
         .iter()
@@ -247,14 +300,24 @@ pub fn qualify_private_artifacts(
     revalidate_artifact_set(&artifacts, &authenticated_identities)?;
     validate_support_assets(&artifacts, &authenticated_identities, task)?;
     revalidate_artifact_set(&artifacts, &authenticated_identities)?;
+    revalidate_private_scope(&private_scope)?;
 
-    let qualification_identity_sha256 = qualification_identity(model, task, &qualified);
+    let qualification_identity_sha256 = qualification_identity(
+        model,
+        task,
+        &private_scope.authorization_record_sha256,
+        &private_scope.authorization_source_document_sha256,
+        &qualified,
+    );
     Ok(H3PrivateArtifactQualificationReport {
-        schema: "mold.minimax-h3.private-artifact-qualification.v1",
+        schema: QUALIFICATION_SCHEMA,
         claim_marker: H3_PRIVATE_UAT_CLAIM_MARKER,
         decision: "qualified-private-artifacts",
         authorization_scope: H3_PRIVATE_AUTHORIZATION_SCOPE,
-        host_authority_sha256: H3_PRIVATE_HOST_AUTHORITY_SHA256,
+        authorization_schema: AUTHORIZATION_SCHEMA,
+        authorization_record_sha256: private_scope.authorization_record_sha256,
+        authorization_source_document_sha256: private_scope.authorization_source_document_sha256,
+        authorization_review_reference: private_scope.authorization_review_reference,
         canonical_model: model.to_string(),
         task: task_id(task),
         layout: "comfy-pruned-int8-convrot-plus-nvfp4-awq",
@@ -277,49 +340,338 @@ pub fn qualify_private_artifacts(
     })
 }
 
-fn validate_private_scope(models_root: &Path, authorization_scope: &str) -> Result<()> {
-    if authorization_scope != H3_PRIVATE_AUTHORIZATION_SCOPE {
-        bail!(
-            "MiniMax H3 artifact qualification requires authorization scope {H3_PRIVATE_AUTHORIZATION_SCOPE:?}"
-        )
-    }
-    let hostname = fs::read_to_string("/etc/hostname")
-        .context("private H3 qualification requires a readable /etc/hostname")?;
-    let hostname_authority = format!("{:x}", Sha256::digest(hostname.trim().as_bytes()));
-    if hostname_authority != H3_PRIVATE_HOST_AUTHORITY_SHA256 {
-        bail!("private MiniMax H3 qualification is outside the authorized host scope")
-    }
-    let canonical = models_root
-        .canonicalize()
-        .context("failed to canonicalize the requested private H3 models root")?;
-    if canonical != Path::new(H3_PRIVATE_MODELS_ROOT) {
-        bail!(
-            "private MiniMax H3 qualification is authorized only for the reviewed models root {H3_PRIVATE_MODELS_ROOT}"
-        )
-    }
-    require_private_directory(&canonical)?;
-    let campaign_root = canonical
-        .parent()
-        .ok_or_else(|| anyhow!("private H3 models root has no campaign parent"))?;
-    require_private_directory(campaign_root)
+fn validate_private_scope(
+    models_root: &Path,
+    authorization_record: &Path,
+) -> Result<ValidatedPrivateScope> {
+    validate_private_scope_against_evidence(
+        models_root,
+        authorization_record,
+        REVIEWED_AUTHORIZATION_EVIDENCE_SHA256,
+    )
 }
 
-fn require_private_directory(path: &Path) -> Result<()> {
+fn validate_private_scope_against_evidence(
+    models_root: &Path,
+    authorization_record: &Path,
+    reviewed_evidence_sha256: &str,
+) -> Result<ValidatedPrivateScope> {
+    let models_root = canonical_absolute_path(models_root, "private H3 models root")?;
+    if models_root.file_name().and_then(|name| name.to_str()) != Some("models") {
+        bail!("private H3 models root must be the campaign mold-home/models directory")
+    }
+    let mold_home = models_root
+        .parent()
+        .ok_or_else(|| anyhow!("private H3 models root has no Mold home parent"))?;
+    if mold_home.file_name().and_then(|name| name.to_str()) != Some("mold-home") {
+        bail!("private H3 models root must be nested directly under campaign mold-home")
+    }
+    let campaign_root = mold_home
+        .parent()
+        .ok_or_else(|| anyhow!("private H3 Mold home has no campaign parent"))?;
+    let repository_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .ok_or_else(|| anyhow!("cannot resolve the Mold repository root"))?
+        .canonicalize()
+        .context("failed to canonicalize the Mold repository root")?;
+    if campaign_root.starts_with(&repository_root) {
+        bail!("private H3 qualification campaign must live outside the Mold repository")
+    }
+    let compliance_root = campaign_root.join("compliance");
+    let authorization_record =
+        canonical_absolute_path(authorization_record, "private H3 authorization record")?;
+    if authorization_record.parent() != Some(compliance_root.as_path()) {
+        bail!("private H3 authorization record must be a direct child of campaign compliance")
+    }
+
+    let mut protected_paths = Vec::new();
+    let campaign = require_private_directory(campaign_root, None)?;
+    let owner = campaign.owner();
+    require_effective_process_owner(owner)?;
+    protected_paths.push(campaign);
+    protected_paths.push(require_private_directory(mold_home, Some(owner))?);
+    protected_paths.push(require_private_directory(&models_root, Some(owner))?);
+    protected_paths.push(require_private_directory(&compliance_root, Some(owner))?);
+    let record_path = require_private_file(&authorization_record, owner)?;
+    let record_bytes = read_protected_file(
+        &record_path,
+        MAX_AUTHORIZATION_RECORD_BYTES,
+        "private H3 authorization record",
+    )?;
+    let authorization_record_sha256 = format!("{:x}", Sha256::digest(&record_bytes));
+    let record: H3PrivateAuthorizationRecord = serde_json::from_slice(&record_bytes)
+        .context("private H3 authorization record is not valid exact-schema JSON")?;
+    validate_authorization_fields(&record, reviewed_evidence_sha256)?;
+
+    let source_document = canonical_absolute_path(
+        &record.source_document_path,
+        "private H3 authorization source document",
+    )?;
+    if source_document == authorization_record
+        || source_document.parent() != Some(compliance_root.as_path())
+    {
+        bail!(
+            "private H3 authorization source document must be a distinct direct child of campaign compliance"
+        )
+    }
+    let source_path = require_private_file(&source_document, owner)?;
+    let source_document_sha256 =
+        hash_protected_file(&source_path, "private H3 authorization source document")?;
+    if source_document_sha256 != record.source_document_sha256 {
+        bail!("private H3 authorization source document hash does not match its record")
+    }
+
+    protected_paths.push(record_path);
+    protected_paths.push(source_path);
+    Ok(ValidatedPrivateScope {
+        models_root,
+        authorization_record_sha256,
+        authorization_source_document_sha256: source_document_sha256,
+        authorization_review_reference: record.review_reference,
+        protected_paths,
+    })
+}
+
+fn validate_authorization_fields(
+    record: &H3PrivateAuthorizationRecord,
+    reviewed_evidence_sha256: &str,
+) -> Result<()> {
+    if !valid_lower_sha256(reviewed_evidence_sha256) {
+        bail!("private H3 reviewed authorization evidence identity is invalid")
+    }
+    if record.schema_version != AUTHORIZATION_SCHEMA {
+        bail!("private H3 authorization record schema is unsupported")
+    }
+    if record.family != contract::FAMILY || record.decision != "approved" {
+        bail!("private H3 authorization record does not approve MiniMax H3")
+    }
+    if record.license_revision != contract::OFFICIAL_REVISION {
+        bail!("private H3 authorization record covers a different license revision")
+    }
+    if record.license_sha256 != contract::LICENSE_SHA256 {
+        bail!("private H3 authorization record covers different license bytes")
+    }
+    let actual_scopes = record
+        .approved_scopes
+        .iter()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+    let expected_scopes = REQUIRED_AUTHORIZATION_SCOPES
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+    if actual_scopes.len() != record.approved_scopes.len()
+        || !expected_scopes.is_subset(&actual_scopes)
+        || actual_scopes.iter().any(|scope| {
+            scope.is_empty()
+                || scope.len() > 128
+                || scope.trim() != *scope
+                || scope.chars().any(char::is_control)
+        })
+    {
+        bail!("private H3 authorization record does not cover every reviewed activity")
+    }
+    if !valid_lower_sha256(&record.source_document_sha256) {
+        bail!("private H3 authorization source document SHA-256 is not canonical")
+    }
+    if record.source_document_sha256 != reviewed_evidence_sha256 {
+        bail!("private H3 authorization record does not bind the reviewed evidence")
+    }
+    let review_reference = record.review_reference.as_str();
+    if review_reference.is_empty()
+        || review_reference.len() > 256
+        || review_reference.trim() != review_reference
+        || review_reference.chars().any(char::is_control)
+    {
+        bail!("private H3 authorization record lacks a canonical external review reference")
+    }
+    Ok(())
+}
+
+fn canonical_absolute_path(path: &Path, label: &str) -> Result<PathBuf> {
+    if !path.is_absolute() {
+        bail!("{label} must be an absolute path")
+    }
+    if path
+        .components()
+        .any(|component| !matches!(component, Component::RootDir | Component::Normal(_)))
+    {
+        bail!("{label} must not contain relative or parent components")
+    }
+    let requested_metadata =
+        fs::symlink_metadata(path).with_context(|| format!("failed to inspect {label}"))?;
+    if requested_metadata.file_type().is_symlink() {
+        bail!("{label} must not be a symlink")
+    }
+    let canonical = path
+        .canonicalize()
+        .with_context(|| format!("failed to canonicalize {label}"))?;
+    if canonical != path {
+        bail!("{label} must not contain aliases or symlink components")
+    }
+    Ok(canonical)
+}
+
+#[cfg(unix)]
+fn require_effective_process_owner(owner: u32) -> Result<()> {
+    if owner != effective_process_owner() {
+        bail!("private H3 qualification campaign must be owned by the invoking process user")
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn effective_process_owner() -> u32 {
+    // SAFETY: `geteuid` has no preconditions, does not dereference pointers,
+    // and only returns the effective uid maintained by the operating system.
+    unsafe { libc::geteuid() }
+}
+
+#[cfg(not(unix))]
+fn require_effective_process_owner(_owner: u32) -> Result<()> {
+    bail!("private H3 qualification currently requires Unix ownership semantics")
+}
+
+fn require_private_directory(path: &Path, expected_owner: Option<u32>) -> Result<ProtectedPath> {
     let metadata = fs::symlink_metadata(path)
         .with_context(|| format!("failed to inspect private directory {}", path.display()))?;
     if !metadata.file_type().is_dir() || metadata.file_type().is_symlink() {
         bail!("private H3 qualification path must be a real directory")
     }
     #[cfg(unix)]
-    if metadata.permissions().mode() & 0o077 != 0 {
+    if metadata.permissions().mode() & 0o7777 != 0o700 {
         bail!(
-            "private H3 qualification directory {} grants group/other access",
+            "private H3 qualification directory {} must have mode 0700",
             path.display()
         )
     }
+    #[cfg(unix)]
+    if expected_owner.is_some_and(|owner| metadata.uid() != owner) {
+        bail!("private H3 qualification directories must have one owner")
+    }
     #[cfg(not(unix))]
     bail!("private H3 qualification currently requires Unix permission semantics");
+    Ok(ProtectedPath {
+        path: path.to_path_buf(),
+        kind: ProtectedPathKind::Directory,
+        identity: FileIdentity::from_metadata(&metadata),
+    })
+}
+
+fn require_private_file(path: &Path, expected_owner: u32) -> Result<ProtectedPath> {
+    let metadata = fs::symlink_metadata(path)
+        .with_context(|| format!("failed to inspect private file {}", path.display()))?;
+    if !metadata.file_type().is_file() || metadata.file_type().is_symlink() {
+        bail!("private H3 qualification evidence must be a regular non-symlink file")
+    }
+    #[cfg(unix)]
+    if metadata.permissions().mode() & 0o7777 != 0o600 {
+        bail!(
+            "private H3 qualification evidence {} must have mode 0600",
+            path.display()
+        )
+    }
+    #[cfg(unix)]
+    if metadata.uid() != expected_owner {
+        bail!("private H3 qualification evidence must share the campaign owner")
+    }
+    #[cfg(not(unix))]
+    bail!("private H3 qualification currently requires Unix permission semantics");
+    Ok(ProtectedPath {
+        path: path.to_path_buf(),
+        kind: ProtectedPathKind::File,
+        identity: FileIdentity::from_metadata(&metadata),
+    })
+}
+
+impl ProtectedPath {
+    #[cfg(unix)]
+    fn owner(&self) -> u32 {
+        self.identity.owner
+    }
+
+    #[cfg(not(unix))]
+    fn owner(&self) -> u32 {
+        0
+    }
+}
+
+fn read_protected_file(path: &ProtectedPath, maximum: u64, label: &str) -> Result<Vec<u8>> {
+    let mut file = File::open(&path.path).with_context(|| format!("failed to open {label}"))?;
+    if FileIdentity::from_metadata(&file.metadata()?) != path.identity {
+        bail!("{label} changed while it was opened")
+    }
+    if path.identity.len > maximum {
+        bail!("{label} exceeds the bounded reader size")
+    }
+    let capacity = usize::try_from(path.identity.len).context("private file is too large")?;
+    let mut bytes = Vec::with_capacity(capacity);
+    file.read_to_end(&mut bytes)
+        .with_context(|| format!("failed to read {label}"))?;
+    if bytes.len() != capacity || FileIdentity::from_metadata(&file.metadata()?) != path.identity {
+        bail!("{label} changed during its read")
+    }
+    revalidate_protected_path(path)?;
+    Ok(bytes)
+}
+
+fn hash_protected_file(path: &ProtectedPath, label: &str) -> Result<String> {
+    let mut file = File::open(&path.path).with_context(|| format!("failed to open {label}"))?;
+    if FileIdentity::from_metadata(&file.metadata()?) != path.identity {
+        bail!("{label} changed while it was opened")
+    }
+    let mut digest = Sha256::new();
+    let mut buffer = vec![0_u8; HASH_BUFFER_BYTES];
+    let mut read_bytes = 0_u64;
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .with_context(|| format!("failed to hash {label}"))?;
+        if read == 0 {
+            break;
+        }
+        digest.update(&buffer[..read]);
+        read_bytes = read_bytes
+            .checked_add(read as u64)
+            .ok_or_else(|| anyhow!("{label} byte count overflow"))?;
+    }
+    if read_bytes != path.identity.len
+        || FileIdentity::from_metadata(&file.metadata()?) != path.identity
+    {
+        bail!("{label} changed during hashing")
+    }
+    revalidate_protected_path(path)?;
+    Ok(format!("{:x}", digest.finalize()))
+}
+
+fn revalidate_private_scope(scope: &ValidatedPrivateScope) -> Result<()> {
+    for path in &scope.protected_paths {
+        revalidate_protected_path(path)?;
+    }
     Ok(())
+}
+
+fn revalidate_protected_path(path: &ProtectedPath) -> Result<()> {
+    let metadata = fs::symlink_metadata(&path.path)
+        .with_context(|| format!("failed to revalidate private path {}", path.path.display()))?;
+    let kind_matches = match path.kind {
+        ProtectedPathKind::Directory => metadata.file_type().is_dir(),
+        ProtectedPathKind::File => metadata.file_type().is_file(),
+    };
+    if !kind_matches
+        || metadata.file_type().is_symlink()
+        || FileIdentity::from_metadata(&metadata) != path.identity
+    {
+        bail!("private H3 authorization or campaign scope changed during qualification")
+    }
+    Ok(())
+}
+
+fn valid_lower_sha256(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
 }
 
 fn qualification_manifest(
@@ -764,13 +1116,21 @@ fn require_string_field(value: &serde_json::Value, field: &str, expected: &str) 
     Ok(())
 }
 
-fn qualification_identity(model: &str, task: Task, artifacts: &[H3QualifiedArtifact]) -> String {
+fn qualification_identity(
+    model: &str,
+    task: Task,
+    authorization_record_sha256: &str,
+    authorization_source_document_sha256: &str,
+    artifacts: &[H3QualifiedArtifact],
+) -> String {
     let mut digest = Sha256::new();
-    digest.update(b"mold.minimax-h3.private-artifact-qualification.v1\0");
+    digest.update(b"mold.minimax-h3.private-artifact-qualification.v2\0");
     digest.update(model.as_bytes());
     digest.update(task_id(task).as_bytes());
     digest.update(contract::OFFICIAL_REVISION.as_bytes());
     digest.update(contract::COMFY_REVISION.as_bytes());
+    digest.update(authorization_record_sha256.as_bytes());
+    digest.update(authorization_source_document_sha256.as_bytes());
     for artifact in artifacts {
         digest.update(artifact.relative_path.as_bytes());
         digest.update(artifact.component.as_bytes());
@@ -851,13 +1211,256 @@ mod tests {
             "mold.minimax-h3.private-uat-artifact-reader.v1"
         );
         assert_eq!(H3_PRIVATE_AUTHORIZATION_SCOPE, "private-h3-uat");
-        assert_eq!(H3_PRIVATE_HOST_AUTHORITY_SHA256.len(), 64);
-        assert!(H3_PRIVATE_HOST_AUTHORITY_SHA256
-            .bytes()
-            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase()));
-        assert!(H3_PRIVATE_MODELS_ROOT.starts_with("/storage/"));
         assert!(!contract::capabilities(Task::Fl2va).runtime_available);
         assert!(!contract::capabilities(Task::Ref2va).runtime_available);
+    }
+
+    #[cfg(unix)]
+    struct PrivateCampaignFixture {
+        _temporary: tempfile::TempDir,
+        campaign_root: PathBuf,
+        models_root: PathBuf,
+        compliance_root: PathBuf,
+        source_document: PathBuf,
+        authorization_record: PathBuf,
+    }
+
+    #[cfg(unix)]
+    impl PrivateCampaignFixture {
+        fn new() -> Self {
+            let temporary = tempfile::tempdir().unwrap();
+            let campaign_root = temporary.path().canonicalize().unwrap().join("campaign");
+            let mold_home = campaign_root.join("mold-home");
+            let models_root = mold_home.join("models");
+            let compliance_root = campaign_root.join("compliance");
+            for directory in [&campaign_root, &mold_home, &models_root, &compliance_root] {
+                fs::create_dir_all(directory).unwrap();
+                set_mode(directory, 0o700);
+            }
+            let source_document = compliance_root.join("authorization-evidence.bin");
+            fs::write(&source_document, b"reviewed private authorization evidence").unwrap();
+            set_mode(&source_document, 0o600);
+            let authorization_record = compliance_root.join("authorization.v1.json");
+            let fixture = Self {
+                _temporary: temporary,
+                campaign_root,
+                models_root,
+                compliance_root,
+                source_document,
+                authorization_record,
+            };
+            fixture.write_record(fixture.valid_record());
+            fixture
+        }
+
+        fn valid_record(&self) -> serde_json::Value {
+            serde_json::json!({
+                "schema_version": "mold.minimax-h3.authorization.v1",
+                "family": contract::FAMILY,
+                "decision": "approved",
+                "license_revision": contract::OFFICIAL_REVISION,
+                "license_sha256": contract::LICENSE_SHA256,
+                "approved_scopes": [
+                    "checkpoint-execution",
+                    "fixture-capture",
+                    "generated-output-retention"
+                ],
+                "source_document_path": self.source_document,
+                "source_document_sha256": sha256_path(&self.source_document),
+                "review_reference": "external-test-review"
+            })
+        }
+
+        fn write_record(&self, value: serde_json::Value) {
+            fs::write(
+                &self.authorization_record,
+                serde_json::to_vec_pretty(&value).unwrap(),
+            )
+            .unwrap();
+            set_mode(&self.authorization_record, 0o600);
+        }
+    }
+
+    #[cfg(unix)]
+    fn set_mode(path: &Path, mode: u32) {
+        fs::set_permissions(path, fs::Permissions::from_mode(mode)).unwrap();
+    }
+
+    #[cfg(unix)]
+    fn sha256_path(path: &Path) -> String {
+        format!("{:x}", Sha256::digest(fs::read(path).unwrap()))
+    }
+
+    #[cfg(unix)]
+    fn validate_fixture_scope(
+        fixture: &PrivateCampaignFixture,
+        models_root: &Path,
+        authorization_record: &Path,
+    ) -> Result<ValidatedPrivateScope> {
+        validate_private_scope_against_evidence(
+            models_root,
+            authorization_record,
+            &sha256_path(&fixture.source_document),
+        )
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn production_scope_rejects_unreviewed_evidence() {
+        let fixture = PrivateCampaignFixture::new();
+        let error = validate_private_scope(&fixture.models_root, &fixture.authorization_record)
+            .unwrap_err();
+        assert!(error.to_string().contains("reviewed evidence"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn authorization_record_and_owner_only_campaign_layout_are_required() {
+        let fixture = PrivateCampaignFixture::new();
+        validate_fixture_scope(
+            &fixture,
+            &fixture.models_root,
+            &fixture.authorization_record,
+        )
+        .unwrap();
+        require_effective_process_owner(effective_process_owner()).unwrap();
+        assert!(
+            require_effective_process_owner(effective_process_owner().wrapping_add(1)).is_err()
+        );
+
+        let other = PrivateCampaignFixture::new();
+        assert!(validate_fixture_scope(
+            &fixture,
+            &fixture.models_root,
+            &other.authorization_record
+        )
+        .is_err());
+
+        set_mode(&fixture.authorization_record, 0o644);
+        assert!(validate_fixture_scope(
+            &fixture,
+            &fixture.models_root,
+            &fixture.authorization_record,
+        )
+        .is_err());
+        set_mode(&fixture.authorization_record, 0o600);
+        set_mode(&fixture.source_document, 0o644);
+        assert!(validate_fixture_scope(
+            &fixture,
+            &fixture.models_root,
+            &fixture.authorization_record,
+        )
+        .is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn authorization_record_fields_and_source_digest_fail_closed() {
+        let fixture = PrivateCampaignFixture::new();
+        let valid = fixture.valid_record();
+
+        let mut broader_scope = valid.clone();
+        broader_scope["approved_scopes"] = serde_json::json!([
+            "checkpoint-execution",
+            "fixture-capture",
+            "generated-output-retention",
+            "later-reviewed-private-activity"
+        ]);
+        fixture.write_record(broader_scope);
+        validate_fixture_scope(
+            &fixture,
+            &fixture.models_root,
+            &fixture.authorization_record,
+        )
+        .unwrap();
+
+        let mut wrong_license = valid.clone();
+        wrong_license["license_sha256"] = serde_json::Value::String("0".repeat(64));
+        fixture.write_record(wrong_license);
+        assert!(validate_fixture_scope(
+            &fixture,
+            &fixture.models_root,
+            &fixture.authorization_record,
+        )
+        .is_err());
+
+        let mut missing_scope = valid.clone();
+        missing_scope["approved_scopes"] = serde_json::json!(["fixture-capture"]);
+        fixture.write_record(missing_scope);
+        assert!(validate_fixture_scope(
+            &fixture,
+            &fixture.models_root,
+            &fixture.authorization_record,
+        )
+        .is_err());
+
+        let mut duplicate_scope = valid.clone();
+        duplicate_scope["approved_scopes"] = serde_json::json!([
+            "checkpoint-execution",
+            "fixture-capture",
+            "fixture-capture",
+            "generated-output-retention"
+        ]);
+        fixture.write_record(duplicate_scope);
+        assert!(validate_fixture_scope(
+            &fixture,
+            &fixture.models_root,
+            &fixture.authorization_record,
+        )
+        .is_err());
+
+        let mut wrong_source = valid;
+        wrong_source["source_document_sha256"] = serde_json::Value::String("0".repeat(64));
+        fixture.write_record(wrong_source);
+        assert!(validate_fixture_scope(
+            &fixture,
+            &fixture.models_root,
+            &fixture.authorization_record,
+        )
+        .is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn authorization_source_and_models_root_reject_symlink_aliases() {
+        use std::os::unix::fs::symlink;
+
+        let fixture = PrivateCampaignFixture::new();
+        let campaign_alias = fixture
+            .campaign_root
+            .parent()
+            .unwrap()
+            .join("campaign-alias");
+        symlink(&fixture.campaign_root, &campaign_alias).unwrap();
+        let aliased_models_root = campaign_alias.join("mold-home/models");
+        assert!(validate_fixture_scope(
+            &fixture,
+            &aliased_models_root,
+            &fixture.authorization_record,
+        )
+        .is_err());
+
+        let source_target = fixture.compliance_root.join("source-target.bin");
+        fs::rename(&fixture.source_document, &source_target).unwrap();
+        symlink(&source_target, &fixture.source_document).unwrap();
+        assert!(validate_fixture_scope(
+            &fixture,
+            &fixture.models_root,
+            &fixture.authorization_record,
+        )
+        .is_err());
+
+        fs::remove_file(&fixture.source_document).unwrap();
+        fs::rename(&source_target, &fixture.source_document).unwrap();
+        let models_target = fixture.campaign_root.join("models-target");
+        fs::rename(&fixture.models_root, &models_target).unwrap();
+        symlink(&models_target, &fixture.models_root).unwrap();
+        assert!(validate_fixture_scope(
+            &fixture,
+            &fixture.models_root,
+            &fixture.authorization_record,
+        )
+        .is_err());
     }
 
     #[test]

--- a/docs/qualification/minimax-h3.md
+++ b/docs/qualification/minimax-h3.md
@@ -1,16 +1,16 @@
 # MiniMax H3 qualification and authorization status
 
 - Public product status: **unavailable; compliance-gated**
-- Private qualification status: **authorized on the private UAT host**
-- Evidence snapshot: **2026-08-08, Mold main `8a826153`**
+- Private qualification status: **authorized under the external private-UAT record**
+- Evidence snapshot: **2026-08-08, Mold main `12bbad65`**
 - Authorization owner: [issue #831](https://github.com/utensils/mold/issues/831)
 - Final qualification owner: [issue #827](https://github.com/utensils/mold/issues/827)
 
 This is an engineering status record and the acceptance plan for a possible
 future MiniMax H3 qualification. It is not a support announcement, a license
 grant, or legal advice. Mold main contains fail-closed H3 contracts, primitives,
-factory authorities, and dispatch seams, but does not currently advertise,
-download, load, or execute H3.
+factory authorities, and dispatch seams, but ordinary product builds do not
+advertise, download, load, or execute H3.
 
 The research used public implementation source and small textual repository
 metadata only. The reviewed
@@ -20,11 +20,13 @@ United Kingdom, and Republic of Korea. On 2026-08-08, the maintainer accepted a
 direct attestation that MiniMax authorized H3 integration with Mold. The
 [decision record](../architecture/minimax-h3-authorization.md) limits that
 authority to private downloads, inference, benign outputs, and conformance work
-on the authorized private host. It does not authorize public product activation,
-hosted or third-party access, distribution, or redistribution. No binary H3
-checkpoint, production safetensors header, generated media, or real-checkpoint
-UAT had been accessed at this evidence snapshot. The excluded external-volume
-UAT home was not used for H3 artifacts.
+under the access-controlled campaign record. It does not authorize public
+product activation, hosted or third-party access, distribution, or
+redistribution. The external campaign contains revision-pinned official and
+practical Comfy artifacts whose size and full SHA-256 identities were verified;
+an authenticated real-checkpoint block-0 qualification also ran on CUDA. That
+does not constitute end-to-end synchronized-A/V generation or runtime
+qualification, and no generated media had been produced at this snapshot.
 
 See the separate [authorization decision record](../architecture/minimax-h3-authorization.md)
 for the reviewed license identity, activation requirements, review ownership,
@@ -197,46 +199,57 @@ conditioner, an FP16 video VAE, and an FP32 AudioVAE.
 
 Comfy's curve-AdaLN representation replaces the official timestep MLP and
 full-width AdaLN projections. Its QKV packing also differs from the official
-layout. The current main-branch validator uses synthetic headers and tiny
-zero-filled tensors; production H3 headers have not been read, and the
-validator deliberately rejects runtime activation.
+layout. Ordinary CI uses synthetic headers and tiny zero-filled tensors.
+Separately, the development-only private path authenticated the released
+headers and full transformer objects before isolated block-0 CUDA execution.
+That narrow evidence does not activate the factory or qualify a full runtime;
+`runtime_available` remains false.
 
 ### Local UAT storage status
 
-`/Volumes/ExternalStorage` was identified as the requested future `MOLD_HOME`
-and model-download volume. At the evidence timestamp, `df -h`, `diskutil info`,
-and `stat` returned nominal mount metadata for a mounted APFS volume with about
-966 GiB available and SMART status reported as Verified. However, time-bounded
-`ls` and `find` directory enumeration did not complete; an earlier bounded
-create/fsync/read/checksum/delete probe and later filesystem commands also did
-not complete. It is not a qualified storage target. Nominal metadata is not a
-substitute for usable filesystem operations.
+The earlier operational exclusion of `/Volumes/ExternalStorage` was superseded
+on 2026-08-08 after the maintainer selected it for private H3 UAT and a fresh
+qualification campaign passed directory enumeration, create/fsync/read/hash/
+delete probes, capacity checks, and repeat artifact inventories. The isolated
+campaign root is `/Volumes/ExternalStorage/mold/uat-h3`; its campaign,
+`mold-home`, `mold-home/models`, and `compliance` directories are owner-only
+mode `0700`, and authorization/model/evidence files are mode `0600`. The volume
+retained about 760 GiB free at this snapshot.
 
-The volume is excluded from Mold UAT. The only attempted write was the bounded
-non-H3 probe described above; after it hung, this audit made no additional
-write, repair, or remount attempt. A separate owner must authorize recovery,
-after which a fresh non-H3 storage probe and clean inventory must pass before
-the volume can even be proposed for an authorized campaign.
+The canonical private `MOLD_HOME` is
+`/Volumes/ExternalStorage/mold/uat-h3/mold-home`. Fifty official payloads at
+revision `bfc8ed0` total 144,028,152,581 bytes; 17 practical Comfy payloads at
+revision `eb8a161` total 42,482,090,318 bytes. Repeated size and SHA-256
+verification found no missing or partial payload. The external authorization
+record and its content-addressed source evidence remain under the sibling
+`compliance` directory. This storage result authorizes only the private scope
+in the decision record and does not alter the public-product gate.
 
 ### Private artifact campaign
 
 After the private authorization decision was accepted on 2026-08-08, the
-campaign moved to the authorized private host. Its reviewed root is
-`/storage/jamesbrink/mold-uat/minimax-h3`, with both that directory and its
-`models` child restricted to mode `0700`. The pinned Comfy FL2VA transformer,
-NVFP4-AWQ Qwen3-VL conditioner, FP16 visual VAE, FP32 AudioVAE, and exact small
-official support files were downloaded directly into that root. All complete
-objects matched the sizes and SHA-256 identities in the hidden manifest. No
-artifact or header was copied into the repository, and no real-checkpoint
-report is public evidence.
+campaign was established under the qualified external root above. The pinned
+Comfy FL2VA transformer, NVFP4-AWQ Qwen3-VL conditioner, FP16 visual VAE, FP32
+AudioVAE, and exact small official support files were downloaded directly into
+its private `mold-home/models`. All complete objects matched the sizes and
+SHA-256 identities in the hidden manifest. No artifact or header was copied
+into the repository, and no real-checkpoint report is public evidence.
 
 The development-only qualifier repeats full-content authentication and bounded
-structural inspection before any later runtime qualification. It is hard-bound
-to the authorized host, root, either exact canonical hidden task name, and the
-explicit scope. Qualify the two independently so a shared component cannot
-hide a task-transformer mismatch:
+structural inspection before any later runtime qualification. It requires the
+exact external authorization-record schema and license pins, hashes both the
+record and its source document, and accepts only the invoking user's owner-only
+`<campaign>/mold-home/models` plus sibling `<campaign>/compliance` layout. It
+does not trust a host name, caller-asserted scope, or hardcoded storage path.
+Qualify the two tasks independently so a shared component cannot hide a
+task-transformer mismatch:
 
 ```bash
+umask 077
+export MOLD_HOME=/Volumes/ExternalStorage/mold/uat-h3/mold-home
+export CARGO_TARGET_DIR=/Volumes/ExternalStorage/mold/uat-h3/cargo-target-qualification-record
+authorization_record=/Volumes/ExternalStorage/mold/uat-h3/compliance/minimax-h3-authorization.v1.json
+
 for model in \
   minimax-h3-fl2va:comfy-pruned-int8 \
   minimax-h3-ref2va:comfy-pruned-int8
@@ -248,24 +261,20 @@ do
     -p mold-ai-inference \
     --features dev-bins,h3-private-uat \
     --bin h3_artifact_qualification -- \
-    --models-root /storage/jamesbrink/mold-uat/minimax-h3/models \
+    --models-root "$MOLD_HOME/models" \
     --model "$model" \
-    --authorization-scope private-h3-uat \
-    > "/storage/jamesbrink/mold-uat/minimax-h3/evidence/artifact-qualification-$task.json"
+    --authorization-record "$authorization_record" \
+    > "/Volumes/ExternalStorage/mold/uat-h3/logs/artifact-qualification-$task.json"
 done
 ```
 
-Each report contains only relative paths and identities, says explicitly that
-no runtime or generated media was constructed, and remains private with the
-model campaign. The feature is not forwarded by `mold-ai`; every published
-binary is scanned for its claim marker and rejected if the private reader is
-present. This qualifies artifact identity only. It does not satisfy numerical
-parity, CUDA generation UAT, public authorization, or release activation.
-
-No H3 model download, `MOLD_HOME`, fixture bundle, checkpoint shard or header,
-generated output, or other H3 artifact was read from or placed on that volume.
-The storage failure is independent of the license restriction: fixing the
-volume would not authorize H3 artifact access or execution.
+Each report contains only relative artifact paths and content identities, binds
+the external record/source identities, says explicitly that no runtime or
+generated media was constructed, and remains private with the model campaign.
+The feature is not forwarded by `mold-ai`; every published binary is scanned
+for its claim marker and rejected if the private reader is present. This
+qualifies artifact identity only. It does not satisfy numerical parity, CUDA
+generation UAT, public authorization, or release activation.
 
 ### Parity and approximate-path rules
 
@@ -307,20 +316,22 @@ before a real run can be admitted.
 
 ## Current evidence status
 
-All evidence in this section is weight-free. A passing synthetic test proves a
-Rust contract or a tiny kernel route; it does not prove real-checkpoint
-correctness, throughput, memory fit, output quality, or release support.
+Most evidence in this section is weight-free. The explicit real-checkpoint row
+is the sole exception: it records authenticated, isolated block-0 execution for
+both released task transformers. A passing synthetic test proves only a Rust
+contract or tiny kernel route, while that block result proves neither an
+end-to-end run nor throughput, memory fit, output quality, or release support.
 
 | Surface             | Current evidence                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | Current claim                                                                                                                                                                                                                                                                                                                                                          |
 | ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | CPU                 | Deterministic frame/sampler/layout/noise fixtures; tiny processor, Qwen, VAE, DiT, ordered FL2VA/Ref2VA pipeline, mux, cancellation, memory-accounting, portable quantization, frozen-factory, and dispatch tests                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | Reference and contract testing only; H3 CPU runtime is unsupported                                                                                                                                                                                                                                                                                                     |
-| CUDA primitives     | Tiny synthetic CPU/CUDA parity and execution tests on private UAT host for the sampler ([#845](https://github.com/utensils/mold/pull/845)), AudioVAE ([#849](https://github.com/utensils/mold/pull/849)), Qwen layer 50 ([#850](https://github.com/utensils/mold/pull/850)), visual VAE ([#851](https://github.com/utensils/mold/pull/851)), DiT ([#853](https://github.com/utensils/mold/pull/853)), and portable quantization ([#860](https://github.com/utensils/mold/pull/860)). The scaled-FP8/Qwen-INT8 slice ([#865](https://github.com/utensils/mold/pull/865)) and fail-closed dispatch seams ([#864](https://github.com/utensils/mold/pull/864), [#866](https://github.com/utensils/mold/pull/866)) have synthetic CPU/reference tests plus CUDA contract/typecheck evidence, not physical CUDA execution.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | Selected tiny primitives only; CPU-only quantization/dispatch evidence and CUDA typechecks are identified separately. No real H3 execution or hardware qualification.                                                                                                                                                                                                  |
+| CUDA primitives     | Tiny synthetic CPU/CUDA parity and execution tests on private UAT host for the sampler ([#845](https://github.com/utensils/mold/pull/845)), AudioVAE ([#849](https://github.com/utensils/mold/pull/849)), Qwen layer 50 ([#850](https://github.com/utensils/mold/pull/850)), visual VAE ([#851](https://github.com/utensils/mold/pull/851)), DiT ([#853](https://github.com/utensils/mold/pull/853)), and portable quantization ([#860](https://github.com/utensils/mold/pull/860)). The scaled-FP8/Qwen-INT8 slice ([#865](https://github.com/utensils/mold/pull/865)) and fail-closed dispatch seams ([#864](https://github.com/utensils/mold/pull/864), [#866](https://github.com/utensils/mold/pull/866)) have synthetic CPU/reference tests plus CUDA contract/typecheck evidence, not physical CUDA execution.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | Selected tiny primitives only; CPU-only quantization/dispatch evidence and CUDA typechecks are identified separately. No end-to-end H3 generation or hardware qualification; see the separate real-checkpoint row.                                                                                                                                                                                                  |
 | CUDA full attention | [PR #857](https://github.com/utensils/mold/pull/857) records the earlier synthetic dense-reference-to-FlashAttention-v2 work. Exact PR #871 implementation head `c0625402` and source tree `b1452b5f` were qualified on private UAT host (4× L40S with 46,068 MiB each, SM89, driver 595.71.05, CUDA 12.8.93, Rust 1.95) without model data or runtime activation. The H3 release contract and all 36 adversarial CUDA distribution/parser cases passed; the production dispatch stayed directly guarded by the release-candidate configuration; every actual `usize` tensor stride and rounded launch row was checked before conversion to the kernel's `u32` contract; the isolated 53-kernel candidate built offline with warnings denied; and 11 attention tests passed with 141 filtered. Ten network-isolated BF16 probes ran on GPU UUID `GPU-9ffc81c5-3944-6490-bfd9-f68366f98226`. Their timing samples were 4,974, 5,006, 5,045, 5,047, 5,056, 5,123, 5,130, 5,167, 5,708, and 168,321 microseconds, with p50 5,056 and p95 5,708 under the probe's percentile convention. Maximum absolute parity delta was `0.00048828125` against a `0.02` bound; swapping Q/K produced `0.04736328`, exceeding the required `0.02` sensitivity floor. The candidate binary SHA-256 was `0d494cfc8a165ff1f00ec9b48c6ce370375bd4ebf7634b5894d042d7e9f453af`; tracing found no internet socket or H3/model-artifact path, and recorded `model_artifacts_accessed = false` and `runtime_activated = false`. Long-row workspace shapes 37,296 and 107,856 were planning-only. | Synthetic development evidence only. The opt-in candidate correctly carries the compiled-kernel claim and is not a shipping binary. The same-tree ordinary fixture proves release-candidate exclusion only for a non-publishable shipping-feature build; it does not establish a public release artifact, real-model correctness, quality, peak memory, or throughput. |
 | Metal               | Shared primitive feature compilation, forced-local typecheck, and [#860](https://github.com/utensils/mold/pull/860)'s tiny deterministic CPU/Metal quantized-forward parity. [#865](https://github.com/utensils/mold/pull/865)'s newer scaled-FP8/Qwen-INT8 cases are CPU-only. The H3 capability and admission contracts reject Metal.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | Unsupported; tiny primitive parity is not H3 Metal execution, hardware qualification, or UAT                                                                                                                                                                                                                                                                           |
 | Server/factory      | Hidden identities, HTTP 451 policy, request contracts, secure reference ingress, prepared shapes, frozen single-GPU admission, block-streaming ownership, immutable factory authority, fail-closed backend adapter, and FL2VA/Ref2VA worker dispatch                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | No catalog/download activation, admitted real engine, or public H3 runtime at this snapshot                                                                                                                                                                                                                                                                            |
 | Studio surfaces     | [#867](https://github.com/utensils/mold/pull/867) is merged in main `50f28de3` with web, desktop, and iPhone authoring, recovery, canonical upload, and provenance contracts. Its media-arithmetic fixtures use ordinary generated test media, not H3 output.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | Authoring and recovery contracts only; gated readiness cannot make the runtime available                                                                                                                                                                                                                                                                               |
 | CLI/TUI/Discord     | [#868](https://github.com/utensils/mold/pull/868) is merged in main `50f28de3` with weight-free ordered-reference authoring, canonical reference leases, and media provenance.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | Authoring and provenance contracts only; no runtime activation                                                                                                                                                                                                                                                                                                         |
-| Real checkpoint     | None                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | Unqualified and unavailable                                                                                                                                                                                                                                                                                                                                            |
+| Real checkpoint     | [PR #883](https://github.com/utensils/mold/pull/883) authenticated both released 20.97 GB INT8 task transformers from retained descriptors, validated the shared 932-tensor header and 200 quantization sidecars, executed isolated block 0 on CUDA, and returned to zero live blocks; both reports recorded `factory_activated: false`. | Private block-0 execution only. Conditioner execution, all 50 denoise blocks, visual/audio decode, mux, synchronized output, quality, and end-to-end memory/performance remain unqualified; the product runtime remains unavailable. |
 
 The ordinary shipping-feature fixture used the same exact `b1452b5f` source
 tree. Its release-profile build completed in 766 seconds, sealed all
@@ -342,26 +353,30 @@ ordinary shipping-feature build assembled from the exact source tree; it is
 not a public Mold release artifact, H3 runtime activation, real-checkpoint
 qualification, or licensed H3 UAT.
 
-The named private UAT host runs used only synthetic tensors and fixtures. They are not
-real CUDA UAT, not a benchmark of H3, and not evidence about the excluded
-external-volume `MOLD_HOME`. No H3 artifact payload or production safetensors
-header-range byte was accessed for any row in this document.
+The earlier attention and primitive probes used synthetic tensors and fixtures.
+Separately, the qualified external campaign stores and authenticates the
+approved payloads, and authenticated real-checkpoint block-0 execution ran on
+CUDA. That narrow block result is not end-to-end synchronized-A/V generation,
+full runtime qualification, output-quality evidence, or a benchmark; no
+generated media was retained.
 
 ## Private qualification and future public acceptance matrix
 
 Private artifact-identity, numerical-parity, T2VA/FL2VA/Ref2VA, Comfy,
 memory/performance, cancellation, fault-recovery, and single-device rows may be
-attempted on authorized private host under the narrow decision record. Their
+attempted under the narrow private decision record. Their
 payloads and evidence remain private. Product-surface, hosted/remote-client,
 distribution, and release-artifact rows remain blocked until issue #831 records
-broader authority and the resulting obligations are implemented. Every row was
-unattempted at this evidence snapshot; the table defines required evidence and
-does not itself report a passing UAT result.
+broader authority and the resulting obligations are implemented. Private
+authorization, clean storage, artifact identity, and isolated block execution
+have partial evidence described above; numerical parity and end-to-end
+generation rows remain unattempted. The table defines final required evidence
+and does not itself report a completed release gate.
 
 | Gate                          | Required campaign                                                                                                                                                                    | Passing evidence                                                                                                                                                                                          |
 | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Authorization                 | Revalidate the pinned license/Q&A and obtain written authority for every intended product, territory, user, artifact, and output flow                                                | Approved external authorization record with reviewed source-document hash, scope, owner, expiry/revocation terms, and issue #831 approval                                                                 |
-| Clean storage                 | Use the qualified private UAT host ZFS pool with a fresh access-controlled absolute `MOLD_HOME`; keep the unhealthy local external volume excluded and never reuse an ordinary Mold home       | Capacity and mount report, private ownership/mode, clean before/after inventory, and no H3 bytes in the checkout                                                                                          |
+| Clean storage                 | Use the qualified isolated external campaign with its access-controlled absolute `MOLD_HOME`; never reuse an ordinary Mold home                                                        | Capacity and mount report, private ownership/mode, clean before/after inventory, and no H3 bytes in the checkout                                                                                          |
 | Artifact identity             | Fetch only the approved task/layout and every pinned companion                                                                                                                       | Exact repository/revision/path/byte count/full SHA-256, component-index hashes, license/NOTICE capture, and no unexpected file                                                                            |
 | Full-path numerical parity    | Run tokenizer/processor, Qwen layer 50, visual VAE, AudioVAE, token refiner, transformer block, packed layout, noise allocation, and dual sampler against pinned Diffusers BF16/FP32 | External fixture bundle passes schema/hash validation and every recorded tolerance; no approximate backend contributed a golden value                                                                     |
 | T2VA                          | Generate 1344x768 at 124 and 362 frames, plus the 243-frame grid control                                                                                                             | Decoded 24 fps MP4, exact frame count, synchronized 32 kHz stereo audio, stable seed/provenance, phase telemetry, and full-reference quality metrics                                                      |

--- a/scripts/tests/minimax-h3-private-uat-release-contract.sh
+++ b/scripts/tests/minimax-h3-private-uat-release-contract.sh
@@ -13,7 +13,7 @@ require_text() {
   local file=$1
   local text=$2
   local message=$3
-  grep -Fq "$text" "$file" || fail "$message"
+  grep -Fq -- "$text" "$file" || fail "$message"
 }
 
 require_text crates/mold-candle/Cargo.toml \
@@ -67,14 +67,41 @@ if [[ $(grep -Fxc 'mod vae_free_inner_seal {' \
   fail "private H3 VAE-free seal is not private in production and test-visible only"
 fi
 require_text crates/mold-inference/src/minimax_h3/private_qualification.rs \
-  'pub const H3_PRIVATE_HOST_AUTHORITY_SHA256: &str =' \
-  "private H3 qualification is not bound to an opaque authorized-host identity"
-require_text crates/mold-inference/src/minimax_h3/private_qualification.rs \
   'pub const H3_PRIVATE_AUTHORIZATION_SCOPE: &str = "private-h3-uat";' \
   "private H3 qualification does not use the generic private authorization scope"
 require_text crates/mold-inference/src/minimax_h3/private_qualification.rs \
-  '"/storage/jamesbrink/mold-uat/minimax-h3/models"' \
-  "private H3 qualification is not bound to the reviewed storage root"
+  'const AUTHORIZATION_SCHEMA: &str = "mold.minimax-h3.authorization.v1";' \
+  "private H3 qualification does not require the reviewed authorization schema"
+require_text crates/mold-inference/src/minimax_h3/private_qualification.rs \
+  'const REVIEWED_AUTHORIZATION_EVIDENCE_SHA256: &str =' \
+  "private H3 qualification does not pin the accepted authorization evidence"
+require_text crates/mold-inference/src/minimax_h3/private_qualification.rs \
+  '8cd4d6e52cff34d7d39721ebab13b8c1187aa87aafc1c4ae2a16609186f22f1d' \
+  "private H3 qualification pins a different authorization evidence identity"
+require_text crates/mold-inference/src/minimax_h3/private_qualification.rs \
+  'if record.source_document_sha256 != reviewed_evidence_sha256 {' \
+  "private H3 qualification does not reject self-declared authorization evidence"
+require_text crates/mold-inference/src/minimax_h3/private_qualification.rs \
+  'fn production_scope_rejects_unreviewed_evidence() {' \
+  "private H3 qualification lacks a regression test for unreviewed evidence"
+require_text crates/mold-inference/src/minimax_h3/private_qualification.rs \
+  'pub authorization_record_sha256: String,' \
+  "private H3 qualification report does not bind the authorization record identity"
+require_text crates/mold-inference/src/minimax_h3/private_qualification.rs \
+  'pub authorization_source_document_sha256: String,' \
+  "private H3 qualification report does not bind the authorization source identity"
+require_text crates/mold-inference/src/bin/h3_artifact_qualification.rs \
+  'remove("--authorization-record")' \
+  "private H3 qualifier CLI does not require the external authorization record"
+if grep -Eq 'H3_PRIVATE_HOST_AUTHORITY_SHA256|H3_PRIVATE_MODELS_ROOT|/etc/hostname|/storage/.*/minimax-h3' \
+  crates/mold-inference/src/minimax_h3/private_qualification.rs \
+  crates/mold-inference/src/bin/h3_artifact_qualification.rs; then
+  fail "private H3 qualification regressed to host-name or hardcoded-path authority"
+fi
+if grep -Fq -- '--authorization-scope' \
+  crates/mold-inference/src/bin/h3_artifact_qualification.rs; then
+  fail "private H3 qualifier accepts a caller-asserted authorization scope"
+fi
 
 if grep -Eq '^h3-private-uat[[:space:]]*=' crates/mold-cli/Cargo.toml; then
   fail "mold-ai forwards the private H3 UAT feature into a runnable product binary"
@@ -132,6 +159,9 @@ require_text .github/workflows/ci.yml \
 require_text docs/qualification/minimax-h3.md \
   'h3_artifact_qualification' \
   "the private artifact qualifier has no operator runbook"
+require_text docs/qualification/minimax-h3.md \
+  '--authorization-record' \
+  "the private artifact qualifier runbook omits its external authorization record"
 
 scratch_dir="$(mktemp -d)"
 trap 'rm -rf "$scratch_dir"' EXIT


### PR DESCRIPTION
## Summary

- replace caller-supplied qualification authority with an exact versioned authorization record and bind reports to the record, source document, review identity, and approved scopes
- fail closed on non-canonical paths, symlinks, owner or mode drift, TOCTOU identity changes, unreviewed evidence, and campaign-layout mismatches
- emit qualification schema v2 and document the external-volume workflow without claiming runtime, media, public activation, or release acceptance
- pin the production authorization binding and rejection coverage in the private UAT release contract

## Verification

- 116 private inference tests passed; one authorized-artifact test remains intentionally ignored
- strict qualifier Clippy passed with warnings denied
- feature-off inference check, formatting, and private UAT release contract passed
- independent exact-diff review found no blockers
- full-content FL2VA and Ref2VA qualification each authenticated 17 artifacts / 42,482,090,318 bytes on the external volume
- both reports retain runtime_constructed=false, generated_media=false, and public_activation=rejected
- clean merge tree against current main; restricted-identifier and conflict-marker scans are clear

Refs #827 and #831.