### PR TITLE
fix(ci): align H3 catalog integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Updated the standalone catalog integration contract for public MiniMax H3 discovery while retaining its separate runtime-access restriction, restoring the main coverage gate after public H3 activation.
+
 - Restored deterministic server and coverage CI by giving preloaded mock engines a conservative synthetic recipe and preventing test-only catalog refreshes from importing or overwriting state through the runner's real Mold home.
 
 - Bound the main Rust and coverage jobs to one hour, cap their test commands at twenty and forty-five minutes respectively, and remove an unbounded scheduling race from the queued SSE position regression, so a stalled server test fails promptly instead of consuming a runner for hours.

--- a/crates/mold-server/tests/catalog_routes.rs
+++ b/crates/mold-server/tests/catalog_routes.rs
@@ -20,6 +20,7 @@ async fn families_endpoint_returns_static_taxonomy() {
         "z-image",
         "ltx-video",
         "ltx2",
+        "minimax-h3",
         "qwen-image",
         "wuerstchen",
     ] {
@@ -28,10 +29,6 @@ async fn families_endpoint_returns_static_taxonomy() {
             "family {expected:?} missing from sidebar list, got {names:?}",
         );
     }
-    assert!(
-        !names.contains(&"minimax-h3"),
-        "compliance-gated H3 must stay out of ordinary taxonomy: {names:?}"
-    );
     // Per-family counts are gone from the wire — live search hits one
     // family at a time, so the SPA's sidebar shows just the family name.
     let flux = families
@@ -50,11 +47,13 @@ async fn capabilities_includes_catalog_block() {
     let v: serde_json::Value = serde_json::from_str(&resp.body).unwrap();
     assert_eq!(v["catalog"]["available"], serde_json::Value::Bool(true));
     assert!(v["catalog"]["families"].is_array());
-    assert!(!v["catalog"]["families"]
+    assert!(v["catalog"]["families"]
         .as_array()
         .unwrap()
         .iter()
         .any(|family| family == "minimax-h3"));
+    // Catalog acquisition is public while runtime access remains an
+    // independently enforced capability.
     assert!(v["model_access"]["restrictions"]
         .as_array()
         .unwrap()


### PR DESCRIPTION
## Summary
- update standalone catalog integration tests for public MiniMax H3 discovery
- retain the independently asserted H3 runtime-access restriction
- restore the main coverage gate without changing production behavior

## Verification
- `cargo test -p mold-ai-server --test catalog_routes` (2/2)
- `cargo clippy -p mold-ai-server --test catalog_routes -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- mandatory peer review approved exact diff SHA-256 `ef3ab1ac3a86fa26343216d4da47bd8368418334dc07cb5831d40f40505ddb61`

Fixes the coverage failure on main run 31721423444.