### PR TITLE
fix(h3): preserve canonical partition identity

### DIFF
--- a/crates/mold-core/src/minimax_h3.rs
+++ b/crates/mold-core/src/minimax_h3.rs
@@ -367,6 +367,23 @@ pub fn resolve_model_name(input: &str) -> Option<&'static str> {
     }
 }
 
+/// Replace any released H3 alias with the exact task/layout manifest identity.
+///
+/// Server ingress calls this before it derives activation, upload-session,
+/// admission, queue, or persistence identity. Non-H3 model names are left
+/// byte-for-byte unchanged so catalog IDs and configured aliases retain their
+/// existing authority.
+pub fn canonicalize_request_model(request: &mut GenerateRequest) -> bool {
+    let Some(canonical) = resolve_model_name(&request.model) else {
+        return false;
+    };
+    if request.model == canonical {
+        return false;
+    }
+    request.model = canonical.to_string();
+    true
+}
+
 pub const fn valid_frame_count(frames: u32) -> bool {
     frames >= MIN_FRAMES
         && frames <= MAX_FRAMES
@@ -2419,6 +2436,25 @@ mod tests {
             assert_eq!(task_for_model(lookalike), None, "{lookalike}");
             assert_eq!(layout_for_model(lookalike), None, "{lookalike}");
         }
+    }
+
+    #[test]
+    fn request_model_canonicalization_preserves_exact_partition_identity() {
+        let mut ref2va = request();
+        ref2va.model = "MiniMax_H3_Ref2VA".into();
+        assert!(canonicalize_request_model(&mut ref2va));
+        assert_eq!(ref2va.model, REF2VA_COMFY);
+        assert!(!canonicalize_request_model(&mut ref2va));
+
+        let mut official = request();
+        official.model = " MINIMAX_H3_FL2VA:OFFICIAL_BF16 ".into();
+        assert!(canonicalize_request_model(&mut official));
+        assert_eq!(official.model, FL2VA_OFFICIAL);
+
+        let mut opaque = request();
+        opaque.model = "hf:example/custom-checkpoint".into();
+        assert!(!canonicalize_request_model(&mut opaque));
+        assert_eq!(opaque.model, "hf:example/custom-checkpoint");
     }
 
     #[test]

