### PR TITLE
fix(h3): admitted route carries the engine partition beside the full turbo identity

### DIFF
--- a/changelog.d/h3-turbo-admission-partition.md
+++ b/changelog.d/h3-turbo-admission-partition.md
@@ -1,0 +1,7 @@
+- **MiniMax H3 Turbo requests admit on their engine partition.** Admission
+  refused every Turbo tag with "private artifact qualification requires an
+  exact Comfy H3 canonical model name" because the once-derived route handed
+  the tag itself to artifact qualification; the route now carries both the
+  full reviewed identity (media facts, provenance, adapter selection) and the
+  task-derived compact partition (qualification, Qwen support, factory
+  authority, admission evidence).

--- a/crates/mold-core/src/minimax_h3.rs
+++ b/crates/mold-core/src/minimax_h3.rs
@@ -117,13 +117,19 @@ pub fn base_compact_model_for_task(task: Task) -> &'static str {
 }
 
 /// The base compact identity a reviewed model executes as: a Turbo tag's
-/// underlying task partition, or the resolved identity itself. The internal
+/// underlying task partition, or the compact identity itself. The internal
 /// engine partition is keyed by this value while the request keeps the full
 /// tag for provenance. The partition is derived from the tag's own TASK, not
 /// hard-wired to FL2VA, so a future reviewed Ref2VA tier cannot resolve to
-/// the FL2VA base.
+/// the FL2VA base. Identities outside the compact layout — the hidden
+/// official BF16 references included — have no compact engine partition and
+/// return `None`, so admission's route refusal fires at the route instead of
+/// deep inside artifact qualification.
 pub fn base_compact_model(model: &str) -> Option<&'static str> {
     let canonical = resolve_model_name(model)?;
+    if layout_for_model(canonical) != Some(Layout::ComfyPrunedInt8ConvrotNvfp4Awq) {
+        return None;
+    }
     if REVIEWED_TURBO_MANIFEST_TIERS
         .iter()
         .any(|tier| tier.model == canonical)
@@ -3674,6 +3680,23 @@ mod tests {
         }
         assert!(is_reviewed_compact_model(FL2VA_COMFY));
         assert!(is_reviewed_compact_model(REF2VA_COMFY));
+        // The compact engine partition exists only for compact-layout
+        // identities: Turbo tags map to their task's base, the bases map to
+        // themselves, and the official BF16 references map to nothing.
+        for tier in REVIEWED_TURBO_MANIFEST_TIERS {
+            assert_eq!(
+                base_compact_model(tier.model),
+                Some(base_compact_model_for_task(
+                    task_for_model(tier.model).unwrap()
+                )),
+                "{}",
+                tier.model
+            );
+        }
+        assert_eq!(base_compact_model(FL2VA_COMFY), Some(FL2VA_COMFY));
+        assert_eq!(base_compact_model(REF2VA_COMFY), Some(REF2VA_COMFY));
+        assert_eq!(base_compact_model(FL2VA_OFFICIAL), None);
+        assert_eq!(base_compact_model(REF2VA_OFFICIAL), None);
     }
 
     #[test]

--- a/crates/mold-core/src/minimax_h3.rs
+++ b/crates/mold-core/src/minimax_h3.rs
@@ -106,17 +106,29 @@ pub const REVIEWED_TURBO_MANIFEST_TIERS: &[TurboManifestTier] = &[
     },
 ];
 
+/// The compact base identity one task executes as. Kept as an exhaustive
+/// `Task` match — never a constant — so a reviewed Turbo tier of either task
+/// partitions to its own base.
+pub fn base_compact_model_for_task(task: Task) -> &'static str {
+    match task {
+        Task::Fl2va => FL2VA_COMFY,
+        Task::Ref2va => REF2VA_COMFY,
+    }
+}
+
 /// The base compact identity a reviewed model executes as: a Turbo tag's
 /// underlying task partition, or the resolved identity itself. The internal
 /// engine partition is keyed by this value while the request keeps the full
