### PR TITLE
fix(h3): bind transformer authorization evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **Private H3 transformer bundles bind the reviewed authorization evidence.** Real CUDA oracle capture exposed that the paired producer wrote the authorization wrapper file hash into layer and bundle evidence even though the validator requires the reviewed source-document hash carried by that wrapper. The producer now derives the published authority only from the validated reviewed source hash and retains transactional rollback on rejection.
+
 - **Private H3 AudioVAE comparison binds its two reviewed checkpoints by role.** Real CUDA capture exposed that the generic input-equality gate rejected the intentionally different official oracle and Comfy folded Mold checkpoint hashes before comparing their record-only numerical evidence. The comparator and protected runner now require each exact role-specific hash, compare the shared input authority separately, and reject any substituted checkpoint.
 
 - **Private H3 visual-VAE seed evidence is bounded across scalar math backends.** The independently generated PyTorch and Mold seed-42 MT19937 streams now retain both hashes and every scalar while enforcing the reviewed `2e-6 + 1e-6 * abs(oracle)` FP32 bound, instead of incorrectly requiring byte identity from different normal-transform implementations. The real 67,200-element CUDA pair measured a maximum absolute difference of `4.7683716e-7` with no violations.

--- a/crates/mold-inference/src/bin/h3_transformer_capture.rs
+++ b/crates/mold-inference/src/bin/h3_transformer_capture.rs
@@ -37,7 +37,7 @@ const AUTHORIZATION_SOURCE_SHA256: &str =
 const CLAIM_MARKER: &str = "mold.minimax-h3.private-uat-transformer-capture.v1";
 const MODEL_REVISION: &str = "bfc8ed0353f5a9733be73e6b2c98ec0948195b86";
 const LICENSE_SHA256: &str = "59b99642b95ea21630e311198ddbfffbfe05aadba0c2f5d884cbdf4efcc90f44";
-const MANIFEST_SHA256: &str = "eefbc5a5a42a196ccd7c93c23db7e77a2c4d418fc5e7201bb1cff7a704159109";
+const MANIFEST_SHA256: &str = "6061a2809112b5967f172d9305cadb12a7e2e75245351f4f86f693d295f51f4b";
 const MAX_MANIFEST_BYTES: u64 = 4 * 1024 * 1024;
 const MAX_AUTHORIZATION_BYTES: u64 = 64 * 1024;
 

--- a/docs/qualification/minimax-h3-conformance.md
+++ b/docs/qualification/minimax-h3-conformance.md
@@ -448,8 +448,11 @@ records use the protected 1/64 comparison bound; FP32 heads retain their hashes
 as record-only evidence. TF32, approximate attention, compilation, FP8, and
 non-deterministic algorithms remain disabled. Raw adapter output and evidence
 use create-new owner-only files below the external fixture root, and raw output
-is parsed from the exact descriptor-retained bytes before revalidation. This
-producer and its CI contract do not claim that the real CUDA campaign has run.
+is parsed from the exact descriptor-retained bytes before revalidation. Every
+published layer and bundle binds the reviewed authorization source-evidence
+hash carried by the validated wrapper record, never the wrapper file's own
+hash. The producer and its CI contract do not claim that the real CUDA campaign
+has passed.
 
 ### Opt-in protected GPU validation
 

--- a/scripts/capture-minimax-h3-transformer.py
+++ b/scripts/capture-minimax-h3-transformer.py
@@ -204,6 +204,13 @@ def required_environment(environment: Mapping[str, str]) -> dict[str, str]:
     return values
 
 
+def reviewed_authorization_sha256(authorization: Mapping[str, Any]) -> str:
+    observed = authorization.get("source_document_sha256")
+    if observed != AUTHORIZATION_SHA256:
+        fail("authorization differs from reviewed evidence")
+    return observed
+
+
 def component_ids(manifest: Mapping[str, Any]) -> tuple[str, ...]:
     layer = next(item for item in manifest["fixture_layers"] if item["id"] == "token-refiner")
     identifiers = tuple(layer["required_component_indexes"])
