### PR TITLE
feat(cli): add nightly update channel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ env:
   # Rolling binaries route to the rolling GHCR map; stable tag builds embed the
   # exact release used to resolve its published target-to-digest manifest.
   MOLD_DISTRIBUTION_IMAGE_VERSION: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || 'latest' }}
+  MOLD_BUILD_CHANNEL: ${{ startsWith(github.ref, 'refs/tags/v') && 'stable' || 'nightly' }}
 
 jobs:
   build-macos:
@@ -661,7 +662,7 @@ jobs:
 
             The install script auto-detects your GPU:
             ```bash
-            curl -fsSL https://raw.githubusercontent.com/utensils/mold/main/install.sh | sh
+            curl -fsSL https://raw.githubusercontent.com/utensils/mold/main/install.sh | MOLD_CHANNEL=nightly sh
             ```
 
             Manual install:

--- a/README.md
+++ b/README.md
@@ -23,13 +23,22 @@ Discord bot, and REST/SSE API built on the same engine.
 
 ## Install
 
+Stable release:
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/utensils/mold/main/install.sh | sh
 ```
 
+Nightly CLI from the latest published `main` build:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/utensils/mold/main/install.sh | MOLD_CHANNEL=nightly sh
+```
+
 The installer picks the right prebuilt binary for your GPU and verifies its
