### PR TITLE
fix(ci): run H3 producer gate with CUDA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -498,9 +498,6 @@ jobs:
       - name: Clippy the private MiniMax H3 artifact qualifier
         if: env.RUN_RUST_SUITE == 'true'
         run: cargo clippy -p mold-ai-inference --features dev-bins,h3-private-uat --bin h3_artifact_qualification -- -D warnings
-      - name: Clippy the development-only MiniMax H3 runtime-record producer
-        if: env.RUN_RUST_SUITE == 'true'
-        run: cargo clippy -p mold-ai-inference --features dev-bins,h3 --bin h3_runtime_qualification_record -- -D warnings
       - name: Clippy the private exact-BF16 Qwen capture adapter
         if: env.RUN_RUST_SUITE == 'true'
         run: cargo clippy -p mold-ai-inference --features dev-bins,h3-private-uat --bin h3_qwen_layer50_capture -- -D warnings
@@ -553,6 +550,8 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Clippy CUDA forced-local, public H3, and server paths
         run: cargo clippy -p mold-ai --features cuda,h3,preview,expand,tui,webp,mp4,mdns --all-targets -- -D warnings
+      - name: Clippy the development-only MiniMax H3 runtime-record producer
+        run: cargo clippy -p mold-ai-inference --features dev-bins,h3 --bin h3_runtime_qualification_record -- -D warnings
       - name: Clippy the CUDA private H3 server bridge
         run: cargo clippy -p mold-ai-server --features h3-private-uat --all-targets -- -D warnings
       - name: Clippy private exact-BF16 Qwen capture adapter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Run the development-only MiniMax H3 runtime-record producer Clippy gate in main's CUDA job, after the toolkit is installed, instead of failing the CPU Rust job on a missing `nvcc`; the local CI mirror and routing contract now enforce the same placement.
+
 - Updated the standalone catalog integration contract for public MiniMax H3 discovery while retaining its separate runtime-access restriction, restoring the main coverage gate after public H3 activation.
 
 - Restored deterministic server and coverage CI by giving preloaded mock engines a conservative synthetic recipe and preventing test-only catalog refreshes from importing or overwriting state through the runner's real Mold home.

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -258,9 +258,6 @@ if wants rust; then
     step "rust: clippy $bin" \
       cargo clippy -p mold-ai-inference --features dev-bins,h3-private-uat --bin "$bin" -- -D warnings
   done
-  step "rust: clippy h3_runtime_qualification_record" \
-    cargo clippy -p mold-ai-inference --features dev-bins,h3 \
-    --bin h3_runtime_qualification_record -- -D warnings
 fi
 
 if wants contracts; then
@@ -353,6 +350,9 @@ if wants gpu; then
       if command -v nvcc >/dev/null 2>&1; then
         step "gpu: CUDA forced-local clippy" \
           cargo clippy -p mold-ai --features cuda,h3,preview,expand,tui,webp,mp4,mdns --all-targets -- -D warnings
+        step "gpu: clippy h3_runtime_qualification_record" \
+          cargo clippy -p mold-ai-inference --features dev-bins,h3 \
+          --bin h3_runtime_qualification_record -- -D warnings
         step "gpu: CUDA private H3 server bridge" \
           cargo clippy -p mold-ai-server --features h3-private-uat --all-targets -- -D warnings
         # The capture adapters compile only under `cuda`, so the CPU rust suite

--- a/scripts/tests/ci-routing-contract.sh
+++ b/scripts/tests/ci-routing-contract.sh
@@ -39,6 +39,19 @@ extract_filter() {
   ' "$file"
 }
 
+rust_job=$(extract_job "$ci" rust)
+cuda_job=$(extract_job "$ci" cuda-check)
+producer_command='cargo clippy -p mold-ai-inference --features dev-bins,h3 --bin h3_runtime_qualification_record -- -D warnings'
+if grep -Fq -- "$producer_command" <<< "$rust_job"; then
+  fail "the CUDA-backed H3 runtime-record producer runs in the CPU Rust job"
+fi
+grep -Fq -- "$producer_command" <<< "$cuda_job" \
+  || fail "the CUDA job does not compile the public H3 runtime-record producer"
+toolkit_line=$(grep -nF -- 'name: Install CUDA toolkit' <<< "$cuda_job" | cut -d: -f1)
+producer_line=$(grep -nF -- "$producer_command" <<< "$cuda_job" | cut -d: -f1)
+[[ -n "$toolkit_line" && -n "$producer_line" && "$toolkit_line" -lt "$producer_line" ]] \
+  || fail "the H3 runtime-record producer is compiled before the CUDA toolkit is installed"
+
 require_text "$ci" \
   "cancel-in-progress: \${{ github.event_name == 'pull_request' }}" \
   "root CI does not cancel superseded PR runs"


### PR DESCRIPTION
## Summary
- move the public H3 runtime-record producer Clippy gate out of the CPU Rust job
- run it in the existing CUDA job after nvcc is installed
- mirror and protect the placement in local CI and routing contracts

## Verification
- bash scripts/tests/ci-routing-contract.sh
- bash -n scripts/ci-local.sh scripts/tests/ci-routing-contract.sh
- git diff --check
- exact-diff independent peer review: approved