### PR TITLE
feat(desktop): improve library multi-selection

### DIFF
--- a/changelog.d/desktop-library-multiselect.md
+++ b/changelog.d/desktop-library-multiselect.md
@@ -1,0 +1,1 @@
+- **Natural desktop Library selection.** Filtered Command-A, Command/Control-click, Shift ranges, and Apple Photos-style drag selection now build multi-print selections; right-click exposes group-safe organization and delete actions. Completed stills on Create also offer **Use as source** from their context menu.

--- a/desktop/src/App.vue
+++ b/desktop/src/App.vue
@@ -144,6 +144,12 @@ function onKeydown(e: KeyboardEvent) {
   // chrome as selected. Editable fields keep their native in-field Select All.
   if (isSelectAllChord(e) && !allowsNativeSelectAll(document.activeElement)) {
     e.preventDefault();
+    // Library owns a real Select All operation. Dispatch from the shell so it
+    // remains reliable even when WebKit delivers the native command to this
+    // long-lived listener before the route view's listener.
+    if (router.currentRoute.value.path === "/library") {
+      window.dispatchEvent(new CustomEvent("mold:library-select-all"));
+    }
     return;
   }
   const action = resolveShellShortcut(e);

--- a/desktop/src/views/GenerateView.sequence.test.ts
+++ b/desktop/src/views/GenerateView.sequence.test.ts
@@ -120,7 +120,7 @@ beforeEach(() => {
 afterEach(() => (document.body.innerHTML = ""));
 
 describe("GenerateView — sequence output", () => {
-  it("offers Save image and Copy file path on a completed still", async () => {
+  it("offers Save image, Use as source, and Copy file path on a completed still", async () => {
     readyLocal();
     installedPayload = [imageModel];
     useModelStore().all = [imageModel];
@@ -155,7 +155,17 @@ describe("GenerateView — sequence output", () => {
       "separator" in entry ? [] : [entry.label],
     );
     expect(labels).toContain("Save image");
+    expect(labels).toContain("Use as source");
     expect(labels).toContain("Copy file path");
+
+    const useAsSource = useContextMenuStore().entries.find(
+      (entry) => !("separator" in entry) && entry.label === "Use as source",
+    );
+    expect(useAsSource).toMatchObject({ disabled: false });
+    useContextMenuStore().activate(useAsSource!);
+    expect(useGenerateFormStore().form.sourceImage).toBe("aW1hZ2U=");
+    expect(useGenerateFormStore().form.sourceImageName).toBe("remote-print.png");
+    expect(useGenerateFormStore().form.sourceFit).toEqual({ mode: "lanczos-resize" });
   });
 
   it.each([

--- a/desktop/src/views/GenerateView.vue
+++ b/desktop/src/views/GenerateView.vue
@@ -32,6 +32,7 @@ import { effectiveGenerationRecipe } from "@studio/lib/generationProfile";
 import { profileConflictMessage } from "@studio/lib/profileFleet";
 import { useLiveActivityStore } from "../stores/liveActivity";
 import { imageDimensionsFromBase64 } from "@studio/lib/imageDimensions";
+import { attachPickedImage } from "../lib/sourceAttachment";
 import {
   resolveDefaultSourceResolution,
   resolveSourceConditioningTarget,
@@ -2021,6 +2022,26 @@ function canvasMenu(): MenuEntry[] {
           .catch((error) =>
             toasts.push(error instanceof Error ? error.message : String(error), "error"),
           );
+      },
+    },
+    {
+      label: "Use as source",
+      disabled:
+        j.status !== "complete" || !j.result?.image || !!j.result.video_frames || isAudioResult(j),
+      action: () => {
+        if (!j.result?.image) return;
+        attachPickedImage(form, {
+          filename:
+            j.result.filename ??
+            suggestOutputFilename(
+              j.result.model,
+              j.result.seed_used,
+              j.result.format,
+              j.submittedAtUnixMs,
+            ),
+          base64: j.result.image,
+        });
+        toasts.push("Loaded as source");
       },
     },
     {

--- a/desktop/src/views/LibraryView.shelf.test.ts
+++ b/desktop/src/views/LibraryView.shelf.test.ts
@@ -449,6 +449,200 @@ describe("tile context menu", () => {
 });
 
 describe("bulk bar", () => {
+  it("enters selection naturally with Command-click and Shift-click", async () => {
+    const { wrapper } = await mountView();
+    await tileFor(wrapper, smurf04.filename).trigger("click");
+    await tileFor(wrapper, river.filename).trigger("click", { metaKey: true });
+
+    expect(wrapper.get("[data-test='bulk-action-bar']").text()).toContain("2 / 4 selected");
+    expect(tileFor(wrapper, smurf04.filename).get("button").attributes("aria-pressed")).toBe(
+      "true",
+    );
+    expect(tileFor(wrapper, river.filename).get("button").attributes("aria-pressed")).toBe("true");
+
+    await tileFor(wrapper, plain.filename).trigger("pointerdown", {
+      pointerId: 40,
+      pointerType: "mouse",
+      button: 0,
+      isPrimary: true,
+      shiftKey: true,
+    });
+    window.dispatchEvent(
+      new PointerEvent("pointerup", {
+        pointerId: 40,
+        pointerType: "mouse",
+        isPrimary: true,
+        shiftKey: true,
+      }),
+    );
+    await tileFor(wrapper, plain.filename).trigger("click", { shiftKey: true });
+    expect(wrapper.get("[data-test='bulk-action-bar']").text()).toContain("3 / 4 selected");
+    wrapper.unmount();
+  });
+
+  it("Command-A selects only the prints in the active filter", async () => {
+    const { wrapper } = await mountView();
+    await wrapper.get("[data-test='tag-chip'][data-tag='smurf']").trigger("click");
+    await flushPromises();
+
+    key("a", { metaKey: true });
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.get("[data-test='bulk-action-bar']").text()).toContain("2 / 2 selected");
+    expect(wrapper.findAll("[data-test='select-indicator']").map((node) => node.text())).toEqual([
+      "✓",
+      "✓",
+    ]);
+    wrapper.unmount();
+  });
+
+  it("drag-selects and drag-deselects every visible tile crossed", async () => {
+    const { wrapper } = await mountView();
+    await wrapper.get('[aria-label="Toggle select mode"]').trigger("click");
+    const tiles = [smurf04, smurf03, river].map((print) => tileFor(wrapper, print.filename));
+    const previous = Object.getOwnPropertyDescriptor(document, "elementsFromPoint");
+    Object.defineProperty(document, "elementsFromPoint", {
+      configurable: true,
+      value: vi.fn((x: number) => [
+        x < 100 ? tiles[0]!.element : x < 200 ? tiles[1]!.element : tiles[2]!.element,
+      ]),
+    });
+    try {
+      await tiles[0]!.trigger("pointerdown", {
+        pointerId: 41,
+        pointerType: "mouse",
+        button: 0,
+        isPrimary: true,
+        clientX: 20,
+        clientY: 200,
+      });
+      window.dispatchEvent(
+        new PointerEvent("pointermove", {
+          pointerId: 41,
+          pointerType: "mouse",
+          isPrimary: true,
+          clientX: 260,
+          clientY: 200,
+        }),
+      );
+      window.dispatchEvent(
+        new PointerEvent("pointerup", { pointerId: 41, pointerType: "mouse", isPrimary: true }),
+      );
+      await wrapper.vm.$nextTick();
+      expect(wrapper.get("[data-test='bulk-action-bar']").text()).toContain("3 / 4 selected");
+
+      await tiles[0]!.trigger("pointerdown", {
+        pointerId: 42,
+        pointerType: "mouse",
+        button: 0,
+        isPrimary: true,
+        clientX: 20,
+        clientY: 200,
+      });
+      window.dispatchEvent(
+        new PointerEvent("pointermove", {
+          pointerId: 42,
+          pointerType: "mouse",
+          isPrimary: true,
+          clientX: 150,
+          clientY: 200,
+        }),
+      );
+      window.dispatchEvent(
+        new PointerEvent("pointerup", { pointerId: 42, pointerType: "mouse", isPrimary: true }),
+      );
+      await wrapper.vm.$nextTick();
+      expect(wrapper.get("[data-test='bulk-action-bar']").text()).toContain("1 / 4 selected");
+      expect(tileFor(wrapper, river.filename).get("button").attributes("aria-pressed")).toBe(
+        "true",
+      );
+    } finally {
+      if (previous) Object.defineProperty(document, "elementsFromPoint", previous);
+      else Reflect.deleteProperty(document, "elementsFromPoint");
+      wrapper.unmount();
+    }
+  });
+
+  it("right-click targets the selected group and resets to an unselected print", async () => {
+    const { wrapper } = await mountView();
+    await wrapper.get('[aria-label="Toggle select mode"]').trigger("click");
+    await tileFor(wrapper, smurf04.filename).trigger("click");
+    await tileFor(wrapper, plain.filename).trigger("click", { metaKey: true });
+
+    await tileFor(wrapper, smurf04.filename).trigger("contextmenu");
+    expect(menuEntry("Favorite 2 selected")).toBeDefined();
+    expect(menuEntry("Move 2 selected to trash")).toBeDefined();
+    expect(menuEntry("Rename…")).toBeUndefined();
+
+    await tileFor(wrapper, river.filename).trigger("contextmenu");
+    expect(wrapper.get("[data-test='bulk-action-bar']").text()).toContain("1 / 4 selected");
+    expect(menuEntry("Move to trash")).toBeDefined();
+    wrapper.unmount();
+  });
+
+  it("preserves the selected group when macOS Control-click opens its context menu", async () => {
+    const { wrapper } = await mountView();
+    await wrapper.get('[aria-label="Toggle select mode"]').trigger("click");
+    await tileFor(wrapper, smurf04.filename).trigger("click");
+    await tileFor(wrapper, plain.filename).trigger("click", { metaKey: true });
+
+    await tileFor(wrapper, smurf04.filename).trigger("pointerdown", {
+      pointerId: 43,
+      pointerType: "mouse",
+      button: 0,
+      isPrimary: true,
+      ctrlKey: true,
+    });
+    await tileFor(wrapper, smurf04.filename).trigger("contextmenu", { ctrlKey: true });
+
+    expect(wrapper.get("[data-test='bulk-action-bar']").text()).toContain("2 / 4 selected");
+    expect(menuEntry("Favorite 2 selected")).toBeDefined();
+    expect(menuEntry("Move 2 selected to trash")).toBeDefined();
+    wrapper.unmount();
+  });
+
+  it("labels mixed trash-capability selections as permanent delete", async () => {
+    const { wrapper, gallery, hosts } = await mountView();
+    const legacy = base("legacy-host-print.png", 8, 8);
+    apiJsonTo.mockImplementation(async (target: { baseUrl?: string }, path: string) => {
+      if (path === "/api/gallery") {
+        return target?.baseUrl === "http://legacy:7680"
+          ? [structuredClone(legacy)]
+          : live.map((print) => structuredClone(print));
+      }
+      if (path.startsWith("/api/gallery/collections/")) return { filenames: [] };
+      return undefined;
+    });
+    hosts.extras.push({
+      id: "legacy-7680",
+      label: "legacy",
+      url: "http://legacy:7680",
+      apiKey: null,
+      status: "ready",
+      error: null,
+      instanceId: null,
+    });
+    hosts.capabilities["legacy-7680"] = {
+      gallery: { can_delete: true, organize: false, trash: null },
+    };
+    gallery.buckets["legacy-7680"] = {
+      items: [legacy],
+      loading: false,
+      error: null,
+      loaded: true,
+    };
+    await flushPromises();
+
+    await wrapper.get('[aria-label="Toggle select mode"]').trigger("click");
+    await tileFor(wrapper, smurf04.filename).trigger("click");
+    await tileFor(wrapper, legacy.filename).trigger("click", { metaKey: true });
+    await tileFor(wrapper, smurf04.filename).trigger("contextmenu");
+
+    expect(menuEntry("Delete 2 selected")).toBeDefined();
+    expect(menuEntry("Move 2 selected to trash")).toBeUndefined();
+    wrapper.unmount();
+  });
+
   it("moves the selection to the trash behind one undo toast; undo restores every print", async () => {
     const { wrapper, gallery } = await mountView();
     vi.useFakeTimers();

--- a/desktop/src/views/LibraryView.vue
+++ b/desktop/src/views/LibraryView.vue
@@ -62,7 +62,7 @@ import { copyImageBytesToClipboard } from "../lib/clipboard";
 import { copyLocalOutputPath } from "../lib/localOutputPath";
 import { formatBytes } from "../lib/format";
 import { primaryModifierPressed } from "../lib/platform";
-import { allowsNativeContextMenu } from "../lib/shortcuts";
+import { allowsNativeContextMenu, allowsNativeSelectAll, isSelectAllChord } from "../lib/shortcuts";
 import { modelDisplayNameForId } from "../lib/models";
 import type { GalleryImage } from "../lib/api/types";
 import { isUpscaledImage } from "../lib/gallery/upscaled";
@@ -82,6 +82,9 @@ const PAD = 16;
 const EXTRA_POLL_MS = 15_000;
 /** Tags offered in the tile menu's Tags ▸ submenu. */
 const MENU_TAG_LIMIT = 12;
+/** Pointer sweep selection auto-scrolls near the top/bottom of the grid. */
+const DRAG_SCROLL_EDGE = 72;
+const DRAG_SCROLL_MAX = 18;
 
 const router = useRouter();
 const route = useRoute();
@@ -896,6 +899,43 @@ function tileMenu(entry: MergedPrint): MenuEntry[] {
   const organize = canOrganizeEntry(entry);
   const favorite = isFavorite(entry);
   const trashable = entryTrashCapable(entry);
+  if (selectedForBulk) {
+    const targets = selectedEntries.value;
+    const allFavorite = targets.every(isFavorite);
+    const allOrganizable = targets.every(canOrganizeEntry);
+    const allTrashable = targets.every(entryTrashCapable);
+    return [
+      ...(allOrganizable
+        ? [
+            {
+              label: allFavorite
+                ? `Unfavorite ${bulkCount} selected`
+                : `Favorite ${bulkCount} selected`,
+              checked: allFavorite,
+              action: () => void setFavorite(targets, !allFavorite),
+            },
+            { label: "Tags", children: tagSubmenu(entry) },
+            { label: "Add to collection", children: collectionSubmenu(entry) },
+            ...(gallery.collectionSlug && inCollections.value
+              ? [
+                  {
+                    label: `Remove ${bulkCount} selected from collection`,
+                    action: () => void removeFromOpenCollection(targets),
+                  },
+                ]
+              : []),
+            { separator: true } as MenuEntry,
+          ]
+        : []),
+      {
+        label: allTrashable
+          ? `Move ${bulkCount} selected to trash`
+          : `Delete ${bulkCount} selected`,
+        danger: true,
+        action: () => void deleteSelectedPrints(),
+      },
+    ];
+  }
   return [
     ...(isSequencePrint(entry)
       ? [
@@ -1074,14 +1114,21 @@ function clearFilters() {
 // ── Bulk select mode ───────────────────────────────────────────────────────
 // Selection is keyed by print identity (filename — the merged grid's
 // cross-host identity), never row index: the virtualized grid re-flows.
-// Drag-marquee selection is a deliberate follow-up — it fights the
-// virtualized justified grid; click / shift-range / meta-toggle ship first.
+// Pointer sweep selection samples the path across visible virtual rows and
+// edge-scrolls, matching the iPhone Library gesture without relying on indexes.
 const selectMode = ref(false);
 const bulkSelection = ref<Set<string>>(new Set());
 const bulkAnchor = ref<string | null>(null);
 const confirmingBulkDelete = ref(false);
 const bulkDeleting = ref(false);
 const bulkBar = ref<InstanceType<typeof BulkBar> | null>(null);
+let dragPointerId: number | null = null;
+let dragSelect = true;
+let dragClientX = 0;
+let dragClientY = 0;
+let dragFrame: number | null = null;
+let dragPendingClicks = 0;
+const dragVisited = new Set<string>();
 
 const selectedEntries = computed(() =>
   entries.value.filter((e) => bulkSelection.value.has(e.item.filename)),
@@ -1115,6 +1162,7 @@ const selectionTrashCapable = computed(
 );
 
 function setSelectMode(next: boolean) {
+  if (!next) finishSelectionDrag();
   selectMode.value = next;
   if (!next) {
     bulkSelection.value = new Set();
@@ -1125,7 +1173,31 @@ function setSelectMode(next: boolean) {
 }
 
 function onTileClick(entry: MergedPrint, e: MouseEvent) {
+  if (selectMode.value && dragPendingClicks > 0 && e.detail !== 0) {
+    dragPendingClicks -= 1;
+    return;
+  }
   if (!selectMode.value) {
+    const extend = e.shiftKey;
+    // Accept both platform conventions here: Command-click on macOS and
+    // Control-click on Windows/Linux, including browser-based desktop QA.
+    const toggle = e.metaKey || e.ctrlKey;
+    if (extend || toggle) {
+      const current = selectedEntry.value;
+      const initial = new Set(current ? [current.item.filename] : []);
+      const anchor = current?.item.filename ?? null;
+      selectMode.value = true;
+      const next = applySelectionClick(
+        initial,
+        anchor,
+        entries.value.map((x) => x.item.filename),
+        entry.item.filename,
+        { shift: extend, meta: toggle },
+      );
+      bulkSelection.value = next.selection;
+      bulkAnchor.value = next.anchor;
+      return;
+    }
     select(entry);
     return;
   }
@@ -1140,6 +1212,122 @@ function onTileClick(entry: MergedPrint, e: MouseEvent) {
   bulkAnchor.value = next.anchor;
 }
 
+function entryAtPoint(x: number, y: number): MergedPrint | null {
+  // The floating bulk bar may overlap the grid during edge scrolling, so use
+  // the complete hit stack and find the first tile underneath it.
+  const elements = document.elementsFromPoint?.(x, y) ?? [document.elementFromPoint(x, y)];
+  const tile = elements
+    .map((element) => element?.closest<HTMLElement>("[data-filename]") ?? null)
+    .find((element) => element !== null);
+  const filename = tile?.dataset.filename;
+  return filename
+    ? (entries.value.find((entry) => entry.item.filename === filename) ?? null)
+    : null;
+}
+
+function applyDragSelection(entry: MergedPrint): void {
+  const filename = entry.item.filename;
+  if (dragVisited.has(filename)) return;
+  dragVisited.add(filename);
+  const next = new Set(bulkSelection.value);
+  if (dragSelect) next.add(filename);
+  else next.delete(filename);
+  bulkSelection.value = next;
+  bulkAnchor.value = filename;
+  confirmingBulkDelete.value = false;
+}
+
+function applyDragAtPoint(): void {
+  const entry = entryAtPoint(dragClientX, dragClientY);
+  if (entry) applyDragSelection(entry);
+}
+
+function applyDragSegment(fromX: number, fromY: number, toX: number, toY: number): void {
+  const distance = Math.hypot(toX - fromX, toY - fromY);
+  // Sampling prevents a quick mouse sweep from jumping over narrow tiles.
+  const steps = Math.max(1, Math.ceil(distance / 12));
+  for (let step = 1; step <= steps; step += 1) {
+    const progress = step / steps;
+    const entry = entryAtPoint(fromX + (toX - fromX) * progress, fromY + (toY - fromY) * progress);
+    if (entry) applyDragSelection(entry);
+  }
+}
+
+function runDragFrame(): void {
+  dragFrame = null;
+  if (dragPointerId === null || !selectMode.value) return;
+  const scroller = scrollEl.value;
+  if (scroller) {
+    const bounds = scroller.getBoundingClientRect();
+    const topDepth = Math.max(0, bounds.top + DRAG_SCROLL_EDGE - dragClientY);
+    const bottomDepth = Math.max(0, dragClientY - (bounds.bottom - DRAG_SCROLL_EDGE));
+    const direction = bottomDepth > 0 ? 1 : topDepth > 0 ? -1 : 0;
+    const depth = Math.max(topDepth, bottomDepth);
+    if (direction && depth) {
+      const speed = Math.min(
+        DRAG_SCROLL_MAX,
+        Math.max(2, (depth / DRAG_SCROLL_EDGE) * DRAG_SCROLL_MAX),
+      );
+      scroller.scrollTop += direction * speed;
+      applyDragAtPoint();
+    }
+  }
+  dragFrame = requestAnimationFrame(runDragFrame);
+}
+
+function beginSelectionDrag(event: PointerEvent, entry: MergedPrint): void {
+  if (
+    !selectMode.value ||
+    event.isPrimary === false ||
+    event.shiftKey ||
+    // macOS synthesizes a context menu from Control-click. Let the click /
+    // contextmenu path handle it; Windows/Linux Ctrl-click still toggles via
+    // onTileClick, while no platform needs Ctrl-modified sweep selection.
+    (event.ctrlKey && !event.metaKey) ||
+    (event.pointerType === "mouse" && event.button !== 0)
+  ) {
+    return;
+  }
+  event.preventDefault();
+  dragPointerId = event.pointerId;
+  dragSelect = !bulkSelection.value.has(entry.item.filename);
+  dragClientX = event.clientX;
+  dragClientY = event.clientY;
+  dragVisited.clear();
+  applyDragSelection(entry);
+  (event.currentTarget as HTMLElement | null)?.setPointerCapture?.(event.pointerId);
+  if (dragFrame === null) dragFrame = requestAnimationFrame(runDragFrame);
+}
+
+function moveSelectionDrag(event: PointerEvent): void {
+  if (event.pointerId !== dragPointerId) return;
+  event.preventDefault();
+  const points = [...(event.getCoalescedEvents?.() ?? []), event];
+  for (const point of points) {
+    applyDragSegment(dragClientX, dragClientY, point.clientX, point.clientY);
+    dragClientX = point.clientX;
+    dragClientY = point.clientY;
+  }
+}
+
+function finishSelectionDrag(event?: PointerEvent): void {
+  if (event && event.pointerId !== dragPointerId) return;
+  if (event?.type === "pointerup") dragPendingClicks += 1;
+  dragPointerId = null;
+  dragVisited.clear();
+  if (dragFrame !== null) cancelAnimationFrame(dragFrame);
+  dragFrame = null;
+}
+
+function onTileContextMenu(entry: MergedPrint, event: MouseEvent): void {
+  if (selectMode.value && !bulkSelection.value.has(entry.item.filename)) {
+    bulkSelection.value = new Set([entry.item.filename]);
+    bulkAnchor.value = entry.item.filename;
+  }
+  select(entry);
+  contextMenu.open(event, tileMenu(entry));
+}
+
 function onTileDblclick(entry: MergedPrint) {
   if (selectMode.value) return;
   select(entry);
@@ -1148,6 +1336,13 @@ function onTileDblclick(entry: MergedPrint) {
 
 function selectAllInFilter() {
   bulkSelection.value = new Set(entries.value.map((e) => e.item.filename));
+}
+
+function selectAllFromShortcut() {
+  if (entries.value.length === 0) return;
+  selectMode.value = true;
+  selectAllInFilter();
+  bulkAnchor.value = entries.value[0]!.item.filename;
 }
 
 function clearBulkSelection() {
@@ -1324,6 +1519,12 @@ function onKeydown(e: KeyboardEvent) {
   }
   // The history drawer owns the keyboard while it's open.
   if (historyOpen.value) return;
+  // ⌘A selects exactly the current filtered result set, never hidden prints.
+  if (isSelectAllChord(e) && !allowsNativeSelectAll(document.activeElement)) {
+    e.preventDefault();
+    selectAllFromShortcut();
+    return;
+  }
   // ⌘⇧N — new collection (organize-capable hosts only).
   if ((e.key === "n" || e.key === "N") && e.shiftKey && primaryModifierPressed(e)) {
     if (!organizeAvailable.value || allowsNativeContextMenu(e.target as Element | null)) return;
@@ -1692,6 +1893,10 @@ watch(
 
 onMounted(() => {
   window.addEventListener("keydown", onKeydown);
+  window.addEventListener("mold:library-select-all", selectAllFromShortcut);
+  window.addEventListener("pointermove", moveSelectionDrag, { passive: false });
+  window.addEventListener("pointerup", finishSelectionDrag);
+  window.addEventListener("pointercancel", finishSelectionDrag);
   pollTimer = setInterval(() => void gallery.pollExtras(), EXTRA_POLL_MS);
   if (scrollEl.value) {
     containerWidth.value = scrollEl.value.clientWidth;
@@ -1703,6 +1908,11 @@ onMounted(() => {
 });
 onUnmounted(() => {
   window.removeEventListener("keydown", onKeydown);
+  window.removeEventListener("mold:library-select-all", selectAllFromShortcut);
+  window.removeEventListener("pointermove", moveSelectionDrag);
+  window.removeEventListener("pointerup", finishSelectionDrag);
+  window.removeEventListener("pointercancel", finishSelectionDrag);
+  finishSelectionDrag();
   if (pollTimer) clearInterval(pollTimer);
   pollTimer = null;
   resizeObserver?.disconnect();
@@ -1895,17 +2105,16 @@ onUnmounted(() => {
             "
             :style="{ width: `${laid.width}px`, height: `${laid.height}px` }"
             :data-filename="laid.item.filename"
+            @pointerdown="beginSelectionDrag($event, laid.entry)"
             @click="onTileClick(laid.entry, $event)"
-            @contextmenu="
-              select(laid.entry);
-              contextMenu.open($event, tileMenu(laid.entry));
-            "
+            @contextmenu="onTileContextMenu(laid.entry, $event)"
             @dblclick="onTileDblclick(laid.entry)"
           >
             <button
               type="button"
               class="absolute inset-0 block h-full w-full overflow-hidden text-left"
               :aria-label="tileTitle(laid.entry)"
+              :aria-pressed="selectMode ? bulkSelection.has(laid.item.filename) : undefined"
             >
               <AuthedMedia
                 :path="


### PR DESCRIPTION
## Summary
- add natural Command/Control-click, Shift-range, filtered Command-A, and drag-sweep selection to the desktop Library
- make right-click preserve selected groups and expose group-safe favorite, tag, collection, trash, and delete actions
- add completed-image Use as source to the Create context menu using the existing source attachment path

## Verification
- 4,270 desktop tests pass
- desktop production build passes
- Prettier check passes
- hands-on browser UAT: filtered 4/4 Command-A, 3/4 drag sweep, group right-click, completed-image Use as source, and clean final console
- sub-agent peer review clean after addressing Shift-click, mixed-capability delete labeling, and macOS Control-click findings