### PR TITLE
test(h3): enforce synthetic conformance contracts

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,6 @@
+self-hosted-runner:
+  labels:
+    - cuda
+    - minimax-h3-private-uat
+
+config-variables: null

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,10 @@ jobs:
               - 'docs/qualification/local-multi-gpu-report.schema.json'
               - 'scripts/minimax-h3-conformance.py'
               - 'scripts/tests/minimax-h3-conformance-contract.py'
+              - 'scripts/run-minimax-h3-gpu-conformance.py'
+              - 'scripts/tests/minimax-h3-gpu-conformance-contract.py'
               - 'scripts/tests/minimax-h3-private-uat-release-contract.sh'
+              - '.github/workflows/minimax-h3-private-conformance.yml'
               - 'tests/fixtures/minimax_h3/**'
               - 'docs/qualification/minimax-h3-*.json'
               - 'docs/qualification/minimax-h3-conformance.md'
@@ -163,6 +166,7 @@ jobs:
               - 'scripts/tests/desktop-candle-nix-source-hash.sh'
               - 'scripts/tests/release-sync-pr.sh'
               - 'scripts/tests/crates-publish-contract.sh'
+              - '.github/actionlint.yaml'
               - '.github/workflows/**'
             # Workflow-only PRs get static actionlint/routing-contract proof.
             # After merge, exercise every dynamic path against the real runner
@@ -413,6 +417,9 @@ jobs:
       - name: Test MiniMax H3 conformance contract
         if: env.RUN_RUST_SUITE == 'true'
         run: python3 scripts/tests/minimax-h3-conformance-contract.py
+      - name: Test MiniMax H3 private GPU conformance contract
+        if: env.RUN_RUST_SUITE == 'true'
+        run: python3 scripts/tests/minimax-h3-gpu-conformance-contract.py
       - name: Clippy the private MiniMax H3 artifact qualifier
         if: env.RUN_RUST_SUITE == 'true'
         run: cargo clippy -p mold-ai-inference --features dev-bins,h3-private-uat --bin h3_artifact_qualification -- -D warnings

--- a/.github/workflows/minimax-h3-private-conformance.yml
+++ b/.github/workflows/minimax-h3-private-conformance.yml
@@ -43,7 +43,9 @@ jobs:
     name: Validate authorized external GPU evidence
     needs: preflight
     environment: minimax-h3-private-uat
-    runs-on: [self-hosted, linux, x64, cuda, minimax-h3-private-uat]
+    runs-on:
+      group: minimax-h3-private-conformance
+      labels: [self-hosted, linux, x64, cuda, minimax-h3-private-uat]
     timeout-minutes: 120
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6

--- a/.github/workflows/minimax-h3-private-conformance.yml
+++ b/.github/workflows/minimax-h3-private-conformance.yml
@@ -45,30 +45,25 @@ jobs:
     environment: minimax-h3-private-uat
     runs-on: [self-hosted, linux, x64, cuda, minimax-h3-private-uat]
     timeout-minutes: 120
-    env:
-      MOLD_H3_FIXTURE_ROOT: ${{ secrets.MOLD_H3_FIXTURE_ROOT }}
-      MOLD_H3_AUTHORIZATION_RECORD: ${{ secrets.MOLD_H3_AUTHORIZATION_RECORD }}
-      MOLD_H3_ORACLE_BUNDLE: ${{ secrets.MOLD_H3_ORACLE_BUNDLE }}
-      MOLD_H3_MOLD_BUNDLE: ${{ secrets.MOLD_H3_MOLD_BUNDLE }}
-      MOLD_H3_SOURCE_SHA: ${{ github.sha }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           clean: true
           persist-credentials: false
           ref: ${{ github.sha }}
-      - name: Require protected runner inputs
+      - name: Require protected runner tools
         shell: bash
         run: |
           set -euo pipefail
-          test -n "$MOLD_H3_FIXTURE_ROOT"
-          test -n "$MOLD_H3_AUTHORIZATION_RECORD"
-          test -n "$MOLD_H3_ORACLE_BUNDLE"
-          test -n "$MOLD_H3_MOLD_BUNDLE"
-          test -n "$MOLD_H3_SOURCE_SHA"
           command -v python3 >/dev/null
           command -v nvidia-smi >/dev/null
       - name: Compare authorization-bound external captures
+        env:
+          MOLD_H3_FIXTURE_ROOT: ${{ secrets.MOLD_H3_FIXTURE_ROOT }}
+          MOLD_H3_AUTHORIZATION_RECORD: ${{ secrets.MOLD_H3_AUTHORIZATION_RECORD }}
+          MOLD_H3_ORACLE_BUNDLE: ${{ secrets.MOLD_H3_ORACLE_BUNDLE }}
+          MOLD_H3_MOLD_BUNDLE: ${{ secrets.MOLD_H3_MOLD_BUNDLE }}
+          MOLD_H3_SOURCE_SHA: ${{ github.sha }}
         run: >-
           PYTHONDONTWRITEBYTECODE=1
           python3 scripts/run-minimax-h3-gpu-conformance.py

--- a/.github/workflows/minimax-h3-private-conformance.yml
+++ b/.github/workflows/minimax-h3-private-conformance.yml
@@ -1,0 +1,74 @@
+name: MiniMax H3 private conformance
+
+on:
+  workflow_dispatch:
+    inputs:
+      expected_source_sha:
+        description: Exact reviewed main commit to validate
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: minimax-h3-private-conformance
+  cancel-in-progress: false
+
+jobs:
+  preflight:
+    name: Verify explicit source authority
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require exact current main
+        env:
+          EXPECTED_SOURCE_SHA: ${{ inputs.expected_source_sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_REF" != 'refs/heads/main' ]]; then
+            echo '::error::Private H3 conformance may only target main.'
+            exit 1
+          fi
+          if [[ ! "$EXPECTED_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo '::error::expected_source_sha must be one lowercase commit SHA.'
+            exit 1
+          fi
+          if [[ "$GITHUB_SHA" != "$EXPECTED_SOURCE_SHA" ]]; then
+            echo '::error::The dispatched revision differs from expected_source_sha.'
+            exit 1
+          fi
+
+  conformance:
+    name: Validate authorized external GPU evidence
+    needs: preflight
+    environment: minimax-h3-private-uat
+    runs-on: [self-hosted, linux, x64, cuda, minimax-h3-private-uat]
+    timeout-minutes: 120
+    env:
+      MOLD_H3_FIXTURE_ROOT: ${{ secrets.MOLD_H3_FIXTURE_ROOT }}
+      MOLD_H3_AUTHORIZATION_RECORD: ${{ secrets.MOLD_H3_AUTHORIZATION_RECORD }}
+      MOLD_H3_ORACLE_BUNDLE: ${{ secrets.MOLD_H3_ORACLE_BUNDLE }}
+      MOLD_H3_MOLD_BUNDLE: ${{ secrets.MOLD_H3_MOLD_BUNDLE }}
+      MOLD_H3_SOURCE_SHA: ${{ github.sha }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          clean: true
+          persist-credentials: false
+          ref: ${{ github.sha }}
+      - name: Require protected runner inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "$MOLD_H3_FIXTURE_ROOT"
+          test -n "$MOLD_H3_AUTHORIZATION_RECORD"
+          test -n "$MOLD_H3_ORACLE_BUNDLE"
+          test -n "$MOLD_H3_MOLD_BUNDLE"
+          test -n "$MOLD_H3_SOURCE_SHA"
+          command -v python3 >/dev/null
+          command -v nvidia-smi >/dev/null
+      - name: Compare authorization-bound external captures
+        run: >-
+          PYTHONDONTWRITEBYTECODE=1
+          python3 scripts/run-minimax-h3-gpu-conformance.py

--- a/docs/qualification/minimax-h3-conformance-manifest.schema.json
+++ b/docs/qualification/minimax-h3-conformance-manifest.schema.json
@@ -25,7 +25,12 @@
     "numerical_authority": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["source_id", "precision", "excluded_accelerations"],
+      "required": [
+        "source_id",
+        "precision",
+        "excluded_accelerations",
+        "excluded_acceleration_aliases"
+      ],
       "properties": {
         "source_id": { "const": "diffusers" },
         "precision": { "const": "official-bf16-fp32-mixed" },
@@ -33,6 +38,32 @@
           "type": "array",
           "minItems": 7,
           "items": { "type": "string", "minLength": 1 }
+        },
+        "excluded_acceleration_aliases": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "torch-compile",
+            "fp8",
+            "cache-dit",
+            "sageattention",
+            "stochastic-sampling",
+            "approximate-attention",
+            "tf32"
+          ],
+          "properties": {
+            "torch-compile": { "$ref": "#/$defs/acceleration_aliases" },
+            "fp8": { "$ref": "#/$defs/acceleration_aliases" },
+            "cache-dit": { "$ref": "#/$defs/acceleration_aliases" },
+            "sageattention": { "$ref": "#/$defs/acceleration_aliases" },
+            "stochastic-sampling": {
+              "$ref": "#/$defs/acceleration_aliases"
+            },
+            "approximate-attention": {
+              "$ref": "#/$defs/acceleration_aliases"
+            },
+            "tf32": { "$ref": "#/$defs/acceleration_aliases" }
+          }
         }
       }
     },
@@ -119,6 +150,11 @@
       "type": "string",
       "pattern": "^[0-9a-f]{40}$"
     },
+    "acceleration_aliases": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 }
+    },
     "source": {
       "type": "object",
       "additionalProperties": false,
@@ -147,20 +183,83 @@
     "fixture_layer": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["id", "authority_tier", "required_provenance", "required_measurements"],
+      "required": [
+        "id",
+        "authority_tier",
+        "input_contract",
+        "required_component_indexes",
+        "required_provenance",
+        "pinned_provenance",
+        "role_invariant_provenance",
+        "required_measurements"
+      ],
       "properties": {
         "id": { "type": "string", "minLength": 1 },
         "authority_tier": {
           "enum": ["exact-full-bf16", "quantized-structural", "synthetic"]
+        },
+        "input_contract": { "$ref": "#/$defs/input_contract" },
+        "required_component_indexes": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
         },
         "required_provenance": {
           "type": "array",
           "minItems": 5,
           "items": { "type": "string", "minLength": 1 }
         },
+        "pinned_provenance": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/pinned_provenance" }
+        },
+        "role_invariant_provenance": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        },
         "required_measurements": {
           "type": "array",
           "minItems": 2,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "input_contract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind"],
+      "properties": {
+        "kind": {
+          "enum": ["identity-sha256-v1", "canonical-e2e-json-sha256-v1"]
+        },
+        "task": { "enum": ["t2va", "fl2va", "ref2va"] },
+        "algorithm": { "type": "string", "minLength": 1 },
+        "guidance": { "type": "string", "minLength": 1 },
+        "video_shift": { "type": "string", "minLength": 1 },
+        "audio_shift": { "type": "string", "minLength": 1 },
+        "dimension_multiple": { "type": "integer", "minimum": 1 },
+        "frame_step": { "type": "integer", "minimum": 1 },
+        "frame_offset": { "type": "integer", "minimum": 0 },
+        "min_frames": { "type": "integer", "minimum": 1 },
+        "max_frames": { "type": "integer", "minimum": 1 },
+        "max_pixels": { "type": "integer", "minimum": 1 },
+        "min_aspect_ratio": { "type": "string", "minLength": 1 },
+        "max_aspect_ratio": { "type": "string", "minLength": 1 },
+        "fps": { "type": "integer", "minimum": 1 },
+        "video_scheduler_component": { "type": "string", "minLength": 1 },
+        "audio_scheduler_component": { "type": "string", "minLength": 1 }
+      }
+    },
+    "pinned_provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["key", "component_indexes"],
+      "properties": {
+        "key": { "type": "string", "minLength": 1 },
+        "component_indexes": {
+          "type": "array",
+          "minItems": 1,
           "items": { "type": "string", "minLength": 1 }
         }
       }

--- a/docs/qualification/minimax-h3-conformance.md
+++ b/docs/qualification/minimax-h3-conformance.md
@@ -169,15 +169,29 @@ trigger. Dispatch it from `main` with the exact reviewed commit as
 the protected runner independently checks its checkout before reading external
 evidence.
 
-The administrator prerequisite is to create and protect the
-`minimax-h3-private-uat` GitHub Environment, configure its four path secrets,
-and provision an ephemeral, isolated runner carrying the workflow's exact
-self-hosted labels. Do not register a persistent public-repository runner for
-this campaign. This runbook does not assert that either is currently
-configured. Without the matching runner the job remains queued; if the
-environment, approval, or secrets are absent, validation fails closed before
-it reads evidence. Each secret value is an absolute path visible only to the
-validator step:
+The following are **unchecked administrator prerequisites**. Verify them in
+GitHub before every dispatch; neither the workflow nor this repository can
+attest repository settings:
+
+- Create the `minimax-h3-private-uat` Environment, add required reviewers and
+  the intended branch/ref protection, and configure its four path secrets.
+  Referencing a missing Environment can create one without the intended
+  protection, so the name in this workflow is not evidence that approval is
+  enforced.
+- Create the dedicated `minimax-h3-private-conformance` runner group, restrict
+  it to selected workflows, and allow exactly
+  `utensils/mold/.github/workflows/minimax-h3-private-conformance.yml@refs/heads/main`.
+  Provision only an ephemeral, isolated runner in that group. Do not register
+  a persistent public-repository runner for this campaign.
+- Give the runner the `self-hosted`, `linux`, `x64`, `cuda`, and
+  `minimax-h3-private-uat` labels. Labels select compatible capacity; they are
+  routing metadata, not an access-control boundary. Runner-group workflow/ref
+  restriction and Environment reviewers provide the administrative boundary.
+
+A missing matching runner can leave the job queued, and missing secrets are
+rejected by the validator, but neither behavior proves that the Environment or
+runner-group restrictions exist. Each secret value is an absolute path visible
+only to the validator step:
 
 - `MOLD_H3_FIXTURE_ROOT`: the external root containing all retained evidence.
 - `MOLD_H3_AUTHORIZATION_RECORD`: the external authorization JSON described
@@ -188,22 +202,43 @@ validator step:
   source SHA.
 
 Both bundles use `mold.minimax-h3.fixture-bundle.v1`; their referenced files use
-`mold.minimax-h3.layer-output.v1`. Bundle and layer environments must declare a
-`cuda:` device and the canonical `bfloat16` dtype. Every layer output accepted
-by this exact path is also `bfloat16`. Non-synthetic documents must bind the
-already reviewed authorization evidence SHA-256 shown above. The runner derives
-the authority-tier map from the validated manifest and requires paired oracle
-and Mold evidence for all eleven `exact-full-bf16` layers; it excludes the
-manifest's synthetic sampler instead of relabeling it. Synthetic and
-quantized-structural authority remain available only to their separate,
-explicitly labeled qualification paths.
+`mold.minimax-h3.layer-output.v1`. Bundle and layer capture environments must
+declare a `cuda:` device and the canonical `bfloat16` execution dtype.
+Non-synthetic documents must bind the already reviewed authorization evidence
+SHA-256 shown above. The protected runner requires a `provenance` record whose
+keys exactly equal each manifest layer's `required_provenance`; canonical
+source, component, device, dtype, attention-backend, and capture-command values
+must also agree with the document's structured producer, input, environment,
+and adapter fields. It likewise requires output and oracle-policy keys to
+exactly equal `required_measurements`. The field remains optional in the base
+schema only so the older checked synthetic contract stays compatible; it is
+mandatory for this protected path.
 
-The layer document's oracle comparison policies are authoritative. Absolute
-and relative tolerances are independently capped at `1/64`, and each bundle's
-duplicated tensor summary must exactly mirror the document's first output. The
-oracle bundle tolerance must exactly mirror that output's policy, and the Mold
-bundle must repeat the same policy summary. A mismatch is rejected rather than
-silently trusting bundle metadata.
+The runner uses an explicit dtype and comparison policy for every required
+measurement. Captured floating activations are `bfloat16`. Computed metric and
+statistical summaries are serialized as `float64` so reductions and derived
+quality values retain stable host-side precision; this does not claim that the
+captured model tensors ran in float64. Discrete tokenizer, shape, layout,
+ordering, allocation, polarity, and hash records are `int64`, use zero absolute
+and relative tolerance, and require an exact content hash. Floating activation
+and metric records use the manifest-specific dtype, `record-only` hashes, and
+absolute and relative tolerances independently capped at `1/64`. Oracle and
+Mold outputs must agree on measurement keys and dtype; the protected policy is
+derived by the runner rather than accepted from a relabeled fixture.
+
+The runner derives the authority-tier map from the validated manifest and
+requires paired oracle and Mold evidence for all eleven `exact-full-bf16`
+layers; it excludes the manifest's synthetic sampler instead of relabeling it.
+Synthetic and quantized-structural authority remain available only to their
+separate, explicitly labeled qualification paths.
+
+Each bundle's duplicated tensor summary must exactly mirror the document's
+first output. The oracle bundle tolerance must exactly mirror that output's
+validated policy, and the Mold bundle must repeat the same policy summary. A
+mismatch is rejected rather than silently trusting bundle metadata. Mold layer
+documents cannot declare a second comparison policy; the runner applies the
+validated oracle policy to both producers, preventing a Mold-side tolerance or
+hash-policy override.
 
 The workflow neither executes the adapter `command` strings nor captures new
 evidence. Those fields remain provenance from separately reviewed capture

--- a/docs/qualification/minimax-h3-conformance.md
+++ b/docs/qualification/minimax-h3-conformance.md
@@ -119,8 +119,8 @@ The external authorization record has this exact shape:
     "fixture-capture",
     "generated-output-retention"
   ],
