### PR TITLE
fix(h3): align terminal duration rounding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix private MiniMax H3 terminal publication to compare the MP4 container's
+  frame duration with ceiling millisecond rounding, matching the retained
+  124-frame, 24 fps mux result instead of rejecting it one millisecond early;
+  the inference-source change alters the authenticated runtime identity, so a
+  fresh exact-source campaign and independent review remain required.
+
 - Refresh the generated Wan 2.2 A14B capability profiles after the measured RTX 4090 frame-envelope defaults changed, restoring the deterministic generation-profile CI gate.
 
 - Make the private MiniMax H3 terminal publication gate identify the mismatched non-secret contract axis while continuing to fail closed, so a successful expensive render cannot collapse model, media, source-fingerprint, or provenance failures into one unactionable message.

--- a/crates/mold-inference/src/av_media.rs
+++ b/crates/mold-inference/src/av_media.rs
@@ -192,6 +192,22 @@ pub struct MuxedMp4 {
     pub report: AacMuxReport,
 }
 
+/// Convert an exact media timeline to the smallest whole millisecond that
+/// contains it. Container timestamps describe a half-open interval, so floor
+/// division would report a duration shorter than a non-integral timeline.
+pub fn timeline_duration_ms(duration_ticks: u64, timescale: u32) -> Result<u64> {
+    if duration_ticks == 0 {
+        bail!("media timeline duration must be greater than zero");
+    }
+    if timescale == 0 {
+        bail!("media timeline timescale must be greater than zero");
+    }
+    duration_ticks
+        .checked_mul(1_000)
+        .context("media timeline millisecond duration overflow")
+        .map(|duration| duration.div_ceil(u64::from(timescale)))
+}
+
 /// Round a media timeline to the nearest whole PCM sample without accumulating
 /// a per-frame error.
 ///
@@ -753,6 +769,15 @@ mod tests {
         assert!(aligned_sample_count(0, 24, 32_000).is_err());
         assert!(aligned_sample_count(124, 0, 32_000).is_err());
         assert!(aligned_sample_count(124, 24, 0).is_err());
+        assert!(timeline_duration_ms(0, 24_000).is_err());
+        assert!(timeline_duration_ms(124_000, 0).is_err());
+        assert!(timeline_duration_ms(u64::MAX, 1).is_err());
+    }
+
+    #[test]
+    fn timeline_duration_covers_non_integral_last_millisecond() {
+        assert_eq!(timeline_duration_ms(124_000, 24_000).unwrap(), 5_167);
+        assert_eq!(timeline_duration_ms(120_000, 24_000).unwrap(), 5_000);
     }
 
     #[cfg(feature = "mp4")]

--- a/crates/mold-inference/src/minimax_h3/engine.rs
+++ b/crates/mold-inference/src/minimax_h3/engine.rs
@@ -676,10 +676,11 @@ where
             let staged =
                 pipeline::execute_staged(&prepared, &mut runtime.backend, progress, observer)?;
             let output = pipeline::finalize_av(staged, progress, observer)?;
