### PR TITLE
fix(nix): restore FlakeHub all-systems evaluation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -821,7 +821,7 @@
               let
                 moduleWarnings =
                   cudaArch: package:
-                  (lib.nixosSystem {
+                  (inputs.nixpkgs.lib.nixosSystem {
                     inherit system;
                     modules = [
                       ./nix/module.nix


### PR DESCRIPTION
## What changed

- build the CUDA module consistency check with `inputs.nixpkgs.lib.nixosSystem`
- retain the per-system `lib` for ordinary option helpers

## Root cause

FlakeHub evaluates every flake output with `nix flake show --all-systems`. The `lib` injected into `perSystem` is the flake-parts module library and does not expose `nixosSystem`, so tagged publication failed before upload.

## Validation

- `nix develop -c nix flake show --all-systems --json --no-write-lock-file .`
- `nix develop -c nix eval --raw .#checks.x86_64-linux.cuda-package-consistency.drvPath`
- `git diff --check -- flake.nix`