### PR TITLE
fix(h3): preserve authorized private ingress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **Authorized private H3 ingress no longer re-enters the public compliance rejection.** The server now applies the ordinary field and family validation through a validation-only `h3-private-uat` edge after its authenticated private grant. Shipping requests still fail at the unchanged public authorization gate, and this adds no artifact or loader access.
+
 - **Private H3 CUDA qualification can observe the real server phase lifecycle.** The authenticated private server stream now exposes the runtime's existing phase progress so external host/device memory samples can be correlated with VAE, Qwen, transformer, decode, and mux work. This remains behind `h3-private-uat` and does not activate a public H3 loader or approve runtime bounds.
 
 - **Private H3 campaign servers retain their measured runtime identity.** The private server now records the exact 64-byte runtime-code identity at startup, ensuring release LTO cannot remove the marker that the content-addressed qualification producer must authenticate in the measured server ELF. This changes no public capability or reviewed runtime allowlist.

--- a/crates/mold-core/Cargo.toml
+++ b/crates/mold-core/Cargo.toml
@@ -13,6 +13,12 @@ description = "Shared types, API protocol, and HTTP client for mold"
 [lib]
 name = "mold_core"
 
+[features]
+default = []
+# Validation-only edge consumed by the authenticated private H3 server. This
+# does not expose artifacts, loaders, or model activation.
+h3-private-uat = []
+
 [dependencies]
 anyhow = "1"
 console = "0.15"

--- a/crates/mold-core/src/validation.rs
+++ b/crates/mold-core/src/validation.rs
@@ -1611,6 +1611,25 @@ pub fn validate_generate_request_with_family(
     validate_generate_request_after_activation(req, family_hint)
 }
 
+/// Validate the exact MiniMax H3 private-UAT request partition after the
+/// server has issued its authenticated ingress grant.
+///
+/// This feature-gated helper does not grant authorization or activate a model;
+/// it only prevents the already-authorized private route from re-entering the
+/// public compliance gate before applying the same field validation.
+#[cfg(feature = "h3-private-uat")]
+pub fn validate_h3_private_uat_request(req: &GenerateRequest) -> Result<(), String> {
+    if !matches!(
+        req.model.as_str(),
+        crate::minimax_h3::FL2VA_COMFY | crate::minimax_h3::REF2VA_COMFY
+    ) {
+        return Err(
+            "private MiniMax H3 validation requires an exact reviewed task model".to_string(),
+        );
+    }
+    validate_generate_request_after_activation(req, Some(crate::minimax_h3::FAMILY))
+}
+
 /// Shape/feature validation after the caller has passed the model-activation
 /// authority. Kept private so tests can prove the future authorized H3 path
 /// without exposing a compliance-gate bypass to production callers.
@@ -3478,6 +3497,23 @@ mod tests {
         // value rather than inheriting the generic img2img default.
         req.strength = 1.0;
         req
+    }
+
+    #[cfg(feature = "h3-private-uat")]
+    #[test]
+    fn private_h3_validation_bypasses_only_activation_for_exact_reviewed_models() {
+        let req = valid_h3_request(crate::minimax_h3::FL2VA_COMFY);
+        let public_error =
+            validate_generate_request_with_family(&req, Some(crate::minimax_h3::FAMILY))
+                .unwrap_err();
+        assert!(public_error.contains(crate::MINIMAX_H3_AUTHORIZATION_REQUIRED));
+        validate_h3_private_uat_request(&req).unwrap();
+
+        let mut official = req;
+        official.model = crate::minimax_h3::FL2VA_OFFICIAL.to_string();
+        assert!(validate_h3_private_uat_request(&official)
+            .unwrap_err()
+            .contains("exact reviewed task model"));
     }
 
     #[test]

