### PR TITLE
fix(ios): restore LTX-2 develop action

### DIFF
--- a/desktop/src/lib/generateForm.test.ts
+++ b/desktop/src/lib/generateForm.test.ts
@@ -150,6 +150,64 @@ describe("recipe defaults", () => {
     });
     expect(form.guidanceOverrides.stgScale).toBeNull();
   });
+
+  it("reconciles stale values to fixed recipe controls on inventory refresh", () => {
+    const profiled = profiledLtx2Model();
+    const recipe = profiled.generation_profile!.recipes[0]!;
+    recipe.defaults.steps = 8;
+    recipe.defaults.guidance = 1;
+    recipe.steps = { ...recipe.steps, mode: "fixed", default: 8, min: 8, max: 8 };
+    recipe.guidance = {
+      ...recipe.guidance,
+      mode: "fixed",
+      default: 1,
+      min: 1,
+      max: 1,
+    };
+    const form = newGenerateForm();
+    form.model = profiled.name;
+    form.family = profiled.family;
+    form.steps = 30;
+    form.guidance = 3.5;
+
+    reconcileModelCapabilities(form, profiled);
+
+    expect(form.steps).toBe(8);
+    expect(form.guidance).toBe(1);
+    expect(profiled.generation_profile?.default_recipe_id).toBe("one-stage");
+  });
+
+  it("reconciles fixed controls from the selected recipe instead of the default", () => {
+    const profiled = profiledLtx2Model();
+    const selectedRecipe = profiled.generation_profile!.recipes[1]!;
+    selectedRecipe.defaults.steps = 12;
+    selectedRecipe.defaults.guidance = 2;
+    selectedRecipe.steps = {
+      ...selectedRecipe.steps,
+      mode: "fixed",
+      default: 12,
+      min: 12,
+      max: 12,
+    };
+    selectedRecipe.guidance = {
+      ...selectedRecipe.guidance,
+      mode: "fixed",
+      default: 2,
+      min: 2,
+      max: 2,
+    };
+    const form = newGenerateForm();
+    form.model = profiled.name;
+    form.family = profiled.family;
+    form.pipeline = "two-stage";
+    form.steps = 30;
+    form.guidance = 3.5;
+
+    reconcileModelCapabilities(form, profiled);
+
+    expect(form.steps).toBe(12);
+    expect(form.guidance).toBe(2);
+  });
 });
 
 function ltx2Form() {

--- a/desktop/src/lib/generateForm.ts
+++ b/desktop/src/lib/generateForm.ts
@@ -430,7 +430,13 @@ export function reconcileModelCapabilities(form: GenerateForm, m: ModelEntry): v
     // clear from here, so the deferred marker has served its purpose.
     form.negativeExplicitClear = false;
   }
