### PR TITLE
fix(ios): restore cached print settings offline

### DIFF
--- a/changelog.d/1182-ios-offline-reuse.md
+++ b/changelog.d/1182-ios-offline-reuse.md
@@ -1,0 +1,8 @@
+- **iPhone Library can reuse saved print settings while a machine is offline.**
+  Library now caches the non-secret model and capability snapshot needed to
+  interpret each server instance's print metadata, restores settings from that
+  snapshot immediately, and refreshes it in the background. A missing snapshot
+  gets a bounded Retry-able load instead of an endless spinner. Print preview's
+  Close control remains available during reuse and source restoration, and a
+  dismissed attempt cannot later alter Create or navigate when its host finally
+  responds ([#1182](https://github.com/utensils/mold/issues/1182)).

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -5,7 +5,12 @@ import { IDBFactory } from "fake-indexeddb";
 import { installMemoryLocalStorage } from "../lib/testSupport/memoryLocalStorage";
 import type { GalleryImage, ModelEntry, ServerStatus } from "../lib/api/types";
 import { applyModelDefaults, type GenerateForm } from "../lib/generateForm";
-import { loadCachedGallery, storeCachedGallery, storeCachedGalleryMedia } from "./galleryCache";
+import {
+  loadCachedGallery,
+  storeCachedGallery,
+  storeCachedGalleryMedia,
+  storeCachedHostPresentation,
+} from "./galleryCache";
 
 const {
   invoke,
@@ -372,6 +377,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   wrapper?.unmount();
   wrapper = null;
   document.body.innerHTML = "";
@@ -5602,6 +5608,365 @@ describe("MobileApp primary navigation", () => {
 });
 
 describe("MobileApp gallery", () => {
+  it("reuses a cached print immediately while its host is offline", async () => {
+    Object.defineProperty(globalThis, "indexedDB", {
+      configurable: true,
+      value: new IDBFactory(),
+    });
+    localStorage.setItem(
+      "mold.mobile.hosts.v1",
+      JSON.stringify([
+        {
+          id: "url-derived-id",
+          instanceId: "studio-instance",
+          name: "Studio",
+          baseUrl: target.baseUrl,
+          online: false,
+        },
+      ]),
+    );
+    await storeCachedGallery("studio-instance", [print]);
+    await storeCachedHostPresentation({
+      hostId: "studio-instance",
+      updatedAt: 1,
+      instanceId: "studio-instance",
+      serverVersion: status.version,
+      models: [model],
+      capabilities: null,
+    });
+    await storeCachedGalleryMedia(
+      "studio-instance",
+      print.filename,
+      "thumbnail",
+      new Blob(["cached thumbnail"], { type: "image/webp" }),
+    );
+    apiJsonTo.mockRejectedValue(new Error("offline"));
+    apiFetchTo.mockRejectedValue(new Error("offline"));
+
+    wrapper = mountMobileApp();
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-tab-gallery']").trigger("click");
+    await vi.waitFor(() => expect(wrapper?.find("[data-test='gallery-item']").exists()).toBe(true));
+    await wrapper.get("[data-test='gallery-item']").trigger("click");
+    await wrapper.get("[data-test='gallery-viewer-reuse']").trigger("click");
+    await flushPromises();
+
+    await vi.waitFor(() =>
+      expect(wrapper?.find("[data-test='gallery-viewer']").exists()).toBe(false),
+    );
+    expect(wrapper.get("#mobile-prompt").element).toHaveProperty(
+      "value",
+      "a ship crossing violet lightning",
+    );
+    const reusedForm = wrapper.getComponent(MobileLoraControls).props("form") as GenerateForm;
+    expect(reusedForm).toMatchObject({ seed: "77", width: 768, height: 512, steps: 28 });
+  });
+
+  it("closes during a pending reuse and ignores its late host response", async () => {
+    Object.defineProperty(globalThis, "indexedDB", {
+      configurable: true,
+      value: new IDBFactory(),
+    });
+    localStorage.setItem(
+      "mold.mobile.hosts.v1",
+      JSON.stringify([
+        {
+          id: "url-derived-id",
+          instanceId: "studio-instance",
+          name: "Studio",
+          baseUrl: target.baseUrl,
+          online: false,
+        },
+      ]),
+    );
+    await storeCachedGallery("studio-instance", [print]);
+    await storeCachedGalleryMedia(
+      "studio-instance",
+      print.filename,
+      "thumbnail",
+      new Blob(["cached thumbnail"], { type: "image/webp" }),
+    );
+    const lateStatus = deferred<ServerStatus>();
+    const lateModels = deferred<ModelEntry[]>();
+    let statusCalls = 0;
+    let modelCalls = 0;
+    apiJsonTo.mockImplementation((_target: unknown, path: string) => {
+      if (path === "/api/status") {
+        statusCalls += 1;
+        return statusCalls === 1 ? Promise.reject(new Error("offline")) : lateStatus.promise;
+      }
+      if (path === "/api/models") {
+        modelCalls += 1;
+        return modelCalls === 1 ? Promise.reject(new Error("offline")) : lateModels.promise;
+      }
+      if (path === "/api/capabilities") return Promise.resolve(null);
+      if (path === "/api/activity") {
+        return Promise.resolve({ instance_id: "mobile-host", observed_at_unix_ms: 1, items: [] });
+      }
+      return Promise.reject(new Error(`Unexpected API path: ${path}`));
+    });
+    apiFetchTo.mockRejectedValue(new Error("offline"));
+
+    wrapper = mountMobileApp();
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-tab-gallery']").trigger("click");
+    await vi.waitFor(() => expect(wrapper?.find("[data-test='gallery-item']").exists()).toBe(true));
+    await wrapper.get("[data-test='gallery-item']").trigger("click");
+    await wrapper.get("[data-test='gallery-viewer-reuse']").trigger("click");
+    await vi.waitFor(() =>
+      expect(wrapper?.get("[data-test='gallery-viewer-reuse']").text()).toBe("Loading settings…"),
+    );
+
+    await wrapper.get("[data-test='gallery-viewer-close']").trigger("click");
+    expect(wrapper.find("[data-test='gallery-viewer']").exists()).toBe(false);
+    lateStatus.resolve({ ...status, instance_id: "studio-instance" });
+    lateModels.resolve([model]);
+    await flushPromises();
+
+    expect(wrapper.get("[data-test='mobile-tab-gallery']").attributes("aria-current")).toBe("page");
+    await wrapper.get("[data-test='mobile-tab-generate']").trigger("click");
+    expect(wrapper.get("#mobile-prompt").element).toHaveProperty("value", "");
+  });
+
+  it("closes during Use as source and ignores its late media response", async () => {
+    const still: GalleryImage = { ...print, filename: "source.png", format: "png" };
+    apiJsonTo.mockImplementation((_target: unknown, path: string) => {
+      if (path === "/api/status") return Promise.resolve(status);
+      if (path === "/api/models") return Promise.resolve([model]);
+      if (path === "/api/gallery") return Promise.resolve([still]);
+      if (path === "/api/activity") {
+        return Promise.resolve({ instance_id: "mobile-host", observed_at_unix_ms: 1, items: [] });
+      }
+      return Promise.reject(new Error(`Unexpected API path: ${path}`));
+    });
+    wrapper = mountMobileApp();
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-tab-gallery']").trigger("click");
+    await vi.waitFor(() => expect(wrapper?.find("[data-test='gallery-item']").exists()).toBe(true));
+    await wrapper.get("[data-test='gallery-item']").trigger("click");
+    const lateMedia = deferred<Response>();
+    apiFetchTo.mockReturnValue(lateMedia.promise);
+
+    await wrapper.get("[data-test='gallery-viewer-use-source']").trigger("click");
+    await vi.waitFor(() =>
+      expect(wrapper?.get("[data-test='gallery-viewer-use-source']").text()).toBe(
+        "Loading source…",
+      ),
+    );
+    await wrapper.get("[data-test='gallery-viewer-close']").trigger("click");
+    lateMedia.resolve({
+      headers: new Headers(),
+      blob: () => Promise.resolve(new Blob(["late source"], { type: "image/png" })),
+    } as Response);
+    await flushPromises();
+
+    expect(wrapper.get("[data-test='mobile-tab-gallery']").attributes("aria-current")).toBe("page");
+    await wrapper.get("[data-test='mobile-tab-generate']").trigger("click");
+    const liveForm = wrapper.getComponent(MobileLoraControls).props("form") as GenerateForm;
+    expect(liveForm.sourceImage).toBeNull();
+  });
+
+  it("labels retained in-memory models as saved after the host goes offline", async () => {
+    wrapper = mountMobileApp();
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-tab-gallery']").trigger("click");
+    await vi.waitFor(() => expect(wrapper?.find("[data-test='gallery-item']").exists()).toBe(true));
+    await wrapper.get("[data-test='gallery-item']").trigger("click");
+    const statusCalls = apiJsonTo.mock.calls.filter(([, path]) => path === "/api/status").length;
+    apiJsonTo.mockImplementation((_target: unknown, path: string) => {
+      if (path === "/api/status") return Promise.reject(new Error("offline"));
+      if (path === "/api/activity") {
+        return Promise.resolve({ instance_id: "mobile-host", observed_at_unix_ms: 1, items: [] });
+      }
+      return Promise.reject(new Error("offline"));
+    });
+    window.dispatchEvent(new Event("pageshow"));
+    await vi.waitFor(() =>
+      expect(
+        apiJsonTo.mock.calls.filter(([, path]) => path === "/api/status").length,
+      ).toBeGreaterThan(statusCalls),
+    );
+
+    await wrapper.get("[data-test='gallery-viewer-reuse']").trigger("click");
+    await vi.waitFor(() =>
+      expect(wrapper?.find("[data-test='gallery-viewer']").exists()).toBe(false),
+    );
+
+    expect(wrapper.get("[data-test='mobile-generation-summary']").text()).toContain(
+      "Saved model information was used and is refreshing in the background.",
+    );
+  });
+
+  it("times out a reuse even when the transport ignores AbortSignal", async () => {
+    Object.defineProperty(globalThis, "indexedDB", {
+      configurable: true,
+      value: new IDBFactory(),
+    });
+    localStorage.setItem(
+      "mold.mobile.hosts.v1",
+      JSON.stringify([
+        {
+          id: "url-derived-id",
+          instanceId: "studio-instance",
+          name: "Studio",
+          baseUrl: target.baseUrl,
+          online: false,
+        },
+      ]),
+    );
+    await storeCachedGallery("studio-instance", [print]);
+    await storeCachedGalleryMedia(
+      "studio-instance",
+      print.filename,
+      "thumbnail",
+      new Blob(["cached thumbnail"], { type: "image/webp" }),
+    );
+    apiJsonTo.mockRejectedValue(new Error("offline"));
+    apiFetchTo.mockRejectedValue(new Error("offline"));
+
+    wrapper = mountMobileApp();
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-tab-gallery']").trigger("click");
+    await vi.waitFor(() => expect(wrapper?.find("[data-test='gallery-item']").exists()).toBe(true));
+    await wrapper.get("[data-test='gallery-item']").trigger("click");
+    apiJsonTo.mockImplementation(() => new Promise(() => {}));
+    const realSetTimeout = globalThis.setTimeout;
+    const timeout = vi.spyOn(globalThis, "setTimeout").mockImplementation((handler, delay) => {
+      if (delay === 9_000) {
+        queueMicrotask(() => (handler as () => void)());
+        return 1 as unknown as ReturnType<typeof setTimeout>;
+      }
+      return realSetTimeout(handler, delay);
+    });
+
+    await wrapper.get("[data-test='gallery-viewer-reuse']").trigger("click");
+    await vi.waitFor(() =>
+      expect(wrapper?.get("[data-test='gallery-viewer-reuse']").text()).toBe("Reuse settings"),
+    );
+    timeout.mockRestore();
+
+    expect(wrapper.get("[role='alert']").text()).toContain(
+      "Loading saved settings from Studio timed out. Try again.",
+    );
+  });
+
+  it("finishes cached reuse when source restoration ignores AbortSignal", async () => {
+    Object.defineProperty(globalThis, "indexedDB", {
+      configurable: true,
+      value: new IDBFactory(),
+    });
+    localStorage.setItem(
+      "mold.mobile.hosts.v1",
+      JSON.stringify([
+        {
+          id: "url-derived-id",
+          instanceId: "studio-instance",
+          name: "Studio",
+          baseUrl: target.baseUrl,
+          online: false,
+        },
+      ]),
+    );
+    const conditioned = {
+      ...print,
+      metadata: { ...print.metadata, source_image_name: "missing-source.png" },
+    };
+    await storeCachedGallery("studio-instance", [conditioned]);
+    await storeCachedHostPresentation({
+      hostId: "studio-instance",
+      updatedAt: Date.now(),
+      instanceId: "studio-instance",
+      serverVersion: status.version,
+      models: [model],
+      capabilities: null,
+    });
+    await storeCachedGalleryMedia(
+      "studio-instance",
+      conditioned.filename,
+      "thumbnail",
+      new Blob(["cached thumbnail"], { type: "image/webp" }),
+    );
+    apiJsonTo.mockRejectedValue(new Error("offline"));
+    apiFetchTo.mockRejectedValue(new Error("offline"));
+
+    wrapper = mountMobileApp();
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-tab-gallery']").trigger("click");
+    await vi.waitFor(() => expect(wrapper?.find("[data-test='gallery-item']").exists()).toBe(true));
+    await wrapper.get("[data-test='gallery-item']").trigger("click");
+    apiFetchTo.mockImplementation(() => new Promise(() => {}));
+    const realSetTimeout = globalThis.setTimeout;
+    const timeout = vi.spyOn(globalThis, "setTimeout").mockImplementation((handler, delay) => {
+      if (delay === 9_000) {
+        queueMicrotask(() => (handler as () => void)());
+        return 1 as unknown as ReturnType<typeof setTimeout>;
+      }
+      return realSetTimeout(handler, delay);
+    });
+
+    await wrapper.get("[data-test='gallery-viewer-reuse']").trigger("click");
+    await vi.waitFor(() =>
+      expect(wrapper?.find("[data-test='gallery-viewer']").exists()).toBe(false),
+    );
+    timeout.mockRestore();
+
+    expect(wrapper.get("[data-test='mobile-generation-summary']").text()).toContain(
+      "The original source image is unavailable. Reattach it before developing.",
+    );
+  });
+
+  it("does not trust cached model data from a different known server version", async () => {
+    Object.defineProperty(globalThis, "indexedDB", {
+      configurable: true,
+      value: new IDBFactory(),
+    });
+    localStorage.setItem(
+      "mold.mobile.hosts.v1",
+      JSON.stringify([
+        {
+          id: "url-derived-id",
+          instanceId: "studio-instance",
+          name: "Studio",
+          baseUrl: target.baseUrl,
+          version: "2.0.0",
+          online: false,
+        },
+      ]),
+    );
+    await storeCachedGallery("studio-instance", [print]);
+    await storeCachedHostPresentation({
+      hostId: "studio-instance",
+      updatedAt: 1,
+      instanceId: "studio-instance",
+      serverVersion: "1.0.0",
+      models: [model],
+      capabilities: null,
+    });
+    await storeCachedGalleryMedia(
+      "studio-instance",
+      print.filename,
+      "thumbnail",
+      new Blob(["cached thumbnail"], { type: "image/webp" }),
+    );
+    apiJsonTo.mockRejectedValue(new Error("offline"));
+    apiFetchTo.mockRejectedValue(new Error("offline"));
+
+    wrapper = mountMobileApp();
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-tab-gallery']").trigger("click");
+    await vi.waitFor(() => expect(wrapper?.find("[data-test='gallery-item']").exists()).toBe(true));
+    await wrapper.get("[data-test='gallery-item']").trigger("click");
+    await wrapper.get("[data-test='gallery-viewer-reuse']").trigger("click");
+    await vi.waitFor(() =>
+      expect(wrapper?.find("[data-test='gallery-viewer-reuse']").attributes("aria-busy")).toBe(
+        "false",
+      ),
+    );
+
+    expect(wrapper.find("[data-test='gallery-viewer']").exists()).toBe(true);
+    expect(wrapper.get("[role='alert']").text()).toContain("Couldn’t load models from Studio");
+  });
+
   it("renders instance-scoped cached gallery metadata and thumbnails while its host is offline", async () => {
     Object.defineProperty(globalThis, "indexedDB", {
       configurable: true,
@@ -6439,7 +6804,11 @@ describe("MobileApp gallery", () => {
       ),
     );
 
-    expect(apiFetchTo).toHaveBeenCalledWith(target, "/api/gallery/image/source%20print.png");
+    expect(apiFetchTo).toHaveBeenCalledWith(
+      target,
+      "/api/gallery/image/source%20print.png",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
     expect(wrapper.get("[data-test='mobile-source-preview']").attributes("alt")).toBe(
       "source print.png",
     );

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -299,14 +299,18 @@ import {
   type MobileLibraryScope,
 } from "./libraryOrganization";
 import {
+  captureCachedHostFence,
   clearCachedGalleryHosts,
   loadCachedGallery,
   loadCachedGalleryMedia,
+  loadCachedHostPresentation,
   patchCachedGalleryPrints,
   pruneCachedGalleryMedia,
   removeCachedGalleryPrints,
   storeCachedGallery,
   storeCachedGalleryMedia,
+  storeCachedHostPresentation,
+  type CachedHostPresentation,
 } from "./galleryCache";
 import {
   MOBILE_GALLERY_COLUMNS_MAX,
@@ -395,6 +399,12 @@ interface PendingGalleryPrint extends MobileGalleryImage {
   cacheKey: string;
   hostName: string;
   target: ApiTarget;
+}
+
+interface ModelSnapshotIdentity {
+  cacheKey: string;
+  updatedAt: number;
+  serverVersion: string | null;
 }
 
 /** The Library's bottom-sheet editors (one open at a time). */
@@ -492,6 +502,7 @@ const HOST_PROBE_TIMEOUT_MS = 9_000;
  *  a deadline that fires with no route would manufacture a dead end. */
 const MOBILE_PLACEMENT_SETTLE_MS = 1_500;
 const GALLERY_HOST_TIMEOUT_MS = 9_000;
+const REUSE_PRESENTATION_TIMEOUT_MS = 9_000;
 const OUTPUT_OPTIONS = [
   { value: "single" as const, label: "One shot" },
   { value: "sequence" as const, label: "Sequence" },
@@ -554,6 +565,8 @@ const modelsHostId = ref("");
  *  to the union picker the automatic policies need. The browsed machine's copy
  *  is written by `refreshModels`; peers are filled in by `refreshRoutingModels`. */
 const modelsByHost = ref<Record<string, ModelEntry[]>>({});
+/** Identity and freshness authority for each in-memory model snapshot. */
+const modelSnapshotIdentities = ref<Record<string, ModelSnapshotIdentity>>({});
 /** Persisted generation target: a machine id, `auto`, or `capable`. */
 const generateTargetPolicy = ref(loadMobileGenerateTarget());
 const loadingModels = ref(false);
@@ -753,6 +766,10 @@ let pendingGallery: PendingGalleryPrint[] = [];
 /** Every concrete device copy behind the deduplicated Library tiles. */
 let galleryCopies: PendingGalleryPrint[] = [];
 let modelLoadEpoch = 0;
+let reusePrintEpoch = 0;
+let reusePrintController: AbortController | null = null;
+let sourceUseEpoch = 0;
+let sourceUseController: AbortController | null = null;
 let galleryRefreshRequested = false;
 let galleryRefreshDeferred = false;
 let galleryRefreshTask: Promise<void> | null = null;
@@ -2444,7 +2461,10 @@ async function refreshModels(): Promise<boolean> {
     host.online = true;
     host.version = status.version;
     host.hostname = status.hostname ?? undefined;
+    const priorCacheKey = mobileGalleryCacheKey(host);
     host.instanceId = status.instance_id ?? host.instanceId;
+    const nextCacheKey = mobileGalleryCacheKey(host);
+    if (priorCacheKey !== nextCacheKey) await clearCachedGalleryHosts([priorCacheKey]);
     captureHostTelemetry(hostId, status);
     expandCapabilities[hostId] = capabilities?.expand;
     serverCapabilities[hostId] = capabilities;
@@ -2454,6 +2474,22 @@ async function refreshModels(): Promise<boolean> {
     models.value = filterRestrictedModels(entries, capabilities);
     modelsHostId.value = hostId;
     modelsByHost.value = { ...modelsByHost.value, [hostId]: models.value };
+    modelSnapshotIdentities.value = {
+      ...modelSnapshotIdentities.value,
+      [hostId]: {
+        cacheKey: nextCacheKey,
+        updatedAt: Date.now(),
+        serverVersion: status.version ?? null,
+      },
+    };
+    await storeCachedHostPresentation({
+      hostId: nextCacheKey,
+      updatedAt: Date.now(),
+      instanceId: host.instanceId?.trim() || null,
+      serverVersion: status.version ?? null,
+      models: models.value,
+      capabilities,
+    });
     const selectedEntry = generationModels.value.find((model) => model.name === form.model);
     if (selectedEntry) {
       reconcileModelCapabilities(form, selectedEntry);
@@ -2487,30 +2523,54 @@ async function refreshRoutingModels(): Promise<void> {
     peers.map(async (host) => {
       try {
         const target = mobileHostTarget(host);
+        const cacheKey = mobileGalleryCacheKey(host);
+        const serverVersion = host.version ?? null;
         const [entries, capabilities] = await Promise.all([
           apiJsonTo<ModelEntry[]>(target, "/api/models"),
           apiJsonTo<ServerCapabilities>(target, "/api/capabilities").catch(() => null),
         ]);
+        const currentHost = hosts.value.find((candidate) => candidate.id === host.id);
+        if (
+          !currentHost ||
+          mobileGalleryCacheKey(currentHost) !== cacheKey ||
+          currentHost.baseUrl !== target.baseUrl ||
+          (currentHost.apiKey || null) !== target.apiKey
+        ) {
+          return null;
+        }
         if (capabilities !== null) {
           expandCapabilities[host.id] = capabilities.expand;
           serverCapabilities[host.id] = capabilities;
         }
-        return [host.id, filterRestrictedModels(entries, capabilities)] as const;
+        return [
+          host.id,
+          { cacheKey, updatedAt: Date.now(), serverVersion } satisfies ModelSnapshotIdentity,
+          filterRestrictedModels(entries, capabilities),
+        ] as const;
       } catch {
         return null;
       }
     }),
   );
   if (unmounted) return;
-  const connected = new Set(connectedHosts.value.map((host) => host.id));
   const next: Record<string, ModelEntry[]> = {};
+  const nextIdentities: Record<string, ModelSnapshotIdentity> = {};
   for (const [id, entries] of Object.entries(modelsByHost.value)) {
-    if (connected.has(id)) next[id] = entries;
+    const host = connectedHosts.value.find((candidate) => candidate.id === id);
+    const identity = modelSnapshotIdentities.value[id];
+    if (host && identity?.cacheKey === mobileGalleryCacheKey(host)) {
+      next[id] = entries;
+      nextIdentities[id] = identity;
+    }
   }
   for (const snapshot of snapshots) {
-    if (snapshot) next[snapshot[0]] = snapshot[1];
+    if (snapshot) {
+      next[snapshot[0]] = snapshot[2];
+      nextIdentities[snapshot[0]] = snapshot[1];
+    }
   }
   modelsByHost.value = next;
+  modelSnapshotIdentities.value = nextIdentities;
   // The union just grew: a machine other than the browsed one may hold the
   // only generation model in the fleet, and the picker must land on it the
   // same way `refreshModels` lands on the browsed machine's first model.
@@ -5205,23 +5265,60 @@ async function loadMoreGalleryPage(): Promise<void> {
 
 async function reusePrint(print: GalleryPrint): Promise<void> {
   if (reusingPrint.value || print.metadata_synthetic) return;
+  const epoch = ++reusePrintEpoch;
+  reusePrintController?.abort();
+  const controller = new AbortController();
+  reusePrintController = controller;
   reusingPrint.value = true;
   reusePrintError.value = "";
   try {
     if (selectedHostId.value !== print.hostId) {
       selectedHostId.value = print.hostId;
     }
-    if (modelsHostId.value !== print.hostId) {
-      if (!(await refreshModels())) {
-        reusePrintError.value = `Couldn’t load models from ${print.hostName}. Check the host and try again.`;
-        return;
-      }
+    const printHost = hosts.value.find((candidate) => candidate.id === print.hostId);
+    const inMemoryIdentity = modelSnapshotIdentities.value[print.hostId];
+    const inMemoryModels =
+      inMemoryIdentity?.cacheKey === print.cacheKey &&
+      (!printHost?.version ||
+        !inMemoryIdentity.serverVersion ||
+        inMemoryIdentity.serverVersion === printHost.version)
+        ? modelsByHost.value[print.hostId]
+        : undefined;
+    let reuseModels =
+      inMemoryModels?.filter((model) => model.downloaded && isGenerationModel(model)) ?? [];
+    let usedCachedPresentationAt: number | null =
+      inMemoryModels && printHost?.online !== true ? (inMemoryIdentity?.updatedAt ?? null) : null;
+    const cachedPresentation = await loadCachedHostPresentation(print.cacheKey);
+    if (cancelledReuse(epoch, controller)) return;
+    const cacheMatchesHost =
+      cachedPresentation !== null &&
+      (!cachedPresentation.instanceId || cachedPresentation.instanceId === print.cacheKey) &&
+      (!printHost?.version ||
+        !cachedPresentation.serverVersion ||
+        cachedPresentation.serverVersion === printHost.version);
+    const validCachedPresentation = cacheMatchesHost ? cachedPresentation : null;
+    if (reuseModels.length === 0 && validCachedPresentation) {
+      reuseModels = validCachedPresentation.models.filter(
+        (model) => model.downloaded && isGenerationModel(model),
+      );
+      if (reuseModels.length > 0) usedCachedPresentationAt = validCachedPresentation.updatedAt;
     }
-    if (generationModels.value.length === 0) {
+    if (reuseModels.length === 0) {
+      const presentation = await readReusePresentation(print, controller.signal);
+      if (cancelledReuse(epoch, controller)) return;
+      reuseModels = presentation.models.filter(
+        (model) => model.downloaded && isGenerationModel(model),
+      );
+    } else {
+      // Saved state is authoritative for this interaction. Refresh it for the
+      // next one without holding the viewer or mutating this reuse attempt.
+      void readReusePresentation(print, new AbortController().signal).catch(() => undefined);
+    }
+    if (reuseModels.length === 0) {
       reusePrintError.value = `${print.hostName} has no downloaded models available.`;
       return;
     }
-    const reuse = applyMobileGalleryMetadata(form, print.metadata, generationModels.value);
+    const reuse = applyMobileGalleryMetadata(form, print.metadata, reuseModels);
     if (reuse.sequenceUnsupportedReason) {
       reusePrintError.value = reuse.sequenceUnsupportedReason;
       return;
@@ -5229,7 +5326,14 @@ async function reusePrint(print: GalleryPrint): Promise<void> {
     // The print's own saved title comes back with its settings; the Library
     // title (a later rename) wins over the metadata stamp when it exists.
     printTitle.value = organizationOf(print)?.title ?? reuse.title;
-    if (!reuse.sequence) await restoreOrdinaryReusedSource(print);
+    const sourceRestoreNotice = !reuse.sequence
+      ? await restoreOrdinaryReusedSource(
+          print,
+          controller.signal,
+          () => !cancelledReuse(epoch, controller),
+        )
+      : null;
+    if (cancelledReuse(epoch, controller)) return;
     if (reuse.sequence) {
       // A sequence print reloads the clip rail as a NEW draft: no edit
       // session, nothing cached (iPhone has no chain-detail recovery route,
@@ -5257,6 +5361,14 @@ async function reusePrint(print: GalleryPrint): Promise<void> {
       draft.lastSingleModel = null;
     }
     const notes: string[] = [];
+    if (usedCachedPresentationAt !== null) {
+      const ageMinutes = Math.max(0, Math.floor((Date.now() - usedCachedPresentationAt) / 60_000));
+      notes.push(
+        ageMinutes < 1
+          ? "Saved model information was used and is refreshing in the background."
+          : `Model information saved ${ageMinutes} min ago was used and is refreshing in the background.`,
+      );
+    }
     if (reuse.substitutedModel) {
       notes.push(
         `The original model isn’t installed on ${print.hostName}; using ${reuse.modelName}.`,
@@ -5265,13 +5377,12 @@ async function reusePrint(print: GalleryPrint): Promise<void> {
     if (reuse.sequence) {
       notes.push(sequenceReuseNote(reuse.sequence.clips.length, reuse.sequence.lossy));
       if (reuse.sequence.raised > 0) {
-        notes.push(
-          sequenceReuseClampNote(modelDisplayNameForId(form.model, generationModels.value)),
-        );
+        notes.push(sequenceReuseClampNote(modelDisplayNameForId(form.model, reuseModels)));
       }
     } else if (notes.length === 0) {
       notes.push("Prompt settings restored");
     }
+    if (sourceRestoreNotice) notes.push(sourceRestoreNotice);
     // A first/last-frame print restores every knob except its closing still:
     // saved metadata records each keyframe's name and digest, never the bytes
     // (`applyMetadataToForm` already cleared `form.endFrame`). Say so, the same
@@ -5285,7 +5396,7 @@ async function reusePrint(print: GalleryPrint): Promise<void> {
       Boolean(print.metadata.source_image_sha256 ?? print.metadata.source_image_name),
     );
     if (endFrameNotice) notes.push(endFrameNotice);
-    setGenerationStatus(notes.join(" · "), !!endFrameNotice);
+    setGenerationStatus(notes.join(" · "), !!endFrameNotice || !!sourceRestoreNotice);
     // FL2VA reuse leaves bytes-less boundary descriptors; when the original
     // was a gallery image its bytes are still on the print's host — fetch
     // them so the wells fill instead of demanding a reattach.
@@ -5296,17 +5407,100 @@ async function reusePrint(print: GalleryPrint): Promise<void> {
     galleryRefreshDeferred = false;
     tab.value = "generate";
     void nextTick(() => document.querySelector<HTMLTextAreaElement>("#mobile-prompt")?.focus());
+  } catch (error) {
+    if (!cancelledReuse(epoch, controller)) {
+      reusePrintError.value =
+        error instanceof Error && error.message.includes("timed out")
+          ? error.message
+          : `Couldn’t load models from ${print.hostName}. ${describeTransportError(error, print.hostName)}`;
+    }
   } finally {
-    reusingPrint.value = false;
+    if (epoch === reusePrintEpoch) {
+      reusingPrint.value = false;
+      reusePrintController = null;
+    }
   }
 }
 
-async function restoreOrdinaryReusedSource(print: GalleryPrint): Promise<void> {
-  if (caps.value.sourceImageMode !== "single") return;
+function cancelledReuse(epoch: number, controller: AbortController): boolean {
+  return unmounted || controller.signal.aborted || epoch !== reusePrintEpoch;
+}
+
+async function readReusePresentation(
+  print: GalleryPrint,
+  signal: AbortSignal,
+): Promise<CachedHostPresentation> {
+  const host = hosts.value.find((candidate) => candidate.id === print.hostId);
+  if (!host) throw new Error("This machine is no longer configured.");
+  const target = mobileHostTarget(host);
+  const cacheFence = captureCachedHostFence(print.cacheKey);
+  const timeoutController = new AbortController();
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+  let rejectCancellation: ((reason: Error) => void) | null = null;
+  const cancelled = new Promise<never>((_resolve, reject) => {
+    rejectCancellation = reject;
+  });
+  const abort = () => {
+    timeoutController.abort();
+    rejectCancellation?.(new DOMException("Reuse settings was cancelled", "AbortError"));
+  };
+  signal.addEventListener("abort", abort, { once: true });
+  if (signal.aborted) abort();
+  timeout = setTimeout(() => {
+    timeoutController.abort();
+    rejectCancellation?.(
+      new Error(`Loading saved settings from ${print.hostName} timed out. Try again.`),
+    );
+  }, REUSE_PRESENTATION_TIMEOUT_MS);
+  try {
+    const [status, entries, capabilities] = await Promise.race([
+      Promise.all([
+        apiJsonTo<ServerStatus>(target, "/api/status", { signal: timeoutController.signal }),
+        apiJsonTo<ModelEntry[]>(target, "/api/models", { signal: timeoutController.signal }),
+        apiJsonTo<ServerCapabilities>(target, "/api/capabilities", {
+          signal: timeoutController.signal,
+        }).catch(() => null),
+      ]),
+      cancelled,
+    ]);
+    const instanceId = status.instance_id?.trim() || null;
+    const expectedInstanceId =
+      print.cacheKey !== print.hostId ? print.cacheKey : host.instanceId?.trim();
+    if (expectedInstanceId && instanceId !== expectedInstanceId) {
+      throw new Error("This machine now reports a different server identity.");
+    }
+    const currentHost = hosts.value.find((candidate) => candidate.id === print.hostId);
+    if (!currentHost || mobileGalleryCacheKey(currentHost) !== print.cacheKey) {
+      throw new Error("This machine changed while its saved settings were refreshing.");
+    }
+    const presentation: CachedHostPresentation = {
+      hostId: print.cacheKey,
+      updatedAt: Date.now(),
+      instanceId,
+      serverVersion: status.version ?? null,
+      models: filterRestrictedModels(entries, capabilities),
+      capabilities,
+    };
+    await storeCachedHostPresentation(presentation, cacheFence);
+    return presentation;
+  } finally {
+    if (timeout !== null) clearTimeout(timeout);
+    signal.removeEventListener("abort", abort);
+    rejectCancellation = null;
+  }
+}
+
+async function restoreOrdinaryReusedSource(
+  print: GalleryPrint,
+  signal: AbortSignal,
+  isCurrent: () => boolean,
+): Promise<string | null> {
+  if (caps.value.sourceImageMode !== "single") return null;
   const restoredSourceFit = parseSourceFitPolicy(print.metadata.source_fit);
   const stored = await restoreGenerationSourceMedia(print.metadata.source_image_sha256).catch(
     () => null,
   );
+  if (!isCurrent()) return null;
   if (stored) {
     preserveRestoredSourceCanvas(stored.base64);
     form.sourceImage = stored.base64;
@@ -5315,16 +5509,17 @@ async function restoreOrdinaryReusedSource(print: GalleryPrint): Promise<void> {
     // image. Let that watcher settle, then reassert provenance attributes:
     // Library reuse is restoration, not a new pick.
     await nextTick();
+    if (!isCurrent()) return null;
     form.sourceImageWidth = stored.width ?? null;
     form.sourceImageHeight = stored.height ?? null;
     form.width = print.metadata.generation_width ?? print.metadata.width;
     form.height = print.metadata.generation_height ?? print.metadata.height;
     if (restoredSourceFit) form.sourceFit = restoredSourceFit;
-    return;
+    return null;
   }
 
   const filename = print.metadata.source_image_name;
-  if (!filename) return;
+  if (!filename) return null;
   const candidates = new Map<string, ApiTarget>([[print.hostId, print.target]]);
   for (const entry of gallery.value) {
     if (entry.filename === filename && !candidates.has(entry.hostId)) {
@@ -5333,30 +5528,68 @@ async function restoreOrdinaryReusedSource(print: GalleryPrint): Promise<void> {
   }
   for (const target of candidates.values()) {
     try {
-      const response = await apiFetchTo(target, galleryMediaPath(filename, "host"));
-      if (!response.ok) continue;
-      const blob = await response.blob();
-      if (!blob.size) continue;
-      const base64 = await blobToBase64(blob);
-      const dimensions = imageDimensionsFromBase64(base64);
-      preserveRestoredSourceCanvas(base64);
-      form.sourceImage = base64;
+      const source = await readReusedSourceCandidate(target, filename, signal);
+      if (!isCurrent()) return null;
+      if (!source) continue;
+      preserveRestoredSourceCanvas(source.base64);
+      form.sourceImage = source.base64;
       form.sourceImageName = filename;
       await nextTick();
-      form.sourceImageWidth = dimensions?.width ?? null;
-      form.sourceImageHeight = dimensions?.height ?? null;
+      if (!isCurrent()) return null;
+      form.sourceImageWidth = source.dimensions?.width ?? null;
+      form.sourceImageHeight = source.dimensions?.height ?? null;
       form.width = print.metadata.generation_width ?? print.metadata.width;
       form.height = print.metadata.generation_height ?? print.metadata.height;
       if (restoredSourceFit) form.sourceFit = restoredSourceFit;
-      return;
+      return null;
     } catch {
       // Continue through every host that advertises the named source.
     }
   }
-  setGenerationStatus(
-    "The original source image is unavailable. Reattach it before developing.",
-    true,
-  );
+  if (!isCurrent()) return null;
+  return "The original source image is unavailable. Reattach it before developing.";
+}
+
+async function readReusedSourceCandidate(
+  target: ApiTarget,
+  filename: string,
+  signal: AbortSignal,
+): Promise<{ base64: string; dimensions: SourceDimensions | null } | null> {
+  const controller = new AbortController();
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+  let rejectDeadline: ((reason: Error) => void) | null = null;
+  const deadline = new Promise<never>((_resolve, reject) => {
+    rejectDeadline = reject;
+  });
+  const abort = () => {
+    controller.abort();
+    rejectDeadline?.(new DOMException("Reuse source restoration was cancelled", "AbortError"));
+  };
+  signal.addEventListener("abort", abort, { once: true });
+  if (signal.aborted) abort();
+  timeout = setTimeout(() => {
+    controller.abort();
+    rejectDeadline?.(new Error("Source restoration timed out"));
+  }, REUSE_PRESENTATION_TIMEOUT_MS);
+  try {
+    return await Promise.race([
+      (async () => {
+        const response = await apiFetchTo(target, galleryMediaPath(filename, "host"), {
+          signal: controller.signal,
+        });
+        if (response.ok === false) return null;
+        const blob = await response.blob();
+        if (!blob.size) return null;
+        const base64 = await blobToBase64(blob);
+        return { base64, dimensions: imageDimensionsFromBase64(base64) };
+      })(),
+      deadline,
+    ]);
+  } finally {
+    if (timeout !== null) clearTimeout(timeout);
+    signal.removeEventListener("abort", abort);
+    rejectDeadline = null;
+  }
 }
 
 /** Fetch bytes for the reuse-restored FL2VA boundary descriptors, within the
@@ -5418,10 +5651,18 @@ async function restoreReusedH3BoundaryMedia(print: {
 async function useSelectedPrintAsSource(): Promise<void> {
   const print = selectedPrint.value;
   if (!print || !canUseSelectedPrintAsSource.value || usingPrintAsSource.value) return;
+  const epoch = ++sourceUseEpoch;
+  sourceUseController?.abort();
+  const controller = new AbortController();
+  sourceUseController = controller;
+  const isCurrent = () => !unmounted && !controller.signal.aborted && epoch === sourceUseEpoch;
   usingPrintAsSource.value = true;
   reusePrintError.value = "";
   try {
-    const response = await apiFetchTo(print.target, galleryMediaPath(print.filename, "host"));
+    const response = await apiFetchTo(print.target, galleryMediaPath(print.filename, "host"), {
+      signal: controller.signal,
+    });
+    if (!isCurrent()) return;
     const h3Task = minimaxH3TaskForModel(form.model);
     const attachmentMode = caps.value.sourceImageMode !== "single";
     const existingBytes = inlineGenerationMediaBytes(
@@ -5438,9 +5679,11 @@ async function useSelectedPrintAsSource(): Promise<void> {
       throw new Error(MOBILE_MEDIA_BUDGET_ERROR);
     }
     const blob = await response.blob();
+    if (!isCurrent()) return;
     if (blob.size === 0) throw new Error("That gallery image is empty.");
     if (exceedsBudget(blob.size)) throw new Error(MOBILE_MEDIA_BUDGET_ERROR);
     const base64 = await blobToBase64(blob);
+    if (!isCurrent()) return;
     if (h3Task) {
       const dimensions = imageDimensionsFromBase64(base64) ?? {
         width: print.metadata.width,
@@ -5487,9 +5730,12 @@ async function useSelectedPrintAsSource(): Promise<void> {
     galleryRefreshDeferred = false;
     tab.value = "generate";
   } catch (error) {
-    reusePrintError.value = describeTransportError(error, print.hostName);
+    if (isCurrent()) reusePrintError.value = describeTransportError(error, print.hostName);
   } finally {
-    usingPrintAsSource.value = false;
+    if (epoch === sourceUseEpoch) {
+      usingPrintAsSource.value = false;
+      sourceUseController = null;
+    }
   }
 }
 
@@ -6746,7 +6992,14 @@ function navigateSelectedPrint(delta: -1 | 1): void {
 }
 
 function closePrint(): void {
-  if (reusingPrint.value || usingPrintAsSource.value) return;
+  reusePrintEpoch += 1;
+  reusePrintController?.abort();
+  reusePrintController = null;
+  reusingPrint.value = false;
+  sourceUseEpoch += 1;
+  sourceUseController?.abort();
+  sourceUseController = null;
+  usingPrintAsSource.value = false;
   reusePrintError.value = "";
   selectedPrint.value = null;
   if (galleryRefreshDeferred || galleryRefreshRequested) {
@@ -7081,6 +7334,10 @@ onMounted(async () => {
 
 onBeforeUnmount(() => {
   unmounted = true;
+  reusePrintEpoch += 1;
+  reusePrintController?.abort();
+  sourceUseEpoch += 1;
+  sourceUseController?.abort();
   if (pairingScannerOpen.value) {
     pairingScannerCancelled = true;
     void cancelBarcodeScanner().catch(() => undefined);

--- a/desktop/src/mobile/MobileGalleryViewer.test.ts
+++ b/desktop/src/mobile/MobileGalleryViewer.test.ts
@@ -129,6 +129,19 @@ describe("MobileGalleryViewer", () => {
     expect(view.emitted("reuse")).toHaveLength(1);
   });
 
+  it("always allows dismissal while settings are loading", async () => {
+    const view = mountViewer();
+    await view.setProps({ reusing: true });
+
+    const close = view.get("[data-test='gallery-viewer-close']");
+    expect(close.attributes("disabled")).toBeUndefined();
+    await close.trigger("click");
+    expect(view.emitted("close")).toHaveLength(1);
+
+    await view.get("dialog").trigger("cancel");
+    expect(view.emitted("close")).toHaveLength(2);
+  });
+
   it("shows the recorded runtime pipeline for an LTX video", async () => {
     const view = mountViewer({
       ...image,

--- a/desktop/src/mobile/MobileGalleryViewer.vue
+++ b/desktop/src/mobile/MobileGalleryViewer.vue
@@ -332,7 +332,7 @@ function mediaFailed(): void {
 }
 
 function cancelViewer(): void {
-  if (!props.reusing) emit("close");
+  emit("close");
 }
 
 function navigate(direction: "previous" | "next"): void {
@@ -580,7 +580,6 @@ onBeforeUnmount(() => {
         type="button"
         aria-label="Close print"
         data-test="gallery-viewer-close"
-        :disabled="reusing"
         @click="emit('close')"
       >
         <span aria-hidden="true">×</span>

--- a/desktop/src/mobile/galleryCache.test.ts
+++ b/desktop/src/mobile/galleryCache.test.ts
@@ -3,14 +3,18 @@ import { beforeEach, describe, expect, it } from "vitest";
 import type { GalleryImage } from "../lib/api/types";
 import type { MobileGalleryImage } from "./libraryOrganization";
 import {
+  captureCachedHostFence,
   loadCachedGallery,
   loadCachedGalleryMedia,
+  loadCachedHostPresentation,
   clearCachedGalleryHosts,
   patchCachedGalleryPrints,
   removeCachedGalleryPrints,
   storeCachedGallery,
   storeCachedGalleryMedia,
+  storeCachedHostPresentation,
 } from "./galleryCache";
+import type { ModelEntry } from "../lib/api/types";
 
 function print(filename: string, timestamp: number): GalleryImage {
   return {
@@ -58,6 +62,48 @@ describe("mobile gallery cache", () => {
     );
   });
 
+  it("persists non-secret model presentation data under the server identity", async () => {
+    const model = {
+      name: "flux-dev:q8",
+      family: "flux",
+      downloaded: true,
+    } as ModelEntry;
+    await storeCachedHostPresentation({
+      hostId: "instance-1",
+      updatedAt: 42,
+      instanceId: "instance-1",
+      serverVersion: "1.2.3",
+      models: [model],
+      capabilities: null,
+    });
+
+    const restored = await loadCachedHostPresentation("instance-1");
+    expect(restored).toMatchObject({
+      instanceId: "instance-1",
+      serverVersion: "1.2.3",
+      models: [model],
+    });
+    expect(JSON.stringify(restored)).not.toContain("apiKey");
+  });
+
+  it("does not resurrect a presentation when a host is cleared during refresh", async () => {
+    const fence = captureCachedHostFence("removed-instance");
+    await clearCachedGalleryHosts(["removed-instance"]);
+    await storeCachedHostPresentation(
+      {
+        hostId: "removed-instance",
+        updatedAt: 42,
+        instanceId: "removed-instance",
+        serverVersion: "1.2.3",
+        models: [],
+        capabilities: null,
+      },
+      fence,
+    );
+
+    expect(await loadCachedHostPresentation("removed-instance")).toBeNull();
+  });
+
   it("removes metadata and thumbnail bytes after a successful delete", async () => {
     await storeCachedGallery("studio", [print("keep.png", 2), print("delete.png", 1)]);
     await storeCachedGalleryMedia("studio", "delete.png", "thumbnail", new Blob(["thumb"]));
@@ -102,6 +148,14 @@ describe("mobile gallery cache", () => {
         }),
     } as Blob;
     const write = storeCachedGalleryMedia("old-instance", "old.png", "thumbnail", pendingBlob);
+    await storeCachedHostPresentation({
+      hostId: "old-instance",
+      updatedAt: 1,
+      instanceId: "old-instance",
+      serverVersion: "1.0.0",
+      models: [],
+      capabilities: null,
+    });
     await Promise.resolve();
 
     await clearCachedGalleryHosts(["old-instance"]);
@@ -110,6 +164,7 @@ describe("mobile gallery cache", () => {
 
     expect(await loadCachedGallery("old-instance")).toEqual([]);
     expect(await loadCachedGalleryMedia("old-instance", "old.png", "thumbnail")).toBeNull();
+    expect(await loadCachedHostPresentation("old-instance")).toBeNull();
   });
 });
 

--- a/desktop/src/mobile/galleryCache.ts
+++ b/desktop/src/mobile/galleryCache.ts
@@ -1,10 +1,11 @@
-import type { GalleryImage } from "../lib/api/types";
+import type { GalleryImage, ModelEntry, ServerCapabilities } from "../lib/api/types";
 import type { MobileGalleryImage } from "./libraryOrganization";
 
 const DB_NAME = "mold-mobile-gallery-cache";
-const DB_VERSION = 2;
+const DB_VERSION = 3;
 const GALLERIES_STORE = "galleries";
 const MEDIA_STORE = "media";
+const PRESENTATIONS_STORE = "host-presentations";
 const MAX_PRINTS_PER_HOST = 500;
 const MAX_THUMBNAIL_RECORDS = 320;
 const mediaMutationVersions = new Map<string, number>();
@@ -16,6 +17,22 @@ interface CachedGalleryRecord {
   hostId: string;
   updatedAt: number;
   prints: GalleryImage[];
+}
+
+/** Non-secret host state needed to interpret a saved print while its machine
+ * is offline. The key is the same stable instance identity as gallery rows. */
+export interface CachedHostPresentation {
+  hostId: string;
+  updatedAt: number;
+  instanceId: string | null;
+  serverVersion: string | null;
+  models: ModelEntry[];
+  capabilities: ServerCapabilities | null;
+}
+
+export interface CachedHostFence {
+  hostId: string;
+  version: number;
 }
 
 interface CachedMediaRecord {
@@ -63,6 +80,9 @@ function openDb(): Promise<IDBDatabase | null> {
       } else {
         const media = request.transaction!.objectStore(MEDIA_STORE);
         if (!media.indexNames.contains("hostId")) media.createIndex("hostId", "hostId");
+      }
+      if (!db.objectStoreNames.contains(PRESENTATIONS_STORE)) {
+        db.createObjectStore(PRESENTATIONS_STORE, { keyPath: "hostId" });
       }
     };
     request.onsuccess = () => finish(request.result);
@@ -123,6 +143,35 @@ export async function storeCachedGallery(
       ? store.put({ hostId, updatedAt: Date.now(), prints: bounded })
       : store.get(hostId),
   );
+}
+
+export async function loadCachedHostPresentation(
+  hostId: string,
+): Promise<CachedHostPresentation | null> {
+  const record = await requestFromStore<CachedHostPresentation>(
+    PRESENTATIONS_STORE,
+    "readonly",
+    (store) => store.get(hostId),
+  );
+  return record && Array.isArray(record.models) ? record : null;
+}
+
+export async function storeCachedHostPresentation(
+  presentation: CachedHostPresentation,
+  fence: CachedHostFence = captureCachedHostFence(presentation.hostId),
+): Promise<void> {
+  await requestFromStore(PRESENTATIONS_STORE, "readwrite", (store) =>
+    fence.hostId === presentation.hostId &&
+    (hostMutationVersions.get(presentation.hostId) ?? 0) === fence.version
+      ? store.put(presentation)
+      : store.get(presentation.hostId),
+  );
+}
+
+/** Capture before a network refresh. A later clear/removal advances this
+ * generation so the response cannot recreate a purged instance record. */
+export function captureCachedHostFence(hostId: string): CachedHostFence {
+  return { hostId, version: hostMutationVersions.get(hostId) ?? 0 };
 }
 
 export async function loadCachedGalleryMedia(
@@ -280,12 +329,17 @@ export async function clearCachedGalleryHosts(hostIds: readonly string[]): Promi
       resolve();
     };
     try {
-      const transaction = db.transaction([GALLERIES_STORE, MEDIA_STORE], "readwrite");
+      const transaction = db.transaction(
+        [GALLERIES_STORE, MEDIA_STORE, PRESENTATIONS_STORE],
+        "readwrite",
+      );
       const galleries = transaction.objectStore(GALLERIES_STORE);
       const media = transaction.objectStore(MEDIA_STORE);
+      const presentations = transaction.objectStore(PRESENTATIONS_STORE);
       const hostIndex = media.index("hostId");
       for (const hostId of ids) {
         galleries.delete(hostId);
+        presentations.delete(hostId);
         const keys = hostIndex.getAllKeys(hostId);
         keys.onsuccess = () => {
           for (const key of keys.result) {


### PR DESCRIPTION
## Summary

- cache non-secret, instance-scoped model and capability presentation snapshots alongside the bounded iPhone Library cache
- restore saved print settings immediately with stale-while-revalidate behavior, explicit saved-inventory status, server identity/version fencing, and purge-safe late writes
- keep Print preview dismissible during reuse and source actions; cancellation epochs prevent late form mutation or navigation
- bound model refresh and source restoration even when a transport ignores AbortSignal, leaving recoverable Retry or reattach-source guidance

## Verification

- nix develop: Vue typecheck passed
- Prettier check passed for every changed frontend and changelog file
- Vitest: 298/298 passed across MobileApp, MobileGalleryViewer, galleryCache, and reuse suites
- independent subagent peer review approved with no findings after concurrency and identity follow-up

Closes #1182