### PR TITLE
fix(core): bind remote license consent to the displayed terms and surface license-listing failures

### DIFF
--- a/changelog.d/pulid-contract.md
+++ b/changelog.d/pulid-contract.md
@@ -51,9 +51,13 @@
   into its own `$MOLD_HOME`, instead of the client accepting on its own behalf
   and the server refusing anyway. New `GET /api/licenses` lists each license
   with its pinned terms, `accepted`, and `required_by`; `POST /api/downloads`
-  and `POST /api/models/pull` take an additive `accept_licenses` array; a gated
-  download without one is a `403` with code `LICENSE_NOT_ACCEPTED` and a
-  structured `license` object so web, desktop, and iPhone can offer acceptance
-  in-app. Servers advertise `capabilities.licenses`, and `mold licenses` shows
+  and `POST /api/models/pull` take an additive `accept_licenses` array of
+  `{ id, url, sha256 }` entries carrying the exact terms the user was shown, so
+  a server on a different release cannot resolve a bare id to its own revision
+  and record consent for text nobody read. A gated download without one is a
+  `403` (`LICENSE_NOT_ACCEPTED`); terms the server does not pin are a `409`
+  (`LICENSE_TERMS_MISMATCH`) carrying the server's own terms to re-display.
+  Both write nothing, and both are structured so web, desktop, and iPhone can
+  offer acceptance in-app. Servers advertise `capabilities.licenses`, and `mold licenses` shows
   the state along with which machine it read
   ([#1220](https://github.com/utensils/mold/issues/1220)).

--- a/crates/mold-cli/src/commands/licenses.rs
+++ b/crates/mold-cli/src/commands/licenses.rs
@@ -1,19 +1,65 @@
 //! `mold licenses` — third-party model licenses and their acceptance state.
 //!
 //! Acceptance is per Mold data root, so the only meaningful answer is "on
-//! which machine?". This command asks the server the pull would go to, and
-//! falls back to this machine's own root only when no server answers —
-//! reporting which one it read, because a user staring at "accepted" for the
-//! wrong host is exactly the confusion this command exists to prevent.
+//! which machine?". This command asks the server the pull would go to and
+//! names the root it read, because a user staring at "accepted" for the wrong
+//! host is exactly the confusion this command exists to prevent.
+//!
+//! It reads THIS machine's root only when there is genuinely no server to ask
+//! — a connection failure, or the explicit `--local` flag. An authentication
+//! failure, a 5xx, or a malformed body all mean a server IS there and did not
+//! answer the question; substituting local state then would report one
+//! machine's acceptances under another machine's name, which is the same class
+//! of bug as accepting on the wrong host in the first place.
 
 use anyhow::Result;
 use colored::Colorize;
 
-use crate::control::{is_loopback_host, CliContext};
+use crate::control::CliContext;
 use crate::output::status;
 use crate::theme;
 use crate::ui::col_width;
 use crate::AlreadyReported;
+
+/// Where a listing came from, for the header and for error wording.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LicenseSource {
+    Server(String),
+    ThisMachine,
+}
+
+impl LicenseSource {
+    fn label(&self) -> String {
+        match self {
+            Self::Server(host) => host.clone(),
+            Self::ThisMachine => "this machine".to_string(),
+        }
+    }
+}
+
+/// Decide what a failed `GET /api/licenses` means.
+///
+/// Split out from the I/O so every arm is unit-testable: the whole finding is
+/// that "the request failed" is not one outcome but two, and only one of them
+/// may be answered with local state.
+pub fn resolve_listing_failure(error: &anyhow::Error, host: &str) -> LicenseListingFailure {
+    match mold_core::classify_server_error(error) {
+        mold_core::ServerAvailability::FallbackLocal => LicenseListingFailure::NoServer,
+        mold_core::ServerAvailability::SurfaceError => {
+            LicenseListingFailure::Unusable(format!("{host} did not report its licenses: {error}"))
+        }
+    }
+}
+
+/// The two meanings of a failed listing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LicenseListingFailure {
+    /// Nothing is listening. This machine's root is the honest answer.
+    NoServer,
+    /// A server answered, but not with a listing — auth, 5xx, or a body that
+    /// would not parse. Reported against the host; never papered over.
+    Unusable(String),
+}
 
 fn local_statuses() -> Result<Vec<mold_core::ThirdPartyLicenseStatus>> {
     let Some(mold_home) = mold_core::Config::mold_dir() else {
@@ -26,21 +72,32 @@ fn local_statuses() -> Result<Vec<mold_core::ThirdPartyLicenseStatus>> {
     Ok(mold_core::license_acceptance::license_statuses(&mold_home))
 }
 
-pub async fn run() -> Result<()> {
+pub async fn run(local: bool) -> Result<()> {
     let ctx = CliContext::new(None);
     let host = ctx.client().host().to_string();
 
-    let (licenses, source) = match ctx.client().list_licenses().await {
-        Ok(licenses) => (licenses, host.clone()),
-        Err(_) if is_loopback_host(&host) => (local_statuses()?, "this machine".to_string()),
-        Err(_) => {
-            // A named remote that did not answer must not be papered over
-            // with local state — that would report the wrong machine's
-            // acceptances under the remote's name.
-            crate::ui::print_server_fallback(&host, "showing this machine's licenses");
-            (local_statuses()?, "this machine".to_string())
+    let (licenses, source) = if local {
+        (local_statuses()?, LicenseSource::ThisMachine)
+    } else {
+        match ctx.client().list_licenses().await {
+            Ok(licenses) => (licenses, LicenseSource::Server(host.clone())),
+            Err(error) => match resolve_listing_failure(&error, &host) {
+                LicenseListingFailure::NoServer => {
+                    crate::ui::print_server_fallback(&host, "showing this machine's licenses");
+                    (local_statuses()?, LicenseSource::ThisMachine)
+                }
+                LicenseListingFailure::Unusable(message) => {
+                    eprintln!("{} {message}", theme::prefix_error());
+                    eprintln!(
+                        "  Run {} to read this machine's own acceptances instead.",
+                        "mold licenses --local".bold()
+                    );
+                    return Err(AlreadyReported.into());
+                }
+            },
         }
     };
+    let source = source.label();
 
     if licenses.is_empty() {
         status!(
@@ -93,4 +150,50 @@ pub async fn run() -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mold_core::error::MoldError;
+
+    /// Nothing is listening: this machine's root is the honest answer.
+    #[test]
+    fn a_connection_failure_falls_back_to_this_machine() {
+        let error = anyhow::Error::new(MoldError::Client("connect failed".into()));
+        assert_eq!(
+            resolve_listing_failure(&error, "http://box:7680"),
+            LicenseListingFailure::NoServer
+        );
+    }
+
+    /// A server IS there and refused or failed. Reporting local acceptances
+    /// under its name would answer a different question than the one asked.
+    #[test]
+    fn auth_and_server_errors_are_reported_against_the_host() {
+        for error in [
+            anyhow::anyhow!("HTTP 401 Unauthorized"),
+            anyhow::anyhow!("HTTP 500 Internal Server Error"),
+            anyhow::anyhow!("error decoding response body"),
+        ] {
+            match resolve_listing_failure(&error, "http://box:7680") {
+                LicenseListingFailure::Unusable(message) => {
+                    assert!(
+                        message.contains("http://box:7680"),
+                        "the failure must name the host: {message}"
+                    );
+                }
+                other => panic!("expected an unusable listing, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn source_labels_name_the_root_that_was_read() {
+        assert_eq!(
+            LicenseSource::Server("http://box:7680".into()).label(),
+            "http://box:7680"
+        );
+        assert_eq!(LicenseSource::ThisMachine.label(), "this machine");
+    }
 }

--- a/crates/mold-cli/src/commands/pull.rs
+++ b/crates/mold-cli/src/commands/pull.rs
@@ -211,16 +211,39 @@ fn show(name: &str, summary: &str, url: &str, canonical: &str) {
 
 /// Read the terms from the SERVER that will record the acceptance.
 ///
-/// Returns `None` when there is no such server to ask — unreachable, or an
-/// older build without `capabilities.licenses` — in which case the pull will
-/// land locally (or on a server with no license gate at all) and this build's
-/// own constants are the right thing to display.
-async fn server_license_terms(ctx: &CliContext) -> Option<Vec<mold_core::ThirdPartyLicenseStatus>> {
-    let capabilities = ctx.client().capabilities().await.ok()?;
+/// Returns `Ok(None)` only when there is genuinely no such server to ask —
+/// a connection failure, or an older build without `capabilities.licenses` —
+/// in which case the pull will land locally (or on a server with no license
+/// gate at all) and this build's own constants are the right thing to display.
+/// A server that answered but could not be read (auth, 5xx, malformed body)
+/// is an error naming the host: showing this build's terms in its place
+/// would prompt the user to consent to text the recording machine never saw.
+async fn server_license_terms(
+    ctx: &CliContext,
+) -> Result<Option<Vec<mold_core::ThirdPartyLicenseStatus>>> {
+    let host = ctx.client().host().to_string();
+    let capabilities = match ctx.client().capabilities().await {
+        Ok(capabilities) => capabilities,
+        Err(error) => return terms_fetch_failure(&error, &host, "capabilities"),
+    };
     if !capabilities.licenses {
-        return None;
+        return Ok(None);
     }
-    ctx.client().list_licenses().await.ok()
+    match ctx.client().list_licenses().await {
+        Ok(listing) => Ok(Some(listing)),
+        Err(error) => terms_fetch_failure(&error, &host, "licenses"),
+    }
+}
+
+/// Connection failures mean "no server to consult"; everything else is a
+/// server that answered and must not be silently replaced by local terms.
+fn terms_fetch_failure<T>(error: &anyhow::Error, host: &str, what: &str) -> Result<Option<T>> {
+    match mold_core::classify_server_error(error) {
+        mold_core::ServerAvailability::FallbackLocal => Ok(None),
+        mold_core::ServerAvailability::SurfaceError => Err(anyhow::anyhow!(
+            "{host} did not report its {what}, so its license terms cannot be shown for acceptance: {error}"
+        )),
+    }
 }
 
 /// Resolve a `--accept-license` id and SHOW the user what they are accepting.
@@ -357,7 +380,7 @@ pub async fn run(
     let server_terms = if accept_licenses.is_empty() {
         None
     } else {
-        server_license_terms(&ctx).await
+        server_license_terms(&ctx).await?
     };
 
     // Resolve and display before anything is dispatched: an unknown id must
@@ -586,6 +609,18 @@ async fn pull_via_server(
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn a_server_that_answered_but_could_not_be_read_is_an_error_naming_the_host() {
+        let error = anyhow::anyhow!("401 Unauthorized");
+        let outcome = super::terms_fetch_failure::<()>(&error, "http://box:7680", "licenses");
+        let message = outcome
+            .expect_err("a non-connection failure must surface")
+            .to_string();
+        assert!(message.contains("http://box:7680"), "{message}");
+        assert!(message.contains("licenses"), "{message}");
+        assert!(message.contains("401 Unauthorized"), "{message}");
+    }
+
     use super::*;
     use mold_catalog::entry::{DownloadRecipe, RecipeFile, RecipeFileRole};
 

--- a/crates/mold-cli/src/commands/pull.rs
+++ b/crates/mold-cli/src/commands/pull.rs
@@ -175,41 +175,118 @@ fn print_unknown_model_error(model: &str) {
     eprintln!("Usage: mold pull <model>");
 }
 
+/// A license the user was shown, and the exact payload that must be sent as a
+/// result.
+pub struct AcceptedLicense {
+    /// Precisely the identity that was displayed. Sending anything else would
+    /// mean the recorded consent is not the consent that was given.
+    pub acceptance: mold_core::LicenseAcceptance,
+    /// This build's pinned license, when the displayed terms were ours.
+    /// `None` when a server showed terms from a different Mold release — in
+    /// which case we must not record locally, because we would be storing our
+    /// own text under an agreement made to theirs.
+    pub local: Option<&'static mold_core::license_acceptance::ThirdPartyLicense>,
+}
+
+fn print_known_licenses_error(id: &str, known: impl Iterator<Item = (String, String)>) {
+    eprintln!(
+        "{} unknown license id '{}'",
+        theme::prefix_error(),
+        id.bold()
+    );
+    eprintln!();
+    eprintln!("  Known licenses:");
+    for (license_id, name) in known {
+        eprintln!("    {} — {}", license_id.bold(), name);
+    }
+}
+
+fn show(name: &str, summary: &str, url: &str, canonical: &str) {
+    status!("{} {}", theme::icon_info(), name.bold());
+    status!("  {}", summary);
+    status!("  Terms (pinned): {}", url);
+    status!("  Project terms:  {}", canonical);
+    status!("");
+}
+
+/// Read the terms from the SERVER that will record the acceptance.
+///
+/// Returns `None` when there is no such server to ask — unreachable, or an
+/// older build without `capabilities.licenses` — in which case the pull will
+/// land locally (or on a server with no license gate at all) and this build's
+/// own constants are the right thing to display.
+async fn server_license_terms(ctx: &CliContext) -> Option<Vec<mold_core::ThirdPartyLicenseStatus>> {
+    let capabilities = ctx.client().capabilities().await.ok()?;
+    if !capabilities.licenses {
+        return None;
+    }
+    ctx.client().list_licenses().await.ok()
+}
+
 /// Resolve a `--accept-license` id and SHOW the user what they are accepting.
 ///
-/// Always called before the pull is dispatched, on both the local and the
-/// server route, so the terms appear in the same invocation that agrees to
-/// them — a flag that silently consents is not consent.
+/// The terms displayed are the ones held by the machine that will RECORD the
+/// acceptance, and the payload sent back is byte-for-byte what was displayed.
+/// Showing our own pinned revision and then letting a server on a different
+/// release resolve the bare id to its own would record consent for text the
+/// user never read.
 ///
-/// Deliberately offline: the terms are pinned to an exact upstream commit
-/// whose digest was verified when the pin landed, so there is nothing a
-/// network round-trip could add, and accepting must work on an air-gapped
-/// host.
+/// Still offline in the local case: the terms are pinned to an exact upstream
+/// commit whose digest was verified when the pin landed, so accepting works on
+/// an air-gapped host.
 pub fn resolve_and_show_license(
     id: &str,
-) -> Result<&'static mold_core::license_acceptance::ThirdPartyLicense> {
+    server_terms: Option<&[mold_core::ThirdPartyLicenseStatus]>,
+) -> Result<AcceptedLicense> {
     use mold_core::license_acceptance;
 
-    let Some(license) = license_acceptance::license_by_id(id) else {
-        eprintln!(
-            "{} unknown license id '{}'",
-            theme::prefix_error(),
-            id.bold()
+    if let Some(terms) = server_terms {
+        let Some(status) = terms.iter().find(|entry| entry.id == id) else {
+            print_known_licenses_error(
+                id,
+                terms
+                    .iter()
+                    .map(|entry| (entry.id.clone(), entry.name.clone())),
+            );
+            return Err(AlreadyReported.into());
+        };
+        show(
+            &status.name,
+            &status.summary,
+            &status.url,
+            &status.canonical,
         );
-        eprintln!();
-        eprintln!("  Known licenses:");
-        for known in license_acceptance::THIRD_PARTY_LICENSES {
-            eprintln!("    {} — {}", known.id.bold(), known.name);
-        }
+        let local = license_acceptance::license_by_id(id)
+            .filter(|ours| ours.url == status.url && ours.sha256 == status.sha256);
+        return Ok(AcceptedLicense {
+            acceptance: mold_core::LicenseAcceptance {
+                id: status.id.clone(),
+                url: status.url.clone(),
+                sha256: status.sha256.clone(),
+            },
+            local,
+        });
+    }
+
+    let Some(license) = license_acceptance::license_by_id(id) else {
+        print_known_licenses_error(
+            id,
+            license_acceptance::THIRD_PARTY_LICENSES
+                .iter()
+                .map(|known| (known.id.to_string(), known.name.to_string())),
+        );
         return Err(AlreadyReported.into());
     };
-
-    status!("{} {}", theme::icon_info(), license.name.bold());
-    status!("  {}", license.summary);
-    status!("  Terms (pinned): {}", license.url);
-    status!("  Project terms:  {}", license.canonical);
-    status!("");
-    Ok(license)
+    show(
+        license.name,
+        license.summary,
+        license.url,
+        license.canonical,
+    );
+    Ok(AcceptedLicense {
+        acceptance: license_acceptance::acceptance_for(license),
+        local: Some(license),
+    })
 }
 
 /// Write the acceptance into THIS machine's Mold data root.
@@ -219,9 +296,20 @@ pub fn resolve_and_show_license(
 /// it in its own root — recording here and pulling there is exactly the bug
 /// that made the documented `--accept-license` command fail against a remote
 /// `MOLD_HOST`.
-pub fn record_license_locally(
-    license: &mold_core::license_acceptance::ThirdPartyLicense,
-) -> Result<()> {
+pub fn record_license_locally(accepted: &AcceptedLicense) -> Result<()> {
+    // The displayed terms came from a server on a different release, and the
+    // pull has since fallen back to this machine. Recording our own text under
+    // an agreement made to theirs would be exactly the substitution this whole
+    // payload shape exists to prevent.
+    let Some(license) = accepted.local else {
+        eprintln!(
+            "{} the terms shown for '{}' came from the server, but the pull fell back to this machine.",
+            theme::prefix_error(),
+            accepted.acceptance.id.bold()
+        );
+        eprintln!("  Re-run the command to review and accept this machine's terms.");
+        return Err(AlreadyReported.into());
+    };
     let Some(mold_home) = Config::mold_dir() else {
         eprintln!(
             "{} could not resolve the Mold data directory to record acceptance",
@@ -261,18 +349,32 @@ pub async fn run(
         }
     };
 
+    let ctx = CliContext::new(None);
+
+    // Ask the machine that will RECORD the acceptance for its terms before
+    // displaying anything — only skipped entirely when nothing is being
+    // accepted, so an ordinary pull pays no extra round trip.
+    let server_terms = if accept_licenses.is_empty() {
+        None
+    } else {
+        server_license_terms(&ctx).await
+    };
+
     // Resolve and display before anything is dispatched: an unknown id must
     // fail here rather than after a download has been enqueued somewhere.
     let mut licenses = Vec::with_capacity(accept_licenses.len());
     for id in accept_licenses {
-        licenses.push(resolve_and_show_license(id)?);
+        licenses.push(resolve_and_show_license(id, server_terms.as_deref())?);
     }
+    let payload: Vec<mold_core::LicenseAcceptance> = licenses
+        .iter()
+        .map(|accepted| accepted.acceptance.clone())
+        .collect();
 
-    let ctx = CliContext::new(None);
-    // The server path carries the ids on the wire so the SERVER records them
-    // in its own root; the local path records them here. Which machine runs
-    // the pull decides which machine's acceptance counts.
-    match pull_via_server(&ctx, manifest, accept_licenses).await {
+    // The server path carries the accepted terms on the wire so the SERVER
+    // records them in its own root; the local path records them here. Which
+    // machine runs the pull decides which machine's acceptance counts.
+    match pull_via_server(&ctx, manifest, &payload).await {
         Ok(()) => {}
         Err(e) => match classify_server_error(&e) {
             ServerAvailability::FallbackLocal => {
@@ -455,7 +557,7 @@ pub async fn run_recipe(
 async fn pull_via_server(
     ctx: &CliContext,
     manifest: &ModelManifest,
-    accept_licenses: &[String],
+    accept_licenses: &[mold_core::LicenseAcceptance],
 ) -> Result<()> {
     status!(
         "{} Pulling {} on {}",
@@ -486,6 +588,71 @@ async fn pull_via_server(
 mod tests {
     use super::*;
     use mold_catalog::entry::{DownloadRecipe, RecipeFile, RecipeFileRole};
+
+    fn server_status(url: &str, sha256: &str) -> mold_core::ThirdPartyLicenseStatus {
+        mold_core::ThirdPartyLicenseStatus {
+            id: "insightface-antelopev2".into(),
+            name: "Server's name for it".into(),
+            url: url.into(),
+            canonical: "https://example.invalid/terms".into(),
+            sha256: sha256.into(),
+            summary: "Server's summary".into(),
+            accepted: false,
+            required_by: vec!["pulid-flux".into()],
+        }
+    }
+
+    /// The consent-integrity rule at the client end: whatever identity was
+    /// displayed is exactly what gets sent. A server on a different release
+    /// pins a different revision, we show THAT, and we send THAT — never our
+    /// own constant under the server's summary.
+    #[test]
+    fn the_payload_is_exactly_the_displayed_identity() {
+        let their_url = "https://raw.githubusercontent.com/deepinsight/insightface/1111111111111111111111111111111111111111/README.md";
+        let their_sha = "1".repeat(64);
+        let terms = vec![server_status(their_url, &their_sha)];
+
+        let accepted = resolve_and_show_license("insightface-antelopev2", Some(&terms)).unwrap();
+        assert_eq!(accepted.acceptance.id, "insightface-antelopev2");
+        assert_eq!(accepted.acceptance.url, their_url);
+        assert_eq!(accepted.acceptance.sha256, their_sha);
+        assert!(
+            accepted.local.is_none(),
+            "terms that are not ours must not be recordable locally"
+        );
+    }
+
+    /// When the server pins what we pin, the payload still comes from the
+    /// server's row, and the local handle is available for a fallback pull.
+    #[test]
+    fn matching_server_terms_stay_recordable_locally() {
+        let ours = &mold_core::license_acceptance::INSIGHTFACE_ANTELOPEV2;
+        let terms = vec![server_status(ours.url, ours.sha256)];
+
+        let accepted = resolve_and_show_license("insightface-antelopev2", Some(&terms)).unwrap();
+        assert_eq!(accepted.acceptance.url, ours.url);
+        assert_eq!(accepted.acceptance.sha256, ours.sha256);
+        assert_eq!(accepted.local.map(|license| license.id), Some(ours.id));
+    }
+
+    /// No server to ask (older build, or unreachable): this build's own pinned
+    /// constant is displayed and sent.
+    #[test]
+    fn without_server_terms_the_local_pin_is_displayed_and_sent() {
+        let ours = &mold_core::license_acceptance::INSIGHTFACE_ANTELOPEV2;
+        let accepted = resolve_and_show_license("insightface-antelopev2", None).unwrap();
+        assert_eq!(accepted.acceptance.url, ours.url);
+        assert_eq!(accepted.acceptance.sha256, ours.sha256);
+        assert_eq!(accepted.local.map(|license| license.id), Some(ours.id));
+    }
+
+    #[test]
+    fn an_id_the_server_does_not_know_is_refused() {
+        let ours = &mold_core::license_acceptance::INSIGHTFACE_ANTELOPEV2;
+        let terms = vec![server_status(ours.url, ours.sha256)];
+        assert!(resolve_and_show_license("not-a-license", Some(&terms)).is_err());
+        assert!(resolve_and_show_license("not-a-license", None).is_err());
+    }
 
     #[test]
     fn rendered_primary_dest_skips_explicit_companion_roles() {

--- a/crates/mold-cli/src/control.rs
+++ b/crates/mold-cli/src/control.rs
@@ -54,7 +54,7 @@ impl CliContext {
     pub(crate) async fn stream_server_pull_accepting(
         &self,
         model: &str,
-        accept_licenses: &[String],
+        accept_licenses: &[mold_core::LicenseAcceptance],
     ) -> Result<()> {
         stream_server_pull(&self.client, model, accept_licenses).await
     }
@@ -98,7 +98,7 @@ pub(crate) fn is_loopback_host(host: &str) -> bool {
 pub(crate) async fn stream_server_pull(
     client: &MoldClient,
     model: &str,
-    accept_licenses: &[String],
+    accept_licenses: &[mold_core::LicenseAcceptance],
 ) -> Result<()> {
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
     let render = tokio::spawn(render_progress(rx));

--- a/crates/mold-cli/src/main.rs
+++ b/crates/mold-cli/src/main.rs
@@ -1281,7 +1281,11 @@ runs the pull: the server at MOLD_HOST when one answers, otherwise this
 machine. Accept a license as part of the pull it unblocks:
 
   mold pull pulid-flux --accept-license insightface-antelopev2")]
-    Licenses,
+    Licenses {
+        /// Read this machine's own acceptances instead of asking the server
+        #[arg(long)]
+        local: bool,
+    },
 
     /// Remove downloaded model(s) and their unique files
     #[command(
@@ -2295,8 +2299,8 @@ async fn run() -> anyhow::Result<()> {
                 commands::pull::run(&model, &opts, &accept_licenses).await?;
             }
         }
-        Commands::Licenses => {
-            commands::licenses::run().await?;
+        Commands::Licenses { local } => {
+            commands::licenses::run(local).await?;
         }
         Commands::Rm { models, force } => {
             commands::rm::run(&models, force).await?;

--- a/crates/mold-cli/src/skill/SKILL.md
+++ b/crates/mold-cli/src/skill/SKILL.md
@@ -866,6 +866,7 @@ mold info flux-dev:q4        # Show model details and file sizes
 mold rm flux-dev:q4          # Remove a downloaded model
 mold rm flux-dev:q4 --force  # Remove without confirmation
 mold licenses                # Third-party model licenses and acceptance state
+mold licenses --local        # ...this machine's own, without asking the server
 ```
 
 ### Third-party model licenses
@@ -875,7 +876,8 @@ the InsightFace antelopev2 face models PuLID needs, non-commercial research
 only). Mold refuses to download them until acceptance is on record.
 
 ```bash
-mold licenses                                              # what needs accepting, and where
+mold licenses                # what needs accepting, and on which machine
+mold licenses --local        # this machine's own acceptances, never the server's
 mold pull pulid-flux --accept-license insightface-antelopev2
 ```
 
@@ -892,11 +894,19 @@ newer upstream revision invalidates existing acceptances and asks again.
 Accepting is offline — Mold never fetches the license text, so it works
 air-gapped. There is no environment-variable bypass.
 
-Over HTTP: `GET /api/licenses` lists ids, terms links, `accepted`, and
-`required_by`; `POST /api/downloads` and `POST /api/models/pull` take an
-additive `accept_licenses: []`; a gated download without it is `403` with code
-`LICENSE_NOT_ACCEPTED` and a structured `license` object. Servers advertise
-`capabilities.licenses: true`.
+Consent is bound to the terms that were displayed. When a server will record
+the acceptance, `mold pull` reads `GET /api/licenses` from THAT server, shows
+its terms, and sends back exactly those — a bare id would let a server on a
+different release resolve its own revision and record agreement to text the
+user never read.
+
+Over HTTP: `GET /api/licenses` lists ids, terms links, `sha256`, `accepted`,
+and `required_by`. `POST /api/downloads` and `POST /api/models/pull` take an
+additive `accept_licenses: [{ id, url, sha256 }]`. A gated download without one
+is `403` / `LICENSE_NOT_ACCEPTED`; terms the server does not pin are `409` /
+`LICENSE_TERMS_MISMATCH` carrying the server's own `url`/`sha256`/`canonical`
+so a client can re-display and retry. Both refusals write nothing. Servers
+advertise `capabilities.licenses: true`.
 
 ## Model discovery catalog
 

--- a/crates/mold-core/src/client.rs
+++ b/crates/mold-core/src/client.rs
@@ -25,7 +25,10 @@ use tokio_util::io::ReaderStream;
 /// `accept_licenses` is omitted when empty so requests to older servers —
 /// which reject unknown fields on some builds and would otherwise see a field
 /// they never asked for — stay byte-identical to what they got before.
-fn pull_body(model: &str, accept_licenses: &[String]) -> serde_json::Value {
+fn pull_body(
+    model: &str,
+    accept_licenses: &[crate::types::LicenseAcceptance],
+) -> serde_json::Value {
     let mut body = serde_json::json!({ "model": model });
     if !accept_licenses.is_empty() {
         body["accept_licenses"] = serde_json::json!(accept_licenses);
@@ -1074,7 +1077,7 @@ impl MoldClient {
     pub async fn pull_model_accepting(
         &self,
         model: &str,
-        accept_licenses: &[String],
+        accept_licenses: &[crate::types::LicenseAcceptance],
     ) -> Result<String> {
         let resp = self
             .client
@@ -1129,7 +1132,7 @@ impl MoldClient {
     pub async fn pull_model_stream_accepting(
         &self,
         model: &str,
-        accept_licenses: &[String],
+        accept_licenses: &[crate::types::LicenseAcceptance],
         progress_tx: tokio::sync::mpsc::UnboundedSender<SseProgressEvent>,
     ) -> Result<()> {
         let mut resp = self

--- a/crates/mold-core/src/license_acceptance.rs
+++ b/crates/mold-core/src/license_acceptance.rs
@@ -178,6 +178,7 @@ pub fn refusal(license: &ThirdPartyLicense) -> crate::types::LicenseRefusal {
         name: license.name.to_string(),
         url: license.url.to_string(),
         canonical: license.canonical.to_string(),
+        sha256: license.sha256.to_string(),
         summary: license.summary.to_string(),
     }
 }
@@ -207,19 +208,29 @@ impl std::fmt::Display for UnknownLicenseId {
 
 impl std::error::Error for UnknownLicenseId {}
 
-/// Resolve every id, then record all of them.
+/// Resolve and VERIFY every acceptance, then record them all.
 ///
-/// Resolution happens for the WHOLE list before the first write, so one bad id
-/// cannot leave a request half-applied — the caller's 400 then describes a
-/// root that was not touched.
+/// Two things are checked before anything is written, for the whole list:
+/// that the id is known, and that the `(url, sha256)` the caller displayed is
+/// the document this build pins. The second check is the point of the whole
+/// struct — the caller may be a client on a different Mold release, and
+/// recording its consent against terms of OUR choosing would store agreement
+/// to text the user never read.
+///
+/// Nothing is written until every entry passes, so a rejected request leaves a
+/// root the caller can describe as untouched.
 pub fn record_acceptances(
     mold_home: &Path,
-    ids: &[String],
+    acceptances: &[crate::types::LicenseAcceptance],
 ) -> Result<Vec<&'static ThirdPartyLicense>, RecordAcceptancesError> {
-    let mut resolved = Vec::with_capacity(ids.len());
-    for id in ids {
-        let license = license_by_id(id)
-            .ok_or_else(|| RecordAcceptancesError::Unknown(UnknownLicenseId(id.clone())))?;
+    let mut resolved = Vec::with_capacity(acceptances.len());
+    for acceptance in acceptances {
+        let license = license_by_id(&acceptance.id).ok_or_else(|| {
+            RecordAcceptancesError::Unknown(UnknownLicenseId(acceptance.id.clone()))
+        })?;
+        if !acceptance.matches(license.url, license.sha256) {
+            return Err(RecordAcceptancesError::TermsMismatch(license));
+        }
         resolved.push(license);
     }
     for license in &resolved {
@@ -233,6 +244,10 @@ pub fn record_acceptances(
 pub enum RecordAcceptancesError {
     /// The request named a license this build does not know — a client error.
     Unknown(UnknownLicenseId),
+    /// The caller accepted a DIFFERENT revision of a license this build knows.
+    /// Carries our pinned license so the refusal can show the caller what it
+    /// would have to accept instead.
+    TermsMismatch(&'static ThirdPartyLicense),
     /// The record could not be written — a server error.
     Io(io::Error),
 }
@@ -241,12 +256,29 @@ impl std::fmt::Display for RecordAcceptancesError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Unknown(error) => write!(f, "{error}"),
+            Self::TermsMismatch(license) => write!(
+                f,
+                "the accepted terms for '{}' are not the ones this server pins. \
+                 This server pins {} (sha256 {}). Review those terms and accept again.",
+                license.id, license.url, license.sha256
+            ),
             Self::Io(error) => write!(f, "failed to record license acceptance: {error}"),
         }
     }
 }
 
 impl std::error::Error for RecordAcceptancesError {}
+
+/// The acceptance payload for `license` as this build pins it.
+///
+/// Used by the CLI's older-server fallback, and by tests.
+pub fn acceptance_for(license: &ThirdPartyLicense) -> crate::types::LicenseAcceptance {
+    crate::types::LicenseAcceptance {
+        id: license.id.to_string(),
+        url: license.url.to_string(),
+        sha256: license.sha256.to_string(),
+    }
+}
 
 /// Path of the acceptance record inside a Mold data root.
 pub fn acceptance_path(mold_home: &Path) -> PathBuf {
@@ -484,6 +516,78 @@ mod tests {
         record_acceptance(home.path(), &INSIGHTFACE_ANTELOPEV2).unwrap();
         let record = load(home.path());
         assert_eq!(record.acceptances.len(), 1);
+    }
+
+    /// The consent-integrity rule: a caller may only have its acceptance
+    /// recorded against the document it actually displayed.
+    #[test]
+    fn recording_requires_the_terms_the_caller_displayed() {
+        let home = tempfile::tempdir().unwrap();
+        let ours = &INSIGHTFACE_ANTELOPEV2;
+
+        let honest = [acceptance_for(ours)];
+        record_acceptances(home.path(), &honest).unwrap();
+        assert!(is_accepted(home.path(), ours));
+
+        // A caller on a different release, resolving the same id to its own
+        // pinned revision.
+        let fresh = tempfile::tempdir().unwrap();
+        let other_revision = crate::types::LicenseAcceptance {
+            id: ours.id.to_string(),
+            url: "https://raw.githubusercontent.com/deepinsight/insightface/0000000000000000000000000000000000000000/README.md".to_string(),
+            sha256: ours.sha256.to_string(),
+        };
+        let error = record_acceptances(fresh.path(), &[other_revision]).unwrap_err();
+        assert!(matches!(
+            error,
+            RecordAcceptancesError::TermsMismatch(license) if license.id == ours.id
+        ));
+        assert!(
+            !is_accepted(fresh.path(), ours),
+            "a mismatched acceptance must record nothing"
+        );
+
+        // Same URL, different digest, is equally a mismatch — the URL alone
+        // is not the identity.
+        let wrong_digest = crate::types::LicenseAcceptance {
+            id: ours.id.to_string(),
+            url: ours.url.to_string(),
+            sha256: "0".repeat(64),
+        };
+        assert!(matches!(
+            record_acceptances(fresh.path(), &[wrong_digest]).unwrap_err(),
+            RecordAcceptancesError::TermsMismatch(_)
+        ));
+        assert!(!is_accepted(fresh.path(), ours));
+    }
+
+    #[test]
+    fn digest_casing_is_not_part_of_the_identity() {
+        let home = tempfile::tempdir().unwrap();
+        let ours = &INSIGHTFACE_ANTELOPEV2;
+        let upper = crate::types::LicenseAcceptance {
+            id: ours.id.to_string(),
+            url: ours.url.to_string(),
+            sha256: ours.sha256.to_ascii_uppercase(),
+        };
+        record_acceptances(home.path(), &[upper]).unwrap();
+        assert!(is_accepted(home.path(), ours));
+    }
+
+    /// A rejected entry must not leave earlier entries in the same request
+    /// applied — the refusal describes a root that was not touched.
+    #[test]
+    fn a_mismatch_late_in_the_list_writes_nothing_at_all() {
+        let home = tempfile::tempdir().unwrap();
+        let ours = &INSIGHTFACE_ANTELOPEV2;
+        let bad = crate::types::LicenseAcceptance {
+            id: ours.id.to_string(),
+            url: ours.url.to_string(),
+            sha256: "0".repeat(64),
+        };
+        let error = record_acceptances(home.path(), &[acceptance_for(ours), bad]).unwrap_err();
+        assert!(matches!(error, RecordAcceptancesError::TermsMismatch(_)));
+        assert!(!is_accepted(home.path(), ours));
     }
 
     #[test]

--- a/crates/mold-core/src/types.rs
+++ b/crates/mold-core/src/types.rs
@@ -7861,6 +7861,46 @@ pub struct LicenseListing {
     pub licenses: Vec<ThirdPartyLicenseStatus>,
 }
 
+/// One license the user accepted, carrying the EXACT terms they were shown.
+///
+/// Deliberately not a bare id string. Acceptance is recorded on whichever
+/// machine runs the download, and that machine may be on a different Mold
+/// release with a different pinned revision of the same license. An id alone
+/// would let it resolve terms of its own choosing and record consent for text
+/// the user never read — the server must be able to prove it is storing
+/// agreement to the document that was actually displayed, so the identity
+/// travels with the id and a mismatch is refused rather than reconciled.
+///
+/// There is no bare-string compatibility shape on purpose: accepting one would
+/// reintroduce exactly the hole this struct closes, and no client has shipped
+/// against the id-only form.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct LicenseAcceptance {
+    /// Stable license id.
+    pub id: String,
+    /// Immutable, commit-pinned URL of the terms the user was shown.
+    pub url: String,
+    /// SHA-256 of the text at `url`, as displayed.
+    pub sha256: String,
+}
+
+impl LicenseAcceptance {
+    /// True when `self` names the same document as `(url, sha256)`.
+    ///
+    /// Digest comparison is case-insensitive because hex casing is not part of
+    /// the identity; the URL must match exactly.
+    pub fn matches(&self, url: &str, sha256: &str) -> bool {
+        self.url == url && self.sha256.eq_ignore_ascii_case(sha256)
+    }
+}
+
+/// Error code for an acceptance whose terms are not the ones this server pins.
+///
+/// Distinct from [`LICENSE_NOT_ACCEPTED`]: nothing is missing, the two sides
+/// simply disagree about what the license says. The refusal carries the
+/// server's own terms so a client can display those and retry.
+pub const LICENSE_TERMS_MISMATCH: &str = "LICENSE_TERMS_MISMATCH";
+
 /// The machine-readable half of a `LICENSE_NOT_ACCEPTED` refusal.
 ///
 /// Rides the error body beside the human message so a UI can render its own
@@ -7872,6 +7912,9 @@ pub struct LicenseRefusal {
     pub name: String,
     pub url: String,
     pub canonical: String,
+    /// SHA-256 of the text at `url`. Lets a client that was refused for a
+    /// terms mismatch re-display and re-send exactly what this server pins.
+    pub sha256: String,
     pub summary: String,
 }
 

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -109,6 +109,30 @@ impl ApiError {
     /// exists — the server is declining to act until consent is on record.
     /// The structured `license` payload lets a client offer acceptance and
     /// retry with `accept_licenses`, which a prose-only error could not.
+    /// The caller accepted a different revision of a license this server
+    /// knows.
+    ///
+    /// `409` rather than `400`: the request is well-formed and the license is
+    /// real — the two sides disagree about the current terms, which a client
+    /// resolves by re-reading `GET /api/licenses` and accepting again. The
+    /// structured payload carries THIS server's `url`/`sha256`/`canonical` so
+    /// it can display them without a second round trip.
+    pub fn license_terms_mismatch(
+        license: &mold_core::license_acceptance::ThirdPartyLicense,
+    ) -> Self {
+        Self {
+            error: format!(
+                "the accepted terms for '{}' are not the ones this server pins.\n\n  {}\n  Terms (pinned): {}\n  sha256: {}\n  Project terms: {}\n\nReview those terms and accept again.",
+                license.id, license.summary, license.url, license.sha256, license.canonical
+            ),
+            code: mold_core::LICENSE_TERMS_MISMATCH.to_string(),
+            reference: None,
+            field: None,
+            license: Some(Box::new(mold_core::license_acceptance::refusal(license))),
+            status: StatusCode::CONFLICT,
+        }
+    }
+
     pub fn license_not_accepted(
         model: &str,
         license: &mold_core::license_acceptance::ThirdPartyLicense,
@@ -917,7 +941,7 @@ async fn require_server_model_acquisition(
 /// rejected rather than ignored.
 fn apply_download_license_acceptances(
     model: &str,
-    accept_licenses: &[String],
+    accept_licenses: &[mold_core::LicenseAcceptance],
 ) -> Result<(), ApiError> {
     use mold_core::license_acceptance;
 
@@ -934,6 +958,9 @@ fn apply_download_license_acceptances(
                         "UNKNOWN_LICENSE",
                         StatusCode::BAD_REQUEST,
                     )
+                }
+                license_acceptance::RecordAcceptancesError::TermsMismatch(ours) => {
+                    ApiError::license_terms_mismatch(ours)
                 }
                 license_acceptance::RecordAcceptancesError::Io(io) => {
                     ApiError::internal(format!("failed to record license acceptance: {io}"))
@@ -3743,11 +3770,12 @@ pub struct LoadModelBody {
     /// default placement strategy.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub gpu: Option<usize>,
-    /// Third-party license ids the user has accepted. Honoured by
-    /// `POST /api/models/pull`; ignored by `/api/models/load`, which moves no
-    /// bytes over the network. Additive and empty by default.
+    /// Third-party licenses the user has accepted, each carrying the exact
+    /// terms they were shown. Honoured by `POST /api/models/pull`; ignored by
+    /// `/api/models/load`, which moves no bytes over the network. Additive and
+    /// empty by default.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub accept_licenses: Vec<String>,
+    pub accept_licenses: Vec<mold_core::LicenseAcceptance>,
 }
 
 #[utoipa::path(
@@ -7850,13 +7878,14 @@ async fn list_licenses_endpoint() -> Result<Json<mold_core::LicenseListing>, Api
 #[derive(serde::Deserialize, utoipa::ToSchema)]
 pub struct CreateDownloadBody {
     pub model: String,
-    /// Third-party license ids the user has accepted, recorded in this
-    /// server's Mold data root before the pull starts.
+    /// Third-party licenses the user has accepted, each carrying the exact
+    /// terms they were shown, recorded in this server's Mold data root before
+    /// the pull starts.
     ///
     /// Additive: absent means "accept nothing", which is what every existing
     /// client sends and leaves their behaviour unchanged.
     #[serde(default)]
-    pub accept_licenses: Vec<String>,
+    pub accept_licenses: Vec<mold_core::LicenseAcceptance>,
 }
 
 #[derive(serde::Serialize, utoipa::ToSchema)]

--- a/crates/mold-server/src/routes_test.rs
+++ b/crates/mold-server/src/routes_test.rs
@@ -11188,6 +11188,86 @@ mod tests {
             .unwrap()
     }
 
+    /// The exact terms this build pins — what an honest client would have
+    /// read from `GET /api/licenses` and displayed before accepting.
+    fn accepted_terms() -> serde_json::Value {
+        let license = &mold_core::license_acceptance::INSIGHTFACE_ANTELOPEV2;
+        serde_json::json!({
+            "id": license.id,
+            "url": license.url,
+            "sha256": license.sha256,
+        })
+    }
+
+    /// A client on a different Mold release resolves the same id to a
+    /// different pinned revision. Recording ITS consent against OUR text would
+    /// store agreement to a document the user never read, so the server
+    /// refuses and shows its own terms instead.
+    #[tokio::test]
+    async fn post_api_downloads_rejects_terms_the_server_does_not_pin() {
+        let (home, _guard) = license_home();
+        let state = licensed_state();
+        let app = app_with_state(state.clone());
+
+        let stale = serde_json::json!({
+            "id": "insightface-antelopev2",
+            "url": "https://raw.githubusercontent.com/deepinsight/insightface/0000000000000000000000000000000000000000/README.md",
+            "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+        });
+        let res = app
+            .oneshot(download_request(serde_json::json!({
+                "model": "pulid-flux",
+                "accept_licenses": [stale],
+            })))
+            .await
+            .unwrap();
+
+        assert_eq!(res.status(), StatusCode::CONFLICT);
+        let body = json_body(res).await;
+        assert_eq!(body["code"], mold_core::LICENSE_TERMS_MISMATCH);
+        // The server's OWN terms ride the refusal so the client can display
+        // them and retry without a second round trip.
+        let ours = &mold_core::license_acceptance::INSIGHTFACE_ANTELOPEV2;
+        assert_eq!(body["license"]["url"], ours.url);
+        assert_eq!(body["license"]["sha256"], ours.sha256);
+        assert_eq!(body["license"]["canonical"], ours.canonical);
+
+        assert!(!mold_core::license_acceptance::is_accepted(
+            home.path(),
+            ours
+        ));
+        assert!(state.downloads.listing().await.queued.is_empty());
+    }
+
+    /// A right id with a wrong digest is still a mismatch — the URL alone is
+    /// not the identity.
+    #[tokio::test]
+    async fn post_api_downloads_rejects_a_matching_url_with_a_different_digest() {
+        let (home, _guard) = license_home();
+        let state = licensed_state();
+        let app = app_with_state(state.clone());
+
+        let ours = &mold_core::license_acceptance::INSIGHTFACE_ANTELOPEV2;
+        let res = app
+            .oneshot(download_request(serde_json::json!({
+                "model": "pulid-flux",
+                "accept_licenses": [{
+                    "id": ours.id,
+                    "url": ours.url,
+                    "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+                }],
+            })))
+            .await
+            .unwrap();
+
+        assert_eq!(res.status(), StatusCode::CONFLICT);
+        assert!(!mold_core::license_acceptance::is_accepted(
+            home.path(),
+            ours
+        ));
+        assert!(state.downloads.listing().await.queued.is_empty());
+    }
+
     #[tokio::test]
     async fn get_api_licenses_reflects_this_servers_acceptance_state() {
         let (home, _guard) = license_home();
@@ -11292,7 +11372,7 @@ mod tests {
         let res = app
             .oneshot(download_request(serde_json::json!({
                 "model": "pulid-flux",
-                "accept_licenses": ["insightface-antelopev2"],
+                "accept_licenses": [accepted_terms()],
             })))
             .await
             .unwrap();
@@ -11317,7 +11397,10 @@ mod tests {
         let res = app
             .oneshot(download_request(serde_json::json!({
                 "model": "pulid-flux",
-                "accept_licenses": ["insightface-antelopev2", "not-a-license"],
+                "accept_licenses": [
+                    accepted_terms(),
+                    { "id": "not-a-license", "url": "https://example.invalid/x", "sha256": "0" },
+                ],
             })))
             .await
             .unwrap();

--- a/website/api/index.md
+++ b/website/api/index.md
@@ -1413,20 +1413,44 @@ server that answered — a multi-host client must ask each one.
 ### Accepting a license
 
 `POST /api/downloads` and `POST /api/models/pull` take an additive
-`accept_licenses` array of ids. The server records them in **its own**
-`$MOLD_HOME/license-acceptances.json` (owner-only, `0600`) before the pull
-starts:
+`accept_licenses` array. Each entry carries the **exact terms the user was
+shown**, not just an id:
 
 ```bash
 curl -X POST http://localhost:7680/api/downloads \
   -H "Content-Type: application/json" \
-  -d '{"model":"pulid-flux","accept_licenses":["insightface-antelopev2"]}'
+  -d '{
+    "model": "pulid-flux",
+    "accept_licenses": [{
+      "id": "insightface-antelopev2",
+      "url": "https://raw.githubusercontent.com/deepinsight/insightface/7fadd420c2351d0ffa8cac403421c1a3ed733365/README.md",
+      "sha256": "84606d9ab37a38606b12c10d96172c6343768d2ef72c802a16482e476f8baf22"
+    }]
+  }'
 ```
 
-Omitting the field means "accept nothing", which is what every existing client
-sends. An id this server does not know is a `400` with code `UNKNOWN_LICENSE`,
-and nothing is written — resolution happens for the whole list before the first
-write, so one bad id cannot leave the request half-applied.
+An id alone would not be safe. The client and the server may be on different
+Mold releases pinning different revisions of the same license, and a bare id
+would let the server resolve terms of its own choosing and record consent for
+text the user never read. So the server compares the submitted `(url, sha256)`
+against its own pin and only records a match. Read `GET /api/licenses` first,
+display what it returned, and send back exactly that.
+
+The server records into **its own** `$MOLD_HOME/license-acceptances.json`
+(owner-only, `0600`) before the pull starts. Omitting the field means "accept
+nothing", which is what every existing client sends.
+
+Nothing is written unless every entry passes, so a rejected request leaves the
+root untouched:
+
+| Condition                                | Status | Code                     |
+| ---------------------------------------- | ------ | ------------------------ |
+| Id this server does not know             | `400`  | `UNKNOWN_LICENSE`        |
+| Known id, terms this server does not pin | `409`  | `LICENSE_TERMS_MISMATCH` |
+
+A `409` carries the server's own `url`, `sha256`, and `canonical` in the
+`license` object, so a client can display the server's terms and retry without
+a second round trip.
 
 ### Refusals
 
@@ -1442,6 +1466,7 @@ and code `LICENSE_NOT_ACCEPTED`, before any bytes move:
     "name": "InsightFace pretrained models (antelopev2)",
     "url": "https://raw.githubusercontent.com/deepinsight/insightface/7fadd420c2351d0ffa8cac403421c1a3ed733365/README.md",
     "canonical": "https://github.com/deepinsight/insightface#license",
+    "sha256": "84606d9ab37a38606b12c10d96172c6343768d2ef72c802a16482e476f8baf22",
     "summary": "InsightFace pretrained models (antelopev2: scrfd_10g_bnkps, glintr100) are licensed for non-commercial research purposes only."
   }
 }

--- a/website/guide/configuration.md
+++ b/website/guide/configuration.md
@@ -374,18 +374,34 @@ The acceptance has to live on the machine that does the downloading, and
 - **No server, or `--local`**: the pull runs here, so the acceptance is
   recorded here.
 
-Either way the terms are printed before the request goes out. Run
-`mold licenses` to see what needs accepting and which root was read:
+Either way the terms are printed before the request goes out — and they are the
+terms of the machine that will record them. When a server will do the
+recording, `mold pull` reads that server's `GET /api/licenses`, displays what
+it returned, and sends back exactly that; the server refuses anything else.
+This matters because the two sides can be on different Mold releases pinning
+different revisions of the same license, and consent has to mean the document
+that was actually shown.
+
+Run `mold licenses` to see what needs accepting and which root was read:
 
 ```bash
-mold licenses
+mold licenses           # asks the server at MOLD_HOST when one answers
+mold licenses --local   # this machine's own acceptances, without asking
 ```
+
+`mold licenses` reads this machine only when nothing is listening at
+`MOLD_HOST`, or when you pass `--local`. If a server is there but the request
+fails — authentication, a 5xx, an unreadable body — the command reports that
+against the host rather than quietly showing you a different machine's
+acceptances.
 
 Over HTTP, `GET /api/licenses` returns each license with `accepted` and
 `required_by`, and `POST /api/downloads` / `POST /api/models/pull` accept an
-additive `accept_licenses` array. A gated download without one is refused with
-`403` and code `LICENSE_NOT_ACCEPTED`, carrying a structured `license` object a
-UI can build its own prompt from. Servers that support this advertise
+additive `accept_licenses` array of `{ id, url, sha256 }` entries. A gated
+download without one is refused with `403` and code `LICENSE_NOT_ACCEPTED`;
+terms the server does not pin are refused with `409` and code
+`LICENSE_TERMS_MISMATCH`. Both carry a structured `license` object — including
+the server's own `url` and `sha256` — that a UI can build its own prompt from. Servers that support this advertise
 `capabilities.licenses: true`; older ones do not, and can only be accepted by
 running `mold pull --accept-license` in a shell on that host.
 


### PR DESCRIPTION
Follow-up to #1242 (merged before these two codex findings landed). Refs #1220.

- **P1 — consent bound to the displayed terms.** `accept_licenses` entries on `POST /api/downloads` and `POST /api/models/pull` are now `{id, url, sha256}`; the server verifies them against its own pinned license before recording anything and answers a mismatch with `409 LICENSE_TERMS_MISMATCH` carrying its real `url`/`sha256`/`canonical`. `mold pull --accept-license` fetches and displays the recording server's terms (falling back to this build's pin only when no such server exists) and sends exactly what it displayed; it refuses to record locally under an agreement made to a server's different text. No bare-id compatibility on purpose — that is the hole being closed.
- **P2 — `mold licenses` no longer masks server errors.** Local fallback only on a genuine connection failure (announced) or explicit `--local`; auth, 5xx, and malformed bodies are reported against the host.

Tests: core (revision/digest mismatch rejected, nothing written on a late mismatch, case-insensitive digest), server (409 body + untouched root + empty queue), CLI (payload equals displayed identity; no-server path; unknown id; all three listing arms). Verified end to end against a live server. Docs: `website/api/index.md`, SKILL.md, `website/guide/configuration.md`, changelog bullet.