-  const recipe = effectiveGenerationRecipe(m, null);
+  const recipe = effectiveGenerationRecipe(m, form.pipeline);
+  // A row refresh can resolve a persisted/template form against a newer
+  // authoritative recipe. Fixed controls are not user choices: normalize the
+  // hidden form value to the same value the disabled control displays, or the
+  // validator can strand Generate behind an error the user cannot correct.
+  if (recipe?.steps.mode === "fixed") form.steps = recipe.steps.default;
+  if (recipe?.guidance.mode === "fixed") form.guidance = recipe.guidance.default;
   const caps = generationCapabilitiesForFamily(
     m.family,
     m.name,

--- a/desktop/src/mobile/MobileApp.prompt.test.ts
+++ b/desktop/src/mobile/MobileApp.prompt.test.ts
@@ -17,10 +17,10 @@ describe("MobileApp prompt requirement", () => {
 
   it("uses that one gate for both the button and the pre-submit guard", () => {
     const occurrences = mobileAppSource.match(/promptMissing(\.value)?\b/g) ?? [];
-    // definition + the `:disabled` binding + the `generate()` guard
+    // definition + the shared Develop-disabled computation + the `generate()` guard
     expect(occurrences.length).toBeGreaterThanOrEqual(3);
     expect(mobileAppSource).toMatch(/promptMissing\.value \|\|\s*!selectedModelAvailable\.value/);
-    expect(mobileAppSource).toMatch(/promptMissing \|\|\s*!selectedModelAvailable/);
+    expect(mobileAppSource).toContain(':disabled="developDisabled"');
     // The bare check must not survive anywhere in the generation path; only
     // "Use as prompt" may still skip a print with no recorded prompt.
     expect(mobileAppSource).not.toContain("!form.prompt.trim() ||");

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -648,6 +648,34 @@ describe("MobileApp Output field", () => {
     expect(wrapper.find("[data-test='mobile-sequence-composer']").exists()).toBe(false);
   });
 
+  it("keeps the one-shot Develop action outside the scrolling form", async () => {
+    installModels([model, sequenceModel]);
+    wrapper = mountMobileApp();
+    await flushPromises();
+
+    const action = wrapper.get("[data-test='mobile-create-action']");
+    expect(action.find("[data-test='mobile-develop-button']").exists()).toBe(true);
+    expect(
+      wrapper.get(".mobile-content").find("[data-test='mobile-develop-button']").exists(),
+    ).toBe(false);
+
+    await outputSegment("Sequence").trigger("click");
+    await flushPromises();
+    expect(wrapper.find("[data-test='mobile-create-action']").exists()).toBe(false);
+  });
+
+  it("keeps a corrective explanation beside a disabled persistent Develop action", async () => {
+    installModels([]);
+    wrapper = mountMobileApp();
+    await flushPromises();
+
+    const action = wrapper.get("[data-test='mobile-create-action']");
+    expect(action.get("[data-test='mobile-develop-button']").attributes("disabled")).toBeDefined();
+    expect(action.get("[data-test='mobile-develop-blocker']").text()).toContain(
+      "Choose an installed model before generating.",
+    );
+  });
+
   it("migrates the legacy create-mode key into the shared draft and retires it", async () => {
     localStorage.setItem("mold.mobile.create-mode.v1", "sequence");
     installModels([model, sequenceModel]);
@@ -1367,6 +1395,11 @@ describe("MobileApp generation queue", () => {
     expect(stale.text()).not.toContain("cv:1759168");
     expect(stale.find("[data-test='mobile-reexpand-and-develop']").exists()).toBe(true);
     expect(stale.find("[data-test='mobile-develop-expanded-anyway']").exists()).toBe(true);
+    const action = wrapper.get("[data-test='mobile-create-action']");
+    expect(action.get("[data-test='mobile-develop-button']").attributes("disabled")).toBeDefined();
+    expect(action.get("[data-test='mobile-develop-blocker']").text()).toContain(
+      "Use a recovery action above.",
+    );
 
     await stale.get("[data-test='mobile-develop-expanded-anyway']").trigger("click");
     await flushPromises();

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -84,6 +84,7 @@ import type { ChainJobDetail, ChainLimits } from "@studio/lib/api/chainTypes";
 import SegmentedControl from "@ui/components/SegmentedControl.vue";
 import LiveActivityList from "@ui/components/LiveActivityList.vue";
 import ErrorNotice from "@ui/components/ErrorNotice.vue";
+import ActionBlocker from "@ui/components/ActionBlocker.vue";
 import { upscaleImage } from "../lib/api/upscale";
 import {
   generationCapabilitiesForFamily,
@@ -1089,6 +1090,28 @@ const mobileMediaBudgetError = computed(() => mobileMediaBudgetValidationError(f
 // host would accept. The placeholder carries the same news.
 const promptMissing = computed(() => promptRequired(form) && !form.prompt.trim());
 const promptFieldPlaceholder = computed(() => promptPlaceholder(form, "Describe the print…"));
+const developBlockerReason = computed<string | null>(() => {
+  // An empty prompt is self-evident beside the composer and does not warrant
+  // a persistent banner. Everything outside the visible composer names the
+  // exact correction beside the pinned action.
+  if (!selectedModelAvailable.value) return "Choose an installed model before generating.";
+  if (quickExpansionSnapshot.value && quickStaleReasons.value.length > 0) {
+    return "The prepared rewrite no longer matches these settings. Use a recovery action above.";
+  }
+  if (!seedValid.value) return "Enter a valid whole-number seed, or choose Random.";
+  if (!resolutionValid.value) return "Choose a supported size for this model.";
+  if (stepsError.value) return stepsError.value;
+  if (guidanceError.value) return guidanceError.value;
+  if (mobileMediaBudgetError.value) return mobileMediaBudgetError.value;
+  if (sourceConditioningError.value) return sourceConditioningError.value;
+  if (h3AuthoringError.value) return h3AuthoringError.value;
+  if (!sourceControlsValid.value) return "Open Advanced and correct the source image settings.";
+  if (!parameterValid.value) return "Open Advanced and correct the highlighted settings.";
+  return null;
+});
+const developDisabled = computed(
+  () => promptMissing.value || developBlockerReason.value !== null || preparingGeneration.value,
+);
 const estimateRequest = computed(() => {
   if (!form.model) return null;
   return buildGenerationEstimateRequest(buildRequest(form), form.family);
@@ -4970,31 +4993,6 @@ onBeforeUnmount(() => {
               @load="loadTemplate"
             />
 
-            <div class="mobile-estimate">
-              <EstimateBadge :request="estimateRequest" :target="selectedTarget" />
-            </div>
-            <button
-              v-if="!preparedBatch"
-              class="primary-button"
-              type="button"
-              :disabled="
-                promptMissing ||
-                !selectedModelAvailable ||
-                !seedValid ||
-                !parameterValid ||
-                !sourceControlsValid ||
-                !resolutionValid ||
-                !basicParametersValid ||
-                !!mobileMediaBudgetError ||
-                !!sourceConditioningError ||
-                !!h3AuthoringError ||
-                preparingGeneration
-              "
-              data-test="mobile-develop-button"
-              @click="generate"
-            >
-              {{ developButtonLabel }}
-            </button>
             <!-- Live develop bed: once the host streams latent previews the
                active print literally forms here — the preview's blur tightens
                with denoise progress while the Develop grain thins over it.
@@ -5496,6 +5494,31 @@ onBeforeUnmount(() => {
         />
       </KeepAlive>
     </section>
+
+    <div
+      v-if="!settingsOpen && tab === 'generate' && selectedHost && !isSequence && !preparedBatch"
+      class="mobile-create-action"
+      data-test="mobile-create-action"
+    >
+      <ActionBlocker
+        v-if="developBlockerReason"
+        :reason="developBlockerReason"
+        compact
+        data-test="mobile-develop-blocker"
+      />
+      <div class="mobile-estimate">
+        <EstimateBadge :request="estimateRequest" :target="selectedTarget" />
+      </div>
+      <button
+        class="primary-button"
+        type="button"
+        :disabled="developDisabled"
+        data-test="mobile-develop-button"
+        @click="generate"
+      >
+        {{ developButtonLabel }}
+      </button>
+    </div>
 
     <MobileGalleryViewer
       v-if="selectedPrint"

--- a/desktop/src/mobile/mobile.css
+++ b/desktop/src/mobile/mobile.css
@@ -46,7 +46,7 @@ button {
   box-sizing: border-box;
   overflow: hidden;
   display: grid;
-  grid-template-rows: auto minmax(0, 1fr) auto;
+  grid-template-rows: auto minmax(0, 1fr) auto auto;
   background: var(--bath);
   color: var(--rebate);
   padding-top: env(safe-area-inset-top);
@@ -2256,6 +2256,37 @@ button.mobile-generate-disclosure {
   min-height: 24px;
   margin: 4px 0 8px;
   color: var(--ink-3);
+}
+
+.mobile-create-action {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  padding: 8px max(16px, env(safe-area-inset-right)) 8px max(16px, env(safe-area-inset-left));
+  border-top: 1px solid var(--edge);
+  background: color-mix(in srgb, var(--bench) 96%, transparent);
+  box-shadow: 0 -10px 24px color-mix(in srgb, #000 12%, transparent);
+  -webkit-backdrop-filter: blur(16px);
+  backdrop-filter: blur(16px);
+}
+
+.mobile-create-action .mobile-estimate {
+  min-width: 0;
+  min-height: 0;
+  margin: 0;
+  overflow: hidden;
+}
+
+.mobile-create-action .ms-action-blocker {
+  grid-column: 1 / -1;
+}
+
+.mobile-create-action .primary-button {
+  width: auto;
+  min-width: 128px;
+  min-height: 48px;
+  padding-inline: 18px;
 }
 
 .mobile-surface .mask-editor-backdrop {

--- a/desktop/src/mobile/mobile.css.test.ts
+++ b/desktop/src/mobile/mobile.css.test.ts
@@ -58,6 +58,23 @@ describe("mobile scrolling", () => {
 });
 
 describe("mobile navigation", () => {
+  it("reserves a persistent row for the one-shot Develop action", () => {
+    const shell = css.match(/\.mobile-shell\s*\{([^}]*)\}/s);
+    const action = css.match(/\.mobile-create-action\s*\{([^}]*)\}/s);
+    const actionButton = css.match(/\.mobile-create-action \.primary-button\s*\{([^}]*)\}/s);
+
+    expect(shell?.[1]).toMatch(/grid-template-rows:\s*auto minmax\(0, 1fr\) auto auto\s*;/);
+    expect(action?.[1]).toMatch(/grid-template-columns:\s*minmax\(0, 1fr\) auto\s*;/);
+    expect(action?.[1]).toContain("env(safe-area-inset-left)");
+    expect(action?.[1]).toContain("env(safe-area-inset-right)");
+    expect(css).toMatch(
+      /\.mobile-create-action \.ms-action-blocker\s*\{[^}]*grid-column:\s*1 \/ -1/s,
+    );
+    expect(Number(actionButton?.[1]?.match(/min-height:\s*(\d+)px/)?.[1])).toBeGreaterThanOrEqual(
+      48,
+    );
+  });
+
   it("visually marks the tab exposed as the current page", () => {
     expect(css).toMatch(/\.mobile-tab\[aria-current="page"\]\s*\{/);
     expect(css).not.toMatch(/\.mobile-tab\[aria-selected="true"\]\s*\{/);


### PR DESCRIPTION
## Summary

- reconcile persisted LTX-2 steps and guidance with the selected authoritative fixed recipe
- keep the one-shot Develop action persistently visible above the iOS tab bar
- show the shared ActionBlocker beside disabled Develop for non-obvious corrective states, including stale prepared rewrites
- preserve the intentionally quiet empty-prompt state

## Root cause

The iOS control displayed the fixed recipe guidance while validation still read a stale persisted/template value. That disabled Develop behind a correction the user could not make. The action also lived below the long scrolling form, so it was easy to miss on LTX-2.

## Verification

- `cd desktop && bun run test` (3,377 passed)
- `cd desktop && bun run build:mobile`
- `./scripts/ios.sh simulator`
- installed and launched the signed bundle on iPhone 16 Pro Simulator
- agent peer review completed; all findings addressed; final pass had no actionable findings