### PR TITLE
fix(ios): restore tapped queue items

### DIFF
--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -530,7 +530,7 @@ describe("MobileApp sequence generation", () => {
       if (path === "/api/gallery") return Promise.resolve([print]);
       if (path === "/api/activity") {
         return Promise.resolve({
-          instance_id: "mobile-host",
+          instance_id: status.instance_id,
           observed_at_unix_ms: 10,
           items: [
             {
@@ -554,6 +554,209 @@ describe("MobileApp sequence generation", () => {
     expect(activity.text()).toContain("Studio");
     expect(activity.text()).toContain("flux-dev:q4");
     expect(localStorage.getItem("mold.mobile.live-activity.v1")).not.toContain(target.apiKey);
+  });
+
+  it("loads a tapped server-owned generation into Create like desktop", async () => {
+    const metadata = {
+      prompt: "a lighthouse beyond the red dunes",
+      negative_prompt: "fog",
+      model: model.name,
+      seed: 0,
+      steps: 18,
+      guidance: 2.5,
+      width: 1024,
+      height: 576,
+    };
+    apiJsonTo.mockImplementation((_target: unknown, path: string) => {
+      if (path === "/api/status") return Promise.resolve(status);
+      if (path === "/api/models") return Promise.resolve([model]);
+      if (path === "/api/gallery") return Promise.resolve([print]);
+      if (path === "/api/activity") {
+        return Promise.resolve({
+          instance_id: status.instance_id,
+          observed_at_unix_ms: 10,
+          items: [
+            {
+              id: "foreign-job",
+              kind: "generation",
+              phase: "running",
+              model: model.name,
+              created_at_unix_ms: 1,
+              updated_at_unix_ms: 9,
+              can_cancel: false,
+            },
+          ],
+        });
+      }
+      if (path === "/api/queue") {
+        return Promise.resolve({
+          entries: [
+            {
+              id: "foreign-job",
+              model: model.name,
+              state: "running",
+              started_at_unix_ms: 1,
+              position: 0,
+              metadata,
+              seed_pinned: false,
+            },
+          ],
+          plan: null,
+        });
+      }
+      return Promise.reject(new Error(`Unexpected API path: ${path}`));
+    });
+    wrapper = mountMobileApp();
+    await flushPromises();
+    await flushPromises();
+
+    const row = wrapper.get("[data-test='live-activity-select-studio-id:generation:foreign-job']");
+    expect(row.element.tagName).toBe("BUTTON");
+    await row.trigger("click");
+    await flushPromises();
+
+    expect(fieldControl("Prompt").element).toHaveProperty(
+      "value",
+      "a lighthouse beyond the red dunes",
+    );
+    expect(fieldControl("Steps").element).toHaveProperty("value", "18");
+    expect(wrapper.text()).toContain("New seed for every print.");
+    expect(wrapper.get("[data-test='mobile-generation-summary']").text()).toBe(
+      "Prompt settings restored",
+    );
+    expect(apiJsonTo).toHaveBeenCalledWith(target, "/api/queue");
+  });
+
+  it("loads a tapped server-owned sequence script into the clip rail", async () => {
+    const pinia = createPinia();
+    const priorModel: ModelEntry = {
+      ...model,
+      name: "flux-dev:q8",
+      family: "flux",
+      default_guidance: 4,
+    };
+    const sequenceModel: ModelEntry = {
+      ...model,
+      name: "ltx-video-0.9.8-2b-distilled:bf16",
+      family: "ltx-video",
+    };
+    apiJsonTo.mockImplementation((_target: unknown, path: string) => {
+      if (path === "/api/status") return Promise.resolve(status);
+      if (path === "/api/models") return Promise.resolve([priorModel, sequenceModel]);
+      if (path === "/api/gallery") return Promise.resolve([print]);
+      if (path === "/api/activity") {
+        return Promise.resolve({
+          instance_id: status.instance_id,
+          observed_at_unix_ms: 10,
+          items: [
+            {
+              id: "foreign-sequence",
+              kind: "sequence",
+              phase: "running",
+              model: sequenceModel.name,
+              created_at_unix_ms: 1,
+              updated_at_unix_ms: 9,
+              can_cancel: false,
+            },
+          ],
+        });
+      }
+      if (path === "/api/queue") return Promise.resolve({ entries: [], plan: null });
+      if (path === "/api/chain-jobs/foreign-sequence") {
+        return Promise.resolve({
+          id: "foreign-sequence",
+          state: "running",
+          model: sequenceModel.name,
+          stage_count: 2,
+          current_stage: 0,
+          created_at_unix_ms: 1,
+          updated_at_unix_ms: 9,
+          error: null,
+          ephemeral: false,
+          stages: [],
+          script: {
+            schema: "mold.chain.v1",
+            chain: {
+              model: sequenceModel.name,
+              width: 1024,
+              height: 576,
+              fps: 24,
+              steps: 18,
+              guidance: 2.5,
+            },
+            stages: [
+              { prompt: "A lighthouse wakes", frames: 25, transition: "smooth" },
+              { prompt: "The beam crosses red dunes", frames: 33, transition: "smooth" },
+            ],
+          },
+        });
+      }
+      return Promise.reject(new Error(`Unexpected API path: ${path}`));
+    });
+    wrapper = mountMobileApp(pinia);
+    await flushPromises();
+    await flushPromises();
+
+    await wrapper
+      .get("[data-test='live-activity-select-studio-id:sequence:foreign-sequence']")
+      .trigger("click");
+    await flushPromises();
+
+    const draft = useSequenceDraftStore(pinia);
+    expect(draft.output).toBe("sequence");
+    expect(draft.clips.map((clip) => clip.prompt)).toEqual([
+      "A lighthouse wakes",
+      "The beam crosses red dunes",
+    ]);
+    expect(wrapper.find("[data-test='mobile-sequence-composer']").exists()).toBe(true);
+    expect(fieldControl("Video model").element).toHaveProperty("value", sequenceModel.name);
+    expect(wrapper.text()).toContain("Distilled recipe fixes CFG at 1.0");
+    expect(apiJsonTo).toHaveBeenCalledWith(target, "/api/chain-jobs/foreign-sequence");
+  });
+
+  it("refuses to restore a stale queue row after the server instance changes", async () => {
+    apiJsonTo.mockImplementation((_target: unknown, path: string) => {
+      if (path === "/api/status") return Promise.resolve(status);
+      if (path === "/api/models") return Promise.resolve([model]);
+      if (path === "/api/gallery") return Promise.resolve([print]);
+      if (path === "/api/activity") {
+        return Promise.resolve({
+          instance_id: "replaced-studio-id",
+          observed_at_unix_ms: 10,
+          items: [
+            {
+              id: "colliding-job-id",
+              kind: "generation",
+              phase: "running",
+              model: model.name,
+              created_at_unix_ms: 1,
+              updated_at_unix_ms: 9,
+              can_cancel: false,
+            },
+          ],
+        });
+      }
+      if (path === "/api/queue") {
+        return Promise.reject(new Error("queue must not be read from the replacement instance"));
+      }
+      return Promise.reject(new Error(`Unexpected API path: ${path}`));
+    });
+    wrapper = mountMobileApp();
+    await flushPromises();
+    await flushPromises();
+    const queueReads = apiJsonTo.mock.calls.filter(([, path]) => path === "/api/queue").length;
+
+    await wrapper
+      .get("[data-test='live-activity-select-studio-id:generation:colliding-job-id']")
+      .trigger("click");
+    await flushPromises();
+
+    expect(wrapper.get("[data-test='mobile-generation-summary']").text()).toContain(
+      "different Mold server instance",
+    );
+    expect(apiJsonTo.mock.calls.filter(([, path]) => path === "/api/queue")).toHaveLength(
+      queueReads,
+    );
   });
 
   it("queues a durable two-clip sequence on the selected Keychain-authenticated host", async () => {

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -91,6 +91,7 @@ import {
   listActiveWork,
   reconcileActivityHost,
   type ActivityHostSnapshot,
+  type FleetActiveWork,
 } from "@studio/api/activity";
 import { listQueue, type QueueListing } from "@studio/api/queuePlan";
 import { buildChainRequest } from "@studio/lib/sequenceForm";
@@ -122,6 +123,7 @@ import type {
   Ltx2ControlAdapterInfo,
   Ltx2CameraControlInfo,
   ModelEntry,
+  OutputMetadata,
   PromptTransformProvenance,
   RemixDimension,
   RemixSourceKind,
@@ -144,6 +146,7 @@ import {
 } from "../lib/chainRouting";
 import {
   applyModelDefaults,
+  applyMetadataToForm,
   applyRequestToForm,
   buildRequest,
   cloneGenerateForm,
@@ -1352,11 +1355,19 @@ function selectCurrentMobileSequence(): void {
   const route = sequenceRoute.value;
   const detail = sequenceJob.value;
   if (!route || !detail) return;
+  loadMobileSequenceIntoCreate(detail);
+}
+
+function loadMobileSequenceIntoCreate(detail: ChainJobDetail): void {
   const script = normalizeServerChainScript(detail.script);
   if (script) {
     const loaded = chainScriptToClips(script);
     const shared = loaded.shared;
-    if (shared.model) form.model = shared.model;
+    if (shared.model) {
+      const model = generationModels.value.find((entry) => entry.name === shared.model);
+      if (model) applyModelDefaults(form, model);
+      else form.model = shared.model;
+    }
     if (shared.width != null) form.width = shared.width;
     if (shared.height != null) form.height = shared.height;
     if (shared.fps != null) form.fps = shared.fps;
@@ -1373,6 +1384,93 @@ function selectCurrentMobileSequence(): void {
     draft.openingImage = loaded.openingImage;
   }
   tab.value = "generate";
+}
+
+let mobileLiveWorkSelectionEpoch = 0;
+
+/** Restore server-owned work through its exact Keychain-authenticated route.
+ *  This mirrors desktop's live-work selection while keeping iPhone remote-only:
+ *  generation settings come from the authoritative queue row, and durable
+ *  sequences come from their server-side script. */
+async function openMobileLiveWork(row: FleetActiveWork): Promise<void> {
+  const epoch = ++mobileLiveWorkSelectionEpoch;
+  const host = connectedHosts.value.find((candidate) => candidate.id === row.hostId);
+  if (!host) {
+    setGenerationStatus("That machine is no longer connected.", true);
+    return;
+  }
+  const target = mobileHostTarget(host);
+  const snapshot = liveActivityHosts.value[row.hostId];
+
+  try {
+    if (!snapshot?.instanceId || snapshot.routeUrl !== target.baseUrl) {
+      throw new Error("This queue item belongs to a machine route that has changed.");
+    }
+    const verifyAuthority = async (): Promise<void> => {
+      const current = await apiJsonTo<ServerStatus>(target, "/api/status");
+      if (current.instance_id !== snapshot.instanceId) {
+        throw new Error("This queue item belongs to a different Mold server instance.");
+      }
+    };
+    await verifyAuthority();
+    if (epoch !== mobileLiveWorkSelectionEpoch) return;
+
+    if (row.kind === "generation") {
+      const queue = await listQueue(target);
+      if (epoch !== mobileLiveWorkSelectionEpoch) return;
+      await verifyAuthority();
+      if (epoch !== mobileLiveWorkSelectionEpoch) return;
+      const entry = queue.entries.find((candidate) => candidate.id === row.id);
+      if (!entry?.metadata) {
+        setGenerationStatus("This host cannot restore settings for that generation.", true);
+        return;
+      }
+      await selectHost(host.id);
+      if (epoch !== mobileLiveWorkSelectionEpoch) return;
+      const metadata = entry.metadata as OutputMetadata;
+      applyMetadataToForm(
+        form,
+        entry.seed_pinned === false
+          ? ({ ...metadata, seed: null } as unknown as OutputMetadata)
+          : metadata,
+        generationModels.value,
+      );
+      draft.stopEditing();
+      draft.output = "single";
+      setGenerationStatus("Prompt settings restored");
+      tab.value = "generate";
+      void nextTick(() => document.querySelector<HTMLTextAreaElement>("#mobile-prompt")?.focus());
+      return;
+    }
+
+    if (row.kind === "sequence") {
+      const detail = await apiJsonTo<ChainJobDetail>(
+        target,
+        `/api/chain-jobs/${encodeURIComponent(row.id)}`,
+      );
+      if (epoch !== mobileLiveWorkSelectionEpoch) return;
+      await verifyAuthority();
+      if (epoch !== mobileLiveWorkSelectionEpoch) return;
+      await selectHost(host.id);
+      if (epoch !== mobileLiveWorkSelectionEpoch) return;
+      if (!normalizeServerChainScript(detail.script)) {
+        throw new Error("This sequence job has no restorable script.");
+      }
+      loadMobileSequenceIntoCreate(detail);
+      setGenerationStatus("Sequence settings restored");
+      return;
+    }
+
+    if (row.kind === "download") {
+      openCatalog(host.id);
+      return;
+    }
+    tab.value = "hosts";
+    showHostDetail(host.id);
+  } catch (error) {
+    if (epoch !== mobileLiveWorkSelectionEpoch) return;
+    setGenerationStatus(describeTransportError(error, host.name), true);
+  }
 }
 /**
  * Running and waiting are counted apart. A settled sequence keeps its row (for
@@ -5705,7 +5803,11 @@ onBeforeUnmount(() => {
                 </template>
               </li>
             </ol>
-            <LiveActivityList :rows="sharedMobileActivity" />
+            <LiveActivityList
+              :rows="sharedMobileActivity"
+              interactive
+              @select="openMobileLiveWork"
+            />
           </section>
           <p
             v-if="sequenceError && sequenceRoute && !isSequence"


### PR DESCRIPTION
## Summary

- make server-owned iOS queue rows tappable and restore one-shot settings from the authoritative queue entry
- load durable sequence scripts into the mobile Create clip rail with the selected model's defaults and capabilities
- fence restoration to the exact Keychain-authenticated route and Mold server instance
- preserve desktop seed semantics, including random seed 0 when `seed_pinned` is false

## Validation

- `nix develop -c bun run test -- src/mobile/MobileApp.test.ts` (169 passed)
- `nix develop -c bunx vue-tsc --noEmit -p tsconfig.json`
- `nix develop -c bun run build:mobile`
- `nix develop -c bunx prettier --check src/mobile/MobileApp.vue src/mobile/MobileApp.test.ts`
- `git diff --check`

## Review

An independent review agent checked desktop parity, exact-route/instance authority, Keychain handling, race safety, accessibility, and regression coverage. Two findings were fixed (sequence model capability reconciliation and server-instance fencing); the follow-up review reported no remaining findings.