### PR TITLE
fix(h3): bind runtime records to stable CUDA routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **Private H3 runtime records now bind the scheduler's stable CUDA route.** Memory-gated smoke testing exposed that the candidate producer required an ordinal-shaped `cuda:N` identifier while runtime admission required the UUID-backed scheduler device ID, making every record impossible to authorize. Capture and runtime validation now require the exact lowercase 128-bit CUDA identity while retaining the process-local ordinal as a separate crossed-route check.
+
 - **Authorized private H3 ingress no longer re-enters the public compliance rejection.** The server now applies the ordinary field and family validation through a validation-only `h3-private-uat` edge after its authenticated private grant. Shipping requests still fail at the unchanged public authorization gate, and this adds no artifact or loader access.
 
 - **Private H3 CUDA qualification can observe the real server phase lifecycle.** The authenticated private server stream now exposes the runtime's existing phase progress so external host/device memory samples can be correlated with VAE, Qwen, transformer, decode, and mux work. This remains behind `h3-private-uat` and does not activate a public H3 loader or approve runtime bounds.

--- a/crates/mold-inference/src/minimax_h3/private_runtime_qualification.rs
+++ b/crates/mold-inference/src/minimax_h3/private_runtime_qualification.rs
@@ -21,10 +21,10 @@ use super::private_qualification::{
     qualify_private_artifacts, H3ArtifactHashProgress, H3PrivateArtifactQualificationReport,
 };
 use super::private_server::{
-    runtime_qualification_identity, validate_runtime_qualification_record_shape,
-    H3PrivateRuntimeBoundRecord, H3PrivateRuntimeEvidenceArtifact,
-    H3PrivateRuntimeQualificationRecord, MAX_RUNTIME_QUALIFICATION_BYTES,
-    RUNTIME_QUALIFICATION_DECISION, RUNTIME_QUALIFICATION_SCHEMA,
+    runtime_qualification_identity, valid_stable_cuda_device_id,
+    validate_runtime_qualification_record_shape, H3PrivateRuntimeBoundRecord,
+    H3PrivateRuntimeEvidenceArtifact, H3PrivateRuntimeQualificationRecord,
+    MAX_RUNTIME_QUALIFICATION_BYTES, RUNTIME_QUALIFICATION_DECISION, RUNTIME_QUALIFICATION_SCHEMA,
 };
 
 pub const H3_PRIVATE_RUNTIME_RECORD_PRODUCER_MARKER: &str =
