### PR TITLE
fix(release): keep checksum asset names compatible

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -608,7 +608,7 @@ jobs:
           merge-multiple: true
 
       - name: Generate checksums
-        run: cd artifacts && sha256sum ./*.tar.gz > SHA256SUMS
+        run: cd artifacts && sha256sum -- *.tar.gz > SHA256SUMS
 
       - name: Verify rolling release source is current main
         run: scripts/check-desktop-nightly-main-head.sh "$GITHUB_SHA"
@@ -786,7 +786,7 @@ jobs:
         run: cp artifacts/Mold_*_aarch64.dmg artifacts/Mold-macos-arm64.dmg
 
       - name: Generate checksums
-        run: cd artifacts && sha256sum ./*.tar.gz ./*.dmg ./*.zip > SHA256SUMS
+        run: cd artifacts && sha256sum -- *.tar.gz *.dmg *.zip > SHA256SUMS
 
       - name: Create Apple-first release
         uses: softprops/action-gh-release@v2
@@ -927,7 +927,7 @@ jobs:
           set -euo pipefail
           (
             cd artifacts
-            sha256sum ./*.tar.gz ./*.dmg ./*.zip > SHA256SUMS
+            sha256sum -- *.tar.gz *.dmg *.zip > SHA256SUMS
           )
           gh release upload "$GITHUB_REF_NAME" \
             artifacts/mold-x86_64-unknown-linux-gnu-cuda-sm86.tar.gz \
@@ -964,7 +964,7 @@ jobs:
           set -euo pipefail
           (
             cd artifacts
-            sha256sum ./*.tar.gz ./*.dmg ./*.zip > SHA256SUMS
+            sha256sum -- *.tar.gz *.dmg *.zip > SHA256SUMS
           )
           scripts/create-container-digest-manifest.sh \
             artifacts/mold-container-digests.json \

--- a/changelog.d/update-checksum-paths.md
+++ b/changelog.d/update-checksum-paths.md
@@ -1,0 +1,5 @@
+- **`mold update` works again for older installations.** Release checksum
+  manifests once again record archive names exactly as GitHub publishes them,
+  without a leading `./` that Mold 0.9 and other legacy clients could not
+  match. The release contract now guards every rolling and stable publication
+  phase against reintroducing the incompatible path form.

--- a/scripts/tests/cuda-distribution-contract.sh
+++ b/scripts/tests/cuda-distribution-contract.sh
@@ -343,6 +343,15 @@ require_text "flake.nix" \
   '"mold.cachix.org-1:9HBc/bEXDdpbxMjOwpaIDpjZqBh9JYg0h5Fipm+D8m4="'
 require_release_job_need "publish" "release-version"
 require_release_job_need "publish-aur" "release-native"
+require_release_job_text "release-latest" \
+  'sha256sum -- *.tar.gz > SHA256SUMS'
+for checksum_job in release-version release-native release-containers; do
+  require_release_job_text "$checksum_job" \
+    'sha256sum -- *.tar.gz *.dmg *.zip > SHA256SUMS'
+done
+if grep -Fq 'sha256sum ./*' "$repo_root/$release"; then
+  fail "$release must write asset names without a ./ prefix for legacy updater compatibility"
+fi
 require_release_job_text "release-containers" \
   'scripts/create-container-digest-manifest.sh'
 require_release_job_text "release-containers" \


### PR DESCRIPTION
## Summary

- generate prefix-free SHA256SUMS filenames in every rolling and stable publication phase
- preserve shell option safety with the sha256sum end-of-options delimiter
- enforce the legacy-updater compatibility contract and document the repair

## Root cause

Mold 0.9.0 compares the SHA256SUMS filename literally with the GitHub asset name. Commit 4fe424c2 changed release globs from `*.tar.gz` to `./*.tar.gz`, causing GNU sha256sum to publish `./mold-aarch64-apple-darwin.tar.gz`. The asset exists, but legacy clients cannot match that manifest entry and fail before downloading the tolerant newer client.

## Validation

- `nix develop -c nix run nixpkgs#actionlint -- .github/workflows/release.yml`
- `nix develop -c bash scripts/tests/changelog-fragments-contract.sh`
- `nix develop -c bash -n scripts/tests/cuda-distribution-contract.sh`
- prefix-free checksum fixture accepted by the Mold 0.9 exact-name contract
- `nix develop -c nix fmt` (0 files changed)
- independent subagent peer review: no findings

The full CUDA distribution contract reaches its Linux ELF/PTX fixture tail after the new assertions pass; that tail is not runnable on this macOS host because its generated fixtures are Mach-O rather than ELF.