### PR TITLE
docs(changelog): note iOS layout fixes

### DIFF
--- a/changelog.d/fix-ios-keyboard-media-layout.md
+++ b/changelog.d/fix-ios-keyboard-media-layout.md
@@ -1,0 +1,1 @@
+- **Keep iPhone editors and wide media in view.** Tag and collection editors now stay above the keyboard with aligned actions, while wide photos and videos remain centered inside the Library viewer ([#1259](https://github.com/utensils/mold/pull/1259)).


### PR DESCRIPTION
## Summary
- add the release fragment required for the iOS keyboard, alignment, and wide-media fix merged in #1259

## Context
- #1259 was merged while its changelog policy check was still finishing
- this follow-up contains only the missing changelog fragment