### PR TITLE
fix(ios): restore source picker viewport and queued admission

### DIFF
--- a/apps/mobile/src-tauri/Cargo.toml
+++ b/apps/mobile/src-tauri/Cargo.toml
@@ -35,7 +35,7 @@ block2 = "0.6"
 objc2 = "0.6"
 objc2-foundation = { version = "0.3.2", default-features = false, features = ["NSData", "NSError", "NSString", "NSURL"] }
 objc2-photos = { version = "0.3.2", default-features = false, features = ["PHAssetChangeRequest", "PHChangeRequest", "PHPhotoLibrary", "block2", "dispatch2"] }
-objc2-ui-kit = { version = "0.3.2", default-features = false, features = ["UIActivity", "UIActivityViewController", "UIInterface", "UIImage", "UIPasteboard", "UIPopoverPresentationController", "UIPresentationController", "UIResponder", "UIView", "UIViewController"] }
+objc2-ui-kit = { version = "0.3.2", default-features = false, features = ["UIActivity", "UIActivityViewController", "UIInterface", "UIImage", "UIPasteboard", "UIPopoverPresentationController", "UIPresentationController", "UIResponder", "UIView", "UIViewController", "objc2-core-foundation"] }
 reqwest = { version = "0.13", default-features = false, features = ["rustls-no-provider"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 tauri-plugin-barcode-scanner = "2.4.5"

--- a/apps/mobile/src-tauri/src/lib.rs
+++ b/apps/mobile/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ mod appearance;
 mod discovery;
 mod keychain;
 mod media;
+mod viewport;
 
 fn app_context() -> tauri::Context<tauri::Wry> {
     tauri::generate_context!()
@@ -44,6 +45,7 @@ pub fn run() {
             media::save_image_to_photos,
             media::save_video_to_photos,
             media::share_exported_animation,
+            viewport::restore_mobile_viewport,
         ])
         .run(app_context())
         .expect("error while running mold-mobile");

--- a/apps/mobile/src-tauri/src/viewport.rs
+++ b/apps/mobile/src-tauri/src/viewport.rs
@@ -1,0 +1,39 @@
+/// Native pickers and the software keyboard can leave WKWebView using their
+/// temporary presentation frame. Reapplying the controller's bounds forces
+/// WebKit to publish the real viewport before the web shell lays itself out.
+#[tauri::command]
+pub fn restore_mobile_viewport(window: tauri::WebviewWindow) -> Result<(), String> {
+    window
+        .with_webview(|webview| {
+            #[cfg(target_os = "ios")]
+            {
+                use objc2_ui_kit::{UIView, UIViewAutoresizing, UIViewController};
+
+                // SAFETY: Tauri supplies live UIKit objects and runs this
+                // callback on the main thread. Both pointers are borrowed only
+                // for the duration of the callback.
+                unsafe {
+                    let view = webview.inner().cast::<UIView>().as_ref();
+                    let controller = webview
+                        .view_controller()
+                        .cast::<UIViewController>()
+                        .as_ref();
+                    if let (Some(view), Some(root)) =
+                        (view, controller.and_then(UIViewController::view))
+                    {
+                        root.layoutIfNeeded();
+                        view.setAutoresizingMask(
+                            UIViewAutoresizing::FlexibleWidth | UIViewAutoresizing::FlexibleHeight,
+                        );
+                        view.setFrame(root.bounds());
+                        view.setNeedsLayout();
+                        view.layoutIfNeeded();
+                    }
+                }
+            }
+
+            #[cfg(not(target_os = "ios"))]
+            let _ = webview;
+        })
+        .map_err(|error| format!("failed to restore mobile viewport: {error}"))
+}

--- a/crates/mold-server/src/scheduler/mod.rs
+++ b/crates/mold-server/src/scheduler/mod.rs
@@ -2510,9 +2510,11 @@ impl Coordinator {
                     },
                     available_at_ms: active_lease.map(|lease| lease.estimated_finish_ms),
                     worker_generation: ready.map_or(0, |ready| ready.generation),
-                    available_vram_bytes: effective_available_vram_bytes(
+                    available_vram_bytes: schedulable_available_vram_bytes(
                         device.sampled_free_vram_bytes,
                         reclaimable_cache_bytes,
+                        device.sampled_mold_vram_bytes,
+                        active_lease.is_some(),
                         worker.map_or(0, |worker| worker.gpu.total_vram_bytes),
                     ),
                     warm_execution_fingerprints: warm,
@@ -6118,6 +6120,32 @@ pub(crate) fn effective_available_vram_bytes(
         .min(total_vram_bytes)
 }
 
+/// Effective capacity for serialized work on a device. While a lease is
+/// active, the sampler's Mold-owned bytes belong to work that must finish
+/// before the next lease can start, so those bytes are future-reclaimable.
+/// Unknown attribution and memory owned by other processes remain excluded.
+pub(crate) fn schedulable_available_vram_bytes(
+    sampled_free_bytes: u64,
+    reclaimable_cache_bytes: u64,
+    sampled_mold_bytes: Option<u64>,
+    has_active_lease: bool,
+    total_vram_bytes: u64,
+) -> u64 {
+    let immediate = effective_available_vram_bytes(
+        sampled_free_bytes,
+        reclaimable_cache_bytes,
+        total_vram_bytes,
+    );
+    if !has_active_lease {
+        return immediate;
+    }
+    sampled_mold_bytes.map_or(immediate, |mold_bytes| {
+        immediate
+            .max(sampled_free_bytes.saturating_add(mold_bytes))
+            .min(total_vram_bytes)
+    })
+}
+
 fn monotonic_deadline_ms(deadline: Instant) -> u64 {
     monotonic_ms().saturating_add(
         deadline
@@ -7772,6 +7800,32 @@ mod tests {
         assert_eq!(
             coordinator.device_snapshots()[0].available_vram_bytes,
             5 << 30
+        );
+    }
+
+    #[test]
+    fn queued_capacity_reclaims_only_known_mold_vram_from_active_work() {
+        const GIB: u64 = 1 << 30;
+
+        assert_eq!(
+            schedulable_available_vram_bytes(10 * GIB, 0, Some(14 * GIB), true, 24 * GIB),
+            24 * GIB,
+            "a sibling session should queue behind active Mold work"
+        );
+        assert_eq!(
+            schedulable_available_vram_bytes(10 * GIB, 0, Some(14 * GIB), false, 24 * GIB),
+            10 * GIB,
+            "idle Mold attribution is not automatically reclaimable"
+        );
+        assert_eq!(
+            schedulable_available_vram_bytes(10 * GIB, 0, None, true, 24 * GIB),
+            10 * GIB,
+            "unknown attribution must remain fail closed"
+        );
+        assert_eq!(
+            schedulable_available_vram_bytes(4 * GIB, 0, Some(14 * GIB), true, 24 * GIB),
+            18 * GIB,
+            "external allocations remain unavailable after active Mold work completes"
         );
     }
 

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -4459,6 +4459,21 @@ describe("MobileApp foreground resume", () => {
     },
   };
 
+  it("restores the native WKWebView frame on launch and after a picker resume", async () => {
+    Object.defineProperty(window, "__TAURI_INTERNALS__", {
+      value: {},
+      configurable: true,
+    });
+    wrapper = mountMobileApp();
+    await flushPromises();
+    expect(invoke).toHaveBeenCalledWith("restore_mobile_viewport");
+
+    invoke.mockClear();
+    window.dispatchEvent(new Event("pageshow"));
+    await flushPromises();
+    expect(invoke).toHaveBeenCalledWith("restore_mobile_viewport");
+  });
+
   async function submitSeededPrompt(prompt: string, seed: number): Promise<void> {
     const liveForm = wrapper!.getComponent(MobileLoraControls).props("form") as GenerateForm;
     liveForm.seed = String(seed);

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -4467,6 +4467,9 @@ watch(
  */
 function handleForegroundResume(): void {
   if (unmounted || document.visibilityState === "hidden") return;
+  if ("__TAURI_INTERNALS__" in window) {
+    void invoke("restore_mobile_viewport").catch(() => undefined);
+  }
   probeHosts();
   void refreshMobileActivity();
   if (modelLoadError.value && !loadingModels.value) void refreshModels();
@@ -4481,6 +4484,7 @@ watch(resultPreviewError, (error) => {
 
 onMounted(async () => {
   if ("__TAURI_INTERNALS__" in window) {
+    void invoke("restore_mobile_viewport").catch(() => undefined);
     void import("@tauri-apps/api/app")
       .then(({ getVersion }) => getVersion())
       .then((version) => {

--- a/desktop/src/mobile/mobile.css
+++ b/desktop/src/mobile/mobile.css
@@ -40,10 +40,8 @@ button {
   --radius-card: 16px;
   --radius-pill: 20px;
   --text-large-title: 1.875rem;
-  /* The native WKWebView already owns the safe-area-constrained viewport.
-     iOS can leave `dvh` stuck at the keyboard-reduced height after dismissal,
-     while `svh` can exceed Tauri's constrained WebView and push tabs below
-     the screen. Follow the stable app container instead. */
+  /* UIKit restores the WKWebView frame after native pickers dismiss. Follow
+     that stable native container instead of WebKit's transient dvh. */
   height: 100%;
   min-height: 0;
   box-sizing: border-box;

--- a/desktop/src/mobile/mobile.css.test.ts
+++ b/desktop/src/mobile/mobile.css.test.ts
@@ -212,7 +212,7 @@ describe("mobile style row", () => {
 });
 
 describe("mobile safe areas", () => {
-  it("keeps the shell on the stable viewport after iOS dismisses the keyboard", () => {
+  it("follows the native viewport instead of a picker-reduced dynamic viewport", () => {
     const shell = css.match(/\.mobile-shell\s*\{([^}]*)\}/s);
     const header = css.match(/\.mobile-header\s*\{([^}]*)\}/s);
     const content = css.match(/\.mobile-content\s*\{([^}]*)\}/s);


### PR DESCRIPTION
## Summary

- restore the native WKWebView frame after launch and foreground returns so dismissing the iOS Photos picker cannot leave Create compressed above a dead viewport
- queue work behind an active Mold lease using only known Mold-owned VRAM as future-reclaimable capacity
- keep unknown attribution and external allocations fail-closed

The distilled-model fixed-guidance blocker shown in the companion report is already fixed across web, desktop, iPhone, sequences, and TUI by #1095 on the current base.

## Reproduction

- reproduced the source-image defect on an unmodified iPhone 16 Pro Simulator build by selecting a real Photos-library image; the returning WKWebView retained a shortened presentation frame
- reproduced the queue rejection in scheduler admission: placement used current free VRAM while another Mold session held the active lease, even though device execution is serialized

## Verification

- real iOS Photos picker return on iPhone 16 Pro Simulator with source preview, status bar, pinned action, and tabs correctly framed
- `nix develop -c bash -lc "cd desktop && bun run test"` — 317 files / 3,515 tests
- `nix develop -c bash -lc "cd desktop && bun run build:mobile"`
- `nix develop -c cargo test -p mold-ai-server scheduler::tests --lib` — 93 tests
- `nix develop -c cargo clippy -p mold-ai-server --all-targets -- -D warnings`
- `nix develop -c ios-check`
- `nix develop -c ./scripts/tests/ios-release-assets.sh`
- root and mobile Rust formatting checks