### PR TITLE
fix(desktop): cancel shared jobs from sidebar

### DIFF
--- a/desktop/src/components/shell/NavRail.test.ts
+++ b/desktop/src/components/shell/NavRail.test.ts
@@ -12,6 +12,8 @@ import { useChainJobsStore } from "../../stores/chainJobs";
 import { useHostModelsStore } from "../../stores/hostModels";
 import { useLiveActivityStore } from "../../stores/liveActivity";
 import { useComposerStore } from "../../stores/composer";
+import { useContextMenuStore } from "../../stores/contextMenu";
+import { useJobsStore } from "../../stores/jobs";
 
 const stub = { template: "<div />" };
 const authedMediaStub = {
@@ -107,6 +109,149 @@ describe("NavRail collapse", () => {
 });
 
 describe("NavRail developing jobs", () => {
+  function setLocalAuthority(baseUrl = "http://127.0.0.1:49152", instanceId = "local-instance") {
+    const connection = useConnectionStore();
+    connection.info = { mode: "local", baseUrl, apiKey: "secret" };
+    connection.status = "ready";
+    useHostsStore().telemetry.local = {
+      queueDepth: 1,
+      queueCapacity: 1,
+      version: null,
+      instanceId,
+    };
+  }
+
+  it("cancels another client's running job from its context menu", async () => {
+    const wrapper = await mountAt("/create");
+    setLocalAuthority();
+    const liveActivity = useLiveActivityStore();
+    vi.spyOn(liveActivity, "refresh").mockResolvedValue(undefined);
+    const cancel = vi.spyOn(useJobsStore(), "cancelJob").mockResolvedValue(undefined);
+    liveActivity.hosts = {
+      local: {
+        hostId: "local",
+        hostLabel: "This Mac",
+        target: { baseUrl: "http://127.0.0.1:49152", apiKey: "secret" },
+        routeUrl: "http://127.0.0.1:49152",
+        instanceId: "local-instance",
+        observedAtUnixMs: 2,
+        stale: false,
+        error: null,
+        unavailableKinds: [],
+        items: [
+          {
+            id: "foreign-running",
+            kind: "generation",
+            phase: "running",
+            model: "ltx-2.3-22b-distilled:fp8",
+            created_at_unix_ms: 1,
+            updated_at_unix_ms: 2,
+            can_cancel: true,
+          },
+        ],
+      },
+    };
+    await flushPromises();
+
+    await wrapper.get("[data-test^='live-activity-select-']").trigger("contextmenu");
+    const menu = useContextMenuStore();
+    expect(menu.visible).toBe(true);
+    expect(menu.entries).toMatchObject([{ label: "Cancel", danger: true, disabled: false }]);
+
+    menu.activate(menu.entries[0]!);
+    await flushPromises();
+    expect(cancel).toHaveBeenCalledWith("local", "foreign-running");
+  });
+
+  it("does not send duplicate cancellation requests while one is in flight", async () => {
+    const wrapper = await mountAt("/create");
+    setLocalAuthority();
+    const liveActivity = useLiveActivityStore();
+    vi.spyOn(liveActivity, "refresh").mockResolvedValue(undefined);
+    liveActivity.hosts = {
+      local: {
+        hostId: "local",
+        hostLabel: "This Mac",
+        target: { baseUrl: "http://127.0.0.1:49152", apiKey: "secret" },
+        routeUrl: "http://127.0.0.1:49152",
+        instanceId: "local-instance",
+        observedAtUnixMs: 2,
+        stale: false,
+        error: null,
+        unavailableKinds: [],
+        items: [
+          {
+            id: "foreign-running",
+            kind: "generation",
+            phase: "running",
+            model: "flux-dev",
+            created_at_unix_ms: 1,
+            updated_at_unix_ms: 2,
+            can_cancel: true,
+          },
+        ],
+      },
+    };
+    let finishCancel!: () => void;
+    const cancel = vi
+      .spyOn(useJobsStore(), "cancelJob")
+      .mockImplementation(() => new Promise<void>((resolve) => (finishCancel = resolve)));
+    await flushPromises();
+
+    const row = wrapper.get("[data-test^='live-activity-select-']");
+    await row.trigger("contextmenu");
+    const menu = useContextMenuStore();
+    menu.activate(menu.entries[0]!);
+    await row.trigger("contextmenu");
+    expect(menu.entries).toMatchObject([{ label: "Cancel", disabled: true }]);
+    menu.activate(menu.entries[0]!);
+    expect(cancel).toHaveBeenCalledTimes(1);
+
+    finishCancel();
+    await flushPromises();
+  });
+
+  it("refuses cancellation if the host authority changed after the menu opened", async () => {
+    const wrapper = await mountAt("/create");
+    setLocalAuthority();
+    const liveActivity = useLiveActivityStore();
+    vi.spyOn(liveActivity, "refresh").mockResolvedValue(undefined);
+    liveActivity.hosts = {
+      local: {
+        hostId: "local",
+        hostLabel: "This Mac",
+        target: { baseUrl: "http://127.0.0.1:49152", apiKey: "secret" },
+        routeUrl: "http://127.0.0.1:49152",
+        instanceId: "local-instance",
+        observedAtUnixMs: 2,
+        stale: false,
+        error: null,
+        unavailableKinds: [],
+        items: [
+          {
+            id: "foreign-running",
+            kind: "generation",
+            phase: "running",
+            model: "flux-dev",
+            created_at_unix_ms: 1,
+            updated_at_unix_ms: 2,
+            can_cancel: true,
+          },
+        ],
+      },
+    };
+    const cancel = vi.spyOn(useJobsStore(), "cancelJob").mockResolvedValue(undefined);
+    await flushPromises();
+
+    await wrapper.get("[data-test^='live-activity-select-']").trigger("contextmenu");
+    useHostsStore().telemetry.local!.instanceId = "replacement-instance";
+    const menu = useContextMenuStore();
+    menu.activate(menu.entries[0]!);
+    await flushPromises();
+
+    expect(cancel).not.toHaveBeenCalled();
+  });
+
   it("shows recovered work and reloads its submitted settings", async () => {
     const wrapper = await mountAt("/create");
     useHostsStore().extras.push({

--- a/desktop/src/components/shell/NavRail.vue
+++ b/desktop/src/components/shell/NavRail.vue
@@ -31,6 +31,7 @@ import { useGalleryStore } from "../../stores/gallery";
 import { useHostsStore } from "../../stores/hosts";
 import { useHostModelsStore } from "../../stores/hostModels";
 import { useLiveActivityStore } from "../../stores/liveActivity";
+import { useJobsStore } from "../../stores/jobs";
 import { useToastStore } from "../../stores/toasts";
 import { badgeCount } from "../../lib/notifications";
 import { shortcutLabel } from "../../lib/platform";
@@ -38,6 +39,7 @@ import { modelDisplayNameForId } from "../../lib/models";
 import { useSequenceDraftStore } from "@studio/stores/sequenceDraft";
 import { useOpenLiveWork } from "../../composables/useOpenLiveWork";
 import { thumbnailPath } from "../../lib/gallery/media";
+import type { FleetActiveWork } from "@studio/api/activity";
 
 const route = useRoute();
 const router = useRouter();
@@ -49,10 +51,12 @@ const contextMenu = useContextMenuStore();
 const hosts = useHostsStore();
 const hostModels = useHostModelsStore();
 const liveActivity = useLiveActivityStore();
+const jobs = useJobsStore();
 const gallery = useGalleryStore();
 const toasts = useToastStore();
 const draft = useSequenceDraftStore();
 const openLiveWork = useOpenLiveWork();
+const cancellingSharedJobs = ref<string[]>([]);
 
 // Workspace badges (§08 G11): Library counts prints developed since the last
 // visit; Machines shows a stop dot when any connected host is offline.
@@ -237,6 +241,57 @@ function jobMenu(job: Job): MenuEntry[] {
   ];
 }
 
+function sharedJobMenu(row: FleetActiveWork): MenuEntry[] {
+  return [
+    {
+      label: "Cancel",
+      danger: true,
+      disabled:
+        row.kind !== "generation" ||
+        !row.can_cancel ||
+        row.stale ||
+        cancellingSharedJobs.value.includes(row.key),
+      action: () => void cancelSharedJob(row),
+    },
+  ];
+}
+
+async function cancelSharedJob(row: FleetActiveWork) {
+  if (cancellingSharedJobs.value.includes(row.key)) return;
+  const snapshot = liveActivity.hosts[row.hostId];
+  const host = hosts.all.find((candidate) => candidate.id === row.hostId);
+  if (
+    !snapshot ||
+    snapshot.stale ||
+    snapshot.routeUrl !== row.routeUrl ||
+    snapshot.instanceId !== row.instanceId ||
+    host?.baseUrl !== row.routeUrl ||
+    host.instanceId !== row.instanceId
+  ) {
+    toasts.push("This machine changed. Refresh its jobs and try again.", "error");
+    void liveActivity.refresh();
+    return;
+  }
+
+  cancellingSharedJobs.value = [...cancellingSharedJobs.value, row.key];
+  try {
+    await jobs.cancelJob(row.hostId, row.id);
+    const current = liveActivity.hosts[row.hostId]?.items.find(
+      (item) => item.kind === row.kind && item.id === row.id,
+    );
+    if (current) {
+      current.can_cancel = false;
+      current.phase = "cancelling";
+    }
+    toasts.push("Cancelled");
+  } catch (error) {
+    toasts.push(error instanceof Error ? error.message : String(error), "error");
+  } finally {
+    await liveActivity.refresh();
+    cancellingSharedJobs.value = cancellingSharedJobs.value.filter((key) => key !== row.key);
+  }
+}
+
 function selectPrint(job: Job) {
   generation.select(job.clientId);
   draft.stopEditing();
@@ -318,7 +373,13 @@ function selectSequence(vm: ActivityJobVM & { kind: "sequence" }) {
         data-test="developing-jobs"
         class="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto px-2"
       >
-        <LiveActivityList :rows="sharedRows" compact interactive @select="openLiveWork" />
+        <LiveActivityList
+          :rows="sharedRows"
+          compact
+          interactive
+          @select="openLiveWork"
+          @contextmenu="(row, event) => contextMenu.open(event, sharedJobMenu(row))"
+        />
         <a
           v-for="vm in railSequences"
           :key="vm.key"

--- a/desktop/src/stores/liveActivity.test.ts
+++ b/desktop/src/stores/liveActivity.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+import { useHostsStore } from "./hosts";
+import { useLiveActivityStore } from "./liveActivity";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => (resolve = done));
+  return { promise, resolve };
+}
+
+function activityResponse(items: unknown[]) {
+  return new Response(
+    JSON.stringify({
+      instance_id: "render-instance",
+      observed_at_unix_ms: Date.now(),
+      items,
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+describe("live activity refresh", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("guarantees a fresh pass after a refresh requested during an in-flight poll", async () => {
+    setActivePinia(createPinia());
+    useHostsStore().extras.push({
+      id: "render",
+      label: "Render box",
+      url: "http://render:7680",
+      apiKey: "secret",
+      status: "ready",
+      error: null,
+      instanceId: "render-instance",
+    });
+    const first = deferred<Response>();
+    const second = deferred<Response>();
+    const fetchMock = vi
+      .fn()
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    vi.stubGlobal("fetch", fetchMock);
+    const activity = useLiveActivityStore();
+
+    const preCancelRefresh = activity.refresh();
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const postCancelRefresh = activity.refresh();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    first.resolve(
+      activityResponse([
+        {
+          id: "job-1",
+          kind: "generation",
+          phase: "running",
+          created_at_unix_ms: 1,
+          updated_at_unix_ms: 2,
+          can_cancel: true,
+        },
+      ]),
+    );
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    second.resolve(activityResponse([]));
+
+    await Promise.all([preCancelRefresh, postCancelRefresh]);
+    expect(activity.hosts.render?.items).toEqual([]);
+    expect(activity.refreshing).toBe(false);
+  });
+});

--- a/desktop/src/stores/liveActivity.ts
+++ b/desktop/src/stores/liveActivity.ts
@@ -35,6 +35,8 @@ export const useLiveActivityStore = defineStore("liveActivity", {
     epochs: {} as Record<string, number>,
     timer: null as ReturnType<typeof setInterval> | null,
     refreshing: false,
+    refreshQueued: false,
+    refreshPromise: null as Promise<void> | null,
     consumers: 0,
   }),
   getters: {
@@ -49,40 +51,54 @@ export const useLiveActivityStore = defineStore("liveActivity", {
       localStorage.setItem(STORAGE_KEY, JSON.stringify(safe));
     },
     async refresh() {
-      if (this.refreshing) return;
+      if (this.refreshPromise) {
+        this.refreshQueued = true;
+        return this.refreshPromise;
+      }
       this.refreshing = true;
-      const hosts = useHostsStore();
+      const run = async () => {
+        do {
+          this.refreshQueued = false;
+          await this.refreshOnce();
+        } while (this.refreshQueued);
+      };
+      this.refreshPromise = run();
       try {
-        await Promise.all(
-          hosts.all.map(async (host) => {
-            if (!host.baseUrl) return;
-            const route = {
-              hostId: host.id,
-              hostLabel: host.label,
-              target: { baseUrl: host.baseUrl, apiKey: host.apiKey },
-            };
-            const epoch = (this.epochs[host.id] ?? 0) + 1;
-            this.epochs[host.id] = epoch;
-            const previous = this.hosts[host.id];
-            let result;
-            try {
-              if (host.status !== "ready") throw new Error("Host is offline");
-              result = await listActiveWork(route.target);
-            } catch (error) {
-              result = error instanceof Error ? error : new Error(String(error));
-            }
-            if (this.epochs[host.id] !== epoch) return;
-            this.hosts[host.id] = reconcileActivityHost(route, previous, result);
-          }),
-        );
-        const configured = new Set(hosts.all.map((host) => host.id));
-        for (const id of Object.keys(this.hosts)) {
-          if (!configured.has(id)) delete this.hosts[id];
-        }
-        this.persist();
+        await this.refreshPromise;
       } finally {
+        this.refreshPromise = null;
         this.refreshing = false;
       }
+    },
+    async refreshOnce() {
+      const hosts = useHostsStore();
+      await Promise.all(
+        hosts.all.map(async (host) => {
+          if (!host.baseUrl) return;
+          const route = {
+            hostId: host.id,
+            hostLabel: host.label,
+            target: { baseUrl: host.baseUrl, apiKey: host.apiKey },
+          };
+          const epoch = (this.epochs[host.id] ?? 0) + 1;
+          this.epochs[host.id] = epoch;
+          const previous = this.hosts[host.id];
+          let result;
+          try {
+            if (host.status !== "ready") throw new Error("Host is offline");
+            result = await listActiveWork(route.target);
+          } catch (error) {
+            result = error instanceof Error ? error : new Error(String(error));
+          }
+          if (this.epochs[host.id] !== epoch) return;
+          this.hosts[host.id] = reconcileActivityHost(route, previous, result);
+        }),
+      );
+      const configured = new Set(hosts.all.map((host) => host.id));
+      for (const id of Object.keys(this.hosts)) {
+        if (!configured.has(id)) delete this.hosts[id];
+      }
+      this.persist();
     },
     start() {
       this.consumers += 1;

--- a/studio/api/activity.ts
+++ b/studio/api/activity.ts
@@ -146,6 +146,8 @@ export interface FleetActiveWork extends ActiveWorkItem {
   key: string;
   hostId: string;
   hostLabel: string;
+  routeUrl: string;
+  instanceId: string | null;
   stale: boolean;
   hostError: string | null;
 }
@@ -161,6 +163,8 @@ export function mergeFleetActivity(
         key: `${host.hostId}:${item.kind}:${item.id}`,
         hostId: host.hostId,
         hostLabel: host.hostLabel,
+        routeUrl: host.routeUrl,
+        instanceId: host.instanceId,
         stale: host.stale || host.unavailableKinds.includes(item.kind),
         hostError: host.unavailableKinds.includes(item.kind)
           ? `${item.kind.replaceAll("_", " ")} status is temporarily unavailable`

--- a/ui/components/LiveActivityList.vue
+++ b/ui/components/LiveActivityList.vue
@@ -13,7 +13,10 @@ withDefaults(
   },
 );
 
-const emit = defineEmits<{ select: [row: FleetActiveWork] }>();
+const emit = defineEmits<{
+  select: [row: FleetActiveWork];
+  contextmenu: [row: FleetActiveWork, event: MouseEvent];
+}>();
 
 function title(row: FleetActiveWork): string {
   if (row.kind === "download")
@@ -52,6 +55,7 @@ function progress(row: FleetActiveWork): number | null {
         class="live-activity-surface"
         :data-test="interactive ? `live-activity-select-${row.key}` : undefined"
         @click="interactive && emit('select', row)"
+        @contextmenu="interactive && emit('contextmenu', row, $event)"
       >
         <span
           class="live-activity-dot"

--- a/web/src/components/create/ActivityStrip.test.ts
+++ b/web/src/components/create/ActivityStrip.test.ts
@@ -77,6 +77,8 @@ describe("ActivityStrip", () => {
       model: "ltx-2",
       hostId: "render",
       hostLabel: "Render box",
+      routeUrl: "http://render:7680",
+      instanceId: "render-instance",
       stale: true,
       hostError: "offline",
       created_at_unix_ms: 1,

--- a/web/src/components/shell/NowDevelopingPopover.test.ts
+++ b/web/src/components/shell/NowDevelopingPopover.test.ts
@@ -19,6 +19,8 @@ function row(): FleetActiveWork {
     key: "origin/job-1",
     hostId: "origin",
     hostLabel: "this server",
+    routeUrl: "http://origin:7680",
+    instanceId: "origin-instance",
     stale: false,
     hostError: null,
   };


### PR DESCRIPTION
## Summary

- expose the standard right-click context menu on shared Now Developing rows
- route foreign generation cancellation through the existing host-scoped queue cancellation path
- fence destructive cancellation to the displayed host URL and instance, prevent duplicate requests, and coalesce overlapping activity refreshes

## Root cause

Foreign-client jobs use the shared live-activity component, which only forwarded left-click selection. Session-owned rows had a context menu, but shared rows never exposed one even though Machines already supported cancelling those queue entries.

## Validation

- `nix develop -c desktop-check`
- `nix develop -c bash -lc "cd desktop && bun run test"` (326 files, 3,726 tests)
- focused NavRail/live-activity tests (20/20)
- local Vite UI smoke check: Mold shell/sidebar rendered with no console warnings or errors
- independent sub-agent peer review: no remaining findings