### PR TITLE
fix(ci): preserve Nix cache builds

### DIFF
--- a/.github/workflows/nix-cache.yml
+++ b/.github/workflows/nix-cache.yml
@@ -6,8 +6,10 @@ on:
     tags: ["v*"]
 
 concurrency:
+  # CUDA builds routinely outlive the interval between main pushes. Queue them
+  # so each completed build reaches Cachix instead of cancelling every upload.
   group: nix-cache-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/scripts/tests/cuda-distribution-contract.sh
+++ b/scripts/tests/cuda-distribution-contract.sh
@@ -288,6 +288,8 @@ require_release_job_text "docker" 'suffix: ""'
 require_ci_release_path "$cache_workflow"
 require_text "$cache_workflow" 'branches: [main]'
 require_text "$cache_workflow" 'tags: ["v*"]'
+require_text "$cache_workflow" 'group: nix-cache-${{ github.ref }}'
+require_text "$cache_workflow" 'cancel-in-progress: false'
 require_text "$cache_workflow" 'permissions:'
 require_text "$cache_workflow" 'contents: read'
 require_text "$cache_workflow" 'continue-on-error: true'


### PR DESCRIPTION
## Summary

- queue branch-scoped Nix cache runs instead of cancelling the active CUDA build
- preserve the single-run concurrency throttle while allowing completed outputs to reach Cachix
- lock the concurrency group and cancellation policy in the CUDA distribution contract

## Root cause

The sm89 CUDA build takes longer than the interval between many `main` pushes. With `cancel-in-progress: true`, each new push cancelled the active build before `cachix-action` could upload its output, leaving the cache empty.

## Validation

- independent agent peer review: no findings
- `actionlint .github/workflows/nix-cache.yml`
- cache concurrency contract assertions
- `git diff --check`

The full CUDA distribution script reaches the new assertions on macOS; its later ELF/PTX fixture tests remain Linux-only because macOS fixtures are Mach-O.