### PR TITLE
feat(h3): add protected conditioner capture producer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,8 @@ jobs:
               - 'scripts/tests/minimax-h3-conformance-contract.py'
               - 'scripts/run-minimax-h3-gpu-conformance.py'
               - 'scripts/tests/minimax-h3-gpu-conformance-contract.py'
+              - 'scripts/capture-minimax-h3-conditioner.py'
+              - 'scripts/tests/minimax-h3-capture-producer-contract.py'
               - 'scripts/tests/minimax-h3-private-uat-release-contract.sh'
               - '.github/workflows/minimax-h3-private-conformance.yml'
               - 'tests/fixtures/minimax_h3/**'
@@ -420,6 +422,9 @@ jobs:
       - name: Test MiniMax H3 private GPU conformance contract
         if: env.RUN_RUST_SUITE == 'true'
         run: python3 scripts/tests/minimax-h3-gpu-conformance-contract.py
+      - name: Test MiniMax H3 capture producer contract
+        if: env.RUN_RUST_SUITE == 'true'
+        run: python3 scripts/tests/minimax-h3-capture-producer-contract.py
       - name: Clippy the private MiniMax H3 artifact qualifier
         if: env.RUN_RUST_SUITE == 'true'
         run: cargo clippy -p mold-ai-inference --features dev-bins,h3-private-uat --bin h3_artifact_qualification -- -D warnings

--- a/docs/qualification/minimax-h3-conformance-manifest.schema.json
+++ b/docs/qualification/minimax-h3-conformance-manifest.schema.json
@@ -28,12 +28,14 @@
       "required": [
         "source_id",
         "precision",
+        "oracle_runtime",
         "excluded_accelerations",
         "excluded_acceleration_aliases"
       ],
       "properties": {
         "source_id": { "const": "diffusers" },
         "precision": { "const": "official-bf16-fp32-mixed" },
+        "oracle_runtime": { "$ref": "#/$defs/oracle_runtime" },
         "excluded_accelerations": {
           "type": "array",
           "minItems": 7,
@@ -69,7 +71,7 @@
     },
     "sources": {
       "type": "array",
-      "minItems": 7,
+      "minItems": 8,
       "items": { "$ref": "#/$defs/source" }
     },
     "component_indexes": {
@@ -155,6 +157,37 @@
       "minItems": 1,
       "items": { "type": "string", "minLength": 1 }
     },
+    "oracle_runtime": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["python", "torch", "numpy", "cuda", "transformers_revision"],
+      "properties": {
+        "python": { "type": "string", "minLength": 1 },
+        "torch": { "type": "string", "minLength": 1 },
+        "numpy": { "type": "string", "minLength": 1 },
+        "cuda": { "type": "string", "minLength": 1 },
+        "transformers_revision": { "$ref": "#/$defs/commit" }
+      }
+    },
+    "oracle_adapter": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "command_prefix",
+        "implementation_path",
+        "implementation_sha256"
+      ],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "command_prefix": { "type": "string", "minLength": 1 },
+        "implementation_path": {
+          "type": "string",
+          "pattern": "^scripts/[a-zA-Z0-9._/-]+\\.py$"
+        },
+        "implementation_sha256": { "$ref": "#/$defs/sha256" }
+      }
+    },
     "source": {
       "type": "object",
       "additionalProperties": false,
@@ -199,6 +232,7 @@
           "enum": ["exact-full-bf16", "quantized-structural", "synthetic"]
         },
         "input_contract": { "$ref": "#/$defs/input_contract" },
+        "oracle_adapter": { "$ref": "#/$defs/oracle_adapter" },
         "required_component_indexes": {
           "type": "array",
           "minItems": 1,

--- a/docs/qualification/minimax-h3-conformance.md
+++ b/docs/qualification/minimax-h3-conformance.md
@@ -159,6 +159,85 @@ shape/dtype/statistics/sampled values, evidence hash, and numerical tolerance.
 Quantized Comfy results use structural, temporal, and audio quality metrics;
 they are never mislabeled as bit-identical full-precision evidence.
 
+### Tokenizer and processor capture producer
+
+The first production capture slice is
+scripts/capture-minimax-h3-conditioner.py tokenizer-processor. It is an opt-in
+evidence producer, not a Mold runtime command. It has no Cargo feature, binary
+entry point, release dependency, automatic workflow trigger, or model download
+path. Its Python ML imports occur only after the authorization, external-root,
+source, and component preflights pass.
+
+The producer fixes one reproducible conditioner case:
+
+- a UTF-8 raw prompt containing both non-ASCII text and a literal Qwen vision
+  token spelling, with no chat template and no added special tokens;
+- one generated 256 by 256 RGB image, chosen to meet the pinned processor
+  minimum without a resize;
+- one generated 37-frame, 24 fps, 64 by 64 RGB video, sampled through the
+  pinned Diffusers helper at 2 fps into source frames 0, 12, 24, and 36 and
+  paired into timestamped Qwen vision blocks;
+- the exact combined image/video Ref2VA presentation from the pinned Diffusers
+  implementation.
+
+It records four manifest-required measurements. Token IDs are length-prefixed
+raw and multimodal presentations. Special-token evidence is a length-prefixed
+set of the required token IDs, H3 row tags, Qwen modality type IDs, sampled
+source indices, and millisecond timestamps. Processor shapes use stable numeric
+field IDs followed by rank and dimensions. Processor pixel values are
+concatenated after an actual CUDA BF16 copy and hashed as canonical typed
+little-endian bytes. The raw generated pixels are not retained; only their
+input hashes and strict tensor summaries leave the process.
+
+Capture requires clean external checkouts at these exact revisions:
+
+- Diffusers: 9c6a68c32b3b2a64db91800b624d33cec6e25ab8
+- Transformers: 42f189ded85d18d00b51161d694cafd325e32b91
+- MiniMaxAI/MiniMax-H3 snapshot:
+  bfc8ed0353f5a9733be73e6b2c98ec0948195b86
+
+The Transformers revision is the main-tree companion available when the
+pinned Diffusers H3 integration landed and includes the exact
+create_mm_token_type_ids authority that integration calls. The producer
+resolves both imported implementations back into those clean checkouts. For
+every model metadata file, it verifies both the manifest SHA-256 and the
+Hugging Face local-directory metadata revision. A manually assembled directory
+without revision metadata fails closed even if its visible files happen to
+hash correctly.
+
+Prepare the external paths, including both tokenizer/ and processor/ metadata
+directories from the exact model snapshot, then run:
+
+    export MOLD_H3_FIXTURE_ROOT=/external/h3/evidence
+    export MOLD_H3_AUTHORIZATION_RECORD=/external/h3/compliance/authorization.json
+    export MOLD_H3_OFFICIAL_MODEL=/external/h3/models/MiniMax-H3
+    export MOLD_H3_DIFFUSERS_CHECKOUT=/external/h3/src/diffusers
+    export MOLD_H3_TRANSFORMERS_CHECKOUT=/external/h3/src/transformers
+    python3 scripts/capture-minimax-h3-conditioner.py \
+      tokenizer-processor --device cuda:0
+
+The producer disables TF32, flash and memory-efficient SDPA, cuDNN SDPA,
+non-deterministic algorithms, and every manifest-excluded acceleration before
+the CUDA copy. Environment variables that configure an excluded acceleration
+are rejected before any ML package import. It writes mode-0600 oracle.json and
+oracle-bundle.json files under a new, input-addressed directory below
+MOLD_H3_FIXTURE_ROOT and refuses to overwrite an existing capture.
+
+The emitted partial bundle is independently valid under
+mold.minimax-h3.fixture-bundle.v1, and its layer is accepted by the exact
+protected measurement validator. It is intentionally not a complete campaign:
+the protected runner still requires paired oracle and Mold evidence for all
+exact-full-bf16 layers.
+
+Qwen layer 50 is the next conditioner boundary, not part of this producer.
+The released Mold private conditioner currently exercises the deployment
+NVFP4/AWQ route, while the qwen-layer-50 manifest layer is
+exact-full-bf16. Relabeling that quantized output would be false evidence. The
+next slice must add an authorization-bound exact-BF16 Mold adapter and paired
+Diffusers capture for text-only and representative multimodal presentations,
+both recording the unnormalized hidden state after language layer 49, before
+this partial bundle can expand to that layer.
+
 ### Opt-in protected GPU validation
 
 The manual `MiniMax H3 private conformance` workflow validates an approved,

--- a/docs/qualification/minimax-h3-conformance.md
+++ b/docs/qualification/minimax-h3-conformance.md
@@ -78,6 +78,7 @@ python3 scripts/minimax-h3-conformance.py verify-sources \
   --source minimax-official-code=/absolute/path/to/MiniMax-H3-code \
   --source minimax-official-model=/absolute/path/to/MiniMax-H3-model \
   --source diffusers=/absolute/path/to/diffusers \
+  --source transformers=/absolute/path/to/transformers \
   --source comfyui=/absolute/path/to/ComfyUI \
   --source comfy-checkpoints=/absolute/path/to/Comfy-H3-model \
   --source sglang=/absolute/path/to/sglang \
@@ -180,11 +181,14 @@ The producer fixes one reproducible conditioner case:
 - the exact combined image/video Ref2VA presentation from the pinned Diffusers
   implementation.
 
-It records four manifest-required measurements. Token IDs are length-prefixed
+It records five manifest-required measurements. Token IDs are length-prefixed
 raw and multimodal presentations. Special-token evidence is a length-prefixed
 set of the required token IDs, H3 row tags, Qwen modality type IDs, sampled
 source indices, and millisecond timestamps. Processor shapes use stable numeric
-field IDs followed by rank and dimensions. Processor pixel values are
+field IDs followed by rank and dimensions. `processor-grids` records the actual
+flattened image and video `grid_thw` integer values, not only their tensor
+shapes, so token counts and multimodal rotary geometry are exact evidence.
+Processor pixel values are
 concatenated after an actual CUDA BF16 copy and hashed as canonical typed
 little-endian bytes. The raw generated pixels are not retained; only their
 input hashes and strict tensor summaries leave the process.
@@ -204,6 +208,27 @@ every model metadata file, it verifies both the manifest SHA-256 and the
 Hugging Face local-directory metadata revision. A manually assembled directory
 without revision metadata fails closed even if its visible files happen to
 hash correctly.
+
+The manifest also pins the complete oracle runtime identity used by this
+producer: Python 3.13.13, PyTorch 2.13.0+cu130, NumPy 2.5.1, CUDA 13.0, and the
+full Transformers revision above. The capture script itself is a
+manifest-pinned SHA-256 authority whose repository-relative implementation path
+is traversal-, symlink-, and checkout-containment checked before hashing. Both
+identities are repeated in structured layer and bundle evidence and enforced
+again by the protected runner. Bundles carry a canonical per-layer
+`oracle_adapters` list derived from the manifest contracts for the fixture
+layers they contain. Missing, extra, duplicate, reordered, or cross-wired
+adapter records fail closed, which permits later capture producers to add their
+own adapter contract without weakening or special-casing this one.
+
+Before importing either source or opening model configuration at execution
+time, the producer creates an owner-only temporary directory under the external
+fixture root. It exports each exact Git revision with `git archive` and copies
+each required model component from one no-follow read whose bytes match the
+manifest hash. Runtime imports and `from_pretrained` calls use only this staged
+snapshot. The complete staged file set, sizes, and hashes are revalidated after
+execution and immediately before evidence is written; the original checkouts
+and model paths are never reopened as runtime authority.
 
 Prepare the external paths, including both tokenizer/ and processor/ metadata
 directories from the exact model snapshot, then run:

--- a/docs/qualification/minimax-h3-fixture-bundle.schema.json
+++ b/docs/qualification/minimax-h3-fixture-bundle.schema.json
@@ -35,6 +35,12 @@
         "attention_backend": { "type": "string", "minLength": 1 },
         "acceleration_policy": { "$ref": "#/$defs/acceleration_policy" },
         "command": { "type": "string", "minLength": 1 },
+        "oracle_runtime": { "$ref": "#/$defs/oracle_runtime" },
+        "oracle_adapters": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/oracle_adapter_capture" }
+        },
         "forbidden_accelerations_disabled": { "const": true }
       }
     },
@@ -67,6 +73,29 @@
           "minItems": 1,
           "items": { "type": "string", "minLength": 1 }
         }
+      }
+    },
+    "oracle_runtime": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["python", "torch", "numpy", "cuda", "transformers_revision"],
+      "properties": {
+        "python": { "type": "string", "minLength": 1 },
+        "torch": { "type": "string", "minLength": 1 },
+        "numpy": { "type": "string", "minLength": 1 },
+        "cuda": { "type": "string", "minLength": 1 },
+        "transformers_revision": { "$ref": "#/$defs/commit" }
+      }
+    },
+    "oracle_adapter_capture": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["layer", "id", "command", "implementation_sha256"],
+      "properties": {
+        "layer": { "type": "string", "minLength": 1 },
+        "id": { "type": "string", "minLength": 1 },
+        "command": { "type": "string", "minLength": 1 },
+        "implementation_sha256": { "$ref": "#/$defs/sha256" }
       }
     },
     "fixture": {

--- a/docs/qualification/minimax-h3-layer-output.schema.json
+++ b/docs/qualification/minimax-h3-layer-output.schema.json
@@ -107,7 +107,8 @@
         "schema_version": { "const": "mold.minimax-h3.layer-adapter.v1" },
         "id": { "$ref": "#/$defs/key" },
         "command": { "type": "string", "minLength": 1 },
-        "tensor_hash_encoding": { "$ref": "#/$defs/key" }
+        "tensor_hash_encoding": { "$ref": "#/$defs/key" },
+        "implementation_sha256": { "$ref": "#/$defs/sha256" }
       }
     },
     "environment": {
@@ -124,6 +125,7 @@
         "dtype": { "type": "string", "minLength": 1 },
         "attention_backend": { "type": "string", "minLength": 1 },
         "acceleration_policy": { "$ref": "#/$defs/acceleration_policy" },
+        "oracle_runtime": { "$ref": "#/$defs/oracle_runtime" },
         "forbidden_accelerations_disabled": { "const": true }
       }
     },
@@ -141,6 +143,18 @@
           "minItems": 1,
           "items": { "$ref": "#/$defs/key" }
         }
