### PR TITLE
fix(ios): harden keyboard viewport recovery

### DIFF
--- a/apps/mobile/src-tauri/Cargo.toml
+++ b/apps/mobile/src-tauri/Cargo.toml
@@ -35,7 +35,7 @@ block2 = "0.6"
 objc2 = "0.6"
 objc2-foundation = { version = "0.3.2", default-features = false, features = ["NSData", "NSError", "NSString", "NSURL"] }
 objc2-photos = { version = "0.3.2", default-features = false, features = ["PHAssetChangeRequest", "PHChangeRequest", "PHPhotoLibrary", "block2", "dispatch2"] }
-objc2-ui-kit = { version = "0.3.2", default-features = false, features = ["UIActivity", "UIActivityViewController", "UIInterface", "UIImage", "UIPasteboard", "UIPopoverPresentationController", "UIPresentationController", "UIResponder", "UIView", "UIViewController", "objc2-core-foundation"] }
+objc2-ui-kit = { version = "0.3.2", default-features = false, features = ["UIActivity", "UIActivityViewController", "UIInterface", "UIImage", "UIPasteboard", "UIPopoverPresentationController", "UIPresentationController", "UIResponder", "UIScrollView", "UIView", "UIViewController", "objc2-core-foundation"] }
 reqwest = { version = "0.13", default-features = false, features = ["rustls-no-provider"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 tauri-plugin-barcode-scanner = "2.4.5"

--- a/apps/mobile/src-tauri/src/viewport.rs
+++ b/apps/mobile/src-tauri/src/viewport.rs
@@ -1,13 +1,14 @@
 /// Native pickers and the software keyboard can leave WKWebView using their
-/// temporary presentation frame. Reapplying the controller's bounds forces
-/// WebKit to publish the real viewport before the web shell lays itself out.
+/// temporary presentation frame or retaining the scroll offset WebKit used to
+/// reveal an editor above the keyboard. Restore both: fixing only the frame
+/// leaves the whole shell shifted upward with an equal dead region below it.
 #[tauri::command]
 pub fn restore_mobile_viewport(window: tauri::WebviewWindow) -> Result<(), String> {
     window
         .with_webview(|webview| {
             #[cfg(target_os = "ios")]
             {
-                use objc2_ui_kit::{UIView, UIViewAutoresizing, UIViewController};
+                use objc2_ui_kit::{UIScrollView, UIView, UIViewAutoresizing, UIViewController};
 
                 // SAFETY: Tauri supplies live UIKit objects and runs this
                 // callback on the main thread. Both pointers are borrowed only
@@ -22,10 +23,21 @@ pub fn restore_mobile_viewport(window: tauri::WebviewWindow) -> Result<(), Strin
                         (view, controller.and_then(UIViewController::view))
                     {
                         root.layoutIfNeeded();
+                        let bounds = root.bounds();
                         view.setAutoresizingMask(
                             UIViewAutoresizing::FlexibleWidth | UIViewAutoresizing::FlexibleHeight,
                         );
-                        view.setFrame(root.bounds());
+                        view.setFrame(bounds);
+
+                        // WKWebView owns a UIScrollView. Keyboard avoidance can
+                        // leave that view scrolled even though Mold's document
+                        // itself is intentionally non-scrolling. Ask through
+                        // Objective-C so this stays scoped to the iOS-only path.
+                        let scroll_view: *const UIScrollView = objc2::msg_send![view, scrollView];
+                        if let Some(scroll_view) = scroll_view.as_ref() {
+                            scroll_view.setContentOffset(bounds.origin);
+                        }
+
                         view.setNeedsLayout();
                         view.layoutIfNeeded();
                     }

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -4945,6 +4945,7 @@ describe("MobileApp foreground resume", () => {
 
   it("restores the native WKWebView frame after the software keyboard dismisses", async () => {
     vi.useFakeTimers();
+    const scrollTo = vi.spyOn(window, "scrollTo").mockImplementation(() => undefined);
     try {
       Object.defineProperty(window, "__TAURI_INTERNALS__", {
         value: {},
@@ -4960,16 +4961,72 @@ describe("MobileApp foreground resume", () => {
       await vi.advanceTimersByTimeAsync(0);
       expect(invoke).toHaveBeenCalledTimes(1);
       expect(invoke).toHaveBeenLastCalledWith("restore_mobile_viewport");
+      expect(scrollTo).toHaveBeenLastCalledWith(0, 0);
 
       await vi.advanceTimersByTimeAsync(400);
       expect(invoke).toHaveBeenCalledTimes(2);
       expect(invoke).toHaveBeenLastCalledWith("restore_mobile_viewport");
+      expect(scrollTo).toHaveBeenCalledTimes(2);
     } finally {
+      scrollTo.mockRestore();
       vi.useRealTimers();
     }
   });
 
-  it("does not restore the viewport while focus moves between keyboard editors", async () => {
+  it("resets only the keyboard-shifted document layer and preserves Create scrolling", async () => {
+    const scrollTo = vi.spyOn(window, "scrollTo").mockImplementation(() => undefined);
+    try {
+      Object.defineProperty(window, "__TAURI_INTERNALS__", {
+        value: {},
+        configurable: true,
+      });
+      wrapper = mountMobileApp();
+      await flushPromises();
+      scrollTo.mockClear();
+
+      const content = wrapper.get(".mobile-content").element as HTMLElement;
+      content.scrollTop = 420;
+      const prompt = fieldControl("Prompt").element as HTMLTextAreaElement;
+      prompt.focus();
+      prompt.blur();
+      await Promise.resolve();
+
+      expect(scrollTo).toHaveBeenCalledWith(0, 0);
+      expect(content.scrollTop).toBe(420);
+    } finally {
+      scrollTo.mockRestore();
+    }
+  });
+
+  it("counters visual-viewport keyboard panning so the header stays below iOS chrome", async () => {
+    const originalViewport = Object.getOwnPropertyDescriptor(window, "visualViewport");
+    const visualViewport = new EventTarget() as EventTarget & { pageTop: number };
+    visualViewport.pageTop = 58;
+    Object.defineProperty(window, "visualViewport", {
+      value: visualViewport,
+      configurable: true,
+    });
+    try {
+      wrapper = mountMobileApp();
+      await flushPromises();
+      expect(
+        document.documentElement.style.getPropertyValue("--mobile-visual-viewport-page-top"),
+      ).toBe("58px");
+
+      visualViewport.pageTop = 0;
+      visualViewport.dispatchEvent(new Event("scroll"));
+      expect(
+        document.documentElement.style.getPropertyValue("--mobile-visual-viewport-page-top"),
+      ).toBe("0px");
+    } finally {
+      wrapper?.unmount();
+      wrapper = null;
+      if (originalViewport) Object.defineProperty(window, "visualViewport", originalViewport);
+      else Reflect.deleteProperty(window, "visualViewport");
+    }
+  });
+
+  it("reanchors the viewport when focus moves between keyboard editors", async () => {
     Object.defineProperty(window, "__TAURI_INTERNALS__", {
       value: {},
       configurable: true,
@@ -4984,10 +5041,11 @@ describe("MobileApp foreground resume", () => {
     negativePrompt.focus();
     await Promise.resolve();
 
-    expect(invoke).not.toHaveBeenCalled();
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(invoke).toHaveBeenLastCalledWith("restore_mobile_viewport");
   });
 
-  it("cancels the settling restore when an editor refocuses before it fires", async () => {
+  it("replaces a dismissal restore with active-keyboard re-anchoring on refocus", async () => {
     vi.useFakeTimers();
     try {
       Object.defineProperty(window, "__TAURI_INTERNALS__", {
@@ -5006,7 +5064,8 @@ describe("MobileApp foreground resume", () => {
 
       prompt.focus();
       await vi.advanceTimersByTimeAsync(400);
-      expect(invoke).toHaveBeenCalledTimes(1);
+      expect(invoke).toHaveBeenCalledTimes(3);
+      expect(invoke).toHaveBeenLastCalledWith("restore_mobile_viewport");
     } finally {
       vi.useRealTimers();
     }

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -4951,8 +4951,21 @@ function usesSoftwareKeyboard(target: EventTarget | null): target is HTMLElement
   return !NON_KEYBOARD_INPUT_TYPES.has(target.type.toLowerCase());
 }
 
+function syncVisualViewportOffset(): void {
+  const pageTop = window.visualViewport?.pageTop ?? window.scrollY;
+  document.documentElement.style.setProperty(
+    "--mobile-visual-viewport-page-top",
+    `${Math.max(0, pageTop)}px`,
+  );
+}
+
 function restoreNativeViewport(): void {
   if (!("__TAURI_INTERNALS__" in window) || unmounted) return;
+  // Keyboard avoidance may scroll WebKit's document layer despite Mold's
+  // non-scrolling root. Reset it without disturbing .mobile-content, whose
+  // independent scroll position belongs to the user.
+  window.scrollTo(0, 0);
+  syncVisualViewportOffset();
   void invoke("restore_mobile_viewport").catch(() => undefined);
 }
 
@@ -4963,7 +4976,21 @@ function cancelKeyboardViewportRestore(): void {
 }
 
 function handleKeyboardFocusIn(event: FocusEvent): void {
-  if (usesSoftwareKeyboard(event.target)) cancelKeyboardViewportRestore();
+  if (!usesSoftwareKeyboard(event.target)) return;
+  const editor = event.target;
+  cancelKeyboardViewportRestore();
+  // iOS pans WKWebView after focus to reveal an editor. Re-anchor after the
+  // focus turn and once more after the keyboard animation; the Create body's
+  // own overflow remains the only scrollable app layer.
+  queueMicrotask(() => {
+    if (unmounted || document.activeElement !== editor) return;
+    restoreNativeViewport();
+    keyboardViewportRestoreTimer = setTimeout(() => {
+      keyboardViewportRestoreTimer = null;
+      if (document.activeElement !== editor) return;
+      restoreNativeViewport();
+    }, KEYBOARD_VIEWPORT_SETTLE_MS);
+  });
 }
 
 /**
@@ -4993,6 +5020,10 @@ watch(resultPreviewError, (error) => {
 onMounted(async () => {
   document.addEventListener("focusin", handleKeyboardFocusIn, true);
   document.addEventListener("focusout", handleKeyboardFocusOut, true);
+  window.addEventListener("scroll", syncVisualViewportOffset, true);
+  window.visualViewport?.addEventListener("resize", syncVisualViewportOffset);
+  window.visualViewport?.addEventListener("scroll", syncVisualViewportOffset);
+  syncVisualViewportOffset();
   if ("__TAURI_INTERNALS__" in window) {
     void invoke("restore_mobile_viewport").catch(() => undefined);
     void import("@tauri-apps/api/app")
@@ -5047,6 +5078,10 @@ onBeforeUnmount(() => {
   document.removeEventListener("visibilitychange", handleForegroundResume);
   document.removeEventListener("focusin", handleKeyboardFocusIn, true);
   document.removeEventListener("focusout", handleKeyboardFocusOut, true);
+  window.removeEventListener("scroll", syncVisualViewportOffset, true);
+  window.visualViewport?.removeEventListener("resize", syncVisualViewportOffset);
+  window.visualViewport?.removeEventListener("scroll", syncVisualViewportOffset);
+  document.documentElement.style.removeProperty("--mobile-visual-viewport-page-top");
   window.removeEventListener("pageshow", handleForegroundResume);
   cancelKeyboardViewportRestore();
   stopPairingDeepLinks?.();

--- a/desktop/src/mobile/mobile.css
+++ b/desktop/src/mobile/mobile.css
@@ -40,9 +40,13 @@ button {
   --radius-card: 16px;
   --radius-pill: 20px;
   --text-large-title: 1.875rem;
-  /* UIKit restores the WKWebView frame after native pickers dismiss. Follow
-     that stable native container instead of WebKit's transient dvh. */
-  height: 100%;
+  /* Stay pinned to the unobscured iPhone viewport. WebKit can leave the root
+     percentage height at its keyboard-reduced value after dismissal; lvh is
+     deliberately independent of that transient visual viewport. */
+  height: 100lvh;
+  /* Counter WebKit's visual-viewport pan while an editor is focused. Without
+     this, keyboard avoidance can move the app header under iOS status chrome. */
+  transform: translateY(var(--mobile-visual-viewport-page-top, 0px));
   min-height: 0;
   box-sizing: border-box;
   overflow: hidden;

--- a/desktop/src/mobile/mobile.css.test.ts
+++ b/desktop/src/mobile/mobile.css.test.ts
@@ -212,15 +212,19 @@ describe("mobile style row", () => {
 });
 
 describe("mobile safe areas", () => {
-  it("follows the native viewport instead of a picker-reduced dynamic viewport", () => {
+  it("pins the shell to the unobscured viewport instead of a keyboard-reduced root", () => {
     const shell = css.match(/\.mobile-shell\s*\{([^}]*)\}/s);
     const header = css.match(/\.mobile-header\s*\{([^}]*)\}/s);
     const content = css.match(/\.mobile-content\s*\{([^}]*)\}/s);
     const tabs = css.match(/\.mobile-tabs\s*\{([^}]*)\}/s);
 
-    expect(shell?.[1]).toMatch(/height:\s*100%\s*;/);
+    expect(shell?.[1]).toMatch(/height:\s*100lvh\s*;/);
+    expect(shell?.[1]).not.toMatch(/height:\s*100%\s*;/);
     expect(shell?.[1]).not.toMatch(/height:\s*100svh\s*;/);
     expect(shell?.[1]).not.toMatch(/height:\s*100dvh\s*;/);
+    expect(shell?.[1]).toMatch(
+      /transform:\s*translateY\(var\(--mobile-visual-viewport-page-top,\s*0px\)\)\s*;/,
+    );
     expect(shell?.[1]).toMatch(/box-sizing:\s*border-box\s*;/);
     for (const rule of [header?.[1], content?.[1], tabs?.[1]]) {
       expect(rule).toContain("env(safe-area-inset-left)");


### PR DESCRIPTION
## Summary

- Use the large viewport height so keyboard-driven WebKit resizing cannot persist as a bottom gap.
- Counter visual-viewport panning so the app header stays below the iOS status bar and Dynamic Island.
- Reset both the document viewport and native WKWebView scroll view after focus and keyboard dismissal.
- Add regression coverage for focus transfer, delayed keyboard animation recovery, visual-viewport offsets, and scroll preservation.

## Root cause

The prior recovery restored the WKWebView frame, but WebKit could retain three independent pieces of state: a keyboard-reduced percentage-height root, a panned visual viewport, and a native scroll-view content offset. Together, these could leave a gap below the app or move the header into the system status area.

## Verification

- Focused mobile tests: 198/198 passed
- iOS checks passed
- Rust and frontend formatting passed
- iOS release-assets validation passed
- Diff validation passed

## Simulator UAT

Tested on iPhone 16 Pro with iOS 18.6:

- Before: keyboard interaction could retain keyboard/accessory space below the shell and shift the app beneath the status bar.
- After: with the full software keyboard open, the Mold header remains below the status bar and Dynamic Island.
- After dismissal, the shell returns to the bottom safe area without a gap or retained keyboard chrome.
- Repeated focus and dismissal cycles remained clean.

## Peer review

Independent agent review found no issues with the native offset reset, visual-viewport compensation, focus timing, scroll preservation, or safe-area behavior.