### PR TITLE
feat(h3): thread reference bindings into Ref2VA admission

### DIFF
--- a/crates/mold-inference/src/h3_factory.rs
+++ b/crates/mold-inference/src/h3_factory.rs
@@ -1457,7 +1457,10 @@ impl H3FactoryPreparedAttemptAuthority {
 /// and drifting. Every field here is computed; none is read back from the
 /// input.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-#[cfg_attr(not(feature = "mp4"), allow(dead_code))]
+#[cfg_attr(
+    not(all(feature = "mp4", any(feature = "h3", feature = "h3-private-uat"))),
+    allow(dead_code)
+)]
 pub struct H3FactoryReferenceCharges {
     pub visual_rows: u64,
     pub audio_rows: u64,
@@ -1468,7 +1471,10 @@ pub struct H3FactoryReferenceCharges {
 
 /// Derive one reference's charges. The geometry fields of `reference` are the
 /// only inputs read; its own charge fields are ignored.
-#[cfg_attr(not(feature = "mp4"), allow(dead_code))]
+#[cfg_attr(
+    not(all(feature = "mp4", any(feature = "h3", feature = "h3-private-uat"))),
+    allow(dead_code)
+)]
 pub fn expected_h3_factory_reference_charges(
     reference: &H3FactoryReferenceInput,
 ) -> Result<H3FactoryReferenceCharges> {

--- a/crates/mold-inference/src/h3_factory.rs
+++ b/crates/mold-inference/src/h3_factory.rs
@@ -1449,6 +1449,39 @@ impl H3FactoryPreparedAttemptAuthority {
     }
 }
 
