### PR TITLE
fix(studio): honor model generation controls

### DIFF
--- a/desktop/src/components/create/InspectorPanel.vue
+++ b/desktop/src/components/create/InspectorPanel.vue
@@ -44,6 +44,7 @@ import {
   aspectIdFor,
   closestResolutionPreset,
   megapixelLabel,
+  presetsForAspectGroup,
   presetsForModel,
   presetsNearRatio,
 } from "../../lib/resolutions";
@@ -380,12 +381,15 @@ const shapeId = computed(() =>
         : aspectIdFor(props.form.width, props.form.height)) ?? ""),
 );
 const resolutionRatio = computed(() => props.form.width / props.form.height);
-const resolutionPresets = computed(() =>
-  presetsNearRatio(
-    presetsForModel(selectedModel.value ?? props.form.family, props.form.pipeline),
-    resolutionRatio.value,
-  ),
-);
+const resolutionPresets = computed(() => {
+  const exactGroup = presetsForAspectGroup(selectedModel.value, props.form.pipeline, shapeId.value);
+  return exactGroup.length > 0
+    ? exactGroup
+    : presetsNearRatio(
+        presetsForModel(selectedModel.value ?? props.form.family, props.form.pipeline),
+        resolutionRatio.value,
+      );
+});
 const resolutionOptions = computed(() => {
   const presets = resolutionPresets.value.map((preset, index, all) => ({
     mp: (preset.width * preset.height) / 1_000_000,
@@ -448,11 +452,14 @@ function onShape(id: string) {
   }
   const aspect = shapeOptions.value.find((option) => option.id === id);
   if (!aspect) return;
+  const exactGroup = presetsForAspectGroup(selectedModel.value, props.form.pipeline, id);
   const preset = closestResolutionPreset(
-    presetsNearRatio(
-      presetsForModel(selectedModel.value ?? props.form.family, props.form.pipeline),
-      aspect.ratio,
-    ),
+    exactGroup.length > 0
+      ? exactGroup
+      : presetsNearRatio(
+          presetsForModel(selectedModel.value ?? props.form.family, props.form.pipeline),
+          aspect.ratio,
+        ),
     props.form.width,
     props.form.height,
   );

--- a/desktop/src/components/create/SequenceComposer.vue
+++ b/desktop/src/components/create/SequenceComposer.vue
@@ -17,6 +17,7 @@ import {
   formatFrameDuration,
   sequenceDuration,
   sequenceFrameOptions,
+  sequenceFrameStep,
   sequenceMotionTailFrames,
   sequenceValidation,
   transitionLabel,
@@ -179,6 +180,9 @@ const validation = computed(() =>
   sequenceValidation(stages.value, {
     maxStages: maxStages.value,
     maxTotalFrames: props.chainLimits?.max_total_frames ?? Number.MAX_SAFE_INTEGER,
+    ...(props.chainLimits ? { maxFramesPerClip: props.chainLimits.frames_per_clip_cap } : {}),
+    frameStep: sequenceFrameStep(props.selectedModel?.family ?? props.form.family),
+    frameOffset: 1,
     motionTailFrames: motionTail.value,
     promptOptional: clipPromptOptional.value,
   }),

--- a/desktop/src/lib/api/chains.test.ts
+++ b/desktop/src/lib/api/chains.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from "vitest";
+
+const apiJson = vi.hoisted(() => vi.fn());
+const apiJsonTo = vi.hoisted(() => vi.fn());
+
+vi.mock("./client", () => ({
+  apiJson,
+  apiJsonTo,
+}));
+
+import { fetchChainLimits } from "./chains";
+
+describe("chain limits API", () => {
+  it("requests the cap for the active fps", async () => {
+    apiJson.mockResolvedValueOnce({ frames_per_clip_cap: 241 });
+
+    await fetchChainLimits("ltx-2-19b-distilled:fp8", null, 12);
+
+    expect(apiJson).toHaveBeenCalledWith(
+      "/api/capabilities/chain-limits?model=ltx-2-19b-distilled%3Afp8&fps=12",
+    );
+  });
+});

--- a/desktop/src/lib/api/chains.ts
+++ b/desktop/src/lib/api/chains.ts
@@ -5,7 +5,9 @@ import type { ChainLimits } from "./types";
 export function fetchChainLimits(
   model: string,
   target: ApiTarget | null = null,
+  fps?: number | null,
 ): Promise<ChainLimits> {
-  const path = `/api/capabilities/chain-limits?model=${encodeURIComponent(model)}`;
+  const fpsQuery = fps && fps > 0 ? `&fps=${encodeURIComponent(Math.floor(fps))}` : "";
+  const path = `/api/capabilities/chain-limits?model=${encodeURIComponent(model)}${fpsQuery}`;
   return target ? apiJsonTo<ChainLimits>(target, path) : apiJson<ChainLimits>(path);
 }

--- a/desktop/src/lib/api/types.ts
+++ b/desktop/src/lib/api/types.ts
@@ -1047,6 +1047,8 @@ export interface ChainScript {
 export interface ChainLimits {
   model: string;
   frames_per_clip_cap: number;
+  fps?: number | null;
+  frames_per_clip_runtime_seconds?: number | null;
   frames_per_clip_recommended: number;
   max_stages: number;
   max_total_frames: number;

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -2125,25 +2125,24 @@ function setOutputMode(mode: string | number): void {
 
 let chainLimitsFetch = 0;
 async function loadChainLimits(): Promise<void> {
+  const version = ++chainLimitsFetch;
   const host = selectedHost.value;
   const entry = selectedGenerationModel.value;
   if (!host || !entry) {
     chainLimits.value = null;
     return;
   }
-  const version = ++chainLimitsFetch;
   try {
     const limits = await apiJsonTo<ChainLimits>(
       mobileHostTarget(host),
-      `/api/capabilities/chain-limits?model=${encodeURIComponent(entry.name)}`,
+      `/api/capabilities/chain-limits?model=${encodeURIComponent(entry.name)}&fps=${encodeURIComponent(Math.max(1, Math.floor(form.fps)))}`,
     );
     if (version !== chainLimitsFetch) return;
     chainLimits.value = limits;
     if (!limits.supports_audio) draft.enableAudio = false;
-    // A clip longer than the routed host's per-clip cap would be rejected on
-    // submit; shrink it here rather than failing the whole sequence.
-    for (const clip of draft.clips) {
-      if (clip.frames > limits.frames_per_clip_cap) clip.frames = limits.frames_per_clip_cap;
+    if (!draft.editing) {
+      const frames = defaultClipFrames(entry, limits, sequenceMotionTail.value);
+      draft.adoptSequenceModel(entry.name, frames);
     }
   } catch {
     if (version === chainLimitsFetch) chainLimits.value = null;
@@ -2153,7 +2152,15 @@ async function loadChainLimits(): Promise<void> {
 // Chain limits are per model AND per host — refetch when either moves, and
 // keep the two-clip floor stocked once Sequence is the active output.
 watch(
-  [isSequence, () => form.model, selectedHostId],
+  () => form.model,
+  (next, previous) => {
+    if (isSequence.value && previous && next !== previous) {
+      if (draft.editing) draft.stopEditing();
+    }
+  },
+);
+watch(
+  [isSequence, () => form.model, () => form.fps, selectedHostId],
   () => {
     if (!isSequence.value) return;
     draft.ensureClips(sequenceDefaultFrames.value);
@@ -3890,6 +3897,7 @@ async function reusePrint(print: GalleryPrint): Promise<void> {
       draft.clips.splice(0, draft.clips.length, ...reuse.sequence.clips);
       draft.activeClipId = reuse.sequence.clips[0]?.id ?? null;
       draft.enableAudio = print.metadata.enable_audio === true;
+      draft.bindSequenceModel(form.model);
     }
     const notes: string[] = [];
     if (reuse.substitutedModel) {

--- a/desktop/src/mobile/MobileSequenceComposer.test.ts
+++ b/desktop/src/mobile/MobileSequenceComposer.test.ts
@@ -428,6 +428,29 @@ describe("MobileSequenceComposer guardrails", () => {
     expect(wrapper!.emitted("submit")).toHaveLength(1);
   });
 
+  it("blocks a stale clip above the active fps cap without silently clamping it", async () => {
+    const draft = useSequenceDraftStore();
+    draft.clips[0]!.prompt = "opening";
+    draft.clips[1]!.prompt = "ending";
+    draft.clips[0]!.frames = 481;
+    mountComposer({
+      chainLimits: {
+        ...limits,
+        frames_per_clip_cap: 241,
+        max_total_frames: 241 * 4,
+      },
+    });
+
+    expect(draft.clips[0]!.frames).toBe(481);
+    expect(wrapper!.get("[data-test='mobile-sequence-error']").text()).toContain(
+      "Reduce clip 1 to 241 frames or fewer.",
+    );
+    expect(
+      (wrapper!.get("[data-test='mobile-generate-sequence']").element as HTMLButtonElement)
+        .disabled,
+    ).toBe(true);
+  });
+
   it("shows the server's reason when the model cannot render a sequence", () => {
     const draft = useSequenceDraftStore();
     draft.clips[0]!.prompt = "a";

--- a/desktop/src/mobile/MobileSequenceComposer.vue
+++ b/desktop/src/mobile/MobileSequenceComposer.vue
@@ -19,6 +19,7 @@ import {
   friendlySequenceError,
   sequenceDuration,
   sequenceFrameOptions,
+  sequenceFrameStep,
   sequenceMotionTailFrames,
   sequenceValidation,
   transitionLabel,
@@ -180,6 +181,9 @@ const validation = computed(() =>
   sequenceValidation(stages.value, {
     maxStages: maxStages.value,
     maxTotalFrames: props.chainLimits?.max_total_frames ?? Number.MAX_SAFE_INTEGER,
+    ...(props.chainLimits ? { maxFramesPerClip: props.chainLimits.frames_per_clip_cap } : {}),
+    frameStep: sequenceFrameStep(props.selectedModel?.family),
+    frameOffset: 1,
     motionTailFrames: motionTail.value,
     promptOptional: clipPromptOptional.value,
   }),

--- a/desktop/src/views/GenerateView.sequence.test.ts
+++ b/desktop/src/views/GenerateView.sequence.test.ts
@@ -420,6 +420,41 @@ describe("GenerateView — sequence output", () => {
     expect(wrapper.find("sequence-composer-stub").exists()).toBe(false);
   });
 
+  it("detaches an amend session before switching its model authority", async () => {
+    readyLocal();
+    const wanModel = {
+      ...videoModel,
+      name: "wan22-i2v-a14b:q5",
+      family: "wan",
+      default_frames: 53,
+    } as ModelEntry;
+    installedPayload = [videoModel, wanModel];
+    useModelStore().all = [videoModel, wanModel];
+    const formStore = useGenerateFormStore();
+    formStore.form.model = videoModel.name;
+    const draft = useSequenceDraftStore();
+    draft.hydrate();
+    draft.output = "sequence";
+    draft.ensureClips(97);
+    draft.loadFromJob(
+      {
+        jobId: "job-model-a",
+        hostId: "local",
+        baseline: draft.clips.map((clip) => ({ ...clip })),
+        completedStages: 0,
+      },
+      draft.clips.map((clip) => ({ ...clip })),
+      false,
+    );
+
+    mountView();
+    await flushPromises();
+    formStore.form.model = wanModel.name;
+    await flushPromises();
+
+    expect(draft.editing).toBeNull();
+  });
+
   it("amends with an explicit enable_audio boolean so edits can turn audio off", async () => {
     // null means "keep current" server-side — sending it when the draft's
     // audio is off would make disabling audio via edit-in-place impossible.

--- a/desktop/src/views/GenerateView.vue
+++ b/desktop/src/views/GenerateView.vue
@@ -980,18 +980,22 @@ function consumeOutputQuery() {
 
 let chainLimitsFetch = 0;
 async function loadChainLimits() {
+  const version = ++chainLimitsFetch;
   const entry = selectedSequenceEntry.value;
   if (!entry) {
     chainLimits.value = null;
     return;
   }
-  const version = ++chainLimitsFetch;
   try {
     const target = routeForModel(entry)?.target ?? null;
-    const limits = (await fetchChainLimits(entry.name, target)) as ChainLimits;
+    const limits = (await fetchChainLimits(entry.name, target, form.fps)) as ChainLimits;
     if (version !== chainLimitsFetch) return;
     chainLimits.value = limits;
     if (!limits.supports_audio) draft.enableAudio = false;
+    if (!draft.editing) {
+      const frames = defaultClipFrames(entry, limits, sequenceMotionTail.value);
+      draft.adoptSequenceModel(entry.name, frames);
+    }
   } catch {
     if (version === chainLimitsFetch) chainLimits.value = null;
   }
@@ -999,7 +1003,18 @@ async function loadChainLimits() {
 
 // Chain limits are per model AND per host — refetch when either moves.
 watch(
-  [isSequence, () => form.model, stickyTarget, () => readyHostSignature(hosts.all)],
+  () => form.model,
+  (next, previous) => {
+    if (isSequence.value && previous && next !== previous) {
+      if (draft.editing) {
+        draft.stopEditing();
+        editSharedBaseline.value = null;
+      }
+    }
+  },
+);
+watch(
+  [isSequence, () => form.model, () => form.fps, stickyTarget, () => readyHostSignature(hosts.all)],
   () => {
     if (isSequence.value && form.model) void loadChainLimits();
   },
@@ -1508,6 +1523,7 @@ async function loadSequence(payload: { hostId: string; jobId: string }, editing:
       draft.enableAudio = loaded.enableAudio;
       draft.openingImage = loaded.openingImage;
     }
+    if (form.model) draft.bindSequenceModel(form.model);
     sequenceStageClipIdsByJob.set(
       `${payload.hostId}:${payload.jobId}`,
       draft.clips.map((clip) => clip.id),
@@ -2931,6 +2947,7 @@ function applySequenceReuse(metadata: OutputMetadata) {
   draft.clips.splice(0, draft.clips.length, ...clips);
   draft.activeClipId = clips[0]?.id ?? null;
   draft.enableAudio = metadata.enable_audio === true;
+  draft.bindSequenceModel(form.model);
 
   const notes = [sequenceReuseNote(clips.length, plan.lossy)];
   if (raised > 0) {

--- a/studio/lib/api/chainTypes.ts
+++ b/studio/lib/api/chainTypes.ts
@@ -227,6 +227,8 @@ export type ChainJobEvent =
 export interface ChainLimits {
   model: string;
   frames_per_clip_cap: number;
+  fps?: number | null;
+  frames_per_clip_runtime_seconds?: number | null;
   frames_per_clip_recommended: number;
   max_stages: number;
   max_total_frames: number;

--- a/studio/lib/resolutions.test.ts
+++ b/studio/lib/resolutions.test.ts
@@ -12,6 +12,7 @@ import {
   maxPixelsForModel,
   megapixelLabel,
   presetsForFamily,
+  presetsForAspectGroup,
   presetsForModel,
 } from "./resolutions";
 
@@ -117,6 +118,110 @@ describe("shared resolution contract", () => {
       width: 1216,
       height: 704,
     });
+  });
+
+  it("selects an exact profile aspect group without nearby-ratio leakage", () => {
+    const model = {
+      family: "ltx2",
+      generation_profile: {
+        schema_version: 1 as const,
+        profile_id: "ltx2.fixture",
+        profile_hash: "hash",
+        default_recipe_id: "auto",
+        recipes: [
+          {
+            id: "auto",
+            label: "Auto",
+            request_selector: { pipeline: null },
+            defaults: { width: 1216, height: 704, steps: 8, guidance: 3 },
+            resolution: {
+              domain: "dynamic" as const,
+              alignment: 64,
+              min_width: 64,
+              min_height: 64,
+              max_pixels: 8_912_896,
+              max_axis_pixels: 4096,
+              min_aspect_ratio: null,
+              max_aspect_ratio: null,
+              aspect_groups: [
+                {
+                  id: "16:9",
+                  label: "16:9",
+                  presets: [
+                    {
+                      id: "1024x576",
+                      width: 1024,
+                      height: 576,
+                      tier: "recommended",
+                    },
+                  ],
+                },
+                {
+                  id: "19:11",
+                  label: "19:11",
+                  presets: [
+                    {
+                      id: "1216x704",
+                      width: 1216,
+                      height: 704,
+                      tier: "recommended",
+                    },
+                  ],
+                },
+              ],
+            },
+            steps: {
+              default: 8,
+              min: 1,
+              max: 50,
+              step: 1,
+              mode: "adjustable" as const,
+            },
+            guidance: {
+              default: 3,
+              min: 0,
+              max: 10,
+              step: 0.1,
+              mode: "adjustable" as const,
+            },
+            temporal: null,
+            capabilities: {
+              guidance: { adjustable: true, supports_negative_prompt: true },
+              negative_prompt: {
+                mode: "adjustable" as const,
+                required: false,
+              },
+              supports_lora: false,
+              supports_controlnet: false,
+              supports_sequence: true,
+              supports_extend: false,
+              supports_audio: false,
+              source_video: { mode: "hidden" as const, required: false },
+              mask: { mode: "hidden" as const, required: false },
+              keyframes: { mode: "hidden" as const, required: false },
+              audio: { mode: "hidden" as const, required: false },
+              lora: { mode: "hidden" as const, max_count: 0 },
+              controlnet: { mode: "hidden" as const, max_count: 0 },
+              output: {
+                default_format: "mp4" as const,
+                formats: ["mp4" as const],
+                audio_requires_mp4: false,
+              },
+              wan_recipe: {
+                mode: "hidden" as const,
+                supports_distill_strength: false,
+                supports_first_last_frame: false,
+              },
+              schedulers: [],
+            },
+            provenance: [],
+          },
+        ],
+      },
+    };
+    expect(presetsForAspectGroup(model, null, "16:9")).toEqual([
+      expect.objectContaining({ width: 1024, height: 576, aspect: "16:9" }),
+    ]);
   });
 
   it("offers upstream's 1080p pair and a 9:16 portrait for ltx2 only", () => {

--- a/studio/lib/resolutions.ts
+++ b/studio/lib/resolutions.ts
@@ -228,6 +228,31 @@ export function presetsForModel(
     .map(({ width, height }) => p(width, height));
 }
 
+/**
+ * Exact presets authored for one generation-profile aspect group.
+ *
+ * A profile group ID is a user selection, not a fuzzy ratio hint. Keeping
+ * this lookup separate from `presetsNearRatio` prevents nearby buckets such
+ * as LTX-2's 19:11 or Wan's 26:15 from stealing a 16:9 click.
+ */
+export function presetsForAspectGroup(
+  model: ModelResolutionContract | null | undefined,
+  pipeline: string | null | undefined,
+  aspectGroupId: string | null | undefined,
+): ResolutionPreset[] {
+  if (!model || !aspectGroupId) return [];
+  const group = effectiveGenerationRecipe(
+    model,
+    pipeline,
+  )?.resolution.aspect_groups.find(
+    (candidate) => candidate.id === aspectGroupId,
+  );
+  return (
+    group?.presets.map(({ width, height }) => p(width, height, group.label)) ??
+    []
+  );
+}
+
 export function matchPreset(
   width: number,
   height: number,

--- a/studio/lib/sequence.test.ts
+++ b/studio/lib/sequence.test.ts
@@ -270,6 +270,14 @@ describe("sequence authoring", () => {
     expect(defaultClipFrames({ default_frames: 500 }, limits, 17)).toBe(97);
     // Never at or below the motion tail — raised to the first valid option.
     expect(defaultClipFrames({ default_frames: 9 }, limits, 17)).toBe(25);
+    // Wan owns a different 4k+1 grid; its shipped 53-frame default stays 53.
+    expect(
+      defaultClipFrames(
+        { default_frames: 53, family: "wan" },
+        { frames_per_clip_cap: 257, frames_per_clip_recommended: 53 },
+        1,
+      ),
+    ).toBe(53);
   });
 
   it("defaults fps from the model, then the current value, then the fallback", () => {
@@ -284,6 +292,42 @@ describe("sequence authoring", () => {
     // Nothing at all → the 24-fps fallback.
     expect(defaultVideoFps(null)).toBe(DEFAULT_VIDEO_FPS);
     expect(defaultVideoFps({ default_fps: null }, null)).toBe(24);
+  });
+
+  it("rejects a stale clip above the selected model and fps cap", () => {
+    expect(
+      sequenceValidation(
+        [
+          { prompt: "opening", frames: 481, transition: "smooth" },
+          { prompt: "ending", frames: 97, transition: "smooth" },
+        ],
+        {
+          maxStages: 16,
+          maxTotalFrames: 241 * 16,
+          maxFramesPerClip: 241,
+          motionTailFrames: 17,
+        },
+      ),
+    ).toEqual(["Reduce clip 1 to 241 frames or fewer."]);
+  });
+
+  it("rejects a stale clip from another family's temporal grid", () => {
+    expect(
+      sequenceValidation(
+        [
+          { prompt: "opening", frames: 53, transition: "smooth" },
+          { prompt: "ending", frames: 97, transition: "smooth" },
+        ],
+        {
+          maxStages: 16,
+          maxTotalFrames: 481 * 16,
+          maxFramesPerClip: 481,
+          frameStep: 8,
+          frameOffset: 1,
+          motionTailFrames: 17,
+        },
+      ),
+    ).toEqual(["Change clip 1 to the 8k+1 frame grid."]);
   });
 
   it("formats frame durations consistently across sequence surfaces", () => {

--- a/studio/lib/sequence.ts
+++ b/studio/lib/sequence.ts
@@ -47,6 +47,9 @@ export interface SequenceStage {
 export interface SequenceLimits {
   maxStages: number;
   maxTotalFrames: number;
+  maxFramesPerClip?: number;
+  frameStep?: number;
+  frameOffset?: number;
   motionTailFrames: number;
   /**
    * Whether a clip may be left undescribed — `promptOptional` from
@@ -181,6 +184,25 @@ export function sequenceValidation(
   if (stages.length > limits.maxStages) {
     return [`Reduce the sequence to ${limits.maxStages} clips or fewer.`];
   }
+  if (limits.maxFramesPerClip != null) {
+    const cap = limits.maxFramesPerClip;
+    const oversized = stages.findIndex((stage) => stage.frames > cap);
+    if (oversized >= 0) {
+      return [`Reduce clip ${oversized + 1} to ${cap} frames or fewer.`];
+    }
+  }
+  if (limits.frameStep != null) {
+    const step = limits.frameStep;
+    const offset = limits.frameOffset ?? 1;
+    const offGrid = stages.findIndex(
+      (stage) => stage.frames % step !== offset % step,
+    );
+    if (offGrid >= 0) {
+      return [
+        `Change clip ${offGrid + 1} to the ${step}k+${offset} frame grid.`,
+      ];
+    }
+  }
   const total = sequenceDuration(stages, 1, limits.motionTailFrames).frames;
   if (total > limits.maxTotalFrames) {
     return [
@@ -237,21 +259,25 @@ export function defaultVideoFps(
  * active GPU — which is exactly why default/recommended win over cap.
  */
 export function defaultClipFrames(
-  model: { default_frames?: number | null } | null | undefined,
+  model:
+    | { default_frames?: number | null; family?: string | null }
+    | null
+    | undefined,
   limits:
     | { frames_per_clip_cap: number; frames_per_clip_recommended: number }
     | null
     | undefined,
   motionTailFrames: number,
 ): number {
+  const step = sequenceFrameStep(model?.family);
   const cap = limits?.frames_per_clip_cap ?? Number.MAX_SAFE_INTEGER;
   const preferred =
     model?.default_frames ??
     limits?.frames_per_clip_recommended ??
     DEFAULT_SEQUENCE_CLIP_FRAMES;
   let frames = Math.min(preferred, cap);
-  if (frames > 1) frames -= (frames - 1) % 8;
-  while (frames <= motionTailFrames) frames += 8;
-  return Math.max(frames, 9);
+  if (frames > 1) frames -= (frames - 1) % step;
+  while (frames <= motionTailFrames) frames += step;
+  return Math.max(frames, step + 1);
 }
 import { describeTransportError } from "./errors";

--- a/studio/stores/sequenceDraft.test.ts
+++ b/studio/stores/sequenceDraft.test.ts
@@ -348,6 +348,51 @@ describe("sequence draft store", () => {
     expect(store.output).toBe("sequence");
   });
 
+  it("resets only model-owned clip lengths when the selected model changes", () => {
+    const store = freshStore();
+    store.hydrate();
+    store.ensureClips(97);
+    store.clips[0]!.prompt = "opening";
+    store.clips[1]!.prompt = "ending";
+    store.clips[1]!.transition = "cut";
+
+    store.resetClipFrames(53);
+
+    expect(store.clips.map((clip) => clip.frames)).toEqual([53, 53]);
+    expect(store.clips.map((clip) => clip.prompt)).toEqual([
+      "opening",
+      "ending",
+    ]);
+    expect(store.clips[1]!.transition).toBe("cut");
+  });
+
+  it("persists the model that owns clip lengths and resets only on a change", () => {
+    const store = freshStore();
+    store.hydrate();
+    store.ensureClips(53);
+
+    expect(store.adoptSequenceModel("wan22-i2v-a14b:q5", 53)).toBe(true);
+    store.clips[0]!.frames = 57;
+    expect(store.adoptSequenceModel("wan22-i2v-a14b:q5", 53)).toBe(false);
+    expect(store.clips[0]!.frames).toBe(57);
+    expect(store.adoptSequenceModel("ltx-2.3-22b-dev:fp8", 97)).toBe(true);
+    expect(store.clips.map((clip) => clip.frames)).toEqual([97, 97]);
+  });
+
+  it("binds deliberately imported timings without resetting them", () => {
+    const store = freshStore();
+    store.hydrate();
+    store.ensureClips(97);
+    store.clips[0]!.frames = 481;
+
+    store.bindSequenceModel("ltx-2.3-22b-dev:fp8");
+
+    expect(store.sequenceModel).toBe("ltx-2.3-22b-dev:fp8");
+    expect(store.clips[0]!.frames).toBe(481);
+    expect(store.adoptSequenceModel("ltx-2.3-22b-dev:fp8", 97)).toBe(false);
+    expect(store.clips[0]!.frames).toBe(481);
+  });
+
   it("tracks an edit session without persisting it", () => {
     const store = freshStore();
     store.hydrate();

--- a/studio/stores/sequenceDraft.ts
+++ b/studio/stores/sequenceDraft.ts
@@ -89,6 +89,7 @@ interface PersistedDraftV1 {
     (Omit<SequenceClipSourceImage, "base64"> & { base64: null }) | null;
   enableAudio: boolean;
   lastSingleModel: string | null;
+  sequenceModel?: string | null;
 }
 
 function persistableClips(clips: readonly SequenceClipForm[]): PersistedClip[] {
@@ -137,6 +138,7 @@ export const useSequenceDraftStore = defineStore("sequence-draft", () => {
   const enableAudio = ref(false);
   const editing = ref<SequenceEditSession | null>(null);
   const lastSingleModel = ref<string | null>(null);
+  const sequenceModel = ref<string | null>(null);
   const hydrated = ref(false);
 
   let persistTimer: ReturnType<typeof setTimeout> | null = null;
@@ -180,6 +182,7 @@ export const useSequenceDraftStore = defineStore("sequence-draft", () => {
         : null,
       enableAudio: enableAudio.value,
       lastSingleModel: lastSingleModel.value,
+      sequenceModel: sequenceModel.value,
     };
     try {
       draftStorage()?.setItem(SEQUENCE_DRAFT_KEY, JSON.stringify(draft));
@@ -200,6 +203,7 @@ export const useSequenceDraftStore = defineStore("sequence-draft", () => {
     openingImage.value = saved.openingImage ?? null;
     enableAudio.value = saved.enableAudio;
     lastSingleModel.value = saved.lastSingleModel ?? null;
+    sequenceModel.value = saved.sequenceModel ?? null;
   }
 
   async function restorePersistedMedia() {
@@ -317,6 +321,29 @@ export const useSequenceDraftStore = defineStore("sequence-draft", () => {
     clips.push(clip);
     activeClipId.value = clip.id;
     return clip;
+  }
+
+  /** Reset the model-owned duration field without disturbing prompts, media,
+   * transitions, seeds, or the active clip. Model selectors call this only
+   * after the new model's authoritative chain limits have arrived. */
+  function resetClipFrames(defaultFrames: number) {
+    for (const clip of clips) clip.frames = defaultFrames;
+  }
+
+  /** Adopt one concrete model as the clip-duration authority. */
+  function adoptSequenceModel(model: string, defaultFrames: number): boolean {
+    if (sequenceModel.value === model) return false;
+    sequenceModel.value = model;
+    resetClipFrames(defaultFrames);
+    return true;
+  }
+
+  /** Bind deliberately imported timings to their concrete model without
+   * treating that import as a model switch. Reuse/edit loaders own the clip
+   * lengths they just restored; later model changes still flow through
+   * `adoptSequenceModel` and reset those model-owned values. */
+  function bindSequenceModel(model: string) {
+    sequenceModel.value = model;
   }
 
   function removeClip(id: string) {
@@ -450,7 +477,7 @@ export const useSequenceDraftStore = defineStore("sequence-draft", () => {
   // Sync flush so the debounce timer arms on the mutation itself (the
   // callback only re-arms a setTimeout — cheap enough for every keystroke).
   watch(
-    [output, clips, openingImage, enableAudio, lastSingleModel],
+    [output, clips, openingImage, enableAudio, lastSingleModel, sequenceModel],
     () => schedulePersist(),
     { deep: true, flush: "sync" },
   );
@@ -464,10 +491,14 @@ export const useSequenceDraftStore = defineStore("sequence-draft", () => {
     enableAudio,
     editing,
     lastSingleModel,
+    sequenceModel,
     hydrated,
     hydrate,
     ensureClips,
     addClip,
+    resetClipFrames,
+    adoptSequenceModel,
+    bindSequenceModel,
     removeClip,
     moveClip,
     setTransition,

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -12,6 +12,7 @@ import {
   gcChainJobs,
   generateStream,
   generateChainStream,
+  fetchChainLimits,
   getChainJob,
   listChainJobs,
   resumeChainJob,
@@ -182,6 +183,33 @@ describe("queue api", () => {
 });
 
 describe("chain validation api", () => {
+  it("requests chain limits for the selected fps", async () => {
+    const limits = {
+      model: "ltx-2-19b-distilled:fp8",
+      frames_per_clip_cap: 241,
+      frames_per_clip_recommended: 97,
+      max_stages: 16,
+      max_total_frames: 3856,
+      fade_frames_max: 32,
+      transition_modes: ["smooth"],
+      quantization_family: "fp8",
+      supports_audio: true,
+      supports_sequence: true,
+    };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(JSON.stringify(limits), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      fetchChainLimits(limits.model, undefined, 12),
+    ).resolves.toEqual(limits);
+    expect(fetchMock).toHaveBeenCalledWith(
+      `/api/capabilities/chain-limits?model=${encodeURIComponent(limits.model)}&fps=12`,
+      { headers: {} },
+    );
+  });
+
   it("validates on the exact authenticated host without creating a job", async () => {
     const response = {
       model: "ltx-2-19b-distilled:fp8",

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -64,6 +64,8 @@ export async function deleteGalleryImage(filename: string): Promise<void> {
 export interface ChainLimits {
   model: string;
   frames_per_clip_cap: number;
+  fps?: number | null;
+  frames_per_clip_runtime_seconds?: number | null;
   frames_per_clip_recommended: number;
   max_stages: number;
   max_total_frames: number;
@@ -188,15 +190,17 @@ const CHAIN_LIMITS_TTL_MS = 30_000;
 export async function fetchChainLimits(
   model: string,
   target?: StreamTarget,
+  fps?: number | null,
 ): Promise<ChainLimits> {
   const now = Date.now();
   // Limits are per model AND per host — a remote's checkpoint may chain
   // where the origin's doesn't.
-  const key = `${targetBase(target)}|${model}`;
+  const effectiveFps = fps && fps > 0 ? Math.floor(fps) : null;
+  const key = `${targetBase(target)}|${model}|${effectiveFps ?? "default"}`;
   const cached = chainLimitsCache.get(key);
   if (cached && now - cached.at < CHAIN_LIMITS_TTL_MS) return cached.value;
   const res = await fetch(
-    `${targetBase(target)}/api/capabilities/chain-limits?model=${encodeURIComponent(model)}`,
+    `${targetBase(target)}/api/capabilities/chain-limits?model=${encodeURIComponent(model)}${effectiveFps ? `&fps=${effectiveFps}` : ""}`,
     { headers: targetHeaders(target) },
   );
   if (!res.ok) throw new Error(`chain-limits fetch failed: ${res.status}`);

--- a/web/src/components/SequenceComposer.test.ts
+++ b/web/src/components/SequenceComposer.test.ts
@@ -88,6 +88,80 @@ describe("SequenceComposer", () => {
     expect(wrapper.text()).toContain("Describe clip 1");
   });
 
+  it("resets model-owned clip lengths and fetches limits at the active fps", async () => {
+    const wrapper = mountComposer();
+    await flushPromises();
+    const store = useSequenceDraftStore();
+    store.clips[0]!.frames = 481;
+    store.clips[1]!.frames = 53;
+
+    fetchChainLimitsMock.mockResolvedValueOnce(
+      ltx2Limits({
+        model: "wan22-i2v-a14b:q5",
+        frames_per_clip_cap: 257,
+        frames_per_clip_recommended: 53,
+      }),
+    );
+    await wrapper.setProps({
+      model: "wan22-i2v-a14b:q5",
+      family: "wan",
+      modelDefaultFrames: 53,
+      shared: {
+        ...shared(),
+        model: "wan22-i2v-a14b:q5",
+        family: "wan",
+        fps: 16,
+      },
+    });
+    await flushPromises();
+
+    expect(fetchChainLimitsMock).toHaveBeenLastCalledWith(
+      "wan22-i2v-a14b:q5",
+      undefined,
+      16,
+    );
+    expect(store.clips.map((clip) => clip.frames)).toEqual([53, 53]);
+  });
+
+  it("detaches an amend session before switching its model authority", async () => {
+    const wrapper = mountComposer();
+    await flushPromises();
+    const store = useSequenceDraftStore();
+    store.loadFromJob(
+      {
+        jobId: "job-model-a",
+        hostId: "origin",
+        baseline: store.clips.map((clip) => ({ ...clip })),
+        completedStages: 0,
+      },
+      store.clips.map((clip) => ({ ...clip })),
+      false,
+    );
+
+    fetchChainLimitsMock.mockResolvedValueOnce(
+      ltx2Limits({
+        model: "wan22-i2v-a14b:q5",
+        frames_per_clip_cap: 257,
+        frames_per_clip_recommended: 53,
+      }),
+    );
+    await wrapper.setProps({
+      model: "wan22-i2v-a14b:q5",
+      family: "wan",
+      modelDefaultFrames: 53,
+      shared: {
+        ...shared(),
+        model: "wan22-i2v-a14b:q5",
+        family: "wan",
+        fps: 16,
+      },
+    });
+    await flushPromises();
+
+    expect(store.editing).toBeNull();
+    expect(store.clips.map((clip) => clip.frames)).toEqual([53, 53]);
+  });
+
   // An opening image conditions clip 1 and every later clip inherits the
   // previous clip's motion tail, so a promptless-capable family can render an
   // undescribed sequence — the same rule the one-shot composer applies.
@@ -616,15 +690,7 @@ describe("SequenceComposer — wan", () => {
     );
   });
 
-  /**
-   * Making the grid family-dependent made it possible for a loaded clip to sit
-   * off the current model's ladder — wan's 53 is not an LTX `8k+1` value, and
-   * a sequence reused or edited across a model switch carries it in. A select
-   * whose `:value` matches no option renders blank and silently rewrites the
-   * clip on the next change, so the loaded value stays listed. Desktop and
-   * iPhone already guard this; web did not.
-   */
-  it("keeps an off-grid loaded duration selectable", async () => {
+  it("resets stale off-grid durations when the model authority changes", async () => {
     fetchChainLimitsMock.mockResolvedValue(ltx2Limits());
     const store = useSequenceDraftStore();
     store.clearSequence(53);
@@ -634,12 +700,12 @@ describe("SequenceComposer — wan", () => {
 
     const wrapper = mountComposer();
     await flushPromises();
-    const select = wrapper.get("[data-test='clip-frames']");
-    const frames = select
+    const frames = wrapper
+      .get("[data-test='clip-frames']")
       .findAll("option")
       .map((option) => Number(option.attributes("value")));
-    expect(frames).toContain(53);
-    // Still sorted, and the LTX grid is otherwise untouched.
+    expect(store.clips.map((clip) => clip.frames)).toEqual([97, 97]);
+    expect(frames).not.toContain(53);
     expect(frames).toEqual([...frames].sort((a, b) => a - b));
     expect(frames).toContain(97);
   });

--- a/web/src/components/SequenceComposer.vue
+++ b/web/src/components/SequenceComposer.vue
@@ -25,6 +25,7 @@ import {
   formatFrameDuration,
   sequenceDuration,
   sequenceFrameOptions,
+  sequenceFrameStep,
   sequenceMotionTailFrames,
   sequenceValidation,
   transitionLabel,
@@ -122,20 +123,34 @@ const motionTail = computed(() =>
 );
 const defaultFrames = computed(() =>
   defaultClipFrames(
-    { default_frames: props.modelDefaultFrames },
+    { default_frames: props.modelDefaultFrames, family: props.family },
     limits.value,
     motionTail.value,
   ),
 );
 
+let limitsFetch = 0;
 async function loadLimits() {
+  const version = ++limitsFetch;
   limitsLoaded.value = false;
-  limits.value = await fetchChainLimits(props.model, props.target).catch(
-    () => null,
-  );
+  const next = await fetchChainLimits(
+    props.model,
+    props.target,
+    props.shared.fps,
+  ).catch(() => null);
+  if (version !== limitsFetch) return;
+  limits.value = next;
   limitsLoaded.value = true;
   // A non-AV model must not carry a stale audio request onto the wire.
   if (!limits.value?.supports_audio) draft.enableAudio = false;
+  if (!draft.editing && limits.value) {
+    const frames = defaultClipFrames(
+      { default_frames: props.modelDefaultFrames, family: props.family },
+      limits.value,
+      motionTail.value,
+    );
+    draft.adoptSequenceModel(props.model, frames);
+  }
 }
 
 onMounted(() => {
@@ -145,8 +160,18 @@ onMounted(() => {
 });
 
 watch(
-  () => [props.model, props.family, props.target?.baseUrl],
-  () => void loadLimits(),
+  () =>
+    [
+      props.model,
+      props.family,
+      props.target?.baseUrl,
+      props.shared.fps,
+    ] as const,
+  (next, previous) => {
+    const modelChanged = next[0] !== previous?.[0];
+    if (modelChanged && draft.editing) draft.stopEditing();
+    void loadLimits();
+  },
 );
 
 // ── Active clip ───────────────────────────────────────────────────────
@@ -217,6 +242,11 @@ const validationErrors = computed(() =>
   sequenceValidation(stages.value, {
     maxStages: maxStages.value,
     maxTotalFrames: limits.value?.max_total_frames ?? 1552,
+    ...(limits.value
+      ? { maxFramesPerClip: limits.value.frames_per_clip_cap }
+      : {}),
+    frameStep: sequenceFrameStep(props.family),
+    frameOffset: 1,
     motionTailFrames: motionTail.value,
     // The opening image conditions clip 1, and every later clip inherits the
     // previous clip's motion tail — the same handoff extend uses — so a

--- a/web/src/components/create/ControlsAside.vue
+++ b/web/src/components/create/ControlsAside.vue
@@ -27,6 +27,7 @@ import type { GenerateFormState, ModelInfoExtended } from "../../types";
 import {
   closestResolutionPreset,
   megapixelLabel,
+  presetsForAspectGroup,
   presetsForModel,
   presetsNearRatio,
 } from "@studio/lib/resolutions";
@@ -203,12 +204,19 @@ function patch(patch: Partial<GenerateFormState>) {
   emit("update:modelValue", { ...props.modelValue, ...patch });
 }
 
-const resolutionPresets = computed(() =>
-  presetsNearRatio(
-    presetsForModel(props.model ?? props.family, props.modelValue.pipeline),
-    currentRatio.value,
-  ),
-);
+const resolutionPresets = computed(() => {
+  const exactGroup = presetsForAspectGroup(
+    props.model,
+    props.modelValue.pipeline,
+    aspectId.value,
+  );
+  return exactGroup.length > 0
+    ? exactGroup
+    : presetsNearRatio(
+        presetsForModel(props.model ?? props.family, props.modelValue.pipeline),
+        currentRatio.value,
+      );
+});
 const resolutionOptions = computed(() => {
   const presets = resolutionPresets.value.map((preset, index, all) => ({
     mp: (preset.width * preset.height) / 1_000_000,
@@ -270,11 +278,21 @@ function setAspect(id: string) {
   }
   const a = shapeOptions.value.find((x) => x.id === id);
   if (!a) return;
+  const exactGroup = presetsForAspectGroup(
+    props.model,
+    props.modelValue.pipeline,
+    id,
+  );
   const preset = closestResolutionPreset(
-    presetsNearRatio(
-      presetsForModel(props.model ?? props.family, props.modelValue.pipeline),
-      a.ratio,
-    ),
+    exactGroup.length > 0
+      ? exactGroup
+      : presetsNearRatio(
+          presetsForModel(
+            props.model ?? props.family,
+            props.modelValue.pipeline,
+          ),
+          a.ratio,
+        ),
     props.modelValue.width,
     props.modelValue.height,
   );

--- a/web/src/pages/CreatePage.test.ts
+++ b/web/src/pages/CreatePage.test.ts
@@ -1265,6 +1265,11 @@ describe("CreatePage layout and behavior", () => {
     await wrapper.get("[data-test='sequence-generate']").trigger("click");
     await flushPromises();
 
+    expect(fetchChainLimitsMock).toHaveBeenCalledWith(
+      "ltx-2-19b-distilled:fp8",
+      expect.anything(),
+      24,
+    );
     expect(createChainJobMock).toHaveBeenCalledTimes(1);
     expect(createChainJobMock).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/web/src/pages/CreatePage.vue
+++ b/web/src/pages/CreatePage.vue
@@ -1486,7 +1486,9 @@ async function onSubmitSequence() {
   }
   // Refresh chain limits when stale (30 s cache) — the server still remains
   // the final authority at submission.
-  await fetchChainLimits(shared.model, initialRoute.target).catch(() => {});
+  await fetchChainLimits(shared.model, initialRoute.target, shared.fps).catch(
+    () => {},
+  );
   const preliminaryRequest = buildChainRequest(shared, clips, {
     motionTailFrames,
     enableAudio,
@@ -1664,6 +1666,7 @@ async function loadSequence(hostId: string, jobId: string, editing: boolean) {
       draft.enableAudio = loaded.enableAudio;
       draft.openingImage = loaded.openingImage;
     }
+    if (form.state.value.model) draft.bindSequenceModel(form.state.value.model);
     sequenceStageClipIdsByJob.set(
       `${hostId}:${jobId}`,
       draft.clips.map((clip) => clip.id),
@@ -1761,6 +1764,7 @@ function applySequenceReuse(metadata: OutputMetadata) {
   draft.clips.splice(0, draft.clips.length, ...clips);
   draft.activeClipId = clips[0]?.id ?? null;
   draft.enableAudio = metadata.enable_audio === true;
+  draft.bindSequenceModel(form.state.value.model);
 
   const notes = [sequenceReuseNote(clips.length, plan.lossy)];
   if (raised > 0) notes.push(sequenceReuseClampNote(currentModelLabel.value));


### PR DESCRIPTION
## Summary

- select exact generation-profile aspect groups instead of unrelated nearest ratios
- keep sequence frame limits, defaults, and validation model- and FPS-aware across desktop, web, and iPhone
- reset stale model-owned clip timing while preserving intentionally imported/edit-loaded timings
- invalidate stale limit requests and detach durable edits before model changes

## Root cause

The UI mixed profile-authored aspect groups with fuzzy ratio matching, and sequence controls retained frame values across model/FPS changes without a durable model authority. This exposed visible-but-inert ratios and allowed Wan/LTX frame grids to leak across models.

## Validation

- Studio: 65 files, 622 tests
- Desktop/mobile: 308 files, 3,362 tests
- Web: 90 files, 1,282 tests
- Desktop and web Vue type checks
- git diff --check
- Independent exact-head peer review: no P0/P1 findings