### PR TITLE
fix(studio): correct MiniMax H3 authoring parity

### DIFF
--- a/crates/mold-server/src/h3_private_bridge.rs
+++ b/crates/mold-server/src/h3_private_bridge.rs
@@ -533,9 +533,7 @@ fn build_fl2va_capability(models_root: &std::path::Path) -> Option<mold_core::Mi
 
 #[cfg(any(test, feature = "h3", feature = "h3-private-uat"))]
 fn reviewed_h3_private_generation_profile() -> Option<(mold_core::GenerationProfileSet, u32, u64)> {
-    use mold_core::generation_profile::{
-        AspectGroup, ControlMode, FpsControl, ResolutionDomain, ResolutionPreset,
-    };
+    use mold_core::generation_profile::{ControlMode, FpsControl, ResolutionDomain};
 
     let width = mold_core::minimax_h3::DEFAULT_WIDTH;
     let height = mold_core::minimax_h3::DEFAULT_HEIGHT;
@@ -568,16 +566,28 @@ fn reviewed_h3_private_generation_profile() -> Option<(mold_core::GenerationProf
     recipe.resolution.max_axis_pixels = Some(width.max(height));
     recipe.resolution.min_aspect_ratio = Some(aspect);
     recipe.resolution.max_aspect_ratio = Some(aspect);
-    recipe.resolution.aspect_groups = vec![AspectGroup {
-        id: "reviewed-landscape".into(),
-        label: "Reviewed landscape".into(),
-        presets: vec![ResolutionPreset {
-            id: format!("{width}x{height}"),
-            width,
-            height,
-            tier: "reviewed".into(),
-        }],
-    }];
+    // Keep the generated profile's canonical reduced-ratio identity (`7:4`).
+    // Create surfaces render this label inside a compact aspect chip; replacing
+    // it with prose here made one server-only presentation fork wrap outside
+    // the control even though every surface already shares the profile.
+    let mut reviewed_group = recipe
+        .resolution
+        .aspect_groups
+        .iter()
+        .find(|group| {
+            group
+                .presets
+                .iter()
+                .any(|preset| preset.width == width && preset.height == height)
+        })?
+        .clone();
+    reviewed_group
+        .presets
+        .retain(|preset| preset.width == width && preset.height == height);
+    for preset in &mut reviewed_group.presets {
+        preset.tier = "reviewed".into();
+    }
+    recipe.resolution.aspect_groups = vec![reviewed_group];
     recipe.steps.default = steps;
     recipe.steps.min = steps;
     recipe.steps.max = steps;
@@ -666,9 +676,9 @@ pub(crate) fn authenticated_h3_private_model_row(
             size_gb: disk_usage_bytes as f32 / 1_000_000_000.0,
             is_loaded: false,
             last_used: None,
-            // Acquisition is represented by the registered public manifest;
-            // this installed runtime row must not introduce another recipe.
-            hf_repo: String::new(),
+            // The row remains the sole executable recipe, while its acquisition
+            // provenance is the same pinned Hugging Face repo as the manifest.
+            hf_repo: mold_core::minimax_h3::COMFY_REPO.into(),
         },
         defaults: mold_core::ModelDefaults {
             default_steps: request.steps,
@@ -1452,6 +1462,31 @@ fn validate_private_h3_live_owner_route(
     Ok(())
 }
 
+#[cfg(test)]
+mod presentation_tests {
+    #[test]
+    fn reviewed_profile_keeps_the_canonical_exact_aspect_identity() {
+        let (profile, _, _) = super::reviewed_h3_private_generation_profile()
+            .expect("the reviewed H3 profile must resolve");
+        let recipe = profile.default_recipe().expect("one reviewed recipe");
+        let group = recipe
+            .resolution
+            .aspect_groups
+            .first()
+            .expect("one reviewed aspect group");
+
+        assert_eq!(recipe.resolution.aspect_groups.len(), 1);
+        assert_eq!(group.id, "7:4");
+        assert_eq!(group.label, "7:4");
+        assert_eq!(group.presets.len(), 1);
+        assert_eq!(
+            (group.presets[0].width, group.presets[0].height),
+            (1344, 768)
+        );
+        assert_eq!(group.presets[0].tier, "reviewed");
+    }
+}
+
 #[cfg(all(test, any(feature = "h3", feature = "h3-private-uat")))]
 mod tests {
     use std::fs::{self, OpenOptions};
@@ -1537,7 +1572,7 @@ mod tests {
         assert_eq!(row.info.name, mold_core::minimax_h3::FL2VA_COMFY);
         assert_eq!(row.info.family, mold_core::minimax_h3::FAMILY);
         assert!(row.downloaded);
-        assert_eq!(row.info.hf_repo, "");
+        assert_eq!(row.info.hf_repo, mold_core::minimax_h3::COMFY_REPO);
         assert_eq!(row.defaults.default_width, 1344);
         assert_eq!(row.defaults.default_height, 768);
         assert_eq!(row.defaults.default_frames, Some(124));
@@ -1563,6 +1598,14 @@ mod tests {
             mold_core::generation_profile::ResolutionDomain::Buckets
         );
         assert_eq!(recipe.resolution.aspect_groups[0].presets.len(), 1);
+        assert_eq!(recipe.resolution.aspect_groups[0].id, "7:4");
+        assert_eq!(recipe.resolution.aspect_groups[0].label, "7:4");
+        assert_eq!(recipe.resolution.aspect_groups[0].presets[0].width, 1344);
+        assert_eq!(recipe.resolution.aspect_groups[0].presets[0].height, 768);
+        assert_eq!(
+            recipe.resolution.aspect_groups[0].presets[0].tier,
+            "reviewed"
+        );
         assert_eq!(recipe.steps.min, 21);
         assert_eq!(recipe.steps.max, 21);
         assert_eq!(

--- a/desktop/src/components/create/AdvancedSettings.test.ts
+++ b/desktop/src/components/create/AdvancedSettings.test.ts
@@ -484,6 +484,38 @@ describe("AdvancedSettings — video (LTX-2)", () => {
     expect(form.keyframes[0]!.frame).toBe(0);
   });
 
+  it("uses the existing upload and gallery picker for an H3 first frame", async () => {
+    const form = formFor("minimax-h3");
+    form.model = "minimax-h3-fl2va:comfy-pruned-int8";
+    const wrapper = mountSettings(form, {
+      selectedModel: {
+        name: form.model,
+        family: form.family,
+        source_image: "required",
+      } as ModelEntry,
+    });
+
+    await wrapper.get("[data-test='h3-first-picker']").trigger("click");
+    const picker = wrapper
+      .findAllComponents(ImagePickerModal)
+      .find((candidate) => candidate.props("title") === "First frame");
+    if (!picker) throw new Error("H3 first-frame picker not found");
+    expect(picker.props("open")).toBe(true);
+    picker.vm.$emit("pick", [
+      {
+        filename: "opening.png",
+        base64: "iVBORw0KGgoAAAANSUhEUgAAAAcAAAAECAIAAAAmkwkpAAAAAElFTkSuQmCC",
+      },
+    ]);
+    await flushPromises();
+
+    expect(form.h3Authoring?.firstFrame).toMatchObject({
+      filename: "opening.png",
+      width: 7,
+      height: 4,
+    });
+  });
+
   it("shows the chained-clips cue when frames exceed one clip for a chainable model", async () => {
     const form = formFor("ltx2");
     form.model = "ltx-2.3-22b-distilled:fp8";

--- a/desktop/src/components/create/AdvancedSettings.vue
+++ b/desktop/src/components/create/AdvancedSettings.vue
@@ -97,6 +97,7 @@ import {
   emptyMinimaxH3AuthoringState,
   isMinimaxH3Identity,
   minimaxH3TaskForModel,
+  setMinimaxH3PickedImageFirstFrame,
   type MinimaxH3AuthoringState,
 } from "@studio/lib/minimaxH3Authoring";
 
@@ -146,6 +147,19 @@ const h3Family = computed(() => isMinimaxH3Identity(props.form.family, props.for
 const h3Authoring = computed(() => props.form.h3Authoring ?? emptyMinimaxH3AuthoringState());
 function setH3Authoring(value: MinimaxH3AuthoringState): void {
   props.form.h3Authoring = value;
+}
+const h3FirstFramePickerOpen = ref(false);
+const h3FirstFramePickerError = ref<string | null>(null);
+function onH3FirstFramePicked(images: PickedImage[]): void {
+  const image = images[0];
+  if (!image) return;
+  const result = setMinimaxH3PickedImageFirstFrame(props.form.h3Authoring, image);
+  if (!result.ok) {
+    h3FirstFramePickerError.value = result.error;
+    return;
+  }
+  h3FirstFramePickerError.value = null;
+  props.form.h3Authoring = result.state;
 }
 
 // ── Scheduler & sampling ─────────────────────────────────────────────────────
@@ -664,6 +678,17 @@ function reset() {
           :task="h3Task"
           :required-endpoint="caps.requiresSourceImage ? 'first' : null"
           @update:model-value="setH3Authoring"
+          @request-first-frame="h3FirstFramePickerOpen = true"
+        />
+        <p v-if="h3FirstFramePickerError" class="ms-hint text-stop" role="alert">
+          {{ h3FirstFramePickerError }}
+        </p>
+        <ImagePickerModal
+          :open="h3FirstFramePickerOpen"
+          title="First frame"
+          :multiple="false"
+          @pick="onH3FirstFramePicked"
+          @close="h3FirstFramePickerOpen = false"
         />
       </AccordionSection>
 

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -4123,6 +4123,44 @@ describe("MobileApp wan source conditioning", () => {
     await flushPromises();
   }
 
+  it("shows the H3 first-frame blocker before prompt entry and clears it after picking", async () => {
+    const h3Model: ModelEntry = {
+      ...wanModel,
+      name: "minimax-h3-fl2va:comfy-pruned-int8",
+      family: "minimax-h3",
+      hf_repo: "Comfy-Org/MiniMax-H3",
+      default_steps: 21,
+      default_guidance: 0,
+      default_width: 1344,
+      default_height: 768,
+      default_frames: 124,
+      default_fps: 24,
+      source_image: "required",
+    };
+    serveWan(h3Model);
+    wrapper = mountMobileApp();
+    await flushPromises();
+
+    expect(wrapper.get("[data-test='mobile-h3-authoring-error']").text()).toContain(
+      "requires a first frame",
+    );
+    expect(wrapper.get("[data-test='mobile-develop-button']").attributes()).toHaveProperty(
+      "disabled",
+    );
+
+    await wrapper.get("[data-test='mobile-open-advanced']").trigger("click");
+    await flushPromises();
+    await pickInto(
+      "First frame",
+      "opening.png",
+      "iVBORw0KGgoAAAANSUhEUgAAAAcAAAAECAIAAAAmkwkpAAAAAElFTkSuQmCC",
+    );
+    expect(wrapper.find("[data-test='mobile-h3-authoring-error']").exists()).toBe(false);
+    expect(wrapper.get("[data-test='mobile-develop-button']").attributes()).toHaveProperty(
+      "disabled",
+    );
+  });
+
   it("keeps the well and offers no end frame when the host advertises no contract", async () => {
     serveWan(wanModel);
     wrapper = mountMobileApp();

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -735,8 +735,7 @@ const h3AuthoringError = computed(() =>
     form.family,
     form.model,
     form.h3Authoring,
-    effectiveGenerationRecipe(selectedGenerationModel.value, form.pipeline)?.capabilities
-      .source_image === "required",
+    caps.value.requiresSourceImage,
   ),
 );
 const effectiveBatchSize = computed(() =>
@@ -4912,6 +4911,7 @@ onBeforeUnmount(() => {
             >
               <MobileGenerateParameters
                 :form="form"
+                :target="selectedTarget"
                 :upscalers="upscalers"
                 :selected-model="selectedGenerationModel"
                 :audio-output-supported="selectedGenerationModel?.supports_audio !== false"

--- a/desktop/src/mobile/MobileGenerateParameters.test.ts
+++ b/desktop/src/mobile/MobileGenerateParameters.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import { buildRequest, newGenerateForm, type GenerateForm } from "../lib/generateForm";
 import type { Ltx2CameraControlInfo, Ltx2ControlAdapterInfo, ModelEntry } from "../lib/api/types";
 import MobileGenerateParameters from "./MobileGenerateParameters.vue";
+import MobileImagePickerSheet from "./MobileImagePickerSheet.vue";
 
 const { fileToBase64 } = vi.hoisted(() => ({ fileToBase64: vi.fn() }));
 
@@ -72,6 +73,38 @@ async function attachFile(wrapper: VueWrapper, selector: string, file: File): Pr
 }
 
 describe("MobileGenerateParameters", () => {
+  it("reuses the mobile local/gallery picker for the required H3 first frame", async () => {
+    const model = {
+      name: "minimax-h3-fl2va:comfy-pruned-int8",
+      family: "minimax-h3",
+      source_image: "required",
+    } as ModelEntry;
+    const { wrapper, form } = mountParameters(
+      formFor(model.family, model.name),
+      [],
+      true,
+      [],
+      [],
+      model,
+    );
+
+    expect(wrapper.find("[data-test='h3-first-file']").exists()).toBe(false);
+    await wrapper.get("[data-test='h3-first-picker']").trigger("click");
+    const picker = wrapper.getComponent(MobileImagePickerSheet);
+    expect(picker.props("open")).toBe(true);
+    picker.vm.$emit("pick", {
+      filename: "opening.png",
+      base64: "iVBORw0KGgoAAAANSUhEUgAAAAcAAAAECAIAAAAmkwkpAAAAAElFTkSuQmCC",
+    });
+    await flushPromises();
+
+    expect(form.h3Authoring?.firstFrame).toMatchObject({
+      filename: "opening.png",
+      width: 7,
+      height: 4,
+    });
+  });
+
   it("resets model-owned controls when the recipe changes", async () => {
     const model = {
       name: "ltx2:test",

--- a/desktop/src/mobile/MobileGenerateParameters.vue
+++ b/desktop/src/mobile/MobileGenerateParameters.vue
@@ -9,6 +9,7 @@ import type {
   Ltx2TemporalUpscale,
   ModelEntry,
 } from "../lib/api/types";
+import type { ApiTarget } from "../lib/api/client";
 import { generationCapabilitiesForFamily, MAX_LORA_STACK } from "../lib/capabilities";
 import {
   clampVideoFrames,
@@ -78,10 +79,12 @@ import {
   pipelineForControlId,
 } from "@studio/lib/ltx2Control";
 import MinimaxH3AuthoringPanel from "@studio/components/MinimaxH3AuthoringPanel.vue";
+import MobileImagePickerSheet, { type MobilePickedImage } from "./MobileImagePickerSheet.vue";
 import {
   emptyMinimaxH3AuthoringState,
   isMinimaxH3Identity,
   minimaxH3TaskForModel,
+  setMinimaxH3PickedImageFirstFrame,
   type MinimaxH3AuthoringState,
 } from "@studio/lib/minimaxH3Authoring";
 
@@ -90,6 +93,7 @@ const props = withDefaults(
     form: GenerateForm;
     /** Selected model row; carries the continuation capability. */
     selectedModel?: ModelEntry | null;
+    target?: ApiTarget | null;
     upscalers?: ModelEntry[];
     audioOutputSupported?: boolean;
     controlAdapters?: Ltx2ControlAdapterInfo[];
@@ -99,6 +103,7 @@ const props = withDefaults(
   }>(),
   {
     selectedModel: null,
+    target: null,
     upscalers: () => [],
     audioOutputSupported: true,
     controlAdapters: () => [],
@@ -130,6 +135,24 @@ const h3Family = computed(() => isMinimaxH3Identity(props.form.family, props.for
 const h3Authoring = computed(() => props.form.h3Authoring ?? emptyMinimaxH3AuthoringState());
 function setH3Authoring(value: MinimaxH3AuthoringState): void {
   props.form.h3Authoring = value;
+}
+const h3FirstFramePickerOpen = ref(false);
+const h3FirstFramePickerError = ref<string | null>(null);
+const h3FirstFramePickerMaxBytes = computed(() =>
+  Math.max(
+    0,
+    MAX_MOBILE_GENERATION_REQUEST_MEDIA_BYTES -
+      inlineGenerationMediaBytes(props.form, "h3FirstFrame"),
+  ),
+);
+function onH3FirstFramePicked(image: MobilePickedImage): void {
+  const result = setMinimaxH3PickedImageFirstFrame(props.form.h3Authoring, image);
+  if (!result.ok) {
+    h3FirstFramePickerError.value = result.error;
+    return;
+  }
+  h3FirstFramePickerError.value = null;
+  props.form.h3Authoring = result.state;
 }
 const videoContract = computed(() => props.selectedModel ?? { family: props.form.family });
 const frameGridLabel = computed(() => videoFrameGridLabel(videoContract.value));
@@ -743,6 +766,19 @@ const fpsErrorId = `mobile-fps-error-${useId()}`;
         :required-endpoint="caps.requiresSourceImage ? 'first' : null"
         touch-friendly
         @update:model-value="setH3Authoring"
+        @request-first-frame="h3FirstFramePickerOpen = true"
+      />
+      <p v-if="h3FirstFramePickerError" class="mobile-generate-validation" role="alert">
+        {{ h3FirstFramePickerError }}
+      </p>
+      <MobileImagePickerSheet
+        :open="h3FirstFramePickerOpen"
+        :target="target"
+        title="First frame"
+        :max-bytes="h3FirstFramePickerMaxBytes"
+        oversize-message="Combined generation media must be 45 MiB or smaller on iPhone."
+        @pick="onH3FirstFramePicked"
+        @close="h3FirstFramePickerOpen = false"
       />
     </fieldset>
 

--- a/desktop/src/views/GenerateView.sourceConditioning.test.ts
+++ b/desktop/src/views/GenerateView.sourceConditioning.test.ts
@@ -16,6 +16,7 @@ import { useComposerStore } from "../stores/composer";
 import { useToastStore } from "../stores/toasts";
 import { useUiStore } from "../stores/ui";
 import type { ModelEntry, OutputMetadata } from "../lib/api/types";
+import ComposerCard from "../components/create/ComposerCard.vue";
 
 vi.mock("vue-router", () => ({
   useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
@@ -139,6 +140,34 @@ describe("GenerateView source-conditioning gating (#772, #779)", () => {
     useUiStore().generateTick++;
     await flushPromises();
     expect(submitBatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the required H3 first frame before the user starts typing", async () => {
+    const model = {
+      ...wanModel("minimax-h3-fl2va:comfy-pruned-int8", "required"),
+      family: "minimax-h3",
+      default_width: 1344,
+      default_height: 768,
+      default_steps: 21,
+      default_frames: 124,
+      default_fps: 24,
+    } as ModelEntry;
+    useModelStore().all = [model];
+    const wrapper = mount(GenerateView, {
+      shallow: true,
+      attachTo: document.body,
+    });
+    await flushPromises();
+    const form = useGenerateFormStore().form;
+    form.prompt = "";
+    form.model = model.name;
+    form.family = model.family;
+    form.sourceImageCapability = "required";
+    await flushPromises();
+
+    expect(wrapper.getComponent(ComposerCard).props("disabledReason")).toBe(
+      "This reviewed MiniMax H3 runtime requires a first frame.",
+    );
   });
 
   it("blocks an end-frame-only draft until a first frame joins it", async () => {

--- a/desktop/src/views/GenerateView.vue
+++ b/desktop/src/views/GenerateView.vue
@@ -2390,7 +2390,9 @@ const promptMissing = computed(() => promptRequired(form) && !form.prompt.trim()
 const h3RequireFirstFrame = computed(
   () =>
     effectiveGenerationRecipe(selectedEntry.value, form.pipeline)?.capabilities.source_image ===
-    "required",
+      "required" ||
+    selectedEntry.value?.source_image === "required" ||
+    form.sourceImageCapability === "required",
 );
 const h3AuthoringError = computed(() =>
   minimaxH3AuthoringError(form.family, form.model, form.h3Authoring, h3RequireFirstFrame.value),
@@ -2402,8 +2404,11 @@ const h3AuthoringError = computed(() =>
  * conditions the user can correct or explicitly resolve.
  */
 const generationInputBlockerReason = computed<string | null>(() => {
-  if (promptMissing.value) return "Add a prompt before generating.";
+  // Required media is the first actionable step for a conditioned model. The
+  // ordinary empty-prompt blocker stays visually quiet, but must not hide the
+  // H3 opening-frame correction until the user starts typing.
   if (h3AuthoringError.value) return h3AuthoringError.value;
+  if (promptMissing.value) return "Add a prompt before generating.";
   if (!form.model) return "Choose an installed model before generating.";
   if (chainValidationError.value) return chainValidationError.value;
   if (quickStaleReasons.value.length > 0) {
@@ -2414,7 +2419,7 @@ const generationInputBlockerReason = computed<string | null>(() => {
 });
 
 const composerBlockerReason = computed<string | null>(() => {
-  if (promptMissing.value) return null;
+  if (promptMissing.value && !h3AuthoringError.value) return null;
   if (generationInputBlockerReason.value) return generationInputBlockerReason.value;
   if (preparedBatch.value) {
     return "Use the reviewed variations panel to generate this prepared batch, or discard it to return to one-shot generation.";

--- a/studio/components/MinimaxH3AuthoringPanel.test.ts
+++ b/studio/components/MinimaxH3AuthoringPanel.test.ts
@@ -81,6 +81,20 @@ describe("MinimaxH3AuthoringPanel", () => {
     expect(wrapper.find("[data-test='h3-last-file']").exists()).toBe(false);
   });
 
+  it("delegates the opening frame to a surface's upload and gallery picker", async () => {
+    const wrapper = mount(MinimaxH3AuthoringPanel, {
+      props: {
+        modelValue: emptyMinimaxH3AuthoringState(),
+        task: "fl2va",
+        requiredEndpoint: "first",
+      },
+    });
+
+    expect(wrapper.find("[data-test='h3-first-file']").exists()).toBe(false);
+    await wrapper.get("[data-test='h3-first-picker']").trigger("click");
+    expect(wrapper.emitted("request-first-frame")).toHaveLength(1);
+  });
+
   it("keeps an incompatible restored last frame removable", () => {
     const restored = emptyMinimaxH3AuthoringState();
     restored.lastFrame = {

--- a/studio/components/MinimaxH3AuthoringPanel.vue
+++ b/studio/components/MinimaxH3AuthoringPanel.vue
@@ -32,11 +32,16 @@ const props = withDefaults(
     disabled?: boolean;
     touchFriendly?: boolean;
   }>(),
-  { requiredEndpoint: null, disabled: false, touchFriendly: false },
+  {
+    requiredEndpoint: null,
+    disabled: false,
+    touchFriendly: false,
+  },
 );
 
 const emit = defineEmits<{
   "update:modelValue": [state: MinimaxH3AuthoringState];
+  "request-first-frame": [];
 }>();
 
 const error = ref("");
@@ -332,13 +337,18 @@ function durationLabel(
             modelValue.firstFrame?.filename ??
             (requiredEndpoint === "first" ? "Required" : "Optional")
           }}</small>
-          <input
-            type="file"
-            accept="image/*"
+          <button
+            type="button"
             :disabled="disabled || busy"
-            data-test="h3-first-file"
-            @change="pickBoundary('firstFrame', $event)"
-          />
+            data-test="h3-first-picker"
+            @click="emit('request-first-frame')"
+          >
+            {{
+              modelValue.firstFrame
+                ? "Replace first frame"
+                : "Choose first frame"
+            }}
+          </button>
           <button
             v-if="modelValue.firstFrame"
             type="button"

--- a/studio/lib/minimaxH3Authoring.test.ts
+++ b/studio/lib/minimaxH3Authoring.test.ts
@@ -21,6 +21,7 @@ import {
   moveMinimaxH3Reference,
   serializeMinimaxH3Authoring,
   setMinimaxH3GalleryImageFirstFrame,
+  setMinimaxH3PickedImageFirstFrame,
 } from "./minimaxH3Authoring";
 
 const image = (name: string): GenerationReference => ({
@@ -77,6 +78,24 @@ describe("MiniMax H3 Studio authority", () => {
       MINIMAX_H3_REF2VA_COMFY,
     );
     expect(canonicalMinimaxH3ModelName("minimax-h3-ref2va:future")).toBeNull();
+  });
+
+  it("normalizes an existing surface-picker image into the FL2VA first-frame authority", () => {
+    const png = "iVBORw0KGgoAAAANSUhEUgAAAAcAAAAECAIAAAAmkwkpAAAAAElFTkSuQmCC";
+    const result = setMinimaxH3PickedImageFirstFrame(null, {
+      filename: "opening.png",
+      base64: png,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.state.firstFrame).toMatchObject({
+      filename: "opening.png",
+      mimeType: "image/png",
+      width: 7,
+      height: 4,
+      data: png,
+    });
   });
 
   it.each([

--- a/studio/lib/minimaxH3Authoring.ts
+++ b/studio/lib/minimaxH3Authoring.ts
@@ -6,6 +6,7 @@ import {
   isModelAccessRestricted,
   type ModelAccessCapabilityRecord,
 } from "./modelAccess";
+import { imageDimensionsFromBase64 } from "./imageDimensions";
 
 export const MINIMAX_H3_FIXED_FPS = 24;
 export const MINIMAX_H3_MIN_FRAMES = 124;
@@ -173,6 +174,17 @@ export interface MinimaxH3GalleryImageSource {
   sha256?: string | null;
 }
 
+/** Surface-picker shape shared by desktop, web, and iPhone. Their established
+ * pickers all return base64 + a filename, while dimensions and MIME may be
+ * present when the picker already knows them. */
+export interface MinimaxH3PickedImageSource {
+  filename: string;
+  base64: string;
+  mimeType?: string | null;
+  width?: number | null;
+  height?: number | null;
+}
+
 export type MinimaxH3GalleryImageResult =
   | {
       ok: true;
@@ -271,6 +283,31 @@ export function setMinimaxH3GalleryImageFirstFrame(
     },
     reference: null,
   };
+}
+
+/** Normalize an image from any existing surface picker into the one FL2VA
+ * boundary contract. This replaces three H3-only file readers without making
+ * the shared authoring state depend on a desktop, web, or native picker type. */
+export function setMinimaxH3PickedImageFirstFrame(
+  state: MinimaxH3AuthoringState | null | undefined,
+  image: MinimaxH3PickedImageSource,
+): MinimaxH3GalleryImageResult {
+  const decoded = imageDimensionsFromBase64(image.base64);
+  const width = image.width ?? decoded?.width ?? 0;
+  const height = image.height ?? decoded?.height ?? 0;
+  const extension = image.filename.trim().toLowerCase();
+  const mimeType =
+    image.mimeType?.split(";", 1)[0]?.trim().toLowerCase() ||
+    (extension.endsWith(".jpg") || extension.endsWith(".jpeg")
+      ? "image/jpeg"
+      : "image/png");
+  return setMinimaxH3GalleryImageFirstFrame(state, {
+    filename: image.filename,
+    mimeType,
+    width,
+    height,
+    data: image.base64,
+  });
 }
 
 export function cloneMinimaxH3AuthoringState(

--- a/web/src/components/create/AdvancedDrawer.test.ts
+++ b/web/src/components/create/AdvancedDrawer.test.ts
@@ -76,6 +76,24 @@ function factory(
 }
 
 describe("AdvancedDrawer sequence contract", () => {
+  it("delegates the H3 opening frame to the page's existing upload/gallery picker", async () => {
+    const model = {
+      name: "minimax-h3-fl2va:comfy-pruned-int8",
+      family: "minimax-h3",
+      source_image: "required",
+      downloaded: true,
+    } as ModelInfoExtended;
+    const wrapper = factory(
+      model.family,
+      { model: model.name, modelFamily: model.family },
+      { models: [model] },
+    );
+
+    expect(wrapper.find("[data-test='h3-first-file']").exists()).toBe(false);
+    await wrapper.get("[data-test='h3-first-picker']").trigger("click");
+    expect(wrapper.emitted("open-h3-first-frame-picker")).toHaveLength(1);
+  });
+
   it("preserves but disables clip negatives for a distilled recipe", () => {
     const wrapper = factory(
       "ltx2",

--- a/web/src/components/create/AdvancedDrawer.vue
+++ b/web/src/components/create/AdvancedDrawer.vue
@@ -128,6 +128,7 @@ const emit = defineEmits<{
   "update:modelValue": [value: GenerateFormState];
   close: [];
   "open-picker": [];
+  "open-h3-first-frame-picker": [];
   "clear-source": [];
   /** Wan first/last-frame conditioning (#779). The closing still gets its own
    * picker so it can never overwrite the opening one. */
@@ -815,6 +816,7 @@ function setSequenceCameraMode(mode: string) {
             :task="h3Task"
             :required-endpoint="caps.requiresSourceImage ? 'first' : null"
             @update:model-value="setH3Authoring"
+            @request-first-frame="emit('open-h3-first-frame-picker')"
           />
         </AccordionSection>
 

--- a/web/src/components/create/ComposerCard.test.ts
+++ b/web/src/components/create/ComposerCard.test.ts
@@ -73,6 +73,22 @@ describe("ComposerCard", () => {
     expect(wrapper.emitted("submit")).toBeUndefined();
   });
 
+  it("shows an actionable prerequisite and disables Generate", async () => {
+    const wrapper = factory({
+      disabledReason:
+        "This reviewed MiniMax H3 runtime requires a first frame.",
+    });
+
+    expect(wrapper.text()).toContain("requires a first frame");
+    expect(
+      wrapper.get("[data-test='composer-submit']").attributes("disabled"),
+    ).toBeDefined();
+    await wrapper
+      .get("[data-test='composer-prompt']")
+      .trigger("keydown", { key: "Enter", metaKey: true });
+    expect(wrapper.emitted("submit")).toBeUndefined();
+  });
+
   it("emits the prompt on input without touching style", async () => {
     const wrapper = factory();
     const ta = wrapper.get("[data-test='composer-prompt']")

--- a/web/src/components/create/ComposerCard.vue
+++ b/web/src/components/create/ComposerCard.vue
@@ -11,6 +11,7 @@ import { computed, nextTick, ref, watch } from "vue";
 import Chip from "@ui/components/Chip.vue";
 import Icon from "@ui/components/Icon.vue";
 import Keycap from "@ui/components/Keycap.vue";
+import ActionBlocker from "@ui/components/ActionBlocker.vue";
 import { STYLE_PRESETS, stylePresetById } from "../../lib/stylePresets";
 import {
   PromptCycler,
@@ -35,6 +36,8 @@ const props = withDefaults(
     expanded?: boolean;
     /** Disable submit/expand (e.g. a job is mid-flight). */
     busy?: boolean;
+    /** Actionable request prerequisite shown beside Generate. */
+    disabledReason?: string | null;
     /** The visual conditioning lets this render go out undescribed. */
     promptOptional?: boolean;
     /** Model-specific required-prompt wording. */
@@ -45,6 +48,7 @@ const props = withDefaults(
   {
     expanded: false,
     busy: false,
+    disabledReason: null,
     promptOptional: false,
     requiredPlaceholder: "Describe the image you want to create…",
     history: () => [],
@@ -80,6 +84,9 @@ const placeholder = computed(() =>
 const expandLabel = computed(() =>
   props.batchSize > 1 ? `Expand to ${props.batchSize}` : "Expand prompt",
 );
+const generateDisabled = computed(
+  () => props.busy || Boolean(props.disabledReason),
+);
 
 // Shell-style ↑/↓ prompt-history recall. The cycler is fed the latest history
 // and gated on caret line so ↑/↓ still move the caret within a multi-line
@@ -99,7 +106,7 @@ function onInput(event: Event) {
 function onKeydown(event: KeyboardEvent) {
   if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
     event.preventDefault();
-    if (!props.busy) emit("submit");
+    if (!generateDisabled.value) emit("submit");
     return;
   }
   const el = event.target as HTMLTextAreaElement;
@@ -236,7 +243,7 @@ watch(
         type="button"
         class="composer__generate"
         data-test="composer-submit"
-        :disabled="busy"
+        :disabled="generateDisabled"
         @click="emit('submit')"
       >
         <Icon name="sparkle" :size="16" :stroke-width="2" />
@@ -244,6 +251,11 @@ watch(
         <Keycap on-accent>⌘<span class="composer__return">↵</span></Keycap>
       </button>
     </div>
+    <ActionBlocker
+      v-if="disabledReason"
+      class="composer__blocker"
+      :reason="disabledReason"
+    />
   </div>
 </template>
 
@@ -312,6 +324,10 @@ watch(
   gap: 14px;
   margin-top: 12px;
   flex-wrap: wrap;
+}
+
+.composer__blocker {
+  margin-top: 12px;
 }
 
 .composer__summary {

--- a/web/src/pages/CreatePage.test.ts
+++ b/web/src/pages/CreatePage.test.ts
@@ -762,6 +762,57 @@ describe("CreatePage layout and behavior", () => {
     expect(wrapper.find("[data-test='cold-start-stub']").exists()).toBe(true);
   });
 
+  it("shows the H3 first-frame blocker before prompt entry", async () => {
+    const h3Model: ModelInfoExtended = {
+      name: "minimax-h3-fl2va:comfy-pruned-int8",
+      family: "minimax-h3",
+      display_name: "MiniMax H3 FL2VA",
+      size_gb: 42.5,
+      is_loaded: false,
+      last_used: null,
+      hf_repo: "Comfy-Org/MiniMax-H3",
+      downloaded: true,
+      default_steps: 21,
+      default_guidance: 0,
+      default_width: 1344,
+      default_height: 768,
+      default_frames: 124,
+      default_fps: 24,
+      description: "Reviewed first-frame H3 runtime",
+      source_image: "required",
+    };
+    hostModelsMock.mockResolvedValue([h3Model]);
+    const wrapper = mount(CreatePage, { global: { stubs: pageStubs() } });
+    await flushPromises();
+    const form = useGenerateForm();
+    form.state.value.model = h3Model.name;
+    form.state.value.modelFamily = h3Model.family;
+    form.state.value.prompt = "";
+    form.state.value.sourceImageCapability = "required";
+    form.state.value.h3Authoring = {
+      firstFrame: null,
+      lastFrame: null,
+      references: [],
+    };
+    await nextTick();
+
+    expect(
+      wrapper.get("[data-test='page-generation-blocker']").text(),
+    ).toContain("requires a first frame");
+
+    form.state.value.h3Authoring.firstFrame = {
+      filename: "opening.png",
+      mimeType: "image/png",
+      width: 1344,
+      height: 768,
+      data: "FIRST",
+    };
+    await nextTick();
+    expect(wrapper.get("[data-test='page-generation-blocker']").text()).toBe(
+      "Add a prompt before generating.",
+    );
+  });
+
   it("blocks non-Qwen mask submissions until a source image is selected", async () => {
     const wrapper = mount(CreatePage, { global: { stubs: pageStubs() } });
     const form = useGenerateForm();
@@ -3325,9 +3376,9 @@ function pageStubs() {
     },
     ComposerCard: {
       name: "ComposerCard",
-      props: ["busy"],
+      props: ["busy", "disabledReason"],
       template:
-        '<div><div data-test="prompt-style-stub"/><slot name="mobile-controls"/><button data-test="composer-submit" @click="$emit(\'submit\')">go</button><button data-test="composer-expand" @click="$emit(\'expand\')">expand</button><button data-test="composer-undo" @click="$emit(\'undo-expand\')">undo</button></div>',
+        '<div><div data-test="prompt-style-stub"/><slot name="mobile-controls"/><p v-if="disabledReason" data-test="page-generation-blocker">{{ disabledReason }}</p><button data-test="composer-submit" @click="$emit(\'submit\')">go</button><button data-test="composer-expand" @click="$emit(\'expand\')">expand</button><button data-test="composer-undo" @click="$emit(\'undo-expand\')">undo</button></div>',
       // The page calls these through its template ref on submit / new-print;
       // a stub without them throws an unhandled TypeError mid-run.
       methods: { record: vi.fn(), focus: vi.fn() },

--- a/web/src/pages/CreatePage.vue
+++ b/web/src/pages/CreatePage.vue
@@ -178,13 +178,14 @@ import {
   serverExtendOverlapDefault,
   submitsExtend,
 } from "@studio/lib/extend";
-import { promptOptional } from "@studio/lib/promptRequirement";
+import { promptOptional, promptRequired } from "@studio/lib/promptRequirement";
 import {
   MINIMAX_H3_PROMPT_PLACEHOLDER,
   emptyMinimaxH3AuthoringState,
   isMinimaxH3Identity,
   minimaxH3AuthoringError,
   minimaxH3TaskForModel,
+  setMinimaxH3PickedImageFirstFrame,
 } from "@studio/lib/minimaxH3Authoring";
 import {
   firstLastFrameRestoreNotice,
@@ -238,6 +239,7 @@ const showRemix = ref(false);
 const remixRoute = ref<HostRoute | null>(null);
 const remixTask = ref<ExpandTask>("text-to-image");
 const showPicker = ref(false);
+const showH3FirstFramePicker = ref(false);
 /** Wan's closing still gets its own picker (#779) so attaching one can never
  * overwrite the opening frame the source well holds. */
 const showEndFramePicker = ref(false);
@@ -1216,6 +1218,29 @@ const capabilities = computed(() =>
     effectiveGenerationRecipe(currentModel.value, form.state.value.pipeline),
   ),
 );
+const h3FrameError = computed(() =>
+  minimaxH3AuthoringError(
+    currentFamily.value,
+    form.state.value.model,
+    form.state.value.h3Authoring,
+    capabilities.value.requiresSourceImage,
+  ),
+);
+const h3GenerationInputBlocker = computed<string | null>(() => {
+  if (h3FrameError.value) return h3FrameError.value;
+  if (
+    isMinimaxH3Identity(currentFamily.value, form.state.value.model) &&
+    promptRequired({
+      family: currentFamily.value,
+      model: form.state.value.model,
+      sourceImage: form.state.value.h3Authoring?.firstFrame,
+    }) &&
+    !form.state.value.prompt.trim()
+  ) {
+    return "Add a prompt before generating.";
+  }
+  return null;
+});
 
 // A conditioned LTX-2 render may go out undescribed — the server admits it,
 // so the composer says so instead of implying a prompt is mandatory. Nothing
@@ -2280,16 +2305,14 @@ function validateSubmit(): boolean {
     composerError.value = "Pick a model to start.";
     return false;
   }
-  const h3Error = minimaxH3AuthoringError(
-    currentFamily.value,
-    form.state.value.model,
-    form.state.value.h3Authoring,
-    effectiveGenerationRecipe(currentModel.value, form.state.value.pipeline)
-      ?.capabilities.source_image === "required",
-  );
+  const h3Error = h3FrameError.value;
   if (h3Error) {
     composerError.value = h3Error;
     showAdvanced.value = true;
+    return false;
+  }
+  if (h3GenerationInputBlocker.value) {
+    composerError.value = h3GenerationInputBlocker.value;
     return false;
   }
   const recipe = effectiveGenerationRecipe(
@@ -3137,6 +3160,27 @@ async function onPickSource(v: SourceImageState[]) {
   composerError.value = null;
 }
 
+function onPickH3FirstFrame(images: SourceImageState[]): void {
+  const image = images[0];
+  if (!image) return;
+  const result = setMinimaxH3PickedImageFirstFrame(
+    form.state.value.h3Authoring,
+    {
+      filename: image.filename,
+      base64: image.base64,
+      mimeType: image.mime,
+      width: image.width,
+      height: image.height,
+    },
+  );
+  if (!result.ok) {
+    composerError.value = result.error;
+    return;
+  }
+  form.state.value.h3Authoring = result.state;
+  composerError.value = null;
+}
+
 async function resolveMaskSourceConflict(): Promise<boolean> {
   const choice = await requestChoice({
     title: "Source image has a mask",
@@ -3725,6 +3769,7 @@ onBeforeUnmount(() => {
             :steps="form.state.value.steps"
             :batch-size="form.state.value.batchSize"
             :busy="ordinarySubmitBlocked"
+            :disabled-reason="h3GenerationInputBlocker"
             :expanded="expanded"
             :prompt-optional="canSkipPrompt"
             :required-placeholder="requiredPromptPlaceholder"
@@ -3942,6 +3987,7 @@ onBeforeUnmount(() => {
             currentFamily === 'ltx2' && currentModel?.supports_audio !== false
           "
           @open-picker="showPicker = true"
+          @open-h3-first-frame-picker="showH3FirstFramePicker = true"
           @clear-source="onClearSource"
           @open-end-frame-picker="showEndFramePicker = true"
           @clear-end-frame="onClearEndFrame"
@@ -3972,6 +4018,7 @@ onBeforeUnmount(() => {
         "
         @close="showAdvanced = false"
         @open-picker="showPicker = true"
+        @open-h3-first-frame-picker="showH3FirstFramePicker = true"
         @clear-source="onClearSource"
         @open-end-frame-picker="showEndFramePicker = true"
         @clear-end-frame="onClearEndFrame"
@@ -4027,6 +4074,13 @@ onBeforeUnmount(() => {
       "
       @pick="onPickSource"
       @close="showPicker = false"
+    />
+    <ImagePickerModal
+      :open="showH3FirstFramePicker"
+      title="First frame"
+      :multiple="false"
+      @pick="onPickH3FirstFrame"
+      @close="showH3FirstFramePicker = false"
     />
     <ImagePickerModal
       :open="showEndFramePicker"


### PR DESCRIPTION
## Summary

- restore the reviewed MiniMax H3 FL2VA profile's canonical 7:4 aspect identity and Hugging Face provenance
- route first-frame selection through each surface's existing upload, drag-and-drop, and gallery picker
- surface the required first-frame blocker before prompt entry while preserving the reviewed prompt-required contract
- add desktop, web, iOS, shared Studio, and server regressions for the cross-surface behavior

## Source of truth

The authenticated H3 model row now retains the canonical exact 1344x768 profile group and reports `Comfy-Org/MiniMax-H3` as its source. The shared authoring panel owns presentation and state only; desktop, web, and iOS own picker UX through their existing components.

## Verification

- `bun run check:frontend`
  - Studio: 627 passed
  - Web: 1,286 passed
  - Desktop: 3,383 passed
  - web and desktop production builds passed
- `bun run build:mobile`
- `nix develop -c cargo fmt --all -- --check`
- `nix develop -c cargo test -p mold-ai-server reviewed_profile_keeps_the_canonical_exact_aspect_identity --no-default-features`
- iOS native simulator build, install, and launch passed
- independent agent peer review completed; its raw-input fallback finding was fixed and the final re-review found no actionable issues

## UAT note

The saved MiniMax H3 / Play-Doh generation host was offline during final live UAT, so no real H3 generation was submitted. Cross-surface interaction behavior is covered by integration tests and all three production builds.
