### PR TITLE
fix(wan): preserve chained video continuity

### DIFF
--- a/crates/mold-core/src/chain.rs
+++ b/crates/mold-core/src/chain.rs
@@ -847,6 +847,7 @@ impl ChainRequest {
                 clip_frames,
                 motion_tail,
                 source_image,
+                family.as_deref(),
             )?;
         }
 
@@ -1048,6 +1049,7 @@ fn build_auto_expand_stages(
     clip_frames: u32,
     motion_tail_frames: u32,
     source_image: Option<Vec<u8>>,
+    family: Option<&str>,
 ) -> Result<Vec<ChainStage>> {
     let (stage_count, per_stage_frames) = if total_frames <= clip_frames {
         // Single stage: match the user's requested length exactly so we
@@ -1072,20 +1074,23 @@ fn build_auto_expand_stages(
     }
 
     let mut stages = Vec::with_capacity(count_usize);
-    for _ in 0..stage_count {
-        // Every stage carries the starting image: stage 0 uses it as the
-        // i2v replacement at frame 0, and continuation stages use it as a
-        // soft identity anchor through the append path (see
-        // `Ltx2Engine::render_chain_stage`). Keeping a durable reference
-        // across stages is what stops scene/identity drift past the first
-        // clip, whose effects were traced in render-chain v1 as the
-        // dominant cause of "strange" continuations — the motion tail
-        // alone only carries ~0.7 s of pixel context, nowhere near enough
-        // for the model to remember the scene across an 8-stage chain.
+    for idx in 0..stage_count {
+        // LTX-2 consumes the repeated starting image as a soft identity
+        // anchor alongside the motion tail. Wan has no such append path: a
+        // stage-local source image is its hard frame-0 authority, and its
+        // renderer deliberately refuses to replace one with the preceding
+        // stage's tail. Repeating the opening still therefore restarted every
+        // auto-expanded Wan continuation from the same frame instead of
+        // producing the promised seamless handoff.
+        let stage_source = if family == Some("wan") && idx > 0 {
+            None
+        } else {
+            source_image.clone()
+        };
         stages.push(ChainStage {
             prompt: prompt.to_string(),
             frames: per_stage_frames,
-            source_image: source_image.clone(),
+            source_image: stage_source,
             negative_prompt: None,
             seed_offset: None,
             transition: TransitionMode::Smooth,
@@ -1278,7 +1283,7 @@ mod tests {
     }
 
     #[test]
-    fn normalise_preserves_starting_image_across_all_stages() {
+    fn normalise_preserves_ltx2_starting_image_across_all_stages() {
         let png = vec![0x89, 0x50, 0x4e, 0x47, 0xde, 0xad, 0xbe, 0xef];
         let normalised = auto_expand_request("test", 200, 97, 9, Some(png.clone()))
             .normalise()
@@ -1296,6 +1301,28 @@ mod tests {
                 "stage {idx} must carry the starting image for cross-stage identity anchoring",
             );
         }
+    }
+
+    #[test]
+    fn normalise_seeds_only_the_first_wan_stage_from_the_opening_image() {
+        let png = vec![0x89, 0x50, 0x4e, 0x47, 0xde, 0xad, 0xbe, 0xef];
+        let mut request = auto_expand_request("test", 105, 53, 1, Some(png.clone()));
+        request.model = "hf:opaque-wan-i2v".into();
+        request.width = 832;
+        request.height = 480;
+        let normalised = request
+            .normalise_with_family(Some("wan"))
+            .expect("wan auto-expand should succeed");
+
+        assert_eq!(normalised.stages.len(), 2);
+        assert_eq!(
+            normalised.stages[0].source_image.as_deref(),
+            Some(png.as_slice())
+        );
+        assert!(
+            normalised.stages[1].source_image.is_none(),
+            "the continuation must accept Wan's previous-frame seam carry"
+        );
     }
 
     #[test]

--- a/crates/mold-server/src/chain_job_runner.rs
+++ b/crates/mold-server/src/chain_job_runner.rs
@@ -2972,16 +2972,16 @@ impl StageExecutor for ProductionStageExecutor {
                 }
                 config.install_frozen_model_config(model, frozen.config.clone());
                 if frozen.runtime_model_id.is_empty() {
-                    model
+                    model.to_string()
                 } else {
-                    frozen.runtime_model_id.as_str()
+                    crate::gpu_pool::frozen_chain_cache_key(&frozen.runtime_model_id, model)
                 }
             } else {
-                model
+                model.to_string()
             };
             return self
                 .render_stage_with_authority(
-                    cache_key,
+                    &cache_key,
                     model,
                     &config,
                     stage_req,
@@ -3005,7 +3005,9 @@ impl StageExecutor for ProductionStageExecutor {
         let mut frozen_config = self.fresh_config();
         let cache_key = frozen_model
             .and_then(|frozen| {
-                (!frozen.runtime_model_id.is_empty()).then_some(frozen.runtime_model_id.clone())
+                (!frozen.runtime_model_id.is_empty()).then(|| {
+                    crate::gpu_pool::frozen_chain_cache_key(&frozen.runtime_model_id, model)
+                })
             })
             .unwrap_or_else(|| model.to_string());
         let expected_fingerprint = frozen_model.map(|frozen| {
@@ -8278,7 +8280,8 @@ mod tests {
             }
         }
         let stage_request = stage_requests[0].clone();
-        let expected_cache_key = frozen.runtime_model_id.clone();
+        let expected_cache_key =
+            crate::gpu_pool::frozen_chain_cache_key(&frozen.runtime_model_id, "test-chain:q4");
         let expected_frozen_config = frozen.config.clone();
         let task = tokio::task::spawn_blocking(move || {
             executor.render_stage_with_context(

--- a/crates/mold-server/src/gpu_pool.rs
+++ b/crates/mold-server/src/gpu_pool.rs
@@ -334,6 +334,25 @@ pub(crate) fn clear_model_cuda_ooms_for_tests() {
     MODEL_CUDA_OOMS.write().unwrap().clear();
 }
 
+const CHAIN_CACHE_MODEL_SEPARATOR: &str = "\u{1f}model:";
+
+/// Keep the immutable frozen artifact identity as the cache authority while
+/// retaining the semantic model name for status/UI consumers.
+pub(crate) fn frozen_chain_cache_key(runtime_model_id: &str, model: &str) -> String {
+    format!("{runtime_model_id}{CHAIN_CACHE_MODEL_SEPARATOR}{model}")
+}
+
+/// Translate an internal cache identity back to the model a user selected.
+/// Ordinary cache keys pass through unchanged.
+pub(crate) fn resident_model_display_name(cache_key: &str) -> &str {
+    if !cache_key.starts_with("mold-frozen-chain:") {
+        return cache_key;
+    }
+    cache_key
+        .split_once(CHAIN_CACHE_MODEL_SEPARATOR)
+        .map_or(cache_key, |(_, model)| model)
+}
+
 /// Per-GPU worker state. Each GPU gets its own model cache, load lock, and health tracking.
 pub struct GpuWorker {
     pub owner_epoch: u64,
@@ -1695,10 +1714,14 @@ impl GpuWorker {
     pub fn status(&self) -> GpuWorkerStatus {
         let active_gen = self.active_generation.read().unwrap();
         let in_flight = self.in_flight.load(Ordering::SeqCst);
-        let loaded_model = active_gen
-            .as_ref()
-            .map(|g| g.model.clone())
-            .or_else(|| self.resident_model.read().unwrap().clone());
+        let loaded_model = active_gen.as_ref().map(|g| g.model.clone()).or_else(|| {
+            self.resident_model
+                .read()
+                .unwrap()
+                .as_deref()
+                .map(resident_model_display_name)
+                .map(str::to_string)
+        });
 
         let state = if self.is_degraded() {
             GpuWorkerState::Degraded
@@ -2284,6 +2307,27 @@ mod tests {
         let status = worker.status();
         assert_eq!(status.loaded_model.as_deref(), Some("flux-dev:q4"));
         assert_eq!(status.vram_used_bytes, 0);
+    }
+
+    #[test]
+    fn worker_status_hides_frozen_chain_cache_identity() {
+        let (worker, _job_rx) = test_worker(0, 24_000_000_000);
+        *worker.resident_model.write().unwrap() = Some(frozen_chain_cache_key(
+            "mold-frozen-chain:0123456789abcdef",
+            "wan22-i2v-a14b:q4",
+        ));
+
+        let status = worker.status();
+        assert_eq!(status.loaded_model.as_deref(), Some("wan22-i2v-a14b:q4"));
+    }
+
+    #[test]
+    fn cache_display_name_preserves_opaque_model_separators() {
+        let opaque = format!("hf:opaque{CHAIN_CACHE_MODEL_SEPARATOR}variant");
+        assert_eq!(resident_model_display_name(&opaque), opaque);
+
+        let frozen = frozen_chain_cache_key("mold-frozen-chain:0123456789abcdef", &opaque);
+        assert_eq!(resident_model_display_name(&frozen), opaque);
     }
 
     #[test]

--- a/crates/mold-server/src/gpu_worker.rs
+++ b/crates/mold-server/src/gpu_worker.rs
@@ -2169,12 +2169,20 @@ fn process_admin_unload(worker: &GpuWorker, job: AdminModelUnloadJob) -> bool {
             .read()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .clone();
-        if resident.as_deref() != Some(expected) {
+        if resident
+            .as_deref()
+            .map(crate::gpu_pool::resident_model_display_name)
+            != Some(expected)
+        {
             let _ = job.result_tx.send(Ok(None));
             return true;
         }
     }
-    let result = unload_blocking(worker).map_err(|error| error.to_string());
+    let result = unload_blocking(worker)
+        .map(|unloaded| {
+            unloaded.map(|model| crate::gpu_pool::resident_model_display_name(&model).to_string())
+        })
+        .map_err(|error| error.to_string());
     let successful = result.is_ok();
     let _ = job.result_tx.send(result);
     successful

--- a/crates/mold-server/src/model_manager.rs
+++ b/crates/mold-server/src/model_manager.rs
@@ -359,7 +359,15 @@ fn loaded_models_across_pool(state: &AppState) -> Vec<String> {
             .read()
             .ok()
             .and_then(|g| g.as_ref().map(|g| g.model.clone()));
-        let loaded = active.or_else(|| worker.resident_model.read().ok()?.clone());
+        let loaded = active.or_else(|| {
+            worker
+                .resident_model
+                .read()
+                .ok()?
+                .as_deref()
+                .map(crate::gpu_pool::resident_model_display_name)
+                .map(str::to_string)
+        });
         if let Some(name) = loaded {
             if !names.contains(&name) {
                 names.push(name);

--- a/crates/mold-server/src/queue.rs
+++ b/crates/mold-server/src/queue.rs
@@ -1403,7 +1403,7 @@ fn multi_gpu_loaded_models(state: &AppState) -> std::collections::HashSet<String
         }
         if let Ok(resident) = worker.resident_model.read() {
             if let Some(name) = resident.as_ref() {
-                set.insert(name.clone());
+                set.insert(crate::gpu_pool::resident_model_display_name(name).to_string());
             }
         }
     }

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -3895,6 +3895,7 @@ async fn unload_model(
                         .read()
                         .unwrap_or_else(|poisoned| poisoned.into_inner())
                         .as_deref()
+                        .map(crate::gpu_pool::resident_model_display_name)
                         == Some(model)
                 })
                 .collect(),
@@ -3987,7 +3988,11 @@ async fn model_is_gpu_resident(state: &AppState, canonical: &str) -> bool {
             }
         }
         if let Ok(resident) = worker.resident_model.read() {
-            if resident.as_deref() == Some(canonical) {
+            if resident
+                .as_deref()
+                .map(crate::gpu_pool::resident_model_display_name)
+                == Some(canonical)
+            {
                 return true;
             }
         }


### PR DESCRIPTION
## Summary
- let WAN image-to-video continuation stages consume the previous stage carry instead of restarting from the opening still
- keep LTX-2 starting-image anchoring unchanged
- retain frozen execution identity internally while reporting and unloading the semantic model name in machine status
- preserve opaque custom model identifiers when decoding frozen cache keys

## Live diagnosis
- inspected `mold.service` and the incident chain on hal9000
- both WAN stages completed successfully; the reset came from cloning `source_image` into every auto-expanded WAN stage
- confirmed the visible `mold-frozen-chain:*` value was the immutable internal cache key leaking through status consumers

## Validation
- `nix develop -c cargo fmt --all -- --check`
- `nix develop -c cargo test -p mold-ai-core normalise_` (23 passed)
- focused server cache/status and production V2 executor tests
- `nix develop -c cargo clippy -p mold-ai-core -p mold-ai-server --all-targets -- -D warnings`
- server lib suite: 1535 passed, 12 ignored; two gallery timing tests failed under parallel load and both passed individually
- independent agent peer review completed; one opaque-ID parsing edge case was found, fixed, and regression-tested

## Notes
The hal9000 service stayed healthy and produced the final MP4. The ordinary 105-frame WAN placement probe remains correctly infeasible on its 24 GB GPU, while each 53-frame chained stage is schedulable; this fix preserves the chain route and corrects its inter-stage source authority.