### PR TITLE
fix(ios): improve generation and gallery resilience

### DIFF
--- a/desktop/src/lib/generateForm.test.ts
+++ b/desktop/src/lib/generateForm.test.ts
@@ -1599,6 +1599,24 @@ describe("applyModelDefaults — wan sampler recipe and solver", () => {
   });
 });
 
+describe("buildRequest prompt provenance", () => {
+  it("does not attach an earlier prompt to an intentionally promptless request", () => {
+    const form = newGenerateForm();
+    form.prompt = "";
+    form.originalPrompt = "an earlier expanded prompt";
+
+    expect(buildRequest(form).original_prompt).toBeUndefined();
+  });
+
+  it("keeps original prompt provenance when a visible transformed prompt is submitted", () => {
+    const form = newGenerateForm();
+    form.prompt = "an expanded lighthouse at dusk";
+    form.originalPrompt = "a lighthouse";
+
+    expect(buildRequest(form).original_prompt).toBe("a lighthouse");
+  });
+});
+
 describe("newGenerateForm source-fit default", () => {
   it("starts on pad-repaint, matching the web SPA's default policy", () => {
     expect(newGenerateForm().sourceFit).toEqual({ mode: "pad-repaint" });

--- a/desktop/src/lib/generateForm.ts
+++ b/desktop/src/lib/generateForm.ts
@@ -775,7 +775,7 @@ export function buildRequest(form: GenerateForm): GenerateRequest {
   };
 
   if (parsedSeed !== undefined && Number.isFinite(parsedSeed)) req.seed = parsedSeed;
-  if (form.originalPrompt && form.originalPrompt !== req.prompt) {
+  if (req.prompt && form.originalPrompt && form.originalPrompt !== req.prompt) {
     req.original_prompt = form.originalPrompt;
   }
   if (caps.supportsNegativePrompt) {

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -1,9 +1,11 @@
 import { flushPromises, mount, type DOMWrapper, type VueWrapper } from "@vue/test-utils";
 import { createPinia, type Pinia } from "pinia";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { IDBFactory } from "fake-indexeddb";
 import { installMemoryLocalStorage } from "../lib/testSupport/memoryLocalStorage";
 import type { GalleryImage, ModelEntry, ServerStatus } from "../lib/api/types";
 import { applyModelDefaults, type GenerateForm } from "../lib/generateForm";
+import { loadCachedGallery, storeCachedGallery, storeCachedGalleryMedia } from "./galleryCache";
 
 const {
   invoke,
@@ -370,9 +372,114 @@ afterEach(() => {
   delete document.documentElement.dataset.themeFamily;
   delete (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
   delete (globalThis as Partial<typeof globalThis>).IntersectionObserver;
+  Reflect.deleteProperty(globalThis, "indexedDB");
 });
 
 describe("MobileApp sequence generation", () => {
+  it("acknowledges a tap through placement preview and blocks duplicate submission", async () => {
+    const preview = deferred<ReturnType<typeof plannedPlacement>>();
+    previewGenerationPlacement.mockReturnValueOnce(preview.promise);
+    wrapper = mountMobileApp();
+    await flushPromises();
+    await fieldControl("Prompt").setValue("a responsive placement check");
+
+    await wrapper.get("[data-test='mobile-develop-button']").trigger("click");
+    await vi.waitFor(() => expect(previewGenerationPlacement).toHaveBeenCalledTimes(1));
+
+    const button = wrapper.get("[data-test='mobile-develop-button']");
+    expect(button.text()).toBe("Checking placement…");
+    expect(button.attributes("disabled")).toBe("");
+    await button.trigger("click");
+    expect(previewGenerationPlacement).toHaveBeenCalledTimes(1);
+    expect(openStreams).toHaveLength(0);
+
+    preview.resolve(plannedPlacement());
+    await flushPromises();
+    expect(openStreams).toHaveLength(1);
+    expect(button.text()).toContain("Develop print");
+  });
+
+  it("cancels a placement-pending submission when prompt work takes authority", async () => {
+    const preview = deferred<ReturnType<typeof plannedPlacement>>();
+    previewGenerationPlacement.mockReturnValueOnce(preview.promise);
+    wrapper = mountMobileApp();
+    await flushPromises();
+    await fieldControl("Prompt").setValue("a placement-pending prompt");
+
+    await wrapper.get("[data-test='mobile-develop-button']").trigger("click");
+    await vi.waitFor(() => expect(previewGenerationPlacement).toHaveBeenCalledTimes(1));
+    await wrapper.get("[data-test='mobile-prompt-expand']").trigger("click");
+    await flushPromises();
+    preview.resolve(plannedPlacement());
+    await flushPromises();
+
+    expect(openStreams).toHaveLength(0);
+    expect(
+      wrapper.get("[data-test='mobile-develop-button']").attributes("disabled"),
+    ).toBeUndefined();
+  });
+
+  it("cancels source preparation and releases Generate when prompt work takes authority", async () => {
+    const imageModel: ModelEntry = { ...model, name: "flux:image", family: "flux" };
+    apiJsonTo.mockImplementation((_target: unknown, path: string) => {
+      if (path === "/api/status") return Promise.resolve(status);
+      if (path === "/api/models") return Promise.resolve([imageModel]);
+      if (path === "/api/gallery") return Promise.resolve([]);
+      return Promise.reject(new Error(`Unexpected API path: ${path}`));
+    });
+    const preprocess = deferred<{ source: string | null; mask: string | null; changed: boolean }>();
+    applySourceFitPreprocess.mockReturnValueOnce(preprocess.promise);
+    wrapper = mountMobileApp();
+    await flushPromises();
+    const liveForm = wrapper.getComponent(MobileLoraControls).props("form") as GenerateForm;
+    liveForm.sourceImage = btoa("source");
+    liveForm.sourceImageName = "source.png";
+    await fieldControl("Prompt").setValue("a source-preparing prompt");
+
+    await wrapper.get("[data-test='mobile-develop-button']").trigger("click");
+    await vi.waitFor(() => expect(applySourceFitPreprocess).toHaveBeenCalledTimes(1));
+    await wrapper.get("[data-test='mobile-prompt-expand']").trigger("click");
+    await flushPromises();
+    preprocess.resolve({ source: btoa("source"), mask: null, changed: false });
+    await flushPromises();
+
+    expect(openStreams).toHaveLength(0);
+    expect(
+      wrapper.get("[data-test='mobile-develop-button']").attributes("disabled"),
+    ).toBeUndefined();
+  });
+
+  it("releases Generate when invalidated source preparation rejects", async () => {
+    const imageModel: ModelEntry = { ...model, name: "flux:image", family: "flux" };
+    apiJsonTo.mockImplementation((_target: unknown, path: string) => {
+      if (path === "/api/status") return Promise.resolve(status);
+      if (path === "/api/models") return Promise.resolve([imageModel]);
+      if (path === "/api/gallery") return Promise.resolve([]);
+      return Promise.reject(new Error(`Unexpected API path: ${path}`));
+    });
+    const preprocess = deferred<{ source: string | null; mask: string | null; changed: boolean }>();
+    applySourceFitPreprocess.mockReturnValueOnce(preprocess.promise);
+    wrapper = mountMobileApp();
+    await flushPromises();
+    const liveForm = wrapper.getComponent(MobileLoraControls).props("form") as GenerateForm;
+    liveForm.sourceImage = btoa("source");
+    liveForm.sourceImageName = "source.png";
+    await fieldControl("Prompt").setValue("a source-preparing prompt");
+
+    await wrapper.get("[data-test='mobile-develop-button']").trigger("click");
+    await vi.waitFor(() => expect(applySourceFitPreprocess).toHaveBeenCalledTimes(1));
+    await wrapper.get("[data-test='mobile-prompt-expand']").trigger("click");
+    await flushPromises();
+    preprocess.reject(new Error("stale source failure"));
+    await flushPromises();
+
+    expect(openStreams).toHaveLength(0);
+    expect(wrapper.text()).not.toContain("stale source failure");
+    expect(
+      wrapper.get("[data-test='mobile-develop-button']").attributes("disabled"),
+    ).toBeUndefined();
+  });
+
   it("removes capability-restricted models from the picker before submission", async () => {
     const restrictedModel: ModelEntry = {
       ...model,
@@ -5025,6 +5132,140 @@ describe("MobileApp primary navigation", () => {
 });
 
 describe("MobileApp gallery", () => {
+  it("renders instance-scoped cached gallery metadata and thumbnails while its host is offline", async () => {
+    Object.defineProperty(globalThis, "indexedDB", {
+      configurable: true,
+      value: new IDBFactory(),
+    });
+    localStorage.setItem(
+      "mold.mobile.hosts.v1",
+      JSON.stringify([
+        {
+          id: "url-derived-id",
+          instanceId: "studio-instance",
+          name: "Studio",
+          baseUrl: target.baseUrl,
+          online: false,
+        },
+      ]),
+    );
+    await storeCachedGallery("studio-instance", [print]);
+    await storeCachedGalleryMedia(
+      "studio-instance",
+      print.filename,
+      "thumbnail",
+      new Blob(["cached thumbnail"], { type: "image/webp" }),
+    );
+    apiJsonTo.mockImplementation((_target: unknown, path: string) => {
+      if (path === "/api/status" || path === "/api/gallery") {
+        return Promise.reject(new Error("offline"));
+      }
+      if (path === "/api/models") return Promise.resolve([model]);
+      if (path === "/api/activity")
+        return Promise.resolve({ instance_id: "mobile-host", observed_at_unix_ms: 1, items: [] });
+      return Promise.reject(new Error(`Unexpected API path: ${path}`));
+    });
+    apiFetchTo.mockRejectedValue(new Error("offline"));
+
+    wrapper = mountMobileApp();
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-tab-gallery']").trigger("click");
+
+    await vi.waitFor(() => expect(wrapper?.find("[data-test='gallery-item']").exists()).toBe(true));
+    expect(wrapper.get("[data-test='gallery-item'] img").attributes("src")).toContain("blob:");
+    expect(wrapper.text()).toContain("Showing saved Library");
+  });
+
+  it("does not restore an old instance cache from a gallery response that resolves after replacement", async () => {
+    Object.defineProperty(globalThis, "indexedDB", {
+      configurable: true,
+      value: new IDBFactory(),
+    });
+    localStorage.setItem(
+      "mold.mobile.hosts.v1",
+      JSON.stringify([
+        {
+          id: "url-derived-id",
+          instanceId: "old-instance",
+          name: "Studio",
+          baseUrl: target.baseUrl,
+          online: false,
+        },
+      ]),
+    );
+    await storeCachedGallery("old-instance", [print]);
+    const galleryResponse = deferred<GalleryImage[]>();
+    let replacement = false;
+    apiJsonTo.mockImplementation((_target: unknown, path: string) => {
+      if (path === "/api/status") {
+        return Promise.resolve({
+          ...status,
+          instance_id: replacement ? "replacement-instance" : "old-instance",
+        });
+      }
+      if (path === "/api/models") return Promise.resolve([model]);
+      if (path === "/api/gallery") return galleryResponse.promise;
+      if (path === "/api/activity") {
+        return Promise.resolve({ instance_id: "mobile-host", observed_at_unix_ms: 1, items: [] });
+      }
+      return Promise.reject(new Error(`Unexpected API path: ${path}`));
+    });
+
+    wrapper = mountMobileApp();
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-tab-gallery']").trigger("click");
+    await vi.waitFor(() =>
+      expect(apiJsonTo).toHaveBeenCalledWith(target, "/api/gallery", expect.anything()),
+    );
+    const statusCalls = apiJsonTo.mock.calls.filter(([, path]) => path === "/api/status").length;
+    replacement = true;
+    window.dispatchEvent(new Event("pageshow"));
+    await vi.waitFor(() =>
+      expect(
+        apiJsonTo.mock.calls.filter(([, path]) => path === "/api/status").length,
+      ).toBeGreaterThan(statusCalls),
+    );
+    await vi.waitFor(async () => expect(await loadCachedGallery("old-instance")).toEqual([]));
+    galleryResponse.resolve([print]);
+    await flushPromises();
+
+    expect(await loadCachedGallery("old-instance")).toEqual([]);
+  });
+
+  it("reuses promptless print settings without reviving stale original prompt text", async () => {
+    const promptless: GalleryImage = {
+      ...print,
+      metadata: {
+        ...print.metadata,
+        prompt: "",
+        original_prompt: "a previous prompt that did not render this print",
+      },
+    };
+    apiJsonTo.mockImplementation((_target: unknown, path: string) => {
+      if (path === "/api/status") return Promise.resolve(status);
+      if (path === "/api/models") return Promise.resolve([model]);
+      if (path === "/api/gallery") return Promise.resolve([promptless]);
+      if (path === "/api/activity")
+        return Promise.resolve({ instance_id: "mobile-host", observed_at_unix_ms: 1, items: [] });
+      return Promise.reject(new Error(`Unexpected API path: ${path}`));
+    });
+    wrapper = mountMobileApp();
+    await flushPromises();
+
+    await wrapper.get("[data-test='mobile-tab-gallery']").trigger("click");
+    await vi.waitFor(() => expect(wrapper?.find("[data-test='gallery-item']").exists()).toBe(true));
+    await wrapper.get("[data-test='gallery-item']").trigger("click");
+    await flushPromises();
+
+    expect(wrapper.get("[data-test='gallery-viewer-reuse']").text()).toBe("Reuse settings");
+    expect(wrapper.text()).toContain("No prompt was used for this print.");
+    expect(wrapper.text()).not.toContain("a previous prompt that did not render this print");
+    await wrapper.get("[data-test='gallery-viewer-reuse']").trigger("click");
+    await flushPromises();
+    expect(wrapper.get("#mobile-prompt").element).toHaveProperty("value", "");
+    expect(fieldControl("Negative prompt").element).toHaveProperty("value", "calm water");
+  });
+
   it("loads reachable hosts without waiting for a host already known to be offline", async () => {
     const offlineTarget = { baseUrl: "http://halcyon.tailnet.ts.net:7680", apiKey: "secret" };
     localStorage.setItem(

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -219,6 +219,15 @@ import {
   type MobileHost,
 } from "./hosts";
 import { applyMobileGalleryMetadata } from "./reuse";
+import {
+  clearCachedGalleryHosts,
+  loadCachedGallery,
+  loadCachedGalleryMedia,
+  pruneCachedGalleryMedia,
+  removeCachedGalleryPrints,
+  storeCachedGallery,
+  storeCachedGalleryMedia,
+} from "./galleryCache";
 import MobileAdvancedSheet from "./MobileAdvancedSheet.vue";
 import MobileCatalogView from "./MobileCatalogView.vue";
 import MobileExpansionPullStatus from "./MobileExpansionPullStatus.vue";
@@ -280,6 +289,7 @@ interface DiscoveredHost {
 
 interface GalleryPrint extends GalleryImage {
   hostId: string;
+  cacheKey: string;
   hostName: string;
   target: ApiTarget;
   thumbnailUrl: string;
@@ -287,6 +297,7 @@ interface GalleryPrint extends GalleryImage {
 
 interface PendingGalleryPrint extends GalleryImage {
   hostId: string;
+  cacheKey: string;
   hostName: string;
   target: ApiTarget;
 }
@@ -521,6 +532,7 @@ function resetAdvancedSettings(): void {
   form.wanRecipe = emptyWanRecipe();
 }
 const preparingGeneration = ref(false);
+const generationSubmissionPhase = ref<"preparing" | "placement" | null>(null);
 const preparedBatch = ref<PreparedExpansionBatchState | null>(null);
 const expansionRunning = ref(false);
 const expansionError = ref("");
@@ -1439,8 +1451,10 @@ const resultPreviewError = computed(() => {
   return job?.resultError ? describeTransportError(job.resultError, job.hostLabel) : "";
 });
 const developButtonLabel = computed(() =>
-  preparingGeneration.value
-    ? "Preparing source…"
+  generationSubmissionPhase.value
+    ? generationSubmissionPhase.value === "placement"
+      ? "Checking placement…"
+      : "Preparing source…"
     : `${form.batchSize > 1 ? `Develop ${form.batchSize} prints` : "Develop print"}${
         queuedJobs.value.length > 0 ? ` (+${queuedJobs.value.length} queued)` : ""
       }`,
@@ -1765,9 +1779,13 @@ function updateHostStatus(payload: { id: string; status: ServerStatus | null }):
   if (!host) return;
   host.online = payload.status !== null;
   if (payload.status) {
+    const priorCacheKey = host.instanceId?.trim() || host.id;
+    const nextInstanceId = payload.status.instance_id ?? host.instanceId;
+    const nextCacheKey = nextInstanceId?.trim() || host.id;
+    if (priorCacheKey !== nextCacheKey) void clearCachedGalleryHosts([priorCacheKey]);
     host.version = payload.status.version;
     host.hostname = payload.status.hostname ?? undefined;
-    host.instanceId = payload.status.instance_id ?? host.instanceId;
+    host.instanceId = nextInstanceId;
     captureHostTelemetry(host.id, payload.status);
   } else {
     delete hostTelemetry[host.id];
@@ -1921,6 +1939,7 @@ function removeHost(id: string): void {
   const removedSelectedHost = selectedHostId.value === id;
   const removedCatalogHost = catalogHostId.value === id;
   if (hostDetailId.value === id) hostDetailId.value = "";
+  const removedHost = hosts.value.find((host) => host.id === id);
   hosts.value = hosts.value.filter((host) => host.id !== id);
   if (removedSelectedHost) {
     selectedHostId.value = connectedHosts.value[0]?.id ?? "";
@@ -1930,6 +1949,12 @@ function removeHost(id: string): void {
   }
   if (removedCatalogHost) catalogHostId.value = connectedHosts.value[0]?.id ?? "";
   persistHosts();
+  if (removedHost) {
+    void clearCachedGalleryHosts([
+      removedHost.instanceId?.trim() || removedHost.id,
+      removedHost.id,
+    ]);
+  }
   void invoke("keychain_delete_api_key", { hostId: id });
 }
 
@@ -3044,6 +3069,7 @@ function restoreQuickExpansion(): void {
   expansionRunning.value = false;
   preparedSubmitting.value = false;
   preparingGeneration.value = false;
+  generationSubmissionPhase.value = null;
   submissionUiId += 1;
 }
 
@@ -3131,6 +3157,7 @@ function collapsePreparedBatch(removedId: string): void {
   expansionRunning.value = false;
   preparedSubmitting.value = false;
   preparingGeneration.value = false;
+  generationSubmissionPhase.value = null;
   expansionError.value = "";
   clearExpansionRecovery();
   form.batchSize = 1;
@@ -3160,6 +3187,7 @@ function discardPreparedBatch(): void {
   expansionRunning.value = false;
   preparedSubmitting.value = false;
   preparingGeneration.value = false;
+  generationSubmissionPhase.value = null;
   expansionError.value = "";
   clearExpansionRecovery();
   if (restoreFocus) {
@@ -3586,10 +3614,15 @@ async function generate(): Promise<void> {
     submissionGuard.isCurrent(token) &&
     (!preparedSubmission || preparedBatch.value?.batchId === preparedSubmission.batchId);
   const releasePreparedSubmission = () => {
+    if (!unmounted && uiId === submissionUiId) {
+      preparingGeneration.value = false;
+      generationSubmissionPhase.value = null;
+    }
     if (ownsPreparedSubmission()) preparedSubmitting.value = false;
   };
   let request: GenerateRequest;
   preparingGeneration.value = true;
+  generationSubmissionPhase.value = "preparing";
   preparedSubmitting.value = !!preparedSubmission;
   try {
     request = await prepareGenerationRequest(target, draft, () => submissionGuard.isCurrent(token));
@@ -3607,16 +3640,18 @@ async function generate(): Promise<void> {
       };
     }
   } catch (error) {
-    if (!ownsPreparedSubmission()) return;
+    if (!ownsPreparedSubmission()) {
+      releasePreparedSubmission();
+      return;
+    }
     setGenerationStatus(describeTransportError(error, route.label), true);
     generationAnnouncement.value = `Couldn’t prepare the source image. ${progress.value}`;
     releasePreparedSubmission();
     return;
-  } finally {
-    if (!unmounted && uiId === submissionUiId) preparingGeneration.value = false;
   }
 
   if (!submissionGuard.isCurrent(token)) {
+    releasePreparedSubmission();
     return;
   }
   if (guardedSubmission && JSON.stringify(cloneGenerateForm(form)) !== liveFormIdentity) {
@@ -3672,6 +3707,7 @@ async function generate(): Promise<void> {
     releasePreparedSubmission();
     return;
   }
+  if (!unmounted && uiId === submissionUiId) generationSubmissionPhase.value = "placement";
   const requireAuthoritativePlacement = requiresAuthoritativePlacement(
     request as unknown as Record<string, unknown>,
   );
@@ -3697,6 +3733,10 @@ async function generate(): Promise<void> {
             batchSize,
           );
   } catch (error) {
+    if (!submissionGuard.isCurrent(token)) {
+      releasePreparedSubmission();
+      return;
+    }
     if (error instanceof ApiError && (error.status === 404 || error.status === 405)) {
       if (requireAuthoritativePlacement) {
         setGenerationStatus(
@@ -3712,6 +3752,10 @@ async function generate(): Promise<void> {
       releasePreparedSubmission();
       return;
     }
+  }
+  if (!submissionGuard.isCurrent(token)) {
+    releasePreparedSubmission();
+    return;
   }
   const classification: string = classifyPlacementPreview(placement);
   if (requireAuthoritativePlacement && classification === "unsupported") {
@@ -3982,11 +4026,20 @@ function retryGeneratedPreview(): void {
   renewGeneratedResult(true);
 }
 
-async function thumbnailUrl(target: ApiTarget, filename: string): Promise<string> {
-  const response = await apiFetchTo(target, galleryMediaPath(filename, "host", true));
-  const url = URL.createObjectURL(await response.blob());
+async function thumbnailUrl(target: ApiTarget, hostId: string, filename: string): Promise<string> {
+  let blob = await loadCachedGalleryMedia(hostId, filename, "thumbnail");
+  if (!blob) {
+    const response = await apiFetchTo(target, galleryMediaPath(filename, "host", true));
+    blob = await response.blob();
+    void storeCachedGalleryMedia(hostId, filename, "thumbnail", blob);
+  }
+  const url = URL.createObjectURL(blob);
   objectUrls.add(url);
   return url;
+}
+
+function mobileGalleryCacheKey(host: MobileHost): string {
+  return host.instanceId?.trim() || host.id;
 }
 
 function refreshGallery(): Promise<void> {
@@ -4039,13 +4092,41 @@ async function performGalleryRefresh(): Promise<void> {
   const prior = gallery.value;
   gallery.value = [];
   for (const item of prior) revokeObjectUrl(item.thumbnailUrl);
-  const galleryHosts = connectedHosts.value.filter(
+  const allHosts = connectedHosts.value;
+  const cachedResults = await Promise.all(
+    allHosts.map(async (host) => ({
+      host,
+      cacheKey: mobileGalleryCacheKey(host),
+      prints: await loadCachedGallery(mobileGalleryCacheKey(host)),
+    })),
+  );
+  const cachedByHost = new Map(
+    cachedResults.map(({ host, cacheKey, prints }) => [host.id, { cacheKey, prints }]),
+  );
+  const cachedCopies = cachedResults.flatMap(({ host, cacheKey, prints }) => {
+    const target = { baseUrl: host.baseUrl, apiKey: host.apiKey || null };
+    return prints.map((print) => ({
+      ...print,
+      hostId: host.id,
+      cacheKey,
+      hostName: host.name,
+      target,
+    }));
+  });
+  if (cachedCopies.length > 0) {
+    galleryCopies = cachedCopies.sort((a, b) => b.timestamp - a.timestamp);
+    pendingGallery = groupLogicalGalleryPrints(galleryCopies).map((group) => group.representative);
+    await loadMoreGalleryPage();
+  }
+
+  const galleryHosts = allHosts.filter(
     (host) => host.online || !knownHostReachability.has(host.id),
   );
-  const knownOffline = connectedHosts.value.length - galleryHosts.length;
+  const knownOffline = allHosts.length - galleryHosts.length;
   const results = await Promise.allSettled(
     galleryHosts.map(async (host) => {
       const target = { baseUrl: host.baseUrl, apiKey: host.apiKey || null };
+      const cacheKey = mobileGalleryCacheKey(host);
       const controller = new AbortController();
       const timeout = setTimeout(() => controller.abort(), GALLERY_HOST_TIMEOUT_MS);
       let prints: GalleryImage[];
@@ -4056,21 +4137,57 @@ async function performGalleryRefresh(): Promise<void> {
       } finally {
         clearTimeout(timeout);
       }
+      const currentHost = hosts.value.find((candidate) => candidate.id === host.id);
+      if (!currentHost || mobileGalleryCacheKey(currentHost) !== cacheKey) {
+        throw new Error("Gallery host identity changed while refreshing");
+      }
+      await storeCachedGallery(cacheKey, prints);
+      return { host, cacheKey, target, prints };
+    }),
+  );
+  const refreshedByHost = new Map(
+    results.flatMap((result) =>
+      result.status === "fulfilled" ? [[result.value.host.id, result.value] as const] : [],
+    ),
+  );
+  const refreshedCopies = connectedHosts.value
+    .flatMap((host) => {
+      const refreshed = refreshedByHost.get(host.id);
+      const cacheKey = refreshed?.cacheKey ?? mobileGalleryCacheKey(host);
+      const target = refreshed?.target ?? { baseUrl: host.baseUrl, apiKey: host.apiKey || null };
+      const cached = cachedByHost.get(host.id);
+      const prints = refreshed?.prints ?? (cached?.cacheKey === cacheKey ? cached.prints : []);
       return prints.map((print) => ({
         ...print,
         hostId: host.id,
+        cacheKey,
         hostName: host.name,
         target,
       }));
-    }),
-  );
-  galleryCopies = results
-    .flatMap((result) => (result.status === "fulfilled" ? result.value : []))
+    })
     .sort((a, b) => b.timestamp - a.timestamp);
-  pendingGallery = groupLogicalGalleryPrints(galleryCopies).map((group) => group.representative);
   const failed = knownOffline + results.filter((result) => result.status === "rejected").length;
-  if (failed) galleryError.value = `${failed} host${failed === 1 ? "" : "s"} unavailable`;
+  if (selectedPrint.value) {
+    galleryRefreshDeferred = true;
+    if (failed) {
+      galleryError.value = `${failed} host${failed === 1 ? "" : "s"} unavailable${
+        cachedCopies.length > 0 ? " · Showing saved Library" : ""
+      }`;
+    }
+    galleryLoading.value = false;
+    return;
+  }
+  galleryCopies = refreshedCopies;
+  for (const item of gallery.value) revokeObjectUrl(item.thumbnailUrl);
+  gallery.value = [];
+  pendingGallery = groupLogicalGalleryPrints(galleryCopies).map((group) => group.representative);
+  if (failed) {
+    galleryError.value = `${failed} host${failed === 1 ? "" : "s"} unavailable${
+      cachedCopies.length > 0 ? " · Showing saved Library" : ""
+    }`;
+  }
   await loadMoreGalleryPage();
+  void pruneCachedGalleryMedia();
   galleryLoading.value = false;
 }
 
@@ -4100,7 +4217,7 @@ async function loadMoreGalleryPage(): Promise<void> {
       page.slice(offset, offset + 4).map(async ({ target, ...print }) => ({
         ...print,
         target,
-        thumbnailUrl: await thumbnailUrl(target, print.filename),
+        thumbnailUrl: await thumbnailUrl(target, print.cacheKey, print.filename),
       })),
     );
     gallery.value.push(
@@ -4113,7 +4230,7 @@ async function loadMoreGalleryPage(): Promise<void> {
 }
 
 async function reusePrint(print: GalleryPrint): Promise<void> {
-  if (reusingPrint.value || print.metadata_synthetic || !print.metadata.prompt?.trim()) return;
+  if (reusingPrint.value || print.metadata_synthetic) return;
   reusingPrint.value = true;
   reusePrintError.value = "";
   try {
@@ -4472,11 +4589,16 @@ async function deleteSelectedGalleryPrints(): Promise<void> {
   );
   const deletedKeys = new Set<string>();
   const failedKeys = new Set<string>();
+  const deletedCacheEntries: Array<{ hostId: string; filename: string }> = [];
   results.forEach((result, index) => {
     const key = galleryPrintKey(targetList[index]!);
-    if (result.status === "fulfilled") deletedKeys.add(key);
-    else failedKeys.add(key);
+    if (result.status === "fulfilled") {
+      const print = targetList[index]!;
+      deletedKeys.add(key);
+      deletedCacheEntries.push({ hostId: print.cacheKey, filename: print.filename });
+    } else failedKeys.add(key);
   });
+  await removeCachedGalleryPrints(deletedCacheEntries);
   for (const print of gallery.value) revokeObjectUrl(print.thumbnailUrl);
   galleryCopies = galleryCopies.filter((print) => !deletedKeys.has(galleryPrintKey(print)));
   gallery.value = [];
@@ -5920,7 +6042,7 @@ onBeforeUnmount(() => {
       v-if="selectedPrint"
       :item="selectedPrint"
       :target="selectedPrint.target"
-      :cache-key="selectedPrint.hostId"
+      :cache-key="selectedPrint.cacheKey"
       :host-name="selectedPrint.hostName"
       :thumbnail-url="selectedPrint.thumbnailUrl"
       :reusing="reusingPrint"

--- a/desktop/src/mobile/MobileGalleryViewer.test.ts
+++ b/desktop/src/mobile/MobileGalleryViewer.test.ts
@@ -533,7 +533,27 @@ describe("MobileGalleryViewer", () => {
 
     const reuse = view.get("[data-test='gallery-viewer-reuse']");
     expect(reuse.attributes("disabled")).toBe("");
-    expect(reuse.text()).toBe("Prompt unavailable");
+    expect(reuse.text()).toBe("Settings unavailable");
+  });
+
+  it("offers settings reuse for a promptless print and hides stale original prompt provenance", async () => {
+    const view = mountViewer({
+      ...image,
+      metadata: {
+        ...image.metadata,
+        prompt: "",
+        original_prompt: "stale prior prompt",
+      },
+    });
+    await flushPromises();
+
+    const reuse = view.get("[data-test='gallery-viewer-reuse']");
+    expect(reuse.attributes("disabled")).toBeUndefined();
+    expect(reuse.text()).toBe("Reuse settings");
+    expect(view.text()).toContain("No prompt was used for this print.");
+    expect(view.text()).not.toContain("stale prior prompt");
+    await reuse.trigger("click");
+    expect(view.emitted("reuse")).toHaveLength(1);
   });
 
   it("shows prepared sibling position and source prompt with graceful legacy absence", async () => {

--- a/desktop/src/mobile/MobileGalleryViewer.vue
+++ b/desktop/src/mobile/MobileGalleryViewer.vue
@@ -78,12 +78,10 @@ const canExportVideo = computed(
 );
 const canSaveVideo = computed(() => props.exportEnabled && video.value);
 const pipeline = computed(() => (video.value ? (props.item.metadata.pipeline ?? null) : null));
-const canReuse = computed(
-  () => !props.item.metadata_synthetic && !!props.item.metadata.prompt?.trim(),
-);
+const canReuse = computed(() => !props.item.metadata_synthetic);
 const canUseSource = computed(() => props.canUseAsSource && !video.value && !audio.value);
 const actionLabel = computed(() =>
-  props.reusing ? "Loading prompt…" : canReuse.value ? "Use as prompt" : "Prompt unavailable",
+  props.reusing ? "Loading settings…" : canReuse.value ? "Reuse settings" : "Settings unavailable",
 );
 const galleryTotal = computed(() => Math.max(1, Math.floor(props.total)));
 const galleryPosition = computed(() =>
@@ -103,7 +101,9 @@ const preparedPosition = computed(() => {
     ? `Batch ${index} of ${count}`
     : "";
 });
-const originalPrompt = computed(() => props.item.metadata.original_prompt?.trim() ?? "");
+const originalPrompt = computed(() =>
+  props.item.metadata.prompt?.trim() ? (props.item.metadata.original_prompt?.trim() ?? "") : "",
+);
 const upscaled = computed(() => isUpscaledImage(props.item));
 const actionStatus = ref("");
 const actionBusy = ref<"copy" | "save" | "save-video" | null>(null);
@@ -546,7 +546,7 @@ onBeforeUnmount(() => {
       <div class="gallery-viewer-prompt">
         <span v-if="preparedPosition" data-test="gallery-viewer-batch">{{ preparedPosition }}</span>
         <span>Prompt</span>
-        <p data-selectable>{{ item.metadata.prompt || "No prompt saved with this print." }}</p>
+        <p data-selectable>{{ item.metadata.prompt || "No prompt was used for this print." }}</p>
         <p v-if="pipeline" data-test="gallery-viewer-pipeline" data-selectable>
           <span>Pipeline</span> {{ pipeline }}
         </p>

--- a/desktop/src/mobile/galleryCache.test.ts
+++ b/desktop/src/mobile/galleryCache.test.ts
@@ -1,0 +1,112 @@
+import { IDBFactory } from "fake-indexeddb";
+import { beforeEach, describe, expect, it } from "vitest";
+import type { GalleryImage } from "../lib/api/types";
+import {
+  loadCachedGallery,
+  loadCachedGalleryMedia,
+  clearCachedGalleryHosts,
+  removeCachedGalleryPrints,
+  storeCachedGallery,
+  storeCachedGalleryMedia,
+} from "./galleryCache";
+
+function print(filename: string, timestamp: number): GalleryImage {
+  return {
+    filename,
+    timestamp,
+    format: "png",
+    metadata: {
+      prompt: "",
+      model: "flux-dev:q8",
+      seed: timestamp,
+      steps: 4,
+      guidance: 3.5,
+      width: 512,
+      height: 512,
+    },
+  };
+}
+
+beforeEach(() => {
+  Object.defineProperty(globalThis, "indexedDB", {
+    configurable: true,
+    value: new IDBFactory(),
+  });
+});
+
+describe("mobile gallery cache", () => {
+  it("persists a bounded newest-first gallery without connection secrets", async () => {
+    const prints = Array.from({ length: 505 }, (_, index) => print(`${index}.png`, index));
+    await storeCachedGallery("studio", prints);
+
+    const restored = await loadCachedGallery("studio");
+    expect(restored).toHaveLength(500);
+    expect(restored[0]?.filename).toBe("504.png");
+    expect(restored.at(-1)?.filename).toBe("5.png");
+    expect(JSON.stringify(restored)).not.toContain("apiKey");
+  });
+
+  it("round-trips thumbnail blobs for offline browsing", async () => {
+    const thumbnail = new Blob(["thumbnail"], { type: "image/webp" });
+
+    await storeCachedGalleryMedia("studio", "one.png", "thumbnail", thumbnail);
+
+    expect(await (await loadCachedGalleryMedia("studio", "one.png", "thumbnail"))?.text()).toBe(
+      "thumbnail",
+    );
+  });
+
+  it("removes metadata and thumbnail bytes after a successful delete", async () => {
+    await storeCachedGallery("studio", [print("keep.png", 2), print("delete.png", 1)]);
+    await storeCachedGalleryMedia("studio", "delete.png", "thumbnail", new Blob(["thumb"]));
+
+    await removeCachedGalleryPrints([{ hostId: "studio", filename: "delete.png" }]);
+
+    expect((await loadCachedGallery("studio")).map((entry) => entry.filename)).toEqual([
+      "keep.png",
+    ]);
+    expect(await loadCachedGalleryMedia("studio", "delete.png", "thumbnail")).toBeNull();
+  });
+
+  it("does not resurrect thumbnail bytes when delete wins a pending cache write", async () => {
+    let finishBytes!: (bytes: ArrayBuffer) => void;
+    const pendingBlob = {
+      size: 5,
+      type: "image/webp",
+      arrayBuffer: () =>
+        new Promise<ArrayBuffer>((resolve) => {
+          finishBytes = resolve;
+        }),
+    } as Blob;
+    const write = storeCachedGalleryMedia("studio", "delete.png", "thumbnail", pendingBlob);
+    await Promise.resolve();
+
+    await removeCachedGalleryPrints([{ hostId: "studio", filename: "delete.png" }]);
+    finishBytes(new TextEncoder().encode("thumb").buffer);
+    await write;
+
+    expect(await loadCachedGalleryMedia("studio", "delete.png", "thumbnail")).toBeNull();
+  });
+
+  it("purges instance-scoped metadata and media without allowing pending writes back", async () => {
+    await storeCachedGallery("old-instance", [print("old.png", 1)]);
+    let finishBytes!: (bytes: ArrayBuffer) => void;
+    const pendingBlob = {
+      size: 5,
+      type: "image/webp",
+      arrayBuffer: () =>
+        new Promise<ArrayBuffer>((resolve) => {
+          finishBytes = resolve;
+        }),
+    } as Blob;
+    const write = storeCachedGalleryMedia("old-instance", "old.png", "thumbnail", pendingBlob);
+    await Promise.resolve();
+
+    await clearCachedGalleryHosts(["old-instance"]);
+    finishBytes(new TextEncoder().encode("thumb").buffer);
+    await write;
+
+    expect(await loadCachedGallery("old-instance")).toEqual([]);
+    expect(await loadCachedGalleryMedia("old-instance", "old.png", "thumbnail")).toBeNull();
+  });
+});

--- a/desktop/src/mobile/galleryCache.ts
+++ b/desktop/src/mobile/galleryCache.ts
@@ -1,0 +1,281 @@
+import type { GalleryImage } from "../lib/api/types";
+
+const DB_NAME = "mold-mobile-gallery-cache";
+const DB_VERSION = 2;
+const GALLERIES_STORE = "galleries";
+const MEDIA_STORE = "media";
+const MAX_PRINTS_PER_HOST = 500;
+const MAX_THUMBNAIL_RECORDS = 320;
+const mediaMutationVersions = new Map<string, number>();
+const hostMutationVersions = new Map<string, number>();
+
+type MediaKind = "thumbnail";
+
+interface CachedGalleryRecord {
+  hostId: string;
+  updatedAt: number;
+  prints: GalleryImage[];
+}
+
+interface CachedMediaRecord {
+  key: string;
+  hostId: string;
+  filename: string;
+  kind: MediaKind;
+  cachedAt: number;
+  bytes: ArrayBuffer;
+  mimeType: string;
+}
+
+function mediaKey(hostId: string, filename: string, kind: MediaKind): string {
+  return `${hostId}\u0000${kind}\u0000${filename}`;
+}
+
+function openDb(): Promise<IDBDatabase | null> {
+  if (typeof indexedDB === "undefined") return Promise.resolve(null);
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (db: IDBDatabase | null) => {
+      if (settled) {
+        db?.close();
+        return;
+      }
+      settled = true;
+      resolve(db);
+    };
+    let request: IDBOpenDBRequest;
+    try {
+      request = indexedDB.open(DB_NAME, DB_VERSION);
+    } catch {
+      finish(null);
+      return;
+    }
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(GALLERIES_STORE)) {
+        db.createObjectStore(GALLERIES_STORE, { keyPath: "hostId" });
+      }
+      if (!db.objectStoreNames.contains(MEDIA_STORE)) {
+        const media = db.createObjectStore(MEDIA_STORE, { keyPath: "key" });
+        media.createIndex("cachedAt", "cachedAt");
+        media.createIndex("hostId", "hostId");
+      } else {
+        const media = request.transaction!.objectStore(MEDIA_STORE);
+        if (!media.indexNames.contains("hostId")) media.createIndex("hostId", "hostId");
+      }
+    };
+    request.onsuccess = () => finish(request.result);
+    request.onerror = () => finish(null);
+    request.onblocked = () => finish(null);
+  });
+}
+
+async function requestFromStore<T>(
+  storeName: string,
+  mode: IDBTransactionMode,
+  operation: (store: IDBObjectStore) => IDBRequest<T>,
+): Promise<T | null> {
+  const db = await openDb();
+  if (!db) return null;
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (value: T | null) => {
+      if (settled) return;
+      settled = true;
+      db.close();
+      resolve(value);
+    };
+    try {
+      const transaction = db.transaction(storeName, mode);
+      const request = operation(transaction.objectStore(storeName));
+      let value: T | null = null;
+      request.onsuccess = () => {
+        value = request.result ?? null;
+      };
+      request.onerror = () => finish(null);
+      transaction.oncomplete = () => finish(value);
+      transaction.onerror = () => finish(null);
+      transaction.onabort = () => finish(null);
+    } catch {
+      finish(null);
+    }
+  });
+}
+
+export async function loadCachedGallery(hostId: string): Promise<GalleryImage[]> {
+  const record = await requestFromStore<CachedGalleryRecord>(GALLERIES_STORE, "readonly", (store) =>
+    store.get(hostId),
+  );
+  return Array.isArray(record?.prints) ? record.prints : [];
+}
+
+export async function storeCachedGallery(
+  hostId: string,
+  prints: readonly GalleryImage[],
+): Promise<void> {
+  const hostVersion = hostMutationVersions.get(hostId) ?? 0;
+  const bounded = [...prints]
+    .sort((left, right) => right.timestamp - left.timestamp)
+    .slice(0, MAX_PRINTS_PER_HOST);
+  await requestFromStore(GALLERIES_STORE, "readwrite", (store) =>
+    (hostMutationVersions.get(hostId) ?? 0) === hostVersion
+      ? store.put({ hostId, updatedAt: Date.now(), prints: bounded })
+      : store.get(hostId),
+  );
+}
+
+export async function loadCachedGalleryMedia(
+  hostId: string,
+  filename: string,
+  kind: MediaKind,
+): Promise<Blob | null> {
+  const record = await requestFromStore<CachedMediaRecord>(MEDIA_STORE, "readonly", (store) =>
+    store.get(mediaKey(hostId, filename, kind)),
+  );
+  return record?.bytes ? new Blob([record.bytes], { type: record.mimeType }) : null;
+}
+
+export async function storeCachedGalleryMedia(
+  hostId: string,
+  filename: string,
+  kind: MediaKind,
+  blob: Blob,
+): Promise<void> {
+  if (!blob.size) return;
+  const key = mediaKey(hostId, filename, kind);
+  const version = mediaMutationVersions.get(key) ?? 0;
+  const hostVersion = hostMutationVersions.get(hostId) ?? 0;
+  const bytes = await blob.arrayBuffer();
+  await requestFromStore(MEDIA_STORE, "readwrite", (store) =>
+    (mediaMutationVersions.get(key) ?? 0) === version &&
+    (hostMutationVersions.get(hostId) ?? 0) === hostVersion
+      ? store.put({
+          key,
+          hostId,
+          filename,
+          kind,
+          cachedAt: Date.now(),
+          bytes,
+          mimeType: blob.type,
+        })
+      : store.get(key),
+  );
+}
+
+export async function pruneCachedGalleryMedia(): Promise<void> {
+  const db = await openDb();
+  if (!db) return;
+  await new Promise<void>((resolve) => {
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      db.close();
+      resolve();
+    };
+    try {
+      const transaction = db.transaction(MEDIA_STORE, "readwrite");
+      const store = transaction.objectStore(MEDIA_STORE);
+      const request = store.index("cachedAt").getAllKeys();
+      request.onsuccess = () => {
+        const excess = request.result.length - MAX_THUMBNAIL_RECORDS;
+        for (const key of request.result.slice(0, Math.max(0, excess))) store.delete(key);
+      };
+      request.onerror = finish;
+      transaction.oncomplete = finish;
+      transaction.onerror = finish;
+      transaction.onabort = finish;
+    } catch {
+      finish();
+    }
+  });
+}
+
+export async function removeCachedGalleryPrints(
+  removed: readonly { hostId: string; filename: string }[],
+): Promise<void> {
+  for (const hostId of new Set(removed.map(({ hostId }) => hostId))) {
+    hostMutationVersions.set(hostId, (hostMutationVersions.get(hostId) ?? 0) + 1);
+  }
+  for (const { hostId, filename } of removed) {
+    const key = mediaKey(hostId, filename, "thumbnail");
+    mediaMutationVersions.set(key, (mediaMutationVersions.get(key) ?? 0) + 1);
+  }
+  const filenamesByHost = new Map<string, Set<string>>();
+  for (const { hostId, filename } of removed) {
+    const filenames = filenamesByHost.get(hostId) ?? new Set<string>();
+    filenames.add(filename);
+    filenamesByHost.set(hostId, filenames);
+  }
+  for (const [hostId, filenames] of filenamesByHost) {
+    const prints = await loadCachedGallery(hostId);
+    await storeCachedGallery(
+      hostId,
+      prints.filter((print) => !filenames.has(print.filename)),
+    );
+  }
+  const db = await openDb();
+  if (!db) return;
+  await new Promise<void>((resolve) => {
+    try {
+      const transaction = db.transaction(MEDIA_STORE, "readwrite");
+      const store = transaction.objectStore(MEDIA_STORE);
+      for (const { hostId, filename } of removed) {
+        store.delete(mediaKey(hostId, filename, "thumbnail"));
+      }
+      transaction.oncomplete = () => {
+        db.close();
+        resolve();
+      };
+      transaction.onerror = transaction.onabort = () => {
+        db.close();
+        resolve();
+      };
+    } catch {
+      db.close();
+      resolve();
+    }
+  });
+}
+
+export async function clearCachedGalleryHosts(hostIds: readonly string[]): Promise<void> {
+  const ids = [...new Set(hostIds.filter(Boolean))];
+  if (ids.length === 0) return;
+  for (const hostId of ids) {
+    hostMutationVersions.set(hostId, (hostMutationVersions.get(hostId) ?? 0) + 1);
+  }
+  const db = await openDb();
+  if (!db) return;
+  await new Promise<void>((resolve) => {
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      db.close();
+      resolve();
+    };
+    try {
+      const transaction = db.transaction([GALLERIES_STORE, MEDIA_STORE], "readwrite");
+      const galleries = transaction.objectStore(GALLERIES_STORE);
+      const media = transaction.objectStore(MEDIA_STORE);
+      const hostIndex = media.index("hostId");
+      for (const hostId of ids) {
+        galleries.delete(hostId);
+        const keys = hostIndex.getAllKeys(hostId);
+        keys.onsuccess = () => {
+          for (const key of keys.result) {
+            if (typeof key === "string") {
+              mediaMutationVersions.set(key, (mediaMutationVersions.get(key) ?? 0) + 1);
+            }
+            media.delete(key);
+          }
+        };
+      }
+      transaction.oncomplete = finish;
+      transaction.onerror = finish;
+      transaction.onabort = finish;
+    } catch {
+      finish();
+    }
+  });
+}

--- a/desktop/src/mobile/reuse.test.ts
+++ b/desktop/src/mobile/reuse.test.ts
@@ -110,6 +110,21 @@ describe("applyMobileGalleryMetadata", () => {
     expect(request.upscale_model).toBeUndefined();
   });
 
+  it("clears stale provenance when reusing a promptless print", () => {
+    const form = newGenerateForm();
+    form.prompt = "previous expanded prompt";
+    form.originalPrompt = "previous source prompt";
+
+    applyMobileGalleryMetadata(form, { ...metadata, prompt: "", original_prompt: "stale" }, [
+      model,
+    ]);
+
+    expect(form.prompt).toBe("");
+    expect(form.originalPrompt).toBeNull();
+    form.prompt = "a newly typed prompt";
+    expect(buildRequest(form).original_prompt).toBeUndefined();
+  });
+
   it("keeps generation valid when the print's original model is no longer installed", () => {
     const replacement = {
       ...model,
@@ -379,12 +394,14 @@ describe("applyMobileGalleryMetadata — sequence prints", () => {
   it("returns the clip rail without overwriting the one-shot prompt", () => {
     const form = newGenerateForm();
     form.prompt = "parked one shot";
+    form.originalPrompt = "parked provenance";
     const result = applyMobileGalleryMetadata(form, chainPrint([25, 33]), [sequenceModel]);
 
     expect(result.sequence?.clips.map((c) => c.prompt)).toEqual(["clip 1", "clip 2"]);
     expect(result.sequence?.clips.map((c) => c.frames)).toEqual([25, 33]);
     expect(result.sequence?.raised).toBe(0);
     expect(form.prompt).toBe("parked one shot");
+    expect(form.originalPrompt).toBe("parked provenance");
   });
 
   it("raises clips that no longer clear the model's motion tail", () => {

--- a/desktop/src/mobile/reuse.ts
+++ b/desktop/src/mobile/reuse.ts
@@ -52,6 +52,7 @@ export function applyMobileGalleryMetadata(
 ): MobileGalleryReuseResult {
   const plan = planSequenceReuse(metadata);
   const oneShotPrompt = form.prompt;
+  const oneShotOriginalPrompt = form.originalPrompt;
   const canonicalRecordedModel = canonicalMinimaxH3ModelName(metadata.model);
   const recordedH3Identity = isMinimaxH3Identity(null, metadata.model);
   const installedRecordedModel = models.find(
@@ -151,6 +152,11 @@ export function applyMobileGalleryMetadata(
     sequence = { clips, lossy: plan.lossy, raised };
     // Reusing a sequence must not overwrite the parked one-shot prompt.
     form.prompt = oneShotPrompt;
+    form.originalPrompt = oneShotOriginalPrompt;
+  } else if (!metadata.prompt?.trim()) {
+    // A promptless print has no prompt provenance. Clear any provenance left
+    // by the previously edited print so typing a new prompt cannot revive it.
+    form.originalPrompt = null;
   }
 
   return {


### PR DESCRIPTION
## Summary

- acknowledge iPhone Generate immediately during source preparation and placement checks, block duplicate taps, and fence stale prompt-tool submissions
- persist bounded, instance-scoped Library metadata and thumbnails in IndexedDB for fast/offline gallery browsing, with deletion, host-removal, and identity-change race protection
- allow promptless prints to reuse their saved settings, relabel the action to **Reuse settings**, and prevent stale source-prompt provenance from appearing or being resubmitted

## Validation

- `nix develop -c sh -c 'cd desktop && bun run test'` — 321 files / 3,632 tests passed\n- `nix develop -c sh -c 'cd desktop && bun run build:mobile'`\n- `nix develop -c ios-check`\n- `nix develop -c sh -c 'cd desktop && bun run fmt:check'`\n- responsive browser smoke check at 390×844 with no console warnings/errors\n\n## Peer review\n\nAn independent agent reviewed the branch, identified submission-invalidation, prompt-provenance, cache-identity, and cache-write race issues, and re-reviewed the fixes. Final result: no remaining actionable defects; focused 5-suite verification passed 357 tests.