### PR TITLE
feat(ltx2): typed checkpoint-generation image-preprocessing authority (#1055)

### DIFF
--- a/crates/mold-core/src/lib.rs
+++ b/crates/mold-core/src/lib.rs
@@ -20,6 +20,7 @@ pub mod lambda;
 pub mod ltx2_camera;
 pub use ltx2_camera::{Ltx2CameraControlAvailability, Ltx2CameraControlInfo};
 pub mod ltx2_control;
+pub mod ltx2_preprocess;
 pub use ltx2_control::Ltx2ControlAdapterInfo;
 pub mod manifest;
 pub mod media_paths;

--- a/crates/mold-core/src/ltx2_preprocess.rs
+++ b/crates/mold-core/src/ltx2_preprocess.rs
@@ -1,0 +1,184 @@
+//! LTX-2 checkpoint-generation identity and image-conditioning
+//! preprocessing profiles.
+//!
+//! Upstream LTX-2 re-compresses every still-image conditioning input
+//! through a one-frame H.264/YUV420 round-trip so the tensor the VAE sees
+//! matches the compressed-video-frame distribution the model was trained
+//! on. The compression level is a property of the checkpoint *generation*
+//! (upstream `ltx_pipelines/utils/constants.py`: CRF 33 for LTX-2/2.3,
+//! CRF 18 for the future 2.4), so the profile must be resolved from
+//! authoritative model identity and must fail closed for generations this
+//! build does not know — a guessed CRF silently degrades conditioning.
+//!
+//! This module is the single authority shared by admission, the engine,
+//! and diagnostics; `mold-inference`'s `preset_for_model_with_hint`
+//! delegates its 2.0-vs-2.3 split here (a contract test pins the two
+//! together).
+
+use serde::{Deserialize, Serialize};
+
+/// A known LTX-2 checkpoint generation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Ltx2Generation {
+    /// LTX-2 2.0/2.1/2.2 (the 19B lineage).
+    V2,
+    /// LTX-2.3 (the 22B lineage).
+    V2_3,
+}
+
+impl Ltx2Generation {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::V2 => "LTX-2",
+            Self::V2_3 => "LTX-2.3",
+        }
+    }
+}
+
+/// The still-image conditioning preprocessing contract for a checkpoint
+/// generation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Ltx2ImagePreprocessingProfile {
+    pub generation: Ltx2Generation,
+    /// H.264 compression level the conditioning image is round-tripped
+    /// at, matching upstream's per-generation CRF constant. `0` means
+    /// lossless/no round-trip (upstream parity).
+    pub image_crf: u8,
+}
+
+/// Upstream `DEFAULT_IMAGE_CRF` — LTX-2 and LTX-2.3 were both trained
+/// against CRF 33 conditioning (constants.py:36, 80-88 @ fd4ded7).
+const LTX2_IMAGE_CRF: u8 = 33;
+
+/// Resolve the checkpoint generation from the model name and, failing
+/// that, the safetensors `__metadata__.model_version` header hint.
+///
+/// Returns `None` for anything unrecognised — including a future
+/// `model_version: "2.4.x"`, which upstream maps to CRF 18 but which this
+/// build has no runnable preset for. Callers that need a preprocessing
+/// profile must treat `None` as fail-closed rather than guessing.
+pub fn ltx2_generation(
+    model_name: &str,
+    model_version_hint: Option<&str>,
+) -> Option<Ltx2Generation> {
+    if model_name.contains("ltx-2.3") || model_name.contains("ltx2.3") {
+        return Some(Ltx2Generation::V2_3);
+    }
+    // "ltx-2" followed by ".<digit>" is some *other* generation (2.4, …):
+    // never fold it into V2 by substring accident.
+    if let Some(idx) = model_name.find("ltx-2") {
+        let rest = &model_name[idx + "ltx-2".len()..];
+        let names_unknown_minor = rest
+            .strip_prefix('.')
+            .is_some_and(|r| r.starts_with(|c: char| c.is_ascii_digit()));
+        if !names_unknown_minor {
+            return Some(Ltx2Generation::V2);
+        }
+        return None;
+    }
+    match model_version_hint {
+        Some(v) if version_has_minor(v, 3) => Some(Ltx2Generation::V2_3),
+        Some(v) if [0u32, 1, 2].iter().any(|&m| version_has_minor(v, m)) => {
+            Some(Ltx2Generation::V2)
+        }
+        _ => None,
+    }
+}
+
+/// True when `version` is `2.<minor>` or `2.<minor>.<anything>`.
+fn version_has_minor(version: &str, minor: u32) -> bool {
+    let Some(rest) = version.strip_prefix("2.") else {
+        return false;
+    };
+    let digits = rest.split(['.', '-', '+']).next().unwrap_or("");
+    digits.parse::<u32>() == Ok(minor)
+}
+
+/// The preprocessing profile for a known generation. Both currently
+/// supported generations were trained against CRF 33.
+pub fn ltx2_image_preprocessing_profile(
+    generation: Ltx2Generation,
+) -> Ltx2ImagePreprocessingProfile {
+    Ltx2ImagePreprocessingProfile {
+        generation,
+        image_crf: LTX2_IMAGE_CRF,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ltx2_generation_resolves_known_names_and_hints() {
+        assert_eq!(ltx2_generation("ltx-2-19b", None), Some(Ltx2Generation::V2));
+        assert_eq!(
+            ltx2_generation("ltx-2-19b-distilled:fp8", None),
+            Some(Ltx2Generation::V2)
+        );
+        assert_eq!(
+            ltx2_generation("ltx-2.3-22b", None),
+            Some(Ltx2Generation::V2_3)
+        );
+        assert_eq!(
+            ltx2_generation("ltx-2.3-22b-distilled:q8", None),
+            Some(Ltx2Generation::V2_3)
+        );
+        // Companion naming without the dash.
+        assert_eq!(
+            ltx2_generation("ltx2.3-vae", None),
+            Some(Ltx2Generation::V2_3)
+        );
+        // Catalog IDs carry no family marker; the safetensors
+        // `model_version` header hint decides.
+        assert_eq!(
+            ltx2_generation("cv:2752735", Some("2.3.0")),
+            Some(Ltx2Generation::V2_3)
+        );
+        assert_eq!(
+            ltx2_generation("hf:someone/some-repo", Some("2.0.1")),
+            Some(Ltx2Generation::V2)
+        );
+        assert_eq!(
+            ltx2_generation("cv:1", Some("2.1.0")),
+            Some(Ltx2Generation::V2)
+        );
+        assert_eq!(
+            ltx2_generation("cv:1", Some("2.2")),
+            Some(Ltx2Generation::V2)
+        );
+    }
+
+    #[test]
+    fn ltx2_generation_fails_closed_on_unknown() {
+        // Upstream 2.4 exists (CRF 18) but this build cannot load it —
+        // it must not inherit either known profile.
+        assert_eq!(ltx2_generation("cv:1", Some("2.4.0")), None);
+        assert_eq!(ltx2_generation("cv:1", Some("3.0")), None);
+        assert_eq!(ltx2_generation("cv:1", Some("2.30")), None);
+        assert_eq!(ltx2_generation("cv:1", Some("garbage")), None);
+        assert_eq!(ltx2_generation("cv:1", None), None);
+        assert_eq!(ltx2_generation("some-model", None), None);
+        // A future name marker is not folded into V2 by substring.
+        assert_eq!(ltx2_generation("ltx-2.4-24b", None), None);
+    }
+
+    #[test]
+    fn profile_maps_both_generations_to_crf_33() {
+        for generation in [Ltx2Generation::V2, Ltx2Generation::V2_3] {
+            let profile = ltx2_image_preprocessing_profile(generation);
+            assert_eq!(profile.generation, generation);
+            assert_eq!(profile.image_crf, 33);
+        }
+    }
+
+    #[test]
+    fn profile_serde_round_trips() {
+        let profile = ltx2_image_preprocessing_profile(Ltx2Generation::V2_3);
+        let json = serde_json::to_string(&profile).unwrap();
+        assert_eq!(json, r#"{"generation":"v2_3","image_crf":33}"#);
+        let back: Ltx2ImagePreprocessingProfile = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, profile);
+    }
+}

--- a/crates/mold-core/src/ltx2_preprocess.rs
+++ b/crates/mold-core/src/ltx2_preprocess.rs
@@ -62,37 +62,54 @@ pub fn ltx2_generation(
     model_name: &str,
     model_version_hint: Option<&str>,
 ) -> Option<Ltx2Generation> {
-    if model_name.contains("ltx-2.3") || model_name.contains("ltx2.3") {
-        return Some(Ltx2Generation::V2_3);
-    }
-    // "ltx-2" followed by ".<digit>" is some *other* generation (2.4, …):
-    // never fold it into V2 by substring accident.
-    if let Some(idx) = model_name.find("ltx-2") {
-        let rest = &model_name[idx + "ltx-2".len()..];
-        let names_unknown_minor = rest
-            .strip_prefix('.')
-            .is_some_and(|r| r.starts_with(|c: char| c.is_ascii_digit()));
-        if !names_unknown_minor {
-            return Some(Ltx2Generation::V2);
+    // A name-embedded version marker (`ltx-2`, `ltx-2.3`, `ltx2.3`, …) is
+    // parsed as a COMPLETE minor component, never an unrestricted
+    // substring: `ltx-2.30` names an unknown generation and must fail
+    // closed rather than be swallowed by an `ltx-2.3` prefix match, and
+    // an explicit `ltx-2.0`/`ltx-2.1`/`ltx-2.2` is the supported V2
+    // lineage rather than an unknown future one.
+    for marker in ["ltx-2", "ltx2"] {
+        let Some(idx) = model_name.find(marker) else {
+            continue;
+        };
+        let rest = &model_name[idx + marker.len()..];
+        let Some(after_dot) = rest.strip_prefix('.') else {
+            // Bare `ltx-2-19b` style names are the V2 lineage; a bare
+            // `ltx2` (no dash, no version) is too weak a marker — fall
+            // through to the metadata hint.
+            if marker == "ltx-2" {
+                return Some(Ltx2Generation::V2);
+            }
+            continue;
+        };
+        let digits: String = after_dot
+            .chars()
+            .take_while(|c| c.is_ascii_digit())
+            .collect();
+        if digits.is_empty() {
+            // `ltx-2.` followed by a non-digit — treat the dot as part of
+            // the surrounding name, not a version separator.
+            if marker == "ltx-2" {
+                return Some(Ltx2Generation::V2);
+            }
+            continue;
         }
-        return None;
+        return generation_for_minor(digits.parse().ok()?);
     }
-    match model_version_hint {
-        Some(v) if version_has_minor(v, 3) => Some(Ltx2Generation::V2_3),
-        Some(v) if [0u32, 1, 2].iter().any(|&m| version_has_minor(v, m)) => {
-            Some(Ltx2Generation::V2)
-        }
-        _ => None,
-    }
+    let version = model_version_hint?;
+    let rest = version.strip_prefix("2.")?;
+    let digits = rest.split(['.', '-', '+']).next().unwrap_or("");
+    generation_for_minor(digits.parse().ok()?)
 }
 
-/// True when `version` is `2.<minor>` or `2.<minor>.<anything>`.
-fn version_has_minor(version: &str, minor: u32) -> bool {
-    let Some(rest) = version.strip_prefix("2.") else {
-        return false;
-    };
-    let digits = rest.split(['.', '-', '+']).next().unwrap_or("");
-    digits.parse::<u32>() == Ok(minor)
+/// The generation a `2.<minor>` version component belongs to. Unknown
+/// minors (2.4 and beyond) return `None` — fail closed.
+fn generation_for_minor(minor: u32) -> Option<Ltx2Generation> {
+    match minor {
+        0..=2 => Some(Ltx2Generation::V2),
+        3 => Some(Ltx2Generation::V2_3),
+        _ => None,
+    }
 }
 
 /// The preprocessing profile for a known generation. Both currently
@@ -162,6 +179,23 @@ mod tests {
         assert_eq!(ltx2_generation("some-model", None), None);
         // A future name marker is not folded into V2 by substring.
         assert_eq!(ltx2_generation("ltx-2.4-24b", None), None);
+        // A version marker is a complete minor component: `2.30` is not
+        // `2.3` (codex review, PR #1071).
+        assert_eq!(ltx2_generation("ltx-2.30-22b", None), None);
+        assert_eq!(ltx2_generation("ltx2.30-vae", None), None);
+    }
+
+    #[test]
+    fn explicit_v2_minor_names_resolve_to_v2() {
+        // Codex review (PR #1071): `ltx-2.0`/`2.1`/`2.2` name the
+        // supported V2 lineage explicitly and must not fail closed.
+        for name in ["ltx-2.0-19b", "ltx-2.1-19b:fp8", "ltx-2.2-19b"] {
+            assert_eq!(
+                ltx2_generation(name, None),
+                Some(Ltx2Generation::V2),
+                "{name}"
+            );
+        }
     }
 
     #[test]

--- a/crates/mold-inference/src/ltx2/pipeline.rs
+++ b/crates/mold-inference/src/ltx2/pipeline.rs
@@ -427,6 +427,34 @@ impl Ltx2Engine {
         lora::camera_control_preset(name)
     }
 
+    /// The still-image conditioning preprocessing contract for this
+    /// checkpoint, resolved through the shared
+    /// `mold_core::ltx2_preprocess` authority from the model name and the
+    /// safetensors `model_version` header hint. Errors — naming both —
+    /// when the generation is unknown: upstream's conditioning CRF is a
+    /// per-generation training property (33 for LTX-2/2.3, 18 for 2.4),
+    /// so guessing one for an unrecognised checkpoint silently degrades
+    /// I2V instead of failing actionably.
+    pub(crate) fn image_preprocessing_profile(
+        &self,
+    ) -> Result<mold_core::ltx2_preprocess::Ltx2ImagePreprocessingProfile> {
+        let hint = self.preset_hint.as_deref();
+        let generation = mold_core::ltx2_preprocess::ltx2_generation(&self.model_name, hint)
+            .with_context(|| {
+                format!(
+                    "cannot resolve the LTX-2 checkpoint generation for model '{}'{} — \
+                     image conditioning needs the generation's training-time compression \
+                     profile and refuses to guess; text-to-video remains available",
+                    self.model_name,
+                    match hint {
+                        Some(h) => format!(" (header hint: model_version={h:?})"),
+                        None => String::new(),
+                    }
+                )
+            })?;
+        Ok(mold_core::ltx2_preprocess::ltx2_image_preprocessing_profile(generation))
+    }
+
     pub(crate) fn materialize_request(
         &self,
         req: &GenerateRequest,
@@ -439,6 +467,16 @@ impl Ltx2Engine {
         let prompt_tokens = GemmaAssets::discover(&gemma_root)?
             .encode_prompt_pair(&req.prompt, req.negative_prompt.as_deref())?;
         let conditioning = conditioning::stage_conditioning(req, work_dir)?;
+        // Still-image conditioning is re-compressed to match the
+        // checkpoint generation's training distribution; an unknown
+        // generation has no known CRF, so I2V/keyframe requests fail
+        // closed here — before any GPU work — while T2V on the same
+        // checkpoint stays unaffected.
+        let image_preprocessing = if conditioning.images.is_empty() {
+            None
+        } else {
+            Some(self.image_preprocessing_profile()?)
+        };
         let loras = lora::resolve_loras(&self.paths, req)?;
         let preset =
             preset::preset_for_model_with_hint(&self.model_name, self.preset_hint.as_deref())?;
@@ -539,6 +577,7 @@ impl Ltx2Engine {
             quantization: self.request_quantization(),
             streaming_prefetch_count: Some(preset.streaming_prefetch_count),
             conditioning,
+            image_preprocessing,
             loras,
             retake_range: req.retake_range.clone(),
             spatial_upscale: req.spatial_upscale,
@@ -2712,6 +2751,69 @@ mod tests {
     /// a stage-level EXR target is the orchestrator's per-stage window, so a
     /// continuation can never stream clip-local `frame_00000.exr..` over
     /// another stage's frames (the latent extend-path bug #688 predicted).
+    #[test]
+    fn i2v_on_unknown_generation_fails_closed_with_model_name() {
+        let gemma_dir = tempfile::tempdir().unwrap();
+        write_test_gemma_assets(gemma_dir.path());
+        let mut engine = Ltx2Engine::with_runtime_session(
+            "cv:12345".to_string(),
+            dummy_paths_with_gemma_root(gemma_dir.path()),
+            runtime_session(),
+        );
+        // Upstream 2.4 maps to CRF 18, which this build has no runnable
+        // checkpoint to verify — the generation resolver refuses it while
+        // the architecture preset keeps its historical 19B fall-through.
+        engine.preset_hint = Some("2.4.0".to_string());
+
+        let work_dir = tempfile::tempdir().unwrap();
+        let output = work_dir.path().join("out.mp4");
+
+        // T2V on the same checkpoint stays available.
+        let t2v = request(OutputFormat::Mp4, Some(false));
+        let plan = engine
+            .materialize_request(&t2v, work_dir.path(), &output)
+            .unwrap();
+        assert!(plan.image_preprocessing.is_none());
+
+        // I2V fails closed, naming the model and the header hint.
+        let mut i2v = request(OutputFormat::Mp4, Some(false));
+        i2v.source_image = Some(vec![0x89, b'P', b'N', b'G', b'\r', b'\n', 0x1a, b'\n']);
+        let err = engine
+            .materialize_request(&i2v, work_dir.path(), &output)
+            .unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("cv:12345"), "got: {msg}");
+        assert!(msg.contains("model_version=\"2.4.0\""), "got: {msg}");
+        assert!(
+            msg.contains("text-to-video remains available"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn i2v_on_known_generation_resolves_crf_33_profile() {
+        let gemma_dir = tempfile::tempdir().unwrap();
+        write_test_gemma_assets(gemma_dir.path());
+        let engine = Ltx2Engine::with_runtime_session(
+            "ltx-2.3-22b-distilled:fp8".to_string(),
+            dummy_paths_with_gemma_root(gemma_dir.path()),
+            runtime_session(),
+        );
+        let work_dir = tempfile::tempdir().unwrap();
+        let output = work_dir.path().join("out.mp4");
+        let mut i2v = request(OutputFormat::Mp4, Some(false));
+        i2v.source_image = Some(vec![0x89, b'P', b'N', b'G', b'\r', b'\n', 0x1a, b'\n']);
+        let plan = engine
+            .materialize_request(&i2v, work_dir.path(), &output)
+            .unwrap();
+        let profile = plan.image_preprocessing.expect("profile for staged image");
+        assert_eq!(
+            profile.generation,
+            mold_core::ltx2_preprocess::Ltx2Generation::V2_3
+        );
+        assert_eq!(profile.image_crf, 33);
+    }
+
     #[test]
     fn stage_sidecar_is_the_only_route_to_a_stage_exr_target() {
         let gemma_dir = tempfile::tempdir().unwrap();

--- a/crates/mold-inference/src/ltx2/plan.rs
+++ b/crates/mold-inference/src/ltx2/plan.rs
@@ -127,6 +127,14 @@ pub(crate) struct Ltx2GeneratePlan {
     pub(crate) quantization: Option<String>,
     pub(crate) streaming_prefetch_count: Option<u32>,
     pub(crate) conditioning: StagedConditioning,
+    /// Still-image conditioning preprocessing contract, resolved from the
+    /// checkpoint generation (`mold_core::ltx2_preprocess`). `Some` exactly
+    /// when `conditioning.images` is non-empty — materialization fails
+    /// closed for an unknown generation rather than guessing a CRF.
+    // TODO(#1055 PR2): consumed by the conditioning-image H.264 round-trip.
+    #[allow(dead_code)]
+    pub(crate) image_preprocessing:
+        Option<mold_core::ltx2_preprocess::Ltx2ImagePreprocessingProfile>,
     pub(crate) loras: Vec<LoraWeight>,
     pub(crate) retake_range: Option<TimeRange>,
     pub(crate) spatial_upscale: Option<Ltx2SpatialUpscale>,

--- a/crates/mold-inference/src/ltx2/preset.rs
+++ b/crates/mold-inference/src/ltx2/preset.rs
@@ -204,6 +204,18 @@ pub(crate) fn preset_for_model_with_hint(
     model_name: &str,
     hint: Option<&str>,
 ) -> Result<Ltx2ModelPreset> {
+    // The 2.0-vs-2.3 generation split is owned by the shared
+    // `mold_core::ltx2_preprocess` resolver so admission, preprocessing,
+    // and this architecture pick can never disagree; the looser arms
+    // below survive only as architecture fall-through for inputs the
+    // strict resolver refuses (it fails closed on e.g. a future
+    // `model_version: "2.4"`, which for *architecture* selection keeps
+    // its historical 19B mapping).
+    match mold_core::ltx2_preprocess::ltx2_generation(model_name, hint) {
+        Some(mold_core::ltx2_preprocess::Ltx2Generation::V2_3) => return Ok(PRESET_22B),
+        Some(mold_core::ltx2_preprocess::Ltx2Generation::V2) => return Ok(PRESET_19B),
+        None => {}
+    }
     if model_name.contains("ltx-2.3") {
         return Ok(PRESET_22B);
     }
@@ -278,6 +290,34 @@ mod tests {
         let err = preset_for_model_with_hint("cv:42", Some("3.0.0")).unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("model_version=\"3.0.0\""), "got: {msg}");
+    }
+
+    #[test]
+    fn preset_and_generation_resolvers_agree_for_shipped_names() {
+        // Contract: wherever the shared `mold_core::ltx2_preprocess`
+        // resolver recognises a generation, the architecture preset must
+        // match — V2 → 19B, V2_3 → 22B. Divergence would let admission
+        // preprocess for one generation while the engine loads the other.
+        use mold_core::ltx2_preprocess::{ltx2_generation, Ltx2Generation};
+        let cases: &[(&str, Option<&str>)] = &[
+            ("ltx-2-19b", None),
+            ("ltx-2-19b-distilled:fp8", None),
+            ("ltx-2.3-22b-dev:fp8", None),
+            ("ltx-2.3-22b-distilled:bf16", None),
+            ("cv:2752735", Some("2.3.0")),
+            ("cv:9999", Some("2.0.0")),
+            ("hf:someone/repo", Some("2.1.0")),
+        ];
+        for (name, hint) in cases {
+            let generation = ltx2_generation(name, *hint)
+                .unwrap_or_else(|| panic!("generation resolver must recognise {name}"));
+            let preset = preset_for_model_with_hint(name, *hint).unwrap();
+            let expected = match generation {
+                Ltx2Generation::V2 => "ltx-2-19b",
+                Ltx2Generation::V2_3 => "ltx-2.3-22b",
+            };
+            assert_eq!(preset.name, expected, "for model {name} hint {hint:?}");
+        }
     }
 
     #[test]

--- a/crates/mold-inference/src/ltx2/runtime.rs
+++ b/crates/mold-inference/src/ltx2/runtime.rs
@@ -8630,6 +8630,7 @@ mod tests {
             quantization: Some("fp8-cast".to_string()),
             streaming_prefetch_count: Some(2),
             conditioning,
+            image_preprocessing: None,
             loras,
             retake_range: req.retake_range.clone(),
             spatial_upscale: req.spatial_upscale,


### PR DESCRIPTION
Upstream LTX-2 re-compresses still-image conditioning through a one-frame
H.264 round-trip whose CRF is a property of the checkpoint generation
(33 for LTX-2/2.3, 18 for the unreleased 2.4). Introduce
mold_core::ltx2_preprocess as the single generation + profile authority,
delegate the preset's 2.0-vs-2.3 split to it (pinned by a contract test),
resolve the profile at materialize time when conditioning images are
staged, and fail closed with an actionable error for unknown generations
while leaving T2V on the same checkpoint available.

Part of #1055 (stacked PR 1/4). Next: #1072 (preprocessing), then the conditioning-init fix and client relabel.

Tests: `ltx2_preprocess` unit tests in mold-core (name/hint resolution, fail-closed on 2.4/unknown, CRF-33 profile, serde), `preset_and_generation_resolvers_agree_for_shipped_names` contract test, and materialize-time fail-closed coverage (`i2v_on_unknown_generation_fails_closed_with_model_name`, `i2v_on_known_generation_resolves_crf_33_profile`).