### PR TITLE
feat(h3): wire the compiled capture-scope authority into Ref2VA admission

### DIFF
--- a/crates/mold-inference/src/minimax_h3/private_fl2va_runtime.rs
+++ b/crates/mold-inference/src/minimax_h3/private_fl2va_runtime.rs
@@ -1844,7 +1844,7 @@ where
             allocation_commit,
             attempt,
         } = self;
-        let (prepared, retention) = prepared.into_runtime_parts();
+        let (prepared, retention) = prepared.into_runtime_parts()?;
         retention.revalidate()?;
         let expected_denoise_forwards =
             super::sampler::H3DualSchedule::new_for_sampler_with_video_shift(

--- a/crates/mold-inference/src/minimax_h3/private_opened_evidence.rs
+++ b/crates/mold-inference/src/minimax_h3/private_opened_evidence.rs
@@ -618,10 +618,32 @@ impl H3PrivateQualifiedRuntimeBounds {
     }
 }
 
+/// The task-shaped concrete runtime request one prepared owner attempt
+/// retains. FL2VA keeps its endpoint-normalized tensor request unchanged;
+/// Ref2VA — constructible only in the developer campaign build — retains the
+/// resolved reference-conditioned preparation. There is deliberately no
+/// Ref2VA variant outside `h3-private-uat`, so a shipping build cannot even
+/// represent a Ref2VA prepared owner attempt.
+pub(crate) enum H3PrivatePreparedTaskRequest {
+    Fl2va(H3PreparedFl2VaRequest),
+    #[cfg(all(feature = "mp4", feature = "h3-private-uat"))]
+    Ref2va(super::pipeline::ref2va::H3PreparedRef2VaRequest),
+}
+
+impl H3PrivatePreparedTaskRequest {
+    fn seed(&self) -> u64 {
+        match self {
+            Self::Fl2va(prepared) => prepared.seed,
+            #[cfg(all(feature = "mp4", feature = "h3-private-uat"))]
+            Self::Ref2va(prepared) => prepared.seed(),
+        }
+    }
+}
+
 /// Opaque, one-shot prepared attempt. The concrete normalized CPU tensors and
 /// resolved seed stay owned here until the caller consumes the record.
 pub(crate) struct H3PrivatePreparedFl2VaAttempt {
-    prepared: H3PreparedFl2VaRequest,
+    prepared: H3PrivatePreparedTaskRequest,
     factory_attempt: H3FactoryPreparedAttemptInput,
     budget_echo: H3FactoryExecutionBudgetEchoInput,
     // Retain the authenticated descriptor so the artifact priced into the
@@ -638,7 +660,7 @@ pub(crate) struct H3PrivateFl2VaAdmissionPreparedRequest {
 }
 
 pub(crate) struct H3PrivatePreparedFl2VaFactoryInputs {
-    pub(crate) prepared: H3PreparedFl2VaRequest,
+    pub(crate) prepared: H3PrivatePreparedTaskRequest,
     pub(crate) factory_attempt: H3FactoryPreparedAttemptInput,
     pub(crate) budget_echo: H3FactoryExecutionBudgetEchoInput,
     _transformer_support: H3PrivateOpenedTaskConfigAuthority,
@@ -658,6 +680,7 @@ impl H3PrivatePreparedFl2VaAttempt {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn prepare(
         request: &GenerateRequest,
+        references: &[crate::engine::GenerationReferenceBinding],
         execution_fingerprint: &str,
         storage: &H3PrivateComfyStorageAuthority,
         support: &H3PrivateQwenSupport,
@@ -674,8 +697,43 @@ impl H3PrivatePreparedFl2VaAttempt {
         storage.validate_opened_components(support, transformer, qwen, vae)?;
         let transformer_support = storage.open_task_config()?;
         transformer_support.revalidate()?;
-        let (prepared, factory_request) =
-            prepare_private_fl2va_request_input(request, support, progress, observer)?;
+        // The preparation is task-shaped by the storage authority the caller
+        // already resolved for the frozen route: FL2VA keeps its endpoint
+        // path byte-identical, Ref2VA re-derives the same reference-decoded
+        // request admission froze — and only in the campaign build.
+        let task = storage.task;
+        if !super::private_server::reviewed_h3_private_runtime_available_for_task(task) {
+            bail!(
+                "private H3 prepared attempts for {task:?} have no reviewed runtime in this build"
+            )
+        }
+        let (prepared, factory_request) = match task {
+            Task::Fl2va => {
+                if !references.is_empty() {
+                    bail!("private H3 FL2VA preparation was handed Ref2VA reference bindings")
+                }
+                let (prepared, factory_request) =
+                    prepare_private_fl2va_request_input(request, support, progress, observer)?;
+                (
+                    H3PrivatePreparedTaskRequest::Fl2va(prepared),
+                    factory_request,
+                )
+            }
+            #[cfg(all(feature = "mp4", feature = "h3-private-uat"))]
+            Task::Ref2va => {
+                let (prepared, factory_request) = prepare_private_ref2va_request_input(
+                    request, references, support, progress, observer,
+                )?;
+                (
+                    H3PrivatePreparedTaskRequest::Ref2va(prepared),
+                    factory_request,
+                )
+            }
+            #[cfg(not(all(feature = "mp4", feature = "h3-private-uat")))]
+            Task::Ref2va => {
+                bail!("private H3 Ref2VA prepared attempts require the campaign build")
+            }
+        };
         let raw_checkpoint = raw_checkpoint_input(factory_request.task, transformer)?;
         let target_budget = build_canonical_private_fl2va_target_budget(
             &factory_request,
@@ -710,7 +768,7 @@ impl H3PrivatePreparedFl2VaAttempt {
     }
 
     pub(crate) fn seed(&self) -> u64 {
-        self.prepared.seed
+        self.prepared.seed()
     }
 
     pub(crate) fn identity_sha256(&self) -> &str {
@@ -882,6 +940,29 @@ pub(crate) fn prepare_private_ref2va_admission_request(
     progress: &ProgressReporter,
     observer: &mut dyn H3PipelineObserver,
 ) -> Result<H3PrivateFl2VaAdmissionPreparedRequest> {
+    let (prepared, factory_request) =
+        prepare_private_ref2va_request_input(request, references, support, progress, observer)?;
+    Ok(H3PrivateFl2VaAdmissionPreparedRequest {
+        seed: prepared.seed(),
+        request: factory_request,
+    })
+}
+
+/// The shared Ref2VA preparation both admission and the frozen-plan reopen
+/// derive their factory request from — exactly one decoder, exactly one row
+/// derivation, so the reopen's recomputation can only agree with admission by
+/// reproducing it.
+#[cfg(feature = "mp4")]
+fn prepare_private_ref2va_request_input(
+    request: &GenerateRequest,
+    references: &[crate::engine::GenerationReferenceBinding],
+    support: &H3PrivateQwenSupport,
+    progress: &ProgressReporter,
+    observer: &mut dyn H3PipelineObserver,
+) -> Result<(
+    super::pipeline::ref2va::H3PreparedRef2VaRequest,
+    H3FactoryPreparedRequestInput,
+)> {
     if support.model() != contract::REF2VA_COMFY || support.task() != Task::Ref2va {
         bail!("private H3 Ref2VA admission has cross-task Qwen support")
     }
@@ -917,10 +998,7 @@ pub(crate) fn prepare_private_ref2va_admission_request(
         factory_references,
         u64::try_from(qwen_output_text_rows)?,
     )?;
-    Ok(H3PrivateFl2VaAdmissionPreparedRequest {
-        seed: prepared.seed(),
-        request: factory_request,
-    })
+    Ok((prepared, factory_request))
 }
 
 pub(crate) fn prepare_private_fl2va_admission_request(
@@ -1012,10 +1090,10 @@ impl H3PrivatePreparedFl2VaFactoryInputs {
             &self.factory_attempt.target_budget.identity_sha256,
             "private H3 target budget",
         )?;
-        if self.factory_attempt.request.canonical_model != contract::FL2VA_COMFY
-            || self.factory_attempt.request.task != Task::Fl2va
-            || self.factory_attempt.identity_sha256
-                != expected_h3_factory_prepared_attempt_identity(&self.factory_attempt)
+        validate_prepared_attempt_task_authority(&self.factory_attempt.request)?;
+        let task = self.factory_attempt.request.task;
+        if self.factory_attempt.identity_sha256
+            != expected_h3_factory_prepared_attempt_identity(&self.factory_attempt)
             || self.factory_attempt.target_budget.identity_sha256
                 != expected_h3_factory_target_budget_identity(&self.factory_attempt.target_budget)
             || self.budget_echo.prepared_attempt_identity_sha256
@@ -1033,7 +1111,16 @@ impl H3PrivatePreparedFl2VaFactoryInputs {
         {
             bail!("private H3 prepared runtime input changed after opened-evidence binding")
         }
-        validate_prepared_runtime_request(&self.prepared, &self.factory_attempt.request)?;
+        match (&self.prepared, task) {
+            (H3PrivatePreparedTaskRequest::Fl2va(prepared), Task::Fl2va) => {
+                validate_prepared_runtime_request(prepared, &self.factory_attempt.request)?
+            }
+            #[cfg(all(feature = "mp4", feature = "h3-private-uat"))]
+            (H3PrivatePreparedTaskRequest::Ref2va(prepared), Task::Ref2va) => {
+                validate_prepared_ref2va_runtime_request(prepared, &self.factory_attempt.request)?
+            }
+            _ => bail!("private H3 prepared runtime request does not match its frozen task"),
+        }
         Ok(())
     }
 
@@ -1075,15 +1162,29 @@ impl H3PrivatePreparedFl2VaFactoryInputs {
 
     pub(crate) fn into_runtime_parts(
         self,
-    ) -> (H3PreparedFl2VaRequest, H3PrivatePreparedFl2VaRetention) {
-        (
-            self.prepared,
+    ) -> Result<(H3PreparedFl2VaRequest, H3PrivatePreparedFl2VaRetention)> {
+        // Execution is still the FL2VA runtime only: a Ref2VA prepared
+        // attempt is an admission/reopen authority, and the campaign's
+        // execution slice must extend this split rather than run the FL2VA
+        // pipeline against reference conditioning. The match is infallible
+        // only outside the campaign build, where the Ref2VA variant does not
+        // exist at all.
+        #[allow(clippy::infallible_destructuring_match)]
+        let prepared = match self.prepared {
+            H3PrivatePreparedTaskRequest::Fl2va(prepared) => prepared,
+            #[cfg(all(feature = "mp4", feature = "h3-private-uat"))]
+            H3PrivatePreparedTaskRequest::Ref2va(_) => {
+                bail!("private H3 Ref2VA prepared attempts have no runtime execution slice yet")
+            }
+        };
+        Ok((
+            prepared,
             H3PrivatePreparedFl2VaRetention {
                 factory_attempt: self.factory_attempt,
                 budget_echo: self.budget_echo,
                 transformer_support: self._transformer_support,
             },
-        )
+        ))
     }
 }
 
@@ -1211,6 +1312,57 @@ fn validate_prepared_runtime_request(
         || conditioning_fingerprint(&current_endpoints) != frozen.conditioning_fingerprint
     {
         bail!("private H3 prepared prompt, geometry, rows, or conditioning changed")
+    }
+    Ok(())
+}
+
+/// The task pin every prepared owner attempt revalidation applies, keyed
+/// exactly like the reopen's base-factory gate: the frozen request's
+/// canonical model must be its own task's compact engine partition, and the
+/// task must have reviewed runtime availability in this build — which keeps
+/// a Ref2VA prepared owner attempt refused everywhere outside the developer
+/// campaign build while FL2VA keeps its old constant pin byte-identical.
+fn validate_prepared_attempt_task_authority(request: &H3FactoryPreparedRequestInput) -> Result<()> {
+    let task = request.task;
+    if !super::private_server::reviewed_h3_private_runtime_available_for_task(task)
+        || request.canonical_model != contract::base_compact_model_for_task(task)
+    {
+        bail!("private H3 prepared attempt is not a reviewed task authority in this build")
+    }
+    Ok(())
+}
+
+/// The Ref2VA mirror of [`validate_prepared_runtime_request`]: the retained
+/// concrete preparation must still describe exactly the frozen factory
+/// request. Reference row and byte charges are identity-bound inside the
+/// frozen request itself; what this re-derives is everything the prepared
+/// value carries — prompt, seed, schedule, geometry, and the ordered
+/// reference fingerprint.
+#[cfg(all(feature = "mp4", feature = "h3-private-uat"))]
+fn validate_prepared_ref2va_runtime_request(
+    prepared: &super::pipeline::ref2va::H3PreparedRef2VaRequest,
+    frozen: &H3FactoryPreparedRequestInput,
+) -> Result<()> {
+    let geometry = prepared.geometry();
+    let counts =
+        H3DualSchedule::new_for_sampler(prepared.grid_points(), H3SamplerKind::ComfyResMultistep)?
+            .counts();
+    if frozen.mode != Mode::ReferenceToAudioVideo
+        || geometry.mode != frozen.mode
+        || !frozen.endpoints.is_empty()
+        || frozen.references.len() != prepared.references().len()
+        || sha256(prepared.prompt().as_bytes()) != frozen.prompt_sha256
+        || prepared.seed() != frozen.seed
+        || prepared.grid_points() != usize::try_from(frozen.grid_points)?
+        || u32::try_from(counts.transformer_evaluations)? != frozen.denoise_forward_count
+        || geometry.width != usize::try_from(frozen.width)?
+        || geometry.height != usize::try_from(frozen.height)?
+        || geometry.frames != usize::try_from(frozen.frames)?
+        || geometry.latent_frames != usize::try_from(frozen.video_latent_frames)?
+        || geometry.audio_latents_per_channel != usize::try_from(frozen.audio_latents_per_channel)?
+        || prepared.reference_fingerprint() != frozen.reference_fingerprint
+    {
+        bail!("private H3 prepared Ref2VA request differs from its frozen authority")
     }
     Ok(())
 }
@@ -2308,6 +2460,124 @@ mod tests {
                 total_packed_rows: 103,
             },
         };
+        (prepared, frozen)
+    }
+
+    /// The prepared owner attempt authority is task-shaped: FL2VA passes the
+    /// task pin on every build, a Ref2VA prepared attempt is admissible only
+    /// in the developer campaign build (mirroring
+    /// `reviewed_allowlist_is_scoped_to_fl2va`), and a crossed partition is
+    /// refused everywhere.
+    #[test]
+    fn ref2va_prepared_attempt_task_authority_is_gated_per_build() {
+        let (_, fl2va_frozen) = prepared_runtime_pair();
+        validate_prepared_attempt_task_authority(&fl2va_frozen).unwrap();
+
+        let mut ref2va_frozen = fl2va_frozen.clone();
+        ref2va_frozen.canonical_model = contract::REF2VA_COMFY.into();
+        ref2va_frozen.task = Task::Ref2va;
+        assert_eq!(
+            validate_prepared_attempt_task_authority(&ref2va_frozen).is_ok(),
+            cfg!(feature = "h3-private-uat"),
+            "a Ref2VA prepared owner attempt is constructible exactly in the campaign build"
+        );
+
+        // Either task carrying the other task's partition model is refused
+        // on every build.
+        let mut crossed = fl2va_frozen.clone();
+        crossed.canonical_model = contract::REF2VA_COMFY.into();
+        assert!(validate_prepared_attempt_task_authority(&crossed).is_err());
+        let mut crossed = fl2va_frozen;
+        crossed.task = Task::Ref2va;
+        assert!(validate_prepared_attempt_task_authority(&crossed).is_err());
+    }
+
+    /// A Ref2VA prepared owner attempt in the campaign build: the resolved
+    /// preparation and the frozen factory request it derives agree through
+    /// the task-aware runtime validator, and every retained axis — prompt,
+    /// seed, schedule, and the ordered reference fingerprint — is load-bearing.
+    #[cfg(all(feature = "mp4", feature = "h3-private-uat"))]
+    #[test]
+    fn ref2va_prepared_owner_attempt_is_constructible_in_the_campaign_build() {
+        let (prepared, frozen) = ref2va_prepared_runtime_pair();
+        validate_prepared_attempt_task_authority(&frozen).unwrap();
+        validate_prepared_ref2va_runtime_request(&prepared, &frozen).unwrap();
+
+        for mutate in [
+            (|frozen: &mut H3FactoryPreparedRequestInput| {
+                frozen.reference_fingerprint = sha256(b"other-references")
+            }) as fn(&mut H3FactoryPreparedRequestInput),
+            |frozen| frozen.prompt_sha256 = sha256(b"other-prompt"),
+            |frozen| frozen.seed += 1,
+            |frozen| frozen.grid_points += 1,
+            |frozen| frozen.references.clear(),
+            |frozen| frozen.mode = Mode::TextToAudioVideo,
+        ] {
+            let mut crossed = frozen.clone();
+            mutate(&mut crossed);
+            assert!(validate_prepared_ref2va_runtime_request(&prepared, &crossed).is_err());
+        }
+
+        // The FL2VA frozen request is not a valid authority for a Ref2VA
+        // preparation.
+        let (_, fl2va_frozen) = prepared_runtime_pair();
+        assert!(validate_prepared_ref2va_runtime_request(&prepared, &fl2va_frozen).is_err());
+    }
+
+    #[cfg(all(feature = "mp4", feature = "h3-private-uat"))]
+    fn ref2va_prepared_runtime_pair() -> (
+        super::super::pipeline::ref2va::H3PreparedRef2VaRequest,
+        H3FactoryPreparedRequestInput,
+    ) {
+        use mold_core::{
+            GenerationReference, GenerationReferenceAuthority, GenerationReferenceKind,
+            GenerationReferenceProvenance,
+        };
+
+        let mut request: GenerateRequest = serde_json::from_value(serde_json::json!({
+            "model": contract::REF2VA_COMFY,
+            "prompt": "a reviewed reference scene",
+            "width": 1344,
+            "height": 768,
+            "steps": 21,
+            "guidance": 0.0,
+            "strength": 1.0,
+            "batch_size": 1,
+            "output_format": "mp4",
+            "frames": 124,
+            "fps": contract::FIXED_FPS,
+            "seed": 42
+        }))
+        .unwrap();
+        request.references = Some(vec![GenerationReference::Image {
+            media: GenerationReferenceAuthority::Descriptor,
+            provenance: GenerationReferenceProvenance {
+                name: Some("portrait.png".to_string()),
+                sha256: Some(sha256(b"reference-bytes")),
+            },
+            mime_type: "image/png".into(),
+            width: 640,
+            height: 640,
+        }]);
+        let mut observer = super::super::pipeline::NoopH3PipelineObserver;
+        let prepared = super::super::pipeline::ref2va::prepare_resolved_request(
+            &request,
+            &ProgressReporter::default(),
+            &mut observer,
+        )
+        .unwrap();
+        // Native geometry as the decoder would report it for the one image.
+        let decoded = vec![super::super::pipeline::ref2va::H3DecodedReferenceFacts {
+            index: 1,
+            kind: GenerationReferenceKind::Image,
+            width: Some(4_000),
+            height: Some(3_000),
+            frame_count: None,
+            fps: None,
+            audio: None,
+        }];
+        let references = ref2va_factory_references(prepared.references(), &decoded).unwrap();
+        let frozen = ref2va_prepared_request_input(&request, &prepared, references, 96).unwrap();
         (prepared, frozen)
     }
 

--- a/crates/mold-inference/src/minimax_h3/private_server.rs
+++ b/crates/mold-inference/src/minimax_h3/private_server.rs
@@ -1262,21 +1262,16 @@ fn prepare_reviewed_h3_private_fl2va_admission(
         .map_err(|error| anyhow!("{}: {}", error.code, error.message))?;
     let submitted_request_identity_sha256 = private_h3_request_identity(request)?;
 
-    // Private UAT retains its reviewed-record gate before bulk model I/O.
-    // Ordinary public H3 derives authority from compiled policy, the exact
-    // artifact graph, and the live SM89 attention route instead.
+    // Private UAT retains its reviewed-record gate before bulk model I/O —
+    // resolved per task, because Ref2VA has no reviewed record and its only
+    // authority is the compiled capture-scope profile. Ordinary public H3
+    // derives authority from compiled policy, the exact artifact graph, and
+    // the live SM89 attention route instead.
     #[cfg(not(feature = "h3"))]
-    let reviewed_runtime_qualification = open_reviewed_h3_private_runtime_qualification(
-        paths.runtime_qualification_record,
-        REVIEWED_RUNTIME_QUALIFICATION_RECORD_SHA256,
-    )?;
+    let runtime_qualification_source =
+        private_runtime_qualification_source(admitted_task, paths.runtime_qualification_record)?;
     #[cfg(not(feature = "h3"))]
-    reviewed_runtime_qualification.validate_route(device_id, device_ordinal, compute_capability)?;
-    #[cfg(not(feature = "h3"))]
-    let attention_qualification_sha256 = reviewed_runtime_qualification
-        .record
-        .attention_qualification_sha256
-        .clone();
+    runtime_qualification_source.validate_route(device_id, device_ordinal, compute_capability)?;
     // Cheap capacity floors BEFORE the artifact pass below hashes ~37 GB.
     // Refusing a hopeless device after several minutes of SHA-256 was the
     // worst failure this path had; both floors are provable lower bounds of
@@ -1285,7 +1280,7 @@ fn prepare_reviewed_h3_private_fl2va_admission(
     #[cfg(feature = "h3")]
     let precheck_bounds = public_runtime_bounds();
     #[cfg(not(feature = "h3"))]
-    let precheck_bounds = reviewed_runtime_qualification.record.bounds.clone();
+    let precheck_bounds = runtime_qualification_source.precheck_bounds();
     precheck_private_h3_admission_capacity(
         &precheck_bounds,
         available_device_bytes,
@@ -1316,6 +1311,9 @@ fn prepare_reviewed_h3_private_fl2va_admission(
             .map_err(|error| anyhow!(error.to_string()))?;
     #[cfg(feature = "h3")]
     let attention_qualification_sha256 = attention.identity_sha256().to_string();
+    #[cfg(not(feature = "h3"))]
+    let attention_qualification_sha256 =
+        runtime_qualification_source.attention_qualification_sha256(&attention);
     let attention_input = H3FactoryAttentionInput {
         generic_backend: AttentionBackend::Flash,
         generic_chunk: AttentionChunkPolicy::Off,
@@ -1340,7 +1338,7 @@ fn prepare_reviewed_h3_private_fl2va_admission(
     let turbo_adapter =
         super::turbo::resolve_turbo_authority_for_request(admitted_model, paths.models_root)?;
     #[cfg(not(feature = "h3"))]
-    let runtime_qualification = reviewed_runtime_qualification.authenticate(
+    let runtime_qualification = runtime_qualification_source.authenticate(
         &artifact_report,
         device_id,
         device_ordinal,
@@ -2357,13 +2355,17 @@ fn prepare_reviewed_h3_private_fl2va_attempt(
     // FL2VA constant, so a frozen Ref2VA attempt reaches its own validators.
     let frozen_route = validate_frozen_reopen_route(request, frozen_factory, &owner_fence)?;
     let mode = frozen_route.mode;
+    // The same per-task source admission resolved: the frozen FL2VA route
+    // reopens the reviewed record file, the frozen Ref2VA route re-mints the
+    // compiled capture-scope profile (deterministic, so the identity fence
+    // below still compares it against what admission froze).
     #[cfg(not(feature = "h3"))]
-    let reviewed_runtime_qualification = open_reviewed_h3_private_runtime_qualification(
+    let runtime_qualification_source = private_runtime_qualification_source(
+        frozen_route.task,
         paths.runtime_qualification_record,
-        REVIEWED_RUNTIME_QUALIFICATION_RECORD_SHA256,
     )?;
     #[cfg(not(feature = "h3"))]
-    reviewed_runtime_qualification.validate_route(
+    runtime_qualification_source.validate_route(
         &owner_fence.device_id,
         owner_fence.device_ordinal,
         owner_fence.compute_capability,
@@ -2418,7 +2420,7 @@ fn prepare_reviewed_h3_private_fl2va_attempt(
         lossless: true,
     };
     #[cfg(not(feature = "h3"))]
-    let runtime_qualification = reviewed_runtime_qualification.authenticate(
+    let runtime_qualification = runtime_qualification_source.authenticate(
         &artifact_report,
         &owner_fence.device_id,
         owner_fence.device_ordinal,
@@ -4841,6 +4843,132 @@ impl H3PrivateReviewedRuntimeQualification {
     }
 }
 
+/// The runtime-qualification source for one task under the private-record
+/// build (`not(feature = "h3")`), resolved BEFORE bulk model I/O.
+///
+/// FL2VA keeps its reviewed-record gate exactly as before. Ref2VA has no
+/// reviewed record at all: its only authority is the compiled capture-scope
+/// profile with provisional bounds, which exists precisely so the
+/// instrumented campaign run can be admitted and measure the real ones — so
+/// the Ref2VA arm never touches the record file. That arm is constructible
+/// only under the developer-only `h3-private-uat` feature; every other build
+/// keeps refusing the task here, and public `h3` builds never reach this type
+/// (their Ref2VA refusal lives in `public_runtime_qualification`).
+#[cfg(not(feature = "h3"))]
+enum H3PrivateRuntimeQualificationSource {
+    // Boxed: the opened record dwarfs the unit capture arm
+    // (clippy::large_enum_variant).
+    ReviewedRecord(Box<H3PrivateReviewedRuntimeQualification>),
+    #[cfg(feature = "h3-private-uat")]
+    CaptureCompiled,
+}
+
+#[cfg(not(feature = "h3"))]
+fn private_runtime_qualification_source(
+    task: Task,
+    record_path: &Path,
+) -> Result<H3PrivateRuntimeQualificationSource> {
+    match task {
+        Task::Fl2va => Ok(H3PrivateRuntimeQualificationSource::ReviewedRecord(
+            Box::new(open_reviewed_h3_private_runtime_qualification(
+                record_path,
+                REVIEWED_RUNTIME_QUALIFICATION_RECORD_SHA256,
+            )?),
+        )),
+        #[cfg(feature = "h3-private-uat")]
+        Task::Ref2va => Ok(H3PrivateRuntimeQualificationSource::CaptureCompiled),
+        #[cfg(not(feature = "h3-private-uat"))]
+        Task::Ref2va => bail!(
+            "private H3 Ref2VA has no reviewed runtime qualification outside the campaign build"
+        ),
+    }
+}
+
+#[cfg(not(feature = "h3"))]
+impl H3PrivateRuntimeQualificationSource {
+    /// Reject a route this source cannot authorize before the caller starts
+    /// the multi-artifact qualification pass. The capture arm mirrors the pin
+    /// `capture_runtime_qualification` enforces at minting, so a wrong-arch
+    /// device refuses cheaply instead of after hashing ~37 GB.
+    fn validate_route(
+        &self,
+        device_id: &str,
+        device_ordinal: usize,
+        compute_capability: (u16, u16),
+    ) -> Result<()> {
+        match self {
+            Self::ReviewedRecord(reviewed) => {
+                reviewed.validate_route(device_id, device_ordinal, compute_capability)
+            }
+            #[cfg(feature = "h3-private-uat")]
+            Self::CaptureCompiled => {
+                let _ = device_ordinal;
+                if device_id.trim().is_empty() || compute_capability != (8, 9) {
+                    bail!("capture-scope H3 runtime requires the exact compact Ref2VA SM89 route")
+                }
+                Ok(())
+            }
+        }
+    }
+
+    /// The bounds the cheap admission capacity floors are derived from.
+    fn precheck_bounds(&self) -> H3PrivateRuntimeBoundRecord {
+        match self {
+            Self::ReviewedRecord(reviewed) => reviewed.record.bounds.clone(),
+            #[cfg(feature = "h3-private-uat")]
+            Self::CaptureCompiled => capture_runtime_bounds(),
+        }
+    }
+
+    /// The attention qualification identity this source vouches for: the
+    /// reviewed record carries its campaign's own value, while the compiled
+    /// capture profile — like the compiled public profile — vouches for the
+    /// live qualified attention route itself.
+    fn attention_qualification_sha256(&self, attention: &H3AttentionRuntimeAuthority) -> String {
+        match self {
+            Self::ReviewedRecord(reviewed) => {
+                reviewed.record.attention_qualification_sha256.clone()
+            }
+            #[cfg(feature = "h3-private-uat")]
+            Self::CaptureCompiled => attention.identity_sha256().to_string(),
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn authenticate(
+        self,
+        artifact_qualification: &H3PrivateArtifactQualificationReport,
+        device_id: &str,
+        device_ordinal: usize,
+        compute_capability: (u16, u16),
+        attention_runtime_identity_sha256: &str,
+        attention_kernel_identity: &str,
+        attention_qualification_sha256: &str,
+    ) -> Result<H3PrivateRuntimeQualificationAuthority> {
+        match self {
+            Self::ReviewedRecord(reviewed) => reviewed.authenticate(
+                artifact_qualification,
+                device_id,
+                device_ordinal,
+                compute_capability,
+                attention_runtime_identity_sha256,
+                attention_kernel_identity,
+                attention_qualification_sha256,
+            ),
+            #[cfg(feature = "h3-private-uat")]
+            Self::CaptureCompiled => capture_runtime_qualification(
+                artifact_qualification,
+                device_id,
+                device_ordinal,
+                compute_capability,
+                attention_runtime_identity_sha256,
+                attention_kernel_identity,
+                attention_qualification_sha256,
+            ),
+        }
+    }
+}
+
 fn open_reviewed_h3_private_runtime_qualification(
     path: &Path,
     reviewed_record_sha256: &[&str],
@@ -6610,6 +6738,147 @@ mod tests {
         assert!(crossed_task.validate().is_err());
     }
 
+    /// A Ref2VA admission under the campaign build must not require the
+    /// reviewed-record FILE: Ref2VA has no reviewed record, and its authority
+    /// is the compiled capture-scope profile. With the record path absent the
+    /// admission must proceed past the runtime-qualification gate and fail
+    /// later (here: at artifact qualification against an empty models root).
+    #[cfg(all(feature = "mp4", not(feature = "h3")))]
+    #[test]
+    fn ref2va_admission_proceeds_past_the_missing_reviewed_record() {
+        let models_root = tempfile::tempdir().unwrap();
+        let staging_root = tempfile::tempdir().unwrap();
+        let request = ref2va_reopen_request();
+        let progress = ProgressReporter::default();
+        let error = prepare_reviewed_h3_private_fl2va_admission(
+            H3PrivateFl2VaAdmissionInput {
+                request: &request,
+                paths: H3PrivateFl2VaUatPaths {
+                    models_root: models_root.path(),
+                    staging_root: staging_root.path(),
+                    authorization_record: Path::new("/nonexistent/authorization.json"),
+                    runtime_qualification_record: Path::new(
+                        "/nonexistent/runtime-qualification.json",
+                    ),
+                },
+                references: &[],
+                device_id: DEVICE_0,
+                device_ordinal: 0,
+                compute_capability: (8, 9),
+                available_device_bytes: 1 << 60,
+                available_host_headroom_bytes: 1 << 60,
+            },
+            &progress,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(
+            !error.contains("runtime qualification"),
+            "Ref2VA admission still died at the reviewed-record gate: {error}"
+        );
+    }
+
+    /// Ref2VA under the campaign build resolves the compiled capture-scope
+    /// authority: `CaptureCompiled` storage, the provisional decision string,
+    /// and a record `validate_capture_runtime_profile` accepts — the same
+    /// checks the constructor enforces at minting.
+    #[cfg(all(not(feature = "h3"), feature = "h3-private-uat"))]
+    #[test]
+    fn ref2va_admission_resolves_the_compiled_capture_authority() {
+        let source = private_runtime_qualification_source(
+            Task::Ref2va,
+            Path::new("/nonexistent/runtime-qualification.json"),
+        )
+        .unwrap();
+        assert!(matches!(
+            source,
+            H3PrivateRuntimeQualificationSource::CaptureCompiled
+        ));
+        source.validate_route(DEVICE_0, 0, (8, 9)).unwrap();
+        assert!(source.validate_route(DEVICE_0, 0, (9, 0)).is_err());
+        assert_eq!(
+            source.precheck_bounds(),
+            capture_runtime_bounds(),
+            "the capture arm's admission floors come from the capture ceilings"
+        );
+
+        let mut artifact = artifact_report();
+        artifact.canonical_model = contract::REF2VA_COMFY.into();
+        artifact.task = "ref2va";
+        let attention_device = H3AttentionDevice::Cuda {
+            compute_capability: Some((8, 9)),
+        };
+        let attention_model = H3AttentionModelContract::released_bf16();
+        let kernel = H3AttentionKernel::CandleFlashFwdHdim128Bf16Sm80V011;
+        let runtime_identity = H3AttentionRuntimeAuthority::expected_identity_for(
+            H3AttentionBackend::FlashAttentionV2,
+            kernel,
+            H3AttentionActivation::ReleaseCandidateQualificationOnly,
+            attention_device,
+            attention_model,
+        )
+        .unwrap();
+        let authority = source
+            .authenticate(
+                &artifact,
+                DEVICE_0,
+                0,
+                (8, 9),
+                &runtime_identity,
+                kernel.identity(),
+                &runtime_identity,
+            )
+            .unwrap();
+        assert!(matches!(
+            authority.storage,
+            RuntimeQualificationStorage::CaptureCompiled
+        ));
+        assert_eq!(authority.record.decision, CAPTURE_RUNTIME_PROFILE_DECISION);
+        assert!(authority.record.decision.contains("provisional"));
+        assert_eq!(authority.record.canonical_model, contract::REF2VA_COMFY);
+        assert_eq!(authority.record.task, "ref2va");
+        validate_capture_runtime_profile(&authority.record, &authority.record_file_sha256).unwrap();
+        authority.revalidate().unwrap();
+
+        // A cross-task artifact report cannot mint the capture authority.
+        let error = private_runtime_qualification_source(
+            Task::Ref2va,
+            Path::new("/nonexistent/runtime-qualification.json"),
+        )
+        .unwrap()
+        .authenticate(
+            &artifact_report(),
+            DEVICE_0,
+            0,
+            (8, 9),
+            &runtime_identity,
+            kernel.identity(),
+            &runtime_identity,
+        )
+        .map(|_| ())
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("Ref2VA"), "{error}");
+    }
+
+    /// FL2VA under the same build keeps its reviewed-record FILE gate exactly
+    /// as before: a missing record still refuses the task.
+    #[cfg(not(feature = "h3"))]
+    #[test]
+    fn fl2va_admission_still_requires_the_reviewed_record_file() {
+        let Err(error) = private_runtime_qualification_source(
+            Task::Fl2va,
+            Path::new("/nonexistent/runtime-qualification.json"),
+        ) else {
+            panic!("FL2VA must not resolve a runtime qualification without its record file")
+        };
+        let error = error.to_string();
+        assert!(
+            error.contains("failed to open private H3 runtime qualification"),
+            "{error}"
+        );
+    }
+
     /// The capture-scope profile must never be mistakable for a qualified one.
     #[test]
     #[cfg(feature = "h3-private-uat")]
@@ -6979,7 +7248,7 @@ mod tests {
         let admission = &source[admission_start..admission_end];
         assert!(!admission.contains("Device::new_cuda"));
         let runtime_open = admission
-            .find("open_reviewed_h3_private_runtime_qualification")
+            .find("private_runtime_qualification_source(")
             .unwrap();
         let route_check = admission.find(".validate_route(").unwrap();
         let artifact_qualification = admission
@@ -6996,7 +7265,7 @@ mod tests {
         let prepare = &source[prepare_start..prepare_end];
         assert!(!prepare.contains("Device::new_cuda"));
         let runtime_open = prepare
-            .find("open_reviewed_h3_private_runtime_qualification")
+            .find("private_runtime_qualification_source(")
             .unwrap();
         let route_check = prepare.find(".validate_route(").unwrap();
         let artifact_qualification = prepare

--- a/crates/mold-inference/src/minimax_h3/private_server.rs
+++ b/crates/mold-inference/src/minimax_h3/private_server.rs
@@ -791,6 +791,12 @@ pub struct H3PrivateFl2VaPrepareInput<'a> {
     pub admission_evidence: &'a H3PrivateFl2VaAdmissionEvidence,
     pub paths: H3PrivateFl2VaUatPaths<'a>,
     pub owner_fence: H3PrivateFl2VaOwnerFenceFacts,
+    /// Verified bindings for the ordered Ref2VA references, minted by the
+    /// caller from the staged set immediately before owner preparation —
+    /// the same shape admission consumed, because the reopen re-derives the
+    /// exact frozen factory request through the same decoder. Empty for
+    /// FL2VA.
+    pub references: &'a [GenerationReferenceBinding],
 }
 
 /// Canonical private-UAT filesystem inputs. Preparation resolves every model
@@ -2321,6 +2327,7 @@ fn prepare_reviewed_h3_private_fl2va_attempt(
         admission_evidence,
         paths,
         owner_fence,
+        references,
     } = input;
     owner_fence.validate()?;
     admission_evidence.validate_for(
@@ -2542,6 +2549,7 @@ fn prepare_reviewed_h3_private_fl2va_attempt(
     let frozen_turbo = frozen_factory.quantization().turbo_adapter();
     let prepared_attempt = H3PrivatePreparedFl2VaAttempt::prepare(
         request,
+        references,
         frozen_factory.execution_fingerprint(),
         &storage,
         &qwen_support,

--- a/crates/mold-server/src/h3_private_bridge.rs
+++ b/crates/mold-server/src/h3_private_bridge.rs
@@ -1463,10 +1463,16 @@ pub(crate) fn prepare_for_owner(
     if job.h3_prepared_attempt.is_some() {
         return Err("MiniMax H3 owner received a prepared attempt before final dispatch".into());
     }
-    if mold_core::minimax_h3::task_for_model(&job.request.model)
-        != Some(mold_core::minimax_h3::Task::Fl2va)
-    {
-        return Err("MiniMax H3 accepts only the supported FL2VA partition".into());
+    // Keyed on the same per-task availability predicate ingress advertises:
+    // FL2VA on every reviewed build, Ref2VA only in the developer campaign
+    // build, everything else refused.
+    match mold_core::minimax_h3::task_for_model(&job.request.model) {
+        Some(task) if reviewed_h3_private_runtime_available(task) => {}
+        _ => {
+            return Err(
+                "MiniMax H3 owner preparation accepts only a reviewed task partition".into(),
+            )
+        }
     }
     let plan = job
         .execution_plan
@@ -1577,6 +1583,19 @@ pub(crate) fn prepare_for_owner(
     progress.set_callback(Box::new(move |event| {
         crate::gpu_worker::record_h3_progress(event, progress_tx.as_ref());
     }));
+    // Bind the staged Ref2VA references immediately before preparation — the
+    // reopen re-derives the frozen factory request through the same decoder
+    // admission used, so it needs the same verified bindings. FL2VA jobs
+    // carry no resolved set and bind nothing.
+    let reference_bindings = job
+        .resolved_references
+        .as_ref()
+        .map(|references| references.inference_bindings(&job.request, Some(&cancellation)))
+        .transpose()
+        .map_err(|error| {
+            format!("MiniMax H3 owner preparation could not bind its staged references: {error}")
+        })?
+        .unwrap_or_default();
     progress.set_cancellation_token(cancellation);
     let prepared = mold_inference::prepare_h3_private_fl2va_attempt(
         mold_inference::H3PrivateFl2VaPrepareInput {
@@ -1584,6 +1603,7 @@ pub(crate) fn prepare_for_owner(
             frozen_factory,
             admission_evidence,
             paths: paths.inference_paths(),
+            references: &reference_bindings,
             owner_fence: mold_inference::H3PrivateFl2VaOwnerFenceFacts {
                 work_identity_sha256: work_identity_sha256.clone(),
                 cancellation_scope_identity_sha256: cancellation_scope_identity_sha256.clone(),

--- a/crates/mold-server/src/h3_private_bridge.rs
+++ b/crates/mold-server/src/h3_private_bridge.rs
@@ -1314,6 +1314,12 @@ impl H3PrivateUatPathSet {
     /// owner-only and non-recursive in spirit: an existing directory is left
     /// exactly as the operator set it, and failures stay silent here because
     /// admission's own validation reports the authoritative error.
+    ///
+    /// The only lib caller is `feature = "h3"`-gated on purpose — the
+    /// private-UAT campaign layout stays fail-closed, its hand-built scope
+    /// must already exist — so the campaign build (`h3-private-uat` without
+    /// `h3`) compiles this method dead; tests still exercise it there.
+    #[cfg_attr(not(feature = "h3"), allow(dead_code))]
     pub(crate) fn ensure_staging_root(&self) {
         #[cfg(unix)]
         {

--- a/scripts/tests/minimax-h3-private-uat-release-contract.sh
+++ b/scripts/tests/minimax-h3-private-uat-release-contract.sh
@@ -404,7 +404,7 @@ prepare_source=$(sed -n \
 if grep -Fq 'Device::new_cuda' <<<"$prepare_source"; then
   fail "private H3 preparation constructs a CUDA device before the owner allocation commit"
 fi
-reviewed_line=$(grep -nF 'open_reviewed_h3_private_runtime_qualification' \
+reviewed_line=$(grep -nF 'private_runtime_qualification_source(' \
   <<<"$prepare_source" | head -n 1 | cut -d: -f1)
 artifact_line=$(grep -nF 'qualify_private_artifacts_with_control' \
   <<<"$prepare_source" | head -n 1 | cut -d: -f1)
@@ -418,7 +418,7 @@ admission_source=$(sed -n \
 if grep -Fq 'Device::new_cuda' <<<"$admission_source"; then
   fail "private H3 admission constructs a CUDA device"
 fi
-admission_reviewed_line=$(grep -nF 'open_reviewed_h3_private_runtime_qualification' \
+admission_reviewed_line=$(grep -nF 'private_runtime_qualification_source(' \
   <<<"$admission_source" | head -n 1 | cut -d: -f1)
 admission_artifact_line=$(grep -nF 'qualify_private_artifacts_with_control' \
   <<<"$admission_source" | head -n 1 | cut -d: -f1)


### PR DESCRIPTION
## Summary

First live Ref2VA campaign attempt on the RTX 4090 died at `failed to open private H3 runtime qualification …/runtime-qualification.json`: the `#[cfg(not(feature = "h3"))]` admission and reopen paths unconditionally opened the reviewed-record file for every task, leaving `capture_runtime_qualification` — the compiled capture-scope authority built precisely for the campaign — with zero callers.

Both paths now resolve a per-task `H3PrivateRuntimeQualificationSource` before bulk model I/O:
- **FL2VA** keeps the reviewed-record file gate byte-for-byte (open, validate_route, record-bound floors, authenticate).
- **Ref2VA** (constructible only under `h3-private-uat`; explicit fail-closed arm otherwise) never touches the record file: SM89 route pinned cheaply pre-hash, capacity floors from `capture_runtime_bounds()`, and `authenticate` mints `capture_runtime_qualification` — first caller. The reopen re-mints the same deterministic profile so the frozen-plan identity fence still compares exactly.
- Public `h3` builds untouched; the bridge 503 untouched.

TDD: a black-box red test reproduced the live campaign error verbatim before the fix; new tests pin the `CaptureCompiled` storage + provisional decision string + capture floors + `validate_capture_runtime_profile` acceptance, and that FL2VA still requires the record file. The `reviewed_preparation_source_is_cuda_construction_free` ordering pin re-anchored with its guarantee preserved.

Rides along: boxed the new enum's large variant, and a documented `allow(dead_code)` for the pre-existing `ensure_staging_root` campaign-build clippy red.

## Gates
fmt, `check --workspace --all-targets`, `h3-cuda,mp4` clippy, Metal-proxy clippy, and `mold-ai-server --features h3-private-uat` clippy all clean; inference `h3-private-uat,mp4` suite 2173 ✓ (+known staged_weights flake). The exact CI Metal clippy command was additionally run clean on Apple Silicon (disposable worktree at this SHA).