### PR TITLE
fix(ci): bound stalled workspace tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,6 +298,7 @@ jobs:
         run: nix build .#mold-web --print-build-logs
 
   rust:
+    timeout-minutes: 60
     needs: changes
     if: >-
       always() && !cancelled() &&
@@ -469,7 +470,7 @@ jobs:
       # responses, so keep that signal on main without forcing PR reruns.
       - name: Test (full main suite)
         if: env.RUN_RUST_SUITE == 'true'
-        run: cargo test --workspace
+        run: timeout --signal=TERM --kill-after=60s 20m cargo test --workspace
       - name: Test local multi-GPU qualification contract
         if: env.RUN_RUST_SUITE == 'true'
         run: bash scripts/tests/local-multi-gpu-qualification-contract.sh
@@ -664,6 +665,7 @@ jobs:
         run: cargo clippy -p mold-ai --features metal,preview,expand,tui,webp,mp4,mdns --all-targets -- -D warnings
 
   coverage:
+    timeout-minutes: 60
     needs: changes
     # Retain the required status name on PRs, but collect coverage only after
     # merge so no pull-request revision recompiles the workspace.
@@ -731,7 +733,7 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Generate coverage
-        run: cargo llvm-cov --workspace --lcov --output-path lcov.info
+        run: timeout --signal=TERM --kill-after=60s 45m cargo llvm-cov --workspace --lcov --output-path lcov.info
 
       - name: Upload to Codecov
         uses: codecov/codecov-action@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Bound the main Rust and coverage jobs to one hour, cap their test commands at twenty and forty-five minutes respectively, and remove an unbounded scheduling race from the queued SSE position regression, so a stalled server test fails promptly instead of consuming a runner for hours.
+
 - Corrected public SM89 H3 release provenance so the authenticated Qwen support loader carries a public marker while private-UAT builds retain the release-rejected private marker.
 
 - Fixed CUDA container source-identity verification to authenticate the full embedded commit directly from the shipped binary while checking the intentionally abbreviated human-facing version separately.

