### PR TITLE
feat(h3): bind attention before allocation

### DIFF
--- a/crates/mold-candle/src/minimax_h3/attention.rs
+++ b/crates/mold-candle/src/minimax_h3/attention.rs
@@ -719,6 +719,51 @@ impl H3AttentionRuntimeAuthority {
         Ok(())
     }
 
+    /// Prove that this authority was issued by the exact release-candidate
+    /// kernel compiled into the current binary and targets the observed
+    /// Candle device. A serialized identity record alone is not executable
+    /// authority: private runtime composition calls this before any model
+    /// tensor is allocated.
+    pub fn verify_current_release_candidate_dispatch(
+        &self,
+        device: &Device,
+    ) -> InspectionResult<()> {
+        let observed = H3AttentionDevice::from_candle(device);
+        self.verify_release_candidate_build(
+            &H3AttentionReleaseCandidateBuild::current(),
+            observed,
+        )?;
+        if !self.device.matches_candle(device) {
+            return Err(failure(
+                H3AttentionErrorCode::RuntimePlanMismatch,
+                "MiniMax H3 release-candidate attention targets a different Candle device",
+                vec![H3AttentionRequirement::ExactDeviceBackend],
+            ));
+        }
+        Ok(())
+    }
+
+    fn verify_release_candidate_build(
+        &self,
+        build: &H3AttentionReleaseCandidateBuild,
+        observed: H3AttentionDevice,
+    ) -> InspectionResult<()> {
+        self.validate_identity()?;
+        let expected = build.qualify(observed)?;
+        if self != &expected {
+            return Err(failure(
+                H3AttentionErrorCode::RuntimePlanMismatch,
+                "MiniMax H3 attention authority does not match the current compiled release candidate",
+                vec![
+                    H3AttentionRequirement::CompiledH3FlashAttentionV2,
+                    H3AttentionRequirement::QualifiedCudaSm89,
+                    H3AttentionRequirement::UntamperedFrozenPlan,
+                ],
+            ));
+        }
+        Ok(())
+    }
+
     pub fn freeze_execution(
         &self,
         batch_size: usize,
@@ -1525,6 +1570,36 @@ mod tests {
             true,
         )
         .unwrap()
+    }
+
+    #[test]
+    fn release_candidate_dispatch_requires_the_current_compiled_build() {
+        let authority = exact_flash_candidate();
+        let sm89 = H3AttentionDevice::Cuda {
+            compute_capability: Some((8, 9)),
+        };
+        let compiled = H3AttentionReleaseCandidateBuild::from_build_inputs(true, Some("89"));
+        authority
+            .verify_release_candidate_build(&compiled, sm89)
+            .unwrap();
+
+        for build in [
+            H3AttentionReleaseCandidateBuild::from_build_inputs(false, Some("89")),
+            H3AttentionReleaseCandidateBuild::from_build_inputs(true, Some("86")),
+            H3AttentionReleaseCandidateBuild::from_build_inputs(true, None),
+        ] {
+            assert!(authority
+                .verify_release_candidate_build(&build, sm89)
+                .is_err());
+        }
+        assert!(authority
+            .verify_release_candidate_build(
+                &compiled,
+                H3AttentionDevice::Cuda {
+                    compute_capability: Some((8, 6)),
+                },
+            )
+            .is_err());
     }
 
     #[test]

--- a/crates/mold-inference/src/minimax_h3/private_fl2va_runtime.rs
+++ b/crates/mold-inference/src/minimax_h3/private_fl2va_runtime.rs
@@ -4,19 +4,18 @@
 //! feature. It does not register a model, loader, capability, catalog,
 //! download, server, CLI, or product-surface route.
 //!
-//! The concrete core is attempt-scoped and one-shot. Activation additionally
-//! requires an engine/session contract that consumes and reconstructs it on
-//! every success, error, and cancellation; the current cached H3 engine must
-//! never retain this runtime for a second job.
+//! The concrete core is attempt-scoped and one-shot. The engine constructs and
+//! consumes a fresh session per job; this private composer remains additionally
+//! sealed until every artifact, memory, and execution authority is available.
 
 use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::{bail, Result};
-use candle_core::{Device, Tensor};
+use candle_core::{Device, DeviceLocation, Tensor};
 use mold_candle::minimax_h3::{
-    H3AttentionRuntimeAuthority, H3ComfyOpenedInt8Checkpoint, H3ForwardInput, H3FrozenPackedLayout,
-    H3TransformerOutput, H3TransformerTask, StereoLatents, StereoWaveform,
+    H3AttentionDevice, H3AttentionRuntimeAuthority, H3ComfyOpenedInt8Checkpoint, H3ForwardInput,
+    H3FrozenPackedLayout, H3TransformerOutput, H3TransformerTask, StereoLatents, StereoWaveform,
 };
 use mold_core::minimax_h3::{self as contract, Task};
 use sha2::{Digest, Sha256};
@@ -33,8 +32,9 @@ use super::private_qwen::{
 };
 use super::private_qwen_support::H3PrivateQwenSupport;
 use super::private_runtime::{
-    load_and_pair_private_comfy_stream, H3PrivateComfyBlockLoader, H3PrivateComfyCancellationGuard,
-    H3PrivateComfyCancellationSlot, H3PrivateComfyStreamAuthority,
+    bind_private_comfy_stream, load_and_pair_private_comfy_stream,
+    H3PrivateComfyBindingExpectation, H3PrivateComfyBlockLoader, H3PrivateComfyCancellationGuard,
+    H3PrivateComfyCancellationSlot, H3PrivateComfyCheckpointFacts, H3PrivateComfyStreamAuthority,
     H3PrivateComfyTransformerExecutor,
 };
 use super::private_vae_adapter::H3PrivateComfyVaeAdapter;
@@ -62,6 +62,9 @@ pub(crate) unsafe trait H3PrivateFl2VaArtifactLease:
     fn audio_vae_component_content_sha256(&self) -> &str;
     fn audio_vae_component_validation_sha256(&self) -> &str;
     fn vae_artifact_plan_identity_sha256(&self) -> &str;
+    fn transformer_task(&self) -> H3TransformerTask;
+    fn transformer_checkpoint_content_sha256(&self) -> &str;
+    fn transformer_checkpoint_layout_identity_sha256(&self) -> &str;
     fn transformer_checkpoint_identity_sha256(&self) -> &str;
     fn transformer_policy_identity_sha256(&self) -> &str;
     fn pruned_adaln_table_identity_sha256(&self) -> &str;
