### PR TITLE
fix(ci): stabilize release and queue checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -706,11 +706,18 @@ jobs:
             -f "sha=${GITHUB_SHA}" \
             -F force=true >/dev/null
 
-          tag_sha="$(
-            gh api \
-              "repos/${GITHUB_REPOSITORY}/git/ref/tags/latest" \
-              --jq '.object.sha'
-          )"
+          # GitHub's ref read can briefly lag a successful forced update.
+          # Retry only the observation; the mutation remains single-shot.
+          tag_sha=""
+          for attempt in $(seq 1 10); do
+            tag_sha="$(
+              gh api \
+                "repos/${GITHUB_REPOSITORY}/git/ref/tags/latest" \
+                --jq '.object.sha'
+            )"
+            [[ "$tag_sha" == "$GITHUB_SHA" ]] && break
+            [[ "$attempt" -eq 10 ]] || sleep 2
+          done
           if [[ "$tag_sha" != "$GITHUB_SHA" ]]; then
             echo "::error::latest resolved to $tag_sha instead of $GITHUB_SHA"
             exit 1

--- a/crates/mold-server/src/routes_test.rs
+++ b/crates/mold-server/src/routes_test.rs
@@ -6722,7 +6722,6 @@ mod tests {
             .register("already-running", "flux-dev:q4");
         state.job_registry.mark_running("already-running", Some(0));
         let worker_state = state.clone();
-        tokio::spawn(crate::queue::run_queue_worker(rx, worker_state));
         let app = create_router(state);
 
         let response = app
@@ -6735,6 +6734,11 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
+        // Keep the worker stopped until the handler has snapshotted the seed.
+        // Under coverage instrumentation, starting it first can let the new
+        // job reach its processing `position: 0` event before this assertion
+        // observes the submit-time event this test is meant to pin.
+        tokio::spawn(crate::queue::run_queue_worker(rx, worker_state));
         let body = axum::body::to_bytes(response.into_body(), 1024 * 1024)
             .await
             .unwrap();

--- a/scripts/tests/cuda-distribution-contract.sh
+++ b/scripts/tests/cuda-distribution-contract.sh
@@ -187,6 +187,10 @@ require_release_job_text "release-latest" \
 require_release_job_text "release-latest" \
   '-F force=true'
 require_release_job_text "release-latest" \
+  'for attempt in $(seq 1 10); do'
+require_release_job_text "release-latest" \
+  '[[ "$attempt" -eq 10 ]] || sleep 2'
+require_release_job_text "release-latest" \
   'if [[ "$tag_sha" != "$GITHUB_SHA" ]]; then'
 main_freshness_guard_count="$(
   awk '

--- a/scripts/tests/minimax-h3-private-uat-release-contract.sh
+++ b/scripts/tests/minimax-h3-private-uat-release-contract.sh
@@ -548,7 +548,7 @@ require_text crates/mold-server/src/gpu_worker.rs \
   'with_private_h3_cuda_preparation_attempt(worker, || {' \
   "server owner preparation is not inside a separate CUDA containment scope"
 require_text crates/mold-server/src/gpu_worker.rs \
-  'request_private_h3_host_headroom(' \
+  'request_lease_host_headroom(' \
   "private H3 live owner does not request ledger-aware host headroom"
 require_text crates/mold-server/src/scheduler/mod.rs \
   'WorkerEvent::HostMemoryRecheck { fence, reply }' \
@@ -563,8 +563,8 @@ require_text crates/mold-server/src/scheduler/mod.rs \
   '!reservation.charge_until_release' \
   "Scheduler V2 can absorb a gradual private H3 reservation into a premature host sample"
 require_text crates/mold-server/src/scheduler/mod.rs \
-  'mold_core::minimax_h3::is_family(&execution.model_family)' \
-  "Scheduler V2 does not select private H3 leases for sticky host-memory accounting"
+  'charge_until_release: item.host_ram_bytes > 0,' \
+  "Scheduler V2 does not keep host-memory leases charged through release"
 require_text crates/mold-server/src/scheduler/mod.rs \
   'fn h3_reservation_stays_charged_until_release_and_blocks_ordinary_work()' \
   "Scheduler V2 lacks a regression for private H3 host-memory isolation"


### PR DESCRIPTION
## Summary

- update the MiniMax H3 release contract for the generalized host-memory lease fence
- remove the queue SSE regression test race exposed by coverage instrumentation
- tolerate GitHub ref-read propagation after the rolling `latest` tag moves

## Failure evidence

- release-plz PR `rust`: stale `request_private_h3_host_headroom` contract marker
- main `Codecov coverage`: submit-time queue event lost a race to the worker
- main `Release`: the forced tag update succeeded, but the immediate ref read returned the previous SHA before converging

## Verification

- `nix develop -c bash scripts/tests/minimax-h3-private-uat-release-contract.sh`
- `nix develop -c cargo test -p mold-ai-server routes_test::tests::the_first_queued_event_is_on_the_registry_scale -- --exact --nocapture`
- exact queue regression repeated 20 times
- `nix develop -c cargo fmt --all -- --check`
- `nix develop -c nix run nixpkgs#actionlint -- .github/workflows/release.yml`
- `nix develop -c nix run nixpkgs#shellcheck -- scripts/tests/minimax-h3-private-uat-release-contract.sh scripts/tests/cuda-distribution-contract.sh`

The complete CUDA distribution contract contains Linux ELF fixtures and is left to the Linux CI runner; its changed shell assertions pass syntax, actionlint, and ShellCheck locally.