### PR TITLE
feat(h3): expose private runtime phase progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **Private H3 CUDA qualification can observe the real server phase lifecycle.** The authenticated private server stream now exposes the runtime's existing phase progress so external host/device memory samples can be correlated with VAE, Qwen, transformer, decode, and mux work. This remains behind `h3-private-uat` and does not activate a public H3 loader or approve runtime bounds.
+
 - **Private H3 campaign servers retain their measured runtime identity.** The private server now records the exact 64-byte runtime-code identity at startup, ensuring release LTO cannot remove the marker that the content-addressed qualification producer must authenticate in the measured server ELF. This changes no public capability or reviewed runtime allowlist.
 
 - **Private H3 Qwen qualification now uses a reviewed magnitude-aware BF16 policy.** After the production precision-boundary fixes, a complete 686,080-coordinate L40S comparison measured no ordinary-value violations under `48 + abs(oracle) / 64`; only seven multimodal coordinates reached an oracle magnitude of 1,024 or greater, with a worst observed relative difference of `5/13`. The protected comparison therefore uses that ordinary bound below 1,024 and `48 + 3 * abs(oracle) / 8` at or above it, retains both full-stream hashes as record evidence, requires every row-major coordinate, and rejects any policy widening. A clean paired CUDA campaign remains required before the Qwen qualification box can close.

--- a/crates/mold-inference/src/minimax_h3/engine.rs
+++ b/crates/mold-inference/src/minimax_h3/engine.rs
@@ -477,7 +477,7 @@ impl InferenceEngine for H3Fl2VaEngine {
     }
 }
 
-struct H3EngineProgressObserver<'a> {
+pub(crate) struct H3EngineProgressObserver<'a> {
     progress: &'a ProgressReporter,
     started: HashMap<H3PipelinePhase, Instant>,
     last_completed: HashMap<H3PipelinePhase, usize>,
@@ -485,7 +485,7 @@ struct H3EngineProgressObserver<'a> {
 }
 
 impl<'a> H3EngineProgressObserver<'a> {
-    fn new(progress: &'a ProgressReporter) -> Self {
+    pub(crate) fn new(progress: &'a ProgressReporter) -> Self {
         Self {
             progress,
             started: HashMap::new(),

--- a/crates/mold-inference/src/minimax_h3/private_server.rs
+++ b/crates/mold-inference/src/minimax_h3/private_server.rs
@@ -40,7 +40,9 @@ use sha2::{Digest, Sha256};
 #[cfg(feature = "mp4")]
 use super::backend::{H3BackendArtifactLease, H3BackendExecutionLease, H3CandleBackendDevice};
 #[cfg(feature = "mp4")]
-use super::pipeline::{H3PipelineCheckpoint, H3PipelineEvent, NoopH3PipelineObserver};
+use super::engine::H3EngineProgressObserver;
+#[cfg(feature = "mp4")]
+use super::pipeline::{H3PipelineCheckpoint, H3PipelineEvent};
 #[cfg(feature = "mp4")]
 use super::private_fl2va_runtime::{
     bind_private_comfy_fl2va_phase_owner, issue_private_fl2va_memory_overlap,
@@ -863,7 +865,7 @@ fn prepare_reviewed_h3_private_fl2va_admission(
     let opened_vae = open_h3_comfy_vae_authority(&vae_plan, &mut vae_observer);
     let opened_vae = vae_observer.finish(opened_vae)?;
 
-    let mut prepare_observer = NoopH3PipelineObserver;
+    let mut prepare_observer = H3EngineProgressObserver::new(progress);
     let admission_request = prepare_private_fl2va_admission_request(
         request,
         &qwen_support,
@@ -1934,7 +1936,7 @@ fn prepare_reviewed_h3_private_fl2va_attempt(
     )?;
     progress.checkpoint()?;
 
-    let mut prepare_observer = NoopH3PipelineObserver;
+    let mut prepare_observer = H3EngineProgressObserver::new(progress);
     let prepared_attempt = H3PrivatePreparedFl2VaAttempt::prepare(
         request,
         frozen_factory.execution_fingerprint(),
@@ -2737,7 +2739,7 @@ impl H3PrivateFl2VaPreparedRunner for H3PrivateConcretePreparedRunner {
                 memory_overlap,
                 allocation_commit,
             )?;
-            let mut observer = NoopH3PipelineObserver;
+            let mut observer = H3EngineProgressObserver::new(progress);
             let output = run_private_comfy_fl2va_attempt(phase_owner, progress, &mut observer)?;
             completion_device
                 .synchronize()

--- a/scripts/tests/minimax-h3-private-uat-release-contract.sh
+++ b/scripts/tests/minimax-h3-private-uat-release-contract.sh
@@ -185,6 +185,10 @@ require_text crates/mold-inference/src/lib.rs \
 require_text crates/mold-server/src/main.rs \
   'mold_inference::h3_private_runtime_code_identity_sha256()' \
   "the private H3 server ELF does not retain its measured code identity"
+if grep -Fq 'NoopH3PipelineObserver' \
+  crates/mold-inference/src/minimax_h3/private_server.rs; then
+  fail "the private H3 server suppresses timestampable pipeline progress"
+fi
 require_text crates/mold-inference/src/minimax_h3/private_runtime_qualification.rs \
   'MAX_RUNTIME_QUALIFICATION_BYTES' \
   "the private H3 runtime-record producer does not share the activation record limit"


### PR DESCRIPTION
## Summary
- route the existing MiniMax H3 pipeline observer through private admission preparation, one-shot attempt preparation, and the full runtime/mux lifecycle
- expose timestampable phase progress to the authenticated server stream for external CUDA memory correlation
- guard against restoring the prior no-op observer in the private release contract

This stays behind `h3-private-uat`; it does not activate a public loader, change authorization, or approve runtime-memory bounds.

## Verification
- mandatory peer review approved exact commit `d06448fddaf73a70461bcd48e36bd69916cd9ad8` with no findings
- `nix develop -c cargo test -p mold-ai-inference --features h3-private-uat,mp4 --lib progress_observer_emits_independent_h3_runtime_phases`
- `nix develop -c bash scripts/tests/minimax-h3-private-uat-release-contract.sh`
- `nix develop -c cargo check --locked -p mold-ai-inference --features h3-private-uat,mp4 --lib`
- `cargo fmt --all -- --check`
- `git diff --check`
- exact merge-tree against `origin/main` is conflict-free