### PR TITLE
fix(ios): repair Library selection gestures

### DIFF
--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -6441,6 +6441,38 @@ describe("MobileApp gallery", () => {
     ]);
   });
 
+  it("leaves a vertical Select-mode swipe to native Library scrolling", async () => {
+    wrapper = mountMobileApp();
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-tab-gallery']").trigger("click");
+    await vi.waitFor(() => expect(wrapper?.find("[data-test='gallery-item']").exists()).toBe(true));
+    await wrapper.get("[data-test='mobile-gallery-select']").trigger("click");
+    const tile = wrapper.get("[data-test='gallery-item']");
+
+    await tile.trigger("pointerdown", {
+      pointerId: 43,
+      pointerType: "touch",
+      isPrimary: true,
+      clientX: 40,
+      clientY: 300,
+    });
+    const verticalMove = new PointerEvent("pointermove", {
+      pointerId: 43,
+      pointerType: "touch",
+      isPrimary: true,
+      clientX: 43,
+      clientY: 360,
+      cancelable: true,
+    });
+    window.dispatchEvent(verticalMove);
+    window.dispatchEvent(new PointerEvent("pointercancel", { pointerId: 43 }));
+    await wrapper.vm.$nextTick();
+
+    expect(verticalMove.defaultPrevented).toBe(false);
+    expect(tile.attributes("aria-pressed")).toBe("false");
+    expect(wrapper.get("[data-test='mobile-gallery-actions']").text()).toContain("0 selected");
+  });
+
   it("deletes one selected print from every host that contains a copy", async () => {
     const renderTarget = { baseUrl: "http://render.tailnet.ts.net:7680", apiKey: "secret" };
     localStorage.setItem(
@@ -7790,7 +7822,7 @@ describe("mobile Library pinch-to-resize", () => {
     const app = await openLibrary();
     await app.get("[data-test='mobile-gallery-select']").trigger("click");
 
-    // The first finger paints its tile before any movement proves intent.
+    // The first finger remains pending until movement proves drag intent.
     await app.get("[data-test='gallery-item']").trigger("pointerdown", {
       pointerId: 91,
       pointerType: "touch",
@@ -7798,9 +7830,9 @@ describe("mobile Library pinch-to-resize", () => {
       clientX: 0,
       clientY: 0,
     });
-    expect(app.get("[data-test='mobile-gallery-actions']").text()).toContain("1 selected");
+    expect(app.get("[data-test='mobile-gallery-actions']").text()).toContain("0 selected");
 
-    // The second finger makes it a pinch, so that paint was never intended.
+    // The second finger makes it a pinch without changing the selection.
     touchDown(app.get("[data-test='mobile-gallery-grid']").element, 92, 200);
     touchMove(91, 0, 900);
     touchMove(92, 340);

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -779,7 +779,10 @@ let gallerySentinelObserver: IntersectionObserver | null = null;
 let galleryChainedFetches = 0;
 const MAX_GALLERY_CHAINED_FETCHES = 3;
 let galleryDragPointerId: number | null = null;
+let galleryDragActive = false;
 let galleryDragSelect = true;
+let galleryDragStartX = 0;
+let galleryDragStartY = 0;
 let galleryDragClientX = 0;
 let galleryDragClientY = 0;
 let galleryDragFrame: number | null = null;
@@ -787,6 +790,7 @@ let galleryDragPendingClicks = 0;
 let galleryPinchPendingClicks = 0;
 let galleryDragSelectionBaseline: Set<string> | null = null;
 const galleryDragVisited = new Set<string>();
+const GALLERY_DRAG_INTENT_THRESHOLD = 8;
 const GALLERY_DRAG_SCROLL_EDGE = 72;
 const GALLERY_DRAG_SCROLL_MAX = 18;
 let resultMediaRecoveryClientId: number | null = null;
@@ -6751,7 +6755,7 @@ function applyGalleryDragSegment(fromX: number, fromY: number, toX: number, toY:
 
 function runGalleryDragFrame(): void {
   galleryDragFrame = null;
-  if (galleryDragPointerId === null || !gallerySelectMode.value) return;
+  if (galleryDragPointerId === null || !galleryDragActive || !gallerySelectMode.value) return;
   const scroller = mobileContent.value;
   if (scroller) {
     const bounds = scroller.getBoundingClientRect();
@@ -6782,26 +6786,46 @@ function beginGallerySelectionDrag(event: PointerEvent, print: GalleryPrint): vo
   ) {
     return;
   }
-  event.preventDefault();
   galleryDragPointerId = event.pointerId;
-  // The first tile is painted before any movement proves this is a drag. Keep
-  // the pre-drag selection so a second finger — which makes this a pinch, not a
-  // drag — can put it back exactly as the user left it.
+  galleryDragActive = event.pointerType === "mouse";
   galleryDragSelectionBaseline = new Set(gallerySelection.value);
   galleryDragSelect = !gallerySelection.value.has(galleryPrintKey(print));
+  galleryDragStartX = event.clientX;
+  galleryDragStartY = event.clientY;
   galleryDragClientX = event.clientX;
   galleryDragClientY = event.clientY;
   galleryDragVisited.clear();
-  applyGalleryDragSelection(print);
-  (event.currentTarget as HTMLElement | null)?.setPointerCapture?.(event.pointerId);
-  if (galleryDragFrame === null) galleryDragFrame = requestAnimationFrame(runGalleryDragFrame);
+  // Mouse has no native vertical-pan gesture to preserve, so it can paint on
+  // pointerdown. Touch waits for movement intent: vertical remains native
+  // scrolling, while horizontal/diagonal movement claims drag-selection.
+  if (galleryDragActive) {
+    event.preventDefault();
+    applyGalleryDragSelection(print);
+    (event.currentTarget as HTMLElement | null)?.setPointerCapture?.(event.pointerId);
+    if (galleryDragFrame === null) galleryDragFrame = requestAnimationFrame(runGalleryDragFrame);
+  }
 }
 
 function moveGallerySelectionDrag(event: PointerEvent): void {
   if (event.pointerId !== galleryDragPointerId) return;
-  event.preventDefault();
   const points = [...(event.getCoalescedEvents?.() ?? []), event];
   for (const point of points) {
+    if (!galleryDragActive) {
+      const deltaX = point.clientX - galleryDragStartX;
+      const deltaY = point.clientY - galleryDragStartY;
+      if (Math.hypot(deltaX, deltaY) < GALLERY_DRAG_INTENT_THRESHOLD) continue;
+      if (Math.abs(deltaY) > Math.abs(deltaX)) {
+        // Do not prevent this event: WebKit keeps ownership and scrolls the
+        // Library with native momentum. No tile was painted speculatively.
+        finishGallerySelectionDrag();
+        return;
+      }
+      galleryDragActive = true;
+      const startingPrint = galleryPrintAtPoint(galleryDragStartX, galleryDragStartY);
+      if (startingPrint) applyGalleryDragSelection(startingPrint);
+      if (galleryDragFrame === null) galleryDragFrame = requestAnimationFrame(runGalleryDragFrame);
+    }
+    event.preventDefault();
     applyGalleryDragSegment(galleryDragClientX, galleryDragClientY, point.clientX, point.clientY);
     galleryDragClientX = point.clientX;
     galleryDragClientY = point.clientY;
@@ -6810,8 +6834,9 @@ function moveGallerySelectionDrag(event: PointerEvent): void {
 
 function finishGallerySelectionDrag(event?: PointerEvent): void {
   if (event && event.pointerId !== galleryDragPointerId) return;
-  if (event?.type === "pointerup") galleryDragPendingClicks += 1;
+  if (event?.type === "pointerup" && galleryDragActive) galleryDragPendingClicks += 1;
   galleryDragPointerId = null;
+  galleryDragActive = false;
   galleryDragSelectionBaseline = null;
   galleryDragVisited.clear();
   if (galleryDragFrame !== null) cancelAnimationFrame(galleryDragFrame);

--- a/desktop/src/mobile/mobile.css
+++ b/desktop/src/mobile/mobile.css
@@ -2541,7 +2541,9 @@ button:disabled {
 }
 
 .gallery-grid.is-selecting .gallery-item {
-  touch-action: none;
+  /* WebKit keeps vertical pans native until the pointer handler sees
+     horizontal/diagonal drag-selection intent. */
+  touch-action: pan-y;
   user-select: none;
   -webkit-user-select: none;
   -webkit-touch-callout: none;
@@ -2661,7 +2663,9 @@ button:disabled {
   position: sticky;
   bottom: 8px;
   z-index: 8;
-  display: flex;
+  display: grid;
+  flex-shrink: 0;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
   align-items: center;
   gap: 6px;
   min-height: 56px;
@@ -2676,15 +2680,19 @@ button:disabled {
 
 .mobile-gallery-actions > span {
   min-width: 0;
-  flex: 1;
+  grid-column: span 2;
   padding-left: 8px;
   color: var(--ink-2);
   font-family: var(--font-utility);
   font-size: var(--text-data);
-  white-space: nowrap;
+  overflow-wrap: anywhere;
+  white-space: normal;
 }
 
 .mobile-gallery-actions button {
+  box-sizing: border-box;
+  grid-column: span 2;
+  width: 100%;
   min-width: 44px;
   min-height: 44px;
   border: 1px solid var(--control-edge);
@@ -2694,6 +2702,15 @@ button:disabled {
   color: var(--ink);
   font-family: var(--font-utility);
   font-weight: 650;
+  line-height: 1.15;
+  overflow-wrap: anywhere;
+  text-align: center;
+  white-space: normal;
+}
+
+.mobile-gallery-actions [data-test="mobile-gallery-favorite"],
+.mobile-gallery-actions [data-test="mobile-gallery-tag"] {
+  grid-column: span 1;
 }
 
 .mobile-gallery-actions button.danger {

--- a/desktop/src/mobile/mobile.css.test.ts
+++ b/desktop/src/mobile/mobile.css.test.ts
@@ -468,6 +468,19 @@ describe("mobile Library organization", () => {
     expect(chips?.[1]).toMatch(/overflow-x:\s*auto\s*;/);
   });
 
+  it("keeps Select-mode scrolling native and selection labels inside their buttons", () => {
+    const selectingTile = css.match(/\.gallery-grid\.is-selecting \.gallery-item\s*\{([^}]*)\}/s);
+    const actions = css.match(/\.mobile-gallery-actions\s*\{([^}]*)\}/s);
+    const actionButton = css.match(/\.mobile-gallery-actions button\s*\{([^}]*)\}/s);
+
+    expect(selectingTile?.[1]).toMatch(/touch-action:\s*pan-y\s*;/);
+    expect(actions?.[1]).toMatch(/flex-shrink:\s*0\s*;/);
+    expect(actions?.[1]).toMatch(/grid-template-columns:\s*repeat\(6,\s*minmax\(0,\s*1fr\)\)/);
+    expect(actionButton?.[1]).toMatch(/box-sizing:\s*border-box\s*;/);
+    expect(actionButton?.[1]).toMatch(/overflow-wrap:\s*anywhere\s*;/);
+    expect(actionButton?.[1]).toMatch(/white-space:\s*normal\s*;/);
+  });
+
   it("gives the Library sheet the pinned fixed-overlay and body invariants", () => {
     const sheet = css.match(/\.mobile-library-sheet\s*\{([^}]*)\}/s);
     const open = css.match(/\.mobile-library-sheet\.is-open\s*\{([^}]*)\}/s);


### PR DESCRIPTION
## Summary
- keep Select-mode vertical swipes under native WebKit scrolling while reserving horizontal intent for drag-selection
- contain the mobile Library action toolbar with a six-column grid, wrapping labels, and border-box sizing
- preserve mouse drag-selection and scoped pinch-to-resize behavior

## Verification
- `nix develop -c bash -lc "cd desktop && bunx prettier --check src/mobile/MobileApp.vue src/mobile/MobileApp.test.ts src/mobile/mobile.css src/mobile/mobile.css.test.ts && bunx vitest run src/mobile/MobileApp.test.ts src/mobile/mobile.css.test.ts"` (271 tests)
- `nix develop -c bash -lc "cd desktop && bun run build:mobile"`
- `nix develop -c ./scripts/tests/ios-release-assets.sh`
- `nix develop -c ./scripts/ios.sh simulator` (signed iPhone Simulator build)
- iPhone 17 / iOS 26.5 UAT: vertical touch swipes scroll in both directions without selecting; horizontal touch drag selects three tiles; toolbar labels remain contained
- independent agent peer review completed; border-box containment finding addressed before PR