### PR TITLE
feat(h3): prepare authenticated opened evidence

### DIFF
--- a/crates/mold-candle/src/minimax_h3/comfy_dit.rs
+++ b/crates/mold-candle/src/minimax_h3/comfy_dit.rs
@@ -20,7 +20,7 @@ use std::error::Error as StdError;
 use std::fmt;
 use std::fs::{File, Metadata};
 use std::io::{Read, Seek, SeekFrom};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -31,6 +31,9 @@ use serde::de::{DeserializeOwned, Error as _, MapAccess, SeqAccess, Visitor};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::{Map, Number, Value};
 use sha2::{Digest, Sha256};
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 
 use super::attention::{
     H3AttentionDType, H3AttentionDevice, H3AttentionModelContract, H3AttentionRuntimeAuthority,
@@ -359,6 +362,37 @@ pub struct H3ComfyInt8BlockMemory {
     pub protected_device_bytes: u64,
 }
 
+/// Exact pre-allocation record for one authenticated main block.
+///
+/// The content digest covers the block's complete encoded safetensors payload
+/// in file order, including the authenticated quantization sidecars. The
+/// memory record deliberately excludes those sidecars because they are policy
+/// metadata and are never retained by the block loader.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct H3ComfyOpenedBlockMemoryEvidence {
+    pub index: u16,
+    pub memory: H3ComfyInt8BlockMemory,
+    pub content_sha256: String,
+}
+
+/// Exact pre-allocation memory evidence derived from the same retained file
+/// descriptor that later supplies the resident core and streamed blocks.
+///
+/// `fixed_*` covers every non-main-block tensor that the resident transformer
+/// loads. F16 curve projections are charged at their logical F32 residency.
+/// The fifty block records are ordered and exhaustive for released H3.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct H3ComfyOpenedMemoryEvidence {
+    pub verified_file_bytes: u64,
+    pub header_bytes: u64,
+    pub fixed_encoded_host_bytes: u64,
+    pub fixed_protected_device_bytes: u64,
+    pub fixed_max_host_read_staging_bytes: u64,
+    pub fixed_max_device_weight_staging_bytes: u64,
+    pub blocks: Vec<H3ComfyOpenedBlockMemoryEvidence>,
+    pub identity_sha256: String,
+}
+
 /// An exact, already-opened Comfy INT8 artifact authority.
 ///
 /// Header parsing, schema/policy validation, full-content hashing, resident
@@ -370,6 +404,7 @@ pub struct H3ComfyOpenedInt8Checkpoint {
     config: H3TransformerConfig,
     source: Arc<H3ComfyOpenedSource>,
     checkpoint_identity_sha256: String,
+    memory_evidence: H3ComfyOpenedMemoryEvidence,
 }
 
 impl fmt::Debug for H3ComfyOpenedInt8Checkpoint {
@@ -395,8 +430,36 @@ impl H3ComfyOpenedInt8Checkpoint {
         &self.checkpoint_identity_sha256
     }
 
+    pub fn content_sha256(&self) -> &str {
+        &self.source.content_sha256
+    }
+
+    pub fn source_path(&self) -> &Path {
+        &self.source.path
+    }
+
+    pub fn revalidate(&self) -> InspectionResult<()> {
+        self.source.revalidate_authority()
+    }
+
+    pub fn config_identity_sha256(&self) -> String {
+        let mut digest = Sha256::new();
+        digest.update(b"mold.minimax-h3.comfy-transformer-config.v1\0");
+        digest.update(
+            serde_json::to_vec(&self.config)
+                .expect("validated H3 transformer configuration is serializable"),
+        );
+        hex_digest(digest.finalize())
+    }
+
     pub fn verified_file_bytes(&self) -> u64 {
         self.source.identity.len
+    }
+
+    /// Immutable host/device/staging facts established before any Candle
+    /// model tensor is allocated.
+    pub fn memory_evidence(&self) -> &H3ComfyOpenedMemoryEvidence {
+        &self.memory_evidence
     }
 
     pub fn bytes_read_after_verification(&self) -> u64 {
@@ -576,18 +639,31 @@ fn open_h3_comfy_int8_checkpoint(
             "H3 Comfy execution authority must be opened from a regular non-symlink file",
         ));
     }
