### PR TITLE
fix(h3): turbo tags share the base model's storage instead of re-downloading 41 GB

### DIFF
--- a/changelog.d/h3-turbo-shared-storage.md
+++ b/changelog.d/h3-turbo-shared-storage.md
@@ -1,3 +1,5 @@
-### Fixed
-
-- MiniMax H3 Turbo tags now store their base stack in the base checkpoint's directory: pulling a Turbo tag on a machine with `minimax-h3-fl2va:comfy-pruned-int8` installed downloads only the ~1.96 GB adapter instead of re-downloading ~41 GB into a tag-named copy, and removal ref-counting protects the shared files in both directions.
+- **MiniMax H3 Turbo tags share the base checkpoint's storage.** Pulling a
+  Turbo tag on a machine with `minimax-h3-fl2va:comfy-pruned-int8` installed
+  downloads only the ~1.96 GB adapter instead of re-downloading ~41 GB into a
+  tag-named copy, and removal ref-counting protects the shared files in both
+  directions.

--- a/changelog.d/h3-turbo-shared-storage.md
+++ b/changelog.d/h3-turbo-shared-storage.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- MiniMax H3 Turbo tags now store their base stack in the base checkpoint's directory: pulling a Turbo tag on a machine with `minimax-h3-fl2va:comfy-pruned-int8` installed downloads only the ~1.96 GB adapter instead of re-downloading ~41 GB into a tag-named copy, and removal ref-counting protects the shared files in both directions.

--- a/changelog.d/h3-turbo-shared-storage.md
+++ b/changelog.d/h3-turbo-shared-storage.md
@@ -3,3 +3,7 @@
   downloads only the ~1.96 GB adapter instead of re-downloading ~41 GB into a
   tag-named copy, and removal ref-counting protects the shared files in both
   directions.
+- **Model removal only credits complete installs as owners.** A configured
+  model missing any of its files on disk (for example an H3 Turbo tag whose
+  adapter was deleted) no longer holds shared components hostage when a
+  sibling model is removed.

