### PR TITLE
fix(models): clear failed history after successful retry

### DIFF
--- a/crates/mold-server/src/downloads.rs
+++ b/crates/mold-server/src/downloads.rs
@@ -587,6 +587,11 @@ impl DownloadQueue {
     /// the most recent 20.
     pub(crate) fn push_history(&self, job: DownloadJob) {
         let mut history = self.history.lock().expect("history lock poisoned");
+        if job.status == JobStatus::Completed {
+            history.retain(|attempt| {
+                attempt.model != job.model || attempt.status != JobStatus::Failed
+            });
+        }
         if history.len() >= HISTORY_CAP {
             history.pop_front();
         }

--- a/crates/mold-server/src/downloads_test.rs
+++ b/crates/mold-server/src/downloads_test.rs
@@ -59,6 +59,38 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio_util::sync::CancellationToken;
 
+fn settled_job(id: &str, model: &str, status: JobStatus) -> mold_core::types::DownloadJob {
+    mold_core::types::DownloadJob {
+        id: id.into(),
+        model: model.into(),
+        catalog_id: None,
+        status,
+        files_done: 1,
+        files_total: 1,
+        bytes_done: 100,
+        bytes_total: 100,
+        current_file: None,
+        started_at: Some(1),
+        completed_at: Some(2),
+        error: (status == JobStatus::Failed).then(|| "permission denied".into()),
+    }
+}
+
+#[tokio::test]
+async fn completed_retry_retires_the_same_models_failed_history() {
+    let queue = DownloadQueue::new_for_test();
+    queue.push_history(settled_job("other", "z-image:q6", JobStatus::Failed));
+    queue.push_history(settled_job("failed", "minimax-h3:fp8", JobStatus::Failed));
+    queue.push_history(settled_job("retry", "minimax-h3:fp8", JobStatus::Completed));
+
+    let listing = queue.listing().await;
+    assert_eq!(listing.history.len(), 2);
+    assert_eq!(listing.history[0].id, "other");
+    assert_eq!(listing.history[1].id, "retry");
+    assert_eq!(listing.history[1].status, JobStatus::Completed);
+    assert!(listing.history[1].error.is_none());
+}
+
 /// Recipe driver that the manifest-flow tests never invoke. If a test
 /// expects manifest behavior and the queue accidentally takes the recipe
 /// branch, the test sees `Err("noop recipe driver")` rather than silent

--- a/desktop/src/components/models/DownloadsTray.test.ts
+++ b/desktop/src/components/models/DownloadsTray.test.ts
@@ -266,6 +266,23 @@ describe("DownloadsTray a11y", () => {
     expect(list.text()).toContain("connection reset");
   });
 
+  it("replaces a failed attempt with the completed retry in rendered history", async () => {
+    const store = useDownloadsStore();
+    store.apply({ type: "enqueued", id: "first", model: "minimax-h3:fp8", position: 0 });
+    store.apply({ type: "started", id: "first", files_total: 6, bytes_total: 100 });
+    store.apply({ type: "job_failed", id: "first", error: "permission denied" });
+    store.apply({ type: "enqueued", id: "retry", model: "minimax-h3:fp8", position: 0 });
+    store.apply({ type: "started", id: "retry", files_total: 6, bytes_total: 100 });
+    store.apply({ type: "job_done", id: "retry", model: "minimax-h3:fp8" });
+    const wrapper = mount(DownloadsTray);
+
+    expect(wrapper.get('[data-test="history-toggle"]').text()).toContain("History (1)");
+    await wrapper.get('[data-test="history-toggle"]').trigger("click");
+    const statuses = wrapper.findAll('[data-test="history-status"]');
+    expect(statuses.map((status) => status.text())).toEqual(["completed"]);
+    expect(wrapper.text()).not.toContain("permission denied");
+  });
+
   it("retries a failed history job on its own host", async () => {
     const store = useDownloadsStore();
     store.hostStates.hal9000 = {

--- a/desktop/src/lib/downloads.ts
+++ b/desktop/src/lib/downloads.ts
@@ -34,8 +34,14 @@ function finishJob(
     state.queued.find((candidate) => candidate.id === id);
   const activeJobs = state.activeJobs.filter((candidate) => candidate.id !== id);
   const queued = state.queued.filter((candidate) => candidate.id !== id);
+  const priorHistory =
+    job && status === "completed"
+      ? state.history.filter(
+          (attempt) => attempt.model !== job.model || attempt.status !== "failed",
+        )
+      : state.history;
   const history = job
-    ? [{ ...job, status, error: error ?? job.error ?? null }, ...state.history]
+    ? [{ ...job, status, error: error ?? job.error ?? null }, ...priorHistory]
     : state.history;
   return { activeJobs, queued, history };
 }

--- a/desktop/src/stores/downloads.test.ts
+++ b/desktop/src/stores/downloads.test.ts
@@ -142,6 +142,37 @@ describe("applyDownloadEvent", () => {
     expect(s.history[0]!.error).toBe("connection reset");
   });
 
+  it("clears a model's stale failure when its retry completes", () => {
+    const s = reduce([
+      { type: "enqueued", id: "first", model: "minimax-h3:fp8", position: 0 },
+      { type: "started", id: "first", files_total: 6, bytes_total: 100 },
+      { type: "job_failed", id: "first", error: "permission denied" },
+      { type: "enqueued", id: "retry", model: "minimax-h3:fp8", position: 0 },
+      { type: "started", id: "retry", files_total: 6, bytes_total: 100 },
+      { type: "job_done", id: "retry", model: "minimax-h3:fp8" },
+    ]);
+
+    expect(s.history).toHaveLength(1);
+    expect(s.history[0]).toMatchObject({ id: "retry", status: "completed" });
+    expect(s.history[0]!.error).toBeNull();
+  });
+
+  it("keeps failures for other models when a retry completes", () => {
+    const s = reduce([
+      { type: "enqueued", id: "other", model: "z-image:q6", position: 0 },
+      { type: "job_failed", id: "other", error: "disk full" },
+      { type: "enqueued", id: "retry", model: "minimax-h3:fp8", position: 0 },
+      { type: "job_failed", id: "retry", error: "permission denied" },
+      { type: "enqueued", id: "success", model: "minimax-h3:fp8", position: 0 },
+      { type: "job_done", id: "success", model: "minimax-h3:fp8" },
+    ]);
+
+    expect(s.history.map((job) => [job.model, job.status])).toEqual([
+      ["minimax-h3:fp8", "completed"],
+      ["z-image:q6", "failed"],
+    ]);
+  });
+
   it("cancels a queued job into history", () => {
     const s = reduce([
       { type: "snapshot", listing: snapshot },

--- a/web/src/composables/useDownloads.test.ts
+++ b/web/src/composables/useDownloads.test.ts
@@ -234,6 +234,50 @@ describe("applyDownloadEvent", () => {
     expect(state.history.at(-1)?.id).toBe("id-24");
   });
 
+  it("JobDone clears a stale failure for the retried model", () => {
+    const state = newDownloadsState();
+    state.history = [
+      {
+        id: "failed-attempt",
+        model: "minimax-h3:fp8",
+        catalog_id: null,
+        status: "failed",
+        files_done: 4,
+        files_total: 6,
+        bytes_done: 80,
+        bytes_total: 100,
+        current_file: null,
+        started_at: 1,
+        completed_at: 2,
+        error: "permission denied",
+      },
+    ];
+    applyDownloadEvent(state, {
+      type: "enqueued",
+      id: "retry",
+      model: "minimax-h3:fp8",
+      position: 1,
+    });
+    applyDownloadEvent(state, {
+      type: "started",
+      id: "retry",
+      files_total: 6,
+      bytes_total: 100,
+    });
+    applyDownloadEvent(state, {
+      type: "job_done",
+      id: "retry",
+      model: "minimax-h3:fp8",
+    });
+
+    expect(state.history).toHaveLength(1);
+    expect(state.history[0]).toMatchObject({
+      id: "retry",
+      status: "completed",
+      error: null,
+    });
+  });
+
   it("JobCancelled moves a queued job into terminal history", () => {
     const state = newDownloadsState();
     applyDownloadEvent(state, {

--- a/web/src/composables/useDownloads.ts
+++ b/web/src/composables/useDownloads.ts
@@ -133,6 +133,10 @@ export function applyDownloadEvent(
       };
       state.activeJobs = state.activeJobs.filter((job) => job.id !== event.id);
       state.active = state.activeJobs[0] ?? null;
+      state.history = state.history.filter(
+        (attempt) =>
+          attempt.model !== completed.model || attempt.status !== "failed",
+      );
       state.history.push(completed);
       while (state.history.length > HISTORY_CAP) state.history.shift();
       return;


### PR DESCRIPTION
## Summary

- remove stale failed download attempts when a retry of the same model completes successfully
- keep server snapshots and live desktop/mobile/web SSE state consistent
- preserve unrelated failures and completed download history

## Root cause

Download history retained every terminal attempt. A successful retry added a completed row but did not retire the earlier failure, so the Models download tray could show contradictory failed and completed states for the same model, sometimes with the failure above the success.

## Validation

- `nix develop -c cargo test -p mold-ai-server downloads::tests --lib` (31 passed)
- `nix develop -c bun run test -- src/stores/downloads.test.ts src/components/models/DownloadsTray.test.ts` in `desktop/` (43 passed)
- `nix develop -c bun run test -- src/composables/useDownloads.test.ts` in `web/` (16 passed)
- desktop and web production builds
- Rustfmt, Prettier, and `git diff --check`
- independent agent peer review: no actionable findings
