### PR TITLE
fix(studio): reset invalid duration on model switch

### DIFF
--- a/desktop/src/lib/generateForm.test.ts
+++ b/desktop/src/lib/generateForm.test.ts
@@ -1020,6 +1020,37 @@ describe("applyModelDefaults — model-advertised fps", () => {
   });
 });
 
+describe("applyModelDefaults — model-aware duration", () => {
+  it("replaces an off-grid H3 duration with Wan's advertised default", () => {
+    const form = newGenerateForm();
+    form.frames = 124;
+
+    applyModelDefaults(form, {
+      ...wanModel(),
+      default_frames: 121,
+      default_fps: 24,
+      frame_step: 4,
+    });
+
+    expect(form.frames).toBe(121);
+    expect(form.fps).toBe(24);
+  });
+
+  it("preserves a deliberate duration that is valid for the target model", () => {
+    const form = newGenerateForm();
+    form.frames = 125;
+
+    applyModelDefaults(form, {
+      ...wanModel(),
+      default_frames: 121,
+      default_fps: 24,
+      frame_step: 4,
+    });
+
+    expect(form.frames).toBe(125);
+  });
+});
+
 describe("applyModelDefaults resets advanced video on family change", () => {
   it("clears the LTX-2 settings knobs but retains staged media when leaving", () => {
     const form = ltx2Form();

--- a/desktop/src/lib/generateForm.ts
+++ b/desktop/src/lib/generateForm.ts
@@ -30,6 +30,7 @@ import {
   type SourceFitPolicy,
 } from "@studio/lib/sourceFit";
 import { defaultVideoFps } from "@studio/lib/sequence";
+import { videoFramesForModelSelection } from "@studio/lib/videoDuration";
 import { familySupportsExtend, resolveExtendOverlapFrames } from "@studio/lib/extend";
 import { findInstalledModel } from "./generateModels";
 import {
@@ -324,6 +325,8 @@ export function applyModelDefaults(form: GenerateForm, m: ModelEntry): void {
   form.guidanceCapabilities = m.guidance_capabilities ?? null;
   if (isMinimaxH3Family(m.family)) {
     form.frames = m.default_frames ?? MINIMAX_H3_MIN_FRAMES;
+  } else if (m.default_frames != null) {
+    form.frames = videoFramesForModelSelection(form.frames, m);
   }
   // The model's advertised rate is applied like steps/guidance — it is only
   // absent-server/absent-field that leaves the current value in place.

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -379,6 +379,46 @@ afterEach(() => {
 });
 
 describe("MobileApp sequence generation", () => {
+  it("enters Wan on its default duration after an H3 model", async () => {
+    const h3: ModelEntry = {
+      ...model,
+      name: "minimax-h3-fl2va:official-bf16",
+      family: "minimax-h3",
+      source_image: "required",
+      default_frames: 124,
+      default_fps: 24,
+    };
+    const wan: ModelEntry = {
+      ...model,
+      name: "wan22-ti2v-5b:turbo",
+      family: "wan",
+      default_frames: 121,
+      default_fps: 24,
+      frame_step: 4,
+    };
+    apiJsonTo.mockImplementation((_target: unknown, path: string) => {
+      if (path === "/api/status") return Promise.resolve(status);
+      if (path === "/api/models") return Promise.resolve([h3, wan]);
+      if (path === "/api/gallery") return Promise.resolve([]);
+      if (path === "/api/activity") {
+        return Promise.resolve({ instance_id: "mobile-host", observed_at_unix_ms: 1, items: [] });
+      }
+      return Promise.reject(new Error(`Unexpected API path: ${path}`));
+    });
+
+    wrapper = mountMobileApp();
+    await flushPromises();
+    const liveForm = wrapper.getComponent(MobileLoraControls).props("form") as GenerateForm;
+    expect(liveForm.frames).toBe(124);
+
+    await fieldControl("Model").setValue(wan.name);
+    await flushPromises();
+
+    expect(liveForm.frames).toBe(121);
+    expect(liveForm.fps).toBe(24);
+    expect(wrapper.text()).not.toContain("Frames must be 4n+1");
+  });
+
   it("retires dormant original-prompt provenance when a new prompt is authored", async () => {
     wrapper = mountMobileApp();
     await flushPromises();

--- a/studio/lib/videoDuration.test.ts
+++ b/studio/lib/videoDuration.test.ts
@@ -7,6 +7,7 @@ import {
   minVideoFrames,
   snapVideoFrames,
   videoFramesError,
+  videoFramesForModelSelection,
   videoFrameStep,
   videoFrameOffset,
   fixedVideoFps,
@@ -64,6 +65,18 @@ describe("video duration controls", () => {
     expect(snapVideoFrames(45, { family: "ltx2" })).toBe(49);
     expect(snapVideoFrames(53, wan)).toBe(53);
     expect(snapVideoFrames(53, { family: "ltx2" })).toBe(57);
+  });
+
+  it("uses the target default instead of carrying an off-grid duration", () => {
+    const wan = {
+      family: "wan",
+      default_frames: 121,
+      default_fps: 24,
+      frame_step: 4,
+    };
+
+    expect(videoFramesForModelSelection(124, wan)).toBe(121);
+    expect(videoFramesForModelSelection(125, wan)).toBe(125);
   });
 
   it("validates frame counts against the selected model grid", () => {

--- a/studio/lib/videoDuration.ts
+++ b/studio/lib/videoDuration.ts
@@ -196,6 +196,28 @@ export function videoFrameGridError(
   return null;
 }
 
+/**
+ * Keep an authored duration when it is valid for the newly selected model,
+ * otherwise enter that model on its advertised default. This is deliberately
+ * different from snapping to the nearest grid point: a carried H3 value such
+ * as 124 would render as 125 in Wan's slider while the request still contained
+ * the rejected 124. Model selection is the authority boundary, so an invalid
+ * carried value yields to the target model's own measured default instead.
+ */
+export function videoFramesForModelSelection(
+  frames: number | null | undefined,
+  model?: VideoFrameContract | null,
+): number {
+  const fallback = model?.default_frames ?? frames ?? 25;
+  const rate = fixedVideoFps(model) ?? model?.default_fps ?? 24;
+  const normalizedDefault = clampVideoFrames(fallback, rate, model);
+
+  if (frames == null || videoFrameGridError(frames, model)) {
+    return normalizedDefault;
+  }
+  return frames;
+}
+
 export function clampVideoFrames(
   frames: number,
   fps: number,

--- a/web/src/composables/useGenerateForm.test.ts
+++ b/web/src/composables/useGenerateForm.test.ts
@@ -1028,6 +1028,24 @@ describe("useGenerateForm", () => {
     expect(form.state.value.fps).toBe(30);
   });
 
+  it("applyModelDefaults replaces an off-grid H3 duration with Wan's default", () => {
+    const form = useGenerateForm();
+    form.state.value.frames = 124;
+
+    form.applyModelDefaults(
+      makeModel({
+        name: "wan22-t2v-a14b:q5",
+        family: "wan",
+        default_frames: 121,
+        default_fps: 24,
+        frame_step: 4,
+      }),
+    );
+
+    expect(form.state.value.frames).toBe(121);
+    expect(form.state.value.fps).toBe(24);
+  });
+
   it("applyModelDefaults clears a scheduler the new family's options reject", () => {
     const form = useGenerateForm();
     // A UNet scheduler carried into wan is a server-side rejection, not a

--- a/web/src/composables/useGenerateForm.ts
+++ b/web/src/composables/useGenerateForm.ts
@@ -36,6 +36,7 @@ import {
   restoredNegativePrompt,
 } from "@studio/lib/negativePrompt";
 import { defaultVideoFps } from "@studio/lib/sequence";
+import { videoFramesForModelSelection } from "@studio/lib/videoDuration";
 import {
   familySupportsExtend,
   resolveExtendOverlapFrames,
@@ -281,7 +282,7 @@ function modelDefaultsPatch(
   if (capabilities.supportsVideo) {
     next.frames = isMinimaxH3Family(model.family)
       ? (model.default_frames ?? MINIMAX_H3_MIN_FRAMES)
-      : (next.frames ?? model.default_frames ?? 25);
+      : videoFramesForModelSelection(next.frames, model);
     // The model's advertised rate is applied like steps/guidance — it is only
     // absent-server/absent-field that leaves the current value in place.
     next.fps = defaultVideoFps(model, next.fps);


### PR DESCRIPTION
## Summary
- reset off-grid carried video durations to the newly selected model's advertised default
- share the model-selection policy across desktop, web, and iPhone while preserving compatible authored durations
- cover the MiniMax H3 124-frame to Wan TI2V 121-frame regression and confirm the TUI already applies model defaults

## Validation
- `nix develop -c bun run test:studio` (738 tests)
- `nix develop -c bun run test:web` (1,371 tests)
- `nix develop -c bun run test:desktop` (3,670 tests before latest main; 318 focused desktop/mobile tests after rebase)
- `nix develop -c bun run check:architecture`
- `nix develop -c bun run build:web`
- `nix develop -c bun run build:desktop`
- `nix develop -c bun run build:mobile`
- independent agent peer review: approved after one test-fixture correction; no remaining findings