### PR TITLE
fix(h3): bound visual seed evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **Private H3 visual-VAE seed evidence is bounded across scalar math backends.** The independently generated PyTorch and Mold seed-42 MT19937 streams now retain both hashes and every scalar while enforcing the reviewed `2e-6 + 1e-6 * abs(oracle)` FP32 bound, instead of incorrectly requiring byte identity from different normal-transform implementations. The real 67,200-element CUDA pair measured a maximum absolute difference of `4.7683716e-7` with no violations.
+
 - **Private H3 visual-VAE qualification uses the official shortest round-trip temporal case.** Real CUDA capture showed that the former five-frame case encodes to two latent frames but cannot enter the pinned official decoder's temporal loop. The paired oracle and Mold case now uses 22 frames, the documented shortest `17n+5` input that produces seven latent frames and round-trips exactly; its full tensor shapes, seam probes, request identity, and external raw-evidence bound are enforced before evidence publication.
 
 - **Private H3 capture source snapshots keep every staging directory owner-only.** Qwen, visual-VAE, and AudioVAE capture now create their shared `sources/` parent explicitly as `0700` before extracting authenticated package snapshots. This fixes a real-UAT failure where the intermediate parent inherited `0755` even though the temporary root and package leaves were private; the existing fail-closed staging audit correctly rejected the capture before model execution.

--- a/docs/qualification/minimax-h3-conformance.md
+++ b/docs/qualification/minimax-h3-conformance.md
@@ -329,9 +329,11 @@ official three-shard FP32 checkpoint. The Mold role compiles the isolated
 in manifest order, FP32 ImageNet-normalized pixels, FP32 posterior moments, the
 fresh CPU seed-42 FP32 noise, the FP32 posterior sample, the actual FP16
 round-trip tensor, FP32 normalized latents, FP32 decoded unit-RGB frames, and
-the complete bounded FP32 seam-probe vector. Only the seed-42 noise stream is
-hash-exact across implementations; numerical model records use the checked
-1/64 elementwise tolerance and retain their hashes as record evidence.
+the complete bounded FP32 seam-probe vector. The independently generated
+seed-42 noise streams use the same PyTorch MT19937 recipe but permit the
+reviewed 2e-6 absolute plus 1e-6 relative FP32 scalar-math bound; their hashes
+remain record evidence. Numerical model records use the checked 1/64
+elementwise tolerance and likewise retain their hashes as record evidence.
 
 Use the same five external environment paths as the conditioner captures and
 run each role separately:

--- a/scripts/capture-minimax-h3-visual-vae.py
+++ b/scripts/capture-minimax-h3-visual-vae.py
@@ -115,6 +115,8 @@ MEASUREMENT_DTYPES = {
     "decoded-frames": "float32",
     "tile-seams": "float32",
 }
+SEED_NOISE_ABSOLUTE_TOLERANCE = 0.000002
+SEED_NOISE_RELATIVE_TOLERANCE = 0.000001
 TENSOR_HASH_ENCODING = "canonical-typed-le-v1"
 MOLD_BINARY = "h3_visual_vae_capture"
 MOLD_FEATURES = "dev-bins,h3-private-uat,cuda"
