### PR TITLE
fix(ios): restore viewport and distilled generation

### DIFF
--- a/crates/mold-tui/src/app.rs
+++ b/crates/mold-tui/src/app.rs
@@ -2381,6 +2381,31 @@ impl App {
         self.refresh_create_rows();
     }
 
+    /// Materialize a fixed recipe's effective guidance only in the frozen
+    /// request. The live TUI form retains its guided value so switching back
+    /// to an adjustable recipe restores the user's setting.
+    fn normalize_fixed_guidance_for_submit(&self, params: &mut GenerateParams) {
+        let family = family_for_model(&params.model, &self.config);
+        let advertised = self
+            .models
+            .catalog
+            .iter()
+            .find(|entry| entry.name == params.model)
+            .and_then(|entry| entry.guidance_capabilities);
+        let capabilities = params
+            .pipeline
+            .map(|pipeline| {
+                mold_core::GuidanceCapabilities::for_recipe(&family, &params.model, Some(pipeline))
+            })
+            .or(advertised)
+            .unwrap_or_else(|| {
+                mold_core::GuidanceCapabilities::for_recipe(&family, &params.model, None)
+            });
+        if let Some(fixed_scale) = capabilities.fixed_scale {
+            params.guidance = fixed_scale;
+        }
+    }
+
     /// Re-resolve the primary guidance/negative-prompt contract after the
     /// user changes an explicit LTX-2 recipe. Returning to Auto must restore
     /// the server-advertised checkpoint contract instead of inferring from an