--- a/crates/mold-server/src/reference_uploads.rs
+++ b/crates/mold-server/src/reference_uploads.rs
@@ -371,8 +371,13 @@ impl ReferenceUploadStore {
         &self,
         identity: &str,
         instance_id: &str,
-        payload: ReferenceUploadSessionRequest,
+        mut payload: ReferenceUploadSessionRequest,
     ) -> Result<ReferenceUploadSessionResponse, ApiError> {
+        // Session storage and every scope digest must bind the same explicit
+        // partition identity that generation preparation will queue later.
+        // Keep this defensive normalization inside the store as well as the
+        // HTTP ingress so internal callers cannot mint alias-scoped sessions.
+        minimax_h3::canonicalize_request_model(&mut payload.request);
         self.purge_expired().await;
         let references = payload.request.references.as_deref().ok_or_else(|| {
             ApiError::structured(
@@ -1809,9 +1814,10 @@ fn authenticated_identity(
 pub(crate) async fn create_reference_upload_session(
     State(state): State<AppState>,
     authenticated: Option<Extension<ApiKeyAuthenticated>>,
-    Json(payload): Json<ReferenceUploadSessionRequest>,
+    Json(mut payload): Json<ReferenceUploadSessionRequest>,
 ) -> Result<impl IntoResponse, ApiError> {
     let identity = authenticated_identity(authenticated)?;
+    minimax_h3::canonicalize_request_model(&mut payload.request);
     if payload.request.batch_size > 1 {
         return Err(ApiError::with_code(
             "MiniMax H3 references do not support durable server batches yet",
@@ -2142,6 +2148,45 @@ mod tests {
             audio_sample_rate: Some(44_100),
             audio_channels: Some(2),
         }
+    }
+
+    #[tokio::test]
+    async fn upload_session_scope_and_storage_use_canonical_h3_partition() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ReferenceUploadStore::at(dir.path().join("cache"));
+        let descriptor = png_reference(
+            GenerationReferenceAuthority::Descriptor,
+            Some("11".repeat(32)),
+        );
+        let mut alias_request = request(descriptor);
+        alias_request.model = "MiniMax_H3_Ref2VA".into();
+        let mut canonical_request = alias_request.clone();
+        assert!(minimax_h3::canonicalize_request_model(
+            &mut canonical_request
+        ));
+
+        let session = store
+            .create_session(
+                "auth-a",
+                "instance-a",
+                ReferenceUploadSessionRequest {
+                    request: alias_request,
+                    upload_references: vec![1],
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            session.request_scope_sha256,
+            request_scope_sha256(&canonical_request).unwrap()
+        );
+        let session_digest = store.session_digest(&session.session_handle);
+        let inner = store.inner.lock().await;
+        assert_eq!(
+            inner.sessions[&session_digest].request.model,
+            minimax_h3::REF2VA_COMFY
+        );
     }
 
     #[tokio::test]

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -773,6 +773,12 @@ async fn prepare_generation(
     ),
     ApiError,
 > {
+    // Collapse every released H3 alias to one exact task/layout identity
+    // before activation, upload scope, admission, placement, queue, metadata,
+    // and retry state can observe the request. This is deliberately a no-op
+    // for every non-H3 configured alias and catalog ID.
+    mold_core::minimax_h3::canonicalize_request_model(request);
+
     // `hdr_exr_dir` names an output directory on the machine doing inference.
     // An HTTP client must never choose that server-local path: unlike media
     // inputs there is no useful remote artifact to return and no safe root to
@@ -1593,6 +1599,7 @@ async fn generate(
     authenticated: Option<Extension<crate::auth::ApiKeyAuthenticated>>,
     Json(mut req): Json<mold_core::GenerateRequest>,
 ) -> Result<Response, ApiError> {
+    mold_core::minimax_h3::canonicalize_request_model(&mut req);
     validate_live_server_batch_admission(&req)?;
     // Capture before prepare_generation: prompt expansion mutates req.prompt,
     // and history should hold what the user typed.
@@ -2606,6 +2613,7 @@ async fn generate_stream(
     headers: HeaderMap,
     Json(mut req): Json<mold_core::GenerateRequest>,
 ) -> Result<Response, ApiError> {
+    mold_core::minimax_h3::canonicalize_request_model(&mut req);
     let completion_payload = requested_sse_completion_payload(&headers)?;
     validate_live_server_batch_admission(&req)?;
     // Capture before prepare_generation: prompt expansion mutates req.prompt,
@@ -2819,8 +2827,9 @@ async fn list_models(State(state): State<AppState>) -> Json<Vec<ModelInfoExtende
 
 async fn generate_estimate(
     State(state): State<AppState>,
-    Json(req): Json<GenerateRequest>,
+    Json(mut req): Json<GenerateRequest>,
 ) -> Result<Json<mold_core::GenerationMemoryEstimate>, ApiError> {
+    mold_core::minimax_h3::canonicalize_request_model(&mut req);
     Ok(Json(
         model_manager::estimate_generation_memory(&state, &req).await?,
     ))
@@ -2847,6 +2856,7 @@ pub(crate) async fn placement_preview_for_request(
     mut request: GenerateRequest,
     copies: u32,
 ) -> mold_core::GenerationPlacementPreview {
+    mold_core::minimax_h3::canonicalize_request_model(&mut request);
     let plan = state.scheduled_work.latest_plan();
     let unavailable = |outcome: &str, reason: String| mold_core::GenerationPlacementPreview {
         version: 1,

--- a/desktop/src/lib/generateValidation.test.ts
+++ b/desktop/src/lib/generateValidation.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { newGenerateForm } from "./generateForm";
+import { inlineGenerationMediaBytes } from "./generateValidation";
+
+function formWithEveryH3MediaField() {
+  const form = newGenerateForm();
+  form.h3Authoring = {
+    firstFrame: {
+      filename: "first.png",
+      mimeType: "image/png",
+      width: 32,
+      height: 32,
+      data: "QUJD",
+    },
+    lastFrame: {
+      filename: "last.png",
+      mimeType: "image/png",
+      width: 32,
+      height: 32,
+      data: "REVG",
+    },
+    references: [
+      {
+        reference: {
+          kind: "image",
+          media: { authority: "inline", data: "R0hJ" },
+          provenance: { name: "reference.png" },
+          mime_type: "image/png",
+          width: 32,
+          height: 32,
+        },
+      },
+    ],
+  };
+  return form;
+}
+
+describe("inlineGenerationMediaBytes — MiniMax H3 active partition", () => {
+  it("counts only FL2VA boundaries and preserves replacement exclusion", () => {
+    const form = formWithEveryH3MediaField();
+    form.model = "minimax-h3-fl2va:official-bf16";
+
+    expect(inlineGenerationMediaBytes(form)).toBe(6);
+    expect(inlineGenerationMediaBytes(form, "h3FirstFrame")).toBe(3);
+    expect(inlineGenerationMediaBytes(form, "h3References")).toBe(6);
+  });
+
+  it("counts only ordered Ref2VA media and preserves replacement exclusion", () => {
+    const form = formWithEveryH3MediaField();
+    form.model = "minimax-h3-ref2va:comfy-pruned-int8";
+
+    expect(inlineGenerationMediaBytes(form)).toBe(3);
+    expect(inlineGenerationMediaBytes(form, "h3References")).toBe(0);
+    expect(inlineGenerationMediaBytes(form, "h3FirstFrame")).toBe(3);
+  });
+
+  it.each(["flux:replacement", "minimax-h3-ref2va:future-layout"])(
+    "ignores parked H3 media when %s has no released H3 wire task",
+    (model) => {
+      const form = formWithEveryH3MediaField();
+      form.model = model;
+
+      expect(inlineGenerationMediaBytes(form)).toBe(0);
+    },
+  );
+});

--- a/desktop/src/lib/generateValidation.ts
+++ b/desktop/src/lib/generateValidation.ts
@@ -26,7 +26,10 @@ export type InlineGenerationMediaField =
   | "sourceVideo"
   | "extendVideo"
   | "keyframes"
-  | "audioFile";
+  | "audioFile"
+  | "h3FirstFrame"
+  | "h3LastFrame"
+  | "h3References";
 
 export function decodedBase64Bytes(value: string | null | undefined): number {
   if (!value) return 0;
@@ -53,6 +56,18 @@ export function inlineGenerationMediaBytes(
       (sum, keyframe) => sum + decodedBase64Bytes(keyframe.image.base64),
       0,
     );
+  }
+  if (exclude !== "h3FirstFrame") {
+    total += decodedBase64Bytes(form.h3Authoring?.firstFrame?.data);
+  }
+  if (exclude !== "h3LastFrame") {
+    total += decodedBase64Bytes(form.h3Authoring?.lastFrame?.data);
+  }
+  if (exclude !== "h3References") {
+    total += (form.h3Authoring?.references ?? []).reduce((sum, draft) => {
+      const media = draft.reference.media;
+      return sum + (media.authority === "inline" ? decodedBase64Bytes(media.data) : 0);
+    }, 0);
   }
   return total;
 }

--- a/desktop/src/lib/generateValidation.ts
+++ b/desktop/src/lib/generateValidation.ts
@@ -9,6 +9,7 @@ import {
 } from "@studio/lib/resolutions";
 import { guidanceOverridesError } from "@studio/lib/guidanceOverrides";
 import { wanRecipeError } from "@studio/lib/wanRecipe";
+import { minimaxH3TaskForModel } from "@studio/lib/minimaxH3Authoring";
 
 export const MAX_INLINE_GENERATION_MEDIA_BYTES = 64 * 1024 * 1024;
 // JSON base64 expands bytes by roughly 4/3 and the server body limit is 64
@@ -57,13 +58,14 @@ export function inlineGenerationMediaBytes(
       0,
     );
   }
-  if (exclude !== "h3FirstFrame") {
+  const h3Task = minimaxH3TaskForModel(form.model);
+  if (h3Task === "fl2va" && exclude !== "h3FirstFrame") {
     total += decodedBase64Bytes(form.h3Authoring?.firstFrame?.data);
   }
-  if (exclude !== "h3LastFrame") {
+  if (h3Task === "fl2va" && exclude !== "h3LastFrame") {
     total += decodedBase64Bytes(form.h3Authoring?.lastFrame?.data);
   }
-  if (exclude !== "h3References") {
+  if (h3Task === "ref2va" && exclude !== "h3References") {
     total += (form.h3Authoring?.references ?? []).reduce((sum, draft) => {
       const media = draft.reference.media;
       return sum + (media.authority === "inline" ? decodedBase64Bytes(media.data) : 0);

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -4878,6 +4878,48 @@ describe("MobileApp gallery", () => {
     );
   });
 
+  it("appends a gallery source to the selected Ref2VA partition", async () => {
+    const ref2vaModel: ModelEntry = {
+      ...model,
+      name: "minimax-h3-ref2va:comfy-pruned-int8",
+      family: "minimax-h3",
+      default_steps: 50,
+      default_guidance: 0,
+      default_width: 1344,
+      default_height: 768,
+      default_frames: 124,
+      default_fps: 24,
+      supports_audio: true,
+    };
+    const still = { ...print, filename: "ordered subject.png", format: "png" as const };
+    apiJsonTo.mockImplementation((_target: unknown, path: string) => {
+      if (path === "/api/status") return Promise.resolve(status);
+      if (path === "/api/models") return Promise.resolve([ref2vaModel]);
+      if (path === "/api/gallery") return Promise.resolve([still]);
+      return Promise.reject(new Error(`Unexpected API path: ${path}`));
+    });
+    apiFetchTo.mockResolvedValue({
+      headers: new Headers({ "content-type": "image/png" }),
+      blob: () => Promise.resolve(new Blob(["subject bytes"], { type: "image/png" })),
+    } as Response);
+
+    wrapper = mountMobileApp();
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-tab-gallery']").trigger("click");
+    await flushPromises();
+    await wrapper.get("[data-test='gallery-item']").trigger("click");
+    await wrapper.get("[data-test='gallery-viewer-use-source']").trigger("click");
+    await vi.waitFor(() =>
+      expect(wrapper?.get("[data-test='mobile-generation-summary']").text()).toContain(
+        "reference 1",
+      ),
+    );
+
+    await wrapper.get("[data-test='mobile-open-advanced']").trigger("click");
+    await flushPromises();
+    expect(wrapper.get("[data-test='h3-reference-0']").text()).toContain("ordered subject.png");
+  });
+
   it("rejects an oversized gallery source before reading or base64 expansion", async () => {
     const still = { ...print, filename: "huge source.png", format: "png" as const };
     apiJsonTo.mockImplementation((_target: unknown, path: string) => {
@@ -5036,6 +5078,54 @@ describe("MobileApp gallery", () => {
       "page",
     );
     expect(wrapper.find("[data-test='gallery-viewer']").exists()).toBe(false);
+  });
+
+  it("keeps an H3 sequence snapshot in the viewer with an explicit refusal", async () => {
+    const sequenceModel: ModelEntry = {
+      ...model,
+      name: "ltx-video-0.9.8-2b-distilled:bf16",
+      family: "ltx-video",
+      supports_sequence: true,
+    } as ModelEntry;
+    const h3Sequence: GalleryImage = {
+      ...print,
+      filename: "invalid-h3-sequence.mp4",
+      metadata: {
+        ...print.metadata,
+        model: "minimax-h3-fl2va:official-bf16",
+        chain_job_id: "job-h3",
+        chain: {
+          stage_count: 2,
+          motion_tail_frames: 0,
+          stages: [
+            { prompt: "opening", frames: 25, transition: "smooth" },
+            { prompt: "closing", frames: 25, transition: "cut" },
+          ],
+        },
+      },
+    };
+    apiJsonTo.mockImplementation((_target: unknown, path: string) => {
+      if (path === "/api/status") return Promise.resolve(status);
+      if (path === "/api/models") return Promise.resolve([sequenceModel]);
+      if (path === "/api/gallery") return Promise.resolve([h3Sequence]);
+      return Promise.reject(new Error(`Unexpected API path: ${path}`));
+    });
+
+    const pinia = createPinia();
+    wrapper = mountMobileApp(pinia);
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-tab-gallery']").trigger("click");
+    await vi.waitFor(() => expect(wrapper?.find("[data-test='gallery-item']").exists()).toBe(true));
+    await wrapper.get("[data-test='gallery-item']").trigger("click");
+    await flushPromises();
+    await wrapper.get("[data-test='gallery-viewer-reuse']").trigger("click");
+    await flushPromises();
+
+    expect(wrapper.get(".gallery-viewer-reuse-error").text()).toContain(
+      "cannot render a clip sequence",
+    );
+    expect(wrapper.find("[data-test='gallery-viewer']").exists()).toBe(true);
+    expect(useSequenceDraftStore(pinia).output).toBe("single");
   });
 
   it("reloads model ownership after removing the active host before reuse", async () => {

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -51,7 +51,13 @@ import {
   type OutputMode,
 } from "@studio/lib/sequence";
 import { promptPlaceholder, promptRequired } from "@studio/lib/promptRequirement";
-import { isMinimaxH3Identity, minimaxH3AuthoringError } from "@studio/lib/minimaxH3Authoring";
+import {
+  appendMinimaxH3GalleryImageReference,
+  isMinimaxH3Identity,
+  minimaxH3AuthoringError,
+  minimaxH3TaskForModel,
+  setMinimaxH3GalleryImageFirstFrame,
+} from "@studio/lib/minimaxH3Authoring";
 import {
   classifyPlacementPreview,
   previewChainPlacement,
@@ -3796,6 +3802,10 @@ async function reusePrint(print: GalleryPrint): Promise<void> {
       return;
     }
     const reuse = applyMobileGalleryMetadata(form, print.metadata, generationModels.value);
+    if (reuse.sequenceUnsupportedReason) {
+      reusePrintError.value = reuse.sequenceUnsupportedReason;
+      return;
+    }
     if (reuse.sequence) {
       // A sequence print reloads the clip rail as a NEW draft: no edit
       // session, nothing cached (iPhone has no chain-detail recovery route,
@@ -3841,8 +3851,12 @@ async function useSelectedPrintAsSource(): Promise<void> {
   reusePrintError.value = "";
   try {
     const response = await apiFetchTo(print.target, galleryMediaPath(print.filename, "host"));
+    const h3Task = minimaxH3TaskForModel(form.model);
     const attachmentMode = caps.value.sourceImageMode !== "single";
-    const existingBytes = inlineGenerationMediaBytes(form, attachmentMode ? null : "sourceImage");
+    const existingBytes = inlineGenerationMediaBytes(
+      form,
+      h3Task === "fl2va" ? "h3FirstFrame" : attachmentMode ? null : "sourceImage",
+    );
     const exceedsBudget = (incomingBytes: number) =>
       existingBytes + incomingBytes > MAX_MOBILE_GENERATION_REQUEST_MEDIA_BYTES;
     // Reject from Content-Length before materialising the response Blob when
@@ -3856,7 +3870,34 @@ async function useSelectedPrintAsSource(): Promise<void> {
     if (blob.size === 0) throw new Error("That gallery image is empty.");
     if (exceedsBudget(blob.size)) throw new Error(MOBILE_MEDIA_BUDGET_ERROR);
     const base64 = await blobToBase64(blob);
-    if (attachmentMode) {
+    if (h3Task) {
+      const dimensions = imageDimensionsFromBase64(base64) ?? {
+        width: print.metadata.width,
+        height: print.metadata.height,
+      };
+      const image = {
+        filename: print.filename,
+        mimeType: galleryImageMimeType(print, blob.type),
+        width: dimensions.width,
+        height: dimensions.height,
+        data: base64,
+      };
+      const result =
+        h3Task === "ref2va"
+          ? appendMinimaxH3GalleryImageReference(form.h3Authoring, image)
+          : setMinimaxH3GalleryImageFirstFrame(form.h3Authoring, image);
+      if (!result.ok) throw new Error(result.error);
+      form.h3Authoring = result.state;
+      setGenerationStatus(
+        h3Task === "ref2va"
+          ? `Added gallery print as reference ${result.reference}`
+          : "Gallery print selected as first frame",
+      );
+    } else if (isMinimaxH3Identity(form.family, form.model)) {
+      throw new Error(
+        "Choose an explicit MiniMax H3 FL2VA or Ref2VA model before adding a source.",
+      );
+    } else if (attachmentMode) {
       form.imageAttachments = [base64, ...form.imageAttachments].slice(
         0,
         isFlux2DevModel(form.model) ? 4 : undefined,
@@ -3879,6 +3920,15 @@ async function useSelectedPrintAsSource(): Promise<void> {
   } finally {
     usingPrintAsSource.value = false;
   }
+}
+
+function galleryImageMimeType(print: GalleryImage, declared: string): string {
+  const mime = declared.split(";", 1)[0]!.trim().toLowerCase();
+  if (mime.startsWith("image/")) return mime;
+  const format = (print.format ?? print.filename.split(".").pop() ?? "")
+    .toLowerCase()
+    .replace("jpg", "jpeg");
+  return format ? `image/${format}` : "application/octet-stream";
 }
 
 function openPrint(print: GalleryPrint): void {

--- a/desktop/src/mobile/reuse.test.ts
+++ b/desktop/src/mobile/reuse.test.ts
@@ -147,6 +147,103 @@ describe("applyMobileGalleryMetadata", () => {
     expect(buildRequest(form).upscale_model).toBeUndefined();
   });
 
+  it("preserves a recorded Ref2VA partition instead of substituting another model", () => {
+    const replacement = {
+      ...model,
+      name: "flux:replacement",
+      family: "flux",
+      default_width: 1024,
+      default_height: 1024,
+    } as ModelEntry;
+    const form = newGenerateForm();
+
+    const result = applyMobileGalleryMetadata(
+      form,
+      {
+        ...metadata,
+        model: "MiniMax_H3_Ref2VA",
+        output_format: "mp4",
+        references: [
+          {
+            kind: "image",
+            index: 1,
+            name: "subject.png",
+            sha256: "a".repeat(64),
+            mime_type: "image/png",
+            width: 1024,
+            height: 768,
+          },
+        ],
+      },
+      [replacement],
+    );
+
+    expect(result).toMatchObject({
+      modelName: "minimax-h3-ref2va:comfy-pruned-int8",
+      substitutedModel: false,
+    });
+    expect(form).toMatchObject({
+      model: "minimax-h3-ref2va:comfy-pruned-int8",
+      family: "minimax-h3",
+      outputFormat: "mp4",
+    });
+    expect(form.h3Authoring?.references[0]?.reference).toMatchObject({
+      kind: "image",
+      media: { authority: "descriptor" },
+      provenance: { name: "subject.png" },
+    });
+  });
+
+  it("matches a legacy Ref2VA alias to its installed canonical checkpoint", () => {
+    const ref2va = {
+      ...model,
+      name: "minimax-h3-ref2va:comfy-pruned-int8",
+      family: "minimax-h3",
+      default_width: 1344,
+      default_height: 768,
+      default_steps: 50,
+      default_guidance: 0,
+    } as ModelEntry;
+    const form = newGenerateForm();
+
+    const result = applyMobileGalleryMetadata(
+      form,
+      { ...metadata, model: "minimax_h3_ref2va", output_format: "mp4" },
+      [ref2va],
+    );
+
+    expect(result.substitutedModel).toBe(false);
+    expect(form.model).toBe(ref2va.name);
+    expect(form.family).toBe("minimax-h3");
+  });
+
+  it("preserves a missing official FL2VA checkpoint for exact-model recovery", () => {
+    const replacement = {
+      ...model,
+      name: "minimax-h3-fl2va:comfy-pruned-int8",
+      family: "minimax-h3",
+    } as ModelEntry;
+    const form = newGenerateForm();
+
+    const result = applyMobileGalleryMetadata(
+      form,
+      {
+        ...metadata,
+        model: "minimax-h3-fl2va:official-bf16",
+        output_format: "mp4",
+      },
+      [replacement],
+    );
+
+    expect(result).toMatchObject({
+      modelName: "minimax-h3-fl2va:official-bf16",
+      substitutedModel: false,
+      sequence: null,
+    });
+    expect(form.model).toBe("minimax-h3-fl2va:official-bf16");
+    expect(form.family).toBe("minimax-h3");
+  });
+
   it("restores a wan print's solver and recipe", () => {
     const wan = {
       ...model,
@@ -287,6 +384,29 @@ describe("applyMobileGalleryMetadata — sequence prints", () => {
     expect(result.substitutedModel).toBe(true);
     expect(result.modelName).toBe(other.name);
     expect(result.sequence?.clips).toHaveLength(2);
+  });
+
+  it("fails an H3 sequence explicitly without substituting another partition", () => {
+    const other = {
+      ...sequenceModel,
+      name: "ltx-video-0.9.8-2b-distilled:q8",
+    } as ModelEntry;
+    const form = newGenerateForm();
+    const initialModel = form.model;
+    const result = applyMobileGalleryMetadata(
+      form,
+      chainPrint([25, 25], { model: "minimax-h3-fl2va:official-bf16" }),
+      [other],
+    );
+
+    expect(result).toMatchObject({
+      modelName: "minimax-h3-fl2va:official-bf16",
+      substitutedModel: false,
+      sequence: null,
+    });
+    expect(result.sequenceUnsupportedReason).toContain("cannot render a clip sequence");
+    expect(form.model).toBe(initialModel);
+    expect(form.model).not.toBe(other.name);
   });
 
   it("reports what the print could not give back", () => {

--- a/desktop/src/mobile/reuse.test.ts
+++ b/desktop/src/mobile/reuse.test.ts
@@ -244,6 +244,43 @@ describe("applyMobileGalleryMetadata", () => {
     expect(form.family).toBe("minimax-h3");
   });
 
+  it.each([
+    ["unavailable", []],
+    [
+      "installed",
+      [
+        {
+          ...model,
+          name: "minimax-h3-ref2va:future-layout",
+          family: "minimax-h3",
+        } as ModelEntry,
+      ],
+    ],
+  ])("keeps an %s unknown H3 one-shot inside its fail-closed family", (_state, installed) => {
+    const replacement = {
+      ...model,
+      name: "flux:replacement",
+      family: "flux",
+    } as ModelEntry;
+    const form = newGenerateForm();
+    const unknown = "minimax-h3-ref2va:future-layout";
+
+    const result = applyMobileGalleryMetadata(
+      form,
+      { ...metadata, model: unknown, output_format: "mp4" },
+      [...installed, replacement],
+    );
+
+    expect(result).toMatchObject({
+      modelName: unknown,
+      substitutedModel: false,
+      sequence: null,
+    });
+    expect(form.model).toBe(unknown);
+    expect(form.family).toBe("minimax-h3");
+    expect(form.model).not.toBe(replacement.name);
+  });
+
   it("restores a wan print's solver and recipe", () => {
     const wan = {
       ...model,
@@ -408,6 +445,39 @@ describe("applyMobileGalleryMetadata — sequence prints", () => {
     expect(form.model).toBe(initialModel);
     expect(form.model).not.toBe(other.name);
   });
+
+  it.each(["unavailable", "installed"])(
+    "refuses an %s unknown H3 sequence without mutating the form",
+    (availability) => {
+      const unknown = "minimax-h3-ref2va:future-layout";
+      const other = {
+        ...sequenceModel,
+        name: "ltx-video-0.9.8-2b-distilled:q8",
+      } as ModelEntry;
+      const installedUnknown = {
+        ...sequenceModel,
+        name: unknown,
+        family: "minimax-h3",
+      } as ModelEntry;
+      const form = newGenerateForm();
+      form.prompt = "parked one shot";
+      const before = structuredClone(form);
+
+      const result = applyMobileGalleryMetadata(
+        form,
+        chainPrint([25, 25], { model: unknown }),
+        availability === "installed" ? [installedUnknown, other] : [other],
+      );
+
+      expect(result).toMatchObject({
+        modelName: unknown,
+        substitutedModel: false,
+        sequence: null,
+      });
+      expect(result.sequenceUnsupportedReason).toContain("cannot render a clip sequence");
+      expect(form).toEqual(before);
+    },
+  );
 
   it("reports what the print could not give back", () => {
     const form = newGenerateForm();

--- a/desktop/src/mobile/reuse.ts
+++ b/desktop/src/mobile/reuse.ts
@@ -14,6 +14,7 @@ import {
 import { applyMetadataToForm, type GenerateForm } from "../lib/generateForm";
 import { emptyGuidanceOverrides } from "@studio/lib/guidanceOverrides";
 import { emptyWanRecipe } from "@studio/lib/wanRecipe";
+import { canonicalMinimaxH3ModelName } from "@studio/lib/minimaxH3Authoring";
 
 /** The clip rail a sequence print reloads, plus what it could not give back. */
 export interface MobileSequenceReuse {
@@ -29,6 +30,9 @@ export interface MobileGalleryReuseResult {
   substitutedModel: boolean;
   /** Non-null only for a print stitched from a sequence (`metadata.chain`). */
   sequence: MobileSequenceReuse | null;
+  /** Present when durable metadata claims a sequence for a model partition
+   * that cannot safely be reinterpreted as a sequence-capable checkpoint. */
+  sequenceUnsupportedReason?: string;
 }
 
 /**
@@ -48,20 +52,55 @@ export function applyMobileGalleryMetadata(
 ): MobileGalleryReuseResult {
   const plan = planSequenceReuse(metadata);
   const oneShotPrompt = form.prompt;
-  const originalModelInstalled = models.some((model) => model.name === metadata.model);
+  const canonicalRecordedModel = canonicalMinimaxH3ModelName(metadata.model);
+  const installedRecordedModel = models.find(
+    (model) =>
+      model.name === metadata.model ||
+      (canonicalRecordedModel !== null &&
+        canonicalMinimaxH3ModelName(model.name) === canonicalRecordedModel),
+  );
+  const originalModelInstalled = installedRecordedModel !== undefined;
+  // Every released H3 identity binds both task and weight layout. If its exact
+  // checkpoint is not installed, preserve that unavailable selection so the
+  // existing missing-model recovery can repair it; substituting any other
+  // installed model could change the task or quantized/official layout.
+  const preserveMissingH3 = !originalModelInstalled && canonicalRecordedModel !== null;
+
+  // H3 is one-shot-only. A malformed or future durable snapshot must not turn
+  // an H3 chain into an unrelated installed sequence model merely because the
+  // original exact checkpoint is absent. Leave the form untouched and give
+  // the caller a concrete recovery error instead.
+  if (plan && canonicalRecordedModel !== null) {
+    return {
+      modelName: canonicalRecordedModel,
+      substitutedModel: false,
+      sequence: null,
+      sequenceUnsupportedReason:
+        "This print records a MiniMax H3 checkpoint, which cannot render a clip sequence.",
+    };
+  }
   // A sequence must fall back to a SEQUENCE-capable model; the first installed
   // model could be an image model the clip rail can never render.
   const candidates = plan ? modelsForOutput(models, "sequence") : models;
   const fallbackModel =
     candidates.find((model) => model.name === form.model) ?? candidates[0] ?? models[0];
-  const mobileMetadata =
-    originalModelInstalled || !fallbackModel
-      ? metadata
-      : { ...metadata, model: fallbackModel.name };
+  const mobileMetadata = installedRecordedModel
+    ? { ...metadata, model: installedRecordedModel.name }
+    : preserveMissingH3
+      ? { ...metadata, model: canonicalRecordedModel ?? metadata.model }
+      : !fallbackModel
+        ? metadata
+        : { ...metadata, model: fallbackModel.name };
 
   applyMetadataToForm(form, mobileMetadata, models);
 
-  if (!originalModelInstalled && fallbackModel) {
+  if (preserveMissingH3) {
+    form.model = mobileMetadata.model;
+    form.family = "minimax-h3";
+  }
+
+  const substitutedModel = !originalModelInstalled && !preserveMissingH3 && !!fallbackModel;
+  if (substitutedModel) {
     // Adapters and auxiliary models are host/model artifacts, not portable
     // print settings. Replaying them against a fallback can fail outright or,
     // worse, produce a result with unrelated weights.
@@ -107,7 +146,7 @@ export function applyMobileGalleryMetadata(
 
   return {
     modelName: form.model,
-    substitutedModel: !originalModelInstalled && !!fallbackModel,
+    substitutedModel,
     sequence,
   };
 }

--- a/desktop/src/mobile/reuse.ts
+++ b/desktop/src/mobile/reuse.ts
@@ -14,7 +14,7 @@ import {
 import { applyMetadataToForm, type GenerateForm } from "../lib/generateForm";
 import { emptyGuidanceOverrides } from "@studio/lib/guidanceOverrides";
 import { emptyWanRecipe } from "@studio/lib/wanRecipe";
-import { canonicalMinimaxH3ModelName } from "@studio/lib/minimaxH3Authoring";
+import { canonicalMinimaxH3ModelName, isMinimaxH3Identity } from "@studio/lib/minimaxH3Authoring";
 
 /** The clip rail a sequence print reloads, plus what it could not give back. */
 export interface MobileSequenceReuse {
@@ -53,6 +53,7 @@ export function applyMobileGalleryMetadata(
   const plan = planSequenceReuse(metadata);
   const oneShotPrompt = form.prompt;
   const canonicalRecordedModel = canonicalMinimaxH3ModelName(metadata.model);
+  const recordedH3Identity = isMinimaxH3Identity(null, metadata.model);
   const installedRecordedModel = models.find(
     (model) =>
       model.name === metadata.model ||
@@ -60,19 +61,19 @@ export function applyMobileGalleryMetadata(
         canonicalMinimaxH3ModelName(model.name) === canonicalRecordedModel),
   );
   const originalModelInstalled = installedRecordedModel !== undefined;
-  // Every released H3 identity binds both task and weight layout. If its exact
-  // checkpoint is not installed, preserve that unavailable selection so the
-  // existing missing-model recovery can repair it; substituting any other
-  // installed model could change the task or quantized/official layout.
-  const preserveMissingH3 = !originalModelInstalled && canonicalRecordedModel !== null;
+  // Every H3-shaped identity is a fail-closed family boundary. Released
+  // aliases canonicalize to their exact task/layout; an unknown future
+  // partition remains byte-for-byte unavailable instead of being guessed or
+  // substituted into another family.
+  const preserveMissingH3 = !originalModelInstalled && recordedH3Identity;
 
   // H3 is one-shot-only. A malformed or future durable snapshot must not turn
   // an H3 chain into an unrelated installed sequence model merely because the
   // original exact checkpoint is absent. Leave the form untouched and give
   // the caller a concrete recovery error instead.
-  if (plan && canonicalRecordedModel !== null) {
+  if (plan && recordedH3Identity) {
     return {
-      modelName: canonicalRecordedModel,
+      modelName: canonicalRecordedModel ?? metadata.model,
       substitutedModel: false,
       sequence: null,
       sequenceUnsupportedReason:

--- a/desktop/src/views/LibraryView.test.ts
+++ b/desktop/src/views/LibraryView.test.ts
@@ -242,6 +242,43 @@ describe("LibraryView delete keyboard handling", () => {
     wrapper.unmount();
   });
 
+  it("appends a Library source image to Ref2VA's dedicated ordered references", async () => {
+    const remotePrint: GalleryImage = {
+      ...prints[0]!,
+      filename: "ordered-subject.png",
+      timestamp: 3,
+      metadata: { ...prints[0]!.metadata, seed: 9 },
+    };
+    apiFetchTo.mockResolvedValueOnce(new Response(new Uint8Array([65, 66, 67])));
+    const { wrapper, router } = await mountView(remotePrint);
+    const form = useGenerateFormStore().form;
+    form.model = "minimax-h3-ref2va:comfy-pruned-int8";
+    form.family = "minimax-h3";
+
+    const tile = wrapper.findAll("button").find((button) => button.text().includes("S 9"));
+    expect(tile).toBeDefined();
+    await tile!.trigger("contextmenu");
+    const menu = useContextMenuStore();
+    const sourceEntry = menu.entries.find(
+      (entry) => !("separator" in entry) && entry.label === "Use as source",
+    )!;
+    menu.activate(sourceEntry);
+    await flushPromises();
+
+    expect(form.sourceImage).toBeNull();
+    expect(form.h3Authoring?.references).toHaveLength(1);
+    expect(form.h3Authoring?.references[0]?.reference).toMatchObject({
+      kind: "image",
+      media: { authority: "inline", data: "QUJD" },
+      provenance: { name: "ordered-subject.png" },
+      mime_type: "image/png",
+      width: 1024,
+      height: 1024,
+    });
+    expect(router.currentRoute.value.path).toBe("/create");
+    wrapper.unmount();
+  });
+
   it.each(["Delete", "Backspace"])(
     "prevents %s navigation and only DELETEs after the undo window",
     async (key) => {

--- a/desktop/src/views/LibraryView.vue
+++ b/desktop/src/views/LibraryView.vue
@@ -49,6 +49,13 @@ import { allowsNativeContextMenu } from "../lib/shortcuts";
 import { modelDisplayNameForId } from "../lib/models";
 import type { GalleryImage } from "../lib/api/types";
 import { isUpscaledImage } from "../lib/gallery/upscaled";
+import { imageDimensionsFromBase64 } from "@studio/lib/imageDimensions";
+import {
+  appendMinimaxH3GalleryImageReference,
+  isMinimaxH3Identity,
+  minimaxH3TaskForModel,
+  setMinimaxH3GalleryImageFirstFrame,
+} from "@studio/lib/minimaxH3Authoring";
 
 const GAP = 8;
 const PAD = 16;
@@ -110,12 +117,15 @@ const canReveal = (entry: MergedPrint) =>
 const canSaveLocally = (entry: MergedPrint) =>
   inTauri() && gallery.hostFor(entry.sourceKey)?.kind === "remote" && !gallery.existsLocally(entry);
 
-/** Authed source bytes for a host-gallery item, as base64 (origin-aware). */
-async function fetchItemBase64(entry: MergedPrint): Promise<string> {
+/** Authed source bytes for a host-gallery item (origin-aware). */
+async function fetchItemBlob(entry: MergedPrint): Promise<Blob> {
   const path = mediaPath(entry.item.filename);
   const target = targetFor(entry);
-  const blob = await (target ? apiFetchTo(target, path) : apiFetch(path)).then((r) => r.blob());
-  return blobToBase64(blob);
+  return (target ? apiFetchTo(target, path) : apiFetch(path)).then((r) => r.blob());
+}
+
+async function fetchItemBase64(entry: MergedPrint): Promise<string> {
+  return blobToBase64(await fetchItemBlob(entry));
 }
 
 async function saveToThisMac(entry: MergedPrint) {
@@ -702,16 +712,52 @@ function removeSelected() {
  */
 async function useAsSource(entry: MergedPrint) {
   try {
-    const base64 = await fetchItemBase64(entry);
-    generateForm.form.sourceImage = base64;
-    generateForm.form.sourceImageName = entry.item.filename;
-    generateForm.form.sourceFit = { mode: "lanczos-resize" };
+    const blob = await fetchItemBlob(entry);
+    const base64 = await blobToBase64(blob);
+    const form = generateForm.form;
+    const h3Task = minimaxH3TaskForModel(form.model);
+    if (h3Task) {
+      const dimensions = imageDimensionsFromBase64(base64) ?? {
+        width: entry.item.metadata.width,
+        height: entry.item.metadata.height,
+      };
+      const image = {
+        filename: entry.item.filename,
+        mimeType: galleryImageMimeType(entry.item, blob.type),
+        width: dimensions.width,
+        height: dimensions.height,
+        data: base64,
+      };
+      const result =
+        h3Task === "ref2va"
+          ? appendMinimaxH3GalleryImageReference(form.h3Authoring, image)
+          : setMinimaxH3GalleryImageFirstFrame(form.h3Authoring, image);
+      if (!result.ok) throw new Error(result.error);
+      form.h3Authoring = result.state;
+    } else if (isMinimaxH3Identity(form.family, form.model)) {
+      throw new Error(
+        "Choose an explicit MiniMax H3 FL2VA or Ref2VA model before adding a source.",
+      );
+    } else {
+      form.sourceImage = base64;
+      form.sourceImageName = entry.item.filename;
+      form.sourceFit = { mode: "lanczos-resize" };
+    }
     lightboxOpen.value = false;
-    toasts.push("Loaded as source");
+    toasts.push(h3Task === "ref2va" ? "Added as ordered reference" : "Loaded as source");
     void router.push("/create");
   } catch (error) {
     toasts.push(error instanceof Error ? error.message : String(error), "error");
   }
+}
+
+function galleryImageMimeType(item: GalleryImage, declared: string): string {
+  const mime = declared.split(";", 1)[0]!.trim().toLowerCase();
+  if (mime.startsWith("image/")) return mime;
+  const format = (item.format ?? item.filename.split(".").pop() ?? "")
+    .toLowerCase()
+    .replace("jpg", "jpeg");
+  return format ? `image/${format}` : "application/octet-stream";
 }
 
 async function useSelectedAsSource() {

--- a/studio/lib/minimaxH3Authoring.test.ts
+++ b/studio/lib/minimaxH3Authoring.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from "vitest";
 import type { GenerationReference } from "./generationReferences";
 import {
   MINIMAX_H3_FIXED_FPS,
+  MINIMAX_H3_REF2VA_COMFY,
   MINIMAX_H3_RESYNTHESIS_GUIDANCE,
+  appendMinimaxH3GalleryImageReference,
+  canonicalMinimaxH3ModelName,
   emptyMinimaxH3AuthoringState,
   isMinimaxH3Family,
   isMinimaxH3Identity,
@@ -16,6 +19,7 @@ import {
   minimaxH3TaskForModel,
   moveMinimaxH3Reference,
   serializeMinimaxH3Authoring,
+  setMinimaxH3GalleryImageFirstFrame,
 } from "./minimaxH3Authoring";
 
 const image = (name: string): GenerationReference => ({
@@ -67,6 +71,118 @@ describe("MiniMax H3 Studio authority", () => {
     expect(minimaxH3TaskForModel("hf:opaque")).toBeNull();
     expect(isMinimaxH3Identity(null, "minimax_h3_ref2va")).toBe(true);
     expect(isMinimaxH3Identity(null, "hf:opaque")).toBe(false);
+    expect(isMinimaxH3Identity(null, "minimax-h3-ref2va:future")).toBe(true);
+    expect(canonicalMinimaxH3ModelName(" MiniMax_H3_Ref2VA ")).toBe(
+      MINIMAX_H3_REF2VA_COMFY,
+    );
+    expect(canonicalMinimaxH3ModelName("minimax-h3-ref2va:future")).toBeNull();
+  });
+
+  it.each([
+    ["MiniMax_H3", "minimax-h3-fl2va:comfy-pruned-int8"],
+    ["MiniMax_H3_Ref2VA", "minimax-h3-ref2va:comfy-pruned-int8"],
+    ["MiniMax_H3_FL2VA:OFFICIAL_BF16", "minimax-h3-fl2va:official-bf16"],
+    [
+      "minimax-h3-ref2va:comfy-pruned-int8",
+      "minimax-h3-ref2va:comfy-pruned-int8",
+    ],
+  ])("canonicalizes %s inside the frozen H3 request", (model, expected) => {
+    const request = serializeMinimaxH3Authoring(
+      { model, frames: 124 },
+      null,
+      model,
+      emptyMinimaxH3AuthoringState(),
+    );
+    expect(request.model).toBe(expected);
+  });
+
+  it("keeps an unknown H3 partition unchanged while failing its task projection closed", () => {
+    const model = "minimax-h3-ref2va:future-layout";
+    const request = serializeMinimaxH3Authoring(
+      {
+        model,
+        frames: 124,
+        source_image: "STALE",
+        references: [image("stale.png")],
+      },
+      "minimax-h3",
+      model,
+      emptyMinimaxH3AuthoringState(),
+    );
+    expect(request.model).toBe(model);
+    expect(request).not.toHaveProperty("source_image");
+    expect(request).not.toHaveProperty("references");
+    expect(minimaxH3AuthoringError(null, model, null)).toContain(
+      "explicit FL2VA or Ref2VA",
+    );
+  });
+
+  it("appends a gallery image as the final ordered inline Ref2VA reference", () => {
+    const state = emptyMinimaxH3AuthoringState();
+    const original = { reference: video("motion.mp4") };
+    state.references = [original];
+
+    const result = appendMinimaxH3GalleryImageReference(state, {
+      filename: " subject.png ",
+      mimeType: "image/png; charset=binary",
+      width: 1280,
+      height: 720,
+      data: "SUBJECT",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.reference).toBe(2);
+    expect(result.state.references[0]).toBe(original);
+    expect(result.state.references[1]?.reference).toEqual({
+      kind: "image",
+      media: { authority: "inline", data: "SUBJECT" },
+      provenance: { name: "subject.png" },
+      mime_type: "image/png",
+      width: 1280,
+      height: 720,
+    });
+  });
+
+  it("enforces gallery reference limits and maps FL2VA source to its first frame", () => {
+    const images = Array.from({ length: 9 }, (_, index) => ({
+      reference: image(`${index}.png`),
+    }));
+    const rejected = appendMinimaxH3GalleryImageReference(
+      { ...emptyMinimaxH3AuthoringState(), references: images },
+      {
+        filename: "overflow.png",
+        mimeType: "image/png",
+        width: 10,
+        height: 10,
+        data: "OVERFLOW",
+      },
+    );
+    expect(rejected).toEqual({
+      ok: false,
+      error: "Use at most 9 image references.",
+    });
+
+    const boundary = setMinimaxH3GalleryImageFirstFrame(null, {
+      filename: "opening.jpg",
+      mimeType: "image/jpeg",
+      width: 640,
+      height: 480,
+      data: "OPENING",
+    });
+    expect(boundary).toMatchObject({
+      ok: true,
+      reference: null,
+      state: {
+        firstFrame: {
+          filename: "opening.jpg",
+          mimeType: "image/jpeg",
+          width: 640,
+          height: 480,
+          data: "OPENING",
+        },
+      },
+    });
   });
 
   it("restores opening-frame gallery provenance as explicitly missing media", () => {

--- a/studio/lib/minimaxH3Authoring.ts
+++ b/studio/lib/minimaxH3Authoring.ts
@@ -30,6 +30,11 @@ export const MINIMAX_H3_PROMPT_PLACEHOLDER =
 
 export type MinimaxH3Task = "fl2va" | "ref2va";
 
+export const MINIMAX_H3_FL2VA_OFFICIAL = "minimax-h3-fl2va:official-bf16";
+export const MINIMAX_H3_REF2VA_OFFICIAL = "minimax-h3-ref2va:official-bf16";
+export const MINIMAX_H3_FL2VA_COMFY = "minimax-h3-fl2va:comfy-pruned-int8";
+export const MINIMAX_H3_REF2VA_COMFY = "minimax-h3-ref2va:comfy-pruned-int8";
+
 /** Browser-owned first/last-frame authority. The raw bytes live in IndexedDB
  * when a draft/template is persisted; only the small descriptor is allowed in
  * localStorage. */
@@ -82,6 +87,34 @@ function normalize(value: string): string {
   return value.trim().toLowerCase().replaceAll("_", "-");
 }
 
+/** Browser-side mirror of the server's released H3 alias resolver. Opaque
+ * catalog IDs and unknown future variants stay unresolved instead of being
+ * guessed into a task/layout partition. */
+export function canonicalMinimaxH3ModelName(
+  model: string | null | undefined,
+): string | null {
+  const value = normalize(model ?? "");
+  if (
+    value === "minimax-h3" ||
+    value === "minimaxh3" ||
+    value === "minimax-h3-fl2va"
+  ) {
+    return MINIMAX_H3_FL2VA_COMFY;
+  }
+  if (value === "minimax-h3-ref2va") {
+    return MINIMAX_H3_REF2VA_COMFY;
+  }
+  if (
+    value === MINIMAX_H3_FL2VA_OFFICIAL ||
+    value === MINIMAX_H3_REF2VA_OFFICIAL ||
+    value === MINIMAX_H3_FL2VA_COMFY ||
+    value === MINIMAX_H3_REF2VA_COMFY
+  ) {
+    return value;
+  }
+  return null;
+}
+
 export function isMinimaxH3Family(family: string | null | undefined): boolean {
   const value = normalize(family ?? "").replaceAll("-", "");
   return value === "minimaxh3";
@@ -92,33 +125,147 @@ export function isMinimaxH3Family(family: string | null | undefined): boolean {
 export function minimaxH3TaskForModel(
   model: string | null | undefined,
 ): MinimaxH3Task | null {
-  const value = normalize(model ?? "");
-  if (value === "minimax-h3-ref2va" || value.startsWith("minimax-h3-ref2va:")) {
+  const value = canonicalMinimaxH3ModelName(model);
+  if (value?.startsWith("minimax-h3-ref2va:")) {
     return "ref2va";
   }
-  if (
-    value === "minimax-h3" ||
-    value === "minimaxh3" ||
-    value === "minimax-h3-fl2va" ||
-    value.startsWith("minimax-h3-fl2va:")
-  ) {
+  if (value?.startsWith("minimax-h3-fl2va:")) {
     return "fl2va";
   }
   return null;
 }
 
-/** Family metadata can be absent in durable gallery/request snapshots. Exact
- * released model identities still carry enough authority to recover the H3
- * contract without guessing opaque catalog IDs. */
+/** Family metadata can be absent in durable gallery/request snapshots. An
+ * H3-shaped model name still identifies the family boundary, while task and
+ * layout resolution remain restricted to the exact released identities. */
 export function isMinimaxH3Identity(
   family: string | null | undefined,
   model: string | null | undefined,
 ): boolean {
-  return isMinimaxH3Family(family) || minimaxH3TaskForModel(model) !== null;
+  if (isMinimaxH3Family(family)) return true;
+  const value = normalize(model ?? "");
+  return (
+    value === "minimax-h3" ||
+    value === "minimaxh3" ||
+    value === "minimax-h3-fl2va" ||
+    value === "minimax-h3-ref2va" ||
+    value.startsWith("minimax-h3-fl2va:") ||
+    value.startsWith("minimax-h3-ref2va:")
+  );
 }
 
 export function emptyMinimaxH3AuthoringState(): MinimaxH3AuthoringState {
   return { firstFrame: null, lastFrame: null, references: [] };
+}
+
+export interface MinimaxH3GalleryImageSource {
+  filename: string;
+  mimeType: string;
+  width: number;
+  height: number;
+  /** Raw base64 without a data-URI prefix. */
+  data: string;
+  sha256?: string | null;
+}
+
+export type MinimaxH3GalleryImageResult =
+  | {
+      ok: true;
+      state: MinimaxH3AuthoringState;
+      /** One-based ordered reference position; null for an FL2VA boundary. */
+      reference: number | null;
+    }
+  | { ok: false; error: string };
+
+function validateGalleryImageSource(
+  image: MinimaxH3GalleryImageSource,
+): string | null {
+  if (!image.filename.trim()) return "The gallery image needs a filename.";
+  const mimeType = image.mimeType.split(";", 1)[0]!.trim().toLowerCase();
+  if (!mimeType.startsWith("image/")) {
+    return "Only gallery images can be used as MiniMax H3 visual references.";
+  }
+  if (
+    !Number.isInteger(image.width) ||
+    image.width <= 0 ||
+    !Number.isInteger(image.height) ||
+    image.height <= 0
+  ) {
+    return "The gallery image dimensions could not be read.";
+  }
+  if (!image.data.trim()) return "The gallery image is empty.";
+  return null;
+}
+
+/** Append one gallery print to the authoritative Ref2VA order as inline media.
+ * The returned state is shallowly immutable: existing potentially-large media
+ * strings are retained without a JSON-clone, while the ordered array and new
+ * row are fresh objects for Vue reactivity. */
+export function appendMinimaxH3GalleryImageReference(
+  state: MinimaxH3AuthoringState | null | undefined,
+  image: MinimaxH3GalleryImageSource,
+): MinimaxH3GalleryImageResult {
+  const invalid = validateGalleryImageSource(image);
+  if (invalid) return { ok: false, error: invalid };
+  const current = state ?? emptyMinimaxH3AuthoringState();
+  const budget = minimaxH3ReferenceBudget(current.references);
+  if (budget.total >= MINIMAX_H3_MAX_REFERENCES) {
+    return {
+      ok: false,
+      error: `Use at most ${MINIMAX_H3_MAX_REFERENCES} references total.`,
+    };
+  }
+  if (budget.images >= MINIMAX_H3_MAX_REFERENCE_IMAGES) {
+    return {
+      ok: false,
+      error: `Use at most ${MINIMAX_H3_MAX_REFERENCE_IMAGES} image references.`,
+    };
+  }
+  const mimeType = image.mimeType.split(";", 1)[0]!.trim().toLowerCase();
+  const reference: GenerationReference = {
+    kind: "image",
+    media: { authority: "inline", data: image.data },
+    provenance: {
+      name: image.filename.trim(),
+      ...(image.sha256 ? { sha256: image.sha256.toLowerCase() } : {}),
+    },
+    mime_type: mimeType,
+    width: image.width,
+    height: image.height,
+  };
+  const references = [...current.references, { reference }];
+  return {
+    ok: true,
+    state: { ...current, references },
+    reference: references.length,
+  };
+}
+
+/** Use one gallery print as the FL2VA opening boundary. Kept beside the
+ * ordered-reference helper so every Library surface validates identical image
+ * facts before writing dedicated H3 authoring state. */
+export function setMinimaxH3GalleryImageFirstFrame(
+  state: MinimaxH3AuthoringState | null | undefined,
+  image: MinimaxH3GalleryImageSource,
+): MinimaxH3GalleryImageResult {
+  const invalid = validateGalleryImageSource(image);
+  if (invalid) return { ok: false, error: invalid };
+  const current = state ?? emptyMinimaxH3AuthoringState();
+  return {
+    ok: true,
+    state: {
+      ...current,
+      firstFrame: {
+        filename: image.filename.trim(),
+        mimeType: image.mimeType.split(";", 1)[0]!.trim().toLowerCase(),
+        width: image.width,
+        height: image.height,
+        data: image.data,
+        ...(image.sha256 ? { sha256: image.sha256.toLowerCase() } : {}),
+      },
+    },
+    reference: null,
+  };
 }
 
 export function cloneMinimaxH3AuthoringState(
@@ -388,6 +535,7 @@ export function minimaxH3AuthoringError(
 
 type H3Request = {
   frames?: number | null;
+  model?: string;
 };
 
 const FOREIGN_H3_FIELDS = [
@@ -452,6 +600,8 @@ export function serializeMinimaxH3Authoring<T extends H3Request>(
     strength: 1,
     output_format: "mp4",
   };
+  const canonicalModel = canonicalMinimaxH3ModelName(model);
+  if (canonicalModel) next.model = canonicalModel;
   for (const field of FOREIGN_H3_FIELDS) delete next[field];
   delete next.edit_images;
 

--- a/web/src/pages/LibraryPage.test.ts
+++ b/web/src/pages/LibraryPage.test.ts
@@ -269,6 +269,31 @@ describe("LibraryPage", () => {
     );
   });
 
+  it("appends Library source images to Ref2VA's dedicated ordered references", async () => {
+    const form = useGenerateForm();
+    form.state.value.model = "minimax-h3-ref2va:comfy-pruned-int8";
+    form.state.value.modelFamily = "minimax-h3";
+    const wrapper = await mounted();
+
+    await wrapper.get("[data-test='grid-open']").trigger("click");
+    await wrapper.get("[data-test='lb-source']").trigger("click");
+    await flushPromises();
+
+    expect(form.state.value.imageAttachments).toEqual([]);
+    expect(form.state.value.h3Authoring?.references).toHaveLength(1);
+    expect(
+      form.state.value.h3Authoring?.references[0]?.reference,
+    ).toMatchObject({
+      kind: "image",
+      media: { authority: "inline", data: "Ynl0ZXM=" },
+      provenance: { name: "dog.png" },
+      mime_type: "image/png",
+      width: 1024,
+      height: 1024,
+    });
+    expect(pushMock).toHaveBeenCalledWith({ name: "create" });
+  });
+
   it("refreshes the gallery while the page remains visible", async () => {
     vi.useFakeTimers();
     const wrapper = mountPage();

--- a/web/src/pages/LibraryPage.vue
+++ b/web/src/pages/LibraryPage.vue
@@ -63,6 +63,13 @@ import Lightbox from "../components/gallery/Lightbox.vue";
 import { setSequenceHandoff } from "../composables/useSequenceHandoff";
 import { useSequenceDraftStore } from "@studio/stores/sequenceDraft";
 import { groupLogicalGalleryPrints } from "@studio/lib/galleryPrintIdentity";
+import { imageDimensionsFromBase64 } from "@studio/lib/imageDimensions";
+import {
+  appendMinimaxH3GalleryImageReference,
+  isMinimaxH3Identity,
+  minimaxH3TaskForModel,
+  setMinimaxH3GalleryImageFirstFrame,
+} from "@studio/lib/minimaxH3Authoring";
 
 type FilterKind = "all" | "images" | "video" | "audio";
 type ViewMode = "feed" | "grid";
@@ -666,14 +673,49 @@ async function setAsSource(item: GalleryImage): Promise<boolean> {
     if (!host) throw missingHostError(item);
     const blob = await fetchGalleryBlob(host, item.filename);
     const base64 = await blobToBase64(blob);
-    form.state.value.imageAttachments = [
-      { kind: "gallery", filename: item.filename, base64 },
-    ];
+    const state = form.state.value;
+    const h3Task = minimaxH3TaskForModel(state.model);
+    if (h3Task) {
+      const dimensions = imageDimensionsFromBase64(base64) ?? {
+        width: item.metadata.width,
+        height: item.metadata.height,
+      };
+      const image = {
+        filename: item.filename,
+        mimeType: galleryImageMimeType(item, blob.type),
+        width: dimensions.width,
+        height: dimensions.height,
+        data: base64,
+      };
+      const result =
+        h3Task === "ref2va"
+          ? appendMinimaxH3GalleryImageReference(state.h3Authoring, image)
+          : setMinimaxH3GalleryImageFirstFrame(state.h3Authoring, image);
+      if (!result.ok) throw new Error(result.error);
+      state.h3Authoring = result.state;
+    } else if (isMinimaxH3Identity(state.modelFamily, state.model)) {
+      throw new Error(
+        "Choose an explicit MiniMax H3 FL2VA or Ref2VA model before adding a source.",
+      );
+    } else {
+      state.imageAttachments = [
+        { kind: "gallery", filename: item.filename, base64 },
+      ];
+    }
     return true;
   } catch (err) {
     toast("error", err instanceof Error ? err.message : String(err));
     return false;
   }
+}
+
+function galleryImageMimeType(item: GalleryImage, declared: string): string {
+  const mime = declared.split(";", 1)[0]!.trim().toLowerCase();
+  if (mime.startsWith("image/")) return mime;
+  const format = (item.format ?? item.filename.split(".").pop() ?? "")
+    .toLowerCase()
+    .replace("jpg", "jpeg");
+  return format ? `image/${format}` : "application/octet-stream";
 }
 
 async function onUseAsSource(item: GalleryImage) {


### PR DESCRIPTION
## Summary

- canonicalize every released H3 alias before server activation, upload scope, admission, placement, queue, and persistence identity
- write the same canonical task/layout model into shared browser request snapshots while unknown variants remain fail-closed
- route Library Use as source into FL2VA first-frame or ordered Ref2VA reference authority across web, desktop, and iPhone
- count only the active H3 task media in the iPhone request budget; parked, unknown, and non-H3 bytes cannot cause false rejection
- preserve exact missing official/Comfy H3 checkpoints during mobile gallery replay
- keep unknown H3-shaped snapshots inside the fail-closed family boundary and refuse every H3 sequence snapshot without form mutation or fallback

## Why

Generation, upload, retry, and gallery flows could retain different aliases for the same released checkpoint. Generic gallery source fields were also removed by the H3 serializer, mobile replay could silently substitute a different task/layout, and parked authoring bytes could falsely exceed the iPhone request cap. Those paths now share one exact canonical identity and fail closed when no released partition is known.

## Validation

- Rust canonicalization and upload-scope regressions passed
- strict all-target core/server Clippy passed
- Studio 18/18, web Library 26/26, desktop Library 18/18
- mobile replay 16/16, active-task media budget 4/4, and MobileApp 140/140
- web and desktop TypeScript checks passed
- Prettier, rustfmt, diff check, conflict check, and path/restricted-identifier scans passed
- current exact patch digest under final independent re-review: 6b1e7a0f9b632fd1b712120d2d5808465ed8cbd24f7abac803a48d524cc65ae6

Progresses #825 and #841. Part of #814.