@@ -800,7 +802,7 @@ def capture_mold(
 
 def sample_indexes(payload: TensorPayload) -> list[int]:
     length = math.prod(payload.shape)
-    if payload.key == "tile-seams":
+    if payload.key in {"posterior-seed-42", "tile-seams"}:
         return list(range(length))
     count = min(257, length)
     if count == 1:
@@ -974,14 +976,22 @@ def build_layer_document(
     if role == "oracle":
         document["comparison"] = []
         for key in MEASUREMENTS:
-            exact = key == "posterior-seed-42"
+            seed_noise = key == "posterior-seed-42"
             document["comparison"].append(
                 {
                     "key": key,
-                    "absolute": 0.0 if exact else 0.015625,
-                    "relative": 0.0 if exact else 0.015625,
+                    "absolute": (
+                        SEED_NOISE_ABSOLUTE_TOLERANCE
+                        if seed_noise
+                        else 0.015625
+                    ),
+                    "relative": (
+                        SEED_NOISE_RELATIVE_TOLERANCE
+                        if seed_noise
+                        else 0.015625
+                    ),
                     "metric": "elementwise-atol-plus-rtol",
-                    "hash_policy": "exact" if exact else "record-only",
+                    "hash_policy": "record-only",
                 }
             )
     return document

--- a/scripts/run-minimax-h3-gpu-conformance.py
+++ b/scripts/run-minimax-h3-gpu-conformance.py
@@ -170,6 +170,7 @@ RECORD_ONLY_FLOAT_MEASUREMENTS = {
         {
             "pixel-normalization",
             "posterior-moments",
+            "posterior-seed-42",
             "posterior-sample",
             "posterior-fp16-roundtrip",
             "latent-normalization",

--- a/scripts/tests/minimax-h3-gpu-conformance-contract.py
+++ b/scripts/tests/minimax-h3-gpu-conformance-contract.py
@@ -302,11 +302,7 @@ def comparison_fixture(key: str, kind: str) -> dict[str, object]:
         "absolute": 0 if integer else 0.000002,
         "relative": 0 if integer else 0.000001,
         "metric": "elementwise-atol-plus-rtol",
-        "hash_policy": (
-            "record-only"
-            if kind in {"float16", "float32"} and key != "posterior-seed-42"
-            else "exact"
-        ),
+        "hash_policy": "record-only" if kind in {"float16", "float32"} else "exact",
     }
 
 
@@ -1583,19 +1579,23 @@ def test_manifest_layer_contract(runner, tool, authorization_sha: str) -> None:
                 oracle, fixture, mismatched_hash, fixture, manifest_layer
             )
             exact_key = next(
-                policy["key"]
-                for policy in oracle["comparison"]
-                if policy["hash_policy"] == "exact"
-            )
-            record_by_key(mismatched_hash["outputs"], exact_key)["content_sha256"] = (
-                "e" * 64
-            )
-            expect_failure(
-                lambda: runner.validate_oracle_mold_policy_parity(
-                    oracle, fixture, mismatched_hash, fixture, manifest_layer
+                (
+                    policy["key"]
+                    for policy in oracle["comparison"]
+                    if policy["hash_policy"] == "exact"
                 ),
-                "content hashes differ",
+                None,
             )
+            if exact_key is not None:
+                record_by_key(mismatched_hash["outputs"], exact_key)[
+                    "content_sha256"
+                ] = "e" * 64
+                expect_failure(
+                    lambda: runner.validate_oracle_mold_policy_parity(
+                        oracle, fixture, mismatched_hash, fixture, manifest_layer
+                    ),
+                    "content hashes differ",
+                )
 
         if layer in E2E_LAYER_TASKS:
             mismatched_input = copy.deepcopy(mold)

--- a/scripts/tests/minimax-h3-visual-vae-capture-contract.py
+++ b/scripts/tests/minimax-h3-visual-vae-capture-contract.py
@@ -37,6 +37,10 @@ def load_module(name: str, path: pathlib.Path):
 
 
 producer = load_module("minimax_h3_visual_vae_capture_contract", PRODUCER_PATH)
+conformance = load_module(
+    "minimax_h3_visual_vae_conformance_contract",
+    REPO_ROOT / "scripts" / "minimax-h3-conformance.py",
+)
 
 
 def manifest() -> dict:
@@ -169,10 +173,80 @@ class VisualCaptureContract(unittest.TestCase):
             [producer.MEASUREMENT_DTYPES[key] for key in producer.MEASUREMENTS],
         )
         policies = {item["key"]: item for item in document["comparison"]}
-        self.assertEqual(policies["posterior-seed-42"]["hash_policy"], "exact")
+        seed_policy = policies["posterior-seed-42"]
+        self.assertEqual(seed_policy["hash_policy"], "record-only")
+        self.assertEqual(
+            seed_policy["absolute"], producer.SEED_NOISE_ABSOLUTE_TOLERANCE
+        )
+        self.assertEqual(
+            seed_policy["relative"], producer.SEED_NOISE_RELATIVE_TOLERANCE
+        )
         for key in set(producer.MEASUREMENTS) - {"posterior-seed-42"}:
             self.assertEqual(policies[key]["hash_policy"], "record-only")
             self.assertLessEqual(policies[key]["absolute"], 1 / 64)
+
+    def test_seed_policy_checks_every_value_including_formerly_unsampled_indexes(
+        self,
+    ) -> None:
+        length = 300
+        former_samples = {
+            index * (length - 1) // 256 for index in range(257)
+        }
+        formerly_unsampled = next(index for index in range(length) if index not in former_samples)
+
+        oracle_payloads = []
+        mold_payloads = []
+        for key, dtype in producer.MEASUREMENT_DTYPES.items():
+            oracle_values = [0.0] * length
+            mold_values = list(oracle_values)
+            if key == "posterior-seed-42":
+                mold_values[formerly_unsampled] = 0.001
+            oracle_payloads.append(payload(key, dtype, oracle_values))
+            mold_payloads.append(payload(key, dtype, mold_values))
+
+        common = (
+            manifest(),
+            "a" * 64,
+            "cuda:0",
+            "d" * 64,
+            producer.build_case(),
+        )
+        oracle = producer.build_layer_document(
+            common[0],
+            "oracle",
+            producer.DIFFUSERS_REVISION,
+            *common[1:],
+            tuple(oracle_payloads),
+            {
+                "python": "test",
+                "torch": "test",
+                "numpy": "test",
+                "cuda": "test",
+                "transformers_revision": producer.TRANSFORMERS_REVISION,
+            },
+        )
+        mold = producer.build_layer_document(
+            common[0],
+            "mold",
+            "b" * 40,
+            *common[1:],
+            tuple(mold_payloads),
+            {"unavailable": "contract-test"},
+        )
+
+        seed_record = next(
+            item for item in oracle["outputs"] if item["key"] == "posterior-seed-42"
+        )
+        self.assertEqual(len(seed_record["samples"]), length)
+        self.assertEqual(
+            [sample["index"] for sample in seed_record["samples"]],
+            [[index] for index in range(length)],
+        )
+        with self.assertRaisesRegex(
+            conformance.ConformanceFailure,
+            "posterior-seed-42.*tolerance exceeded",
+        ):
+            conformance.compare_layer_outputs(oracle, mold)
 
     def test_mold_document_cannot_claim_oracle_comparison_policy(self) -> None:
         document = producer.build_layer_document(


### PR DESCRIPTION
## Summary
- replace the incorrect byte-identity requirement for independently generated seed-42 normal streams with a tightly bounded FP32 comparison
- retain and compare all 67,200 seed values, plus both content hashes, so no unsampled region can bypass the protected gate
- update the protected runner, adversarial contracts, qualification runbook, and changelog with the measured CUDA result

## Real CUDA evidence
- 67,200 FP32 values compared
- maximum absolute difference: `4.76837158203125e-7`
- maximum nonzero relative difference: `2.784542927952458e-7`
- maximum error / allowed bound: `0.10161911084226459`
- violations of `2e-6 + 1e-6 * abs(oracle)`: `0`

## Verification
- `nix develop --no-write-lock-file -c python3.13 scripts/tests/minimax-h3-visual-vae-capture-contract.py` (22/22)
- full MiniMax H3 GPU conformance contract
- base MiniMax H3 conformance contract
- private-UAT release exclusion contract
- `git diff --check`
- exact `git merge-tree --write-tree origin/main HEAD`

A dedicated peer review of the exact pre-PR snapshot approved the policy math, complete-coordinate enforcement, fail-closed runner behavior, documentation, release boundary, and diff hygiene with no remaining findings.

Progresses #832.
