### PR TITLE
fix(ui): address request advisory follow-ups

### DIFF
--- a/changelog.d/request-advisory-followups.md
+++ b/changelog.d/request-advisory-followups.md
@@ -1,0 +1,9 @@
+- **Browser surfaces show accepted-request advisories.** Web and desktop now
+  raise warning notifications for `x-mold-request-warning`, while iPhone keeps
+  each advisory in a dismissible inline banner; advisory prose containing
+  semicolons stays intact.
+- **Literal hash-prefixed tags stay editable.** Library tag normalization now
+  matches the server, so `#blue` remains distinct from `blue` when displayed,
+  filtered, added, or removed.
+- **TUI size guidance uses warning styling.** Accepted off-recipe custom sizes
+  now render in the amber warning slot instead of the red error slot.

--- a/crates/mold-tui/src/app.rs
+++ b/crates/mold-tui/src/app.rs
@@ -3715,7 +3715,8 @@ impl App {
                                 .and_then(|recipe| mold_core::resolution_advisory(&recipe, w, h));
                             self.generate.params.width = w;
                             self.generate.params.height = h;
-                            self.generate.error_message = advisory;
+                            self.generate.error_message = None;
+                            self.generate.warning_message = advisory;
                         }
                     }
                     KeyCode::Char(c)
@@ -14360,6 +14361,7 @@ mod tests {
             .position(|r| *r == CreateRow::Field(ParamField::Size))
             .unwrap();
         app.generate.param_index = size_idx;
+        app.generate.error_message = Some("a stale size error".to_string());
         app.dispatch_action(Action::Confirm);
         assert!(matches!(app.popup, Some(Popup::SizeInput { .. })));
         // Clear the prefilled WxH and type a new one.
@@ -14381,6 +14383,7 @@ mod tests {
         )));
         assert_eq!(app.generate.params.width, 1152);
         assert_eq!(app.generate.params.height, 832);
+        assert_eq!(app.generate.error_message, None);
     }
 
     #[tokio::test]
@@ -14400,6 +14403,7 @@ mod tests {
             .position(|r| *r == CreateRow::Field(ParamField::Size))
             .unwrap();
         app.generate.param_index = size_idx;
+        app.generate.error_message = Some("a stale size error".to_string());
         app.dispatch_action(Action::Confirm);
         assert!(matches!(app.popup, Some(Popup::SizeInput { .. })));
         for _ in 0..12 {
@@ -14423,8 +14427,9 @@ mod tests {
         )));
         assert_eq!(app.generate.params.width, 1001);
         assert_eq!(app.generate.params.height, 601);
+        assert_eq!(app.generate.error_message, None);
         if app.active_generation_recipe().is_some() {
-            let advisory = app.generate.error_message.as_deref().unwrap_or_default();
+            let advisory = app.generate.warning_message.as_deref().unwrap_or_default();
             assert!(advisory.contains("server may reject"), "got: {advisory}");
         }
     }

--- a/desktop/src/components/library/TagEditor.test.ts
+++ b/desktop/src/components/library/TagEditor.test.ts
@@ -43,9 +43,9 @@ describe("TagEditor", () => {
     const wrapper = mountEditor(["blue"]);
     await input(wrapper).setValue("  #Portrait ");
     await key(wrapper, "Enter");
-    // Canonical casing from the suggestion list wins over what was typed.
-    expect(wrapper.emitted("update:modelValue")).toEqual([[["blue", "portrait"]]]);
-    expect(wrapper.emitted("add")).toEqual([["portrait"]]);
+    // A literal leading hash addresses a distinct tag, matching the server.
+    expect(wrapper.emitted("update:modelValue")).toEqual([[["blue", "#Portrait"]]]);
+    expect(wrapper.emitted("add")).toEqual([["#Portrait"]]);
     expect(input(wrapper).element.value).toBe("");
     wrapper.unmount();
   });

--- a/desktop/src/lib/api/sse.test.ts
+++ b/desktop/src/lib/api/sse.test.ts
@@ -53,6 +53,7 @@ describe("sseStream", () => {
     });
 
     expect(onOpen).toHaveBeenCalledTimes(2);
