### PR TITLE
fix(ios): restore gallery source images

### DIFF
--- a/changelog.d/ios-gallery-source-images.md
+++ b/changelog.d/ios-gallery-source-images.md
@@ -1,0 +1,1 @@
+- **iPhone gallery source images are selectable again.** The source picker now falls back to its authenticated HTTP thumbnail route when the iOS shell does not provide the desktop-only native thumbnail command, instead of rendering every gallery print as unreadable.

--- a/desktop/src/lib/gallery/media.test.ts
+++ b/desktop/src/lib/gallery/media.test.ts
@@ -374,6 +374,22 @@ describe("authedMediaUrl host-keyed cache", () => {
     expect(apiFetchTo).not.toHaveBeenCalled();
   });
 
+  it("falls back to authenticated HTTP when the Tauri shell has no native thumbnail command", async () => {
+    vi.mocked(inTauri).mockReturnValue(true);
+    vi.mocked(ipc.fetchGalleryThumbnail).mockRejectedValue(
+      new Error("Command fetch_gallery_thumbnail not found"),
+    );
+    const target = { baseUrl: "http://hal9000:7680", apiKey: "hk" };
+    const path = "/api/gallery/thumbnail/ios-source.png";
+
+    await expect(authedMediaUrl(path, { target, cacheKey: "ios-source-picker" })).resolves.toMatch(
+      /^blob:mock-/,
+    );
+
+    expect(ipc.fetchGalleryThumbnail).toHaveBeenCalledWith(target, "ios-source.png");
+    expect(apiFetchTo).toHaveBeenCalledWith(target, path);
+  });
+
   it("caches the same path separately per cacheKey", async () => {
     const path = "/api/gallery/thumbnail/same.png";
     const target = { baseUrl: "http://hal9000:7680", apiKey: "hk" };

--- a/desktop/src/lib/gallery/media.ts
+++ b/desktop/src/lib/gallery/media.ts
@@ -60,10 +60,17 @@ export function authedMediaUrl(path: string, opts: AuthedMediaOptions = {}): Pro
       } catch {
         return null;
       }
-      const media = await ipc.fetchGalleryThumbnail(target, filename);
-      if (!media) return null;
-      const bytes = Uint8Array.from(atob(media.base64), (character) => character.charCodeAt(0));
-      return new Blob([bytes], { type: media.contentType });
+      try {
+        const media = await ipc.fetchGalleryThumbnail(target, filename);
+        if (!media) return null;
+        const bytes = Uint8Array.from(atob(media.base64), (character) => character.charCodeAt(0));
+        return new Blob([bytes], { type: media.contentType });
+      } catch {
+        // Native commands differ between the desktop and iPhone shells. A
+        // missing/refused desktop-only bridge must preserve the authenticated
+        // web fallback instead of making every mobile thumbnail unreadable.
+        return null;
+      }
     };
     url = nativeThumbnail()
       .then(


### PR DESCRIPTION
## Summary
- fall back to authenticated HTTP when the iPhone shell lacks the desktop-only native thumbnail command
- keep desktop native-first thumbnail loading unchanged
- add regression coverage for the exact missing-command failure

## Verification
- `nix develop -c bash -lc 'cd desktop && bun run test'` — 4,260 passed\n- `nix develop -c bash -lc 'cd desktop && bun run fmt:check && bun run build:mobile'`\n- `nix develop -c ./scripts/tests/ios-release-assets.sh`\n- iPhone 17 simulator UAT against `plato`: gallery thumbnails rendered, tapping a print closed the picker, selected image appeared in the source well\n- independent peer review: no actionable findings\n\n## Physical device\nAttempted installation on James’s iPhone, but Xcode rejected the saved Apple account login and no iOS Development certificate for team `28X9H69QGE` was available. The build did not reach device installation.