### PR TITLE
fix(studio): explain Auto profile conflicts

### DIFF
--- a/desktop/src/views/GenerateView.vue
+++ b/desktop/src/views/GenerateView.vue
@@ -28,6 +28,7 @@ import SequenceComposer from "../components/create/SequenceComposer.vue";
 import { useSequenceDraftStore } from "@studio/stores/sequenceDraft";
 import { filterRestrictedModels } from "@studio/lib/modelAccess";
 import { effectiveGenerationRecipe } from "@studio/lib/generationProfile";
+import { profileConflictMessage } from "@studio/lib/profileFleet";
 import { useLiveActivityStore } from "../stores/liveActivity";
 import { imageDimensionsFromBase64 } from "@studio/lib/imageDimensions";
 import {
@@ -209,8 +210,7 @@ const liveActivity = useLiveActivityStore();
 
 function placementFailureMessage(result: Exclude<FeasibleRouteResult, { kind: "route" }>): string {
   if (result.kind === "profile_mismatch") {
-    const machines = result.perHost.map((host) => host.label).join(", ");
-    return `Settings differ by machine${machines ? ` (${machines})` : ""}. Choose a specific machine before generating. Nothing was queued.`;
+    return profileConflictMessage(result.perHost);
   }
   if (result.kind === "infeasible") {
     const details = result.perHost

--- a/studio/lib/profileFleet.test.ts
+++ b/studio/lib/profileFleet.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { profileHashConflict } from "./profileFleet";
+import { profileConflictMessage, profileHashConflict } from "./profileFleet";
 
 const model = (hash: string | null, downloaded = true) => ({
   name: "z-image-turbo:q4",
@@ -60,5 +60,27 @@ describe("profileHashConflict", () => {
         ["local", "catalog"],
       ),
     ).toBeNull();
+  });
+});
+
+describe("profileConflictMessage", () => {
+  it("names conflicting machines and gives an immediate recovery action", () => {
+    expect(
+      profileConflictMessage([
+        { label: "This Mac", profileHash: "local-profile" },
+        { label: "plato", profileHash: "remote-profile" },
+      ]),
+    ).toBe(
+      "Auto can't safely choose a machine because This Mac and plato use different generation settings for this model. They may be running different Mold versions or builds, so the same controls could produce different results. Update and reconnect them, or choose one machine for this print. Nothing was queued.",
+    );
+  });
+
+  it("explains when an older machine may lack a generation profile", () => {
+    expect(
+      profileConflictMessage([
+        { label: "This Mac", profileHash: "current-profile" },
+        { label: "studio", profileHash: null },
+      ]),
+    ).toContain("At least one may be running an older Mold version");
   });
 });

--- a/studio/lib/profileFleet.ts
+++ b/studio/lib/profileFleet.ts
@@ -19,6 +19,30 @@ export interface ProfileHashConflict {
   hashesByHost: Record<string, string | null>;
 }
 
+export interface ProfileConflictHost {
+  label: string;
+  profileHash: string | null;
+}
+
+function formatMachineList(hosts: readonly ProfileConflictHost[]): string {
+  const labels = hosts.map((host) => host.label);
+  if (labels.length < 2) return labels[0] ?? "the available machines";
+  if (labels.length === 2) return `${labels[0]} and ${labels[1]}`;
+  return `${labels.slice(0, -1).join(", ")}, and ${labels.at(-1)}`;
+}
+
+/** Explain why automatic routing cannot safely choose between model owners. */
+export function profileConflictMessage(
+  hosts: readonly ProfileConflictHost[],
+): string {
+  const owners = formatMachineList(hosts);
+  const hasLegacyOwner = hosts.some((host) => !host.profileHash);
+  const cause = hasLegacyOwner
+    ? "At least one may be running an older Mold version, so the same controls could produce different results."
+    : "They may be running different Mold versions or builds, so the same controls could produce different results.";
+  return `Auto can't safely choose a machine because ${owners} use different generation settings for this model. ${cause} Update and reconnect them, or choose one machine for this print. Nothing was queued.`;
+}
+
 export function profileHashConflict(
   modelsByHost: Readonly<Record<string, readonly FleetProfileModel[]>>,
   modelName: string,

--- a/web/src/pages/CreatePage.vue
+++ b/web/src/pages/CreatePage.vue
@@ -173,6 +173,7 @@ import {
   useHostRouting,
   type FeasibilityResult,
 } from "../composables/useHostRouting";
+import { profileConflictMessage } from "@studio/lib/profileFleet";
 import { generationCapabilitiesForFamily } from "../lib/generateCapabilities";
 import {
   canOfferExtend,
@@ -2484,8 +2485,7 @@ function feasibilityMessage(
   subject: string,
 ): string {
   if (result.kind === "profile_mismatch") {
-    const machines = result.perHost.map((host) => host.label).join(", ");
-    return `Settings differ by machine${machines ? ` (${machines})` : ""}. Choose a specific machine before generating. Nothing was queued.`;
+    return profileConflictMessage(result.perHost);
   }
   const unreachableMessages = (
     hosts: ReadonlyArray<{ label: string; error: string }>,


### PR DESCRIPTION
## What changed

- replace the opaque "Settings differ by machine" failure with a shared desktop/web explanation
- name every conflicting machine and explain why Auto stops
- distinguish a missing legacy profile from two current profiles that disagree
- give users two concrete recovery paths: update and reconnect the fleet, or choose one machine

## Why

Automatic routing fails closed when eligible owners of the same model advertise different generation-profile hashes. The previous notification did not explain what differed, why Auto could not simply choose a host, or how to recover.

Follow-up: #1092 tracks redesigning Auto to choose a host and bind settings to that host's profile without weakening the current safety boundary.

## Validation

- `nix develop -c bun run test:studio -- studio/lib/profileFleet.test.ts` (6 passed)
- `nix develop -c bunx prettier --check studio/lib/profileFleet.ts studio/lib/profileFleet.test.ts desktop/src/views/GenerateView.vue web/src/pages/CreatePage.vue`
- `nix develop -c bun run build:desktop`
- `nix develop -c bun run build:web`
- browser smoke check of the web Create and Notifications surfaces