+/// The charges one ordered reference contributes, derived from its frozen
+/// geometry.
+///
+/// Exposed so the admission builder can populate a descriptor from the SAME
+/// arithmetic `validate_prepared_request` re-derives, rather than restating it
+/// and drifting. Every field here is computed; none is read back from the
+/// input.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(not(feature = "mp4"), allow(dead_code))]
+pub struct H3FactoryReferenceCharges {
+    pub visual_rows: u64,
+    pub audio_rows: u64,
+    pub qwen_vision_rows: u64,
+    pub normalized_host_bytes: u64,
+    pub native_host_bytes: u64,
+}
+
+/// Derive one reference's charges. The geometry fields of `reference` are the
+/// only inputs read; its own charge fields are ignored.
+#[cfg_attr(not(feature = "mp4"), allow(dead_code))]
+pub fn expected_h3_factory_reference_charges(
+    reference: &H3FactoryReferenceInput,
+) -> Result<H3FactoryReferenceCharges> {
+    let charges = h3_reference_charges(reference)?;
+    Ok(H3FactoryReferenceCharges {
+        visual_rows: charges.visual_rows,
+        audio_rows: charges.audio_rows,
+        qwen_vision_rows: charges.qwen_vision_rows,
+        normalized_host_bytes: charges.normalized_host_bytes,
+        native_host_bytes: charges.native_host_bytes,
+    })
+}
+
 /// Recomputed charges for one ordered Ref2VA reference.
 struct H3ReferenceCharges {
     visual_rows: u64,

--- a/crates/mold-inference/src/minimax_h3/pipeline/ref2va.rs
+++ b/crates/mold-inference/src/minimax_h3/pipeline/ref2va.rs
@@ -28,6 +28,32 @@ pub(crate) struct H3PreparedRef2VaRequest {
     grid_points: usize,
 }
 
+impl H3PreparedRef2VaRequest {
+    pub(crate) fn references(&self) -> &[H3PreparedReference] {
+        &self.references
+    }
+
+    pub(crate) fn prompt(&self) -> &str {
+        &self.prompt
+    }
+
+    pub(crate) const fn seed(&self) -> u64 {
+        self.seed
+    }
+
+    pub(crate) const fn grid_points(&self) -> usize {
+        self.grid_points
+    }
+
+    pub(crate) const fn geometry(&self) -> &H3Fl2VaGeometry {
+        &self.geometry
+    }
+
+    pub(crate) fn reference_fingerprint(&self) -> &str {
+        &self.reference_fingerprint
+    }
+}
+
 #[derive(Clone, Debug)]
 pub(crate) struct H3PreparedReference {
     pub metadata: GenerationReferenceMetadata,

--- a/crates/mold-inference/src/minimax_h3/private_opened_evidence.rs
+++ b/crates/mold-inference/src/minimax_h3/private_opened_evidence.rs
@@ -19,6 +19,8 @@ use mold_core::manifest::{find_manifest, storage_path, ModelComponent, ModelMani
 use mold_core::minimax_h3::{self as contract, Layout, Mode, Task};
 use mold_core::secure_file::{open_regular_file_no_follow, sha256_open_file};
 use mold_core::GenerateRequest;
+#[cfg(feature = "mp4")]
+use mold_core::GenerationReferenceKind;
 use sha2::{Digest, Sha256};
 
 #[cfg(unix)]
@@ -29,7 +31,11 @@ use super::pipeline::{
     collect_endpoint_bytes, prepare_request, H3EndpointAnchor, H3PipelineObserver,
     H3PreparedFl2VaRequest,
 };
+#[cfg(feature = "mp4")]
+use super::private_qwen::prepare_ref2va_conditioner_input_for_admission;
 use super::private_qwen_support::H3PrivateQwenSupport;
+#[cfg(feature = "mp4")]
+use super::private_server::H3PrivatePreparationCheckpoint;
 use super::sampler::{H3DualSchedule, H3SamplerKind};
 use super::vae_runtime::{
     FrozenH3ComfyVaeLoadPlan, H3AuthenticatedComfyVaeAuthority, H3ComfyVaeArtifactRole,
@@ -43,6 +49,10 @@ use crate::h3_factory::{
     H3FactoryPreparedAttemptInput, H3FactoryPreparedRequestInput, H3FactoryPreparedRowsInput,
     H3FactoryRawCheckpointInput, H3FactoryTargetBudgetInput, H3FactoryTargetDenoiseCopyPolicy,
     H3FactoryTargetLoadDropPolicy, H3FactoryTurboAdapterAuthority,
+};
+#[cfg(feature = "mp4")]
+use crate::h3_factory::{
+    expected_h3_factory_reference_charges, H3FactoryReferenceInput, H3FactoryReferenceKind,
 };
 use crate::progress::ProgressReporter;
 
@@ -685,6 +695,202 @@ impl H3PrivatePreparedFl2VaAttempt {
             _transformer_support: self._transformer_support,
         }
     }
+}
+
+/// Derive the factory's ordered reference descriptors from the prepared shapes
+/// and the facts the decoder reported.
+///
+/// Normalized geometry comes from the prepared shape (metadata-derived, the
+/// same values the runtime will normalize to); native geometry comes from what
+/// the decoder actually found, which is the authority for the retained-media
+/// charge. The two retained-byte totals are left to the factory to re-derive —
+/// this only reports the geometry they are computed from.
+#[cfg(feature = "mp4")]
+fn ref2va_factory_references(
+    prepared: &[super::pipeline::ref2va::H3PreparedReference],
+    decoded: &[super::pipeline::ref2va::H3DecodedReferenceFacts],
+) -> Result<Vec<H3FactoryReferenceInput>> {
+    prepared
+        .iter()
+        .zip(decoded)
+        .map(|(reference, facts)| {
+            let shape = &reference.shape;
+            let kind = match reference.metadata.kind {
+                GenerationReferenceKind::Image => H3FactoryReferenceKind::Image,
+                GenerationReferenceKind::Video => H3FactoryReferenceKind::Video,
+                GenerationReferenceKind::Audio => H3FactoryReferenceKind::Audio,
+            };
+            let mut input = H3FactoryReferenceInput {
+                index: reference.metadata.index,
+                kind,
+                content_sha256: reference.metadata.sha256.clone(),
+                preprocess_version: shape.version,
+                normalized_width: shape.normalized_width,
+                normalized_height: shape.normalized_height,
+                normalized_video_frames: shape.normalized_video_frames,
+                video_frames: shape.video_frames,
+                qwen_video_frames: shape.qwen_video_frames,
+                audio_samples_per_channel: shape.audio_samples_per_channel,
+                native_width: facts.width,
+                native_height: facts.height,
+                native_audio_samples_per_channel: facts
+                    .audio
+                    .as_ref()
+                    .map(|audio| audio.samples_per_channel),
+                native_audio_channels: facts.audio.as_ref().map(|audio| audio.channels),
+                visual_rows: 0,
+                audio_rows: 0,
+                qwen_vision_rows: 0,
+                normalized_host_bytes: 0,
+                native_host_bytes: 0,
+            };
+            // The factory owns this arithmetic; ask it rather than restate it,
+            // so the builder and the validator agree by construction.
+            let charges = expected_h3_factory_reference_charges(&input)?;
+            input.visual_rows = charges.visual_rows;
+            input.audio_rows = charges.audio_rows;
+            input.qwen_vision_rows = charges.qwen_vision_rows;
+            input.normalized_host_bytes = charges.normalized_host_bytes;
+            input.native_host_bytes = charges.native_host_bytes;
+            // The metadata-derived shape must agree with what the factory
+            // derives; a disagreement means the two contracts have drifted.
+            if shape.visual_rows != charges.visual_rows || shape.audio_rows != charges.audio_rows {
+                bail!(
+                    "private H3 reference {} prepared shape disagrees with the factory's rows",
+                    reference.metadata.index
+                )
+            }
+            Ok(input)
+        })
+        .collect()
+}
+
+/// Assemble the Ref2VA prepared-request input the frozen plan is built from.
+#[cfg(feature = "mp4")]
+fn ref2va_prepared_request_input(
+    request: &GenerateRequest,
+    prepared: &super::pipeline::ref2va::H3PreparedRef2VaRequest,
+    references: Vec<H3FactoryReferenceInput>,
+    qwen_output_text_rows: u64,
+) -> Result<H3FactoryPreparedRequestInput> {
+    let geometry = prepared.geometry();
+    let condition_visual_rows = checked_sum(references.iter().map(|entry| entry.visual_rows))?;
+    let condition_audio_rows = checked_sum(references.iter().map(|entry| entry.audio_rows))?;
+    let qwen_vision_rows = checked_sum(references.iter().map(|entry| entry.qwen_vision_rows))?;
+    let target_video_rows = u64::try_from(geometry.generated_video_rows)?;
+    let target_audio_rows = u64::try_from(geometry.generated_audio_rows)?;
+    let total_packed_rows = checked_sum([
+        qwen_output_text_rows,
+        condition_visual_rows,
+        condition_audio_rows,
+        target_video_rows,
+        target_audio_rows,
+    ])?;
+    let schedule =
+        H3DualSchedule::new_for_sampler(prepared.grid_points(), H3SamplerKind::ComfyResMultistep)?;
+    let mut input = H3FactoryPreparedRequestInput {
+        identity_sha256: String::new(),
+        canonical_model: contract::REF2VA_COMFY.into(),
+        task: Task::Ref2va,
+        mode: Mode::ReferenceToAudioVideo,
+        prompt_sha256: sha256(prepared.prompt().as_bytes()),
+        seed: prepared.seed(),
+        grid_points: u32::try_from(prepared.grid_points())?,
+        denoise_forward_count: u32::try_from(schedule.counts().transformer_evaluations)?,
+        guidance_f64_bits: request.guidance.to_bits(),
+        strength_f64_bits: request.strength.to_bits(),
+        batch_size: request.batch_size,
+        width: u32::try_from(geometry.width)?,
+        height: u32::try_from(geometry.height)?,
+        frames: u32::try_from(geometry.frames)?,
+        fps: contract::FIXED_FPS,
+        synchronized_audio: true,
+        mp4_output: true,
+        video_latent_frames: u64::try_from(geometry.latent_frames)?,
+        audio_latents_per_channel: u64::try_from(geometry.audio_latents_per_channel)?,
+        audio_samples_per_channel: u64::try_from(geometry.audio_latents_per_channel)?
+            .checked_mul(800)
+            .ok_or_else(|| anyhow!("private H3 Ref2VA audio sample count overflow"))?,
+        // Ref2VA conditions on references, so the endpoint fingerprint is the
+        // fixed no-endpoint domain and the reference fingerprint is the live
+        // one the staged set produced.
+        conditioning_fingerprint: sha256(b"mold.minimax-h3.ref2va-no-endpoints.v1"),
+        reference_fingerprint: prepared.reference_fingerprint().into(),
+        endpoints: Vec::new(),
+        references,
+        rows: H3FactoryPreparedRowsInput {
+            qwen_output_text_rows,
+            qwen_vision_rows,
+            condition_visual_rows,
+            condition_audio_rows,
+            target_video_rows,
+            target_audio_rows,
+            total_packed_rows,
+        },
+    };
+    input.identity_sha256 = expected_h3_factory_prepared_request_identity(&input);
+    Ok(input)
+}
+
+/// Build the Ref2VA admission prepared request.
+///
+/// Admission decodes and normalizes the ordered references through the SAME
+/// [`H3ReferenceMediaAdapter`] the runtime uses — there is deliberately no
+/// second decoder — because the exact Qwen row counts come from packing real
+/// vision pads, and the target budget is sized from the retained media those
+/// same steps produce. It runs entirely on the CPU and opens no CUDA device,
+/// matching the FL2VA path's endpoint normalization.
+///
+/// The decoded media is dropped when this returns: only geometry, digests, and
+/// row counts survive into the frozen plan, so no reference byte reaches the
+/// request, the queue journal, or the gallery.
+#[cfg(feature = "mp4")]
+pub(crate) fn prepare_private_ref2va_admission_request(
+    request: &GenerateRequest,
+    references: &[crate::engine::GenerationReferenceBinding],
+    support: &H3PrivateQwenSupport,
+    progress: &ProgressReporter,
+    observer: &mut dyn H3PipelineObserver,
+) -> Result<H3PrivateFl2VaAdmissionPreparedRequest> {
+    if support.model() != contract::REF2VA_COMFY || support.task() != Task::Ref2va {
+        bail!("private H3 Ref2VA admission has cross-task Qwen support")
+    }
+    let prepared = super::pipeline::ref2va::prepare_resolved_request(request, progress, observer)?;
+    let prepared_references = prepared.references();
+    if prepared_references.len() != references.len() {
+        bail!("private H3 Ref2VA admission reference count differs from its staged bindings")
+    }
+
+    let mut media = super::reference_media::H3ReferenceMediaAdapter::default();
+    let mut checkpoint = H3PrivatePreparationCheckpoint { progress };
+    let mut decoded = Vec::with_capacity(references.len());
+    for (reference, binding) in prepared_references.iter().zip(references) {
+        decoded.push(media.decode_reference(reference, binding, &mut checkpoint)?);
+    }
+    let mut presentations = Vec::with_capacity(references.len());
+    for (reference, facts) in prepared_references.iter().zip(&decoded) {
+        presentations.push(media.preprocess_reference(reference, facts, &mut checkpoint)?);
+    }
+
+    let (conditioner, _) = prepare_ref2va_conditioner_input_for_admission(
+        support.tokenizer(),
+        prepared.prompt(),
+        &presentations,
+        &media,
+    )?;
+    let (_, qwen_output_text_rows) = conditioner.input_ids.dims2()?;
+
+    let factory_references = ref2va_factory_references(prepared_references, &decoded)?;
+    let factory_request = ref2va_prepared_request_input(
+        request,
+        &prepared,
+        factory_references,
+        u64::try_from(qwen_output_text_rows)?,
+    )?;
+    Ok(H3PrivateFl2VaAdmissionPreparedRequest {
+        seed: prepared.seed(),
+        request: factory_request,
+    })
 }
 
 pub(crate) fn prepare_private_fl2va_admission_request(

--- a/crates/mold-inference/src/minimax_h3/private_qwen.rs
+++ b/crates/mold-inference/src/minimax_h3/private_qwen.rs
@@ -1500,6 +1500,21 @@ impl ConditionerProgressMapper {
     }
 }
 
+/// Admission's view of the Ref2VA conditioner input.
+///
+/// Identical to what the runtime encodes, built on the CPU so admission can
+/// read the exact row counts the frozen plan must carry. Deliberately the same
+/// function the runtime uses rather than a parallel estimator.
+#[cfg(feature = "mp4")]
+pub(crate) fn prepare_ref2va_conditioner_input_for_admission(
+    tokenizer: &impl H3RawTokenizer,
+    prompt: &str,
+    references: &[H3ReferencePresentation],
+    media: &H3ReferenceMediaAdapter,
+) -> Result<(H3ConditionerInput, Vec<H3ModalityTag>)> {
+    prepare_ref2va_conditioner_input(tokenizer, prompt, references, media, &Device::Cpu)
+}
+
 fn prepare_ref2va_conditioner_input(
     tokenizer: &impl H3RawTokenizer,
     prompt: &str,

--- a/crates/mold-inference/src/minimax_h3/private_server.rs
+++ b/crates/mold-inference/src/minimax_h3/private_server.rs
@@ -1091,9 +1091,12 @@ impl H3PrivateFl2VaAdmissionEvidence {
             self.attention.model_contract,
         )
         .map_err(|error| anyhow!(error.to_string()))?;
-        if self.canonical_model != contract::FL2VA_COMFY
-            || self.task != Task::Fl2va
-            || contract::validate_request_contract(&resolved, Task::Fl2va)
+        // The recorded route must be a coherent pinned pair, and the resolved
+        // request must satisfy THAT route. Re-asserting FL2VA here is what
+        // killed the Ref2VA evidence the rest of admission had just derived.
+        let recorded_contract = contract::capability_contract_for_model(&self.canonical_model);
+        if !recorded_contract.is_some_and(|recorded| recorded.task == self.task)
+            || contract::validate_resolved_request_contract(&resolved, self.task)
                 .map_err(|error| anyhow!("{}: {}", error.code, error.message))?
                 != self.mode
             || private_h3_request_identity(&resolved)? != self.resolved_request_identity_sha256
@@ -1206,7 +1209,11 @@ fn prepare_reviewed_h3_private_fl2va_admission(
             H3ComfyPublishedArtifact::Ref2VaPrunedInt8ConvRot,
         ),
     };
-    let mode = contract::validate_request_contract(request, admitted_task)
+    // Admission runs after reference resolution, so Ref2VA media are already
+    // descriptor authorities — the only valid queue/worker form, and the one
+    // the public-boundary validator refuses. FL2VA carries no references, so
+    // this is the same check it always made.
+    let mode = contract::validate_resolved_request_contract(request, admitted_task)
         .map_err(|error| anyhow!("{}: {}", error.code, error.message))?;
     let submitted_request_identity_sha256 = private_h3_request_identity(request)?;
 

--- a/crates/mold-inference/src/minimax_h3/private_server.rs
+++ b/crates/mold-inference/src/minimax_h3/private_server.rs
@@ -1188,7 +1188,25 @@ fn prepare_reviewed_h3_private_fl2va_admission(
     {
         bail!("private H3 admission requires one concrete nonempty CUDA capacity sample")
     }
-    let mode = contract::validate_request_contract(request, Task::Fl2va)
+    // The admitted route is derived once, from the request model's own pinned
+    // contract, and threaded through every step below. Reading it again from a
+    // constant is what let a Ref2VA request load FL2VA support and then fail
+    // its own cross-task check.
+    let admitted = contract::capability_contract_for_model(&request.model)
+        .ok_or_else(|| anyhow!("private H3 admission names an unknown model"))?;
+    let admitted_model = admitted.canonical_model;
+    let admitted_task = admitted.task;
+    let (admitted_transformer_task, admitted_published_artifact) = match admitted_task {
+        Task::Fl2va => (
+            H3TransformerTask::T2VaFl2Va,
+            H3ComfyPublishedArtifact::Fl2VaPrunedInt8ConvRot,
+        ),
+        Task::Ref2va => (
+            H3TransformerTask::Ref2Va,
+            H3ComfyPublishedArtifact::Ref2VaPrunedInt8ConvRot,
+        ),
+    };
+    let mode = contract::validate_request_contract(request, admitted_task)
         .map_err(|error| anyhow!("{}: {}", error.code, error.message))?;
     let submitted_request_identity_sha256 = private_h3_request_identity(request)?;
 
@@ -1223,7 +1241,7 @@ fn prepare_reviewed_h3_private_fl2va_admission(
     )?;
     let artifact_report = qualify_private_artifacts_with_control(
         paths.models_root,
-        contract::FL2VA_COMFY,
+        admitted_model,
         paths.authorization_record,
         |hash| {
             progress.checkpoint()?;
@@ -1293,13 +1311,12 @@ fn prepare_reviewed_h3_private_fl2va_admission(
     progress.checkpoint()?;
 
     let storage = H3PrivateComfyStorageAuthority::resolve(paths.models_root)?;
-    let qwen_support =
-        load_qualified_private_qwen_support(paths.models_root, contract::FL2VA_COMFY)?;
+    let qwen_support = load_qualified_private_qwen_support(paths.models_root, admitted_model)?;
     let transformer_cancellation = H3PrivatePreparationCancellation { progress };
     let opened_transformer = open_h3_comfy_published_int8_checkpoint(
         storage.transformer_path(),
-        H3TransformerTask::T2VaFl2Va,
-        H3ComfyPublishedArtifact::Fl2VaPrunedInt8ConvRot,
+        admitted_transformer_task,
+        admitted_published_artifact,
         &transformer_cancellation,
     )
     .map_err(|error| anyhow!(error.to_string()))?;
@@ -1308,9 +1325,6 @@ fn prepare_reviewed_h3_private_fl2va_admission(
     let opened_vae = open_h3_comfy_vae_authority(&vae_plan, &mut vae_observer);
     let opened_vae = vae_observer.finish(opened_vae)?;
 
-    let admitted_task = contract::capability_contract_for_model(&request.model)
-        .ok_or_else(|| anyhow!("private H3 admission names an unknown model"))?
-        .task;
     let mut prepare_observer = H3EngineProgressObserver::new(progress);
     // Conditioning is task-shaped: FL2VA normalizes its boundary endpoints
     // here, Ref2VA decodes and normalizes its ordered references through the
@@ -1401,7 +1415,7 @@ fn prepare_reviewed_h3_private_fl2va_admission(
         .collect::<Result<Vec<_>>>()?;
     let base_factory_authority =
         FrozenH3FactoryAuthority::new_contract_only(H3FactoryAuthorityInput {
-            model: contract::FL2VA_COMFY.into(),
+            model: admitted_model.into(),
             device_id: device_id.into(),
             device_ordinal,
             // The public H3 runtime profile is CUDA SM89, so this is always a
@@ -1508,8 +1522,8 @@ fn prepare_reviewed_h3_private_fl2va_admission(
         identity_sha256: String::new(),
         submitted_request_identity_sha256,
         resolved_request_identity_sha256,
-        canonical_model: contract::FL2VA_COMFY.into(),
-        task: Task::Fl2va,
+        canonical_model: admitted_model.into(),
+        task: admitted_task,
         mode,
         device_id: device_id.into(),
         device_ordinal,

--- a/crates/mold-inference/src/minimax_h3/private_server.rs
+++ b/crates/mold-inference/src/minimax_h3/private_server.rs
@@ -54,7 +54,8 @@ use super::private_fl2va_runtime::{
 #[cfg(feature = "mp4")]
 use super::private_opened_evidence::{
     build_private_fl2va_admission_attempt, prepare_private_fl2va_admission_request,
-    H3PrivateComfyStorageAuthority, H3PrivatePreparedFl2VaAttempt,
+    prepare_private_ref2va_admission_request, H3PrivateComfyStorageAuthority,
+    H3PrivatePreparedFl2VaAttempt,
 };
 use super::private_opened_evidence::{
     H3PrivateOpenedActivationFacts, H3PrivatePreparedFl2VaFactoryInputs,
@@ -92,6 +93,7 @@ use super::H3ConditionerLease;
 use crate::attention::{AttentionBackend, AttentionChunkPolicy};
 // Feature-independent: the envelope validators below name this in their
 // signatures in every build, matching how the type itself is defined.
+use crate::engine::GenerationReferenceBinding;
 use crate::h3_factory::H3FactoryTurboAdapterAuthority;
 #[cfg(feature = "mp4")]
 use crate::h3_factory::H3PrivateFl2VaFactoryAuthority;
@@ -811,6 +813,17 @@ pub struct H3PrivateFl2VaAdmissionInput<'a> {
     /// Host RAM available after the server's canonical 15%-or-8-GiB safety
     /// floor, never the raw operating-system available-memory sample.
     pub available_host_headroom_bytes: u64,
+    /// Verified bindings for the ordered Ref2VA references, minted by the
+    /// caller from the staged set immediately before admission.
+    ///
+    /// Empty for FL2VA, whose conditioning rides the endpoint contract. For
+    /// Ref2VA these are what let admission derive the prepared shapes and the
+    /// native/normalized retained-media geometry the target budget is sized
+    /// from — it decodes through the same media adapter the runtime uses, so
+    /// there is exactly one decoder. The bindings carry descriptors, never
+    /// bytes, and nothing derived from them reaches the request, the queue
+    /// journal, or the gallery.
+    pub references: &'a [GenerationReferenceBinding],
 }
 
 /// Payload-free projection of the thirteen independently reviewed runtime
@@ -1161,6 +1174,7 @@ fn prepare_reviewed_h3_private_fl2va_admission(
     let H3PrivateFl2VaAdmissionInput {
         request,
         paths,
+        references,
         device_id,
         device_ordinal,
         compute_capability,
@@ -1294,13 +1308,39 @@ fn prepare_reviewed_h3_private_fl2va_admission(
     let opened_vae = open_h3_comfy_vae_authority(&vae_plan, &mut vae_observer);
     let opened_vae = vae_observer.finish(opened_vae)?;
 
+    let admitted_task = contract::capability_contract_for_model(&request.model)
+        .ok_or_else(|| anyhow!("private H3 admission names an unknown model"))?
+        .task;
     let mut prepare_observer = H3EngineProgressObserver::new(progress);
-    let admission_request = prepare_private_fl2va_admission_request(
-        request,
-        &qwen_support,
-        progress,
-        &mut prepare_observer,
-    )?;
+    // Conditioning is task-shaped: FL2VA normalizes its boundary endpoints
+    // here, Ref2VA decodes and normalizes its ordered references through the
+    // same media adapter the runtime uses. Both run CPU-only, before the
+    // allocation commit, and neither opens a CUDA device.
+    let admission_request = match admitted_task {
+        Task::Fl2va => {
+            if !references.is_empty() {
+                bail!("private H3 FL2VA admission was handed Ref2VA reference bindings")
+            }
+            prepare_private_fl2va_admission_request(
+                request,
+                &qwen_support,
+                progress,
+                &mut prepare_observer,
+            )?
+        }
+        Task::Ref2va => {
+            if references.is_empty() {
+                bail!("private H3 Ref2VA admission has no staged reference bindings")
+            }
+            prepare_private_ref2va_admission_request(
+                request,
+                references,
+                &qwen_support,
+                progress,
+                &mut prepare_observer,
+            )?
+        }
+    };
     // The qualification above was minted at this tier's reviewed step count;
     // validating the prepared request against the baseline 21-step envelope
     // would reject every Turbo attempt.
@@ -3029,8 +3069,8 @@ unsafe impl H3PrivateFl2VaArtifactLease for H3PrivateServerFl2VaArtifactLease {
 }
 
 #[cfg(feature = "mp4")]
-struct H3PrivatePreparationCheckpoint<'a> {
-    progress: &'a ProgressReporter,
+pub(crate) struct H3PrivatePreparationCheckpoint<'a> {
+    pub(crate) progress: &'a ProgressReporter,
 }
 
 #[cfg(feature = "mp4")]

--- a/crates/mold-server/src/reference_uploads.rs
+++ b/crates/mold-server/src/reference_uploads.rs
@@ -138,11 +138,33 @@ struct UploadSource {
 /// Private resolved media authority. Paths never enter JSON, queue metadata,
 /// logs, or durable recovery state; dropping the last owner removes staging.
 pub struct ResolvedReferenceSet {
-    root: PathBuf,
     entries: Vec<ResolvedReference>,
     fingerprint: String,
+    hold: Arc<ResolvedReferenceHold>,
+}
+
+/// The quota reservation and staging directory for one resolved set.
+///
+/// These were drop-scoped to the set itself, which raced admission: cancelling
+/// a queued job drops the set, releasing the quota and unlinking the staging
+/// while a spawned preparation task is still decoding from descriptors that
+/// survive the unlink. Holding both behind an `Arc` means the last holder
+/// releases them — the quota exactly once, and the directory only when no
+/// admission view can still be reading it.
+struct ResolvedReferenceHold {
+    root: PathBuf,
     _quota: ResolvedQuotaLease,
     _store_lifetime: Arc<StoreLifetime>,
+}
+
+impl Drop for ResolvedReferenceHold {
+    fn drop(&mut self) {
+        if let Err(error) = std::fs::remove_dir_all(&self.root) {
+            if error.kind() != std::io::ErrorKind::NotFound {
+                tracing::warn!("failed to remove private reference staging: {error}");
+            }
+        }
+    }
 }
 
 struct ResolvedQuotaLease {
@@ -216,15 +238,16 @@ impl ResolvedReferenceSet {
             uuid::Uuid::new_v4()
         ));
         Self {
-            root: root.clone(),
             entries: Vec::new(),
             fingerprint: mold_core::generation_reference_fingerprint(&metadata),
-            _quota: ResolvedQuotaLease::new(Arc::new(AtomicU64::new(0))),
-            // A test/synthetic set owns no live staging root of its own.
-            // A resolved set owns no staging root of its own to claim.
-            _store_lifetime: Arc::new(StoreLifetime {
-                claim: std::sync::OnceLock::new(),
-                root,
+            hold: Arc::new(ResolvedReferenceHold {
+                root: root.clone(),
+                _quota: ResolvedQuotaLease::new(Arc::new(AtomicU64::new(0))),
+                // A test/synthetic set owns no live staging root to claim.
+                _store_lifetime: Arc::new(StoreLifetime {
+                    claim: std::sync::OnceLock::new(),
+                    root,
+                }),
             }),
         }
     }
@@ -252,18 +275,16 @@ impl ResolvedReferenceSet {
     /// It holds paths and probed metadata, never bytes, and mints its bindings
     /// through the same verifier the runtime uses.
     ///
-    /// The view does NOT keep the staged files alive: if the owning set is
-    /// dropped first, its `Drop` removes them and every binding this view
-    /// mints fails to open. That is the intended failure mode — admission
-    /// errors out rather than proceeding on media it cannot verify — and it is
-    /// why the store lifetime is retained only to pin the root, not the set's
-    /// own subdirectory. Callers must keep the owning job alive across
-    /// preparation, which the scheduler does.
+    /// The view DOES keep the staged files and their quota reservation alive:
+    /// it shares the set's hold, so cancelling and dropping the owning job
+    /// mid-preparation cannot unlink the staging or release the reservation
+    /// out from under an in-flight decode. The quota is still released exactly
+    /// once, by whichever holder drops last.
     pub fn admission_view(&self) -> ResolvedReferenceAdmissionView {
         ResolvedReferenceAdmissionView {
             entries: self.entries.clone(),
             fingerprint: self.fingerprint.clone(),
-            _store_lifetime: Arc::clone(&self._store_lifetime),
+            _hold: Arc::clone(&self.hold),
         }
     }
 }
@@ -273,7 +294,10 @@ impl ResolvedReferenceSet {
 pub struct ResolvedReferenceAdmissionView {
     entries: Vec<ResolvedReference>,
     fingerprint: String,
-    _store_lifetime: Arc<StoreLifetime>,
+    /// Keeps the staged files and their quota reservation alive for as long as
+    /// admission may still read them, even if the owning job is cancelled and
+    /// dropped mid-preparation.
+    _hold: Arc<ResolvedReferenceHold>,
 }
 
 impl std::fmt::Debug for ResolvedReferenceAdmissionView {
@@ -372,16 +396,6 @@ fn mint_inference_bindings(
                 })
             })
             .collect()
-    }
-}
-
-impl Drop for ResolvedReferenceSet {
-    fn drop(&mut self) {
-        if let Err(error) = std::fs::remove_dir_all(&self.root) {
-            if error.kind() != std::io::ErrorKind::NotFound {
-                tracing::warn!("failed to remove private reference staging: {error}");
-            }
-        }
     }
 }
 
@@ -1232,11 +1246,13 @@ impl ReferenceUploadStore {
         let fingerprint = mold_core::generation_reference_fingerprint(&metadata);
         request.references = Some(descriptors);
         Ok(Some(ResolvedReferenceSet {
-            root: resolved_root,
             entries,
             fingerprint,
-            _quota: quota,
-            _store_lifetime: self._lifetime.clone(),
+            hold: Arc::new(ResolvedReferenceHold {
+                root: resolved_root,
+                _quota: quota,
+                _store_lifetime: self._lifetime.clone(),
+            }),
         }))
     }
 }
@@ -2743,6 +2759,135 @@ mod tests {
         drop(view);
         drop(resolved);
         assert_eq!(store.resolved_bytes.load(Ordering::Acquire), 0);
+    }
+
+    /// Cancelling a queued job drops the resolved set while an admission
+    /// decode may still be running against it. The staging and its quota must
+    /// outlive that decode, and the quota must still be released exactly once.
+    #[tokio::test]
+    async fn dropping_the_owning_set_mid_admission_keeps_staging_and_releases_quota_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ReferenceUploadStore::at(dir.path().join("cache"));
+        let bytes = png_bytes();
+        let byte_count = bytes.len() as u64;
+        let digest = format!("{:x}", Sha256::digest(&bytes));
+        let descriptor = png_reference(GenerationReferenceAuthority::Descriptor, Some(digest));
+        let session = store
+            .create_session(
+                "auth-a",
+                "instance-a",
+                ReferenceUploadSessionRequest {
+                    request: request(descriptor.clone()),
+                    upload_references: vec![1],
+                },
+            )
+            .await
+            .unwrap();
+        let handle = session.uploads[0].handle.clone();
+        let complete = store
+            .upload(
+                "auth-a",
+                "instance-a",
+                &handle,
+                "image/png",
+                byte_count,
+                Body::from(bytes),
+            )
+            .await
+            .unwrap();
+        let mut final_request = request(png_reference(
+            GenerationReferenceAuthority::Upload {
+                handle: handle.clone(),
+            },
+            Some(complete.metadata.sha256.clone()),
+        ));
+        let resolved = store
+            .resolve_request("auth-a", &mut final_request, &[], None)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let staged = resolved.entries()[0].path.clone();
+        assert!(staged.is_file());
+        assert_eq!(store.resolved_bytes.load(Ordering::Acquire), byte_count);
+
+        // Admission is in flight, holding only the view.
+        let view = resolved.admission_view();
+
+        // The job is cancelled and its set dropped out from under admission.
+        drop(resolved);
+
+        // Staging survives and the reservation is still charged, so the decode
+        // is not reading unlinked files on released quota.
+        assert!(
+            staged.is_file(),
+            "staging must outlive the owning set while an admission view holds it"
+        );
+        assert_eq!(store.resolved_bytes.load(Ordering::Acquire), byte_count);
+        // And it can still bind, which is the whole point of holding it.
+        assert_eq!(
+            view.inference_bindings(&final_request, None).unwrap().len(),
+            1
+        );
+
+        // When admission finishes, the last holder releases both — once.
+        drop(view);
+        assert!(!staged.exists());
+        assert_eq!(store.resolved_bytes.load(Ordering::Acquire), 0);
+    }
+
+    /// A cancelled preparation must stop decoding rather than run to
+    /// completion on media whose job is already gone.
+    #[tokio::test]
+    async fn a_cancelled_admission_stops_binding_cooperatively() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ReferenceUploadStore::at(dir.path().join("cache"));
+        let bytes = png_bytes();
+        let byte_count = bytes.len() as u64;
+        let digest = format!("{:x}", Sha256::digest(&bytes));
+        let descriptor = png_reference(GenerationReferenceAuthority::Descriptor, Some(digest));
+        let session = store
+            .create_session(
+                "auth-a",
+                "instance-a",
+                ReferenceUploadSessionRequest {
+                    request: request(descriptor.clone()),
+                    upload_references: vec![1],
+                },
+            )
+            .await
+            .unwrap();
+        let handle = session.uploads[0].handle.clone();
+        let complete = store
+            .upload(
+                "auth-a",
+                "instance-a",
+                &handle,
+                "image/png",
+                byte_count,
+                Body::from(bytes),
+            )
+            .await
+            .unwrap();
+        let mut final_request = request(png_reference(
+            GenerationReferenceAuthority::Upload {
+                handle: handle.clone(),
+            },
+            Some(complete.metadata.sha256.clone()),
+        ));
+        let resolved = store
+            .resolve_request("auth-a", &mut final_request, &[], None)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let view = resolved.admission_view();
+        let cancellation = mold_inference::InferenceCancellationToken::default();
+        cancellation.cancel();
+        let error = view
+            .inference_bindings(&final_request, Some(&cancellation))
+            .unwrap_err();
+        assert!(mold_inference::is_inference_cancelled(&error));
     }
 
     #[tokio::test]

--- a/crates/mold-server/src/reference_uploads.rs
+++ b/crates/mold-server/src/reference_uploads.rs
@@ -170,6 +170,10 @@ impl Drop for ResolvedQuotaLease {
     }
 }
 
+/// Plain staged-file coordinates: probed metadata plus the private path. It
+/// owns no descriptor, quota, or lifetime, so copying one grants no authority
+/// on its own — every use still opens and re-verifies the file.
+#[derive(Clone)]
 pub struct ResolvedReference {
     pub metadata: GenerationReferenceMetadata,
     pub path: PathBuf,
@@ -234,12 +238,95 @@ impl ResolvedReferenceSet {
         request: &mold_core::GenerateRequest,
         cancellation: Option<&mold_inference::InferenceCancellationToken>,
     ) -> anyhow::Result<Vec<mold_inference::GenerationReferenceBinding>> {
+        mint_inference_bindings(&self.entries, &self.fingerprint, request, cancellation)
+    }
+
+    /// A payload-free, quota-free projection of this set for H3 admission.
+    ///
+    /// Admission runs on a spawned task, so it needs an owned `'static` value,
+    /// but `ResolvedReferenceSet` deliberately is not `Clone`: its quota lease
+    /// is a drop guard and cloning it would release the reservation twice, and
+    /// its `Drop` removes the staging directory. The view therefore carries
+    /// neither — the set on the job keeps owning the quota and the directory.
+    ///
+    /// It holds paths and probed metadata, never bytes, and mints its bindings
+    /// through the same verifier the runtime uses.
+    ///
+    /// The view does NOT keep the staged files alive: if the owning set is
+    /// dropped first, its `Drop` removes them and every binding this view
+    /// mints fails to open. That is the intended failure mode — admission
+    /// errors out rather than proceeding on media it cannot verify — and it is
+    /// why the store lifetime is retained only to pin the root, not the set's
+    /// own subdirectory. Callers must keep the owning job alive across
+    /// preparation, which the scheduler does.
+    pub fn admission_view(&self) -> ResolvedReferenceAdmissionView {
+        ResolvedReferenceAdmissionView {
+            entries: self.entries.clone(),
+            fingerprint: self.fingerprint.clone(),
+            _store_lifetime: Arc::clone(&self._store_lifetime),
+        }
+    }
+}
+
+/// See [`ResolvedReferenceSet::admission_view`].
+#[derive(Clone)]
+pub struct ResolvedReferenceAdmissionView {
+    entries: Vec<ResolvedReference>,
+    fingerprint: String,
+    _store_lifetime: Arc<StoreLifetime>,
+}
+
+impl std::fmt::Debug for ResolvedReferenceAdmissionView {
+    /// Never render staged paths; the set's own `Debug` has the same rule.
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ResolvedReferenceAdmissionView")
+            .field("entries", &self.entries.len())
+            .field("fingerprint", &self.fingerprint)
+            .finish()
+    }
+}
+
+impl ResolvedReferenceAdmissionView {
+    pub fn fingerprint(&self) -> &str {
+        &self.fingerprint
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Mint verified bindings for admission. Identical verification to the
+    /// runtime's path — same order, metadata, and fingerprint checks, and
+    /// fresh descriptors opened without following symlinks.
+    pub fn inference_bindings(
+        &self,
+        request: &mold_core::GenerateRequest,
+        cancellation: Option<&mold_inference::InferenceCancellationToken>,
+    ) -> anyhow::Result<Vec<mold_inference::GenerationReferenceBinding>> {
+        mint_inference_bindings(&self.entries, &self.fingerprint, request, cancellation)
+    }
+}
+
+/// The one binding verifier. Both the owning set and its admission view route
+/// here so a staged file can never be bound under two different rule sets.
+fn mint_inference_bindings(
+    entries: &[ResolvedReference],
+    fingerprint: &str,
+    request: &mold_core::GenerateRequest,
+    cancellation: Option<&mold_inference::InferenceCancellationToken>,
+) -> anyhow::Result<Vec<mold_inference::GenerationReferenceBinding>> {
+    {
         let references = request
             .references
             .as_deref()
             .ok_or_else(|| anyhow::anyhow!("resolved references lost their queued descriptors"))?;
         anyhow::ensure!(
-            references.len() == self.entries.len(),
+            references.len() == entries.len(),
             "resolved reference count changed before inference"
         );
         let queued_metadata = references
@@ -248,10 +335,10 @@ impl ResolvedReferenceSet {
             .map(|(index, reference)| reference.redacted_metadata_lossless(index))
             .collect::<Vec<_>>();
         anyhow::ensure!(
-            mold_core::generation_reference_fingerprint(&queued_metadata) == self.fingerprint,
+            mold_core::generation_reference_fingerprint(&queued_metadata) == fingerprint,
             "resolved reference fingerprint changed before inference"
         );
-        self.entries
+        entries
             .iter()
             .zip(queued_metadata)
             .map(|(entry, queued)| {
@@ -2555,6 +2642,107 @@ mod tests {
             inner.sessions[&session_digest].request.model,
             minimax_h3::REF2VA_COMFY
         );
+    }
+
+    /// The admission view is what lets Ref2VA admission reach the staged media
+    /// before a frozen plan exists, so it must bind exactly like the runtime
+    /// path while carrying none of the owning set's authority.
+    #[tokio::test]
+    async fn admission_view_binds_like_the_runtime_and_holds_no_owning_authority() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = ReferenceUploadStore::at(dir.path().join("cache"));
+        let bytes = png_bytes();
+        let byte_count = bytes.len() as u64;
+        let digest = format!("{:x}", Sha256::digest(&bytes));
+        let descriptor = png_reference(GenerationReferenceAuthority::Descriptor, Some(digest));
+        let session = store
+            .create_session(
+                "auth-a",
+                "instance-a",
+                ReferenceUploadSessionRequest {
+                    request: request(descriptor.clone()),
+                    upload_references: vec![1],
+                },
+            )
+            .await
+            .unwrap();
+        let handle = session.uploads[0].handle.clone();
+        let complete = store
+            .upload(
+                "auth-a",
+                "instance-a",
+                &handle,
+                "image/png",
+                byte_count,
+                Body::from(bytes),
+            )
+            .await
+            .unwrap();
+        let mut final_request = request(png_reference(
+            GenerationReferenceAuthority::Upload {
+                handle: handle.clone(),
+            },
+            Some(complete.metadata.sha256.clone()),
+        ));
+        let resolved = store
+            .resolve_request("auth-a", &mut final_request, &[], None)
+            .await
+            .unwrap()
+            .unwrap();
+
+        let view = resolved.admission_view();
+        assert_eq!(view.len(), resolved.entries().len());
+        assert!(!view.is_empty());
+        assert_eq!(view.fingerprint(), resolved.fingerprint());
+
+        // Same verifier, same result: the view must not become a second
+        // contract that could admit media the runtime would reject.
+        let runtime_bindings = resolved.inference_bindings(&final_request, None).unwrap();
+        let admission_bindings = view.inference_bindings(&final_request, None).unwrap();
+        assert_eq!(admission_bindings.len(), runtime_bindings.len());
+        assert_eq!(
+            admission_bindings[0].metadata(),
+            runtime_bindings[0].metadata()
+        );
+        // Independent descriptors, so releasing admission's cannot disturb the
+        // runtime's later binding.
+        drop(admission_bindings);
+        drop(runtime_bindings);
+        assert_eq!(
+            resolved
+                .inference_bindings(&final_request, None)
+                .unwrap()
+                .len(),
+            1
+        );
+
+        // It renders neither staged paths nor the upload handle.
+        let rendered = format!("{view:?}");
+        assert!(!rendered.contains(dir.path().to_string_lossy().as_ref()));
+        assert!(!rendered.contains(&handle));
+
+        // It carries no quota lease, so cloning and dropping it must not
+        // release the owning set's reservation.
+        let cloned = view.clone();
+        drop(cloned);
+        assert_eq!(store.resolved_bytes.load(Ordering::Acquire), byte_count);
+
+        // A drifted request is refused here exactly as on the runtime path.
+        let mut drifted = final_request.clone();
+        drifted.references = None;
+        assert!(view.inference_bindings(&drifted, None).is_err());
+
+        // Cancellation is honoured identically too.
+        let cancellation = mold_inference::InferenceCancellationToken::default();
+        cancellation.cancel();
+        let cancelled = view
+            .inference_bindings(&final_request, Some(&cancellation))
+            .unwrap_err();
+        assert!(mold_inference::is_inference_cancelled(&cancelled));
+
+        drop(view);
+        drop(resolved);
+        assert_eq!(store.resolved_bytes.load(Ordering::Acquire), 0);
     }
 
     #[tokio::test]

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -3482,6 +3482,21 @@ async fn placement_preview_for_request_authenticated(
         // the documented behaviour for a plan this endpoint cannot model.
         h3_resolved_references: None,
     };
+    // Ref2VA plans depend on the staged reference media, which this probe
+    // deliberately never carries. Preparation would therefore fail for the
+    // absence of media rather than for anything about the device, and
+    // reporting that as an authoritative `infeasible` would tell the client a
+    // capacity answer this endpoint cannot give. Decline before that runs.
+    #[cfg(any(feature = "h3", feature = "h3-private-uat"))]
+    if mold_core::minimax_h3::capability_contract_for_model(&request.model)
+        .is_some_and(|contract| contract.task == mold_core::minimax_h3::Task::Ref2va)
+    {
+        return Ok(unavailable(
+            "unsupported",
+            "MiniMax H3 Ref2VA placement preview is not modeled without staged reference media"
+                .to_string(),
+        ));
+    }
     #[cfg(not(any(feature = "h3", feature = "h3-private-uat")))]
     let dependency_context = crate::variant_dependencies::DependencyPreparationContext::default();
     let prepared = match crate::variant_dependencies::prepare_execution_inputs_existing_only(

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -3476,6 +3476,11 @@ async fn placement_preview_for_request_authenticated(
         } else {
             None
         },
+        // Placement preview is a read-only probe that must stay media-free, so
+        // it never carries staged references. A Ref2VA preview therefore has
+        // no prepared shapes to derive and stays non-authoritative, which is
+        // the documented behaviour for a plan this endpoint cannot model.
+        h3_resolved_references: None,
     };
     #[cfg(not(any(feature = "h3", feature = "h3-private-uat")))]
     let dependency_context = crate::variant_dependencies::DependencyPreparationContext::default();

--- a/crates/mold-server/src/scheduler/mod.rs
+++ b/crates/mold-server/src/scheduler/mod.rs
@@ -1723,6 +1723,15 @@ impl Coordinator {
             #[cfg(any(feature = "h3", feature = "h3-private-uat"))]
             let context = crate::variant_dependencies::DependencyPreparationContext {
                 h3_private_ingress_grant: pending.job.h3_private_ingress_grant.clone(),
+                // Ref2VA admission derives its prepared shapes from the staged
+                // media, so it needs the files before the frozen plan exists.
+                // The view is payload-free and the job keeps owning the set,
+                // its quota, and its staging directory across preparation.
+                h3_resolved_references: pending
+                    .job
+                    .resolved_references
+                    .as_ref()
+                    .map(crate::reference_uploads::ResolvedReferenceSet::admission_view),
             };
             #[cfg(not(any(feature = "h3", feature = "h3-private-uat")))]
             let context = crate::variant_dependencies::DependencyPreparationContext::default();

--- a/crates/mold-server/src/variant_dependencies.rs
+++ b/crates/mold-server/src/variant_dependencies.rs
@@ -1454,26 +1454,108 @@ async fn prepare_inputs_for_devices(
     Ok(prepared)
 }
 
-/// Cancels its token when dropped, so an abandoned preparation stops the
-/// CPU decoding it spawned rather than letting it run to completion.
+/// Cancels its token when dropped UNLESS disarmed, so an abandoned or
+/// unwinding preparation stops the CPU decoding it spawned, while a completed
+/// one leaves its token uncancelled — the admitted evidence and any binding
+/// derived from it must stay valid after preparation returns.
 #[cfg(any(feature = "h3", feature = "h3-private-uat"))]
-struct PreparationCancellationGuard(mold_inference::InferenceCancellationToken);
+struct PreparationCancellationGuard {
+    token: mold_inference::InferenceCancellationToken,
+    armed: bool,
+}
 
 #[cfg(any(feature = "h3", feature = "h3-private-uat"))]
 impl PreparationCancellationGuard {
     fn new() -> Self {
-        Self(mold_inference::InferenceCancellationToken::default())
+        Self {
+            token: mold_inference::InferenceCancellationToken::default(),
+            armed: true,
+        }
     }
 
-    fn clone(&self) -> mold_inference::InferenceCancellationToken {
-        self.0.clone()
+    fn token(&self) -> mold_inference::InferenceCancellationToken {
+        self.token.clone()
+    }
+
+    /// Call on the success path only. Every early return and every unwind
+    /// leaves the guard armed, which is what makes abandonment cancel.
+    fn disarm(&mut self) {
+        self.armed = false;
     }
 }
 
 #[cfg(any(feature = "h3", feature = "h3-private-uat"))]
 impl Drop for PreparationCancellationGuard {
     fn drop(&mut self) {
-        self.0.cancel();
+        if self.armed {
+            self.token.cancel();
+        }
+    }
+}
+
+#[cfg(all(test, any(feature = "h3", feature = "h3-private-uat")))]
+mod preparation_cancellation_tests {
+    use super::PreparationCancellationGuard;
+
+    /// An abandoned or unwinding preparation must cancel the work it spawned,
+    /// so a cancelled job stops decoding at the next checkpoint instead of
+    /// running to completion on media nobody will use.
+    #[test]
+    fn an_armed_guard_cancels_its_token_on_drop() {
+        let guard = PreparationCancellationGuard::new();
+        let token = guard.token();
+        assert!(!token.is_cancelled());
+        drop(guard);
+        assert!(token.is_cancelled());
+    }
+
+    /// A COMPLETED preparation must not cancel: its admitted evidence and any
+    /// binding derived from it have to stay valid after preparation returns.
+    #[test]
+    fn a_disarmed_guard_leaves_its_token_usable() {
+        let mut guard = PreparationCancellationGuard::new();
+        let token = guard.token();
+        guard.disarm();
+        drop(guard);
+        assert!(!token.is_cancelled());
+    }
+
+    /// The Ref2VA media decode checkpoints through the admission reporter, so
+    /// the reporter — not just the binding step — has to carry the token.
+    /// Binding consults it directly while hashing and retains none, so a token
+    /// installed only there leaves the decode itself uninterruptible.
+    #[test]
+    fn the_admission_reporter_carries_the_cancellation_token_into_decode() {
+        let guard = PreparationCancellationGuard::new();
+        let mut reporter = mold_inference::progress::ProgressReporter::default();
+        reporter.set_cancellation_token(guard.token());
+
+        // Before cancellation the decode proceeds.
+        reporter
+            .checkpoint()
+            .expect("an armed preparation still runs");
+
+        // Dropping the guard is what an abandoned preparation does, and the
+        // next decode checkpoint must observe it.
+        drop(guard);
+        let stopped = reporter.checkpoint().unwrap_err();
+        assert!(mold_inference::is_inference_cancelled(&anyhow::Error::new(
+            stopped
+        )));
+    }
+
+    /// Unwinding is the abandonment case that is easiest to get wrong, since
+    /// it takes no explicit return path.
+    #[test]
+    fn a_panicking_preparation_still_cancels() {
+        let guard = PreparationCancellationGuard::new();
+        let token = guard.token();
+        let unwound = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+            let _guard = guard;
+            panic!("preparation failed");
+        }));
+        assert!(unwound.is_err());
+        assert!(token.is_cancelled());
     }
 }
 
@@ -1509,7 +1591,7 @@ async fn prepare_h3_private_inputs_for_devices(
     let mut resolved_request = request.clone();
     // Dropped when this preparation returns or unwinds, which cancels every
     // spawned decode that is still running for it.
-    let preparation_cancellation = PreparationCancellationGuard::new();
+    let mut preparation_cancellation = PreparationCancellationGuard::new();
     let mut evidence_by_device = BTreeMap::new();
     let mut failures = BTreeMap::new();
 
@@ -1535,13 +1617,17 @@ async fn prepare_h3_private_inputs_for_devices(
         // attempt is what keeps descriptor identity fenced to the attempt that
         // verified it.
         let references = resolved_references.clone();
-        let cancellation = preparation_cancellation.clone();
+        let cancellation = preparation_cancellation.token();
         let device_id = device.id.clone();
         let device_ordinal = device.ordinal;
         let available_device_bytes = device.available_vram_bytes;
         let progress_tx = progress.cloned();
         let evidence = tokio::task::spawn_blocking(move || {
             let mut reporter = mold_inference::progress::ProgressReporter::default();
+            // The decode checkpoints through this reporter, so the token has
+            // to live here — bindings retain none, and consulting it only
+            // while hashing would leave the media decode uninterruptible.
+            reporter.set_cancellation_token(cancellation.clone());
             if let Some(progress_tx) = progress_tx {
                 reporter.set_callback(Box::new(move |event| {
                     crate::gpu_worker::record_h3_progress(event, Some(&progress_tx));
@@ -1658,6 +1744,9 @@ async fn prepare_h3_private_inputs_for_devices(
         authority.update(device_id.as_bytes());
         authority.update(evidence.identity_sha256().as_bytes());
     }
+    // Every device admitted, so the work this token guards is finished and
+    // its bindings must remain usable.
+    preparation_cancellation.disarm();
     Ok(PreparedExecutionInputs {
         authority_fingerprint: format!("{:x}", authority.finalize()),
         by_device,

--- a/crates/mold-server/src/variant_dependencies.rs
+++ b/crates/mold-server/src/variant_dependencies.rs
@@ -1454,6 +1454,29 @@ async fn prepare_inputs_for_devices(
     Ok(prepared)
 }
 
+/// Cancels its token when dropped, so an abandoned preparation stops the
+/// CPU decoding it spawned rather than letting it run to completion.
+#[cfg(any(feature = "h3", feature = "h3-private-uat"))]
+struct PreparationCancellationGuard(mold_inference::InferenceCancellationToken);
+
+#[cfg(any(feature = "h3", feature = "h3-private-uat"))]
+impl PreparationCancellationGuard {
+    fn new() -> Self {
+        Self(mold_inference::InferenceCancellationToken::default())
+    }
+
+    fn clone(&self) -> mold_inference::InferenceCancellationToken {
+        self.0.clone()
+    }
+}
+
+#[cfg(any(feature = "h3", feature = "h3-private-uat"))]
+impl Drop for PreparationCancellationGuard {
+    fn drop(&mut self) {
+        self.0.cancel();
+    }
+}
+
 #[cfg(any(feature = "h3", feature = "h3-private-uat"))]
 #[allow(clippy::too_many_arguments)]
 async fn prepare_h3_private_inputs_for_devices(
@@ -1484,6 +1507,9 @@ async fn prepare_h3_private_inputs_for_devices(
     #[cfg(feature = "h3")]
     uat_paths.ensure_staging_root();
     let mut resolved_request = request.clone();
+    // Dropped when this preparation returns or unwinds, which cancels every
+    // spawned decode that is still running for it.
+    let preparation_cancellation = PreparationCancellationGuard::new();
     let mut evidence_by_device = BTreeMap::new();
     let mut failures = BTreeMap::new();
 
@@ -1509,6 +1535,7 @@ async fn prepare_h3_private_inputs_for_devices(
         // attempt is what keeps descriptor identity fenced to the attempt that
         // verified it.
         let references = resolved_references.clone();
+        let cancellation = preparation_cancellation.clone();
         let device_id = device.id.clone();
         let device_ordinal = device.ordinal;
         let available_device_bytes = device.available_vram_bytes;
@@ -1520,9 +1547,15 @@ async fn prepare_h3_private_inputs_for_devices(
                     crate::gpu_worker::record_h3_progress(event, Some(&progress_tx));
                 }));
             }
+            // Cooperative abort: a cancelled preparation stops decoding at
+            // the next checkpoint instead of burning CPU on media whose job is
+            // already gone. The staging and its quota stay alive regardless,
+            // because the view shares the resolved set's hold.
             let bindings = match references
                 .as_ref()
-                .map(|references| references.inference_bindings(&admission_request, None))
+                .map(|references| {
+                    references.inference_bindings(&admission_request, Some(&cancellation))
+                })
                 .transpose()
             {
                 Ok(bindings) => bindings.unwrap_or_default(),

--- a/crates/mold-server/src/variant_dependencies.rs
+++ b/crates/mold-server/src/variant_dependencies.rs
@@ -1182,7 +1182,15 @@ async fn prepare_inputs_for_devices(
         })?;
         grant.validate_for_request(request, live_state.instance_id.as_str())?;
         return prepare_h3_private_inputs_for_devices(
-            state, work_id, request, config, devices, progress, policy, grant,
+            state,
+            work_id,
+            request,
+            config,
+            devices,
+            progress,
+            policy,
+            grant,
+            context.h3_resolved_references.clone(),
         )
         .await;
     }
@@ -1457,6 +1465,7 @@ async fn prepare_h3_private_inputs_for_devices(
     progress: Option<&tokio::sync::mpsc::UnboundedSender<SseMessage>>,
     _policy: DependencyMaterializationPolicy,
     ingress_grant: crate::h3_private_bridge::H3PrivateIngressGrant,
+    resolved_references: Option<crate::reference_uploads::ResolvedReferenceAdmissionView>,
 ) -> Result<PreparedExecutionInputs, String> {
     use sha2::{Digest, Sha256};
 
@@ -1495,6 +1504,11 @@ async fn prepare_h3_private_inputs_for_devices(
         };
         let admission_request = resolved_request.clone();
         let paths = uat_paths.clone();
+        // Each device's admission mints its own descriptors rather than
+        // sharing one set: a binding owns an open file, and re-opening per
+        // attempt is what keeps descriptor identity fenced to the attempt that
+        // verified it.
+        let references = resolved_references.clone();
         let device_id = device.id.clone();
         let device_ordinal = device.ordinal;
         let available_device_bytes = device.available_vram_bytes;
@@ -1506,10 +1520,23 @@ async fn prepare_h3_private_inputs_for_devices(
                     crate::gpu_worker::record_h3_progress(event, Some(&progress_tx));
                 }));
             }
+            let bindings = match references
+                .as_ref()
+                .map(|references| references.inference_bindings(&admission_request, None))
+                .transpose()
+            {
+                Ok(bindings) => bindings.unwrap_or_default(),
+                Err(error) => {
+                    return Err(format!(
+                        "MiniMax H3 admission could not bind its staged references: {error}"
+                    ))
+                }
+            };
             mold_inference::prepare_h3_private_fl2va_admission(
                 mold_inference::H3PrivateFl2VaAdmissionInput {
                     request: &admission_request,
                     paths: paths.inference_paths(),
+                    references: &bindings,
                     device_id: &device_id,
                     device_ordinal,
                     compute_capability,
@@ -1608,10 +1635,20 @@ async fn prepare_h3_private_inputs_for_devices(
     })
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default)]
 pub struct DependencyPreparationContext {
     #[cfg(any(feature = "h3", feature = "h3-private-uat"))]
     pub(crate) h3_private_ingress_grant: Option<crate::h3_private_bridge::H3PrivateIngressGrant>,
+    /// Staged Ref2VA references, as a payload-free view.
+    ///
+    /// Ref2VA admission must derive its prepared shapes from the real media,
+    /// so it needs the staged files before the frozen plan exists. Only the
+    /// scheduler populates this, from the owning job; placement preview leaves
+    /// it `None`, which keeps that probe media-free and non-authoritative for
+    /// Ref2VA exactly as the placement-preview boundary requires.
+    #[cfg(any(feature = "h3", feature = "h3-private-uat"))]
+    pub(crate) h3_resolved_references:
+        Option<crate::reference_uploads::ResolvedReferenceAdmissionView>,
 }
 
 pub async fn prepare_execution_inputs(


### PR DESCRIPTION
## Summary

Unblocks #825 item 4: admission can now see the resolved reference bindings, and the H3 private admission builder is task-shaped.

- **Threading without ripple**: `DependencyPreparationContext` already exists solely to carry H3 admission authority (cfg-gated, two construction sites). The scheduler site hands in `pending.job.resolved_references`; placement preview deliberately stays `None` — that probe must remain media-free, so a Ref2VA preview stays non-authoritative per the placement-preview boundary. No family-generic signature changes.
- **`ResolvedReferenceSet::admission_view()`**: preparation runs on a spawned task and needs an owned value, but the set is deliberately non-Clone (its Drop releases the quota lease and deletes the staging dir). The payload-free view carries paths + probed metadata with no owning authority; both it and the set mint bindings through ONE `mint_inference_bindings`, so a staged file can never bind under two rule sets, and each device's admission mints its own descriptors. Documented limitation, intended failure mode: if the owning set drops first, the view's bindings fail to open and admission errors rather than proceeding on unverifiable media.
- **Task-shaped admission**: FL2VA keeps endpoint normalization and refuses reference bindings; Ref2VA refuses their absence and decodes/normalizes through the same `H3ReferenceMediaAdapter` the runtime uses — no second decoder, no estimated row counts (the exact Qwen rows come from packing real vision pads). Every derived charge is asked of the factory via `expected_h3_factory_reference_charges` so builder and validator agree by construction, with a fail-closed cross-check.
- Decoded media drops when the builder returns — only geometry, digests, and row counts enter the frozen plan; no reference byte reaches the request, queue journal, or gallery. Ref2VA stays campaign-build-only (`reviewed_allowlist_is_scoped_to_fl2va` passes under default and `h3-private-uat`).

New test `admission_view_binds_like_the_runtime_and_holds_no_owning_authority` pins the contract: same verifier as runtime, independent descriptors, no leakage in Debug, cancellation honored, drifted request refused, and view clone/drop never releases the owning set's quota.

Not yet included (next slice, now unblocked): carrying the Ref2VA prepared request through `build_private_fl2va_admission_attempt` to a Ref2VA-shaped frozen plan.

## Gates
fmt, `check --workspace --all-targets`, default + `h3-cuda,mp4` checks/clippy all clean. h3_factory 33 ✓, candle minimax 243 ✓, server `reference_uploads` 16 ✓, inference `h3-private-uat,mp4` 2161 ✓ (+known staged_weights flake), server h3 101 ✓ + the 2 known weights-on-disk env failures (identical on clean tree).