### PR TITLE
fix(nix): accelerate cached deployments

### DIFF
--- a/.github/workflows/nix-cache.yml
+++ b/.github/workflows/nix-cache.yml
@@ -1,0 +1,53 @@
+name: Publish Nix Cache
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+
+concurrency:
+  group: nix-cache-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    # Cache availability is an optimization. This separate best-effort workflow
+    # can never delay or fail rolling nightlies or stable releases.
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Free runner disk space
+        shell: bash
+        run: |
+          set -euxo pipefail
+          sudo rm -rf \
+            /usr/share/dotnet \
+            /usr/local/lib/android \
+            /opt/ghc \
+            /usr/local/.ghcup \
+            /usr/local/share/boost \
+            "$AGENT_TOOLSDIRECTORY"
+          sudo apt-get clean
+          sudo rm -rf /var/lib/apt/lists/*
+          df -h
+
+      - uses: cachix/install-nix-action@v31
+
+      # Pull the exact default sm89 package before building, then push only its
+      # runtime closure. Avoid daemon/store-scan uploads: the public cache is
+      # intentionally scoped to the package consumed by NixOS deployments.
+      - name: Configure Mold binary cache
+        uses: cachix/cachix-action@v17
+        with:
+          name: mold
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          useDaemon: false
+          pathsToPush: result-mold
+
+      - name: Build cacheable default sm89 output
+        run: nix build .#mold --out-link result-mold

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,8 @@ categories = ["command-line-utilities", "multimedia::images", "science"]
 name = "mold"
 
 [profile.release]
-lto = "fat"
-codegen-units = 1
+lto = "thin"
+codegen-units = 16
 strip = true
 
 [profile.dev-fast]

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,13 @@
 {
   description = "mold — local AI image generation CLI for FLUX, SD1.5, SDXL & Z-Image diffusion models";
 
+  nixConfig = {
+    extra-substituters = [ "https://mold.cachix.org" ];
+    extra-trusted-public-keys = [
+      "mold.cachix.org-1:9HBc/bEXDdpbxMjOwpaIDpjZqBh9JYg0h5Fipm+D8m4="
+    ];
+  };
+
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";

--- a/scripts/tests/cuda-distribution-contract.sh
+++ b/scripts/tests/cuda-distribution-contract.sh
@@ -75,6 +75,7 @@ require_release_job_need() {
 }
 
 release=".github/workflows/release.yml"
+cache_workflow=".github/workflows/nix-cache.yml"
 require_text "$release" \
   "MOLD_DISTRIBUTION_IMAGE_VERSION: \${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || 'latest' }}"
 require_text ".github/workflows/desktop-distribution.yml" \
@@ -284,8 +285,26 @@ for target in 80 86 90 100 120; do
 done
 require_release_job_text "docker" 'cuda_cap: "89"'
 require_release_job_text "docker" 'suffix: ""'
+require_ci_release_path "$cache_workflow"
+require_text "$cache_workflow" 'branches: [main]'
+require_text "$cache_workflow" 'tags: ["v*"]'
+require_text "$cache_workflow" 'permissions:'
+require_text "$cache_workflow" 'contents: read'
+require_text "$cache_workflow" 'continue-on-error: true'
+require_text "$cache_workflow" 'uses: cachix/cachix-action@v17'
+require_text "$cache_workflow" 'name: mold'
+require_text "$cache_workflow" 'authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}'
+require_text "$cache_workflow" 'useDaemon: false'
+require_text "$cache_workflow" 'pathsToPush: result-mold'
+require_text "$cache_workflow" 'nix build .#mold --out-link result-mold'
+if grep -Fq 'cachix/cachix-action' "$repo_root/$release"; then
+  fail "$release must not wait for best-effort Cachix publication"
+fi
 require_release_job_text "build-nix-distribution" \
   'nix build .#mold-sm86 .#mold-sm100 .#mold-desktop-sm86 --no-link'
+require_text "flake.nix" 'extra-substituters = [ "https://mold.cachix.org" ];'
+require_text "flake.nix" \
+  '"mold.cachix.org-1:9HBc/bEXDdpbxMjOwpaIDpjZqBh9JYg0h5Fipm+D8m4="'
 require_release_job_need "publish" "release-version"
 require_release_job_text "release-version" \
   'scripts/create-container-digest-manifest.sh'

--- a/website/deployment/nixos.md
+++ b/website/deployment/nixos.md
@@ -28,6 +28,30 @@ Add mold to your flake inputs and import the module:
 }
 ```
 
+## Binary Cache
+
+Direct `nix build github:utensils/mold` commands use Mold's signed public
+binary cache automatically after Nix accepts the flake configuration. When
+Mold is an input of another flake, that input's `nixConfig` is not inherited.
+Configure the consuming NixOS system explicitly so deployments can substitute
+the exact CI-built package instead of compiling Mold locally:
+
+```nix
+{
+  nix.settings = {
+    extra-substituters = [ "https://mold.cachix.org" ];
+    extra-trusted-public-keys = [
+      "mold.cachix.org-1:9HBc/bEXDdpbxMjOwpaIDpjZqBh9JYg0h5Fipm+D8m4="
+    ];
+  };
+}
+```
+
+Only store paths signed by that key are accepted. The cache is an optimization:
+Nix falls back to a local source build when CI has not published the exact
+revision and package variant. CI currently publishes the default Ada/sm89
+package; the other architecture variants fall back to a local build.
+
 ## Minimal Configuration
 
 ```nix


### PR DESCRIPTION
## Summary

- replace fat LTO and one codegen unit with ThinLTO and 16 units to reduce source-build link time
- publish the default sm89 Nix package to the signed public `mold` Cachix cache
- isolate best-effort cache publication in a separate workflow so it cannot delay or fail nightly or stable releases
- document consumer-side NixOS trust configuration and exact cache scope
- guard the release distribution contract against cache workflow regressions

## Security and reliability

- cache token is available only to trusted `main` and `v*` push workflows
- publication pushes only the `result-mold` closure, with daemon/store scanning disabled
- cache failures are non-blocking and independent of the release workflow
- Nix continues to verify the managed Cachix signing key and falls back to source builds

## Validation

- `cargo metadata --no-deps --format-version 1`
- `cargo fmt --all -- --check`
- `bun run --cwd website fmt:check`
- `nix eval --accept-flake-config --no-write-lock-file .#packages.x86_64-linux.mold.drvPath`
- actionlint 1.7.12 on both affected workflows
- YAML parse and `git diff --check`
- independent sub-agent pair review: approved with no actionable findings

The complete CUDA distribution contract reaches its embedded PTX suite locally, which requires Linux `readelf`; the Ubuntu CI gate provides that environment.

Fixes #1053