--- a/crates/mold-server/src/routes_test.rs
+++ b/crates/mold-server/src/routes_test.rs
@@ -97,6 +97,7 @@ mod tests {
 
     /// Minimal mock engine for testing routes without loading models.
     struct MockEngine {
+        model_name: &'static str,
         loaded: bool,
         fail: bool,
         empty_images: bool,
@@ -112,7 +113,12 @@ mod tests {
 
     impl MockEngine {
         fn ready() -> Self {
+            Self::ready_for_model("mock-model")
+        }
+
+        fn ready_for_model(model_name: &'static str) -> Self {
             Self {
+                model_name,
                 loaded: true,
                 fail: false,
                 empty_images: false,
@@ -127,6 +133,7 @@ mod tests {
         }
         fn failing() -> Self {
             Self {
+                model_name: "mock-model",
                 loaded: true,
                 fail: true,
                 empty_images: false,
@@ -141,6 +148,7 @@ mod tests {
         }
         fn empty_images() -> Self {
             Self {
+                model_name: "mock-model",
                 loaded: true,
                 fail: false,
                 empty_images: true,
@@ -155,6 +163,7 @@ mod tests {
         }
         fn unloaded(load_count: Arc<AtomicUsize>, load_delay: Duration) -> Self {
             Self {
+                model_name: "mock-model",
                 loaded: false,
                 fail: false,
                 empty_images: false,
@@ -173,6 +182,7 @@ mod tests {
             progress_clear_count: Arc<AtomicUsize>,
         ) -> Self {
             Self {
+                model_name: "mock-model",
                 loaded: true,
                 fail: false,
                 empty_images: false,
@@ -188,6 +198,7 @@ mod tests {
 
         fn blocking_generate(blocker: Arc<GenerateBlocker>) -> Self {
             Self {
+                model_name: "mock-model",
                 loaded: true,
                 fail: false,
                 empty_images: false,
@@ -205,6 +216,7 @@ mod tests {
         /// simulating FP8→Q8 conversion status messages.
         fn unloaded_with_progress() -> Self {
             Self {
+                model_name: "mock-model",
                 loaded: false,
                 fail: false,
                 empty_images: false,
@@ -255,7 +267,7 @@ mod tests {
         }
 
         fn model_name(&self) -> &str {
-            "mock-model"
+            self.model_name
         }
 
         fn is_loaded(&self) -> bool {
@@ -825,8 +837,12 @@ mod tests {
 
     fn generate_body(prompt: &str, width: u32, height: u32) -> String {
         // Use "mock-model" to match MockEngine::model_name() — avoids hot-swap path.
+        generate_body_for_model(prompt, "mock-model", width, height)
+    }
+
+    fn generate_body_for_model(prompt: &str, model: &str, width: u32, height: u32) -> String {
         format!(
-            r#"{{"prompt":"{prompt}","model":"mock-model","width":{width},"height":{height},"steps":4,"batch_size":1,"output_format":"png"}}"#
+            r#"{{"prompt":"{prompt}","model":"{model}","width":{width},"height":{height},"steps":4,"batch_size":1,"output_format":"png"}}"#
         )
     }
 
@@ -7178,59 +7194,77 @@ mod tests {
     /// and close their SSE streams.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn queued_stream_receives_position_event() {
-        let (state, rx) = AppState::with_engine_and_queue(MockEngine::ready());
+        let model = "sd15:fp16";
+        let (state, rx) = AppState::with_engine_and_queue(MockEngine::ready_for_model(model));
         let queue = state.queue.clone();
         let worker_state = state.clone();
         let app = app_with_state(state);
 
-        // Submit first request (worker not started — handler completes fast)
-        let _resp1 = {
-            let app = app.clone();
-            tokio::spawn(async move {
-                app.oneshot(
-                    Request::post("/api/generate/stream")
-                        .header("content-type", "application/json")
-                        .body(Body::from(generate_body("first", 768, 768)))
-                        .unwrap(),
-                )
+        // The SSE route submits while its body is polled, so retain a task that
+        // consumes the first response while waiting for the queue transition.
+        let resp1 = app
+            .clone()
+            .oneshot(
+                Request::post("/api/generate/stream")
+                    .header("content-type", "application/json")
+                    .body(Body::from(generate_body_for_model(
+                        "first", model, 768, 768,
+                    )))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        if resp1.status() != StatusCode::OK {
+            let status = resp1.status();
+            let body = axum::body::to_bytes(resp1.into_body(), 1024 * 1024)
                 .await
-            })
-        };
-
-        // Wait for the first request to be queued before submitting the second,
-        // guaranteeing the second request sees pending_count == 1 (position 1).
-        while queue.pending() < 1 {
-            tokio::time::sleep(Duration::from_millis(1)).await;
+                .unwrap();
+            panic!(
+                "first streaming request returned {status}: {}",
+                String::from_utf8_lossy(&body)
+            );
         }
+        let body1 =
+            tokio::spawn(async move { axum::body::to_bytes(resp1.into_body(), 1024 * 1024).await });
+        tokio::time::timeout(Duration::from_secs(10), async {
+            while queue.pending() < 1 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("first streaming request should enter the queue");
 
         // Submit second request — should be queued at position 1
-        let resp2 = {
-            let app = app.clone();
-            tokio::spawn(async move {
-                let resp = app
-                    .oneshot(
-                        Request::post("/api/generate/stream")
-                            .header("content-type", "application/json")
-                            .body(Body::from(generate_body("second", 768, 768)))
-                            .unwrap(),
-                    )
-                    .await
-                    .unwrap();
-                let body = axum::body::to_bytes(resp.into_body(), 1024 * 1024)
-                    .await
-                    .unwrap();
-                String::from_utf8_lossy(&body).to_string()
-            })
-        };
+        let resp2 = app
+            .oneshot(
+                Request::post("/api/generate/stream")
+                    .header("content-type", "application/json")
+                    .body(Body::from(generate_body_for_model(
+                        "second", model, 768, 768,
+                    )))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body2 =
+            tokio::spawn(async move { axum::body::to_bytes(resp2.into_body(), 1024 * 1024).await });
+        tokio::time::timeout(Duration::from_secs(10), async {
+            while queue.pending() < 2 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("second streaming request should enter the queue");
 
-        // Wait for both requests to be queued, then start the worker so
-        // both jobs are processed and their SSE streams close.
-        while queue.pending() < 2 {
-            tokio::time::sleep(Duration::from_millis(1)).await;
-        }
+        // Start the worker so both jobs are processed and the streams close.
         tokio::spawn(crate::queue::run_queue_worker(rx, worker_state));
 
-        let text2 = resp2.await.unwrap();
+        let body2 = tokio::time::timeout(Duration::from_secs(10), body2)
+            .await
+            .expect("second queued stream should close")
+            .expect("second queued stream task should complete")
+            .unwrap();
+        let text2 = String::from_utf8_lossy(&body2).to_string();
         assert!(
             text2.contains(r#""type":"queued""#),
             "second request should receive a queued event, got: {text2}"
@@ -7240,6 +7274,12 @@ mod tests {
             text2.contains(r#""position":1"#),
             "second request should be at position 1, got: {text2}"
         );
+
+        tokio::time::timeout(Duration::from_secs(10), body1)
+            .await
+            .expect("first queued stream should close")
+            .expect("first queued stream task should complete")
+            .unwrap();
     }
 
     /// Verify that both streaming and non-streaming requests are properly

--- a/scripts/tests/ci-coverage-disk-guard.sh
+++ b/scripts/tests/ci-coverage-disk-guard.sh
@@ -30,6 +30,10 @@ grep -Fq '/usr/local/lib/android' <<< "$coverage_job" \
   || fail "coverage cleanup does not remove the preinstalled Android SDK"
 grep -Fq 'df -h' <<< "$coverage_job" \
   || fail "coverage cleanup does not report disk capacity"
+grep -Fq 'timeout-minutes: 60' <<< "$coverage_job" \
+  || fail "coverage job does not have a bounded runtime"
+grep -Fq 'run: timeout --signal=TERM --kill-after=60s 45m cargo llvm-cov --workspace --lcov --output-path lcov.info' <<< "$coverage_job" \
+  || fail "coverage generation does not have a bounded runtime"
 
 fixture="$(mktemp)"
 trap 'rm -f "$fixture"' EXIT

--- a/scripts/tests/ci-routing-contract.sh
+++ b/scripts/tests/ci-routing-contract.sh
@@ -327,6 +327,8 @@ if grep -Fq 'name: Test (PR suite)' <<< "$rust_gate"; then
 fi
 grep -Fq 'name: Test (full main suite)' <<< "$rust_gate" \
   || fail "main Rust suite does not retain the complete workspace tests"
+grep -Fq 'run: timeout --signal=TERM --kill-after=60s 20m cargo test --workspace' <<< "$rust_gate" \
+  || fail "main Rust suite does not bound the complete workspace tests"
 if grep -Fq 'run: cargo check --workspace' "$ci"; then
   fail "root Rust CI still runs cargo check immediately before all-target Clippy"
 fi


### PR DESCRIPTION
## Summary
- repair the queued SSE position regression so it uses a deliverable model recipe and owns/bounds every async wait
- cap the full workspace test command at 20 minutes and coverage at 45 minutes
- cap both Rust and coverage jobs at 60 minutes and protect those limits with CI contracts

## Root cause
Exact-main run 31694495856 stalled for roughly 2.5 hours because `routes_test::tests::queued_stream_receives_position_event` submitted obsolete `mock-model`, received HTTP 422 before queueing, ignored that response, and polled the queue forever. The same test stalled the coverage process.

## Verification
- focused regression: passed
- stress run: 25/25 passed
- CI routing contract: passed
- coverage disk/runtime guard: passed
- cargo fmt: passed
- git diff --check: passed
- mandatory exact-snapshot peer review: approved with no findings

The broad local server suite also revealed existing shared-home/process-state contamination when run in parallel; this PR does not disguise those failures, but it guarantees no individual test can consume a runner for hours again.