### PR TITLE
fix(ios): restore gallery swiping across videos

### DIFF
--- a/desktop/src/mobile/MobileGalleryViewer.test.ts
+++ b/desktop/src/mobile/MobileGalleryViewer.test.ts
@@ -249,13 +249,6 @@ describe("MobileGalleryViewer", () => {
     await flushPromises();
 
     const video = view.get("[data-test='gallery-viewer-video']");
-    const stage = view.get("[data-test='gallery-viewer-stage']");
-    const setPointerCapture = vi.fn();
-    Object.defineProperty(stage.element, "setPointerCapture", {
-      value: setPointerCapture,
-      configurable: true,
-    });
-
     await video.trigger("pointerdown", {
       pointerId: 7,
       pointerType: "touch",
@@ -263,22 +256,24 @@ describe("MobileGalleryViewer", () => {
       clientX: 280,
       clientY: 200,
     });
-    expect(setPointerCapture).not.toHaveBeenCalled();
-    await stage.trigger("pointermove", {
-      pointerId: 7,
-      pointerType: "touch",
-      isPrimary: true,
-      clientX: 180,
-      clientY: 204,
-    });
-    expect(setPointerCapture).toHaveBeenCalledWith(7);
-    await stage.trigger("pointerup", {
-      pointerId: 7,
-      pointerType: "touch",
-      isPrimary: true,
-      clientX: 80,
-      clientY: 204,
-    });
+    window.dispatchEvent(
+      new PointerEvent("pointermove", {
+        pointerId: 7,
+        pointerType: "touch",
+        isPrimary: true,
+        clientX: 180,
+        clientY: 204,
+      }),
+    );
+    window.dispatchEvent(
+      new PointerEvent("pointerup", {
+        pointerId: 7,
+        pointerType: "touch",
+        isPrimary: true,
+        clientX: 80,
+        clientY: 204,
+      }),
+    );
     expect(view.emitted("next")).toHaveLength(1);
 
     await video.trigger("pointerdown", {
@@ -288,13 +283,15 @@ describe("MobileGalleryViewer", () => {
       clientX: 80,
       clientY: 200,
     });
-    await stage.trigger("pointerup", {
-      pointerId: 8,
-      pointerType: "touch",
-      isPrimary: true,
-      clientX: 280,
-      clientY: 204,
-    });
+    window.dispatchEvent(
+      new PointerEvent("pointerup", {
+        pointerId: 8,
+        pointerType: "touch",
+        isPrimary: true,
+        clientX: 280,
+        clientY: 204,
+      }),
+    );
     expect(view.emitted("previous")).toHaveLength(1);
 
     await video.trigger("pointerdown", {
@@ -304,13 +301,15 @@ describe("MobileGalleryViewer", () => {
       clientX: 180,
       clientY: 200,
     });
-    await stage.trigger("pointerup", {
-      pointerId: 9,
-      pointerType: "touch",
-      isPrimary: true,
-      clientX: 184,
-      clientY: 202,
-    });
+    window.dispatchEvent(
+      new PointerEvent("pointerup", {
+        pointerId: 9,
+        pointerType: "touch",
+        isPrimary: true,
+        clientX: 184,
+        clientY: 202,
+      }),
+    );
     expect(view.emitted("next")).toHaveLength(1);
     expect(view.emitted("previous")).toHaveLength(1);
   });
@@ -328,11 +327,6 @@ describe("MobileGalleryViewer", () => {
 
     const video = view.get("[data-test='gallery-viewer-video']");
     const stage = view.get("[data-test='gallery-viewer-stage']");
-    const setPointerCapture = vi.fn();
-    Object.defineProperty(stage.element, "setPointerCapture", {
-      value: setPointerCapture,
-      configurable: true,
-    });
     vi.spyOn(video.element, "getBoundingClientRect").mockReturnValue({
       top: 0,
       bottom: 400,
@@ -359,8 +353,6 @@ describe("MobileGalleryViewer", () => {
       clientX: 184,
       clientY: 202,
     });
-    expect(setPointerCapture).not.toHaveBeenCalled();
-
     await video.trigger("pointerdown", {
       pointerId: 11,
       pointerType: "touch",
@@ -382,7 +374,6 @@ describe("MobileGalleryViewer", () => {
       clientX: 80,
       clientY: 380,
     });
-    expect(setPointerCapture).not.toHaveBeenCalled();
     expect(view.emitted("next")).toBeUndefined();
     expect(view.emitted("previous")).toBeUndefined();
   });

--- a/desktop/src/mobile/MobileGalleryViewer.vue
+++ b/desktop/src/mobile/MobileGalleryViewer.vue
@@ -119,7 +119,6 @@ let activeMedia: MediaLoad | null = null;
 let gesturePointerId: number | null = null;
 let gestureStartX = 0;
 let gestureStartY = 0;
-let gestureCaptured = false;
 
 const SWIPE_DISTANCE = 48;
 const HORIZONTAL_INTENT_RATIO = 1.25;
@@ -247,28 +246,13 @@ function beginSwipe(event: PointerEvent): void {
   gesturePointerId = event.pointerId;
   gestureStartX = event.clientX;
   gestureStartY = event.clientY;
-  gestureCaptured = false;
 }
 
 function trackSwipe(event: PointerEvent): void {
   if (gesturePointerId !== event.pointerId) return;
   const deltaX = event.clientX - gestureStartX;
   const deltaY = event.clientY - gestureStartY;
-  if (Math.abs(deltaX) > 12 && Math.abs(deltaX) > Math.abs(deltaY)) {
-    event.preventDefault();
-    if (
-      !gestureCaptured &&
-      event.currentTarget instanceof Element &&
-      "setPointerCapture" in event.currentTarget
-    ) {
-      try {
-        event.currentTarget.setPointerCapture(event.pointerId);
-        gestureCaptured = true;
-      } catch {
-        // WebKit can reject pointer capture when the gesture has already ended.
-      }
-    }
-  }
+  if (Math.abs(deltaX) > 12 && Math.abs(deltaX) > Math.abs(deltaY)) event.preventDefault();
 }
 
 function finishSwipe(event: PointerEvent): void {
@@ -276,7 +260,6 @@ function finishSwipe(event: PointerEvent): void {
   const deltaX = event.clientX - gestureStartX;
   const deltaY = event.clientY - gestureStartY;
   gesturePointerId = null;
-  gestureCaptured = false;
 
   if (
     Math.abs(deltaX) < SWIPE_DISTANCE ||
@@ -288,10 +271,7 @@ function finishSwipe(event: PointerEvent): void {
 }
 
 function cancelSwipe(event?: PointerEvent): void {
-  if (!event || gesturePointerId === event.pointerId) {
-    gesturePointerId = null;
-    gestureCaptured = false;
-  }
+  if (!event || gesturePointerId === event.pointerId) gesturePointerId = null;
 }
 
 function handleViewerKeydown(event: KeyboardEvent): void {
@@ -414,6 +394,14 @@ async function performVideoExport(options: VideoExportOptions): Promise<void> {
 
 onMounted(() => {
   mounted = true;
+  // WKWebView's native video layer can stop the target/bubble phase once a
+  // playback control recognizes the touch. Keep the active swipe at the
+  // window capture boundary so image -> video -> image navigation cannot be
+  // stranded by a media element, while the excluded control strip still gets
+  // ordinary taps and scrubbing gestures.
+  window.addEventListener("pointermove", trackSwipe, { capture: true, passive: false });
+  window.addEventListener("pointerup", finishSwipe, true);
+  window.addEventListener("pointercancel", cancelSwipe, true);
   restoreFocusElement = document.activeElement as HTMLElement | null;
   try {
     dialog.value?.showModal();
@@ -426,6 +414,10 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   mounted = false;
+  window.removeEventListener("pointermove", trackSwipe, true);
+  window.removeEventListener("pointerup", finishSwipe, true);
+  window.removeEventListener("pointercancel", cancelSwipe, true);
+  cancelSwipe();
   loadEpoch += 1;
   if (dialog.value?.open && typeof dialog.value.close === "function") dialog.value.close();
   evictLoad(activeMedia);
@@ -480,11 +472,10 @@ onBeforeUnmount(() => {
     <div
       class="gallery-viewer-stage"
       data-test="gallery-viewer-stage"
-      @pointerdown="beginSwipe"
+      @pointerdown.capture="beginSwipe"
       @pointermove="trackSwipe"
       @pointerup="finishSwipe"
       @pointercancel="cancelSwipe"
-      @lostpointercapture="cancelSwipe"
     >
       <img
         v-if="!mediaUrl"


### PR DESCRIPTION
## Summary

- keep gallery swipe tracking at the window capture boundary so native iOS video playback cannot strand a gesture
- remove delayed pointer capture, which regressed ordinary image swiping
- preserve taps and scrubbing in the native video control strip
- cover the native-video event boundary with a regression test

## Root cause

PR #1127 deferred pointer capture for every gallery item and still relied on pointer move/up events bubbling out of the native `<video>` surface. In WKWebView, the native media layer can consume that target/bubble phase, leaving both normal image gestures and video transitions unreliable.

## Verification

- iPhone 16 Pro Simulator (iOS 18.6), disposable image/video/image gallery: swipe-only navigation verified `2 of 3` image → `1 of 3` video → `2 of 3` image → `3 of 3` image; no arrow buttons used
- `nix develop -c bun run --cwd desktop test -- src/mobile/MobileGalleryViewer.test.ts` (30 passed)
- `nix develop -c bun run test:desktop` (3,665 passed)
- `nix develop -c bun run build:mobile`
- `nix develop -c ios-check`
- `nix develop -c bash scripts/tests/ios-release-assets.sh`
- focused Prettier check and `git diff --check`
