### PR TITLE
fix(ci): isolate server recipe fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Restored deterministic server and coverage CI by giving preloaded mock engines a conservative synthetic recipe and preventing test-only catalog refreshes from importing or overwriting state through the runner's real Mold home.
+
 - Bound the main Rust and coverage jobs to one hour, cap their test commands at twenty and forty-five minutes respectively, and remove an unbounded scheduling race from the queued SSE position regression, so a stalled server test fails promptly instead of consuming a runner for hours.
 
 - Corrected public SM89 H3 release provenance so the authenticated Qwen support loader carries a public marker while private-UAT builds retain the release-rejected private marker.

--- a/crates/mold-server/src/model_manager.rs
+++ b/crates/mold-server/src/model_manager.rs
@@ -176,14 +176,25 @@ pub(crate) enum PullStatus {
 }
 
 pub(crate) async fn refresh_config(state: &AppState) -> mold_core::Config {
-    let fresh = {
-        let current = state.config.read().await;
-        current.reload_from_disk_preserving_runtime()
-    };
+    // Unit-test states intentionally carry isolated in-memory model and
+    // output authorities. Reloading is explicit per state so another
+    // parallel test's temporary process-global MOLD_HOME cannot erase
+    // synthetic recipes or import unrelated disk configuration. Production
+    // always takes the reload path because cfg!(test) is false.
+    if cfg!(test) && !state.reload_config_from_disk {
+        return state.config.read().await.clone();
+    }
 
-    let mut config = state.config.write().await;
-    *config = fresh.clone();
-    fresh
+    {
+        let fresh = {
+            let current = state.config.read().await;
+            current.reload_from_disk_preserving_runtime()
+        };
+
+        let mut config = state.config.write().await;
+        *config = fresh.clone();
+        fresh
+    }
 }
 
 pub(crate) async fn list_models(state: &AppState) -> Vec<ModelInfoExtended> {
@@ -5340,8 +5351,18 @@ mod tests {
             ..Default::default()
         };
         let te_dir = models_dir.join("z-image-te");
-        config.models.insert(
-            "z-image-te".into(),
+        for path in [
+            te_dir.join("text_encoder/model-00001-of-00003.safetensors"),
+            te_dir.join("text_encoder/model-00002-of-00003.safetensors"),
+            te_dir.join("text_encoder/model-00003-of-00003.safetensors"),
+            te_dir.join("vae/diffusion_pytorch_model.safetensors"),
+            te_dir.join("tokenizer/tokenizer.json"),
+        ] {
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(path, b"test fixture").unwrap();
+        }
+        config.install_frozen_model_config(
+            "z-image-te",
             mold_core::ModelConfig {
                 family: Some("companion".into()),
                 transformer: Some(

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -939,12 +939,6 @@ async fn prepare_generation(
             .find(|entry| entry.info.name == request.model || entry.info.name == canonical_model)
             .and_then(|entry| entry.generation_profile)
     };
-    if !private_h3_ingress && resolved_profile.is_none() {
-        return Err(ApiError::validation(format!(
-            "model '{}' has no generation recipe deliverable by this server build",
-            request.model
-        )));
-    }
     // The effective, delivery-qualified recipe owns the output default. A
     // family heuristic here can select MP4 even when this binary did not link
     // the encoder, causing an omitted field to fail its own advertised profile.
@@ -972,6 +966,20 @@ async fn prepare_generation(
     // provenance equal to what actually rendered (#783).
     mold_core::validation::materialize_extend_overlap_frames(request, resolved_family.as_deref());
 
+    // A model with no deliverable recipe cannot reach media-dependent
+    // preparation. Preserve basic request/unknown-model diagnostics first,
+    // then fail before control planning, LipDub probing, reference resolution,
+    // or server-local media access.
+    if !private_h3_ingress && resolved_profile.is_none() {
+        validate_generate_request(request, resolved_family.as_deref())
+            .map_err(ApiError::validation)?;
+        let _ = model_manager::check_model_available(state, &request.model).await?;
+        return Err(ApiError::validation(format!(
+            "model '{}' has no generation recipe deliverable by this server build",
+            request.model
+        )));
+    }
+
     let planned_control = plan_builtin_ltx2_control(state, request).await?;
     let planned_camera_controls = plan_builtin_ltx2_camera_controls(state, request).await?;
 
@@ -991,12 +999,6 @@ async fn prepare_generation(
     } else {
         &*request
     };
-    if !private_h3_ingress {
-        if let Some(profile) = resolved_profile {
-            mold_core::validate_request_against_generation_profile(&profile, validation_request)
-                .map_err(ApiError::validation)?;
-        }
-    }
     #[cfg(any(feature = "h3", feature = "h3-private-uat"))]
     let validation = if private_h3_ingress {
         mold_core::validation::validate_h3_private_uat_request(validation_request)
@@ -1007,6 +1009,13 @@ async fn prepare_generation(
     let validation = validate_generate_request(validation_request, resolved_family.as_deref());
     if let Err(e) = validation {
         return Err(ApiError::validation(e));
+    }
+    if !private_h3_ingress {
+        if let Some(profile) = resolved_profile.as_ref() {
+            mold_core::validate_request_against_generation_profile(profile, validation_request)
+                .map_err(ApiError::validation)?;
+        }
+        let _ = model_manager::check_model_available(state, &request.model).await?;
     }
     enforce_source_image_capability(state, request, resolved_family.as_deref()).await?;
 
@@ -1033,10 +1042,6 @@ async fn prepare_generation(
         materialize_builtin_ltx2_control(state, request, adapter, path).await?;
     }
     materialize_builtin_ltx2_camera_controls(state, &planned_camera_controls).await?;
-
-    if !private_h3_ingress {
-        let _ = model_manager::check_model_available(state, &request.model).await?;
-    }
 
     let (output_dir, dim_warning) = {
         let config = state.config.read().await;

--- a/crates/mold-server/src/routes_chain_jobs.rs
+++ b/crates/mold-server/src/routes_chain_jobs.rs
@@ -1677,10 +1677,11 @@ mod tests {
         std::fs::write(&transformer, b"transformer").unwrap();
         std::fs::write(&vae, b"vae").unwrap();
 
-        let state = state_with(
+        let mut state = state_with(
             Arc::new(Some(MetadataDb::open_in_memory().unwrap())),
             crate::chain_job_runner::ChainJobRunnerHandle::inert_for_tests(),
         );
+        state.reload_config_from_disk = true;
         assert!(!state
             .config
             .read()

--- a/crates/mold-server/src/routes_test.rs
+++ b/crates/mold-server/src/routes_test.rs
@@ -3952,7 +3952,7 @@ mod tests {
         );
         assert!(body["catalog"]["families"]
             .as_array()
-            .is_some_and(|families| families.iter().all(|family| family != "minimax-h3")));
+            .is_some_and(|families| families.iter().any(|family| family == "minimax-h3")));
         assert_eq!(
             body["model_access"]["restrictions"][0]["code"],
             mold_core::MINIMAX_H3_AUTHORIZATION_REQUIRED
@@ -6973,6 +6973,7 @@ mod tests {
             config: Arc::new(tokio::sync::RwLock::new(AppState::test_config())),
             reference_uploads: crate::reference_uploads::ReferenceUploadStore::from_mold_home(),
             output_disabled_override: true,
+            reload_config_from_disk: false,
             start_time: std::time::Instant::now(),
             model_load_lock: Arc::new(tokio::sync::Mutex::new(())),
             pull_lock: Arc::new(tokio::sync::Mutex::new(())),
@@ -7045,6 +7046,7 @@ mod tests {
             config: Arc::new(tokio::sync::RwLock::new(AppState::test_config())),
             reference_uploads: crate::reference_uploads::ReferenceUploadStore::from_mold_home(),
             output_disabled_override: true,
+            reload_config_from_disk: false,
             start_time: std::time::Instant::now(),
             model_load_lock: Arc::new(tokio::sync::Mutex::new(())),
             pull_lock: Arc::new(tokio::sync::Mutex::new(())),
@@ -7344,6 +7346,7 @@ mod tests {
             config: Arc::new(tokio::sync::RwLock::new(AppState::test_config())),
             reference_uploads: crate::reference_uploads::ReferenceUploadStore::from_mold_home(),
             output_disabled_override: true,
+            reload_config_from_disk: false,
             start_time: std::time::Instant::now(),
             model_load_lock: Arc::new(tokio::sync::Mutex::new(())),
             pull_lock: Arc::new(tokio::sync::Mutex::new(())),

--- a/crates/mold-server/src/state.rs
+++ b/crates/mold-server/src/state.rs
@@ -295,6 +295,10 @@ pub struct AppState {
     /// remain authoritative in production, while mock-generation fixtures
     /// must never inherit any process-level `MOLD_OUTPUT_DIR`.
     pub output_disabled_override: bool,
+    /// Test-only opt-in for cases that deliberately exercise config reloads.
+    /// Ordinary fixtures keep their in-memory recipe authority isolated from
+    /// process-global Mold home state.
+    pub(crate) reload_config_from_disk: bool,
     pub start_time: Instant,
     /// Guards concurrent model loads and hot-swaps.
     pub model_load_lock: Arc<Mutex<()>>,
@@ -542,10 +546,23 @@ impl AppState {
     /// Persistence tests opt back in with their own temporary output dir.
     #[cfg(test)]
     pub(crate) fn test_config() -> Config {
-        Config {
+        let mut config = Config {
             output_dir: Some(String::new()),
             ..Config::default()
-        }
+        };
+        config
+            .models
+            .insert("mock-model".to_string(), mold_core::ModelConfig::default());
+        config
+    }
+
+    #[cfg(test)]
+    fn test_config_with_model(model_name: &str) -> Config {
+        let mut config = Self::test_config();
+        config
+            .models
+            .insert(model_name.to_string(), mold_core::ModelConfig::default());
+        config
     }
 
     pub(crate) fn is_output_disabled(&self, config: &Config) -> bool {
@@ -575,6 +592,7 @@ impl AppState {
             config: Arc::new(tokio::sync::RwLock::new(config)),
             reference_uploads: crate::reference_uploads::ReferenceUploadStore::from_mold_home(),
             output_disabled_override: false,
+            reload_config_from_disk: false,
             start_time: Instant::now(),
             model_load_lock: Arc::new(Mutex::new(())),
             pull_lock: Arc::new(Mutex::new(())),
@@ -644,6 +662,7 @@ impl AppState {
             config: Arc::new(tokio::sync::RwLock::new(config)),
             reference_uploads: crate::reference_uploads::ReferenceUploadStore::from_mold_home(),
             output_disabled_override: false,
+            reload_config_from_disk: false,
             start_time: Instant::now(),
             model_load_lock: Arc::new(Mutex::new(())),
             pull_lock: Arc::new(Mutex::new(())),
@@ -706,6 +725,7 @@ impl AppState {
 
     #[cfg(test)]
     pub fn with_engine(engine: impl InferenceEngine + 'static) -> Self {
+        let model_name = engine.model_name().to_string();
         let (tx, _rx) = tokio::sync::mpsc::channel(16);
         let queue = QueueHandle::new(tx);
         let mut cache = ModelCache::new(resolve_max_cached_models());
@@ -720,9 +740,12 @@ impl AppState {
             queue_capacity: 200,
             model_cache: Arc::new(Mutex::new(cache)),
             active_generation: Arc::new(RwLock::new(None)),
-            config: Arc::new(tokio::sync::RwLock::new(Self::test_config())),
+            config: Arc::new(tokio::sync::RwLock::new(Self::test_config_with_model(
+                &model_name,
+            ))),
             reference_uploads: crate::reference_uploads::ReferenceUploadStore::from_mold_home(),
             output_disabled_override: true,
+            reload_config_from_disk: false,
             start_time: Instant::now(),
             model_load_lock: Arc::new(Mutex::new(())),
             pull_lock: Arc::new(Mutex::new(())),
@@ -752,6 +775,7 @@ impl AppState {
     pub fn with_engine_and_queue(
         engine: impl InferenceEngine + 'static,
     ) -> (Self, tokio::sync::mpsc::Receiver<GenerationJob>) {
+        let model_name = engine.model_name().to_string();
         let (tx, rx) = tokio::sync::mpsc::channel(16);
         let queue = QueueHandle::new(tx);
         let mut cache = ModelCache::new(resolve_max_cached_models());
@@ -766,9 +790,12 @@ impl AppState {
             queue_capacity: 200,
             model_cache: Arc::new(Mutex::new(cache)),
             active_generation: Arc::new(RwLock::new(None)),
-            config: Arc::new(tokio::sync::RwLock::new(Self::test_config())),
+            config: Arc::new(tokio::sync::RwLock::new(Self::test_config_with_model(
+                &model_name,
+            ))),
             reference_uploads: crate::reference_uploads::ReferenceUploadStore::from_mold_home(),
             output_disabled_override: true,
+            reload_config_from_disk: false,
             start_time: Instant::now(),
             model_load_lock: Arc::new(Mutex::new(())),
             pull_lock: Arc::new(Mutex::new(())),
@@ -815,6 +842,7 @@ impl AppState {
             config: Arc::new(tokio::sync::RwLock::new(Config::default())),
             reference_uploads: crate::reference_uploads::ReferenceUploadStore::from_mold_home(),
             output_disabled_override: false,
+            reload_config_from_disk: false,
             start_time: Instant::now(),
             model_load_lock: Arc::new(Mutex::new(())),
             pull_lock: Arc::new(Mutex::new(())),


### PR DESCRIPTION
## Summary
- give mock server engines a conservative synthetic recipe matching their model name
- make config reload intent explicit per test state so parallel tests cannot import another test or developer Mold home
- preserve request diagnostics while rejecting models without executable recipes before any media-dependent preparation
- update public H3 catalog capability expectation and freeze the Z-Image companion fixture

## Verification
- `cargo test -p mold-ai-server --lib` (1431 passed, 0 failed, 12 ignored)
- `cargo test -p mold-ai-server --lib routes_test::tests` (231 passed)
- `cargo clippy -p mold-ai-server --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- mandatory peer review approved exact diff SHA-256 `a829fe94238b225f408f04f4bf48c1ef79a86059844742bd2ddf40afe596b805`

Fixes the Rust and coverage failures on main run 31709673832.