### PR TITLE
ci: accelerate pull request feedback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,16 +20,16 @@ concurrency:
   group: ci-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-# Cache strategy: jobs that compile the same features share a cache key.
-# Only main-branch pushes save caches; PRs read from main's cache.
+# Cache strategy: main jobs that compile the same features share a cache key.
+# Pull requests do not compile or restore compiler caches.
 #
-# Path-aware gating: the `changes` job classifies the diff, and each gate only
-# runs when its surface actually changed — a docs-only PR no longer compiles
-# the Rust workspace twice. This MUST stay as job-level `if:` conditions, NOT
-# `on.<event>.paths` filters: rust/coverage/docs/web are required status
-# checks, and a workflow that never triggers leaves them "Expected — waiting"
-# forever (blocking every docs-only PR and the release-plz PR). A job skipped
-# by `if:` reports "skipped", which branch protection counts as passing.
+# Path-aware gating: PRs run only Rust/docs/frontend formatting for changed
+# source trees, plus static workflow syntax/routing validation. Substantive
+# compilation, tests, builds, and platform checks run after merge on main.
+# Keep rust/coverage/docs/web as job-level gates, NOT `on.<event>.paths`
+# filters: they are required status checks, and a workflow that never triggers
+# leaves them "Expected — waiting" forever. A skipped job reports success to
+# branch protection while retaining its established status-check name.
 
 jobs:
   changes:
@@ -39,6 +39,7 @@ jobs:
       pull-requests: read
     outputs:
       rust: ${{ steps.filter.outputs.rust }}
+      rust_format: ${{ steps.filter.outputs.rust_format }}
       gpu: ${{ steps.filter.outputs.gpu }}
       website: ${{ steps.filter.outputs.website }}
       web: ${{ steps.filter.outputs.web }}
@@ -84,6 +85,8 @@ jobs:
               - 'docs/qualification/minimax-h3-*.json'
               - 'docs/qualification/minimax-h3-conformance.md'
               - 'docs/qualification/README.md'
+            rust_format:
+              - 'crates/**/*.rs'
             # Forced-local checks exist to compile backend-specific code that
             # the ordinary workspace gate cannot see. Backend-neutral crates
             # (catalog, DB, Discord, scheduler) are already covered by `rust`.
@@ -196,7 +199,9 @@ jobs:
             # After merge, exercise every dynamic path against the real runner
             # environment without putting those expensive jobs on the PR.
             workflow:
-              - '.github/workflows/ci.yml'
+              - '.github/actionlint.yaml'
+              - '.github/workflows/**'
+              - 'scripts/tests/ci-routing-contract.sh'
 
   docs:
     needs: changes
@@ -224,9 +229,11 @@ jobs:
         working-directory: website
         run: bun run fmt:check
       - name: Verify docs references
+        if: github.event_name == 'push'
         working-directory: website
         run: bun run verify
       - name: Build docs
+        if: github.event_name == 'push'
         working-directory: website
         run: bun run build
 
@@ -252,24 +259,29 @@ jobs:
       - name: Install web dependencies
         run: bun install --frozen-lockfile
       - name: Check frontend architecture and dead code
+        if: github.event_name == 'push'
         run: bun run check:architecture && bun run check:dead-code
       - name: Run shared Studio tests
+        if: github.event_name == 'push'
         run: bun run test:studio
       - name: Check web formatting
         working-directory: web
         run: bun run fmt:check
       - name: Run web tests
+        if: github.event_name == 'push'
         working-directory: web
         run: bun run test
       - name: Build web SPA (includes vue-tsc typecheck)
+        if: github.event_name == 'push'
         working-directory: web
         run: bun run build
 
   nix-web:
     needs: changes
     if: >-
-      needs.changes.outputs.nix == 'true' ||
-      (github.event_name == 'push' && needs.changes.outputs.workflow == 'true')
+      github.event_name == 'push' &&
+      (needs.changes.outputs.nix == 'true' ||
+       needs.changes.outputs.workflow == 'true')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -285,10 +297,11 @@ jobs:
        needs.changes.outputs.trusted_release_pr == 'true' ||
        needs.changes.outputs.release == 'true' ||
        needs.changes.outputs.rust == 'true' ||
-       (github.event_name == 'push' && needs.changes.outputs.workflow == 'true'))
+       needs.changes.outputs.workflow == 'true')
     runs-on: ubuntu-latest
     env:
-      RUN_RUST_SUITE: ${{ needs.changes.outputs.trusted_release_pr != 'true' && (needs.changes.outputs.rust == 'true' || (github.event_name == 'push' && needs.changes.outputs.workflow == 'true')) }}
+      RUN_RUST_SUITE: ${{ github.event_name == 'push' && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.workflow == 'true') }}
+      RUN_RUST_FORMAT: ${{ needs.changes.outputs.trusted_release_pr != 'true' && needs.changes.outputs.rust_format == 'true' }}
       SCCACHE_GHA_ENABLED: "true"
     steps:
       - name: Require successful change classification
@@ -342,7 +355,7 @@ jobs:
             exit 1
           }
       - name: Validate all locked Cargo graphs
-        if: needs.changes.outputs.release == 'true'
+        if: github.event_name == 'push' && needs.changes.outputs.release == 'true'
         env:
           RUSTC_WRAPPER: ""
         run: |
@@ -352,9 +365,15 @@ jobs:
           cargo metadata --locked --no-deps --format-version 1 \
             --manifest-path apps/mobile/src-tauri/Cargo.toml >/dev/null
       - uses: DeterminateSystems/determinate-nix-action@v3
