### PR TITLE
fix(h3): match Qwen BF16 precision boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **MiniMax H3 Qwen now matches the released BF16 precision boundaries.** The text conditioner casts multimodal rotary cosine and sine values to the hidden-state dtype before the products and residual sum, while the vision tower accumulates learned-position interpolation with FP32 weights in the released multiply/divide order before casting once to BF16. Real CUDA qualification showed the corrections reduce text layer-50 drift and restore the official massive-activation direction for the representative multimodal state; the complete pair still requires a separately reviewed magnitude-aware policy before qualification can pass.
+
 - **Private H3 Qwen qualification now retains every compared activation coordinate.** Real paired CUDA evidence exposed cross-backend differences after the 50-layer text and multimodal paths. The producer now emits the complete ordered BF16 activation in each role's layer document, and protected validation rejects any missing, extra, or reordered coordinate. Rejection diagnostics are bounded even when a complete tensor differs, while still reporting the total omitted issue count. The exact-hash policy remains unchanged until complete evidence justifies a narrower reviewed policy.
 
 - **Private H3 Qwen bundles retain the complete component authority.** The paired producer now copies each layer document's canonical 15-record text-encoder authority-set hash into its bundle fixture instead of reverting to the single index-file hash. Protected validation therefore sees the same reviewed index and shard authority at both evidence boundaries.

--- a/crates/mold-candle/src/minimax_h3/text.rs
+++ b/crates/mold-candle/src/minimax_h3/text.rs
@@ -201,7 +201,7 @@ impl MultimodalRotaryEmbedding {
         })
     }
 