-            let duration_ms = u64::from(1_000_u16)
-                .checked_mul(output.mux_report.video_duration_ticks)
-                .context("MiniMax H3 output duration overflow")?
-                / u64::from(output.mux_report.video_timescale);
+            let duration_ms = crate::av_media::timeline_duration_ms(
+                output.mux_report.video_duration_ticks,
+                output.mux_report.video_timescale,
+            )
+            .context("MiniMax H3 output has an invalid duration")?;
             Ok(H3EngineOutput {
                 mp4: output.mp4,
                 thumbnail_png: output.thumbnail_png,
@@ -792,10 +793,11 @@ fn h3_engine_output_from_pipeline(
     mode: Mode,
     component_set_identity_sha256: &str,
 ) -> Result<H3EngineOutput> {
-    let duration_ms = u64::from(1_000_u16)
-        .checked_mul(output.mux_report.video_duration_ticks)
-        .context("MiniMax H3 output duration overflow")?
-        / u64::from(output.mux_report.video_timescale);
+    let duration_ms = crate::av_media::timeline_duration_ms(
+        output.mux_report.video_duration_ticks,
+        output.mux_report.video_timescale,
+    )
+    .context("MiniMax H3 output has an invalid duration")?;
     Ok(H3EngineOutput {
         mp4: output.mp4,
         thumbnail_png: output.thumbnail_png,

--- a/crates/mold-inference/src/minimax_h3/private_server.rs
+++ b/crates/mold-inference/src/minimax_h3/private_server.rs
@@ -3072,17 +3072,11 @@ fn private_run_output(
     {
         bail!("private H3 terminal output differs from the prepared attempt authority")
     }
-    let timescale = u64::from(output.mux_report.video_timescale);
-    if timescale == 0 {
-        bail!("private H3 mux returned a zero video timescale")
-    }
-    let duration_ms = 1_000_u64
-        .checked_mul(output.mux_report.video_duration_ticks)
-        .context("private H3 output duration overflow")?
-        / timescale;
-    if duration_ms == 0 {
-        bail!("private H3 mux returned a zero duration")
-    }
+    let duration_ms = crate::av_media::timeline_duration_ms(
+        output.mux_report.video_duration_ticks,
+        output.mux_report.video_timescale,
+    )
+    .context("private H3 mux returned an invalid duration")?;
     let pipeline_provenance_sha256 =
         format!("{:x}", Sha256::digest(serde_json::to_vec(provenance)?));
     let generation_time_ms = u64::try_from(started.elapsed().as_millis())

--- a/crates/mold-server/src/gpu_worker.rs
+++ b/crates/mold-server/src/gpu_worker.rs
@@ -3263,12 +3263,13 @@ fn validate_h3_publication_contract(
         .request
         .frames
         .unwrap_or(mold_core::minimax_h3::MIN_FRAMES);
-    let expected_duration_ms = u64::from(expected_frames)
-        .checked_mul(1_000)
-        .ok_or_else(|| {
-            anyhow::anyhow!("private H3 terminal media provenance mismatch: request-duration")
-        })?
-        / u64::from(mold_core::minimax_h3::FIXED_FPS);
+    let expected_duration_ms = mold_inference::av_media::timeline_duration_ms(
+        u64::from(expected_frames),
+        mold_core::minimax_h3::FIXED_FPS,
+    )
+    .map_err(|_| {
+        anyhow::anyhow!("private H3 terminal media provenance mismatch: request-duration")
+    })?;
     let echo = &output.identity_echo;
     let video = output.response.video.as_ref().ok_or_else(|| {
         anyhow::anyhow!("private H3 terminal media provenance mismatch: response-video")
@@ -5863,7 +5864,9 @@ mod tests {
             thumbnail: vec![0x89, b'P', b'N', b'G'],
             gif_preview: Vec::new(),
             has_audio: true,
-            duration_ms: Some(u64::from(facts.media.frames) * 1_000 / u64::from(facts.media.fps)),
+            duration_ms: Some(
+                (u64::from(facts.media.frames) * 1_000).div_ceil(u64::from(facts.media.fps)),
+            ),
             audio_sample_rate: Some(mold_core::minimax_h3::AUDIO_SAMPLE_RATE_HZ),
             audio_channels: Some(mold_core::minimax_h3::AUDIO_CHANNELS),
         });
@@ -5899,7 +5902,8 @@ mod tests {
                     .clone(),
                 consumption_identity_sha256: facts.consumption_identity_sha256.clone(),
                 media: facts.media.clone(),
-                duration_ms: u64::from(facts.media.frames) * 1_000 / u64::from(facts.media.fps),
+                duration_ms: (u64::from(facts.media.frames) * 1_000)
+                    .div_ceil(u64::from(facts.media.fps)),
                 audio_sample_rate: mold_core::minimax_h3::AUDIO_SAMPLE_RATE_HZ,
                 audio_channels: u16::try_from(mold_core::minimax_h3::AUDIO_CHANNELS).unwrap(),
                 synchronized_audio_video: true,
@@ -6465,6 +6469,24 @@ mod tests {
                 .contains("cache-sentinel"));
             assert_eq!(std::fs::read_dir(output.path()).unwrap().count(), 0);
         }
+    }
+
+    #[tokio::test]
+    async fn claimed_h3_publication_accepts_container_rounded_duration() {
+        let (job, _result_rx, _progress_rx, _queue_rx, _queue, _registry) =
+            claimed_h3_job_fixture("claimed-h3-rounded-duration").await;
+        let facts = fake_h3_facts();
+        let claimed_output = fake_h3_output(&facts, true, false);
+        let duration_ms = claimed_output.identity_echo.duration_ms;
+        let worker = single_worker_pool_with_parked("cache-sentinel", Duration::ZERO);
+
+        assert_eq!(duration_ms, 5_167);
+        assert_ne!(
+            duration_ms,
+            u64::from(facts.media.frames) * 1_000 / u64::from(facts.media.fps)
+        );
+        validate_h3_publication_contract(&worker, &job, &facts, &claimed_output)
+            .expect("the MP4 timescale's rounded-up millisecond duration must publish");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- derive H3 terminal durations from the exact MP4 timeline with checked ceiling millisecond rounding
- share the same conversion across private and generic FL2VA/Ref2VA producers and server publication authority
- retain fail-closed zero/overflow handling and add the exact 124-frame / 24 fps regression

## Evidence
- exact CUDA campaign completed Qwen, 20 denoise evaluations, decode, H.264 encode, audio decode, and mux before the labeled publication gate identified `echo-duration`
- the mux timeline is 124000 ticks at timescale 24000: 5167 ms when represented without shortening the half-open interval

## Validation
- `nix develop --no-write-lock-file -c cargo fmt --all -- --check`
- `nix develop --no-write-lock-file -c cargo test -p mold-ai-inference timeline_duration --lib -- --nocapture`
- `nix develop --no-write-lock-file -c cargo test -p mold-ai-server claimed_h3_publication_accepts_container_rounded_duration --lib -- --nocapture`
- `nix develop --no-write-lock-file -c cargo test -p mold-ai-server claimed_h3_publication_gate_rejects_every_independent_media_axis --lib -- --nocapture`
- `bash scripts/tests/minimax-h3-private-uat-release-contract.sh`
- `git diff --check`

Local CUDA Clippy cannot run on this Mac because `nvcc` is absent; the exact gate will run on the authorized CUDA host and in CI. This changes authenticated runtime source, so a fresh campaign and independent qualification review remain required.