### PR TITLE
fix(h3): distinguish public support provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Corrected public SM89 H3 release provenance so the authenticated Qwen support loader carries a public marker while private-UAT builds retain the release-rejected private marker.
+
 - Fixed CUDA container source-identity verification to authenticate the full embedded commit directly from the shipped binary while checking the intentionally abbreviated human-facing version separately.
 
 - Made hermetic CUTLASS staging reproducible across Nix builders by fetching a content-only GitHub archive and reconstructing only the exact pinned commit object required by cudaforge, avoiding platform-dependent `.git` metadata in the fixed-output hash.

--- a/crates/mold-inference/src/minimax_h3/private_qwen_support.rs
+++ b/crates/mold-inference/src/minimax_h3/private_qwen_support.rs
@@ -1,11 +1,10 @@
-//! Opened-file-bound Qwen support assets for private MiniMax H3 UAT.
+//! Opened-file-bound Qwen support assets for MiniMax H3.
 //!
-//! This module is compiled only with `h3-private-uat`. It resolves the five
-//! lightweight files consumed by the conditioner through the exact pinned H3
-//! manifest and `storage_path` contract, then parses only bytes read from
-//! authenticated, no-follow file descriptors. It does not register an engine,
-//! expose runtime capability, download anything, or relax H3 execution
-//! admission.
+//! Public `h3` and private `h3-private-uat` builds both resolve the five
+//! lightweight conditioner files through the exact pinned manifest and
+//! `storage_path` contract, then parse only bytes read from authenticated,
+//! no-follow file descriptors. It does not register an engine, expose runtime
+//! capability, download anything, or relax H3 execution admission.
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs::{File, Metadata};
@@ -24,10 +23,15 @@ use tokenizers::Tokenizer;
 #[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
 
-/// Retained by every executable that reaches the private support loader and
-/// rejected by `scripts/verify-h3-release-exclusion.sh` in published binaries.
+/// Retained by every executable that reaches the support loader. Private UAT
+/// keeps a release-rejectable marker; the public H3 runtime uses a distinct
+/// non-private provenance marker for the same authenticated loader mechanics.
+#[cfg(feature = "h3-private-uat")]
 pub const H3_PRIVATE_QWEN_SUPPORT_CLAIM_MARKER: &str =
     "mold.minimax-h3.private-uat-qwen-support-loader.v1";
+
+#[cfg(all(feature = "h3", not(feature = "h3-private-uat")))]
+pub const H3_PRIVATE_QWEN_SUPPORT_CLAIM_MARKER: &str = "mold.minimax-h3.qwen-support-loader.v1";
 
 const SUPPORT_IDENTITY_SCHEMA: &str = "mold.minimax-h3.private-qwen-support.v1";
 const RELEASED_TOKENIZER_BASE_VOCAB_SIZE: usize = 151_643;
@@ -680,6 +684,20 @@ fn validate_tokenizer(tokenizer: &Tokenizer, config: &H3ConditionerConfig) -> Re
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn support_loader_marker_matches_the_compiled_runtime_scope() {
+        #[cfg(feature = "h3-private-uat")]
+        assert_eq!(
+            H3_PRIVATE_QWEN_SUPPORT_CLAIM_MARKER,
+            "mold.minimax-h3.private-uat-qwen-support-loader.v1"
+        );
+        #[cfg(all(feature = "h3", not(feature = "h3-private-uat")))]
+        assert_eq!(
+            H3_PRIVATE_QWEN_SUPPORT_CLAIM_MARKER,
+            "mold.minimax-h3.qwen-support-loader.v1"
+        );
+    }
 
     const CONDITIONER_CONFIG: &str = r#"{
       "architectures":["Qwen3VLForConditionalGeneration"],

--- a/scripts/tests/minimax-h3-attention-release-contract.sh
+++ b/scripts/tests/minimax-h3-attention-release-contract.sh
@@ -171,6 +171,7 @@ omitted_marker='mold.minimax-h3.attention-release-provenance.v2:h3-rc=omitted:gl
 claim_marker='mold.minimax-h3.attention-rc.kernel-compiled.v1'
 private_qwen_support_marker='mold.minimax-h3.private-uat-qwen-support-loader.v1'
 h3_compiled_marker='mold.minimax-h3.attention-release-provenance.v2:h3-rc=compiled:global-flash=omitted'
