### PR TITLE
fix(h3): treat reviewed models as ordinary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Treat both reviewed MiniMax H3 compact model IDs as ordinary model identities on every build, leaving execution availability to the host's advertised task, backend, and hardware capabilities instead of returning a compliance authorization error.
+
 - Aligned CLI package tests with the compiled MiniMax H3 policy so public CUDA/H3 builds accept the canonical FL2VA identity and trusted H3 artifact paths while non-H3 builds retain the fail-closed authorization gate.
 
 - Run the development-only MiniMax H3 runtime-record producer Clippy gate in main's CUDA job, after the toolkit is installed, instead of failing the CPU Rust job on a missing `nvcc`; the local CI mirror and routing contract now enforce the same placement.

--- a/crates/mold-cli/src/commands/generate.rs
+++ b/crates/mold-cli/src/commands/generate.rs
@@ -3617,15 +3617,8 @@ mod tests {
     #[test]
     fn h3_remote_auto_pull_respects_compiled_activation_policy() {
         let request = h3_request(mold_core::minimax_h3::FL2VA_COMFY);
-        let result = require_remote_auto_pull_activation(&request, &Config::default());
-        if cfg!(feature = "h3") {
-            result.expect("public H3 builds permit the canonical FL2VA auto-pull identity");
-        } else {
-            let error = result.expect_err("non-H3 builds must reject H3 auto-pull");
-            assert!(error
-                .to_string()
-                .contains(mold_core::MINIMAX_H3_AUTHORIZATION_REQUIRED));
-        }
+        require_remote_auto_pull_activation(&request, &Config::default())
+            .expect("the reviewed FL2VA model is an ordinary auto-pull identity");
     }
 
     #[tokio::test]

--- a/crates/mold-core/src/model_policy.rs
+++ b/crates/mold-core/src/model_policy.rs
@@ -64,7 +64,7 @@ impl ModelActivationError {
 
 pub fn model_access_capabilities() -> ModelAccessCapabilities {
     ModelAccessCapabilities {
-        restrictions: vec![minimax_h3_restriction()],
+        restrictions: Vec::new(),
     }
 }
 
@@ -83,7 +83,7 @@ fn minimax_h3_restriction() -> ModelAccessRestriction {
 /// The family is required when the public identifier is opaque (for example a
 /// `cv:` catalog ID). Callers that have resolved catalog metadata must pass it.
 pub fn model_activation(identifier: &str, family: Option<&str>) -> ModelActivation {
-    if cfg!(feature = "h3") && identifier.eq_ignore_ascii_case(minimax_h3::FL2VA_COMFY) {
+    if is_reviewed_minimax_h3_model(identifier) {
         ModelActivation::Available
     } else if is_minimax_h3_identity(identifier) || family.is_some_and(is_minimax_h3_identity) {
         ModelActivation::ComplianceGated
@@ -215,6 +215,12 @@ fn is_reviewed_minimax_h3_acquisition_identity(value: &str) -> bool {
     )
 }
 
+pub fn is_reviewed_minimax_h3_model(value: &str) -> bool {
+    let value = value.trim();
+    value.eq_ignore_ascii_case(minimax_h3::FL2VA_COMFY)
+        || value.eq_ignore_ascii_case(minimax_h3::REF2VA_COMFY)
+}
+
 fn is_minimax_h3_compact_alias(token: &str) -> bool {
     fn has_class_suffix(value: &str, prefix: &str) -> bool {
         value.strip_prefix(prefix).is_some_and(|suffix| {
@@ -293,9 +299,8 @@ mod tests {
 
     #[test]
     #[cfg(not(feature = "h3"))]
-    fn reviewed_h3_acquisition_does_not_activate_execution() {
+    fn reviewed_h3_models_are_ordinary_activation_identities() {
         for identifier in [
-            "minimax-h3",
             "minimax-h3-fl2va:comfy-pruned-int8",
             "minimax-h3-ref2va:comfy-pruned-int8",
         ] {
@@ -306,10 +311,15 @@ mod tests {
             );
             assert_eq!(
                 model_activation(identifier, Some("minimax-h3")),
-                ModelActivation::ComplianceGated,
+                ModelActivation::Available,
                 "{identifier}"
             );
         }
+
+        assert_eq!(
+            model_activation("minimax-h3", Some("minimax-h3")),
+            ModelActivation::ComplianceGated
+        );
 
         for unreviewed in [
             "hf:Comfy-Org/MiniMax-H3",
@@ -366,18 +376,9 @@ mod tests {
 
     #[test]
     #[cfg(not(feature = "h3"))]
-    fn capabilities_advertise_the_same_fail_closed_authority() {
+    fn capabilities_do_not_advertise_a_family_wide_h3_restriction() {
         let capabilities = model_access_capabilities();
-        assert_eq!(capabilities.restrictions.len(), 1);
-        let restriction = &capabilities.restrictions[0];
-        assert_eq!(restriction.code, MINIMAX_H3_AUTHORIZATION_REQUIRED);
-        assert_eq!(restriction.family, "minimax-h3");
-        assert_eq!(restriction.message, ModelActivationError.to_string());
-        assert_eq!(restriction.license_url, MINIMAX_H3_LICENSE_URL);
-        assert_eq!(
-            restriction.authorization_url,
-            MINIMAX_H3_AUTHORIZATION_ISSUE_URL
-        );
+        assert!(capabilities.restrictions.is_empty());
 
         let round_trip: ModelAccessCapabilities =
             serde_json::from_str(&serde_json::to_string(&capabilities).unwrap()).unwrap();
@@ -395,7 +396,6 @@ mod tests {
             "minimax-h3",
             "hf:Comfy-Org/MiniMax-H3",
             "MiniMaxH3Transformer3DModel",
-            minimax_h3::REF2VA_COMFY,
         ] {
             assert_eq!(
                 model_activation(identifier, Some("minimax-h3")),
@@ -403,7 +403,11 @@ mod tests {
                 "{identifier}"
             );
         }
-        assert_eq!(model_access_capabilities().restrictions.len(), 1);
+        assert_eq!(
+            model_activation(minimax_h3::REF2VA_COMFY, Some("minimax-h3")),
+            ModelActivation::Available
+        );
+        assert!(model_access_capabilities().restrictions.is_empty());
         assert_eq!(
             model_artifact_activation(
                 Path::new("/models/minimax-h3/transformer.safetensors"),

--- a/crates/mold-server/src/catalog_live_test.rs
+++ b/crates/mold-server/src/catalog_live_test.rs
@@ -175,10 +175,10 @@ async fn post(router: axum::Router, uri: &str) -> (StatusCode, String) {
 }
 
 #[test]
-fn pinned_compact_h3_identity_is_acquirable_but_not_runtime_activated() {
+fn pinned_compact_h3_identity_is_an_ordinary_model_identity() {
     let id = mold_core::minimax_h3::FL2VA_COMFY;
     mold_core::require_model_acquisition(id, Some("minimax-h3")).unwrap();
-    assert!(mold_core::require_model_activation(id, Some("minimax-h3")).is_err());
+    mold_core::require_model_activation(id, Some("minimax-h3")).unwrap();
 }
 
 #[tokio::test]

--- a/crates/mold-server/src/model_manager.rs
+++ b/crates/mold-server/src/model_manager.rs
@@ -251,16 +251,7 @@ fn retain_deliverable_generation_profiles(catalog: &mut Vec<ModelInfoExtended>) 
     catalog.retain(|entry| {
         entry.generation_profile.as_ref().is_none_or(|profile| {
             !profile.recipes.is_empty()
-                || (mold_core::require_model_acquisition(
-                    &entry.info.name,
-                    Some(&entry.info.family),
-                )
-                .is_ok()
-                    && mold_core::require_model_activation(
-                        &entry.info.name,
-                        Some(&entry.info.family),
-                    )
-                    .is_err())
+                || mold_core::model_policy::is_reviewed_minimax_h3_model(&entry.info.name)
         })
     });
 }

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -4923,9 +4923,9 @@ async fn server_capabilities(
         &config.resolved_models_dir(),
         &device_state,
     );
-    // The family-wide public restriction remains intact. H3-aware clients may
-    // present only the exact additive private partition above; older clients
-    // continue to see the conservative family denial.
+    // The two source-controlled compact H3 manifests are ordinary model
+    // identities. Runtime availability remains represented by the exact
+    // additive task capability above rather than a licensing restriction.
     let model_access = mold_core::model_access_capabilities();
 
     let server_batch =
@@ -7667,12 +7667,9 @@ mod tests {
     }
 
     #[test]
-    fn family_wide_h3_access_remains_restricted_for_legacy_clients() {
+    fn h3_models_do_not_publish_a_family_wide_access_restriction() {
         let access = mold_core::model_access_capabilities();
-        assert!(access
-            .restrictions
-            .iter()
-            .any(|restriction| restriction.family == mold_core::minimax_h3::FAMILY));
+        assert!(access.restrictions.is_empty());
     }
 
     /// #787: an absent negative on a wan request materializes the tuned

--- a/crates/mold-server/src/routes_test.rs
+++ b/crates/mold-server/src/routes_test.rs
@@ -3934,7 +3934,7 @@ mod tests {
     /// Clients feature-detect server-side catalog sorting against this
     /// advertisement — older servers omit the field entirely.
     #[tokio::test]
-    async fn capabilities_reports_catalog_sort_vocabulary_and_h3_model_access_restriction() {
+    async fn capabilities_reports_catalog_sort_vocabulary_without_h3_access_restriction() {
         let app = app_empty();
         let resp = app
             .oneshot(
@@ -3953,14 +3953,7 @@ mod tests {
         assert!(body["catalog"]["families"]
             .as_array()
             .is_some_and(|families| families.iter().any(|family| family == "minimax-h3")));
-        assert_eq!(
-            body["model_access"]["restrictions"][0]["code"],
-            mold_core::MINIMAX_H3_AUTHORIZATION_REQUIRED
-        );
-        assert_eq!(
-            body["model_access"]["restrictions"][0]["family"],
-            "minimax-h3"
-        );
+        assert_eq!(body["model_access"]["restrictions"], serde_json::json!([]));
     }
 
     /// Poll the registry until the submitted job shows up (the generate

--- a/crates/mold-server/tests/catalog_routes.rs
+++ b/crates/mold-server/tests/catalog_routes.rs
@@ -52,14 +52,8 @@ async fn capabilities_includes_catalog_block() {
         .unwrap()
         .iter()
         .any(|family| family == "minimax-h3"));
-    // Catalog acquisition is public while runtime access remains an
-    // independently enforced capability.
-    assert!(v["model_access"]["restrictions"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .any(|restriction| {
-            restriction["family"] == "minimax-h3"
-                && restriction["code"] == mold_core::MINIMAX_H3_AUTHORIZATION_REQUIRED
-        }));
+    // The reviewed compact H3 rows are ordinary model identities. Execution
+    // availability is advertised by the task/backend capability instead of a
+    // family-wide licensing restriction.
+    assert_eq!(v["model_access"]["restrictions"], serde_json::json!([]));
 }


### PR DESCRIPTION
## Summary
- treat the two reviewed compact MiniMax H3 manifest IDs as ordinary model identities on every build
- remove the family-wide licensing restriction from server capabilities
- keep exact H3 rows visible and downloadable even when the host cannot execute them
- preserve fail-closed rejection for arbitrary raw H3 repositories, aliases, and manifests

## Verification
- `cargo test -p mold-ai-core model_policy::tests`
- `cargo test -p mold-ai --bin mold h3_remote_auto_pull_respects_compiled_activation_policy`
- `cargo test -p mold-ai-server h3` (101 passed)
- `cargo test -p mold-ai-server --test catalog_routes capabilities_includes_catalog_block`
- `cargo clippy -p mold-ai-core -p mold-ai-server -p mold-ai --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`