### PR TITLE
fix(desktop): contain activity scrolling

### DIFF
--- a/desktop/src/components/create/ActivityStrip.vue
+++ b/desktop/src/components/create/ActivityStrip.vue
@@ -315,59 +315,61 @@ function deleteConfirmed() {
       </button>
     </div>
 
-    <LiveActivityList :rows="sharedRows" interactive @select="openLiveWork" />
+    <div data-test="activity-list-scroll" class="ms-activity__list">
+      <LiveActivityList :rows="sharedRows" interactive @select="openLiveWork" />
 
-    <!-- In-flight sequence rows (merged jobs surface) -->
-    <SequenceJobRow
-      v-for="vm in sequenceRows"
-      :key="vm.key"
-      data-test="activity-sequence"
-      :vm="vm"
-      :model-label="modelLabel(vm.model)"
-      :show-error="false"
-      @action="runAction"
-      @select="selectSequence"
-    />
+      <!-- In-flight sequence rows (merged jobs surface) -->
+      <SequenceJobRow
+        v-for="vm in sequenceRows"
+        :key="vm.key"
+        data-test="activity-sequence"
+        :vm="vm"
+        :model-label="modelLabel(vm.model)"
+        :show-error="false"
+        @action="runAction"
+        @select="selectSequence"
+      />
 
-    <!-- Settled but still wanting a decision: capped, expiring, dismissible. -->
-    <SequenceJobRow
-      v-for="vm in attentionSequences"
-      :key="vm.key"
-      data-test="activity-sequence"
-      :vm="vm"
-      :model-label="modelLabel(vm.model)"
-      :show-error="false"
-      dismissible
-      @action="runAction"
-      @select="selectSequence"
-      @dismiss="dismiss"
-    />
+      <!-- Settled but still wanting a decision: capped, expiring, dismissible. -->
+      <SequenceJobRow
+        v-for="vm in attentionSequences"
+        :key="vm.key"
+        data-test="activity-sequence"
+        :vm="vm"
+        :model-label="modelLabel(vm.model)"
+        :show-error="false"
+        dismissible
+        @action="runAction"
+        @select="selectSequence"
+        @dismiss="dismiss"
+      />
 
-    <div
-      v-for="vm in attentionPrints"
-      :key="vm.key"
-      class="ms-activity__seq"
-      data-test="activity-print-attention"
-      role="alert"
-      tabindex="0"
-      @click="selectPrintVm(vm)"
-      @keydown.enter.prevent="selectPrintVm(vm)"
-      @keydown.space.prevent="selectPrintVm(vm)"
-    >
-      <span class="ms-activity__state data-mono text-stop">failed</span>
-      <span class="ms-activity__seq-model" :title="vm.prompt">{{ vm.prompt }}</span>
-      <div class="ms-activity__seq-spacer" />
-      <span class="ms-activity__seq-error">Open Create for details</span>
-      <button
-        type="button"
-        class="ms-activity__cancel"
-        data-test="print-dismiss"
-        title="Hide this failure. Nothing is deleted."
-        :aria-label="`Dismiss failed print: ${vm.prompt}`"
-        @click.stop="dismiss(vm)"
+      <div
+        v-for="vm in attentionPrints"
+        :key="vm.key"
+        class="ms-activity__seq"
+        data-test="activity-print-attention"
+        role="alert"
+        tabindex="0"
+        @click="selectPrintVm(vm)"
+        @keydown.enter.prevent="selectPrintVm(vm)"
+        @keydown.space.prevent="selectPrintVm(vm)"
       >
-        ✕
-      </button>
+        <span class="ms-activity__state data-mono text-stop">failed</span>
+        <span class="ms-activity__seq-model" :title="vm.prompt">{{ vm.prompt }}</span>
+        <div class="ms-activity__seq-spacer" />
+        <span class="ms-activity__seq-error">Open Create for details</span>
+        <button
+          type="button"
+          class="ms-activity__cancel"
+          data-test="print-dismiss"
+          title="Hide this failure. Nothing is deleted."
+          :aria-label="`Dismiss failed print: ${vm.prompt}`"
+          @click.stop="dismiss(vm)"
+        >
+          ✕
+        </button>
+      </div>
     </div>
 
     <ConfirmDialog
@@ -391,8 +393,20 @@ function deleteConfirmed() {
   flex-direction: column;
   gap: 8px;
   min-width: 0;
+  min-height: 0;
+  max-height: min(42cqh, 220px);
   overflow: hidden;
-  flex-shrink: 0;
+  flex-shrink: 1;
+}
+.ms-activity__list {
+  display: flex;
+  min-height: 0;
+  flex-direction: column;
+  gap: 8px;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
 }
 .ms-activity__row {
   display: flex;

--- a/desktop/src/components/create/SequenceComposer.vue
+++ b/desktop/src/components/create/SequenceComposer.vue
@@ -657,10 +657,10 @@ async function copyToml() {
    * min-height the bench is floored at its own min-content — which counts
    * the rail's 204px preferred basis, not its 104px floor — so the panel
    * grew a scrollbar before the filmstrip's shrink weight ever engaged.
-   * Zero lets the bench take exactly the panel's space and flex the rail
-   * down for real; the internal floors below keep content honest, and a
-   * genuinely impossible height overflows into the panel's scrollbar
-   * rather than clipping the Generate button invisibly.
+   * Zero lets the bench take exactly its protected parent shell's space and
+   * flex the rail down for real. GenerateView gives that shell a 300px floor,
+   * so Activity yields before the internal floors below or the Generate
+   * button can clip.
    */
   min-height: 0;
   border-top: 1px solid var(--edge);

--- a/desktop/src/views/GenerateView.layout.test.ts
+++ b/desktop/src/views/GenerateView.layout.test.ts
@@ -5,6 +5,7 @@ import modelPickerSource from "../components/create/ModelPicker.vue?raw";
 import advancedSource from "../components/create/AdvancedSettings.vue?raw";
 import sequenceComposerSource from "../components/create/SequenceComposer.vue?raw";
 import composerCardSource from "../components/create/ComposerCard.vue?raw";
+import activityStripSource from "../components/create/ActivityStrip.vue?raw";
 
 function tagFor(source: string, testId: string): string {
   return source.match(new RegExp(`<[^>]*data-test="${testId}"[^>]*>`, "s"))?.[0] ?? "";
@@ -20,8 +21,17 @@ describe("GenerateView layout", () => {
     expect(classesFor(viewSource, "generate-layout")).toContain("overflow-hidden");
     expect(classesFor(viewSource, "generate-workbench")).toContain("min-h-0");
     expect(classesFor(viewSource, "generate-workbench")).toContain("overflow-hidden");
-    expect(classesFor(viewSource, "create-bottom-panel")).toContain("overflow-x-hidden");
+    expect(classesFor(viewSource, "create-bottom-panel")).toContain("overflow-hidden");
+    expect(classesFor(viewSource, "create-bottom-panel")).not.toContain("overflow-y-auto");
     expect(classesFor(viewSource, "generate-composer")).toContain("flex-1");
+  });
+
+  it("keeps activity as the bottom bench's only scroll surface", () => {
+    expect(classesFor(activityStripSource, "activity-list-scroll")).toContain("ms-activity__list");
+    expect(activityStripSource).toMatch(/\.ms-activity\s*\{[^}]*min-height:\s*0/s);
+    expect(activityStripSource).toMatch(/\.ms-activity\s*\{[^}]*max-height:/s);
+    expect(activityStripSource).toMatch(/\.ms-activity__list\s*\{[^}]*min-height:\s*0/s);
+    expect(activityStripSource).toMatch(/\.ms-activity__list\s*\{[^}]*overflow-y:\s*auto/s);
   });
 
   it("keeps the canvas visible and makes the bottom bench resizable", () => {
@@ -38,6 +48,8 @@ describe("GenerateView layout", () => {
   it("fills the bottom panel and pins composer actions to its bottom edge", () => {
     expect(classesFor(viewSource, "create-bottom-panel")).toContain("flex");
     expect(classesFor(viewSource, "create-bottom-panel")).toContain("flex-col");
+    expect(classesFor(viewSource, "generate-sequence-shell")).toContain("min-h-[300px]");
+    expect(classesFor(viewSource, "generate-sequence-shell")).toContain("flex-[1_0_300px]");
     expect(classesFor(viewSource, "generate-sequence-composer")).toContain("flex-1");
     expect(classesFor(viewSource, "generate-composer")).toContain("flex-1");
     expect(sequenceComposerSource).toMatch(/\.ms-seqbench__footer\s*\{[^}]*margin-top:\s*auto/s);

--- a/desktop/src/views/GenerateView.vue
+++ b/desktop/src/views/GenerateView.vue
@@ -3371,7 +3371,7 @@ onBeforeUnmount(() => {
 
         <div
           data-test="create-bottom-panel"
-          class="flex min-h-0 shrink-0 flex-col overflow-x-hidden overflow-y-auto bg-desk"
+          class="flex min-h-0 shrink-0 flex-col overflow-hidden bg-desk"
           :style="{
             height: `${benchHeight}px`,
             containerType: 'size',
@@ -3409,23 +3409,32 @@ onBeforeUnmount(() => {
               </button>
             </template>
           </EmptyStateBlock>
-          <SequenceComposer
+          <!-- Protect the sequence's hard chrome floor from Activity. The
+               composer itself stays min-h-0 so its filmstrip can squash, but
+               this parent flex item makes Activity yield before the footer or
+               Generate button can clip at the supported 390px bench floor. -->
+          <div
             v-else-if="isSequence"
-            data-test="generate-sequence-composer"
-            class="flex-1"
-            :form="form"
-            :selected-model="selectedSequenceEntry"
-            :chain-limits="chainLimits"
-            :installed-models="installedModels"
-            :submitting="sequenceSubmitting"
-            :chain-level-dirty="chainLevelDirty"
-            :stage-media-by-clip-id="sequenceFilmstripMediaByClipId"
-            :playing-clip-id="playingSequenceClipId"
-            :target="sequenceTarget"
-            @submit="generateSequence"
-            @duplicate="duplicateSequenceAsNew"
-            @play-clip="playSequenceClip"
-          />
+            data-test="generate-sequence-shell"
+            class="flex min-h-[300px] flex-[1_0_300px] overflow-hidden"
+          >
+            <SequenceComposer
+              data-test="generate-sequence-composer"
+              class="min-h-0 flex-1"
+              :form="form"
+              :selected-model="selectedSequenceEntry"
+              :chain-limits="chainLimits"
+              :installed-models="installedModels"
+              :submitting="sequenceSubmitting"
+              :chain-level-dirty="chainLevelDirty"
+              :stage-media-by-clip-id="sequenceFilmstripMediaByClipId"
+              :playing-clip-id="playingSequenceClipId"
+              :target="sequenceTarget"
+              @submit="generateSequence"
+              @duplicate="duplicateSequenceAsNew"
+              @play-clip="playSequenceClip"
+            />
+          </div>
           <ComposerCard
             v-else
             ref="composerRef"


### PR DESCRIPTION
## Summary

- make the desktop Create bench itself non-scrolling so the composer and Generate controls remain pinned
- bound active work to an inner Activity scroll region that yields height as the bench is resized
- protect Sequence's 300px hard-control floor so activity cannot clip its filmstrip footer or Generate button
- add regression coverage for scroll ownership and the sequence shell contract

## Root cause

The entire `create-bottom-panel` owned `overflow-y: auto`. A sufficiently long activity list therefore scrolled the composer and Generate controls out of view, making the desktop workspace behave like a document page instead of fixed application chrome.

## Validation

- independent agent peer review; one sequence-floor finding fixed, re-review clean
- rendered desktop UAT with nine concurrent activity rows in One shot and Sequence
- exact 390px Sequence bench floor: Activity 90px, protected composer shell 300px, parent `scrollTop = 0`, inner list `scrollTop = 320`, Generate fully visible
- browser console clean; no framework overlay
- `nix develop -c bun run --cwd desktop test` — 295 files / 3,149 tests passed
- `nix develop -c bun run --cwd desktop build`
- `nix develop -c bun run --cwd desktop fmt:check`
- `git diff --check`
