### PR TITLE
fix(desktop): keep gallery and auto routing responsive

### DIFF
--- a/desktop/src-tauri/src/gallery.rs
+++ b/desktop/src-tauri/src/gallery.rs
@@ -1,14 +1,25 @@
-use std::io::{Read, Seek, SeekFrom};
+use std::{
+    io::{Read, Seek, SeekFrom},
+    sync::OnceLock,
+    time::Duration,
+};
 
 use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
 use tauri::http::{header, Request, Response, StatusCode};
 use tauri::Manager;
+use tokio::sync::Semaphore;
 
 use crate::commands::{AppState, LocalServer, LocalServerInfo, SettingsStore};
 
 const MAX_SOURCE_IMAGE_BYTES: u64 = 64 * 1024 * 1024;
+const MAX_GALLERY_THUMBNAIL_BYTES: usize = 8 * 1024 * 1024;
+const MAX_CONCURRENT_GALLERY_THUMBNAILS: usize = 16;
 const GALLERY_IMPORT_CONTENT_TYPE: &str = "application/vnd.mold.gallery-import";
+
+static GALLERY_THUMBNAIL_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+static GALLERY_THUMBNAIL_PERMITS: Semaphore =
+    Semaphore::const_new(MAX_CONCURRENT_GALLERY_THUMBNAILS);
 
 #[derive(Debug, Serialize)]
 pub struct ImportedSourceImage {
@@ -512,6 +523,79 @@ pub async fn save_output_bytes(
 pub struct MediaSaveTarget {
     base_url: String,
     api_key: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NativeGalleryThumbnail {
+    base64: String,
+    content_type: String,
+}
+
+#[tauri::command]
+pub async fn fetch_gallery_thumbnail(
+    target: MediaSaveTarget,
+    filename: String,
+) -> Result<NativeGalleryThumbnail, String> {
+    use base64::Engine;
+
+    if !valid_filename(&filename) {
+        return Err("Invalid gallery filename.".into());
+    }
+    let _permit = tokio::time::timeout(Duration::from_secs(5), GALLERY_THUMBNAIL_PERMITS.acquire())
+        .await
+        .map_err(|_| "The gallery thumbnail queue is busy; retrying may help.".to_string())?
+        .map_err(|_| "The gallery thumbnail service is unavailable.".to_string())?;
+    let encoded =
+        percent_encoding::utf8_percent_encode(&filename, percent_encoding::NON_ALPHANUMERIC);
+    let url = format!(
+        "{}/api/gallery/thumbnail/{encoded}",
+        target.base_url.trim_end_matches('/')
+    );
+    let client = GALLERY_THUMBNAIL_CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(5))
+            .timeout(Duration::from_secs(15))
+            .pool_max_idle_per_host(MAX_CONCURRENT_GALLERY_THUMBNAILS)
+            .build()
+            .expect("static gallery HTTP client settings must be valid")
+    });
+    let mut request = client.get(url);
+    if let Some(key) = target.api_key.filter(|key| !key.is_empty()) {
+        request = request.header("X-Api-Key", key);
+    }
+    let response = request
+        .send()
+        .await
+        .map_err(|error| format!("Couldn't reach the gallery host: {error}"))?;
+    if !response.status().is_success() {
+        return Err(response_error(response).await);
+    }
+    if response
+        .content_length()
+        .is_some_and(|length| length > MAX_GALLERY_THUMBNAIL_BYTES as u64)
+    {
+        return Err("The gallery thumbnail is unexpectedly large.".into());
+    }
+    let content_type = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("application/octet-stream")
+        .to_string();
+    let mut bytes = Vec::new();
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|error| format!("The thumbnail transfer failed: {error}"))?;
+        if bytes.len().saturating_add(chunk.len()) > MAX_GALLERY_THUMBNAIL_BYTES {
+            return Err("The gallery thumbnail is unexpectedly large.".into());
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+    Ok(NativeGalleryThumbnail {
+        base64: base64::engine::general_purpose::STANDARD.encode(bytes),
+        content_type,
+    })
 }
 
 #[derive(Debug, Serialize)]

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -177,6 +177,7 @@ pub fn run() {
             updater::install_pending_update,
             gallery::local_gallery_list,
             gallery::local_gallery_delete,
+            gallery::fetch_gallery_thumbnail,
             gallery::import_source_image,
             gallery::save_output_bytes,
             gallery::save_media_bytes,

--- a/desktop/src/components/gallery/AuthedMedia.test.ts
+++ b/desktop/src/components/gallery/AuthedMedia.test.ts
@@ -1,6 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { mount } from "@vue/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { flushPromises, mount } from "@vue/test-utils";
 import AuthedMedia from "./AuthedMedia.vue";
+import { authedMediaUrl } from "../../lib/gallery/media";
 
 vi.mock("../../lib/gallery/media", () => ({
   authedMediaUrl: vi.fn().mockResolvedValue("blob:video"),
@@ -8,7 +9,10 @@ vi.mock("../../lib/gallery/media", () => ({
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.mocked(authedMediaUrl).mockResolvedValue("blob:video");
 });
+
+afterEach(() => vi.useRealTimers());
 
 describe("AuthedMedia", () => {
   it("disables Picture-in-Picture for desktop video playback", async () => {
@@ -18,5 +22,66 @@ describe("AuthedMedia", () => {
     await vi.waitFor(() => expect(wrapper.find("video").exists()).toBe(true));
 
     expect(wrapper.get("video").attributes()).toHaveProperty("disablepictureinpicture");
+  });
+
+  it("retries transient failures and renders the recovered thumbnail", async () => {
+    vi.useFakeTimers();
+    vi.mocked(authedMediaUrl)
+      .mockRejectedValueOnce(new Error("temporary native transport failure"))
+      .mockResolvedValueOnce("blob:recovered");
+    const wrapper = mount(AuthedMedia, {
+      props: {
+        path: "/api/gallery/thumbnail/demo.png",
+        target: { baseUrl: "http://local:7680", apiKey: "old-key" },
+        cacheKey: "local",
+      },
+    });
+    await flushPromises();
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(authedMediaUrl).toHaveBeenCalledTimes(2);
+    expect(wrapper.get("img").attributes("src")).toBe("blob:recovered");
+  });
+
+  it("does not retry an unbounded full-media fetch", async () => {
+    vi.useFakeTimers();
+    vi.mocked(authedMediaUrl).mockRejectedValue(new Error("video transfer failed"));
+    const wrapper = mount(AuthedMedia, {
+      props: { path: "/api/gallery/image/large-video.mp4", video: true },
+    });
+    await flushPromises();
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    expect(authedMediaUrl).toHaveBeenCalledTimes(1);
+    expect(wrapper.text()).toContain("UNREADABLE");
+  });
+
+  it("reloads an unreadable thumbnail when its host route changes", async () => {
+    vi.useFakeTimers();
+    vi.mocked(authedMediaUrl).mockRejectedValue(new Error("host unavailable"));
+    const wrapper = mount(AuthedMedia, {
+      props: {
+        path: "/api/gallery/thumbnail/demo.png",
+        target: { baseUrl: "http://local:7680", apiKey: "old-key" },
+        cacheKey: "local",
+      },
+    });
+    await flushPromises();
+    await vi.advanceTimersByTimeAsync(1_250);
+    expect(wrapper.text()).toContain("UNREADABLE");
+
+    vi.mocked(authedMediaUrl).mockResolvedValue("blob:reconnected");
+    await wrapper.setProps({
+      target: { baseUrl: "http://local:7680", apiKey: "new-key" },
+    });
+    await flushPromises();
+
+    expect(wrapper.get("img").attributes("src")).toBe("blob:reconnected");
+    expect(authedMediaUrl).toHaveBeenLastCalledWith(
+      "/api/gallery/thumbnail/demo.png",
+      expect.objectContaining({
+        target: { baseUrl: "http://local:7680", apiKey: "new-key" },
+      }),
+    );
   });
 });

--- a/desktop/src/components/gallery/AuthedMedia.vue
+++ b/desktop/src/components/gallery/AuthedMedia.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, ref, watch } from "vue";
+import { onMounted, onUnmounted, ref, watch } from "vue";
 import { authedMediaUrl } from "../../lib/gallery/media";
 import type { ApiTarget } from "../../lib/api/client";
 
@@ -21,22 +21,38 @@ const props = withDefaults(
 
 const src = ref<string | null>(null);
 const failed = ref(false);
+let loadEpoch = 0;
+
+const retryDelaysMs = [0, 250, 1_000] as const;
 
 async function load() {
+  const epoch = ++loadEpoch;
   src.value = null;
   failed.value = false;
-  try {
-    src.value = await authedMediaUrl(props.path, {
-      ...(props.target ? { target: props.target } : {}),
-      ...(props.cacheKey ? { cacheKey: props.cacheKey } : {}),
-    });
-  } catch {
-    failed.value = true;
+  const delays = props.path.startsWith("/api/gallery/thumbnail/") ? retryDelaysMs : ([0] as const);
+  for (const delayMs of delays) {
+    if (delayMs > 0) await new Promise((resolve) => setTimeout(resolve, delayMs));
+    if (epoch !== loadEpoch) return;
+    try {
+      const url = await authedMediaUrl(props.path, {
+        ...(props.target ? { target: props.target } : {}),
+        ...(props.cacheKey ? { cacheKey: props.cacheKey } : {}),
+      });
+      if (epoch === loadEpoch) src.value = url;
+      return;
+    } catch {
+      // Retry bounded transient native/network failures. The media cache
+      // evicts rejected promises, so each attempt performs a fresh request.
+    }
   }
+  if (epoch === loadEpoch) failed.value = true;
 }
 
-watch(() => [props.path, props.cacheKey], load);
+watch(() => [props.path, props.cacheKey, props.target?.baseUrl, props.target?.apiKey], load);
 onMounted(load);
+onUnmounted(() => {
+  loadEpoch += 1;
+});
 </script>
 
 <template>

--- a/desktop/src/components/models/CatalogTab.test.ts
+++ b/desktop/src/components/models/CatalogTab.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { flushPromises, mount } from "@vue/test-utils";
+import { enableAutoUnmount, flushPromises, mount } from "@vue/test-utils";
 import { createPinia, setActivePinia } from "pinia";
 import type { CatalogEntry } from "../../lib/api/types";
 import type { CatalogSearchParams } from "../../lib/api/catalog";
@@ -35,6 +35,23 @@ import { useHostsStore } from "../../stores/hosts";
 import { useModelStore } from "../../stores/models";
 
 const PAGE_SIZE = 24;
+
+enableAutoUnmount(afterEach);
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function familyOptionValues(wrapper: ReturnType<typeof mount>): string[] {
+  return wrapper
+    .get("select[aria-label='Model family']")
+    .findAll("option")
+    .map((option) => option.attributes("value") ?? "");
+}
 
 /** Records instances so tests can walk the sentinel into view. */
 class FakeIntersectionObserver {
@@ -90,6 +107,13 @@ function imagePage(page: number, size = PAGE_SIZE): CatalogEntry[] {
 
 async function mountTab(mediaType: "all" | "image" | "video" = "all") {
   setActivePinia(createPinia());
+  const connection = useConnectionStore();
+  connection.info = {
+    mode: "local",
+    baseUrl: "http://127.0.0.1:7680",
+    apiKey: "local-key",
+  };
+  connection.status = "ready";
   const wrapper = mount(CatalogTab, {
     props: { query: "", layout: "grid" as const, mediaType },
     global: { plugins: [] },
@@ -117,6 +141,99 @@ afterEach(() => {
 });
 
 describe("CatalogTab media filter under pagination", () => {
+  it("offers installed families immediately while the taxonomy request is still pending", async () => {
+    const taxonomy = deferred<string[]>();
+    fetchCatalogFamilies.mockReturnValue(taxonomy.promise);
+    setActivePinia(createPinia());
+    const wrapper = mount(CatalogTab, {
+      props: {
+        query: "",
+        layout: "grid" as const,
+        installedEntries: [
+          {
+            name: "qwen-image:q4",
+            family: "qwen-image",
+            downloaded: true,
+            hostIds: ["local"],
+          },
+          {
+            name: "z-image-turbo:q4",
+            family: "z-image",
+            downloaded: true,
+            hostIds: ["local"],
+          },
+        ] as never,
+      },
+    });
+    await flushPromises();
+
+    expect(familyOptionValues(wrapper)).toEqual(["", "qwen-image", "z-image"]);
+
+    taxonomy.resolve(["flux", "qwen-image", "z-image"]);
+    await flushPromises();
+    expect(familyOptionValues(wrapper)).toEqual(["", "flux", "qwen-image", "z-image"]);
+  });
+
+  it("falls back to families observed across inventory and results without collapsing after filtering", async () => {
+    fetchCatalogFamilies.mockRejectedValue(new Error("taxonomy unavailable"));
+    searchCatalog.mockResolvedValue({
+      entries: [entry("Flux model", "flux"), entry("Video model", "ltx2")],
+      page: 1,
+      page_size: PAGE_SIZE,
+      total: 2,
+    });
+    setActivePinia(createPinia());
+    const wrapper = mount(CatalogTab, {
+      props: {
+        query: "",
+        layout: "grid" as const,
+        installedEntries: [
+          {
+            name: "qwen-image:q4",
+            family: "qwen-image",
+            downloaded: true,
+            hostIds: ["local"],
+          },
+        ] as never,
+      },
+    });
+    await flushPromises();
+
+    expect(familyOptionValues(wrapper)).toEqual(["", "flux", "ltx2", "qwen-image"]);
+    await wrapper.get("select[aria-label='Model family']").setValue("ltx2");
+    await flushPromises();
+    expect(familyOptionValues(wrapper)).toEqual(["", "flux", "ltx2", "qwen-image"]);
+  });
+
+  it("retries taxonomy when reachability changes and retains the last good families", async () => {
+    fetchCatalogFamilies
+      .mockResolvedValueOnce(["flux"])
+      .mockRejectedValueOnce(new Error("host restarting"))
+      .mockResolvedValueOnce(["qwen-image", "z-image"]);
+    setActivePinia(createPinia());
+    const connection = useConnectionStore();
+    connection.info = {
+      mode: "local",
+      baseUrl: "http://127.0.0.1:7680",
+      apiKey: "local-key",
+    };
+    connection.status = "ready";
+    const wrapper = mount(CatalogTab, {
+      props: { query: "", layout: "grid" as const },
+    });
+    await flushPromises();
+    expect(familyOptionValues(wrapper)).toEqual(["", "flux"]);
+
+    connection.status = "error";
+    await flushPromises();
+    expect(familyOptionValues(wrapper)).toEqual(["", "flux"]);
+
+    connection.status = "ready";
+    await flushPromises();
+    expect(familyOptionValues(wrapper)).toEqual(["", "qwen-image", "z-image"]);
+    expect(fetchCatalogFamilies).toHaveBeenCalledTimes(3);
+  });
+
   it("shows an installed model ONCE, host-tagged, when a live catalog copy also matches", async () => {
     setActivePinia(createPinia());
     searchCatalog.mockResolvedValue({

--- a/desktop/src/components/models/CatalogTab.vue
+++ b/desktop/src/components/models/CatalogTab.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from "vue";
+import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 import CatalogLayoutToggle, {
   type CatalogLayoutChoice,
 } from "@ui/components/CatalogLayoutToggle.vue";
@@ -76,6 +76,10 @@ const kind = ref<CatalogKindFilter | "">("");
 const sort = ref<CatalogSortOption>("downloads");
 const includeNsfw = ref(false);
 const families = ref<string[]>([]);
+/** Families observed anywhere in this component's inventory/search lifetime.
+ *  This is deliberately not derived from the currently filtered rows: doing
+ *  so collapses the selector to its active family and strands the user. */
+const observedFamilies = ref<string[]>([]);
 
 const entries = ref<CatalogEntry[]>([]);
 const page = ref(1);
@@ -88,6 +92,27 @@ const pendingEntry = ref<CatalogEntry | null>(null);
 const detailEntry = ref<CatalogListEntry | null>(null);
 
 let debounce: ReturnType<typeof setTimeout> | null = null;
+let familyEpoch = 0;
+let mounted = false;
+let activeCatalogRoute = "";
+
+function recordFamilies(values: Iterable<string | null | undefined>): void {
+  const seen = new Set(observedFamilies.value);
+  const before = seen.size;
+  for (const value of values) {
+    const name = value?.trim();
+    if (name) seen.add(name);
+  }
+  if (seen.size !== before) observedFamilies.value = [...seen].sort((a, b) => a.localeCompare(b));
+}
+
+/** Prefer the host taxonomy once available; inventory/results cover startup
+ *  latency and failed taxonomy reads without ever presenting an empty picker. */
+const familyOptions = computed(() => {
+  const options = families.value.length > 0 ? [...families.value] : [...observedFamilies.value];
+  if (family.value && !options.includes(family.value)) options.push(family.value);
+  return options.sort((a, b) => a.localeCompare(b));
+});
 
 /** True when `entry` passes the active media-type chip. */
 function matchesMediaType(entry: CatalogEntry): boolean {
@@ -347,6 +372,7 @@ async function runSearch(reset: boolean) {
         target,
       );
       if (epoch !== searchEpoch) return;
+      recordFamilies(res.entries.map((entry) => entry.family));
       entries.value = [...entries.value, ...res.entries];
       // Exhaustion comes from the wire `total`, not page fullness: under
       // source=All the server splits the page budget across sources, so a
@@ -489,6 +515,50 @@ watch([() => props.query, source, family, kind, sort, includeNsfw], () => {
   scheduleSearch();
 });
 
+watch(
+  () => [
+    ...(props.installedEntries ?? []).map((model) => model.family),
+    ...models.all.map((model) => model.family),
+  ],
+  (values) => recordFamilies(values),
+  { immediate: true },
+);
+
+async function loadFamilies(): Promise<void> {
+  const epoch = ++familyEpoch;
+  try {
+    const { target, forward } = catalogTarget();
+    const result = await fetchCatalogFamilies(forward, target);
+    if (epoch === familyEpoch) families.value = result;
+  } catch {
+    // Retain the last good taxonomy. `familyOptions` covers first-load errors.
+  }
+}
+
+/** URL/key/reachability decide which catalog authority answers. Re-drive a
+ * failed/empty view when that route changes so a late connection self-heals. */
+const catalogRoute = computed(() => {
+  const { target, forward } = catalogTarget();
+  return JSON.stringify([
+    target?.baseUrl ?? "primary",
+    target?.apiKey ?? null,
+    forward,
+    hosts.all.map((host) => [host.id, host.status, host.baseUrl]),
+  ]);
+});
+
+watch(
+  catalogRoute,
+  (route) => {
+    if (!mounted) return;
+    if (route === activeCatalogRoute) return;
+    activeCatalogRoute = route;
+    void loadFamilies();
+    if (error.value || entries.value.length === 0) void runSearch(true);
+  },
+  { flush: "sync" },
+);
+
 // Flipping to a media chip with no matching entries loaded yet continues the
 // existing pagination instead of leaving a blank grid behind the chip.
 watch(
@@ -500,13 +570,23 @@ watch(
 );
 
 onMounted(async () => {
-  try {
-    const { target, forward } = catalogTarget();
-    families.value = await fetchCatalogFamilies(forward, target);
-  } catch {
-    /* families are a nicety; search still works without them */
-  }
-  void runSearch(true);
+  const startingRoute = catalogRoute.value;
+  activeCatalogRoute = startingRoute;
+  await Promise.allSettled([loadFamilies(), runSearch(true)]);
+  mounted = true;
+  const currentRoute = catalogRoute.value;
+  if (currentRoute === startingRoute) return;
+  activeCatalogRoute = currentRoute;
+  void loadFamilies();
+  if (error.value || entries.value.length === 0) void runSearch(true);
+});
+
+onUnmounted(() => {
+  mounted = false;
+  familyEpoch += 1;
+  searchEpoch += 1;
+  if (debounce) clearTimeout(debounce);
+  debounce = null;
 });
 </script>
 
@@ -553,10 +633,11 @@ onMounted(async () => {
 
       <select
         v-model="family"
+        aria-label="Model family"
         class="border-edge h-7 rounded-control border bg-bath px-1.5 text-caption text-ink"
       >
         <option value="">All families</option>
-        <option v-for="f in families" :key="f" :value="f">{{ f }}</option>
+        <option v-for="f in familyOptions" :key="f" :value="f">{{ f }}</option>
       </select>
 
       <select

--- a/desktop/src/lib/gallery/media.test.ts
+++ b/desktop/src/lib/gallery/media.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ApiError, apiFetch, apiFetchTo, currentTarget } from "../api/client";
+import { inTauri, ipc } from "../ipc";
 import {
   authedMediaUrl,
   evictHostMedia,
@@ -14,9 +15,21 @@ vi.mock("../api/client", async (importOriginal) => ({
   apiFetchTo: vi.fn(),
   currentTarget: vi.fn(),
 }));
+vi.mock("../ipc", () => ({
+  inTauri: vi.fn(),
+  ipc: { fetchGalleryThumbnail: vi.fn() },
+}));
 
 const blobResponse = () =>
   ({ blob: () => Promise.resolve(new Blob(["png bytes"])) }) as unknown as Response;
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
 
 let objectUrlSeq = 0;
 const revoked: string[] = [];
@@ -26,6 +39,8 @@ beforeEach(() => {
   vi.mocked(apiFetch).mockImplementation(() => Promise.resolve(blobResponse()));
   vi.mocked(apiFetchTo).mockImplementation(() => Promise.resolve(blobResponse()));
   vi.mocked(currentTarget).mockReturnValue({ baseUrl: "http://primary:7680", apiKey: null });
+  vi.mocked(inTauri).mockReturnValue(false);
+  vi.mocked(ipc.fetchGalleryThumbnail).mockReset();
   revoked.length = 0;
   URL.createObjectURL = vi.fn(() => `blob:mock-${++objectUrlSeq}`);
   URL.revokeObjectURL = vi.fn((url: string) => void revoked.push(url));
@@ -162,6 +177,25 @@ describe("galleryMediaPath", () => {
 });
 
 describe("authedMediaUrl host-keyed cache", () => {
+  it("loads desktop thumbnails through native HTTP so held generation streams cannot starve them", async () => {
+    vi.mocked(inTauri).mockReturnValue(true);
+    vi.mocked(ipc.fetchGalleryThumbnail).mockResolvedValue({
+      base64: btoa("thumbnail bytes"),
+      contentType: "image/png",
+    });
+    const target = { baseUrl: "http://hal9000:7680", apiKey: "hk" };
+
+    await expect(
+      authedMediaUrl("/api/gallery/thumbnail/new%20print.png", {
+        target,
+        cacheKey: "hal9000-7680",
+      }),
+    ).resolves.toMatch(/^blob:mock-/);
+
+    expect(ipc.fetchGalleryThumbnail).toHaveBeenCalledWith(target, "new print.png");
+    expect(apiFetchTo).not.toHaveBeenCalled();
+  });
+
   it("caches the same path separately per cacheKey", async () => {
     const path = "/api/gallery/thumbnail/same.png";
     const target = { baseUrl: "http://hal9000:7680", apiKey: "hk" };
@@ -175,6 +209,26 @@ describe("authedMediaUrl host-keyed cache", () => {
     // A repeat on either key hits the cache — no third fetch.
     expect(await authedMediaUrl(path, { target, cacheKey: "hal9000-7680" })).toBe(a);
     expect(apiFetchTo).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not reuse an in-flight thumbnail after the host route changes", async () => {
+    const oldResponse = deferred<Response>();
+    const oldTarget = { baseUrl: "http://hal9000:7680", apiKey: "old-key" };
+    const newTarget = { baseUrl: "http://hal9000:7680", apiKey: "new-key" };
+    vi.mocked(apiFetchTo).mockImplementation((target) =>
+      target.apiKey === "old-key" ? oldResponse.promise : Promise.resolve(blobResponse()),
+    );
+    const path = "/api/gallery/thumbnail/reconnected.png";
+
+    const oldLoad = authedMediaUrl(path, { target: oldTarget, cacheKey: "hal9000-7680" });
+    await Promise.resolve();
+    const newLoad = authedMediaUrl(path, { target: newTarget, cacheKey: "hal9000-7680" });
+    await expect(newLoad).resolves.toMatch(/^blob:mock-/);
+
+    expect(apiFetchTo).toHaveBeenCalledTimes(2);
+    expect(apiFetchTo).toHaveBeenLastCalledWith(newTarget, path);
+    oldResponse.resolve(blobResponse());
+    await expect(oldLoad).resolves.toMatch(/^blob:mock-/);
   });
 
   it("uses the primary connection when no target is given", async () => {

--- a/desktop/src/lib/gallery/media.ts
+++ b/desktop/src/lib/gallery/media.ts
@@ -1,5 +1,6 @@
 import { ApiError, apiFetch, apiFetchTo, currentTarget, type ApiTarget } from "../api/client";
 import type { GalleryImage } from "../api/types";
+import { inTauri, ipc } from "../ipc";
 
 /**
  * Gallery media sits behind X-Api-Key auth, and <img>/<video> cannot send
@@ -31,16 +32,41 @@ export interface StreamableMediaOptions extends AuthedMediaOptions {
   allowLegacyBlob?: boolean;
 }
 
-const keyOf = (path: string, cacheKey?: string) => `${cacheKey ?? "primary"}|${path}`;
+const keyOf = (path: string, target: ApiTarget, cacheKey?: string) =>
+  `${cacheKey ?? "primary"}|${path}|${JSON.stringify([target.baseUrl, target.apiKey])}`;
 
 export function authedMediaUrl(path: string, opts: AuthedMediaOptions = {}): Promise<string> {
   if (path.startsWith("mold-local:")) return Promise.resolve(path);
-  const key = keyOf(path, opts.cacheKey);
+  const target = opts.target;
+  const effectiveTarget = target ?? currentTarget();
+  // Target identity is part of the cache authority. A reconnect may retain
+  // the host bucket and path while changing URL or credentials; an in-flight
+  // object URL from the old route must never satisfy the new one.
+  const key = keyOf(path, effectiveTarget, opts.cacheKey);
   let url = cache.get(key);
   if (!url) {
-    const target = opts.target;
-    url = (target ? apiFetchTo(target, path) : apiFetch(path))
-      .then((r) => r.blob())
+    const thumbnailPrefix = "/api/gallery/thumbnail/";
+    const encodedFilename = path.startsWith(thumbnailPrefix)
+      ? path.slice(thumbnailPrefix.length)
+      : null;
+    const nativeThumbnail = async (): Promise<Blob | null> => {
+      if (!target || !inTauri() || encodedFilename === null) return null;
+      let filename: string;
+      try {
+        filename = decodeURIComponent(encodedFilename);
+      } catch {
+        return null;
+      }
+      const media = await ipc.fetchGalleryThumbnail(target, filename);
+      if (!media) return null;
+      const bytes = Uint8Array.from(atob(media.base64), (character) => character.charCodeAt(0));
+      return new Blob([bytes], { type: media.contentType });
+    };
+    url = nativeThumbnail()
+      .then(
+        async (native) =>
+          native ?? (await (target ? apiFetchTo(target, path) : apiFetch(path))).blob(),
+      )
       .then((b) => URL.createObjectURL(b));
     cache.set(key, url);
     url.catch(() => cache.delete(key));
@@ -104,10 +130,12 @@ export async function streamableMediaUrl(
 }
 
 export function evictMedia(path: string, cacheKey?: string): void {
-  const key = keyOf(path, cacheKey);
-  const cached = cache.get(key);
-  cache.delete(key);
-  void cached?.then((u) => URL.revokeObjectURL(u)).catch(() => {});
+  const prefix = `${cacheKey ?? "primary"}|${path}|`;
+  for (const [key, cached] of [...cache]) {
+    if (!key.startsWith(prefix)) continue;
+    cache.delete(key);
+    void cached.then((u) => URL.revokeObjectURL(u)).catch(() => {});
+  }
 }
 
 /** Drop every cached blob belonging to one origin (host bucket dropped). */

--- a/desktop/src/lib/ipc.ts
+++ b/desktop/src/lib/ipc.ts
@@ -65,6 +65,11 @@ export interface SavedMedia {
   directory: string;
 }
 
+export interface NativeGalleryThumbnail {
+  base64: string;
+  contentType: string;
+}
+
 /** A remote host the app has connected to before (most recent first). */
 export interface SavedHost {
   /** URL-derived slug; its API key lives at secret `remote-api-key.<id>`. */
@@ -279,6 +284,17 @@ export const ipc = {
   localGalleryDelete(filename: string): Promise<void> {
     if (!inTauri()) return Promise.resolve();
     return invoke<void>("local_gallery_delete", { filename });
+  },
+  /** Fetch a bounded gallery thumbnail through native HTTP. Long-lived
+   * generation SSE requests can exhaust WebKit's per-host connection pool;
+   * the native client keeps Library media responsive without reducing GPU
+   * submission concurrency. */
+  fetchGalleryThumbnail(
+    target: ApiTarget,
+    filename: string,
+  ): Promise<NativeGalleryThumbnail | null> {
+    if (!inTauri()) return Promise.resolve(null);
+    return invoke<NativeGalleryThumbnail>("fetch_gallery_thumbnail", { target, filename });
   },
   /** Read a native OS-dropped PNG/JPEG plus any embedded Mold metadata. */
   importSourceImage(path: string): Promise<DesktopImageImport> {

--- a/desktop/src/stores/hosts.test.ts
+++ b/desktop/src/stores/hosts.test.ts
@@ -427,7 +427,7 @@ describe("hosts store", () => {
     expect(hosts.resolveRoute(null)?.hostId).toBe("hal9000-7680");
   });
 
-  it("requires an explicit machine when installed model profiles differ", async () => {
+  it("allows Auto across differing profiles on the same Mold major version", () => {
     const hosts = useHostsStore();
     hosts.extras.push({
       id: hal.id,
@@ -438,6 +438,46 @@ describe("hosts store", () => {
       error: null,
       instanceId: "hal-instance",
     });
+    hosts.telemetry.local = { queueDepth: 1, queueCapacity: 8, version: "0.23.1" };
+    hosts.telemetry[hal.id] = { queueDepth: 0, queueCapacity: 8, version: "0.23.0" };
+    const hostModels = useHostModelsStore();
+    hostModels.byHost.local = {
+      entries: [
+        {
+          ...installedModel(placementRequest.model),
+          generation_profile: { profile_hash: "local-profile" } as never,
+        },
+      ],
+      fetchedAt: Date.now(),
+      error: null,
+    };
+    hostModels.byHost[hal.id] = {
+      entries: [
+        {
+          ...installedModel(placementRequest.model),
+          generation_profile: { profile_hash: "remote-profile" } as never,
+        },
+      ],
+      fetchedAt: Date.now(),
+      error: null,
+    };
+
+    expect(hosts.resolveRoute(null, placementRequest.model)?.hostId).toBe(hal.id);
+  });
+
+  it("requires an explicit machine when model owners use different Mold major versions", async () => {
+    const hosts = useHostsStore();
+    hosts.extras.push({
+      id: hal.id,
+      label: "hal9000",
+      url: hal.url,
+      apiKey: "host-key",
+      status: "ready",
+      error: null,
+      instanceId: "hal-instance",
+    });
+    hosts.telemetry.local = { queueDepth: 0, queueCapacity: 8, version: "0.23.1" };
+    hosts.telemetry[hal.id] = { queueDepth: 0, queueCapacity: 8, version: "1.0.0" };
     const hostModels = useHostModelsStore();
     hostModels.byHost.local = {
       entries: [

--- a/desktop/src/stores/hosts.ts
+++ b/desktop/src/stores/hosts.ts
@@ -192,7 +192,12 @@ export type FeasibleRouteResult =
   | { kind: "route"; route: HostRoute }
   | {
       kind: "profile_mismatch";
-      perHost: Array<{ hostId: string; label: string; profileHash: string | null }>;
+      perHost: Array<{
+        hostId: string;
+        label: string;
+        profileHash: string | null;
+        version: string | null;
+      }>;
     }
   | { kind: "infeasible"; perHost: HostPlacementFailure[] }
   | { kind: "unreachable"; perHost: HostProbeFailure[] }
@@ -577,6 +582,9 @@ export const useHostsStore = defineStore("hosts", {
           ),
           modelName,
           routable.filter((host) => host.status === "ready").map((host) => host.id),
+          Object.fromEntries(
+            routable.map((host) => [host.id, this.telemetry[host.id]?.version ?? null]),
+          ),
         )
       ) {
         return null;
@@ -692,6 +700,9 @@ export const useHostsStore = defineStore("hosts", {
               ),
               request.model,
               candidates.map((host) => host.id),
+              Object.fromEntries(
+                candidates.map((host) => [host.id, this.telemetry[host.id]?.version ?? null]),
+              ),
             )
           : null;
         if (profileConflict) {
@@ -701,6 +712,7 @@ export const useHostsStore = defineStore("hosts", {
               hostId,
               label: this.all.find((host) => host.id === hostId)?.label ?? hostId,
               profileHash: profileConflict.hashesByHost[hostId] ?? null,
+              version: this.telemetry[hostId]?.version ?? null,
             })),
           };
         }

--- a/desktop/src/views/GenerateView.prepared.test.ts
+++ b/desktop/src/views/GenerateView.prepared.test.ts
@@ -11,6 +11,7 @@ import { useConnectionStore } from "../stores/connection";
 import { useGenerateFormStore } from "../stores/generateForm";
 import { newJob, useGenerationStore } from "../stores/generation";
 import { useHostsStore, type FeasibleRouteResult } from "../stores/hosts";
+import { useHostModelsStore } from "../stores/hostModels";
 import { useModelStore } from "../stores/models";
 import { useToastStore } from "../stores/toasts";
 import { useDownloadsStore } from "../stores/downloads";
@@ -192,6 +193,54 @@ describe("GenerateView prepared expansion batches", () => {
       "aerial coast",
     ]);
     expect(prepared.props("batch").route.hostId).toBe("local");
+  });
+
+  it("expands in Auto when model owners differ only by patch version", async () => {
+    const hosts = useHostsStore();
+    hosts.extras.push({
+      id: "hal9000-7680",
+      label: "hal9000",
+      url: "http://hal9000:7680",
+      apiKey: "remote-key",
+      status: "ready",
+      error: null,
+      instanceId: "hal-instance",
+    });
+    hosts.telemetry.local = { queueDepth: 1, queueCapacity: 8, version: "0.23.1" };
+    hosts.telemetry["hal9000-7680"] = {
+      queueDepth: 0,
+      queueCapacity: 8,
+      version: "0.23.0",
+    };
+    const hostModels = useHostModelsStore();
+    hostModels.byHost.local = {
+      entries: [{ ...model, generation_profile: { profile_hash: "local-profile" } } as ModelEntry],
+      fetchedAt: Date.now(),
+      error: null,
+    };
+    hostModels.byHost["hal9000-7680"] = {
+      entries: [{ ...model, generation_profile: { profile_hash: "remote-profile" } } as ModelEntry],
+      fetchedAt: Date.now(),
+      error: null,
+    };
+    vi.mocked(expandPrompt).mockResolvedValue({
+      original: "a lighthouse at dusk",
+      expanded: ["storm light", "sea mist", "aerial coast"],
+    });
+    const wrapper = mountView();
+    await flushPromises();
+
+    wrapper.findComponent(ExpandControl).vm.$emit("expand");
+    await flushPromises();
+
+    expect(expandPrompt).toHaveBeenCalledWith(
+      "a lighthouse at dusk",
+      { variations: 3, modelFamily: "flux", task: "text-to-image" },
+      { baseUrl: "http://hal9000:7680", apiKey: "remote-key" },
+    );
+    expect(wrapper.findComponent(PreparedExpansionBatch).props("batch").route.hostId).toBe(
+      "hal9000-7680",
+    );
   });
 
   it("generates Batch N directly without implicitly expanding the prompt", async () => {

--- a/studio/lib/profileFleet.test.ts
+++ b/studio/lib/profileFleet.test.ts
@@ -18,24 +18,37 @@ describe("profileHashConflict", () => {
     ).toBeNull();
   });
 
-  it("requires an explicit machine for different or missing hashes", () => {
+  it("allows profile drift within one Mold major version", () => {
     expect(
       profileHashConflict(
         { local: [model("old")], remote: [model("new")] },
         "z-image-turbo:q4",
         ["local", "remote"],
+        { local: "0.23.1", remote: "0.23.0" },
       ),
-    ).toEqual({
-      hostIds: ["local", "remote"],
-      hashesByHost: { local: "old", remote: "new" },
-    });
+    ).toBeNull();
     expect(
       profileHashConflict(
         { local: [model("same")], remote: [model(null)] },
         "z-image-turbo:q4",
         ["local", "remote"],
+        { local: "0.23.1", remote: "0.22.4" },
       ),
-    ).not.toBeNull();
+    ).toBeNull();
+  });
+
+  it("requires an explicit machine when profile drift crosses a major version", () => {
+    expect(
+      profileHashConflict(
+        { local: [model("old")], remote: [model("new")] },
+        "z-image-turbo:q4",
+        ["local", "remote"],
+        { local: "0.23.1", remote: "1.0.0" },
+      ),
+    ).toEqual({
+      hostIds: ["local", "remote"],
+      hashesByHost: { local: "old", remote: "new" },
+    });
   });
 
   it("keeps an all-legacy fleet routable during the compatibility release", () => {
@@ -67,20 +80,11 @@ describe("profileConflictMessage", () => {
   it("names conflicting machines and gives an immediate recovery action", () => {
     expect(
       profileConflictMessage([
-        { label: "This Mac", profileHash: "local-profile" },
-        { label: "plato", profileHash: "remote-profile" },
+        { label: "This Mac", profileHash: "local-profile", version: "0.23.1" },
+        { label: "plato", profileHash: "remote-profile", version: "1.0.0" },
       ]),
     ).toBe(
-      "Auto can't safely choose a machine because This Mac and plato use different generation settings for this model. They may be running different Mold versions or builds, so the same controls could produce different results. Update and reconnect them, or choose one machine for this print. Nothing was queued.",
+      "Auto can't safely choose a machine because This Mac and plato use incompatible major Mold versions for this model. Update and reconnect them, or choose one machine for this print. Nothing was queued.",
     );
-  });
-
-  it("explains when an older machine may lack a generation profile", () => {
-    expect(
-      profileConflictMessage([
-        { label: "This Mac", profileHash: "current-profile" },
-        { label: "studio", profileHash: null },
-      ]),
-    ).toContain("At least one may be running an older Mold version");
   });
 });

--- a/studio/lib/profileFleet.ts
+++ b/studio/lib/profileFleet.ts
@@ -1,11 +1,10 @@
 /**
  * Profile-consistency checks for automatic multi-host generation routing.
  *
- * A model name is not a sufficient execution contract: two machines may run
- * different Mold versions and advertise different settings for that model.
- * Explicit routing is always safe because the selected machine is the
- * authority. Automatic routing is safe only when every eligible owner agrees
- * on the exact profile hash.
+ * A model name is not a sufficient execution contract across incompatible
+ * protocol generations. Explicit routing is always safe because the selected
+ * machine is the authority. Automatic routing only stops at a Mold major-
+ * version boundary; minor, patch, and build drift is intentionally compatible.
  */
 
 export interface FleetProfileModel {
@@ -22,6 +21,7 @@ export interface ProfileHashConflict {
 export interface ProfileConflictHost {
   label: string;
   profileHash: string | null;
+  version?: string | null;
 }
 
 function formatMachineList(hosts: readonly ProfileConflictHost[]): string {
@@ -36,17 +36,21 @@ export function profileConflictMessage(
   hosts: readonly ProfileConflictHost[],
 ): string {
   const owners = formatMachineList(hosts);
-  const hasLegacyOwner = hosts.some((host) => !host.profileHash);
-  const cause = hasLegacyOwner
-    ? "At least one may be running an older Mold version, so the same controls could produce different results."
-    : "They may be running different Mold versions or builds, so the same controls could produce different results.";
-  return `Auto can't safely choose a machine because ${owners} use different generation settings for this model. ${cause} Update and reconnect them, or choose one machine for this print. Nothing was queued.`;
+  return `Auto can't safely choose a machine because ${owners} use incompatible major Mold versions for this model. Update and reconnect them, or choose one machine for this print. Nothing was queued.`;
+}
+
+function majorVersion(version: string | null | undefined): number | null {
+  const match = version?.trim().match(/^v?(\d+)(?:\.|$)/);
+  if (!match) return null;
+  const major = Number(match[1]);
+  return Number.isSafeInteger(major) ? major : null;
 }
 
 export function profileHashConflict(
   modelsByHost: Readonly<Record<string, readonly FleetProfileModel[]>>,
   modelName: string,
   eligibleHostIds: readonly string[],
+  versionsByHost: Readonly<Record<string, string | null | undefined>> = {},
 ): ProfileHashConflict | null {
   const owners = eligibleHostIds.flatMap((hostId) => {
     const model = modelsByHost[hostId]?.find(
@@ -62,15 +66,15 @@ export function profileHashConflict(
       model.generation_profile?.profile_hash?.trim() || null,
     ]),
   );
-  const hashes = Object.values(hashesByHost);
-  // During the one-release compatibility window, a fleet made entirely of
-  // legacy servers has one shared (legacy) contract. The unsafe case is a
-  // partially upgraded fleet or two concrete hashes that disagree.
-  if (
-    hashes.every((hash) => hash === null) ||
-    (hashes.every((hash) => hash !== null) && new Set(hashes).size === 1)
-  ) {
-    return null;
-  }
+  const majors = new Set(
+    owners
+      .map(({ hostId }) => majorVersion(versionsByHost[hostId]))
+      .filter((major): major is number => major !== null),
+  );
+  // Profile hashes naturally drift as defaults and capabilities evolve. They
+  // remain useful diagnostics, but only a definite major-version split is an
+  // automatic-routing incompatibility. Unknown versions fail open here; the
+  // selected host's placement preview still validates the concrete request.
+  if (majors.size <= 1) return null;
   return { hostIds: owners.map(({ hostId }) => hostId), hashesByHost };
 }

--- a/web/src/composables/useHostRouting.test.ts
+++ b/web/src/composables/useHostRouting.test.ts
@@ -1443,15 +1443,36 @@ describe("useHostRouting", () => {
     expect(route?.target.baseUrl).not.toContain("sk-studio");
   });
 
-  it("requires an explicit machine when installed model profiles differ", async () => {
+  it("allows Auto across differing model profiles on the same Mold major version", async () => {
     const studio = addHost({ url: "http://studio:7680", name: "Studio" });
-    statuses.set(ORIGIN_HOST_ID, status());
+    statuses.set(ORIGIN_HOST_ID, status({ version: "0.23.1", queue_depth: 1 }));
     models.set(ORIGIN_HOST_ID, [
       model("flux-dev:q4", {
         generation_profile: { profile_hash: "origin-profile" } as never,
       }),
     ]);
-    statuses.set(studio.id, status());
+    statuses.set(studio.id, status({ version: "0.23.0", queue_depth: 0 }));
+    models.set(studio.id, [
+      model("flux-dev:q4", {
+        generation_profile: { profile_hash: "studio-profile" } as never,
+      }),
+    ]);
+    setGenerateTargetId(AUTO_TARGET_ID);
+    const routing = useHostRouting();
+    await routing.refresh();
+
+    expect(routing.resolve("flux-dev:q4")?.hostId).toBe(studio.id);
+  });
+
+  it("requires an explicit machine when model owners use different Mold major versions", async () => {
+    const studio = addHost({ url: "http://studio:7680", name: "Studio" });
+    statuses.set(ORIGIN_HOST_ID, status({ version: "0.23.1" }));
+    models.set(ORIGIN_HOST_ID, [
+      model("flux-dev:q4", {
+        generation_profile: { profile_hash: "origin-profile" } as never,
+      }),
+    ]);
+    statuses.set(studio.id, status({ version: "1.0.0" }));
     models.set(studio.id, [
       model("flux-dev:q4", {
         generation_profile: { profile_hash: "studio-profile" } as never,
@@ -1483,10 +1504,12 @@ describe("useHostRouting", () => {
         expect.objectContaining({
           hostId: ORIGIN_HOST_ID,
           profileHash: "origin-profile",
+          version: "0.23.1",
         }),
         expect.objectContaining({
           hostId: studio.id,
           profileHash: "studio-profile",
+          version: "1.0.0",
         }),
       ],
     });

--- a/web/src/composables/useHostRouting.ts
+++ b/web/src/composables/useHostRouting.ts
@@ -86,6 +86,7 @@ type GpuInfoWithBackend = GpuInfo & { backend?: string | null };
 
 interface HostTelemetry {
   status: HostRoutingStatus;
+  version: string | null;
   instanceId: string | null;
   queueDepth: number | null;
   gpu: RoutableGpu | null;
@@ -184,6 +185,7 @@ export type FeasibilityResult =
         hostId: string;
         label: string;
         profileHash: string | null;
+        version: string | null;
       }>;
     }
   | {
@@ -450,6 +452,7 @@ async function pollHost(entry: HostEntry): Promise<void> {
       ...telemetry.value,
       [entry.id]: {
         status: generationReady ? "ready" : "error",
+        version: status.value.version ?? null,
         instanceId: nextInstanceId,
         queueDepth: status.value.queue_depth ?? null,
         gpu: gpuFromStatus(status.value, inventory),
@@ -468,6 +471,7 @@ async function pollHost(entry: HostEntry): Promise<void> {
       ...telemetry.value,
       [entry.id]: {
         status: "error",
+        version: telemetry.value[entry.id]?.version ?? null,
         instanceId:
           telemetry.value[entry.id]?.instanceId ?? entry.instanceId ?? null,
         queueDepth: null,
@@ -605,6 +609,12 @@ function resolve(model: string | null): HostRoute | null {
       accessibleModelsByHost.value,
       model,
       eligible.filter((host) => host.status === "ready").map((host) => host.id),
+      Object.fromEntries(
+        eligible.map((host) => [
+          host.id,
+          telemetry.value[host.id]?.version ?? null,
+        ]),
+      ),
     )
   ) {
     return null;
@@ -655,6 +665,12 @@ async function resolveFeasibleWithPreview(
       accessibleModelsByHost.value,
       model,
       candidates.map((candidate) => candidate.id),
+      Object.fromEntries(
+        candidates.map((candidate) => [
+          candidate.id,
+          telemetry.value[candidate.id]?.version ?? null,
+        ]),
+      ),
     );
     if (conflict) {
       return {
@@ -665,6 +681,7 @@ async function resolveFeasibleWithPreview(
             candidates.find((candidate) => candidate.id === hostId)?.label ??
             hostId,
           profileHash: conflict.hashesByHost[hostId] ?? null,
+          version: telemetry.value[hostId]?.version ?? null,
         })),
       };
     }


### PR DESCRIPTION
## Root causes

- Four long-lived generation SSE requests can occupy WebKit's per-origin connection pool, leaving Library thumbnail requests queued even though gallery metadata and files are already available.
- Auto routing treated any generation-profile hash drift as incompatible, so 0.23.1 and 0.23.0 owners incorrectly blocked prompt expansion and generation.
- Discover loaded family taxonomy once and rendered an empty selector while that request was slow or failed; it had no inventory/result fallback or reconnect re-drive.

## Fix

- Fetch bounded thumbnails through a shared, authenticated native HTTP client with concurrency, queue, request, and size limits; keep transient thumbnail retries route-aware without retrying unbounded media.
- Treat only definite Mold major-version splits as Auto-routing conflicts; minor/patch/build drift remains routable and placement preview validates the concrete request.
- Populate model families immediately from installed inventory/search history, retain the last taxonomy, and retry taxonomy/failed searches when the browsing route changes.

## Validation

- `nix develop -c desktop-check`
- `nix develop -c desktop-test` (120 native/integration tests; 3,676 frontend tests)
- Rendered browser QA: Discover exposed 11 family choices immediately; filtering to Qwen retained the full selector; no console errors
- Independent subagent peer review completed; all findings addressed and final re-review reported no actionable defects.