### PR TITLE
fix(desktop): explain generation blockers and unify source reuse

### DIFF
--- a/desktop/src/components/create/AdvancedSettings.vue
+++ b/desktop/src/components/create/AdvancedSettings.vue
@@ -91,6 +91,7 @@ import { AUDIO_ONLY_PIPELINE, isAudioOnlyPipeline } from "@studio/lib/ltx2Pipeli
 import SourceImageWell from "../generate/SourceImageWell.vue";
 import LoraStack from "../generate/LoraStack.vue";
 import ImagePickerModal from "../generate/ImagePickerModal.vue";
+import { attachPickedVideo } from "../../lib/sourceAttachment";
 import MinimaxH3AuthoringPanel from "@studio/components/MinimaxH3AuthoringPanel.vue";
 import {
   emptyMinimaxH3AuthoringState,
@@ -388,7 +389,7 @@ function removeKeyframe(index: number) {
 async function setSourceVideo(event: Event) {
   const file = (event.target as HTMLInputElement).files?.[0];
   if (!file) return;
-  props.form.sourceVideo = { filename: file.name, base64: await fileToBase64(file) };
+  attachPickedVideo(props.form, { filename: file.name, base64: await fileToBase64(file) });
 }
 function clearSourceVideo() {
   props.form.sourceVideo = null;

--- a/desktop/src/components/create/ComposerCard.test.ts
+++ b/desktop/src/components/create/ComposerCard.test.ts
@@ -31,8 +31,7 @@ function mountComposer(form: GenerateForm, overrides: Record<string, unknown> = 
       expansionHostLabel: null,
       canUndo: false,
       preparedBlocked: false,
-      hasPrepared: false,
-      chainReject: false,
+      disabledReason: null,
       submitting: false,
       buttonLabel: "Generate",
       estimateRequest: null,
@@ -70,14 +69,18 @@ describe("ComposerCard", () => {
     expect(form.prompt).toBe("a lighthouse"); // textarea untouched
   });
 
-  it("disables Generate without a prompt or with a prepared batch", () => {
+  it("disables Generate and displays the shared corrective reason", () => {
     const emptyForm = baseForm();
     emptyForm.prompt = "";
+    const missingPrompt = mountComposer(emptyForm, {
+      disabledReason: "Add a prompt before generating.",
+    });
+    expect(missingPrompt.get("[data-test='generate-button']").attributes("disabled")).toBeDefined();
+    expect(missingPrompt.get("[data-test='action-blocker']").text()).toContain(
+      "Add a prompt before generating.",
+    );
     expect(
-      mountComposer(emptyForm).get("[data-test='generate-button']").attributes("disabled"),
-    ).toBeDefined();
-    expect(
-      mountComposer(baseForm(), { hasPrepared: true })
+      mountComposer(baseForm(), { disabledReason: "Use the reviewed variations panel." })
         .get("[data-test='generate-button']")
         .attributes("disabled"),
     ).toBeDefined();
@@ -97,6 +100,7 @@ describe("ComposerCard", () => {
     const wrapper = mountComposer(baseForm(), {
       effectiveBatchSize: 3,
       expansionRunning: true,
+      disabledReason: "Wait for prompt preparation to finish.",
     });
     expect(wrapper.get("[data-test='generate-button']").attributes("disabled")).toBeDefined();
   });
@@ -104,7 +108,7 @@ describe("ComposerCard", () => {
   it("does not submit from the shortcut while Generate is disabled", async () => {
     const wrapper = mountComposer(baseForm(), {
       effectiveBatchSize: 3,
-      hasPrepared: true,
+      disabledReason: "Use the reviewed variations panel.",
     });
     await wrapper
       .get("textarea[aria-label='Prompt']")

--- a/desktop/src/components/create/ComposerCard.vue
+++ b/desktop/src/components/create/ComposerCard.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, ref, watch } from "vue";
-import { promptPlaceholder, promptRequired } from "@studio/lib/promptRequirement";
-import { minimaxH3AuthoringError } from "@studio/lib/minimaxH3Authoring";
+import { promptPlaceholder } from "@studio/lib/promptRequirement";
 import Keycap from "@ui/components/Keycap.vue";
 import Icon from "@ui/components/Icon.vue";
+import ActionBlocker from "@ui/components/ActionBlocker.vue";
 import ExpandControl from "../generate/ExpandControl.vue";
 import EstimateBadge from "../generate/EstimateBadge.vue";
 import StyleChips from "./StyleChips.vue";
@@ -28,14 +28,12 @@ const props = withDefaults(
     expansionHostLabel: string | null;
     canUndo: boolean;
     preparedBlocked: boolean;
-    hasPrepared: boolean;
-    chainReject: boolean;
+    disabledReason: string | null;
     submitting: boolean;
     buttonLabel: string;
     estimateRequest: GenerateRequest | null;
     estimateTarget: ApiTarget | null;
     preprocessingStatus: string | null;
-    h3RequireFirstFrame?: boolean;
     remixSource?: "original" | "current";
     /** Recent prompts for ↑/↓ history cycling. */
     history?: string[];
@@ -51,28 +49,9 @@ const emit = defineEmits<{
   "update:remixSource": [value: "original" | "current"];
 }>();
 
-// A conditioned LTX-2 render may go out undescribed. The placeholder says so,
-// and Generate must not stay disabled on a request the server would admit —
-// the view's `generate()` early return moves with this in lockstep.
-const promptMissing = computed(() => promptRequired(props.form) && !props.form.prompt.trim());
-const h3AuthoringError = computed(() =>
-  minimaxH3AuthoringError(
-    props.form.family,
-    props.form.model,
-    props.form.h3Authoring,
-    props.h3RequireFirstFrame,
-  ),
-);
-const generateDisabled = computed(
-  () =>
-    promptMissing.value ||
-    !!h3AuthoringError.value ||
-    !props.form.model ||
-    props.chainReject ||
-    props.hasPrepared ||
-    props.expansionRunning ||
-    props.submitting,
-);
+// The view owns one blocker authority shared with its submit guard. This card
+// only renders that reason and reflects it in the button state.
+const generateDisabled = computed(() => props.disabledReason !== null || props.submitting);
 const placeholder = computed(() =>
   promptPlaceholder(props.form, "Describe the image you want to create…"),
 );
@@ -176,10 +155,10 @@ defineExpose({ focus, expand, record });
       />
       <div class="ms-composer__right">
         <span
-          v-if="h3AuthoringError || preprocessingStatus"
+          v-if="preprocessingStatus"
           class="ms-composer__status"
-          :data-test="h3AuthoringError ? 'h3-authoring-error' : 'preprocessing-status'"
-          >{{ h3AuthoringError || preprocessingStatus }}</span
+          data-test="preprocessing-status"
+          >{{ preprocessingStatus }}</span
         >
         <EstimateBadge :request="estimateRequest" :target="estimateTarget" />
         <button
@@ -195,6 +174,7 @@ defineExpose({ focus, expand, record });
         </button>
       </div>
     </div>
+    <ActionBlocker v-if="disabledReason" class="ms-composer__blocker" :reason="disabledReason" />
   </div>
 </template>
 
@@ -249,6 +229,10 @@ defineExpose({ focus, expand, record });
   gap: 12px;
   margin-left: auto;
   min-width: 0;
+}
+.ms-composer__blocker {
+  order: 3;
+  margin-top: 10px;
 }
 .ms-composer__status {
   font-size: 11px;

--- a/desktop/src/components/create/InspectorPanel.vue
+++ b/desktop/src/components/create/InspectorPanel.vue
@@ -649,7 +649,11 @@ function resetSettings() {
           :disabled="activeRecipe?.guidance.mode === 'fixed' || !caps.guidanceAdjustable"
           @update:model-value="form.guidance = $event"
         />
-        <p v-if="!caps.guidanceAdjustable" class="ms-hint" data-test="fixed-guidance-hint">
+        <p
+          v-if="!caps.guidanceAdjustable"
+          class="ms-field__hint ms-field__hint--after-slider"
+          data-test="fixed-guidance-hint"
+        >
           Distilled recipe fixes CFG at 1.0. Choose a Dev checkpoint with Auto or a guided pipeline
           to adjust it.
         </p>
@@ -894,6 +898,9 @@ function resetSettings() {
   color: var(--ink-3);
   margin-top: 6px;
   line-height: 1.4;
+}
+.ms-field__hint--after-slider {
+  margin-top: 12px;
 }
 .ms-field__error {
   font-size: 11px;

--- a/desktop/src/components/create/SequenceComposer.vue
+++ b/desktop/src/components/create/SequenceComposer.vue
@@ -30,6 +30,7 @@ import {
   stageInvalidation,
 } from "@studio/lib/sequenceForm";
 import { promptOptional } from "@studio/lib/promptRequirement";
+import ActionBlocker from "@ui/components/ActionBlocker.vue";
 import { parseChainScript, serializeChainScript } from "@studio/lib/chainToml";
 import type { ChainLimits } from "@studio/lib/api/chainTypes";
 import { sequenceParams } from "../../lib/sequenceParams";
@@ -616,14 +617,14 @@ async function copyToml() {
         Clear sequence
       </button>
 
-      <span
+      <ActionBlocker
         v-if="disabledReason"
         data-test="sequence-validation"
-        role="alert"
-        class="ms-seqbench__note ms-seqbench__note--blocked"
-      >
-        {{ disabledReason }}
-      </span>
+        class="ms-seqbench__blocker"
+        compact
+        :reason="disabledReason"
+        title="Before you generate"
+      />
       <span v-else data-test="sequence-fit" class="ms-seqbench__note">{{ fitNote }}</span>
 
       <div class="ms-seqbench__spacer" />
@@ -881,8 +882,8 @@ async function copyToml() {
   font-size: 10px;
   color: var(--halide);
 }
-.ms-seqbench__note--blocked {
-  color: var(--stop);
+.ms-seqbench__blocker {
+  max-width: min(380px, 38vw);
 }
 .ms-seqbench__generate {
   height: 32px;

--- a/desktop/src/components/gallery/Lightbox.vue
+++ b/desktop/src/components/gallery/Lightbox.vue
@@ -520,7 +520,9 @@ async function performVideoExport(options: VideoExportOptions) {
         <div class="mt-2.5 flex gap-2.5">
           <button
             type="button"
+            data-test="lightbox-use-source"
             class="border-ce h-10 flex-1 rounded-control border text-body font-semibold text-ink-2 transition-colors duration-100 hover:text-ink"
+            :disabled="audio"
             @click="emit('useSource')"
           >
             Use as source

--- a/desktop/src/components/generate/ImagePickerModal.test.ts
+++ b/desktop/src/components/generate/ImagePickerModal.test.ts
@@ -89,12 +89,12 @@ describe("ImagePickerModal", () => {
     pinia = createPinia();
     setActivePinia(pinia);
     apiJson.mockReset();
-    apiFetch.mockReset().mockResolvedValue({
-      blob: () => Promise.resolve(new Blob(["x"], { type: "image/png" })),
-    });
-    apiFetchTo.mockReset().mockResolvedValue({
-      blob: () => Promise.resolve(new Blob(["y"], { type: "image/jpeg" })),
-    });
+    apiFetch
+      .mockReset()
+      .mockResolvedValue(new Response(new Blob(["x"], { type: "image/png" }), { status: 200 }));
+    apiFetchTo
+      .mockReset()
+      .mockResolvedValue(new Response(new Blob(["y"], { type: "image/jpeg" }), { status: 200 }));
   });
 
   afterEach(() => {

--- a/desktop/src/components/generate/ImagePickerModal.vue
+++ b/desktop/src/components/generate/ImagePickerModal.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import AuthedMedia from "../gallery/AuthedMedia.vue";
-import { apiFetch, apiFetchTo } from "../../lib/api/client";
-import { galleryMediaPath, localMediaPath, mediaPath } from "../../lib/gallery/media";
-import { blobToBase64, fileToBase64, isStillImageFile } from "../../lib/image";
+import { galleryMediaPath } from "../../lib/gallery/media";
+import { readGalleryMediaBase64 } from "../../lib/gallery/sourceMedia";
+import { fileToBase64, isStillImageFile } from "../../lib/image";
 import { inTauri, ipc } from "../../lib/ipc";
 import type { PickedImage } from "../../lib/generateForm";
 import { useGalleryStore, type MergedPrint } from "../../stores/gallery";
@@ -132,23 +132,9 @@ async function chooseFiles() {
 
 async function pickFromGallery(entry: MergedPrint) {
   try {
-    // Bytes come from the print's own origin: a host print is fetched with
-    // that host's auth, and a This-Mac IPC print (local engine down or
-    // mid-restart) over the mold-local:// protocol — the same source its
-    // thumbnail rendered from, so a pick can't fail where a preview worked.
-    let res: Response;
-    if (gallery.mediaSourceOf(entry.sourceKey) === "local") {
-      res = await fetch(localMediaPath(entry.item.filename));
-      // fetch() resolves on 404/500 — the host branch throws via apiFetchTo,
-      // so match it rather than base64-encoding an error body.
-      if (!res.ok) throw new Error(`Could not read ${entry.item.filename} (HTTP ${res.status})`);
-    } else {
-      const path = mediaPath(entry.item.filename);
-      const target = gallery.targetOf(entry.sourceKey);
-      res = await (target ? apiFetchTo(target, path) : apiFetch(path));
-    }
-    const blob = await res.blob();
-    emit("pick", [{ filename: entry.item.filename, base64: await blobToBase64(blob) }]);
+    emit("pick", [
+      { filename: entry.item.filename, base64: await readGalleryMediaBase64(entry, gallery) },
+    ]);
     emit("close");
   } catch (e) {
     error.value = e instanceof Error ? e.message : String(e);

--- a/desktop/src/components/generate/SourceImageWell.vue
+++ b/desktop/src/components/generate/SourceImageWell.vue
@@ -18,6 +18,7 @@ import { useHostModelsStore } from "../../stores/hostModels";
 import { useHostsStore } from "../../stores/hosts";
 import { useModelStore } from "../../stores/models";
 import { useToastStore } from "../../stores/toasts";
+import { attachPickedImage } from "../../lib/sourceAttachment";
 import ImagePickerModal from "./ImagePickerModal.vue";
 import MaskEditorModal from "./MaskEditorModal.vue";
 
@@ -52,12 +53,7 @@ const maskOpen = ref(false);
 
 function onSourcePicked(picked: PickedImage[]) {
   const first = picked[0];
-  if (first) {
-    props.form.sourceImage = first.base64;
-    // Provenance label for Reuse-settings source restore.
-    props.form.sourceImageName = first.filename || null;
-    props.form.sourceFit = { mode: "lanczos-resize" };
-  }
+  if (first) attachPickedImage(props.form, first);
 }
 function onEndFramePicked(picked: PickedImage[]) {
   const first = picked[0];

--- a/desktop/src/lib/gallery/sourceMedia.test.ts
+++ b/desktop/src/lib/gallery/sourceMedia.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { readGalleryMediaBase64 } from "./sourceMedia";
+import type { GalleryMediaAuthority } from "./sourceMedia";
+import type { MergedPrint } from "../../stores/gallery";
+
+const { apiFetch, apiFetchTo } = vi.hoisted(() => ({
+  apiFetch: vi.fn(),
+  apiFetchTo: vi.fn(),
+}));
+vi.mock("../api/client", () => ({ apiFetch, apiFetchTo }));
+
+const entry = {
+  sourceKey: "local",
+  hostLabel: "This Mac",
+  availableOn: [],
+  item: {
+    filename: "source.png",
+    timestamp: 1,
+    metadata: {
+      prompt: "",
+      model: "flux",
+      seed: 1,
+      steps: 1,
+      guidance: 1,
+      width: 64,
+      height: 64,
+      version: "test",
+    },
+  },
+} as MergedPrint;
+
+describe("gallery source-media authority", () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it("reads native-only This-Mac media through mold-local without HTTP fallback", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(new Uint8Array([65, 66, 67]), { status: 200 }));
+    const gallery: GalleryMediaAuthority = {
+      mediaSourceOf: () => "local",
+      targetOf: () => null,
+    };
+
+    await expect(readGalleryMediaBase64(entry, gallery)).resolves.toBe("QUJD");
+    expect(fetchMock).toHaveBeenCalledWith("mold-local://localhost/source.png");
+    expect(apiFetch).not.toHaveBeenCalled();
+    expect(apiFetchTo).not.toHaveBeenCalled();
+  });
+
+  it("reads a host row from its exact authenticated origin", async () => {
+    apiFetchTo.mockResolvedValue(new Response(new Uint8Array([65, 66, 67]), { status: 200 }));
+    const target = { baseUrl: "http://plato:7680", apiKey: "secret" };
+    const gallery: GalleryMediaAuthority = {
+      mediaSourceOf: () => "host",
+      targetOf: () => target,
+    };
+
+    await expect(
+      readGalleryMediaBase64({ ...entry, sourceKey: "plato-7680" }, gallery),
+    ).resolves.toBe("QUJD");
+    expect(apiFetchTo).toHaveBeenCalledWith(target, "/api/gallery/image/source.png");
+  });
+
+  it("rejects an error body before it can become invalid source base64", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("missing", { status: 404 }));
+    const gallery: GalleryMediaAuthority = {
+      mediaSourceOf: () => "local",
+      targetOf: () => null,
+    };
+
+    await expect(readGalleryMediaBase64(entry, gallery)).rejects.toThrow(
+      "Could not read source.png (HTTP 404)",
+    );
+  });
+});

--- a/desktop/src/lib/gallery/sourceMedia.ts
+++ b/desktop/src/lib/gallery/sourceMedia.ts
@@ -1,0 +1,44 @@
+import { blobToBase64 } from "@studio/lib/base64";
+import { apiFetch, apiFetchTo } from "../api/client";
+import { localMediaPath, mediaPath } from "./media";
+import type { MergedPrint } from "../../stores/gallery";
+
+export interface GalleryMediaAuthority {
+  mediaSourceOf(sourceKey: string): "host" | "local";
+  targetOf(sourceKey: string): { baseUrl: string; apiKey: string | null } | null;
+}
+
+/**
+ * Read the original bytes behind one unified-gallery row.
+ *
+ * This is the authority boundary shared by the gallery picker, Library
+ * actions, and Lightbox actions. Host-backed rows use the exact origin's
+ * authenticated API target. Native-only This-Mac rows use the restricted
+ * `mold-local://` protocol that already rendered their preview. Never fall
+ * through from a native row to the primary HTTP connection: that can return
+ * an error body which only fails later as an undecodable "image".
+ */
+export async function readGalleryMediaBlob(
+  entry: MergedPrint,
+  gallery: GalleryMediaAuthority,
+): Promise<Blob> {
+  let response: Response;
+  if (gallery.mediaSourceOf(entry.sourceKey) === "local") {
+    response = await fetch(localMediaPath(entry.item.filename));
+  } else {
+    const path = mediaPath(entry.item.filename);
+    const target = gallery.targetOf(entry.sourceKey);
+    response = await (target ? apiFetchTo(target, path) : apiFetch(path));
+  }
+  if (!response.ok) {
+    throw new Error(`Could not read ${entry.item.filename} (HTTP ${response.status})`);
+  }
+  return response.blob();
+}
+
+export async function readGalleryMediaBase64(
+  entry: MergedPrint,
+  gallery: GalleryMediaAuthority,
+): Promise<string> {
+  return blobToBase64(await readGalleryMediaBlob(entry, gallery));
+}

--- a/desktop/src/lib/sourceAttachment.test.ts
+++ b/desktop/src/lib/sourceAttachment.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { newGenerateForm } from "./generateForm";
+import { attachPickedImage, attachPickedVideo } from "./sourceAttachment";
+
+describe("source attachment", () => {
+  it("applies one image policy for uploads and gallery actions", () => {
+    const form = newGenerateForm();
+    form.sourceFit = { mode: "pad-repaint" };
+    attachPickedImage(form, { filename: "source.png", base64: "QUJD" });
+    expect(form.sourceImage).toBe("QUJD");
+    expect(form.sourceImageName).toBe("source.png");
+    expect(form.sourceFit).toEqual({ mode: "lanczos-resize" });
+  });
+
+  it("attaches a gallery video to the existing LTX source-video field", () => {
+    const form = newGenerateForm();
+    attachPickedVideo(form, { filename: "clip.mp4", base64: "QUJD" });
+    expect(form.sourceVideo).toEqual({ filename: "clip.mp4", base64: "QUJD" });
+  });
+});

--- a/desktop/src/lib/sourceAttachment.ts
+++ b/desktop/src/lib/sourceAttachment.ts
@@ -1,0 +1,13 @@
+import type { GenerateForm, PickedImage } from "./generateForm";
+
+/** One source-attachment policy shared by uploads, gallery picks, and Library. */
+export function attachPickedImage(form: GenerateForm, picked: PickedImage): void {
+  form.sourceImage = picked.base64;
+  form.sourceImageName = picked.filename || null;
+  form.sourceFit = { mode: "lanczos-resize" };
+}
+
+/** Video outputs become LTX source-video bytes, including cross-host reuse. */
+export function attachPickedVideo(form: GenerateForm, picked: PickedImage): void {
+  form.sourceVideo = picked;
+}

--- a/desktop/src/views/GenerateView.layout.test.ts
+++ b/desktop/src/views/GenerateView.layout.test.ts
@@ -82,29 +82,21 @@ describe("GenerateView layout", () => {
     expect(viewSource).toContain("Describe an image below, pick a look, and press Generate.");
   });
 
-  // A conditioned LTX-2 render may go out undescribed. The disabled Generate
-  // button and `generate()`'s silent early return are the two halves of one
-  // rule; if they ever disagree the enabled control becomes the text-only
-  // dead end the prepared-expansion invariant forbids. Both must read the
-  // shared predicate, and neither may keep a bare `!form.prompt.trim()`.
-  it("gates Generate on the shared prompt-requirement predicate in lockstep", () => {
-    expect(composerCardSource).toContain('from "@studio/lib/promptRequirement"');
-    expect(composerCardSource).toMatch(
-      /const promptMissing = computed\(\s*\(\) => promptRequired\(props\.form\) && !props\.form\.prompt\.trim\(\),?\s*\);/s,
-    );
+  // A conditioned LTX-2 render may go out undescribed. The view owns the
+  // shared blocker authority; the composer only renders and reflects it.
+  it("gates Generate on one visible blocker authority", () => {
     expect(tagFor(composerCardSource, "generate-button")).toContain(':disabled="generateDisabled"');
-    expect(composerCardSource).toMatch(
-      /const generateDisabled = computed\([\s\S]*?promptMissing\.value/,
-    );
+    expect(composerCardSource).toContain("props.disabledReason !== null");
+    expect(composerCardSource).toContain('<ActionBlocker v-if="disabledReason"');
     expect(composerCardSource).not.toContain("!form.prompt.trim() || !form.model");
 
     expect(viewSource).toContain('from "@studio/lib/promptRequirement"');
     expect(viewSource).toMatch(
       /const promptMissing = computed\(\(\) => promptRequired\(form\) && !form\.prompt\.trim\(\)\);/,
     );
-    expect(viewSource).toMatch(
-      /async function generate\(\) \{\s*if \(\s*promptMissing\.value \|\|/s,
-    );
+    expect(viewSource).toContain("const generationInputBlockerReason = computed");
+    expect(viewSource).toContain("if (generationInputBlockerReason.value ||");
+    expect(viewSource).toContain(':disabled-reason="composerBlockerReason"');
   });
 
   it("softens the blank-canvas guidance when the prompt is optional", () => {

--- a/desktop/src/views/GenerateView.persistence.test.ts
+++ b/desktop/src/views/GenerateView.persistence.test.ts
@@ -7,6 +7,7 @@ import { useModelStore } from "../stores/models";
 import { useConnectionStore } from "../stores/connection";
 import { useHostModelsStore } from "../stores/hostModels";
 import { useHostsStore } from "../stores/hosts";
+import { useGenerationStore } from "../stores/generation";
 import type { ModelEntry } from "../lib/api/types";
 
 vi.mock("vue-router", () => ({
@@ -42,7 +43,14 @@ function mountView() {
   return mount(GenerateView, {
     shallow: true,
     attachTo: document.body,
-    global: { stubs: { ComposerCard: false, InspectorPanel: false, ModelPicker: false } },
+    global: {
+      stubs: {
+        ComposerCard: false,
+        InspectorPanel: false,
+        ModelPicker: false,
+        ActionBlocker: false,
+      },
+    },
   });
 }
 
@@ -132,6 +140,44 @@ describe("GenerateView form persistence", () => {
     const wrapper = mountView();
     await flushPromises();
 
+    expect(wrapper.get('[data-test="generate-button"]').attributes("disabled")).toBeUndefined();
+  });
+
+  it("shows the exact LTX blocker and enables a valid conditioned request", async () => {
+    const ltx = {
+      ...model,
+      name: "ltx-2.3-22b-distilled:fp8",
+      family: "ltx2",
+      default_frames: 97,
+      default_fps: 24,
+      dimension_alignment: 32,
+    } as ModelEntry;
+    useModelStore().all = [ltx];
+    const form = useGenerateFormStore().form;
+    form.model = ltx.name;
+    form.family = ltx.family;
+    form.prompt = "";
+    form.width = 768;
+    form.height = 512;
+    form.frames = 97;
+    form.fps = 24;
+    form.sourceVideo = { filename: "guide.mp4", base64: "" };
+    const submit = vi.spyOn(useGenerationStore(), "submitBatch");
+
+    const wrapper = mountView();
+    await flushPromises();
+
+    expect(wrapper.get('[data-test="action-blocker"]').text()).toContain(
+      "Source video cannot be empty.",
+    );
+    expect(wrapper.get('[data-test="generate-button"]').attributes("disabled")).toBeDefined();
+    await wrapper.get('[data-test="generate-button"]').trigger("click");
+    expect(submit).not.toHaveBeenCalled();
+
+    form.sourceVideo = { filename: "guide.mp4", base64: "video-bytes" };
+    await flushPromises();
+
+    expect(wrapper.find('[data-test="action-blocker"]').exists()).toBe(false);
     expect(wrapper.get('[data-test="generate-button"]').attributes("disabled")).toBeUndefined();
   });
 

--- a/desktop/src/views/GenerateView.vue
+++ b/desktop/src/views/GenerateView.vue
@@ -548,17 +548,17 @@ const formValidationError = computed(
     advancedVideoValidationError(form) ??
     wanRecipeValidationError(form),
 );
-/** Over-budget video frames on a non-chainable model would fail server-side —
- *  the drawer shows the reason under Frames; this blocks the submit. */
-const chainReject = computed(() => {
-  if (formValidationError.value) return true;
-  if (!caps.value.supportsVideo) return false;
+/** Exact submit blocker for request-shape and automatic-chain validation. */
+const chainValidationError = computed<string | null>(() => {
+  if (formValidationError.value) return formValidationError.value;
+  if (!caps.value.supportsVideo) return null;
   const request = buildRequest(form);
   const decision = decideGenerateRequestRouting(request, form.family);
-  return (
-    decision.kind === "reject" ||
-    (decision.kind === "chain" && unsupportedAutoChainFields(buildRequest(form)).length > 0)
-  );
+  if (decision.kind === "reject") return decision.reason;
+  const unsupported = decision.kind === "chain" ? unsupportedAutoChainFields(request) : [];
+  return unsupported.length
+    ? "This long video uses options automatic sequencing cannot preserve. Reduce Duration or remove the incompatible Advanced options."
+    : null;
 });
 const installedModels = computed(() =>
   mergeInstalledModels(
@@ -2380,6 +2380,31 @@ const h3AuthoringError = computed(() =>
   minimaxH3AuthoringError(form.family, form.model, form.h3Authoring, h3RequireFirstFrame.value),
 );
 
+/**
+ * One visible blocker authority drives both the button and the submit guard.
+ * Keep transient in-flight states on the button label; this list is only for
+ * conditions the user can correct or explicitly resolve.
+ */
+const generationInputBlockerReason = computed<string | null>(() => {
+  if (promptMissing.value) return "Add a prompt before generating.";
+  if (h3AuthoringError.value) return h3AuthoringError.value;
+  if (!form.model) return "Choose an installed model before generating.";
+  if (chainValidationError.value) return chainValidationError.value;
+  if (quickStaleReasons.value.length > 0) {
+    return "The prepared rewrite no longer matches this model or machine. Choose a recovery action above.";
+  }
+  if (expansionRunning.value) return "Wait for prompt preparation to finish.";
+  return null;
+});
+
+const composerBlockerReason = computed<string | null>(() => {
+  if (generationInputBlockerReason.value) return generationInputBlockerReason.value;
+  if (preparedBatch.value) {
+    return "Use the reviewed variations panel to generate this prepared batch, or discard it to return to one-shot generation.";
+  }
+  return null;
+});
+
 const emptyCanvasGuidance = computed(() =>
   promptRequired(form)
     ? "Describe an image below, pick a look, and press Generate. Everything runs on your own machine."
@@ -2387,15 +2412,7 @@ const emptyCanvasGuidance = computed(() =>
 );
 
 async function generate() {
-  if (
-    promptMissing.value ||
-    h3AuthoringError.value ||
-    !form.model ||
-    chainReject.value ||
-    expansionRunning.value ||
-    preparedSubmitting.value ||
-    submissionPlanning.value
-  )
+  if (generationInputBlockerReason.value || preparedSubmitting.value || submissionPlanning.value)
     return;
   const prepared = preparedBatch.value;
   if (
@@ -3510,14 +3527,12 @@ onBeforeUnmount(() => {
             :expansion-host-label="expansionHostLabel"
             :can-undo="quickExpansionOriginal !== null"
             :prepared-blocked="!!preparedBatch && effectiveBatchSize === 1"
-            :has-prepared="!!preparedBatch"
-            :chain-reject="chainReject"
+            :disabled-reason="composerBlockerReason"
             :submitting="submissionPlanning"
             :button-label="buttonLabel"
             :estimate-request="estimateRequest"
             :estimate-target="estimateTarget"
             :preprocessing-status="preprocessingStatus"
-            :h3-require-first-frame="h3RequireFirstFrame"
             :history="promptHistory"
             :remix-source="remixSource"
             @generate="generate"

--- a/desktop/src/views/LibraryView.test.ts
+++ b/desktop/src/views/LibraryView.test.ts
@@ -136,8 +136,11 @@ async function mountView(
       loaded: true,
     };
   }
-  localGalleryList.mockResolvedValue({ images: [...prints], target: null });
   seed?.(gallery);
+  localGalleryList.mockResolvedValue({
+    images: [...(gallery.buckets.local?.items ?? prints)],
+    target: null,
+  });
 
   const wrapper = mount(LibraryView, {
     global: {
@@ -446,6 +449,63 @@ describe("LibraryView delete keyboard handling", () => {
     const event = new KeyboardEvent("keydown", { key: "Backspace", cancelable: true });
     expect(search.dispatchEvent(event)).toBe(true);
     expect(localGalleryDelete).not.toHaveBeenCalled();
+    wrapper.unmount();
+  });
+});
+
+describe("LibraryView source reuse", () => {
+  it("uses the same native-authority loader from the Lightbox as the gallery picker", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(new Uint8Array([65, 66, 67]), {
+        status: 200,
+        headers: { "Content-Type": "image/png" },
+      }),
+    );
+    const { wrapper, router } = await mountView();
+    const tile = wrapper.findAll("button").find((button) => button.text().includes("S 1"));
+    expect(tile).toBeDefined();
+    await tile!.trigger("dblclick");
+    await wrapper.get("[data-test='lightbox-use-source']").trigger("click");
+    await flushPromises();
+
+    expect(fetchMock).toHaveBeenCalledWith("mold-local://localhost/first.png");
+    expect(useGenerateFormStore().form.sourceImage).toBe("QUJD");
+    expect(useGenerateFormStore().form.sourceFit).toEqual({ mode: "lanczos-resize" });
+    expect(router.currentRoute.value.path).toBe("/create");
+    wrapper.unmount();
+  });
+
+  it("enables Use as source for video and attaches it to the LTX source-video field", async () => {
+    const video = {
+      ...prints[0]!,
+      filename: "clip.mp4",
+      format: "mp4",
+      metadata: { ...prints[0]!.metadata, model: "ltx-2.3-22b-dev:fp8" },
+    } as GalleryImage;
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(new Uint8Array([65, 66, 67]), {
+        status: 200,
+        headers: { "Content-Type": "video/mp4" },
+      }),
+    );
+    const { wrapper, router } = await mountView(undefined, (gallery) => {
+      gallery.buckets.local!.items = [video];
+    });
+    const tile = wrapper.get(".ms-lib-tile");
+    await tile.trigger("contextmenu");
+    const source = useContextMenuStore().entries.find(
+      (entry) => !("separator" in entry) && entry.label === "Use as source",
+    );
+    expect(source).toMatchObject({ disabled: false });
+    useContextMenuStore().activate(source!);
+    await flushPromises();
+
+    expect(useGenerateFormStore().form.sourceVideo).toEqual({
+      filename: "clip.mp4",
+      base64: "QUJD",
+    });
+    expect(router.currentRoute.value.path).toBe("/create");
+    expect(useToastStore().items.at(-1)?.message).toBe("Loaded as source video");
     wrapper.unmount();
   });
 });

--- a/desktop/src/views/LibraryView.vue
+++ b/desktop/src/views/LibraryView.vue
@@ -19,7 +19,7 @@ import HistoryDrawer from "../components/library/HistoryDrawer.vue";
 import EmptyState from "../components/shell/EmptyState.vue";
 import HostFilterChips from "../components/shell/HostFilterChips.vue";
 import { layoutJustifiedRows } from "../lib/gallery/layout";
-import { galleryMediaPath, isAudioItem, isVideoItem, mediaPath } from "../lib/gallery/media";
+import { galleryMediaPath, isAudioItem, isVideoItem } from "../lib/gallery/media";
 import { applySelectionClick } from "../lib/gallery/selection";
 import {
   planSequenceReuse,
@@ -27,7 +27,7 @@ import {
   sequenceGoneMessage,
   sequenceHostUnreachableMessage,
 } from "@studio/lib/sequenceReuse";
-import { ApiError, apiFetch, apiFetchTo, type ApiTarget } from "../lib/api/client";
+import { ApiError, apiFetchTo, type ApiTarget } from "../lib/api/client";
 import {
   useGalleryStore,
   type GalleryKindFilter,
@@ -50,6 +50,8 @@ import { modelDisplayNameForId } from "../lib/models";
 import type { GalleryImage } from "../lib/api/types";
 import { isUpscaledImage } from "../lib/gallery/upscaled";
 import { imageDimensionsFromBase64 } from "@studio/lib/imageDimensions";
+import { readGalleryMediaBase64, readGalleryMediaBlob } from "../lib/gallery/sourceMedia";
+import { attachPickedImage, attachPickedVideo } from "../lib/sourceAttachment";
 import {
   appendMinimaxH3GalleryImageReference,
   isMinimaxH3Identity,
@@ -119,13 +121,11 @@ const canSaveLocally = (entry: MergedPrint) =>
 
 /** Authed source bytes for a host-gallery item (origin-aware). */
 async function fetchItemBlob(entry: MergedPrint): Promise<Blob> {
-  const path = mediaPath(entry.item.filename);
-  const target = targetFor(entry);
-  return (target ? apiFetchTo(target, path) : apiFetch(path)).then((r) => r.blob());
+  return readGalleryMediaBlob(entry, gallery);
 }
 
 async function fetchItemBase64(entry: MergedPrint): Promise<string> {
-  return blobToBase64(await fetchItemBlob(entry));
+  return readGalleryMediaBase64(entry, gallery);
 }
 
 async function saveToThisMac(entry: MergedPrint) {
@@ -319,7 +319,7 @@ function tileMenu(entry: MergedPrint): MenuEntry[] {
     },
     {
       label: "Use as source",
-      disabled: isVideo(item),
+      disabled: isAudio(item),
       action: () => void useAsSource(entry),
     },
     {
@@ -715,6 +715,13 @@ async function useAsSource(entry: MergedPrint) {
     const blob = await fetchItemBlob(entry);
     const base64 = await blobToBase64(blob);
     const form = generateForm.form;
+    if (isVideo(entry.item)) {
+      attachPickedVideo(form, { filename: entry.item.filename, base64 });
+      lightboxOpen.value = false;
+      toasts.push("Loaded as source video");
+      void router.push("/create");
+      return;
+    }
     const h3Task = minimaxH3TaskForModel(form.model);
     if (h3Task) {
       const dimensions = imageDimensionsFromBase64(base64) ?? {
@@ -739,9 +746,7 @@ async function useAsSource(entry: MergedPrint) {
         "Choose an explicit MiniMax H3 FL2VA or Ref2VA model before adding a source.",
       );
     } else {
-      form.sourceImage = base64;
-      form.sourceImageName = entry.item.filename;
-      form.sourceFit = { mode: "lanczos-resize" };
+      attachPickedImage(form, { filename: entry.item.filename, base64 });
     }
     lightboxOpen.value = false;
     toasts.push(h3Task === "ref2va" ? "Added as ordered reference" : "Loaded as source");

--- a/ui/components/ActionBlocker.test.ts
+++ b/ui/components/ActionBlocker.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { mount } from "@vue/test-utils";
+import ActionBlocker from "./ActionBlocker.vue";
+
+describe("ActionBlocker", () => {
+  it("names the blocked action and its correction accessibly", () => {
+    const wrapper = mount(ActionBlocker, {
+      props: { title: "Before you generate", reason: "Choose a model first." },
+    });
+    expect(wrapper.get("[role='status']").text()).toContain(
+      "Before you generate",
+    );
+    expect(wrapper.text()).toContain("Choose a model first.");
+  });
+});

--- a/ui/components/ActionBlocker.vue
+++ b/ui/components/ActionBlocker.vue
@@ -1,0 +1,78 @@
+<script setup lang="ts">
+withDefaults(
+  defineProps<{
+    reason: string;
+    title?: string;
+    compact?: boolean;
+  }>(),
+  { title: "Before you generate", compact: false },
+);
+</script>
+
+<template>
+  <div
+    class="ms-action-blocker"
+    :class="{ 'ms-action-blocker--compact': compact }"
+    role="status"
+    data-test="action-blocker"
+  >
+    <span class="ms-action-blocker__mark" aria-hidden="true">!</span>
+    <span class="ms-action-blocker__copy">
+      <strong>{{ title }}</strong>
+      <span>{{ reason }}</span>
+    </span>
+  </div>
+</template>
+
+<style scoped>
+.ms-action-blocker {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  padding: 9px 11px;
+  border: 1px solid color-mix(in srgb, var(--stop) 28%, var(--edge));
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--stop) 7%, var(--bath));
+  color: var(--ink-2);
+}
+.ms-action-blocker__mark {
+  display: grid;
+  flex: 0 0 22px;
+  width: 22px;
+  height: 22px;
+  place-items: center;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--stop) 14%, transparent);
+  color: var(--stop);
+  font-family: var(--f-mono);
+  font-size: 12px;
+  font-weight: 700;
+}
+.ms-action-blocker__copy {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 3px 7px;
+  font-size: 11px;
+  line-height: 1.35;
+}
+.ms-action-blocker__copy strong {
+  flex: 0 0 auto;
+  color: var(--ink);
+  font-weight: 700;
+}
+.ms-action-blocker__copy span {
+  min-width: 0;
+}
+.ms-action-blocker--compact {
+  padding: 6px 9px;
+}
+.ms-action-blocker--compact .ms-action-blocker__mark {
+  flex-basis: 18px;
+  width: 18px;
+  height: 18px;
+  font-size: 10px;
+}
+</style>


### PR DESCRIPTION
## Summary
- show one consistent corrective UI when Generate or sequence generation is disabled
- unify Library, Lightbox, and gallery-picker media loading behind the exact local or authenticated remote authority
- enable image and video Use as source, carrying local bytes in the generation request for remote targets
- improve spacing below the fixed LTX prompt-strength slider

## Root cause
Library and Lightbox had a separate media-fetch path that fell through to the primary HTTP server for native-only This Mac rows. That could encode an error response as source media and later fail image decoding. Generate also combined several boolean gates with silent early returns, so valid LTX values could still appear disabled without exposing the stale or hidden condition.

## Verification
- `cd desktop && bun run test` (3352 passed)
- `cd desktop && bun run build`
- focused mounted LTX blocker/source-video regression coverage
- peer-agent review completed; its integration-test finding was addressed

## Live QA note
The Vite server returned HTTP 200, but the Codex in-app browser remained bound to a stale failed port and blocked navigation to the corrected port by URL policy. Automated component, mounted-view, full-suite, and production-build checks are green.