### PR TITLE
fix(ios): restore media viewing

### DIFF
--- a/changelog.d/ios-media-view.md
+++ b/changelog.d/ios-media-view.md
@@ -1,0 +1,1 @@
+- **Restore iPhone media viewing.** Keep the full-screen Library viewer aligned to the viewport and recover generated videos from transient iOS loading failures ([#1250](https://github.com/utensils/mold/pull/1250)).

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -4484,7 +4484,8 @@ describe("MobileApp generation queue", () => {
     ).toBe(true);
   });
 
-  it("remounts generated video when forced renewal returns the same URL", async () => {
+  it("backs off transient generated-video failures before remounting the media element", async () => {
+    vi.useFakeTimers();
     const unchangedUrl =
       "https://studio/media/missing-video?media_token=unchanged&expires=4102444800";
     streamableMediaUrl.mockResolvedValueOnce(unchangedUrl).mockResolvedValueOnce(unchangedUrl);
@@ -4509,20 +4510,105 @@ describe("MobileApp generation queue", () => {
     await flushPromises();
 
     const originalVideo = wrapper.get("video.result-media").element;
+    expect(wrapper.get("video.result-media").attributes("preload")).toBe("metadata");
     await wrapper.get("video.result-media").trigger("error");
     await flushPromises();
 
+    expect(streamableMediaUrl).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(249);
+    expect(streamableMediaUrl).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    await flushPromises();
     expect(streamableMediaUrl).toHaveBeenCalledTimes(2);
     expect(wrapper.get("video.result-media").attributes("src")).toBe(unchangedUrl);
     expect(wrapper.get("video.result-media").element).not.toBe(originalVideo);
+  });
+
+  it("bounds delayed generated-video recovery and exposes a manual retry", async () => {
+    vi.useFakeTimers();
+    const unchangedUrl =
+      "https://studio/media/missing-video?media_token=unchanged&expires=4102444800";
+    streamableMediaUrl.mockResolvedValue(unchangedUrl);
+    wrapper = mountMobileApp();
+    await flushPromises();
+
+    await submitPrompt("persistently missing generated video");
+    openStreams[0]!.options.onEvent(
+      "complete",
+      JSON.stringify({
+        image: "",
+        format: "mp4",
+        filename: "missing-video.mp4",
+        width: 768,
+        height: 512,
+        seed_used: 7,
+        generation_time_ms: 500,
+        model: model.name,
+      }),
+    );
+    openStreams[0]!.resolve();
+    await flushPromises();
+
+    for (const delay of [250, 750, 1_500]) {
+      await wrapper.get("video.result-media").trigger("error");
+      await vi.advanceTimersByTimeAsync(delay);
+      await flushPromises();
+    }
+    expect(streamableMediaUrl).toHaveBeenCalledTimes(4);
 
     await wrapper.get("video.result-media").trigger("error");
     await flushPromises();
-    expect(streamableMediaUrl).toHaveBeenCalledTimes(2);
     expect(wrapper.find("video.result-media").exists()).toBe(false);
     expect(wrapper.get(".result-preview-error").text()).toContain(
       "Couldn’t load this generated print",
     );
+    expect(
+      wrapper
+        .findAll(".result-preview-error button")
+        .some((button) => button.text() === "Try preview again"),
+    ).toBe(true);
+  });
+
+  it("replaces a stale video retry when a newer generated result fails", async () => {
+    vi.useFakeTimers();
+    streamableMediaUrl.mockResolvedValue(
+      "https://studio/media/video?media_token=renewed&expires=4102444800",
+    );
+    wrapper = mountMobileApp();
+    await flushPromises();
+
+    const completeVideo = async (streamIndex: number, filename: string, seed: number) => {
+      openStreams[streamIndex]!.options.onEvent(
+        "complete",
+        JSON.stringify({
+          image: "",
+          format: "mp4",
+          filename,
+          width: 768,
+          height: 512,
+          seed_used: seed,
+          generation_time_ms: 500,
+          model: model.name,
+        }),
+      );
+      openStreams[streamIndex]!.resolve();
+      await flushPromises();
+    };
+
+    await submitPrompt("first video");
+    await completeVideo(0, "first-video.mp4", 1);
+    await wrapper.get("video.result-media").trigger("error");
+
+    await submitPrompt("second video");
+    await completeVideo(1, "second-video.mp4", 2);
+    const secondVideo = wrapper.get("video.result-media").element;
+    await wrapper.get("video.result-media").trigger("error");
+
+    expect(streamableMediaUrl).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(250);
+    await flushPromises();
+    expect(streamableMediaUrl).toHaveBeenCalledTimes(3);
+    expect(wrapper.get("video.result-media").element).not.toBe(secondVideo);
   });
 
   it("shows a completion that wins the cancellation race", async () => {

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -776,6 +776,7 @@ const usingPrintAsSource = ref(false);
 const reusePrintError = ref("");
 const latestResultClientId = ref<number | null>(null);
 const resultMediaLoadKey = ref(0);
+const GENERATED_VIDEO_RECOVERY_DELAYS_MS = [250, 750, 1_500] as const;
 const objectUrls = new Set<string>();
 const handledGenerationClientIds = new Set<number>();
 let pendingGallery: PendingGalleryPrint[] = [];
@@ -786,6 +787,7 @@ let reusePrintEpoch = 0;
 let reusePrintController: AbortController | null = null;
 let sourceUseEpoch = 0;
 let sourceUseController: AbortController | null = null;
+let resultMediaRecoveryTimer: ReturnType<typeof setTimeout> | null = null;
 let galleryRefreshRequested = false;
 let galleryRefreshDeferred = false;
 let galleryRefreshTask: Promise<void> | null = null;
@@ -5156,6 +5158,10 @@ function renewGeneratedResult(force: boolean): void {
 }
 
 function generatedMediaReady(): void {
+  if (resultMediaRecoveryTimer !== null) {
+    clearTimeout(resultMediaRecoveryTimer);
+    resultMediaRecoveryTimer = null;
+  }
   resultMediaRecoveryClientId = latestResultClientId.value;
   resultMediaRecoveryAttempts = 0;
 }
@@ -5164,12 +5170,28 @@ function recoverGeneratedMedia(): void {
   const job = latestResultJob.value;
   if (!job || job.resultUrlLoading) return;
   if (resultMediaRecoveryClientId !== job.clientId) {
+    if (resultMediaRecoveryTimer !== null) {
+      clearTimeout(resultMediaRecoveryTimer);
+      resultMediaRecoveryTimer = null;
+    }
     resultMediaRecoveryClientId = job.clientId;
     resultMediaRecoveryAttempts = 0;
   }
-  if (resultMediaRecoveryAttempts === 0) {
-    resultMediaRecoveryAttempts = 1;
-    renewGeneratedResult(true);
+  if (resultMediaRecoveryTimer !== null) return;
+
+  const retryDelays = job.result?.format === "mp4" ? GENERATED_VIDEO_RECOVERY_DELAYS_MS : [0];
+  const delay = retryDelays[resultMediaRecoveryAttempts];
+  if (delay !== undefined) {
+    resultMediaRecoveryAttempts += 1;
+    if (delay === 0) {
+      renewGeneratedResult(true);
+      return;
+    }
+    const clientId = job.clientId;
+    resultMediaRecoveryTimer = setTimeout(() => {
+      resultMediaRecoveryTimer = null;
+      if (latestResultClientId.value === clientId) renewGeneratedResult(true);
+    }, delay);
     return;
   }
 
@@ -5181,6 +5203,10 @@ function recoverGeneratedMedia(): void {
 }
 
 function retryGeneratedPreview(): void {
+  if (resultMediaRecoveryTimer !== null) {
+    clearTimeout(resultMediaRecoveryTimer);
+    resultMediaRecoveryTimer = null;
+  }
   resultMediaRecoveryClientId = latestResultClientId.value;
   resultMediaRecoveryAttempts = 0;
   renewGeneratedResult(true);
@@ -7560,6 +7586,10 @@ onBeforeUnmount(() => {
   document.documentElement.style.removeProperty("--mobile-visual-viewport-page-top");
   window.removeEventListener("pageshow", handleForegroundResume);
   cancelKeyboardViewportRestore();
+  if (resultMediaRecoveryTimer !== null) {
+    clearTimeout(resultMediaRecoveryTimer);
+    resultMediaRecoveryTimer = null;
+  }
   stopPairingDeepLinks?.();
   stopPairingDeepLinks = null;
   if (hostProbeTimer) clearInterval(hostProbeTimer);
@@ -8269,6 +8299,7 @@ onBeforeUnmount(() => {
               :src="resultUrl"
               controls
               playsinline
+              preload="metadata"
               @play="renewGeneratedResult(false)"
               @loadedmetadata="generatedMediaReady"
               @error="recoverGeneratedMedia"

--- a/desktop/src/mobile/mobile.css
+++ b/desktop/src/mobile/mobile.css
@@ -2722,9 +2722,11 @@ button:disabled {
   position: fixed;
   inset: 0;
   z-index: 100;
-  width: 100%;
-  height: 100%;
-  height: 100dvh;
+  /* Let the fixed edges size the top-layer dialog. iOS WebKit can retain the
+     dialog's UA inline placement when an explicit 100% width is combined
+     with `inset: 0`, shifting a viewport-wide stage to the right. */
+  width: auto;
+  height: auto;
   max-width: none;
   max-height: none;
   grid-template-rows: auto minmax(0, 1fr) auto;

--- a/desktop/src/mobile/mobile.css.test.ts
+++ b/desktop/src/mobile/mobile.css.test.ts
@@ -21,6 +21,19 @@ describe("mobile viewport scaling", () => {
   });
 });
 
+describe("mobile gallery viewer", () => {
+  it("lets fixed edges size the top-layer dialog without iOS inline offset", () => {
+    const viewer = css.match(/\.gallery-viewer\s*\{([^}]*)\}/s);
+
+    expect(viewer?.[1]).toMatch(/position:\s*fixed\s*;/);
+    expect(viewer?.[1]).toMatch(/inset:\s*0\s*;/);
+    expect(viewer?.[1]).toMatch(/width:\s*auto\s*;/);
+    expect(viewer?.[1]).toMatch(/height:\s*auto\s*;/);
+    expect(viewer?.[1]).toMatch(/margin:\s*0\s*;/);
+    expect(viewer?.[1]).not.toMatch(/(?:width|height):\s*100(?:%|dvh)\s*;/);
+  });
+});
+
 describe("mobile Library thumbnail sizing", () => {
   it("drives every gallery column count from the pinch variable", () => {
     // Match every `.gallery-grid` selector, nested or at top level, so a


### PR DESCRIPTION
## Summary
- let fixed dialog edges size the iOS Library viewer so it fills the viewport without the rightward offset
- preload generated MP4 metadata and retry transient WKWebView media failures with bounded backoff
- cancel stale recovery timers when a newer print becomes current

## UAT
- iPhone viewport 393×852: viewer bounds left=0, right=393, top=0, bottom=852
- real H.264/AAC MP4 loaded with readyState=4 and 512×512 intrinsic dimensions
- native iPhone 17 / iOS 26.5 simulator build installed and launched
- no browser console errors

## Validation
- `nix develop -c bash -lc "cd desktop && bun run test"` — 4,340 tests passed
- `nix develop -c bash -lc "cd desktop && bun run fmt:check"`
- `nix develop -c bash -lc "cd desktop && bun run build:mobile"`
- `nix develop -c ./scripts/tests/ios-release-assets.sh`
- `nix develop -c ./scripts/ios.sh simulator`
- Claude peer review: race finding fixed; re-review returned no actionable findings