-        if: needs.changes.outputs.release == 'true'
+        if: github.event_name == 'push' && needs.changes.outputs.release == 'true'
+      - name: Validate workflow syntax
+        if: github.event_name == 'pull_request' && needs.changes.outputs.workflow == 'true'
+        uses: docker://rhysd/actionlint:1.7.12
+      - name: Validate CI routing policy
+        if: github.event_name == 'pull_request' && needs.changes.outputs.workflow == 'true'
+        run: bash scripts/tests/ci-routing-contract.sh
       - name: Run protected release contracts
-        if: needs.changes.outputs.release == 'true'
+        if: github.event_name == 'push' && needs.changes.outputs.release == 'true'
         run: |
           nix run nixpkgs#actionlint -- .github/workflows/*.yml
           bash scripts/tests/release-sync-pr.sh
@@ -376,8 +395,12 @@ jobs:
           bash scripts/tests/regression-matrix-transient-retry.sh
           bash scripts/tests/wan-regression-matrix.sh
       - name: Test MiniMax H3 private-UAT release contract
-        if: needs.changes.outputs.release == 'true'
+        if: github.event_name == 'push' && needs.changes.outputs.release == 'true'
         run: bash scripts/tests/minimax-h3-private-uat-release-contract.sh
+      - uses: dtolnay/rust-toolchain@stable
+        if: github.event_name == 'pull_request' && env.RUN_RUST_FORMAT == 'true'
+        with:
+          components: rustfmt
       - uses: dtolnay/rust-toolchain@stable
         if: env.RUN_RUST_SUITE == 'true'
         with:
@@ -425,7 +448,7 @@ jobs:
           cargo "+$msrv_toolchain" check -p mold-ai --locked \
             --features preview,discord,expand,tui,metrics,webp,mp4,mdns
       - name: Format
-        if: env.RUN_RUST_SUITE == 'true'
+        if: env.RUN_RUST_FORMAT == 'true'
         run: cargo fmt --all -- --check
       - name: Clippy
         if: env.RUN_RUST_SUITE == 'true'
@@ -433,13 +456,8 @@ jobs:
       # The live Hugging Face search is an external-service monitor, not a
       # deterministic change gate. It has repeatedly failed release PRs on 429
       # responses, so keep that signal on main without forcing PR reruns.
-      - name: Test (PR suite)
-        if: env.RUN_RUST_SUITE == 'true' && github.event_name == 'pull_request'
-        run: >-
-          cargo test --workspace --
-          --skip catalog_api::catalog_live_test::live_search_free_text_can_find_manual_clip_components
       - name: Test (full main suite)
-        if: env.RUN_RUST_SUITE == 'true' && github.event_name == 'push'
+        if: env.RUN_RUST_SUITE == 'true'
         run: cargo test --workspace
       - name: Test local multi-GPU qualification contract
         if: env.RUN_RUST_SUITE == 'true'
@@ -484,9 +502,9 @@ jobs:
     name: CUDA forced-local typecheck
     needs: changes
     if: >-
+      github.event_name == 'push' &&
       needs.changes.outputs.trusted_release_pr != 'true' &&
-      (needs.changes.outputs.gpu == 'true' ||
-       (github.event_name == 'push' && needs.changes.outputs.workflow == 'true'))
+      (needs.changes.outputs.gpu == 'true' || needs.changes.outputs.workflow == 'true')
     runs-on: ubuntu-22.04
     env:
       CUDA_COMPUTE_CAP: "89"
@@ -610,9 +628,9 @@ jobs:
     name: Metal forced-local typecheck
     needs: changes
     if: >-
+      github.event_name == 'push' &&
       needs.changes.outputs.trusted_release_pr != 'true' &&
-      (needs.changes.outputs.gpu == 'true' ||
-       (github.event_name == 'push' && needs.changes.outputs.workflow == 'true'))
+      (needs.changes.outputs.gpu == 'true' || needs.changes.outputs.workflow == 'true')
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v6
@@ -628,9 +646,8 @@ jobs:
 
   coverage:
     needs: changes