-checksum. Nix (`nix run github:utensils/mold`), Arch (`paru -S mold-ai-bin`),
-and source builds are covered in the
+checksum. Use `mold update` to stay on stable or `mold update --nightly` to
+install the newest nightly. Nix (`nix run github:utensils/mold`), Arch
+(`paru -S mold-ai-bin`), and source builds are covered in the
 [installation guide](https://utensils.io/mold/guide/installation);
 binaries and checksums are on the
 [releases page](https://github.com/utensils/mold/releases/latest).

--- a/changelog.d/cli-nightly-update.md
+++ b/changelog.d/cli-nightly-update.md
@@ -1,0 +1,1 @@
+- **CLI nightly channel.** `mold update --nightly` now installs the latest verified rolling CLI build from `main`, and the one-line installer accepts `MOLD_CHANNEL=nightly` for fresh nightly installs.

--- a/crates/mold-cli/src/commands/update.rs
+++ b/crates/mold-cli/src/commands/update.rs
@@ -15,6 +15,7 @@ use mold_core::cuda_distribution::{
 
 const GITHUB_REPO: &str = "utensils/mold";
 const GITHUB_API_BASE: &str = "https://api.github.com";
+const NIGHTLY_TAG: &str = "latest";
 
 // ── GitHub API types ────────────────────────────────────────────────────────
 
@@ -29,6 +30,16 @@ struct GitHubAsset {
     name: String,
     browser_download_url: String,
     size: u64,
+}
+
+#[derive(serde::Deserialize)]
+struct GitHubRef {
+    object: GitHubRefObject,
+}
+
+#[derive(serde::Deserialize)]
+struct GitHubRefObject {
+    sha: String,
 }
 
 // ── Version comparison ──────────────────────────────────────────────────────
@@ -53,6 +64,41 @@ fn is_newer(current: &str, remote: &str) -> bool {
         (Some(c), Some(r)) => r > c,
         _ => false,
     }
+}
+
+fn is_same_commit(current: &str, remote: &str) -> bool {
+    if current == "unknown"
+        || current.len() < mold_core::build_info::SHORT_SHA_LENGTH
+        || remote.len() < mold_core::build_info::SHORT_SHA_LENGTH
+        || !current
+            .chars()
+            .all(|character| character.is_ascii_hexdigit())
+        || !remote
+            .chars()
+            .all(|character| character.is_ascii_hexdigit())
+    {
+        return false;
+    }
+    current.starts_with(remote) || remote.starts_with(current)
+}
+
+fn is_current_nightly(build_channel: &str, current_commit: &str, remote_commit: &str) -> bool {
+    build_channel == "nightly" && is_same_commit(current_commit, remote_commit)
+}
+
+fn binary_contains_commit(binary: &[u8], commit: &str) -> bool {
+    commit.len() == 40
+        && commit
+            .chars()
+            .all(|character| character.is_ascii_hexdigit())
+        && binary
+            .windows(commit.len())
+            .any(|candidate| candidate == commit.as_bytes())
+}
+
+fn short_commit(sha: &str) -> &str {
+    sha.get(..mold_core::build_info::SHORT_SHA_LENGTH)
+        .unwrap_or(sha)
 }
 
 // ── Platform detection ──────────────────────────────────────────────────────
@@ -395,6 +441,61 @@ async fn fetch_release_by_tag(client: &reqwest::Client, tag: &str) -> Result<Git
         .context("failed to parse GitHub release response")
 }
 
+/// Fetch the mutable rolling prerelease used by CLI nightly builds.
+async fn fetch_nightly_release(client: &reqwest::Client) -> Result<GitHubRelease> {
+    let url = format!("{GITHUB_API_BASE}/repos/{GITHUB_REPO}/releases/tags/{NIGHTLY_TAG}");
+    let resp = client
+        .get(&url)
+        .send()
+        .await
+        .context("failed to connect to GitHub API")?;
+
+    if resp.status() == reqwest::StatusCode::NOT_FOUND {
+        bail!("nightly release not found on GitHub");
+    }
+    if resp.status() == reqwest::StatusCode::FORBIDDEN {
+        bail!(
+            "GitHub API rate limit exceeded. Set GITHUB_TOKEN to authenticate:\n  \
+             export GITHUB_TOKEN=$(gh auth token)"
+        );
+    }
+    if !resp.status().is_success() {
+        bail!("GitHub API returned {}", resp.status());
+    }
+
+    resp.json()
+        .await
+        .context("failed to parse GitHub nightly release response")
+}
+
+async fn fetch_nightly_commit(client: &reqwest::Client) -> Result<String> {
+    let url = format!("{GITHUB_API_BASE}/repos/{GITHUB_REPO}/git/ref/tags/{NIGHTLY_TAG}");
+    let resp = client
+        .get(&url)
+        .send()
+        .await
+        .context("failed to resolve the GitHub nightly tag")?;
+
+    if resp.status() == reqwest::StatusCode::FORBIDDEN {
+        bail!(
+            "GitHub API rate limit exceeded. Set GITHUB_TOKEN to authenticate:\n  \
+             export GITHUB_TOKEN=$(gh auth token)"
+        );
+    }
+    if !resp.status().is_success() {
+        bail!(
+            "GitHub API returned {} while resolving nightly",
+            resp.status()
+        );
+    }
+
+    let git_ref: GitHubRef = resp
+        .json()
+        .await
+        .context("failed to parse the GitHub nightly tag response")?;
+    Ok(git_ref.object.sha)
+}
+
 /// Download a release asset with a progress bar.
 async fn download_asset(client: &reqwest::Client, url: &str, size: u64) -> Result<Vec<u8>> {
     let resp = client
@@ -458,16 +559,30 @@ fn select_release_asset<'a>(
 
 // ── Main command ────────────────────────────────────────────────────────────
 
-pub async fn run(check: bool, force: bool, version: Option<String>) -> Result<()> {
+pub async fn run(check: bool, force: bool, nightly: bool, version: Option<String>) -> Result<()> {
     let current = mold_core::build_info::VERSION;
-    eprintln!("{} Current version: {current}", theme::icon_info());
-    eprintln!("{} Checking for updates...", theme::icon_info());
+    let current_display = mold_core::build_info::version_string();
+    eprintln!("{} Current version: {current_display}", theme::icon_info());
+    if nightly {
+        eprintln!("{} Checking for nightly updates...", theme::icon_info());
+    } else {
+        eprintln!("{} Checking for updates...", theme::icon_info());
+    }
 
     let client = build_client()?;
 
-    let release = match &version {
-        Some(tag) => fetch_release_by_tag(&client, tag).await?,
-        None => fetch_latest_release(&client).await?,
+    let release = if nightly {
+        fetch_nightly_release(&client).await?
+    } else {
+        match &version {
+            Some(tag) => fetch_release_by_tag(&client, tag).await?,
+            None => fetch_latest_release(&client).await?,
+        }
+    };
+    let nightly_commit = if nightly {
+        Some(fetch_nightly_commit(&client).await?)
+    } else {
+        None
     };
 
     let remote_version = release
@@ -475,14 +590,28 @@ pub async fn run(check: bool, force: bool, version: Option<String>) -> Result<()
         .strip_prefix('v')
         .unwrap_or(&release.tag_name);
 
-    // Version comparison
+    // Nightlies are identified by source commit because their rolling release
+    // tag is always `latest` and their Cargo version may match stable.
     if !force {
-        if remote_version == current {
+        if let Some(commit) = nightly_commit.as_deref() {
+            if is_current_nightly(
+                mold_core::build_info::BUILD_CHANNEL,
+                mold_core::build_info::GIT_SHA,
+                commit,
+            ) {
+                eprintln!(
+                    "{} Already up to date (nightly {})",
+                    theme::icon_done(),
+                    short_commit(commit)
+                );
+                return Ok(());
+            }
+        } else if remote_version == current {
             eprintln!("{} Already up to date ({current})", theme::icon_done());
             return Ok(());
         }
 
-        if version.is_none() && !is_newer(current, remote_version) {
+        if !nightly && version.is_none() && !is_newer(current, remote_version) {
             eprintln!(
                 "{} Current version ({current}) is newer than latest release ({remote_version})",
                 theme::icon_done()
@@ -491,7 +620,9 @@ pub async fn run(check: bool, force: bool, version: Option<String>) -> Result<()
         }
     }
 
-    let action = if is_newer(current, remote_version) {
+    let action = if nightly {
+        "Installing nightly"
+    } else if is_newer(current, remote_version) {
         "Updating"
     } else if remote_version == current {
         "Reinstalling"
@@ -501,7 +632,13 @@ pub async fn run(check: bool, force: bool, version: Option<String>) -> Result<()
 
     // --check: report availability and exit (no write access needed)
     if check {
-        if is_newer(current, remote_version) {
+        if let Some(commit) = nightly_commit.as_deref() {
+            eprintln!(
+                "{} Nightly available: {} (current: {current_display})",
+                theme::icon_info(),
+                short_commit(commit)
+            );
+        } else if is_newer(current, remote_version) {
             eprintln!(
                 "{} New version available: {remote_version} (current: {current})",
                 theme::icon_info()
@@ -546,8 +683,12 @@ pub async fn run(check: bool, force: bool, version: Option<String>) -> Result<()
         }
     }
 
+    let remote_display = nightly_commit
+        .as_deref()
+        .map(|commit| format!("nightly {}", short_commit(commit)))
+        .unwrap_or_else(|| remote_version.to_string());
     eprintln!(
-        "{} {action}: {current} -> {remote_version}",
+        "{} {action}: {current_display} -> {remote_display}",
         theme::icon_info()
     );
 
@@ -607,11 +748,26 @@ pub async fn run(check: bool, force: bool, version: Option<String>) -> Result<()
     // Extract binary
     let binary = extract_binary_from_tarball(&archive_data)?;
 
+    if let Some(expected_commit) = nightly_commit.as_deref() {
+        anyhow::ensure!(
+            binary_contains_commit(&binary, expected_commit),
+            "nightly publication changed while downloading; the archive does not match commit {}. Retry `mold update --nightly`.",
+            short_commit(expected_commit)
+        );
+        let final_commit = fetch_nightly_commit(&client).await?;
+        anyhow::ensure!(
+            final_commit == expected_commit,
+            "nightly publication advanced from {} to {} while downloading. Retry `mold update --nightly`.",
+            short_commit(expected_commit),
+            short_commit(&final_commit)
+        );
+    }
+
     // Replace binary
     replace_binary(&binary, &exe_path)?;
 
     eprintln!(
-        "{} {action} complete: mold {remote_version} ({})",
+        "{} {action} complete: mold {remote_display} ({})",
         theme::icon_done(),
         exe_path.display()
     );
@@ -665,6 +821,37 @@ mod tests {
         assert!(is_newer("0.9.9", "1.0.0"));
         assert!(is_newer("0.99.99", "1.0.0"));
         assert!(!is_newer("1.0.0", "0.99.99"));
+    }
+
+    #[test]
+    fn nightly_commit_comparison_accepts_full_and_abbreviated_shas() {
+        let full = "9ea1353730812787f9214545c0f54201f1ced188";
+        assert!(is_same_commit(full, full));
+        assert!(is_same_commit("9ea1353", full));
+        assert!(is_same_commit(full, "9ea1353"));
+        assert!(!is_same_commit("bc6b99b", full));
+        assert!(!is_same_commit("unknown", full));
+    }
+
+    #[test]
+    fn only_an_official_nightly_at_the_same_commit_is_current() {
+        let full = "9ea1353730812787f9214545c0f54201f1ced188";
+        assert!(is_current_nightly("nightly", full, full));
+        assert!(!is_current_nightly("stable", full, full));
+        assert!(!is_current_nightly("development", full, full));
+        assert!(!is_current_nightly("nightly", "bc6b99b", full));
+    }
+
+    #[test]
+    fn nightly_archive_must_embed_the_exact_rolling_commit() {
+        let commit = "9ea1353730812787f9214545c0f54201f1ced188";
+        let binary = format!("binary-prefix\0{commit}\0binary-suffix");
+        assert!(binary_contains_commit(binary.as_bytes(), commit));
+        assert!(!binary_contains_commit(binary.as_bytes(), "bc6b99b"));
+        assert!(!binary_contains_commit(
+            binary.as_bytes(),
+            "bc6b99b423f0e85909ffceca9f4ae2b7fa900744"
+        ));
     }
 
     // ── Platform detection ──────────────────────────────────────────────

--- a/crates/mold-cli/src/main.rs
+++ b/crates/mold-cli/src/main.rs
@@ -1536,6 +1536,7 @@ Examples:
         after_long_help = "\
 Examples:
   mold update                   Update to latest release
+  mold update --nightly         Update to latest rolling build from main
   mold update --check           Check for updates without installing
   mold update --version v0.7.0  Install a specific version
   mold update --force           Reinstall even if already up-to-date"
@@ -1548,6 +1549,10 @@ Examples:
         /// Reinstall even if the current version matches
         #[arg(long)]
         force: bool,
+
+        /// Install the latest rolling build from main
+        #[arg(long, conflicts_with = "version")]
+        nightly: bool,
 
         /// Install a specific version tag (e.g. v0.7.0)
         #[arg(long)]
@@ -2488,9 +2493,10 @@ async fn run() -> anyhow::Result<()> {
         Commands::Update {
             check,
             force,
+            nightly,
             version,
         } => {
-            commands::update::run(check, force, version).await?;
+            commands::update::run(check, force, nightly, version).await?;
         }
         #[cfg(feature = "discord")]
         Commands::Discord => {

--- a/crates/mold-cli/src/skill/SKILL.md
+++ b/crates/mold-cli/src/skill/SKILL.md
@@ -889,6 +889,7 @@ On first launch after upgrading from a pre-#265 release, mold imports the `[expa
 
 ```bash
 mold update                       # Update to latest GitHub release
+mold update --nightly             # Install latest rolling build from main
 mold update --check               # Check for updates without installing
 mold update --version v0.6.0      # Install a specific version
 mold update --force               # Reinstall even if already up-to-date

--- a/crates/mold-cli/tests/cli_integration.rs
+++ b/crates/mold-cli/tests/cli_integration.rs
@@ -663,8 +663,19 @@ fn update_help_text() {
         .stdout(
             predicate::str::contains("--check")
                 .and(predicate::str::contains("--force"))
+                .and(predicate::str::contains("--nightly"))
                 .and(predicate::str::contains("--version")),
         );
+}
+
+#[test]
+fn update_nightly_conflicts_with_exact_version() {
+    let env = TestEnv::new();
+    env.cmd()
+        .args(["update", "--nightly", "--version", "v0.23.3"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("cannot be used with"));
 }
 
 #[test]

--- a/crates/mold-core/build.rs
+++ b/crates/mold-core/build.rs
@@ -50,6 +50,11 @@ fn main() {
     println!("cargo:rustc-env=MOLD_GIT_SHA={sha}");
     println!("cargo:rustc-env=MOLD_GIT_SHA_SHORT={short_sha}");
     println!("cargo:rustc-env=MOLD_BUILD_DATE={date}");
+    let build_channel = std::env::var("MOLD_BUILD_CHANNEL")
+        .ok()
+        .filter(|channel| matches!(channel.as_str(), "stable" | "nightly"))
+        .unwrap_or_else(|| "development".to_string());
+    println!("cargo:rustc-env=MOLD_BUILD_CHANNEL={build_channel}");
 
     // Build a full version string as a compile-time constant for clap's
     // #[command(version = ...)] which requires &'static str.
@@ -67,4 +72,5 @@ fn main() {
     println!("cargo:rerun-if-changed=../../.git/packed-refs");
     println!("cargo:rerun-if-env-changed=MOLD_GIT_SHA");
     println!("cargo:rerun-if-env-changed=MOLD_BUILD_DATE");
+    println!("cargo:rerun-if-env-changed=MOLD_BUILD_CHANNEL");
 }

--- a/crates/mold-core/src/build_info.rs
+++ b/crates/mold-core/src/build_info.rs
@@ -22,6 +22,12 @@ pub const SHORT_SHA_LENGTH: usize = 7;
 /// Date of the git commit (YYYY-MM-DD), or `"unknown"`.
 pub const BUILD_DATE: &str = env!("MOLD_BUILD_DATE");
 
+/// Distribution channel embedded by official release workflows.
+///
+/// Local and third-party builds use `"development"`, so commit equality alone
+/// can never make them impersonate an installed official nightly.
+pub const BUILD_CHANNEL: &str = env!("MOLD_BUILD_CHANNEL");
+
 /// Compile-time version string: `"0.2.0 (abc1234 2026-03-25)"`.
 ///
 /// Equivalent to [`version_string()`] but as a `&'static str` for use in
@@ -82,6 +88,14 @@ mod tests {
         assert!(parts[0].parse::<u32>().is_ok(), "year should be numeric");
         assert!(parts[1].parse::<u32>().is_ok(), "month should be numeric");
         assert!(parts[2].parse::<u32>().is_ok(), "day should be numeric");
+    }
+
+    #[test]
+    fn build_channel_is_known() {
+        assert!(matches!(
+            BUILD_CHANNEL,
+            "stable" | "nightly" | "development"
+        ));
     }
 
     #[test]

--- a/install.sh
+++ b/install.sh
@@ -10,6 +10,7 @@
 #
 # Options (via environment):
 #   MOLD_INSTALL_DIR  — install directory (default: ~/.local/bin)
+#   MOLD_CHANNEL      — release channel: stable or nightly (default: stable)
 #   MOLD_VERSION      — release tag to install (default: resolved from the
 #                       GitHub "latest release" redirect). Pin to a specific
 #                       tag like "v0.8.0" to reproduce an older install.
@@ -22,7 +23,8 @@ REPO="utensils/mold"
 # Empty / "latest" means "whatever /releases/latest currently redirects to".
 # We resolve this to a concrete tag name below so the status line reports the
 # real version and the download URL is deterministic.
-VERSION="${MOLD_VERSION:-latest}"
+CHANNEL="${MOLD_CHANNEL:-stable}"
+REQUESTED_VERSION="${MOLD_VERSION:-}"
 INSTALL_DIR="${MOLD_INSTALL_DIR:-$HOME/.local/bin}"
 
 # Detect platform
@@ -57,9 +59,25 @@ resolve_latest_tag() {
     echo "${RESOLVED_TAG}"
 }
 
-if [ "${VERSION}" = "latest" ] || [ -z "${VERSION}" ]; then
-    VERSION="$(resolve_latest_tag)"
-fi
+case "${CHANNEL}" in
+    stable)
+        VERSION="${REQUESTED_VERSION:-latest}"
+        if [ "${VERSION}" = "latest" ]; then
+            VERSION="$(resolve_latest_tag)"
+        fi
+        ;;
+    nightly)
+        if [ -n "${REQUESTED_VERSION}" ]; then
+            echo "Error: MOLD_CHANNEL=nightly cannot be combined with MOLD_VERSION." >&2
+            exit 1
+        fi
+        VERSION="latest"
+        ;;
+    *)
+        echo "Error: unsupported MOLD_CHANNEL=${CHANNEL}; expected stable or nightly." >&2
+        exit 1
+        ;;
+esac
 
 # Print the compute capability of every CUDA-visible GPU or MIG instance.
 # NVIDIA's management API sees the whole machine, so apply

--- a/scripts/tests/cuda-distribution-contract.sh
+++ b/scripts/tests/cuda-distribution-contract.sh
@@ -450,6 +450,8 @@ require_text "install.sh" 'nvidia-smi -L'
 require_text "install.sh" 'CUDA_VISIBLE_DEVICES'
 require_text "install.sh" 'SHA256SUMS'
 require_text "install.sh" 'return 44'
+require_text ".github/workflows/release.yml" 'MOLD_BUILD_CHANNEL:'
+require_text ".github/workflows/release.yml" "'stable' || 'nightly'"
 require_text "crates/mold-cli/src/commands/lambda.rs" \
   'resolve_distribution_image_reference'
 require_text "crates/mold-cli/src/commands/runpod.rs" \

--- a/scripts/tests/install-cuda-arch.sh
+++ b/scripts/tests/install-cuda-arch.sh
@@ -40,6 +40,33 @@ EOF
 
 chmod +x "$stub_bin/uname" "$stub_bin/nvidia-smi" "$stub_bin/curl"
 
+nightly_output="$(
+  PATH="$stub_bin:$PATH" \
+  TEST_INVENTORY="0, GPU-aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa, 8.9" \
+  TEST_MIG_LISTING="" \
+  MOLD_CHANNEL=nightly \
+  MOLD_INSTALL_DIR="$test_root/install" \
+  sh "$repo_root/install.sh" 2>&1 || true
+)"
+grep -Fq "/releases/download/latest/mold-x86_64-unknown-linux-gnu-cuda-sm89.tar.gz" \
+  <<<"$nightly_output" \
+  || {
+    echo "installer nightly channel did not select the rolling latest release" >&2
+    echo "$nightly_output" >&2
+    exit 1
+  }
+
+if PATH="$stub_bin:$PATH" \
+  TEST_INVENTORY="0, GPU-aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa, 8.9" \
+  TEST_MIG_LISTING="" \
+  MOLD_CHANNEL=nightly \
+  MOLD_VERSION=v0.23.3 \
+  MOLD_INSTALL_DIR="$test_root/install" \
+  sh "$repo_root/install.sh" >/dev/null 2>&1; then
+  echo "installer accepted both MOLD_CHANNEL=nightly and MOLD_VERSION" >&2
+  exit 1
+fi
+
 assert_inventory() {
   local inventory="$1"
   local expected_arch="$2"

--- a/website/guide/cli-reference.md
+++ b/website/guide/cli-reference.md
@@ -408,19 +408,19 @@ Common subcommands are `doctor`, `availability`, `deploy`, `status`, `logs`,
 
 ## Other Commands
 
-| Command                                           | Purpose                                                         |
-| ------------------------------------------------- | --------------------------------------------------------------- |
-| `mold default [MODEL]`                            | Get or set the default model                                    |
-| `mold stats [--json]`                             | Show disk usage for models, output, logs, and shared components |
-| `mold clean [--force] [--older-than DURATION]`    | Remove stale downloads, orphaned files, and old outputs         |
-| `mold server start/status/stop`                   | Manage a background server daemon                               |
-| `mold server discover`                            | Find mold servers advertised on the local network (mDNS)        |
-| `mold rm <MODELS...> [--force]`                   | Remove downloaded models                                        |
-| `mold ps`                                         | Show server status or local mold processes                      |
-| `mold unload`                                     | Unload the current server model                                 |
-| `mold update [--check] [--force] [--version TAG]` | Update a release binary                                         |
-| `mold skill <COMMAND>`                            | Manage Mold's embedded Agent Skill                              |
-| `mold version`                                    | Show version, build date, and git SHA                           |
+| Command                                                       | Purpose                                                         |
+| ------------------------------------------------------------- | --------------------------------------------------------------- |
+| `mold default [MODEL]`                                        | Get or set the default model                                    |
+| `mold stats [--json]`                                         | Show disk usage for models, output, logs, and shared components |
+| `mold clean [--force] [--older-than DURATION]`                | Remove stale downloads, orphaned files, and old outputs         |
+| `mold server start/status/stop`                               | Manage a background server daemon                               |
+| `mold server discover`                                        | Find mold servers advertised on the local network (mDNS)        |
+| `mold rm <MODELS...> [--force]`                               | Remove downloaded models                                        |
+| `mold ps`                                                     | Show server status or local mold processes                      |
+| `mold unload`                                                 | Unload the current server model                                 |
+| `mold update [--check] [--force] [--nightly] [--version TAG]` | Update a stable, nightly, or exact release binary               |
+| `mold skill <COMMAND>`                                        | Manage Mold's embedded Agent Skill                              |
+| `mold version`                                                | Show version, build date, and git SHA                           |
 
 ## `mold skill`
 

--- a/website/guide/index.md
+++ b/website/guide/index.md
@@ -60,6 +60,9 @@ mold run "a sunset over mountains"
 # That's it — the model downloads on first run (~12GB for flux-schnell:q8)
 ```
 
+For the latest rolling CLI build from `main`, add `MOLD_CHANNEL=nightly` on
+the `sh` side of the install pipe.
+
 ## What You Get
 
 - **Broad model support** — FLUX.1, SDXL, SD 1.5, SD 3.5, Z-Image, Flux.2 Klein

--- a/website/guide/installation.md
+++ b/website/guide/installation.md
@@ -16,6 +16,8 @@ agents, and custom API clients.
 
 ## One-Line Install (recommended)
 
+Stable release:
+
 ```bash
 curl -fsSL https://raw.githubusercontent.com/utensils/mold/main/install.sh | sh
 ```
@@ -36,6 +38,18 @@ which was the historical name for that same target. Timeouts, authentication
 failures, server failures, duplicate checksums, and checksum mismatches stop
 installation.
 
+### Nightly CLI
+
+Install the latest successfully published CLI build from `main`:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/utensils/mold/main/install.sh | MOLD_CHANNEL=nightly sh
+```
+
+Nightly uses the rolling `latest` prerelease and the same platform detection
+and SHA-256 verification as stable. It may be less tested than a tagged
+release. Re-run that command or use `mold update --nightly` to refresh it.
+
 ### Options
 
 All options are passed as environment variables:
@@ -46,6 +60,9 @@ curl -fsSL ... | MOLD_INSTALL_DIR=/usr/local/bin sh
 
 # Pin to a specific release tag (default: latest)
 curl -fsSL ... | MOLD_VERSION=v0.10.0 sh
+
+# Install the latest rolling build from main
+curl -fsSL ... | MOLD_CHANNEL=nightly sh
 
 # Force a GPU architecture (default: auto-detect on Linux)
 curl -fsSL ... | MOLD_CUDA_ARCH=sm86  sh   # Ampere (RTX 3090 / A40)
@@ -83,6 +100,7 @@ points at.
 
 ```bash
 mold update                       # Update to latest release
+mold update --nightly             # Install latest rolling build from main
 mold update --check               # Check for updates without installing
 mold update --version v0.7.0      # Install a specific version
 ```
@@ -209,9 +227,9 @@ See [Docker & RunPod](/deployment/docker) for full deployment instructions.
 
 ## Pre-Built Binaries
 
-The one-line installer always targets the latest tag from the
-[releases page](https://github.com/utensils/mold/releases). Each release ships
-the following assets:
+The one-line installer targets the latest stable tag by default; with
+`MOLD_CHANNEL=nightly`, it targets the rolling `latest` prerelease. Both use
+assets from the [releases page](https://github.com/utensils/mold/releases):
 
 | Platform                                         | File                                              |
 | ------------------------------------------------ | ------------------------------------------------- |

--- a/website/index.md
+++ b/website/index.md
@@ -131,6 +131,9 @@ mold run flux-dev:q4 "a sunset over mountains"
 mold run "neon cityscape" | viu -
 ```
 
+For the latest rolling CLI build from `main`, install with
+`curl -fsSL https://raw.githubusercontent.com/utensils/mold/main/install.sh | MOLD_CHANNEL=nightly sh`.
+
 ## Gallery
 
 All images generated locally with mold — click any to see the model and prompt.

--- a/website/scripts/verify-docs.mjs
+++ b/website/scripts/verify-docs.mjs
@@ -185,6 +185,7 @@ try {
 }
 
 const ignoredEnvVars = new Set([
+  'MOLD_BUILD_CHANNEL',
   'MOLD_BUILD_DATE',
   'MOLD_GIT_SHA',
   'MOLD_GIT_SHA_SHORT',


### PR DESCRIPTION
## Summary

- add `mold update --nightly` for the rolling CLI build from `main`
- add `MOLD_CHANNEL=nightly` to the verified one-line installer
- bind nightly downloads to their exact build channel and Git commit across mutable publication updates
- document stable and nightly CLI installation across the README, website, CLI reference, embedded skill, and release notes

## Validation

- `nix develop -c cargo test -p mold-ai-core build_info::tests`
- `nix develop -c cargo test -p mold-ai --bin mold commands::update::tests`
- `nix develop -c cargo test -p mold-ai --test cli_integration update_ --no-fail-fast`
- `nix develop -c cargo clippy -p mold-ai --bin mold -- -D warnings`
- `bash scripts/tests/install-cuda-arch.sh`
- `cd website && bun run fmt:check && bun run verify && bun run build`
- independent subagent review: no findings
