### PR TITLE
fix(h3): carry request_warnings on the private-server GenerateResponse

### DIFF
--- a/crates/mold-inference/src/minimax_h3/private_server.rs
+++ b/crates/mold-inference/src/minimax_h3/private_server.rs
@@ -3855,6 +3855,7 @@ fn private_run_output(
     };
     let response = GenerateResponse {
         images: Vec::new(),
+        request_warnings: Vec::new(),
         video: Some(VideoData {
             data: output.mp4,
             format: OutputFormat::Mp4,


### PR DESCRIPTION
main's Desktop **Linux (clippy, test; main AppImage)** job has been red since 9cec0ef7 (#1251): that PR added `GenerateResponse.request_warnings` and updated every literal the default feature set compiles, but the `h3-private-uat` server's literal in `crates/mold-inference/src/minimax_h3/private_server.rs` was missed, and only the Linux H3/CUDA job compiles it. One-line fix; `cargo check -p mold-ai-inference --features h3-private-uat` and `--features h3` are clean.