@@ -209,7 +209,7 @@ impl H3PrivateRuntimeBoundCaptureManifest {
         {
             bail!("private H3 runtime capture differs from the embedded campaign build")
         }
-        if self.device_id != format!("cuda:{}", self.device_ordinal)
+        if !valid_stable_cuda_device_id(&self.device_id)
             || self.compute_capability[0] == 0
             || self.compute_capability[0] > 99
             || self.compute_capability[1] > 99
@@ -756,6 +756,8 @@ mod tests {
 
     use super::*;
 
+    const DEVICE_0: &str = "cuda:00000000000000000000000000000000";
+
     fn sha(byte: char) -> String {
         std::iter::repeat_n(byte, 64).collect()
     }
@@ -814,7 +816,7 @@ mod tests {
             authorization_record_sha256: sha('a'),
             authorization_source_document_sha256: sha('b'),
             artifact_qualification_identity_sha256: sha('c'),
-            device_id: "cuda:0".into(),
+            device_id: DEVICE_0.into(),
             device_ordinal: 0,
             compute_capability: [8, 9],
             attention_runtime_identity_sha256: sha('d'),
@@ -975,7 +977,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn capture_rejects_unembedded_source_or_out_of_schema_compute_capability() {
+    fn capture_rejects_unembedded_source_or_invalid_cuda_authority() {
         let mut manifest = capture("logs/runtime.log");
         assert!(manifest
             .validate(
@@ -988,6 +990,14 @@ mod tests {
             .contains("embedded campaign build"));
 
         manifest.compute_capability = [100, 0];
+        assert!(manifest
+            .validate(&artifact_report(), &source_sha(), &runtime_code_identity())
+            .unwrap_err()
+            .to_string()
+            .contains("CUDA attention authority"));
+
+        manifest.compute_capability = [8, 9];
+        manifest.device_id = "cuda:0".into();
         assert!(manifest
             .validate(&artifact_report(), &source_sha(), &runtime_code_identity())
             .unwrap_err()

--- a/crates/mold-inference/src/minimax_h3/private_server.rs
+++ b/crates/mold-inference/src/minimax_h3/private_server.rs
@@ -97,6 +97,16 @@ pub(crate) const RUNTIME_QUALIFICATION_SCHEMA: &str =
 pub(crate) const RUNTIME_QUALIFICATION_DECISION: &str = "qualified-private-fl2va-runtime";
 pub(crate) const MAX_RUNTIME_QUALIFICATION_BYTES: u64 = 128 * 1024;
 
+pub(crate) fn valid_stable_cuda_device_id(value: &str) -> bool {
+    let Some(uuid) = value.strip_prefix("cuda:") else {
+        return false;
+    };
+    uuid.len() == 32
+        && uuid
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
 /// Exact reviewed runtime-qualification record hashes.
 ///
 /// This is intentionally empty. Artifact qualification and the payload-free
@@ -3727,7 +3737,7 @@ pub(crate) fn validate_runtime_qualification_record_shape(
             .windows(2)
             .any(|pair| pair[0].relative_path >= pair[1].relative_path)
         || record.artifact_total_bytes == 0
-        || record.device_id != format!("cuda:{}", record.device_ordinal)
+        || !valid_stable_cuda_device_id(&record.device_id)
         || !(1..=99).contains(&record.compute_capability[0])
         || record.compute_capability[1] > 99
         || !valid_runtime_evidence_relative_path(&record.measured_server_executable_relative_path)
@@ -3852,12 +3862,30 @@ mod tests {
         H3FactoryComponentRole, H3FactoryConditionerPlacement, H3FactoryQuantizationAuthority,
     };
 
+    const DEVICE_0: &str = "cuda:00000000000000000000000000000000";
+    const DEVICE_1: &str = "cuda:00000000000000000000000000000001";
+
     fn sha(byte: char) -> String {
         std::iter::repeat_n(byte, 64).collect()
     }
 
     fn source_sha(byte: char) -> String {
         std::iter::repeat_n(byte, 40).collect()
+    }
+
+    #[test]
+    fn runtime_record_requires_scheduler_stable_cuda_identity() {
+        assert!(valid_stable_cuda_device_id(DEVICE_0));
+        assert!(!valid_stable_cuda_device_id("cuda:0"));
+        assert!(!valid_stable_cuda_device_id(
+            "cuda:0000000000000000000000000000000A"
+        ));
+        assert!(!valid_stable_cuda_device_id(
+            "cuda:0000000000000000000000000000000"
+        ));
+        assert!(!valid_stable_cuda_device_id(
+            "runtime:gpu:00000000000000000000000000000000"
+        ));
     }
 
     fn media() -> H3PrivateFl2VaMediaContract {
@@ -3914,7 +3942,7 @@ mod tests {
             authorization_source_document_sha256: sha('b'),
             artifact_qualification_identity_sha256: sha('c'),
             artifact_total_bytes: 42,
-            device_id: "cuda:0".into(),
+            device_id: DEVICE_0.into(),
             device_ordinal: 0,
             compute_capability: [8, 9],
             attention_runtime_identity_sha256: sha('1'),
@@ -3965,7 +3993,7 @@ mod tests {
     fn base_factory() -> FrozenH3FactoryAuthority {
         FrozenH3FactoryAuthority::new_contract_only(H3FactoryAuthorityInput {
             model: contract::FL2VA_COMFY.into(),
-            device_id: "cuda:0".into(),
+            device_id: DEVICE_0.into(),
             device_ordinal: 0,
             compute_capability: (8, 9),
             execution_fingerprint: sha('4'),
@@ -4046,7 +4074,7 @@ mod tests {
             canonical_model: contract::FL2VA_COMFY.into(),
             task: Task::Fl2va,
             mode: Mode::TextToAudioVideo,
-            device_id: "cuda:0".into(),
+            device_id: DEVICE_0.into(),
             device_ordinal: 0,
             compute_capability: (8, 9),
             admitted_available_device_bytes: 10,
@@ -4089,7 +4117,7 @@ mod tests {
             admission_evidence_identity_sha256: sha('3'),
             artifact_qualification_identity_sha256: sha('4'),
             runtime_qualification_identity_sha256: sha('5'),
-            device_id: "cuda:0".into(),
+            device_id: DEVICE_0.into(),
             device_ordinal: 0,
             execution_fingerprint: sha('6'),
             prepared_attempt_identity_sha256: sha('7'),
@@ -4149,7 +4177,7 @@ mod tests {
                 owner_fence: H3PrivateFl2VaOwnerFenceFacts {
                     work_identity_sha256: sha('9'),
                     cancellation_scope_identity_sha256: sha('a'),
-                    device_id: "cuda:0".into(),
+                    device_id: DEVICE_0.into(),
                     device_ordinal: 0,
                     compute_capability: (8, 9),
                     memory_ledger_sequence: 1,
@@ -4184,7 +4212,7 @@ mod tests {
                     authorization_record: missing,
                     runtime_qualification_record: missing,
                 },
-                device_id: "cuda:0",
+                device_id: DEVICE_0,
                 device_ordinal: 0,
                 compute_capability: (8, 9),
                 available_device_bytes: 1,
@@ -4205,7 +4233,7 @@ mod tests {
         let error = authenticate_h3_private_runtime_qualification(
             &path,
             &artifact_report(),
-            "cuda:0",
+            DEVICE_0,
             0,
             (8, 9),
             &sha('1'),
@@ -4226,7 +4254,7 @@ mod tests {
         let authority = authenticate_h3_private_runtime_qualification_for_source(
             &path,
             &artifact_report(),
-            "cuda:0",
+            DEVICE_0,
             0,
             (8, 9),
             &sha('1'),
@@ -4277,7 +4305,7 @@ mod tests {
         let error = authenticate_h3_private_runtime_qualification_for_source(
             &path,
             &artifact_report(),
-            "cuda:1",
+            DEVICE_1,
             1,
             (8, 9),
             &sha('1'),
@@ -4301,9 +4329,9 @@ mod tests {
         let digest = sha256_open_file(&file).unwrap();
         let reviewed_records = [digest.as_str()];
         for (device_id, device_ordinal, compute_capability) in [
-            ("cuda:1", 0, (8, 9)),
-            ("cuda:0", 1, (8, 9)),
-            ("cuda:0", 0, (9, 0)),
+            (DEVICE_1, 0, (8, 9)),
+            (DEVICE_0, 1, (8, 9)),
+            (DEVICE_0, 0, (9, 0)),
         ] {
             let reviewed = open_reviewed_h3_private_runtime_qualification_for_source(
                 &path,

--- a/docs/qualification/minimax-h3-private-runtime-capture.schema.json
+++ b/docs/qualification/minimax-h3-private-runtime-capture.schema.json
@@ -37,7 +37,7 @@
     "authorization_record_sha256": { "$ref": "#/$defs/sha256" },
     "authorization_source_document_sha256": { "$ref": "#/$defs/sha256" },
     "artifact_qualification_identity_sha256": { "$ref": "#/$defs/sha256" },
-    "device_id": { "type": "string", "pattern": "^cuda:[0-9]+$" },
+    "device_id": { "type": "string", "pattern": "^cuda:[0-9a-f]{32}$" },
     "device_ordinal": { "type": "integer", "minimum": 0 },
     "compute_capability": {
       "type": "array",

--- a/docs/qualification/minimax-h3.md
+++ b/docs/qualification/minimax-h3.md
@@ -292,7 +292,7 @@ The capture manifest uses
 [`mold.minimax-h3.private-runtime-bound-capture.v1`](./minimax-h3-private-runtime-capture.schema.json).
 It binds the exact 40-character Mold source SHA, the stable runtime-code
 identity, the measured server executable, artifact/authorization identities,
-`cuda:<ordinal>` route, compute capability, attention
+stable `cuda:<32 lowercase UUID hex>` route plus its process-local ordinal, compute capability, attention
 runtime/kernel/qualification identities, and a sorted list of relative
 evidence paths. The candidate producer requires its own embedded source SHA and
 runtime-code identity to equal the capture and proves that both exact values


### PR DESCRIPTION
## Summary

- bind private H3 runtime captures and reviewed records to the scheduler's UUID-backed stable CUDA identity
- retain the process-local ordinal and compute capability as separate crossed-route authorities
- reject ordinal-shaped, uppercase, truncated, or non-CUDA record identities in Rust and the capture schema

## Why

A memory-gated private smoke reached scheduler admission without loading the model, then exposed an impossible contract: the candidate producer accepted only `cuda:<ordinal>`, while runtime admission compared the record against the stable `cuda:<32 lowercase UUID hex>` route. No candidate could satisfy both sides.

The reviewed runtime allowlist remains empty. This PR does not activate a public or private shipping runtime and does not claim successful model UAT.

## Verification

- Nix: all 6 private runtime candidate tests
- Nix: all 17 private server record/authority tests
- Nix: private-UAT release contract
- Nix: Rust formatting
- JSON schema parse and diff hygiene
- exact-head peer review: approved with no actionable findings
- exact merge-tree against `origin/main`: clean
