### PR TITLE
fix(studio): restore reused duration notches

### DIFF
--- a/desktop/src/components/create/InspectorPanel.test.ts
+++ b/desktop/src/components/create/InspectorPanel.test.ts
@@ -83,6 +83,14 @@ describe("InspectorPanel — layout", () => {
     const wrapper = mount(InspectorPanel, { props: { form } });
     const duration = wrapper.getComponent(VideoDurationSlider);
     expect(duration.text()).toContain("4.0s");
+    expect(duration.findAll(".ms-slider__mark b").map((mark) => mark.text())).toEqual([
+      "1×",
+      "2×",
+      "3×",
+      "4×",
+      "5×",
+      "6×",
+    ]);
     expect(wrapper.find('[data-test="generate-audio-control"]').exists()).toBe(true);
     wrapper.getComponent(SwitchToggle).vm.$emit("update:modelValue", true);
     expect(form.enableAudio).toBe(true);

--- a/desktop/src/lib/generateForm.test.ts
+++ b/desktop/src/lib/generateForm.test.ts
@@ -1704,6 +1704,51 @@ function richImageMetadata(): OutputMetadata {
 }
 
 describe("applyMetadataToForm", () => {
+  it("keeps automatic-chain reuse eligible for the same generation count and notches", () => {
+    const form = newGenerateForm();
+    applyMetadataToForm(
+      form,
+      {
+        prompt: "a long tracking shot",
+        model: "ltx-2-19b-distilled:fp8",
+        seed: 42,
+        steps: 8,
+        guidance: 1,
+        width: 768,
+        height: 512,
+        frames: 177,
+        fps: 24,
+        pipeline: "distilled",
+        output_mode: "one-shot",
+        chain: { stages: [{ frames: 97 }, { frames: 97 }] },
+      } as OutputMetadata,
+      [{ ...ltx2Model(), name: "ltx-2-19b-distilled:fp8" }],
+    );
+
+    expect(form.frames).toBe(177);
+    expect(form.pipeline).toBeNull();
+    expect(buildRequest(form).pipeline).toBeUndefined();
+
+    applyMetadataToForm(
+      form,
+      {
+        prompt: "a legacy long tracking shot",
+        model: "ltx-2-19b-distilled:fp8",
+        seed: 43,
+        steps: 8,
+        guidance: 1,
+        width: 768,
+        height: 512,
+        frames: 177,
+        fps: 24,
+        pipeline: "distilled",
+        chain: { stages: [{ frames: 97 }, { frames: 97 }] },
+      } as OutputMetadata,
+      [{ ...ltx2Model(), name: "ltx-2-19b-distilled:fp8" }],
+    );
+    expect(form.pipeline).toBeNull();
+  });
+
   it("restores the full serialized parameter set for an installed model", () => {
     const form = newGenerateForm();
     applyMetadataToForm(form, richImageMetadata(), [sd15Model()]);

--- a/desktop/src/lib/generateForm.ts
+++ b/desktop/src/lib/generateForm.ts
@@ -31,6 +31,7 @@ import {
 } from "@studio/lib/sourceFit";
 import { defaultVideoFps } from "@studio/lib/sequence";
 import { videoFramesForModelSelection } from "@studio/lib/videoDuration";
+import { pipelineForSettingsReuse } from "@studio/lib/outputReuse";
 import { familySupportsExtend, resolveExtendOverlapFrames } from "@studio/lib/extend";
 import { findInstalledModel } from "./generateModels";
 import {
@@ -1029,7 +1030,7 @@ export function applyMetadataToForm(
   const fps = metadata.fps ?? metadata.video_fps;
   if (fps != null) form.fps = fps;
   if (metadata.enable_audio != null) form.enableAudio = metadata.enable_audio;
-  form.pipeline = metadata.pipeline ?? null;
+  form.pipeline = pipelineForSettingsReuse(metadata);
   form.icLoraControl = metadata.ic_lora_control ?? null;
   form.retakeRange = metadata.retake_range ?? null;
   form.spatialUpscale = metadata.spatial_upscale ?? null;

--- a/desktop/src/mobile/MobileSharedParams.test.ts
+++ b/desktop/src/mobile/MobileSharedParams.test.ts
@@ -62,6 +62,11 @@ describe("MobileSharedParams video duration", () => {
 
     const slider = wrapper.get("[data-test='mobile-duration'] input[type='range']");
     expect(wrapper.get("[data-test='mobile-duration']").text()).toContain("4.0s");
+    expect(
+      wrapper
+        .findAll("[data-test='mobile-duration'] .ms-slider__mark b")
+        .map((mark) => mark.text()),
+    ).toEqual(["1×", "2×", "3×", "4×", "5×", "6×"]);
     await slider.setValue("241");
     expect(form.frames).toBe(241);
   });

--- a/studio/lib/outputReuse.test.ts
+++ b/studio/lib/outputReuse.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { pipelineForSettingsReuse } from "./outputReuse";
+
+describe("pipelineForSettingsReuse", () => {
+  it("does not turn an automatic chain's runtime pipeline into an authored override", () => {
+    expect(
+      pipelineForSettingsReuse({
+        pipeline: "distilled",
+        output_mode: "one-shot",
+        chain: { stages: [{ frames: 97 }, { frames: 97 }] },
+      }),
+    ).toBeNull();
+    expect(
+      pipelineForSettingsReuse({
+        pipeline: "distilled",
+        chain: { stages: [{ frames: 97 }, { frames: 97 }] },
+      }),
+    ).toBeNull();
+  });
+
+  it("preserves explicit pipeline provenance for ordinary and authored sequence outputs", () => {
+    expect(
+      pipelineForSettingsReuse({
+        pipeline: "two-stage",
+        output_mode: "one-shot",
+      }),
+    ).toBe("two-stage");
+    expect(
+      pipelineForSettingsReuse({
+        pipeline: "distilled",
+        chain_job_id: "legacy-authored-sequence",
+        chain: { stages: [] },
+      }),
+    ).toBe("distilled");
+  });
+});

--- a/studio/lib/outputReuse.ts
+++ b/studio/lib/outputReuse.ts
@@ -1,0 +1,19 @@
+/**
+ * Runtime-resolved pipeline metadata is provenance, not always an authored
+ * override. An automatically chained One shot records the pipeline used by
+ * its stages, but restoring that value as an explicit selector disables the
+ * same chain route and collapses the duration control to "1 generation".
+ */
+export function pipelineForSettingsReuse<T>(metadata: {
+  pipeline?: T | null;
+  output_mode?: "one-shot" | "sequence" | null;
+  chain?: unknown | null;
+  chain_job_id?: string | null;
+}): T | null {
+  const automaticChain =
+    Boolean(metadata.chain) &&
+    (metadata.output_mode === "one-shot" ||
+      (metadata.output_mode !== "sequence" && !metadata.chain_job_id));
+  if (automaticChain) return null;
+  return metadata.pipeline ?? null;
+}

--- a/ui/components/SliderRow.test.ts
+++ b/ui/components/SliderRow.test.ts
@@ -47,4 +47,64 @@ describe("SliderRow", () => {
     expect(input.attributes("aria-label")).toBe("Detail");
     expect(input.attributes("aria-valuetext")).toBe("28 steps");
   });
+
+  it("renders every numbered mark in a dedicated row", () => {
+    const wrapper = make({
+      marks: [
+        { value: 14, label: "1x" },
+        { value: 28, label: "2x" },
+        { value: 42, label: "3x" },
+      ],
+    });
+
+    expect(wrapper.get(".ms-slider__track").classes()).toContain(
+      "ms-slider__track--marked",
+    );
+    expect(
+      wrapper.findAll(".ms-slider__mark b").map((mark) => mark.text()),
+    ).toEqual(["1x", "2x", "3x"]);
+    const marks = wrapper.get(".ms-slider__marks").element;
+    const input = wrapper.get("input[type=range]").element;
+    expect(
+      marks.compareDocumentPosition(input) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("snaps a pointer drag when mobile commits change before pointerup", async () => {
+    const wrapper = make({
+      modelValue: 30,
+      step: 2,
+      marks: [
+        { value: 20, label: "1x" },
+        { value: 40, label: "2x" },
+      ],
+      snapThresholdRatio: 0.1,
+    });
+    const input = wrapper.get("input[type=range]");
+
+    await input.trigger("pointerdown");
+    await input.setValue("38");
+    await input.trigger("change");
+    await input.trigger("pointerup");
+
+    expect(wrapper.emitted("update:modelValue")).toEqual([[38], [40]]);
+  });
+
+  it("does not magnetically snap keyboard changes", async () => {
+    const wrapper = make({
+      modelValue: 30,
+      step: 2,
+      marks: [
+        { value: 20, label: "1x" },
+        { value: 40, label: "2x" },
+      ],
+      snapThresholdRatio: 0.1,
+    });
+    const input = wrapper.get("input[type=range]");
+
+    await input.setValue("38");
+    await input.trigger("change");
+
+    expect(wrapper.emitted("update:modelValue")).toEqual([[38]]);
+  });
 });

--- a/ui/components/SliderRow.vue
+++ b/ui/components/SliderRow.vue
@@ -79,13 +79,24 @@ function onPointerDown() {
 }
 
 function onPointerUp(event: PointerEvent) {
+  finishPointerDrag(Number((event.target as HTMLInputElement).value));
+}
+
+function finishPointerDrag(fallbackValue: number) {
   if (!pointerDragging.value) return;
   pointerDragging.value = false;
-  const value =
-    pointerValue.value ?? Number((event.target as HTMLInputElement).value);
+  const value = pointerValue.value ?? fallbackValue;
   pointerValue.value = null;
   const snapped = snappedValue(value);
   if (snapped !== value) emit("update:modelValue", snapped);
+}
+
+// Mobile range controls can commit with `change` before WebKit delivers the
+// final pointerup to the input. Finish the same drag here so touch snapping is
+// not dependent on that browser-specific event order. Keyboard changes do not
+// set pointerDragging and therefore retain exact frame-grid movement.
+function onChange(event: Event) {
+  finishPointerDrag(Number((event.target as HTMLInputElement).value));
 }
 
 function onPointerCancel() {
@@ -104,29 +115,6 @@ function onPointerCancel() {
       class="ms-slider__track"
       :class="{ 'ms-slider__track--marked': positionedMarks.length > 1 }"
     >
-      <input
-        class="ms-slider__input"
-        type="range"
-        :min="min"
-        :max="max"
-        :step="step"
-        :value="modelValue"
-        :list="positionedMarks.length > 1 ? datalistId : undefined"
-        :aria-label="label"
-        :aria-valuetext="ariaValueText ?? readout"
-        :disabled="disabled"
-        @pointerdown="onPointerDown"
-        @pointerup="onPointerUp"
-        @pointercancel="onPointerCancel"
-        @input="onInput"
-      />
-      <datalist v-if="positionedMarks.length > 1" :id="datalistId">
-        <option
-          v-for="mark in positionedMarks"
-          :key="mark.value"
-          :value="mark.value"
-        />
-      </datalist>
       <div
         v-if="positionedMarks.length > 1"
         class="ms-slider__marks"
@@ -143,6 +131,30 @@ function onPointerCancel() {
           <b>{{ mark.label }}</b>
         </span>
       </div>
+      <input
+        class="ms-slider__input"
+        type="range"
+        :min="min"
+        :max="max"
+        :step="step"
+        :value="modelValue"
+        :list="positionedMarks.length > 1 ? datalistId : undefined"
+        :aria-label="label"
+        :aria-valuetext="ariaValueText ?? readout"
+        :disabled="disabled"
+        @pointerdown="onPointerDown"
+        @pointerup="onPointerUp"
+        @pointercancel="onPointerCancel"
+        @input="onInput"
+        @change="onChange"
+      />
+      <datalist v-if="positionedMarks.length > 1" :id="datalistId">
+        <option
+          v-for="mark in positionedMarks"
+          :key="mark.value"
+          :value="mark.value"
+        />
+      </datalist>
     </div>
   </div>
 </template>
@@ -176,6 +188,10 @@ function onPointerCancel() {
   height: 4px;
   border-radius: var(--radius-pill);
   background: var(--ce);
+}
+
+.ms-slider__track--marked .ms-slider__input {
+  grid-row: 2;
 }
 
 .ms-slider__input::-webkit-slider-thumb {
@@ -215,12 +231,14 @@ function onPointerCancel() {
 }
 
 .ms-slider__track--marked {
-  padding-top: 20px;
+  display: grid;
+  grid-template-rows: 20px auto;
 }
 
 .ms-slider__marks {
-  position: absolute;
-  inset: 0 8px auto;
+  grid-row: 1;
+  position: relative;
+  margin: 0 8px;
   height: 20px;
   pointer-events: none;
 }

--- a/ui/components/VideoDurationSlider.vue
+++ b/ui/components/VideoDurationSlider.vue
@@ -133,8 +133,4 @@ function update(frames: number): void {
     transparent 24px
   );
 }
-
-.video-duration--touch :deep(.ms-slider__track--marked) {
-  padding-top: 0;
-}
 </style>

--- a/web/src/components/create/ControlsAside.test.ts
+++ b/web/src/components/create/ControlsAside.test.ts
@@ -267,6 +267,9 @@ describe("ControlsAside", () => {
     });
     const duration = wrapper.getComponent(VideoDurationSlider);
     expect(duration.text()).toContain("4.0s");
+    expect(
+      duration.findAll(".ms-slider__mark b").map((mark) => mark.text()),
+    ).toEqual(["1×", "2×", "3×", "4×", "5×", "6×"]);
     duration.vm.$emit("update:frames", 241);
     await wrapper.vm.$nextTick();
     expect(wrapper.emitted("update:modelValue")?.at(-1)?.[0]).toMatchObject({

--- a/web/src/composables/useGenerateForm.test.ts
+++ b/web/src/composables/useGenerateForm.test.ts
@@ -569,6 +569,43 @@ describe("useGenerateForm", () => {
       expect(optedOut.negativePrompt).toBe("");
     });
 
+    it("does not restore an automatic chain's runtime pipeline as an authored override", () => {
+      const base = JSON.parse(
+        JSON.stringify(useGenerateForm().state.value),
+      ) as GenerateFormState;
+      const restored = applyMetadataToForm(
+        base,
+        {
+          prompt: "a long tracking shot",
+          model: "ltx-2-19b-distilled:fp8",
+          seed: 7,
+          steps: 8,
+          guidance: 1,
+          width: 768,
+          height: 512,
+          frames: 177,
+          fps: 24,
+          pipeline: "distilled",
+          output_mode: "one-shot",
+          chain: { stages: [{ frames: 97 }, { frames: 97 }] },
+        } as OutputMetadata,
+        {
+          models: [
+            makeModel({
+              name: "ltx-2-19b-distilled:fp8",
+              family: "ltx2",
+              default_frames: 97,
+              default_fps: 24,
+              frame_step: 8,
+            }),
+          ],
+        },
+      );
+
+      expect(restored.frames).toBe(177);
+      expect(restored.pipeline).toBeNull();
+    });
+
     it("an explicit clear restored before rows load survives the wan row arriving", () => {
       // Reuse settings with the inventory not yet resolved: the model row is
       // unknown, the default restores as "", and the saved `""` opt-out is

--- a/web/src/composables/useGenerateForm.ts
+++ b/web/src/composables/useGenerateForm.ts
@@ -37,6 +37,7 @@ import {
 } from "@studio/lib/negativePrompt";
 import { defaultVideoFps } from "@studio/lib/sequence";
 import { videoFramesForModelSelection } from "@studio/lib/videoDuration";
+import { pipelineForSettingsReuse } from "@studio/lib/outputReuse";
 import {
   familySupportsExtend,
   resolveExtendOverlapFrames,
@@ -635,7 +636,7 @@ export function applyMetadataToForm(
     sourceVideoPath: metadata.source_video_path ?? "",
     extendVideoPath: metadata.extend_video_path ?? "",
     extendOverlapFrames: metadata.extend_overlap_frames ?? null,
-    pipeline: metadata.pipeline ?? null,
+    pipeline: pipelineForSettingsReuse(metadata),
     icLoraControl: metadata.ic_lora_control ?? null,
     retakeRange: metadata.retake_range ?? null,
     spatialUpscale: metadata.spatial_upscale ?? null,


### PR DESCRIPTION
## Summary

- keep automatic-chain runtime pipeline provenance from becoming an explicit Reuse settings override on web, desktop, and iPhone
- restore visible numbered generation notches above desktop and touch duration tracks
- make mobile range commits snap reliably when WebKit sends change before pointerup
- cover current and legacy automatic-chain metadata, surface rendering, mark placement, generation counts, and pointer/keyboard behavior

## UAT

- built and launched the shared mobile app on an iPhone 17 Pro simulator (iOS 26.5) against Plato2
- opened Library, reused an LTX-2.3 distilled video, and confirmed 1× through 6× duration notches
- confirmed 257 frames / 10.7s reports 3 generations
- selected the 2× boundary and confirmed 177 frames / 7.4s reports 2 generations
- dragged near the boundary and confirmed release snaps back to 177 frames

## Verification

- `nix develop -c bun run check:frontend`
  - studio: 752 tests
  - web: 1,379 tests
  - desktop/shared mobile: 3,719 tests
  - web and desktop production builds
- focused post-review suites: shared helper 2, desktop/shared iOS 208, web 161
- Prettier check and `git diff --check`
- independent agent peer review, with both findings addressed and clean re-review