-    let mut file = File::open(path).map_err(|error| {
+    #[cfg(unix)]
+    if symlink_metadata.permissions().mode() & 0o022 != 0 {
+        return Err(failure(
+            H3ComfyCheckpointErrorCode::FileIdentityChanged,
+            "H3 Comfy execution authority must not be group/other writable",
+        ));
+    }
+    let canonical_path = std::fs::canonicalize(path).map_err(|error| {
+        failure(
+            H3ComfyCheckpointErrorCode::Io,
+            format!("failed to canonicalize H3 Comfy checkpoint: {error}"),
+        )
+    })?;
+    let mut file = File::open(&canonical_path).map_err(|error| {
         failure(
             H3ComfyCheckpointErrorCode::Io,
             format!("failed to open H3 Comfy checkpoint: {error}"),
         )
     })?;
-    let identity = H3OpenedFileIdentity::from_metadata(
-        &file
-            .metadata()
-            .map_err(|error| failure(H3ComfyCheckpointErrorCode::Io, error.to_string()))?,
-    );
-    if identity.len != symlink_metadata.len() {
+    let requested_identity = H3OpenedFileIdentity::from_metadata(&symlink_metadata);
+    let opened_metadata = file
+        .metadata()
+        .map_err(|error| failure(H3ComfyCheckpointErrorCode::Io, error.to_string()))?;
+    let identity = H3OpenedFileIdentity::from_metadata(&opened_metadata);
+    if identity != requested_identity {
         return Err(failure(
             H3ComfyCheckpointErrorCode::FileIdentityChanged,
             "H3 Comfy checkpoint changed while its descriptor was opened",
@@ -620,7 +696,10 @@ fn open_h3_comfy_int8_checkpoint(
             cancellation,
         )?;
     }
-    let content_sha256 = hash_open_file(&mut file, parsed.file_len, cancellation)?;
+    let H3ComfyOpenedHashes {
+        content_sha256,
+        block_content_sha256,
+    } = hash_open_file(&mut file, &parsed, config.num_layers, cancellation)?;
     if let Some((_, expected_sha256)) = expected_content {
         if content_sha256 != expected_sha256 {
             return Err(failure(
@@ -646,10 +725,17 @@ fn open_h3_comfy_int8_checkpoint(
     let f16_curve_projection_tensors = published_artifact
         .map(|_| published_int8_curve_projection_tensors(&config))
         .unwrap_or_default();
+    let memory_evidence = calculate_opened_memory_evidence(
+        &parsed,
+        &f16_curve_projection_tensors,
+        config.num_layers,
+        &block_content_sha256,
+    )?;
     Ok(H3ComfyOpenedInt8Checkpoint {
         candidate,
         config,
         source: Arc::new(H3ComfyOpenedSource {
+            path: canonical_path,
             file: Mutex::new(file),
             header: parsed,
             identity,
@@ -659,6 +745,7 @@ fn open_h3_comfy_int8_checkpoint(
             f16_curve_projection_upcast_loads: AtomicU64::new(0),
         }),
         checkpoint_identity_sha256,
+        memory_evidence,
     })
 }
 
@@ -723,6 +810,7 @@ impl H3OpenedFileIdentity {
 }
 
 struct H3ComfyOpenedSource {
+    path: PathBuf,
     file: Mutex<File>,
     header: ParsedHeader,
     identity: H3OpenedFileIdentity,
@@ -1030,11 +1118,17 @@ fn validate_published_int8_quantization_sidecars(
     cancellation_boundary_inspection(cancellation)
 }
 
+struct H3ComfyOpenedHashes {
+    content_sha256: String,
+    block_content_sha256: Vec<String>,
+}
+
 fn hash_open_file(
     file: &mut File,
-    file_len: u64,
+    parsed: &ParsedHeader,
+    block_count: usize,
     cancellation: &dyn H3ComfyInt8Cancellation,
-) -> InspectionResult<String> {
+) -> InspectionResult<H3ComfyOpenedHashes> {
     file.seek(SeekFrom::Start(0)).map_err(|error| {
         failure(
             H3ComfyCheckpointErrorCode::Io,
@@ -1042,17 +1136,62 @@ fn hash_open_file(
         )
     })?;
     let mut digest = Sha256::new();
+    let data_start = 8_u64.checked_add(parsed.header_len).ok_or_else(|| {
+        failure(
+            H3ComfyCheckpointErrorCode::InvalidHeader,
+            "H3 Comfy data offset overflows",
+        )
+    })?;
+    let mut block_ranges = Vec::with_capacity(block_count);
+    for index in 0..block_count {
+        let prefix = format!("blocks.{index}.");
+        let mut ranges = parsed
+            .tensors
+            .range(prefix.clone()..)
+            .take_while(|(name, _)| name.starts_with(&prefix))
+            .map(|(_, tensor)| {
+                Ok([
+                    data_start
+                        .checked_add(tensor.data_offsets[0])
+                        .ok_or_else(|| {
+                            failure(
+                                H3ComfyCheckpointErrorCode::InvalidHeader,
+                                "H3 Comfy block start offset overflows",
+                            )
+                        })?,
+                    data_start
+                        .checked_add(tensor.data_offsets[1])
+                        .ok_or_else(|| {
+                            failure(
+                                H3ComfyCheckpointErrorCode::InvalidHeader,
+                                "H3 Comfy block end offset overflows",
+                            )
+                        })?,
+                ])
+            })
+            .collect::<InspectionResult<Vec<_>>>()?;
+        ranges.sort_by_key(|range| range[0]);
+        if ranges.is_empty() {
+            return Err(failure(
+                H3ComfyCheckpointErrorCode::TensorSchemaMismatch,
+                format!("H3 Comfy opened checkpoint has no tensors for block {index}"),
+            ));
+        }
+        block_ranges.push(ranges);
+    }
+    let mut block_digests = (0..block_count).map(|_| Sha256::new()).collect::<Vec<_>>();
     let mut verified = 0u64;
     let mut buffer = vec![0u8; FILE_READ_CHUNK_BYTES];
-    while verified < file_len {
+    while verified < parsed.file_len {
         cancellation_boundary_inspection(cancellation)?;
-        let remaining = usize::try_from((file_len - verified).min(FILE_READ_CHUNK_BYTES as u64))
-            .map_err(|_| {
-                failure(
-                    H3ComfyCheckpointErrorCode::Io,
-                    "H3 Comfy hash read size does not fit this platform",
-                )
-            })?;
+        let remaining =
+            usize::try_from((parsed.file_len - verified).min(FILE_READ_CHUNK_BYTES as u64))
+                .map_err(|_| {
+                    failure(
+                        H3ComfyCheckpointErrorCode::Io,
+                        "H3 Comfy hash read size does not fit this platform",
+                    )
+                })?;
         file.read_exact(&mut buffer[..remaining]).map_err(|error| {
             failure(
                 H3ComfyCheckpointErrorCode::Io,
@@ -1060,10 +1199,30 @@ fn hash_open_file(
             )
         })?;
         digest.update(&buffer[..remaining]);
+        let chunk_end = verified + remaining as u64;
+        for (block_digest, ranges) in block_digests.iter_mut().zip(&block_ranges) {
+            for [start, end] in ranges {
+                let overlap_start = verified.max(*start);
+                let overlap_end = chunk_end.min(*end);
+                if overlap_start < overlap_end {
+                    let start =
+                        usize::try_from(overlap_start - verified).expect("chunk offset fits usize");
+                    let end =
+                        usize::try_from(overlap_end - verified).expect("chunk offset fits usize");
+                    block_digest.update(&buffer[start..end]);
+                }
+            }
+        }
         verified += remaining as u64;
     }
     cancellation_boundary_inspection(cancellation)?;
-    Ok(hex_digest(digest.finalize()))
+    Ok(H3ComfyOpenedHashes {
+        content_sha256: hex_digest(digest.finalize()),
+        block_content_sha256: block_digests
+            .into_iter()
+            .map(|digest| hex_digest(digest.finalize()))
+            .collect(),
+    })
 }
 
 fn comfy_checkpoint_identity(
@@ -1087,6 +1246,36 @@ fn comfy_checkpoint_identity(
 }
 
 impl H3ComfyOpenedSource {
+    fn revalidate_authority(&self) -> InspectionResult<()> {
+        let path_metadata = std::fs::symlink_metadata(&self.path).map_err(|error| {
+            failure(
+                H3ComfyCheckpointErrorCode::FileIdentityChanged,
+                format!("opened H3 Comfy checkpoint path disappeared: {error}"),
+            )
+        })?;
+        if path_metadata.file_type().is_symlink()
+            || !path_metadata.file_type().is_file()
+            || H3OpenedFileIdentity::from_metadata(&path_metadata) != self.identity
+        {
+            return Err(failure(
+                H3ComfyCheckpointErrorCode::FileIdentityChanged,
+                "opened H3 Comfy checkpoint path no longer names the authenticated file",
+            ));
+        }
+        let file = self.file.lock().map_err(|_| {
+            failure(
+                H3ComfyCheckpointErrorCode::Io,
+                "opened H3 Comfy checkpoint lock is poisoned",
+            )
+        })?;
+        self.verify_identity(&file).map_err(|error| {
+            failure(
+                H3ComfyCheckpointErrorCode::FileIdentityChanged,
+                error.to_string(),
+            )
+        })
+    }
+
     fn verify_identity(&self, file: &File) -> candle::Result<()> {
         let current = file.metadata().map_err(|error| {
             candle::Error::Msg(format!(
@@ -1436,6 +1625,164 @@ fn calculate_block_memory(
         max_device_weight_staging_bytes,
         protected_device_bytes,
     })
+}
+
+fn calculate_opened_memory_evidence(
+    parsed: &ParsedHeader,
+    f16_curve_projection_tensors: &BTreeSet<String>,
+    block_count: usize,
+    block_content_sha256: &[String],
+) -> InspectionResult<H3ComfyOpenedMemoryEvidence> {
+    if block_count == 0
+        || block_content_sha256.len() != block_count
+        || block_content_sha256.iter().any(|digest| {
+            digest.len() != 64 || !digest.bytes().all(|byte| byte.is_ascii_hexdigit())
+        })
+    {
+        return Err(failure(
+            H3ComfyCheckpointErrorCode::TensorSchemaMismatch,
+            "H3 Comfy opened checkpoint block evidence is incomplete",
+        ));
+    }
+
+    let mut fixed_encoded_host_bytes = 0_u64;
+    let mut fixed_protected_device_bytes = 0_u64;
+    let mut fixed_max_host_read_staging_bytes = 0_u64;
+    let mut fixed_max_device_weight_staging_bytes = 0_u64;
+    for (name, tensor) in &parsed.tensors {
+        if name.starts_with("blocks.") || name.ends_with(".comfy_quant") {
+            continue;
+        }
+        let encoded = tensor.data_offsets[1] - tensor.data_offsets[0];
+        let logical_device = if tensor.dtype == "F16" && f16_curve_projection_tensors.contains(name)
+        {
+            tensor
+                .shape
+                .iter()
+                .try_fold(1_u64, |elements, dimension| {
+                    elements.checked_mul(*dimension as u64)
+                })
+                .and_then(|elements| elements.checked_mul(std::mem::size_of::<f32>() as u64))
+                .ok_or_else(|| {
+                    failure(
+                        H3ComfyCheckpointErrorCode::TensorSchemaMismatch,
+                        "H3 Comfy fixed logical device bytes overflow",
+                    )
+                })?
+        } else {
+            encoded
+        };
+        fixed_encoded_host_bytes =
+            fixed_encoded_host_bytes
+                .checked_add(encoded)
+                .ok_or_else(|| {
+                    failure(
+                        H3ComfyCheckpointErrorCode::TensorSchemaMismatch,
+                        "H3 Comfy fixed host bytes overflow",
+                    )
+                })?;
+        fixed_protected_device_bytes = fixed_protected_device_bytes
+            .checked_add(logical_device)
+            .ok_or_else(|| {
+                failure(
+                    H3ComfyCheckpointErrorCode::TensorSchemaMismatch,
+                    "H3 Comfy fixed device bytes overflow",
+                )
+            })?;
+        fixed_max_host_read_staging_bytes = fixed_max_host_read_staging_bytes.max(encoded);
+        fixed_max_device_weight_staging_bytes =
+            fixed_max_device_weight_staging_bytes.max(logical_device);
+    }
+    if fixed_encoded_host_bytes == 0
+        || fixed_protected_device_bytes == 0
+        || fixed_max_host_read_staging_bytes == 0
+        || fixed_max_device_weight_staging_bytes == 0
+    {
+        return Err(failure(
+            H3ComfyCheckpointErrorCode::TensorSchemaMismatch,
+            "H3 Comfy opened checkpoint has incomplete fixed memory evidence",
+        ));
+    }
+
+    let blocks = (0..block_count)
+        .map(|index| {
+            let memory =
+                calculate_block_memory(parsed, f16_curve_projection_tensors, index, block_count)
+                    .map_err(|error| {
+                        failure(
+                            H3ComfyCheckpointErrorCode::TensorSchemaMismatch,
+                            error.to_string(),
+                        )
+                    })?;
+            if memory.encoded_host_bytes == 0
+                || memory.protected_device_bytes == 0
+                || memory.max_host_read_staging_bytes == 0
+                || memory.max_device_weight_staging_bytes == 0
+            {
+                return Err(failure(
+                    H3ComfyCheckpointErrorCode::TensorSchemaMismatch,
+                    format!("H3 Comfy block {index} has incomplete memory evidence"),
+                ));
+            }
+            Ok(H3ComfyOpenedBlockMemoryEvidence {
+                index: u16::try_from(index).map_err(|_| {
+                    failure(
+                        H3ComfyCheckpointErrorCode::TensorSchemaMismatch,
+                        "H3 Comfy block index exceeds u16",
+                    )
+                })?,
+                memory,
+                content_sha256: block_content_sha256[index].clone(),
+            })
+        })
+        .collect::<InspectionResult<Vec<_>>>()?;
+    let header_bytes = parsed.header_len.checked_add(8).ok_or_else(|| {
+        failure(
+            H3ComfyCheckpointErrorCode::InvalidHeader,
+            "H3 Comfy header byte charge overflows",
+        )
+    })?;
+    let mut evidence = H3ComfyOpenedMemoryEvidence {
+        verified_file_bytes: parsed.file_len,
+        header_bytes,
+        fixed_encoded_host_bytes,
+        fixed_protected_device_bytes,
+        fixed_max_host_read_staging_bytes,
+        fixed_max_device_weight_staging_bytes,
+        blocks,
+        identity_sha256: String::new(),
+    };
+    evidence.identity_sha256 = opened_memory_evidence_identity(&evidence);
+    Ok(evidence)
+}
+
+fn opened_memory_evidence_identity(evidence: &H3ComfyOpenedMemoryEvidence) -> String {
+    let mut digest = Sha256::new();
+    digest.update(b"mold.minimax-h3.comfy-opened-memory-evidence.v1\0");
+    for value in [
+        evidence.verified_file_bytes,
+        evidence.header_bytes,
+        evidence.fixed_encoded_host_bytes,
+        evidence.fixed_protected_device_bytes,
+        evidence.fixed_max_host_read_staging_bytes,
+        evidence.fixed_max_device_weight_staging_bytes,
+    ] {
+        digest.update(value.to_le_bytes());
+    }
+    digest.update((evidence.blocks.len() as u64).to_le_bytes());
+    for block in &evidence.blocks {
+        digest.update(block.index.to_le_bytes());
+        for value in [
+            block.memory.encoded_host_bytes,
+            block.memory.protected_device_bytes,
+            block.memory.max_device_weight_staging_bytes,
+            block.memory.max_host_read_staging_bytes,
+        ] {
+            digest.update(value.to_le_bytes());
+        }
+        digest.update(block.content_sha256.as_bytes());
+    }
+    hex_digest(digest.finalize())
 }
 
 #[derive(Deserialize)]
@@ -3157,6 +3504,7 @@ mod tests {
             let file = File::open(&path).unwrap();
             let identity = H3OpenedFileIdentity::from_metadata(&file.metadata().unwrap());
             H3ComfyOpenedSource {
+                path: std::fs::canonicalize(&path).unwrap(),
                 file: Mutex::new(file),
                 header: parsed.clone(),
                 identity,
@@ -3251,6 +3599,63 @@ mod tests {
     }
 
     #[test]
+    fn opened_memory_evidence_freezes_all_fifty_block_records() {
+        let mut tensors = BTreeMap::from([(
+            "x_embedder.weight".into(),
+            HeaderTensor {
+                dtype: "F32".into(),
+                shape: vec![1],
+                data_offsets: [0, 4],
+            },
+        )]);
+        for index in 0..50 {
+            let start = 4 + index as u64 * 12;
+            tensors.insert(
+                format!("blocks.{index}.attn.qkv_proj.weight"),
+                HeaderTensor {
+                    dtype: "I8".into(),
+                    shape: vec![1, 4],
+                    data_offsets: [start, start + 4],
+                },
+            );
+            tensors.insert(
+                format!("blocks.{index}.attn.qkv_proj.weight_scale"),
+                HeaderTensor {
+                    dtype: "F32".into(),
+                    shape: vec![1, 1],
+                    data_offsets: [start + 4, start + 8],
+                },
+            );
+            tensors.insert(
+                format!("blocks.{index}.norm1.weight"),
+                HeaderTensor {
+                    dtype: "F32".into(),
+                    shape: vec![1],
+                    data_offsets: [start + 8, start + 12],
+                },
+            );
+        }
+        let parsed = ParsedHeader {
+            metadata: BTreeMap::new(),
+            tensors,
+            header_len: 128,
+            file_len: 8 + 128 + 4 + 50 * 12,
+            header_identity_sha256: "a".repeat(64),
+        };
+        let digests = (0..50)
+            .map(|index| format!("{index:064x}"))
+            .collect::<Vec<_>>();
+        let evidence =
+            calculate_opened_memory_evidence(&parsed, &BTreeSet::new(), 50, &digests).unwrap();
+        assert_eq!(evidence.blocks.len(), 50);
+        assert_eq!(evidence.blocks[49].index, 49);
+        assert_eq!(evidence.blocks[49].content_sha256, digests[49]);
+        assert_eq!(evidence.fixed_encoded_host_bytes, 4);
+        assert_eq!(evidence.fixed_protected_device_bytes, 4);
+        assert_eq!(evidence.identity_sha256.len(), 64);
+    }
+
+    #[test]
     fn opened_int8_runtime_streams_exactly_one_cpu_packed_block() -> candle::Result<()> {
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<H3ComfyOpenedInt8Checkpoint>();
@@ -3269,6 +3674,21 @@ mod tests {
         .map_err(|error| candle::Error::Msg(error.to_string()))?;
         assert_eq!(opened.bytes_read_after_verification(), 0);
         assert_eq!(opened.checkpoint_identity_sha256().len(), 64);
+        let opened_memory = opened.memory_evidence().clone();
+        assert_eq!(
+            opened_memory.verified_file_bytes,
+            std::fs::metadata(&path).unwrap().len()
+        );
+        assert_eq!(opened_memory.blocks.len(), 2);
+        assert_eq!(opened_memory.identity_sha256.len(), 64);
+        assert!(opened_memory.fixed_encoded_host_bytes > 0);
+        assert!(opened_memory.fixed_protected_device_bytes > 0);
+        assert!(opened_memory.fixed_max_host_read_staging_bytes > 0);
+        assert!(opened_memory.fixed_max_device_weight_staging_bytes > 0);
+        for (index, block) in opened_memory.blocks.iter().enumerate() {
+            assert_eq!(usize::from(block.index), index);
+            assert_eq!(block.content_sha256.len(), 64);
+        }
         let expected_identity = opened.checkpoint_identity_sha256().to_owned();
         let (transformer, mut loader) = opened.load(&Device::Cpu)?;
         assert!(loader.is_exact_pair_for(&transformer));
@@ -3282,6 +3702,9 @@ mod tests {
             loader.bytes_read() > 0,
             "resident weights must be file-backed"
         );
+        for block in &opened_memory.blocks {
+            assert_eq!(loader.block_memory(usize::from(block.index))?, block.memory);
+        }
         let memory = loader.block_memory(0)?;
         assert!(memory.encoded_host_bytes > 0);
         assert!(memory.max_host_read_staging_bytes > 0);
@@ -3439,6 +3862,25 @@ mod tests {
         mutable.sync_all().unwrap();
         let error = opened.load(&Device::Cpu).unwrap_err().to_string();
         assert!(error.contains("changed after full verification"), "{error}");
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn opened_int8_runtime_rejects_group_writable_source() {
+        let (config, header, data) = runtime_fixture();
+        let path = write_fixture(&header, &data, "opened-permissions");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o666)).unwrap();
+        let error = open_h3_comfy_int8_checkpoint(
+            &path,
+            config,
+            H3TransformerTask::T2VaFl2Va,
+            None,
+            None,
+            &H3ComfyNeverCancel,
+        )
+        .unwrap_err();
+        assert_eq!(error.code, H3ComfyCheckpointErrorCode::FileIdentityChanged);
         let _ = std::fs::remove_file(path);
     }
 

--- a/crates/mold-candle/src/minimax_h3/mod.rs
+++ b/crates/mold-candle/src/minimax_h3/mod.rs
@@ -67,7 +67,8 @@ pub use comfy_dit::{
     H3ComfyAccuracyTier, H3ComfyCheckpointCandidate, H3ComfyCheckpointError,
     H3ComfyCheckpointErrorCode, H3ComfyCurveInterpolation, H3ComfyFrozenStrategyMetadata,
     H3ComfyInt8BlockLoader, H3ComfyInt8BlockMemory, H3ComfyInt8Cancellation,
-    H3ComfyMemoryAccounting, H3ComfyNeverCancel, H3ComfyOpenedInt8Checkpoint, H3ComfyPrunedFormat,
+    H3ComfyMemoryAccounting, H3ComfyNeverCancel, H3ComfyOpenedBlockMemoryEvidence,
+    H3ComfyOpenedInt8Checkpoint, H3ComfyOpenedMemoryEvidence, H3ComfyPrunedFormat,
     H3ComfyPublishedArtifact, H3ComfyQuantizationPolicy, H3ComfyRuntimeBackend,
     H3ComfyRuntimeRejection, H3ComfyRuntimeRequirement, H3_COMFYUI_SOURCE_REVISION,
     H3_COMFY_KITCHEN_REPOSITORY, H3_COMFY_KITCHEN_SOURCE_REVISION, H3_COMFY_KITCHEN_VERSION,
@@ -125,11 +126,14 @@ pub use qwen_nvfp4::{
 #[cfg(feature = "h3-private-uat")]
 #[doc(hidden)]
 pub use qwen_nvfp4_runtime::{
-    load_h3_qwen_nvfp4_conditioner_after_authorization, released_h3_qwen_nvfp4_output_tensor_bytes,
+    load_h3_qwen_nvfp4_conditioner_after_authorization,
+    load_h3_qwen_nvfp4_conditioner_from_authority,
+    open_h3_qwen_nvfp4_authority_after_authorization, released_h3_qwen_nvfp4_output_tensor_bytes,
     released_h3_qwen_nvfp4_runtime_memory_facts,
-    released_h3_qwen_nvfp4_runtime_memory_facts_for_placement, H3QwenNvfp4LoadEvent,
-    H3QwenNvfp4LoadObserver, H3QwenNvfp4RuntimeError, H3QwenNvfp4RuntimeMemoryFacts,
-    H3QwenNvfp4RuntimePlacement, LoadedH3QwenNvfp4Conditioner, NoopH3QwenNvfp4LoadObserver,
+    released_h3_qwen_nvfp4_runtime_memory_facts_for_placement, H3AuthenticatedQwenNvfp4Authority,
+    H3QwenNvfp4LoadEvent, H3QwenNvfp4LoadObserver, H3QwenNvfp4RuntimeError,
+    H3QwenNvfp4RuntimeMemoryFacts, H3QwenNvfp4RuntimePlacement, LoadedH3QwenNvfp4Conditioner,
+    NoopH3QwenNvfp4LoadObserver,
 };
 pub use qwen_quant::{
     expected_h3_qwen_int8_weight_only_schema, validate_h3_qwen_int8_weight_only_schema,

--- a/crates/mold-candle/src/minimax_h3/qwen_nvfp4.rs
+++ b/crates/mold-candle/src/minimax_h3/qwen_nvfp4.rs
@@ -23,6 +23,9 @@ use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use thiserror::Error;
 
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
 use super::artifacts::{expected_checkpoint_shapes, expected_materialized_keys};
 use super::config::{H3ConditionerConfig, H3_SELECTED_LANGUAGE_LAYERS};
 use super::qwen_quant::{H3QwenTensorDType, H3QwenTensorSpec};
@@ -696,6 +699,10 @@ pub(crate) struct OpenedH3QwenNvfp4AwqArtifact {
 }
 
 impl OpenedH3QwenNvfp4AwqArtifact {
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+
     pub(crate) fn inspection(&self) -> &H3QwenNvfp4AwqInspection {
         &self.inspection
     }
@@ -837,6 +844,12 @@ fn checked_path_identity(
     if !metadata.file_type().is_file() {
         return Err(H3QwenNvfp4AwqError::Io(format!(
             "{operation}: artifact path must be a regular file"
+        )));
+    }
+    #[cfg(unix)]
+    if metadata.permissions().mode() & 0o022 != 0 {
+        return Err(H3QwenNvfp4AwqError::Io(format!(
+            "{operation}: artifact path must not be group/other writable"
         )));
     }
     let identity = file_identity(&metadata);
@@ -1342,6 +1355,19 @@ pub(crate) mod tests {
         );
         std::fs::remove_file(link).unwrap();
         std::fs::remove_file(target).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bounded_inspector_rejects_group_writable_weights() {
+        let path = temp_path("writable");
+        std::fs::write(&path, b"not opened while writable").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o666)).unwrap();
+        let error = inspect_h3_qwen_nvfp4_awq_header(&path).unwrap_err();
+        assert!(
+            matches!(error, H3QwenNvfp4AwqError::Io(message) if message.contains("group/other writable"))
+        );
+        std::fs::remove_file(path).unwrap();
     }
 
     #[cfg(unix)]

--- a/crates/mold-candle/src/minimax_h3/qwen_nvfp4_runtime.rs
+++ b/crates/mold-candle/src/minimax_h3/qwen_nvfp4_runtime.rs
@@ -8,6 +8,7 @@
 
 use candle::{DType, Device, Tensor};
 use candle_nn::VarBuilder;
+use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::path::Path;
 use thiserror::Error;
@@ -98,6 +99,93 @@ pub struct H3QwenNvfp4RuntimeMemoryFacts {
 pub enum H3QwenNvfp4RuntimePlacement {
     Accelerated,
     Cpu,
+}
+
+/// Fully authenticated, still-open Qwen authority established before any
+/// model tensor is allocated.
+///
+/// This token is intentionally non-Clone and consumed by the loader. It binds
+/// the retained descriptor, released schema/policy/content identities,
+/// concrete host/device residency route, and every exact loader memory fact.
+pub struct H3AuthenticatedQwenNvfp4Authority {
+    artifact: OpenedH3QwenNvfp4AwqArtifact,
+    placement: H3QwenNvfp4RuntimePlacement,
+    memory_facts: H3QwenNvfp4RuntimeMemoryFacts,
+    identity_sha256: String,
+}
+
+impl H3AuthenticatedQwenNvfp4Authority {
+    pub const fn placement(&self) -> H3QwenNvfp4RuntimePlacement {
+        self.placement
+    }
+
+    pub const fn memory_facts(&self) -> &H3QwenNvfp4RuntimeMemoryFacts {
+        &self.memory_facts
+    }
+
+    pub fn artifact_identity_sha256(&self) -> &str {
+        &self.artifact.inspection().expected_artifact_sha256
+    }
+
+    pub fn header_identity_sha256(&self) -> &str {
+        &self.artifact.inspection().header_identity_sha256
+    }
+
+    pub fn policy_identity_sha256(&self) -> &str {
+        &self.artifact.inspection().policy_sha256
+    }
+
+    pub fn artifact_file_bytes(&self) -> u64 {
+        self.artifact.inspection().artifact_file_bytes
+    }
+
+    pub fn source_path(&self) -> &Path {
+        self.artifact.path()
+    }
+
+    pub fn identity_sha256(&self) -> &str {
+        &self.identity_sha256
+    }
+
+    pub fn revalidate(&self) -> Result<(), H3QwenNvfp4RuntimeError> {
+        self.artifact
+            .revalidate("while retaining authenticated H3 Qwen authority")?;
+        if self.identity_sha256 != authenticated_qwen_authority_identity(self) {
+            return Err(H3QwenNvfp4RuntimeError::Contract(
+                "authenticated Qwen authority identity changed".into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn authenticated_qwen_authority_identity(authority: &H3AuthenticatedQwenNvfp4Authority) -> String {
+    let mut digest = Sha256::new();
+    digest.update(b"mold.minimax-h3.qwen-authenticated-open.v1\0");
+    digest.update(match authority.placement {
+        H3QwenNvfp4RuntimePlacement::Accelerated => b"accelerated".as_slice(),
+        H3QwenNvfp4RuntimePlacement::Cpu => b"cpu".as_slice(),
+    });
+    digest.update(authority.artifact_identity_sha256().as_bytes());
+    digest.update(authority.header_identity_sha256().as_bytes());
+    digest.update(authority.policy_identity_sha256().as_bytes());
+    let memory = &authority.memory_facts;
+    for value in [
+        memory.effective_parameter_bytes,
+        memory.host_resident_parameter_bytes,
+        memory.device_resident_parameter_bytes,
+        memory.retained_parameter_bytes,
+        memory.retained_raw_header_bytes,
+        memory.maximum_tensor_staging_bytes,
+        memory.authentication_scratch_bytes,
+        memory.bounded_inspection_io_bytes,
+        memory.authentication_io_bytes,
+        memory.tensor_io_bytes,
+        memory.aggregate_io_bytes,
+    ] {
+        digest.update(value.to_le_bytes());
+    }
+    format!("{:x}", digest.finalize())
 }
 
 /// Exact BF16 output-copy charge for the released `[1, sequence, hidden]`
@@ -356,33 +444,24 @@ impl TensorLoadProgress<'_> {
     }
 }
 
-/// Open and load the authenticated private Qwen object after the caller has
-/// established the complete attempt authority.
+/// Open and completely authenticate the private Qwen object without
+/// allocating any model tensors.
 ///
 /// # Safety
 ///
 /// Before calling, the consumer must validate one frozen factory authority,
 /// active conditioner/execution/artifact leases, the exact support identity,
-/// route, released quantization policy, and exact runtime memory facts. Those
-/// authorities must be polled by `observer` at every load checkpoint. This is
-/// an unsafe cross-crate implementation seam, not an independently callable
-/// model loader; the safe authority-first entrypoint lives in mold-inference.
-pub unsafe fn load_h3_qwen_nvfp4_conditioner_after_authorization(
+/// route, and released quantization policy. Those authorities must be polled
+/// by `observer` at every authentication checkpoint. This is an unsafe
+/// cross-crate implementation seam, not an independently callable artifact
+/// opener; the safe authority-first entrypoint lives in mold-inference.
+pub unsafe fn open_h3_qwen_nvfp4_authority_after_authorization(
     path: &Path,
-    config: &H3ConditionerConfig,
-    device: &Device,
+    placement: H3QwenNvfp4RuntimePlacement,
     observer: &mut dyn H3QwenNvfp4LoadObserver,
-) -> Result<LoadedH3QwenNvfp4Conditioner, H3QwenNvfp4RuntimeError> {
-    config
-        .validate()
-        .map_err(|error| H3QwenNvfp4RuntimeError::Contract(error.to_string()))?;
-    if config != &released_config()? {
-        return Err(H3QwenNvfp4RuntimeError::Contract(
-            "runtime config differs from the frozen published layer-50 Qwen contract".into(),
-        ));
-    }
-
-    let expected_memory_facts = released_h3_qwen_nvfp4_runtime_memory_facts(device)?;
+) -> Result<H3AuthenticatedQwenNvfp4Authority, H3QwenNvfp4RuntimeError> {
+    let expected_memory_facts =
+        released_h3_qwen_nvfp4_runtime_memory_facts_for_placement(placement)?;
     let mut artifact = open_h3_qwen_nvfp4_awq_artifact(path)?;
     artifact.authenticate_full_sha256(&mut |completed_bytes, total_bytes| {
         let event = H3QwenNvfp4LoadEvent::Authenticating {
@@ -421,6 +500,67 @@ pub unsafe fn load_h3_qwen_nvfp4_conditioner_after_authorization(
             expected_memory_facts.effective_parameter_bytes
         )));
     }
+    artifact.revalidate("after authenticating H3 Qwen authority")?;
+    let mut authority = H3AuthenticatedQwenNvfp4Authority {
+        artifact,
+        placement,
+        memory_facts: expected_memory_facts,
+        identity_sha256: String::new(),
+    };
+    authority.identity_sha256 = authenticated_qwen_authority_identity(&authority);
+    authority.revalidate()?;
+    Ok(authority)
+}
+
+/// Consume one authenticated Qwen authority and allocate the released runtime
+/// on its frozen placement route.
+///
+/// # Safety
+///
+/// The caller must retain and poll the same complete attempt authority used to
+/// open `authority`, and must have validated its exact memory facts at the
+/// allocation boundary. This function consumes the non-Clone authority so one
+/// authenticated descriptor cannot authorize multiple model allocations.
+pub unsafe fn load_h3_qwen_nvfp4_conditioner_from_authority(
+    mut authority: H3AuthenticatedQwenNvfp4Authority,
+    config: &H3ConditionerConfig,
+    device: &Device,
+    observer: &mut dyn H3QwenNvfp4LoadObserver,
+) -> Result<LoadedH3QwenNvfp4Conditioner, H3QwenNvfp4RuntimeError> {
+    config
+        .validate()
+        .map_err(|error| H3QwenNvfp4RuntimeError::Contract(error.to_string()))?;
+    if config != &released_config()? {
+        return Err(H3QwenNvfp4RuntimeError::Contract(
+            "runtime config differs from the frozen published layer-50 Qwen contract".into(),
+        ));
+    }
+    authority.revalidate()?;
+    let device_placement = if device.is_cpu() {
+        H3QwenNvfp4RuntimePlacement::Cpu
+    } else {
+        H3QwenNvfp4RuntimePlacement::Accelerated
+    };
+    if authority.placement != device_placement {
+        return Err(H3QwenNvfp4RuntimeError::Contract(format!(
+            "authenticated Qwen placement {:?} differs from selected device placement {:?}",
+            authority.placement, device_placement
+        )));
+    }
+    let expected_memory_facts = released_h3_qwen_nvfp4_runtime_memory_facts(device)?;
+    if authority.memory_facts != expected_memory_facts {
+        return Err(H3QwenNvfp4RuntimeError::Contract(
+            "authenticated Qwen memory facts differ from selected device facts".into(),
+        ));
+    }
+    let loadable_names = authority
+        .artifact
+        .tensors()
+        .iter()
+        .filter(|(name, _)| !name.ends_with(".comfy_quant"))
+        .map(|(name, _)| name.clone())
+        .collect::<Vec<_>>();
+    let loadable_bytes = expected_memory_facts.effective_parameter_bytes;
     let mut progress = TensorLoadProgress {
         observer,
         tensor_index: 1,
@@ -430,13 +570,13 @@ pub unsafe fn load_h3_qwen_nvfp4_conditioner_after_authorization(
     };
 
     let embed_weight = load_tensor(
-        &mut artifact,
+        &mut authority.artifact,
         "model.embed_tokens.weight",
         &Device::Cpu,
         &mut progress,
     )?;
     let embed_scale = load_tensor(
-        &mut artifact,
+        &mut authority.artifact,
         "model.embed_tokens.weight_scale",
         &Device::Cpu,
         &mut progress,
@@ -447,40 +587,59 @@ pub unsafe fn load_h3_qwen_nvfp4_conditioner_after_authorization(
     for layer in 0..H3_SELECTED_LANGUAGE_LAYERS {
         layers.push(Qwen3VlNvfp4LayerWeights {
             q_proj: load_linear(
-                &mut artifact,
+                &mut authority.artifact,
                 config,
                 layer,
                 "self_attn.q_proj",
                 &mut progress,
             )?,
             k_proj: load_linear(
-                &mut artifact,
+                &mut authority.artifact,
                 config,
                 layer,
                 "self_attn.k_proj",
                 &mut progress,
             )?,
             v_proj: load_linear(
-                &mut artifact,
+                &mut authority.artifact,
                 config,
                 layer,
                 "self_attn.v_proj",
                 &mut progress,
             )?,
             o_proj: load_linear(
-                &mut artifact,
+                &mut authority.artifact,
                 config,
                 layer,
                 "self_attn.o_proj",
                 &mut progress,
             )?,
-            gate_proj: load_linear(&mut artifact, config, layer, "mlp.gate_proj", &mut progress)?,
-            up_proj: load_linear(&mut artifact, config, layer, "mlp.up_proj", &mut progress)?,
-            down_proj: load_linear(&mut artifact, config, layer, "mlp.down_proj", &mut progress)?,
+            gate_proj: load_linear(
+                &mut authority.artifact,
+                config,
+                layer,
+                "mlp.gate_proj",
+                &mut progress,
+            )?,
+            up_proj: load_linear(
+                &mut authority.artifact,
+                config,
+                layer,
+                "mlp.up_proj",
+                &mut progress,
+            )?,
+            down_proj: load_linear(
+                &mut authority.artifact,
+                config,
+                layer,
+                "mlp.down_proj",
+                &mut progress,
+            )?,
         });
     }
 
-    let dense_names = artifact
+    let dense_names = authority
+        .artifact
         .tensors()
         .iter()
         .filter(|(name, header)| header.dtype == "BF16" && !name.ends_with(".pre_quant_scale"))
@@ -488,7 +647,7 @@ pub unsafe fn load_h3_qwen_nvfp4_conditioner_after_authorization(
         .collect::<Vec<_>>();
     let mut dense = HashMap::with_capacity(dense_names.len());
     for name in dense_names {
-        let tensor = load_tensor(&mut artifact, &name, device, &mut progress)?;
+        let tensor = load_tensor(&mut authority.artifact, &name, device, &mut progress)?;
         if dense.insert(name.clone(), tensor).is_some() {
             return Err(H3QwenNvfp4RuntimeError::Contract(format!(
                 "duplicate dense tensor {name:?}"
@@ -506,7 +665,9 @@ pub unsafe fn load_h3_qwen_nvfp4_conditioner_after_authorization(
             progress.total_bytes
         )));
     }
-    artifact.revalidate("after constructing H3 Qwen tensor storage")?;
+    authority
+        .artifact
+        .revalidate("after constructing H3 Qwen tensor storage")?;
     let builder = VarBuilder::from_tensors(dense, DType::BF16, device);
     let model = H3QwenNvfp4Layer50Conditioner::new(
         config,
@@ -522,13 +683,47 @@ pub unsafe fn load_h3_qwen_nvfp4_conditioner_after_authorization(
             model.resident_language_layers()
         )));
     }
-    artifact.revalidate("after constructing H3 Qwen layer-50 model")?;
+    authority
+        .artifact
+        .revalidate("after constructing H3 Qwen layer-50 model")?;
     Ok(LoadedH3QwenNvfp4Conditioner {
         model,
-        artifact,
+        artifact: authority.artifact,
         device: device.clone(),
         memory_facts: expected_memory_facts,
     })
+}
+
+/// Compatibility wrapper for callers that do not need to inspect the opened
+/// evidence between authentication and allocation.
+///
+/// # Safety
+///
+/// The same authority requirements as
+/// [`open_h3_qwen_nvfp4_authority_after_authorization`] and
+/// [`load_h3_qwen_nvfp4_conditioner_from_authority`] apply.
+pub unsafe fn load_h3_qwen_nvfp4_conditioner_after_authorization(
+    path: &Path,
+    config: &H3ConditionerConfig,
+    device: &Device,
+    observer: &mut dyn H3QwenNvfp4LoadObserver,
+) -> Result<LoadedH3QwenNvfp4Conditioner, H3QwenNvfp4RuntimeError> {
+    config
+        .validate()
+        .map_err(|error| H3QwenNvfp4RuntimeError::Contract(error.to_string()))?;
+    if config != &released_config()? {
+        return Err(H3QwenNvfp4RuntimeError::Contract(
+            "runtime config differs from the frozen published layer-50 Qwen contract".into(),
+        ));
+    }
+    let placement = if device.is_cpu() {
+        H3QwenNvfp4RuntimePlacement::Cpu
+    } else {
+        H3QwenNvfp4RuntimePlacement::Accelerated
+    };
+    let authority =
+        unsafe { open_h3_qwen_nvfp4_authority_after_authorization(path, placement, observer)? };
+    unsafe { load_h3_qwen_nvfp4_conditioner_from_authority(authority, config, device, observer) }
 }
 
 fn load_linear(
@@ -707,10 +902,9 @@ mod tests {
         let path = sparse_published_fixture();
         let mut observer = CancelAuthentication { events: Vec::new() };
         let error = unsafe {
-            load_h3_qwen_nvfp4_conditioner_after_authorization(
+            open_h3_qwen_nvfp4_authority_after_authorization(
                 &path,
-                &released_config().unwrap(),
-                &Device::Cpu,
+                H3QwenNvfp4RuntimePlacement::Cpu,
                 &mut observer,
             )
         }

--- a/crates/mold-inference/src/minimax_h3/mod.rs
+++ b/crates/mold-inference/src/minimax_h3/mod.rs
@@ -11,6 +11,8 @@ pub(crate) mod pipeline;
 #[cfg(feature = "h3-private-uat")]
 pub(crate) mod private_fl2va_runtime;
 #[cfg(feature = "h3-private-uat")]
+pub(crate) mod private_opened_evidence;
+#[cfg(feature = "h3-private-uat")]
 pub mod private_qualification;
 #[cfg(feature = "h3-private-uat")]
 pub(crate) mod private_qwen;

--- a/crates/mold-inference/src/minimax_h3/pipeline.rs
+++ b/crates/mold-inference/src/minimax_h3/pipeline.rs
@@ -995,7 +995,7 @@ struct EncodedVideo {
     thumbnail_png: Vec<u8>,
 }
 
-fn collect_endpoint_bytes(
+pub(crate) fn collect_endpoint_bytes(
     req: &GenerateRequest,
     mode: Mode,
 ) -> Result<Vec<(H3EndpointAnchor, &[u8])>> {

--- a/crates/mold-inference/src/minimax_h3/private_opened_evidence.rs
+++ b/crates/mold-inference/src/minimax_h3/private_opened_evidence.rs
@@ -1,0 +1,1430 @@
+//! Opaque opened-evidence preparation for private MiniMax H3 FL2VA UAT.
+//!
+//! This non-shipping module resolves component locations only from the hidden
+//! manifest/storage contract, performs normal CPU endpoint preprocessing and
+//! seed resolution, and derives the existing factory value records from
+//! authenticated opened objects. It deliberately does not issue a scheduler
+//! lease, clear an activation prerequisite, or expose a server/family bridge.
+
+use std::fs::File;
+use std::path::{Component, Path, PathBuf};
+
+use anyhow::{anyhow, bail, Context, Result};
+use candle_core::Device;
+use mold_candle::minimax_h3::{
+    H3AuthenticatedQwenNvfp4Authority, H3ComfyOpenedInt8Checkpoint, H3ComfyPublishedArtifact,
+    H3QwenNvfp4RuntimePlacement, H3TransformerTask,
+};
+use mold_core::manifest::{find_manifest, storage_path, ModelComponent, ModelManifest};
+use mold_core::minimax_h3::{self as contract, Layout, Mode, Task};
+use mold_core::secure_file::{open_regular_file_no_follow, sha256_open_file};
+use mold_core::GenerateRequest;
+use sha2::{Digest, Sha256};
+
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
+
+use super::backend::prepare_fl2va_conditioner_input;
+use super::pipeline::{
+    collect_endpoint_bytes, prepare_request, H3EndpointAnchor, H3PipelineObserver,
+    H3PreparedFl2VaRequest,
+};
+use super::private_qwen_support::H3PrivateQwenSupport;
+use super::sampler::H3DualSchedule;
+use super::vae_runtime::{
+    FrozenH3ComfyVaeLoadPlan, H3AuthenticatedComfyVaeAuthority, H3ComfyVaeArtifactRole,
+};
+use crate::h3_factory::{
+    expected_h3_factory_prepared_attempt_identity, expected_h3_factory_prepared_request_identity,
+    expected_h3_factory_raw_checkpoint_identity, expected_h3_factory_target_budget_identity,
+    H3FactoryArtifactHostInput, H3FactoryArtifactHostRole, H3FactoryBlockMemoryInput,
+    H3FactoryEndpointAnchor, H3FactoryEndpointInput, H3FactoryEndpointPreprocess,
+    H3FactoryExecutionBudgetEchoInput, H3FactoryPreparedAttemptInput,
+    H3FactoryPreparedRequestInput, H3FactoryPreparedRowsInput, H3FactoryRawCheckpointInput,
+    H3FactoryTargetBudgetInput, H3FactoryTargetDenoiseCopyPolicy, H3FactoryTargetLoadDropPolicy,
+};
+use crate::progress::ProgressReporter;
+
+const FL2VA_TRANSFORMER_SOURCE: &str =
+    "diffusion_models/minimax_h3_fl2va_pruned_int8_convrot.safetensors";
+const QWEN_WEIGHT_SOURCE: &str = "text_encoders/qwen3vl_32b_minimax_h3_nvfp4_awq.safetensors";
+const FL2VA_TASK_CONFIG_SOURCE: &str = "transformer/config.json";
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct H3PrivateStorageRootIdentity {
+    #[cfg(unix)]
+    device: u64,
+    #[cfg(unix)]
+    inode: u64,
+    #[cfg(unix)]
+    user: u32,
+    #[cfg(unix)]
+    mode: u32,
+    #[cfg(unix)]
+    modified_seconds: i64,
+    #[cfg(unix)]
+    modified_nanoseconds: i64,
+    #[cfg(unix)]
+    changed_seconds: i64,
+    #[cfg(unix)]
+    changed_nanoseconds: i64,
+}
+
+impl H3PrivateStorageRootIdentity {
+    fn from_metadata(metadata: &std::fs::Metadata) -> Self {
+        Self {
+            #[cfg(unix)]
+            device: metadata.dev(),
+            #[cfg(unix)]
+            inode: metadata.ino(),
+            #[cfg(unix)]
+            user: metadata.uid(),
+            #[cfg(unix)]
+            mode: metadata.mode(),
+            #[cfg(unix)]
+            modified_seconds: metadata.mtime(),
+            #[cfg(unix)]
+            modified_nanoseconds: metadata.mtime_nsec(),
+            #[cfg(unix)]
+            changed_seconds: metadata.ctime(),
+            #[cfg(unix)]
+            changed_nanoseconds: metadata.ctime_nsec(),
+        }
+    }
+
+    fn update_digest(&self, digest: &mut Sha256) {
+        #[cfg(unix)]
+        for value in [
+            self.device,
+            self.inode,
+            u64::from(self.user),
+            u64::from(self.mode),
+            self.modified_seconds as u64,
+            self.modified_nanoseconds as u64,
+            self.changed_seconds as u64,
+            self.changed_nanoseconds as u64,
+        ] {
+            digest.update(value.to_le_bytes());
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct H3PrivateOpenedFileIdentity {
+    len: u64,
+    #[cfg(unix)]
+    device: u64,
+    #[cfg(unix)]
+    inode: u64,
+    #[cfg(unix)]
+    modified_seconds: i64,
+    #[cfg(unix)]
+    modified_nanoseconds: i64,
+    #[cfg(unix)]
+    changed_seconds: i64,
+    #[cfg(unix)]
+    changed_nanoseconds: i64,
+}
+
+impl H3PrivateOpenedFileIdentity {
+    fn from_metadata(metadata: &std::fs::Metadata) -> Self {
+        Self {
+            len: metadata.len(),
+            #[cfg(unix)]
+            device: metadata.dev(),
+            #[cfg(unix)]
+            inode: metadata.ino(),
+            #[cfg(unix)]
+            modified_seconds: metadata.mtime(),
+            #[cfg(unix)]
+            modified_nanoseconds: metadata.mtime_nsec(),
+            #[cfg(unix)]
+            changed_seconds: metadata.ctime(),
+            #[cfg(unix)]
+            changed_nanoseconds: metadata.ctime_nsec(),
+        }
+    }
+}
+
+struct H3PrivateOpenedTaskConfigAuthority {
+    path: PathBuf,
+    file: File,
+    identity: H3PrivateOpenedFileIdentity,
+    content_sha256: String,
+}
+
+impl H3PrivateOpenedTaskConfigAuthority {
+    fn open(path: &Path, expected_bytes: u64, expected_sha256: &str) -> Result<Self> {
+        require_sha256(expected_sha256, "private H3 task config")?;
+        let requested =
+            std::fs::symlink_metadata(path).context("failed to inspect private H3 task config")?;
+        if requested.file_type().is_symlink() || !requested.file_type().is_file() {
+            bail!("private H3 task config must be a regular non-symlink file")
+        }
+        #[cfg(unix)]
+        {
+            // SAFETY: `geteuid` has no preconditions and only reads process state.
+            let effective_uid = unsafe { libc::geteuid() };
+            if requested.uid() != effective_uid || requested.mode() & 0o022 != 0 {
+                bail!("private H3 task config must be process-owned and not group/other writable")
+            }
+        }
+        let path = std::fs::canonicalize(path)?;
+        let file = open_regular_file_no_follow(&path)?;
+        fs2::FileExt::lock_shared(&file)?;
+        let identity = H3PrivateOpenedFileIdentity::from_metadata(&file.metadata()?);
+        if identity != H3PrivateOpenedFileIdentity::from_metadata(&requested)
+            || identity.len != expected_bytes
+        {
+            bail!("private H3 task config changed while its descriptor was opened")
+        }
+        let content_sha256 = sha256_open_file(&file)?;
+        if content_sha256 != expected_sha256 {
+            bail!("private H3 task config content differs from the hidden manifest")
+        }
+        let authority = Self {
+            path,
+            file,
+            identity,
+            content_sha256,
+        };
+        authority.revalidate()?;
+        Ok(authority)
+    }
+
+    fn revalidate(&self) -> Result<()> {
+        let descriptor = H3PrivateOpenedFileIdentity::from_metadata(&self.file.metadata()?);
+        let current = open_regular_file_no_follow(&self.path)?;
+        let path_identity = H3PrivateOpenedFileIdentity::from_metadata(&current.metadata()?);
+        let content_sha256 = sha256_open_file(&self.file)?;
+        if descriptor != self.identity
+            || path_identity != self.identity
+            || content_sha256 != self.content_sha256
+        {
+            bail!("private H3 task config changed after authentication")
+        }
+        Ok(())
+    }
+
+    fn file_bytes(&self) -> u64 {
+        self.identity.len
+    }
+}
+
+/// Exact hidden-manifest paths for the private Comfy FL2VA partition.
+///
+/// This value is intentionally non-Clone. It binds the canonical models-root
+/// identity and never accepts `ModelPaths` or config-file overrides.
+pub(crate) struct H3PrivateComfyStorageAuthority {
+    models_root: PathBuf,
+    root_identity: H3PrivateStorageRootIdentity,
+    transformer: PathBuf,
+    qwen_weights: PathBuf,
+    task_config: PathBuf,
+    identity_sha256: String,
+}
+
+impl H3PrivateComfyStorageAuthority {
+    pub(crate) fn resolve(models_root: &Path) -> Result<Self> {
+        let (models_root, root_identity) = validate_storage_root(models_root)?;
+        let manifest = private_fl2va_manifest()?;
+        let transformer = resolve_component(
+            manifest,
+            &models_root,
+            FL2VA_TRANSFORMER_SOURCE,
+            ModelComponent::Transformer,
+        )?;
+        let qwen_weights = resolve_component(
+            manifest,
+            &models_root,
+            QWEN_WEIGHT_SOURCE,
+            ModelComponent::TextEncoder,
+        )?;
+        let task_config = resolve_component(
+            manifest,
+            &models_root,
+            FL2VA_TASK_CONFIG_SOURCE,
+            ModelComponent::TaskConfig,
+        )?;
+        let mut authority = Self {
+            models_root,
+            root_identity,
+            transformer,
+            qwen_weights,
+            task_config,
+            identity_sha256: String::new(),
+        };
+        authority.identity_sha256 = storage_authority_identity(&authority);
+        authority.validate()?;
+        Ok(authority)
+    }
+
+    pub(crate) fn transformer_path(&self) -> &Path {
+        &self.transformer
+    }
+
+    pub(crate) fn qwen_weights_path(&self) -> &Path {
+        &self.qwen_weights
+    }
+
+    pub(crate) fn task_config_path(&self) -> &Path {
+        &self.task_config
+    }
+
+    pub(crate) fn identity_sha256(&self) -> &str {
+        &self.identity_sha256
+    }
+
+    pub(crate) fn vae_plan(&self, staging_root: &Path) -> Result<FrozenH3ComfyVaeLoadPlan> {
+        self.validate()?;
+        FrozenH3ComfyVaeLoadPlan::from_hidden_storage(
+            contract::FL2VA_COMFY,
+            &self.models_root,
+            staging_root,
+        )
+        .map_err(Into::into)
+    }
+
+    fn open_task_config(&self) -> Result<H3PrivateOpenedTaskConfigAuthority> {
+        self.validate()?;
+        let manifest = private_fl2va_manifest()?;
+        let matches = manifest
+            .files
+            .iter()
+            .filter(|file| {
+                file.hf_filename == FL2VA_TASK_CONFIG_SOURCE
+                    && file.component == ModelComponent::TaskConfig
+            })
+            .collect::<Vec<_>>();
+        let [file] = matches.as_slice() else {
+            bail!("hidden MiniMax H3 manifest requires exactly one FL2VA task config")
+        };
+        if self.task_config != self.models_root.join(storage_path(manifest, file)) {
+            bail!("private H3 task config path differs from hidden storage authority")
+        }
+        let expected_sha256 = file
+            .sha256
+            .ok_or_else(|| anyhow!("hidden MiniMax H3 task config has no digest"))?;
+        let authority = H3PrivateOpenedTaskConfigAuthority::open(
+            &self.task_config,
+            file.size_bytes,
+            expected_sha256,
+        )?;
+        if authority.path != self.task_config {
+            bail!("private H3 task config resolves outside hidden storage authority")
+        }
+        Ok(authority)
+    }
+
+    fn vae_source_path(&self, role: H3ComfyVaeArtifactRole) -> Result<PathBuf> {
+        resolve_component(
+            private_fl2va_manifest()?,
+            &self.models_root,
+            role.source_path(),
+            role.manifest_component(),
+        )
+    }
+
+    fn validate_opened_components(
+        &self,
+        support: &H3PrivateQwenSupport,
+        transformer: &H3ComfyOpenedInt8Checkpoint,
+        qwen: &H3AuthenticatedQwenNvfp4Authority,
+        vae: &H3AuthenticatedComfyVaeAuthority,
+    ) -> Result<()> {
+        self.validate()?;
+        support.revalidate()?;
+        support.validate_storage_root(&self.models_root)?;
+        transformer.revalidate()?;
+        qwen.revalidate()?;
+        vae.validate()?;
+        validate_fl2va_transformer_contract(transformer.candidate().artifact)?;
+        validate_fl2va_vae_contract(vae.task(), vae.canonical_model())?;
+        if transformer.source_path() != self.transformer || qwen.source_path() != self.qwen_weights
+        {
+            bail!(
+                "private H3 opened component does not belong to the hidden FL2VA storage authority"
+            )
+        }
+        for role in H3ComfyVaeArtifactRole::ALL {
+            if vae.source_path(role)? != self.vae_source_path(role)? {
+                bail!("private H3 opened VAE path differs from hidden FL2VA storage authority")
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn validate(&self) -> Result<()> {
+        let (root, root_identity) = validate_storage_root(&self.models_root)?;
+        if root != self.models_root
+            || root_identity != self.root_identity
+            || self.identity_sha256 != storage_authority_identity(self)
+            || self.transformer
+                != resolve_component(
+                    private_fl2va_manifest()?,
+                    &root,
+                    FL2VA_TRANSFORMER_SOURCE,
+                    ModelComponent::Transformer,
+                )?
+            || self.qwen_weights
+                != resolve_component(
+                    private_fl2va_manifest()?,
+                    &root,
+                    QWEN_WEIGHT_SOURCE,
+                    ModelComponent::TextEncoder,
+                )?
+            || self.task_config
+                != resolve_component(
+                    private_fl2va_manifest()?,
+                    &root,
+                    FL2VA_TASK_CONFIG_SOURCE,
+                    ModelComponent::TaskConfig,
+                )?
+        {
+            bail!("private H3 hidden storage authority changed after resolution")
+        }
+        Ok(())
+    }
+}
+
+fn private_fl2va_manifest() -> Result<&'static ModelManifest> {
+    let manifest = find_manifest(contract::FL2VA_COMFY)
+        .ok_or_else(|| anyhow!("missing hidden MiniMax H3 FL2VA Comfy manifest"))?;
+    let manifest_contract = contract::manifest_contract(manifest)
+        .ok_or_else(|| anyhow!("hidden MiniMax H3 manifest lost its contract"))?;
+    if manifest.name != contract::FL2VA_COMFY
+        || manifest.family != contract::FAMILY
+        || !manifest.hidden
+        || manifest_contract.task != Task::Fl2va
+        || manifest_contract.layout != Layout::ComfyPrunedInt8ConvrotNvfp4Awq
+        || manifest_contract.runtime_available
+    {
+        bail!("private H3 storage requires the exact inactive hidden FL2VA Comfy manifest")
+    }
+    Ok(manifest)
+}
+
+fn resolve_component(
+    manifest: &ModelManifest,
+    models_root: &Path,
+    source_path: &str,
+    component: ModelComponent,
+) -> Result<PathBuf> {
+    let matches = manifest
+        .files
+        .iter()
+        .filter(|file| file.hf_filename == source_path && file.component == component)
+        .collect::<Vec<_>>();
+    let [file] = matches.as_slice() else {
+        bail!("hidden MiniMax H3 manifest requires exactly one {source_path}")
+    };
+    let relative = storage_path(manifest, file);
+    if relative.is_absolute()
+        || relative
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        bail!("hidden MiniMax H3 manifest produced an unsafe component path")
+    }
+    Ok(models_root.join(relative))
+}
+
+fn validate_storage_root(path: &Path) -> Result<(PathBuf, H3PrivateStorageRootIdentity)> {
+    if !path.is_absolute()
+        || path
+            .components()
+            .any(|component| !matches!(component, Component::RootDir | Component::Normal(_)))
+    {
+        bail!("private H3 models root must be an absolute canonical path")
+    }
+    let metadata =
+        std::fs::symlink_metadata(path).context("failed to inspect private H3 models root")?;
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        bail!("private H3 models root must be a real non-symlink directory")
+    }
+    #[cfg(unix)]
+    {
+        // SAFETY: `geteuid` has no preconditions and only reads process state.
+        let effective_uid = unsafe { libc::geteuid() };
+        if metadata.uid() != effective_uid || metadata.mode() & 0o022 != 0 {
+            bail!("private H3 models root must be process-owned and not group/other writable")
+        }
+    }
+    #[cfg(not(unix))]
+    bail!("private H3 opened storage currently requires Unix ownership semantics");
+    let canonical = std::fs::canonicalize(path)?;
+    if canonical != path {
+        bail!("private H3 models root must not contain aliases or symlink components")
+    }
+    Ok((
+        canonical,
+        H3PrivateStorageRootIdentity::from_metadata(&metadata),
+    ))
+}
+
+fn storage_authority_identity(authority: &H3PrivateComfyStorageAuthority) -> String {
+    let mut digest = Sha256::new();
+    digest.update(b"mold.minimax-h3.private-hidden-storage.v1\0");
+    authority.root_identity.update_digest(&mut digest);
+    for path in [
+        &authority.models_root,
+        &authority.transformer,
+        &authority.qwen_weights,
+        &authority.task_config,
+    ] {
+        let bytes = path.as_os_str().as_encoded_bytes();
+        digest.update((bytes.len() as u64).to_le_bytes());
+        digest.update(bytes);
+    }
+    format!("{:x}", digest.finalize())
+}
+
+/// Independently qualified non-artifact runtime bounds. Artifact, geometry,
+/// row, residency, and phase totals are never accepted through this type;
+/// they are recomputed by the binder below.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct H3PrivateQualifiedRuntimeBounds {
+    pub(crate) fixed_runtime_host_bytes: u64,
+    pub(crate) fixed_runtime_device_bytes: u64,
+    pub(crate) qwen_activation_workspace_bytes: u64,
+    pub(crate) vae_construction_device_workspace_bytes: u64,
+    pub(crate) condition_vae_workspace_device_bytes: u64,
+    pub(crate) attention_workspace_device_bytes: u64,
+    pub(crate) ffn_workspace_device_bytes: u64,
+    pub(crate) decoder_tile_workspace_device_bytes: u64,
+    pub(crate) audio_decode_workspace_device_bytes: u64,
+    pub(crate) encoded_video_host_bytes_bound: u64,
+    pub(crate) thumbnail_host_bytes_bound: u64,
+    pub(crate) mux_output_host_bytes_bound: u64,
+    pub(crate) aac_mux_staging_host_bytes: u64,
+}
+
+impl H3PrivateQualifiedRuntimeBounds {
+    fn validate(&self) -> Result<()> {
+        if [
+            self.fixed_runtime_host_bytes,
+            self.fixed_runtime_device_bytes,
+            self.qwen_activation_workspace_bytes,
+            self.vae_construction_device_workspace_bytes,
+            self.condition_vae_workspace_device_bytes,
+            self.attention_workspace_device_bytes,
+            self.ffn_workspace_device_bytes,
+            self.decoder_tile_workspace_device_bytes,
+            self.audio_decode_workspace_device_bytes,
+            self.encoded_video_host_bytes_bound,
+            self.thumbnail_host_bytes_bound,
+            self.mux_output_host_bytes_bound,
+            self.aac_mux_staging_host_bytes,
+        ]
+        .contains(&0)
+        {
+            bail!("private H3 qualified runtime bounds must all be nonzero")
+        }
+        Ok(())
+    }
+}
+
+/// Opaque, one-shot prepared attempt. The concrete normalized CPU tensors and
+/// resolved seed stay owned here until the caller consumes the record.
+pub(crate) struct H3PrivatePreparedFl2VaAttempt {
+    prepared: H3PreparedFl2VaRequest,
+    factory_attempt: H3FactoryPreparedAttemptInput,
+    budget_echo: H3FactoryExecutionBudgetEchoInput,
+    // Retain the authenticated descriptor so the artifact priced into the
+    // prepared budget cannot be replaced before these inputs are consumed.
+    _transformer_support: H3PrivateOpenedTaskConfigAuthority,
+}
+
+pub(crate) struct H3PrivatePreparedFl2VaFactoryInputs {
+    pub(crate) prepared: H3PreparedFl2VaRequest,
+    pub(crate) factory_attempt: H3FactoryPreparedAttemptInput,
+    pub(crate) budget_echo: H3FactoryExecutionBudgetEchoInput,
+    _transformer_support: H3PrivateOpenedTaskConfigAuthority,
+}
+
+impl H3PrivatePreparedFl2VaAttempt {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn prepare(
+        request: &GenerateRequest,
+        execution_fingerprint: &str,
+        storage: &H3PrivateComfyStorageAuthority,
+        support: &H3PrivateQwenSupport,
+        transformer: &H3ComfyOpenedInt8Checkpoint,
+        qwen: &H3AuthenticatedQwenNvfp4Authority,
+        vae: &H3AuthenticatedComfyVaeAuthority,
+        bounds: &H3PrivateQualifiedRuntimeBounds,
+        progress: &ProgressReporter,
+        observer: &mut dyn H3PipelineObserver,
+    ) -> Result<Self> {
+        require_sha256(execution_fingerprint, "private H3 execution fingerprint")?;
+        bounds.validate()?;
+        storage.validate_opened_components(support, transformer, qwen, vae)?;
+        let transformer_support = storage.open_task_config()?;
+        transformer_support.revalidate()?;
+        let mode = contract::validate_request_contract(request, Task::Fl2va)
+            .map_err(|error| anyhow!("{}: {}", error.code, error.message))?;
+        let encoded_endpoints = collect_endpoint_bytes(request, mode)?
+            .into_iter()
+            .map(|(anchor, bytes)| (anchor, bytes.len() as u64, sha256(bytes)))
+            .collect::<Vec<_>>();
+        let prepared = prepare_request(request, progress, observer)?;
+        let factory_request =
+            prepared_request_input(request, mode, &prepared, &encoded_endpoints, support)?;
+        let raw_checkpoint = raw_checkpoint_input(transformer)?;
+        let target_budget = bind_target_budget(
+            &factory_request,
+            &raw_checkpoint,
+            support,
+            qwen,
+            vae,
+            &transformer_support,
+            bounds,
+        )?;
+        let mut factory_attempt = H3FactoryPreparedAttemptInput {
+            identity_sha256: String::new(),
+            execution_fingerprint: execution_fingerprint.to_owned(),
+            request: factory_request,
+            raw_checkpoint,
+            target_budget,
+        };
+        factory_attempt.identity_sha256 =
+            expected_h3_factory_prepared_attempt_identity(&factory_attempt);
+        let budget_echo = H3FactoryExecutionBudgetEchoInput {
+            prepared_attempt_identity_sha256: factory_attempt.identity_sha256.clone(),
+            device_peak_bytes: factory_attempt.target_budget.predicted_device_peak_bytes,
+            host_increment_bytes: factory_attempt.target_budget.predicted_host_increment_bytes,
+        };
+        Ok(Self {
+            prepared,
+            factory_attempt,
+            budget_echo,
+            _transformer_support: transformer_support,
+        })
+    }
+
+    pub(crate) fn seed(&self) -> u64 {
+        self.prepared.seed
+    }
+
+    pub(crate) fn identity_sha256(&self) -> &str {
+        &self.factory_attempt.identity_sha256
+    }
+
+    pub(crate) fn into_factory_inputs(self) -> H3PrivatePreparedFl2VaFactoryInputs {
+        H3PrivatePreparedFl2VaFactoryInputs {
+            prepared: self.prepared,
+            factory_attempt: self.factory_attempt,
+            budget_echo: self.budget_echo,
+            _transformer_support: self._transformer_support,
+        }
+    }
+}
+
+fn prepared_request_input(
+    request: &GenerateRequest,
+    mode: Mode,
+    prepared: &H3PreparedFl2VaRequest,
+    encoded: &[(H3EndpointAnchor, u64, String)],
+    support: &H3PrivateQwenSupport,
+) -> Result<H3FactoryPreparedRequestInput> {
+    if support.model() != contract::FL2VA_COMFY || support.task() != Task::Fl2va {
+        bail!("private H3 prepared request has cross-task Qwen support")
+    }
+    let (conditioner, _) = prepare_fl2va_conditioner_input(
+        support.tokenizer(),
+        &prepared.prompt,
+        &prepared.endpoints,
+        &Device::Cpu,
+    )?;
+    let (_, qwen_output_text_rows) = conditioner.input_ids.dims2()?;
+    let qwen_vision_rows = conditioner
+        .image
+        .as_ref()
+        .map(|image| image.pixel_values.dim(0))
+        .transpose()?
+        .unwrap_or(0);
+    let mut endpoints = Vec::with_capacity(prepared.endpoints.len());
+    for (index, endpoint) in prepared.endpoints.iter().enumerate() {
+        let (encoded_anchor, encoded_bytes, encoded_sha256) = encoded
+            .get(index)
+            .ok_or_else(|| anyhow!("private H3 encoded endpoint vector is incomplete"))?;
+        if *encoded_anchor != endpoint.anchor {
+            bail!("private H3 encoded and normalized endpoint order differs")
+        }
+        let pixels = endpoint.pixels.flatten_all()?.to_vec1::<u8>()?;
+        let normalized_shape = endpoint
+            .pixels
+            .dims5()
+            .map(|(b, c, t, h, w)| [b, c, t, h, w])?
+            .map(u32::try_from)
+            .into_iter()
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        let normalized_shape: [u32; 5] = normalized_shape
+            .try_into()
+            .map_err(|_| anyhow!("private H3 normalized endpoint shape changed"))?;
+        endpoints.push(H3FactoryEndpointInput {
+            anchor: factory_anchor(endpoint.anchor),
+            encoded_bytes: *encoded_bytes,
+            encoded_content_sha256: encoded_sha256.clone(),
+            preprocess: H3FactoryEndpointPreprocess::PillowLanczosRgbU8CpuV1,
+            normalized_shape,
+            normalized_cpu_bytes: pixels.len() as u64,
+            normalized_cpu_content_sha256: sha256(&pixels),
+        });
+    }
+    if endpoints.len() != encoded.len() {
+        bail!("private H3 endpoint preprocessing lost an encoded endpoint")
+    }
+    let geometry = &prepared.geometry;
+    let qwen_output_text_rows = u64::try_from(qwen_output_text_rows)?;
+    let qwen_vision_rows = u64::try_from(qwen_vision_rows)?;
+    let condition_visual_rows = u64::try_from(geometry.condition_video_rows)?;
+    let target_video_rows = u64::try_from(geometry.generated_video_rows)?;
+    let target_audio_rows = u64::try_from(geometry.generated_audio_rows)?;
+    let total_packed_rows = [
+        qwen_output_text_rows,
+        condition_visual_rows,
+        target_video_rows,
+        target_audio_rows,
+    ]
+    .into_iter()
+    .try_fold(0_u64, |sum, value| sum.checked_add(value))
+    .ok_or_else(|| anyhow!("private H3 packed row count overflow"))?;
+    let conditioning_fingerprint = conditioning_fingerprint(&endpoints);
+    let reference_fingerprint = sha256(b"mold.minimax-h3.fl2va-no-references.v1");
+    let schedule = H3DualSchedule::new(prepared.grid_points)?;
+    let counts = schedule.counts();
+    let mut input = H3FactoryPreparedRequestInput {
+        identity_sha256: String::new(),
+        canonical_model: contract::FL2VA_COMFY.into(),
+        task: Task::Fl2va,
+        mode,
+        prompt_sha256: sha256(prepared.prompt.as_bytes()),
+        seed: prepared.seed,
+        grid_points: u32::try_from(prepared.grid_points)?,
+        denoise_forward_count: u32::try_from(counts.transformer_evaluations)?,
+        guidance_f64_bits: request.guidance.to_bits(),
+        strength_f64_bits: request.strength.to_bits(),
+        batch_size: request.batch_size,
+        width: u32::try_from(geometry.width)?,
+        height: u32::try_from(geometry.height)?,
+        frames: u32::try_from(geometry.frames)?,
+        fps: contract::FIXED_FPS,
+        synchronized_audio: true,
+        mp4_output: true,
+        video_latent_frames: u64::try_from(geometry.latent_frames)?,
+        audio_latents_per_channel: u64::try_from(geometry.audio_latents_per_channel)?,
+        audio_samples_per_channel: u64::try_from(geometry.audio_latents_per_channel)?
+            .checked_mul(800)
+            .ok_or_else(|| anyhow!("private H3 audio sample count overflow"))?,
+        conditioning_fingerprint,
+        reference_fingerprint,
+        endpoints,
+        rows: H3FactoryPreparedRowsInput {
+            qwen_output_text_rows,
+            qwen_vision_rows,
+            condition_visual_rows,
+            condition_audio_rows: 0,
+            target_video_rows,
+            target_audio_rows,
+            total_packed_rows,
+        },
+    };
+    input.identity_sha256 = expected_h3_factory_prepared_request_identity(&input);
+    Ok(input)
+}
+
+fn raw_checkpoint_input(
+    transformer: &H3ComfyOpenedInt8Checkpoint,
+) -> Result<H3FactoryRawCheckpointInput> {
+    transformer.revalidate()?;
+    validate_fl2va_transformer_contract(transformer.candidate().artifact)?;
+    let evidence = transformer.memory_evidence();
+    if transformer.content_sha256()
+        != H3ComfyPublishedArtifact::Fl2VaPrunedInt8ConvRot.content_sha256()
+        || evidence.verified_file_bytes
+            != H3ComfyPublishedArtifact::Fl2VaPrunedInt8ConvRot.file_bytes()
+        || evidence.blocks.len() != 50
+    {
+        bail!("private H3 opened transformer evidence differs from the exact FL2VA artifact")
+    }
+    let blocks = evidence
+        .blocks
+        .iter()
+        .map(|block| H3FactoryBlockMemoryInput {
+            index: block.index,
+            encoded_host_bytes: block.memory.encoded_host_bytes,
+            protected_device_bytes: block.memory.protected_device_bytes,
+            max_device_weight_staging_bytes: block.memory.max_device_weight_staging_bytes,
+            max_host_read_staging_bytes: block.memory.max_host_read_staging_bytes,
+            content_sha256: block.content_sha256.clone(),
+        })
+        .collect();
+    let mut input = H3FactoryRawCheckpointInput {
+        identity_sha256: String::new(),
+        raw_content_sha256: transformer.content_sha256().into(),
+        verified_file_bytes: evidence.verified_file_bytes,
+        raw_header_identity_sha256: transformer.candidate().header_identity_sha256.clone(),
+        opened_checkpoint_identity_sha256: transformer.checkpoint_identity_sha256().into(),
+        quantization_policy_identity_sha256: transformer
+            .candidate()
+            .strategy
+            .quantization_policy
+            .policy_sha256
+            .clone(),
+        config_identity_sha256: transformer.config_identity_sha256(),
+        fixed_transformer_encoded_host_bytes: evidence.fixed_encoded_host_bytes,
+        fixed_transformer_protected_device_bytes: evidence.fixed_protected_device_bytes,
+        fixed_transformer_max_host_read_staging_bytes: evidence.fixed_max_host_read_staging_bytes,
+        fixed_transformer_max_device_weight_staging_bytes: evidence
+            .fixed_max_device_weight_staging_bytes,
+        blocks,
+    };
+    input.identity_sha256 = expected_h3_factory_raw_checkpoint_identity(&input);
+    Ok(input)
+}
+
+fn validate_fl2va_transformer_contract(artifact: H3ComfyPublishedArtifact) -> Result<()> {
+    if artifact != H3ComfyPublishedArtifact::Fl2VaPrunedInt8ConvRot
+        || artifact.task() != H3TransformerTask::T2VaFl2Va
+    {
+        bail!("private H3 prepared attempt requires the exact FL2VA INT8 ConvRot transformer")
+    }
+    Ok(())
+}
+
+fn validate_fl2va_vae_contract(task: Task, canonical_model: &str) -> Result<()> {
+    if task != Task::Fl2va || canonical_model != contract::FL2VA_COMFY {
+        bail!("private H3 prepared attempt requires the exact FL2VA VAE authority")
+    }
+    Ok(())
+}
+
+fn bind_target_budget(
+    request: &H3FactoryPreparedRequestInput,
+    checkpoint: &H3FactoryRawCheckpointInput,
+    support: &H3PrivateQwenSupport,
+    qwen: &H3AuthenticatedQwenNvfp4Authority,
+    vae: &H3AuthenticatedComfyVaeAuthority,
+    transformer_support: &H3PrivateOpenedTaskConfigAuthority,
+    bounds: &H3PrivateQualifiedRuntimeBounds,
+) -> Result<H3FactoryTargetBudgetInput> {
+    transformer_support.revalidate()?;
+    let mut artifacts = support
+        .artifact_facts()
+        .iter()
+        .enumerate()
+        .map(|(index, fact)| {
+            Ok(H3FactoryArtifactHostInput {
+                role: H3FactoryArtifactHostRole::Conditioner,
+                index: u16::try_from(index)?,
+                content_sha256: fact.content_sha256.clone(),
+                bytes: fact.file_bytes,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    artifacts.push(H3FactoryArtifactHostInput {
+        role: H3FactoryArtifactHostRole::Conditioner,
+        index: u16::try_from(artifacts.len())?,
+        content_sha256: qwen.artifact_identity_sha256().into(),
+        bytes: qwen.artifact_file_bytes(),
+    });
+    artifacts.push(H3FactoryArtifactHostInput {
+        role: H3FactoryArtifactHostRole::RawTransformerCheckpoint,
+        index: 0,
+        content_sha256: checkpoint.raw_content_sha256.clone(),
+        bytes: checkpoint.verified_file_bytes,
+    });
+    artifacts.push(H3FactoryArtifactHostInput {
+        role: H3FactoryArtifactHostRole::TransformerSupport,
+        index: 0,
+        content_sha256: transformer_support.content_sha256.clone(),
+        bytes: transformer_support.file_bytes(),
+    });
+    let mut visual_index = 0_u16;
+    let mut audio_index = 0_u16;
+    for fact in vae.artifact_facts() {
+        let (role, index) = match fact.role {
+            H3ComfyVaeArtifactRole::VisualConfig | H3ComfyVaeArtifactRole::VisualWeights => {
+                let index = visual_index;
+                visual_index += 1;
+                (H3FactoryArtifactHostRole::VisualVae, index)
+            }
+            H3ComfyVaeArtifactRole::AudioConfig | H3ComfyVaeArtifactRole::AudioWeights => {
+                let index = audio_index;
+                audio_index += 1;
+                (H3FactoryArtifactHostRole::AudioVae, index)
+            }
+        };
+        artifacts.push(H3FactoryArtifactHostInput {
+            role,
+            index,
+            content_sha256: fact.content_sha256.clone(),
+            bytes: fact.file_bytes,
+        });
+    }
+    artifacts.sort_by_key(|artifact| (artifact.role, artifact.index));
+    let artifact_host_bytes = checked_sum(artifacts.iter().map(|artifact| artifact.bytes))?;
+    let qwen_memory = qwen.memory_facts();
+    let qwen_output_state_device_bytes = request
+        .rows
+        .qwen_output_text_rows
+        .checked_mul(5_120 * 2)
+        .ok_or_else(|| anyhow!("private H3 Qwen output bytes overflow"))?;
+    let (
+        qwen_host_activation_bytes,
+        qwen_host_output_state_bytes,
+        qwen_device_parameter_bytes,
+        qwen_activation_device_bytes,
+        qwen_output_transfer_device_bytes,
+    ) = match qwen.placement() {
+        H3QwenNvfp4RuntimePlacement::Accelerated => (
+            0,
+            0,
+            qwen_memory.device_resident_parameter_bytes,
+            bounds.qwen_activation_workspace_bytes,
+            0,
+        ),
+        H3QwenNvfp4RuntimePlacement::Cpu => (
+            bounds.qwen_activation_workspace_bytes,
+            qwen_output_state_device_bytes,
+            0,
+            0,
+            qwen_output_state_device_bytes,
+        ),
+    };
+    let qwen_host_parameter_bytes = qwen_memory.host_resident_parameter_bytes;
+    let qwen_host_workspace_bytes = checked_sum([
+        qwen_host_parameter_bytes,
+        qwen_host_activation_bytes,
+        qwen_host_output_state_bytes,
+    ])?;
+    let condition_latent_backing_device_bytes = request
+        .rows
+        .condition_visual_rows
+        .checked_mul(96 * 4)
+        .ok_or_else(|| anyhow!("private H3 condition latent bytes overflow"))?;
+    let target_video_latent_device_bytes = request
+        .rows
+        .target_video_rows
+        .checked_mul(96 * 4)
+        .ok_or_else(|| anyhow!("private H3 target video bytes overflow"))?;
+    let target_audio_latent_device_bytes = request
+        .rows
+        .target_audio_rows
+        .checked_mul(32 * 4)
+        .ok_or_else(|| anyhow!("private H3 target audio bytes overflow"))?;
+    let packed_video_state_device_bytes = condition_latent_backing_device_bytes
+        .checked_add(target_video_latent_device_bytes)
+        .ok_or_else(|| anyhow!("private H3 packed video bytes overflow"))?;
+    let packed_audio_state_device_bytes = target_audio_latent_device_bytes;
+    let packed_layout_device_bytes = request
+        .rows
+        .total_packed_rows
+        .checked_mul(24)
+        .ok_or_else(|| anyhow!("private H3 packed layout bytes overflow"))?;
+    let denoise_tensor_copy_workspace_device_bytes = packed_video_state_device_bytes
+        .checked_add(packed_audio_state_device_bytes)
+        .and_then(|bytes| bytes.checked_mul(6))
+        .ok_or_else(|| anyhow!("private H3 denoise copy bytes overflow"))?;
+    let waveform_host_bytes = request
+        .audio_samples_per_channel
+        .checked_mul(u64::from(contract::AUDIO_CHANNELS))
+        .and_then(|samples| samples.checked_mul(4))
+        .ok_or_else(|| anyhow!("private H3 waveform bytes overflow"))?;
+    let vae_memory = vae.memory();
+    let retained_vaes = vae_memory.resident_device_weight_bytes;
+    let max_device_weight_staging_bytes = checkpoint
+        .blocks
+        .iter()
+        .map(|block| block.max_device_weight_staging_bytes)
+        .max()
+        .unwrap_or(0);
+    let max_host_read_staging_bytes = checkpoint
+        .blocks
+        .iter()
+        .map(|block| block.max_host_read_staging_bytes)
+        .max()
+        .unwrap_or(0);
+    let streamed_block_device_overlap_bytes = checkpoint
+        .blocks
+        .iter()
+        .map(|block| block.protected_device_bytes)
+        .max()
+        .unwrap_or(0);
+    let max_streamed_block_host_overlap_bytes = checkpoint
+        .blocks
+        .iter()
+        .map(|block| {
+            block
+                .encoded_host_bytes
+                .checked_add(block.max_host_read_staging_bytes)
+                .ok_or_else(|| anyhow!("private H3 streamed host overlap overflow"))
+        })
+        .collect::<Result<Vec<_>>>()?
+        .into_iter()
+        .max()
+        .unwrap_or(0);
+    let fixed_transformer_load_host_staging_bytes = checkpoint
+        .fixed_transformer_encoded_host_bytes
+        .checked_add(checkpoint.fixed_transformer_max_host_read_staging_bytes)
+        .ok_or_else(|| anyhow!("private H3 fixed host staging overflow"))?;
+    let fixed_transformer_load_device_staging_bytes =
+        checkpoint.fixed_transformer_max_device_weight_staging_bytes;
+    let protected_block_device_bytes = checked_sum(
+        checkpoint
+            .blocks
+            .iter()
+            .map(|block| block.protected_device_bytes),
+    )?;
+    let streamed_block_device_bytes = protected_block_device_bytes;
+    let endpoint_encoded_host_bytes = checked_sum(
+        request
+            .endpoints
+            .iter()
+            .map(|endpoint| endpoint.encoded_bytes),
+    )?;
+    let normalized_endpoint_host_bytes = checked_sum(
+        request
+            .endpoints
+            .iter()
+            .map(|endpoint| endpoint.normalized_cpu_bytes),
+    )?;
+    let schedule_host_bytes = u64::from(request.grid_points) * 16;
+    let packed_layout_host_bytes = request.rows.total_packed_rows * 24;
+    let packed_layout_construction_staging_host_bytes = request.rows.total_packed_rows * 16;
+    let packed_layout_freeze_staging_host_bytes = request.rows.total_packed_rows * 12;
+    let text_modality_tags_host_bytes = request.rows.qwen_output_text_rows * 8;
+    let noise_cpu_staging_host_bytes = condition_latent_backing_device_bytes
+        .max(target_video_latent_device_bytes)
+        .max(target_audio_latent_device_bytes);
+    let condition_backing_host_bytes = condition_latent_backing_device_bytes;
+    let condition_vae_workspace_device_bytes = if request.rows.condition_visual_rows == 0 {
+        0
+    } else {
+        bounds.condition_vae_workspace_device_bytes
+    };
+    let vae_load_phase_device_bytes = checked_sum([
+        bounds.fixed_runtime_device_bytes,
+        retained_vaes,
+        bounds.vae_construction_device_workspace_bytes,
+    ])?;
+    let qwen_encode_phase_device_bytes = match qwen.placement() {
+        H3QwenNvfp4RuntimePlacement::Accelerated => checked_sum([
+            bounds.fixed_runtime_device_bytes,
+            retained_vaes,
+            qwen_device_parameter_bytes,
+            qwen_activation_device_bytes,
+            qwen_output_state_device_bytes,
+        ])?,
+        H3QwenNvfp4RuntimePlacement::Cpu => {
+            checked_sum([bounds.fixed_runtime_device_bytes, retained_vaes])?
+        }
+    };
+    let qwen_transfer_phase_device_bytes = match qwen.placement() {
+        H3QwenNvfp4RuntimePlacement::Accelerated => 0,
+        H3QwenNvfp4RuntimePlacement::Cpu => checked_sum([
+            bounds.fixed_runtime_device_bytes,
+            retained_vaes,
+            qwen_output_transfer_device_bytes,
+        ])?,
+    };
+    let condition_encode_phase_device_bytes = checked_sum([
+        bounds.fixed_runtime_device_bytes,
+        retained_vaes,
+        qwen_output_state_device_bytes,
+        condition_vae_workspace_device_bytes,
+        condition_latent_backing_device_bytes,
+        packed_layout_device_bytes,
+    ])?;
+    let noise_allocation_phase_device_bytes = checked_sum([
+        bounds.fixed_runtime_device_bytes,
+        retained_vaes,
+        qwen_output_state_device_bytes,
+        condition_latent_backing_device_bytes,
+        condition_latent_backing_device_bytes,
+        packed_layout_device_bytes,
+        target_video_latent_device_bytes,
+        target_video_latent_device_bytes,
+        target_audio_latent_device_bytes,
+        target_audio_latent_device_bytes,
+        packed_video_state_device_bytes,
+        packed_audio_state_device_bytes,
+    ])?;
+    let transformer_load_phase_device_bytes = checked_sum([
+        bounds.fixed_runtime_device_bytes,
+        retained_vaes,
+        checkpoint.fixed_transformer_protected_device_bytes,
+        qwen_output_state_device_bytes,
+        condition_latent_backing_device_bytes,
+        packed_layout_device_bytes,
+        packed_video_state_device_bytes,
+        packed_audio_state_device_bytes,
+        fixed_transformer_load_device_staging_bytes,
+    ])?;
+    let denoise_phase_device_bytes = checked_sum([
+        bounds.fixed_runtime_device_bytes,
+        retained_vaes,
+        checkpoint.fixed_transformer_protected_device_bytes,
+        qwen_output_state_device_bytes,
+        condition_latent_backing_device_bytes,
+        packed_layout_device_bytes,
+        packed_video_state_device_bytes,
+        packed_audio_state_device_bytes,
+        denoise_tensor_copy_workspace_device_bytes,
+        bounds.attention_workspace_device_bytes,
+        bounds.ffn_workspace_device_bytes,
+        streamed_block_device_overlap_bytes,
+        max_device_weight_staging_bytes,
+    ])?;
+    let visual_decode_phase_device_bytes = checked_sum([
+        bounds.fixed_runtime_device_bytes,
+        retained_vaes,
+        packed_video_state_device_bytes,
+        packed_audio_state_device_bytes,
+        target_video_latent_device_bytes,
+        target_audio_latent_device_bytes,
+        bounds.decoder_tile_workspace_device_bytes,
+    ])?;
+    let audio_decode_phase_device_bytes = checked_sum([
+        bounds.fixed_runtime_device_bytes,
+        retained_vaes,
+        packed_video_state_device_bytes,
+        packed_audio_state_device_bytes,
+        target_audio_latent_device_bytes,
+        bounds.audio_decode_workspace_device_bytes,
+        waveform_host_bytes,
+    ])?;
+    let waveform_transfer_phase_device_bytes = checked_sum([
+        bounds.fixed_runtime_device_bytes,
+        retained_vaes,
+        waveform_host_bytes,
+    ])?;
+    let predicted_device_peak_bytes = [
+        vae_load_phase_device_bytes,
+        qwen_encode_phase_device_bytes,
+        qwen_transfer_phase_device_bytes,
+        condition_encode_phase_device_bytes,
+        noise_allocation_phase_device_bytes,
+        transformer_load_phase_device_bytes,
+        denoise_phase_device_bytes,
+        visual_decode_phase_device_bytes,
+        audio_decode_phase_device_bytes,
+        waveform_transfer_phase_device_bytes,
+    ]
+    .into_iter()
+    .max()
+    .unwrap_or(0);
+    let predicted_host_increment_bytes = checked_sum([
+        artifact_host_bytes,
+        bounds.fixed_runtime_host_bytes,
+        qwen_host_workspace_bytes,
+        condition_backing_host_bytes,
+        endpoint_encoded_host_bytes,
+        normalized_endpoint_host_bytes,
+        schedule_host_bytes,
+        packed_layout_host_bytes,
+        packed_layout_construction_staging_host_bytes,
+        packed_layout_freeze_staging_host_bytes,
+        text_modality_tags_host_bytes,
+        noise_cpu_staging_host_bytes,
+        vae_memory.peak_host_io_buffer_bytes,
+        vae_memory.peak_host_mapped_file_bytes,
+        max_streamed_block_host_overlap_bytes,
+        fixed_transformer_load_host_staging_bytes,
+        bounds.encoded_video_host_bytes_bound,
+        bounds.thumbnail_host_bytes_bound,
+        waveform_host_bytes,
+        bounds.mux_output_host_bytes_bound,
+        bounds.aac_mux_staging_host_bytes,
+    ])?;
+    let mut budget = H3FactoryTargetBudgetInput {
+        identity_sha256: String::new(),
+        load_drop_policy: H3FactoryTargetLoadDropPolicy::LoadVaesLoadQwenEncodeTransferDropQwenEncodeConditionsAllocateNoiseLoadTransformerDenoiseDropTransformerDecodeVisualAudioDropVaesMux,
+        artifacts,
+        artifact_host_bytes,
+        fixed_runtime_host_bytes: bounds.fixed_runtime_host_bytes,
+        qwen_host_parameter_bytes,
+        qwen_host_activation_bytes,
+        qwen_host_output_state_bytes,
+        qwen_host_workspace_bytes,
+        condition_backing_host_bytes,
+        endpoint_encoded_host_bytes,
+        normalized_endpoint_host_bytes,
+        schedule_host_bytes,
+        packed_layout_host_bytes,
+        packed_layout_construction_staging_host_bytes,
+        packed_layout_freeze_staging_host_bytes,
+        text_modality_tags_host_bytes,
+        noise_cpu_staging_host_bytes,
+        vae_peak_host_io_buffer_bytes: vae_memory.peak_host_io_buffer_bytes,
+        vae_peak_host_mapped_file_bytes: vae_memory.peak_host_mapped_file_bytes,
+        vae_peak_staging_disk_bytes: vae_memory.peak_staging_disk_bytes,
+        max_host_read_staging_bytes,
+        max_streamed_block_host_overlap_bytes,
+        fixed_transformer_load_host_staging_bytes,
+        encoded_video_host_bytes_bound: bounds.encoded_video_host_bytes_bound,
+        thumbnail_host_bytes_bound: bounds.thumbnail_host_bytes_bound,
+        waveform_host_bytes,
+        mux_output_host_bytes_bound: bounds.mux_output_host_bytes_bound,
+        aac_mux_staging_host_bytes: bounds.aac_mux_staging_host_bytes,
+        predicted_host_increment_bytes,
+        fixed_runtime_device_bytes: bounds.fixed_runtime_device_bytes,
+        fixed_transformer_device_bytes: checkpoint.fixed_transformer_protected_device_bytes,
+        visual_vae_resident_device_bytes: vae_memory.visual.resident_device_weight_bytes,
+        audio_vae_resident_device_bytes: vae_memory.audio.resident_device_weight_bytes,
+        attempt_resident_vae_device_bytes: retained_vaes,
+        vae_construction_device_workspace_bytes: bounds.vae_construction_device_workspace_bytes,
+        vae_memory_evidence_identity_sha256: vae.identity_sha256().into(),
+        qwen_device_parameter_bytes,
+        qwen_activation_device_bytes,
+        qwen_output_state_device_bytes,
+        qwen_output_transfer_device_bytes,
+        condition_vae_workspace_device_bytes,
+        condition_latent_backing_device_bytes,
+        target_video_latent_device_bytes,
+        target_audio_latent_device_bytes,
+        packed_layout_device_bytes,
+        packed_video_state_device_bytes,
+        packed_audio_state_device_bytes,
+        denoise_copy_policy: H3FactoryTargetDenoiseCopyPolicy::CandleF32PairedEulerV1,
+        denoise_tensor_copy_workspace_device_bytes,
+        audio_waveform_device_bytes: waveform_host_bytes,
+        attention_workspace_device_bytes: bounds.attention_workspace_device_bytes,
+        ffn_workspace_device_bytes: bounds.ffn_workspace_device_bytes,
+        decoder_tile_workspace_device_bytes: bounds.decoder_tile_workspace_device_bytes,
+        audio_decode_workspace_device_bytes: bounds.audio_decode_workspace_device_bytes,
+        resident_block_device_bytes: 0,
+        streamed_block_device_bytes,
+        prefetch_device_bytes: 0,
+        dequantization_workspace_device_bytes: max_device_weight_staging_bytes,
+        protected_block_device_bytes,
+        streamed_block_device_overlap_bytes,
+        max_device_weight_staging_bytes,
+        fixed_transformer_load_device_staging_bytes,
+        vae_load_phase_device_bytes,
+        qwen_encode_phase_device_bytes,
+        qwen_transfer_phase_device_bytes,
+        condition_encode_phase_device_bytes,
+        noise_allocation_phase_device_bytes,
+        transformer_load_phase_device_bytes,
+        denoise_phase_device_bytes,
+        visual_decode_phase_device_bytes,
+        audio_decode_phase_device_bytes,
+        waveform_transfer_phase_device_bytes,
+        mux_phase_device_bytes: 0,
+        predicted_device_peak_bytes,
+    };
+    budget.identity_sha256 = expected_h3_factory_target_budget_identity(&budget);
+    Ok(budget)
+}
+
+fn conditioning_fingerprint(endpoints: &[H3FactoryEndpointInput]) -> String {
+    let mut digest = Sha256::new();
+    digest.update(b"mold.minimax-h3.fl2va-conditioning.v1\0");
+    for endpoint in endpoints {
+        digest.update(match endpoint.anchor {
+            H3FactoryEndpointAnchor::First => b"first".as_slice(),
+            H3FactoryEndpointAnchor::Last => b"last".as_slice(),
+        });
+        digest.update(endpoint.encoded_content_sha256.as_bytes());
+        digest.update(endpoint.normalized_cpu_content_sha256.as_bytes());
+    }
+    format!("{:x}", digest.finalize())
+}
+
+fn factory_anchor(anchor: H3EndpointAnchor) -> H3FactoryEndpointAnchor {
+    match anchor {
+        H3EndpointAnchor::First => H3FactoryEndpointAnchor::First,
+        H3EndpointAnchor::Last => H3FactoryEndpointAnchor::Last,
+    }
+}
+
+fn checked_sum(values: impl IntoIterator<Item = u64>) -> Result<u64> {
+    values
+        .into_iter()
+        .try_fold(0_u64, |sum, value| sum.checked_add(value))
+        .ok_or_else(|| anyhow!("private H3 byte sum overflow"))
+}
+
+fn require_sha256(value: &str, label: &str) -> Result<()> {
+    if value.len() != 64
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+    {
+        bail!("{label} must be a lowercase 64-character SHA-256 digest")
+    }
+    Ok(())
+}
+
+fn sha256(bytes: impl AsRef<[u8]>) -> String {
+    format!("{:x}", Sha256::digest(bytes.as_ref()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn opened_authorities_and_prepared_attempt_are_single_consumption() {
+        trait AmbiguousIfClone<Marker> {
+            fn assert_not_implemented() {}
+        }
+        impl<T: ?Sized> AmbiguousIfClone<()> for T {}
+        struct ImplementsClone;
+        impl<T: Clone> AmbiguousIfClone<ImplementsClone> for T {}
+
+        <H3PrivateComfyStorageAuthority as AmbiguousIfClone<_>>::assert_not_implemented();
+        <H3PrivateOpenedTaskConfigAuthority as AmbiguousIfClone<_>>::assert_not_implemented();
+        <H3ComfyOpenedInt8Checkpoint as AmbiguousIfClone<_>>::assert_not_implemented();
+        <H3AuthenticatedQwenNvfp4Authority as AmbiguousIfClone<_>>::assert_not_implemented();
+        <H3AuthenticatedComfyVaeAuthority as AmbiguousIfClone<_>>::assert_not_implemented();
+        <H3PrivatePreparedFl2VaAttempt as AmbiguousIfClone<_>>::assert_not_implemented();
+        <H3PrivatePreparedFl2VaFactoryInputs as AmbiguousIfClone<_>>::assert_not_implemented();
+    }
+
+    #[test]
+    fn opened_task_config_rejects_path_replacement_after_authentication() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("config.json");
+        let bytes = br#"{"task":"fl2va"}"#;
+        std::fs::write(&path, bytes).unwrap();
+        let authority =
+            H3PrivateOpenedTaskConfigAuthority::open(&path, bytes.len() as u64, &sha256(bytes))
+                .unwrap();
+        authority.revalidate().unwrap();
+
+        std::fs::rename(&path, root.path().join("authenticated-config.json")).unwrap();
+        std::fs::write(&path, bytes).unwrap();
+        assert!(authority.revalidate().is_err());
+    }
+
+    #[test]
+    fn opened_task_config_rejects_content_mutation_after_authentication() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("config.json");
+        let bytes = b"task-config-a";
+        std::fs::write(&path, bytes).unwrap();
+        let authority =
+            H3PrivateOpenedTaskConfigAuthority::open(&path, bytes.len() as u64, &sha256(bytes))
+                .unwrap();
+
+        std::fs::write(&path, b"task-config-b").unwrap();
+        assert!(authority.revalidate().is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn opened_task_config_rejects_symlink_and_group_writable_sources() {
+        use std::os::unix::fs::{symlink, PermissionsExt};
+
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("config.json");
+        let alias = root.path().join("config-alias.json");
+        let bytes = b"task-config";
+        std::fs::write(&path, bytes).unwrap();
+        symlink(&path, &alias).unwrap();
+        assert!(H3PrivateOpenedTaskConfigAuthority::open(
+            &alias,
+            bytes.len() as u64,
+            &sha256(bytes),
+        )
+        .is_err());
+
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o666)).unwrap();
+        assert!(H3PrivateOpenedTaskConfigAuthority::open(
+            &path,
+            bytes.len() as u64,
+            &sha256(bytes),
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn hidden_storage_resolution_is_canonical_and_permission_bound() {
+        let root = tempfile::tempdir().unwrap();
+        let root = root.path().canonicalize().unwrap();
+        let authority = H3PrivateComfyStorageAuthority::resolve(&root).unwrap();
+        authority.validate().unwrap();
+        assert!(authority
+            .transformer_path()
+            .ends_with(FL2VA_TRANSFORMER_SOURCE));
+        assert!(authority.qwen_weights_path().ends_with(QWEN_WEIGHT_SOURCE));
+        assert!(authority
+            .task_config_path()
+            .ends_with(FL2VA_TASK_CONFIG_SOURCE));
+        assert_eq!(authority.identity_sha256().len(), 64);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn hidden_storage_rejects_symlink_and_group_writable_roots() {
+        use std::os::unix::fs::{symlink, PermissionsExt};
+
+        let parent = tempfile::tempdir().unwrap();
+        let real = parent.path().join("real");
+        std::fs::create_dir(&real).unwrap();
+        let real = real.canonicalize().unwrap();
+        let alias = parent.path().join("alias");
+        symlink(&real, &alias).unwrap();
+        assert!(H3PrivateComfyStorageAuthority::resolve(&alias).is_err());
+
+        std::fs::set_permissions(&real, std::fs::Permissions::from_mode(0o777)).unwrap();
+        assert!(H3PrivateComfyStorageAuthority::resolve(&real).is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn hidden_storage_rejects_root_identity_replacement() {
+        let parent = tempfile::tempdir().unwrap();
+        let parent = parent.path().canonicalize().unwrap();
+        let root = parent.join("models");
+        std::fs::create_dir(&root).unwrap();
+        let authority = H3PrivateComfyStorageAuthority::resolve(&root).unwrap();
+        let authenticated = parent.join("authenticated-models");
+        std::fs::rename(&root, authenticated).unwrap();
+        std::fs::create_dir(&root).unwrap();
+
+        let error = authority.validate().unwrap_err();
+        assert!(error.to_string().contains("authority changed"), "{error}");
+    }
+
+    #[test]
+    fn cross_task_transformer_and_vae_authorities_fail_closed() {
+        assert!(validate_fl2va_transformer_contract(
+            H3ComfyPublishedArtifact::Ref2VaPrunedInt8ConvRot
+        )
+        .is_err());
+        assert!(validate_fl2va_vae_contract(Task::Ref2va, contract::REF2VA_COMFY).is_err());
+        validate_fl2va_transformer_contract(H3ComfyPublishedArtifact::Fl2VaPrunedInt8ConvRot)
+            .unwrap();
+        validate_fl2va_vae_contract(Task::Fl2va, contract::FL2VA_COMFY).unwrap();
+    }
+
+    #[test]
+    fn execution_fingerprint_must_be_a_digest() {
+        assert!(require_sha256("not-a-digest", "execution").is_err());
+        assert!(require_sha256(&"A".repeat(64), "execution").is_err());
+        require_sha256(&sha256(b"execution"), "execution").unwrap();
+    }
+
+    #[test]
+    fn normalized_digest_is_an_identity_axis() {
+        let first = H3FactoryEndpointInput {
+            anchor: H3FactoryEndpointAnchor::First,
+            encoded_bytes: 3,
+            encoded_content_sha256: sha256(b"raw-a"),
+            preprocess: H3FactoryEndpointPreprocess::PillowLanczosRgbU8CpuV1,
+            normalized_shape: [1, 3, 1, 64, 64],
+            normalized_cpu_bytes: 12_288,
+            normalized_cpu_content_sha256: sha256(b"normalized-a"),
+        };
+        let mut second = first.clone();
+        second.normalized_cpu_content_sha256 = sha256(b"normalized-b");
+        assert_ne!(
+            conditioning_fingerprint(&[first]),
+            conditioning_fingerprint(&[second])
+        );
+    }
+}

--- a/crates/mold-inference/src/minimax_h3/private_qwen.rs
+++ b/crates/mold-inference/src/minimax_h3/private_qwen.rs
@@ -8,14 +8,15 @@
 use anyhow::{anyhow, bail, Context, Result};
 use candle_core::{DType, Device, Tensor};
 use mold_candle::minimax_h3::{
-    build_ref2va_presentation, load_h3_qwen_nvfp4_conditioner_after_authorization,
-    pack_qwen_vision_u8, qwen_mrope_positions, released_h3_qwen_nvfp4_output_tensor_bytes,
-    released_h3_qwen_nvfp4_runtime_memory_facts,
+    build_ref2va_presentation, load_h3_qwen_nvfp4_conditioner_from_authority,
+    open_h3_qwen_nvfp4_authority_after_authorization, pack_qwen_vision_u8, qwen_mrope_positions,
+    released_h3_qwen_nvfp4_output_tensor_bytes, released_h3_qwen_nvfp4_runtime_memory_facts,
     released_h3_qwen_nvfp4_runtime_memory_facts_for_placement, ConditionerCheckpoint, GridThw,
-    H3ConditionerInput, H3ModalityTag, H3QwenNvfp4LoadObserver, H3QwenNvfp4RuntimeError,
-    H3QwenNvfp4RuntimeMemoryFacts, H3QwenNvfp4RuntimePlacement, H3RawTokenizer, H3VisionInput,
-    LoadedH3QwenNvfp4Conditioner, PackedVisionPatches, RefPresentationKind,
-    H3_QWEN_NVFP4_AWQ_POLICY_SHA256, H3_QWEN_NVFP4_AWQ_SHA256, H3_SELECTED_LANGUAGE_LAYERS,
+    H3AuthenticatedQwenNvfp4Authority, H3ConditionerInput, H3ModalityTag, H3QwenNvfp4LoadObserver,
+    H3QwenNvfp4RuntimeError, H3QwenNvfp4RuntimeMemoryFacts, H3QwenNvfp4RuntimePlacement,
+    H3RawTokenizer, H3VisionInput, LoadedH3QwenNvfp4Conditioner, PackedVisionPatches,
+    RefPresentationKind, H3_QWEN_NVFP4_AWQ_POLICY_SHA256, H3_QWEN_NVFP4_AWQ_SHA256,
+    H3_SELECTED_LANGUAGE_LAYERS,
 };
 use mold_core::minimax_h3::Task;
 use std::path::Path;
@@ -230,25 +231,87 @@ where
         authority: &'authority FrozenH3FactoryAuthority,
         checkpoint: &mut dyn H3PipelineCheckpoint,
     ) -> Result<Self> {
-        Self::load_with(
-            weights_path,
+        let mut resources = H3PrivateQwenResources {
+            model: None,
             support,
             conditioner_lease,
+            conditioner_released: false,
+        };
+        let device = resources.conditioner_lease.device();
+        let placement = if device.is_cpu() {
+            H3QwenNvfp4RuntimePlacement::Cpu
+        } else {
+            H3QwenNvfp4RuntimePlacement::Accelerated
+        };
+        let memory_facts = released_h3_qwen_nvfp4_runtime_memory_facts(device)?;
+        validate_preload_authorities(
+            &resources.support,
+            &resources.conditioner_lease,
+            &execution_lease,
+            &artifact_lease,
+            authority,
+            &memory_facts,
+        )?;
+
+        let opened = {
+            let mut observer = H3PrivateQwenLoadCheckpoint::new(checkpoint, || {
+                poll_active_authorities(
+                    &resources.support,
+                    &resources.conditioner_lease,
+                    &execution_lease,
+                    &artifact_lease,
+                    authority,
+                )
+            });
+            // SAFETY: every immutable attempt/lease binding was validated
+            // above and is polled at each bounded authentication checkpoint.
+            let result = unsafe {
+                open_h3_qwen_nvfp4_authority_after_authorization(
+                    weights_path,
+                    placement,
+                    &mut observer,
+                )
+            };
+            observer.finish(result)?
+        };
+        validate_opened_qwen_authority(&opened, &artifact_lease, authority, &memory_facts)?;
+        poll_active_authorities(
+            &resources.support,
+            &resources.conditioner_lease,
+            &execution_lease,
+            &artifact_lease,
+            authority,
+        )?;
+
+        let loaded = {
+            let config = resources.support.conditioner_config();
+            let device = resources.conditioner_lease.device();
+            let mut observer = H3PrivateQwenLoadCheckpoint::new(checkpoint, || {
+                poll_active_authorities(
+                    &resources.support,
+                    &resources.conditioner_lease,
+                    &execution_lease,
+                    &artifact_lease,
+                    authority,
+                )
+            });
+            // SAFETY: `opened` is the non-Clone authority validated at the
+            // allocation boundary above. It is consumed exactly once here.
+            let result = unsafe {
+                load_h3_qwen_nvfp4_conditioner_from_authority(opened, config, device, &mut observer)
+            };
+            observer.finish(result)?
+        };
+        validate_output_dtype(loaded.dtype_profile().output_dtype)?;
+        resources.model = Some(loaded);
+        let adapter = Self {
+            resources,
             execution_lease,
             artifact_lease,
             authority,
-            checkpoint,
-            |path, config, device, observer| {
-                // SAFETY: `load_with` invokes this closure only after the
-                // complete preload binding succeeds. The observer repeats
-                // that validation at every bounded load checkpoint.
-                unsafe {
-                    load_h3_qwen_nvfp4_conditioner_after_authorization(
-                        path, config, device, observer,
-                    )
-                }
-            },
-        )
+        };
+        adapter.validate_active_authorities()?;
+        Ok(adapter)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -773,6 +836,30 @@ where
     let frozen = frozen_binding_claims(authority)?;
     let leases = lease_binding_claims(conditioner, execution, artifact, true);
     validate_binding(&loaded, &frozen, &leases)
+}
+
+fn validate_opened_qwen_authority<A>(
+    opened: &H3AuthenticatedQwenNvfp4Authority,
+    artifact: &A,
+    authority: &FrozenH3FactoryAuthority,
+    expected_memory: &H3QwenNvfp4RuntimeMemoryFacts,
+) -> Result<()>
+where
+    A: H3PrivateQwenArtifactLease,
+{
+    opened.revalidate()?;
+    require_sha256(opened.identity_sha256(), "opened authority")?;
+    if opened.artifact_file_bytes() == 0
+        || opened.artifact_identity_sha256() != artifact.weight_identity_sha256()
+        || opened.header_identity_sha256() != artifact.weight_header_identity_sha256()
+        || opened.policy_identity_sha256() != artifact.weight_policy_identity_sha256()
+        || opened.memory_facts() != expected_memory
+    {
+        bail!(
+            "authenticated H3 Qwen opened evidence differs from the frozen artifact or memory authority"
+        )
+    }
+    validate_parameter_memory(authority, opened.memory_facts())
 }
 
 /// Cheap checkpoint poll. Expensive descriptor rehash/reopen validation runs

--- a/crates/mold-inference/src/minimax_h3/private_qwen_support.rs
+++ b/crates/mold-inference/src/minimax_h3/private_qwen_support.rs
@@ -205,7 +205,18 @@ pub(crate) struct H3PrivateQwenSupport {
     conditioner_config: H3ConditionerConfig,
     tokenizer: Arc<Tokenizer>,
     support_identity_sha256: String,
+    artifact_facts: Vec<H3PrivateQwenSupportArtifactFact>,
     artifacts: Vec<OpenedSupportArtifact>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct H3PrivateQwenSupportArtifactFact {
+    pub(crate) role: &'static str,
+    pub(crate) source_repository: String,
+    pub(crate) source_revision: String,
+    pub(crate) source_path: String,
+    pub(crate) content_sha256: String,
+    pub(crate) file_bytes: u64,
 }
 
 impl H3PrivateQwenSupport {
@@ -227,6 +238,26 @@ impl H3PrivateQwenSupport {
 
     pub(crate) fn support_identity_sha256(&self) -> &str {
         &self.support_identity_sha256
+    }
+
+    pub(crate) fn artifact_facts(&self) -> &[H3PrivateQwenSupportArtifactFact] {
+        &self.artifact_facts
+    }
+
+    pub(crate) fn validate_storage_root(&self, models_root: &Path) -> Result<()> {
+        let contracts = production_support_contracts(&self.model)?;
+        for artifact in &self.artifacts {
+            let contract = contracts
+                .iter()
+                .find(|contract| contract.role == artifact.role)
+                .ok_or_else(|| anyhow!("private H3 support storage binding omits a role"))?;
+            if artifact.path != models_root.join(&contract.relative_path)
+                || std::fs::canonicalize(&artifact.path)? != artifact.path
+            {
+                bail!("private H3 support descriptor is outside the hidden storage authority")
+            }
+        }
+        Ok(())
     }
 
     /// Re-hash the retained descriptors and prove that every manifest path
@@ -343,12 +374,31 @@ fn load_support_from_contracts_at_boundary(
     if !root_metadata.file_type().is_dir() || root_metadata.file_type().is_symlink() {
         bail!("private H3 models root must be a real non-symlink directory")
     }
+    #[cfg(unix)]
+    {
+        // SAFETY: `geteuid` has no preconditions and only reads process state.
+        let effective_uid = unsafe { libc::geteuid() };
+        if root_metadata.uid() != effective_uid || root_metadata.mode() & 0o022 != 0 {
+            bail!("private H3 models root must be process-owned and not group/other writable")
+        }
+    }
     let root_identity = FileIdentity::from_metadata(&root_metadata);
     root_validated(models_root)?;
     validate_models_root_identity(models_root, &root_identity)?;
     let root = models_root.to_path_buf();
 
     let support_identity_sha256 = support_identity(model, &contracts)?;
+    let artifact_facts = contracts
+        .iter()
+        .map(|contract| H3PrivateQwenSupportArtifactFact {
+            role: contract.role.stable_id(),
+            source_repository: contract.source_repo.clone(),
+            source_revision: contract.source_revision.clone(),
+            source_path: contract.source_path.clone(),
+            content_sha256: contract.sha256.clone(),
+            file_bytes: contract.size_bytes,
+        })
+        .collect();
     let mut opened = Vec::with_capacity(contracts.len());
     let mut bytes_by_role = BTreeMap::new();
     for contract in &contracts {
@@ -386,6 +436,7 @@ fn load_support_from_contracts_at_boundary(
         conditioner_config,
         tokenizer: Arc::new(tokenizer),
         support_identity_sha256,
+        artifact_facts,
         artifacts: opened,
     };
     support.revalidate()?;
@@ -475,7 +526,19 @@ fn authenticate_support_file(
             contract.relative_path.display()
         )
     })?;
-    let before = FileIdentity::from_metadata(&file.metadata()?);
+    let opened_metadata = file.metadata()?;
+    #[cfg(unix)]
+    {
+        // SAFETY: `geteuid` has no preconditions and only reads process state.
+        let effective_uid = unsafe { libc::geteuid() };
+        if opened_metadata.uid() != effective_uid || opened_metadata.mode() & 0o022 != 0 {
+            bail!(
+                "private H3 {} must be process-owned and not group/other writable",
+                contract.role.stable_id()
+            )
+        }
+    }
+    let before = FileIdentity::from_metadata(&opened_metadata);
     if before.len != contract.size_bytes {
         bail!(
             "private H3 {} has {} bytes, expected {}",
@@ -852,6 +915,58 @@ mod tests {
             Err(error) => error,
         };
         assert!(error.to_string().contains("models root changed"), "{error}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn group_writable_models_root_fails_before_support_open() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempfile::tempdir().unwrap();
+        let contracts = synthetic_contracts(root.path());
+        std::fs::set_permissions(root.path(), std::fs::Permissions::from_mode(0o770)).unwrap();
+
+        let error = match load_support_from_contracts(root.path(), contract::FL2VA_COMFY, contracts)
+        {
+            Ok(_) => panic!("group-writable models root must fail closed"),
+            Err(error) => error,
+        };
+        assert!(
+            error
+                .to_string()
+                .contains("process-owned and not group/other writable"),
+            "{error}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn group_writable_support_file_fails_before_authentication() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempfile::tempdir().unwrap();
+        let contracts = synthetic_contracts(root.path());
+        let tokenizer = contracts
+            .iter()
+            .find(|contract| contract.role == SupportRole::Tokenizer)
+            .unwrap();
+        std::fs::set_permissions(
+            root.path().join(&tokenizer.relative_path),
+            std::fs::Permissions::from_mode(0o666),
+        )
+        .unwrap();
+
+        let error = match load_support_from_contracts(root.path(), contract::FL2VA_COMFY, contracts)
+        {
+            Ok(_) => panic!("group-writable support file must fail closed"),
+            Err(error) => error,
+        };
+        assert!(
+            error
+                .to_string()
+                .contains("process-owned and not group/other writable"),
+            "{error}"
+        );
     }
 
     #[test]

--- a/crates/mold-inference/src/minimax_h3/vae_runtime.rs
+++ b/crates/mold-inference/src/minimax_h3/vae_runtime.rs
@@ -11,7 +11,7 @@
 use std::collections::BTreeSet;
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use candle_core::{DType, Device};
 use mold_candle::minimax_h3::{
@@ -21,7 +21,7 @@ use mold_candle::minimax_h3::{
     AudioTensorLayout, AudioVae, AudioVaeLoadObserver, DecodeComputePolicy, MiniMaxH3VisualVae,
     VisualAttentionBackend, VisualVaeEvent, VisualVaeObserver,
 };
-use mold_core::manifest::{find_manifest, ModelComponent, ModelManifest};
+use mold_core::manifest::{find_manifest, storage_path, ModelComponent, ModelManifest};
 use mold_core::minimax_h3::{self as contract, ArtifactRole as ContractArtifactRole, Layout, Task};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
@@ -46,7 +46,7 @@ pub(crate) enum H3ComfyVaeArtifactRole {
 }
 
 impl H3ComfyVaeArtifactRole {
-    const ALL: [Self; 4] = [
+    pub(crate) const ALL: [Self; 4] = [
         Self::VisualConfig,
         Self::VisualWeights,
         Self::AudioConfig,
@@ -66,6 +66,23 @@ impl H3ComfyVaeArtifactRole {
 
     const fn is_config(self) -> bool {
         matches!(self, Self::VisualConfig | Self::AudioConfig)
+    }
+
+    pub(crate) const fn source_path(self) -> &'static str {
+        match self {
+            Self::VisualConfig => VISUAL_CONFIG_SOURCE_PATH,
+            Self::VisualWeights => COMFY_VISUAL_WEIGHT_SOURCE_PATH,
+            Self::AudioConfig => AUDIO_CONFIG_SOURCE_PATH,
+            Self::AudioWeights => COMFY_AUDIO_WEIGHT_SOURCE_PATH,
+        }
+    }
+
+    pub(crate) const fn manifest_component(self) -> ModelComponent {
+        match self {
+            Self::VisualConfig | Self::AudioConfig => ModelComponent::ModelConfig,
+            Self::VisualWeights => ModelComponent::Vae,
+            Self::AudioWeights => ModelComponent::AudioVae,
+        }
     }
 }
 
@@ -222,6 +239,62 @@ pub(crate) struct FrozenH3ComfyVaeLoadPlan {
 }
 
 impl FrozenH3ComfyVaeLoadPlan {
+    /// Resolve the exact private VAE component paths from Mold's hidden,
+    /// source-pinned manifest and canonical storage authority. No caller-
+    /// mutable `ModelPaths` value participates in this plan.
+    pub(crate) fn from_hidden_storage(
+        model: &str,
+        models_root: &Path,
+        staging_root: &Path,
+    ) -> LoadResult<Self> {
+        let models_root = validate_private_storage_directory(models_root, "models root")?;
+        let staging_root = validate_private_storage_directory(staging_root, "staging root")?;
+        let manifest = find_manifest(model).ok_or_else(|| {
+            H3ComfyVaeLoadError::InvalidPlan(format!("missing manifest {model:?}"))
+        })?;
+        if !manifest.hidden {
+            return Err(H3ComfyVaeLoadError::InvalidPlan(
+                "private H3 VAE storage resolution requires a hidden manifest".into(),
+            ));
+        }
+        let path_for = |role: H3ComfyVaeArtifactRole| -> LoadResult<PathBuf> {
+            let expected_path = role.source_path();
+            let matches = manifest
+                .files
+                .iter()
+                .filter(|file| {
+                    file.hf_filename == expected_path && file.component == role.manifest_component()
+                })
+                .collect::<Vec<_>>();
+            let [file] = matches.as_slice() else {
+                return Err(H3ComfyVaeLoadError::InvalidPlan(format!(
+                    "hidden manifest {model:?} requires exactly one {expected_path}"
+                )));
+            };
+            let relative = storage_path(manifest, file);
+            if relative.is_absolute()
+                || relative
+                    .components()
+                    .any(|component| !matches!(component, Component::Normal(_)))
+            {
+                return Err(H3ComfyVaeLoadError::InvalidPlan(
+                    "hidden manifest produced a non-canonical VAE storage path".into(),
+                ));
+            }
+            Ok(models_root.join(relative))
+        };
+        Self::new(
+            model,
+            H3ComfyVaeArtifactPaths {
+                visual_config: path_for(H3ComfyVaeArtifactRole::VisualConfig)?,
+                visual_weights: path_for(H3ComfyVaeArtifactRole::VisualWeights)?,
+                audio_config: path_for(H3ComfyVaeArtifactRole::AudioConfig)?,
+                audio_weights: path_for(H3ComfyVaeArtifactRole::AudioWeights)?,
+            },
+            staging_root,
+        )
+    }
+
     pub(crate) fn new(
         model: &str,
         paths: H3ComfyVaeArtifactPaths,
@@ -436,6 +509,16 @@ pub(crate) struct H3ComfyVaeRuntimeMemory {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct H3ComfyVaeOpenedArtifactFact {
+    pub(crate) role: H3ComfyVaeArtifactRole,
+    pub(crate) source_repository: String,
+    pub(crate) source_revision: String,
+    pub(crate) source_path: String,
+    pub(crate) content_sha256: String,
+    pub(crate) file_bytes: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 struct ComponentLoadFacts {
     artifact_file_bytes: u64,
     header_bytes: u64,
@@ -472,6 +555,77 @@ impl ComponentLoadFacts {
             effective_device_weight_bytes: self.effective_device_weight_bytes,
             construction_staging_disk_bytes: self.artifact_file_bytes,
         }
+    }
+}
+
+/// Fully authenticated VAE source and exact pre-allocation memory authority.
+///
+/// The token intentionally does not implement `Clone`. It owns all four
+/// opened source descriptors and both private authenticated staging files,
+/// and the construction function consumes it exactly once.
+pub(crate) struct H3AuthenticatedComfyVaeAuthority {
+    plan: FrozenH3ComfyVaeLoadPlan,
+    opened: Vec<OpenedArtifact>,
+    staged: StagedWeights,
+    visual_config: Vec<u8>,
+    audio_config: Vec<u8>,
+    visual_facts: ComponentLoadFacts,
+    audio_facts: ComponentLoadFacts,
+    memory: H3ComfyVaeRuntimeMemory,
+    artifact_facts: Vec<H3ComfyVaeOpenedArtifactFact>,
+    identity_sha256: String,
+}
+
+impl H3AuthenticatedComfyVaeAuthority {
+    pub(crate) const fn task(&self) -> Task {
+        self.plan.task
+    }
+
+    pub(crate) fn canonical_model(&self) -> &str {
+        &self.plan.canonical_model
+    }
+
+    pub(crate) fn source_path(&self, role: H3ComfyVaeArtifactRole) -> LoadResult<&Path> {
+        self.opened
+            .iter()
+            .find(|artifact| artifact.expected.role == role)
+            .map(|artifact| artifact.canonical_path.as_path())
+            .ok_or_else(|| H3ComfyVaeLoadError::InvalidPlan(format!("missing opened {role:?}")))
+    }
+
+    pub(crate) fn plan_identity_sha256(&self) -> &str {
+        self.plan.identity_sha256()
+    }
+
+    pub(crate) fn artifact_plan_identity_sha256(&self) -> &str {
+        self.plan.artifact_plan_identity_sha256()
+    }
+
+    pub(crate) fn identity_sha256(&self) -> &str {
+        &self.identity_sha256
+    }
+
+    pub(crate) fn memory(&self) -> &H3ComfyVaeRuntimeMemory {
+        &self.memory
+    }
+
+    pub(crate) fn artifact_facts(&self) -> &[H3ComfyVaeOpenedArtifactFact] {
+        &self.artifact_facts
+    }
+
+    pub(crate) fn validate(&self) -> LoadResult<()> {
+        self.plan.validate()?;
+        for artifact in &self.opened {
+            artifact.validate_source("while authenticated VAE authority is retained")?;
+        }
+        self.staged
+            .validate("while authenticated VAE authority is retained")?;
+        if self.identity_sha256 != authenticated_vae_authority_identity(self) {
+            return Err(H3ComfyVaeLoadError::InvalidPlan(
+                "authenticated VAE authority identity changed".into(),
+            ));
+        }
+        Ok(())
     }
 }
 
@@ -578,7 +732,443 @@ pub(crate) fn load_h3_comfy_vae_runtime(
     device: &Device,
     observer: &mut dyn H3ComfyVaeLoadObserver,
 ) -> LoadResult<H3ComfyVaeRuntimeBundle> {
-    load_with_factory(plan, device, observer, &mut ProductionVaeFactory)
+    let authority = open_h3_comfy_vae_authority(plan, observer)?;
+    load_h3_comfy_vae_runtime_from_authority(authority, device, observer)
+}
+
+/// Open, completely authenticate, privately stage, and inspect the exact VAE
+/// artifacts before any visual/audio model tensor allocation occurs.
+pub(crate) fn open_h3_comfy_vae_authority(
+    plan: &FrozenH3ComfyVaeLoadPlan,
+    observer: &mut dyn H3ComfyVaeLoadObserver,
+) -> LoadResult<H3AuthenticatedComfyVaeAuthority> {
+    plan.validate()?;
+    let mut opened = Vec::with_capacity(H3ComfyVaeArtifactRole::ALL.len());
+    for role in H3ComfyVaeArtifactRole::ALL {
+        opened.push(OpenedArtifact::open(
+            plan.artifact(role)?.clone(),
+            plan.paths.get(role),
+            observer,
+        )?);
+    }
+    let visual_config = opened_for_mut(&mut opened, H3ComfyVaeArtifactRole::VisualConfig)?
+        .read_authenticated_config(observer)?;
+    let audio_config = opened_for_mut(&mut opened, H3ComfyVaeArtifactRole::AudioConfig)?
+        .read_authenticated_config(observer)?;
+    let required_staging_bytes = required_staging_bytes(plan)?;
+    ensure_staging_capacity(plan, required_staging_bytes)?;
+    let staged = StagedWeights::create(plan, &mut opened, observer)?;
+    for artifact in &opened {
+        artifact.validate_source("before VAE pre-allocation inspection")?;
+    }
+    let visual_facts = inspect_visual_component(
+        staged.path(H3ComfyVaeArtifactRole::VisualWeights)?,
+        &visual_config,
+        observer,
+    )?;
+    visual_facts.validate(plan.artifact(H3ComfyVaeArtifactRole::VisualWeights)?)?;
+    let audio_facts = inspect_audio_component(
+        staged.path(H3ComfyVaeArtifactRole::AudioWeights)?,
+        &audio_config,
+        observer,
+    )?;
+    audio_facts.validate(plan.artifact(H3ComfyVaeArtifactRole::AudioWeights)?)?;
+    for artifact in &opened {
+        artifact.validate_source("after VAE pre-allocation inspection")?;
+    }
+    let memory = vae_runtime_memory(
+        &visual_facts,
+        &audio_facts,
+        visual_config.len(),
+        audio_config.len(),
+        required_staging_bytes,
+    )?;
+    let artifact_facts = opened
+        .iter()
+        .map(|artifact| H3ComfyVaeOpenedArtifactFact {
+            role: artifact.expected.role,
+            source_repository: artifact.expected.source_repository.clone(),
+            source_revision: artifact.expected.source_revision.clone(),
+            source_path: artifact.expected.source_path.clone(),
+            content_sha256: artifact.expected.content_sha256.clone(),
+            file_bytes: artifact.expected.file_bytes,
+        })
+        .collect();
+    let mut authority = H3AuthenticatedComfyVaeAuthority {
+        plan: plan.clone(),
+        opened,
+        staged,
+        visual_config,
+        audio_config,
+        visual_facts,
+        audio_facts,
+        memory,
+        artifact_facts,
+        identity_sha256: String::new(),
+    };
+    authority.identity_sha256 = authenticated_vae_authority_identity(&authority);
+    authority.validate()?;
+    Ok(authority)
+}
+
+/// Consume one authenticated, non-Clone VAE authority and construct both
+/// runtime models on the selected device.
+pub(crate) fn load_h3_comfy_vae_runtime_from_authority(
+    authority: H3AuthenticatedComfyVaeAuthority,
+    device: &Device,
+    observer: &mut dyn H3ComfyVaeLoadObserver,
+) -> LoadResult<H3ComfyVaeRuntimeBundle> {
+    authority.validate()?;
+    if authority.plan.requires_cuda() && !device.is_cuda() {
+        return Err(H3ComfyVaeLoadError::InvalidPlan(
+            "production Comfy VAE construction requires the frozen CUDA route".into(),
+        ));
+    }
+    let H3AuthenticatedComfyVaeAuthority {
+        plan,
+        opened,
+        staged,
+        visual_config,
+        audio_config,
+        visual_facts,
+        audio_facts,
+        memory,
+        artifact_facts: _,
+        identity_sha256: _,
+    } = authority;
+    let mut factory = ProductionVaeFactory;
+    staged.validate("before visual VAE construction")?;
+    let (visual_vae, loaded_visual_facts) = factory
+        .load_visual(
+            staged.path(H3ComfyVaeArtifactRole::VisualWeights)?,
+            &visual_config,
+            device,
+            observer,
+        )
+        .map_err(factory_error)?;
+    staged.validate("after visual VAE construction")?;
+    staged.validate("before audio VAE construction")?;
+    let (audio_vae, loaded_audio_facts) = factory
+        .load_audio(
+            staged.path(H3ComfyVaeArtifactRole::AudioWeights)?,
+            &audio_config,
+            device,
+            observer,
+        )
+        .map_err(factory_error)?;
+    staged.validate("after audio VAE construction")?;
+    if loaded_visual_facts != visual_facts || loaded_audio_facts != audio_facts {
+        return Err(H3ComfyVaeLoadError::InvalidPlan(
+            "constructed VAE facts differ from authenticated pre-allocation evidence".into(),
+        ));
+    }
+    for artifact in &opened {
+        artifact.validate_source("after VAE construction")?;
+    }
+    drop(staged);
+    let authority_identity_sha256 = artifact_lease_identity(plan.identity_sha256(), &opened);
+    let artifact_lease = H3ComfyVaeArtifactLease {
+        plan_identity_sha256: plan.identity_sha256().into(),
+        authority_identity_sha256,
+        artifacts: opened,
+    };
+    artifact_lease.validate()?;
+    Ok(H3ComfyVaeRuntimeBundle {
+        visual_vae,
+        audio_vae,
+        memory,
+        task: plan.task,
+        canonical_model: plan.canonical_model,
+        artifact_plan_identity_sha256: plan.artifact_plan_identity_sha256,
+        plan_identity_sha256: plan.identity_sha256,
+        #[cfg(feature = "h3-private-uat")]
+        device: device.clone(),
+        artifact_lease,
+    })
+}
+
+fn required_staging_bytes(plan: &FrozenH3ComfyVaeLoadPlan) -> LoadResult<u64> {
+    H3ComfyVaeArtifactRole::WEIGHTS
+        .into_iter()
+        .try_fold(0_u64, |total, role| {
+            total
+                .checked_add(plan.artifact(role)?.file_bytes)
+                .ok_or_else(|| {
+                    H3ComfyVaeLoadError::InvalidPlan("VAE staging byte count overflow".into())
+                })
+        })
+}
+
+fn ensure_staging_capacity(plan: &FrozenH3ComfyVaeLoadPlan, required_bytes: u64) -> LoadResult<()> {
+    let available_bytes = fs2::available_space(&plan.staging_root).map_err(|error| {
+        H3ComfyVaeLoadError::InvalidPlan(format!(
+            "cannot inspect staging capacity at {}: {error}",
+            plan.staging_root.display()
+        ))
+    })?;
+    if available_bytes < required_bytes {
+        return Err(H3ComfyVaeLoadError::InsufficientStaging {
+            path: plan.staging_root.clone(),
+            required_bytes,
+            available_bytes,
+        });
+    }
+    Ok(())
+}
+
+fn inspect_visual_component(
+    weight_path: &Path,
+    config_bytes: &[u8],
+    observer: &mut dyn H3ComfyVaeLoadObserver,
+) -> LoadResult<ComponentLoadFacts> {
+    if !checkpoint(
+        observer,
+        H3ComfyVaeArtifactRole::VisualConfig,
+        H3ComfyVaeLoadPhase::ValidateConfig,
+        0,
+        1,
+    ) {
+        return Err(H3ComfyVaeLoadError::Cancelled {
+            role: H3ComfyVaeArtifactRole::VisualConfig,
+            phase: H3ComfyVaeLoadPhase::ValidateConfig,
+        });
+    }
+    let config = inspect_visual_vae_config_bytes(config_bytes).map_err(|error| {
+        H3ComfyVaeLoadError::Validation {
+            role: H3ComfyVaeArtifactRole::VisualConfig,
+            message: error.to_string(),
+        }
+    })?;
+    if !checkpoint(
+        observer,
+        H3ComfyVaeArtifactRole::VisualConfig,
+        H3ComfyVaeLoadPhase::ValidateConfig,
+        1,
+        1,
+    ) || !checkpoint(
+        observer,
+        H3ComfyVaeArtifactRole::VisualWeights,
+        H3ComfyVaeLoadPhase::ValidateHeader,
+        0,
+        1,
+    ) {
+        return Err(H3ComfyVaeLoadError::Cancelled {
+            role: H3ComfyVaeArtifactRole::VisualWeights,
+            phase: H3ComfyVaeLoadPhase::ValidateHeader,
+        });
+    }
+    let header = inspect_safetensors_header(weight_path).map_err(|error| {
+        H3ComfyVaeLoadError::Validation {
+            role: H3ComfyVaeArtifactRole::VisualWeights,
+            message: error.to_string(),
+        }
+    })?;
+    let validated = validate_comfy_weight_file(&config, weight_path).map_err(|error| {
+        H3ComfyVaeLoadError::Validation {
+            role: H3ComfyVaeArtifactRole::VisualWeights,
+            message: error.to_string(),
+        }
+    })?;
+    let resident_device_weight_bytes = expected_visual_vae_parameter_bytes(&config, DType::F16)
+        .map_err(|error| H3ComfyVaeLoadError::Validation {
+            role: H3ComfyVaeArtifactRole::VisualWeights,
+            message: error.to_string(),
+        })?;
+    if !checkpoint(
+        observer,
+        H3ComfyVaeArtifactRole::VisualWeights,
+        H3ComfyVaeLoadPhase::ValidateHeader,
+        1,
+        1,
+    ) {
+        return Err(H3ComfyVaeLoadError::Cancelled {
+            role: H3ComfyVaeArtifactRole::VisualWeights,
+            phase: H3ComfyVaeLoadPhase::ValidateHeader,
+        });
+    }
+    let header_bytes =
+        header
+            .header_len
+            .checked_add(8)
+            .ok_or_else(|| H3ComfyVaeLoadError::Validation {
+                role: H3ComfyVaeArtifactRole::VisualWeights,
+                message: "visual header byte overflow".into(),
+            })?;
+    let encoded_tensor_bytes = header.file_len.checked_sub(header_bytes).ok_or_else(|| {
+        H3ComfyVaeLoadError::Validation {
+            role: H3ComfyVaeArtifactRole::VisualWeights,
+            message: "visual tensor byte underflow".into(),
+        }
+    })?;
+    if validated.inspection().total_size != header.file_len {
+        return Err(H3ComfyVaeLoadError::Validation {
+            role: H3ComfyVaeArtifactRole::VisualWeights,
+            message: "visual validated file bytes differ from opened header".into(),
+        });
+    }
+    Ok(ComponentLoadFacts {
+        artifact_file_bytes: header.file_len,
+        header_bytes,
+        encoded_tensor_bytes,
+        resident_device_weight_bytes,
+        effective_device_weight_bytes: resident_device_weight_bytes,
+    })
+}
+
+fn inspect_audio_component(
+    weight_path: &Path,
+    config_bytes: &[u8],
+    observer: &mut dyn H3ComfyVaeLoadObserver,
+) -> LoadResult<ComponentLoadFacts> {
+    if !checkpoint(
+        observer,
+        H3ComfyVaeArtifactRole::AudioConfig,
+        H3ComfyVaeLoadPhase::ValidateConfig,
+        0,
+        1,
+    ) {
+        return Err(H3ComfyVaeLoadError::Cancelled {
+            role: H3ComfyVaeArtifactRole::AudioConfig,
+            phase: H3ComfyVaeLoadPhase::ValidateConfig,
+        });
+    }
+    let config = inspect_audio_vae_config_bytes(config_bytes).map_err(|error| {
+        H3ComfyVaeLoadError::Validation {
+            role: H3ComfyVaeArtifactRole::AudioConfig,
+            message: error.to_string(),
+        }
+    })?;
+    if !checkpoint(
+        observer,
+        H3ComfyVaeArtifactRole::AudioConfig,
+        H3ComfyVaeLoadPhase::ValidateConfig,
+        1,
+        1,
+    ) || !checkpoint(
+        observer,
+        H3ComfyVaeArtifactRole::AudioWeights,
+        H3ComfyVaeLoadPhase::ValidateHeader,
+        0,
+        1,
+    ) {
+        return Err(H3ComfyVaeLoadError::Cancelled {
+            role: H3ComfyVaeArtifactRole::AudioWeights,
+            phase: H3ComfyVaeLoadPhase::ValidateHeader,
+        });
+    }
+    let validated =
+        validate_audio_safetensors(weight_path, &config, AudioTensorLayout::ComfyFolded).map_err(
+            |error| H3ComfyVaeLoadError::Validation {
+                role: H3ComfyVaeArtifactRole::AudioWeights,
+                message: error.to_string(),
+            },
+        )?;
+    let file_bytes = std::fs::metadata(weight_path)
+        .map_err(|error| H3ComfyVaeLoadError::Validation {
+            role: H3ComfyVaeArtifactRole::AudioWeights,
+            message: error.to_string(),
+        })?
+        .len();
+    if !checkpoint(
+        observer,
+        H3ComfyVaeArtifactRole::AudioWeights,
+        H3ComfyVaeLoadPhase::ValidateHeader,
+        1,
+        1,
+    ) {
+        return Err(H3ComfyVaeLoadError::Cancelled {
+            role: H3ComfyVaeArtifactRole::AudioWeights,
+            phase: H3ComfyVaeLoadPhase::ValidateHeader,
+        });
+    }
+    let header_bytes = file_bytes
+        .checked_sub(validated.tensor_bytes)
+        .ok_or_else(|| H3ComfyVaeLoadError::Validation {
+            role: H3ComfyVaeArtifactRole::AudioWeights,
+            message: "audio header byte underflow".into(),
+        })?;
+    Ok(ComponentLoadFacts {
+        artifact_file_bytes: file_bytes,
+        header_bytes,
+        encoded_tensor_bytes: validated.tensor_bytes,
+        resident_device_weight_bytes: validated.tensor_bytes,
+        effective_device_weight_bytes: validated.tensor_bytes,
+    })
+}
+
+fn vae_runtime_memory(
+    visual: &ComponentLoadFacts,
+    audio: &ComponentLoadFacts,
+    visual_config_bytes: usize,
+    audio_config_bytes: usize,
+    required_staging_bytes: u64,
+) -> LoadResult<H3ComfyVaeRuntimeMemory> {
+    let visual = visual.memory();
+    let audio = audio.memory();
+    let resident_device_weight_bytes = visual
+        .resident_device_weight_bytes
+        .checked_add(audio.resident_device_weight_bytes)
+        .ok_or_else(|| H3ComfyVaeLoadError::InvalidPlan("resident VAE byte overflow".into()))?;
+    let effective_device_weight_bytes = visual
+        .effective_device_weight_bytes
+        .checked_add(audio.effective_device_weight_bytes)
+        .ok_or_else(|| H3ComfyVaeLoadError::InvalidPlan("effective VAE byte overflow".into()))?;
+    let config_bytes = u64::try_from(visual_config_bytes)
+        .ok()
+        .and_then(|visual| {
+            u64::try_from(audio_config_bytes)
+                .ok()
+                .and_then(|audio| visual.checked_add(audio))
+        })
+        .ok_or_else(|| H3ComfyVaeLoadError::InvalidPlan("VAE config byte overflow".into()))?;
+    Ok(H3ComfyVaeRuntimeMemory {
+        peak_host_mapped_file_bytes: visual.artifact_file_bytes.max(audio.artifact_file_bytes),
+        visual,
+        audio,
+        config_bytes,
+        peak_host_io_buffer_bytes: AUTHENTICATION_CHUNK_BYTES as u64,
+        peak_staging_disk_bytes: required_staging_bytes,
+        resident_host_weight_bytes: 0,
+        resident_device_weight_bytes,
+        effective_device_weight_bytes,
+    })
+}
+
+fn authenticated_vae_authority_identity(authority: &H3AuthenticatedComfyVaeAuthority) -> String {
+    let mut digest = Sha256::new();
+    digest.update(b"mold.minimax-h3.comfy-vae-authenticated-open.v1\0");
+    digest.update(authority.plan.identity_sha256().as_bytes());
+    digest.update(artifact_lease_identity(
+        authority.plan.identity_sha256(),
+        &authority.opened,
+    ));
+    authority.staged.update_identity(&mut digest);
+    for fact in &authority.artifact_facts {
+        digest.update(fact.role.stable_id().as_bytes());
+        digest.update([0]);
+        digest.update(fact.content_sha256.as_bytes());
+        digest.update(fact.file_bytes.to_le_bytes());
+    }
+    for value in [
+        authority.memory.visual.artifact_file_bytes,
+        authority.memory.visual.header_bytes,
+        authority.memory.visual.encoded_tensor_bytes,
+        authority.memory.visual.resident_device_weight_bytes,
+        authority.memory.audio.artifact_file_bytes,
+        authority.memory.audio.header_bytes,
+        authority.memory.audio.encoded_tensor_bytes,
+        authority.memory.audio.resident_device_weight_bytes,
+        authority.memory.config_bytes,
+        authority.memory.peak_host_io_buffer_bytes,
+        authority.memory.peak_host_mapped_file_bytes,
+        authority.memory.peak_staging_disk_bytes,
+        authority.memory.resident_host_weight_bytes,
+        authority.memory.resident_device_weight_bytes,
+        authority.memory.effective_device_weight_bytes,
+    ] {
+        digest.update(value.to_le_bytes());
+    }
+    format!("{:x}", digest.finalize())
 }
 
 trait VaeFactory {
@@ -1086,8 +1676,15 @@ fn checkpoint(
 
 struct StagedWeights {
     _directory: tempfile::TempDir,
-    visual: PathBuf,
-    audio: PathBuf,
+    visual: StagedWeight,
+    audio: StagedWeight,
+}
+
+struct StagedWeight {
+    role: H3ComfyVaeArtifactRole,
+    path: PathBuf,
+    identity: FileIdentity,
+    file: File,
 }
 
 impl StagedWeights {
@@ -1124,11 +1721,69 @@ impl StagedWeights {
 
     fn path(&self, role: H3ComfyVaeArtifactRole) -> LoadResult<&Path> {
         match role {
-            H3ComfyVaeArtifactRole::VisualWeights => Ok(&self.visual),
-            H3ComfyVaeArtifactRole::AudioWeights => Ok(&self.audio),
+            H3ComfyVaeArtifactRole::VisualWeights => Ok(&self.visual.path),
+            H3ComfyVaeArtifactRole::AudioWeights => Ok(&self.audio.path),
             _ => Err(H3ComfyVaeLoadError::InvalidPlan(format!(
                 "artifact {role:?} is not a staged weight"
             ))),
+        }
+    }
+
+    fn validate(&self, operation: &str) -> LoadResult<()> {
+        self.visual.validate(operation)?;
+        self.audio.validate(operation)
+    }
+
+    fn update_identity(&self, digest: &mut Sha256) {
+        self.visual.update_identity(digest);
+        self.audio.update_identity(digest);
+    }
+}
+
+impl StagedWeight {
+    fn validate(&self, operation: &str) -> LoadResult<()> {
+        let descriptor_identity = file_identity(&self.file.metadata().map_err(|error| {
+            artifact_error(
+                self.role,
+                format!("cannot stat retained staging descriptor {operation}: {error}"),
+            )
+        })?)?;
+        let path_metadata = std::fs::symlink_metadata(&self.path).map_err(|error| {
+            artifact_error(
+                self.role,
+                format!("cannot stat private staging path {operation}: {error}"),
+            )
+        })?;
+        if path_metadata.file_type().is_symlink()
+            || !path_metadata.file_type().is_file()
+            || descriptor_identity != self.identity
+            || file_identity(&path_metadata)? != self.identity
+        {
+            return Err(artifact_error(
+                self.role,
+                format!("retained staging descriptor or path changed {operation}"),
+            ));
+        }
+        Ok(())
+    }
+
+    fn update_identity(&self, digest: &mut Sha256) {
+        digest.update(self.role.stable_id().as_bytes());
+        digest.update([0]);
+        let path = self.path.as_os_str().as_encoded_bytes();
+        digest.update((path.len() as u64).to_le_bytes());
+        digest.update(path);
+        digest.update(self.identity.len.to_le_bytes());
+        #[cfg(unix)]
+        for value in [
+            self.identity.device,
+            self.identity.inode,
+            self.identity.modified_seconds as u64,
+            self.identity.modified_nanoseconds as u64,
+            self.identity.changed_seconds as u64,
+            self.identity.changed_nanoseconds as u64,
+        ] {
+            digest.update(value.to_le_bytes());
         }
     }
 }
@@ -1137,7 +1792,7 @@ fn stage_weight(
     artifact: &mut OpenedArtifact,
     directory: &Path,
     observer: &mut dyn H3ComfyVaeLoadObserver,
-) -> LoadResult<PathBuf> {
+) -> LoadResult<StagedWeight> {
     let role = artifact.expected.role;
     let target = directory.join(artifact.expected.basename()?);
     let mut options = OpenOptions::new();
@@ -1221,16 +1876,24 @@ fn stage_weight(
     output
         .set_permissions(permissions)
         .map_err(|error| artifact_error(role, format!("cannot seal staging file: {error}")))?;
-    drop(output);
-    if std::fs::metadata(&target)
-        .map_err(|error| artifact_error(role, format!("cannot stat sealed staging file: {error}")))?
-        .len()
-        != total
-    {
+    let identity = file_identity(&output.metadata().map_err(|error| {
+        artifact_error(
+            role,
+            format!("cannot stat sealed staging descriptor: {error}"),
+        )
+    })?)?;
+    if identity.len != total {
         return Err(artifact_error(role, "sealed staging length changed"));
     }
     artifact.validate_source("after authentication and staging")?;
-    Ok(target)
+    let staged = StagedWeight {
+        role,
+        path: target,
+        identity,
+        file: output,
+    };
+    staged.validate("after sealing")?;
+    Ok(staged)
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -1288,6 +1951,18 @@ impl OpenedArtifact {
                     requested_path.display()
                 ),
             ));
+        }
+        #[cfg(unix)]
+        {
+            // SAFETY: `geteuid` has no preconditions and only reads process
+            // state.
+            let effective_uid = unsafe { libc::geteuid() };
+            if requested_metadata.uid() != effective_uid || requested_metadata.mode() & 0o022 != 0 {
+                return Err(artifact_error(
+                    role,
+                    "source must be process-owned and not group/other writable",
+                ));
+            }
         }
         let canonical_path = std::fs::canonicalize(requested_path).map_err(|error| {
             artifact_error(
@@ -1481,6 +2156,53 @@ fn file_identity(metadata: &std::fs::Metadata) -> LoadResult<FileIdentity> {
         #[cfg(not(unix))]
         modified: metadata.modified().ok(),
     })
+}
+
+fn validate_private_storage_directory(path: &Path, label: &str) -> LoadResult<PathBuf> {
+    if !path.is_absolute()
+        || path
+            .components()
+            .any(|component| !matches!(component, Component::RootDir | Component::Normal(_)))
+    {
+        return Err(H3ComfyVaeLoadError::InvalidPlan(format!(
+            "private H3 {label} must be an absolute canonical path"
+        )));
+    }
+    let metadata = std::fs::symlink_metadata(path).map_err(|error| {
+        H3ComfyVaeLoadError::InvalidPlan(format!(
+            "cannot inspect private H3 {label} {}: {error}",
+            path.display()
+        ))
+    })?;
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        return Err(H3ComfyVaeLoadError::InvalidPlan(format!(
+            "private H3 {label} must be a real directory"
+        )));
+    }
+    #[cfg(unix)]
+    {
+        // SAFETY: `geteuid` has no preconditions and only reads the process
+        // effective user identifier.
+        let effective_uid = unsafe { libc::geteuid() };
+        if metadata.uid() != effective_uid || metadata.mode() & 0o022 != 0 {
+            return Err(H3ComfyVaeLoadError::InvalidPlan(format!(
+                "private H3 {label} must be process-owned and not group/other writable"
+            )));
+        }
+    }
+    #[cfg(not(unix))]
+    return Err(H3ComfyVaeLoadError::InvalidPlan(
+        "private H3 storage resolution currently requires Unix ownership semantics".into(),
+    ));
+    let canonical = std::fs::canonicalize(path).map_err(|error| {
+        H3ComfyVaeLoadError::InvalidPlan(format!("cannot canonicalize private H3 {label}: {error}"))
+    })?;
+    if canonical != path {
+        return Err(H3ComfyVaeLoadError::InvalidPlan(format!(
+            "private H3 {label} must not contain aliases or symlink components"
+        )));
+    }
+    Ok(canonical)
 }
 
 fn production_artifacts(manifest: &ModelManifest) -> LoadResult<Vec<ExpectedArtifact>> {
@@ -1900,6 +2622,63 @@ mod tests {
     }
 
     #[test]
+    fn hidden_storage_plan_uses_manifest_paths_without_model_paths() {
+        let models = tempfile::tempdir().unwrap();
+        let staging = tempfile::tempdir().unwrap();
+        let models_root = models.path().canonicalize().unwrap();
+        let staging_root = staging.path().canonicalize().unwrap();
+        let plan = FrozenH3ComfyVaeLoadPlan::from_hidden_storage(
+            contract::FL2VA_COMFY,
+            &models_root,
+            &staging_root,
+        )
+        .unwrap();
+        let manifest = find_manifest(contract::FL2VA_COMFY).unwrap();
+        for role in H3ComfyVaeArtifactRole::ALL {
+            let source = plan.artifact(role).unwrap().source_path.as_str();
+            let file = manifest
+                .files
+                .iter()
+                .find(|file| file.hf_filename == source)
+                .unwrap();
+            assert_eq!(
+                plan.paths.get(role),
+                models_root.join(storage_path(manifest, file))
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn hidden_storage_plan_rejects_alias_and_writable_roots() {
+        use std::os::unix::fs::{symlink, PermissionsExt};
+
+        let parent = tempfile::tempdir().unwrap();
+        let models = parent.path().join("models");
+        let staging = parent.path().join("staging");
+        std::fs::create_dir(&models).unwrap();
+        std::fs::create_dir(&staging).unwrap();
+        let models = models.canonicalize().unwrap();
+        let staging = staging.canonicalize().unwrap();
+        let alias = parent.path().join("models-alias");
+        symlink(&models, &alias).unwrap();
+        assert!(FrozenH3ComfyVaeLoadPlan::from_hidden_storage(
+            contract::FL2VA_COMFY,
+            &alias,
+            &staging,
+        )
+        .is_err());
+
+        std::fs::set_permissions(&models, std::fs::Permissions::from_mode(0o777)).unwrap();
+        assert!(FrozenH3ComfyVaeLoadPlan::from_hidden_storage(
+            contract::FL2VA_COMFY,
+            &models,
+            &staging,
+        )
+        .is_err());
+    }
+
+    #[test]
     fn synthetic_loader_is_opened_file_bound_and_reports_exact_memory() {
         let source = tempfile::tempdir().unwrap();
         let staging = tempfile::tempdir().unwrap();
@@ -1956,6 +2735,80 @@ mod tests {
             }
         ));
         assert_eq!(std::fs::read_dir(staging.path()).unwrap().count(), 0);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn opened_vae_source_rejects_group_writable_artifacts() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let source = tempfile::tempdir().unwrap();
+        let staging = tempfile::tempdir().unwrap();
+        let (paths, artifacts) = write_artifacts(source.path(), b"\x08visual");
+        std::fs::set_permissions(
+            &paths.visual_weights,
+            std::fs::Permissions::from_mode(0o666),
+        )
+        .unwrap();
+        let plan =
+            FrozenH3ComfyVaeLoadPlan::synthetic(paths, staging.path().to_path_buf(), artifacts)
+                .unwrap();
+        let error = load_with_factory(
+            &plan,
+            &Device::Cpu,
+            &mut RecordingObserver::default(),
+            &mut FakeFactory,
+        )
+        .err()
+        .unwrap();
+        assert!(matches!(
+            error,
+            H3ComfyVaeLoadError::Artifact {
+                role: H3ComfyVaeArtifactRole::VisualWeights,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn authenticated_staging_descriptor_rejects_path_replacement_before_allocation() {
+        let source = tempfile::tempdir().unwrap();
+        let staging_root = tempfile::tempdir().unwrap();
+        let (paths, artifacts) = write_artifacts(source.path(), b"\x08visual");
+        let plan = FrozenH3ComfyVaeLoadPlan::synthetic(
+            paths,
+            staging_root.path().to_path_buf(),
+            artifacts,
+        )
+        .unwrap();
+        let mut observer = RecordingObserver::default();
+        let mut opened = H3ComfyVaeArtifactRole::WEIGHTS
+            .into_iter()
+            .map(|role| {
+                OpenedArtifact::open(
+                    plan.artifact(role).unwrap().clone(),
+                    plan.paths.get(role),
+                    &mut observer,
+                )
+                .unwrap()
+            })
+            .collect::<Vec<_>>();
+        let staged = StagedWeights::create(&plan, &mut opened, &mut observer).unwrap();
+        let target = staged
+            .path(H3ComfyVaeArtifactRole::VisualWeights)
+            .unwrap()
+            .to_path_buf();
+        let authenticated = target.with_extension("authenticated");
+        std::fs::rename(&target, &authenticated).unwrap();
+        std::fs::write(&target, b"replacement").unwrap();
+
+        let error = staged.validate("before allocation").unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("staging descriptor or path changed"),
+            "{error}"
+        );
     }
 
     struct ReplacingObserver {


### PR DESCRIPTION
## Summary

- authenticate and retain opened transformer, Qwen, VAE, support, and task-config evidence from the hidden private-storage contract
- freeze exact memory/factory inputs and a one-shot prepared FL2VA attempt without creating an execution lease or public activation path
- fail closed on path replacement, digest drift, unsafe ownership/permissions, cross-task artifacts, and changed storage identity

## Safety boundary

- remains gated by the non-shipping `h3-private-uat` feature
- all nine runtime activation prerequisites remain sealed and public admission remains rejected
- authorized-artifact prepare-to-freeze execution remains an explicit CUDA UAT requirement

## Verification

- exact head: `fca16b37706498f1756a79b5a71ac03177d2b72d`
- exact parent/main: `27913923d932b5ff1ffd96428be6f606fadfff38`
- rebased binary diff SHA-256: `da52e5a8b762748634737b5e5ab2a5ac5546c4b3f412be4d594e73b08cfef2da`
- stable patch identity unchanged across rebase; `git range-diff` reports exact equality
- `cargo fmt --all -- --check`
- `cargo check -p mold-ai-inference --features h3-private-uat`
- opened-evidence tests: 10 passed
- Candle H3 tests: 174 passed, 1 authorized-artifact test ignored
- strict all-target inference and Candle Clippy with warnings denied
- private-UAT and attention release-candidate contract scripts
- clean merge-tree against current main and prospective combined tree with PR #908; no overlapping changed path

Part of #814. Advances #825, #830, #839.