### PR TITLE
fix(h3): bind audio checkpoints by role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **Private H3 AudioVAE comparison binds its two reviewed checkpoints by role.** Real CUDA capture exposed that the generic input-equality gate rejected the intentionally different official oracle and Comfy folded Mold checkpoint hashes before comparing their record-only numerical evidence. The comparator and protected runner now require each exact role-specific hash, compare the shared input authority separately, and reject any substituted checkpoint.
+
 - **Private H3 visual-VAE seed evidence is bounded across scalar math backends.** The independently generated PyTorch and Mold seed-42 MT19937 streams now retain both hashes and every scalar while enforcing the reviewed `2e-6 + 1e-6 * abs(oracle)` FP32 bound, instead of incorrectly requiring byte identity from different normal-transform implementations. The real 67,200-element CUDA pair measured a maximum absolute difference of `4.7683716e-7` with no violations.
 
 - **Private H3 visual-VAE qualification uses the official shortest round-trip temporal case.** Real CUDA capture showed that the former five-frame case encodes to two latent frames but cannot enter the pinned official decoder's temporal loop. The paired oracle and Mold case now uses 22 frames, the documented shortest `17n+5` input that produces seven latent frames and round-trips exactly; its full tensor shapes, seam probes, request identity, and external raw-evidence bound are enforced before evidence publication.

--- a/docs/qualification/minimax-h3-conformance.md
+++ b/docs/qualification/minimax-h3-conformance.md
@@ -375,7 +375,9 @@ waveform statistics, lagged phase/polarity correlations, the exact packing
 map, and the complete typed content hashes. The two checkpoints have different
 reviewed hashes, so continuous AudioVAE records use bounded numerical
 tolerances with `record-only` hashes; packing and timeline records remain
-zero-tolerance and hash-exact.
+zero-tolerance and hash-exact. Pair comparison requires the official checkpoint
+hash for the oracle role and the reviewed Comfy folded checkpoint hash for the
+Mold role; any other role/checkpoint pairing fails before numerical comparison.
 
 Prepare the five external paths and run each role in a fresh process so GPU
 memory from one implementation cannot affect the other:

--- a/scripts/minimax-h3-conformance.py
+++ b/scripts/minimax-h3-conformance.py
@@ -388,6 +388,11 @@ EXPECTED_LAYERS = {
     "end-to-end-ref2va",
 }
 
