### PR TITLE
fix(mobile): improve keyboard-aware editors

### DIFF
--- a/changelog.d/mobile-gallery-info.md
+++ b/changelog.d/mobile-gallery-info.md
@@ -1,0 +1,3 @@
+- **Calmer mobile gallery details.** Gallery Info on iOS and Android now waits to
+  open the keyboard until an editor is selected and shows the complete desktop
+  print metadata set.

--- a/changelog.d/mobile-gallery-info.md
+++ b/changelog.d/mobile-gallery-info.md
@@ -1,3 +1,4 @@
 - **Calmer mobile gallery details.** Gallery Info on iOS and Android now waits to
   open the keyboard until an editor is selected and shows the complete desktop
-  print metadata set.
+  print metadata set; the iOS Create prompt also scrolls above the keyboard when
+  selected.

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -5555,6 +5555,31 @@ describe("MobileApp foreground resume", () => {
     }
   });
 
+  it("scrolls the prompt field into view when its keyboard opens", async () => {
+    vi.useFakeTimers();
+    try {
+      wrapper = mountMobileApp();
+      await flushPromises();
+
+      const prompt = fieldControl("Prompt").element as HTMLTextAreaElement;
+      const promptField = prompt.closest<HTMLElement>(".field")!;
+      const scrollIntoView = vi.fn();
+      Object.defineProperty(promptField, "scrollIntoView", {
+        configurable: true,
+        value: scrollIntoView,
+      });
+
+      prompt.focus();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(scrollIntoView).toHaveBeenCalledWith({ block: "center", inline: "nearest" });
+
+      await vi.advanceTimersByTimeAsync(400);
+      expect(scrollIntoView).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("tracks the visual viewport so sheets clear the keyboard and the header stays put", async () => {
     const originalViewport = Object.getOwnPropertyDescriptor(window, "visualViewport");
     const visualViewport = new EventTarget() as EventTarget & { pageTop: number; height: number };

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -7845,6 +7845,12 @@ function restoreNativeViewport(): void {
   void invoke("restore_mobile_viewport").catch(() => undefined);
 }
 
+function revealFocusedPrompt(editor: HTMLElement): void {
+  if (editor.id !== "mobile-prompt") return;
+  const field = editor.closest<HTMLElement>(".field") ?? editor;
+  field.scrollIntoView?.({ block: "center", inline: "nearest" });
+}
+
 function cancelKeyboardViewportRestore(): void {
   if (!keyboardViewportRestoreTimer) return;
   clearTimeout(keyboardViewportRestoreTimer);
@@ -7861,10 +7867,12 @@ function handleKeyboardFocusIn(event: FocusEvent): void {
   queueMicrotask(() => {
     if (unmounted || document.activeElement !== editor) return;
     restoreNativeViewport();
+    revealFocusedPrompt(editor);
     keyboardViewportRestoreTimer = setTimeout(() => {
       keyboardViewportRestoreTimer = null;
       if (document.activeElement !== editor) return;
       restoreNativeViewport();
+      revealFocusedPrompt(editor);
     }, KEYBOARD_VIEWPORT_SETTLE_MS);
   });
 }

--- a/desktop/src/mobile/MobileGalleryViewer.test.ts
+++ b/desktop/src/mobile/MobileGalleryViewer.test.ts
@@ -899,10 +899,62 @@ describe("MobileGalleryViewer info sheet", () => {
     return wrapper;
   }
 
-  it("hides the Info control until a host can organize or the print is trashed", async () => {
+  it("shows metadata Info even when the host cannot organize", async () => {
     const view = mountViewer();
     await flushPromises();
-    expect(view.find("[data-test='gallery-viewer-info']").exists()).toBe(false);
+    expect(view.find("[data-test='gallery-viewer-info']").exists()).toBe(true);
+    await view.get("[data-test='gallery-viewer-info']").trigger("click");
+    await flushPromises();
+
+    expect(document.activeElement).toBe(view.get(".mobile-library-sheet-panel").element);
+    expect(view.get("[data-test='gallery-viewer-print-details']").text()).toContain("flux-dev:q8");
+    expect(view.get("[data-test='gallery-viewer-print-details']").text()).toContain("1024×1024");
+  });
+
+  it("matches the desktop print-detail metadata fields", async () => {
+    const view = mountViewer({
+      ...image,
+      size_bytes: 1_500_000,
+      metadata: {
+        ...image.metadata,
+        original_prompt: "a beacon",
+        negative_prompt: "fog",
+        batch_id: "batch-9",
+        batch_index: 2,
+        batch_count: 3,
+        scheduler: "euler-a",
+        cfg_plus: true,
+        strength: 0.65,
+        frames: 97,
+        fps: 24,
+        pipeline: "two-stage",
+        loras: [{ path: "detail.safetensors", scale: 0.8 }],
+        version: "0.21.0",
+      },
+    });
+    await flushPromises();
+    await view.get("[data-test='gallery-viewer-info']").trigger("click");
+
+    const details = view.get("[data-test='gallery-viewer-print-details']").text();
+    for (const value of [
+      "print one.png",
+      "Original a beacon",
+      "Negative fog",
+      "Prepared batch 2 of 3 · batch-9",
+      "Seed42",
+      "Steps · guidance4 · 3.5",
+      "Schedulereuler-a",
+      "CFG++on",
+      "Denoise strength0.65",
+      "Frames97 · 24 fps",
+      "LoRAdetail.safetensors × 0.80",
+      "File size1.5 MB",
+      "FormatPNG",
+      "HostStudio",
+      "mold 0.21.0",
+    ]) {
+      expect(details).toContain(value);
+    }
   });
 
   it("shows the saved title as the viewer title line", async () => {

--- a/desktop/src/mobile/MobileGalleryViewer.vue
+++ b/desktop/src/mobile/MobileGalleryViewer.vue
@@ -5,6 +5,8 @@ import VideoExportDialog from "@ui/components/VideoExportDialog.vue";
 import { apiFetchTo, apiJsonTo, type ApiTarget } from "../lib/api/client";
 import type { GalleryImage } from "../lib/api/types";
 import { blobToBase64 } from "../lib/image";
+import { formatBytes, formatScheduler } from "../lib/format";
+import { modelDisplayNameForId } from "../lib/models";
 import {
   evictMedia,
   galleryMediaPath,
@@ -33,6 +35,7 @@ import {
 } from "@studio/lib/libraryOrganization";
 import type { TagCount } from "@studio/lib/api/galleryOrganization";
 import { mobileIdentityProvenanceRows } from "./identity";
+import { strengthSemanticsForModel } from "@studio/lib/strengthSemantics";
 import MobileLibrarySheet from "./MobileLibrarySheet.vue";
 import {
   validateCollectionName,
@@ -167,10 +170,8 @@ const deleteForeverArmed = ref(false);
  */
 const identityRows = computed(() => mobileIdentityProvenanceRows(props.item.metadata));
 // Identity provenance is worth reading on a host that has no organization
-// capability at all, so it opens the Info sheet in its own right.
-const infoAvailable = computed(
-  () => props.organizeEnabled || props.trashed || identityRows.value !== null,
-);
+// Metadata is useful on every print, even when its host cannot organize.
+const infoAvailable = computed(() => true);
 const savedTitle = computed(() => props.organization?.title ?? null);
 /** Header line: the print's title, else its prompt, else the filename. */
 const viewerTitle = computed(() =>
@@ -192,6 +193,30 @@ const purgeCopy = computed(() => {
   const purgeAt =
     props.organization?.purgeAt ?? (props.item as MobileGalleryImage).purge_at ?? null;
   return purgeCountdownFromPurgeAt(purgeAt, Date.now()).label;
+});
+const modelLabel = computed(() => modelDisplayNameForId(props.item.metadata.model, []));
+const schedulerName = computed(() => formatScheduler(props.item.metadata.scheduler));
+const strengthCaption = computed(
+  () => strengthSemanticsForModel(props.item.metadata.model, null).label,
+);
+const frames = computed(
+  () => props.item.metadata.frames ?? props.item.metadata.video_frames ?? null,
+);
+const fps = computed(() => props.item.metadata.fps ?? props.item.metadata.video_fps ?? null);
+const fileFormat = computed(() => props.item.format ?? props.item.metadata.output_format ?? null);
+const fileSize = computed(() =>
+  props.item.size_bytes != null ? formatBytes(props.item.size_bytes) : null,
+);
+const createdAt = computed(() =>
+  new Date(props.item.timestamp * 1000).toLocaleString(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }),
+);
+const loraStack = computed(() => {
+  const metadata = props.item.metadata;
+  if (metadata.loras?.length) return metadata.loras;
+  return metadata.lora ? [{ path: metadata.lora, scale: metadata.lora_scale ?? 1 }] : [];
 });
 
 function openInfo(): void {
@@ -813,6 +838,7 @@ onBeforeUnmount(() => {
     <MobileLibrarySheet
       :open="infoOpen"
       :title="viewerTitle"
+      :focus-first-control="false"
       test-id="gallery-viewer-info-sheet"
       @close="infoOpen = false"
     >
@@ -974,6 +1000,100 @@ onBeforeUnmount(() => {
           </template>
         </dl>
       </template>
+      <section class="gallery-viewer-print-details" data-test="gallery-viewer-print-details">
+        <p class="mobile-library-sheet-label">Print details</p>
+        <p class="gallery-viewer-info-filename" :title="item.filename">{{ item.filename }}</p>
+        <p class="gallery-viewer-info-prompt" :title="item.metadata.prompt">
+          {{ item.metadata.prompt }}
+        </p>
+        <p
+          v-if="item.metadata.prompt.trim() && item.metadata.original_prompt"
+          class="gallery-viewer-info-secondary"
+          data-test="gallery-viewer-original"
+        >
+          <span>Original</span> {{ item.metadata.original_prompt }}
+        </p>
+        <p
+          v-if="item.metadata.negative_prompt"
+          class="gallery-viewer-info-secondary"
+          data-test="gallery-viewer-negative"
+        >
+          <span>Negative</span> {{ item.metadata.negative_prompt }}
+        </p>
+        <p
+          v-if="item.metadata.batch_id && item.metadata.batch_index && item.metadata.batch_count"
+          class="gallery-viewer-info-secondary"
+          data-test="gallery-viewer-batch"
+          :title="item.metadata.batch_id"
+        >
+          <span>Prepared batch</span> {{ item.metadata.batch_index }} of
+          {{ item.metadata.batch_count }} · {{ item.metadata.batch_id }}
+        </p>
+        <dl class="gallery-viewer-info-facts">
+          <div>
+            <dt>Model</dt>
+            <dd>{{ modelLabel }}</dd>
+          </div>
+          <div>
+            <dt>Seed</dt>
+            <dd>{{ item.metadata.seed }}</dd>
+          </div>
+          <div>
+            <dt>Dimensions</dt>
+            <dd>{{ item.metadata.width }}×{{ item.metadata.height }}</dd>
+          </div>
+          <div>
+            <dt>Steps · guidance</dt>
+            <dd>{{ item.metadata.steps }} · {{ item.metadata.guidance.toFixed(1) }}</dd>
+          </div>
+          <div v-if="schedulerName">
+            <dt>Scheduler</dt>
+            <dd>{{ schedulerName }}</dd>
+          </div>
+          <div v-if="item.metadata.cfg_plus">
+            <dt>CFG++</dt>
+            <dd>on</dd>
+          </div>
+          <div v-if="item.metadata.strength != null">
+            <dt>{{ strengthCaption }}</dt>
+            <dd>{{ item.metadata.strength.toFixed(2) }}</dd>
+          </div>
+          <div v-if="frames">
+            <dt>Frames</dt>
+            <dd>
+              {{ frames }}<template v-if="fps"> · {{ fps }} fps</template>
+            </dd>
+          </div>
+          <div v-if="pipeline">
+            <dt>Pipeline</dt>
+            <dd>{{ pipeline }}</dd>
+          </div>
+          <div v-for="lora in loraStack" :key="lora.path">
+            <dt>LoRA</dt>
+            <dd :title="lora.path">{{ lora.path }} × {{ lora.scale.toFixed(2) }}</dd>
+          </div>
+          <div v-if="fileSize">
+            <dt>File size</dt>
+            <dd>{{ fileSize }}</dd>
+          </div>
+          <div v-if="fileFormat">
+            <dt>Format</dt>
+            <dd>{{ fileFormat.toUpperCase() }}</dd>
+          </div>
+          <div>
+            <dt>Created</dt>
+            <dd>{{ createdAt }}</dd>
+          </div>
+          <div>
+            <dt>Host</dt>
+            <dd>{{ hostName }}</dd>
+          </div>
+        </dl>
+        <p v-if="item.metadata.version" class="gallery-viewer-info-version">
+          mold {{ item.metadata.version }}
+        </p>
+        <span v-if="item.metadata_synthetic" class="edge-code">SYNTHETIC METADATA</span>
+      </section>
       <template v-if="trashed">
         <p class="status-line" data-test="gallery-viewer-purge">{{ purgeCopy }}</p>
         <button
@@ -1020,6 +1140,73 @@ onBeforeUnmount(() => {
   font-family: var(--font-mono, ui-monospace, monospace);
   font-size: 13px;
   overflow-wrap: anywhere;
+}
+
+.gallery-viewer-print-details {
+  display: grid;
+  gap: 10px;
+  min-width: 0;
+}
+
+.gallery-viewer-info-filename,
+.gallery-viewer-info-prompt,
+.gallery-viewer-info-secondary,
+.gallery-viewer-info-version {
+  margin: 0;
+}
+
+.gallery-viewer-info-filename,
+.gallery-viewer-info-version {
+  overflow: hidden;
+  color: var(--ink-3);
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 13px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.gallery-viewer-info-prompt {
+  color: var(--rebate);
+  font-size: var(--text-body);
+  overflow-wrap: anywhere;
+}
+
+.gallery-viewer-info-secondary {
+  color: var(--ink-2);
+  font-size: 13px;
+  overflow-wrap: anywhere;
+}
+
+.gallery-viewer-info-secondary span {
+  color: var(--ink-3);
+}
+
+.gallery-viewer-info-facts {
+  display: grid;
+  gap: 8px;
+  margin: 2px 0 0;
+}
+
+.gallery-viewer-info-facts > div {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.7fr);
+  gap: 12px;
+}
+
+.gallery-viewer-info-facts dt {
+  color: var(--ink-3);
+  font-size: 13px;
+}
+
+.gallery-viewer-info-facts dd {
+  min-width: 0;
+  margin: 0;
+  overflow: hidden;
+  color: var(--rebate);
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 13px;
+  overflow-wrap: anywhere;
+  text-align: right;
 }
 
 .gallery-viewer-media,

--- a/desktop/src/mobile/MobileLibrarySheet.vue
+++ b/desktop/src/mobile/MobileLibrarySheet.vue
@@ -13,13 +13,20 @@ const props = withDefaults(
   defineProps<{
     open: boolean;
     title: string;
+    /** Focus the first editor when the sheet opens. Disable for read-first sheets. */
+    focusFirstControl?: boolean;
     /** Trailing label of the one closing control. */
     doneLabel?: string;
     testId?: string;
     /** Platform-specific minimum target for the closing control. */
     touchTargetSize?: number;
   }>(),
-  { doneLabel: "Done", testId: "mobile-library-sheet", touchTargetSize: 46 },
+  {
+    focusFirstControl: true,
+    doneLabel: "Done",
+    testId: "mobile-library-sheet",
+    touchTargetSize: 46,
+  },
 );
 
 const emit = defineEmits<{ close: [] }>();
@@ -32,9 +39,13 @@ watch(
   (open) => {
     if (open) {
       restoreFocus = document.activeElement as HTMLElement | null;
-      // Land focus on the first editable control so the keyboard rises with
-      // the sheet; fall back to the panel itself.
+      // Editing sheets may raise the keyboard immediately. Read-first sheets
+      // focus the panel so the keyboard waits for an explicit field tap.
       queueMicrotask(() => {
+        if (!props.focusFirstControl) {
+          panel.value?.focus?.();
+          return;
+        }
         const first = panel.value?.querySelector<HTMLElement>(
           "input, textarea, select, button:not([data-sheet-close])",
         );


### PR DESCRIPTION
## Summary
- keep the iOS and Android keyboard closed when Gallery Info opens, focusing the read-first sheet until the user selects an editor
- expose Info for every print and match the desktop detail set: prompt provenance, batch, model, generation settings, media/file facts, host, version, and synthetic metadata
- scroll the iOS Create prompt into view immediately and after the software-keyboard animation
- preserve immediate autofocus for the other editing-first mobile sheets

## Validation
- `nix develop -c bunx vitest run src/mobile` (38 files, 847 tests passed)
- `nix develop -c bun --cwd desktop build:mobile`
- iPhone 17 Pro iOS 26.5 Simulator using `MOLD_HOME=/Volumes/ExternalStorage/mold2`: verified Gallery Info opens with no keyboard, explicit title selection opens it, all details render/scroll cleanly, and Create keeps the full Prompt field visible above the software keyboard
- Android debug APK built successfully with the CI-pinned Tauri CLI 2.11.4 and external Android caches
- Prettier, changelog policy, and `git diff --check`
