### PR TITLE
fix(ci): allow tracked LTX-2 image fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,8 @@ web/*.tsbuildinfo
 !docs/design/**/*.png
 !apps/mobile/src-tauri/app-icon.png
 !apps/mobile/src-tauri/gen/apple/Assets.xcassets/**/*.png
+!crates/mold-inference/src/ltx2/testdata/preprocess/*.jpg
+!crates/mold-inference/src/ltx2/testdata/preprocess/*.png
 apps/mobile/src-tauri/gen/schemas/
 result
 result-*


### PR DESCRIPTION
## Summary

- explicitly allow the committed LTX-2 preprocessing JPG and PNG fixtures
- restore release-plz clean-worktree validation
- allow the release workflow to refresh the conflicted v0.22.0 release PR

## Validation

- `git diff --check`
- `test -z "$(git ls-files -ci --exclude-standard)"`