### PR TITLE
fix(h3): advertise the reviewed compact envelope in the generation profiles

### DIFF
--- a/changelog.d/h3-compact-profile-truth.md
+++ b/changelog.d/h3-compact-profile-truth.md
@@ -1,0 +1,10 @@
+- **MiniMax H3's reviewed models now advertise the envelope they actually
+  run.** The four compact and Turbo tags offered the official flexible ladder —
+  six aspect presets, 2–100 steps, 124–345 frames — while the engine admits
+  exactly 1344×768, the tier's own step count (21, 9, or 5), and exactly 124
+  frames. Picking anything else queued a print that failed late, after the
+  model was loaded. Create on web, desktop, and iPhone now shows the single
+  canvas and the fixed step and frame counts, snaps a stale saved value onto
+  them, and refuses an off-envelope request at submission with a message that
+  says what the limit is. The hidden official BF16 references keep the flexible
+  canvas unchanged.

--- a/crates/mold-cli/src/commands/generate.rs
+++ b/crates/mold-cli/src/commands/generate.rs
@@ -240,6 +240,7 @@ fn effective_dimensions(
 /// admission cost has been paid.
 fn effective_generation_steps(
     is_h3: bool,
+    model: &str,
     model_cfg: &mold_core::ModelConfig,
     config: &Config,
     steps: Option<u32>,
@@ -248,6 +249,21 @@ fn effective_generation_steps(
         return steps;
     }
     if is_h3 {
+        // Compact layouts (base + Turbo tags) run exactly their tier's
+        // reviewed step count, so it comes from the identity — never from
+        // `default_steps`, which `build_model_catalog` launders a user
+        // `model_pref` into and which can therefore be stale. Only the
+        // official BF16 reference keeps the stored value; its ladder really
+        // is adjustable. An unrecognized identity takes the compact answer,
+        // the same fail-toward-the-stricter-contract rule as
+        // `source_fit_dimensions` above.
+        if mold_core::minimax_h3::layout_for_model(model)
+            != Some(mold_core::minimax_h3::Layout::OfficialBf16)
+        {
+            return mold_core::minimax_h3::turbo_tier_for_model(model)
+                .map(|tier| tier.steps)
+                .unwrap_or(mold_core::minimax_h3::COMFY_DEFAULT_STEPS);
+        }
         model_cfg
             .default_steps
             .unwrap_or(mold_core::minimax_h3::COMFY_DEFAULT_STEPS)
@@ -333,6 +349,7 @@ fn refit_request_after_pull(
     if cli_steps.is_none() {
         req.steps = effective_generation_steps(
             family.is_some_and(mold_core::minimax_h3::is_family),
+            &req.model,
             model_cfg,
             config,
             None,
@@ -836,7 +853,7 @@ pub async fn run(
         source_image.as_deref(),
         edit_images.as_deref(),
     )?;
-    let effective_steps = effective_generation_steps(is_h3, &model_cfg, &config, steps);
+    let effective_steps = effective_generation_steps(is_h3, model, &model_cfg, &config, steps);
     let guidance_caps = mold_core::GuidanceCapabilities::for_recipe(
         family.as_deref().unwrap_or_default(),
         model,
@@ -4406,13 +4423,13 @@ mod tests {
                 "{model}"
             );
             assert_eq!(
-                effective_generation_steps(true, &model_cfg, &config, None),
+                effective_generation_steps(true, model, &model_cfg, &config, None),
                 expected_steps,
                 "{model}"
             );
             // An explicit --steps always wins.
             assert_eq!(
-                effective_generation_steps(true, &model_cfg, &config, Some(2)),
+                effective_generation_steps(true, model, &model_cfg, &config, Some(2)),
                 2
             );
             assert_eq!(
@@ -4438,8 +4455,100 @@ mod tests {
         // default through the same path.
         let official = config.resolved_model_config(mold_core::minimax_h3::FL2VA_OFFICIAL);
         assert_eq!(
-            effective_generation_steps(true, &official, &config, None),
+            effective_generation_steps(
+                true,
+                mold_core::minimax_h3::FL2VA_OFFICIAL,
+                &official,
+                &config,
+                None
+            ),
             mold_core::minimax_h3::DEFAULT_STEPS
+        );
+    }
+
+    /// `build_model_catalog` launders a user's saved `model_pref` into
+    /// `ModelConfig.default_steps`, so a value stored before the reviewed
+    /// envelope was pinned can outlive it. The compact tiers run exactly
+    /// their own step count, so an omitted `--steps` must resolve from the
+    /// tier identity and never from that stored preference — otherwise the
+    /// CLI builds a request its own profile then refuses. An explicit
+    /// `--steps` stays user input: the profile answers it with the clear
+    /// fixed-at message rather than a silent snap. The hidden official BF16
+    /// reference keeps the stored value, because its ladder is adjustable.
+    #[test]
+    fn h3_compact_steps_ignore_a_stale_model_pref_default() {
+        let config = Config::default();
+        for (model, expected_steps) in [
+            (mold_core::minimax_h3::FL2VA_COMFY, 21),
+            (mold_core::minimax_h3::REF2VA_COMFY, 21),
+            (mold_core::minimax_h3::FL2VA_COMFY_TURBO_8STEP, 9),
+            (mold_core::minimax_h3::FL2VA_COMFY_TURBO_4STEP_768P, 5),
+        ] {
+            let mut stale = config.resolved_model_config(model);
+            stale.default_steps = Some(30);
+            assert_eq!(
+                effective_generation_steps(true, model, &stale, &config, None),
+                expected_steps,
+                "{model}"
+            );
+            assert_eq!(
+                effective_generation_steps(true, model, &stale, &config, Some(30)),
+                30,
+                "{model}"
+            );
+
+            // End to end: the request the CLI builds from that stale config
+            // is admitted by the very profile that pins the envelope. A
+            // build without `mp4` withholds H3's MP4-only recipes entirely,
+            // so there is nothing to validate against there.
+            if let Some(profile) = local_generation_profile(&config, model)
+                .filter(|profile| profile.default_recipe().is_some())
+            {
+                let request: mold_core::GenerateRequest =
+                    serde_json::from_value(serde_json::json!({
+                        "prompt": "test",
+                        "model": model,
+                        "width": mold_core::minimax_h3::DEFAULT_WIDTH,
+                        "height": mold_core::minimax_h3::DEFAULT_HEIGHT,
+                        "steps": effective_generation_steps(true, model, &stale, &config, None),
+                        "guidance": 0.0,
+                        "frames": mold_core::minimax_h3::MIN_FRAMES,
+                        "fps": mold_core::minimax_h3::FIXED_FPS,
+                    }))
+                    .unwrap();
+                mold_core::generation_profile::validate_request_against_generation_profile(
+                    &profile, &request,
+                )
+                .unwrap_or_else(|error| panic!("{model}: {error}"));
+
+                // ...and the stale value the old code submitted is exactly
+                // what that profile refuses, with the message a user can act
+                // on. This is what an explicit `--steps 30` still earns.
+                let mut stale_request = request.clone();
+                stale_request.steps = 30;
+                assert!(
+                    mold_core::generation_profile::validate_request_against_generation_profile(
+                        &profile,
+                        &stale_request,
+                    )
+                    .unwrap_err()
+                    .contains("steps is fixed at"),
+                    "{model}"
+                );
+            }
+        }
+
+        let mut official = config.resolved_model_config(mold_core::minimax_h3::FL2VA_OFFICIAL);
+        official.default_steps = Some(30);
+        assert_eq!(
+            effective_generation_steps(
+                true,
+                mold_core::minimax_h3::FL2VA_OFFICIAL,
+                &official,
+                &config,
+                None
+            ),
+            30
         );
     }
 

--- a/crates/mold-core/src/generation_profile.rs
+++ b/crates/mold-core/src/generation_profile.rs
@@ -827,6 +827,14 @@ const H3: &[(u32, u32)] = &[
     (768, 1024),
     (768, 1344),
 ];
+/// The reviewed compact stack renders exactly one canvas: `private_server.rs`
+/// admits `DEFAULT_WIDTH`x`DEFAULT_HEIGHT` and nothing else, and the engine
+/// fits any source into it. Advertising the official ladder here is what let
+/// users pick a size the engine refuses after the load was paid for.
+const H3_COMPACT: &[(u32, u32)] = &[(
+    crate::minimax_h3::DEFAULT_WIDTH,
+    crate::minimax_h3::DEFAULT_HEIGHT,
+)];
 
 const Z_IMAGE_QUALIFICATION: ResolutionQualificationRecord =
     ResolutionQualificationRecord {
@@ -891,6 +899,16 @@ pub fn presets_for_identity<'a>(
     sub_family: Option<&str>,
 ) -> &'a [(u32, u32)] {
     let family = canonical_family(family);
+    if family == "minimax-h3" {
+        // Only the hidden official BF16 references keep the flexible ladder.
+        // Every compact identity — and any identity the layout resolver does
+        // not recognize — takes the fixed reviewed envelope, the same
+        // fail-toward-the-stricter-contract rule as `source_fit_dimensions`.
+        return match crate::minimax_h3::layout_for_model(model) {
+            Some(crate::minimax_h3::Layout::OfficialBf16) => H3,
+            _ => H3_COMPACT,
+        };
+    }
     if family != "wan" {
         return family_presets(family);
     }
@@ -960,6 +978,16 @@ fn recipe(
     pipeline: Option<Ltx2PipelineMode>,
 ) -> GenerationRecipeProfile {
     let family = canonical_family(input.family);
+    // The reviewed compact H3 stack has one canvas, one step count, and one
+    // frame count. All three are derived from the identity, never from
+    // `input.default_*` — those are laundered through user `model_prefs` in
+    // `build_model_catalog` and can carry a stale off-envelope value.
+    let h3_compact = family == "minimax-h3"
+        && crate::minimax_h3::layout_for_model(input.model)
+            != Some(crate::minimax_h3::Layout::OfficialBf16);
+    let h3_compact_steps = crate::minimax_h3::turbo_tier_for_model(input.model)
+        .map(|tier| tier.steps)
+        .unwrap_or(crate::minimax_h3::COMFY_DEFAULT_STEPS);
     let audio_only = pipeline == Some(Ltx2PipelineMode::T2a);
     let source_driven = family == "qwen-image-edit"
         || matches!(
@@ -1024,7 +1052,7 @@ fn recipe(
         ResolutionProfile {
             domain: if source_driven {
                 ResolutionDomain::SourceDriven
-            } else if family == "wan" {
+            } else if family == "wan" || h3_compact {
                 ResolutionDomain::Buckets
             } else {
                 ResolutionDomain::Dynamic
@@ -1045,8 +1073,13 @@ fn recipe(
                 .then_some(crate::minimax_h3::MAX_ASPECT_RATIO),
             // Wan's buckets are the trained sizes, not the only runnable
             // ones — a deliberate off-bucket request is admitted and the
-            // advisory warning channel says results may vary.
-            off_bucket: (family == "wan").then_some(OffBucketPolicy::Warn),
+            // advisory warning channel says results may vary. H3's compact
+            // bucket is the only size its admission accepts, so it refuses.
+            off_bucket: if h3_compact {
+                Some(OffBucketPolicy::Reject)
+            } else {
+                (family == "wan").then_some(OffBucketPolicy::Warn)
+            },
             aspect_groups: aspect_groups(family, &dimensions),
         }
     };
@@ -1061,7 +1094,17 @@ fn recipe(
         GuidanceCapabilities::for_recipe(family, input.model, pipeline)
     };
     let effective_guidance = guidance_caps.fixed_scale.unwrap_or(input.default_guidance);
-    let temporal = temporal_profile(input, family);
+    let mut temporal = temporal_profile(input, family);
+    if let Some(temporal) = temporal.as_mut().filter(|_| h3_compact) {
+        temporal.frames = IntegerControl {
+            default: crate::minimax_h3::MIN_FRAMES,
+            min: crate::minimax_h3::MIN_FRAMES,
+            max: crate::minimax_h3::MIN_FRAMES,
+            step: crate::minimax_h3::FRAME_STEP,
+            recommended: vec![crate::minimax_h3::MIN_FRAMES],
+            mode: ControlMode::Fixed,
+        };
+    }
     let flux2_dev = family == "flux2"
         && crate::manifest::resolve_model_name(input.model)
             .to_ascii_lowercase()
@@ -1123,10 +1166,25 @@ fn recipe(
             delivery_reason: None,
         }
     };
+    let default_width = if h3_compact {
+        crate::minimax_h3::DEFAULT_WIDTH
+    } else {
+        input.default_width
+    };
+    let default_height = if h3_compact {
+        crate::minimax_h3::DEFAULT_HEIGHT
+    } else {
+        input.default_height
+    };
+    let default_steps = if h3_compact {
+        h3_compact_steps
+    } else {
+        input.default_steps
+    };
     let defaults = GenerationDefaultsProfile {
-        width: if audio_only { 0 } else { input.default_width },
-        height: if audio_only { 0 } else { input.default_height },
-        steps: input.default_steps,
+        width: if audio_only { 0 } else { default_width },
+        height: if audio_only { 0 } else { default_height },
+        steps: default_steps,
         guidance: effective_guidance,
         frames: temporal.as_ref().map(|profile| profile.frames.default),
         fps: temporal.as_ref().map(|profile| match profile.fps {
@@ -1142,12 +1200,22 @@ fn recipe(
         defaults,
         resolution,
         steps: IntegerControl {
-            default: input.default_steps,
-            min: if family == "minimax-h3" { 2 } else { 1 },
-            max: 100,
+            default: default_steps,
+            min: if h3_compact {
+                h3_compact_steps
+            } else if family == "minimax-h3" {
+                2
+            } else {
+                1
+            },
+            max: if h3_compact { h3_compact_steps } else { 100 },
             step: 1,
-            recommended: vec![input.default_steps],
-            mode: ControlMode::Adjustable,
+            recommended: vec![default_steps],
+            mode: if h3_compact {
+                ControlMode::Fixed
+            } else {
+                ControlMode::Adjustable
+            },
         },
         guidance: FloatControl {
             default: effective_guidance,
@@ -1986,6 +2054,163 @@ mod tests {
         assert!(generation_profile_default_output_format(&h3, None)
             .unwrap_err()
             .contains("no default recipe"));
+    }
+
+    #[test]
+    fn h3_compact_profiles_pin_the_reviewed_envelope() {
+        // The reviewed compact stack admits exactly one canvas, one step
+        // count, and one frame count. The laundered manifest defaults below
+        // are deliberately wrong (a stale user `model_pref` reaches this
+        // input through `build_model_catalog`), so the profile must derive
+        // the envelope from the identity rather than from what it was told.
+        for (model, steps) in [
+            (crate::minimax_h3::FL2VA_COMFY, 21),
+            (crate::minimax_h3::REF2VA_COMFY, 21),
+            (crate::minimax_h3::FL2VA_COMFY_TURBO_8STEP, 9),
+            (crate::minimax_h3::FL2VA_COMFY_TURBO_4STEP_768P, 5),
+        ] {
+            let mut h3_input = input(model, "minimax-h3");
+            h3_input.default_width = 768;
+            h3_input.default_height = 768;
+            h3_input.default_steps = 30;
+            h3_input.default_frames = Some(crate::minimax_h3::MAX_FRAMES);
+            h3_input.default_fps = Some(crate::minimax_h3::FIXED_FPS);
+            let profile = resolve_generation_profile(h3_input);
+            let recipe = profile.default_recipe().unwrap();
+
+            assert_eq!(
+                recipe.resolution.domain,
+                ResolutionDomain::Buckets,
+                "{model}"
+            );
+            assert_eq!(
+                recipe.resolution.off_bucket,
+                Some(OffBucketPolicy::Reject),
+                "{model}"
+            );
+            let presets = recipe
+                .resolution
+                .aspect_groups
+                .iter()
+                .flat_map(|group| &group.presets)
+                .map(|preset| (preset.width, preset.height))
+                .collect::<Vec<_>>();
+            assert_eq!(
+                presets,
+                vec![(
+                    crate::minimax_h3::DEFAULT_WIDTH,
+                    crate::minimax_h3::DEFAULT_HEIGHT
+                )],
+                "{model}"
+            );
+
+            assert_eq!(recipe.defaults.width, crate::minimax_h3::DEFAULT_WIDTH);
+            assert_eq!(recipe.defaults.height, crate::minimax_h3::DEFAULT_HEIGHT);
+            assert_eq!(recipe.defaults.steps, steps, "{model}");
+            assert_eq!(
+                recipe.defaults.frames,
+                Some(crate::minimax_h3::MIN_FRAMES),
+                "{model}"
+            );
+
+            assert_eq!(recipe.steps.mode, ControlMode::Fixed, "{model}");
+            assert_eq!(recipe.steps.min, steps, "{model}");
+            assert_eq!(recipe.steps.max, steps, "{model}");
+            assert_eq!(recipe.steps.default, steps, "{model}");
+            assert_eq!(recipe.steps.recommended, vec![steps], "{model}");
+
+            let temporal = recipe.temporal.as_ref().unwrap();
+            assert_eq!(temporal.frames.mode, ControlMode::Fixed, "{model}");
+            assert_eq!(
+                temporal.frames.min,
+                crate::minimax_h3::MIN_FRAMES,
+                "{model}"
+            );
+            assert_eq!(
+                temporal.frames.max,
+                crate::minimax_h3::MIN_FRAMES,
+                "{model}"
+            );
+            assert_eq!(
+                temporal.frames.default,
+                crate::minimax_h3::MIN_FRAMES,
+                "{model}"
+            );
+
+            let mut request = request_for(
+                &profile,
+                crate::minimax_h3::DEFAULT_WIDTH,
+                crate::minimax_h3::DEFAULT_HEIGHT,
+            );
+            request.output_format = Some(OutputFormat::Mp4);
+            validate_request_against_generation_profile(&profile, &request).unwrap();
+
+            let off_bucket = request_for(&profile, 768, 768);
+            assert!(
+                validate_request_against_generation_profile(&profile, &off_bucket)
+                    .unwrap_err()
+                    .contains("not an available bucket"),
+                "{model}"
+            );
+
+            let mut wrong_steps = request.clone();
+            wrong_steps.steps = 30;
+            assert!(
+                validate_request_against_generation_profile(&profile, &wrong_steps)
+                    .unwrap_err()
+                    .contains("steps is fixed at"),
+                "{model}"
+            );
+
+            let mut wrong_frames = request.clone();
+            wrong_frames.frames =
+                Some(crate::minimax_h3::MIN_FRAMES + crate::minimax_h3::FRAME_STEP);
+            assert!(
+                validate_request_against_generation_profile(&profile, &wrong_frames)
+                    .unwrap_err()
+                    .contains("frames is fixed at 124"),
+                "{model}"
+            );
+        }
+    }
+
+    #[test]
+    fn h3_official_profiles_keep_the_flexible_ladder() {
+        for model in [
+            crate::minimax_h3::FL2VA_OFFICIAL,
+            crate::minimax_h3::REF2VA_OFFICIAL,
+        ] {
+            let mut h3_input = input(model, "minimax-h3");
+            h3_input.default_width = crate::minimax_h3::DEFAULT_WIDTH;
+            h3_input.default_height = crate::minimax_h3::DEFAULT_HEIGHT;
+            h3_input.default_steps = crate::minimax_h3::DEFAULT_STEPS;
+            h3_input.default_frames = Some(crate::minimax_h3::MIN_FRAMES);
+            h3_input.default_fps = Some(crate::minimax_h3::FIXED_FPS);
+            let profile = resolve_generation_profile(h3_input);
+            let recipe = profile.default_recipe().unwrap();
+
+            assert_eq!(
+                recipe.resolution.domain,
+                ResolutionDomain::Dynamic,
+                "{model}"
+            );
+            assert_eq!(recipe.resolution.off_bucket, None, "{model}");
+            assert!(
+                recipe.resolution.aspect_groups.len() >= 2,
+                "{model}: the official ladder keeps every reviewed aspect"
+            );
+            assert_eq!(recipe.steps.mode, ControlMode::Adjustable, "{model}");
+            assert_eq!(recipe.steps.min, 2, "{model}");
+            assert_eq!(recipe.steps.max, 100, "{model}");
+
+            let temporal = recipe.temporal.as_ref().unwrap();
+            assert_eq!(temporal.frames.mode, ControlMode::Adjustable, "{model}");
+            assert_eq!(
+                temporal.frames.max,
+                crate::minimax_h3::MAX_FRAMES,
+                "{model}"
+            );
+        }
     }
 
     #[test]

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -4731,6 +4731,116 @@ describe("MobileApp wan source conditioning", () => {
     expect(wrapper.find("[data-test='mobile-h3-authoring-error']").exists()).toBe(false);
   });
 
+  it("snaps a stale steps value onto the recipe's fixed control instead of blocking Develop", async () => {
+    // The reviewed compact H3 tags pin steps at their tier count. Gallery
+    // reuse restores a print saved before that pin by writing straight into
+    // the live form (`applyMetadataToForm`), leaving the model alone and
+    // only moving `steps` — so the model-pick reconcile never runs. The
+    // submit-time snap cannot rescue it either: `stepsError` disables
+    // Develop and `basicParametersValid` returns `generate()` early, both
+    // first. The live form has to re-assert the fixed value itself.
+    const fixedStepsProfile = {
+      schema_version: 1,
+      profile_id: "minimax-h3.minimax-h3-fl2va",
+      profile_hash: "h3-compact-hash",
+      default_recipe_id: "default",
+      recipes: [
+        {
+          id: "default",
+          label: "Default",
+          request_selector: {},
+          defaults: { width: 1344, height: 768, steps: 21, guidance: 0, frames: 124, fps: 24 },
+          resolution: {
+            domain: "buckets" as const,
+            alignment: 32,
+            min_width: 64,
+            min_height: 64,
+            max_pixels: 1344 * 768,
+            off_bucket: "reject" as const,
+            aspect_groups: [
+              {
+                id: "7:4",
+                label: "7:4",
+                presets: [
+                  { id: "1344x768", width: 1344, height: 768, tier: "recommended" as const },
+                ],
+              },
+            ],
+          },
+          steps: { default: 21, min: 21, max: 21, step: 1, mode: "fixed" as const },
+          guidance: { default: 0, min: 0, max: 0, step: 0.1, mode: "fixed" as const },
+          temporal: {
+            frames: { default: 124, min: 124, max: 124, step: 17, mode: "fixed" as const },
+            frame_offset: 5,
+            fps: { mode: "fixed" as const, value: 24 },
+          },
+          capabilities: {
+            guidance: {
+              adjustable: false,
+              supports_negative_prompt: false,
+              fixed_scale: 0,
+            },
+            negative_prompt: { mode: "hidden" as const, required: false },
+            supports_lora: false,
+            supports_controlnet: false,
+            supports_sequence: false,
+            supports_extend: false,
+            supports_audio: true,
+            source_video: { mode: "hidden" as const, required: false },
+            mask: { mode: "hidden" as const, required: false },
+            keyframes: { mode: "hidden" as const, required: false },
+            audio: { mode: "hidden" as const, required: false },
+            lora: { mode: "hidden" as const, max_count: 0 },
+            controlnet: { mode: "hidden" as const, max_count: 0 },
+            output: {
+              default_format: "mp4" as const,
+              formats: ["mp4" as const],
+              audio_requires_mp4: true,
+            },
+            wan_recipe: {
+              mode: "hidden" as const,
+              supports_distill_strength: false,
+              supports_first_last_frame: false,
+            },
+            schedulers: [],
+          },
+          provenance: [],
+        },
+      ],
+    };
+    const h3Model = {
+      ...wanModel,
+      name: "minimax-h3-fl2va:comfy-pruned-int8",
+      family: "minimax-h3",
+      hf_repo: "Comfy-Org/MiniMax-H3",
+      default_steps: 21,
+      default_guidance: 0,
+      default_width: 1344,
+      default_height: 768,
+      default_frames: 124,
+      default_fps: 24,
+      generation_profile: fixedStepsProfile,
+    } as unknown as ModelEntry;
+    serveWan(h3Model);
+    wrapper = mountMobileApp();
+    await flushPromises();
+
+    const liveForm = wrapper.getComponent(MobileLoraControls).props("form") as GenerateForm;
+    expect(liveForm.steps).toBe(21);
+
+    // Exactly what reuse does for a print saved at the old flexible ladder:
+    // a direct write, same model, no reconcile.
+    liveForm.steps = 30;
+    await flushPromises();
+
+    expect(liveForm.steps).toBe(21);
+    await fieldControl("Prompt").setValue("a ship crossing violet lightning");
+    await flushPromises();
+    expect(wrapper.get("[data-test='mobile-develop-button']").attributes()).not.toHaveProperty(
+      "disabled",
+    );
+  });
+
   it("shows the H3 first-frame blocker before prompt entry and clears it after picking", async () => {
     const h3Model: ModelEntry = {
       ...wanModel,

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -1477,6 +1477,50 @@ const sourceControlsValid = computed(() => !caps.value.supportsImg2img || source
  * advertised text-to-video checkpoint hides the well entirely.
  */
 const sourceConditioningError = computed(() => sourceConditioningValidationError(form));
+const fixedRecipeControls = computed(() =>
+  fixedRecipeControlOverrides(
+    effectiveGenerationRecipe(selectedGenerationModel.value, form.pipeline),
+  ),
+);
+/**
+ * A fixed recipe control is authority the moment the recipe is known, and
+ * the gates below read the LIVE form: `stepsError` disables Develop through
+ * `developBlockerReason`, and `basicParametersValid` returns `generate()`
+ * early — both before the submit-time snap in `prepareGenerationRequest`
+ * can run. So a stale value would strand Develop behind an error on a
+ * control the user cannot edit.
+ *
+ * `applyModelDefaults` already reconciles a model *pick*; what it cannot
+ * cover is a later write straight into the form — gallery reuse restoring a
+ * print saved before the envelope was pinned goes through
+ * `applyMetadataToForm`, which can leave the model alone and only move
+ * `steps`. So this watches the VALUES, not just the recipe identity, and
+ * re-asserts only the fields that disagree (assigning an equal value would
+ * re-trigger it for nothing). Shared policy with desktop's
+ * `reconcileModelCapabilities`.
+ */
+watch(
+  () =>
+    [
+      fixedRecipeControls.value,
+      form.steps,
+      form.guidance,
+      form.width,
+      form.height,
+      form.frames,
+    ] as const,
+  () => {
+    const fixed = fixedRecipeControls.value;
+    if (fixed.steps !== undefined && form.steps !== fixed.steps) form.steps = fixed.steps;
+    if (fixed.guidance !== undefined && form.guidance !== fixed.guidance) {
+      form.guidance = fixed.guidance;
+    }
+    if (fixed.width !== undefined && form.width !== fixed.width) form.width = fixed.width;
+    if (fixed.height !== undefined && form.height !== fixed.height) form.height = fixed.height;
+    if (fixed.frames !== undefined && form.frames !== fixed.frames) form.frames = fixed.frames;
+  },
+  { immediate: true },
+);
 const stepsError = computed(() =>
   profileStepsValidationError(form.steps, selectedGenerationModel.value, form.pipeline),
 );

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -28,7 +28,10 @@ import { SourceFitPreprocessCache } from "@ui/lib/sourceFitPreprocessCache";
 import { createUuid } from "@studio/lib/id";
 import { filterRestrictedModels, modelAccessRestrictionFor } from "@studio/lib/modelAccess";
 import { expansionTaskForRequest } from "@studio/lib/expandTask";
-import { effectiveGenerationRecipe } from "@studio/lib/generationProfile";
+import {
+  effectiveGenerationRecipe,
+  fixedRecipeControlOverrides,
+} from "@studio/lib/generationProfile";
 import {
   conditioningFingerprint,
   defaultRemixDimensions,
@@ -4307,6 +4310,17 @@ async function prepareGenerationRequest(
   draft: GenerateForm,
   isCurrent: () => boolean = () => true,
 ) {
+  // Fixed recipe controls are not user choices: a stale draft value (restored
+  // before the recipe landed, model swapped under it) snaps to what the
+  // disabled control displays instead of queueing a shape the host refuses.
+  // It runs before the source fits below so their target is the canvas that
+  // actually renders. Shared with desktop and web.
+  Object.assign(
+    draft,
+    fixedRecipeControlOverrides(
+      effectiveGenerationRecipe(selectedGenerationModel.value, draft.pipeline),
+    ),
+  );
   const draftCaps = generationCapabilitiesForFamily(
     draft.family,
     draft.model,

--- a/docs/generated/generation-profiles-v1.json
+++ b/docs/generated/generation-profiles-v1.json
@@ -15514,7 +15514,7 @@
       "profile": {
         "schema_version": 1,
         "profile_id": "minimax-h3.minimax-h3-fl2va",
-        "profile_hash": "9918f8fe577353ebfeb588e8c020cbfbc70c0108038755e65be076abee3d66b0",
+        "profile_hash": "798cc1389b0b775773aa4db8a7721b9285eaad1668fce4e1ff0ccf48b3bcc9ec",
         "default_recipe_id": "default",
         "recipes": [
           {
@@ -15530,26 +15530,15 @@
               "fps": 24
             },
             "resolution": {
-              "domain": "dynamic",
+              "domain": "buckets",
               "alignment": 32,
               "min_width": 64,
               "min_height": 64,
               "max_pixels": 1069056,
               "min_aspect_ratio": 0.25,
               "max_aspect_ratio": 4.0,
+              "off_bucket": "reject",
               "aspect_groups": [
-                {
-                  "id": "16:7",
-                  "label": "16:7",
-                  "presets": [
-                    {
-                      "id": "1536x672",
-                      "width": 1536,
-                      "height": 672,
-                      "tier": "recommended"
-                    }
-                  ]
-                },
                 {
                   "id": "7:4",
                   "label": "7:4",
@@ -15561,66 +15550,18 @@
                       "tier": "recommended"
                     }
                   ]
-                },
-                {
-                  "id": "4:3",
-                  "label": "4:3",
-                  "presets": [
-                    {
-                      "id": "1024x768",
-                      "width": 1024,
-                      "height": 768,
-                      "tier": "recommended"
-                    }
-                  ]
-                },
-                {
-                  "id": "1:1",
-                  "label": "1:1",
-                  "presets": [
-                    {
-                      "id": "768x768",
-                      "width": 768,
-                      "height": 768,
-                      "tier": "recommended"
-                    }
-                  ]
-                },
-                {
-                  "id": "3:4",
-                  "label": "3:4",
-                  "presets": [
-                    {
-                      "id": "768x1024",
-                      "width": 768,
-                      "height": 1024,
-                      "tier": "recommended"
-                    }
-                  ]
-                },
-                {
-                  "id": "4:7",
-                  "label": "4:7",
-                  "presets": [
-                    {
-                      "id": "768x1344",
-                      "width": 768,
-                      "height": 1344,
-                      "tier": "recommended"
-                    }
-                  ]
                 }
               ]
             },
             "steps": {
               "default": 21,
-              "min": 2,
-              "max": 100,
+              "min": 21,
+              "max": 21,
               "step": 1,
               "recommended": [
                 21
               ],
-              "mode": "adjustable"
+              "mode": "fixed"
             },
             "guidance": {
               "default": 0.0,
@@ -15633,12 +15574,12 @@
               "frames": {
                 "default": 124,
                 "min": 124,
-                "max": 345,
+                "max": 124,
                 "step": 17,
                 "recommended": [
                   124
                 ],
-                "mode": "adjustable"
+                "mode": "fixed"
               },
               "frame_offset": 5,
               "fps": {
@@ -15732,7 +15673,7 @@
       "profile": {
         "schema_version": 1,
         "profile_id": "minimax-h3.minimax-h3-fl2va",
-        "profile_hash": "9c3a8270a55ab5194ec2248e389154d579d081b0921bc378d186f76e64d9c800",
+        "profile_hash": "4c4add73f9e0ef40117147e7856f1bb905502d6b87435945204c832dc946c434",
         "default_recipe_id": "default",
         "recipes": [
           {
@@ -15748,26 +15689,15 @@
               "fps": 24
             },
             "resolution": {
-              "domain": "dynamic",
+              "domain": "buckets",
               "alignment": 32,
               "min_width": 64,
               "min_height": 64,
               "max_pixels": 1069056,
               "min_aspect_ratio": 0.25,
               "max_aspect_ratio": 4.0,
+              "off_bucket": "reject",
               "aspect_groups": [
-                {
-                  "id": "16:7",
-                  "label": "16:7",
-                  "presets": [
-                    {
-                      "id": "1536x672",
-                      "width": 1536,
-                      "height": 672,
-                      "tier": "recommended"
-                    }
-                  ]
-                },
                 {
                   "id": "7:4",
                   "label": "7:4",
@@ -15779,66 +15709,18 @@
                       "tier": "recommended"
                     }
                   ]
-                },
-                {
-                  "id": "4:3",
-                  "label": "4:3",
-                  "presets": [
-                    {
-                      "id": "1024x768",
-                      "width": 1024,
-                      "height": 768,
-                      "tier": "recommended"
-                    }
-                  ]
-                },
-                {
-                  "id": "1:1",
-                  "label": "1:1",
-                  "presets": [
-                    {
-                      "id": "768x768",
-                      "width": 768,
-                      "height": 768,
-                      "tier": "recommended"
-                    }
-                  ]
-                },
-                {
-                  "id": "3:4",
-                  "label": "3:4",
-                  "presets": [
-                    {
-                      "id": "768x1024",
-                      "width": 768,
-                      "height": 1024,
-                      "tier": "recommended"
-                    }
-                  ]
-                },
-                {
-                  "id": "4:7",
-                  "label": "4:7",
-                  "presets": [
-                    {
-                      "id": "768x1344",
-                      "width": 768,
-                      "height": 1344,
-                      "tier": "recommended"
-                    }
-                  ]
                 }
               ]
             },
             "steps": {
               "default": 5,
-              "min": 2,
-              "max": 100,
+              "min": 5,
+              "max": 5,
               "step": 1,
               "recommended": [
                 5
               ],
-              "mode": "adjustable"
+              "mode": "fixed"
             },
             "guidance": {
               "default": 0.0,
@@ -15851,12 +15733,12 @@
               "frames": {
                 "default": 124,
                 "min": 124,
-                "max": 345,
+                "max": 124,
                 "step": 17,
                 "recommended": [
                   124
                 ],
-                "mode": "adjustable"
+                "mode": "fixed"
               },
               "frame_offset": 5,
               "fps": {
@@ -15950,7 +15832,7 @@
       "profile": {
         "schema_version": 1,
         "profile_id": "minimax-h3.minimax-h3-fl2va",
-        "profile_hash": "c78c1015b3187c8be0065a1462fa3abcc94faac1df7cda17ee477f7d0c99166e",
+        "profile_hash": "0cadfd2f7d60061941fff0d96761bd060dc9c557b08eb2c1787c6132a8570e22",
         "default_recipe_id": "default",
         "recipes": [
           {
@@ -15966,26 +15848,15 @@
               "fps": 24
             },
             "resolution": {
-              "domain": "dynamic",
+              "domain": "buckets",
               "alignment": 32,
               "min_width": 64,
               "min_height": 64,
               "max_pixels": 1069056,
               "min_aspect_ratio": 0.25,
               "max_aspect_ratio": 4.0,
+              "off_bucket": "reject",
               "aspect_groups": [
-                {
-                  "id": "16:7",
-                  "label": "16:7",
-                  "presets": [
-                    {
-                      "id": "1536x672",
-                      "width": 1536,
-                      "height": 672,
-                      "tier": "recommended"
-                    }
-                  ]
-                },
                 {
                   "id": "7:4",
                   "label": "7:4",
@@ -15997,66 +15868,18 @@
                       "tier": "recommended"
                     }
                   ]
-                },
-                {
-                  "id": "4:3",
-                  "label": "4:3",
-                  "presets": [
-                    {
-                      "id": "1024x768",
-                      "width": 1024,
-                      "height": 768,
-                      "tier": "recommended"
-                    }
-                  ]
-                },
-                {
-                  "id": "1:1",
-                  "label": "1:1",
-                  "presets": [
-                    {
-                      "id": "768x768",
-                      "width": 768,
-                      "height": 768,
-                      "tier": "recommended"
-                    }
-                  ]
-                },
-                {
-                  "id": "3:4",
-                  "label": "3:4",
-                  "presets": [
-                    {
-                      "id": "768x1024",
-                      "width": 768,
-                      "height": 1024,
-                      "tier": "recommended"
-                    }
-                  ]
-                },
-                {
-                  "id": "4:7",
-                  "label": "4:7",
-                  "presets": [
-                    {
-                      "id": "768x1344",
-                      "width": 768,
-                      "height": 1344,
-                      "tier": "recommended"
-                    }
-                  ]
                 }
               ]
             },
             "steps": {
               "default": 9,
-              "min": 2,
-              "max": 100,
+              "min": 9,
+              "max": 9,
               "step": 1,
               "recommended": [
                 9
               ],
-              "mode": "adjustable"
+              "mode": "fixed"
             },
             "guidance": {
               "default": 0.0,
@@ -16069,12 +15892,12 @@
               "frames": {
                 "default": 124,
                 "min": 124,
-                "max": 345,
+                "max": 124,
                 "step": 17,
                 "recommended": [
                   124
                 ],
-                "mode": "adjustable"
+                "mode": "fixed"
               },
               "frame_offset": 5,
               "fps": {
@@ -16386,7 +16209,7 @@
       "profile": {
         "schema_version": 1,
         "profile_id": "minimax-h3.minimax-h3-ref2va",
-        "profile_hash": "104fe16b6d900be648295d3fcbc1783ab03fc4a9b769af9d37a897dac2bff0f1",
+        "profile_hash": "c557cc2cabef7688f5ed5a9ce37867da9ab84d41076bd7eb348af8cc3d180b62",
         "default_recipe_id": "default",
         "recipes": [
           {
@@ -16402,26 +16225,15 @@
               "fps": 24
             },
             "resolution": {
-              "domain": "dynamic",
+              "domain": "buckets",
               "alignment": 32,
               "min_width": 64,
               "min_height": 64,
               "max_pixels": 1069056,
               "min_aspect_ratio": 0.25,
               "max_aspect_ratio": 4.0,
+              "off_bucket": "reject",
               "aspect_groups": [
-                {
-                  "id": "16:7",
-                  "label": "16:7",
-                  "presets": [
-                    {
-                      "id": "1536x672",
-                      "width": 1536,
-                      "height": 672,
-                      "tier": "recommended"
-                    }
-                  ]
-                },
                 {
                   "id": "7:4",
                   "label": "7:4",
@@ -16433,66 +16245,18 @@
                       "tier": "recommended"
                     }
                   ]
-                },
-                {
-                  "id": "4:3",
-                  "label": "4:3",
-                  "presets": [
-                    {
-                      "id": "1024x768",
-                      "width": 1024,
-                      "height": 768,
-                      "tier": "recommended"
-                    }
-                  ]
-                },
-                {
-                  "id": "1:1",
-                  "label": "1:1",
-                  "presets": [
-                    {
-                      "id": "768x768",
-                      "width": 768,
-                      "height": 768,
-                      "tier": "recommended"
-                    }
-                  ]
-                },
-                {
-                  "id": "3:4",
-                  "label": "3:4",
-                  "presets": [
-                    {
-                      "id": "768x1024",
-                      "width": 768,
-                      "height": 1024,
-                      "tier": "recommended"
-                    }
-                  ]
-                },
-                {
-                  "id": "4:7",
-                  "label": "4:7",
-                  "presets": [
-                    {
-                      "id": "768x1344",
-                      "width": 768,
-                      "height": 1344,
-                      "tier": "recommended"
-                    }
-                  ]
                 }
               ]
             },
             "steps": {
               "default": 21,
-              "min": 2,
-              "max": 100,
+              "min": 21,
+              "max": 21,
               "step": 1,
               "recommended": [
                 21
               ],
-              "mode": "adjustable"
+              "mode": "fixed"
             },
             "guidance": {
               "default": 0.0,
@@ -16505,12 +16269,12 @@
               "frames": {
                 "default": 124,
                 "min": 124,
-                "max": 345,
+                "max": 124,
                 "step": 17,
                 "recommended": [
                   124
                 ],
-                "mode": "adjustable"
+                "mode": "fixed"
               },
               "frame_offset": 5,
               "fps": {

--- a/docs/model-resolution-matrix.md
+++ b/docs/model-resolution-matrix.md
@@ -1383,73 +1383,58 @@ Provenance: [Upstream](https://github.com/Lightricks/LTX-2) at `4f8905737aac86a5
 
 ### `minimax-h3-fl2va:comfy-pruned-int8`
 
-Schema 1 · hash `9918f8fe577353ebfeb588e8c020cbfbc70c0108038755e65be076abee3d66b0` · default recipe `default`
+Schema 1 · hash `798cc1389b0b775773aa4db8a7721b9285eaad1668fce4e1ff0ccf48b3bcc9ec` · default recipe `default`
 
 Models: `minimax-h3-fl2va:comfy-pruned-int8`.
 
 #### Default (`default`)
 
-- Resolution: dynamic; alignment `32`; minimum `64x64`; maximum `1069056` pixels; axis limit `none`; aspect range `0.25–4`.
+- Resolution: buckets; alignment `32`; minimum `64x64`; maximum `1069056` pixels; axis limit `none`; aspect range `0.25–4`.
 - Defaults: `1344x768`, 21 steps, guidance 0.
-- Steps: 2–100 by 1; guidance: 0–0 by 0.1 (Fixed).
-- Temporal: frames 124–345 on `17n+5` (default 124); FPS fixed 24; duration limit 15s.
+- Steps: 21–21 by 1; guidance: 0–0 by 0.1 (Fixed).
+- Temporal: frames 124–124 on `17n+5` (default 124); FPS fixed 24; duration limit 15s.
 
 | Exact ratio | Qualified presets |
 |---|---|
-| `16:7` | `1536x672` (recommended) |
 | `7:4` | `1344x768` (recommended) |
-| `4:3` | `1024x768` (recommended) |
-| `1:1` | `768x768` (recommended) |
-| `3:4` | `768x1024` (recommended) |
-| `4:7` | `768x1344` (recommended) |
 
 Provenance: [Upstream](https://github.com/MiniMax-AI/MiniMax-H3) at `fa6891ff7cdaaa03fa4497e89ac64ff169219acf`, qualified: `true`, evidence: `mold.generation-profile.v1`.
 
 ### `minimax-h3-fl2va:comfy-pruned-int8-turbo-4step-768p`
 
-Schema 1 · hash `9c3a8270a55ab5194ec2248e389154d579d081b0921bc378d186f76e64d9c800` · default recipe `default`
+Schema 1 · hash `4c4add73f9e0ef40117147e7856f1bb905502d6b87435945204c832dc946c434` · default recipe `default`
 
 Models: `minimax-h3-fl2va:comfy-pruned-int8-turbo-4step-768p`.
 
 #### Default (`default`)
 
-- Resolution: dynamic; alignment `32`; minimum `64x64`; maximum `1069056` pixels; axis limit `none`; aspect range `0.25–4`.
+- Resolution: buckets; alignment `32`; minimum `64x64`; maximum `1069056` pixels; axis limit `none`; aspect range `0.25–4`.
 - Defaults: `1344x768`, 5 steps, guidance 0.
-- Steps: 2–100 by 1; guidance: 0–0 by 0.1 (Fixed).
-- Temporal: frames 124–345 on `17n+5` (default 124); FPS fixed 24; duration limit 15s.
+- Steps: 5–5 by 1; guidance: 0–0 by 0.1 (Fixed).
+- Temporal: frames 124–124 on `17n+5` (default 124); FPS fixed 24; duration limit 15s.
 
 | Exact ratio | Qualified presets |
 |---|---|
-| `16:7` | `1536x672` (recommended) |
 | `7:4` | `1344x768` (recommended) |
-| `4:3` | `1024x768` (recommended) |
-| `1:1` | `768x768` (recommended) |
-| `3:4` | `768x1024` (recommended) |
-| `4:7` | `768x1344` (recommended) |
 
 Provenance: [Upstream](https://github.com/MiniMax-AI/MiniMax-H3) at `fa6891ff7cdaaa03fa4497e89ac64ff169219acf`, qualified: `true`, evidence: `mold.generation-profile.v1`.
 
 ### `minimax-h3-fl2va:comfy-pruned-int8-turbo-8step`
 
-Schema 1 · hash `c78c1015b3187c8be0065a1462fa3abcc94faac1df7cda17ee477f7d0c99166e` · default recipe `default`
+Schema 1 · hash `0cadfd2f7d60061941fff0d96761bd060dc9c557b08eb2c1787c6132a8570e22` · default recipe `default`
 
 Models: `minimax-h3-fl2va:comfy-pruned-int8-turbo-8step`.
 
 #### Default (`default`)
 
-- Resolution: dynamic; alignment `32`; minimum `64x64`; maximum `1069056` pixels; axis limit `none`; aspect range `0.25–4`.
+- Resolution: buckets; alignment `32`; minimum `64x64`; maximum `1069056` pixels; axis limit `none`; aspect range `0.25–4`.
 - Defaults: `1344x768`, 9 steps, guidance 0.
-- Steps: 2–100 by 1; guidance: 0–0 by 0.1 (Fixed).
-- Temporal: frames 124–345 on `17n+5` (default 124); FPS fixed 24; duration limit 15s.
+- Steps: 9–9 by 1; guidance: 0–0 by 0.1 (Fixed).
+- Temporal: frames 124–124 on `17n+5` (default 124); FPS fixed 24; duration limit 15s.
 
 | Exact ratio | Qualified presets |
 |---|---|
-| `16:7` | `1536x672` (recommended) |
 | `7:4` | `1344x768` (recommended) |
-| `4:3` | `1024x768` (recommended) |
-| `1:1` | `768x768` (recommended) |
-| `3:4` | `768x1024` (recommended) |
-| `4:7` | `768x1344` (recommended) |
 
 Provenance: [Upstream](https://github.com/MiniMax-AI/MiniMax-H3) at `fa6891ff7cdaaa03fa4497e89ac64ff169219acf`, qualified: `true`, evidence: `mold.generation-profile.v1`.
 
@@ -1479,25 +1464,20 @@ Provenance: [Upstream](https://github.com/MiniMax-AI/MiniMax-H3) at `fa6891ff7cd
 
 ### `minimax-h3-ref2va:comfy-pruned-int8`
 
-Schema 1 · hash `104fe16b6d900be648295d3fcbc1783ab03fc4a9b769af9d37a897dac2bff0f1` · default recipe `default`
+Schema 1 · hash `c557cc2cabef7688f5ed5a9ce37867da9ab84d41076bd7eb348af8cc3d180b62` · default recipe `default`
 
 Models: `minimax-h3-ref2va:comfy-pruned-int8`.
 
 #### Default (`default`)
 
-- Resolution: dynamic; alignment `32`; minimum `64x64`; maximum `1069056` pixels; axis limit `none`; aspect range `0.25–4`.
+- Resolution: buckets; alignment `32`; minimum `64x64`; maximum `1069056` pixels; axis limit `none`; aspect range `0.25–4`.
 - Defaults: `1344x768`, 21 steps, guidance 0.
-- Steps: 2–100 by 1; guidance: 0–0 by 0.1 (Fixed).
-- Temporal: frames 124–345 on `17n+5` (default 124); FPS fixed 24; duration limit 15s.
+- Steps: 21–21 by 1; guidance: 0–0 by 0.1 (Fixed).
+- Temporal: frames 124–124 on `17n+5` (default 124); FPS fixed 24; duration limit 15s.
 
 | Exact ratio | Qualified presets |
 |---|---|
-| `16:7` | `1536x672` (recommended) |
 | `7:4` | `1344x768` (recommended) |
-| `4:3` | `1024x768` (recommended) |
-| `1:1` | `768x768` (recommended) |
-| `3:4` | `768x1024` (recommended) |
-| `4:7` | `768x1344` (recommended) |
 
 Provenance: [Upstream](https://github.com/MiniMax-AI/MiniMax-H3) at `fa6891ff7cdaaa03fa4497e89ac64ff169219acf`, qualified: `true`, evidence: `mold.generation-profile.v1`.
 

--- a/studio/lib/generationProfile.test.ts
+++ b/studio/lib/generationProfile.test.ts
@@ -189,9 +189,94 @@ describe("generation profile contract", () => {
     // a stale form value on a fixed control is never user authority (the
     // control is disabled), so it snaps instead of stranding Generate
     // behind an error the user cannot correct. Desktop and web share this.
+    // Its single reject-policy bucket is fixed authority too, exactly like
+    // H3's reviewed compact envelope.
     const recipe = effectiveGenerationRecipe(profileModel(), "one-stage");
-    expect(fixedRecipeControlOverrides(recipe)).toEqual({ guidance: 0 });
+    expect(fixedRecipeControlOverrides(recipe)).toEqual({
+      guidance: 0,
+      width: 1024,
+      height: 576,
+    });
     expect(fixedRecipeControlOverrides(null)).toEqual({});
+  });
+
+  it("treats a single reject-policy bucket as fixed resolution authority", () => {
+    const base = effectiveGenerationRecipe(profileModel(), "one-stage")!;
+    const single = (
+      overrides: Partial<GenerationRecipeProfile["resolution"]>,
+    ): GenerationRecipeProfile => ({
+      ...base,
+      resolution: { ...base.resolution, ...overrides },
+    });
+
+    // An absent policy means Reject — the fail-closed reading every other
+    // client path already takes — so it snaps just like an explicit one.
+    expect(
+      fixedRecipeControlOverrides(single({ off_bucket: "reject" })),
+    ).toMatchObject({
+      width: 1024,
+      height: 576,
+    });
+    expect(fixedRecipeControlOverrides(single({}))).toMatchObject({
+      width: 1024,
+      height: 576,
+    });
+
+    // Wan admits an off-bucket size with an advisory, so its buckets are
+    // recommendations rather than the only runnable canvas.
+    const warn = fixedRecipeControlOverrides(single({ off_bucket: "warn" }));
+    expect(warn.width).toBeUndefined();
+    expect(warn.height).toBeUndefined();
+
+    // More than one advertised bucket is a choice, not an envelope.
+    const multiple = fixedRecipeControlOverrides(
+      single({
+        aspect_groups: [
+          ...base.resolution.aspect_groups,
+          {
+            id: "1:1",
+            label: "1:1",
+            presets: [
+              { id: "768x768", width: 768, height: 768, tier: "recommended" },
+            ],
+          },
+        ],
+      }),
+    );
+    expect(multiple.width).toBeUndefined();
+
+    // Wuerstchen advertises one preset on a dynamic canvas — a preset is a
+    // suggestion there, and any aligned size is admitted.
+    const dynamic = fixedRecipeControlOverrides(single({ domain: "dynamic" }));
+    expect(dynamic.width).toBeUndefined();
+  });
+
+  it("snaps a fixed temporal frame count", () => {
+    const base = effectiveGenerationRecipe(profileModel(), "one-stage")!;
+    const adjustable: GenerationRecipeProfile = {
+      ...base,
+      temporal: {
+        frames: {
+          default: 124,
+          min: 124,
+          max: 345,
+          step: 17,
+          mode: "adjustable",
+        },
+        frame_offset: 5,
+        fps: { mode: "fixed", value: 24 },
+      },
+    };
+    expect(fixedRecipeControlOverrides(adjustable).frames).toBeUndefined();
+
+    const fixed: GenerationRecipeProfile = {
+      ...adjustable,
+      temporal: {
+        ...adjustable.temporal!,
+        frames: { ...adjustable.temporal!.frames, max: 124, mode: "fixed" },
+      },
+    };
+    expect(fixedRecipeControlOverrides(fixed).frames).toBe(124);
   });
 });
 

--- a/studio/lib/generationProfile.ts
+++ b/studio/lib/generationProfile.ts
@@ -679,14 +679,43 @@ export function profileAspectIdForResolution(
  * behind an error the user cannot correct. Desktop's
  * `reconcileModelCapabilities` and web's model-defaults/submit paths share
  * this so the two surfaces cannot drift.
+ *
+ * Resolution is fixed authority under exactly one shape: a bucket domain
+ * that refuses off-bucket sizes and advertises a single preset, which is
+ * H3's reviewed compact envelope. An absent `off_bucket` reads as Reject —
+ * the same fail-closed reading admission takes. Wan advertises buckets that
+ * only warn, and Wuerstchen advertises one preset on a dynamic canvas; a
+ * preset is a recommendation in both cases and neither snaps.
  */
 export function fixedRecipeControlOverrides(
   recipe: GenerationRecipeProfile | null | undefined,
-): { steps?: number; guidance?: number } {
-  const overrides: { steps?: number; guidance?: number } = {};
+): {
+  steps?: number;
+  guidance?: number;
+  width?: number;
+  height?: number;
+  frames?: number;
+} {
+  const overrides: ReturnType<typeof fixedRecipeControlOverrides> = {};
   if (recipe?.steps.mode === "fixed") overrides.steps = recipe.steps.default;
   if (recipe?.guidance.mode === "fixed") {
     overrides.guidance = recipe.guidance.default;
+  }
+  const resolution = recipe?.resolution;
+  if (
+    resolution?.domain === "buckets" &&
+    (resolution.off_bucket ?? "reject") !== "warn"
+  ) {
+    const [only, ...rest] = resolution.aspect_groups.flatMap(
+      (group) => group.presets,
+    );
+    if (only && rest.length === 0) {
+      overrides.width = only.width;
+      overrides.height = only.height;
+    }
+  }
+  if (recipe?.temporal?.frames.mode === "fixed") {
+    overrides.frames = recipe.temporal.frames.default;
   }
   return overrides;
 }

--- a/web/src/pages/CreatePage.vue
+++ b/web/src/pages/CreatePage.vue
@@ -2761,6 +2761,15 @@ function validateSubmit(): boolean {
   if (fixedControls.guidance !== undefined) {
     form.state.value.guidance = fixedControls.guidance;
   }
+  if (fixedControls.width !== undefined) {
+    form.state.value.width = fixedControls.width;
+  }
+  if (fixedControls.height !== undefined) {
+    form.state.value.height = fixedControls.height;
+  }
+  if (fixedControls.frames !== undefined) {
+    form.state.value.frames = fixedControls.frames;
+  }
   // Resolution constraints are advisory — the server is the authority and
   // its own refusal surfaces as the failed job's error. Only malformed
   // input that cannot form a request blocks the submit (recipe or not).

--- a/website/models/minimax-h3.md
+++ b/website/models/minimax-h3.md
@@ -134,6 +134,11 @@ of the source's aspect ratio — the engine fits the frame internally. The
 aspect-derived short-edge canvas applies only to the hidden official BF16
 reference.
 
+Every reviewed compact and Turbo tag advertises exactly this envelope, so
+Create on web, desktop, and iPhone offers the single `1344x768` canvas with the
+tier's step count and 124 frames already fixed, and an off-envelope request is
+refused at submission instead of after the model loads.
+
 Mold rejects rather than silently resizing, rerouting, changing steps, dropping
 the source image, or falling back to another backend. A downloaded checkpoint
 can remain stored on an unsupported host; Create and request routing become


### PR DESCRIPTION
The four reviewed MiniMax H3 compact/Turbo tags advertised the official flexible canvas — six aspect presets, adjustable steps 2–100, adjustable frames 124–345 — while the reviewed runtime admits exactly 1344×768, the tier's fixed step count (21 / 9 / 5), and exactly 124 frames. Create on every surface treats the profile as data authority, so users could pick 768×768 or steps 30 and get a late engine refusal after the load was paid for (the same defect class as #1202, on the profile side).

## Changes

- **mold-core `generation_profile.rs`**: compact H3 identities (base + Turbo + any unrecognized layout, fail-toward-stricter like `source_fit_dimensions`) now emit `Buckets` + a single 1344×768 preset + `off_bucket: Reject`, `ControlMode::Fixed` steps pinned to the tier count, and fixed 124 frames. All fixed values derive from `minimax_h3` identity constants — never from `input.default_*`, which `build_model_catalog` launders user `model_prefs` into. The hidden `official-bf16` references keep the flexible ladder; their generated profile documents are byte-identical (codex-verified).
- **Generated artifacts** regenerated (`generation-profiles-v1.json`, `model-resolution-matrix.md`); the TS wire contract is unchanged.
- **studio `fixedRecipeControlOverrides`**: also returns `width`/`height` for a single-preset reject-bucket recipe (absent `off_bucket` reads as Reject, matching admission) and `frames` for a fixed temporal control, so stale saved values snap on all three surfaces; web applies the new keys at submit.
- **iPhone**: a live-form watcher re-asserts fixed controls (a gallery reuse writes straight into the form without a model change, and the old submit-time-only snap sat behind the very validation gate the stale value tripped).
- **CLI**: an omitted `--steps` on a compact tag now resolves from the tier identity instead of a stale `model_pref` default; an explicit `--steps` stays user input and earns the profile's clear fixed-at refusal.

Deliberately out of scope (noted for follow-up): rendering the blocking `resolutionProfileError` / gating the Advanced exact-size inputs — the never-block advisory philosophy is a cross-surface policy decision; the server now refuses early with a clean message.

## Verification

- mold-core: 22 profile tests incl. new `h3_compact_profiles_pin_the_reviewed_envelope` (asserts refusal messages and happy path under deliberately stale laundered defaults) and `h3_official_profiles_keep_the_flexible_ladder`; `generate_generation_profiles -- --check` clean
- CLI: new `h3_compact_steps_ignore_a_stale_model_pref_default`
- Frontend: studio 19 tests, MobileApp 232 tests incl. the new stale-steps snap test, outputShape suite green
- `cargo fmt` / workspace clippy `-D warnings` clean
- Codex peer review: two P2 findings (CLI implicit steps, iPhone snap ordering) — both fixed above; no P1; official-bf16 hash stability confirmed