-    # PRs already run the deterministic behavioral suite in `rust`; only the
-    # external-service catalog monitor is main-only. Coverage is informational,
-    # so collect it after merge instead of recompiling on every revision.
+    # Retain the required status name on PRs, but collect coverage only after
+    # merge so no pull-request revision recompiles the workspace.
     if: >-
       always() && !cancelled() &&
       (needs.changes.result != 'success' ||

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -72,7 +72,7 @@ on:
       - "desktop/src/stores/**"
       - "desktop/src/styles/**"
       - "desktop/src/views/**"
-      - "desktop/src-tauri/**"
+      - "desktop/src-tauri/**/*.rs"
       - "desktop/.prettierignore"
       - "desktop/icon-master.png"
       - "desktop/index.html"
@@ -85,37 +85,6 @@ on:
       - "package.json"
       - "bun.lock"
       - "bun.nix"
-      - "crates/mold-core/**"
-      - "crates/mold-catalog/**"
-      - "crates/mold-db/**"
-      - "crates/mold-candle/**"
-      - "crates/mold-inference/**"
-      - "crates/mold-scheduler/**"
-      - "crates/mold-server/**"
-      - "flake.nix"
-      - "Cargo.toml"
-      - ".github/workflows/desktop.yml"
-      - ".github/workflows/desktop-distribution.yml"
-      - "scripts/check-desktop-nightly-main-head.sh"
-      - "scripts/create-desktop-bundle-version.sh"
-      - "scripts/create-desktop-nightly-version.sh"
-      - "scripts/create-desktop-update-manifest.sh"
-      - "scripts/fix-desktop-macos-linkage.sh"
-      - "scripts/notarize-desktop-dmg.sh"
-      - "scripts/prepare-desktop-linuxdeploy.sh"
-      - "scripts/verify-h3-release-exclusion.sh"
-      - "scripts/prune-desktop-nightly-assets.sh"
-      - "scripts/select-desktop-stable-latest.sh"
-      - "scripts/tests/check-desktop-nightly-main-head.sh"
-      - "scripts/tests/create-desktop-bundle-version.sh"
-      - "scripts/tests/create-desktop-nightly-version.sh"
-      - "scripts/tests/create-desktop-update-manifest.sh"
-      - "scripts/tests/desktop-nightly-race-guards.sh"
-      - "scripts/tests/prune-desktop-nightly-assets.sh"
-      - "scripts/tests/select-desktop-stable-latest.sh"
-      - "scripts/tests/verify-desktop-updater-signature.sh"
-      - "scripts/verify-desktop-release.sh"
-      - "scripts/verify-desktop-updater-signature.sh"
   workflow_dispatch:
 
 concurrency:
@@ -148,8 +117,7 @@ jobs:
     outputs:
       frontend: ${{ steps.filter.outputs.frontend }}
       rust: ${{ steps.filter.outputs.rust }}
-      updater: ${{ steps.filter.outputs.updater }}
-      bundle: ${{ steps.filter.outputs.bundle }}
+      rust_format: ${{ steps.filter.outputs.rust_format }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
@@ -177,27 +145,6 @@ jobs:
               - 'package.json'
               - 'bun.lock'
               - 'bun.nix'
-              - '.github/workflows/desktop.yml'
-              - '.github/workflows/desktop-distribution.yml'
-              - 'scripts/check-desktop-nightly-main-head.sh'
-              - 'scripts/create-desktop-bundle-version.sh'
-              - 'scripts/create-desktop-nightly-version.sh'
-              - 'scripts/create-desktop-update-manifest.sh'
-              - 'scripts/fix-desktop-macos-linkage.sh'
-              - 'scripts/notarize-desktop-dmg.sh'
-              - 'scripts/prepare-desktop-linuxdeploy.sh'
-              - 'scripts/prune-desktop-nightly-assets.sh'
-              - 'scripts/select-desktop-stable-latest.sh'
-              - 'scripts/tests/check-desktop-nightly-main-head.sh'
-              - 'scripts/tests/create-desktop-bundle-version.sh'
-              - 'scripts/tests/create-desktop-nightly-version.sh'
-              - 'scripts/tests/create-desktop-update-manifest.sh'
-              - 'scripts/tests/desktop-nightly-race-guards.sh'
-              - 'scripts/tests/prune-desktop-nightly-assets.sh'
-              - 'scripts/tests/select-desktop-stable-latest.sh'
-              - 'scripts/tests/verify-desktop-updater-signature.sh'
-              - 'scripts/verify-desktop-release.sh'
-              - 'scripts/verify-desktop-updater-signature.sh'
             rust:
               - 'desktop/src-tauri/**'
               - 'crates/mold-core/**'
@@ -213,42 +160,8 @@ jobs:
               - 'scripts/verify-h3-release-exclusion.sh'
               - '.github/workflows/desktop.yml'
               - '.github/workflows/desktop-distribution.yml'
-            updater:
-              - '.github/workflows/desktop.yml'
-              - '.github/workflows/desktop-distribution.yml'
-              - 'scripts/check-desktop-nightly-main-head.sh'
-              - 'scripts/create-desktop-bundle-version.sh'
-              - 'scripts/create-desktop-nightly-version.sh'
-              - 'scripts/create-desktop-update-manifest.sh'
-              - 'scripts/notarize-desktop-dmg.sh'
-              - 'scripts/prune-desktop-nightly-assets.sh'
-              - 'scripts/select-desktop-stable-latest.sh'
-              - 'scripts/tests/check-desktop-nightly-main-head.sh'
-              - 'scripts/tests/create-desktop-bundle-version.sh'
-              - 'scripts/tests/create-desktop-nightly-version.sh'
-              - 'scripts/tests/create-desktop-update-manifest.sh'
-              - 'scripts/tests/desktop-nightly-race-guards.sh'
-              - 'scripts/tests/prune-desktop-nightly-assets.sh'
-              - 'scripts/tests/select-desktop-stable-latest.sh'
-              - 'scripts/tests/verify-desktop-updater-signature.sh'
-              - 'scripts/verify-desktop-release.sh'
-              - 'scripts/verify-desktop-updater-signature.sh'
-            # The debug bundle has caught macOS packaging/linkage regressions,
-            # but ordinary Rust/frontend changes are already covered by their
-            # focused gates. Run it only when bundle inputs actually change.
-            bundle:
-              - 'desktop/src-tauri/Cargo.toml'
-              - 'desktop/src-tauri/Cargo.lock'
-              - 'desktop/src-tauri/build.rs'
-              - 'desktop/src-tauri/tauri.conf.json'
-              - 'desktop/src-tauri/tauri.macos.conf.json'
-              - 'desktop/src-tauri/Entitlements.plist'
-              - 'desktop/src-tauri/Info.plist'
-              - 'desktop/src-tauri/capabilities/**'
-              - 'desktop/src-tauri/icons/**'
-              - 'desktop/package.json'
-              - 'desktop/vite.config.ts'
-              - 'scripts/fix-desktop-macos-linkage.sh'
+            rust_format:
+              - 'desktop/src-tauri/**/*.rs'
 
   desktop-frontend:
     name: Frontend (typecheck, tests, format)
@@ -262,10 +175,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
       - name: Install updater verification tooling
-        if: github.event_name != 'pull_request' || needs.changes.outputs.updater == 'true'
+        if: github.event_name == 'push'
         run: sudo apt-get update && sudo apt-get install -y minisign
       - name: Test updater release scripts
-        if: github.event_name != 'pull_request' || needs.changes.outputs.updater == 'true'
+        if: github.event_name == 'push'
         run: |
           bash ../scripts/tests/check-desktop-nightly-main-head.sh
           bash ../scripts/tests/create-desktop-bundle-version.sh
@@ -279,47 +192,47 @@ jobs:
         working-directory: .
       - run: bun run fmt:check
       - run: bun run test
+        if: github.event_name == 'push'
       # `build` already runs vue-tsc before Vite; a separate typecheck compiled
       # the same project twice on every frontend PR.
       - run: bun run build
+        if: github.event_name == 'push'
 
   desktop-rust:
-    name: macOS Rust (fmt, clippy, test)
+    name: Native Rust (fmt; main clippy and test)
     needs: changes
     if: >-
-      github.event_name != 'pull_request' ||
-      needs.changes.outputs.rust == 'true' ||
-      needs.changes.outputs.bundle == 'true'
-    runs-on: macos-14
+      github.event_name != 'pull_request' || needs.changes.outputs.rust_format == 'true'
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'macos-14' }}
     defaults:
       run:
         working-directory: desktop
     steps:
       - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        if: github.event_name == 'pull_request'
