### PR TITLE
fix(ios): restore viewport after keyboard dismissal

### DIFF
--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -4607,6 +4607,75 @@ describe("MobileApp foreground resume", () => {
     expect(invoke).toHaveBeenCalledWith("restore_mobile_viewport");
   });
 
+  it("restores the native WKWebView frame after the software keyboard dismisses", async () => {
+    vi.useFakeTimers();
+    try {
+      Object.defineProperty(window, "__TAURI_INTERNALS__", {
+        value: {},
+        configurable: true,
+      });
+      wrapper = mountMobileApp();
+      await flushPromises();
+      invoke.mockClear();
+
+      const prompt = fieldControl("Prompt").element as HTMLTextAreaElement;
+      prompt.focus();
+      prompt.blur();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(invoke).toHaveBeenCalledTimes(1);
+      expect(invoke).toHaveBeenLastCalledWith("restore_mobile_viewport");
+
+      await vi.advanceTimersByTimeAsync(400);
+      expect(invoke).toHaveBeenCalledTimes(2);
+      expect(invoke).toHaveBeenLastCalledWith("restore_mobile_viewport");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not restore the viewport while focus moves between keyboard editors", async () => {
+    Object.defineProperty(window, "__TAURI_INTERNALS__", {
+      value: {},
+      configurable: true,
+    });
+    wrapper = mountMobileApp();
+    await flushPromises();
+    invoke.mockClear();
+
+    const prompt = fieldControl("Prompt").element as HTMLTextAreaElement;
+    const negativePrompt = fieldControl("Negative prompt").element as HTMLTextAreaElement;
+    prompt.focus();
+    negativePrompt.focus();
+    await Promise.resolve();
+
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it("cancels the settling restore when an editor refocuses before it fires", async () => {
+    vi.useFakeTimers();
+    try {
+      Object.defineProperty(window, "__TAURI_INTERNALS__", {
+        value: {},
+        configurable: true,
+      });
+      wrapper = mountMobileApp();
+      await flushPromises();
+      invoke.mockClear();
+
+      const prompt = fieldControl("Prompt").element as HTMLTextAreaElement;
+      prompt.focus();
+      prompt.blur();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(invoke).toHaveBeenCalledTimes(1);
+
+      prompt.focus();
+      await vi.advanceTimersByTimeAsync(400);
+      expect(invoke).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   async function submitSeededPrompt(prompt: string, seed: number): Promise<void> {
     const liveForm = wrapper!.getComponent(MobileLoraControls).props("form") as GenerateForm;
     liveForm.seed = String(seed);

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -547,6 +547,20 @@ let expansionRecoveryId = 0;
 let submissionUiId = 0;
 let recoveryRetryId = 0;
 let unmounted = false;
+let keyboardViewportRestoreTimer: ReturnType<typeof setTimeout> | null = null;
+const KEYBOARD_VIEWPORT_SETTLE_MS = 400;
+const NON_KEYBOARD_INPUT_TYPES = new Set([
+  "button",
+  "checkbox",
+  "color",
+  "file",
+  "hidden",
+  "image",
+  "radio",
+  "range",
+  "reset",
+  "submit",
+]);
 const downloadConsumerId = `mobile-generate-${createUuid()}`;
 const progress = ref("Ready");
 /** Whether the status line under Develop currently shows a failure. Set with
@@ -4705,12 +4719,55 @@ function handleForegroundResume(): void {
   if (tab.value === "gallery") void refreshGallery();
 }
 
+function usesSoftwareKeyboard(target: EventTarget | null): target is HTMLElement {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target.matches("textarea, select, [contenteditable='true']")) return true;
+  if (!(target instanceof HTMLInputElement)) return false;
+  return !NON_KEYBOARD_INPUT_TYPES.has(target.type.toLowerCase());
+}
+
+function restoreNativeViewport(): void {
+  if (!("__TAURI_INTERNALS__" in window) || unmounted) return;
+  void invoke("restore_mobile_viewport").catch(() => undefined);
+}
+
+function cancelKeyboardViewportRestore(): void {
+  if (!keyboardViewportRestoreTimer) return;
+  clearTimeout(keyboardViewportRestoreTimer);
+  keyboardViewportRestoreTimer = null;
+}
+
+function handleKeyboardFocusIn(event: FocusEvent): void {
+  if (usesSoftwareKeyboard(event.target)) cancelKeyboardViewportRestore();
+}
+
+/**
+ * WKWebView can keep the keyboard-reduced presentation frame after an editor
+ * blurs. Repair once after focus has moved, then again after UIKit's keyboard
+ * dismissal animation so its final layout pass cannot reinstate the gap.
+ */
+function handleKeyboardFocusOut(event: FocusEvent): void {
+  if (!usesSoftwareKeyboard(event.target)) return;
+  queueMicrotask(() => {
+    if (unmounted || usesSoftwareKeyboard(document.activeElement)) return;
+    restoreNativeViewport();
+    cancelKeyboardViewportRestore();
+    keyboardViewportRestoreTimer = setTimeout(() => {
+      keyboardViewportRestoreTimer = null;
+      if (usesSoftwareKeyboard(document.activeElement)) return;
+      restoreNativeViewport();
+    }, KEYBOARD_VIEWPORT_SETTLE_MS);
+  });
+}
+
 watch(resultPreviewError, (error) => {
   if (!error) return;
   generationAnnouncement.value = `Generation completed, but its preview is unavailable. ${error}`;
 });
 
 onMounted(async () => {
+  document.addEventListener("focusin", handleKeyboardFocusIn, true);
+  document.addEventListener("focusout", handleKeyboardFocusOut, true);
   if ("__TAURI_INTERNALS__" in window) {
     void invoke("restore_mobile_viewport").catch(() => undefined);
     void import("@tauri-apps/api/app")
@@ -4763,7 +4820,10 @@ onBeforeUnmount(() => {
   expansionPullRequestId += 1;
   clearExpansionRecovery();
   document.removeEventListener("visibilitychange", handleForegroundResume);
+  document.removeEventListener("focusin", handleKeyboardFocusIn, true);
+  document.removeEventListener("focusout", handleKeyboardFocusOut, true);
   window.removeEventListener("pageshow", handleForegroundResume);
+  cancelKeyboardViewportRestore();
   stopPairingDeepLinks?.();
   stopPairingDeepLinks = null;
   if (hostProbeTimer) clearInterval(hostProbeTimer);


### PR DESCRIPTION
## Summary

- restore the native iOS WKWebView frame when a keyboard editor loses focus, covering prompt edits that do not trigger the existing launch or foreground repair
- repeat the repair after the UIKit dismissal animation, while cancelling it if another editor refocuses and fencing component teardown
- add regressions for dismissal, direct editor focus transfer, and refocus during the settle window

## Root cause

The mobile shell correctly fills `100%` of its WKWebView, but iOS can leave that native view at the keyboard-reduced presentation frame after keyboard dismissal. The existing `restore_mobile_viewport` command was only called on launch and foreground/pageshow, so an ordinary prompt edit had no recovery path. That left the correctly sized shell filling the wrong native frame and exposed a dead region below the tab bar.

## Verification

- `nix develop -c bash -lc "cd desktop && bun run test"` — 320 files / 3,616 tests
- `nix develop -c bash -lc "cd desktop && bun run build:mobile && bun run fmt:check"`
- `nix develop -c bash -lc "ios-check && ./scripts/tests/ios-release-assets.sh"`
- signed iPhone 16 Pro / iOS 18.6 Simulator build: focused Prompt, typed `flying down a busy street in NYC` with the software keyboard visible, dismissed via Done, and verified the Develop action plus four-tab bar returned to the bottom safe area with no gap
- agent peer review found one refocus race; fixed with focus-in cancellation and a delayed active-editor guard, then re-review approved with no remaining findings (159/159 focused tests)