### PR TITLE
fix(ios): enable library video swiping

### DIFF
--- a/desktop/src/mobile/MobileGalleryViewer.test.ts
+++ b/desktop/src/mobile/MobileGalleryViewer.test.ts
@@ -233,6 +233,29 @@ describe("MobileGalleryViewer", () => {
     await video.trigger("loadedmetadata");
     expect(view.find("[role='status']").exists()).toBe(false);
 
+    await view.get("dialog").trigger("cancel");
+    expect(view.emitted("close")).toHaveLength(1);
+  });
+
+  it("swipes naturally in both directions from native video playback", async () => {
+    const view = mountViewer(
+      {
+        ...image,
+        filename: "developed clip.mp4",
+        format: "mp4",
+      },
+      { position: 2, total: 4 },
+    );
+    await flushPromises();
+
+    const video = view.get("[data-test='gallery-viewer-video']");
+    const stage = view.get("[data-test='gallery-viewer-stage']");
+    const setPointerCapture = vi.fn();
+    Object.defineProperty(stage.element, "setPointerCapture", {
+      value: setPointerCapture,
+      configurable: true,
+    });
+
     await video.trigger("pointerdown", {
       pointerId: 7,
       pointerType: "touch",
@@ -240,17 +263,128 @@ describe("MobileGalleryViewer", () => {
       clientX: 280,
       clientY: 200,
     });
-    await view.get("[data-test='gallery-viewer-stage']").trigger("pointerup", {
+    expect(setPointerCapture).not.toHaveBeenCalled();
+    await stage.trigger("pointermove", {
       pointerId: 7,
+      pointerType: "touch",
+      isPrimary: true,
+      clientX: 180,
+      clientY: 204,
+    });
+    expect(setPointerCapture).toHaveBeenCalledWith(7);
+    await stage.trigger("pointerup", {
+      pointerId: 7,
+      pointerType: "touch",
+      isPrimary: true,
+      clientX: 80,
+      clientY: 204,
+    });
+    expect(view.emitted("next")).toHaveLength(1);
+
+    await video.trigger("pointerdown", {
+      pointerId: 8,
       pointerType: "touch",
       isPrimary: true,
       clientX: 80,
       clientY: 200,
     });
-    expect(view.emitted("next")).toBeUndefined();
+    await stage.trigger("pointerup", {
+      pointerId: 8,
+      pointerType: "touch",
+      isPrimary: true,
+      clientX: 280,
+      clientY: 204,
+    });
+    expect(view.emitted("previous")).toHaveLength(1);
 
-    await view.get("dialog").trigger("cancel");
-    expect(view.emitted("close")).toHaveLength(1);
+    await video.trigger("pointerdown", {
+      pointerId: 9,
+      pointerType: "touch",
+      isPrimary: true,
+      clientX: 180,
+      clientY: 200,
+    });
+    await stage.trigger("pointerup", {
+      pointerId: 9,
+      pointerType: "touch",
+      isPrimary: true,
+      clientX: 184,
+      clientY: 202,
+    });
+    expect(view.emitted("next")).toHaveLength(1);
+    expect(view.emitted("previous")).toHaveLength(1);
+  });
+
+  it("leaves taps and native video scrubber gestures with the playback controls", async () => {
+    const view = mountViewer(
+      {
+        ...image,
+        filename: "developed clip.mp4",
+        format: "mp4",
+      },
+      { position: 2, total: 4 },
+    );
+    await flushPromises();
+
+    const video = view.get("[data-test='gallery-viewer-video']");
+    const stage = view.get("[data-test='gallery-viewer-stage']");
+    const setPointerCapture = vi.fn();
+    Object.defineProperty(stage.element, "setPointerCapture", {
+      value: setPointerCapture,
+      configurable: true,
+    });
+    vi.spyOn(video.element, "getBoundingClientRect").mockReturnValue({
+      top: 0,
+      bottom: 400,
+      left: 0,
+      right: 320,
+      width: 320,
+      height: 400,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    });
+
+    await video.trigger("pointerdown", {
+      pointerId: 10,
+      pointerType: "touch",
+      isPrimary: true,
+      clientX: 180,
+      clientY: 200,
+    });
+    await stage.trigger("pointerup", {
+      pointerId: 10,
+      pointerType: "touch",
+      isPrimary: true,
+      clientX: 184,
+      clientY: 202,
+    });
+    expect(setPointerCapture).not.toHaveBeenCalled();
+
+    await video.trigger("pointerdown", {
+      pointerId: 11,
+      pointerType: "touch",
+      isPrimary: true,
+      clientX: 280,
+      clientY: 380,
+    });
+    await stage.trigger("pointermove", {
+      pointerId: 11,
+      pointerType: "touch",
+      isPrimary: true,
+      clientX: 180,
+      clientY: 380,
+    });
+    await stage.trigger("pointerup", {
+      pointerId: 11,
+      pointerType: "touch",
+      isPrimary: true,
+      clientX: 80,
+      clientY: 380,
+    });
+    expect(setPointerCapture).not.toHaveBeenCalled();
+    expect(view.emitted("next")).toBeUndefined();
+    expect(view.emitted("previous")).toBeUndefined();
   });
 
   it("saves the original MP4 to Photos through the native iOS bridge", async () => {

--- a/desktop/src/mobile/MobileGalleryViewer.vue
+++ b/desktop/src/mobile/MobileGalleryViewer.vue
@@ -119,9 +119,11 @@ let activeMedia: MediaLoad | null = null;
 let gesturePointerId: number | null = null;
 let gestureStartX = 0;
 let gestureStartY = 0;
+let gestureCaptured = false;
 
 const SWIPE_DISTANCE = 48;
 const HORIZONTAL_INTENT_RATIO = 1.25;
+const VIDEO_CONTROL_STRIP_HEIGHT = 64;
 
 interface MediaLoad {
   path: string;
@@ -216,10 +218,26 @@ function isMediaControl(target: EventTarget | null): boolean {
   );
 }
 
+function isSwipeBlockingControl(target: EventTarget | null): boolean {
+  return (
+    target instanceof Element &&
+    !!target.closest("button, input, textarea, select, a, [contenteditable='true']")
+  );
+}
+
+function isVideoControlStrip(event: PointerEvent): boolean {
+  if (!(event.target instanceof Element)) return false;
+  const videoElement = event.target.closest("video");
+  if (!videoElement) return false;
+  const bounds = videoElement.getBoundingClientRect();
+  return bounds.height > 0 && event.clientY >= bounds.bottom - VIDEO_CONTROL_STRIP_HEIGHT;
+}
+
 function beginSwipe(event: PointerEvent): void {
   if (
     props.reusing ||
-    isMediaControl(event.target) ||
+    isSwipeBlockingControl(event.target) ||
+    isVideoControlStrip(event) ||
     event.isPrimary === false ||
     (event.pointerType === "mouse" && event.button !== 0)
   ) {
@@ -229,20 +247,28 @@ function beginSwipe(event: PointerEvent): void {
   gesturePointerId = event.pointerId;
   gestureStartX = event.clientX;
   gestureStartY = event.clientY;
-  if (event.currentTarget instanceof Element && "setPointerCapture" in event.currentTarget) {
-    try {
-      event.currentTarget.setPointerCapture(event.pointerId);
-    } catch {
-      // WebKit can reject pointer capture when the gesture has already ended.
-    }
-  }
+  gestureCaptured = false;
 }
 
 function trackSwipe(event: PointerEvent): void {
   if (gesturePointerId !== event.pointerId) return;
   const deltaX = event.clientX - gestureStartX;
   const deltaY = event.clientY - gestureStartY;
-  if (Math.abs(deltaX) > 12 && Math.abs(deltaX) > Math.abs(deltaY)) event.preventDefault();
+  if (Math.abs(deltaX) > 12 && Math.abs(deltaX) > Math.abs(deltaY)) {
+    event.preventDefault();
+    if (
+      !gestureCaptured &&
+      event.currentTarget instanceof Element &&
+      "setPointerCapture" in event.currentTarget
+    ) {
+      try {
+        event.currentTarget.setPointerCapture(event.pointerId);
+        gestureCaptured = true;
+      } catch {
+        // WebKit can reject pointer capture when the gesture has already ended.
+      }
+    }
+  }
 }
 
 function finishSwipe(event: PointerEvent): void {
@@ -250,6 +276,7 @@ function finishSwipe(event: PointerEvent): void {
   const deltaX = event.clientX - gestureStartX;
   const deltaY = event.clientY - gestureStartY;
   gesturePointerId = null;
+  gestureCaptured = false;
 
   if (
     Math.abs(deltaX) < SWIPE_DISTANCE ||
@@ -261,7 +288,10 @@ function finishSwipe(event: PointerEvent): void {
 }
 
 function cancelSwipe(event?: PointerEvent): void {
-  if (!event || gesturePointerId === event.pointerId) gesturePointerId = null;
+  if (!event || gesturePointerId === event.pointerId) {
+    gesturePointerId = null;
+    gestureCaptured = false;
+  }
 }
 
 function handleViewerKeydown(event: KeyboardEvent): void {
@@ -642,9 +672,13 @@ onBeforeUnmount(() => {
 </template>
 
 <style scoped>
-.gallery-viewer-media:not(video),
+.gallery-viewer-media,
 .gallery-viewer-placeholder {
   touch-action: pan-y;
+}
+
+.gallery-viewer-media:not(video),
+.gallery-viewer-placeholder {
   user-select: none;
   -webkit-user-drag: none;
   -webkit-touch-callout: default;


### PR DESCRIPTION
## Summary

- allow horizontal Library navigation gestures to begin on inline videos
- defer pointer capture until horizontal intent is clear so taps still reach native playback controls
- reserve the bottom native-control strip for scrubbing and playback actions
- apply the viewer swipe touch policy to video media

## Root cause

The mobile gallery viewer rejected every pointer gesture whose target was a video element, and the swipe-specific touch policy excluded videos.

## Verification

- `nix develop -c bun run --cwd desktop test -- src/mobile/MobileGalleryViewer.test.ts` (30 passed)
- `nix develop -c bun run test:desktop` (3,662 passed)
- `nix develop -c bun run build:mobile`
- `nix develop -c ios-check`
- `nix develop -c bash scripts/tests/ios-release-assets.sh`
- focused Prettier check and `git diff --check`
- independent agent review completed; initial pointer-capture finding fixed and re-review approved