+AUDIO_VAE_CHECKPOINT_SHA256_BY_ROLE = {
+    "oracle": "52c59e67ba8de5477c81bfbced0327aabf500f1bfdeefd5ee754529241cb26cb",
+    "mold": "8e505d95dd1561d47abd43d4238fd40d9bb1ae9e147ed0a4cba778d76ae4db48",
+}
+
 FORBIDDEN_FIXTURE_SUFFIXES = {
     ".bin",
     ".ckpt",
@@ -926,12 +931,26 @@ def compare_layer_outputs(oracle: Any, mold: Any) -> list[str]:
         fail("--mold document producer role is not mold")
 
     issues: list[str] = []
-    for field in ("case_id", "layer", "authority_tier", "input"):
+    for field in ("case_id", "layer", "authority_tier"):
         if oracle[field] != mold[field]:
             issues.append(
                 f"comparison {field} mismatch: oracle={oracle[field]!r}, "
                 f"mold={mold[field]!r}"
             )
+    oracle_input = dict(oracle["input"])
+    mold_input = dict(mold["input"])
+    if oracle["layer"] == "audio-vae" and mold["layer"] == "audio-vae":
+        for role, evidence in (("oracle", oracle_input), ("mold", mold_input)):
+            expected_checkpoint = AUDIO_VAE_CHECKPOINT_SHA256_BY_ROLE[role]
+            if evidence.pop("checkpoint_sha256", None) != expected_checkpoint:
+                issues.append(
+                    f"audio-vae {role} checkpoint authority differs from the "
+                    "reviewed role-specific checkpoint"
+                )
+    if oracle_input != mold_input:
+        issues.append(
+            f"comparison input mismatch: oracle={oracle_input!r}, mold={mold_input!r}"
+        )
     if (
         oracle["adapter"]["tensor_hash_encoding"]
         != mold["adapter"]["tensor_hash_encoding"]

--- a/scripts/run-minimax-h3-gpu-conformance.py
+++ b/scripts/run-minimax-h3-gpu-conformance.py
@@ -48,6 +48,10 @@ IDENTITY_INPUT_KIND = "identity-sha256-v1"
 COMPONENT_AUTHORITY_SET_SCHEMA = "mold.minimax-h3.component-authority-set.v1"
 MAX_EXACT_ABSOLUTE_TOLERANCE = 1.0 / 64.0
 MAX_EXACT_RELATIVE_TOLERANCE = 1.0 / 64.0
+AUDIO_VAE_CHECKPOINT_SHA256_BY_ROLE = {
+    "oracle": "52c59e67ba8de5477c81bfbced0327aabf500f1bfdeefd5ee754529241cb26cb",
+    "mold": "8e505d95dd1561d47abd43d4238fd40d9bb1ae9e147ed0a4cba778d76ae4db48",
+}
 SIGNED_INT64_MIN = -(2**63)
 SIGNED_INT64_MAX = 2**63 - 1
 UNSIGNED_INT64_MAX = 2**64 - 1
@@ -1116,6 +1120,10 @@ def validate_manifest_layer_evidence(
         fail(
             f"{role} layer {layer} component authority summary differs from the manifest"
         )
+    if layer == "audio-vae" and document["input"].get("checkpoint_sha256") != (
+        AUDIO_VAE_CHECKPOINT_SHA256_BY_ROLE[role]
+    ):
+        fail(f"{role} layer audio-vae checkpoint authority is not exact")
 
     validate_acceleration_policy(
         document["environment"],

--- a/scripts/tests/minimax-h3-audio-vae-capture-contract.py
+++ b/scripts/tests/minimax-h3-audio-vae-capture-contract.py
@@ -173,6 +173,18 @@ class AudioVaeCaptureContractTests(unittest.TestCase):
                 "sampled-values": "float32",
             },
         )
+        expected_checkpoints = {
+            "oracle": PRODUCER.OFFICIAL_AUDIO_CHECKPOINT_SHA256,
+            "mold": PRODUCER.COMFY_AUDIO_CHECKPOINT_SHA256,
+        }
+        self.assertEqual(
+            CONFORMANCE.AUDIO_VAE_CHECKPOINT_SHA256_BY_ROLE,
+            expected_checkpoints,
+        )
+        self.assertEqual(
+            GPU.AUDIO_VAE_CHECKPOINT_SHA256_BY_ROLE,
+            expected_checkpoints,
+        )
 
     def test_oracle_and_mold_documents_satisfy_strict_schema(self) -> None:
         for role in ("oracle", "mold"):
@@ -315,7 +327,8 @@ class AudioVaeCaptureContractTests(unittest.TestCase):
         mutations.append(empty_runtime)
         for mutation in mutations:
             with self.assertRaisesRegex(
-                GPU.GpuConformanceFailure, "lacks canonical structured evidence"
+                GPU.GpuConformanceFailure,
+                "lacks canonical structured evidence|checkpoint authority is not exact",
             ):
                 GPU.validate_manifest_layer_evidence(mutation, self.contract, "oracle")
 
@@ -350,6 +363,31 @@ class AudioVaeCaptureContractTests(unittest.TestCase):
         ):
             GPU.validate_manifest_layer_evidence(
                 weakened_timeline, self.contract, "oracle"
+            )
+
+    def test_role_specific_checkpoint_authorities_compare_and_fail_closed(self) -> None:
+        oracle = self.layer_document("oracle")
+        mold = self.layer_document("mold")
+        CONFORMANCE.compare_layer_outputs(oracle, mold)
+
+        wrong_checkpoint = copy.deepcopy(mold)
+        wrong_checkpoint["input"]["checkpoint_sha256"] = "0" * 64
+        next(
+            item
+            for item in wrong_checkpoint["provenance"]
+            if item["key"] == "checkpoint-sha256"
+        )["value"] = "0" * 64
+        with self.assertRaisesRegex(
+            CONFORMANCE.ConformanceFailure,
+            "checkpoint authority differs",
+        ):
+            CONFORMANCE.compare_layer_outputs(oracle, wrong_checkpoint)
+        with self.assertRaisesRegex(
+            GPU.GpuConformanceFailure,
+            "checkpoint authority is not exact",
+        ):
+            GPU.validate_manifest_layer_evidence(
+                wrong_checkpoint, self.contract, "mold"
             )
 
     def test_environment_and_repository_local_fixture_fail_closed(self) -> None:

--- a/scripts/tests/minimax-h3-gpu-conformance-contract.py
+++ b/scripts/tests/minimax-h3-gpu-conformance-contract.py
@@ -374,7 +374,9 @@ def layer_document(
         "component_indexes": component_indexes,
     }
     if layer == "audio-vae":
-        input_evidence["checkpoint_sha256"] = "4" * 64
+        input_evidence["checkpoint_sha256"] = (
+            tool.AUDIO_VAE_CHECKPOINT_SHA256_BY_ROLE[role]
+        )
     task = E2E_LAYER_TASKS.get(layer)
     if task is not None:
         conditioning = []


### PR DESCRIPTION
## Summary
- allow the intentional official-oracle vs reviewed-deployment AudioVAE checkpoint distinction without weakening shared input equality
- require the exact approved checkpoint hash for each role in both direct comparison and the protected campaign runner
- add adversarial coverage for arbitrary/substituted authorities and document the real CUDA-discovered contract failure

## Real CUDA evidence
On exact `main` commit `d041b24f`, both AudioVAE roles captured successfully. Comparison stopped before metrics only because the prior generic gate required these intentionally different hashes to be equal:
- oracle: `52c59e67ba8de5477c81bfbced0327aabf500f1bfdeefd5ee754529241cb26cb`
- Mold: `8e505d95dd1561d47abd43d4238fd40d9bb1ae9e147ed0a4cba778d76ae4db48`

## Verification
- AudioVAE producer/adversarial contract: 15/15
- base MiniMax H3 conformance contract
- full MiniMax H3 GPU conformance contract
- private-UAT release exclusion contract
- `git diff --check`
- exact `git merge-tree --write-tree origin/main HEAD`

A dedicated peer review of the exact pre-PR snapshot approved the layer/role scoping, exact hash authorities, shared input equality, structured provenance, adversarial coverage, documentation, and release boundary with no findings. The reviewer additionally exercised swapped hashes, identical arbitrary hashes, and shared-input drift; all were rejected.

Progresses #832.
