### PR TITLE
fix(server): pass the offload policy in the identity memory-preflight test

### DIFF
--- a/crates/mold-server/src/memory_preflight.rs
+++ b/crates/mold-server/src/memory_preflight.rs
@@ -1929,8 +1929,8 @@ mod fail_closed_tests {
                 request,
                 &model_paths,
                 activation,
+                offload(AdmissionPolicy::Disabled),
                 Some(24_000_000_000),
-                false,
                 false,
                 false,
             )


### PR DESCRIPTION
`main`'s required `rust` (MSRV test build) job is red: #1239 added `identity_conditioning_charges_exactly_its_named_overhead_and_weight_zero_charges_nothing` calling `estimate_generation_memory_for_request` with the pre-#1230 arity, and the two PRs merged without a rebase between them. One-line test fix; unblocks #1242, #1243, #1244.