### PR TITLE
test(wan): add wan to the GPU regression matrix and gate the harness in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,13 @@ jobs:
               - 'scripts/tests/install-cuda-arch.sh'
               - 'scripts/tests/cuda-qualification-contract.sh'
               - 'scripts/tests/minimax-h3-attention-release-contract.sh'
+              - 'scripts/regression-matrix.sh'
+              - 'scripts/tests/regression-matrix-aggregate-failures.sh'
+              - 'scripts/tests/regression-matrix-concurrency.sh'
+              - 'scripts/tests/regression-matrix-family-sizing.sh'
+              - 'scripts/tests/regression-matrix-source-image.sh'
+              - 'scripts/tests/regression-matrix-transient-retry.sh'
+              - 'scripts/tests/wan-regression-matrix.sh'
               - 'scripts/tests/minimax-h3-private-uat-release-contract.sh'
               - 'scripts/qualify-cuda-sm86.sh'
               - 'docs/qualification/**'
@@ -347,6 +354,12 @@ jobs:
           bash scripts/tests/install-cuda-arch.sh
           bash scripts/tests/cuda-qualification-contract.sh
           bash scripts/tests/minimax-h3-attention-release-contract.sh
+          bash scripts/tests/regression-matrix-aggregate-failures.sh
+          bash scripts/tests/regression-matrix-concurrency.sh
+          bash scripts/tests/regression-matrix-family-sizing.sh
+          bash scripts/tests/regression-matrix-source-image.sh
+          bash scripts/tests/regression-matrix-transient-retry.sh
+          bash scripts/tests/wan-regression-matrix.sh
       - name: Test MiniMax H3 private-UAT release contract
         if: needs.changes.outputs.release == 'true'
         run: bash scripts/tests/minimax-h3-private-uat-release-contract.sh

--- a/docs/qualification/multi-gpu-family-matrix.md
+++ b/docs/qualification/multi-gpu-family-matrix.md
@@ -72,7 +72,7 @@ SD1.5, SDXL, and SD3.
 | `qwen-image-edit` | runtime qualification | `scripts/qwen-edit-parity-smoke.sh`, explicit source-edit CUDA smoke |
 | `ltx-video` | runtime qualification | `scripts/regression-matrix.sh`, video and independent-chain cases |
 | `ltx2` | runtime qualification | `scripts/regression-matrix.sh`, video/source/audio/durable-chain cases |
-| `wan` | runtime qualification | `scripts/regression-matrix.sh`, text-to-video cases (no hardware campaign recorded yet) |
+| `wan` | runtime qualification | `scripts/regression-matrix.sh`, text-to-video, image-to-video, first/last-frame, and single-frame-still cases across every installed tier (no hardware campaign recorded yet) |
 | `wuerstchen` | runtime qualification | `scripts/regression-matrix.sh`, installed-family base/source cases |
 
 These are executable owners, not a claim that every case passed on the current

--- a/scripts/regression-matrix.sh
+++ b/scripts/regression-matrix.sh
@@ -14,6 +14,7 @@ FAILURE_LOCK="$RUN_DIR/failures.lock"
 LOG_LOCK="$RUN_DIR/results.lock"
 ATTEMPT_LOCK="$RUN_DIR/attempt-errors.lock"
 SOURCE_IMAGE="$RUN_DIR/source.png"
+SOURCE_IMAGE_B="$RUN_DIR/source-b.png"
 
 PROMPT_IMAGE="${MOLD_REGRESSION_PROMPT_IMAGE:-a small ceramic teapot on a wooden table, soft window light, realistic}"
 PROMPT_VIDEO="${MOLD_REGRESSION_PROMPT_VIDEO:-a small ceramic teapot on a wooden table as the camera slowly pushes in, soft window light}"
@@ -63,6 +64,16 @@ magick -size 1024x1024 gradient:'#c8d8df-#f7ead8' \
   -draw "path 'M 690,520 C 790,455 900,485 925,565 C 840,565 790,610 700,620 Z'" \
   "$SOURCE_IMAGE"
 
