### PR TITLE
fix(ios): keep mobile editors and media in bounds

### DIFF
--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -5435,10 +5435,11 @@ describe("MobileApp foreground resume", () => {
     }
   });
 
-  it("counters visual-viewport keyboard panning so the header stays below iOS chrome", async () => {
+  it("tracks the visual viewport so sheets clear the keyboard and the header stays put", async () => {
     const originalViewport = Object.getOwnPropertyDescriptor(window, "visualViewport");
-    const visualViewport = new EventTarget() as EventTarget & { pageTop: number };
+    const visualViewport = new EventTarget() as EventTarget & { pageTop: number; height: number };
     visualViewport.pageTop = 58;
+    visualViewport.height = 510;
     Object.defineProperty(window, "visualViewport", {
       value: visualViewport,
       configurable: true,
@@ -5449,12 +5450,19 @@ describe("MobileApp foreground resume", () => {
       expect(
         document.documentElement.style.getPropertyValue("--mobile-visual-viewport-page-top"),
       ).toBe("58px");
+      expect(
+        document.documentElement.style.getPropertyValue("--mobile-visual-viewport-height"),
+      ).toBe("510px");
 
       visualViewport.pageTop = 0;
-      visualViewport.dispatchEvent(new Event("scroll"));
+      visualViewport.height = 844;
+      visualViewport.dispatchEvent(new Event("resize"));
       expect(
         document.documentElement.style.getPropertyValue("--mobile-visual-viewport-page-top"),
       ).toBe("0px");
+      expect(
+        document.documentElement.style.getPropertyValue("--mobile-visual-viewport-height"),
+      ).toBe("844px");
     } finally {
       wrapper?.unmount();
       wrapper = null;

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -7399,11 +7399,20 @@ function usesSoftwareKeyboard(target: EventTarget | null): target is HTMLElement
 }
 
 function syncVisualViewportOffset(): void {
-  const pageTop = window.visualViewport?.pageTop ?? window.scrollY;
+  const viewport = window.visualViewport;
+  const pageTop = viewport?.pageTop ?? window.scrollY;
   document.documentElement.style.setProperty(
     "--mobile-visual-viewport-page-top",
     `${Math.max(0, pageTop)}px`,
   );
+  if (viewport && Number.isFinite(viewport.height) && viewport.height > 0) {
+    document.documentElement.style.setProperty(
+      "--mobile-visual-viewport-height",
+      `${viewport.height}px`,
+    );
+  } else {
+    document.documentElement.style.removeProperty("--mobile-visual-viewport-height");
+  }
 }
 
 function restoreNativeViewport(): void {
@@ -7558,6 +7567,7 @@ onBeforeUnmount(() => {
   window.visualViewport?.removeEventListener("resize", syncVisualViewportOffset);
   window.visualViewport?.removeEventListener("scroll", syncVisualViewportOffset);
   document.documentElement.style.removeProperty("--mobile-visual-viewport-page-top");
+  document.documentElement.style.removeProperty("--mobile-visual-viewport-height");
   window.removeEventListener("pageshow", handleForegroundResume);
   cancelKeyboardViewportRestore();
   stopPairingDeepLinks?.();

--- a/desktop/src/mobile/mobile.css
+++ b/desktop/src/mobile/mobile.css
@@ -1888,7 +1888,8 @@ button.mobile-generate-disclosure {
 .mobile-advanced-sheet {
   display: none;
   position: fixed;
-  inset: 0;
+  inset: 0 0 auto;
+  height: var(--mobile-visual-viewport-height, 100dvh);
   z-index: 45;
   flex-direction: column;
   background: var(--bath);
@@ -1997,7 +1998,8 @@ button.mobile-generate-disclosure {
 .mobile-seam-sheet {
   display: none;
   position: fixed;
-  inset: 0;
+  inset: 0 0 auto;
+  height: var(--mobile-visual-viewport-height, 100dvh);
   z-index: 46;
   flex-direction: column;
   justify-content: flex-end;
@@ -2018,7 +2020,7 @@ button.mobile-generate-disclosure {
   position: relative;
   display: flex;
   min-height: 0;
-  max-height: 86dvh;
+  max-height: min(86dvh, var(--mobile-visual-viewport-height, 100dvh));
   flex-direction: column;
   border-top: 1px solid var(--edge);
   border-radius: 18px 18px 0 0;
@@ -2729,6 +2731,7 @@ button:disabled {
   max-height: none;
   grid-template-rows: auto minmax(0, 1fr) auto;
   box-sizing: border-box;
+  overflow: hidden;
   margin: 0;
   border: 0;
   padding-right: 0;
@@ -2749,10 +2752,13 @@ button:disabled {
 
 .gallery-viewer-header {
   display: flex;
+  width: 100%;
+  min-width: 0;
   min-height: 52px;
   align-items: center;
   justify-content: space-between;
   gap: 16px;
+  box-sizing: border-box;
   padding: 6px max(16px, env(safe-area-inset-right)) 6px max(16px, env(safe-area-inset-left));
   border-bottom: 1px solid rgba(245, 239, 255, 0.12);
   background: rgba(8, 7, 12, 0.92);
@@ -2760,6 +2766,7 @@ button:disabled {
 
 .gallery-viewer-close {
   display: inline-flex;
+  flex: 0 0 auto;
   min-width: 44px;
   min-height: 44px;
   align-items: center;
@@ -2780,6 +2787,7 @@ button:disabled {
 }
 
 .gallery-viewer-origin {
+  flex: 1 1 0;
   min-width: 0;
   text-align: right;
 }
@@ -2806,6 +2814,8 @@ button:disabled {
 
 .gallery-viewer-stage {
   position: relative;
+  width: 100%;
+  min-width: 0;
   min-height: 0;
   overflow: hidden;
   background: #000;
@@ -2815,6 +2825,8 @@ button:disabled {
 .gallery-viewer-placeholder {
   display: block;
   width: 100%;
+  min-width: 0;
+  max-width: 100%;
   height: 100%;
   object-fit: contain;
 }
@@ -2853,6 +2865,9 @@ button:disabled {
 
 .gallery-viewer-details {
   display: grid;
+  width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
   gap: 14px;
   padding: 14px max(16px, env(safe-area-inset-right)) 16px max(16px, env(safe-area-inset-left));
   border-top: 1px solid rgba(245, 239, 255, 0.12);
@@ -4626,7 +4641,8 @@ button:disabled {
 .mobile-library-sheet {
   display: none;
   position: fixed;
-  inset: 0;
+  inset: 0 0 auto;
+  height: var(--mobile-visual-viewport-height, 100dvh);
   z-index: 46;
   flex-direction: column;
   justify-content: flex-end;
@@ -4647,7 +4663,7 @@ button:disabled {
   position: relative;
   display: flex;
   min-height: 0;
-  max-height: 86dvh;
+  max-height: min(86dvh, var(--mobile-visual-viewport-height, 100dvh));
   flex-direction: column;
   border-top: 1px solid var(--edge);
   border-radius: 18px 18px 0 0;
@@ -4728,6 +4744,7 @@ button:disabled {
 
 .mobile-library-sheet-form .field {
   min-width: 0;
+  margin: 0;
 }
 
 /* Tag chips with an inline × remove target. */

--- a/desktop/src/mobile/mobile.css.test.ts
+++ b/desktop/src/mobile/mobile.css.test.ts
@@ -172,12 +172,16 @@ describe("mobile seam sheet", () => {
     const open = css.match(/\.mobile-seam-sheet\.is-open\s*\{([^}]*)\}/s);
     expect(sheet?.[1]).toMatch(/position:\s*fixed\s*;/);
     expect(sheet?.[1]).toMatch(/display:\s*none\s*;/);
-    expect(sheet?.[1]).toMatch(/inset:\s*0\s*;/);
+    expect(sheet?.[1]).toMatch(/inset:\s*0 0 auto\s*;/);
     expect(open?.[1]).toMatch(/display:\s*flex\s*;/);
   });
 
   it("scrolls its own body with the pinned mobile containment invariants", () => {
+    const panel = css.match(/\.mobile-seam-sheet-panel\s*\{([^}]*)\}/s);
     const body = css.match(/\.mobile-seam-sheet-body\s*\{([^}]*)\}/s);
+    expect(panel?.[1]).toMatch(
+      /max-height:\s*min\(86dvh,\s*var\(--mobile-visual-viewport-height,\s*100dvh\)\)\s*;/,
+    );
     expect(body?.[1]).toMatch(/overflow-y:\s*auto\s*;/);
     expect(body?.[1]).toMatch(/overscroll-behavior:\s*none\s*;/);
     expect(body?.[1]).toMatch(/touch-action:\s*manipulation\s*;/);
@@ -439,6 +443,35 @@ describe("mobile develop bed", () => {
   });
 });
 
+describe("mobile gallery viewer", () => {
+  it("contains wide intrinsic media inside the iPhone viewport", () => {
+    const viewer = css.match(/\.gallery-viewer\s*\{([^}]*)\}/s);
+    const stage = css.match(/\.gallery-viewer-stage\s*\{([^}]*)\}/s);
+    const media = css.match(
+      /\.gallery-viewer-media,\s*\.gallery-viewer-placeholder\s*\{([^}]*)\}/s,
+    );
+    expect(viewer?.[1]).toMatch(/overflow:\s*hidden\s*;/);
+    expect(stage?.[1]).toMatch(/width:\s*100%\s*;/);
+    expect(stage?.[1]).toMatch(/min-width:\s*0\s*;/);
+    expect(media?.[1]).toMatch(/min-width:\s*0\s*;/);
+    expect(media?.[1]).toMatch(/max-width:\s*100%\s*;/);
+  });
+
+  it("keeps the header and actions within the same viewport column", () => {
+    const header = css.match(/\.gallery-viewer-header\s*\{([^}]*)\}/s);
+    const origin = css.match(/\.gallery-viewer-origin\s*\{([^}]*)\}/s);
+    const details = css.match(/\.gallery-viewer-details\s*\{([^}]*)\}/s);
+    expect(header?.[1]).toMatch(/width:\s*100%\s*;/);
+    expect(header?.[1]).toMatch(/min-width:\s*0\s*;/);
+    expect(header?.[1]).toMatch(/box-sizing:\s*border-box\s*;/);
+    expect(origin?.[1]).toMatch(/flex:\s*1 1 0\s*;/);
+    expect(origin?.[1]).toMatch(/min-width:\s*0\s*;/);
+    expect(details?.[1]).toMatch(/width:\s*100%\s*;/);
+    expect(details?.[1]).toMatch(/min-width:\s*0\s*;/);
+    expect(details?.[1]).toMatch(/box-sizing:\s*border-box\s*;/);
+  });
+});
+
 describe("mobile Library organization", () => {
   it("keeps the scope row, chips, and tag targets at the 44pt floor", () => {
     for (const selector of [
@@ -488,7 +521,8 @@ describe("mobile Library organization", () => {
     const done = css.match(/\.mobile-library-sheet-done\s*\{([^}]*)\}/s);
     expect(sheet?.[1]).toMatch(/position:\s*fixed\s*;/);
     expect(sheet?.[1]).toMatch(/display:\s*none\s*;/);
-    expect(sheet?.[1]).toMatch(/inset:\s*0\s*;/);
+    expect(sheet?.[1]).toMatch(/inset:\s*0 0 auto\s*;/);
+    expect(sheet?.[1]).toMatch(/height:\s*var\(--mobile-visual-viewport-height,\s*100dvh\)\s*;/);
     expect(open?.[1]).toMatch(/display:\s*flex\s*;/);
     expect(body?.[1]).toMatch(/overflow-y:\s*auto\s*;/);
     expect(body?.[1]).toMatch(/overscroll-behavior:\s*none\s*;/);
@@ -497,6 +531,23 @@ describe("mobile Library organization", () => {
     expect(body?.[1]).toContain("env(safe-area-inset-right)");
     expect(body?.[1]).toContain("env(safe-area-inset-bottom)");
     expect(Number(done?.[1]?.match(/min-height:\s*(\d+)px/)?.[1])).toBeGreaterThanOrEqual(44);
+  });
+
+  it("keeps every keyboard-capable sheet inside the visual viewport", () => {
+    for (const className of ["mobile-advanced-sheet", "mobile-seam-sheet"]) {
+      const sheet = css.match(new RegExp(`\\.${className}\\s*\\{([^}]*)\\}`, "s"));
+      expect(sheet?.[1]).toMatch(/inset:\s*0 0 auto\s*;/);
+      expect(sheet?.[1]).toMatch(/height:\s*var\(--mobile-visual-viewport-height,\s*100dvh\)\s*;/);
+    }
+  });
+
+  it("aligns Library sheet actions with their controls instead of the labeled field margin", () => {
+    const panel = css.match(/\.mobile-library-sheet-panel\s*\{([^}]*)\}/s);
+    const field = css.match(/\.mobile-library-sheet-form \.field\s*\{([^}]*)\}/s);
+    expect(panel?.[1]).toMatch(
+      /max-height:\s*min\(86dvh,\s*var\(--mobile-visual-viewport-height,\s*100dvh\)\)\s*;/,
+    );
+    expect(field?.[1]).toMatch(/margin:\s*0\s*;/);
   });
 
   it("uses the iPhone radii scale for chips, covers, and collection cards", () => {


### PR DESCRIPTION
## Summary
- size iOS sheets from the live visual viewport so tag, collection, seam, and advanced editors stay above the keyboard
- align Library sheet text fields with their action buttons
- constrain gallery viewer headers, wide images/videos, and details to the phone viewport

## UAT
- rendered iPhone viewport against `MOLD_HOME=/Volumes/ExternalStorage/mold2`: tag sheet, collection sheet, wide video, and wide photo all stayed in bounds
- `nix develop -c bash -lc 'cd desktop && bun run test -- src/mobile'` (729 passed)\n- focused regression suite (319 passed)\n- `nix develop -c bash -lc 'cd desktop && bun run build:mobile'`\n- `nix develop -c ios-check`\n- `MOLD_HOME=/Volumes/ExternalStorage/mold2 nix develop -c ./scripts/ios.sh simulator`\n\n## Peer review\n- Claude reviewed the commit, identified the inner-panel viewport clamp, and confirmed the revised diff has no actionable findings.\n\n## Device note\n- Physical iPhone deployment was attempted but blocked by the local Apple developer login/certificate: account login rejected and no matching iOS Development private key for team `28X9H69QGE`.