@@ -6697,6 +6722,7 @@ impl App {
             .seed_mode
             .resolve(self.generate.params.seed);
         let mut params = self.generate.params.clone();
+        self.normalize_fixed_guidance_for_submit(&mut params);
         params.seed = Some(resolved_seed);
         // Nothing to expand when the conditioning carries the shot — expanding
         // "" would let the model invent the prompt. Mirrors the server's
@@ -12259,6 +12285,9 @@ mod tests {
         app.adjust_field(ParamField::Guidance, 1);
 
         assert_eq!(app.generate.params.guidance, 7.0);
+        let mut submitted = app.generate.params.clone();
+        app.normalize_fixed_guidance_for_submit(&mut submitted);
+        assert_eq!(submitted.guidance, 1.0);
         assert!(!app.generate.guidance_adjustable());
         assert!(!app.generate.capabilities.supports_negative_prompt);
     }
@@ -12379,6 +12408,13 @@ mod tests {
     async fn distilled_checkpoint_guidance_cannot_be_adjusted() {
         let mut app = make_settings_test_app();
         app.generate.params.model = "ltx-2.3-22b-distilled:fp8".into();
+        app.config.models.insert(
+            app.generate.params.model.clone(),
+            mold_core::ModelConfig {
+                family: Some("ltx2".into()),
+                ..Default::default()
+            },
+        );
         app.generate.capabilities = crate::model_info::capabilities_for_model(
             "ltx2",
             &app.generate.params.model,
@@ -12387,8 +12423,12 @@ mod tests {
             None,
         );
         app.generate.params.guidance = 7.0;
+        app.sync_generate_capabilities();
         app.adjust_field(ParamField::Guidance, 1);
         assert_eq!(app.generate.params.guidance, 7.0);
+        let mut submitted = app.generate.params.clone();
+        app.normalize_fixed_guidance_for_submit(&mut submitted);
+        assert_eq!(submitted.guidance, 1.0);
 
         app.generate.params.model = "ltx-2.3-22b-dev:fp8".into();
         app.generate.capabilities = crate::model_info::capabilities_for_model(

--- a/desktop/src/lib/generateForm.test.ts
+++ b/desktop/src/lib/generateForm.test.ts
@@ -704,7 +704,7 @@ describe("cloneGenerateForm", () => {
 });
 
 describe("buildRequest — LTX-2 advanced video", () => {
-  it("preserves distilled guidance state while omitting an ineffective negative", () => {
+  it("serializes fixed distilled guidance while preserving reusable form state", () => {
     const form = ltx2Form();
     form.model = "hf:opaque/distilled-checkpoint";
     form.guidance = 7;
@@ -714,6 +714,7 @@ describe("buildRequest — LTX-2 advanced video", () => {
       supports_negative_prompt: false,
       fixed_scale: 1,
     };
+    expect(buildRequest(form)).toMatchObject({ guidance: 1 });
     expect(buildRequest(form).negative_prompt).toBeUndefined();
     expect(form.negativePrompt).toBe("flicker");
     expect(form.guidance).toBe(7);

--- a/desktop/src/lib/generateForm.ts
+++ b/desktop/src/lib/generateForm.ts
@@ -58,7 +58,7 @@ import {
 } from "@studio/lib/negativePrompt";
 import { pipelineForControlId } from "@studio/lib/ltx2Control";
 import { firstLastFrameKeyframes } from "@studio/lib/sourceImageCapability";
-import { isWanFamily } from "@studio/lib/generationCapabilities";
+import { effectiveGenerationGuidance, isWanFamily } from "@studio/lib/generationCapabilities";
 import { stripAudioOnlyIncompatibleFields } from "@studio/lib/ltx2Pipeline";
 import {
   effectiveGenerationRecipe,
@@ -765,7 +765,7 @@ export function buildRequest(form: GenerateForm): GenerateRequest {
     width: form.width,
     height: form.height,
     steps: form.steps,
-    guidance: form.guidance,
+    guidance: effectiveGenerationGuidance(caps, form.guidance),
     batch_size:
       caps.forcesBatchSizeOne ||
       (caps.sourceImageMode === "references" && form.imageAttachments.length > 0)

--- a/desktop/src/lib/sequenceParams.test.ts
+++ b/desktop/src/lib/sequenceParams.test.ts
@@ -42,4 +42,19 @@ describe("sequenceParams", () => {
     const entry = { name: "cv:12345", family: "ltx2" } as ModelEntry;
     expect(sequenceParams(form, entry).family).toBe("ltx2");
   });
+
+  it("projects the effective fixed guidance for a distilled sequence", () => {
+    const form = newGenerateForm();
+    form.model = "hf:opaque/distilled-checkpoint";
+    form.family = "ltx2";
+    form.guidance = 7;
+    form.guidanceCapabilities = {
+      adjustable: false,
+      supports_negative_prompt: false,
+      fixed_scale: 1,
+    };
+
+    expect(sequenceParams(form).guidance).toBe(1);
+    expect(form.guidance).toBe(7);
+  });
 });

--- a/desktop/src/lib/sequenceParams.ts
+++ b/desktop/src/lib/sequenceParams.ts
@@ -7,19 +7,28 @@
 import type { SequenceSharedParams } from "@studio/lib/sequenceForm";
 import type { GenerateForm } from "./generateForm";
 import type { ModelEntry } from "./api/types";
+import { generationCapabilitiesForFamily } from "./capabilities";
+import { effectiveGenerationGuidance } from "@studio/lib/generationCapabilities";
 
 export function sequenceParams(
   form: GenerateForm,
   selectedModel: ModelEntry | null = null,
 ): SequenceSharedParams {
+  const family = selectedModel?.family || form.family;
+  const capabilities = generationCapabilitiesForFamily(
+    family,
+    form.model,
+    form.pipeline,
+    selectedModel?.guidance_capabilities ?? form.guidanceCapabilities,
+  );
   return {
     model: form.model,
-    family: selectedModel?.family || form.family,
+    family,
     width: form.width,
     height: form.height,
     fps: form.fps,
     steps: form.steps,
-    guidance: form.guidance,
+    guidance: effectiveGenerationGuidance(capabilities, form.guidance),
     strength: form.strength,
     sourceFitPolicy: form.sourceFit,
     upscalerModel: form.upscaleModel,

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -1086,7 +1086,11 @@ const stepsError = computed(() =>
   profileStepsValidationError(form.steps, selectedGenerationModel.value, form.pipeline),
 );
 const guidanceError = computed(() =>
-  profileGuidanceValidationError(form.guidance, selectedGenerationModel.value, form.pipeline),
+  profileGuidanceValidationError(
+    caps.value.fixedGuidance ?? form.guidance,
+    selectedGenerationModel.value,
+    form.pipeline,
+  ),
 );
 const basicParametersValid = computed(() => !stepsError.value && !guidanceError.value);
 const mobileMediaBudgetError = computed(() => mobileMediaBudgetValidationError(form));

--- a/desktop/src/mobile/MobileSharedParams.test.ts
+++ b/desktop/src/mobile/MobileSharedParams.test.ts
@@ -27,6 +27,12 @@ describe("MobileSharedParams video duration", () => {
     expect(wrapper.get("[data-test='mobile-fixed-guidance-hint']").text()).toContain(
       "fixes CFG at 1.0",
     );
+    expect(wrapper.get("[data-test='mobile-fixed-guidance-hint']").classes()).toContain(
+      "mobile-generate-hint",
+    );
+    expect(wrapper.get("[data-test='mobile-fixed-guidance-hint']").classes()).not.toContain(
+      "mobile-generate-validation",
+    );
     form.pipeline = "two-stage";
     await wrapper.vm.$nextTick();
     expect(wrapper.get("input[step='0.1']").attributes("disabled")).toBeUndefined();

--- a/desktop/src/mobile/MobileSharedParams.vue
+++ b/desktop/src/mobile/MobileSharedParams.vue
@@ -163,7 +163,7 @@ const sourceDimensions = computed(() => {
   </div>
   <p
     v-if="!guidanceCaps.guidanceAdjustable"
-    class="mobile-generate-validation"
+    class="mobile-generate-hint"
     data-test="mobile-fixed-guidance-hint"
   >
     Distilled recipe fixes CFG at 1.0. Choose a Dev checkpoint with Auto or a guided pipeline to

--- a/desktop/src/mobile/mobile.css
+++ b/desktop/src/mobile/mobile.css
@@ -40,8 +40,11 @@ button {
   --radius-card: 16px;
   --radius-pill: 20px;
   --text-large-title: 1.875rem;
+  /* The native WKWebView already owns the safe-area-constrained viewport.
+     iOS can leave `dvh` stuck at the keyboard-reduced height after dismissal,
+     while `svh` can exceed Tauri's constrained WebView and push tabs below
+     the screen. Follow the stable app container instead. */
   height: 100%;
-  height: 100dvh;
   min-height: 0;
   box-sizing: border-box;
   overflow: hidden;
@@ -1757,6 +1760,13 @@ textarea.control {
   background: color-mix(in srgb, var(--stop) 8%, transparent);
   color: var(--stop);
   font-size: var(--text-body);
+}
+
+.mobile-generate-hint {
+  margin: 8px 0 0;
+  color: var(--ink-3);
+  font-size: var(--text-caption);
+  line-height: 1.45;
 }
 
 .mobile-generate-validation-copy,

--- a/desktop/src/mobile/mobile.css.test.ts
+++ b/desktop/src/mobile/mobile.css.test.ts
@@ -212,13 +212,15 @@ describe("mobile style row", () => {
 });
 
 describe("mobile safe areas", () => {
-  it("keeps the shell inside the dynamic viewport and clears both landscape notches", () => {
+  it("keeps the shell on the stable viewport after iOS dismisses the keyboard", () => {
     const shell = css.match(/\.mobile-shell\s*\{([^}]*)\}/s);
     const header = css.match(/\.mobile-header\s*\{([^}]*)\}/s);
     const content = css.match(/\.mobile-content\s*\{([^}]*)\}/s);
     const tabs = css.match(/\.mobile-tabs\s*\{([^}]*)\}/s);
 
-    expect(shell?.[1]).toMatch(/height:\s*100dvh\s*;/);
+    expect(shell?.[1]).toMatch(/height:\s*100%\s*;/);
+    expect(shell?.[1]).not.toMatch(/height:\s*100svh\s*;/);
+    expect(shell?.[1]).not.toMatch(/height:\s*100dvh\s*;/);
     expect(shell?.[1]).toMatch(/box-sizing:\s*border-box\s*;/);
     for (const rule of [header?.[1], content?.[1], tabs?.[1]]) {
       expect(rule).toContain("env(safe-area-inset-left)");

--- a/desktop/src/views/GenerateView.vue
+++ b/desktop/src/views/GenerateView.vue
@@ -543,7 +543,11 @@ const formValidationError = computed(
       form.pipeline,
     ) ??
     profileStepsValidationError(form.steps, selectedEntry.value, form.pipeline) ??
-    profileGuidanceValidationError(form.guidance, selectedEntry.value, form.pipeline) ??
+    profileGuidanceValidationError(
+      caps.value.fixedGuidance ?? form.guidance,
+      selectedEntry.value,
+      form.pipeline,
+    ) ??
     (caps.value.supportsVideo
       ? videoFramesError(form.frames, selectedEntry.value ?? { family: form.family })
       : null) ??

--- a/studio/lib/generationCapabilities.ts
+++ b/studio/lib/generationCapabilities.ts
@@ -90,6 +90,21 @@ export interface AdvertisedGuidanceCapabilities {
   fixed_scale?: number | null;
 }
 
+/**
+ * Resolve the guidance value that may cross a request boundary.
+ *
+ * Forms deliberately retain the user's adjustable value so switching back to
+ * a guided recipe restores it. A fixed distilled recipe still owns the wire
+ * value; sending the hidden form value makes the server reject a control the
+ * user cannot edit.
+ */
+export function effectiveGenerationGuidance(
+  capabilities: Pick<BaseGenerationCapabilities, "fixedGuidance">,
+  formGuidance: number,
+): number {
+  return capabilities.fixedGuidance ?? formGuidance;
+}
+
 const SCHEDULER_OPTIONS: GenerationScheduler[] = [
   "default",
   "ddim",

--- a/web/src/composables/useGenerateForm.test.ts
+++ b/web/src/composables/useGenerateForm.test.ts
@@ -1680,6 +1680,7 @@ describe("useGenerateForm", () => {
         fixed_scale: 1,
       },
     });
+    expect(form.toRequest().guidance).toBe(1);
     expect(form.toRequest().negative_prompt).toBeNull();
     expect(form.state.value.negativePrompt).toBe("flicker");
     expect(form.state.value.guidance).toBe(7);

--- a/web/src/composables/useGenerateForm.ts
+++ b/web/src/composables/useGenerateForm.ts
@@ -44,6 +44,7 @@ import {
   effectiveGenerationRecipe,
   fixedRecipeControlOverrides,
 } from "@studio/lib/generationProfile";
+import { effectiveGenerationGuidance } from "@studio/lib/generationCapabilities";
 import {
   cameraMotionLoraPath,
   normalizeCameraMotionLoraState,
@@ -1164,7 +1165,7 @@ export function useGenerateForm(): UseGenerateForm {
         width: s.width,
         height: s.height,
         steps: s.steps,
-        guidance: s.guidance,
+        guidance: effectiveGenerationGuidance(capabilities, s.guidance),
         seed: s.seedMode === "random" ? null : s.seed,
         batch_size: requestForcesBatchSizeOne ? 1 : s.batchSize,
         output_format: s.outputFormat,

--- a/web/src/lib/sequenceParams.test.ts
+++ b/web/src/lib/sequenceParams.test.ts
@@ -64,7 +64,7 @@ describe("sequenceSharedParams", () => {
       height: 704,
       fps: 24,
       steps: 8,
-      guidance: 3.5,
+      guidance: 1,
       strength: 0.9,
       sourceFitPolicy: { mode: "crop-fill" },
       upscalerModel: "",
@@ -86,5 +86,18 @@ describe("sequenceSharedParams", () => {
     const state = formState();
     state.fps = null;
     expect(sequenceSharedParams(state, "ltx2").fps).toBe(24);
+  });
+
+  it("projects the effective fixed guidance for a distilled sequence", () => {
+    const state = formState();
+    state.guidance = 7;
+    state.guidanceCapabilities = {
+      adjustable: false,
+      supports_negative_prompt: false,
+      fixed_scale: 1,
+    };
+
+    expect(sequenceSharedParams(state, "ltx2").guidance).toBe(1);
+    expect(state.guidance).toBe(7);
   });
 });

--- a/web/src/lib/sequenceParams.ts
+++ b/web/src/lib/sequenceParams.ts
@@ -10,12 +10,20 @@
 import type { SequenceSharedParams } from "@studio/lib/sequenceForm";
 import { DEFAULT_VIDEO_FPS } from "@studio/lib/sequence";
 import type { GenerateFormState } from "../types";
+import { generationCapabilitiesForFamily } from "./generateCapabilities";
+import { effectiveGenerationGuidance } from "@studio/lib/generationCapabilities";
 
 /** Project the live web generate form onto the shared chain params. */
 export function sequenceSharedParams(
   state: GenerateFormState,
   family: string,
 ): SequenceSharedParams {
+  const capabilities = generationCapabilitiesForFamily(
+    family,
+    state.model,
+    state.pipeline,
+    state.guidanceCapabilities,
+  );
   return {
     model: state.model,
     family,
@@ -25,7 +33,7 @@ export function sequenceSharedParams(
     // only covers a form that never saw a video model.
     fps: state.fps ?? DEFAULT_VIDEO_FPS,
     steps: state.steps,
-    guidance: state.guidance,
+    guidance: effectiveGenerationGuidance(capabilities, state.guidance),
     strength: state.strength,
     sourceFitPolicy: state.sourceFitPolicy,
     upscalerModel: state.upscaleModel,

--- a/web/src/pages/CreatePage.test.ts
+++ b/web/src/pages/CreatePage.test.ts
@@ -1383,7 +1383,9 @@ describe("CreatePage layout and behavior", () => {
         width: 1216,
         height: 704,
         steps: 4,
-        guidance: 5.5,
+        // Distilled recipes materialize their fixed guidance at submission
+        // while preserving the inspector's adjustable value for other models.
+        guidance: 1,
         fps: 24,
         output_format: "mp4",
         stages: [


### PR DESCRIPTION
## Summary

- keep the iPhone shell pinned to the native safe-area WebView after keyboard viewport changes
- materialize fixed distilled guidance at request submission for web, desktop, iPhone, sequences, and TUI
- present fixed CFG as neutral recipe guidance instead of an error state

## Verification

- iPhone 16 Pro Simulator build, install, launch, and visual safe-area/tab-bar QA
- mobile browser QA at 393x852 with exact shell/viewport bounds
- desktop: 316 files / 3,454 tests
- web: 92 files / 1,308 tests
- TUI: 655 tests; Clippy with warnings denied
- desktop, web, and mobile production builds
- formatting and iOS release-assets contract