### PR TITLE
feat(h3): bind Ref2VA owner authority

### DIFF
--- a/crates/mold-inference/src/lib.rs
+++ b/crates/mold-inference/src/lib.rs
@@ -46,12 +46,13 @@ pub use minimax_h3::private_qwen::{
 pub use minimax_h3::private_server::{
     authenticate_h3_private_runtime_qualification, prepare_h3_private_fl2va_admission,
     prepare_h3_private_fl2va_attempt, reviewed_h3_private_runtime_available,
-    H3PrivateAllocationCommit, H3PrivateFl2VaAdmissionEvidence, H3PrivateFl2VaAdmissionInput,
-    H3PrivateFl2VaAttemptFacts, H3PrivateFl2VaMediaContract, H3PrivateFl2VaOwnerFenceFacts,
-    H3PrivateFl2VaPrepareError, H3PrivateFl2VaPrepareInput, H3PrivateFl2VaPreparedAttempt,
-    H3PrivateFl2VaRunContext, H3PrivateFl2VaRunOutput, H3PrivateFl2VaRuntimeBounds,
-    H3PrivateFl2VaTerminalIdentityEcho, H3PrivateFl2VaUatPaths,
-    H3PrivateRuntimeQualificationAuthority, H3PrivateSchedulerLedgerIdentity,
+    reviewed_h3_private_runtime_available_for_task, H3PrivateAllocationCommit,
+    H3PrivateFl2VaAdmissionEvidence, H3PrivateFl2VaAdmissionInput, H3PrivateFl2VaAttemptFacts,
+    H3PrivateFl2VaMediaContract, H3PrivateFl2VaOwnerFenceFacts, H3PrivateFl2VaPrepareError,
+    H3PrivateFl2VaPrepareInput, H3PrivateFl2VaPreparedAttempt, H3PrivateFl2VaRunContext,
+    H3PrivateFl2VaRunOutput, H3PrivateFl2VaRuntimeBounds, H3PrivateFl2VaTerminalIdentityEcho,
+    H3PrivateFl2VaUatPaths, H3PrivateRuntimeQualificationAuthority,
+    H3PrivateSchedulerLedgerIdentity,
 };
 pub mod model_registry;
 pub(crate) mod nvfp4;

--- a/crates/mold-inference/src/minimax_h3/private_server.rs
+++ b/crates/mold-inference/src/minimax_h3/private_server.rs
@@ -106,7 +106,20 @@ const REVIEWED_RUNTIME_QUALIFICATION_RECORD_SHA256: &[&str] = &[];
 /// qualification record. This performs no filesystem access and is suitable
 /// for an authenticated ingress gate before queue or dependency setup.
 pub const fn reviewed_h3_private_runtime_available() -> bool {
-    !REVIEWED_RUNTIME_QUALIFICATION_RECORD_SHA256.is_empty()
+    reviewed_h3_private_runtime_available_for_task(Task::Fl2va)
+}
+
+/// Report whether this binary contains a reviewed qualification for the
+/// exact private task partition. A qualification for one H3 transformer task
+/// must never authorize another task with different artifacts, conditioning,
+/// and peak-memory behavior.
+pub const fn reviewed_h3_private_runtime_available_for_task(task: Task) -> bool {
+    match task {
+        Task::Fl2va => !REVIEWED_RUNTIME_QUALIFICATION_RECORD_SHA256.is_empty(),
+        // Ref2VA remains sealed until its own artifact and runtime campaign is
+        // reviewed. Do not infer authority from an FL2VA record.
+        Task::Ref2va => false,
+    }
 }
 
 const PRIVATE_ACTIVATION_COVERAGE: [H3FactoryActivationPrerequisite; 9] = [
@@ -3960,6 +3973,10 @@ mod tests {
     #[test]
     fn empty_reviewed_allowlist_rejects_before_any_path_access() {
         assert!(!reviewed_h3_private_runtime_available());
+        assert!(!reviewed_h3_private_runtime_available_for_task(Task::Fl2va));
+        assert!(!reviewed_h3_private_runtime_available_for_task(
+            Task::Ref2va
+        ));
         let factory = base_factory();
         let request: GenerateRequest = serde_json::from_value(serde_json::json!({
             "prompt": "test",

--- a/crates/mold-server/src/execution_plan.rs
+++ b/crates/mold-server/src/execution_plan.rs
@@ -1335,7 +1335,7 @@ fn resolve_private_h3_execution_plans(
         )
     })?;
     grant
-        .validate_for_request(request)
+        .validate_bound_request(request)
         .map_err(ExecutionPlanError::PreparedInputsStale)?;
     if prepared
         .h3_private_admission_by_device
@@ -1725,7 +1725,7 @@ fn validate_private_h3_before_cuda(
         )
     })?;
     grant
-        .validate_for_request(request)
+        .validate_bound_request(request)
         .map_err(ExecutionPlanError::PlanInvalidated)?;
     let evidence = prepared
         .h3_private_admission_by_device

--- a/crates/mold-server/src/gpu_worker.rs
+++ b/crates/mold-server/src/gpu_worker.rs
@@ -2913,19 +2913,18 @@ fn run_claimed_h3_generation(
         tracing::debug!(gpu = ordinal, model = %model_name, "skipping claimed H3 job — client disconnected");
         return false;
     }
-    if mold_core::minimax_h3::task_for_model(&job.request.model)
-        != Some(mold_core::minimax_h3::Task::Fl2va)
-    {
-        return reject_claimed_h3_generation_message(
-            job,
-            "MiniMax H3 private owner bridge accepts only the sealed FL2VA partition".to_string(),
-        );
-    }
-
     let scope_facts = scope.facts();
     let prepared_facts = prepared.facts();
     if let Err(error) = validate_h3_prepared_attempt_facts(scope_facts, &prepared_facts) {
         return reject_claimed_h3_generation_message(job, error.to_string());
+    }
+    if let Err(error) = prepared_facts.media.validate_for_request(
+        &job.request,
+        job.resolved_references
+            .as_ref()
+            .map(crate::reference_uploads::ResolvedReferenceSet::fingerprint),
+    ) {
+        return reject_claimed_h3_generation_message(job, error);
     }
     let lease = match job.lease.clone() {
         Some(lease) if scope_facts.matches_lease(&lease) => lease,
@@ -3236,11 +3235,14 @@ fn validate_h3_publication_contract(
     output: &crate::h3_private_bridge::H3ClaimedRunOutput,
 ) -> anyhow::Result<()> {
     let contract = &prepared.media;
-    let expected_mode = mold_core::minimax_h3::validate_request_contract(
-        &job.request,
-        mold_core::minimax_h3::Task::Fl2va,
-    )
-    .map_err(|error| anyhow::anyhow!("{}: {}", error.code, error.message))?;
+    contract
+        .validate_for_request(
+            &job.request,
+            job.resolved_references
+                .as_ref()
+                .map(crate::reference_uploads::ResolvedReferenceSet::fingerprint),
+        )
+        .map_err(anyhow::Error::msg)?;
     let expected_seed = job
         .request
         .seed
@@ -3259,9 +3261,17 @@ fn validate_h3_publication_contract(
         .video
         .as_ref()
         .ok_or_else(|| anyhow::anyhow!("private H3 response has no video"))?;
-    if contract.canonical_model != mold_core::minimax_h3::FL2VA_COMFY
-        || contract.task != mold_core::minimax_h3::Task::Fl2va
-        || contract.mode != expected_mode
+    let durable_metadata = mold_core::OutputMetadata::from_generate_request(
+        &job.request,
+        expected_seed,
+        None,
+        "private-owner-publication-validation",
+    );
+    let durable_reference_fingerprint = durable_metadata
+        .references
+        .as_deref()
+        .map(mold_core::generation_reference_fingerprint);
+    if contract.canonical_model != job.request.model
         || contract.seed != expected_seed
         || contract.width != job.request.width
         || contract.height != job.request.height
@@ -3280,8 +3290,9 @@ fn validate_h3_publication_contract(
             .all(|byte| byte.is_ascii_hexdigit())
         || !output.response.images.is_empty()
         || output.response.audio.is_some()
-        || output.response.model != mold_core::minimax_h3::FL2VA_COMFY
+        || output.response.model != contract.canonical_model
         || output.response.seed_used != expected_seed
+        || durable_reference_fingerprint != contract.reference_fingerprint_sha256
         || video.data.is_empty()
         || video.thumbnail.is_empty()
         || video.format != OutputFormat::Mp4
@@ -5667,8 +5678,42 @@ mod tests {
                 height: mold_core::minimax_h3::DEFAULT_HEIGHT,
                 frames: mold_core::minimax_h3::MIN_FRAMES,
                 fps: mold_core::minimax_h3::FIXED_FPS,
+                reference_fingerprint_sha256: None,
+                resolved_reference_fingerprint_sha256: None,
+                reference_count: 0,
             },
         }
+    }
+
+    fn fake_ref2va_request(mut request: mold_core::GenerateRequest) -> mold_core::GenerateRequest {
+        use mold_core::{
+            GenerationReference, GenerationReferenceAuthority, GenerationReferenceProvenance,
+        };
+
+        let provenance = |name: &str, byte: u8| GenerationReferenceProvenance {
+            name: Some(name.to_string()),
+            sha256: Some(format!("{byte:02x}").repeat(32)),
+        };
+        request.model = mold_core::minimax_h3::REF2VA_COMFY.to_string();
+        request.references = Some(vec![
+            GenerationReference::Image {
+                media: GenerationReferenceAuthority::Descriptor,
+                provenance: provenance("subject.png", 1),
+                mime_type: "image/png".to_string(),
+                width: 1024,
+                height: 768,
+            },
+            GenerationReference::Audio {
+                media: GenerationReferenceAuthority::Descriptor,
+                provenance: provenance("voice.wav", 2),
+                mime_type: "audio/wav".to_string(),
+                duration_ms: 2_000,
+                sample_rate: 48_000,
+                channels: 1,
+                sample_count: Some(96_000),
+            },
+        ]);
+        request
     }
 
     fn fake_h3_output(
@@ -5698,8 +5743,8 @@ mod tests {
                 video,
                 audio: None,
                 generation_time_ms: 42,
-                model: mold_core::minimax_h3::FL2VA_COMFY.to_string(),
-                seed_used: 7,
+                model: facts.media.canonical_model.clone(),
+                seed_used: facts.media.seed,
                 gpu: None,
             },
             identity_echo: crate::h3_private_bridge::H3TerminalIdentityEcho {
@@ -5737,6 +5782,14 @@ mod tests {
         job: &mut GpuJob,
         outcome: FakeH3Outcome,
     ) -> (Arc<AtomicUsize>, Arc<AtomicUsize>) {
+        install_fake_h3_attempt_with_facts(job, outcome, fake_h3_facts())
+    }
+
+    fn install_fake_h3_attempt_with_facts(
+        job: &mut GpuJob,
+        outcome: FakeH3Outcome,
+        facts: crate::h3_private_bridge::H3PreparedAttemptFacts,
+    ) -> (Arc<AtomicUsize>, Arc<AtomicUsize>) {
         let runs = Arc::new(AtomicUsize::new(0));
         let drops = Arc::new(AtomicUsize::new(0));
         job.lease = Some(crate::scheduler::LeaseFence {
@@ -5750,7 +5803,7 @@ mod tests {
             memory_ledger_sequence: 23,
         });
         job.h3_prepared_attempt = Some(Box::new(FakeH3PreparedAttempt {
-            facts: fake_h3_facts(),
+            facts,
             outcome: Some(outcome),
             runs: Arc::clone(&runs),
             drops: Arc::clone(&drops),
@@ -5873,6 +5926,187 @@ mod tests {
             .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "mp4"))
             .count();
         assert_eq!(published, 1);
+    }
+
+    #[tokio::test]
+    async fn claimed_ref2va_success_publishes_exact_ordered_durable_metadata() {
+        let id = "claimed-h3-ref2va-ordered-publication";
+        let (mut job, result_rx, mut progress_rx, _queue_rx, queue, registry) =
+            claimed_h3_job_fixture(id).await;
+        let output = tempfile::tempdir().unwrap();
+        job.output_dir = Some(output.path().to_path_buf());
+        job.request = fake_ref2va_request(job.request);
+        job.model = job.request.model.clone();
+        let resolved =
+            crate::reference_uploads::ResolvedReferenceSet::authority_only_for_test(&job.request);
+        let mut facts = fake_h3_facts();
+        facts.media = crate::h3_private_bridge::H3PreparedMediaContract::from_request(
+            &job.request,
+            Some(resolved.fingerprint()),
+        )
+        .expect("synthetic resolved Ref2VA authority");
+        let reference_fingerprint = facts
+            .media
+            .reference_fingerprint_sha256
+            .clone()
+            .expect("Ref2VA fingerprint");
+        job.resolved_references = Some(resolved);
+        let db = Arc::new(Some(mold_db::MetadataDb::open_in_memory().unwrap()));
+        job.metadata_db = Arc::clone(&db);
+        let (runs, drops) =
+            install_fake_h3_attempt_with_facts(&mut job, FakeH3Outcome::Success, facts);
+        let worker = single_worker_pool_with_parked("cache-sentinel", Duration::ZERO);
+        let (scheduler_tx, mut scheduler_rx) = tokio::sync::mpsc::unbounded_channel();
+
+        let owner_worker = Arc::clone(&worker);
+        let owner_scheduler = scheduler_tx.clone();
+        let settlements =
+            std::thread::spawn(move || run_fake_claimed_h3(&owner_worker, job, &owner_scheduler))
+                .join()
+                .expect("fake Ref2VA owner thread must not panic");
+        let result = result_rx.await.unwrap().expect("fake Ref2VA success");
+
+        assert_eq!(runs.load(Ordering::SeqCst), 1);
+        assert_eq!(drops.load(Ordering::SeqCst), 1);
+        assert_eq!(settlements.load(Ordering::SeqCst), 1);
+        assert_eq!(queue.pending(), 1);
+        assert!(registry.snapshot().entries.is_empty());
+        assert_eq!(result.response.model, mold_core::minimax_h3::REF2VA_COMFY);
+        assert!(matches!(
+            scheduler_rx.try_recv(),
+            Ok(crate::scheduler::WorkerEvent::AllocationCommitted { work_id, .. }) if work_id == id
+        ));
+
+        let rows = db
+            .as_ref()
+            .as_ref()
+            .expect("metadata database")
+            .list(Some(output.path()))
+            .unwrap();
+        assert_eq!(rows.len(), 1);
+        let references = rows[0]
+            .metadata
+            .references
+            .as_deref()
+            .expect("saved Ref2VA references");
+        assert_eq!(
+            references
+                .iter()
+                .map(|reference| (reference.index, reference.kind))
+                .collect::<Vec<_>>(),
+            [
+                (1, mold_core::GenerationReferenceKind::Image),
+                (2, mold_core::GenerationReferenceKind::Audio),
+            ]
+        );
+        assert_eq!(
+            mold_core::generation_reference_fingerprint(references),
+            reference_fingerprint
+        );
+        let durable = serde_json::to_string(&rows[0].metadata).unwrap();
+        for private in ["descriptor", "upload", "server_path", "api_key"] {
+            assert!(!durable.contains(private));
+        }
+        assert!(progress_rx.try_recv().is_ok());
+    }
+
+    #[tokio::test]
+    async fn claimed_ref2va_rejects_order_drift_before_runtime_or_publication() {
+        let id = "claimed-h3-ref2va-order-drift";
+        let (mut job, result_rx, _progress_rx, _queue_rx, queue, registry) =
+            claimed_h3_job_fixture(id).await;
+        let output = tempfile::tempdir().unwrap();
+        job.output_dir = Some(output.path().to_path_buf());
+        job.request = fake_ref2va_request(job.request);
+        job.model = job.request.model.clone();
+        let admitted =
+            crate::reference_uploads::ResolvedReferenceSet::authority_only_for_test(&job.request);
+        let mut facts = fake_h3_facts();
+        facts.media = crate::h3_private_bridge::H3PreparedMediaContract::from_request(
+            &job.request,
+            Some(admitted.fingerprint()),
+        )
+        .expect("synthetic admitted Ref2VA authority");
+        job.resolved_references = Some(admitted);
+        let (runs, drops) =
+            install_fake_h3_attempt_with_facts(&mut job, FakeH3Outcome::Success, facts);
+
+        job.request
+            .references
+            .as_mut()
+            .expect("ordered references")
+            .reverse();
+        job.resolved_references = Some(
+            crate::reference_uploads::ResolvedReferenceSet::authority_only_for_test(&job.request),
+        );
+        let worker = single_worker_pool_with_parked("cache-sentinel", Duration::ZERO);
+        let (scheduler_tx, mut scheduler_rx) = tokio::sync::mpsc::unbounded_channel();
+        let owner_worker = Arc::clone(&worker);
+        let owner_scheduler = scheduler_tx.clone();
+        let settlements =
+            std::thread::spawn(move || run_fake_claimed_h3(&owner_worker, job, &owner_scheduler))
+                .join()
+                .expect("order-drift owner thread must not panic");
+        let error = match result_rx.await.unwrap() {
+            Err(error) => error,
+            Ok(_) => panic!("reordered Ref2VA authority unexpectedly published"),
+        };
+
+        assert!(error.contains("ordered request authority"));
+        assert_eq!(runs.load(Ordering::SeqCst), 0);
+        assert_eq!(drops.load(Ordering::SeqCst), 1);
+        assert_eq!(settlements.load(Ordering::SeqCst), 1);
+        assert_eq!(queue.pending(), 1);
+        assert!(registry.snapshot().entries.is_empty());
+        assert!(scheduler_rx.try_recv().is_err());
+        assert_eq!(std::fs::read_dir(output.path()).unwrap().count(), 0);
+    }
+
+    #[tokio::test]
+    async fn claimed_ref2va_cancellation_keeps_authority_and_publishes_nothing() {
+        let id = "claimed-h3-ref2va-cancelled";
+        let (mut job, result_rx, _progress_rx, _queue_rx, queue, registry) =
+            claimed_h3_job_fixture(id).await;
+        let output = tempfile::tempdir().unwrap();
+        job.output_dir = Some(output.path().to_path_buf());
+        job.request = fake_ref2va_request(job.request);
+        job.model = job.request.model.clone();
+        let resolved =
+            crate::reference_uploads::ResolvedReferenceSet::authority_only_for_test(&job.request);
+        let mut facts = fake_h3_facts();
+        facts.media = crate::h3_private_bridge::H3PreparedMediaContract::from_request(
+            &job.request,
+            Some(resolved.fingerprint()),
+        )
+        .expect("synthetic cancellation authority");
+        job.resolved_references = Some(resolved);
+        let (runs, drops) =
+            install_fake_h3_attempt_with_facts(&mut job, FakeH3Outcome::Cancelled, facts);
+        let worker = single_worker_pool_with_parked("cache-sentinel", Duration::ZERO);
+        let (scheduler_tx, mut scheduler_rx) = tokio::sync::mpsc::unbounded_channel();
+        let owner_worker = Arc::clone(&worker);
+        let owner_scheduler = scheduler_tx.clone();
+        let settlements =
+            std::thread::spawn(move || run_fake_claimed_h3(&owner_worker, job, &owner_scheduler))
+                .join()
+                .expect("cancelled Ref2VA owner thread must not panic");
+        let error = match result_rx.await.unwrap() {
+            Err(error) => error,
+            Ok(_) => panic!("cancelled Ref2VA attempt unexpectedly published"),
+        };
+
+        assert!(error.contains("cancelled"));
+        assert_eq!(runs.load(Ordering::SeqCst), 1);
+        assert_eq!(drops.load(Ordering::SeqCst), 1);
+        assert_eq!(settlements.load(Ordering::SeqCst), 1);
+        assert_eq!(queue.pending(), 1);
+        assert!(registry.snapshot().entries.is_empty());
+        assert!(matches!(
+            scheduler_rx.try_recv(),
+            Ok(crate::scheduler::WorkerEvent::AllocationCommitted { work_id, .. }) if work_id == id
+        ));
+        assert!(scheduler_rx.try_recv().is_err());
+        assert_eq!(std::fs::read_dir(output.path()).unwrap().count(), 0);
     }
 
     #[tokio::test]

--- a/crates/mold-server/src/h3_attempt.rs
+++ b/crates/mold-server/src/h3_attempt.rs
@@ -771,8 +771,6 @@ fn validate_prepared_facts_against_plan(
         || facts.predicted_host_increment_bytes != plan.predicted_host_increment_bytes
         || facts.media.canonical_model != authority.canonical_model()
         || facts.media.task != authority.task()
-        || facts.media.task != mold_core::minimax_h3::Task::Fl2va
-        || facts.media.mode == mold_core::minimax_h3::Mode::ReferenceToAudioVideo
         || facts.media.fps != mold_core::minimax_h3::FIXED_FPS
         || !valid_sha256(&facts.prepared_attempt_identity_sha256)
         || !valid_sha256(&facts.target_budget_identity_sha256)
@@ -785,6 +783,34 @@ fn validate_prepared_facts_against_plan(
         || facts.memory_ledger_sequence == 0
     {
         return Err(H3AttemptError::IdentityMismatch);
+    }
+    match facts.media.task {
+        mold_core::minimax_h3::Task::Fl2va => {
+            if facts.media.mode == mold_core::minimax_h3::Mode::ReferenceToAudioVideo
+                || facts.media.reference_count != 0
+                || facts.media.reference_fingerprint_sha256.is_some()
+                || facts.media.resolved_reference_fingerprint_sha256.is_some()
+            {
+                return Err(H3AttemptError::IdentityMismatch);
+            }
+        }
+        mold_core::minimax_h3::Task::Ref2va => {
+            if facts.media.mode != mold_core::minimax_h3::Mode::ReferenceToAudioVideo
+                || facts.media.reference_count == 0
+                || !facts
+                    .media
+                    .reference_fingerprint_sha256
+                    .as_deref()
+                    .is_some_and(valid_sha256)
+                || !facts
+                    .media
+                    .resolved_reference_fingerprint_sha256
+                    .as_deref()
+                    .is_some_and(valid_sha256)
+            {
+                return Err(H3AttemptError::IdentityMismatch);
+            }
+        }
     }
     Ok(())
 }
@@ -803,7 +829,7 @@ fn validate_private_prepared_binding(
         .h3_private_ingress_grant
         .as_ref()
         .ok_or(H3AttemptError::IdentityMismatch)?
-        .validate_for_request(&job.request)
+        .validate_bound_request(&job.request)
         .map_err(|_| H3AttemptError::IdentityMismatch)?;
     let evidence = prepared
         .h3_private_admission_by_device

--- a/crates/mold-server/src/h3_private_bridge.rs
+++ b/crates/mold-server/src/h3_private_bridge.rs
@@ -19,7 +19,9 @@ pub(crate) const H3_PRIVATE_RUNTIME_UNAVAILABLE: &str = "MINIMAX_H3_PRIVATE_RUNT
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct H3PrivateIngressGrant {
     canonical_model: String,
+    task: mold_core::minimax_h3::Task,
     authenticated_identity_sha256: String,
+    instance_identity_sha256: String,
     partition_identity_sha256: String,
     policy_identity_sha256: String,
     request_authority_sha256: String,
@@ -38,7 +40,9 @@ impl H3PrivateIngressGrant {
             b"mold.minimax-h3.private-ingress-grant.v1\0",
             &[
                 self.canonical_model.as_bytes(),
+                h3_task_label(self.task),
                 self.authenticated_identity_sha256.as_bytes(),
+                self.instance_identity_sha256.as_bytes(),
                 self.partition_identity_sha256.as_bytes(),
                 self.policy_identity_sha256.as_bytes(),
                 self.request_authority_sha256.as_bytes(),
@@ -49,20 +53,40 @@ impl H3PrivateIngressGrant {
     pub(crate) fn validate_for_request(
         &self,
         request: &mold_core::GenerateRequest,
+        instance_id: &str,
     ) -> Result<(), String> {
-        if request.model != self.canonical_model {
-            return Err("MiniMax H3 ingress authority model changed after authentication".into());
+        self.validate_bound_request(request)?;
+        if self.instance_identity_sha256 != private_instance_identity_sha256(instance_id) {
+            return Err("MiniMax H3 private ingress server instance changed".into());
+        }
+        Ok(())
+    }
+
+    /// Revalidate the immutable request portion when the current server
+    /// instance was already cross-bound into the prepared-input authority.
+    pub(crate) fn validate_bound_request(
+        &self,
+        request: &mold_core::GenerateRequest,
+    ) -> Result<(), String> {
+        if request.model != self.canonical_model
+            || mold_core::minimax_h3::task_for_model(&request.model) != Some(self.task)
+        {
+            return Err(
+                "MiniMax H3 ingress authority task or model changed after authentication".into(),
+            );
         }
         let request_authority_sha256 = request_authority_sha256(request)?;
         if request_authority_sha256 != self.request_authority_sha256 {
             return Err("MiniMax H3 request changed after authenticated ingress".into());
         }
         if self.authenticated_identity_sha256.len() != 64
-            || self.partition_identity_sha256 != private_ingress_partition_identity_sha256()
+            || self.instance_identity_sha256.len() != 64
+            || self.partition_identity_sha256
+                != private_ingress_partition_identity_sha256(self.task)
         {
-            return Err("MiniMax H3 private ingress identity is malformed".into());
+            return Err("MiniMax H3 private ingress route or instance identity changed".into());
         }
-        if self.policy_identity_sha256 != private_ingress_policy_identity_sha256() {
+        if self.policy_identity_sha256 != private_ingress_policy_identity_sha256(self.task) {
             return Err("MiniMax H3 private ingress policy identity changed".into());
         }
         Ok(())
@@ -75,8 +99,9 @@ impl H3PrivateIngressGrant {
         &self,
         submitted: &mold_core::GenerateRequest,
         resolved: &mold_core::GenerateRequest,
+        instance_id: &str,
     ) -> Result<Self, String> {
-        self.validate_for_request(submitted)?;
+        self.validate_for_request(submitted, instance_id)?;
         let mut expected = submitted.clone();
         match (submitted.seed, resolved.seed) {
             (None, Some(seed)) => expected.seed = Some(seed),
@@ -88,13 +113,18 @@ impl H3PrivateIngressGrant {
         }
         let mut rebound = self.clone();
         rebound.request_authority_sha256 = request_authority_sha256(resolved)?;
-        rebound.validate_for_request(resolved)?;
+        rebound.validate_for_request(resolved, instance_id)?;
         Ok(rebound)
     }
 
     #[cfg(test)]
     fn authenticated_identity_sha256(&self) -> &str {
         &self.authenticated_identity_sha256
+    }
+
+    #[cfg(test)]
+    fn instance_identity_sha256(&self) -> &str {
+        &self.instance_identity_sha256
     }
 
     #[cfg(test)]
@@ -121,10 +151,12 @@ impl H3PrivateIngressGrant {
 pub(crate) fn classify_h3_private_ingress(
     request: &mold_core::GenerateRequest,
     authenticated: Option<&crate::auth::ApiKeyAuthenticated>,
+    instance_id: &str,
 ) -> Result<Option<H3PrivateIngressGrant>, crate::routes::ApiError> {
     classify_h3_private_ingress_with_runtime(
         request,
         authenticated,
+        instance_id,
         reviewed_h3_private_runtime_available,
     )
 }
@@ -133,7 +165,8 @@ pub(crate) fn classify_h3_private_ingress(
 fn classify_h3_private_ingress_with_runtime(
     request: &mold_core::GenerateRequest,
     authenticated: Option<&crate::auth::ApiKeyAuthenticated>,
-    runtime_available: impl FnOnce() -> bool,
+    instance_id: &str,
+    runtime_available: impl FnOnce(mold_core::minimax_h3::Task) -> bool,
 ) -> Result<Option<H3PrivateIngressGrant>, crate::routes::ApiError> {
     use axum::http::StatusCode;
 
@@ -152,23 +185,32 @@ fn classify_h3_private_ingress_with_runtime(
     let output_format = request
         .output_format
         .unwrap_or(mold_core::OutputFormat::Mp4);
+    let references_match_task = match contract.task {
+        mold_core::minimax_h3::Task::Fl2va => request.references.is_none(),
+        mold_core::minimax_h3::Task::Ref2va => request
+            .references
+            .as_ref()
+            .is_some_and(|references| !references.is_empty()),
+    };
     let exact_partition = request.model == contract.canonical_model
-        && contract.canonical_model == mold_core::minimax_h3::FL2VA_COMFY
-        && contract.task == mold_core::minimax_h3::Task::Fl2va
+        && matches!(
+            contract.canonical_model,
+            mold_core::minimax_h3::FL2VA_COMFY | mold_core::minimax_h3::REF2VA_COMFY
+        )
         && contract.layout == mold_core::minimax_h3::Layout::ComfyPrunedInt8ConvrotNvfp4Awq
         && request.batch_size == 1
         && output_format == mold_core::OutputFormat::Mp4
         && request.expand != Some(true)
         && request.upscale_model.is_none()
-        && request.references.is_none();
+        && references_match_task;
     if !exact_partition {
         return Err(crate::routes::ApiError::with_code(
-            "MiniMax H3 private ingress accepts only authenticated FL2VA Comfy batch-1 MP4 requests without expansion, upscaling, or ordered references",
+            "MiniMax H3 private ingress accepts only an exact authenticated Comfy task partition with its required conditioning contract",
             H3_PRIVATE_PARTITION_REJECTED,
             StatusCode::UNPROCESSABLE_ENTITY,
         ));
     }
-    if !runtime_available() {
+    if !runtime_available(contract.task) {
         return Err(crate::routes::ApiError::with_code(
             "MiniMax H3 private runtime has no reviewed server admission implementation",
             H3_PRIVATE_RUNTIME_UNAVAILABLE,
@@ -176,7 +218,7 @@ fn classify_h3_private_ingress_with_runtime(
         ));
     }
 
-    let partition_identity_sha256 = private_ingress_partition_identity_sha256();
+    let partition_identity_sha256 = private_ingress_partition_identity_sha256(contract.task);
     let request_authority_sha256 = request_authority_sha256(request).map_err(|error| {
         crate::routes::ApiError::with_code(
             error,
@@ -186,12 +228,14 @@ fn classify_h3_private_ingress_with_runtime(
     })?;
     Ok(Some(H3PrivateIngressGrant {
         canonical_model: contract.canonical_model.to_string(),
+        task: contract.task,
         authenticated_identity_sha256: ingress_digest(
             b"mold.minimax-h3.private-authenticated-identity.v1\0",
             &[authenticated.identity.as_bytes()],
         ),
+        instance_identity_sha256: private_instance_identity_sha256(instance_id),
         partition_identity_sha256,
-        policy_identity_sha256: private_ingress_policy_identity_sha256(),
+        policy_identity_sha256: private_ingress_policy_identity_sha256(contract.task),
         request_authority_sha256,
     }))
 }
@@ -199,13 +243,13 @@ fn classify_h3_private_ingress_with_runtime(
 /// Fail closed until the inference facade contains at least one exact reviewed
 /// private-runtime qualification record. This check performs no path access.
 #[cfg(feature = "h3-private-uat")]
-fn reviewed_h3_private_runtime_available() -> bool {
-    mold_inference::reviewed_h3_private_runtime_available()
+fn reviewed_h3_private_runtime_available(task: mold_core::minimax_h3::Task) -> bool {
+    mold_inference::reviewed_h3_private_runtime_available_for_task(task)
 }
 
 #[cfg(all(test, not(feature = "h3-private-uat")))]
 #[allow(dead_code)]
-fn reviewed_h3_private_runtime_available() -> bool {
+fn reviewed_h3_private_runtime_available(_task: mold_core::minimax_h3::Task) -> bool {
     false
 }
 
@@ -223,36 +267,72 @@ fn ingress_digest(domain: &[u8], values: &[&[u8]]) -> String {
 }
 
 #[cfg(any(test, feature = "h3-private-uat"))]
-fn private_ingress_policy_identity_sha256() -> String {
+fn h3_task_label(task: mold_core::minimax_h3::Task) -> &'static [u8] {
+    match task {
+        mold_core::minimax_h3::Task::Fl2va => b"fl2va",
+        mold_core::minimax_h3::Task::Ref2va => b"ref2va",
+    }
+}
+
+#[cfg(any(test, feature = "h3-private-uat"))]
+fn private_instance_identity_sha256(instance_id: &str) -> String {
+    ingress_digest(
+        b"mold.minimax-h3.private-server-instance.v1\0",
+        &[instance_id.as_bytes()],
+    )
+}
+
+#[cfg(any(test, feature = "h3-private-uat"))]
+fn private_ingress_policy_identity_sha256(task: mold_core::minimax_h3::Task) -> String {
+    let (model, references) = match task {
+        mold_core::minimax_h3::Task::Fl2va => (
+            mold_core::minimax_h3::FL2VA_COMFY,
+            b"no-references".as_slice(),
+        ),
+        mold_core::minimax_h3::Task::Ref2va => (
+            mold_core::minimax_h3::REF2VA_COMFY,
+            b"ordered-heterogeneous-references".as_slice(),
+        ),
+    };
     ingress_digest(
         b"mold.minimax-h3.private-ingress-policy.v1\0",
         &[
-            mold_core::minimax_h3::FL2VA_COMFY.as_bytes(),
-            b"fl2va",
+            model.as_bytes(),
+            h3_task_label(task),
             b"comfy-pruned-int8",
             b"batch-1",
             b"mp4",
             b"no-expand",
             b"no-upscale",
-            b"no-references",
+            references,
             b"api-key-authenticated",
         ],
     )
 }
 
 #[cfg(any(test, feature = "h3-private-uat"))]
-fn private_ingress_partition_identity_sha256() -> String {
+fn private_ingress_partition_identity_sha256(task: mold_core::minimax_h3::Task) -> String {
+    let (model, references) = match task {
+        mold_core::minimax_h3::Task::Fl2va => (
+            mold_core::minimax_h3::FL2VA_COMFY,
+            b"no-references".as_slice(),
+        ),
+        mold_core::minimax_h3::Task::Ref2va => (
+            mold_core::minimax_h3::REF2VA_COMFY,
+            b"ordered-heterogeneous-references".as_slice(),
+        ),
+    };
     ingress_digest(
         b"mold.minimax-h3.private-ingress-partition.v1\0",
         &[
-            mold_core::minimax_h3::FL2VA_COMFY.as_bytes(),
-            b"fl2va",
+            model.as_bytes(),
+            h3_task_label(task),
             b"comfy-pruned-int8",
             b"batch-1",
             b"mp4",
             b"no-expand",
             b"no-upscale",
-            b"no-references",
+            references,
         ],
     )
 }
@@ -345,6 +425,113 @@ pub(crate) struct H3PreparedMediaContract {
     pub(crate) height: u32,
     pub(crate) frames: u32,
     pub(crate) fps: u32,
+    /// Fingerprint of the target-duration prepared reference metadata in
+    /// exact request order. Ref2VA requires this; FL2VA must leave it absent.
+    pub(crate) reference_fingerprint_sha256: Option<String>,
+    /// Fingerprint of the probed descriptor set that owns the private staged
+    /// files. This separately detects byte/probe replacement even when the
+    /// target-duration prepared shapes are unchanged.
+    pub(crate) resolved_reference_fingerprint_sha256: Option<String>,
+    pub(crate) reference_count: u32,
+}
+
+impl H3PreparedMediaContract {
+    pub(crate) fn from_request(
+        request: &mold_core::GenerateRequest,
+        resolved_reference_fingerprint_sha256: Option<&str>,
+    ) -> Result<Self, String> {
+        let task = mold_core::minimax_h3::task_for_model(&request.model)
+            .ok_or_else(|| "MiniMax H3 prepared media lost its task partition".to_string())?;
+        let mode = match task {
+            mold_core::minimax_h3::Task::Fl2va => {
+                mold_core::minimax_h3::validate_request_contract(request, task)
+            }
+            mold_core::minimax_h3::Task::Ref2va => {
+                mold_core::minimax_h3::validate_resolved_request_contract(request, task)
+            }
+        }
+        .map_err(|error| format!("{}: {}", error.code, error.message))?;
+        let seed = request
+            .seed
+            .ok_or_else(|| "MiniMax H3 prepared media has no frozen seed".to_string())?;
+        let frames = request.frames.unwrap_or(mold_core::minimax_h3::MIN_FRAMES);
+        let (reference_fingerprint_sha256, resolved_fingerprint, reference_count) = match task {
+            mold_core::minimax_h3::Task::Fl2va => {
+                if resolved_reference_fingerprint_sha256.is_some() {
+                    return Err(
+                        "MiniMax H3 FL2VA cannot inherit resolved Ref2VA authority".to_string()
+                    );
+                }
+                (None, None, 0)
+            }
+            mold_core::minimax_h3::Task::Ref2va => {
+                let references = request.references.as_deref().ok_or_else(|| {
+                    "MiniMax H3 Ref2VA prepared media lost ordered references".to_string()
+                })?;
+                let reference_count = u32::try_from(references.len())
+                    .map_err(|_| "MiniMax H3 Ref2VA reference count exceeded u32".to_string())?;
+                let resolved_fingerprint =
+                    resolved_reference_fingerprint_sha256.ok_or_else(|| {
+                        "MiniMax H3 Ref2VA prepared media lost resolved reference authority"
+                            .to_string()
+                    })?;
+                let resolved_metadata = references
+                    .iter()
+                    .enumerate()
+                    .map(|(index, reference)| reference.redacted_metadata_lossless(index))
+                    .collect::<Vec<_>>();
+                let expected_resolved =
+                    mold_core::generation_reference_fingerprint(&resolved_metadata);
+                if expected_resolved != resolved_fingerprint {
+                    return Err(
+                        "MiniMax H3 Ref2VA resolved reference order or artifact identity changed"
+                            .to_string(),
+                    );
+                }
+                let prepared_metadata = references
+                    .iter()
+                    .enumerate()
+                    .map(|(index, reference)| {
+                        reference.redacted_metadata_lossless_for_target(index, frames)
+                    })
+                    .collect::<Vec<_>>();
+                (
+                    Some(mold_core::generation_reference_fingerprint(
+                        &prepared_metadata,
+                    )),
+                    Some(resolved_fingerprint.to_string()),
+                    reference_count,
+                )
+            }
+        };
+        Ok(Self {
+            canonical_model: request.model.clone(),
+            task,
+            mode,
+            seed,
+            width: request.width,
+            height: request.height,
+            frames,
+            fps: mold_core::minimax_h3::FIXED_FPS,
+            reference_fingerprint_sha256,
+            resolved_reference_fingerprint_sha256: resolved_fingerprint,
+            reference_count,
+        })
+    }
+
+    pub(crate) fn validate_for_request(
+        &self,
+        request: &mold_core::GenerateRequest,
+        resolved_reference_fingerprint_sha256: Option<&str>,
+    ) -> Result<(), String> {
+        let expected = Self::from_request(request, resolved_reference_fingerprint_sha256)?;
+        if &expected != self {
+            return Err(
+                "MiniMax H3 prepared media changed from its ordered request authority".to_string(),
+            );
+        }
+        Ok(())
+    }
 }
 
 pub(crate) struct H3ClaimedRunOutput {
@@ -554,6 +741,9 @@ fn inference_media(media: mold_inference::H3PrivateFl2VaMediaContract) -> H3Prep
         height: media.height,
         frames: media.frames,
         fps: media.fps,
+        reference_fingerprint_sha256: None,
+        resolved_reference_fingerprint_sha256: None,
+        reference_count: 0,
     }
 }
 
@@ -593,7 +783,13 @@ pub(crate) fn prepare_for_owner(
         .h3_private_ingress_grant
         .as_ref()
         .ok_or_else(|| "MiniMax H3 private preparation lost its ingress grant".to_string())?;
-    ingress_grant.validate_for_request(&job.request)?;
+    ingress_grant.validate_bound_request(&job.request)?;
+    let expected_media = H3PreparedMediaContract::from_request(
+        &job.request,
+        job.resolved_references
+            .as_ref()
+            .map(crate::reference_uploads::ResolvedReferenceSet::fingerprint),
+    )?;
     let compute_capability = worker.gpu.compute_capability.ok_or_else(|| {
         "MiniMax H3 private preparation requires exact CUDA compute capability".to_string()
     })?;
@@ -722,15 +918,6 @@ pub(crate) fn prepare_for_owner(
 
     let boxed = InferenceH3PreparedAttempt::boxed(prepared);
     let facts = boxed.facts();
-    let expected_mode = mold_core::minimax_h3::validate_request_contract(
-        &job.request,
-        mold_core::minimax_h3::Task::Fl2va,
-    )
-    .map_err(|error| format!("{}: {}", error.code, error.message))?;
-    let expected_frames = job
-        .request
-        .frames
-        .unwrap_or(mold_core::minimax_h3::MIN_FRAMES);
     if facts.device_id != device_id
         || facts.device_ordinal != worker.gpu.ordinal
         || facts.execution_identity_sha256 != admission_evidence.execution_fingerprint()
@@ -754,14 +941,7 @@ pub(crate) fn prepare_for_owner(
             .consumption_identity_sha256
             .bytes()
             .all(|byte| byte.is_ascii_hexdigit())
-        || facts.media.canonical_model != mold_core::minimax_h3::FL2VA_COMFY
-        || facts.media.task != mold_core::minimax_h3::Task::Fl2va
-        || facts.media.mode != expected_mode
-        || facts.media.width != job.request.width
-        || facts.media.height != job.request.height
-        || facts.media.frames != expected_frames
-        || facts.media.fps != mold_core::minimax_h3::FIXED_FPS
-        || job.request.seed != Some(facts.media.seed)
+        || facts.media != expected_media
     {
         return Err("MiniMax H3 prepared attempt changed from the frozen owner admission".into());
     }
@@ -827,6 +1007,8 @@ mod tests {
 mod structural_tests {
     use super::BoxedH3PreparedAttempt;
 
+    const INSTANCE_ID: &str = "test-server-instance";
+
     fn request(model: &str) -> mold_core::GenerateRequest {
         serde_json::from_value(serde_json::json!({
             "prompt": "private prompt bytes must not enter the ingress grant",
@@ -844,6 +1026,44 @@ mod structural_tests {
         crate::auth::ApiKeyAuthenticated {
             identity: "process-local-auth-marker".to_string(),
         }
+    }
+
+    fn ref2va_request(swapped: bool) -> mold_core::GenerateRequest {
+        use mold_core::{
+            GenerationReference, GenerationReferenceAuthority, GenerationReferenceProvenance,
+        };
+
+        let provenance = |name: &str, byte: u8| GenerationReferenceProvenance {
+            name: Some(name.to_string()),
+            sha256: Some(format!("{byte:02x}").repeat(32)),
+        };
+        let image = GenerationReference::Image {
+            media: GenerationReferenceAuthority::Descriptor,
+            provenance: provenance("subject.png", 1),
+            mime_type: "image/png".to_string(),
+            width: 1024,
+            height: 768,
+        };
+        let audio = GenerationReference::Audio {
+            media: GenerationReferenceAuthority::Descriptor,
+            provenance: provenance("voice.wav", 2),
+            mime_type: "audio/wav".to_string(),
+            duration_ms: 2_000,
+            sample_rate: 48_000,
+            channels: 1,
+            sample_count: Some(96_000),
+        };
+        let mut request = request(mold_core::minimax_h3::REF2VA_COMFY);
+        request.seed = Some(7);
+        request.guidance = 0.0;
+        request.strength = 1.0;
+        request.enable_audio = Some(true);
+        request.references = Some(if swapped {
+            vec![audio, image]
+        } else {
+            vec![image, audio]
+        });
+        request
     }
 
     #[test]
@@ -878,7 +1098,8 @@ mod structural_tests {
         let grant = super::classify_h3_private_ingress_with_runtime(
             &request("flux-schnell:q8"),
             None,
-            || {
+            INSTANCE_ID,
+            |_| {
                 runtime_checked.set(true);
                 true
             },
@@ -897,7 +1118,8 @@ mod structural_tests {
         let error = super::classify_h3_private_ingress_with_runtime(
             &request(mold_core::minimax_h3::FL2VA_COMFY),
             None,
-            || {
+            INSTANCE_ID,
+            |_| {
                 runtime_checked.set(true);
                 true
             },
@@ -919,7 +1141,8 @@ mod structural_tests {
         let grant = super::classify_h3_private_ingress_with_runtime(
             &submitted,
             Some(&authenticated()),
-            || true,
+            INSTANCE_ID,
+            |_| true,
         )
         .expect("exact authenticated partition")
         .expect("private grant");
@@ -927,17 +1150,141 @@ mod structural_tests {
         let mut resolved = submitted.clone();
         resolved.seed = Some(42);
         let rebound = grant
-            .rebind_resolved_request(&submitted, &resolved)
+            .rebind_resolved_request(&submitted, &resolved, INSTANCE_ID)
             .expect("one omitted seed may be resolved once");
-        assert!(grant.validate_for_request(&resolved).is_err());
+        assert!(grant.validate_for_request(&resolved, INSTANCE_ID).is_err());
         rebound
-            .validate_for_request(&resolved)
+            .validate_for_request(&resolved, INSTANCE_ID)
             .expect("rebound grant must bind the exact resolved request");
 
         let mut mutated = resolved.clone();
         mutated.prompt.push_str(" changed");
-        assert!(rebound.validate_for_request(&mutated).is_err());
-        assert!(grant.rebind_resolved_request(&submitted, &mutated).is_err());
+        assert!(rebound.validate_for_request(&mutated, INSTANCE_ID).is_err());
+        assert!(grant
+            .rebind_resolved_request(&submitted, &mutated, INSTANCE_ID)
+            .is_err());
+    }
+
+    #[test]
+    fn ref2va_ingress_is_task_scoped_and_server_instance_bound() {
+        use axum::response::IntoResponse;
+
+        let request = ref2va_request(false);
+        let seen_task = std::cell::Cell::new(None);
+        let grant = super::classify_h3_private_ingress_with_runtime(
+            &request,
+            Some(&authenticated()),
+            INSTANCE_ID,
+            |task| {
+                seen_task.set(Some(task));
+                task == mold_core::minimax_h3::Task::Ref2va
+            },
+        )
+        .expect("exact Ref2VA partition must classify with injected authority")
+        .expect("exact Ref2VA partition must return a grant");
+        assert_eq!(seen_task.get(), Some(mold_core::minimax_h3::Task::Ref2va));
+        grant
+            .validate_for_request(&request, INSTANCE_ID)
+            .expect("unchanged task and server instance must validate");
+        assert!(grant
+            .validate_for_request(&request, "replacement-server-instance")
+            .is_err());
+
+        let error = super::classify_h3_private_ingress_with_runtime(
+            &request,
+            Some(&authenticated()),
+            INSTANCE_ID,
+            |task| task == mold_core::minimax_h3::Task::Fl2va,
+        )
+        .expect_err("an FL2VA qualification must not authorize Ref2VA");
+        assert_eq!(error.code, super::H3_PRIVATE_RUNTIME_UNAVAILABLE);
+        assert_eq!(
+            error.into_response().status(),
+            axum::http::StatusCode::SERVICE_UNAVAILABLE
+        );
+    }
+
+    #[test]
+    fn ref2va_preparation_binds_swapped_order_and_resolved_artifact_identity() {
+        let original = ref2va_request(false);
+        let original_resolved =
+            crate::reference_uploads::ResolvedReferenceSet::authority_only_for_test(&original);
+        let original_media = super::H3PreparedMediaContract::from_request(
+            &original,
+            Some(original_resolved.fingerprint()),
+        )
+        .expect("resolved Ref2VA request must freeze ordered authority");
+
+        let swapped = ref2va_request(true);
+        let swapped_resolved =
+            crate::reference_uploads::ResolvedReferenceSet::authority_only_for_test(&swapped);
+        let swapped_media = super::H3PreparedMediaContract::from_request(
+            &swapped,
+            Some(swapped_resolved.fingerprint()),
+        )
+        .expect("swapped Ref2VA request must freeze its distinct order");
+
+        assert_ne!(
+            original_media.reference_fingerprint_sha256,
+            swapped_media.reference_fingerprint_sha256
+        );
+        assert_ne!(
+            original_media.resolved_reference_fingerprint_sha256,
+            swapped_media.resolved_reference_fingerprint_sha256
+        );
+        assert!(original_media
+            .validate_for_request(&swapped, Some(swapped_resolved.fingerprint()))
+            .is_err());
+
+        let mut replaced = original.clone();
+        let first = replaced
+            .references
+            .as_mut()
+            .and_then(|references| references.first_mut())
+            .expect("fixture reference");
+        match first {
+            mold_core::GenerationReference::Image { provenance, .. }
+            | mold_core::GenerationReference::Video { provenance, .. }
+            | mold_core::GenerationReference::Audio { provenance, .. } => {
+                provenance.sha256 = Some("03".repeat(32));
+            }
+        }
+        assert!(super::H3PreparedMediaContract::from_request(
+            &replaced,
+            Some(original_resolved.fingerprint()),
+        )
+        .is_err());
+
+        let metadata = mold_core::OutputMetadata::from_generate_request(&original, 7, None, "test");
+        let durable = metadata.references.expect("durable ordered references");
+        assert_eq!(
+            durable.iter().map(|item| item.index).collect::<Vec<_>>(),
+            [1, 2]
+        );
+        assert_eq!(
+            mold_core::generation_reference_fingerprint(&durable),
+            original_media
+                .reference_fingerprint_sha256
+                .as_deref()
+                .expect("prepared reference fingerprint")
+        );
+        let serialized = serde_json::to_string(&durable).unwrap();
+        for private in ["descriptor", "upload", "server_path", "api_key"] {
+            assert!(!serialized.contains(private));
+        }
+
+        let replay_request: mold_core::GenerateRequest =
+            serde_json::from_slice(&serde_json::to_vec(&original).unwrap()).unwrap();
+        let replay_resolved =
+            crate::reference_uploads::ResolvedReferenceSet::authority_only_for_test(
+                &replay_request,
+            );
+        let replay_media = super::H3PreparedMediaContract::from_request(
+            &replay_request,
+            Some(replay_resolved.fingerprint()),
+        )
+        .expect("descriptor-only durable replay must retain exact order identity");
+        assert_eq!(replay_media, original_media);
     }
 
     #[test]
@@ -948,23 +1295,31 @@ mod structural_tests {
             request(mold_core::minimax_h3::FL2VA_OFFICIAL),
         ] {
             let runtime_checked = std::cell::Cell::new(false);
-            let error =
-                super::classify_h3_private_ingress_with_runtime(&invalid, Some(&auth), || {
+            let error = super::classify_h3_private_ingress_with_runtime(
+                &invalid,
+                Some(&auth),
+                INSTANCE_ID,
+                |_| {
                     runtime_checked.set(true);
                     true
-                })
-                .expect_err("wrong H3 task/layout must fail closed");
+                },
+            )
+            .expect_err("wrong H3 task/layout must fail closed");
             assert_eq!(error.code, super::H3_PRIVATE_PARTITION_REJECTED);
             assert!(!runtime_checked.get());
 
             invalid.model = mold_core::minimax_h3::FL2VA_COMFY.to_string();
             invalid.batch_size = 2;
-            let error =
-                super::classify_h3_private_ingress_with_runtime(&invalid, Some(&auth), || {
+            let error = super::classify_h3_private_ingress_with_runtime(
+                &invalid,
+                Some(&auth),
+                INSTANCE_ID,
+                |_| {
                     runtime_checked.set(true);
                     true
-                })
-                .expect_err("batch H3 ingress must fail closed");
+                },
+            )
+            .expect_err("batch H3 ingress must fail closed");
             assert_eq!(error.code, super::H3_PRIVATE_PARTITION_REJECTED);
             assert!(!runtime_checked.get());
         }
@@ -974,22 +1329,28 @@ mod structural_tests {
     fn accepted_ingress_grant_is_cloneable_and_payload_free() {
         let auth = authenticated();
         let request = request(mold_core::minimax_h3::FL2VA_COMFY);
-        let grant = super::classify_h3_private_ingress_with_runtime(&request, Some(&auth), || true)
-            .expect("exact private partition must classify")
-            .expect("exact private partition must return a grant");
+        let grant = super::classify_h3_private_ingress_with_runtime(
+            &request,
+            Some(&auth),
+            INSTANCE_ID,
+            |_| true,
+        )
+        .expect("exact private partition must classify")
+        .expect("exact private partition must return a grant");
         let cloned = grant.clone();
 
         assert_eq!(cloned.canonical_model(), mold_core::minimax_h3::FL2VA_COMFY);
         assert_eq!(cloned.authenticated_identity_sha256().len(), 64);
+        assert_eq!(cloned.instance_identity_sha256().len(), 64);
         assert_eq!(cloned.partition_identity_sha256().len(), 64);
         assert_eq!(cloned.policy_identity_sha256().len(), 64);
         assert_eq!(cloned.request_authority_sha256().len(), 64);
         cloned
-            .validate_for_request(&request)
+            .validate_for_request(&request, INSTANCE_ID)
             .expect("unmodified canonical request must retain its grant");
         let mut mutated = request.clone();
         mutated.prompt.push_str(" changed");
-        assert!(cloned.validate_for_request(&mutated).is_err());
+        assert!(cloned.validate_for_request(&mutated, INSTANCE_ID).is_err());
         let debug = format!("{cloned:?}");
         assert!(!debug.contains(&auth.identity));
         assert!(!debug.contains(&request.prompt));

--- a/crates/mold-server/src/queue.rs
+++ b/crates/mold-server/src/queue.rs
@@ -4394,6 +4394,22 @@ mod tests {
         assert!(references[0].has_audio);
         assert_eq!(references[0].audio_sample_rate, Some(48_000));
         assert_eq!(references[2].index, 3);
+        let saved_fingerprint = mold_core::generation_reference_fingerprint(references);
+        let mut swapped_request = request.clone();
+        swapped_request
+            .references
+            .as_mut()
+            .expect("ordered references")
+            .swap(0, 1);
+        let swapped_metadata =
+            OutputMetadata::from_generate_request(&swapped_request, 42, None, "test");
+        let swapped_fingerprint = mold_core::generation_reference_fingerprint(
+            swapped_metadata
+                .references
+                .as_deref()
+                .expect("swapped ordered metadata"),
+        );
+        assert_ne!(saved_fingerprint, swapped_fingerprint);
         let durable_json = serde_json::to_string(&rows[0].metadata).unwrap();
         for secret in ["authority", "handle", "server_path", "/synthetic/"] {
             assert!(!durable_json.contains(secret));

--- a/crates/mold-server/src/reference_uploads.rs
+++ b/crates/mold-server/src/reference_uploads.rs
@@ -180,6 +180,31 @@ impl ResolvedReferenceSet {
         &self.fingerprint
     }
 
+    /// Payload-free authority fixture for owner/publication contract tests.
+    /// It deliberately contains no opened media and therefore must never be
+    /// passed to `inference_bindings`; production sets are built only by the
+    /// authenticated resolver above.
+    #[cfg(test)]
+    pub(crate) fn authority_only_for_test(request: &mold_core::GenerateRequest) -> Self {
+        let references = request.references.as_deref().unwrap_or_default();
+        let metadata = references
+            .iter()
+            .enumerate()
+            .map(|(index, reference)| reference.redacted_metadata_lossless(index))
+            .collect::<Vec<_>>();
+        let root = std::env::temp_dir().join(format!(
+            "mold-h3-reference-authority-{}",
+            uuid::Uuid::new_v4()
+        ));
+        Self {
+            root: root.clone(),
+            entries: Vec::new(),
+            fingerprint: mold_core::generation_reference_fingerprint(&metadata),
+            _quota: ResolvedQuotaLease::new(Arc::new(AtomicU64::new(0))),
+            _store_lifetime: Arc::new(StoreLifetime { root }),
+        }
+    }
+
     /// Bind the payload-free queued request back to the private staged files
     /// immediately before inference. The order, complete probed metadata, and
     /// aggregate fingerprint must all still match; paths never enter the

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -796,8 +796,11 @@ async fn prepare_generation(
         request.normalise_output_format(Some(mold_core::minimax_h3::FAMILY));
     }
     #[cfg(feature = "h3-private-uat")]
-    let h3_private_ingress_grant =
-        crate::h3_private_bridge::classify_h3_private_ingress(request, authenticated)?;
+    let h3_private_ingress_grant = crate::h3_private_bridge::classify_h3_private_ingress(
+        request,
+        authenticated,
+        state.instance_id.as_str(),
+    )?;
     #[cfg(feature = "h3-private-uat")]
     let private_h3_ingress = h3_private_ingress_grant.is_some();
     #[cfg(not(feature = "h3-private-uat"))]
@@ -979,7 +982,11 @@ async fn prepare_generation(
     warnings.dimension = dim_warning;
     #[cfg(feature = "h3-private-uat")]
     let h3_private_ingress_grant = if h3_private_ingress_grant.is_some() {
-        crate::h3_private_bridge::classify_h3_private_ingress(request, authenticated)?
+        crate::h3_private_bridge::classify_h3_private_ingress(
+            request,
+            authenticated,
+            state.instance_id.as_str(),
+        )?
     } else {
         None
     };
@@ -3046,8 +3053,11 @@ async fn placement_preview_for_request_authenticated(
         crate::h3_private_bridge::pin_private_preview_seed(&mut request)?;
     }
     #[cfg(feature = "h3-private-uat")]
-    let h3_private_ingress_grant =
-        crate::h3_private_bridge::classify_h3_private_ingress(&request, authenticated)?;
+    let h3_private_ingress_grant = crate::h3_private_bridge::classify_h3_private_ingress(
+        &request,
+        authenticated,
+        state.instance_id.as_str(),
+    )?;
     #[cfg(feature = "h3-private-uat")]
     let private_h3_ingress = h3_private_ingress_grant.is_some();
     #[cfg(not(feature = "h3-private-uat"))]
@@ -3187,7 +3197,11 @@ async fn placement_preview_for_request_authenticated(
     #[cfg(feature = "h3-private-uat")]
     let dependency_context = crate::variant_dependencies::DependencyPreparationContext {
         h3_private_ingress_grant: if h3_private_ingress_grant.is_some() {
-            crate::h3_private_bridge::classify_h3_private_ingress(&request, authenticated)?
+            crate::h3_private_bridge::classify_h3_private_ingress(
+                &request,
+                authenticated,
+                state.instance_id.as_str(),
+            )?
         } else {
             None
         },

--- a/crates/mold-server/src/variant_dependencies.rs
+++ b/crates/mold-server/src/variant_dependencies.rs
@@ -1004,7 +1004,10 @@ async fn prepare_inputs_for_devices(
 ) -> Result<PreparedExecutionInputs, String> {
     #[cfg(feature = "h3-private-uat")]
     if let Some(grant) = context.h3_private_ingress_grant.clone() {
-        grant.validate_for_request(request)?;
+        let live_state = state.ok_or_else(|| {
+            "MiniMax H3 private dependency preparation has no server instance authority".to_string()
+        })?;
+        grant.validate_for_request(request, live_state.instance_id.as_str())?;
         return prepare_h3_private_inputs_for_devices(
             state, work_id, request, config, devices, progress, policy, grant,
         )
@@ -1245,7 +1248,7 @@ async fn prepare_inputs_for_devices(
 #[cfg(feature = "h3-private-uat")]
 #[allow(clippy::too_many_arguments)]
 async fn prepare_h3_private_inputs_for_devices(
-    _state: Option<&AppState>,
+    state: Option<&AppState>,
     _work_id: &str,
     request: &GenerateRequest,
     config: &Config,
@@ -1349,7 +1352,14 @@ async fn prepare_h3_private_inputs_for_devices(
         ));
     }
 
-    let rebound_grant = ingress_grant.rebind_resolved_request(request, &resolved_request)?;
+    let instance_id = state
+        .ok_or_else(|| {
+            "MiniMax H3 private admission lost its server instance authority".to_string()
+        })?
+        .instance_id
+        .as_str();
+    let rebound_grant =
+        ingress_grant.rebind_resolved_request(request, &resolved_request, instance_id)?;
     let engine_paths = ModelPaths::resolve(&resolved_request.model, config).ok_or_else(|| {
         "reviewed MiniMax H3 admission could not project its verified manifest paths".to_string()
     })?;

--- a/scripts/tests/minimax-h3-private-uat-release-contract.sh
+++ b/scripts/tests/minimax-h3-private-uat-release-contract.sh
@@ -521,6 +521,31 @@ require_text docs/qualification/minimax-h3.md \
   '--authorization-record' \
   "the private artifact qualifier runbook omits its external authorization record"
 
+# Ref2VA may share the one-shot owner protocol, but it must retain a distinct
+# runtime qualification, ordered-reference authority, and publication fence.
+# Until a reviewed campaign lands, production ingress remains closed.
+require_text crates/mold-inference/src/minimax_h3/private_server.rs \
+  'pub const fn reviewed_h3_private_runtime_available_for_task(task: Task) -> bool {' \
+  "private H3 runtime availability is not scoped to an exact task"
+require_text crates/mold-inference/src/minimax_h3/private_server.rs \
+  'Task::Ref2va => false,' \
+  "Ref2VA can inherit authority without its own reviewed runtime qualification"
+require_text crates/mold-server/src/h3_private_bridge.rs \
+  'b"ordered-heterogeneous-references"' \
+  "the private ingress partition does not bind ordered Ref2VA conditioning"
+require_text crates/mold-server/src/h3_private_bridge.rs \
+  'pub(crate) reference_fingerprint_sha256: Option<String>' \
+  "the one-shot owner contract omits target-duration reference order identity"
+require_text crates/mold-server/src/h3_private_bridge.rs \
+  'pub(crate) resolved_reference_fingerprint_sha256: Option<String>' \
+  "the one-shot owner contract omits resolved reference artifact identity"
+require_text crates/mold-server/src/gpu_worker.rs \
+  'durable_reference_fingerprint != contract.reference_fingerprint_sha256' \
+  "terminal publication does not cross-check durable Ref2VA order metadata"
+require_text crates/mold-server/src/h3_attempt.rs \
+  'mold_core::minimax_h3::Task::Ref2va => {' \
+  "the one-shot attempt fence does not validate the Ref2VA task partition"
+
 scratch_dir="$(mktemp -d)"
 trap 'rm -rf "$scratch_dir"' EXIT
 ordinary_marker='mold.minimax-h3.attention-release-provenance.v2:h3-rc=omitted:global-flash=omitted'


### PR DESCRIPTION
Summary:
- bind each authenticated private H3 ingress grant to its exact task partition and server instance
- preserve ordered heterogeneous Ref2VA identities through resolved media, owner dispatch, cancellation, publication, gallery metadata, and durable replay
- reject swapped references and route/instance drift before runtime execution or output publication
- keep Ref2VA runtime availability hard false until its own reviewed artifact and CUDA campaign exists

Validation:
- cargo check and clippy for mold-ai-server with h3-private-bridge, all targets
- 9 focused Ref2VA server/worker/gallery tests
- private-UAT release-exclusion contract
- Rust formatting, diff check, restricted-name scan, and exact merge-tree conflict check

This is an owner-authority bridge only; it does not add a Ref2VA runtime allowlist record or advertise public support.

Advances #825.