-    fn cos_sin(&self, position_ids: &Tensor) -> Result<(Tensor, Tensor)> {
+    fn cos_sin(&self, position_ids: &Tensor, dtype: DType) -> Result<(Tensor, Tensor)> {
         let (axes, _batch, sequence) = position_ids.dims3()?;
         if axes != 3 {
             candle::bail!("Qwen multimodal RoPE needs three position axes, got {axes}");
@@ -239,7 +239,10 @@ impl MultimodalRotaryEmbedding {
         let interleaved = Tensor::cat(&refs, D::Minus1)?;
         debug_assert_eq!(interleaved.dim(1)?, sequence);
         let doubled = Tensor::cat(&[&interleaved, &interleaved], D::Minus1)?;
-        Ok((doubled.cos()?, doubled.sin()?))
+        Ok((
+            doubled.cos()?.to_dtype(dtype)?,
+            doubled.sin()?.to_dtype(dtype)?,
+        ))
     }
 }
 
@@ -251,11 +254,17 @@ fn rotate_half(input: &Tensor) -> Result<Tensor> {
 }
 
 fn apply_rotary(input: &Tensor, cos: &Tensor, sin: &Tensor) -> Result<Tensor> {
-    let dtype = input.dtype();
-    let input = input.to_dtype(DType::F32)?;
+    if cos.dtype() != input.dtype() || sin.dtype() != input.dtype() {
+        candle::bail!(
+            "Qwen text rotary inputs must share one dtype, got {:?}, {:?}, and {:?}",
+            input.dtype(),
+            cos.dtype(),
+            sin.dtype()
+        );
+    }
     let cos = cos.unsqueeze(1)?;
     let sin = sin.unsqueeze(1)?;
-    (input.broadcast_mul(&cos)? + rotate_half(&input)?.broadcast_mul(&sin)?)?.to_dtype(dtype)
+    input.broadcast_mul(&cos)? + rotate_half(input)?.broadcast_mul(&sin)?
 }
 
 struct Attention {
@@ -552,7 +561,7 @@ impl Qwen3VlTextEncoder {
         if deepstack.is_some_and(|features| features.len() > self.layers.len()) {
             candle::bail!("H3 DeepStack has more feature layers than language layers");
         }
-        let (cos, sin) = self.rotary.cos_sin(position_ids)?;
+        let (cos, sin) = self.rotary.cos_sin(position_ids, hidden.dtype())?;
         let causal = causal_mask(sequence, hidden.device())?;
         for (index, layer) in self.layers.iter().enumerate() {
             hidden = layer.forward(&hidden, &cos, &sin, &causal)?;
@@ -642,7 +651,7 @@ impl Qwen3VlStreamingTextEncoder {
         if deepstack.is_some_and(|features| features.len() > self.layer_count()) {
             candle::bail!("H3 DeepStack has more feature layers than language layers");
         }
-        let (cos, sin) = self.rotary.cos_sin(position_ids)?;
+        let (cos, sin) = self.rotary.cos_sin(position_ids, hidden.dtype())?;
         let causal = causal_mask(sequence, hidden.device())?;
         for index in 0..self.layer_count() {
             let layer = self.load_layer(index)?;
@@ -912,13 +921,17 @@ mod tests {
         let vb = VarBuilder::zeros(DType::F32, &Device::Cpu);
         let rotary = MultimodalRotaryEmbedding::new(&config, &vb).unwrap();
         let positions = Tensor::new(&[[[2_u32]], [[3_u32]], [[4_u32]]], &Device::Cpu).unwrap();
-        let (cos, sin) = rotary.cos_sin(&positions).unwrap();
+        let (cos, sin) = rotary.cos_sin(&positions, DType::F32).unwrap();
         assert_eq!(cos.dtype(), DType::F32);
         assert_eq!(sin.dtype(), DType::F32);
         assert_eq!(cos.dims(), [1, 1, 4]);
         let values = cos.flatten_all().unwrap().to_vec1::<f32>().unwrap();
         assert!((values[0] - 2.0_f32.cos()).abs() < 1e-6);
         assert!((values[1] - (3.0_f32 / 100.0).cos()).abs() < 1e-6);
+
+        let (cos, sin) = rotary.cos_sin(&positions, DType::BF16).unwrap();
+        assert_eq!(cos.dtype(), DType::BF16);
+        assert_eq!(sin.dtype(), DType::BF16);
     }
 
     #[test]

--- a/crates/mold-candle/src/minimax_h3/vision.rs
+++ b/crates/mold-candle/src/minimax_h3/vision.rs
@@ -566,13 +566,11 @@ impl Qwen3VlVisionModel {
         let gathered = self
             .position_embedding
             .forward(&Tensor::stack(&index_refs, 0)?)?;
-        let interpolated = gathered
-            .broadcast_mul(
-                &Tensor::stack(&weight_refs, 0)?
-                    .to_dtype(dtype)?
-                    .unsqueeze(D::Minus1)?,
-            )?
-            .sum(0)?;
+        let interpolated = weighted_position_sum(
+            &gathered,
+            &Tensor::stack(&weight_refs, 0)?.unsqueeze(D::Minus1)?,
+            dtype,
+        )?;
         let mut outputs = Vec::with_capacity(grid.len());
         let mut offset = 0;
         for (&[temporal, height, width], area) in grid.iter().zip(areas) {
@@ -639,6 +637,14 @@ impl Qwen3VlVisionModel {
     }
 }
 
+fn weighted_position_sum(gathered: &Tensor, weights: &Tensor, dtype: DType) -> Result<Tensor> {
+    gathered
+        .to_dtype(DType::F32)?
+        .broadcast_mul(weights)?
+        .sum(0)?
+        .to_dtype(dtype)
+}
+
 fn parse_grid(grid: &Tensor, merge: usize) -> Result<Vec<[usize; 3]>> {
     let rows = grid
         .to_device(&Device::Cpu)?
@@ -670,8 +676,9 @@ fn linspace(steps: usize, position_grid_side: usize) -> Vec<f32> {
     if steps == 1 {
         return vec![0.0];
     }
-    let stride = (position_grid_side - 1) as f32 / (steps - 1) as f32;
-    (0..steps).map(|index| index as f32 * stride).collect()
+    (0..steps)
+        .map(|index| index as f32 * (position_grid_side - 1) as f32 / (steps - 1) as f32)
+        .collect()
 }
 
 fn cumulative_sequence_lengths(grid: &[[usize; 3]]) -> Vec<usize> {
@@ -690,6 +697,44 @@ fn cumulative_sequence_lengths(grid: &[[usize; 3]]) -> Vec<usize> {
 mod tests {
     use super::*;
     use candle_nn::VarMap;
+
+    #[test]
+    fn interpolation_points_match_the_released_fp32_operation_order() {
+        let points = linspace(16, 48);
+        assert_eq!(points[3].to_bits(), 0x4116_6666);
+        assert_eq!(points[7].to_bits(), 0x41af_7777);
+        assert_eq!(points[14].to_bits(), 0x422f_7777);
+    }
+
+    #[test]
+    fn bf16_position_interpolation_accumulates_with_fp32_weights() {
+        let gathered = Tensor::new(
+            &[[[4.09375_f32]], [[3.9375]], [[-4.875]], [[1.171875]]],
+            &Device::Cpu,
+        )
+        .unwrap()
+        .to_dtype(DType::BF16)
+        .unwrap();
+        let weights = Tensor::new(
+            &[
+                [[0.15096787_f32]],
+                [[0.21469931]],
+                [[0.31650212]],
+                [[0.31783068]],
+            ],
+            &Device::Cpu,
+        )
+        .unwrap();
+        let value = weighted_position_sum(&gathered, &weights, DType::BF16)
+            .unwrap()
+            .to_dtype(DType::F32)
+            .unwrap()
+            .flatten_all()
+            .unwrap()
+            .to_vec1::<f32>()
+            .unwrap();
+        assert_eq!(value, vec![0.29296875]);
+    }
 
     #[test]
     fn tiny_vision_tower_returns_main_and_three_deepstack_rows() {


### PR DESCRIPTION
## Summary

- cast Qwen multimodal rotary cosine and sine values to the hidden-state dtype before the BF16 products and residual sum
- accumulate learned vision-position interpolation with FP32 weights, then cast once to BF16
- match the released interpolation multiply/divide order and pin the boundaries with focused tests

## Qualification evidence

Real CUDA diagnosis on an L40S showed the text correction reduced layer-50 drift and the vision correction restored the official high-magnitude multimodal activation direction. The remaining magnitude difference is intentionally not hidden by a broad tolerance; #832 remains open pending a separately reviewed protected comparison policy and a clean paired capture.

## Verification

- `nix develop -c cargo fmt --all -- --check`
- `nix develop -c cargo test -p mold-ai-candle minimax_h3 --features h3-private-uat` (181 passed, 1 authorization-only ignored)
- `nix develop -c cargo clippy -p mold-ai-candle --features h3-private-uat -- -D warnings`
- `nix develop -c python3.13 scripts/tests/minimax-h3-qwen-layer50-capture-contract.py` (27 passed)
- base and private GPU conformance contracts
- private-UAT release exclusion contract
- exact-head independent peer review approved with no findings