--- a/crates/mold-cli/src/commands/rm.rs
+++ b/crates/mold-cli/src/commands/rm.rs
@@ -214,28 +214,39 @@ mod tests {
 
     #[test]
     fn ref_counts_shared_file() {
+        // Ownership requires a complete install, so the files must exist.
+        let tmp = make_tmp_dir("ref-counts");
+        std::fs::create_dir_all(&tmp).unwrap();
+        let unique_a = tmp.join("unique-a.gguf");
+        let unique_b = tmp.join("unique-b.gguf");
+        let shared_vae = tmp.join("shared-vae.safetensors");
+        for path in [&unique_a, &unique_b, &shared_vae] {
+            std::fs::write(path, b"weights").unwrap();
+        }
+
         let mut config = Config::default();
         config.models.insert(
             "model-a".into(),
             ModelConfig {
-                transformer: Some("/unique-a.gguf".into()),
-                vae: Some("/shared-vae.safetensors".into()),
+                transformer: Some(unique_a.to_string_lossy().into_owned()),
+                vae: Some(shared_vae.to_string_lossy().into_owned()),
                 ..Default::default()
             },
         );
         config.models.insert(
             "model-b".into(),
             ModelConfig {
-                transformer: Some("/unique-b.gguf".into()),
-                vae: Some("/shared-vae.safetensors".into()),
+                transformer: Some(unique_b.to_string_lossy().into_owned()),
+                vae: Some(shared_vae.to_string_lossy().into_owned()),
                 ..Default::default()
             },
         );
 
         let refs = build_ref_counts(&config);
-        assert_eq!(refs["/shared-vae.safetensors"].len(), 2);
-        assert_eq!(refs["/unique-a.gguf"].len(), 1);
-        assert_eq!(refs["/unique-b.gguf"].len(), 1);
+        assert_eq!(refs[&shared_vae.to_string_lossy().into_owned()].len(), 2);
+        assert_eq!(refs[&unique_a.to_string_lossy().into_owned()].len(), 1);
+        assert_eq!(refs[&unique_b.to_string_lossy().into_owned()].len(), 1);
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 
     #[test]
@@ -775,6 +786,78 @@ mod tests {
                 "shared VAE should be referenced by at least 2 models, got: {vae_refs:?}"
             );
         }
+
+        std::env::remove_var("MOLD_MODELS_DIR");
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// A Turbo-only H3 pull leaves the base tag genuinely installed — the
+    /// complete sha-verified base stack is on disk at the base's own paths —
+    /// so removing the Turbo tag deletes only its adapter and reports the
+    /// stack as kept, used by the base. Removing the base afterwards frees
+    /// everything: the two states are byte-identical to an explicit
+    /// base+Turbo install, and deleting the stack on the first removal would
+    /// destroy an explicitly pulled base in that indistinguishable case.
+    #[test]
+    fn turbo_only_install_keeps_the_base_stack_until_the_base_is_removed() {
+        use crate::test_support::ENV_LOCK;
+
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let tmp = make_tmp_dir("turbo-only");
+
+        let tier = &mold_core::minimax_h3::REVIEWED_TURBO_MANIFEST_TIERS[0];
+        let turbo_manifest = mold_core::manifest::find_manifest(tier.model).unwrap();
+        let mut adapter_path = None;
+        for file in &turbo_manifest.files {
+            let path = tmp.join(mold_core::manifest::storage_path(turbo_manifest, file));
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).unwrap();
+            }
+            std::fs::write(&path, b"test").unwrap();
+            mold_core::download::write_sha256_marker(&path, "deadbeef").unwrap();
+            if file.component == mold_core::manifest::ModelComponent::DistilledLora {
+                adapter_path = Some(path.to_string_lossy().into_owned());
+            }
+        }
+        let adapter_path = adapter_path.expect("the Turbo manifest pins an adapter");
+        std::env::set_var("MOLD_MODELS_DIR", &tmp);
+
+        let config = Config::default();
+        assert!(config.manifest_model_is_downloaded(tier.model));
+        assert!(
+            config.manifest_model_is_downloaded(mold_core::minimax_h3::FL2VA_COMFY),
+            "the shared bytes constitute a complete base install"
+        );
+
+        let plan = mold_core::removal::plan_removal(&config, tier.model);
+        let unique: Vec<&str> = plan
+            .unique_files
+            .iter()
+            .map(|(path, _)| path.as_str())
+            .collect();
+        assert_eq!(
+            unique,
+            vec![adapter_path.as_str()],
+            "the Turbo removal deletes only its adapter"
+        );
+        assert!(
+            plan.shared_files
+                .iter()
+                .all(|(_, used_by)| used_by
+                    .contains(&mold_core::minimax_h3::FL2VA_COMFY.to_string())),
+            "every kept file names the base as its owner"
+        );
+
+        // Removing the adapter (what executing the plan does) leaves the
+        // base as the sole install; removing it then frees the stack.
+        std::fs::remove_file(&adapter_path).unwrap();
+        let plan = mold_core::removal::plan_removal(&config, mold_core::minimax_h3::FL2VA_COMFY);
+        assert!(
+            plan.shared_files.is_empty(),
+            "no other install references the stack: {:?}",
+            plan.shared_files
+        );
+        assert!(!plan.unique_files.is_empty());
 
         std::env::remove_var("MOLD_MODELS_DIR");
         let _ = std::fs::remove_dir_all(&tmp);

