### PR TITLE
fix(release): verify exact container source identity

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -554,11 +554,12 @@ jobs:
             docker run --rm \
               --entrypoint /bin/sh \
               -e LD_LIBRARY_PATH=/usr/local/cuda/compat:/usr/local/cuda/lib64 \
+              -e EXPECTED_SOURCE_SHA="$GITHUB_SHA" \
               "$BUILT_IMAGE" \
-              -c 'exec mold version'
+              -c 'grep -aFq "$EXPECTED_SOURCE_SHA" "$(command -v mold)" && exec mold version'
           )"
-          grep -Fq "$GITHUB_SHA" <<<"$version" || {
-            echo "::error::container does not report exact source SHA $GITHUB_SHA: $version"
+          grep -Fq "${GITHUB_SHA:0:7}" <<<"$version" || {
+            echo "::error::container binary embeds exact source SHA but its human version does not report the matching abbreviation: $version"
             exit 1
           }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fixed CUDA container source-identity verification to authenticate the full embedded commit directly from the shipped binary while checking the intentionally abbreviated human-facing version separately.
+
 - Made hermetic CUTLASS staging reproducible across Nix builders by fetching a content-only GitHub archive and reconstructing only the exact pinned commit object required by cudaforge, avoiding platform-dependent `.git` metadata in the fixed-output hash.
 
 - Completed the public H3 distribution CI repair by retaining `.cargo/config.toml` and its Clang/LLD toolchain in Docker's manifest-first source layer for runtime-identity hashing and updating the desktop packaging contract to recognize the SM89 `cuda,h3` AppImage build.

--- a/scripts/tests/cuda-distribution-contract.sh
+++ b/scripts/tests/cuda-distribution-contract.sh
@@ -230,9 +230,11 @@ require_release_job_text "docker" \
 require_release_job_text "docker" \
   '-e LD_LIBRARY_PATH=/usr/local/cuda/compat:/usr/local/cuda/lib64'
 require_release_job_text "docker" \
-  "-c 'exec mold version'"
+  '-e EXPECTED_SOURCE_SHA="$GITHUB_SHA"'
 require_release_job_text "docker" \
-  'grep -Fq "$GITHUB_SHA"'
+  '-c '\''grep -aFq "$EXPECTED_SOURCE_SHA" "$(command -v mold)" && exec mold version'\'''
+require_release_job_text "docker" \
+  'grep -Fq "${GITHUB_SHA:0:7}" <<<"$version"'
 require_text "Dockerfile" 'ARG MOLD_GIT_SHA'
 require_text "Dockerfile" 'ENV MOLD_GIT_SHA=${MOLD_GIT_SHA}'
 


### PR DESCRIPTION
## Summary
- authenticate the full source commit directly from the shipped `mold` executable
- retain a separate assertion for the intentionally abbreviated human-facing version
- update the protected CUDA distribution contract to pin both checks

## Failure evidence
Exact-main SM100 built and pushed successfully, then failed because the workflow expected the full 40-character SHA in `mold version`, which intentionally prints seven characters: `mold 0.21.0 (b996f67 unknown)`.

## Verification
- static CUDA distribution assertions pass through the modified section (the later PTX fixture suite remains Linux-only because macOS lacks `readelf`)
- local shipped-binary scan proves the exact SHA is retained while version output is abbreviated
- `git diff --check origin/main...HEAD`
- mandatory exact-head peer review approved with no findings