### PR TITLE
feat(cli): add standalone administration fallbacks

### DIFF
--- a/changelog.d/cli-standalone-admin.md
+++ b/changelog.d/cli-standalone-admin.md
@@ -1,0 +1,8 @@
+### Added
+
+- Let `mold gpu list` inspect local runtime-visible compute devices when the
+  loopback server is stopped, and let `mold gpu enable|disable` persist the
+  selected stable device preference for the next server start. GPU stable IDs
+  and completion-shell names now participate in dynamic shell completion.
+- Make `mold ps`, `mold info`, and the idempotent `mold unload` useful with no
+  local server running while keeping configured remote-host failures explicit.

--- a/changelog.d/cli-standalone-admin.md
+++ b/changelog.d/cli-standalone-admin.md
@@ -1,8 +1,6 @@
-### Added
-
-- Let `mold gpu list` inspect local runtime-visible compute devices when the
-  loopback server is stopped, and let `mold gpu enable|disable` persist the
-  selected stable device preference for the next server start. GPU stable IDs
-  and completion-shell names now participate in dynamic shell completion.
-- Make `mold ps`, `mold info`, and the idempotent `mold unload` useful with no
-  local server running while keeping configured remote-host failures explicit.
+- **CLI administration now works without a running local server.** `mold gpu
+  list` inspects runtime-visible devices, `gpu enable|disable` persists stable
+  startup preferences, and `ps`, `info`, and idempotent `unload` provide useful
+  standalone behavior without masking configured remote-host failures. GPU
+  stable IDs and completion-shell names also participate in dynamic shell
+  completion.

--- a/crates/mold-cli/src/commands/gpu.rs
+++ b/crates/mold-cli/src/commands/gpu.rs
@@ -1,6 +1,15 @@
+use std::collections::BTreeMap;
+
 use anyhow::{bail, Context, Result};
+use clap_complete::engine::CompletionCandidate;
 use colored::Colorize;
-use mold_core::{DeviceAdminState, DeviceHealth, DeviceInfo, MoldClient, ServerCapabilities};
+use mold_core::{
+    classify_server_error, DeviceActivity, DeviceAdminState, DeviceHealth, DeviceInfo,
+    DeviceMemoryInfo, DeviceState, DeviceTelemetry, MoldClient, ServerAvailability,
+    ServerCapabilities,
+};
+
+use crate::control::is_loopback_host;
 
 fn ensure_supported(
     capabilities: &ServerCapabilities,
@@ -44,7 +53,7 @@ fn human_state(device: &DeviceInfo) -> String {
     }
 }
 