+public_qwen_support_marker='mold.minimax-h3.qwen-support-loader.v1'
 global_compiled_markers=(
   'mold.minimax-h3.attention-release-provenance.v2:h3-rc=omitted:global-flash=compiled'
   'mold.minimax-h3.attention-release-provenance.v2:h3-rc=compiled:global-flash=compiled'
@@ -188,11 +189,19 @@ printf '%s\n%s\n' "$omitted_marker" "$claim_marker" > "$scratch_dir/claimed"
 if scripts/verify-h3-release-exclusion.sh "$scratch_dir/claimed" >/dev/null 2>&1; then
   fail "release verifier accepted an H3 claim without H3 provenance"
 fi
-printf '%s\n%s\n' "$h3_compiled_marker" "$claim_marker" > "$scratch_dir/public-h3"
+printf '%s\n%s\n' "$omitted_marker" "$public_qwen_support_marker" > "$scratch_dir/ordinary-with-support"
+if scripts/verify-h3-release-exclusion.sh "$scratch_dir/ordinary-with-support" >/dev/null 2>&1; then
+  fail "release verifier accepted public H3 Qwen support provenance without H3 provenance"
+fi
+printf '%s\n%s\n%s\n' "$h3_compiled_marker" "$claim_marker" "$public_qwen_support_marker" > "$scratch_dir/public-h3"
 scripts/verify-h3-release-exclusion.sh "$scratch_dir/public-h3" >/dev/null
 printf '%s\n' "$h3_compiled_marker" > "$scratch_dir/public-h3-missing-claim"
 if scripts/verify-h3-release-exclusion.sh "$scratch_dir/public-h3-missing-claim" >/dev/null 2>&1; then
   fail "release verifier accepted H3 provenance without its kernel claim"
+fi
+printf '%s\n%s\n' "$h3_compiled_marker" "$claim_marker" > "$scratch_dir/public-h3-missing-support"
+if scripts/verify-h3-release-exclusion.sh "$scratch_dir/public-h3-missing-support" >/dev/null 2>&1; then
+  fail "release verifier accepted H3 provenance without public Qwen support provenance"
 fi
 printf '%s\n%s\n' "$omitted_marker" "$private_qwen_support_marker" > "$scratch_dir/private-qwen-support"
 if scripts/verify-h3-release-exclusion.sh "$scratch_dir/private-qwen-support" >/dev/null 2>&1; then

--- a/scripts/verify-h3-release-exclusion.sh
+++ b/scripts/verify-h3-release-exclusion.sh
@@ -10,6 +10,7 @@ binary=$1
 claim_marker='mold.minimax-h3.attention-rc.kernel-compiled.v1'
 private_uat_marker='mold.minimax-h3.private-uat-artifact-reader.v1'
 private_qwen_support_marker='mold.minimax-h3.private-uat-qwen-support-loader.v1'
+public_qwen_support_marker='mold.minimax-h3.qwen-support-loader.v1'
 private_runtime_record_marker='mold.minimax-h3.private-runtime-record-producer.v1'
 private_runtime_observation_markers=(
   'mold.minimax-h3.private-uat-runtime-bound-observation.v1'
@@ -58,8 +59,15 @@ if grep -aFq "$h3_compiled_marker" "$binary"; then
     echo "published H3 binary lacks its H3-scoped kernel claim" >&2
     exit 1
   }
+  grep -aFq "$public_qwen_support_marker" "$binary" || {
+    echo "published H3 binary lacks its public Qwen support-loader provenance" >&2
+    exit 1
+  }
 elif grep -aFq "$claim_marker" "$binary"; then
   echo "ordinary published binary contains an unexpected H3 kernel claim" >&2
+  exit 1
+elif grep -aFq "$public_qwen_support_marker" "$binary"; then
+  echo "ordinary published binary contains unexpected H3 Qwen support provenance" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- give the authenticated Qwen support loader a public provenance marker under `h3`
- retain the private-UAT marker under `h3-private-uat`
- require public support provenance iff H3 is compiled and continue rejecting private markers

## Failure evidence
Exact-main SM89 native and Docker builds completed their expensive H3 compilation, then release verification correctly rejected the shipping binary because the public loader still carried `mold.minimax-h3.private-uat-qwen-support-loader.v1`.

## Verification
- MiniMax H3 attention release contract: PASS
- MiniMax H3 private-UAT release contract: PASS
- Rustfmt and diff-check: PASS
- mandatory exact-head peer review: APPROVED, no findings
- isolated Plato feature test was attempted but the 64-way FlashAttention test build exhausted an nvcc worker; release-contract coverage directly pins this cfg behavior