+        with:
+          components: rustfmt
+      - uses: dtolnay/rust-toolchain@stable
+        if: github.event_name == 'push'
+        with:
+          components: rustfmt,clippy
       - uses: Swatinem/rust-cache@v2
+        if: github.event_name == 'push'
         with:
           workspaces: desktop/src-tauri
       - run: cargo fmt --manifest-path src-tauri/Cargo.toml -- --check
-        if: github.event_name != 'pull_request' || needs.changes.outputs.rust == 'true'
       - run: cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings
-        if: github.event_name != 'pull_request' || needs.changes.outputs.rust == 'true'
+        if: github.event_name == 'push'
       # CPU-only: the metal feature is deliberately off in CI.
       - run: cargo test --manifest-path src-tauri/Cargo.toml
-        if: github.event_name != 'pull_request' || needs.changes.outputs.rust == 'true'
-      - uses: oven-sh/setup-bun@v2
-        if: github.event_name == 'pull_request' && needs.changes.outputs.bundle == 'true'
-      - run: bun install --frozen-lockfile
-        if: github.event_name == 'pull_request' && needs.changes.outputs.bundle == 'true'
-        working-directory: .
-      - name: Bundle macOS packaging inputs (debug .app)
-        if: github.event_name == 'pull_request' && needs.changes.outputs.bundle == 'true'
-        run: bunx tauri build --debug --bundles app --ci
+        if: github.event_name == 'push'
 
   desktop-linux:
     name: Linux (clippy, test; main AppImage)
     needs: changes
-    # macOS remains the single native PR gate. Every relevant main push repeats
-    # Linux clippy/tests and adds the stronger CUDA AppImage build + launch.
+    # Native PR feedback is rustfmt-only on Linux. Every relevant main push
+    # runs Linux clippy/tests and the stronger CUDA AppImage build + launch.
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-22.04
     defaults:
@@ -481,8 +394,7 @@ jobs:
   # Every desktop-relevant main commit that passes the frontend and macOS Rust
   # gates becomes a signed, notarized nightly. Linux remains an independent
   # required check so its slower AppImage build cannot delay macOS updates.
-  # The updater-artifact overlay stays isolated from the fast debug PR bundle
-  # proof above.
+  # Distribution packaging remains isolated from pull-request formatting.
   desktop-nightly:
     name: Build nightly distribution
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -36,33 +36,14 @@ on:
   pull_request:
     paths:
       [
-        "apps/mobile/**",
-        "studio/**",
-        "ui/**",
+        "apps/mobile/src-tauri/**/*.rs",
         "package.json",
         "bun.lock",
         "bun.nix",
         "desktop/src/mobile/**",
-        "desktop/src/components/**",
-        "desktop/src/lib/**",
-        "desktop/src/stores/**",
-        "desktop/src/styles/**",
-        "desktop/src/assets/**",
         "desktop/package.json",
-        "desktop/icon-master.png",
         "desktop/vite.mobile.config.ts",
         "desktop/index.mobile.html",
-        "scripts/ios.sh",
-        "scripts/generate-ios-icons.sh",
-        "scripts/tests/ios-release-assets.sh",
-        "scripts/tests/ios-testflight-distribution.sh",
-        "scripts/ios-sim.sh",
-        "scripts/tests/ios-sim-pick.sh",
-        "scripts/ensure-testflight-tester.rb",
-        "scripts/wait-for-testflight.rb",
-        "flake.nix",
-        ".github/workflows/ios.yml",
-        ".github/workflows/testflight-ios.yml",
       ]
   workflow_dispatch:
 
@@ -93,6 +74,7 @@ jobs:
     outputs:
       frontend: ${{ steps.filter.outputs.frontend }}
       rust: ${{ steps.filter.outputs.rust }}
