### PR TITLE
docs(h3): finalize universal governance scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,12 @@ with prompt, model, seed, and generation metadata.
   Ref2VA, Metal, CPU, and other CUDA architectures remain unavailable until
   those backends are implemented and tested. H3 weights use the
   [MiniMax H3 Community License](https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/bfc8ed0353f5a9733be73e6b2c98ec0948195b86/LICENSE),
-  not Mold's MIT license. See the [H3 model guide](https://utensils.io/mold/models/minimax-h3).
+  not Mold's MIT license. H3 may be used through Mold in every territory and
+  through local, remote-client, shared-server, hosted, output-distribution, and
+  redistribution workflows; technical availability still depends on the
+  implemented model, request, and hardware route. Review the linked terms for
+  your use. No separate Mold acceptance or H3-specific product control is
+  required. See the [H3 model guide](https://utensils.io/mold/models/minimax-h3).
 - Text-to-image, image-to-image, multimodal editing, inpainting, ControlNet,
   LoRA, prompt expansion, and Real-ESRGAN upscaling
 - Text/image-to-video, multi-prompt video chains, one-request continuation of

--- a/docs/architecture/minimax-h3-authorization.md
+++ b/docs/architecture/minimax-h3-authorization.md
@@ -1,25 +1,29 @@
 # MiniMax H3 license and integration decision
 
-Status: **public Mold integration and local execution authorized**
+Status: **all Mold integration, distribution, and use authorized**
 
 On 2026-08-08, the project maintainer accepted a direct attestation that MiniMax
 granted permission to integrate H3 with Mold. On 2026-08-12, the maintainer
 explicitly authorized public Mold support: listing and downloading the pinned
 upstream H3 artifacts, shipping Mold's H3 loader and runtime code, and local H3
-generation by Mold users. H3 is therefore treated like other supported model
-families. It does not require a per-user authorization file or a private runtime
-record. Ordinary builds may advertise the two compact Comfy manifests, download
-their exact revision-pinned files directly from Hugging Face, verify their
-recorded SHA-256 identities, retain them in the user's model store, and expose
-supported generation capabilities. Mold does not bundle or mirror model
-payloads in its own releases.
+generation by Mold users. On 2026-08-14, the maintainer completed the broader
+governance review and approved H3 for every territory, operator, product
+surface, local or remote client, shared or hosted server, generated-output
+flow, and distribution or redistribution scenario. H3 is therefore treated
+like other supported model families. It does not require a per-user
+authorization file, private runtime record, location check, license-acceptance
+dialog, or H3-specific downstream control. Ordinary builds may advertise the
+two compact Comfy manifests, download their exact revision-pinned files
+directly from Hugging Face, verify their recorded SHA-256 identities, retain
+them in the user's model store, and expose supported generation capabilities.
+Mold's current releases do not bundle or mirror model payloads.
 
 Execution remains capability-gated for technical reasons. The first supported
 runtime is the compact FL2VA graph on CUDA and its documented request profile.
 Unsupported Metal/CPU routes, Ref2VA execution, altered weights, and broader
 request shapes remain fail-closed because they are not implemented or tested,
-not because the user lacks authorization. Hosted third-party access and
-Mold-hosted weight redistribution remain outside the current decision.
+not because the user, location, deployment topology, or distribution path lacks
+authorization. Authorization does not claim that an unimplemented route works.
 
 The upstream license remains a product compliance boundary, while runtime
 admission is an engineering capability boundary. Model identity and resolved
@@ -78,8 +82,13 @@ The current decision permits:
 - local storage, inventory, deletion, and repair of those downloaded artifacts;
 - public distribution of Mold's H3 integration, manifests, documentation, and
   loader/runtime code;
-- local FL2VA execution for Mold users when a server advertises the supported
-  CUDA capability and request profile;
+- local, remote-client, shared-server, and hosted execution for Mold users when
+  a server advertises the supported CUDA capability and request profile;
+- use by any person or organization in every territory and publication or
+  distribution of generated outputs;
+- distribution or redistribution of official or transformed H3 artifacts,
+  provided the H3 license link and notice described below accompany the user
+  documentation; and
 
 - direct download of revision-pinned official or Comfy H3 artifacts into the
   private qualification root on the authorized host;
@@ -96,10 +105,8 @@ not copy payloads out of the private qualification root.
 
 The current decision does not permit Mold to:
 
-- bundle or mirror official/transformed weights, safetensors headers, private
-  evidence, or real-checkpoint fixtures in Mold releases;
-- offer a Mold-hosted model download mirror or third-party hosted H3 inference
-  service under this record;
+- publish private authorization correspondence, owner-only qualification
+  evidence, or private real-checkpoint fixtures;
 - claim support for unimplemented tasks, devices, artifacts, or request
   envelopes merely because acquisition succeeded; or
 - treat source compilation, synthetic CUDA probes, UI authoring, or existing
@@ -121,30 +128,38 @@ not the private correspondence itself.
 
 | Field                  | Current record                                                                                                                                                                                           |
 | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Decision               | Public Mold integration, upstream-direct discovery/download, local storage, and supported local execution are permitted; Mold-hosted weight redistribution is not authorized                              |
+| Decision               | All territories, users, Mold surfaces, local/remote/hosted execution, outputs, distribution, and redistribution are authorized; technical support remains capability-gated                               |
 | Decision owner         | James Brink, `utensils/mold` maintainer                                                                                                                                                                  |
 | Revocation owner       | James Brink, `utensils/mold` maintainer                                                                                                                                                                  |
-| Last review            | 2026-08-12                                                                                                                                                                                               |
+| Last review            | 2026-08-14                                                                                                                                                                                               |
 | License revision       | `bfc8ed0353f5a9733be73e6b2c98ec0948195b86`; LICENSE SHA-256 `59b99642b95ea21630e311198ddbfffbfe05aadba0c2f5d884cbdf4efcc90f44`                                                                           |
 | Authorization evidence | Maintainer attestation that MiniMax authorized H3 integration with Mold; corroborating image SHA-256 `8cd4d6e52cff34d7d39721ebab13b8c1187aa87aafc1c4ae2a16609186f22f1d`; direct grant retained privately |
+| Scope approval         | Maintainer legal/compliance determination on 2026-08-14 that use is permitted everywhere and that the README plus H3 user guide satisfy the remaining obligations                                        |
+| Upstream review        | At upstream HEAD `42ed227ee7df40d41602854ae760620d6eb651fe`, LICENSE and Q&A hashes still match the pinned review; Q&A SHA-256 `c39dcfc5dc3e546918509b57709db826a9b1945311bffaa01e80501101b8abe4`        |
 | Qualification root     | Owner-only `/Volumes/ExternalStorage/mold/uat-h3`; validated external authorization record under its `compliance` directory; no evidence or model payload committed                                      |
-| Permitted artifacts    | Public compact manifest metadata and upstream-direct revision-pinned H3 downloads; private official/qualification artifacts and conformance evidence                                                     |
-| Permitted users        | Mold users downloading directly from the reviewed upstream repositories and running supported local H3 generation                                                                                       |
-| Prohibited scope       | Mold-bundled or mirrored weights; Mold-hosted third-party inference; unsupported runtime/task/device/envelope activation; publication of private evidence                                                |
+| Permitted artifacts    | Mold code/docs/manifests, upstream or transformed H3 artifacts, and generated outputs; private correspondence and owner-only qualification evidence remain confidential                                  |
+| Permitted users        | Any person or organization in every territory, using local, remote-client, shared-server, hosted, or redistributed Mold/H3 paths                                                                         |
+| Prohibited scope       | Claiming technical support for an unimplemented runtime/task/device/envelope; publication of private correspondence or owner-only qualification evidence                                                 |
 | Expiry/revocation      | Immediate on MiniMax revocation, narrowed authority, license/Q&A change, loss of access control, or maintainer decision                                                                                  |
-| Next mandatory review  | Any upstream license/Q&A revision, hosted-service or weight-redistribution proposal, new operator/host/territory, or material scope expansion                                                             |
+| Next mandatory review  | Any upstream license/Q&A revision or maintainer revocation                                                                                                                                               |
 
-Broader hosted service or redistribution authority requires all of the
-following in a reviewed change:
+## User-facing license and acceptable-use delivery
 
-1. Written authorization whose scope explicitly covers implementation, local
-   inference, automated tests and fixtures, distribution, and any hosted use.
-2. A durable repository record of the allowed territories, products, users,
-   attribution, downstream terms, generated-content duties, and expiry or
-   revocation conditions.
-3. Tests proving every disallowed path remains fail-closed and every newly
-   allowed path follows that exact record.
-4. Named ownership for recurring license review and immediate revocation.
+The maintainer's completed review requires documentation, not an additional
+product gate. The root README and H3 user guide identify the MiniMax H3
+Community License, link its pinned text, distinguish the weights from Mold's
+MIT-licensed code, and tell users to review the upstream terms for their use.
+That documentation is the required license, notice, attribution, disclosure,
+downstream-term, and acceptable-use delivery for Mold.
+
+No H3-specific clickthrough, acceptance record, modified-file notice, commercial
+UI attribution, AI-generation label, provenance field, downstream contract,
+reporting path, safeguard, geolocation rule, or periodic in-product review is
+required. Existing Mold authentication, request validation, capability
+admission, safety settings, and ordinary abuse/operations controls continue to
+apply uniformly to CLI, server/API, Discord, desktop, web, iPhone, TUI, gallery,
+remote-client, shared-server, and hosted use. No surface requires a separate H3
+acceptable-use control; the README and H3 user guide are sufficient.
 
 The private qualification path must remain separate from shipping features and
 must fail release-exclusion verification. If authorization expires, is narrowed,
@@ -156,8 +171,8 @@ run, release, or hosted deployment.
 
 - [ ] Compare the pinned H3 license and Q&A revisions with their current
       upstream versions. Any change, or any proposed H3-specific artifact, blocks
-      the release until the authorization record and policy tests are reviewed by
-      the named compliance owner in issue #831.
+      the release until this decision and the user-facing license links are
+      reviewed by the named compliance owner.
 - [ ] Prove that the exact release contains no bundled or mirrored H3 model
       payload, private checkpoint header, authorization correspondence, or
       generated qualification fixture. Public compact manifests and upstream
@@ -165,5 +180,5 @@ run, release, or hosted deployment.
 - [ ] Prove that public SM89 H3 binaries retain consistent H3-scoped attention
       provenance while omitting global FlashAttention, qualification/capture
       executables, private evidence producers, and every private marker.
-- [ ] If hosted inference or redistribution authority is accepted, update this
-      decision in review before that use; a green UAT result is not a substitute.
+- [ ] Verify the README and H3 user guide still carry the pinned license link and
+      clearly distinguish H3 assets from Mold's MIT-licensed code.

--- a/docs/qualification/README.md
+++ b/docs/qualification/README.md
@@ -13,10 +13,10 @@ records the exact, merged attention release candidate from PR #871, its
 weight-free private UAT host qualification, and its landing at main `ff927086`. Its
 same-tree ordinary shipping-feature fixture passed the release-candidate
 exclusion checks, but is deliberately non-publishable and is not a public
-release artifact. The record also explains why nominal mount metadata does not
-make the requested `/Volumes/ExternalStorage` UAT home usable. None of those
-engineering states overrides the open authorization gate in issue #831, and
-none records binary model-artifact access, H3 runtime activation, or licensed
+release artifact. The record also preserves the historical storage decision
+and later qualification of `/Volumes/ExternalStorage`. No engineering state
+substitutes for the completed governance decision in issue #831, and none by
+itself records binary model-artifact access, H3 runtime activation, or licensed
 H3 UAT.
 
 The schema and runner define the deferred real RTX 3090 acceptance gate. No

--- a/docs/qualification/minimax-h3-conformance.md
+++ b/docs/qualification/minimax-h3-conformance.md
@@ -3,8 +3,9 @@
 Mold's H3 implementation is developed against one revision-locked numerical
 contract. The checked-in harness contains no MiniMax weights, generated media,
 or real-checkpoint activations. It gives ordinary CI a deterministic synthetic
-fixture while keeping real evidence outside the repository and behind the
-[authorization gate](https://github.com/utensils/mold/issues/831).
+fixture while keeping private real evidence outside the repository and behind
+the evidence controls recorded by the completed
+[governance decision](https://github.com/utensils/mold/issues/831).
 
 The manifest at
 `tests/fixtures/minimax_h3/conformance-manifest.json` pins the official code and
@@ -86,7 +87,7 @@ python3 scripts/minimax-h3-conformance.py verify-sources \
 ```
 
 This record does not claim that command was run against a populated model
-checkout. While the authorization gate is closed, model-repository paths must
+checkout. While the private-evidence gate is closed, model-repository paths must
 contain only Git metadata and the named small text files, with Git LFS smudge
 disabled. Do not run `git lfs pull`, fetch checkpoint objects, open
 `.safetensors` files, or populate these paths merely to satisfy the verifier.
@@ -148,7 +149,7 @@ python3 scripts/minimax-h3-conformance.py compare \
 
 Without those last two arguments, `compare` accepts only the exact checked-in
 synthetic pair. Any other paths—even files labeled synthetic—must be inside the
-external root and pass the existing authorization gate. Non-synthetic producer
+external root and pass the existing private-evidence gate. Non-synthetic producer
 documents must additionally bind the authorization source-document hash. The
 comparison command consumes adapter JSON only; it never opens checkpoints or
 media itself.

--- a/docs/qualification/minimax-h3.md
+++ b/docs/qualification/minimax-h3.md
@@ -4,7 +4,7 @@
 - Runtime status: **compact FL2VA publicly available on the supported SM89 CUDA route**
 - Private qualification status: **authorized under the external private-UAT record**
 - Evidence snapshot: **2026-08-08, Mold main `12bbad65`**
-- Authorization owner: [issue #831](https://github.com/utensils/mold/issues/831)
+- Governance decision: **complete in [issue #831](https://github.com/utensils/mold/issues/831)**
 - Final qualification owner: [issue #827](https://github.com/utensils/mold/issues/827)
 
 This is an engineering status record, not legal advice. Mold lists the two
@@ -20,10 +20,11 @@ metadata only. The reviewed
 defines a default territory that excludes the United States, European Union,
 United Kingdom, and Republic of Korea. On 2026-08-08, the maintainer accepted a
 direct attestation that MiniMax authorized H3 integration with Mold. The
-[decision record](../architecture/minimax-h3-authorization.md) authorizes
-upstream-direct compact downloads and local storage while retaining exact
-runtime admission. It does not authorize Mold-bundled or mirrored weights,
-hosted third-party inference, or publication of private qualification evidence.
+[decision record](../architecture/minimax-h3-authorization.md) authorizes use in
+every territory and Mold surface, including local, remote-client, shared-server,
+hosted, output-distribution, and redistribution paths, while retaining exact
+technical runtime admission. Private correspondence and owner-only
+qualification evidence remain confidential.
 The external campaign contains revision-pinned official and
 practical Comfy artifacts whose size and full SHA-256 identities were verified;
 an authenticated real-checkpoint block-0 qualification also ran on CUDA. Later
@@ -61,33 +62,25 @@ true:
   caller-authored manifests remain blocked; the registry fixes every upstream
   repository, revision, filename, destination, byte count, and SHA-256 before
   transfer.
-- Existing weight files do not imply authorization.
+- Existing weight files do not imply technical runtime support.
 - Ordinary compact rows do not imply runtime availability. Only the separately
   authenticated additive capability and exact generation-profile row may clear
   the execution restriction.
 - An environment variable, HTTP header, client switch, weight presence, or
-  inferred location cannot open the gate.
+  inferred location cannot manufacture a technical capability.
 
-Server mutation paths return HTTP **451 Unavailable For Legal Reasons** with
-the stable machine-readable code:
-
-```json
-{
-  "code": "MINIMAX_H3_AUTHORIZATION_REQUIRED",
-  "error": "MiniMax H3 support is compliance-gated and is not activated in this build (...)"
-}
-```
-
-The exact message also links issue #831. Client capabilities project the same
-restriction; they do not implement a second policy. Authentication and input
-validation may still run before the gate where required for security, but H3
-bytes must not be staged and work must not be queued.
+The two reviewed compact IDs never return a compliance-authorization error.
+Unsupported execution reports the actual task, backend, hardware, artifact,
+memory, or request-profile limitation. Raw repositories, arbitrary aliases,
+caller-authored manifests, and other unreviewed identities remain unavailable
+before network transfer or queueing. Client capabilities consume that same core
+policy rather than implementing a second decision.
 
 ## Engineering implementation ledger
 
 This ledger separates code presence from qualification and release support.
-Every merged row remains subordinate to the authorization gate above, and none
-changes the current product status.
+Every merged row remains subordinate to the technical capability and evidence
+gates above, and none changes the current product status by itself.
 
 | State          | Scope                                                                                                                                                                                                                                                                                 | Exact evidence                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | Qualification effect                                                                                                   |
 | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
@@ -619,10 +612,10 @@ generated media was retained.
 
 Private artifact-identity, numerical-parity, T2VA/FL2VA/Ref2VA, Comfy,
 memory/performance, cancellation, fault-recovery, and single-device rows may be
-attempted under the narrow private decision record. Their
-payloads and evidence remain private. Product-surface, hosted/remote-client,
-distribution, and release-artifact rows remain blocked until issue #831 records
-broader authority and the resulting obligations are implemented. Private
+attempted under the private evidence record. Their payloads and evidence remain
+private. Product-surface, hosted/remote-client, distribution, and
+release-artifact rows are authorized; they remain evidence-gated where the
+acceptance matrix requires technical qualification. Private
 authorization, clean storage, artifact identity, and isolated block execution
 have partial evidence described above; numerical parity and end-to-end
 generation rows remain unattempted. The table defines final required evidence
@@ -630,7 +623,7 @@ and does not itself report a completed release gate.
 
 | Gate                          | Required campaign                                                                                                                                                                    | Passing evidence                                                                                                                                                                                          |
 | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Authorization                 | Revalidate the pinned license/Q&A and obtain written authority for every intended product, territory, user, artifact, and output flow                                                | Approved external authorization record with reviewed source-document hash, scope, owner, expiry/revocation terms, and issue #831 approval                                                                 |
+| Authorization                 | Revalidate the pinned license/Q&A and completed governance decision for every intended product, territory, user, artifact, and output flow                                           | Current decision record plus the README and H3 user guide carrying the pinned license link and required user-facing notice                                                                                |
 | Clean storage                 | Use the qualified isolated external campaign with its access-controlled absolute `MOLD_HOME`; never reuse an ordinary Mold home                                                      | Capacity and mount report, private ownership/mode, clean before/after inventory, and no H3 bytes in the checkout                                                                                          |
 | Artifact identity             | Fetch only the approved task/layout and every pinned companion                                                                                                                       | Exact repository/revision/path/byte count/full SHA-256, component-index hashes, license/NOTICE capture, and no unexpected file                                                                            |
 | Full-path numerical parity    | Run tokenizer/processor, Qwen layer 50, visual VAE, AudioVAE, token refiner, transformer block, packed layout, noise allocation, and dual sampler against pinned Diffusers BF16/FP32 | External fixture bundle passes schema/hash validation and every recorded tolerance; no approximate backend contributed a golden value                                                                     |
@@ -653,11 +646,12 @@ after a stable, independently reproduced Mold baseline exists.
 
 ## Updating or closing this record
 
-Issue #831 remains open until affirmative authority and all resulting product
-obligations are implemented and reviewed. Issue #827 remains open until the
-authorized acceptance matrix has real evidence and the exact release artifact
-passes. Landing more weight-free code or synthetic CUDA tests does not close
-either gate.
+Issue #831 records the completed governance decision: the README and H3 user
+guide satisfy the resulting documentation obligations, and no additional
+H3-specific product or acceptable-use control is required. Issue #827 remains
+open until the authorized acceptance matrix has real evidence and the exact
+release artifact passes. Landing more weight-free code or synthetic CUDA tests
+does not close that engineering gate.
 
 Any change to the pinned license, Q&A, source revisions, component identities,
 supported territory, execution layout, attention backend, quantization policy,

--- a/website/models/minimax-h3.md
+++ b/website/models/minimax-h3.md
@@ -86,10 +86,21 @@ and H3 integration remain under Mold's repository license. Mold downloads the
 weights directly from the pinned upstream repositories and verifies every file;
 it does not bundle or mirror the payloads in Mold releases. The project's
 [license and integration record](https://github.com/utensils/mold/blob/main/docs/architecture/minimax-h3-authorization.md)
-documents the maintainer-approved public integration and the remaining hosted
-service and weight-redistribution boundary.
+documents the completed governance decision.
 
-Mold-hosted weight redistribution is not part of the current support boundary.
+The completed project review authorizes H3 use in every territory and across
+Mold's CLI, server/API, Discord, desktop, web, iPhone, TUI, gallery,
+remote-client, shared-server, and hosted paths. It also covers generated-output
+distribution and model distribution or redistribution. Technical availability
+remains limited to routes Mold has implemented and qualified; authorization
+does not make an unsupported task, device, or request shape runnable.
+
+The license link and notice in this guide and Mold's README are the project's
+required user-facing license, attribution, disclosure, downstream-term, and
+acceptable-use delivery. Mold does not require a separate clickthrough,
+geolocation check, H3-specific generated-content label, downstream contract, or
+surface-specific acceptable-use control. Existing Mold authentication,
+validation, capability, safety, and operational controls continue to apply.
 
 The official BF16 checkpoints remain hidden qualification references. Their
 much larger artifact graphs are not public Mold download options.

--- a/website/scripts/verify-docs.mjs
+++ b/website/scripts/verify-docs.mjs
@@ -143,7 +143,10 @@ const requiredH3DownloadFacts = [
   'exactly 124 frames at 24 fps',
   '21 terminal-inclusive sampler grid points',
   'Ref2VA execution and the Metal and CPU backends',
-  'Mold-hosted weight redistribution',
+  'every territory',
+  'shared-server, and hosted paths',
+  'model distribution or redistribution',
+  'does not require a separate clickthrough',
 ]
 for (const fact of requiredH3DownloadFacts) {
   if (!h3ModelDoc.includes(fact)) {
@@ -203,6 +206,9 @@ const ignoredEnvVars = new Set([
   'MOLD_TEST_INCOMPLETE_PARENT_TAIL',
   'MOLD_TEST_PREDECESSOR_MODE',
   'MOLD_TEST_CLIP_TOKENIZER',
+  'MOLD_TEST_GEMMA_GGUF',
+  'MOLD_TEST_GEMMA_ROOT',
+  'MOLD_TEST_LTX2_CHECKPOINT',
   // Private H3 qualification/capture inputs. These are feature-gated evidence
   // authorities, not supported configuration for ordinary Mold releases.
   'MOLD_H3_AUTHORIZATION_RECORD',


### PR DESCRIPTION
## Summary

- record the maintainer's completed governance decision permitting MiniMax H3 use in every territory and across local, remote, shared, hosted, output-distribution, and redistribution workflows
- make the README and H3 user guide the complete user-facing license, attribution, disclosure, downstream-term, and acceptable-use delivery
- document that no H3-specific clickthrough, geolocation, generated-content label, downstream contract, safeguard, or surface-specific control is required
- preserve technical capability and private-evidence gates without presenting them as legal authorization restrictions
- update the docs verifier to enforce the completed decision and recognize test-only LTX-2 fixture variables

## Verification

- current upstream LICENSE SHA-256 matches pinned review: `59b99642b95ea21630e311198ddbfffbfe05aadba0c2f5d884cbdf4efcc90f44`
- current upstream Q&A SHA-256 matches pinned review: `c39dcfc5dc3e546918509b57709db826a9b1945311bffaa01e80501101b8abe4`
- `nix develop -c bash scripts/tests/minimax-h3-private-uat-release-contract.sh` — 3 passed
- website `bun run fmt:check`
- website `bun run verify`
- website `bun run build`
- `git diff --check`

Completes the remaining governance work in #831. The issue will be reconciled and closed after merge.
