### PR TITLE
fix(ios): preserve gallery tap selection

### DIFF
--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -5855,6 +5855,73 @@ describe("MobileApp gallery", () => {
     expect(wrapper.get("[data-test='mobile-gallery-selection-indicator']").text()).toBe("✓");
   });
 
+  it("keeps a tapped Library tile selected after iOS dispatches its delayed click", async () => {
+    wrapper = mountMobileApp();
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-tab-gallery']").trigger("click");
+    await vi.waitFor(() => expect(wrapper?.find("[data-test='gallery-item']").exists()).toBe(true));
+
+    await wrapper.get("[data-test='mobile-gallery-select']").trigger("click");
+    const tile = wrapper.get("[data-test='gallery-item']");
+    await tile.trigger("pointerdown", {
+      pointerId: 40,
+      pointerType: "touch",
+      isPrimary: true,
+      clientX: 20,
+      clientY: 240,
+    });
+    window.dispatchEvent(
+      new PointerEvent("pointerup", {
+        pointerId: 40,
+        pointerType: "touch",
+        isPrimary: true,
+      }),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await tile.trigger("click", { detail: 1 });
+
+    expect(wrapper.get("[data-test='mobile-gallery-actions']").text()).toContain("1 selected");
+    expect(tile.attributes("aria-pressed")).toBe("true");
+
+    // Two more taps complete before WKWebView dispatches either compatibility
+    // click. Both delayed clicks must be consumed without changing the two
+    // pointerdown selections.
+    await tile.trigger("pointerdown", {
+      pointerId: 41,
+      pointerType: "touch",
+      isPrimary: true,
+      clientX: 20,
+      clientY: 240,
+    });
+    window.dispatchEvent(
+      new PointerEvent("pointerup", {
+        pointerId: 41,
+        pointerType: "touch",
+        isPrimary: true,
+      }),
+    );
+    await tile.trigger("pointerdown", {
+      pointerId: 42,
+      pointerType: "touch",
+      isPrimary: true,
+      clientX: 20,
+      clientY: 240,
+    });
+    window.dispatchEvent(
+      new PointerEvent("pointerup", {
+        pointerId: 42,
+        pointerType: "touch",
+        isPrimary: true,
+      }),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await tile.trigger("click", { detail: 1 });
+    await tile.trigger("click", { detail: 1 });
+
+    expect(wrapper.get("[data-test='mobile-gallery-actions']").text()).toContain("1 selected");
+    expect(tile.attributes("aria-pressed")).toBe("true");
+  });
+
   it("backs the native iOS image context menu with image data instead of a blob URL", async () => {
     isNativeIOSRuntime.mockReturnValue(true);
     apiFetchTo.mockResolvedValue({

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -616,7 +616,7 @@ let galleryDragSelect = true;
 let galleryDragClientX = 0;
 let galleryDragClientY = 0;
 let galleryDragFrame: number | null = null;
-let galleryDragSuppressClick = false;
+let galleryDragPendingClicks = 0;
 const galleryDragVisited = new Set<string>();
 const GALLERY_DRAG_SCROLL_EDGE = 72;
 const GALLERY_DRAG_SCROLL_MAX = 18;
@@ -4735,7 +4735,10 @@ function allGalleryPrints(): Array<GalleryPrint | PendingGalleryPrint> {
 }
 
 function setGallerySelectMode(next: boolean): void {
-  if (!next) finishGallerySelectionDrag();
+  if (!next) {
+    finishGallerySelectionDrag();
+    galleryDragPendingClicks = 0;
+  }
   gallerySelectMode.value = next;
   galleryDeleteConfirming.value = false;
   if (!next) gallerySelection.value = new Set();
@@ -4840,7 +4843,6 @@ function beginGallerySelectionDrag(event: PointerEvent, print: GalleryPrint): vo
   galleryDragClientX = event.clientX;
   galleryDragClientY = event.clientY;
   galleryDragVisited.clear();
-  galleryDragSuppressClick = true;
   applyGalleryDragSelection(print);
   (event.currentTarget as HTMLElement | null)?.setPointerCapture?.(event.pointerId);
   if (galleryDragFrame === null) galleryDragFrame = requestAnimationFrame(runGalleryDragFrame);
@@ -4859,13 +4861,11 @@ function moveGallerySelectionDrag(event: PointerEvent): void {
 
 function finishGallerySelectionDrag(event?: PointerEvent): void {
   if (event && event.pointerId !== galleryDragPointerId) return;
+  if (event?.type === "pointerup") galleryDragPendingClicks += 1;
   galleryDragPointerId = null;
   galleryDragVisited.clear();
   if (galleryDragFrame !== null) cancelAnimationFrame(galleryDragFrame);
   galleryDragFrame = null;
-  setTimeout(() => {
-    galleryDragSuppressClick = false;
-  }, 0);
 }
 
 function selectAllGalleryPrints(): void {
@@ -4874,7 +4874,13 @@ function selectAllGalleryPrints(): void {
 }
 
 function handleGalleryTileClick(event: MouseEvent, print: GalleryPrint): void {
-  if (gallerySelectMode.value && galleryDragSuppressClick && event.detail !== 0) return;
+  // WKWebView may delay compatibility clicks until after another tap has
+  // already completed. Consume one click for every pointer gesture instead
+  // of keeping a single flag that the first delayed click can clear.
+  if (gallerySelectMode.value && galleryDragPendingClicks > 0 && event.detail !== 0) {
+    galleryDragPendingClicks -= 1;
+    return;
+  }
   if (gallerySelectMode.value) toggleGallerySelection(print);
   else openPrint(print);
 }


### PR DESCRIPTION
## Summary

- keep iOS Library tiles selected after WKWebView delivers the delayed compatibility click for a tap
- count completed pointer gestures so rapid taps and drag-then-tap interactions suppress every duplicate click
- retain drag select/deselect, pointer-cancellation, and keyboard activation behavior

## Root cause

Drag selection updates a tile on `pointerdown`, but the click-suppression flag was cleared on a zero-delay timer after `pointerup`. WKWebView can dispatch the synthesized click later, causing the click handler to toggle the tile off again. A single flag also could not represent multiple rapid gestures whose clicks were still pending.

## Verification

- `nix develop -c bash -lc 'cd desktop && bun run test -- src/mobile/MobileApp.test.ts src/mobile/MobileGalleryViewer.test.ts'` (210 tests)
- `nix develop -c bash -lc 'cd desktop && bun run build:mobile'`
- `nix develop -c ios-check`
- Prettier check for both changed files
- independent agent review, including a rapid-tap follow-up: no findings
