### PR TITLE
docs(h3): document compact model downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,10 @@ with prompt, model, seed, and generation metadata.
 - FLUX.1, Flux.2 Klein and Dev, SD 1.5, SDXL, SD 3.5, Z-Image, Qwen-Image,
   Qwen-Image-Edit, Wuerstchen v2, LTX Video, LTX-2 / LTX-2.3, and Wan 2.1/2.2
   text-to-video
+- Upstream-direct downloads for the 42.482 GB compact MiniMax H3 FL2VA and
+  Ref2VA variants. Execution is narrower than acquisition: only the exact
+  reviewed CUDA FL2VA route is available; Ref2VA, Metal, CPU, and hosted H3 are
+  unsupported. See the [H3 model guide](https://utensils.io/mold/models/minimax-h3).
 - Text-to-image, image-to-image, multimodal editing, inpainting, ControlNet,
   LoRA, prompt expansion, and Real-ESRGAN upscaling
 - Text/image-to-video, multi-prompt video chains, one-request continuation of

--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -138,6 +138,7 @@ export default defineConfig({
             { text: 'Qwen-Image', link: '/models/qwen-image' },
             { text: 'LTX-2', link: '/models/ltx2' },
             { text: 'LTX Video', link: '/models/ltx-video' },
+            { text: 'MiniMax H3', link: '/models/minimax-h3' },
             { text: 'Wan Video', link: '/models/wan' },
             { text: 'Upscalers', link: '/models/upscalers' },
           ],

--- a/website/models/index.md
+++ b/website/models/index.md
@@ -160,6 +160,7 @@ for more options.
 | [Qwen-Image-Edit](/models/qwen-image) | Derived from first edit image | Qwen2.5-VL multimodal edit, flow-matching, CFG |
 | [LTX-2](/models/ltx2)                 | 1216x704                      | Gemma 3, joint audio-video transformer         |
 | [LTX Video](/models/ltx-video)        | 768x512                       | T5-XXL, DiT, 3D causal VAE                     |
+| [MiniMax H3](/models/minimax-h3)      | 1344x768                      | Qwen3-VL, joint audio-video DiT, dual VAEs     |
 | [Wan Video](/models/wan)              | 832x480 / 1280x704            | UMT5-XXL, flow DiT, causal 3D VAE, A14B MoE    |
 
 Each family page lists recommended dimensions for non-square aspect ratios.
@@ -175,5 +176,7 @@ All image families and `LTX Video` run on CUDA, Apple Metal, and CPU. LTX-2 /
 LTX-2.3 is performance-qualified on CUDA; its CPU and Apple Metal paths are
 correctness-oriented and can be extremely slow. Metal checkpoint-backed UAT
 remains pending. Wan is CUDA-only for real generation; its CPU path is
-correctness-oriented and Metal is unsupported.
+correctness-oriented and Metal is unsupported. MiniMax H3 compact checkpoints
+are downloadable, but only the exact reviewed FL2VA route can execute on an
+authenticated CUDA server; Ref2VA execution, Metal, and CPU are unsupported.
 :::

--- a/website/models/minimax-h3.md
+++ b/website/models/minimax-h3.md
@@ -1,0 +1,90 @@
+# MiniMax H3
+
+MiniMax H3 is an audio-video generation family from
+[MiniMax](https://huggingface.co/MiniMaxAI/MiniMax-H3). Mold can discover,
+download, verify, repair, inventory, and remove two compact Comfy variants. The
+files are downloaded directly from their pinned Hugging Face repositories;
+Mold does not bundle or mirror the weights.
+
+::: warning Downloadable does not mean runnable
+Both compact variants can be downloaded on any Mold host, but H3 execution is
+not generally enabled in ordinary release builds. FL2VA runs only when a server
+authenticates the exact reviewed CUDA runtime, artifacts, device, and request
+profile described below. Ref2VA, Metal, CPU, broader request shapes, and hosted
+third-party inference are unsupported.
+:::
+
+## Compact variants
+
+| Model                                 | Task                                     | Total pull | Runtime status                       |
+| ------------------------------------- | ---------------------------------------- | ---------: | ------------------------------------ |
+| `minimax-h3-fl2va:comfy-pruned-int8`  | First/last-frame conditioning with audio |  42.482 GB | Exact CUDA route is first-frame-only |
+| `minimax-h3-ref2va:comfy-pruned-int8` | Reference media to video with audio      |  42.482 GB | Downloadable; execution unavailable  |
+
+Pull a variant from the CLI, or install it from **Models → Discover** in Mold
+Studio:
+
+```bash
+mold pull minimax-h3-fl2va:comfy-pruned-int8
+mold pull minimax-h3-ref2va:comfy-pruned-int8
+```
+
+The files are revision-pinned and SHA-256 verified before Mold marks the model
+complete. Raw repository IDs, custom manifests, configured aliases, and live
+catalog recipes cannot substitute for either registered graph.
+
+## Download size and sources
+
+Each compact variant has the same component graph except for its task-specific
+transformer:
+
+| Component                                              |              Bytes |  Decimal size | Upstream source                                                                                                     |
+| ------------------------------------------------------ | -----------------: | ------------: | ------------------------------------------------------------------------------------------------------------------- |
+| Task transformer                                       |     20,970,379,616 |     20.970 GB | [`Comfy-Org/MiniMax-H3`](https://huggingface.co/Comfy-Org/MiniMax-H3/tree/eb8a16107c595128b3a578f82d2ce2f75920c355) |
+| Qwen3-VL NVFP4-AWQ text encoder                        |     15,687,142,551 |     15.687 GB | `Comfy-Org/MiniMax-H3`                                                                                              |
+| FP16 video VAE                                         |      5,207,808,496 |      5.208 GB | `Comfy-Org/MiniMax-H3`                                                                                              |
+| FP32 audio VAE                                         |        605,254,808 |      0.605 GB | `Comfy-Org/MiniMax-H3`                                                                                              |
+| Tokenizer, processor, scheduler, and component configs |         11,504,847 |      0.012 GB | [`MiniMaxAI/MiniMax-H3`](https://huggingface.co/MiniMaxAI/MiniMax-H3/tree/bfc8ed0353f5a9733be73e6b2c98ec0948195b86) |
+| **One complete variant**                               | **42,482,090,318** | **42.482 GB** | Both pinned repositories                                                                                            |
+
+The encoder, VAEs, and common support files are shared between the variants.
+After one complete variant is installed, adding the other downloads its 20.970
+GB transformer and 546-byte task config. Both variants together occupy 63.452
+GB (63,452,470,480 bytes) of model payloads, excluding filesystem and Hugging
+Face cache overhead.
+
+Sizes above are decimal gigabytes (`1 GB = 1,000,000,000 bytes`) and describe
+downloads and disk use, not peak VRAM. They come from Mold's registered,
+full-file manifest identities rather than estimates from repository listings.
+
+## Qualified FL2VA request
+
+Even with all files installed, a request is accepted only when the server
+advertises the authenticated FL2VA capability and the request matches this
+entire envelope:
+
+- CUDA on the exact qualified runtime and device identity; no generic
+  “CUDA-compatible” promise
+- `1344x768`, batch size 1
+- exactly 124 frames at 24 fps
+- exactly 21 terminal-inclusive sampler grid points (20 model evaluations)
+- one required first-frame image and no last-frame endpoint
+- MP4 output with synchronized generated audio
+
+Mold rejects rather than resizing, rerouting, changing steps, dropping the
+source image, or falling back to another backend. The Models screen may still
+show a downloaded H3 checkpoint on a host that cannot execute it; Create and
+request routing remain unavailable unless that host supplies the exact runtime
+capability.
+
+## License and support boundary
+
+H3 uses the
+[MiniMax H3 Community License](https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/bfc8ed0353f5a9733be73e6b2c98ec0948195b86/LICENSE),
+not Mold's MIT license. Review the upstream terms for your intended use. Mold's
+[authorization decision](https://github.com/utensils/mold/blob/main/docs/architecture/minimax-h3-authorization.md)
+permits these upstream-direct compact downloads and local storage; it does not
+permit Mold-hosted weight redistribution or hosted third-party H3 inference.
+
+The official BF16 checkpoints remain hidden qualification references. Their
+much larger artifact graphs are not public Mold download options.

--- a/website/models/z-image.md
+++ b/website/models/z-image.md
@@ -53,6 +53,15 @@ Z-Image uses a Qwen3 text encoder (BF16 or GGUF with auto-fallback). The
 quantized transformer is implemented directly in mold (not upstream candle) due
 to GGUF tensor naming differences.
 
+On CUDA, `MOLD_ZIMAGE_GGUF_DENSE=1` is a diagnostic escape hatch that
+dequantizes a GGUF transformer into a dense BF16 parameter map. This uses about
+12 GB for the map instead of keeping a Q4 checkpoint near its roughly 3.4 GB
+quantized size, and its speed advantage has not been measured. Leave it unset
+for normal use. Do not enable it on Metal: that backend expands the map to about
+24 GB of F32 parameters, and the retained dense route has produced corrupted
+renders there. The setting is read when the runtime is created, so restart Mold
+after changing it; `true` and `yes` are accepted as alternatives to `1`.
+
 Catalog `cv:*` Z-Image checkpoints use the hidden `z-image-te` companion for
 the same Qwen3 text encoder shards, tokenizer, and VAE. When the Civitai
 version publishes its own text-encoder file, that per-version file is downloaded

--- a/website/scripts/verify-docs.mjs
+++ b/website/scripts/verify-docs.mjs
@@ -119,11 +119,35 @@ const requiredVisibleDocs = [
   'guide/video.md',
   'guide/iphone.md',
   'docs/catalog.md',
+  'models/minimax-h3.md',
 ]
 for (const relPath of requiredVisibleDocs) {
   const route = routeForDoc(relPath)
   if (!visibleLinks.has(route)) {
     fail(`published docs page is not linked from sidebar: ${route}`)
+  }
+}
+
+const h3ModelDoc = readRel('models/minimax-h3.md')
+const requiredH3DownloadFacts = [
+  'minimax-h3-fl2va:comfy-pruned-int8',
+  'minimax-h3-ref2va:comfy-pruned-int8',
+  '42,482,090,318',
+  '63,452,470,480',
+  '20,970,379,616',
+  '15,687,142,551',
+  '5,207,808,496',
+  '605,254,808',
+  '11,504,847',
+  '1344x768',
+  'exactly 124 frames at 24 fps',
+  '21 terminal-inclusive sampler grid points',
+  'Ref2VA, Metal, CPU',
+  'Mold-hosted weight redistribution',
+]
+for (const fact of requiredH3DownloadFacts) {
+  if (!h3ModelDoc.includes(fact)) {
+    fail(`MiniMax H3 model guide missing required scoped fact: ${fact}`)
   }
 }
 
@@ -148,6 +172,7 @@ try {
 const ignoredEnvVars = new Set([
   'MOLD_BUILD_DATE',
   'MOLD_GIT_SHA',
+  'MOLD_GIT_SHA_SHORT',
   'MOLD_VERSION',
   // Build-time only — consumed by crates/mold-server/build.rs to stage
   // the web SPA bundle for rust-embed. Not user-facing runtime config.
@@ -160,6 +185,8 @@ const ignoredEnvVars = new Set([
   // is a unit-test fixture path. Surfacing them in docs would invite users
   // to set them in normal operation, which is wrong.
   'MOLD_FLUX2_DUMP_LATENT',
+  'MOLD_DIFF_BF16',
+  'MOLD_DIFF_GGUF',
   'MOLD_NVFP4_PROBE_PATH',
   // Batch transaction subprocess fixtures and their stdout marker. These are
   // compiled only for Rust tests and are not supported runtime configuration.
@@ -176,6 +203,29 @@ const ignoredEnvVars = new Set([
   'MOLD_TEST_INCOMPLETE_PARENT_TAIL',
   'MOLD_TEST_PREDECESSOR_MODE',
   'MOLD_TEST_CLIP_TOKENIZER',
+  // Private H3 qualification/capture inputs. These are feature-gated evidence
+  // authorities, not supported configuration for ordinary Mold releases.
+  'MOLD_H3_AUTHORIZATION_RECORD',
+  'MOLD_H3_CANONICAL_SERVER_FEATURES',
+  'MOLD_H3_HOST_COMPILER_PATH',
+  'MOLD_H3_HOST_COMPILER_VERSION',
+  'MOLD_H3_MODEL',
+  'MOLD_H3_MODELS_ROOT',
+  'MOLD_H3_NATIVE_CUDA_TOOLCHAIN',
+  'MOLD_H3_NVCC_PATH',
+  'MOLD_H3_NVCC_VERSION',
+  'MOLD_H3_PRIVATE_UAT_ROOT',
+  'MOLD_H3_PRIVATE_VAE_ARTIFACT_ROOT',
+  'MOLD_H3_PRIVATE_VAE_STAGING_ROOT',
+  'MOLD_H3_QWEN_HEADER_SHA256',
+  'MOLD_H3_QWEN_NVFP4_PATH',
+  'MOLD_H3_QWEN_PATH',
+  'MOLD_H3_RUNTIME_CODE_IDENTITY_SHA256',
+  'MOLD_H3_RUNTIME_QUALIFICATION_RECORD',
+  'MOLD_H3_STAGING_ROOT',
+  // Internal desktop migration bootstrap override, not a supported end-user
+  // configuration knob.
+  'MOLD_HOME_POINTER_PATH',
   // Execution-plan classifier/error-display sentinels, not real settings.
   'MOLD_NOT_A_SHAPING_VARIABLE',
   'MOLD_X',


### PR DESCRIPTION
## Summary
- add the public MiniMax H3 compact-model guide with exact manifest IDs, sizes, sources, and pull commands
- document the narrow qualified CUDA FL2VA envelope and the still-closed Ref2VA, Metal, CPU, hosted, and redistribution boundaries
- link the guide from README, model index, and navigation
- strengthen docs verification and document the retained Z-Image diagnostic dense mode

## Verification
- mandatory exact-head peer review: approved with no findings
- Nix targeted Prettier check
- full docs verifier
- VitePress build before the identity-preserving rebase
- diff checks

Depends on merged #993.