+      rust_format: ${{ steps.filter.outputs.rust_format }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
@@ -100,39 +82,20 @@ jobs:
         with:
           filters: |
             frontend:
-              - 'apps/mobile/src-tauri/app-icon.png'
-              - 'apps/mobile/src-tauri/app-icon-source.sha256'
-              - 'apps/mobile/src-tauri/gen/apple/Assets.xcassets/**'
-              - 'studio/**'
-              - 'ui/**'
               - 'package.json'
               - 'bun.lock'
               - 'bun.nix'
               - 'desktop/src/mobile/**'
-              - 'desktop/src/components/**'
-              - 'desktop/src/lib/**'
-              - 'desktop/src/stores/**'
-              - 'desktop/src/styles/**'
-              - 'desktop/src/assets/**'
               - 'desktop/package.json'
-              - 'desktop/icon-master.png'
               - 'desktop/vite.mobile.config.ts'
               - 'desktop/index.mobile.html'
-              - 'scripts/ios.sh'
-              - 'scripts/generate-ios-icons.sh'
-              - 'scripts/tests/ios-release-assets.sh'
-              - 'scripts/tests/ios-testflight-distribution.sh'
-              - 'scripts/ios-sim.sh'
-              - 'scripts/tests/ios-sim-pick.sh'
-              - 'scripts/ensure-testflight-tester.rb'
-              - 'scripts/wait-for-testflight.rb'
-              - '.github/workflows/ios.yml'
-              - '.github/workflows/testflight-ios.yml'
             rust:
               - 'apps/mobile/src-tauri/**'
               - 'flake.nix'
               - '.github/workflows/ios.yml'
               - '.github/workflows/testflight-ios.yml'
+            rust_format:
+              - 'apps/mobile/src-tauri/**/*.rs'
 
   frontend:
     name: Mobile frontend
@@ -148,33 +111,43 @@ jobs:
       - run: bun install --frozen-lockfile
         working-directory: .
       - run: ../scripts/tests/ios-release-assets.sh
+        if: github.event_name == 'push'
       - run: ../scripts/tests/ios-testflight-distribution.sh
+        if: github.event_name == 'push'
       - run: ../scripts/tests/ios-sim-pick.sh
+        if: github.event_name == 'push'
       # The full desktop + Studio suite runs in Desktop CI. Keep iOS focused on
       # its 29 mobile tests and mobile-only formatting; the release-assets
       # contract above already performs the authoritative mobile typecheck/build.
       - run: bunx vitest run src/mobile
+        if: github.event_name == 'push'
       - run: bunx prettier --check "src/mobile/**/*.{ts,vue,css}" vite.mobile.config.ts index.mobile.html
 
   simulator-rust:
     name: iOS simulator Rust
     needs: changes
-    # This is the only compiler for the standalone mobile crate and has caught
-    # native-only PR failures. Keep Clippy, but drop the redundant cargo check
-    # because Clippy compiles the same target before linting it.
-    if: github.event_name != 'pull_request' || needs.changes.outputs.rust == 'true'
-    runs-on: macos-14
+    # PRs only need rustfmt and stay on Linux. Main retains the simulator Clippy
+    # compiler gate on macOS for the standalone mobile crate.
+    if: github.event_name != 'pull_request' || needs.changes.outputs.rust_format == 'true'
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'macos-14' }}
     defaults:
       run:
         working-directory: apps/mobile/src-tauri
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
+        if: github.event_name == 'pull_request'
+        with:
+          components: rustfmt
+      - uses: dtolnay/rust-toolchain@stable
+        if: github.event_name == 'push'
         with:
           targets: aarch64-apple-ios-sim
           components: rustfmt,clippy
       - uses: Swatinem/rust-cache@v2
+        if: github.event_name == 'push'
         with:
           workspaces: apps/mobile/src-tauri
       - run: cargo fmt -- --check
       - run: cargo clippy --target aarch64-apple-ios-sim -- -D warnings
+        if: github.event_name == 'push'

--- a/scripts/tests/ci-routing-contract.sh
+++ b/scripts/tests/ci-routing-contract.sh
@@ -112,13 +112,21 @@ if rust is None:
 rust_text = rust.group(1)
 
 run_suite = (
-    "needs.changes.outputs.trusted_release_pr != 'true' && "
+    "github.event_name == 'push' && "
     "(needs.changes.outputs.rust == 'true' || "
-    "(github.event_name == 'push' && needs.changes.outputs.workflow == 'true'))"
+    "needs.changes.outputs.workflow == 'true')"
 )
 match = re.search(r"RUN_RUST_SUITE:\s*\$\{\{\s*(.*?)\s*\}\}", rust_text, re.S)
 if match is None or normalize(match.group(1)) != run_suite:
     raise SystemExit("FAIL: protected Rust suite selector does not match the complete policy")
+
+run_format = (
+    "needs.changes.outputs.trusted_release_pr != 'true' && "
+    "needs.changes.outputs.rust_format == 'true'"
+)
+match = re.search(r"RUN_RUST_FORMAT:\s*\$\{\{\s*(.*?)\s*\}\}", rust_text, re.S)
+if match is None or normalize(match.group(1)) != run_format:
+    raise SystemExit("FAIL: protected Rust formatter selector does not match the complete policy")
 
 
 def step_condition(name: str) -> str:
