### PR TITLE
fix(ltx2): gate Metal-only VAE test imports

### DIFF
--- a/crates/mold-inference/src/ltx2/model/video_vae.rs
+++ b/crates/mold-inference/src/ltx2/model/video_vae.rs
@@ -1604,11 +1604,15 @@ impl AutoencoderKLLtx2Video {
 mod tests {
     use super::{
         patchify_video, unpatchify_video, AutoencoderKLLtx2Video, AutoencoderKLLtx2VideoConfig,
-        Ltx2VideoCausalConv3d, Ltx2VideoDownsampler3d, Ltx2VideoResnetBlock3d,
-        Ltx2VideoUpsampler3d, PerChannelRmsNorm, SpatialDecodeTiling, SpatialPaddingMode,
-        VaeBlockConfig,
+        Ltx2VideoDownsampler3d, Ltx2VideoResnetBlock3d, Ltx2VideoUpsampler3d, SpatialDecodeTiling,
+        SpatialPaddingMode, VaeBlockConfig,
     };
+    // Only the Metal-gated tests below reach these, so the default
+    // `--workspace --all-targets` Clippy gate sees them as unused otherwise.
+    #[cfg(feature = "metal")]
+    use super::{Ltx2VideoCausalConv3d, PerChannelRmsNorm};
     use candle_core::{DType, Device, Tensor};
+    #[cfg(feature = "metal")]
     use candle_nn::group_norm;
     use candle_nn::VarBuilder;
     use std::collections::HashMap;


### PR DESCRIPTION
Follow-up to #1011, from the Codex review of that branch.

`Ltx2VideoCausalConv3d`, `PerChannelRmsNorm` and `group_norm` are reached only by `#[cfg(feature = "metal")]` tests. The required default gate — `cargo clippy --workspace --all-targets -- -D warnings` — builds *without* that feature, so it failed on unused imports:

```
error: unused imports: `Ltx2VideoCausalConv3d` and `PerChannelRmsNorm`
error: unused import: `candle_nn::group_norm`
```

I verified #1011 with `--features metal` only, which is exactly why this slipped past.

Verified both ways now:

- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo clippy -p mold-ai-inference --features metal --all-targets -- -D warnings` — clean
- 16 LTX-2 VAE / `metal_reduce` tests pass
- `cargo fmt --all -- --check` clean

https://claude.ai/code/session_01Pxua2XMEmCwbpbRFmPQLas