### PR TITLE
fix(mobile): improve form field spacing

### DIFF
--- a/changelog.d/ios-form-spacing.md
+++ b/changelog.d/ios-form-spacing.md
@@ -1,0 +1,1 @@
+- **Improved iPhone form spacing.** Labels beneath segmented controls and sliders now keep consistent vertical separation for easier scanning.

--- a/desktop/src/mobile/MobileSharedParams.vue
+++ b/desktop/src/mobile/MobileSharedParams.vue
@@ -105,6 +105,7 @@ const sourceDimensions = computed(() => {
   />
   <VideoDurationSlider
     v-if="supportsVideo && !showFps"
+    class="mobile-duration-field"
     :frames="form.frames"
     :fps="form.fps"
     :model="durationModel ?? model"

--- a/desktop/src/mobile/mobile.css
+++ b/desktop/src/mobile/mobile.css
@@ -321,7 +321,7 @@ html.mobile-surface:has(.mobile-shell.is-pair-scanning) #app,
 .mobile-output-mode {
   display: grid;
   gap: 7px;
-  margin-top: 14px;
+  margin: 14px 0;
 }
 
 .mobile-output-mode .ms-seg {
@@ -1491,12 +1491,16 @@ textarea.control {
 .mobile-range-field {
   display: grid;
   gap: 2px;
-  margin-top: 14px;
+  margin: 14px 0;
   color: var(--ink-3);
   font-family: var(--font-utility);
   font-size: var(--text-edge-code);
   letter-spacing: 0.04em;
   text-transform: uppercase;
+}
+
+.mobile-duration-field {
+  margin-bottom: 14px;
 }
 
 .mobile-range-field > span {

--- a/desktop/src/mobile/mobile.css.test.ts
+++ b/desktop/src/mobile/mobile.css.test.ts
@@ -6,6 +6,7 @@ const mobileHtml = readFileSync("index.mobile.html", "utf8");
 const preparedComponent = readFileSync("src/mobile/MobilePreparedExpansionBatch.vue", "utf8");
 const pullComponent = readFileSync("src/mobile/MobileExpansionPullStatus.vue", "utf8");
 const composerComponent = readFileSync("src/mobile/MobileSequenceComposer.vue", "utf8");
+const sharedParamsComponent = readFileSync("src/mobile/MobileSharedParams.vue", "utf8");
 const seamPillComponent = readFileSync("../ui/components/SeamPill.vue", "utf8");
 
 describe("mobile viewport scaling", () => {
@@ -234,6 +235,21 @@ describe("mobile style row", () => {
     expect(head?.[1]).toMatch(/min-height:\s*44px\s*;/);
     const chip = css.match(/\.mobile-style-chip\s*\{([^}]*)\}/s);
     expect(chip?.[1]).toMatch(/min-height:\s*44px\s*;/);
+  });
+});
+
+describe("mobile form spacing", () => {
+  it("preserves form rhythm after custom mobile controls", () => {
+    const output = css.match(/\.mobile-output-mode\s*\{([^}]*)\}/s);
+    const range = css.match(/\.mobile-range-field\s*\{([^}]*)\}/s);
+    const duration = css.match(/\.mobile-duration-field\s*\{([^}]*)\}/s);
+
+    expect(output?.[1]).toMatch(/margin:\s*14px 0\s*;/);
+    expect(range?.[1]).toMatch(/margin:\s*14px 0\s*;/);
+    expect(sharedParamsComponent).toMatch(
+      /<VideoDurationSlider[\s\S]*?class="mobile-duration-field"/,
+    );
+    expect(duration?.[1]).toMatch(/margin-bottom:\s*14px\s*;/);
   });
 });
 


### PR DESCRIPTION
## Summary
- restore 14px separation between Output and Model on iPhone
- apply the same vertical rhythm after strength sliders and video duration controls
- add a mobile CSS contract test for all custom form-control transitions

## Validation
- 88 focused mobile tests
- mobile production build
- native iOS cargo check
- iOS release-assets contract
- Prettier and git diff checks
- rendered iPhone-width UI audit with a measured 14px Output-to-Model gap
- sub-agent peer review, with all findings addressed and no remaining actionable findings