### PR TITLE
fix(studio): preserve server-owned generation state

### DIFF
--- a/desktop/src/App.vue
+++ b/desktop/src/App.vue
@@ -153,7 +153,14 @@ function onKeydown(e: KeyboardEvent) {
     case "cancel-job": {
       const job = generation.active;
       if (job && job.status !== "complete" && job.status !== "error") {
-        void generation.cancel(job.clientId).then(() => toasts.push("Cancelled"));
+        void generation
+          .cancel(job.clientId)
+          .then((cancelled) => {
+            if (cancelled) toasts.push("Cancelled");
+          })
+          .catch((error) =>
+            toasts.push(error instanceof Error ? error.message : String(error), "error"),
+          );
       }
       break;
     }
@@ -198,7 +205,15 @@ async function listenForMenu() {
       case "randomize-seed":
         return ui.randomizeSeed();
       case "cancel-job":
-        if (generation.active) void generation.cancel().then(() => toasts.push("Cancelled"));
+        if (generation.active)
+          void generation
+            .cancel()
+            .then((cancelled) => {
+              if (cancelled) toasts.push("Cancelled");
+            })
+            .catch((error) =>
+              toasts.push(error instanceof Error ? error.message : String(error), "error"),
+            );
         return;
       case "toggle-sidebar":
         void appPrefs.update({ sidebarCollapsed: !appPrefs.sidebarCollapsed });

--- a/desktop/src/components/create/ActivityStrip.test.ts
+++ b/desktop/src/components/create/ActivityStrip.test.ts
@@ -7,6 +7,7 @@ import { useGenerationStore } from "../../stores/generation";
 import { useHostsStore } from "../../stores/hosts";
 import { useRunPodStore } from "../../stores/runpod";
 import { useLiveActivityStore } from "../../stores/liveActivity";
+import { useToastStore } from "../../stores/toasts";
 import type { ChainJobSummary } from "@studio/lib/api/chainTypes";
 import type { Job } from "../../stores/generation";
 
@@ -82,13 +83,25 @@ describe("ActivityStrip", () => {
 
   it("lists queued siblings with a working cancel", async () => {
     const generation = useGenerationStore();
-    const cancel = vi.spyOn(generation, "cancel").mockResolvedValue(undefined as never);
+    const cancel = vi.spyOn(generation, "cancel").mockResolvedValue(true);
     generation.jobs = [{ ...baseJob(), clientId: 7, status: "queued", prompt: "queued one" }];
     const wrapper = mount(ActivityStrip);
     const pill = wrapper.get("[data-test='activity-queued']");
     expect(pill.text()).toContain("queued one");
     await pill.get("button").trigger("click");
     expect(cancel).toHaveBeenCalledWith(7);
+    expect(useToastStore().items.map((item) => item.message)).toContain("Cancelled");
+  });
+
+  it("does not claim cancellation when a terminal server event won the race", async () => {
+    const generation = useGenerationStore();
+    vi.spyOn(generation, "cancel").mockResolvedValue(false);
+    generation.jobs = [{ ...baseJob(), clientId: 7, status: "queued" }];
+    const wrapper = mount(ActivityStrip);
+
+    await wrapper.get("[data-test='activity-queued'] button").trigger("click");
+
+    expect(useToastStore().items).toHaveLength(0);
   });
 
   it("selects queued prints with Space", async () => {

--- a/desktop/src/components/create/ActivityStrip.vue
+++ b/desktop/src/components/create/ActivityStrip.vue
@@ -99,7 +99,12 @@ watchEffect(() => {
 });
 
 function cancel(job: Job) {
-  void generation.cancel(job.clientId).then(() => toasts.push("Cancelled"));
+  void generation
+    .cancel(job.clientId)
+    .then((cancelled) => {
+      if (cancelled) toasts.push("Cancelled");
+    })
+    .catch((error) => toasts.push(error instanceof Error ? error.message : String(error), "error"));
 }
 
 // ── Sequences via the shared activity merge ──────────────────────────────────

--- a/desktop/src/components/machines/HostQueuePanel.vue
+++ b/desktop/src/components/machines/HostQueuePanel.vue
@@ -155,9 +155,11 @@ function laneDroppable(laneKey: LaneKey): boolean {
 
 async function cancelEntry(entry: EnrichedQueueEntry) {
   try {
-    if (entry.clientId !== null) await generation.cancel(entry.clientId);
-    else await jobs.cancelJob(props.host.id, entry.id);
-    toasts.push("Cancelled");
+    const cancelled =
+      entry.clientId !== null
+        ? await generation.cancel(entry.clientId)
+        : await jobs.cancelJob(props.host.id, entry.id).then(() => true);
+    if (cancelled) toasts.push("Cancelled");
   } catch (err) {
     toasts.push(String(err), "error");
   }

--- a/desktop/src/components/machines/QueueColumn.vue
+++ b/desktop/src/components/machines/QueueColumn.vue
@@ -48,9 +48,11 @@ function progressPct(row: QueueSurfaceRow): number {
 
 async function cancel(row: QueueSurfaceRow) {
   try {
-    if (row.entry.clientId !== null) await generation.cancel(row.entry.clientId);
-    else await jobs.cancelJob(row.hostId, row.entry.id);
-    toasts.push("Cancelled");
+    const cancelled =
+      row.entry.clientId !== null
+        ? await generation.cancel(row.entry.clientId)
+        : await jobs.cancelJob(row.hostId, row.entry.id).then(() => true);
+    if (cancelled) toasts.push("Cancelled");
   } catch (err) {
     toasts.push(String(err), "error");
   }

--- a/desktop/src/components/shell/CommandPalette.test.ts
+++ b/desktop/src/components/shell/CommandPalette.test.ts
@@ -25,6 +25,8 @@ import { useHostsStore } from "../../stores/hosts";
 import { useConnectionStore } from "../../stores/connection";
 import { useDownloadsStore } from "../../stores/downloads";
 import { useComposerStore } from "../../stores/composer";
+import { useGenerationStore } from "../../stores/generation";
+import { useToastStore } from "../../stores/toasts";
 import type { GalleryImage, ModelEntry } from "../../lib/api/types";
 
 beforeEach(() => {
@@ -112,6 +114,29 @@ describe("CommandPalette command registry", () => {
     const texts = wrapper.findAll("[role='option']").map((o) => o.text());
     expect(texts.some((t) => t.includes("Switch to built-in engine"))).toBe(false);
     expect(texts.some((t) => t.includes("Restart engine"))).toBe(true);
+    wrapper.unmount();
+  });
+
+  it("reports the confirmed count when bulk cancellation races terminal jobs", async () => {
+    const generation = useGenerationStore();
+    generation.jobs = [
+      { clientId: 1, status: "queued" },
+      { clientId: 2, status: "queued" },
+    ] as never;
+    vi.spyOn(generation, "cancel").mockImplementation(async (id) => id === 1);
+    const wrapper = await openPalette();
+    await wrapper.get("input").setValue("cancel all");
+
+    await wrapper
+      .findAll("[role='option']")
+      .find((option) => option.text().includes("Cancel all 2 jobs"))!
+      .trigger("click");
+    await flushPromises();
+
+    expect(useToastStore().items.map((item) => item.message)).toContain(
+      "Cancelled 1 job; remaining jobs already settled",
+    );
+    expect(useToastStore().items.map((item) => item.message)).not.toContain("Cancelled all jobs");
     wrapper.unmount();
   });
 });

--- a/desktop/src/components/shell/CommandPalette.vue
+++ b/desktop/src/components/shell/CommandPalette.vue
@@ -329,7 +329,14 @@ const staticCommands = computed<Command[]>(() => {
       id: "act-cancel",
       title: "Cancel job",
       run: () => {
-        void generation.cancel().then(() => toasts.push("Cancelled"));
+        void generation
+          .cancel()
+          .then((cancelled) => {
+            if (cancelled) toasts.push("Cancelled");
+          })
+          .catch((error) =>
+            toasts.push(error instanceof Error ? error.message : String(error), "error"),
+          );
         close();
       },
     });
@@ -341,9 +348,18 @@ const staticCommands = computed<Command[]>(() => {
       keywords: ["queue", "stop"],
       run: () => {
         const ids = generation.pending.map((j) => j.clientId);
-        void Promise.all(ids.map((id) => generation.cancel(id))).then(() =>
-          toasts.push("Cancelled all jobs"),
-        );
+        void Promise.all(ids.map((id) => generation.cancel(id)))
+          .then((outcomes) => {
+            const cancelled = outcomes.filter(Boolean).length;
+            if (cancelled === outcomes.length) toasts.push("Cancelled all jobs");
+            else if (cancelled > 0)
+              toasts.push(
+                `Cancelled ${cancelled} ${cancelled === 1 ? "job" : "jobs"}; remaining jobs already settled`,
+              );
+          })
+          .catch((error) =>
+            toasts.push(error instanceof Error ? error.message : String(error), "error"),
+          );
         close();
       },
     });

--- a/desktop/src/components/shell/NavRail.vue
+++ b/desktop/src/components/shell/NavRail.vue
@@ -195,7 +195,15 @@ function jobMenu(job: Job): MenuEntry[] {
       label: "Cancel",
       danger: true,
       disabled: !live,
-      action: () => void generation.cancel(job.clientId).then(() => toasts.push("Cancelled")),
+      action: () =>
+        void generation
+          .cancel(job.clientId)
+          .then((cancelled) => {
+            if (cancelled) toasts.push("Cancelled");
+          })
+          .catch((error) =>
+            toasts.push(error instanceof Error ? error.message : String(error), "error"),
+          ),
     },
     { separator: true },
     {

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -1476,6 +1476,7 @@ describe("MobileApp generation queue", () => {
     expect(openStreams.map((stream) => stream.options.body.prompt)).toEqual([
       "three storm studies · prepared 1",
       "three storm studies · prepared 2",
+      "three storm studies · prepared 3",
     ]);
   });
 
@@ -1997,24 +1998,27 @@ describe("MobileApp generation queue", () => {
     expect(wrapper.get("[data-test='mobile-develop-button']").text()).toBe(
       "Develop 3 prints (+3 queued)",
     );
-    expect(openStreams).toHaveLength(2);
+    expect(openStreams).toHaveLength(3);
     const firstSeed = openStreams[0]?.options.body.seed as number;
-    expect(openStreams.map((stream) => stream.options.body.batch_size)).toEqual([1, 1]);
+    expect(openStreams.map((stream) => stream.options.body.batch_size)).toEqual([1, 1, 1]);
     expect(openStreams.map((stream) => stream.options.body.seed)).toEqual([
       firstSeed,
       firstSeed + 1,
+      firstSeed + 2,
     ]);
     expect(openStreams.map((stream) => stream.options.body.prompt)).toEqual([
       "three variations of a storm · prepared 1",
       "an edited middle storm",
+      "three variations of a storm · prepared 3",
     ]);
     expect(openStreams.map((stream) => stream.options.body.original_prompt)).toEqual([
       "three variations of a storm",
       "three variations of a storm",
+      "three variations of a storm",
     ]);
     expect(openStreams[0]?.options.body.batch_id).toEqual(expect.any(String));
-    expect(openStreams.map((stream) => stream.options.body.batch_index)).toEqual([1, 2]);
-    expect(openStreams.map((stream) => stream.options.body.batch_count)).toEqual([3, 3]);
+    expect(openStreams.map((stream) => stream.options.body.batch_index)).toEqual([1, 2, 3]);
+    expect(openStreams.map((stream) => stream.options.body.batch_count)).toEqual([3, 3, 3]);
   });
 
   it.each([
@@ -2251,7 +2255,7 @@ describe("MobileApp generation queue", () => {
     expect(wrapper.find("img.result-media").exists()).toBe(true);
   });
 
-  it("composes prepared sibling failures with an unconfirmed cancellation caveat", async () => {
+  it("keeps a prepared sibling live when cancellation is unconfirmed", async () => {
     wrapper = mountMobileApp();
     await flushPromises();
     await wrapper.get("[data-test='mobile-batch-increment']").trigger("click");
@@ -2286,6 +2290,22 @@ describe("MobileApp generation queue", () => {
       .find((row) => row.text().includes("cancelled dusk"))!;
     await cancelRow.get("[data-test='mobile-generation-cancel']").trigger("click");
     await flushPromises();
+    expect(openStreams[2]!.options.signal.aborted).toBe(false);
+    expect(wrapper.findAll(".sr-only[aria-live='polite']")[1]!.text()).toContain(
+      "Cancellation failed",
+    );
+    openStreams[2]!.options.onEvent(
+      "complete",
+      JSON.stringify({
+        image: btoa("third"),
+        format: "png",
+        width: 768,
+        height: 512,
+        seed_used: 3,
+        generation_time_ms: 700,
+        model: model.name,
+      }),
+    );
     openStreams[2]!.resolve();
     openStreams[1]!.options.onEvent("error", JSON.stringify({ message: "host ran out of memory" }));
     openStreams[1]!.resolve();
@@ -2296,8 +2316,7 @@ describe("MobileApp generation queue", () => {
     expect(liveSummary).toContain(
       "Studio ran out of memory. Try a smaller model, image size, or batch.",
     );
-    expect(liveSummary).toContain("Cancellation failed");
-    expect(liveSummary).toContain("remote cancellation was not confirmed");
+    expect(liveSummary).not.toContain("remote cancellation was not confirmed");
     expect(wrapper.find("img.result-media").exists()).toBe(true);
   });
 
@@ -3321,28 +3340,34 @@ describe("MobileApp generation queue", () => {
     expect(firstSignal?.aborted).toBe(true);
   });
 
-  it("keeps an unconfirmed remote-cancellation warning after the stream settles", async () => {
+  it("keeps a pre-ID job live when remote cancellation is unconfirmed", async () => {
     wrapper = mountMobileApp();
     await flushPromises();
     await submitPrompt("cancel before the remote queue id arrives");
 
     await wrapper.get("[data-test='mobile-generation-cancel']").trigger("click");
     await flushPromises();
-    expect(wrapper.get("[data-test='mobile-generation-summary']").text()).toMatch(
-      /remote cancellation was not confirmed/i,
-    );
+    expect(wrapper.get("[data-test='mobile-generation-summary']").text()).toBe("Queued");
+    expect(openStreams[0]?.options.signal.aborted).toBe(false);
     expect(wrapper.findAll(".sr-only[aria-live='polite']")[1]?.text()).toContain(
       "Cancellation failed",
     );
 
+    openStreams[0]?.options.onEvent(
+      "complete",
+      JSON.stringify({
+        image: btoa("finished after failed cancellation"),
+        format: "png",
+        width: 768,
+        height: 512,
+        seed_used: 1,
+        generation_time_ms: 500,
+        model: model.name,
+      }),
+    );
     openStreams[0]?.resolve();
     await flushPromises();
-    expect(wrapper.get("[data-test='mobile-generation-summary']").text()).toMatch(
-      /remote cancellation was not confirmed/i,
-    );
-    expect(wrapper.findAll(".sr-only[aria-live='polite']")[1]?.text()).toContain(
-      "Cancellation failed",
-    );
+    expect(wrapper.find("img.result-media").exists()).toBe(true);
   });
 
   it("keeps a completed result visible while a queued sibling settles independently", async () => {

--- a/desktop/src/stores/generation.concurrency.test.ts
+++ b/desktop/src/stores/generation.concurrency.test.ts
@@ -120,50 +120,59 @@ describe("submitBatch connection cap", () => {
     store.resetJobs();
   });
 
-  it("holds at most two sibling streams open at once", async () => {
+  it("holds at most four sibling streams open at once", async () => {
     const store = useGenerationStore();
-    store.submitBatch(req, 4);
+    store.submitBatch(req, 5);
     await flushPromises();
-    // Seeds 100 and 101 open; 102 and 103 wait their turn.
-    expect(streams.map((s) => s.seed).sort()).toEqual([100, 101]);
+    expect(streams.map((s) => s.seed).sort()).toEqual([100, 101, 102, 103]);
 
     resolveStream(100);
     await flushPromises();
-    expect(streams.map((s) => s.seed).sort()).toEqual([101, 102]);
+    expect(streams.map((s) => s.seed).sort()).toEqual([101, 102, 103, 104]);
   });
 
-  it("holds at most two streams across separate Generate submissions", async () => {
+  it("holds at most four streams across separate Generate submissions", async () => {
     const store = useGenerationStore();
     const first = store.submitBatch({ ...req, seed: 200 }, 1);
     const second = store.submitBatch({ ...req, seed: 201 }, 1);
     const third = store.submitBatch({ ...req, seed: 202 }, 1);
+    const fourth = store.submitBatch({ ...req, seed: 203 }, 1);
+    const fifth = store.submitBatch({ ...req, seed: 204 }, 1);
     await flushPromises();
 
-    expect(streams.map((stream) => stream.seed).sort()).toEqual([200, 201]);
+    expect(streams.map((stream) => stream.seed).sort()).toEqual([200, 201, 202, 203]);
 
     resolveStream(200);
     await flushPromises();
-    expect(streams.map((stream) => stream.seed).sort()).toEqual([201, 202]);
+    expect(streams.map((stream) => stream.seed).sort()).toEqual([201, 202, 203, 204]);
 
     resolveStream(201);
     resolveStream(202);
-    await Promise.all([first.settled, second.settled, third.settled]);
+    resolveStream(203);
+    resolveStream(204);
+    await Promise.all([
+      first.settled,
+      second.settled,
+      third.settled,
+      fourth.settled,
+      fifth.settled,
+    ]);
   });
 
-  it("shares the two-stream host cap across overlapping batches", async () => {
+  it("shares the four-stream host cap across overlapping batches", async () => {
     const store = useGenerationStore();
     const first = store.submitBatch({ ...req, seed: 400 }, 3);
     const second = store.submitBatch({ ...req, seed: 500 }, 3);
     await flushPromises();
 
-    expect(streams.map((stream) => stream.seed).sort()).toEqual([400, 401]);
+    expect(streams).toHaveLength(4);
 
     resolveStream(400);
     await flushPromises();
-    expect(streams).toHaveLength(2);
+    expect(streams).toHaveLength(4);
     resolveStream(401);
     await flushPromises();
-    expect(streams).toHaveLength(2);
+    expect(streams).toHaveLength(4);
 
     while (streams.length > 0) {
       streams[0]!.resolve();
@@ -177,8 +186,10 @@ describe("submitBatch connection cap", () => {
     const first = store.submitBatch({ ...req, seed: 300 }, 1);
     const second = store.submitBatch({ ...req, seed: 301 }, 1);
     const third = store.submitBatch({ ...req, seed: 302 }, 1);
+    const fourth = store.submitBatch({ ...req, seed: 303 }, 1);
+    const fifth = store.submitBatch({ ...req, seed: 304 }, 1);
     await flushPromises();
-    expect(streams.map((stream) => stream.seed).sort()).toEqual([300, 301]);
+    expect(streams.map((stream) => stream.seed).sort()).toEqual([300, 301, 302, 303]);
 
     streams
       .find((stream) => stream.seed === 300)!
@@ -196,20 +207,28 @@ describe("submitBatch connection cap", () => {
       );
     await flushPromises();
 
-    expect(streams.map((stream) => stream.seed).sort()).toEqual([301, 302]);
+    expect(streams.map((stream) => stream.seed).sort()).toEqual([301, 302, 303, 304]);
     resolveStream(301);
     resolveStream(302);
-    await Promise.all([first.settled, second.settled, third.settled]);
+    resolveStream(303);
+    resolveStream(304);
+    await Promise.all([
+      first.settled,
+      second.settled,
+      third.settled,
+      fourth.settled,
+      fifth.settled,
+    ]);
   });
 
   it("never opens a stream for a sibling cancelled before its turn", async () => {
     const store = useGenerationStore();
-    const { jobs, settled } = store.submitBatch(req, 4);
+    const { jobs, settled } = store.submitBatch(req, 5);
     await flushPromises();
 
-    // Cancel the last sibling while the first two hold the pool.
-    jobs[3]!.status = "error";
-    jobs[3]!.error = "Cancelled";
+    // Cancel the last sibling while the first four hold the pool.
+    jobs[4]!.status = "error";
+    jobs[4]!.error = "Cancelled";
 
     resolveStream(100);
     await flushPromises();
@@ -217,10 +236,12 @@ describe("submitBatch connection cap", () => {
     await flushPromises();
     resolveStream(102);
     await flushPromises();
+    resolveStream(103);
+    await flushPromises();
     await settled;
 
     const openedSeeds = mockSse.mock.calls.map((c) => (c[1].body as { seed: number }).seed);
     expect(openedSeeds).toContain(102);
-    expect(openedSeeds).not.toContain(103);
+    expect(openedSeeds).not.toContain(104);
   });
 });

--- a/desktop/src/stores/generation.ts
+++ b/desktop/src/stores/generation.ts
@@ -1,6 +1,6 @@
 import { reactive } from "vue";
 import { defineStore } from "pinia";
-import { apiFetchTo, currentTarget, ApiError, type ApiTarget } from "../lib/api/client";
+import { apiFetchTo, currentTarget, type ApiTarget } from "../lib/api/client";
 import { sseStream } from "../lib/api/sse";
 import { evictMedia, galleryMediaPath, streamableMediaUrl } from "../lib/gallery/media";
 import { ipc } from "../lib/ipc";
@@ -244,11 +244,11 @@ const MIME: Record<string, string> = {
 
 /**
  * Held generation SSE requests share the browser's per-origin HTTP pool with
- * gallery reads and queue cancellation. Keep two slots per host globally —
- * not merely per batch — so repeated Generate taps cannot starve those other
- * requests. Later jobs remain visible as locally queued until a slot opens.
+ * gallery reads and queue cancellation. Four slots match the web surface and
+ * let a four-worker host stay busy while retaining connection headroom. The
+ * limit is global per host, not merely per batch.
  */
-const MAX_STREAMS_PER_TARGET = 2;
+const MAX_STREAMS_PER_TARGET = 4;
 
 interface StreamSlotWaiter {
   signal: AbortSignal;
@@ -482,7 +482,7 @@ export const useGenerationStore = defineStore("generation", {
         if (job.status === "error") return Promise.resolve();
         return this.streamJob(job, plans[i]!);
       });
-      const settled = runWithConcurrency(tasks, 2).then(() => {
+      const settled = runWithConcurrency(tasks, MAX_STREAMS_PER_TARGET).then(() => {
         // Background notification (the view toasts in the foreground).
         const failed = jobs.find((s) => s.status === "error");
         const completed = jobs.find((s) => s.status === "complete");
@@ -517,15 +517,15 @@ export const useGenerationStore = defineStore("generation", {
      * Cancel one job (default: the canvas job). Ordinary queued jobs leave
      * the server queue via DELETE /api/queue/:id; automatic chains use their
      * durable shim id with POST /api/chain-jobs/:id/cancel. The stream is
-     * aborted either way and the job is marked cancelled.
+     * aborted only after the server confirms cancellation. A running job's
+     * 409 response leaves its stream and local state intact.
      */
-    async cancel(clientId?: number): Promise<void> {
+    async cancel(clientId?: number): Promise<boolean> {
       const job =
         clientId !== undefined
           ? (this.jobs.find((j) => j.clientId === clientId) ?? null)
           : this.active;
-      if (!job || job.status === "complete" || job.status === "error") return;
-      let cancellationError: unknown = null;
+      if (!job || job.status === "complete" || job.status === "error") return false;
       if (job.id) {
         try {
           const chainRoute = chainRoutes.get(job.clientId);
@@ -537,28 +537,23 @@ export const useGenerationStore = defineStore("generation", {
             { method: chainRoute ? "POST" : "DELETE" },
           );
         } catch (err) {
-          if (!(err instanceof ApiError && (err.status === 409 || err.status === 404))) {
-            cancellationError = err;
-          }
+          // A terminal SSE frame may win while DELETE is in flight. Preserve
+          // that authoritative outcome; otherwise the failed DELETE means the
+          // server still owns the job and the live stream must remain open.
+          if (jobHasSettled(job)) return false;
+          throw err;
         }
       } else if (job.streamStarted) {
-        cancellationError = new Error(
-          "Remote cancellation was not confirmed before the queue ID arrived.",
-        );
+        throw new Error("Remote cancellation was not confirmed before the queue ID arrived.");
       }
       // A terminal SSE frame may win while DELETE is in flight. Preserve that
       // authoritative outcome, even if the DELETE request itself then fails.
-      if (jobHasSettled(job)) return;
+      if (jobHasSettled(job)) return false;
       aborts.get(job.clientId)?.abort();
       aborts.delete(job.clientId);
       settleJob(job, "error");
-      if (cancellationError) {
-        // Release the local stream permit even when the host did not confirm
-        // cancellation. The server may still finish the queued work.
-        job.error = "Cancelled locally; remote cancellation was not confirmed.";
-        throw cancellationError;
-      }
       job.error = "Cancelled";
+      return true;
     },
     /** Single generation — a batch of one. */
     async generate(req: GenerateRequest): Promise<Job> {

--- a/desktop/src/stores/generationQueue.test.ts
+++ b/desktop/src/stores/generationQueue.test.ts
@@ -124,21 +124,15 @@ describe("generation queueing", () => {
     expect(store.active?.clientId).toBe(jobs[0]!.clientId);
   });
 
-  it("creates every batch sibling but holds at most two streams open", async () => {
+  it("creates every batch sibling and opens enough streams to fill a four-GPU host", async () => {
     const store = useGenerationStore();
-    const { jobs } = store.submitBatch({ ...req, seed: 100 }, 3);
+    const { jobs } = store.submitBatch({ ...req, seed: 100 }, 5);
     await flushPromises();
-    expect(jobs).toHaveLength(3);
-    // All three jobs exist immediately, but the connection cap keeps only two
-    // SSE streams open at once so the browser's per-host budget isn't drained.
-    expect(openStreams).toHaveLength(2);
-    expect(jobs.map((j) => j.batchId)).toEqual([
-      jobs[0]!.batchId,
-      jobs[0]!.batchId,
-      jobs[0]!.batchId,
-    ]);
+    expect(jobs).toHaveLength(5);
+    expect(openStreams).toHaveLength(4);
+    expect(jobs.map((j) => j.batchId)).toEqual(Array(5).fill(jobs[0]!.batchId));
     // The active job's siblings drive the batch dots.
-    expect(store.siblings).toHaveLength(3);
+    expect(store.siblings).toHaveLength(5);
   });
 
   it("cancel marks the job cancelled and asks the server to drop it", async () => {
@@ -158,6 +152,26 @@ describe("generation queueing", () => {
     );
     expect(store.jobs[0]!.status).toBe("error");
     expect(store.jobs[0]!.error).toBe("Cancelled");
+  });
+
+  it("keeps a running job and its stream alive when the server refuses cancellation", async () => {
+    const store = useGenerationStore();
+    const { jobs } = store.submitBatch({ ...req }, 1);
+    await flushPromises();
+    openStreams[0]!.onEvent(
+      "progress",
+      JSON.stringify({ type: "denoise_step", step: 1, total: 4, id: "running-job" }),
+    );
+    jobs[0]!.id = "running-job";
+    const { apiFetchTo, ApiError } = await import("../lib/api/client");
+    vi.mocked(apiFetchTo).mockRejectedValueOnce(
+      new ApiError("queue job running-job is already running", 409),
+    );
+
+    await expect(store.cancel(jobs[0]!.clientId)).rejects.toThrow("already running");
+
+    expect(openStreams[0]!.signal.aborted).toBe(false);
+    expect(jobs[0]).toMatchObject({ status: "denoising", error: null });
   });
 
   it("keeps a server cancellation frame classified as cancellation during DELETE", async () => {
@@ -269,12 +283,12 @@ describe("generation queueing", () => {
       throw new Error("DELETE connection reset");
     });
 
-    await expect(store.cancel(jobs[0]!.clientId)).resolves.toBeUndefined();
+    await expect(store.cancel(jobs[0]!.clientId)).resolves.toBe(false);
     await settled;
     expect(jobs[0]).toMatchObject({ status: "complete", error: null, result: { seed_used: 12 } });
   });
 
-  it("releases the local stream when remote cancellation cannot be confirmed", async () => {
+  it("keeps the local stream when remote cancellation cannot be confirmed", async () => {
     const store = useGenerationStore();
     const { jobs, settled } = store.submitBatch({ ...req }, 1);
     await flushPromises();
@@ -286,11 +300,8 @@ describe("generation queueing", () => {
     vi.mocked(apiFetchTo).mockRejectedValueOnce(new Error("host went offline"));
 
     await expect(store.cancel(jobs[0]!.clientId)).rejects.toThrow("host went offline");
-    expect(openStreams[0]!.signal.aborted).toBe(true);
-    expect(jobs[0]).toMatchObject({
-      status: "error",
-      error: "Cancelled locally; remote cancellation was not confirmed.",
-    });
+    expect(openStreams[0]!.signal.aborted).toBe(false);
+    expect(jobs[0]).toMatchObject({ status: "queued", error: null });
     openStreams[0]!.resolve();
     await settled;
   });
@@ -307,11 +318,8 @@ describe("generation queueing", () => {
 
     const { apiFetchTo } = await import("../lib/api/client");
     expect(vi.mocked(apiFetchTo)).not.toHaveBeenCalled();
-    expect(openStreams[0]!.signal.aborted).toBe(true);
-    expect(jobs[0]).toMatchObject({
-      status: "error",
-      error: "Cancelled locally; remote cancellation was not confirmed.",
-    });
+    expect(openStreams[0]!.signal.aborted).toBe(false);
+    expect(jobs[0]).toMatchObject({ status: "queued", error: null });
 
     openStreams[0]!.resolve();
     await settled;

--- a/desktop/src/views/GenerateView.vue
+++ b/desktop/src/views/GenerateView.vue
@@ -1637,7 +1637,15 @@ function canvasMenu(): MenuEntry[] {
       label: "Cancel",
       danger: true,
       disabled: !live,
-      action: () => void generation.cancel(j.clientId).then(() => toasts.push("Cancelled")),
+      action: () =>
+        void generation
+          .cancel(j.clientId)
+          .then((cancelled) => {
+            if (cancelled) toasts.push("Cancelled");
+          })
+          .catch((error) =>
+            toasts.push(error instanceof Error ? error.message : String(error), "error"),
+          ),
     },
     { separator: true },
     {

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -132,7 +132,7 @@ export async function fetchQueue(
   return (await res.json()) as QueueListing;
 }
 
-/** Cancel a queued or running generation on the exact host that owns it. */
+/** Cancel a queued generation on the exact host that owns it. */
 export async function cancelQueueJob(
   id: string,
   target?: StreamTarget,
@@ -141,7 +141,7 @@ export async function cancelQueueJob(
     `${targetBase(target)}/api/queue/${encodeURIComponent(id)}`,
     { method: "DELETE", headers: targetHeaders(target) },
   );
-  if (!res.ok && res.status !== 404) {
+  if (!res.ok) {
     const detail = await res.text().catch(() => "");
     throw new Error(
       `Cancel failed (${res.status})${detail ? `: ${detail}` : ""}`,

--- a/web/src/components/machines/hostClient.test.ts
+++ b/web/src/components/machines/hostClient.test.ts
@@ -100,9 +100,11 @@ describe("hostClient auth + requests", () => {
     expect(JSON.parse(init.body as string)).toEqual({ position: 0 });
   });
 
-  it("treats a 404 cancel as already gone", async () => {
+  it("rejects a 404 cancel because cancellation was not confirmed", async () => {
     fetchMock.mockResolvedValueOnce(ok({}, 404));
-    await expect(cancelQueueJob(remote, "job1")).resolves.toBeUndefined();
+    await expect(cancelQueueJob(remote, "job1")).rejects.toThrow(
+      "DELETE /api/queue/job1 failed: 404",
+    );
   });
 
   it("routes queue-wide controls to the selected host", async () => {

--- a/web/src/components/machines/hostClient.ts
+++ b/web/src/components/machines/hostClient.ts
@@ -75,6 +75,7 @@ async function send(
   path: string,
   method: string,
   body?: unknown,
+  allowNotFound = true,
 ): Promise<void> {
   const headers: Record<string, string> = { ...authHeaders(host.apiKey) };
   if (body !== undefined) headers["content-type"] = "application/json";
@@ -83,8 +84,9 @@ async function send(
     headers,
     body: body !== undefined ? JSON.stringify(body) : undefined,
   });
-  // DELETE routes answer 204; treat a 404 cancel as already-gone.
-  if (!res.ok && res.status !== 204 && res.status !== 404) {
+  // DELETE routes answer 204. A missing queue id is not proof that this
+  // client's job stopped, so cancellation callers must observe 404.
+  if (!res.ok && res.status !== 204 && (res.status !== 404 || !allowNotFound)) {
     throw new Error(`${method} ${path} failed: ${res.status}`);
   }
 }
@@ -229,7 +231,13 @@ export async function hostCapabilities(
 }
 
 export function cancelQueueJob(host: HostEntry, id: string): Promise<void> {
-  return send(host, `/api/queue/${encodeURIComponent(id)}`, "DELETE");
+  return send(
+    host,
+    `/api/queue/${encodeURIComponent(id)}`,
+    "DELETE",
+    undefined,
+    false,
+  );
 }
 
 export function pauseHostQueue(host: HostEntry): Promise<void> {

--- a/web/src/composables/useGenerateStream.test.ts
+++ b/web/src/composables/useGenerateStream.test.ts
@@ -360,7 +360,10 @@ describe("workStarted tracking", () => {
     const stream = useGenerateStream();
     stream.canvasErrorJobId.value = null;
     for (const j of stream.jobs.value) {
-      if (j.state === "running") stream.cancel(j.id);
+      if (j.state === "running") {
+        j.controller.abort();
+        j.state = "canceled";
+      }
     }
     stream.clearDone();
   });
@@ -548,7 +551,10 @@ describe("auto-remove completed jobs", () => {
     stream.canvasErrorJobId.value = null;
     // Cancel anything still "running" then drop everything settled.
     for (const j of stream.jobs.value) {
-      if (j.state === "running") stream.cancel(j.id);
+      if (j.state === "running") {
+        j.controller.abort();
+        j.state = "canceled";
+      }
     }
     stream.clearDone();
   });
@@ -649,12 +655,14 @@ describe("auto-remove completed jobs", () => {
     );
   });
 
-  it("does NOT auto-remove a canceled job", () => {
+  it("does NOT auto-remove a locally waiting canceled job", async () => {
     const stream = useGenerateStream();
     const id = stream.submit(singleGen({ frames: 1 }), { kind: "single" });
     stream.select(id);
     expect(stream.selectedJob.value?.id).toBe(id);
-    stream.cancel(id);
+    const submitted = stream.jobs.value.find((j) => j.id === id)!;
+    submitted.streamStarted = false;
+    await stream.cancel(id);
     const job = stream.jobs.value.find((j) => j.id === id);
     expect(job?.state).toBe("canceled");
     expect(stream.selectedJob.value).toBeNull();
@@ -683,26 +691,21 @@ describe("auto-remove completed jobs", () => {
     expect(stream.jobs.value.find((j) => j.id === id)).toBeUndefined();
   });
 
-  it("does NOT auto-remove if user cancels during the grace period (no flash)", () => {
-    // Regression: prior code unconditionally removed at +1500ms, so a
-    // cancel landing between done-flip and timer-fire would briefly show
-    // "canceled" on the card and then auto-dismiss anyway, losing the
-    // user's signal. Timer must re-check `state === "done"` at fire time.
+  it("keeps a completed result authoritative if cancel is clicked during its grace period", () => {
     const stream = useGenerateStream();
     const id = stream.submit(singleGen({ frames: 1 }), { kind: "single" });
     expect(lastSingleHandlers).not.toBeNull();
     lastSingleHandlers!.onComplete(fakeCompleteEvent());
     expect(stream.jobs.value.find((j) => j.id === id)?.state).toBe("done");
 
-    // User clicks Cancel during the 1500ms grace window.
+    // A late Cancel cannot rewrite the server's completed terminal result.
     vi.advanceTimersByTime(500);
     stream.cancel(id);
-    expect(stream.jobs.value.find((j) => j.id === id)?.state).toBe("canceled");
+    expect(stream.jobs.value.find((j) => j.id === id)?.state).toBe("done");
 
-    // Timer fires; job must still be present and still in `canceled`.
+    // It follows the normal completed-row removal path.
     vi.advanceTimersByTime(__testing__.AUTO_REMOVE_DONE_MS + 100);
-    expect(stream.jobs.value.find((j) => j.id === id)).toBeDefined();
-    expect(stream.jobs.value.find((j) => j.id === id)?.state).toBe("canceled");
+    expect(stream.jobs.value.find((j) => j.id === id)).toBeUndefined();
   });
 
   it("auto-removes a chain job ~1500ms after chain complete", () => {
@@ -753,7 +756,10 @@ describe("live latent preview", () => {
     }
     const stream = useGenerateStream();
     for (const j of stream.jobs.value) {
-      if (j.state === "running") stream.cancel(j.id);
+      if (j.state === "running") {
+        j.controller.abort();
+        j.state = "canceled";
+      }
     }
     stream.clearDone();
   });
@@ -938,6 +944,7 @@ describe("activeCanvasJob", () => {
       hostLabel: null,
       target: null,
       serverId: null,
+      streamStarted: false,
       previewUrl: null,
       seedVisual: "seed",
       ...overrides,
@@ -1000,6 +1007,7 @@ describe("latestUnresolvedError", () => {
       hostLabel: null,
       target: null,
       serverId: null,
+      streamStarted: false,
       previewUrl: null,
       seedVisual: "seed",
       ...overrides,
@@ -1102,6 +1110,46 @@ describe("useGenerateStream host routing", () => {
       studioRoute.target,
     );
     expect(stream.jobs.value.find((j) => j.id === id)?.state).toBe("canceled");
+  });
+
+  it("keeps a server-owned job running when cancellation is refused", async () => {
+    vi.mocked(cancelQueueJob).mockRejectedValueOnce(
+      new Error("already running"),
+    );
+    const stream = useGenerateStream();
+    const id = stream.submit(
+      singleGen({ frames: 1 }),
+      { kind: "single" },
+      studioRoute,
+    );
+    lastSingleHandlers?.onProgress({
+      type: "queued",
+      id: "server-job-running",
+      position: 0,
+    });
+
+    await expect(stream.cancel(id)).rejects.toThrow("already running");
+
+    const job = stream.jobs.value.find((candidate) => candidate.id === id);
+    expect(job?.state).toBe("running");
+    expect(job?.controller.signal.aborted).toBe(false);
+  });
+
+  it("keeps an opened stream live until its queue id can be cancelled", async () => {
+    const stream = useGenerateStream();
+    const id = stream.submit(
+      singleGen({ frames: 1 }),
+      { kind: "single" },
+      studioRoute,
+    );
+
+    await expect(stream.cancel(id)).rejects.toThrow(
+      "Remote cancellation was not confirmed before the queue ID arrived.",
+    );
+
+    const job = stream.jobs.value.find((candidate) => candidate.id === id);
+    expect(job?.state).toBe("running");
+    expect(job?.controller.signal.aborted).toBe(false);
   });
 
   it("leaves an unrouted job unattributed rather than guessing", () => {

--- a/web/src/composables/useGenerateStream.ts
+++ b/web/src/composables/useGenerateStream.ts
@@ -79,6 +79,10 @@ export interface Job {
    * `null` until the required queued event arrives. The reconciliation poller
    * only sweeps cards whose `serverId` is known. */
   serverId: string | null;
+  /** True once the generation endpoint has been opened. Before this flips the
+   * job is only waiting for a local browser slot and can be safely aborted;
+   * afterward cancellation requires a server queue id and confirmed DELETE. */
+  streamStarted?: boolean;
   /** Latest live latent preview as a `data:image/png;base64,…` URI.
    * Deliberately a data URI rather than a blob URL: the module-singleton job
    * list is persisted and shared across consumers, so there is no sane place
@@ -595,6 +599,7 @@ function loadPersistedState(raw: string | null): LoadedJobsState {
         hostLabel: p.hostLabel,
         target: null,
         serverId: p.serverId,
+        streamStarted: false,
         // Previews are ephemeral SSE payload — never persisted.
         previewUrl: null,
         seedVisual: seedVisualFor(p.request),
@@ -746,12 +751,10 @@ function failRunningJob(id: string, error: string) {
 const AUTO_REMOVE_DONE_MS = 1500;
 
 /** Schedule auto-removal of a successfully-completed job. The timer
- * re-checks `state` at fire time and bails if the job has since flipped
- * to `canceled` (user clicked Cancel during the grace period) — without
- * this, the card would briefly flash "canceled" then auto-dismiss
- * anyway, losing the user's signal. Safe to call for jobs that have
- * already been manually dismissed: `removeJob` filters by id, so a
- * missing id is a no-op. */
+ * re-checks `state` at fire time so any later terminal reconciliation
+ * remains authoritative. Safe to call for jobs that have already been
+ * manually dismissed: `removeJob` filters by id, so a missing id is a
+ * no-op. */
 function scheduleAutoRemoveOnDone(id: string) {
   setTimeout(() => {
     const job = jobs.value.find((j) => j.id === id);
@@ -822,6 +825,7 @@ function submitJob(
     hostLabel: route?.label ?? null,
     target: route?.target ?? null,
     serverId: null,
+    streamStarted: false,
     previewUrl: null,
     seedVisual: seedVisualFor(req),
   }) as Job;
@@ -851,6 +855,7 @@ function submitJob(
   const startStream = async () => {
     if (decision.kind === "chain") {
       const chainReq = resolveChainRequest(req, decision);
+      job.streamStarted = true;
       await generateChainStream(
         chainReq,
         {
@@ -901,6 +906,7 @@ function submitJob(
           lease = prepared;
           transportRequest = prepared.request;
         }
+        job.streamStarted = true;
         await generateStream(
           transportRequest,
           {
@@ -945,19 +951,27 @@ function submitJob(
 
 async function cancelJob(id: string): Promise<void> {
   const job = jobs.value.find((j) => j.id === id);
-  if (!job) return;
+  if (!job || job.state !== "running") return;
+  if (job.serverId) {
+    try {
+      await cancelQueueJob(job.serverId, job.target ?? undefined);
+    } catch (error) {
+      // Completion can race the DELETE. If the stream already settled, its
+      // terminal frame is authoritative; otherwise cancellation was not
+      // confirmed and the server-owned job must remain live locally.
+      if (job.state !== "running") return;
+      throw error;
+    }
+  } else if (job.streamStarted) {
+    throw new Error(
+      "Remote cancellation was not confirmed before the queue ID arrived.",
+    );
+  }
   job.controller.abort();
   job.state = "canceled";
   job.settledAt = Date.now();
   job.previewUrl = null;
   if (selectedJobId.value === id) selectedJobId.value = null;
-  if (!job.serverId) return;
-  try {
-    await cancelQueueJob(job.serverId, job.target ?? undefined);
-  } catch (error) {
-    job.error = error instanceof Error ? error.message : String(error);
-    recordFailedSettlement(job);
-  }
 }
 
 function clearDoneJobs() {

--- a/web/src/pages/CreatePage.test.ts
+++ b/web/src/pages/CreatePage.test.ts
@@ -153,6 +153,7 @@ const gcChainJobsMock = vi.hoisted(() =>
   vi.fn(async () => ({ swept_ephemeral_jobs: 0, pruned_artifact_dirs: 0 })),
 );
 const amendChainJobMock = vi.hoisted(() => vi.fn());
+const cancelPrintMock = vi.hoisted(() => vi.fn(async () => undefined));
 
 vi.mock("../api", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../api")>();
@@ -195,7 +196,7 @@ vi.mock("../composables/useGenerateStream", async (importOriginal) => ({
     canvasErrorJobId: streamCanvasErrorJobIdRef,
     selectedJob: streamSelectedJobRef,
     submit: submitMock,
-    cancel: vi.fn(),
+    cancel: cancelPrintMock,
     failRunning: vi.fn(),
     remove: vi.fn(),
     clearDone: vi.fn(),
@@ -307,6 +308,8 @@ describe("CreatePage layout and behavior", () => {
     streamCanvasErrorJobIdRef.value = null;
     streamSelectedJobRef.value = null;
     streamSelectMock.mockReset();
+    cancelPrintMock.mockReset();
+    cancelPrintMock.mockResolvedValue(undefined);
     upscaleStreamMock.mockReset();
     upscaleStreamMock.mockResolvedValue(undefined);
     createChainJobMock.mockClear();
@@ -2333,6 +2336,22 @@ describe("CreatePage layout and behavior", () => {
     expect(
       (strip.props("sequences") as { jobId: string }[]).map((s) => s.jobId),
     ).toEqual(["chain-9"]);
+  });
+
+  it("reports an unconfirmed print cancellation instead of claiming success", async () => {
+    cancelPrintMock.mockRejectedValueOnce(new Error("job is already running"));
+    const wrapper = mount(CreatePage, { global: { stubs: pageStubs() } });
+    await flushPromises();
+
+    wrapper
+      .getComponent({ name: "ActivityStrip" })
+      .vm.$emit("cancel", "print-9");
+    await flushPromises();
+
+    expect(cancelPrintMock).toHaveBeenCalledWith("print-9");
+    expect(useNotifications().toasts.map((item) => item.text)).toContain(
+      "job is already running",
+    );
   });
 
   it("clears stale advanced fields when a selected job omits optional keys", async () => {

--- a/web/src/pages/CreatePage.vue
+++ b/web/src/pages/CreatePage.vue
@@ -1764,6 +1764,14 @@ function onSequenceAction(action: ActivityAction, vm: ActivityJobVM) {
   }
 }
 
+function cancelPrint(id: string) {
+  void stream
+    .cancel(id)
+    .catch((error) =>
+      toast("error", error instanceof Error ? error.message : String(error)),
+    );
+}
+
 /**
  * Reuse a sequence print's recorded clips as a BRAND-NEW draft: no edit
  * session, nothing cached, Generate queues a fresh job. Shared params ride
@@ -3535,7 +3543,7 @@ onBeforeUnmount(() => {
           :jobs="stream.jobs.value"
           :sequences="sequenceVMs"
           :shared="sharedActivityRows"
-          @cancel="stream.cancel"
+          @cancel="cancelPrint"
           @dismiss="stream.remove"
           @open="openJob"
           @sequence-action="onSequenceAction"

--- a/web/src/pages/HostDetailPage.test.ts
+++ b/web/src/pages/HostDetailPage.test.ts
@@ -57,6 +57,7 @@ const setDeviceEnabled = vi.hoisted(() =>
     }),
   ),
 );
+const toastMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@studio/api/devices", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@studio/api/devices")>()),
@@ -67,7 +68,7 @@ const hostCapabilitiesCall = vi.hoisted(() => vi.fn());
 const hostQueueCall = vi.hoisted(() => vi.fn());
 
 vi.mock("../lib/toasts", () => ({
-  toast: vi.fn(),
+  toast: toastMock,
   requestConfirm,
   requestText,
 }));
@@ -239,6 +240,7 @@ beforeEach(() => {
   models = [];
   downloadsListing = { active: null, active_jobs: [], queued: [], history: [] };
   cancelQueueJob.mockClear();
+  toastMock.mockClear();
   setQueueJobLane.mockClear();
   moveQueueJob.mockClear();
   pauseHostQueue.mockClear();
@@ -589,6 +591,21 @@ describe("HostDetailPage — queue", () => {
     expect(cancelQueueJob).toHaveBeenCalledWith(
       expect.objectContaining({ id: routeHolder.id }),
       "a",
+    );
+  });
+
+  it("keeps a queued job visible and reports an unconfirmed cancellation", async () => {
+    queueEntries = [queued("a", 0)];
+    cancelQueueJob.mockRejectedValueOnce(new Error("DELETE failed: 404"));
+    const w = await mountDetail();
+
+    await w.get('[data-test="queue-cancel"]').trigger("click");
+    await flushPromises();
+
+    expect(w.find('[data-test="queue-cancel"]').exists()).toBe(true);
+    expect(toastMock).toHaveBeenCalledWith(
+      "error",
+      "Couldn't cancel job: DELETE failed: 404",
     );
   });
 


### PR DESCRIPTION
## Summary

- raise desktop and iPhone per-host generation admission from two to four streams so a four-worker host can fill every available GPU
- keep desktop, iPhone, and web jobs live when queue cancellation is refused, unknown, or not yet addressable by a server job ID
- surface cancellation failures across every Create and machine queue action without false Cancelled success states
- preserve terminal SSE authority during DELETE races, including truthful mixed bulk-cancellation feedback

## Root cause

The desktop shared generation store limited each host to two held SSE requests, so H3 and Wan consumed both client slots and Qwen never reached the server even though GPU 1 was idle. Separately, the store swallowed HTTP 409 and 404 cancellation failures, aborted its own stream, and labeled the job Cancelled while the server continued running it. Clearing finished only removed that false local row; live queue reconciliation then rediscovered the actual H3 job.

## Coverage

- complete frontend gate: 5,414 tests passed
- frontend architecture contract passed
- web production build passed
- desktop production build passed
- iPhone production build passed
- focused cancellation coverage includes 409, 404, pre-ID, terminal-race, mixed bulk, machine-detail, and mobile UI paths
- focused admission coverage proves four concurrent streams and fifth-job permit release

## Review

An independent subagent peer-reviewed the final diff. Three findings were fixed and the final re-review approved with no remaining actionable findings.