### PR TITLE
feat(h3): checkpoint reference audio encoding

### DIFF
--- a/crates/mold-candle/src/minimax_h3/audio.rs
+++ b/crates/mold-candle/src/minimax_h3/audio.rs
@@ -1026,21 +1026,31 @@ impl AudioVae {
         waveform: &StereoWaveform,
         cancellation: &dyn AudioVaeCancellation,
     ) -> Result<(AudioPosterior, usize)> {
-        cancellation_boundary(cancellation, AudioVaePhase::EncodePreprocess)?;
+        self.encode_posterior_with_checkpoint(waveform, &mut |phase| {
+            cancellation_boundary(cancellation, phase)
+        })
+    }
+
+    fn encode_posterior_with_checkpoint(
+        &self,
+        waveform: &StereoWaveform,
+        checkpoint: &mut dyn FnMut(AudioVaePhase) -> Result<()>,
+    ) -> Result<(AudioPosterior, usize)> {
+        checkpoint(AudioVaePhase::EncodePreprocess)?;
         let (batch, _, samples) = waveform.samples().dims3()?;
         let padded = self.config.padded_samples(samples)?;
         let mut mono = waveform.pack_mono_batch()?;
         if padded > samples {
             mono = mono.pad_with_zeros(2, 0, padded - samples)?;
         }
-        cancellation_boundary(cancellation, AudioVaePhase::EncodeDac)?;
+        checkpoint(AudioVaePhase::EncodeDac)?;
         let encoded = self.encoder.forward(&mono)?;
-        cancellation_boundary(cancellation, AudioVaePhase::EncodeProjection)?;
+        checkpoint(AudioVaePhase::EncodeProjection)?;
         let projected = self
             .pre_block
             .forward(&encoded.transpose(1, 2)?)?
             .transpose(1, 2)?;
-        cancellation_boundary(cancellation, AudioVaePhase::EncodePosterior)?;
+        checkpoint(AudioVaePhase::EncodePosterior)?;
         let mean = self.mean_proj.forward(&projected)?;
         let logs = self.logs_proj.forward(&projected)?;
         Ok((AudioPosterior::new(mean, logs)?, batch))
@@ -1052,7 +1062,32 @@ impl AudioVae {
         waveform: &StereoWaveform,
         cancellation: &dyn AudioVaeCancellation,
     ) -> Result<StereoLatents> {
-        let (posterior, batch) = self.encode_posterior(waveform, cancellation)?;
+        self.encode_with_checkpoint(waveform, &mut |phase| {
+            cancellation_boundary(cancellation, phase)
+        })
+    }
+
+    /// Encode with a fallible callback at each named audio safe point.
+    ///
+    /// This developer-only seam lets a private Ref2VA runtime retain the
+    /// original request-scoped cancellation error instead of reducing it to
+    /// the string-only [`AudioVaeCancellation`] transport.
+    #[cfg(feature = "h3-private-uat")]
+    #[doc(hidden)]
+    pub fn encode_with_phase_checkpoint(
+        &self,
+        waveform: &StereoWaveform,
+        checkpoint: &mut dyn FnMut(AudioVaePhase) -> Result<()>,
+    ) -> Result<StereoLatents> {
+        self.encode_with_checkpoint(waveform, checkpoint)
+    }
+
+    fn encode_with_checkpoint(
+        &self,
+        waveform: &StereoWaveform,
+        checkpoint: &mut dyn FnMut(AudioVaePhase) -> Result<()>,
+    ) -> Result<StereoLatents> {
+        let (posterior, batch) = self.encode_posterior_with_checkpoint(waveform, checkpoint)?;
         let normalized = self.normalize_mono_latents(&posterior.mode())?;
         StereoLatents::from_mono_batch(normalized, batch, &self.config)
     }
@@ -1541,6 +1576,60 @@ mod tests {
         }
         #[cfg(feature = "h3-private-uat")]
         {
+            let encode_phases = [
+                AudioVaePhase::EncodePreprocess,
+                AudioVaePhase::EncodeDac,
+                AudioVaePhase::EncodeProjection,
+                AudioVaePhase::EncodePosterior,
+            ];
+            let mut phases = Vec::new();
+            let checkpoint_latents = vae.encode_with_phase_checkpoint(&waveform, &mut |phase| {
+                phases.push(phase);
+                Ok(())
+            })?;
+            assert_eq!(checkpoint_latents.normalized().dims4()?, (1, 2, 2, 2));
+            assert_eq!(phases, encode_phases);
+            assert_eq!(
+                waveform.association(),
+                AudioSoundtrackAssociation::StandaloneReference { reference_index: 1 }
+            );
+
+            for cancelled_phase in [
+                AudioVaePhase::EncodePreprocess,
+                AudioVaePhase::EncodeProjection,
+                AudioVaePhase::EncodePosterior,
+            ] {
+                let mut seen = Vec::new();
+                let error = vae
+                    .encode_with_phase_checkpoint(&waveform, &mut |phase| {
+                        seen.push(phase);
+                        if phase == cancelled_phase {
+                            bail!("synthetic pipeline cancellation at {phase:?}")
+                        }
+                        Ok(())
+                    })
+                    .unwrap_err();
+                assert_eq!(seen.last(), Some(&cancelled_phase));
+                assert!(error
+                    .to_string()
+                    .contains("synthetic pipeline cancellation"));
+                assert_eq!(
+                    waveform.association(),
+                    AudioSoundtrackAssociation::StandaloneReference { reference_index: 1 }
+                );
+            }
+
+            let soundtrack = StereoWaveform::new_for_config(
+                waveform.samples().clone(),
+                &config,
+                AudioSoundtrackAssociation::VideoSoundtrack { reference_index: 4 },
+            )?;
+            vae.encode_with_phase_checkpoint(&soundtrack, &mut |_phase| Ok(()))?;
+            assert_eq!(
+                soundtrack.association(),
+                AudioSoundtrackAssociation::VideoSoundtrack { reference_index: 4 }
+            );
+
             let mut phases = Vec::new();
             vae.decode_with_phase_checkpoint(
                 &latents,

--- a/crates/mold-inference/src/minimax_h3/private_vae_adapter.rs
+++ b/crates/mold-inference/src/minimax_h3/private_vae_adapter.rs
@@ -13,9 +13,9 @@ use anyhow::{bail, Result};
 use candle_core::{DType, Device, Tensor};
 use image::RgbImage;
 use mold_candle::minimax_h3::{
-    AudioSoundtrackAssociation, AudioVaePhase, DecodeSink, H3ForwardInput, H3FrozenPackedLayout,
-    H3TransformerOutput, StereoLatents, StereoWaveform, Uint8RgbPixels, VisualVaeEvent,
-    VisualVaeObserver,
+    AudioSoundtrackAssociation, AudioVae, AudioVaePhase, DecodeSink, H3ForwardInput,
+    H3FrozenPackedLayout, H3TransformerOutput, StereoLatents, StereoWaveform, Uint8RgbPixels,
+    VisualVaeEvent, VisualVaeObserver,
 };
 use mold_core::minimax_h3::{self as contract, Task};
 
@@ -29,6 +29,23 @@ use super::pipeline::{
 };
 use super::private_fl2va_runtime::H3PrivateVaeFreeInnerAuthority;
 use super::vae_runtime::{H3ComfyVaeRuntimeBundle, H3ComfyVaeRuntimeMemory};
+
+/// Encode one already-normalized reference waveform while preserving typed
+/// pipeline failures across Candle's callback error boundary.
+///
+/// The dormant Ref2VA composer will own media lookup and association. This
+/// seam deliberately accepts only an already-associated reference waveform
+/// and exposes no registry, factory, server, or public-engine activation.
+#[allow(dead_code)]
+pub(crate) fn encode_private_audio_reference(
+    audio_vae: &AudioVae,
+    waveform: &StereoWaveform,
+    checkpoint: &mut dyn H3PipelineCheckpoint,
+) -> Result<StereoLatents> {
+    encode_private_audio_reference_with(waveform, checkpoint, |phase_checkpoint| {
+        audio_vae.encode_with_phase_checkpoint(waveform, phase_checkpoint)
+    })
+}
 
 pub(crate) trait H3PrivateVaeRuntime: Send + Sync {
     fn task(&self) -> Task;
@@ -367,6 +384,70 @@ where
 
 fn valid_sha256(value: &str) -> bool {
     value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn encode_private_audio_reference_with(
+    waveform: &StereoWaveform,
+    checkpoint: &mut dyn H3PipelineCheckpoint,
+    encode: impl FnOnce(
+        &mut dyn FnMut(AudioVaePhase) -> candle_core::Result<()>,
+    ) -> candle_core::Result<StereoLatents>,
+) -> Result<StereoLatents> {
+    validate_reference_audio_association(waveform.association())?;
+    let error_bridge = H3CallbackErrorBridge::default();
+    let mut phase_checkpoint =
+        |phase| checkpoint_audio_encode_phase(checkpoint, phase, &error_bridge);
+    let result = encode(&mut phase_checkpoint);
+    let latents = error_bridge.finish(result)?;
+    checkpoint.checkpoint(H3PipelineEvent {
+        phase: H3PipelinePhase::ReferenceAudioEncodeChunk,
+        completed: 4,
+        total: 4,
+    })?;
+    Ok(latents)
+}
+
+fn validate_reference_audio_association(association: AudioSoundtrackAssociation) -> Result<()> {
+    match association {
+        AudioSoundtrackAssociation::StandaloneReference { reference_index }
+        | AudioSoundtrackAssociation::VideoSoundtrack { reference_index }
+            if reference_index > 0 =>
+        {
+            Ok(())
+        }
+        AudioSoundtrackAssociation::StandaloneReference { .. }
+        | AudioSoundtrackAssociation::VideoSoundtrack { .. } => {
+            bail!("private MiniMax H3 audio reference index must be one-based")
+        }
+        AudioSoundtrackAssociation::Generated => {
+            bail!("private MiniMax H3 reference encoder received generated audio")
+        }
+    }
+}
+
+fn audio_encode_phase_progress(phase: AudioVaePhase) -> candle_core::Result<usize> {
+    match phase {
+        AudioVaePhase::EncodePreprocess => Ok(0),
+        AudioVaePhase::EncodeDac => Ok(1),
+        AudioVaePhase::EncodeProjection => Ok(2),
+        AudioVaePhase::EncodePosterior => Ok(3),
+        _ => candle_core::bail!("MiniMax H3 audio encoder reported a decode-only phase"),
+    }
+}
+
+fn checkpoint_audio_encode_phase(
+    checkpoint: &mut dyn H3PipelineCheckpoint,
+    phase: AudioVaePhase,
+    error_bridge: &H3CallbackErrorBridge,
+) -> candle_core::Result<()> {
+    let completed = audio_encode_phase_progress(phase)?;
+    checkpoint
+        .checkpoint(H3PipelineEvent {
+            phase: H3PipelinePhase::ReferenceAudioEncodeChunk,
+            completed,
+            total: 4,
+        })
+        .map_err(|error| error_bridge.capture(error))
 }
 
 fn audio_decode_phase_progress(phase: AudioVaePhase) -> candle_core::Result<usize> {
@@ -1201,6 +1282,129 @@ mod tests {
             assert!(is_inference_cancelled(&error), "phase {phase:?}");
         }
         assert!(audio_decode_phase_progress(AudioVaePhase::EncodeDac).is_err());
+    }
+
+    #[test]
+    fn audio_reference_encode_bridge_preserves_typed_cancellation_before_during_and_after() {
+        struct CancelAtEvent {
+            event: usize,
+            events: Vec<H3PipelineEvent>,
+        }
+
+        impl H3PipelineCheckpoint for CancelAtEvent {
+            fn checkpoint(&mut self, event: H3PipelineEvent) -> Result<()> {
+                self.events.push(event);
+                if self.events.len() == self.event {
+                    Err(InferenceCancelled.into())
+                } else {
+                    Ok(())
+                }
+            }
+        }
+
+        let phases = [
+            AudioVaePhase::EncodePreprocess,
+            AudioVaePhase::EncodeDac,
+            AudioVaePhase::EncodeProjection,
+            AudioVaePhase::EncodePosterior,
+        ];
+        let waveform = StereoWaveform::new(
+            Tensor::zeros((1, 2, 8), DType::F32, &Device::Cpu).unwrap(),
+            32_000,
+            AudioSoundtrackAssociation::StandaloneReference { reference_index: 7 },
+        )
+        .unwrap();
+        let latents = StereoLatents::new(
+            Tensor::zeros((1, LATENT_CHANNELS, 2, 1), DType::F32, &Device::Cpu).unwrap(),
+            &AudioVaeConfig::default(),
+        )
+        .unwrap();
+
+        for event in [1, 3, 5] {
+            let mut checkpoint = CancelAtEvent {
+                event,
+                events: Vec::new(),
+            };
+            let error = encode_private_audio_reference_with(
+                &waveform,
+                &mut checkpoint,
+                |phase_checkpoint| {
+                    for phase in phases {
+                        phase_checkpoint(phase)?;
+                    }
+                    Ok(latents.clone())
+                },
+            )
+            .unwrap_err();
+            assert!(is_inference_cancelled(&error), "event {event}");
+            assert_eq!(checkpoint.events.len(), event);
+            assert!(checkpoint.events.iter().all(|progress| {
+                progress.phase == H3PipelinePhase::ReferenceAudioEncodeChunk && progress.total == 4
+            }));
+            assert_eq!(
+                waveform.association(),
+                AudioSoundtrackAssociation::StandaloneReference { reference_index: 7 }
+            );
+        }
+    }
+
+    #[test]
+    fn audio_reference_encode_bridge_preserves_association_index_and_phase_order() {
+        let phases = [
+            AudioVaePhase::EncodePreprocess,
+            AudioVaePhase::EncodeDac,
+            AudioVaePhase::EncodeProjection,
+            AudioVaePhase::EncodePosterior,
+        ];
+        for association in [
+            AudioSoundtrackAssociation::StandaloneReference { reference_index: 3 },
+            AudioSoundtrackAssociation::VideoSoundtrack { reference_index: 9 },
+        ] {
+            let waveform = StereoWaveform::new(
+                Tensor::zeros((1, 2, 8), DType::F32, &Device::Cpu).unwrap(),
+                32_000,
+                association,
+            )
+            .unwrap();
+            let latents = StereoLatents::new(
+                Tensor::zeros((1, LATENT_CHANNELS, 2, 1), DType::F32, &Device::Cpu).unwrap(),
+                &AudioVaeConfig::default(),
+            )
+            .unwrap();
+            let mut checkpoint = RecordingCheckpoint::default();
+            let encoded = encode_private_audio_reference_with(
+                &waveform,
+                &mut checkpoint,
+                |phase_checkpoint| {
+                    for phase in phases {
+                        phase_checkpoint(phase)?;
+                    }
+                    Ok(latents.clone())
+                },
+            )
+            .unwrap();
+            assert_eq!(encoded.normalized().dims(), [1, LATENT_CHANNELS, 2, 1]);
+            assert_eq!(waveform.association(), association);
+            assert_eq!(
+                checkpoint
+                    .events
+                    .iter()
+                    .map(|event| (event.phase, event.completed, event.total))
+                    .collect::<Vec<_>>(),
+                (0..=4)
+                    .map(|completed| { (H3PipelinePhase::ReferenceAudioEncodeChunk, completed, 4) })
+                    .collect::<Vec<_>>()
+            );
+        }
+
+        assert!(
+            validate_reference_audio_association(AudioSoundtrackAssociation::Generated).is_err()
+        );
+        assert!(validate_reference_audio_association(
+            AudioSoundtrackAssociation::StandaloneReference { reference_index: 0 }
+        )
+        .is_err());
+        assert!(audio_encode_phase_progress(AudioVaePhase::DecodeProjection).is_err());
     }
 
     #[test]

--- a/scripts/tests/minimax-h3-private-uat-release-contract.sh
+++ b/scripts/tests/minimax-h3-private-uat-release-contract.sh
@@ -22,6 +22,22 @@ require_text crates/mold-candle/Cargo.toml \
 require_text crates/mold-inference/Cargo.toml \
   'h3-private-uat = ["mold-candle/h3-private-uat"]' \
   "mold-inference does not narrowly forward the private H3 runtime feature"
+audio_encode_checkpoint=$(sed -n \
+  '/This developer-only seam lets a private Ref2VA runtime/,/fn encode_with_checkpoint/p' \
+  crates/mold-candle/src/minimax_h3/audio.rs)
+if ! grep -Fq '#[cfg(feature = "h3-private-uat")]' <<<"$audio_encode_checkpoint" \
+  || ! grep -Fq 'pub fn encode_with_phase_checkpoint(' <<<"$audio_encode_checkpoint"; then
+  fail "the typed H3 audio encode checkpoint is not private-feature-gated"
+fi
+require_text crates/mold-inference/src/minimax_h3/private_vae_adapter.rs \
+  'pub(crate) fn encode_private_audio_reference(' \
+  "the private H3 VAE adapter omits the reference-audio encode seam"
+require_text crates/mold-inference/src/minimax_h3/private_vae_adapter.rs \
+  'audio_vae.encode_with_phase_checkpoint(waveform, phase_checkpoint)' \
+  "the private H3 VAE adapter bypasses the typed audio encode checkpoint"
+require_text crates/mold-inference/src/minimax_h3/private_vae_adapter.rs \
+  'phase: H3PipelinePhase::ReferenceAudioEncodeChunk,' \
+  "the private H3 audio encode seam omits attempt-scoped phase checkpoints"
 require_text crates/mold-inference/Cargo.toml \
   'required-features = ["dev-bins", "h3-private-uat"]' \
   "the private H3 artifact qualifier is reachable without both development features"


### PR DESCRIPTION
## Summary

- route AudioVAE encoding through fallible named phase checkpoints without changing the public encode path
- add a private-feature-only Ref2VA adapter seam that preserves typed cancellation and one-based reference association
- report ordered reference-audio encode progress, including a final post-encode cancellation boundary
- keep the seam dormant: no registry, factory, server, catalog, CLI, or release activation

## Why

Ref2VA must be cancellable while a reference waveform is encoded, and cancellation must remain the original typed pipeline error across Candle callback boundaries. The adapter also needs to reject generated audio and zero-based reference associations before allocation proceeds.

## Validation

- 308 tests passed; 2 authorized-artifact tests ignored
- focused AudioVAE checkpoint and private adapter cancellation/association tests passed
- strict all-target Clippy passed for Candle and inference private-feature configurations, including MP4
- cargo fmt, private UAT contract, attention release contract, diff check, conflict check, and path/restricted-identifier scans passed
- independently reviewed frozen patch digest: 99105c2c019b62dd18348aca91f28c289b8d65f08b7fe4b50dd344404b846dd1

Progresses #825 and #834. Part of #814.