### PR TITLE
fix(cuda): include candle kernel build inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Restore CUDA distribution builds after the H3 native INT8 kernel landed by including the Candle build script and its CUDA source in Docker's dependency-cache context, with a release-contract regression for the compiled input.
+
 - Run compact MiniMax H3 DiT INT8 projections through the source-matched CUDA path: BF16/F16/F32 ConvRot activations are dynamically quantized by row, multiplied as signed INT8 into INT32 with cached cuBLASLt plans, and dequantized in the pinned F32 scale order. A representative 4096x5376 by 7168 BF16 projection on the qualification L40S measured about 42 ms after plan warmup; the portable CPU/Metal and Qwen weight-only paths are unchanged. This optimization changes the qualified executable identity, so a fresh exact-source campaign remains required before the private allowlist can use it.
 
 - Stage MiniMax H3 compact INT8 transformer weight bytes directly on the execution device before exact signed widening, eliminating per-evaluation host scalar expansion and reducing each streamed weight transfer from four bytes per value to one without changing the portable W8A8 reference equations.

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,6 +82,8 @@ COPY crates/mold-core/Cargo.toml crates/mold-core/Cargo.toml
 COPY crates/mold-catalog/Cargo.toml crates/mold-catalog/Cargo.toml
 COPY crates/mold-db/Cargo.toml crates/mold-db/Cargo.toml
 COPY crates/mold-candle/Cargo.toml crates/mold-candle/Cargo.toml
+COPY crates/mold-candle/build.rs crates/mold-candle/build.rs
+COPY crates/mold-candle/src/minimax_h3/cuda/int8_linear.cu crates/mold-candle/src/minimax_h3/cuda/int8_linear.cu
 COPY crates/mold-inference/Cargo.toml crates/mold-inference/Cargo.toml
 COPY crates/mold-scheduler/Cargo.toml crates/mold-scheduler/Cargo.toml
 COPY crates/mold-server/Cargo.toml crates/mold-server/Cargo.toml

--- a/scripts/tests/cuda-distribution-contract.sh
+++ b/scripts/tests/cuda-distribution-contract.sh
@@ -106,6 +106,8 @@ require_text "Dockerfile" \
   'scripts/seal-cuda-ptx-manifest.py /build/target/release/mold'
 require_text "Dockerfile" \
   'scripts/probe-cuda-embedded-ptx.py /build/target/release/mold'
+require_text "Dockerfile" \
+  'COPY crates/mold-candle/src/minimax_h3/cuda/int8_linear.cu crates/mold-candle/src/minimax_h3/cuda/int8_linear.cu'
 while IFS= read -r workspace_member; do
   require_text "Dockerfile" \
     "COPY ${workspace_member}/Cargo.toml ${workspace_member}/Cargo.toml"


### PR DESCRIPTION
## Summary

- include the `mold-candle` build script in Docker dependency caching
- include the CUDA source consumed by that build script before the cache-stage build
- guard the compiled CUDA input in the distribution contract

## Verification

- exact-snapshot mandatory peer review approved after catching and closing the missing CUDA-source dependency
- `git diff --check`
- shell syntax and exact Docker COPY assertions pass locally
- the full distribution contract proceeds through this repaired assertion; its nested Linux ELF fixture suite requires CI because macOS does not provide the expected ELF behavior

## Context

Post-merge CI for #1003 failed because the Docker dependency-cache context omitted the newly added Candle build script. Copying only the script would still fail when it opened its CUDA source, so this patch includes and pins both inputs.