### PR TITLE
fix(mobile): install rustls provider at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix the iPhone app aborting during native startup by installing its selected rustls cryptography provider before Tauri or any networking plugin can construct a reqwest client.
+
 - Fix web generation routing to react immediately when a machine is added or selected in the same tab, and make the qualified MiniMax H3 FL2VA editor visibly require its sole supported first-frame endpoint across web, desktop, and mobile surfaces.
 
 - **The downloadable MiniMax H3 build now has a freshly reviewed compact FL2VA runtime record.** A memory-preflighted L40S campaign used a new alpine-lake first frame and prompt, authenticated all 42,482,090,318 artifact bytes, retained 18,611 telemetry samples and all thirteen synchronized observations, and produced a 6,429,310-byte, 124-frame H.264 plus stereo AAC result. The source-controlled allowlist now accepts only that candidate's exact source/runtime, artifact, CUDA, attention, process, and 1344×768 first-frame envelope. Ref2VA, other endpoints, broader envelopes, other devices/builds, and public release execution remain closed.

--- a/apps/mobile/src-tauri/src/lib.rs
+++ b/apps/mobile/src-tauri/src/lib.rs
@@ -10,8 +10,20 @@ fn app_context() -> tauri::Context<tauri::Wry> {
     tauri::generate_context!()
 }
 
+#[cfg(target_os = "ios")]
+fn install_network_crypto_provider() {
+    if rustls::crypto::CryptoProvider::get_default().is_none() {
+        rustls::crypto::ring::default_provider()
+            .install_default()
+            .expect("the iPhone app must install its rustls crypto provider before networking");
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    #[cfg(target_os = "ios")]
+    install_network_crypto_provider();
+
     tauri::Builder::default()
         .plugin(tauri_plugin_deep_link::init())
         .setup(|_app| {
@@ -98,5 +110,14 @@ mod tests {
         assert!(config.contains("\"scheme\": [\"mold\"]"));
         assert!(generated_plist.contains("<key>CFBundleURLTypes</key>"));
         assert!(generated_plist.contains("<string>mold</string>"));
+    }
+
+    #[cfg(target_os = "ios")]
+    #[test]
+    fn ios_installs_crypto_provider_before_building_network_clients() {
+        super::install_network_crypto_provider();
+        reqwest::Client::builder()
+            .build()
+            .expect("reqwest must be usable after iPhone startup installs the provider");
     }
 }


### PR DESCRIPTION
## Summary

- install the selected rustls ring provider before Tauri or any plugin can construct a reqwest client
- keep the setup idempotent when a process provider is already present
- add an iOS-target regression that proves reqwest clients can be built after startup initialization

## Verification

- `nix develop -c ios-check`
- `nix develop -c bash scripts/tests/ios-release-assets.sh`
- `nix develop -c env -u CFLAGS -u CXXFLAGS -u LDFLAGS CC=/usr/bin/clang CXX=/usr/bin/clang++ cargo clippy --manifest-path apps/mobile/src-tauri/Cargo.toml --target aarch64-apple-ios-sim -- -D warnings`
- full `nix develop -c ios-dev` Xcode simulator build and launch
- iPhone 17 Pro simulator: native startup remained stable, one-use pairing succeeded, exact MiniMax H3 FL2VA profile loaded, retained H3 videos appeared in Library, and authenticated video playback visibly advanced
- mandatory independent peer review approved the exact pre-PR diff with no findings

No model generation was started by this change.