### PR TITLE
feat(h3): Ref2VA-shaped frozen plans from the admitted task

### DIFF
--- a/crates/mold-inference/src/h3_factory.rs
+++ b/crates/mold-inference/src/h3_factory.rs
@@ -5600,21 +5600,51 @@ mod tests {
 
     /// FL2VA's frozen plan must be byte-identical across the Ref2VA work.
     ///
-    /// The prepared-attempt identity covers the request, the raw checkpoint,
-    /// and the whole target budget, so pinning it to a literal digest is the
-    /// cheapest complete statement that adding a second task changed nothing
-    /// about the first. Recomputed from the fixture, which is path- and
-    /// machine-independent by construction.
+    /// Two pinned literals, each with its own coverage:
     ///
-    /// If this digest changes, an FL2VA frozen plan changed. That is either a
-    /// deliberate FL2VA change — update the literal and say so — or a Ref2VA
-    /// change that leaked, which is a bug.
+    /// * The prepared-attempt digest (862ae3c2…) is
+    ///   `expected_h3_factory_prepared_attempt_identity` over the
+    ///   hand-assembled fixture, so it covers the identity FUNCTIONS — the
+    ///   request, endpoint, raw-checkpoint, and target-budget hash layouts and
+    ///   every field they bind — but NOT the production budget builder
+    ///   (`build_canonical_private_fl2va_target_budget`), which needs opened
+    ///   weights and is exercised by the budget arithmetic tests instead.
+    /// * The backend-plan digest (b9e5fe2e…) is taken from an authority built
+    ///   by `FrozenH3FactoryAuthority::new_contract_only` — the same
+    ///   constructor server admission calls — so it covers what the production
+    ///   builder actually freezes for an FL2VA route: canonical model, task,
+    ///   layout, device route, execution fingerprint, conditioner placement,
+    ///   block streaming, and the component-authority set (the
+    ///   `backend_plan_identity` domain in `minimax_h3/backend.rs`). Captured
+    ///   2026-08-20 from that builder over `exact_input()`, which is path- and
+    ///   machine-independent by construction.
+    ///
+    /// Still uncovered without weights on disk: storage-authority resolution
+    /// and opened-component digests (pinned functionally by the
+    /// `private_opened_evidence` tests).
+    ///
+    /// If either digest changes, an FL2VA frozen plan changed. That is either
+    /// a deliberate FL2VA change — update the literal and say so — or a
+    /// Ref2VA change that leaked, which is a bug.
     #[test]
     fn fl2va_frozen_plan_identity_is_pinned() {
         let attempt = prepared_attempt();
         assert_eq!(
             expected_h3_factory_prepared_attempt_identity(&attempt),
             "862ae3c24e6956fece01b429f8361da5028a0efa8b175470900cb7cb0087219c"
+        );
+
+        // Through the production builder: the frozen authority must preserve
+        // the pinned attempt identity unchanged, and its backend plan — the
+        // part that hashes canonical model + task — must stay pinned too.
+        let authority = FrozenH3FactoryAuthority::new_contract_only(exact_input()).unwrap();
+        let (attempt_identity, budget_identity) =
+            authority.prepared_target_attempt_identities().unwrap();
+        assert_eq!(attempt_identity, attempt.identity_sha256);
+        assert_eq!(budget_identity, attempt.target_budget.identity_sha256);
+        assert_eq!(
+            authority.backend_plan.identity_sha256(),
+            "b9e5fe2ebf3a61852578c9d208c2b6e35ba8e7cce95016367a6600b00d82cb4e"
         );
     }
 

--- a/crates/mold-inference/src/h3_factory.rs
+++ b/crates/mold-inference/src/h3_factory.rs
@@ -5598,6 +5598,26 @@ mod tests {
         assert_ne!(transposed_budget.identity_sha256, base.identity_sha256);
     }
 
+    /// FL2VA's frozen plan must be byte-identical across the Ref2VA work.
+    ///
+    /// The prepared-attempt identity covers the request, the raw checkpoint,
+    /// and the whole target budget, so pinning it to a literal digest is the
+    /// cheapest complete statement that adding a second task changed nothing
+    /// about the first. Recomputed from the fixture, which is path- and
+    /// machine-independent by construction.
+    ///
+    /// If this digest changes, an FL2VA frozen plan changed. That is either a
+    /// deliberate FL2VA change — update the literal and say so — or a Ref2VA
+    /// change that leaked, which is a bug.
+    #[test]
+    fn fl2va_frozen_plan_identity_is_pinned() {
+        let attempt = prepared_attempt();
+        assert_eq!(
+            expected_h3_factory_prepared_attempt_identity(&attempt),
+            "862ae3c24e6956fece01b429f8361da5028a0efa8b175470900cb7cb0087219c"
+        );
+    }
+
     fn raw_checkpoint() -> H3FactoryRawCheckpointInput {
         let blocks = (0_u16..50)
             .map(|index| H3FactoryBlockMemoryInput {

--- a/crates/mold-inference/src/minimax_h3/private_opened_evidence.rs
+++ b/crates/mold-inference/src/minimax_h3/private_opened_evidence.rs
@@ -58,8 +58,22 @@ use crate::progress::ProgressReporter;
 
 const FL2VA_TRANSFORMER_SOURCE: &str =
     "diffusion_models/minimax_h3_fl2va_pruned_int8_convrot.safetensors";
+const REF2VA_TRANSFORMER_SOURCE: &str =
+    "diffusion_models/minimax_h3_ref2va_pruned_int8_convrot.safetensors";
 const QWEN_WEIGHT_SOURCE: &str = "text_encoders/qwen3vl_32b_minimax_h3_nvfp4_awq.safetensors";
 const FL2VA_TASK_CONFIG_SOURCE: &str = "transformer/config.json";
+const REF2VA_TASK_CONFIG_SOURCE: &str = "transformer_ref/config.json";
+
+/// The two manifest entries that differ between the compact FL2VA and Ref2VA
+/// stacks. Everything else — Qwen weights, both VAEs, and every runtime
+/// support file — is shared, and the task config's content and digest are
+/// identical between them; only its manifest lookup key differs.
+const fn comfy_task_sources(task: Task) -> (&'static str, &'static str) {
+    match task {
+        Task::Fl2va => (FL2VA_TRANSFORMER_SOURCE, FL2VA_TASK_CONFIG_SOURCE),
+        Task::Ref2va => (REF2VA_TRANSFORMER_SOURCE, REF2VA_TASK_CONFIG_SOURCE),
+    }
+}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct H3PrivateStorageRootIdentity {
@@ -224,6 +238,11 @@ pub(crate) struct H3PrivateComfyStorageAuthority {
     transformer: PathBuf,
     qwen_weights: PathBuf,
     task_config: PathBuf,
+    /// The task this authority resolved for. Deliberately NOT part of
+    /// `storage_authority_identity`: that digest already covers the four
+    /// resolved paths, two of which differ per task, so it distinguishes the
+    /// tasks on its own — and FL2VA's digest stays byte-identical.
+    task: Task,
     identity_sha256: String,
 }
 
@@ -247,13 +266,14 @@ pub(crate) struct H3PrivateOpenedActivationFacts {
 }
 
 impl H3PrivateComfyStorageAuthority {
-    pub(crate) fn resolve(models_root: &Path) -> Result<Self> {
+    pub(crate) fn resolve(models_root: &Path, task: Task) -> Result<Self> {
         let (models_root, root_identity) = validate_storage_root(models_root)?;
-        let manifest = private_fl2va_manifest()?;
+        let manifest = private_comfy_manifest(task)?;
+        let (transformer_source, task_config_source) = comfy_task_sources(task);
         let transformer = resolve_component(
             manifest,
             &models_root,
-            FL2VA_TRANSFORMER_SOURCE,
+            transformer_source,
             ModelComponent::Transformer,
         )?;
         let qwen_weights = resolve_component(
@@ -265,7 +285,7 @@ impl H3PrivateComfyStorageAuthority {
         let task_config = resolve_component(
             manifest,
             &models_root,
-            FL2VA_TASK_CONFIG_SOURCE,
+            task_config_source,
             ModelComponent::TaskConfig,
         )?;
         let mut authority = Self {
@@ -274,6 +294,7 @@ impl H3PrivateComfyStorageAuthority {
             transformer,
             qwen_weights,
             task_config,
+            task,
             identity_sha256: String::new(),
         };
         authority.identity_sha256 = storage_authority_identity(&authority);
@@ -316,7 +337,7 @@ impl H3PrivateComfyStorageAuthority {
 
     fn open_task_config(&self) -> Result<H3PrivateOpenedTaskConfigAuthority> {
         self.validate()?;
-        let manifest = private_fl2va_manifest()?;
+        let manifest = private_comfy_manifest(self.task)?;
         let matches = manifest
             .files
             .iter()
@@ -347,7 +368,7 @@ impl H3PrivateComfyStorageAuthority {
 
     fn vae_source_path(&self, role: H3ComfyVaeArtifactRole) -> Result<PathBuf> {
         resolve_component(
-            private_fl2va_manifest()?,
+            private_comfy_manifest(self.task)?,
             &self.models_root,
             role.source_path(),
             role.manifest_component(),
@@ -367,8 +388,8 @@ impl H3PrivateComfyStorageAuthority {
         transformer.revalidate()?;
         qwen.revalidate()?;
         vae.validate()?;
-        validate_fl2va_transformer_contract(transformer.candidate().artifact)?;
-        validate_fl2va_vae_contract(vae.task(), vae.canonical_model())?;
+        validate_transformer_contract(self.task, transformer.candidate().artifact)?;
+        validate_vae_contract(self.task, vae.task(), vae.canonical_model())?;
         if transformer.source_path() != self.transformer || qwen.source_path() != self.qwen_weights
         {
             bail!(
@@ -434,21 +455,21 @@ impl H3PrivateComfyStorageAuthority {
             || self.identity_sha256 != storage_authority_identity(self)
             || self.transformer
                 != resolve_component(
-                    private_fl2va_manifest()?,
+                    private_comfy_manifest(self.task)?,
                     &root,
                     FL2VA_TRANSFORMER_SOURCE,
                     ModelComponent::Transformer,
                 )?
             || self.qwen_weights
                 != resolve_component(
-                    private_fl2va_manifest()?,
+                    private_comfy_manifest(self.task)?,
                     &root,
                     QWEN_WEIGHT_SOURCE,
                     ModelComponent::TextEncoder,
                 )?
             || self.task_config
                 != resolve_component(
-                    private_fl2va_manifest()?,
+                    private_comfy_manifest(self.task)?,
                     &root,
                     FL2VA_TASK_CONFIG_SOURCE,
                     ModelComponent::TaskConfig,
@@ -460,18 +481,22 @@ impl H3PrivateComfyStorageAuthority {
     }
 }
 
-fn private_fl2va_manifest() -> Result<&'static ModelManifest> {
-    let manifest = find_manifest(contract::FL2VA_COMFY)
-        .ok_or_else(|| anyhow!("missing MiniMax H3 FL2VA Comfy manifest"))?;
+fn private_comfy_manifest(task: Task) -> Result<&'static ModelManifest> {
+    // One authority for the task -> engine-partition mapping. #1203 made this
+    // the route's `partition_model`, so deriving it a second time here would
+    // be exactly the duplication that let a turbo tag reach qualification.
+    let expected_model = contract::base_compact_model_for_task(task);
+    let manifest = find_manifest(expected_model)
+        .ok_or_else(|| anyhow!("missing MiniMax H3 {expected_model} Comfy manifest"))?;
     let manifest_contract = contract::manifest_contract(manifest)
         .ok_or_else(|| anyhow!("MiniMax H3 manifest lost its contract"))?;
-    if manifest.name != contract::FL2VA_COMFY
+    if manifest.name != expected_model
         || manifest.family != contract::FAMILY
-        || manifest_contract.task != Task::Fl2va
+        || manifest_contract.task != task
         || manifest_contract.layout != Layout::ComfyPrunedInt8ConvrotNvfp4Awq
         || manifest_contract.runtime_available
     {
-        bail!("private H3 storage requires the exact inactive FL2VA Comfy manifest")
+        bail!("private H3 storage requires the exact inactive {expected_model} Comfy manifest")
     }
     Ok(manifest)
 }
@@ -646,7 +671,7 @@ impl H3PrivatePreparedFl2VaAttempt {
         transformer_support.revalidate()?;
         let (prepared, factory_request) =
             prepare_private_fl2va_request_input(request, support, progress, observer)?;
-        let raw_checkpoint = raw_checkpoint_input(transformer)?;
+        let raw_checkpoint = raw_checkpoint_input(factory_request.task, transformer)?;
         let target_budget = build_canonical_private_fl2va_target_budget(
             &factory_request,
             &raw_checkpoint,
@@ -928,7 +953,7 @@ pub(crate) fn build_private_fl2va_admission_attempt(
     storage.validate_opened_components(support, transformer, qwen, vae)?;
     let transformer_support = storage.open_task_config()?;
     transformer_support.revalidate()?;
-    let raw_checkpoint = raw_checkpoint_input(transformer)?;
+    let raw_checkpoint = raw_checkpoint_input(request.task, transformer)?;
     let target_budget = build_canonical_private_fl2va_target_budget(
         &request,
         &raw_checkpoint,
@@ -1302,18 +1327,18 @@ fn prepared_request_input(
 }
 
 fn raw_checkpoint_input(
+    task: Task,
     transformer: &H3ComfyOpenedInt8Checkpoint,
 ) -> Result<H3FactoryRawCheckpointInput> {
     transformer.revalidate()?;
-    validate_fl2va_transformer_contract(transformer.candidate().artifact)?;
+    validate_transformer_contract(task, transformer.candidate().artifact)?;
+    let (expected_artifact, _) = expected_published_transformer(task);
     let evidence = transformer.memory_evidence();
-    if transformer.content_sha256()
-        != H3ComfyPublishedArtifact::Fl2VaPrunedInt8ConvRot.content_sha256()
-        || evidence.verified_file_bytes
-            != H3ComfyPublishedArtifact::Fl2VaPrunedInt8ConvRot.file_bytes()
+    if transformer.content_sha256() != expected_artifact.content_sha256()
+        || evidence.verified_file_bytes != expected_artifact.file_bytes()
         || evidence.blocks.len() != 50
     {
-        bail!("private H3 opened transformer evidence differs from the exact FL2VA artifact")
+        bail!("private H3 opened transformer evidence differs from the exact {task:?} artifact")
     }
     let blocks = evidence
         .blocks
@@ -1355,18 +1380,35 @@ fn raw_checkpoint_input(
     Ok(input)
 }
 
-fn validate_fl2va_transformer_contract(artifact: H3ComfyPublishedArtifact) -> Result<()> {
-    if artifact != H3ComfyPublishedArtifact::Fl2VaPrunedInt8ConvRot
-        || artifact.task() != H3TransformerTask::T2VaFl2Va
-    {
-        bail!("private H3 prepared attempt requires the exact FL2VA INT8 ConvRot transformer")
+/// The exact published transformer and its transformer-task discriminant for
+/// one admitted task.
+const fn expected_published_transformer(
+    task: Task,
+) -> (H3ComfyPublishedArtifact, H3TransformerTask) {
+    match task {
+        Task::Fl2va => (
+            H3ComfyPublishedArtifact::Fl2VaPrunedInt8ConvRot,
+            H3TransformerTask::T2VaFl2Va,
+        ),
+        Task::Ref2va => (
+            H3ComfyPublishedArtifact::Ref2VaPrunedInt8ConvRot,
+            H3TransformerTask::Ref2Va,
+        ),
+    }
+}
+
+fn validate_transformer_contract(task: Task, artifact: H3ComfyPublishedArtifact) -> Result<()> {
+    let (expected_artifact, expected_task) = expected_published_transformer(task);
+    if artifact != expected_artifact || artifact.task() != expected_task {
+        bail!("private H3 prepared attempt requires the exact {task:?} INT8 ConvRot transformer")
     }
     Ok(())
 }
 
-fn validate_fl2va_vae_contract(task: Task, canonical_model: &str) -> Result<()> {
-    if task != Task::Fl2va || canonical_model != contract::FL2VA_COMFY {
-        bail!("private H3 prepared attempt requires the exact FL2VA VAE authority")
+fn validate_vae_contract(expected_task: Task, task: Task, canonical_model: &str) -> Result<()> {
+    let expected_model = contract::base_compact_model_for_task(expected_task);
+    if task != expected_task || canonical_model != expected_model {
+        bail!("private H3 prepared attempt requires the exact {expected_task:?} VAE authority")
     }
     Ok(())
 }
@@ -2343,7 +2385,7 @@ mod tests {
     fn hidden_storage_resolution_is_canonical_and_identity_bound() {
         let root = tempfile::tempdir().unwrap();
         let root = root.path().canonicalize().unwrap();
-        let authority = H3PrivateComfyStorageAuthority::resolve(&root).unwrap();
+        let authority = H3PrivateComfyStorageAuthority::resolve(&root, Task::Fl2va).unwrap();
         authority.validate().unwrap();
         assert!(authority
             .transformer_path()
@@ -2366,10 +2408,10 @@ mod tests {
         let real = real.canonicalize().unwrap();
         let alias = parent.path().join("alias");
         symlink(&real, &alias).unwrap();
-        assert!(H3PrivateComfyStorageAuthority::resolve(&alias).is_err());
+        assert!(H3PrivateComfyStorageAuthority::resolve(&alias, Task::Fl2va).is_err());
 
         std::fs::set_permissions(&real, std::fs::Permissions::from_mode(0o777)).unwrap();
-        assert!(H3PrivateComfyStorageAuthority::resolve(&real).is_ok());
+        assert!(H3PrivateComfyStorageAuthority::resolve(&real, Task::Fl2va).is_ok());
     }
 
     #[cfg(unix)]
@@ -2379,7 +2421,7 @@ mod tests {
         let parent = parent.path().canonicalize().unwrap();
         let root = parent.join("models");
         std::fs::create_dir(&root).unwrap();
-        let authority = H3PrivateComfyStorageAuthority::resolve(&root).unwrap();
+        let authority = H3PrivateComfyStorageAuthority::resolve(&root, Task::Fl2va).unwrap();
         let authenticated = parent.join("authenticated-models");
         std::fs::rename(&root, authenticated).unwrap();
         std::fs::create_dir(&root).unwrap();
@@ -2388,16 +2430,113 @@ mod tests {
         assert!(error.to_string().contains("authority changed"), "{error}");
     }
 
+    /// The two tasks resolve different storage, and the Ref2VA route differs
+    /// from FL2VA in exactly the two manifest entries that actually differ.
+    /// The storage authority keys on TASK while #1203's route keys engine
+    /// partitioning on `partition_model`. Those are two names for one fact, so
+    /// pin them together: if they ever disagree, a turbo tag resolves storage
+    /// from one identity and qualification from another — the #1203 defect,
+    /// one layer down.
+    #[test]
+    fn storage_task_keying_agrees_with_the_route_partition_for_every_model() {
+        for model in [
+            contract::FL2VA_COMFY,
+            contract::REF2VA_COMFY,
+            contract::FL2VA_COMFY_TURBO_8STEP,
+            contract::FL2VA_COMFY_TURBO_4STEP_768P,
+        ] {
+            let route = contract::capability_contract_for_model(model)
+                .unwrap_or_else(|| panic!("{model} must resolve a contract"));
+            let partition = contract::base_compact_model(model)
+                .unwrap_or_else(|| panic!("{model} must resolve a partition"));
+            // What the storage authority would resolve for this request.
+            let storage_model = contract::base_compact_model_for_task(route.task);
+            assert_eq!(
+                storage_model, partition,
+                "{model}: storage resolved {storage_model} but the route partitions on {partition}"
+            );
+            // And that identity is the manifest the authority actually opens.
+            let manifest = private_comfy_manifest(route.task).unwrap();
+            assert_eq!(manifest.name, partition, "{model}");
+        }
+    }
+
+    #[test]
+    fn the_two_tasks_resolve_their_own_transformer_and_task_config() {
+        let (fl2va_transformer, fl2va_config) = comfy_task_sources(Task::Fl2va);
+        let (ref2va_transformer, ref2va_config) = comfy_task_sources(Task::Ref2va);
+        assert_ne!(fl2va_transformer, ref2va_transformer);
+        assert_ne!(fl2va_config, ref2va_config);
+        assert_eq!(fl2va_config, "transformer/config.json");
+        assert_eq!(ref2va_config, "transformer_ref/config.json");
+
+        // Both manifests exist and each is the inactive compact stack for its
+        // own task, so neither can be mistaken for the other.
+        let fl2va = private_comfy_manifest(Task::Fl2va).unwrap();
+        let ref2va = private_comfy_manifest(Task::Ref2va).unwrap();
+        assert_eq!(fl2va.name, contract::FL2VA_COMFY);
+        assert_eq!(ref2va.name, contract::REF2VA_COMFY);
+
+        // Everything else is shared: the Qwen weights and both VAEs are the
+        // same files, which is why only the two entries above are switched.
+        let shared = |manifest: &ModelManifest, source: &str| {
+            manifest
+                .files
+                .iter()
+                .find(|file| file.hf_filename == source)
+                .map(|file| file.sha256)
+        };
+        for source in [
+            QWEN_WEIGHT_SOURCE,
+            "vae/minimax_h3_video_vae_fp16.safetensors",
+            "vae/minimax_h3_audio_vae_fp32.safetensors",
+        ] {
+            assert_eq!(
+                shared(fl2va, source),
+                shared(ref2va, source),
+                "{source} must be shared between the two tasks"
+            );
+            assert!(shared(fl2va, source).is_some(), "{source} must exist");
+        }
+        // The task config's CONTENT is identical too; only its key differs.
+        assert_eq!(
+            shared(fl2va, fl2va_config),
+            shared(ref2va, ref2va_config),
+            "the task config differs only by manifest key, never by content"
+        );
+    }
+
     #[test]
     fn cross_task_transformer_and_vae_authorities_fail_closed() {
-        assert!(validate_fl2va_transformer_contract(
+        // Each task accepts only its own artifacts, in BOTH directions — the
+        // Ref2VA arm must be exactly as strict as the FL2VA one it mirrors.
+        validate_transformer_contract(
+            Task::Fl2va,
+            H3ComfyPublishedArtifact::Fl2VaPrunedInt8ConvRot,
+        )
+        .unwrap();
+        validate_transformer_contract(
+            Task::Ref2va,
+            H3ComfyPublishedArtifact::Ref2VaPrunedInt8ConvRot,
+        )
+        .unwrap();
+        assert!(validate_transformer_contract(
+            Task::Fl2va,
             H3ComfyPublishedArtifact::Ref2VaPrunedInt8ConvRot
         )
         .is_err());
-        assert!(validate_fl2va_vae_contract(Task::Ref2va, contract::REF2VA_COMFY).is_err());
-        validate_fl2va_transformer_contract(H3ComfyPublishedArtifact::Fl2VaPrunedInt8ConvRot)
-            .unwrap();
-        validate_fl2va_vae_contract(Task::Fl2va, contract::FL2VA_COMFY).unwrap();
+        assert!(validate_transformer_contract(
+            Task::Ref2va,
+            H3ComfyPublishedArtifact::Fl2VaPrunedInt8ConvRot
+        )
+        .is_err());
+
+        validate_vae_contract(Task::Fl2va, Task::Fl2va, contract::FL2VA_COMFY).unwrap();
+        validate_vae_contract(Task::Ref2va, Task::Ref2va, contract::REF2VA_COMFY).unwrap();
+        assert!(validate_vae_contract(Task::Fl2va, Task::Ref2va, contract::REF2VA_COMFY).is_err());
+        assert!(validate_vae_contract(Task::Ref2va, Task::Fl2va, contract::FL2VA_COMFY).is_err());
+        // A matching task with the other task's model is still refused.
+        assert!(validate_vae_contract(Task::Ref2va, Task::Ref2va, contract::FL2VA_COMFY).is_err());
     }
 
     #[test]

--- a/crates/mold-inference/src/minimax_h3/private_opened_evidence.rs
+++ b/crates/mold-inference/src/minimax_h3/private_opened_evidence.rs
@@ -328,7 +328,7 @@ impl H3PrivateComfyStorageAuthority {
     pub(crate) fn vae_plan(&self, staging_root: &Path) -> Result<FrozenH3ComfyVaeLoadPlan> {
         self.validate()?;
         FrozenH3ComfyVaeLoadPlan::from_hidden_storage(
-            contract::FL2VA_COMFY,
+            contract::base_compact_model_for_task(self.task),
             &self.models_root,
             staging_root,
         )
@@ -338,16 +338,17 @@ impl H3PrivateComfyStorageAuthority {
     fn open_task_config(&self) -> Result<H3PrivateOpenedTaskConfigAuthority> {
         self.validate()?;
         let manifest = private_comfy_manifest(self.task)?;
+        let (_, task_config_source) = comfy_task_sources(self.task);
         let matches = manifest
             .files
             .iter()
             .filter(|file| {
-                file.hf_filename == FL2VA_TASK_CONFIG_SOURCE
+                file.hf_filename == task_config_source
                     && file.component == ModelComponent::TaskConfig
             })
             .collect::<Vec<_>>();
         let [file] = matches.as_slice() else {
-            bail!("hidden MiniMax H3 manifest requires exactly one FL2VA task config")
+            bail!("hidden MiniMax H3 manifest requires exactly one task config")
         };
         if self.task_config != self.models_root.join(storage_path(manifest, file)) {
             bail!("private H3 task config path differs from hidden storage authority")
@@ -450,6 +451,10 @@ impl H3PrivateComfyStorageAuthority {
 
     pub(crate) fn validate(&self) -> Result<()> {
         let (root, root_identity) = validate_storage_root(&self.models_root)?;
+        // Recompute through the same task-keyed source resolution `resolve`
+        // used; re-deriving from one task's constants would refuse the other
+        // task's authority at its own first validation.
+        let (transformer_source, task_config_source) = comfy_task_sources(self.task);
         if root != self.models_root
             || root_identity != self.root_identity
             || self.identity_sha256 != storage_authority_identity(self)
@@ -457,7 +462,7 @@ impl H3PrivateComfyStorageAuthority {
                 != resolve_component(
                     private_comfy_manifest(self.task)?,
                     &root,
-                    FL2VA_TRANSFORMER_SOURCE,
+                    transformer_source,
                     ModelComponent::Transformer,
                 )?
             || self.qwen_weights
@@ -471,7 +476,7 @@ impl H3PrivateComfyStorageAuthority {
                 != resolve_component(
                     private_comfy_manifest(self.task)?,
                     &root,
-                    FL2VA_TASK_CONFIG_SOURCE,
+                    task_config_source,
                     ModelComponent::TaskConfig,
                 )?
         {
@@ -2395,6 +2400,38 @@ mod tests {
             .task_config_path()
             .ends_with(FL2VA_TASK_CONFIG_SOURCE));
         assert_eq!(authority.identity_sha256().len(), 64);
+    }
+
+    /// A Ref2VA storage authority must survive its own revalidation:
+    /// `validate` recomputes the transformer and task-config paths through
+    /// the same task-keyed `comfy_task_sources` resolution `resolve` used.
+    /// Recomputing them from FL2VA's source constants made every Ref2VA
+    /// authority fail at construction (resolve validates before returning),
+    /// so this is the pin that the two path derivations stay one authority.
+    #[test]
+    fn ref2va_hidden_storage_resolution_survives_its_own_revalidation() {
+        let root = tempfile::tempdir().unwrap();
+        let root = root.path().canonicalize().unwrap();
+        let authority = H3PrivateComfyStorageAuthority::resolve(&root, Task::Ref2va).unwrap();
+        authority.validate().unwrap();
+        assert!(authority
+            .transformer_path()
+            .ends_with(REF2VA_TRANSFORMER_SOURCE));
+        assert!(authority.qwen_weights_path().ends_with(QWEN_WEIGHT_SOURCE));
+        assert!(authority
+            .task_config_path()
+            .ends_with(REF2VA_TASK_CONFIG_SOURCE));
+        assert_eq!(authority.identity_sha256().len(), 64);
+
+        // The derived VAE plan follows the task's own manifest as well,
+        // rather than re-deriving from the FL2VA constant.
+        let staging = tempfile::tempdir().unwrap();
+        let staging = staging.path().canonicalize().unwrap();
+        authority.vae_plan(&staging).unwrap();
+
+        // And the two tasks keep distinct storage identities.
+        let fl2va = H3PrivateComfyStorageAuthority::resolve(&root, Task::Fl2va).unwrap();
+        assert_ne!(fl2va.identity_sha256(), authority.identity_sha256());
     }
 
     #[cfg(unix)]

--- a/crates/mold-inference/src/minimax_h3/private_server.rs
+++ b/crates/mold-inference/src/minimax_h3/private_server.rs
@@ -1356,7 +1356,7 @@ fn prepare_reviewed_h3_private_fl2va_admission(
     )?;
     progress.checkpoint()?;
 
-    let storage = H3PrivateComfyStorageAuthority::resolve(paths.models_root)?;
+    let storage = H3PrivateComfyStorageAuthority::resolve(paths.models_root, admitted_task)?;
     let qwen_support = load_qualified_private_qwen_support(paths.models_root, partition_model)?;
     let transformer_cancellation = H3PrivatePreparationCancellation { progress };
     let opened_transformer = open_h3_comfy_published_int8_checkpoint(
@@ -2439,14 +2439,26 @@ fn prepare_reviewed_h3_private_fl2va_attempt(
     }
     progress.checkpoint()?;
 
-    let storage = H3PrivateComfyStorageAuthority::resolve(paths.models_root)?;
-    let qwen_support =
-        load_qualified_private_qwen_support(paths.models_root, contract::FL2VA_COMFY)?;
+    // The reopen must follow what admission froze, never a fresh constant.
+    let reopened_task = frozen_factory.task();
+    let reopened_model = frozen_factory.canonical_model().to_owned();
+    let (reopened_transformer_task, reopened_published_artifact) = match reopened_task {
+        Task::Fl2va => (
+            H3TransformerTask::T2VaFl2Va,
+            H3ComfyPublishedArtifact::Fl2VaPrunedInt8ConvRot,
+        ),
+        Task::Ref2va => (
+            H3TransformerTask::Ref2Va,
+            H3ComfyPublishedArtifact::Ref2VaPrunedInt8ConvRot,
+        ),
+    };
+    let storage = H3PrivateComfyStorageAuthority::resolve(paths.models_root, reopened_task)?;
+    let qwen_support = load_qualified_private_qwen_support(paths.models_root, &reopened_model)?;
     let transformer_cancellation = H3PrivatePreparationCancellation { progress };
     let opened_transformer = open_h3_comfy_published_int8_checkpoint(
         storage.transformer_path(),
-        H3TransformerTask::T2VaFl2Va,
-        H3ComfyPublishedArtifact::Fl2VaPrunedInt8ConvRot,
+        reopened_transformer_task,
+        reopened_published_artifact,
         &transformer_cancellation,
     )
     .map_err(|error| anyhow!(error.to_string()))?;

--- a/crates/mold-inference/src/minimax_h3/private_server.rs
+++ b/crates/mold-inference/src/minimax_h3/private_server.rs
@@ -726,17 +726,23 @@ pub struct H3PrivateFl2VaMediaContract {
 impl H3PrivateFl2VaMediaContract {
     fn validate(&self) -> Result<()> {
         // The request keeps its full reviewed identity — a Turbo tag included
-        // — while the engine partition it executes as must be compact FL2VA.
-        if contract::base_compact_model(&self.canonical_model) != Some(contract::FL2VA_COMFY)
+        // — while the engine partition it executes as must be its own task's
+        // compact base, and the mode must be the task's own conditioning
+        // shape. For FL2VA this is exactly the old constant pin.
+        let mode_matches_task = match self.task {
+            Task::Fl2va => self.mode != Mode::ReferenceToAudioVideo,
+            Task::Ref2va => self.mode == Mode::ReferenceToAudioVideo,
+        };
+        if contract::base_compact_model(&self.canonical_model)
+            != Some(contract::base_compact_model_for_task(self.task))
             || !contract::is_reviewed_compact_model(&self.canonical_model)
-            || self.task != Task::Fl2va
-            || self.mode == Mode::ReferenceToAudioVideo
+            || !mode_matches_task
             || self.width == 0
             || self.height == 0
             || self.frames == 0
             || self.fps != contract::FIXED_FPS
         {
-            bail!("private H3 frozen media contract is not exact FL2VA")
+            bail!("private H3 frozen media contract does not pair with its exact task")
         }
         Ok(())
     }
@@ -2346,9 +2352,11 @@ fn prepare_reviewed_h3_private_fl2va_attempt(
     {
         bail!("private H3 owner fence differs from immutable admission evidence")
     }
-    validate_base_factory(frozen_factory, &owner_fence)?;
-    let mode = contract::validate_request_contract(request, Task::Fl2va)
-        .map_err(|error| anyhow!("{}: {}", error.code, error.message))?;
+    // Every gate from here on is keyed on what admission froze — the frozen
+    // factory's own task and its compact engine partition — never on an
+    // FL2VA constant, so a frozen Ref2VA attempt reaches its own validators.
+    let frozen_route = validate_frozen_reopen_route(request, frozen_factory, &owner_fence)?;
+    let mode = frozen_route.mode;
     #[cfg(not(feature = "h3"))]
     let reviewed_runtime_qualification = open_reviewed_h3_private_runtime_qualification(
         paths.runtime_qualification_record,
@@ -2363,7 +2371,7 @@ fn prepare_reviewed_h3_private_fl2va_attempt(
 
     let artifact_report = qualify_private_artifacts_with_control(
         paths.models_root,
-        contract::FL2VA_COMFY,
+        frozen_route.partition_model,
         paths.authorization_record,
         |hash| {
             progress.checkpoint()?;
@@ -2440,25 +2448,17 @@ fn prepare_reviewed_h3_private_fl2va_attempt(
     progress.checkpoint()?;
 
     // The reopen must follow what admission froze, never a fresh constant.
-    let reopened_task = frozen_factory.task();
-    let reopened_model = frozen_factory.canonical_model().to_owned();
-    let (reopened_transformer_task, reopened_published_artifact) = match reopened_task {
-        Task::Fl2va => (
-            H3TransformerTask::T2VaFl2Va,
-            H3ComfyPublishedArtifact::Fl2VaPrunedInt8ConvRot,
-        ),
-        Task::Ref2va => (
-            H3TransformerTask::Ref2Va,
-            H3ComfyPublishedArtifact::Ref2VaPrunedInt8ConvRot,
-        ),
-    };
+    // The route above already validated the base factory and keyed the
+    // request contract and artifact qualification on the frozen task.
+    let reopened_task = frozen_route.task;
     let storage = H3PrivateComfyStorageAuthority::resolve(paths.models_root, reopened_task)?;
-    let qwen_support = load_qualified_private_qwen_support(paths.models_root, &reopened_model)?;
+    let qwen_support =
+        load_qualified_private_qwen_support(paths.models_root, frozen_route.partition_model)?;
     let transformer_cancellation = H3PrivatePreparationCancellation { progress };
     let opened_transformer = open_h3_comfy_published_int8_checkpoint(
         storage.transformer_path(),
-        reopened_transformer_task,
-        reopened_published_artifact,
+        frozen_route.transformer_task,
+        frozen_route.published_artifact,
         &transformer_cancellation,
     )
     .map_err(|error| anyhow!(error.to_string()))?;
@@ -2581,7 +2581,7 @@ fn prepare_reviewed_h3_private_fl2va_attempt(
     }
     let media = H3PrivateFl2VaMediaContract {
         canonical_model: request.model.clone(),
-        task: Task::Fl2va,
+        task: reopened_task,
         mode,
         seed,
         width: request.width,
@@ -2679,8 +2679,13 @@ fn validate_base_factory(
     factory: &FrozenH3FactoryAuthority,
     owner: &H3PrivateFl2VaOwnerFenceFacts,
 ) -> Result<()> {
-    if factory.canonical_model() != contract::FL2VA_COMFY
-        || factory.task() != Task::Fl2va
+    // The gate is keyed on the FROZEN task: the canonical model must be that
+    // task's own compact engine partition, and the task must have reviewed
+    // runtime availability in this build — which is what keeps a frozen
+    // Ref2VA attempt refused everywhere outside the developer campaign build.
+    let task = factory.task();
+    if !reviewed_h3_private_runtime_available_for_task(task)
+        || factory.canonical_model() != contract::base_compact_model_for_task(task)
         || factory.device_id() != owner.device_id
         || factory.device_ordinal() != owner.device_ordinal
         || factory.compute_capability() != Some(owner.compute_capability)
@@ -2689,9 +2694,58 @@ fn validate_base_factory(
         || factory.attention_backend() != AttentionBackend::Flash
         || factory.attention_chunk() != AttentionChunkPolicy::Off
     {
-        bail!("private H3 base factory differs from the exact FL2VA owner route")
+        bail!("private H3 base factory differs from the exact frozen owner route")
     }
     Ok(())
+}
+
+/// The route every reopen gate below the fence is keyed on, derived from the
+/// frozen factory rather than from a task constant. `partition_model` is the
+/// frozen task's compact engine partition — the identity artifact
+/// qualification, storage, and Qwen support key on — mirroring admission's
+/// `H3AdmittedRoute` split.
+#[cfg(feature = "mp4")]
+#[derive(Debug)]
+struct H3FrozenReopenRoute {
+    task: Task,
+    partition_model: &'static str,
+    transformer_task: H3TransformerTask,
+    published_artifact: H3ComfyPublishedArtifact,
+    mode: Mode,
+}
+
+/// Validate the frozen factory against the owner fence and the request
+/// against the FROZEN task's contract, then hand back the task-keyed route.
+/// The request at reopen is the resolved queue/worker form, so Ref2VA
+/// references must be descriptor authorities — the same contract admission
+/// validated; for FL2VA the resolved and submitted contracts are identical.
+#[cfg(feature = "mp4")]
+fn validate_frozen_reopen_route(
+    request: &GenerateRequest,
+    frozen_factory: &FrozenH3FactoryAuthority,
+    owner_fence: &H3PrivateFl2VaOwnerFenceFacts,
+) -> Result<H3FrozenReopenRoute> {
+    validate_base_factory(frozen_factory, owner_fence)?;
+    let task = frozen_factory.task();
+    let (transformer_task, published_artifact) = match task {
+        Task::Fl2va => (
+            H3TransformerTask::T2VaFl2Va,
+            H3ComfyPublishedArtifact::Fl2VaPrunedInt8ConvRot,
+        ),
+        Task::Ref2va => (
+            H3TransformerTask::Ref2Va,
+            H3ComfyPublishedArtifact::Ref2VaPrunedInt8ConvRot,
+        ),
+    };
+    let mode = contract::validate_resolved_request_contract(request, task)
+        .map_err(|error| anyhow!("{}: {}", error.code, error.message))?;
+    Ok(H3FrozenReopenRoute {
+        task,
+        partition_model: contract::base_compact_model_for_task(task),
+        transformer_task,
+        published_artifact,
+        mode,
+    })
 }
 
 #[cfg(feature = "mp4")]
@@ -6153,8 +6207,14 @@ mod tests {
     }
 
     fn base_factory() -> FrozenH3FactoryAuthority {
+        contract_factory(contract::FL2VA_COMFY)
+    }
+
+    /// The same contract-only frozen factory the FL2VA reopen fixtures use,
+    /// parameterized so a Ref2VA route can freeze one too.
+    fn contract_factory(model: &str) -> FrozenH3FactoryAuthority {
         FrozenH3FactoryAuthority::new_contract_only(H3FactoryAuthorityInput {
-            model: contract::FL2VA_COMFY.into(),
+            model: model.into(),
             device_id: DEVICE_0.into(),
             device_ordinal: 0,
             compute_capability: Some((8, 9)),
@@ -6381,6 +6441,173 @@ mod tests {
             reviewed_h3_private_runtime_available_for_task(Task::Ref2va),
             cfg!(feature = "h3-private-uat")
         );
+    }
+
+    /// An owner fence agreeing with the frozen factory's own route, so a test
+    /// isolates the task keying rather than a crossed device.
+    #[cfg(feature = "mp4")]
+    fn owner_fence_for(factory: &FrozenH3FactoryAuthority) -> H3PrivateFl2VaOwnerFenceFacts {
+        H3PrivateFl2VaOwnerFenceFacts {
+            work_identity_sha256: sha('1'),
+            cancellation_scope_identity_sha256: sha('2'),
+            device_id: factory.device_id().into(),
+            device_ordinal: factory.device_ordinal(),
+            compute_capability: factory
+                .compute_capability()
+                .expect("contract fixtures freeze a CUDA route"),
+            memory_ledger_sequence: 9,
+            admission_evidence_identity_sha256: sha('3'),
+            artifact_qualification_identity_sha256: sha('4'),
+            runtime_qualification_identity_sha256: sha('5'),
+            prepared_attempt_identity_sha256: sha('6'),
+            target_budget_identity_sha256: sha('7'),
+            predicted_device_peak_bytes: 7,
+            predicted_host_increment_bytes: 8,
+        }
+    }
+
+    /// The resolved queue/worker form of an FL2VA request, matching what the
+    /// reopen receives from the durable queue.
+    #[cfg(feature = "mp4")]
+    fn fl2va_reopen_request() -> GenerateRequest {
+        serde_json::from_value(serde_json::json!({
+            "model": contract::FL2VA_COMFY,
+            "prompt": "a calm scene",
+            "width": 1344,
+            "height": 768,
+            "steps": 21,
+            "guidance": 0.0,
+            "strength": 1.0,
+            "batch_size": 1,
+            "output_format": "mp4",
+            "frames": 124,
+            "fps": contract::FIXED_FPS,
+            "seed": 42
+        }))
+        .unwrap()
+    }
+
+    /// The resolved Ref2VA form: references are descriptor authorities, which
+    /// is the only shape the queue and worker may hold.
+    #[cfg(feature = "mp4")]
+    fn ref2va_reopen_request() -> GenerateRequest {
+        use mold_core::{
+            GenerationReference, GenerationReferenceAuthority, GenerationReferenceProvenance,
+        };
+
+        let mut request = fl2va_reopen_request();
+        request.model = contract::REF2VA_COMFY.into();
+        request.references = Some(vec![GenerationReference::Image {
+            media: GenerationReferenceAuthority::Descriptor,
+            provenance: GenerationReferenceProvenance {
+                name: Some("portrait.png".to_string()),
+                sha256: Some(sha('9')),
+            },
+            mime_type: "image/png".into(),
+            width: 48,
+            height: 48,
+        }]);
+        request
+    }
+
+    /// A frozen Ref2VA attempt must reach and pass the task-aware reopen
+    /// validators: the base-factory gate, the resolved request contract, and
+    /// the qualification partition are all keyed on the FROZEN task, never on
+    /// an FL2VA constant. Validating the request as `Task::Fl2va` and
+    /// qualifying `contract::FL2VA_COMFY` before the frozen-task logic ran is
+    /// exactly what made the Ref2VA reopen path unreachable.
+    #[cfg(all(feature = "mp4", feature = "h3-private-uat"))]
+    #[test]
+    fn frozen_ref2va_attempt_passes_the_task_aware_reopen_validators() {
+        let factory = contract_factory(contract::REF2VA_COMFY);
+        assert_eq!(factory.task(), Task::Ref2va);
+        let fence = owner_fence_for(&factory);
+        let route =
+            validate_frozen_reopen_route(&ref2va_reopen_request(), &factory, &fence).unwrap();
+        assert_eq!(route.task, Task::Ref2va);
+        assert_eq!(route.partition_model, contract::REF2VA_COMFY);
+        assert_eq!(route.transformer_task, H3TransformerTask::Ref2Va);
+        assert_eq!(
+            route.published_artifact,
+            H3ComfyPublishedArtifact::Ref2VaPrunedInt8ConvRot
+        );
+        assert_eq!(route.mode, Mode::ReferenceToAudioVideo);
+
+        // A crossed request — the other task's shape on this frozen route —
+        // is refused by the same task-keyed validator.
+        assert!(validate_frozen_reopen_route(&fl2va_reopen_request(), &factory, &fence).is_err());
+    }
+
+    /// The FL2VA reopen route is unchanged by the task keying.
+    #[cfg(feature = "mp4")]
+    #[test]
+    fn frozen_fl2va_attempt_keeps_its_exact_reopen_route() {
+        let factory = base_factory();
+        let fence = owner_fence_for(&factory);
+        let route =
+            validate_frozen_reopen_route(&fl2va_reopen_request(), &factory, &fence).unwrap();
+        assert_eq!(route.task, Task::Fl2va);
+        assert_eq!(route.partition_model, contract::FL2VA_COMFY);
+        assert_eq!(route.transformer_task, H3TransformerTask::T2VaFl2Va);
+        assert_eq!(
+            route.published_artifact,
+            H3ComfyPublishedArtifact::Fl2VaPrunedInt8ConvRot
+        );
+        assert_eq!(route.mode, Mode::TextToAudioVideo);
+        assert!(validate_frozen_reopen_route(&ref2va_reopen_request(), &factory, &fence).is_err());
+    }
+
+    /// Without the developer campaign build a frozen Ref2VA factory must stay
+    /// refused at the reopen's first gate: task availability is per task, and
+    /// an FL2VA qualification never authorizes Ref2VA.
+    #[cfg(all(feature = "mp4", not(feature = "h3-private-uat")))]
+    #[test]
+    fn frozen_ref2va_attempt_stays_refused_without_the_campaign_build() {
+        let factory = contract_factory(contract::REF2VA_COMFY);
+        let fence = owner_fence_for(&factory);
+        let error = validate_frozen_reopen_route(&ref2va_reopen_request(), &factory, &fence)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("frozen owner route"), "{error}");
+    }
+
+    /// The frozen media contract pairs mode and partition with its own task
+    /// in both directions.
+    #[test]
+    fn frozen_media_contract_is_task_paired() {
+        media().validate().unwrap();
+
+        let ref2va = H3PrivateFl2VaMediaContract {
+            canonical_model: contract::REF2VA_COMFY.into(),
+            task: Task::Ref2va,
+            mode: Mode::ReferenceToAudioVideo,
+            ..media()
+        };
+        ref2va.validate().unwrap();
+
+        // Each axis crossed against the task is refused: the FL2VA mode on a
+        // Ref2VA contract, the Ref2VA mode on an FL2VA contract, and either
+        // task carrying the other task's partition model.
+        let crossed_mode = H3PrivateFl2VaMediaContract {
+            mode: Mode::TextToAudioVideo,
+            ..ref2va.clone()
+        };
+        assert!(crossed_mode.validate().is_err());
+        let crossed_fl2va = H3PrivateFl2VaMediaContract {
+            mode: Mode::ReferenceToAudioVideo,
+            ..media()
+        };
+        assert!(crossed_fl2va.validate().is_err());
+        let crossed_model = H3PrivateFl2VaMediaContract {
+            canonical_model: contract::FL2VA_COMFY.into(),
+            ..ref2va
+        };
+        assert!(crossed_model.validate().is_err());
+        let crossed_task = H3PrivateFl2VaMediaContract {
+            canonical_model: contract::REF2VA_COMFY.into(),
+            ..media()
+        };
+        assert!(crossed_task.validate().is_err());
     }
 
     /// The capture-scope profile must never be mistakable for a qualified one.


### PR DESCRIPTION
## Summary

Final model-side slice for #825: carries the Ref2VA prepared request through `build_private_fl2va_admission_attempt` to a Ref2VA-shaped frozen plan. Four remaining FL2VA-pinned points now follow the admitted task: the storage authority's manifest resolution, the transformer contract validator, the VAE contract validator, and the raw checkpoint's expected artifact. The reopen path follows what admission froze, so a re-derived attempt cannot drift to the other task's checkpoint.

**One authority, pinned:** reconciling with #1203 revealed the slice was carrying a second copy of the task→partition mapping — the same duplication class that produced the turbo qualification defect — so both call sites now delegate to `contract::base_compact_model_for_task`, and a test walks all four identities (both bases + both turbo tags) asserting the storage authority's task-derived identity equals the route's partition and is the manifest actually opened.

**Storage fact as a test:** the Ref2VA stack differs from FL2VA in exactly two manifest entries — the transformer weight file and the `transformer_ref/config.json` lookup key (content and sha256 identical, 546 bytes, 74c11bff…); Qwen weights and both VAEs shared, asserted by digest comparison.

**FL2VA byte-identity, verified:** a prepared-attempt identity pin (862ae3c2…) captured BEFORE this work still holds across #1200/#1201/#1202/#1203 and this slice — now a permanent regression test. The cross-task validator test checks both directions.

Ref2VA remains campaign-build-only under `h3-private-uat`; the public allowlist is untouched (`reviewed_allowlist_is_scoped_to_fl2va` passes on both feature sets). Next: the instrumented capture campaign on the 4090.

## Known pre-existing failures (NOT this PR)

Running the `h3-private-uat` server suite correctly surfaces 10 deterministic `gpu_worker::tests::claimed_h3_*`/`claimed_ref2va_*` failures that are byte-identical on the commit before #1201 — tracked in #1204; this branch adds zero to that set.

## Gates
fmt, `check --workspace --all-targets`, `h3-cuda,mp4` clippy, Metal-proxy clippy all clean; `private_opened_evidence` 13, `h3_factory` 34, inference `h3-private-uat,mp4` 2166 ✓ (+known staged_weights flake).