--- a/crates/mold-server/Cargo.toml
+++ b/crates/mold-server/Cargo.toml
@@ -35,6 +35,7 @@ h3-private-bridge = []
 # incomplete private server binary cannot be built accidentally.
 h3-private-uat = [
     "h3-private-bridge",
+    "mold-core/h3-private-uat",
     "mold-inference/h3-private-uat",
     "mold-inference/dev-bins",
     "mold-inference/h3-attention-rc",

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -924,7 +924,15 @@ async fn prepare_generation(
     } else {
         &*request
     };
-    if let Err(e) = validate_generate_request(validation_request, resolved_family.as_deref()) {
+    #[cfg(feature = "h3-private-uat")]
+    let validation = if private_h3_ingress {
+        mold_core::validation::validate_h3_private_uat_request(validation_request)
+    } else {
+        validate_generate_request(validation_request, resolved_family.as_deref())
+    };
+    #[cfg(not(feature = "h3-private-uat"))]
+    let validation = validate_generate_request(validation_request, resolved_family.as_deref());
+    if let Err(e) = validation {
         return Err(ApiError::validation(e));
     }
     enforce_source_image_capability(state, request, resolved_family.as_deref()).await?;

--- a/scripts/tests/minimax-h3-private-uat-release-contract.sh
+++ b/scripts/tests/minimax-h3-private-uat-release-contract.sh
@@ -22,6 +22,15 @@ require_text crates/mold-candle/Cargo.toml \
 require_text crates/mold-inference/Cargo.toml \
   'h3-private-uat = ["mold-candle/h3-private-uat"]' \
   "mold-inference does not narrowly forward the private H3 runtime feature"
+require_text crates/mold-server/Cargo.toml \
+  '"mold-core/h3-private-uat"' \
+  "the private H3 server does not activate its validation-only core edge"
+require_text crates/mold-core/src/validation.rs \
+  '#[cfg(feature = "h3-private-uat")]' \
+  "the private H3 post-authorization validator is not feature-gated"
+require_text crates/mold-server/src/routes.rs \
+  'validate_h3_private_uat_request(validation_request)' \
+  "authenticated private H3 ingress re-enters the public compliance validator"
 containment_rev=9b3b1bc276bc27c3e99343ee82db7f99705b9ed5
 containment_patch="cudarc = { git = \"https://github.com/utensils/cudarc\", rev = \"${containment_rev}\" }"
 require_text Cargo.toml "$containment_patch" \
@@ -646,6 +655,7 @@ fi
 h3_uat_feature=$(sed -n '/^h3-private-uat = \[/,/^\]/p' crates/mold-server/Cargo.toml)
 for edge in \
   h3-private-bridge \
+  mold-core/h3-private-uat \
   mold-inference/h3-private-uat \
   mold-inference/dev-bins \
   mold-inference/h3-attention-rc \
@@ -654,7 +664,7 @@ for edge in \
   grep -Fq "\"${edge}\"" <<<"$h3_uat_feature" \
     || fail "mold-ai-server private H3 UAT feature omits ${edge}"
 done
-if [[ $(grep -Ec '^[[:space:]]*"[^"]+",?$' <<<"$h3_uat_feature") -ne 6 ]]; then
+if [[ $(grep -Ec '^[[:space:]]*"[^"]+",?$' <<<"$h3_uat_feature") -ne 7 ]]; then
   fail "mold-ai-server private H3 UAT feature contains an unexpected runtime edge"
 fi
 


### PR DESCRIPTION
## Summary

- keep authenticated private MiniMax H3 ingress from re-entering the public compliance rejection
- expose only the existing post-activation field/family validator behind the private UAT feature and exact reviewed Comfy model IDs
- preserve the unchanged public authorization gate and all artifact, loader, catalog, and release exclusions

## Why

A memory-gated private smoke run failed closed before model construction: the server issued the authenticated private ingress grant, then routed the request back through the public validator, which correctly rejected all public H3 activation. This patch preserves that public behavior while allowing the already-authorized private route to continue through ordinary request validation.

No model was allocated during the failed smoke, and this PR does not add a runtime allowlist or public activation.

## Verification

- Nix: focused private exact-model validator test
- Nix: ordinary public compliance-rejection regression
- Nix: private-UAT release contract
- authorized CUDA host: private-server Clippy with warnings denied
- authorized CUDA host: `private_h3_generation_requires_explicit_auth_before_queueing`
- exact-head peer review: approved with no actionable findings
- exact merge-tree against `origin/main`: clean
