### PR TITLE
fix(ci): unignore PuLID input fixture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ web/*.tsbuildinfo
 # PuLID face-extraction parity fixtures (#1222): public-domain portraits and
 # the warp goldens captured from them. Un-ignored rather than force-added,
 # because release-plz refuses to run while a tracked file is also gitignored.
+!crates/mold-inference/testdata/pulid/input_pattern.png
 !crates/mold-inference/testdata/pulid/faces/*.jpg
 !crates/mold-inference/testdata/pulid/faces/*.png
 apps/mobile/src-tauri/gen/schemas/


### PR DESCRIPTION
## Summary

- explicitly unignore the tracked PuLID preprocessing input fixture
- prevent release-plz from rejecting the checkout as dirty

## Verification

- `git ls-files -ci --exclude-standard` returns no files
- `git check-ignore crates/mold-inference/testdata/pulid/input_pattern.png` confirms the fixture is not ignored
- `git diff --check`