### PR TITLE
fix(wan): hold chained renders to the checkpoint's own seam, recipe, and contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   architectures, Metal, and CPU execution unavailable until those runtimes are
   implemented and qualified.
 
+||||||| parent of 15146993 (docs(changelog): record the Wan chain correctness fixes)
+- **Fix chained Wan renders silently losing sixteen frames at every seam.** `--motion-tail` defaults to LTX-2's 17 for every family, and `17 % 4 == 1` sits on Wan's own `4k+1` grid — so a script-authored or repeated-`--prompt` Wan chain validated clean and then discarded sixteen good frames at each Smooth boundary, because the engine seeds a continuation from one frame while the stitch drops seventeen. Only the server normalized this; `mold run --script`, `mold chain validate`, `--dry-run`, and the multi-prompt sugar path now read the same `mold-core` authority, applied before validation so a short clip is not rejected for a seam that was never going to render.
+
+- **Fix `mold run <model> --prompt A --prompt B` rendering every family with LTX-2's recipe.** The multi-prompt sugar path accepts any model but hardcoded 1216x704, 24 fps, 8 steps, and guidance 3.0, so `wan22-t2v-a14b:q5` was encoded at 24 fps instead of its own 16 and denoised for 8 steps against a 4-step Lightning recipe, which renders noise. Geometry, timing, and the denoise recipe now come from the selected model, as they already did for a single shot.
+
+- **Fix Discord `/sequence` rejecting Wan's own clip defaults.** The command validated an `8n+1` grid with a minimum of 25, so 53 — the A14B routing default — was refused before submission while 81/97/121 passed only by coincidence. Grid, floor, cap, per-clip default, and the seam now come from the model's family and checkpoint. `/sequence` also stops offering image-required Wan I2V checkpoints it has no image input to seed.
+
+- **Fix installed `cv:` / `hf:` Wan checkpoints being refused from every chain path.** `normalise` classified models from the built-in manifest alone, so a catalog checkpoint fell back to the LTX `8k+1` grid and its 53-frame stages were rejected as off-grid. `POST /api/generate/chain/validate` separately read a different config than submission did, so Validate plan and the submit that followed disagreed about those same models.
+
+- **Fix a Wan I2V sequence being admitted with no opening image.** Chain admission never applied the per-checkpoint source-image contract, so an image-required checkpoint failed only after the text encode and both expert loads were paid for, and a text-to-video checkpoint accepted an opening image it has no channel for. Both are now refused at admission.
+
 - Fix private MiniMax H3 terminal publication to compare the MP4 container's
   frame duration with ceiling millisecond rounding, matching the retained
   124-frame, 24 fps mux result instead of rejecting it one millisecond early;