-  "source_document_path": "/external/compliance/minimax-h3-authorization.pdf",
-  "source_document_sha256": "<sha256>",
+  "source_document_path": "/external/compliance/reviewed-authorization-evidence.bin",
+  "source_document_sha256": "8cd4d6e52cff34d7d39721ebab13b8c1187aa87aafc1c4ae2a16609186f22f1d",
   "review_reference": "<external review identifier>"
 }
 ```
@@ -169,9 +169,15 @@ trigger. Dispatch it from `main` with the exact reviewed commit as
 the protected runner independently checks its checkout before reading external
 evidence.
 
-The protected `minimax-h3-private-uat` GitHub Environment supplies four
-environment-scoped secrets. Each value is an absolute path visible only to the
-protected runner:
+The administrator prerequisite is to create and protect the
+`minimax-h3-private-uat` GitHub Environment, configure its four path secrets,
+and provision an ephemeral, isolated runner carrying the workflow's exact
+self-hosted labels. Do not register a persistent public-repository runner for
+this campaign. This runbook does not assert that either is currently
+configured. Without the matching runner the job remains queued; if the
+environment, approval, or secrets are absent, validation fails closed before
+it reads evidence. Each secret value is an absolute path visible only to the
+validator step:
 
 - `MOLD_H3_FIXTURE_ROOT`: the external root containing all retained evidence.
 - `MOLD_H3_AUTHORIZATION_RECORD`: the external authorization JSON described
@@ -183,17 +189,30 @@ protected runner:
 
 Both bundles use `mold.minimax-h3.fixture-bundle.v1`; their referenced files use
 `mold.minimax-h3.layer-output.v1`. Bundle and layer environments must declare a
-`cuda:` device, and non-synthetic documents must bind the authorization source
-hash. The runner rejects mismatched case/layer sets, component indexes,
-producer roles, framework revisions, or numerical comparisons. This path
-requires `exact-full-bf16`; synthetic and quantized-structural authority remain
-available only to their separate, explicitly labeled qualification paths.
+`cuda:` device and the canonical `bfloat16` dtype. Every layer output accepted
+by this exact path is also `bfloat16`. Non-synthetic documents must bind the
+already reviewed authorization evidence SHA-256 shown above. The runner derives
+the authority-tier map from the validated manifest and requires paired oracle
+and Mold evidence for all eleven `exact-full-bf16` layers; it excludes the
+manifest's synthetic sampler instead of relabeling it. Synthetic and
+quantized-structural authority remain available only to their separate,
+explicitly labeled qualification paths.
+
+The layer document's oracle comparison policies are authoritative. Absolute
+and relative tolerances are independently capped at `1/64`, and each bundle's
+duplicated tensor summary must exactly mirror the document's first output. The
+oracle bundle tolerance must exactly mirror that output's policy, and the Mold
+bundle must repeat the same policy summary. A mismatch is rejected rather than
+silently trusting bundle metadata.
 
 The workflow neither executes the adapter `command` strings nor captures new
 evidence. Those fields remain provenance from separately reviewed capture
 steps. It also does not upload artifacts or copy external evidence into the
 checkout; detailed evidence stays on the protected runner, and failures expose
-only redacted contract context in CI logs. Adding this validation
+only redacted contract context in CI logs. Evidence bytes are hashed, parsed,
+validated, and retained from one read; numerical comparison uses those same
+in-memory documents, so a later path replacement cannot change the compared
+values. Adding this validation
 infrastructure does not by itself claim that a real checkpoint was captured or
 that licensed GPU UAT passed.
 

--- a/docs/qualification/minimax-h3-conformance.md
+++ b/docs/qualification/minimax-h3-conformance.md
@@ -154,7 +154,7 @@ media itself.
 
 The bundle schema is
 `docs/qualification/minimax-h3-fixture-bundle.schema.json`. Every fixture names
-its primitive layer, authority tier, component-index hash, environment,
+its primitive layer, authority tier, component-index authorities, environment,
 shape/dtype/statistics/sampled values, evidence hash, and numerical tolerance.
 Quantized Comfy results use structural, temporal, and audio quality metrics;
 they are never mislabeled as bit-identical full-precision evidence.
@@ -203,28 +203,83 @@ only to the validator step:
 
 Both bundles use `mold.minimax-h3.fixture-bundle.v1`; their referenced files use
 `mold.minimax-h3.layer-output.v1`. Bundle and layer capture environments must
-declare a `cuda:` device and the canonical `bfloat16` execution dtype.
+declare a `cuda:` device and the canonical `bfloat16` execution dtype, and their
+attention backend must not name an acceleration excluded by the manifest. Both
+scopes also carry `acceleration_policy.enabled` and `.disabled`: identifiers
+must be canonical and duplicate-free, `disabled` must equal the complete
+manifest exclusion set, `enabled` must contain none of it, and each layer must
+repeat its bundle's capture policy. The manifest separately pins reviewed
+aliases for every exclusion, so names such as precision formats or abbreviated
+attention backends cannot bypass the enabled/backend checks. This is structured
+capture attestation; the runner does not execute the recorded command or
+inspect the original process.
 Non-synthetic documents must bind the already reviewed authorization evidence
 SHA-256 shown above. The protected runner requires a `provenance` record whose
 keys exactly equal each manifest layer's `required_provenance`; canonical
 source, component, device, dtype, attention-backend, and capture-command values
 must also agree with the document's structured producer, input, environment,
-and adapter fields. It likewise requires output and oracle-policy keys to
-exactly equal `required_measurements`. The field remains optional in the base
-schema only so the older checked synthetic contract stays compatible; it is
-mandatory for this protected path.
+and adapter fields. Each layer must carry the exact manifest-selected component
+authority records, including every member of a multi-component layer; the
+singular component hash remains only a compatibility summary of the first
+manifest-selected record. Manifest-declared role-invariant provenance must
+also match between the oracle and Mold documents. The runner likewise requires
+output and oracle-policy keys to exactly equal `required_measurements`, and
+pins `tensor_hash_encoding` to `canonical-typed-le-v1`. The additive component
+authority and provenance fields remain optional in the base schemas only so
+the older checked synthetic contract stays compatible; they are mandatory for
+this protected path.
+
+The tokenizer and processor provenance hashes are separately authority-pinned,
+not merely compared between roles. Each is SHA-256 over canonical UTF-8 JSON
+with schema `mold.minimax-h3.component-authority-set.v1` and a sorted
+`components` array of `{id,sha256}` records. The tokenizer set binds its JSON,
+configuration, merges, and vocabulary; the processor set binds its image and
+video configuration, chat template, and processor-local tokenizer files. All
+of those raw files are independently content-addressed at the official model
+revision and must also belong to the layer's component authority set.
 
 The runner uses an explicit dtype and comparison policy for every required
 measurement. Captured floating activations are `bfloat16`. Computed metric and
 statistical summaries are serialized as `float64` so reductions and derived
 quality values retain stable host-side precision; this does not claim that the
 captured model tensors ran in float64. Discrete tokenizer, shape, layout,
-ordering, allocation, polarity, and hash records are `int64`, use zero absolute
-and relative tolerance, and require an exact content hash. Floating activation
-and metric records use the manifest-specific dtype, `record-only` hashes, and
-absolute and relative tolerances independently capped at `1/64`. Oracle and
-Mold outputs must agree on measurement keys and dtype; the protected policy is
-derived by the runner rather than accepted from a relabeled fixture.
+ordering, allocation, polarity, and hash records are signed `int64`; every
+minimum, maximum, and sampled value must remain within the signed 64-bit range.
+They use zero absolute and relative tolerance and require an exact content hash.
+For `bfloat16` records, every minimum, maximum, and sample must round-trip
+exactly through BF16; means and standard deviations must be finite, exactly
+representable binary64 values. Every `float64` metric statistic and sample, and
+every oracle tolerance, must likewise be finite and exactly representable in
+binary64. Floating records require an exact content hash and retain absolute
+and relative tolerances independently capped at `1/64`. Any protected
+exact-tier hash mismatch is fatal,
+including when the recorded summaries and samples still agree. Oracle and Mold
+outputs must agree on measurement keys, dtype, content hashes, and declared
+role-invariant provenance; the protected policy is derived by the runner rather
+than accepted from a relabeled fixture.
+
+The three end-to-end layers use an explicit
+`mold.minimax-h3.e2e-input.v1` descriptor. `input.sha256` is SHA-256 of its UTF-8
+JSON with keys sorted recursively, comma/colon separators, non-ASCII text
+emitted directly rather than `\u`-escaped, no insignificant whitespace, and no
+non-finite numbers; sampler decimal values are canonical strings so the digest
+does not depend on language-specific float formatting. The descriptor binds
+exact prompt bytes,
+the absence of a negative prompt, ordered raw conditioning-byte digests, an
+unsigned 64-bit seed, dimensions, frame count, FPS, and both sampler settings.
+The runner enforces the H3 32-pixel dimension grid, pixel/aspect limits,
+124–362-frame `17k+5` grid, 24 FPS, equal step counts of at least two, zero
+guidance, rectified-flow Euler schedules, and video/audio shifts 12/3. T2VA has
+no conditioning, FL2VA has canonical first/last-frame ordering, and Ref2VA has
+a non-empty ordered reference list. Oracle and Mold input digests must match;
+the end-to-end component sets also bind tokenizer, processor, transformer, VAE,
+and both official scheduler configurations.
+
+No fixed prompt, media set, seed, dimensions, frame count, or step count is yet
+pinned as the single approved UAT case. This contract proves each supplied
+descriptor is canonical and that both roles ran the same semantically valid H3
+case; a later reviewed campaign digest is required to mandate one particular
+case.
 
 The runner derives the authority-tier map from the validated manifest and
 requires paired oracle and Mold evidence for all eleven `exact-full-bf16`

--- a/docs/qualification/minimax-h3-conformance.md
+++ b/docs/qualification/minimax-h3-conformance.md
@@ -94,12 +94,12 @@ until checkpoint access is authorized.
 
 ## External real-checkpoint fixtures
 
-Real checkpoint execution and fixture capture remain unavailable until the
-license gate is cleared. After that decision, evidence must be stored under an
-absolute fixture root outside the Mold checkout. The authorization record must
-also live outside the repository and content-address the reviewed source
-document. The validator is an accidental-bypass guard: it does not authenticate
-the issuer or replace legal review.
+Real checkpoint execution and fixture capture are restricted to an explicitly
+approved scope. Evidence must be stored under an absolute fixture root outside
+the Mold checkout. The authorization record must also live outside the
+repository and content-address the reviewed source document. The validator is
+an accidental-bypass guard: it does not authenticate the issuer or replace
+legal review.
 
 Everything in this section is a deferred runbook. No authorization record,
 real-checkpoint fixture bundle, generated H3 output, or passing licensed UAT is
@@ -158,6 +158,44 @@ its primitive layer, authority tier, component-index hash, environment,
 shape/dtype/statistics/sampled values, evidence hash, and numerical tolerance.
 Quantized Comfy results use structural, temporal, and audio quality metrics;
 they are never mislabeled as bit-identical full-precision evidence.
+
+### Opt-in protected GPU validation
+
+The manual `MiniMax H3 private conformance` workflow validates an approved,
+already-captured real-checkpoint campaign on an access-controlled self-hosted
+CUDA runner. It has no push, pull-request, schedule, or chained-workflow
+trigger. Dispatch it from `main` with the exact reviewed commit as
+`expected_source_sha`; its preflight rejects every other ref or source SHA, and
+the protected runner independently checks its checkout before reading external
+evidence.
+
+The protected `minimax-h3-private-uat` GitHub Environment supplies four
+environment-scoped secrets. Each value is an absolute path visible only to the
+protected runner:
+
+- `MOLD_H3_FIXTURE_ROOT`: the external root containing all retained evidence.
+- `MOLD_H3_AUTHORIZATION_RECORD`: the external authorization JSON described
+  above.
+- `MOLD_H3_ORACLE_BUNDLE`: a Diffusers bundle captured at the manifest's exact
+  pinned revision.
+- `MOLD_H3_MOLD_BUNDLE`: a distinct Mold bundle captured at the dispatched
+  source SHA.
+
+Both bundles use `mold.minimax-h3.fixture-bundle.v1`; their referenced files use
+`mold.minimax-h3.layer-output.v1`. Bundle and layer environments must declare a
+`cuda:` device, and non-synthetic documents must bind the authorization source
+hash. The runner rejects mismatched case/layer sets, component indexes,
+producer roles, framework revisions, or numerical comparisons. This path
+requires `exact-full-bf16`; synthetic and quantized-structural authority remain
+available only to their separate, explicitly labeled qualification paths.
+
+The workflow neither executes the adapter `command` strings nor captures new
+evidence. Those fields remain provenance from separately reviewed capture
+steps. It also does not upload artifacts or copy external evidence into the
+checkout; detailed evidence stays on the protected runner, and failures expose
+only redacted contract context in CI logs. Adding this validation
+infrastructure does not by itself claim that a real checkpoint was captured or
+that licensed GPU UAT passed.
 
 ## Day-zero frame decision
 

--- a/docs/qualification/minimax-h3-fixture-bundle.schema.json
+++ b/docs/qualification/minimax-h3-fixture-bundle.schema.json
@@ -33,6 +33,7 @@
         "device": { "type": "string", "minLength": 1 },
         "dtype": { "type": "string", "minLength": 1 },
         "attention_backend": { "type": "string", "minLength": 1 },
+        "acceleration_policy": { "$ref": "#/$defs/acceleration_policy" },
         "command": { "type": "string", "minLength": 1 },
         "forbidden_accelerations_disabled": { "const": true }
       }
@@ -51,6 +52,22 @@
     "commit": {
       "type": "string",
       "pattern": "^[0-9a-f]{40}$"
+    },
+    "acceleration_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["enabled", "disabled"],
+      "properties": {
+        "enabled": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "disabled": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
     },
     "fixture": {
       "type": "object",
@@ -74,6 +91,11 @@
         "relative_path": { "type": "string", "minLength": 1 },
         "sha256": { "$ref": "#/$defs/sha256" },
         "component_index_sha256": { "$ref": "#/$defs/sha256" },
+        "component_indexes": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/component_index_authority" }
+        },
         "tensor": {
           "type": "object",
           "additionalProperties": false,
@@ -106,6 +128,15 @@
             "metric": { "type": "string", "minLength": 1 }
           }
         }
+      }
+    },
+    "component_index_authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "sha256"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "sha256": { "$ref": "#/$defs/sha256" }
       }
     }
   }

--- a/docs/qualification/minimax-h3-layer-output.schema.json
+++ b/docs/qualification/minimax-h3-layer-output.schema.json
@@ -70,7 +70,22 @@
       "properties": {
         "id": { "$ref": "#/$defs/key" },
         "sha256": { "$ref": "#/$defs/sha256" },
-        "component_index_sha256": { "$ref": "#/$defs/sha256" }
+        "component_index_sha256": { "$ref": "#/$defs/sha256" },
+        "component_indexes": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/component_index_authority" }
+        },
+        "conformance": { "$ref": "#/$defs/e2e_input" }
+      }
+    },
+    "component_index_authority": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "sha256"],
+      "properties": {
+        "id": { "$ref": "#/$defs/key" },
+        "sha256": { "$ref": "#/$defs/sha256" }
       }
     },
     "producer": {
@@ -108,7 +123,93 @@
         "device": { "type": "string", "minLength": 1 },
         "dtype": { "type": "string", "minLength": 1 },
         "attention_backend": { "type": "string", "minLength": 1 },
+        "acceleration_policy": { "$ref": "#/$defs/acceleration_policy" },
         "forbidden_accelerations_disabled": { "const": true }
+      }
+    },
+    "acceleration_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["enabled", "disabled"],
+      "properties": {
+        "enabled": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/key" }
+        },
+        "disabled": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/key" }
+        }
+      }
+    },
+    "e2e_input": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "schema_version",
+        "task",
+        "prompt_sha256",
+        "negative_prompt_sha256",
+        "conditioning",
+        "seed",
+        "width",
+        "height",
+        "frames",
+        "fps",
+        "video_sampler",
+        "audio_sampler"
+      ],
+      "properties": {
+        "schema_version": { "const": "mold.minimax-h3.e2e-input.v1" },
+        "task": { "enum": ["t2va", "fl2va", "ref2va"] },
+        "prompt_sha256": { "$ref": "#/$defs/sha256" },
+        "negative_prompt_sha256": { "$ref": "#/$defs/sha256" },
+        "conditioning": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/conditioning_input" }
+        },
+        "seed": { "type": "integer" },
+        "width": { "type": "integer", "minimum": 1 },
+        "height": { "type": "integer", "minimum": 1 },
+        "frames": { "type": "integer", "minimum": 1 },
+        "fps": { "type": "integer", "minimum": 1 },
+        "video_sampler": { "$ref": "#/$defs/sampler_input" },
+        "audio_sampler": { "$ref": "#/$defs/sampler_input" }
+      }
+    },
+    "conditioning_input": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["role", "sha256"],
+      "properties": {
+        "role": {
+          "enum": [
+            "first-frame",
+            "last-frame",
+            "reference-image",
+            "reference-video",
+            "reference-audio"
+          ]
+        },
+        "sha256": { "$ref": "#/$defs/sha256" }
+      }
+    },
+    "sampler_input": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["algorithm", "steps", "guidance", "shift"],
+      "properties": {
+        "algorithm": { "$ref": "#/$defs/key" },
+        "steps": { "type": "integer", "minimum": 1 },
+        "guidance": {
+          "type": "string",
+          "pattern": "^(0|[1-9][0-9]*)(\\.[0-9]+)?$"
+        },
+        "shift": {
+          "type": "string",
+          "pattern": "^(0|[1-9][0-9]*)(\\.[0-9]+)?$"
+        }
       }
     },
     "provenance": {

--- a/docs/qualification/minimax-h3-layer-output.schema.json
+++ b/docs/qualification/minimax-h3-layer-output.schema.json
@@ -33,6 +33,11 @@
     "producer": { "$ref": "#/$defs/producer" },
     "adapter": { "$ref": "#/$defs/adapter" },
     "environment": { "$ref": "#/$defs/environment" },
+    "provenance": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/provenance" }
+    },
     "outputs": {
       "type": "array",
       "minItems": 1,
@@ -104,6 +109,18 @@
         "dtype": { "type": "string", "minLength": 1 },
         "attention_backend": { "type": "string", "minLength": 1 },
         "forbidden_accelerations_disabled": { "const": true }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["key", "value"],
+      "properties": {
+        "key": { "$ref": "#/$defs/key" },
+        "value": {
+          "type": "string",
+          "minLength": 1
+        }
       }
     },
     "statistics": {

--- a/scripts/minimax-h3-conformance.py
+++ b/scripts/minimax-h3-conformance.py
@@ -70,6 +70,20 @@ EXPECTED_EXCLUDED_ACCELERATIONS = {
     "approximate-attention",
     "tf32",
 }
+EXPECTED_EXCLUDED_ACCELERATION_ALIASES = {
+    "torch-compile": {"torch-compile", "torch-inductor", "inductor"},
+    "fp8": {"fp8", "float8", "e4m3", "e4m3fn", "e5m2"},
+    "cache-dit": {"cache-dit"},
+    "sageattention": {"sageattention", "sage-attn"},
+    "stochastic-sampling": {"stochastic-sampling", "stochastic", "ancestral"},
+    "approximate-attention": {
+        "approximate-attention",
+        "approximate",
+        "approx-attn",
+        "approx",
+    },
+    "tf32": {"tf32", "tensorfloat32"},
+}
 
 EXPECTED_COMPONENT_INDEXES = {
     "official-license": (
@@ -103,6 +117,58 @@ EXPECTED_COMPONENT_INDEXES = {
     "official-audio-vae-config": (
         "audio_vae/config.json",
         "9a3c645ff892b376c6f5f4c8685964cd75474731af594ff058492a0000caabb6",
+    ),
+    "official-tokenizer-json": (
+        "tokenizer/tokenizer.json",
+        "a5d85b6dcc535e6b93115a9ef287e6132fdbf30270da6218194ba742261173c7",
+    ),
+    "official-tokenizer-config": (
+        "tokenizer/tokenizer_config.json",
+        "a07e942ac874baa13758de8d1fbdb186683cc03416b5589e1b6671c6b3057c68",
+    ),
+    "official-tokenizer-merges": (
+        "tokenizer/merges.txt",
+        "599bab54075088774b1733fde865d5bd747cbcc7a547c5bc12610e874e26f5e3",
+    ),
+    "official-tokenizer-vocab": (
+        "tokenizer/vocab.json",
+        "ca10d7e9fb3ed18575dd1e277a2579c16d108e32f27439684afa0e10b1440910",
+    ),
+    "official-processor-config": (
+        "processor/preprocessor_config.json",
+        "27225450ac9c6529872ee1924fcb0962ff5634834f817040f444118116f4e516",
+    ),
+    "official-processor-video-config": (
+        "processor/video_preprocessor_config.json",
+        "7768af27c1fafa9cc9011c1dc20067e03f8915e03b63504550e11d5066986d13",
+    ),
+    "official-processor-chat-template": (
+        "processor/chat_template.json",
+        "5c72a170d2a4a1a3bc5adad2e689ae28138a9700e5b8c96c0266331e86c0acce",
+    ),
+    "official-processor-tokenizer-json": (
+        "processor/tokenizer.json",
+        "a5d85b6dcc535e6b93115a9ef287e6132fdbf30270da6218194ba742261173c7",
+    ),
+    "official-processor-tokenizer-config": (
+        "processor/tokenizer_config.json",
+        "a07e942ac874baa13758de8d1fbdb186683cc03416b5589e1b6671c6b3057c68",
+    ),
+    "official-processor-merges": (
+        "processor/merges.txt",
+        "599bab54075088774b1733fde865d5bd747cbcc7a547c5bc12610e874e26f5e3",
+    ),
+    "official-processor-vocab": (
+        "processor/vocab.json",
+        "ca10d7e9fb3ed18575dd1e277a2579c16d108e32f27439684afa0e10b1440910",
+    ),
+    "official-video-scheduler-config": (
+        "scheduler/scheduler_config.json",
+        "8fa6c3aa70dc9e691e1a6df899fd1b6f75f70481a27cee6e18a303817075c304",
+    ),
+    "official-audio-scheduler-config": (
+        "audio_scheduler/scheduler_config.json",
+        "804780f7133477067bd6bbfbc02dc8b3cf9feeb400f97c08f5b1d5f6cbab3840",
     ),
 }
 
@@ -515,6 +581,21 @@ def validate_layer_output(value: Any, label: str) -> dict[str, Any]:
     }
     if value["input"]["component_index_sha256"] not in component_hashes:
         fail(f"{label} component index hash is not in the pinned authority set")
+    component_indexes = value["input"].get("component_indexes")
+    if component_indexes is not None:
+        component_ids: set[str] = set()
+        for component in component_indexes:
+            identifier = component["id"]
+            if identifier in component_ids:
+                fail(f"{label} component indexes contain duplicate id {identifier!r}")
+            component_ids.add(identifier)
+            expected = EXPECTED_COMPONENT_INDEXES.get(identifier)
+            if expected is None or component["sha256"] != expected[1]:
+                fail(f"{label} component index authority is not pinned")
+        if value["input"]["component_index_sha256"] not in {
+            component["sha256"] for component in component_indexes
+        }:
+            fail(f"{label} component index summary is absent from its authority list")
 
     producer = value["producer"]
     if producer["role"] == "oracle":
@@ -566,8 +647,11 @@ def tolerance_issue(
 ) -> str | None:
     absolute = policy["absolute"]
     relative = policy["relative"]
-    error = abs(mold_value - oracle_value)
-    allowed = absolute + relative * abs(oracle_value)
+    try:
+        error = abs(mold_value - oracle_value)
+        allowed = absolute + relative * abs(oracle_value)
+    except OverflowError:
+        return f"{context} values are outside the finite comparison domain"
     if error <= allowed:
         return None
     return (
@@ -699,6 +783,14 @@ def validate_manifest() -> dict[str, Any]:
         or excluded != EXPECTED_EXCLUDED_ACCELERATIONS
     ):
         fail("ground-truth acceleration exclusions drifted")
+    raw_aliases = manifest["numerical_authority"]["excluded_acceleration_aliases"]
+    aliases = {identifier: set(values) for identifier, values in raw_aliases.items()}
+    if (
+        set(raw_aliases) != excluded
+        or any(len(values) != len(set(values)) for values in raw_aliases.values())
+        or aliases != EXPECTED_EXCLUDED_ACCELERATION_ALIASES
+    ):
+        fail("ground-truth acceleration exclusion aliases drifted")
 
     indexes = {
         item["id"]: (item["relative_path"], item["sha256"])
@@ -716,6 +808,69 @@ def validate_manifest() -> dict[str, Any]:
         or layers != EXPECTED_LAYERS
     ):
         fail("fixture layer coverage is incomplete or contains an unreviewed layer")
+    for layer in manifest["fixture_layers"]:
+        component_ids = layer["required_component_indexes"]
+        if len(component_ids) != len(set(component_ids)) or not set(
+            component_ids
+        ).issubset(EXPECTED_COMPONENT_INDEXES):
+            fail(f"fixture layer {layer['id']} has unreviewed component authority")
+        provenance = layer["required_provenance"]
+        pinned_provenance = layer["pinned_provenance"]
+        pinned_keys = [record["key"] for record in pinned_provenance]
+        pinned_components = [
+            component_id
+            for record in pinned_provenance
+            for component_id in record["component_indexes"]
+        ]
+        invariants = layer["role_invariant_provenance"]
+        if (
+            len(provenance) != len(set(provenance))
+            or len(pinned_keys) != len(set(pinned_keys))
+            or not set(pinned_keys).issubset(provenance)
+            or any(
+                len(record["component_indexes"])
+                != len(set(record["component_indexes"]))
+                or not set(record["component_indexes"]).issubset(component_ids)
+                for record in pinned_provenance
+            )
+            or not set(pinned_components).issubset(EXPECTED_COMPONENT_INDEXES)
+            or not set(pinned_keys).issubset(invariants)
+            or len(invariants) != len(set(invariants))
+            or not set(invariants).issubset(provenance)
+        ):
+            fail(f"fixture layer {layer['id']} has invalid provenance authority")
+        input_contract = layer["input_contract"]
+        expected_task = {
+            "end-to-end-t2va": "t2va",
+            "end-to-end-fl2va": "fl2va",
+            "end-to-end-ref2va": "ref2va",
+        }.get(layer["id"])
+        if expected_task is None:
+            if input_contract != {"kind": "identity-sha256-v1"}:
+                fail(f"fixture layer {layer['id']} has an invalid input contract")
+        elif input_contract != {
+            "kind": "canonical-e2e-json-sha256-v1",
+            "task": expected_task,
+            "algorithm": "minimax-h3-flow-euler-v1",
+            "guidance": "0",
+            "video_shift": "12",
+            "audio_shift": "3",
+            "dimension_multiple": 32,
+            "frame_step": 17,
+            "frame_offset": 5,
+            "min_frames": 124,
+            "max_frames": 362,
+            "max_pixels": 1_069_056,
+            "min_aspect_ratio": "0.25",
+            "max_aspect_ratio": "4",
+            "fps": 24,
+            "video_scheduler_component": "official-video-scheduler-config",
+            "audio_scheduler_component": "official-audio-scheduler-config",
+        } or not {
+            input_contract["video_scheduler_component"],
+            input_contract["audio_scheduler_component"],
+        }.issubset(component_ids):
+            fail(f"fixture layer {layer['id']} has an invalid input contract")
 
     policy = manifest["capture_policy"]
     if not all(
@@ -1074,7 +1229,7 @@ def main(argv: list[str]) -> int:
                 print(f"MiniMax H3 conformance note: {note}")
         print(f"MiniMax H3 conformance {args.command} passed")
         return 0
-    except (ConformanceFailure, OSError) as error:
+    except (ConformanceFailure, OSError, OverflowError) as error:
         print(f"invalid MiniMax H3 conformance evidence: {error}", file=sys.stderr)
         return 1
 

--- a/scripts/run-minimax-h3-gpu-conformance.py
+++ b/scripts/run-minimax-h3-gpu-conformance.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""Validate an authorization-bound MiniMax H3 GPU conformance campaign.
+
+This runner consumes already captured external evidence. Adapter commands in
+the evidence are provenance only and are never executed here. The public Mold
+product remains fail-closed and no evidence is copied into the checkout or CI.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import pathlib
+import re
+import subprocess
+import sys
+from collections.abc import Callable, Mapping
+from typing import Any
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+TOOL_PATH = REPO_ROOT / "scripts" / "minimax-h3-conformance.py"
+REQUIRED_ENVIRONMENT = (
+    "MOLD_H3_FIXTURE_ROOT",
+    "MOLD_H3_AUTHORIZATION_RECORD",
+    "MOLD_H3_ORACLE_BUNDLE",
+    "MOLD_H3_MOLD_BUNDLE",
+    "MOLD_H3_SOURCE_SHA",
+)
+COMMIT_SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+EXACT_AUTHORITY_TIER = "exact-full-bf16"
+
+
+class GpuConformanceFailure(Exception):
+    """A fail-closed private GPU campaign contract violation."""
+
+
+def fail(message: str) -> None:
+    raise GpuConformanceFailure(message)
+
+
+def load_tool() -> Any:
+    spec = importlib.util.spec_from_file_location("minimax_h3_conformance", TOOL_PATH)
+    if spec is None or spec.loader is None:
+        fail("cannot load the pinned MiniMax H3 conformance tool")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def required_environment(environment: Mapping[str, str]) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for name in REQUIRED_ENVIRONMENT:
+        value = environment.get(name, "").strip()
+        if not value:
+            fail(f"{name} is required")
+        values[name] = value
+    if COMMIT_SHA_PATTERN.fullmatch(values["MOLD_H3_SOURCE_SHA"]) is None:
+        fail("MOLD_H3_SOURCE_SHA must be one lowercase 40-character commit SHA")
+    return values
+
+
+def resolve_external_file(label: str, value: str) -> pathlib.Path:
+    path = pathlib.Path(value)
+    if not path.is_absolute():
+        fail(f"{label} path must be absolute")
+    try:
+        resolved = path.resolve(strict=True)
+    except OSError:
+        fail(f"{label} is unavailable")
+    if not resolved.is_file():
+        fail(f"{label} is not a file")
+    try:
+        resolved.relative_to(REPO_ROOT)
+    except ValueError:
+        return resolved
+    fail(f"{label} must live outside the Mold repository")
+
+
+def resolve_bundle_path(
+    fixture_root: pathlib.Path, label: str, value: str
+) -> pathlib.Path:
+    path = pathlib.Path(value)
+    if not path.is_absolute():
+        fail(f"{label} path must be absolute")
+    try:
+        resolved = path.resolve(strict=True)
+    except OSError:
+        fail(f"{label} is unavailable")
+    if not resolved.is_file():
+        fail(f"{label} is not a file")
+    try:
+        resolved.relative_to(fixture_root)
+    except ValueError:
+        fail(f"{label} must be inside MOLD_H3_FIXTURE_ROOT")
+    return resolved
+
+
+def probe_cuda() -> None:
+    try:
+        result = subprocess.run(
+            [
+                "nvidia-smi",
+                "--query-gpu=name",
+                "--format=csv,noheader,nounits",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        fail("CUDA probe failed")
+    if result.returncode != 0 or not result.stdout.strip():
+        fail("CUDA probe failed")
+
+
+def probe_source_sha() -> str:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=REPO_ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        fail("checkout source SHA probe failed")
+    source_sha = result.stdout.strip()
+    if result.returncode != 0 or COMMIT_SHA_PATTERN.fullmatch(source_sha) is None:
+        fail("checkout source SHA probe failed")
+    return source_sha
+
+
+def is_cuda_environment(value: Any) -> bool:
+    return isinstance(value, str) and value.lower().startswith("cuda:")
+
+
+def call_redacted(tool: Any, context: str, action: Callable[[], Any]) -> Any:
+    try:
+        return action()
+    except (tool.ConformanceFailure, OSError, ValueError):
+        fail(f"{context} failed; inspect evidence only on the protected runner")
+
+
+def validate_capture_environment(
+    tool: Any,
+    bundle: dict[str, Any],
+    role: str,
+    source_sha: str,
+) -> None:
+    capture = bundle["capture_environment"]
+    if not is_cuda_environment(capture["device"]):
+        fail(f"{role} bundle does not declare a CUDA capture environment")
+    if role == "oracle":
+        expected_framework = "diffusers"
+        expected_revision = tool.EXPECTED_REVISIONS["diffusers"]
+    else:
+        expected_framework = "mold"
+        expected_revision = source_sha
+    if capture["framework"] != expected_framework:
+        fail(f"{role} bundle framework is not {expected_framework}")
+    if capture["framework_revision"] != expected_revision:
+        fail(f"{role.capitalize()} bundle framework revision is not exact")
+
+
+def load_layer_documents(
+    tool: Any,
+    fixture_root: pathlib.Path,
+    authorization_sha: str,
+    bundle: dict[str, Any],
+    role: str,
+    source_sha: str,
+) -> dict[tuple[str, str], pathlib.Path]:
+    documents: dict[tuple[str, str], pathlib.Path] = {}
+    for position, fixture in enumerate(bundle["fixtures"], start=1):
+        if fixture["authority_tier"] == "synthetic":
+            fail(f"{role} bundle synthetic evidence is forbidden in the GPU campaign")
+        if fixture["authority_tier"] != EXACT_AUTHORITY_TIER:
+            fail(f"{role} bundle evidence must be {EXACT_AUTHORITY_TIER}")
+        try:
+            evidence_path = (fixture_root / fixture["relative_path"]).resolve(
+                strict=True
+            )
+        except OSError:
+            fail(f"{role} evidence {position} is unavailable")
+        try:
+            evidence_path.relative_to(fixture_root)
+        except ValueError:
+            fail(f"{role} evidence escapes MOLD_H3_FIXTURE_ROOT")
+        document = call_redacted(
+            tool,
+            f"{role} layer evidence validation",
+            lambda: tool.validate_layer_output(
+                tool.load_json(evidence_path), f"{role} evidence {position}"
+            ),
+        )
+        producer = document["producer"]
+        if producer["role"] != role:
+            fail(f"{role} bundle contains a different producer role")
+        if role == "oracle":
+            if (
+                producer["source_id"] != "diffusers"
+                or producer["revision"] != tool.EXPECTED_REVISIONS["diffusers"]
+            ):
+                fail("oracle evidence is not from the pinned Diffusers authority")
+        elif producer["source_id"] != "mold" or producer["revision"] != source_sha:
+            fail("Mold evidence is not from the exact requested source SHA")
+        if document["authority_tier"] == "synthetic":
+            fail(f"{role} layer synthetic evidence is forbidden in the GPU campaign")
+        if document["authority_tier"] != EXACT_AUTHORITY_TIER:
+            fail(f"{role} layer evidence must be {EXACT_AUTHORITY_TIER}")
+        if document["authorization_document_sha256"] != authorization_sha:
+            fail(f"{role} layer is not bound to the authorization evidence")
+        if not is_cuda_environment(document["environment"]["device"]):
+            fail(f"{role} layer does not declare a CUDA execution environment")
+        if fixture["layer"] != document["layer"]:
+            fail(f"{role} bundle layer does not match its evidence")
+        if fixture["authority_tier"] != document["authority_tier"]:
+            fail(f"{role} bundle authority tier does not match its evidence")
+        if (
+            fixture["component_index_sha256"]
+            != document["input"]["component_index_sha256"]
+        ):
+            fail(f"{role} bundle component index does not match its evidence")
+        key = (document["case_id"], document["layer"])
+        if key in documents:
+            fail(f"{role} bundle contains duplicate case/layer evidence")
+        documents[key] = evidence_path
+    return documents
+
+
+def run_campaign(
+    environment: Mapping[str, str],
+    gpu_probe: Callable[[], None] = probe_cuda,
+    source_probe: Callable[[], str] = probe_source_sha,
+) -> dict[str, int | str]:
+    values = required_environment(environment)
+    if source_probe() != values["MOLD_H3_SOURCE_SHA"]:
+        fail("checkout source SHA differs from MOLD_H3_SOURCE_SHA")
+    tool = load_tool()
+    manifest = call_redacted(
+        tool, "checked conformance contract", tool.validate_manifest
+    )
+    fixture_root = call_redacted(
+        tool,
+        "external fixture root validation",
+        lambda: tool.canonical_external_directory(
+            "fixture root", values["MOLD_H3_FIXTURE_ROOT"]
+        ),
+    )
+    authorization_path = resolve_external_file(
+        "authorization record", values["MOLD_H3_AUTHORIZATION_RECORD"]
+    )
+    authorization = call_redacted(
+        tool,
+        "authorization validation",
+        lambda: tool.validate_authorization(authorization_path),
+    )
+    oracle_bundle_path = resolve_bundle_path(
+        fixture_root, "oracle bundle", values["MOLD_H3_ORACLE_BUNDLE"]
+    )
+    mold_bundle_path = resolve_bundle_path(
+        fixture_root, "Mold bundle", values["MOLD_H3_MOLD_BUNDLE"]
+    )
+    if oracle_bundle_path == mold_bundle_path:
+        fail("oracle and Mold bundles must be distinct files")
+
+    gpu_probe()
+
+    for label, path in (
+        ("oracle bundle", oracle_bundle_path),
+        ("Mold bundle", mold_bundle_path),
+    ):
+        call_redacted(
+            tool,
+            f"{label} validation",
+            lambda path=path: tool.validate_bundle(
+                manifest,
+                str(fixture_root),
+                str(path),
+                str(authorization_path),
+            ),
+        )
+    oracle_bundle = call_redacted(
+        tool, "oracle bundle reload", lambda: tool.load_json(oracle_bundle_path)
+    )
+    mold_bundle = call_redacted(
+        tool, "Mold bundle reload", lambda: tool.load_json(mold_bundle_path)
+    )
+    source_sha = values["MOLD_H3_SOURCE_SHA"]
+    validate_capture_environment(tool, oracle_bundle, "oracle", source_sha)
+    validate_capture_environment(tool, mold_bundle, "mold", source_sha)
+    authorization_sha = authorization["source_document_sha256"]
+    oracle_documents = load_layer_documents(
+        tool,
+        fixture_root,
+        authorization_sha,
+        oracle_bundle,
+        "oracle",
+        source_sha,
+    )
+    mold_documents = load_layer_documents(
+        tool,
+        fixture_root,
+        authorization_sha,
+        mold_bundle,
+        "mold",
+        source_sha,
+    )
+    if not oracle_documents or set(oracle_documents) != set(mold_documents):
+        fail(
+            "oracle and Mold comparison sets differ "
+            f"(oracle={len(oracle_documents)}, mold={len(mold_documents)})"
+        )
+
+    notes = 0
+    for position, key in enumerate(sorted(oracle_documents), start=1):
+        comparison_notes = call_redacted(
+            tool,
+            f"authorized comparison {position}",
+            lambda key=key: tool.compare_output_files(
+                str(oracle_documents[key]),
+                str(mold_documents[key]),
+                str(fixture_root),
+                str(authorization_path),
+            ),
+        )
+        notes += len(comparison_notes)
+    return {
+        "comparisons": len(oracle_documents),
+        "notes": notes,
+        "source_sha": source_sha,
+    }
+
+
+def main() -> int:
+    try:
+        result = run_campaign(os.environ)
+        print(
+            "MiniMax H3 private GPU conformance passed: "
+            f"comparisons={result['comparisons']} notes={result['notes']} "
+            f"source={result['source_sha']}"
+        )
+        return 0
+    except (GpuConformanceFailure, OSError) as error:
+        print(f"MiniMax H3 private GPU conformance rejected: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run-minimax-h3-gpu-conformance.py
+++ b/scripts/run-minimax-h3-gpu-conformance.py
@@ -11,12 +11,15 @@ from __future__ import annotations
 import hashlib
 import importlib.util
 import json
+import math
 import os
 import pathlib
 import re
+import struct
 import subprocess
 import sys
 from collections.abc import Callable, Mapping
+from fractions import Fraction
 from typing import Any
 
 
@@ -34,8 +37,34 @@ EXACT_AUTHORITY_TIER = "exact-full-bf16"
 CANONICAL_BF16_DTYPE = "bfloat16"
 CANONICAL_INTEGER_DTYPE = "int64"
 CANONICAL_METRIC_DTYPE = "float64"
+CANONICAL_TENSOR_HASH_ENCODING = "canonical-typed-le-v1"
+CANONICAL_E2E_INPUT_SCHEMA = "mold.minimax-h3.e2e-input.v1"
+CANONICAL_E2E_INPUT_KIND = "canonical-e2e-json-sha256-v1"
+IDENTITY_INPUT_KIND = "identity-sha256-v1"
+COMPONENT_AUTHORITY_SET_SCHEMA = "mold.minimax-h3.component-authority-set.v1"
 MAX_EXACT_ABSOLUTE_TOLERANCE = 1.0 / 64.0
 MAX_EXACT_RELATIVE_TOLERANCE = 1.0 / 64.0
+SIGNED_INT64_MIN = -(2**63)
+SIGNED_INT64_MAX = 2**63 - 1
+UNSIGNED_INT64_MAX = 2**64 - 1
+E2E_LAYER_TASKS = {
+    "end-to-end-t2va": "t2va",
+    "end-to-end-fl2va": "fl2va",
+    "end-to-end-ref2va": "ref2va",
+}
+EXPECTED_EXCLUDED_ACCELERATION_ALIASES = {
+    "torch-compile": frozenset({"torch-compile", "torch-inductor", "inductor"}),
+    "fp8": frozenset({"fp8", "float8", "e4m3", "e4m3fn", "e5m2"}),
+    "cache-dit": frozenset({"cache-dit"}),
+    "sageattention": frozenset({"sageattention", "sage-attn"}),
+    "stochastic-sampling": frozenset(
+        {"stochastic-sampling", "stochastic", "ancestral"}
+    ),
+    "approximate-attention": frozenset(
+        {"approximate-attention", "approximate", "approx-attn", "approx"}
+    ),
+    "tf32": frozenset({"tf32", "tensorfloat32"}),
+}
 MEASUREMENT_DTYPES = {
     "tokenizer-processor": {
         "token-ids": CANONICAL_INTEGER_DTYPE,
@@ -114,8 +143,6 @@ MEASUREMENT_DTYPES = {
 PROVENANCE_HASH_KEYS = {
     "tokenizer-hash",
     "processor-hash",
-    "component-index-hash",
-    "component-index-hashes",
 }
 CONTROL_CHARACTER_PATTERN = re.compile(r"[\x00-\x1f\x7f]")
 REVIEWED_AUTHORIZATION_EVIDENCE_SHA256 = (
@@ -227,10 +254,69 @@ def is_cuda_environment(value: Any) -> bool:
     return isinstance(value, str) and value.lower().startswith("cuda:")
 
 
+def normalized_acceleration(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "", value.lower())
+
+
+def names_excluded_acceleration(
+    value: str, excluded_accelerations: frozenset[str]
+) -> bool:
+    normalized = normalized_acceleration(value)
+    return any(
+        normalized_acceleration(alias) in normalized
+        for identifier in excluded_accelerations
+        for alias in EXPECTED_EXCLUDED_ACCELERATION_ALIASES.get(
+            identifier, frozenset({identifier})
+        )
+        if normalized_acceleration(alias)
+    )
+
+
+def reject_excluded_attention_backend(
+    value: Any, excluded_accelerations: frozenset[str], context: str
+) -> None:
+    if not isinstance(value, str):
+        fail(f"{context} attention backend is invalid")
+    if names_excluded_acceleration(value, excluded_accelerations):
+        fail(f"{context} uses a manifest-excluded acceleration")
+
+
+def validate_acceleration_policy(
+    environment: dict[str, Any],
+    excluded_accelerations: frozenset[str],
+    context: str,
+) -> None:
+    policy = environment.get("acceleration_policy")
+    if not isinstance(policy, dict):
+        fail(f"{context} lacks structured acceleration evidence")
+    enabled = policy.get("enabled")
+    disabled = policy.get("disabled")
+    if not isinstance(enabled, list) or not isinstance(disabled, list):
+        fail(f"{context} structured acceleration evidence is invalid")
+    if (
+        any(
+            not isinstance(value, str) or not value or value != value.strip().lower()
+            for value in [*enabled, *disabled]
+        )
+        or len(enabled) != len(set(enabled))
+        or len(disabled) != len(set(disabled))
+    ):
+        fail(f"{context} structured acceleration evidence is not canonical")
+    if frozenset(disabled) != excluded_accelerations:
+        fail(f"{context} does not disable every manifest-excluded acceleration")
+    if any(
+        names_excluded_acceleration(value, excluded_accelerations) for value in enabled
+    ):
+        fail(f"{context} enables a manifest-excluded acceleration")
+    reject_excluded_attention_backend(
+        environment.get("attention_backend"), excluded_accelerations, context
+    )
+
+
 def call_redacted(tool: Any, context: str, action: Callable[[], Any]) -> Any:
     try:
         return action()
-    except (tool.ConformanceFailure, OSError, ValueError):
+    except (tool.ConformanceFailure, OSError, OverflowError, ValueError):
         fail(f"{context} failed; inspect evidence only on the protected runner")
 
 
@@ -252,7 +338,64 @@ def manifest_layer_tiers(manifest: dict[str, Any]) -> dict[str, str]:
     return tiers
 
 
+def manifest_component_authorities(manifest: dict[str, Any]) -> dict[str, str]:
+    authorities = {
+        component["id"]: component["sha256"]
+        for component in manifest["component_indexes"]
+    }
+    if len(authorities) != len(manifest["component_indexes"]):
+        fail("checked manifest contains duplicate component authority identities")
+    return authorities
+
+
+def manifest_excluded_accelerations(manifest: dict[str, Any]) -> frozenset[str]:
+    values = manifest["numerical_authority"]["excluded_accelerations"]
+    excluded = frozenset(value.lower() for value in values)
+    raw_aliases = manifest["numerical_authority"]["excluded_acceleration_aliases"]
+    aliases = {
+        identifier: frozenset(values) for identifier, values in raw_aliases.items()
+    }
+    if (
+        len(excluded) != len(values)
+        or set(raw_aliases) != excluded
+        or any(len(values) != len(set(values)) for values in raw_aliases.values())
+        or aliases != EXPECTED_EXCLUDED_ACCELERATION_ALIASES
+    ):
+        fail("checked manifest contains invalid acceleration exclusions")
+    return excluded
+
+
+def canonical_json_sha256(value: Any) -> str:
+    try:
+        encoded = json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError):
+        fail("canonical JSON evidence is invalid")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def component_authority_set_sha256(
+    component_ids: list[str], component_authorities: dict[str, str]
+) -> str:
+    return canonical_json_sha256(
+        {
+            "schema_version": COMPONENT_AUTHORITY_SET_SCHEMA,
+            "components": [
+                {"id": identifier, "sha256": component_authorities[identifier]}
+                for identifier in sorted(component_ids)
+            ],
+        }
+    )
+
+
 def exact_layer_contracts(manifest: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    component_authorities = manifest_component_authorities(manifest)
+    excluded_accelerations = manifest_excluded_accelerations(manifest)
     contracts: dict[str, dict[str, Any]] = {}
     for layer in manifest["fixture_layers"]:
         if layer["authority_tier"] != EXACT_AUTHORITY_TIER:
@@ -260,7 +403,71 @@ def exact_layer_contracts(manifest: dict[str, Any]) -> dict[str, dict[str, Any]]
         identifier = layer["id"]
         if identifier in contracts:
             fail("checked manifest contains duplicate exact layer identities")
-        contracts[identifier] = layer
+        required_components = layer["required_component_indexes"]
+        if len(required_components) != len(set(required_components)) or not set(
+            required_components
+        ).issubset(component_authorities):
+            fail(f"checked manifest layer {identifier} has invalid component authority")
+        role_invariants = layer["role_invariant_provenance"]
+        if len(role_invariants) != len(set(role_invariants)) or not set(
+            role_invariants
+        ).issubset(layer["required_provenance"]):
+            fail(f"checked manifest layer {identifier} has invalid provenance parity")
+        pinned_provenance = layer["pinned_provenance"]
+        pinned_keys = [record["key"] for record in pinned_provenance]
+        if (
+            len(pinned_keys) != len(set(pinned_keys))
+            or not set(pinned_keys).issubset(layer["required_provenance"])
+            or not set(pinned_keys).issubset(role_invariants)
+            or any(
+                len(record["component_indexes"])
+                != len(set(record["component_indexes"]))
+                or not set(record["component_indexes"]).issubset(required_components)
+                for record in pinned_provenance
+            )
+        ):
+            fail(f"checked manifest layer {identifier} has invalid pinned provenance")
+        expected_task = E2E_LAYER_TASKS.get(identifier)
+        input_contract = layer["input_contract"]
+        if expected_task is None:
+            if input_contract != {"kind": IDENTITY_INPUT_KIND}:
+                fail(f"checked manifest layer {identifier} has invalid input authority")
+        elif input_contract != {
+            "kind": CANONICAL_E2E_INPUT_KIND,
+            "task": expected_task,
+            "algorithm": "minimax-h3-flow-euler-v1",
+            "guidance": "0",
+            "video_shift": "12",
+            "audio_shift": "3",
+            "dimension_multiple": 32,
+            "frame_step": 17,
+            "frame_offset": 5,
+            "min_frames": 124,
+            "max_frames": 362,
+            "max_pixels": 1_069_056,
+            "min_aspect_ratio": "0.25",
+            "max_aspect_ratio": "4",
+            "fps": 24,
+            "video_scheduler_component": "official-video-scheduler-config",
+            "audio_scheduler_component": "official-audio-scheduler-config",
+        } or not {
+            input_contract["video_scheduler_component"],
+            input_contract["audio_scheduler_component"],
+        }.issubset(required_components):
+            fail(f"checked manifest layer {identifier} has invalid input authority")
+        contract = dict(layer)
+        contract["_required_component_authorities"] = [
+            {"id": component_id, "sha256": component_authorities[component_id]}
+            for component_id in required_components
+        ]
+        contract["_pinned_provenance_values"] = {
+            record["key"]: component_authority_set_sha256(
+                record["component_indexes"], component_authorities
+            )
+            for record in pinned_provenance
+        }
+        contract["_excluded_accelerations"] = excluded_accelerations
+        contracts[identifier] = contract
 
     if set(contracts) != set(MEASUREMENT_DTYPES):
         fail("protected measurement policy does not cover the exact manifest layers")
@@ -306,12 +513,14 @@ def validate_capture_environment(
     bundle: dict[str, Any],
     role: str,
     source_sha: str,
+    excluded_accelerations: frozenset[str],
 ) -> None:
     capture = bundle["capture_environment"]
     if not is_cuda_environment(capture["device"]):
         fail(f"{role} bundle does not declare a CUDA capture environment")
     if capture["dtype"] != CANONICAL_BF16_DTYPE:
         fail(f"{role} bundle capture environment dtype must be {CANONICAL_BF16_DTYPE}")
+    validate_acceleration_policy(capture, excluded_accelerations, f"{role} bundle")
     if role == "oracle":
         expected_framework = "diffusers"
         expected_revision = tool.EXPECTED_REVISIONS["diffusers"]
@@ -361,11 +570,40 @@ def keyed_evidence_records(
     return keyed
 
 
+def keyed_component_records(records: Any, label: str) -> dict[str, str]:
+    if not isinstance(records, list) or not records:
+        fail(f"{label} must be a non-empty component authority list")
+    keyed: dict[str, str] = {}
+    for record in records:
+        if (
+            not isinstance(record, dict)
+            or not isinstance(record.get("id"), str)
+            or not isinstance(record.get("sha256"), str)
+        ):
+            fail(f"{label} contains an invalid component authority")
+        identifier = record["id"]
+        if identifier in keyed:
+            fail(f"{label} contains duplicate component id {identifier!r}")
+        keyed[identifier] = record["sha256"]
+    return keyed
+
+
 def structured_provenance_value(document: dict[str, Any], key: str) -> str | None:
     if key == "source-revision":
         return document["producer"]["revision"]
-    if key in {"component-index-hash", "component-index-hashes"}:
-        return document["input"]["component_index_sha256"]
+    if key == "component-index-hash":
+        components = document["input"]["component_indexes"]
+        if len(components) != 1:
+            fail("singular component provenance requires one component authority")
+        return components[0]["sha256"]
+    if key == "component-index-hashes":
+        components = sorted(
+            document["input"]["component_indexes"],
+            key=lambda component: component["id"],
+        )
+        return ",".join(
+            f"{component['id']}={component['sha256']}" for component in components
+        )
     if key in {"device", "generator-device"}:
         return document["environment"]["device"]
     if key == "dtype":
@@ -381,14 +619,194 @@ def is_json_integer(value: Any) -> bool:
     return isinstance(value, int) and not isinstance(value, bool)
 
 
+def is_signed_int64(value: Any) -> bool:
+    return is_json_integer(value) and SIGNED_INT64_MIN <= value <= SIGNED_INT64_MAX
+
+
+def is_unsigned_int64(value: Any) -> bool:
+    return is_json_integer(value) and 0 <= value <= UNSIGNED_INT64_MAX
+
+
+def is_finite_float64(value: Any) -> bool:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return False
+    try:
+        converted = float(value)
+    except (OverflowError, ValueError):
+        return False
+    return math.isfinite(converted) and (
+        not is_json_integer(value) or int(converted) == value
+    )
+
+
+def is_exact_bfloat16(value: Any) -> bool:
+    if not is_finite_float64(value):
+        return False
+    converted = float(value)
+    try:
+        float32_bits = struct.unpack(">I", struct.pack(">f", converted))[0]
+    except (OverflowError, struct.error):
+        return False
+    rounding_bias = 0x7FFF + ((float32_bits >> 16) & 1)
+    bfloat16_bits = (float32_bits + rounding_bias) >> 16
+    if bfloat16_bits & 0x7F80 == 0x7F80:
+        return False
+    reconstructed = struct.unpack(">f", struct.pack(">I", bfloat16_bits << 16))[0]
+    return reconstructed == converted
+
+
+def validate_output_numeric_domain(
+    output: dict[str, Any], expected_dtype: str, context: str
+) -> None:
+    statistics = output["statistics"]
+    samples = output["samples"]
+    if not all(is_finite_float64(statistics[key]) for key in ("mean", "std")):
+        fail(f"{context} summary is outside the finite float64 domain")
+    if expected_dtype == CANONICAL_INTEGER_DTYPE:
+        if (
+            not is_signed_int64(statistics["min"])
+            or not is_signed_int64(statistics["max"])
+            or any(not is_signed_int64(sample["value"]) for sample in samples)
+        ):
+            fail(f"{context} integer min/max and samples must be signed int64")
+        return
+    if expected_dtype == CANONICAL_BF16_DTYPE:
+        if (
+            not is_exact_bfloat16(statistics["min"])
+            or not is_exact_bfloat16(statistics["max"])
+            or any(not is_exact_bfloat16(sample["value"]) for sample in samples)
+        ):
+            fail(f"{context} activation min/max and samples must be exact bfloat16")
+        return
+    if expected_dtype == CANONICAL_METRIC_DTYPE and (
+        not is_finite_float64(statistics["min"])
+        or not is_finite_float64(statistics["max"])
+        or any(not is_finite_float64(sample["value"]) for sample in samples)
+    ):
+        fail(f"{context} metric min/max and samples must be finite float64")
+
+
+def validate_e2e_input_contract(
+    document: dict[str, Any], manifest_layer: dict[str, Any], role: str
+) -> None:
+    layer = manifest_layer["id"]
+    input_contract = manifest_layer["input_contract"]
+    conformance = document["input"].get("conformance")
+    if input_contract["kind"] == IDENTITY_INPUT_KIND:
+        if conformance is not None:
+            fail(f"{role} layer {layer} has unexpected end-to-end input evidence")
+        return
+    if input_contract["kind"] != CANONICAL_E2E_INPUT_KIND:
+        fail(f"protected manifest layer {layer} has an unsupported input contract")
+    if not isinstance(conformance, dict):
+        fail(f"{role} layer {layer} lacks canonical end-to-end input evidence")
+    if (
+        conformance.get("schema_version") != CANONICAL_E2E_INPUT_SCHEMA
+        or conformance.get("task") != input_contract["task"]
+    ):
+        fail(f"{role} layer {layer} end-to-end input task is invalid")
+    if not is_unsigned_int64(conformance.get("seed")):
+        fail(f"{role} layer {layer} end-to-end input seed must be unsigned int64")
+    for key in ("width", "height", "frames", "fps"):
+        if not is_signed_int64(conformance.get(key)) or conformance[key] <= 0:
+            fail(
+                f"{role} layer {layer} end-to-end input {key} "
+                "must be a positive signed int64"
+            )
+    width = conformance["width"]
+    height = conformance["height"]
+    frames = conformance["frames"]
+    aspect_ratio = Fraction(width, height)
+    if (
+        width % input_contract["dimension_multiple"] != 0
+        or height % input_contract["dimension_multiple"] != 0
+        or width * height > input_contract["max_pixels"]
+        or aspect_ratio < Fraction(input_contract["min_aspect_ratio"])
+        or aspect_ratio > Fraction(input_contract["max_aspect_ratio"])
+    ):
+        fail(f"{role} layer {layer} end-to-end dimensions violate the H3 contract")
+    if (
+        frames < input_contract["min_frames"]
+        or frames > input_contract["max_frames"]
+        or (frames - input_contract["frame_offset"]) % input_contract["frame_step"] != 0
+        or conformance["fps"] != input_contract["fps"]
+    ):
+        fail(f"{role} layer {layer} end-to-end frame contract is invalid")
+    video_sampler = conformance["video_sampler"]
+    audio_sampler = conformance["audio_sampler"]
+    if (
+        not is_signed_int64(video_sampler.get("steps"))
+        or video_sampler["steps"] < 2
+        or audio_sampler.get("steps") != video_sampler["steps"]
+        or video_sampler.get("algorithm") != input_contract["algorithm"]
+        or audio_sampler.get("algorithm") != input_contract["algorithm"]
+        or video_sampler.get("guidance") != input_contract["guidance"]
+        or audio_sampler.get("guidance") != input_contract["guidance"]
+        or video_sampler.get("shift") != input_contract["video_shift"]
+        or audio_sampler.get("shift") != input_contract["audio_shift"]
+    ):
+        fail(f"{role} layer {layer} end-to-end sampler contract is invalid")
+    if conformance["negative_prompt_sha256"] != hashlib.sha256(b"").hexdigest():
+        fail(f"{role} layer {layer} end-to-end negative prompt must be absent")
+    conditioning_roles = [item["role"] for item in conformance["conditioning"]]
+    task = conformance["task"]
+    if task == "t2va" and conditioning_roles:
+        fail(f"{role} layer {layer} T2VA input must not carry conditioning media")
+    if task == "fl2va" and conditioning_roles not in (
+        ["first-frame"],
+        ["last-frame"],
+        ["first-frame", "last-frame"],
+    ):
+        fail(f"{role} layer {layer} FL2VA conditioning order is invalid")
+    if task == "ref2va" and (
+        not conditioning_roles
+        or any(not value.startswith("reference-") for value in conditioning_roles)
+    ):
+        fail(f"{role} layer {layer} Ref2VA conditioning order is invalid")
+    if document["input"]["sha256"] != canonical_json_sha256(conformance):
+        fail(f"{role} layer {layer} input hash does not match canonical evidence")
+
+
 def validate_manifest_layer_evidence(
     document: dict[str, Any],
     manifest_layer: dict[str, Any],
     role: str,
+    excluded_accelerations: frozenset[str] | None = None,
 ) -> None:
     layer = manifest_layer["id"]
+    if excluded_accelerations is None:
+        protected_exclusions = manifest_layer.get("_excluded_accelerations")
+        if not isinstance(protected_exclusions, frozenset):
+            fail(f"protected manifest layer {layer} lacks acceleration authority")
+        excluded_accelerations = protected_exclusions
     if document.get("layer") != layer:
         fail(f"{role} evidence does not match manifest layer {layer}")
+    if document["adapter"]["tensor_hash_encoding"] != CANONICAL_TENSOR_HASH_ENCODING:
+        fail(f"{role} layer {layer} tensor hash encoding is not canonical")
+
+    required_components = manifest_layer.get("_required_component_authorities")
+    if not isinstance(required_components, list) or not required_components:
+        fail(f"protected manifest layer {layer} lacks component authority")
+    actual_components = document.get("input", {}).get("component_indexes")
+    expected_component_map = {
+        component["id"]: component["sha256"] for component in required_components
+    }
+    actual_component_map = keyed_component_records(
+        actual_components, f"{role} layer {layer} component authorities"
+    )
+    if actual_component_map != expected_component_map:
+        fail(f"{role} layer {layer} component authorities differ from the manifest")
+    if document["input"]["component_index_sha256"] != required_components[0]["sha256"]:
+        fail(
+            f"{role} layer {layer} component authority summary differs from the manifest"
+        )
+
+    validate_acceleration_policy(
+        document["environment"],
+        excluded_accelerations,
+        f"{role} layer {layer}",
+    )
+    validate_e2e_input_contract(document, manifest_layer, role)
 
     provenance = keyed_evidence_records(
         document.get("provenance"), f"{role} layer {layer} provenance"
@@ -412,6 +830,9 @@ def validate_manifest_layer_evidence(
             fail(f"{role} layer {layer} provenance {key!r} is not canonical")
         if key == "seed" and re.fullmatch(r"0|[1-9][0-9]*", value) is None:
             fail(f"{role} layer {layer} provenance {key!r} is not canonical")
+        pinned_value = manifest_layer["_pinned_provenance_values"].get(key)
+        if pinned_value is not None and value != pinned_value:
+            fail(f"{role} layer {layer} provenance {key!r} is not authority-pinned")
         structured = structured_provenance_value(document, key)
         if structured is not None and value != structured:
             fail(
@@ -447,18 +868,11 @@ def validate_manifest_layer_evidence(
         expected_dtype = expected_dtypes[key]
         if output.get("dtype") != expected_dtype:
             fail(f"{role} layer {layer} output {key!r} dtype must be {expected_dtype}")
-        if expected_dtype == CANONICAL_INTEGER_DTYPE:
-            statistics = output.get("statistics", {})
-            samples = output.get("samples", [])
-            if (
-                not is_json_integer(statistics.get("min"))
-                or not is_json_integer(statistics.get("max"))
-                or any(not is_json_integer(sample.get("value")) for sample in samples)
-            ):
-                fail(
-                    f"{role} layer {layer} output {key!r} integer evidence "
-                    "must use integer min/max and samples"
-                )
+        validate_output_numeric_domain(
+            output,
+            expected_dtype,
+            f"{role} layer {layer} output {key!r}",
+        )
         if role != "oracle":
             continue
         policy = policies[key]
@@ -475,13 +889,13 @@ def validate_manifest_layer_evidence(
                     "must use zero tolerances and exact hashes"
                 )
         elif (
-            not isinstance(policy.get("absolute"), (int, float))
-            or not isinstance(policy.get("relative"), (int, float))
+            not is_finite_float64(policy.get("absolute"))
+            or not is_finite_float64(policy.get("relative"))
             or policy["absolute"] > MAX_EXACT_ABSOLUTE_TOLERANCE
             or policy["relative"] > MAX_EXACT_RELATIVE_TOLERANCE
             or policy["absolute"] < 0
             or policy["relative"] < 0
-            or policy.get("hash_policy") != "record-only"
+            or policy.get("hash_policy") != "exact"
         ):
             fail(
                 f"oracle layer {layer} output {key!r} floating policy "
@@ -494,8 +908,11 @@ def validate_exact_outputs(
     fixture: dict[str, Any],
     manifest_layer: dict[str, Any],
     role: str,
+    excluded_accelerations: frozenset[str],
 ) -> None:
-    validate_manifest_layer_evidence(document, manifest_layer, role)
+    validate_manifest_layer_evidence(
+        document, manifest_layer, role, excluded_accelerations
+    )
 
     first_output = document["outputs"][0]
     if fixture["tensor"] != expected_tensor_summary(first_output):
@@ -518,6 +935,7 @@ def load_layer_documents(
     source_sha: str,
     layer_tiers: dict[str, str],
     layer_contracts: dict[str, dict[str, Any]],
+    excluded_accelerations: frozenset[str],
 ) -> dict[tuple[str, str], tuple[dict[str, Any], dict[str, Any]]]:
     documents: dict[tuple[str, str], tuple[dict[str, Any], dict[str, Any]]] = {}
     for position, fixture in enumerate(bundle["fixtures"], start=1):
@@ -576,6 +994,10 @@ def load_layer_documents(
             fail(f"{role} layer does not declare a CUDA execution environment")
         if document["environment"]["dtype"] != CANONICAL_BF16_DTYPE:
             fail(f"{role} layer environment dtype must be {CANONICAL_BF16_DTYPE}")
+        if document["environment"].get("acceleration_policy") != bundle[
+            "capture_environment"
+        ].get("acceleration_policy"):
+            fail(f"{role} layer acceleration policy differs from its bundle")
         if fixture["layer"] != document["layer"]:
             fail(f"{role} bundle layer does not match its evidence")
         if fixture["authority_tier"] != document["authority_tier"]:
@@ -588,7 +1010,18 @@ def load_layer_documents(
         manifest_layer = layer_contracts.get(document["layer"])
         if manifest_layer is None:
             fail(f"{role} layer lacks a protected manifest contract")
-        validate_exact_outputs(document, fixture, manifest_layer, role)
+        fixture_components = keyed_component_records(
+            fixture.get("component_indexes"), f"{role} bundle component authorities"
+        )
+        document_components = keyed_component_records(
+            document["input"].get("component_indexes"),
+            f"{role} layer component authorities",
+        )
+        if fixture_components != document_components:
+            fail(f"{role} bundle component authorities do not match its evidence")
+        validate_exact_outputs(
+            document, fixture, manifest_layer, role, excluded_accelerations
+        )
         key = (document["case_id"], document["layer"])
         if key in documents:
             fail(f"{role} bundle contains duplicate case/layer evidence")
@@ -619,6 +1052,7 @@ def validate_oracle_mold_policy_parity(
     oracle_fixture: dict[str, Any],
     mold_document: dict[str, Any],
     mold_fixture: dict[str, Any],
+    manifest_layer: dict[str, Any],
 ) -> None:
     oracle_outputs = keyed_evidence_records(
         oracle_document["outputs"], "oracle paired outputs"
@@ -631,6 +1065,19 @@ def validate_oracle_mold_policy_parity(
     for key in oracle_outputs:
         if oracle_outputs[key]["dtype"] != mold_outputs[key]["dtype"]:
             fail(f"oracle and Mold output {key!r} dtypes differ")
+        if oracle_outputs[key]["content_sha256"] != mold_outputs[key]["content_sha256"]:
+            fail(f"oracle and Mold output {key!r} content hashes differ")
+    oracle_provenance = keyed_evidence_records(
+        oracle_document["provenance"], "oracle paired provenance"
+    )
+    mold_provenance = keyed_evidence_records(
+        mold_document["provenance"], "Mold paired provenance"
+    )
+    if oracle_document["input"]["sha256"] != mold_document["input"]["sha256"]:
+        fail("oracle and Mold input hashes differ")
+    for key in manifest_layer["role_invariant_provenance"]:
+        if oracle_provenance[key]["value"] != mold_provenance[key]["value"]:
+            fail(f"oracle and Mold provenance {key!r} differs")
     if mold_fixture["tolerance"] != oracle_fixture["tolerance"]:
         fail("Mold bundle tolerance summary differs from oracle policy")
 
@@ -649,6 +1096,7 @@ def run_campaign(
     )
     layer_tiers = manifest_layer_tiers(manifest)
     layer_contracts = exact_layer_contracts(manifest)
+    excluded_accelerations = manifest_excluded_accelerations(manifest)
     fixture_root = call_redacted(
         tool,
         "external fixture root validation",
@@ -691,8 +1139,12 @@ def run_campaign(
         "Mold bundle",
     )
     source_sha = values["MOLD_H3_SOURCE_SHA"]
-    validate_capture_environment(tool, oracle_bundle, "oracle", source_sha)
-    validate_capture_environment(tool, mold_bundle, "mold", source_sha)
+    validate_capture_environment(
+        tool, oracle_bundle, "oracle", source_sha, excluded_accelerations
+    )
+    validate_capture_environment(
+        tool, mold_bundle, "mold", source_sha, excluded_accelerations
+    )
     oracle_documents = load_layer_documents(
         tool,
         fixture_root,
@@ -702,6 +1154,7 @@ def run_campaign(
         source_sha,
         layer_tiers,
         layer_contracts,
+        excluded_accelerations,
     )
     mold_documents = load_layer_documents(
         tool,
@@ -712,6 +1165,7 @@ def run_campaign(
         source_sha,
         layer_tiers,
         layer_contracts,
+        excluded_accelerations,
     )
     require_complete_exact_coverage(oracle_documents, layer_tiers, "oracle")
     require_complete_exact_coverage(mold_documents, layer_tiers, "mold")
@@ -730,6 +1184,7 @@ def run_campaign(
             oracle_fixture,
             mold_document,
             mold_fixture,
+            layer_contracts[key[1]],
         )
         comparison_notes = call_redacted(
             tool,

--- a/scripts/run-minimax-h3-gpu-conformance.py
+++ b/scripts/run-minimax-h3-gpu-conformance.py
@@ -8,7 +8,9 @@ product remains fail-closed and no evidence is copied into the checkout or CI.
 
 from __future__ import annotations
 
+import hashlib
 import importlib.util
+import json
 import os
 import pathlib
 import re
@@ -29,6 +31,12 @@ REQUIRED_ENVIRONMENT = (
 )
 COMMIT_SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
 EXACT_AUTHORITY_TIER = "exact-full-bf16"
+CANONICAL_BF16_DTYPE = "bfloat16"
+MAX_EXACT_ABSOLUTE_TOLERANCE = 1.0 / 64.0
+MAX_EXACT_RELATIVE_TOLERANCE = 1.0 / 64.0
+REVIEWED_AUTHORIZATION_EVIDENCE_SHA256 = (
+    "8cd4d6e52cff34d7d39721ebab13b8c1187aa87aafc1c4ae2a16609186f22f1d"
+)
 
 
 class GpuConformanceFailure(Exception):
@@ -142,6 +150,47 @@ def call_redacted(tool: Any, context: str, action: Callable[[], Any]) -> Any:
         fail(f"{context} failed; inspect evidence only on the protected runner")
 
 
+def read_json_once(path: pathlib.Path, label: str) -> tuple[bytes, Any]:
+    try:
+        encoded = path.read_bytes()
+        value = json.loads(encoded)
+    except (OSError, ValueError):
+        fail(f"{label} is unavailable or invalid")
+    return encoded, value
+
+
+def manifest_layer_tiers(manifest: dict[str, Any]) -> dict[str, str]:
+    tiers = {
+        layer["id"]: layer["authority_tier"] for layer in manifest["fixture_layers"]
+    }
+    if len(tiers) != len(manifest["fixture_layers"]):
+        fail("checked manifest contains duplicate layer identities")
+    return tiers
+
+
+def load_bundle_once(
+    tool: Any,
+    path: pathlib.Path,
+    authorization_sha: str,
+    label: str,
+) -> dict[str, Any]:
+    _, bundle = read_json_once(path, label)
+    call_redacted(
+        tool,
+        f"{label} schema validation",
+        lambda: tool.validate_schema(bundle, tool.BUNDLE_SCHEMA_PATH),
+    )
+    if bundle["schema_version"] != tool.BUNDLE_SCHEMA_VERSION:
+        fail(f"{label} schema version is unsupported")
+    if bundle["manifest_sha256"] != tool.sha256_file(tool.MANIFEST_PATH):
+        fail(f"{label} targets a different conformance manifest")
+    if bundle["authorization_document_sha256"] != authorization_sha:
+        fail(f"{label} is not bound to the reviewed authorization evidence")
+    if not bundle["fixtures"]:
+        fail(f"{label} contains no evidence")
+    return bundle
+
+
 def validate_capture_environment(
     tool: Any,
     bundle: dict[str, Any],
@@ -151,6 +200,8 @@ def validate_capture_environment(
     capture = bundle["capture_environment"]
     if not is_cuda_environment(capture["device"]):
         fail(f"{role} bundle does not declare a CUDA capture environment")
+    if capture["dtype"] != CANONICAL_BF16_DTYPE:
+        fail(f"{role} bundle capture environment dtype must be {CANONICAL_BF16_DTYPE}")
     if role == "oracle":
         expected_framework = "diffusers"
         expected_revision = tool.EXPECTED_REVISIONS["diffusers"]
@@ -163,6 +214,54 @@ def validate_capture_environment(
         fail(f"{role.capitalize()} bundle framework revision is not exact")
 
 
+def expected_tensor_summary(output: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "shape": output["shape"],
+        "dtype": output["dtype"],
+        "min": output["statistics"]["min"],
+        "max": output["statistics"]["max"],
+        "mean": output["statistics"]["mean"],
+        "std": output["statistics"]["std"],
+        "sampled_values": [sample["value"] for sample in output["samples"]],
+    }
+
+
+def expected_tolerance_summary(policy: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "absolute": policy["absolute"],
+        "relative": policy["relative"],
+        "metric": policy["metric"],
+    }
+
+
+def validate_exact_outputs(
+    document: dict[str, Any],
+    fixture: dict[str, Any],
+    role: str,
+) -> None:
+    outputs = {output["key"]: output for output in document["outputs"]}
+    for output in outputs.values():
+        if output["dtype"] != CANONICAL_BF16_DTYPE:
+            fail(f"{role} layer output dtype must be {CANONICAL_BF16_DTYPE}")
+
+    first_output = document["outputs"][0]
+    if fixture["tensor"] != expected_tensor_summary(first_output):
+        fail(f"{role} bundle tensor summary does not match layer evidence")
+
+    if role != "oracle":
+        return
+    policies = {policy["key"]: policy for policy in document["comparison"]}
+    for policy in policies.values():
+        if (
+            policy["absolute"] > MAX_EXACT_ABSOLUTE_TOLERANCE
+            or policy["relative"] > MAX_EXACT_RELATIVE_TOLERANCE
+        ):
+            fail(f"{role} comparison policy is not bounded for exact BF16 evidence")
+    first_policy = policies[first_output["key"]]
+    if fixture["tolerance"] != expected_tolerance_summary(first_policy):
+        fail(f"{role} bundle tolerance summary does not match oracle policy")
+
+
 def load_layer_documents(
     tool: Any,
     fixture_root: pathlib.Path,
@@ -170,13 +269,18 @@ def load_layer_documents(
     bundle: dict[str, Any],
     role: str,
     source_sha: str,
-) -> dict[tuple[str, str], pathlib.Path]:
-    documents: dict[tuple[str, str], pathlib.Path] = {}
+    layer_tiers: dict[str, str],
+) -> dict[tuple[str, str], tuple[dict[str, Any], dict[str, Any]]]:
+    documents: dict[tuple[str, str], tuple[dict[str, Any], dict[str, Any]]] = {}
     for position, fixture in enumerate(bundle["fixtures"], start=1):
-        if fixture["authority_tier"] == "synthetic":
-            fail(f"{role} bundle synthetic evidence is forbidden in the GPU campaign")
-        if fixture["authority_tier"] != EXACT_AUTHORITY_TIER:
-            fail(f"{role} bundle evidence must be {EXACT_AUTHORITY_TIER}")
+        manifest_tier = layer_tiers.get(fixture["layer"])
+        if manifest_tier != EXACT_AUTHORITY_TIER:
+            fail(
+                f"{role} bundle layer {fixture['layer']} has manifest authority tier "
+                f"{manifest_tier!r}, not {EXACT_AUTHORITY_TIER}"
+            )
+        if fixture["authority_tier"] != manifest_tier:
+            fail(f"{role} bundle authority tier drifts from the manifest")
         try:
             evidence_path = (fixture_root / fixture["relative_path"]).resolve(
                 strict=True
@@ -187,11 +291,16 @@ def load_layer_documents(
             evidence_path.relative_to(fixture_root)
         except ValueError:
             fail(f"{role} evidence escapes MOLD_H3_FIXTURE_ROOT")
+        encoded, raw_document = read_json_once(
+            evidence_path, f"{role} evidence {position}"
+        )
+        if hashlib.sha256(encoded).hexdigest() != fixture["sha256"]:
+            fail(f"{role} evidence {position} hash does not match its bundle")
         document = call_redacted(
             tool,
             f"{role} layer evidence validation",
             lambda: tool.validate_layer_output(
-                tool.load_json(evidence_path), f"{role} evidence {position}"
+                raw_document, f"{role} evidence {position}"
             ),
         )
         producer = document["producer"]
@@ -205,14 +314,20 @@ def load_layer_documents(
                 fail("oracle evidence is not from the pinned Diffusers authority")
         elif producer["source_id"] != "mold" or producer["revision"] != source_sha:
             fail("Mold evidence is not from the exact requested source SHA")
-        if document["authority_tier"] == "synthetic":
-            fail(f"{role} layer synthetic evidence is forbidden in the GPU campaign")
-        if document["authority_tier"] != EXACT_AUTHORITY_TIER:
-            fail(f"{role} layer evidence must be {EXACT_AUTHORITY_TIER}")
+        document_manifest_tier = layer_tiers.get(document["layer"])
+        if document_manifest_tier != EXACT_AUTHORITY_TIER:
+            fail(
+                f"{role} layer {document['layer']} has manifest authority tier "
+                f"{document_manifest_tier!r}, not {EXACT_AUTHORITY_TIER}"
+            )
+        if document["authority_tier"] != document_manifest_tier:
+            fail(f"{role} layer authority tier drifts from the manifest")
         if document["authorization_document_sha256"] != authorization_sha:
             fail(f"{role} layer is not bound to the authorization evidence")
         if not is_cuda_environment(document["environment"]["device"]):
             fail(f"{role} layer does not declare a CUDA execution environment")
+        if document["environment"]["dtype"] != CANONICAL_BF16_DTYPE:
+            fail(f"{role} layer environment dtype must be {CANONICAL_BF16_DTYPE}")
         if fixture["layer"] != document["layer"]:
             fail(f"{role} bundle layer does not match its evidence")
         if fixture["authority_tier"] != document["authority_tier"]:
@@ -222,11 +337,30 @@ def load_layer_documents(
             != document["input"]["component_index_sha256"]
         ):
             fail(f"{role} bundle component index does not match its evidence")
+        validate_exact_outputs(document, fixture, role)
         key = (document["case_id"], document["layer"])
         if key in documents:
             fail(f"{role} bundle contains duplicate case/layer evidence")
-        documents[key] = evidence_path
+        documents[key] = (document, fixture)
     return documents
+
+
+def require_complete_exact_coverage(
+    documents: dict[tuple[str, str], tuple[dict[str, Any], dict[str, Any]]],
+    layer_tiers: dict[str, str],
+    role: str,
+) -> None:
+    required = {
+        layer
+        for layer, authority_tier in layer_tiers.items()
+        if authority_tier == EXACT_AUTHORITY_TIER
+    }
+    observed = {layer for _, layer in documents}
+    if observed != required:
+        fail(
+            f"{role} bundle lacks complete exact layer coverage "
+            f"(required={len(required)}, observed={len(observed)})"
+        )
 
 
 def run_campaign(
@@ -256,6 +390,9 @@ def run_campaign(
         "authorization validation",
         lambda: tool.validate_authorization(authorization_path),
     )
+    authorization_sha = authorization["source_document_sha256"]
+    if authorization_sha != REVIEWED_AUTHORIZATION_EVIDENCE_SHA256:
+        fail("authorization record does not bind the reviewed authorization evidence")
     oracle_bundle_path = resolve_bundle_path(
         fixture_root, "oracle bundle", values["MOLD_H3_ORACLE_BUNDLE"]
     )
@@ -267,30 +404,22 @@ def run_campaign(
 
     gpu_probe()
 
-    for label, path in (
-        ("oracle bundle", oracle_bundle_path),
-        ("Mold bundle", mold_bundle_path),
-    ):
-        call_redacted(
-            tool,
-            f"{label} validation",
-            lambda path=path: tool.validate_bundle(
-                manifest,
-                str(fixture_root),
-                str(path),
-                str(authorization_path),
-            ),
-        )
-    oracle_bundle = call_redacted(
-        tool, "oracle bundle reload", lambda: tool.load_json(oracle_bundle_path)
+    oracle_bundle = load_bundle_once(
+        tool,
+        oracle_bundle_path,
+        authorization_sha,
+        "oracle bundle",
     )
-    mold_bundle = call_redacted(
-        tool, "Mold bundle reload", lambda: tool.load_json(mold_bundle_path)
+    mold_bundle = load_bundle_once(
+        tool,
+        mold_bundle_path,
+        authorization_sha,
+        "Mold bundle",
     )
     source_sha = values["MOLD_H3_SOURCE_SHA"]
     validate_capture_environment(tool, oracle_bundle, "oracle", source_sha)
     validate_capture_environment(tool, mold_bundle, "mold", source_sha)
-    authorization_sha = authorization["source_document_sha256"]
+    layer_tiers = manifest_layer_tiers(manifest)
     oracle_documents = load_layer_documents(
         tool,
         fixture_root,
@@ -298,6 +427,7 @@ def run_campaign(
         oracle_bundle,
         "oracle",
         source_sha,
+        layer_tiers,
     )
     mold_documents = load_layer_documents(
         tool,
@@ -306,7 +436,10 @@ def run_campaign(
         mold_bundle,
         "mold",
         source_sha,
+        layer_tiers,
     )
+    require_complete_exact_coverage(oracle_documents, layer_tiers, "oracle")
+    require_complete_exact_coverage(mold_documents, layer_tiers, "mold")
     if not oracle_documents or set(oracle_documents) != set(mold_documents):
         fail(
             "oracle and Mold comparison sets differ "
@@ -315,14 +448,15 @@ def run_campaign(
 
     notes = 0
     for position, key in enumerate(sorted(oracle_documents), start=1):
+        oracle_document, oracle_fixture = oracle_documents[key]
+        mold_document, mold_fixture = mold_documents[key]
+        if mold_fixture["tolerance"] != oracle_fixture["tolerance"]:
+            fail("Mold bundle tolerance summary differs from oracle policy")
         comparison_notes = call_redacted(
             tool,
             f"authorized comparison {position}",
-            lambda key=key: tool.compare_output_files(
-                str(oracle_documents[key]),
-                str(mold_documents[key]),
-                str(fixture_root),
-                str(authorization_path),
+            lambda oracle_document=oracle_document, mold_document=mold_document: (
+                tool.compare_layer_outputs(oracle_document, mold_document)
             ),
         )
         notes += len(comparison_notes)

--- a/scripts/run-minimax-h3-gpu-conformance.py
+++ b/scripts/run-minimax-h3-gpu-conformance.py
@@ -32,8 +32,92 @@ REQUIRED_ENVIRONMENT = (
 COMMIT_SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
 EXACT_AUTHORITY_TIER = "exact-full-bf16"
 CANONICAL_BF16_DTYPE = "bfloat16"
+CANONICAL_INTEGER_DTYPE = "int64"
+CANONICAL_METRIC_DTYPE = "float64"
 MAX_EXACT_ABSOLUTE_TOLERANCE = 1.0 / 64.0
 MAX_EXACT_RELATIVE_TOLERANCE = 1.0 / 64.0
+MEASUREMENT_DTYPES = {
+    "tokenizer-processor": {
+        "token-ids": CANONICAL_INTEGER_DTYPE,
+        "special-token-presentation": CANONICAL_INTEGER_DTYPE,
+        "processor-shapes": CANONICAL_INTEGER_DTYPE,
+        "sampled-values": CANONICAL_BF16_DTYPE,
+    },
+    "qwen-layer-50": {
+        "shape": CANONICAL_INTEGER_DTYPE,
+        "dtype": CANONICAL_INTEGER_DTYPE,
+        "statistics": CANONICAL_METRIC_DTYPE,
+        "sampled-values": CANONICAL_BF16_DTYPE,
+        "tolerance": CANONICAL_METRIC_DTYPE,
+    },
+    "visual-vae": {
+        "pixel-normalization": CANONICAL_BF16_DTYPE,
+        "posterior-seed-42": CANONICAL_BF16_DTYPE,
+        "latent-statistics": CANONICAL_METRIC_DTYPE,
+        "sampled-values": CANONICAL_BF16_DTYPE,
+        "tile-seams": CANONICAL_METRIC_DTYPE,
+    },
+    "audio-vae": {
+        "stereo-packing": CANONICAL_INTEGER_DTYPE,
+        "latent-rate": CANONICAL_METRIC_DTYPE,
+        "waveform-statistics": CANONICAL_METRIC_DTYPE,
+        "phase-polarity": CANONICAL_INTEGER_DTYPE,
+        "sampled-values": CANONICAL_BF16_DTYPE,
+    },
+    "token-refiner": {
+        "shape": CANONICAL_INTEGER_DTYPE,
+        "statistics": CANONICAL_METRIC_DTYPE,
+        "sampled-values": CANONICAL_BF16_DTYPE,
+        "tolerance": CANONICAL_METRIC_DTYPE,
+    },
+    "transformer-block": {
+        "qk-rms": CANONICAL_METRIC_DTYPE,
+        "partial-mm-rope": CANONICAL_BF16_DTYPE,
+        "adaln": CANONICAL_BF16_DTYPE,
+        "video-head": CANONICAL_BF16_DTYPE,
+        "audio-head": CANONICAL_BF16_DTYPE,
+        "tolerance": CANONICAL_METRIC_DTYPE,
+    },
+    "packed-layout": {
+        "row-order": CANONICAL_INTEGER_DTYPE,
+        "modality-tags": CANONICAL_INTEGER_DTYPE,
+        "rotary-coordinates": CANONICAL_INTEGER_DTYPE,
+        "timestep-indices": CANONICAL_INTEGER_DTYPE,
+    },
+    "noise-allocation": {
+        "draw-order": CANONICAL_INTEGER_DTYPE,
+        "tensor-shapes": CANONICAL_INTEGER_DTYPE,
+        "sampled-values": CANONICAL_BF16_DTYPE,
+        "hash": CANONICAL_INTEGER_DTYPE,
+    },
+    "end-to-end-t2va": {
+        "latent-statistics": CANONICAL_METRIC_DTYPE,
+        "av-timing": CANONICAL_METRIC_DTYPE,
+        "video-metrics": CANONICAL_METRIC_DTYPE,
+        "audio-metrics": CANONICAL_METRIC_DTYPE,
+    },
+    "end-to-end-fl2va": {
+        "condition-latents": CANONICAL_BF16_DTYPE,
+        "latent-statistics": CANONICAL_METRIC_DTYPE,
+        "av-timing": CANONICAL_METRIC_DTYPE,
+        "video-metrics": CANONICAL_METRIC_DTYPE,
+        "audio-metrics": CANONICAL_METRIC_DTYPE,
+    },
+    "end-to-end-ref2va": {
+        "packed-order": CANONICAL_INTEGER_DTYPE,
+        "latent-statistics": CANONICAL_METRIC_DTYPE,
+        "av-timing": CANONICAL_METRIC_DTYPE,
+        "video-metrics": CANONICAL_METRIC_DTYPE,
+        "audio-metrics": CANONICAL_METRIC_DTYPE,
+    },
+}
+PROVENANCE_HASH_KEYS = {
+    "tokenizer-hash",
+    "processor-hash",
+    "component-index-hash",
+    "component-index-hashes",
+}
+CONTROL_CHARACTER_PATTERN = re.compile(r"[\x00-\x1f\x7f]")
 REVIEWED_AUTHORIZATION_EVIDENCE_SHA256 = (
     "8cd4d6e52cff34d7d39721ebab13b8c1187aa87aafc1c4ae2a16609186f22f1d"
 )
@@ -168,6 +252,32 @@ def manifest_layer_tiers(manifest: dict[str, Any]) -> dict[str, str]:
     return tiers
 
 
+def exact_layer_contracts(manifest: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    contracts: dict[str, dict[str, Any]] = {}
+    for layer in manifest["fixture_layers"]:
+        if layer["authority_tier"] != EXACT_AUTHORITY_TIER:
+            continue
+        identifier = layer["id"]
+        if identifier in contracts:
+            fail("checked manifest contains duplicate exact layer identities")
+        contracts[identifier] = layer
+
+    if set(contracts) != set(MEASUREMENT_DTYPES):
+        fail("protected measurement policy does not cover the exact manifest layers")
+    for identifier, contract in contracts.items():
+        required = contract["required_measurements"]
+        if len(required) != len(set(required)):
+            fail(f"checked manifest layer {identifier} repeats required measurements")
+        if set(required) != set(MEASUREMENT_DTYPES[identifier]):
+            fail(
+                f"protected measurement policy drifts from manifest layer {identifier}"
+            )
+        provenance = contract["required_provenance"]
+        if len(provenance) != len(set(provenance)):
+            fail(f"checked manifest layer {identifier} repeats required provenance")
+    return contracts
+
+
 def load_bundle_once(
     tool: Any,
     path: pathlib.Path,
@@ -234,15 +344,158 @@ def expected_tolerance_summary(policy: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def keyed_evidence_records(
+    records: Any,
+    label: str,
+) -> dict[str, dict[str, Any]]:
+    if not isinstance(records, list) or not records:
+        fail(f"{label} must be a non-empty record list")
+    keyed: dict[str, dict[str, Any]] = {}
+    for record in records:
+        if not isinstance(record, dict) or not isinstance(record.get("key"), str):
+            fail(f"{label} contains an invalid record")
+        key = record["key"]
+        if key in keyed:
+            fail(f"{label} contains duplicate key {key!r}")
+        keyed[key] = record
+    return keyed
+
+
+def structured_provenance_value(document: dict[str, Any], key: str) -> str | None:
+    if key == "source-revision":
+        return document["producer"]["revision"]
+    if key in {"component-index-hash", "component-index-hashes"}:
+        return document["input"]["component_index_sha256"]
+    if key in {"device", "generator-device"}:
+        return document["environment"]["device"]
+    if key == "dtype":
+        return document["environment"]["dtype"]
+    if key == "attention-backend":
+        return document["environment"]["attention_backend"]
+    if key == "capture-command":
+        return document["adapter"]["command"]
+    return None
+
+
+def is_json_integer(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def validate_manifest_layer_evidence(
+    document: dict[str, Any],
+    manifest_layer: dict[str, Any],
+    role: str,
+) -> None:
+    layer = manifest_layer["id"]
+    if document.get("layer") != layer:
+        fail(f"{role} evidence does not match manifest layer {layer}")
+
+    provenance = keyed_evidence_records(
+        document.get("provenance"), f"{role} layer {layer} provenance"
+    )
+    required_provenance = set(manifest_layer["required_provenance"])
+    if set(provenance) != required_provenance:
+        fail(f"{role} layer {layer} provenance keys differ from the manifest")
+    for key, record in provenance.items():
+        value = record.get("value")
+        if (
+            not isinstance(value, str)
+            or not value
+            or value != value.strip()
+            or len(value) > 4096
+            or CONTROL_CHARACTER_PATTERN.search(value) is not None
+        ):
+            fail(f"{role} layer {layer} provenance {key!r} is not canonical")
+        if key == "source-revision" and COMMIT_SHA_PATTERN.fullmatch(value) is None:
+            fail(f"{role} layer {layer} provenance {key!r} is not canonical")
+        if key in PROVENANCE_HASH_KEYS and re.fullmatch(r"[0-9a-f]{64}", value) is None:
+            fail(f"{role} layer {layer} provenance {key!r} is not canonical")
+        if key == "seed" and re.fullmatch(r"0|[1-9][0-9]*", value) is None:
+            fail(f"{role} layer {layer} provenance {key!r} is not canonical")
+        structured = structured_provenance_value(document, key)
+        if structured is not None and value != structured:
+            fail(
+                f"{role} layer {layer} provenance {key!r} "
+                "does not match structured evidence"
+            )
+
+    outputs = keyed_evidence_records(
+        document.get("outputs"), f"{role} layer {layer} outputs"
+    )
+    measurement_order = manifest_layer["required_measurements"]
+    required_measurements = set(measurement_order)
+    if set(outputs) != required_measurements:
+        fail(f"{role} layer {layer} measurement keys differ from the manifest")
+    if [output["key"] for output in document["outputs"]] != measurement_order:
+        fail(f"{role} layer {layer} measurement order differs from the manifest")
+
+    expected_dtypes = MEASUREMENT_DTYPES.get(layer)
+    if expected_dtypes is None or set(expected_dtypes) != required_measurements:
+        fail(f"protected measurement policy is missing manifest layer {layer}")
+
+    policies: dict[str, dict[str, Any]] = {}
+    if role == "oracle":
+        policies = keyed_evidence_records(
+            document.get("comparison"), f"{role} layer {layer} comparison policies"
+        )
+        if set(policies) != required_measurements:
+            fail(f"{role} layer {layer} policy keys differ from the manifest")
+    elif document.get("comparison") is not None:
+        fail("Mold evidence must not declare oracle comparison policies")
+
+    for key, output in outputs.items():
+        expected_dtype = expected_dtypes[key]
+        if output.get("dtype") != expected_dtype:
+            fail(f"{role} layer {layer} output {key!r} dtype must be {expected_dtype}")
+        if expected_dtype == CANONICAL_INTEGER_DTYPE:
+            statistics = output.get("statistics", {})
+            samples = output.get("samples", [])
+            if (
+                not is_json_integer(statistics.get("min"))
+                or not is_json_integer(statistics.get("max"))
+                or any(not is_json_integer(sample.get("value")) for sample in samples)
+            ):
+                fail(
+                    f"{role} layer {layer} output {key!r} integer evidence "
+                    "must use integer min/max and samples"
+                )
+        if role != "oracle":
+            continue
+        policy = policies[key]
+        if policy.get("metric") != "elementwise-atol-plus-rtol":
+            fail(f"oracle layer {layer} output {key!r} policy metric is invalid")
+        if expected_dtype == CANONICAL_INTEGER_DTYPE:
+            if (
+                policy.get("absolute") != 0
+                or policy.get("relative") != 0
+                or policy.get("hash_policy") != "exact"
+            ):
+                fail(
+                    f"oracle layer {layer} output {key!r} integer policy "
+                    "must use zero tolerances and exact hashes"
+                )
+        elif (
+            not isinstance(policy.get("absolute"), (int, float))
+            or not isinstance(policy.get("relative"), (int, float))
+            or policy["absolute"] > MAX_EXACT_ABSOLUTE_TOLERANCE
+            or policy["relative"] > MAX_EXACT_RELATIVE_TOLERANCE
+            or policy["absolute"] < 0
+            or policy["relative"] < 0
+            or policy.get("hash_policy") != "record-only"
+        ):
+            fail(
+                f"oracle layer {layer} output {key!r} floating policy "
+                "is not the bounded protected policy"
+            )
+
+
 def validate_exact_outputs(
     document: dict[str, Any],
     fixture: dict[str, Any],
+    manifest_layer: dict[str, Any],
     role: str,
 ) -> None:
-    outputs = {output["key"]: output for output in document["outputs"]}
-    for output in outputs.values():
-        if output["dtype"] != CANONICAL_BF16_DTYPE:
-            fail(f"{role} layer output dtype must be {CANONICAL_BF16_DTYPE}")
+    validate_manifest_layer_evidence(document, manifest_layer, role)
 
     first_output = document["outputs"][0]
     if fixture["tensor"] != expected_tensor_summary(first_output):
@@ -251,12 +504,6 @@ def validate_exact_outputs(
     if role != "oracle":
         return
     policies = {policy["key"]: policy for policy in document["comparison"]}
-    for policy in policies.values():
-        if (
-            policy["absolute"] > MAX_EXACT_ABSOLUTE_TOLERANCE
-            or policy["relative"] > MAX_EXACT_RELATIVE_TOLERANCE
-        ):
-            fail(f"{role} comparison policy is not bounded for exact BF16 evidence")
     first_policy = policies[first_output["key"]]
     if fixture["tolerance"] != expected_tolerance_summary(first_policy):
         fail(f"{role} bundle tolerance summary does not match oracle policy")
@@ -270,6 +517,7 @@ def load_layer_documents(
     role: str,
     source_sha: str,
     layer_tiers: dict[str, str],
+    layer_contracts: dict[str, dict[str, Any]],
 ) -> dict[tuple[str, str], tuple[dict[str, Any], dict[str, Any]]]:
     documents: dict[tuple[str, str], tuple[dict[str, Any], dict[str, Any]]] = {}
     for position, fixture in enumerate(bundle["fixtures"], start=1):
@@ -337,7 +585,10 @@ def load_layer_documents(
             != document["input"]["component_index_sha256"]
         ):
             fail(f"{role} bundle component index does not match its evidence")
-        validate_exact_outputs(document, fixture, role)
+        manifest_layer = layer_contracts.get(document["layer"])
+        if manifest_layer is None:
+            fail(f"{role} layer lacks a protected manifest contract")
+        validate_exact_outputs(document, fixture, manifest_layer, role)
         key = (document["case_id"], document["layer"])
         if key in documents:
             fail(f"{role} bundle contains duplicate case/layer evidence")
@@ -363,6 +614,27 @@ def require_complete_exact_coverage(
         )
 
 
+def validate_oracle_mold_policy_parity(
+    oracle_document: dict[str, Any],
+    oracle_fixture: dict[str, Any],
+    mold_document: dict[str, Any],
+    mold_fixture: dict[str, Any],
+) -> None:
+    oracle_outputs = keyed_evidence_records(
+        oracle_document["outputs"], "oracle paired outputs"
+    )
+    mold_outputs = keyed_evidence_records(
+        mold_document["outputs"], "Mold paired outputs"
+    )
+    if set(oracle_outputs) != set(mold_outputs):
+        fail("oracle and Mold measurement sets differ")
+    for key in oracle_outputs:
+        if oracle_outputs[key]["dtype"] != mold_outputs[key]["dtype"]:
+            fail(f"oracle and Mold output {key!r} dtypes differ")
+    if mold_fixture["tolerance"] != oracle_fixture["tolerance"]:
+        fail("Mold bundle tolerance summary differs from oracle policy")
+
+
 def run_campaign(
     environment: Mapping[str, str],
     gpu_probe: Callable[[], None] = probe_cuda,
@@ -375,6 +647,8 @@ def run_campaign(
     manifest = call_redacted(
         tool, "checked conformance contract", tool.validate_manifest
     )
+    layer_tiers = manifest_layer_tiers(manifest)
+    layer_contracts = exact_layer_contracts(manifest)
     fixture_root = call_redacted(
         tool,
         "external fixture root validation",
@@ -419,7 +693,6 @@ def run_campaign(
     source_sha = values["MOLD_H3_SOURCE_SHA"]
     validate_capture_environment(tool, oracle_bundle, "oracle", source_sha)
     validate_capture_environment(tool, mold_bundle, "mold", source_sha)
-    layer_tiers = manifest_layer_tiers(manifest)
     oracle_documents = load_layer_documents(
         tool,
         fixture_root,
@@ -428,6 +701,7 @@ def run_campaign(
         "oracle",
         source_sha,
         layer_tiers,
+        layer_contracts,
     )
     mold_documents = load_layer_documents(
         tool,
@@ -437,6 +711,7 @@ def run_campaign(
         "mold",
         source_sha,
         layer_tiers,
+        layer_contracts,
     )
     require_complete_exact_coverage(oracle_documents, layer_tiers, "oracle")
     require_complete_exact_coverage(mold_documents, layer_tiers, "mold")
@@ -450,8 +725,12 @@ def run_campaign(
     for position, key in enumerate(sorted(oracle_documents), start=1):
         oracle_document, oracle_fixture = oracle_documents[key]
         mold_document, mold_fixture = mold_documents[key]
-        if mold_fixture["tolerance"] != oracle_fixture["tolerance"]:
-            fail("Mold bundle tolerance summary differs from oracle policy")
+        validate_oracle_mold_policy_parity(
+            oracle_document,
+            oracle_fixture,
+            mold_document,
+            mold_fixture,
+        )
         comparison_notes = call_redacted(
             tool,
             f"authorized comparison {position}",

--- a/scripts/tests/minimax-h3-conformance-contract.py
+++ b/scripts/tests/minimax-h3-conformance-contract.py
@@ -56,6 +56,33 @@ def test_manifest_drift(tool, temporary: pathlib.Path) -> None:
     finally:
         tool.MANIFEST_PATH = original_path
 
+    manifest = json.loads(original_path.read_text(encoding="utf-8"))
+    tokenizer_layer = next(
+        layer
+        for layer in manifest["fixture_layers"]
+        if layer["id"] == "tokenizer-processor"
+    )
+    tokenizer_layer["pinned_provenance"][0]["component_indexes"] = ["official-license"]
+    changed = temporary / "remapped-provenance-manifest.json"
+    write_json(changed, manifest)
+    tool.MANIFEST_PATH = changed
+    try:
+        expect_failure(tool.validate_manifest, "invalid provenance authority")
+    finally:
+        tool.MANIFEST_PATH = original_path
+
+    manifest = json.loads(original_path.read_text(encoding="utf-8"))
+    manifest["numerical_authority"]["excluded_acceleration_aliases"]["fp8"].remove(
+        "float8"
+    )
+    changed = temporary / "narrowed-acceleration-aliases-manifest.json"
+    write_json(changed, manifest)
+    tool.MANIFEST_PATH = changed
+    try:
+        expect_failure(tool.validate_manifest, "exclusion aliases drifted")
+    finally:
+        tool.MANIFEST_PATH = original_path
+
 
 def test_synthetic_drift(tool, temporary: pathlib.Path) -> None:
     original_path = tool.SYNTHETIC_PATH
@@ -148,6 +175,15 @@ def test_comparison_diagnostics(tool) -> None:
     expect_failure(
         lambda: tool.compare_layer_outputs(oracle, tolerance_mold),
         "sample=[0] tolerance exceeded",
+    )
+
+    overflow_oracle = copy.deepcopy(oracle)
+    overflow_mold = copy.deepcopy(mold)
+    output_with_key(overflow_oracle, "audio_next")["samples"][0]["value"] = 10**400
+    output_with_key(overflow_mold, "audio_next")["samples"][0]["value"] = 10**400
+    expect_failure(
+        lambda: tool.compare_layer_outputs(overflow_oracle, overflow_mold),
+        "outside the finite comparison domain",
     )
 
     nan_mold = copy.deepcopy(mold)

--- a/scripts/tests/minimax-h3-gpu-conformance-contract.py
+++ b/scripts/tests/minimax-h3-gpu-conformance-contract.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""Contract tests for the opt-in MiniMax H3 private GPU conformance runner."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import importlib.util
+import json
+import pathlib
+import tempfile
+from collections.abc import Callable
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+RUNNER_PATH = REPO_ROOT / "scripts" / "run-minimax-h3-gpu-conformance.py"
+TOOL_PATH = REPO_ROOT / "scripts" / "minimax-h3-conformance.py"
+WORKFLOW_PATH = (
+    REPO_ROOT / ".github" / "workflows" / "minimax-h3-private-conformance.yml"
+)
+SOURCE_SHA = "a" * 40
+
+
+def load_module(path: pathlib.Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise AssertionError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def sha256(path: pathlib.Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def write_json(path: pathlib.Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
+
+
+def expect_failure(action: Callable[[], object], fragment: str) -> None:
+    try:
+        action()
+    except Exception as error:  # noqa: BLE001 - adversarial fail-closed tests
+        assert fragment in str(error), (fragment, str(error))
+    else:
+        raise AssertionError(f"expected failure containing {fragment!r}")
+
+
+def authorization_fixture(tool, root: pathlib.Path) -> tuple[pathlib.Path, str]:
+    source = root / "authorization-source.txt"
+    source.write_text("private conformance contract fixture\n", encoding="utf-8")
+    source_sha = sha256(source)
+    record = {
+        "schema_version": tool.AUTHORIZATION_SCHEMA_VERSION,
+        "family": "minimax-h3",
+        "decision": "approved",
+        "license_revision": tool.EXPECTED_REVISIONS["minimax-official-model"],
+        "license_sha256": tool.EXPECTED_LICENSE_SHA256,
+        "approved_scopes": [
+            "checkpoint-execution",
+            "fixture-capture",
+            "generated-output-retention",
+        ],
+        "source_document_path": str(source),
+        "source_document_sha256": source_sha,
+        "review_reference": "contract-test-only",
+    }
+    path = root / "authorization.json"
+    write_json(path, record)
+    return path, source_sha
+
+
+def layer_document(
+    tool,
+    role: str,
+    authorization_sha: str,
+) -> dict[str, object]:
+    fixture_path = (
+        tool.SYNTHETIC_ORACLE_PATH if role == "oracle" else tool.SYNTHETIC_MOLD_PATH
+    )
+    document = json.loads(fixture_path.read_text(encoding="utf-8"))
+    document["case_id"] = "gpu-contract-case"
+    document["authority_tier"] = "exact-full-bf16"
+    document["authorization_document_sha256"] = authorization_sha
+    document["environment"] = {
+        "device": "cuda:contract-test",
+        "dtype": "bfloat16",
+        "attention_backend": "math",
+        "forbidden_accelerations_disabled": True,
+    }
+    if role == "mold":
+        document["producer"]["revision"] = SOURCE_SHA
+    return document
+
+
+def bundle_fixture(
+    tool,
+    fixture_root: pathlib.Path,
+    authorization_sha: str,
+) -> tuple[pathlib.Path, pathlib.Path]:
+    manifest_sha = sha256(tool.MANIFEST_PATH)
+    bundle_paths: list[pathlib.Path] = []
+    for role in ("oracle", "mold"):
+        document = layer_document(tool, role, authorization_sha)
+        evidence_path = fixture_root / role / "gpu-contract-case.json"
+        write_json(evidence_path, document)
+        output = document["outputs"][0]
+        bundle = {
+            "schema_version": tool.BUNDLE_SCHEMA_VERSION,
+            "manifest_sha256": manifest_sha,
+            "authorization_document_sha256": authorization_sha,
+            "capture_environment": {
+                "framework": "diffusers" if role == "oracle" else "mold",
+                "framework_revision": (
+                    tool.EXPECTED_REVISIONS["diffusers"]
+                    if role == "oracle"
+                    else SOURCE_SHA
+                ),
+                "device": "cuda:contract-test",
+                "dtype": "bfloat16",
+                "attention_backend": "math",
+                "command": f"contract-test {role} capture",
+                "forbidden_accelerations_disabled": True,
+            },
+            "fixtures": [
+                {
+                    "id": f"gpu-contract-case-{role}",
+                    "layer": document["layer"],
+                    "authority_tier": document["authority_tier"],
+                    "relative_path": str(evidence_path.relative_to(fixture_root)),
+                    "sha256": sha256(evidence_path),
+                    "component_index_sha256": document["input"][
+                        "component_index_sha256"
+                    ],
+                    "tensor": {
+                        "shape": output["shape"],
+                        "dtype": output["dtype"],
+                        "min": output["statistics"]["min"],
+                        "max": output["statistics"]["max"],
+                        "mean": output["statistics"]["mean"],
+                        "std": output["statistics"]["std"],
+                        "sampled_values": [
+                            sample["value"] for sample in output["samples"]
+                        ],
+                    },
+                    "tolerance": {
+                        "absolute": 0.000002,
+                        "relative": 0.000001,
+                        "metric": "elementwise-atol-plus-rtol",
+                    },
+                }
+            ],
+        }
+        bundle_path = fixture_root / f"{role}-bundle.json"
+        write_json(bundle_path, bundle)
+        bundle_paths.append(bundle_path)
+    return bundle_paths[0], bundle_paths[1]
+
+
+def campaign_environment(
+    fixture_root: pathlib.Path,
+    authorization: pathlib.Path,
+    oracle_bundle: pathlib.Path,
+    mold_bundle: pathlib.Path,
+) -> dict[str, str]:
+    return {
+        "MOLD_H3_FIXTURE_ROOT": str(fixture_root),
+        "MOLD_H3_AUTHORIZATION_RECORD": str(authorization),
+        "MOLD_H3_ORACLE_BUNDLE": str(oracle_bundle),
+        "MOLD_H3_MOLD_BUNDLE": str(mold_bundle),
+        "MOLD_H3_SOURCE_SHA": SOURCE_SHA,
+    }
+
+
+def test_runner_contract(runner, tool, temporary: pathlib.Path) -> None:
+    fixture_root = temporary / "fixtures"
+    fixture_root.mkdir()
+    authorization, authorization_sha = authorization_fixture(tool, temporary)
+    oracle_bundle, mold_bundle = bundle_fixture(tool, fixture_root, authorization_sha)
+    environment = campaign_environment(
+        fixture_root, authorization, oracle_bundle, mold_bundle
+    )
+
+    expect_failure(
+        lambda: runner.resolve_external_file("authorization record", str(TOOL_PATH)),
+        "must live outside the Mold repository",
+    )
+
+    expect_failure(
+        lambda: runner.run_campaign({}, lambda: None),
+        "MOLD_H3_FIXTURE_ROOT is required",
+    )
+    missing_authorization = dict(environment)
+    del missing_authorization["MOLD_H3_AUTHORIZATION_RECORD"]
+    expect_failure(
+        lambda: runner.run_campaign(missing_authorization, lambda: None),
+        "MOLD_H3_AUTHORIZATION_RECORD is required",
+    )
+
+    probes = 0
+
+    def counted_probe() -> None:
+        nonlocal probes
+        probes += 1
+
+    result = runner.run_campaign(environment, counted_probe, lambda: SOURCE_SHA)
+    assert result == {"comparisons": 1, "notes": 1, "source_sha": SOURCE_SHA}
+    assert probes == 1
+
+    expect_failure(
+        lambda: runner.run_campaign(environment, lambda: None, lambda: "b" * 40),
+        "checkout source SHA",
+    )
+
+    expect_failure(
+        lambda: runner.run_campaign(
+            environment,
+            lambda: (_ for _ in ()).throw(
+                runner.GpuConformanceFailure("CUDA probe failed")
+            ),
+            lambda: SOURCE_SHA,
+        ),
+        "CUDA probe failed",
+    )
+
+    drifted_source = dict(environment)
+    drifted_source["MOLD_H3_SOURCE_SHA"] = "b" * 40
+    expect_failure(
+        lambda: runner.run_campaign(drifted_source, lambda: None, lambda: "b" * 40),
+        "Mold bundle framework revision",
+    )
+
+    mold_bundle_value = json.loads(mold_bundle.read_text(encoding="utf-8"))
+    mismatched_component = copy.deepcopy(mold_bundle_value)
+    mismatched_component["fixtures"][0]["component_index_sha256"] = "0" * 64
+    write_json(mold_bundle, mismatched_component)
+    expect_failure(
+        lambda: runner.run_campaign(environment, lambda: None, lambda: SOURCE_SHA),
+        "component index does not match",
+    )
+    write_json(mold_bundle, mold_bundle_value)
+
+    mold_document_path = (
+        fixture_root / mold_bundle_value["fixtures"][0]["relative_path"]
+    )
+    mold_document = json.loads(mold_document_path.read_text(encoding="utf-8"))
+    quantized_document = copy.deepcopy(mold_document)
+    quantized_document["authority_tier"] = "quantized-structural"
+    write_json(mold_document_path, quantized_document)
+    quantized_bundle = copy.deepcopy(mold_bundle_value)
+    quantized_bundle["fixtures"][0]["authority_tier"] = "quantized-structural"
+    quantized_bundle["fixtures"][0]["sha256"] = sha256(mold_document_path)
+    write_json(mold_bundle, quantized_bundle)
+    expect_failure(
+        lambda: runner.run_campaign(environment, lambda: None, lambda: SOURCE_SHA),
+        "exact-full-bf16",
+    )
+
+    synthetic_document = copy.deepcopy(mold_document)
+    synthetic_document["authority_tier"] = "synthetic"
+    synthetic_document["authorization_document_sha256"] = None
+    write_json(mold_document_path, synthetic_document)
+    synthetic_bundle = copy.deepcopy(mold_bundle_value)
+    synthetic_bundle["fixtures"][0]["authority_tier"] = "synthetic"
+    synthetic_bundle["fixtures"][0]["sha256"] = sha256(mold_document_path)
+    write_json(mold_bundle, synthetic_bundle)
+    expect_failure(
+        lambda: runner.run_campaign(environment, lambda: None, lambda: SOURCE_SHA),
+        "synthetic evidence is forbidden",
+    )
+
+
+def test_workflow_contract() -> None:
+    workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+    actionlint = (REPO_ROOT / ".github" / "actionlint.yaml").read_text(encoding="utf-8")
+    assert "workflow_dispatch:" in workflow
+    for trigger in ("push:", "pull_request:", "schedule:", "workflow_run:"):
+        assert f"  {trigger}" not in workflow
+    assert "environment: minimax-h3-private-uat" in workflow
+    assert (
+        "runs-on: [self-hosted, linux, x64, cuda, minimax-h3-private-uat]" in workflow
+    )
+    assert "permissions:\n  contents: read" in workflow
+    assert "expected_source_sha:" in workflow
+    assert "\"$GITHUB_REF\" != 'refs/heads/main'" in workflow
+    assert '"$GITHUB_SHA" != "$EXPECTED_SOURCE_SHA"' in workflow
+    for secret in (
+        "MOLD_H3_FIXTURE_ROOT",
+        "MOLD_H3_AUTHORIZATION_RECORD",
+        "MOLD_H3_ORACLE_BUNDLE",
+        "MOLD_H3_MOLD_BUNDLE",
+    ):
+        assert f"secrets.{secret}" in workflow
+    assert "MOLD_H3_SOURCE_SHA: ${{ github.sha }}" in workflow
+    assert "python3 scripts/run-minimax-h3-gpu-conformance.py" in workflow
+    assert "upload-artifact" not in workflow
+    assert "h3-private-uat" not in workflow.replace("minimax-h3-private-uat", "")
+    assert "    - cuda" in actionlint
+    assert "    - minimax-h3-private-uat" in actionlint
+
+    ci = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    for path in (
+        ".github/actionlint.yaml",
+        ".github/workflows/minimax-h3-private-conformance.yml",
+        "scripts/run-minimax-h3-gpu-conformance.py",
+        "scripts/tests/minimax-h3-gpu-conformance-contract.py",
+    ):
+        assert f"'{path}'" in ci
+    assert "python3 scripts/tests/minimax-h3-gpu-conformance-contract.py" in ci
+
+
+def main() -> int:
+    runner = load_module(RUNNER_PATH, "minimax_h3_gpu_conformance")
+    tool = load_module(TOOL_PATH, "minimax_h3_conformance")
+    with tempfile.TemporaryDirectory(prefix="mold-h3-gpu-contract-") as value:
+        test_runner_contract(runner, tool, pathlib.Path(value).resolve())
+    test_workflow_contract()
+    print("MiniMax H3 private GPU conformance contract tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/minimax-h3-gpu-conformance-contract.py
+++ b/scripts/tests/minimax-h3-gpu-conformance-contract.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import copy
 import hashlib
 import importlib.util
 import json
@@ -23,6 +24,88 @@ REVIEWED_AUTHORIZATION_EVIDENCE_SHA256 = (
 )
 CHECKOUT_V6_SHA = "d23441a48e516b6c34aea4fa41551a30e30af803"
 CANONICAL_BF16_DTYPE = "bfloat16"
+CANONICAL_INTEGER_DTYPE = "int64"
+CANONICAL_METRIC_DTYPE = "float64"
+TEST_MEASUREMENT_KINDS = {
+    "tokenizer-processor": {
+        "token-ids": "integer",
+        "special-token-presentation": "integer",
+        "processor-shapes": "integer",
+        "sampled-values": "activation",
+    },
+    "qwen-layer-50": {
+        "shape": "integer",
+        "dtype": "integer",
+        "statistics": "metric",
+        "sampled-values": "activation",
+        "tolerance": "metric",
+    },
+    "visual-vae": {
+        "pixel-normalization": "activation",
+        "posterior-seed-42": "activation",
+        "latent-statistics": "metric",
+        "sampled-values": "activation",
+        "tile-seams": "metric",
+    },
+    "audio-vae": {
+        "stereo-packing": "integer",
+        "latent-rate": "metric",
+        "waveform-statistics": "metric",
+        "phase-polarity": "integer",
+        "sampled-values": "activation",
+    },
+    "token-refiner": {
+        "shape": "integer",
+        "statistics": "metric",
+        "sampled-values": "activation",
+        "tolerance": "metric",
+    },
+    "transformer-block": {
+        "qk-rms": "metric",
+        "partial-mm-rope": "activation",
+        "adaln": "activation",
+        "video-head": "activation",
+        "audio-head": "activation",
+        "tolerance": "metric",
+    },
+    "packed-layout": {
+        "row-order": "integer",
+        "modality-tags": "integer",
+        "rotary-coordinates": "integer",
+        "timestep-indices": "integer",
+    },
+    "noise-allocation": {
+        "draw-order": "integer",
+        "tensor-shapes": "integer",
+        "sampled-values": "activation",
+        "hash": "integer",
+    },
+    "end-to-end-t2va": {
+        "latent-statistics": "metric",
+        "av-timing": "metric",
+        "video-metrics": "metric",
+        "audio-metrics": "metric",
+    },
+    "end-to-end-fl2va": {
+        "condition-latents": "activation",
+        "latent-statistics": "metric",
+        "av-timing": "metric",
+        "video-metrics": "metric",
+        "audio-metrics": "metric",
+    },
+    "end-to-end-ref2va": {
+        "packed-order": "integer",
+        "latent-statistics": "metric",
+        "av-timing": "metric",
+        "video-metrics": "metric",
+        "audio-metrics": "metric",
+    },
+}
+DTYPE_BY_KIND = {
+    "integer": CANONICAL_INTEGER_DTYPE,
+    "activation": CANONICAL_BF16_DTYPE,
+    "metric": CANONICAL_METRIC_DTYPE,
+}
 
 
 def load_module(path: pathlib.Path, name: str):
@@ -82,31 +165,101 @@ def authorization_fixture(
     return path, source, source_sha
 
 
+def exact_manifest_layers(tool) -> dict[str, dict[str, object]]:
+    manifest = tool.validate_manifest()
+    layers = {
+        layer["id"]: layer
+        for layer in manifest["fixture_layers"]
+        if layer["authority_tier"] == "exact-full-bf16"
+    }
+    assert len(layers) == 11
+    assert "dual-sampler" not in layers
+    assert set(layers) == set(TEST_MEASUREMENT_KINDS)
+    for identifier, layer in layers.items():
+        assert set(layer["required_measurements"]) == set(
+            TEST_MEASUREMENT_KINDS[identifier]
+        )
+    return layers
+
+
+def output_fixture(layer: str, key: str, kind: str) -> dict[str, object]:
+    integer = kind == "integer"
+    low: int | float = 1 if integer else 0.25
+    high: int | float = 2 if integer else 0.75
+    mean: int | float = 1 if integer else 0.5
+    deviation: int | float = 0 if integer else 0.25
+    return {
+        "key": key,
+        "shape": [2],
+        "dtype": DTYPE_BY_KIND[kind],
+        "content_sha256": hashlib.sha256(
+            f"gpu-contract:{layer}:{key}:{kind}".encode()
+        ).hexdigest(),
+        "statistics": {
+            "min": low,
+            "max": high,
+            "mean": mean,
+            "std": deviation,
+        },
+        "samples": [
+            {"index": [0], "value": low},
+            {"index": [1], "value": high},
+        ],
+    }
+
+
+def comparison_fixture(key: str, kind: str) -> dict[str, object]:
+    integer = kind == "integer"
+    return {
+        "key": key,
+        "absolute": 0 if integer else 0.000002,
+        "relative": 0 if integer else 0.000001,
+        "metric": "elementwise-atol-plus-rtol",
+        "hash_policy": "exact" if integer else "record-only",
+    }
+
+
+def provenance_fixture(
+    manifest_layer: dict[str, object], document: dict[str, object]
+) -> list[dict[str, str]]:
+    values = {
+        "source-revision": document["producer"]["revision"],
+        "tokenizer-hash": hashlib.sha256(b"contract-tokenizer").hexdigest(),
+        "processor-hash": hashlib.sha256(b"contract-processor").hexdigest(),
+        "component-index-hash": document["input"]["component_index_sha256"],
+        "component-index-hashes": document["input"]["component_index_sha256"],
+        "device": document["environment"]["device"],
+        "generator-device": document["environment"]["device"],
+        "dtype": document["environment"]["dtype"],
+        "attention-backend": document["environment"]["attention_backend"],
+        "capture-command": document["adapter"]["command"],
+        "workflow": "private-conformance-v1",
+        "reference-order": "source-then-reference-v1",
+        "seed": "42",
+        "allocation-version": "canonical-draw-order-v1",
+        "float-policy": "coupled-bfloat16-v1",
+        "video-shift": "8.0",
+        "audio-shift": "5.0",
+        "endpoint-signature": "fl2va-v1",
+    }
+    return [
+        {"key": key, "value": values[key]}
+        for key in manifest_layer["required_provenance"]
+    ]
+
+
 def layer_document(
     tool,
     role: str,
     authorization_sha: str,
-    layer: str,
+    manifest_layer: dict[str, object],
 ) -> dict[str, object]:
+    layer = manifest_layer["id"]
     component_sha = next(iter(tool.EXPECTED_COMPONENT_INDEXES.values()))[1]
-    output = {
-        "key": "activation",
-        "shape": [2],
-        "dtype": CANONICAL_BF16_DTYPE,
-        "content_sha256": hashlib.sha256(
-            f"gpu-contract:{layer}:activation".encode()
-        ).hexdigest(),
-        "statistics": {
-            "min": 0.25,
-            "max": 0.75,
-            "mean": 0.5,
-            "std": 0.25,
-        },
-        "samples": [
-            {"index": [0], "value": 0.25},
-            {"index": [1], "value": 0.75},
-        ],
-    }
+    outputs = [
+        output_fixture(layer, key, TEST_MEASUREMENT_KINDS[layer][key])
+        for key in manifest_layer["required_measurements"]
+    ]
     document: dict[str, object] = {
         "schema_version": tool.LAYER_OUTPUT_SCHEMA_VERSION,
         "family": "minimax-h3",
@@ -131,7 +284,7 @@ def layer_document(
             "schema_version": "mold.minimax-h3.layer-adapter.v1",
             "id": f"contract-{role}-adapter",
             "command": f"contract-test {role} {layer} capture",
-            "tensor_hash_encoding": "canonical-bf16-le-v1",
+            "tensor_hash_encoding": "canonical-typed-le-v1",
         },
         "environment": {
             "device": "cuda:contract-test",
@@ -139,31 +292,19 @@ def layer_document(
             "attention_backend": "math",
             "forbidden_accelerations_disabled": True,
         },
-        "outputs": [output],
+        "outputs": outputs,
     }
+    document["provenance"] = provenance_fixture(manifest_layer, document)
     if role == "oracle":
         document["comparison"] = [
-            {
-                "key": "activation",
-                "absolute": 0.000002,
-                "relative": 0.000001,
-                "metric": "elementwise-atol-plus-rtol",
-                "hash_policy": "exact",
-            }
+            comparison_fixture(key, TEST_MEASUREMENT_KINDS[layer][key])
+            for key in manifest_layer["required_measurements"]
         ]
     return document
 
 
 def exact_layer_ids(tool) -> list[str]:
-    manifest = tool.validate_manifest()
-    layers = [
-        layer["id"]
-        for layer in manifest["fixture_layers"]
-        if layer["authority_tier"] == "exact-full-bf16"
-    ]
-    assert len(layers) == 11
-    assert "dual-sampler" not in layers
-    return layers
+    return list(exact_manifest_layers(tool))
 
 
 def bundle_fixture(
@@ -172,22 +313,17 @@ def bundle_fixture(
     authorization_sha: str,
 ) -> tuple[pathlib.Path, pathlib.Path]:
     manifest_sha = sha256(tool.MANIFEST_PATH)
+    manifest_layers = exact_manifest_layers(tool)
     bundle_paths: list[pathlib.Path] = []
     for role in ("oracle", "mold"):
         fixtures = []
-        for layer in exact_layer_ids(tool):
-            document = layer_document(tool, role, authorization_sha, layer)
+        for layer, manifest_layer in manifest_layers.items():
+            document = layer_document(tool, role, authorization_sha, manifest_layer)
             evidence_path = fixture_root / role / f"{layer}.json"
             write_json(evidence_path, document)
             output = document["outputs"][0]
-            comparison = (
-                document["comparison"][0]
-                if role == "oracle"
-                else {
-                    "absolute": 0.000002,
-                    "relative": 0.000001,
-                    "metric": "elementwise-atol-plus-rtol",
-                }
+            comparison = comparison_fixture(
+                output["key"], TEST_MEASUREMENT_KINDS[layer][output["key"]]
             )
             fixtures.append(
                 {
@@ -277,12 +413,300 @@ def mutate_evidence(
     return bundle, evidence_path
 
 
+def record_by_key(records: list[dict[str, object]], key: str) -> dict[str, object]:
+    return next(record for record in records if record["key"] == key)
+
+
+def test_manifest_layer_contract(runner, tool, authorization_sha: str) -> None:
+    manifest = tool.validate_manifest()
+    manifest_layers = exact_manifest_layers(tool)
+    assert set(runner.exact_layer_contracts(manifest)) == set(manifest_layers)
+
+    for layer, manifest_layer in manifest_layers.items():
+        for key, kind in TEST_MEASUREMENT_KINDS[layer].items():
+            assert runner.MEASUREMENT_DTYPES[layer][key] == DTYPE_BY_KIND[kind]
+
+        for role in ("oracle", "mold"):
+            document = layer_document(tool, role, authorization_sha, manifest_layer)
+            tool.validate_layer_output(document, f"valid {role} {layer}")
+            runner.validate_manifest_layer_evidence(document, manifest_layer, role)
+
+        generic = layer_document(tool, "oracle", authorization_sha, manifest_layer)
+        generic["outputs"] = [output_fixture(layer, "activation", "activation")]
+        generic["comparison"] = [comparison_fixture("activation", "activation")]
+        expect_failure(
+            lambda generic=generic, manifest_layer=manifest_layer: (
+                runner.validate_manifest_layer_evidence(
+                    generic, manifest_layer, "oracle"
+                )
+            ),
+            "measurement keys differ from the manifest",
+        )
+
+        reordered = layer_document(tool, "oracle", authorization_sha, manifest_layer)
+        reordered["outputs"][0], reordered["outputs"][1] = (
+            reordered["outputs"][1],
+            reordered["outputs"][0],
+        )
+        expect_failure(
+            lambda reordered=reordered, manifest_layer=manifest_layer: (
+                runner.validate_manifest_layer_evidence(
+                    reordered, manifest_layer, "oracle"
+                )
+            ),
+            "measurement order differs from the manifest",
+        )
+
+        for provenance_key in manifest_layer["required_provenance"]:
+            missing = layer_document(tool, "oracle", authorization_sha, manifest_layer)
+            missing["provenance"] = [
+                record
+                for record in missing["provenance"]
+                if record["key"] != provenance_key
+            ]
+            expect_failure(
+                lambda missing=missing, manifest_layer=manifest_layer: (
+                    runner.validate_manifest_layer_evidence(
+                        missing, manifest_layer, "oracle"
+                    )
+                ),
+                "provenance keys differ from the manifest",
+            )
+
+            renamed = layer_document(tool, "oracle", authorization_sha, manifest_layer)
+            record_by_key(renamed["provenance"], provenance_key)["key"] = (
+                f"{provenance_key}-renamed"
+            )
+            expect_failure(
+                lambda renamed=renamed, manifest_layer=manifest_layer: (
+                    runner.validate_manifest_layer_evidence(
+                        renamed, manifest_layer, "oracle"
+                    )
+                ),
+                "provenance keys differ from the manifest",
+            )
+
+            noncanonical = layer_document(
+                tool, "oracle", authorization_sha, manifest_layer
+            )
+            record = record_by_key(noncanonical["provenance"], provenance_key)
+            record["value"] = f" {record['value']}"
+            expect_failure(
+                lambda noncanonical=noncanonical, manifest_layer=manifest_layer: (
+                    runner.validate_manifest_layer_evidence(
+                        noncanonical, manifest_layer, "oracle"
+                    )
+                ),
+                "is not canonical",
+            )
+
+            empty = layer_document(tool, "oracle", authorization_sha, manifest_layer)
+            record_by_key(empty["provenance"], provenance_key)["value"] = ""
+            expect_failure(
+                lambda empty=empty, manifest_layer=manifest_layer: (
+                    runner.validate_manifest_layer_evidence(
+                        empty, manifest_layer, "oracle"
+                    )
+                ),
+                "is not canonical",
+            )
+
+        structured_drifts = {
+            "source-revision": "b" * 40,
+            "component-index-hash": "b" * 64,
+            "component-index-hashes": "b" * 64,
+            "device": "cuda:other",
+            "generator-device": "cuda:other",
+            "dtype": "float32",
+            "attention-backend": "flash",
+            "capture-command": "different capture command",
+        }
+        for provenance_key, value in structured_drifts.items():
+            if provenance_key not in manifest_layer["required_provenance"]:
+                continue
+            drifted = layer_document(tool, "oracle", authorization_sha, manifest_layer)
+            record_by_key(drifted["provenance"], provenance_key)["value"] = value
+            expect_failure(
+                lambda drifted=drifted, manifest_layer=manifest_layer: (
+                    runner.validate_manifest_layer_evidence(
+                        drifted, manifest_layer, "oracle"
+                    )
+                ),
+                "does not match structured evidence",
+            )
+
+        for measurement in manifest_layer["required_measurements"]:
+            missing = layer_document(tool, "oracle", authorization_sha, manifest_layer)
+            missing["outputs"] = [
+                output for output in missing["outputs"] if output["key"] != measurement
+            ]
+            missing["comparison"] = [
+                policy
+                for policy in missing["comparison"]
+                if policy["key"] != measurement
+            ]
+            expect_failure(
+                lambda missing=missing, manifest_layer=manifest_layer: (
+                    runner.validate_manifest_layer_evidence(
+                        missing, manifest_layer, "oracle"
+                    )
+                ),
+                "measurement keys differ from the manifest",
+            )
+
+            renamed = layer_document(tool, "oracle", authorization_sha, manifest_layer)
+            record_by_key(renamed["outputs"], measurement)["key"] = (
+                f"{measurement}-renamed"
+            )
+            record_by_key(renamed["comparison"], measurement)["key"] = (
+                f"{measurement}-renamed"
+            )
+            expect_failure(
+                lambda renamed=renamed, manifest_layer=manifest_layer: (
+                    runner.validate_manifest_layer_evidence(
+                        renamed, manifest_layer, "oracle"
+                    )
+                ),
+                "measurement keys differ from the manifest",
+            )
+
+            kind = TEST_MEASUREMENT_KINDS[layer][measurement]
+            wrong_dtype = layer_document(
+                tool, "oracle", authorization_sha, manifest_layer
+            )
+            output = record_by_key(wrong_dtype["outputs"], measurement)
+            output["dtype"] = (
+                CANONICAL_METRIC_DTYPE if kind != "metric" else CANONICAL_BF16_DTYPE
+            )
+            expect_failure(
+                lambda wrong_dtype=wrong_dtype, manifest_layer=manifest_layer: (
+                    runner.validate_manifest_layer_evidence(
+                        wrong_dtype, manifest_layer, "oracle"
+                    )
+                ),
+                "dtype must be",
+            )
+
+            if kind == "integer":
+                fractional_sample = layer_document(
+                    tool, "oracle", authorization_sha, manifest_layer
+                )
+                record_by_key(fractional_sample["outputs"], measurement)["samples"][0][
+                    "value"
+                ] = 0.25
+                expect_failure(
+                    lambda fractional_sample=fractional_sample, manifest_layer=manifest_layer: (
+                        runner.validate_manifest_layer_evidence(
+                            fractional_sample, manifest_layer, "oracle"
+                        )
+                    ),
+                    "integer min/max and samples",
+                )
+
+                fractional_mold_sample = layer_document(
+                    tool, "mold", authorization_sha, manifest_layer
+                )
+                record_by_key(fractional_mold_sample["outputs"], measurement)[
+                    "samples"
+                ][0]["value"] = 0.25
+                expect_failure(
+                    lambda fractional_mold_sample=fractional_mold_sample, manifest_layer=manifest_layer: (
+                        runner.validate_manifest_layer_evidence(
+                            fractional_mold_sample, manifest_layer, "mold"
+                        )
+                    ),
+                    "integer min/max and samples",
+                )
+
+                for statistic, value in (("min", 0.25), ("max", 2.25)):
+                    fractional_bound = layer_document(
+                        tool, "oracle", authorization_sha, manifest_layer
+                    )
+                    record_by_key(fractional_bound["outputs"], measurement)[
+                        "statistics"
+                    ][statistic] = value
+                    expect_failure(
+                        lambda fractional_bound=fractional_bound, manifest_layer=manifest_layer: (
+                            runner.validate_manifest_layer_evidence(
+                                fractional_bound, manifest_layer, "oracle"
+                            )
+                        ),
+                        "integer min/max and samples",
+                    )
+
+                fractional_summary = layer_document(
+                    tool, "oracle", authorization_sha, manifest_layer
+                )
+                summary_statistics = record_by_key(
+                    fractional_summary["outputs"], measurement
+                )["statistics"]
+                summary_statistics["mean"] = 1.5
+                summary_statistics["std"] = 0.5
+                runner.validate_manifest_layer_evidence(
+                    fractional_summary, manifest_layer, "oracle"
+                )
+
+            wrong_policy = layer_document(
+                tool, "oracle", authorization_sha, manifest_layer
+            )
+            policy = record_by_key(wrong_policy["comparison"], measurement)
+            if kind == "integer":
+                policy["absolute"] = 0.25
+                expected_policy_error = "integer policy"
+            else:
+                policy["absolute"] = 1.0
+                expected_policy_error = "bounded protected policy"
+            expect_failure(
+                lambda wrong_policy=wrong_policy, manifest_layer=manifest_layer: (
+                    runner.validate_manifest_layer_evidence(
+                        wrong_policy, manifest_layer, "oracle"
+                    )
+                ),
+                expected_policy_error,
+            )
+
+            wrong_hash_policy = layer_document(
+                tool, "oracle", authorization_sha, manifest_layer
+            )
+            hash_policy = record_by_key(wrong_hash_policy["comparison"], measurement)
+            hash_policy["hash_policy"] = "record-only" if kind == "integer" else "exact"
+            expect_failure(
+                lambda wrong_hash_policy=wrong_hash_policy, manifest_layer=manifest_layer: (
+                    runner.validate_manifest_layer_evidence(
+                        wrong_hash_policy, manifest_layer, "oracle"
+                    )
+                ),
+                ("integer policy" if kind == "integer" else "bounded protected policy"),
+            )
+
+        oracle = layer_document(tool, "oracle", authorization_sha, manifest_layer)
+        mold = layer_document(tool, "mold", authorization_sha, manifest_layer)
+        first_policy = oracle["comparison"][0]
+        fixture = {
+            "tolerance": {
+                "absolute": first_policy["absolute"],
+                "relative": first_policy["relative"],
+                "metric": first_policy["metric"],
+            }
+        }
+        runner.validate_oracle_mold_policy_parity(oracle, fixture, mold, fixture)
+        mismatched_mold = copy.deepcopy(mold)
+        mismatched_mold["outputs"][0]["dtype"] = "float32"
+        expect_failure(
+            lambda: runner.validate_oracle_mold_policy_parity(
+                oracle, fixture, mismatched_mold, fixture
+            ),
+            "dtypes differ",
+        )
+
+
 def test_runner_contract(runner, tool, temporary: pathlib.Path) -> None:
     fixture_root = temporary / "fixtures"
     fixture_root.mkdir()
     authorization, reviewed_source, authorization_sha = authorization_fixture(
         tool, temporary
     )
+    test_manifest_layer_contract(runner, tool, authorization_sha)
     original_sha256_file = tool.sha256_file
     original_load_tool = runner.load_tool
 
@@ -436,7 +860,7 @@ def test_runner_contract(runner, tool, temporary: pathlib.Path) -> None:
         )
         expect_failure(
             lambda: runner.run_campaign(environment, lambda: None, lambda: SOURCE_SHA),
-            "output dtype",
+            "dtype must be",
         )
 
         environment, _, mold_bundle = reset_campaign()
@@ -485,7 +909,7 @@ def test_runner_contract(runner, tool, temporary: pathlib.Path) -> None:
         )
         expect_failure(
             lambda: runner.run_campaign(environment, lambda: None, lambda: SOURCE_SHA),
-            "bounded",
+            "policy",
         )
 
         environment, _, mold_bundle = reset_campaign()
@@ -549,9 +973,8 @@ def test_workflow_contract() -> None:
     for trigger in ("push:", "pull_request:", "schedule:", "workflow_run:"):
         assert f"  {trigger}" not in workflow
     assert "environment: minimax-h3-private-uat" in workflow
-    assert (
-        "runs-on: [self-hosted, linux, x64, cuda, minimax-h3-private-uat]" in workflow
-    )
+    assert "runs-on:\n      group: minimax-h3-private-conformance" in workflow
+    assert "labels: [self-hosted, linux, x64, cuda, minimax-h3-private-uat]" in workflow
     assert "permissions:\n  contents: read" in workflow
     assert "expected_source_sha:" in workflow
     assert "\"$GITHUB_REF\" != 'refs/heads/main'" in workflow
@@ -576,16 +999,27 @@ def test_workflow_contract() -> None:
     assert "h3-private-uat" not in workflow.replace("minimax-h3-private-uat", "")
     assert "    - cuda" in actionlint
     assert "    - minimax-h3-private-uat" in actionlint
-    assert "administrator prerequisite" in normalized_docs
-    assert "remains queued" in normalized_docs
-    assert "does not assert that either is currently configured" in normalized_docs
+    assert "unchecked administrator prerequisites" in normalized_docs
+    assert "can create one without the intended protection" in normalized_docs
+    assert "routing metadata, not an access-control boundary" in normalized_docs
+    assert (
+        "utensils/mold/.github/workflows/minimax-h3-private-conformance.yml@refs/heads/main"
+        in normalized_docs
+    )
+    assert "runner-group restrictions exist" in normalized_docs
     assert "persistent public-repository runner" in normalized_docs
+    assert "if the environment, approval, or secrets are absent" not in normalized_docs
+    assert "Computed metric and statistical summaries are serialized as `float64`" in (
+        normalized_docs
+    )
+    assert "Discrete tokenizer, shape, layout" in normalized_docs
     assert REVIEWED_AUTHORIZATION_EVIDENCE_SHA256 in qualification_docs
 
     ci = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
     for path in (
         ".github/actionlint.yaml",
         ".github/workflows/minimax-h3-private-conformance.yml",
+        "docs/qualification/minimax-h3-*.json",
         "scripts/run-minimax-h3-gpu-conformance.py",
         "scripts/tests/minimax-h3-gpu-conformance-contract.py",
     ):

--- a/scripts/tests/minimax-h3-gpu-conformance-contract.py
+++ b/scripts/tests/minimax-h3-gpu-conformance-contract.py
@@ -26,6 +26,13 @@ CHECKOUT_V6_SHA = "d23441a48e516b6c34aea4fa41551a30e30af803"
 CANONICAL_BF16_DTYPE = "bfloat16"
 CANONICAL_INTEGER_DTYPE = "int64"
 CANONICAL_METRIC_DTYPE = "float64"
+CANONICAL_E2E_INPUT_SCHEMA = "mold.minimax-h3.e2e-input.v1"
+COMPONENT_AUTHORITY_SET_SCHEMA = "mold.minimax-h3.component-authority-set.v1"
+E2E_LAYER_TASKS = {
+    "end-to-end-t2va": "t2va",
+    "end-to-end-fl2va": "fl2va",
+    "end-to-end-ref2va": "ref2va",
+}
 TEST_MEASUREMENT_KINDS = {
     "tokenizer-processor": {
         "token-ids": "integer",
@@ -126,6 +133,31 @@ def write_json(path: pathlib.Path, value: object) -> None:
     path.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
 
 
+def canonical_json_sha256(value: object) -> str:
+    encoded = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def component_authority_set_sha256(
+    component_ids: list[str], component_authorities: dict[str, str]
+) -> str:
+    return canonical_json_sha256(
+        {
+            "schema_version": COMPONENT_AUTHORITY_SET_SCHEMA,
+            "components": [
+                {"id": identifier, "sha256": component_authorities[identifier]}
+                for identifier in sorted(component_ids)
+            ],
+        }
+    )
+
+
 def expect_failure(action: Callable[[], object], fragment: str) -> None:
     try:
         action()
@@ -167,11 +199,29 @@ def authorization_fixture(
 
 def exact_manifest_layers(tool) -> dict[str, dict[str, object]]:
     manifest = tool.validate_manifest()
-    layers = {
-        layer["id"]: layer
-        for layer in manifest["fixture_layers"]
-        if layer["authority_tier"] == "exact-full-bf16"
+    component_authorities = {
+        component["id"]: component["sha256"]
+        for component in manifest["component_indexes"]
     }
+    layers = {}
+    for raw_layer in manifest["fixture_layers"]:
+        if raw_layer["authority_tier"] != "exact-full-bf16":
+            continue
+        layer = copy.deepcopy(raw_layer)
+        layer["_required_component_authorities"] = [
+            {"id": identifier, "sha256": component_authorities[identifier]}
+            for identifier in layer["required_component_indexes"]
+        ]
+        layer["_pinned_provenance_values"] = {
+            record["key"]: component_authority_set_sha256(
+                record["component_indexes"], component_authorities
+            )
+            for record in layer["pinned_provenance"]
+        }
+        layer["_excluded_accelerations"] = frozenset(
+            manifest["numerical_authority"]["excluded_accelerations"]
+        )
+        layers[layer["id"]] = layer
     assert len(layers) == 11
     assert "dual-sampler" not in layers
     assert set(layers) == set(TEST_MEASUREMENT_KINDS)
@@ -215,19 +265,26 @@ def comparison_fixture(key: str, kind: str) -> dict[str, object]:
         "absolute": 0 if integer else 0.000002,
         "relative": 0 if integer else 0.000001,
         "metric": "elementwise-atol-plus-rtol",
-        "hash_policy": "exact" if integer else "record-only",
+        "hash_policy": "exact",
     }
 
 
 def provenance_fixture(
     manifest_layer: dict[str, object], document: dict[str, object]
 ) -> list[dict[str, str]]:
+    component_indexes = document["input"]["component_indexes"]
+    component_index_hashes = ",".join(
+        f"{component['id']}={component['sha256']}"
+        for component in sorted(
+            component_indexes, key=lambda component: component["id"]
+        )
+    )
     values = {
         "source-revision": document["producer"]["revision"],
-        "tokenizer-hash": hashlib.sha256(b"contract-tokenizer").hexdigest(),
-        "processor-hash": hashlib.sha256(b"contract-processor").hexdigest(),
+        "tokenizer-hash": "0" * 64,
+        "processor-hash": "0" * 64,
         "component-index-hash": document["input"]["component_index_sha256"],
-        "component-index-hashes": document["input"]["component_index_sha256"],
+        "component-index-hashes": component_index_hashes,
         "device": document["environment"]["device"],
         "generator-device": document["environment"]["device"],
         "dtype": document["environment"]["dtype"],
@@ -242,6 +299,7 @@ def provenance_fixture(
         "audio-shift": "5.0",
         "endpoint-signature": "fl2va-v1",
     }
+    values.update(manifest_layer["_pinned_provenance_values"])
     return [
         {"key": key, "value": values[key]}
         for key in manifest_layer["required_provenance"]
@@ -255,7 +313,64 @@ def layer_document(
     manifest_layer: dict[str, object],
 ) -> dict[str, object]:
     layer = manifest_layer["id"]
-    component_sha = next(iter(tool.EXPECTED_COMPONENT_INDEXES.values()))[1]
+    component_indexes = copy.deepcopy(manifest_layer["_required_component_authorities"])
+    input_evidence: dict[str, object] = {
+        "id": f"gpu-contract-{layer}",
+        "sha256": hashlib.sha256(f"input:{layer}".encode()).hexdigest(),
+        "component_index_sha256": component_indexes[0]["sha256"],
+        "component_indexes": component_indexes,
+    }
+    task = E2E_LAYER_TASKS.get(layer)
+    if task is not None:
+        conditioning = []
+        if task == "fl2va":
+            conditioning = [
+                {
+                    "role": "first-frame",
+                    "sha256": hashlib.sha256(b"contract-first-frame").hexdigest(),
+                },
+                {
+                    "role": "last-frame",
+                    "sha256": hashlib.sha256(b"contract-last-frame").hexdigest(),
+                },
+            ]
+        elif task == "ref2va":
+            conditioning = [
+                {
+                    "role": "reference-image",
+                    "sha256": hashlib.sha256(b"contract-reference-image").hexdigest(),
+                },
+                {
+                    "role": "reference-audio",
+                    "sha256": hashlib.sha256(b"contract-reference-audio").hexdigest(),
+                },
+            ]
+        conformance = {
+            "schema_version": CANONICAL_E2E_INPUT_SCHEMA,
+            "task": task,
+            "prompt_sha256": hashlib.sha256(b"contract prompt").hexdigest(),
+            "negative_prompt_sha256": hashlib.sha256(b"").hexdigest(),
+            "conditioning": conditioning,
+            "seed": 42,
+            "width": 1280,
+            "height": 768,
+            "frames": 362,
+            "fps": 24,
+            "video_sampler": {
+                "algorithm": "minimax-h3-flow-euler-v1",
+                "steps": 30,
+                "guidance": "0",
+                "shift": "12",
+            },
+            "audio_sampler": {
+                "algorithm": "minimax-h3-flow-euler-v1",
+                "steps": 30,
+                "guidance": "0",
+                "shift": "3",
+            },
+        }
+        input_evidence["conformance"] = conformance
+        input_evidence["sha256"] = canonical_json_sha256(conformance)
     outputs = [
         output_fixture(layer, key, TEST_MEASUREMENT_KINDS[layer][key])
         for key in manifest_layer["required_measurements"]
@@ -267,11 +382,7 @@ def layer_document(
         "layer": layer,
         "authority_tier": "exact-full-bf16",
         "authorization_document_sha256": authorization_sha,
-        "input": {
-            "id": f"gpu-contract-{layer}",
-            "sha256": hashlib.sha256(f"input:{layer}".encode()).hexdigest(),
-            "component_index_sha256": component_sha,
-        },
+        "input": input_evidence,
         "producer": {
             "role": role,
             "implementation": f"contract-{role}",
@@ -290,6 +401,10 @@ def layer_document(
             "device": "cuda:contract-test",
             "dtype": CANONICAL_BF16_DTYPE,
             "attention_backend": "math",
+            "acceleration_policy": {
+                "enabled": ["math"],
+                "disabled": sorted(manifest_layer["_excluded_accelerations"]),
+            },
             "forbidden_accelerations_disabled": True,
         },
         "outputs": outputs,
@@ -314,6 +429,9 @@ def bundle_fixture(
 ) -> tuple[pathlib.Path, pathlib.Path]:
     manifest_sha = sha256(tool.MANIFEST_PATH)
     manifest_layers = exact_manifest_layers(tool)
+    excluded_accelerations = sorted(
+        tool.validate_manifest()["numerical_authority"]["excluded_accelerations"]
+    )
     bundle_paths: list[pathlib.Path] = []
     for role in ("oracle", "mold"):
         fixtures = []
@@ -335,6 +453,9 @@ def bundle_fixture(
                     "component_index_sha256": document["input"][
                         "component_index_sha256"
                     ],
+                    "component_indexes": copy.deepcopy(
+                        document["input"]["component_indexes"]
+                    ),
                     "tensor": {
                         "shape": output["shape"],
                         "dtype": output["dtype"],
@@ -367,6 +488,10 @@ def bundle_fixture(
                 "device": "cuda:contract-test",
                 "dtype": CANONICAL_BF16_DTYPE,
                 "attention_backend": "math",
+                "acceleration_policy": {
+                    "enabled": ["math"],
+                    "disabled": excluded_accelerations,
+                },
                 "command": f"contract-test {role} capture",
                 "forbidden_accelerations_disabled": True,
             },
@@ -398,9 +523,18 @@ def mutate_evidence(
     bundle_path: pathlib.Path,
     mutate_document: Callable[[dict[str, object]], None] | None = None,
     mutate_fixture: Callable[[dict[str, object]], None] | None = None,
+    fixture_layer: str | None = None,
 ) -> tuple[dict[str, object], pathlib.Path]:
     bundle = json.loads(bundle_path.read_text(encoding="utf-8"))
-    fixture = bundle["fixtures"][0]
+    fixture = (
+        bundle["fixtures"][0]
+        if fixture_layer is None
+        else next(
+            candidate
+            for candidate in bundle["fixtures"]
+            if candidate["layer"] == fixture_layer
+        )
+    )
     evidence_path = fixture_root / fixture["relative_path"]
     document = json.loads(evidence_path.read_text(encoding="utf-8"))
     if mutate_document is not None:
@@ -417,12 +551,64 @@ def record_by_key(records: list[dict[str, object]], key: str) -> dict[str, objec
     return next(record for record in records if record["key"] == key)
 
 
+def rehash_e2e_input(document: dict[str, object]) -> None:
+    document["input"]["sha256"] = canonical_json_sha256(
+        document["input"]["conformance"]
+    )
+
+
 def test_manifest_layer_contract(runner, tool, authorization_sha: str) -> None:
     manifest = tool.validate_manifest()
     manifest_layers = exact_manifest_layers(tool)
     assert set(runner.exact_layer_contracts(manifest)) == set(manifest_layers)
+    assert manifest_layers["tokenizer-processor"]["_pinned_provenance_values"] == {
+        "tokenizer-hash": (
+            "00c15d010418b4b43af4bf87555435e46a5bf6c1fc2cd4cc1c8c545375ca1547"
+        ),
+        "processor-hash": (
+            "44e3ff907049587aa580bb17f0374bb78e704e74efbf4626ed6366f4d15be287"
+        ),
+    }
+    bfloat16_max = float.fromhex("0x1.fep+127")
+    assert runner.is_exact_bfloat16(bfloat16_max)
+    assert runner.is_exact_bfloat16(-bfloat16_max)
+    assert not runner.is_exact_bfloat16(0.1)
+    assert runner.is_finite_float64(float.fromhex("0x1.fffffffffffffp+1023"))
+    assert runner.is_finite_float64(2**80)
+    assert not runner.is_finite_float64(2**80 + 1)
+
+    remapped_manifest = copy.deepcopy(manifest)
+    tokenizer_contract = next(
+        layer
+        for layer in remapped_manifest["fixture_layers"]
+        if layer["id"] == "tokenizer-processor"
+    )
+    tokenizer_contract["pinned_provenance"][0]["component_indexes"] = [
+        "official-license"
+    ]
+    expect_failure(
+        lambda: runner.exact_layer_contracts(remapped_manifest),
+        "invalid pinned provenance",
+    )
+    narrowed_alias_manifest = copy.deepcopy(manifest)
+    narrowed_alias_manifest["numerical_authority"]["excluded_acceleration_aliases"][
+        "fp8"
+    ].remove("float8")
+    expect_failure(
+        lambda: runner.exact_layer_contracts(narrowed_alias_manifest),
+        "invalid acceleration exclusions",
+    )
+    excluded_accelerations = runner.manifest_excluded_accelerations(manifest)
+    component_authorities = {
+        component["id"]: component["sha256"]
+        for component in manifest["component_indexes"]
+    }
 
     for layer, manifest_layer in manifest_layers.items():
+        assert manifest_layer["_required_component_authorities"]
+        assert set(manifest_layer["role_invariant_provenance"]).issubset(
+            manifest_layer["required_provenance"]
+        )
         for key, kind in TEST_MEASUREMENT_KINDS[layer].items():
             assert runner.MEASUREMENT_DTYPES[layer][key] == DTYPE_BY_KIND[kind]
 
@@ -430,6 +616,276 @@ def test_manifest_layer_contract(runner, tool, authorization_sha: str) -> None:
             document = layer_document(tool, role, authorization_sha, manifest_layer)
             tool.validate_layer_output(document, f"valid {role} {layer}")
             runner.validate_manifest_layer_evidence(document, manifest_layer, role)
+
+            wrong_encoding = copy.deepcopy(document)
+            wrong_encoding["adapter"]["tensor_hash_encoding"] = "partial-record-v1"
+            expect_failure(
+                lambda wrong_encoding=wrong_encoding, manifest_layer=manifest_layer, role=role: (
+                    runner.validate_manifest_layer_evidence(
+                        wrong_encoding, manifest_layer, role
+                    )
+                ),
+                "tensor hash encoding is not canonical",
+            )
+
+            for provenance_key in manifest_layer["_pinned_provenance_values"]:
+                unpinned = copy.deepcopy(document)
+                record_by_key(unpinned["provenance"], provenance_key)["value"] = (
+                    "f" * 64
+                )
+                expect_failure(
+                    lambda unpinned=unpinned, manifest_layer=manifest_layer, role=role: (
+                        runner.validate_manifest_layer_evidence(
+                            unpinned, manifest_layer, role
+                        )
+                    ),
+                    f"provenance {provenance_key!r} is not authority-pinned",
+                )
+
+        if len(manifest_layer["_required_component_authorities"]) > 1:
+            reordered_components = layer_document(
+                tool, "oracle", authorization_sha, manifest_layer
+            )
+            reordered_components["input"]["component_indexes"].reverse()
+            tool.validate_layer_output(
+                reordered_components, f"reordered component set {layer}"
+            )
+            runner.validate_manifest_layer_evidence(
+                reordered_components, manifest_layer, "oracle"
+            )
+
+        unrelated_component_id = next(
+            identifier
+            for identifier in component_authorities
+            if identifier not in manifest_layer["required_component_indexes"]
+        )
+        unrelated = layer_document(tool, "oracle", authorization_sha, manifest_layer)
+        unrelated["input"]["component_indexes"][0] = {
+            "id": unrelated_component_id,
+            "sha256": component_authorities[unrelated_component_id],
+        }
+        unrelated["input"]["component_index_sha256"] = component_authorities[
+            unrelated_component_id
+        ]
+        for provenance_key in ("component-index-hash", "component-index-hashes"):
+            if provenance_key not in manifest_layer["required_provenance"]:
+                continue
+            record_by_key(unrelated["provenance"], provenance_key)["value"] = (
+                runner.structured_provenance_value(unrelated, provenance_key)
+            )
+        tool.validate_layer_output(unrelated, f"globally valid unrelated {layer}")
+        expect_failure(
+            lambda unrelated=unrelated, manifest_layer=manifest_layer: (
+                runner.validate_manifest_layer_evidence(
+                    unrelated, manifest_layer, "oracle"
+                )
+            ),
+            "component authorities differ from the manifest",
+        )
+
+        extra_component = layer_document(
+            tool, "oracle", authorization_sha, manifest_layer
+        )
+        extra_component["input"]["component_indexes"].append(
+            {
+                "id": unrelated_component_id,
+                "sha256": component_authorities[unrelated_component_id],
+            }
+        )
+        tool.validate_layer_output(extra_component, f"extra component {layer}")
+        expect_failure(
+            lambda extra_component=extra_component, manifest_layer=manifest_layer: (
+                runner.validate_manifest_layer_evidence(
+                    extra_component, manifest_layer, "oracle"
+                )
+            ),
+            "component authorities differ from the manifest",
+        )
+
+        if len(manifest_layer["_required_component_authorities"]) > 1:
+            missing_one_component = layer_document(
+                tool, "oracle", authorization_sha, manifest_layer
+            )
+            missing_one_component["input"]["component_indexes"].pop()
+            tool.validate_layer_output(
+                missing_one_component, f"missing one component {layer}"
+            )
+            expect_failure(
+                lambda missing_one_component=missing_one_component, manifest_layer=manifest_layer: (
+                    runner.validate_manifest_layer_evidence(
+                        missing_one_component, manifest_layer, "oracle"
+                    )
+                ),
+                "component authorities differ from the manifest",
+            )
+
+        missing_components = layer_document(
+            tool, "oracle", authorization_sha, manifest_layer
+        )
+        del missing_components["input"]["component_indexes"]
+        tool.validate_layer_output(
+            missing_components, f"legacy component summary {layer}"
+        )
+        expect_failure(
+            lambda missing_components=missing_components, manifest_layer=manifest_layer: (
+                runner.validate_manifest_layer_evidence(
+                    missing_components, manifest_layer, "oracle"
+                )
+            ),
+            "non-empty component authority list",
+        )
+
+        if layer in E2E_LAYER_TASKS:
+            for role in ("oracle", "mold"):
+                unsigned_boundary = layer_document(
+                    tool, role, authorization_sha, manifest_layer
+                )
+                unsigned_boundary["input"]["conformance"]["seed"] = (
+                    runner.UNSIGNED_INT64_MAX
+                )
+                rehash_e2e_input(unsigned_boundary)
+                runner.validate_manifest_layer_evidence(
+                    unsigned_boundary, manifest_layer, role
+                )
+
+                unsigned_overflow = layer_document(
+                    tool, role, authorization_sha, manifest_layer
+                )
+                unsigned_overflow["input"]["conformance"]["seed"] = (
+                    runner.UNSIGNED_INT64_MAX + 1
+                )
+                rehash_e2e_input(unsigned_overflow)
+                expect_failure(
+                    lambda unsigned_overflow=unsigned_overflow, manifest_layer=manifest_layer, role=role: (
+                        runner.validate_manifest_layer_evidence(
+                            unsigned_overflow, manifest_layer, role
+                        )
+                    ),
+                    "seed must be unsigned int64",
+                )
+
+                dimension_overflow = layer_document(
+                    tool, role, authorization_sha, manifest_layer
+                )
+                dimension_overflow["input"]["conformance"]["width"] = 2**63
+                rehash_e2e_input(dimension_overflow)
+                expect_failure(
+                    lambda dimension_overflow=dimension_overflow, manifest_layer=manifest_layer, role=role: (
+                        runner.validate_manifest_layer_evidence(
+                            dimension_overflow, manifest_layer, role
+                        )
+                    ),
+                    "width must be a positive signed int64",
+                )
+
+            unhashed_input = layer_document(
+                tool, "oracle", authorization_sha, manifest_layer
+            )
+            unhashed_input["input"]["conformance"]["seed"] = 43
+            expect_failure(
+                lambda unhashed_input=unhashed_input, manifest_layer=manifest_layer: (
+                    runner.validate_manifest_layer_evidence(
+                        unhashed_input, manifest_layer, "oracle"
+                    )
+                ),
+                "input hash does not match canonical evidence",
+            )
+
+            semantic_mutations: list[
+                tuple[Callable[[dict[str, object]], None], str]
+            ] = [
+                (
+                    lambda document: document["input"]["conformance"].update(
+                        {
+                            "task": (
+                                "fl2va" if E2E_LAYER_TASKS[layer] == "t2va" else "t2va"
+                            )
+                        }
+                    ),
+                    "end-to-end input task is invalid",
+                ),
+                (
+                    lambda document: document["input"]["conformance"].update(
+                        {"width": 1279}
+                    ),
+                    "dimensions violate",
+                ),
+                (
+                    lambda document: document["input"]["conformance"].update(
+                        {"frames": 123}
+                    ),
+                    "frame contract is invalid",
+                ),
+                (
+                    lambda document: document["input"]["conformance"].update(
+                        {"fps": 25}
+                    ),
+                    "frame contract is invalid",
+                ),
+                (
+                    lambda document: document["input"]["conformance"][
+                        "video_sampler"
+                    ].update({"guidance": "1"}),
+                    "sampler contract is invalid",
+                ),
+                (
+                    lambda document: document["input"]["conformance"][
+                        "audio_sampler"
+                    ].update({"steps": 29}),
+                    "sampler contract is invalid",
+                ),
+                (
+                    lambda document: document["input"]["conformance"].update(
+                        {"negative_prompt_sha256": "f" * 64}
+                    ),
+                    "negative prompt must be absent",
+                ),
+            ]
+            if layer == "end-to-end-t2va":
+                semantic_mutations.append(
+                    (
+                        lambda document: document["input"]["conformance"].update(
+                            {
+                                "conditioning": [
+                                    {"role": "first-frame", "sha256": "f" * 64}
+                                ]
+                            }
+                        ),
+                        "T2VA input must not carry conditioning media",
+                    )
+                )
+            elif layer == "end-to-end-fl2va":
+                semantic_mutations.append(
+                    (
+                        lambda document: document["input"]["conformance"].update(
+                            {"conditioning": []}
+                        ),
+                        "FL2VA conditioning order is invalid",
+                    )
+                )
+            else:
+                semantic_mutations.append(
+                    (
+                        lambda document: document["input"]["conformance"].update(
+                            {"conditioning": []}
+                        ),
+                        "Ref2VA conditioning order is invalid",
+                    )
+                )
+            for mutate_input, expected_error in semantic_mutations:
+                invalid_input = layer_document(
+                    tool, "oracle", authorization_sha, manifest_layer
+                )
+                mutate_input(invalid_input)
+                rehash_e2e_input(invalid_input)
+                expect_failure(
+                    lambda invalid_input=invalid_input, manifest_layer=manifest_layer: (
+                        runner.validate_manifest_layer_evidence(
+                            invalid_input, manifest_layer, "oracle"
+                        )
+                    ),
+                    expected_error,
+                )
 
         generic = layer_document(tool, "oracle", authorization_sha, manifest_layer)
         generic["outputs"] = [output_fixture(layer, "activation", "activation")]
@@ -535,6 +991,143 @@ def test_manifest_layer_contract(runner, tool, authorization_sha: str) -> None:
                 "does not match structured evidence",
             )
 
+        if layer == "tokenizer-processor":
+            missing_acceleration_policy = layer_document(
+                tool, "oracle", authorization_sha, manifest_layer
+            )
+            del missing_acceleration_policy["environment"]["acceleration_policy"]
+            expect_failure(
+                lambda: runner.validate_manifest_layer_evidence(
+                    missing_acceleration_policy,
+                    manifest_layer,
+                    "oracle",
+                    excluded_accelerations,
+                ),
+                "lacks structured acceleration evidence",
+            )
+
+        for excluded_acceleration in sorted(excluded_accelerations):
+            missing_exclusion = layer_document(
+                tool, "oracle", authorization_sha, manifest_layer
+            )
+            missing_exclusion["environment"]["acceleration_policy"]["disabled"].remove(
+                excluded_acceleration
+            )
+            expect_failure(
+                lambda missing_exclusion=missing_exclusion, manifest_layer=manifest_layer: (
+                    runner.validate_manifest_layer_evidence(
+                        missing_exclusion,
+                        manifest_layer,
+                        "oracle",
+                        excluded_accelerations,
+                    )
+                ),
+                "does not disable every manifest-excluded acceleration",
+            )
+
+            enabled_exclusion = layer_document(
+                tool, "oracle", authorization_sha, manifest_layer
+            )
+            enabled_exclusion["environment"]["acceleration_policy"]["enabled"].append(
+                excluded_acceleration
+            )
+            expect_failure(
+                lambda enabled_exclusion=enabled_exclusion, manifest_layer=manifest_layer: (
+                    runner.validate_manifest_layer_evidence(
+                        enabled_exclusion,
+                        manifest_layer,
+                        "oracle",
+                        excluded_accelerations,
+                    )
+                ),
+                "enables a manifest-excluded acceleration",
+            )
+
+        for excluded_alias in ("float8-e4m3fn", "sage-attn", "euler-ancestral"):
+            enabled_alias = layer_document(
+                tool, "oracle", authorization_sha, manifest_layer
+            )
+            enabled_alias["environment"]["acceleration_policy"]["enabled"].append(
+                excluded_alias
+            )
+            expect_failure(
+                lambda enabled_alias=enabled_alias, manifest_layer=manifest_layer: (
+                    runner.validate_manifest_layer_evidence(
+                        enabled_alias,
+                        manifest_layer,
+                        "oracle",
+                        excluded_accelerations,
+                    )
+                ),
+                "enables a manifest-excluded acceleration",
+            )
+
+        if layer == "tokenizer-processor":
+            for policy_mutation in ("duplicate", "uppercase"):
+                noncanonical_policy = layer_document(
+                    tool, "oracle", authorization_sha, manifest_layer
+                )
+                disabled = noncanonical_policy["environment"]["acceleration_policy"][
+                    "disabled"
+                ]
+                if policy_mutation == "duplicate":
+                    disabled.append(disabled[0])
+                else:
+                    disabled[0] = disabled[0].upper()
+                expect_failure(
+                    lambda noncanonical_policy=noncanonical_policy: (
+                        runner.validate_manifest_layer_evidence(
+                            noncanonical_policy,
+                            manifest_layer,
+                            "oracle",
+                            excluded_accelerations,
+                        )
+                    ),
+                    "structured acceleration evidence is not canonical",
+                )
+
+        if "attention-backend" in manifest_layer["required_provenance"]:
+            excluded_backend = next(iter(excluded_accelerations))
+            excluded = layer_document(tool, "oracle", authorization_sha, manifest_layer)
+            excluded["environment"]["attention_backend"] = excluded_backend
+            record_by_key(excluded["provenance"], "attention-backend")["value"] = (
+                excluded_backend
+            )
+            expect_failure(
+                lambda excluded=excluded, manifest_layer=manifest_layer: (
+                    runner.validate_manifest_layer_evidence(
+                        excluded,
+                        manifest_layer,
+                        "oracle",
+                        excluded_accelerations,
+                    )
+                ),
+                "manifest-excluded acceleration",
+            )
+            for excluded_alias in (
+                "float8-e4m3fn",
+                "sage-attn",
+                "euler-ancestral",
+            ):
+                excluded = layer_document(
+                    tool, "oracle", authorization_sha, manifest_layer
+                )
+                excluded["environment"]["attention_backend"] = excluded_alias
+                record_by_key(excluded["provenance"], "attention-backend")["value"] = (
+                    excluded_alias
+                )
+                expect_failure(
+                    lambda excluded=excluded, manifest_layer=manifest_layer: (
+                        runner.validate_manifest_layer_evidence(
+                            excluded,
+                            manifest_layer,
+                            "oracle",
+                            excluded_accelerations,
+                        )
+                    ),
+                    "manifest-excluded acceleration",
+                )
+
         for measurement in manifest_layer["required_measurements"]:
             missing = layer_document(tool, "oracle", authorization_sha, manifest_layer)
             missing["outputs"] = [
@@ -586,6 +1179,68 @@ def test_manifest_layer_contract(runner, tool, authorization_sha: str) -> None:
                 ),
                 "dtype must be",
             )
+
+            for role in ("oracle", "mold"):
+                for summary_key in ("mean", "std"):
+                    summary_overflow = layer_document(
+                        tool, role, authorization_sha, manifest_layer
+                    )
+                    record_by_key(summary_overflow["outputs"], measurement)[
+                        "statistics"
+                    ][summary_key] = 10**400
+                    expect_failure(
+                        lambda summary_overflow=summary_overflow, manifest_layer=manifest_layer, role=role: (
+                            runner.validate_manifest_layer_evidence(
+                                summary_overflow, manifest_layer, role
+                            )
+                        ),
+                        "summary is outside the finite float64 domain",
+                    )
+
+                if kind == "activation":
+                    for invalid_value in (0.1, 10**100):
+                        for location in ("min", "max", "sample"):
+                            invalid_activation = layer_document(
+                                tool, role, authorization_sha, manifest_layer
+                            )
+                            activation_output = record_by_key(
+                                invalid_activation["outputs"], measurement
+                            )
+                            if location == "sample":
+                                activation_output["samples"][0]["value"] = invalid_value
+                            else:
+                                activation_output["statistics"][location] = (
+                                    invalid_value
+                                )
+                            expect_failure(
+                                lambda invalid_activation=invalid_activation, manifest_layer=manifest_layer, role=role: (
+                                    runner.validate_manifest_layer_evidence(
+                                        invalid_activation, manifest_layer, role
+                                    )
+                                ),
+                                "must be exact bfloat16",
+                            )
+                elif kind == "metric":
+                    for invalid_value in (10**400, 2**80 + 1):
+                        for location in ("min", "max", "sample"):
+                            invalid_metric = layer_document(
+                                tool, role, authorization_sha, manifest_layer
+                            )
+                            metric_output = record_by_key(
+                                invalid_metric["outputs"], measurement
+                            )
+                            if location == "sample":
+                                metric_output["samples"][0]["value"] = invalid_value
+                            else:
+                                metric_output["statistics"][location] = invalid_value
+                            expect_failure(
+                                lambda invalid_metric=invalid_metric, manifest_layer=manifest_layer, role=role: (
+                                    runner.validate_manifest_layer_evidence(
+                                        invalid_metric, manifest_layer, role
+                                    )
+                                ),
+                                "must be finite float64",
+                            )
 
             if kind == "integer":
                 fractional_sample = layer_document(
@@ -646,6 +1301,53 @@ def test_manifest_layer_contract(runner, tool, authorization_sha: str) -> None:
                     fractional_summary, manifest_layer, "oracle"
                 )
 
+                for role in ("oracle", "mold"):
+                    bounded = layer_document(
+                        tool, role, authorization_sha, manifest_layer
+                    )
+                    bounded_output = record_by_key(bounded["outputs"], measurement)
+                    bounded_output["statistics"]["min"] = runner.SIGNED_INT64_MIN
+                    bounded_output["statistics"]["max"] = runner.SIGNED_INT64_MAX
+                    bounded_output["samples"][0]["value"] = runner.SIGNED_INT64_MIN
+                    bounded_output["samples"][1]["value"] = runner.SIGNED_INT64_MAX
+                    runner.validate_manifest_layer_evidence(
+                        bounded, manifest_layer, role
+                    )
+
+                    for field, value in (
+                        ("min", runner.SIGNED_INT64_MIN - 1),
+                        ("max", runner.SIGNED_INT64_MAX + 1),
+                    ):
+                        overflow = layer_document(
+                            tool, role, authorization_sha, manifest_layer
+                        )
+                        record_by_key(overflow["outputs"], measurement)["statistics"][
+                            field
+                        ] = value
+                        expect_failure(
+                            lambda overflow=overflow, manifest_layer=manifest_layer, role=role: (
+                                runner.validate_manifest_layer_evidence(
+                                    overflow, manifest_layer, role
+                                )
+                            ),
+                            "signed int64",
+                        )
+
+                    sample_overflow = layer_document(
+                        tool, role, authorization_sha, manifest_layer
+                    )
+                    record_by_key(sample_overflow["outputs"], measurement)["samples"][
+                        0
+                    ]["value"] = runner.SIGNED_INT64_MAX + 1
+                    expect_failure(
+                        lambda sample_overflow=sample_overflow, manifest_layer=manifest_layer, role=role: (
+                            runner.validate_manifest_layer_evidence(
+                                sample_overflow, manifest_layer, role
+                            )
+                        ),
+                        "signed int64",
+                    )
+
             wrong_policy = layer_document(
                 tool, "oracle", authorization_sha, manifest_layer
             )
@@ -665,11 +1367,28 @@ def test_manifest_layer_contract(runner, tool, authorization_sha: str) -> None:
                 expected_policy_error,
             )
 
+            if kind != "integer":
+                for policy_key in ("absolute", "relative"):
+                    overflow_policy = layer_document(
+                        tool, "oracle", authorization_sha, manifest_layer
+                    )
+                    record_by_key(overflow_policy["comparison"], measurement)[
+                        policy_key
+                    ] = 10**400
+                    expect_failure(
+                        lambda overflow_policy=overflow_policy, manifest_layer=manifest_layer: (
+                            runner.validate_manifest_layer_evidence(
+                                overflow_policy, manifest_layer, "oracle"
+                            )
+                        ),
+                        "bounded protected policy",
+                    )
+
             wrong_hash_policy = layer_document(
                 tool, "oracle", authorization_sha, manifest_layer
             )
             hash_policy = record_by_key(wrong_hash_policy["comparison"], measurement)
-            hash_policy["hash_policy"] = "record-only" if kind == "integer" else "exact"
+            hash_policy["hash_policy"] = "record-only"
             expect_failure(
                 lambda wrong_hash_policy=wrong_hash_policy, manifest_layer=manifest_layer: (
                     runner.validate_manifest_layer_evidence(
@@ -689,15 +1408,58 @@ def test_manifest_layer_contract(runner, tool, authorization_sha: str) -> None:
                 "metric": first_policy["metric"],
             }
         }
-        runner.validate_oracle_mold_policy_parity(oracle, fixture, mold, fixture)
+        runner.validate_oracle_mold_policy_parity(
+            oracle, fixture, mold, fixture, manifest_layer
+        )
         mismatched_mold = copy.deepcopy(mold)
         mismatched_mold["outputs"][0]["dtype"] = "float32"
         expect_failure(
             lambda: runner.validate_oracle_mold_policy_parity(
-                oracle, fixture, mismatched_mold, fixture
+                oracle, fixture, mismatched_mold, fixture, manifest_layer
             ),
             "dtypes differ",
         )
+
+        mismatched_hash = copy.deepcopy(mold)
+        mismatched_hash["outputs"][0]["content_sha256"] = "f" * 64
+        expect_failure(
+            lambda: runner.validate_oracle_mold_policy_parity(
+                oracle, fixture, mismatched_hash, fixture, manifest_layer
+            ),
+            "content hashes differ",
+        )
+
+        if layer in E2E_LAYER_TASKS:
+            mismatched_input = copy.deepcopy(mold)
+            mismatched_input["input"]["conformance"]["seed"] = 43
+            rehash_e2e_input(mismatched_input)
+            runner.validate_manifest_layer_evidence(
+                mismatched_input, manifest_layer, "mold"
+            )
+            expect_failure(
+                lambda: runner.validate_oracle_mold_policy_parity(
+                    oracle, fixture, mismatched_input, fixture, manifest_layer
+                ),
+                "input hashes differ",
+            )
+
+        for provenance_key in manifest_layer["role_invariant_provenance"]:
+            mismatched_provenance = copy.deepcopy(mold)
+            record_by_key(mismatched_provenance["provenance"], provenance_key)[
+                "value"
+            ] += "-mold-drift"
+            expect_failure(
+                lambda mismatched_provenance=mismatched_provenance: (
+                    runner.validate_oracle_mold_policy_parity(
+                        oracle,
+                        fixture,
+                        mismatched_provenance,
+                        fixture,
+                        manifest_layer,
+                    )
+                ),
+                f"provenance {provenance_key!r} differs",
+            )
 
 
 def test_runner_contract(runner, tool, temporary: pathlib.Path) -> None:
@@ -841,6 +1603,131 @@ def test_runner_contract(runner, tool, temporary: pathlib.Path) -> None:
         )
 
         environment, _, mold_bundle = reset_campaign()
+        excluded_accelerations = runner.manifest_excluded_accelerations(
+            tool.validate_manifest()
+        )
+        valid_capture_bundle = json.loads(mold_bundle.read_text(encoding="utf-8"))
+        missing_capture_policy = copy.deepcopy(valid_capture_bundle)
+        del missing_capture_policy["capture_environment"]["acceleration_policy"]
+        expect_failure(
+            lambda: runner.validate_capture_environment(
+                tool,
+                missing_capture_policy,
+                "mold",
+                SOURCE_SHA,
+                excluded_accelerations,
+            ),
+            "lacks structured acceleration evidence",
+        )
+        for excluded_acceleration in sorted(excluded_accelerations):
+            missing_exclusion = copy.deepcopy(valid_capture_bundle)
+            missing_exclusion["capture_environment"]["acceleration_policy"][
+                "disabled"
+            ].remove(excluded_acceleration)
+            expect_failure(
+                lambda missing_exclusion=missing_exclusion: (
+                    runner.validate_capture_environment(
+                        tool,
+                        missing_exclusion,
+                        "mold",
+                        SOURCE_SHA,
+                        excluded_accelerations,
+                    )
+                ),
+                "does not disable every manifest-excluded acceleration",
+            )
+
+            enabled_exclusion = copy.deepcopy(valid_capture_bundle)
+            enabled_exclusion["capture_environment"]["acceleration_policy"][
+                "enabled"
+            ].append(excluded_acceleration)
+            expect_failure(
+                lambda enabled_exclusion=enabled_exclusion: (
+                    runner.validate_capture_environment(
+                        tool,
+                        enabled_exclusion,
+                        "mold",
+                        SOURCE_SHA,
+                        excluded_accelerations,
+                    )
+                ),
+                "enables a manifest-excluded acceleration",
+            )
+
+        duplicate_exclusion = copy.deepcopy(valid_capture_bundle)
+        duplicate_exclusion["capture_environment"]["acceleration_policy"][
+            "disabled"
+        ].append(sorted(excluded_accelerations)[0])
+        expect_failure(
+            lambda: runner.validate_capture_environment(
+                tool,
+                duplicate_exclusion,
+                "mold",
+                SOURCE_SHA,
+                excluded_accelerations,
+            ),
+            "structured acceleration evidence is not canonical",
+        )
+
+        uppercase_exclusion = copy.deepcopy(valid_capture_bundle)
+        uppercase_exclusion["capture_environment"]["acceleration_policy"]["disabled"][
+            0
+        ] = uppercase_exclusion["capture_environment"]["acceleration_policy"][
+            "disabled"
+        ][0].upper()
+        expect_failure(
+            lambda: runner.validate_capture_environment(
+                tool,
+                uppercase_exclusion,
+                "mold",
+                SOURCE_SHA,
+                excluded_accelerations,
+            ),
+            "structured acceleration evidence is not canonical",
+        )
+
+        excluded_backend = sorted(excluded_accelerations)[0]
+        capture_backend = json.loads(mold_bundle.read_text(encoding="utf-8"))
+        capture_backend["capture_environment"]["attention_backend"] = excluded_backend
+        write_json(mold_bundle, capture_backend)
+        expect_failure(
+            lambda: runner.run_campaign(environment, lambda: None, lambda: SOURCE_SHA),
+            "manifest-excluded acceleration",
+        )
+
+        for excluded_alias in ("float8-e4m3fn", "euler-ancestral"):
+            environment, _, mold_bundle = reset_campaign()
+            capture_alias = json.loads(mold_bundle.read_text(encoding="utf-8"))
+            capture_alias["capture_environment"]["acceleration_policy"][
+                "enabled"
+            ].append(excluded_alias)
+            write_json(mold_bundle, capture_alias)
+            expect_failure(
+                lambda: runner.run_campaign(
+                    environment, lambda: None, lambda: SOURCE_SHA
+                ),
+                "enables a manifest-excluded acceleration",
+            )
+
+        environment, _, mold_bundle = reset_campaign()
+
+        def drift_layer_acceleration_summary(document: dict[str, object]) -> None:
+            document["environment"]["acceleration_policy"]["enabled"].append(
+                "dense-math"
+            )
+
+        mutate_evidence(
+            fixture_root,
+            mold_bundle,
+            drift_layer_acceleration_summary,
+            fixture_layer="qwen-layer-50",
+        )
+        expect_failure(
+            lambda: runner.run_campaign(environment, lambda: None, lambda: SOURCE_SHA),
+            "layer acceleration policy differs from its bundle",
+        )
+
+        environment, _, mold_bundle = reset_campaign()
         mutate_evidence(
             fixture_root,
             mold_bundle,
@@ -849,6 +1736,44 @@ def test_runner_contract(runner, tool, temporary: pathlib.Path) -> None:
         expect_failure(
             lambda: runner.run_campaign(environment, lambda: None, lambda: SOURCE_SHA),
             "layer environment dtype",
+        )
+
+        environment, _, mold_bundle = reset_campaign()
+
+        def use_excluded_backend(document: dict[str, object]) -> None:
+            document["environment"]["attention_backend"] = excluded_backend
+            record_by_key(document["provenance"], "attention-backend")["value"] = (
+                excluded_backend
+            )
+
+        mutate_evidence(
+            fixture_root,
+            mold_bundle,
+            use_excluded_backend,
+            fixture_layer="transformer-block",
+        )
+        expect_failure(
+            lambda: runner.run_campaign(environment, lambda: None, lambda: SOURCE_SHA),
+            "manifest-excluded acceleration",
+        )
+
+        environment, _, mold_bundle = reset_campaign()
+
+        def use_excluded_backend_alias(document: dict[str, object]) -> None:
+            document["environment"]["attention_backend"] = "sage-attn"
+            record_by_key(document["provenance"], "attention-backend")["value"] = (
+                "sage-attn"
+            )
+
+        mutate_evidence(
+            fixture_root,
+            mold_bundle,
+            use_excluded_backend_alias,
+            fixture_layer="transformer-block",
+        )
+        expect_failure(
+            lambda: runner.run_campaign(environment, lambda: None, lambda: SOURCE_SHA),
+            "manifest-excluded acceleration",
         )
 
         environment, _, mold_bundle = reset_campaign()
@@ -862,6 +1787,60 @@ def test_runner_contract(runner, tool, temporary: pathlib.Path) -> None:
             lambda: runner.run_campaign(environment, lambda: None, lambda: SOURCE_SHA),
             "dtype must be",
         )
+
+        for output_key, location, invalid_value, expected_error in (
+            (
+                "sampled-values",
+                "sample",
+                10**100,
+                "must be exact bfloat16",
+            ),
+            (
+                "statistics",
+                "sample",
+                10**400,
+                "must be finite float64",
+            ),
+            (
+                "statistics",
+                "sample",
+                2**80 + 1,
+                "must be finite float64",
+            ),
+            (
+                "sampled-values",
+                "mean",
+                10**400,
+                "summary is outside the finite float64 domain",
+            ),
+        ):
+            environment, _, mold_bundle = reset_campaign()
+
+            def violate_numeric_domain(
+                document: dict[str, object],
+                output_key: str = output_key,
+                location: str = location,
+                invalid_value: int = invalid_value,
+            ) -> None:
+                output = record_by_key(document["outputs"], output_key)
+                if location == "sample":
+                    output["samples"][0]["value"] = invalid_value
+                else:
+                    output["statistics"][location] = invalid_value
+                    output["statistics"]["max"] = invalid_value
+
+            mutate_evidence(
+                fixture_root,
+                mold_bundle,
+                violate_numeric_domain,
+                fixture_layer="qwen-layer-50",
+            )
+            expect_failure(
+                lambda: runner.run_campaign(
+                    environment, lambda: None, lambda: SOURCE_SHA
+                ),
+                expected_error,
+            )
 
         environment, _, mold_bundle = reset_campaign()
         mutate_evidence(
@@ -910,6 +1889,164 @@ def test_runner_contract(runner, tool, temporary: pathlib.Path) -> None:
         expect_failure(
             lambda: runner.run_campaign(environment, lambda: None, lambda: SOURCE_SHA),
             "policy",
+        )
+
+        environment, oracle_bundle, _ = reset_campaign()
+
+        def overflow_floating_policy(document: dict[str, object]) -> None:
+            record_by_key(document["comparison"], "sampled-values")["absolute"] = (
+                10**400
+            )
+
+        mutate_evidence(
+            fixture_root,
+            oracle_bundle,
+            overflow_floating_policy,
+            fixture_layer="qwen-layer-50",
+        )
+        expect_failure(
+            lambda: runner.run_campaign(environment, lambda: None, lambda: SOURCE_SHA),
+            "bounded protected policy",
+        )
+
+        environment, _, mold_bundle = reset_campaign()
+
+        def change_floating_content_hash(document: dict[str, object]) -> None:
+            record_by_key(document["outputs"], "sampled-values")["content_sha256"] = (
+                "f" * 64
+            )
+
+        mutate_evidence(
+            fixture_root,
+            mold_bundle,
+            change_floating_content_hash,
+            fixture_layer="qwen-layer-50",
+        )
+        expect_failure(
+            lambda: runner.run_campaign(environment, lambda: None, lambda: SOURCE_SHA),
+            "content hashes differ",
+        )
+
+        environment, _, mold_bundle = reset_campaign()
+
+        def change_seed(document: dict[str, object]) -> None:
+            record_by_key(document["provenance"], "seed")["value"] = "43"
+
+        mutate_evidence(
+            fixture_root,
+            mold_bundle,
+            change_seed,
+            fixture_layer="noise-allocation",
+        )
+        expect_failure(
+            lambda: runner.run_campaign(environment, lambda: None, lambda: SOURCE_SHA),
+            "provenance 'seed' differs",
+        )
+
+        for provenance_key in ("tokenizer-hash", "processor-hash"):
+            environment, oracle_bundle, mold_bundle = reset_campaign()
+
+            def forge_pinned_provenance(
+                document: dict[str, object], provenance_key: str = provenance_key
+            ) -> None:
+                record_by_key(document["provenance"], provenance_key)["value"] = (
+                    "f" * 64
+                )
+
+            mutate_evidence(
+                fixture_root,
+                oracle_bundle,
+                forge_pinned_provenance,
+                fixture_layer="tokenizer-processor",
+            )
+            mutate_evidence(
+                fixture_root,
+                mold_bundle,
+                forge_pinned_provenance,
+                fixture_layer="tokenizer-processor",
+            )
+            expect_failure(
+                lambda: runner.run_campaign(
+                    environment, lambda: None, lambda: SOURCE_SHA
+                ),
+                f"provenance {provenance_key!r} is not authority-pinned",
+            )
+
+        environment, _, mold_bundle = reset_campaign()
+
+        def change_e2e_seed_without_hash(document: dict[str, object]) -> None:
+            document["input"]["conformance"]["seed"] = 43
+
+        mutate_evidence(
+            fixture_root,
+            mold_bundle,
+            change_e2e_seed_without_hash,
+            fixture_layer="end-to-end-t2va",
+        )
+        expect_failure(
+            lambda: runner.run_campaign(environment, lambda: None, lambda: SOURCE_SHA),
+            "input hash does not match canonical evidence",
+        )
+
+        environment, _, mold_bundle = reset_campaign()
+
+        def change_e2e_seed_and_hash(document: dict[str, object]) -> None:
+            document["input"]["conformance"]["seed"] = 43
+            rehash_e2e_input(document)
+
+        mutate_evidence(
+            fixture_root,
+            mold_bundle,
+            change_e2e_seed_and_hash,
+            fixture_layer="end-to-end-t2va",
+        )
+        expect_failure(
+            lambda: runner.run_campaign(environment, lambda: None, lambda: SOURCE_SHA),
+            "input hashes differ",
+        )
+
+        environment, _, mold_bundle = reset_campaign()
+        manifest = tool.validate_manifest()
+        component_authorities = {
+            component["id"]: component["sha256"]
+            for component in manifest["component_indexes"]
+        }
+        required_qwen_components = next(
+            layer["required_component_indexes"]
+            for layer in manifest["fixture_layers"]
+            if layer["id"] == "qwen-layer-50"
+        )
+        unrelated_component_id = next(
+            identifier
+            for identifier in component_authorities
+            if identifier not in required_qwen_components
+        )
+        unrelated_component = {
+            "id": unrelated_component_id,
+            "sha256": component_authorities[unrelated_component_id],
+        }
+
+        def use_unrelated_component(document: dict[str, object]) -> None:
+            document["input"]["component_indexes"] = [unrelated_component]
+            document["input"]["component_index_sha256"] = unrelated_component["sha256"]
+            record_by_key(document["provenance"], "component-index-hash")["value"] = (
+                unrelated_component["sha256"]
+            )
+
+        def bundle_unrelated_component(fixture: dict[str, object]) -> None:
+            fixture["component_indexes"] = [unrelated_component]
+            fixture["component_index_sha256"] = unrelated_component["sha256"]
+
+        mutate_evidence(
+            fixture_root,
+            mold_bundle,
+            use_unrelated_component,
+            bundle_unrelated_component,
+            fixture_layer="qwen-layer-50",
+        )
+        expect_failure(
+            lambda: runner.run_campaign(environment, lambda: None, lambda: SOURCE_SHA),
+            "component authorities differ from the manifest",
         )
 
         environment, _, mold_bundle = reset_campaign()
@@ -1013,6 +2150,10 @@ def test_workflow_contract() -> None:
         normalized_docs
     )
     assert "Discrete tokenizer, shape, layout" in normalized_docs
+    assert "structured capture attestation" in normalized_docs
+    assert "mold.minimax-h3.component-authority-set.v1" in normalized_docs
+    assert "mold.minimax-h3.e2e-input.v1" in normalized_docs
+    assert "No fixed prompt, media set, seed, dimensions" in normalized_docs
     assert REVIEWED_AUTHORIZATION_EVIDENCE_SHA256 in qualification_docs
 
     ci = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")

--- a/scripts/tests/minimax-h3-gpu-conformance-contract.py
+++ b/scripts/tests/minimax-h3-gpu-conformance-contract.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import copy
 import hashlib
 import importlib.util
 import json
@@ -19,6 +18,11 @@ WORKFLOW_PATH = (
     REPO_ROOT / ".github" / "workflows" / "minimax-h3-private-conformance.yml"
 )
 SOURCE_SHA = "a" * 40
+REVIEWED_AUTHORIZATION_EVIDENCE_SHA256 = (
+    "8cd4d6e52cff34d7d39721ebab13b8c1187aa87aafc1c4ae2a16609186f22f1d"
+)
+CHECKOUT_V6_SHA = "d23441a48e516b6c34aea4fa41551a30e30af803"
+CANONICAL_BF16_DTYPE = "bfloat16"
 
 
 def load_module(path: pathlib.Path, name: str):
@@ -48,10 +52,16 @@ def expect_failure(action: Callable[[], object], fragment: str) -> None:
         raise AssertionError(f"expected failure containing {fragment!r}")
 
 
-def authorization_fixture(tool, root: pathlib.Path) -> tuple[pathlib.Path, str]:
-    source = root / "authorization-source.txt"
-    source.write_text("private conformance contract fixture\n", encoding="utf-8")
-    source_sha = sha256(source)
+def authorization_fixture(
+    tool,
+    root: pathlib.Path,
+    *,
+    name: str = "reviewed",
+    reviewed: bool = True,
+) -> tuple[pathlib.Path, pathlib.Path, str]:
+    source = root / f"{name}-authorization-source.bin"
+    source.write_bytes(f"{name} contract evidence".encode())
+    source_sha = REVIEWED_AUTHORIZATION_EVIDENCE_SHA256 if reviewed else sha256(source)
     record = {
         "schema_version": tool.AUTHORIZATION_SCHEMA_VERSION,
         "family": "minimax-h3",
@@ -67,32 +77,93 @@ def authorization_fixture(tool, root: pathlib.Path) -> tuple[pathlib.Path, str]:
         "source_document_sha256": source_sha,
         "review_reference": "contract-test-only",
     }
-    path = root / "authorization.json"
+    path = root / f"{name}-authorization.json"
     write_json(path, record)
-    return path, source_sha
+    return path, source, source_sha
 
 
 def layer_document(
     tool,
     role: str,
     authorization_sha: str,
+    layer: str,
 ) -> dict[str, object]:
-    fixture_path = (
-        tool.SYNTHETIC_ORACLE_PATH if role == "oracle" else tool.SYNTHETIC_MOLD_PATH
-    )
-    document = json.loads(fixture_path.read_text(encoding="utf-8"))
-    document["case_id"] = "gpu-contract-case"
-    document["authority_tier"] = "exact-full-bf16"
-    document["authorization_document_sha256"] = authorization_sha
-    document["environment"] = {
-        "device": "cuda:contract-test",
-        "dtype": "bfloat16",
-        "attention_backend": "math",
-        "forbidden_accelerations_disabled": True,
+    component_sha = next(iter(tool.EXPECTED_COMPONENT_INDEXES.values()))[1]
+    output = {
+        "key": "activation",
+        "shape": [2],
+        "dtype": CANONICAL_BF16_DTYPE,
+        "content_sha256": hashlib.sha256(
+            f"gpu-contract:{layer}:activation".encode()
+        ).hexdigest(),
+        "statistics": {
+            "min": 0.25,
+            "max": 0.75,
+            "mean": 0.5,
+            "std": 0.25,
+        },
+        "samples": [
+            {"index": [0], "value": 0.25},
+            {"index": [1], "value": 0.75},
+        ],
     }
-    if role == "mold":
-        document["producer"]["revision"] = SOURCE_SHA
+    document: dict[str, object] = {
+        "schema_version": tool.LAYER_OUTPUT_SCHEMA_VERSION,
+        "family": "minimax-h3",
+        "case_id": "gpu-contract-case",
+        "layer": layer,
+        "authority_tier": "exact-full-bf16",
+        "authorization_document_sha256": authorization_sha,
+        "input": {
+            "id": f"gpu-contract-{layer}",
+            "sha256": hashlib.sha256(f"input:{layer}".encode()).hexdigest(),
+            "component_index_sha256": component_sha,
+        },
+        "producer": {
+            "role": role,
+            "implementation": f"contract-{role}",
+            "source_id": "diffusers" if role == "oracle" else "mold",
+            "revision": (
+                tool.EXPECTED_REVISIONS["diffusers"] if role == "oracle" else SOURCE_SHA
+            ),
+        },
+        "adapter": {
+            "schema_version": "mold.minimax-h3.layer-adapter.v1",
+            "id": f"contract-{role}-adapter",
+            "command": f"contract-test {role} {layer} capture",
+            "tensor_hash_encoding": "canonical-bf16-le-v1",
+        },
+        "environment": {
+            "device": "cuda:contract-test",
+            "dtype": CANONICAL_BF16_DTYPE,
+            "attention_backend": "math",
+            "forbidden_accelerations_disabled": True,
+        },
+        "outputs": [output],
+    }
+    if role == "oracle":
+        document["comparison"] = [
+            {
+                "key": "activation",
+                "absolute": 0.000002,
+                "relative": 0.000001,
+                "metric": "elementwise-atol-plus-rtol",
+                "hash_policy": "exact",
+            }
+        ]
     return document
+
+
+def exact_layer_ids(tool) -> list[str]:
+    manifest = tool.validate_manifest()
+    layers = [
+        layer["id"]
+        for layer in manifest["fixture_layers"]
+        if layer["authority_tier"] == "exact-full-bf16"
+    ]
+    assert len(layers) == 11
+    assert "dual-sampler" not in layers
+    return layers
 
 
 def bundle_fixture(
@@ -103,31 +174,25 @@ def bundle_fixture(
     manifest_sha = sha256(tool.MANIFEST_PATH)
     bundle_paths: list[pathlib.Path] = []
     for role in ("oracle", "mold"):
-        document = layer_document(tool, role, authorization_sha)
-        evidence_path = fixture_root / role / "gpu-contract-case.json"
-        write_json(evidence_path, document)
-        output = document["outputs"][0]
-        bundle = {
-            "schema_version": tool.BUNDLE_SCHEMA_VERSION,
-            "manifest_sha256": manifest_sha,
-            "authorization_document_sha256": authorization_sha,
-            "capture_environment": {
-                "framework": "diffusers" if role == "oracle" else "mold",
-                "framework_revision": (
-                    tool.EXPECTED_REVISIONS["diffusers"]
-                    if role == "oracle"
-                    else SOURCE_SHA
-                ),
-                "device": "cuda:contract-test",
-                "dtype": "bfloat16",
-                "attention_backend": "math",
-                "command": f"contract-test {role} capture",
-                "forbidden_accelerations_disabled": True,
-            },
-            "fixtures": [
+        fixtures = []
+        for layer in exact_layer_ids(tool):
+            document = layer_document(tool, role, authorization_sha, layer)
+            evidence_path = fixture_root / role / f"{layer}.json"
+            write_json(evidence_path, document)
+            output = document["outputs"][0]
+            comparison = (
+                document["comparison"][0]
+                if role == "oracle"
+                else {
+                    "absolute": 0.000002,
+                    "relative": 0.000001,
+                    "metric": "elementwise-atol-plus-rtol",
+                }
+            )
+            fixtures.append(
                 {
-                    "id": f"gpu-contract-case-{role}",
-                    "layer": document["layer"],
+                    "id": f"gpu-contract-{layer}-{role}",
+                    "layer": layer,
                     "authority_tier": document["authority_tier"],
                     "relative_path": str(evidence_path.relative_to(fixture_root)),
                     "sha256": sha256(evidence_path),
@@ -146,12 +211,30 @@ def bundle_fixture(
                         ],
                     },
                     "tolerance": {
-                        "absolute": 0.000002,
-                        "relative": 0.000001,
-                        "metric": "elementwise-atol-plus-rtol",
+                        "absolute": comparison["absolute"],
+                        "relative": comparison["relative"],
+                        "metric": comparison["metric"],
                     },
                 }
-            ],
+            )
+        bundle = {
+            "schema_version": tool.BUNDLE_SCHEMA_VERSION,
+            "manifest_sha256": manifest_sha,
+            "authorization_document_sha256": authorization_sha,
+            "capture_environment": {
+                "framework": "diffusers" if role == "oracle" else "mold",
+                "framework_revision": (
+                    tool.EXPECTED_REVISIONS["diffusers"]
+                    if role == "oracle"
+                    else SOURCE_SHA
+                ),
+                "device": "cuda:contract-test",
+                "dtype": CANONICAL_BF16_DTYPE,
+                "attention_backend": "math",
+                "command": f"contract-test {role} capture",
+                "forbidden_accelerations_disabled": True,
+            },
+            "fixtures": fixtures,
         }
         bundle_path = fixture_root / f"{role}-bundle.json"
         write_json(bundle_path, bundle)
@@ -174,107 +257,294 @@ def campaign_environment(
     }
 
 
+def mutate_evidence(
+    fixture_root: pathlib.Path,
+    bundle_path: pathlib.Path,
+    mutate_document: Callable[[dict[str, object]], None] | None = None,
+    mutate_fixture: Callable[[dict[str, object]], None] | None = None,
+) -> tuple[dict[str, object], pathlib.Path]:
+    bundle = json.loads(bundle_path.read_text(encoding="utf-8"))
+    fixture = bundle["fixtures"][0]
+    evidence_path = fixture_root / fixture["relative_path"]
+    document = json.loads(evidence_path.read_text(encoding="utf-8"))
+    if mutate_document is not None:
+        mutate_document(document)
+        write_json(evidence_path, document)
+        fixture["sha256"] = sha256(evidence_path)
+    if mutate_fixture is not None:
+        mutate_fixture(fixture)
+    write_json(bundle_path, bundle)
+    return bundle, evidence_path
+
+
 def test_runner_contract(runner, tool, temporary: pathlib.Path) -> None:
     fixture_root = temporary / "fixtures"
     fixture_root.mkdir()
-    authorization, authorization_sha = authorization_fixture(tool, temporary)
-    oracle_bundle, mold_bundle = bundle_fixture(tool, fixture_root, authorization_sha)
-    environment = campaign_environment(
-        fixture_root, authorization, oracle_bundle, mold_bundle
+    authorization, reviewed_source, authorization_sha = authorization_fixture(
+        tool, temporary
     )
+    original_sha256_file = tool.sha256_file
+    original_load_tool = runner.load_tool
 
-    expect_failure(
-        lambda: runner.resolve_external_file("authorization record", str(TOOL_PATH)),
-        "must live outside the Mold repository",
-    )
+    def controlled_sha256_file(path: pathlib.Path) -> str:
+        if pathlib.Path(path).resolve() == reviewed_source.resolve():
+            return REVIEWED_AUTHORIZATION_EVIDENCE_SHA256
+        return original_sha256_file(path)
 
-    expect_failure(
-        lambda: runner.run_campaign({}, lambda: None),
-        "MOLD_H3_FIXTURE_ROOT is required",
-    )
-    missing_authorization = dict(environment)
-    del missing_authorization["MOLD_H3_AUTHORIZATION_RECORD"]
-    expect_failure(
-        lambda: runner.run_campaign(missing_authorization, lambda: None),
-        "MOLD_H3_AUTHORIZATION_RECORD is required",
-    )
+    tool.sha256_file = controlled_sha256_file
+    runner.load_tool = lambda: tool
 
-    probes = 0
-
-    def counted_probe() -> None:
-        nonlocal probes
-        probes += 1
-
-    result = runner.run_campaign(environment, counted_probe, lambda: SOURCE_SHA)
-    assert result == {"comparisons": 1, "notes": 1, "source_sha": SOURCE_SHA}
-    assert probes == 1
-
-    expect_failure(
-        lambda: runner.run_campaign(environment, lambda: None, lambda: "b" * 40),
-        "checkout source SHA",
-    )
-
-    expect_failure(
-        lambda: runner.run_campaign(
-            environment,
-            lambda: (_ for _ in ()).throw(
-                runner.GpuConformanceFailure("CUDA probe failed")
+    def reset_campaign() -> tuple[dict[str, str], pathlib.Path, pathlib.Path]:
+        oracle_bundle, mold_bundle = bundle_fixture(
+            tool, fixture_root, authorization_sha
+        )
+        return (
+            campaign_environment(
+                fixture_root, authorization, oracle_bundle, mold_bundle
             ),
-            lambda: SOURCE_SHA,
-        ),
-        "CUDA probe failed",
-    )
+            oracle_bundle,
+            mold_bundle,
+        )
 
-    drifted_source = dict(environment)
-    drifted_source["MOLD_H3_SOURCE_SHA"] = "b" * 40
-    expect_failure(
-        lambda: runner.run_campaign(drifted_source, lambda: None, lambda: "b" * 40),
-        "Mold bundle framework revision",
-    )
+    try:
+        environment, oracle_bundle, mold_bundle = reset_campaign()
+        assert set(exact_layer_ids(tool)) == {
+            fixture["layer"]
+            for fixture in json.loads(oracle_bundle.read_text(encoding="utf-8"))[
+                "fixtures"
+            ]
+        }
 
-    mold_bundle_value = json.loads(mold_bundle.read_text(encoding="utf-8"))
-    mismatched_component = copy.deepcopy(mold_bundle_value)
-    mismatched_component["fixtures"][0]["component_index_sha256"] = "0" * 64
-    write_json(mold_bundle, mismatched_component)
-    expect_failure(
-        lambda: runner.run_campaign(environment, lambda: None, lambda: SOURCE_SHA),
-        "component index does not match",
-    )
-    write_json(mold_bundle, mold_bundle_value)
+        expect_failure(
+            lambda: runner.resolve_external_file(
+                "authorization record", str(TOOL_PATH)
+            ),
+            "must live outside the Mold repository",
+        )
+        expect_failure(
+            lambda: runner.run_campaign({}, lambda: None),
+            "MOLD_H3_FIXTURE_ROOT is required",
+        )
+        missing_authorization = dict(environment)
+        del missing_authorization["MOLD_H3_AUTHORIZATION_RECORD"]
+        expect_failure(
+            lambda: runner.run_campaign(missing_authorization, lambda: None),
+            "MOLD_H3_AUTHORIZATION_RECORD is required",
+        )
 
-    mold_document_path = (
-        fixture_root / mold_bundle_value["fixtures"][0]["relative_path"]
-    )
-    mold_document = json.loads(mold_document_path.read_text(encoding="utf-8"))
-    quantized_document = copy.deepcopy(mold_document)
-    quantized_document["authority_tier"] = "quantized-structural"
-    write_json(mold_document_path, quantized_document)
-    quantized_bundle = copy.deepcopy(mold_bundle_value)
-    quantized_bundle["fixtures"][0]["authority_tier"] = "quantized-structural"
-    quantized_bundle["fixtures"][0]["sha256"] = sha256(mold_document_path)
-    write_json(mold_bundle, quantized_bundle)
-    expect_failure(
-        lambda: runner.run_campaign(environment, lambda: None, lambda: SOURCE_SHA),
-        "exact-full-bf16",
-    )
+        probes = 0
 
-    synthetic_document = copy.deepcopy(mold_document)
-    synthetic_document["authority_tier"] = "synthetic"
-    synthetic_document["authorization_document_sha256"] = None
-    write_json(mold_document_path, synthetic_document)
-    synthetic_bundle = copy.deepcopy(mold_bundle_value)
-    synthetic_bundle["fixtures"][0]["authority_tier"] = "synthetic"
-    synthetic_bundle["fixtures"][0]["sha256"] = sha256(mold_document_path)
-    write_json(mold_bundle, synthetic_bundle)
-    expect_failure(
-        lambda: runner.run_campaign(environment, lambda: None, lambda: SOURCE_SHA),
-        "synthetic evidence is forbidden",
-    )
+        def counted_probe() -> None:
+            nonlocal probes
+            probes += 1
+
+        result = runner.run_campaign(environment, counted_probe, lambda: SOURCE_SHA)
+        assert result == {
+            "comparisons": 11,
+            "notes": 0,
+            "source_sha": SOURCE_SHA,
+        }
+        assert probes == 1
+
+        expect_failure(
+            lambda: runner.run_campaign(environment, lambda: None, lambda: "b" * 40),
+            "checkout source SHA",
+        )
+        expect_failure(
+            lambda: runner.run_campaign(
+                environment,
+                lambda: (_ for _ in ()).throw(
+                    runner.GpuConformanceFailure("CUDA probe failed")
+                ),
+                lambda: SOURCE_SHA,
+            ),
+            "CUDA probe failed",
+        )
+
+        drifted_source = dict(environment)
+        drifted_source["MOLD_H3_SOURCE_SHA"] = "b" * 40
+        expect_failure(
+            lambda: runner.run_campaign(drifted_source, lambda: None, lambda: "b" * 40),
+            "Mold bundle framework revision",
+        )
+
+        environment, _, mold_bundle = reset_campaign()
+        incomplete = json.loads(mold_bundle.read_text(encoding="utf-8"))
+        incomplete["fixtures"].pop()
+        write_json(mold_bundle, incomplete)
+        expect_failure(
+            lambda: runner.run_campaign(environment, lambda: None, lambda: SOURCE_SHA),
+            "complete exact layer coverage",
+        )
+
+        environment, _, mold_bundle = reset_campaign()
+
+        def relabel_synthetic_layer(document: dict[str, object]) -> None:
+            document["layer"] = "dual-sampler"
+
+        mutate_evidence(
+            fixture_root,
+            mold_bundle,
+            relabel_synthetic_layer,
+            lambda fixture: fixture.update({"layer": "dual-sampler"}),
+        )
+        expect_failure(
+            lambda: runner.run_campaign(environment, lambda: None, lambda: SOURCE_SHA),
+            "manifest authority tier",
+        )
+
+        environment, _, mold_bundle = reset_campaign()
+        mutate_evidence(
+            fixture_root,
+            mold_bundle,
+            lambda document: document.update(
+                {"authority_tier": "quantized-structural"}
+            ),
+            lambda fixture: fixture.update({"authority_tier": "quantized-structural"}),
+        )
+        expect_failure(
+            lambda: runner.run_campaign(environment, lambda: None, lambda: SOURCE_SHA),
+            "authority tier drifts from the manifest",
+        )
+
+        environment, _, mold_bundle = reset_campaign()
+        capture_dtype = json.loads(mold_bundle.read_text(encoding="utf-8"))
+        capture_dtype["capture_environment"]["dtype"] = "float32"
+        write_json(mold_bundle, capture_dtype)
+        expect_failure(
+            lambda: runner.run_campaign(environment, lambda: None, lambda: SOURCE_SHA),
+            "capture environment dtype",
+        )
+
+        environment, _, mold_bundle = reset_campaign()
+        mutate_evidence(
+            fixture_root,
+            mold_bundle,
+            lambda document: document["environment"].update({"dtype": "float32"}),
+        )
+        expect_failure(
+            lambda: runner.run_campaign(environment, lambda: None, lambda: SOURCE_SHA),
+            "layer environment dtype",
+        )
+
+        environment, _, mold_bundle = reset_campaign()
+        mutate_evidence(
+            fixture_root,
+            mold_bundle,
+            lambda document: document["outputs"][0].update({"dtype": "uint8"}),
+            lambda fixture: fixture["tensor"].update({"dtype": "uint8"}),
+        )
+        expect_failure(
+            lambda: runner.run_campaign(environment, lambda: None, lambda: SOURCE_SHA),
+            "output dtype",
+        )
+
+        environment, _, mold_bundle = reset_campaign()
+        mutate_evidence(
+            fixture_root,
+            mold_bundle,
+            mutate_fixture=lambda fixture: fixture["tensor"].update({"mean": 0.125}),
+        )
+        expect_failure(
+            lambda: runner.run_campaign(environment, lambda: None, lambda: SOURCE_SHA),
+            "bundle tensor summary",
+        )
+
+        environment, oracle_bundle, _ = reset_campaign()
+        mutate_evidence(
+            fixture_root,
+            oracle_bundle,
+            mutate_fixture=lambda fixture: fixture["tolerance"].update(
+                {"absolute": 0.000003}
+            ),
+        )
+        expect_failure(
+            lambda: runner.run_campaign(environment, lambda: None, lambda: SOURCE_SHA),
+            "bundle tolerance summary",
+        )
+
+        environment, _, mold_bundle = reset_campaign()
+        mutate_evidence(
+            fixture_root,
+            mold_bundle,
+            mutate_fixture=lambda fixture: fixture["tolerance"].update(
+                {"relative": 0.000002}
+            ),
+        )
+        expect_failure(
+            lambda: runner.run_campaign(environment, lambda: None, lambda: SOURCE_SHA),
+            "differs from oracle policy",
+        )
+
+        environment, oracle_bundle, _ = reset_campaign()
+        mutate_evidence(
+            fixture_root,
+            oracle_bundle,
+            lambda document: document["comparison"][0].update({"absolute": 1.0}),
+            lambda fixture: fixture["tolerance"].update({"absolute": 1.0}),
+        )
+        expect_failure(
+            lambda: runner.run_campaign(environment, lambda: None, lambda: SOURCE_SHA),
+            "bounded",
+        )
+
+        environment, _, mold_bundle = reset_campaign()
+        mismatched_component = json.loads(mold_bundle.read_text(encoding="utf-8"))
+        mismatched_component["fixtures"][0]["component_index_sha256"] = "0" * 64
+        write_json(mold_bundle, mismatched_component)
+        expect_failure(
+            lambda: runner.run_campaign(environment, lambda: None, lambda: SOURCE_SHA),
+            "component index does not match",
+        )
+
+        environment, _, _ = reset_campaign()
+        wrong_record, _, wrong_sha = authorization_fixture(
+            tool, temporary, name="self-consistent-wrong", reviewed=False
+        )
+        assert wrong_sha != REVIEWED_AUTHORIZATION_EVIDENCE_SHA256
+        wrong_environment = dict(environment)
+        wrong_environment["MOLD_H3_AUTHORIZATION_RECORD"] = str(wrong_record)
+        expect_failure(
+            lambda: runner.run_campaign(
+                wrong_environment, lambda: None, lambda: SOURCE_SHA
+            ),
+            "reviewed authorization evidence",
+        )
+
+        environment, _, mold_bundle = reset_campaign()
+        original_loader = runner.load_layer_documents
+        mutated_after_load = False
+
+        def mutating_loader(*args, **kwargs):
+            nonlocal mutated_after_load
+            loaded = original_loader(*args, **kwargs)
+            role = args[4]
+            if role == "mold" and not mutated_after_load:
+                bundle = args[3]
+                evidence_path = fixture_root / bundle["fixtures"][0]["relative_path"]
+                evidence_path.write_text("{}\n", encoding="utf-8")
+                mutated_after_load = True
+            return loaded
+
+        runner.load_layer_documents = mutating_loader
+        try:
+            result = runner.run_campaign(environment, lambda: None, lambda: SOURCE_SHA)
+        finally:
+            runner.load_layer_documents = original_loader
+        assert mutated_after_load
+        assert result["comparisons"] == 11
+    finally:
+        tool.sha256_file = original_sha256_file
+        runner.load_tool = original_load_tool
 
 
 def test_workflow_contract() -> None:
     workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
     actionlint = (REPO_ROOT / ".github" / "actionlint.yaml").read_text(encoding="utf-8")
+    qualification_docs = (
+        REPO_ROOT / "docs" / "qualification" / "minimax-h3-conformance.md"
+    ).read_text(encoding="utf-8")
+    normalized_docs = " ".join(qualification_docs.split())
     assert "workflow_dispatch:" in workflow
     for trigger in ("push:", "pull_request:", "schedule:", "workflow_run:"):
         assert f"  {trigger}" not in workflow
@@ -286,19 +556,31 @@ def test_workflow_contract() -> None:
     assert "expected_source_sha:" in workflow
     assert "\"$GITHUB_REF\" != 'refs/heads/main'" in workflow
     assert '"$GITHUB_SHA" != "$EXPECTED_SOURCE_SHA"' in workflow
+    assert f"uses: actions/checkout@{CHECKOUT_V6_SHA} # v6" in workflow
+    checkout_position = workflow.index(f"actions/checkout@{CHECKOUT_V6_SHA}")
+    validator_position = workflow.index(
+        "- name: Compare authorization-bound external captures"
+    )
+    assert checkout_position < validator_position
     for secret in (
         "MOLD_H3_FIXTURE_ROOT",
         "MOLD_H3_AUTHORIZATION_RECORD",
         "MOLD_H3_ORACLE_BUNDLE",
         "MOLD_H3_MOLD_BUNDLE",
     ):
-        assert f"secrets.{secret}" in workflow
+        assert workflow.count(f"secrets.{secret}") == 1
+        assert workflow.index(f"secrets.{secret}") > validator_position
     assert "MOLD_H3_SOURCE_SHA: ${{ github.sha }}" in workflow
     assert "python3 scripts/run-minimax-h3-gpu-conformance.py" in workflow
     assert "upload-artifact" not in workflow
     assert "h3-private-uat" not in workflow.replace("minimax-h3-private-uat", "")
     assert "    - cuda" in actionlint
     assert "    - minimax-h3-private-uat" in actionlint
+    assert "administrator prerequisite" in normalized_docs
+    assert "remains queued" in normalized_docs
+    assert "does not assert that either is currently configured" in normalized_docs
+    assert "persistent public-repository runner" in normalized_docs
+    assert REVIEWED_AUTHORIZATION_EVIDENCE_SHA256 in qualification_docs
 
     ci = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
     for path in (

--- a/tests/fixtures/minimax_h3/conformance-manifest.json
+++ b/tests/fixtures/minimax_h3/conformance-manifest.json
@@ -12,7 +12,25 @@
       "stochastic-sampling",
       "approximate-attention",
       "tf32"
-    ]
+    ],
+    "excluded_acceleration_aliases": {
+      "torch-compile": ["torch-compile", "torch-inductor", "inductor"],
+      "fp8": ["fp8", "float8", "e4m3", "e4m3fn", "e5m2"],
+      "cache-dit": ["cache-dit"],
+      "sageattention": ["sageattention", "sage-attn"],
+      "stochastic-sampling": [
+        "stochastic-sampling",
+        "stochastic",
+        "ancestral"
+      ],
+      "approximate-attention": [
+        "approximate-attention",
+        "approximate",
+        "approx-attn",
+        "approx"
+      ],
+      "tf32": ["tf32", "tensorfloat32"]
+    }
   },
   "sources": [
     {
@@ -113,6 +131,84 @@
       "source_id": "minimax-official-model",
       "relative_path": "audio_vae/config.json",
       "sha256": "9a3c645ff892b376c6f5f4c8685964cd75474731af594ff058492a0000caabb6"
+    },
+    {
+      "id": "official-tokenizer-json",
+      "source_id": "minimax-official-model",
+      "relative_path": "tokenizer/tokenizer.json",
+      "sha256": "a5d85b6dcc535e6b93115a9ef287e6132fdbf30270da6218194ba742261173c7"
+    },
+    {
+      "id": "official-tokenizer-config",
+      "source_id": "minimax-official-model",
+      "relative_path": "tokenizer/tokenizer_config.json",
+      "sha256": "a07e942ac874baa13758de8d1fbdb186683cc03416b5589e1b6671c6b3057c68"
+    },
+    {
+      "id": "official-tokenizer-merges",
+      "source_id": "minimax-official-model",
+      "relative_path": "tokenizer/merges.txt",
+      "sha256": "599bab54075088774b1733fde865d5bd747cbcc7a547c5bc12610e874e26f5e3"
+    },
+    {
+      "id": "official-tokenizer-vocab",
+      "source_id": "minimax-official-model",
+      "relative_path": "tokenizer/vocab.json",
+      "sha256": "ca10d7e9fb3ed18575dd1e277a2579c16d108e32f27439684afa0e10b1440910"
+    },
+    {
+      "id": "official-processor-config",
+      "source_id": "minimax-official-model",
+      "relative_path": "processor/preprocessor_config.json",
+      "sha256": "27225450ac9c6529872ee1924fcb0962ff5634834f817040f444118116f4e516"
+    },
+    {
+      "id": "official-processor-video-config",
+      "source_id": "minimax-official-model",
+      "relative_path": "processor/video_preprocessor_config.json",
+      "sha256": "7768af27c1fafa9cc9011c1dc20067e03f8915e03b63504550e11d5066986d13"
+    },
+    {
+      "id": "official-processor-chat-template",
+      "source_id": "minimax-official-model",
+      "relative_path": "processor/chat_template.json",
+      "sha256": "5c72a170d2a4a1a3bc5adad2e689ae28138a9700e5b8c96c0266331e86c0acce"
+    },
+    {
+      "id": "official-processor-tokenizer-json",
+      "source_id": "minimax-official-model",
+      "relative_path": "processor/tokenizer.json",
+      "sha256": "a5d85b6dcc535e6b93115a9ef287e6132fdbf30270da6218194ba742261173c7"
+    },
+    {
+      "id": "official-processor-tokenizer-config",
+      "source_id": "minimax-official-model",
+      "relative_path": "processor/tokenizer_config.json",
+      "sha256": "a07e942ac874baa13758de8d1fbdb186683cc03416b5589e1b6671c6b3057c68"
+    },
+    {
+      "id": "official-processor-merges",
+      "source_id": "minimax-official-model",
+      "relative_path": "processor/merges.txt",
+      "sha256": "599bab54075088774b1733fde865d5bd747cbcc7a547c5bc12610e874e26f5e3"
+    },
+    {
+      "id": "official-processor-vocab",
+      "source_id": "minimax-official-model",
+      "relative_path": "processor/vocab.json",
+      "sha256": "ca10d7e9fb3ed18575dd1e277a2579c16d108e32f27439684afa0e10b1440910"
+    },
+    {
+      "id": "official-video-scheduler-config",
+      "source_id": "minimax-official-model",
+      "relative_path": "scheduler/scheduler_config.json",
+      "sha256": "8fa6c3aa70dc9e691e1a6df899fd1b6f75f70481a27cee6e18a303817075c304"
+    },
+    {
+      "id": "official-audio-scheduler-config",
+      "source_id": "minimax-official-model",
+      "relative_path": "audio_scheduler/scheduler_config.json",
+      "sha256": "804780f7133477067bd6bbfbc02dc8b3cf9feeb400f97c08f5b1d5f6cbab3840"
     }
   ],
   "capture_policy": {
@@ -128,6 +224,22 @@
     {
       "id": "tokenizer-processor",
       "authority_tier": "exact-full-bf16",
+      "input_contract": { "kind": "identity-sha256-v1" },
+      "required_component_indexes": [
+        "official-model-index",
+        "official-modular-index",
+        "official-tokenizer-json",
+        "official-tokenizer-config",
+        "official-tokenizer-merges",
+        "official-tokenizer-vocab",
+        "official-processor-config",
+        "official-processor-video-config",
+        "official-processor-chat-template",
+        "official-processor-tokenizer-json",
+        "official-processor-tokenizer-config",
+        "official-processor-merges",
+        "official-processor-vocab"
+      ],
       "required_provenance": [
         "source-revision",
         "tokenizer-hash",
@@ -135,6 +247,30 @@
         "device",
         "capture-command"
       ],
+      "pinned_provenance": [
+        {
+          "key": "tokenizer-hash",
+          "component_indexes": [
+            "official-tokenizer-json",
+            "official-tokenizer-config",
+            "official-tokenizer-merges",
+            "official-tokenizer-vocab"
+          ]
+        },
+        {
+          "key": "processor-hash",
+          "component_indexes": [
+            "official-processor-config",
+            "official-processor-video-config",
+            "official-processor-chat-template",
+            "official-processor-tokenizer-json",
+            "official-processor-tokenizer-config",
+            "official-processor-merges",
+            "official-processor-vocab"
+          ]
+        }
+      ],
+      "role_invariant_provenance": ["tokenizer-hash", "processor-hash"],
       "required_measurements": [
         "token-ids",
         "special-token-presentation",
@@ -145,6 +281,8 @@
     {
       "id": "qwen-layer-50",
       "authority_tier": "exact-full-bf16",
+      "input_contract": { "kind": "identity-sha256-v1" },
+      "required_component_indexes": ["official-text-encoder-index"],
       "required_provenance": [
         "source-revision",
         "component-index-hash",
@@ -152,11 +290,15 @@
         "dtype",
         "capture-command"
       ],
+      "pinned_provenance": [],
+      "role_invariant_provenance": ["component-index-hash", "dtype"],
       "required_measurements": ["shape", "dtype", "statistics", "sampled-values", "tolerance"]
     },
     {
       "id": "visual-vae",
       "authority_tier": "exact-full-bf16",
+      "input_contract": { "kind": "identity-sha256-v1" },
+      "required_component_indexes": ["official-video-vae-index"],
       "required_provenance": [
         "source-revision",
         "component-index-hash",
@@ -164,6 +306,8 @@
         "dtype",
         "capture-command"
       ],
+      "pinned_provenance": [],
+      "role_invariant_provenance": ["component-index-hash", "dtype"],
       "required_measurements": [
         "pixel-normalization",
         "posterior-seed-42",
@@ -175,6 +319,8 @@
     {
       "id": "audio-vae",
       "authority_tier": "exact-full-bf16",
+      "input_contract": { "kind": "identity-sha256-v1" },
+      "required_component_indexes": ["official-audio-vae-config"],
       "required_provenance": [
         "source-revision",
         "component-index-hash",
@@ -182,6 +328,8 @@
         "dtype",
         "capture-command"
       ],
+      "pinned_provenance": [],
+      "role_invariant_provenance": ["component-index-hash", "dtype"],
       "required_measurements": [
         "stereo-packing",
         "latent-rate",
@@ -193,26 +341,40 @@
     {
       "id": "token-refiner",
       "authority_tier": "exact-full-bf16",
+      "input_contract": { "kind": "identity-sha256-v1" },
+      "required_component_indexes": [
+        "official-fl2va-transformer-index",
+        "official-ref2va-transformer-index"
+      ],
       "required_provenance": [
         "source-revision",
-        "component-index-hash",
+        "component-index-hashes",
         "device",
         "dtype",
         "capture-command"
       ],
+      "pinned_provenance": [],
+      "role_invariant_provenance": ["component-index-hashes", "dtype"],
       "required_measurements": ["shape", "statistics", "sampled-values", "tolerance"]
     },
     {
       "id": "transformer-block",
       "authority_tier": "exact-full-bf16",
+      "input_contract": { "kind": "identity-sha256-v1" },
+      "required_component_indexes": [
+        "official-fl2va-transformer-index",
+        "official-ref2va-transformer-index"
+      ],
       "required_provenance": [
         "source-revision",
-        "component-index-hash",
+        "component-index-hashes",
         "device",
         "dtype",
         "attention-backend",
         "capture-command"
       ],
+      "pinned_provenance": [],
+      "role_invariant_provenance": ["component-index-hashes", "dtype"],
       "required_measurements": [
         "qk-rms",
         "partial-mm-rope",
@@ -225,6 +387,8 @@
     {
       "id": "packed-layout",
       "authority_tier": "exact-full-bf16",
+      "input_contract": { "kind": "identity-sha256-v1" },
+      "required_component_indexes": ["official-modular-index"],
       "required_provenance": [
         "source-revision",
         "workflow",
@@ -232,6 +396,8 @@
         "device",
         "capture-command"
       ],
+      "pinned_provenance": [],
+      "role_invariant_provenance": ["workflow", "reference-order"],
       "required_measurements": [
         "row-order",
         "modality-tags",
@@ -242,6 +408,12 @@
     {
       "id": "dual-sampler",
       "authority_tier": "synthetic",
+      "input_contract": { "kind": "identity-sha256-v1" },
+      "required_component_indexes": [
+        "official-modular-index",
+        "official-video-scheduler-config",
+        "official-audio-scheduler-config"
+      ],
       "required_provenance": [
         "source-revision",
         "float-policy",
@@ -249,11 +421,15 @@
         "audio-shift",
         "capture-command"
       ],
+      "pinned_provenance": [],
+      "role_invariant_provenance": ["float-policy", "video-shift", "audio-shift"],
       "required_measurements": ["sigma-arrays", "timesteps", "coupled-update", "evaluation-count"]
     },
     {
       "id": "noise-allocation",
       "authority_tier": "exact-full-bf16",
+      "input_contract": { "kind": "identity-sha256-v1" },
+      "required_component_indexes": ["official-modular-index"],
       "required_provenance": [
         "source-revision",
         "seed",
@@ -261,11 +437,53 @@
         "allocation-version",
         "capture-command"
       ],
+      "pinned_provenance": [],
+      "role_invariant_provenance": ["seed", "generator-device", "allocation-version"],
       "required_measurements": ["draw-order", "tensor-shapes", "sampled-values", "hash"]
     },
     {
       "id": "end-to-end-t2va",
       "authority_tier": "exact-full-bf16",
+      "input_contract": {
+        "kind": "canonical-e2e-json-sha256-v1",
+        "task": "t2va",
+        "algorithm": "minimax-h3-flow-euler-v1",
+        "guidance": "0",
+        "video_shift": "12",
+        "audio_shift": "3",
+        "dimension_multiple": 32,
+        "frame_step": 17,
+        "frame_offset": 5,
+        "min_frames": 124,
+        "max_frames": 362,
+        "max_pixels": 1069056,
+        "min_aspect_ratio": "0.25",
+        "max_aspect_ratio": "4",
+        "fps": 24,
+        "video_scheduler_component": "official-video-scheduler-config",
+        "audio_scheduler_component": "official-audio-scheduler-config"
+      },
+      "required_component_indexes": [
+        "official-model-index",
+        "official-modular-index",
+        "official-tokenizer-json",
+        "official-tokenizer-config",
+        "official-tokenizer-merges",
+        "official-tokenizer-vocab",
+        "official-processor-config",
+        "official-processor-video-config",
+        "official-processor-chat-template",
+        "official-processor-tokenizer-json",
+        "official-processor-tokenizer-config",
+        "official-processor-merges",
+        "official-processor-vocab",
+        "official-text-encoder-index",
+        "official-video-vae-index",
+        "official-audio-vae-config",
+        "official-fl2va-transformer-index",
+        "official-video-scheduler-config",
+        "official-audio-scheduler-config"
+      ],
       "required_provenance": [
         "source-revision",
         "component-index-hashes",
@@ -273,11 +491,53 @@
         "dtype",
         "capture-command"
       ],
+      "pinned_provenance": [],
+      "role_invariant_provenance": ["component-index-hashes", "dtype"],
       "required_measurements": ["latent-statistics", "av-timing", "video-metrics", "audio-metrics"]
     },
     {
       "id": "end-to-end-fl2va",
       "authority_tier": "exact-full-bf16",
+      "input_contract": {
+        "kind": "canonical-e2e-json-sha256-v1",
+        "task": "fl2va",
+        "algorithm": "minimax-h3-flow-euler-v1",
+        "guidance": "0",
+        "video_shift": "12",
+        "audio_shift": "3",
+        "dimension_multiple": 32,
+        "frame_step": 17,
+        "frame_offset": 5,
+        "min_frames": 124,
+        "max_frames": 362,
+        "max_pixels": 1069056,
+        "min_aspect_ratio": "0.25",
+        "max_aspect_ratio": "4",
+        "fps": 24,
+        "video_scheduler_component": "official-video-scheduler-config",
+        "audio_scheduler_component": "official-audio-scheduler-config"
+      },
+      "required_component_indexes": [
+        "official-model-index",
+        "official-modular-index",
+        "official-tokenizer-json",
+        "official-tokenizer-config",
+        "official-tokenizer-merges",
+        "official-tokenizer-vocab",
+        "official-processor-config",
+        "official-processor-video-config",
+        "official-processor-chat-template",
+        "official-processor-tokenizer-json",
+        "official-processor-tokenizer-config",
+        "official-processor-merges",
+        "official-processor-vocab",
+        "official-text-encoder-index",
+        "official-video-vae-index",
+        "official-audio-vae-config",
+        "official-fl2va-transformer-index",
+        "official-video-scheduler-config",
+        "official-audio-scheduler-config"
+      ],
       "required_provenance": [
         "source-revision",
         "component-index-hashes",
@@ -285,6 +545,8 @@
         "device",
         "capture-command"
       ],
+      "pinned_provenance": [],
+      "role_invariant_provenance": ["component-index-hashes", "endpoint-signature"],
       "required_measurements": [
         "condition-latents",
         "latent-statistics",
@@ -296,6 +558,46 @@
     {
       "id": "end-to-end-ref2va",
       "authority_tier": "exact-full-bf16",
+      "input_contract": {
+        "kind": "canonical-e2e-json-sha256-v1",
+        "task": "ref2va",
+        "algorithm": "minimax-h3-flow-euler-v1",
+        "guidance": "0",
+        "video_shift": "12",
+        "audio_shift": "3",
+        "dimension_multiple": 32,
+        "frame_step": 17,
+        "frame_offset": 5,
+        "min_frames": 124,
+        "max_frames": 362,
+        "max_pixels": 1069056,
+        "min_aspect_ratio": "0.25",
+        "max_aspect_ratio": "4",
+        "fps": 24,
+        "video_scheduler_component": "official-video-scheduler-config",
+        "audio_scheduler_component": "official-audio-scheduler-config"
+      },
+      "required_component_indexes": [
+        "official-model-index",
+        "official-modular-index",
+        "official-tokenizer-json",
+        "official-tokenizer-config",
+        "official-tokenizer-merges",
+        "official-tokenizer-vocab",
+        "official-processor-config",
+        "official-processor-video-config",
+        "official-processor-chat-template",
+        "official-processor-tokenizer-json",
+        "official-processor-tokenizer-config",
+        "official-processor-merges",
+        "official-processor-vocab",
+        "official-text-encoder-index",
+        "official-video-vae-index",
+        "official-audio-vae-config",
+        "official-ref2va-transformer-index",
+        "official-video-scheduler-config",
+        "official-audio-scheduler-config"
+      ],
       "required_provenance": [
         "source-revision",
         "component-index-hashes",
@@ -303,6 +605,8 @@
         "device",
         "capture-command"
       ],
+      "pinned_provenance": [],
+      "role_invariant_provenance": ["component-index-hashes", "reference-order"],
       "required_measurements": [
         "packed-order",
         "latent-statistics",


### PR DESCRIPTION
## Summary

- bind fixture provenance and exact layer evidence to reviewed component authority sets
- reject invalid numeric domains, excluded acceleration paths, and incomplete sampled tensors
- add the protected external-GPU conformance runner with fail-closed CI routing

## Why

The H3 qualification boundary must not accept mixed provenance, partial floating-point evidence, or excluded runtime paths as authoritative conformance.

## Validation

- `python3 scripts/tests/minimax-h3-conformance-contract.py`
- `python3 scripts/tests/minimax-h3-gpu-conformance-contract.py`
- `bash scripts/tests/minimax-h3-private-uat-release-contract.sh`
- `bash scripts/tests/ci-routing-contract.sh`
- `nix run nixpkgs#actionlint -- .github/workflows/*.yml`
- conflict-free `git merge-tree` against current `origin/main`

Refs #832