### PR TITLE
ci: schedule Nix and Docker publication

### DIFF
--- a/.github/workflows/nix-cache.yml
+++ b/.github/workflows/nix-cache.yml
@@ -2,11 +2,13 @@ name: Publish Nix Cache
 
 on:
   push:
-    branches: [main]
+    # Cachix is a release convenience, not a per-commit validation signal.
+    # Build each public closure once for the immutable full release revision.
+    tags: ["v*"]
 
 concurrency:
-  # CUDA builds routinely outlive the interval between main pushes. Queue them
-  # so each completed build reaches Cachix instead of cancelling every upload.
+  # Full release tags are immutable. Let their cache publication finish rather
+  # than replacing a release closure if two tags are processed close together.
   group: nix-cache-${{ github.ref }}
   cancel-in-progress: false
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,13 @@ on:
   push:
     branches: [main]
     tags: ["v*"]
+  schedule:
+    # Rolling containers are deliberately separated from main-push delivery.
+    # 12:47 UTC is 05:47 America/Phoenix and avoids the top-of-hour surge.
+    - cron: "47 12 * * *"
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-${{ github.event_name == 'schedule' && 'docker-nightly' || github.ref }}
   cancel-in-progress: true
 
 env:
@@ -16,6 +20,7 @@ env:
 
 jobs:
   build-macos:
+    if: github.event_name != 'schedule'
     runs-on: macos-14
     env:
       # sccache rejects incremental rustc invocations.
@@ -75,6 +80,7 @@ jobs:
 
   # Ampere (RTX 3090/A40, sm_86)
   build-linux-sm86:
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     env:
       CARGO_INCREMENTAL: "0"
@@ -161,6 +167,7 @@ jobs:
 
   # Ada Lovelace (RTX 40-series, sm_89)
   build-linux-sm89:
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     env:
       CARGO_INCREMENTAL: "0"
@@ -251,6 +258,7 @@ jobs:
   # Datacenter Blackwell (B200/B300, sm_100). Built and statically validated;
   # hardware qualification remains deferred.
   build-linux-sm100:
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     env:
       CARGO_INCREMENTAL: "0"
@@ -337,6 +345,7 @@ jobs:
 
   # Consumer Blackwell (RTX 50-series, sm_120)
   build-linux-sm120:
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
     env:
       CARGO_INCREMENTAL: "0"
@@ -433,14 +442,19 @@ jobs:
       channel: stable
     secrets: inherit
 
-  # Docker images — main publishes the mutable rolling latest* map; v* jobs
-  # create-once/verify semver aliases and export exact digest fragments.
+  # Docker images — the off-hours schedule publishes the mutable rolling
+  # latest* map; v* jobs create-once/verify semver aliases and export exact
+  # digest fragments. Main pushes never allocate this six-target matrix.
   docker:
+    if: github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
     strategy:
+      # Keep nightly maintenance from reclaiming the daytime runner pool.
+      # Full releases retain the existing parallel publication behavior.
+      max-parallel: ${{ github.event_name == 'schedule' && 2 || 6 }}
       matrix:
         include:
           - cuda_cap: "89"
@@ -591,7 +605,7 @@ jobs:
 
   # Rolling pre-release on every push to main
   release-latest:
-    if: github.ref == 'refs/heads/main'
+    if: github.event_name != 'schedule' && github.ref == 'refs/heads/main'
     # Native rolling artifacts should not wait for best-effort Nix validation
     # or the lower-priority container matrix. Docker publishes its own rolling
     # aliases, and Nix builds live in nix-cache.yml.

--- a/scripts/tests/cuda-distribution-contract.sh
+++ b/scripts/tests/cuda-distribution-contract.sh
@@ -250,6 +250,15 @@ rolling_tag_patch_line="$(
   && "$second_release_guard_line" -lt "$rolling_tag_patch_line" ]] \
   || fail "fresh-main guards must surround release mutation and tag movement"
 require_text "$release" 'tags: ["v*"]'
+require_text "$release" '- cron: "47 12 * * *"'
+require_text "$release" \
+  'group: release-${{ github.event_name == '\''schedule'\'' && '\''docker-nightly'\'' || github.ref }}'
+require_release_job_text "docker" \
+  "if: github.event_name == 'schedule' || startsWith(github.ref, 'refs/tags/v')"
+require_release_job_text "docker" \
+  'max-parallel: ${{ github.event_name == '\''schedule'\'' && 2 || 6 }}'
+require_release_job_text "release-latest" \
+  "if: github.event_name != 'schedule' && github.ref == 'refs/heads/main'"
 require_release_job_text "docker" \
   'type=raw,value=latest${{ matrix.suffix }},enable={{is_default_branch}}'
 require_release_job_text "docker" \
@@ -316,7 +325,10 @@ done
 require_release_job_text "docker" 'cuda_cap: "89"'
 require_release_job_text "docker" 'suffix: ""'
 require_ci_release_path "$cache_workflow"
-require_text "$cache_workflow" 'branches: [main]'
+require_text "$cache_workflow" 'tags: ["v*"]'
+if grep -Fq 'branches: [main]' "$repo_root/$cache_workflow"; then
+  fail "$cache_workflow must not build Cachix closures on main pushes"
+fi
 require_text "$cache_workflow" 'group: nix-cache-${{ github.ref }}'
 require_text "$cache_workflow" 'cancel-in-progress: false'
 require_text "$cache_workflow" 'permissions:'


### PR DESCRIPTION
## Summary
- publish Cachix closures only for immutable version tags
- move rolling Docker publication from every main push to a 05:47 America/Phoenix nightly schedule
- cap nightly Docker builds at two runners while preserving six-way stable release publication
- keep scheduled Docker isolated from main-push release concurrency and add routing contracts

## Impact
A broad main push no longer allocates the four-job Nix matrix or six-job Docker matrix, removing roughly 9.4 runner-hours of competing work per revision. Stable tags retain both publication paths.

## Validation
- `nix develop -c bash scripts/tests/ci-routing-contract.sh`
- `nix develop -c go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/release.yml .github/workflows/nix-cache.yml`
- `nix develop -c shellcheck scripts/tests/cuda-distribution-contract.sh`
- `nix develop -c bash scripts/tests/cuda-distribution-contract.sh` reached its PTX parser suite after all routing assertions; local PTX fixtures require unavailable `readelf`, which CI supplies
- `git diff --check`