### PR TITLE
fix(desktop): route notification clicks by context

### DIFF
--- a/changelog.d/desktop-notification-routing.md
+++ b/changelog.d/desktop-notification-routing.md
@@ -1,0 +1,5 @@
+- **Desktop notifications open the work they describe.** Finished prints and
+  sequences open Library, generation failures return to Create, model pulls
+  open Models, and update alerts open Settings. A model pulled from Create to
+  resume a waiting generation returns there instead, including remote-host and
+  already-downloading pulls.

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -4076,6 +4076,7 @@ dependencies = [
  "mold-ai-core",
  "mold-ai-db",
  "mold-ai-server",
+ "notify-rust",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -92,6 +92,11 @@ objc2 = "0.6.4"
 objc2-app-kit = { version = "0.3.2", default-features = false, features = ["NSButton", "NSColor", "NSView", "NSWindow", "objc2-core-graphics", "objc2-quartz-core"] }
 objc2-quartz-core = { version = "0.3.2", default-features = false, features = ["CALayer", "objc2-core-foundation", "objc2-core-graphics"] }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+# Tauri's notification click actions are mobile-only. Use the XDG handle so
+# Linux notification-body clicks carry the same semantic routes as macOS.
+notify-rust = "4.18"
+
 [features]
 default = []
 # CPU-only by default so CI runs without a GPU; desktop-dev/desktop-build

--- a/desktop/src-tauri/src/notifications.rs
+++ b/desktop/src-tauri/src/notifications.rs
@@ -3,15 +3,31 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum NotificationAction {
-    Gallery { filename: String },
+    Gallery { filename: Option<String> },
+    Create,
+    Models,
+    Updates,
 }
 
 static PENDING_ACTION: std::sync::Mutex<Option<NotificationAction>> = std::sync::Mutex::new(None);
 
-/// Send through Apple's current UserNotifications framework so Notification
-/// Center associates the alert with the running signed Mold bundle and uses
-/// its CFBundleIconFile. The previous NSUserNotification/private-identity-image
-/// path is ignored by current macOS releases and produced a generic icon.
+fn activate(app: &tauri::AppHandle, action: NotificationAction) {
+    use tauri::{Emitter, Manager};
+
+    if let Ok(mut pending) = PENDING_ACTION.lock() {
+        *pending = Some(action.clone());
+    }
+    if let Some(window) = app.get_webview_window("main") {
+        let _ = window.unminimize();
+        let _ = window.show();
+        let _ = window.set_focus();
+    }
+    let _ = app.emit("notification-action", action);
+}
+
+/// Send through the platform path that preserves a click action. macOS uses
+/// UserNotifications so Notification Center associates alerts with the signed
+/// Mold bundle; Linux retains the XDG notification handle until activation.
 #[tauri::command]
 pub async fn send_native_notification(
     app: tauri::AppHandle,
@@ -39,7 +55,34 @@ pub async fn send_native_notification(
         Ok(true)
     }
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(target_os = "linux")]
+    {
+        let Some(action) = action else {
+            return Ok(false);
+        };
+        tauri::async_runtime::spawn_blocking(move || {
+            let mut notification = notify_rust::Notification::new();
+            notification.summary(&title).appname("Mold");
+            if let Some(body) = body.as_deref() {
+                notification.body(body);
+            }
+            notification.action("default", "Open Mold");
+            let handle = notification.show().map_err(|error| error.to_string())?;
+            std::thread::spawn(move || {
+                handle.wait_for_action(move |response| {
+                    if response == "default" {
+                        activate(&app, action);
+                    }
+                });
+            });
+            Ok::<_, String>(())
+        })
+        .await
+        .map_err(|error| error.to_string())??;
+        Ok(true)
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
     {
         let _ = (app, title, body, action);
         Ok(false)
@@ -130,11 +173,19 @@ fn send_macos_notification(
     content.setTitle(&NSString::from_str(title));
     content.setBody(&NSString::from_str(body.unwrap_or("")));
     let id = match action {
-        Some(NotificationAction::Gallery { filename }) => format!(
+        Some(NotificationAction::Gallery {
+            filename: Some(filename),
+        }) => format!(
             "mold-gallery:{}:{}",
             uuid::Uuid::new_v4(),
             base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(filename.as_bytes())
         ),
+        Some(NotificationAction::Gallery { filename: None }) => {
+            format!("mold-library:{}", uuid::Uuid::new_v4())
+        }
+        Some(NotificationAction::Create) => format!("mold-create:{}", uuid::Uuid::new_v4()),
+        Some(NotificationAction::Models) => format!("mold-models:{}", uuid::Uuid::new_v4()),
+        Some(NotificationAction::Updates) => format!("mold-updates:{}", uuid::Uuid::new_v4()),
         None => uuid::Uuid::new_v4().to_string(),
     };
     let identifier = NSString::from_str(&id);
@@ -156,6 +207,23 @@ fn send_macos_notification(
 fn action_from_identifier(identifier: &str) -> Option<NotificationAction> {
     use base64::Engine;
 
+    for (prefix, action) in [
+        (
+            "mold-library",
+            NotificationAction::Gallery { filename: None },
+        ),
+        ("mold-create", NotificationAction::Create),
+        ("mold-models", NotificationAction::Models),
+        ("mold-updates", NotificationAction::Updates),
+    ] {
+        if identifier
+            .strip_prefix(prefix)
+            .is_some_and(|suffix| suffix.starts_with(':') && suffix.len() > 1)
+        {
+            return Some(action);
+        }
+    }
+
     let mut parts = identifier.splitn(3, ':');
     if parts.next()? != "mold-gallery" || parts.next()?.is_empty() {
         return None;
@@ -164,14 +232,16 @@ fn action_from_identifier(identifier: &str) -> Option<NotificationAction> {
         .decode(parts.next()?)
         .ok()?;
     let filename = String::from_utf8(bytes).ok()?;
-    (!filename.is_empty()).then_some(NotificationAction::Gallery { filename })
+    (!filename.is_empty()).then_some(NotificationAction::Gallery {
+        filename: Some(filename),
+    })
 }
 
 #[cfg(target_os = "macos")]
 mod delegate {
     use super::{
         action_from_identifier, delegate_install_decision, macos_bundle_identifier,
-        DelegateInstall, NotificationAction, PENDING_ACTION,
+        DelegateInstall, NotificationAction,
     };
     use block2::DynBlock;
     use objc2::runtime::ProtocolObject;
@@ -180,7 +250,6 @@ mod delegate {
     use objc2_user_notifications::{
         UNNotificationResponse, UNUserNotificationCenter, UNUserNotificationCenterDelegate,
     };
-    use tauri::{Emitter, Manager};
 
     static APP: std::sync::OnceLock<tauri::AppHandle> = std::sync::OnceLock::new();
 
@@ -217,16 +286,8 @@ mod delegate {
     }
 
     fn activate(action: NotificationAction) {
-        if let Ok(mut pending) = PENDING_ACTION.lock() {
-            *pending = Some(action.clone());
-        }
         let Some(app) = APP.get() else { return };
-        if let Some(window) = app.get_webview_window("main") {
-            let _ = window.unminimize();
-            let _ = window.show();
-            let _ = window.set_focus();
-        }
-        let _ = app.emit("notification-action", action);
+        super::activate(app, action);
     }
 
     pub fn install(app: &tauri::AppHandle) {
@@ -321,9 +382,31 @@ mod tests {
         assert_eq!(
             action_from_identifier(&format!("mold-gallery:request-id:{encoded}")),
             Some(NotificationAction::Gallery {
-                filename: filename.into()
+                filename: Some(filename.into())
             })
         );
         assert_eq!(action_from_identifier("ordinary-request-id"), None);
+    }
+
+    #[test]
+    fn workspace_actions_decode_only_from_mold_identifiers() {
+        assert_eq!(
+            action_from_identifier("mold-library:request-id"),
+            Some(NotificationAction::Gallery { filename: None })
+        );
+        assert_eq!(
+            action_from_identifier("mold-create:request-id"),
+            Some(NotificationAction::Create)
+        );
+        assert_eq!(
+            action_from_identifier("mold-models:request-id"),
+            Some(NotificationAction::Models)
+        );
+        assert_eq!(
+            action_from_identifier("mold-updates:request-id"),
+            Some(NotificationAction::Updates)
+        );
+        assert_eq!(action_from_identifier("mold-create"), None);
+        assert_eq!(action_from_identifier("mold-models:"), None);
     }
 }

--- a/desktop/src/App.vue
+++ b/desktop/src/App.vue
@@ -9,6 +9,7 @@ import ContextMenu from "./components/shell/ContextMenu.vue";
 import UpdateBanner from "./components/shell/UpdateBanner.vue";
 import { dockBadgeValue } from "./lib/dockBadge";
 import { ipc } from "./lib/ipc";
+import { notificationRoute, type NotificationAction } from "./lib/notificationAction";
 import { appIsBackground } from "./lib/notify";
 import {
   HOST_OFFLINE_DESCRIPTION,
@@ -55,10 +56,8 @@ const toasts = useToastStore();
 const ui = useUiStore();
 const updater = useUpdaterStore();
 
-function openNotificationAction(action: { kind: "gallery"; filename: string } | null) {
-  if (action?.kind === "gallery" && action.filename) {
-    void router.push({ path: "/library", query: { print: action.filename } });
-  }
+function openNotificationAction(action: NotificationAction | null) {
+  if (action) void router.push(notificationRoute(action));
 }
 
 let unlistenNotificationAction: (() => void) | null = null;
@@ -66,7 +65,7 @@ let unlistenNotificationAction: (() => void) | null = null;
 async function listenForNotificationActions() {
   if (!("__TAURI_INTERNALS__" in window)) return;
   const { listen } = await import("@tauri-apps/api/event");
-  unlistenNotificationAction = await listen<{ kind: "gallery"; filename: string }>(
+  unlistenNotificationAction = await listen<NotificationAction>(
     "notification-action",
     ({ payload }) => {
       // The native side retains the action in case activation races startup.

--- a/desktop/src/lib/ipc.ts
+++ b/desktop/src/lib/ipc.ts
@@ -9,6 +9,7 @@ import type {
 import type { GalleryImage, OutputMetadata } from "./api/types";
 import type { ApiTarget } from "./api/client";
 import type { DesktopImageImport } from "./desktopImageDrop";
+import type { NotificationAction } from "./notificationAction";
 import type { Theme, ThemeFamily } from "./theme";
 
 export type { Theme, ThemeFamily } from "./theme";
@@ -454,7 +455,7 @@ export const ipc = {
   sendNativeNotification(
     title: string,
     body?: string,
-    action?: { kind: "gallery"; filename: string },
+    action?: NotificationAction,
   ): Promise<boolean> {
     if (!inTauri()) return Promise.resolve(false);
     return invoke<boolean>("send_native_notification", {
@@ -464,9 +465,9 @@ export const ipc = {
     }).catch(() => false);
   },
   /** Consume a notification activation retained during native/cold startup. */
-  takeNotificationAction(): Promise<{ kind: "gallery"; filename: string } | null> {
+  takeNotificationAction(): Promise<NotificationAction | null> {
     if (!inTauri()) return Promise.resolve(null);
-    return invoke<{ kind: "gallery"; filename: string } | null>("take_notification_action");
+    return invoke<NotificationAction | null>("take_notification_action");
   },
   /** Open the engine's log directory in Finder. */
   openLogsDir(): Promise<void> {

--- a/desktop/src/lib/notificationAction.ts
+++ b/desktop/src/lib/notificationAction.ts
@@ -1,0 +1,27 @@
+/** Closed set of internal destinations encoded into native notifications. */
+export type NotificationAction =
+  | { kind: "gallery"; filename?: string }
+  | { kind: "create" }
+  | { kind: "models" }
+  | { kind: "updates" };
+
+export interface NotificationRoute {
+  path: string;
+  query?: Record<string, string>;
+}
+
+/** Translate native actions into allowlisted router locations. */
+export function notificationRoute(action: NotificationAction): NotificationRoute {
+  switch (action.kind) {
+    case "gallery":
+      return action.filename
+        ? { path: "/library", query: { print: action.filename } }
+        : { path: "/library" };
+    case "create":
+      return { path: "/create" };
+    case "models":
+      return { path: "/models" };
+    case "updates":
+      return { path: "/settings", query: { section: "updates" } };
+  }
+}

--- a/desktop/src/lib/notify.test.ts
+++ b/desktop/src/lib/notify.test.ts
@@ -17,7 +17,15 @@ vi.mock("@tauri-apps/plugin-notification", () => ({
   sendNotification,
 }));
 
-import { notifyGenerated, notifyUpdateAvailable } from "./notify";
+import {
+  notifyChainFinished,
+  notifyGenerated,
+  notifyGenerationFailed,
+  notifyPulled,
+  notifyPullFailed,
+  notifyUpdateAvailable,
+} from "./notify";
+import { notificationRoute } from "./notificationAction";
 
 describe("desktop notifications", () => {
   beforeEach(() => {
@@ -61,9 +69,47 @@ describe("desktop notifications", () => {
       expect(sendNativeNotification).toHaveBeenCalledWith(
         "Mold 0.18.0 is available",
         "Open Mold to update and restart.",
-        undefined,
+        { kind: "updates" },
       ),
     );
+  });
+
+  it.each([
+    [
+      () => notifyGenerated("a deer at sunrise"),
+      "Generated — a deer at sunrise",
+      { kind: "gallery" },
+    ],
+    [() => notifyGenerationFailed("host offline"), "Generation failed", { kind: "create" }],
+    [() => notifyChainFinished(81), "Chain finished · 81 frames", { kind: "gallery" }],
+    [() => notifyPulled("flux-dev:q4"), "Pulled flux-dev:q4", { kind: "models" }],
+    [
+      () => notifyPullFailed("flux-dev:q4", "disk full"),
+      "Couldn't pull flux-dev:q4",
+      { kind: "models" },
+    ],
+  ])("gives %s an intentional click destination", async (dispatch, title, action) => {
+    sendNativeNotification.mockResolvedValue(true);
+
+    dispatch();
+
+    await vi.waitFor(() => expect(sendNativeNotification).toHaveBeenCalled());
+    expect(sendNativeNotification.mock.calls.at(-1)?.[0]).toBe(title);
+    expect(sendNativeNotification.mock.calls.at(-1)?.[2]).toEqual(action);
+  });
+
+  it("maps every native action through the internal route allowlist", () => {
+    expect(notificationRoute({ kind: "gallery", filename: "print.png" })).toEqual({
+      path: "/library",
+      query: { print: "print.png" },
+    });
+    expect(notificationRoute({ kind: "gallery" })).toEqual({ path: "/library" });
+    expect(notificationRoute({ kind: "create" })).toEqual({ path: "/create" });
+    expect(notificationRoute({ kind: "models" })).toEqual({ path: "/models" });
+    expect(notificationRoute({ kind: "updates" })).toEqual({
+      path: "/settings",
+      query: { section: "updates" },
+    });
   });
 
   it("keeps notification delivery failures best effort", async () => {

--- a/desktop/src/lib/notify.ts
+++ b/desktop/src/lib/notify.ts
@@ -4,6 +4,7 @@
  * unfocused. In a plain browser (no Tauri) these are all no-ops.
  */
 import { inTauri, ipc } from "./ipc";
+import type { NotificationAction } from "./notificationAction";
 import { useAppPrefsStore } from "../stores/appPrefs";
 
 let permissionResolved = false;
@@ -23,11 +24,6 @@ async function ensurePermission(): Promise<boolean> {
 /** True when the app is backgrounded — the moment a notification earns its keep. */
 export function appIsBackground(): boolean {
   return document.hidden || !document.hasFocus();
-}
-
-export interface NotificationAction {
-  kind: "gallery";
-  filename: string;
 }
 
 async function notify(title: string, body?: string, action?: NotificationAction): Promise<void> {
@@ -50,24 +46,29 @@ function dispatchNotification(title: string, body?: string, action?: Notificatio
 }
 
 export function notifyGenerated(prompt: string, filename?: string | null): void {
-  dispatchNotification(
-    `Generated — ${prompt.trim().slice(0, 40)}`,
-    undefined,
-    filename ? { kind: "gallery", filename } : undefined,
-  );
+  dispatchNotification(`Generated — ${prompt.trim().slice(0, 40)}`, undefined, {
+    kind: "gallery",
+    ...(filename ? { filename } : {}),
+  });
 }
 export function notifyGenerationFailed(message: string): void {
-  dispatchNotification("Generation failed", message.slice(0, 80));
+  dispatchNotification("Generation failed", message.slice(0, 80), { kind: "create" });
 }
 export function notifyChainFinished(frames: number): void {
-  dispatchNotification(`Chain finished · ${frames} frames`);
+  dispatchNotification(`Chain finished · ${frames} frames`, undefined, { kind: "gallery" });
 }
-export function notifyPulled(model: string): void {
-  dispatchNotification(`Pulled ${model}`);
+export function notifyPulled(model: string, action: NotificationAction = { kind: "models" }): void {
+  dispatchNotification(`Pulled ${model}`, undefined, action);
 }
-export function notifyPullFailed(model: string, message?: string): void {
-  dispatchNotification(`Couldn't pull ${model}`, message?.slice(0, 80));
+export function notifyPullFailed(
+  model: string,
+  message?: string,
+  action: NotificationAction = { kind: "models" },
+): void {
+  dispatchNotification(`Couldn't pull ${model}`, message?.slice(0, 80), action);
 }
 export function notifyUpdateAvailable(version: string): void {
-  dispatchNotification(`Mold ${version} is available`, "Open Mold to update and restart.");
+  dispatchNotification(`Mold ${version} is available`, "Open Mold to update and restart.", {
+    kind: "updates",
+  });
 }

--- a/desktop/src/stores/downloads.notify.test.ts
+++ b/desktop/src/stores/downloads.notify.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createPinia, setActivePinia } from "pinia";
 import { useDownloadsStore } from "./downloads";
 import { useToastStore } from "./toasts";
-import { notifyPullFailed } from "../lib/notify";
+import { notifyPulled, notifyPullFailed } from "../lib/notify";
 import { emptyDownloadsState } from "../lib/downloads";
 import type { DownloadJob } from "../lib/api/types";
 
@@ -24,6 +24,7 @@ const failed = (overrides: Partial<DownloadJob> = {}): DownloadJob => ({
 beforeEach(() => {
   setActivePinia(createPinia());
   vi.mocked(notifyPullFailed).mockReset();
+  vi.mocked(notifyPulled).mockReset();
 });
 
 describe("pull failure notifications (G11)", () => {
@@ -37,7 +38,61 @@ describe("pull failure notifications (G11)", () => {
     expect(msg?.kind).toBe("error");
     expect(msg?.message).toContain("Couldn't pull flux2-klein:q4");
     expect(msg?.message).toContain("disk full");
-    expect(notifyPullFailed).toHaveBeenCalledWith("flux2-klein:q4", "disk full");
+    expect(notifyPullFailed).toHaveBeenCalledWith("flux2-klein:q4", "disk full", {
+      kind: "models",
+    });
+  });
+
+  it("routes an ordinary completed pull to Models", () => {
+    const store = useDownloadsStore();
+
+    store.onJobComplete("job-1", "flux2-klein:q4");
+
+    expect(notifyPulled).toHaveBeenCalledWith("flux2-klein:q4", { kind: "models" });
+  });
+
+  it("routes an exact Create-origin pull back to Create and consumes the intent", () => {
+    const store = useDownloadsStore();
+    store.armNotificationAction("flux2-klein:q4", null, "create-1", { kind: "create" });
+    store.refineNotificationAction("flux2-klein:q4", null, "create-1", "job-1");
+
+    store.onJobComplete("job-1", "flux2-klein:q4");
+    store.onJobComplete("job-2", "flux2-klein:q4");
+
+    expect(notifyPulled).toHaveBeenNthCalledWith(1, "flux2-klein:q4", { kind: "create" });
+    expect(notifyPulled).toHaveBeenNthCalledWith(2, "flux2-klein:q4", { kind: "models" });
+  });
+
+  it("keeps pre-ID Create intent for an already-running remote pull", () => {
+    const store = useDownloadsStore();
+    store.armNotificationAction("flux2-klein:q4", "hal9000", "create-1", {
+      kind: "create",
+    });
+
+    store.onJobComplete("existing-job", "flux2-klein:q4", "hal9000");
+
+    expect(notifyPulled).toHaveBeenCalledWith("flux2-klein:q4", { kind: "create" });
+  });
+
+  it("does not resurrect intent when completion beats the POST response", () => {
+    const store = useDownloadsStore();
+    store.armNotificationAction("flux2-klein:q4", null, "create-1", { kind: "create" });
+
+    store.onJobComplete("job-1", "flux2-klein:q4");
+    expect(store.refineNotificationAction("flux2-klein:q4", null, "create-1", "job-1")).toBe(false);
+
+    expect(store.notificationActions).toEqual({});
+  });
+
+  it("lets stale cleanup remove only its own intent", () => {
+    const store = useDownloadsStore();
+    store.armNotificationAction("flux2-klein:q4", null, "old", { kind: "create" });
+    store.armNotificationAction("flux2-klein:q4", null, "replacement", { kind: "models" });
+
+    store.clearNotificationAction("flux2-klein:q4", null, "old");
+    store.onJobComplete("job-1", "flux2-klein:q4");
+
+    expect(notifyPulled).toHaveBeenCalledWith("flux2-klein:q4", { kind: "models" });
   });
 
   it("names the host on a remote pull failure", () => {

--- a/desktop/src/stores/downloads.ts
+++ b/desktop/src/stores/downloads.ts
@@ -12,6 +12,7 @@ import { sseStream } from "../lib/api/sse";
 import { startCatalogDownload } from "../lib/api/catalog";
 import { applyDownloadEvent, emptyDownloadsState, type DownloadsState } from "../lib/downloads";
 import { notifyPulled, notifyPullFailed } from "../lib/notify";
+import type { NotificationAction } from "../lib/notificationAction";
 import { useModelStore } from "./models";
 import { useHostModelsStore } from "./hostModels";
 import { useToastStore } from "./toasts";
@@ -35,10 +36,23 @@ export interface HostedDownloadJob {
   job: DownloadJob;
 }
 
+interface DownloadNotificationIntent {
+  owner: string;
+  action: NotificationAction;
+}
+
 const STREAM_OPEN_TIMEOUT_MS = 10_000;
 
 /** Scope prefix for the primary stream's rate samples (host streams use their id). */
 const PRIMARY_RATE_SCOPE = "primary";
+
+function notificationKey(
+  hostId: string | null | undefined,
+  identity: "job" | "model",
+  value: string,
+): string {
+  return JSON.stringify([hostId ?? PRIMARY_RATE_SCOPE, identity, value]);
+}
 
 /** One byte-count observation on an active download. */
 export interface RateSample {
@@ -101,6 +115,8 @@ export const useDownloadsStore = defineStore("downloads", {
     hostStates: {} as Record<string, DownloadHostState>,
     /** Sliding rate windows keyed `<scope>:<job id>` (scope = "primary" or host id). */
     rateSamples: {} as Record<string, RateSample[]>,
+    /** Semantic click destinations retained for pulls started outside Models. */
+    notificationActions: {} as Record<string, DownloadNotificationIntent>,
   }),
   getters: {
     /** In-flight rows for the tray: the active job first, then the queue. */
@@ -280,8 +296,9 @@ export const useDownloadsStore = defineStore("downloads", {
           try {
             const ev = JSON.parse(data) as DownloadEvent;
             this.apply(ev);
-            if (ev.type === "job_done") this.onJobComplete(ev.model);
+            if (ev.type === "job_done") this.onJobComplete(ev.id, ev.model);
             else if (ev.type === "job_failed") this.onJobFailed(ev.id);
+            else if (ev.type === "job_cancelled") this.onJobCancelled(ev.id);
           } catch {
             /* skip malformed frame */
           }
@@ -342,8 +359,9 @@ export const useDownloadsStore = defineStore("downloads", {
           try {
             const ev = JSON.parse(data) as DownloadEvent;
             this.applyForHost(host.id, ev);
-            if (ev.type === "job_done") this.onJobComplete(ev.model, host.id);
+            if (ev.type === "job_done") this.onJobComplete(ev.id, ev.model, host.id);
             else if (ev.type === "job_failed") this.onJobFailed(ev.id, host.id);
+            else if (ev.type === "job_cancelled") this.onJobCancelled(ev.id, host.id);
           } catch {
             /* skip malformed frame */
           }
@@ -375,10 +393,63 @@ export const useDownloadsStore = defineStore("downloads", {
       delete this.hostStates[hostId];
       this.clearRates(hostId);
     },
-    onJobComplete(model: string, hostId?: string) {
+    /**
+     * Retain the initiating surface for a pull. Register by model before POST
+     * so a 409/already-running pull is covered, then refine to the returned id.
+     */
+    armNotificationAction(
+      model: string,
+      hostId: string | null,
+      owner: string,
+      action: NotificationAction,
+    ) {
+      this.notificationActions[notificationKey(hostId, "model", model)] = { owner, action };
+    },
+    /** Move a still-owned pre-ID intent to the exact job. If a terminal event
+     * already consumed it, do nothing instead of resurrecting stale state. */
+    refineNotificationAction(
+      model: string,
+      hostId: string | null,
+      owner: string,
+      jobId?: string | null,
+    ): boolean {
+      if (!jobId) return true;
+      const modelKey = notificationKey(hostId, "model", model);
+      const intent = this.notificationActions[modelKey];
+      if (intent?.owner !== owner) return false;
+      delete this.notificationActions[modelKey];
+      this.notificationActions[notificationKey(hostId, "job", jobId)] = intent;
+      return true;
+    },
+    clearNotificationAction(
+      model: string,
+      hostId: string | null,
+      owner: string,
+      jobId?: string | null,
+    ) {
+      for (const key of [
+        notificationKey(hostId, "model", model),
+        ...(jobId ? [notificationKey(hostId, "job", jobId)] : []),
+      ]) {
+        if (this.notificationActions[key]?.owner === owner) delete this.notificationActions[key];
+      }
+    },
+    takeNotificationAction(
+      model: string,
+      hostId: string | null | undefined,
+      jobId: string,
+    ): NotificationAction | undefined {
+      const jobKey = notificationKey(hostId, "job", jobId);
+      const modelKey = notificationKey(hostId, "model", model);
+      const intent = this.notificationActions[jobKey] ?? this.notificationActions[modelKey];
+      delete this.notificationActions[jobKey];
+      delete this.notificationActions[modelKey];
+      return intent?.action;
+    },
+    onJobComplete(id: string, model: string, hostId?: string) {
       const host = hostId ? this.hostStates[hostId] : null;
       useToastStore().push(`Pulled ${model}${host ? ` on ${host.label}` : ""}`);
-      notifyPulled(model);
+      notifyPulled(model, this.takeNotificationAction(model, hostId, id) ?? { kind: "models" });
       if (host) void useHostModelsStore().refresh(true);
       else void useModelStore().fetch();
     },
@@ -394,7 +465,21 @@ export const useDownloadsStore = defineStore("downloads", {
       const suffix = host ? ` on ${host.label}` : "";
       const detail = job?.error ? ` — ${job.error}` : "";
       useToastStore().push(`Couldn't pull ${model}${suffix}${detail}`, "error");
-      notifyPullFailed(model, job?.error ?? undefined);
+      notifyPullFailed(
+        model,
+        job?.error ?? undefined,
+        this.takeNotificationAction(model, hostId, id) ?? { kind: "models" },
+      );
+    },
+    onJobCancelled(id: string, hostId?: string) {
+      const host = hostId ? this.hostStates[hostId] : null;
+      const job = (host?.history ?? this.history).find((candidate) => candidate.id === id);
+      if (job) {
+        const intent =
+          this.notificationActions[notificationKey(hostId, "job", id)] ??
+          this.notificationActions[notificationKey(hostId, "model", job.model)];
+        if (intent) this.clearNotificationAction(job.model, hostId ?? null, intent.owner, id);
+      }
     },
     /** Enqueue a plain-name model. A 409 means it's already queued/installed. */
     async createDownload(model: string) {

--- a/desktop/src/views/GenerateView.missingModel.test.ts
+++ b/desktop/src/views/GenerateView.missingModel.test.ts
@@ -239,6 +239,9 @@ describe("GenerateView missing-model pull before submit", () => {
       jobId: "pull-job-1",
     });
     expect(pullResume.pending?.request.prompt).toBe("a lighthouse at dusk");
+    expect(Object.values(useDownloadsStore().notificationActions)).toContainEqual(
+      expect.objectContaining({ action: { kind: "create" } }),
+    );
   });
 
   it("offers the pull from the picker's Not installed row without queueing", async () => {

--- a/desktop/src/views/GenerateView.vue
+++ b/desktop/src/views/GenerateView.vue
@@ -328,6 +328,7 @@ interface MissingModelSubmission {
    */
   resumeAfterPull?: boolean;
 }
+let missingModelNotificationId = 0;
 
 /** An open machine picker for a pre-submit pull (more than one candidate). */
 const missingModelTargets = ref<{
@@ -503,10 +504,13 @@ async function pullMissingModel() {
     return;
   }
   const resumes = info.resumeAfterPull !== false;
+  const notificationOwner = `create-model:${++missingModelNotificationId}`;
+  downloads.armNotificationAction(info.model, bucketId, notificationOwner, { kind: "create" });
   try {
     // Watch the EXACT job the server enqueues; a stale completed pull of the
     // same model in history can then never trigger a premature resume.
     const jobId = await startCatalogDownload(info.model, route?.target, route?.kind === "remote");
+    downloads.refineNotificationAction(info.model, bucketId, notificationOwner, jobId);
     if (resumes) pullResume.arm({ ...armed, jobId });
     toasts.push(
       resumes
@@ -524,12 +528,16 @@ async function pullMissingModel() {
           : `${info.model} is already downloading on ${label} — press Generate again once it's ready.`,
       );
     } else if (/unknown model/i.test(String(err))) {
+      downloads.clearNotificationAction(info.model, bucketId, notificationOwner);
       toasts.push(
         `${label} can't pull ${info.model} by name — pull it from the Catalog there, then generate again.`,
         "error",
       );
     } else if (routeRequired.value) {
+      downloads.clearNotificationAction(info.model, bucketId, notificationOwner);
       toasts.push(String(err), "error");
+    } else {
+      downloads.clearNotificationAction(info.model, bucketId, notificationOwner);
     }
   }
 }
@@ -630,6 +638,7 @@ const expansionError = ref<string | null>(null);
 const expansionMissingModel = ref<{ model: string; route: HostRoute } | null>(null);
 interface ExpansionPullAttempt {
   id: number;
+  notificationOwner: string;
   model: string;
   route: HostRoute;
   phase: Exclude<ExpansionPullPhase, "missing">;
@@ -2593,8 +2602,10 @@ async function pullExpansionModel() {
   const route = missing.route;
   const bucket = downloadBucketForRoute(route);
   const baselineInFlight = [...bucket.activeJobs, ...bucket.queued];
+  const attemptId = ++expansionPullRequestId;
   const attempt: ExpansionPullAttempt = {
-    id: ++expansionPullRequestId,
+    id: attemptId,
+    notificationOwner: `create-expansion:${attemptId}`,
     model: missing.model,
     route: { ...route, target: { ...route.target } },
     phase: "connecting",
@@ -2610,6 +2621,7 @@ async function pullExpansionModel() {
   };
   expansionPullAttempt.value = attempt;
   const host = hosts.all.find((candidate) => candidate.id === route.hostId) ?? null;
+  const notificationHostId = downloadNotificationHostId(route);
   const streamHost = host
     ? {
         ...host,
@@ -2625,11 +2637,34 @@ async function pullExpansionModel() {
     await downloads.subscribe(streamHost ?? undefined);
     if (expansionPullAttempt.value?.id !== attempt.id) return;
     expansionPullAttempt.value.phase = "starting";
+    downloads.armNotificationAction(missing.model, notificationHostId, attempt.notificationOwner, {
+      kind: "create",
+    });
     const jobId = await startCatalogDownload(missing.model, route.target, route.kind === "remote");
-    if (expansionPullAttempt.value?.id !== attempt.id) return;
+    if (expansionPullAttempt.value?.id !== attempt.id) {
+      downloads.clearNotificationAction(
+        missing.model,
+        notificationHostId,
+        attempt.notificationOwner,
+      );
+      return;
+    }
     expansionPullAttempt.value.jobId = jobId;
+    downloads.refineNotificationAction(
+      missing.model,
+      notificationHostId,
+      attempt.notificationOwner,
+      jobId,
+    );
   } catch (error) {
-    if (expansionPullAttempt.value?.id !== attempt.id) return;
+    if (expansionPullAttempt.value?.id !== attempt.id) {
+      downloads.clearNotificationAction(
+        missing.model,
+        notificationHostId,
+        attempt.notificationOwner,
+      );
+      return;
+    }
     if (error instanceof ApiError && error.status === 409) {
       expansionPullAttempt.value.phase = "starting";
       expansionPullAttempt.value.allowExistingInFlight = true;
@@ -2645,6 +2680,7 @@ async function pullExpansionModel() {
         conflictId ?? expansionPullAttempt.value.baselineMatchingInFlightId;
       return;
     }
+    downloads.clearNotificationAction(missing.model, notificationHostId, attempt.notificationOwner);
     expansionPullAttempt.value.requestError =
       error instanceof Error ? error.message : `Couldn't pull ${missing.model} on ${route.label}.`;
   }
@@ -2657,13 +2693,26 @@ function downloadBucketForRoute(route: HostRoute): DownloadsState {
   return downloads.hostStates[route.hostId] ?? { activeJobs: [], queued: [], history: [] };
 }
 
+function downloadNotificationHostId(route: HostRoute): string | null {
+  return route.kind === "local" || route.hostId === downloads.primaryHostId ? null : route.hostId;
+}
+
 const expansionPullBucket = computed<DownloadsState>(() => {
   const route = expansionPullAttempt.value?.route ?? expansionMissingModel.value?.route;
   return route ? downloadBucketForRoute(route) : { activeJobs: [], queued: [], history: [] };
 });
 
 watch(expansionMissingModel, (missing) => {
-  if (!missing) expansionPullAttempt.value = null;
+  if (!missing && expansionPullAttempt.value) {
+    const attempt = expansionPullAttempt.value;
+    downloads.clearNotificationAction(
+      attempt.model,
+      downloadNotificationHostId(attempt.route),
+      attempt.notificationOwner,
+      attempt.jobId,
+    );
+    expansionPullAttempt.value = null;
+  }
 });
 
 watch(


### PR DESCRIPTION
## Summary
- encode a closed set of semantic notification destinations across macOS and Linux
- return Create-initiated model pulls to Create while ordinary pulls open Models
- route print, sequence, failure, and update notifications to their relevant workspaces
- retain pull origin through pre-ID, remote-host, 409, cancellation, and supersession races

## Root cause
Only completed gallery notifications carried a click action. Model pulls and the other native alerts were actionless, so clicking them merely restored the app at whatever route was current or persisted. The downloads store also discarded the initiating surface, so it could not distinguish an auto-resume pull from an ordinary Models pull.

## Verification
- `nix develop -c desktop-check`
- `nix develop -c desktop-test` (4,275 frontend tests; 129 Rust/integration tests)
- focused notification routing tests (61 frontend; 6 Rust)
- paired agent review completed with no blocking findings