-/// tag for provenance.
+/// tag for provenance. The partition is derived from the tag's own TASK, not
+/// hard-wired to FL2VA, so a future reviewed Ref2VA tier cannot resolve to
+/// the FL2VA base.
 pub fn base_compact_model(model: &str) -> Option<&'static str> {
     let canonical = resolve_model_name(model)?;
     if REVIEWED_TURBO_MANIFEST_TIERS
         .iter()
         .any(|tier| tier.model == canonical)
     {
-        return Some(FL2VA_COMFY);
+        return Some(base_compact_model_for_task(task_for_model(canonical)?));
     }
     Some(canonical)
 }

--- a/crates/mold-inference/src/minimax_h3/private_qualification.rs
+++ b/crates/mold-inference/src/minimax_h3/private_qualification.rs
@@ -1411,7 +1411,7 @@ fn candle_task(task: Task) -> H3TransformerTask {
     }
 }
 
-const fn task_id(task: Task) -> &'static str {
+pub(crate) const fn task_id(task: Task) -> &'static str {
     match task {
         Task::Fl2va => "fl2va",
         Task::Ref2va => "ref2va",

--- a/crates/mold-inference/src/minimax_h3/private_qualification.rs
+++ b/crates/mold-inference/src/minimax_h3/private_qualification.rs
@@ -1461,6 +1461,24 @@ mod tests {
         }
     }
 
