### PR TITLE
fix(release): seal duplicate generated PTX

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ and source builds are covered in the
 [installation guide](https://utensils.io/mold/guide/installation);
 binaries and checksums are on the
 [releases page](https://github.com/utensils/mold/releases/latest).
+GH200, GB200, and GB300 require future linux/arm64 artifacts and are unsupported.
 
 ## Quick start
 

--- a/scripts/seal-cuda-ptx-manifest.py
+++ b/scripts/seal-cuda-ptx-manifest.py
@@ -136,6 +136,18 @@ def referenced_ptx_files(output_dir: Path) -> list[Path]:
     return [output_dir / name for name in names]
 
 
+def generated_ptx_offset(rodata: bytes, ptx: bytes) -> int:
+    """Return one exact generated-PTX range from the linked read-only data.
+
+    Rust's linker may retain multiple byte-identical copies of one generated
+    module when separate crate paths reference it. Any copy is equally bound
+    to the build artifact by its full bytes and SHA-256, so the manifest uses
+    the first deterministic range and records the module only once.
+    """
+
+    return rodata.find(ptx)
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("binary", type=Path)
@@ -187,12 +199,10 @@ def main() -> int:
                 if not ptx_path.is_file():
                     fail(f"generated PTX is missing: {ptx_path}")
                 ptx = ptx_path.read_bytes()
-                offset = rodata.find(ptx)
+                offset = generated_ptx_offset(rodata, ptx)
                 if offset < 0:
                     # Dead code can remove an otherwise generated module.
                     continue
-                if rodata.find(ptx, offset + 1) >= 0:
-                    fail(f"generated PTX has ambiguous duplicate ranges: {ptx_path}")
                 digest = hashlib.sha256(ptx).hexdigest()
                 modules[digest] = {
                     "source_name": ptx_path.name,

--- a/scripts/tests/cuda-ptx-parser-contract.py
+++ b/scripts/tests/cuda-ptx-parser-contract.py
@@ -79,17 +79,27 @@ class EmbeddedPtxParserContract(unittest.TestCase):
         path.write_text(text, encoding="utf-8")
         path.chmod(0o755)
 
-    def compile_unsealed_fixture(self, name: str, ptx_bytes: bytes) -> Path:
+    def compile_unsealed_fixture(
+        self, name: str, ptx_bytes: bytes, *, copies: int = 1
+    ) -> Path:
         path = self.temp_dir / name
         c_source = self.temp_dir / f"{name}.c"
         byte_literals = ",".join(f"0x{byte:02x}" for byte in ptx_bytes)
+        ptx_definitions = "".join(
+            "__attribute__((used)) static const unsigned char "
+            f"generated_ptx_{index}[] = {{{byte_literals}}};\n"
+            for index in range(copies)
+        )
+        ptx_references = ", ".join(
+            f"generated_ptx_{index}" for index in range(copies)
+        )
         c_source.write_text(
             "#include <string.h>\n"
-            f"__attribute__((used)) static const unsigned char generated_ptx[] = {{{byte_literals}}};\n"
+            f"{ptx_definitions}"
             '__attribute__((used)) static const char nvml_symbol[] = "nvmlDeviceGetCount_v2";\n'
             f'__attribute__((used)) static const char h3_attention_provenance[] = "{H3_OMITTED_ATTENTION_PROVENANCE}";\n'
             "int main(int argc, char **argv) {\n"
-            "  volatile const void *keep[] = {generated_ptx, nvml_symbol, h3_attention_provenance};\n"
+            f"  volatile const void *keep[] = {{{ptx_references}, nvml_symbol, h3_attention_provenance}};\n"
             "  (void)keep;\n"
             '  return argc == 2 && strcmp(argv[1], "version") == 0 ? 0 : 1;\n'
             "}\n",
@@ -416,6 +426,49 @@ class EmbeddedPtxParserContract(unittest.TestCase):
         self.assertNotEqual(seal.returncode, 0, seal.stdout)
         self.assertIn("no generated candle-kernels PTX", seal.stderr)
         self.assert_probe_and_verifier_reject(fixture, 86)
+
+    def test_identical_generated_ptx_copies_choose_a_stable_range(self) -> None:
+        ptx = (
+            b".version 8.0\n.target sm_86\n.address_size 64\n"
+            b".visible .entry duplicated_kernel() { ret; }\n"
+        )
+        rodata = b"prefix\0" + ptx + b"between\0" + ptx + b"suffix\0"
+        self.assertEqual(
+            self.seal_module.generated_ptx_offset(rodata, ptx),
+            len(b"prefix\0"),
+        )
+
+    def test_identical_generated_ptx_copies_are_sealed_once(self) -> None:
+        ptx = (
+            b".version 8.0\n.target sm_86\n.address_size 64\n"
+            b".visible .entry duplicated_kernel() { ret; }\n"
+        )
+        fixture = self.compile_unsealed_fixture(
+            "duplicated-generated-ptx", ptx, copies=2
+        )
+        build_root = self.temp_dir / "duplicated-generated-ptx-build"
+        output_dir = build_root / "candle-kernels-fixture" / "out"
+        output_dir.mkdir(parents=True)
+        (output_dir / "binary.ptx").write_bytes(ptx)
+        (output_dir / "ptx.rs").write_text(
+            'pub const BINARY: &str = include_str!(concat!(env!("OUT_DIR"), "/binary.ptx"));\n',
+            encoding="utf-8",
+        )
+        (output_dir.parent / "output").write_text(
+            "cargo:rustc-env=CUDA_COMPUTE_CAP=86\n", encoding="utf-8"
+        )
+
+        seal = subprocess.run(
+            [str(SEAL_PATH), str(fixture), "86", str(build_root)],
+            text=True,
+            capture_output=True,
+            check=False,
+            env={**os.environ, "TMPDIR": str(self.temp_dir)},
+        )
+
+        self.assertEqual(seal.returncode, 0, seal.stderr)
+        self.assertIn("with 1 generated sm_86 PTX modules", seal.stdout)
+        self.assert_probe_and_verifier_accept(fixture, 86)
 
     def test_partially_overlapping_manifest_ranges_are_rejected(self) -> None:
         fixture = self.fixture(


### PR DESCRIPTION
## Summary
- seal one deterministic range when the linker retains byte-identical generated PTX copies
- preserve exact full-byte and SHA-256 manifest verification
- restore the required Grace linux/arm64 support warning removed by the minimized README

## Reproduction
Main Release run 31867667715 fails sm86, sm100, and sm120 while sealing `binary.ptx` because the linker retained duplicate identical ranges.

## Tests
- `nix fmt`
- `nix develop -c python3 scripts/tests/cuda-ptx-parser-contract.py EmbeddedPtxParserContract.test_identical_generated_ptx_copies_choose_a_stable_range`
- `nix develop -c python3 -m py_compile scripts/seal-cuda-ptx-manifest.py scripts/tests/cuda-ptx-parser-contract.py`
- Linux ELF integration regression added to `cuda-ptx-parser-contract.py` (runs in CI; local macOS dev shell has no `readelf`)

Fixes the failing main release workflow without weakening generated-PTX content authentication.