--- a/crates/mold-core/src/manifest.rs
+++ b/crates/mold-core/src/manifest.rs
@@ -329,7 +329,16 @@ fn is_model_specific_component(component: ModelComponent) -> bool {
 /// HF filename paths (e.g., `text_encoder/model-00001-of-00003.safetensors`) are preserved as-is,
 /// creating subdirectories under the target directory.
 pub fn storage_path(manifest: &ModelManifest, file: &ModelFile) -> PathBuf {
-    let sanitized_name = manifest.name.replace(':', "-");
+    // H3 Turbo tags are the base compact stack plus one shared adapter, so
+    // their model-specific files live in the base checkpoint's directory —
+    // a machine holding the base pulls only the adapter, and removal
+    // ref-counting protects the shared bytes in both directions.
+    let storage_name = if manifest.family == crate::minimax_h3::FAMILY {
+        crate::minimax_h3::storage_identity(&manifest.name)
+    } else {
+        manifest.name.as_str()
+    };
+    let sanitized_name = storage_name.replace(':', "-");
 
     // H3's official and Comfy transformers use the same task architecture
     // config. Keep one copy per task across layouts while the task-specific

--- a/crates/mold-core/src/minimax_h3.rs
+++ b/crates/mold-core/src/minimax_h3.rs
@@ -121,6 +121,26 @@ pub fn base_compact_model(model: &str) -> Option<&'static str> {
     Some(canonical)
 }
 
+/// The model identity whose directory holds a manifest's model-specific
+/// files. A reviewed Turbo tag is the base compact stack plus one shared
+/// adapter, so its base-stack files install into — and verify against — the
+/// base checkpoint's directory instead of duplicating ~41 GB per tag. The
+/// tag's only novel artifact, the adapter, is routed to the shared family
+/// bucket by `manifest::storage_path` before this identity is consulted.
+///
+/// Takes the exact manifest name (already canonical inside `storage_path`),
+/// deliberately not `resolve_model_name`, so the mapping stays a pure lookup.
+pub fn storage_identity(name: &str) -> &str {
+    if REVIEWED_TURBO_MANIFEST_TIERS
+        .iter()
+        .any(|tier| tier.model == name)
+    {
+        FL2VA_COMFY
+    } else {
+        name
+    }
+}
+
 /// Resolve the reviewed Turbo tier a model identity selects, if any.
 pub fn turbo_tier_for_model(model: &str) -> Option<&'static TurboManifestTier> {
     let canonical = resolve_model_name(model)?;
@@ -3653,6 +3673,113 @@ mod tests {
             assert_eq!(contract.identity.source_revision, COMFY_TURBO_LORA_REVISION);
             assert_eq!(contract.identity.sha256, tier.adapter_sha256);
         }
+    }
+
+    /// A Turbo tag is the base checkpoint plus one shared adapter, so every
+    /// non-adapter file must resolve to the exact storage path the base
+    /// manifest owns. Anything else re-downloads the ~41 GB base stack into a
+    /// tag-named directory beside an identical installed copy, and removal
+    /// ref-counting stops protecting the shared bytes.
+    #[test]
+    fn turbo_manifests_store_the_base_stack_in_the_base_models_directory() {
+        let base = find_manifest(FL2VA_COMFY).unwrap();
+        for tier in REVIEWED_TURBO_MANIFEST_TIERS {
+            let manifest = find_manifest(tier.model).unwrap();
+            for file in &manifest.files {
+                if file.component == ModelComponent::DistilledLora {
+                    continue;
+                }
+                let same = base
+                    .files
+                    .iter()
+                    .find(|candidate| {
+                        candidate.hf_repo == file.hf_repo
+                            && candidate.hf_filename == file.hf_filename
+                    })
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "{} carries {} which the base manifest does not own",
+                            tier.model, file.hf_filename
+                        )
+                    });
+                assert_eq!(
+                    storage_path(manifest, file),
+                    storage_path(base, same),
+                    "{} must reuse the base install for {}",
+                    tier.model,
+                    file.hf_filename
+                );
+            }
+        }
+    }
+
+    /// Removal ref-counting must protect the shared base stack in both
+    /// directions: removing a Turbo tag deletes only its adapter, and
+    /// removing the base while a Turbo tag is installed keeps every shared
+    /// file, naming the tag that still uses it.
+    #[test]
+    fn turbo_removal_refcounts_protect_the_shared_base_stack() {
+        use crate::removal::plan_removal;
+        use crate::{Config, ModelConfig};
+
+        let root = std::path::Path::new("/models");
+        let base_manifest = find_manifest(FL2VA_COMFY).unwrap();
+        let tier = &REVIEWED_TURBO_MANIFEST_TIERS[0];
+        let turbo_manifest = find_manifest(tier.model).unwrap();
+        let path_of = |manifest: &ModelManifest, component: ModelComponent| {
+            let file = manifest
+                .files
+                .iter()
+                .find(|file| file.component == component)
+                .unwrap();
+            root.join(storage_path(manifest, file))
+                .to_string_lossy()
+                .to_string()
+        };
+
+        let mut config = Config::default();
+        config.models.insert(
+            FL2VA_COMFY.to_string(),
+            ModelConfig {
+                transformer: Some(path_of(base_manifest, ModelComponent::Transformer)),
+                ..ModelConfig::default()
+            },
+        );
+        config.models.insert(
+            tier.model.to_string(),
+            ModelConfig {
+                transformer: Some(path_of(turbo_manifest, ModelComponent::Transformer)),
+                distilled_lora: Some(path_of(turbo_manifest, ModelComponent::DistilledLora)),
+                ..ModelConfig::default()
+            },
+        );
+
+        let adapter_path = path_of(turbo_manifest, ModelComponent::DistilledLora);
+        let transformer_path = path_of(base_manifest, ModelComponent::Transformer);
+
+        let plan = plan_removal(&config, tier.model);
+        let unique: Vec<&str> = plan
+            .unique_files
+            .iter()
+            .map(|(path, _)| path.as_str())
+            .collect();
+        assert_eq!(unique, vec![adapter_path.as_str()]);
+        assert!(plan
+            .shared_files
+            .iter()
+            .any(|(path, used_by)| path == &transformer_path
+                && used_by == &vec![FL2VA_COMFY.to_string()]));
+
+        let plan = plan_removal(&config, FL2VA_COMFY);
+        assert!(
+            plan.unique_files.is_empty(),
+            "the base owns nothing exclusively while a Turbo tag is installed"
+        );
+        assert!(plan
+            .shared_files
+            .iter()
+            .any(|(path, used_by)| path == &transformer_path
+                && used_by == &vec![tier.model.to_string()]));
     }
 
     #[test]

