### PR TITLE
fix(desktop): show developing thumbnails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **Now Developing shows completed image and video thumbnails.** Desktop sidebar activity rows now load the same authenticated gallery thumbnails as Library, including remote-host videos that previously fell back to an empty black tile.
+
 ## [0.22.1] - 2026-08-16
 
 ## [0.22.0] - 2026-08-15

--- a/desktop/src/components/shell/NavRail.test.ts
+++ b/desktop/src/components/shell/NavRail.test.ts
@@ -14,6 +14,11 @@ import { useLiveActivityStore } from "../../stores/liveActivity";
 import { useComposerStore } from "../../stores/composer";
 
 const stub = { template: "<div />" };
+const authedMediaStub = {
+  props: ["path", "target", "cacheKey", "alt"],
+  template:
+    '<img data-test="rail-library-thumbnail" :data-path="path" :data-cache-key="cacheKey" :data-target-base-url="target?.baseUrl" :data-target-authenticated="String(Boolean(target?.apiKey))" :alt="alt" />',
+};
 
 function makeRouter(): Router {
   return createRouter({
@@ -40,7 +45,7 @@ async function mountAt(path: string) {
       plugins: [pinia, router],
       // StatusPopover opens its own telemetry streams on mount; the rail tests
       // don't exercise it, so stub it out to keep them off the network.
-      stubs: { StatusPopover: stub },
+      stubs: { StatusPopover: stub, AuthedMedia: authedMediaStub },
     },
   });
 }
@@ -239,6 +244,35 @@ describe("NavRail developing jobs", () => {
 
     await wrapper.get("[data-test='developing-print']").trigger("click");
     expect(refresh).toHaveBeenCalledWith(13);
+  });
+
+  it("shows the authenticated Library thumbnail for a completed video", async () => {
+    const wrapper = await mountAt("/create");
+    const generation = useGenerationStore();
+    vi.spyOn(generation, "targetForJob").mockReturnValue({
+      baseUrl: "http://hal9000:7680",
+      apiKey: "secret",
+    });
+    generation.jobs = [
+      {
+        clientId: 14,
+        model: "ltx-2.3-22b-distilled:fp8",
+        prompt: "a finished clip",
+        status: "complete",
+        hostId: "hal9000-7680",
+        resultUrl: "https://example.test/result.mp4",
+        previewUrl: null,
+        result: { filename: "finished clip.mp4", video_frames: 97 },
+      } as never,
+    ];
+    await flushPromises();
+
+    const thumbnail = wrapper.get("[data-test='rail-library-thumbnail']");
+    expect(thumbnail.attributes("data-path")).toBe("/api/gallery/thumbnail/finished%20clip.mp4");
+    expect(thumbnail.attributes("data-cache-key")).toBe("hal9000-7680");
+    expect(thumbnail.attributes("data-target-base-url")).toBe("http://hal9000:7680");
+    expect(thumbnail.attributes("data-target-authenticated")).toBe("true");
+    expect(thumbnail.attributes("alt")).toBe("a finished clip");
   });
 
   // G14 hole: the rail only ever read `generation.jobs`, so a running sequence

--- a/desktop/src/components/shell/NavRail.vue
+++ b/desktop/src/components/shell/NavRail.vue
@@ -4,6 +4,7 @@ import { useRoute, useRouter } from "vue-router";
 import NavItem from "@ui/components/NavItem.vue";
 import Keycap from "@ui/components/Keycap.vue";
 import LiveActivityList from "@ui/components/LiveActivityList.vue";
+import AuthedMedia from "../gallery/AuthedMedia.vue";
 import type { IconName } from "@ui/icons";
 import logoUrl from "../../assets/logo.png";
 import StatusPopover from "./StatusPopover.vue";
@@ -36,6 +37,7 @@ import { shortcutLabel } from "../../lib/platform";
 import { modelDisplayNameForId } from "../../lib/models";
 import { useSequenceDraftStore } from "@studio/stores/sequenceDraft";
 import { useOpenLiveWork } from "../../composables/useOpenLiveWork";
+import { thumbnailPath } from "../../lib/gallery/media";
 
 const route = useRoute();
 const router = useRouter();
@@ -356,8 +358,15 @@ function selectSequence(vm: ActivityJobVM & { kind: "sequence" }) {
           <span
             class="h-[30px] w-[30px] shrink-0 overflow-hidden rounded-[6px] border border-[color-mix(in_srgb,var(--rebate)_12%,transparent)] bg-print-surface"
           >
+            <AuthedMedia
+              v-if="job.status === 'complete' && job.result?.filename"
+              :path="thumbnailPath(job.result.filename)"
+              :target="generation.targetForJob(job.clientId)"
+              :cache-key="job.hostId ?? hosts.primaryHost?.id ?? 'primary'"
+              :alt="job.prompt"
+            />
             <img
-              v-if="job.resultUrl && !job.result?.video_frames"
+              v-else-if="job.resultUrl && !job.result?.video_frames"
               :src="job.resultUrl"
               alt=""
               class="h-full w-full object-cover"


### PR DESCRIPTION
## Summary
- render completed image and video rows in Now Developing with the same authenticated thumbnails as Library
- preserve the originating host target and cache bucket for remote thumbnails
- restore the missing Unreleased notes so Release-plz can render the v0.22.1 PR body

## Verification
- `nix develop -c bun run test:desktop -- NavRail.test.ts` (16 passed)
- `nix develop -c bun run build:desktop`
- `nix develop -c bash scripts/tests/release-sync-pr.sh`
- local desktop preview rendered with no console errors
- peer review: no blockers