@@ -745,7 +752,7 @@ def run_capture(
     fixture_root = BASE.external_directory("fixture root", values["MOLD_H3_FIXTURE_ROOT"])
     authorization = BASE.external_file("authorization record", values["MOLD_H3_AUTHORIZATION_RECORD"])
     auth = BASE.validate_reviewed_authorization(conformance, authorization)
-    if auth["source_document_sha256"] != AUTHORIZATION_SHA256: fail("authorization differs from reviewed evidence")
+    authorization_sha256 = reviewed_authorization_sha256(auth)
     model_root = BASE.external_directory("official model", values["MOLD_H3_OFFICIAL_MODEL"])
     diffusers = BASE.external_directory("Diffusers checkout", values["MOLD_H3_DIFFUSERS_CHECKOUT"])
     transformers = BASE.external_directory("Transformers checkout", values["MOLD_H3_TRANSFORMERS_CHECKOUT"])
@@ -754,7 +761,6 @@ def run_capture(
     runtime = load_runtime(diffusers, transformers)
     runtime_identity = BASE.observed_oracle_runtime(runtime)
     if runtime_identity != manifest["numerical_authority"]["oracle_runtime"]: fail("oracle runtime differs from reviewed authority")
-    authorization_sha256 = BASE.sha256_file(authorization)
     paths: list[pathlib.Path] = []
     bundles: list[pathlib.Path] = []
     revision = (

--- a/scripts/tests/minimax-h3-transformer-capture-contract.py
+++ b/scripts/tests/minimax-h3-transformer-capture-contract.py
@@ -89,6 +89,21 @@ def raw_document(task: str, revision: str = "b" * 40) -> dict:
 
 
 class TransformerCaptureContract(unittest.TestCase):
+    def test_bundle_authorization_binds_reviewed_source_evidence(self) -> None:
+        self.assertEqual(
+            producer.reviewed_authorization_sha256(
+                {"source_document_sha256": producer.AUTHORIZATION_SHA256}
+            ),
+            producer.AUTHORIZATION_SHA256,
+        )
+        with self.assertRaisesRegex(
+            producer.CaptureFailure,
+            "authorization differs from reviewed evidence",
+        ):
+            producer.reviewed_authorization_sha256(
+                {"source_document_sha256": "0" * 64}
+            )
+
     def test_task_cases_are_distinct_and_content_addressed(self) -> None:
         fl2va = producer.build_case("fl2va")
         ref2va = producer.build_case("ref2va")

--- a/tests/fixtures/minimax_h3/conformance-manifest.json
+++ b/tests/fixtures/minimax_h3/conformance-manifest.json
@@ -738,7 +738,7 @@
         "id": "minimax-h3-token-refiner-oracle-v1",
         "command_prefix": "python3 scripts/capture-minimax-h3-transformer.py capture --role oracle",
         "implementation_path": "scripts/capture-minimax-h3-transformer.py",
-        "implementation_sha256": "5ad05236f6be8280fd47f4185f4a8e5ddc2671153e504036f53011bcc209b92b"
+        "implementation_sha256": "b599e8d178f2f9068b68a242abead076ca09a36b169eb6cd36f089d64b661b7d"
       },
       "required_measurements": ["shape", "statistics", "sampled-values", "tolerance"]
     },
@@ -797,7 +797,7 @@
         "id": "minimax-h3-transformer-block-oracle-v1",
         "command_prefix": "python3 scripts/capture-minimax-h3-transformer.py capture --role oracle",
         "implementation_path": "scripts/capture-minimax-h3-transformer.py",
-        "implementation_sha256": "5ad05236f6be8280fd47f4185f4a8e5ddc2671153e504036f53011bcc209b92b"
+        "implementation_sha256": "b599e8d178f2f9068b68a242abead076ca09a36b169eb6cd36f089d64b661b7d"
       },
       "required_measurements": [
         "qk-rms",


### PR DESCRIPTION
## Summary
- publish the validated reviewed authorization source-document hash in transformer layer/bundle evidence instead of the wrapper JSON file hash
- retain two-task transactional rollback and add a focused authority regression
- refresh the producer hash, both manifest adapter pins, manifest hash, and Rust adapter manifest pin as one reviewed cascade

## Real CUDA finding
On exact `main` commit `0e20dd40`, the oracle executed both FL2VA and Ref2VA selective module captures, then bundle validation rejected the wrapper-file hash before valid evidence publication. Transactional cleanup left the source-addressed evidence root empty.

## Verification
- transformer producer/adversarial contract: 13/13
- base MiniMax H3 conformance contract
- full MiniMax H3 GPU conformance contract
- private-UAT release exclusion contract
- Cargo format check
- authorized-host CUDA Clippy with warnings denied for `h3_transformer_capture`
- `git diff --check`
- exact `git merge-tree --write-tree origin/main HEAD`

Exact authority cascade:
- producer: `b599e8d178f2f9068b68a242abead076ca09a36b169eb6cd36f089d64b661b7d`
- manifest: `6061a2809112b5967f172d9305cadb12a7e2e75245351f4f86f693d295f51f4b`

A dedicated peer review of the exact pre-PR snapshot approved the validated source-hash path, rollback behavior, complete hash cascade, documentation, release boundary, and prohibited-term absence with no findings.

Progresses #832.
