### PR TITLE
fix(desktop): improve model detail layout and selection

### DIFF
--- a/desktop/src/components/models/CatalogCard.test.ts
+++ b/desktop/src/components/models/CatalogCard.test.ts
@@ -166,6 +166,17 @@ describe("CatalogCard", () => {
     expect(card.attributes("tabindex")).toBe("0");
   });
 
+  it("marks the card that backs the open model detail", async () => {
+    const wrapper = mount(CatalogCard, {
+      props: { entry: entry(), pulling: false, selected: true },
+    });
+    await flushPromises();
+    const card = wrapper.get('[data-test="catalog-card"]');
+    expect(card.attributes("data-selected")).toBe("true");
+    expect(card.attributes("aria-current")).toBe("true");
+    expect(card.classes()).toContain("catalog-card-contained--selected");
+  });
+
   it("opens the drawer from Enter and Space on the focused card", async () => {
     const wrapper = mount(CatalogCard, { props: { entry: entry(), pulling: false } });
     await flushPromises();

--- a/desktop/src/components/models/CatalogCard.vue
+++ b/desktop/src/components/models/CatalogCard.vue
@@ -37,9 +37,11 @@ const props = withDefaults(
      *  keeps its Pull action until every reachable machine has it; the parent
      *  decides, because only it knows the fleet. */
     installable?: boolean | undefined;
+    /** The card currently backing the open detail drawer. */
+    selected?: boolean;
   }>(),
   // Explicit so Vue's boolean casting doesn't turn "not supplied" into false.
-  { installable: undefined },
+  { installable: undefined, selected: false },
 );
 const emit = defineEmits<{
   (e: "pull", entry: CatalogEntry): void;
@@ -115,11 +117,14 @@ function onCardKeydown(event: KeyboardEvent): void {
 <template>
   <div
     class="catalog-card-contained border-edge flex cursor-pointer flex-col rounded-chrome border bg-bath transition-colors duration-150 hover:bg-bench focus-visible:outline-2 focus-visible:outline-safelight"
+    :class="selected ? 'catalog-card-contained--selected' : ''"
     role="button"
     tabindex="0"
     data-test="catalog-card"
     data-layout="grid"
     :aria-label="accessibilityLabel"
+    :aria-current="selected ? 'true' : undefined"
+    :data-selected="selected ? 'true' : undefined"
     @click="emit('open', entry)"
     @keydown.enter="onCardKeydown"
     @keydown.space="onCardKeydown"
@@ -260,6 +265,13 @@ function onCardKeydown(event: KeyboardEvent): void {
 <style scoped>
 .catalog-card-contained {
   contain: layout paint style;
+}
+
+.catalog-card-contained--selected,
+.catalog-card-contained--selected:hover {
+  border-color: var(--sel-border);
+  background: var(--sel-bg);
+  box-shadow: inset 0 0 0 1px var(--sel-border);
 }
 
 /* Model previews are overwhelmingly portrait subjects, and a centred cover

--- a/desktop/src/components/models/CatalogDetailDrawer.test.ts
+++ b/desktop/src/components/models/CatalogDetailDrawer.test.ts
@@ -371,7 +371,7 @@ describe("CatalogDetailDrawer", () => {
     expect(wrapper.emitted("pull")?.[0]?.[0]).toMatchObject({ id: "cv:8001" });
   });
 
-  it("makes the selected variant the exact pull target", async () => {
+  it("selects the variant context and makes it the exact pull target", async () => {
     const wrapper = await mountDrawer(summary(), {
       variants: [
         { id: "flux-dev:q4", label: "q4" },
@@ -387,8 +387,10 @@ describe("CatalogDetailDrawer", () => {
     await wrapper.get("[data-test='drawer-pull']").trigger("click");
     expect(wrapper.emitted("pull")?.[0]?.[0]).toMatchObject({ id: "flux-dev:q4" });
 
-    // Selecting q8 repoints the pull without re-opening the drawer.
+    // Selection is surfaced to the owner so it can replace every detail field,
+    // while the drawer also repoints Pull immediately for responsive feedback.
     await chips[1]!.trigger("click");
+    expect(wrapper.emitted("select-variant")?.[0]).toEqual(["flux-dev:q8"]);
     await wrapper.get("[data-test='drawer-pull']").trigger("click");
     expect(wrapper.emitted("pull")?.[1]?.[0]).toMatchObject({ id: "flux-dev:q8" });
   });

--- a/desktop/src/components/models/CatalogDetailDrawer.vue
+++ b/desktop/src/components/models/CatalogDetailDrawer.vue
@@ -59,6 +59,7 @@ const props = defineProps<{
 const emit = defineEmits<{
   (e: "close"): void;
   (e: "pull", entry: CatalogEntry): void;
+  (e: "select-variant", id: string): void;
 }>();
 
 const detail = ref<CatalogEntry | null>(null);
@@ -273,6 +274,14 @@ watch(
  *  variant id so the selection is the download target. */
 const pullEntry = computed<CatalogEntry>(() => ({ ...merged.value, id: selectedVariantId.value }));
 
+/** Select immediately for responsive feedback, then let the catalog owner
+ * replace the drawer entry so every title, size, component, and action field
+ * follows the chosen runnable model instead of changing only the Pull id. */
+function selectVariant(id: string): void {
+  selectedVariantId.value = id;
+  emit("select-variant", id);
+}
+
 function formatSize(bytes: number | null): string {
   return bytes != null ? formatGB(bytes) : "—";
 }
@@ -464,7 +473,7 @@ onUnmounted(() => window.removeEventListener("keydown", onKeydown));
                   : 'border-edge text-ink-2 hover:text-ink'
               "
               :aria-pressed="variant.id === selectedVariantId"
-              @click="selectedVariantId = variant.id"
+              @click="selectVariant(variant.id)"
             >
               {{ variant.label }}
               <span v-if="variant.sizeBytes != null" class="text-ink-3">

--- a/desktop/src/components/models/CatalogTab.test.ts
+++ b/desktop/src/components/models/CatalogTab.test.ts
@@ -27,6 +27,7 @@ vi.mock("../../lib/catalogSizes", () => ({
 vi.mock("../../lib/openExternal", () => ({ openExternal: vi.fn() }));
 
 import CatalogTab from "./CatalogTab.vue";
+import CatalogDetailDrawer from "./CatalogDetailDrawer.vue";
 import { useConnectionStore } from "../../stores/connection";
 import { useDownloadsStore } from "../../stores/downloads";
 import { useHostModelsStore } from "../../stores/hostModels";
@@ -1118,13 +1119,17 @@ describe("CatalogTab variant chips", () => {
       },
     ];
     const wrapper = mount(CatalogTab, {
-      props: { query: "", layout: "grid" as const },
+      props: { query: "", layout: "table" as const },
       global: { plugins: [] },
     });
     await flushPromises();
 
-    await wrapper.findAll("[data-test='catalog-card']")[0]!.trigger("click");
+    const rows = wrapper.findAll("[data-test='catalog-table-row']");
+    const q4Row = rows.find((row) => row.text().includes("flux-dev:q4"))!;
+    const q8Row = rows.find((row) => row.text().includes("flux-dev:q8"))!;
+    await q4Row.trigger("click");
     await flushPromises();
+    expect(q4Row.attributes("data-selected")).toBe("true");
 
     const chips = wrapper
       .get("[data-test='drawer-variants']")
@@ -1134,5 +1139,123 @@ describe("CatalogTab variant chips", () => {
     expect(labels.some((t) => t.includes("q8"))).toBe(true);
     // Each variant advertises its footprint so the choice is informed.
     expect(labels.some((t) => t.includes("6.0 GB"))).toBe(true);
+
+    const q8 = chips.find((chip) => chip.text().includes("q8"))!;
+    await q8.trigger("click");
+    await flushPromises();
+
+    // The chosen variant becomes the drawer's actual entry; every detail and
+    // repair field now derives from q8 rather than changing only the Pull id,
+    // and the selected-list highlight follows that same authority.
+    expect(wrapper.getComponent(CatalogDetailDrawer).props("entry").id).toBe("flux-dev:q8");
+    expect(q8.attributes("aria-pressed")).toBe("true");
+    expect(q4Row.attributes("data-selected")).toBeUndefined();
+    expect(q8Row.attributes("data-selected")).toBe("true");
+  });
+
+  it("keeps a filtered non-installed sibling as a full manifest Pull entry", async () => {
+    setActivePinia(createPinia());
+    useModelStore().all = [
+      {
+        name: "flux-dev:q4",
+        family: "flux",
+        size_gb: 6,
+        is_loaded: false,
+        hf_repo: "org/flux-dev",
+        default_steps: 4,
+        default_guidance: 1,
+        default_width: 1024,
+        default_height: 1024,
+        description: "",
+        downloaded: false,
+      },
+      {
+        name: "flux-dev:q8",
+        family: "flux",
+        size_gb: 12,
+        remaining_download_bytes: 20_000_000_000,
+        is_loaded: false,
+        hf_repo: "org/flux-dev",
+        default_steps: 4,
+        default_guidance: 1,
+        default_width: 1024,
+        default_height: 1024,
+        description: "",
+        downloaded: false,
+      },
+    ];
+    const wrapper = mount(CatalogTab, {
+      props: { query: "q4", layout: "table" as const },
+      global: { plugins: [] },
+    });
+    await flushPromises();
+
+    await wrapper.get("[data-test='catalog-table-row']").trigger("click");
+    await flushPromises();
+    const q8 = wrapper
+      .get("[data-test='drawer-variants']")
+      .findAll("[data-test='variant-chip']")
+      .find((chip) => chip.text().includes("q8"))!;
+    await q8.trigger("click");
+    await flushPromises();
+
+    const chosen = wrapper.getComponent(CatalogDetailDrawer).props("entry") as CatalogEntry;
+    expect(chosen.id).toBe("flux-dev:q8");
+    expect(chosen.installed).toBe(false);
+    expect(chosen.size_bytes).toBe(12_000_000_000);
+    expect(chosen.companion_details).toEqual([
+      { name: "shared runtime components", size_bytes: 8_000_000_000 },
+    ]);
+    expect(wrapper.getComponent(CatalogDetailDrawer).props("action")).toBe("Pull");
+  });
+
+  it("preserves remote ownership when a filtered installed sibling is selected", async () => {
+    setActivePinia(createPinia());
+    const q4 = {
+      name: "flux-dev:q4",
+      family: "flux",
+      size_gb: 6,
+      is_loaded: false,
+      hf_repo: "org/flux-dev",
+      default_steps: 4,
+      default_guidance: 1,
+      default_width: 1024,
+      default_height: 1024,
+      description: "",
+      downloaded: false,
+    };
+    const q8 = {
+      ...q4,
+      name: "flux-dev:q8",
+      size_gb: 12,
+      downloaded: true,
+      hostIds: ["render-box"],
+    };
+    useModelStore().all = [q4, q8];
+    const wrapper = mount(CatalogTab, {
+      props: {
+        query: "q4",
+        layout: "table" as const,
+        installedEntries: [q8],
+      },
+      global: { plugins: [] },
+    });
+    await flushPromises();
+
+    await wrapper.get("[data-test='catalog-table-row']").trigger("click");
+    await flushPromises();
+    const q8Chip = wrapper
+      .get("[data-test='drawer-variants']")
+      .findAll("[data-test='variant-chip']")
+      .find((chip) => chip.text().includes("q8"))!;
+    await q8Chip.trigger("click");
+    await flushPromises();
+
+    const chosen = wrapper.getComponent(CatalogDetailDrawer).props("entry") as CatalogEntry & {
+      hostIds?: string[];
+    };
+    expect(chosen.id).toBe("flux-dev:q8");
+    expect(chosen.installed).toBe(true);
+    expect(chosen.hostIds).toEqual(["render-box"]);
   });
 });

--- a/desktop/src/components/models/CatalogTab.vue
+++ b/desktop/src/components/models/CatalogTab.vue
@@ -31,6 +31,7 @@ import { installedModelToEntry } from "../../lib/catalogDetail";
 import type { CatalogEntry, ModelEntry } from "../../lib/api/types";
 
 type LibraryModelEntry = ModelEntry & { hostIds?: string[] };
+type CatalogListEntry = CatalogEntry & { hostIds?: string[] };
 
 const props = defineProps<{
   query: string;
@@ -84,7 +85,7 @@ const error = ref<string | null>(null);
 const pulling = ref<Set<string>>(new Set());
 const pendingEntry = ref<CatalogEntry | null>(null);
 /** Entry whose in-app detail drawer is open. */
-const detailEntry = ref<CatalogEntry | null>(null);
+const detailEntry = ref<CatalogListEntry | null>(null);
 
 let debounce: ReturnType<typeof setTimeout> | null = null;
 
@@ -104,7 +105,7 @@ const installedNames = computed(() => new Set((props.installedEntries ?? []).map
 
 /** Installed models as catalog-shaped rows for the unified list — the host
  *  chips are the visual "you have this" indicator. */
-const installedCatalogEntries = computed<(CatalogEntry & { hostIds?: string[] })[]>(() => {
+const installedCatalogEntries = computed<CatalogListEntry[]>(() => {
   const q = props.query.trim().toLowerCase();
   return (props.installedEntries ?? [])
     .filter(
@@ -121,12 +122,37 @@ const installedCatalogEntries = computed<(CatalogEntry & { hostIds?: string[] })
     );
 });
 
+/** Canonical catalog shape for one not-yet-installed manifest model. Keep
+ * this outside the filtered list so variant selection can resolve a sibling
+ * hidden by search/source/family controls without fabricating install state
+ * or dropping its shared-runtime footprint. */
+function manifestCatalogEntry(model: ModelEntry): CatalogEntry {
+  const weights = Math.round(model.size_gb * 1_000_000_000);
+  const fetch = model.remaining_download_bytes ?? weights;
+  const shared = Math.max(0, fetch - weights);
+  return {
+    id: model.name,
+    source: "hf",
+    source_id: model.hf_repo || null,
+    name: model.name,
+    family: model.family,
+    kind: "checkpoint",
+    nsfw: false,
+    installed: false,
+    size_bytes: weights,
+    thumbnail_url: null,
+    page_url: model.hf_repo ? `https://huggingface.co/${model.hf_repo}` : null,
+    companion_details:
+      shared > 0 ? [{ name: "shared runtime components", size_bytes: shared }] : [],
+  };
+}
+
 /** Preserve installed identity/host state while filling older `/api/models`
  * rows with richer metadata from the matching live catalog result. */
 function enrichInstalledEntry(
-  installed: CatalogEntry & { hostIds?: string[] },
+  installed: CatalogListEntry,
   live: CatalogEntry | undefined,
-): CatalogEntry & { hostIds?: string[] } {
+): CatalogListEntry {
   if (!live) return installed;
   const installedDescription = installed.description?.trim();
   const modality = installed.modality ?? live.modality;
@@ -146,7 +172,7 @@ function enrichInstalledEntry(
 }
 
 /** Host chip labels for an installed row (host ids → display labels). */
-function hostLabelsFor(entry: CatalogEntry & { hostIds?: string[] }): string[] {
+function hostLabelsFor(entry: CatalogListEntry): string[] {
   return (entry.hostIds ?? []).map(
     (id) =>
       hosts.all.find((host) => host.id === id)?.label ?? (id === "local" ? "This device" : id),
@@ -164,26 +190,7 @@ const manifestEntries = computed<CatalogEntry[]>(() => {
     .filter((model) => !installed.has(model.name))
     .filter((model) => !q || model.name.toLowerCase().includes(q))
     .filter((model) => !family.value || model.family === family.value)
-    .map((model) => {
-      const weights = Math.round(model.size_gb * 1_000_000_000);
-      const fetch = model.remaining_download_bytes ?? weights;
-      const shared = Math.max(0, fetch - weights);
-      return {
-        id: model.name,
-        source: "hf",
-        source_id: model.hf_repo || null,
-        name: model.name,
-        family: model.family,
-        kind: "checkpoint",
-        nsfw: false,
-        installed: false,
-        size_bytes: weights,
-        thumbnail_url: null,
-        page_url: model.hf_repo ? `https://huggingface.co/${model.hf_repo}` : null,
-        companion_details:
-          shared > 0 ? [{ name: "shared runtime components", size_bytes: shared }] : [],
-      };
-    });
+    .map(manifestCatalogEntry);
 });
 
 const combinedEntries = computed(() => {
@@ -421,9 +428,8 @@ const detailTarget = computed(() => catalogTarget());
 
 /**
  * Quantization variants for a manifest model (`base:tag`) — the sibling rows
- * the manifest already describes, so the drawer's variant chips repoint a Pull
- * without changing which runnable model it targets. Live HF/Civitai rows carry
- * no colon base and get no chips (their precedence is decided in the list).
+ * the manifest already describes. Live HF/Civitai rows carry no colon base
+ * and get no chips (their precedence is decided in the list).
  */
 function variantsFor(entry: CatalogEntry): DrawerVariant[] | undefined {
   // Catalog ids (`cv:252914`) contain a colon that is part of the
@@ -443,6 +449,30 @@ function variantsFor(entry: CatalogEntry): DrawerVariant[] | undefined {
 const detailVariants = computed(() =>
   detailEntry.value ? variantsFor(detailEntry.value) : undefined,
 );
+
+/** A variant chip selects the sibling as the drawer's real entry, not merely
+ * as a hidden download override. That keeps weights, footprint, installed
+ * state, repair components, and the eventual Pull target on one authority. */
+function selectDrawerVariant(id: string): void {
+  const listed = combinedEntries.value.find((entry) => entry.id === id);
+  if (listed) {
+    detailEntry.value = listed;
+    return;
+  }
+  const installed = (props.installedEntries ?? []).find((model) => model.name === id);
+  if (installed) {
+    detailEntry.value = {
+      ...installedModelToEntry(installed),
+      hostIds: [...(installed.hostIds ?? [])],
+    };
+    return;
+  }
+  const inventory = models.all.find((model) => model.name === id);
+  if (!inventory) return;
+  detailEntry.value = inventory.downloaded
+    ? installedModelToEntry(inventory)
+    : manifestCatalogEntry(inventory);
+}
 
 /** Pull vs Repair in the drawer follows the fleet, not this one row's flag. */
 const detailAction = computed(() =>
@@ -600,6 +630,7 @@ onMounted(async () => {
           :pulling="pulling.has(entry.id)"
           :hosts="hostLabelsFor(entry)"
           :installable="installable(entry)"
+          :selected="detailEntry?.id === entry.id"
           @pull="pull"
           @open="detailEntry = $event"
         />
@@ -609,6 +640,7 @@ onMounted(async () => {
           :pulling="pulling.has(entry.id)"
           :hosts="hostLabelsFor(entry)"
           :installable="installable(entry)"
+          :selected="detailEntry?.id === entry.id"
           class="px-3 py-2"
           @pull="pull"
           @open="detailEntry = $event"
@@ -644,6 +676,7 @@ onMounted(async () => {
       :action="detailAction"
       @close="detailEntry = null"
       @pull="pullFromDrawer"
+      @select-variant="selectDrawerVariant"
     />
   </div>
 </template>

--- a/desktop/src/components/models/CatalogTableRow.vue
+++ b/desktop/src/components/models/CatalogTableRow.vue
@@ -27,9 +27,11 @@ const props = withDefaults(
      *  keeps its Pull action until every reachable machine has it; the parent
      *  decides, because only it knows the fleet. */
     installable?: boolean | undefined;
+    /** The row currently backing the open detail drawer. */
+    selected?: boolean;
   }>(),
   // Explicit so Vue's boolean casting doesn't turn "not supplied" into false.
-  { installable: undefined },
+  { installable: undefined, selected: false },
 );
 const emit = defineEmits<{
   (e: "pull", entry: CatalogEntry): void;
@@ -96,6 +98,7 @@ const counts = computed(() => {
     :size-primary="sizePrimary"
     :size-secondary="sizeSecondary"
     :accessibility-label="accessibilityLabel"
+    :selected="selected"
     clickable
     data-test="catalog-table-row"
     @open="emit('open', entry)"

--- a/desktop/src/components/models/ModelFootprintBar.vue
+++ b/desktop/src/components/models/ModelFootprintBar.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+/**
+ * Relative model-footprint meter used by every desktop model table. It is a
+ * comparison within the current list, not transfer progress, so the shared
+ * hover and accessibility copy makes that distinction explicit everywhere.
+ */
+const props = defineProps<{
+  percent: number;
+  sizeLabel?: string | null;
+  descriptionId: string;
+}>();
+
+const clamped = computed(() => Math.min(100, Math.max(0, props.percent)));
+const explanation = computed(() => {
+  const size = props.sizeLabel ? `${props.sizeLabel}. ` : "";
+  return `${size}Relative on-disk footprint compared with the largest model in this list. This is not download progress.`;
+});
+</script>
+
+<template>
+  <span
+    class="model-footprint"
+    role="meter"
+    :aria-label="explanation"
+    :aria-valuenow="Math.round(clamped)"
+    aria-valuemin="0"
+    aria-valuemax="100"
+    :title="explanation"
+    data-test="model-footprint-bar"
+  >
+    <span class="model-footprint__fill" :style="{ width: `${clamped}%` }" />
+  </span>
+  <span :id="descriptionId" class="sr-only" data-test="model-footprint-description">
+    {{ explanation }}
+  </span>
+</template>
+
+<style scoped>
+.model-footprint {
+  display: block;
+  min-width: 32px;
+  height: 6px;
+  flex: 1 1 auto;
+  overflow: hidden;
+  border-radius: 999px;
+  background: var(--bath);
+  cursor: help;
+}
+
+.model-footprint__fill {
+  display: block;
+  height: 100%;
+  background: var(--halide);
+}
+</style>

--- a/desktop/src/components/models/ModelTableRow.test.ts
+++ b/desktop/src/components/models/ModelTableRow.test.ts
@@ -60,7 +60,19 @@ describe("ModelTableRow", () => {
     const sizes = wrapper.get("[data-test='row-sizes']");
     expect(sizes.text()).toContain("11.8 GB weights");
     expect(sizes.text()).toContain("23.1 GB with shared runtime");
-    expect(wrapper.html()).toContain("width: 40%");
+    const footprint = wrapper.get("[data-test='model-footprint-bar']");
+    expect(footprint.html()).toContain("width: 40%");
+    expect(footprint.attributes("title")).toContain("23.1 GB with shared runtime");
+    expect(footprint.attributes("title")).toContain("largest model in this list");
+    expect(footprint.attributes("title")).toContain("not download progress");
+    expect(footprint.attributes("aria-label")).toBe(footprint.attributes("title"));
+    expect(footprint.attributes("role")).toBe("meter");
+    expect(footprint.attributes("aria-valuenow")).toBe("40");
+    const description = wrapper.get("[data-test='model-footprint-description']");
+    expect(wrapper.get("[data-test='model-table-row']").attributes("aria-describedby")).toBe(
+      description.attributes("id"),
+    );
+    expect(description.text()).toBe(footprint.attributes("title"));
   });
 
   it("opens the external model page without triggering the row's open action", async () => {

--- a/desktop/src/components/models/ModelTableRow.test.ts
+++ b/desktop/src/components/models/ModelTableRow.test.ts
@@ -98,4 +98,12 @@ describe("ModelTableRow", () => {
     const wrapper = mountRow({}, { actions: "<button data-test='pull'>Pull</button>" });
     expect(wrapper.get("[data-test='pull']").text()).toBe("Pull");
   });
+
+  it("marks the row that backs the open model detail", () => {
+    const wrapper = mountRow({ selected: true });
+    const row = wrapper.get("[data-test='model-table-row']");
+    expect(row.attributes("data-selected")).toBe("true");
+    expect(row.attributes("aria-current")).toBe("true");
+    expect(row.classes()).toContain("model-table-row--selected");
+  });
 });

--- a/desktop/src/components/models/ModelTableRow.vue
+++ b/desktop/src/components/models/ModelTableRow.vue
@@ -36,6 +36,8 @@ const props = withDefaults(
     barPercent?: number | null;
     /** Row and name become buttons that emit `open` (catalog detail drawer). */
     clickable?: boolean;
+    /** The row currently backing an open detail drawer. */
+    selected?: boolean;
     /** Rich accessible name when visible metadata adds context to the row. */
     accessibilityLabel?: string | null;
   }>(),
@@ -49,6 +51,7 @@ const props = withDefaults(
     sizeSecondary: null,
     barPercent: null,
     clickable: false,
+    selected: false,
     accessibilityLabel: null,
   },
 );
@@ -83,11 +86,14 @@ function onRowKeydown(event: KeyboardEvent): void {
       clickable ? 'cursor-pointer focus-visible:outline-2 focus-visible:outline-safelight' : '',
       barPercent != null ? 'model-table-row--has-footprint' : '',
       $slots.actions ? 'model-table-row--has-actions' : '',
+      selected ? 'model-table-row--selected' : '',
     ]"
     :role="clickable ? 'button' : undefined"
     :tabindex="clickable ? 0 : undefined"
     :aria-label="clickable ? (accessibilityLabel ?? `${name} — view details`) : undefined"
     :aria-describedby="barPercent != null ? footprintDescriptionId : undefined"
+    :aria-current="selected ? 'true' : undefined"
+    :data-selected="selected ? 'true' : undefined"
     data-test="model-table-row"
     @click="clickable && emit('open')"
     @keydown.enter="onRowKeydown"
@@ -228,6 +234,12 @@ function onRowKeydown(event: KeyboardEvent): void {
 .model-table-row__title {
   min-width: 48px;
   flex: 1 1 10rem;
+}
+
+.model-table-row--selected,
+.model-table-row--selected:hover {
+  background: var(--sel-bg);
+  box-shadow: inset 3px 0 var(--sel-border);
 }
 
 .model-table-row__footprint {

--- a/desktop/src/components/models/ModelTableRow.vue
+++ b/desktop/src/components/models/ModelTableRow.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, useId } from "vue";
 
 import { familyLabel } from "@studio/lib/modelFamily";
 
 import SourceGlyph from "../generate/SourceGlyph.vue";
+import ModelFootprintBar from "./ModelFootprintBar.vue";
 import { openExternal } from "../../lib/openExternal";
 import type { ModelSource } from "../../lib/modelSource";
 
@@ -15,7 +16,7 @@ import type { ModelSource } from "../../lib/modelSource";
  * Purely presentational: parents own data fetching, size resolution, and
  * actions (the `#actions` slot). Column recipe, left to right: residency
  * dot · source glyph · name · host chips · quant chip · family code ·
- * page link · `#meta` · usage bar + two-line size block · `#actions`.
+ * page link · `#meta` · relative footprint + two-line size block · `#actions`.
  */
 const props = withDefaults(
   defineProps<{
@@ -53,6 +54,7 @@ const props = withDefaults(
 );
 
 const emit = defineEmits<{ (e: "open"): void }>();
+const footprintDescriptionId = `model-footprint-${useId()}`;
 
 /**
  * The chip shows the family's name, not its wire slug (#806) — a Wan row read
@@ -76,101 +78,106 @@ function onRowKeydown(event: KeyboardEvent): void {
 
 <template>
   <div
-    class="flex items-center gap-2 rounded-control transition-colors duration-100 hover:bg-bath"
-    :class="
-      clickable ? 'cursor-pointer focus-visible:outline-2 focus-visible:outline-safelight' : ''
-    "
+    class="model-table-row rounded-control transition-colors duration-100 hover:bg-bath"
+    :class="[
+      clickable ? 'cursor-pointer focus-visible:outline-2 focus-visible:outline-safelight' : '',
+      barPercent != null ? 'model-table-row--has-footprint' : '',
+      $slots.actions ? 'model-table-row--has-actions' : '',
+    ]"
     :role="clickable ? 'button' : undefined"
     :tabindex="clickable ? 0 : undefined"
     :aria-label="clickable ? (accessibilityLabel ?? `${name} — view details`) : undefined"
+    :aria-describedby="barPercent != null ? footprintDescriptionId : undefined"
     data-test="model-table-row"
     @click="clickable && emit('open')"
     @keydown.enter="onRowKeydown"
     @keydown.space="onRowKeydown"
   >
-    <span
-      v-if="loaded !== undefined"
-      class="h-1.5 w-1.5 shrink-0 rounded-full"
-      :class="loaded ? 'bg-safelight' : 'bg-transparent'"
-      role="img"
-      :title="loaded ? 'On GPU' : 'Cold'"
-      :aria-label="loaded ? 'On GPU' : 'Cold'"
-    />
-    <SourceGlyph :source="source" class="text-ink-3" />
-    <button
-      v-if="clickable"
-      type="button"
-      class="truncate text-left text-body text-ink transition-colors duration-100 hover:text-safelight"
-      :title="`${name} — view details`"
-      data-test="row-title"
-      @click.stop="emit('open')"
-    >
-      {{ name }}
-    </button>
-    <span v-else class="truncate text-body text-ink" :title="name" data-test="row-title">
-      {{ name }}
-    </span>
-    <span
-      v-for="label in hostLabels"
-      :key="label"
-      data-test="installed-host"
-      class="border-edge data-mono shrink-0 rounded-full border px-1.5 text-caption text-ink-3"
-    >
-      {{ label }}
-    </span>
-    <span
-      v-if="quant"
-      class="border-edge data-mono shrink-0 rounded-full border px-1.5 text-caption text-ink-2"
-    >
-      {{ quant }}
-    </span>
-    <span v-if="familyChip" class="edge-code shrink-0" data-test="row-family">{{
-      familyChip
-    }}</span>
-    <button
-      v-if="pageUrl"
-      type="button"
-      class="shrink-0 text-ink-3 transition-colors duration-100 hover:text-ink"
-      :aria-label="`Open ${name} model page`"
-      title="Open model page"
-      data-test="model-page-link"
-      @click.stop="pageUrl && void openExternal(pageUrl)"
-    >
-      <svg
-        viewBox="0 0 12 12"
-        width="11"
-        height="11"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="1.2"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        aria-hidden="true"
+    <div class="model-table-row__identity">
+      <span
+        v-if="loaded !== undefined"
+        class="h-1.5 w-1.5 shrink-0 rounded-full"
+        :class="loaded ? 'bg-safelight' : 'bg-transparent'"
+        role="img"
+        :title="loaded ? 'On GPU' : 'Cold'"
+        :aria-label="loaded ? 'On GPU' : 'Cold'"
+      />
+      <SourceGlyph :source="source" class="shrink-0 text-ink-3" />
+      <button
+        v-if="clickable"
+        type="button"
+        class="model-table-row__title truncate text-left text-body text-ink transition-colors duration-100 hover:text-safelight"
+        :title="`${name} — view details`"
+        data-test="row-title"
+        @click.stop="emit('open')"
       >
-        <path d="M8.5 6.75v2.75a1 1 0 0 1-1 1H2.5a1 1 0 0 1-1-1v-5a1 1 0 0 1 1-1h2.75" />
-        <path d="M7 1.5h3.5V5" />
-        <path d="M10.5 1.5 5.75 6.25" />
-      </svg>
-    </button>
+        {{ name }}
+      </button>
+      <span
+        v-else
+        class="model-table-row__title truncate text-body text-ink"
+        :title="name"
+        data-test="row-title"
+      >
+        {{ name }}
+      </span>
+      <span
+        v-for="label in hostLabels"
+        :key="label"
+        data-test="installed-host"
+        class="border-edge data-mono shrink-0 rounded-full border px-1.5 text-caption text-ink-3"
+      >
+        {{ label }}
+      </span>
+      <span
+        v-if="quant"
+        class="border-edge data-mono shrink-0 rounded-full border px-1.5 text-caption text-ink-2"
+      >
+        {{ quant }}
+      </span>
+      <span v-if="familyChip" class="edge-code shrink-0" data-test="row-family">{{
+        familyChip
+      }}</span>
+      <button
+        v-if="pageUrl"
+        type="button"
+        class="shrink-0 text-ink-3 transition-colors duration-100 hover:text-ink"
+        :aria-label="`Open ${name} model page`"
+        title="Open model page"
+        data-test="model-page-link"
+        @click.stop="pageUrl && void openExternal(pageUrl)"
+      >
+        <svg
+          viewBox="0 0 12 12"
+          width="11"
+          height="11"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M8.5 6.75v2.75a1 1 0 0 1-1 1H2.5a1 1 0 0 1-1-1v-5a1 1 0 0 1 1-1h2.75" />
+          <path d="M7 1.5h3.5V5" />
+          <path d="M10.5 1.5 5.75 6.25" />
+        </svg>
+      </button>
 
-    <slot name="meta" />
+      <slot name="meta" />
+    </div>
 
     <!-- Primary weights and full runtime footprint are deliberately separate
          lines: the latter includes shared encoders/VAEs (SIZE vs FETCH on
-         catalog rows). The block targets a fixed basis so table columns
-         align, but may shrink in narrow containers — lines truncate with
-         tooltips instead of escaping the card. -->
-    <div
-      class="ml-auto flex min-w-0 shrink items-center justify-end gap-2"
-      :class="barPercent != null ? 'basis-64' : ''"
-    >
-      <div
+         catalog rows). The grid owns this column so it cannot overlap the
+         identity metadata; narrow rows hide only the secondary comparison. -->
+    <div class="model-table-row__footprint">
+      <ModelFootprintBar
         v-if="barPercent != null"
-        class="hidden h-1.5 min-w-8 flex-1 overflow-hidden rounded-full bg-bath @[24rem]:block sm:block"
-        aria-hidden="true"
-      >
-        <div class="h-full bg-halide" :style="{ width: `${barPercent}%` }" />
-      </div>
+        :percent="barPercent"
+        :size-label="sizeSecondary ?? sizePrimary"
+        :description-id="footprintDescriptionId"
+      />
       <span class="min-w-0 max-w-40 shrink text-right" data-test="row-sizes">
         <span
           v-if="sizePrimary"
@@ -195,3 +202,55 @@ function onRowKeydown(event: KeyboardEvent): void {
     </div>
   </div>
 </template>
+
+<style scoped>
+.model-table-row {
+  container-type: inline-size;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.model-table-row--has-actions {
+  grid-template-columns: minmax(0, 1fr) auto auto;
+}
+
+.model-table-row__identity {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 8px;
+  overflow: hidden;
+}
+
+.model-table-row__title {
+  min-width: 48px;
+  flex: 1 1 10rem;
+}
+
+.model-table-row__footprint {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.model-table-row--has-footprint .model-table-row__footprint {
+  width: clamp(9rem, 33cqw, 16rem);
+}
+
+/* At host-card widths, protect metadata and sizes first. The footprint is a
+   secondary comparison and returns as soon as its own row has enough room. */
+@container (max-width: 30rem) {
+  .model-table-row__footprint :deep(.model-footprint) {
+    display: none;
+  }
+
+  .model-table-row--has-footprint .model-table-row__footprint {
+    width: auto;
+  }
+}
+</style>

--- a/desktop/src/views/HostDetailView.test.ts
+++ b/desktop/src/views/HostDetailView.test.ts
@@ -949,6 +949,19 @@ describe("HostDetailView loaded-chip unload", () => {
 });
 
 describe("HostDetailView layout", () => {
+  it("uses the full workspace width instead of preserving a fixed desktop cap", async () => {
+    const wrapper = await mountView();
+    const content = wrapper.get("[data-test='host-detail-content']");
+    expect(content.classes()).toContain("w-full");
+    expect(content.classes().some((name) => name.startsWith("max-w-"))).toBe(false);
+    expect(
+      wrapper
+        .get("[data-test='host-model-column']")
+        .classes()
+        .some((name) => name.includes("max-w-")),
+    ).toBe(false);
+  });
+
   it("shows uptime from /api/status in the telemetry header", async () => {
     installApi({ uptime_secs: 200_000 });
     const wrapper = await mountView();

--- a/desktop/src/views/HostDetailView.vue
+++ b/desktop/src/views/HostDetailView.vue
@@ -449,7 +449,7 @@ async function forget() {
 
 <template>
   <div class="h-full overflow-y-auto p-6">
-    <div class="mx-auto max-w-7xl">
+    <div class="w-full" data-test="host-detail-content">
       <template v-if="host">
         <!-- Header: back to Machines · status · name · address · target chip -->
         <div class="flex flex-wrap items-center gap-x-3 gap-y-2">
@@ -726,7 +726,10 @@ async function forget() {
           <!-- Right: loaded models, installed models, connection actions.
                Fluid on wide windows so long model names and size labels
                un-truncate instead of pinning to a fixed 320px column. -->
-          <div class="flex min-w-0 flex-col gap-4 lg:min-w-80 lg:max-w-xl lg:flex-1">
+          <div
+            class="flex min-w-0 flex-col gap-4 lg:min-w-80 lg:flex-1"
+            data-test="host-model-column"
+          >
             <CardSurface large>
               <h2 class="edge-code" data-test="loaded-label">LOADED</h2>
               <div v-if="loadedChips.length" class="mt-3 flex flex-col gap-2">


### PR DESCRIPTION
## Summary
- separate model identity metadata from footprint metrics so kind badges and bars cannot overlap
- add one shared hover and accessible explanation clarifying that the bar is relative on-disk footprint, not download progress
- let remote-host detail content and the model column expand when UI scale or window width creates more space
- make variant chips select the actual sibling model context, including sizes, installed/repair state, components, and Pull target
- highlight the selected model in both table and grid lists, moving the highlight when variant selection changes

## Root cause
The shared model row used one shrinking flex line, so metadata pills could visually escape their allocation into the footprint bar. The host workspace and model column also had fixed maximum widths, preventing zoomed-out layouts from using available space. Variant chips changed only a hidden Pull id, leaving the visible drawer and list selection on the previous variant.

## Validation
- 3,370 desktop tests pass
- focused post-review model tests pass: 80/80
- desktop production build passes
- Prettier check passes
- browser QA at 1600x900 and 700x900 confirms wide fill and clean narrow stacking
- independent agent peer review completed; all findings fixed and final re-review has no actionable findings

## Web applicability
The web host-detail and installed-model surfaces do not render this relative footprint bar. Web catalog detail currently exposes one catalog variant per row, so the multi-variant selection behavior applies to the desktop manifest list shown here.