### PR TITLE
fix(catalog): preserve models during provider outages

### DIFF
--- a/crates/mold-catalog/src/live.rs
+++ b/crates/mold-catalog/src/live.rs
@@ -24,7 +24,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::civitai_map::{map_base_model, CIVITAI_BASE_MODELS};
 use crate::companions::{Companion, COMPANIONS};
@@ -398,6 +398,60 @@ pub struct LiveSearchResult {
     /// Complete filtered row count when the upstream exposes it; otherwise a
     /// conservative lower bound that keeps pagination available.
     pub total: usize,
+    /// Provider-scoped failures from a merged search. A healthy provider's
+    /// rows remain usable; clients render these as retryable, non-blocking
+    /// warnings instead of replacing the entire catalog with an error page.
+    pub provider_errors: Vec<CatalogProviderError>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct CatalogProviderError {
+    pub source: Source,
+    pub message: String,
+}
+
+const SEARCH_RETRY_DELAYS: [Duration; 2] = [Duration::from_millis(100), Duration::from_millis(250)];
+
+fn retryable_search_error(error: &LiveSearchError) -> bool {
+    match error {
+        LiveSearchError::Network(_) | LiveSearchError::Decode(_) => true,
+        LiveSearchError::Upstream { status, .. } => {
+            matches!(status, 408 | 425 | 429 | 500..=599)
+        }
+    }
+}
+
+async fn retry_search<T, F, Fut>(mut search: F) -> Result<T, LiveSearchError>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<T, LiveSearchError>>,
+{
+    for (attempt, delay) in SEARCH_RETRY_DELAYS.iter().enumerate() {
+        match search().await {
+            Err(error) if retryable_search_error(&error) => {
+                tracing::warn!(
+                    target: "catalog.live",
+                    attempt = attempt + 1,
+                    error = %error,
+                    "catalog provider request failed; retrying"
+                );
+                tokio::time::sleep(*delay).await;
+            }
+            result => return result,
+        }
+    }
+    search().await
+}
+
+fn provider_error(source: Source) -> CatalogProviderError {
+    let provider = match source {
+        Source::Hf => "Hugging Face",
+        Source::Civitai => "Civitai",
+    };
+    CatalogProviderError {
+        source,
+        message: format!("{provider} is temporarily unavailable."),
+    }
 }
 
 /// Backwards-compatible one-shot query for Rust consumers that only need the
@@ -441,14 +495,14 @@ pub async fn search_page(
     let want_hf = !matches!(opts.source, Some(Source::Civitai));
     let civitai_fut = async {
         if want_civitai {
-            Some(civitai_search_paged(civitai_base, cache, &upstream_opts).await)
+            Some(retry_search(|| civitai_search_paged(civitai_base, cache, &upstream_opts)).await)
         } else {
             None
         }
     };
     let hf_fut = async {
         if want_hf {
-            Some(hf_search_paged(hf_base, cache, &upstream_opts).await)
+            Some(retry_search(|| hf_search_paged(hf_base, cache, &upstream_opts)).await)
         } else {
             None
         }
@@ -457,9 +511,24 @@ pub async fn search_page(
 
     let mut entries = Vec::new();
     let mut total = 0;
-    if let Some(page) = civitai_result.transpose()? {
-        total += page.total;
-        entries.extend(page.entries);
+    let mut provider_errors = Vec::new();
+    if let Some(result) = civitai_result {
+        match result {
+            Ok(page) => {
+                total += page.total;
+                entries.extend(page.entries);
+            }
+            Err(
+                error @ LiveSearchError::Upstream {
+                    status: 401 | 403, ..
+                },
+            ) => return Err(error),
+            Err(error) if matches!(opts.source, Some(Source::Civitai)) => return Err(error),
+            Err(error) => {
+                tracing::warn!(target: "catalog.live", error = %error, "civitai search failed");
+                provider_errors.push(provider_error(Source::Civitai));
+            }
+        }
     }
     if let Some(result) = hf_result {
         // Authentication errors must surface so the server can retry with its
@@ -477,6 +546,7 @@ pub async fn search_page(
             Err(e) if matches!(opts.source, Some(Source::Hf)) => return Err(e),
             Err(e) => {
                 tracing::warn!(target: "catalog.live", error = %e, "hf search failed");
+                provider_errors.push(provider_error(Source::Hf));
             }
         }
     }
@@ -486,8 +556,18 @@ pub async fn search_page(
         entries.extend(local_page.entries);
     }
     entries.truncate(opts.page_size as usize);
+    if !provider_errors.is_empty() {
+        // A provider recovering on a later page would start at that later
+        // provider page and permanently skip its earlier rows. End degraded
+        // pagination here; Retry restarts the merged epoch from page 1.
+        total = page_offset(opts).saturating_add(entries.len());
+    }
 
-    Ok(LiveSearchResult { entries, total })
+    Ok(LiveSearchResult {
+        entries,
+        total,
+        provider_errors,
+    })
 }
 
 fn paginate_local(entries: Vec<CatalogEntry>, opts: &LiveSearchOpts) -> LiveSearchResult {
@@ -498,7 +578,11 @@ fn paginate_local(entries: Vec<CatalogEntry>, opts: &LiveSearchOpts) -> LiveSear
         .skip(start)
         .take(opts.page_size as usize)
         .collect();
-    LiveSearchResult { entries, total }
+    LiveSearchResult {
+        entries,
+        total,
+        provider_errors: Vec::new(),
+    }
 }
 
 fn page_offset(opts: &LiveSearchOpts) -> usize {
@@ -799,6 +883,7 @@ async fn civitai_search_paged(
                 let page_result = LiveSearchResult {
                     entries,
                     total: chain.total(),
+                    provider_errors: Vec::new(),
                 };
                 cache.put_civitai_page(
                     SourcePageKey {
@@ -818,6 +903,7 @@ async fn civitai_search_paged(
         let page_result = LiveSearchResult {
             entries,
             total: chain.total(),
+            provider_errors: Vec::new(),
         };
         cache.put_civitai_page(
             SourcePageKey {
@@ -836,6 +922,7 @@ async fn civitai_search_paged(
             result = Some(LiveSearchResult {
                 entries: Vec::new(),
                 total: chain.total(),
+                provider_errors: Vec::new(),
             });
             break;
         }
@@ -845,6 +932,7 @@ async fn civitai_search_paged(
     Ok(result.unwrap_or(LiveSearchResult {
         entries: Vec::new(),
         total,
+        provider_errors: Vec::new(),
     }))
 }
 
@@ -1108,7 +1196,11 @@ async fn hf_search(base: &str, opts: &LiveSearchOpts) -> Result<LiveSearchResult
             .saturating_add(entries.len())
             .saturating_add(usize::from(!entries.is_empty()))
     };
-    Ok(LiveSearchResult { entries, total })
+    Ok(LiveSearchResult {
+        entries,
+        total,
+        provider_errors: Vec::new(),
+    })
 }
 
 /// Build a recipe-less `CatalogEntry` from an HF search hit. The recipe
@@ -2287,10 +2379,31 @@ mod tests {
         .expect("merged search must survive an HF 5xx");
         assert!(result.entries.iter().all(|e| e.id.0.starts_with("cv:")));
         assert!(!result.entries.is_empty());
+        assert_eq!(
+            result.total,
+            result.entries.len(),
+            "a degraded merged page is terminal until the client retries page 1"
+        );
+        assert_eq!(
+            result.provider_errors,
+            [CatalogProviderError {
+                source: Source::Hf,
+                message: "Hugging Face is temporarily unavailable.".into(),
+            }]
+        );
+        let requests = server.received_requests().await.expect("requests");
+        assert_eq!(
+            requests
+                .iter()
+                .filter(|request| request.url.path() == "/api/models")
+                .count(),
+            3,
+            "transient provider failures get two bounded retries"
+        );
     }
 
     #[tokio::test]
-    async fn merged_search_propagates_civitai_errors() {
+    async fn merged_search_soft_fails_civitai_server_errors() {
         let server = MockServer::start().await;
         Mock::given(method("GET"))
             .and(path("/api/v1/models"))
@@ -2303,21 +2416,50 @@ mod tests {
             .mount(&server)
             .await;
 
-        let err = search_page(
+        let result = search_page(
             &server.uri(),
             &server.uri(),
             &test_cache(),
             &LiveSearchOpts::default(),
         )
         .await
-        .expect_err("civitai errors must propagate from the parallel path");
-        match err {
-            LiveSearchError::Upstream { host, status, .. } => {
-                assert_eq!(host, "civitai.com");
-                assert_eq!(status, 500);
+        .expect("merged search must survive a Civitai 5xx");
+        assert!(result.entries.iter().all(|e| e.id.0.starts_with("hf:")));
+        assert!(!result.entries.is_empty());
+        assert_eq!(
+            result.total,
+            result.entries.len(),
+            "a degraded merged page is terminal until the client retries page 1"
+        );
+        assert_eq!(
+            result.provider_errors,
+            [CatalogProviderError {
+                source: Source::Civitai,
+                message: "Civitai is temporarily unavailable.".into(),
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn transient_search_retry_stops_after_a_success() {
+        let attempts = std::sync::atomic::AtomicUsize::new(0);
+        let result = retry_search(|| async {
+            let attempt = attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            if attempt == 0 {
+                Err(LiveSearchError::Upstream {
+                    host: "huggingface.co",
+                    status: 502,
+                    body: "bad gateway".into(),
+                })
+            } else {
+                Ok("recovered")
             }
-            other => panic!("expected Upstream 500, got {other:?}"),
-        }
+        })
+        .await
+        .expect("the second attempt succeeds");
+
+        assert_eq!(result, "recovered");
+        assert_eq!(attempts.load(std::sync::atomic::Ordering::SeqCst), 2);
     }
 
     #[tokio::test]

--- a/crates/mold-server/src/catalog_api.rs
+++ b/crates/mold-server/src/catalog_api.rs
@@ -901,6 +901,59 @@ pub async fn live_search_catalog(
     };
     let result = match search_result {
         Ok(result) => result,
+        Err(error) if opts.source.is_none() => {
+            // Merged searches propagate auth failures so the credential loop
+            // above can try its candidates. If that loop is exhausted, keep
+            // the other provider usable instead of turning one rejected token
+            // into a blank catalog.
+            let failed_source = match &error {
+                mold_catalog::live::LiveSearchError::Upstream { host, .. }
+                    if *host == "civitai.com" =>
+                {
+                    mold_catalog::entry::Source::Civitai
+                }
+                _ => mold_catalog::entry::Source::Hf,
+            };
+            let mut fallback_opts = opts.clone();
+            fallback_opts.source = Some(match failed_source {
+                mold_catalog::entry::Source::Hf => mold_catalog::entry::Source::Civitai,
+                mold_catalog::entry::Source::Civitai => mold_catalog::entry::Source::Hf,
+            });
+            match mold_catalog::live::search_page(
+                state.catalog_live_civitai_base.as_str(),
+                "https://huggingface.co",
+                &state.catalog_live_cache,
+                &fallback_opts,
+            )
+            .await
+            {
+                Ok(mut partial) => {
+                    let provider = match failed_source {
+                        mold_catalog::entry::Source::Hf => "Hugging Face",
+                        mold_catalog::entry::Source::Civitai => "Civitai",
+                    };
+                    partial
+                        .provider_errors
+                        .push(mold_catalog::live::CatalogProviderError {
+                            source: failed_source,
+                            message: format!("{provider} is temporarily unavailable."),
+                        });
+                    partial
+                }
+                Err(fallback_error) => {
+                    tracing::warn!(
+                        target: "catalog.live",
+                        error = %fallback_error,
+                        "catalog fallback provider failed"
+                    );
+                    return (
+                        StatusCode::BAD_GATEWAY,
+                        format!("upstream: {fallback_error}"),
+                    )
+                        .into_response();
+                }
+            }
+        }
         Err(e) => {
             tracing::warn!(target: "catalog.live", error = %e, "live search failed");
             return (StatusCode::BAD_GATEWAY, format!("upstream: {e}")).into_response();
@@ -918,6 +971,7 @@ pub async fn live_search_catalog(
         "page": opts.page,
         "page_size": opts.page_size,
         "total": result.total,
+        "provider_errors": result.provider_errors,
     }))
     .into_response()
 }

--- a/crates/mold-server/src/catalog_live_test.rs
+++ b/crates/mold-server/src/catalog_live_test.rs
@@ -187,7 +187,7 @@ async fn h3_search_identity_reaches_the_upstream_catalog() {
     Mock::given(method("GET"))
         .and(wm_path("/api/v1/models"))
         .respond_with(ResponseTemplate::new(500))
-        .expect(2)
+        .expect(6)
         .mount(&server)
         .await;
     let state = AppState::for_tests().with_civitai_base(server.uri());
@@ -207,7 +207,8 @@ async fn h3_search_identity_reaches_the_upstream_catalog() {
             .await
             .expect("recorded requests")
             .len(),
-        2
+        6,
+        "each transient upstream failure gets two bounded retries"
     );
     server.verify().await;
 }

--- a/desktop/src/components/models/CatalogTab.test.ts
+++ b/desktop/src/components/models/CatalogTab.test.ts
@@ -122,6 +122,22 @@ async function mountTab(mediaType: "all" | "image" | "video" = "all") {
   return wrapper;
 }
 
+async function mountCatalog(extraProps: Record<string, unknown> = {}) {
+  setActivePinia(createPinia());
+  const connection = useConnectionStore();
+  connection.info = {
+    mode: "local",
+    baseUrl: "http://127.0.0.1:7680",
+    apiKey: "local-key",
+  };
+  connection.status = "ready";
+  const wrapper = mount(CatalogTab, {
+    props: { query: "", layout: "grid" as const, ...extraProps },
+  });
+  await flushPromises();
+  return wrapper;
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   FakeIntersectionObserver.instances = [];
@@ -203,6 +219,59 @@ describe("CatalogTab media filter under pagination", () => {
     await wrapper.get("select[aria-label='Model family']").setValue("ltx2");
     await flushPromises();
     expect(familyOptionValues(wrapper)).toEqual(["", "flux", "ltx2", "qwen-image"]);
+  });
+
+  it("keeps available models visible with a provider warning and retries on demand", async () => {
+    searchCatalog.mockResolvedValue({
+      entries: [entry("Healthy HF model", "flux")],
+      page: 1,
+      page_size: PAGE_SIZE,
+      total: 1,
+      provider_errors: [{ source: "civitai", message: "Civitai is temporarily unavailable." }],
+    });
+    const wrapper = await mountCatalog({
+      installedEntries: [
+        {
+          name: "qwen-image-edit:q4",
+          family: "qwen-image-edit",
+          downloaded: true,
+          hostIds: ["local"],
+        },
+      ] as never,
+    });
+
+    expect(wrapper.get("[data-test='catalog-provider-warning']").text()).toContain("Civitai");
+    expect(wrapper.text()).toContain("Healthy HF model");
+    expect(wrapper.text()).toContain("qwen-image-edit:q4");
+
+    searchCatalog.mockRejectedValueOnce(new Error("still unavailable"));
+    await wrapper.get("[data-test='catalog-retry']").trigger("click");
+    await flushPromises();
+    expect(searchCatalog).toHaveBeenCalledTimes(2);
+    expect(wrapper.text()).toContain("Healthy HF model");
+    expect(wrapper.text()).toContain("qwen-image-edit:q4");
+    expect(wrapper.get("[data-test='catalog-provider-warning']").text()).toContain(
+      "still unavailable",
+    );
+  });
+
+  it("lists Qwen Image Edit models under the Qwen Image family", async () => {
+    const wrapper = await mountCatalog({
+      installedEntries: [
+        {
+          name: "qwen-image-edit-2511:q4",
+          family: "qwen-image-edit",
+          downloaded: true,
+          hostIds: ["local"],
+        },
+      ] as never,
+    });
+
+    expect(familyOptionValues(wrapper)).toContain("qwen-image");
+    expect(familyOptionValues(wrapper)).not.toContain("qwen-image-edit");
+    await wrapper.get("select[aria-label='Model family']").setValue("qwen-image");
+    await flushPromises();
+    expect(wrapper.text()).toContain("qwen-image-edit-2511:q4");
   });
 
   it("retries taxonomy when reachability changes and retains the last good families", async () => {

--- a/desktop/src/components/models/CatalogTab.vue
+++ b/desktop/src/components/models/CatalogTab.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref, watch } from "vue";
+import { catalogFamily, matchesCatalogFamily } from "@studio/lib/modelFamily";
 import CatalogLayoutToggle, {
   type CatalogLayoutChoice,
 } from "@ui/components/CatalogLayoutToggle.vue";
@@ -28,7 +29,7 @@ import CatalogTableRow from "./CatalogTableRow.vue";
 import CatalogDetailDrawer, { type DrawerVariant } from "./CatalogDetailDrawer.vue";
 import DownloadTargetDialog from "./DownloadTargetDialog.vue";
 import { installedModelToEntry } from "../../lib/catalogDetail";
-import type { CatalogEntry, ModelEntry } from "../../lib/api/types";
+import type { CatalogEntry, CatalogProviderError, ModelEntry } from "../../lib/api/types";
 
 type LibraryModelEntry = ModelEntry & { hostIds?: string[] };
 type CatalogListEntry = CatalogEntry & { hostIds?: string[] };
@@ -86,6 +87,7 @@ const page = ref(1);
 const hasMore = ref(false);
 const loading = ref(false);
 const error = ref<string | null>(null);
+const providerErrors = ref<CatalogProviderError[]>([]);
 const pulling = ref<Set<string>>(new Set());
 const pendingEntry = ref<CatalogEntry | null>(null);
 /** Entry whose in-app detail drawer is open. */
@@ -101,7 +103,7 @@ function recordFamilies(values: Iterable<string | null | undefined>): void {
   const before = seen.size;
   for (const value of values) {
     const name = value?.trim();
-    if (name) seen.add(name);
+    if (name) seen.add(catalogFamily(name));
   }
   if (seen.size !== before) observedFamilies.value = [...seen].sort((a, b) => a.localeCompare(b));
 }
@@ -137,7 +139,7 @@ const installedCatalogEntries = computed<CatalogListEntry[]>(() => {
       (m) =>
         !q || m.name.toLowerCase().includes(q) || modelDisplayName(m).toLowerCase().includes(q),
     )
-    .filter((m) => !family.value || m.family === family.value)
+    .filter((m) => matchesCatalogFamily(m.family, family.value))
     .map((m) => ({ ...installedModelToEntry(m), hostIds: m.hostIds ?? [] }))
     .filter(
       (entry) =>
@@ -214,7 +216,7 @@ const manifestEntries = computed<CatalogEntry[]>(() => {
     .filter((model) => !model.downloaded && isGenerationModel(model))
     .filter((model) => !installed.has(model.name))
     .filter((model) => !q || model.name.toLowerCase().includes(q))
-    .filter((model) => !family.value || model.family === family.value)
+    .filter((model) => matchesCatalogFamily(model.family, family.value))
     .map(manifestCatalogEntry);
 });
 
@@ -348,9 +350,9 @@ let searchEpoch = 0;
 
 async function runSearch(reset: boolean) {
   const epoch = ++searchEpoch;
+  let nextEntries = reset ? [] : [...entries.value];
   if (reset) {
     page.value = 1;
-    entries.value = [];
   }
   loading.value = true;
   error.value = null;
@@ -372,8 +374,10 @@ async function runSearch(reset: boolean) {
         target,
       );
       if (epoch !== searchEpoch) return;
+      providerErrors.value = res.provider_errors ?? [];
       recordFamilies(res.entries.map((entry) => entry.family));
-      entries.value = [...entries.value, ...res.entries];
+      nextEntries = [...nextEntries, ...res.entries];
+      entries.value = nextEntries;
       // Exhaustion comes from the wire `total`, not page fullness: under
       // source=All the server splits the page budget across sources, so a
       // merged page is legitimately short whenever one source has no rows
@@ -410,6 +414,10 @@ function loadMore() {
   if (loading.value || !hasMore.value) return;
   page.value += 1;
   void runSearch(false);
+}
+
+function retrySearch(): void {
+  void runSearch(true);
 }
 
 const sentinel = ref<HTMLElement | null>(null);
@@ -667,12 +675,31 @@ onUnmounted(() => {
       />
     </div>
 
-    <p v-if="error" class="text-caption text-stop">{{ error }}</p>
+    <div
+      v-if="error || providerErrors.length"
+      data-test="catalog-provider-warning"
+      class="border-stop/30 bg-stop/5 flex items-center gap-3 rounded-control border px-3 py-2 text-caption text-stop"
+      role="alert"
+    >
+      <p class="min-w-0 flex-1">
+        {{ error ?? providerErrors.map((item) => item.message).join(" ") }}
+        <span v-if="providerErrors.length"> Showing available models.</span>
+      </p>
+      <button
+        type="button"
+        data-test="catalog-retry"
+        class="border-stop/40 shrink-0 rounded-control border px-2 py-1 font-medium hover:bg-stop/10"
+        :disabled="loading"
+        @click="retrySearch"
+      >
+        {{ loading ? "Retrying…" : "Retry" }}
+      </button>
+    </div>
 
     <!-- Empty state — keyed on the FILTERED list so an all-image page under
          the Video chip explains itself instead of rendering a blank grid. -->
     <div
-      v-else-if="!loading && displayEntries.length === 0"
+      v-if="!loading && displayEntries.length === 0"
       class="p-8 text-center text-body text-ink-2"
       data-test="catalog-empty"
     >

--- a/desktop/src/lib/api/types.ts
+++ b/desktop/src/lib/api/types.ts
@@ -877,6 +877,13 @@ export interface CatalogSearchResponse {
   page: number;
   page_size: number;
   total: number;
+  /** A merged search can keep one provider's rows when the other is down. */
+  provider_errors?: CatalogProviderError[];
+}
+
+export interface CatalogProviderError {
+  source: "hf" | "civitai";
+  message: string;
 }
 
 /** One family from `GET /api/catalog/families`. */

--- a/desktop/src/mobile/MobileCatalogView.test.ts
+++ b/desktop/src/mobile/MobileCatalogView.test.ts
@@ -1902,6 +1902,23 @@ describe("MobileCatalogView", () => {
     expect(wrapper.text()).not.toContain("Couldn’t reach Studio");
   });
 
+  it("keeps partial provider rows when a manual retry still fails", async () => {
+    searchCatalog.mockResolvedValueOnce({
+      ...searchResponse([entry("Healthy HF model")]),
+      provider_errors: [{ source: "civitai", message: "Civitai is temporarily unavailable." }],
+    });
+    wrapper = mountCatalog(studio.id, [studio]);
+    await flushPromises();
+    expect(wrapper.text()).toContain("Healthy HF model");
+
+    searchCatalog.mockRejectedValueOnce(new Error("still unavailable"));
+    await wrapper.get(".mobile-catalog-retry").trigger("click");
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("Healthy HF model");
+    expect(wrapper.text()).toContain("still unavailable");
+  });
+
   it("falls back to the families seen in results when the taxonomy is unavailable", async () => {
     fetchCatalogFamilies.mockRejectedValue(new Error("fetch failed"));
     searchCatalog.mockResolvedValue(

--- a/desktop/src/mobile/MobileCatalogView.vue
+++ b/desktop/src/mobile/MobileCatalogView.vue
@@ -33,7 +33,7 @@ import {
   type CatalogKindFilter,
   type CatalogSortOption,
 } from "../lib/catalogFilters";
-import { familyLabel } from "@studio/lib/modelFamily";
+import { catalogFamily, familyLabel, matchesCatalogFamily } from "@studio/lib/modelFamily";
 import { filterRestrictedModels } from "@studio/lib/modelAccess";
 import { isMinimaxH3Identity } from "@studio/lib/minimaxH3Authoring";
 import { reviewedMiniMaxH3ModelAccess } from "@studio/lib/minimaxH3Inventory";
@@ -262,7 +262,7 @@ function recordFamilies(values: Iterable<string | null | undefined>): void {
   const before = seen.size;
   for (const value of values) {
     const name = value?.trim();
-    if (name) seen.add(name);
+    if (name) seen.add(catalogFamily(name));
   }
   if (seen.size !== before) observedFamilies.value = [...seen].sort((a, b) => a.localeCompare(b));
 }
@@ -309,7 +309,7 @@ const manifestEntries = computed<MobileCatalogEntry[]>(() => {
     .filter((model) => !model.downloaded && !isUtilityModel(model))
     .filter((model) => !installedNames.value.has(model.name))
     .filter((model) => !q || model.name.toLowerCase().includes(q))
-    .filter((model) => !family.value || model.family === family.value)
+    .filter((model) => matchesCatalogFamily(model.family, family.value))
     .map(manifestModelToEntry);
 });
 
@@ -391,7 +391,7 @@ const filteredInstalled = computed(() => {
       (entry) =>
         !q || entry.name.toLowerCase().includes(q) || entryTitle(entry).toLowerCase().includes(q),
     )
-    .filter((entry) => !family.value || entry.family === family.value)
+    .filter((entry) => matchesCatalogFamily(entry.family, family.value))
     .filter((entry) => !kind.value || entry.kind === kind.value)
     .filter(sourceMatches)
     .filter(mediaMatches);
@@ -630,9 +630,9 @@ async function runSearch(reset: boolean): Promise<void> {
   const target = selectedTarget.value;
   if (!target || source.value === "installed") return;
   const epoch = ++searchEpoch;
+  let nextEntries = reset ? [] : [...entries.value];
   if (reset) {
     page.value = 1;
-    entries.value = [];
   }
   loading.value = true;
   error.value = "";
@@ -653,7 +653,9 @@ async function runSearch(reset: boolean): Promise<void> {
         target,
       );
       if (epoch !== searchEpoch) return;
-      entries.value = [...entries.value, ...response.entries];
+      error.value = (response.provider_errors ?? []).map((item) => item.message).join(" ");
+      nextEntries = [...nextEntries, ...response.entries];
+      entries.value = nextEntries;
       recordFamilies(response.entries.map((row) => row.family));
       // Exhaustion comes from the wire `total`, not page fullness: under
       // source=All the server splits the page budget across sources, so a
@@ -1358,7 +1360,20 @@ onBeforeUnmount(() => {
         </label>
       </div>
 
-      <p v-if="error" class="mobile-catalog-error error-text" role="alert">{{ error }}</p>
+      <div v-if="error" class="mobile-catalog-error error-text" role="alert">
+        <span>
+          {{ error }}
+          <template v-if="combinedEntries.length"> Showing available models.</template>
+        </span>
+        <button
+          class="mobile-catalog-retry"
+          type="button"
+          :disabled="loading"
+          @click="runSearch(true)"
+        >
+          {{ loading ? "Retrying…" : "Retry" }}
+        </button>
+      </div>
       <div v-if="loading && combinedEntries.length === 0" class="mobile-catalog-empty empty-state">
         Loading models…
       </div>

--- a/desktop/src/mobile/mobile.css
+++ b/desktop/src/mobile/mobile.css
@@ -3234,7 +3234,21 @@ button:disabled {
 }
 
 .mobile-catalog-error {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
   margin: 14px 0;
+}
+
+.mobile-catalog-retry {
+  min-width: 72px;
+  min-height: 44px;
+  border: 1px solid currentcolor;
+  border-radius: var(--radius-control);
+  padding: 0 12px;
+  color: inherit;
+  font: inherit;
 }
 
 .mobile-catalog-action-status {

--- a/studio/lib/modelFamily.test.ts
+++ b/studio/lib/modelFamily.test.ts
@@ -12,7 +12,11 @@ import { existsSync, readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
-import { familyLabel } from "./modelFamily";
+import {
+  catalogFamily,
+  familyLabel,
+  matchesCatalogFamily,
+} from "./modelFamily";
 
 const FIXTURE_RELATIVE = "tests/fixtures/wan/surface-parity-v1.json";
 
@@ -61,6 +65,12 @@ describe("model family labels", () => {
     expect(familyLabel("some-new-family")).toBe("Some New Family");
     expect(familyLabel("another_one")).toBe("Another One");
     expect(familyLabel("")).toBe("");
+  });
+
+  it("groups Qwen Image Edit under Qwen Image for catalog browsing", () => {
+    expect(catalogFamily("qwen-image-edit")).toBe("qwen-image");
+    expect(matchesCatalogFamily("qwen-image-edit", "qwen-image")).toBe(true);
+    expect(catalogFamily("flux")).toBe("flux");
   });
 
   it("does not make a family chip wider than it already is", () => {

--- a/studio/lib/modelFamily.ts
+++ b/studio/lib/modelFamily.ts
@@ -45,3 +45,17 @@ export function familyLabel(family: string): string {
       .join(" ")
   );
 }
+
+/** Catalog browsing groups edit-specialized Qwen Image variants with the
+ * Qwen Image shelf. Runtime forms keep the concrete `qwen-image-edit` family;
+ * this only controls Models taxonomy/filtering. */
+export function catalogFamily(family: string): string {
+  return family === "qwen-image-edit" ? "qwen-image" : family;
+}
+
+export function matchesCatalogFamily(
+  family: string,
+  selected: string,
+): boolean {
+  return !selected || catalogFamily(family) === catalogFamily(selected);
+}

--- a/web/src/components/CatalogCardGrid.test.ts
+++ b/web/src/components/CatalogCardGrid.test.ts
@@ -80,6 +80,8 @@ let mockState: {
   loadingMore: any;
   hasMore: any;
   errorMsg: any;
+  providerErrors: any;
+  refresh: ReturnType<typeof vi.fn>;
   loadMore: ReturnType<typeof vi.fn>;
   openDetail: ReturnType<typeof vi.fn>;
   startDownload: ReturnType<typeof vi.fn>;
@@ -102,6 +104,8 @@ beforeEach(() => {
     loadingMore: ref(false),
     hasMore: ref(true),
     errorMsg: ref<string | null>(null),
+    providerErrors: ref([]),
+    refresh: vi.fn(),
     loadMore: vi.fn(),
     openDetail: vi.fn(),
     startDownload: vi.fn(),
@@ -132,6 +136,22 @@ describe("CatalogCardGrid result count", () => {
     expect(w.find('[data-testid="catalog-result-count"]').text()).toBe(
       "1 result",
     );
+  });
+});
+
+describe("CatalogCardGrid provider resilience", () => {
+  it("keeps healthy rows visible beside a provider warning and retries", async () => {
+    mockState.providerErrors = ref([
+      { source: "civitai", message: "Civitai is temporarily unavailable." },
+    ]);
+    const w = mount(CatalogCardGrid);
+
+    expect(w.get("[data-test='catalog-provider-warning']").text()).toContain(
+      "Civitai",
+    );
+    expect(w.findAllComponents({ name: "CatalogCard" })).toHaveLength(1);
+    await w.get("[data-test='catalog-retry']").trigger("click");
+    expect(mockState.refresh).toHaveBeenCalledOnce();
   });
 });
 

--- a/web/src/components/CatalogCardGrid.vue
+++ b/web/src/components/CatalogCardGrid.vue
@@ -66,7 +66,7 @@ async function pullCard(entry: CatalogEntryWire) {
   <div class="min-w-0 flex-1">
     <!-- Loading state -->
     <div
-      v-if="cat.loading.value"
+      v-if="cat.loading.value && cat.visibleEntries.value.length === 0"
       class="flex items-center justify-center py-12 text-sm text-ink-3"
     >
       Loading…
@@ -74,19 +74,44 @@ async function pullCard(entry: CatalogEntryWire) {
 
     <!-- Error state -->
     <div
-      v-else-if="cat.errorMsg.value"
+      v-if="cat.errorMsg.value || cat.providerErrors.value.length"
+      data-test="catalog-provider-warning"
       class="bg-bench border border-edge flex items-start gap-3 rounded-2xl px-4 py-3 text-sm text-rose-200"
+      role="alert"
     >
       <span class="mt-0.5">⚠</span>
-      <div>
-        <p class="font-medium text-rose-100">Couldn't load the catalog.</p>
-        <p class="text-rose-200/80">{{ cat.errorMsg.value }}</p>
+      <div class="min-w-0 flex-1">
+        <p class="font-medium text-rose-100">
+          {{
+            cat.errorMsg.value
+              ? "Couldn't refresh the catalog."
+              : "Part of the catalog is unavailable."
+          }}
+        </p>
+        <p class="text-rose-200/80">
+          {{
+            cat.errorMsg.value ??
+            cat.providerErrors.value.map((item) => item.message).join(" ")
+          }}
+          <span v-if="cat.providerErrors.value.length">
+            Showing available models.</span
+          >
+        </p>
       </div>
+      <button
+        type="button"
+        data-test="catalog-retry"
+        class="border border-rose-200/40 shrink-0 rounded-lg px-3 py-1.5 font-medium text-rose-100 hover:bg-rose-100/10"
+        :disabled="cat.loading.value"
+        @click="cat.refresh()"
+      >
+        {{ cat.loading.value ? "Retrying…" : "Retry" }}
+      </button>
     </div>
 
     <!-- Empty state -->
     <div
-      v-else-if="cat.visibleEntries.value.length === 0"
+      v-if="!cat.loading.value && cat.visibleEntries.value.length === 0"
       class="flex flex-col items-center justify-center gap-2 py-16 text-ink-3"
     >
       <p class="text-sm">No models found.</p>
@@ -96,7 +121,7 @@ async function pullCard(entry: CatalogEntryWire) {
     </div>
 
     <!-- Grid -->
-    <template v-else>
+    <template v-else-if="cat.visibleEntries.value.length > 0">
       <p
         data-testid="catalog-result-count"
         class="mb-3 text-[12px] text-ink-3"

--- a/web/src/composables/useCatalog.ts
+++ b/web/src/composables/useCatalog.ts
@@ -1,4 +1,5 @@
 import { computed, ref, watch } from "vue";
+import { matchesCatalogFamily } from "@studio/lib/modelFamily";
 import {
   deleteModel,
   fetchCatalogEntry,
@@ -16,6 +17,7 @@ import type {
   CatalogEntryWire,
   CatalogFamilyCount,
   CatalogListParams,
+  CatalogProviderError,
   ModelComponentStatus,
   ModelInfoExtended,
 } from "../types";
@@ -94,6 +96,7 @@ function build() {
   const loading = ref(false);
   const loadingMore = ref(false);
   const errorMsg = ref<string | null>(null);
+  const providerErrors = ref<CatalogProviderError[]>([]);
   const detail = ref<ModelDetail | null>(null);
   // Detail drawer non-content states (G4: the drawer is never blank). While a
   // non-cached row's `/api/catalog/:id` fetch is in flight the drawer shows a
@@ -125,8 +128,8 @@ function build() {
     if (filter.value.kind && filter.value.kind !== "checkpoint") return [];
     return availableManifests.value
       .filter((model) => model.family === "minimax-h3" && !model.downloaded)
-      .filter(
-        (model) => !filter.value.family || model.family === filter.value.family,
+      .filter((model) =>
+        matchesCatalogFamily(model.family, filter.value.family ?? ""),
       )
       .filter(
         (model) =>
@@ -209,6 +212,7 @@ function build() {
     if (!hasMore.value) return false;
     const next = page.value + 1;
     const list = await fetchCatalogSearch(searchParams(next));
+    providerErrors.value = list.provider_errors ?? [];
     entries.value = [...entries.value, ...list.entries];
     page.value = next;
     if (typeof list.total === "number") total.value = list.total;
@@ -231,15 +235,21 @@ function build() {
   async function refresh() {
     loading.value = true;
     errorMsg.value = null;
+    providerErrors.value = [];
     try {
-      const [list, fams] = await Promise.all([
+      const [listResult, familiesResult] = await Promise.allSettled([
         fetchCatalogSearch(searchParams(1)),
         fetchCatalogFamilies(),
       ]);
+      if (listResult.status === "rejected") throw listResult.reason;
+      const list = listResult.value;
       entries.value = list.entries;
       total.value = typeof list.total === "number" ? list.total : null;
       page.value = 1;
-      families.value = fams.families;
+      providerErrors.value = list.provider_errors ?? [];
+      if (familiesResult.status === "fulfilled") {
+        families.value = familiesResult.value.families;
+      }
       await autoFill();
     } catch (e: unknown) {
       errorMsg.value = e instanceof Error ? e.message : String(e);
@@ -487,6 +497,7 @@ function build() {
     loading,
     loadingMore,
     errorMsg,
+    providerErrors,
     detail,
     detailLoadingId,
     detailError,

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -1223,6 +1223,12 @@ export interface CatalogListResponse {
   page_size: number;
   /** Total rows matching the request's filters, ignoring pagination. */
   total: number;
+  provider_errors?: CatalogProviderError[];
+}
+
+export interface CatalogProviderError {
+  source: "hf" | "civitai";
+  message: string;
 }
 
 export interface CatalogFamilyCount {


### PR DESCRIPTION
## Summary
- retry transient Hugging Face and Civitai catalog failures with bounded backoff
- return and render healthy-provider results with provider-specific warnings and Retry controls across desktop, web, and iPhone
- preserve usable rows across failed retries and stop degraded pagination until a clean page-1 retry
- group Qwen Image Edit models under the Qwen Image family in Models without changing runtime family semantics

## Verification
- `nix develop -c cargo test -p mold-ai-catalog live::tests:: --lib`
- `nix develop -c cargo test -p mold-ai-server catalog_live_test:: --lib`
- `nix develop -c cargo clippy -p mold-ai-catalog -p mold-ai-server --all-targets -- -D warnings`
- focused desktop/mobile/shared tests: 88 passed
- focused web tests: 39 passed
- `nix develop -c bun run build:web`
- `nix develop -c bun run build:desktop`
- `nix develop -c bun run build:mobile`
- in-app browser QA at `/models?tab=discover`: warning + Retry visible, healthy-provider row retained, retry exercised, clean console

## Peer review
An independent agent review found two edge cases (failed Retry clearing healthy rows and provider recovery between pages skipping rows). Both were fixed and covered by regression tests before publication.