### PR TITLE
perf(h3): use native int8 cuda linear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Run compact MiniMax H3 DiT INT8 projections through the source-matched CUDA path: BF16/F16/F32 ConvRot activations are dynamically quantized by row, multiplied as signed INT8 into INT32 with cached cuBLASLt plans, and dequantized in the pinned F32 scale order. A representative 4096x5376 by 7168 BF16 projection on the qualification L40S measured about 42 ms after plan warmup; the portable CPU/Metal and Qwen weight-only paths are unchanged. This optimization changes the qualified executable identity, so a fresh exact-source campaign remains required before the private allowlist can use it.
+
 - Stage MiniMax H3 compact INT8 transformer weight bytes directly on the execution device before exact signed widening, eliminating per-evaluation host scalar expansion and reducing each streamed weight transfer from four bytes per value to one without changing the portable W8A8 reference equations.
 
 - Fix the iPhone app aborting during native startup by installing its selected rustls cryptography provider before Tauri or any networking plugin can construct a reqwest client.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3139,6 +3139,8 @@ dependencies = [
  "candle-flash-attn",
  "candle-nn",
  "candle-transformers",
+ "cudaforge",
+ "half",
  "serde",
  "serde_json",
  "sha2",

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,5 +1,21 @@
 # Third-Party Notices
 
+## comfy-kitchen INT8 CUDA reference
+
+The MiniMax H3 native INT8 CUDA kernels and cuBLASLt operation layout are
+adapted from comfy-kitchen 0.2.26, commit
+`255a43879fe57bbcbecfdb273b46d772b00c5a90`, specifically
+`backends/cuda/ops/int8_linear.cu` and
+`backends/cuda/ops/cublas_gemm_int8.cu`.
+
+    Copyright (c) 2025 Comfy Org. All rights reserved.
+    Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+Those sources are licensed under the Apache License, Version 2.0. Mold's copy
+retains attribution and identifies its changes; the complete license text is
+included in `crates/mold-candle/LICENSE-APACHE-2.0` and in the published
+`mold-ai-candle` crate.
+
 ## Pillow image resampling algorithm
 
 The pure-Rust MiniMax H3 endpoint resampler in

--- a/crates/mold-candle/Cargo.toml
+++ b/crates/mold-candle/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mold-ai-candle"
 version.workspace = true
 edition.workspace = true
-license.workspace = true
+license = "MIT AND Apache-2.0"
 repository.workspace = true
 rust-version.workspace = true
 description = "Mold-owned models and extension operations for upstream Candle"
@@ -30,6 +30,7 @@ flash-attn = ["dep:candle-flash-attn", "cuda"]
 candle = { package = "candle-core", version = "0.11" }
 candle-nn = "0.11"
 candle-transformers = "0.11"
+half = "2"
 # The H3 runtime fingerprint qualifies this exact crates.io payload, not
 # an arbitrary semver-compatible 0.11.x implementation.
 candle-flash-attn = { version = "=0.11.0", optional = true }
@@ -39,3 +40,6 @@ sha2 = "0.10"
 thiserror = "2"
 tokenizers = { version = "0.21", default-features = false, features = ["fancy-regex"] }
 tracing = "0.1"
+
+[build-dependencies]
+cudaforge = "=0.1.6"

--- a/crates/mold-candle/LICENSE-APACHE-2.0
+++ b/crates/mold-candle/LICENSE-APACHE-2.0
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/crates/mold-candle/LICENSE-MIT
+++ b/crates/mold-candle/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 James Brink <brink.james@gmail.com> and Jeffrey Dilley <jeff.dilley@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/mold-candle/THIRD_PARTY_NOTICES.md
+++ b/crates/mold-candle/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,16 @@
+# Third-Party Notices
+
+## comfy-kitchen INT8 CUDA reference
+
+The MiniMax H3 native INT8 CUDA kernels and cuBLASLt operation layout are
+adapted from comfy-kitchen 0.2.26, commit
+`255a43879fe57bbcbecfdb273b46d772b00c5a90`, specifically
+`backends/cuda/ops/int8_linear.cu` and
+`backends/cuda/ops/cublas_gemm_int8.cu`.
+
+    Copyright (c) 2025 Comfy Org. All rights reserved.
+    Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+
+Those sources are licensed under the Apache License, Version 2.0. Mold's copy
+retains attribution and identifies its changes; the complete license text is
+included in `LICENSE-APACHE-2.0`.

--- a/crates/mold-candle/build.rs
+++ b/crates/mold-candle/build.rs
@@ -1,0 +1,26 @@
+fn main() {
+    println!("cargo::rerun-if-changed=build.rs");
+
+    #[cfg(feature = "cuda")]
+    {
+        use std::env;
+        use std::path::PathBuf;
+
+        println!("cargo::rerun-if-changed=src/minimax_h3/cuda/int8_linear.cu");
+        let output = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR is set by Cargo"))
+            .join("h3_int8_cuda.rs");
+        let bindings = cudaforge::KernelBuilder::new()
+            .source_files(vec!["src/minimax_h3/cuda/int8_linear.cu"])
+            .arg("-std=c++17")
+            .arg("-O3")
+            .arg("-U__CUDA_NO_HALF_OPERATORS__")
+            .arg("-U__CUDA_NO_HALF_CONVERSIONS__")
+            .arg("-U__CUDA_NO_BFLOAT16_OPERATORS__")
+            .arg("-U__CUDA_NO_BFLOAT16_CONVERSIONS__")
+            .build_ptx()
+            .expect("compile MiniMax H3 INT8 CUDA kernels");
+        bindings
+            .write(output)
+            .expect("write MiniMax H3 INT8 PTX bindings");
+    }
+}

--- a/crates/mold-candle/src/minimax_h3/comfy_quant.rs
+++ b/crates/mold-candle/src/minimax_h3/comfy_quant.rs
@@ -12,8 +12,9 @@
 //! - The pruned DiT stores INT8 weights after a regular, normalized, 256-wide
 //!   ConvRot transform and carries one F32 scale per output row. Its source
 //!   reference rotates activations in the input dtype, performs dynamic
-//!   per-row INT8 QDQ, streams output-row chunks, and applies both F32 scales
-//!   without retaining a dense weight.
+//!   per-row INT8 QDQ, and applies both F32 scales. CUDA uses the pinned
+//!   INT8-to-INT32 cuBLASLt boundary; CPU and Metal stream portable F32
+//!   output-row chunks without retaining a dense weight.
 //! - The pruned DiT's scaled FP8 matrices retain E4M3 weights plus scalar F32
 //!   weight/input scales. Their reference path preserves the source QDQ order
 //!   and accumulates against bounded, reconstructed F32 weight chunks.
@@ -39,6 +40,10 @@ pub const H3_COMFY_NVFP4_BLOCK_SIZE: usize = 16;
 
 /// Bounded default for portable dequantized weight staging.
 pub const H3_COMFY_PORTABLE_ROW_CHUNK: usize = 256;
+
+/// Workspace offered to the source-matched cuBLASLt INT8 heuristic.
+#[cfg(any(feature = "cuda", feature = "h3-private-uat"))]
+pub(crate) const H3_NATIVE_INT8_CUBLAS_WORKSPACE_BYTES: usize = 4 * 1024 * 1024;
 
 const E2M1_LUT: [f32; 16] = [
     0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0, -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0,
@@ -471,6 +476,7 @@ impl H3ComfyInt8ConvRotLinear {
         output_dtype: DType,
         rows_per_chunk: usize,
         has_bias: bool,
+        native_cuda: bool,
     ) -> Result<u64> {
         if input_rows == 0 || rows_per_chunk == 0 {
             candle::bail!("MiniMax H3 reference workspace requires positive rows and chunk size")
@@ -501,6 +507,44 @@ impl H3ComfyInt8ConvRotLinear {
             H3_COMFY_CONVROT_GROUP_SIZE,
             input_bytes,
         ])?;
+        if native_cuda {
+            if has_bias {
+                candle::bail!("MiniMax H3 native INT8 CUDA workspace does not accept bias")
+            }
+            let rotated_input = activation_input;
+            let packed_weight = checked(&[
+                self.out_features,
+                self.in_features,
+                std::mem::size_of::<u8>(),
+            ])?;
+            let weight_scales = checked(&[self.out_features, std::mem::size_of::<f32>()])?;
+            let quantized_input =
+                checked(&[input_rows, self.in_features, std::mem::size_of::<i8>()])?;
+            let input_scales = checked(&[input_rows, std::mem::size_of::<f32>()])?;
+            let accumulator =
+                checked(&[input_rows, self.out_features, std::mem::size_of::<i32>()])?;
+            let output = checked(&[input_rows, self.out_features, output_bytes])?;
+            return [
+                hadamard_f32,
+                hadamard_input,
+                rotated_input,
+                packed_weight,
+                weight_scales,
+                quantized_input,
+                input_scales,
+                accumulator,
+                u64::try_from(H3_NATIVE_INT8_CUBLAS_WORKSPACE_BYTES).map_err(|_| {
+                    candle::Error::Msg("MiniMax H3 cuBLAS workspace exceeds u64".into())
+                })?,
+                output,
+            ]
+            .into_iter()
+            .try_fold(0u64, |total, bytes| {
+                total.checked_add(bytes).ok_or_else(|| {
+                    candle::Error::Msg("MiniMax H3 native CUDA workspace sum overflows".into())
+                })
+            });
+        }
         let signed_widening_workspace = accelerator_signed_widening_workspace_upper_bound(
             chunk.checked_mul(self.in_features).ok_or_else(|| {
                 candle::Error::Msg("MiniMax H3 signed widening element count overflows".into())
@@ -738,14 +782,14 @@ impl H3ComfyInt8ConvRotLinear {
         )
     }
 
-    /// Execute Comfy's source-defined INT8 ConvRot W8A8 reference order.
+    /// Execute Comfy's source-defined INT8 ConvRot W8A8 order.
     ///
     /// Activations are rotated in their input dtype, dynamically quantized
     /// per row with `absmax / 127`, rounded and clamped to signed INT8, then
-    /// accumulated against the checkpoint's packed signed bytes. Scales are
-    /// applied in F32 before each bounded output-row chunk is converted to the
-    /// requested output dtype. This mirrors comfy-kitchen's eager fallback
-    /// while retaining neither a dense block weight nor the full output-width
+    /// accumulated against the checkpoint's packed signed bytes. CUDA performs
+    /// native signed INT8-to-INT32 multiplication and applies both scales in
+    /// F32. CPU and Metal mirror the eager fallback with bounded output-row
+    /// chunks, retaining neither a dense block weight nor the full-width
     /// accumulator.
     pub fn forward_reference(
         &self,
@@ -773,6 +817,26 @@ impl H3ComfyInt8ConvRotLinear {
             .reshape((grouped_rows, H3_COMFY_CONVROT_GROUP_SIZE))?
             .matmul(&hadamard)?
             .reshape((rows, self.in_features))?;
+        #[cfg(feature = "cuda")]
+        if device.is_cuda()
+            && bias.is_none()
+            && self.in_features.is_multiple_of(4)
+            && self.out_features.is_multiple_of(4)
+        {
+            let weight = self.weight.to_device(device)?;
+            let weight_scale = self.weight_scale.to_device(device)?;
+            let mut output_shape = output_shape;
+            *output_shape
+                .last_mut()
+                .expect("flattened_input established a nonempty shape") = self.out_features;
+            return super::int8_cuda::native_int8_linear(
+                &rotated,
+                &weight,
+                &weight_scale,
+                output_dtype,
+            )?
+            .reshape(&*output_shape);
+        }
         let input_scale = rotated
             .abs()?
             .max_keepdim(1)?
@@ -1689,6 +1753,62 @@ mod tests {
         Ok(())
     }
 
+    #[cfg(feature = "h3-private-uat")]
+    #[test]
+    fn int8_convrot_workspace_prices_native_cuda_lifetimes() -> Result<()> {
+        let outputs = 16;
+        let input_rows = 3;
+        let linear = H3ComfyInt8ConvRotLinear::new(
+            Tensor::zeros(
+                (outputs, H3_COMFY_CONVROT_GROUP_SIZE),
+                DType::U8,
+                &Device::Cpu,
+            )?,
+            Tensor::ones((outputs, 1), DType::F32, &Device::Cpu)?,
+        )?;
+        let hadamard_f32 = H3_COMFY_CONVROT_GROUP_SIZE.pow(2) * 4;
+        let hadamard_bf16 = H3_COMFY_CONVROT_GROUP_SIZE.pow(2) * 2;
+        let rotated_bf16 = input_rows * H3_COMFY_CONVROT_GROUP_SIZE * 2;
+        let packed_weight = outputs * H3_COMFY_CONVROT_GROUP_SIZE;
+        let weight_scales = outputs * 4;
+        let quantized_input = input_rows * H3_COMFY_CONVROT_GROUP_SIZE;
+        let input_scales = input_rows * 4;
+        let accumulator = input_rows * outputs * 4;
+        let output = input_rows * outputs * 2;
+        let expected = hadamard_f32
+            + hadamard_bf16
+            + rotated_bf16
+            + packed_weight
+            + weight_scales
+            + quantized_input
+            + input_scales
+            + accumulator
+            + H3_NATIVE_INT8_CUBLAS_WORKSPACE_BYTES
+            + output;
+        assert_eq!(
+            linear.reference_workspace_upper_bound(
+                input_rows,
+                DType::BF16,
+                DType::BF16,
+                H3_COMFY_PORTABLE_ROW_CHUNK,
+                false,
+                true,
+            )?,
+            expected as u64
+        );
+        assert!(linear
+            .reference_workspace_upper_bound(
+                input_rows,
+                DType::BF16,
+                DType::BF16,
+                H3_COMFY_PORTABLE_ROW_CHUNK,
+                true,
+                true,
+            )
+            .is_err());
+        Ok(())
+    }
+
     fn assert_signed_rows(device: &Device) -> Result<()> {
         let mut bytes = vec![0u8; H3_COMFY_CONVROT_GROUP_SIZE];
         bytes[..4].copy_from_slice(&[0x80, 0xff, 0x00, 0x7f]);
@@ -1717,6 +1837,70 @@ mod tests {
             return Ok(());
         };
         assert_signed_rows(&device)
+    }
+
+    #[cfg(feature = "cuda")]
+    #[test]
+    fn int8_convrot_native_cuda_matches_portable_reference() -> Result<()> {
+        let Ok(cuda) = Device::new_cuda(0) else {
+            return Ok(());
+        };
+        let cpu = Device::Cpu;
+        let columns = H3_COMFY_CONVROT_GROUP_SIZE;
+        let outputs = 8;
+        let raw = (0..outputs * columns)
+            .map(|index| (((index * 37 + 11) % 251) as i16 - 125) as i8 as u8)
+            .collect::<Vec<_>>();
+        let linear = H3ComfyInt8ConvRotLinear::new(
+            Tensor::from_vec(raw, (outputs, columns), &cpu)?,
+            Tensor::from_vec(
+                (0..outputs)
+                    .map(|index| (index + 1) as f32 / 256.0)
+                    .collect::<Vec<_>>(),
+                (outputs, 1),
+                &cpu,
+            )?,
+        )?;
+        let values = (0..3 * columns)
+            .map(|index| ((index * 17 % 257) as f32 - 128.0) / 37.0)
+            .collect::<Vec<_>>();
+        let expected = linear.forward_reference(
+            &Tensor::from_vec(values.clone(), (3, columns), &cpu)?,
+            None,
+            DType::F32,
+            4,
+        )?;
+        let actual = linear
+            .forward_reference(
+                &Tensor::from_vec(values.clone(), (3, columns), &cuda)?,
+                None,
+                DType::F32,
+                4,
+            )?
+            .to_device(&cpu)?;
+        assert!(max_error(&actual, &expected)? <= 1e-4);
+
+        // Exact BF16 values from the source-pinned PyTorch/Comfy operation:
+        // BF16 ConvRot, rowwise QDQ, signed INT8 accumulation, then ordered
+        // F32 activation-scale and weight-scale multiplication.
+        let expected_bf16 = vec![
+            -8.8125, 11.5625, 9.9375, -17.75, -35.0, -29.125, -4.71875, 11.75, -8.25, 14.125,
+            -1.4453125, -23.375, -51.25, 43.75, -3.921875, -16.375, -14.4375, 8.375, 38.25, -59.25,
+            -58.25, 39.5, 56.25, -84.5,
+        ];
+        let actual_bf16 = linear
+            .forward_reference(
+                &Tensor::from_vec(values, (3, columns), &cuda)?.to_dtype(DType::BF16)?,
+                None,
+                DType::BF16,
+                4,
+            )?
+            .to_device(&cpu)?
+            .to_dtype(DType::F32)?
+            .flatten_all()?
+            .to_vec1::<f32>()?;
+        assert_eq!(actual_bf16, expected_bf16);
+        Ok(())
     }
 
     #[cfg(feature = "metal")]

--- a/crates/mold-candle/src/minimax_h3/cuda/int8_linear.cu
+++ b/crates/mold-candle/src/minimax_h3/cuda/int8_linear.cu
@@ -1,0 +1,146 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The row quantization and dequantization equations are adapted from the
+ * source-pinned comfy-kitchen 0.2.26 INT8 CUDA reference. Mold keeps only the
+ * two kernels surrounding cuBLASLt; ConvRot remains in the shared Candle path.
+ */
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cfloat>
+#include <cstdint>
+
+constexpr int H3_INT8_THREADS = 256;
+
+template <typename T> __device__ __forceinline__ float h3_to_float(T value);
+template <> __device__ __forceinline__ float h3_to_float<float>(float value) { return value; }
+template <> __device__ __forceinline__ float h3_to_float<half>(half value) { return __half2float(value); }
+template <> __device__ __forceinline__ float h3_to_float<nv_bfloat16>(nv_bfloat16 value) {
+    return __bfloat162float(value);
+}
+
+template <typename T> __device__ __forceinline__ T h3_from_float(float value);
+template <> __device__ __forceinline__ float h3_from_float<float>(float value) { return value; }
+template <> __device__ __forceinline__ half h3_from_float<half>(float value) {
+    return __float2half_rn(value);
+}
+template <> __device__ __forceinline__ nv_bfloat16 h3_from_float<nv_bfloat16>(float value) {
+    return __float2bfloat16_rn(value);
+}
+
+template <typename T> __device__ __forceinline__ float h3_finite_max();
+template <> __device__ __forceinline__ float h3_finite_max<float>() { return FLT_MAX; }
+template <> __device__ __forceinline__ float h3_finite_max<half>() { return 65504.0f; }
+template <> __device__ __forceinline__ float h3_finite_max<nv_bfloat16>() { return 3.38953139e38f; }
+
+__device__ __forceinline__ float h3_warp_max(float value) {
+    for (int offset = 16; offset > 0; offset >>= 1) {
+        value = fmaxf(value, __shfl_down_sync(0xffffffff, value, offset));
+    }
+    return value;
+}
+
+template <typename T>
+__device__ __forceinline__ void h3_quantize_int8_rowwise_kernel(
+    const T* __restrict__ input,
+    int8_t* __restrict__ quantized,
+    float* __restrict__ scales,
+    int columns) {
+    __shared__ float warp_maxima[H3_INT8_THREADS / 32];
+    __shared__ float row_maximum;
+
+    const int row = static_cast<int>(blockIdx.x);
+    const int lane = threadIdx.x & 31;
+    const int warp = threadIdx.x >> 5;
+    const int64_t row_offset = static_cast<int64_t>(row) * columns;
+
+    float maximum = 0.0f;
+    for (int column = threadIdx.x; column < columns; column += blockDim.x) {
+        maximum = fmaxf(maximum, fabsf(h3_to_float(input[row_offset + column])));
+    }
+    maximum = h3_warp_max(maximum);
+    if (lane == 0) {
+        warp_maxima[warp] = maximum;
+    }
+    __syncthreads();
+    if (warp == 0) {
+        maximum = lane < H3_INT8_THREADS / 32 ? warp_maxima[lane] : 0.0f;
+        maximum = h3_warp_max(maximum);
+        if (lane == 0) {
+            row_maximum = maximum;
+        }
+    }
+    __syncthreads();
+
+    const float scale = fmaxf(
+        fminf(row_maximum, h3_finite_max<T>()) * (1.0f / 127.0f),
+        1.0e-30f);
+    if (threadIdx.x == 0) {
+        scales[row] = scale;
+    }
+    const float typed_scale = h3_to_float(h3_from_float<T>(scale));
+    for (int column = threadIdx.x; column < columns; column += blockDim.x) {
+        const int64_t index = row_offset + column;
+        const float value = h3_to_float(h3_from_float<T>(h3_to_float(input[index]) / typed_scale));
+        const float rounded = nearbyintf(value);
+        quantized[index] = static_cast<int8_t>(fminf(127.0f, fmaxf(-128.0f, rounded)));
+    }
+}
+
+template <typename T>
+__device__ __forceinline__ void h3_dequantize_int8_linear_kernel(
+    const int32_t* __restrict__ accumulator,
+    const float* __restrict__ input_scales,
+    const float* __restrict__ weight_scales,
+    T* __restrict__ output,
+    int64_t elements,
+    int columns) {
+    const int64_t index = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (index >= elements) {
+        return;
+    }
+    const int column = static_cast<int>(index % columns);
+    const int row = static_cast<int>(index / columns);
+    const float value = static_cast<float>(accumulator[index])
+        * input_scales[row]
+        * weight_scales[column];
+    output[index] = h3_from_float<T>(value);
+}
+
+extern "C" __global__ void h3_quantize_int8_rowwise_f32(
+    const float* input, int8_t* quantized, float* scales, int columns) {
+    h3_quantize_int8_rowwise_kernel(input, quantized, scales, columns);
+}
+
+extern "C" __global__ void h3_quantize_int8_rowwise_f16(
+    const half* input, int8_t* quantized, float* scales, int columns) {
+    h3_quantize_int8_rowwise_kernel(input, quantized, scales, columns);
+}
+
+extern "C" __global__ void h3_quantize_int8_rowwise_bf16(
+    const nv_bfloat16* input, int8_t* quantized, float* scales, int columns) {
+    h3_quantize_int8_rowwise_kernel(input, quantized, scales, columns);
+}
+
+extern "C" __global__ void h3_dequantize_int8_linear_f32(
+    const int32_t* accumulator, const float* input_scales, const float* weight_scales,
+    float* output, int64_t elements, int columns) {
+    h3_dequantize_int8_linear_kernel(
+        accumulator, input_scales, weight_scales, output, elements, columns);
+}
+
+extern "C" __global__ void h3_dequantize_int8_linear_f16(
+    const int32_t* accumulator, const float* input_scales, const float* weight_scales,
+    half* output, int64_t elements, int columns) {
+    h3_dequantize_int8_linear_kernel(
+        accumulator, input_scales, weight_scales, output, elements, columns);
+}
+
+extern "C" __global__ void h3_dequantize_int8_linear_bf16(
+    const int32_t* accumulator, const float* input_scales, const float* weight_scales,
+    nv_bfloat16* output, int64_t elements, int columns) {
+    h3_dequantize_int8_linear_kernel(
+        accumulator, input_scales, weight_scales, output, elements, columns);
+}

--- a/crates/mold-candle/src/minimax_h3/dit.rs
+++ b/crates/mold-candle/src/minimax_h3/dit.rs
@@ -1490,12 +1490,14 @@ impl H3ComfyInt8Attention {
                 candle::Error::Msg("MiniMax H3 attention row count overflows".into())
             })?;
             let dtype = hidden.dtype();
+            let native_cuda = cfg!(feature = "cuda") && hidden.device().is_cuda();
             let qkv_workspace = self.qkv.reference_workspace_upper_bound(
                 rows,
                 dtype,
                 dtype,
                 H3_COMFY_PORTABLE_ROW_CHUNK,
                 false,
+                native_cuda,
             )?;
             let out_workspace = self.out.reference_workspace_upper_bound(
                 rows,
@@ -1503,6 +1505,7 @@ impl H3ComfyInt8Attention {
                 dtype,
                 H3_COMFY_PORTABLE_ROW_CHUNK,
                 false,
+                native_cuda,
             )?;
             let qkv_width = self
                 .inner_dim
@@ -1600,6 +1603,7 @@ impl H3ComfyInt8Mlp {
                 dtype,
                 H3_COMFY_PORTABLE_ROW_CHUNK,
                 false,
+                cfg!(feature = "cuda") && hidden.device().is_cuda(),
             )?;
             let fc2 = self.fc2.reference_workspace_upper_bound(
                 input_rows,
@@ -1607,6 +1611,7 @@ impl H3ComfyInt8Mlp {
                 dtype,
                 H3_COMFY_PORTABLE_ROW_CHUNK,
                 false,
+                cfg!(feature = "cuda") && hidden.device().is_cuda(),
             )?;
             let retained_fc2 = projected
                 .checked_add(gated.saturating_mul(2))

--- a/crates/mold-candle/src/minimax_h3/int8_cuda.rs
+++ b/crates/mold-candle/src/minimax_h3/int8_cuda.rs
@@ -1,0 +1,499 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 Comfy Org. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Mold adaptation: native Candle custom-op dispatch, retained U8 checkpoint
+// storage, descriptor lifetime management, and dimension/device plan caching.
+
+use candle::backend::BackendStorage;
+use candle::cuda_backend::cudarc::cublas::sys::cublasOperation_t;
+use candle::cuda_backend::cudarc::cublaslt::{result as lt, sys};
+use candle::cuda_backend::cudarc::driver::{
+    DevicePtr, DevicePtrMut, DeviceRepr, LaunchConfig, PushKernelArg,
+};
+use candle::cuda_backend::{CudaDType, DeviceId, WrapErr};
+use candle::{CpuStorage, CudaStorage, CustomOp3, DType, Layout, Result, Shape, WithDType};
+use half::{bf16, f16};
+use std::ffi::c_void;
+use std::{cell::RefCell, collections::HashMap};
+
+use super::comfy_quant::H3_NATIVE_INT8_CUBLAS_WORKSPACE_BYTES;
+
+#[rustfmt::skip]
+mod kernels {
+    include!(concat!(env!("OUT_DIR"), "/h3_int8_cuda.rs"));
+}
+
+const THREADS: u32 = 256;
+
+struct LtPlan {
+    _device: candle::CudaDevice,
+    handle: sys::cublasLtHandle_t,
+    operation: sys::cublasLtMatmulDesc_t,
+    weight: sys::cublasLtMatrixLayout_t,
+    activation: sys::cublasLtMatrixLayout_t,
+    output: sys::cublasLtMatrixLayout_t,
+    preference: sys::cublasLtMatmulPreference_t,
+    algorithm: sys::cublasLtMatmulAlgo_t,
+}
+
+impl Drop for LtPlan {
+    fn drop(&mut self) {
+        // SAFETY: Every descriptor is created once by `new` and is owned by
+        // this plan until drop. Cleanup failures cannot be recovered here.
+        unsafe {
+            let _ = lt::destroy_matmul_pref(self.preference);
+            let _ = lt::destroy_matrix_layout(self.output);
+            let _ = lt::destroy_matrix_layout(self.activation);
+            let _ = lt::destroy_matrix_layout(self.weight);
+            let _ = lt::destroy_matmul_desc(self.operation);
+            let _ = lt::destroy_handle(self.handle);
+        }
+    }
+}
+
+impl LtPlan {
+    fn new(device: candle::CudaDevice, rows: usize, columns: usize, inner: usize) -> Result<Self> {
+        fn err(context: &str, error: impl std::fmt::Debug) -> candle::Error {
+            candle::Error::Msg(format!("MiniMax H3 {context}: {error:?}"))
+        }
+
+        let handle = lt::create_handle().map_err(|error| err("cuBLASLt handle", error))?;
+        let operation = match lt::create_matmul_desc(
+            sys::cublasComputeType_t::CUBLAS_COMPUTE_32I,
+            sys::cudaDataType_t::CUDA_R_32I,
+        ) {
+            Ok(value) => value,
+            Err(error) => {
+                // SAFETY: `handle` was created immediately above.
+                unsafe {
+                    let _ = lt::destroy_handle(handle);
+                }
+                return Err(err("cuBLASLt operation descriptor", error));
+            }
+        };
+
+        let mut weight = std::ptr::null_mut();
+        let mut activation = std::ptr::null_mut();
+        let mut output = std::ptr::null_mut();
+        let mut preference = std::ptr::null_mut();
+        let result = (|| -> Result<sys::cublasLtMatmulAlgo_t> {
+            let transa = cublasOperation_t::CUBLAS_OP_T;
+            let transb = cublasOperation_t::CUBLAS_OP_N;
+            // SAFETY: `operation` is live and the attribute pointers refer to
+            // correctly typed stack values for the duration of each call.
+            unsafe {
+                lt::set_matmul_desc_attribute(
+                    operation,
+                    sys::cublasLtMatmulDescAttributes_t::CUBLASLT_MATMUL_DESC_TRANSA,
+                    (&transa as *const cublasOperation_t).cast(),
+                    std::mem::size_of_val(&transa),
+                )
+                .map_err(|error| err("cuBLASLt transpose A", error))?;
+                lt::set_matmul_desc_attribute(
+                    operation,
+                    sys::cublasLtMatmulDescAttributes_t::CUBLASLT_MATMUL_DESC_TRANSB,
+                    (&transb as *const cublasOperation_t).cast(),
+                    std::mem::size_of_val(&transb),
+                )
+                .map_err(|error| err("cuBLASLt transpose B", error))?;
+            }
+            weight = lt::create_matrix_layout(
+                sys::cudaDataType_t::CUDA_R_8I,
+                inner as u64,
+                columns as u64,
+                inner as i64,
+            )
+            .map_err(|error| err("cuBLASLt weight layout", error))?;
+            activation = lt::create_matrix_layout(
+                sys::cudaDataType_t::CUDA_R_8I,
+                inner as u64,
+                rows as u64,
+                inner as i64,
+            )
+            .map_err(|error| err("cuBLASLt activation layout", error))?;
+            output = lt::create_matrix_layout(
+                sys::cudaDataType_t::CUDA_R_32I,
+                columns as u64,
+                rows as u64,
+                columns as i64,
+            )
+            .map_err(|error| err("cuBLASLt output layout", error))?;
+            preference =
+                lt::create_matmul_pref().map_err(|error| err("cuBLASLt preference", error))?;
+            let workspace_bytes = H3_NATIVE_INT8_CUBLAS_WORKSPACE_BYTES;
+            // SAFETY: `preference` is live and the pointer is valid for this call.
+            unsafe {
+                lt::set_matmul_pref_attribute(
+                    preference,
+                    sys::cublasLtMatmulPreferenceAttributes_t::CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES,
+                    (&workspace_bytes as *const usize).cast(),
+                    std::mem::size_of_val(&workspace_bytes),
+                )
+                .map_err(|error| err("cuBLASLt workspace preference", error))?;
+                let heuristic = lt::get_matmul_algo_heuristic(
+                    handle, operation, weight, activation, output, output, preference,
+                )
+                .map_err(|error| err("cuBLASLt INT8 heuristic", error))?;
+                Ok(heuristic.algo)
+            }
+        })();
+        let algorithm = match result {
+            Ok(value) => value,
+            Err(error) => {
+                // SAFETY: Only non-null descriptors were successfully created.
+                unsafe {
+                    if !preference.is_null() {
+                        let _ = lt::destroy_matmul_pref(preference);
+                    }
+                    if !output.is_null() {
+                        let _ = lt::destroy_matrix_layout(output);
+                    }
+                    if !activation.is_null() {
+                        let _ = lt::destroy_matrix_layout(activation);
+                    }
+                    if !weight.is_null() {
+                        let _ = lt::destroy_matrix_layout(weight);
+                    }
+                    let _ = lt::destroy_matmul_desc(operation);
+                    let _ = lt::destroy_handle(handle);
+                }
+                return Err(error);
+            }
+        };
+        Ok(Self {
+            _device: device,
+            handle,
+            operation,
+            weight,
+            activation,
+            output,
+            preference,
+            algorithm,
+        })
+    }
+}
+
+thread_local! {
+    static LT_PLANS: RefCell<HashMap<(DeviceId, usize, usize, usize), LtPlan>> =
+        RefCell::new(HashMap::new());
+}
+
+fn with_lt_plan<T>(
+    device: &candle::CudaDevice,
+    rows: usize,
+    columns: usize,
+    inner: usize,
+    f: impl FnOnce(&LtPlan) -> Result<T>,
+) -> Result<T> {
+    LT_PLANS.with(|plans| {
+        let mut plans = plans.borrow_mut();
+        let plan = match plans.entry((device.id(), rows, columns, inner)) {
+            std::collections::hash_map::Entry::Occupied(entry) => entry.into_mut(),
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert(LtPlan::new(device.clone(), rows, columns, inner)?)
+            }
+        };
+        f(plan)
+    })
+}
+
+#[derive(Debug)]
+struct H3Int8Linear {
+    rows: usize,
+    columns: usize,
+    inner: usize,
+    output_dtype: DType,
+}
+
+impl H3Int8Linear {
+    fn cuda_fwd_t<I, O>(
+        &self,
+        input: &CudaStorage,
+        input_layout: &Layout,
+        weight: &CudaStorage,
+        weight_layout: &Layout,
+        scales: &CudaStorage,
+        scale_layout: &Layout,
+    ) -> Result<(CudaStorage, Shape)>
+    where
+        I: CudaDType + DeviceRepr + WithDType,
+        O: CudaDType + DeviceRepr + WithDType,
+    {
+        let contiguous = |layout: &Layout, label: &str| -> Result<(usize, usize)> {
+            layout
+                .contiguous_offsets()
+                .ok_or_else(|| candle::Error::Msg(format!("MiniMax H3 {label} must be contiguous")))
+        };
+        let (input_start, input_end) = contiguous(input_layout, "INT8 activation")?;
+        let (weight_start, weight_end) = contiguous(weight_layout, "INT8 weight")?;
+        let (scale_start, scale_end) = contiguous(scale_layout, "INT8 scales")?;
+        if input_layout.shape().dims() != [self.rows, self.inner]
+            || weight_layout.shape().dims() != [self.columns, self.inner]
+            || !matches!(scale_layout.shape().dims(), [columns, 1] if *columns == self.columns)
+        {
+            candle::bail!("MiniMax H3 native INT8 CUDA operand shape mismatch")
+        }
+
+        let device = input.device();
+        let input = input.as_cuda_slice::<I>()?.slice(input_start..input_end);
+        let weight = weight
+            .as_cuda_slice::<u8>()?
+            .slice(weight_start..weight_end);
+        let scales = scales.as_cuda_slice::<f32>()?.slice(scale_start..scale_end);
+        let stream = device.cuda_stream();
+        // SAFETY: Every allocation is fully written by the queued kernel/GEMM
+        // before it is read or wrapped as the returned Candle storage.
+        let quantized = unsafe { stream.alloc::<i8>(self.rows * self.inner) }.w()?;
+        let input_scales = unsafe { stream.alloc::<f32>(self.rows) }.w()?;
+        let mut accumulator = unsafe { stream.alloc::<i32>(self.rows * self.columns) }.w()?;
+        let mut workspace =
+            unsafe { stream.alloc::<u8>(H3_NATIVE_INT8_CUBLAS_WORKSPACE_BYTES) }.w()?;
+        let output = unsafe { stream.alloc::<O>(self.rows * self.columns) }.w()?;
+
+        let quantize_name = match I::DTYPE {
+            DType::F32 => "h3_quantize_int8_rowwise_f32",
+            DType::F16 => "h3_quantize_int8_rowwise_f16",
+            DType::BF16 => "h3_quantize_int8_rowwise_bf16",
+            dtype => {
+                candle::bail!("MiniMax H3 native INT8 CUDA input dtype {dtype:?} is unsupported")
+            }
+        };
+        let quantize = device.get_or_load_custom_func(
+            quantize_name,
+            "h3-int8-linear",
+            kernels::INT8_LINEAR,
+        )?;
+        let mut builder = quantize.builder();
+        builder.arg(&input);
+        builder.arg(&quantized);
+        builder.arg(&input_scales);
+        candle::builder_arg!(builder, self.inner as i32);
+        let cfg = LaunchConfig {
+            grid_dim: (self.rows as u32, 1, 1),
+            block_dim: (THREADS, 1, 1),
+            shared_mem_bytes: 0,
+        };
+        // SAFETY: Kernel arguments and launch geometry match the compiled signature.
+        unsafe { builder.launch(cfg) }.w()?;
+
+        let (activation_ptr, activation_read) = quantized.device_ptr(&stream);
+        let (weight_ptr, weight_read) = weight.device_ptr(&stream);
+        let (accumulator_ptr, accumulator_write) = accumulator.device_ptr_mut(&stream);
+        let (workspace_ptr, workspace_write) = workspace.device_ptr_mut(&stream);
+        let alpha: i32 = 1;
+        let beta: i32 = 0;
+        with_lt_plan(device, self.rows, self.columns, self.inner, |plan| {
+            // SAFETY: The plan descriptors describe these exact contiguous
+            // row-major allocations and all pointers remain live until the
+            // queued operation.
+            unsafe {
+                lt::matmul(
+                    plan.handle,
+                    plan.operation,
+                    (&alpha as *const i32).cast(),
+                    (&beta as *const i32).cast(),
+                    weight_ptr as *const c_void,
+                    plan.weight,
+                    activation_ptr as *const c_void,
+                    plan.activation,
+                    accumulator_ptr as *const c_void,
+                    plan.output,
+                    accumulator_ptr as *mut c_void,
+                    plan.output,
+                    &plan.algorithm,
+                    workspace_ptr as *mut c_void,
+                    H3_NATIVE_INT8_CUBLAS_WORKSPACE_BYTES,
+                    stream.cu_stream().cast(),
+                )
+                .map_err(|error| {
+                    candle::Error::Msg(format!("MiniMax H3 INT8 cuBLASLt GEMM: {error:?}"))
+                })
+            }
+        })?;
+        drop(workspace_write);
+        drop(accumulator_write);
+        drop(weight_read);
+        drop(activation_read);
+
+        let dequantize_name = match O::DTYPE {
+            DType::F32 => "h3_dequantize_int8_linear_f32",
+            DType::F16 => "h3_dequantize_int8_linear_f16",
+            DType::BF16 => "h3_dequantize_int8_linear_bf16",
+            dtype => {
+                candle::bail!("MiniMax H3 native INT8 CUDA output dtype {dtype:?} is unsupported")
+            }
+        };
+        let dequantize = device.get_or_load_custom_func(
+            dequantize_name,
+            "h3-int8-linear",
+            kernels::INT8_LINEAR,
+        )?;
+        let mut builder = dequantize.builder();
+        builder.arg(&accumulator);
+        builder.arg(&input_scales);
+        builder.arg(&scales);
+        builder.arg(&output);
+        candle::builder_arg!(
+            builder,
+            (self.rows * self.columns) as i64,
+            self.columns as i32
+        );
+        let cfg = LaunchConfig::for_num_elems((self.rows * self.columns) as u32);
+        // SAFETY: Kernel arguments and launch geometry match the compiled signature.
+        unsafe { builder.launch(cfg) }.w()?;
+
+        Ok((
+            CudaStorage::wrap_cuda_slice(output, device.clone()),
+            (self.rows, self.columns).into(),
+        ))
+    }
+}
+
+impl CustomOp3 for H3Int8Linear {
+    fn name(&self) -> &'static str {
+        "minimax-h3-native-int8-linear"
+    }
+
+    fn cpu_fwd(
+        &self,
+        _: &CpuStorage,
+        _: &Layout,
+        _: &CpuStorage,
+        _: &Layout,
+        _: &CpuStorage,
+        _: &Layout,
+    ) -> Result<(CpuStorage, Shape)> {
+        candle::bail!("MiniMax H3 native INT8 linear is CUDA-only")
+    }
+
+    fn cuda_fwd(
+        &self,
+        input: &CudaStorage,
+        input_layout: &Layout,
+        weight: &CudaStorage,
+        weight_layout: &Layout,
+        scales: &CudaStorage,
+        scale_layout: &Layout,
+    ) -> Result<(CudaStorage, Shape)> {
+        macro_rules! output_dispatch {
+            ($input:ty) => {
+                match self.output_dtype {
+                    DType::F32 => self.cuda_fwd_t::<$input, f32>(
+                        input,
+                        input_layout,
+                        weight,
+                        weight_layout,
+                        scales,
+                        scale_layout,
+                    ),
+                    DType::F16 => self.cuda_fwd_t::<$input, f16>(
+                        input,
+                        input_layout,
+                        weight,
+                        weight_layout,
+                        scales,
+                        scale_layout,
+                    ),
+                    DType::BF16 => self.cuda_fwd_t::<$input, bf16>(
+                        input,
+                        input_layout,
+                        weight,
+                        weight_layout,
+                        scales,
+                        scale_layout,
+                    ),
+                    dtype => candle::bail!(
+                        "MiniMax H3 native INT8 CUDA output dtype {dtype:?} is unsupported"
+                    ),
+                }
+            };
+        }
+        match input.dtype() {
+            DType::F32 => output_dispatch!(f32),
+            DType::F16 => output_dispatch!(f16),
+            DType::BF16 => output_dispatch!(bf16),
+            dtype => {
+                candle::bail!("MiniMax H3 native INT8 CUDA input dtype {dtype:?} is unsupported")
+            }
+        }
+    }
+}
+
+pub(crate) fn native_int8_linear(
+    input: &candle::Tensor,
+    weight: &candle::Tensor,
+    scales: &candle::Tensor,
+    output_dtype: DType,
+) -> Result<candle::Tensor> {
+    let (rows, inner) = input.dims2()?;
+    let (columns, weight_inner) = weight.dims2()?;
+    validate_native_int8_dimensions(rows, columns, inner, weight_inner)?;
+    let activation_elements = rows.checked_mul(inner).ok_or_else(|| {
+        candle::Error::Msg("MiniMax H3 native INT8 activation size overflows".into())
+    })?;
+    let weight_elements = columns
+        .checked_mul(inner)
+        .ok_or_else(|| candle::Error::Msg("MiniMax H3 native INT8 weight size overflows".into()))?;
+    let output_elements = rows
+        .checked_mul(columns)
+        .ok_or_else(|| candle::Error::Msg("MiniMax H3 native INT8 output size overflows".into()))?;
+    u32::try_from(output_elements).map_err(|_| {
+        candle::Error::Msg("MiniMax H3 native INT8 output element count exceeds u32".into())
+    })?;
+    if input.elem_count() != activation_elements || weight.elem_count() != weight_elements {
+        candle::bail!("MiniMax H3 native INT8 CUDA operand element count mismatch")
+    }
+    input.apply_op3_no_bwd(
+        weight,
+        scales,
+        &H3Int8Linear {
+            rows,
+            columns,
+            inner,
+            output_dtype,
+        },
+    )
+}
+
+fn validate_native_int8_dimensions(
+    rows: usize,
+    columns: usize,
+    inner: usize,
+    weight_inner: usize,
+) -> Result<()> {
+    if rows == 0 || columns == 0 || inner == 0 {
+        candle::bail!("MiniMax H3 native INT8 CUDA dimensions must be positive")
+    }
+    if inner != weight_inner {
+        candle::bail!("MiniMax H3 native INT8 CUDA inner dimension mismatch")
+    }
+    if !inner.is_multiple_of(4) || !columns.is_multiple_of(4) {
+        candle::bail!("MiniMax H3 native INT8 CUDA dimensions must be multiples of four")
+    }
+    i32::try_from(rows)
+        .map_err(|_| candle::Error::Msg("MiniMax H3 native INT8 row count exceeds i32".into()))?;
+    i32::try_from(columns).map_err(|_| {
+        candle::Error::Msg("MiniMax H3 native INT8 output width exceeds i32".into())
+    })?;
+    i32::try_from(inner)
+        .map_err(|_| candle::Error::Msg("MiniMax H3 native INT8 inner width exceeds i32".into()))?;
+    const MAX_SIGNED_INT8_PRODUCT: usize = 128 * 128;
+    if inner > i32::MAX as usize / MAX_SIGNED_INT8_PRODUCT {
+        candle::bail!("MiniMax H3 native INT8 dot product can overflow i32")
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_native_int8_dimensions;
+
+    #[test]
+    fn native_int8_dimensions_reject_index_and_accumulator_overflow() {
+        validate_native_int8_dimensions(3, 8, 256, 256).unwrap();
+        assert!(validate_native_int8_dimensions(i32::MAX as usize + 1, 8, 256, 256).is_err());
+        assert!(validate_native_int8_dimensions(3, i32::MAX as usize + 1, 256, 256).is_err());
+        assert!(validate_native_int8_dimensions(3, 8, 131_072, 131_072).is_err());
+    }
+}

--- a/crates/mold-candle/src/minimax_h3/mod.rs
+++ b/crates/mold-candle/src/minimax_h3/mod.rs
@@ -10,6 +10,8 @@ mod comfy_dit;
 mod comfy_quant;
 mod config;
 mod dit;
+#[cfg(feature = "cuda")]
+mod int8_cuda;
 mod loader;
 mod model;
 mod presentation;

--- a/docs/qualification/minimax-h3-comfy-quantization.md
+++ b/docs/qualification/minimax-h3-comfy-quantization.md
@@ -1,7 +1,8 @@
 # MiniMax H3 Comfy quantization source audit
 
-Status: authorized bounded artifact contract plus portable primitives; runtime
-activation remains blocked.
+Status: authorized compact acquisition plus one exact private CUDA FL2VA
+runtime envelope. Any executable-path change, including the native INT8 kernel
+described below, requires a fresh exact-source campaign before allowlisting.
 
 The source-derived quantization math remains pinned to public implementation
 source. After the project received authorization for private qualification,
@@ -10,9 +11,9 @@ safetensors header and its small per-layer `comfy_quant` marker tensors. The
 complete artifact digest was verified independently against the pinned
 manifest identity; no weight payload or generated output is committed. The
 model's public-product license gate in `mold-core` remains authoritative.
-Frozen H3 factory authority and FL2VA/Ref2VA dispatch seams exist, but
-`runtime_available` remains false and the Comfy checkpoint candidate continues
-to reject every production runtime backend.
+Frozen H3 factory authority and FL2VA/Ref2VA dispatch seams remain separate
+from acquisition. Only the independently reviewed compact FL2VA envelope is
+admissible; Ref2VA and broader runtime routes remain closed.
 
 ## Pinned implementation sources
 
@@ -28,7 +29,9 @@ to reject every production runtime backend.
 The relevant ComfyUI authorities are `comfy/quant_ops.py`, `comfy/ops.py`,
 `comfy/sd1_clip.py`, and `comfy/text_encoders/minimax.py`. The relevant
 comfy-kitchen authorities are `tensor/int8.py`, `tensor/int8_utils.py`,
-`tensor/nvfp4.py`, `backends/eager/quantization.py`, and `float_utils.py`.
+`tensor/nvfp4.py`, `backends/eager/quantization.py`,
+`backends/cuda/ops/int8_linear.cu`,
+`backends/cuda/ops/cublas_gemm_int8.cu`, and `float_utils.py`.
 
 ## Pruned DiT INT8 ConvRot
 
@@ -47,23 +50,42 @@ Q_w[row] = round(W_rot[row] / s_w[row])
 ```
 
 The accelerated forward rotates activations online, dynamically quantizes each
-activation row, performs an INT8 accumulation, and applies the activation and
-weight scales. The portable Mold path deliberately uses the source-defined
-dequantized alternative instead:
+activation row, performs an INT8-to-INT32 accumulation, and applies the
+activation and weight scales. Mold's CUDA path now follows that boundary:
+
+```text
+x_rot = bf16_or_f16_or_f32(x * H)
+s_x = f32(max(abs(x_rot))) / 127
+Q_x = i8(round_ties_even(x_rot / cast_input_dtype(s_x)))
+A = int32(Q_x * Q_w^T)
+y = cast_output_dtype(f32(A) * s_x * s_w)
+```
+
+The CUDA implementation retains exact checkpoint bytes as U8 Candle storage,
+passes their unchanged device pointer to signed-INT8 cuBLASLt layouts, caches
+the dimension/device-specific plan, and uses source-matched row-quantization
+and dequantization kernels. F32 and BF16 regression cases are pinned against
+the released operation order. A representative
+`[4096,5376] x [7168,5376]^T` BF16 projection measured about 42 ms after plan
+warmup on the qualification L40S; this is a focused operator measurement, not
+a full-render timing claim.
+
+CPU and Metal retain the source-defined portable fallback:
 
 ```text
 y = (x * H) * (Q_w * s_w)^T + bias
 ```
 
-Because `H` is symmetric and orthonormal, this equals a full-precision linear
-operation with the reconstructed `W = (Q_w * s_w) * H`. Output-row chunking
-keeps the dense F32 staging bound explicit. It does not claim numerical parity
-with Comfy's additional lossy activation quantization or fused CUDA kernel.
+Because `H` is symmetric and orthonormal, the fallback equals a full-precision
+linear operation with reconstructed `W = (Q_w * s_w) * H`. Output-row chunking
+keeps its dense F32 staging bound explicit. It intentionally does not claim
+numerical parity with the lossy CUDA W8A8 path.
 
 Candle has no signed-I8 tensor dtype. Mold retains checkpoint INT8 data as
-unaltered two's-complement bytes in CPU U8 storage and widens each byte through
-signed interpretation when staging a chunk. A numeric U8 cast would corrupt
-negative weights and is never used.
+unaltered two's-complement bytes in CPU U8 storage. Portable execution widens
+each byte through signed interpretation; CUDA transfers the same U8 bytes and
+binds them to a signed-I8 matrix layout without numeric conversion. A numeric
+U8 cast would corrupt negative weights and is never used.
 
 ## Pruned DiT scaled FP8
 

--- a/scripts/tests/minimax-h3-private-uat-release-contract.sh
+++ b/scripts/tests/minimax-h3-private-uat-release-contract.sh
@@ -19,6 +19,17 @@ require_text() {
 require_text crates/mold-candle/Cargo.toml \
   'h3-private-uat = []' \
   "mold-candle does not keep the private H3 runtime behind its own feature"
+require_text crates/mold-candle/Cargo.toml \
+  'license = "MIT AND Apache-2.0"' \
+  "mold-candle does not declare the combined license of its packaged sources"
+require_text crates/mold-candle/THIRD_PARTY_NOTICES.md \
+  'comfy-kitchen INT8 CUDA reference' \
+  "mold-candle omits the packaged INT8 CUDA attribution notice"
+package_files=$(cargo package -p mold-ai-candle --allow-dirty --no-verify --list)
+for packaged_notice in LICENSE-MIT LICENSE-APACHE-2.0 THIRD_PARTY_NOTICES.md; do
+  grep -Fxq "$packaged_notice" <<<"$package_files" \
+    || fail "mold-candle package omits ${packaged_notice}"
+done
 require_text crates/mold-inference/Cargo.toml \
   'h3-private-uat = ["mold-candle/h3-private-uat"]' \
   "mold-inference does not narrowly forward the private H3 runtime feature"


### PR DESCRIPTION
## Summary

- replace compact H3 DiT portable F32 projections on CUDA with the pinned upstream W8A8 path: BF16/F16/F32 row quantization, signed INT8 cuBLASLt accumulation into INT32, and ordered F32 scale application
- cache device-and-shape-specific cuBLASLt plans and conservatively account every native workspace allocation in private runtime qualification
- retain portable CPU/Metal and Qwen paths, with fail-closed dimension and overflow guards
- ship the Apache-derived source with correct combined crate metadata, licenses, attribution, and a package-content release regression

## Evidence

- authorized L40S exact F32 portable parity and exact BF16 upstream oracle pass
- representative `[4096,5376] x [7168,5376]^T` BF16 projection: about 42 ms after plan warmup
- authorized L40S CUDA Clippy `-D warnings` and fallback regression pass
- local Nix: 186 H3 tests pass (1 authorization-only ignore), non-CUDA Clippy, rustfmt, private-UAT release contract, and crate package-content check pass
- mandatory independent exact-head peer review approved commit `8e180b30`

This changes the qualified executable identity. A fresh exact-source campaign is required before the private allowlist can use the optimized runtime.

Refs #830
Refs #814