### PR TITLE
fix(desktop): hide obvious missing prompt guidance

### DIFF
--- a/desktop/src/components/create/ComposerCard.test.ts
+++ b/desktop/src/components/create/ComposerCard.test.ts
@@ -31,6 +31,7 @@ function mountComposer(form: GenerateForm, overrides: Record<string, unknown> = 
       expansionHostLabel: null,
       canUndo: false,
       preparedBlocked: false,
+      disabled: false,
       disabledReason: null,
       submitting: false,
       buttonLabel: "Generate",
@@ -69,18 +70,20 @@ describe("ComposerCard", () => {
     expect(form.prompt).toBe("a lighthouse"); // textarea untouched
   });
 
-  it("disables Generate and displays the shared corrective reason", () => {
+  it("can disable Generate without displaying obvious guidance", () => {
     const emptyForm = baseForm();
     emptyForm.prompt = "";
-    const missingPrompt = mountComposer(emptyForm, {
-      disabledReason: "Add a prompt before generating.",
-    });
+    const missingPrompt = mountComposer(emptyForm, { disabled: true });
     expect(missingPrompt.get("[data-test='generate-button']").attributes("disabled")).toBeDefined();
-    expect(missingPrompt.get("[data-test='action-blocker']").text()).toContain(
-      "Add a prompt before generating.",
-    );
+    expect(missingPrompt.find("[data-test='action-blocker']").exists()).toBe(false);
+  });
+
+  it("disables Generate and displays non-obvious corrective guidance", () => {
     expect(
-      mountComposer(baseForm(), { disabledReason: "Use the reviewed variations panel." })
+      mountComposer(baseForm(), {
+        disabled: true,
+        disabledReason: "Use the reviewed variations panel.",
+      })
         .get("[data-test='generate-button']")
         .attributes("disabled"),
     ).toBeDefined();
@@ -100,6 +103,7 @@ describe("ComposerCard", () => {
     const wrapper = mountComposer(baseForm(), {
       effectiveBatchSize: 3,
       expansionRunning: true,
+      disabled: true,
       disabledReason: "Wait for prompt preparation to finish.",
     });
     expect(wrapper.get("[data-test='generate-button']").attributes("disabled")).toBeDefined();
@@ -108,6 +112,7 @@ describe("ComposerCard", () => {
   it("does not submit from the shortcut while Generate is disabled", async () => {
     const wrapper = mountComposer(baseForm(), {
       effectiveBatchSize: 3,
+      disabled: true,
       disabledReason: "Use the reviewed variations panel.",
     });
     await wrapper

--- a/desktop/src/components/create/ComposerCard.vue
+++ b/desktop/src/components/create/ComposerCard.vue
@@ -28,6 +28,7 @@ const props = withDefaults(
     expansionHostLabel: string | null;
     canUndo: boolean;
     preparedBlocked: boolean;
+    disabled: boolean;
     disabledReason: string | null;
     submitting: boolean;
     buttonLabel: string;
@@ -49,9 +50,9 @@ const emit = defineEmits<{
   "update:remixSource": [value: "original" | "current"];
 }>();
 
-// The view owns one blocker authority shared with its submit guard. This card
-// only renders that reason and reflects it in the button state.
-const generateDisabled = computed(() => props.disabledReason !== null || props.submitting);
+// Disabled state and corrective guidance are intentionally separate: obvious
+// requirements such as an empty prompt do not need a persistent warning.
+const generateDisabled = computed(() => props.disabled || props.submitting);
 const placeholder = computed(() =>
   promptPlaceholder(props.form, "Describe the image you want to create…"),
 );

--- a/desktop/src/views/GenerateView.layout.test.ts
+++ b/desktop/src/views/GenerateView.layout.test.ts
@@ -83,10 +83,11 @@ describe("GenerateView layout", () => {
   });
 
   // A conditioned LTX-2 render may go out undescribed. The view owns the
-  // shared blocker authority; the composer only renders and reflects it.
-  it("gates Generate on one visible blocker authority", () => {
+  // shared blocker authority; obvious required inputs can disable the button
+  // without taking over the composer with corrective guidance.
+  it("keeps Generate gating separate from visible blocker guidance", () => {
     expect(tagFor(composerCardSource, "generate-button")).toContain(':disabled="generateDisabled"');
-    expect(composerCardSource).toContain("props.disabledReason !== null");
+    expect(composerCardSource).toContain("props.disabled || props.submitting");
     expect(composerCardSource).toContain('<ActionBlocker v-if="disabledReason"');
     expect(composerCardSource).not.toContain("!form.prompt.trim() || !form.model");
 
@@ -96,6 +97,7 @@ describe("GenerateView layout", () => {
     );
     expect(viewSource).toContain("const generationInputBlockerReason = computed");
     expect(viewSource).toContain("if (generationInputBlockerReason.value ||");
+    expect(viewSource).toContain(':disabled="composerDisabled"');
     expect(viewSource).toContain(':disabled-reason="composerBlockerReason"');
   });
 

--- a/desktop/src/views/GenerateView.persistence.test.ts
+++ b/desktop/src/views/GenerateView.persistence.test.ts
@@ -143,6 +143,20 @@ describe("GenerateView form persistence", () => {
     expect(wrapper.get('[data-test="generate-button"]').attributes("disabled")).toBeUndefined();
   });
 
+  it("disables an empty required prompt without showing an obvious blocker", async () => {
+    useModelStore().all = [model];
+    const form = useGenerateFormStore().form;
+    form.model = model.name;
+    form.family = model.family;
+    form.prompt = "";
+
+    const wrapper = mountView();
+    await flushPromises();
+
+    expect(wrapper.get('[data-test="generate-button"]').attributes("disabled")).toBeDefined();
+    expect(wrapper.find('[data-test="action-blocker"]').exists()).toBe(false);
+  });
+
   it("shows the exact LTX blocker and enables a valid conditioned request", async () => {
     const ltx = {
       ...model,

--- a/desktop/src/views/GenerateView.vue
+++ b/desktop/src/views/GenerateView.vue
@@ -2414,12 +2414,17 @@ const generationInputBlockerReason = computed<string | null>(() => {
 });
 
 const composerBlockerReason = computed<string | null>(() => {
+  if (promptMissing.value) return null;
   if (generationInputBlockerReason.value) return generationInputBlockerReason.value;
   if (preparedBatch.value) {
     return "Use the reviewed variations panel to generate this prepared batch, or discard it to return to one-shot generation.";
   }
   return null;
 });
+
+const composerDisabled = computed(
+  () => generationInputBlockerReason.value !== null || preparedBatch.value !== null,
+);
 
 const emptyCanvasGuidance = computed(() =>
   promptRequired(form)
@@ -3544,6 +3549,7 @@ onBeforeUnmount(() => {
             :expansion-host-label="expansionHostLabel"
             :can-undo="quickExpansionOriginal !== null"
             :prepared-blocked="!!preparedBatch && effectiveBatchSize === 1"
+            :disabled="composerDisabled"
             :disabled-reason="composerBlockerReason"
             :submitting="submissionPlanning"
             :button-label="buttonLabel"


### PR DESCRIPTION
## Summary
- keep Generate disabled when a required prompt is empty without showing the obvious corrective banner
- preserve visible guidance for non-obvious blockers such as missing models, invalid source media, and stale prepared work
- separate disabled state from explanatory state in the shared composer contract

## Verification
- `cd desktop && bun run test` (3367 passed)
- `cd desktop && bun run build`
- rendered Create QA at `http://127.0.0.1:1430/`: Generate disabled, zero blocker banners for an empty prompt, zero console warnings/errors
- interaction check: entering a prompt still surfaces the useful missing-model blocker when applicable