-fn format_device_line(device: &DeviceInfo) -> String {
+pub(crate) fn format_device_line(device: &DeviceInfo) -> String {
     let ordinal = device
         .ordinal
         .map(|value| format!("GPU {value}"))
@@ -83,16 +92,36 @@ fn format_device_line(device: &DeviceInfo) -> String {
 }
 
 pub async fn list(json: bool) -> Result<()> {
-    let state = MoldClient::from_env()
-        .devices()
-        .await
-        .context("failed to read server devices")?;
+    let client = MoldClient::from_env();
+    let (state, local) = match client.devices().await {
+        Ok(state) => (state, false),
+        Err(error)
+            if is_loopback_host(client.host())
+                && classify_server_error(&error) == ServerAvailability::FallbackLocal =>
+        {
+            (local_device_state()?, true)
+        }
+        Err(error) => return Err(error).context("failed to read server devices"),
+    };
     if json {
+        if local {
+            eprintln!(
+                "server unavailable at {}; returning local runtime inventory",
+                client.host()
+            );
+        }
         println!("{}", serde_json::to_string_pretty(&state)?);
         return Ok(());
     }
+    if local {
+        println!("No mold server is running; showing this machine's runtime-visible devices.");
+        println!("States below are startup preferences; live activity requires `mold serve`.\n");
+    }
     if state.devices.is_empty() {
-        println!("No compute devices visible.");
+        println!("No runtime-visible compute devices on this machine.");
+        if mold_inference::compiled_backend_label() == "cpu" {
+            println!("This mold binary was built without a GPU backend.");
+        }
         return Ok(());
     }
     for device in &state.devices {
@@ -103,7 +132,157 @@ pub async fn list(json: bool) -> Result<()> {
 
 pub async fn set(selector: &str, enabled: bool) -> Result<()> {
     let client = MoldClient::from_env();
-    set_enabled_with_client(&client, selector, enabled).await
+    match set_enabled_with_client(&client, selector, enabled).await {
+        Ok(()) => Ok(()),
+        Err(error)
+            if is_loopback_host(client.host())
+                && classify_server_error(&error) == ServerAvailability::FallbackLocal =>
+        {
+            set_local_preference(selector, enabled)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+/// Dynamic completion candidates for local stable device IDs.
+///
+/// Completion deliberately performs no network request: it remains useful
+/// with the server stopped and never substitutes local IDs for a remote host.
+pub fn complete_device_id() -> Vec<CompletionCandidate> {
+    complete_device_id_for_host(MoldClient::from_env().host())
+}
+
+fn complete_device_id_for_host(host: &str) -> Vec<CompletionCandidate> {
+    if !is_loopback_host(host) {
+        return Vec::new();
+    }
+    let mut ids = mold_inference::device::discover_gpus()
+        .into_iter()
+        .filter_map(|device| device.stable_id)
+        .collect::<Vec<_>>();
+    ids.sort();
+    ids.into_iter().map(CompletionCandidate::new).collect()
+}
+
+pub(crate) fn local_device_state() -> Result<DeviceState> {
+    let preferences = crate::metadata_db::handle()
+        .map(|db| mold_db::DevicePreferences::new(db).list())
+        .transpose()?
+        .unwrap_or_default();
+    Ok(project_local_devices(
+        mold_inference::device::discover_gpus(),
+        &preferences,
+    ))
+}
+
+fn project_local_devices(
+    discovered: Vec<mold_inference::device::DiscoveredGpu>,
+    preferences: &BTreeMap<String, mold_db::DevicePreference>,
+) -> DeviceState {
+    let devices = discovered
+        .into_iter()
+        .map(|device| {
+            let stable = device.stable_id.is_some();
+            let id = device.stable_id.unwrap_or_else(|| {
+                format!("{}:unavailable-{}", device.backend.as_str(), device.ordinal)
+            });
+            let desired_enabled = preferences
+                .get(&id)
+                .map(|preference| preference.desired_enabled)
+                .unwrap_or(true);
+            let total = (device.total_vram_bytes > 0).then_some(device.total_vram_bytes);
+            let used = total.map(|total| total.saturating_sub(device.free_vram_bytes));
+            let device_kind = match device.device_kind {
+                Some(mold_inference::device::CudaDeviceKind::FullGpu) => {
+                    mold_core::DeviceKind::FullGpu
+                }
+                Some(mold_inference::device::CudaDeviceKind::Mig) => mold_core::DeviceKind::Mig,
+                Some(mold_inference::device::CudaDeviceKind::UnknownCuda) => {
+                    mold_core::DeviceKind::UnknownCuda
+                }
+                None => mold_core::DeviceKind::Metal,
+            };
+            DeviceInfo {
+                id,
+                backend: device.backend,
+                ordinal: Some(device.ordinal),
+                device_kind,
+                nvml_uuid: None,
+                physical_uuid: None,
+                mig_uuid: None,
+                mig_parent_uuid: None,
+                mig_profile: None,
+                name: device.name,
+                pci_bus_id: device.pci_bus_id,
+                compute_capability: device
+                    .compute_capability
+                    .map(|(major, minor)| format!("{major}.{minor}")),
+                memory: DeviceMemoryInfo {
+                    total_bytes: total,
+                    used_bytes: used,
+                    mold_used_bytes: None,
+                    other_used_bytes: None,
+                },
+                telemetry: DeviceTelemetry {
+                    utilization_percent: None,
+                    temperature_c: None,
+                    power_w: None,
+                },
+                desired_enabled,
+                restart_required: false,
+                admin_state: if desired_enabled {
+                    DeviceAdminState::Enabled
+                } else {
+                    DeviceAdminState::Disabled
+                },
+                health: if stable {
+                    DeviceHealth::Healthy
+                } else {
+                    DeviceHealth::Unavailable
+                },
+                activity: DeviceActivity::Idle,
+                schedulable: false,
+                unschedulable_reason: Some(
+                    device
+                        .identity_error
+                        .unwrap_or_else(|| "mold server is not running".into()),
+                ),
+                loaded_models: vec![],
+                active_work_id: None,
+                planned_work_ids: vec![],
+            }
+        })
+        .collect();
+    DeviceState {
+        devices,
+        plan_version: 0,
+    }
+}
+
+fn set_local_preference(selector: &str, enabled: bool) -> Result<()> {
+    let state = local_device_state()?;
+    let device = resolve_device(&state.devices, selector)?;
+    if device.health == DeviceHealth::Unavailable {
+        bail!(
+            "{} is visible but has no stable identity; its startup preference cannot be persisted",
+            device.name
+        );
+    }
+    let Some(db) = crate::metadata_db::handle() else {
+        bail!(
+            "cannot persist the device preference because the metadata DB is disabled or unavailable"
+        );
+    };
+    let preferences = mold_db::DevicePreferences::new(db);
+    let previous = preferences.get(&device.id)?;
+    preferences.set(&device.id, enabled)?;
+    let action = if enabled { "enabled" } else { "disabled" };
+    if previous == Some(enabled) {
+        println!("{}: already {action} for the next server start", device.id);
+    } else {
+        println!("{}: {action} for the next server start", device.id);
+    }
+    Ok(())
 }
 
 async fn set_enabled_with_client(client: &MoldClient, selector: &str, enabled: bool) -> Result<()> {
@@ -134,6 +313,11 @@ async fn set_enabled_with_client(client: &MoldClient, selector: &str, enabled: b
 mod tests {
     use super::*;
     use mold_core::{DeviceActivity, DeviceKind, DeviceMemoryInfo, DeviceTelemetry, GpuBackend};
+
+    #[test]
+    fn remote_completion_never_substitutes_local_device_ids() {
+        assert!(complete_device_id_for_host("https://gpu-box:7680").is_empty());
+    }
 
     fn device(id: &str, ordinal: usize) -> DeviceInfo {
         DeviceInfo {
@@ -246,6 +430,67 @@ mod tests {
         unknown.memory.total_bytes = None;
         assert!(format_device_line(&unknown).contains("VRAM —"));
         assert!(!format_device_line(&unknown).contains("0.0/0.0"));
+    }
+
+    #[test]
+    fn local_projection_preserves_stable_identity_preferences_and_unknown_telemetry() {
+        let discovered = mold_inference::device::DiscoveredGpu {
+            ordinal: 2,
+            stable_id: Some("cuda:stable".into()),
+            raw_cuda_uuid: None,
+            device_kind: Some(mold_inference::device::CudaDeviceKind::FullGpu),
+            identity_error: None,
+            backend: GpuBackend::Cuda,
+            name: "Local GPU".into(),
+            compute_capability: Some((8, 9)),
+            pci_bus_id: Some("0000:01:00.0".into()),
+            total_vram_bytes: 24 << 30,
+            free_vram_bytes: 20 << 30,
+        };
+        let mut preferences = BTreeMap::new();
+        preferences.insert(
+            "cuda:stable".into(),
+            mold_db::DevicePreference {
+                device_id: "cuda:stable".into(),
+                desired_enabled: false,
+                updated_at: 1,
+            },
+        );
+
+        let state = project_local_devices(vec![discovered], &preferences);
+        let device = &state.devices[0];
+        assert_eq!(device.id, "cuda:stable");
+        assert_eq!(device.ordinal, Some(2));
+        assert_eq!(device.compute_capability.as_deref(), Some("8.9"));
+        assert_eq!(device.memory.used_bytes, Some(4 << 30));
+        assert_eq!(device.telemetry.utilization_percent, None);
+        assert!(!device.desired_enabled);
+        assert_eq!(device.admin_state, DeviceAdminState::Disabled);
+        assert!(!device.schedulable);
+    }
+
+    #[test]
+    fn local_projection_keeps_identity_failures_visible_but_not_addressable() {
+        let discovered = mold_inference::device::DiscoveredGpu {
+            ordinal: 0,
+            stable_id: None,
+            raw_cuda_uuid: None,
+            device_kind: Some(mold_inference::device::CudaDeviceKind::UnknownCuda),
+            identity_error: Some("UUID unavailable".into()),
+            backend: GpuBackend::Cuda,
+            name: "Broken GPU".into(),
+            compute_capability: None,
+            pci_bus_id: None,
+            total_vram_bytes: 0,
+            free_vram_bytes: 0,
+        };
+        let state = project_local_devices(vec![discovered], &BTreeMap::new());
+        assert_eq!(state.devices[0].health, DeviceHealth::Unavailable);
+        assert_eq!(state.devices[0].memory.total_bytes, None);
+        assert_eq!(
+            state.devices[0].unschedulable_reason.as_deref(),
+            Some("UUID unavailable")
+        );
     }
 
     #[tokio::test]

--- a/crates/mold-cli/src/commands/info.rs
+++ b/crates/mold-cli/src/commands/info.rs
@@ -1,10 +1,12 @@
 use std::collections::HashSet;
 use std::time::Duration;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use colored::Colorize;
 use mold_core::manifest::{find_manifest, resolve_model_name, ModelComponent};
-use mold_core::{build_model_catalog, Config, ModelPaths, MoldClient};
+use mold_core::{
+    build_model_catalog, classify_server_error, Config, ModelPaths, MoldClient, ServerAvailability,
+};
 use sha2::{Digest, Sha256};
 
 use crate::fs_util::dir_stats;
@@ -383,9 +385,20 @@ pub async fn run_overview() -> Result<()> {
                 loaded,
             );
         }
-        _ => {
+        Ok(Err(error))
+            if crate::control::is_loopback_host(client.host())
+                && classify_server_error(&error) == ServerAvailability::FallbackLocal =>
+        {
             println!("  {:<18} {}", "Status:".dimmed(), "Not running".dimmed(),);
+            let local = crate::commands::gpu::local_device_state()?;
+            println!(
+                "  {:<18} {} runtime-visible",
+                "Local compute:".dimmed(),
+                local.devices.len()
+            );
         }
+        Ok(Err(error)) => return Err(error).context("failed to read mold server status"),
+        Err(error) => return Err(error).context("timed out reading mold server status"),
     }
 
     Ok(())

--- a/crates/mold-cli/src/commands/ps.rs
+++ b/crates/mold-cli/src/commands/ps.rs
@@ -1,6 +1,7 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use colored::Colorize;
 use mold_core::types::{DeviceAdminState, DeviceHealth, GpuWorkerState, QueuePlan, QueueWorkItem};
+use mold_core::{classify_server_error, ServerAvailability};
 
 use crate::control::CliContext;
 use crate::procinfo;
@@ -121,12 +122,29 @@ pub async fn run() -> Result<()> {
                 }
             }
         }
-        Err(_) => {
-            println!(
-                "  {} no mold server running — start with {}",
-                theme::prefix_hint(),
-                "mold serve".bold()
-            );
+        Err(error) => {
+            if crate::control::is_loopback_host(ctx.client().host())
+                && classify_server_error(&error) == ServerAvailability::FallbackLocal
+            {
+                println!(
+                    "  {} no mold server running — start with {}",
+                    theme::prefix_hint(),
+                    "mold serve".bold()
+                );
+                let local = crate::commands::gpu::local_device_state()?;
+                if !local.devices.is_empty() {
+                    println!();
+                    println!("Local compute (startup preferences):");
+                    for device in &local.devices {
+                        println!("  {}", crate::commands::gpu::format_device_line(device));
+                    }
+                }
+            } else {
+                return Err(error).context(format!(
+                    "failed to read mold server status from {}",
+                    ctx.client().host()
+                ));
+            }
         }
     }
 

--- a/crates/mold-cli/src/commands/unload.rs
+++ b/crates/mold-cli/src/commands/unload.rs
@@ -15,8 +15,13 @@ pub async fn run() -> Result<()> {
         }
         Err(e) => match classify_server_error(&e) {
             ServerAvailability::FallbackLocal => {
-                print_server_unavailable(ctx.client().host(), &e);
-                Err(crate::AlreadyReported.into())
+                if crate::control::is_loopback_host(ctx.client().host()) {
+                    println!("No mold server is running; no server-loaded model to unload.");
+                    Ok(())
+                } else {
+                    print_server_unavailable(ctx.client().host(), &e);
+                    Err(crate::AlreadyReported.into())
+                }
             }
             ServerAvailability::SurfaceError => Err(e),
         },

--- a/crates/mold-cli/src/control.rs
+++ b/crates/mold-cli/src/control.rs
@@ -65,10 +65,48 @@ pub(crate) fn client_for_host(host: Option<&str>) -> MoldClient {
     }
 }
 
+/// Whether an unavailable HTTP target names this machine.
+///
+/// Server-first commands may fall back to local, read-only facts only for a
+/// loopback target. Falling back when `MOLD_HOST` names another machine would
+/// silently answer a different question.
+pub(crate) fn is_loopback_host(host: &str) -> bool {
+    reqwest::Url::parse(host)
+        .ok()
+        .and_then(|url| url.host_str().map(str::to_owned))
+        .is_some_and(|host| {
+            host.eq_ignore_ascii_case("localhost")
+                || host
+                    .trim_matches(['[', ']'])
+                    .parse::<std::net::IpAddr>()
+                    .is_ok_and(|address| address.is_loopback())
+        })
+}
+
 pub(crate) async fn stream_server_pull(client: &MoldClient, model: &str) -> Result<()> {
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
     let render = tokio::spawn(render_progress(rx));
     let result = client.pull_model_stream(model, tx).await;
     let _ = render.await;
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_loopback_host;
+
+    #[test]
+    fn local_fallback_is_limited_to_loopback_targets() {
+        for host in [
+            "http://localhost:7680",
+            "http://127.0.0.1:7680",
+            "http://127.0.0.2:7680",
+            "http://[::1]:7680",
+        ] {
+            assert!(is_loopback_host(host), "{host}");
+        }
+        for host in ["http://gpu-box:7680", "https://10.0.0.8:7680", "not a url"] {
+            assert!(!is_loopback_host(host), "{host}");
+        }
+    }
 }

--- a/crates/mold-cli/src/main.rs
+++ b/crates/mold-cli/src/main.rs
@@ -13,7 +13,7 @@ mod theme;
 mod ui;
 
 use clap::{builder::ValueHint, CommandFactory, Parser, Subcommand};
-use clap_complete::engine::ArgValueCandidates;
+use clap_complete::engine::{ArgValueCandidates, CompletionCandidate};
 use mold_core::{OutputFormat, Scheduler};
 
 /// Value parser for OutputFormat with tab-completion candidates.
@@ -185,11 +185,13 @@ enum GpuAction {
     /// Stop assigning new work to a device; active work drains first.
     Disable {
         /// Opaque stable ID (preferred) or current display ordinal.
+        #[arg(add = ArgValueCandidates::new(commands::gpu::complete_device_id))]
         device: String,
     },
     /// Return a disabled or draining device to service.
     Enable {
         /// Opaque stable ID (preferred) or current display ordinal.
+        #[arg(add = ArgValueCandidates::new(commands::gpu::complete_device_id))]
         device: String,
     },
 }
@@ -1642,8 +1644,16 @@ Examples:
 
     Completions {
         /// Shell to generate completions for (bash, zsh, fish, elvish, powershell)
+        #[arg(add = ArgValueCandidates::new(complete_shell))]
         shell: String,
     },
+}
+
+fn complete_shell() -> Vec<CompletionCandidate> {
+    ["bash", "zsh", "fish", "elvish", "powershell"]
+        .into_iter()
+        .map(CompletionCandidate::new)
+        .collect()
 }
 
 /// Republish `--spatial-tile` as `MOLD_LTX2_SPATIAL_TILE`.

--- a/crates/mold-cli/tests/cli_integration.rs
+++ b/crates/mold-cli/tests/cli_integration.rs
@@ -12,6 +12,31 @@ mod common;
 use common::TestEnv;
 use predicates::prelude::*;
 
+#[tokio::test(flavor = "multi_thread")]
+async fn loopback_admin_commands_do_not_hide_live_server_http_errors() {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    for status in [401, 500] {
+        let env = TestEnv::new();
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/status"))
+            .respond_with(ResponseTemplate::new(status))
+            .mount(&server)
+            .await;
+
+        for command in ["ps", "info"] {
+            env.cmd()
+                .env("MOLD_HOST", server.uri())
+                .arg(command)
+                .assert()
+                .failure()
+                .stderr(predicate::str::contains("server status"));
+        }
+    }
+}
+
 // ── mold version ──────────────────────────────────────────────────────────
 
 #[test]
@@ -344,6 +369,39 @@ fn info_known_model_shows_details() {
         .assert()
         .success()
         .stdout(predicate::str::contains("flux2-klein:q4"));
+}
+
+// ── standalone server administration ────────────────────────────────────
+
+#[test]
+fn gpu_list_json_falls_back_to_local_inventory_when_loopback_server_is_stopped() {
+    let env = TestEnv::new();
+    let output = env
+        .cmd()
+        .env("MOLD_HOST", "http://127.0.0.1:9")
+        .args(["gpu", "list", "--json"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let body: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert!(body["devices"].is_array());
+    assert_eq!(body["plan_version"], 0);
+    assert!(String::from_utf8_lossy(&output.stderr).contains("local runtime inventory"));
+}
+
+#[test]
+fn unload_is_idempotent_when_loopback_server_is_stopped() {
+    let env = TestEnv::new();
+    env.cmd()
+        .env("MOLD_HOST", "http://127.0.0.1:9")
+        .arg("unload")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("no server-loaded model to unload"));
 }
 
 // ── mold rm ───────────────────────────────────────────────────────────────

--- a/website/guide/cli-reference.md
+++ b/website/guide/cli-reference.md
@@ -436,15 +436,15 @@ The CLI does not need a daemon for work whose authority already exists on disk,
 in the local runtime, or in a named cloud API. Server-first commands fall back
 only when doing so preserves the target the user asked about.
 
-| Behavior without a local server | Commands | Result |
-| ------------------------------- | -------- | ------ |
-| Fully standalone, local files | `list`, `info`, `default`, `config`, `stats`, `clean`, `rm`, `chain validate` | Reads or changes `MOLD_HOME` directly |
-| Fully standalone, local runtime | `gpu list`, `gpu enable`, `gpu disable`, `ps`, `unload` | Lists local devices, persists next-start device preferences, reports processes, or completes an already-empty unload |
-| Server-first with local execution | `run`, `pull`, `upscale` | Uses the server when reachable, otherwise executes or downloads locally |
-| Standalone prompt tooling | `expand`, `remix` | Uses the configured local expansion model or external API backend |
-| Standalone lifecycle/discovery | `serve`, `server start`, `server status`, `server stop`, `server discover` | Starts or inspects processes, or browses mDNS directly |
-| Standalone utility/network clients | `version`, `update`, `completions`, `skill`, `runpod`, `lambda` | Uses embedded data, GitHub, agent paths, or the explicitly named cloud API |
-| Requires a live Mold server | `jobs`, `trash`, `mcp`, `discord`; `tui` unless `--local` is used | These operate on server-owned queue, gallery, tool, or UI state and do not substitute a different local authority |
+| Behavior without a local server    | Commands                                                                      | Result                                                                                                               |
+| ---------------------------------- | ----------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| Fully standalone, local files      | `list`, `info`, `default`, `config`, `stats`, `clean`, `rm`, `chain validate` | Reads or changes `MOLD_HOME` directly                                                                                |
+| Fully standalone, local runtime    | `gpu list`, `gpu enable`, `gpu disable`, `ps`, `unload`                       | Lists local devices, persists next-start device preferences, reports processes, or completes an already-empty unload |
+| Server-first with local execution  | `run`, `pull`, `upscale`                                                      | Uses the server when reachable, otherwise executes or downloads locally                                              |
+| Standalone prompt tooling          | `expand`, `remix`                                                             | Uses the configured local expansion model or external API backend                                                    |
+| Standalone lifecycle/discovery     | `serve`, `server start`, `server status`, `server stop`, `server discover`    | Starts or inspects processes, or browses mDNS directly                                                               |
+| Standalone utility/network clients | `version`, `update`, `completions`, `skill`, `runpod`, `lambda`               | Uses embedded data, GitHub, agent paths, or the explicitly named cloud API                                           |
+| Requires a live Mold server        | `jobs`, `trash`, `mcp`, `discord`; `tui` unless `--local` is used             | These operate on server-owned queue, gallery, tool, or UI state and do not substitute a different local authority    |
 
 An unreachable non-loopback `MOLD_HOST` remains an error for host-administration
 commands. In particular, `gpu`, `ps`, and `unload` do not answer with this

--- a/website/guide/cli-reference.md
+++ b/website/guide/cli-reference.md
@@ -239,6 +239,14 @@ mold gpu disable <stable-id-or-ordinal>
 mold gpu enable <stable-id-or-ordinal>
 ```
 
+When the target is loopback and no server is running, `gpu list` discovers the
+devices visible to the current Mold runtime directly. The JSON schema stays the
+same; operational telemetry that only the server samples remains `null` rather
+than being fabricated. `gpu enable` and `gpu disable` persist the stable
+device's startup preference in the local metadata database and report that it
+takes effect on the next `mold serve`. They never fall back to local hardware
+when `MOLD_HOST` names another machine.
+
 Disable removes the device from future scheduling immediately. Active work
 finishes before Mold drops its device-backed caches on the owner thread and
 joins it. Re-enable starts a fresh owner thread; it never resets and reuses a
@@ -422,6 +430,26 @@ Common subcommands are `doctor`, `availability`, `deploy`, `status`, `logs`,
 | `mold skill <COMMAND>`                                        | Manage Mold's embedded Agent Skill                              |
 | `mold version`                                                | Show version, build date, and git SHA                           |
 
+## Running commands without `mold serve`
+
+The CLI does not need a daemon for work whose authority already exists on disk,
+in the local runtime, or in a named cloud API. Server-first commands fall back
+only when doing so preserves the target the user asked about.
+
+| Behavior without a local server | Commands | Result |
+| ------------------------------- | -------- | ------ |
+| Fully standalone, local files | `list`, `info`, `default`, `config`, `stats`, `clean`, `rm`, `chain validate` | Reads or changes `MOLD_HOME` directly |
+| Fully standalone, local runtime | `gpu list`, `gpu enable`, `gpu disable`, `ps`, `unload` | Lists local devices, persists next-start device preferences, reports processes, or completes an already-empty unload |
+| Server-first with local execution | `run`, `pull`, `upscale` | Uses the server when reachable, otherwise executes or downloads locally |
+| Standalone prompt tooling | `expand`, `remix` | Uses the configured local expansion model or external API backend |
+| Standalone lifecycle/discovery | `serve`, `server start`, `server status`, `server stop`, `server discover` | Starts or inspects processes, or browses mDNS directly |
+| Standalone utility/network clients | `version`, `update`, `completions`, `skill`, `runpod`, `lambda` | Uses embedded data, GitHub, agent paths, or the explicitly named cloud API |
+| Requires a live Mold server | `jobs`, `trash`, `mcp`, `discord`; `tui` unless `--local` is used | These operate on server-owned queue, gallery, tool, or UI state and do not substitute a different local authority |
+
+An unreachable non-loopback `MOLD_HOST` remains an error for host-administration
+commands. In particular, `gpu`, `ps`, and `unload` do not answer with this
+machine's state when the user selected a remote machine.
+
 ## `mold skill`
 
 Install the embedded Mold Agent Skill for AI coding agents:
@@ -455,6 +483,10 @@ mold completions fish
 mold completions elvish
 mold completions powershell
 ```
+
+Dynamic completion includes command and flag names, known and installed model
+IDs where appropriate, upscaler IDs, config keys, RunPod resources, completion
+shell names, and locally visible stable GPU IDs for `gpu enable|disable`.
 
 Common setup:
 


### PR DESCRIPTION
## Summary

- make GPU inventory and stable enable/disable preferences work when the loopback server is stopped
- make ps, info, and idempotent unload useful offline without masking remote, auth, timeout, or server errors
- add dynamic GPU and completion-shell candidates plus an audited standalone-command matrix

## Validation

- cargo clippy --workspace --all-targets -- -D warnings
- cargo check -p mold-ai --features preview,discord,expand,tui,webp,mp4
- focused unit and black-box CLI tests, including loopback 401/500 behavior
- website bun run verify
- cargo fmt --all -- --check
- independent agent peer review and clean re-review

## Test environment note

The full workspace run passed the changed CLI/core suites. A first all-workspace attempt exhausted local temporary storage in unrelated inference fixtures after 2,095 passes; build and test scratch storage were then moved to the external Mold volume. The Metal-enabled all-workspace attempt passed the CLI unit and new integration tests but was stopped when two pre-existing prompt tests began real local Metal execution. CI provides the authoritative clean full-workspace gate.