+    expect(onOpen).toHaveBeenLastCalledWith(expect.any(Response));
   });
 
   for (const status of [401, 403, 404]) {

--- a/desktop/src/lib/api/sse.ts
+++ b/desktop/src/lib/api/sse.ts
@@ -11,7 +11,7 @@ export interface StreamOptions {
   signal: AbortSignal;
   onEvent: (event: string, data: string) => void;
   /** Called whenever the server accepts the SSE response, including reconnects. */
-  onOpen?: () => void;
+  onOpen?: (response: Response) => void;
   /** Called when the initial connection cannot be established. */
   onOpenError?: (error: Error) => void;
   /** Called when the stream ends or errors after retries. */
@@ -78,7 +78,7 @@ export async function sseStream(path: string, options: StreamOptions): Promise<v
           throw error;
         }
         opened = true;
-        options.onOpen?.();
+        options.onOpen?.(response);
         return Promise.resolve();
       },
       onmessage(msg) {

--- a/desktop/src/lib/generationJob.ts
+++ b/desktop/src/lib/generationJob.ts
@@ -44,6 +44,8 @@ export interface Job {
   /** Total clips reported by the chain stream. */
   chainStageCount: number | null;
   error: string | null;
+  /** Advisories from an accepted request; each header value stays whole. */
+  requestWarnings: string[];
   /** Structured transport-close marker used by resume reconciliation. */
   interrupted: boolean;
   /** The host ended this job's stream while KEEPING the job: it journalled the
@@ -116,6 +118,7 @@ export function newJob(req: GenerateRequest): Job {
     chainStageIndex: null,
     chainStageCount: null,
     error: null,
+    requestWarnings: [],
     interrupted: false,
     retainedByHost: false,
     submittedAtUnixMs: Date.now(),

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -313,9 +313,17 @@ beforeEach(() => {
       return Promise.resolve({ instance_id: "mobile-host", observed_at_unix_ms: 1, items: [] });
     return Promise.reject(new Error(`Unexpected API path: ${path}`));
   });
-  apiFetchTo.mockReset().mockResolvedValue({
-    blob: () => Promise.resolve(new Blob(["thumbnail"])),
-  } as Response);
+  apiFetchTo
+    .mockReset()
+    .mockImplementation(async (requestTarget: unknown, path: string, init?: RequestInit) => {
+      if (path === "/api/chain-jobs" && init?.method === "POST") {
+        const body = await apiJsonTo(requestTarget, path, init);
+        return new Response(JSON.stringify(body));
+      }
+      return {
+        blob: () => Promise.resolve(new Blob(["thumbnail"])),
+      } as Response;
+    });
   openStreams.length = 0;
   sseStream.mockReset().mockImplementation(
     (
@@ -882,6 +890,20 @@ describe("MobileApp sequence generation", () => {
       }
       return Promise.reject(new Error(`Unexpected API path: ${path}`));
     });
+    apiFetchTo.mockImplementation(
+      async (requestTarget: unknown, path: string, init?: RequestInit) => {
+        if (path === "/api/chain-jobs" && init?.method === "POST") {
+          const body = await apiJsonTo(requestTarget, path, init);
+          return new Response(JSON.stringify(body), {
+            headers: {
+              "x-mold-request-warning":
+                "Reference timing was adjusted; the sequence still rendered.",
+            },
+          });
+        }
+        return { blob: () => Promise.resolve(new Blob(["thumbnail"])) } as Response;
+      },
+    );
 
     let finishPreview!: (value: Awaited<ReturnType<typeof previewChainPlacement>>) => void;
     previewChainPlacement.mockReturnValueOnce(
@@ -939,6 +961,12 @@ describe("MobileApp sequence generation", () => {
     });
     expect(recovery).not.toContain(target.apiKey);
     expect(wrapper.get("[data-test='mobile-sequence-job']").text()).toContain("queued");
+    const advisory = wrapper.get("[data-test='mobile-request-advisories']");
+    expect(advisory.text()).toContain(
+      "Reference timing was adjusted; the sequence still rendered.",
+    );
+    await advisory.get("[data-test='mobile-request-advisories-dismiss']").trigger("click");
+    expect(wrapper.find("[data-test='mobile-request-advisories']").exists()).toBe(false);
   });
 
   it("parks a retained opening image when the checkpoint reads no source image", async () => {

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -264,6 +264,7 @@ import type { HostRoute } from "../stores/hosts";
 import { domCanvasOps } from "../lib/sourceFitCanvas";
 import { applyH3BoundaryFit, applySourceFitPreprocess } from "../lib/sourceFitPreprocess";
 import { coerceSourceFitForMaskless, parseSourceFitPolicy } from "@studio/lib/sourceFit";
+import { requestWarningsFromHeaders } from "@studio/lib/requestWarnings";
 import {
   persistGenerationSourceMedia,
   restoreGenerationSourceMedia,
@@ -817,6 +818,8 @@ const libraryHostCounts = ref<Record<string, number>>({});
 const libraryPrintCount = ref(0);
 /** Inline (never a toast) organization failure banner. */
 const organizationError = ref("");
+/** Accepted-request advisories stay visible until dismissed or superseded. */
+const requestAdvisories = ref<string[]>([]);
 const organizationBusy = ref(false);
 /** Trash listing, fetched lazily the first time the Trash scope opens. */
 let trashCopies: PendingGalleryPrint[] = [];
@@ -3359,7 +3362,8 @@ async function submitMobileSequence(): Promise<void> {
         `/api/chain-jobs/${encodeURIComponent(operationId)}/operations/${encodeURIComponent(operationId)}/cancel`,
         { method: "POST", keepalive: true },
       );
-    const response = await apiJsonTo<CreateChainJobResponse>(target, "/api/chain-jobs", {
+    requestAdvisories.value = [];
+    const chainResponse = await apiFetchTo(target, "/api/chain-jobs", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -3367,6 +3371,8 @@ async function submitMobileSequence(): Promise<void> {
       },
       body: JSON.stringify(request),
     });
+    requestAdvisories.value = requestWarningsFromHeaders(chainResponse.headers);
+    const response = (await chainResponse.json()) as CreateChainJobResponse;
     if (!isCurrent()) {
       await apiFetchTo(target, `/api/chain-jobs/${encodeURIComponent(response.job_id)}/cancel`, {
         method: "POST",
@@ -5173,6 +5179,7 @@ async function generate(): Promise<void> {
   // prepared/quick submission's frozen route, or the pinned machine. Every
   // Batch sibling spreads this one request, so they share the outcome.
   request = fileUnderForFrozenRoute(request, route);
+  requestAdvisories.value = [];
   const { settled } = generation.submitBatch(
     request,
     batchSize,
@@ -5227,6 +5234,7 @@ async function generate(): Promise<void> {
       isActive: () => !unmounted,
     });
     if (unmounted) return;
+    requestAdvisories.value = [...new Set(jobs.flatMap((candidate) => candidate.requestWarnings))];
     for (const candidate of jobs) handledGenerationClientIds.add(candidate.clientId);
     const completed = jobs.filter(
       (candidate) => candidate.status === "complete" && candidate.result,
@@ -8260,6 +8268,21 @@ onBeforeUnmount(() => {
               type="button"
               data-test="mobile-file-under-dropped-dismiss"
               @click="fileUnderDropNotice = ''"
+            >
+              Dismiss
+            </button>
+          </div>
+          <div
+            v-if="requestAdvisories.length > 0"
+            class="mobile-file-under-dropped"
+            role="status"
+            data-test="mobile-request-advisories"
+          >
+            <p v-for="warning in requestAdvisories" :key="warning">{{ warning }}</p>
+            <button
+              type="button"
+              data-test="mobile-request-advisories-dismiss"
+              @click="requestAdvisories = []"
             >
               Dismiss
             </button>

--- a/desktop/src/mobile/MobileGalleryViewer.test.ts
+++ b/desktop/src/mobile/MobileGalleryViewer.test.ts
@@ -955,7 +955,7 @@ describe("MobileGalleryViewer info sheet", () => {
     const input = view.get("[data-test='gallery-viewer-tag-input']");
     await input.setValue("  #Grain ");
     await view.get("[data-test='gallery-viewer-tag-add']").trigger("submit");
-    expect(view.emitted("tags")?.at(-1)).toEqual([{ add: ["Grain"] }]);
+    expect(view.emitted("tags")?.at(-1)).toEqual([{ add: ["#Grain"] }]);
   });
 
   it("suggests merged tags the print does not already carry", async () => {

--- a/desktop/src/mobile/sequenceWatch.test.ts
+++ b/desktop/src/mobile/sequenceWatch.test.ts
@@ -26,7 +26,7 @@ interface StreamCall {
   path: string;
   target: unknown;
   onEvent: (event: string, data: string) => void;
-  onOpen?: (() => void) | undefined;
+  onOpen?: ((response: Response) => void) | undefined;
   onClose?: ((error: Error | null) => void) | undefined;
   signal: AbortSignal;
 }
@@ -39,7 +39,7 @@ function harness() {
       options: {
         target?: unknown;
         onEvent: (event: string, data: string) => void;
-        onOpen?: () => void;
+        onOpen?: (response: Response) => void;
         onClose?: (error: Error | null) => void;
         signal: AbortSignal;
       },
@@ -149,7 +149,7 @@ describe("watchChainJob", () => {
       expect(h.streams).toHaveLength(2);
 
       // A later stream attempt that opens cleanly retires the poll.
-      h.streams.at(-1)?.onOpen?.();
+      h.streams.at(-1)?.onOpen?.(new Response());
       expect(handle.polling).toBe(false);
       await vi.advanceTimersByTimeAsync(5_000);
       expect(h.fetchDetail.mock.calls.length).toBe(initialFetches + 2);

--- a/desktop/src/stores/chainJobs.test.ts
+++ b/desktop/src/stores/chainJobs.test.ts
@@ -62,7 +62,13 @@ beforeEach(() => {
         : { jobs: [] },
     ),
   );
-  apiFetchTo.mockResolvedValue({});
+  apiFetchTo.mockImplementation((_target: ApiTarget, path: string, init?: RequestInit) =>
+    Promise.resolve(
+      path === "/api/chain-jobs" && init?.method === "POST"
+        ? new Response(JSON.stringify({ job_id: "remote-chain-1" }))
+        : {},
+    ),
+  );
   readyHosts();
 });
 
@@ -125,7 +131,7 @@ describe("create", () => {
     const store = useChainJobsStore();
     const jobId = await store.create(REMOTE_ID, request);
     expect(jobId).toBe("remote-chain-1");
-    expect(apiJsonTo).toHaveBeenCalledWith(
+    expect(apiFetchTo).toHaveBeenCalledWith(
       REMOTE_TARGET,
       "/api/chain-jobs",
       expect.objectContaining({ method: "POST" }),

--- a/desktop/src/stores/chainJobs.ts
+++ b/desktop/src/stores/chainJobs.ts
@@ -20,6 +20,7 @@ import { notifyChainFinished } from "../lib/notify";
 import type { ChainCreateRequest, GcOutcome, RetakeRequest } from "../lib/api/types";
 import { useHostsStore } from "./hosts";
 import { useToastStore } from "./toasts";
+import { requestWarningsFromHeaders } from "@studio/lib/requestWarnings";
 
 /** One host's durable chain-job listing. */
 export interface HostChainJobs {
@@ -124,11 +125,11 @@ export const useChainJobsStore = defineStore("chainJobs", {
       operationId?: string,
     ): Promise<string> {
       const target = frozenTarget ?? this.targetFor(hostId);
-      const res = await apiJsonTo<CreateChainJobResponse>(
-        target,
-        "/api/chain-jobs",
-        jsonInit(req, operationId),
-      );
+      const response = await apiFetchTo(target, "/api/chain-jobs", jsonInit(req, operationId));
+      for (const warning of requestWarningsFromHeaders(response.headers)) {
+        useToastStore().push(warning, "warning");
+      }
+      const res = (await response.json()) as CreateChainJobResponse;
       await this.fetchHost(hostId);
       this.watch(hostId, res.job_id);
       return res.job_id;

--- a/desktop/src/stores/events.test.ts
+++ b/desktop/src/stores/events.test.ts
@@ -86,7 +86,7 @@ describe("events subscription", () => {
 
     await events.subscribe();
     const options = vi.mocked(sseStream).mock.calls[0]![1]!;
-    options.onOpen?.();
+    options.onOpen?.(new Response());
     options.onEvent?.(
       "message",
       JSON.stringify({

--- a/desktop/src/stores/gallery.test.ts
+++ b/desktop/src/stores/gallery.test.ts
@@ -1459,16 +1459,17 @@ describe("organization fan-out", () => {
     await gallery.addTags(print, ["#Blue", " portrait "]);
     expect(organization.organizeGallery).toHaveBeenCalledWith(HAL_TARGET, {
       filenames: ["shared.png"],
-      add_tags: ["Blue", "portrait"],
+      add_tags: ["#Blue", "portrait"],
     });
-    // local already had "blue": only portrait is new there.
-    expect(gallery.buckets["local"]!.items[0]!.tags).toEqual(["blue", "portrait"]);
+    // A leading hash is literal, so #Blue is distinct from the existing blue.
+    expect(gallery.buckets["local"]!.items[0]!.tags).toEqual(["blue", "#Blue", "portrait"]);
     expect(gallery.tagsByHost["local"]!.items).toEqual([
       { name: "blue", count: 1 },
+      { name: "#Blue", count: 1 },
       { name: "portrait", count: 1 },
     ]);
     expect(gallery.tagsByHost["hal9000-7680"]!.items).toEqual([
-      { name: "Blue", count: 1 },
+      { name: "#Blue", count: 1 },
       { name: "portrait", count: 1 },
     ]);
 
@@ -1477,9 +1478,12 @@ describe("organization fan-out", () => {
       filenames: ["shared.png"],
       remove_tags: ["BLUE"],
     });
-    expect(gallery.buckets["local"]!.items[0]!.tags).toEqual(["portrait"]);
-    expect(gallery.tagsByHost["local"]!.items).toEqual([{ name: "portrait", count: 1 }]);
-    expect(gallery.organizationOf(print).tags).toEqual(["portrait"]);
+    expect(gallery.buckets["local"]!.items[0]!.tags).toEqual(["#Blue", "portrait"]);
+    expect(gallery.tagsByHost["local"]!.items).toEqual([
+      { name: "#Blue", count: 1 },
+      { name: "portrait", count: 1 },
+    ]);
+    expect(gallery.organizationOf(print).tags).toEqual(["#Blue", "portrait"]);
   });
 
   it("addToCollection creates the collection by name on hosts lacking the slug first", async () => {

--- a/desktop/src/stores/generateForm.test.ts
+++ b/desktop/src/stores/generateForm.test.ts
@@ -78,6 +78,8 @@ describe("generateForm store", () => {
     const captured = store.form;
     store.form.prompt = "a cat";
     store.form.model = "flux-dev:q8";
+    store.form.title = "Smurf village";
+    store.form.fileUnder.manualTags = ["blue"];
 
     store.resetAll();
 
@@ -85,6 +87,8 @@ describe("generateForm store", () => {
     expect(store.form).toBe(captured);
     expect(captured.prompt).toBe("");
     expect(captured.model).toBe("");
+    expect(captured.title).toBe("Smurf village");
+    expect(captured.fileUnder.manualTags).toEqual(["blue"]);
   });
 });
 

--- a/desktop/src/stores/generateForm.ts
+++ b/desktop/src/stores/generateForm.ts
@@ -1,6 +1,6 @@
 import { defineStore } from "pinia";
 import { emptyFileUnderState } from "@studio/lib/fileUnder";
-import { applyModelDefaults, newGenerateForm } from "../lib/generateForm";
+import { applyModelDefaults, keepingPrintIdentity, newGenerateForm } from "../lib/generateForm";
 import type { ModelEntry } from "../lib/api/types";
 
 /**
@@ -44,7 +44,7 @@ export const useGenerateFormStore = defineStore("generateForm", {
      * object identity — the view and child panels hold references to it.
      */
     resetAll() {
-      Object.assign(this.form, newGenerateForm());
+      keepingPrintIdentity(this.form, () => Object.assign(this.form, newGenerateForm()));
     },
   },
 });

--- a/desktop/src/stores/generation.ts
+++ b/desktop/src/stores/generation.ts
@@ -43,6 +43,7 @@ import {
   type ReferenceUploadCapabilities,
   type ReferenceUploadLease,
 } from "@studio/api/referenceUploads";
+import { requestWarningsFromHeaders } from "@studio/lib/requestWarnings";
 
 export {
   applyChainProgress,
@@ -875,6 +876,9 @@ export const useGenerationStore = defineStore("generation", {
           ? { headers: { "X-Mold-SSE-Payload": "metadata-only" } }
           : {}),
         ...(streamTarget ? { target: streamTarget } : {}),
+        onOpen: (response) => {
+          job.requestWarnings = requestWarningsFromHeaders(response.headers);
+        },
         onEvent: (event, data) => {
           const current = job;
           // Abort/reset/cancel and terminal frames are final. Some SSE

--- a/desktop/src/stores/pullResume.test.ts
+++ b/desktop/src/stores/pullResume.test.ts
@@ -65,9 +65,7 @@ describe("pullResume store", () => {
         {
           status: "complete",
           error: null,
-          requestWarnings: [
-            "Reference timing was used; the requested frame count was adjusted",
-          ],
+          requestWarnings: ["Reference timing was used; the requested frame count was adjusted"],
         },
       ]),
     } as never);

--- a/desktop/src/stores/pullResume.test.ts
+++ b/desktop/src/stores/pullResume.test.ts
@@ -57,6 +57,35 @@ describe("pullResume store", () => {
     expect(store.pending).toBeNull();
   });
 
+  it("surfaces request advisories from the resumed generation", async () => {
+    const store = armOnPrimary();
+    vi.spyOn(useGenerationStore(), "submitBatch").mockReturnValue({
+      jobs: [],
+      settled: Promise.resolve([
+        {
+          status: "complete",
+          error: null,
+          requestWarnings: [
+            "Reference timing was used; the requested frame count was adjusted",
+          ],
+        },
+      ]),
+    } as never);
+
+    useDownloadsStore().history = [job("d1", "jibmix-flux:fp8", "completed")];
+    store.check();
+    await Promise.resolve();
+
+    expect(useToastStore().items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "warning",
+          message: "Reference timing was used; the requested frame count was adjusted",
+        }),
+      ]),
+    );
+  });
+
   it("ignores terminal jobs that predate the arm (a stale history entry must not resume)", () => {
     const downloads = useDownloadsStore();
     downloads.history = [job("old", "jibmix-flux:fp8", "completed")];

--- a/desktop/src/stores/pullResume.ts
+++ b/desktop/src/stores/pullResume.ts
@@ -103,6 +103,9 @@ export const usePullResumeStore = defineStore("pullResume", {
               pending.chainRouting ?? null,
             );
         void submission.settled.then((jobs) => {
+          for (const warning of new Set(jobs.flatMap((job) => job.requestWarnings))) {
+            useToastStore().push(warning, "warning");
+          }
           const failed = jobs.find((job) => job.status === "error");
           if (failed?.error && failed.error !== "Cancelled") {
             useToastStore().push(

--- a/desktop/src/views/GenerateView.vue
+++ b/desktop/src/views/GenerateView.vue
@@ -3469,6 +3469,9 @@ async function generate() {
     );
     void settled.then((done) => {
       void loadPromptHistory();
+      for (const warning of new Set(done.flatMap((job) => job.requestWarnings))) {
+        toasts.push(warning, "warning");
+      }
       const ok = done.filter((s) => s.status === "complete").length;
       const failedCount = done.filter((s) => s.status === "error").length;
       const failed = done.find((s) => s.status === "error");

--- a/studio/lib/fileUnder.ts
+++ b/studio/lib/fileUnder.ts
@@ -23,12 +23,9 @@
  * `mold_core` by its own parity fixtures. Rust remains the authority for
  * every limit and rule mirrored below.
  *
- * Tag normalization is the one deliberate exception. The Library's
- * `normalizeTagName` also strips a leading `#` — a display affordance the V3
- * tag editors chose — but `mold_core::organization::normalize_tag_name` does
- * NOT: `#blue` is the literal tag `#blue` there. A request tag is storage,
- * not display, so `normalizeRequestTag` below mirrors Rust exactly and the
- * `#` affordance is offered separately as `stripTagHash`, for a surface to
+ * Tag normalization mirrors the Library and Rust: `#blue` is the literal tag
+ * `#blue`. The Create form still offers `#` as a typed-input affordance through
+ * `stripTagHash`, for a surface to
  * apply to TYPED input before calling `addTag` (never to a suggestion the
  * host reported, or picking `#blue` would file a different tag called
  * `blue`). Searching is the exception `suggestTags` owns: it strips the

--- a/studio/lib/libraryOrganization.test.ts
+++ b/studio/lib/libraryOrganization.test.ts
@@ -92,10 +92,10 @@ describe("collectionSlug", () => {
 });
 
 describe("normalizeTagName / tagKey", () => {
-  it("trims, collapses whitespace, and drops a leading hash", () => {
-    expect(normalizeTagName("  #Portrait   Study  ")).toBe("Portrait Study");
-    expect(normalizeTagName("\t#\n")).toBe("");
-    expect(normalizeTagName("#")).toBe("");
+  it("trims and collapses whitespace while keeping a leading hash literal", () => {
+    expect(normalizeTagName("  #Portrait   Study  ")).toBe("#Portrait Study");
+    expect(normalizeTagName("\t#\n")).toBe("#");
+    expect(normalizeTagName("#")).toBe("#");
     expect(normalizeTagName("plain")).toBe("plain");
   });
 
@@ -105,7 +105,8 @@ describe("normalizeTagName / tagKey", () => {
 
   it("tagKey is the case-insensitive merge key", () => {
     expect(tagKey("Portrait")).toBe("portrait");
-    expect(tagKey("  #PORTRAIT ")).toBe("portrait");
+    expect(tagKey("  #PORTRAIT ")).toBe("#portrait");
+    expect(tagKey("#blue")).not.toBe(tagKey("blue"));
   });
 });
 

--- a/studio/lib/libraryOrganization.ts
+++ b/studio/lib/libraryOrganization.ts
@@ -64,16 +64,11 @@ export function collectionSlug(name: string): string {
 const CONTROL_CHARS = /[\u0000-\u001f\u007f]/;
 const CONTROL_CHARS_ALL = /[\u0000-\u001f\u007f]/g;
 
-/** Display form of a tag as typed: trimmed, inner whitespace collapsed, a
- * leading `#` dropped, control characters removed. Case is preserved —
+/** Display and wire form of a tag: trimmed, inner whitespace collapsed, and
+ * control characters removed. A leading `#` is literal. Case is preserved —
  * the server stores tags `COLLATE NOCASE`, so compare with `tagKey`. */
 export function normalizeTagName(raw: string): string {
-  return raw
-    .replace(CONTROL_CHARS_ALL, "")
-    .replace(/\s+/g, " ")
-    .trim()
-    .replace(/^#+\s*/, "")
-    .trim();
+  return raw.replace(CONTROL_CHARS_ALL, "").replace(/\s+/g, " ").trim();
 }
 
 /** Case-insensitive merge key for a tag (tags merge across hosts by it). */

--- a/studio/lib/requestWarnings.test.ts
+++ b/studio/lib/requestWarnings.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { requestWarningsFromHeaders } from "./requestWarnings";
+
+describe("requestWarningsFromHeaders", () => {
+  it("keeps a semicolon inside one advisory", () => {
+    const headers = new Headers({
+      "x-mold-request-warning":
+        "Tags were ignored; the gallery database is disabled.",
+    });
+    expect(requestWarningsFromHeaders(headers)).toEqual([
+      "Tags were ignored; the gallery database is disabled.",
+    ]);
+  });
+
+  it("preserves separate values when the runtime exposes getAll", () => {
+    expect(
+      requestWarningsFromHeaders({
+        get: () => "combined fallback",
+        getAll: () => ["first advisory", "second advisory"],
+      }),
+    ).toEqual(["first advisory", "second advisory"]);
+  });
+
+  it("falls back when a browser-compatible getAll rejects ordinary headers", () => {
+    expect(
+      requestWarningsFromHeaders({
+        get: () => "one combined advisory",
+        getAll: () => {
+          throw new TypeError('Only "set-cookie" is supported.');
+        },
+      }),
+    ).toEqual(["one combined advisory"]);
+  });
+});

--- a/studio/lib/requestWarnings.ts
+++ b/studio/lib/requestWarnings.ts
@@ -1,0 +1,27 @@
+/**
+ * Read advisories attached to an accepted browser request.
+ *
+ * Each header value is one opaque advisory. In particular, never split on
+ * `; `: advisory prose may contain semicolons. The optional `getAll` branch
+ * preserves one-header-per-advisory responses in runtimes that expose it.
+ * Standard browser `Headers` irreversibly combines repeated response fields,
+ * so the server must keep emitting one joined field until the wire gains a
+ * structured encoding; browsers deliberately surface that combined value as
+ * one advisory rather than guessing at prose delimiters.
+ */
+export function requestWarningsFromHeaders(
+  headers: Pick<Headers, "get"> & { getAll?: (name: string) => string[] },
+): string[] {
+  let all: string[] = [];
+  try {
+    all = headers.getAll?.("x-mold-request-warning") ?? [];
+  } catch {
+    // Bun and some browser-compatible runtimes expose getAll only for
+    // Set-Cookie. Their ordinary response fields still remain available via get().
+  }
+  const values = all.length > 0 ? all : [headers.get("x-mold-request-warning")];
+  return values.flatMap((value) => {
+    const warning = value?.trim();
+    return warning ? [warning] : [];
+  });
+}

--- a/web/src/api.test.ts
+++ b/web/src/api.test.ts
@@ -55,6 +55,8 @@ function singleHandlers() {
     onProgress: vi.fn<GenerateStreamHandlers["onProgress"]>(),
     onComplete: vi.fn<GenerateStreamHandlers["onComplete"]>(),
     onError: vi.fn<GenerateStreamHandlers["onError"]>(),
+    onRequestWarnings:
+      vi.fn<NonNullable<GenerateStreamHandlers["onRequestWarnings"]>>(),
   };
 }
 
@@ -63,6 +65,8 @@ function chainHandlers() {
     onProgress: vi.fn<ChainStreamHandlers["onProgress"]>(),
     onComplete: vi.fn<ChainStreamHandlers["onComplete"]>(),
     onError: vi.fn<ChainStreamHandlers["onError"]>(),
+    onRequestWarnings:
+      vi.fn<NonNullable<ChainStreamHandlers["onRequestWarnings"]>>(),
   };
 }
 
@@ -287,6 +291,29 @@ describe("chain validation api", () => {
 });
 
 describe("generateStream", () => {
+  it("surfaces an accepted request warning without splitting semicolons", async () => {
+    vi.mocked(streamSse).mockImplementationOnce(async (opts) => {
+      opts.onOpen?.(
+        new Response("", {
+          headers: {
+            "x-mold-request-warning": "retimed clip; output still rendered",
+          },
+        }),
+      );
+      opts.onEvent({
+        event: "complete",
+        data: JSON.stringify({ image: "AAAA" }),
+      });
+      return new Response("");
+    });
+    const h = singleHandlers();
+
+    await generateStream(singleRequest(), h);
+
+    expect(h.onRequestWarnings).toHaveBeenCalledWith([
+      "retimed clip; output still rendered",
+    ]);
+  });
   it("flips a job to network error when the stream resolves without complete/error", async () => {
     // Server-side scenario: the worker crashed mid-job, or a proxy /
     // network blip closed the SSE pipe after a few progress events.
@@ -543,6 +570,24 @@ describe("chain job api helpers", () => {
       },
       body: JSON.stringify(chainRequest()),
     });
+
+    const onRequestWarnings = vi.fn();
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ job_id: "job/2" }), {
+        headers: {
+          "x-mold-request-warning": "retimed clip; output was still created",
+        },
+      }),
+    );
+    await createChainJob(
+      chainRequest(),
+      undefined,
+      undefined,
+      onRequestWarnings,
+    );
+    expect(onRequestWarnings).toHaveBeenCalledWith([
+      "retimed clip; output was still created",
+    ]);
 
     fetchMock.mockResolvedValueOnce(
       new Response(JSON.stringify({ jobs: [summary] })),

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -30,6 +30,7 @@ import type {
   AmendResponse as AmendResponseWire,
   ChainValidationResponse,
 } from "@studio/lib/api/chainTypes";
+import { requestWarningsFromHeaders } from "@studio/lib/requestWarnings";
 export type {
   ChainValidationResponse,
   ChainValidationStage,
@@ -265,6 +266,7 @@ export interface GenerateStreamHandlers {
   onProgress: (evt: SseProgressEvent) => void;
   onComplete: (evt: SseCompleteEvent) => void;
   onError: (err: StreamError) => void;
+  onRequestWarnings?: (warnings: string[]) => void;
 }
 
 /**
@@ -382,6 +384,7 @@ export interface ChainStreamHandlers {
   onProgress: (evt: ChainProgressEvent) => void;
   onComplete: (evt: SseChainCompleteEvent) => void;
   onError: (err: StreamError) => void;
+  onRequestWarnings?: (warnings: string[]) => void;
 }
 
 /** POST /api/generate/chain/stream — SSE stream for chained video
@@ -456,12 +459,23 @@ export async function createChainJob(
   req: ChainRequestWire,
   target?: StreamTarget,
   operationId?: string,
+  onRequestWarnings?: (warnings: string[]) => void,
 ): Promise<CreateChainJobResponse> {
-  return chainJobJson("", target, {
+  const path = "/api/chain-jobs";
+  const res = await fetch(`${targetBase(target)}${path}`, {
     method: "POST",
-    body: req,
-    operationId,
+    headers: {
+      "content-type": "application/json",
+      ...(operationId ? { "x-mold-operation-id": operationId } : {}),
+      ...targetHeaders(target),
+    },
+    body: JSON.stringify(req),
   });
+  if (res.ok) {
+    const warnings = requestWarningsFromHeaders(res.headers);
+    if (warnings.length > 0) onRequestWarnings?.(warnings);
+  }
+  return requireJson<CreateChainJobResponse>(res, "POST /api/chain-jobs");
 }
 
 export async function listChainJobs(

--- a/web/src/components/gallery/Lightbox.test.ts
+++ b/web/src/components/gallery/Lightbox.test.ts
@@ -280,7 +280,7 @@ describe("Lightbox organization (title · ♥ · tags · collections · trash)",
     ).toEqual(["outdoor3"]);
     await tagInput.setValue("#Keep");
     await tagInput.trigger("keydown", { key: "Enter" });
-    expect(wrapper.emitted("add-tag")?.[0]).toEqual([tagged, "Keep"]);
+    expect(wrapper.emitted("add-tag")?.[0]).toEqual([tagged, "#Keep"]);
     await wrapper.get("[data-test='tag-remove']").trigger("click");
     expect(wrapper.emitted("remove-tag")?.[0]).toEqual([tagged, "blue"]);
 

--- a/web/src/composables/useChainJobs.ts
+++ b/web/src/composables/useChainJobs.ts
@@ -42,6 +42,7 @@ import type {
   ChainRequestWire,
 } from "@studio/lib/api/chainTypes";
 import type { RetakeRequest } from "../types";
+import { toast } from "../lib/toasts";
 
 export interface ChainJobsHostState {
   jobs: ChainJobSummary[];
@@ -299,7 +300,14 @@ async function create(
   ensureLoaded();
   const target = frozenTarget ?? targetFor(hostId);
   if (!target) throw new Error("That machine is no longer connected.");
-  const { job_id } = await createChainJob(req, target, operationId);
+  const { job_id } = await createChainJob(
+    req,
+    target,
+    operationId,
+    (warnings) => {
+      for (const warning of warnings) toast("warning", warning);
+    },
+  );
   track(hostId, job_id);
   void fetchHost(hostId);
   watch(hostId, job_id);

--- a/web/src/composables/useGenerateStream.ts
+++ b/web/src/composables/useGenerateStream.ts
@@ -25,6 +25,11 @@ import {
 } from "@studio/api/referenceUploads";
 import { redactGenerationReference } from "@studio/lib/generationReferences";
 import { getHost, ORIGIN_HOST_ID } from "../lib/hostRegistry";
+import { toast } from "../lib/toasts";
+
+function surfaceRequestWarnings(warnings: string[]): void {
+  for (const warning of warnings) toast("warning", warning);
+}
 
 export interface JobProgress {
   stage: string;
@@ -1071,6 +1076,7 @@ function submitJob(
             scheduleAutoRemoveOnDone(id);
           },
           onError: onErrorCommon,
+          onRequestWarnings: surfaceRequestWarnings,
         },
         controller.signal,
         route?.target,
@@ -1128,6 +1134,7 @@ function submitJob(
               scheduleAutoRemoveOnDone(id);
             },
             onError: onErrorCommon,
+            onRequestWarnings: surfaceRequestWarnings,
           },
           controller.signal,
           route?.target,

--- a/web/src/lib/apiStream.ts
+++ b/web/src/lib/apiStream.ts
@@ -1,4 +1,5 @@
 import { streamSse } from "./sse";
+import { requestWarningsFromHeaders } from "@studio/lib/requestWarnings";
 
 export type StreamError =
   | { kind: "http"; status: number; retryAfter?: number; body: string }
@@ -8,6 +9,7 @@ export interface PostSseJsonHandlers<TProgress, TComplete> {
   onProgress: (evt: TProgress) => void;
   onComplete: (evt: TComplete) => void;
   onError: (err: StreamError) => void;
+  onRequestWarnings?: (warnings: string[]) => void;
 }
 
 export interface PostSseJsonOptions<TBody, TProgress, TComplete> {
@@ -37,6 +39,11 @@ export async function postSseJsonStream<TBody, TProgress, TComplete>(
       body: opts.body,
       signal: opts.signal,
       headers: opts.headers,
+      onOpen: (res) => {
+        if (!opts.handlers.onRequestWarnings) return;
+        const warnings = requestWarningsFromHeaders(res.headers);
+        if (warnings.length > 0) opts.handlers.onRequestWarnings(warnings);
+      },
       onEvent: (evt) => {
         if (!evt.data) return;
         let parsed: unknown;

--- a/web/src/lib/sse.test.ts
+++ b/web/src/lib/sse.test.ts
@@ -49,6 +49,25 @@ describe("streamSse", () => {
     ]);
   });
 
+  it("exposes accepted response headers before reading the stream", async () => {
+    globalThis.fetch = vi.fn(
+      async () =>
+        new Response("event: complete\ndata: {}\n\n", {
+          headers: {
+            "x-mold-request-warning": "kept whole; still one advisory",
+          },
+        }),
+    ) as typeof fetch;
+    const onOpen = vi.fn();
+
+    await streamSse({ url: "/x", body: {}, onEvent: vi.fn(), onOpen });
+
+    expect(onOpen).toHaveBeenCalledOnce();
+    expect(
+      onOpen.mock.calls[0]?.[0].headers.get("x-mold-request-warning"),
+    ).toBe("kept whole; still one advisory");
+  });
+
   it("concatenates multi-line data fields with '\\n'", async () => {
     const body =
       "event: info\n" +

--- a/web/src/lib/sse.ts
+++ b/web/src/lib/sse.ts
@@ -19,6 +19,8 @@ export interface StreamSseOptions<TBody> {
   /** Extra request headers — how a cross-host stream carries its `x-api-key`. */
   headers?: Record<string, string>;
   onEvent: (evt: SseEvent) => void;
+  /** Called once with an accepted response before its event body is read. */
+  onOpen?: (res: Response) => void;
   /** Called once with the Response if the server returned a non-2xx. */
   onHttpError?: (res: Response) => void;
 }
@@ -44,6 +46,7 @@ export async function streamSse<TBody>(
   if (!res.body) {
     throw new Error("SSE response has no body");
   }
+  opts.onOpen?.(res);
 
   const reader = res.body.getReader();
   const decoder = new TextDecoder();

--- a/web/src/pages/CreatePage.test.ts
+++ b/web/src/pages/CreatePage.test.ts
@@ -1747,6 +1747,7 @@ describe("CreatePage layout and behavior", () => {
       }),
       expect.objectContaining({ baseUrl: expect.any(String) }),
       expect.stringMatching(/^[0-9a-f-]{36}$/),
+      expect.any(Function),
     );
     expect(placementPreviewMock).toHaveBeenCalledWith(
       expect.objectContaining({ baseUrl: expect.any(String) }),

--- a/website/api/index.md
+++ b/website/api/index.md
@@ -312,7 +312,9 @@ Several advisories are joined with `; `, but the advisory text itself contains
 that sequence — "…were not applied; the print was generated and saved
 normally". Splitting on it turns one advisory into two dangling half-sentences.
 Show the value whole: the semicolons read as ordinary punctuation. `mold`'s own
-client does exactly that.
+client does exactly that. Browser Fetch also combines repeated response fields
+and cannot recover their original boundaries, so servers must continue sending
+this as one joined field until a future structured warning encoding replaces it.
 :::
 
 ### Video and audio responses


### PR DESCRIPTION
## Summary

- preserve literal leading hashes in Library tag identity while keeping Create typed-input convenience
- surface accepted request advisories on web, desktop, desktop pull-resume, and iPhone without splitting semicolon-bearing prose
- render accepted TUI size advisories in the warning slot and clear stale errors
- make generateForm.resetAll preserve print identity through the shared helper

## Validation

- Studio: 98 files, 1151 tests passed
- Web: 103 files, 1602 tests passed
- Desktop: 375 files, 4783 tests passed
- TUI: 752 tests passed; clippy clean with warnings denied
- web, desktop, and mobile production builds passed
- changelog contract, rustfmt, and diff checks passed
- rendered iPhone-size mobile QA passed with no console warnings or errors
- independent agent peer review completed; all findings addressed and re-review clean

Closes #1263
Closes #1264
Closes #1265
Closes #1266