### PR TITLE
fix(h3): bind claimed-attempt test doubles to the owner run context and arm the release-contract phase gate

### DIFF
--- a/changelog.d/h3-claimed-owner-binding.md
+++ b/changelog.d/h3-claimed-owner-binding.md
@@ -1,0 +1,18 @@
+- **Fixed the private H3 claimed-attempt test doubles and the release-contract
+  phase gate.** Under `--features h3-private-uat` ten `claimed_h3_*` /
+  `claimed_ref2va_*` GPU-worker tests failed against two correct production
+  fences: the doubles echoed constant identity digests instead of the run
+  binding the owner scope derives, and their scheduler stand-in never answered
+  the ledger-aware host-memory recheck the owner blocks on before the CUDA
+  allocation boundary. The fixtures now derive the same work-identity,
+  cancellation-scope, and ledger-sequence values the real runtime receives and
+  answer that recheck while forwarding every other worker event untouched
+  ([#1204](https://github.com/utensils/mold/issues/1204)).
+- **The private-UAT release contract now enforces its phase ordering.** Its
+  VAE-drop → terminal-identity → mux markers also matched the Ref2VA twins, so
+  the resolved line numbers were multi-line values that made bash arithmetic
+  error out and pass the whole ordering check silently. Every marker is now
+  anchored to the block that identifies the FL2VA occurrence, the Ref2VA attempt
+  gets its own terminal-before-mux check, and any marker resolving to zero or
+  several lines fails the script by name
+  ([#1207](https://github.com/utensils/mold/issues/1207)).

--- a/crates/mold-server/src/gpu_worker.rs
+++ b/crates/mold-server/src/gpu_worker.rs
@@ -6152,8 +6152,19 @@ mod tests {
         }
     }
 
-    fn fake_h3_facts() -> crate::h3_private_bridge::H3PreparedAttemptFacts {
+    /// Prepared-attempt facts for the fake runtime bound to `work_id`.
+    ///
+    /// The real `InferenceH3PreparedAttempt` echoes the work identity,
+    /// cancellation scope, and ledger sequence it received from the owner's
+    /// `H3AttemptScope::private_run_context`, and
+    /// `validate_h3_prepared_attempt_facts` re-derives them from the claim.
+    /// So the double takes them from the same derivation rather than a
+    /// constant, which the fence correctly reads as a changed owner run
+    /// binding (#1204).
+    fn fake_h3_facts(work_id: &str) -> crate::h3_private_bridge::H3PreparedAttemptFacts {
         let identity = |byte: char| std::iter::repeat_n(byte, 64).collect::<String>();
+        let (work_identity_sha256, cancellation_scope_identity_sha256, memory_ledger_sequence) =
+            crate::h3_attempt::private_run_binding_for_test(work_id);
         crate::h3_private_bridge::H3PreparedAttemptFacts {
             device_id: "cuda:0".to_string(),
             device_ordinal: 0,
@@ -6164,9 +6175,9 @@ mod tests {
             admission_evidence_identity_sha256: identity('e'),
             artifact_qualification_identity_sha256: identity('f'),
             runtime_qualification_identity_sha256: identity('1'),
-            work_identity_sha256: identity('2'),
-            cancellation_scope_identity_sha256: identity('3'),
-            memory_ledger_sequence: 23,
+            work_identity_sha256,
+            cancellation_scope_identity_sha256,
+            memory_ledger_sequence,
             consumption_identity_sha256: identity('4'),
             predicted_device_peak_bytes: 11_000_000_000,
             predicted_host_increment_bytes: 2_000_000_000,
@@ -6288,7 +6299,8 @@ mod tests {
         job: &mut GpuJob,
         outcome: FakeH3Outcome,
     ) -> (Arc<AtomicUsize>, Arc<AtomicUsize>) {
-        install_fake_h3_attempt_with_facts(job, outcome, fake_h3_facts())
+        let facts = fake_h3_facts(&job.id);
+        install_fake_h3_attempt_with_facts(job, outcome, facts)
     }
 
     fn install_fake_h3_attempt_with_facts(
@@ -6315,6 +6327,92 @@ mod tests {
             drops: Arc::clone(&drops),
         }));
         (runs, drops)
+    }
+
+    /// Host headroom the Scheduler V2 stand-in grants, comfortably above the
+    /// fake attempt's `predicted_host_increment_bytes`.
+    const FAKE_SCHEDULER_HOST_HEADROOM_BYTES: u64 = 64 * 1024 * 1024 * 1024;
+
+    #[derive(Clone, Copy)]
+    enum FakeSchedulerV2Mode {
+        /// Answer the host-memory recheck and keep forwarding worker events.
+        Live,
+        /// Answer the host-memory recheck, then drop the receiver so the
+        /// allocation commit that follows cannot reach the scheduler.
+        ClosedAfterRecheck,
+    }
+
+    /// Scheduler V2 stand-in for the claimed-H3 owner tests.
+    ///
+    /// `run_claimed_h3_generation` requests ledger-aware host headroom before
+    /// the CUDA allocation boundary and blocks on the scheduler's reply
+    /// (#1099), so a bare channel with no responder stalls the owner thread for
+    /// five seconds and then fails the job on that timeout instead of on what
+    /// the test is actually asserting. This answers exactly `HostMemoryRecheck`
+    /// and forwards every other worker event untouched, so the event-stream
+    /// assertions still see only what the worker itself emitted.
+    struct FakeSchedulerV2 {
+        tx: tokio::sync::mpsc::UnboundedSender<crate::scheduler::WorkerEvent>,
+        forwarded: tokio::sync::mpsc::UnboundedReceiver<crate::scheduler::WorkerEvent>,
+        responder: std::thread::JoinHandle<()>,
+    }
+
+    impl FakeSchedulerV2 {
+        fn sender(&self) -> &tokio::sync::mpsc::UnboundedSender<crate::scheduler::WorkerEvent> {
+            &self.tx
+        }
+
+        /// Close the stand-in and hand back the worker events it forwarded.
+        /// Joining the responder is what makes `try_recv` deterministic.
+        fn settle(self) -> tokio::sync::mpsc::UnboundedReceiver<crate::scheduler::WorkerEvent> {
+            let FakeSchedulerV2 {
+                tx,
+                forwarded,
+                responder,
+            } = self;
+            drop(tx);
+            responder
+                .join()
+                .expect("fake Scheduler V2 responder must not panic");
+            forwarded
+        }
+    }
+
+    fn fake_scheduler_v2(mode: FakeSchedulerV2Mode) -> FakeSchedulerV2 {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let (forward_tx, forwarded) = tokio::sync::mpsc::unbounded_channel();
+        let answers_recheck = cfg!(any(feature = "h3", feature = "h3-private-uat"));
+        let responder =
+            if !answers_recheck && matches!(mode, FakeSchedulerV2Mode::ClosedAfterRecheck) {
+                // This build compiles the host-memory recheck out, so a scheduler
+                // that must already be gone by the allocation commit has to be gone
+                // before the owner thread starts — dropping the receiver here, not
+                // on the responder, is what makes that ordering deterministic.
+                rx.close();
+                drop(rx);
+                std::thread::spawn(|| {})
+            } else {
+                std::thread::spawn(move || {
+                    while let Some(event) = rx.blocking_recv() {
+                        match event {
+                            crate::scheduler::WorkerEvent::HostMemoryRecheck { reply, .. } => {
+                                let _ = reply.send(Ok(FAKE_SCHEDULER_HOST_HEADROOM_BYTES));
+                                if matches!(mode, FakeSchedulerV2Mode::ClosedAfterRecheck) {
+                                    break;
+                                }
+                            }
+                            other => {
+                                let _ = forward_tx.send(other);
+                            }
+                        }
+                    }
+                })
+            };
+        FakeSchedulerV2 {
+            tx,
+            forwarded,
+            responder,
+        }
     }
 
     fn run_fake_claimed_h3(
@@ -6379,14 +6477,15 @@ mod tests {
         job.output_dir = Some(output.path().to_path_buf());
         let (runs, drops) = install_fake_h3_attempt(&mut job, FakeH3Outcome::Success);
         let worker = single_worker_pool_with_parked("cache-sentinel", Duration::ZERO);
-        let (scheduler_tx, mut scheduler_rx) = tokio::sync::mpsc::unbounded_channel();
+        let scheduler = fake_scheduler_v2(FakeSchedulerV2Mode::Live);
 
         let owner_worker = Arc::clone(&worker);
-        let owner_scheduler = scheduler_tx.clone();
+        let owner_scheduler = scheduler.sender().clone();
         let settlements =
             std::thread::spawn(move || run_fake_claimed_h3(&owner_worker, job, &owner_scheduler))
                 .join()
                 .expect("fake H3 owner thread must not panic");
+        let mut scheduler_rx = scheduler.settle();
         let result = result_rx.await.unwrap().expect("fake H3 success result");
 
         assert_eq!(runs.load(Ordering::SeqCst), 1);
@@ -6445,7 +6544,7 @@ mod tests {
         job.model = job.request.model.clone();
         let resolved =
             crate::reference_uploads::ResolvedReferenceSet::authority_only_for_test(&job.request);
-        let mut facts = fake_h3_facts();
+        let mut facts = fake_h3_facts(id);
         facts.media = crate::h3_private_bridge::H3PreparedMediaContract::from_request(
             &job.request,
             Some(resolved.fingerprint()),
@@ -6462,14 +6561,15 @@ mod tests {
         let (runs, drops) =
             install_fake_h3_attempt_with_facts(&mut job, FakeH3Outcome::Success, facts);
         let worker = single_worker_pool_with_parked("cache-sentinel", Duration::ZERO);
-        let (scheduler_tx, mut scheduler_rx) = tokio::sync::mpsc::unbounded_channel();
+        let scheduler = fake_scheduler_v2(FakeSchedulerV2Mode::Live);
 
         let owner_worker = Arc::clone(&worker);
-        let owner_scheduler = scheduler_tx.clone();
+        let owner_scheduler = scheduler.sender().clone();
         let settlements =
             std::thread::spawn(move || run_fake_claimed_h3(&owner_worker, job, &owner_scheduler))
                 .join()
                 .expect("fake Ref2VA owner thread must not panic");
+        let mut scheduler_rx = scheduler.settle();
         let result = result_rx.await.unwrap().expect("fake Ref2VA success");
 
         assert_eq!(runs.load(Ordering::SeqCst), 1);
@@ -6527,7 +6627,7 @@ mod tests {
         job.model = job.request.model.clone();
         let admitted =
             crate::reference_uploads::ResolvedReferenceSet::authority_only_for_test(&job.request);
-        let mut facts = fake_h3_facts();
+        let mut facts = fake_h3_facts(id);
         facts.media = crate::h3_private_bridge::H3PreparedMediaContract::from_request(
             &job.request,
             Some(admitted.fingerprint()),
@@ -6546,13 +6646,14 @@ mod tests {
             crate::reference_uploads::ResolvedReferenceSet::authority_only_for_test(&job.request),
         );
         let worker = single_worker_pool_with_parked("cache-sentinel", Duration::ZERO);
-        let (scheduler_tx, mut scheduler_rx) = tokio::sync::mpsc::unbounded_channel();
+        let scheduler = fake_scheduler_v2(FakeSchedulerV2Mode::Live);
         let owner_worker = Arc::clone(&worker);
-        let owner_scheduler = scheduler_tx.clone();
+        let owner_scheduler = scheduler.sender().clone();
         let settlements =
             std::thread::spawn(move || run_fake_claimed_h3(&owner_worker, job, &owner_scheduler))
                 .join()
                 .expect("order-drift owner thread must not panic");
+        let mut scheduler_rx = scheduler.settle();
         let error = match result_rx.await.unwrap() {
             Err(error) => error,
             Ok(_) => panic!("reordered Ref2VA authority unexpectedly published"),
@@ -6579,7 +6680,7 @@ mod tests {
         job.model = job.request.model.clone();
         let resolved =
             crate::reference_uploads::ResolvedReferenceSet::authority_only_for_test(&job.request);
-        let mut facts = fake_h3_facts();
+        let mut facts = fake_h3_facts(id);
         facts.media = crate::h3_private_bridge::H3PreparedMediaContract::from_request(
             &job.request,
             Some(resolved.fingerprint()),
@@ -6589,13 +6690,14 @@ mod tests {
         let (runs, drops) =
             install_fake_h3_attempt_with_facts(&mut job, FakeH3Outcome::Cancelled, facts);
         let worker = single_worker_pool_with_parked("cache-sentinel", Duration::ZERO);
-        let (scheduler_tx, mut scheduler_rx) = tokio::sync::mpsc::unbounded_channel();
+        let scheduler = fake_scheduler_v2(FakeSchedulerV2Mode::Live);
         let owner_worker = Arc::clone(&worker);
-        let owner_scheduler = scheduler_tx.clone();
+        let owner_scheduler = scheduler.sender().clone();
         let settlements =
             std::thread::spawn(move || run_fake_claimed_h3(&owner_worker, job, &owner_scheduler))
                 .join()
                 .expect("cancelled Ref2VA owner thread must not panic");
+        let mut scheduler_rx = scheduler.settle();
         let error = match result_rx.await.unwrap() {
             Err(error) => error,
             Ok(_) => panic!("cancelled Ref2VA attempt unexpectedly published"),
@@ -6648,9 +6750,10 @@ mod tests {
                 drop(fake);
             }
             let worker = single_worker_pool_with_parked("cache-sentinel", Duration::ZERO);
-            let (scheduler_tx, mut scheduler_rx) = tokio::sync::mpsc::unbounded_channel();
+            let scheduler = fake_scheduler_v2(FakeSchedulerV2Mode::Live);
 
-            let settlements = run_fake_claimed_h3(&worker, job, &scheduler_tx);
+            let settlements = run_fake_claimed_h3(&worker, job, scheduler.sender());
+            let mut scheduler_rx = scheduler.settle();
             let error = match result_rx.await.unwrap() {
                 Err(error) => error,
                 Ok(_) => panic!("identity-mismatched H3 attempt unexpectedly completed"),
@@ -6709,9 +6812,10 @@ mod tests {
             job.output_dir = Some(output.path().to_path_buf());
             let (runs, drops) = install_fake_h3_attempt(&mut job, outcome);
             let worker = single_worker_pool_with_parked("cache-sentinel", Duration::ZERO);
-            let (scheduler_tx, _scheduler_rx) = tokio::sync::mpsc::unbounded_channel();
+            let scheduler = fake_scheduler_v2(FakeSchedulerV2Mode::Live);
 
-            let settlements = run_fake_claimed_h3(&worker, job, &scheduler_tx);
+            let settlements = run_fake_claimed_h3(&worker, job, scheduler.sender());
+            drop(scheduler.settle());
             let error = match result_rx.await.unwrap() {
                 Err(error) => error,
                 Ok(_) => panic!("invalid fake H3 attempt unexpectedly completed"),
@@ -6742,10 +6846,12 @@ mod tests {
         job.output_dir = Some(output.path().to_path_buf());
         let (runs, drops) = install_fake_h3_attempt(&mut job, FakeH3Outcome::Success);
         let worker = single_worker_pool_with_parked("cache-sentinel", Duration::ZERO);
-        let (scheduler_tx, scheduler_rx) = tokio::sync::mpsc::unbounded_channel();
-        drop(scheduler_rx);
+        // The host-memory recheck is answered so the attempt reaches the
+        // allocation commit; the scheduler is gone only from that point on.
+        let scheduler = fake_scheduler_v2(FakeSchedulerV2Mode::ClosedAfterRecheck);
 
-        let settlements = run_fake_claimed_h3(&worker, job, &scheduler_tx);
+        let settlements = run_fake_claimed_h3(&worker, job, scheduler.sender());
+        drop(scheduler.settle());
         let error = match result_rx.await.unwrap() {
             Err(error) => error,
             Ok(_) => panic!("H3 attempt completed without a scheduler allocation commit"),
@@ -6775,10 +6881,10 @@ mod tests {
         let (runs, drops) =
             install_fake_h3_attempt(&mut job, FakeH3Outcome::SwallowAllocationCommitFailure);
         let worker = single_worker_pool_with_parked("cache-sentinel", Duration::ZERO);
-        let (scheduler_tx, scheduler_rx) = tokio::sync::mpsc::unbounded_channel();
-        drop(scheduler_rx);
+        let scheduler = fake_scheduler_v2(FakeSchedulerV2Mode::ClosedAfterRecheck);
 
-        let settlements = run_fake_claimed_h3(&worker, job, &scheduler_tx);
+        let settlements = run_fake_claimed_h3(&worker, job, scheduler.sender());
+        drop(scheduler.settle());
         let error = match result_rx.await.unwrap() {
             Err(error) => error,
             Ok(_) => panic!("H3 attempt published after swallowing a callback failure"),
@@ -6819,9 +6925,10 @@ mod tests {
             let (runs, drops) =
                 install_fake_h3_attempt(&mut job, FakeH3Outcome::PublicationFault(fault));
             let worker = single_worker_pool_with_parked("cache-sentinel", Duration::ZERO);
-            let (scheduler_tx, _scheduler_rx) = tokio::sync::mpsc::unbounded_channel();
+            let scheduler = fake_scheduler_v2(FakeSchedulerV2Mode::Live);
 
-            let settlements = run_fake_claimed_h3(&worker, job, &scheduler_tx);
+            let settlements = run_fake_claimed_h3(&worker, job, scheduler.sender());
+            drop(scheduler.settle());
             let error = match result_rx.await.unwrap() {
                 Err(error) => error,
                 Ok(_) => panic!("invalid H3 publication unexpectedly completed"),
@@ -6847,7 +6954,7 @@ mod tests {
     async fn claimed_h3_publication_accepts_container_rounded_duration() {
         let (job, _result_rx, _progress_rx, _queue_rx, _queue, _registry) =
             claimed_h3_job_fixture("claimed-h3-rounded-duration").await;
-        let facts = fake_h3_facts();
+        let facts = fake_h3_facts(&job.id);
         let claimed_output = fake_h3_output(&facts, true, false);
         let duration_ms = claimed_output.identity_echo.duration_ms;
         let worker = single_worker_pool_with_parked("cache-sentinel", Duration::ZERO);
@@ -6892,7 +6999,7 @@ mod tests {
             let id = format!("claimed-h3-contract-fault-{index}");
             let (job, _result_rx, _progress_rx, _queue_rx, _queue, _registry) =
                 claimed_h3_job_fixture(&id).await;
-            let mut facts = fake_h3_facts();
+            let mut facts = fake_h3_facts(&id);
             apply_fake_h3_contract_fault(&mut facts.media, fault);
             let worker = single_worker_pool_with_parked("cache-sentinel", Duration::ZERO);
             let claimed_output = fake_h3_output(&facts, true, false);
@@ -6914,7 +7021,7 @@ mod tests {
         let id = "claimed-h3-invalid-request-contract";
         let (mut job, _result_rx, _progress_rx, _queue_rx, _queue, _registry) =
             claimed_h3_job_fixture(id).await;
-        let facts = fake_h3_facts();
+        let facts = fake_h3_facts(id);
         let claimed_output = fake_h3_output(&facts, true, false);
         job.request.model = SENTINEL.to_string();
         job.model = SENTINEL.to_string();
@@ -6945,9 +7052,10 @@ mod tests {
             job.output_dir = Some(output.path().to_path_buf());
             let (runs, drops) = install_fake_h3_attempt(&mut job, outcome);
             let worker = single_worker_pool_with_parked("cache-sentinel", Duration::ZERO);
-            let (scheduler_tx, _scheduler_rx) = tokio::sync::mpsc::unbounded_channel();
+            let scheduler = fake_scheduler_v2(FakeSchedulerV2Mode::Live);
 
-            let settlements = run_fake_claimed_h3(&worker, job, &scheduler_tx);
+            let settlements = run_fake_claimed_h3(&worker, job, scheduler.sender());
+            drop(scheduler.settle());
             let error = match result_rx.await.unwrap() {
                 Err(error) => error,
                 Ok(_) => panic!("quarantined fake H3 attempt unexpectedly completed"),

--- a/crates/mold-server/src/h3_attempt.rs
+++ b/crates/mold-server/src/h3_attempt.rs
@@ -11,7 +11,7 @@ use std::fmt;
 use std::marker::PhantomData;
 use std::rc::Rc;
 
-#[cfg(any(feature = "h3", feature = "h3-private-uat"))]
+#[cfg(any(test, feature = "h3", feature = "h3-private-uat"))]
 pub(crate) fn private_work_identity_sha256(work_id: &str) -> String {
     use sha2::{Digest, Sha256};
 
@@ -22,7 +22,7 @@ pub(crate) fn private_work_identity_sha256(work_id: &str) -> String {
     format!("{:x}", digest.finalize())
 }
 
-#[cfg(any(feature = "h3", feature = "h3-private-uat"))]
+#[cfg(any(test, feature = "h3", feature = "h3-private-uat"))]
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn private_cancellation_scope_identity_sha256(
     work_identity_sha256: &str,
@@ -528,16 +528,9 @@ impl H3GenerationAttempt {
 }
 
 #[cfg(test)]
-pub(crate) fn generation_attempt_for_test(
-    work_id: &str,
-    cancellation: mold_inference::InferenceCancellationToken,
-) -> (
-    H3GenerationAttempt,
-    H3AttemptCurrent,
-    std::sync::Arc<std::sync::atomic::AtomicUsize>,
-) {
+fn generation_attempt_claim_for_test(work_id: &str) -> H3AttemptClaim {
     let identity = |byte: char| std::iter::repeat_n(byte, 64).collect::<String>();
-    let claim = H3AttemptClaim {
+    H3AttemptClaim {
         work_id: work_id.to_string(),
         device_id: "cuda:0".to_string(),
         device_ordinal: 0,
@@ -553,7 +546,49 @@ pub(crate) fn generation_attempt_for_test(
         component_set_identity_sha256: identity('d'),
         predicted_device_peak_bytes: 11_000_000_000,
         predicted_host_increment_bytes: 2_000_000_000,
-    };
+    }
+}
+
+/// The private run binding a `generation_attempt_for_test` scope hands the
+/// runtime through `private_run_context`, as `(work identity, cancellation
+/// scope identity, memory ledger sequence)`.
+///
+/// `matches_private_run_binding` re-derives these from the owner's own claim,
+/// so a prepared-attempt test double must echo exactly them or the fence
+/// correctly refuses it as a changed owner run binding. Both sides read this
+/// one derivation because a fixture that restates constants instead is what
+/// left ten `claimed_*` tests failing against a fence that was working (#1204).
+#[cfg(test)]
+pub(crate) fn private_run_binding_for_test(work_id: &str) -> (String, String, u64) {
+    let claim = generation_attempt_claim_for_test(work_id);
+    let work_identity_sha256 = private_work_identity_sha256(&claim.work_id);
+    let cancellation_scope_identity_sha256 = private_cancellation_scope_identity_sha256(
+        &work_identity_sha256,
+        &claim.device_id,
+        claim.owner_epoch,
+        claim.state_version,
+        claim.plan_version,
+        claim.worker_generation,
+        claim.memory_sample_generation,
+        claim.memory_ledger_sequence,
+    );
+    (
+        work_identity_sha256,
+        cancellation_scope_identity_sha256,
+        claim.memory_ledger_sequence,
+    )
+}
+
+#[cfg(test)]
+pub(crate) fn generation_attempt_for_test(
+    work_id: &str,
+    cancellation: mold_inference::InferenceCancellationToken,
+) -> (
+    H3GenerationAttempt,
+    H3AttemptCurrent,
+    std::sync::Arc<std::sync::atomic::AtomicUsize>,
+) {
+    let claim = generation_attempt_claim_for_test(work_id);
     let current = H3AttemptCurrent {
         work_id: claim.work_id.clone(),
         device_id: claim.device_id.clone(),
@@ -1286,5 +1321,48 @@ mod tests {
             assert_eq!(error, H3AttemptError::StaleOwnerFence);
             assert!(!called.load(Ordering::SeqCst));
         }
+    }
+
+    /// The owner scope accepts exactly the binding it derives from its own
+    /// claim, and nothing else. `private_run_binding_for_test` is therefore
+    /// the only correct source for a prepared-attempt test double's echoed
+    /// identities: a constant digest is refused on every axis (#1204).
+    #[cfg(any(feature = "h3", feature = "h3-private-uat"))]
+    #[test]
+    fn the_owner_scope_accepts_only_its_own_derived_private_run_binding() {
+        let work_id = "h3-attempt-derived-run-binding";
+        let (work_identity, cancellation_scope, ledger_sequence) =
+            private_run_binding_for_test(work_id);
+        let constant: String = std::iter::repeat_n('2', 64).collect();
+        let (attempt, current, _settlements) = generation_attempt_for_test(
+            work_id,
+            mold_inference::InferenceCancellationToken::default(),
+        );
+
+        attempt
+            .run_once(current, |scope| {
+                let facts = scope.facts();
+                assert!(facts.matches_private_run_binding(
+                    &work_identity,
+                    &cancellation_scope,
+                    ledger_sequence,
+                ));
+                assert!(!facts.matches_private_run_binding(
+                    &constant,
+                    &cancellation_scope,
+                    ledger_sequence,
+                ));
+                assert!(!facts.matches_private_run_binding(
+                    &work_identity,
+                    &constant,
+                    ledger_sequence,
+                ));
+                assert!(!facts.matches_private_run_binding(
+                    &work_identity,
+                    &cancellation_scope,
+                    ledger_sequence + 1,
+                ));
+            })
+            .expect("the synthetic owner attempt runs once");
     }
 }

--- a/scripts/tests/minimax-h3-private-uat-release-contract.sh
+++ b/scripts/tests/minimax-h3-private-uat-release-contract.sh
@@ -23,6 +23,84 @@ require_text() {
   grep -Fq -- "$text" "$file" || fail "$message"
 }
 
+# Ordering gates below anchor on source markers and compare their line numbers.
+# A marker that resolves to zero or several lines must FAIL rather than be
+# swallowed: `(( ))` treats a multi-line value as a syntax error, which returns
+# non-zero and therefore reads as "the ordering is fine" (#1207). Every marker
+# resolution goes through one of these helpers so an ambiguous anchor is
+# reported by name instead of silently disarming its check.
+#
+# `fail` exits the command substitution; the caller's plain assignment inherits
+# that status and `set -e` ends the script. Assign these at top level only —
+# `local x=$(...)` would mask the status.
+marker_lines() {
+  # Reads text on stdin; prints one line number per match of the fixed marker.
+  grep -nF -- "$1" | cut -d: -f1
+}
+
+sole_line_of() {
+  # Exactly one match of $2 in the text on stdin, reported as $1.
+  local label=$1
+  local marker=$2
+  local -a hits=()
+  local line
+  while IFS= read -r line; do
+    hits+=("$line")
+  done < <(marker_lines "$marker")
+  if ((${#hits[@]} != 1)); then
+    fail "release-contract marker '${label}' resolved ${#hits[@]} lines (expected exactly 1): ${marker}"
+  fi
+  printf '%s\n' "${hits[0]}"
+}
+
+first_line_of() {
+  # First match of $2 in the text on stdin, reported as $1. Used where the
+  # marker legitimately repeats and the invariant is about the earliest one.
+  local label=$1
+  local marker=$2
+  local -a hits=()
+  local line
+  while IFS= read -r line; do
+    hits+=("$line")
+  done < <(marker_lines "$marker")
+  if ((${#hits[@]} == 0)); then
+    fail "release-contract marker '${label}' resolved no lines: ${marker}"
+  fi
+  printf '%s\n' "${hits[0]}"
+}
+
+sole_file_line() {
+  # Exactly one match of $3 inside the inclusive absolute line range
+  # [${4:-1}, ${5:-end}] of file $2, reported as $1. The range is how a marker
+  # that repeats verbatim in a sibling function still names one occurrence.
+  local label=$1
+  local file=$2
+  local marker=$3
+  local lo=${4:-1}
+  local hi=${5:-0}
+  local -a hits=()
+  local line
+  while IFS= read -r line; do
+    hits+=("$line")
+  done < <(marker_lines "$marker" <"$file" \
+    | awk -v lo="$lo" -v hi="$hi" '$1 >= lo && (hi == 0 || $1 <= hi)')
+  if ((${#hits[@]} != 1)); then
+    fail "release-contract marker '${label}' resolved ${#hits[@]} lines in ${file} within [${lo},${hi:-end}] (expected exactly 1): ${marker}"
+  fi
+  printf '%s\n' "${hits[0]}"
+}
+
+block_end() {
+  # Absolute line of the top-level `}` closing the block that starts at $2.
+  local file=$1
+  local start=$2
+  local line
+  line=$(awk -v s="$start" 'NR > s && $0 == "}" { print NR; exit }' "$file")
+  [[ -n "$line" ]] \
+    || fail "release-contract could not find the end of the block starting at ${file}:${start}"
+  printf '%s\n' "$line"
+}
+
 require_text crates/mold-candle/Cargo.toml \
   'h3-private-uat = []' \
   "mold-candle does not keep the private H3 runtime behind its own feature"
@@ -381,15 +459,18 @@ runner_source=$(awk '
   capture { print }
   capture && /^fn private_run_output/ { exit }
 ' crates/mold-inference/src/minimax_h3/private_server.rs)
-boundary_line=$(grep -nF 'with_private_h3_cuda_execution_attempt(||' <<<"$runner_source" | cut -d: -f1)
-commit_line=$(grep -nF 'commit_private_h3_allocation_then' <<<"$runner_source" | cut -d: -f1)
-device_line=$(grep -nF 'Device::new_cuda' <<<"$runner_source" | cut -d: -f1)
-execute_line=$(grep -nF 'run_private_comfy_fl2va_attempt' <<<"$runner_source" | cut -d: -f1)
-sync_line=$(grep -nF '.synchronize()' <<<"$runner_source" | cut -d: -f1)
-if [[ -z "$boundary_line" || -z "$commit_line" || -z "$device_line" \
-  || -z "$execute_line" || -z "$sync_line" ]] \
-  || (( boundary_line >= commit_line || commit_line >= device_line \
-    || device_line >= execute_line || execute_line >= sync_line )); then
+boundary_line=$(sole_line_of 'runner containment boundary' \
+  'with_private_h3_cuda_execution_attempt(||' <<<"$runner_source")
+commit_line=$(sole_line_of 'runner allocation commit' \
+  'commit_private_h3_allocation_then' <<<"$runner_source")
+device_line=$(sole_line_of 'runner CUDA construction' \
+  'Device::new_cuda' <<<"$runner_source")
+execute_line=$(sole_line_of 'runner FL2VA execution' \
+  'run_private_comfy_fl2va_attempt' <<<"$runner_source")
+sync_line=$(sole_line_of 'runner completion synchronization' \
+  '.synchronize()' <<<"$runner_source")
+if ((boundary_line >= commit_line || commit_line >= device_line \
+  || device_line >= execute_line || execute_line >= sync_line)); then
   fail "private H3 containment, allocation, construction, execution, and completion ordering changed"
 fi
 require_text crates/mold-inference/src/minimax_h3/private_server.rs \
@@ -404,12 +485,11 @@ prepare_source=$(sed -n \
 if grep -Fq 'Device::new_cuda' <<<"$prepare_source"; then
   fail "private H3 preparation constructs a CUDA device before the owner allocation commit"
 fi
-reviewed_line=$(grep -nF 'private_runtime_qualification_source(' \
-  <<<"$prepare_source" | head -n 1 | cut -d: -f1)
-artifact_line=$(grep -nF 'qualify_private_artifacts_with_control' \
-  <<<"$prepare_source" | head -n 1 | cut -d: -f1)
-if [[ -z "$reviewed_line" || -z "$artifact_line" ]] \
-  || (( reviewed_line >= artifact_line )); then
+reviewed_line=$(first_line_of 'prepared reviewed-record gate' \
+  'private_runtime_qualification_source(' <<<"$prepare_source")
+artifact_line=$(first_line_of 'prepared artifact qualification' \
+  'qualify_private_artifacts_with_control' <<<"$prepare_source")
+if ((reviewed_line >= artifact_line)); then
   fail "private H3 reviewed-record hash gate no longer precedes bulk artifact qualification"
 fi
 admission_source=$(sed -n \
@@ -418,12 +498,11 @@ admission_source=$(sed -n \
 if grep -Fq 'Device::new_cuda' <<<"$admission_source"; then
   fail "private H3 admission constructs a CUDA device"
 fi
-admission_reviewed_line=$(grep -nF 'private_runtime_qualification_source(' \
-  <<<"$admission_source" | head -n 1 | cut -d: -f1)
-admission_artifact_line=$(grep -nF 'qualify_private_artifacts_with_control' \
-  <<<"$admission_source" | head -n 1 | cut -d: -f1)
-if [[ -z "$admission_reviewed_line" || -z "$admission_artifact_line" ]] \
-  || (( admission_reviewed_line >= admission_artifact_line )); then
+admission_reviewed_line=$(first_line_of 'admission reviewed-record gate' \
+  'private_runtime_qualification_source(' <<<"$admission_source")
+admission_artifact_line=$(first_line_of 'admission artifact qualification' \
+  'qualify_private_artifacts_with_control' <<<"$admission_source")
+if ((admission_reviewed_line >= admission_artifact_line)); then
   fail "private H3 admission no longer checks reviewed evidence before bulk artifact I/O"
 fi
 require_text crates/mold-inference/src/minimax_h3/private_runtime.rs \
@@ -470,16 +549,18 @@ done
 owner_bind=$(sed -n \
   '/pub(crate) fn bind_private_comfy_fl2va_phase_owner/,/^}/p' \
   crates/mold-inference/src/minimax_h3/private_fl2va_runtime.rs)
-prepared_line=$(grep -nF 'prepared.revalidate()?;' <<<"$owner_bind" | cut -d: -f1)
-qwen_capture_line=$(grep -nF 'H3PrivateQwenArtifactAuthority::capture(&qwen_support, &opened_qwen)?;' \
-  <<<"$owner_bind" | cut -d: -f1)
-overlap_line=$(grep -nF 'validate_prepared_overlap_binding(' <<<"$owner_bind" | cut -d: -f1)
-bind_line=$(grep -nF 'let bound_transformer = bind_private_comfy_stream(' <<<"$owner_bind" | cut -d: -f1)
-attempt_line=$(grep -nF 'let attempt = H3PrivateAttemptAuthority::new' <<<"$owner_bind" | cut -d: -f1)
-if [[ -z "$prepared_line" || -z "$qwen_capture_line" || -z "$overlap_line" \
-  || -z "$bind_line" || -z "$attempt_line" ]] \
-  || (( prepared_line >= qwen_capture_line || qwen_capture_line >= overlap_line \
-    || overlap_line >= bind_line || bind_line >= attempt_line )); then
+prepared_line=$(sole_line_of 'owner prepared revalidation' \
+  'prepared.revalidate()?;' <<<"$owner_bind")
+qwen_capture_line=$(sole_line_of 'owner Qwen artifact capture' \
+  'H3PrivateQwenArtifactAuthority::capture(&qwen_support, &opened_qwen)?;' <<<"$owner_bind")
+overlap_line=$(sole_line_of 'owner overlap binding' \
+  'validate_prepared_overlap_binding(' <<<"$owner_bind")
+bind_line=$(sole_line_of 'owner checkpoint binding' \
+  'let bound_transformer = bind_private_comfy_stream(' <<<"$owner_bind")
+attempt_line=$(sole_line_of 'owner singular attempt' \
+  'let attempt = H3PrivateAttemptAuthority::new' <<<"$owner_bind")
+if ((prepared_line >= qwen_capture_line || qwen_capture_line >= overlap_line \
+  || overlap_line >= bind_line || bind_line >= attempt_line)); then
   fail "private H3 prepared, Qwen, overlap, checkpoint, and singular-attempt binding order changed"
 fi
 if grep -Fq 'load_authorized_from_opened' <<<"$owner_bind"; then
@@ -494,24 +575,62 @@ if [[ $(grep -Fc 'bound_execution.device()' <<<"$owner_bind") -ne 1 ]] \
   fail "private H3 bound execution token is not shared with checkpoint binding and consumed by the attempt"
 fi
 runtime_source=crates/mold-inference/src/minimax_h3/private_fl2va_runtime.rs
-vae_load_line=$(grep -nF 'let loaded = load_h3_comfy_vae_runtime_from_authority(' "$runtime_source" | cut -d: -f1)
-qwen_load_line=$(grep -nF 'let qwen = H3PrivateQwenAdapter::load_authorized_from_opened(' "$runtime_source" | cut -d: -f1)
-vae_park_line=$(grep -nF 'drop(self.vae.take());' "$runtime_source" | head -n 1 | cut -d: -f1)
-transformer_load_line=$(grep -nF 'let stream = load_and_pair_private_comfy_stream(' "$runtime_source" | cut -d: -f1)
-transformer_drop_line=$(grep -nF 'drop(self.denoiser.take());' "$runtime_source" | cut -d: -f1)
-vae_reload_line=$(grep -nF 'self.construct_vaes(reload, checkpoint)?;' "$runtime_source" | cut -d: -f1)
-vae_drop_line=$(grep -nF 'drop(self.vae.take());' "$runtime_source" | tail -n 1 | cut -d: -f1)
-terminal_line=$(grep -nF 'let identity_echo = backend.terminal_identity_echo()?;' "$runtime_source" | cut -d: -f1)
-mux_line=$(grep -nF 'let output = super::pipeline::finalize_av(' "$runtime_source" | cut -d: -f1)
-if [[ -z "$vae_load_line" || -z "$qwen_load_line" || -z "$transformer_load_line" \
-  || -z "$vae_park_line" || -z "$transformer_drop_line" || -z "$vae_reload_line" \
-  || -z "$vae_drop_line" || -z "$terminal_line" || -z "$mux_line" ]] \
-  || (( vae_load_line >= qwen_load_line || qwen_load_line >= vae_park_line \
-    || vae_park_line >= transformer_load_line \
-    || transformer_load_line >= transformer_drop_line \
-    || transformer_drop_line >= vae_reload_line || vae_reload_line >= vae_drop_line \
-    || vae_drop_line >= terminal_line || terminal_line >= mux_line )); then
+# The Ref2VA backend and its attempt are verbatim twins of the FL2VA phase
+# markers, so each anchor is resolved inside the block that identifies the
+# FL2VA occurrence rather than by a whole-file grep. `H3PrivatePhaseBackend`'s
+# inherent impl owns VAE construction; the `H3Fl2VaBackend` impl owns the
+# encode/park/denoise/decode phases; `run_private_comfy_fl2va_attempt` owns the
+# terminal identity echo and the mux.
+phase_impl_line=$(sole_file_line 'phase backend impl' "$runtime_source" \
+  'impl<C, E, A> H3PrivatePhaseBackend<C, E, A>')
+phase_impl_end=$(block_end "$runtime_source" "$phase_impl_line")
+fl2va_impl_line=$(sole_file_line 'FL2VA backend impl' "$runtime_source" \
+  'impl<C, E, A> H3Fl2VaBackend for H3PrivatePhaseBackend<C, E, A>')
+fl2va_impl_end=$(block_end "$runtime_source" "$fl2va_impl_line")
+fl2va_attempt_line=$(sole_file_line 'FL2VA attempt' "$runtime_source" \
+  'pub(crate) fn run_private_comfy_fl2va_attempt<C, E, A>(')
+fl2va_attempt_end=$(block_end "$runtime_source" "$fl2va_attempt_line")
+fl2va_decode_audio_line=$(sole_file_line 'FL2VA audio decode' "$runtime_source" \
+  'fn decode_audio(' "$fl2va_impl_line" "$fl2va_impl_end")
+vae_load_line=$(sole_file_line 'VAE construction' "$runtime_source" \
+  'let loaded = load_h3_comfy_vae_runtime_from_authority(' \
+  "$phase_impl_line" "$phase_impl_end")
+qwen_load_line=$(sole_file_line 'FL2VA Qwen load' "$runtime_source" \
+  'let qwen = H3PrivateQwenAdapter::load_authorized_from_opened(' \
+  "$fl2va_impl_line" "$fl2va_impl_end")
+vae_park_line=$(sole_file_line 'FL2VA VAE park' "$runtime_source" \
+  'drop(self.vae.take());' "$fl2va_impl_line" "$((fl2va_decode_audio_line - 1))")
+transformer_load_line=$(sole_file_line 'FL2VA transformer load' "$runtime_source" \
+  'let stream = load_and_pair_private_comfy_stream(' "$fl2va_impl_line" "$fl2va_impl_end")
+transformer_drop_line=$(sole_file_line 'FL2VA transformer drop' "$runtime_source" \
+  'drop(self.denoiser.take());' "$fl2va_impl_line" "$fl2va_impl_end")
+vae_reload_line=$(sole_file_line 'FL2VA VAE reload' "$runtime_source" \
+  'self.construct_vaes(reload, checkpoint)?;' "$fl2va_impl_line" "$fl2va_impl_end")
+vae_drop_line=$(sole_file_line 'FL2VA VAE drop' "$runtime_source" \
+  'drop(self.vae.take());' "$fl2va_decode_audio_line" "$fl2va_impl_end")
+terminal_line=$(sole_file_line 'FL2VA terminal identity echo' "$runtime_source" \
+  'let identity_echo = backend.terminal_identity_echo()?;' \
+  "$fl2va_attempt_line" "$fl2va_attempt_end")
+mux_line=$(sole_file_line 'FL2VA AV mux' "$runtime_source" \
+  'let output = super::pipeline::finalize_av(' "$fl2va_attempt_line" "$fl2va_attempt_end")
+if ((vae_load_line >= qwen_load_line || qwen_load_line >= vae_park_line \
+  || vae_park_line >= transformer_load_line \
+  || transformer_load_line >= transformer_drop_line \
+  || transformer_drop_line >= vae_reload_line || vae_reload_line >= vae_drop_line \
+  || vae_drop_line >= terminal_line || terminal_line >= mux_line)); then
   fail "private H3 phase runtime no longer parks, reloads, and drops components before terminal-only mux"
+fi
+# The developer-only Ref2VA attempt owns the same terminal-before-mux rule.
+ref2va_attempt_line=$(sole_file_line 'Ref2VA attempt' "$runtime_source" \
+  'pub(crate) fn run_private_comfy_ref2va_attempt<C, E, A>(')
+ref2va_attempt_end=$(block_end "$runtime_source" "$ref2va_attempt_line")
+ref2va_terminal_line=$(sole_file_line 'Ref2VA terminal identity echo' "$runtime_source" \
+  'let identity_echo = backend.terminal_identity_echo()?;' \
+  "$ref2va_attempt_line" "$ref2va_attempt_end")
+ref2va_mux_line=$(sole_file_line 'Ref2VA AV mux' "$runtime_source" \
+  'let output = super::pipeline::finalize_av(' "$ref2va_attempt_line" "$ref2va_attempt_end")
+if ((ref2va_terminal_line >= ref2va_mux_line)); then
+  fail "private H3 Ref2VA attempt no longer captures its terminal identity before the mux"
 fi
 require_text "$runtime_source" \
   'pub(crate) struct H3PrivatePhaseIdentityEcho {' \


### PR DESCRIPTION
Fixes #1204. Fixes #1207.

Both defects were in the tests and the check script. No production behavior changed: `matches_private_run_binding`, `validate_h3_prepared_attempt_facts`, and the `HostMemoryRecheck` gate are untouched.

## #1204 — 10 `claimed_h3_*` / `claimed_ref2va_*` failures

Two stacked causes, both in the test doubles.

1. **Constant run binding.** `fake_h3_facts` hard-coded `work_identity_sha256: identity('2')` / `cancellation_scope_identity_sha256: identity('3')`. The real prepared attempt echoes what the owner scope *derived* from its claim, and `matches_private_run_binding` re-derives and compares. The fence was right to refuse a constant.
2. **Unanswered host-memory recheck**, exposed once the first was fixed — 9 of 10 still failed. `run_claimed_h3_generation` blocks on `WorkerEvent::HostMemoryRecheck`; the test scheduler stand-in never answered, so every job died on `"host-memory recheck did not complete: timed out waiting on channel"`. That recheck is the #1099 host-RAM ledger discipline and is load-bearing.

The fixtures now derive the binding from the same claim the attempt is built from (extracted so the two cannot drift), and the fake scheduler answers the recheck while forwarding every other worker event untouched — so the existing event-stream assertions still see exactly what the worker emitted. A new test, `the_owner_scope_accepts_only_its_own_derived_private_run_binding`, pins that the scope accepts only its derived binding and rejects a constant on each of the three axes independently.

The only change outside `#[cfg(test)]` is widening two pure digest helpers from `any(feature = "h3", ...)` to `any(test, ...)`.

## #1207 — release contract printed PASS while its check was disarmed

The VAE-drop → terminal-identity → mux markers also matched the Ref2VA twins, so the resolved line numbers were multi-line values. `(( ))` treats that as a syntax error and returns non-zero, which `if [[ ... ]] || (( ... ))` reads as "ordering fine": stderr noise, exit 0, `PASS`. Separately `vae_drop_line`'s `tail -n 1` had drifted off FL2VA's `decode_audio` onto Ref2VA's `park_reference_components`.

Every marker now resolves through helpers that fail by name on zero or several matches, anchored to the block identifying the FL2VA occurrence; Ref2VA gets its own terminal-before-mux check.

Proof the gate bites (perturbations applied, then reverted):

| Perturbation | Before | After |
| --- | --- | --- |
| Swap terminal echo / mux in the FL2VA attempt | `exit=0` **PASS** | `exit=1` `FAIL: ...before terminal-only mux` |
| Duplicate `drop(self.vae.take());` in `decode_audio` | — | `exit=1` `FAIL: marker 'FL2VA VAE drop' resolved 2 lines` |
| Rename `fn decode_audio` | — | `exit=1` `FAIL: marker 'FL2VA audio decode' resolved 0 lines` |

## Gates

```
cargo test -p mold-ai-server --features h3-private-uat --lib -- --test-threads=1 claimed_
test result: ok. 20 passed; 0 failed        (baseline on main: 10 passed; 10 failed)

cargo test -p mold-ai-server --lib -- --test-threads=1 claimed_ h3_attempt::
test result: ok. 31 passed; 0 failed        (default features, checks the #[cfg] widening)

cargo clippy -p mold-ai-server --features h3-private-uat --lib -- -D warnings    exit=0
cargo fmt --all -- --check                                                       exit=0
bash scripts/tests/minimax-h3-private-uat-release-contract.sh                     PASS
```

Codex reviewed the branch; its only finding was against a CI step I had added, which is dropped from this PR — see below.

## Not in this PR

**CI still does not run these tests.** Nothing executes `cargo test -p mold-ai-server --features h3-private-uat`; clippy compiles that combination but no step runs it, which is why ten tests guarding commit-exactly-once, quarantine-without-partial-publication, and ordered Ref2VA durability sat red. Simply adding the step breaks every Rust-affecting PR: `h3-private-uat` enables `cuda`, and 9 of these tests reach `CudaContext::new`, so a CPU-only runner gives `11 passed; 9 failed`. Filed as #1271 with the measurement and the options.

Two other markers use `head -n 1` where they legitimately repeat; those are hardened against zero matches rather than forced to exactly one.