--- a/crates/mold-cli/src/commands/chain.rs
+++ b/crates/mold-cli/src/commands/chain.rs
@@ -1049,9 +1049,11 @@ pub async fn run_from_script(
     // otherwise be rejected for a seam that was never going to be applied,
     // and the dry-run totals below would describe a render that cannot happen.
     let mut built = build_request_from_script(&script)?;
-    let substitution = normalize_script_motion_tail(&mut built);
+    let authority =
+        resolve_chain_model_authority(&built.model, &mold_core::Config::load_or_default());
+    let substitution = normalize_script_motion_tail(&mut built, &authority);
     report_motion_tail_substitution(substitution, &built.model);
-    let req = built.normalise()?;
+    let req = built.normalise_with_family(authority.family_hint())?;
 
     if dry_run {
         print_dry_run_summary(&req);
@@ -1079,6 +1081,17 @@ pub async fn run_from_script(
         offload,
     )
     .await
+}
+
+/// Round a frame count down onto the family's own `step*k + offset` grid,
+/// never below the first renderable clip.
+fn snap_down_to_family_grid(frames: u32, family: &str) -> u32 {
+    let step = mold_core::validation::frame_step_for_family(family).unwrap_or(1);
+    let offset = mold_core::validation::frame_offset_for_family(family).unwrap_or(0);
+    if step == 0 || frames <= offset {
+        return frames;
+    }
+    offset + ((frames - offset) / step) * step
 }
 
 /// The generation recipe repeated `--prompt` renders a chain with.
@@ -1127,10 +1140,22 @@ pub(crate) fn sugar_recipe(model: &str, config: &mold_core::Config) -> SugarReci
         .and_then(|family| mold_core::validation::max_frames_for_family_at_fps(family, fps))
         .unwrap_or(LTX2_DEFAULT_CLIP_FRAMES);
 
-    // The clip default is the routing envelope, not the ceiling: wan's two
-    // -expert A14B measures near 24 GB well before its 257-frame cap.
+    // The clip default is the routing envelope, not the ceiling: wan's
+    // two-expert A14B measures near 24 GB well before its 257-frame cap.
+    //
+    // `wan_default_clip_frames` reads the tier name, which an opaque `cv:` /
+    // `hf:` ID does not carry — it would pick the 121-frame non-A14B floor
+    // for an installed A14B checkpoint and blow past the envelope its own
+    // sidecar records. Prefer the resolved default there, snapped onto the
+    // family's grid so the value stays submittable.
     let clip_frames = match family.as_deref() {
-        Some("wan") => wan_default_clip_frames(&resolved),
+        Some("wan") if mold_core::manifest::find_manifest(&resolved).is_some() => {
+            wan_default_clip_frames(&resolved)
+        }
+        Some("wan") => model_cfg
+            .effective_frames()
+            .map(|frames| snap_down_to_family_grid(frames, "wan"))
+            .unwrap_or_else(|| wan_default_clip_frames(&resolved)),
         _ => model_cfg
             .effective_frames()
             .unwrap_or(LTX2_DEFAULT_CLIP_FRAMES),
@@ -1166,21 +1191,20 @@ pub(crate) fn sugar_recipe(model: &str, config: &mold_core::Config) -> SugarReci
 /// applied, and a dry run would report frame totals for a seam that will not
 /// render.
 ///
-/// The contract comes from the manifest, which is what the CLI can resolve
-/// without the inference crate's header probe. An installed `cv:` / `hf:`
-/// checkpoint yields `None` — "unknown", which takes the conservative
-/// independent-clips path rather than assuming a handoff.
-pub(crate) fn normalize_script_motion_tail(req: &mut ChainRequest) -> Option<(u32, u32)> {
-    let resolved = mold_core::manifest::resolve_model_name(&req.model);
-    let manifest = mold_core::manifest::find_manifest(&resolved);
-    let family = manifest
-        .map(|model| model.family.to_string())
-        .unwrap_or_default();
-    let source_image = manifest.and_then(|model| model.defaults.source_image);
-
+/// The family and contract come from the same places the server reads them:
+/// the sidecar-derived `ModelConfig` an installed `cv:` / `hf:` checkpoint
+/// carries, then the checkpoint's own headers, then the manifest. A
+/// manifest-only lookup left every catalog wan checkpoint unclassified, which
+/// is not merely conservative — an unclassified family also means the LTX
+/// `8k+1` grid, so a valid 53-frame wan chain was rejected outright and a
+/// 97-frame one silently kept its 17-frame tail.
+pub(crate) fn normalize_script_motion_tail(
+    req: &mut ChainRequest,
+    authority: &ChainModelAuthority,
+) -> Option<(u32, u32)> {
     let applied = mold_core::validation::chain_motion_tail_frames_for_family(
-        &family,
-        source_image,
+        &authority.family,
+        authority.source_image,
         req.motion_tail_frames,
     );
     if applied == req.motion_tail_frames {
@@ -1189,6 +1213,64 @@ pub(crate) fn normalize_script_motion_tail(req: &mut ChainRequest) -> Option<(u3
     let original = req.motion_tail_frames;
     req.motion_tail_frames = applied;
     Some((original, applied))
+}
+
+/// What a chain needs to know about the selected checkpoint before it can
+/// validate or render: the family that owns the frame grid and per-clip cap,
+/// and the conditioning contract that decides the seam.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub(crate) struct ChainModelAuthority {
+    /// Empty when neither the config nor the manifest can classify the model.
+    pub family: String,
+    pub source_image: Option<mold_core::SourceImageCapability>,
+}
+
+impl ChainModelAuthority {
+    /// `None` when the model is unclassified, which callers pass through to
+    /// `normalise_with_family` as "no hint".
+    pub fn family_hint(&self) -> Option<&str> {
+        (!self.family.is_empty()).then_some(self.family.as_str())
+    }
+}
+
+/// Resolve the family and conditioning contract for a chain's model.
+///
+/// Mirrors the server's `resolve_chain_family` plus its wan header probe, so
+/// a forced-local render and an HTTP submission classify the same checkpoint
+/// the same way.
+pub(crate) fn resolve_chain_model_authority(
+    model: &str,
+    config: &mold_core::Config,
+) -> ChainModelAuthority {
+    let resolved = mold_core::manifest::resolve_model_name(model);
+    let manifest = mold_core::manifest::find_manifest(&resolved);
+    // The installed sidecar's config wins: it is what an opaque catalog ID
+    // resolves to, and the manifest cannot classify one at all.
+    let family = config
+        .resolved_model_config(model)
+        .family
+        .clone()
+        .or_else(|| manifest.map(|model| model.family.to_string()))
+        .unwrap_or_default();
+
+    let manifest_contract = manifest.and_then(|model| model.defaults.source_image);
+    // Wan's contract is a property of the weights, so read the headers of the
+    // artifacts that will actually load; path overrides can point one manifest
+    // name at a different checkpoint.
+    let source_image = if family == "wan" {
+        mold_core::ModelPaths::resolve(model, config)
+            .and_then(|paths| {
+                mold_inference::wan_source_image_capability(&paths.transformer, &paths.vae)
+            })
+            .or(manifest_contract)
+    } else {
+        manifest_contract
+    };
+
+    ChainModelAuthority {
+        family,
+        source_image,
+    }
 }
 
 /// Tell the user which seam actually rendered. A substituted tail changes the
@@ -1351,9 +1433,10 @@ pub async fn run_from_sugar(
     // honour. Resolve it before `normalise()` for the same reason the
     // script path does (#783).
     let mut built = req;
-    let substitution = normalize_script_motion_tail(&mut built);
+    let authority = resolve_chain_model_authority(&built.model, &config);
+    let substitution = normalize_script_motion_tail(&mut built, &authority);
     report_motion_tail_substitution(substitution, &built.model);
-    let req = built.normalise()?;
+    let req = built.normalise_with_family(authority.family_hint())?;
 
     if dry_run {
         print_dry_run_summary(&req);
@@ -1429,9 +1512,13 @@ mod tests {
             ..empty_chain_request()
         };
 
+        let config = mold_core::Config::default();
+        let authority_for = |model: &str| resolve_chain_model_authority(model, &config);
+
         // TI2V-5B is `Optional` — it can be seeded, so the seam is one frame.
         let mut ti2v = wan_script_request("wan22-ti2v-5b:q8", 17);
-        let substitution = normalize_script_motion_tail(&mut ti2v);
+        let substitution =
+            normalize_script_motion_tail(&mut ti2v, &authority_for("wan22-ti2v-5b:q8"));
         assert_eq!(
             ti2v.motion_tail_frames,
             mold_core::validation::WAN_HANDOFF_DUPLICATED_FRAMES,
@@ -1448,12 +1535,18 @@ mod tests {
         // A text-to-video checkpoint has no channel to be seeded through, so
         // its Smooth boundaries concatenate.
         let mut t2v = wan_script_request("wan21-t2v-1.3b:bf16", 17);
-        assert_eq!(normalize_script_motion_tail(&mut t2v), Some((17, 0)));
+        assert_eq!(
+            normalize_script_motion_tail(&mut t2v, &authority_for("wan21-t2v-1.3b:bf16")),
+            Some((17, 0))
+        );
         assert_eq!(t2v.motion_tail_frames, 0);
 
         // An already-correct script is left alone and reports nothing.
         let mut correct = wan_script_request("wan22-ti2v-5b:q8", 1);
-        assert_eq!(normalize_script_motion_tail(&mut correct), None);
+        assert_eq!(
+            normalize_script_motion_tail(&mut correct, &authority_for("wan22-ti2v-5b:q8")),
+            None
+        );
         assert_eq!(correct.motion_tail_frames, 1);
 
         // LTX-2's tail is a real latent window; the script still owns it.
@@ -1469,7 +1562,10 @@ mod tests {
             fps: 24,
             ..empty_chain_request()
         };
-        assert_eq!(normalize_script_motion_tail(&mut ltx2), None);
+        assert_eq!(
+            normalize_script_motion_tail(&mut ltx2, &authority_for("ltx-2-19b-distilled:fp8")),
+            None
+        );
         assert_eq!(ltx2.motion_tail_frames, 17);
     }
 
@@ -1587,6 +1683,81 @@ mod tests {
             source_image: None,
             enable_audio: None,
         }
+    }
+
+    /// An installed `cv:` / `hf:` wan checkpoint is classified from its
+    /// sidecar, not its name (#783).
+    ///
+    /// `find_manifest` cannot classify a catalog id, so a manifest-only
+    /// lookup left the family empty — and an empty family is not merely
+    /// "unknown", it is the LTX `8k+1` grid and a preserved 17-frame tail.
+    /// A valid 53-frame wan chain was rejected outright, and a 97-frame one
+    /// (which also clears `8k+1`) kept a seam that discards sixteen frames.
+    /// The tier name is likewise absent, so the routing default cannot be
+    /// sniffed from it either.
+    #[test]
+    fn an_opaque_catalog_wan_model_is_classified_from_its_sidecar() {
+        let mut config = mold_core::Config::default();
+        config.models.insert(
+            "cv:2041121".to_string(),
+            mold_core::ModelConfig {
+                family: Some("wan".to_string()),
+                default_frames: Some(81),
+                default_fps: Some(16),
+                default_width: Some(832),
+                default_height: Some(480),
+                ..Default::default()
+            },
+        );
+
+        // The family now comes from the sidecar, so wan's grid applies.
+        let authority = resolve_chain_model_authority("cv:2041121", &config);
+        assert_eq!(authority.family, "wan");
+        assert_eq!(authority.family_hint(), Some("wan"));
+
+        // A 53-frame chain is on wan's grid and must survive normalisation.
+        let mut req = ChainRequest {
+            model: "cv:2041121".into(),
+            stages: vec![
+                stage_with_frames("a paper boat", 53),
+                stage_with_frames("it reaches the drain", 53),
+            ],
+            motion_tail_frames: 17,
+            width: 832,
+            height: 480,
+            fps: 16,
+            ..empty_chain_request()
+        };
+        normalize_script_motion_tail(&mut req, &authority);
+        assert!(
+            req.normalise_with_family(authority.family_hint()).is_ok(),
+            "53 is 4k+1; the LTX fallback grid rejected it"
+        );
+
+        // Its routing default comes from the sidecar rather than the
+        // 121-frame non-A14B floor the tier name would have selected.
+        let recipe = sugar_recipe("cv:2041121", &config);
+        assert_eq!(recipe.family.as_deref(), Some("wan"));
+        assert_eq!(recipe.fps, 16);
+        assert_eq!(
+            recipe.clip_frames, 81,
+            "the sidecar records this checkpoint's measured envelope"
+        );
+        assert_eq!(
+            (recipe.clip_frames - 1) % mold_core::validation::WAN_TEMPORAL_SCALE,
+            0
+        );
+    }
+
+    /// An off-grid recorded default is snapped down, never submitted as-is.
+    #[test]
+    fn a_catalog_default_off_the_family_grid_snaps_down() {
+        assert_eq!(snap_down_to_family_grid(80, "wan"), 77);
+        assert_eq!(snap_down_to_family_grid(81, "wan"), 81);
+        assert_eq!(snap_down_to_family_grid(97, "ltx2"), 97);
+        assert_eq!(snap_down_to_family_grid(96, "ltx2"), 89);
+        // Never below the first renderable clip.
+        assert_eq!(snap_down_to_family_grid(1, "wan"), 1);
     }
 
     fn stage_with_frames(prompt: &str, frames: u32) -> mold_core::chain::ChainStage {

--- a/crates/mold-cli/src/commands/chain.rs
+++ b/crates/mold-cli/src/commands/chain.rs
@@ -670,7 +670,8 @@ async fn run_chain_local(
         let renderer = engine.as_chain_renderer().ok_or_else(|| {
             anyhow::anyhow!(
                 "model '{}' does not support chained video generation \
-                 (only LTX-2 distilled engines expose a ChainStageRenderer view)",
+                 (LTX-2, LTX-Video, and Wan Video engines expose a \
+                 ChainStageRenderer view)",
                 req_clone.model,
             )
         })?;
@@ -1044,7 +1045,13 @@ pub async fn run_from_script(
     let script = mold_core::chain_toml::read_script_resolving_paths(&toml_src, script_dir)
         .map_err(|e| anyhow::anyhow!("invalid chain TOML in {}: {e}", path.display()))?;
 
-    let req = build_request_from_script(&script)?.normalise()?;
+    // Before `normalise()`: a stage shorter than the requested tail would
+    // otherwise be rejected for a seam that was never going to be applied,
+    // and the dry-run totals below would describe a render that cannot happen.
+    let mut built = build_request_from_script(&script)?;
+    let substitution = normalize_script_motion_tail(&mut built);
+    report_motion_tail_substitution(substitution, &built.model);
+    let req = built.normalise()?;
 
     if dry_run {
         print_dry_run_summary(&req);
@@ -1072,6 +1079,129 @@ pub async fn run_from_script(
         offload,
     )
     .await
+}
+
+/// The generation recipe repeated `--prompt` renders a chain with.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct SugarRecipe {
+    pub width: u32,
+    pub height: u32,
+    pub fps: u32,
+    pub steps: u32,
+    pub guidance: f64,
+    /// Default frames per clip, on the family's own grid.
+    pub clip_frames: u32,
+    /// Per-clip ceiling an explicit `--frames-per-clip` is clamped to.
+    pub clip_cap: u32,
+    /// Family the cap and grid were resolved from, for the clamp warning.
+    pub family: Option<String>,
+}
+
+/// Resolve the multi-prompt sugar recipe from the model's own configuration.
+///
+/// This path accepts any known model — `main.rs` gates only MiniMax H3 — but
+/// used to hardcode LTX-2's 1216x704, 24 fps, 8 steps, guidance 3.0, a
+/// 97-frame clip default, and a cap resolved against a literal `"ltx2"`. Those
+/// values reach the engine unchanged through the orchestrator's
+/// `build_stage_generate_request`, so `wan22-t2v-a14b:q5` was encoded at 24
+/// fps rather than its own 16 and denoised for 8 steps against a 4-step
+/// Lightning recipe, which renders noise (#783).
+///
+/// `resolved_model_config` is the same authority the single-shot `run` path
+/// uses, so config overrides and manifest defaults layer identically. A model
+/// neither can classify keeps the historical LTX-2 shape rather than an
+/// invented one.
+pub(crate) fn sugar_recipe(model: &str, config: &mold_core::Config) -> SugarRecipe {
+    let resolved = mold_core::manifest::resolve_model_name(model);
+    let model_cfg = config.resolved_model_config(&resolved);
+    let family = crate::commands::generate::resolve_family(&resolved, config);
+
+    let fps = model_cfg
+        .effective_fps()
+        .unwrap_or(mold_core::validation::LTX2_DEFAULT_FPS);
+
+    // The cap is a per-clip ceiling, so it is resolved at the fps this chain
+    // will actually render at — LTX-2's budget is a runtime, not a count.
+    let clip_cap = family
+        .as_deref()
+        .and_then(|family| mold_core::validation::max_frames_for_family_at_fps(family, fps))
+        .unwrap_or(LTX2_DEFAULT_CLIP_FRAMES);
+
+    // The clip default is the routing envelope, not the ceiling: wan's two
+    // -expert A14B measures near 24 GB well before its 257-frame cap.
+    let clip_frames = match family.as_deref() {
+        Some("wan") => wan_default_clip_frames(&resolved),
+        _ => model_cfg
+            .effective_frames()
+            .unwrap_or(LTX2_DEFAULT_CLIP_FRAMES),
+    }
+    .min(clip_cap);
+
+    SugarRecipe {
+        width: model_cfg.effective_width(config),
+        height: model_cfg.effective_height(config),
+        fps,
+        steps: model_cfg.effective_steps(config),
+        guidance: model_cfg.effective_guidance(),
+        clip_frames,
+        clip_cap,
+        family,
+    }
+}
+
+/// Replace a script-authored motion tail with the one the family and the
+/// selected checkpoint can actually honour, returning `(original, applied)`
+/// when a substitution was made.
+///
+/// The server has done this since #936 (`routes_chain::validate_and_normalize_
+/// chain_family`); the CLI never did, so a forced-local `--script` run,
+/// `mold chain validate`, and `--dry-run` all carried the caller's value into
+/// the stitcher. `17 % 4 == 1`, so LTX-2's default clears wan's own `4k+1`
+/// grid check and then discards sixteen good frames at every Smooth seam —
+/// the engine seeds the continuation from one frame while the stitch drops
+/// seventeen. Both surfaces now read one authority in `mold-core`.
+///
+/// This runs **before** `normalise()`: a wan stage shorter than the requested
+/// tail would otherwise be rejected for a tail that was never going to be
+/// applied, and a dry run would report frame totals for a seam that will not
+/// render.
+///
+/// The contract comes from the manifest, which is what the CLI can resolve
+/// without the inference crate's header probe. An installed `cv:` / `hf:`
+/// checkpoint yields `None` — "unknown", which takes the conservative
+/// independent-clips path rather than assuming a handoff.
+pub(crate) fn normalize_script_motion_tail(req: &mut ChainRequest) -> Option<(u32, u32)> {
+    let resolved = mold_core::manifest::resolve_model_name(&req.model);
+    let manifest = mold_core::manifest::find_manifest(&resolved);
+    let family = manifest
+        .map(|model| model.family.to_string())
+        .unwrap_or_default();
+    let source_image = manifest.and_then(|model| model.defaults.source_image);
+
+    let applied = mold_core::validation::chain_motion_tail_frames_for_family(
+        &family,
+        source_image,
+        req.motion_tail_frames,
+    );
+    if applied == req.motion_tail_frames {
+        return None;
+    }
+    let original = req.motion_tail_frames;
+    req.motion_tail_frames = applied;
+    Some((original, applied))
+}
+
+/// Tell the user which seam actually rendered. A substituted tail changes the
+/// stitched length, so it is disclosed rather than applied silently.
+fn report_motion_tail_substitution(substitution: Option<(u32, u32)>, model: &str) {
+    if let Some((original, applied)) = substitution {
+        status!(
+            "{} {model} carries {} frame(s) across a seam, not {original}; using --motion-tail {}",
+            theme::prefix_warning(),
+            applied,
+            applied,
+        );
+    }
 }
 
 /// Build a canonical `ChainRequest` from the parsed TOML script.
@@ -1150,25 +1280,25 @@ pub async fn run_from_sugar(
     };
     let model = resolve_model_name(&model_raw);
 
-    // Default to the routing clip size, but let an explicit --frames-per-clip
-    // go up to the model's real single-request budget. The sugar path always
-    // renders at the default fps (see `fps` below), so resolve the cap there.
-    let sugar_fps = mold_core::validation::LTX2_DEFAULT_FPS;
-    let clip_cap = mold_core::validation::max_frames_for_family_at_fps("ltx2", sugar_fps)
-        .unwrap_or(LTX2_DEFAULT_CLIP_FRAMES);
+    // Every dimension of the render is the selected model's own, resolved
+    // through the same `resolved_model_config` the single-shot path uses.
+    // Hardcoding LTX-2's here encoded wan A14B at 24 fps instead of 16 and
+    // denoised it for 8 steps against a 4-step recipe (#783).
+    let recipe = sugar_recipe(&model, &config);
     let clip_frames = frames_per_clip
-        .unwrap_or(LTX2_DEFAULT_CLIP_FRAMES)
-        .min(clip_cap);
+        .unwrap_or(recipe.clip_frames)
+        .min(recipe.clip_cap);
     if let Some(requested) = frames_per_clip {
-        if requested > clip_cap {
+        if requested > recipe.clip_cap {
             crate::output::status!(
-                "{} --frames-per-clip {} exceeds the LTX-2 per-clip budget of {} frames \
-                 ({}s at {sugar_fps} fps), clamping to {}",
+                "{} --frames-per-clip {} exceeds the per-clip budget for '{}' at {} fps \
+                 ({} frames), clamping to {}",
                 theme::prefix_warning(),
                 requested,
-                clip_cap,
-                mold_core::validation::LTX2_MAX_RUNTIME_SECONDS,
-                clip_cap,
+                recipe.family.as_deref().unwrap_or("this model"),
+                recipe.fps,
+                recipe.clip_cap,
+                recipe.clip_cap,
             );
         }
     }
@@ -1190,17 +1320,17 @@ pub async fn run_from_sugar(
         })
         .collect();
 
-    // LTX-2 19B/22B distilled defaults: 1216×704, 24 fps, 8 steps, 3.0 guidance.
+    // Geometry, timing, and the denoise recipe all come from the model.
     let req = ChainRequest {
         model: model.clone(),
         stages,
         motion_tail_frames: motion_tail,
-        width: 1216,
-        height: 704,
-        fps: 24,
+        width: recipe.width,
+        height: recipe.height,
+        fps: recipe.fps,
         seed: None,
-        steps: 8,
-        guidance: 3.0,
+        steps: recipe.steps,
+        guidance: recipe.guidance,
         strength: 1.0,
         output_format: OutputFormat::Mp4,
         placement: None,
@@ -1214,8 +1344,16 @@ pub async fn run_from_sugar(
         clip_frames: None,
         source_image: None,
         enable_audio,
-    }
-    .normalise()?;
+    };
+
+    // `--motion-tail` defaults to LTX-2's 17 for every family, so repeated
+    // `--prompt` on a wan model inherited a seam its checkpoint cannot
+    // honour. Resolve it before `normalise()` for the same reason the
+    // script path does (#783).
+    let mut built = req;
+    let substitution = normalize_script_motion_tail(&mut built);
+    report_motion_tail_substitution(substitution, &built.model);
+    let req = built.normalise()?;
 
     if dry_run {
         print_dry_run_summary(&req);
@@ -1266,6 +1404,205 @@ fn print_dry_run_summary(req: &ChainRequest) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A script-authored wan chain renders with the checkpoint's seam, not
+    /// the caller's (#783).
+    ///
+    /// The server has normalized this since #936; the CLI never did. A wan
+    /// TOML carrying LTX-2's 17 passes `normalise()` clean — `17 % 4 == 1`
+    /// sits on wan's own `4k+1` grid — and then the Smooth stitch drops all
+    /// seventeen incoming frames while the engine seeded the continuation
+    /// from one. Sixteen good frames vanish per seam, with correct-looking
+    /// validation output. This is the regression test for that.
+    #[test]
+    fn a_script_authored_wan_chain_takes_the_checkpoints_seam() {
+        let wan_script_request = |model: &str, tail: u32| ChainRequest {
+            model: model.to_string(),
+            stages: vec![
+                stage_with_frames("a paper boat drifting down a rain gutter", 49),
+                stage_with_frames("the boat reaches a storm drain", 49),
+            ],
+            motion_tail_frames: tail,
+            width: 704,
+            height: 384,
+            fps: 24,
+            ..empty_chain_request()
+        };
+
+        // TI2V-5B is `Optional` — it can be seeded, so the seam is one frame.
+        let mut ti2v = wan_script_request("wan22-ti2v-5b:q8", 17);
+        let substitution = normalize_script_motion_tail(&mut ti2v);
+        assert_eq!(
+            ti2v.motion_tail_frames,
+            mold_core::validation::WAN_HANDOFF_DUPLICATED_FRAMES,
+            "wan re-renders exactly the frame it was seeded with"
+        );
+        assert_eq!(
+            substitution,
+            Some((17, 1)),
+            "a substituted seam must be reported, never applied silently"
+        );
+        // And it still normalises — the value we wrote is on wan's grid.
+        assert!(ti2v.normalise().is_ok());
+
+        // A text-to-video checkpoint has no channel to be seeded through, so
+        // its Smooth boundaries concatenate.
+        let mut t2v = wan_script_request("wan21-t2v-1.3b:bf16", 17);
+        assert_eq!(normalize_script_motion_tail(&mut t2v), Some((17, 0)));
+        assert_eq!(t2v.motion_tail_frames, 0);
+
+        // An already-correct script is left alone and reports nothing.
+        let mut correct = wan_script_request("wan22-ti2v-5b:q8", 1);
+        assert_eq!(normalize_script_motion_tail(&mut correct), None);
+        assert_eq!(correct.motion_tail_frames, 1);
+
+        // LTX-2's tail is a real latent window; the script still owns it.
+        let mut ltx2 = ChainRequest {
+            model: "ltx-2-19b-distilled:fp8".to_string(),
+            stages: vec![
+                stage_with_frames("a drone shot over pine forest", 97),
+                stage_with_frames("the trees give way to a lake", 97),
+            ],
+            motion_tail_frames: 17,
+            width: 1216,
+            height: 704,
+            fps: 24,
+            ..empty_chain_request()
+        };
+        assert_eq!(normalize_script_motion_tail(&mut ltx2), None);
+        assert_eq!(ltx2.motion_tail_frames, 17);
+    }
+
+    /// Repeated `--prompt` renders with the selected model's own recipe, not
+    /// LTX-2's (#783).
+    ///
+    /// `run_from_sugar` accepts any known model — `main.rs` gates only
+    /// MiniMax H3 — and then hardcoded 1216x704, 24 fps, 8 steps, guidance
+    /// 3.0, a 97-frame clip default, and a cap resolved against a literal
+    /// `"ltx2"`. Those values reach wan unchanged through the orchestrator's
+    /// `build_stage_generate_request`, so `wan22-t2v-a14b:q5` was encoded at
+    /// 24 fps instead of its own 16 — 1.5x fast playback — and denoised for 8
+    /// steps against a 4-step Lightning recipe, which renders noise.
+    #[test]
+    fn multi_prompt_sugar_uses_the_selected_models_own_recipe() {
+        let config = mold_core::Config::default();
+
+        // A14B Lightning: its own geometry, 16 fps, and a 4-step recipe.
+        let a14b = sugar_recipe("wan22-t2v-a14b:q5", &config);
+        assert_eq!(
+            (a14b.width, a14b.height, a14b.fps, a14b.steps, a14b.guidance),
+            (832, 480, 16, 4, 1.0),
+            "sugar sent 1216x704 / 24 fps / 8 steps / 3.0 for this checkpoint"
+        );
+        // The Quality tier is the same checkpoint family on a different
+        // recipe, which is exactly why one hardcoded tuple cannot serve both.
+        let a14b_q8 = sugar_recipe("wan22-t2v-a14b:q8", &config);
+        assert_eq!(
+            (a14b_q8.fps, a14b_q8.steps, a14b_q8.guidance),
+            (16, 20, 3.5)
+        );
+
+        assert_eq!(
+            (a14b.clip_frames - 1) % mold_core::validation::WAN_TEMPORAL_SCALE,
+            0,
+            "the clip default must sit on wan's own 4k+1 grid"
+        );
+        assert!(
+            a14b.clip_frames <= a14b.clip_cap,
+            "clip default {} exceeds the resolved cap {}",
+            a14b.clip_frames,
+            a14b.clip_cap
+        );
+        assert_eq!(
+            a14b.clip_cap,
+            mold_core::validation::max_frames_for_family_at_fps("wan", 16).unwrap(),
+            "the cap is wan's flat request ceiling, not LTX-2's runtime budget"
+        );
+        // The routing envelope, matching what `decide_chain_routing` picks so
+        // sugar and auto-chain cannot disagree about the same model.
+        assert_eq!(
+            a14b.clip_frames,
+            wan_default_clip_frames("wan22-t2v-a14b:q5")
+        );
+
+        // TI2V-5B is 24 fps, but for its own reason, and 1280x704.
+        let ti2v = sugar_recipe("wan22-ti2v-5b:q8", &config);
+        assert_eq!(
+            (ti2v.width, ti2v.height, ti2v.fps, ti2v.steps, ti2v.guidance),
+            (1280, 704, 24, 20, 5.0)
+        );
+        assert_eq!(
+            (ti2v.clip_frames - 1) % mold_core::validation::WAN_TEMPORAL_SCALE,
+            0
+        );
+
+        // LTX-2 keeps exactly what it had, so nothing regresses for it.
+        let ltx2 = sugar_recipe("ltx-2-19b-distilled:fp8", &config);
+        assert_eq!(ltx2.fps, 24);
+        assert_eq!(ltx2.steps, 8);
+        assert_eq!(ltx2.width, 1216);
+        assert_eq!(ltx2.height, 704);
+        assert_eq!(ltx2.clip_frames, LTX2_DEFAULT_CLIP_FRAMES);
+        assert_eq!(
+            ltx2.clip_cap,
+            mold_core::validation::max_frames_for_family_at_fps(
+                "ltx2",
+                mold_core::validation::LTX2_DEFAULT_FPS
+            )
+            .unwrap()
+        );
+
+        // An unresolvable model keeps the historical LTX-2 shape rather than
+        // inventing one.
+        let unknown = sugar_recipe("cv:2041121", &config);
+        assert_eq!(unknown.fps, 24);
+        assert_eq!(unknown.clip_frames, LTX2_DEFAULT_CLIP_FRAMES);
+    }
+
+    /// Everything a `ChainRequest` needs that these tests do not care about.
+    /// `model`, `stages`, `motion_tail_frames`, `width`, `height`, and `fps`
+    /// are always spelled out at the call site.
+    fn empty_chain_request() -> ChainRequest {
+        ChainRequest {
+            model: String::new(),
+            stages: vec![],
+            motion_tail_frames: 0,
+            width: 0,
+            height: 0,
+            fps: 24,
+            seed: None,
+            steps: 8,
+            guidance: 3.0,
+            strength: 1.0,
+            output_format: mold_core::OutputFormat::Mp4,
+            placement: None,
+            original_prompt: None,
+            prompt_transform: None,
+            batch_id: None,
+            batch_index: None,
+            batch_count: None,
+            prompt: None,
+            total_frames: None,
+            clip_frames: None,
+            source_image: None,
+            enable_audio: None,
+        }
+    }
+
+    fn stage_with_frames(prompt: &str, frames: u32) -> mold_core::chain::ChainStage {
+        mold_core::chain::ChainStage {
+            prompt: prompt.to_string(),
+            frames,
+            source_image: None,
+            negative_prompt: None,
+            seed_offset: None,
+            transition: mold_core::chain::TransitionMode::Smooth,
+            fade_frames: None,
+            model: None,
+            loras: vec![],
+            references: vec![],
+        }
+    }
 
     /// Wan auto-chains instead of being rejected, on its own grid and with a
     /// seam its checkpoint can actually honour (#783).

--- a/crates/mold-cli/src/commands/chain_validate.rs
+++ b/crates/mold-cli/src/commands/chain_validate.rs
@@ -17,10 +17,12 @@ pub async fn run(path: &Path) -> Result<()> {
     // TOML asked for. Wan carries one frame across a seam, or none on a
     // text-to-video checkpoint — never LTX-2's 17, which sits on wan's own
     // `4k+1` grid and so would otherwise validate clean (#783).
+    let config = mold_core::Config::load_or_default();
     let mut built = super::chain::build_request_from_script(&script)?;
-    let substitution = super::chain::normalize_script_motion_tail(&mut built);
+    let authority = super::chain::resolve_chain_model_authority(&built.model, &config);
+    let substitution = super::chain::normalize_script_motion_tail(&mut built, &authority);
     let model = built.model.clone();
-    let req = built.normalise()?;
+    let req = built.normalise_with_family(authority.family_hint())?;
     if let Some((original, applied)) = substitution {
         println!(
             "note: {model} carries {applied} frame(s) across a seam, not {original}; \

--- a/crates/mold-cli/src/commands/chain_validate.rs
+++ b/crates/mold-cli/src/commands/chain_validate.rs
@@ -12,7 +12,21 @@ pub async fn run(path: &Path) -> Result<()> {
     let script_dir = path.parent().unwrap_or_else(|| Path::new("."));
     let script = mold_core::chain_toml::read_script_resolving_paths(&toml_src, script_dir)
         .map_err(|e| anyhow::anyhow!("invalid chain TOML in {}: {e}", path.display()))?;
-    let req = super::chain::build_request_from_script(&script)?.normalise()?;
+    // The seam a family can honour is resolved before `normalise()`, so this
+    // reports the chain that will actually render rather than the one the
+    // TOML asked for. Wan carries one frame across a seam, or none on a
+    // text-to-video checkpoint — never LTX-2's 17, which sits on wan's own
+    // `4k+1` grid and so would otherwise validate clean (#783).
+    let mut built = super::chain::build_request_from_script(&script)?;
+    let substitution = super::chain::normalize_script_motion_tail(&mut built);
+    let model = built.model.clone();
+    let req = built.normalise()?;
+    if let Some((original, applied)) = substitution {
+        println!(
+            "note: {model} carries {applied} frame(s) across a seam, not {original}; \
+             validated with motion_tail_frames = {applied}"
+        );
+    }
     println!(
         "OK — {} stages, {} frames estimated",
         req.stages.len(),

--- a/crates/mold-cli/src/commands/generate.rs
+++ b/crates/mold-cli/src/commands/generate.rs
@@ -90,7 +90,7 @@ fn qwen_image_edit_dimensions(bytes: &[u8]) -> Result<(u32, u32)> {
     Ok((width, height))
 }
 
-fn resolve_family(model: &str, config: &Config) -> Option<String> {
+pub(crate) fn resolve_family(model: &str, config: &Config) -> Option<String> {
     config
         .resolved_model_config(model)
         .family

--- a/crates/mold-core/src/chain.rs
+++ b/crates/mold-core/src/chain.rs
@@ -745,14 +745,31 @@ impl ChainRequest {
     /// - Each stage's `frames` is `8k+1` and `> 0`.
     /// - `self.stages.len() <= MAX_CHAIN_STAGES`.
     /// - All auto-expand fields are `None` (caller must use `self.stages`).
-    pub fn normalise(mut self) -> Result<Self> {
+    pub fn normalise(self) -> Result<Self> {
+        self.normalise_with_family(None)
+    }
+
+    /// [`normalise`](Self::normalise) with the family already resolved.
+    ///
+    /// The manifest cannot classify an installed `cv:` / `hf:` id, so a
+    /// manifest-only lookup fell back to the LTX `8k+1` grid and rejected a
+    /// 53-frame wan stage as "this family requires 8k+1" — immediately after
+    /// the server had resolved it as wan from the sidecar overlay (#783).
+    /// Callers holding a resolved family pass it; `None` keeps the historical
+    /// manifest-only behaviour for callers that do not.
+    pub fn normalise_with_family(mut self, family_hint: Option<&str>) -> Result<Self> {
         // Resolve the family from the manifest rather than passing `None`.
         // With a family-aware ceiling and grid, a `None` check is not merely
         // loose — it is a different answer: it would reject a 1920x1088 LTX-2
         // sequence the HTTP path admits, and accept a 16-aligned size the
-        // LTX-2 VAE's /32 grid cannot render. `None` remains correct for an
-        // opaque catalog ID with no manifest, exactly as before.
-        let family = crate::manifest::find_manifest(&self.model).map(|m| m.family.clone());
+        // LTX-2 VAE's /32 grid cannot render.
+        let family = crate::manifest::find_manifest(&self.model)
+            .map(|m| m.family.clone())
+            .or_else(|| {
+                family_hint
+                    .filter(|hint| !hint.is_empty())
+                    .map(str::to_string)
+            });
         // A sequence clip is one generation, so it is bound by exactly the
         // same ceiling — including the composed one. Resolving the
         // composition from the model keeps a 4K sequence admissible wherever a
@@ -1074,6 +1091,74 @@ fn build_auto_expand_stages(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// An installed catalog wan checkpoint normalises on wan's grid (#783).
+    ///
+    /// `normalise` resolved the family from the built-in manifest alone, and
+    /// `find_manifest` cannot classify a `cv:` / `hf:` id — so the grid fell
+    /// back to `8k+1` and a 53-frame wan stage was rejected with "this family
+    /// requires 8k+1", immediately after the server had correctly resolved it
+    /// as wan from the sidecar overlay. Catalog-installed checkpoints are
+    /// exactly the models the sequence work targets.
+    #[test]
+    fn an_installed_catalog_wan_checkpoint_normalises_on_wans_grid() {
+        let installed_wan = || ChainRequest {
+            model: "cv:2041121".into(),
+            stages: vec![
+                wan_stage("a paper boat drifting down a rain gutter", 53),
+                wan_stage("the boat reaches a storm drain", 53),
+            ],
+            motion_tail_frames: 1,
+            width: 832,
+            height: 480,
+            fps: 16,
+            ..auto_expand_request("unused", 106, 53, 1, None)
+        };
+
+        // Without the hint the id is opaque and the LTX grid rejects it —
+        // this is the defect, kept explicit so the fix cannot silently lapse.
+        let unhinted = installed_wan().normalise();
+        assert!(
+            unhinted.is_err(),
+            "a `cv:` id has no manifest, so an unhinted normalise still cannot know the grid"
+        );
+
+        // The server and CLI both resolve the family before calling, so the
+        // hint is what they actually have in hand.
+        let normalised = installed_wan()
+            .normalise_with_family(Some("wan"))
+            .expect("53 is 4k+1, which is wan's own grid");
+        assert_eq!(normalised.stages.len(), 2);
+        assert!(normalised.stages.iter().all(|stage| stage.frames == 53));
+        assert_eq!(normalised.motion_tail_frames, 1);
+
+        // Wan's grid is still enforced, just wan's and not LTX-2's.
+        let off_grid = ChainRequest {
+            stages: vec![wan_stage("one", 50), wan_stage("two", 50)],
+            ..installed_wan()
+        };
+        let error = off_grid.normalise_with_family(Some("wan")).unwrap_err();
+        assert!(error.to_string().contains("4k+1"), "got: {error}");
+
+        // An explicit hint never overrides a model the manifest does know.
+        let ltx2 = auto_expand_request("a drone shot", 194, 97, 17, None);
+        assert!(ltx2.normalise_with_family(Some("ltx2")).is_ok());
+    }
+
+    fn wan_stage(prompt: &str, frames: u32) -> ChainStage {
+        ChainStage {
+            prompt: prompt.into(),
+            frames,
+            source_image: None,
+            negative_prompt: None,
+            seed_offset: None,
+            transition: TransitionMode::Smooth,
+            fade_frames: None,
+            model: None,
+            loras: Vec::new(),
+            references: Vec::new(),
+        }
+    }
 
     /// Build a minimal auto-expand request with the given knobs. All other
     /// fields use their v1 defaults so tests can focus on the logic under

--- a/crates/mold-core/src/validation.rs
+++ b/crates/mold-core/src/validation.rs
@@ -139,6 +139,51 @@ pub fn materialize_extend_overlap_frames(req: &mut GenerateRequest, family: Opti
     }
 }
 
+/// The motion-tail overlap a chain seam actually renders with.
+///
+/// The tail is a property of the family's carryover and, for wan, of the
+/// selected *checkpoint's* conditioning contract — never of what the caller
+/// asked for. Wan has no latent motion tail: its seam re-renders exactly the
+/// one frame the continuation was seeded with, and only an image-conditioned
+/// checkpoint can be seeded at all. LTX-Video has no img2vid path, so its
+/// Smooth boundaries collapse to clean concatenation.
+///
+/// This lives here, beside [`WAN_HANDOFF_DUPLICATED_FRAMES`], because the
+/// server had been the only caller that normalized it (#936). The forced-local
+/// `--script` path, `mold chain validate`, and `--dry-run` all ran the
+/// family-generic `ChainRequest::normalise` and passed the requested tail
+/// through untouched — and `17 % 4 == 1`, so LTX-2's default clears wan's own
+/// `4k+1` grid check and then discards sixteen good frames at every Smooth
+/// seam, with correct-looking validation output (#783).
+///
+/// `source_image` is the resolved contract — probed from the checkpoint's own
+/// headers where possible, the manifest as the cold fallback. `None` is
+/// "unknown", which takes the conservative path rather than assuming a
+/// handoff. Families with a real latent window keep what the caller asked for.
+pub fn chain_motion_tail_frames_for_family(
+    family: &str,
+    source_image: Option<crate::SourceImageCapability>,
+    requested: u32,
+) -> u32 {
+    match family {
+        "wan" => {
+            let carries_context = source_image.is_some_and(|capability| {
+                matches!(
+                    capability,
+                    crate::SourceImageCapability::Required | crate::SourceImageCapability::Optional
+                )
+            });
+            if carries_context {
+                WAN_HANDOFF_DUPLICATED_FRAMES
+            } else {
+                0
+            }
+        }
+        "ltx-video" => 0,
+        _ => requested,
+    }
+}
+
 /// Inline `extend_video` payloads share the source-video body budget.
 pub const MAX_INLINE_EXTEND_VIDEO_BYTES: usize = MAX_INLINE_SOURCE_VIDEO_BYTES;
 
@@ -4664,6 +4709,54 @@ mod tests {
             req.effective_extend_overlap_frames_for_family(Some("wan")),
             9
         );
+    }
+
+    /// A chain seam's carryover is the family's, never the caller's (#783).
+    ///
+    /// The server has normalized this since #936, but only the server: a
+    /// forced-local `--script` run, `mold chain validate`, and `--dry-run`
+    /// all called the family-generic `normalise()` and passed the requested
+    /// tail straight through. `17 % 4 == 1`, so LTX-2's default clears wan's
+    /// own `4k+1` grid check and then silently discards sixteen good frames
+    /// at every Smooth seam. One authority so the two cannot drift.
+    #[test]
+    fn chain_motion_tail_follows_the_checkpoints_carryover_not_the_request() {
+        use crate::SourceImageCapability::{Optional, Required, Unsupported};
+
+        // Wan's seam re-renders exactly the one frame it was seeded with, and
+        // only an image-conditioned checkpoint can be seeded at all.
+        for capability in [Required, Optional] {
+            assert_eq!(
+                chain_motion_tail_frames_for_family("wan", Some(capability), 17),
+                WAN_HANDOFF_DUPLICATED_FRAMES,
+                "{capability:?} carries context, so the tail is one frame"
+            );
+        }
+        assert_eq!(
+            chain_motion_tail_frames_for_family("wan", Some(Unsupported), 17),
+            0,
+            "a text-to-video checkpoint has no channel to be seeded through"
+        );
+        // Unclassified is "unknown", never an assumed handoff.
+        assert_eq!(chain_motion_tail_frames_for_family("wan", None, 17), 0);
+
+        // An already-correct request is left exactly as it is.
+        assert_eq!(
+            chain_motion_tail_frames_for_family("wan", Some(Required), 1),
+            WAN_HANDOFF_DUPLICATED_FRAMES
+        );
+
+        // LTX-Video has no img2vid path, so its Smooth seams concatenate.
+        assert_eq!(
+            chain_motion_tail_frames_for_family("ltx-video", None, 17),
+            0
+        );
+
+        // Every other family keeps what the caller asked for — LTX-2's tail
+        // is a real latent window and the request owns it.
+        assert_eq!(chain_motion_tail_frames_for_family("ltx2", None, 17), 17);
+        assert_eq!(chain_motion_tail_frames_for_family("ltx2", None, 9), 9);
+        assert_eq!(chain_motion_tail_frames_for_family("", None, 17), 17);
     }
 
     /// Saved provenance has to name the overlap that actually rendered.

--- a/crates/mold-discord/src/commands/sequence.rs
+++ b/crates/mold-discord/src/commands/sequence.rs
@@ -93,11 +93,42 @@ struct SequenceParams<'a> {
     seed: Option<u64>,
     audio: Option<bool>,
     defaults: Option<&'a ModelDefaults>,
+    /// Resolved family. The clip grid, the floor, and the seam are all its
+    /// properties, never LTX-2 constants (#783).
+    family: Option<&'a str>,
+    /// The checkpoint's own conditioning contract. Wan's seam is last-frame
+    /// image conditioning, so only an image-conditioned checkpoint carries
+    /// anything across a boundary.
+    source_image: Option<mold_core::SourceImageCapability>,
 }
 
 fn build_sequence_request(params: SequenceParams<'_>) -> Result<ChainRequest, String> {
-    if params.frames_per_clip < 25 || (params.frames_per_clip - 1) & 7 != 0 {
-        return Err("Frames per clip must be 25 or greater and satisfy 8n+1.".to_string());
+    // The grid is the family's: wan's VAE compresses time by 4 where the LTX
+    // families compress by 8. Hardcoding `8n+1` here rejected wan's own
+    // 53-frame routing default before the request was ever submitted.
+    let family = params.family.unwrap_or("ltx2");
+    let step = mold_core::validation::frame_step_for_family(family).unwrap_or(8);
+    let offset = mold_core::validation::frame_offset_for_family(family).unwrap_or(1);
+    // LTX-2's 25 is three latent frames under its 8x stride; the equivalent
+    // floor scales with the family's own stride rather than carrying over.
+    let min_frames = step * 3 + offset;
+    if params.frames_per_clip < min_frames || params.frames_per_clip % step != offset % step {
+        return Err(format!(
+            "Frames per clip must be {min_frames} or greater and satisfy {step}n+{offset}."
+        ));
+    }
+    if let Some(cap) = mold_core::validation::max_frames_for_family_at_fps(
+        family,
+        params
+            .fps
+            .or_else(|| params.defaults.and_then(|defaults| defaults.default_fps))
+            .unwrap_or(mold_core::validation::LTX2_DEFAULT_FPS),
+    ) {
+        if params.frames_per_clip > cap {
+            return Err(format!(
+                "Frames per clip must be {cap} or fewer for this model's family."
+            ));
+        }
     }
     let (default_width, default_height, default_fps, default_steps, default_guidance) =
         params.defaults.map_or((1216, 704, 24, 8, 3.0), |defaults| {
@@ -130,10 +161,18 @@ fn build_sequence_request(params: SequenceParams<'_>) -> Result<ChainRequest, St
             references: Vec::new(),
         })
         .collect();
+    // The seam a family and checkpoint can actually honour. Sending LTX-2's
+    // 17 for wan meant the server silently repaired it, so the bot advertised
+    // a boundary it was not submitting.
+    let motion_tail_frames = mold_core::validation::chain_motion_tail_frames_for_family(
+        family,
+        params.source_image,
+        mold_core::validation::DEFAULT_EXTEND_OVERLAP_FRAMES,
+    );
     Ok(ChainRequest {
         model: params.model,
         stages,
-        motion_tail_frames: 17,
+        motion_tail_frames,
         width,
         height,
         fps,
@@ -220,16 +259,17 @@ async fn send_completed_sequence(
     Ok(())
 }
 
-/// Render a durable multi-prompt LTX-2 sequence.
+/// Render a durable multi-prompt video sequence.
 #[allow(clippy::too_many_arguments)]
 #[poise::command(slash_command)]
 pub async fn sequence(
     ctx: Context<'_>,
     #[description = "Clip prompts separated by | (2–16 prompts)"] prompts: String,
-    #[description = "LTX-2 model to use"]
+    #[description = "Sequence-capable model (LTX-2, LTX Video, or Wan Video)"]
     #[autocomplete = "autocomplete_sequence_model"]
     model: Option<String>,
-    #[description = "Frames per clip (8n+1, minimum 25; default 97)"] frames_per_clip: Option<u32>,
+    #[description = "Frames per clip; must sit on the model family's frame grid"]
+    frames_per_clip: Option<u32>,
     #[description = "Output width"] width: Option<u32>,
     #[description = "Output height"] height: Option<u32>,
     #[description = "Output FPS (default 24)"] fps: Option<u32>,
@@ -260,7 +300,7 @@ pub async fn sequence(
         .await?;
         return Ok(());
     }
-    // The interaction token expires after 15 minutes, while a durable LTX-2
+    // The interaction token expires after 15 minutes, while a durable
     // sequence can legitimately run longer. Use it only for a private handoff;
     // all long-lived progress and delivery use a normal bot-authored message.
     ctx.defer_ephemeral().await?;
@@ -280,10 +320,32 @@ pub async fn sequence(
         .await?;
         return Ok(());
     }
+    let family = model_entry.map(|entry| entry.info.family.as_str());
+    // A wan I2V checkpoint cannot render stage 0 without an image, and this
+    // command has no attachment to give it. Refuse before spending the
+    // model load rather than after (#783).
+    if model_entry
+        .is_some_and(|entry| entry.source_image == Some(mold_core::SourceImageCapability::Required))
+    {
+        ctx.data().quotas.refund(user_id);
+        handler::send_error(
+            ctx,
+            "This checkpoint requires a source image for every clip, and `/sequence` \
+             has no image input. Pick a text-to-video or optionally-conditioned model.",
+        )
+        .await?;
+        return Ok(());
+    }
+    // The default clip length is the family's own, not LTX-2's 97: 97 is off
+    // wan's `4k+1` grid only by luck of arithmetic, and its routing envelope
+    // is smaller than its cap.
+    let default_clip_frames = model_entry
+        .and_then(|entry| entry.defaults.default_frames)
+        .unwrap_or(97);
     let request = match build_sequence_request(SequenceParams {
         prompts,
         model,
-        frames_per_clip: frames_per_clip.unwrap_or(97),
+        frames_per_clip: frames_per_clip.unwrap_or(default_clip_frames),
         width,
         height,
         fps,
@@ -292,6 +354,8 @@ pub async fn sequence(
         seed,
         audio,
         defaults: model_entry.map(|entry| &entry.defaults),
+        family,
+        source_image: model_entry.and_then(|entry| entry.source_image),
     }) {
         Ok(request) => request,
         Err(message) => {
@@ -420,6 +484,92 @@ mod tests {
         assert!(parse_prompts("one prompt").is_err());
     }
 
+    /// Discord builds a wan sequence on wan's own grid and seam (#783).
+    ///
+    /// Eligibility was de-`ltx2`-ed in #936, but request construction stayed
+    /// LTX-shaped: an `8n+1` grid with a minimum of 25, and a motion tail of
+    /// 17. Wan is `4k+1`, so **53** — the A14B routing default the CLI itself
+    /// picks — was rejected here before the request was ever submitted, while
+    /// 81/97/121 passed only by coincidence. The tail was repaired silently
+    /// by the server, so the bot advertised a seam it was not sending.
+    #[test]
+    fn a_wan_sequence_uses_wans_grid_and_seam() {
+        let wan = |frames_per_clip: u32, source_image| {
+            build_sequence_request(SequenceParams {
+                prompts: vec!["a paper boat".into(), "it reaches the drain".into()],
+                model: "wan22-ti2v-5b:q8".into(),
+                frames_per_clip,
+                width: None,
+                height: None,
+                fps: None,
+                steps: None,
+                guidance: None,
+                seed: None,
+                audio: None,
+                defaults: None,
+                family: Some("wan"),
+                source_image,
+            })
+        };
+
+        // The A14B routing default. Rejected outright before this.
+        let request = wan(53, Some(mold_core::SourceImageCapability::Optional))
+            .expect("53 is on wan's 4k+1 grid");
+        assert_eq!(request.stages[0].frames, 53);
+        assert_eq!(
+            request.motion_tail_frames,
+            mold_core::validation::WAN_HANDOFF_DUPLICATED_FRAMES,
+            "wan re-renders exactly the frame the continuation was seeded with"
+        );
+
+        // A text-to-video checkpoint cannot be seeded, so its seam carries
+        // nothing rather than a value the server has to repair.
+        let t2v = wan(53, Some(mold_core::SourceImageCapability::Unsupported)).unwrap();
+        assert_eq!(t2v.motion_tail_frames, 0);
+
+        // Off-grid for wan is still refused, and the message names wan's grid.
+        let error = wan(50, Some(mold_core::SourceImageCapability::Optional)).unwrap_err();
+        assert!(error.contains("4n+1"), "got: {error}");
+
+        // Below wan's own floor, which is not LTX-2's 25.
+        assert!(wan(1, Some(mold_core::SourceImageCapability::Optional)).is_err());
+
+        // LTX-2 is unchanged: 8n+1, minimum 25, tail 17.
+        let ltx2 = build_sequence_request(SequenceParams {
+            prompts: vec!["one".into(), "two".into()],
+            model: "ltx-2-19b-distilled:fp8".into(),
+            frames_per_clip: 97,
+            width: None,
+            height: None,
+            fps: None,
+            steps: None,
+            guidance: None,
+            seed: None,
+            audio: None,
+            defaults: None,
+            family: Some("ltx2"),
+            source_image: None,
+        })
+        .unwrap();
+        assert_eq!(ltx2.motion_tail_frames, 17);
+        assert!(build_sequence_request(SequenceParams {
+            prompts: vec!["one".into(), "two".into()],
+            model: "ltx-2-19b-distilled:fp8".into(),
+            frames_per_clip: 53,
+            width: None,
+            height: None,
+            fps: None,
+            steps: None,
+            guidance: None,
+            seed: None,
+            audio: None,
+            defaults: None,
+            family: Some("ltx2"),
+            source_image: None,
+        })
+        .is_err());
+    }
+
     #[test]
     fn request_has_one_smooth_stage_per_prompt() {
         let request = build_sequence_request(SequenceParams {
@@ -434,6 +584,8 @@ mod tests {
             seed: Some(42),
             audio: Some(true),
             defaults: None,
+            family: Some("ltx2"),
+            source_image: None,
         })
         .unwrap();
         assert_eq!(request.stages.len(), 2);
@@ -461,6 +613,8 @@ mod tests {
             seed: None,
             audio: None,
             defaults: None,
+            family: Some("ltx2"),
+            source_image: None,
         });
         assert!(result.is_err());
     }

--- a/crates/mold-server/src/routes_chain.rs
+++ b/crates/mold-server/src/routes_chain.rs
@@ -928,14 +928,26 @@ pub(crate) fn validate_and_normalize_chain_family(
     // not this path — so a wan I2V sequence with no opening image was
     // admitted and then died after the UMT5 encode and both expert loads had
     // been paid for, and a T2V sequence carrying one was admitted too (#783).
+    //
+    // The two arms read different sets on purpose. `Required` asks whether
+    // stage 0 can be seeded at all, so only the opening image counts — every
+    // continuation is seeded by the seam. `Unsupported` asks whether an image
+    // was supplied anywhere the engine has no channel for, so a per-stage
+    // image on a continuation has to count too; a script may attach one to
+    // any stage (`source_image_path`).
+    let opening_image =
+        req.source_image.is_some() || req.stages.first().is_some_and(|s| s.source_image.is_some());
+    let any_image = opening_image || req.stages.iter().any(|s| s.source_image.is_some());
+    let family_hint = (!family.is_empty()).then_some(family.as_str());
+    let has_source = match contract {
+        Some(mold_core::SourceImageCapability::Unsupported) => any_image,
+        _ => opening_image,
+    };
     if let Some(message) = mold_core::validation::source_image_contract_violation(
-        (!family.is_empty()).then_some(family.as_str()),
+        family_hint,
         &req.model,
         contract,
-        req.stages
-            .first()
-            .is_some_and(|stage| stage.source_image.is_some())
-            || req.source_image.is_some(),
+        has_source,
     ) {
         return Err(ApiError::validation(message));
     }
@@ -2033,6 +2045,34 @@ mod tests {
         opening_image(&mut plain_t2v, None);
         validate_and_normalize_chain_family(&config, &mut plain_t2v).expect("admitted");
         assert_eq!(plain_t2v.motion_tail_frames, 0);
+
+        // A script can attach an image to any stage, so an unsupported
+        // checkpoint is refused for one on a continuation too — the two arms
+        // read different sets: `Required` asks only whether stage 0 can be
+        // seeded, because every continuation is seeded by the seam.
+        let mut late_image = req(OutputFormat::Mp4);
+        late_image.model = "wan21-t2v-1.3b".into();
+        late_image.width = 832;
+        late_image.height = 480;
+        assert!(
+            late_image.stages.len() > 1,
+            "this case needs a continuation to attach to"
+        );
+        late_image.stages[1].source_image = Some(vec![1, 2, 3]);
+        assert!(
+            validate_and_normalize_chain_family(&config, &mut late_image).is_err(),
+            "an image on a continuation is still an image the engine cannot take"
+        );
+
+        // The mirror: a Required checkpoint seeded only on a continuation is
+        // still unseeded where it matters.
+        let mut late_only = req(OutputFormat::Mp4);
+        late_only.model = "wan22-i2v-a14b:q5".into();
+        late_only.width = 832;
+        late_only.height = 480;
+        opening_image(&mut late_only, None);
+        late_only.stages[1].source_image = Some(vec![1, 2, 3]);
+        assert!(validate_and_normalize_chain_family(&config, &mut late_only).is_err());
     }
 
     struct HandlerFailingExecutor;

--- a/crates/mold-server/src/routes_chain.rs
+++ b/crates/mold-server/src/routes_chain.rs
@@ -935,8 +935,13 @@ pub(crate) fn validate_and_normalize_chain_family(
     // was supplied anywhere the engine has no channel for, so a per-stage
     // image on a continuation has to count too; a script may attach one to
     // any stage (`source_image_path`).
-    let opening_image =
-        req.source_image.is_some() || req.stages.first().is_some_and(|s| s.source_image.is_some());
+    // The top-level `source_image` is the auto-expand form's opening image and
+    // `normalise` only projects it onto stage 0 when `stages` is empty — with
+    // explicit stages it is cleared. Counting it either way admitted a mixed
+    // form whose image is discarded before execution, so the I2V model loaded
+    // and then failed on an unseeded stage 0.
+    let opening_image = (req.stages.is_empty() && req.source_image.is_some())
+        || req.stages.first().is_some_and(|s| s.source_image.is_some());
     let any_image = opening_image || req.stages.iter().any(|s| s.source_image.is_some());
     let family_hint = (!family.is_empty()).then_some(family.as_str());
     let has_source = match contract {
@@ -2073,6 +2078,38 @@ mod tests {
         opening_image(&mut late_only, None);
         late_only.stages[1].source_image = Some(vec![1, 2, 3]);
         assert!(validate_and_normalize_chain_family(&config, &mut late_only).is_err());
+
+        // The top-level `source_image` belongs to the auto-expand form.
+        // `normalise` projects it onto stage 0 only when `stages` is empty and
+        // clears it otherwise, so counting it alongside explicit stages
+        // admitted a request whose image is discarded before execution — the
+        // I2V model loaded, then failed on an unseeded stage 0.
+        let mut mixed_form = req(OutputFormat::Mp4);
+        mixed_form.model = "wan22-i2v-a14b:q5".into();
+        mixed_form.width = 832;
+        mixed_form.height = 480;
+        opening_image(&mut mixed_form, None);
+        mixed_form.source_image = Some(vec![1, 2, 3]);
+        assert!(
+            !mixed_form.stages.is_empty(),
+            "the defect needs explicit stages beside the top-level image"
+        );
+        assert!(
+            validate_and_normalize_chain_family(&config, &mut mixed_form).is_err(),
+            "an image `normalise` is about to discard cannot satisfy the contract"
+        );
+
+        // The auto-expand form still seeds stage 0 from that same field.
+        let mut auto_expand = req(OutputFormat::Mp4);
+        auto_expand.model = "wan22-i2v-a14b:q5".into();
+        auto_expand.width = 832;
+        auto_expand.height = 480;
+        auto_expand.stages = Vec::new();
+        auto_expand.prompt = Some("a balloon lifts off".into());
+        auto_expand.total_frames = Some(106);
+        auto_expand.clip_frames = Some(53);
+        auto_expand.source_image = Some(vec![1, 2, 3]);
+        validate_and_normalize_chain_family(&config, &mut auto_expand).expect("admitted");
     }
 
     struct HandlerFailingExecutor;

--- a/crates/mold-server/src/routes_chain.rs
+++ b/crates/mold-server/src/routes_chain.rs
@@ -901,18 +901,13 @@ pub(crate) fn validate_and_normalize_chain_family(
             mold_inference::wan_source_image_capability(&paths.transformer, &paths.vae)
         });
         let contract = probed.or_else(|| manifest.and_then(|model| model.defaults.source_image));
-        let carries_context = contract.is_some_and(|capability| {
-            matches!(
-                capability,
-                mold_core::SourceImageCapability::Required
-                    | mold_core::SourceImageCapability::Optional
-            )
-        });
-        let normalized = if carries_context {
-            mold_inference::wan::pipeline::WAN_HANDOFF_DUPLICATED_FRAMES
-        } else {
-            0
-        };
+        // One authority, shared with the forced-local CLI path: the two had
+        // drifted, and only this one normalized (#783).
+        let normalized = mold_core::validation::chain_motion_tail_frames_for_family(
+            &family,
+            contract,
+            req.motion_tail_frames,
+        );
         if req.motion_tail_frames != normalized {
             tracing::debug!(
                 model = %req.model,

--- a/crates/mold-server/src/routes_chain.rs
+++ b/crates/mold-server/src/routes_chain.rs
@@ -312,8 +312,9 @@ async fn shim_start_job(state: &AppState, req: ChainRequest) -> Result<ShimJob, 
     validate_chain_build_features(&req)?;
     let authority = resolve_chain_model_authority(state, &req.model).await?;
     validate_and_normalize_chain_family(&authority.config, &mut req)?;
+    let family = resolve_chain_family(&authority.config, &req.model);
     let mut req = req
-        .normalise()
+        .normalise_with_family(Some(&family))
         .map_err(|e| ApiError::validation(e.to_string()))?;
     validate_and_normalize_chain_family(&authority.config, &mut req)?;
     crate::routes::materialize_chain_camera_controls(state, &authority.config, &req).await?;
@@ -779,6 +780,24 @@ pub(crate) fn validate_chain_build_features(_req: &ChainRequest) -> Result<(), A
     Ok(())
 }
 
+/// The family a chain request will actually render as.
+///
+/// The sidecar-derived `ModelConfig` an installed `cv:` / `hf:` checkpoint
+/// carries is the authority; the built-in manifest is the fallback. Reading
+/// only the manifest leaves a catalog wan checkpoint unclassified, and an
+/// unclassified family means the LTX `8k+1` grid (#783).
+pub(crate) fn resolve_chain_family(config: &mold_core::Config, model: &str) -> String {
+    let resolved_model = config.resolved_model_config(model);
+    let canonical_model = mold_core::manifest::resolve_model_name(model);
+    resolved_model
+        .family
+        .clone()
+        .or_else(|| {
+            mold_core::manifest::find_manifest(&canonical_model).map(|model| model.family.clone())
+        })
+        .unwrap_or_default()
+}
+
 pub(crate) fn validate_and_normalize_chain_family(
     config: &mold_core::Config,
     req: &mut ChainRequest,
@@ -787,11 +806,7 @@ pub(crate) fn validate_and_normalize_chain_family(
     let resolved_model = config.resolved_model_config(&req.model);
     let canonical_model = mold_core::manifest::resolve_model_name(&req.model);
     let manifest = mold_core::manifest::find_manifest(&canonical_model);
-    let family = resolved_model
-        .family
-        .clone()
-        .or_else(|| manifest.map(|model| model.family.clone()))
-        .unwrap_or_default();
+    let family = resolve_chain_family(config, &req.model);
     mold_core::require_model_activation(
         &req.model,
         (!family.is_empty()).then_some(family.as_str()),
@@ -889,18 +904,47 @@ pub(crate) fn validate_and_normalize_chain_family(
             )));
         }
     }
+    // Wan probes the resolved checkpoint's own headers FIRST, exactly as
+    // `/api/models` and single-generation admission do: `ModelPaths` honors
+    // config/env path overrides, so the artifacts actually loaded can differ
+    // from the manifest's task structure. The manifest is the cold fallback
+    // for a model that is not downloaded yet. Other families have no header
+    // probe and their manifest contract binds directly.
+    let manifest_contract = manifest.and_then(|model| model.defaults.source_image);
+    let contract = if family == "wan" {
+        mold_core::ModelPaths::resolve(&req.model, config)
+            .and_then(|paths| {
+                mold_inference::wan_source_image_capability(&paths.transformer, &paths.vae)
+            })
+            .or(manifest_contract)
+    } else {
+        manifest_contract
+    };
+
+    // Stage 0 is the only clip that can carry an opening image; every
+    // continuation is seeded by the seam. Admission never asked the
+    // checkpoint whether it could accept one — `enforce_source_image_
+    // capability` covered single generations and the placement preview but
+    // not this path — so a wan I2V sequence with no opening image was
+    // admitted and then died after the UMT5 encode and both expert loads had
+    // been paid for, and a T2V sequence carrying one was admitted too (#783).
+    if let Some(message) = mold_core::validation::source_image_contract_violation(
+        (!family.is_empty()).then_some(family.as_str()),
+        &req.model,
+        contract,
+        req.stages
+            .first()
+            .is_some_and(|stage| stage.source_image.is_some())
+            || req.source_image.is_some(),
+    ) {
+        return Err(ApiError::validation(message));
+    }
+
     if family == "wan" {
         // Wan has no latent motion tail. Its seam re-renders exactly the one
         // frame the continuation was seeded with, and only an image-conditioned
         // checkpoint can be seeded at all — so the tail is 1 or 0, never the
         // LTX-shaped value a client may have carried over.
-        // Probe the resolved checkpoint's own headers first, exactly as
-        // `/api/models` and generation admission do; the manifest is the cold
-        // fallback for a model that is not downloaded yet.
-        let probed = mold_core::ModelPaths::resolve(&req.model, config).and_then(|paths| {
-            mold_inference::wan_source_image_capability(&paths.transformer, &paths.vae)
-        });
-        let contract = probed.or_else(|| manifest.and_then(|model| model.defaults.source_image));
         // One authority, shared with the forced-local CLI path: the two had
         // drifted, and only this one normalized (#783).
         let normalized = mold_core::validation::chain_motion_tail_frames_for_family(
@@ -969,10 +1013,15 @@ pub async fn validate_chain(
     let requested_motion_tail = req.motion_tail_frames;
     let mut warnings = Vec::new();
 
-    {
-        let config = state.config.read().await;
-        validate_and_normalize_chain_family(&config, &mut req)?;
-    }
+    // The same authority submission uses. Reading `state.config` directly
+    // left an installed `cv:` / `hf:` wan checkpoint with an empty family,
+    // which skipped the wan tail normalization, the family cap, the grid
+    // check, and the sequence-support check — so "Validate plan" and the
+    // submission that follows it disagreed about exactly the models the
+    // sequence work targets (#783).
+    let authority = resolve_chain_model_authority(&state, &req.model).await?;
+    validate_and_normalize_chain_family(&authority.config, &mut req)?;
+    let family = resolve_chain_family(&authority.config, &req.model);
     if req.motion_tail_frames != requested_motion_tail {
         warnings.push(format!(
             "The selected model normalized motion_tail_frames from {requested_motion_tail} to {}.",
@@ -981,15 +1030,14 @@ pub async fn validate_chain(
     }
 
     let mut req = req
-        .normalise()
+        .normalise_with_family(Some(&family))
         .map_err(|error| ApiError::validation(error.to_string()))?;
     if opening_transition.is_some_and(|transition| transition != TransitionMode::Smooth) {
         warnings.push("The opening clip transition was normalized to smooth.".to_string());
     }
     {
-        let config = state.config.read().await;
         let before = req.motion_tail_frames;
-        validate_and_normalize_chain_family(&config, &mut req)?;
+        validate_and_normalize_chain_family(&authority.config, &mut req)?;
         if req.motion_tail_frames != before && req.motion_tail_frames != requested_motion_tail {
             warnings.push(format!(
                 "The selected model normalized motion_tail_frames from {before} to {}.",
@@ -1917,6 +1965,74 @@ mod tests {
         t2v.motion_tail_frames = 17;
         validate_and_normalize_chain_family(&config, &mut t2v).expect("admitted");
         assert_eq!(t2v.motion_tail_frames, 0);
+    }
+
+    /// Chain admission holds a checkpoint to its own conditioning contract
+    /// (#783).
+    ///
+    /// The tail was normalized here since #936, but the contract that decides
+    /// the tail was never enforced: `enforce_source_image_capability` lives on
+    /// the single-generation path and the placement preview, and nothing on
+    /// the chain path called it. So a wan A14B I2V sequence with no opening
+    /// image was admitted and then died after the UMT5 encode and both expert
+    /// loads were paid for, and a text-to-video sequence carrying an opening
+    /// image was admitted too. This is the acceptance criterion "T2V-only
+    /// checkpoints offer Cut/Crossfade only or are excluded, per advertised
+    /// capability".
+    #[test]
+    fn chain_preflight_holds_a_checkpoint_to_its_source_image_contract() {
+        let config = mold_core::Config::default();
+        let opening_image = |request: &mut ChainRequest, image: Option<Vec<u8>>| {
+            request.stages[0].source_image = image;
+        };
+
+        // A14B I2V denoises a 36-channel mask-plus-image concat: without an
+        // image there is nothing to seed stage 0 with.
+        let mut required = req(OutputFormat::Mp4);
+        required.model = "wan22-i2v-a14b:q5".into();
+        required.width = 832;
+        required.height = 480;
+        opening_image(&mut required, None);
+        let error = validate_and_normalize_chain_family(&config, &mut required)
+            .expect_err("a Required checkpoint cannot open a sequence unseeded");
+        assert!(
+            error.error.to_lowercase().contains("source image"),
+            "got: {}",
+            error.error
+        );
+
+        // The same checkpoint with an opening image is admitted.
+        let mut seeded = req(OutputFormat::Mp4);
+        seeded.model = "wan22-i2v-a14b:q5".into();
+        seeded.width = 832;
+        seeded.height = 480;
+        opening_image(&mut seeded, Some(vec![1, 2, 3]));
+        validate_and_normalize_chain_family(&config, &mut seeded).expect("admitted");
+        assert_eq!(
+            seeded.motion_tail_frames,
+            mold_inference::wan::pipeline::WAN_HANDOFF_DUPLICATED_FRAMES
+        );
+
+        // A text-to-video checkpoint has no conditioning channel at all, so
+        // an attached opening image is refused rather than ignored.
+        let mut unsupported = req(OutputFormat::Mp4);
+        unsupported.model = "wan21-t2v-1.3b".into();
+        unsupported.width = 832;
+        unsupported.height = 480;
+        opening_image(&mut unsupported, Some(vec![1, 2, 3]));
+        assert!(
+            validate_and_normalize_chain_family(&config, &mut unsupported).is_err(),
+            "a T2V checkpoint has no channel for an opening image"
+        );
+
+        // And without one it is admitted, carrying nothing across its seams.
+        let mut plain_t2v = req(OutputFormat::Mp4);
+        plain_t2v.model = "wan21-t2v-1.3b".into();
+        plain_t2v.width = 832;
+        plain_t2v.height = 480;
+        opening_image(&mut plain_t2v, None);
+        validate_and_normalize_chain_family(&config, &mut plain_t2v).expect("admitted");
+        assert_eq!(plain_t2v.motion_tail_frames, 0);
     }
 
     struct HandlerFailingExecutor;

--- a/crates/mold-server/src/routes_chain_jobs.rs
+++ b/crates/mold-server/src/routes_chain_jobs.rs
@@ -93,8 +93,12 @@ pub async fn create_chain_job(
     crate::routes_chain::validate_chain_build_features(&req)?;
     let authority = crate::routes_chain::resolve_chain_model_authority(&state, &req.model).await?;
     crate::routes_chain::validate_and_normalize_chain_family(&authority.config, &mut req)?;
+    // The sidecar-derived family, so an installed `cv:` / `hf:` wan
+    // checkpoint normalises on wan's `4k+1` grid rather than the LTX
+    // fallback a manifest-only lookup leaves behind (#783).
+    let family = crate::routes_chain::resolve_chain_family(&authority.config, &req.model);
     let req = req
-        .normalise()
+        .normalise_with_family(Some(&family))
         .map_err(|e| ApiError::validation(e.to_string()))?;
     if req.output_format != mold_core::OutputFormat::Mp4 {
         return Err(ApiError::validation(
@@ -185,7 +189,8 @@ pub async fn preview_chain_job_placement(
     {
         return Json(unavailable(error.error));
     }
-    let req = match req.normalise() {
+    let family = crate::routes_chain::resolve_chain_family(&validation_config, &req.model);
+    let req = match req.normalise_with_family(Some(&family)) {
         Ok(req) => req,
         Err(error) => return Json(unavailable(error.to_string())),
     };
@@ -528,8 +533,10 @@ pub async fn amend_chain_job(
             &validation_config,
             &mut candidate,
         )?;
+        let family =
+            crate::routes_chain::resolve_chain_family(&validation_config, &candidate.model);
         let candidate = candidate
-            .normalise()
+            .normalise_with_family(Some(&family))
             .map_err(|error| ApiError::validation(error.to_string()))?;
         if candidate.output_format != mold_core::OutputFormat::Mp4 {
             return Err(ApiError::validation(


### PR DESCRIPTION
Part of #783. Six correctness defects found while auditing what actually
remains of the Wan chain/sequence wave — #936, #982, and #984 landed the
capability arm, the handoff, Studio/Discord eligibility, and extend, so the
issue body is stale. These are the bugs that survived it.

Every one is a silent failure: each produced a plausible-looking result or a
confident rejection rather than an error at the point of the mistake.

## The seam

`--motion-tail` defaults to LTX-2's 17 for every family, and `17 % 4 == 1`
sits on Wan's own `4k+1` grid — so a script-authored or repeated-`--prompt`
Wan chain **validated clean** and then discarded sixteen good frames at every
Smooth boundary: the engine seeds a continuation from one frame while the
stitch drops seventeen. Only the server normalized this.

`chain_motion_tail_frames_for_family` is now the single authority in
`mold-core`, applied **before** `normalise()` so a short clip is not rejected
for a seam that was never going to render and a dry run does not report totals
for one either. `mold run --script`, `mold chain validate`, `--dry-run`, the
sugar path, Discord, and the server all read it.

Measured, `wan22-ti2v-5b:q8`, two 25-frame Smooth stages authored with
`motion_tail_frames = 17`:

```
note: wan22-ti2v-5b:q8 carries 1 frame(s) across a seam, not 17;
      validated with motion_tail_frames = 1
OK — 2 stages, 49 frames estimated
```

49 = `25 + (25 - 1)`. Before: 33 = `25 + (25 - 17)`.

## The recipe

`run_from_sugar` accepts any model — `main.rs` gates only MiniMax H3 — and
hardcoded 1216x704, 24 fps, 8 steps, guidance 3.0, a 97-frame clip default,
and a cap resolved against a literal `"ltx2"`. Those values reach the engine
unchanged through the orchestrator, so `wan22-t2v-a14b:q5` was encoded at 24
fps rather than its own 16 and denoised for 8 steps against a 4-step Lightning
recipe, which renders noise. The recipe now comes from
`resolved_model_config`, the same authority a single shot uses.

Measured, `mold run wan21-t2v-1.3b --prompt A --prompt B --frames-per-clip 25`:
**50 frames, 832x480, 16 fps** in 289.5 s, frame 0 and frame 30 both clean.
Before: 33 frames at 1216x704, 24 fps, 8 steps.

## Discord

`/sequence` validated an `8n+1` grid with a minimum of 25, so **53** — the
A14B routing default the CLI itself picks — was refused before submission,
while 81/97/121 passed only by coincidence. Grid, floor, cap, per-clip
default, and the seam now come from the family and checkpoint. It also stops
offering `source_image: Required` I2V checkpoints it has no image input to
seed, and its user-facing strings no longer name LTX-2 for a command serving
three families.

## Installed catalog checkpoints

`normalise` classified models from the built-in manifest alone, and
`find_manifest` cannot classify a `cv:` / `hf:` id. An unclassified family is
not merely "unknown" — it *is* the LTX `8k+1` grid, so a valid 53-frame Wan
chain was rejected outright and a 97-frame one silently kept its 17-frame
tail. `validate_chain` separately read `state.config` while submission read
`authority.config`, so **Validate plan and submit disagreed** about exactly
the models this work targets.

This also fixes a pre-existing failure in
`web_sequence_freezes_installed_ltx23_catalog_model_without_mutating_live_config`.

## The source-image contract

Chain admission never asked a checkpoint whether it could accept the opening
image it was given: `enforce_source_image_capability` covered single
generations and the placement preview, nothing on the chain path. So a Wan
A14B I2V sequence with **no** opening image was admitted and died after the
UMT5 encode and both expert loads were paid for, and a text-to-video sequence
carrying one was admitted too. This is #783's acceptance criterion "T2V-only
checkpoints offer Cut/Crossfade only or are excluded, per advertised
capability".

Verified against a running pre-fix server (`569b2337`) and this build:

| Request | before | after |
| --- | --- | --- |
| A14B I2V sequence, no opening image | `200` + full plan, `has_source_image: false` | `422` |
| T2V sequence with an opening image | `200` + full plan | `422` |

The two contract arms deliberately read different sets: `Required` asks only
whether stage 0 can be seeded, because every continuation is seeded by the
seam; `Unsupported` counts an image on any stage, since a script may attach
one anywhere. The top-level `source_image` counts only in the auto-expand
form, because `normalise` discards it when stages are explicit — counting it
otherwise admitted a request whose image was thrown away before execution.

## Review

Peer-reviewed with `codex review --base origin/main`, which found three real
defects in the first pass of this branch — the CLI's manifest-only authority,
the name-sniffed routing default for opaque IDs, and the mixed-form
`source_image` above. All three are fixed here with tests.

## Testing

TDD throughout: failing test first for each defect.

- `mold-ai-core` 1180 passed, `mold-ai-discord` 143 passed, both 0 failed
- `mold-ai` bin 556 passed (baseline 552) / 12 failed
- `mold-ai-server --lib -- chain_` 194 passed (baseline 193) / 3 failed
- `cargo clippy --workspace --all-targets` and `cargo fmt --all -- --check` clean

The 12 and 3 failures are pre-existing and depend on the developer's own Mold
config; each was confirmed against a stashed baseline rather than assumed.

## UAT

Real renders on an RTX 4090 against installed weights, not simulated. The
sugar-path and seam numbers above are measured. Not covered here: the MP4 mux
path (this UAT binary lacks the `mp4` feature, so outputs fell back to APNG —
frame counts and pixels are unaffected), Discord end-to-end (unit-tested
only), and the A5 Validate-plan/submit split against a checkpoint installed
via catalog sidecar and absent from `config.toml`, which no installed model
here reproduces.

## Not in this PR

The Studio-side defects and the remaining #783 close-out work — test coverage,
docs, the regression-matrix wan chain and extend cases, and the follow-up
issue for the multi-frame TI2V handoff — are separate.

https://claude.ai/code/session_0149HHWp2CfH4pRR13MjDDpi