+    /// A Turbo tag is a first-class request identity but NOT a qualification
+    /// name: admission must hand this function the tag's engine partition
+    /// (`admitted_h3_route().partition_model`), and that partition must
+    /// resolve to the base FL2VA manifest. Passing the tag itself is the
+    /// exact live failure "requires an exact Comfy H3 canonical model name".
+    #[test]
+    fn turbo_tags_qualify_through_their_engine_partition() {
+        for tier in contract::REVIEWED_TURBO_MANIFEST_TIERS {
+            assert!(qualification_manifest(tier.model).is_err());
+            let route = crate::minimax_h3::private_server::admitted_h3_route(tier.model).unwrap();
+            let (manifest, task, published) =
+                qualification_manifest(route.partition_model).unwrap();
+            assert_eq!(manifest.name, contract::FL2VA_COMFY);
+            assert_eq!(task, Task::Fl2va);
+            assert_eq!(published, H3ComfyPublishedArtifact::Fl2VaPrunedInt8ConvRot);
+        }
+    }
+
     #[test]
     fn claim_marker_and_scope_are_stable_and_private() {
         assert_eq!(

--- a/crates/mold-inference/src/minimax_h3/private_server.rs
+++ b/crates/mold-inference/src/minimax_h3/private_server.rs
@@ -1143,6 +1143,39 @@ impl H3PrivateFl2VaAdmissionEvidence {
 }
 
 /// Produce exact, CUDA-allocation-free admission evidence for one private
+/// The once-derived admission route, carrying BOTH model names.
+///
+/// `admitted_model` keeps the full reviewed request identity — a Turbo tag
+/// included — for the media contract, provenance, and Turbo adapter
+/// resolution. `partition_model` is the compact engine partition that
+/// identity executes as (`base_compact_model`): artifact qualification, Qwen
+/// support, the factory authority, execution fingerprints, and admission
+/// evidence are all keyed on it, and the terminal media pairing
+/// (`media_model_matches_h3_authority`) expects exactly that split. For the
+/// base task models the two names are identical, so Ref2VA's task threading
+/// is unchanged. Deriving either name downstream instead of here is what let
+/// a Turbo tag reach `qualification_manifest` as itself and be refused.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct H3AdmittedRoute {
+    pub(crate) admitted_model: &'static str,
+    pub(crate) partition_model: &'static str,
+    pub(crate) task: Task,
+}
+
+pub(crate) fn admitted_h3_route(model: &str) -> Result<H3AdmittedRoute> {
+    let admitted = contract::capability_contract_for_model(model)
+        .ok_or_else(|| anyhow!("private H3 admission names an unknown model"))?;
+    let partition_model =
+        contract::base_compact_model(admitted.canonical_model).ok_or_else(|| {
+            anyhow!("private H3 admission names a model without a compact engine partition")
+        })?;
+    Ok(H3AdmittedRoute {
+        admitted_model: admitted.canonical_model,
+        partition_model,
+        task: admitted.task,
+    })
+}
+
 /// FL2VA request and one concrete CUDA route. Endpoint normalization and noise
 /// preparation deliberately remain here and may construct CPU-only Candle
 /// tensors; this function never creates a CUDA `Device` or CUDA tensor. It
@@ -1194,11 +1227,17 @@ fn prepare_reviewed_h3_private_fl2va_admission(
     // The admitted route is derived once, from the request model's own pinned
     // contract, and threaded through every step below. Reading it again from a
     // constant is what let a Ref2VA request load FL2VA support and then fail
-    // its own cross-task check.
-    let admitted = contract::capability_contract_for_model(&request.model)
-        .ok_or_else(|| anyhow!("private H3 admission names an unknown model"))?;
-    let admitted_model = admitted.canonical_model;
-    let admitted_task = admitted.task;
+    // its own cross-task check — and the route carries BOTH names, because a
+    // Turbo tag is a first-class canonical identity whose engine partition is
+    // the base compact model: qualification, Qwen support, the factory
+    // authority, and admission evidence key on the partition, while media
+    // facts and provenance keep the full tag. Threading the tag into the
+    // partition consumers is what refused every Turbo admission with
+    // "requires an exact Comfy H3 canonical model name".
+    let route = admitted_h3_route(&request.model)?;
+    let admitted_model = route.admitted_model;
+    let partition_model = route.partition_model;
+    let admitted_task = route.task;
     let (admitted_transformer_task, admitted_published_artifact) = match admitted_task {
         Task::Fl2va => (
             H3TransformerTask::T2VaFl2Va,
@@ -1248,7 +1287,7 @@ fn prepare_reviewed_h3_private_fl2va_admission(
     )?;
     let artifact_report = qualify_private_artifacts_with_control(
         paths.models_root,
-        admitted_model,
+        partition_model,
         paths.authorization_record,
         |hash| {
             progress.checkpoint()?;
@@ -1293,7 +1332,7 @@ fn prepare_reviewed_h3_private_fl2va_admission(
     // reviewed Turbo manifest tag); the env pair survives only as the
     // capture-scope UAT override inside `resolve_turbo_selection`.
     let turbo_adapter =
-        super::turbo::resolve_turbo_authority_for_request(&request.model, paths.models_root)?;
+        super::turbo::resolve_turbo_authority_for_request(admitted_model, paths.models_root)?;
     #[cfg(not(feature = "h3"))]
     let runtime_qualification = reviewed_runtime_qualification.authenticate(
         &artifact_report,
@@ -1318,7 +1357,7 @@ fn prepare_reviewed_h3_private_fl2va_admission(
     progress.checkpoint()?;
 
     let storage = H3PrivateComfyStorageAuthority::resolve(paths.models_root)?;
-    let qwen_support = load_qualified_private_qwen_support(paths.models_root, admitted_model)?;
+    let qwen_support = load_qualified_private_qwen_support(paths.models_root, partition_model)?;
     let transformer_cancellation = H3PrivatePreparationCancellation { progress };
     let opened_transformer = open_h3_comfy_published_int8_checkpoint(
         storage.transformer_path(),
@@ -1422,7 +1461,7 @@ fn prepare_reviewed_h3_private_fl2va_admission(
         .collect::<Result<Vec<_>>>()?;
     let base_factory_authority =
         FrozenH3FactoryAuthority::new_contract_only(H3FactoryAuthorityInput {
-            model: admitted_model.into(),
+            model: partition_model.into(),
             device_id: device_id.into(),
             device_ordinal,
             // The public H3 runtime profile is CUDA SM89, so this is always a
@@ -1529,7 +1568,10 @@ fn prepare_reviewed_h3_private_fl2va_admission(
         identity_sha256: String::new(),
         submitted_request_identity_sha256,
         resolved_request_identity_sha256,
-        canonical_model: admitted_model.into(),
+        // The engine partition, matching the factory authority the validate
+        // path equates it with; the request identity hashes retain the full
+        // reviewed tag.
+        canonical_model: partition_model.into(),
         task: admitted_task,
         mode,
         device_id: device_id.into(),
@@ -5350,6 +5392,50 @@ mod tests {
                 "{steps}: {error}"
             );
         }
+    }
+
+    /// The admitted route carries BOTH names: a Turbo tag stays the admitted
+    /// request identity while its engine partition is the task's compact
+    /// base — the name artifact qualification, Qwen support, the factory
+    /// authority, and admission evidence key on. Threading the tag into
+    /// those consumers refused every live Turbo admission with "requires an
+    /// exact Comfy H3 canonical model name" even though every piece passed
+    /// its own tests; this is the pin on the combination. Base models keep
+    /// partition == admitted, so Ref2VA's task threading is unchanged.
+    #[test]
+    fn turbo_admission_routes_on_the_compact_engine_partition() {
+        for tier in contract::REVIEWED_TURBO_MANIFEST_TIERS {
+            let route = admitted_h3_route(tier.model).unwrap();
+            assert_eq!(route.admitted_model, tier.model);
+            assert_eq!(route.partition_model, contract::FL2VA_COMFY);
+            assert_eq!(route.task, Task::Fl2va);
+            // The partition is derived from the tier's own task, never a
+            // constant — a future reviewed Ref2VA tier must partition to
+            // REF2VA_COMFY through the same seam.
+            assert_eq!(
+                route.partition_model,
+                contract::base_compact_model_for_task(route.task)
+            );
+        }
+        assert_eq!(
+            contract::base_compact_model_for_task(Task::Ref2va),
+            contract::REF2VA_COMFY
+        );
+
+        let base = admitted_h3_route(contract::FL2VA_COMFY).unwrap();
+        assert_eq!(base.admitted_model, contract::FL2VA_COMFY);
+        assert_eq!(base.partition_model, contract::FL2VA_COMFY);
+        assert_eq!(base.task, Task::Fl2va);
+
+        let ref2va = admitted_h3_route(contract::REF2VA_COMFY).unwrap();
+        assert_eq!(ref2va.admitted_model, contract::REF2VA_COMFY);
+        assert_eq!(ref2va.partition_model, contract::REF2VA_COMFY);
+        assert_eq!(ref2va.task, Task::Ref2va);
+
+        assert!(
+            admitted_h3_route("minimax-h3-fl2va:comfy-pruned-int8-turbo-2step").is_err(),
+            "unreviewed lookalike tags stay outside the admitted route"
+        );
     }
 
     /// A Turbo tier moves the step axis and ONLY the step axis, and only to the

--- a/crates/mold-inference/src/minimax_h3/private_server.rs
+++ b/crates/mold-inference/src/minimax_h3/private_server.rs
@@ -1431,6 +1431,8 @@ fn prepare_reviewed_h3_private_fl2va_admission(
         qwen_artifact,
     )?;
     let execution_fingerprint = private_h3_admission_execution_fingerprint(
+        partition_model,
+        admitted_task,
         &resolved_request_identity_sha256,
         &artifact_report,
         runtime_qualification.identity_sha256(),
@@ -1850,6 +1852,8 @@ fn update_private_h3_qualified_artifact(digest: &mut Sha256, artifact: &H3Qualif
 #[cfg(feature = "mp4")]
 #[allow(clippy::too_many_arguments)]
 fn private_h3_admission_execution_fingerprint(
+    partition_model: &str,
+    task: Task,
     resolved_request_identity_sha256: &str,
     artifact_report: &H3PrivateArtifactQualificationReport,
     runtime_qualification_identity_sha256: &str,
@@ -1861,9 +1865,12 @@ fn private_h3_admission_execution_fingerprint(
 ) -> String {
     let mut digest = Sha256::new();
     digest.update(b"mold.minimax-h3.private-admission-execution.v1\0");
+    // The route's engine partition and task, not constants: Ref2VA evidence
+    // must mint in its own execution namespace even though the full-request
+    // hash already separates the two tasks.
     for value in [
-        contract::FL2VA_COMFY,
-        "fl2va",
+        partition_model,
+        super::private_qualification::task_id(task),
         resolved_request_identity_sha256,
         artifact_report.qualification_identity_sha256.as_str(),
         runtime_qualification_identity_sha256,
@@ -2476,7 +2483,11 @@ fn prepare_reviewed_h3_private_fl2va_attempt(
         qwen_artifact,
     )?;
     validate_owner_component_digests(frozen_factory, &owner_component_digests)?;
+    // Recomputed under the frozen factory's own partition and task, so the
+    // comparison stays self-consistent with what admission stamped.
     let owner_execution_fingerprint = private_h3_admission_execution_fingerprint(
+        frozen_factory.canonical_model(),
+        frozen_factory.task(),
         &resolved_request_identity_sha256,
         &artifact_report,
         runtime_qualification.identity_sha256(),
@@ -5436,6 +5447,17 @@ mod tests {
             admitted_h3_route("minimax-h3-fl2va:comfy-pruned-int8-turbo-2step").is_err(),
             "unreviewed lookalike tags stay outside the admitted route"
         );
+
+        // The hidden official BF16 references have no compact engine
+        // partition, so the route's None refusal fires HERE — not several
+        // steps later inside artifact qualification.
+        for official in [contract::FL2VA_OFFICIAL, contract::REF2VA_OFFICIAL] {
+            let error = admitted_h3_route(official).unwrap_err().to_string();
+            assert!(
+                error.contains("compact engine partition"),
+                "{official}: {error}"
+            );
+        }
     }
 
     /// A Turbo tier moves the step axis and ONLY the step axis, and only to the


### PR DESCRIPTION
## Summary

Definitive tag UAT on the 4090 (post #1199/#1201/#1202): admission refused the turbo tag with `private artifact qualification requires an exact Comfy H3 canonical model name`. #1201's once-derived route set `admitted_model` to the turbo tag itself, but artifact qualification, Qwen support, the factory authority, and admission evidence all require the ENGINE PARTITION (`FL2VA_COMFY`) — the split #1199 designed for media vs engine identity.

- New `H3AdmittedRoute { admitted_model, partition_model, task }` from `admitted_h3_route(&request.model)`: `partition_model = base_compact_model(admitted_model)` (refused with an explicit error on `None`) keys qualification/support/factory/evidence; `admitted_model` (the full reviewed tag) keys Turbo adapter resolution and the media contract/provenance the terminal gate already pairs via `media_model_matches_h3_authority`.
- #1201's Ref2VA task threading is preserved byte-for-byte — for base models partition == admitted.
- **Hardening**: `base_compact_model` no longer hard-wires `FL2VA_COMFY` — exhaustive `base_compact_model_for_task(Task)` derives the partition from the tag's own task, so a future reviewed Ref2VA tier partitions to `REF2VA_COMFY` instead of silently landing on FL2VA (latent trap found during slice reconciliation).
- Tests pin the exact combination no prior test crossed: `turbo_admission_routes_on_the_compact_engine_partition` and `turbo_tags_qualify_through_their_engine_partition` (the latter reproduces the live refusal for the raw tag and proves the partition resolves).

## Gates
fmt, workspace clippy, `h3-cuda,mp4` clippy clean; mold-core 1260 + `--features h3` minimax 38; inference default 1978; server h3 103; CLI 603; docs checks ✓. The 7 `--features h3,mp4` reviewed_record failures are proven pre-existing on a detached origin/main checkout.