### PR TITLE
fix(models): add batch discovery downloads

### DIFF
--- a/desktop/src/components/models/CatalogCard.test.ts
+++ b/desktop/src/components/models/CatalogCard.test.ts
@@ -57,6 +57,7 @@ describe("CatalogCard", () => {
     expect(wrapper.get("img").attributes("decoding")).toBe("async");
     expect(wrapper.get("img").attributes("fetchpriority")).toBe("low");
     expect(wrapper.get('[data-test="catalog-card"]').classes()).toContain("catalog-card-contained");
+    expect(wrapper.get('[data-test="catalog-card"]').attributes("role")).toBeUndefined();
   });
 
   it("labels the model kind and mature content, includes both in the accessible name", async () => {
@@ -158,12 +159,14 @@ describe("CatalogCard", () => {
     expect(openExternalMock).not.toHaveBeenCalled();
   });
 
-  it("exposes the card as a keyboard-focusable button", async () => {
+  it("uses dedicated keyboard controls instead of nesting them in a card button", async () => {
     const wrapper = mount(CatalogCard, { props: { entry: entry(), pulling: false } });
     await flushPromises();
     const card = wrapper.get('[data-test="catalog-card"]');
-    expect(card.attributes("role")).toBe("button");
-    expect(card.attributes("tabindex")).toBe("0");
+    expect(card.attributes("role")).toBeUndefined();
+    expect(card.attributes("tabindex")).toBeUndefined();
+    expect(wrapper.get('[data-test="card-title"]').element.tagName).toBe("BUTTON");
+    expect(wrapper.get('[data-test="catalog-select"]').element.tagName).toBe("INPUT");
   });
 
   it("marks the card that backs the open model detail", async () => {
@@ -177,14 +180,11 @@ describe("CatalogCard", () => {
     expect(card.classes()).toContain("catalog-card-contained--selected");
   });
 
-  it("opens the drawer from Enter and Space on the focused card", async () => {
+  it("opens the drawer from the dedicated title button", async () => {
     const wrapper = mount(CatalogCard, { props: { entry: entry(), pulling: false } });
     await flushPromises();
-    const card = wrapper.get('[data-test="catalog-card"]');
-
-    await card.trigger("keydown.enter");
-    await card.trigger("keydown.space");
-    expect(wrapper.emitted("open")).toHaveLength(2);
+    await wrapper.get('[data-test="card-title"]').trigger("click");
+    expect(wrapper.emitted("open")).toHaveLength(1);
     expect(wrapper.emitted("open")?.[0]?.[0]).toMatchObject({ id: "cv:8001" });
   });
 

--- a/desktop/src/components/models/CatalogCard.vue
+++ b/desktop/src/components/models/CatalogCard.vue
@@ -39,13 +39,17 @@ const props = withDefaults(
     installable?: boolean | undefined;
     /** The card currently backing the open detail drawer. */
     selected?: boolean;
+    /** Batch-download checkbox state. */
+    selectable?: boolean;
+    checked?: boolean;
   }>(),
   // Explicit so Vue's boolean casting doesn't turn "not supplied" into false.
-  { installable: undefined, selected: false },
+  { installable: undefined, selected: false, selectable: true, checked: false },
 );
 const emit = defineEmits<{
   (e: "pull", entry: CatalogEntry): void;
   (e: "open", entry: CatalogEntry): void;
+  (e: "toggle-select", entry: CatalogEntry, checked: boolean): void;
 }>();
 
 const glyphSource = computed<ModelSource>(() =>
@@ -101,34 +105,34 @@ const thumbFailed = ref(false);
 function openPage(): void {
   if (pageUrl.value) void openExternal(pageUrl.value);
 }
-
-/**
- * Enter/Space on the card opens the drawer, but keydown bubbles — a keypress
- * on an inner control (Pull, the link-out) reaches here too. Only act when the
- * card itself is focused so those controls keep their own single action.
- */
-function onCardKeydown(event: KeyboardEvent): void {
-  if (event.target !== event.currentTarget) return;
-  event.preventDefault();
-  emit("open", props.entry);
-}
 </script>
 
 <template>
-  <div
-    class="catalog-card-contained border-edge flex cursor-pointer flex-col rounded-chrome border bg-bath transition-colors duration-150 hover:bg-bench focus-visible:outline-2 focus-visible:outline-safelight"
+  <article
+    class="catalog-card-contained border-edge flex cursor-pointer flex-col rounded-chrome border bg-bath transition-colors duration-150 hover:bg-bench"
     :class="selected ? 'catalog-card-contained--selected' : ''"
-    role="button"
-    tabindex="0"
     data-test="catalog-card"
     data-layout="grid"
     :aria-label="accessibilityLabel"
     :aria-current="selected ? 'true' : undefined"
     :data-selected="selected ? 'true' : undefined"
     @click="emit('open', entry)"
-    @keydown.enter="onCardKeydown"
-    @keydown.space="onCardKeydown"
   >
+    <label
+      class="catalog-card-checkbox border-edge absolute left-2 top-2 z-10 flex h-7 w-7 items-center justify-center rounded-control border bg-bench/95"
+      :title="selectable ? 'Select model for batch download' : 'No download target available'"
+      @click.stop
+    >
+      <input
+        type="checkbox"
+        class="h-4 w-4 accent-[var(--safelight)]"
+        :checked="checked"
+        :disabled="!selectable"
+        :aria-label="`Select ${displayName}`"
+        data-test="catalog-select"
+        @change="emit('toggle-select', entry, ($event.target as HTMLInputElement).checked)"
+      />
+    </label>
     <!-- Civitai preview image (public URL); shimmer while loading and use a
          local family mark when no custom image is available. -->
     <div
@@ -259,12 +263,18 @@ function onCardKeydown(event: KeyboardEvent): void {
         </button>
       </div>
     </div>
-  </div>
+  </article>
 </template>
 
 <style scoped>
 .catalog-card-contained {
+  position: relative;
   contain: layout paint style;
+}
+
+.catalog-card-contained:has(.catalog-card-checkbox input:checked) {
+  border-color: var(--safelight);
+  box-shadow: inset 0 0 0 1px var(--safelight);
 }
 
 .catalog-card-contained--selected,

--- a/desktop/src/components/models/CatalogTab.test.ts
+++ b/desktop/src/components/models/CatalogTab.test.ts
@@ -33,6 +33,7 @@ import { useDownloadsStore } from "../../stores/downloads";
 import { useHostModelsStore } from "../../stores/hostModels";
 import { useHostsStore } from "../../stores/hosts";
 import { useModelStore } from "../../stores/models";
+import { ApiError } from "../../lib/api/client";
 
 const PAGE_SIZE = 24;
 
@@ -1117,6 +1118,149 @@ describe("CatalogTab install on a machine that is missing the model", () => {
     expect(wrapper.text()).toContain("● installed");
     expect(wrapper.find("[data-test='pull']").exists()).toBe(false);
     wrapper.unmount();
+  });
+});
+
+describe("CatalogTab batch downloads", () => {
+  it("queues every checked model on the selected target machine", async () => {
+    setActivePinia(createPinia());
+    const connection = useConnectionStore();
+    connection.info = {
+      mode: "local",
+      baseUrl: "http://127.0.0.1:7680",
+      apiKey: "local-key",
+    };
+    connection.status = "ready";
+    useHostModelsStore().byHost.local = {
+      entries: [],
+      fetchedAt: Date.now(),
+      error: null,
+    };
+    vi.spyOn(useDownloadsStore(), "subscribe").mockResolvedValue(undefined);
+    searchCatalog.mockResolvedValue({
+      entries: [entry("flux-one", "flux"), entry("flux-two", "flux")],
+      page: 1,
+      page_size: PAGE_SIZE,
+      total: 2,
+    });
+    const wrapper = mount(CatalogTab, {
+      props: { query: "", layout: "table" as const },
+    });
+    await flushPromises();
+
+    const checks = wrapper.findAll<HTMLInputElement>("[data-test='catalog-select']");
+    expect(checks).toHaveLength(2);
+    await checks[0]!.setValue(true);
+    await wrapper.findAll<HTMLInputElement>("[data-test='catalog-select']")[1]!.setValue(true);
+
+    expect(wrapper.get("[data-test='catalog-batch-bar']").text()).toContain("2 selected");
+    expect(wrapper.get<HTMLSelectElement>("[data-test='catalog-batch-target']").element.value).toBe(
+      "local",
+    );
+    await wrapper.get("[data-test='catalog-batch-download']").trigger("click");
+    await flushPromises();
+
+    expect(startCatalogDownload).toHaveBeenCalledTimes(2);
+    expect(startCatalogDownload).toHaveBeenCalledWith(
+      "hf:flux-one",
+      { baseUrl: "http://127.0.0.1:7680", apiKey: "local-key" },
+      false,
+    );
+    expect(startCatalogDownload).toHaveBeenCalledWith(
+      "hf:flux-two",
+      { baseUrl: "http://127.0.0.1:7680", apiKey: "local-key" },
+      false,
+    );
+    expect(wrapper.find("[data-test='catalog-batch-bar']").exists()).toBe(false);
+  });
+
+  it("does not offer a batch checkbox before a host inventory is known", async () => {
+    setActivePinia(createPinia());
+    const connection = useConnectionStore();
+    connection.info = {
+      mode: "local",
+      baseUrl: "http://127.0.0.1:7680",
+      apiKey: "local-key",
+    };
+    connection.status = "ready";
+    searchCatalog.mockResolvedValue({
+      entries: [entry("flux-one", "flux")],
+      page: 1,
+      page_size: PAGE_SIZE,
+      total: 1,
+    });
+    const wrapper = mount(CatalogTab, {
+      props: { query: "", layout: "table" as const },
+    });
+    await flushPromises();
+
+    expect(wrapper.get<HTMLInputElement>("[data-test='catalog-select']").element.disabled).toBe(
+      true,
+    );
+  });
+
+  it("does not offer unsupported catalog packages for batch download", async () => {
+    setActivePinia(createPinia());
+    const connection = useConnectionStore();
+    connection.info = {
+      mode: "local",
+      baseUrl: "http://127.0.0.1:7680",
+      apiKey: "local-key",
+    };
+    connection.status = "ready";
+    useHostModelsStore().byHost.local = {
+      entries: [],
+      fetchedAt: Date.now(),
+      error: null,
+    };
+    searchCatalog.mockResolvedValue({
+      entries: [{ ...entry("unsupported", "flux"), supported: false }],
+      page: 1,
+      page_size: PAGE_SIZE,
+      total: 1,
+    });
+    const wrapper = mount(CatalogTab, {
+      props: { query: "", layout: "table" as const },
+    });
+    await flushPromises();
+
+    expect(wrapper.get<HTMLInputElement>("[data-test='catalog-select']").element.disabled).toBe(
+      true,
+    );
+  });
+
+  it("clears already-queued models from the batch selection", async () => {
+    setActivePinia(createPinia());
+    const connection = useConnectionStore();
+    connection.info = {
+      mode: "local",
+      baseUrl: "http://127.0.0.1:7680",
+      apiKey: "local-key",
+    };
+    connection.status = "ready";
+    useHostModelsStore().byHost.local = {
+      entries: [],
+      fetchedAt: Date.now(),
+      error: null,
+    };
+    vi.spyOn(useDownloadsStore(), "subscribe").mockResolvedValue(undefined);
+    startCatalogDownload.mockRejectedValueOnce(new ApiError("already queued", 409));
+    searchCatalog.mockResolvedValue({
+      entries: [entry("flux-one", "flux")],
+      page: 1,
+      page_size: PAGE_SIZE,
+      total: 1,
+    });
+    const wrapper = mount(CatalogTab, {
+      props: { query: "", layout: "table" as const },
+    });
+    await flushPromises();
+    await wrapper.get<HTMLInputElement>("[data-test='catalog-select']").setValue(true);
+
+    await wrapper.get("[data-test='catalog-batch-download']").trigger("click");
+    await flushPromises();
+
+    expect(wrapper.find("[data-test='catalog-batch-bar']").exists()).toBe(false);
   });
 });
 

--- a/desktop/src/components/models/CatalogTab.vue
+++ b/desktop/src/components/models/CatalogTab.vue
@@ -5,6 +5,7 @@ import CatalogLayoutToggle, {
   type CatalogLayoutChoice,
 } from "@ui/components/CatalogLayoutToggle.vue";
 import { planModelInstall } from "@studio/lib/modelInstallTargets";
+import { isAlreadyQueuedError, planBatchInstallTargets } from "@studio/lib/modelBatchInstall";
 import { useDownloadsStore } from "../../stores/downloads";
 import { useHostsStore, type HostView } from "../../stores/hosts";
 import { useInventoryKnown } from "../../lib/modelInventory";
@@ -28,7 +29,7 @@ import CatalogCard from "./CatalogCard.vue";
 import CatalogTableRow from "./CatalogTableRow.vue";
 import CatalogDetailDrawer, { type DrawerVariant } from "./CatalogDetailDrawer.vue";
 import DownloadTargetDialog from "./DownloadTargetDialog.vue";
-import { installedModelToEntry } from "../../lib/catalogDetail";
+import { canDownloadEntry, installedModelToEntry } from "../../lib/catalogDetail";
 import type { CatalogEntry, CatalogProviderError, ModelEntry } from "../../lib/api/types";
 
 type LibraryModelEntry = ModelEntry & { hostIds?: string[] };
@@ -89,6 +90,9 @@ const loading = ref(false);
 const error = ref<string | null>(null);
 const providerErrors = ref<CatalogProviderError[]>([]);
 const pulling = ref<Set<string>>(new Set());
+const selected = ref(new Map<string, CatalogListEntry>());
+const selectedTargetId = ref("");
+const batchStarting = ref(false);
 const pendingEntry = ref<CatalogEntry | null>(null);
 /** Entry whose in-app detail drawer is open. */
 const detailEntry = ref<CatalogListEntry | null>(null);
@@ -321,6 +325,46 @@ function actionTargets(entry: CatalogEntry & { hostIds?: string[] }) {
   return installPlan(entry).targets;
 }
 
+function selectable(entry: CatalogListEntry): boolean {
+  return canDownloadEntry(entry) && actionTargets(entry).length > 0;
+}
+
+function toggleSelection(entry: CatalogListEntry, checked: boolean): void {
+  const next = new Map(selected.value);
+  if (checked) next.set(entry.id, entry);
+  else next.delete(entry.id);
+  selected.value = next;
+}
+
+const batchTargets = computed(() =>
+  planBatchInstallTargets(
+    [...selected.value.values()].map((entry) => ({
+      modelId: entry.id,
+      targets: actionTargets(entry),
+    })),
+  ),
+);
+
+watch(
+  batchTargets,
+  (targets) => {
+    if (targets.some(({ host }) => host.id === selectedTargetId.value)) return;
+    selectedTargetId.value = targets.length === 1 ? targets[0]!.host.id : "";
+  },
+  { immediate: true },
+);
+
+const selectedBatchTarget = computed(() =>
+  batchTargets.value.find(({ host }) => host.id === selectedTargetId.value),
+);
+
+function targetSummary(installCount: number, repairCount: number): string {
+  const parts = [];
+  if (installCount) parts.push(`${installCount} new`);
+  if (repairCount) parts.push(`${repairCount} repair`);
+  return parts.join(", ");
+}
+
 /** The row keeps its action while any machine can still receive the model —
  *  and an entry nobody owns always keeps it, even before hosts resolve. */
 function installable(entry: CatalogEntry & { hostIds?: string[] }): boolean {
@@ -423,14 +467,18 @@ function retrySearch(): void {
 const sentinel = ref<HTMLElement | null>(null);
 useInfiniteScrollSentinel(sentinel, loading, hasMore, loadMore, MAX_AUTO_PAGES);
 
+async function queueOnHost(entry: CatalogEntry, host: HostView | null): Promise<void> {
+  const target = host?.baseUrl ? { baseUrl: host.baseUrl, apiKey: host.apiKey } : undefined;
+  // Attach the snapshot-first stream before enqueueing so a cached,
+  // near-instant pull still produces a visible terminal event and refresh.
+  await downloads.subscribe(host ?? undefined);
+  await startCatalogDownload(entry.id, target, host ? host.kind === "remote" : false);
+}
+
 async function pullTo(entry: CatalogEntry, host: HostView | null) {
   pulling.value.add(entry.id);
   try {
-    const target = host?.baseUrl ? { baseUrl: host.baseUrl, apiKey: host.apiKey } : undefined;
-    // Attach the snapshot-first stream before enqueueing so a cached,
-    // near-instant pull still produces a visible terminal event and refresh.
-    await downloads.subscribe(host ?? undefined);
-    await startCatalogDownload(entry.id, target, host ? host.kind === "remote" : false);
+    await queueOnHost(entry, host);
     toasts.push(`Pulling ${entry.display_name ?? entry.name}${host ? ` on ${host.label}` : ""}`);
   } catch (err) {
     if (err instanceof ApiError && err.status === 409) {
@@ -442,6 +490,50 @@ async function pullTo(entry: CatalogEntry, host: HostView | null) {
     pulling.value.delete(entry.id);
     pendingEntry.value = null;
   }
+}
+
+async function startBatch(): Promise<void> {
+  const target = selectedBatchTarget.value;
+  if (!target || batchStarting.value) return;
+  batchStarting.value = true;
+  for (const item of target.items) pulling.value.add(item.modelId);
+  const entriesById = new Map(selected.value);
+  const results = await Promise.allSettled(
+    target.items.map(async (item) => {
+      const entry = entriesById.get(item.modelId);
+      if (!entry) throw new Error(`Model ${item.modelId} is no longer selected`);
+      try {
+        await queueOnHost(entry, target.host);
+      } catch (error) {
+        if (!isAlreadyQueuedError(error)) throw error;
+      }
+      return item.modelId;
+    }),
+  );
+  const next = new Map(selected.value);
+  let succeeded = 0;
+  const failures: string[] = [];
+  results.forEach((result, index) => {
+    const item = target.items[index]!;
+    pulling.value.delete(item.modelId);
+    if (result.status === "fulfilled") {
+      next.delete(result.value);
+      succeeded += 1;
+    } else {
+      const entry = entriesById.get(item.modelId);
+      failures.push(
+        `${entry?.display_name ?? entry?.name ?? "Model"}: ${result.reason instanceof Error ? result.reason.message : String(result.reason)}`,
+      );
+    }
+  });
+  selected.value = next;
+  if (succeeded) {
+    toasts.push(
+      `${succeeded} ${succeeded === 1 ? "download" : "downloads"} queued on ${target.host.label}`,
+    );
+  }
+  if (failures.length) toasts.push(failures.join(" · "), "error");
+  batchStarting.value = false;
 }
 
 function pull(entry: CatalogEntry) {
@@ -696,6 +788,51 @@ onUnmounted(() => {
       </button>
     </div>
 
+    <div
+      v-if="selected.size > 0"
+      class="border-edge sticky top-2 z-20 flex flex-wrap items-center gap-3 rounded-control border bg-bench/95 p-2.5 shadow-raised backdrop-blur"
+      data-test="catalog-batch-bar"
+      aria-live="polite"
+    >
+      <strong class="text-body text-ink">{{ selected.size }} selected</strong>
+      <template v-if="batchTargets.length">
+        <label class="ml-auto flex items-center gap-2 text-caption text-ink-2">
+          Target machine
+          <select
+            v-model="selectedTargetId"
+            data-test="catalog-batch-target"
+            :disabled="batchStarting"
+            class="border-edge h-8 rounded-control border bg-bath px-2 text-caption text-ink"
+          >
+            <option value="" disabled>Choose a machine…</option>
+            <option v-for="target in batchTargets" :key="target.host.id" :value="target.host.id">
+              {{ target.host.label }} · {{ targetSummary(target.installCount, target.repairCount) }}
+            </option>
+          </select>
+        </label>
+        <button
+          type="button"
+          data-test="catalog-batch-download"
+          class="h-8 rounded-control bg-safelight px-3 text-caption font-semibold text-on-accent disabled:opacity-50"
+          :disabled="!selectedBatchTarget || batchStarting"
+          @click="startBatch"
+        >
+          {{ batchStarting ? "Starting…" : `Download ${selected.size}` }}
+        </button>
+      </template>
+      <span v-else class="ml-auto text-caption text-stop">
+        No machine can receive every selected model.
+      </span>
+      <button
+        type="button"
+        class="border-edge h-8 rounded-control border px-2.5 text-caption text-ink-2 hover:text-ink"
+        :disabled="batchStarting"
+        @click="selected = new Map()"
+      >
+        Clear
+      </button>
+    </div>
+
     <!-- Empty state — keyed on the FILTERED list so an all-image page under
          the Video chip explains itself instead of rendering a blank grid. -->
     <div
@@ -724,7 +861,7 @@ onUnmounted(() => {
     <!-- Results, installed first. Grid keeps preview cards; the table layout
          is the app-wide model-row shape — clean info, no thumbnails. -->
     <div
-      v-else
+      v-if="loading || displayEntries.length > 0"
       :class="
         effectiveLayout === 'grid'
           ? 'grid grid-cols-[repeat(auto-fill,minmax(260px,1fr))] gap-2'
@@ -739,8 +876,11 @@ onUnmounted(() => {
           :hosts="hostLabelsFor(entry)"
           :installable="installable(entry)"
           :selected="detailEntry?.id === entry.id"
+          :selectable="!batchStarting && selectable(entry)"
+          :checked="selected.has(entry.id)"
           @pull="pull"
           @open="detailEntry = $event"
+          @toggle-select="toggleSelection"
         />
         <CatalogTableRow
           v-else
@@ -749,9 +889,12 @@ onUnmounted(() => {
           :hosts="hostLabelsFor(entry)"
           :installable="installable(entry)"
           :selected="detailEntry?.id === entry.id"
+          :selectable="!batchStarting && selectable(entry)"
+          :checked="selected.has(entry.id)"
           class="px-3 py-2"
           @pull="pull"
           @open="detailEntry = $event"
+          @toggle-select="toggleSelection"
         />
       </template>
     </div>

--- a/desktop/src/components/models/CatalogTableRow.test.ts
+++ b/desktop/src/components/models/CatalogTableRow.test.ts
@@ -62,8 +62,10 @@ describe("CatalogTableRow", () => {
     expect(wrapper.get('[data-test="model-kind-badge"]').text()).toBe("LoRA");
     expect(wrapper.get('[data-test="model-nsfw-badge"]').text()).toBe("18+ NSFW");
     const row = wrapper.get("[data-test='catalog-table-row']");
-    expect(row.attributes("aria-label")).toContain("LoRA");
-    expect(row.attributes("aria-label")).toContain("18+ NSFW");
+    expect(row.attributes("role")).toBeUndefined();
+    const title = wrapper.get("[data-test='row-title']");
+    expect(title.attributes("aria-label")).toContain("LoRA");
+    expect(title.attributes("aria-label")).toContain("18+ NSFW");
   });
 
   it("shows SIZE and FETCH as the two size lines once resolved", async () => {

--- a/desktop/src/components/models/CatalogTableRow.vue
+++ b/desktop/src/components/models/CatalogTableRow.vue
@@ -29,13 +29,16 @@ const props = withDefaults(
     installable?: boolean | undefined;
     /** The row currently backing the open detail drawer. */
     selected?: boolean;
+    selectable?: boolean;
+    checked?: boolean;
   }>(),
   // Explicit so Vue's boolean casting doesn't turn "not supplied" into false.
-  { installable: undefined, selected: false },
+  { installable: undefined, selected: false, selectable: true, checked: false },
 );
 const emit = defineEmits<{
   (e: "pull", entry: CatalogEntry): void;
   (e: "open", entry: CatalogEntry): void;
+  (e: "toggle-select", entry: CatalogEntry, checked: boolean): void;
 }>();
 
 const glyphSource = computed<ModelSource>(() =>
@@ -100,10 +103,26 @@ const counts = computed(() => {
     :accessibility-label="accessibilityLabel"
     :selected="selected"
     clickable
+    :interactive-container="false"
     data-test="catalog-table-row"
     @open="emit('open', entry)"
   >
     <template #meta>
+      <label
+        class="flex h-6 w-6 shrink-0 items-center justify-center"
+        :title="selectable ? 'Select model for batch download' : 'No download target available'"
+        @click.stop
+      >
+        <input
+          type="checkbox"
+          class="h-4 w-4 accent-[var(--safelight)]"
+          :checked="checked"
+          :disabled="!selectable"
+          :aria-label="`Select ${entry.display_name ?? entry.name}`"
+          data-test="catalog-select"
+          @change="emit('toggle-select', entry, ($event.target as HTMLInputElement).checked)"
+        />
+      </label>
       <ModelMetadataBadges
         :kind="entry.kind"
         :family="entry.family"

--- a/desktop/src/components/models/ModelTableRow.vue
+++ b/desktop/src/components/models/ModelTableRow.vue
@@ -38,6 +38,9 @@ const props = withDefaults(
     barPercent?: number | null;
     /** Row and name become buttons that emit `open` (catalog detail drawer). */
     clickable?: boolean;
+    /** When false, only the title is a semantic button. Use this when slots
+     * contain their own interactive controls such as selection checkboxes. */
+    interactiveContainer?: boolean;
     /** The row currently backing an open detail drawer. */
     selected?: boolean;
     /** Rich accessible name when visible metadata adds context to the row. */
@@ -53,6 +56,7 @@ const props = withDefaults(
     sizeSecondary: null,
     barPercent: null,
     clickable: false,
+    interactiveContainer: true,
     selected: false,
     accessibilityLabel: null,
   },
@@ -90,9 +94,13 @@ function onRowKeydown(event: KeyboardEvent): void {
       $slots.actions ? 'model-table-row--has-actions' : '',
       selected ? 'model-table-row--selected' : '',
     ]"
-    :role="clickable ? 'button' : undefined"
-    :tabindex="clickable ? 0 : undefined"
-    :aria-label="clickable ? (accessibilityLabel ?? `${name} — view details`) : undefined"
+    :role="clickable && interactiveContainer ? 'button' : undefined"
+    :tabindex="clickable && interactiveContainer ? 0 : undefined"
+    :aria-label="
+      clickable && interactiveContainer
+        ? (accessibilityLabel ?? `${name} — view details`)
+        : undefined
+    "
     :aria-describedby="barPercent != null ? footprintDescriptionId : undefined"
     :aria-current="selected ? 'true' : undefined"
     :data-selected="selected ? 'true' : undefined"
@@ -116,6 +124,9 @@ function onRowKeydown(event: KeyboardEvent): void {
         type="button"
         class="model-table-row__title truncate text-left text-body text-ink transition-colors duration-100 hover:text-safelight"
         :title="`${name} — view details`"
+        :aria-label="
+          !interactiveContainer ? (accessibilityLabel ?? `${name} — view details`) : undefined
+        "
         data-test="row-title"
         @click.stop="emit('open')"
       >

--- a/studio/lib/modelBatchInstall.test.ts
+++ b/studio/lib/modelBatchInstall.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import {
+  isAlreadyQueuedError,
+  planBatchInstallTargets,
+} from "./modelBatchInstall";
+
+const local = { id: "local", label: "This device" };
+const studio = { id: "studio", label: "Studio GPU" };
+
+describe("planBatchInstallTargets", () => {
+  it("keeps only machines that can receive every selected model", () => {
+    const plans = planBatchInstallTargets([
+      {
+        modelId: "flux",
+        targets: [
+          { host: local, action: "install" as const },
+          { host: studio, action: "repair" as const },
+        ],
+      },
+      {
+        modelId: "ltx",
+        targets: [{ host: local, action: "install" as const }],
+      },
+    ]);
+
+    expect(plans).toEqual([
+      {
+        host: local,
+        items: [
+          { modelId: "flux", action: "install" },
+          { modelId: "ltx", action: "install" },
+        ],
+        installCount: 2,
+        repairCount: 0,
+      },
+    ]);
+  });
+
+  it("summarises mixed install and repair work for each machine", () => {
+    const plans = planBatchInstallTargets([
+      {
+        modelId: "flux",
+        targets: [{ host: studio, action: "repair" as const }],
+      },
+      {
+        modelId: "ltx",
+        targets: [{ host: studio, action: "install" as const }],
+      },
+    ]);
+
+    expect(plans[0]).toMatchObject({
+      host: studio,
+      installCount: 1,
+      repairCount: 1,
+    });
+  });
+
+  it("returns no target for an incompatible selection", () => {
+    expect(
+      planBatchInstallTargets([
+        {
+          modelId: "flux",
+          targets: [{ host: local, action: "install" as const }],
+        },
+        {
+          modelId: "ltx",
+          targets: [{ host: studio, action: "install" as const }],
+        },
+      ]),
+    ).toEqual([]);
+  });
+});
+
+describe("isAlreadyQueuedError", () => {
+  it("recognises transport errors that preserve an HTTP conflict status", () => {
+    expect(isAlreadyQueuedError({ status: 409 })).toBe(true);
+    expect(isAlreadyQueuedError({ status: 500 })).toBe(false);
+    expect(isAlreadyQueuedError(new Error("already queued"))).toBe(false);
+  });
+});

--- a/studio/lib/modelBatchInstall.ts
+++ b/studio/lib/modelBatchInstall.ts
@@ -1,0 +1,64 @@
+import type {
+  ModelInstallAction,
+  ModelInstallTarget,
+} from "./modelInstallTargets";
+
+export interface BatchInstallSelection<H> {
+  modelId: string;
+  targets: readonly ModelInstallTarget<H>[];
+}
+
+export interface BatchInstallItem {
+  modelId: string;
+  action: ModelInstallAction;
+}
+
+export interface BatchInstallHostPlan<H> {
+  host: H;
+  items: BatchInstallItem[];
+  installCount: number;
+  repairCount: number;
+}
+
+/** Both browser and desktop API clients retain an HTTP status, but use
+ * different error classes. Treat a duplicate enqueue as idempotent without
+ * coupling this shared planner to either surface's transport layer. */
+export function isAlreadyQueuedError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "status" in error &&
+    (error as { status?: unknown }).status === 409
+  );
+}
+
+/**
+ * Finds machines that can accept every selected model. The first selection's
+ * target order stays authoritative so each surface retains its normal
+ * install-first, repair-last machine ordering.
+ */
+export function planBatchInstallTargets<H extends { id: string }>(
+  selections: readonly BatchInstallSelection<H>[],
+): BatchInstallHostPlan<H>[] {
+  const first = selections[0];
+  if (!first) return [];
+
+  return first.targets.flatMap((candidate) => {
+    const items: BatchInstallItem[] = [];
+    for (const selection of selections) {
+      const target = selection.targets.find(
+        ({ host }) => host.id === candidate.host.id,
+      );
+      if (!target) return [];
+      items.push({ modelId: selection.modelId, action: target.action });
+    }
+    return [
+      {
+        host: candidate.host,
+        items,
+        installCount: items.filter(({ action }) => action === "install").length,
+        repairCount: items.filter(({ action }) => action === "repair").length,
+      },
+    ];
+  });
+}

--- a/web/src/components/CatalogCard.vue
+++ b/web/src/components/CatalogCard.vue
@@ -14,10 +14,19 @@ import type { CatalogEntryWire } from "../types";
 import { formatGB } from "../util/format";
 
 const props = withDefaults(
-  defineProps<{ entry: CatalogEntryWire; layout?: "grid" | "list" }>(),
-  { layout: "grid" },
+  defineProps<{
+    entry: CatalogEntryWire;
+    layout?: "grid" | "list";
+    selectable?: boolean;
+    checked?: boolean;
+  }>(),
+  { layout: "grid", selectable: true, checked: false },
 );
-const emit = defineEmits<{ open: []; pull: [] }>();
+const emit = defineEmits<{
+  open: [];
+  pull: [];
+  "toggle-select": [checked: boolean];
+}>();
 
 const CATALOG_THUMBNAIL_WIDTH = 512;
 const CIVITAI_IMAGE_HOSTS = new Set([
@@ -120,6 +129,7 @@ const pullLabel = computed(() =>
 <template>
   <article
     class="card"
+    :class="{ 'card--checked': checked }"
     data-test="discover-card"
     :data-layout="props.layout"
     :aria-label="accessibleName"
@@ -162,6 +172,26 @@ const pullLabel = computed(() =>
     </button>
 
     <div class="card__top">
+      <label
+        class="card__select"
+        :title="
+          selectable
+            ? 'Select model for batch download'
+            : 'No common download target available'
+        "
+        @click.stop
+      >
+        <input
+          type="checkbox"
+          :checked="checked"
+          :disabled="!selectable"
+          :aria-label="`Select ${props.entry.name}`"
+          data-test="catalog-select"
+          @change="
+            emit('toggle-select', ($event.target as HTMLInputElement).checked)
+          "
+        />
+      </label>
       <ModelMetadataBadges
         :kind="props.entry.kind"
         :family="props.entry.family"
@@ -234,6 +264,31 @@ const pullLabel = computed(() =>
 
 .card:hover {
   border-color: var(--ce);
+}
+
+.card--checked {
+  border-color: var(--safelight);
+  box-shadow: inset 0 0 0 1px var(--safelight);
+}
+
+.card__select {
+  display: inline-flex;
+  align-items: center;
+  min-width: 20px;
+  min-height: 20px;
+}
+
+.card__select input {
+  width: 15px;
+  height: 15px;
+  margin: 0;
+  accent-color: var(--safelight);
+  cursor: pointer;
+}
+
+.card__select input:disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
 }
 
 .card[data-layout="list"] {

--- a/web/src/components/CatalogCardGrid.test.ts
+++ b/web/src/components/CatalogCardGrid.test.ts
@@ -172,6 +172,82 @@ describe("CatalogCardGrid download feedback", () => {
   });
 });
 
+describe("CatalogCardGrid batch downloads", () => {
+  it("checks multiple models and queues all of them on one chosen machine", async () => {
+    const second = { ...baseEntry, id: "hf:row-1", name: "Row 1" };
+    mockState.entries = ref([baseEntry, second]);
+    mockState.visibleEntries = ref([baseEntry, second]);
+    mockState.resultCount = ref(2);
+    const w = mount(CatalogCardGrid);
+
+    const cards = w.findAllComponents({ name: "CatalogCard" });
+    cards[0]!.vm.$emit("toggle-select", true);
+    cards[1]!.vm.$emit("toggle-select", true);
+    await w.vm.$nextTick();
+
+    expect(w.get("[data-test='catalog-batch-bar']").text()).toContain(
+      "2 selected",
+    );
+    expect(
+      w.get<HTMLSelectElement>("[data-test='catalog-batch-target']").element
+        .value,
+    ).toBe("origin");
+    await w.get("[data-test='catalog-batch-download']").trigger("click");
+    await flushPromises();
+
+    expect(mockState.startDownload).toHaveBeenCalledTimes(2);
+    expect(mockState.startDownload).toHaveBeenCalledWith("hf:row-0");
+    expect(mockState.startDownload).toHaveBeenCalledWith("hf:row-1");
+    expect(w.find("[data-test='catalog-batch-bar']").exists()).toBe(false);
+    expect(toastMock).toHaveBeenCalledWith(
+      "success",
+      "2 downloads queued on this server",
+    );
+  });
+
+  it("keeps failed models selected for retry", async () => {
+    const second = { ...baseEntry, id: "hf:row-1", name: "Row 1" };
+    mockState.entries = ref([baseEntry, second]);
+    mockState.visibleEntries = ref([baseEntry, second]);
+    mockState.resultCount = ref(2);
+    mockState.startDownload
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("disk full"));
+    const w = mount(CatalogCardGrid);
+    const cards = w.findAllComponents({ name: "CatalogCard" });
+    cards[0]!.vm.$emit("toggle-select", true);
+    cards[1]!.vm.$emit("toggle-select", true);
+    await w.vm.$nextTick();
+
+    await w.get("[data-test='catalog-batch-download']").trigger("click");
+    await flushPromises();
+
+    expect(w.get("[data-test='catalog-batch-bar']").text()).toContain(
+      "1 selected",
+    );
+    expect(toastMock).toHaveBeenCalledWith("error", "Row 1: disk full");
+  });
+
+  it("treats an already-queued conflict as an idempotent success", async () => {
+    mockState.startDownload.mockRejectedValueOnce(
+      Object.assign(new Error("already queued"), { status: 409 }),
+    );
+    const w = mount(CatalogCardGrid);
+    w.getComponent({ name: "CatalogCard" }).vm.$emit("toggle-select", true);
+    await w.vm.$nextTick();
+
+    await w.get("[data-test='catalog-batch-download']").trigger("click");
+    await flushPromises();
+
+    expect(w.find("[data-test='catalog-batch-bar']").exists()).toBe(false);
+    expect(toastMock).toHaveBeenCalledWith(
+      "success",
+      "1 download queued on this server",
+    );
+    expect(toastMock).not.toHaveBeenCalledWith("error", expect.anything());
+  });
+});
+
 describe("CatalogCardGrid layout", () => {
   it("renders the existing card grid by default", () => {
     const w = mount(CatalogCardGrid);

--- a/web/src/components/CatalogCardGrid.vue
+++ b/web/src/components/CatalogCardGrid.vue
@@ -1,5 +1,9 @@
 <script setup lang="ts">
-import { onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
+import {
+  isAlreadyQueuedError,
+  planBatchInstallTargets,
+} from "@studio/lib/modelBatchInstall";
 import { useCatalog } from "../composables/useCatalog";
 import { useModelInstallTargets } from "../composables/useModelInstallTargets";
 import { toast } from "../lib/toasts";
@@ -9,6 +13,9 @@ import CatalogCard from "./CatalogCard.vue";
 const cat = useCatalog();
 const installTargets = useModelInstallTargets();
 const sentinel = ref<HTMLElement | null>(null);
+const selected = ref(new Map<string, CatalogEntryWire>());
+const selectedTargetId = ref("");
+const batchStarting = ref(false);
 let observer: IntersectionObserver | null = null;
 
 function detach() {
@@ -59,6 +66,93 @@ async function pullCard(entry: CatalogEntryWire) {
   } catch (error) {
     toast("error", error instanceof Error ? error.message : String(error));
   }
+}
+
+function selectionTargets(entry: CatalogEntryWire) {
+  return installTargets.planFor(entry.id, entry.installed).targets;
+}
+
+function selectable(entry: CatalogEntryWire): boolean {
+  return entry.supported && selectionTargets(entry).length > 0;
+}
+
+function toggleSelection(entry: CatalogEntryWire, checked: boolean): void {
+  const next = new Map(selected.value);
+  if (checked) next.set(entry.id, entry);
+  else next.delete(entry.id);
+  selected.value = next;
+}
+
+const batchTargets = computed(() =>
+  planBatchInstallTargets(
+    [...selected.value.values()].map((entry) => ({
+      modelId: entry.id,
+      targets: selectionTargets(entry),
+    })),
+  ),
+);
+
+watch(
+  batchTargets,
+  (targets) => {
+    if (targets.some(({ host }) => host.id === selectedTargetId.value)) return;
+    selectedTargetId.value = targets.length === 1 ? targets[0]!.host.id : "";
+  },
+  { immediate: true },
+);
+
+const selectedBatchTarget = computed(() =>
+  batchTargets.value.find(({ host }) => host.id === selectedTargetId.value),
+);
+
+function targetSummary(installCount: number, repairCount: number): string {
+  const parts = [];
+  if (installCount) parts.push(`${installCount} new`);
+  if (repairCount) parts.push(`${repairCount} repair`);
+  return parts.join(", ");
+}
+
+async function startBatch(): Promise<void> {
+  const target = selectedBatchTarget.value;
+  if (!target || batchStarting.value) return;
+  batchStarting.value = true;
+  const entriesById = new Map(selected.value);
+  const results = await Promise.allSettled(
+    target.items.map(async (item) => {
+      try {
+        await installTargets.startDownloadOn(
+          { host: target.host, action: item.action },
+          item.modelId,
+        );
+      } catch (error) {
+        if (!isAlreadyQueuedError(error)) throw error;
+      }
+      return item.modelId;
+    }),
+  );
+  const next = new Map(selected.value);
+  let succeeded = 0;
+  const failures: string[] = [];
+  results.forEach((result, index) => {
+    if (result.status === "fulfilled") {
+      next.delete(result.value);
+      succeeded += 1;
+    } else {
+      const item = target.items[index]!;
+      const entry = entriesById.get(item.modelId);
+      failures.push(
+        `${entry?.name ?? "Model"}: ${result.reason instanceof Error ? result.reason.message : String(result.reason)}`,
+      );
+    }
+  });
+  selected.value = next;
+  if (succeeded)
+    toast(
+      "success",
+      `${succeeded} ${succeeded === 1 ? "download" : "downloads"} queued on ${target.host.label}`,
+    );
+  if (failures.length) toast("error", failures.join(" · "));
+  batchStarting.value = false;
 }
 </script>
 
@@ -132,6 +226,55 @@ async function pullCard(entry: CatalogEntryWire) {
       </p>
 
       <div
+        v-if="selected.size > 0"
+        class="batch-bar"
+        data-test="catalog-batch-bar"
+        aria-live="polite"
+      >
+        <strong>{{ selected.size }} selected</strong>
+        <template v-if="batchTargets.length">
+          <label class="batch-bar__target">
+            <span>Target machine</span>
+            <select
+              v-model="selectedTargetId"
+              data-test="catalog-batch-target"
+              :disabled="batchStarting"
+            >
+              <option value="" disabled>Choose a machine…</option>
+              <option
+                v-for="target in batchTargets"
+                :key="target.host.id"
+                :value="target.host.id"
+              >
+                {{ target.host.label }} ·
+                {{ targetSummary(target.installCount, target.repairCount) }}
+              </option>
+            </select>
+          </label>
+          <button
+            type="button"
+            class="batch-bar__download"
+            data-test="catalog-batch-download"
+            :disabled="!selectedBatchTarget || batchStarting"
+            @click="startBatch"
+          >
+            {{ batchStarting ? "Starting…" : `Download ${selected.size}` }}
+          </button>
+        </template>
+        <span v-else class="batch-bar__warning"
+          >No machine can receive every selected model.</span
+        >
+        <button
+          type="button"
+          class="batch-bar__clear"
+          :disabled="batchStarting"
+          @click="selected = new Map()"
+        >
+          Clear
+        </button>
+      </div>
+
+      <div
         data-test="catalog-results"
         :data-layout="cat.layout.value"
         :class="
@@ -145,8 +288,11 @@ async function pullCard(entry: CatalogEntryWire) {
           :key="entry.id"
           :entry="entry"
           :layout="cat.layout.value"
+          :selectable="!batchStarting && selectable(entry)"
+          :checked="selected.has(entry.id)"
           @open="openCard(entry.id)"
           @pull="pullCard(entry)"
+          @toggle-select="toggleSelection(entry, $event)"
         />
       </div>
 
@@ -170,3 +316,77 @@ async function pullCard(entry: CatalogEntryWire) {
     </template>
   </div>
 </template>
+
+<style scoped>
+.batch-bar {
+  position: sticky;
+  top: 8px;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--ce);
+  border-radius: var(--radius-control-lg);
+  background: color-mix(in srgb, var(--bench) 94%, transparent);
+  box-shadow: var(--shadow-raised);
+  backdrop-filter: blur(12px);
+  color: var(--rebate);
+  font-size: 12px;
+}
+
+.batch-bar__target {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  color: var(--ink-2);
+}
+
+.batch-bar select,
+.batch-bar button {
+  min-height: 34px;
+  border: 1px solid var(--ce);
+  border-radius: var(--radius-control);
+  background: var(--bath);
+  color: var(--rebate);
+  padding: 0 10px;
+}
+
+.batch-bar__download {
+  border-color: var(--safelight) !important;
+  background: var(--safelight) !important;
+  color: var(--on-accent) !important;
+  font-weight: 700;
+}
+
+.batch-bar button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.batch-bar__clear {
+  background: transparent !important;
+}
+
+.batch-bar__warning {
+  flex: 1;
+  color: var(--stop);
+}
+
+@media (max-width: 700px) {
+  .batch-bar {
+    align-items: stretch;
+    flex-wrap: wrap;
+  }
+
+  .batch-bar__target {
+    width: 100%;
+    flex-basis: 100%;
+    align-items: stretch;
+    flex-direction: column;
+  }
+}
+</style>

--- a/web/src/components/machines/hostClient.ts
+++ b/web/src/components/machines/hostClient.ts
@@ -27,7 +27,11 @@ import type {
   ServerStatus,
 } from "../../types";
 import type { HostEntry } from "../../lib/hostRegistry";
-import { looksLikeCatalogId, type CatalogDownloadResponse } from "../../api";
+import {
+  ApiHttpError,
+  looksLikeCatalogId,
+  type CatalogDownloadResponse,
+} from "../../api";
 import { parseCurrentServerStatus } from "@studio/api/client";
 import {
   listDevices,
@@ -208,7 +212,7 @@ export async function hostModelDownload(
   });
   if (!res.ok) {
     const detail = await res.text().catch(() => "");
-    throw new Error(detail || `POST ${path} failed: ${res.status}`);
+    throw new ApiHttpError(`POST ${path}`, res.status, detail);
   }
   return catalog ? ((await res.json()) as CatalogDownloadResponse) : null;
 }


### PR DESCRIPTION
## Summary
- add accessible model-selection checkboxes to Discover on desktop and web
- intersect eligible machine targets across the selection and queue every model on one chosen host
- retain failed selections for retry, treat already-queued conflicts idempotently, and lock selection during dispatch
- preserve per-machine install/repair planning and unsupported/inventory-unknown safeguards

## Validation
- `nix develop -c bun run --cwd web test --run` (1,378 tests)
- `nix develop -c bun run --cwd desktop test --run --maxWorkers=1` (3,713 tests)
- `nix develop -c bun run --cwd web build`
- `nix develop -c bun run --cwd desktop build`
- Prettier and `git diff --check`
- browser QA on both web and desktop fixture flows: select two models, confirm common target/count, queue batch, confirm success state

## Review
- pre-PR subagent peer review completed; all findings addressed and final pass reported no remaining actionable findings