### PR TITLE
fix(profiles): refresh wan measured defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Refresh the generated Wan 2.2 A14B capability profiles after the measured RTX 4090 frame-envelope defaults changed, restoring the deterministic generation-profile CI gate.
+
 - Make the private MiniMax H3 terminal publication gate identify the mismatched non-secret contract axis while continuing to fail closed, so a successful expensive render cannot collapse model, media, source-fingerprint, or provenance failures into one unactionable message.
 
 - Restore CUDA distribution builds after the H3 native INT8 kernel landed by including the Candle build script and its CUDA source in Docker's dependency-cache context, with a release-contract regression for the compiled input.

--- a/docs/generated/generation-profiles-v1.json
+++ b/docs/generated/generation-profiles-v1.json
@@ -20498,7 +20498,7 @@
       "profile": {
         "schema_version": 1,
         "profile_id": "wan.wan22-i2v-a14b",
-        "profile_hash": "1b25374233788728a736c10bb64f4120d7fd54d889525dbedb48952a6457bc38",
+        "profile_hash": "b1b456db84441fbe2b68d5623ec330a0225db399ad46e19809fd67f79fada023",
         "default_recipe_id": "default",
         "recipes": [
           {
@@ -20510,7 +20510,7 @@
               "height": 480,
               "steps": 20,
               "guidance": 3.5,
-              "frames": 33,
+              "frames": 45,
               "fps": 16,
               "negative_prompt": "色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走"
             },
@@ -20590,12 +20590,12 @@
             },
             "temporal": {
               "frames": {
-                "default": 33,
+                "default": 45,
                 "min": 1,
                 "max": 257,
                 "step": 4,
                 "recommended": [
-                  33
+                  45
                 ],
                 "mode": "adjustable"
               },
@@ -20902,7 +20902,7 @@
       "profile": {
         "schema_version": 1,
         "profile_id": "wan.wan22-i2v-a14b",
-        "profile_hash": "336c247661f038abcdcfb6a8cd5445736356d98e6652c13bbf0c997dfe5b4c61",
+        "profile_hash": "3a13c7774410f2cec5b92ab77d2502e95f14a8269217beb98ffa4ae8a1821810",
         "default_recipe_id": "default",
         "recipes": [
           {
@@ -20914,7 +20914,7 @@
               "height": 480,
               "steps": 20,
               "guidance": 3.5,
-              "frames": 33,
+              "frames": 73,
               "fps": 16,
               "negative_prompt": "色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走"
             },
@@ -20994,12 +20994,12 @@
             },
             "temporal": {
               "frames": {
-                "default": 33,
+                "default": 73,
                 "min": 1,
                 "max": 257,
                 "step": 4,
                 "recommended": [
-                  33
+                  73
                 ],
                 "mode": "adjustable"
               },
@@ -21101,7 +21101,7 @@
       "profile": {
         "schema_version": 1,
         "profile_id": "wan.wan22-t2v-a14b",
-        "profile_hash": "b6b43fd3534f4c01921d141958be4b380216936a61ad4cd0c47860ad4f00081f",
+        "profile_hash": "72bc0445be2151847f91d9db6645039d24a784229b9c0c21c9ac3174bb97d2a0",
         "default_recipe_id": "default",
         "recipes": [
           {
@@ -21113,7 +21113,7 @@
               "height": 480,
               "steps": 20,
               "guidance": 3.5,
-              "frames": 33,
+              "frames": 45,
               "fps": 16,
               "negative_prompt": "色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走"
             },
@@ -21193,12 +21193,12 @@
             },
             "temporal": {
               "frames": {
-                "default": 33,
+                "default": 45,
                 "min": 1,
                 "max": 257,
                 "step": 4,
                 "recommended": [
-                  33
+                  45
                 ],
                 "mode": "adjustable"
               },
@@ -21505,7 +21505,7 @@
       "profile": {
         "schema_version": 1,
         "profile_id": "wan.wan22-t2v-a14b",
-        "profile_hash": "f0ae6ec71175c832387067e71c38118c130275ae06c764e687d74aad30ff9443",
+        "profile_hash": "350ae3e22cd7cd0b7c7db1f0a2f3954bb91a64b5b9a7326d6f698918193d9431",
         "default_recipe_id": "default",
         "recipes": [
           {
@@ -21517,7 +21517,7 @@
               "height": 480,
               "steps": 20,
               "guidance": 3.5,
-              "frames": 33,
+              "frames": 73,
               "fps": 16,
               "negative_prompt": "色调艳丽，过曝，静态，细节模糊不清，字幕，风格，作品，画作，画面，静止，整体发灰，最差质量，低质量，JPEG压缩残留，丑陋的，残缺的，多余的手指，画得不好的手部，画得不好的脸部，畸形的，毁容的，形态畸形的肢体，手指融合，静止不动的画面，杂乱的背景，三条腿，背景人很多，倒着走"
             },
@@ -21597,12 +21597,12 @@
             },
             "temporal": {
               "frames": {
-                "default": 33,
+                "default": 73,
                 "min": 1,
                 "max": 257,
                 "step": 4,
                 "recommended": [
-                  33
+                  73
                 ],
                 "mode": "adjustable"
               },

--- a/docs/model-resolution-matrix.md
+++ b/docs/model-resolution-matrix.md
@@ -1954,7 +1954,7 @@ Provenance: [Upstream](https://github.com/Wan-Video/Wan2.2) at `42bf4cfaa384bc21
 
 ### `wan22-i2v-a14b:fp8`
 
-Schema 1 · hash `1b25374233788728a736c10bb64f4120d7fd54d889525dbedb48952a6457bc38` · default recipe `default`
+Schema 1 · hash `b1b456db84441fbe2b68d5623ec330a0225db399ad46e19809fd67f79fada023` · default recipe `default`
 
 Models: `wan22-i2v-a14b:fp8`.
 
@@ -1963,7 +1963,7 @@ Models: `wan22-i2v-a14b:fp8`.
 - Resolution: buckets; alignment `16`; minimum `64x64`; maximum `1800000` pixels; axis limit `none`; aspect range `unbounded`.
 - Defaults: `832x480`, 20 steps, guidance 3.5.
 - Steps: 1–100 by 1; guidance: 0–100 by 0.1 (Adjustable).
-- Temporal: frames 1–257 on `4n+1` (default 33); FPS 1–120 by 1, default 16; duration limit none.
+- Temporal: frames 1–257 on `4n+1` (default 45); FPS 1–120 by 1, default 16; duration limit none.
 
 | Exact ratio | Qualified presets |
 |---|---|
@@ -1998,7 +1998,7 @@ Provenance: [Upstream](https://github.com/Wan-Video/Wan2.2) at `42bf4cfaa384bc21
 
 ### `wan22-i2v-a14b:q8`
 
-Schema 1 · hash `336c247661f038abcdcfb6a8cd5445736356d98e6652c13bbf0c997dfe5b4c61` · default recipe `default`
+Schema 1 · hash `3a13c7774410f2cec5b92ab77d2502e95f14a8269217beb98ffa4ae8a1821810` · default recipe `default`
 
 Models: `wan22-i2v-a14b:q8`.
 
@@ -2007,7 +2007,7 @@ Models: `wan22-i2v-a14b:q8`.
 - Resolution: buckets; alignment `16`; minimum `64x64`; maximum `1800000` pixels; axis limit `none`; aspect range `unbounded`.
 - Defaults: `832x480`, 20 steps, guidance 3.5.
 - Steps: 1–100 by 1; guidance: 0–100 by 0.1 (Adjustable).
-- Temporal: frames 1–257 on `4n+1` (default 33); FPS 1–120 by 1, default 16; duration limit none.
+- Temporal: frames 1–257 on `4n+1` (default 73); FPS 1–120 by 1, default 16; duration limit none.
 
 | Exact ratio | Qualified presets |
 |---|---|
@@ -2020,7 +2020,7 @@ Provenance: [Upstream](https://github.com/Wan-Video/Wan2.2) at `42bf4cfaa384bc21
 
 ### `wan22-t2v-a14b:fp8`
 
-Schema 1 · hash `b6b43fd3534f4c01921d141958be4b380216936a61ad4cd0c47860ad4f00081f` · default recipe `default`
+Schema 1 · hash `72bc0445be2151847f91d9db6645039d24a784229b9c0c21c9ac3174bb97d2a0` · default recipe `default`
 
 Models: `wan22-t2v-a14b:fp8`.
 
@@ -2029,7 +2029,7 @@ Models: `wan22-t2v-a14b:fp8`.
 - Resolution: buckets; alignment `16`; minimum `64x64`; maximum `1800000` pixels; axis limit `none`; aspect range `unbounded`.
 - Defaults: `832x480`, 20 steps, guidance 3.5.
 - Steps: 1–100 by 1; guidance: 0–100 by 0.1 (Adjustable).
-- Temporal: frames 1–257 on `4n+1` (default 33); FPS 1–120 by 1, default 16; duration limit none.
+- Temporal: frames 1–257 on `4n+1` (default 45); FPS 1–120 by 1, default 16; duration limit none.
 
 | Exact ratio | Qualified presets |
 |---|---|
@@ -2064,7 +2064,7 @@ Provenance: [Upstream](https://github.com/Wan-Video/Wan2.2) at `42bf4cfaa384bc21
 
 ### `wan22-t2v-a14b:q8`
 
-Schema 1 · hash `f0ae6ec71175c832387067e71c38118c130275ae06c764e687d74aad30ff9443` · default recipe `default`
+Schema 1 · hash `350ae3e22cd7cd0b7c7db1f0a2f3954bb91a64b5b9a7326d6f698918193d9431` · default recipe `default`
 
 Models: `wan22-t2v-a14b:q8`.
 
@@ -2073,7 +2073,7 @@ Models: `wan22-t2v-a14b:q8`.
 - Resolution: buckets; alignment `16`; minimum `64x64`; maximum `1800000` pixels; axis limit `none`; aspect range `unbounded`.
 - Defaults: `832x480`, 20 steps, guidance 3.5.
 - Steps: 1–100 by 1; guidance: 0–100 by 0.1 (Adjustable).
-- Temporal: frames 1–257 on `4n+1` (default 33); FPS 1–120 by 1, default 16; duration limit none.
+- Temporal: frames 1–257 on `4n+1` (default 73); FPS 1–120 by 1, default 16; duration limit none.
 
 | Exact ratio | Qualified presets |
 |---|---|


### PR DESCRIPTION
## Summary
- regenerate Wan 2.2 A14B profiles after measured RTX 4090 defaults changed
- align generated JSON and the resolution matrix for FP8 45-frame and Q8 73-frame defaults
- restore the deterministic generation-profile CI gate

## Verification
- `nix develop --no-write-lock-file -c cargo run -p mold-ai-core --bin generate_generation_profiles -- --check`
- `git diff --check`

Peer-reviewed on the exact final snapshot with no findings.