@@ -140,16 +148,28 @@ expected_step_conditions = {
     "Validate trusted release-plz file scope": (
         "needs.changes.outputs.trusted_release_pr == 'true'"
     ),
-    "Validate all locked Cargo graphs": "needs.changes.outputs.release == 'true'",
-    "Run protected release contracts": "needs.changes.outputs.release == 'true'",
+    "Validate workflow syntax": (
+        "github.event_name == 'pull_request' && "
+        "needs.changes.outputs.workflow == 'true'"
+    ),
+    "Validate CI routing policy": (
+        "github.event_name == 'pull_request' && "
+        "needs.changes.outputs.workflow == 'true'"
+    ),
+    "Run protected release contracts": (
+        "github.event_name == 'push' && needs.changes.outputs.release == 'true'"
+    ),
     "Test MiniMax H3 private-UAT release contract": (
-        "needs.changes.outputs.release == 'true'"
+        "github.event_name == 'push' && needs.changes.outputs.release == 'true'"
     ),
     "Clippy the private MiniMax H3 artifact qualifier": (
         "env.RUN_RUST_SUITE == 'true'"
     ),
     "Test private MiniMax H3 foundations": "env.RUN_RUST_SUITE == 'true'",
 }
+expected_step_conditions["Validate all locked Cargo graphs"] = (
+    "github.event_name == 'push' && needs.changes.outputs.release == 'true'"
+)
 for name, expected in expected_step_conditions.items():
     actual = step_condition(name)
     if actual != expected:
@@ -169,10 +189,19 @@ for step in (candidate for candidate in heavy_steps if candidate.strip()):
     if condition is None:
         raise SystemExit(f"FAIL: heavy Rust step is not suite-gated: {label}")
     actual = normalize(condition.group(1))
-    if not (
-        actual == "env.RUN_RUST_SUITE == 'true'"
-        or actual.startswith("env.RUN_RUST_SUITE == 'true' && ")
-    ):
+    if label == "- uses: dtolnay/rust-toolchain@stable":
+        allowed = actual in {
+            "github.event_name == 'pull_request' && env.RUN_RUST_FORMAT == 'true'",
+            "env.RUN_RUST_SUITE == 'true'",
+        }
+    elif label == "- name: Format":
+        allowed = actual == "env.RUN_RUST_FORMAT == 'true'"
+    else:
+        allowed = (
+            actual == "env.RUN_RUST_SUITE == 'true'"
+            or actual.startswith("env.RUN_RUST_SUITE == 'true' && ")
+        )
+    if not allowed:
         raise SystemExit(f"FAIL: heavy Rust step bypasses suite routing: {label}: {actual}")
 PY
 
@@ -228,11 +257,13 @@ require_text "$ci" \
   "Metal-gated production code is not linted"
 require_text "$ci" \
   "nix run nixpkgs#actionlint -- .github/workflows/*.yml" \
-  "workflow-only PRs have no protected actionlint proof"
+  "main release validation has no protected actionlint proof"
 [[ "$(grep -Fc "needs.changes.outputs.gpu == 'true' ||" "$ci")" -eq 2 ]] \
-  || fail "CUDA and Metal are not retained for relevant PRs with workflow-only main proof"
+  || fail "CUDA and Metal are not retained for relevant main/workflow changes"
 for backend_job in cuda-check metal-check; do
   backend_block="$(extract_job "$ci" "$backend_job")"
+  grep -Fq "github.event_name == 'push'" <<< "$backend_block" \
+    || fail "$backend_job still runs on pull requests"
   grep -Fq "needs.changes.outputs.trusted_release_pr != 'true'" <<< "$backend_block" \
     || fail "$backend_job still runs on generated release PRs"
 done
@@ -256,6 +287,25 @@ for required_job in rust coverage docs web; do
     || fail "required $required_job classifier sentinel does not fail"
 done
 
