### PR TITLE
fix(wan): make offload relief backend aware

### DIFF
--- a/changelog.d/wan-metal-offload-admission.md
+++ b/changelog.d/wan-metal-offload-admission.md
@@ -1,0 +1,4 @@
+- **Wan memory admission no longer credits inactive block offload on Metal.**
+  Oversized clips are refused before inference unless an explicit override can
+  actually park every transformer block, while CUDA automatic offload keeps
+  receiving the relief it can use ([#1060](https://github.com/utensils/mold/issues/1060)).

--- a/crates/mold-inference/src/device.rs
+++ b/crates/mold-inference/src/device.rs
@@ -1115,6 +1115,8 @@ pub struct WanActivationGeometry {
     pub ffn_dim: u64,
     /// Attention heads — every shipped variant uses a 128-wide head.
     pub num_heads: u64,
+    /// Transformer block count, read from the highest `blocks.{i}` index.
+    pub num_layers: u64,
     /// VAE generation, which sets the latent grid.
     pub vae: WanVaeGeneration,
     /// The DiT patch's spatial width (`patch_size.1`), which halves each
@@ -1136,6 +1138,7 @@ impl WanActivationGeometry {
             dim: 1536,
             ffn_dim: 8960,
             num_heads: 12,
+            num_layers: 30,
             vae: WanVaeGeneration::V21,
             patch_spatial: 2,
             per_token_timesteps: false,
@@ -1148,6 +1151,7 @@ impl WanActivationGeometry {
             dim: 5120,
             ffn_dim: 13824,
             num_heads: 40,
+            num_layers: 40,
             vae: WanVaeGeneration::V21,
             patch_spatial: 2,
             per_token_timesteps: false,
@@ -1160,6 +1164,7 @@ impl WanActivationGeometry {
             dim: 3072,
             ffn_dim: 14336,
             num_heads: 24,
+            num_layers: 30,
             vae: WanVaeGeneration::V22,
             patch_spatial: 2,
             per_token_timesteps: true,

--- a/crates/mold-inference/src/wan/block_offload.rs
+++ b/crates/mold-inference/src/wan/block_offload.rs
@@ -60,6 +60,7 @@ use std::sync::Arc;
 
 use candle_core::quantized::{ggml_file, QTensor};
 use candle_core::{Device, Result};
+use mold_core::GpuBackend;
 
 /// Checkpoint-name prefix for the tensors belonging to block `index`.
 ///
@@ -192,6 +193,65 @@ fn resolve_forced_block_count(blocks: Option<&str>, offload: Option<&str>) -> Op
 
 fn forced_offload_requested(value: Option<&str>) -> bool {
     matches!(value.map(str::trim), Some("1" | "true" | "yes"))
+}
+
+/// Block-parking authority admission may rely on for a selected backend.
+///
+/// Automatic parking needs a device-local free-VRAM reading, which the Wan
+/// runtime currently has only for CUDA. An explicit block count or the generic
+/// offload override still engages parking on Metal because it does not need to
+/// infer a shortfall from that missing reading.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AdmissionPolicy {
+    Disabled,
+    Automatic,
+    ForcedFinite(usize),
+    ForcedAll,
+}
+
+impl AdmissionPolicy {
+    pub fn from_values(backend: GpuBackend, blocks: Option<&str>, offload: Option<&str>) -> Self {
+        if let Some(raw) = blocks {
+            return match raw.trim().parse::<usize>() {
+                Ok(0) => Self::Disabled,
+                Ok(blocks) => Self::ForcedFinite(blocks),
+                Err(_) if backend == GpuBackend::Cuda => Self::Automatic,
+                Err(_) => Self::Disabled,
+            };
+        }
+        if forced_offload_requested(offload) {
+            Self::ForcedAll
+        } else if backend == GpuBackend::Cuda {
+            Self::Automatic
+        } else {
+            Self::Disabled
+        }
+    }
+
+    /// Whether this policy parks any blocks for the given fit check.
+    pub fn will_park(self, predicted_peak_bytes: u64, available_bytes: u64) -> bool {
+        match self {
+            Self::Disabled => false,
+            Self::Automatic => predicted_peak_bytes > available_bytes,
+            Self::ForcedFinite(blocks) => blocks > 0,
+            Self::ForcedAll => true,
+        }
+    }
+
+    /// Whether admission may credit the measured maximum parking relief.
+    ///
+    /// A finite count engages parking but only proves the measured maximum
+    /// when it covers every checkpoint block. Crediting that maximum for a
+    /// partial count can admit a request the pinned count cannot fit.
+    pub fn supports_max_relief(self, total_blocks: Option<usize>) -> bool {
+        match self {
+            Self::Automatic | Self::ForcedAll => true,
+            Self::ForcedFinite(blocks) => {
+                total_blocks.is_some_and(|total| total > 0 && blocks >= total)
+            }
+            Self::Disabled => false,
+        }
+    }
 }
 
 /// Whether a render at this shape will park blocks at all.
@@ -349,6 +409,41 @@ mod tests {
     use super::*;
     use candle_core::quantized::GgmlDType;
     use candle_core::{DType, Tensor};
+
+    #[test]
+    fn admission_policy_matches_backend_and_override_precedence() {
+        assert_eq!(
+            AdmissionPolicy::from_values(GpuBackend::Cuda, None, None),
+            AdmissionPolicy::Automatic
+        );
+        assert_eq!(
+            AdmissionPolicy::from_values(GpuBackend::Metal, None, None),
+            AdmissionPolicy::Disabled
+        );
+        assert_eq!(
+            AdmissionPolicy::from_values(GpuBackend::Metal, Some("12"), None),
+            AdmissionPolicy::ForcedFinite(12)
+        );
+        assert_eq!(
+            AdmissionPolicy::from_values(GpuBackend::Metal, None, Some("1")),
+            AdmissionPolicy::ForcedAll
+        );
+        assert_eq!(
+            AdmissionPolicy::from_values(GpuBackend::Cuda, Some("0"), Some("1")),
+            AdmissionPolicy::Disabled
+        );
+        assert_eq!(
+            AdmissionPolicy::from_values(GpuBackend::Metal, Some("invalid"), Some("1")),
+            AdmissionPolicy::Disabled
+        );
+
+        assert!(!AdmissionPolicy::ForcedFinite(1).supports_max_relief(Some(40)));
+        assert!(AdmissionPolicy::ForcedFinite(1).will_park(1, 2));
+        assert!(AdmissionPolicy::ForcedFinite(40).supports_max_relief(Some(40)));
+        assert!(AdmissionPolicy::ForcedFinite(999).supports_max_relief(Some(40)));
+        assert!(!AdmissionPolicy::ForcedFinite(40).supports_max_relief(None));
+        assert!(AdmissionPolicy::ForcedAll.supports_max_relief(None));
+    }
 
     fn quantized(name: &str, rows: usize, cols: usize) -> (String, Arc<QTensor>) {
         let device = Device::Cpu;

--- a/crates/mold-inference/src/wan/pipeline.rs
+++ b/crates/mold-inference/src/wan/pipeline.rs
@@ -167,6 +167,7 @@ fn denoise_activation_bytes(
             dim: config.dim as u64,
             ffn_dim: config.ffn_dim as u64,
             num_heads: config.num_heads as u64,
+            num_layers: config.num_layers as u64,
             vae,
             patch_spatial: config.patch_size.1.max(1) as u64,
             per_token_timesteps: false,
@@ -228,6 +229,7 @@ pub fn activation_geometry_across(
         dim: config.dim as u64,
         ffn_dim: config.ffn_dim as u64,
         num_heads: config.num_heads as u64,
+        num_layers: config.num_layers as u64,
         vae,
         patch_spatial: config.patch_size.1.max(1) as u64,
         // Per-token timesteps are a property of the *request* — only the

--- a/crates/mold-server/src/execution_plan.rs
+++ b/crates/mold-server/src/execution_plan.rs
@@ -2325,6 +2325,17 @@ fn build_plan(
         context.family,
     ));
     let request_has_lora = !context.effective_loras.is_empty();
+    let wan_block_offload_policy = mold_inference::wan::block_offload::AdmissionPolicy::from_values(
+        device.backend,
+        context
+            .engine_config
+            .runtime_environment
+            .value("MOLD_WAN_OFFLOAD_BLOCKS"),
+        context
+            .engine_config
+            .runtime_environment
+            .value("MOLD_OFFLOAD"),
+    );
     let gemma_placement = mold_inference::device::resolve_ltx2_gemma_device_override_from_values(
         context
             .engine_config
@@ -2357,8 +2368,11 @@ fn build_plan(
         context.request,
         context.paths,
         hint,
+        crate::memory_preflight::GenerationOffloadPolicy::new(
+            context.offload_requested,
+            wan_block_offload_policy,
+        ),
         Some(device_budget),
-        context.offload_requested,
         request_has_lora,
         gemma_competes,
     );
@@ -2415,8 +2429,11 @@ fn build_plan(
         context.request,
         &gpu_paths,
         hint,
+        crate::memory_preflight::GenerationOffloadPolicy::new(
+            initial_memory.block_offload && !transformer_on_cpu,
+            wan_block_offload_policy,
+        ),
         Some(device_budget),
-        initial_memory.block_offload && !transformer_on_cpu,
         request_has_lora,
         gemma_competes,
     );
@@ -2435,8 +2452,11 @@ fn build_plan(
             context.request,
             &gpu_paths,
             hint,
+            crate::memory_preflight::GenerationOffloadPolicy::new(
+                initial_memory.block_offload && !transformer_on_cpu,
+                wan_block_offload_policy,
+            ),
             Some(device_budget),
-            initial_memory.block_offload && !transformer_on_cpu,
             request_has_lora,
             gemma_competes,
         );

--- a/crates/mold-server/src/memory_preflight.rs
+++ b/crates/mold-server/src/memory_preflight.rs
@@ -1210,6 +1210,21 @@ pub(crate) struct GenerationMemoryBudget {
     pub(crate) fits_available_memory: Option<bool>,
 }
 
+#[derive(Clone, Copy)]
+pub(crate) struct GenerationOffloadPolicy {
+    forced: bool,
+    wan: mold_inference::wan::block_offload::AdmissionPolicy,
+}
+
+impl GenerationOffloadPolicy {
+    pub(crate) const fn new(
+        forced: bool,
+        wan: mold_inference::wan::block_offload::AdmissionPolicy,
+    ) -> Self {
+        Self { forced, wan }
+    }
+}
+
 /// Resolve one generation's memory/load policy against an explicit sampled
 /// free-memory budget.
 ///
@@ -1221,8 +1236,8 @@ pub(crate) fn estimate_generation_memory_for_request(
     req: &GenerateRequest,
     paths: &ModelPaths,
     hint: Option<ActivationHint>,
+    offload_policy: GenerationOffloadPolicy,
     available_memory_bytes: Option<u64>,
-    forced_offload: bool,
     request_has_lora: bool,
     gemma_competes: bool,
 ) -> GenerationMemoryBudget {
@@ -1248,10 +1263,10 @@ pub(crate) fn estimate_generation_memory_for_request(
         paths,
         hint,
         request_has_lora,
-        forced_offload,
+        offload_policy.forced,
     );
     let block_offload = if conservative_block_offload
-        && !forced_offload
+        && !offload_policy.forced
         && !request_has_lora
         && large_flux2_bf16_should_auto_offload(paths, hint, None, 0)
     {
@@ -1303,7 +1318,11 @@ pub(crate) fn estimate_generation_memory_for_request(
                 // blocks in host RAM, so a shape that does not fit resident
                 // may still be feasible. Charging the full weight term would
                 // refuse it before the engine ever got the chance.
-                wan_offload_relief = wan_block_offload_relief(paths);
+                wan_offload_relief = wan_block_offload_relief_for_policy(
+                    paths,
+                    offload_policy.wan,
+                    wan_geometry.map(|geometry| geometry.num_layers as usize),
+                );
                 base_peak = base_peak.saturating_sub(wan_offload_relief);
             }
             // Carry the wan checkpoint geometry in here too. Wan is never
@@ -1380,10 +1399,9 @@ pub(crate) fn estimate_generation_memory_for_request(
     let wan_block_offload = wan_family
         && wan_transformer_can_park(paths)
         && available_memory_bytes.is_some_and(|available| {
-            mold_inference::wan::block_offload::will_park(
-                peak.saturating_add(wan_offload_relief),
-                available,
-            )
+            offload_policy
+                .wan
+                .will_park(peak.saturating_add(wan_offload_relief), available)
         });
     // `MOLD_OFFLOAD=1` sets the generic streaming flag for every family, but
     // no wan arm streams a transformer from host RAM — the factory does not
@@ -1447,6 +1465,18 @@ fn wan_block_offload_relief(paths: &ModelPaths) -> u64 {
         .map(|m| m.len())
         .unwrap_or(0);
     mold_inference::wan::block_offload::max_block_offload_relief_bytes(bytes)
+}
+
+fn wan_block_offload_relief_for_policy(
+    paths: &ModelPaths,
+    policy: mold_inference::wan::block_offload::AdmissionPolicy,
+    total_blocks: Option<usize>,
+) -> u64 {
+    if policy.supports_max_relief(total_blocks) {
+        wan_block_offload_relief(paths)
+    } else {
+        0
+    }
 }
 
 /// Whether this checkpoint's weights can park at all.
@@ -1573,8 +1603,13 @@ fn request_sensitive_activation_memory_with_wan_geometry(
 mod fail_closed_tests {
     use super::*;
     use image::{DynamicImage, ImageBuffer, ImageFormat, Rgb};
+    use mold_inference::wan::block_offload::AdmissionPolicy;
     use std::io::Cursor;
     use std::path::{Path, PathBuf};
+
+    fn offload(wan: AdmissionPolicy) -> GenerationOffloadPolicy {
+        GenerationOffloadPolicy::new(false, wan)
+    }
 
     fn png(width: u32, height: u32) -> Vec<u8> {
         let image = ImageBuffer::from_pixel(width, height, Rgb([1u8, 2, 3]));
@@ -1813,8 +1848,8 @@ mod fail_closed_tests {
             &request,
             &model_paths,
             activation,
+            offload(AdmissionPolicy::Disabled),
             Some(64_000_000_000),
-            false,
             false,
             false,
         );
@@ -1825,8 +1860,8 @@ mod fail_closed_tests {
             &request,
             &model_paths,
             activation,
+            offload(AdmissionPolicy::Disabled),
             Some(64_000_000_000),
-            false,
             false,
             false,
         );
@@ -1871,8 +1906,8 @@ mod fail_closed_tests {
                 req,
                 paths,
                 activation,
+                offload(AdmissionPolicy::Automatic),
                 Some(24_000_000_000),
-                false,
                 false,
                 false,
             )
@@ -1894,6 +1929,79 @@ mod fail_closed_tests {
             !parks.block_offload,
             "wan parks a subset of one expert; it must not be charged as a \
              streamed transformer"
+        );
+
+        // Metal has no automatic parking plan because the runtime cannot take
+        // the CUDA-ordinal free-VRAM reading it needs. Admission must retain
+        // the resident weight term there instead of crediting CUDA-only
+        // relief (#1060).
+        let metal = estimate_generation_memory_for_request(
+            &request(81),
+            &model_paths,
+            activation,
+            offload(AdmissionPolicy::Disabled),
+            Some(24_000_000_000),
+            false,
+            false,
+        );
+        assert_eq!(
+            metal.peak_memory_bytes,
+            parks
+                .peak_memory_bytes
+                .saturating_add(wan_block_offload_relief(&model_paths))
+        );
+        assert_eq!(metal.fits_available_memory, Some(false));
+        assert!(!metal.wan_block_offload);
+
+        let finite_override = estimate_generation_memory_for_request(
+            &request(81),
+            &model_paths,
+            activation,
+            offload(AdmissionPolicy::ForcedFinite(1)),
+            Some(24_000_000_000),
+            false,
+            false,
+        );
+        assert_eq!(finite_override.peak_memory_bytes, metal.peak_memory_bytes);
+        assert_eq!(finite_override.fits_available_memory, Some(false));
+        assert!(finite_override.wan_block_offload);
+
+        let full_override = estimate_generation_memory_for_request(
+            &request(81),
+            &model_paths,
+            activation,
+            offload(AdmissionPolicy::ForcedFinite(40)),
+            Some(24_000_000_000),
+            false,
+            false,
+        );
+        assert_eq!(full_override.peak_memory_bytes, metal.peak_memory_bytes);
+        assert_eq!(full_override.fits_available_memory, Some(false));
+        assert!(full_override.wan_block_offload);
+        let exact_relief = wan_block_offload_relief(&model_paths);
+        assert_eq!(
+            wan_block_offload_relief_for_policy(
+                &model_paths,
+                AdmissionPolicy::ForcedFinite(40),
+                Some(40),
+            ),
+            exact_relief
+        );
+        assert_eq!(
+            wan_block_offload_relief_for_policy(
+                &model_paths,
+                AdmissionPolicy::ForcedFinite(999),
+                Some(40),
+            ),
+            exact_relief
+        );
+        assert_eq!(
+            wan_block_offload_relief_for_policy(
+                &model_paths,
+                AdmissionPolicy::ForcedFinite(40),
+                None,
+            ),
+            0
         );
 
         // A short clip fits with the weights resident and must keep exactly the
@@ -1960,8 +2068,8 @@ mod fail_closed_tests {
             &request,
             &model_paths,
             activation,
+            offload(AdmissionPolicy::Disabled),
             Some(24_000_000_000),
-            false,
             false,
             false,
         );
@@ -1976,8 +2084,8 @@ mod fail_closed_tests {
             &request,
             &model_paths,
             activation,
+            offload(AdmissionPolicy::Disabled),
             Some(96_000_000_000),
-            false,
             false,
             false,
         );
@@ -1991,8 +2099,8 @@ mod fail_closed_tests {
             &request,
             &model_paths,
             activation,
+            offload(AdmissionPolicy::Disabled),
             Some(24_000_000_000),
-            false,
             false,
             false,
         );
@@ -2004,8 +2112,8 @@ mod fail_closed_tests {
             &request,
             &model_paths,
             activation,
+            offload(AdmissionPolicy::Disabled),
             Some(24_000_000_000),
-            false,
             false,
             false,
         );
@@ -2102,8 +2210,8 @@ mod fail_closed_tests {
             &request,
             &ltx2_paths(dir.path()),
             Some(hint),
+            offload(AdmissionPolicy::Disabled),
             Some(RTX_4090_AVAILABLE),
-            false,
             false,
             false,
         );
@@ -2132,8 +2240,8 @@ mod fail_closed_tests {
             &request,
             &ltx2_paths(dir.path()),
             Some(hint),
+            offload(AdmissionPolicy::Disabled),
             Some(RTX_4090_AVAILABLE),
-            false,
             false,
             false,
         );
@@ -2165,8 +2273,8 @@ mod fail_closed_tests {
             &request,
             &ltx2_paths(dir.path()),
             Some(hint),
+            offload(AdmissionPolicy::Disabled),
             Some(RTX_4090_AVAILABLE),
-            false,
             false,
             false,
         );

--- a/crates/mold-server/src/model_manager.rs
+++ b/crates/mold-server/src/model_manager.rs
@@ -35,6 +35,7 @@ pub(crate) use crate::memory_preflight::{
     preflight_memory_guard_after_drop_for_request, preflight_memory_guard_for_request,
     request_requires_fresh_engine_for_offload_policy, select_server_load_strategy_for_budget,
     select_server_load_strategy_for_device, server_offload_enabled_for_paths,
+    GenerationOffloadPolicy,
 };
 
 pub(crate) fn request_has_effective_lora(req: &GenerateRequest) -> bool {
@@ -1051,6 +1052,7 @@ pub(crate) async fn estimate_generation_memory(
                                 gpu.vram_total.saturating_sub(gpu.vram_used),
                                 gpu.vram_total,
                                 gpu.ordinal,
+                                gpu.backend,
                             )
                         })
                 })
@@ -1059,17 +1061,17 @@ pub(crate) async fn estimate_generation_memory(
         .unwrap_or_default();
     let roomiest = candidates
         .iter()
-        .map(|(available, _, ordinal)| (*available, *ordinal))
-        .max_by_key(|(available, ordinal)| (*available, std::cmp::Reverse(*ordinal)));
+        .map(|(available, _, ordinal, backend)| (*available, *ordinal, *backend))
+        .max_by_key(|(available, ordinal, _)| (*available, std::cmp::Reverse(*ordinal)));
     // The Create badge answers a different question from current admission:
     // whether this request fits the host's hardware once earlier work releases
     // its allocations. Resolve that estimate against physical capacity so an
     // active denoise/load cannot make the answer oscillate on every sample.
     let roomiest_capacity = candidates
         .iter()
-        .map(|(_, capacity, ordinal)| (*capacity, *ordinal))
-        .max_by_key(|(capacity, ordinal)| (*capacity, std::cmp::Reverse(*ordinal)));
-    let available = roomiest.map(|(available, _)| available);
+        .map(|(_, capacity, ordinal, backend)| (*capacity, *ordinal, *backend))
+        .max_by_key(|(capacity, ordinal, _)| (*capacity, std::cmp::Reverse(*ordinal)));
+    let available = roomiest.map(|(available, _, _)| available);
     let forced_offload = matches!(
         mold_inference::runtime_env::value("MOLD_OFFLOAD").as_deref(),
         Some("1") | Some("true") | Some("yes")
@@ -1078,20 +1080,39 @@ pub(crate) async fn estimate_generation_memory(
         &effective_req,
         &paths,
         hint,
+        GenerationOffloadPolicy::new(
+            forced_offload,
+            roomiest.map_or(
+                mold_inference::wan::block_offload::AdmissionPolicy::Disabled,
+                |(_, _, backend)| {
+                    mold_inference::wan::block_offload::AdmissionPolicy::from_values(
+                        backend,
+                        mold_inference::runtime_env::value("MOLD_WAN_OFFLOAD_BLOCKS").as_deref(),
+                        mold_inference::runtime_env::value("MOLD_OFFLOAD").as_deref(),
+                    )
+                },
+            ),
+        ),
         available,
-        forced_offload,
         request_has_effective_lora(&effective_req),
-        roomiest.is_some_and(|(_, ordinal)| {
+        roomiest.is_some_and(|(_, ordinal, _)| {
             crate::memory_preflight::ltx2_encoder_phase_competes_with_transformer_gpu(ordinal)
         }),
     );
-    let capacity_estimate = roomiest_capacity.map(|(capacity, ordinal)| {
+    let capacity_estimate = roomiest_capacity.map(|(capacity, ordinal, backend)| {
         estimate_generation_memory_for_request(
             &effective_req,
             &paths,
             hint,
+            GenerationOffloadPolicy::new(
+                forced_offload,
+                mold_inference::wan::block_offload::AdmissionPolicy::from_values(
+                    backend,
+                    mold_inference::runtime_env::value("MOLD_WAN_OFFLOAD_BLOCKS").as_deref(),
+                    mold_inference::runtime_env::value("MOLD_OFFLOAD").as_deref(),
+                ),
+            ),
             Some(capacity),
-            forced_offload,
             request_has_effective_lora(&effective_req),
             crate::memory_preflight::ltx2_encoder_phase_competes_with_transformer_gpu(ordinal),
         )
@@ -1107,7 +1128,7 @@ pub(crate) async fn estimate_generation_memory(
         capacity_peak_memory_bytes: capacity_estimate
             .as_ref()
             .map(|estimate| estimate.peak_memory_bytes),
-        device_capacity_bytes: roomiest_capacity.map(|(capacity, _)| capacity),
+        device_capacity_bytes: roomiest_capacity.map(|(capacity, _, _)| capacity),
         fits_device_capacity: capacity_estimate.and_then(|estimate| estimate.fits_available_memory),
     })
 }


### PR DESCRIPTION
## Summary

- resolve Wan block-offload admission policy from the selected backend and frozen runtime environment
- credit maximum memory relief only when runtime parking can actually engage, including exact-layer gating for finite explicit overrides
- carry the policy through execution planning and model-manager estimates with regression coverage for CUDA, Metal, aliases, precedence, finite counts, and unknown geometry

## Validation

- `nix develop -c cargo fmt --all -- --check`
- `nix develop -c cargo clippy --workspace --all-targets -- -D warnings`
- 15 focused Wan block-offload tests passed
- 17 focused server memory-preflight tests passed
- independent agent review completed with no actionable findings

## Smoke test status

The real Metal inference smoke test is intentionally pending until sufficient unified memory is available. No checkpoint was loaded and no inference was run during implementation or review.

Fixes #1060