### PR TITLE
fix(studio): retire stale prompt provenance across surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **Fixed stale prompt provenance across Create surfaces.** Starting a genuinely new prompt now retires any dormant `original_prompt` and transform authority left by a prior gallery reuse, Expand, Remix, prepared batch, history recall, or LoRA trigger-word insertion across web, desktop, iPhone, and the TUI. Active quick-transform snapshots still retain their source long enough for the explicit stale-work recovery flow.
+- **Fixed machine compute cards and queue visibility.** Desktop and web now keep multi-GPU cards consistently sized and constrain long model, device, and work identifiers so they cannot overlap adjacent metrics or controls. Host Queue panels also show scheduler-only active and staged work that is absent from the durable queue listing, while de-duplicating normal queue rows and leaving blocked work in its recovery section.
+
 - **The iPhone Generate control now acknowledges work immediately, and Library remains useful on slow or offline connections** ([#1121](https://github.com/utensils/mold/pull/1121)). Source preparation and placement checks now keep the button visibly busy and block duplicate taps without letting stale Expand/Remix work submit or permanently latch the control. Library metadata and bounded thumbnails are cached per server instance for fast/offline browsing, with deletion, host replacement, and delayed-write fences preventing stale prints from returning. Promptless prints now say that no prompt was used and offer **Reuse settings** instead of a disabled **Prompt unavailable** action; reuse restores their generation settings without displaying or resubmitting an unrelated previous prompt.
 
 ## [0.23.0] - 2026-08-17

--- a/crates/mold-tui/src/app.rs
+++ b/crates/mold-tui/src/app.rs
@@ -3107,13 +3107,10 @@ impl App {
                                 && textarea.cursor().0 == 0
                             {
                                 let current = self.generate.prompt.lines().join("\n");
-                                if let Some(prompt) = self.history.prev(&current) {
-                                    self.generate.prompt = TextArea::new(
-                                        prompt.lines().map(String::from).collect(),
-                                    );
-                                    self.generate
-                                        .prompt
-                                        .set_cursor_line_style(ratatui::style::Style::default());
+                                if let Some(prompt) =
+                                    self.history.prev(&current).map(str::to_owned)
+                                {
+                                    self.set_authored_prompt_text(&prompt);
                                 }
                                 return;
                             }
@@ -3138,13 +3135,10 @@ impl App {
                                 && textarea.cursor().0 >= last_line
                             {
                                 let current = self.generate.prompt.lines().join("\n");
-                                if let Some(prompt) = self.history.next(&current) {
-                                    self.generate.prompt = TextArea::new(
-                                        prompt.lines().map(String::from).collect(),
-                                    );
-                                    self.generate
-                                        .prompt
-                                        .set_cursor_line_style(ratatui::style::Style::default());
+                                if let Some(prompt) =
+                                    self.history.next(&current).map(str::to_owned)
+                                {
+                                    self.set_authored_prompt_text(&prompt);
                                 }
                                 return;
                             }
@@ -3175,20 +3169,24 @@ impl App {
                         }
                         _ => {
                             // Let the textarea consume the event
+                            let previous_prompt = if self.generate.focus == GenerateFocus::Prompt {
+                                Some(self.generate.prompt.lines().join("\n"))
+                            } else {
+                                None
+                            };
                             let textarea = match self.generate.focus {
                                 GenerateFocus::Prompt => &mut self.generate.prompt,
                                 GenerateFocus::NegativePrompt => &mut self.generate.negative_prompt,
                                 _ => unreachable!(),
                             };
                             textarea.input(event);
-                            if self.generate.focus == GenerateFocus::Prompt {
+                            let prompt_changed = previous_prompt.is_some_and(|previous| {
+                                previous != self.generate.prompt.lines().join("\n")
+                            });
+                            if prompt_changed {
                                 self.generate.prompt_transform_token =
                                     self.generate.prompt_transform_token.wrapping_add(1);
-                                self.generate.params.prompt_transform = None;
-                                self.generate.params.quick_transform_snapshot = None;
-                                self.generate.params.prepared_prompts.clear();
-                                self.generate.params.prepared_prompt_transforms.clear();
-                                self.generate.params.prepared_transform_snapshot = None;
+                                self.retire_prompt_provenance();
                             }
                             // Reset history navigation when user types
                             self.history.reset_cursor();
@@ -3366,12 +3364,7 @@ impl App {
                     self.start_prompt_transform(operation);
                 }
                 PromptAlternativeEffect::Restore(source) => {
-                    self.set_prompt_text(&source);
-                    self.generate.params.prepared_prompts.clear();
-                    self.generate.params.prepared_prompt_transforms.clear();
-                    self.generate.params.prepared_transform_snapshot = None;
-                    self.generate.params.prompt_transform = None;
-                    self.generate.params.quick_transform_snapshot = None;
+                    self.set_authored_prompt_text(&source);
                     self.close_popup();
                 }
             }
@@ -3576,12 +3569,7 @@ impl App {
                     KeyCode::Enter => {
                         if let Some(prompt) = results.get(*selected).cloned() {
                             self.close_popup();
-                            self.generate.prompt =
-                                TextArea::new(prompt.lines().map(String::from).collect());
-                            self.generate
-                                .prompt
-                                .set_cursor_line_style(ratatui::style::Style::default());
-                            self.generate.focus = GenerateFocus::Prompt;
+                            self.set_authored_prompt_text(&prompt);
                         }
                     }
                     KeyCode::Up | KeyCode::Char('k')
@@ -4307,12 +4295,8 @@ impl App {
                     && self.generate.focus == GenerateFocus::Prompt =>
             {
                 let current = self.generate.prompt.lines().join("\n");
-                if let Some(prompt) = self.history.prev(&current) {
-                    self.generate.prompt =
-                        TextArea::new(prompt.lines().map(String::from).collect());
-                    self.generate
-                        .prompt
-                        .set_cursor_line_style(ratatui::style::Style::default());
+                if let Some(prompt) = self.history.prev(&current).map(str::to_owned) {
+                    self.set_authored_prompt_text(&prompt);
                 }
             }
             Action::HistoryNext
@@ -4320,12 +4304,8 @@ impl App {
                     && self.generate.focus == GenerateFocus::Prompt =>
             {
                 let current = self.generate.prompt.lines().join("\n");
-                if let Some(prompt) = self.history.next(&current) {
-                    self.generate.prompt =
-                        TextArea::new(prompt.lines().map(String::from).collect());
-                    self.generate
-                        .prompt
-                        .set_cursor_line_style(ratatui::style::Style::default());
+                if let Some(prompt) = self.history.next(&current).map(str::to_owned) {
+                    self.set_authored_prompt_text(&prompt);
                 }
             }
             Action::SearchHistory => {
@@ -5145,6 +5125,20 @@ impl App {
         // restoring an empty editor would flip the reuse into an explicit
         // empty-uncond opt-out (#787).
         self.generate.prompt = tui_textarea::TextArea::from(meta.prompt.lines());
+        self.generate.params.original_prompt = if meta.prompt.trim().is_empty() {
+            None
+        } else {
+            meta.original_prompt.clone()
+        };
+        self.generate.params.prompt_transform = if meta.prompt.trim().is_empty() {
+            None
+        } else {
+            meta.prompt_transform.clone()
+        };
+        self.generate.params.quick_transform_snapshot = None;
+        self.generate.params.prepared_prompts.clear();
+        self.generate.params.prepared_prompt_transforms.clear();
+        self.generate.params.prepared_transform_snapshot = None;
         self.update_model(&meta.model);
         let restored_negative = meta
             .negative_prompt
@@ -6760,6 +6754,20 @@ impl App {
             .prompt
             .set_cursor_line_style(ratatui::style::Style::default());
         self.generate.focus = GenerateFocus::Prompt;
+    }
+
+    fn set_authored_prompt_text(&mut self, prompt: &str) {
+        self.set_prompt_text(prompt);
+        self.retire_prompt_provenance();
+    }
+
+    fn retire_prompt_provenance(&mut self) {
+        self.generate.params.original_prompt = None;
+        self.generate.params.prompt_transform = None;
+        self.generate.params.quick_transform_snapshot = None;
+        self.generate.params.prepared_prompts.clear();
+        self.generate.params.prepared_prompt_transforms.clear();
+        self.generate.params.prepared_transform_snapshot = None;
     }
 
     fn prompt_transform_task(&self) -> mold_core::ExpandTask {
@@ -10443,6 +10451,29 @@ mod tests {
             mold_core::manifest::WAN_DEFAULT_NEGATIVE_PROMPT,
             "absence predates truthful recording: the default conditioned the render"
         );
+    }
+
+    #[tokio::test]
+    async fn gallery_reuse_restores_only_provenance_backed_by_a_prompt() {
+        let mut app = make_settings_test_app();
+        let mut transformed = make_test_entry();
+        transformed.metadata.prompt = "an expanded lighthouse".into();
+        transformed.metadata.original_prompt = Some("a lighthouse".into());
+        app.gallery.entries = vec![transformed];
+        app.gallery.selected = 0;
+
+        app.load_gallery_into_generate();
+        assert_eq!(
+            app.generate.params.original_prompt.as_deref(),
+            Some("a lighthouse")
+        );
+
+        let mut promptless = make_test_entry();
+        promptless.metadata.prompt.clear();
+        promptless.metadata.original_prompt = Some("stale source".into());
+        app.gallery.entries = vec![promptless];
+        app.load_gallery_into_generate();
+        assert_eq!(app.generate.params.original_prompt, None);
     }
 
     /// #787 round 2: `App::new` never runs `sync_generate_capabilities`, so
@@ -15732,6 +15763,57 @@ mod tests {
         };
         assert_eq!(current_prompt, "current edited prompt");
         assert_eq!(root_prompt, "original idea");
+    }
+
+    #[tokio::test]
+    async fn authored_prompt_retires_dormant_transform_provenance() {
+        let mut app = make_settings_test_app();
+        let snapshot = PromptTransformSnapshot {
+            operation: PromptTransformOperation::Remix,
+            model: app.generate.params.model.clone(),
+            target: crate::hosts::GenTarget::Auto,
+            task: app.prompt_transform_task(),
+            reference_fingerprint: String::new(),
+            source_prompt: "old source".into(),
+            current_prompt: "old rewrite".into(),
+            root_prompt: Some("old source".into()),
+            source_kind: mold_core::RemixSourceKind::Original,
+        };
+        app.generate.params.original_prompt = Some("old source".into());
+        app.generate.params.prompt_transform = Some(App::prompt_provenance(&snapshot, vec![]));
+        app.generate.params.quick_transform_snapshot = Some(snapshot.clone());
+        app.generate.params.prepared_prompts = vec!["prepared sibling".into()];
+        app.generate.params.prepared_prompt_transforms =
+            vec![App::prompt_provenance(&snapshot, vec![])];
+        app.generate.params.prepared_transform_snapshot = Some(snapshot);
+
+        app.set_authored_prompt_text("a completely new idea");
+
+        assert_eq!(
+            app.generate.prompt.lines().join("\n"),
+            "a completely new idea"
+        );
+        assert_eq!(app.generate.params.original_prompt, None);
+        assert_eq!(app.generate.params.prompt_transform, None);
+        assert_eq!(app.generate.params.quick_transform_snapshot, None);
+        assert!(app.generate.params.prepared_prompts.is_empty());
+        assert!(app.generate.params.prepared_prompt_transforms.is_empty());
+        assert_eq!(app.generate.params.prepared_transform_snapshot, None);
+    }
+
+    #[tokio::test]
+    async fn moving_the_prompt_cursor_preserves_transform_provenance() {
+        use crossterm::event::{Event, KeyEvent};
+
+        let mut app = make_settings_test_app();
+        app.set_prompt_text("an expanded prompt");
+        app.generate.params.original_prompt = Some("the original idea".into());
+        app.handle_crossterm_event(Event::Key(KeyEvent::new(KeyCode::Left, KeyModifiers::NONE)));
+
+        assert_eq!(
+            app.generate.params.original_prompt.as_deref(),
+            Some("the original idea")
+        );
     }
 
     /// Build a catalog entry for a wan checkpoint advertising `capability`,

--- a/desktop/src/components/create/ComposerCard.vue
+++ b/desktop/src/components/create/ComposerCard.vue
@@ -50,6 +50,7 @@ const emit = defineEmits<{
   expand: [];
   remix: [];
   restore: [];
+  "prompt-authored": [value: string];
   "update:remixSource": [value: "original" | "current"];
 }>();
 
@@ -87,10 +88,17 @@ function cycleHistory(direction: "prev" | "next") {
   const replacement = direction === "prev" ? cycler.prev(props.form.prompt) : cycler.next();
   if (replacement === null) return;
   props.form.prompt = replacement;
+  emit("prompt-authored", replacement);
   void nextTick(() => {
     const el = promptEl.value;
     el?.setSelectionRange(el.value.length, el.value.length);
   });
+}
+
+function onPromptInput(event: Event) {
+  cycler.reset();
+  growPrompt();
+  emit("prompt-authored", (event.target as HTMLTextAreaElement).value);
 }
 
 function onKeydown(e: KeyboardEvent) {
@@ -134,10 +142,7 @@ defineExpose({ focus, expand, record });
         :placeholder="placeholder"
         class="ms-composer__input"
         @keydown="onKeydown"
-        @input="
-          cycler.reset();
-          growPrompt();
-        "
+        @input="onPromptInput"
       />
       <StyleChips v-model="form.stylePreset" />
     </div>

--- a/desktop/src/components/machines/HostQueuePanel.test.ts
+++ b/desktop/src/components/machines/HostQueuePanel.test.ts
@@ -17,6 +17,7 @@ import HostQueuePanel from "./HostQueuePanel.vue";
 import { useConnectionStore } from "../../stores/connection";
 import { useHostsStore } from "../../stores/hosts";
 import { useJobsStore, type QueueEntry } from "../../stores/jobs";
+import type { QueuePlan } from "@studio/api/queuePlan";
 
 const stub = { template: "<div />" };
 let router: Router;
@@ -32,7 +33,11 @@ function queued(id: string, position: number, targetGpu: number): QueueEntry {
   };
 }
 
-async function mountPanel(gpuOrdinals: number[], entries: QueueEntry[]) {
+async function mountPanel(
+  gpuOrdinals: number[],
+  entries: QueueEntry[],
+  plan: QueuePlan | null = null,
+) {
   router = createRouter({
     history: createMemoryHistory(),
     routes: [
@@ -54,6 +59,7 @@ async function mountPanel(gpuOrdinals: number[], entries: QueueEntry[]) {
     paused: null,
     caps: { canPause: true, canCancelAll: true, canReorder: true },
     gpuOrdinals,
+    plan,
     error: null,
   };
   const host = hosts.all[0]!;
@@ -101,6 +107,33 @@ describe("HostQueuePanel", () => {
   it("shows the configurable empty line for a host with nothing queued", async () => {
     const { wrapper } = await mountPanel([], []);
     expect(wrapper.get("[data-test='queue-empty']").text()).toBe("Nothing queued");
+  });
+
+  it("shows scheduler-only work instead of an empty queue", async () => {
+    const { wrapper } = await mountPanel([], [], {
+      plan_version: 1,
+      state_version: 1,
+      optimizer_state: "optimized",
+      dirty_since_unix_ms: null,
+      next_replan_at_unix_ms: null,
+      work_items: [
+        {
+          work_id: "chain-stage-2",
+          parent_id: "chain-parent",
+          work_kind: "chain_stage",
+          chain_stage: 1,
+          priority_class: "user",
+          queue_rank: 0,
+          bypass_count: 0,
+          gpu: 2,
+          estimate_confidence: "medium",
+          activity_phase: "active",
+        },
+      ],
+    });
+
+    expect(wrapper.find("[data-test='queue-empty']").exists()).toBe(false);
+    expect(wrapper.findAll("[data-test='planned-queue-row']")).toHaveLength(1);
   });
 });
 

--- a/desktop/src/components/machines/HostQueuePanel.vue
+++ b/desktop/src/components/machines/HostQueuePanel.vue
@@ -378,11 +378,7 @@ function loadQueueSettings(metadata: OutputMetadata) {
         </p>
       </div>
     </template>
-    <QueuePlanWorkList
-      class="mt-2"
-      :plan="snapshot?.plan ?? null"
-      :exclude-ids="entryIds"
-    />
+    <QueuePlanWorkList class="mt-2" :plan="snapshot?.plan ?? null" :exclude-ids="entryIds" />
     <p
       v-if="!hasEntries && !hasPlanOnlyWork"
       class="mt-1 text-caption text-ink-3"

--- a/desktop/src/components/machines/HostQueuePanel.vue
+++ b/desktop/src/components/machines/HostQueuePanel.vue
@@ -30,6 +30,8 @@ import {
   type LaneKey,
 } from "../../lib/queueLanes";
 import type { OutputMetadata } from "../../lib/api/types";
+import QueuePlanWorkList from "@studio/components/QueuePlanWorkList.vue";
+import { queuePlanOnlyWork } from "@studio/lib/queuePlanPresentation";
 
 const props = withDefaults(
   defineProps<{
@@ -74,6 +76,12 @@ const lanes = computed(() => {
 });
 
 const hasEntries = computed(() => lanes.value.some((lane) => lane.entries.length > 0));
+const entryIds = computed(() =>
+  lanes.value.flatMap((lane) => lane.entries.map((entry) => entry.id)),
+);
+const hasPlanOnlyWork = computed(
+  () => queuePlanOnlyWork(snapshot.value?.plan, entryIds.value).length > 0,
+);
 const modelLabel = (name: string) =>
   modelDisplayNameForId(name, hostModels.modelsOn(props.host.id));
 
@@ -370,7 +378,18 @@ function loadQueueSettings(metadata: OutputMetadata) {
         </p>
       </div>
     </template>
-    <p v-else class="mt-1 text-caption text-ink-3" data-test="queue-empty">{{ emptyLabel }}</p>
+    <QueuePlanWorkList
+      class="mt-2"
+      :plan="snapshot?.plan ?? null"
+      :exclude-ids="entryIds"
+    />
+    <p
+      v-if="!hasEntries && !hasPlanOnlyWork"
+      class="mt-1 text-caption text-ink-3"
+      data-test="queue-empty"
+    >
+      {{ emptyLabel }}
+    </p>
 
     <QueueEntryDrawer
       v-if="queueDetail"

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -376,6 +376,32 @@ afterEach(() => {
 });
 
 describe("MobileApp sequence generation", () => {
+  it("retires dormant original-prompt provenance when a new prompt is authored", async () => {
+    wrapper = mountMobileApp();
+    await flushPromises();
+    const form = wrapper.getComponent(MobileLoraControls).props("form") as GenerateForm;
+    form.originalPrompt = "the source for an earlier generated print";
+
+    await fieldControl("Prompt").setValue("a completely new print");
+
+    expect(form.originalPrompt).toBeNull();
+  });
+
+  it("preserves quick-expansion provenance when the rewrite is hand-edited", async () => {
+    wrapper = mountMobileApp();
+    await flushPromises();
+    const form = wrapper.getComponent(MobileLoraControls).props("form") as GenerateForm;
+    await fieldControl("Prompt").setValue("a lighthouse");
+    await wrapper.get("[data-test='mobile-prompt-expand']").trigger("click");
+    await flushPromises();
+
+    await fieldControl("Prompt").setValue("a hand-edited lighthouse rewrite");
+    await flushPromises();
+
+    expect(form.originalPrompt).toBe("a lighthouse");
+    expect(wrapper.find("[data-test='mobile-quick-expansion-stale']").exists()).toBe(true);
+  });
+
   it("acknowledges a tap through placement preview and blocks duplicate submission", async () => {
     const preview = deferred<ReturnType<typeof plannedPlacement>>();
     previewGenerationPlacement.mockReturnValueOnce(preview.promise);

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -52,6 +52,7 @@ import {
   type OutputMode,
 } from "@studio/lib/sequence";
 import { promptPlaceholder, promptRequired } from "@studio/lib/promptRequirement";
+import { applyAuthoredPrompt } from "@studio/lib/promptProvenance";
 import {
   appendMinimaxH3GalleryImageReference,
   emptyMinimaxH3AuthoringState,
@@ -2411,7 +2412,11 @@ function clearHostScopedGenerationSelections(): void {
 function appendPromptWord(word: string): void {
   const trimmed = word.trim();
   if (!trimmed) return;
-  form.prompt = form.prompt.trim() ? `${form.prompt.trimEnd()}, ${trimmed}` : trimmed;
+  onPromptAuthored(form.prompt.trim() ? `${form.prompt.trimEnd()}, ${trimmed}` : trimmed);
+}
+
+function onPromptAuthored(prompt: string): void {
+  applyAuthoredPrompt(form, prompt, quickExpansionSnapshot.value !== null);
 }
 
 let templateLoadEpoch = 0;
@@ -5198,6 +5203,7 @@ onBeforeUnmount(() => {
                 v-model="form.prompt"
                 class="control"
                 :placeholder="promptFieldPlaceholder"
+                @input="onPromptAuthored(($event.target as HTMLTextAreaElement).value)"
               />
             </label>
             <MobileStyleChips v-model="form.stylePreset" />

--- a/desktop/src/views/GenerateView.prepared.test.ts
+++ b/desktop/src/views/GenerateView.prepared.test.ts
@@ -213,6 +213,37 @@ describe("GenerateView prepared expansion batches", () => {
     expect(options).toEqual({});
   });
 
+  it("retires dormant original-prompt provenance when a new prompt is authored", async () => {
+    const form = useGenerateFormStore().form;
+    form.originalPrompt = "the source for an earlier generated print";
+    const wrapper = mountView();
+    await flushPromises();
+
+    await wrapper.get("textarea[aria-label='Prompt']").setValue("a completely new print");
+
+    expect(form.originalPrompt).toBeNull();
+    expect(form.prompt).toBe("a completely new print");
+  });
+
+  it("preserves quick-expansion provenance when the rewrite is hand-edited", async () => {
+    const form = useGenerateFormStore().form;
+    form.batchSize = 1;
+    vi.mocked(expandPrompt).mockResolvedValue({
+      original: "a lighthouse at dusk",
+      expanded: ["storm light"],
+    });
+    const wrapper = mountView();
+    await flushPromises();
+
+    wrapper.findComponent(ExpandControl).vm.$emit("expand");
+    await flushPromises();
+    await wrapper.get("textarea[aria-label='Prompt']").setValue("hand-edited storm light");
+    await nextTick();
+
+    expect(form.originalPrompt).toBe("a lighthouse at dusk");
+    expect(wrapper.find("[data-test='quick-expansion-stale']").exists()).toBe(true);
+  });
+
   it("prepares and preserves exactly eight reviewed prompts", async () => {
     const prompts = Array.from({ length: 8 }, (_, index) => `variation ${index + 1}`);
     useGenerateFormStore().form.batchSize = prompts.length;

--- a/desktop/src/views/GenerateView.vue
+++ b/desktop/src/views/GenerateView.vue
@@ -47,6 +47,7 @@ import {
   sequenceMotionTailFrames,
 } from "@studio/lib/sequence";
 import { OPTIONAL_PROMPT_GUIDANCE, promptRequired } from "@studio/lib/promptRequirement";
+import { applyAuthoredPrompt } from "@studio/lib/promptProvenance";
 import {
   emptyMinimaxH3AuthoringState,
   minimaxH3AuthoringError,
@@ -2324,7 +2325,11 @@ function retryExpansionAfterPull() {
 function appendPromptWord(word: string) {
   const trimmed = word.trim();
   if (!trimmed) return;
-  form.prompt = form.prompt.trim() ? `${form.prompt.trimEnd()}, ${trimmed}` : trimmed;
+  onPromptAuthored(form.prompt.trim() ? `${form.prompt.trimEnd()}, ${trimmed}` : trimmed);
+}
+
+function onPromptAuthored(prompt: string) {
+  applyAuthoredPrompt(form, prompt, quickExpansionSnapshot.value !== null);
 }
 
 /** Status line while the source is upscaled/refit ahead of the submit. */
@@ -3745,6 +3750,7 @@ onBeforeUnmount(() => {
             :preprocessing-status="preprocessingStatus"
             :history="promptHistory"
             :remix-source="remixSource"
+            @prompt-authored="onPromptAuthored"
             @generate="generate"
             @expand="expandForCurrentBatch()"
             @remix="remixForCurrentPrompt()"

--- a/desktop/src/views/HostDetailView.vue
+++ b/desktop/src/views/HostDetailView.vue
@@ -9,6 +9,7 @@ import ModelMetadataBadges from "@studio/components/ModelMetadataBadges.vue";
 import DevicePanel from "@studio/components/DevicePanel.vue";
 import MinimaxH3InventoryPanel from "@studio/components/MinimaxH3InventoryPanel.vue";
 import { setQueueDevicePin } from "@studio/api/queuePlan";
+import { queuePlanOnlyWork } from "@studio/lib/queuePlanPresentation";
 import { modelKindLabel, modelKindValue } from "@studio/lib/modelMetadata";
 import { setDeviceEnabled } from "@studio/api/devices";
 import CatalogDetailDrawer from "../components/models/CatalogDetailDrawer.vue";
@@ -268,6 +269,7 @@ const h3Host = computed(() => [
 ]);
 
 const queueSnapshot = computed(() => jobs.queues[hostId.value] ?? null);
+const scheduledWorkCount = computed(() => queuePlanOnlyWork(queueSnapshot.value?.plan, []).length);
 const mutatingDeviceIds = ref(new Set<string>());
 const queuePaused = computed(() => queueSnapshot.value?.paused === true);
 
@@ -754,8 +756,10 @@ async function forget() {
                   PAUSED
                 </span>
                 <span class="edge-code" data-test="queue-depth">
+                  <template v-if="scheduledWorkCount"> {{ scheduledWorkCount }} work · </template>
                   {{ queueDepth ?? "—"
-                  }}<template v-if="queueCapacity">/{{ queueCapacity }}</template>
+                  }}<template v-if="queueCapacity">/{{ queueCapacity }}</template
+                  ><template v-if="scheduledWorkCount"> queued</template>
                 </span>
               </div>
               <HostQueuePanel

--- a/studio/components/DevicePanel.test.ts
+++ b/studio/components/DevicePanel.test.ts
@@ -256,9 +256,7 @@ describe("DevicePanel", () => {
         expect(wrapper.text()).not.toContain("Live GPU controls");
       }
       expect(
-        utility
-          .findAll("li")
-          .map((row) => row.text().split(" · ").slice(0, 2).join(" · ")),
+        utility.findAll(".device-card__work").map((row) => row.text()),
       ).toEqual([
         "expand-parent-1 · Prompt expansion",
         "future-parent-2 · Future utility",

--- a/studio/components/DevicePanel.vue
+++ b/studio/components/DevicePanel.vue
@@ -96,8 +96,7 @@ const lifecycleNote = computed(() => {
 });
 
 function shortId(id: string): string {
-  const tail = id.split(":").at(-1) ?? id;
-  return tail.length > 10 ? `…${tail.slice(-8)}` : tail;
+  return id.length > 14 ? `…${id.slice(-12)}` : id;
 }
 
 function gib(bytes: number | null): string {
@@ -159,6 +158,13 @@ function eta(work: QueueWorkItem): string {
 function workKindLabel(kind: unknown): string {
   const words = typeof kind === "string" ? kind.replaceAll("_", " ") : "";
   return words.length ? `${words[0]!.toUpperCase()}${words.slice(1)}` : "Work";
+}
+
+function workLabel(work: QueueWorkItem): string {
+  const kind = workKindLabel(work.work_kind);
+  return work.chain_stage == null
+    ? kind
+    : `${kind} · stage ${work.chain_stage + 1}`;
 }
 
 function replanLabel(): string | null {
@@ -266,10 +272,19 @@ onBeforeUnmount(() => {
           </span>
         </div>
         <div v-if="device.loaded_models.length" class="device-card__line">
-          Loaded: {{ device.loaded_models.join(", ") }}
+          <span class="device-card__line-label">Loaded</span>
+          <span
+            class="device-card__line-value"
+            :title="device.loaded_models.join(', ')"
+          >
+            {{ device.loaded_models.join(", ") }}
+          </span>
         </div>
         <div v-if="device.active_work_id" class="device-card__line">
-          Active: {{ device.active_work_id }}
+          <span class="device-card__line-label">Active</span>
+          <code class="device-card__line-value" :title="device.active_work_id">
+            {{ shortId(device.active_work_id) }}
+          </code>
         </div>
         <ol
           v-if="planned(device).length"
@@ -277,7 +292,10 @@ onBeforeUnmount(() => {
           data-test="device-lane"
         >
           <li v-for="work in planned(device)" :key="work.work_id">
-            {{ work.work_id }} · {{ eta(work) }}
+            <span class="device-card__work" :title="work.work_id">
+              {{ work.work_id }} · {{ workLabel(work) }}
+            </span>
+            <span class="device-card__eta">· {{ eta(work) }}</span>
           </li>
         </ol>
         <button
@@ -306,8 +324,10 @@ onBeforeUnmount(() => {
         </div>
         <ol class="device-card__lane">
           <li v-for="work in unassignedDeviceWork" :key="work.work_id">
-            {{ work.work_id }} · {{ workKindLabel(work.work_kind) }} ·
-            {{ eta(work) }}
+            <span class="device-card__work" :title="work.work_id">
+              {{ work.work_id }} · {{ workLabel(work) }}
+            </span>
+            <span class="device-card__eta">· {{ eta(work) }}</span>
           </li>
         </ol>
       </article>
@@ -325,8 +345,10 @@ onBeforeUnmount(() => {
         </div>
         <ol class="device-card__lane" data-test="cpu-utility-lane-list">
           <li v-for="work in cpuUtilityWork" :key="work.work_id">
-            {{ work.work_id }} · {{ workKindLabel(work.work_kind) }} ·
-            {{ eta(work) }}
+            <span class="device-card__work" :title="work.work_id">
+              {{ work.work_id }} · {{ workLabel(work) }}
+            </span>
+            <span class="device-card__eta">· {{ eta(work) }}</span>
           </li>
         </ol>
       </article>
@@ -341,8 +363,10 @@ onBeforeUnmount(() => {
         </div>
         <ol class="device-card__lane">
           <li v-for="work in otherComputeWork" :key="work.work_id">
-            {{ work.work_id }} · {{ workKindLabel(work.work_kind) }} ·
-            {{ eta(work) }}
+            <span class="device-card__work" :title="work.work_id">
+              {{ work.work_id }} · {{ workLabel(work) }}
+            </span>
+            <span class="device-card__eta">· {{ eta(work) }}</span>
           </li>
         </ol>
       </article>
@@ -405,7 +429,8 @@ onBeforeUnmount(() => {
 }
 .device-panel__grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 300px), 1fr));
+  align-items: stretch;
   gap: 10px;
 }
 .device-panel--compact .device-panel__grid {
@@ -413,6 +438,9 @@ onBeforeUnmount(() => {
 }
 .device-card {
   display: grid;
+  min-width: 0;
+  min-height: 226px;
+  align-content: start;
   gap: 8px;
   padding: 12px;
   border: 1px solid var(--line, #d5d5d5);
@@ -431,20 +459,33 @@ onBeforeUnmount(() => {
 .device-card[data-health="poisoned"] {
   opacity: 0.68;
 }
-.device-card__title,
-.device-card__meta,
-.device-card__metrics {
+.device-card__title {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  gap: 6px;
+  align-items: center;
+}
+.device-card__meta {
   display: flex;
   flex-wrap: wrap;
   gap: 6px 10px;
   align-items: center;
 }
+.device-card__metrics {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 6px 10px;
+  align-items: center;
+}
 .device-card__name {
   min-width: 0;
-  flex: 1;
   font-weight: 650;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .device-card__badge {
+  white-space: nowrap;
   padding: 2px 6px;
   border: 1px solid var(--line, #aaa);
   border-radius: 999px;
@@ -459,14 +500,45 @@ onBeforeUnmount(() => {
   color: var(--ink-2, #555);
   font-size: 12px;
 }
-.device-card__metrics {
-  justify-content: space-between;
+.device-card__line {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 6px;
+  min-width: 0;
+}
+.device-card__line-label::after {
+  content: ":";
+}
+.device-card__line-value {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .device-card__lane {
+  display: grid;
+  gap: 4px;
   margin: 0;
-  padding-left: 18px;
+  padding: 0;
+  list-style: none;
+}
+.device-card__lane li {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+  min-width: 0;
+}
+.device-card__work {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.device-card__eta {
+  white-space: nowrap;
 }
 .device-card__toggle {
+  margin-top: auto;
   justify-self: start;
   min-height: 32px;
   padding: 4px 10px;

--- a/studio/components/QueuePlanWorkList.test.ts
+++ b/studio/components/QueuePlanWorkList.test.ts
@@ -1,0 +1,74 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+import type { QueuePlan } from "../api/queuePlan";
+import QueuePlanWorkList from "./QueuePlanWorkList.vue";
+
+function plan(): QueuePlan {
+  return {
+    plan_version: 1,
+    state_version: 1,
+    optimizer_state: "optimized",
+    dirty_since_unix_ms: null,
+    next_replan_at_unix_ms: null,
+    work_items: [
+      {
+        work_id: "chain:67fa2076-stage-2",
+        parent_id: "chain:67fa2076",
+        work_kind: "chain_stage",
+        chain_stage: 1,
+        priority_class: "user",
+        queue_rank: 0,
+        bypass_count: 0,
+        gpu: 2,
+        lane_order: 0,
+        estimate_confidence: "medium",
+        activity_phase: "active",
+      },
+    ],
+  };
+}
+
+describe("QueuePlanWorkList", () => {
+  it("shows scheduler work even when no durable queue row represents it", () => {
+    const wrapper = mount(QueuePlanWorkList, { props: { plan: plan() } });
+
+    expect(wrapper.get('[data-test="planned-queue-row"]').text()).toContain(
+      "Chain stage · stage 2",
+    );
+    expect(wrapper.text()).toContain("active");
+    expect(wrapper.text()).toContain("GPU 2");
+    expect(wrapper.get("code").attributes("title")).toBe("chain:67fa2076");
+  });
+
+  it("does not duplicate work already represented by a queue parent", () => {
+    const wrapper = mount(QueuePlanWorkList, {
+      props: { plan: plan(), excludeIds: ["chain:67fa2076"] },
+    });
+
+    expect(wrapper.find('[data-test="planned-queue-row"]').exists()).toBe(
+      false,
+    );
+  });
+
+  it("leaves blocked work to the recovery section when phase is absent", () => {
+    const blocked = plan();
+    delete blocked.work_items[0]!.activity_phase;
+    blocked.work_items[0]!.blocked_reason = "no_capacity";
+    const wrapper = mount(QueuePlanWorkList, { props: { plan: blocked } });
+
+    expect(wrapper.find('[data-test="planned-queue-row"]').exists()).toBe(
+      false,
+    );
+  });
+
+  it("leaves phase-only blocked work to the recovery section", () => {
+    const blocked = plan();
+    blocked.work_items[0]!.activity_phase = "blocked";
+    blocked.work_items[0]!.blocked_reason = null;
+    const wrapper = mount(QueuePlanWorkList, { props: { plan: blocked } });
+
+    expect(wrapper.find('[data-test="planned-queue-row"]').exists()).toBe(
+      false,
+    );
+  });
+});

--- a/studio/components/QueuePlanWorkList.vue
+++ b/studio/components/QueuePlanWorkList.vue
@@ -1,0 +1,119 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import type { QueuePlan, QueueWorkItem } from "../api/queuePlan";
+import { queuePlanOnlyWork } from "../lib/queuePlanPresentation";
+
+const props = withDefaults(
+  defineProps<{
+    plan?: QueuePlan | null;
+    excludeIds?: readonly string[];
+  }>(),
+  { plan: null, excludeIds: () => [] },
+);
+
+const work = computed(() => queuePlanOnlyWork(props.plan, props.excludeIds));
+
+defineExpose({ work });
+
+function shortId(id: string): string {
+  const tail = id.split(":").at(-1) ?? id;
+  return tail.length > 10 ? `…${tail.slice(-8)}` : tail;
+}
+
+function words(value: string): string {
+  return value.replaceAll("_", " ");
+}
+
+function kindLabel(item: QueueWorkItem): string {
+  const base = words(item.work_kind || "work");
+  const label = `${base[0]?.toUpperCase() ?? ""}${base.slice(1)}`;
+  return item.chain_stage == null
+    ? label
+    : `${label} · stage ${item.chain_stage + 1}`;
+}
+
+function phaseLabel(item: QueueWorkItem): string {
+  return words(item.activity_phase ?? "scheduled");
+}
+
+function laneLabel(item: QueueWorkItem): string {
+  if (item.gpu != null) return `GPU ${item.gpu}`;
+  if (item.planned_lane_kind === "host_utility") return "CPU";
+  if (item.planned_device_id) return shortId(item.planned_device_id);
+  return "Auto";
+}
+</script>
+
+<template>
+  <ul v-if="work.length" class="plan-work" data-test="planned-queue-list">
+    <li
+      v-for="item in work"
+      :key="item.work_id"
+      class="plan-work__row"
+      data-test="planned-queue-row"
+    >
+      <span class="plan-work__phase">{{ phaseLabel(item) }}</span>
+      <span class="plan-work__main">
+        <strong>{{ kindLabel(item) }}</strong>
+        <code :title="item.parent_id || item.work_id">
+          {{ shortId(item.parent_id || item.work_id) }}
+        </code>
+      </span>
+      <span class="plan-work__lane">{{ laneLabel(item) }}</span>
+    </li>
+  </ul>
+</template>
+
+<style scoped>
+.plan-work {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.plan-work__row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  padding: 8px 10px;
+  border: 1px solid var(--line, var(--ce));
+  border-radius: 7px;
+  color: var(--ink-2, currentColor);
+  font-size: 12px;
+}
+.plan-work__phase {
+  padding: 2px 6px;
+  border: 1px solid var(--line, var(--ce));
+  border-radius: 999px;
+  font-size: 10px;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+.plan-work__main {
+  display: flex;
+  min-width: 0;
+  gap: 8px;
+  align-items: baseline;
+}
+.plan-work__main strong,
+.plan-work__main code {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.plan-work__lane {
+  color: var(--ink-3, currentColor);
+  white-space: nowrap;
+}
+@media (max-width: 639px) {
+  .plan-work__row {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+  .plan-work__lane {
+    grid-column: 2;
+  }
+}
+</style>

--- a/studio/lib/promptProvenance.test.ts
+++ b/studio/lib/promptProvenance.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { applyAuthoredPrompt } from "./promptProvenance";
+
+describe("applyAuthoredPrompt", () => {
+  it("retires provenance that no longer has active quick-transform authority", () => {
+    const draft = {
+      prompt: "expanded lighthouse",
+      originalPrompt: "a lighthouse",
+    };
+
+    applyAuthoredPrompt(draft, "a completely new print", false);
+
+    expect(draft).toEqual({
+      prompt: "a completely new print",
+      originalPrompt: null,
+    });
+  });
+
+  it("preserves provenance while quick-transform stale recovery still owns it", () => {
+    const draft = {
+      prompt: "expanded lighthouse",
+      originalPrompt: "a lighthouse",
+    };
+
+    applyAuthoredPrompt(draft, "an edited expanded lighthouse", true);
+
+    expect(draft).toEqual({
+      prompt: "an edited expanded lighthouse",
+      originalPrompt: "a lighthouse",
+    });
+  });
+});

--- a/studio/lib/promptProvenance.ts
+++ b/studio/lib/promptProvenance.ts
@@ -1,0 +1,23 @@
+/** Minimal mutable shape shared by the web, desktop, and iPhone composers. */
+export interface PromptProvenanceDraft {
+  prompt: string;
+  originalPrompt?: string | null;
+}
+
+/**
+ * Apply prompt text authored directly by the user.
+ *
+ * `originalPrompt` describes the provenance of one concrete transformed
+ * prompt. Once that transform has been submitted its route snapshot is
+ * retired, so later typing starts a new print and must retire the old
+ * provenance too. While a quick transform snapshot is still active, keep the
+ * root so stale-work recovery can offer re-expand, generate anyway, or restore.
+ */
+export function applyAuthoredPrompt(
+  draft: PromptProvenanceDraft,
+  prompt: string,
+  activeQuickTransform: boolean,
+): void {
+  draft.prompt = prompt;
+  if (!activeQuickTransform) draft.originalPrompt = null;
+}

--- a/studio/lib/queuePlanPresentation.ts
+++ b/studio/lib/queuePlanPresentation.ts
@@ -1,0 +1,24 @@
+import type { QueuePlan, QueueWorkItem } from "../api/queuePlan";
+import { normalizeBlockedReason } from "./queuePosition";
+
+/** Scheduler work that is not already represented by the durable queue list. */
+export function queuePlanOnlyWork(
+  plan: QueuePlan | null | undefined,
+  excludeIds: readonly string[],
+): QueueWorkItem[] {
+  const excluded = new Set(excludeIds);
+  return [...(plan?.work_items ?? [])]
+    .filter(
+      (item) =>
+        !excluded.has(item.work_id) &&
+        !excluded.has(item.parent_id) &&
+        item.activity_phase !== "blocked" &&
+        normalizeBlockedReason(item.blocked_reason ?? item.reason) === null,
+    )
+    .sort(
+      (a, b) =>
+        a.queue_rank - b.queue_rank ||
+        (a.lane_order ?? Number.MAX_SAFE_INTEGER) -
+          (b.lane_order ?? Number.MAX_SAFE_INTEGER),
+    );
+}

--- a/web/src/components/machines/QueueCard.test.ts
+++ b/web/src/components/machines/QueueCard.test.ts
@@ -132,3 +132,38 @@ describe("held rows", () => {
     expect(wrapper.find("[data-test='queue-cancel']").exists()).toBe(true);
   });
 });
+
+describe("scheduler plan work", () => {
+  it("does not claim the queue is empty when the scheduler has active work", () => {
+    const wrapper = mount(QueueCard, {
+      props: {
+        entries: [],
+        gpuOrdinals: [0],
+        plan: {
+          plan_version: 1,
+          state_version: 1,
+          optimizer_state: "optimized",
+          dirty_since_unix_ms: null,
+          next_replan_at_unix_ms: null,
+          work_items: [
+            {
+              work_id: "chain-stage-2",
+              parent_id: "chain-parent",
+              work_kind: "chain_stage",
+              chain_stage: 1,
+              priority_class: "user",
+              queue_rank: 0,
+              bypass_count: 0,
+              gpu: 0,
+              estimate_confidence: "medium",
+              activity_phase: "active",
+            },
+          ],
+        },
+      },
+    });
+
+    expect(wrapper.find("[data-test='queue-empty']").exists()).toBe(false);
+    expect(wrapper.findAll("[data-test='planned-queue-row']")).toHaveLength(1);
+  });
+});

--- a/web/src/components/machines/QueueCard.vue
+++ b/web/src/components/machines/QueueCard.vue
@@ -14,10 +14,14 @@ import Icon from "@ui/components/Icon.vue";
 import type { QueueEntry } from "../../types";
 import type { ModelInfoExtended } from "../../types";
 import { modelDisplayNameForId } from "@studio/lib/modelDisplay";
+import QueuePlanWorkList from "@studio/components/QueuePlanWorkList.vue";
+import type { QueuePlan } from "@studio/api/queuePlan";
+import { queuePlanOnlyWork } from "@studio/lib/queuePlanPresentation";
 
 const props = withDefaults(
   defineProps<{
     entries: QueueEntry[];
+    plan?: QueuePlan | null;
     models?: ModelInfoExtended[];
     /** Exact schedulable CUDA ordinals advertised by this host. */
     gpuOrdinals: number[];
@@ -35,6 +39,7 @@ const props = withDefaults(
     paused: false,
     dimmed: false,
     models: () => [],
+    plan: null,
   },
 );
 const modelLabel = (name: string) => modelDisplayNameForId(name, props.models);
@@ -49,6 +54,14 @@ const emit = defineEmits<{
 
 const queuedIds = computed(() =>
   props.entries.filter((e) => e.state === "queued").map((e) => e.id),
+);
+const entryIds = computed(() => props.entries.map((entry) => entry.id));
+const hasPlanOnlyWork = computed(
+  () => queuePlanOnlyWork(props.plan, entryIds.value).length > 0,
+);
+const visibleWorkCount = computed(
+  () =>
+    props.entries.length + queuePlanOnlyWork(props.plan, entryIds.value).length,
 );
 
 function laneValue(entry: QueueEntry): string {
@@ -79,7 +92,11 @@ function queuedIndexOf(id: string): number {
 <template>
   <CardSurface :padded="false">
     <div class="qc" :data-dimmed="dimmed ? 'true' : undefined">
-      <div class="qc__label">Queue</div>
+      <div class="qc__label">
+        Queue<template v-if="visibleWorkCount">
+          · {{ visibleWorkCount }} work</template
+        >
+      </div>
 
       <div
         v-if="canPause || (canCancelAll && queuedIds.length > 0) || paused"
@@ -111,11 +128,15 @@ function queuedIndexOf(id: string): number {
         </button>
       </div>
 
-      <p v-if="entries.length === 0" class="qc__empty" data-test="queue-empty">
+      <p
+        v-if="entries.length === 0 && !hasPlanOnlyWork"
+        class="qc__empty"
+        data-test="queue-empty"
+      >
         Nothing queued.
       </p>
 
-      <ul v-else class="qc__list">
+      <ul v-if="entries.length" class="qc__list">
         <li
           v-for="entry in entries"
           :key="entry.id"
@@ -194,6 +215,11 @@ function queuedIndexOf(id: string): number {
           </button>
         </li>
       </ul>
+      <QueuePlanWorkList
+        class="qc__planned"
+        :plan="plan"
+        :exclude-ids="entryIds"
+      />
     </div>
   </CardSurface>
 </template>
@@ -264,6 +290,10 @@ function queuedIndexOf(id: string): number {
   display: flex;
   flex-direction: column;
   gap: 4px;
+}
+
+.qc__planned {
+  margin-top: 8px;
 }
 
 .qc__row {

--- a/web/src/pages/CreatePage.test.ts
+++ b/web/src/pages/CreatePage.test.ts
@@ -2056,6 +2056,66 @@ describe("CreatePage layout and behavior", () => {
     expect(form.state.value.negativePrompt).toBe("text");
   });
 
+  it("retires dormant original-prompt provenance when a new prompt is authored", async () => {
+    const wrapper = mount(CreatePage, { global: { stubs: pageStubs() } });
+    const form = useGenerateForm();
+    form.state.value.originalPrompt =
+      "the source for an earlier generated print";
+    await nextTick();
+
+    wrapper
+      .getComponent({ name: "ComposerCard" })
+      .vm.$emit("update:prompt", "a completely new print");
+    await nextTick();
+
+    expect(form.state.value.originalPrompt).toBeNull();
+    expect(form.toRequest().original_prompt).toBeUndefined();
+  });
+
+  it("retires dormant provenance when a LoRA trigger phrase edits the prompt", async () => {
+    const wrapper = mount(CreatePage, { global: { stubs: pageStubs() } });
+    const form = useGenerateForm();
+    form.state.value.prompt = "a portrait";
+    form.state.value.originalPrompt = "an earlier generated print";
+    await nextTick();
+
+    wrapper
+      .getComponent({ name: "AdvancedDrawer" })
+      .vm.$emit("append-prompt", "cinematic light");
+    await nextTick();
+
+    expect(form.state.value.prompt).toBe("a portrait, cinematic light");
+    expect(form.state.value.originalPrompt).toBeNull();
+    expect(form.toRequest().original_prompt).toBeUndefined();
+  });
+
+  it("preserves the source while an active quick expansion becomes stale", async () => {
+    const wrapper = mount(CreatePage, { global: { stubs: pageStubs() } });
+    const form = useGenerateForm();
+    form.state.value.model = "sdxl-base:fp16";
+    form.state.value.modelFamily = "sdxl";
+    form.state.value.prompt = "a lighthouse";
+    await nextTick();
+
+    await wrapper.get("[data-test='composer-expand']").trigger("click");
+    await nextTick();
+    wrapper
+      .getComponent({ name: "ExpandModal" })
+      .vm.$emit("apply-prompt", "a lighthouse in storm light");
+    await nextTick();
+
+    wrapper
+      .getComponent({ name: "ComposerCard" })
+      .vm.$emit("update:prompt", "a hand-edited storm lighthouse");
+    await nextTick();
+
+    expect(form.state.value.originalPrompt).toBe("a lighthouse");
+    const stale = wrapper.get("[data-test='web-quick-expansion-stale']");
+    expect(
+      stale.find("[data-test='web-reexpand-current-prompt']").exists(),
+    ).toBe(true);
+  });
+
   it("undoes an original-source Remix to the latest live composer edit", async () => {
     const wrapper = mount(CreatePage, { global: { stubs: pageStubs() } });
     const form = useGenerateForm();

--- a/web/src/pages/CreatePage.vue
+++ b/web/src/pages/CreatePage.vue
@@ -48,6 +48,7 @@ import type { DevelopPhase } from "@ui/lib/grain";
 import type { ClipRailMedia } from "@ui/components/types";
 import { SourceFitPreprocessCache } from "@ui/lib/sourceFitPreprocessCache";
 import { createUuid } from "@studio/lib/id";
+import { applyAuthoredPrompt } from "@studio/lib/promptProvenance";
 import { requestNeedsReferenceUpload } from "@studio/api/referenceUploads";
 import {
   expansionTaskForRequest,
@@ -1994,6 +1995,15 @@ function onShowSequenceHistory() {
 
 const composerCardRef = ref<InstanceType<typeof ComposerCard> | null>(null);
 
+function onPromptAuthored(prompt: string) {
+  applyAuthoredPrompt(form.state.value, prompt, quickPrepared.value !== null);
+}
+
+function onAppendPromptPhrase(phrase: string) {
+  form.appendPromptPhrase(phrase);
+  onPromptAuthored(form.state.value.prompt);
+}
+
 // ⌘K "New print" (spec §06): start a fresh print without leaving Create.
 // Reset the advanced knobs to the current model's defaults, clear the prompt,
 // source media, and any in-flight expansion/variation review, but KEEP the
@@ -2002,6 +2012,7 @@ function onNewPrint() {
   const model = currentModel.value;
   if (model) form.applyModelDefaults(model);
   form.state.value.prompt = "";
+  form.state.value.originalPrompt = null;
   form.state.value.stylePreset = null;
   form.state.value.imageAttachments = [];
   form.state.value.endFrame = null;
@@ -4017,7 +4028,7 @@ onBeforeUnmount(() => {
         <template v-else>
           <ComposerCard
             ref="composerCardRef"
-            v-model:prompt="form.state.value.prompt"
+            :prompt="form.state.value.prompt"
             v-model:style-preset="form.state.value.stylePreset"
             :aspect-label="aspectLabel"
             :width="form.state.value.width"
@@ -4030,6 +4041,7 @@ onBeforeUnmount(() => {
             :prompt-optional="canSkipPrompt"
             :required-placeholder="requiredPromptPlaceholder"
             :history="promptHistory"
+            @update:prompt="onPromptAuthored"
             @submit="onSubmit"
             @expand="onExpand"
             @remix="onRemix"
@@ -4281,7 +4293,7 @@ onBeforeUnmount(() => {
           @open-end-frame-picker="showEndFramePicker = true"
           @clear-end-frame="onClearEndFrame"
           @open-mask="showMask = true"
-          @append-prompt="form.appendPromptPhrase"
+          @append-prompt="onAppendPromptPhrase"
         />
       </div>
     </div>
@@ -4313,7 +4325,7 @@ onBeforeUnmount(() => {
         @open-end-frame-picker="showEndFramePicker = true"
         @clear-end-frame="onClearEndFrame"
         @open-mask="showMask = true"
-        @append-prompt="form.appendPromptPhrase"
+        @append-prompt="onAppendPromptPhrase"
       />
     </div>
 

--- a/web/src/pages/HostDetailPage.vue
+++ b/web/src/pages/HostDetailPage.vue
@@ -708,6 +708,7 @@ onBeforeUnmount(() => {
         </CardSurface>
         <QueueCard
           :entries="queue"
+          :plan="queuePlan"
           :models="models"
           :gpu-ordinals="gpuOrdinals"
           :can-reorder="canReorder"


### PR DESCRIPTION
## Summary

Fix prompt provenance so starting a genuinely new item cannot inherit a stale `original_prompt` merely because a prior gallery reuse, Expand, Remix, or prepared batch left dormant form state behind.

This also fixes the reported Machines host-detail presentation issues: multi-GPU cards now remain consistently sized without long identifiers overlapping metrics or controls, and Queue panels show scheduler-only active/staged work even when the durable queue listing is empty.

## Root cause

The long-lived Create stores retained `originalPrompt` independently from the visible prompt. Several authored-prompt paths updated the text without retiring that dormant provenance, so a later ordinary generation could serialize the previous print's source as its own `original_prompt`.

Separately, the shared device cards used unconstrained wrapping flex rows for long model/work identifiers, and the Queue panels rendered only `/api/queue.entries` even though active chain stages can exist exclusively in `/api/queue.plan.work_items`.

## What changed

- Added one shared authored-prompt policy that clears dormant original/transform authority while preserving an active quick-transform snapshot for explicit stale-work recovery.
- Routed web, desktop, and iPhone text edits and trigger-word insertions through that policy.
- Updated TUI typing, history recall/search, alternate restore, and gallery reuse paths to retire or restore provenance deliberately; cursor-only movement does not clear it.
- Audited CLI, Discord, and server request paths; they are request-scoped and do not retain the affected dormant draft state.
- Reworked the shared `DevicePanel` grid/card constraints so long names, model IDs, and work IDs truncate safely with their full values available via titles.
- Added a shared scheduler-plan work list for desktop and web Queue panels, de-duplicated against durable parent/work IDs and excluding blocked work that belongs in the recovery section.
- Clarified desktop queue totals as scheduler work versus durable queued capacity.
- Added two `[Unreleased]` changelog entries for release-plz.

## Surface coverage

- Web Create and Machines host detail
- Desktop Create and Machines host detail
- iPhone Create
- Persistent TUI Create/history/gallery reuse
- Shared Studio prompt, device, and queue-plan contracts
- CLI, Discord, and server audited as stateless/non-affected

## Validation

- `nix develop -c cargo test -p mold-ai-tui` — 671 passed
- Full frontend architecture/test pass — Studio 729, Web 1368, Desktop/iPhone 3640 tests passed
- Focused final-state suites — Studio 23, Web 126, Desktop/iPhone 250 passed
- `nix develop -c sh -c 'cd desktop && bun run build && bun run build:mobile'`
- Web production build passed as part of the frontend gate
- Rust and frontend formatting checks passed
- `git diff --check`

Rendered web QA used a four-L40S fixture with long model/work identifiers and an active chain stage absent from durable queue entries. All four cards measured 226px high with no card overflow at desktop width and at an 820px responsive viewport; the page had no horizontal overflow, the plan-only queue row rendered, the empty state stayed hidden, and no new console warnings/errors appeared.

## Peer review

An independent agent reviewed the complete uncommitted diff before this PR. Its findings covered missed TUI state, web LoRA trigger words, cursor-only edits, changelog noise, active quick-transform recovery, queue de-duplication, and blocked-work classification. All findings were addressed, and the agent approved the final delta with no remaining findings.

## Release impact

Patch-level user-visible fix. No schema, API, or version bump is included; release-plz can promote the detailed `[Unreleased]` entries.
