### PR TITLE
fix(ci): complete H3 distribution gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Completed the public H3 distribution CI repair by retaining `.cargo/config.toml` and its Clang/LLD toolchain in Docker's manifest-first source layer for runtime-identity hashing and updating the desktop packaging contract to recognize the SM89 `cuda,h3` AppImage build.
+
 - Fixed `main` distribution CI after public MiniMax H3 activation by teaching the CUDA Docker contract to recognize the conditional SM89 production build, synchronizing the standalone desktop lockfile with `mold-core`'s TypeScript binding dependency, permitting only the reviewed orthogonal desktop/server features alongside the canonical public H3 feature set, and supplying the pinned CUTLASS checkout to cudaforge inside hermetic Nix builds.
 
 - **MiniMax H3 compact FL2VA is publicly runnable on supported SM89 CUDA builds.** Ordinary generation no longer depends on a private campaign record or authorization file. Mold still verifies every byte of the exact 42.482 GB artifact graph, requires the fixed 1344x768/124-frame/24 fps/21-grid-point first-frame profile, admits only the exact SM89 attention route, and applies the conservative thirteen-field memory policy with synchronous runtime bounds checks. Ref2VA, other architectures, broader request envelopes, hosted inference, and bundled or mirrored weights remain unavailable; private campaign records and capture tools remain engineering evidence rather than public activation authority.

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,8 @@ RUN set -eux; \
     for attempt in 1 2 3 4 5; do \
         apt-get update && apt-get install -y --no-install-recommends \
             build-essential \
+            clang \
+            lld \
             pkg-config \
             libssl-dev \
             libwebp-dev \
@@ -78,6 +80,7 @@ WORKDIR /build
 # Must include every workspace member listed in the root Cargo.toml — cargo
 # fails to resolve the workspace if any member's manifest is missing.
 COPY Cargo.toml Cargo.lock ./
+COPY .cargo/config.toml .cargo/config.toml
 COPY crates/mold-core/Cargo.toml crates/mold-core/Cargo.toml
 COPY crates/mold-catalog/Cargo.toml crates/mold-catalog/Cargo.toml
 COPY crates/mold-db/Cargo.toml crates/mold-db/Cargo.toml

--- a/scripts/tests/cuda-distribution-contract.sh
+++ b/scripts/tests/cuda-distribution-contract.sh
@@ -246,6 +246,13 @@ docker_seal_line="$(
 docker_source_sha_env_line="$(
   grep -n -m1 'ENV MOLD_GIT_SHA=${MOLD_GIT_SHA}' "$repo_root/Dockerfile" | cut -d: -f1
 )"
+grep -Fq 'COPY .cargo/config.toml .cargo/config.toml' "$repo_root/Dockerfile" \
+  || fail "Docker H3 runtime identity build omits .cargo/config.toml"
+docker_builder_packages="$(sed -n '/apt-get update && apt-get install/,/&& break/p' "$repo_root/Dockerfile")"
+for package in clang lld; do
+  grep -Eq "^[[:space:]]+${package}[[:space:]]*\\\\$" <<< "$docker_builder_packages" \
+    || fail "Docker builder omits ${package} required by .cargo/config.toml"
+done
 docker_dependency_build_line="$(
   grep -n -m1 -E '^RUN cargo build --release -p mold-ai([[:space:]]|$)' \
     "$repo_root/Dockerfile" | cut -d: -f1

--- a/scripts/tests/desktop-nightly-race-guards.sh
+++ b/scripts/tests/desktop-nightly-race-guards.sh
@@ -27,7 +27,7 @@ grep -Fq 'run: cargo test --manifest-path src-tauri/Cargo.toml' <<< "$rust_job" 
   || fail "the native desktop gate no longer runs the test suite"
 
 linux_job="$(sed -n '/^  desktop-linux:/,/^  desktop-nightly:/p' "$workflow")"
-grep -Fq 'bunx tauri build --features cuda --bundles appimage --ci -v' <<< "$linux_job" \
+grep -Fq 'bunx tauri build --features cuda,h3 --bundles appimage --ci -v' <<< "$linux_job" \
   || fail "main pushes have no Linux packaging proof"
 grep -Fq "if: github.event_name != 'pull_request'" <<< "$linux_job" \
   || fail "Linux packaging is not reserved for main pushes"


### PR DESCRIPTION
## Summary

- copy the runtime-identity Cargo config into Docker and install its Clang/LLD toolchain
- protect that source/toolchain closure in the CUDA distribution contract
- require the actual qualified cuda,h3 SM89 AppImage in the desktop packaging proof

## Live-main failures fixed

- Release docker SM89: runtime identity enumeration could not find the Cargo config
- Desktop frontend: stale contract expected cuda after packaging moved to cuda,h3

## Verification

- Linux CUDA distribution contract: 36/36, PASS
- Linux desktop nightly race guards: PASS
- cargo fmt and diff check: PASS
- peer review approved exact head 1b8ccd0ca470ae613419cbe41a7025299a12e64c