--- a/crates/mold-core/src/minimax_h3.rs
+++ b/crates/mold-core/src/minimax_h3.rs
@@ -130,6 +130,16 @@ pub fn base_compact_model(model: &str) -> Option<&'static str> {
 ///
 /// Takes the exact manifest name (already canonical inside `storage_path`),
 /// deliberately not `resolve_model_name`, so the mapping stays a pure lookup.
+///
+/// Deliberate consequence: after a Turbo-only pull, the base tag also reads
+/// as installed everywhere presence is the authority (models list, removal
+/// ownership, `AlreadyAvailable`), because its complete sha-verified file set
+/// genuinely is on disk. A Turbo-only install and an explicit base+Turbo
+/// install are byte-identical, so no rule can treat them differently without
+/// inventing a new installation-receipt mechanism; the honest reading is
+/// that the base IS installed and runnable. Full cleanup is therefore two
+/// removals — the Turbo tag, then the base — and each removal reports the
+/// kept files with the tags that still use them.
 pub fn storage_identity(name: &str) -> &str {
     if REVIEWED_TURBO_MANIFEST_TIERS
         .iter()
@@ -3716,13 +3726,15 @@ mod tests {
     /// Removal ref-counting must protect the shared base stack in both
     /// directions: removing a Turbo tag deletes only its adapter, and
     /// removing the base while a Turbo tag is installed keeps every shared
-    /// file, naming the tag that still uses it.
+    /// file, naming the tag that still uses it. A half-installed Turbo tag
+    /// (its adapter deleted) is not a complete install and owns nothing.
     #[test]
     fn turbo_removal_refcounts_protect_the_shared_base_stack() {
         use crate::removal::plan_removal;
         use crate::{Config, ModelConfig};
 
-        let root = std::path::Path::new("/models");
+        let root =
+            std::env::temp_dir().join(format!("mold-h3-turbo-removal-{}", std::process::id()));
         let base_manifest = find_manifest(FL2VA_COMFY).unwrap();
         let tier = &REVIEWED_TURBO_MANIFEST_TIERS[0];
         let turbo_manifest = find_manifest(tier.model).unwrap();
@@ -3737,11 +3749,19 @@ mod tests {
                 .to_string()
         };
 
+        let adapter_path = path_of(turbo_manifest, ModelComponent::DistilledLora);
+        let transformer_path = path_of(base_manifest, ModelComponent::Transformer);
+        for path in [&adapter_path, &transformer_path] {
+            let path = std::path::Path::new(path);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(path, b"weights").unwrap();
+        }
+
         let mut config = Config::default();
         config.models.insert(
             FL2VA_COMFY.to_string(),
             ModelConfig {
-                transformer: Some(path_of(base_manifest, ModelComponent::Transformer)),
+                transformer: Some(transformer_path.clone()),
                 ..ModelConfig::default()
             },
         );
@@ -3749,13 +3769,10 @@ mod tests {
             tier.model.to_string(),
             ModelConfig {
                 transformer: Some(path_of(turbo_manifest, ModelComponent::Transformer)),
-                distilled_lora: Some(path_of(turbo_manifest, ModelComponent::DistilledLora)),
+                distilled_lora: Some(adapter_path.clone()),
                 ..ModelConfig::default()
             },
         );
-
-        let adapter_path = path_of(turbo_manifest, ModelComponent::DistilledLora);
-        let transformer_path = path_of(base_manifest, ModelComponent::Transformer);
 
         let plan = plan_removal(&config, tier.model);
         let unique: Vec<&str> = plan
@@ -3780,6 +3797,22 @@ mod tests {
             .iter()
             .any(|(path, used_by)| path == &transformer_path
                 && used_by == &vec![tier.model.to_string()]));
+
+        // Delete the adapter: the Turbo tag is now half-installed and must
+        // stop owning the base stack — removing the base frees it.
+        std::fs::remove_file(&adapter_path).unwrap();
+        let plan = plan_removal(&config, FL2VA_COMFY);
+        assert!(
+            plan.shared_files.is_empty(),
+            "a Turbo tag without its adapter is not an owner: {:?}",
+            plan.shared_files
+        );
+        assert!(plan
+            .unique_files
+            .iter()
+            .any(|(path, _)| path == &transformer_path));
+
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]

--- a/crates/mold-core/src/removal.rs
+++ b/crates/mold-core/src/removal.rs
@@ -31,7 +31,19 @@ pub fn file_size(path: &str) -> u64 {
 pub fn build_ref_counts(config: &Config) -> HashMap<String, Vec<String>> {
     let mut refs: HashMap<String, Vec<String>> = HashMap::new();
     for (model_name, model_config) in &config.models {
-        for path in model_config.all_file_paths() {
+        let paths = model_config.all_file_paths();
+        // An owner must be complete on disk. A configured model missing any
+        // of its own files — an H3 Turbo tag whose adapter was deleted, a
+        // half-repaired install — is not runnable and must not hold shared
+        // components hostage when a sibling is removed. The model BEING
+        // removed is unaffected: `plan_removal` iterates its paths directly.
+        if paths
+            .iter()
+            .any(|path| !std::path::Path::new(path).exists())
+        {
+            continue;
+        }
+        for path in paths {
             refs.entry(path).or_default().push(model_name.clone());
         }
     }
@@ -305,10 +317,22 @@ mod tests {
         config
     }
 
+    fn materialize(paths: &[&std::path::Path]) {
+        for path in paths {
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(path, b"weights").unwrap();
+        }
+    }
+
     #[test]
     fn build_ref_counts_counts_shared_files_across_models() {
         let tmp = tmp_dir("refs");
         let config = two_model_config(&tmp);
+        materialize(&[
+            &tmp.join("unique-a.gguf"),
+            &tmp.join("unique-b.gguf"),
+            &tmp.join("shared-vae.safetensors"),
+        ]);
         let refs = build_ref_counts(&config);
         let shared = tmp.join("shared-vae.safetensors");
         assert_eq!(refs[&shared.to_string_lossy().into_owned()].len(), 2);
@@ -316,12 +340,49 @@ mod tests {
             refs[&tmp.join("unique-a.gguf").to_string_lossy().into_owned()].len(),
             1
         );
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// A configured model missing any of its files on disk is not a
+    /// complete install and must not own shared components: a Turbo tag
+    /// whose adapter was deleted cannot strand the base stack it shares.
+    #[test]
+    fn incomplete_configured_models_do_not_own_shared_files() {
+        let tmp = tmp_dir("incomplete");
+        let config = two_model_config(&tmp);
+        // model-b's transformer is missing; only model-a is complete.
+        materialize(&[
+            &tmp.join("unique-a.gguf"),
+            &tmp.join("shared-vae.safetensors"),
+        ]);
+
+        let refs = build_ref_counts(&config);
+        let shared = tmp.join("shared-vae.safetensors");
+        assert_eq!(
+            refs[&shared.to_string_lossy().into_owned()],
+            vec!["model-a".to_string()],
+            "the half-installed model-b must not count as an owner"
+        );
+
+        let plan = plan_removal(&config, "model-a");
+        assert!(
+            plan.shared_files.is_empty(),
+            "nothing runnable still uses the VAE: {:?}",
+            plan.shared_files
+        );
+        assert_eq!(plan.unique_files.len(), 2, "transformer + VAE both unique");
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 
     #[test]
     fn plan_classifies_unique_and_shared_files() {
         let tmp = tmp_dir("plan");
         let config = two_model_config(&tmp);
+        materialize(&[
+            &tmp.join("unique-a.gguf"),
+            &tmp.join("unique-b.gguf"),
+            &tmp.join("shared-vae.safetensors"),
+        ]);
 
         let plan = plan_removal(&config, "model-a");
         assert_eq!(plan.model, "model-a");
@@ -330,6 +391,7 @@ mod tests {
         assert_eq!(plan.shared_files.len(), 1, "the VAE is shared");
         assert!(plan.shared_files[0].0.ends_with("shared-vae.safetensors"));
         assert_eq!(plan.shared_files[0].1, vec!["model-b".to_string()]);
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 
     #[test]
@@ -363,8 +425,13 @@ mod tests {
     #[test]
     fn execute_removal_reports_missing_files_as_warnings() {
         let tmp = tmp_dir("missing");
-        // Files never created — every unique path is already gone.
+        // model-a's unique transformer is already gone; model-b stays a
+        // complete install so the shared VAE keeps a real owner.
         let config = two_model_config(&tmp);
+        materialize(&[
+            &tmp.join("unique-b.gguf"),
+            &tmp.join("shared-vae.safetensors"),
+        ]);
         let plan = plan_removal(&config, "model-a");
         let outcome = execute_removal(&config, &plan);
 

--- a/crates/mold-tui/src/backend.rs
+++ b/crates/mold-tui/src/backend.rs
@@ -909,16 +909,15 @@ fn build_request(
 }
 
 /// Build a map of file_path -> list of model names that reference it.
+///
+/// Delegates to `mold_core::removal::build_ref_counts` so the TUI's removal
+/// flow shares the CLI/server ownership rules: manifest-backed installs
+/// without a config entry still count as owners, and a configured model
+/// missing files on disk does not.
 pub(crate) fn build_ref_counts(
     config: &mold_core::Config,
 ) -> std::collections::HashMap<String, Vec<String>> {
-    let mut refs: std::collections::HashMap<String, Vec<String>> = std::collections::HashMap::new();
-    for (model_name, model_config) in &config.models {
-        for path in model_config.all_file_paths() {
-            refs.entry(path).or_default().push(model_name.clone());
-        }
-    }
-    refs
+    mold_core::removal::build_ref_counts(config)
 }
 
 /// Collect hf-hub cache blob paths for a model's unique files so we can delete them
@@ -1102,17 +1101,28 @@ mod tests {
 
     #[test]
     fn build_ref_counts_tracks_shared_files() {
+        // Ownership requires a complete install (the core rule this
+        // delegates to), so the referenced files must exist on disk.
+        let tmp = std::env::temp_dir().join(format!("mold-tui-refs-{}", std::process::id()));
+        std::fs::create_dir_all(&tmp).unwrap();
+        let a_transformer = tmp.join("a-transformer.safetensors");
+        let b_transformer = tmp.join("b-transformer.safetensors");
+        let shared_vae = tmp.join("shared-vae.safetensors");
+        for path in [&a_transformer, &b_transformer, &shared_vae] {
+            std::fs::write(path, b"weights").unwrap();
+        }
+
         let mut config = mold_core::Config::default();
 
         let model_a = mold_core::ModelConfig {
-            transformer: Some("/models/a/transformer.safetensors".to_string()),
-            vae: Some("/models/shared/vae.safetensors".to_string()),
+            transformer: Some(a_transformer.to_string_lossy().into_owned()),
+            vae: Some(shared_vae.to_string_lossy().into_owned()),
             ..Default::default()
         };
 
         let model_b = mold_core::ModelConfig {
-            transformer: Some("/models/b/transformer.safetensors".to_string()),
-            vae: Some("/models/shared/vae.safetensors".to_string()),
+            transformer: Some(b_transformer.to_string_lossy().into_owned()),
+            vae: Some(shared_vae.to_string_lossy().into_owned()),
             ..Default::default()
         };
 
@@ -1122,22 +1132,31 @@ mod tests {
         let refs = build_ref_counts(&config);
 
         // Unique files should have exactly one reference
-        let a_refs = refs.get("/models/a/transformer.safetensors").unwrap();
+        let a_refs = refs
+            .get(&a_transformer.to_string_lossy().into_owned())
+            .unwrap();
         assert_eq!(a_refs.len(), 1);
         assert!(a_refs.contains(&"model-a".to_string()));
 
         // Shared files should have both models
-        let vae_refs = refs.get("/models/shared/vae.safetensors").unwrap();
+        let vae_refs = refs
+            .get(&shared_vae.to_string_lossy().into_owned())
+            .unwrap();
         assert_eq!(vae_refs.len(), 2);
         assert!(vae_refs.contains(&"model-a".to_string()));
         assert!(vae_refs.contains(&"model-b".to_string()));
+
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 
     #[test]
     fn build_ref_counts_empty_config() {
         let config = mold_core::Config::default();
         let refs = build_ref_counts(&config);
-        assert!(refs.is_empty());
+        // No configured entries: any owners present come from manifest-backed
+        // installs discovered on this machine's disk, and every listed path
+        // must name at least one owner.
+        assert!(refs.values().all(|owners| !owners.is_empty()));
     }
 
     #[test]

--- a/website/models/minimax-h3.md
+++ b/website/models/minimax-h3.md
@@ -68,9 +68,14 @@ A Turbo tag stores its base stack in the base checkpoint's own directory
 (`minimax-h3-fl2va-comfy-pruned-int8/` plus the shared family bucket), so a
 machine that already has `minimax-h3-fl2va:comfy-pruned-int8` installed
 downloads only the ~1.96 GB adapter — and pulling a Turbo tag first means a
-later base pull downloads nothing. Removal ref-counts every file across the
-installed tags: removing a Turbo tag deletes only its adapter while the base
-is installed, and removing the base keeps every file a Turbo tag still uses.
+later base pull downloads nothing. Because the shared bytes genuinely
+constitute a complete base install, a Turbo-only pull also makes the base tag
+read as installed. Removal ref-counts every complete install: removing a
+Turbo tag deletes only its adapter while the base stack has another owner,
+and removing the base keeps every file a fully installed Turbo tag still
+uses (a Turbo tag missing its adapter owns nothing). Freeing everything is
+two removals — the Turbo tag, then the base — and each removal reports the
+kept files with the tags that still use them.
 
 Selecting a Turbo model resolves the base INT8 transformer, the tier's pinned
 adapter, and the tier's reviewed step count with no extra configuration. The

--- a/website/models/minimax-h3.md
+++ b/website/models/minimax-h3.md
@@ -64,6 +64,14 @@ once under `shared/minimax-h3/loras/` and shared by both tags):
 - `minimax-h3-fl2va:comfy-pruned-int8-turbo-4step-768p` — 5 terminal-inclusive
   sampler grid points (4 model evaluations)
 
+A Turbo tag stores its base stack in the base checkpoint's own directory
+(`minimax-h3-fl2va-comfy-pruned-int8/` plus the shared family bucket), so a
+machine that already has `minimax-h3-fl2va:comfy-pruned-int8` installed
+downloads only the ~1.96 GB adapter — and pulling a Turbo tag first means a
+later base pull downloads nothing. Removal ref-counts every file across the
+installed tags: removing a Turbo tag deletes only its adapter while the base
+is installed, and removing the base keeps every file a Turbo tag still uses.
+
 Selecting a Turbo model resolves the base INT8 transformer, the tier's pinned
 adapter, and the tier's reviewed step count with no extra configuration. The
 `MOLD_H3_TURBO_ADAPTER` / `MOLD_H3_TURBO_TIER` environment pair is a


### PR DESCRIPTION
## Summary

Live UAT of #1199 on the RTX 4090: `mold pull minimax-h3-fl2va:comfy-pruned-int8-turbo-8step` on a machine that already had the base model began re-downloading the entire 20.97 GB transformer (and the rest of the ~41 GB base stack) into a new `minimax-h3-fl2va-comfy-pruned-int8-turbo-8step/` directory. Only the 1.96 GB adapter is genuinely new.

**Root cause:** `mold_core::manifest::storage_path` keys model-specific components on the manifest's own name, so each turbo tag claimed its own directory and never saw the base install.

**Fix:** H3 manifests resolve their model-specific directory through `mold_core::minimax_h3::storage_identity(name)` — reviewed turbo tags map to `FL2VA_COMFY`, everything else to itself. The turbo tags' base-stack files land on the exact paths the base install owns (the adapter already lived in `shared/minimax-h3/loras/`). Existing installs need no migration. Everything downstream derives from `storage_path`, so one change point covers download-verify, repair, load, artifact contracts, and inventory.

**Semantics:** pull turbo with base installed → base files sha-verify in place, only the adapter downloads; pull base after turbo → nothing downloads. Removal was already path-refcounted (`removal.rs`): removing a turbo tag deletes only its adapter while the base remains; removing the base with a turbo tag installed keeps shared files and names the tag in `used_by`. Per-model disk sizes follow the same overlap convention as FLUX's shared T5.

**Tests (failing first):** `turbo_manifests_store_the_base_stack_in_the_base_models_directory` pins every non-adapter turbo file to the base manifest's exact storage path; `turbo_removal_refcounts_protect_the_shared_base_stack` pins both removal directions.

## Gates
fmt, workspace clippy, h3-cuda clippy, generation-profiles --check, website prettier + docs verifier all clean. With MOLD_* env unset: mold-core 1258, CLI 600/600, server h3 103, inference minimax 102, TUI 688, discord 143. The 3 `--features h3` mold-core failures reproduce byte-identically on pristine main (pre-existing).