### PR TITLE
fix(h3): compact checkpoints keep the fixed envelope when a source image sets dimensions

### DIFF
--- a/changelog.d/h3-cli-compact-dims.md
+++ b/changelog.d/h3-cli-compact-dims.md
@@ -1,0 +1,6 @@
+- **H3 source images no longer bend compact requests off the reviewed
+  envelope.** `mold run` and the Discord builder with a first-frame image and
+  no explicit dimensions now submit the fixed `1344x768` canvas for the
+  compact base and Turbo tags (the engine fits the frame internally) instead
+  of an aspect-derived canvas that compact admission rejects; the hidden
+  official BF16 reference keeps its flexible canvas.

--- a/crates/mold-cli/src/commands/generate.rs
+++ b/crates/mold-cli/src/commands/generate.rs
@@ -189,7 +189,11 @@ fn effective_dimensions(
             (None, None, Some(source_image)) => {
                 let image = image::load_from_memory(source_image)
                     .map_err(|error| anyhow::anyhow!("failed to decode H3 first frame: {error}"))?;
-                Ok(mold_core::minimax_h3::recommended_dimensions(
+                // Compact layouts (base + Turbo tags) must submit the fixed
+                // reviewed envelope regardless of source aspect; only the
+                // official BF16 reference keeps the aspect-derived canvas.
+                Ok(mold_core::minimax_h3::source_fit_dimensions(
+                    model,
                     image.width(),
                     image.height(),
                 ))
@@ -4436,6 +4440,78 @@ mod tests {
         assert_eq!(
             effective_generation_steps(true, &official, &config, None),
             mold_core::minimax_h3::DEFAULT_STEPS
+        );
+    }
+
+    /// A source image without explicit dims must not bend a compact H3
+    /// request off the reviewed envelope: admission validates exact
+    /// 1344x768, and the engine fits the source internally. The hidden
+    /// official BF16 reference keeps its flexible aspect-derived canvas.
+    #[test]
+    fn h3_source_image_keeps_the_compact_envelope() {
+        let config = Config::default();
+        let model_cfg = ModelConfig::default();
+
+        // A square 1024x1024 source (encoded as a real PNG).
+        let mut png = Vec::new();
+        image::DynamicImage::ImageRgb8(image::RgbImage::new(1024, 1024))
+            .write_to(&mut std::io::Cursor::new(&mut png), image::ImageFormat::Png)
+            .unwrap();
+
+        for model in [
+            mold_core::minimax_h3::FL2VA_COMFY,
+            mold_core::minimax_h3::FL2VA_COMFY_TURBO_8STEP,
+            mold_core::minimax_h3::FL2VA_COMFY_TURBO_4STEP_768P,
+        ] {
+            assert_eq!(
+                effective_dimensions(
+                    &config,
+                    &model_cfg,
+                    model,
+                    Some("minimax-h3"),
+                    None,
+                    None,
+                    Some(&png),
+                    None
+                )
+                .unwrap(),
+                (
+                    mold_core::minimax_h3::DEFAULT_WIDTH,
+                    mold_core::minimax_h3::DEFAULT_HEIGHT
+                ),
+                "{model}"
+            );
+        }
+
+        assert_eq!(
+            effective_dimensions(
+                &config,
+                &model_cfg,
+                mold_core::minimax_h3::FL2VA_OFFICIAL,
+                Some("minimax-h3"),
+                None,
+                None,
+                Some(&png),
+                None
+            )
+            .unwrap(),
+            mold_core::minimax_h3::recommended_dimensions(1024, 1024)
+        );
+
+        // Explicit dims still win on every layout.
+        assert_eq!(
+            effective_dimensions(
+                &config,
+                &model_cfg,
+                mold_core::minimax_h3::FL2VA_COMFY_TURBO_8STEP,
+                Some("minimax-h3"),
+                Some(1344),
+                Some(768),
+                Some(&png),
+                None
+            )
+            .unwrap(),
+            (1344, 768)
         );
     }
 

--- a/crates/mold-cli/src/commands/h3.rs
+++ b/crates/mold-cli/src/commands/h3.rs
@@ -248,7 +248,13 @@ pub(crate) fn prepare_authoring(
     let (width, height) = match (width, height, inferred_dimensions) {
         (Some(width), Some(height), _) => (Some(width), Some(height)),
         (None, None, Some((source_width, source_height))) => {
-            let (width, height) = minimax_h3::recommended_dimensions(source_width, source_height);
+            // Compact layouts (base + Turbo tags) must submit the fixed
+            // reviewed envelope regardless of source aspect; only the
+            // official BF16 reference keeps the aspect-derived canvas. This
+            // promote path runs before `effective_dimensions`, so it must
+            // apply the same layout policy.
+            let (width, height) =
+                minimax_h3::source_fit_dimensions(model, source_width, source_height);
             (Some(width), Some(height))
         }
         (None, None, None) => (None, None),
@@ -767,6 +773,75 @@ mod tests {
         let keyframe = &prepared.keyframes.unwrap()[0];
         assert_eq!(keyframe.frame, 123);
         assert_eq!(keyframe.name.as_deref(), Some("closing.png"));
+    }
+
+    /// The authoring path promotes inferred dimensions to explicit values
+    /// before `effective_dimensions` runs, so it must apply the same layout
+    /// policy: a compact tag submits the fixed reviewed envelope regardless
+    /// of source aspect, and only the official BF16 reference keeps the
+    /// aspect-derived canvas.
+    #[test]
+    fn boundary_image_dimensions_keep_the_compact_envelope() {
+        let dir = tempfile::tempdir().unwrap();
+        let square = dir.path().join("square.png");
+        let mut png = Vec::new();
+        image::codecs::png::PngEncoder::new(&mut png)
+            .write_image(
+                &[0_u8; 256 * 256 * 3],
+                256,
+                256,
+                image::ExtendedColorType::Rgb8,
+            )
+            .unwrap();
+        std::fs::write(&square, png).unwrap();
+
+        for model in [
+            minimax_h3::FL2VA_COMFY,
+            minimax_h3::FL2VA_COMFY_TURBO_8STEP,
+            minimax_h3::FL2VA_COMFY_TURBO_4STEP_768P,
+        ] {
+            let prepared = prepare_authoring(
+                model,
+                minimax_h3::FAMILY,
+                Some(5.0),
+                None,
+                None,
+                None,
+                None,
+                Some(&square),
+                None,
+                None,
+                &[],
+                None,
+            )
+            .unwrap();
+            assert_eq!(
+                prepared.width.zip(prepared.height),
+                Some((minimax_h3::DEFAULT_WIDTH, minimax_h3::DEFAULT_HEIGHT)),
+                "{model}"
+            );
+        }
+
+        let prepared = prepare_authoring(
+            minimax_h3::FL2VA_OFFICIAL,
+            minimax_h3::FAMILY,
+            Some(5.0),
+            None,
+            None,
+            None,
+            None,
+            Some(&square),
+            None,
+            None,
+            &[],
+            None,
+        )
+        .unwrap();
+        assert_eq!(
+            prepared.width.zip(prepared.height),
+            Some(minimax_h3::recommended_dimensions(256, 256)),
+            "the official reference keeps the aspect-derived canvas"
+        );
     }
 
     #[test]

--- a/crates/mold-core/src/minimax_h3.rs
+++ b/crates/mold-core/src/minimax_h3.rs
@@ -575,6 +575,22 @@ pub fn recommended_frames(frames: u32) -> u32 {
     }
 }
 
+/// The canvas an H3 request should submit when the caller attached a source
+/// image without explicit dimensions. The official BF16 reference keeps its
+/// flexible short-edge/area canvas ([`recommended_dimensions`]); every
+/// compact layout — the base task partitions and the Turbo tiers — must
+/// submit the fixed reviewed envelope regardless of source aspect, because
+/// compact admission validates exact `DEFAULT_WIDTH`x`DEFAULT_HEIGHT`
+/// dimensions and the engine fits the source internally. A model the layout
+/// resolver does not recognize also takes the envelope: fail toward the
+/// stricter contract.
+pub fn source_fit_dimensions(model: &str, width: u32, height: u32) -> (u32, u32) {
+    match layout_for_model(model) {
+        Some(Layout::OfficialBf16) => recommended_dimensions(width, height),
+        _ => (DEFAULT_WIDTH, DEFAULT_HEIGHT),
+    }
+}
+
 pub fn recommended_dimensions(width: u32, height: u32) -> (u32, u32) {
     if width == 0 || height == 0 {
         return (DEFAULT_WIDTH, DEFAULT_HEIGHT);
@@ -2629,6 +2645,42 @@ mod tests {
             distill_strength_low: None,
             placement: None,
         }
+    }
+
+    /// A source image never bends a compact request off the reviewed
+    /// envelope: the aspect-derived canvas is official-BF16 behavior only,
+    /// and compact admission validates exact envelope dimensions.
+    #[test]
+    fn source_fit_keeps_the_compact_envelope_and_the_official_aspect_canvas() {
+        for model in [
+            FL2VA_COMFY,
+            REF2VA_COMFY,
+            FL2VA_COMFY_TURBO_8STEP,
+            FL2VA_COMFY_TURBO_4STEP_768P,
+        ] {
+            assert_eq!(
+                source_fit_dimensions(model, 1024, 1024),
+                (DEFAULT_WIDTH, DEFAULT_HEIGHT),
+                "{model}"
+            );
+            assert_eq!(
+                source_fit_dimensions(model, 1920, 1080),
+                (DEFAULT_WIDTH, DEFAULT_HEIGHT),
+                "{model}"
+            );
+        }
+        for (width, height) in [(1024, 1024), (1920, 1080), (1080, 1920)] {
+            assert_eq!(
+                source_fit_dimensions(FL2VA_OFFICIAL, width, height),
+                recommended_dimensions(width, height)
+            );
+        }
+        // Unresolvable family-configured models fail toward the stricter
+        // compact contract.
+        assert_eq!(
+            source_fit_dimensions("custom-h3-finetune", 1920, 1080),
+            (DEFAULT_WIDTH, DEFAULT_HEIGHT)
+        );
     }
 
     #[test]

--- a/crates/mold-discord/src/commands/generate.rs
+++ b/crates/mold-discord/src/commands/generate.rs
@@ -737,9 +737,13 @@ fn fit_attachment_dims(
     h: u32,
     defaults: Option<&mold_core::ModelDefaults>,
     family: Option<&str>,
+    model: &str,
 ) -> (u32, u32) {
     if family.is_some_and(mold_core::minimax_h3::is_family) {
-        return mold_core::minimax_h3::recommended_dimensions(w, h);
+        // Compact layouts (base + Turbo tags) must submit the fixed reviewed
+        // envelope regardless of source aspect; only the official BF16
+        // reference keeps the aspect-derived canvas.
+        return mold_core::minimax_h3::source_fit_dimensions(model, w, h);
     }
     let (model_w, model_h) = defaults
         .map(|d| (d.default_width, d.default_height))
@@ -1235,7 +1239,7 @@ pub async fn generate(
                 source_image.as_ref().and_then(|a| a.height),
             ) {
                 (Some(w), Some(h)) => {
-                    let (sw, sh) = fit_attachment_dims(w, h, model_defaults, family);
+                    let (sw, sh) = fit_attachment_dims(w, h, model_defaults, family, &model_name);
                     (Some(sw), Some(sh))
                 }
                 _ => (width, height),
@@ -2185,26 +2189,26 @@ mod tests {
         let d = defaults_1024();
         // Landscape photo is no longer squashed to a square.
         assert_eq!(
-            fit_attachment_dims(1920, 1080, Some(&d), Some("flux")),
+            fit_attachment_dims(1920, 1080, Some(&d), Some("flux"), "flux-dev:q8"),
             (1024, 576)
         );
         // Portrait keeps its orientation.
         assert_eq!(
-            fit_attachment_dims(1080, 1920, Some(&d), Some("flux")),
+            fit_attachment_dims(1080, 1920, Some(&d), Some("flux"), "flux-dev:q8"),
             (576, 1024)
         );
         // Square source fills the model's native square.
         assert_eq!(
-            fit_attachment_dims(1000, 1000, Some(&d), Some("flux")),
+            fit_attachment_dims(1000, 1000, Some(&d), Some("flux"), "flux-dev:q8"),
             (1024, 1024)
         );
         // Missing defaults fall back to a 1024x1024 canvas.
         assert_eq!(
-            fit_attachment_dims(1920, 1080, None, Some("flux")),
+            fit_attachment_dims(1920, 1080, None, Some("flux"), "flux-dev:q8"),
             (1024, 576)
         );
         // Output always lands on the 16px grid.
-        let (w, h) = fit_attachment_dims(777, 513, Some(&d), Some("flux"));
+        let (w, h) = fit_attachment_dims(777, 513, Some(&d), Some("flux"), "flux-dev:q8");
         assert_eq!((w % 16, h % 16), (0, 0));
     }
 
@@ -2223,7 +2227,7 @@ mod tests {
             ..defaults_1024()
         };
         assert_eq!(
-            fit_attachment_dims(1617, 1000, Some(&five_b), Some("wan")),
+            fit_attachment_dims(1617, 1000, Some(&five_b), Some("wan"), "wan22-ti2v-5b:q8"),
             (1120, 704)
         );
 
@@ -2234,7 +2238,13 @@ mod tests {
             ..defaults_1024()
         };
         assert_eq!(
-            fit_attachment_dims(1617, 1000, Some(&fourteen_b), Some("wan")),
+            fit_attachment_dims(
+                1617,
+                1000,
+                Some(&fourteen_b),
+                Some("wan"),
+                "wan22-t2v-a14b:q6"
+            ),
             (1136, 704)
         );
 
@@ -2245,7 +2255,13 @@ mod tests {
             ..defaults_1024()
         };
         assert_eq!(
-            fit_attachment_dims(1617, 1000, Some(&unadvertised), Some("wan")),
+            fit_attachment_dims(
+                1617,
+                1000,
+                Some(&unadvertised),
+                Some("wan"),
+                "wan22-ti2v-5b:q8"
+            ),
             (1136, 704)
         );
     }
@@ -2266,6 +2282,10 @@ mod tests {
         );
     }
 
+    /// The aspect-derived canvas is official-BF16 behavior only; every
+    /// compact identity (base + Turbo tags) must submit the fixed reviewed
+    /// envelope regardless of the attachment's aspect, because compact
+    /// admission validates exact dimensions.
     #[test]
     fn h3_attachment_dims_use_the_official_32px_canvas_authority() {
         for (source_width, source_height) in [(1920, 1080), (1080, 1920)] {
@@ -2274,12 +2294,39 @@ mod tests {
                 source_height,
                 Some(&defaults_1024()),
                 Some("minimax_h3"),
+                mold_core::minimax_h3::FL2VA_OFFICIAL,
             );
             assert_eq!((width % 32, height % 32), (0, 0));
             assert_eq!(
                 (width, height),
                 mold_core::minimax_h3::recommended_dimensions(source_width, source_height)
             );
+        }
+    }
+
+    #[test]
+    fn h3_attachment_dims_keep_the_compact_envelope() {
+        for model in [
+            mold_core::minimax_h3::FL2VA_COMFY,
+            mold_core::minimax_h3::FL2VA_COMFY_TURBO_8STEP,
+            mold_core::minimax_h3::FL2VA_COMFY_TURBO_4STEP_768P,
+        ] {
+            for (source_width, source_height) in [(1024, 1024), (1920, 1080), (1080, 1920)] {
+                assert_eq!(
+                    fit_attachment_dims(
+                        source_width,
+                        source_height,
+                        Some(&defaults_1024()),
+                        Some("minimax-h3"),
+                        model,
+                    ),
+                    (
+                        mold_core::minimax_h3::DEFAULT_WIDTH,
+                        mold_core::minimax_h3::DEFAULT_HEIGHT
+                    ),
+                    "{model} {source_width}x{source_height}"
+                );
+            }
         }
     }
     // --- autocomplete ranking ---

--- a/website/models/minimax-h3.md
+++ b/website/models/minimax-h3.md
@@ -128,6 +128,12 @@ The initial compact CUDA implementation supports this request profile:
 - one required first-frame image and no last-frame endpoint
 - MP4 output with synchronized generated audio
 
+When a first-frame image is attached without explicit `--width`/`--height`,
+the CLI and Discord builders submit the fixed `1344x768` envelope regardless
+of the source's aspect ratio — the engine fits the frame internally. The
+aspect-derived short-edge canvas applies only to the hidden official BF16
+reference.
+
 Mold rejects rather than silently resizing, rerouting, changing steps, dropping
 the source image, or falling back to another backend. A downloaded checkpoint
 can remain stored on an unsupported host; Create and request routing become


### PR DESCRIPTION
## Summary

Last blocker from the end-to-end tag UAT on the 4090: `mold run minimax-h3-fl2va:comfy-pruned-int8-turbo-8step --image <square png>` (no explicit dims) submitted a 768×768 canvas — `effective_dimensions` fed the source aspect through `recommended_dimensions`, which is the OFFICIAL BF16 flexible-canvas rule — and the compact reviewed envelope (exactly 1344×768) refused the whole render at admission.

New `mold_core::minimax_h3::source_fit_dimensions(model, w, h)` is the one policy: official BF16 keeps the aspect-derived canvas; every compact layout (base + both Turbo tiers, resolved through the existing `layout_for_model`, no name matching) takes the fixed 1344×768 envelope regardless of source aspect; an unresolvable H3 model fails toward the stricter contract. CLI and Discord route through it (explicit `--width`/`--height` still win); TUI audited — it has no source-derived dimension path.

TDD: the new CLI test first failed with exactly the UAT numbers (`(768, 768)` vs `(1344, 768)` for a 1024×1024 PNG). Core, CLI, and Discord tests pin all four compact identities, the official aspect fit, and the explicit-dims override.

## Gates
core 1260, CLI 602, discord 144, server h3 103, TUI 688, inference minimax 102 all ✓; workspace + h3-cuda clippy, fmt, generation-profiles --check, website prettier/docs verifier clean. The 2 `--features h3` core failures are the known pre-existing set (verified on pristine main by the prior branch).