### PR TITLE
fix(h3): align CLI tests with public activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Aligned CLI package tests with the compiled MiniMax H3 policy so public CUDA/H3 builds accept the canonical FL2VA identity and trusted H3 artifact paths while non-H3 builds retain the fail-closed authorization gate.
+
 - Run the development-only MiniMax H3 runtime-record producer Clippy gate in main's CUDA job, after the toolkit is installed, instead of failing the CPU Rust job on a missing `nvcc`; the local CI mirror and routing contract now enforce the same placement.
 
 - Updated the standalone catalog integration contract for public MiniMax H3 discovery while retaining its separate runtime-access restriction, restoring the main coverage gate after public H3 activation.

--- a/crates/mold-cli/src/catalog_bridge.rs
+++ b/crates/mold-cli/src/catalog_bridge.rs
@@ -292,7 +292,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn cloud_activation_rejects_configured_family_and_path_without_catalog_io() {
+    async fn cloud_activation_respects_compiled_h3_policy_without_catalog_io() {
         let mut family_config = explicit_config("/tmp/mold-cloud-policy-family");
         family_config.models.insert(
             "renamed-model".into(),
@@ -318,12 +318,15 @@ mod tests {
                 ..Default::default()
             },
         );
-        let error = require_cloud_model_activation(&mut path_config, "renamed-model")
-            .await
-            .expect_err("configured H3 path must be rejected");
-        assert!(error
-            .to_string()
-            .contains(mold_core::MINIMAX_H3_AUTHORIZATION_REQUIRED));
+        let path_result = require_cloud_model_activation(&mut path_config, "renamed-model").await;
+        if cfg!(feature = "h3") {
+            path_result.expect("public H3 builds accept trusted H3 artifact paths");
+        } else {
+            let error = path_result.expect_err("non-H3 builds must reject configured H3 paths");
+            assert!(error
+                .to_string()
+                .contains(mold_core::MINIMAX_H3_AUTHORIZATION_REQUIRED));
+        }
     }
 
     #[tokio::test]

--- a/crates/mold-cli/src/commands/generate.rs
+++ b/crates/mold-cli/src/commands/generate.rs
@@ -3615,12 +3615,17 @@ mod tests {
     }
 
     #[test]
-    fn h3_remote_missing_model_cannot_enter_auto_pull() {
+    fn h3_remote_auto_pull_respects_compiled_activation_policy() {
         let request = h3_request(mold_core::minimax_h3::FL2VA_COMFY);
-        let error = require_remote_auto_pull_activation(&request, &Config::default()).unwrap_err();
-        assert!(error
-            .to_string()
-            .contains(mold_core::MINIMAX_H3_AUTHORIZATION_REQUIRED));
+        let result = require_remote_auto_pull_activation(&request, &Config::default());
+        if cfg!(feature = "h3") {
+            result.expect("public H3 builds permit the canonical FL2VA auto-pull identity");
+        } else {
+            let error = result.expect_err("non-H3 builds must reject H3 auto-pull");
+            assert!(error
+                .to_string()
+                .contains(mold_core::MINIMAX_H3_AUTHORIZATION_REQUIRED));
+        }
     }
 
     #[tokio::test]
@@ -4430,7 +4435,7 @@ mod tests {
     }
 
     #[test]
-    fn forced_local_policy_gates_nested_models_and_artifacts_before_pull() {
+    fn forced_local_policy_respects_compiled_h3_artifact_activation() {
         let root = "/Volumes/ExternalStorage/mold-uat/minimax-h3/models";
         let mut config = Config {
             models_dir: root.to_string(),
@@ -4464,7 +4469,12 @@ mod tests {
 
             expert: None,
         });
-        assert!(require_local_request_model_activation(&request, &config).is_err());
+        let h3_artifact_result = require_local_request_model_activation(&request, &config);
+        if cfg!(feature = "h3") {
+            h3_artifact_result.expect("public H3 builds accept trusted H3 artifact paths");
+        } else {
+            assert!(h3_artifact_result.is_err());
+        }
 
         request.lora.as_mut().unwrap().path = format!("{root}/flux/ordinary-adapter.safetensors");
         assert!(require_local_request_model_activation(&request, &config).is_ok());


### PR DESCRIPTION
## Summary
- align CLI activation tests with the compiled public H3 feature policy
- retain fail-closed expectations for non-H3 builds and noncanonical H3 identities
- unblock the Nix release package test used by host deployments

## Verification
- three focused `mold-ai` CLI tests
- `cargo fmt --all -- --check`
- `git diff --check`