### PR TITLE
fix(studio): cancel generation preparation everywhere

### DIFF
--- a/changelog.d/cancel-generation-preflight.md
+++ b/changelog.d/cancel-generation-preflight.md
@@ -1,0 +1,5 @@
+- **Cancel now works before generation starts.** Web, desktop, and iPhone can
+  stop route planning, source preparation, variation planning, model handoff,
+  and sequence setup without allowing a late response to queue hidden work.
+  The active stage is named while it runs, and an unconfirmed server cancel is
+  reported instead of claiming that nothing was queued.

--- a/crates/mold-server/src/chain_job_runner.rs
+++ b/crates/mold-server/src/chain_job_runner.rs
@@ -4,7 +4,7 @@ use std::ops::ControlFlow;
 use std::path::{Component, Path, PathBuf};
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, bail, Context};
 use image::codecs::jpeg::JpegEncoder;
@@ -45,6 +45,7 @@ pub struct ChainJobRunnerHandle {
     events: Arc<JobEventBus>,
     job_locks: Arc<JobMutationLocks>,
     claims: Arc<EphemeralClaims>,
+    mutation_cancels: Arc<Mutex<HashMap<String, Instant>>>,
 }
 
 struct ActiveChainAttemptGuard {
@@ -427,6 +428,7 @@ impl ChainJobRunnerHandle {
             events: Arc::new(JobEventBus::new()),
             job_locks: Arc::new(JobMutationLocks::new()),
             claims: Arc::new(EphemeralClaims::default()),
+            mutation_cancels: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -459,6 +461,30 @@ impl ChainJobRunnerHandle {
 
     pub fn unregister_cancel(&self, job_id: &str) {
         self.cancel.unregister(job_id);
+    }
+
+    /// Remember a client-known mutation cancellation even when its create or
+    /// amend request has not reached the mutation boundary yet. Entries are
+    /// short-lived because operation ids are single-use and a response may be
+    /// lost after the mutation has already completed.
+    pub fn request_mutation_cancel(&self, operation_id: &str) {
+        const RETENTION: Duration = Duration::from_secs(10 * 60);
+        let now = Instant::now();
+        let mut cancelled = self
+            .mutation_cancels
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        cancelled.retain(|_, requested_at| now.duration_since(*requested_at) < RETENTION);
+        cancelled.insert(operation_id.to_string(), now);
+    }
+
+    /// Atomically consume a pre-mutation cancellation fence.
+    pub fn take_mutation_cancel(&self, operation_id: &str) -> bool {
+        self.mutation_cancels
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .remove(operation_id)
+            .is_some()
     }
 
     pub async fn lock_job(&self, job_id: &str) -> tokio::sync::OwnedMutexGuard<()> {
@@ -531,6 +557,7 @@ pub fn spawn_runner(deps: RunnerDeps) -> ChainJobRunnerHandle {
         events,
         job_locks,
         claims,
+        mutation_cancels: Arc::new(Mutex::new(HashMap::new())),
     }
 }
 
@@ -4845,6 +4872,7 @@ mod tests {
             events: Arc::new(JobEventBus::new()),
             job_locks: Arc::new(JobMutationLocks::new()),
             claims: Arc::new(EphemeralClaims::default()),
+            mutation_cancels: Arc::new(Mutex::new(HashMap::new())),
         };
 
         let mut rx = handle

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -272,6 +272,7 @@ use crate::queue::clean_error_message;
         crate::routes_chain_jobs::retake_chain_job,
         crate::routes_chain_jobs::amend_chain_job,
         crate::routes_chain_jobs::cancel_chain_job,
+        crate::routes_chain_jobs::cancel_chain_job_mutation,
         crate::routes_chain_jobs::delete_chain_job,
         crate::routes_chain_jobs::gc_chain_jobs,
         crate::routes_chain_jobs::chain_job_stage_preview,
@@ -494,6 +495,10 @@ pub fn create_router(state: AppState) -> Router {
         .route(
             "/api/chain-jobs/:id/cancel",
             post(crate::routes_chain_jobs::cancel_chain_job),
+        )
+        .route(
+            "/api/chain-jobs/:id/operations/:operation_id/cancel",
+            post(crate::routes_chain_jobs::cancel_chain_job_mutation),
         )
         .route(
             "/api/chain-jobs/gc",

--- a/crates/mold-server/src/routes_chain_jobs.rs
+++ b/crates/mold-server/src/routes_chain_jobs.rs
@@ -30,6 +30,20 @@ const CHAIN_JOB_RUNNING: &str = "CHAIN_JOB_RUNNING";
 const CHAIN_JOB_NOT_RESUMABLE: &str = "CHAIN_JOB_NOT_RESUMABLE";
 const RETAKE_SPLICE_REQUIRES_CUT_OR_FADE: &str = "RETAKE_SPLICE_REQUIRES_CUT_OR_FADE";
 pub const CHAIN_JOB_EPHEMERAL: &str = "CHAIN_JOB_EPHEMERAL";
+const CHAIN_MUTATION_CANCELLED: &str = "CHAIN_MUTATION_CANCELLED";
+const MUTATION_ID_HEADER: &str = "x-mold-operation-id";
+
+fn mutation_id(headers: &HeaderMap) -> Result<Option<String>, ApiError> {
+    let Some(value) = headers.get(MUTATION_ID_HEADER) else {
+        return Ok(None);
+    };
+    let value = value
+        .to_str()
+        .map_err(|_| ApiError::validation("x-mold-operation-id must be a UUID"))?;
+    let id = uuid::Uuid::parse_str(value)
+        .map_err(|_| ApiError::validation("x-mold-operation-id must be a UUID"))?;
+    Ok(Some(id.to_string()))
+}
 
 #[derive(Debug, Clone, serde::Deserialize, utoipa::ToSchema)]
 pub struct ChainPlacementPreviewRequest {
@@ -81,6 +95,7 @@ impl ChainPlacementPreviewBody {
 )]
 pub async fn create_chain_job(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Json(mut req): Json<ChainRequest>,
 ) -> Result<(StatusCode, Json<CreateChainJobResponse>), ApiError> {
     crate::routes::ensure_generation_available(&state)?;
@@ -106,7 +121,20 @@ pub async fn create_chain_job(
         ));
     }
     crate::routes::materialize_chain_camera_controls(&state, &authority.config, &req).await?;
-    let job_id = uuid::Uuid::new_v4().to_string();
+    let operation_id = mutation_id(&headers)?;
+    let job_id = operation_id
+        .clone()
+        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+    let _guard = handle.lock_job(&job_id).await;
+    if operation_id
+        .as_deref()
+        .is_some_and(|id| handle.take_mutation_cancel(id))
+    {
+        return Err(conflict(
+            CHAIN_MUTATION_CANCELLED,
+            "sequence creation was cancelled before it was queued",
+        ));
+    }
     let jobs_root = jobs_root()?;
     let model = req.model.clone();
     let stage_count = req.stages.len() as u32;
@@ -486,6 +514,7 @@ pub async fn retake_chain_job(
 pub async fn amend_chain_job(
     State(state): State<AppState>,
     Path(id): Path<String>,
+    headers: HeaderMap,
     Json(req): Json<AmendRequest>,
 ) -> Result<(StatusCode, Json<AmendResponse>), ApiError> {
     let handle = chain_jobs_handle(&state)?;
@@ -550,6 +579,17 @@ pub async fn amend_chain_job(
         }
     }
 
+    let operation_id = mutation_id(&headers)?;
+    if operation_id
+        .as_deref()
+        .is_some_and(|operation_id| handle.take_mutation_cancel(operation_id))
+    {
+        return Err(conflict(
+            CHAIN_MUTATION_CANCELLED,
+            "sequence amendment was cancelled before it was queued",
+        ));
+    }
+
     let (updated, preserved_stages) = crate::chain_job_runner::apply_amend(db, &root, &id, &req)
         .map_err(|e| {
             let msg = e.to_string();
@@ -607,19 +647,65 @@ pub async fn cancel_chain_job(
     let db = metadata_db(&state)?;
     let root = jobs_root()?;
     let _guard = handle.lock_job(&id).await;
-    let mut row = chain_jobs::get_job(db, &id)
+    let summary = cancel_chain_job_locked(handle, db, &root, &id)?;
+    Ok((StatusCode::ACCEPTED, Json(summary)))
+}
+
+/// Cancel one client-known create/amend operation. The operation id is known
+/// before the mutation response, so a lost response cannot orphan work. The
+/// fence is recorded before waiting for the job mutation lock; a request that
+/// is still validating observes it before persistence, while an already
+/// persisted mutation is cancelled under the same job lock.
+#[utoipa::path(
+    post,
+    path = "/api/chain-jobs/{id}/operations/{operation_id}/cancel",
+    tag = "chain-jobs",
+    params(
+        ("id" = String, Path, description = "Chain job or proposed job id"),
+        ("operation_id" = String, Path, description = "Client mutation UUID")
+    ),
+    responses((status = 202, description = "Mutation cancellation accepted"))
+)]
+pub async fn cancel_chain_job_mutation(
+    State(state): State<AppState>,
+    Path((id, operation_id)): Path<(String, String)>,
+) -> Result<StatusCode, ApiError> {
+    let operation_id = uuid::Uuid::parse_str(&operation_id)
+        .map_err(|_| ApiError::validation("operation id must be a UUID"))?
+        .to_string();
+    let handle = chain_jobs_handle(&state)?;
+    let db = metadata_db(&state)?;
+    let root = jobs_root()?;
+    handle.request_mutation_cancel(&operation_id);
+    let _guard = handle.lock_job(&id).await;
+    if chain_jobs::get_job(db, &id)
         .map_err(|e| ApiError::internal(format!("failed to load chain job: {e:#}")))?
-        .ok_or_else(|| not_found(&id))?;
+        .is_some()
+    {
+        let _ = cancel_chain_job_locked(handle, db, &root, &id)?;
+    }
+    Ok(StatusCode::ACCEPTED)
+}
+
+fn cancel_chain_job_locked(
+    handle: &crate::chain_job_runner::ChainJobRunnerHandle,
+    db: &MetadataDb,
+    root: &FsPath,
+    id: &str,
+) -> Result<ChainJobSummary, ApiError> {
+    let mut row = chain_jobs::get_job(db, id)
+        .map_err(|e| ApiError::internal(format!("failed to load chain job: {e:#}")))?
+        .ok_or_else(|| not_found(id))?;
     let cancelling = if row.state == ChainJobState::Running {
-        let requested = handle.request_cancel(&id);
-        row = chain_jobs::get_job(db, &id)
+        let requested = handle.request_cancel(id);
+        row = chain_jobs::get_job(db, id)
             .map_err(|e| ApiError::internal(format!("failed to reload chain job: {e:#}")))?
-            .ok_or_else(|| not_found(&id))?;
+            .ok_or_else(|| not_found(id))?;
         requested && row.state == ChainJobState::Running
     } else if row.state == ChainJobState::Queued {
         let changed = chain_jobs::try_transition(
             db,
-            &id,
+            id,
             &[ChainJobState::Queued],
             ChainJobState::Cancelled,
             None,
@@ -627,9 +713,9 @@ pub async fn cancel_chain_job(
         )
         .map_err(|e| ApiError::internal(format!("failed to cancel queued chain job: {e:#}")))?;
         if changed {
-            handle.publish_settled_state(&id, ChainJobState::Cancelled, None);
+            handle.publish_settled_state(id, ChainJobState::Cancelled, None);
         } else {
-            cancel_after_cas_loss(handle, db, &id)?;
+            cancel_after_cas_loss(handle, db, id)?;
         }
         false
     } else if settled(row.state) {
@@ -639,18 +725,12 @@ pub async fn cancel_chain_job(
     } else {
         false
     };
-    let updated = chain_jobs::get_job(db, &id)
+    let updated = chain_jobs::get_job(db, id)
         .map_err(|e| ApiError::internal(format!("failed to reload chain job: {e:#}")))?
-        .ok_or_else(|| not_found(&id))?;
-    Ok((
-        StatusCode::ACCEPTED,
-        Json({
-            let mut summary =
-                summary_for_row(&updated, read_manifest_optional(&updated, &root).as_ref());
-            summary.cancelling = cancelling && updated.state == ChainJobState::Running;
-            summary
-        }),
-    ))
+        .ok_or_else(|| not_found(id))?;
+    let mut summary = summary_for_row(&updated, read_manifest_optional(&updated, root).as_ref());
+    summary.cancelling = cancelling && updated.state == ChainJobState::Running;
+    Ok(summary)
 }
 
 /// 204; 409 CHAIN_JOB_RUNNING while running; removes job dir + row.
@@ -1389,7 +1469,11 @@ mod tests {
 
         let mut events_rx = state.events.subscribe();
         let (_status, Json(body)) = with_mold_home(home.path(), || {
-            futures::executor::block_on(create_chain_job(State(state), Json(request)))
+            futures::executor::block_on(create_chain_job(
+                State(state),
+                HeaderMap::new(),
+                Json(request),
+            ))
         })
         .unwrap();
 
@@ -1426,7 +1510,11 @@ mod tests {
         request.model = "private-checkpoint".into();
 
         let error = with_mold_home(home.path(), || {
-            futures::executor::block_on(create_chain_job(State(state), Json(request)))
+            futures::executor::block_on(create_chain_job(
+                State(state),
+                HeaderMap::new(),
+                Json(request),
+            ))
         })
         .unwrap_err();
 
@@ -1457,7 +1545,11 @@ mod tests {
         request.enable_audio = Some(true);
 
         let error = with_mold_home(home.path(), || {
-            futures::executor::block_on(create_chain_job(State(state), Json(request)))
+            futures::executor::block_on(create_chain_job(
+                State(state),
+                HeaderMap::new(),
+                Json(request),
+            ))
         })
         .unwrap_err();
 
@@ -1540,7 +1632,11 @@ mod tests {
             }
 
             let error = with_mold_home(home.path(), || {
-                futures::executor::block_on(create_chain_job(State(state.clone()), Json(request)))
+                futures::executor::block_on(create_chain_job(
+                    State(state.clone()),
+                    HeaderMap::new(),
+                    Json(request),
+                ))
             })
             .unwrap_err();
 
@@ -1596,7 +1692,11 @@ mod tests {
         });
 
         let (status, Json(created)) = with_mold_home(home.path(), || {
-            futures::executor::block_on(create_chain_job(State(state.clone()), Json(request)))
+            futures::executor::block_on(create_chain_job(
+                State(state.clone()),
+                HeaderMap::new(),
+                Json(request),
+            ))
         })
         .unwrap();
 
@@ -1662,7 +1762,11 @@ mod tests {
         request.model = "unfreezable-chain".into();
 
         let error = with_mold_home(home.path(), || {
-            futures::executor::block_on(create_chain_job(State(state), Json(request)))
+            futures::executor::block_on(create_chain_job(
+                State(state),
+                HeaderMap::new(),
+                Json(request),
+            ))
         })
         .unwrap_err();
         assert!(error
@@ -1732,6 +1836,7 @@ mod tests {
         let err = with_mold_home(home.path(), || {
             futures::executor::block_on(create_chain_job(
                 State(state),
+                HeaderMap::new(),
                 Json(req(OutputFormat::Apng)),
             ))
         })
@@ -1840,6 +1945,106 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn create_honours_a_cancel_that_arrives_before_the_mutation_request() {
+        let home = tempfile::tempdir().unwrap();
+        let db = Arc::new(Some(MetadataDb::open_in_memory().unwrap()));
+        let state = state_with(
+            db.clone(),
+            crate::chain_job_runner::ChainJobRunnerHandle::inert_for_tests(),
+        );
+        let request = freezable_amend_request(&state, home.path()).await;
+        let operation_id = uuid::Uuid::new_v4().to_string();
+
+        let error = with_mold_home(home.path(), || {
+            futures::executor::block_on(async {
+                cancel_chain_job_mutation(
+                    State(state.clone()),
+                    Path((operation_id.clone(), operation_id.clone())),
+                )
+                .await
+                .unwrap();
+                let mut headers = HeaderMap::new();
+                headers.insert(
+                    MUTATION_ID_HEADER,
+                    HeaderValue::from_str(&operation_id).unwrap(),
+                );
+                create_chain_job(State(state.clone()), headers, Json(request)).await
+            })
+        })
+        .unwrap_err();
+
+        assert_eq!(error.code, CHAIN_MUTATION_CANCELLED);
+        assert!(
+            chain_jobs::get_job(db.as_ref().as_ref().unwrap(), &operation_id)
+                .unwrap()
+                .is_none(),
+            "a pre-cancelled create must never persist or queue a job"
+        );
+    }
+
+    #[tokio::test]
+    async fn amend_honours_a_cancel_that_arrives_before_the_mutation_request() {
+        let home = tempfile::tempdir().unwrap();
+        let db = Arc::new(Some(MetadataDb::open_in_memory().unwrap()));
+        let state = state_with(
+            db.clone(),
+            crate::chain_job_runner::ChainJobRunnerHandle::inert_for_tests(),
+        );
+        let request = freezable_amend_request(&state, home.path()).await;
+        let (_status, Json(created)) = with_mold_home(home.path(), || {
+            futures::executor::block_on(create_chain_job(
+                State(state.clone()),
+                HeaderMap::new(),
+                Json(request.clone()),
+            ))
+        })
+        .unwrap();
+        let db_ref = db.as_ref().as_ref().unwrap();
+        chain_jobs::update_job_state(
+            db_ref,
+            &created.job_id,
+            ChainJobState::Completed,
+            None,
+            now_ms(),
+        )
+        .unwrap();
+        let operation_id = uuid::Uuid::new_v4().to_string();
+        let mut amended_stages = request.stages;
+        amended_stages[0].prompt = "must not be persisted".into();
+
+        let error = with_mold_home(home.path(), || {
+            futures::executor::block_on(async {
+                cancel_chain_job_mutation(
+                    State(state.clone()),
+                    Path((created.job_id.clone(), operation_id.clone())),
+                )
+                .await
+                .unwrap();
+                let mut headers = HeaderMap::new();
+                headers.insert(
+                    MUTATION_ID_HEADER,
+                    HeaderValue::from_str(&operation_id).unwrap(),
+                );
+                amend_chain_job(
+                    State(state.clone()),
+                    Path(created.job_id.clone()),
+                    headers,
+                    Json(amend_body(amended_stages)),
+                )
+                .await
+            })
+        })
+        .unwrap_err();
+
+        assert_eq!(error.code, CHAIN_MUTATION_CANCELLED);
+        let stored = chain_jobs::get_job(db_ref, &created.job_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(stored.state, ChainJobState::Completed);
+        assert!(!stored.request_json.contains("must not be persisted"));
+    }
+
+    #[tokio::test]
     async fn amend_chain_job_returns_202_with_preserved_stages_and_requeues() {
         let home = tempfile::tempdir().unwrap();
         let db = Arc::new(Some(MetadataDb::open_in_memory().unwrap()));
@@ -1852,6 +2057,7 @@ mod tests {
         let (_status, Json(created)) = with_mold_home(home.path(), || {
             futures::executor::block_on(create_chain_job(
                 State(state.clone()),
+                HeaderMap::new(),
                 Json(request.clone()),
             ))
         })
@@ -1875,6 +2081,7 @@ mod tests {
             futures::executor::block_on(amend_chain_job(
                 State(state.clone()),
                 Path(created.job_id.clone()),
+                HeaderMap::new(),
                 Json(amend_body(stages)),
             ))
         })
@@ -1907,6 +2114,7 @@ mod tests {
         let (_status, Json(created)) = with_mold_home(home.path(), || {
             futures::executor::block_on(create_chain_job(
                 State(state.clone()),
+                HeaderMap::new(),
                 Json(request.clone()),
             ))
         })
@@ -1928,6 +2136,7 @@ mod tests {
             futures::executor::block_on(amend_chain_job(
                 State(state.clone()),
                 Path(created.job_id.clone()),
+                HeaderMap::new(),
                 Json(amend_body(stages)),
             ))
         })
@@ -1966,6 +2175,7 @@ mod tests {
         let (_status, Json(created)) = with_mold_home(home.path(), || {
             futures::executor::block_on(create_chain_job(
                 State(state.clone()),
+                HeaderMap::new(),
                 Json(request.clone()),
             ))
         })
@@ -1977,6 +2187,7 @@ mod tests {
             futures::executor::block_on(amend_chain_job(
                 State(state.clone()),
                 Path(created.job_id.clone()),
+                HeaderMap::new(),
                 Json(amend_body(request.stages)),
             ))
         })
@@ -2015,6 +2226,7 @@ mod tests {
             futures::executor::block_on(amend_chain_job(
                 State(state.clone()),
                 Path(job_id.to_string()),
+                HeaderMap::new(),
                 Json(amend_body(req(OutputFormat::Mp4).stages)),
             ))
         })
@@ -2036,6 +2248,7 @@ mod tests {
         let (_status, Json(created)) = with_mold_home(home.path(), || {
             futures::executor::block_on(create_chain_job(
                 State(state.clone()),
+                HeaderMap::new(),
                 Json(request.clone()),
             ))
         })
@@ -2047,6 +2260,7 @@ mod tests {
             futures::executor::block_on(amend_chain_job(
                 State(state.clone()),
                 Path(created.job_id.clone()),
+                HeaderMap::new(),
                 Json(amend_body(stages)),
             ))
         })

--- a/crates/mold-server/src/scheduler/mod.rs
+++ b/crates/mold-server/src/scheduler/mod.rs
@@ -3553,12 +3553,26 @@ impl Coordinator {
         )
     }
 
+    #[cfg(test)]
     fn placement_preview(
         &self,
         request: &mold_core::GenerateRequest,
         copies: u32,
         prepared_inputs: &crate::execution_plan::PreparedExecutionInputs,
     ) -> mold_core::GenerationPlacementPreview {
+        self.placement_preview_cancellable(request, copies, prepared_inputs, &|| false)
+    }
+
+    fn placement_preview_cancellable(
+        &self,
+        request: &mold_core::GenerateRequest,
+        copies: u32,
+        prepared_inputs: &crate::execution_plan::PreparedExecutionInputs,
+        cancelled: &dyn Fn() -> bool,
+    ) -> mold_core::GenerationPlacementPreview {
+        if cancelled() {
+            return self.cancelled_placement_preview();
+        }
         if !(1..=64).contains(&copies) {
             return mold_core::GenerationPlacementPreview {
                 version: 1,
@@ -3601,20 +3615,52 @@ impl Coordinator {
                 missing_components: Vec::new(),
             };
         }
-        self.placement_preview_dag(request, copies, prepared_inputs)
+        self.placement_preview_dag_cancellable(request, copies, prepared_inputs, cancelled)
+    }
+
+    fn cancelled_placement_preview(&self) -> mold_core::GenerationPlacementPreview {
+        mold_core::GenerationPlacementPreview {
+            version: 1,
+            authoritative: false,
+            state_version: self.state_version,
+            plan_version: self.plan_version,
+            outcome: "temporarily_unavailable".to_string(),
+            reason: Some("placement preview cancelled".to_string()),
+            candidate: None,
+            stage_candidates: Vec::new(),
+            pending_downloads: Vec::new(),
+            missing_components: Vec::new(),
+        }
     }
 
     /// Non-mutating scheduler projection for the complete ordinary-generation
     /// DAG. Utility stages exercise this path in tests, but the public preview
     /// remains non-authoritative until their CPU/GPU execution plans and host
     /// reservations are frozen rather than dynamically selected at runtime.
+    #[cfg(test)]
     fn placement_preview_dag(
         &self,
         request: &mold_core::GenerateRequest,
         copies: u32,
         prepared_inputs: &crate::execution_plan::PreparedExecutionInputs,
     ) -> mold_core::GenerationPlacementPreview {
-        self.placement_preview_dag_for_device(request, copies, prepared_inputs, None)
+        self.placement_preview_dag_cancellable(request, copies, prepared_inputs, &|| false)
+    }
+
+    fn placement_preview_dag_cancellable(
+        &self,
+        request: &mold_core::GenerateRequest,
+        copies: u32,
+        prepared_inputs: &crate::execution_plan::PreparedExecutionInputs,
+        cancelled: &dyn Fn() -> bool,
+    ) -> mold_core::GenerationPlacementPreview {
+        self.placement_preview_dag_for_device_cancellable(
+            request,
+            copies,
+            prepared_inputs,
+            None,
+            cancelled,
+        )
     }
 
     /// Return one exact singleton timing profile for every currently eligible
@@ -3625,13 +3671,25 @@ impl Coordinator {
     /// device for arbitrary parent sizes, so it profiles each device against
     /// one immutable coordinator snapshot and leaves child-count scaling to
     /// `BatchPartitionPlanner`.
+    #[cfg(test)]
     fn batch_device_profiles(
         &self,
         request: &mold_core::GenerateRequest,
         parent_size: u32,
         prepared_inputs: &crate::execution_plan::PreparedExecutionInputs,
     ) -> anyhow::Result<Vec<mold_core::GenerationPlacementCandidate>> {
+        self.batch_device_profiles_cancellable(request, parent_size, prepared_inputs, &|| false)
+    }
+
+    fn batch_device_profiles_cancellable(
+        &self,
+        request: &mold_core::GenerateRequest,
+        parent_size: u32,
+        prepared_inputs: &crate::execution_plan::PreparedExecutionInputs,
+        cancelled: &dyn Fn() -> bool,
+    ) -> anyhow::Result<Vec<mold_core::GenerationPlacementCandidate>> {
         anyhow::ensure!(parent_size > 0, "batch parent size must be positive");
+        anyhow::ensure!(!cancelled(), "placement preview cancelled");
         let device_ids = self
             .device_snapshots()
             .into_iter()
@@ -3640,11 +3698,13 @@ impl Coordinator {
         let mut profiles = Vec::with_capacity(device_ids.len());
         let mut rejection = None;
         for device_id in device_ids {
-            let preview = self.placement_preview_dag_for_device(
+            anyhow::ensure!(!cancelled(), "placement preview cancelled");
+            let preview = self.placement_preview_dag_for_device_cancellable(
                 request,
                 1,
                 prepared_inputs,
                 Some(&device_id),
+                cancelled,
             );
             if preview.authoritative && preview.outcome == "planned" {
                 let generation_stage = preview
@@ -3682,12 +3742,30 @@ impl Coordinator {
         Ok(profiles)
     }
 
+    #[cfg(test)]
     fn placement_preview_dag_for_device(
         &self,
         request: &mold_core::GenerateRequest,
         copies: u32,
         prepared_inputs: &crate::execution_plan::PreparedExecutionInputs,
         required_device_id: Option<&str>,
+    ) -> mold_core::GenerationPlacementPreview {
+        self.placement_preview_dag_for_device_cancellable(
+            request,
+            copies,
+            prepared_inputs,
+            required_device_id,
+            &|| false,
+        )
+    }
+
+    fn placement_preview_dag_for_device_cancellable(
+        &self,
+        request: &mold_core::GenerateRequest,
+        copies: u32,
+        prepared_inputs: &crate::execution_plan::PreparedExecutionInputs,
+        required_device_id: Option<&str>,
+        cancelled: &dyn Fn() -> bool,
     ) -> mold_core::GenerationPlacementPreview {
         let empty = |outcome: &str, reason: String| mold_core::GenerationPlacementPreview {
             version: 1,
@@ -3703,6 +3781,9 @@ impl Coordinator {
         };
         if !(1..=64).contains(&copies) {
             return empty("infeasible", "copies must be between 1 and 64".to_string());
+        }
+        if cancelled() {
+            return self.cancelled_placement_preview();
         }
         if self.state.queue_pause.is_paused() {
             return empty(
@@ -3733,6 +3814,9 @@ impl Coordinator {
             })
             .collect::<BTreeMap<_, _>>();
         let (mut snapshot, _) = self.planner_snapshot(&owner_plan_cache);
+        if cancelled() {
+            return self.cancelled_placement_preview();
+        }
         let device_facts = self.device_facts_from_snapshots(&snapshot.devices);
         let config = match self.state.config.try_read() {
             Ok(config) => config,
@@ -3757,6 +3841,9 @@ impl Coordinator {
             Ok(plans) => plans,
             Err(error) => return empty("infeasible", error.to_string()),
         };
+        if cancelled() {
+            return self.cancelled_placement_preview();
+        }
         let local_expansion_model = if request.expand == Some(true) {
             let settings = config.expand.clone().with_env_overrides();
             settings.is_local().then(|| settings.model.clone())
@@ -3796,6 +3883,9 @@ impl Coordinator {
             .filter(|plan| !failed.contains(&plan.device_ordinal))
             .filter(|plan| required_device_id.is_none_or(|device_id| plan.device_id == device_id))
             .filter_map(|plan| {
+                if cancelled() {
+                    return None;
+                }
                 let worker = self.state.gpu_pool.worker_by_ordinal(plan.device_ordinal)?;
                 let key = generation_estimate_key(
                     &self.state,
@@ -3828,6 +3918,9 @@ impl Coordinator {
                 )
             })
             .collect::<Vec<_>>();
+        if cancelled() {
+            return self.cancelled_placement_preview();
+        }
         if candidates.is_empty() {
             return empty(
                 "infeasible",
@@ -3853,6 +3946,9 @@ impl Coordinator {
         let mut generation_stage_index = 0_u32;
 
         if let Some(expansion_model) = &local_expansion_model {
+            if cancelled() {
+                return self.cancelled_placement_preview();
+            }
             snapshot.work.push(self.owner_work_snapshot(
                 OwnerWorkSchedulingView {
                     id: &format!("{expansion_prefix}parent"),
@@ -3875,6 +3971,9 @@ impl Coordinator {
                 &snapshot.devices,
             ));
             rank_cursor = rank_cursor.saturating_add(1);
+            if cancelled() {
+                return self.cancelled_placement_preview();
+            }
             let expansion_plan = match self.planner.plan(&snapshot) {
                 Ok(plan) => plan,
                 Err(error) => {
@@ -3884,6 +3983,9 @@ impl Coordinator {
                     )
                 }
             };
+            if cancelled() {
+                return self.cancelled_placement_preview();
+            }
             let expansion_assignments = expansion_plan
                 .lanes
                 .iter()
@@ -3920,6 +4022,9 @@ impl Coordinator {
         }
 
         for index in 0..copies {
+            if cancelled() {
+                return self.cancelled_placement_preview();
+            }
             snapshot.work.push(
                 WorkSnapshot::new(
                     WorkId::new(format!("{generation_prefix}{index}")),
@@ -3930,6 +4035,9 @@ impl Coordinator {
             );
             rank_cursor = rank_cursor.saturating_add(1);
         }
+        if cancelled() {
+            return self.cancelled_placement_preview();
+        }
         let generation_plan = match self.planner.plan(&snapshot) {
             Ok(plan) => plan,
             Err(error) => {
@@ -3939,6 +4047,9 @@ impl Coordinator {
                 )
             }
         };
+        if cancelled() {
+            return self.cancelled_placement_preview();
+        }
         let mut selected = generation_plan
             .lanes
             .iter()
@@ -3972,6 +4083,9 @@ impl Coordinator {
                 .unwrap_or(snapshot.now_ms);
         }
         for (index, assignment) in selected.iter().enumerate() {
+            if cancelled() {
+                return self.cancelled_placement_preview();
+            }
             ready_at[index] = assignment.estimated_finish_ms;
             let confidence = confidence_by_edge
                 .get(&(
@@ -3994,6 +4108,9 @@ impl Coordinator {
 
         if let Some((upscale_model, estimated_vram_bytes)) = &post_upscale {
             for index in 0..copies {
+                if cancelled() {
+                    return self.cancelled_placement_preview();
+                }
                 snapshot.work.push(self.owner_work_snapshot(
                     OwnerWorkSchedulingView {
                         id: &format!("{upscale_prefix}{index}"),
@@ -4017,6 +4134,9 @@ impl Coordinator {
                 ));
                 rank_cursor = rank_cursor.saturating_add(1);
             }
+            if cancelled() {
+                return self.cancelled_placement_preview();
+            }
             let upscale_plan = match self.planner.plan(&snapshot) {
                 Ok(plan) => plan,
                 Err(error) => {
@@ -4026,6 +4146,9 @@ impl Coordinator {
                     )
                 }
             };
+            if cancelled() {
+                return self.cancelled_placement_preview();
+            }
             let mut upscale_assignments = upscale_plan
                 .lanes
                 .iter()
@@ -4050,6 +4173,9 @@ impl Coordinator {
                 .max()
                 .unwrap_or(predicted_finish_ms);
             for (index, assignment) in upscale_assignments.iter().enumerate() {
+                if cancelled() {
+                    return self.cancelled_placement_preview();
+                }
                 stage_candidates.push(stage_placement_candidate(
                     generation_stage_index.saturating_add(1),
                     Some(index as u32),
@@ -4060,6 +4186,10 @@ impl Coordinator {
                 ));
             }
             final_plan_version = upscale_plan.plan_version;
+        }
+
+        if cancelled() {
+            return self.cancelled_placement_preview();
         }
 
         let warm = snapshot.devices.iter().any(|device| {
@@ -4113,6 +4243,9 @@ impl Coordinator {
             .unwrap_or_default();
         let mut pending_by_identity = BTreeMap::new();
         for assignment in &selected {
+            if cancelled() {
+                return self.cancelled_placement_preview();
+            }
             for download in
                 prepared_inputs.pending_downloads_for_device(assignment.device_id.as_str())
             {
@@ -4132,12 +4265,18 @@ impl Coordinator {
             confidence = mold_core::QueueEstimateConfidence::Low;
         }
         for stage in &mut stage_candidates {
+            if cancelled() {
+                return self.cancelled_placement_preview();
+            }
             if !prepared_inputs
                 .pending_downloads_for_device(&stage.candidate.device_id)
                 .is_empty()
             {
                 stage.candidate.estimate_confidence = mold_core::QueueEstimateConfidence::Low;
             }
+        }
+        if cancelled() {
+            return self.cancelled_placement_preview();
         }
         mold_core::GenerationPlacementPreview {
             version: 1,
@@ -5258,12 +5397,18 @@ pub async fn run_scheduler_coordinator(
                             prepared_inputs,
                             reply_tx,
                         } => {
-                            let response = coordinator.placement_preview(
-                                &request,
-                                copies,
-                                &prepared_inputs,
-                            );
-                            let _ = reply_tx.send(response);
+                            // Dropping the HTTP request drops the oneshot
+                            // receiver. Do not spend scheduler time planning a
+                            // print the caller has already cancelled.
+                            if !reply_tx.is_closed() {
+                                let response = coordinator.placement_preview_cancellable(
+                                    &request,
+                                    copies,
+                                    &prepared_inputs,
+                                    &|| reply_tx.is_closed(),
+                                );
+                                let _ = reply_tx.send(response);
+                            }
                         }
                         PlacementPreviewQuery::BatchDevices {
                             request,
@@ -5271,10 +5416,17 @@ pub async fn run_scheduler_coordinator(
                             prepared_inputs,
                             reply_tx,
                         } => {
-                            let response = coordinator
-                                .batch_device_profiles(&request, parent_size, &prepared_inputs)
-                                .map_err(|error| format!("{error:#}"));
-                            let _ = reply_tx.send(response);
+                            if !reply_tx.is_closed() {
+                                let response = coordinator
+                                    .batch_device_profiles_cancellable(
+                                        &request,
+                                        parent_size,
+                                        &prepared_inputs,
+                                        &|| reply_tx.is_closed(),
+                                    )
+                                    .map_err(|error| format!("{error:#}"));
+                                let _ = reply_tx.send(response);
+                            }
                         }
                         PlacementPreviewQuery::SetQueuePaused { paused, reply_tx } => {
                             let response = coordinator.set_queue_paused_and_publish(paused);
@@ -12324,6 +12476,21 @@ mod tests {
 
         let first = coordinator.placement_preview(&request, 1, &prepared);
         assert_eq!(first.outcome, "planned", "{:?}", first.reason);
+        let cancellation_checks = std::cell::Cell::new(0_u32);
+        let cancelled_after_planning =
+            coordinator.placement_preview_cancellable(&request, 1, &prepared, &|| {
+                let next = cancellation_checks.get().saturating_add(1);
+                cancellation_checks.set(next);
+                next >= 9
+            });
+        assert_eq!(
+            cancelled_after_planning.reason.as_deref(),
+            Some("placement preview cancelled")
+        );
+        assert!(
+            cancellation_checks.get() >= 9,
+            "cancellation must be observed after generation planning starts"
+        );
         assert_eq!(
             first
                 .candidate
@@ -12896,6 +13063,45 @@ mod tests {
         let unavailable = coordinator.placement_preview(&request, 1, &prepared);
         assert_eq!(unavailable.outcome, "infeasible");
         assert!(unavailable.candidate.is_none());
+    }
+
+    #[test]
+    fn placement_preview_stops_when_the_reply_receiver_is_dropped() {
+        let pool = Arc::new(GpuPool {
+            workers: Vec::new().into(),
+        });
+        let (ingress_tx, _ingress_rx) = tokio::sync::mpsc::channel(1);
+        let state = AppState::empty(
+            mold_core::Config::default(),
+            QueueHandle::new(ingress_tx),
+            pool,
+            1,
+        );
+        let coordinator = Coordinator::with_preparer_and_memory(
+            state,
+            Arc::new(ImmediatePreparer),
+            ample_memory(),
+        );
+        let request: mold_core::GenerateRequest = serde_json::from_str(
+            r#"{"prompt":"","model":"missing","width":512,"height":512,"steps":4,"guidance":1.0,"batch_size":1}"#,
+        )
+        .unwrap();
+        let prepared = crate::execution_plan::PreparedExecutionInputs::default();
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel::<()>();
+        drop(reply_rx);
+
+        let preview = coordinator
+            .placement_preview_cancellable(&request, 1, &prepared, &|| reply_tx.is_closed());
+        assert_eq!(preview.outcome, "temporarily_unavailable");
+        assert_eq!(
+            preview.reason.as_deref(),
+            Some("placement preview cancelled")
+        );
+        assert!(coordinator
+            .batch_device_profiles_cancellable(&request, 1, &prepared, &|| reply_tx.is_closed(),)
+            .unwrap_err()
+            .to_string()
+            .contains("cancelled"));
     }
 
     #[test]

--- a/desktop/src/components/create/ComposerCard.test.ts
+++ b/desktop/src/components/create/ComposerCard.test.ts
@@ -105,7 +105,7 @@ describe("ComposerCard", () => {
     expect(missingPrompt.find("[data-test='action-blocker']").exists()).toBe(false);
   });
 
-  it("disables Generate and displays non-obvious corrective guidance", () => {
+  it("disables blocked Generate but keeps an in-flight submission cancellable", async () => {
     expect(
       mountComposer(baseForm(), {
         disabled: true,
@@ -114,11 +114,11 @@ describe("ComposerCard", () => {
         .get("[data-test='generate-button']")
         .attributes("disabled"),
     ).toBeDefined();
-    expect(
-      mountComposer(baseForm(), { submitting: true })
-        .get("[data-test='generate-button']")
-        .attributes("disabled"),
-    ).toBeDefined();
+    const submitting = mountComposer(baseForm(), { submitting: true });
+    const cancel = submitting.get("[data-test='generate-button']");
+    expect(cancel.attributes("disabled")).toBeUndefined();
+    await cancel.trigger("click");
+    expect(submitting.emitted("cancel")).toHaveLength(1);
   });
 
   it("shows a non-blocking size advisory while Generate stays enabled", () => {

--- a/desktop/src/components/create/ComposerCard.vue
+++ b/desktop/src/components/create/ComposerCard.vue
@@ -47,6 +47,7 @@ const props = withDefaults(
 
 const emit = defineEmits<{
   generate: [];
+  cancel: [];
   expand: [];
   remix: [];
   restore: [];
@@ -56,7 +57,7 @@ const emit = defineEmits<{
 
 // Disabled state and corrective guidance are intentionally separate: obvious
 // requirements such as an empty prompt do not need a persistent warning.
-const generateDisabled = computed(() => props.disabled || props.submitting);
+const generateDisabled = computed(() => props.disabled && !props.submitting);
 const placeholder = computed(() =>
   promptPlaceholder(props.form, "Describe the image you want to create…"),
 );
@@ -105,7 +106,7 @@ function onPromptInput(event: Event) {
 function onKeydown(e: KeyboardEvent) {
   if (e.key === "Enter" && primaryModifierPressed(e)) {
     e.preventDefault();
-    if (!generateDisabled.value) emit("generate");
+    if (!generateDisabled.value) submitOrCancel();
   } else if ((e.key === "e" || e.key === "E") && primaryModifierPressed(e)) {
     e.preventDefault();
     expandControl.value?.expand();
@@ -114,6 +115,11 @@ function onKeydown(e: KeyboardEvent) {
   } else if (e.key === "ArrowDown" && promptEl.value && caretOnLastLine(promptEl.value)) {
     if (cycleHistory("next")) e.preventDefault();
   }
+}
+
+function submitOrCancel() {
+  if (props.submitting) emit("cancel");
+  else emit("generate");
 }
 
 function focus() {
@@ -174,7 +180,7 @@ defineExpose({ focus, expand, record });
           data-test="generate-button"
           class="ms-composer__generate"
           :disabled="generateDisabled"
-          @click="emit('generate')"
+          @click="submitOrCancel"
         >
           <Icon name="sparkle" :size="16" />
           {{ buttonLabel }}

--- a/desktop/src/components/create/SequenceComposer.test.ts
+++ b/desktop/src/components/create/SequenceComposer.test.ts
@@ -146,6 +146,17 @@ describe("SequenceComposer — active clip editor", () => {
 });
 
 describe("SequenceComposer — footer", () => {
+  it("keeps the preparing action responsive and emits cancel", async () => {
+    seedDraft();
+    const wrapper = mountComposer({ submitting: true });
+    const button = wrapper.get("[data-test='generate-sequence']");
+    expect(button.attributes("disabled")).toBeUndefined();
+    expect(button.text()).toContain("Cancel · Preparing sequence");
+    await button.trigger("click");
+    expect(wrapper.emitted("cancel")).toHaveLength(1);
+    expect(wrapper.emitted("submit")).toBeUndefined();
+  });
+
   it("discards an in-flight validation when the rendering host changes", async () => {
     let resolveValidation!: (value: Awaited<ReturnType<typeof validateChain>>) => void;
     validateChainMock.mockReturnValue(

--- a/desktop/src/components/create/SequenceComposer.vue
+++ b/desktop/src/components/create/SequenceComposer.vue
@@ -74,10 +74,17 @@ const props = withDefaults(
 const emit = defineEmits<{
   /** Generate sequence / Update sequence (create vs amend is the parent's call). */
   submit: [];
+  /** Stop source preparation / placement before the sequence is queued. */
+  cancel: [];
   /** Edit session: submit the current clips as a NEW job instead of amending. */
   duplicate: [];
   "play-clip": [clipId: string];
 }>();
+
+function submitOrCancel() {
+  if (props.submitting) emit("cancel");
+  else emit("submit");
+}
 
 const draft = useSequenceDraftStore();
 const hosts = useHostsStore();
@@ -650,10 +657,16 @@ async function copyToml() {
         type="button"
         data-test="generate-sequence"
         class="ms-seqbench__generate"
-        :disabled="disabledReason !== null || submitting"
-        @click="submit"
+        :disabled="disabledReason !== null && !submitting"
+        @click="submitOrCancel"
       >
-        {{ submitting ? "Starting…" : draft.editing ? "Update sequence" : "Generate sequence" }}
+        {{
+          submitting
+            ? "Cancel · Preparing sequence…"
+            : draft.editing
+              ? "Update sequence"
+              : "Generate sequence"
+        }}
       </button>
     </div>
 

--- a/desktop/src/lib/preparedExpansion.test.ts
+++ b/desktop/src/lib/preparedExpansion.test.ts
@@ -207,12 +207,18 @@ describe("prepared expansion lifecycle", () => {
   it("lets only the newest request apply and invalidates a discarded request", () => {
     const guard = new PreparationRequestGuard();
     const first = guard.begin();
+    const firstSignal = guard.signalFor(first);
     const second = guard.begin();
+    const secondSignal = guard.signalFor(second);
     expect(guard.isCurrent(first)).toBe(false);
+    expect(firstSignal.aborted).toBe(true);
     expect(guard.isCurrent(second)).toBe(true);
+    expect(secondSignal.aborted).toBe(false);
 
     guard.invalidate();
     expect(guard.isCurrent(second)).toBe(false);
+    expect(secondSignal.aborted).toBe(true);
+    expect(() => guard.signalFor(second)).toThrow("no longer current");
   });
 
   it("applies prepared-style stale checks to a frozen quick expansion route", () => {

--- a/desktop/src/lib/preparedExpansion.ts
+++ b/desktop/src/lib/preparedExpansion.ts
@@ -289,14 +289,26 @@ export function quickExpansionRouteIsCurrent(
 /** Monotonic guard used to reject late refreshes and discarded requests. */
 export class PreparationRequestGuard {
   private token = 0;
+  private controller: AbortController | null = null;
 
   begin(): number {
+    this.controller?.abort(new Error("superseded"));
     this.token += 1;
+    this.controller = new AbortController();
     return this.token;
   }
 
   invalidate(): void {
+    this.controller?.abort(new Error("cancelled"));
+    this.controller = null;
     this.token += 1;
+  }
+
+  signalFor(token: number): AbortSignal {
+    if (token !== this.token || !this.controller) {
+      throw new Error("request token is no longer current");
+    }
+    return this.controller.signal;
   }
 
   isCurrent(token: number): boolean {

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -456,7 +456,7 @@ describe("MobileApp sequence generation", () => {
     expect(wrapper.find("[data-test='mobile-quick-expansion-stale']").exists()).toBe(true);
   });
 
-  it("acknowledges a tap through placement preview and blocks duplicate submission", async () => {
+  it("lets the user cancel a placement preview before anything is queued", async () => {
     const preview = deferred<ReturnType<typeof plannedPlacement>>();
     previewGenerationPlacement.mockReturnValueOnce(preview.promise);
     wrapper = mountMobileApp();
@@ -467,15 +467,18 @@ describe("MobileApp sequence generation", () => {
     await vi.waitFor(() => expect(previewGenerationPlacement).toHaveBeenCalledTimes(1));
 
     const button = wrapper.get("[data-test='mobile-develop-button']");
-    expect(button.text()).toBe("Checking placement…");
-    expect(button.attributes("disabled")).toBe("");
+    expect(button.text()).toBe("Cancel · Checking placement…");
+    expect(button.attributes("disabled")).toBeUndefined();
     await button.trigger("click");
     expect(previewGenerationPlacement).toHaveBeenCalledTimes(1);
     expect(openStreams).toHaveLength(0);
 
+    const previewOptions = previewGenerationPlacement.mock.calls[0]?.[3];
+    expect(previewOptions?.signal?.aborted).toBe(true);
+
     preview.resolve(plannedPlacement());
     await flushPromises();
-    expect(openStreams).toHaveLength(1);
+    expect(openStreams).toHaveLength(0);
     expect(button.text()).toContain("Develop print");
   });
 
@@ -901,7 +904,12 @@ describe("MobileApp sequence generation", () => {
     });
     await flushPromises();
 
-    expect(previewChainPlacement).toHaveBeenCalledWith(target, expect.anything());
+    expect(previewChainPlacement).toHaveBeenCalledWith(
+      target,
+      expect.anything(),
+      1,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
     expect(apiJsonTo).toHaveBeenCalledWith(
       target,
       "/api/chain-jobs",
@@ -925,6 +933,79 @@ describe("MobileApp sequence generation", () => {
     });
     expect(recovery).not.toContain(target.apiKey);
     expect(wrapper.get("[data-test='mobile-sequence-job']").text()).toContain("queued");
+  });
+
+  it("cancels the exact sequence when cancellation arrives before its id", async () => {
+    const sequenceModel = {
+      ...model,
+      name: "ltx-video-0.9.8-2b-distilled:bf16",
+      family: "ltx-video",
+      default_steps: 7,
+      default_guidance: 1,
+    };
+    localStorage.setItem("mold.mobile.create-mode.v1", "sequence");
+    let finishCreate!: (value: { job_id: string }) => void;
+    apiJsonTo.mockImplementation((_target: unknown, path: string, init?: RequestInit) => {
+      if (path === "/api/status") return Promise.resolve(status);
+      if (path === "/api/models") return Promise.resolve([sequenceModel]);
+      if (path === "/api/capabilities") return Promise.resolve({});
+      if (path.startsWith("/api/capabilities/chain-limits")) {
+        return Promise.resolve({
+          model: sequenceModel.name,
+          frames_per_clip_cap: 97,
+          frames_per_clip_recommended: 97,
+          max_stages: 8,
+          max_total_frames: 777,
+          fade_frames_max: 32,
+          transition_modes: ["smooth", "cut", "fade"],
+          quantization_family: "bf16",
+          supports_audio: false,
+        });
+      }
+      if (path === "/api/chain-jobs" && init?.method === "POST") {
+        return new Promise((resolve) => (finishCreate = resolve));
+      }
+      return Promise.reject(new Error(`Unexpected API path: ${path}`));
+    });
+    previewChainPlacement.mockResolvedValue({
+      ...plannedPlacement(),
+      authoritative: false,
+      outcome: "unsupported",
+      candidate: null,
+    });
+    wrapper = mountMobileApp();
+    await flushPromises();
+    const prompts = wrapper.findAll("[data-test='mobile-sequence-clip'] textarea");
+    await prompts[0]!.setValue("opening");
+    await prompts[1]!.setValue("ending");
+
+    await wrapper.get("[data-test='mobile-generate-sequence']").trigger("click");
+    await vi.waitFor(() => expect(finishCreate).toBeTypeOf("function"));
+    const create = apiJsonTo.mock.calls.find(
+      (call) => call[1] === "/api/chain-jobs" && (call[2] as RequestInit)?.method === "POST",
+    );
+    expect((create?.[2] as RequestInit).signal).toBeUndefined();
+    const operationId = new Headers((create?.[2] as RequestInit).headers).get(
+      "x-mold-operation-id",
+    );
+    expect(operationId).toMatch(/^[0-9a-f-]{36}$/);
+    const cancel = wrapper.get("[data-test='mobile-generate-sequence']");
+    expect(cancel.text()).toContain("Cancel");
+    await cancel.trigger("click");
+    await vi.waitFor(() =>
+      expect(apiFetchTo).toHaveBeenCalledWith(
+        target,
+        `/api/chain-jobs/${operationId}/operations/${operationId}/cancel`,
+        { method: "POST", keepalive: true },
+      ),
+    );
+    finishCreate({ job_id: "late-sequence" });
+    await flushPromises();
+
+    expect(apiFetchTo).toHaveBeenCalledWith(target, "/api/chain-jobs/late-sequence/cancel", {
+      method: "POST",
+    });
+    expect(localStorage.getItem("mold.mobile.sequence-job.v1")).toBeNull();
   });
 
   it("refuses recovery when a saved server identity cannot be verified", async () => {
@@ -2443,6 +2524,7 @@ describe("MobileApp generation queue", () => {
       target,
       expect.objectContaining({ batch_size: 1 }),
       3,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
     expect(wrapper.findAll("[data-test='mobile-generation-job']")).toHaveLength(3);
     expect(document.activeElement).toBe(fieldControl("Prompt").element);
@@ -2502,6 +2584,7 @@ describe("MobileApp generation queue", () => {
         target,
         expect.objectContaining({ batch_size: 1 }),
         count,
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
       );
 
       apiJsonTo.mockImplementation((_target: unknown, path: string) => {

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -26,6 +26,7 @@ import { remixPrompt } from "../lib/api/remix";
 import { summarizeStatusGpuMemory } from "../lib/api/gpuStatus";
 import { SourceFitPreprocessCache } from "@ui/lib/sourceFitPreprocessCache";
 import { createUuid } from "@studio/lib/id";
+import { confirmCancellation } from "@studio/lib/cancellationRetry";
 import { filterRestrictedModels, modelAccessRestrictionFor } from "@studio/lib/modelAccess";
 import { expansionTaskForRequest } from "@studio/lib/expandTask";
 import { effectiveGenerationRecipe } from "@studio/lib/generationProfile";
@@ -573,6 +574,7 @@ const loadingModels = ref(false);
 const modelLoadError = ref("");
 const sequenceJob = ref<ChainJobDetail | null>(null);
 const sequenceStarting = ref(false);
+let sequenceCancellationRequest: (() => Promise<unknown>) | null = null;
 const sequenceError = ref("");
 const sequenceProgress = ref<{ step: number; total: number } | null>(null);
 const chainLimits = ref<ChainLimits | null>(null);
@@ -677,6 +679,7 @@ const quickExpansionNegative = ref<{ before: string; baked: string } | null>(nul
 const preparedSubmitting = ref(false);
 const preparationGuard = new PreparationRequestGuard();
 const submissionGuard = new PreparationRequestGuard();
+const sequenceSubmissionGuard = new PreparationRequestGuard();
 let expansionPullRequestId = 0;
 let expansionRecoveryId = 0;
 let submissionUiId = 0;
@@ -1512,9 +1515,7 @@ const developBlockerReason = computed<string | null>(() => {
   if (!parameterValid.value) return "Open Advanced and correct the highlighted settings.";
   return null;
 });
-const developDisabled = computed(
-  () => promptMissing.value || developBlockerReason.value !== null || preparingGeneration.value,
-);
+const developDisabled = computed(() => promptMissing.value || developBlockerReason.value !== null);
 const estimateRequest = computed(() => {
   if (!form.model) return null;
   return buildGenerationEstimateRequest(buildRequest(form), form.family);
@@ -1890,8 +1891,8 @@ const resultPreviewError = computed(() => {
 const developButtonLabel = computed(() =>
   generationSubmissionPhase.value
     ? generationSubmissionPhase.value === "placement"
-      ? "Checking placement…"
-      : "Preparing source…"
+      ? "Cancel · Checking placement…"
+      : "Cancel · Preparing source…"
     : `${form.batchSize > 1 ? `Develop ${form.batchSize} prints` : "Develop print"}${
         queuedJobs.value.length > 0 ? ` (+${queuedJobs.value.length} queued)` : ""
       }`,
@@ -2850,6 +2851,7 @@ async function routeAutomaticGeneration(options: {
   subject: "print" | "sequence";
   requireAuthoritative: boolean;
   isCurrent?: () => boolean;
+  signal?: AbortSignal;
 }): Promise<MobileAutomaticRoute> {
   const isCurrent = options.isCurrent ?? (() => true);
   const { hosts: candidates, error } = automaticRoutingCandidates(options.model, options.family);
@@ -2863,9 +2865,13 @@ async function routeAutomaticGeneration(options: {
   const firstPlanned = new Promise<void>((resolve) => (resolveFirstPlanned = resolve));
   candidates.forEach((host, index) => {
     void (async () => {
+      const controller = controllers[index]!;
+      const abortFromCaller = () => controller.abort(options.signal?.reason);
+      if (options.signal?.aborted) abortFromCaller();
+      else options.signal?.addEventListener("abort", abortFromCaller, { once: true });
       const started = performance.now();
       const elapsed = () => Math.max(0, performance.now() - started);
-      const probeOptions = { signal: controllers[index]!.signal };
+      const probeOptions = { signal: controller.signal };
       // Frozen before the request leaves: the winner carries this snapshot, so
       // a URL, key, or instance that changed mid-flight is caught by the
       // caller's connection fence instead of silently replacing the endpoint
@@ -2902,6 +2908,7 @@ async function routeAutomaticGeneration(options: {
             (probeError.status === 404 || probeError.status === 405),
         });
       } finally {
+        options.signal?.removeEventListener("abort", abortFromCaller);
         pending -= 1;
         if (pending === 0) resolveAllSettled();
       }
@@ -2978,6 +2985,10 @@ async function routeAutomaticGeneration(options: {
 }
 
 async function submitMobileSequence(): Promise<void> {
+  if (sequenceStarting.value) {
+    cancelMobileSequenceSubmission();
+    return;
+  }
   const automatic = automaticRouting.value;
   // Under an automatic policy the machine is provisional until the placement
   // fan-out answers; source fitting only ever uses it for an optional upscale,
@@ -2998,7 +3009,7 @@ async function submitMobileSequence(): Promise<void> {
     return;
   }
   const entry = selectedGenerationModel.value;
-  if (!initialHost || !entry || sequenceStarting.value) return;
+  if (!initialHost || !entry) return;
   let host: MobileHost = initialHost;
   let target = { ...mobileHostTarget(host) };
   let frozenRoute: HostRoute = {
@@ -3017,10 +3028,15 @@ async function submitMobileSequence(): Promise<void> {
   const enableAudio = draft.enableAudio;
   const motionTailFrames = sequenceMotionTail.value;
   sequenceStarting.value = true;
+  sequenceCancellationRequest = null;
+  const token = sequenceSubmissionGuard.begin();
+  const signal = sequenceSubmissionGuard.signalFor(token);
+  const isCurrent = () => sequenceSubmissionGuard.isCurrent(token) && !signal.aborted;
   sequenceError.value = "";
   try {
     // Stale limits would mis-gate audio and frame caps for the routed host.
     if (!chainLimits.value || chainLimits.value.model !== entry.name) await loadChainLimits();
+    if (!isCurrent()) return;
     requestForm.sourceImage = openingSnapshot?.base64 ?? null;
     requestForm.maskImage = null;
     if (requestForm.sourceImage) {
@@ -3034,10 +3050,11 @@ async function submitMobileSequence(): Promise<void> {
         {
           ops: domCanvasOps,
           cache: sourceFitCache,
-          upscale: (image, model) => upscaleImage({ image, model, target }),
+          upscale: (image, model) => upscaleImage({ image, model, target, signal }),
           onStatus: setGenerationStatus,
         },
       );
+      if (!isCurrent()) return;
       requestForm.sourceImage = result.source;
     }
     const openingImage = openingSnapshot
@@ -3059,6 +3076,8 @@ async function submitMobileSequence(): Promise<void> {
         family: form.family,
         subject: "sequence",
         requireAuthoritative: false,
+        isCurrent,
+        signal,
       });
       if (routed.kind === "abandoned") return;
       if (routed.kind === "error") throw new Error(routed.message);
@@ -3074,6 +3093,8 @@ async function submitMobileSequence(): Promise<void> {
         preview = await previewChainPlacement(
           target,
           request as unknown as Record<string, unknown>,
+          1,
+          { signal },
         );
       } catch (error) {
         if (error instanceof ApiError && (error.status === 404 || error.status === 405)) {
@@ -3084,6 +3105,7 @@ async function submitMobileSequence(): Promise<void> {
       }
     }
     const classification: string = classifyPlacementPreview(preview);
+    if (!isCurrent()) return;
     if (!legacyUnsupported && classification !== "unsupported" && classification !== "planned") {
       throw new Error(mobilePlacementFailure(preview, host.name, "sequence"));
     }
@@ -3093,21 +3115,61 @@ async function submitMobileSequence(): Promise<void> {
     if (!sameFrozenHost(frozenRoute, fenceHost)) {
       throw new Error("The selected host changed while checking this sequence.");
     }
+    const operationId = createUuid();
+    sequenceCancellationRequest = () =>
+      apiFetchTo(
+        target,
+        `/api/chain-jobs/${encodeURIComponent(operationId)}/operations/${encodeURIComponent(operationId)}/cancel`,
+        { method: "POST", keepalive: true },
+      );
     const response = await apiJsonTo<CreateChainJobResponse>(target, "/api/chain-jobs", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        "x-mold-operation-id": operationId,
+      },
       body: JSON.stringify(request),
     });
+    if (!isCurrent()) {
+      await apiFetchTo(target, `/api/chain-jobs/${encodeURIComponent(response.job_id)}/cancel`, {
+        method: "POST",
+      }).catch(() => {});
+      return;
+    }
     persistSequenceRecovery(host, response.job_id);
     watchSequenceJob(host.id, target, response.job_id, {
       model: entry.name,
       stageCount: clips.length,
     });
   } catch (error) {
+    if (!isCurrent()) return;
     sequenceError.value = describeTransportError(error, host.name);
   } finally {
-    sequenceStarting.value = false;
+    if (sequenceSubmissionGuard.isCurrent(token)) {
+      sequenceStarting.value = false;
+      sequenceCancellationRequest = null;
+    }
   }
+}
+
+function cancelMobileSequenceSubmission(): void {
+  if (!sequenceStarting.value) return;
+  sequenceSubmissionGuard.invalidate();
+  const cancellation = sequenceCancellationRequest;
+  sequenceCancellationRequest = null;
+  sequenceStarting.value = false;
+  sequenceError.value = "";
+  if (!cancellation) {
+    setGenerationStatus("Sequence preparation cancelled — nothing was queued");
+    return;
+  }
+  setGenerationStatus("Cancelling sequence creation…");
+  void confirmCancellation(cancellation)
+    .then(() => setGenerationStatus("Sequence creation cancelled — nothing was queued"))
+    .catch(() => {
+      sequenceError.value = "Cancellation could not be confirmed. Check the queue before retrying.";
+      setGenerationStatus(sequenceError.value);
+    });
 }
 
 async function cancelMobileSequence(): Promise<void> {
@@ -4306,6 +4368,7 @@ async function prepareGenerationRequest(
   target: ApiTarget,
   draft: GenerateForm,
   isCurrent: () => boolean = () => true,
+  signal?: AbortSignal,
 ) {
   const draftCaps = generationCapabilitiesForFamily(
     draft.family,
@@ -4329,6 +4392,7 @@ async function prepareGenerationRequest(
               image,
               model,
               target,
+              ...(signal ? { signal } : {}),
               onProgress: (message) => {
                 if (isCurrent()) setGenerationStatus(message);
               },
@@ -4359,6 +4423,7 @@ async function prepareGenerationRequest(
             image,
             model,
             target,
+            ...(signal ? { signal } : {}),
             onProgress: (message) => {
               if (isCurrent()) setGenerationStatus(message);
             },
@@ -4391,6 +4456,7 @@ async function prepareGenerationRequest(
             image,
             model,
             target,
+            ...(signal ? { signal } : {}),
             onProgress: (message) => {
               if (isCurrent()) setGenerationStatus(message);
             },
@@ -4577,6 +4643,7 @@ async function generate(): Promise<void> {
   const guardedSubmission = !!preparedSubmission || !!quickSubmission;
   const liveFormIdentity = guardedSubmission ? JSON.stringify(cloneGenerateForm(form)) : "";
   const token = submissionGuard.begin();
+  const submitSignal = submissionGuard.signalFor(token);
   const uiId = ++submissionUiId;
   const ownsPreparedSubmission = () =>
     !unmounted &&
@@ -4595,7 +4662,12 @@ async function generate(): Promise<void> {
   generationSubmissionPhase.value = "preparing";
   preparedSubmitting.value = !!preparedSubmission;
   try {
-    request = await prepareGenerationRequest(target, draft, () => submissionGuard.isCurrent(token));
+    request = await prepareGenerationRequest(
+      target,
+      draft,
+      () => submissionGuard.isCurrent(token),
+      submitSignal,
+    );
     if (request.source_image && originalSource) {
       void persistGenerationSourceMedia(request.source_image, originalSource);
     }
@@ -4703,6 +4775,7 @@ async function generate(): Promise<void> {
       subject: "print",
       requireAuthoritative: requireAuthoritativePlacement,
       isCurrent: () => submissionGuard.isCurrent(token),
+      signal: submitSignal,
     });
     if (routed.kind === "abandoned") {
       releasePreparedSubmission();
@@ -4723,8 +4796,12 @@ async function generate(): Promise<void> {
     try {
       placement =
         chainRouting.kind === "chain"
-          ? await previewChainPlacement(target, previewRequest, batchSize)
-          : await previewGenerationPlacement(target, previewRequest, batchSize);
+          ? await previewChainPlacement(target, previewRequest, batchSize, {
+              signal: submitSignal,
+            })
+          : await previewGenerationPlacement(target, previewRequest, batchSize, {
+              signal: submitSignal,
+            });
     } catch (error) {
       if (!submissionGuard.isCurrent(token)) {
         releasePreparedSubmission();
@@ -4968,6 +5045,17 @@ async function cancelGeneration(job: Job): Promise<void> {
     setGenerationStatus(describeTransportError(error, job.hostLabel), true);
     generationAnnouncement.value = `Cancellation failed. ${progress.value}`;
   }
+}
+
+function cancelGenerationSubmission(): void {
+  if (!preparingGeneration.value) return;
+  submissionGuard.invalidate();
+  submissionUiId += 1;
+  preparingGeneration.value = false;
+  preparedSubmitting.value = false;
+  generationSubmissionPhase.value = null;
+  setGenerationStatus("Cancelled before generation started");
+  generationAnnouncement.value = "Generation planning cancelled. Nothing was queued.";
 }
 
 function renewGeneratedResult(force: boolean): void {
@@ -7346,6 +7434,12 @@ onBeforeUnmount(() => {
   }
   preparationGuard.invalidate();
   submissionGuard.invalidate();
+  sequenceSubmissionGuard.invalidate();
+  const sequenceCancellation = sequenceCancellationRequest;
+  sequenceCancellationRequest = null;
+  if (sequenceCancellation) {
+    void confirmCancellation(sequenceCancellation).catch(() => {});
+  }
   submissionUiId += 1;
   recoveryRetryId += 1;
   expansionPullRequestId += 1;
@@ -7632,6 +7726,7 @@ onBeforeUnmount(() => {
               :camera-controls-loaded="cameraControlsLoaded"
               :camera-unsupported-reason="cameraUnsupportedReason"
               @submit="submitMobileSequence"
+              @cancel="cancelMobileSequenceSubmission"
             >
               <template #settings>
                 <MobileSharedParams
@@ -7832,6 +7927,7 @@ onBeforeUnmount(() => {
               @refresh="replacePreparedPrompts(false)"
               @discard="discardPreparedBatch"
               @generate="generate"
+              @cancel="cancelGenerationSubmission"
             />
             <p
               v-if="mobileMediaBudgetError"
@@ -9113,7 +9209,7 @@ onBeforeUnmount(() => {
         type="button"
         :disabled="developDisabled"
         data-test="mobile-develop-button"
-        @click="generate"
+        @click="preparingGeneration ? cancelGenerationSubmission() : generate()"
       >
         {{ developButtonLabel }}
       </button>

--- a/desktop/src/mobile/MobilePreparedExpansionBatch.vue
+++ b/desktop/src/mobile/MobilePreparedExpansionBatch.vue
@@ -17,6 +17,7 @@ const emit = defineEmits<{
   refresh: [];
   discard: [];
   generate: [];
+  cancel: [];
 }>();
 
 const root = ref<HTMLElement | null>(null);
@@ -64,6 +65,11 @@ function requestReplacement(kind: "refresh" | "regenerate"): void {
   if (confirming.value) return;
   if (kind === "refresh") emit("refresh");
   else emit("regenerate");
+}
+
+function submitOrCancel(): void {
+  if (props.submitting) emit("cancel");
+  else emit("generate");
 }
 
 async function keep(): Promise<void> {
@@ -270,10 +276,14 @@ watch(
         type="button"
         class="primary-button mobile-touch-action"
         data-test="mobile-develop-prepared"
-        :disabled="preparing || submitting || stale || !valid || !!confirming"
-        @click="emit('generate')"
+        :disabled="preparing || stale || !valid || !!confirming"
+        @click="submitOrCancel"
       >
-        {{ submitting ? "Queueing variations…" : `Develop ${batch.prompts.length} variations` }}
+        {{
+          submitting
+            ? "Cancel · Planning variations…"
+            : `Develop ${batch.prompts.length} variations`
+        }}
       </button>
     </footer>
   </section>

--- a/desktop/src/mobile/MobileSequenceComposer.test.ts
+++ b/desktop/src/mobile/MobileSequenceComposer.test.ts
@@ -155,6 +155,11 @@ describe("MobileSequenceComposer clips", () => {
       (wrapper!.get("[data-test='mobile-sequence-source-fit']").element as HTMLSelectElement)
         .disabled,
     ).toBe(true);
+    const button = wrapper!.get("[data-test='mobile-generate-sequence']");
+    expect(button.attributes("disabled")).toBeUndefined();
+    expect(button.text()).toContain("Cancel · Preparing sequence");
+    await button.trigger("click");
+    expect(wrapper!.emitted("cancel")).toHaveLength(1);
   });
 
   it("renders the shared draft's clips instead of private component state", async () => {

--- a/desktop/src/mobile/MobileSequenceComposer.vue
+++ b/desktop/src/mobile/MobileSequenceComposer.vue
@@ -87,7 +87,12 @@ const props = withDefaults(
   },
 );
 
-const emit = defineEmits<{ submit: [] }>();
+const emit = defineEmits<{ submit: []; cancel: [] }>();
+
+function submitOrCancel(): void {
+  if (props.submitting) emit("cancel");
+  else emit("submit");
+}
 
 const draft = useSequenceDraftStore();
 const guidanceCaps = computed(() =>
@@ -298,11 +303,6 @@ function removeClip(id: string): void {
   draft.removeClip(id);
 }
 
-function submit(): void {
-  if (locked.value || blockingReason.value) return;
-  emit("submit");
-}
-
 function setOpeningImage(image: MobilePickedImage): void {
   draft.openingImage = { filename: image.filename, base64: image.base64 };
   props.form.sourceFit = coerceSourceFitForMaskless(props.form.sourceFit);
@@ -496,10 +496,10 @@ function sourceImageMime(filename: string): string {
       class="primary-button mobile-sequence-generate"
       type="button"
       data-test="mobile-generate-sequence"
-      :disabled="locked || !!blockingReason"
-      @click="submit"
+      :disabled="(locked || !!blockingReason) && !submitting"
+      @click="submitOrCancel"
     >
-      {{ submitting ? "Starting…" : "Generate sequence" }}
+      {{ submitting ? "Cancel · Preparing sequence…" : "Generate sequence" }}
     </button>
 
     <MobileSeamSheet

--- a/desktop/src/stores/chainJobs.ts
+++ b/desktop/src/stores/chainJobs.ts
@@ -32,9 +32,12 @@ const POLL_INTERVAL_MS = 10_000;
 
 const isActive = (job: ChainJobSummary) => job.state === "running" || job.state === "queued";
 
-const jsonInit = (body: unknown): RequestInit => ({
+const jsonInit = (body: unknown, operationId?: string): RequestInit => ({
   method: "POST",
-  headers: { "Content-Type": "application/json" },
+  headers: {
+    "Content-Type": "application/json",
+    ...(operationId ? { "x-mold-operation-id": operationId } : {}),
+  },
   body: JSON.stringify(body),
 });
 
@@ -115,9 +118,18 @@ export const useChainJobsStore = defineStore("chainJobs", {
         this.pollTimer = null;
       }
     },
-    async create(hostId: string, req: ChainRequestWire, frozenTarget?: ApiTarget): Promise<string> {
+    async create(
+      hostId: string,
+      req: ChainRequestWire,
+      frozenTarget?: ApiTarget,
+      operationId?: string,
+    ): Promise<string> {
       const target = frozenTarget ?? this.targetFor(hostId);
-      const res = await apiJsonTo<CreateChainJobResponse>(target, "/api/chain-jobs", jsonInit(req));
+      const res = await apiJsonTo<CreateChainJobResponse>(
+        target,
+        "/api/chain-jobs",
+        jsonInit(req, operationId),
+      );
       await this.fetchHost(hostId);
       this.watch(hostId, res.job_id);
       return res.job_id;
@@ -178,12 +190,25 @@ export const useChainJobsStore = defineStore("chainJobs", {
       await this.fetchHost(hostId);
       this.watch(hostId, jobId);
     },
-    async cancel(hostId: string, jobId: string) {
-      const target = this.targetFor(hostId);
+    async cancel(hostId: string, jobId: string, frozenTarget?: ApiTarget) {
+      const target = frozenTarget ?? this.targetFor(hostId);
       await apiFetchTo(target, `/api/chain-jobs/${encodeURIComponent(jobId)}/cancel`, {
         method: "POST",
       });
       await this.fetchHost(hostId);
+    },
+    async cancelMutation(
+      hostId: string,
+      jobId: string,
+      operationId: string,
+      frozenTarget?: ApiTarget,
+    ) {
+      const target = frozenTarget ?? this.targetFor(hostId);
+      await apiFetchTo(
+        target,
+        `/api/chain-jobs/${encodeURIComponent(jobId)}/operations/${encodeURIComponent(operationId)}/cancel`,
+        { method: "POST", keepalive: true },
+      );
     },
     async remove(hostId: string, jobId: string) {
       const target = this.targetFor(hostId);
@@ -210,12 +235,13 @@ export const useChainJobsStore = defineStore("chainJobs", {
       jobId: string,
       req: AmendRequest,
       frozenTarget?: ApiTarget,
+      operationId?: string,
     ): Promise<AmendResponse> {
       const target = frozenTarget ?? this.targetFor(hostId);
       const outcome = await apiJsonTo<AmendResponse>(
         target,
         `/api/chain-jobs/${encodeURIComponent(jobId)}/amend`,
-        jsonInit(req),
+        jsonInit(req, operationId),
       );
       await this.fetchHost(hostId);
       this.watch(hostId, jobId);

--- a/desktop/src/stores/hosts.ts
+++ b/desktop/src/stores/hosts.ts
@@ -12,6 +12,7 @@ import {
   previewRequestForSiblingFanout,
   requiresAuthoritativePlacement,
   type MissingModelPlacement,
+  type PlacementPreviewOptions,
   type PlacementMissingComponent,
 } from "@studio/api/generationPlacement";
 import { ApiError, apiJsonTo, type ApiTarget } from "../lib/api/client";
@@ -635,6 +636,7 @@ export const useHostsStore = defineStore("hosts", {
       selection: string | null,
       request: GenerateRequest | ChainRequest | AutoChainRequest,
       copies = 1,
+      options: PlacementPreviewOptions = {},
     ): Promise<FeasibleRouteResult> {
       const requireAuthoritative = requiresAuthoritativePlacement(
         request as unknown as Record<string, unknown>,
@@ -778,6 +780,10 @@ export const useHostsStore = defineStore("hosts", {
         const firstPlanned = new Promise<void>((resolve) => (resolveFirstPlanned = resolve));
         candidates.forEach((host, index) => {
           void (async () => {
+            const controller = controllers[index]!;
+            const abortFromCaller = () => controller.abort(options.signal?.reason);
+            if (options.signal?.aborted) abortFromCaller();
+            else options.signal?.addEventListener("abort", abortFromCaller, { once: true });
             const started = performance.now();
             try {
               const target = { baseUrl: host.baseUrl!, apiKey: host.apiKey };
@@ -790,7 +796,7 @@ export const useHostsStore = defineStore("hosts", {
                         copies,
                       ),
                       copies,
-                      { signal: controllers[index]!.signal },
+                      { signal: controller.signal },
                     )
                   : await previewGenerationPlacement(
                       target,
@@ -799,7 +805,7 @@ export const useHostsStore = defineStore("hosts", {
                         copies,
                       ),
                       copies,
-                      { signal: controllers[index]!.signal },
+                      { signal: controller.signal },
                     );
               probes.push({
                 host,
@@ -822,6 +828,7 @@ export const useHostsStore = defineStore("hosts", {
                 roundTripMs: Math.max(0, performance.now() - started),
               });
             } finally {
+              options.signal?.removeEventListener("abort", abortFromCaller);
               pendingProbes -= 1;
               if (pendingProbes === 0) resolveAllProbes();
             }
@@ -1058,8 +1065,9 @@ export const useHostsStore = defineStore("hosts", {
       selection: string | null,
       request: GenerateRequest | ChainRequest | AutoChainRequest,
       copies = 1,
+      options: PlacementPreviewOptions = {},
     ): Promise<HostRoute | null> {
-      const result = await this.resolveFeasible(selection, request, copies);
+      const result = await this.resolveFeasible(selection, request, copies, options);
       return result.kind === "route" ? result.route : null;
     },
     /** Pull queue depth/capacity from every live host. */

--- a/desktop/src/views/GenerateView.layout.test.ts
+++ b/desktop/src/views/GenerateView.layout.test.ts
@@ -87,7 +87,7 @@ describe("GenerateView layout", () => {
   // without taking over the composer with corrective guidance.
   it("keeps Generate gating separate from visible blocker guidance", () => {
     expect(tagFor(composerCardSource, "generate-button")).toContain(':disabled="generateDisabled"');
-    expect(composerCardSource).toContain("props.disabled || props.submitting");
+    expect(composerCardSource).toContain("props.disabled && !props.submitting");
     expect(composerCardSource).toContain('<ActionBlocker v-if="disabledReason"');
     expect(composerCardSource).not.toContain("!form.prompt.trim() || !form.model");
 

--- a/desktop/src/views/GenerateView.prepared.test.ts
+++ b/desktop/src/views/GenerateView.prepared.test.ts
@@ -319,7 +319,7 @@ describe("GenerateView prepared expansion batches", () => {
     ).toEqual(prompts);
   });
 
-  it("acknowledges placement planning immediately and ignores duplicate submits", async () => {
+  it("exposes responsive cancellation while placement planning is pending", async () => {
     useGenerateFormStore().form.batchSize = 1;
     const preview = deferred<unknown>();
     placementPreview.mockReset().mockImplementation(() => preview.promise);
@@ -334,12 +334,19 @@ describe("GenerateView prepared expansion batches", () => {
     await nextTick();
 
     const planningButton = wrapper.get('[data-test="generate-button"]');
-    expect(planningButton.text()).toContain("Planning…");
-    expect(planningButton.attributes("disabled")).toBeDefined();
-    wrapper.findComponent({ name: "ComposerCard" }).vm.$emit("generate");
+    expect(planningButton.text()).toContain("Cancel");
+    expect(wrapper.get('[data-test="preprocessing-status"]').text()).toContain(
+      "Checking machine fit",
+    );
+    expect(planningButton.attributes("disabled")).toBeUndefined();
+    await planningButton.trigger("click");
     await nextTick();
     expect(placementPreview).toHaveBeenCalledTimes(1);
     expect(submit).not.toHaveBeenCalled();
+
+    const previewOptions = placementPreview.mock.calls[0]?.[3];
+    expect(previewOptions?.signal?.aborted).toBe(true);
+    expect(wrapper.get('[data-test="generate-button"]').text()).toContain("Generate");
 
     preview.resolve({
       version: 1,
@@ -359,7 +366,7 @@ describe("GenerateView prepared expansion batches", () => {
     });
     await flushPromises();
 
-    expect(submit).toHaveBeenCalledTimes(1);
+    expect(submit).not.toHaveBeenCalled();
     const readyButton = wrapper.get('[data-test="generate-button"]');
     expect(readyButton.text()).toContain("Generate");
     expect(readyButton.text()).not.toContain("Planning");
@@ -394,7 +401,12 @@ describe("GenerateView prepared expansion batches", () => {
 
     expect(submit).toHaveBeenCalledTimes(1);
     expect(preview).toHaveBeenCalledTimes(1);
-    expect(preview).toHaveBeenCalledWith("local", expect.anything(), 3);
+    expect(preview).toHaveBeenCalledWith(
+      "local",
+      expect.anything(),
+      3,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
     const [, count, submittedRoute, , options] = submit.mock.calls[0]!;
     expect(count).toBe(3);
     expect(submittedRoute).toMatchObject({
@@ -617,7 +629,12 @@ describe("GenerateView prepared expansion batches", () => {
       await flushPromises();
 
       expect(finalizedPreview).toHaveBeenCalledTimes(1);
-      expect(finalizedPreview).toHaveBeenCalledWith(route.hostId, expect.anything(), 3);
+      expect(finalizedPreview).toHaveBeenCalledWith(
+        route.hostId,
+        expect.anything(),
+        3,
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
       expect(submit).not.toHaveBeenCalled();
       const preserved = wrapper.findComponent(PreparedExpansionBatch);
       expect(preserved.exists()).toBe(true);

--- a/desktop/src/views/GenerateView.sequence.test.ts
+++ b/desktop/src/views/GenerateView.sequence.test.ts
@@ -516,6 +516,70 @@ describe("GenerateView — sequence output", () => {
     expect(body.stages[1].source_image).toBeUndefined();
   });
 
+  it("compensates a cancelled in-flight amendment on its frozen target", async () => {
+    readyLocal();
+    installedPayload = [videoModel];
+    useModelStore().all = [videoModel];
+    const formStore = useGenerateFormStore();
+    formStore.form.model = "ltx-video";
+    const draft = useSequenceDraftStore();
+    draft.hydrate();
+    draft.output = "sequence";
+    draft.ensureClips(25);
+    draft.clips[0]!.prompt = "opening";
+    draft.clips[1]!.prompt = "landing";
+    draft.loadFromJob(
+      {
+        jobId: "job-1",
+        hostId: "local",
+        baseline: draft.clips.map((clip) => ({ ...clip })),
+        completedStages: 2,
+      },
+      draft.clips.map((clip) => ({ ...clip })),
+      false,
+    );
+    let finishAmend!: (value: Record<string, unknown>) => void;
+    apiJsonTo.mockImplementation((_target: unknown, path: unknown) => {
+      if (typeof path === "string" && path.endsWith("/amend")) {
+        return new Promise((resolve) => (finishAmend = resolve));
+      }
+      if (path === "/api/chain-jobs") return Promise.resolve({ jobs: [] });
+      if (path === "/api/models") return Promise.resolve(installedPayload);
+      return Promise.resolve({});
+    });
+    apiFetchTo.mockResolvedValue({});
+    const wrapper = mountView();
+    await flushPromises();
+    const composer = wrapper.findComponent({ name: "SequenceComposer" });
+
+    composer.vm.$emit("submit");
+    await vi.waitFor(() => expect(finishAmend).toBeTypeOf("function"));
+    const amendCall = apiJsonTo.mock.calls.find(
+      (call) => typeof call[1] === "string" && call[1].endsWith("/amend"),
+    );
+    const operationId = new Headers((amendCall?.[2] as RequestInit).headers).get(
+      "x-mold-operation-id",
+    );
+    expect(operationId).toMatch(/^[0-9a-f-]{36}$/);
+    composer.vm.$emit("cancel");
+    await vi.waitFor(() =>
+      expect(apiFetchTo).toHaveBeenCalledWith(
+        { baseUrl: "http://127.0.0.1:7680", apiKey: "k" },
+        `/api/chain-jobs/job-1/operations/${operationId}/cancel`,
+        { method: "POST", keepalive: true },
+      ),
+    );
+    finishAmend({ preserved_stages: 0 });
+    await flushPromises();
+
+    expect(apiFetchTo).toHaveBeenCalledWith(
+      { baseUrl: "http://127.0.0.1:7680", apiKey: "k" },
+      "/api/chain-jobs/job-1/cancel",
+      { method: "POST" },
+    );
+    expect(draft.editing).toMatchObject({ jobId: "job-1" });
+  });
+
   it("fits the opening image before a sequence request is submitted", async () => {
     readyLocal();
     installedPayload = [videoModel];

--- a/desktop/src/views/GenerateView.vue
+++ b/desktop/src/views/GenerateView.vue
@@ -87,6 +87,8 @@ import {
   type ExpansionCandidate,
 } from "@studio/lib/expansionRouting";
 import { useAppPrefsStore } from "../stores/appPrefs";
+import { createUuid } from "@studio/lib/id";
+import { confirmCancellation } from "@studio/lib/cancellationRetry";
 import { useHostModelsStore } from "../stores/hostModels";
 import { strongestRoutableGpu, useHostsStore, type FeasibleRouteResult } from "../stores/hosts";
 import { useConnectionStore } from "../stores/connection";
@@ -655,6 +657,7 @@ const preparedSubmitting = ref(false);
 const submissionPlanning = ref(false);
 const preparationGuard = new PreparationRequestGuard();
 const submissionGuard = new PreparationRequestGuard();
+const sequenceSubmissionGuard = new PreparationRequestGuard();
 // Completion is detached from authoring once the store accepts a batch. Only
 // the newest accepted submission may publish mutable recovery authority:
 // older batches can finish later, but must not replace a newer pull/resume
@@ -1215,6 +1218,8 @@ const sequenceInventorySettled = computed(() => {
 });
 const chainLimits = ref<ChainLimits | null>(null);
 const sequenceSubmitting = ref(false);
+let sequenceAmendInFlight = false;
+let sequenceCancellationRequest: (() => Promise<void>) | null = null;
 /** Snapshot of the shared params at edit-load time — drives chainLevelDirty. */
 const editSharedBaseline = ref<string | null>(null);
 /** What a Library reuse could NOT restore, said once and quietly beneath the
@@ -1678,7 +1683,10 @@ function resumeSettledSequence() {
 }
 
 async function generateSequence() {
-  if (sequenceSubmitting.value) return;
+  if (sequenceSubmitting.value) {
+    cancelSequenceSubmission();
+    return;
+  }
   const entry = selectedSequenceEntry.value;
   if (!entry) {
     toasts.push("Choose an installed sequence-capable video model first.", "error");
@@ -1709,14 +1717,18 @@ async function generateSequence() {
     return;
   }
   sequenceSubmitting.value = true;
+  const token = sequenceSubmissionGuard.begin();
+  const signal = sequenceSubmissionGuard.signalFor(token);
+  const isCurrent = () => sequenceSubmissionGuard.isCurrent(token) && !signal.aborted;
   try {
     // Refetch stale limits so frames caps/audio gating match the routed host.
     if (!chainLimits.value || chainLimits.value.model !== entry.name) {
       await loadChainLimits();
+      if (!isCurrent()) return;
     }
     requestForm.sourceImage = openingSnapshot?.base64 ?? null;
     requestForm.maskImage = null;
-    if (!(await preprocessSourceFit(hostRoute, requestForm))) return;
+    if (!(await preprocessSourceFit(hostRoute, requestForm, signal)) || !isCurrent()) return;
     const openingImage = openingSnapshot
       ? { ...openingSnapshot, base64: requestForm.sourceImage }
       : null;
@@ -1740,6 +1752,7 @@ async function generateSequence() {
       return;
     }
     if (editing) {
+      const operationId = createUuid();
       const amend: AmendRequest = {
         stages: request.stages,
         motion_tail_frames: request.motion_tail_frames ?? null,
@@ -1757,7 +1770,20 @@ async function generateSequence() {
           `${editing.hostId}:${editing.jobId}`,
           clips.map((clip) => clip.id),
         );
-        const outcome = await chains.amend(editing.hostId, editing.jobId, amend, hostRoute.target);
+        sequenceAmendInFlight = true;
+        sequenceCancellationRequest = () =>
+          chains.cancelMutation(editing.hostId, editing.jobId, operationId, hostRoute.target);
+        const outcome = await chains.amend(
+          editing.hostId,
+          editing.jobId,
+          amend,
+          hostRoute.target,
+          operationId,
+        );
+        if (!isCurrent()) {
+          await chains.cancel(editing.hostId, editing.jobId, hostRoute.target).catch(() => {});
+          return;
+        }
         toasts.push(
           `Sequence updated · ${outcome.preserved_stages} clip${outcome.preserved_stages === 1 ? "" : "s"} kept from cache`,
         );
@@ -1774,7 +1800,14 @@ async function generateSequence() {
         throw err;
       }
     } else {
-      const jobId = await chains.create(hostRoute.hostId, request, hostRoute.target);
+      const operationId = createUuid();
+      sequenceCancellationRequest = () =>
+        chains.cancelMutation(hostRoute.hostId, operationId, operationId, hostRoute.target);
+      const jobId = await chains.create(hostRoute.hostId, request, hostRoute.target, operationId);
+      if (!isCurrent()) {
+        await chains.cancel(hostRoute.hostId, jobId, hostRoute.target).catch(() => {});
+        return;
+      }
       sequenceStageClipIdsByJob.set(
         `${hostRoute.hostId}:${jobId}`,
         clips.map((clip) => clip.id),
@@ -1784,10 +1817,44 @@ async function generateSequence() {
     // The caveat described the handoff, not the submitted job.
     sequenceReuseNotice.value = null;
   } catch (err) {
+    if (!isCurrent()) return;
     toasts.push(String(err), "error");
   } finally {
-    sequenceSubmitting.value = false;
+    if (sequenceSubmissionGuard.isCurrent(token)) {
+      sequenceSubmitting.value = false;
+      sequenceAmendInFlight = false;
+      sequenceCancellationRequest = null;
+    }
   }
+}
+
+function cancelSequenceSubmission() {
+  if (!sequenceSubmitting.value) return;
+  sequenceSubmissionGuard.invalidate();
+  const cancellation = sequenceCancellationRequest;
+  const cancellingAmendment = sequenceAmendInFlight;
+  sequenceCancellationRequest = null;
+  sequenceAmendInFlight = false;
+  sequenceSubmitting.value = false;
+  preprocessingStatus.value = null;
+  if (!cancellation) {
+    toasts.push("Sequence preparation cancelled — nothing was queued");
+    return;
+  }
+  toasts.push(
+    cancellingAmendment ? "Cancelling the sequence update…" : "Cancelling sequence creation…",
+  );
+  void confirmCancellation(cancellation)
+    .then(() =>
+      toasts.push(
+        cancellingAmendment
+          ? "Sequence update cancelled"
+          : "Sequence creation cancelled — nothing was queued",
+      ),
+    )
+    .catch(() =>
+      toasts.push("Cancellation could not be confirmed. Check Activity before retrying.", "error"),
+    );
 }
 
 /** Edit session: submit the current clips as a brand-new job instead. */
@@ -1884,11 +1951,24 @@ watch(
 );
 
 const buttonLabel = computed(() => {
-  if (submissionPlanning.value) return "Planning…";
+  if (submissionPlanning.value) return "Cancel";
   return generation.pending.length > 0
     ? `Generate (+${generation.pending.length} queued)`
     : "Generate";
 });
+const submissionStatus = computed(() =>
+  submissionPlanning.value
+    ? (preprocessingStatus.value ?? "Checking machine fit and generation route…")
+    : preprocessingStatus.value,
+);
+
+function cancelSubmissionPlanning() {
+  if (!submissionPlanning.value) return;
+  submissionGuard.invalidate();
+  sequenceSubmissionGuard.invalidate();
+  submissionPlanning.value = false;
+  preparedSubmitting.value = false;
+}
 
 const previewWidth = computed(() => job.value?.width ?? form.width);
 const previewHeight = computed(() => job.value?.height ?? form.height);
@@ -2113,6 +2193,7 @@ function expansionInputs(count: number): PreparedExpansionInputs {
 async function remixForCurrentPrompt(replacePrepared = false) {
   if (!form.prompt.trim() || !form.model || expansionRunning.value) return;
   submissionGuard.invalidate();
+  sequenceSubmissionGuard.invalidate();
   const route = currentExpansionRoute.value;
   // Frozen before the request: an Auto rerank mid-flight must not move the
   // print's machine out from under the reviewed set.
@@ -2745,6 +2826,7 @@ const sourceFitCache = new SourceFitPreprocessCache();
 async function preprocessSourceFit(
   route: HostRoute | null,
   draft: ReturnType<typeof cloneGenerateForm>,
+  signal?: AbortSignal,
 ): Promise<boolean> {
   const draftCaps = generationCapabilitiesForFamily(
     draft.family,
@@ -2770,6 +2852,7 @@ async function preprocessSourceFit(
                 model,
                 image,
                 ...(route ? { target: route.target } : {}),
+                ...(signal ? { signal } : {}),
                 onProgress: (message) => (preprocessingStatus.value = message),
               }),
             onStatus: (message) => (preprocessingStatus.value = message),
@@ -2777,6 +2860,7 @@ async function preprocessSourceFit(
         )) ?? emptyMinimaxH3AuthoringState();
       return true;
     } catch (error) {
+      if (signal?.aborted) return false;
       const message = error instanceof Error ? error.message : String(error);
       toasts.push(`Source preprocessing failed: ${message}`, "error");
       return false;
@@ -2806,6 +2890,7 @@ async function preprocessSourceFit(
               model,
               image,
               ...(route ? { target: route.target } : {}),
+              ...(signal ? { signal } : {}),
               onProgress: (message) => (preprocessingStatus.value = message),
             }),
           onStatus: (message) => (preprocessingStatus.value = message),
@@ -2814,6 +2899,7 @@ async function preprocessSourceFit(
       if (result.source) draft.imageAttachments[0] = result.source;
       return true;
     } catch (error) {
+      if (signal?.aborted) return false;
       const message = error instanceof Error ? error.message : String(error);
       toasts.push(`Source preprocessing failed: ${message}`, "error");
       return false;
@@ -2843,6 +2929,7 @@ async function preprocessSourceFit(
             model,
             image,
             ...(route ? { target: route.target } : {}),
+            ...(signal ? { signal } : {}),
             onProgress: (message) => (preprocessingStatus.value = message),
           }),
         onStatus: (message) => (preprocessingStatus.value = message),
@@ -2855,6 +2942,7 @@ async function preprocessSourceFit(
     draft.maskImage = result.mask;
     return true;
   } catch (error) {
+    if (signal?.aborted) return false;
     const message = error instanceof Error ? error.message : String(error);
     toasts.push(`Source preprocessing failed: ${message}`, "error");
     return false;
@@ -3004,6 +3092,7 @@ async function generate() {
       : null
     : null;
   const submitToken = submissionGuard.begin();
+  const submitSignal = submissionGuard.signalFor(submitToken);
   preparedSubmitting.value = preparedSubmission !== null;
   submissionPlanning.value = true;
   try {
@@ -3056,7 +3145,7 @@ async function generate() {
     let routeResolvedAgainstFinalRequest = false;
     let sourcePreprocessed = false;
     if (!route && !routeRequiredForPreprocessing) {
-      if (!(await preprocessSourceFit(null, draft))) return;
+      if (!(await preprocessSourceFit(null, draft, submitSignal))) return;
       if (!submissionGuard.isCurrent(submitToken)) return;
       sourcePreprocessed = true;
     }
@@ -3104,7 +3193,9 @@ async function generate() {
         appPrefs.settings?.generateTargetHost ?? null,
         planningRequest,
         batch,
+        { signal: submitSignal },
       );
+      if (!submissionGuard.isCurrent(submitToken)) return;
       if (feasibility.kind !== "route") {
         // Nothing can run this print. When the only thing in the way is the
         // model itself, offer the pull instead of a dead-end toast — but only
@@ -3127,7 +3218,7 @@ async function generate() {
       routeResolvedAgainstFinalRequest = sourcePreprocessed;
     }
     if (!sourcePreprocessed) {
-      if (!(await preprocessSourceFit(route, draft))) return;
+      if (!(await preprocessSourceFit(route, draft, submitSignal))) return;
       if (!submissionGuard.isCurrent(submitToken)) return;
     }
     if (preparedSubmission) {
@@ -3195,7 +3286,10 @@ async function generate() {
         }
       : {};
     if (route && !routeResolvedAgainstFinalRequest) {
-      const finalized = await hosts.resolveFeasible(route.hostId, finalizedPlanningRequest, batch);
+      const finalized = await hosts.resolveFeasible(route.hostId, finalizedPlanningRequest, batch, {
+        signal: submitSignal,
+      });
+      if (!submissionGuard.isCurrent(submitToken)) return;
       const finalizedRoute = finalized.kind === "route" ? finalized.route : null;
       if (
         !finalizedRoute ||
@@ -3314,8 +3408,10 @@ async function generate() {
       }
     });
   } finally {
-    preparedSubmitting.value = false;
-    submissionPlanning.value = false;
+    if (submissionGuard.isCurrent(submitToken)) {
+      preparedSubmitting.value = false;
+      submissionPlanning.value = false;
+    }
   }
 }
 
@@ -3718,6 +3814,13 @@ onBeforeUnmount(() => {
   if (!import.meta.env.TEST) liveActivity.stop();
   preparationGuard.invalidate();
   submissionGuard.invalidate();
+  sequenceSubmissionGuard.invalidate();
+  const sequenceCancellation = sequenceCancellationRequest;
+  sequenceCancellationRequest = null;
+  sequenceAmendInFlight = false;
+  if (sequenceCancellation) {
+    void confirmCancellation(sequenceCancellation).catch(() => {});
+  }
   clearSequenceStageMedia();
   nativeImageDropUnmounted = true;
   stopNativeImageDrop?.();
@@ -4209,6 +4312,7 @@ onBeforeUnmount(() => {
               :playing-clip-id="playingSequenceClipId"
               :target="sequenceTarget"
               @submit="generateSequence"
+              @cancel="cancelSequenceSubmission"
               @duplicate="duplicateSequenceAsNew"
               @play-clip="playSequenceClip"
             />
@@ -4231,11 +4335,12 @@ onBeforeUnmount(() => {
             :button-label="buttonLabel"
             :estimate-request="estimateRequest"
             :estimate-target="estimateTarget"
-            :preprocessing-status="preprocessingStatus"
+            :preprocessing-status="submissionStatus"
             :history="promptHistory"
             :remix-source="remixSource"
             @prompt-authored="onPromptAuthored"
             @generate="generate"
+            @cancel="cancelSubmissionPlanning"
             @expand="expandForCurrentBatch()"
             @remix="remixForCurrentPrompt()"
             @update:remix-source="remixSource = $event"

--- a/studio/api/generationPlacement.ts
+++ b/studio/api/generationPlacement.ts
@@ -323,9 +323,9 @@ export function redactGenerationForPlacement<T extends Record<string, unknown>>(
  * cold H3 host legitimately verifies its full checkpoint set once (tens of
  * GB — minutes on slow storage), so the bound is deliberately enormous: it
  * exists only so a hung or unreachable host eventually surfaces as a normal
- * placement failure instead of an unbounded Planning spinner. The server
- * keeps verifying after a client abort and its digest cache retains the
- * work, so a retry after a rare timeout completes quickly. */
+ * placement failure instead of an unbounded planning state. A client abort
+ * disconnects the request so the scheduler can discard work that has not
+ * started yet. */
 export const PLACEMENT_PREVIEW_TIMEOUT_MS = 900_000;
 
 interface PlacementPreviewBound {

--- a/studio/lib/cancellationRetry.test.ts
+++ b/studio/lib/cancellationRetry.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest";
+import { confirmCancellation } from "./cancellationRetry";
+
+describe("confirmCancellation", () => {
+  it("retries an idempotent cancellation until the server confirms it", async () => {
+    const cancel = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValue(undefined);
+    const wait = vi.fn(async () => undefined);
+
+    await confirmCancellation(cancel, wait);
+
+    expect(cancel).toHaveBeenCalledTimes(3);
+    expect(wait).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects when cancellation remains unconfirmed", async () => {
+    const cancel = vi.fn(async () => {
+      throw new Error("offline");
+    });
+
+    await expect(
+      confirmCancellation(cancel, async () => undefined),
+    ).rejects.toThrow("offline");
+    expect(cancel).toHaveBeenCalledTimes(3);
+  });
+});

--- a/studio/lib/cancellationRetry.ts
+++ b/studio/lib/cancellationRetry.ts
@@ -1,0 +1,20 @@
+const RETRY_DELAYS_MS = [0, 150, 500] as const;
+
+/** Retry an idempotent cancellation handoff before declaring it unconfirmed. */
+export async function confirmCancellation(
+  cancel: () => Promise<unknown>,
+  wait: (delayMs: number) => Promise<void> = (delayMs) =>
+    new Promise((resolve) => setTimeout(resolve, delayMs)),
+): Promise<void> {
+  let lastError: unknown;
+  for (const delayMs of RETRY_DELAYS_MS) {
+    if (delayMs > 0) await wait(delayMs);
+    try {
+      await cancel();
+      return;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError;
+}

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -3,6 +3,7 @@ import {
   amendChainJob,
   ApiHttpError,
   cancelChainJob,
+  cancelChainJobMutation,
   chainJobEventsUrl,
   chainJobStagePreviewUrl,
   createChainJob,
@@ -533,10 +534,13 @@ describe("chain job api helpers", () => {
       script: { schema: "mold.chain.v1", chain: {}, stage: [] },
     };
     const fetchMock = installFetch({ job_id: "job/1" });
-    await createChainJob(chainRequest());
+    await createChainJob(chainRequest(), undefined, "create-op");
     expect(fetchMock).toHaveBeenLastCalledWith("/api/chain-jobs", {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: {
+        "content-type": "application/json",
+        "x-mold-operation-id": "create-op",
+      },
       body: JSON.stringify(chainRequest()),
     });
 
@@ -579,12 +583,15 @@ describe("chain job api helpers", () => {
     fetchMock.mockResolvedValueOnce(
       new Response(JSON.stringify({ ...summary, preserved_stages: 1 })),
     );
-    await amendChainJob("job/1", amendRequest);
+    await amendChainJob("job/1", amendRequest, undefined, "amend-op");
     expect(fetchMock).toHaveBeenLastCalledWith(
       "/api/chain-jobs/job%2F1/amend",
       {
         method: "POST",
-        headers: { "content-type": "application/json" },
+        headers: {
+          "content-type": "application/json",
+          "x-mold-operation-id": "amend-op",
+        },
         body: JSON.stringify(amendRequest),
       },
     );
@@ -597,6 +604,13 @@ describe("chain job api helpers", () => {
         method: "POST",
         headers: {},
       },
+    );
+
+    fetchMock.mockResolvedValueOnce(new Response("", { status: 202 }));
+    await cancelChainJobMutation("job/1", "amend-op");
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      "/api/chain-jobs/job%2F1/operations/amend-op/cancel",
+      { method: "POST", headers: {}, keepalive: true },
     );
 
     fetchMock.mockResolvedValueOnce(new Response("", { status: 204 }));

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -431,7 +431,7 @@ async function requireJson<T>(res: Response, label: string): Promise<T> {
 async function chainJobJson<T>(
   suffix: string,
   target?: StreamTarget,
-  request: { method?: "POST"; body?: unknown } = {},
+  request: { method?: "POST"; body?: unknown; operationId?: string } = {},
 ): Promise<T> {
   const path = `/api/chain-jobs${suffix}`;
   const hasBody = request.body !== undefined;
@@ -439,6 +439,9 @@ async function chainJobJson<T>(
     ...(request.method ? { method: request.method } : {}),
     headers: {
       ...(hasBody ? { "content-type": "application/json" } : {}),
+      ...(request.operationId
+        ? { "x-mold-operation-id": request.operationId }
+        : {}),
       ...targetHeaders(target),
     },
     ...(hasBody ? { body: JSON.stringify(request.body) } : {}),
@@ -452,10 +455,12 @@ async function chainJobJson<T>(
 export async function createChainJob(
   req: ChainRequestWire,
   target?: StreamTarget,
+  operationId?: string,
 ): Promise<CreateChainJobResponse> {
   return chainJobJson("", target, {
     method: "POST",
     body: req,
+    operationId,
   });
 }
 
@@ -525,11 +530,32 @@ export async function amendChainJob(
   id: string,
   req: AmendRequestWire,
   target?: StreamTarget,
+  operationId?: string,
 ): Promise<AmendResponseWire> {
   return chainJobJson(`/${encodeURIComponent(id)}/amend`, target, {
     method: "POST",
     body: req,
+    operationId,
   });
+}
+
+/** Cancel a create/amend by its client-known id, including before the
+ * mutation response exposes a durable job id. */
+export async function cancelChainJobMutation(
+  jobId: string,
+  operationId: string,
+  target?: StreamTarget,
+): Promise<void> {
+  const path = `/api/chain-jobs/${encodeURIComponent(jobId)}/operations/${encodeURIComponent(operationId)}/cancel`;
+  const res = await fetch(`${targetBase(target)}${path}`, {
+    method: "POST",
+    headers: targetHeaders(target),
+    keepalive: true,
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new ApiHttpError(`POST ${path}`, res.status, body);
+  }
 }
 
 export async function gcChainJobs(target?: StreamTarget): Promise<{

--- a/web/src/components/SequenceComposer.test.ts
+++ b/web/src/components/SequenceComposer.test.ts
@@ -88,6 +88,21 @@ describe("SequenceComposer", () => {
     expect(wrapper.text()).toContain("Describe clip 1");
   });
 
+  it("keeps the preparing action responsive and emits cancel", async () => {
+    const store = useSequenceDraftStore();
+    store.ensureClips(97);
+    store.clips[0]!.prompt = "opening";
+    store.clips[1]!.prompt = "ending";
+    const wrapper = mountComposer({ submitting: true });
+    await flushPromises();
+    const button = wrapper.get("[data-test='sequence-generate']");
+    expect(button.attributes("disabled")).toBeUndefined();
+    expect(button.text()).toContain("Cancel · Preparing sequence");
+    await button.trigger("click");
+    expect(wrapper.emitted("cancel")).toHaveLength(1);
+    expect(wrapper.emitted("submit")).toBeUndefined();
+  });
+
   it("resets model-owned clip lengths and fetches limits at the active fps", async () => {
     const wrapper = mountComposer();
     await flushPromises();

--- a/web/src/components/SequenceComposer.vue
+++ b/web/src/components/SequenceComposer.vue
@@ -67,6 +67,7 @@ const props = withDefaults(
       Record<string, ClipRailMedia | undefined>
     > | null;
     playingClipId?: string | null;
+    submitting?: boolean;
   }>(),
   {
     sourceImage: null,
@@ -74,11 +75,13 @@ const props = withDefaults(
     chainLevelDirty: false,
     stageMediaByClipId: null,
     playingClipId: null,
+    submitting: false,
   },
 );
 
 const emit = defineEmits<{
   submit: [];
+  cancel: [];
   "duplicate-as-new": [];
   "discard-edit": [];
   "expand-clip": [clipId: string, prompt: string];
@@ -370,6 +373,10 @@ function formatBytes(bytes: number): string {
 }
 
 function trySubmit() {
+  if (props.submitting) {
+    emit("cancel");
+    return;
+  }
   if (!canGenerate.value) return;
   emit("submit");
 }
@@ -772,11 +779,17 @@ defineExpose({ importTomlText });
             ? 'bg-safelight text-on-accent hover:brightness-110'
             : 'cursor-not-allowed border border-edge bg-bath text-ink-3'
         "
-        :disabled="!canGenerate"
+        :disabled="!canGenerate && !submitting"
         data-test="sequence-generate"
         @click="trySubmit"
       >
-        {{ draft.editing ? "Update sequence" : "Generate sequence" }}
+        {{
+          submitting
+            ? "Cancel · Preparing sequence…"
+            : draft.editing
+              ? "Update sequence"
+              : "Generate sequence"
+        }}
       </button>
     </div>
   </section>

--- a/web/src/components/create/ComposerCard.vue
+++ b/web/src/components/create/ComposerCard.vue
@@ -36,6 +36,8 @@ const props = withDefaults(
     expanded?: boolean;
     /** Disable submit/expand (e.g. a job is mid-flight). */
     busy?: boolean;
+    cancellable?: boolean;
+    busyLabel?: string;
     /** Actionable request prerequisite shown beside Generate. */
     disabledReason?: string | null;
     /** The visual conditioning lets this render go out undescribed. */
@@ -48,6 +50,8 @@ const props = withDefaults(
   {
     expanded: false,
     busy: false,
+    cancellable: false,
+    busyLabel: "Planning generation…",
     disabledReason: null,
     promptOptional: false,
     requiredPlaceholder: "Describe the image you want to create…",
@@ -59,6 +63,7 @@ const emit = defineEmits<{
   "update:prompt": [value: string];
   "update:stylePreset": [value: string | null];
   submit: [];
+  cancel: [];
   expand: [];
   remix: [];
   "undo-expand": [];
@@ -85,7 +90,7 @@ const expandLabel = computed(() =>
   props.batchSize > 1 ? `Expand to ${props.batchSize}` : "Expand prompt",
 );
 const generateDisabled = computed(
-  () => props.busy || Boolean(props.disabledReason),
+  () => !props.cancellable && (props.busy || Boolean(props.disabledReason)),
 );
 
 // Shell-style ↑/↓ prompt-history recall. The cycler is fed the latest history
@@ -106,7 +111,7 @@ function onInput(event: Event) {
 function onKeydown(event: KeyboardEvent) {
   if ((event.metaKey || event.ctrlKey) && event.key === "Enter") {
     event.preventDefault();
-    if (!generateDisabled.value) emit("submit");
+    if (!generateDisabled.value) submitOrCancel();
     return;
   }
   const el = event.target as HTMLTextAreaElement;
@@ -127,6 +132,11 @@ function onKeydown(event: KeyboardEvent) {
       emit("update:prompt", recalled);
     }
   }
+}
+
+function submitOrCancel() {
+  if (props.cancellable) emit("cancel");
+  else emit("submit");
 }
 
 function pickStyle(id: string) {
@@ -244,12 +254,22 @@ watch(
         class="composer__generate"
         data-test="composer-submit"
         :disabled="generateDisabled"
-        @click="emit('submit')"
+        @click="submitOrCancel"
       >
-        <Icon name="sparkle" :size="16" :stroke-width="2" />
-        Generate
+        <Icon
+          :name="cancellable ? 'close' : 'sparkle'"
+          :size="16"
+          :stroke-width="2"
+        />
+        {{ cancellable ? "Cancel" : "Generate" }}
         <Keycap on-accent>⌘<span class="composer__return">↵</span></Keycap>
       </button>
+      <span
+        v-if="cancellable"
+        class="composer__summary"
+        data-test="composer-busy-status"
+        >{{ busyLabel }}</span
+      >
     </div>
     <ActionBlocker
       v-if="disabledReason"

--- a/web/src/composables/useChainJobs.ts
+++ b/web/src/composables/useChainJobs.ts
@@ -15,6 +15,7 @@ import { computed, reactive, ref, type ComputedRef, type Ref } from "vue";
 import {
   amendChainJob,
   cancelChainJob,
+  cancelChainJobMutation,
   chainJobEventsUrl,
   createChainJob,
   deleteChainJob,
@@ -289,19 +290,28 @@ function watch(hostId: string, jobId: string) {
   });
 }
 
-async function create(hostId: string, req: ChainRequestWire): Promise<string> {
+async function create(
+  hostId: string,
+  req: ChainRequestWire,
+  frozenTarget?: StreamTarget,
+  operationId?: string,
+): Promise<string> {
   ensureLoaded();
-  const target = targetFor(hostId);
+  const target = frozenTarget ?? targetFor(hostId);
   if (!target) throw new Error("That machine is no longer connected.");
-  const { job_id } = await createChainJob(req, target);
+  const { job_id } = await createChainJob(req, target, operationId);
   track(hostId, job_id);
   void fetchHost(hostId);
   watch(hostId, job_id);
   return job_id;
 }
 
-async function cancel(hostId: string, jobId: string): Promise<void> {
-  const target = targetFor(hostId) ?? undefined;
+async function cancel(
+  hostId: string,
+  jobId: string,
+  frozenTarget?: StreamTarget,
+): Promise<void> {
+  const target = frozenTarget ?? targetFor(hostId) ?? undefined;
   await cancelChainJob(jobId, target);
   await fetchHost(hostId);
 }
@@ -340,13 +350,24 @@ async function amend(
   jobId: string,
   req: AmendRequest,
   frozenTarget?: StreamTarget,
+  operationId?: string,
 ): Promise<AmendResponse> {
   const target = frozenTarget ?? targetFor(hostId) ?? undefined;
-  const response = await amendChainJob(jobId, req, target);
+  const response = await amendChainJob(jobId, req, target, operationId);
   track(hostId, jobId);
   void fetchHost(hostId);
   watch(hostId, jobId);
   return response;
+}
+
+async function cancelMutation(
+  hostId: string,
+  jobId: string,
+  operationId: string,
+  frozenTarget?: StreamTarget,
+): Promise<void> {
+  const target = frozenTarget ?? targetFor(hostId) ?? undefined;
+  await cancelChainJobMutation(jobId, operationId, target);
 }
 
 /** Delete every settled job (anything not running or queued) on every host. */
@@ -421,10 +442,25 @@ export interface UseChainJobs {
   start: () => Promise<void>;
   fetchHost: (hostId: string) => Promise<void>;
   fetchAll: () => Promise<void>;
-  create: (hostId: string, req: ChainRequestWire) => Promise<string>;
+  create: (
+    hostId: string,
+    req: ChainRequestWire,
+    frozenTarget?: StreamTarget,
+    operationId?: string,
+  ) => Promise<string>;
   watch: (hostId: string, jobId: string) => void;
   unwatch: () => void;
-  cancel: (hostId: string, jobId: string) => Promise<void>;
+  cancel: (
+    hostId: string,
+    jobId: string,
+    frozenTarget?: StreamTarget,
+  ) => Promise<void>;
+  cancelMutation: (
+    hostId: string,
+    jobId: string,
+    operationId: string,
+    frozenTarget?: StreamTarget,
+  ) => Promise<void>;
   resume: (hostId: string, jobId: string) => Promise<void>;
   remove: (hostId: string, jobId: string) => Promise<void>;
   retake: (hostId: string, jobId: string, req: RetakeRequest) => Promise<void>;
@@ -433,6 +469,7 @@ export interface UseChainJobs {
     jobId: string,
     req: AmendRequest,
     frozenTarget?: StreamTarget,
+    operationId?: string,
   ) => Promise<AmendResponse>;
   clearInactive: () => Promise<{ cleared: number; failed: number }>;
   gc: () => Promise<{
@@ -456,6 +493,7 @@ export function useChainJobs(): UseChainJobs {
     watch,
     unwatch,
     cancel,
+    cancelMutation,
     resume,
     remove,
     retake,

--- a/web/src/composables/useHostRouting.test.ts
+++ b/web/src/composables/useHostRouting.test.ts
@@ -558,6 +558,7 @@ describe("useHostRouting", () => {
       expect.anything(),
       expect.objectContaining({ batch_size: 1 }),
       4,
+      {},
     );
     expect(request.batch_size).toBe(4);
   });

--- a/web/src/composables/useHostRouting.ts
+++ b/web/src/composables/useHostRouting.ts
@@ -59,6 +59,7 @@ import {
   type GenerationPlacementPreview,
   type MissingModelPlacement,
   type PlacementMissingComponent,
+  type PlacementPreviewOptions,
 } from "@studio/api/generationPlacement";
 import {
   AUTO_TARGET_ID,
@@ -136,22 +137,26 @@ export interface HostRouting {
   resolveFeasible: (
     request: GenerateRequestWire,
     copies?: number,
+    options?: PlacementPreviewOptions,
   ) => Promise<FeasibilityResult>;
   /** Revalidate only a previously selected host; never globally rerank. */
   revalidateFeasible: (
     route: HostRoute,
     request: GenerateRequestWire,
     copies?: number,
+    options?: PlacementPreviewOptions,
   ) => Promise<FeasibilityResult>;
   /** Resolve a complete durable sequence through the same scheduler preview. */
   resolveFeasibleChain: (
     request: ChainRequestWire,
     copies?: number,
+    options?: PlacementPreviewOptions,
   ) => Promise<FeasibilityResult>;
   revalidateFeasibleChain: (
     route: HostRoute,
     request: ChainRequestWire,
     copies?: number,
+    options?: PlacementPreviewOptions,
   ) => Promise<FeasibilityResult>;
   /** Re-read the registry and poll every host once. */
   refresh: () => Promise<void>;
@@ -634,8 +639,12 @@ function resolve(model: string | null): HostRoute | null {
 
 async function resolveFeasibleWithPreview(
   model: string,
-  previewFor: (target: ApiTarget) => Promise<GenerationPlacementPreview>,
+  previewFor: (
+    target: ApiTarget,
+    options: PlacementPreviewOptions,
+  ) => Promise<GenerationPlacementPreview>,
   requireAuthoritative = false,
+  options: PlacementPreviewOptions = {},
   authorityRetry = 0,
 ): Promise<FeasibilityResult> {
   readRegistry();
@@ -713,7 +722,7 @@ async function resolveFeasibleWithPreview(
           baseUrl: entry.url,
           apiKey: entry.apiKey ?? null,
         };
-        const preview = await previewFor(target);
+        const preview = await previewFor(target, options);
         return {
           candidate,
           preview,
@@ -749,6 +758,7 @@ async function resolveFeasibleWithPreview(
         model,
         previewFor,
         requireAuthoritative,
+        options,
         1,
       );
     }
@@ -913,10 +923,11 @@ async function resolveFeasibleWithPreview(
 async function resolveFeasible(
   request: GenerateRequestWire,
   copies = 1,
+  options: PlacementPreviewOptions = {},
 ): Promise<FeasibilityResult> {
   return resolveFeasibleWithPreview(
     request.model,
-    (target) =>
+    (target, previewOptions) =>
       previewGenerationPlacement(
         target,
         previewRequestForSiblingFanout(
@@ -924,34 +935,46 @@ async function resolveFeasible(
           copies,
         ),
         copies,
+        previewOptions,
       ),
     requiresAuthoritativePlacement(
       request as unknown as Record<string, unknown>,
     ),
+    options,
   );
 }
 
 async function resolveFeasibleChain(
   request: ChainRequestWire,
   copies = 1,
+  options: PlacementPreviewOptions = {},
 ): Promise<FeasibilityResult> {
-  return resolveFeasibleWithPreview(request.model, (target) =>
-    previewChainPlacement(
-      target,
-      previewRequestForSiblingFanout(
-        request as unknown as Record<string, unknown>,
+  return resolveFeasibleWithPreview(
+    request.model,
+    (target, previewOptions) =>
+      previewChainPlacement(
+        target,
+        previewRequestForSiblingFanout(
+          request as unknown as Record<string, unknown>,
+          copies,
+        ),
         copies,
+        previewOptions,
       ),
-      copies,
-    ),
+    false,
+    options,
   );
 }
 
 async function revalidateFeasibleWithPreview(
   route: HostRoute,
   model: string,
-  previewFor: (target: ApiTarget) => Promise<GenerationPlacementPreview>,
+  previewFor: (
+    target: ApiTarget,
+    options: PlacementPreviewOptions,
+  ) => Promise<GenerationPlacementPreview>,
   requireAuthoritative = false,
+  options: PlacementPreviewOptions = {},
   authorityRetry = 0,
 ): Promise<FeasibilityResult> {
   readRegistry();
@@ -987,10 +1010,13 @@ async function revalidateFeasibleWithPreview(
   let preview: GenerationPlacementPreview | null = null;
   let legacyUnsupported = false;
   try {
-    preview = await previewFor({
-      baseUrl: route.target.baseUrl,
-      apiKey: route.target.apiKey ?? null,
-    });
+    preview = await previewFor(
+      {
+        baseUrl: route.target.baseUrl,
+        apiKey: route.target.apiKey ?? null,
+      },
+      options,
+    );
   } catch (error) {
     if (
       error instanceof ApiError &&
@@ -1027,6 +1053,7 @@ async function revalidateFeasibleWithPreview(
         model,
         previewFor,
         requireAuthoritative,
+        options,
         1,
       );
     }
@@ -1113,11 +1140,12 @@ async function revalidateFeasible(
   route: HostRoute,
   request: GenerateRequestWire,
   copies = 1,
+  options: PlacementPreviewOptions = {},
 ): Promise<FeasibilityResult> {
   return revalidateFeasibleWithPreview(
     route,
     request.model,
-    (target) =>
+    (target, previewOptions) =>
       previewGenerationPlacement(
         target,
         previewRequestForSiblingFanout(
@@ -1125,10 +1153,12 @@ async function revalidateFeasible(
           copies,
         ),
         copies,
+        previewOptions,
       ),
     requiresAuthoritativePlacement(
       request as unknown as Record<string, unknown>,
     ),
+    options,
   );
 }
 
@@ -1136,16 +1166,23 @@ async function revalidateFeasibleChain(
   route: HostRoute,
   request: ChainRequestWire,
   copies = 1,
+  options: PlacementPreviewOptions = {},
 ): Promise<FeasibilityResult> {
-  return revalidateFeasibleWithPreview(route, request.model, (target) =>
-    previewChainPlacement(
-      target,
-      previewRequestForSiblingFanout(
-        request as unknown as Record<string, unknown>,
+  return revalidateFeasibleWithPreview(
+    route,
+    request.model,
+    (target, previewOptions) =>
+      previewChainPlacement(
+        target,
+        previewRequestForSiblingFanout(
+          request as unknown as Record<string, unknown>,
+          copies,
+        ),
         copies,
+        previewOptions,
       ),
-      copies,
-    ),
+    false,
+    options,
   );
 }
 

--- a/web/src/composables/usePullResume.ts
+++ b/web/src/composables/usePullResume.ts
@@ -45,7 +45,7 @@ export interface UsePullResume {
    */
   arm: (next: PendingPull, baseline?: readonly string[]) => Promise<void>;
   captureBaseline: (hostId: string) => Promise<string[]>;
-  cancel: () => void;
+  cancel: (expected?: PendingPull) => void;
   /** Test seam: run one poll now instead of waiting for the interval. */
   check: () => Promise<void>;
 }
@@ -126,7 +126,8 @@ export function usePullResume(): UsePullResume {
     async captureBaseline(hostId: string) {
       return terminalPullJobIds(await jobsFor(hostId));
     },
-    cancel() {
+    cancel(expected?: PendingPull) {
+      if (expected && pending.value !== expected) return;
       pending.value = null;
       stop();
     },

--- a/web/src/pages/CreatePage.test.ts
+++ b/web/src/pages/CreatePage.test.ts
@@ -105,7 +105,7 @@ const streamSelectedJobRef = vi.hoisted(() => ({
 }));
 const streamSelectMock = vi.hoisted(() => vi.fn());
 const placementPreviewMock = vi.hoisted(() =>
-  vi.fn(async (): Promise<Record<string, unknown>> => ({
+  vi.fn(async (..._args: unknown[]): Promise<Record<string, unknown>> => ({
     version: 1,
     authoritative: true,
     state_version: 1,
@@ -155,6 +155,9 @@ const listChainJobsMock = vi.hoisted(() =>
 );
 const getChainJobMock = vi.hoisted(() => vi.fn());
 const cancelChainJobMock = vi.hoisted(() => vi.fn(async () => ({})));
+const cancelChainJobMutationMock = vi.hoisted(() =>
+  vi.fn(async () => undefined),
+);
 const resumeChainJobMock = vi.hoisted(() => vi.fn(async () => ({})));
 const deleteChainJobMock = vi.hoisted(() => vi.fn(async () => undefined));
 const gcChainJobsMock = vi.hoisted(() =>
@@ -194,6 +197,7 @@ vi.mock("../api", async (importOriginal) => {
     listChainJobs: listChainJobsMock,
     getChainJob: getChainJobMock,
     cancelChainJob: cancelChainJobMock,
+    cancelChainJobMutation: cancelChainJobMutationMock,
     resumeChainJob: resumeChainJobMock,
     retakeChainJob: vi.fn(async () => ({})),
     deleteChainJob: deleteChainJobMock,
@@ -360,6 +364,7 @@ describe("CreatePage layout and behavior", () => {
     listChainJobsMock.mockResolvedValue({ jobs: [] });
     getChainJobMock.mockReset();
     cancelChainJobMock.mockClear();
+    cancelChainJobMutationMock.mockClear();
     resumeChainJobMock.mockClear();
     deleteChainJobMock.mockClear();
     gcChainJobsMock.mockClear();
@@ -1596,6 +1601,7 @@ describe("CreatePage layout and behavior", () => {
         ],
       }),
       expect.objectContaining({ baseUrl: expect.any(String) }),
+      expect.stringMatching(/^[0-9a-f-]{36}$/),
     );
     expect(placementPreviewMock).toHaveBeenCalledWith(
       expect.objectContaining({ baseUrl: expect.any(String) }),
@@ -1607,6 +1613,7 @@ describe("CreatePage layout and behavior", () => {
         ],
       }),
       1,
+      expect.any(Object),
     );
     expect(submitMock).not.toHaveBeenCalled();
   });
@@ -1906,6 +1913,7 @@ describe("CreatePage layout and behavior", () => {
       expect.anything(),
       expect.objectContaining({ batch_size: 1 }),
       3,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
   });
 
@@ -2947,6 +2955,7 @@ describe("CreatePage layout and behavior", () => {
         ],
       }),
       expect.objectContaining({ baseUrl: expect.any(String) }),
+      expect.stringMatching(/^[0-9a-f-]{36}$/),
     );
     expect(amendChainJobMock.mock.calls[0]?.[1]).toEqual(
       expect.objectContaining({ strength: 1 }),
@@ -2989,6 +2998,7 @@ describe("CreatePage layout and behavior", () => {
       false,
     );
     await flushPromises();
+    await flushPromises();
     amendChainJobMock.mockRejectedValue(
       new ApiHttpError("POST /api/chain-jobs/job-9/amend", 409, "moved on"),
     );
@@ -3005,6 +3015,105 @@ describe("CreatePage layout and behavior", () => {
     expect(wrapper.get("[data-test='sequence-submit-error']").text()).toContain(
       "Your edits are still here",
     );
+  });
+
+  it("compensates a cancelled in-flight sequence amendment on its frozen target", async () => {
+    hostModelsMock.mockResolvedValue([
+      {
+        name: "ltx-2-19b-distilled:fp8",
+        family: "ltx2",
+        size_gb: 20,
+        is_loaded: false,
+        last_used: null,
+        hf_repo: "",
+        downloaded: true,
+        default_steps: 8,
+        default_guidance: 3,
+        default_width: 1216,
+        default_height: 704,
+        description: "Sequence model",
+        supports_sequence: true,
+      },
+    ]);
+    const wrapper = mount(CreatePage, { global: { stubs: pageStubs() } });
+    await flushPromises();
+    const draft = enterSequenceMode();
+    draft.clips[0]!.prompt = "one";
+    draft.clips[1]!.prompt = "two";
+    draft.loadFromJob(
+      {
+        jobId: "job-9",
+        hostId: ORIGIN_HOST_ID,
+        baseline: draft.clips.map((clip) => ({ ...clip })),
+        completedStages: 1,
+      },
+      draft.clips.map((clip) => ({ ...clip })),
+      false,
+    );
+    await flushPromises();
+    let finishAmend!: (value: { preserved_stages: number }) => void;
+    amendChainJobMock.mockReturnValueOnce(
+      new Promise((resolve) => (finishAmend = resolve)),
+    );
+
+    await wrapper.get("[data-test='sequence-generate']").trigger("click");
+    await vi.waitFor(() => expect(amendChainJobMock).toHaveBeenCalledTimes(1));
+    const frozenTarget = amendChainJobMock.mock.calls[0]?.[2];
+    const operationId = amendChainJobMock.mock.calls[0]?.[3];
+    expect(operationId).toMatch(/^[0-9a-f-]{36}$/);
+    const cancel = wrapper.get("[data-test='sequence-generate']");
+    expect(cancel.text()).toContain("Cancel");
+    await cancel.trigger("click");
+    await vi.waitFor(() =>
+      expect(cancelChainJobMutationMock).toHaveBeenCalledWith(
+        "job-9",
+        operationId,
+        frozenTarget,
+      ),
+    );
+    finishAmend({ preserved_stages: 0 });
+    await flushPromises();
+
+    expect(cancelChainJobMock).toHaveBeenCalledWith("job-9", frozenTarget);
+    expect(draft.editing).toMatchObject({ jobId: "job-9" });
+  });
+
+  it("cancels sequence creation before a lost job-id response", async () => {
+    hostModelsMock.mockResolvedValue([
+      {
+        name: "ltx-2-19b-distilled:fp8",
+        family: "ltx2",
+        downloaded: true,
+        supports_sequence: true,
+        default_width: 1216,
+        default_height: 704,
+        default_steps: 8,
+        default_guidance: 3,
+      },
+    ]);
+    createChainJobMock.mockReturnValueOnce(new Promise(() => {}));
+    const wrapper = mount(CreatePage, { global: { stubs: pageStubs() } });
+    await flushPromises();
+    const draft = enterSequenceMode();
+    draft.clips[0]!.prompt = "one";
+    draft.clips[1]!.prompt = "two";
+    await flushPromises();
+
+    await wrapper.get("[data-test='sequence-generate']").trigger("click");
+    await vi.waitFor(() => expect(createChainJobMock).toHaveBeenCalledTimes(1));
+    const target = createChainJobMock.mock.calls[0]?.[1];
+    const operationId = createChainJobMock.mock.calls[0]?.[2];
+    expect(operationId).toMatch(/^[0-9a-f-]{36}$/);
+    await wrapper.get("[data-test='sequence-generate']").trigger("click");
+
+    await vi.waitFor(() =>
+      expect(cancelChainJobMutationMock).toHaveBeenCalledWith(
+        operationId,
+        operationId,
+        target,
+      ),
+    );
+    expect(cancelChainJobMock).not.toHaveBeenCalled();
   });
 
   it("keeps one stage playing while later stages finish and stops invalidated media", async () => {
@@ -3383,6 +3492,97 @@ describe("CreatePage host routing", () => {
       },
     });
   }
+
+  it("cancels an in-flight placement check without queueing late work", async () => {
+    hostModelsMock.mockResolvedValue([flux]);
+    let release!: (
+      value: Awaited<ReturnType<typeof placementPreviewMock>>,
+    ) => void;
+    placementPreviewMock.mockImplementationOnce(
+      () => new Promise((resolve) => (release = resolve)),
+    );
+    const wrapper = mount(CreatePage, { global: { stubs: pageStubs() } });
+    const form = useGenerateForm();
+    form.state.value.prompt = "cancel this plan";
+    await flushPromises();
+
+    await wrapper.get("[data-test='composer-submit']").trigger("click");
+    await vi.waitFor(() =>
+      expect(placementPreviewMock).toHaveBeenCalledTimes(1),
+    );
+    const button = wrapper.get("[data-test='composer-submit']");
+    expect(button.text()).toContain("Cancel");
+    expect(wrapper.text()).toContain("Checking machine fit");
+    expect(button.attributes("disabled")).toBeUndefined();
+
+    await button.trigger("click");
+    const previewOptions = placementPreviewMock.mock.calls[0]?.[3] as
+      { signal?: AbortSignal } | undefined;
+    expect(previewOptions?.signal?.aborted).toBe(true);
+    expect(submitMock).not.toHaveBeenCalled();
+
+    release({
+      version: 1,
+      authoritative: true,
+      state_version: 1,
+      plan_version: 1,
+      outcome: "planned",
+      candidate: {
+        device_id: "cuda:0",
+        execution_fingerprint: "test",
+        predicted_start_after_ms: 0,
+        predicted_completion_after_ms: 100,
+        setup_ms: 0,
+        setup_kind: "warm",
+        estimate_confidence: "high",
+      },
+    });
+    await flushPromises();
+    expect(submitMock).not.toHaveBeenCalled();
+    expect(button.text()).toContain("Generate");
+  });
+
+  it("aborts an in-flight placement check when Create unmounts", async () => {
+    hostModelsMock.mockResolvedValue([flux]);
+    let release!: (
+      value: Awaited<ReturnType<typeof placementPreviewMock>>,
+    ) => void;
+    placementPreviewMock.mockImplementationOnce(
+      () => new Promise((resolve) => (release = resolve)),
+    );
+    const wrapper = mount(CreatePage, { global: { stubs: pageStubs() } });
+    const form = useGenerateForm();
+    form.state.value.prompt = "leave this plan";
+    await flushPromises();
+
+    await wrapper.get("[data-test='composer-submit']").trigger("click");
+    await vi.waitFor(() =>
+      expect(placementPreviewMock).toHaveBeenCalledTimes(1),
+    );
+    const previewOptions = placementPreviewMock.mock.calls[0]?.[3] as
+      { signal?: AbortSignal } | undefined;
+    wrapper.unmount();
+    expect(previewOptions?.signal?.aborted).toBe(true);
+
+    release({
+      version: 1,
+      authoritative: true,
+      state_version: 1,
+      plan_version: 1,
+      outcome: "planned",
+      candidate: {
+        device_id: "cuda:0",
+        execution_fingerprint: "test",
+        predicted_start_after_ms: 0,
+        predicted_completion_after_ms: 100,
+        setup_ms: 0,
+        setup_kind: "warm",
+        estimate_confidence: "high",
+      },
+    });
+    await flushPromises();
+    expect(submitMock).not.toHaveBeenCalled();
+  });
 
   it("expands on a machine that has the expander while the print stays put", async () => {
     const studio = addHost({
@@ -3848,6 +4048,57 @@ describe("CreatePage host routing", () => {
     expect(toasts.some((t) => /can't run this print/.test(t.text))).toBe(false);
   });
 
+  it("does not arm a late missing-model resume after planning is cancelled", async () => {
+    hostModelsMock.mockResolvedValue([flux]);
+    placementPreviewMock.mockResolvedValue({
+      version: 1,
+      authoritative: true,
+      state_version: 1,
+      plan_version: 1,
+      outcome: "infeasible",
+      reason: "model 'z-image-turbo:q6' has no concrete local artifacts",
+      missing_components: [
+        {
+          kind: "transformer",
+          name: "transformer",
+          present: false,
+          repair_model: "z-image-turbo:q6",
+        },
+      ],
+    });
+    let finishDownload!: () => void;
+    postDownloadMock.mockClear();
+    postDownloadMock.mockImplementationOnce(
+      () =>
+        new Promise<undefined>(
+          (resolve) => (finishDownload = () => resolve(undefined)),
+        ),
+    );
+    const wrapper = mount(CreatePage, { global: { stubs: pageStubs() } });
+    await flushPromises();
+    const form = useGenerateForm();
+    form.state.value.model = "z-image-turbo:q6";
+    form.state.value.modelFamily = "zimage";
+    form.state.value.prompt = "cancel the repair";
+    await nextTick();
+
+    await wrapper.get("[data-test='composer-submit']").trigger("click");
+    await vi.waitFor(() => expect(finishDownload).toBeTypeOf("function"));
+    const cancel = wrapper.get("[data-test='composer-submit']");
+    expect(cancel.text()).toContain("Cancel");
+    await cancel.trigger("click");
+    finishDownload();
+    await flushPromises();
+
+    expect(submitMock).not.toHaveBeenCalled();
+    expect(cancel.text()).toContain("Generate");
+    expect(
+      useNotifications().toasts.some((toast) =>
+        /generation starts when it's ready/.test(toast.text),
+      ),
+    ).toBe(false);
+  });
+
   // The pull is only ever offered on a machine that reported the model
   // absent; one that refused for capacity would refuse again after a repair.
   it("never offers a machine that refused for capacity as a pull target", async () => {
@@ -4114,9 +4365,9 @@ function pageStubs() {
     },
     ComposerCard: {
       name: "ComposerCard",
-      props: ["busy", "disabledReason"],
+      props: ["busy", "cancellable", "busyLabel", "disabledReason"],
       template:
-        '<div><div data-test="prompt-style-stub"/><slot name="mobile-controls"/><p v-if="disabledReason" data-test="page-generation-blocker">{{ disabledReason }}</p><button data-test="composer-submit" @click="$emit(\'submit\')">go</button><button data-test="composer-expand" @click="$emit(\'expand\')">expand</button><button data-test="composer-undo" @click="$emit(\'undo-expand\')">undo</button></div>',
+        '<div><div data-test="prompt-style-stub"/><slot name="mobile-controls"/><p v-if="disabledReason" data-test="page-generation-blocker">{{ disabledReason }}</p><p v-if="cancellable">{{ busyLabel }}</p><button data-test="composer-submit" @click="$emit(cancellable ? \'cancel\' : \'submit\')">{{ cancellable ? "Cancel" : "Generate" }}</button><button data-test="composer-expand" @click="$emit(\'expand\')">expand</button><button data-test="composer-undo" @click="$emit(\'undo-expand\')">undo</button></div>',
       // The page calls these through its template ref on submit / new-print;
       // a stub without them throws an unhandled TypeError mid-run.
       methods: { record: vi.fn(), focus: vi.fn() },
@@ -4163,9 +4414,11 @@ function pageStubs() {
         "chainLevelDirty",
         "stageMediaByClipId",
         "playingClipId",
+        "submitting",
       ],
       emits: [
         "submit",
+        "cancel",
         "duplicate-as-new",
         "discard-edit",
         "expand-clip",
@@ -4174,7 +4427,7 @@ function pageStubs() {
       ],
       template:
         "<div data-test='sequence-composer-stub'>" +
-        "<button data-test='sequence-generate' @click=\"$emit('submit')\">go</button>" +
+        "<button data-test='sequence-generate' @click=\"$emit(submitting ? 'cancel' : 'submit')\">{{ submitting ? 'Cancel' : 'go' }}</button>" +
         "<button v-if='Object.keys(stageMediaByClipId || {}).length' data-test='stub-play-first' @click=\"$emit('play-clip', Object.keys(stageMediaByClipId)[0])\">play</button>" +
         "<button data-test='clip-expand' @click=\"$emit('expand-clip', 'clip-x', 'a stage prompt')\">expand</button>" +
         "</div>",

--- a/web/src/pages/CreatePage.test.ts
+++ b/web/src/pages/CreatePage.test.ts
@@ -36,7 +36,12 @@ import { addHost, ORIGIN_HOST_ID } from "../lib/hostRegistry";
 import { AUTO_TARGET_ID, CAPABLE_TARGET_ID } from "../lib/hostRouting";
 import type { GalleryImage, ModelInfoExtended, OutputMetadata } from "../types";
 import type { Job } from "../composables/useGenerateStream";
-import type { ChainJobDetail } from "@studio/lib/api/chainTypes";
+import type {
+  ChainJobDetail,
+  ChainRequestWire,
+  CreateChainJobResponse,
+} from "@studio/lib/api/chainTypes";
+import type { StreamTarget } from "../api";
 
 const routeQuery = vi.hoisted(() => ({ value: {} as Record<string, unknown> }));
 const routerReplaceMock = vi.hoisted(() =>
@@ -85,7 +90,13 @@ const upscaleStreamMock = vi.hoisted(() =>
   >(async () => undefined),
 );
 const createChainJobMock = vi.hoisted(() =>
-  vi.fn(async () => ({ job_id: "job-1" })),
+  vi.fn<
+    (
+      request: ChainRequestWire,
+      target?: StreamTarget,
+      operationId?: string,
+    ) => Promise<CreateChainJobResponse>
+  >(async () => ({ job_id: "job-1" })),
 );
 const expandPromptMock = vi.hoisted(() =>
   vi.fn(async (request: { variations: number }) => ({

--- a/web/src/pages/CreatePage.vue
+++ b/web/src/pages/CreatePage.vue
@@ -48,6 +48,7 @@ import type { DevelopPhase } from "@ui/lib/grain";
 import type { ClipRailMedia } from "@ui/components/types";
 import { SourceFitPreprocessCache } from "@ui/lib/sourceFitPreprocessCache";
 import { createUuid } from "@studio/lib/id";
+import { confirmCancellation } from "@studio/lib/cancellationRetry";
 import { validatePrintTitle } from "@studio/lib/libraryOrganization";
 import { applyAuthoredPrompt } from "@studio/lib/promptProvenance";
 import { requestNeedsReferenceUpload } from "@studio/api/referenceUploads";
@@ -1791,7 +1792,78 @@ function applySharedToForm(shared: Partial<SequenceSharedParams>) {
   }
 }
 
+const sequenceSubmitInFlight = ref(false);
+let sequenceSubmitController: AbortController | null = null;
+let sequenceSubmitAttempt = 0;
+let sequenceAmendInFlight = false;
+let sequenceCancellationRequest: (() => Promise<void>) | null = null;
+
 async function onSubmitSequence() {
+  if (sequenceSubmitInFlight.value) {
+    cancelSequenceSubmit();
+    return;
+  }
+  const attempt = ++sequenceSubmitAttempt;
+  const controller = new AbortController();
+  sequenceSubmitController = controller;
+  sequenceSubmitInFlight.value = true;
+  try {
+    await onSubmitSequenceInner(
+      controller.signal,
+      () => attempt === sequenceSubmitAttempt && !controller.signal.aborted,
+    );
+  } finally {
+    if (attempt === sequenceSubmitAttempt) {
+      sequenceSubmitController = null;
+      sequenceSubmitInFlight.value = false;
+      sequenceAmendInFlight = false;
+      sequenceCancellationRequest = null;
+    }
+  }
+}
+
+function cancelSequenceSubmit() {
+  if (!sequenceSubmitInFlight.value) return;
+  sequenceSubmitAttempt += 1;
+  sequenceSubmitController?.abort(new Error("cancelled"));
+  sequenceSubmitController = null;
+  const cancellation = sequenceCancellationRequest;
+  const cancellingAmendment = sequenceAmendInFlight;
+  sequenceCancellationRequest = null;
+  sequenceAmendInFlight = false;
+  sequenceSubmitInFlight.value = false;
+  preprocessingStatus.value = null;
+  composerError.value = null;
+  if (!cancellation) {
+    toast("info", "Sequence preparation cancelled — nothing was queued.");
+    return;
+  }
+  toast(
+    "info",
+    cancellingAmendment
+      ? "Cancelling the sequence update…"
+      : "Cancelling sequence creation…",
+  );
+  void confirmCancellation(cancellation)
+    .then(() =>
+      toast(
+        "info",
+        cancellingAmendment
+          ? "Sequence update cancelled."
+          : "Sequence creation cancelled — nothing was queued.",
+      ),
+    )
+    .catch(() => {
+      composerError.value =
+        "Cancellation could not be confirmed. Check Activity before retrying.";
+      toast("error", composerError.value);
+    });
+}
+
+async function onSubmitSequenceInner(
+  signal: AbortSignal,
+  isCurrent: () => boolean,
+) {
   composerError.value = null;
   if (
     !sequenceMode.value ||
@@ -1827,6 +1899,7 @@ async function onSubmitSequence() {
   await fetchChainLimits(shared.model, initialRoute.target, shared.fps).catch(
     () => {},
   );
+  if (!isCurrent()) return;
   const preliminaryRequest = buildChainRequest(shared, clips, {
     motionTailFrames,
     enableAudio,
@@ -1834,7 +1907,14 @@ async function onSubmitSequence() {
   });
   let route = initialRoute;
   if (!editing) {
-    const feasibility = await routing.resolveFeasibleChain(preliminaryRequest);
+    const feasibility = await routing.resolveFeasibleChain(
+      preliminaryRequest,
+      1,
+      {
+        signal,
+      },
+    );
+    if (!isCurrent()) return;
     if (feasibility.kind !== "route") {
       composerError.value = feasibilityMessage(feasibility, "this sequence");
       return;
@@ -1843,29 +1923,33 @@ async function onSubmitSequence() {
   }
   let openingImage = openingSnapshot;
   if (openingImage?.base64) {
-    const prepared = await prepareStillSourceToRequest(route, {
-      source: {
-        kind: "upload",
-        filename: openingImage.filename,
-        base64: openingImage.base64,
-        width: openingImage.width,
-        height: openingImage.height,
-        mime: /\.jpe?g$/i.test(openingImage.filename)
-          ? "image/jpeg"
-          : "image/png",
+    const prepared = await prepareStillSourceToRequest(
+      route,
+      {
+        source: {
+          kind: "upload",
+          filename: openingImage.filename,
+          base64: openingImage.base64,
+          width: openingImage.width,
+          height: openingImage.height,
+          mime: /\.jpe?g$/i.test(openingImage.filename)
+            ? "image/jpeg"
+            : "image/png",
+        },
+        mask: null,
+        maskless: true,
+        settings: {
+          policy: shared.sourceFitPolicy,
+          upscalerModel: shared.upscalerModel,
+          family: shared.family,
+          frames: null,
+          width: shared.width,
+          height: shared.height,
+        },
       },
-      mask: null,
-      maskless: true,
-      settings: {
-        policy: shared.sourceFitPolicy,
-        upscalerModel: shared.upscalerModel,
-        family: shared.family,
-        frames: null,
-        width: shared.width,
-        height: shared.height,
-      },
-    });
-    if (prepared === false) return;
+      signal,
+    );
+    if (prepared === false || !isCurrent()) return;
     openingImage = prepared.source
       ? {
           ...openingImage,
@@ -1882,6 +1966,7 @@ async function onSubmitSequence() {
   });
 
   if (editing) {
+    const operationId = createUuid();
     const amendReq: AmendRequest = {
       stages: req.stages,
       motion_tail_frames: req.motion_tail_frames ?? null,
@@ -1902,12 +1987,27 @@ async function onSubmitSequence() {
         `${editing.hostId}:${editing.jobId}`,
         clips.map((clip) => clip.id),
       );
+      sequenceAmendInFlight = true;
+      sequenceCancellationRequest = () =>
+        chainJobs.cancelMutation(
+          editing.hostId,
+          editing.jobId,
+          operationId,
+          route.target,
+        );
       await chainJobs.amend(
         editing.hostId,
         editing.jobId,
         amendReq,
         route.target,
+        operationId,
       );
+      if (!isCurrent()) {
+        await chainJobs
+          .cancel(editing.hostId, editing.jobId, route.target)
+          .catch(() => {});
+        return;
+      }
       draft.stopEditing();
       editBaselineShared.value = null;
       toast("info", "Sequence updated — unchanged clips stay cached.");
@@ -1930,14 +2030,34 @@ async function onSubmitSequence() {
   }
 
   try {
-    const feasibility = await routing.revalidateFeasibleChain(route, req);
+    const feasibility = await routing.revalidateFeasibleChain(route, req, 1, {
+      signal,
+    });
+    if (!isCurrent()) return;
     if (feasibility.kind !== "route") {
       throw new Error(
         feasibilityMessage(feasibility, "this finalized sequence"),
       );
     }
     route = feasibility.route;
-    const jobId = await chainJobs.create(route.hostId, req);
+    const operationId = createUuid();
+    sequenceCancellationRequest = () =>
+      chainJobs.cancelMutation(
+        route.hostId,
+        operationId,
+        operationId,
+        route.target,
+      );
+    const jobId = await chainJobs.create(
+      route.hostId,
+      req,
+      route.target,
+      operationId,
+    );
+    if (!isCurrent()) {
+      await chainJobs.cancel(route.hostId, jobId, route.target).catch(() => {});
+      return;
+    }
     sequenceStageClipIdsByJob.set(
       `${route.hostId}:${jobId}`,
       clips.map((clip) => clip.id),
@@ -1950,6 +2070,7 @@ async function onSubmitSequence() {
     sequenceReuseNotice.value = null;
     toast("info", `Sequence queued on ${route.label}.`);
   } catch (error) {
+    if (!isCurrent()) return;
     composerError.value =
       error instanceof Error ? error.message : String(error);
   }
@@ -2548,6 +2669,7 @@ async function prepareStillSourceToRequest(
       height: number;
     };
   },
+  signal?: AbortSignal,
 ): Promise<PreparedStillSource | false> {
   let source = override
     ? override.source
@@ -2600,7 +2722,7 @@ async function prepareStillSourceToRequest(
                       : `Source preprocessing failed: ${err.message}`;
                 },
               },
-              undefined,
+              signal,
               route?.target,
             );
             if (output === null)
@@ -2909,15 +3031,17 @@ function resolveSubmitRoute(): HostRoute | null | false {
 
 async function resolveFeasibleSubmitRoute(
   request: GenerateRequestWire,
+  decision: ReturnType<typeof decideGenerateRequestRouting> | undefined,
+  quick: unknown,
+  signal: AbortSignal,
   copies = 1,
-  decision?: ReturnType<typeof decideGenerateRequestRouting>,
-  quick: unknown = null,
 ): Promise<HostRoute | false> {
-  const result = await routing.resolveFeasible(request, copies);
+  const result = await routing.resolveFeasible(request, copies, { signal });
+  if (signal?.aborted) return false;
   if (result.kind !== "route") {
     if (
       !decision ||
-      !(await offerMissingModelPull(result, request, decision, quick))
+      !(await offerMissingModelPull(result, request, decision, quick, signal))
     ) {
       toast("error", feasibilityMessage(result, "this print"));
     }
@@ -3001,7 +3125,8 @@ async function offerMissingModelPull(
   result: Exclude<FeasibilityResult, { kind: "route" }>,
   request: GenerateRequestWire,
   decision: ReturnType<typeof decideGenerateRequestRouting>,
-  quick: unknown = null,
+  quick: unknown,
+  signal: AbortSignal,
 ): Promise<boolean> {
   const failures = missingModelFailures(result);
   if (failures.length === 0) return false;
@@ -3018,6 +3143,7 @@ async function offerMissingModelPull(
     displayName: modelDisplayNameForId(model, models.value),
     restrictToHostIds: candidateIds,
   });
+  if (signal?.aborted) return true;
   // An explicit cancel is an answer: nothing was queued, and the dead-end
   // error toast would only restate what the user just dismissed.
   if (choice.kind === "cancelled") return true;
@@ -3028,6 +3154,7 @@ async function offerMissingModelPull(
   // inside that window would otherwise land in the baseline and be ignored
   // forever.
   const baseline = await pullResume.captureBaseline(hostId);
+  if (signal?.aborted) return true;
   let jobId: string | null = null;
   try {
     jobId = await installTargets.startDownloadOn(target, model);
@@ -3040,6 +3167,7 @@ async function offerMissingModelPull(
     );
     return true;
   }
+  if (signal.aborted) return true;
   if (!frozenRequestIsFinal(request, quick)) {
     toast(
       "info",
@@ -3048,19 +3176,24 @@ async function offerMissingModelPull(
     return true;
   }
   const resumeRoute = routing.multiHost.value ? routeForHostId(hostId) : null;
-  await pullResume.arm(
-    {
-      model,
-      // A catalog download reports its queue id on both routes; a plain
-      // manifest-name POST answers with no body, so that watch matches by
-      // model against the pre-POST terminal snapshot.
-      jobId,
-      hostId,
-      hostLabel,
-      resume: () => submitRequestCopies(request, decision, resumeRoute),
+  const pendingPull = {
+    model,
+    // A catalog download reports its queue id on both routes; a plain
+    // manifest-name POST answers with no body, so that watch matches by
+    // model against the pre-POST terminal snapshot.
+    jobId,
+    hostId,
+    hostLabel,
+    resume: () => {
+      if (!signal.aborted) submitRequestCopies(request, decision, resumeRoute);
     },
-    baseline,
-  );
+  };
+  if (signal.aborted) return true;
+  await pullResume.arm(pendingPull, baseline);
+  if (signal.aborted) {
+    pullResume.cancel(pendingPull);
+    return true;
+  }
   toast(
     "info",
     `Pulling ${model} on ${hostLabel} — generation starts when it's ready`,
@@ -3200,19 +3333,44 @@ function submitRequestCopies(
  * click could double-queue. */
 const submitInFlight = ref(false);
 const placementStatus = ref<string | null>(null);
+let submitController: AbortController | null = null;
+let submitAttempt = 0;
 async function onSubmit(allowStaleQuick = false) {
   if (submitInFlight.value) return;
+  const attempt = ++submitAttempt;
+  const controller = new AbortController();
+  submitController = controller;
   submitInFlight.value = true;
-  placementStatus.value = "Checking fit on the selected machine…";
+  placementStatus.value = "Checking machine fit and generation route…";
   try {
-    await onSubmitInner(allowStaleQuick);
+    await onSubmitInner(
+      controller.signal,
+      () => attempt === submitAttempt && !controller.signal.aborted,
+      allowStaleQuick,
+    );
   } finally {
-    submitInFlight.value = false;
-    placementStatus.value = null;
+    if (attempt === submitAttempt) {
+      submitController = null;
+      submitInFlight.value = false;
+      placementStatus.value = null;
+    }
   }
 }
 
-async function onSubmitInner(allowStaleQuick = false) {
+function cancelSubmitPlanning() {
+  if (!submitInFlight.value) return;
+  submitAttempt += 1;
+  submitController?.abort(new Error("cancelled"));
+  submitController = null;
+  submitInFlight.value = false;
+  placementStatus.value = null;
+}
+
+async function onSubmitInner(
+  signal: AbortSignal,
+  isCurrent: () => boolean,
+  allowStaleQuick = false,
+) {
   if (ordinarySubmitBlocked.value) return;
   // The route is settled first, and before source preprocessing, for two
   // reasons: an unreachable pinned machine is the real complaint (its model
@@ -3264,14 +3422,19 @@ async function onSubmitInner(allowStaleQuick = false) {
             route,
             resolveChainRequest(currentRequest, decision),
             copies,
+            { signal },
           )
-        : await routing.revalidateFeasible(route, currentRequest, copies)
+        : await routing.revalidateFeasible(route, currentRequest, copies, {
+            signal,
+          })
       : await resolveFeasibleSubmitRoute(
           currentRequest,
-          copies,
           decision,
           quick,
+          signal,
+          copies,
         );
+    if (!isCurrent()) return;
     if (result === false) return;
     if ("kind" in result && result.kind !== "route") {
       toast("error", feasibilityMessage(result, "this prepared print"));
@@ -3292,11 +3455,19 @@ async function onSubmitInner(allowStaleQuick = false) {
         ? await routing.resolveFeasibleChain(
             resolveChainRequest(currentRequest, decision),
             copies,
+            { signal },
           )
-        : await routing.resolveFeasible(currentRequest, copies);
+        : await routing.resolveFeasible(currentRequest, copies, { signal });
+    if (!isCurrent()) return;
     if (result.kind !== "route") {
       if (
-        !(await offerMissingModelPull(result, currentRequest, decision, quick))
+        !(await offerMissingModelPull(
+          result,
+          currentRequest,
+          decision,
+          quick,
+          signal,
+        ))
       ) {
         toast("error", feasibilityMessage(result, "this print"));
       }
@@ -3304,7 +3475,12 @@ async function onSubmitInner(allowStaleQuick = false) {
     }
     route = result.route;
   }
-  const preparedSource = await prepareStillSourceToRequest(route);
+  const preparedSource = await prepareStillSourceToRequest(
+    route,
+    undefined,
+    signal,
+  );
+  if (!isCurrent()) return;
   if (preparedSource === false) return;
   const req = form.toRequest(currentModel.value);
   const finalizedCopies = requestCopyCount(req);
@@ -3326,18 +3502,22 @@ async function onSubmitInner(allowStaleQuick = false) {
         mimeType: string;
       },
     ): Promise<string | false> => {
-      const fitted = await prepareStillSourceToRequest(boundaryRoute, {
-        source: {
-          kind: "upload",
-          filename: boundary.filename,
-          base64,
-          width: boundary.width,
-          height: boundary.height,
-          mime: boundary.mimeType,
+      const fitted = await prepareStillSourceToRequest(
+        boundaryRoute,
+        {
+          source: {
+            kind: "upload",
+            filename: boundary.filename,
+            base64,
+            width: boundary.width,
+            height: boundary.height,
+            mime: boundary.mimeType,
+          },
+          mask: null,
+          maskless: true,
         },
-        mask: null,
-        maskless: true,
-      });
+        signal,
+      );
       if (fitted === false) return false;
       return fitted.source?.base64 ?? base64;
     };
@@ -3371,14 +3551,19 @@ async function onSubmitInner(allowStaleQuick = false) {
           route,
           resolveChainRequest(req, decision),
           finalizedCopies,
+          { signal },
         )
-      : await routing.revalidateFeasible(route, req, finalizedCopies)
+      : await routing.revalidateFeasible(route, req, finalizedCopies, {
+          signal,
+        })
     : decision.kind === "chain"
       ? await routing.resolveFeasibleChain(
           resolveChainRequest(req, decision),
           finalizedCopies,
+          { signal },
         )
-      : await routing.resolveFeasible(req, finalizedCopies);
+      : await routing.resolveFeasible(req, finalizedCopies, { signal });
+  if (!isCurrent()) return;
   if (finalizedResult.kind !== "route") {
     toast("error", feasibilityMessage(finalizedResult, "this finalized print"));
     return;
@@ -4246,6 +4431,18 @@ onMounted(async () => {
 });
 
 onBeforeUnmount(() => {
+  submitAttempt += 1;
+  submitController?.abort(new Error("unmounted"));
+  submitController = null;
+  sequenceSubmitAttempt += 1;
+  sequenceSubmitController?.abort(new Error("unmounted"));
+  sequenceSubmitController = null;
+  const sequenceCancellation = sequenceCancellationRequest;
+  sequenceCancellationRequest = null;
+  sequenceAmendInFlight = false;
+  if (sequenceCancellation) {
+    void confirmCancellation(sequenceCancellation).catch(() => {});
+  }
   promptHistoryCoordinator.invalidate();
   stopAutoRefresh();
   clearSequencePreviews();
@@ -4434,7 +4631,9 @@ onBeforeUnmount(() => {
             :chain-level-dirty="chainLevelDirty"
             :stage-media-by-clip-id="sequenceFilmstripMediaByClipId"
             :playing-clip-id="playingSequenceClipId"
+            :submitting="sequenceSubmitInFlight"
             @submit="onSubmitSequence"
+            @cancel="cancelSequenceSubmit"
             @duplicate-as-new="onDuplicateAsNew"
             @discard-edit="onDiscardEdit"
             @expand-clip="onExpandClip"
@@ -4583,6 +4782,8 @@ onBeforeUnmount(() => {
             :steps="form.state.value.steps"
             :batch-size="form.state.value.batchSize"
             :busy="ordinarySubmitBlocked || submitInFlight"
+            :cancellable="submitInFlight"
+            :busy-label="placementStatus ?? 'Planning generation…'"
             :disabled-reason="h3GenerationInputBlocker"
             :expanded="expanded"
             :prompt-optional="canSkipPrompt"
@@ -4590,6 +4791,7 @@ onBeforeUnmount(() => {
             :history="promptHistory"
             @update:prompt="onPromptAuthored"
             @submit="onSubmit"
+            @cancel="cancelSubmitPlanning"
             @expand="onExpand"
             @remix="onRemix"
             @undo-expand="undoExpand"


### PR DESCRIPTION
## Summary
- keep Generate cancellable during placement, source preparation, expansion, missing-model handoff, and sequence startup on web, desktop, and iPhone
- abort client preflight work and add cooperative server placement cancellation checkpoints
- add client-known sequence operation IDs so cancellation remains authoritative before a job ID response, with frozen-target keepalive retries and visible unconfirmed failures
- replace vague Planning labels with the concrete preparation step

## Validation
- focused web cancellation/API tests
- focused desktop and iPhone cancellation tests
- server mutation-fence and mid-planning cancellation tests
- web + desktop vue-tsc
- mold-ai-server clippy with warnings denied
- rendered web QA confirmed Cancel restores Generate immediately and aborts the placement request
- independent agent peer review: no findings