+      }
+    },
+    "oracle_runtime": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["python", "torch", "numpy", "cuda", "transformers_revision"],
+      "properties": {
+        "python": { "type": "string", "minLength": 1 },
+        "torch": { "type": "string", "minLength": 1 },
+        "numpy": { "type": "string", "minLength": 1 },
+        "cuda": { "type": "string", "minLength": 1 },
+        "transformers_revision": { "$ref": "#/$defs/commit" }
       }
     },
     "e2e_input": {

--- a/scripts/capture-minimax-h3-conditioner.py
+++ b/scripts/capture-minimax-h3-conditioner.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import io
 import importlib
 import importlib.util
 import inspect
@@ -20,11 +21,14 @@ import json
 import math
 import os
 import pathlib
+import platform
 import re
 import shutil
+import stat
 import struct
 import subprocess
 import sys
+import tarfile
 import tempfile
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
@@ -92,6 +96,10 @@ EXCLUDED_ACCELERATION_ENV_ALIASES = (
 )
 FALSE_ENVIRONMENT_VALUES = frozenset({"", "0", "false", "no", "off", "disabled"})
 CUDA_DEVICE_PATTERN = re.compile(r"^cuda:([0-9]+)$")
+SOURCE_REPOSITORIES = {
+    "diffusers": "https://github.com/huggingface/diffusers",
+    "transformers": "https://github.com/huggingface/transformers",
+}
 
 
 class CaptureFailure(Exception):
@@ -209,6 +217,21 @@ def command_output(arguments: Sequence[str], cwd: pathlib.Path) -> str:
     return result.stdout.strip()
 
 
+def command_bytes(arguments: Sequence[str], cwd: pathlib.Path) -> bytes:
+    try:
+        result = subprocess.run(
+            list(arguments),
+            cwd=cwd,
+            check=False,
+            capture_output=True,
+        )
+    except OSError:
+        fail("capture source snapshot failed")
+    if result.returncode != 0:
+        fail("capture source snapshot failed")
+    return result.stdout
+
+
 def normalized_repository_url(value: str) -> str:
     normalized = value.strip()
     if normalized.startswith("git@github.com:"):
@@ -237,6 +260,174 @@ def verify_git_checkout(
         fail(f"{label} checkout must be clean before capture")
 
 
+@dataclass(frozen=True)
+class SnapshotFile:
+    relative_path: str
+    size: int
+    sha256: str
+
+
+@dataclass(frozen=True)
+class StagedSnapshot:
+    root: pathlib.Path
+    files: tuple[SnapshotFile, ...]
+
+    def revalidate(self) -> None:
+        observed = snapshot_files(self.root)
+        if observed != self.files:
+            fail("private capture staging snapshot changed during execution")
+
+
+def relative_input_path(value: str) -> pathlib.PurePosixPath:
+    candidate = pathlib.PurePosixPath(value)
+    if candidate.is_absolute() or not candidate.parts or ".." in candidate.parts:
+        fail("capture input contains an unsafe relative path")
+    return candidate
+
+
+def private_directory(path: pathlib.Path) -> None:
+    path.mkdir(mode=0o700, parents=True, exist_ok=True)
+    try:
+        os.chmod(path, 0o700, follow_symlinks=False)
+    except OSError as error:
+        fail(f"cannot secure private capture staging: {error}")
+
+
+def write_private_file(path: pathlib.Path, encoded: bytes) -> None:
+    private_directory(path.parent)
+    try:
+        descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except OSError as error:
+        fail(f"cannot create private capture staging file: {error}")
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "wb") as destination:
+            descriptor = -1
+            destination.write(encoded)
+            destination.flush()
+            os.fsync(destination.fileno())
+    except OSError as error:
+        fail(f"cannot write private capture staging file: {error}")
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+
+
+def read_regular_file_once(root: pathlib.Path, relative_path: str) -> bytes:
+    relative = relative_input_path(relative_path)
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    directory_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | nofollow
+    try:
+        directory = os.open(root, directory_flags)
+    except OSError:
+        fail("required capture input root is unavailable")
+    try:
+        for part in relative.parts[:-1]:
+            try:
+                child = os.open(part, directory_flags, dir_fd=directory)
+            except OSError:
+                fail("required capture input path is unavailable or unsafe")
+            os.close(directory)
+            directory = child
+        flags = os.O_RDONLY | nofollow
+        try:
+            descriptor = os.open(relative.parts[-1], flags, dir_fd=directory)
+        except OSError:
+            fail("required capture input is unavailable or not a regular file")
+    finally:
+        os.close(directory)
+    try:
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode):
+            fail("required capture input is not a regular file")
+        chunks: list[bytes] = []
+        observed = 0
+        while chunk := os.read(descriptor, 1024 * 1024):
+            chunks.append(chunk)
+            observed += len(chunk)
+        if observed != metadata.st_size:
+            fail("required capture input changed while it was read")
+        return b"".join(chunks)
+    finally:
+        os.close(descriptor)
+
+
+def snapshot_files(root: pathlib.Path) -> tuple[SnapshotFile, ...]:
+    files: list[SnapshotFile] = []
+    try:
+        entries = sorted(root.rglob("*"))
+    except OSError as error:
+        fail(f"cannot enumerate private capture staging: {error}")
+    for path in entries:
+        try:
+            metadata = path.lstat()
+        except OSError as error:
+            fail(f"cannot inspect private capture staging: {error}")
+        if stat.S_ISLNK(metadata.st_mode):
+            fail("private capture staging contains a symbolic link")
+        if stat.S_ISDIR(metadata.st_mode):
+            continue
+        if not stat.S_ISREG(metadata.st_mode):
+            fail("private capture staging contains a non-regular file")
+        relative = path.relative_to(root).as_posix()
+        files.append(
+            SnapshotFile(
+                relative_path=relative,
+                size=metadata.st_size,
+                sha256=sha256_file(path),
+            )
+        )
+    if not files:
+        fail("private capture staging is empty")
+    return tuple(files)
+
+
+def extract_git_source_snapshot(
+    label: str,
+    checkout: pathlib.Path,
+    expected_revision: str,
+    expected_repository: str,
+    package: str,
+    destination: pathlib.Path,
+) -> None:
+    verify_git_checkout(label, checkout, expected_revision, expected_repository)
+    archive_bytes = command_bytes(
+        ["git", "archive", "--format=tar", expected_revision, f"src/{package}"],
+        checkout,
+    )
+    expected_prefix = pathlib.PurePosixPath("src") / package
+    private_directory(destination)
+    try:
+        archive = tarfile.open(fileobj=io.BytesIO(archive_bytes), mode="r:")
+    except tarfile.TarError:
+        fail(f"{label} source snapshot is not a valid git archive")
+    with archive:
+        members = archive.getmembers()
+        if not members:
+            fail(f"{label} source snapshot is empty")
+        for member in members:
+            relative = relative_input_path(member.name)
+            if (
+                relative != expected_prefix
+                and expected_prefix not in relative.parents
+                and relative not in expected_prefix.parents
+            ):
+                fail(f"{label} source snapshot contains an unexpected path")
+            target = destination.joinpath(*relative.parts)
+            if member.isdir():
+                private_directory(target)
+                continue
+            if not member.isfile():
+                fail(f"{label} source snapshot contains a non-regular file")
+            source = archive.extractfile(member)
+            if source is None:
+                fail(f"{label} source snapshot cannot be read")
+            encoded = source.read()
+            if len(encoded) != member.size:
+                fail(f"{label} source snapshot changed while it was read")
+            write_private_file(target, encoded)
+
+
 def manifest_component_map(manifest: Mapping[str, Any]) -> dict[str, dict[str, str]]:
     components: dict[str, dict[str, str]] = {}
     for raw in manifest["component_indexes"]:
@@ -252,12 +443,14 @@ def manifest_component_map(manifest: Mapping[str, Any]) -> dict[str, dict[str, s
 
 
 def huggingface_metadata_revision(model_root: pathlib.Path, relative_path: str) -> str:
-    metadata = (
-        model_root / ".cache" / "huggingface" / "download" / f"{relative_path}.metadata"
-    )
+    metadata_path = f".cache/huggingface/download/{relative_path}.metadata"
     try:
-        first_line = metadata.read_text(encoding="utf-8").splitlines()[0]
-    except (OSError, IndexError, UnicodeError):
+        first_line = (
+            read_regular_file_once(model_root, metadata_path)
+            .decode("utf-8")
+            .splitlines()[0]
+        )
+    except (IndexError, UnicodeError):
         fail("official model snapshot lacks revision-bound component metadata")
     return first_line
 
@@ -272,21 +465,37 @@ def verify_model_components(
     for identifier in REQUIRED_COMPONENT_IDS:
         component = component_map[identifier]
         relative_path = component["relative_path"]
-        candidate = model_root / relative_path
-        if candidate.is_symlink():
-            fail("official model component may not be a symbolic link")
-        try:
-            resolved = candidate.resolve(strict=True)
-        except OSError:
-            fail(f"official model component is unavailable: {identifier}")
-        if not resolved.is_file() or not is_relative_to(resolved, model_root):
-            fail(f"official model component escapes the snapshot: {identifier}")
-        if sha256_file(resolved) != component["sha256"]:
+        encoded = read_regular_file_once(model_root, relative_path)
+        if sha256_bytes(encoded) != component["sha256"]:
             fail(f"official model component hash drifted: {identifier}")
         if huggingface_metadata_revision(model_root, relative_path) != MODEL_REVISION:
             fail(f"official model component revision drifted: {identifier}")
         verified.append({"id": identifier, "sha256": component["sha256"]})
     return verified
+
+
+def stage_model_components(
+    model_root: pathlib.Path,
+    destination: pathlib.Path,
+    manifest: Mapping[str, Any],
+) -> list[dict[str, str]]:
+    component_map = manifest_component_map(manifest)
+    if set(REQUIRED_COMPONENT_IDS) - set(component_map):
+        fail("checked manifest lacks conditioner component authority")
+    private_directory(destination)
+    staged: list[dict[str, str]] = []
+    for identifier in REQUIRED_COMPONENT_IDS:
+        component = component_map[identifier]
+        relative_path = component["relative_path"]
+        encoded = read_regular_file_once(model_root, relative_path)
+        if sha256_bytes(encoded) != component["sha256"]:
+            fail(f"official model component hash drifted: {identifier}")
+        if huggingface_metadata_revision(model_root, relative_path) != MODEL_REVISION:
+            fail(f"official model component revision drifted: {identifier}")
+        relative = relative_input_path(relative_path)
+        write_private_file(destination.joinpath(*relative.parts), encoded)
+        staged.append({"id": identifier, "sha256": component["sha256"]})
+    return staged
 
 
 def normalize_acceleration_name(value: str) -> str:
@@ -350,7 +559,9 @@ def finite_statistics(values: Sequence[float | int]) -> dict[str, float | int]:
     }
 
 
-def integer_tensor_record(key: str, values: Sequence[int]) -> dict[str, Any]:
+def integer_tensor_record(
+    key: str, values: Sequence[int], *, sample_all: bool = False
+) -> dict[str, Any]:
     signed_values = [int(value) for value in values]
     if not signed_values or any(
         not -(2**63) <= value <= 2**63 - 1 for value in signed_values
@@ -367,7 +578,11 @@ def integer_tensor_record(key: str, values: Sequence[int]) -> dict[str, Any]:
         "statistics": finite_statistics(signed_values),
         "samples": [
             {"index": [index], "value": signed_values[index]}
-            for index in sample_indexes(len(signed_values))
+            for index in (
+                range(len(signed_values))
+                if sample_all
+                else sample_indexes(len(signed_values))
+            )
         ],
     }
 
@@ -439,6 +654,7 @@ class PrimitiveEvidence:
     token_ids: tuple[int, ...]
     special_presentation: tuple[int, ...]
     processor_shapes: tuple[int, ...]
+    processor_grids: tuple[int, ...]
     sampled_bfloat16_bits: tuple[int, ...]
     prompt_sha256: str
     image_sha256: str
@@ -496,9 +712,18 @@ def layer_contract(manifest: Mapping[str, Any]) -> Mapping[str, Any]:
         "token-ids",
         "special-token-presentation",
         "processor-shapes",
+        "processor-grids",
         "sampled-values",
     ):
         fail("tokenizer/processor measurement contract drifted")
+    expected_adapter = {
+        "id": "minimax-h3-tokenizer-processor-capture-v1",
+        "command_prefix": CAPTURE_COMMAND_PREFIX,
+        "implementation_path": "scripts/capture-minimax-h3-conditioner.py",
+        "implementation_sha256": sha256_file(pathlib.Path(__file__).resolve()),
+    }
+    if layer.get("oracle_adapter") != expected_adapter:
+        fail("tokenizer/processor adapter authority drifted")
     return layer
 
 
@@ -507,6 +732,7 @@ def build_layer_document(
     evidence: PrimitiveEvidence,
     authorization_sha256: str,
     device: str,
+    oracle_runtime: Mapping[str, str],
 ) -> dict[str, Any]:
     contract = layer_contract(manifest)
     component_map = manifest_component_map(manifest)
@@ -538,6 +764,9 @@ def build_layer_document(
             "special-token-presentation", evidence.special_presentation
         ),
         integer_tensor_record("processor-shapes", evidence.processor_shapes),
+        integer_tensor_record(
+            "processor-grids", evidence.processor_grids, sample_all=True
+        ),
         bfloat16_tensor_record("sampled-values", evidence.sampled_bfloat16_bits),
     ]
     comparison = [
@@ -576,16 +805,29 @@ def build_layer_document(
             "id": "minimax-h3-tokenizer-processor-capture-v1",
             "command": command,
             "tensor_hash_encoding": TENSOR_HASH_ENCODING,
+            "implementation_sha256": contract["oracle_adapter"][
+                "implementation_sha256"
+            ],
         },
         "environment": {
             "device": device,
             "dtype": "bfloat16",
             "attention_backend": "none-conditioner-preprocessing",
             "acceleration_policy": policy,
+            "oracle_runtime": dict(oracle_runtime),
             "forbidden_accelerations_disabled": True,
         },
         "provenance": [
             {"key": "source-revision", "value": DIFFUSERS_REVISION},
+            {"key": "transformers-revision", "value": TRANSFORMERS_REVISION},
+            {
+                "key": "adapter-implementation-sha256",
+                "value": contract["oracle_adapter"]["implementation_sha256"],
+            },
+            {
+                "key": "oracle-runtime-sha256",
+                "value": sha256_bytes(canonical_json_bytes(oracle_runtime)),
+            },
             {
                 "key": "tokenizer-hash",
                 "value": component_authority_set_sha256(tokenizer_ids, component_map),
@@ -636,6 +878,17 @@ def build_bundle(
             "attention_backend": "none-conditioner-preprocessing",
             "acceleration_policy": acceleration_policy(manifest),
             "command": layer_document["adapter"]["command"],
+            "oracle_runtime": layer_document["environment"]["oracle_runtime"],
+            "oracle_adapters": [
+                {
+                    "layer": layer_document["layer"],
+                    "id": layer_document["adapter"]["id"],
+                    "command": layer_document["adapter"]["command"],
+                    "implementation_sha256": layer_document["adapter"][
+                        "implementation_sha256"
+                    ],
+                }
+            ],
             "forbidden_accelerations_disabled": True,
         },
         "fixtures": [
@@ -719,6 +972,30 @@ def load_capture_runtime(
         encoder_step=encoder_module.MiniMaxH3Ref2VATextEncoderStep,
         transformers_checkout=transformers_checkout,
     )
+
+
+def observed_oracle_runtime(runtime: SimpleNamespace) -> dict[str, str]:
+    cuda = getattr(getattr(runtime.torch, "version", None), "cuda", None)
+    values = {
+        "python": platform.python_version(),
+        "torch": str(getattr(runtime.torch, "__version__", "")),
+        "numpy": str(getattr(runtime.numpy, "__version__", "")),
+        "cuda": "" if cuda is None else str(cuda),
+        "transformers_revision": TRANSFORMERS_REVISION,
+    }
+    if any(not value for value in values.values()):
+        fail("capture runtime identity is incomplete")
+    return values
+
+
+def validate_oracle_runtime(
+    manifest: Mapping[str, Any], runtime: SimpleNamespace
+) -> dict[str, str]:
+    expected = manifest["numerical_authority"]["oracle_runtime"]
+    observed = observed_oracle_runtime(runtime)
+    if observed != expected:
+        fail("capture runtime identity differs from the reviewed oracle pin")
+    return observed
 
 
 def configure_torch(runtime: SimpleNamespace, device: str) -> Any:
@@ -912,6 +1189,12 @@ def capture_primitives(
             (7, tuple(video_grid.shape)),
         )
     )
+    processor_grids = packed_vectors(
+        (
+            [int(value) for value in image_grid.detach().cpu().reshape(-1).tolist()],
+            [int(value) for value in video_grid.detach().cpu().reshape(-1).tolist()],
+        )
+    )
     special_presentation = packed_vectors(
         (
             special_ids,
@@ -925,6 +1208,7 @@ def capture_primitives(
         token_ids=tuple(packed_vectors((prompt_ids, presentation_ids))),
         special_presentation=tuple(special_presentation),
         processor_shapes=tuple(processor_shapes),
+        processor_grids=tuple(processor_grids),
         sampled_bfloat16_bits=tuple(sampled_bits),
         prompt_sha256=sha256_bytes(prompt.encode("utf-8")),
         image_sha256=sha256_bytes(image.tobytes(order="C")),
@@ -1056,6 +1340,8 @@ def run_tokenizer_processor_capture(
     manifest = conformance_tool.validate_manifest()
     if conformance_tool.EXPECTED_REVISIONS["diffusers"] != DIFFUSERS_REVISION:
         fail("capture Diffusers revision differs from the checked conformance pin")
+    if conformance_tool.EXPECTED_REVISIONS["transformers"] != TRANSFORMERS_REVISION:
+        fail("capture Transformers revision differs from the checked conformance pin")
     if conformance_tool.EXPECTED_REVISIONS["minimax-official-model"] != MODEL_REVISION:
         fail("capture model revision differs from the checked conformance pin")
 
@@ -1076,38 +1362,57 @@ def run_tokenizer_processor_capture(
     transformers_checkout = external_directory(
         "Transformers checkout", values["MOLD_H3_TRANSFORMERS_CHECKOUT"]
     )
-    verify_git_checkout(
-        "Diffusers",
-        diffusers_checkout,
-        DIFFUSERS_REVISION,
-        "https://github.com/huggingface/diffusers",
-    )
-    verify_git_checkout(
-        "Transformers",
-        transformers_checkout,
-        TRANSFORMERS_REVISION,
-        "https://github.com/huggingface/transformers",
-    )
-    verify_model_components(model_root, manifest)
+    manifest_sha256 = sha256_file(MANIFEST_PATH)
+    with tempfile.TemporaryDirectory(
+        prefix=".h3-capture-stage-", dir=fixture_root
+    ) as staged_value:
+        staged_root = pathlib.Path(staged_value).resolve(strict=True)
+        os.chmod(staged_root, 0o700)
+        staged_diffusers = staged_root / "sources" / "diffusers"
+        staged_transformers = staged_root / "sources" / "transformers"
+        staged_model = staged_root / "model"
+        extract_git_source_snapshot(
+            "Diffusers",
+            diffusers_checkout,
+            DIFFUSERS_REVISION,
+            SOURCE_REPOSITORIES["diffusers"],
+            "diffusers",
+            staged_diffusers,
+        )
+        extract_git_source_snapshot(
+            "Transformers",
+            transformers_checkout,
+            TRANSFORMERS_REVISION,
+            SOURCE_REPOSITORIES["transformers"],
+            "transformers",
+            staged_transformers,
+        )
+        stage_model_components(model_root, staged_model, manifest)
+        staged_snapshot = StagedSnapshot(staged_root, snapshot_files(staged_root))
 
-    runtime = load_capture_runtime(diffusers_checkout, transformers_checkout)
-    torch_device = configure_torch(runtime, device)
-    evidence = capture_primitives(runtime, model_root, torch_device)
-    layer_document = build_layer_document(
-        manifest,
-        evidence,
-        authorization["source_document_sha256"],
-        device,
-    )
-    return write_capture(
-        fixture_root,
-        authorization_path,
-        manifest,
-        layer_document,
-        device,
-        conformance_tool,
-        gpu_tool,
-    )
+        runtime = load_capture_runtime(staged_diffusers, staged_transformers)
+        oracle_runtime = validate_oracle_runtime(manifest, runtime)
+        torch_device = configure_torch(runtime, device)
+        evidence = capture_primitives(runtime, staged_model, torch_device)
+        layer_document = build_layer_document(
+            manifest,
+            evidence,
+            authorization["source_document_sha256"],
+            device,
+            oracle_runtime,
+        )
+        staged_snapshot.revalidate()
+        if sha256_file(MANIFEST_PATH) != manifest_sha256:
+            fail("checked conformance manifest changed during capture")
+        return write_capture(
+            fixture_root,
+            authorization_path,
+            manifest,
+            layer_document,
+            device,
+            conformance_tool,
+            gpu_tool,
+        )
 
 
 def parse_args(argv: Sequence[str]) -> argparse.Namespace:

--- a/scripts/capture-minimax-h3-conditioner.py
+++ b/scripts/capture-minimax-h3-conditioner.py
@@ -1,0 +1,1149 @@
+#!/usr/bin/env python3
+"""Capture authorization-bound MiniMax H3 conditioner primitive evidence.
+
+This tool is intentionally separate from every shipped Mold runtime. It opens
+only the public tokenizer and processor metadata named by the checked
+conformance manifest, executes a fixed synthetic-media case, and writes a
+schema-valid oracle layer plus a partial bundle under an approved external
+fixture root. It never opens checkpoint shards or emits evidence in the
+repository.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib
+import importlib.util
+import inspect
+import json
+import math
+import os
+import pathlib
+import re
+import shutil
+import struct
+import subprocess
+import sys
+import tempfile
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+CONFORMANCE_TOOL_PATH = REPO_ROOT / "scripts" / "minimax-h3-conformance.py"
+GPU_CONFORMANCE_TOOL_PATH = REPO_ROOT / "scripts" / "run-minimax-h3-gpu-conformance.py"
+MANIFEST_PATH = (
+    REPO_ROOT / "tests" / "fixtures" / "minimax_h3" / "conformance-manifest.json"
+)
+
+DIFFUSERS_REVISION = "9c6a68c32b3b2a64db91800b624d33cec6e25ab8"
+TRANSFORMERS_REVISION = "42f189ded85d18d00b51161d694cafd325e32b91"
+MODEL_REVISION = "bfc8ed0353f5a9733be73e6b2c98ec0948195b86"
+REVIEWED_AUTHORIZATION_EVIDENCE_SHA256 = (
+    "8cd4d6e52cff34d7d39721ebab13b8c1187aa87aafc1c4ae2a16609186f22f1d"
+)
+CASE_ID = "conditioner-primitives-v1"
+INPUT_SCHEMA = "mold.minimax-h3.tokenizer-processor-input.v1"
+TENSOR_HASH_ENCODING = "canonical-typed-le-v1"
+COMPONENT_AUTHORITY_SET_SCHEMA = "mold.minimax-h3.component-authority-set.v1"
+CAPTURE_COMMAND_PREFIX = (
+    "python3 scripts/capture-minimax-h3-conditioner.py tokenizer-processor"
+)
+REQUIRED_ENVIRONMENT = (
+    "MOLD_H3_FIXTURE_ROOT",
+    "MOLD_H3_AUTHORIZATION_RECORD",
+    "MOLD_H3_OFFICIAL_MODEL",
+    "MOLD_H3_DIFFUSERS_CHECKOUT",
+    "MOLD_H3_TRANSFORMERS_CHECKOUT",
+)
+REQUIRED_COMPONENT_IDS = (
+    "official-model-index",
+    "official-modular-index",
+    "official-tokenizer-json",
+    "official-tokenizer-config",
+    "official-tokenizer-merges",
+    "official-tokenizer-vocab",
+    "official-processor-config",
+    "official-processor-video-config",
+    "official-processor-chat-template",
+    "official-processor-tokenizer-json",
+    "official-processor-tokenizer-config",
+    "official-processor-merges",
+    "official-processor-vocab",
+)
+EXCLUDED_ACCELERATION_ENV_ALIASES = (
+    "torchcompile",
+    "torchinductor",
+    "inductor",
+    "fp8",
+    "float8",
+    "e4m3",
+    "e5m2",
+    "cachedit",
+    "sageattention",
+    "sageattn",
+    "stochasticsampling",
+    "approximateattention",
+    "approxattn",
+    "tf32",
+    "tensorfloat32",
+)
+FALSE_ENVIRONMENT_VALUES = frozenset({"", "0", "false", "no", "off", "disabled"})
+CUDA_DEVICE_PATTERN = re.compile(r"^cuda:([0-9]+)$")
+
+
+class CaptureFailure(Exception):
+    """A fail-closed conditioner capture contract violation."""
+
+
+def fail(message: str) -> None:
+    raise CaptureFailure(message)
+
+
+def load_repo_module(name: str, path: pathlib.Path) -> Any:
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        fail(f"cannot load repository module {name}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    try:
+        return json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError) as error:
+        fail(f"capture evidence is not canonical JSON: {error}")
+
+
+def document_bytes(value: Any) -> bytes:
+    try:
+        return (
+            json.dumps(
+                value,
+                sort_keys=True,
+                indent=2,
+                ensure_ascii=False,
+                allow_nan=False,
+            )
+            + "\n"
+        ).encode("utf-8")
+    except (TypeError, ValueError) as error:
+        fail(f"capture document is not finite JSON: {error}")
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def sha256_file(path: pathlib.Path) -> str:
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as source:
+            while chunk := source.read(1024 * 1024):
+                digest.update(chunk)
+    except OSError as error:
+        fail(f"cannot hash required capture input: {error}")
+    return digest.hexdigest()
+
+
+def is_relative_to(path: pathlib.Path, parent: pathlib.Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def external_directory(label: str, value: str) -> pathlib.Path:
+    path = pathlib.Path(value)
+    if not path.is_absolute():
+        fail(f"{label} must be an absolute path")
+    try:
+        resolved = path.resolve(strict=True)
+    except OSError:
+        fail(f"{label} is unavailable")
+    if not resolved.is_dir():
+        fail(f"{label} is not a directory")
+    if is_relative_to(resolved, REPO_ROOT):
+        fail(f"{label} must live outside the Mold repository")
+    return resolved
+
+
+def external_file(label: str, value: str) -> pathlib.Path:
+    path = pathlib.Path(value)
+    if not path.is_absolute():
+        fail(f"{label} must be an absolute path")
+    try:
+        resolved = path.resolve(strict=True)
+    except OSError:
+        fail(f"{label} is unavailable")
+    if not resolved.is_file():
+        fail(f"{label} is not a file")
+    if is_relative_to(resolved, REPO_ROOT):
+        fail(f"{label} must live outside the Mold repository")
+    return resolved
+
+
+def command_output(arguments: Sequence[str], cwd: pathlib.Path) -> str:
+    try:
+        result = subprocess.run(
+            list(arguments),
+            cwd=cwd,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        fail("capture source checkout probe failed")
+    if result.returncode != 0:
+        fail("capture source checkout probe failed")
+    return result.stdout.strip()
+
+
+def normalized_repository_url(value: str) -> str:
+    normalized = value.strip()
+    if normalized.startswith("git@github.com:"):
+        normalized = "https://github.com/" + normalized.removeprefix("git@github.com:")
+    return normalized.removesuffix("/")
+
+
+def verify_git_checkout(
+    label: str,
+    root: pathlib.Path,
+    expected_revision: str,
+    expected_repository: str,
+) -> None:
+    observed = command_output(["git", "rev-parse", "HEAD"], root)
+    if observed != expected_revision:
+        fail(f"{label} revision differs from the reviewed capture pin")
+    repository = normalized_repository_url(
+        command_output(["git", "remote", "get-url", "origin"], root)
+    )
+    if repository.removesuffix(".git") != expected_repository.removesuffix(".git"):
+        fail(f"{label} repository identity differs from the reviewed capture pin")
+    status = command_output(
+        ["git", "status", "--porcelain=v1", "--untracked-files=all"], root
+    )
+    if status:
+        fail(f"{label} checkout must be clean before capture")
+
+
+def manifest_component_map(manifest: Mapping[str, Any]) -> dict[str, dict[str, str]]:
+    components: dict[str, dict[str, str]] = {}
+    for raw in manifest["component_indexes"]:
+        identifier = raw["id"]
+        if identifier in components:
+            fail("checked manifest repeats component identities")
+        components[identifier] = {
+            "id": identifier,
+            "relative_path": raw["relative_path"],
+            "sha256": raw["sha256"],
+        }
+    return components
+
+
+def huggingface_metadata_revision(model_root: pathlib.Path, relative_path: str) -> str:
+    metadata = (
+        model_root / ".cache" / "huggingface" / "download" / f"{relative_path}.metadata"
+    )
+    try:
+        first_line = metadata.read_text(encoding="utf-8").splitlines()[0]
+    except (OSError, IndexError, UnicodeError):
+        fail("official model snapshot lacks revision-bound component metadata")
+    return first_line
+
+
+def verify_model_components(
+    model_root: pathlib.Path, manifest: Mapping[str, Any]
+) -> list[dict[str, str]]:
+    component_map = manifest_component_map(manifest)
+    if set(REQUIRED_COMPONENT_IDS) - set(component_map):
+        fail("checked manifest lacks conditioner component authority")
+    verified: list[dict[str, str]] = []
+    for identifier in REQUIRED_COMPONENT_IDS:
+        component = component_map[identifier]
+        relative_path = component["relative_path"]
+        candidate = model_root / relative_path
+        if candidate.is_symlink():
+            fail("official model component may not be a symbolic link")
+        try:
+            resolved = candidate.resolve(strict=True)
+        except OSError:
+            fail(f"official model component is unavailable: {identifier}")
+        if not resolved.is_file() or not is_relative_to(resolved, model_root):
+            fail(f"official model component escapes the snapshot: {identifier}")
+        if sha256_file(resolved) != component["sha256"]:
+            fail(f"official model component hash drifted: {identifier}")
+        if huggingface_metadata_revision(model_root, relative_path) != MODEL_REVISION:
+            fail(f"official model component revision drifted: {identifier}")
+        verified.append({"id": identifier, "sha256": component["sha256"]})
+    return verified
+
+
+def normalize_acceleration_name(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "", value.lower())
+
+
+def reject_excluded_acceleration_environment(environment: Mapping[str, str]) -> None:
+    for key, value in environment.items():
+        normalized_key = normalize_acceleration_name(key)
+        normalized_value = value.strip().lower()
+        if normalized_value in FALSE_ENVIRONMENT_VALUES:
+            continue
+        if any(alias in normalized_key for alias in EXCLUDED_ACCELERATION_ENV_ALIASES):
+            fail("capture environment enables or configures an excluded acceleration")
+
+
+def component_authority_set_sha256(
+    component_ids: Iterable[str], component_map: Mapping[str, Mapping[str, str]]
+) -> str:
+    return sha256_bytes(
+        canonical_json_bytes(
+            {
+                "schema_version": COMPONENT_AUTHORITY_SET_SCHEMA,
+                "components": [
+                    {
+                        "id": identifier,
+                        "sha256": component_map[identifier]["sha256"],
+                    }
+                    for identifier in sorted(component_ids)
+                ],
+            }
+        )
+    )
+
+
+def bfloat16_bits_to_float(bits: int) -> float:
+    if not 0 <= bits <= 0xFFFF:
+        fail("bfloat16 capture value is outside its encoded domain")
+    return struct.unpack("<f", struct.pack("<I", bits << 16))[0]
+
+
+def sample_indexes(length: int) -> list[int]:
+    if length <= 0:
+        fail("capture tensors must be non-empty")
+    return sorted({0, length // 4, length // 2, (3 * length) // 4, length - 1})
+
+
+def finite_statistics(values: Sequence[float | int]) -> dict[str, float | int]:
+    if not values:
+        fail("capture tensors must be non-empty")
+    converted = [float(value) for value in values]
+    if not all(math.isfinite(value) for value in converted):
+        fail("capture tensor contains a non-finite value")
+    mean = math.fsum(converted) / len(converted)
+    variance = math.fsum((value - mean) ** 2 for value in converted) / len(converted)
+    return {
+        "min": min(values),
+        "max": max(values),
+        "mean": mean,
+        "std": math.sqrt(variance),
+    }
+
+
+def integer_tensor_record(key: str, values: Sequence[int]) -> dict[str, Any]:
+    signed_values = [int(value) for value in values]
+    if not signed_values or any(
+        not -(2**63) <= value <= 2**63 - 1 for value in signed_values
+    ):
+        fail(f"{key} evidence is outside signed int64")
+    digest = hashlib.sha256()
+    for value in signed_values:
+        digest.update(struct.pack("<q", value))
+    return {
+        "key": key,
+        "shape": [len(signed_values)],
+        "dtype": "int64",
+        "content_sha256": digest.hexdigest(),
+        "statistics": finite_statistics(signed_values),
+        "samples": [
+            {"index": [index], "value": signed_values[index]}
+            for index in sample_indexes(len(signed_values))
+        ],
+    }
+
+
+def bfloat16_tensor_record(key: str, bits: Sequence[int]) -> dict[str, Any]:
+    encoded = [int(value) for value in bits]
+    if not encoded:
+        fail(f"{key} evidence is empty")
+    digest = hashlib.sha256()
+    for value in encoded:
+        if not 0 <= value <= 0xFFFF:
+            fail(f"{key} evidence contains an invalid bfloat16 encoding")
+        digest.update(struct.pack("<H", value))
+    values = [bfloat16_bits_to_float(value) for value in encoded]
+    if not all(math.isfinite(value) for value in values):
+        fail(f"{key} evidence contains a non-finite bfloat16")
+    return {
+        "key": key,
+        "shape": [len(values)],
+        "dtype": "bfloat16",
+        "content_sha256": digest.hexdigest(),
+        "statistics": finite_statistics(values),
+        "samples": [
+            {"index": [index], "value": values[index]}
+            for index in sample_indexes(len(values))
+        ],
+    }
+
+
+def packed_vectors(vectors: Sequence[Sequence[int]]) -> list[int]:
+    result = [len(vectors)]
+    for vector in vectors:
+        result.append(len(vector))
+        result.extend(int(value) for value in vector)
+    return result
+
+
+def packed_shapes(named_shapes: Sequence[tuple[int, Sequence[int]]]) -> list[int]:
+    result = [len(named_shapes)]
+    seen: set[int] = set()
+    for identifier, shape in named_shapes:
+        if identifier in seen:
+            fail("processor shape evidence repeats an identity")
+        seen.add(identifier)
+        dims = [int(value) for value in shape]
+        if not dims or any(value <= 0 for value in dims):
+            fail("processor shape evidence has an invalid dimension")
+        result.extend([identifier, len(dims), *dims])
+    return result
+
+
+def acceleration_policy(manifest: Mapping[str, Any]) -> dict[str, list[str]]:
+    disabled = list(manifest["numerical_authority"]["excluded_accelerations"])
+    if len(disabled) != len(set(disabled)):
+        fail("checked manifest repeats acceleration exclusions")
+    return {
+        "enabled": [
+            "cuda",
+            "deterministic-cuda-copy",
+            "pytorch-bfloat16",
+            "qwen3-vl-processor",
+        ],
+        "disabled": disabled,
+    }
+
+
+@dataclass(frozen=True)
+class PrimitiveEvidence:
+    token_ids: tuple[int, ...]
+    special_presentation: tuple[int, ...]
+    processor_shapes: tuple[int, ...]
+    sampled_bfloat16_bits: tuple[int, ...]
+    prompt_sha256: str
+    image_sha256: str
+    video_sha256: str
+    sampled_source_indices: tuple[int, ...]
+    sampled_timestamps_millis: tuple[int, ...]
+
+
+def build_input_descriptor(evidence: PrimitiveEvidence) -> dict[str, Any]:
+    return {
+        "schema_version": INPUT_SCHEMA,
+        "case_id": CASE_ID,
+        "source_revisions": {
+            "diffusers": DIFFUSERS_REVISION,
+            "transformers": TRANSFORMERS_REVISION,
+            "official_model": MODEL_REVISION,
+        },
+        "prompt": {
+            "encoding": "utf-8",
+            "sha256": evidence.prompt_sha256,
+            "special_tokens_added": False,
+            "chat_template_applied": False,
+        },
+        "image": {
+            "generator": "mold-h3-rgb-pattern-v1",
+            "shape": [256, 256, 3],
+            "dtype": "uint8",
+            "sha256": evidence.image_sha256,
+        },
+        "video": {
+            "generator": "mold-h3-rgb-pattern-v1",
+            "shape": [37, 64, 64, 3],
+            "dtype": "uint8",
+            "fps": 24,
+            "sample_fps": 2,
+            "sha256": evidence.video_sha256,
+            "sampled_source_indices": list(evidence.sampled_source_indices),
+            "sampled_timestamps_millis": list(evidence.sampled_timestamps_millis),
+        },
+    }
+
+
+def layer_contract(manifest: Mapping[str, Any]) -> Mapping[str, Any]:
+    matches = [
+        layer
+        for layer in manifest["fixture_layers"]
+        if layer["id"] == "tokenizer-processor"
+    ]
+    if len(matches) != 1:
+        fail("checked manifest does not contain one tokenizer/processor layer")
+    layer = matches[0]
+    if tuple(layer["required_component_indexes"]) != REQUIRED_COMPONENT_IDS:
+        fail("tokenizer/processor component authority drifted")
+    if tuple(layer["required_measurements"]) != (
+        "token-ids",
+        "special-token-presentation",
+        "processor-shapes",
+        "sampled-values",
+    ):
+        fail("tokenizer/processor measurement contract drifted")
+    return layer
+
+
+def build_layer_document(
+    manifest: Mapping[str, Any],
+    evidence: PrimitiveEvidence,
+    authorization_sha256: str,
+    device: str,
+) -> dict[str, Any]:
+    contract = layer_contract(manifest)
+    component_map = manifest_component_map(manifest)
+    components = [
+        {"id": identifier, "sha256": component_map[identifier]["sha256"]}
+        for identifier in REQUIRED_COMPONENT_IDS
+    ]
+    tokenizer_ids = (
+        "official-tokenizer-json",
+        "official-tokenizer-config",
+        "official-tokenizer-merges",
+        "official-tokenizer-vocab",
+    )
+    processor_ids = (
+        "official-processor-config",
+        "official-processor-video-config",
+        "official-processor-chat-template",
+        "official-processor-tokenizer-json",
+        "official-processor-tokenizer-config",
+        "official-processor-merges",
+        "official-processor-vocab",
+    )
+    command = f"{CAPTURE_COMMAND_PREFIX} --device {device}"
+    input_descriptor = build_input_descriptor(evidence)
+    policy = acceleration_policy(manifest)
+    outputs = [
+        integer_tensor_record("token-ids", evidence.token_ids),
+        integer_tensor_record(
+            "special-token-presentation", evidence.special_presentation
+        ),
+        integer_tensor_record("processor-shapes", evidence.processor_shapes),
+        bfloat16_tensor_record("sampled-values", evidence.sampled_bfloat16_bits),
+    ]
+    comparison = [
+        {
+            "key": key,
+            "absolute": 0,
+            "relative": 0,
+            "metric": "elementwise-atol-plus-rtol",
+            "hash_policy": "exact",
+        }
+        for key in contract["required_measurements"]
+    ]
+    return {
+        "schema_version": "mold.minimax-h3.layer-output.v1",
+        "family": "minimax-h3",
+        "case_id": CASE_ID,
+        "layer": "tokenizer-processor",
+        "authority_tier": "exact-full-bf16",
+        "authorization_document_sha256": authorization_sha256,
+        "input": {
+            "id": CASE_ID,
+            "sha256": sha256_bytes(canonical_json_bytes(input_descriptor)),
+            "component_index_sha256": components[0]["sha256"],
+            "component_indexes": components,
+        },
+        "producer": {
+            "role": "oracle",
+            "implementation": (
+                "diffusers-minimax-h3-transformers-42f189de-tokenizer-processor"
+            ),
+            "source_id": "diffusers",
+            "revision": DIFFUSERS_REVISION,
+        },
+        "adapter": {
+            "schema_version": "mold.minimax-h3.layer-adapter.v1",
+            "id": "minimax-h3-tokenizer-processor-capture-v1",
+            "command": command,
+            "tensor_hash_encoding": TENSOR_HASH_ENCODING,
+        },
+        "environment": {
+            "device": device,
+            "dtype": "bfloat16",
+            "attention_backend": "none-conditioner-preprocessing",
+            "acceleration_policy": policy,
+            "forbidden_accelerations_disabled": True,
+        },
+        "provenance": [
+            {"key": "source-revision", "value": DIFFUSERS_REVISION},
+            {
+                "key": "tokenizer-hash",
+                "value": component_authority_set_sha256(tokenizer_ids, component_map),
+            },
+            {
+                "key": "processor-hash",
+                "value": component_authority_set_sha256(processor_ids, component_map),
+            },
+            {"key": "device", "value": device},
+            {"key": "capture-command", "value": command},
+        ],
+        "outputs": outputs,
+        "comparison": comparison,
+    }
+
+
+def expected_tensor_summary(output: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "shape": output["shape"],
+        "dtype": output["dtype"],
+        "min": output["statistics"]["min"],
+        "max": output["statistics"]["max"],
+        "mean": output["statistics"]["mean"],
+        "std": output["statistics"]["std"],
+        "sampled_values": [sample["value"] for sample in output["samples"]],
+    }
+
+
+def build_bundle(
+    manifest: Mapping[str, Any],
+    layer_document: Mapping[str, Any],
+    layer_encoded: bytes,
+    relative_layer_path: str,
+    authorization_sha256: str,
+    device: str,
+) -> dict[str, Any]:
+    first_output = layer_document["outputs"][0]
+    first_policy = layer_document["comparison"][0]
+    return {
+        "schema_version": "mold.minimax-h3.fixture-bundle.v1",
+        "manifest_sha256": sha256_file(MANIFEST_PATH),
+        "authorization_document_sha256": authorization_sha256,
+        "capture_environment": {
+            "framework": "diffusers",
+            "framework_revision": DIFFUSERS_REVISION,
+            "device": device,
+            "dtype": "bfloat16",
+            "attention_backend": "none-conditioner-preprocessing",
+            "acceleration_policy": acceleration_policy(manifest),
+            "command": layer_document["adapter"]["command"],
+            "forbidden_accelerations_disabled": True,
+        },
+        "fixtures": [
+            {
+                "id": f"oracle-{CASE_ID}-tokenizer-processor",
+                "layer": "tokenizer-processor",
+                "authority_tier": "exact-full-bf16",
+                "relative_path": relative_layer_path,
+                "sha256": sha256_bytes(layer_encoded),
+                "component_index_sha256": layer_document["input"][
+                    "component_index_sha256"
+                ],
+                "component_indexes": layer_document["input"]["component_indexes"],
+                "tensor": expected_tensor_summary(first_output),
+                "tolerance": {
+                    "absolute": first_policy["absolute"],
+                    "relative": first_policy["relative"],
+                    "metric": first_policy["metric"],
+                },
+            }
+        ],
+    }
+
+
+def verify_module_origin(
+    label: str, module_or_class: Any, checkout: pathlib.Path
+) -> None:
+    try:
+        source = pathlib.Path(inspect.getfile(module_or_class)).resolve(strict=True)
+    except (OSError, TypeError):
+        fail(f"cannot bind {label} to its reviewed checkout")
+    if not is_relative_to(source, checkout):
+        fail(f"{label} imported outside its reviewed checkout")
+
+
+def load_capture_runtime(
+    diffusers_checkout: pathlib.Path, transformers_checkout: pathlib.Path
+) -> SimpleNamespace:
+    sys.dont_write_bytecode = True
+    source_paths = [
+        transformers_checkout / "src",
+        diffusers_checkout / "src",
+    ]
+    if any(not path.is_dir() for path in source_paths):
+        fail("capture checkout lacks its source package")
+    for path in reversed(source_paths):
+        sys.path.insert(0, str(path))
+    for package in ("diffusers", "transformers"):
+        if package in sys.modules:
+            fail(f"{package} was imported before provenance was verified")
+    try:
+        torch = importlib.import_module("torch")
+        numpy = importlib.import_module("numpy")
+        transformers = importlib.import_module("transformers")
+        diffusers = importlib.import_module("diffusers")
+        qwen_module = importlib.import_module(
+            "transformers.models.qwen3_vl.processing_qwen3_vl"
+        )
+        encoder_module = importlib.import_module(
+            "diffusers.modular_pipelines.minimax_h3.encoders"
+        )
+    except (ImportError, RuntimeError) as error:
+        fail(f"reviewed capture runtime cannot be imported: {error}")
+    verify_module_origin("Transformers", transformers, transformers_checkout)
+    verify_module_origin(
+        "Qwen3-VL processor", qwen_module.Qwen3VLProcessor, transformers_checkout
+    )
+    verify_module_origin("Diffusers", diffusers, diffusers_checkout)
+    verify_module_origin(
+        "MiniMax H3 encoder",
+        encoder_module.MiniMaxH3Ref2VATextEncoderStep,
+        diffusers_checkout,
+    )
+    if not hasattr(qwen_module.Qwen3VLProcessor, "create_mm_token_type_ids"):
+        fail("reviewed Transformers checkout lacks Qwen modality type authority")
+    return SimpleNamespace(
+        torch=torch,
+        numpy=numpy,
+        tokenizer_class=transformers.Qwen2TokenizerFast,
+        processor_class=qwen_module.Qwen3VLProcessor,
+        encoder_step=encoder_module.MiniMaxH3Ref2VATextEncoderStep,
+        transformers_checkout=transformers_checkout,
+    )
+
+
+def configure_torch(runtime: SimpleNamespace, device: str) -> Any:
+    torch = runtime.torch
+    match = CUDA_DEVICE_PATTERN.fullmatch(device)
+    if match is None:
+        fail("capture device must be an indexed CUDA device such as cuda:0")
+    if not torch.cuda.is_available():
+        fail("CUDA is unavailable for protected capture")
+    index = int(match.group(1))
+    if index >= torch.cuda.device_count():
+        fail("requested CUDA capture device is unavailable")
+    torch.cuda.set_device(index)
+    torch.use_deterministic_algorithms(True)
+    torch.set_float32_matmul_precision("highest")
+    torch.backends.cuda.matmul.allow_tf32 = False
+    if hasattr(torch.backends, "cudnn"):
+        torch.backends.cudnn.allow_tf32 = False
+        torch.backends.cudnn.benchmark = False
+        torch.backends.cudnn.deterministic = True
+    for name, enabled in (
+        ("enable_flash_sdp", False),
+        ("enable_mem_efficient_sdp", False),
+        ("enable_cudnn_sdp", False),
+        ("enable_math_sdp", True),
+    ):
+        callback = getattr(torch.backends.cuda, name, None)
+        if callback is not None:
+            callback(enabled)
+    if torch.backends.cuda.matmul.allow_tf32:
+        fail("TF32 remained enabled after capture preflight")
+    if hasattr(torch.backends, "cudnn") and torch.backends.cudnn.allow_tf32:
+        fail("cuDNN TF32 remained enabled after capture preflight")
+    if not torch.are_deterministic_algorithms_enabled():
+        fail("deterministic PyTorch execution remained disabled after preflight")
+    for name, expected in (
+        ("flash_sdp_enabled", False),
+        ("mem_efficient_sdp_enabled", False),
+        ("cudnn_sdp_enabled", False),
+        ("math_sdp_enabled", True),
+    ):
+        probe = getattr(torch.backends.cuda, name, None)
+        if probe is not None and bool(probe()) != expected:
+            fail("PyTorch attention backend policy drifted after capture preflight")
+    return torch.device(device)
+
+
+def rgb_pattern(numpy: Any, frames: int, height: int, width: int) -> Any:
+    frame_axis = numpy.arange(frames, dtype=numpy.uint16)[:, None, None]
+    y_axis = numpy.arange(height, dtype=numpy.uint16)[None, :, None]
+    x_axis = numpy.arange(width, dtype=numpy.uint16)[None, None, :]
+    red = (3 * x_axis + 5 * y_axis + 19 * frame_axis) % 256
+    green = (7 * x_axis + 11 * y_axis + 17 + 23 * frame_axis) % 256
+    blue = (13 * x_axis + 17 * y_axis + 29 + 31 * frame_axis) % 256
+    return numpy.stack((red, green, blue), axis=-1).astype(numpy.uint8)
+
+
+def bfloat16_bits_from_tensor(torch: Any, tensor: Any, device: Any) -> list[int]:
+    copied = tensor.detach().to(device=device, dtype=torch.bfloat16).contiguous()
+    torch.cuda.synchronize(device)
+    values = copied.to(device="cpu", dtype=torch.float32).reshape(-1).tolist()
+    bits: list[int] = []
+    for value in values:
+        encoded = struct.unpack("<I", struct.pack("<f", float(value)))[0]
+        if encoded & 0xFFFF:
+            fail("CUDA BF16 capture did not round-trip exactly")
+        bits.append(encoded >> 16)
+    return bits
+
+
+def capture_primitives(
+    runtime: SimpleNamespace, model_root: pathlib.Path, device: Any
+) -> PrimitiveEvidence:
+    torch = runtime.torch
+    numpy = runtime.numpy
+    tokenizer_root = model_root / "tokenizer"
+    processor_root = model_root / "processor"
+    try:
+        tokenizer = runtime.tokenizer_class.from_pretrained(
+            tokenizer_root, local_files_only=True
+        )
+        processor = runtime.processor_class.from_pretrained(
+            processor_root, local_files_only=True
+        )
+    except (OSError, RuntimeError, ValueError) as error:
+        fail(f"pinned tokenizer/processor could not be loaded: {error}")
+    verify_module_origin(
+        "Qwen tokenizer", tokenizer.__class__, runtime.transformers_checkout
+    )
+    verify_module_origin(
+        "Qwen processor tokenizer",
+        processor.tokenizer.__class__,
+        runtime.transformers_checkout,
+    )
+    verify_module_origin(
+        "Qwen image processor",
+        processor.image_processor.__class__,
+        runtime.transformers_checkout,
+    )
+    verify_module_origin(
+        "Qwen video processor",
+        processor.video_processor.__class__,
+        runtime.transformers_checkout,
+    )
+
+    prompt = "Raw prompt: coral robot, café, and literal <|vision_start|> bytes."
+    prompt_ids = tokenizer(prompt, add_special_tokens=False)["input_ids"]
+    processor_prompt_ids = processor.tokenizer(prompt, add_special_tokens=False)[
+        "input_ids"
+    ]
+    if prompt_ids != processor_prompt_ids:
+        fail("processor tokenizer differs from the pinned standalone tokenizer")
+
+    image = rgb_pattern(numpy, 1, 256, 256)[0]
+    video = rgb_pattern(numpy, 37, 64, 64)
+    temporal_patch = int(processor.video_processor.temporal_patch_size)
+    sampled_frames, timestamps = runtime.encoder_step._sample_video_condition_frames(
+        video, 24.0, 2.0, temporal_patch
+    )
+    expected_indices = (0, 12, 24, 36)
+    if len(sampled_frames) != len(expected_indices) or any(
+        not numpy.array_equal(frame, video[index])
+        for frame, index in zip(sampled_frames, expected_indices)
+    ):
+        fail("pinned Diffusers video sampling authority drifted")
+    timestamps_millis = tuple(round(value * 1000) for value in timestamps)
+    if timestamps_millis != (250, 1250):
+        fail("pinned Diffusers video timestamp authority drifted")
+
+    try:
+        image_features = processor.image_processor(images=[image], return_tensors="pt")
+        video_features = processor.video_processor(
+            videos=[numpy.stack(sampled_frames)],
+            do_sample_frames=False,
+            return_tensors="pt",
+        )
+    except (RuntimeError, TypeError, ValueError) as error:
+        fail(f"pinned Qwen processor execution failed: {error}")
+
+    merge_size = int(processor.image_processor.merge_size) ** 2
+    image_grid = image_features["image_grid_thw"]
+    video_grid = video_features["video_grid_thw"]
+    image_tokens = int(image_grid[0].prod().item()) // merge_size
+    video_tokens = (
+        int(video_grid[0][1].item()) * int(video_grid[0][2].item()) // merge_size
+    )
+    if int(video_grid[0][0].item()) != len(timestamps):
+        fail("pinned Qwen video processor changed temporal block geometry")
+
+    references = [
+        SimpleNamespace(kind="image", has_audio=False),
+        SimpleNamespace(kind="video", has_audio=False),
+    ]
+    presentation_ids, h3_tags = runtime.encoder_step._build_presentation(
+        tokenizer,
+        prompt,
+        references,
+        [image_tokens],
+        [video_tokens],
+        [list(timestamps)],
+    )
+    mm_type_ids = processor.create_mm_token_type_ids([presentation_ids])[0]
+    if len(mm_type_ids) != len(presentation_ids) or len(h3_tags) != len(
+        presentation_ids
+    ):
+        fail("pinned presentation modality evidence has inconsistent length")
+
+    special_ids = [
+        tokenizer.convert_tokens_to_ids("<|vision_start|>"),
+        tokenizer.convert_tokens_to_ids("<|vision_end|>"),
+        tokenizer.convert_tokens_to_ids("<|image_pad|>"),
+        tokenizer.convert_tokens_to_ids("<|video_pad|>"),
+    ]
+    if any(value is None or value < 0 for value in special_ids):
+        fail("pinned tokenizer lacks required H3 special tokens")
+
+    image_pixels = image_features["pixel_values"]
+    video_pixels = video_features["pixel_values_videos"]
+    sampled_bits = [
+        *bfloat16_bits_from_tensor(torch, image_pixels, device),
+        *bfloat16_bits_from_tensor(torch, video_pixels, device),
+    ]
+    processor_shapes = packed_shapes(
+        (
+            (1, image.shape),
+            (2, video.shape),
+            (3, (len(sampled_frames), *sampled_frames[0].shape)),
+            (4, tuple(image_pixels.shape)),
+            (5, tuple(image_grid.shape)),
+            (6, tuple(video_pixels.shape)),
+            (7, tuple(video_grid.shape)),
+        )
+    )
+    special_presentation = packed_vectors(
+        (
+            special_ids,
+            h3_tags,
+            mm_type_ids,
+            list(expected_indices),
+            list(timestamps_millis),
+        )
+    )
+    return PrimitiveEvidence(
+        token_ids=tuple(packed_vectors((prompt_ids, presentation_ids))),
+        special_presentation=tuple(special_presentation),
+        processor_shapes=tuple(processor_shapes),
+        sampled_bfloat16_bits=tuple(sampled_bits),
+        prompt_sha256=sha256_bytes(prompt.encode("utf-8")),
+        image_sha256=sha256_bytes(image.tobytes(order="C")),
+        video_sha256=sha256_bytes(video.tobytes(order="C")),
+        sampled_source_indices=expected_indices,
+        sampled_timestamps_millis=timestamps_millis,
+    )
+
+
+def exclusive_write(path: pathlib.Path, encoded: bytes) -> None:
+    temporary: pathlib.Path | None = None
+    try:
+        descriptor, temporary_value = tempfile.mkstemp(
+            prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+        )
+        temporary = pathlib.Path(temporary_value)
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "wb") as destination:
+            destination.write(encoded)
+            destination.flush()
+            os.fsync(destination.fileno())
+        os.link(temporary, path)
+    except FileExistsError:
+        fail("capture output already exists; refusing to overwrite evidence")
+    except OSError as error:
+        fail(f"cannot commit external capture evidence: {error}")
+    finally:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
+
+
+def write_capture(
+    fixture_root: pathlib.Path,
+    authorization_path: pathlib.Path,
+    manifest: Mapping[str, Any],
+    layer_document: Mapping[str, Any],
+    device: str,
+    conformance_tool: Any,
+    gpu_tool: Any,
+) -> tuple[pathlib.Path, pathlib.Path]:
+    contracts = gpu_tool.exact_layer_contracts(manifest)
+    gpu_tool.validate_manifest_layer_evidence(
+        layer_document, contracts["tokenizer-processor"], "oracle"
+    )
+    conformance_tool.validate_schema(
+        layer_document, conformance_tool.LAYER_OUTPUT_SCHEMA_PATH
+    )
+    layer_encoded = document_bytes(layer_document)
+    capture_name = f"{CASE_ID}-{layer_document['input']['sha256'][:16]}"
+    parent = fixture_root / "captures" / "tokenizer-processor"
+    parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    resolved_parent = parent.resolve(strict=True)
+    if not is_relative_to(resolved_parent, fixture_root):
+        fail("capture destination escapes MOLD_H3_FIXTURE_ROOT")
+    capture_dir = parent / capture_name
+    try:
+        capture_dir.mkdir(mode=0o700, exist_ok=False)
+    except FileExistsError:
+        fail("capture case already exists; refusing to overwrite evidence")
+    except OSError as error:
+        fail(f"cannot create external capture directory: {error}")
+    layer_path = capture_dir / "oracle.json"
+    bundle_path = capture_dir / "oracle-bundle.json"
+    try:
+        resolved_capture = capture_dir.resolve(strict=True)
+        if not is_relative_to(resolved_capture, fixture_root):
+            fail("capture directory escapes MOLD_H3_FIXTURE_ROOT")
+        relative_layer_path = layer_path.relative_to(fixture_root).as_posix()
+        bundle = build_bundle(
+            manifest,
+            layer_document,
+            layer_encoded,
+            relative_layer_path,
+            layer_document["authorization_document_sha256"],
+            device,
+        )
+        conformance_tool.validate_schema(bundle, conformance_tool.BUNDLE_SCHEMA_PATH)
+        bundle_encoded = document_bytes(bundle)
+        exclusive_write(layer_path, layer_encoded)
+        exclusive_write(bundle_path, bundle_encoded)
+        conformance_tool.validate_bundle(
+            manifest,
+            str(fixture_root),
+            str(bundle_path),
+            str(authorization_path),
+        )
+    except BaseException:
+        shutil.rmtree(capture_dir, ignore_errors=True)
+        raise
+    return layer_path, bundle_path
+
+
+def required_environment(environment: Mapping[str, str]) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for name in REQUIRED_ENVIRONMENT:
+        value = environment.get(name, "").strip()
+        if not value:
+            fail(f"{name} is required")
+        values[name] = value
+    return values
+
+
+def validate_reviewed_authorization(
+    conformance_tool: Any, authorization_path: pathlib.Path
+) -> dict[str, Any]:
+    authorization = conformance_tool.validate_authorization(authorization_path)
+    if (
+        authorization["source_document_sha256"]
+        != REVIEWED_AUTHORIZATION_EVIDENCE_SHA256
+    ):
+        fail("authorization record does not bind the reviewed evidence")
+    external_file(
+        "authorization source document", authorization["source_document_path"]
+    )
+    return authorization
+
+
+def run_tokenizer_processor_capture(
+    environment: Mapping[str, str], device: str
+) -> tuple[pathlib.Path, pathlib.Path]:
+    reject_excluded_acceleration_environment(environment)
+    values = required_environment(environment)
+    conformance_tool = load_repo_module(
+        "minimax_h3_conformance_capture", CONFORMANCE_TOOL_PATH
+    )
+    gpu_tool = load_repo_module(
+        "minimax_h3_gpu_conformance_capture", GPU_CONFORMANCE_TOOL_PATH
+    )
+    manifest = conformance_tool.validate_manifest()
+    if conformance_tool.EXPECTED_REVISIONS["diffusers"] != DIFFUSERS_REVISION:
+        fail("capture Diffusers revision differs from the checked conformance pin")
+    if conformance_tool.EXPECTED_REVISIONS["minimax-official-model"] != MODEL_REVISION:
+        fail("capture model revision differs from the checked conformance pin")
+
+    fixture_root = external_directory("fixture root", values["MOLD_H3_FIXTURE_ROOT"])
+    authorization_path = external_file(
+        "authorization record", values["MOLD_H3_AUTHORIZATION_RECORD"]
+    )
+    authorization = validate_reviewed_authorization(
+        conformance_tool, authorization_path
+    )
+
+    model_root = external_directory(
+        "official model snapshot", values["MOLD_H3_OFFICIAL_MODEL"]
+    )
+    diffusers_checkout = external_directory(
+        "Diffusers checkout", values["MOLD_H3_DIFFUSERS_CHECKOUT"]
+    )
+    transformers_checkout = external_directory(
+        "Transformers checkout", values["MOLD_H3_TRANSFORMERS_CHECKOUT"]
+    )
+    verify_git_checkout(
+        "Diffusers",
+        diffusers_checkout,
+        DIFFUSERS_REVISION,
+        "https://github.com/huggingface/diffusers",
+    )
+    verify_git_checkout(
+        "Transformers",
+        transformers_checkout,
+        TRANSFORMERS_REVISION,
+        "https://github.com/huggingface/transformers",
+    )
+    verify_model_components(model_root, manifest)
+
+    runtime = load_capture_runtime(diffusers_checkout, transformers_checkout)
+    torch_device = configure_torch(runtime, device)
+    evidence = capture_primitives(runtime, model_root, torch_device)
+    layer_document = build_layer_document(
+        manifest,
+        evidence,
+        authorization["source_document_sha256"],
+        device,
+    )
+    return write_capture(
+        fixture_root,
+        authorization_path,
+        manifest,
+        layer_document,
+        device,
+        conformance_tool,
+        gpu_tool,
+    )
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Capture authorization-bound external MiniMax H3 conditioner evidence."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    capture = subparsers.add_parser(
+        "tokenizer-processor",
+        help="capture the pinned Diffusers tokenizer and multimodal processor case",
+    )
+    capture.add_argument(
+        "--device",
+        default=os.environ.get("MOLD_H3_CAPTURE_DEVICE", "cuda:0"),
+        help="indexed CUDA device; defaults to MOLD_H3_CAPTURE_DEVICE or cuda:0",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    try:
+        if args.command != "tokenizer-processor":
+            fail("unsupported capture command")
+        layer_path, bundle_path = run_tokenizer_processor_capture(
+            os.environ, args.device
+        )
+        print(
+            "MiniMax H3 conditioner capture complete: "
+            f"layer={layer_path.name} bundle={bundle_path.name}"
+        )
+        return 0
+    except (CaptureFailure, OSError, subprocess.SubprocessError) as error:
+        print(f"MiniMax H3 conditioner capture rejected: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/minimax-h3-conformance.py
+++ b/scripts/minimax-h3-conformance.py
@@ -51,12 +51,20 @@ EXPECTED_REVISIONS = {
     "minimax-official-code": "8d8824efaf94586c0cc9ac7ad8d0723d4d6420ea",
     "minimax-official-model": "bfc8ed0353f5a9733be73e6b2c98ec0948195b86",
     "diffusers": "9c6a68c32b3b2a64db91800b624d33cec6e25ab8",
+    "transformers": "42f189ded85d18d00b51161d694cafd325e32b91",
     "comfyui": "a464ac33588ae182f81a090d910cfbf21e255b73",
     "comfy-checkpoints": "eb8a16107c595128b3a578f82d2ce2f75920c355",
     "sglang": "0c3a76fa0a5bfab410b645f4143e7e8e3cc25c77",
     "vllm-omni": "3d7fc3b9ba3cac88d579d4dc35b78b0b641675fc",
 }
 
+EXPECTED_ORACLE_RUNTIME = {
+    "python": "3.13.13",
+    "torch": "2.13.0+cu130",
+    "numpy": "2.5.1",
+    "cuda": "13.0",
+    "transformers_revision": EXPECTED_REVISIONS["transformers"],
+}
 EXPECTED_LICENSE_SHA256 = (
     "59b99642b95ea21630e311198ddbfffbfe05aadba0c2f5d884cbdf4efcc90f44"
 )
@@ -229,6 +237,36 @@ def sha256_file(path: pathlib.Path) -> str:
     except OSError as error:
         fail(f"cannot hash {path}: {error}")
     return digest.hexdigest()
+
+
+def checked_repository_implementation_path(value: str) -> pathlib.Path:
+    relative = pathlib.PurePosixPath(value)
+    if (
+        relative.is_absolute()
+        or not relative.parts
+        or relative.parts[0] != "scripts"
+        or ".." in relative.parts
+    ):
+        fail("oracle adapter implementation path escapes the reviewed checkout")
+    current = REPO_ROOT
+    for index, part in enumerate(relative.parts):
+        current = current / part
+        try:
+            current.lstat()
+        except OSError:
+            fail("oracle adapter implementation path is unavailable")
+        if pathlib.Path(current).is_symlink():
+            fail("oracle adapter implementation path may not traverse a symbolic link")
+        if index < len(relative.parts) - 1 and not current.is_dir():
+            fail("oracle adapter implementation path has a non-directory parent")
+    try:
+        resolved = current.resolve(strict=True)
+        resolved.relative_to(REPO_ROOT.resolve(strict=True))
+    except (OSError, ValueError):
+        fail("oracle adapter implementation path escapes the reviewed checkout")
+    if not resolved.is_file():
+        fail("oracle adapter implementation path is not a regular file")
+    return resolved
 
 
 def schema_helper() -> Any:
@@ -775,6 +813,8 @@ def validate_manifest() -> dict[str, Any]:
         or revisions != EXPECTED_REVISIONS
     ):
         fail("source revisions drifted from the reviewed H3 authority set")
+    if manifest["numerical_authority"].get("oracle_runtime") != EXPECTED_ORACLE_RUNTIME:
+        fail("oracle runtime identity drifted from the reviewed H3 authority set")
 
     excluded = set(manifest["numerical_authority"]["excluded_accelerations"])
     if (
@@ -809,6 +849,18 @@ def validate_manifest() -> dict[str, Any]:
     ):
         fail("fixture layer coverage is incomplete or contains an unreviewed layer")
     for layer in manifest["fixture_layers"]:
+        oracle_adapter = layer.get("oracle_adapter")
+        if oracle_adapter is not None:
+            implementation_path = checked_repository_implementation_path(
+                oracle_adapter["implementation_path"]
+            )
+            if oracle_adapter["implementation_sha256"] != sha256_file(
+                implementation_path
+            ):
+                fail(f"fixture layer {layer['id']} adapter authority drifted")
+            expected_command_start = f"python3 {oracle_adapter['implementation_path']} "
+            if not oracle_adapter["command_prefix"].startswith(expected_command_start):
+                fail(f"fixture layer {layer['id']} adapter command is not path-bound")
         component_ids = layer["required_component_indexes"]
         if len(component_ids) != len(set(component_ids)) or not set(
             component_ids

--- a/scripts/run-minimax-h3-gpu-conformance.py
+++ b/scripts/run-minimax-h3-gpu-conformance.py
@@ -70,6 +70,7 @@ MEASUREMENT_DTYPES = {
         "token-ids": CANONICAL_INTEGER_DTYPE,
         "special-token-presentation": CANONICAL_INTEGER_DTYPE,
         "processor-shapes": CANONICAL_INTEGER_DTYPE,
+        "processor-grids": CANONICAL_INTEGER_DTYPE,
         "sampled-values": CANONICAL_BF16_DTYPE,
     },
     "qwen-layer-50": {
@@ -141,6 +142,8 @@ MEASUREMENT_DTYPES = {
     },
 }
 PROVENANCE_HASH_KEYS = {
+    "adapter-implementation-sha256",
+    "oracle-runtime-sha256",
     "tokenizer-hash",
     "processor-hash",
 }
@@ -396,6 +399,21 @@ def component_authority_set_sha256(
 def exact_layer_contracts(manifest: dict[str, Any]) -> dict[str, dict[str, Any]]:
     component_authorities = manifest_component_authorities(manifest)
     excluded_accelerations = manifest_excluded_accelerations(manifest)
+    source_revisions = {
+        source["id"]: source["revision"] for source in manifest.get("sources", [])
+    }
+    oracle_runtime = manifest.get("numerical_authority", {}).get("oracle_runtime")
+    if (
+        not isinstance(oracle_runtime, dict)
+        or set(oracle_runtime)
+        != {"python", "torch", "numpy", "cuda", "transformers_revision"}
+        or any(
+            not isinstance(value, str) or not value for value in oracle_runtime.values()
+        )
+        or oracle_runtime["transformers_revision"]
+        != source_revisions.get("transformers")
+    ):
+        fail("checked manifest contains invalid oracle runtime authority")
     contracts: dict[str, dict[str, Any]] = {}
     for layer in manifest["fixture_layers"]:
         if layer["authority_tier"] != EXACT_AUTHORITY_TIER:
@@ -403,6 +421,39 @@ def exact_layer_contracts(manifest: dict[str, Any]) -> dict[str, dict[str, Any]]
         identifier = layer["id"]
         if identifier in contracts:
             fail("checked manifest contains duplicate exact layer identities")
+        oracle_adapter = layer.get("oracle_adapter")
+        if oracle_adapter is not None:
+            if (
+                not isinstance(oracle_adapter, dict)
+                or set(oracle_adapter)
+                != {
+                    "id",
+                    "command_prefix",
+                    "implementation_path",
+                    "implementation_sha256",
+                }
+                or not isinstance(oracle_adapter["id"], str)
+                or not oracle_adapter["id"]
+                or not isinstance(oracle_adapter["command_prefix"], str)
+                or not oracle_adapter["command_prefix"]
+                or re.fullmatch(
+                    r"scripts/[a-zA-Z0-9._/-]+\.py",
+                    oracle_adapter["implementation_path"],
+                )
+                is None
+                or ".."
+                in pathlib.PurePosixPath(oracle_adapter["implementation_path"]).parts
+                or not oracle_adapter["command_prefix"].startswith(
+                    f"python3 {oracle_adapter['implementation_path']} "
+                )
+                or re.fullmatch(
+                    r"[0-9a-f]{64}", oracle_adapter["implementation_sha256"]
+                )
+                is None
+            ):
+                fail(
+                    f"checked manifest layer {identifier} has invalid adapter authority"
+                )
         required_components = layer["required_component_indexes"]
         if len(required_components) != len(set(required_components)) or not set(
             required_components
@@ -466,6 +517,14 @@ def exact_layer_contracts(manifest: dict[str, Any]) -> dict[str, dict[str, Any]]
             )
             for record in pinned_provenance
         }
+        if identifier == "tokenizer-processor":
+            contract["_pinned_provenance_values"].update(
+                {
+                    "transformers-revision": source_revisions["transformers"],
+                    "oracle-runtime-sha256": canonical_json_sha256(oracle_runtime),
+                }
+            )
+        contract["_oracle_runtime"] = dict(oracle_runtime)
         contract["_excluded_accelerations"] = excluded_accelerations
         contracts[identifier] = contract
 
@@ -508,13 +567,88 @@ def load_bundle_once(
     return bundle
 
 
+def expected_oracle_runtime(
+    layer_contracts: Mapping[str, dict[str, Any]],
+) -> dict[str, str]:
+    if not layer_contracts:
+        fail("protected layer contracts lack oracle runtime authority")
+    runtimes = {
+        json.dumps(
+            contract.get("_oracle_runtime"),
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        for contract in layer_contracts.values()
+    }
+    if len(runtimes) != 1:
+        fail("protected layer contracts disagree on oracle runtime authority")
+    runtime = next(iter(layer_contracts.values())).get("_oracle_runtime")
+    if not isinstance(runtime, dict):
+        fail("protected layer contracts lack oracle runtime authority")
+    return dict(runtime)
+
+
+def validate_bundle_oracle_adapters(
+    bundle: dict[str, Any],
+    layer_contracts: Mapping[str, dict[str, Any]],
+    device: str,
+) -> dict[str, dict[str, str]]:
+    fixture_layers = {fixture["layer"] for fixture in bundle["fixtures"]}
+    expected = {
+        layer: contract["oracle_adapter"]
+        for layer, contract in layer_contracts.items()
+        if layer in fixture_layers and contract.get("oracle_adapter") is not None
+    }
+    records = bundle["capture_environment"].get("oracle_adapters")
+    if not expected:
+        if records is not None:
+            fail("oracle bundle declares adapter records for unbound fixture layers")
+        return {}
+    if not isinstance(records, list) or not records:
+        fail("oracle bundle is missing manifest-required adapter records")
+    observed: dict[str, dict[str, str]] = {}
+    order: list[str] = []
+    for record in records:
+        if not isinstance(record, dict) or set(record) != {
+            "layer",
+            "id",
+            "command",
+            "implementation_sha256",
+        }:
+            fail("oracle bundle contains an invalid adapter record")
+        layer = record.get("layer")
+        if not isinstance(layer, str) or not layer:
+            fail("oracle bundle contains an invalid adapter layer")
+        if layer in observed:
+            fail(f"oracle bundle repeats adapter record for layer {layer}")
+        order.append(layer)
+        observed[layer] = record
+    if order != sorted(order):
+        fail("oracle bundle adapter records are not in canonical layer order")
+    if set(observed) != set(expected):
+        fail("oracle bundle adapter layers differ from its manifest-bound fixtures")
+    for layer, authority in expected.items():
+        expected_record = {
+            "layer": layer,
+            "id": authority["id"],
+            "command": f"{authority['command_prefix']} --device {device}",
+            "implementation_sha256": authority["implementation_sha256"],
+        }
+        if observed[layer] != expected_record:
+            fail(f"oracle bundle adapter record for layer {layer} is not exact")
+    return observed
+
+
 def validate_capture_environment(
     tool: Any,
     bundle: dict[str, Any],
     role: str,
     source_sha: str,
     excluded_accelerations: frozenset[str],
+    layer_contracts: Mapping[str, dict[str, Any]] | None = None,
 ) -> None:
+    if layer_contracts is None:
+        layer_contracts = exact_layer_contracts(tool.validate_manifest())
     capture = bundle["capture_environment"]
     if not is_cuda_environment(capture["device"]):
         fail(f"{role} bundle does not declare a CUDA capture environment")
@@ -524,9 +658,14 @@ def validate_capture_environment(
     if role == "oracle":
         expected_framework = "diffusers"
         expected_revision = tool.EXPECTED_REVISIONS["diffusers"]
+        if capture.get("oracle_runtime") != expected_oracle_runtime(layer_contracts):
+            fail("oracle bundle runtime identity is not exact")
+        validate_bundle_oracle_adapters(bundle, layer_contracts, capture["device"])
     else:
         expected_framework = "mold"
         expected_revision = source_sha
+        if "oracle_runtime" in capture or "oracle_adapters" in capture:
+            fail("Mold bundle must not claim oracle runtime or adapter identity")
     if capture["framework"] != expected_framework:
         fail(f"{role} bundle framework is not {expected_framework}")
     if capture["framework_revision"] != expected_revision:
@@ -591,6 +730,18 @@ def keyed_component_records(records: Any, label: str) -> dict[str, str]:
 def structured_provenance_value(document: dict[str, Any], key: str) -> str | None:
     if key == "source-revision":
         return document["producer"]["revision"]
+    if key == "transformers-revision":
+        runtime = document["environment"].get("oracle_runtime")
+        if isinstance(runtime, dict):
+            return runtime.get("transformers_revision")
+        return None
+    if key == "adapter-implementation-sha256":
+        return document["adapter"].get("implementation_sha256")
+    if key == "oracle-runtime-sha256":
+        runtime = document["environment"].get("oracle_runtime")
+        if isinstance(runtime, dict):
+            return canonical_json_sha256(runtime)
+        return None
     if key == "component-index-hash":
         components = document["input"]["component_indexes"]
         if len(components) != 1:
@@ -783,6 +934,34 @@ def validate_manifest_layer_evidence(
         fail(f"{role} evidence does not match manifest layer {layer}")
     if document["adapter"]["tensor_hash_encoding"] != CANONICAL_TENSOR_HASH_ENCODING:
         fail(f"{role} layer {layer} tensor hash encoding is not canonical")
+    expected_runtime = manifest_layer.get("_oracle_runtime")
+    if not isinstance(expected_runtime, dict):
+        fail(f"protected manifest layer {layer} lacks oracle runtime authority")
+    if role == "oracle":
+        if document["environment"].get("oracle_runtime") != expected_runtime:
+            fail(f"oracle layer {layer} runtime identity is not exact")
+    elif "oracle_runtime" in document["environment"]:
+        fail(f"Mold layer {layer} must not claim oracle runtime identity")
+
+    adapter_authority = manifest_layer.get("oracle_adapter")
+    if role == "oracle" and adapter_authority is not None:
+        expected_command = (
+            f"{adapter_authority['command_prefix']} "
+            f"--device {document['environment']['device']}"
+        )
+        if (
+            document["adapter"].get("id") != adapter_authority["id"]
+            or document["adapter"].get("command") != expected_command
+            or document["adapter"].get("implementation_sha256")
+            != adapter_authority["implementation_sha256"]
+        ):
+            fail(f"oracle layer {layer} adapter identity is not exact")
+    if "adapter-implementation-sha256" in manifest_layer["required_provenance"]:
+        implementation_sha256 = document["adapter"].get("implementation_sha256")
+        if re.fullmatch(r"[0-9a-f]{64}", implementation_sha256 or "") is None:
+            fail(
+                f"{role} layer {layer} adapter implementation is not content-addressed"
+            )
 
     required_components = manifest_layer.get("_required_component_authorities")
     if not isinstance(required_components, list) or not required_components:
@@ -824,7 +1003,9 @@ def validate_manifest_layer_evidence(
             or CONTROL_CHARACTER_PATTERN.search(value) is not None
         ):
             fail(f"{role} layer {layer} provenance {key!r} is not canonical")
-        if key == "source-revision" and COMMIT_SHA_PATTERN.fullmatch(value) is None:
+        if key in {"source-revision", "transformers-revision"} and (
+            COMMIT_SHA_PATTERN.fullmatch(value) is None
+        ):
             fail(f"{role} layer {layer} provenance {key!r} is not canonical")
         if key in PROVENANCE_HASH_KEYS and re.fullmatch(r"[0-9a-f]{64}", value) is None:
             fail(f"{role} layer {layer} provenance {key!r} is not canonical")
@@ -988,16 +1169,50 @@ def load_layer_documents(
             )
         if document["authority_tier"] != document_manifest_tier:
             fail(f"{role} layer authority tier drifts from the manifest")
+        manifest_layer = layer_contracts.get(document["layer"])
+        if manifest_layer is None:
+            fail(f"{role} layer lacks a protected manifest contract")
         if document["authorization_document_sha256"] != authorization_sha:
             fail(f"{role} layer is not bound to the authorization evidence")
         if not is_cuda_environment(document["environment"]["device"]):
             fail(f"{role} layer does not declare a CUDA execution environment")
         if document["environment"]["dtype"] != CANONICAL_BF16_DTYPE:
             fail(f"{role} layer environment dtype must be {CANONICAL_BF16_DTYPE}")
-        if document["environment"].get("acceleration_policy") != bundle[
-            "capture_environment"
-        ].get("acceleration_policy"):
+        reject_excluded_attention_backend(
+            document["environment"].get("attention_backend"),
+            excluded_accelerations,
+            f"{role} layer {document['layer']}",
+        )
+        capture_environment = bundle["capture_environment"]
+        if document["environment"].get(
+            "acceleration_policy"
+        ) != capture_environment.get("acceleration_policy"):
             fail(f"{role} layer acceleration policy differs from its bundle")
+        for field in ("device", "dtype", "attention_backend"):
+            if document["environment"].get(field) != capture_environment.get(field):
+                fail(f"{role} layer {field} differs from its bundle")
+        if document["environment"].get("oracle_runtime") != capture_environment.get(
+            "oracle_runtime"
+        ):
+            fail(f"{role} layer oracle runtime differs from its bundle")
+        if role == "oracle" and manifest_layer.get("oracle_adapter") is not None:
+            adapter_records = {
+                record["layer"]: record
+                for record in capture_environment["oracle_adapters"]
+            }
+            adapter_record = adapter_records[document["layer"]]
+            if {
+                "id": document["adapter"].get("id"),
+                "command": document["adapter"].get("command"),
+                "implementation_sha256": document["adapter"].get(
+                    "implementation_sha256"
+                ),
+            } != {
+                "id": adapter_record["id"],
+                "command": adapter_record["command"],
+                "implementation_sha256": adapter_record["implementation_sha256"],
+            }:
+                fail(f"{role} layer adapter identity differs from its bundle")
         if fixture["layer"] != document["layer"]:
             fail(f"{role} bundle layer does not match its evidence")
         if fixture["authority_tier"] != document["authority_tier"]:
@@ -1007,9 +1222,6 @@ def load_layer_documents(
             != document["input"]["component_index_sha256"]
         ):
             fail(f"{role} bundle component index does not match its evidence")
-        manifest_layer = layer_contracts.get(document["layer"])
-        if manifest_layer is None:
-            fail(f"{role} layer lacks a protected manifest contract")
         fixture_components = keyed_component_records(
             fixture.get("component_indexes"), f"{role} bundle component authorities"
         )
@@ -1140,10 +1352,20 @@ def run_campaign(
     )
     source_sha = values["MOLD_H3_SOURCE_SHA"]
     validate_capture_environment(
-        tool, oracle_bundle, "oracle", source_sha, excluded_accelerations
+        tool,
+        oracle_bundle,
+        "oracle",
+        source_sha,
+        excluded_accelerations,
+        layer_contracts,
     )
     validate_capture_environment(
-        tool, mold_bundle, "mold", source_sha, excluded_accelerations
+        tool,
+        mold_bundle,
+        "mold",
+        source_sha,
+        excluded_accelerations,
+        layer_contracts,
     )
     oracle_documents = load_layer_documents(
         tool,

--- a/scripts/tests/minimax-h3-capture-producer-contract.py
+++ b/scripts/tests/minimax-h3-capture-producer-contract.py
@@ -1,0 +1,530 @@
+#!/usr/bin/env python3
+"""Adversarial contract tests for the external H3 conditioner producer."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import pathlib
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+from types import SimpleNamespace
+from typing import Any
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+PRODUCER_PATH = REPO_ROOT / "scripts" / "capture-minimax-h3-conditioner.py"
+CONFORMANCE_PATH = REPO_ROOT / "scripts" / "minimax-h3-conformance.py"
+GPU_CONFORMANCE_PATH = REPO_ROOT / "scripts" / "run-minimax-h3-gpu-conformance.py"
+
+
+def load_module(name: str, path: pathlib.Path) -> Any:
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise AssertionError(f"cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+producer = load_module("minimax_h3_capture_producer_contract", PRODUCER_PATH)
+conformance = load_module("minimax_h3_capture_base_contract", CONFORMANCE_PATH)
+gpu = load_module("minimax_h3_capture_gpu_contract", GPU_CONFORMANCE_PATH)
+
+
+def run(arguments: list[str], cwd: pathlib.Path) -> str:
+    result = subprocess.run(
+        arguments,
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def sample_evidence() -> Any:
+    return producer.PrimitiveEvidence(
+        token_ids=(2, 3, 151652, 151655, 151653, 5, 7, 11),
+        special_presentation=(3, 1, 0, 2, 4, 151652, 151653, 151655, 151656),
+        processor_shapes=(2, 1, 3, 256, 256, 3, 2, 4, 4, 64, 64, 3),
+        sampled_bfloat16_bits=(0xBF80, 0x0000, 0x3F00, 0x3F80, 0x4000),
+        prompt_sha256=hashlib.sha256(b"prompt").hexdigest(),
+        image_sha256=hashlib.sha256(b"image").hexdigest(),
+        video_sha256=hashlib.sha256(b"video").hexdigest(),
+        sampled_source_indices=(0, 12, 24, 36),
+        sampled_timestamps_millis=(250, 1250),
+    )
+
+
+class FakeConformanceTool:
+    LAYER_OUTPUT_SCHEMA_PATH = conformance.LAYER_OUTPUT_SCHEMA_PATH
+    BUNDLE_SCHEMA_PATH = conformance.BUNDLE_SCHEMA_PATH
+
+    def __init__(self) -> None:
+        self.bundle_validation_calls = 0
+
+    @staticmethod
+    def validate_schema(value: Any, schema_path: pathlib.Path) -> None:
+        conformance.validate_schema(value, schema_path)
+
+    def validate_bundle(
+        self,
+        manifest: dict[str, Any],
+        fixture_root_value: str,
+        bundle_value: str,
+        authorization_value: str,
+    ) -> None:
+        del manifest, authorization_value
+        self.bundle_validation_calls += 1
+        fixture_root = pathlib.Path(fixture_root_value).resolve(strict=True)
+        bundle_path = pathlib.Path(bundle_value).resolve(strict=True)
+        bundle = json.loads(bundle_path.read_text(encoding="utf-8"))
+        for fixture in bundle["fixtures"]:
+            evidence = (fixture_root / fixture["relative_path"]).resolve(strict=True)
+            self.assert_inside(evidence, fixture_root)
+            if hashlib.sha256(evidence.read_bytes()).hexdigest() != fixture["sha256"]:
+                raise AssertionError("fixture hash mismatch")
+
+    @staticmethod
+    def assert_inside(path: pathlib.Path, parent: pathlib.Path) -> None:
+        try:
+            path.relative_to(parent)
+        except ValueError as error:
+            raise AssertionError("fixture escaped root") from error
+
+
+class CaptureProducerContractTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.manifest = conformance.validate_manifest()
+        cls.contract = gpu.exact_layer_contracts(cls.manifest)["tokenizer-processor"]
+
+    def build_document(self) -> dict[str, Any]:
+        return producer.build_layer_document(
+            self.manifest,
+            sample_evidence(),
+            producer.REVIEWED_AUTHORIZATION_EVIDENCE_SHA256,
+            "cuda:0",
+        )
+
+    def assert_gpu_rejects(self, document: dict[str, Any]) -> None:
+        with self.assertRaises(gpu.GpuConformanceFailure):
+            gpu.validate_manifest_layer_evidence(document, self.contract, "oracle")
+
+    def test_emits_the_exact_layer_and_bundle_schemas_consumed_by_gpu_runner(
+        self,
+    ) -> None:
+        document = self.build_document()
+        conformance.validate_schema(document, conformance.LAYER_OUTPUT_SCHEMA_PATH)
+        gpu.validate_manifest_layer_evidence(document, self.contract, "oracle")
+        encoded = producer.document_bytes(document)
+        bundle = producer.build_bundle(
+            self.manifest,
+            document,
+            encoded,
+            "captures/tokenizer-processor/case/oracle.json",
+            producer.REVIEWED_AUTHORIZATION_EVIDENCE_SHA256,
+            "cuda:0",
+        )
+        conformance.validate_schema(bundle, conformance.BUNDLE_SCHEMA_PATH)
+        self.assertEqual(
+            bundle["fixtures"][0]["sha256"], hashlib.sha256(encoded).hexdigest()
+        )
+        self.assertEqual(
+            [output["key"] for output in document["outputs"]],
+            self.contract["required_measurements"],
+        )
+        self.assertEqual(
+            document["adapter"]["tensor_hash_encoding"],
+            gpu.CANONICAL_TENSOR_HASH_ENCODING,
+        )
+
+    def test_source_and_component_authorities_are_not_caller_selectable(self) -> None:
+        document = self.build_document()
+        self.assertEqual(
+            document["producer"]["revision"],
+            conformance.EXPECTED_REVISIONS["diffusers"],
+        )
+        self.assertEqual(document["producer"]["source_id"], "diffusers")
+        self.assertEqual(
+            [item["id"] for item in document["input"]["component_indexes"]],
+            list(producer.REQUIRED_COMPONENT_IDS),
+        )
+        self.assertIn(
+            producer.TRANSFORMERS_REVISION,
+            json.dumps(producer.build_input_descriptor(sample_evidence())),
+        )
+
+    def test_component_authority_drift_is_rejected(self) -> None:
+        document = self.build_document()
+        document["input"]["component_indexes"][3]["sha256"] = "0" * 64
+        self.assert_gpu_rejects(document)
+
+    def test_excluded_acceleration_and_backend_aliases_are_rejected(self) -> None:
+        enabled = self.build_document()
+        enabled["environment"]["acceleration_policy"]["enabled"].append("sage-attn")
+        self.assert_gpu_rejects(enabled)
+
+        backend = self.build_document()
+        backend["environment"]["attention_backend"] = "tensorfloat32-kernel"
+        self.assert_gpu_rejects(backend)
+
+    def test_measurement_order_dtype_and_policy_cannot_be_weakened(self) -> None:
+        reordered = self.build_document()
+        reordered["outputs"][0], reordered["outputs"][1] = (
+            reordered["outputs"][1],
+            reordered["outputs"][0],
+        )
+        self.assert_gpu_rejects(reordered)
+
+        dtype = self.build_document()
+        dtype["outputs"][-1]["dtype"] = "float32"
+        self.assert_gpu_rejects(dtype)
+
+        tolerance = self.build_document()
+        tolerance["comparison"][-1]["absolute"] = 0.5
+        self.assert_gpu_rejects(tolerance)
+
+    def test_canonical_tensor_hashes_bind_typed_little_endian_values(self) -> None:
+        integer = producer.integer_tensor_record("token-ids", (1, -2, 3))
+        expected_int = hashlib.sha256(
+            b"\x01\x00\x00\x00\x00\x00\x00\x00"
+            b"\xfe\xff\xff\xff\xff\xff\xff\xff"
+            b"\x03\x00\x00\x00\x00\x00\x00\x00"
+        ).hexdigest()
+        self.assertEqual(integer["content_sha256"], expected_int)
+
+        bf16 = producer.bfloat16_tensor_record("sampled-values", (0x3F80, 0xBF80))
+        self.assertEqual(
+            bf16["content_sha256"], hashlib.sha256(b"\x80\x3f\x80\xbf").hexdigest()
+        )
+        self.assertEqual(bf16["statistics"]["min"], -1.0)
+        self.assertEqual(bf16["statistics"]["max"], 1.0)
+
+    def test_environment_aliases_fail_closed_before_any_runtime_import(self) -> None:
+        for key in (
+            "TORCH_COMPILE",
+            "TORCHINDUCTOR_CACHE_DIR",
+            "MOLD_H3_FP8",
+            "SAGE_ATTENTION_BACKEND",
+            "NVIDIA_TF32_OVERRIDE",
+        ):
+            with self.subTest(key=key), self.assertRaises(producer.CaptureFailure):
+                producer.reject_excluded_acceleration_environment({key: "1"})
+        producer.reject_excluded_acceleration_environment(
+            {"TORCH_COMPILE": "false", "UNRELATED": "1"}
+        )
+
+    def test_backend_configuration_must_take_effect(self) -> None:
+        class FakeCudaRuntime:
+            @staticmethod
+            def is_available() -> bool:
+                return True
+
+            @staticmethod
+            def device_count() -> int:
+                return 1
+
+            @staticmethod
+            def set_device(index: int) -> None:
+                self.assertEqual(index, 0)
+
+        class FakeCudaBackends:
+            matmul = SimpleNamespace(allow_tf32=True)
+
+            @staticmethod
+            def enable_flash_sdp(enabled: bool) -> None:
+                del enabled
+
+            @staticmethod
+            def enable_mem_efficient_sdp(enabled: bool) -> None:
+                del enabled
+
+            @staticmethod
+            def enable_cudnn_sdp(enabled: bool) -> None:
+                del enabled
+
+            @staticmethod
+            def enable_math_sdp(enabled: bool) -> None:
+                del enabled
+
+            @staticmethod
+            def flash_sdp_enabled() -> bool:
+                return True
+
+            @staticmethod
+            def mem_efficient_sdp_enabled() -> bool:
+                return True
+
+            @staticmethod
+            def cudnn_sdp_enabled() -> bool:
+                return True
+
+            @staticmethod
+            def math_sdp_enabled() -> bool:
+                return True
+
+        class FakeTorch:
+            cuda = FakeCudaRuntime()
+            backends = SimpleNamespace(
+                cuda=FakeCudaBackends(),
+                cudnn=SimpleNamespace(
+                    allow_tf32=True,
+                    benchmark=True,
+                    deterministic=False,
+                ),
+            )
+            deterministic = False
+
+            @classmethod
+            def use_deterministic_algorithms(cls, enabled: bool) -> None:
+                cls.deterministic = enabled
+
+            @staticmethod
+            def set_float32_matmul_precision(value: str) -> None:
+                del value
+
+            @classmethod
+            def are_deterministic_algorithms_enabled(cls) -> bool:
+                return cls.deterministic
+
+            @staticmethod
+            def device(value: str) -> str:
+                return value
+
+        with self.assertRaisesRegex(
+            producer.CaptureFailure, "attention backend policy drifted"
+        ):
+            producer.configure_torch(SimpleNamespace(torch=FakeTorch), "cuda:0")
+
+    def test_missing_authorization_environment_fails_before_capture(self) -> None:
+        with self.assertRaisesRegex(
+            producer.CaptureFailure, "MOLD_H3_FIXTURE_ROOT is required"
+        ):
+            producer.run_tokenizer_processor_capture({}, "cuda:0")
+
+    def test_authorization_must_bind_the_one_reviewed_external_document(self) -> None:
+        class FakeAuthorizationTool:
+            def __init__(self, source: pathlib.Path, digest: str) -> None:
+                self.source = source
+                self.digest = digest
+
+            def validate_authorization(self, path: pathlib.Path) -> dict[str, str]:
+                del path
+                return {
+                    "source_document_path": str(self.source),
+                    "source_document_sha256": self.digest,
+                }
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            source = root / "review.bin"
+            record = root / "authorization.json"
+            source.write_bytes(b"reviewed")
+            record.write_text("{}\n", encoding="utf-8")
+            with self.assertRaises(producer.CaptureFailure):
+                producer.validate_reviewed_authorization(
+                    FakeAuthorizationTool(source, "0" * 64), record
+                )
+            accepted = producer.validate_reviewed_authorization(
+                FakeAuthorizationTool(
+                    source, producer.REVIEWED_AUTHORIZATION_EVIDENCE_SHA256
+                ),
+                record,
+            )
+            self.assertEqual(
+                accepted["source_document_sha256"],
+                producer.REVIEWED_AUTHORIZATION_EVIDENCE_SHA256,
+            )
+
+    def test_repository_paths_are_never_valid_external_roots(self) -> None:
+        with self.assertRaises(producer.CaptureFailure):
+            producer.external_directory("fixture root", str(REPO_ROOT))
+        with self.assertRaises(producer.CaptureFailure):
+            producer.external_file("authorization record", str(PRODUCER_PATH))
+
+    def test_source_checkout_requires_exact_clean_head_and_repository(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            run(["git", "init"], root)
+            run(["git", "config", "user.name", "Capture Contract"], root)
+            run(["git", "config", "user.email", "capture@example.invalid"], root)
+            (root / "source.py").write_text("PIN = 1\n", encoding="utf-8")
+            run(["git", "add", "source.py"], root)
+            run(["git", "commit", "-m", "test: pin source"], root)
+            revision = run(["git", "rev-parse", "HEAD"], root)
+            repository = "https://github.com/example/capture-source"
+            run(["git", "remote", "add", "origin", repository + ".git"], root)
+            producer.verify_git_checkout("source", root, revision, repository)
+            (root / "source.py").write_text("PIN = 2\n", encoding="utf-8")
+            with self.assertRaises(producer.CaptureFailure):
+                producer.verify_git_checkout("source", root, revision, repository)
+
+    def test_model_components_require_hash_and_snapshot_revision_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary).resolve()
+            components = []
+            for position, identifier in enumerate(
+                producer.REQUIRED_COMPONENT_IDS, start=1
+            ):
+                relative_path = f"component/{position}.json"
+                data = f"{identifier}\n".encode()
+                target = root / relative_path
+                target.parent.mkdir(parents=True, exist_ok=True)
+                target.write_bytes(data)
+                metadata = (
+                    root
+                    / ".cache"
+                    / "huggingface"
+                    / "download"
+                    / f"{relative_path}.metadata"
+                )
+                metadata.parent.mkdir(parents=True, exist_ok=True)
+                metadata.write_text(
+                    producer.MODEL_REVISION + "\nopaque-etag\n0\n",
+                    encoding="utf-8",
+                )
+                components.append(
+                    {
+                        "id": identifier,
+                        "source_id": "minimax-official-model",
+                        "relative_path": relative_path,
+                        "sha256": hashlib.sha256(data).hexdigest(),
+                    }
+                )
+            manifest = {"component_indexes": components}
+            verified = producer.verify_model_components(root, manifest)
+            self.assertEqual(len(verified), len(producer.REQUIRED_COMPONENT_IDS))
+
+            metadata = (
+                root
+                / ".cache"
+                / "huggingface"
+                / "download"
+                / f"{components[0]['relative_path']}.metadata"
+            )
+            metadata.write_text("0" * 40 + "\nopaque-etag\n0\n", encoding="utf-8")
+            with self.assertRaises(producer.CaptureFailure):
+                producer.verify_model_components(root, manifest)
+            metadata.write_text(
+                producer.MODEL_REVISION + "\nopaque-etag\n0\n",
+                encoding="utf-8",
+            )
+            (root / components[-1]["relative_path"]).write_bytes(b"drift")
+            with self.assertRaises(producer.CaptureFailure):
+                producer.verify_model_components(root, manifest)
+
+    def test_external_capture_is_exclusive_schema_checked_and_mode_0600(self) -> None:
+        document = self.build_document()
+        with tempfile.TemporaryDirectory() as temporary:
+            fixture_root = pathlib.Path(temporary).resolve()
+            authorization = fixture_root / "authorization.json"
+            authorization.write_text("{}\n", encoding="utf-8")
+            fake = FakeConformanceTool()
+            layer_path, bundle_path = producer.write_capture(
+                fixture_root,
+                authorization,
+                self.manifest,
+                document,
+                "cuda:0",
+                fake,
+                gpu,
+            )
+            self.assertEqual(fake.bundle_validation_calls, 1)
+            self.assertTrue(layer_path.is_file())
+            self.assertTrue(bundle_path.is_file())
+            self.assertEqual(stat.S_IMODE(layer_path.stat().st_mode), 0o600)
+            self.assertEqual(stat.S_IMODE(bundle_path.stat().st_mode), 0o600)
+            with self.assertRaises(producer.CaptureFailure):
+                producer.write_capture(
+                    fixture_root,
+                    authorization,
+                    self.manifest,
+                    document,
+                    "cuda:0",
+                    fake,
+                    gpu,
+                )
+
+    def test_capture_output_cannot_follow_a_symlink_outside_fixture_root(self) -> None:
+        document = self.build_document()
+        with tempfile.TemporaryDirectory() as temporary:
+            base = pathlib.Path(temporary)
+            fixture_root = base / "fixture"
+            outside = base / "outside"
+            fixture_root.mkdir()
+            outside.mkdir()
+            (fixture_root / "captures").symlink_to(outside, target_is_directory=True)
+            authorization = base / "authorization.json"
+            authorization.write_text("{}\n", encoding="utf-8")
+            with self.assertRaises(producer.CaptureFailure):
+                producer.write_capture(
+                    fixture_root.resolve(),
+                    authorization,
+                    self.manifest,
+                    document,
+                    "cuda:0",
+                    FakeConformanceTool(),
+                    gpu,
+                )
+
+    def test_checked_tree_contains_no_production_capture_or_binary_evidence(
+        self,
+    ) -> None:
+        tracked = subprocess.run(
+            ["git", "ls-files", "-z", "--", "tests/fixtures/minimax_h3"],
+            cwd=REPO_ROOT,
+            check=True,
+            capture_output=True,
+        ).stdout.split(b"\0")
+        paths = [pathlib.Path(value.decode("utf-8")) for value in tracked if value]
+        self.assertTrue(paths)
+        self.assertTrue(all(path.suffix == ".json" for path in paths))
+        producer_source = PRODUCER_PATH.read_text(encoding="utf-8")
+        self.assertNotIn("from safetensors", producer_source)
+        self.assertNotIn("safe_open(", producer_source)
+
+    def test_capture_producer_is_not_reachable_from_shipped_runtime_or_release(
+        self,
+    ) -> None:
+        roots = [
+            "Cargo.toml",
+            "Cargo.lock",
+            "flake.nix",
+            "crates",
+            "apps",
+            "desktop",
+            "studio",
+            "web",
+            "scripts/release",
+        ]
+        tracked = subprocess.run(
+            ["git", "ls-files", "-z", "--", *roots],
+            cwd=REPO_ROOT,
+            check=True,
+            capture_output=True,
+        ).stdout.split(b"\0")
+        needle = PRODUCER_PATH.name
+        references = []
+        for value in tracked:
+            if not value:
+                continue
+            path = REPO_ROOT / value.decode("utf-8")
+            if path.is_file() and needle in path.read_text(
+                encoding="utf-8", errors="ignore"
+            ):
+                references.append(path.relative_to(REPO_ROOT).as_posix())
+        self.assertEqual(references, [])
+        protected_workflow = (
+            REPO_ROOT / ".github" / "workflows" / "minimax-h3-private-conformance.yml"
+        ).read_text(encoding="utf-8")
+        self.assertNotIn(needle, protected_workflow)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/tests/minimax-h3-capture-producer-contract.py
+++ b/scripts/tests/minimax-h3-capture-producer-contract.py
@@ -12,6 +12,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from unittest import mock
 from types import SimpleNamespace
 from typing import Any
 
@@ -52,6 +53,7 @@ def sample_evidence() -> Any:
         token_ids=(2, 3, 151652, 151655, 151653, 5, 7, 11),
         special_presentation=(3, 1, 0, 2, 4, 151652, 151653, 151655, 151656),
         processor_shapes=(2, 1, 3, 256, 256, 3, 2, 4, 4, 64, 64, 3),
+        processor_grids=(2, 3, 1, 32, 32, 3, 2, 8, 8),
         sampled_bfloat16_bits=(0xBF80, 0x0000, 0x3F00, 0x3F80, 0x4000),
         prompt_sha256=hashlib.sha256(b"prompt").hexdigest(),
         image_sha256=hashlib.sha256(b"image").hexdigest(),
@@ -110,6 +112,7 @@ class CaptureProducerContractTest(unittest.TestCase):
             sample_evidence(),
             producer.REVIEWED_AUTHORIZATION_EVIDENCE_SHA256,
             "cuda:0",
+            self.manifest["numerical_authority"]["oracle_runtime"],
         )
 
     def assert_gpu_rejects(self, document: dict[str, Any]) -> None:
@@ -159,6 +162,23 @@ class CaptureProducerContractTest(unittest.TestCase):
             producer.TRANSFORMERS_REVISION,
             json.dumps(producer.build_input_descriptor(sample_evidence())),
         )
+        self.assertEqual(
+            document["adapter"]["implementation_sha256"],
+            hashlib.sha256(PRODUCER_PATH.read_bytes()).hexdigest(),
+        )
+        self.assertEqual(
+            document["environment"]["oracle_runtime"],
+            self.manifest["numerical_authority"]["oracle_runtime"],
+        )
+        grid = next(
+            output
+            for output in document["outputs"]
+            if output["key"] == "processor-grids"
+        )
+        self.assertEqual(
+            [sample["value"] for sample in grid["samples"]],
+            list(sample_evidence().processor_grids),
+        )
 
     def test_component_authority_drift_is_rejected(self) -> None:
         document = self.build_document()
@@ -189,6 +209,57 @@ class CaptureProducerContractTest(unittest.TestCase):
         tolerance = self.build_document()
         tolerance["comparison"][-1]["absolute"] = 0.5
         self.assert_gpu_rejects(tolerance)
+
+        missing_grid = self.build_document()
+        missing_grid["outputs"] = [
+            output
+            for output in missing_grid["outputs"]
+            if output["key"] != "processor-grids"
+        ]
+        self.assert_gpu_rejects(missing_grid)
+
+        grid_dtype = self.build_document()
+        next(
+            output
+            for output in grid_dtype["outputs"]
+            if output["key"] == "processor-grids"
+        )["dtype"] = "bfloat16"
+        self.assert_gpu_rejects(grid_dtype)
+
+    def test_runtime_and_adapter_authority_cannot_drift(self) -> None:
+        runtime = self.build_document()
+        runtime["environment"]["oracle_runtime"]["torch"] = "0.0.0"
+        self.assert_gpu_rejects(runtime)
+
+        for field, value in (
+            ("id", "different-adapter"),
+            ("command", "python3 unreviewed.py"),
+            ("implementation_sha256", "0" * 64),
+        ):
+            with self.subTest(field=field):
+                adapter = self.build_document()
+                adapter["adapter"][field] = value
+                self.assert_gpu_rejects(adapter)
+
+    def test_observed_runtime_must_equal_the_manifest_pin(self) -> None:
+        runtime = SimpleNamespace(
+            torch=SimpleNamespace(
+                __version__="2.13.0+cu130", version=SimpleNamespace(cuda="13.0")
+            ),
+            numpy=SimpleNamespace(__version__="2.5.1"),
+        )
+        with mock.patch.object(
+            producer.platform, "python_version", return_value="3.13.13"
+        ):
+            self.assertEqual(
+                producer.validate_oracle_runtime(self.manifest, runtime),
+                self.manifest["numerical_authority"]["oracle_runtime"],
+            )
+            runtime.torch.__version__ = "2.13.1+cu130"
+            with self.assertRaisesRegex(
+                producer.CaptureFailure, "runtime identity differs"
+            ):
+                producer.validate_oracle_runtime(self.manifest, runtime)
 
     def test_canonical_tensor_hashes_bind_typed_little_endian_values(self) -> None:
         integer = producer.integer_tensor_record("token-ids", (1, -2, 3))
@@ -365,6 +436,47 @@ class CaptureProducerContractTest(unittest.TestCase):
             with self.assertRaises(producer.CaptureFailure):
                 producer.verify_git_checkout("source", root, revision, repository)
 
+    def test_source_execution_uses_an_immutable_git_archive_snapshot(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            checkout = root / "checkout"
+            checkout.mkdir()
+            run(["git", "init"], checkout)
+            run(["git", "config", "user.name", "Capture Contract"], checkout)
+            run(
+                ["git", "config", "user.email", "capture@example.invalid"],
+                checkout,
+            )
+            source = checkout / "src" / "example" / "__init__.py"
+            source.parent.mkdir(parents=True)
+            source.write_text("PIN = 1\n", encoding="utf-8")
+            run(["git", "add", "src/example/__init__.py"], checkout)
+            run(["git", "commit", "-m", "test: pin source"], checkout)
+            revision = run(["git", "rev-parse", "HEAD"], checkout)
+            repository = "https://github.com/example/capture-source"
+            run(["git", "remote", "add", "origin", repository + ".git"], checkout)
+
+            staged = root / "stage"
+            producer.extract_git_source_snapshot(
+                "source",
+                checkout,
+                revision,
+                repository,
+                "example",
+                staged,
+            )
+            authority = producer.StagedSnapshot(staged, producer.snapshot_files(staged))
+            staged_source = staged / "src" / "example" / "__init__.py"
+            self.assertEqual(staged_source.read_text(encoding="utf-8"), "PIN = 1\n")
+            source.write_text("PIN = 2\n", encoding="utf-8")
+            authority.revalidate()
+            self.assertEqual(staged_source.read_text(encoding="utf-8"), "PIN = 1\n")
+            staged_source.write_text("PIN = 3\n", encoding="utf-8")
+            with self.assertRaisesRegex(
+                producer.CaptureFailure, "staging snapshot changed"
+            ):
+                authority.revalidate()
+
     def test_model_components_require_hash_and_snapshot_revision_metadata(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = pathlib.Path(temporary).resolve()
@@ -418,6 +530,38 @@ class CaptureProducerContractTest(unittest.TestCase):
             (root / components[-1]["relative_path"]).write_bytes(b"drift")
             with self.assertRaises(producer.CaptureFailure):
                 producer.verify_model_components(root, manifest)
+
+            original = f"{producer.REQUIRED_COMPONENT_IDS[-1]}\n".encode()
+            (root / components[-1]["relative_path"]).write_bytes(original)
+            with tempfile.TemporaryDirectory() as staged_temporary:
+                staged = pathlib.Path(staged_temporary) / "model"
+                producer.stage_model_components(root, staged, manifest)
+                authority = producer.StagedSnapshot(
+                    staged, producer.snapshot_files(staged)
+                )
+                source_component = root / components[0]["relative_path"]
+                staged_component = staged / components[0]["relative_path"]
+                expected = staged_component.read_bytes()
+                source_component.write_bytes(b"mutated after staging")
+                authority.revalidate()
+                self.assertEqual(staged_component.read_bytes(), expected)
+                staged_component.write_bytes(b"mutated staging")
+                with self.assertRaisesRegex(
+                    producer.CaptureFailure, "staging snapshot changed"
+                ):
+                    authority.revalidate()
+
+    def test_model_input_reader_rejects_symlinked_parent_directories(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = pathlib.Path(temporary)
+            model = root / "model"
+            outside = root / "outside"
+            model.mkdir()
+            outside.mkdir()
+            (outside / "config.json").write_text("{}\n", encoding="utf-8")
+            (model / "tokenizer").symlink_to(outside, target_is_directory=True)
+            with self.assertRaisesRegex(producer.CaptureFailure, "unsafe"):
+                producer.read_regular_file_once(model, "tokenizer/config.json")
 
     def test_external_capture_is_exclusive_schema_checked_and_mode_0600(self) -> None:
         document = self.build_document()

--- a/scripts/tests/minimax-h3-conformance-contract.py
+++ b/scripts/tests/minimax-h3-conformance-contract.py
@@ -55,6 +55,30 @@ def test_manifest_drift(tool, temporary: pathlib.Path) -> None:
         expect_failure(tool.validate_manifest, "source revisions drifted")
     finally:
         tool.MANIFEST_PATH = original_path
+    manifest = json.loads(original_path.read_text(encoding="utf-8"))
+    manifest["numerical_authority"]["oracle_runtime"]["torch"] = "0.0.0"
+    changed = temporary / "changed-runtime-manifest.json"
+    write_json(changed, manifest)
+    tool.MANIFEST_PATH = changed
+    try:
+        expect_failure(tool.validate_manifest, "oracle runtime identity drifted")
+    finally:
+        tool.MANIFEST_PATH = original_path
+
+    manifest = json.loads(original_path.read_text(encoding="utf-8"))
+    tokenizer_layer = next(
+        layer
+        for layer in manifest["fixture_layers"]
+        if layer["id"] == "tokenizer-processor"
+    )
+    tokenizer_layer["oracle_adapter"]["implementation_sha256"] = "0" * 64
+    changed = temporary / "changed-adapter-manifest.json"
+    write_json(changed, manifest)
+    tool.MANIFEST_PATH = changed
+    try:
+        expect_failure(tool.validate_manifest, "adapter authority drifted")
+    finally:
+        tool.MANIFEST_PATH = original_path
 
     manifest = json.loads(original_path.read_text(encoding="utf-8"))
     tokenizer_layer = next(
@@ -82,6 +106,47 @@ def test_manifest_drift(tool, temporary: pathlib.Path) -> None:
         expect_failure(tool.validate_manifest, "exclusion aliases drifted")
     finally:
         tool.MANIFEST_PATH = original_path
+
+
+def test_adapter_implementation_path_boundary(tool, temporary: pathlib.Path) -> None:
+    original_root = tool.REPO_ROOT
+    checkout = temporary / "adapter-checkout"
+    scripts = checkout / "scripts"
+    outside = temporary / "outside-adapter.py"
+    scripts.mkdir(parents=True)
+    outside.write_text("VALUE = 1\n", encoding="utf-8")
+    implementation = scripts / "capture.py"
+    implementation.write_text("VALUE = 2\n", encoding="utf-8")
+    tool.REPO_ROOT = checkout
+    try:
+        assert (
+            tool.checked_repository_implementation_path("scripts/capture.py")
+            == implementation.resolve()
+        )
+        expect_failure(
+            lambda: tool.checked_repository_implementation_path(
+                "scripts/../outside-adapter.py"
+            ),
+            "escapes the reviewed checkout",
+        )
+        implementation.unlink()
+        implementation.symlink_to(outside)
+        expect_failure(
+            lambda: tool.checked_repository_implementation_path("scripts/capture.py"),
+            "symbolic link",
+        )
+        implementation.unlink()
+        scripts.rmdir()
+        outside_directory = temporary / "outside-scripts"
+        outside_directory.mkdir()
+        (outside_directory / "capture.py").write_text("VALUE = 3\n", encoding="utf-8")
+        scripts.symlink_to(outside_directory, target_is_directory=True)
+        expect_failure(
+            lambda: tool.checked_repository_implementation_path("scripts/capture.py"),
+            "symbolic link",
+        )
+    finally:
+        tool.REPO_ROOT = original_root
 
 
 def test_synthetic_drift(tool, temporary: pathlib.Path) -> None:
@@ -420,6 +485,7 @@ def main() -> int:
     with tempfile.TemporaryDirectory(prefix="mold-h3-contract-") as value:
         temporary = pathlib.Path(value).resolve()
         test_manifest_drift(tool, temporary)
+        test_adapter_implementation_path_boundary(tool, temporary)
         test_synthetic_drift(tool, temporary)
         test_synthetic_comparison_uses_fixture_math(tool)
         test_comparison_diagnostics(tool)

--- a/scripts/tests/minimax-h3-gpu-conformance-contract.py
+++ b/scripts/tests/minimax-h3-gpu-conformance-contract.py
@@ -38,6 +38,7 @@ TEST_MEASUREMENT_KINDS = {
         "token-ids": "integer",
         "special-token-presentation": "integer",
         "processor-shapes": "integer",
+        "processor-grids": "integer",
         "sampled-values": "activation",
     },
     "qwen-layer-50": {
@@ -218,6 +219,16 @@ def exact_manifest_layers(tool) -> dict[str, dict[str, object]]:
             )
             for record in layer["pinned_provenance"]
         }
+        if layer["id"] == "tokenizer-processor":
+            layer["_pinned_provenance_values"].update(
+                {
+                    "transformers-revision": tool.EXPECTED_REVISIONS["transformers"],
+                    "oracle-runtime-sha256": canonical_json_sha256(
+                        tool.EXPECTED_ORACLE_RUNTIME
+                    ),
+                }
+            )
+        layer["_oracle_runtime"] = copy.deepcopy(tool.EXPECTED_ORACLE_RUNTIME)
         layer["_excluded_accelerations"] = frozenset(
             manifest["numerical_authority"]["excluded_accelerations"]
         )
@@ -270,7 +281,7 @@ def comparison_fixture(key: str, kind: str) -> dict[str, object]:
 
 
 def provenance_fixture(
-    manifest_layer: dict[str, object], document: dict[str, object]
+    tool, manifest_layer: dict[str, object], document: dict[str, object]
 ) -> list[dict[str, str]]:
     component_indexes = document["input"]["component_indexes"]
     component_index_hashes = ",".join(
@@ -281,6 +292,11 @@ def provenance_fixture(
     )
     values = {
         "source-revision": document["producer"]["revision"],
+        "transformers-revision": tool.EXPECTED_REVISIONS["transformers"],
+        "adapter-implementation-sha256": document["adapter"].get(
+            "implementation_sha256", "0" * 64
+        ),
+        "oracle-runtime-sha256": canonical_json_sha256(tool.EXPECTED_ORACLE_RUNTIME),
         "tokenizer-hash": "0" * 64,
         "processor-hash": "0" * 64,
         "component-index-hash": document["input"]["component_index_sha256"],
@@ -375,6 +391,40 @@ def layer_document(
         output_fixture(layer, key, TEST_MEASUREMENT_KINDS[layer][key])
         for key in manifest_layer["required_measurements"]
     ]
+    oracle_adapter = manifest_layer.get("oracle_adapter")
+    command = (
+        f"{oracle_adapter['command_prefix']} --device cuda:contract-test"
+        if role == "oracle" and oracle_adapter is not None
+        else f"contract-test {role} {layer} capture"
+    )
+    adapter = {
+        "schema_version": "mold.minimax-h3.layer-adapter.v1",
+        "id": (
+            oracle_adapter["id"]
+            if role == "oracle" and oracle_adapter is not None
+            else f"contract-{role}-adapter"
+        ),
+        "command": command,
+        "tensor_hash_encoding": "canonical-typed-le-v1",
+    }
+    if "adapter-implementation-sha256" in manifest_layer["required_provenance"]:
+        adapter["implementation_sha256"] = (
+            oracle_adapter["implementation_sha256"]
+            if role == "oracle" and oracle_adapter is not None
+            else "1" * 64
+        )
+    environment = {
+        "device": "cuda:contract-test",
+        "dtype": CANONICAL_BF16_DTYPE,
+        "attention_backend": "math",
+        "acceleration_policy": {
+            "enabled": ["math"],
+            "disabled": sorted(manifest_layer["_excluded_accelerations"]),
+        },
+        "forbidden_accelerations_disabled": True,
+    }
+    if role == "oracle":
+        environment["oracle_runtime"] = copy.deepcopy(tool.EXPECTED_ORACLE_RUNTIME)
     document: dict[str, object] = {
         "schema_version": tool.LAYER_OUTPUT_SCHEMA_VERSION,
         "family": "minimax-h3",
@@ -391,25 +441,11 @@ def layer_document(
                 tool.EXPECTED_REVISIONS["diffusers"] if role == "oracle" else SOURCE_SHA
             ),
         },
-        "adapter": {
-            "schema_version": "mold.minimax-h3.layer-adapter.v1",
-            "id": f"contract-{role}-adapter",
-            "command": f"contract-test {role} {layer} capture",
-            "tensor_hash_encoding": "canonical-typed-le-v1",
-        },
-        "environment": {
-            "device": "cuda:contract-test",
-            "dtype": CANONICAL_BF16_DTYPE,
-            "attention_backend": "math",
-            "acceleration_policy": {
-                "enabled": ["math"],
-                "disabled": sorted(manifest_layer["_excluded_accelerations"]),
-            },
-            "forbidden_accelerations_disabled": True,
-        },
+        "adapter": adapter,
+        "environment": environment,
         "outputs": outputs,
     }
-    document["provenance"] = provenance_fixture(manifest_layer, document)
+    document["provenance"] = provenance_fixture(tool, manifest_layer, document)
     if role == "oracle":
         document["comparison"] = [
             comparison_fixture(key, TEST_MEASUREMENT_KINDS[layer][key])
@@ -497,6 +533,25 @@ def bundle_fixture(
             },
             "fixtures": fixtures,
         }
+        if role == "oracle":
+            bundle["capture_environment"]["oracle_runtime"] = copy.deepcopy(
+                tool.EXPECTED_ORACLE_RUNTIME
+            )
+            bundle["capture_environment"]["oracle_adapters"] = [
+                {
+                    "layer": layer,
+                    "id": contract["oracle_adapter"]["id"],
+                    "command": (
+                        f"{contract['oracle_adapter']['command_prefix']} "
+                        "--device cuda:contract-test"
+                    ),
+                    "implementation_sha256": contract["oracle_adapter"][
+                        "implementation_sha256"
+                    ],
+                }
+                for layer, contract in sorted(manifest_layers.items())
+                if contract.get("oracle_adapter") is not None
+            ]
         bundle_path = fixture_root / f"{role}-bundle.json"
         write_json(bundle_path, bundle)
         bundle_paths.append(bundle_path)
@@ -568,6 +623,8 @@ def test_manifest_layer_contract(runner, tool, authorization_sha: str) -> None:
         "processor-hash": (
             "44e3ff907049587aa580bb17f0374bb78e704e74efbf4626ed6366f4d15be287"
         ),
+        "transformers-revision": tool.EXPECTED_REVISIONS["transformers"],
+        "oracle-runtime-sha256": canonical_json_sha256(tool.EXPECTED_ORACLE_RUNTIME),
     }
     bfloat16_max = float.fromhex("0x1.fep+127")
     assert runner.is_exact_bfloat16(bfloat16_max)
@@ -630,8 +687,8 @@ def test_manifest_layer_contract(runner, tool, authorization_sha: str) -> None:
 
             for provenance_key in manifest_layer["_pinned_provenance_values"]:
                 unpinned = copy.deepcopy(document)
-                record_by_key(unpinned["provenance"], provenance_key)["value"] = (
-                    "f" * 64
+                record_by_key(unpinned["provenance"], provenance_key)["value"] = "f" * (
+                    40 if provenance_key.endswith("revision") else 64
                 )
                 expect_failure(
                     lambda unpinned=unpinned, manifest_layer=manifest_layer, role=role: (
@@ -1531,6 +1588,116 @@ def test_runner_contract(runner, tool, temporary: pathlib.Path) -> None:
             "source_sha": SOURCE_SHA,
         }
         assert probes == 1
+
+        environment, oracle_bundle, _ = reset_campaign()
+        oracle_runtime = json.loads(oracle_bundle.read_text(encoding="utf-8"))
+        oracle_runtime["capture_environment"]["oracle_runtime"]["torch"] = "0.0.0"
+        write_json(oracle_bundle, oracle_runtime)
+        expect_failure(
+            lambda: runner.run_campaign(environment, lambda: None, lambda: SOURCE_SHA),
+            "oracle bundle runtime identity is not exact",
+        )
+
+        environment, oracle_bundle, _ = reset_campaign()
+        oracle_adapter = json.loads(oracle_bundle.read_text(encoding="utf-8"))
+        oracle_adapter["capture_environment"]["oracle_adapters"][0][
+            "implementation_sha256"
+        ] = "0" * 64
+        write_json(oracle_bundle, oracle_adapter)
+        expect_failure(
+            lambda: runner.run_campaign(environment, lambda: None, lambda: SOURCE_SHA),
+            "adapter record for layer tokenizer-processor is not exact",
+        )
+
+        excluded_accelerations = runner.manifest_excluded_accelerations(
+            tool.validate_manifest()
+        )
+        layer_contracts = runner.exact_layer_contracts(tool.validate_manifest())
+        _, valid_oracle_path, _ = reset_campaign()
+        valid_oracle = json.loads(valid_oracle_path.read_text(encoding="utf-8"))
+
+        missing_adapter = copy.deepcopy(valid_oracle)
+        del missing_adapter["capture_environment"]["oracle_adapters"]
+        expect_failure(
+            lambda: runner.validate_capture_environment(
+                tool,
+                missing_adapter,
+                "oracle",
+                SOURCE_SHA,
+                excluded_accelerations,
+                layer_contracts,
+            ),
+            "missing manifest-required adapter records",
+        )
+
+        extra_adapter = copy.deepcopy(valid_oracle)
+        extra_record = copy.deepcopy(
+            extra_adapter["capture_environment"]["oracle_adapters"][0]
+        )
+        extra_record["layer"] = "zz-extra-layer"
+        extra_adapter["capture_environment"]["oracle_adapters"].append(extra_record)
+        expect_failure(
+            lambda: runner.validate_capture_environment(
+                tool,
+                extra_adapter,
+                "oracle",
+                SOURCE_SHA,
+                excluded_accelerations,
+                layer_contracts,
+            ),
+            "adapter layers differ",
+        )
+
+        duplicate_adapter = copy.deepcopy(valid_oracle)
+        duplicate_adapter["capture_environment"]["oracle_adapters"].append(
+            copy.deepcopy(
+                duplicate_adapter["capture_environment"]["oracle_adapters"][0]
+            )
+        )
+        expect_failure(
+            lambda: runner.validate_capture_environment(
+                tool,
+                duplicate_adapter,
+                "oracle",
+                SOURCE_SHA,
+                excluded_accelerations,
+                layer_contracts,
+            ),
+            "repeats adapter record",
+        )
+
+        mixed_adapter = copy.deepcopy(valid_oracle)
+        mixed_adapter["capture_environment"]["oracle_adapters"][0]["id"] = (
+            "different-layer-adapter"
+        )
+        expect_failure(
+            lambda: runner.validate_capture_environment(
+                tool,
+                mixed_adapter,
+                "oracle",
+                SOURCE_SHA,
+                excluded_accelerations,
+                layer_contracts,
+            ),
+            "adapter record for layer tokenizer-processor is not exact",
+        )
+
+        environment, _, mold_bundle = reset_campaign()
+
+        def drift_processor_grid(document: dict[str, object]) -> None:
+            grid = record_by_key(document["outputs"], "processor-grids")
+            grid["content_sha256"] = "f" * 64
+
+        mutate_evidence(
+            fixture_root,
+            mold_bundle,
+            drift_processor_grid,
+            fixture_layer="tokenizer-processor",
+        )
+        expect_failure(
+            lambda: runner.run_campaign(environment, lambda: None, lambda: SOURCE_SHA),
+            "output 'processor-grids' content hashes differ",
+        )
 
         expect_failure(
             lambda: runner.run_campaign(environment, lambda: None, lambda: "b" * 40),

--- a/tests/fixtures/minimax_h3/conformance-manifest.json
+++ b/tests/fixtures/minimax_h3/conformance-manifest.json
@@ -4,6 +4,13 @@
   "numerical_authority": {
     "source_id": "diffusers",
     "precision": "official-bf16-fp32-mixed",
+    "oracle_runtime": {
+      "python": "3.13.13",
+      "torch": "2.13.0+cu130",
+      "numpy": "2.5.1",
+      "cuda": "13.0",
+      "transformers_revision": "42f189ded85d18d00b51161d694cafd325e32b91"
+    },
     "excluded_accelerations": [
       "torch-compile",
       "fp8",
@@ -52,6 +59,13 @@
       "repository": "https://github.com/huggingface/diffusers",
       "revision": "9c6a68c32b3b2a64db91800b624d33cec6e25ab8",
       "role": "official full-precision executable oracle",
+      "authority": "numerical"
+    },
+    {
+      "id": "transformers",
+      "repository": "https://github.com/huggingface/transformers",
+      "revision": "42f189ded85d18d00b51161d694cafd325e32b91",
+      "role": "Qwen3-VL tokenizer and multimodal processor authority",
       "authority": "numerical"
     },
     {
@@ -242,6 +256,9 @@
       ],
       "required_provenance": [
         "source-revision",
+        "transformers-revision",
+        "adapter-implementation-sha256",
+        "oracle-runtime-sha256",
         "tokenizer-hash",
         "processor-hash",
         "device",
@@ -271,10 +288,17 @@
         }
       ],
       "role_invariant_provenance": ["tokenizer-hash", "processor-hash"],
+      "oracle_adapter": {
+        "id": "minimax-h3-tokenizer-processor-capture-v1",
+        "command_prefix": "python3 scripts/capture-minimax-h3-conditioner.py tokenizer-processor",
+        "implementation_path": "scripts/capture-minimax-h3-conditioner.py",
+        "implementation_sha256": "d3f9ec17fa877587821ebc55344e35ce11cae19525685185f1c4cc192655f1c3"
+      },
       "required_measurements": [
         "token-ids",
         "special-token-presentation",
         "processor-shapes",
+        "processor-grids",
         "sampled-values"
       ]
     },


### PR DESCRIPTION
Summary:
- add an opt-in, authorization-bound tokenizer/processor capture producer for the first real #832 primitive
- verify exact model, Diffusers, Transformers, adapter, and runtime revisions; per-file snapshot metadata; CUDA backend state; excluded accelerations; and external-root containment before capture
- atomically emit schema-valid layer evidence plus a partial fixture bundle with owner-only permissions, then validate it through the #918 consumer
- route producer changes through protected CI while keeping the command unreachable from shipped runtimes and release artifacts

Validation:
- 21 adversarial producer contracts
- inherited synthetic, conformance, and private-GPU runner contracts
- private-UAT release-isolation contract, Ruff, JSON parsing, Rust formatting, diff, adapter self-hash, and restricted-name checks
- authorized L40S metadata capture against the pinned revisions plus independent validate-bundle; the exact int64 processor grids and all retained evidence stayed external and owner-only

This deliberately does not claim Qwen layer-50 parity: that row requires paired exact-BF16 Mold and pinned Diffusers adapters, while the current private conditioner is the deployment quantized path.

Advances #827 and #832.
