### PR TITLE
fix(studio): hide opaque H3 generation models

### DIFF
--- a/changelog.d/fix-h3-opaque-picker.md
+++ b/changelog.d/fix-h3-opaque-picker.md
@@ -1,0 +1,1 @@
+- Hide generic MiniMax H3 catalog repositories from Create so iPhone, desktop, and web offer only explicit runnable FL2VA or Ref2VA task partitions instead of presenting an impossible partition error.

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -4714,6 +4714,23 @@ describe("MobileApp wan source conditioning", () => {
     await flushPromises();
   }
 
+  it("keeps opaque H3 catalog rows out of the generation picker", async () => {
+    serveWan({
+      ...wanModel,
+      name: "hf:MiniMaxAI/MiniMax-H3",
+      family: "minimax-h3",
+      hf_repo: "MiniMaxAI/MiniMax-H3",
+      source_image: "required",
+    });
+    wrapper = mountMobileApp();
+    await flushPromises();
+
+    expect(wrapper.get("[data-test='mobile-model-empty']").text()).toContain(
+      "No downloaded generation model is available",
+    );
+    expect(wrapper.find("[data-test='mobile-h3-authoring-error']").exists()).toBe(false);
+  });
+
   it("shows the H3 first-frame blocker before prompt entry and clears it after picking", async () => {
     const h3Model: ModelEntry = {
       ...wanModel,

--- a/studio/lib/minimaxH3Authoring.ts
+++ b/studio/lib/minimaxH3Authoring.ts
@@ -8,6 +8,26 @@ import {
 } from "./modelAccess";
 import { imageDimensionsFromBase64 } from "./imageDimensions";
 import { readFileBase64 } from "./fileBase64";
+import {
+  canonicalMinimaxH3ModelName,
+  isMinimaxH3Identity,
+  minimaxH3TaskForModel,
+  type MinimaxH3Task,
+} from "./minimaxH3Identity";
+
+export {
+  canonicalMinimaxH3ModelName,
+  isMinimaxH3Family,
+  isMinimaxH3Identity,
+  minimaxH3TaskForModel,
+  MINIMAX_H3_FL2VA_COMFY,
+  MINIMAX_H3_FL2VA_COMFY_TURBO_4STEP_768P,
+  MINIMAX_H3_FL2VA_COMFY_TURBO_8STEP,
+  MINIMAX_H3_FL2VA_OFFICIAL,
+  MINIMAX_H3_REF2VA_COMFY,
+  MINIMAX_H3_REF2VA_OFFICIAL,
+  type MinimaxH3Task,
+} from "./minimaxH3Identity";
 
 export const MINIMAX_H3_FIXED_FPS = 24;
 export const MINIMAX_H3_MIN_FRAMES = 124;
@@ -33,17 +53,6 @@ export const MINIMAX_H3_RESYNTHESIS_GUIDANCE =
   "References guide identity, relationships, motion, timing, and sound in a newly synthesized shot. This is not pixel-aligned video editing, so there is no denoise-strength control.";
 export const MINIMAX_H3_PROMPT_PLACEHOLDER =
   "Describe the new synchronized shot…";
-
-export type MinimaxH3Task = "fl2va" | "ref2va";
-
-export const MINIMAX_H3_FL2VA_OFFICIAL = "minimax-h3-fl2va:official-bf16";
-export const MINIMAX_H3_REF2VA_OFFICIAL = "minimax-h3-ref2va:official-bf16";
-export const MINIMAX_H3_FL2VA_COMFY = "minimax-h3-fl2va:comfy-pruned-int8";
-export const MINIMAX_H3_REF2VA_COMFY = "minimax-h3-ref2va:comfy-pruned-int8";
-export const MINIMAX_H3_FL2VA_COMFY_TURBO_8STEP =
-  "minimax-h3-fl2va:comfy-pruned-int8-turbo-8step";
-export const MINIMAX_H3_FL2VA_COMFY_TURBO_4STEP_768P =
-  "minimax-h3-fl2va:comfy-pruned-int8-turbo-4step-768p";
 
 /** Browser-owned first/last-frame authority. The raw bytes live in IndexedDB
  * when a draft/template is persisted; only the small descriptor is allowed in
@@ -92,79 +101,6 @@ export interface MinimaxH3ModelIdentity {
    * runnable-model boundary. */
   runtime_available?: boolean | null;
   generation_profile?: { profile_hash?: string | null } | null;
-}
-
-function normalize(value: string): string {
-  return value.trim().toLowerCase().replaceAll("_", "-");
-}
-
-/** Browser-side mirror of the server's released H3 alias resolver. Opaque
- * catalog IDs and unknown future variants stay unresolved instead of being
- * guessed into a task/layout partition. */
-export function canonicalMinimaxH3ModelName(
-  model: string | null | undefined,
-): string | null {
-  const value = normalize(model ?? "");
-  if (
-    value === "minimax-h3" ||
-    value === "minimaxh3" ||
-    value === "minimax-h3-fl2va"
-  ) {
-    return MINIMAX_H3_FL2VA_COMFY;
-  }
-  if (value === "minimax-h3-ref2va") {
-    return MINIMAX_H3_REF2VA_COMFY;
-  }
-  if (
-    value === MINIMAX_H3_FL2VA_OFFICIAL ||
-    value === MINIMAX_H3_REF2VA_OFFICIAL ||
-    value === MINIMAX_H3_FL2VA_COMFY ||
-    value === MINIMAX_H3_REF2VA_COMFY ||
-    value === MINIMAX_H3_FL2VA_COMFY_TURBO_8STEP ||
-    value === MINIMAX_H3_FL2VA_COMFY_TURBO_4STEP_768P
-  ) {
-    return value;
-  }
-  return null;
-}
-
-export function isMinimaxH3Family(family: string | null | undefined): boolean {
-  const value = normalize(family ?? "").replaceAll("-", "");
-  return value === "minimaxh3";
-}
-
-/** Resolve only the released, explicit task partitions. An opaque catalog ID
- * must carry a future advertised task instead of being guessed from family. */
-export function minimaxH3TaskForModel(
-  model: string | null | undefined,
-): MinimaxH3Task | null {
-  const value = canonicalMinimaxH3ModelName(model);
-  if (value?.startsWith("minimax-h3-ref2va:")) {
-    return "ref2va";
-  }
-  if (value?.startsWith("minimax-h3-fl2va:")) {
-    return "fl2va";
-  }
-  return null;
-}
-
-/** Family metadata can be absent in durable gallery/request snapshots. An
- * H3-shaped model name still identifies the family boundary, while task and
- * layout resolution remain restricted to the exact released identities. */
-export function isMinimaxH3Identity(
-  family: string | null | undefined,
-  model: string | null | undefined,
-): boolean {
-  if (isMinimaxH3Family(family)) return true;
-  const value = normalize(model ?? "");
-  return (
-    value === "minimax-h3" ||
-    value === "minimaxh3" ||
-    value === "minimax-h3-fl2va" ||
-    value === "minimax-h3-ref2va" ||
-    value.startsWith("minimax-h3-fl2va:") ||
-    value.startsWith("minimax-h3-ref2va:")
-  );
 }
 
 export function emptyMinimaxH3AuthoringState(): MinimaxH3AuthoringState {

--- a/studio/lib/minimaxH3Identity.ts
+++ b/studio/lib/minimaxH3Identity.ts
@@ -1,0 +1,74 @@
+export type MinimaxH3Task = "fl2va" | "ref2va";
+
+export const MINIMAX_H3_FL2VA_OFFICIAL = "minimax-h3-fl2va:official-bf16";
+export const MINIMAX_H3_REF2VA_OFFICIAL = "minimax-h3-ref2va:official-bf16";
+export const MINIMAX_H3_FL2VA_COMFY = "minimax-h3-fl2va:comfy-pruned-int8";
+export const MINIMAX_H3_REF2VA_COMFY = "minimax-h3-ref2va:comfy-pruned-int8";
+export const MINIMAX_H3_FL2VA_COMFY_TURBO_8STEP =
+  "minimax-h3-fl2va:comfy-pruned-int8-turbo-8step";
+export const MINIMAX_H3_FL2VA_COMFY_TURBO_4STEP_768P =
+  "minimax-h3-fl2va:comfy-pruned-int8-turbo-4step-768p";
+
+function normalize(value: string): string {
+  return value.trim().toLowerCase().replaceAll("_", "-");
+}
+
+/** Resolve only the released H3 aliases and exact task/layout partitions. */
+export function canonicalMinimaxH3ModelName(
+  model: string | null | undefined,
+): string | null {
+  const value = normalize(model ?? "");
+  if (
+    value === "minimax-h3" ||
+    value === "minimaxh3" ||
+    value === "minimax-h3-fl2va"
+  ) {
+    return MINIMAX_H3_FL2VA_COMFY;
+  }
+  if (value === "minimax-h3-ref2va") {
+    return MINIMAX_H3_REF2VA_COMFY;
+  }
+  if (
+    value === MINIMAX_H3_FL2VA_OFFICIAL ||
+    value === MINIMAX_H3_REF2VA_OFFICIAL ||
+    value === MINIMAX_H3_FL2VA_COMFY ||
+    value === MINIMAX_H3_REF2VA_COMFY ||
+    value === MINIMAX_H3_FL2VA_COMFY_TURBO_8STEP ||
+    value === MINIMAX_H3_FL2VA_COMFY_TURBO_4STEP_768P
+  ) {
+    return value;
+  }
+  return null;
+}
+
+export function isMinimaxH3Family(family: string | null | undefined): boolean {
+  const value = normalize(family ?? "").replaceAll("-", "");
+  return value === "minimaxh3";
+}
+
+/** An opaque catalog ID stays unresolved instead of being guessed into a task. */
+export function minimaxH3TaskForModel(
+  model: string | null | undefined,
+): MinimaxH3Task | null {
+  const value = canonicalMinimaxH3ModelName(model);
+  if (value?.startsWith("minimax-h3-ref2va:")) return "ref2va";
+  if (value?.startsWith("minimax-h3-fl2va:")) return "fl2va";
+  return null;
+}
+
+/** Family metadata may identify H3 even when an opaque model ID has no task. */
+export function isMinimaxH3Identity(
+  family: string | null | undefined,
+  model: string | null | undefined,
+): boolean {
+  if (isMinimaxH3Family(family)) return true;
+  const value = normalize(model ?? "");
+  return (
+    value === "minimax-h3" ||
+    value === "minimaxh3" ||
+    value === "minimax-h3-fl2va" ||
+    value === "minimax-h3-ref2va" ||
+    value.startsWith("minimax-h3-fl2va:") ||
+    value.startsWith("minimax-h3-ref2va:")
+  );
+}

--- a/studio/lib/modelAccess.test.ts
+++ b/studio/lib/modelAccess.test.ts
@@ -56,13 +56,29 @@ describe("model access policy", () => {
     expect(isModelAccessRestricted(capabilities, identity)).toBe(false);
   });
 
-  it("keeps older-server rows and removes restricted current-server rows", () => {
+  it("fails opaque H3 rows closed even when a server advertises no family restriction", () => {
     const models = [
       { name: "flux-dev:q8", family: "flux" },
       { name: "hf:opaque", family: "minimax-h3" },
     ];
-    expect(filterRestrictedModels(models, undefined)).toEqual(models);
+    expect(filterRestrictedModels(models, undefined)).toEqual([models[0]]);
     expect(filterRestrictedModels(models, capabilities)).toEqual([models[0]]);
+  });
+
+  it("keeps the reviewed H3 task partitions explicit", () => {
+    const models = [
+      { name: "minimax-h3-fl2va:comfy-pruned-int8", family: "minimax-h3" },
+      { name: "minimax-h3-ref2va:comfy-pruned-int8", family: "minimax-h3" },
+      {
+        name: "minimax-h3-fl2va:comfy-pruned-int8-turbo-8step",
+        family: "minimax-h3",
+      },
+      {
+        name: "minimax-h3-fl2va:comfy-pruned-int8-turbo-4step-768p",
+        family: "minimax-h3",
+      },
+    ];
+    expect(filterRestrictedModels(models, undefined)).toEqual(models);
   });
 
   it("hides models whose runtime contract is explicitly unavailable", () => {

--- a/studio/lib/modelAccess.ts
+++ b/studio/lib/modelAccess.ts
@@ -2,6 +2,10 @@ import {
   reviewedMiniMaxH3ModelAccess,
   type MiniMaxH3Capability,
 } from "./minimaxH3Inventory";
+import {
+  isMinimaxH3Identity,
+  minimaxH3TaskForModel,
+} from "./minimaxH3Identity";
 
 /**
  * Additive `/api/capabilities.model_access` contract shared by every Studio
@@ -98,7 +102,10 @@ export function isModelAccessRestricted(
   return modelAccessRestrictionFor(capabilities, identity) !== null;
 }
 
-/** Filter model rows using both their request identity and resolved family. */
+/** Filter model rows using both their request identity and resolved family.
+ * H3 additionally fails opaque catalog identities closed: family metadata can
+ * identify the editor, but only a released partition identifies a task the
+ * server can validate and execute. */
 export function filterRestrictedModels<
   T extends {
     name: string;
@@ -113,6 +120,8 @@ export function filterRestrictedModels<
   return models.filter(
     (model) =>
       model.runtime_available !== false &&
+      (!isMinimaxH3Identity(model.family, model.name) ||
+        minimaxH3TaskForModel(model.name) !== null) &&
       !isModelAccessRestricted(capabilities, {
         model: model.name,
         family: model.family,


### PR DESCRIPTION
## Summary

- fail opaque MiniMax H3 catalog identities closed before they reach Create or routing
- keep every reviewed FL2VA/Ref2VA partition, including the new Turbo tiers, available
- centralize H3 identity resolution so authoring and model access cannot drift
- add iPhone regression coverage for the impossible partition warning

## Verification

- `nix develop -c bun run test:studio` (935 tests)
- `nix develop -c bun run --cwd desktop test -- src/mobile/MobileApp.test.ts` (230 tests)
- `nix develop -c bun run --cwd desktop build:mobile`
- `nix develop -c bun run build:web`
- `nix develop -c bun run check:architecture`
- Prettier and `git diff --check`