### PR TITLE
fix(ios): expand Library pinch gesture surface

### DIFF
--- a/changelog.d/ios-gallery-pinch-surface.md
+++ b/changelog.d/ios-gallery-pinch-surface.md
@@ -1,0 +1,1 @@
+- **Reliable iPhone Library pinch resizing.** Pinching anywhere in the Library print area now resizes thumbnails, including unused space below a short final row.

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -7737,6 +7737,20 @@ describe("mobile Library pinch-to-resize", () => {
     expect(localStorage.getItem("mold.mobile.galleryColumns.v1")).toBe("4");
   });
 
+  it("resizes from the unused print area instead of requiring both fingers over tiles", async () => {
+    const app = await openLibrary();
+    const surface = app.get("[data-test='mobile-gallery-pinch-surface']").element;
+
+    touchDown(surface, 73, 20, 700);
+    touchDown(surface, 74, 220, 700);
+    touchMove(74, 360, 700);
+    touchUp(74);
+    touchUp(73);
+    await app.vm.$nextTick();
+
+    expect(columnsOf(app)).toBe("2");
+  });
+
   it("restores the persisted size on the next visit", async () => {
     localStorage.setItem("mold.mobile.galleryColumns.v1", "5");
 

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -716,7 +716,7 @@ const galleryDeleteConfirming = ref(false);
 const galleryColumns = ref(loadMobileGalleryColumns());
 const galleryZoom = createPinchZoom(galleryColumns.value);
 const galleryZoomAnnouncement = ref("");
-const galleryGrid = ref<HTMLElement | null>(null);
+const galleryPinchSurface = ref<HTMLElement | null>(null);
 const galleryDeleting = ref(false);
 const selectedPrint = ref<GalleryPrint | null>(null);
 // ── Library organization (V3 "Shelf") ───────────────────────────────────────
@@ -6821,7 +6821,8 @@ function finishGallerySelectionDrag(event?: PointerEvent): void {
 /**
  * Pinch over the Library grid to resize thumbnails, the iPhone counterpart to
  * the web/desktop thumbnail-size slider. It deliberately shares no state with
- * the gallery viewer's own gestures and owns only the grid element.
+ * the gallery viewer's own gestures and owns the whole print area, including
+ * the unused space below a short final row.
  */
 function beginGalleryPinch(event: PointerEvent): void {
   if (event.pointerType === "mouse") return;
@@ -6841,7 +6842,7 @@ function beginGalleryPinch(event: PointerEvent): void {
     if (galleryDragSelectionBaseline) gallerySelection.value = galleryDragSelectionBaseline;
     finishGallerySelectionDrag();
   }
-  galleryGrid.value?.style.setProperty("touch-action", "none");
+  galleryPinchSurface.value?.style.setProperty("touch-action", "none");
   event.preventDefault();
 }
 
@@ -6870,7 +6871,8 @@ function endGalleryPinch(event: PointerEvent): void {
   // second touch lands, so the next fresh touch sequence discards it.
   if (event.type === "pointerup" && isPinching(galleryZoom)) galleryPinchPendingClicks = 1;
   pinchPointerUp(galleryZoom, event.pointerId);
-  if (galleryZoom.points.size === 0) galleryGrid.value?.style.removeProperty("touch-action");
+  if (galleryZoom.points.size === 0)
+    galleryPinchSurface.value?.style.removeProperty("touch-action");
 }
 
 function selectAllGalleryPrints(): void {
@@ -7191,7 +7193,7 @@ function handleForegroundResume(): void {
   // from a plain scroll. Nothing can still be held after a resume, so drop them.
   galleryPinchPendingClicks = 0;
   resetPinch(galleryZoom, galleryColumns.value);
-  galleryGrid.value?.style.removeProperty("touch-action");
+  galleryPinchSurface.value?.style.removeProperty("touch-action");
   if ("__TAURI_INTERNALS__" in window) {
     void invoke("restore_mobile_viewport").catch(() => undefined);
   }
@@ -7463,7 +7465,11 @@ onBeforeUnmount(() => {
       {{ galleryZoomAnnouncement }}
     </p>
 
-    <section ref="mobileContent" class="mobile-content">
+    <section
+      ref="mobileContent"
+      class="mobile-content"
+      :class="{ 'is-library': !settingsOpen && tab === 'gallery' }"
+    >
       <MobileSettingsView
         v-if="settingsOpen"
         :settings="mobileSettings"
@@ -8526,104 +8532,109 @@ onBeforeUnmount(() => {
             {{ trashError }}
           </p>
           <div
-            v-if="galleryLoading || (libraryScope === 'trash' && trashLoading && !gallery.length)"
-            class="empty-state"
-          >
-            {{ libraryScope === "trash" ? "Loading trash…" : "Loading prints…" }}
-          </div>
-          <div
-            v-else-if="gallery.length"
-            class="gallery-grid"
-            :class="{ 'is-selecting': gallerySelectMode }"
-            ref="galleryGrid"
-            :style="{ '--mobile-gallery-columns': galleryColumns }"
-            :aria-label="`Prints, ${galleryColumns} across. Pinch to resize.`"
-            :data-gallery-columns="galleryColumns"
-            role="group"
-            data-test="mobile-gallery-grid"
+            ref="galleryPinchSurface"
+            class="mobile-gallery-pinch-surface"
+            data-test="mobile-gallery-pinch-surface"
             @pointerdown="beginGalleryPinch"
           >
-            <button
-              v-for="print in gallery"
-              :key="`${print.hostId}:${print.filename}`"
-              class="gallery-item"
-              :class="{ 'gallery-item-selected': gallerySelection.has(galleryPrintKey(print)) }"
-              type="button"
-              :aria-label="
-                gallerySelectMode
-                  ? tileLabel(
-                      print,
-                      gallerySelection.has(galleryPrintKey(print)) ? 'Deselect' : 'Select',
-                    )
-                  : tileLabel(print, 'Open')
-              "
-              :aria-pressed="
-                gallerySelectMode ? gallerySelection.has(galleryPrintKey(print)) : undefined
-              "
-              :data-gallery-print-key="galleryPrintKey(print)"
-              data-test="gallery-item"
-              @pointerdown="beginGallerySelectionDrag($event, print)"
-              @click="handleGalleryTileClick($event, print)"
+            <div
+              v-if="galleryLoading || (libraryScope === 'trash' && trashLoading && !gallery.length)"
+              class="empty-state"
             >
-              <img
-                :src="print.thumbnailUrl"
-                :alt="print.metadata.prompt || print.filename"
-                loading="lazy"
-              />
-              <span
-                v-if="isVideoItem(print) || isAudioItem(print)"
-                class="gallery-video-badge"
-                aria-hidden="true"
-                >{{ isAudioItem(print) ? "♪" : "▶" }}</span
+              {{ libraryScope === "trash" ? "Loading trash…" : "Loading prints…" }}
+            </div>
+            <div
+              v-else-if="gallery.length"
+              class="gallery-grid"
+              :class="{ 'is-selecting': gallerySelectMode }"
+              :style="{ '--mobile-gallery-columns': galleryColumns }"
+              :aria-label="`Prints, ${galleryColumns} across. Pinch to resize.`"
+              :data-gallery-columns="galleryColumns"
+              role="group"
+              data-test="mobile-gallery-grid"
+            >
+              <button
+                v-for="print in gallery"
+                :key="`${print.hostId}:${print.filename}`"
+                class="gallery-item"
+                :class="{ 'gallery-item-selected': gallerySelection.has(galleryPrintKey(print)) }"
+                type="button"
+                :aria-label="
+                  gallerySelectMode
+                    ? tileLabel(
+                        print,
+                        gallerySelection.has(galleryPrintKey(print)) ? 'Deselect' : 'Select',
+                      )
+                    : tileLabel(print, 'Open')
+                "
+                :aria-pressed="
+                  gallerySelectMode ? gallerySelection.has(galleryPrintKey(print)) : undefined
+                "
+                :data-gallery-print-key="galleryPrintKey(print)"
+                data-test="gallery-item"
+                @pointerdown="beginGallerySelectionDrag($event, print)"
+                @click="handleGalleryTileClick($event, print)"
               >
-              <span
-                v-if="!gallerySelectMode && libraryScope !== 'trash' && isFreshMobilePrint(print)"
-                class="gallery-new-badge"
-                data-test="new-badge"
-              >
-                New
-              </span>
-              <span
-                v-if="isUpscaledImage(print)"
-                class="gallery-upscaled-badge"
-                data-test="upscaled-badge"
-              >
-                Upscaled
-              </span>
-              <span
-                v-if="!gallerySelectMode && organizationOf(print)?.favorite"
-                class="gallery-favorite-badge"
-                data-test="favorite-badge"
-                aria-label="Favorite"
-                >♥</span
-              >
-              <span
-                v-if="libraryScope === 'trash' && purgeChipFor(print)"
-                class="gallery-purge-chip"
-                data-test="purge-chip"
-                >{{ purgeChipFor(print) }}</span
-              >
-              <span
-                v-if="gallerySelectMode"
-                class="gallery-selection-indicator"
-                data-test="mobile-gallery-selection-indicator"
-                aria-hidden="true"
-              >
-                {{ gallerySelection.has(galleryPrintKey(print)) ? "✓" : "" }}
-              </span>
-            </button>
-          </div>
-          <div v-else class="empty-state" data-test="mobile-library-empty">
-            {{ libraryEmptyCopy }}
-          </div>
-          <div
-            v-if="!galleryLoading && galleryRemaining"
-            ref="gallerySentinel"
-            class="gallery-scroll-sentinel"
-            data-test="mobile-gallery-sentinel"
-            aria-live="polite"
-          >
-            {{ galleryLoadingMore ? "Loading older prints…" : "" }}
+                <img
+                  :src="print.thumbnailUrl"
+                  :alt="print.metadata.prompt || print.filename"
+                  loading="lazy"
+                />
+                <span
+                  v-if="isVideoItem(print) || isAudioItem(print)"
+                  class="gallery-video-badge"
+                  aria-hidden="true"
+                  >{{ isAudioItem(print) ? "♪" : "▶" }}</span
+                >
+                <span
+                  v-if="!gallerySelectMode && libraryScope !== 'trash' && isFreshMobilePrint(print)"
+                  class="gallery-new-badge"
+                  data-test="new-badge"
+                >
+                  New
+                </span>
+                <span
+                  v-if="isUpscaledImage(print)"
+                  class="gallery-upscaled-badge"
+                  data-test="upscaled-badge"
+                >
+                  Upscaled
+                </span>
+                <span
+                  v-if="!gallerySelectMode && organizationOf(print)?.favorite"
+                  class="gallery-favorite-badge"
+                  data-test="favorite-badge"
+                  aria-label="Favorite"
+                  >♥</span
+                >
+                <span
+                  v-if="libraryScope === 'trash' && purgeChipFor(print)"
+                  class="gallery-purge-chip"
+                  data-test="purge-chip"
+                  >{{ purgeChipFor(print) }}</span
+                >
+                <span
+                  v-if="gallerySelectMode"
+                  class="gallery-selection-indicator"
+                  data-test="mobile-gallery-selection-indicator"
+                  aria-hidden="true"
+                >
+                  {{ gallerySelection.has(galleryPrintKey(print)) ? "✓" : "" }}
+                </span>
+              </button>
+            </div>
+            <div v-else class="empty-state" data-test="mobile-library-empty">
+              {{ libraryEmptyCopy }}
+            </div>
+            <div
+              v-if="!galleryLoading && galleryRemaining"
+              ref="gallerySentinel"
+              class="gallery-scroll-sentinel"
+              data-test="mobile-gallery-sentinel"
+              aria-live="polite"
+            >
+              {{ galleryLoadingMore ? "Loading older prints…" : "" }}
+            </div>
           </div>
         </template>
         <div

--- a/desktop/src/mobile/mobile.css
+++ b/desktop/src/mobile/mobile.css
@@ -307,6 +307,11 @@ html.mobile-surface:has(.mobile-shell.is-pair-scanning) #app,
   padding: 16px max(16px, env(safe-area-inset-right)) 16px max(16px, env(safe-area-inset-left));
 }
 
+.mobile-content.is-library {
+  display: flex;
+  flex-direction: column;
+}
+
 /*
  * Output (One shot | Sequence) — a field in the Create form stack, not a
  * mode pair pinned above it. Same mobile-scoped @ui SegmentedControl override
@@ -2517,13 +2522,18 @@ button:disabled {
   margin-top: 16px;
 }
 
+.mobile-gallery-pinch-surface {
+  /* A short final row still leaves a generous gesture target. Keep one-finger
+     scrolling while the two-finger pinch stays ours. */
+  flex: 1 0 auto;
+  min-height: 42vh;
+  touch-action: pan-y;
+}
+
 .gallery-grid {
   display: grid;
   grid-template-columns: repeat(var(--mobile-gallery-columns, 3), minmax(0, 1fr));
   gap: 6px;
-  /* Keep one-finger scrolling while the two-finger pinch stays ours. The shell
-     already blocks page zoom, so nothing above this element wants the pinch. */
-  touch-action: pan-y;
 }
 
 .gallery-grid.is-selecting .gallery-item {

--- a/desktop/src/mobile/mobile.css.test.ts
+++ b/desktop/src/mobile/mobile.css.test.ts
@@ -38,9 +38,11 @@ describe("mobile Library thumbnail sizing", () => {
   });
 
   it("reserves the two-finger pinch while one-finger scrolling still works", () => {
-    const base = css.match(/\.gallery-grid\s*\{([^}]*)\}/s);
+    const base = css.match(/\.mobile-gallery-pinch-surface\s*\{([^}]*)\}/s);
 
     expect(base?.[1]).toMatch(/touch-action:\s*pan-y\s*;/);
+    expect(base?.[1]).toMatch(/flex:\s*1 0 auto\s*;/);
+    expect(base?.[1]).toMatch(/min-height:\s*42vh\s*;/);
   });
 });
 


### PR DESCRIPTION
## Problem

The iPhone Library pinch handler was attached to the populated grid box. Touches on tiles and grid gaps worked, but blank space below a short final row was outside the gesture target, making resizing feel finicky.

## Fix

- move pinch ownership from the grid to an enclosing print-area surface
- let that surface fill the remaining Library viewport while preserving one-finger vertical scrolling
- keep tile taps, multi-select drag, click suppression, and the infinite-scroll sentinel inside the same gesture boundary
- add regression coverage for a two-finger resize that begins in unused space below the tiles

## Verification

- independent agent peer review: no actionable findings
- `nix develop -c sh -lc "cd desktop && bun run test"` — 357 files / 4,261 tests passed
- `nix develop -c sh -lc "cd desktop && bun run build:mobile"`
- focused pinch/CSS suite — 287 tests passed
- Prettier and `git diff --check`
- iPhone 17 Pro simulator / iOS 26.5: fresh native build and launch succeeded; Library rendered 495 cached prints and tile open/close remained functional
- 368×800 rendered geometry: pinch surface spans 569 px from below Library controls to the bottom tab bar with `touch-action: pan-y`

## UAT note

Simulator automation cannot synthesize a true two-finger touch. The blank-area pinch transition itself is covered by the pointer regression test; native UAT verifies the shipped WKWebView layout, surface extent, scrolling contract, and surrounding Library interactions.