### PR TITLE
fix(desktop): bound Auto placement planning

### DIFF
--- a/desktop/src/stores/hosts.test.ts
+++ b/desktop/src/stores/hosts.test.ts
@@ -849,6 +849,133 @@ describe("hosts store", () => {
     });
   });
 
+  it("stops waiting on a hung Auto candidate after another host returns a planned route", async () => {
+    vi.useFakeTimers();
+    try {
+      const hosts = useHostsStore();
+      hosts.extras.push({
+        id: hal.id,
+        label: "hal9000",
+        url: hal.url,
+        apiKey: "hal-key",
+        status: "ready",
+        error: null,
+        instanceId: "hal-instance",
+      });
+      let remoteSignal: AbortSignal | undefined;
+      previewGenerationPlacement.mockImplementation(
+        (
+          target: { baseUrl: string },
+          _request: unknown,
+          _copies: number,
+          options?: { signal?: AbortSignal },
+        ) => {
+          if (!target.baseUrl.includes("hal9000")) return Promise.resolve(plannedPlacement());
+          remoteSignal = options?.signal;
+          return new Promise(() => {});
+        },
+      );
+
+      const pending = hosts.resolveFeasible(null, placementRequest);
+      await vi.waitFor(() => expect(previewGenerationPlacement).toHaveBeenCalledTimes(2));
+      await vi.advanceTimersByTimeAsync(250);
+
+      await expect(pending).resolves.toMatchObject({
+        kind: "route",
+        route: { hostId: "local" },
+      });
+      expect(remoteSignal?.aborted).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("fails closed when the only Auto candidate never finishes planning", async () => {
+    vi.useFakeTimers();
+    try {
+      let requestSignal: AbortSignal | undefined;
+      previewGenerationPlacement.mockImplementation(
+        (
+          _target: unknown,
+          _request: unknown,
+          _copies: number,
+          options?: { signal?: AbortSignal },
+        ) => {
+          requestSignal = options?.signal;
+          return new Promise(() => {});
+        },
+      );
+      const hosts = useHostsStore();
+
+      const pending = hosts.resolveFeasible(null, placementRequest);
+      await vi.waitFor(() => expect(previewGenerationPlacement).toHaveBeenCalledTimes(1));
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      await expect(pending).resolves.toEqual({
+        kind: "unreachable",
+        perHost: [
+          expect.objectContaining({
+            hostId: "local",
+            error: expect.stringContaining("Auto placement timed out after 5 seconds"),
+          }),
+        ],
+      });
+      expect(requestSignal?.aborted).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("waits for every Most capable probe instead of using Auto's early route window", async () => {
+    vi.useFakeTimers();
+    try {
+      const hosts = useHostsStore();
+      hosts.extras.push({
+        id: hal.id,
+        label: "hal9000",
+        url: hal.url,
+        apiKey: "hal-key",
+        status: "ready",
+        error: null,
+        instanceId: "hal-instance",
+      });
+      const stronger = deferred<ReturnType<typeof plannedPlacement>>();
+      previewGenerationPlacement.mockImplementation((target: { baseUrl: string }) =>
+        target.baseUrl.includes("hal9000")
+          ? stronger.promise
+          : Promise.resolve({
+              ...plannedPlacement("cuda:local"),
+              candidate: {
+                ...plannedPlacement("cuda:local").candidate,
+                predicted_completion_after_ms: 10_000,
+              },
+            }),
+      );
+
+      const pending = hosts.resolveFeasible("capable", placementRequest);
+      await vi.waitFor(() => expect(previewGenerationPlacement).toHaveBeenCalledTimes(2));
+      await vi.advanceTimersByTimeAsync(5_000);
+      let settled = false;
+      void pending.then(() => (settled = true));
+      await Promise.resolve();
+      expect(settled).toBe(false);
+
+      stronger.resolve({
+        ...plannedPlacement("cuda:remote"),
+        candidate: {
+          ...plannedPlacement("cuda:remote").candidate,
+          predicted_completion_after_ms: 10,
+        },
+      });
+      await expect(pending).resolves.toMatchObject({
+        kind: "route",
+        route: { hostId: hal.id },
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("retains the placement probe HTTP status and message", async () => {
     previewGenerationPlacement.mockRejectedValueOnce(
       new ApiError("placement failed", 401, { error: "API key was rejected" }),
@@ -998,7 +1125,9 @@ describe("hosts store", () => {
       instanceId: "instance-a",
       target: { baseUrl: hal.url, apiKey: "host-key" },
     });
-    expect(previewChainPlacement).toHaveBeenCalledWith(expect.anything(), expect.anything(), 3);
+    expect(previewChainPlacement).toHaveBeenCalledWith(expect.anything(), expect.anything(), 3, {
+      signal: expect.any(AbortSignal),
+    });
   });
 
   it("previews an auto-expanded long video through the chain endpoint", async () => {
@@ -1034,6 +1163,7 @@ describe("hosts store", () => {
       expect.anything(),
       expect.objectContaining({ batch_size: 1 }),
       4,
+      { signal: expect.any(AbortSignal) },
     );
     expect(request.batch_size).toBe(4);
   });

--- a/desktop/src/stores/hosts.ts
+++ b/desktop/src/stores/hosts.ts
@@ -41,6 +41,14 @@ import { useHostModelsStore } from "./hostModels";
 
 const POLL_INTERVAL_MS = 10_000;
 const MAX_SAVED_HOSTS = 8;
+/** Once Auto has one authoritative route, allow normal LAN peers a brief
+ * window to return a better plan, then stop waiting on cold artifact checks.
+ * Explicitly selected hosts retain the full placement-preview deadline. */
+const AUTO_PLACEMENT_SETTLE_MS = 250;
+/** Auto must remain a bounded interaction even when no candidate ever answers.
+ * A pinned machine may legitimately spend minutes authenticating cold weights;
+ * Auto instead fails closed and tells the user to retry or pin that machine. */
+const AUTO_PLACEMENT_DEADLINE_MS = 5_000;
 
 /**
  * Serialize this store's settings read-modify-writes: `app_settings_set`
@@ -718,8 +726,22 @@ export const useHostsStore = defineStore("hosts", {
           };
         }
 
-        const probes = await Promise.all(
-          candidates.map(async (host) => {
+        type PlacementProbe = {
+          host: HostView;
+          preview: Awaited<ReturnType<typeof previewGenerationPlacement>> | null;
+          error: unknown;
+          legacyUnsupported: boolean;
+          roundTripMs: number;
+        };
+        const probes: PlacementProbe[] = [];
+        const controllers = candidates.map(() => new AbortController());
+        let pendingProbes = candidates.length;
+        let resolveAllProbes!: () => void;
+        let resolveFirstPlanned!: () => void;
+        const allProbesSettled = new Promise<void>((resolve) => (resolveAllProbes = resolve));
+        const firstPlanned = new Promise<void>((resolve) => (resolveFirstPlanned = resolve));
+        candidates.forEach((host, index) => {
+          void (async () => {
             const started = performance.now();
             try {
               const target = { baseUrl: host.baseUrl!, apiKey: host.apiKey };
@@ -732,6 +754,7 @@ export const useHostsStore = defineStore("hosts", {
                         copies,
                       ),
                       copies,
+                      { signal: controllers[index]!.signal },
                     )
                   : await previewGenerationPlacement(
                       target,
@@ -740,26 +763,72 @@ export const useHostsStore = defineStore("hosts", {
                         copies,
                       ),
                       copies,
+                      { signal: controllers[index]!.signal },
                     );
-              return {
+              probes.push({
                 host,
                 preview,
                 error: null,
                 legacyUnsupported: false,
                 roundTripMs: Math.max(0, performance.now() - started),
-              };
+              });
+              if (classifyPlacementPreview(preview) === "planned") resolveFirstPlanned();
             } catch (error) {
-              return {
+              probes.push({
                 host,
                 preview: null,
                 error,
                 legacyUnsupported:
                   error instanceof ApiError && (error.status === 404 || error.status === 405),
                 roundTripMs: Math.max(0, performance.now() - started),
-              };
+              });
+            } finally {
+              pendingProbes -= 1;
+              if (pendingProbes === 0) resolveAllProbes();
             }
-          }),
-        );
+          })();
+        });
+        const responsiveAuto = selection === null;
+        let autoDeadlineReached = false;
+        if (responsiveAuto) {
+          let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+          const deadline = new Promise<void>((resolve) => {
+            deadlineTimer = setTimeout(() => {
+              autoDeadlineReached = true;
+              resolve();
+            }, AUTO_PLACEMENT_DEADLINE_MS);
+          });
+          const firstRouteWindow = firstPlanned.then(
+            () => new Promise<void>((resolve) => setTimeout(resolve, AUTO_PLACEMENT_SETTLE_MS)),
+          );
+          await Promise.race([
+            allProbesSettled,
+            deadline,
+            ...(candidates.length > 1 ? [firstRouteWindow] : []),
+          ]);
+          clearTimeout(deadlineTimer);
+          if (pendingProbes > 0) controllers.forEach((controller) => controller.abort());
+        } else {
+          await allProbesSettled;
+        }
+        // Aborted fetches settle on a later microtask. Route using the stable
+        // snapshot that met Auto's response window, not late cancellation rows.
+        const settledProbes = probes.slice();
+        if (autoDeadlineReached) {
+          const settledHostIds = new Set(settledProbes.map((probe) => probe.host.id));
+          for (const host of candidates) {
+            if (settledHostIds.has(host.id)) continue;
+            settledProbes.push({
+              host,
+              preview: null,
+              error: new Error(
+                "Auto placement timed out after 5 seconds; retry or select this machine explicitly for a longer cold check",
+              ),
+              legacyUnsupported: false,
+              roundTripMs: AUTO_PLACEMENT_DEADLINE_MS,
+            });
+          }
+        }
         if (intentSignature() !== capturedIntent || identitySignature() !== capturedIdentity) {
           return {
             kind: "transient",
@@ -784,7 +853,7 @@ export const useHostsStore = defineStore("hosts", {
           };
         }
 
-        const planned = probes
+        const planned = settledProbes
           .flatMap((probe) =>
             probe.preview && classifyPlacementPreview(probe.preview) === "planned"
               ? [
@@ -808,7 +877,7 @@ export const useHostsStore = defineStore("hosts", {
           if (route) return { kind: "route", route };
         }
 
-        const unsupportedIds = probes
+        const unsupportedIds = settledProbes
           .filter(
             (probe) =>
               probe.legacyUnsupported || classifyPlacementPreview(probe.preview) === "unsupported",
@@ -837,7 +906,7 @@ export const useHostsStore = defineStore("hosts", {
           if (route) return { kind: "route", route };
         }
 
-        const failures = probes.flatMap<HostFeasibilityFailure>((probe) => {
+        const failures = settledProbes.flatMap<HostFeasibilityFailure>((probe) => {
           const classification = classifyPlacementPreview(probe.preview);
           if (
             requireAuthoritative &&

--- a/studio/api/generationPlacement.test.ts
+++ b/studio/api/generationPlacement.test.ts
@@ -445,4 +445,33 @@ describe("generation placement preview", () => {
       vi.useRealTimers();
     }
   });
+
+  test("combines a fleet cancellation signal with the normal preview deadline", async () => {
+    apiJsonTo.mockClear();
+    const controller = new AbortController();
+    let requestSignal: AbortSignal | undefined;
+    apiJsonTo.mockImplementationOnce((_target, _path, init) => {
+      requestSignal = init?.signal as AbortSignal;
+      return new Promise((_resolve, reject) => {
+        requestSignal?.addEventListener(
+          "abort",
+          () => reject(requestSignal?.reason),
+          {
+            once: true,
+          },
+        );
+      });
+    });
+
+    const pending = previewGenerationPlacement(
+      { baseUrl: "http://plato:7680", apiKey: null },
+      { model: "m", prompt: "p" },
+      1,
+      { signal: controller.signal },
+    );
+    controller.abort(new Error("another Auto host is ready"));
+
+    await expect(pending).rejects.toThrow("another Auto host is ready");
+    expect(requestSignal?.aborted).toBe(true);
+  });
 });

--- a/studio/api/generationPlacement.ts
+++ b/studio/api/generationPlacement.ts
@@ -280,8 +280,33 @@ interface PlacementPreviewBound {
   release: () => void;
 }
 
-function placementPreviewBound(): PlacementPreviewBound | undefined {
+export interface PlacementPreviewOptions {
+  /** Let a fleet router stop a probe once another host has supplied a usable
+   * route. The normal 15-minute authority deadline still applies. */
+  signal?: AbortSignal;
+}
+
+function placementPreviewBound(
+  externalSignal?: AbortSignal,
+): PlacementPreviewBound | undefined {
   if (typeof AbortSignal === "undefined") return undefined;
+  if (externalSignal && typeof AbortController !== "undefined") {
+    const controller = new AbortController();
+    const abort = () => controller.abort(externalSignal.reason);
+    if (externalSignal.aborted) abort();
+    else externalSignal.addEventListener("abort", abort, { once: true });
+    const timer = setTimeout(
+      () => controller.abort(new Error("placement preview timed out")),
+      PLACEMENT_PREVIEW_TIMEOUT_MS,
+    );
+    return {
+      signal: controller.signal,
+      release: () => {
+        clearTimeout(timer);
+        externalSignal.removeEventListener("abort", abort);
+      },
+    };
+  }
   if (typeof AbortSignal.timeout === "function") {
     // Engine-managed timer; nothing to disarm.
     return {
@@ -305,8 +330,9 @@ export async function previewGenerationPlacement(
   target: ApiTarget,
   request: Record<string, unknown>,
   copies = 1,
+  options: PlacementPreviewOptions = {},
 ): Promise<GenerationPlacementPreview> {
-  const bound = placementPreviewBound();
+  const bound = placementPreviewBound(options.signal);
   try {
     return await apiJsonTo<GenerationPlacementPreview>(
       target,
@@ -354,8 +380,9 @@ export async function previewChainPlacement(
   target: ApiTarget,
   request: Record<string, unknown>,
   copies = 1,
+  options: PlacementPreviewOptions = {},
 ): Promise<GenerationPlacementPreview> {
-  const bound = placementPreviewBound();
+  const bound = placementPreviewBound(options.signal);
   try {
     return await apiJsonTo<GenerationPlacementPreview>(
       target,


### PR DESCRIPTION
## Summary

- stop Auto routing from waiting on a cold or hung peer after another authoritative route is ready
- bound Auto-only planning at five seconds while preserving full checks for pinned and Most capable routing
- compose fleet cancellation with generation and sequence placement-preview deadlines

## Root cause

Auto fanned placement-preview requests out to every candidate machine and awaited `Promise.all`. In the live reproduction, hal9000 returned an authoritative planned route in 35 ms while plato returned no bytes for more than 20 seconds, so the frontend stayed in Planning before any generation was queued.

## User impact

Auto now accepts a valid route after a short 250 ms peer window. If every candidate stalls, it fails closed after five seconds with an actionable error and queues nothing. Explicitly selected machines and Most capable retain the longer authoritative planning behavior.

## Validation

- `nix develop -c desktop-test` (3,524 frontend tests plus native, engine boot, and packaging tests)
- `nix develop -c desktop-check`
- independent agent review: no findings
