### PR TITLE
fix(gallery): repair native sharing and remote media

### DIFF
--- a/desktop/src/components/gallery/AuthedMedia.test.ts
+++ b/desktop/src/components/gallery/AuthedMedia.test.ts
@@ -1,20 +1,50 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { flushPromises, mount } from "@vue/test-utils";
 import AuthedMedia from "./AuthedMedia.vue";
-import { authedMediaUrl } from "../../lib/gallery/media";
+import { authedMediaUrl, streamableMediaUrl } from "../../lib/gallery/media";
 
 vi.mock("../../lib/gallery/media", () => ({
   authedMediaUrl: vi.fn().mockResolvedValue("blob:video"),
+  streamableMediaUrl: vi.fn().mockResolvedValue("http://remote/media?ticket=one-use"),
 }));
 
 beforeEach(() => {
   vi.clearAllMocks();
   vi.mocked(authedMediaUrl).mockResolvedValue("blob:video");
+  vi.mocked(streamableMediaUrl).mockResolvedValue("http://remote/media?ticket=one-use");
 });
 
 afterEach(() => vi.useRealTimers());
 
 describe("AuthedMedia", () => {
+  it.each([
+    { video: false, filename: "remote.png", allowLegacyBlob: true, element: "img" },
+    { video: true, filename: "remote.mp4", allowLegacyBlob: false, element: "video" },
+  ])(
+    "opens a remote-only $filename through a streamable media ticket",
+    async ({ video, filename, allowLegacyBlob, element }) => {
+      const target = { baseUrl: "http://plato:7680", apiKey: "secret" };
+      const wrapper = mount(AuthedMedia, {
+        props: {
+          path: `/api/gallery/image/${filename}`,
+          target,
+          cacheKey: "plato-7680",
+          video,
+          controls: video,
+        },
+      });
+      await vi.waitFor(() => expect(wrapper.find(element).exists()).toBe(true));
+
+      expect(streamableMediaUrl).toHaveBeenCalledWith(`/api/gallery/image/${filename}`, {
+        target,
+        cacheKey: "plato-7680",
+        allowLegacyBlob,
+      });
+      expect(authedMediaUrl).not.toHaveBeenCalled();
+      expect(wrapper.get(element).attributes("src")).toBe("http://remote/media?ticket=one-use");
+    },
+  );
+
   it("disables Picture-in-Picture for desktop video playback", async () => {
     const wrapper = mount(AuthedMedia, {
       props: { path: "/api/gallery/video/demo.mp4", video: true, controls: true },
@@ -45,14 +75,14 @@ describe("AuthedMedia", () => {
 
   it("does not retry an unbounded full-media fetch", async () => {
     vi.useFakeTimers();
-    vi.mocked(authedMediaUrl).mockRejectedValue(new Error("video transfer failed"));
+    vi.mocked(streamableMediaUrl).mockRejectedValue(new Error("video transfer failed"));
     const wrapper = mount(AuthedMedia, {
       props: { path: "/api/gallery/image/large-video.mp4", video: true },
     });
     await flushPromises();
     await vi.advanceTimersByTimeAsync(2_000);
 
-    expect(authedMediaUrl).toHaveBeenCalledTimes(1);
+    expect(streamableMediaUrl).toHaveBeenCalledTimes(1);
     expect(wrapper.text()).toContain("UNREADABLE");
   });
 

--- a/desktop/src/components/gallery/AuthedMedia.vue
+++ b/desktop/src/components/gallery/AuthedMedia.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { onMounted, onUnmounted, ref, watch } from "vue";
-import { authedMediaUrl } from "../../lib/gallery/media";
+import { authedMediaUrl, streamableMediaUrl } from "../../lib/gallery/media";
 import type { ApiTarget } from "../../lib/api/client";
 
 const props = withDefaults(
@@ -34,10 +34,20 @@ async function load() {
     if (delayMs > 0) await new Promise((resolve) => setTimeout(resolve, delayMs));
     if (epoch !== loadEpoch) return;
     try {
-      const url = await authedMediaUrl(props.path, {
+      const options = {
         ...(props.target ? { target: props.target } : {}),
         ...(props.cacheKey ? { cacheKey: props.cacheKey } : {}),
-      });
+      };
+      // Full-size remote media must stay streamable. Fetching it into a blob
+      // blocks the viewer until the entire file crosses WebKit and prevents
+      // video seeking; authenticated hosts instead mint a short-lived,
+      // exact-path ticket that the media element can load directly.
+      const url = props.path.startsWith("/api/gallery/thumbnail/")
+        ? await authedMediaUrl(props.path, options)
+        : await streamableMediaUrl(props.path, {
+            ...options,
+            allowLegacyBlob: !props.video && !props.audio,
+          });
       if (epoch === loadEpoch) src.value = url;
       return;
     } catch {

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -31,6 +31,7 @@ const {
   getCurrentDeepLinks,
   onOpenDeepLinks,
   unlistenDeepLinks,
+  isNativeIOSRuntime,
 } = vi.hoisted(() => ({
   invoke: vi.fn(),
   apiFetchTo: vi.fn(),
@@ -55,6 +56,7 @@ const {
   getCurrentDeepLinks: vi.fn(),
   onOpenDeepLinks: vi.fn(),
   unlistenDeepLinks: vi.fn(),
+  isNativeIOSRuntime: vi.fn(),
 }));
 
 vi.mock("@tauri-apps/api/core", () => ({ invoke }));
@@ -105,6 +107,7 @@ vi.mock("@studio/lib/generationSourceMedia", () => ({
   persistGenerationSourceMedia,
   restoreGenerationSourceMedia,
 }));
+vi.mock("./platform", () => ({ isNativeIOSRuntime }));
 
 function plannedPlacement() {
   return {
@@ -362,6 +365,7 @@ beforeEach(() => {
   getCurrentDeepLinks.mockReset().mockResolvedValue(null);
   unlistenDeepLinks.mockReset();
   onOpenDeepLinks.mockReset().mockResolvedValue(unlistenDeepLinks);
+  isNativeIOSRuntime.mockReset().mockReturnValue(false);
   objectUrlSequence = 0;
   URL.createObjectURL = vi.fn(() => `blob:thumbnail-${++objectUrlSequence}`);
   URL.revokeObjectURL = vi.fn();
@@ -376,6 +380,7 @@ afterEach(() => {
   delete (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
   delete (globalThis as Partial<typeof globalThis>).IntersectionObserver;
   Reflect.deleteProperty(globalThis, "indexedDB");
+  Reflect.deleteProperty(document, "elementsFromPoint");
 });
 
 describe("MobileApp sequence generation", () => {
@@ -5848,6 +5853,117 @@ describe("MobileApp gallery", () => {
     expect(wrapper.get("[data-test='mobile-gallery-actions']").text()).toContain("1 selected");
     expect(wrapper.get("[data-test='gallery-item']").attributes("aria-pressed")).toBe("true");
     expect(wrapper.get("[data-test='mobile-gallery-selection-indicator']").text()).toBe("✓");
+  });
+
+  it("backs the native iOS image context menu with image data instead of a blob URL", async () => {
+    isNativeIOSRuntime.mockReturnValue(true);
+    apiFetchTo.mockResolvedValue({
+      blob: () => Promise.resolve(new Blob([Uint8Array.from([1, 2, 3])], { type: "image/png" })),
+    } as Response);
+
+    wrapper = mountMobileApp();
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-tab-gallery']").trigger("click");
+    await vi.waitFor(() => expect(wrapper?.find("[data-test='gallery-item']").exists()).toBe(true));
+
+    const image = wrapper.get("[data-test='gallery-item'] img");
+    expect(image.attributes("src")).toBe("data:image/png;base64,AQID");
+    expect(URL.createObjectURL).not.toHaveBeenCalled();
+
+    const contextMenu = new Event("contextmenu", { bubbles: true, cancelable: true });
+    image.element.dispatchEvent(contextMenu);
+    expect(contextMenu.defaultPrevented).toBe(false);
+  });
+
+  it("drag-selects and drag-deselects every Library tile crossed in Select mode", async () => {
+    const prints = [
+      print,
+      { ...print, filename: "second.png", timestamp: print.timestamp - 1 },
+      { ...print, filename: "third.png", timestamp: print.timestamp - 2 },
+    ];
+    apiJsonTo.mockImplementation((_target: unknown, path: string) => {
+      if (path === "/api/status") return Promise.resolve(status);
+      if (path === "/api/models") return Promise.resolve([model]);
+      if (path === "/api/gallery") return Promise.resolve(prints);
+      return Promise.reject(new Error(`Unexpected API path: ${path}`));
+    });
+
+    wrapper = mountMobileApp();
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-tab-gallery']").trigger("click");
+    await vi.waitFor(() => expect(wrapper?.findAll("[data-test='gallery-item']")).toHaveLength(3));
+    await wrapper.get("[data-test='mobile-gallery-select']").trigger("click");
+    const tiles = wrapper.findAll("[data-test='gallery-item']");
+    const toolbar = wrapper.get("[data-test='mobile-gallery-actions']").element;
+    Object.defineProperty(document, "elementsFromPoint", {
+      configurable: true,
+      value: vi.fn((x: number) => [
+        toolbar,
+        (x < 150 ? tiles[0] : x < 250 ? tiles[1] : tiles[2])!.element,
+      ]),
+    });
+
+    await tiles[0]!.trigger("pointerdown", {
+      pointerId: 41,
+      pointerType: "touch",
+      isPrimary: true,
+      clientX: 20,
+      clientY: 240,
+    });
+    window.dispatchEvent(
+      new PointerEvent("pointermove", {
+        pointerId: 41,
+        pointerType: "touch",
+        isPrimary: true,
+        // One fast event crosses both remaining columns. The sticky toolbar
+        // is deliberately first in the hit stack to cover edge auto-scroll.
+        clientX: 320,
+        clientY: 240,
+      }),
+    );
+    window.dispatchEvent(
+      new PointerEvent("pointerup", {
+        pointerId: 41,
+        pointerType: "touch",
+        isPrimary: true,
+      }),
+    );
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.get("[data-test='mobile-gallery-actions']").text()).toContain("3 selected");
+    expect(tiles.map((tile) => tile.attributes("aria-pressed"))).toEqual(["true", "true", "true"]);
+
+    await tiles[0]!.trigger("pointerdown", {
+      pointerId: 42,
+      pointerType: "touch",
+      isPrimary: true,
+      clientX: 20,
+      clientY: 240,
+    });
+    window.dispatchEvent(
+      new PointerEvent("pointermove", {
+        pointerId: 42,
+        pointerType: "touch",
+        isPrimary: true,
+        clientX: 200,
+        clientY: 240,
+      }),
+    );
+    window.dispatchEvent(
+      new PointerEvent("pointerup", {
+        pointerId: 42,
+        pointerType: "touch",
+        isPrimary: true,
+      }),
+    );
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.get("[data-test='mobile-gallery-actions']").text()).toContain("1 selected");
+    expect(tiles.map((tile) => tile.attributes("aria-pressed"))).toEqual([
+      "false",
+      "false",
+      "true",
+    ]);
   });
 
   it("deletes one selected print from every host that contains a copy", async () => {

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -258,6 +258,7 @@ import {
   type MobileSettings,
 } from "./settings";
 import { useMobileDownloadsStore } from "./mobileDownloads";
+import { isNativeIOSRuntime } from "./platform";
 import {
   createMobileExpansionRecovery,
   mobileExpansionRecoveryStaleReason,
@@ -610,6 +611,15 @@ let galleryLoadMoreQueued = false;
 let gallerySentinelObserver: IntersectionObserver | null = null;
 let galleryChainedFetches = 0;
 const MAX_GALLERY_CHAINED_FETCHES = 3;
+let galleryDragPointerId: number | null = null;
+let galleryDragSelect = true;
+let galleryDragClientX = 0;
+let galleryDragClientY = 0;
+let galleryDragFrame: number | null = null;
+let galleryDragSuppressClick = false;
+const galleryDragVisited = new Set<string>();
+const GALLERY_DRAG_SCROLL_EDGE = 72;
+const GALLERY_DRAG_SCROLL_MAX = 18;
 let resultMediaRecoveryClientId: number | null = null;
 let resultMediaRecoveryAttempts = 0;
 let hostProbeTimer: ReturnType<typeof setInterval> | null = null;
@@ -3535,6 +3545,7 @@ async function retryExpansionAfterPull(): Promise<void> {
 }
 
 function revokeObjectUrl(url: string): void {
+  if (!url.startsWith("blob:")) return;
   URL.revokeObjectURL(url);
   objectUrls.delete(url);
 }
@@ -4210,6 +4221,15 @@ async function thumbnailUrl(target: ApiTarget, hostId: string, filename: string)
     blob = await response.blob();
     void storeCachedGalleryMedia(hostId, filename, "thumbnail", blob);
   }
+  // WKWebView's native image context menu forwards an object URL as text to
+  // Share extensions. Give iOS an inline image resource so Share, Copy, and
+  // Save to Photos receive image data rather than a process-local `blob:` URL.
+  // Thumbnails are bounded to 256 px by the server, so the base64 expansion
+  // stays small; browser development keeps cheaper revocable object URLs.
+  if (isNativeIOSRuntime()) {
+    const mimeType = blob.type.startsWith("image/") ? blob.type : "image/png";
+    return `data:${mimeType};base64,${await blobToBase64(blob)}`;
+  }
   const url = URL.createObjectURL(blob);
   objectUrls.add(url);
   return url;
@@ -4715,6 +4735,7 @@ function allGalleryPrints(): Array<GalleryPrint | PendingGalleryPrint> {
 }
 
 function setGallerySelectMode(next: boolean): void {
+  if (!next) finishGallerySelectionDrag();
   gallerySelectMode.value = next;
   galleryDeleteConfirming.value = false;
   if (!next) gallerySelection.value = new Set();
@@ -4738,12 +4759,122 @@ function toggleGallerySelection(print: GalleryPrint): void {
   galleryDeleteConfirming.value = false;
 }
 
+function applyGalleryDragSelection(print: GalleryPrint): void {
+  const key = galleryPrintKey(print);
+  if (galleryDragVisited.has(key)) return;
+  galleryDragVisited.add(key);
+  const next = new Set(gallerySelection.value);
+  if (galleryDragSelect) next.add(key);
+  else next.delete(key);
+  gallerySelection.value = next;
+  galleryDeleteConfirming.value = false;
+}
+
+function galleryPrintAtPoint(x: number, y: number): GalleryPrint | null {
+  // Keep tiles discoverable beneath the sticky selection toolbar while edge
+  // auto-scroll moves the grid behind it.
+  const elements = document.elementsFromPoint?.(x, y) ?? [document.elementFromPoint(x, y)];
+  const tile = elements
+    .map((element) => element?.closest<HTMLElement>("[data-gallery-print-key]") ?? null)
+    .find((element) => element !== null);
+  const key = tile?.dataset.galleryPrintKey;
+  return key ? (gallery.value.find((print) => galleryPrintKey(print) === key) ?? null) : null;
+}
+
+function applyGalleryDragAtPoint(): void {
+  const print = galleryPrintAtPoint(galleryDragClientX, galleryDragClientY);
+  if (print) applyGalleryDragSelection(print);
+}
+
+function applyGalleryDragSegment(fromX: number, fromY: number, toX: number, toY: number): void {
+  const distance = Math.hypot(toX - fromX, toY - fromY);
+  // This stride is well below the 44pt minimum tile target. Sampling the
+  // whole segment prevents a fast native swipe from jumping over a column.
+  const steps = Math.max(1, Math.ceil(distance / 12));
+  for (let step = 1; step <= steps; step += 1) {
+    const progress = step / steps;
+    const print = galleryPrintAtPoint(
+      fromX + (toX - fromX) * progress,
+      fromY + (toY - fromY) * progress,
+    );
+    if (print) applyGalleryDragSelection(print);
+  }
+}
+
+function runGalleryDragFrame(): void {
+  galleryDragFrame = null;
+  if (galleryDragPointerId === null || !gallerySelectMode.value) return;
+  const scroller = mobileContent.value;
+  if (scroller) {
+    const bounds = scroller.getBoundingClientRect();
+    const topDepth = Math.max(0, bounds.top + GALLERY_DRAG_SCROLL_EDGE - galleryDragClientY);
+    const bottomDepth = Math.max(
+      0,
+      galleryDragClientY - (bounds.bottom - GALLERY_DRAG_SCROLL_EDGE),
+    );
+    const direction = bottomDepth > 0 ? 1 : topDepth > 0 ? -1 : 0;
+    const depth = Math.max(topDepth, bottomDepth);
+    if (direction && depth) {
+      const speed = Math.min(
+        GALLERY_DRAG_SCROLL_MAX,
+        Math.max(2, (depth / GALLERY_DRAG_SCROLL_EDGE) * GALLERY_DRAG_SCROLL_MAX),
+      );
+      scroller.scrollTop += direction * speed;
+      applyGalleryDragAtPoint();
+    }
+  }
+  galleryDragFrame = requestAnimationFrame(runGalleryDragFrame);
+}
+
+function beginGallerySelectionDrag(event: PointerEvent, print: GalleryPrint): void {
+  if (
+    !gallerySelectMode.value ||
+    event.isPrimary === false ||
+    (event.pointerType === "mouse" && event.button !== 0)
+  ) {
+    return;
+  }
+  event.preventDefault();
+  galleryDragPointerId = event.pointerId;
+  galleryDragSelect = !gallerySelection.value.has(galleryPrintKey(print));
+  galleryDragClientX = event.clientX;
+  galleryDragClientY = event.clientY;
+  galleryDragVisited.clear();
+  galleryDragSuppressClick = true;
+  applyGalleryDragSelection(print);
+  (event.currentTarget as HTMLElement | null)?.setPointerCapture?.(event.pointerId);
+  if (galleryDragFrame === null) galleryDragFrame = requestAnimationFrame(runGalleryDragFrame);
+}
+
+function moveGallerySelectionDrag(event: PointerEvent): void {
+  if (event.pointerId !== galleryDragPointerId) return;
+  event.preventDefault();
+  const points = [...(event.getCoalescedEvents?.() ?? []), event];
+  for (const point of points) {
+    applyGalleryDragSegment(galleryDragClientX, galleryDragClientY, point.clientX, point.clientY);
+    galleryDragClientX = point.clientX;
+    galleryDragClientY = point.clientY;
+  }
+}
+
+function finishGallerySelectionDrag(event?: PointerEvent): void {
+  if (event && event.pointerId !== galleryDragPointerId) return;
+  galleryDragPointerId = null;
+  galleryDragVisited.clear();
+  if (galleryDragFrame !== null) cancelAnimationFrame(galleryDragFrame);
+  galleryDragFrame = null;
+  setTimeout(() => {
+    galleryDragSuppressClick = false;
+  }, 0);
+}
+
 function selectAllGalleryPrints(): void {
   gallerySelection.value = new Set(gallery.value.map(galleryPrintKey));
   galleryDeleteConfirming.value = false;
 }
 
-function handleGalleryTileClick(print: GalleryPrint): void {
+function handleGalleryTileClick(event: MouseEvent, print: GalleryPrint): void {
+  if (gallerySelectMode.value && galleryDragSuppressClick && event.detail !== 0) return;
   if (gallerySelectMode.value) toggleGallerySelection(print);
   else openPrint(print);
 }
@@ -5112,6 +5243,9 @@ onMounted(async () => {
   document.addEventListener("focusin", handleKeyboardFocusIn, true);
   document.addEventListener("focusout", handleKeyboardFocusOut, true);
   window.addEventListener("scroll", syncVisualViewportOffset, true);
+  window.addEventListener("pointermove", moveGallerySelectionDrag, { passive: false });
+  window.addEventListener("pointerup", finishGallerySelectionDrag);
+  window.addEventListener("pointercancel", finishGallerySelectionDrag);
   window.visualViewport?.addEventListener("resize", syncVisualViewportOffset);
   window.visualViewport?.addEventListener("scroll", syncVisualViewportOffset);
   syncVisualViewportOffset();
@@ -5170,6 +5304,10 @@ onBeforeUnmount(() => {
   document.removeEventListener("focusin", handleKeyboardFocusIn, true);
   document.removeEventListener("focusout", handleKeyboardFocusOut, true);
   window.removeEventListener("scroll", syncVisualViewportOffset, true);
+  window.removeEventListener("pointermove", moveGallerySelectionDrag);
+  window.removeEventListener("pointerup", finishGallerySelectionDrag);
+  window.removeEventListener("pointercancel", finishGallerySelectionDrag);
+  finishGallerySelectionDrag();
   window.visualViewport?.removeEventListener("resize", syncVisualViewportOffset);
   window.visualViewport?.removeEventListener("scroll", syncVisualViewportOffset);
   document.documentElement.style.removeProperty("--mobile-visual-viewport-page-top");
@@ -6015,7 +6153,11 @@ onBeforeUnmount(() => {
         </div>
         <p v-if="galleryError" class="status-line error-text">{{ galleryError }}</p>
         <div v-if="galleryLoading" class="empty-state">Loading prints…</div>
-        <div v-else-if="gallery.length" class="gallery-grid">
+        <div
+          v-else-if="gallery.length"
+          class="gallery-grid"
+          :class="{ 'is-selecting': gallerySelectMode }"
+        >
           <button
             v-for="print in gallery"
             :key="`${print.hostId}:${print.filename}`"
@@ -6030,8 +6172,10 @@ onBeforeUnmount(() => {
             :aria-pressed="
               gallerySelectMode ? gallerySelection.has(galleryPrintKey(print)) : undefined
             "
+            :data-gallery-print-key="galleryPrintKey(print)"
             data-test="gallery-item"
-            @click="handleGalleryTileClick(print)"
+            @pointerdown="beginGallerySelectionDrag($event, print)"
+            @click="handleGalleryTileClick($event, print)"
           >
             <img
               :src="print.thumbnailUrl"

--- a/desktop/src/mobile/mobile.css
+++ b/desktop/src/mobile/mobile.css
@@ -2523,6 +2523,13 @@ button:disabled {
   gap: 6px;
 }
 
+.gallery-grid.is-selecting .gallery-item {
+  touch-action: none;
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
+}
+
 .mobile-library-heading {
   display: flex;
   align-items: flex-start;


### PR DESCRIPTION
## Summary

- give native iOS image context menus inline image data so Share sends the image instead of a process-local `blob:` URL
- add native-style drag select/deselect with fast-swipe interpolation and edge auto-scroll in iPhone Library Select mode
- route desktop remote-only full-size images, video, and audio through short-lived gallery media tickets instead of buffering full files into blob URLs
- retain the web viewer’s existing host-specific media-ticket behavior and cover it with its gallery regression suites

## Verification

- `nix develop -c desktop-check`
- desktop production build
- iPhone production build
- 248 focused desktop/mobile gallery tests
- 68 focused web gallery tests
- `nix develop -c ios-check`
- repo-native iPhone simulator build and launch
- independent agent review: no findings

## Notes

- Simulator build/launch was verified, but the physical long-press Share sheet and touch drag gesture were not exercised on a hardware iPhone in this run.