+for spec in \
+  "docs|Verify docs references" \
+  "docs|Build docs" \
+  "web|Check frontend architecture and dead code" \
+  "web|Run shared Studio tests" \
+  "web|Run web tests" \
+  "web|Build web SPA (includes vue-tsc typecheck)"; do
+  job=${spec%%|*}
+  step=${spec#*|}
+  block="$(extract_job "$ci" "$job")"
+  grep -A1 -F -- "- name: $step" <<< "$block" \
+    | grep -Fq "if: github.event_name == 'push'" \
+    || fail "$job substantive step still runs on pull requests: $step"
+done
+
+coverage_gate="$(extract_job "$ci" coverage)"
+grep -Fq "github.event_name == 'push'" <<< "$coverage_gate" \
+  || fail "coverage still compiles the workspace on pull requests"
+
 rust_gate="$(extract_job "$ci" rust)"
 grep -Fq 'RUN_RUST_SUITE:' <<< "$rust_gate" \
   || fail "protected Rust status does not select its full suite"
@@ -264,19 +314,19 @@ grep -Fq 'Require trusted release routing' <<< "$rust_gate" \
 grep -Fq 'Run protected release contracts' <<< "$rust_gate" \
   || fail "protected Rust status does not own release-contract failures"
 
-grep -Fq 'Check declared MSRV' <<< "$rust_gate" \
-  || fail "PR Rust suite no longer checks the declared MSRV"
+grep -Fq 'RUN_RUST_FORMAT:' <<< "$rust_gate" \
+  || fail "protected Rust status does not select PR formatting"
+grep -Fq "if: env.RUN_RUST_FORMAT == 'true'" <<< "$rust_gate" \
+  || fail "PR Rust formatting is not isolated from the main suite"
 grep -Fq 'Clippy the private MiniMax H3 artifact qualifier' <<< "$rust_gate" \
-  || fail "PR Rust suite no longer checks the private qualifier"
+  || fail "main Rust suite no longer checks the private qualifier"
 grep -Fq 'Check with all optional features' <<< "$rust_gate" \
-  || fail "PR Rust suite no longer checks the optional feature combination"
-grep -Fq -- '--skip catalog_api::catalog_live_test::live_search_free_text_can_find_manual_clip_components' <<< "$rust_gate" \
-  || fail "PR Rust suite still runs the flaky external catalog monitor"
+  || fail "main Rust suite no longer checks the optional feature combination"
+if grep -Fq 'name: Test (PR suite)' <<< "$rust_gate"; then
+  fail "protected Rust status still runs tests on pull requests"
+fi
 grep -Fq 'name: Test (full main suite)' <<< "$rust_gate" \
   || fail "main Rust suite does not retain the complete workspace tests"
-if grep -Fq -- '--skip batch_transaction::tests::' <<< "$rust_gate"; then
-  fail "PR Rust suite skips the high-signal gallery scale regression"
-fi
 if grep -Fq 'run: cargo check --workspace' "$ci"; then
   fail "root Rust CI still runs cargo check immediately before all-target Clippy"
 fi
@@ -291,8 +341,16 @@ for classifier in rust gpu website web nix; do
   fi
 done
 workflow_filter="$(extract_filter "$ci" workflow)"
-grep -Fxq "              - '.github/workflows/ci.yml'" <<< "$workflow_filter" \
-  || fail "workflow-only changes have no dedicated post-merge classifier"
+for path in .github/actionlint.yaml .github/workflows/\*\* scripts/tests/ci-routing-contract.sh; do
+  grep -Fxq "              - '$path'" <<< "$workflow_filter" \
+    || fail "workflow policy classifier omits $path"
+done
+require_text "$ci" 'name: Validate workflow syntax' \
+  "workflow-only PRs have no lightweight static validation"
+require_text "$ci" 'uses: docker://rhysd/actionlint:1.7.12' \
+  "workflow-only PRs do not use the pinned lightweight actionlint image"
+require_text "$ci" 'name: Validate CI routing policy' \
+  "workflow-only PRs do not run the routing contract"
 
 release_filter="$(extract_filter "$ci" release)"
 for manifest in Cargo.toml Cargo.lock desktop/src-tauri/Cargo.toml desktop/src-tauri/Cargo.lock; do
@@ -310,9 +368,9 @@ if grep -Fq 'desktop/**' <<< "$nix_filter"; then
   fail "desktop-only changes still start the mold-web Nix build"
 fi
 nix_job="$(extract_job "$ci" nix-web)"
-grep -Fq "needs.changes.outputs.nix == 'true' ||" <<< "$nix_job" \
-  || fail "the sandboxed Nix web build no longer protects relevant PRs"
-grep -Fq "github.event_name == 'push' && needs.changes.outputs.workflow == 'true'" <<< "$nix_job" \
+grep -Fq "github.event_name == 'push' &&" <<< "$nix_job" \
+  || fail "the sandboxed Nix web build still runs on pull requests"
+grep -Fq "needs.changes.outputs.workflow == 'true'" <<< "$nix_job" \
   || fail "workflow-only changes do not exercise the Nix build after merge"
 
 desktop_classifier="$(extract_job "$desktop" changes)"
@@ -322,39 +380,40 @@ require_text "$desktop" \
   "if: github.event_name != 'pull_request' || needs.changes.outputs.frontend == 'true'" \
   "desktop frontend job is not path-gated on PRs"
 desktop_rust="$(extract_job "$desktop" desktop-rust)"
-grep -Fq "needs.changes.outputs.rust == 'true' ||" <<< "$desktop_rust" \
-  || fail "the macOS native job is not path-gated on PRs"
-grep -Fq "needs.changes.outputs.bundle == 'true'" <<< "$desktop_rust" \
-  || fail "macOS bundle-sensitive changes do not reach the native job"
-grep -Fq 'name: Bundle macOS packaging inputs (debug .app)' <<< "$desktop_rust" \
-  || fail "macOS packaging inputs have no focused bundle proof"
-grep -Fq "github.event_name == 'pull_request' && needs.changes.outputs.bundle == 'true'" <<< "$desktop_rust" \
-  || fail "macOS debug bundle is not restricted to bundle-sensitive PRs"
-bundle_filter="$(extract_filter "$desktop" bundle)"
-for path in desktop/src-tauri/tauri.macos.conf.json scripts/fix-desktop-macos-linkage.sh; do
-  grep -Fq "$path" <<< "$bundle_filter" \
-    || fail "desktop bundle classifier omits $path"
-done
+grep -Fq "needs.changes.outputs.rust_format == 'true'" <<< "$desktop_rust" \
+  || fail "desktop Rust formatting is not path-gated on PRs"
+grep -Fq "runs-on: \${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'macos-14' }}" <<< "$desktop_rust" \
+  || fail "desktop Rust PR formatting still consumes a macOS runner"
+grep -Fq 'cargo fmt --manifest-path src-tauri/Cargo.toml -- --check' <<< "$desktop_rust" \
+  || fail "desktop native PRs have no Rust formatting check"
+[[ "$(grep -Fc "if: github.event_name == 'push'" <<< "$desktop_rust")" -ge 3 ]] \
+  || fail "desktop native compilation and tests are not main-only"
+if grep -Fq 'Bundle macOS packaging inputs (debug .app)' <<< "$desktop_rust"; then
+  fail "desktop PRs still build a macOS app bundle"
+fi
 desktop_linux="$(extract_job "$desktop" desktop-linux)"
 grep -Fq "if: github.event_name != 'pull_request'" <<< "$desktop_linux" \
   || fail "Desktop Linux still runs on pull requests"
 if grep -Fq 'bunx vue-tsc -b' "$desktop"; then
   fail "desktop frontend still typechecks once explicitly and again during build"
 fi
-[[ "$(grep -Fc "if: github.event_name != 'pull_request' || needs.changes.outputs.updater == 'true'" "$desktop")" -eq 2 ]] \
-  || fail "updater tooling and contract tests are not restricted to updater changes on PRs"
+desktop_frontend="$(extract_job "$desktop" desktop-frontend)"
+grep -Fq 'run: bun run fmt:check' <<< "$desktop_frontend" \
+  || fail "desktop frontend PRs have no formatting check"
+[[ "$(grep -Fc "if: github.event_name == 'push'" <<< "$desktop_frontend")" -eq 4 ]] \
+  || fail "desktop frontend builds, tests, and updater contracts are not main-only"
 if grep -Fq 'desktop/**' <<< "$desktop_classifier"; then
   fail "desktop frontend classifier is broad enough to include native/mobile files"
 fi
 [[ "$(grep -Fc 'desktop/src/components/**' "$desktop")" -eq 3 ]] \
   || fail "desktop frontend trigger/classifier does not track desktop components"
-[[ "$(grep -Fc 'desktop/src-tauri/**' "$desktop")" -eq 3 ]] \
+[[ "$(grep -Fc 'desktop/src-tauri/**' "$desktop")" -eq 4 ]] \
   || fail "desktop native trigger/classifier does not track the Tauri crate"
 if grep -Fq 'desktop/src/mobile/**' "$desktop"; then
   fail "mobile-only changes are not owned exclusively by the iOS workflow"
 fi
-[[ "$(grep -Fc 'crates/mold-scheduler/**' "$desktop")" -eq 3 ]] \
-  || fail "desktop trigger/classifier does not track its scheduler dependency"
+[[ "$(grep -Fc 'crates/mold-scheduler/**' "$desktop")" -eq 2 ]] \
+  || fail "desktop main trigger/classifier does not track its scheduler dependency"
 
 require_text "$ios" \
   "cancel-in-progress: \${{ github.event_name == 'pull_request' }}" \
@@ -363,17 +422,26 @@ require_text "$ios" 'name: Classify iOS changes' \
   "iOS workflow has no path classifier"
 ios_frontend_filter="$(extract_filter "$ios" frontend)"
 if grep -Fq "'apps/mobile/**'" <<< "$ios_frontend_filter"; then
-  fail "native-only iOS changes still run the mobile frontend suite"
+  fail "native-only iOS changes still run mobile formatting"
 fi
-grep -Fq "apps/mobile/src-tauri/gen/apple/Assets.xcassets/**" <<< "$ios_frontend_filter" \
-  || fail "iOS frontend classifier omits release icon assets"
+grep -Fq "desktop/src/mobile/**" <<< "$ios_frontend_filter" \
+  || fail "iOS frontend classifier omits mobile source formatting"
 require_text "$ios" \
-  "if: github.event_name != 'pull_request' || needs.changes.outputs.rust == 'true'" \
-  "iOS simulator Clippy is not retained for native PR changes"
+  "runs-on: \${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'macos-14' }}" \
+  "iOS Rust PR formatting still consumes a macOS runner"
 require_text "$ios" 'run: ../scripts/tests/ios-release-assets.sh' \
   "iOS frontend job does not validate the built mobile entry"
 require_text "$ios" 'run: bunx vitest run src/mobile' \
   "iOS frontend job does not retain its mobile-specific tests"
+ios_frontend="$(extract_job "$ios" frontend)"
+[[ "$(grep -Fc "if: github.event_name == 'push'" <<< "$ios_frontend")" -eq 4 ]] \
+  || fail "iOS frontend builds and tests are not main-only"
+ios_rust="$(extract_job "$ios" simulator-rust)"
+grep -Fq 'run: cargo fmt -- --check' <<< "$ios_rust" \
+  || fail "iOS native PRs have no Rust formatting check"
+grep -A1 -F 'run: cargo clippy --target aarch64-apple-ios-sim -- -D warnings' <<< "$ios_rust" \
+  | grep -Fq "if: github.event_name == 'push'" \
+  || fail "iOS simulator compilation still runs on pull requests"
 if grep -Fq 'run: cargo check --target aarch64-apple-ios-sim' "$ios"; then
   fail "iOS simulator still runs cargo check immediately before Clippy"
 fi


### PR DESCRIPTION
## Summary

- reduce required PR checks to Rust, docs, and frontend formatting plus static workflow validation
- move Rust tests/compilation, GPU/Nix checks, coverage, docs/web builds and tests, and release contracts to main pushes
- keep desktop and iOS PR work format-only on Linux while preserving their full main and nightly behavior
- strengthen the routing contract so the fast-PR/full-main split cannot regress

## Validation

- `bash scripts/tests/ci-routing-contract.sh`
- `nix run nixpkgs#actionlint -- .github/workflows/*.yml`
- `nix shell nixpkgs#shellcheck --command shellcheck scripts/tests/ci-routing-contract.sh`
- `git diff --check`
