### PR TITLE
fix(desktop): scroll to update settings

### DIFF
--- a/changelog.d/desktop-update-settings-scroll.md
+++ b/changelog.d/desktop-update-settings-scroll.md
@@ -1,0 +1,3 @@
+- **Check for Updates opens at the update controls.** Choosing Check for Updates
+  from the desktop app menu now opens Settings with the Updates section aligned
+  at the top of the view instead of leaving it above the visible area.

--- a/desktop/src/views/SettingsView.test.ts
+++ b/desktop/src/views/SettingsView.test.ts
@@ -27,6 +27,12 @@ vi.mock("@studio/components/PairingAccessPanel.vue", () => stub("stub-paired-acc
 
 import SettingsView from "./SettingsView.vue";
 
+const scrollIntoView = vi.fn();
+Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+  configurable: true,
+  value: scrollIntoView,
+});
+
 async function mountView() {
   const pinia = createPinia();
   setActivePinia(pinia);
@@ -128,6 +134,20 @@ describe("SettingsView shell", () => {
     await flushPromises();
     expect(wrapper.find("[data-test='stub-library']").exists()).toBe(true);
     expect(wrapper.find("[data-test='stub-performance']").exists()).toBe(false);
+  });
+
+  it("scrolls the Updates card into view for the native update-check deep link", async () => {
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [{ path: "/settings", component: { template: "<div />" } }],
+    });
+    await router.push({ path: "/settings", query: { section: "updates" } });
+    const pinia = createPinia();
+    setActivePinia(pinia);
+    mount(SettingsView, { global: { plugins: [pinia, router] } });
+    await flushPromises();
+
+    expect(scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "start" });
   });
 
   it("search opens the owning accordion and hides the rest", async () => {

--- a/desktop/src/views/SettingsView.vue
+++ b/desktop/src/views/SettingsView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, watch } from "vue";
+import { computed, nextTick, ref, watch } from "vue";
 import { useRoute } from "vue-router";
 import AccordionSection from "@ui/components/AccordionSection.vue";
 import CardSurface from "@ui/components/CardSurface.vue";
@@ -38,16 +38,22 @@ const pairingBaseUrl = computed(() => conn.baseUrl ?? "http://127.0.0.1:7680");
 const query = ref("");
 /** Which "All settings" accordion is open (one at a time) when not searching. */
 const openSection = ref<SectionId | null>(null);
+const updatesCard = ref<HTMLElement | null>(null);
 
-// Deep link: /settings?section=<id> opens that accordion (the Library trash
-// banner's "Change retention" lands on Settings ▸ Library this way). The view
-// also mounts router-less in tests, so the route is optional.
+// Deep links open accordions or reveal an always-open top card. The native
+// Check for Updates menu action uses `section=updates`; the Library trash
+// banner uses `section=library`. The view also mounts router-less in tests, so
+// the route is optional.
 const route = useRoute();
 watch(
   () => route?.query.section,
-  (section) => {
+  async (section) => {
     if (typeof section !== "string") return;
     if (ACCORDION_SECTIONS.some((s) => s.id === section)) openSection.value = section as SectionId;
+    if (section === "updates") {
+      await nextTick();
+      updatesCard.value?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
   },
   { immediate: true },
 );
@@ -144,7 +150,7 @@ function toggle(id: SectionId): void {
             />
           </section>
 
-          <section data-test="updates-card">
+          <section ref="updatesCard" data-test="updates-card">
             <div class="edge-code mb-2.5 uppercase">Updates</div>
             <UpdatesSection />
           </section>


### PR DESCRIPTION
## Summary
- make the native Check for Updates menu deep link smooth-scroll the Settings view to Updates
- preserve existing accordion deep links
- add regression coverage for the Updates deep link

## Testing
- `nix develop -c bun run test:desktop` (4261 passed)
- `nix develop -c bun run build:desktop`
- `nix develop -c prettier --check desktop/src/views/SettingsView.vue desktop/src/views/SettingsView.test.ts`
- rendered QA at `/settings?section=updates`: Updates card visible at the top of the settings scroller; no console warnings or errors