+# A visibly different second still for wan's first/last-frame cases (#779):
+# reusing the same image for both endpoints would let a broken last-frame
+# pin pass, since the render would look correct either way.
+magick -size 1024x1024 gradient:'#1a2740'-'#4d6fa8' \
+  -fill '#ffd9a0' -stroke '#3a2d1e' -strokewidth 12 \
+  -draw 'roundrectangle 330,300 700,760 40,40' \
+  -fill '#3a2d1e' -draw 'ellipse 515,530 90,90 0,360' \
+  -fill '#ffd9a0' -draw 'ellipse 515,530 42,42 0,360' \
+  "$SOURCE_IMAGE_B"
+
 models_json="$RUN_DIR/models.json"
 loras_json="$RUN_DIR/loras.json"
 curl -fsS "$HOST/api/models" > "$models_json"
@@ -72,7 +83,7 @@ jq -r '
   [
     .[]
     | select(.downloaded == true)
-    | select(.family | IN("flux","flux2","sd15","sdxl","sd3","z-image","qwen-image","wuerstchen","ltx-video","ltx2"))
+    | select(.family | IN("flux","flux2","sd15","sdxl","sd3","z-image","qwen-image","wuerstchen","ltx-video","ltx2","wan"))
     | select((.family != "ltx2") or (((.description // "") | ascii_downcase | contains("fp4") | not) and ((.description // "") | ascii_downcase | contains("nvfp4") | not)))
   ]
   | sort_by(.name)
@@ -80,7 +91,7 @@ jq -r '
   | .[]
   | select(length == 1)
   | .[0]
-  | [.name, .family, (.default_steps|tostring), (.default_width|tostring), (.default_height|tostring)]
+  | [.name, .family, (.default_steps|tostring), (.default_width|tostring), (.default_height|tostring), ((.dimension_alignment // 0)|tostring), ((.source_image // "")|tostring)]
   | @tsv
 ' "$models_json" > "$RUN_DIR/models.tsv"
 
@@ -88,7 +99,7 @@ jq -r '
   [
     .[]
     | select(.downloaded == true)
-    | select(.family | IN("flux","flux2","sd15","sdxl","sd3","z-image","qwen-image","wuerstchen","ltx-video","ltx2"))
+    | select(.family | IN("flux","flux2","sd15","sdxl","sd3","z-image","qwen-image","wuerstchen","ltx-video","ltx2","wan"))
     | select((.family != "ltx2") or (((.description // "") | ascii_downcase | contains("fp4") | not) and ((.description // "") | ascii_downcase | contains("nvfp4") | not)))
   ]
   | sort_by(.name)
@@ -410,7 +421,7 @@ run_mixed_queue() {
     IFS='|' read -r model family case_name <<< "$spec"
     local row default_steps default_width default_height width height steps safe_model prompt output timeout_s
     row="$(model_row "$model")"
-    IFS=$'\t' read -r _ _ default_steps default_width default_height <<< "$row"
+    IFS=$'\t' read -r _ _ default_steps default_width default_height _ _ <<< "$row"
     width="$default_width"
     height="$default_height"
     steps="$default_steps"
@@ -469,10 +480,10 @@ if [[ "$MODE" == "mixed-queue" ]]; then
   exit 0
 fi
 
-while IFS=$'\t' read -r model family default_steps default_width default_height; do
+while IFS=$'\t' read -r model family default_steps default_width default_height dim_align source_image; do
   safe_model="$(case_stem "$family" "$model")"
   prompt="$PROMPT_IMAGE"
-  [[ "$family" == ltx-video || "$family" == ltx2 ]] && prompt="$PROMPT_VIDEO"
+  [[ "$family" == ltx-video || "$family" == ltx2 || "$family" == wan ]] && prompt="$PROMPT_VIDEO"
 
   width="$default_width"
   height="$default_height"
@@ -489,8 +500,83 @@ while IFS=$'\t' read -r model family default_steps default_width default_height;
     width="${MOLD_REGRESSION_LTX_VIDEO_WIDTH:-768}"
     height="${MOLD_REGRESSION_LTX_VIDEO_HEIGHT:-512}"
   fi
-  [[ -n "$STEPS_IMAGE" && "$family" != ltx-video && "$family" != ltx2 ]] && steps="$STEPS_IMAGE"
+  # Wan sizes from what the checkpoint itself advertises: TI2V-5B needs a /32
+  # grid where the A14B tiers take /16, and a family constant would put one
+  # of them off-grid. The advertised alignment is authoritative; the width
+  # and height already came from the same row.
+  if [[ "$family" == wan && "${dim_align:-0}" -gt 0 ]]; then
+    width=$(( (width / dim_align) * dim_align ))
+    height=$(( (height / dim_align) * dim_align ))
+  fi
+
+  [[ -n "$STEPS_IMAGE" && "$family" != ltx-video && "$family" != ltx2 && "$family" != wan ]] && steps="$STEPS_IMAGE"
   [[ -n "$STEPS_VIDEO" && ( "$family" == ltx-video || "$family" == ltx2 ) ]] && steps="$STEPS_VIDEO"
+  # Deliberately NOT step-flattened (#790): wan's tiers ARE the recipe — the
+  # 4-step Lightning tiers and the 20-step quality tiers exercise different
+  # code (distill branch vs none, CFG vs single forward). Overriding steps
+  # would collapse them into one case that tests neither.
+
+  if [[ "$family" == wan ]]; then
+    # The conditioning contract the server advertises decides the cases: a
+    # T2V-only checkpoint has no source case to run, and an I2V-required one
+    # cannot render a bare base case at all (#772).
+    #
+    # An ABSENT contract means unknown — an older server, or a checkpoint
+    # whose headers this build could not classify — not "unsupported".
+    # Guessing either way produces a misleading result: assume T2V and an
+    # I2V-required checkpoint fails for missing input; assume I2V and a
+    # T2V-only one fails for supplying it. Skip the model and say so, so the
+    # run reports a coverage gap rather than a fake regression.
+    if [[ -z "$source_image" ]]; then
+      printf 'skipping %s: server advertises no source_image contract (unknown, not unsupported)\n' \
+        "$model" >&2
+      printf '%s\t%s\tunclassified-source-contract\n' "$model" "$family" \
+        >> "$RUN_DIR/SKIPPED_MODELS.tsv"
+      continue
+    fi
+
+    if [[ "$source_image" != "required" ]]; then
+      base_out="$RUN_DIR/${safe_model}.base.mp4"
+      queue_case "$model" "$family" base "$base_out" "$TIMEOUT_VIDEO" \
+        "$MOLD_BIN" run --host "$HOST" "$model" "$prompt" \
+        --output "$base_out" --format mp4 --frames "$FRAMES_VIDEO" --fps "$FPS_VIDEO" \
+        --width "$width" --height "$height" --steps "$steps"
+    fi
+
+    if [[ "$source_image" == "required" || "$source_image" == "optional" ]]; then
+      src_out="$RUN_DIR/${safe_model}.source.mp4"
+      queue_case "$model" "$family" source "$src_out" "$TIMEOUT_VIDEO" \
+        "$MOLD_BIN" run --host "$HOST" "$model" "$prompt" \
+        --output "$src_out" --format mp4 --frames "$FRAMES_VIDEO" --fps "$FPS_VIDEO" \
+        --width "$width" --height "$height" --steps "$steps" --image "$SOURCE_IMAGE"
+
+      # First/last-frame (#779). The nine-frame floor is TI2V's alone — it
+      # pins both endpoints in latent space, so a shorter clip leaves nothing
+      # to denoise. A14B concatenates its conditioning and happily takes any
+      # valid 4k+1 clip, so applying the floor family-wide would silently
+      # drop its endpoint case at a small FRAMES_VIDEO.
+      flf_min=1
+      [[ "$model" == wan22-ti2v-5b* ]] && flf_min=9
+      if [[ "$FRAMES_VIDEO" -ge "$flf_min" ]]; then
+        flf_out="$RUN_DIR/${safe_model}.flf.mp4"
+        queue_case "$model" "$family" flf "$flf_out" "$TIMEOUT_VIDEO" \
+          "$MOLD_BIN" run --host "$HOST" "$model" "$prompt" \
+          --output "$flf_out" --format mp4 --frames "$FRAMES_VIDEO" --fps "$FPS_VIDEO" \
+          --width "$width" --height "$height" --steps "$steps" \
+          --image "$SOURCE_IMAGE" --last-image "$SOURCE_IMAGE_B"
+      fi
+    fi
+
+    # Single-frame still (#798): wan is the only video family that renders a
+    # PNG, and the format default flips with the frame count.
+    if [[ "$source_image" != "required" ]]; then
+      still_out="$RUN_DIR/${safe_model}.still.png"
+      queue_case "$model" "$family" still "$still_out" "$TIMEOUT_IMAGE" \
+        "$MOLD_BIN" run --host "$HOST" "$model" "$prompt" \
+        --output "$still_out" --format png --frames 1 \
+        --width "$width" --height "$height" --steps "$steps"
+    fi
+  fi
 
   if [[ "$family" == ltx-video || "$family" == ltx2 ]]; then
     base_out="$RUN_DIR/${safe_model}.base.mp4"
@@ -540,7 +626,10 @@ while IFS=$'\t' read -r model family default_steps default_width default_height;
       queue_case "$model" "$family" chain-audio-source "$chain_audio_source_out" "$TIMEOUT_VIDEO" \
         "$MOLD_BIN" run --host "$HOST" --script "$chain_audio_source_script" --output "$chain_audio_source_out"
     fi
-  else
+  elif [[ "$family" != wan ]]; then
+    # wan is handled by its own arm above. Without this guard it would ALSO
+    # take the image-family cases, queueing a bare PNG base case that an
+    # I2V-required checkpoint rejects outright and a duplicate still.
     base_out="$RUN_DIR/${safe_model}.base.png"
     queue_case "$model" "$family" base "$base_out" "$TIMEOUT_IMAGE" \
       "$MOLD_BIN" run --host "$HOST" "$model" "$prompt" \

--- a/scripts/tests/regression-matrix-source-image.sh
+++ b/scripts/tests/regression-matrix-source-image.sh
@@ -10,6 +10,7 @@ mkdir -p "$tmp/bin" "$tmp/run" "$tmp/state"
 cat > "$tmp/bin/magick" <<'FAKE'
 #!/usr/bin/env bash
 set -euo pipefail
+printf '%s\n' "$*" > "${MOLD_FAKE_STATE:?}/magick-args-$(basename "${@: -1}")"
 printf '%s\n' "$*" > "${MOLD_FAKE_STATE:?}/magick-args"
 out="${@: -1}"
 printf 'fake image\n' > "$out"
@@ -71,7 +72,10 @@ MOLD_REGRESSION_RUN_ID=source-image \
 MOLD_REGRESSION_TIMEOUT_IMAGE=10 \
 "$repo_root/scripts/regression-matrix.sh" > "$tmp/stdout" 2> "$tmp/stderr"
 
-args="$(<"$tmp/state/magick-args")"
+# The harness now synthesizes a second still for wan first/last-frame
+# cases, so assert against the source.png invocation specifically rather
+# than whichever magick call happened to run last.
+args="$(<"$tmp/state/magick-args-source.png")"
 if [[ "$args" != *"ellipse 512,560"* || "$args" != *"arc 300,430 455,665"* || "$args" != *"path 'M 690,520"* ]]; then
   echo "expected regression source image to draw a teapot body, handle, and spout" >&2
   echo "$args" >&2

--- a/scripts/tests/wan-regression-matrix.sh
+++ b/scripts/tests/wan-regression-matrix.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# #790: the wan arm of scripts/regression-matrix.sh, gated with no GPU and no
+# weights. Asserts that the generated case set follows what each checkpoint
+# ADVERTISES — its conditioning contract, its dimension alignment, and its
+# tier's own step count — rather than a family constant.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+mkdir -p "$tmp/bin" "$tmp/run" "$tmp/state"
+
+cat > "$tmp/bin/magick" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+out="${@: -1}"
+printf 'fake image\n' > "$out"
+FAKE
+chmod +x "$tmp/bin/magick"
+
+# Three wan tiers covering all three conditioning contracts and both grids:
+# a T2V-only 4-step Lightning tier, a 20-step quality I2V-required tier, and
+# TI2V-5B, which is `optional` and needs /32 rather than /16.
+cat > "$tmp/bin/curl" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+url="${@: -1}"
+case "$url" in
+  */api/models)
+    cat <<'JSON'
+[
+  {
+    "name": "wan22-t2v-a14b:q5",
+    "family": "wan",
+    "downloaded": true,
+    "default_steps": 4,
+    "default_width": 848,
+    "default_height": 480,
+    "dimension_alignment": 16,
+    "source_image": "unsupported"
+  },
+  {
+    "name": "wan22-i2v-a14b:q8",
+    "family": "wan",
+    "downloaded": true,
+    "default_steps": 20,
+    "default_width": 832,
+    "default_height": 480,
+    "dimension_alignment": 16,
+    "source_image": "required"
+  },
+  {
+    "name": "wan22-ti2v-5b:fp16",
+    "family": "wan",
+    "downloaded": true,
+    "default_steps": 20,
+    "default_width": 1296,
+    "default_height": 720,
+    "dimension_alignment": 32,
+    "source_image": "optional"
+  }
+]
+JSON
+    ;;
+  */api/catalog/installed?kind=lora)
+    printf '{"entries": []}\n'
+    ;;
+  *)
+    echo "unexpected curl URL: $url" >&2
+    exit 2
+    ;;
+esac
+FAKE
+chmod +x "$tmp/bin/curl"
+
+cat > "$tmp/bin/fake-mold" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+state_dir="${MOLD_FAKE_STATE:?}"
+output=""; width=""; height=""; steps=""; frames=""; last_image=""; image=""
+while (($# > 0)); do
+  case "$1" in
+    --output) shift; output="$1" ;;
+    --width) shift; width="$1" ;;
+    --height) shift; height="$1" ;;
+    --steps) shift; steps="$1" ;;
+    --frames) shift; frames="$1" ;;
+    --image) shift; image="$1" ;;
+    --last-image) shift; last_image="$1" ;;
+  esac
+  shift || true
+done
+[[ -n "$output" ]] || { echo "fake mold got no --output" >&2; exit 2; }
+stem="$(basename "$output")"
+printf '%s|%s|%s|%s|%s|%s\n' "$width" "$height" "$steps" "$frames" "$image" "$last_image" \
+  > "$state_dir/$stem"
+printf 'fake output\n' > "$output"
+FAKE
+chmod +x "$tmp/bin/fake-mold"
+
+PATH="$tmp/bin:$PATH" \
+MOLD_BIN="$tmp/bin/fake-mold" \
+MOLD_FAKE_STATE="$tmp/state" \
+MOLD_REGRESSION_OUT="$tmp/run" \
+MOLD_REGRESSION_RUN_ID=wan \
+MOLD_REGRESSION_TIMEOUT_IMAGE=10 \
+MOLD_REGRESSION_TIMEOUT_VIDEO=10 \
+MOLD_REGRESSION_STEPS_VIDEO=99 \
+"$repo_root/scripts/regression-matrix.sh" > "$tmp/stdout" 2> "$tmp/stderr" || {
+  echo "regression-matrix.sh failed" >&2
+  tail -n 40 "$tmp/stderr" >&2
+  exit 1
+}
+
+field() { cut -d'|' -f"$2" < "$tmp/state/$1"; }
+exists() { [[ -e "$tmp/state/$1" ]]; }
+
+fail() {
+  echo "$1" >&2
+  echo "--- cases generated ---" >&2
+  ls "$tmp/state" >&2
+  exit 1
+}
+
+# A T2V-only checkpoint gets base + still, and NO source or first/last case:
+# it would be refused at admission.
+exists wan.wan22-t2v-a14b-q5.base.mp4 || fail "expected a base case for the T2V tier"
+exists wan.wan22-t2v-a14b-q5.still.png || fail "expected a single-frame still case (#798)"
+! exists wan.wan22-t2v-a14b-q5.source.mp4 || fail "T2V-only must not get a source case"
+! exists wan.wan22-t2v-a14b-q5.flf.mp4 || fail "T2V-only must not get a first/last case"
+
+# An I2V-required checkpoint gets source + first/last, and NO bare base or
+# still: both would be rejected for lacking the image the model needs.
+exists wan.wan22-i2v-a14b-q8.source.mp4 || fail "expected a source case for the I2V tier"
+exists wan.wan22-i2v-a14b-q8.flf.mp4 || fail "expected a first/last case for the I2V tier (#779)"
+! exists wan.wan22-i2v-a14b-q8.base.mp4 || fail "I2V-required must not get a bare base case"
+! exists wan.wan22-i2v-a14b-q8.still.png || fail "I2V-required must not get a still case"
+
+# `optional` gets the full spread.
+for c in base.mp4 source.mp4 flf.mp4 still.png; do
+  exists "wan.wan22-ti2v-5b-fp16.$c" || fail "expected TI2V case $c"
+done
+
+# The first/last case must anchor two DIFFERENT stills, or a broken
+# last-frame pin renders correctly anyway and the case proves nothing.
+flf_first="$(field wan.wan22-i2v-a14b-q8.flf.mp4 5)"
+flf_last="$(field wan.wan22-i2v-a14b-q8.flf.mp4 6)"
+[[ -n "$flf_first" && -n "$flf_last" ]] || fail "first/last case must pass both endpoints"
+[[ "$flf_first" != "$flf_last" ]] || fail "first/last endpoints must be different images"
+
+# Geometry comes from the checkpoint's ADVERTISED alignment. The fixture
+# sizes are chosen so each grid produces a different answer, and the
+# assertions pin the exact forwarded value — a modulo check would pass even
+# if the script ignored dimension_alignment entirely.
+#   848x480  is /16-clean but NOT /32: a wrong /32 floors width to 832.
+#   1296x720 is /16-clean but NOT /32: a wrong /16 leaves it unfloored.
+ti2v_geom="$(field wan.wan22-ti2v-5b-fp16.base.mp4 1)x$(field wan.wan22-ti2v-5b-fp16.base.mp4 2)"
+[[ "$ti2v_geom" == "1280x704" ]] || fail "TI2V must floor 1296x720 to its /32 grid, saw $ti2v_geom"
+a14b_geom="$(field wan.wan22-t2v-a14b-q5.base.mp4 1)x$(field wan.wan22-t2v-a14b-q5.base.mp4 2)"
+[[ "$a14b_geom" == "848x480" ]] || fail "A14B must keep 848x480 on its /16 grid, saw $a14b_geom"
+
+# Steps come from the tier, NOT from MOLD_REGRESSION_STEPS_VIDEO (set to 99
+# above): flattening would collapse the 4-step Lightning and 20-step quality
+# recipes into one case that exercises neither distill path.
+fast_steps="$(field wan.wan22-t2v-a14b-q5.base.mp4 3)"
+quality_steps="$(field wan.wan22-i2v-a14b-q8.source.mp4 3)"
+[[ "$fast_steps" == "4" ]] || fail "Lightning tier must keep its 4 steps, saw $fast_steps"
+[[ "$quality_steps" == "20" ]] || fail "quality tier must keep its 20 steps, saw $quality_steps"
+
+# The still case is one frame; the video cases are not.
+still_frames="$(field wan.wan22-t2v-a14b-q5.still.png 4)"
+[[ "$still_frames" == "1" ]] || fail "still case must request exactly 1 frame, saw $still_frames"
+
+echo "wan regression-matrix contract OK"


### PR DESCRIPTION
Closes #790.

Two problems, one PR: Wan had no regression coverage at all, and the harness that would provide it was ungated.

## Wan was never in the matrix — and the docs said it was

Both jq family filters in `scripts/regression-matrix.sh` enumerated the other ten families; `wan` appeared nowhere in the file. Meanwhile `docs/qualification/multi-gpu-family-matrix.md` already claimed wan was covered with "text-to-video cases". That line is now true, and specific about what actually gets generated.

Cases derive from what each checkpoint **advertises**, never a family constant:

- **The conditioning contract decides which cases exist** (#772). A T2V-only tier gets base + still and no source/first-last; an I2V-required tier gets source + first/last and no bare base or still — each omitted case is one the server would reject.
- **`dimension_alignment` sizes the render.** TI2V-5B needs /32 where the A14B tiers take /16; a family constant puts one of them off-grid.
- **Steps come from the tier.** `MOLD_REGRESSION_STEPS_VIDEO` deliberately does **not** flatten wan: the 4-step Lightning and 20-step quality recipes exercise different code (distill branch vs none, CFG vs single forward), and flattening collapses them into one case that tests neither.
- **First/last cases anchor two visibly different stills.** Reusing one image would let a broken last-frame pin render correctly and pass.
- The 81-frame A14B shape stays behind the existing `MOLD_REGRESSION_INCLUDE_OVER_BUDGET=1`, ready as the acceptance probe for #776.

## The harness itself was dead code

`scripts/tests/regression-matrix-*.sh` — five contract tests, present in the tree, referenced by **no workflow**. A regression in the harness was silently green. All six (the five existing plus the new wan one) now run in the contracts step with their paths in the trigger filter, validated by the repo's own `ci-routing-contract.sh` and `actionlint`.

## Bug found by writing the test first

Wan models fell through to the **image-family arm as well as their own**, queueing a bare PNG base case that an I2V-required checkpoint rejects outright, plus a duplicate still. Caught by the contract test before any of this ran against hardware.

## Codex xhigh review — four findings, all fixed

- **Absent `source_image` was treated as `unsupported`.** It legitimately means *unknown* (older server, or headers this build cannot classify). Guessing either way produces a misleading failure, so an unclassified wan row is now skipped, reported to stderr, and recorded in `SKIPPED_MODELS.tsv` as a coverage gap rather than a fake regression.
- **The nine-frame floor is TI2V's alone.** It pins both endpoints in latent space; A14B concatenates its conditioning and accepts any valid `4k+1` clip. Applying the floor family-wide silently dropped A14B's endpoint case at small frame counts. Now scoped to TI2V.
- **A sixth harness test existed that I missed** — `regression-matrix-transient-retry.sh`, also dead. Wired into both lists.
- **My alignment assertions were vacuous.** Both fixture sizes (832x480, 1280x704) were already /32-divisible, and the checks were modulo-based, so the test passed even if the script ignored `dimension_alignment` entirely. Fixture sizes now discriminate (848x480 is /16-clean but not /32; 1296x720 floors to 1280x704 only under /32) and the assertions pin the **exact** forwarded geometry. **Mutation-verified**: disabling the alignment logic fails with `TI2V must floor 1296x720 to its /32 grid, saw 1296x720`.

## Gates

All six harness contract tests pass locally; `bash -n` clean; `actionlint` clean; `ci-routing-contract.sh` passes with the new filter paths. No GPU run here — the harness drives a live server and its wan arm is what this PR adds; the CI-gateable half is the contract test, which is the point.

https://claude.ai/code/session_016sixdYQcPerwLBPcUEjDdr
