### PR TITLE
fix(studio): move video audio into basic settings

### DIFF
--- a/desktop/src/components/create/AdvancedSettings.test.ts
+++ b/desktop/src/components/create/AdvancedSettings.test.ts
@@ -649,6 +649,7 @@ describe("AdvancedSettings — reset and summary", () => {
     form.sourceFit = { mode: "crop-fill" };
     form.maskImage = "MASK";
     form.negativePrompt = "blurry";
+    form.enableAudio = true;
     const wrapper = mountSettings(form, { selectedModel: model });
     wrapper.get("[data-test='advanced-reset']").trigger("click");
     expect(form.sourceImage).toBe("SRC");
@@ -657,6 +658,7 @@ describe("AdvancedSettings — reset and summary", () => {
     expect(form.sourceFit).toEqual({ mode: "crop-fill" });
     expect(form.maskImage).toBe("MASK");
     expect(form.negativePrompt).toBe("");
+    expect(form.enableAudio).toBe(true);
   });
 
   it("badges the active advanced count in the header", () => {

--- a/desktop/src/components/create/AdvancedSettings.vue
+++ b/desktop/src/components/create/AdvancedSettings.vue
@@ -95,7 +95,6 @@ import { attachPickedVideo } from "../../lib/sourceAttachment";
 import MinimaxH3AuthoringPanel from "@studio/components/MinimaxH3AuthoringPanel.vue";
 import {
   emptyMinimaxH3AuthoringState,
-  isMinimaxH3Identity,
   minimaxH3TaskForModel,
   type MinimaxH3AuthoringState,
 } from "@studio/lib/minimaxH3Authoring";
@@ -137,13 +136,11 @@ const caps = computed(() =>
     effectiveGenerationRecipe(props.selectedModel, props.form.pipeline),
   ),
 );
-const audioOutputSupported = computed(() => props.selectedModel?.supports_audio !== false);
 const formats = computed(() => caps.value.outputFormats as OutputFormat[]);
 const advancedCount = computed(() => advancedActiveCount(props.form));
 const h3Task = computed(() =>
   props.selectedModel ? minimaxH3TaskForModel(props.form.model) : null,
 );
-const h3Family = computed(() => isMinimaxH3Identity(props.form.family, props.form.model));
 const h3Authoring = computed(() => props.form.h3Authoring ?? emptyMinimaxH3AuthoringState());
 function setH3Authoring(value: MinimaxH3AuthoringState): void {
   props.form.h3Authoring = value;
@@ -870,18 +867,6 @@ function reset() {
           </p>
         </template>
 
-        <div v-if="caps.supportsAudio && !h3Family" class="ms-switch-row ms-switch-row--mt">
-          <div class="ms-switch-row__title">Generate audio</div>
-          <SwitchToggle
-            :model-value="form.enableAudio"
-            :disabled="!audioOutputSupported"
-            label="Generate audio"
-            @update:model-value="form.enableAudio = $event"
-          />
-        </div>
-        <p v-if="caps.supportsAudio && !h3Family && !audioOutputSupported" class="ms-hint">
-          Audio assets are not included with this checkpoint. Video generation remains available.
-        </p>
         <p v-if="audioFormatError" class="ms-error" role="alert">{{ audioFormatError }}</p>
 
         <template v-if="caps.supportsAdvancedVideo">

--- a/desktop/src/components/create/InspectorPanel.test.ts
+++ b/desktop/src/components/create/InspectorPanel.test.ts
@@ -8,6 +8,7 @@ import ResolutionSelector from "@ui/components/ResolutionSelector.vue";
 import SliderRow from "@ui/components/SliderRow.vue";
 import VideoDurationSlider from "@ui/components/VideoDurationSlider.vue";
 import Stepper from "@ui/components/Stepper.vue";
+import SwitchToggle from "@ui/components/SwitchToggle.vue";
 import BadgePill from "@ui/components/BadgePill.vue";
 import PanelResizeHandle from "../shell/PanelResizeHandle.vue";
 import { aspectIdFor } from "../../lib/resolutions";
@@ -82,9 +83,19 @@ describe("InspectorPanel — layout", () => {
     const wrapper = mount(InspectorPanel, { props: { form } });
     const duration = wrapper.getComponent(VideoDurationSlider);
     expect(duration.text()).toContain("4.0s");
+    expect(wrapper.find('[data-test="generate-audio-control"]').exists()).toBe(true);
+    wrapper.getComponent(SwitchToggle).vm.$emit("update:modelValue", true);
+    expect(form.enableAudio).toBe(true);
     duration.vm.$emit("update:frames", 241);
     await flushPromises();
     expect(form.frames).toBe(241);
+  });
+
+  it("does not expose the audio toggle for an H3 model restored without a family", () => {
+    const form = formFor("");
+    form.model = "minimax-h3-fl2va:official-bf16";
+    const wrapper = mount(InspectorPanel, { props: { form } });
+    expect(wrapper.find('[data-test="generate-audio-control"]').exists()).toBe(false);
   });
 
   it("defaults wide enough for one ratio row and persists left-edge resizing", async () => {
@@ -485,9 +496,10 @@ describe("InspectorPanel — advanced", () => {
 
     await wrapper.get('[data-test="open-advanced"]').trigger("click");
 
+    expect(wrapper.find('[data-test="generate-audio-control"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="sequence-section-opening-image"]').exists()).toBe(true);
     expect(wrapper.find('[data-test="sequence-section-negative"]').exists()).toBe(true);
-    expect(wrapper.find('[data-test="sequence-section-audio"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="sequence-section-audio"]').exists()).toBe(false);
     expect(wrapper.find('[data-test="inline-advanced"]').exists()).toBe(false);
   });
 });
@@ -532,6 +544,17 @@ describe("InspectorPanel — reset to model defaults", () => {
     expect(form.steps).toBe(30);
     expect(form.width).toBe(1024);
     expect(form.height).toBe(768);
+  });
+
+  it("resets sequence audio as part of the full Settings reset", async () => {
+    const draft = useSequenceDraftStore();
+    draft.output = "sequence";
+    draft.enableAudio = true;
+    const wrapper = mount(InspectorPanel, { props: { form: formFor("ltx2") } });
+
+    await wrapper.get('[data-test="settings-reset"]').trigger("click");
+
+    expect(draft.enableAudio).toBe(false);
   });
 });
 

--- a/desktop/src/components/create/InspectorPanel.vue
+++ b/desktop/src/components/create/InspectorPanel.vue
@@ -6,9 +6,11 @@ import SegmentedControl from "@ui/components/SegmentedControl.vue";
 import SliderRow from "@ui/components/SliderRow.vue";
 import VideoDurationSlider from "@ui/components/VideoDurationSlider.vue";
 import Stepper from "@ui/components/Stepper.vue";
+import SwitchToggle from "@ui/components/SwitchToggle.vue";
 import BadgePill from "@ui/components/BadgePill.vue";
 import Icon from "@ui/components/Icon.vue";
 import { useSequenceDraftStore } from "@studio/stores/sequenceDraft";
+import { isMinimaxH3Identity } from "@studio/lib/minimaxH3Authoring";
 import { defaultClipFrames, modelsForOutput, sequenceMotionTailFrames } from "@studio/lib/sequence";
 import { filterRestrictedModels } from "@studio/lib/modelAccess";
 import type { ChainLimits } from "@studio/lib/api/chainTypes";
@@ -229,10 +231,22 @@ const advancedCount = computed(() =>
       Number(
         caps.value.supportsNegativePrompt && draft.clips.some((clip) => clip.negativePrompt.trim()),
       ) +
-      Number(Boolean(draft.clips.some((clip) => clip.cameraControl))) +
-      Number(draft.enableAudio)
+      Number(Boolean(draft.clips.some((clip) => clip.cameraControl)))
     : advancedActiveCount(props.form),
 );
+const showGenerateAudio = computed(() =>
+  isSequence.value
+    ? props.chainLimits?.supports_audio === true
+    : caps.value.supportsAudio && !isMinimaxH3Identity(props.form.family, props.form.model),
+);
+const generateAudio = computed(() =>
+  isSequence.value ? draft.enableAudio : props.form.enableAudio,
+);
+const audioOutputSupported = computed(() => selectedModel.value?.supports_audio !== false);
+function setGenerateAudio(value: boolean) {
+  if (isSequence.value) draft.enableAudio = value;
+  else props.form.enableAudio = value;
+}
 const advancedExpanded = ref(false);
 
 // ── Model picker (the shared ModelPicker; chains uses the same control) ──────
@@ -578,6 +592,7 @@ const batchMax = computed(() => (batchLocked.value ? 1 : MAX_BATCH_SIZE));
 // the prompt, the model, and any prepared batch size survive.
 function resetSettings() {
   resetFormToModelDefaults(props.form, selectedModel.value);
+  if (isSequence.value) draft.enableAudio = false;
 }
 </script>
 
@@ -770,6 +785,26 @@ function resetSettings() {
         />
       </div>
 
+      <div
+        v-if="showGenerateAudio"
+        class="ms-field ms-field--row"
+        data-test="generate-audio-control"
+      >
+        <span class="ms-field__label ms-field__label--inline">Generate audio</span>
+        <SwitchToggle
+          :model-value="generateAudio"
+          :disabled="!isSequence && !audioOutputSupported"
+          label="Generate audio"
+          @update:model-value="setGenerateAudio"
+        />
+      </div>
+      <p
+        v-if="showGenerateAudio && !isSequence && !audioOutputSupported"
+        class="ms-field__hint -mt-2"
+      >
+        Audio assets are not included with this checkpoint. Video generation remains available.
+      </p>
+
       <!-- Seed -->
       <div class="ms-field">
         <div class="ms-field__label">Seed</div>
@@ -876,7 +911,6 @@ function resetSettings() {
       <SequenceAdvancedSettings
         v-if="advancedExpanded && isSequence"
         id="desktop-inline-advanced"
-        :chain-limits="chainLimits"
         :form="form"
         :upscalers="models.upscalers"
         :camera-controls-enabled="form.family === 'ltx2'"

--- a/desktop/src/components/create/SequenceAdvancedSettings.test.ts
+++ b/desktop/src/components/create/SequenceAdvancedSettings.test.ts
@@ -86,6 +86,7 @@ describe("SequenceAdvancedSettings camera motion", () => {
 
   it("resets camera motion across the sequence", async () => {
     const draft = useSequenceDraftStore();
+    draft.enableAudio = true;
     draft.clips[0]!.cameraControl = "dolly-in";
     draft.clips[1]!.cameraControl = "/models/camera/custom.safetensors";
     const wrapper = mount(SequenceAdvancedSettings, {
@@ -93,6 +94,7 @@ describe("SequenceAdvancedSettings camera motion", () => {
     });
     await wrapper.get("[data-test='sequence-advanced-reset']").trigger("click");
     expect(draft.clips.map((clip) => clip.cameraControl)).toEqual([null, null]);
+    expect(draft.enableAudio).toBe(true);
   });
 
   it("preserves the opening image and source conditioning across Reset", async () => {

--- a/desktop/src/components/create/SequenceAdvancedSettings.vue
+++ b/desktop/src/components/create/SequenceAdvancedSettings.vue
@@ -2,9 +2,7 @@
 import { computed, ref } from "vue";
 import AccordionSection from "@ui/components/AccordionSection.vue";
 import Chip from "@ui/components/Chip.vue";
-import SwitchToggle from "@ui/components/SwitchToggle.vue";
 import { useSequenceDraftStore } from "@studio/stores/sequenceDraft";
-import type { ChainLimits } from "@studio/lib/api/chainTypes";
 import { cameraMotionMode } from "@studio/lib/cameraMotion";
 import type { GenerateForm, PickedImage } from "../../lib/generateForm";
 import type { Ltx2CameraControlInfo, ModelEntry } from "../../lib/api/types";
@@ -24,7 +22,6 @@ import { useToastStore } from "../../stores/toasts";
 const props = withDefaults(
   defineProps<{
     form: GenerateForm;
-    chainLimits?: ChainLimits | null;
     cameraControlsEnabled?: boolean;
     cameraControls?: Ltx2CameraControlInfo[];
     cameraControlsLoaded?: boolean;
@@ -32,7 +29,6 @@ const props = withDefaults(
     cameraUnsupportedReason?: string | null;
   }>(),
   {
-    chainLimits: null,
     cameraControlsEnabled: false,
     cameraControls: () => [],
     cameraControlsLoaded: false,
@@ -67,8 +63,7 @@ const activeCount = computed(
     Number(
       guidanceCaps.value.supportsNegativePrompt && Boolean(activeClip.value?.negativePrompt.trim()),
     ) +
-    Number(props.cameraControlsEnabled && Boolean(activeClip.value?.cameraControl)) +
-    Number(draft.enableAudio),
+    Number(props.cameraControlsEnabled && Boolean(activeClip.value?.cameraControl)),
 );
 const fitOptions = SOURCE_FIT_OPTIONS.filter((option) => option.value !== "pad-repaint");
 const fitMode = computed(() => coerceSourceFitForMaskless(props.form.sourceFit).mode);
@@ -139,7 +134,6 @@ async function onOpeningImageFile(file: File) {
 // Reset clears sequence-advanced knobs only; the opening image and its
 // strength/fit are staged source media and survive (web parity).
 function reset() {
-  draft.enableAudio = false;
   for (const clip of draft.clips) {
     clip.negativePrompt = "";
     clip.cameraControl = null;
@@ -297,25 +291,6 @@ function reset() {
             "Built-in camera motions are available for LTX-2 19B only. This model accepts a custom LoRA path."
           }}
         </p>
-      </AccordionSection>
-
-      <AccordionSection
-        v-if="props.chainLimits?.supports_audio"
-        icon="video"
-        title="Sequence audio"
-        summary="Generate and mux audio for this timeline"
-        :open="true"
-        :header-interactive="false"
-        data-test="sequence-section-audio"
-      >
-        <div class="ms-switch-row">
-          <span>Generate audio</span>
-          <SwitchToggle
-            :model-value="draft.enableAudio"
-            label="Generate sequence audio"
-            @update:model-value="draft.enableAudio = $event"
-          />
-        </div>
       </AccordionSection>
     </div>
 

--- a/desktop/src/lib/generateForm.test.ts
+++ b/desktop/src/lib/generateForm.test.ts
@@ -2354,6 +2354,7 @@ describe("resetAdvancedToModelDefaults", () => {
     form.extendOverlapFrames = 17;
     form.keyframes = [{ frame: 9, image: { filename: "k.png", base64: "KEY" } }];
     form.audioFile = { filename: "voice.wav", base64: "AUD" };
+    form.enableAudio = true;
     form.h3Authoring!.firstFrame = {
       filename: "first.png",
       mimeType: "image/png",
@@ -2392,6 +2393,7 @@ describe("resetAdvancedToModelDefaults", () => {
     expect(form.extendOverlapFrames).toBe(17);
     expect(form.keyframes).toHaveLength(1);
     expect(form.audioFile?.filename).toBe("voice.wav");
+    expect(form.enableAudio).toBe(true);
     expect(form.h3Authoring!.firstFrame?.filename).toBe("first.png");
   });
 

--- a/desktop/src/lib/generateForm.ts
+++ b/desktop/src/lib/generateForm.ts
@@ -704,6 +704,7 @@ export function resetAdvancedToModelDefaults(
     extendOverlapFrames: form.extendOverlapFrames,
     extendDefaultOverlapFrames: form.extendDefaultOverlapFrames,
     keyframes: form.keyframes,
+    enableAudio: form.enableAudio,
     audioFile: form.audioFile,
     h3Authoring: form.h3Authoring,
   };

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -5437,8 +5437,6 @@ describe("MobileApp create settings reset", () => {
     await fieldControl("Prompt").setValue("a ship crossing violet lightning");
     await fieldControl("Negative prompt").setValue("calm water");
     await fieldControl("Steps").setValue("12");
-    await flushPromises();
-
     await wrapper.get("[data-test='mobile-settings-reset']").trigger("click");
     await flushPromises();
 
@@ -5454,6 +5452,13 @@ describe("MobileApp create settings reset", () => {
     expect(wrapper.get("[data-test='mobile-settings-reset']").element.parentElement).toBe(
       wrapper.get(".mobile-create-head").element,
     );
+
+    const draft = useSequenceDraftStore();
+    draft.output = "sequence";
+    draft.enableAudio = true;
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-settings-reset']").trigger("click");
+    expect(draft.enableAudio).toBe(false);
   });
 
   it("badges and resets LTX-2 guidance overrides from the Advanced sheet", async () => {
@@ -5483,6 +5488,21 @@ describe("MobileApp create settings reset", () => {
     liveForm.family = "flux";
     await flushPromises();
     expect(wrapper.find("[data-test='mobile-advanced-trigger-count']").exists()).toBe(false);
+  });
+
+  it("keeps generated audio in the primary Create settings", async () => {
+    wrapper = mountMobileApp();
+    await flushPromises();
+
+    const control = wrapper.get("[data-test='mobile-generate-audio-control']");
+    expect(control.element.closest(".mobile-advanced-sheet")).toBeNull();
+    await control.get("input").setValue(true);
+    const liveForm = wrapper.getComponent(MobileLoraControls).props("form") as GenerateForm;
+    expect(liveForm.enableAudio).toBe(true);
+
+    await wrapper.get("[data-test='mobile-open-advanced']").trigger("click");
+    await wrapper.get("[data-test='mobile-advanced-reset']").trigger("click");
+    expect(liveForm.enableAudio).toBe(true);
   });
 
   it("keeps the visible source across an H3 round trip via the shared bridge", async () => {
@@ -5536,6 +5556,7 @@ describe("MobileApp create settings reset", () => {
     liveForm.controlScale = 0.8;
     liveForm.imageAttachments = ["ATT"];
     liveForm.negativePrompt = "blurry";
+    liveForm.enableAudio = true;
     liveForm.cameraControl = "dolly-in";
     await flushPromises();
 
@@ -5553,6 +5574,7 @@ describe("MobileApp create settings reset", () => {
     expect(liveForm.controlScale).toBe(0.8);
     expect(liveForm.imageAttachments).toEqual(["ATT"]);
     expect(liveForm.negativePrompt).toBe("");
+    expect(liveForm.enableAudio).toBe(true);
     expect(liveForm.cameraControl).toBeNull();
   });
 });

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -520,6 +520,7 @@ function closeAdvancedSheet(): void {
  * inspector's Reset — the sheet's scoped reset below is deliberately narrower. */
 function resetCreateSettings(): void {
   resetFormToModelDefaults(form, selectedGenerationModel.value);
+  if (isSequence.value) draft.enableAudio = false;
 }
 
 /** Match the desktop Advanced reset: restore model-owned generation controls
@@ -5609,6 +5610,34 @@ onBeforeUnmount(() => {
               @seed-validity="seedValid = $event"
             />
 
+            <label
+              v-if="caps.supportsAudio && !isMinimaxH3Identity(form.family, form.model)"
+              class="mobile-generate-toggle-row"
+              data-test="mobile-generate-audio-control"
+            >
+              <span>
+                <strong>Generate audio</strong>
+                <small>Include a synchronized soundtrack when the model supports it.</small>
+              </span>
+              <input
+                v-model="form.enableAudio"
+                type="checkbox"
+                :disabled="selectedGenerationModel?.supports_audio === false"
+                data-test="mobile-enable-audio"
+              />
+            </label>
+            <p
+              v-if="
+                caps.supportsAudio &&
+                !isMinimaxH3Identity(form.family, form.model) &&
+                selectedGenerationModel?.supports_audio === false
+              "
+              class="mobile-generate-validation"
+            >
+              Audio assets are not included with this checkpoint. Video generation remains
+              available.
+            </p>
+
             <div class="mobile-advanced-row">
               <button
                 class="mobile-advanced-trigger"
@@ -5640,7 +5669,6 @@ onBeforeUnmount(() => {
                 :target="selectedTarget"
                 :upscalers="upscalers"
                 :selected-model="selectedGenerationModel"
-                :audio-output-supported="selectedGenerationModel?.supports_audio !== false"
                 :control-adapters="controlAdapters"
                 :camera-controls="cameraControls"
                 :camera-controls-loaded="cameraControlsLoaded"

--- a/desktop/src/mobile/MobileGenerateParameters.test.ts
+++ b/desktop/src/mobile/MobileGenerateParameters.test.ts
@@ -43,7 +43,6 @@ function formFor(family: string, model = `${family}:test`): GenerateForm {
 function mountParameters(
   initial: GenerateForm,
   upscalers: ModelEntry[] = [],
-  audioOutputSupported = true,
   controlAdapters: Ltx2ControlAdapterInfo[] = [],
   cameraControls: Ltx2CameraControlInfo[] = [cameraControl],
   selectedModel: ModelEntry | null = null,
@@ -52,14 +51,13 @@ function mountParameters(
   const Harness = defineComponent({
     components: { MobileGenerateParameters },
     setup: () => ({
-      audioOutputSupported,
       cameraControls,
       controlAdapters,
       form,
       selectedModel,
       upscalers,
     }),
-    template: `<MobileGenerateParameters :form="form" :upscalers="upscalers" :selected-model="selectedModel" :audio-output-supported="audioOutputSupported" :control-adapters="controlAdapters" :camera-controls="cameraControls" camera-controls-loaded />`,
+    template: `<MobileGenerateParameters :form="form" :upscalers="upscalers" :selected-model="selectedModel" :control-adapters="controlAdapters" :camera-controls="cameraControls" camera-controls-loaded />`,
   });
   return { wrapper: mount(Harness), form };
 }
@@ -78,7 +76,7 @@ describe("MobileGenerateParameters", () => {
       family: "minimax-h3",
       source_image: "required",
     } as ModelEntry;
-    const boundaries = mountParameters(formFor(fl2va.family, fl2va.name), [], true, [], [], fl2va);
+    const boundaries = mountParameters(formFor(fl2va.family, fl2va.name), [], [], [], fl2va);
     // FL2VA boundaries render as the shared source wells in the primary form.
     expect(boundaries.wrapper.find("[data-test='mobile-h3-authoring']").exists()).toBe(false);
 
@@ -86,14 +84,7 @@ describe("MobileGenerateParameters", () => {
       name: "minimax-h3-ref2va:comfy-pruned-int8",
       family: "minimax-h3",
     } as ModelEntry;
-    const references = mountParameters(
-      formFor(ref2va.family, ref2va.name),
-      [],
-      true,
-      [],
-      [],
-      ref2va,
-    );
+    const references = mountParameters(formFor(ref2va.family, ref2va.name), [], [], [], ref2va);
     expect(references.wrapper.find("[data-test='mobile-h3-authoring']").exists()).toBe(true);
     expect(references.wrapper.text()).toContain("Ordered references");
   });
@@ -114,7 +105,7 @@ describe("MobileGenerateParameters", () => {
     } as ModelEntry;
     const initial = formFor("ltx2", model.name);
     Object.assign(initial, { width: 640, height: 640, steps: 7, guidance: 8 });
-    const { wrapper, form } = mountParameters(initial, [], true, [], [], model);
+    const { wrapper, form } = mountParameters(initial, [], [], [], model);
     await wrapper.get("[data-test='mobile-ltx2-disclosure']").trigger("click");
     await wrapper.get("[data-test='mobile-ltx2-pipeline']").setValue("two-stage");
     expect(form).toMatchObject({
@@ -139,7 +130,6 @@ describe("MobileGenerateParameters", () => {
     const { wrapper, form } = mountParameters(
       { ...formFor("ltx2", model.name), frames: 97, fps: 24 },
       [],
-      true,
       [],
       [cameraControl],
       model,
@@ -168,7 +158,6 @@ describe("MobileGenerateParameters", () => {
     const { wrapper, form } = mountParameters(
       formFor("ltx2", "ltx-2-19b-distilled:fp8"),
       [],
-      true,
       adapters,
     );
     await wrapper.get("[data-test='mobile-ltx2-reference-control']").setValue("detailer");
@@ -335,7 +324,6 @@ describe("MobileGenerateParameters", () => {
     const wan = mountParameters(
       { ...formFor("wan", model.name), frames: 45 },
       [],
-      true,
       [],
       [cameraControl],
       model,
@@ -458,17 +446,6 @@ describe("MobileGenerateParameters", () => {
     expect(child.emitted("validity-change")?.at(-1)).toEqual([false]);
   });
 
-  it("disables generated audio for video-only LTX-2 checkpoints", () => {
-    const initial = formFor("ltx2", "cv:3143864");
-    initial.enableAudio = false;
-    const { wrapper } = mountParameters(initial, [], false);
-
-    expect(wrapper.get("[data-test='mobile-enable-audio']").attributes()).toHaveProperty(
-      "disabled",
-    );
-    expect(wrapper.text()).toContain("Audio assets are not included with this checkpoint");
-  });
-
   it("requires a real custom camera LoRA path", async () => {
     const initial = formFor("ltx2", "ltx-2.3-22b-distilled:fp8");
     initial.outputFormat = "mp4";
@@ -520,10 +497,7 @@ describe("MobileGenerateParameters", () => {
     initial.outputFormat = "mp4";
     const { wrapper, form } = mountParameters(initial);
 
-    expect(wrapper.find("[data-test='mobile-enable-audio']").exists()).toBe(true);
-    await wrapper.get("[data-test='mobile-enable-audio']").setValue(true);
     await wrapper.get("[data-test='mobile-camera-motion']").setValue("dolly-in");
-    expect(form.enableAudio).toBe(true);
     expect(form.cameraControl).toBe("dolly-in");
     expect(form.loras).toEqual([
       {
@@ -645,7 +619,6 @@ describe("MobileGenerateParameters — continue a video", () => {
     const capable = mountParameters(
       formFor("ltx2", "ltx-2-19b-distilled:fp8"),
       [],
-      true,
       [],
       [cameraControl],
       extendModel,
@@ -658,7 +631,7 @@ describe("MobileGenerateParameters — continue a video", () => {
     const form = formFor("ltx2", "ltx-2-19b-distilled:fp8");
     form.frames = 97;
     form.extendVideo = { filename: "clip.mp4", base64: "AAAA" };
-    const { wrapper } = mountParameters(form, [], true, [], [cameraControl], extendModel);
+    const { wrapper } = mountParameters(form, [], [], [cameraControl], extendModel);
 
     // 97 rendered frames minus the 17 that re-render the source tail.
     expect(wrapper.get("[data-test='mobile-ltx2-extend-summary']").text()).toContain(
@@ -671,7 +644,7 @@ describe("MobileGenerateParameters — continue a video", () => {
     form.frames = 97;
     form.extendVideo = { filename: "clip.mp4", base64: "AAAA" };
     form.sourceImage = "AAAA";
-    const { wrapper } = mountParameters(form, [], true, [], [cameraControl], extendModel);
+    const { wrapper } = mountParameters(form, [], [], [cameraControl], extendModel);
 
     expect(wrapper.get("[data-test='mobile-ltx2-extend-error']").text()).toContain("source image");
   });
@@ -681,7 +654,7 @@ describe("MobileGenerateParameters — continue a video", () => {
     form.frames = 97;
     form.extendVideo = { filename: "clip.mp4", base64: "AAAA" };
     form.extendOverlapFrames = 33;
-    const { wrapper } = mountParameters(form, [], true, [], [cameraControl], extendModel);
+    const { wrapper } = mountParameters(form, [], [], [cameraControl], extendModel);
 
     await wrapper.get("[data-test='mobile-ltx2-extend-clear']").trigger("click");
     expect(form.extendVideo).toBeNull();
@@ -704,7 +677,7 @@ describe("MobileGenerateParameters — continue a video", () => {
     const form = formFor("wan", "wan22-i2v-a14b:q5");
     form.frames = 53;
     form.extendVideo = { filename: "clip.mp4", base64: "AAAA" };
-    const { wrapper } = mountParameters(form, [], true, [], [cameraControl], wanExtendModel);
+    const { wrapper } = mountParameters(form, [], [], [cameraControl], wanExtendModel);
 
     expect(wrapper.find("[data-test='mobile-ltx2-extend-video']").exists()).toBe(false);
     expect(wrapper.find("[data-test='mobile-ltx2-extend-clear']").exists()).toBe(true);
@@ -725,7 +698,6 @@ describe("MobileGenerateParameters — continue a video", () => {
     const { wrapper } = mountParameters(
       formFor("wan", "wan22-t2v-a14b:q5"),
       [],
-      true,
       [],
       [cameraControl],
       {
@@ -748,7 +720,7 @@ describe("MobileGenerateParameters — continue a video", () => {
     const form = formFor("wan", "wan22-i2v-a14b:q5");
     form.frames = 53;
     form.extendVideo = { filename: "clip.mp4", base64: "AAAA" };
-    const { wrapper, form: live } = mountParameters(form, [], true, [], [cameraControl], {
+    const { wrapper, form: live } = mountParameters(form, [], [], [cameraControl], {
       name: "wan22-i2v-a14b:q5",
       family: "wan",
       source_image: "required",

--- a/desktop/src/mobile/MobileGenerateParameters.vue
+++ b/desktop/src/mobile/MobileGenerateParameters.vue
@@ -81,7 +81,6 @@ import {
 import MinimaxH3AuthoringPanel from "@studio/components/MinimaxH3AuthoringPanel.vue";
 import {
   emptyMinimaxH3AuthoringState,
-  isMinimaxH3Identity,
   minimaxH3TaskForModel,
   type MinimaxH3AuthoringState,
 } from "@studio/lib/minimaxH3Authoring";
@@ -93,7 +92,6 @@ const props = withDefaults(
     selectedModel?: ModelEntry | null;
     target?: ApiTarget | null;
     upscalers?: ModelEntry[];
-    audioOutputSupported?: boolean;
     controlAdapters?: Ltx2ControlAdapterInfo[];
     cameraControls?: Ltx2CameraControlInfo[];
     cameraControlsLoaded?: boolean;
@@ -103,7 +101,6 @@ const props = withDefaults(
     selectedModel: null,
     target: null,
     upscalers: () => [],
-    audioOutputSupported: true,
     controlAdapters: () => [],
     cameraControls: () => [],
     cameraControlsLoaded: false,
@@ -129,7 +126,6 @@ const caps = computed(() =>
 const h3Task = computed(() =>
   props.selectedModel ? minimaxH3TaskForModel(props.form.model) : null,
 );
-const h3Family = computed(() => isMinimaxH3Identity(props.form.family, props.form.model));
 const h3Authoring = computed(() => props.form.h3Authoring ?? emptyMinimaxH3AuthoringState());
 function setH3Authoring(value: MinimaxH3AuthoringState): void {
   props.form.h3Authoring = value;
@@ -868,24 +864,6 @@ const fpsErrorId = `mobile-fps-error-${useId()}`;
         {{ chainDecision.reason }}
       </p>
 
-      <label v-if="caps.supportsAudio && !h3Family" class="mobile-generate-toggle-row">
-        <span>
-          <strong>Generate audio</strong>
-          <small>Include a synchronized soundtrack when the model supports it.</small>
-        </span>
-        <input
-          v-model="form.enableAudio"
-          type="checkbox"
-          :disabled="!audioOutputSupported"
-          data-test="mobile-enable-audio"
-        />
-      </label>
-      <p
-        v-if="caps.supportsAudio && !h3Family && !audioOutputSupported"
-        class="mobile-generate-validation"
-      >
-        Audio assets are not included with this checkpoint. Video generation remains available.
-      </p>
       <p
         v-if="audioFormatError"
         class="mobile-generate-validation"

--- a/desktop/src/mobile/MobileSequenceComposer.test.ts
+++ b/desktop/src/mobile/MobileSequenceComposer.test.ts
@@ -489,6 +489,9 @@ describe("MobileSequenceComposer guardrails", () => {
 
     wrapper!.unmount();
     mountComposer({ chainLimits: { ...limits, supports_audio: true } });
+    expect(
+      wrapper!.get("[data-test='mobile-sequence-audio']").element.closest(".mobile-advanced-sheet"),
+    ).toBeNull();
     const audio = wrapper!.get("[data-test='mobile-sequence-audio'] input");
     await audio.setValue(true);
     expect(useSequenceDraftStore().enableAudio).toBe(true);

--- a/desktop/src/mobile/MobileSequenceComposer.vue
+++ b/desktop/src/mobile/MobileSequenceComposer.vue
@@ -120,8 +120,7 @@ const advancedCount = computed(
     Number(
       guidanceCaps.value.supportsNegativePrompt && Boolean(activeClip.value?.negativePrompt.trim()),
     ) +
-    Number(Boolean(activeClip.value?.cameraControl)) +
-    Number(draft.enableAudio),
+    Number(Boolean(activeClip.value?.cameraControl)),
 );
 const fitOptions = SOURCE_FIT_OPTIONS.filter((option) => option.value !== "pad-repaint");
 const fitMode = computed(() => coerceSourceFitForMaskless(props.form.sourceFit).mode);
@@ -467,6 +466,15 @@ function sourceImageMime(filename: string): string {
       <span v-if="advancedCount > 0">· {{ advancedCount }} on</span>
     </button>
 
+    <label
+      v-if="chainLimits?.supports_audio"
+      class="mobile-sequence-check"
+      data-test="mobile-sequence-audio"
+    >
+      <input v-model="draft.enableAudio" type="checkbox" :disabled="locked" />
+      Generate audio
+    </label>
+
     <p
       v-if="blockingReason"
       class="mobile-sequence-error"
@@ -513,7 +521,6 @@ function sourceImageMime(filename: string): string {
       @close="advancedOpen = false"
       @reset="
         draft.openingImage = null;
-        draft.enableAudio = false;
         form.strength = 0.75;
         form.sourceFit = { mode: 'crop-fill', alignX: 'center', alignY: 'center' };
         draft.clips.forEach((clip) => {
@@ -668,14 +675,6 @@ function sourceImageMime(filename: string): string {
           "Built-in camera motions are available for LTX-2 19B only. This model accepts a custom LoRA path."
         }}
       </p>
-      <label
-        v-if="chainLimits?.supports_audio"
-        class="mobile-sequence-check"
-        data-test="mobile-sequence-audio"
-      >
-        <input v-model="draft.enableAudio" type="checkbox" :disabled="locked" />
-        Generate audio
-      </label>
     </MobileAdvancedSheet>
     <MobileImagePickerSheet
       :open="imagePickerOpen"

--- a/web/src/components/create/AdvancedDrawer.test.ts
+++ b/web/src/components/create/AdvancedDrawer.test.ts
@@ -125,11 +125,7 @@ describe("AdvancedDrawer sequence contract", () => {
   });
 
   it("shows only sequence-owned controls", () => {
-    const wrapper = factory(
-      "ltx2",
-      {},
-      { output: "sequence", sequenceSupportsAudio: true },
-    );
+    const wrapper = factory("ltx2", {}, { output: "sequence" });
     expect(
       wrapper.find("[data-test='sequence-section-opening-image']").exists(),
     ).toBe(true);
@@ -137,7 +133,7 @@ describe("AdvancedDrawer sequence contract", () => {
       wrapper.find("[data-test='sequence-section-negative']").exists(),
     ).toBe(true);
     expect(wrapper.find("[data-test='sequence-section-audio']").exists()).toBe(
-      true,
+      false,
     );
     expect(wrapper.find("[data-test='section-source']").exists()).toBe(false);
     expect(wrapper.find("[data-test='section-lora']").exists()).toBe(false);
@@ -261,6 +257,7 @@ describe("AdvancedDrawer sequence contract", () => {
       { output: "sequence" },
     );
     const draft = useSequenceDraftStore();
+    draft.enableAudio = true;
     draft.openingImage = {
       kind: "upload",
       filename: "open.png",
@@ -268,6 +265,7 @@ describe("AdvancedDrawer sequence contract", () => {
     } as never;
     await wrapper.get("[data-test='advanced-reset']").trigger("click");
     expect(draft.openingImage).not.toBeNull();
+    expect(draft.enableAudio).toBe(true);
     // Strength/fit render beside the opening-image well, not in Advanced.
     const patched = wrapper.emitted("update:modelValue")?.at(-1)?.[0] as
       GenerateFormState | undefined;
@@ -545,15 +543,6 @@ describe("AdvancedDrawer video suite", () => {
     expect(next.pipeline).toBe("two-stage-hq");
   });
 
-  it("toggles LTX-2 audio decode off (null default reads as on)", async () => {
-    const wrapper = await openVideo("ltx2");
-    await wrapper.get("[data-test='ltx2-enable-audio']").trigger("click");
-    const [next] = wrapper.emitted("update:modelValue")!.at(-1) as [
-      GenerateFormState,
-    ];
-    expect(next.enableAudio).toBe(false);
-  });
-
   it("edits an existing keyframe's frame", async () => {
     const wrapper = await openVideo("ltx2", {
       keyframes: [
@@ -588,6 +577,7 @@ describe("AdvancedDrawer video suite", () => {
 
   it("Reset also clears the video suite", async () => {
     const wrapper = factory("ltx2", {
+      enableAudio: false,
       pipeline: "two-stage",
       gifPreview: true,
       spatialUpscale: "x2",
@@ -599,6 +589,7 @@ describe("AdvancedDrawer video suite", () => {
     expect(next.pipeline).toBe(null);
     expect(next.gifPreview).toBe(false);
     expect(next.spatialUpscale).toBe(null);
+    expect(next.enableAudio).toBe(false);
   });
 });
 

--- a/web/src/components/create/AdvancedDrawer.vue
+++ b/web/src/components/create/AdvancedDrawer.vue
@@ -100,13 +100,10 @@ const props = withDefaults(
     placementGpus?: { ordinal: number; name: string }[];
     /** Installed models on the selected generation route. */
     models?: ModelInfoExtended[];
-    /** Selected model's resolved audio assets are available. */
-    audioOutputSupported?: boolean;
     /** Host advertises `video.can_extend`; false hides the continuation UI. */
     canExtend?: boolean;
     extendDefaultOverlapFrames?: number;
     output?: OutputMode;
-    sequenceSupportsAudio?: boolean;
     routingRequest?: Partial<GenerateRoutingRequest> | null | undefined;
   }>(),
   {
@@ -115,11 +112,9 @@ const props = withDefaults(
     mobile: false,
     placementGpus: () => [],
     models: () => [],
-    audioOutputSupported: true,
     canExtend: false,
     extendDefaultOverlapFrames: DEFAULT_EXTEND_OVERLAP_FRAMES,
     output: "single",
-    sequenceSupportsAudio: false,
   },
 );
 
@@ -382,7 +377,7 @@ function setSequenceFit(mode: SourceFitMode) {
     }),
   });
 }
-// LTX-2 / LTX-2.3 own the full advanced video suite (pipeline, audio,
+// LTX-2 / LTX-2.3 own the full advanced video suite (pipeline, conditioning,
 // keyframes, retake, spatial/temporal). `supportsAudio` is true for
 // exactly those families, so it doubles as the suite gate; plain
 // ltx-video keeps just frames/fps/GIF.
@@ -472,7 +467,6 @@ function clampFrames(n: number): number {
 // media lives in the primary form now and must survive too) ───────────
 function resetAdvanced() {
   if (sequenceMode.value) {
-    draft.enableAudio = false;
     for (const clip of draft.clips) {
       clip.negativePrompt = "";
       clip.cameraControl = null;
@@ -726,25 +720,6 @@ function setSequenceCameraMode(mode: string) {
               "
               >+ {{ word }}</Chip
             >
-          </div>
-        </AccordionSection>
-
-        <AccordionSection
-          v-if="sequenceSupportsAudio"
-          icon="video"
-          title="Sequence audio"
-          summary="Generate and mux audio for this timeline"
-          :open="true"
-          :header-interactive="false"
-          data-test="sequence-section-audio"
-        >
-          <div class="adv__row">
-            <span class="adv__label">Generate audio</span>
-            <SwitchToggle
-              :model-value="draft.enableAudio"
-              label="Generate sequence audio"
-              @update:model-value="draft.enableAudio = $event"
-            />
           </div>
         </AccordionSection>
       </template>
@@ -1152,7 +1127,6 @@ function setSequenceCameraMode(mode: string) {
           <Ltx2VideoControls
             v-if="showLtx2"
             :model-value="modelValue"
-            :audio-output-supported="audioOutputSupported"
             @update:model-value="emit('update:modelValue', $event)"
           />
         </AccordionSection>

--- a/web/src/components/create/ControlsAside.test.ts
+++ b/web/src/components/create/ControlsAside.test.ts
@@ -6,6 +6,9 @@ import ResolutionSelector from "@ui/components/ResolutionSelector.vue";
 import Stepper from "@ui/components/Stepper.vue";
 import SliderRow from "@ui/components/SliderRow.vue";
 import VideoDurationSlider from "@ui/components/VideoDurationSlider.vue";
+import SwitchToggle from "@ui/components/SwitchToggle.vue";
+import { createPinia, setActivePinia } from "pinia";
+import { useSequenceDraftStore } from "@studio/stores/sequenceDraft";
 import {
   useGenerateForm,
   __testing__,
@@ -52,6 +55,7 @@ function factory(overrides: Partial<GenerateFormState> = {}, family = "flux") {
 
 describe("ControlsAside", () => {
   beforeEach(() => {
+    setActivePinia(createPinia());
     localStorage.clear();
     pushMock.mockClear();
     routingTesting.reset();
@@ -84,6 +88,70 @@ describe("ControlsAside", () => {
         .find((row) => row.props("label") === "Prompt strength")!
         .props("disabled"),
     ).toBe(false);
+  });
+
+  it("keeps one-shot generated audio in the primary settings", async () => {
+    const model = {
+      name: "ltx-2-19b-distilled:fp8",
+      family: "ltx2",
+      supports_audio: true,
+    } as ModelInfoExtended;
+    const wrapper = mount(ControlsAside, {
+      props: {
+        modelValue: baseForm({
+          model: model.name,
+          modelFamily: "ltx2",
+          enableAudio: null,
+        }),
+        family: "ltx2",
+        model,
+      },
+    });
+    expect(wrapper.find("[data-test='generate-audio-control']").exists()).toBe(
+      true,
+    );
+    wrapper.getComponent(SwitchToggle).vm.$emit("update:modelValue", false);
+    const [next] = wrapper.emitted("update:modelValue")!.at(-1) as [
+      GenerateFormState,
+    ];
+    expect(next.enableAudio).toBe(false);
+  });
+
+  it("keeps sequence generated audio in the primary settings", async () => {
+    const draft = useSequenceDraftStore();
+    const model = {
+      name: "ltx-2-19b-distilled:fp8",
+      family: "ltx2",
+      supports_audio: true,
+    } as ModelInfoExtended;
+    const wrapper = mount(ControlsAside, {
+      props: {
+        modelValue: baseForm({ model: model.name, modelFamily: "ltx2" }),
+        family: "ltx2",
+        model,
+        output: "sequence",
+      },
+    });
+    wrapper.getComponent(SwitchToggle).vm.$emit("update:modelValue", true);
+    expect(draft.enableAudio).toBe(true);
+  });
+
+  it("does not expose the audio toggle for an H3 model restored without a family", () => {
+    const model = {
+      name: "minimax-h3-fl2va:official-bf16",
+      family: "minimax-h3",
+      supports_audio: true,
+    } as ModelInfoExtended;
+    const wrapper = mount(ControlsAside, {
+      props: {
+        modelValue: baseForm({ model: model.name, modelFamily: "" }),
+        family: "",
+        model,
+      },
+    });
+    expect(wrapper.find("[data-test='generate-audio-control']").exists()).toBe(
+      false,
+    );
   });
 
   it("projects the current pixels onto Shape and Resolution", () => {

--- a/web/src/components/create/ControlsAside.vue
+++ b/web/src/components/create/ControlsAside.vue
@@ -15,6 +15,7 @@ import SliderRow from "@ui/components/SliderRow.vue";
 import VideoDurationSlider from "@ui/components/VideoDurationSlider.vue";
 import SegmentedControl from "@ui/components/SegmentedControl.vue";
 import Stepper from "@ui/components/Stepper.vue";
+import SwitchToggle from "@ui/components/SwitchToggle.vue";
 import BadgePill from "@ui/components/BadgePill.vue";
 import Icon from "@ui/components/Icon.vue";
 import { aspectsSupportedByPresets } from "@ui/lib/resolution";
@@ -44,6 +45,8 @@ import {
 } from "@studio/lib/sourceResolution";
 import HostRoutingPicker from "./HostRoutingPicker.vue";
 import { useHostRouting } from "../../composables/useHostRouting";
+import { useSequenceDraftStore } from "@studio/stores/sequenceDraft";
+import { isMinimaxH3Identity } from "@studio/lib/minimaxH3Authoring";
 
 const props = withDefaults(
   defineProps<{
@@ -113,6 +116,28 @@ const resolutionWarning = computed(() => {
   return finding?.level === "warn" ? finding.message : null;
 });
 const sequenceMode = computed(() => props.output === "sequence");
+const draft = useSequenceDraftStore();
+const showGenerateAudio = computed(() =>
+  sequenceMode.value
+    ? props.family === "ltx2" && props.model?.supports_audio !== false
+    : capabilities.value.supportsAudio &&
+      !isMinimaxH3Identity(
+        props.family,
+        props.model?.name ?? props.modelValue.model,
+      ),
+);
+const generateAudio = computed(() =>
+  sequenceMode.value
+    ? draft.enableAudio
+    : props.modelValue.enableAudio !== false,
+);
+const audioOutputSupported = computed(
+  () => props.model?.supports_audio !== false,
+);
+function setGenerateAudio(value: boolean) {
+  if (sequenceMode.value) draft.enableAudio = value;
+  else patch({ enableAudio: value });
+}
 // Edit families (Qwen image edit) render one print at a time; a sequence
 // renders one timeline.
 const batchLocked = computed(
@@ -494,6 +519,29 @@ function lockLastSeed() {
       />
     </div>
 
+    <div
+      v-if="showGenerateAudio"
+      class="controls__group controls__toggle"
+      data-test="generate-audio-control"
+    >
+      <span class="controls__label controls__label--inline"
+        >Generate audio</span
+      >
+      <SwitchToggle
+        :model-value="generateAudio"
+        :disabled="!sequenceMode && !audioOutputSupported"
+        label="Generate audio"
+        @update:model-value="setGenerateAudio"
+      />
+      <p
+        v-if="!sequenceMode && !audioOutputSupported"
+        class="controls__hint controls__hint--full"
+      >
+        Audio assets are not included with this checkpoint. Video generation
+        remains available.
+      </p>
+    </div>
+
     <div class="controls__group">
       <SliderRow
         label="Prompt strength"
@@ -677,6 +725,16 @@ function lockLastSeed() {
 
 .controls__label--inline {
   margin-bottom: 0;
+}
+
+.controls__toggle {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px 12px;
+}
+.controls__hint--full {
+  grid-column: 1 / -1;
 }
 
 .controls__seed {

--- a/web/src/components/create/advanced/Ltx2VideoControls.test.ts
+++ b/web/src/components/create/advanced/Ltx2VideoControls.test.ts
@@ -15,16 +15,10 @@ function baseForm(
   return { ...state, ...overrides };
 }
 
-function factory(
-  overrides: Partial<GenerateFormState> = {},
-  audioOutputSupported = true,
-  extra: { canExtend?: boolean; extendDefaultOverlapFrames?: number } = {},
-) {
+function factory(overrides: Partial<GenerateFormState> = {}) {
   return mount(Ltx2VideoControls, {
     props: {
       modelValue: baseForm(overrides),
-      audioOutputSupported,
-      ...extra,
     },
   });
 }
@@ -49,22 +43,6 @@ describe("Ltx2VideoControls", () => {
   afterEach(() => {
     __testing__.resetForTest();
     vi.unstubAllGlobals();
-  });
-
-  it("reads a null enableAudio as on and writes false when toggled", async () => {
-    const wrapper = factory({ enableAudio: null });
-    await wrapper.get("[data-test='ltx2-enable-audio']").trigger("click");
-    expect(lastPatch(wrapper).enableAudio).toBe(false);
-  });
-
-  it("disables audio with an actionable reason for video-only checkpoints", async () => {
-    const wrapper = factory({ enableAudio: false }, false);
-    const toggle = wrapper.get("[data-test='ltx2-enable-audio']");
-    expect(toggle.attributes("disabled")).toBeDefined();
-    expect(toggle.attributes("aria-checked")).toBe("false");
-    expect(wrapper.text()).toContain("Audio assets are not included");
-    await toggle.trigger("click");
-    expect(wrapper.emitted("update:modelValue")).toBeUndefined();
   });
 
   it("selects a pipeline mode and can return to auto", async () => {

--- a/web/src/components/create/advanced/Ltx2VideoControls.vue
+++ b/web/src/components/create/advanced/Ltx2VideoControls.vue
@@ -3,14 +3,13 @@
  * LTX-2 advanced video suite — the family-specific controls the Advanced
  * drawer nests inside its "Video" section for LTX-2 / LTX-2.3 (the audio
  * families). Restores the full set the deleted GenerateParamsPanel offered:
- * pipeline mode, audio decode toggle + audio conditioning file, source video,
+ * pipeline mode, audio conditioning file, source video,
  * retake range, spatial/temporal upscale, and the keyframe editor. Every
  * control maps onto an existing GenerateFormState field (no renames); binary
  * uploads become SourceImage/SourceMediaState just like the source dropzone.
  * The component holds no local copy — it patches the parent form via v-model.
  */
 import { computed, ref, watch } from "vue";
-import SwitchToggle from "@ui/components/SwitchToggle.vue";
 import SegmentedControl from "@ui/components/SegmentedControl.vue";
 import type {
   GenerateFormState,
@@ -51,13 +50,7 @@ import {
   MAX_GUIDANCE_SKIP_STEP,
 } from "@studio/lib/guidanceOverrides";
 
-const props = withDefaults(
-  defineProps<{
-    modelValue: GenerateFormState;
-    audioOutputSupported?: boolean;
-  }>(),
-  { audioOutputSupported: true },
-);
+const props = defineProps<{ modelValue: GenerateFormState }>();
 const emit = defineEmits<{ "update:modelValue": [value: GenerateFormState] }>();
 const controlAdapters = ref<Ltx2ControlAdapterInfo[]>([]);
 const cameraControls = ref<Ltx2CameraControlInfo[]>([]);
@@ -166,16 +159,6 @@ const cameraSlotAvailable = computed(() =>
     MAX_LORA_STACK,
   ),
 );
-
-// ── Audio decode toggle ───────────────────────────────────────────────
-// enableAudio is boolean | null; null lets the server default (on for MP4).
-// The switch reads on unless explicitly disabled, and writes true/false.
-const audioOn = computed(
-  () => props.audioOutputSupported && props.modelValue.enableAudio !== false,
-);
-function setAudio(on: boolean) {
-  patch({ enableAudio: on });
-}
 
 // ── Pipeline mode ─────────────────────────────────────────────────────
 const PIPELINE_OPTIONS: Ltx2PipelineMode[] = [
@@ -372,17 +355,6 @@ function removeKeyframe(index: number) {
 
 <template>
   <div class="ltx2" data-test="ltx2-suite">
-    <div class="ltx2__row">
-      <span class="ltx2__label">Decode audio</span>
-      <SwitchToggle
-        :model-value="audioOn"
-        :disabled="!audioOutputSupported"
-        label="Decode audio"
-        data-test="ltx2-enable-audio"
-        @update:model-value="setAudio"
-      />
-    </div>
-
     <div class="ltx2__field">
       <label class="ltx2__label">Reference control</label>
       <select
@@ -413,15 +385,6 @@ function removeKeyframe(index: number) {
         }}
       </p>
     </div>
-    <p
-      v-if="!audioOutputSupported"
-      class="ltx2__hint"
-      data-test="ltx2-audio-unavailable"
-    >
-      Audio assets are not included with this checkpoint. Video generation
-      remains available.
-    </p>
-
     <div class="ltx2__field">
       <label class="ltx2__label">Pipeline</label>
       <select

--- a/web/src/components/create/advancedCount.ts
+++ b/web/src/components/create/advancedCount.ts
@@ -27,7 +27,7 @@ export interface AdvancedCountParams {
   /** A video family has non-default video controls set. */
   videoNonDefault: boolean;
   /** Any LTX-2 / video advanced control beyond frames/fps is set — pipeline,
-   * audio, source video, keyframes, retake, spatial/temporal upscale, or the
+   * source video, keyframes, retake, spatial/temporal upscale, or the
    * GIF preview toggle. Counts once. Optional for the same reason. */
   videoSuite?: boolean;
   /** How many wan recipe controls (flow shift, distill strengths) are set.

--- a/web/src/pages/CreatePage.test.ts
+++ b/web/src/pages/CreatePage.test.ts
@@ -739,7 +739,6 @@ describe("CreatePage layout and behavior", () => {
     form.state.value.seedMode = "static";
     form.state.value.seed = 42;
     form.state.value.negativePrompt = "blurry";
-
     await wrapper.get("[data-test='controls-reset']").trigger("click");
     expect(form.state.value.steps).toBe(30);
     expect(form.state.value.guidance).toBe(7.5);
@@ -757,6 +756,18 @@ describe("CreatePage layout and behavior", () => {
     expect(form.state.value.steps).toBe(3);
     expect(form.state.value.seed).toBe(42);
     expect(form.state.value.negativePrompt).toBe("blurry");
+
+    const draft = useSequenceDraftStore();
+    draft.output = "sequence";
+    draft.enableAudio = true;
+    await flushPromises();
+    await wrapper.get("[data-test='controls-reset']").trigger("click");
+    expect(draft.enableAudio).toBe(false);
+    const sequenceToast = [...notifications.toasts]
+      .reverse()
+      .find((t) => /settings/i.test(t.text));
+    runToastAction(sequenceToast!.id);
+    expect(draft.enableAudio).toBe(true);
   });
 
   it("guides a first pull when no models are installed (cold start)", async () => {

--- a/web/src/pages/CreatePage.vue
+++ b/web/src/pages/CreatePage.vue
@@ -2048,11 +2048,15 @@ function onResetSettings() {
   // resetSettings swaps in a freshly built state object, so the previous one is
   // never mutated and can be handed straight back on undo.
   const previous = form.state.value;
+  const previousSequenceAudio = sequenceMode.value ? draft.enableAudio : null;
   form.resetSettings(currentModel.value ?? null);
+  if (sequenceMode.value) draft.enableAudio = false;
   undoableAction({
     text: "Settings reset to model defaults",
     undo: () => {
       form.state.value = previous;
+      if (previousSequenceAudio !== null)
+        draft.enableAudio = previousSequenceAudio;
     },
     commit: () => {},
   });
@@ -2074,8 +2078,7 @@ const advCount = computed(() =>
         capabilities.value.supportsNegativePrompt &&
           draft.clips.some((clip) => clip.negativePrompt.trim()),
       ) +
-      Number(Boolean(draft.clips.some((clip) => clip.cameraControl))) +
-      Number(draft.enableAudio)
+      Number(Boolean(draft.clips.some((clip) => clip.cameraControl)))
     : advancedActiveCount({
         negativePrompt: capabilities.value.supportsNegativePrompt
           ? form.state.value.negativePrompt
@@ -2097,7 +2100,6 @@ const advCount = computed(() =>
           capabilities.value.supportsVideo &&
           (form.state.value.gifPreview ||
             form.state.value.cameraControl != null ||
-            form.state.value.enableAudio === false ||
             form.state.value.pipeline != null ||
             form.state.value.icLoraControl != null ||
             form.state.value.audioFile != null ||
@@ -4310,13 +4312,9 @@ onBeforeUnmount(() => {
           :placement-gpus="gpuListForPlacement"
           :models="models"
           :routing-request="durationRoutingRequest"
-          :audio-output-supported="currentModel?.supports_audio !== false"
           :can-extend="canExtend"
           :extend-default-overlap-frames="extendDefaultOverlapFrames"
           :output="sequenceMode ? 'sequence' : 'single'"
-          :sequence-supports-audio="
-            currentFamily === 'ltx2' && currentModel?.supports_audio !== false
-          "
           @open-picker="showPicker = true"
           @open-h3-first-frame-picker="h3BoundaryPickerTarget = 'firstFrame'"
           @open-h3-last-frame-picker="h3BoundaryPickerTarget = 'lastFrame'"
@@ -4342,13 +4340,9 @@ onBeforeUnmount(() => {
         :placement-gpus="gpuListForPlacement"
         :models="models"
         :routing-request="durationRoutingRequest"
-        :audio-output-supported="currentModel?.supports_audio !== false"
         :can-extend="canExtend"
         :extend-default-overlap-frames="extendDefaultOverlapFrames"
         :output="sequenceMode ? 'sequence' : 'single'"
-        :sequence-supports-audio="
-          currentFamily === 'ltx2' && currentModel?.supports_audio !== false
-        "
         @close="showAdvanced = false"
         @open-picker="showPicker = true"
         @open-h3-first-frame-picker="h3BoundaryPickerTarget = 'firstFrame'"


### PR DESCRIPTION
## Summary

- move Generate audio from Advanced into the basic Create settings on web, desktop, and iPhone for one-shot and sequence video generation
- keep audio out of Advanced active counts and preserve it when Advanced is reset
- retain full Settings reset behavior, including web Undo, and keep checkpoint/H3 capability gating intact

## Verification

- `nix develop -c bun run check:architecture`
- `nix develop -c bun run test:web` (1,374 tests)
- `nix develop -c bun run test:desktop` (3,685 tests)
- `nix develop -c bun run build:web`
- `nix develop -c bun run build:desktop`
- `nix develop -c bun run build:mobile`
- rendered browser QA at desktop and 390x844 mobile widths, including Advanced reset preservation

## Review

- sub-agent peer review completed before opening this PR
- both initial findings were addressed; final rebased review reported no actionable findings