@@ -270,9 +273,12 @@ fn valid_sha256(value: &str) -> bool {
 /// The only owner of the scheduler execution grant and the complete artifact
 /// lease for one private attempt. All component-specific handles below are
 /// projections over this allocation; none can clone either underlying lease.
+/// Device selection is frozen from the validated route before construction so
+/// safe lease implementations cannot redirect later component operations.
 struct H3PrivateAttemptOwner<E, A> {
     execution: E,
     artifacts: A,
+    device: Device,
 }
 
 /// Singular attempt authority retained until every model, streamed block, and
@@ -292,11 +298,13 @@ impl<E, A> Clone for H3PrivateAttemptAuthority<E, A> {
 impl<E, A> H3PrivateAttemptAuthority<E, A> {
     /// Construction stays inside the private runtime composition boundary so
     /// callers can never build projections from independently owned leases.
-    fn new(execution: E, artifacts: A) -> Self {
+    fn new(bound: H3PrivateBoundExecution<E>, artifacts: A) -> Self {
+        let H3PrivateBoundExecution { execution, device } = bound;
         Self {
             owner: Arc::new(H3PrivateAttemptOwner {
                 execution,
                 artifacts,
+                device,
             }),
         }
     }
@@ -330,8 +338,8 @@ impl<E, A> H3PrivateAttemptAuthority<E, A> {
     }
 
     #[cfg(test)]
-    fn new_unchecked_for_test(execution: E, artifacts: A) -> Self {
-        Self::new(execution, artifacts)
+    fn new_unchecked_for_test(execution: E, artifacts: A, device: Device) -> Self {
+        Self::new(H3PrivateBoundExecution { execution, device }, artifacts)
     }
 }
 
@@ -377,7 +385,7 @@ where
     }
 
     fn device(&self) -> &Device {
-        self.owner.execution.device()
+        &self.owner.device
     }
 
     fn is_active(&self) -> bool {
@@ -518,6 +526,20 @@ where
 
     fn vae_artifact_plan_identity_sha256(&self) -> &str {
         self.owner.artifacts.vae_artifact_plan_identity_sha256()
+    }
+
+    fn transformer_task(&self) -> H3TransformerTask {
+        self.owner.artifacts.transformer_task()
+    }
+
+    fn transformer_checkpoint_content_sha256(&self) -> &str {
+        self.owner.artifacts.transformer_checkpoint_content_sha256()
+    }
+
+    fn transformer_checkpoint_layout_identity_sha256(&self) -> &str {
+        self.owner
+            .artifacts
+            .transformer_checkpoint_layout_identity_sha256()
     }
 
     fn transformer_checkpoint_identity_sha256(&self) -> &str {
@@ -743,8 +765,15 @@ where
                 != self.admitted.audio_vae_component_validation_sha256
             || artifacts.vae_artifact_plan_identity_sha256()
                 != self.admitted.vae_artifact_plan_identity_sha256
+            || artifacts.transformer_task() != self.stream_authority.task
+            || artifacts.transformer_checkpoint_content_sha256()
+                != self.stream_authority.transformer_content_sha256
+            || artifacts.transformer_checkpoint_layout_identity_sha256()
+                != self.stream_authority.transformer_layout_identity_sha256
             || artifacts.transformer_checkpoint_identity_sha256()
                 != self.stream_authority.checkpoint_identity_sha256
+            || artifacts.transformer_policy_identity_sha256()
+                != self.stream_authority.transformer_policy_identity_sha256
             || artifacts.attention_runtime_identity_sha256()
                 != self.stream_authority.attention_runtime_identity_sha256
             || artifacts.attention_runtime_identity_sha256()
@@ -895,18 +924,94 @@ type H3PrivateComfyCore<'authority, C, E, A> = H3PrivateVaeFreeStreamedCore<
 type H3PrivateComfyPipelineRuntime<'authority, C, E, A> =
     H3PipelineRuntime<H3PrivateComfyVaeAdapter<H3PrivateComfyCore<'authority, C, E, A>>>;
 
+/// Consuming proof that one execution lease and one retained Candle device
+/// passed route validation together. Keeping the fields private and this type
+/// non-cloneable prevents production composition from mixing authorities.
+struct H3PrivateBoundExecution<E> {
+    execution: E,
+    device: Device,
+}
+
+impl<E> H3PrivateBoundExecution<E> {
+    fn device(&self) -> &Device {
+        &self.device
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct H3PrivateExecutionRouteFacts {
+    active: bool,
+    lease_id: String,
+    device_id: String,
+    execution_fingerprint: String,
+    backend: H3CandleBackendDevice,
+    location: DeviceLocation,
+    attention_device: H3AttentionDevice,
+}
+
+fn validate_private_execution_route_facts(
+    actual: &H3PrivateExecutionRouteFacts,
+    admitted: &H3PrivateFl2VaFactoryAuthority,
+) -> Result<()> {
+    let expected_attention_device = H3AttentionDevice::Cuda {
+        compute_capability: Some(admitted.compute_capability),
+    };
+    if !actual.active
+        || actual.lease_id.trim().is_empty()
+        || actual.device_id != admitted.device_id
+        || actual.execution_fingerprint != admitted.execution_fingerprint
+        || actual.backend
+            != (H3CandleBackendDevice::Cuda {
+                compute_capability: admitted.compute_capability,
+            })
+        || actual.location
+            != (DeviceLocation::Cuda {
+                gpu_id: admitted.device_ordinal,
+            })
+        || admitted.attention.device != expected_attention_device
+        || actual.attention_device != admitted.attention.device
+    {
+        bail!("private MiniMax H3 execution route differs before component binding");
+    }
+    Ok(())
+}
+
+/// Snapshot the safe execution-lease surface once. In particular, the Candle
+/// device is cloned from one call and becomes the only device the bound
+/// transformer stream may later use.
+fn capture_private_execution_route<E>(
+    execution: E,
+    admitted: &H3PrivateFl2VaFactoryAuthority,
+) -> Result<H3PrivateBoundExecution<E>>
+where
+    E: H3BackendExecutionLease,
+{
+    let device = execution.device().clone();
+    let facts = H3PrivateExecutionRouteFacts {
+        active: execution.is_active(),
+        lease_id: execution.lease_id().into(),
+        device_id: execution.device_id().into(),
+        execution_fingerprint: execution.execution_fingerprint().into(),
+        backend: execution.backend(),
+        location: device.location(),
+        attention_device: H3AttentionDevice::from_candle(&device),
+    };
+    validate_private_execution_route_facts(&facts, admitted)?;
+    Ok(H3PrivateBoundExecution { execution, device })
+}
+
 /// Structural composition proof for one private FL2VA attempt. It is private
 /// to this module and its overlap argument is uninhabited in non-test builds,
-/// so there is deliberately no into-runtime escape for the cached H3 engine.
+/// so there is deliberately no production construction escape yet.
 ///
-/// Activation must replace this sealed entry with an attempt-consuming API
-/// that drops the full runtime on every success, error, and cancellation and
-/// reconstructs it per job. It must also accept authenticated VAE plans/opened
-/// descriptors and load both VAEs inside this same owner and cancellation
-/// scope; a preloaded bundle does not prove allocation or cancellation
-/// provenance and is not sufficient. The actual attention authority must also
-/// be bound directly to frozen backend, kernel, activation, device, and model
-/// contract facts before load; an artifact lease echo is not that proof.
+/// The engine already consumes one fresh session per job. Activating this
+/// sealed composer must also accept authenticated VAE plans/opened descriptors
+/// and load both VAEs inside this same owner and cancellation scope; a
+/// preloaded bundle does not prove allocation or cancellation provenance and
+/// is not sufficient. The binding below freezes the exact execution route,
+/// Candle device, concrete attention authority, and opened transformer
+/// identity before Qwen or transformer allocation, without activating any
+/// shipping path.
 #[allow(clippy::too_many_arguments)]
 #[allow(dead_code)]
 fn compose_private_comfy_fl2va_runtime<'authority, C, E, A>(
@@ -929,13 +1034,58 @@ where
     A: H3PrivateFl2VaArtifactLease + Send + Sync,
 {
     let admitted = authority.private_fl2va_runtime_authority()?;
+    let bound_execution = capture_private_execution_route(execution_lease, &admitted)?;
     memory_overlap.validate()?;
     if memory_overlap.factory_identity_sha256 != admitted.factory_identity_sha256
         || memory_overlap.identity_sha256() != artifact_lease.memory_overlap_identity_sha256()
     {
         bail!("private MiniMax H3 overlap authority differs before component loading");
     }
-    let attempt = H3PrivateAttemptAuthority::new(execution_lease, artifact_lease);
+    let expected_transformer_policy = match &admitted.quantization {
+        H3FactoryQuantizationAuthority::ComfyPrunedInt8ConvrotNvfp4Awq {
+            transformer_policy_sha256,
+            ..
+        } => transformer_policy_sha256,
+        H3FactoryQuantizationAuthority::OfficialBf16 => {
+            bail!("private MiniMax H3 Comfy runtime requires quantized transformer authority")
+        }
+    };
+    if !artifact_lease.is_active()
+        || artifact_lease.transformer_task() != H3TransformerTask::T2VaFl2Va
+        || artifact_lease.transformer_policy_identity_sha256() != expected_transformer_policy
+        || artifact_lease.attention_runtime_identity_sha256()
+            != admitted.attention.runtime_identity_sha256
+        || artifact_lease.attention_kernel_identity()
+            != admitted.attention.qualification_kernel_identity
+        || artifact_lease.attention_qualification_sha256()
+            != admitted.attention.qualification_sha256
+    {
+        bail!("private MiniMax H3 artifact lease differs before component loading");
+    }
+    let bound_stream = bind_private_comfy_stream(
+        opened_transformer,
+        bound_execution.device(),
+        attention,
+        H3PrivateComfyBindingExpectation {
+            attention: admitted.attention.clone(),
+            checkpoint: H3PrivateComfyCheckpointFacts {
+                task: artifact_lease.transformer_task(),
+                content_sha256: artifact_lease
+                    .transformer_checkpoint_content_sha256()
+                    .into(),
+                layout_identity_sha256: artifact_lease
+                    .transformer_checkpoint_layout_identity_sha256()
+                    .into(),
+                opened_checkpoint_identity_sha256: artifact_lease
+                    .transformer_checkpoint_identity_sha256()
+                    .into(),
+                quantization_policy_identity_sha256: artifact_lease
+                    .transformer_policy_identity_sha256()
+                    .into(),
+            },
+        },
+    )?;
+    let attempt = H3PrivateAttemptAuthority::new(bound_execution, artifact_lease);
     let (qwen_execution, qwen_artifacts) = attempt.qwen_projections();
     let block_execution = attempt.block_projection();
     let core_execution = attempt.block_projection();
@@ -951,13 +1101,9 @@ where
         authority,
         checkpoint,
     )?;
-    let device = core_execution.device().clone();
     let stream = load_and_pair_private_comfy_stream(
-        opened_transformer,
-        &device,
-        attention,
+        bound_stream,
         &admitted.block_streaming,
-        H3TransformerTask::T2VaFl2Va,
         cancellation_slot,
     )?;
     let identity = H3PipelineBackendIdentity {
@@ -1076,6 +1222,146 @@ mod tests {
         .unwrap()
     }
 
+    fn exact_execution_route_facts(
+        admitted: &H3PrivateFl2VaFactoryAuthority,
+    ) -> H3PrivateExecutionRouteFacts {
+        H3PrivateExecutionRouteFacts {
+            active: true,
+            lease_id: "execution-lease".into(),
+            device_id: admitted.device_id.clone(),
+            execution_fingerprint: admitted.execution_fingerprint.clone(),
+            backend: H3CandleBackendDevice::Cuda {
+                compute_capability: admitted.compute_capability,
+            },
+            location: candle_core::DeviceLocation::Cuda {
+                gpu_id: admitted.device_ordinal,
+            },
+            attention_device: admitted.attention.device,
+        }
+    }
+
+    #[test]
+    fn every_execution_route_axis_fails_closed_before_binding() {
+        let admitted = authority()
+            .private_fl2va_runtime_authority_for_schema_tests()
+            .unwrap();
+        validate_private_execution_route_facts(&exact_execution_route_facts(&admitted), &admitted)
+            .unwrap();
+
+        for axis in [
+            "active",
+            "lease-id",
+            "device-id",
+            "execution",
+            "backend",
+            "location",
+            "attention-device",
+        ] {
+            let mut facts = exact_execution_route_facts(&admitted);
+            match axis {
+                "active" => facts.active = false,
+                "lease-id" => facts.lease_id = "   ".into(),
+                "device-id" => facts.device_id = "other-device".into(),
+                "execution" => facts.execution_fingerprint = sha('f'),
+                "backend" => {
+                    facts.backend = H3CandleBackendDevice::Cuda {
+                        compute_capability: (8, 6),
+                    }
+                }
+                "location" => {
+                    facts.location = candle_core::DeviceLocation::Cuda {
+                        gpu_id: admitted.device_ordinal + 1,
+                    }
+                }
+                "attention-device" => {
+                    facts.attention_device = mold_candle::minimax_h3::H3AttentionDevice::Cpu
+                }
+                _ => unreachable!(),
+            }
+            let error = validate_private_execution_route_facts(&facts, &admitted).expect_err(axis);
+            assert!(
+                error.to_string().contains("execution route"),
+                "{axis}: {error}"
+            );
+        }
+    }
+
+    struct AlternatingDeviceLease {
+        devices: [Device; 2],
+        calls: Arc<AtomicUsize>,
+        device_id: String,
+        execution_fingerprint: String,
+        compute_capability: (u16, u16),
+    }
+
+    impl H3BackendExecutionLease for AlternatingDeviceLease {
+        fn lease_id(&self) -> &str {
+            "alternating-execution-lease"
+        }
+
+        fn device_id(&self) -> &str {
+            &self.device_id
+        }
+
+        fn backend(&self) -> H3CandleBackendDevice {
+            H3CandleBackendDevice::Cuda {
+                compute_capability: self.compute_capability,
+            }
+        }
+
+        fn execution_fingerprint(&self) -> &str {
+            &self.execution_fingerprint
+        }
+
+        fn device(&self) -> &Device {
+            let call = self.calls.fetch_add(1, Ordering::SeqCst);
+            &self.devices[usize::from(call > 0)]
+        }
+
+        fn is_active(&self) -> bool {
+            true
+        }
+    }
+
+    #[test]
+    fn execution_route_capture_reads_an_adversarial_device_lease_once() {
+        let admitted = authority()
+            .private_fl2va_runtime_authority_for_schema_tests()
+            .unwrap();
+        let lease = AlternatingDeviceLease {
+            devices: [Device::Cpu, Device::Cpu],
+            calls: Arc::new(AtomicUsize::new(0)),
+            device_id: admitted.device_id.clone(),
+            execution_fingerprint: admitted.execution_fingerprint.clone(),
+            compute_capability: admitted.compute_capability,
+        };
+        let error = capture_private_execution_route(&lease, &admitted)
+            .err()
+            .expect("the CPU route must fail before binding");
+        assert!(error.to_string().contains("execution route"));
+        assert_eq!(lease.calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn attempt_projections_reuse_the_retained_device_without_repolling_the_lease() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let lease = AlternatingDeviceLease {
+            devices: [Device::Cpu, Device::Cpu],
+            calls: Arc::clone(&calls),
+            device_id: "synthetic-device".into(),
+            execution_fingerprint: sha('a'),
+            compute_capability: (8, 9),
+        };
+        let retained_device = lease.device().clone();
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        let attempt = H3PrivateAttemptAuthority::new_unchecked_for_test(lease, (), retained_device);
+        let projection = attempt.block_projection();
+        assert!(projection.device().is_cpu());
+        assert!(projection.clone().device().is_cpu());
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
     fn overlap(admitted: &H3PrivateFl2VaFactoryAuthority) -> H3PrivateFl2VaMemoryOverlapAuthority {
         let (condition_host, condition_device, normalized_endpoints) =
             if admitted.condition_visual_rows == 0 {
@@ -1113,6 +1399,7 @@ mod tests {
             // Raw checkpoint bytes deliberately use a different identity
             // domain from the admitted logical component aggregate.
             transformer_content_sha256: sha('7'),
+            transformer_layout_identity_sha256: sha('8'),
             checkpoint_identity_sha256: sha('9'),
             transformer_policy_identity_sha256,
             attention_runtime_identity_sha256: admitted.attention.runtime_identity_sha256.clone(),
@@ -1253,6 +1540,18 @@ mod tests {
 
         fn vae_artifact_plan_identity_sha256(&self) -> &str {
             &self.admitted.vae_artifact_plan_identity_sha256
+        }
+
+        fn transformer_task(&self) -> H3TransformerTask {
+            self.stream.task
+        }
+
+        fn transformer_checkpoint_content_sha256(&self) -> &str {
+            &self.stream.transformer_content_sha256
+        }
+
+        fn transformer_checkpoint_layout_identity_sha256(&self) -> &str {
+            &self.stream.transformer_layout_identity_sha256
         }
 
         fn transformer_checkpoint_identity_sha256(&self) -> &str {
@@ -1467,6 +1766,9 @@ mod tests {
         TaskModel,
         ConditionShape,
         TransformerComponent,
+        TransformerTask,
+        TransformerContent,
+        TransformerLayout,
         TransformerCheckpoint,
         TransformerPolicy,
         AttentionRuntime,
@@ -1532,6 +1834,15 @@ mod tests {
             Some(AuthorityMismatch::TransformerComponent) => {
                 artifact_admitted.transformer_component_content_sha256 = sha('f');
             }
+            Some(AuthorityMismatch::TransformerTask) => {
+                artifact_stream.task = H3TransformerTask::Ref2Va;
+            }
+            Some(AuthorityMismatch::TransformerContent) => {
+                artifact_stream.transformer_content_sha256 = sha('f');
+            }
+            Some(AuthorityMismatch::TransformerLayout) => {
+                artifact_stream.transformer_layout_identity_sha256 = sha('f');
+            }
             Some(AuthorityMismatch::TransformerCheckpoint) => {
                 artifact_stream.checkpoint_identity_sha256 = sha('f');
             }
@@ -1555,7 +1866,7 @@ mod tests {
             }
             None => {}
         }
-        let attempt = H3PrivateAttemptAuthority::new(
+        let attempt = H3PrivateAttemptAuthority::new_unchecked_for_test(
             FakeExecution {
                 device: Device::Cpu,
                 device_id: execution_device_id,
@@ -1571,6 +1882,7 @@ mod tests {
                 active: Arc::clone(&artifact_active),
                 events: Arc::clone(&events),
             },
+            Device::Cpu,
         );
         let (qwen_execution, qwen_artifacts) = attempt.qwen_projections();
         let conditioner = FakeConditioner {
@@ -1978,6 +2290,9 @@ mod tests {
             AuthorityMismatch::TaskModel,
             AuthorityMismatch::ConditionShape,
             AuthorityMismatch::TransformerComponent,
+            AuthorityMismatch::TransformerTask,
+            AuthorityMismatch::TransformerContent,
+            AuthorityMismatch::TransformerLayout,
             AuthorityMismatch::TransformerCheckpoint,
             AuthorityMismatch::TransformerPolicy,
             AuthorityMismatch::AttentionRuntime,
@@ -2005,6 +2320,7 @@ mod tests {
                 name: "artifacts",
                 events: Arc::clone(&events),
             },
+            Device::Cpu,
         );
         let second = H3PrivateAttemptAuthority::new_unchecked_for_test(
             DropCount {
@@ -2015,6 +2331,7 @@ mod tests {
                 name: "artifacts",
                 events,
             },
+            Device::Cpu,
         );
         let (execution, artifacts) = first.qwen_projections();
         assert!(execution.belongs_to(&first));
@@ -2079,7 +2396,8 @@ mod tests {
             name: "artifacts",
             events: Arc::clone(&events),
         };
-        let attempt = H3PrivateAttemptAuthority::new_unchecked_for_test(execution, artifacts);
+        let attempt =
+            H3PrivateAttemptAuthority::new_unchecked_for_test(execution, artifacts, Device::Cpu);
         let (qwen_execution, qwen_artifacts) = attempt.qwen_projections();
         let block_execution = attempt.block_projection();
 

--- a/crates/mold-inference/src/minimax_h3/private_runtime.rs
+++ b/crates/mold-inference/src/minimax_h3/private_runtime.rs
@@ -13,12 +13,15 @@ use std::sync::{Arc, Mutex, MutexGuard};
 use anyhow::{bail, Result};
 use candle_core::Device;
 use mold_candle::minimax_h3::{
-    H3AttentionRuntimeAuthority, H3BlockProgress, H3BlockStack, H3ComfyInt8BlockLoader,
-    H3ComfyInt8Cancellation, H3ComfyOpenedInt8Checkpoint, H3ForwardInput, H3FrozenPackedLayout,
-    H3LoadedTransformerBlock, H3StreamedTransformer, H3TransformerOutput, H3TransformerStep,
-    H3TransformerTask,
+    H3AttentionActivation, H3AttentionBackend, H3AttentionDevice, H3AttentionKernel,
+    H3AttentionModelContract, H3AttentionRuntimeAuthority, H3BlockProgress, H3BlockStack,
+    H3ComfyInt8BlockLoader, H3ComfyInt8Cancellation, H3ComfyOpenedInt8Checkpoint, H3ForwardInput,
+    H3FrozenPackedLayout, H3LoadedTransformerBlock, H3StreamedTransformer, H3TransformerOutput,
+    H3TransformerStep, H3TransformerTask,
 };
 
+use crate::attention::{AttentionBackend, AttentionChunkPolicy};
+use crate::h3_factory::H3FactoryAttentionInput;
 use crate::progress::{InferenceCancellationObserver, InferenceCancelled, ProgressReporter};
 
 use super::engine::H3StreamedTransformerExecutor;
@@ -38,9 +41,9 @@ struct H3PrivateComfyCancellationState {
     candle_observed_cancellation: bool,
 }
 
-/// One cached Candle loader can serve multiple serialized inference attempts.
-/// This slot refreshes its read-only cancellation authority for each attempt
-/// instead of retaining the token that happened to load the model initially.
+/// One attempt-scoped Candle loader shares this slot across its resident load
+/// and streamed block operations. Installation binds the fresh session's
+/// read-only cancellation authority before either operation can begin.
 #[derive(Clone, Default)]
 pub(crate) struct H3PrivateComfyCancellationSlot {
     state: Arc<Mutex<H3PrivateComfyCancellationState>>,
@@ -73,8 +76,8 @@ impl H3PrivateComfyCancellationSlot {
     }
 
     /// Run one Candle load operation and prove that it polled this exact slot.
-    /// This closes the otherwise-untyped trait-object seam between the cached
-    /// Candle loader and the attempt authority retained by this adapter.
+    /// This closes the otherwise-untyped trait-object seam between the
+    /// attempt's Candle loader and the authority retained by this adapter.
     pub(crate) fn run_candle_operation<T>(
         &self,
         operation: impl FnOnce() -> candle_core::Result<T>,
@@ -115,7 +118,7 @@ impl H3ComfyInt8Cancellation for H3PrivateComfyCancellationSlot {
     }
 }
 
-#[must_use = "dropping the guard clears the cached runtime's attempt authority"]
+#[must_use = "dropping the guard clears the fresh session's attempt authority"]
 pub(crate) struct H3PrivateComfyCancellationGuard {
     slot: H3PrivateComfyCancellationSlot,
     attempt_id: u64,
@@ -398,9 +401,166 @@ pub(crate) fn pair_private_comfy_stream(
 pub(crate) struct H3PrivateComfyStreamAuthority {
     pub(crate) task: H3TransformerTask,
     pub(crate) transformer_content_sha256: String,
+    pub(crate) transformer_layout_identity_sha256: String,
     pub(crate) checkpoint_identity_sha256: String,
     pub(crate) transformer_policy_identity_sha256: String,
     pub(crate) attention_runtime_identity_sha256: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct H3PrivateComfyCheckpointFacts {
+    pub(crate) task: H3TransformerTask,
+    pub(crate) content_sha256: String,
+    pub(crate) layout_identity_sha256: String,
+    pub(crate) opened_checkpoint_identity_sha256: String,
+    pub(crate) quantization_policy_identity_sha256: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct H3PrivateAttentionRuntimeFacts {
+    backend: H3AttentionBackend,
+    kernel: H3AttentionKernel,
+    activation: H3AttentionActivation,
+    device: H3AttentionDevice,
+    model_contract: H3AttentionModelContract,
+    identity_sha256: String,
+}
+
+impl From<&H3AttentionRuntimeAuthority> for H3PrivateAttentionRuntimeFacts {
+    fn from(authority: &H3AttentionRuntimeAuthority) -> Self {
+        Self {
+            backend: authority.backend(),
+            kernel: authority.kernel(),
+            activation: authority.activation(),
+            device: authority.device(),
+            model_contract: authority.contract(),
+            identity_sha256: authority.identity_sha256().into(),
+        }
+    }
+}
+
+pub(crate) struct H3PrivateComfyBindingExpectation {
+    pub(crate) attention: H3FactoryAttentionInput,
+    pub(crate) checkpoint: H3PrivateComfyCheckpointFacts,
+}
+
+/// Non-cloneable pair that has passed the complete private pre-allocation
+/// attention and opened-checkpoint binding. Only this type may cross into the
+/// resident Candle transformer loader.
+pub(crate) struct H3PrivateBoundComfyStream {
+    opened: H3ComfyOpenedInt8Checkpoint,
+    device: Device,
+    attention: H3AttentionRuntimeAuthority,
+    authority: H3PrivateComfyStreamAuthority,
+}
+
+fn valid_sha256(value: &str) -> bool {
+    value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn validate_private_attention_facts(
+    expected: &H3FactoryAttentionInput,
+    actual: &H3PrivateAttentionRuntimeFacts,
+    actual_device: H3AttentionDevice,
+) -> Result<()> {
+    let canonical_identity = H3AttentionRuntimeAuthority::expected_identity_for(
+        actual.backend,
+        actual.kernel,
+        actual.activation,
+        actual.device,
+        actual.model_contract,
+    )
+    .map_err(|error| anyhow::anyhow!(error.to_string()))?;
+    if expected.generic_backend != AttentionBackend::Flash
+        || expected.generic_chunk != AttentionChunkPolicy::Off
+        || expected.runtime_backend != actual.backend
+        || expected.kernel != actual.kernel
+        || expected.activation != actual.activation
+        || expected.device != actual.device
+        || expected.device != actual_device
+        || expected.model_contract != actual.model_contract
+        || expected.runtime_identity_sha256 != actual.identity_sha256
+        || actual.identity_sha256 != canonical_identity
+        || expected.qualification_kernel_identity != actual.kernel.identity()
+        || !valid_sha256(&expected.runtime_identity_sha256)
+        || !valid_sha256(&expected.qualification_sha256)
+        || !expected.full_noncausal
+        || !expected.lossless
+    {
+        bail!("private MiniMax H3 concrete attention differs from frozen typed authority");
+    }
+    Ok(())
+}
+
+fn validate_private_checkpoint_facts(
+    expected: &H3PrivateComfyCheckpointFacts,
+    actual: &H3PrivateComfyCheckpointFacts,
+) -> Result<()> {
+    let exact_digests = [
+        &expected.content_sha256,
+        &expected.layout_identity_sha256,
+        &expected.opened_checkpoint_identity_sha256,
+        &expected.quantization_policy_identity_sha256,
+        &actual.content_sha256,
+        &actual.layout_identity_sha256,
+        &actual.opened_checkpoint_identity_sha256,
+        &actual.quantization_policy_identity_sha256,
+    ];
+    if exact_digests.into_iter().any(|value| !valid_sha256(value))
+        || expected.task != H3TransformerTask::T2VaFl2Va
+        || actual != expected
+    {
+        bail!("private MiniMax H3 opened checkpoint differs from singular artifact authority");
+    }
+    Ok(())
+}
+
+/// Consume an authenticated opened checkpoint and concrete attention runtime
+/// only after their complete immutable facts match the same admitted artifact
+/// authority. This performs no model tensor reads or allocations.
+pub(crate) fn bind_private_comfy_stream(
+    opened: H3ComfyOpenedInt8Checkpoint,
+    device: &Device,
+    attention: H3AttentionRuntimeAuthority,
+    expected: H3PrivateComfyBindingExpectation,
+) -> Result<H3PrivateBoundComfyStream> {
+    let actual_device = H3AttentionDevice::from_candle(device);
+    validate_private_attention_facts(
+        &expected.attention,
+        &H3PrivateAttentionRuntimeFacts::from(&attention),
+        actual_device,
+    )?;
+    attention
+        .verify_current_release_candidate_dispatch(device)
+        .map_err(|error| anyhow::anyhow!(error.to_string()))?;
+
+    let candidate = opened.candidate();
+    let actual_checkpoint = H3PrivateComfyCheckpointFacts {
+        task: candidate.strategy.task,
+        content_sha256: candidate.expected_content_sha256.clone(),
+        layout_identity_sha256: candidate.header_identity_sha256.clone(),
+        opened_checkpoint_identity_sha256: opened.checkpoint_identity_sha256().into(),
+        quantization_policy_identity_sha256: candidate
+            .strategy
+            .quantization_policy
+            .policy_sha256
+            .clone(),
+    };
+    validate_private_checkpoint_facts(&expected.checkpoint, &actual_checkpoint)?;
+    let authority = H3PrivateComfyStreamAuthority {
+        task: actual_checkpoint.task,
+        transformer_content_sha256: actual_checkpoint.content_sha256,
+        transformer_layout_identity_sha256: actual_checkpoint.layout_identity_sha256,
+        checkpoint_identity_sha256: actual_checkpoint.opened_checkpoint_identity_sha256,
+        transformer_policy_identity_sha256: actual_checkpoint.quantization_policy_identity_sha256,
+        attention_runtime_identity_sha256: attention.identity_sha256().into(),
+    };
+    Ok(H3PrivateBoundComfyStream {
+        opened,
+        device: device.clone(),
+        attention,
+        authority,
+    })
 }
 
 pub(crate) struct H3PrivateComfyStream {
@@ -413,32 +573,20 @@ pub(crate) struct H3PrivateComfyStream {
 /// attempt guard is installed in `cancellation`. The exact same slot is passed
 /// to Candle for the resident load and retained by every later block read.
 pub(crate) fn load_and_pair_private_comfy_stream(
-    opened: H3ComfyOpenedInt8Checkpoint,
-    device: &Device,
-    attention: H3AttentionRuntimeAuthority,
+    bound: H3PrivateBoundComfyStream,
     plan: &FrozenH3BlockStreamingPlan,
-    expected_task: H3TransformerTask,
     cancellation: H3PrivateComfyCancellationSlot,
 ) -> Result<H3PrivateComfyStream> {
     plan.validate()?;
-    if opened.candidate().strategy.task != expected_task {
-        bail!("private H3 Comfy opened checkpoint differs from the frozen task authority");
-    }
-    let authority = H3PrivateComfyStreamAuthority {
-        task: opened.candidate().strategy.task,
-        transformer_content_sha256: opened.candidate().expected_content_sha256.clone(),
-        checkpoint_identity_sha256: opened.checkpoint_identity_sha256().into(),
-        transformer_policy_identity_sha256: opened
-            .candidate()
-            .strategy
-            .quantization_policy
-            .policy_sha256
-            .clone(),
-        attention_runtime_identity_sha256: attention.identity_sha256().into(),
-    };
+    let H3PrivateBoundComfyStream {
+        opened,
+        device,
+        attention,
+        authority,
+    } = bound;
     let cancellation_for_candle: Arc<dyn H3ComfyInt8Cancellation> = Arc::new(cancellation.clone());
     let (transformer, loader) = cancellation.run_candle_operation(|| {
-        opened.load_with_attention_and_cancellation(device, attention, cancellation_for_candle)
+        opened.load_with_attention_and_cancellation(&device, attention, cancellation_for_candle)
     })?;
     if loader.content_sha256() != authority.transformer_content_sha256
         || loader.checkpoint_identity_sha256() != authority.checkpoint_identity_sha256
@@ -446,7 +594,7 @@ pub(crate) fn load_and_pair_private_comfy_stream(
         bail!("private H3 Comfy streamed runtime differs from its opened artifact authority");
     }
     let (loader, executor) =
-        pair_private_comfy_stream(transformer, loader, plan, expected_task, cancellation)?;
+        pair_private_comfy_stream(transformer, loader, plan, authority.task, cancellation)?;
     Ok(H3PrivateComfyStream {
         loader,
         executor,
@@ -536,12 +684,171 @@ impl H3TransformerCallbackErrorBridge {
 mod tests {
     use super::*;
     use crate::progress::{is_inference_cancelled, InferenceCancellationToken};
+    use mold_candle::minimax_h3::H3AttentionDType;
 
     const FINGERPRINT: &str = "1111111111111111111111111111111111111111111111111111111111111111";
     const CHECKPOINT: &str = "2222222222222222222222222222222222222222222222222222222222222222";
 
     fn plan() -> FrozenH3BlockStreamingPlan {
         FrozenH3BlockStreamingPlan::new("gpu-0", FINGERPRINT, 0, 0).unwrap()
+    }
+
+    fn sha(byte: char) -> String {
+        std::iter::repeat_n(byte, 64).collect()
+    }
+
+    fn expected_attention() -> H3FactoryAttentionInput {
+        let runtime_backend = H3AttentionBackend::FlashAttentionV2;
+        let kernel = H3AttentionKernel::CandleFlashFwdHdim128Bf16Sm80V011;
+        let activation = H3AttentionActivation::ReleaseCandidateQualificationOnly;
+        let device = H3AttentionDevice::Cuda {
+            compute_capability: Some((8, 9)),
+        };
+        let model_contract = H3AttentionModelContract::released_bf16();
+        H3FactoryAttentionInput {
+            generic_backend: AttentionBackend::Flash,
+            generic_chunk: AttentionChunkPolicy::Off,
+            runtime_backend,
+            kernel,
+            activation,
+            device,
+            model_contract,
+            runtime_identity_sha256: H3AttentionRuntimeAuthority::expected_identity_for(
+                runtime_backend,
+                kernel,
+                activation,
+                device,
+                model_contract,
+            )
+            .unwrap(),
+            qualification_kernel_identity: kernel.identity().into(),
+            qualification_sha256: sha('b'),
+            full_noncausal: true,
+            lossless: true,
+        }
+    }
+
+    fn runtime_attention() -> H3PrivateAttentionRuntimeFacts {
+        let expected = expected_attention();
+        H3PrivateAttentionRuntimeFacts {
+            backend: expected.runtime_backend,
+            kernel: expected.kernel,
+            activation: expected.activation,
+            device: expected.device,
+            model_contract: expected.model_contract,
+            identity_sha256: expected.runtime_identity_sha256,
+        }
+    }
+
+    fn checkpoint_facts() -> H3PrivateComfyCheckpointFacts {
+        H3PrivateComfyCheckpointFacts {
+            task: H3TransformerTask::T2VaFl2Va,
+            content_sha256: sha('c'),
+            layout_identity_sha256: sha('d'),
+            opened_checkpoint_identity_sha256: sha('e'),
+            quantization_policy_identity_sha256: sha('f'),
+        }
+    }
+
+    #[test]
+    fn exact_preallocation_attention_and_checkpoint_facts_are_accepted() {
+        let attention = expected_attention();
+        validate_private_attention_facts(
+            &attention,
+            &runtime_attention(),
+            H3AttentionDevice::Cuda {
+                compute_capability: Some((8, 9)),
+            },
+        )
+        .unwrap();
+        let checkpoint = checkpoint_facts();
+        validate_private_checkpoint_facts(&checkpoint, &checkpoint).unwrap();
+    }
+
+    #[test]
+    fn every_concrete_attention_axis_fails_closed_before_allocation() {
+        for axis in [
+            "backend",
+            "kernel",
+            "activation",
+            "device",
+            "contract",
+            "identity",
+            "actual-device",
+        ] {
+            let expected = expected_attention();
+            let mut actual = runtime_attention();
+            let mut actual_device = expected.device;
+            match axis {
+                "backend" => actual.backend = H3AttentionBackend::BoundedDenseMath,
+                "kernel" => actual.kernel = H3AttentionKernel::CandleDenseF32V011,
+                "activation" => actual.activation = H3AttentionActivation::SyntheticCorrectnessOnly,
+                "device" => actual.device = H3AttentionDevice::Cpu,
+                "contract" => {
+                    actual.model_contract = H3AttentionModelContract {
+                        heads: 55,
+                        head_dim: 128,
+                        dtype: H3AttentionDType::Bf16,
+                    }
+                }
+                "identity" => actual.identity_sha256 = sha('9'),
+                "actual-device" => actual_device = H3AttentionDevice::Metal,
+                _ => unreachable!(),
+            }
+            let error = validate_private_attention_facts(&expected, &actual, actual_device)
+                .expect_err(axis);
+            assert!(!error.to_string().trim().is_empty(), "{axis}");
+        }
+    }
+
+    #[test]
+    fn generic_attention_qualification_axes_fail_closed() {
+        for axis in [
+            "generic-backend",
+            "generic-chunk",
+            "qualification-kernel",
+            "qualification-sha",
+            "causality",
+            "lossless",
+        ] {
+            let mut expected = expected_attention();
+            match axis {
+                "generic-backend" => expected.generic_backend = AttentionBackend::Math,
+                "generic-chunk" => expected.generic_chunk = AttentionChunkPolicy::Size(64),
+                "qualification-kernel" => expected.qualification_kernel_identity = "other".into(),
+                "qualification-sha" => expected.qualification_sha256 = "not-a-digest".into(),
+                "causality" => expected.full_noncausal = false,
+                "lossless" => expected.lossless = false,
+                _ => unreachable!(),
+            }
+            let error = validate_private_attention_facts(
+                &expected,
+                &runtime_attention(),
+                H3AttentionDevice::Cuda {
+                    compute_capability: Some((8, 9)),
+                },
+            )
+            .expect_err(axis);
+            assert!(error.to_string().contains("attention"), "{axis}: {error}");
+        }
+    }
+
+    #[test]
+    fn every_opened_checkpoint_axis_fails_closed_before_allocation() {
+        for axis in ["task", "content", "layout", "opened", "policy"] {
+            let expected = checkpoint_facts();
+            let mut actual = expected.clone();
+            match axis {
+                "task" => actual.task = H3TransformerTask::Ref2Va,
+                "content" => actual.content_sha256 = sha('1'),
+                "layout" => actual.layout_identity_sha256 = sha('2'),
+                "opened" => actual.opened_checkpoint_identity_sha256 = sha('3'),
+                "policy" => actual.quantization_policy_identity_sha256 = sha('4'),
+                _ => unreachable!(),
+            }
+            let error = validate_private_checkpoint_facts(&expected, &actual).expect_err(axis);
+            assert!(error.to_string().contains("checkpoint"), "{axis}: {error}");
+        }
     }
 
     #[test]

--- a/scripts/tests/minimax-h3-attention-release-contract.sh
+++ b/scripts/tests/minimax-h3-attention-release-contract.sh
@@ -41,6 +41,12 @@ if ! awk '
 ' crates/mold-candle/src/minimax_h3/attention.rs; then
   fail "the isolated H3 feature does not directly guard the production FlashAttention dispatch"
 fi
+require_text crates/mold-candle/src/minimax_h3/attention.rs \
+  'pub fn verify_current_release_candidate_dispatch' \
+  "private H3 dispatch does not revalidate the current compiled attention candidate"
+require_text crates/mold-candle/src/minimax_h3/attention.rs \
+  'H3AttentionReleaseCandidateBuild::current()' \
+  "attention dispatch trusts a serialized authority without current-build provenance"
 require_text crates/mold-inference/Cargo.toml \
   'h3-attention-rc = ["cuda", "mold-candle/h3-flash-attn-rc"]' \
   "mold-inference does not expose the synthetic-only H3 qualification path"

--- a/scripts/tests/minimax-h3-private-uat-release-contract.sh
+++ b/scripts/tests/minimax-h3-private-uat-release-contract.sh
@@ -37,6 +37,78 @@ require_text crates/mold-inference/src/minimax_h3/private_fl2va_runtime.rs \
 require_text crates/mold-inference/src/minimax_h3/private_fl2va_runtime.rs \
   '_activation: admitted_overlap_seal::Token,' \
   "private H3 FL2VA overlap authority no longer contains its uninhabited token"
+require_text crates/mold-inference/src/minimax_h3/private_runtime.rs \
+  'pub(crate) struct H3PrivateBoundComfyStream' \
+  "private H3 checkpoint load lacks a non-cloneable pre-allocation binding"
+require_text crates/mold-inference/src/minimax_h3/private_runtime.rs \
+  'bound: H3PrivateBoundComfyStream,' \
+  "private H3 resident loader still accepts unbound checkpoint and attention values"
+require_text crates/mold-inference/src/minimax_h3/private_runtime.rs \
+  'device: Device,' \
+  "private H3 bound checkpoint does not retain the validated Candle device"
+attempt_owner=$(sed -n \
+  '/struct H3PrivateAttemptOwner/,/^}/p' \
+  crates/mold-inference/src/minimax_h3/private_fl2va_runtime.rs)
+if ! grep -Fq 'device: Device,' <<<"$attempt_owner"; then
+  fail "private H3 singular attempt owner does not retain the validated Candle device"
+fi
+require_text crates/mold-inference/src/minimax_h3/private_fl2va_runtime.rs \
+  'struct H3PrivateBoundExecution<E>' \
+  "private H3 route capture returns forgeable lease/device parts"
+require_text crates/mold-inference/src/minimax_h3/private_fl2va_runtime.rs \
+  'fn new(bound: H3PrivateBoundExecution<E>, artifacts: A)' \
+  "private H3 attempt construction can mix an execution lease with another device"
+execution_projection=$(sed -n \
+  '/impl<E, A> H3BackendExecutionLease for H3PrivateExecutionProjection/,/^}/p' \
+  crates/mold-inference/src/minimax_h3/private_fl2va_runtime.rs)
+if ! grep -Fq '&self.owner.device' <<<"$execution_projection" \
+  || grep -Fq 'execution.device()' <<<"$execution_projection"; then
+  fail "private H3 execution projections can repoll a safe lease for a different device"
+fi
+require_text crates/mold-inference/src/minimax_h3/private_runtime.rs \
+  '.verify_current_release_candidate_dispatch(device)' \
+  "private H3 binding does not verify the actual compiled attention candidate"
+for method in \
+  transformer_task \
+  transformer_checkpoint_content_sha256 \
+  transformer_checkpoint_layout_identity_sha256 \
+  transformer_checkpoint_identity_sha256 \
+  transformer_policy_identity_sha256; do
+  require_text crates/mold-inference/src/minimax_h3/private_fl2va_runtime.rs \
+    "fn ${method}(&self)" \
+    "private H3 artifact lease omits ${method}"
+done
+composer=$(sed -n \
+  '/fn compose_private_comfy_fl2va_runtime/,/^}/p' \
+  crates/mold-inference/src/minimax_h3/private_fl2va_runtime.rs)
+bind_line=$(grep -nF 'let bound_stream = bind_private_comfy_stream(' <<<"$composer" | cut -d: -f1)
+attempt_line=$(grep -nF 'let attempt = H3PrivateAttemptAuthority::new' <<<"$composer" | cut -d: -f1)
+qwen_line=$(grep -nF 'let qwen = H3PrivateQwenAdapter::load_authorized' <<<"$composer" | cut -d: -f1)
+if [[ -z "$bind_line" || -z "$attempt_line" || -z "$qwen_line" ]] \
+  || (( bind_line >= attempt_line || bind_line >= qwen_line )); then
+  fail "private H3 attention/checkpoint binding no longer precedes attempt and Qwen allocation"
+fi
+if [[ $(grep -Fc 'capture_private_execution_route(execution_lease' <<<"$composer") -ne 1 ]] \
+  || grep -Fq 'execution_lease.device()' <<<"$composer"; then
+  fail "private H3 composer must consume and capture the execution lease route exactly once"
+fi
+if [[ $(grep -Fc 'bound_execution.device()' <<<"$composer") -ne 1 ]] \
+  || [[ $(grep -Fc 'H3PrivateAttemptAuthority::new(bound_execution, artifact_lease)' <<<"$composer") -ne 1 ]]; then
+  fail "private H3 bound execution token is not shared with attention binding and consumed by the attempt"
+fi
+capture=$(sed -n \
+  '/fn capture_private_execution_route/,/^}/p' \
+  crates/mold-inference/src/minimax_h3/private_fl2va_runtime.rs)
+if [[ $(grep -Fc 'execution.device()' <<<"$capture") -ne 1 ]] \
+  || [[ $(grep -Fc 'lease_id: execution.lease_id().into()' <<<"$capture") -ne 1 ]]; then
+  fail "private H3 route capture must bind one device and a concrete lease identity"
+fi
+loader=$(sed -n \
+  '/pub(crate) fn load_and_pair_private_comfy_stream/,/^[[:space:]]*{/p' \
+  crates/mold-inference/src/minimax_h3/private_runtime.rs)
+if grep -Fq 'device:' <<<"$loader"; then
+  fail "private H3 resident loader still accepts an external device after binding"
+fi
 overlap_seal=$(sed -n '/mod admitted_overlap_seal {/,/^}/p' \
   crates/mold-inference/src/minimax_h3/private_fl2va_runtime.rs)
 if ! grep -Fq '#[cfg(not(test))]' <<<"$overlap_seal"; then


### PR DESCRIPTION
## Summary
- bind the exact compiled attention candidate and observed CUDA device before any private H3 model allocation
- consume one execution/device token across checkpoint binding and the attempt owner
- bind opened checkpoint content, layout, task, policy, and artifact identities to the same authority
- keep production activation and shipping feature exposure closed

## Validation
- Candle attention tests: 13/13
- private H3 inference suite: 128 passed, 1 authorization-artifact test ignored
- strict Candle and inference Clippy, default and private feature
- formatting and both H3 release-contract scripts
- independent exact-diff review on SHA-256 8ed0072bec9cbeeb1fbcdacfe5c3ec7a57fc8d6ea6e1ee000606f7a7fbc901fc

Contributes to #840 and #830 without enabling public discovery, download, or execution.