### PR TITLE
fix(ios): align generation controls with desktop

### DIFF
--- a/desktop/src/mobile/MobileAdvancedSheet.vue
+++ b/desktop/src/mobile/MobileAdvancedSheet.vue
@@ -36,26 +36,28 @@ defineEmits<{
           {{ count }}
         </span>
       </div>
-      <button
-        class="mobile-advanced-sheet-close"
-        type="button"
-        aria-label="Close advanced settings"
-        data-test="mobile-advanced-close"
-        @click="$emit('close')"
-      >
-        <span aria-hidden="true">✕</span>
-      </button>
+      <div class="mobile-advanced-sheet-actions">
+        <button
+          class="mobile-advanced-sheet-reset"
+          type="button"
+          data-test="mobile-advanced-reset"
+          @click="$emit('reset')"
+        >
+          Reset
+        </button>
+        <button
+          class="mobile-advanced-sheet-close"
+          type="button"
+          aria-label="Close advanced settings"
+          data-test="mobile-advanced-close"
+          @click="$emit('close')"
+        >
+          <span aria-hidden="true">✕</span>
+        </button>
+      </div>
     </header>
     <div class="mobile-advanced-sheet-body">
       <slot />
-      <button
-        class="mobile-advanced-sheet-reset"
-        type="button"
-        data-test="mobile-advanced-reset"
-        @click="$emit('reset')"
-      >
-        Reset advanced
-      </button>
     </div>
   </div>
 </template>

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -14,6 +14,7 @@ const {
   sseStream,
   streamableMediaUrl,
   evictMedia,
+  applyH3BoundaryFit,
   applySourceFitPreprocess,
   expandPrompt,
   remixPrompt,
@@ -37,6 +38,7 @@ const {
   sseStream: vi.fn(),
   streamableMediaUrl: vi.fn(),
   evictMedia: vi.fn(),
+  applyH3BoundaryFit: vi.fn(),
   applySourceFitPreprocess: vi.fn(),
   expandPrompt: vi.fn(),
   remixPrompt: vi.fn(),
@@ -82,7 +84,7 @@ vi.mock("@studio/api/client", async (importOriginal) => ({
   apiJsonTo,
 }));
 vi.mock("../lib/api/sse", () => ({ sseStream }));
-vi.mock("../lib/sourceFitPreprocess", () => ({ applySourceFitPreprocess }));
+vi.mock("../lib/sourceFitPreprocess", () => ({ applyH3BoundaryFit, applySourceFitPreprocess }));
 vi.mock("../lib/api/expand", () => ({ expandPrompt }));
 vi.mock("../lib/api/remix", () => ({ remixPrompt }));
 vi.mock("../lib/api/catalog", async (importOriginal) => ({
@@ -320,6 +322,7 @@ beforeEach(() => {
   );
   streamableMediaUrl.mockReset().mockResolvedValue("https://studio/media/full-video");
   evictMedia.mockReset();
+  applyH3BoundaryFit.mockReset().mockImplementation((state) => Promise.resolve(state));
   applySourceFitPreprocess.mockReset().mockImplementation((input) =>
     Promise.resolve({
       source: input.source,
@@ -1960,14 +1963,12 @@ describe("MobileApp generation queue", () => {
 
     wrapper = mountMobileApp();
     await flushPromises();
-    expect(wrapper.get("[data-orientation='square']").attributes("aria-pressed")).toBe("true");
-    expect(wrapper.get("[data-aspect='1:1']").attributes("aria-pressed")).toBe("true");
+    expect(wrapper.get("[data-shape='1:1']").attributes("aria-checked")).toBe("true");
     expect(wrapper.get("[data-test='mobile-resolution-tier-dims']").text()).toBe("1024 × 1024 px");
 
     await fieldControl("Model").setValue(model.name);
     await flushPromises();
-    expect(wrapper.get("[data-orientation='landscape']").attributes("aria-pressed")).toBe("true");
-    expect(wrapper.get("[data-aspect='3:2']").attributes("aria-pressed")).toBe("true");
+    expect(wrapper.get("[data-shape='3:2']").attributes("aria-checked")).toBe("true");
     expect(wrapper.get("[data-test='mobile-resolution-tier-dims']").text()).toBe("768 × 512 px");
 
     await submitPrompt("use the video defaults");
@@ -2311,10 +2312,10 @@ describe("MobileApp generation queue", () => {
     await wrapper.get("input[aria-label='Custom width']").setValue("2000");
     await wrapper.get("input[aria-label='Custom height']").setValue("2000");
     await flushPromises();
-    // An oversized custom size is advisory only — the server is the
-    // authority, so Develop stays enabled and the size still submits.
+    // This legacy model's synthesized profile leaves custom sizes to server
+    // admission, so the exact model wiring must not invent a local blocker.
     expect(wrapper.find("[data-test='mobile-resolution-error']").exists()).toBe(false);
-    expect(wrapper.get("[data-test='mobile-resolution-warning']").text()).toContain("1.8 MP");
+    expect(wrapper.find("[data-test='mobile-resolution-warning']").exists()).toBe(false);
     expect(wrapper.get("[data-test='mobile-develop-button']").attributes()).not.toHaveProperty(
       "disabled",
     );
@@ -4701,6 +4702,67 @@ describe("MobileApp wan source conditioning", () => {
     );
   });
 
+  it("uses the selected H3 model profile and queues its conditioned render", async () => {
+    const h3Model: ModelEntry = {
+      ...wanModel,
+      name: "minimax-h3-fl2va:comfy-pruned-int8",
+      family: "minimax-h3",
+      hf_repo: "Comfy-Org/MiniMax-H3",
+      default_steps: 21,
+      default_guidance: 0,
+      default_width: 1344,
+      default_height: 768,
+      default_frames: 124,
+      default_fps: 24,
+      source_image: "required",
+      recommended_dimensions: [
+        { width: 1344, height: 768 },
+        { width: 1024, height: 768 },
+        { width: 768, height: 768 },
+        { width: 768, height: 1024 },
+      ],
+      dimension_alignment: 32,
+      max_pixels: 1344 * 768,
+    };
+    serveWan(h3Model);
+    wrapper = mountMobileApp();
+    await flushPromises();
+
+    expect(wrapper.find("[data-orientation]").exists()).toBe(false);
+    expect(
+      wrapper
+        .findAll("[data-test='mobile-resolution-shape'] button")
+        .map((button) => button.text()),
+    ).toEqual(["7:4", "4:3", "1:1", "3:4"]);
+    expect(wrapper.get("[data-shape='7:4']").attributes("aria-checked")).toBe("true");
+
+    const liveForm = wrapper.getComponent(MobileLoraControls).props("form") as GenerateForm;
+    liveForm.h3Authoring = {
+      firstFrame: {
+        filename: "opening.png",
+        mimeType: "image/png",
+        width: 1344,
+        height: 768,
+        data: "QUJD",
+      },
+      lastFrame: null,
+      references: [],
+    };
+    await fieldControl("Prompt").setValue("a pickup crossing a desert at dusk");
+    await wrapper.get("[data-test='mobile-develop-button']").trigger("click");
+    await vi.waitFor(() => expect(openStreams).toHaveLength(1));
+
+    expect(openStreams[0]?.path).toBe("/api/generate/stream");
+    expect(openStreams[0]?.options.body).toMatchObject({
+      model: h3Model.name,
+      width: 1344,
+      height: 768,
+      frames: 124,
+      fps: 24,
+      source_image: "QUJD",
+    });
+  });
+
   it("keeps the well and offers no end frame when the host advertises no contract", async () => {
     serveWan(wanModel);
     wrapper = mountMobileApp();
@@ -5349,6 +5411,9 @@ describe("MobileApp create settings reset", () => {
     expect(wrapper.get("[data-test='mobile-settings-reset']").attributes("aria-label")).toBe(
       "Reset settings to model defaults",
     );
+    expect(wrapper.get("[data-test='mobile-settings-reset']").element.parentElement).toBe(
+      wrapper.get(".mobile-create-head").element,
+    );
   });
 
   it("badges and resets LTX-2 guidance overrides from the Advanced sheet", async () => {
@@ -5356,6 +5421,9 @@ describe("MobileApp create settings reset", () => {
     await flushPromises();
 
     await wrapper.get("[data-test='mobile-open-advanced']").trigger("click");
+    expect(wrapper.get("[data-test='mobile-advanced-reset']").element.closest("header")).toBe(
+      wrapper.get(".mobile-advanced-sheet-head").element,
+    );
     await wrapper.get("[data-test='mobile-ltx2-disclosure']").trigger("click");
     await wrapper.get("[data-test='mobile-ltx2-stg-scale']").setValue("1.5");
     await flushPromises();
@@ -5428,6 +5496,7 @@ describe("MobileApp create settings reset", () => {
     liveForm.controlScale = 0.8;
     liveForm.imageAttachments = ["ATT"];
     liveForm.negativePrompt = "blurry";
+    liveForm.cameraControl = "dolly-in";
     await flushPromises();
 
     await wrapper.get("[data-test='mobile-open-advanced']").trigger("click");
@@ -5444,6 +5513,7 @@ describe("MobileApp create settings reset", () => {
     expect(liveForm.controlScale).toBe(0.8);
     expect(liveForm.imageAttachments).toEqual(["ATT"]);
     expect(liveForm.negativePrompt).toBe("");
+    expect(liveForm.cameraControl).toBeNull();
   });
 });
 
@@ -5937,8 +6007,7 @@ describe("MobileApp gallery", () => {
     );
     expect(wrapper.get("#mobile-prompt").element).toHaveProperty("value", print.metadata.prompt);
     expect(fieldControl("Negative prompt").element).toHaveProperty("value", "calm water");
-    expect(wrapper.get("[data-orientation='landscape']").attributes("aria-pressed")).toBe("true");
-    expect(wrapper.get("[data-aspect='3:2']").attributes("aria-pressed")).toBe("true");
+    expect(wrapper.get("[data-shape='3:2']").attributes("aria-checked")).toBe("true");
     expect(wrapper.get("[data-test='mobile-resolution-tier-dims']").text()).toBe("768 × 512 px");
     expect(fieldControl("Format").element).toHaveProperty("value", "mp4");
     expect(fieldControl("Frames").element).toHaveProperty("value", "121");

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -137,9 +137,9 @@ import {
   parseCameraControlAvailability,
   syncCameraMotionLora,
 } from "@studio/lib/cameraMotion";
-import { emptyGuidanceOverrides, guidanceOverridesAreEmpty } from "@studio/lib/guidanceOverrides";
+import { guidanceOverridesAreEmpty } from "@studio/lib/guidanceOverrides";
 import { negativePromptWireValue } from "@studio/lib/negativePrompt";
-import { emptyWanRecipe, wanRecipeCount } from "@studio/lib/wanRecipe";
+import { wanRecipeCount } from "@studio/lib/wanRecipe";
 import {
   buildAutoChainRequest,
   buildGenerationEstimateRequest,
@@ -155,6 +155,7 @@ import {
   newGenerateForm,
   normalizeLegacyNegativeSnapshot,
   reconcileModelCapabilities,
+  resetAdvancedToModelDefaults,
   resetFormToModelDefaults,
   type GenerateForm,
 } from "../lib/generateForm";
@@ -521,20 +522,10 @@ function resetCreateSettings(): void {
   resetFormToModelDefaults(form, selectedGenerationModel.value);
 }
 
-/** Restore only the advanced-tier fields to their defaults; prompt, model,
- * dimensions, steps, guidance, seed, batch, and staged source media (which
- * lives in the primary form, not the Advanced sheet) are left untouched. */
+/** Match the desktop Advanced reset: restore model-owned generation controls
+ * while preserving the prompt, selected model, batch, and staged source media. */
 function resetAdvancedSettings(): void {
-  const defaults = newGenerateForm();
-  // Reset restores the model's advertised default negative (wan), not an
-  // explicit empty opt-out.
-  form.negativePrompt = form.negativePromptDefault;
-  form.scheduler = defaults.scheduler;
-  form.cfgPlus = defaults.cfgPlus;
-  form.upscaleModel = defaults.upscaleModel;
-  form.loras = [];
-  form.guidanceOverrides = emptyGuidanceOverrides();
-  form.wanRecipe = emptyWanRecipe();
+  resetAdvancedToModelDefaults(form, selectedGenerationModel.value);
 }
 const preparingGeneration = ref(false);
 const generationSubmissionPhase = ref<"preparing" | "placement" | null>(null);
@@ -5245,7 +5236,18 @@ onBeforeUnmount(() => {
           </div>
         </div>
         <template v-else>
-          <h1 class="section-title">Create</h1>
+          <div class="mobile-create-head">
+            <h1 class="section-title">Create</h1>
+            <button
+              class="mobile-settings-reset"
+              type="button"
+              data-test="mobile-settings-reset"
+              aria-label="Reset settings to model defaults"
+              @click="resetCreateSettings"
+            >
+              ↺ Reset
+            </button>
+          </div>
           <p class="section-note">Develop on {{ selectedHost.name }}</p>
           <label v-if="connectedHosts.length > 1" class="field">
             <span>Host</span>
@@ -5597,6 +5599,7 @@ onBeforeUnmount(() => {
 
             <MobileSharedParams
               :form="form"
+              :model="selectedGenerationModel"
               :duration-model="selectedGenerationModel"
               :last-seed="generation.lastSeedUsed"
               :disabled="loadingModels"
@@ -5623,15 +5626,6 @@ onBeforeUnmount(() => {
                   data-test="mobile-advanced-trigger-count"
                   >{{ advancedActiveCount }}</span
                 >
-              </button>
-              <button
-                class="mobile-settings-reset"
-                type="button"
-                data-test="mobile-settings-reset"
-                aria-label="Reset settings to model defaults"
-                @click="resetCreateSettings"
-              >
-                ↺ Reset
               </button>
             </div>
 

--- a/desktop/src/mobile/MobileResolutionPicker.test.ts
+++ b/desktop/src/mobile/MobileResolutionPicker.test.ts
@@ -34,38 +34,32 @@ function mountPicker(
   return { wrapper: mount(Harness), state };
 }
 
-function buttonWithText(wrapper: VueWrapper, text: string) {
-  const button = wrapper.findAll("button").find((candidate) => candidate.text() === text);
-  if (!button) throw new Error(`Missing ${text} button`);
-  return button;
-}
-
 function tierSegments(wrapper: VueWrapper) {
   return wrapper.get("[data-test='mobile-resolution-tier']").findAll("button");
 }
 
 describe("MobileResolutionPicker", () => {
-  it("reuses family presets and applies an orientation-aware resolution", async () => {
+  it("uses the shared desktop shape picker without orientation tabs", async () => {
     const { wrapper, state } = mountPicker(1024, 1024, "flux");
 
     expect(wrapper.find("[data-test='mobile-resolution-summary']").exists()).toBe(false);
     expect(wrapper.get("[data-test='mobile-resolution-announcement']").text()).toBe(
       "Selected resolution: 1024 by 1024 pixels, 1:1, Square.",
     );
-    expect(wrapper.get("[data-orientation='square']").attributes("aria-pressed")).toBe("true");
-    expect(wrapper.get("[data-aspect='1:1']").attributes("aria-pressed")).toBe("true");
+    expect(wrapper.find("[data-orientation]").exists()).toBe(false);
+    expect(wrapper.get("[data-shape='square']").attributes("aria-checked")).toBe("true");
     const active = wrapper.get("[data-test='mobile-resolution-tier'] [aria-checked='true']");
     expect(active.get(".ms-seg__label").text()).toBe("1 MP");
     expect(active.get(".ms-seg__sub").text()).toBe("High");
 
-    await wrapper.get("[data-orientation='portrait']").trigger("click");
+    await wrapper.get("[data-shape='portrait']").trigger("click");
     expect(state).toMatchObject({ width: 768, height: 1024 });
     expect(wrapper.get("[data-test='mobile-resolution-announcement']").text()).toBe(
       "Selected resolution: 768 by 1024 pixels, 3:4, Portrait.",
     );
-    expect(wrapper.get("[data-aspect='3:4']").attributes("aria-pressed")).toBe("true");
+    expect(wrapper.get("[data-shape='portrait']").attributes("aria-checked")).toBe("true");
 
-    await wrapper.get("[data-aspect='9:16']").trigger("click");
+    await wrapper.get("[data-shape='tall']").trigger("click");
     expect(state).toMatchObject({ width: 576, height: 1024 });
   });
 
@@ -73,23 +67,17 @@ describe("MobileResolutionPicker", () => {
     const { wrapper, state } = mountPicker(1328, 1328, "qwen-image");
 
     expect(wrapper.find("[data-test='mobile-resolution-tier']").exists()).toBe(true);
-    expect(wrapper.findAll(".mobile-resolution-aspect").map((button) => button.text())).toEqual([
+    expect(wrapper.findAll(".ms-shape__btn").map((button) => button.text())).toEqual([
       "1:1",
-    ]);
-    await wrapper.get("[data-orientation='portrait']").trigger("click");
-    expect(wrapper.findAll(".mobile-resolution-aspect").map((button) => button.text())).toEqual([
-      "≈9:16",
       "3:4",
-      "2:3",
-    ]);
-    await wrapper.get("[data-aspect='≈9:16']").trigger("click");
-    expect(state).toMatchObject({ width: 928, height: 1664 });
-    await wrapper.get("[data-orientation='landscape']").trigger("click");
-    expect(wrapper.findAll(".mobile-resolution-aspect").map((button) => button.text())).toEqual([
-      "≈16:9",
       "4:3",
-      "3:2",
+      "16:9",
+      "9:16",
     ]);
+    await wrapper.get("[data-shape='tall']").trigger("click");
+    expect(state).toMatchObject({ width: 928, height: 1664 });
+    await wrapper.get("[data-shape='wide']").trigger("click");
+    expect(state).toMatchObject({ width: 1664, height: 928 });
   });
 
   it("projects the selected tier's exact pixel dimensions under the control", async () => {
@@ -137,28 +125,15 @@ describe("MobileResolutionPicker", () => {
     expect(exact[0]?.attributes("aria-checked")).toBe("true");
   });
 
-  it("shows each aspect choice as a proportionally accurate frame", () => {
+  it("renders shared proportional shape swatches", () => {
     const { wrapper } = mountPicker(704, 1216, "ltx2");
-    const choices = wrapper.findAll(".mobile-resolution-aspect");
-
-    expect(choices.map((choice) => choice.text())).toEqual(["11:19", "9:16", "2:3", "17:30"]);
-    const frames = choices.map((choice) =>
-      choice.get("[data-test='mobile-resolution-aspect-shape']"),
-    );
-    expect(frames.every((frame) => frame.attributes("aria-hidden") === "true")).toBe(true);
-    expect(
-      frames.every(
-        (frame) => Number.parseFloat((frame.element as HTMLElement).style.height) === 28,
-      ),
-    ).toBe(true);
-
-    const widths = frames.map((frame) =>
-      Number.parseFloat((frame.element as HTMLElement).style.width),
-    );
-    expect(widths[1]).toBeLessThan(widths[3]!);
-    expect(widths[3]).toBeLessThan(widths[0]!);
-    expect(widths[0]).toBeLessThan(widths[2]!);
-    expect(choices[0]?.attributes("aria-label")).toBe("11 by 19 aspect ratio");
+    const choices = wrapper.findAll(".ms-shape__btn");
+    expect(choices.map((choice) => choice.text())).toEqual(["1:1", "16:9", "9:16"]);
+    const frames = wrapper.findAll(".ms-shape__swatch");
+    expect(frames).toHaveLength(3);
+    expect(frames[0]?.attributes("style")).toContain("width: 24px");
+    expect(frames[1]?.attributes("style")).toContain("width: 27px");
+    expect(frames[2]?.attributes("style")).toContain("height: 27px");
   });
 
   it("falls back to iPhone-friendly custom fields and snaps values to 16", async () => {
@@ -215,18 +190,20 @@ describe("MobileResolutionPicker", () => {
   });
 
   it("highlights the closest aspect chip as approximate for a custom size", () => {
-    const { wrapper } = mountPicker(1000, 600, "flux");
-    const approximate = wrapper.findAll(".mobile-resolution-aspect.is-approximate");
-    expect(approximate).toHaveLength(1);
-    expect(approximate[0]!.classes()).toContain("is-selected");
-    expect(approximate[0]!.text()).toContain("≈");
-    expect(approximate[0]!.attributes("aria-label")).toContain("Approximately");
+    const { wrapper } = mountPicker(1000, 600, "flux", null, {
+      name: "flux:profiled",
+      family: "flux",
+      recommended_dimensions: [{ width: 1024, height: 576 }],
+    } as ModelEntry);
+    const approximate = wrapper.get("[data-approximate='true']");
+    expect(approximate.text()).toContain("≈");
+    expect(approximate.attributes("aria-label")).toContain("closest match");
   });
 
   it("keeps exact presets unmarked", () => {
     const { wrapper } = mountPicker(1024, 1024, "flux");
-    expect(wrapper.findAll(".mobile-resolution-aspect.is-approximate")).toHaveLength(0);
-    expect(wrapper.get("[data-aspect='1:1']").text()).not.toContain("≈");
+    expect(wrapper.find("[data-approximate='true']").exists()).toBe(false);
+    expect(wrapper.get("[data-shape='square']").text()).not.toContain("≈");
   });
 
   it("advises on custom sizes above the 1.8 MP guideline without blocking", async () => {
@@ -246,21 +223,16 @@ describe("MobileResolutionPicker", () => {
     expect(picker.emitted("validity-change")?.at(-1)).toEqual([true]);
   });
 
-  it("exposes every orientation recommended by the shared video contract", async () => {
+  it("exposes portrait and landscape shapes together from the shared contract", async () => {
     const { wrapper, state } = mountPicker(1024, 576, "ltx2");
 
-    expect(wrapper.get("[data-orientation='square']").attributes("disabled")).toBeUndefined();
-    expect(wrapper.get("[data-orientation='portrait']").attributes("disabled")).toBeUndefined();
-    expect(wrapper.get("[data-orientation='landscape']").attributes("aria-pressed")).toBe("true");
-    expect(wrapper.findAll(".mobile-resolution-aspect").map((button) => button.text())).toEqual([
-      "22:15",
-      "3:2",
+    expect(wrapper.findAll(".ms-shape__btn").map((button) => button.text())).toEqual([
+      "1:1",
       "16:9",
-      "19:11",
-      "30:17",
+      "9:16",
     ]);
-
-    await wrapper.get("[data-orientation='portrait']").trigger("click");
+    expect(wrapper.get("[data-shape='wide']").attributes("aria-checked")).toBe("true");
+    await wrapper.get("[data-shape='tall']").trigger("click");
     await flushPromises();
     expect(state).toMatchObject({ width: 576, height: 1024 });
   });
@@ -270,7 +242,7 @@ describe("MobileResolutionPicker", () => {
       props: { family: "sdxl", width: 1024, height: 1024 },
     });
 
-    await buttonWithText(wrapper, "Portrait").trigger("click");
+    await wrapper.get("[data-shape='portrait']").trigger("click");
     expect(wrapper.emitted("update:width")).toEqual([[896]]);
     expect(wrapper.emitted("update:height")).toEqual([[1152]]);
   });

--- a/desktop/src/mobile/MobileResolutionPicker.vue
+++ b/desktop/src/mobile/MobileResolutionPicker.vue
@@ -1,12 +1,17 @@
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
+import ShapePicker from "@ui/components/ShapePicker.vue";
 import SegmentedControl from "@ui/components/SegmentedControl.vue";
+import { aspectsSupportedByPresets } from "@ui/lib/resolution";
 import { resolutionValidationError, resolutionValidationWarning } from "../lib/generateValidation";
 import {
+  aspectIdFor,
   aspectRatioLabel,
   matchPreset,
   orientationLabel,
+  presetsForAspectGroup,
   presetsForModel,
+  presetsNearRatio,
   type ResolutionPreset,
 } from "../lib/resolutions";
 import type { ModelEntry } from "../lib/api/types";
@@ -16,16 +21,16 @@ import {
   sourceResolutionStatus,
   type SourceDimensions,
 } from "@studio/lib/sourceResolution";
-import { effectiveGenerationRecipe } from "@studio/lib/generationProfile";
 import {
-  aspectsForOrientation,
+  closestProfileAspect,
+  effectiveGenerationRecipe,
+  profileAspectOptions,
+} from "@studio/lib/generationProfile";
+import {
   closestResolutionPreset,
-  MOBILE_RESOLUTION_ORIENTATIONS,
-  presetsForOrientation,
   resolutionTierLabel,
   snapMobileDimension,
   sortedResolutionTiers,
-  type ResolutionOrientation,
 } from "./resolutionPicker";
 
 const props = withDefaults(
@@ -82,57 +87,39 @@ const sourceStatus = computed(() =>
   sourceResolution.value ? sourceResolutionStatus(sourceResolution.value) : null,
 );
 watch(resolutionError, (next) => emit("validity-change", !next), { immediate: true });
-const aspectOptions = computed(() =>
-  aspectsForOrientation(presets.value, currentOrientation.value),
+const canonicalShapeOptions = computed(() => {
+  return props.model
+    ? profileAspectOptions(props.model, props.pipeline)
+    : aspectsSupportedByPresets(presets.value);
+});
+const shapeOptions = computed(() => {
+  const source = sourceResolution.value;
+  return source
+    ? [
+        ...canonicalShapeOptions.value,
+        { id: "source", label: "Source", ratio: source.output.width / source.output.height },
+      ]
+    : canonicalShapeOptions.value;
+});
+const closestShape = computed(() =>
+  props.model ? closestProfileAspect(props.model, props.pipeline, width.value, height.value) : null,
 );
-/** With no exact preset match (custom size from the manual fields), the
- * closest preset's aspect chip lights up marked "≈" — never left blank. */
-const approximateAspect = computed(() =>
-  currentPreset.value
-    ? null
-    : (closestResolutionPreset(presets.value, width.value, height.value)?.aspect ?? null),
+const canonicalShapeId = computed(
+  () => closestShape.value?.id ?? aspectIdFor(width.value, height.value) ?? "",
+);
+const explicitShapeId = ref<string | null>(null);
+const shapeId = computed(() => {
+  const explicit = explicitShapeId.value;
+  if (explicit === "source" && followsSource.value) return "source";
+  if (explicit && explicit !== "source" && canonicalShapeId.value === explicit) return explicit;
+  return followsSource.value ? "source" : canonicalShapeId.value;
+});
+const shapeApproximate = computed(
+  () => shapeId.value !== "source" && shapeId.value !== "" && closestShape.value?.exact === false,
 );
 const tierOptions = computed(() =>
   currentPreset.value ? sortedResolutionTiers(presets.value, currentPreset.value.aspect) : [],
 );
-
-function proportionalShapeStyle(
-  shapeWidth: number,
-  shapeHeight: number,
-  maxWidth: number,
-  maxHeight: number,
-): Record<string, string> {
-  const safeWidth = Math.max(1, shapeWidth);
-  const safeHeight = Math.max(1, shapeHeight);
-  const scale = Math.min(maxWidth / safeWidth, maxHeight / safeHeight);
-  return {
-    width: `${(safeWidth * scale).toFixed(2)}px`,
-    height: `${(safeHeight * scale).toFixed(2)}px`,
-  };
-}
-
-function aspectDimensions(aspect: string): [number, number] {
-  const preset = presets.value.find((candidate) => candidate.aspect === aspect);
-  if (preset) return [preset.width, preset.height];
-  const match = aspect.replace(/^≈/, "").match(/^(\d+(?:\.\d+)?):(\d+(?:\.\d+)?)$/);
-  if (!match) return [1, 1];
-  return [Number(match[1]), Number(match[2])];
-}
-
-function aspectOptionShapeStyle(aspect: string): Record<string, string> {
-  const [shapeWidth, shapeHeight] = aspectDimensions(aspect);
-  return proportionalShapeStyle(shapeWidth, shapeHeight, 30, 28);
-}
-
-function aspectAccessibleLabel(aspect: string): string {
-  const approximate = aspect.startsWith("≈");
-  const [left, right] = aspect.replace(/^≈/, "").split(":");
-  return `${approximate ? "Approximately " : ""}${left} by ${right} aspect ratio`;
-}
-
-function isOrientationAvailable(orientation: ResolutionOrientation): boolean {
-  return presetsForOrientation(presets.value, orientation).length > 0;
-}
 
 function applyResolution(preset: ResolutionPreset | null): void {
   if (!preset) return;
@@ -141,20 +128,18 @@ function applyResolution(preset: ResolutionPreset | null): void {
   manualOpen.value = false;
 }
 
-function setOrientation(orientation: ResolutionOrientation): void {
+function setShape(id: string): void {
+  explicitShapeId.value = id;
+  if (id === "source") {
+    matchSource();
+    return;
+  }
+  const shape = shapeOptions.value.find((option) => option.id === id);
+  if (!shape) return;
+  const exactGroup = presetsForAspectGroup(props.model, props.pipeline, id);
   applyResolution(
     closestResolutionPreset(
-      presetsForOrientation(presets.value, orientation),
-      width.value,
-      height.value,
-    ),
-  );
-}
-
-function setAspect(aspect: string): void {
-  applyResolution(
-    closestResolutionPreset(
-      presets.value.filter((preset) => preset.aspect === aspect),
+      exactGroup.length > 0 ? exactGroup : presetsNearRatio(presets.value, shape.ratio),
       width.value,
       height.value,
     ),
@@ -198,6 +183,7 @@ function swapDimensions(): void {
 function matchSource(): void {
   const source = sourceResolution.value;
   if (!source) return;
+  explicitShapeId.value = "source";
   width.value = source.output.width;
   height.value = source.output.height;
   manualOpen.value = true;
@@ -242,54 +228,16 @@ function matchSource(): void {
     </div>
 
     <div class="mobile-resolution-group">
-      <span class="mobile-resolution-label">Orientation</span>
-      <div class="mobile-resolution-segments" role="group" aria-label="Orientation">
-        <button
-          v-for="orientation in MOBILE_RESOLUTION_ORIENTATIONS"
-          :key="orientation"
-          type="button"
-          class="mobile-resolution-segment"
-          :class="{ 'is-selected': currentOrientation === orientation }"
-          :aria-pressed="currentOrientation === orientation"
-          :disabled="!isOrientationAvailable(orientation)"
-          :data-orientation="orientation.toLowerCase()"
-          @click="setOrientation(orientation)"
-        >
-          {{ orientation }}
-        </button>
-      </div>
-    </div>
-
-    <div class="mobile-resolution-group">
-      <span class="mobile-resolution-label">Aspect ratio</span>
-      <div class="mobile-resolution-aspects" role="group" aria-label="Aspect ratio presets">
-        <button
-          v-for="aspect in aspectOptions"
-          :key="aspect"
-          type="button"
-          class="mobile-resolution-aspect"
-          :class="{
-            'is-selected': currentPreset?.aspect === aspect || approximateAspect === aspect,
-            'is-approximate': approximateAspect === aspect,
-          }"
-          :aria-pressed="currentPreset?.aspect === aspect || approximateAspect === aspect"
-          :aria-label="aspectAccessibleLabel(approximateAspect === aspect ? `≈${aspect}` : aspect)"
-          :data-aspect="aspect"
-          @click="setAspect(aspect)"
-        >
-          <span class="mobile-resolution-aspect-visual" aria-hidden="true">
-            <span
-              class="mobile-resolution-aspect-shape"
-              data-test="mobile-resolution-aspect-shape"
-              aria-hidden="true"
-              :style="aspectOptionShapeStyle(aspect)"
-            />
-          </span>
-          <span class="mobile-resolution-aspect-label">
-            {{ approximateAspect === aspect ? "≈" : "" }}{{ aspect }}
-          </span>
-        </button>
-      </div>
+      <span class="mobile-resolution-label">Shape</span>
+      <ShapePicker
+        :model-value="shapeId"
+        :options="shapeOptions"
+        :approximate="shapeApproximate"
+        :disabled="disabled"
+        label="Aspect ratio"
+        data-test="mobile-resolution-shape"
+        @update:model-value="setShape"
+      />
     </div>
 
     <div v-if="currentPreset" class="mobile-resolution-group mobile-resolution-tier">

--- a/desktop/src/mobile/mobile.css
+++ b/desktop/src/mobile/mobile.css
@@ -788,6 +788,13 @@ html.mobile-surface:has(.mobile-shell.is-pair-scanning) #app,
   font-size: var(--text-body);
 }
 
+.mobile-create-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
 /* Screen header row: large title + optional trailing action (Settings gear). */
 .mobile-screen-head {
   display: flex;
@@ -885,81 +892,21 @@ textarea.control {
   margin-top: 13px;
 }
 
-.mobile-resolution-segments {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 3px;
-  padding: 3px;
-  border: 1px solid var(--control-edge);
-  border-radius: var(--radius-control);
-  background: var(--bench);
-}
-
-.mobile-resolution-segment {
-  min-height: 44px;
-  border: 0;
-  border-radius: calc(var(--radius-control) - 2px);
-  background: transparent;
-  color: var(--ink-3);
-  font-family: var(--font-utility);
-  font-size: var(--text-data);
-}
-
-.mobile-resolution-segment.is-selected {
-  background: color-mix(in srgb, var(--safelight) 15%, transparent);
-  color: var(--safelight);
-}
-
-.mobile-resolution-aspects {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(64px, 84px));
+.mobile-resolution-group .ms-shape {
   gap: 7px;
 }
 
-.mobile-resolution-aspect {
-  min-width: 0;
+.mobile-resolution-group .ms-shape__btn {
+  min-width: 60px;
   min-height: 72px;
-  display: grid;
-  grid-template-rows: 32px auto;
-  place-items: center;
-  gap: 5px;
-  border: 1px solid var(--control-edge);
-  border-radius: var(--radius-control);
-  padding: 7px 5px 6px;
-  background: transparent;
-  color: var(--ink-2);
-  font-family: var(--font-utility);
+  width: auto;
+  height: auto;
+  padding: 7px;
+  flex: 1 1 60px;
+}
+
+.mobile-resolution-group .ms-shape__label {
   font-size: var(--text-data);
-}
-
-.mobile-resolution-aspect.is-selected {
-  border-color: var(--safelight);
-  background: color-mix(in srgb, var(--safelight) 9%, transparent);
-  color: var(--safelight);
-}
-
-.mobile-resolution-aspect-visual {
-  display: grid;
-  width: 34px;
-  height: 30px;
-  place-items: center;
-}
-
-.mobile-resolution-aspect-shape {
-  box-sizing: border-box;
-  display: block;
-  border: 1px solid currentColor;
-  border-radius: 2px;
-  background: color-mix(in srgb, currentColor 5%, transparent);
-}
-
-.mobile-resolution-aspect.is-selected .mobile-resolution-aspect-shape {
-  border-width: 2px;
-  background: color-mix(in srgb, currentColor 22%, transparent);
-}
-
-.mobile-resolution-aspect-label {
-  line-height: 1;
 }
 
 .mobile-resolution-tier {
@@ -1425,7 +1372,7 @@ textarea.control {
 
 .mobile-native-disclosure > summary {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   cursor: pointer;
   list-style: none;
 }
@@ -1454,6 +1401,10 @@ textarea.control {
   font-weight: 400;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.mobile-native-disclosure > summary small {
+  text-align: right;
 }
 
 .mobile-native-disclosure > .mobile-source-controls {
@@ -1957,6 +1908,12 @@ button.mobile-generate-disclosure {
   gap: 10px;
 }
 
+.mobile-advanced-sheet-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
 .mobile-advanced-sheet-title strong {
   font-family: var(--font-display);
   font-size: var(--text-display-sm);
@@ -1992,10 +1949,12 @@ button.mobile-generate-disclosure {
 }
 
 .mobile-advanced-sheet-reset {
-  display: block;
-  width: 100%;
+  display: inline-flex;
+  width: auto;
   min-height: 44px;
-  margin-top: 6px;
+  align-items: center;
+  margin: 0;
+  padding: 0 10px;
   border: 0;
   background: transparent;
   color: var(--ink-3);

--- a/desktop/src/mobile/mobile.css.test.ts
+++ b/desktop/src/mobile/mobile.css.test.ts
@@ -234,10 +234,9 @@ describe("mobile safe areas", () => {
 
   it("keeps frequent resolution and catalog controls at least 44px tall", () => {
     for (const selector of [
-      ".mobile-resolution-segment",
+      ".mobile-resolution-group .ms-shape__btn",
       ".mobile-resolution-tier .ms-seg .ms-seg__btn",
       ".mobile-output-mode .ms-seg .ms-seg__btn",
-      ".mobile-resolution-aspect",
       ".mobile-catalog-segment button",
       ".mobile-catalog-media button",
       ".mobile-catalog-sources button",
@@ -306,15 +305,14 @@ describe("mobile safe areas", () => {
     expect(value?.[1]).not.toMatch(/text-overflow:\s*ellipsis\s*;/);
   });
 
-  it("gives aspect choices a proportional visual frame inside a uniform touch tile", () => {
-    const aspects = css.match(/\.mobile-resolution-aspects\s*\{([^}]*)\}/s);
-    const choice = css.match(/\.mobile-resolution-aspect\s*\{([^}]*)\}/s);
-    const shape = css.match(/\.mobile-resolution-aspect-shape\s*\{([^}]*)\}/s);
+  it("gives shared desktop shape choices a uniform mobile touch tile", () => {
+    const group = css.match(/\.mobile-resolution-group \.ms-shape\s*\{([^}]*)\}/s);
+    const choice = css.match(/\.mobile-resolution-group \.ms-shape__btn\s*\{([^}]*)\}/s);
 
-    expect(aspects?.[1]).toMatch(/display:\s*grid\s*;/);
-    expect(aspects?.[1]).toMatch(/minmax\(64px,\s*84px\)/);
+    expect(group?.[1]).toMatch(/gap:\s*7px\s*;/);
+    expect(choice?.[1]).toMatch(/min-width:\s*60px\s*;/);
     expect(choice?.[1]).toMatch(/min-height:\s*72px\s*;/);
-    expect(shape?.[1]).toMatch(/border:\s*1px solid currentColor\s*;/);
+    expect(choice?.[1]).toMatch(/flex:\s*1 1 60px\s*;/);
   });
 
   it("keeps the kit tier segments at touch size with legible sublabels", () => {
@@ -330,6 +328,13 @@ describe("mobile safe areas", () => {
     expect(sub?.[1]).toMatch(/font-size:\s*10px\s*;/);
     expect(dims?.[1]).toMatch(/font-family:\s*var\(--font-utility\)/);
     expect(dims?.[1]).toMatch(/color:\s*var\(--ink-3\)/);
+  });
+
+  it("allocates separate disclosure columns for title, filename, and toggle", () => {
+    const summary = css.match(/\.mobile-native-disclosure > summary\s*\{([^}]*)\}/s);
+    const detail = css.match(/\.mobile-native-disclosure > summary small\s*\{([^}]*)\}/s);
+    expect(summary?.[1]).toMatch(/grid-template-columns:\s*auto minmax\(0,\s*1fr\) auto\s*;/);
+    expect(detail?.[1]).toMatch(/text-align:\s*right\s*;/);
   });
 
   it("does not keep the redundant resolution summary card", () => {

--- a/desktop/src/mobile/resolutionPicker.ts
+++ b/desktop/src/mobile/resolutionPicker.ts
@@ -1,28 +1,4 @@
-import { orientationLabel, type ResolutionPreset } from "../lib/resolutions";
-
-export type ResolutionOrientation = ReturnType<typeof orientationLabel>;
-
-/** Phone-first order: the neutral square first, then the two directional choices. */
-export const MOBILE_RESOLUTION_ORIENTATIONS: readonly ResolutionOrientation[] = [
-  "Square",
-  "Portrait",
-  "Landscape",
-];
-
-export function presetsForOrientation(
-  presets: readonly ResolutionPreset[],
-  orientation: ResolutionOrientation,
-): ResolutionPreset[] {
-  return presets.filter((preset) => orientationLabel(preset.width, preset.height) === orientation);
-}
-
-/** Preserve desktop ordering while collapsing repeated ratios into one chip. */
-export function aspectsForOrientation(
-  presets: readonly ResolutionPreset[],
-  orientation: ResolutionOrientation,
-): string[] {
-  return [...new Set(presetsForOrientation(presets, orientation).map((preset) => preset.aspect))];
-}
+import type { ResolutionPreset } from "../lib/resolutions";
 
 /** Pick the available bucket whose pixel area is closest to the current size. */
 export function closestResolutionPreset(

--- a/ui/components/ShapePicker.vue
+++ b/ui/components/ShapePicker.vue
@@ -69,6 +69,7 @@ function onKeydown(event: KeyboardEvent) {
       class="ms-shape__btn"
       role="radio"
       :aria-checked="option.id === modelValue"
+      :data-shape="option.id"
       :data-on="option.id === modelValue ? 'true' : undefined"
       :data-approximate="
         option.id === modelValue && approximate ? 'true' : undefined


### PR DESCRIPTION
## Summary

- fix the iOS Frame endpoints disclosure so its title, filename, and toggle have independent layout columns
- pass the selected model into the one-shot mobile parameter stack so MiniMax H3 uses its real generation profile and can queue conditioned renders
- replace the mobile Square/Portrait/Landscape tabs and bespoke aspect tiles with the shared desktop ShapePicker and generation-profile helpers
- add Create and Advanced reset actions in the corresponding iOS headers, using the same reset authorities as desktop

## Validation

- `nix develop -c bun run test` (323 files, 3668 tests)
- focused mobile/shared tests (4 files, 230 tests)
- `nix develop -c bun run fmt:check`
- `nix develop -c bun run build:mobile`
- `nix develop -c ./scripts/tests/ios-release-assets.sh`
- `nix develop -c ./scripts/ios.sh check`
- sub-agent peer review: no actionable findings

## Notes

- The unrelated desktop auto-routing/version-difference warning is intentionally out of scope.