### PR TITLE
fix(studio): show sequence image thumbnails

### DIFF
--- a/desktop/src/components/create/SequenceAdvancedSettings.test.ts
+++ b/desktop/src/components/create/SequenceAdvancedSettings.test.ts
@@ -69,6 +69,21 @@ describe("SequenceAdvancedSettings camera motion", () => {
     expect(wrapper.text()).toContain("Install an upscaler");
   });
 
+  it("renders the shared one-shot thumbnail for the sequence opening image", () => {
+    const draft = useSequenceDraftStore();
+    draft.openingImage = { filename: "opening.jpg", base64: "QUJD" };
+    const wrapper = mount(SequenceAdvancedSettings, {
+      props: { form: newGenerateForm() },
+    });
+
+    const image = wrapper.get(
+      "[data-test='sequence-section-opening-image'] .image-well__preview img",
+    );
+    expect(image.attributes("src")).toBe("data:image/jpeg;base64,QUJD");
+    expect(image.attributes("alt")).toBe("Opening sequence image");
+    expect(wrapper.find("[data-test='sequence-opening-image-remove']").exists()).toBe(true);
+  });
+
   it("resets camera motion across the sequence", async () => {
     const draft = useSequenceDraftStore();
     draft.clips[0]!.cameraControl = "dolly-in";

--- a/desktop/src/components/create/SequenceAdvancedSettings.vue
+++ b/desktop/src/components/create/SequenceAdvancedSettings.vue
@@ -16,6 +16,10 @@ import {
 } from "@studio/lib/sourceFit";
 import ImagePickerModal from "../generate/ImagePickerModal.vue";
 import { generationCapabilitiesForFamily } from "../../lib/capabilities";
+import ImageDropWell from "@studio/components/ImageDropWell.vue";
+import { imageDimensionsFromBase64 } from "@studio/lib/imageDimensions";
+import { fileToBase64 } from "../../lib/image";
+import { useToastStore } from "../../stores/toasts";
 
 const props = withDefaults(
   defineProps<{
@@ -38,7 +42,11 @@ const props = withDefaults(
 );
 
 const draft = useSequenceDraftStore();
+const toasts = useToastStore();
 const pickerOpen = ref(false);
+const openingImageMime = computed(() =>
+  /\.jpe?g$/i.test(draft.openingImage?.filename ?? "") ? "image/jpeg" : "image/png",
+);
 const activeClip = computed(
   () => draft.clips.find((clip) => clip.id === draft.activeClipId) ?? draft.clips[0] ?? null,
 );
@@ -108,6 +116,26 @@ function onPickImage(images: PickedImage[]) {
   props.form.sourceFit = coerceSourceFitForMaskless(props.form.sourceFit);
 }
 
+async function onOpeningImageFile(file: File) {
+  try {
+    const base64 = await fileToBase64(file);
+    const dimensions = imageDimensionsFromBase64(base64);
+    if (!dimensions) {
+      toasts.push("Only PNG or JPEG images can be used here.", "error");
+      return;
+    }
+    draft.openingImage = {
+      filename: file.name,
+      base64,
+      width: dimensions.width,
+      height: dimensions.height,
+    };
+    props.form.sourceFit = coerceSourceFitForMaskless(props.form.sourceFit);
+  } catch {
+    toasts.push("Couldn't read the image.", "error");
+  }
+}
+
 // Reset clears sequence-advanced knobs only; the opening image and its
 // strength/fit are staged source media and survive (web parity).
 function reset() {
@@ -144,27 +172,19 @@ function reset() {
         :header-interactive="false"
         data-test="sequence-section-opening-image"
       >
-        <button
-          type="button"
-          class="ms-dropzone"
-          data-test="sequence-opening-image-pick"
-          @click="pickerOpen = true"
-        >
-          {{
-            draft.openingImage
-              ? `Replace ${draft.openingImage.filename}`
-              : "Drop an image or click to choose the original starting frame"
-          }}
-        </button>
-        <button
-          v-if="draft.openingImage"
-          type="button"
-          class="ms-remove"
-          data-test="sequence-opening-image-clear"
-          @click="draft.openingImage = null"
-        >
-          Remove opening image
-        </button>
+        <ImageDropWell
+          :image="draft.openingImage?.base64 ?? null"
+          :mime-type="openingImageMime"
+          :filename="draft.openingImage?.filename ?? null"
+          placeholder="Drop an image or click to pick the original starting frame"
+          accept="image/png,image/jpeg"
+          gallery
+          alt="Opening sequence image"
+          test-id="sequence-opening-image"
+          @file="onOpeningImageFile"
+          @gallery="pickerOpen = true"
+          @clear="draft.openingImage = null"
+        />
         <div v-if="draft.openingImage" class="ms-source-controls">
           <label class="ms-range">
             <span>
@@ -328,17 +348,14 @@ function reset() {
   font-family: var(--f-mono);
   font-size: 10px;
 }
-.ms-adv__reset,
-.ms-remove,
-.ms-dropzone {
+.ms-adv__reset {
   border: 1px solid var(--ce);
   background: transparent;
   color: var(--ink-2);
   border-radius: 8px;
   cursor: pointer;
 }
-.ms-adv__reset,
-.ms-remove {
+.ms-adv__reset {
   padding: 5px 9px;
   font-size: 11px;
 }
@@ -364,16 +381,6 @@ function reset() {
 .ms-range input {
   width: 100%;
   accent-color: var(--safelight);
-}
-.ms-dropzone {
-  width: 100%;
-  border-style: dashed;
-  padding: 22px 12px;
-  font-size: 12px;
-}
-.ms-remove {
-  margin-top: 9px;
-  color: var(--stop);
 }
 .ms-adv__list {
   display: flex;

--- a/web/src/components/create/AdvancedDrawer.test.ts
+++ b/web/src/components/create/AdvancedDrawer.test.ts
@@ -8,6 +8,7 @@ import {
 import type { GenerateFormState, ModelInfoExtended } from "../../types";
 import { createPinia, setActivePinia } from "pinia";
 import { useSequenceDraftStore } from "@studio/stores/sequenceDraft";
+import ImageDropWell from "@studio/components/ImageDropWell.vue";
 
 // The upscale section reads the host's model list. Only upscalers matter here.
 const UPSCALERS: ModelInfoExtended[] = [
@@ -171,6 +172,46 @@ describe("AdvancedDrawer sequence contract", () => {
     expect(wrapper.emitted("update:modelValue")?.at(-1)?.[0]).toMatchObject({
       sourceFitPolicy: { mode: "lanczos-resize" },
     });
+  });
+
+  it("renders the shared one-shot thumbnail for the sequence opening image", async () => {
+    const wrapper = factory("ltx2", {}, { output: "sequence" });
+    useSequenceDraftStore().openingImage = {
+      filename: "opening.jpg",
+      base64: "QUJD",
+    };
+    await wrapper.vm.$nextTick();
+
+    const image = wrapper.get(
+      "[data-test='sequence-section-opening-image'] .image-well__preview img",
+    );
+    expect(image.attributes("src")).toBe("data:image/jpeg;base64,QUJD");
+    expect(image.attributes("alt")).toBe("Opening sequence image");
+    expect(
+      wrapper.find("[data-test='sequence-opening-image-remove']").exists(),
+    ).toBe(true);
+  });
+
+  it("clears a rejected-file error before opening the gallery picker", async () => {
+    const wrapper = factory("ltx2", {}, { output: "sequence" });
+    wrapper.findComponent(ImageDropWell).vm.$emit(
+      "file",
+      new File([new Uint8Array([0x47, 0x49, 0x46, 0x38])], "bad.gif", {
+        type: "image/gif",
+      }),
+    );
+    await flushPromises();
+    expect(
+      wrapper.find("[data-test='sequence-opening-image-error']").exists(),
+    ).toBe(true);
+
+    await wrapper
+      .get("[data-test='sequence-opening-image-gallery']")
+      .trigger("click");
+    expect(
+      wrapper.find("[data-test='sequence-opening-image-error']").exists(),
+    ).toBe(false);
+    expect(wrapper.emitted("open-picker")).toHaveLength(1);
   });
 
   it("edits and resets camera motion on the active clip", async () => {

--- a/web/src/components/create/AdvancedDrawer.vue
+++ b/web/src/components/create/AdvancedDrawer.vue
@@ -25,6 +25,8 @@ import PlacementPanel from "../PlacementPanel.vue";
 import ExtendVideoControls from "./advanced/ExtendVideoControls.vue";
 import Ltx2VideoControls from "./advanced/Ltx2VideoControls.vue";
 import MinimaxH3AuthoringPanel from "@studio/components/MinimaxH3AuthoringPanel.vue";
+import ImageDropWell from "@studio/components/ImageDropWell.vue";
+import { imageDimensionsFromBase64 } from "@studio/lib/imageDimensions";
 import { DEFAULT_EXTEND_OVERLAP_FRAMES } from "@studio/lib/extend";
 import UpscaleSection from "./advanced/UpscaleSection.vue";
 import type {
@@ -83,6 +85,7 @@ import {
   effectiveGenerationRecipe,
   resolutionProfileFinding,
 } from "@studio/lib/generationProfile";
+import { blobToBase64 } from "../../lib/base64";
 
 const props = withDefaults(
   defineProps<{
@@ -218,6 +221,44 @@ const NEG_CHIPS = [
 // Desktop/tablet web (spec §06 v0.12): render inline as an always-visible
 // column. Phone: render inside the Advanced sheet.
 const inline = computed(() => !props.mobile);
+const sequenceOpeningImageError = ref<string | null>(null);
+const sequenceOpeningImageMime = computed(() =>
+  /\.jpe?g$/i.test(draft.openingImage?.filename ?? "")
+    ? "image/jpeg"
+    : "image/png",
+);
+
+async function onSequenceOpeningImageFile(file: File) {
+  const base64 = await blobToBase64(file);
+  const dimensions = imageDimensionsFromBase64(base64);
+  if (!dimensions) {
+    sequenceOpeningImageError.value =
+      "Only PNG or JPEG images can be used here.";
+    return;
+  }
+  sequenceOpeningImageError.value = null;
+  draft.openingImage = {
+    filename: file.name,
+    base64,
+    width: dimensions.width,
+    height: dimensions.height,
+  };
+  patch({
+    sourceFitPolicy: coerceSourceFitForMaskless(
+      props.modelValue.sourceFitPolicy ?? { mode: "crop-fill" },
+    ),
+  });
+}
+
+function clearSequenceOpeningImage() {
+  sequenceOpeningImageError.value = null;
+  draft.openingImage = null;
+}
+
+function openSequenceOpeningImagePicker() {
+  sequenceOpeningImageError.value = null;
+  emit("open-picker");
+}
 
 // The fifth argument is the selected checkpoint's own advertised
 // source-image contract (#772): wan's checkpoints split T2V / I2V-optional /
@@ -527,27 +568,27 @@ function setSequenceCameraMode(mode: string) {
           :header-interactive="false"
           data-test="sequence-section-opening-image"
         >
-          <button
-            type="button"
-            class="adv__dropzone"
-            data-test="sequence-opening-image-pick"
-            @click="emit('open-picker')"
+          <ImageDropWell
+            :image="draft.openingImage?.base64 ?? null"
+            :mime-type="sequenceOpeningImageMime"
+            :filename="draft.openingImage?.filename ?? null"
+            placeholder="Drop an image or click to pick the original starting frame"
+            accept="image/png,image/jpeg"
+            gallery
+            alt="Opening sequence image"
+            test-id="sequence-opening-image"
+            @file="onSequenceOpeningImageFile"
+            @gallery="openSequenceOpeningImagePicker"
+            @clear="clearSequenceOpeningImage"
+          />
+          <p
+            v-if="sequenceOpeningImageError"
+            class="adv__error"
+            role="alert"
+            data-test="sequence-opening-image-error"
           >
-            {{
-              draft.openingImage
-                ? `Replace ${draft.openingImage.filename}`
-                : "Drop an image or browse for the original starting frame"
-            }}
-          </button>
-          <button
-            v-if="draft.openingImage"
-            type="button"
-            class="adv__remove"
-            data-test="sequence-opening-image-clear"
-            @click="draft.openingImage = null"
-          >
-            Remove opening image
-          </button>
+            {{ sequenceOpeningImageError }}
+          </p>
           <template v-if="draft.openingImage">
             <SliderRow
               label="Source strength"
@@ -1292,16 +1333,6 @@ function setSequenceCameraMode(mode: string) {
   border-color: var(--safelight);
   color: var(--rebate);
 }
-.adv__dropzone {
-  width: 100%;
-  border: 1.5px dashed var(--ce);
-  background: transparent;
-  color: var(--ink-2);
-  border-radius: var(--radius-card);
-  padding: 26px;
-  font-size: 13px;
-  cursor: pointer;
-}
 .adv__accent {
   color: var(--safelight);
   font-weight: 600;
@@ -1318,14 +1349,6 @@ function setSequenceCameraMode(mode: string) {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-.adv__remove {
-  border: 0;
-  background: transparent;
-  color: var(--stop);
-  font-size: 12px;
-  font-weight: 600;
-  cursor: pointer;
 }
 .adv__mask {
   margin-top: 12px;


### PR DESCRIPTION
## Summary
- reuse the one-shot ImageDropWell for sequence opening images on web and desktop
- render the attached PNG/JPEG thumbnail with the shared replace, gallery, and remove behavior
- preserve source-fit handling and validate direct file picks
- clear stale validation errors before switching to the gallery picker

## Validation
- nix develop -c bun run check:architecture
- nix develop -c bun run test:web (93 files, 1373 tests)
- nix develop -c bun run test:desktop (323 files, 3683 tests)
- nix develop -c bun run --cwd web build
- nix develop -c bun run --cwd desktop build
- focused web regression suite (52 tests)
- focused desktop regression suite (8 tests)
- browser QA at http://127.0.0.1:5174/create

## Review
- independent subagent review completed
- addressed stale gallery-error state and removed dead bespoke styles
- second review found no remaining actionable issues