### PR TITLE
fix(studio): preserve fleet prompt history offline

### DIFF
--- a/changelog.d/prompt-history-cache.md
+++ b/changelog.d/prompt-history-cache.md
@@ -1,0 +1,1 @@
+- **Prompt history across machines.** Desktop and web now recall prompts from every configured machine in chronological order and keep a bounded local cache so history remains available while machines are offline.

--- a/desktop/src/components/create/ComposerCard.test.ts
+++ b/desktop/src/components/create/ComposerCard.test.ts
@@ -45,6 +45,33 @@ function mountComposer(form: GenerateForm, overrides: Record<string, unknown> = 
 }
 
 describe("ComposerCard", () => {
+  it("walks prompt history chronologically and restores the authored draft", async () => {
+    const form = baseForm();
+    form.prompt = "draft";
+    const wrapper = mountComposer(form, { history: ["newest", "middle", "oldest"] });
+    const textarea = wrapper.get("textarea[aria-label='Prompt']");
+    const el = textarea.element as HTMLTextAreaElement;
+    el.setSelectionRange(0, 0);
+
+    await textarea.trigger("keydown", { key: "ArrowUp" });
+    expect(form.prompt).toBe("newest");
+    await textarea.trigger("keydown", { key: "ArrowUp" });
+    expect(form.prompt).toBe("middle");
+    await textarea.trigger("keydown", { key: "ArrowDown" });
+    expect(form.prompt).toBe("newest");
+    await textarea.trigger("keydown", { key: "ArrowDown" });
+    expect(form.prompt).toBe("draft");
+  });
+
+  it("does not swallow ArrowUp when there is no cached or live history", () => {
+    const wrapper = mountComposer(baseForm(), { history: [] });
+    const el = wrapper.get("textarea[aria-label='Prompt']").element as HTMLTextAreaElement;
+    el.setSelectionRange(0, 0);
+    const event = new KeyboardEvent("keydown", { key: "ArrowUp", cancelable: true });
+    el.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(false);
+  });
+
   it("submits on the primary-modifier Enter shortcut", async () => {
     const wrapper = mountComposer(baseForm());
     await wrapper

--- a/desktop/src/components/create/ComposerCard.vue
+++ b/desktop/src/components/create/ComposerCard.vue
@@ -84,15 +84,16 @@ onMounted(() => {
   promptEl.value?.focus();
 });
 
-function cycleHistory(direction: "prev" | "next") {
+function cycleHistory(direction: "prev" | "next"): boolean {
   const replacement = direction === "prev" ? cycler.prev(props.form.prompt) : cycler.next();
-  if (replacement === null) return;
+  if (replacement === null) return false;
   props.form.prompt = replacement;
   emit("prompt-authored", replacement);
   void nextTick(() => {
     const el = promptEl.value;
     el?.setSelectionRange(el.value.length, el.value.length);
   });
+  return true;
 }
 
 function onPromptInput(event: Event) {
@@ -109,11 +110,9 @@ function onKeydown(e: KeyboardEvent) {
     e.preventDefault();
     expandControl.value?.expand();
   } else if (e.key === "ArrowUp" && promptEl.value && caretOnFirstLine(promptEl.value)) {
-    e.preventDefault();
-    cycleHistory("prev");
+    if (cycleHistory("prev")) e.preventDefault();
   } else if (e.key === "ArrowDown" && promptEl.value && caretOnLastLine(promptEl.value)) {
-    e.preventDefault();
-    cycleHistory("next");
+    if (cycleHistory("next")) e.preventDefault();
   }
 }
 

--- a/desktop/src/views/GenerateView.vue
+++ b/desktop/src/views/GenerateView.vue
@@ -161,7 +161,13 @@ import {
   hydrateGenerationTemplate,
   type GenerationTemplate,
 } from "../lib/generationTemplates";
-import { fetchHistoryAll, type HistoryHostTarget } from "../lib/api/history";
+import { fetchHistoryFrom } from "../lib/api/history";
+import {
+  availablePromptHistoryStorage,
+  PromptHistoryCoordinator,
+  promptHistoryHostSignature,
+  recordPromptHistoryCache,
+} from "@studio/lib/promptHistoryCache";
 import { randomSeed } from "../stores/generation";
 import type { CompleteEvent, GenerateRequest, OutputMetadata } from "../lib/api/types";
 import {
@@ -3255,7 +3261,14 @@ async function generate() {
     ) {
       quickExpansionSnapshot.value = null;
     }
-    composerRef.value?.record?.(preparedSubmission?.originalPrompt ?? request.prompt);
+    const recordedPrompt = preparedSubmission?.originalPrompt ?? request.prompt;
+    composerRef.value?.record?.(recordedPrompt);
+    recordPromptHistoryCache(
+      availablePromptHistoryStorage(),
+      hosts.all.map((host) => ({ hostId: host.id, hostLabel: host.label })),
+      route?.hostId ?? "local",
+      { prompt: recordedPrompt, model: request.model, used_at: Date.now() },
+    );
     void settled.then((done) => {
       void loadPromptHistory();
       const ok = done.filter((s) => s.status === "complete").length;
@@ -3306,21 +3319,20 @@ async function generate() {
   }
 }
 
+const promptHistoryCoordinator = new PromptHistoryCoordinator();
 async function loadPromptHistory() {
   try {
-    const targets: HistoryHostTarget[] = hosts.all.flatMap((host) =>
-      host.status === "ready" && host.baseUrl
-        ? [
-            {
-              hostId: host.id,
-              label: host.label,
-              target: { baseUrl: host.baseUrl, apiKey: host.apiKey },
-            },
-          ]
-        : [],
+    const history = await promptHistoryCoordinator.load(
+      availablePromptHistoryStorage(),
+      hosts.all.map((host) => ({
+        hostId: host.id,
+        hostLabel: host.label,
+        fetchable: host.status === "ready" && Boolean(host.baseUrl),
+        source: { baseUrl: host.baseUrl ?? "", apiKey: host.apiKey },
+      })),
+      (target) => fetchHistoryFrom(target),
     );
-    const history = await fetchHistoryAll(targets);
-    promptHistory.value = history.entries.map((entry) => entry.prompt);
+    if (history) promptHistory.value = history.map((entry) => entry.prompt);
   } catch {
     // No history API (older engine / DB off) — arrows just move the caret.
   }
@@ -3352,13 +3364,12 @@ watch(
   { immediate: true },
 );
 
-// The boot fetch usually races the remote hosts' reconnect and captures only
-// this device's prompts; refetch the merged history whenever the set of
-// ready hosts changes so ↑/↓ recall spans every connected machine.
+// Re-scope on every configured-host and reachability transition. Watching only
+// ready ids leaves a forgotten offline host's cached prompts behind forever.
 watch(
-  () => readyHostSignature(hosts.all),
+  () => promptHistoryHostSignature(hosts.all),
   () => {
-    if (conn.ready) void loadPromptHistory();
+    void loadPromptHistory();
   },
 );
 
@@ -3687,6 +3698,9 @@ watch(
 );
 
 onMounted(() => {
+  // Hydrate cached prompt history even when no engine is reachable. A later
+  // ready-host transition refreshes and replaces each live host's slice.
+  if (!import.meta.env.TEST) void loadPromptHistory();
   if (!import.meta.env.TEST) liveActivity.start();
   document.addEventListener("pointerdown", onDocumentPointerDown);
   document.addEventListener("keydown", onDocumentKeydown);
@@ -3700,6 +3714,7 @@ onMounted(() => {
 });
 
 onBeforeUnmount(() => {
+  promptHistoryCoordinator.invalidate();
   if (!import.meta.env.TEST) liveActivity.stop();
   preparationGuard.invalidate();
   submissionGuard.invalidate();

--- a/studio/lib/promptHistoryCache.test.ts
+++ b/studio/lib/promptHistoryCache.test.ts
@@ -1,0 +1,333 @@
+import { describe, expect, it } from "vitest";
+import {
+  PROMPT_HISTORY_CACHE_KEY,
+  PROMPT_HISTORY_CACHE_CODE_UNIT_BUDGET,
+  PROMPT_HISTORY_MAX_UTF8_BYTES,
+  PROMPT_HISTORY_PER_HOST_LIMIT,
+  PromptHistoryCoordinator,
+  availablePromptHistoryStorage,
+  promptHistoryHostSignature,
+  readPromptHistoryCache,
+  recordPromptHistoryCache,
+  reconcilePromptHistoryCache,
+  type CachedPromptHistoryEntry,
+} from "./promptHistoryCache";
+
+class MemoryStorage {
+  values = new Map<string, string>();
+  getItem(key: string) {
+    return this.values.get(key) ?? null;
+  }
+  setItem(key: string, value: string) {
+    this.values.set(key, value);
+  }
+}
+
+const hosts = [
+  { hostId: "local", hostLabel: "This device" },
+  { hostId: "remote", hostLabel: "Studio" },
+];
+const row = (
+  hostId: string,
+  prompt: string,
+  used_at: number,
+): CachedPromptHistoryEntry => ({
+  hostId,
+  hostLabel: hostId,
+  prompt,
+  model: "flux",
+  used_at,
+});
+
+describe("prompt history cache", () => {
+  it("merges every host into one newest-first timeline", () => {
+    const storage = new MemoryStorage();
+    const merged = reconcilePromptHistoryCache(
+      storage,
+      hosts,
+      [
+        row("local", "middle", 20),
+        row("remote", "newest", 30),
+        row("local", "oldest", 10),
+      ],
+      ["local", "remote"],
+    );
+    expect(merged.map((entry) => entry.prompt)).toEqual([
+      "newest",
+      "middle",
+      "oldest",
+    ]);
+  });
+
+  it("retains an offline host while replacing each successful host slice", () => {
+    const storage = new MemoryStorage();
+    reconcilePromptHistoryCache(
+      storage,
+      hosts,
+      [row("local", "old local", 10), row("remote", "cached remote", 20)],
+      ["local", "remote"],
+    );
+    const merged = reconcilePromptHistoryCache(
+      storage,
+      [hosts[0]!, { hostId: "remote", hostLabel: "Renamed studio" }],
+      [row("local", "fresh local", 30)],
+      ["local"],
+    );
+    expect(merged.map((entry) => entry.prompt)).toEqual([
+      "fresh local",
+      "cached remote",
+    ]);
+    expect(merged.find((entry) => entry.hostId === "remote")?.hostLabel).toBe(
+      "Renamed studio",
+    );
+  });
+
+  it("treats a successful empty response as authoritative after Clear", () => {
+    const storage = new MemoryStorage();
+    reconcilePromptHistoryCache(
+      storage,
+      hosts,
+      [row("remote", "gone", 20)],
+      ["remote"],
+    );
+    expect(reconcilePromptHistoryCache(storage, hosts, [], ["remote"])).toEqual(
+      [],
+    );
+  });
+
+  it("drops forgotten hosts, corrupt rows, and excess per-host entries", () => {
+    const storage = new MemoryStorage();
+    storage.values.set(PROMPT_HISTORY_CACHE_KEY, "not json");
+    expect(readPromptHistoryCache(storage)).toEqual([]);
+
+    const many = Array.from(
+      { length: PROMPT_HISTORY_PER_HOST_LIMIT + 5 },
+      (_, i) => row("local", `prompt ${i}`, i),
+    );
+    reconcilePromptHistoryCache(
+      storage,
+      hosts,
+      [...many, row("remote", "remote", 500)],
+      ["local", "remote"],
+    );
+    const onlyLocal = reconcilePromptHistoryCache(storage, [hosts[0]!], [], []);
+    expect(onlyLocal).toHaveLength(PROMPT_HISTORY_PER_HOST_LIMIT);
+    expect(onlyLocal.some((entry) => entry.hostId === "remote")).toBe(false);
+  });
+
+  it("still returns live history when storage reads or writes throw", () => {
+    const storage = {
+      getItem: () => {
+        throw new Error("denied");
+      },
+      setItem: () => {
+        throw new Error("full");
+      },
+    };
+    expect(
+      reconcilePromptHistoryCache(
+        storage,
+        hosts,
+        [row("local", "live", 1)],
+        ["local"],
+      )[0]?.prompt,
+    ).toBe("live");
+  });
+
+  it("survives a throwing localStorage property getter", async () => {
+    const denied = Object.defineProperty({}, "localStorage", {
+      get() {
+        throw new DOMException("denied", "SecurityError");
+      },
+    });
+    const storage = availablePromptHistoryStorage(denied);
+    expect(storage).toBeNull();
+    const live = await new PromptHistoryCoordinator().load(
+      storage,
+      [{ ...hosts[0]!, fetchable: true, source: "local" }],
+      async () => [
+        { prompt: "live without storage", model: "flux", used_at: 1 },
+      ],
+    );
+    expect(live?.map((entry) => entry.prompt)).toEqual([
+      "live without storage",
+    ]);
+  });
+
+  it("accepts the server's exact 77,000-byte prompt limit", () => {
+    const storage = new MemoryStorage();
+    const prompt = "x".repeat(PROMPT_HISTORY_MAX_UTF8_BYTES);
+    expect(
+      reconcilePromptHistoryCache(
+        storage,
+        hosts,
+        [row("local", prompt, 1)],
+        ["local"],
+      )[0]?.prompt,
+    ).toBe(prompt);
+    expect(
+      reconcilePromptHistoryCache(
+        storage,
+        hosts,
+        [row("local", `${prompt}x`, 2)],
+        ["local"],
+      ),
+    ).toEqual([]);
+  });
+
+  it("bounds the serialized cache while keeping the full live timeline", () => {
+    const storage = new MemoryStorage();
+    const large = "x".repeat(PROMPT_HISTORY_MAX_UTF8_BYTES);
+    const live = Array.from({ length: 100 }, (_, i) =>
+      row("local", `${String(i).padStart(3, "0")}${large.slice(3)}`, i),
+    );
+    const merged = reconcilePromptHistoryCache(storage, hosts, live, ["local"]);
+    const persisted = storage.getItem(PROMPT_HISTORY_CACHE_KEY)!;
+    expect(merged).toHaveLength(100);
+    expect(persisted.length).toBeLessThanOrEqual(
+      PROMPT_HISTORY_CACHE_CODE_UNIT_BUDGET,
+    );
+    expect(readPromptHistoryCache(storage).length).toBeLessThan(100);
+    expect(readPromptHistoryCache(storage)[0]?.used_at).toBe(99);
+  });
+
+  it("changes signature when an offline host is forgotten or renamed", () => {
+    const offline = [
+      {
+        id: "local",
+        label: "This device",
+        status: "error",
+        baseUrl: "http://local",
+      },
+      {
+        id: "remote",
+        label: "Studio",
+        status: "error",
+        baseUrl: "http://studio",
+      },
+    ];
+    expect(promptHistoryHostSignature(offline)).not.toBe(
+      promptHistoryHostSignature(offline.slice(0, 1)),
+    );
+    expect(promptHistoryHostSignature(offline)).not.toBe(
+      promptHistoryHostSignature([
+        { ...offline[0]! },
+        { ...offline[1]!, label: "Renamed" },
+      ]),
+    );
+  });
+});
+
+describe("PromptHistoryCoordinator", () => {
+  it("persists an accepted prompt before settlement for offline reload recall", async () => {
+    const storage = new MemoryStorage();
+    recordPromptHistoryCache(storage, hosts, "remote", {
+      prompt: "accepted and still running",
+      model: "flux",
+      used_at: 50,
+    });
+
+    // New coordinator = reloaded view; neither host can be fetched now.
+    const reloaded = await new PromptHistoryCoordinator().load(
+      storage,
+      hosts.map((host) => ({ ...host, fetchable: false, source: host.hostId })),
+      async () => {
+        throw new Error("must not fetch offline hosts");
+      },
+    );
+    expect(reloaded?.map((entry) => entry.prompt)).toEqual([
+      "accepted and still running",
+    ]);
+  });
+
+  it("fans out exact authenticated targets and merges successful hosts chronologically", async () => {
+    const storage = new MemoryStorage();
+    const coordinator = new PromptHistoryCoordinator();
+    const seen: Array<{ baseUrl: string; apiKey: string | null }> = [];
+    const result = await coordinator.load(
+      storage,
+      [
+        {
+          hostId: "local",
+          hostLabel: "This device",
+          fetchable: true,
+          source: { baseUrl: "http://local", apiKey: "local-secret" },
+        },
+        {
+          hostId: "remote",
+          hostLabel: "Studio",
+          fetchable: true,
+          source: { baseUrl: "http://studio", apiKey: "remote-secret" },
+        },
+      ],
+      async (source) => {
+        seen.push(source);
+        return source.baseUrl.endsWith("studio")
+          ? [{ prompt: "newest", model: "flux", used_at: 30 }]
+          : [{ prompt: "oldest", model: "flux", used_at: 10 }];
+      },
+    );
+    expect(seen).toEqual([
+      { baseUrl: "http://local", apiKey: "local-secret" },
+      { baseUrl: "http://studio", apiKey: "remote-secret" },
+    ]);
+    expect(result?.map((entry) => entry.prompt)).toEqual(["newest", "oldest"]);
+    expect(storage.getItem(PROMPT_HISTORY_CACHE_KEY)).not.toContain("secret");
+    expect(storage.getItem(PROMPT_HISTORY_CACHE_KEY)).not.toContain("http://");
+  });
+
+  it("retains failed offline slices, clears successful empty slices, and evicts forgotten hosts", async () => {
+    const storage = new MemoryStorage();
+    const coordinator = new PromptHistoryCoordinator();
+    reconcilePromptHistoryCache(
+      storage,
+      hosts,
+      [row("local", "clear me", 10), row("remote", "offline", 20)],
+      ["local", "remote"],
+    );
+    const scoped = await coordinator.load(
+      storage,
+      [
+        { ...hosts[0]!, fetchable: true, source: "local" },
+        { ...hosts[1]!, fetchable: true, source: "remote" },
+      ],
+      async (source) => {
+        if (source === "remote") throw new Error("offline");
+        return [];
+      },
+    );
+    expect(scoped?.map((entry) => entry.prompt)).toEqual(["offline"]);
+
+    const forgotten = await coordinator.load(
+      storage,
+      [{ ...hosts[0]!, fetchable: false, source: "local" }],
+      async () => [],
+    );
+    expect(forgotten).toEqual([]);
+    expect(readPromptHistoryCache(storage)).toEqual([]);
+  });
+
+  it("discards a stale async load that resolves after a newer registry transition", async () => {
+    const coordinator = new PromptHistoryCoordinator();
+    const storage = new MemoryStorage();
+    let release!: (
+      entries: Array<{ prompt: string; model: string; used_at: number }>,
+    ) => void;
+    const slow = coordinator.load(
+      storage,
+      [{ ...hosts[0]!, fetchable: true, source: "slow" }],
+      () => new Promise((resolve) => (release = resolve)),
+    );
+    const fresh = await coordinator.load(
+      storage,
+      [{ ...hosts[0]!, fetchable: true, source: "fresh" }],
+      async () => [{ prompt: "fresh", model: "flux", used_at: 2 }],
+    );
+    release([{ prompt: "stale", model: "flux", used_at: 1 }]);
+    expect(await slow).toBeNull();
+    expect(fresh?.map((entry) => entry.prompt)).toEqual(["fresh"]);
+    expect(
+      readPromptHistoryCache(storage).map((entry) => entry.prompt),
+    ).toEqual(["fresh"]);
+  });
+});

--- a/studio/lib/promptHistoryCache.ts
+++ b/studio/lib/promptHistoryCache.ts
@@ -1,0 +1,283 @@
+/**
+ * Durable, host-aware prompt-history cache shared by desktop and web.
+ *
+ * Only prompt metadata is persisted. Host URLs and API keys deliberately stay
+ * outside this cache. A successful read replaces that host's cached slice
+ * (including with an empty slice after Clear); an unreachable host keeps its
+ * last good slice until the host is removed from the client's registry.
+ */
+
+export const PROMPT_HISTORY_CACHE_KEY = "mold.prompt-history-cache.v1";
+export const PROMPT_HISTORY_PER_HOST_LIMIT = 100;
+/** Keep comfortably below common 5 MiB localStorage quotas (UTF-16 storage). */
+export const PROMPT_HISTORY_CACHE_CODE_UNIT_BUDGET = 2_000_000;
+export const PROMPT_HISTORY_MAX_UTF8_BYTES = 77_000;
+
+export interface PromptHistoryCacheHost {
+  hostId: string;
+  hostLabel: string;
+}
+
+export interface CachedPromptHistoryEntry extends PromptHistoryCacheHost {
+  prompt: string;
+  model: string;
+  used_at: number;
+}
+
+interface PromptHistoryCacheWire {
+  version: 1;
+  entries: CachedPromptHistoryEntry[];
+}
+
+export interface PromptHistoryStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+/** Access itself can throw SecurityError when browser persistence is denied. */
+export function availablePromptHistoryStorage(
+  scope: { readonly localStorage?: PromptHistoryStorage } = globalThis,
+): PromptHistoryStorage | null {
+  try {
+    return scope.localStorage ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function validString(value: unknown, max: number): value is string {
+  return typeof value === "string" && value.length > 0 && value.length <= max;
+}
+
+function validPrompt(value: unknown): value is string {
+  return (
+    validString(value, PROMPT_HISTORY_MAX_UTF8_BYTES) &&
+    new TextEncoder().encode(value).byteLength <= PROMPT_HISTORY_MAX_UTF8_BYTES
+  );
+}
+
+function parseEntry(value: unknown): CachedPromptHistoryEntry | null {
+  if (typeof value !== "object" || value === null) return null;
+  const row = value as Record<string, unknown>;
+  if (
+    !validString(row.hostId, 512) ||
+    !validString(row.hostLabel, 512) ||
+    !validPrompt(row.prompt) ||
+    typeof row.model !== "string" ||
+    row.model.length > 2_048 ||
+    typeof row.used_at !== "number" ||
+    !Number.isSafeInteger(row.used_at) ||
+    row.used_at < 0
+  ) {
+    return null;
+  }
+  return {
+    hostId: row.hostId,
+    hostLabel: row.hostLabel,
+    prompt: row.prompt,
+    model: row.model,
+    used_at: row.used_at,
+  };
+}
+
+export function readPromptHistoryCache(
+  storage: PromptHistoryStorage | null | undefined,
+): CachedPromptHistoryEntry[] {
+  if (!storage) return [];
+  try {
+    const raw = storage.getItem(PROMPT_HISTORY_CACHE_KEY);
+    if (!raw) return [];
+    const decoded = JSON.parse(raw) as Partial<PromptHistoryCacheWire>;
+    if (decoded.version !== 1 || !Array.isArray(decoded.entries)) return [];
+    return decoded.entries.flatMap((entry) => {
+      const parsed = parseEntry(entry);
+      return parsed ? [parsed] : [];
+    });
+  } catch {
+    return [];
+  }
+}
+
+function chronological(
+  entries: CachedPromptHistoryEntry[],
+): CachedPromptHistoryEntry[] {
+  return entries.sort(
+    (a, b) =>
+      b.used_at - a.used_at ||
+      a.hostId.localeCompare(b.hostId) ||
+      a.prompt.localeCompare(b.prompt),
+  );
+}
+
+function fitCacheBudget(
+  entries: CachedPromptHistoryEntry[],
+): CachedPromptHistoryEntry[] {
+  const kept: CachedPromptHistoryEntry[] = [];
+  let codeUnits = JSON.stringify({ version: 1, entries: [] }).length;
+  // Measure the actual wire shape. Newest-first eviction is deterministic and
+  // preserves the prompts a user is most likely to recall while hosts are off.
+  for (const entry of entries) {
+    const entryCodeUnits =
+      JSON.stringify(entry).length + (kept.length > 0 ? 1 : 0);
+    if (codeUnits + entryCodeUnits > PROMPT_HISTORY_CACHE_CODE_UNIT_BUDGET)
+      break;
+    kept.push(entry);
+    codeUnits += entryCodeUnits;
+  }
+  return kept;
+}
+
+/** Any configured-host or reachability transition must refresh/re-scope. */
+export function promptHistoryHostSignature(
+  hosts: readonly {
+    id: string;
+    label: string;
+    status: string;
+    baseUrl?: string | null;
+    url?: string | null;
+  }[],
+): string {
+  return hosts
+    .map(
+      (host) =>
+        `${host.id}\u0000${host.label}\u0000${host.status}\u0000${host.baseUrl ?? host.url ?? ""}`,
+    )
+    .sort()
+    .join("\u0001");
+}
+
+/**
+ * Reconcile last-good cached slices with a multi-host fetch and return one
+ * newest-first timeline for the currently configured hosts.
+ */
+export function reconcilePromptHistoryCache(
+  storage: PromptHistoryStorage | null | undefined,
+  hosts: readonly PromptHistoryCacheHost[],
+  liveEntries: readonly CachedPromptHistoryEntry[],
+  refreshedHostIds: readonly string[],
+): CachedPromptHistoryEntry[] {
+  // Registry hydration can briefly expose no hosts at startup. That is not an
+  // authoritative "forget everything" event, so surface the last-good cache
+  // without erasing it; the next registry update will scope it normally.
+  if (hosts.length === 0) return chronological(readPromptHistoryCache(storage));
+  const hostsById = new Map(hosts.map((host) => [host.hostId, host]));
+  const refreshed = new Set(refreshedHostIds.filter((id) => hostsById.has(id)));
+  const merged = readPromptHistoryCache(storage).filter(
+    (entry) => hostsById.has(entry.hostId) && !refreshed.has(entry.hostId),
+  );
+
+  for (const entry of liveEntries) {
+    const host = hostsById.get(entry.hostId);
+    const parsed = parseEntry(entry);
+    if (!host || !refreshed.has(entry.hostId) || !parsed) continue;
+    merged.push({ ...parsed, hostLabel: host.hostLabel });
+  }
+
+  const bounded = chronological(
+    hosts.flatMap((host) =>
+      merged
+        .filter((entry) => entry.hostId === host.hostId)
+        .sort((a, b) => b.used_at - a.used_at)
+        .slice(0, PROMPT_HISTORY_PER_HOST_LIMIT),
+    ),
+  ).map((entry) => ({
+    ...entry,
+    hostLabel: hostsById.get(entry.hostId)?.hostLabel ?? entry.hostLabel,
+  }));
+
+  if (storage) {
+    try {
+      const cached = fitCacheBudget(bounded);
+      storage.setItem(
+        PROMPT_HISTORY_CACHE_KEY,
+        JSON.stringify({
+          version: 1,
+          entries: cached,
+        } satisfies PromptHistoryCacheWire),
+      );
+    } catch {
+      // Private browsing and full quotas must not disable live history recall.
+    }
+  }
+  return bounded;
+}
+
+/** Persist a just-accepted prompt before the host can go offline or reload. */
+export function recordPromptHistoryCache(
+  storage: PromptHistoryStorage | null | undefined,
+  hosts: readonly PromptHistoryCacheHost[],
+  hostId: string,
+  entry: PromptHistoryLiveEntry,
+): CachedPromptHistoryEntry[] {
+  const host = hosts.find((candidate) => candidate.hostId === hostId);
+  if (!host) return chronological(readPromptHistoryCache(storage));
+  const hostEntries = readPromptHistoryCache(storage).filter(
+    (cached) => cached.hostId === hostId,
+  );
+  return reconcilePromptHistoryCache(
+    storage,
+    hosts,
+    [{ ...entry, hostId, hostLabel: host.hostLabel }, ...hostEntries],
+    [hostId],
+  );
+}
+
+export interface PromptHistoryFleetHost<T> extends PromptHistoryCacheHost {
+  fetchable: boolean;
+  source: T;
+}
+
+export interface PromptHistoryLiveEntry {
+  prompt: string;
+  model: string;
+  used_at: number;
+}
+
+/**
+ * One shared fan-out/stale-response authority for desktop and web Create.
+ * Secrets may exist in `source`, but only normalized entry metadata reaches
+ * `reconcilePromptHistoryCache` and persistence.
+ */
+export class PromptHistoryCoordinator {
+  private epoch = 0;
+
+  async load<T>(
+    storage: PromptHistoryStorage | null | undefined,
+    hosts: readonly PromptHistoryFleetHost<T>[],
+    fetchHost: (source: T) => Promise<readonly PromptHistoryLiveEntry[]>,
+  ): Promise<CachedPromptHistoryEntry[] | null> {
+    const epoch = ++this.epoch;
+    const targets = hosts.filter((host) => host.fetchable);
+    const settled = await Promise.allSettled(
+      targets.map(async (host) => ({
+        host,
+        entries: await fetchHost(host.source),
+      })),
+    );
+    if (epoch !== this.epoch) return null;
+
+    const refreshedHostIds: string[] = [];
+    const liveEntries: CachedPromptHistoryEntry[] = [];
+    for (const result of settled) {
+      if (result.status !== "fulfilled") continue;
+      refreshedHostIds.push(result.value.host.hostId);
+      for (const entry of result.value.entries) {
+        liveEntries.push({
+          ...entry,
+          hostId: result.value.host.hostId,
+          hostLabel: result.value.host.hostLabel,
+        });
+      }
+    }
+    return reconcilePromptHistoryCache(
+      storage,
+      hosts,
+      liveEntries,
+      refreshedHostIds,
+    );
+  }
+
+  invalidate(): void {
+    this.epoch += 1;
+  }
+}

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -831,23 +831,3 @@ export async function deleteModel(model: string): Promise<ModelRemovalResult> {
   }
   return (await res.json()) as ModelRemovalResult;
 }
-
-/// Prompt history for ↑/↓ recall in the Create composer (`GET /api/history`,
-/// newest-first). Returns just the prompt strings; the server also carries the
-/// model + timestamp, which the composer doesn't need. Never throws — a server
-/// without the history route just yields an empty list so ↑/↓ falls back to
-/// plain caret movement.
-export async function fetchPromptHistory(limit = 100): Promise<string[]> {
-  try {
-    const res = await fetch(`${base}/api/history?limit=${limit}`);
-    if (!res.ok) return [];
-    const body = (await res.json()) as {
-      entries?: { prompt?: string }[];
-    };
-    return (body.entries ?? [])
-      .map((e) => (e.prompt ?? "").trim())
-      .filter((p) => p.length > 0);
-  } catch {
-    return [];
-  }
-}

--- a/web/src/pages/CreatePage.test.ts
+++ b/web/src/pages/CreatePage.test.ts
@@ -122,6 +122,14 @@ const placementPreviewMock = vi.hoisted(() =>
     },
   })),
 );
+const promptHistoryApiMock = vi.hoisted(() =>
+  vi.fn(async () => ({ entries: [] })),
+);
+
+vi.mock("@studio/api/client", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@studio/api/client")>()),
+  apiJsonTo: promptHistoryApiMock,
+}));
 
 vi.mock("@studio/api/generationPlacement", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@studio/api/generationPlacement")>()),
@@ -308,6 +316,8 @@ describe("CreatePage layout and behavior", () => {
     generateFormTesting.resetForTest();
     resetNotifications();
     submitMock.mockClear();
+    promptHistoryApiMock.mockReset();
+    promptHistoryApiMock.mockResolvedValue({ entries: [] });
     placementPreviewMock.mockReset();
     placementPreviewMock.mockResolvedValue({
       version: 1,
@@ -3290,6 +3300,8 @@ describe("CreatePage host routing", () => {
     generateFormTesting.resetForTest();
     resetNotifications();
     submitMock.mockClear();
+    promptHistoryApiMock.mockReset();
+    promptHistoryApiMock.mockResolvedValue({ entries: [] });
     placementPreviewMock.mockReset();
     placementPreviewMock.mockResolvedValue({
       version: 1,

--- a/web/src/pages/CreatePage.test.ts
+++ b/web/src/pages/CreatePage.test.ts
@@ -188,7 +188,6 @@ vi.mock("../api", async (importOriginal) => {
     listGallery: vi.fn(async () => [entry]),
     deleteGalleryImage: vi.fn(async () => undefined),
     upscaleStream: upscaleStreamMock,
-    fetchPromptHistory: vi.fn(async () => []),
     imageUrl: (name: string) => `/api/gallery/image/${name}`,
     thumbnailUrl: (name: string) => `/api/gallery/thumbnail/${name}`,
     fetchChainLimits: fetchChainLimitsMock,

--- a/web/src/pages/CreatePage.vue
+++ b/web/src/pages/CreatePage.vue
@@ -123,13 +123,19 @@ import {
   deleteGalleryImage,
   expandPrompt,
   fetchChainLimits,
-  fetchPromptHistory,
   getChainJob,
   imageUrl,
   listGallery,
   upscaleStream,
   type StreamTarget,
 } from "../api";
+import { apiJsonTo } from "@studio/api/client";
+import {
+  availablePromptHistoryStorage,
+  PromptHistoryCoordinator,
+  promptHistoryHostSignature,
+  recordPromptHistoryCache,
+} from "@studio/lib/promptHistoryCache";
 import type {
   PromptTransformProvenanceWire,
   RemixDimension,
@@ -1246,9 +1252,34 @@ async function refreshGallery() {
   }
 }
 
+const promptHistoryCoordinator = new PromptHistoryCoordinator();
 async function refreshHistory() {
-  promptHistory.value = await fetchPromptHistory();
+  const history = await promptHistoryCoordinator.load(
+    availablePromptHistoryStorage(),
+    routing.hosts.value.map((host) => ({
+      hostId: host.id,
+      hostLabel: host.label,
+      fetchable: host.status === "ready",
+      source: { baseUrl: host.url, apiKey: host.apiKey ?? null },
+    })),
+    async (target) => {
+      const listing = await apiJsonTo<{
+        entries?: Array<{ prompt: string; model: string; used_at: number }>;
+      }>(target, "/api/history?limit=100");
+      return listing.entries ?? [];
+    },
+  );
+  if (history) promptHistory.value = history.map((entry) => entry.prompt);
 }
+
+// The first call commonly lands while registry hosts are still connecting.
+// Re-run on every reachability transition so the cache is visible offline and
+// each newly reachable host is folded into the same chronological timeline.
+watch(
+  () => promptHistoryHostSignature(routing.hosts.value),
+  () => void refreshHistory(),
+  { immediate: true },
+);
 
 const doneJobIds = computed(() =>
   stream.jobs.value
@@ -3365,6 +3396,15 @@ async function onSubmitInner(allowStaleQuick = false) {
   quickPrepared.value = null;
   // Push to history immediately so ↑ recalls it before the server round-trips.
   composerCardRef.value?.record(req.prompt);
+  recordPromptHistoryCache(
+    availablePromptHistoryStorage(),
+    routing.hosts.value.map((host) => ({
+      hostId: host.id,
+      hostLabel: host.label,
+    })),
+    route.hostId,
+    { prompt: req.prompt, model: req.model, used_at: Date.now() },
+  );
   if (
     form.state.value.seedMode === "increment" &&
     form.state.value.seed !== null
@@ -4206,6 +4246,7 @@ onMounted(async () => {
 });
 
 onBeforeUnmount(() => {
+  promptHistoryCoordinator.invalidate();
   stopAutoRefresh();
   clearSequencePreviews();
   phoneQuery?.removeEventListener?.("change", syncPhone);


### PR DESCRIPTION
## Summary
- merge prompt history chronologically across every reachable desktop and web host
- retain a bounded, validated last-good cache for offline hosts and persist accepted prompts before settlement
- harden host removal, stale responses, denied storage, maximum-size prompts, and empty-history clears
- stop desktop from swallowing ArrowUp when no history is available

## Validation
- `nix develop -c bun run test:studio` (932 passed)
- focused desktop history/composer tests (27 passed)
- focused web Create/composer tests (122 passed)
- `nix develop -c bun run build:web`
- `nix develop -c bun run build:desktop`
- rendered web Create QA with all configured engines offline
- independent agent peer review, findings addressed, final closure clean

## Issue audit
No matching open issue was found for prompt history, ArrowUp recall, or offline history caching.