### PR TITLE
docs(pulid): record the q8 and Metal UAT follow-up

### DIFF
--- a/docs/architecture/pulid-uat.md
+++ b/docs/architecture/pulid-uat.md
@@ -301,3 +301,176 @@ and repeating checks 3 and 4.
 - Krea, block offload, LoRA, and img2img alongside an identity. All are refused
   by the request contract in milestone 1 and belong to a milestone-2
   qualification pass.
+
+## Follow-up UAT (q8 / Metal)
+
+The two checks #1223 deferred, run against `main` at `90d68ef5` (the merged
+#1270; the branch recording this sits on `cf116aff`, a docs-only commit that
+changes no identity code). Same method as above: the tree rsynced to
+`/home/jamesbrink/mold-1223` on plato, built there inside the Nix devshell with
+`cargo build --release -p mold-ai --features cuda,pulid`, and the scratch build
+deleted afterwards. Outputs are at `/Volumes/ExternalStorage/pulid-dev/uat/`
+under `q8-` names.
+
+| # | Check | Host | Tier | Result |
+| --- | --- | --- | --- | --- |
+| 12 | Zero-weight byte identity (three-way SHA) | plato | q8 | **PASS** — A == B, C differs |
+| 13 | Positive identity render, forced-local (Frank Rubio) | plato | q8 | **PASS** — ArcFace cosine **0.5993** |
+| 14 | Positive identity render, second face (Kayla Barron) | plato | q8 | **PASS** — ArcFace cosine **0.7241** |
+| 15 | Identity refused by a server built without `pulid` | plato | q8 | **PASS** — HTTP 422, surfaced verbatim, nothing rendered |
+| 16 | Remote render over HTTP against this build | plato | q8 | **PASS** — byte-identical to the forced-local render |
+| 17 | `supports_identity` advertised for exactly the qualified tiers | plato | — | **PASS** — `['flux-dev:q4', 'flux-dev:q8']`, and `false` for all 125 on the non-`pulid` server |
+| 18 | Metal path | halcyon | — | **NOT RUN** — `flux-dev:q4` needs a gated Hugging Face repo and no token exists on this machine |
+
+## 12. Zero-weight byte identity on q8
+
+The same three-way check as #3, on `flux-dev:q8`: seed 42, the beach prompt,
+1024x1024, 25 steps, `--no-metadata` (see #3 for why the metadata chunk has to
+be excluded — B correctly records that a photograph was supplied at weight 0).
+
+| Run | Flags | SHA-256 |
+| --- | --- | --- |
+| A | none | `0a92b67c8d9be30038d74f32e7a2cf4f2d43678607d4506690c78058d5e31952` |
+| B | `--id-image … --id-weight 0.0` | `0a92b67c8d9be30038d74f32e7a2cf4f2d43678607d4506690c78058d5e31952` |
+| C | `--id-image … --id-weight 1.0` | `c194a5671a33e21d468cca984465208c184b3031a6a97a7da27f585e267688c5` |
+
+**A == B, C differs.** Files: `q8-nometa-{A,B,C}.png`.
+
+The wall clocks say the same thing independently: A and B both reported
+`✓ Done — flux-dev:q8 in 73.6s`, to the tenth of a second, while C took 75.0s.
+Weight zero did not merely produce the same pixels — it did not do the work.
+
+## 13 and 14. Fidelity on q8
+
+Prompt, seed, and flags exactly as #4: the close-up portrait prompt, seed 7,
+1024x1024, 25 steps, `--id-weight 1.0`, default `--id-start-step`.
+
+| Run | Output | SHA-256 | Cosine |
+| --- | --- | --- | --- |
+| baseline (no identity) | `q8-portrait-baseline.png` | `cc1b26ba068996f8980f8b8604b58db4b8669ee4ae323a918167542cd6350d23` | — |
+| identity (Frank Rubio) | `q8-portrait-id-frank-rubio.png` | `200e0645dbb1a128f7b09afecc5c3aef4686e3e90c3fc307fd0d5effc51864c0` | **0.5993** |
+| identity (Kayla Barron) | `q8-portrait-id-kayla-barron.png` | `11b7dd8cfacb0e0af2c12f43b2966521120afb7fbeefd4bdef08d892919964a6` | **0.7241** |
+
+Measured with `crates/mold-inference/tests/pulid_identity_fidelity.rs` against
+the same `glintr100` graph the conditioning used, with
+`MOLD_TEST_PULID_ASSETS=/storage/mold/models/shared/pulid`:
+
+```
+PASS  cosine 0.5993  (threshold 0.28)  q8-portrait-id-frank-rubio.png
+PASS  cosine 0.7241  (threshold 0.28)  q8-portrait-id-kayla-barron.png
+```
+
+Both land in PuLID's own 0.6-0.8 band, and both sit within 0.03 of the q4
+numbers (0.6055 / 0.7016), in opposite directions — which is the expected
+result for a change that only alters the transformer's quantization. The
+adapter does not read it.
+
+The seed-matched unconditioned baseline was scored as a control and SCRFD found
+**no face in it at all** — the same outcome the q4 baseline produced at this
+seed, and the reason a *conditioned* render is the one being measured:
+
+```
+no face in q8-portrait-baseline.png: no face was detected in the identity image
+```
+
+## 15. A server without `pulid` refuses, and never accepts-and-ignores
+
+plato's long-running production server on `:7680` is an ordinary 0.23.3 build
+with no `pulid` feature. The identity request went to it as raw HTTP, so the
+server's own words are on the record:
+
+```console
+$ curl -X POST http://127.0.0.1:7680/api/generate -d '{… "id_image": "…", "id_weight": 1.0}'
+HTTP 422
+{"error":"this server was built without PuLID face-identity support; remove id_image (and any id_weight, id_start_step, or id_image_name) or use a server built with the `pulid` feature","code":"VALIDATION_ERROR"}
+```
+
+and through the CLI, which surfaces it verbatim and exits non-zero without
+rendering anything:
+
+```console
+$ MOLD_HOST=http://127.0.0.1:7680 mold run flux-dev:q8 "<the portrait prompt>" \
+    --seed 7 --id-image frank-rubio-official-portrait.jpg --id-weight 1.0
+error: this server was built without PuLID face-identity support; remove id_image …
+--- exit=1
+```
+
+**Use `127.0.0.1`, not the host's own Tailscale address, when the client runs on
+the server.** The first attempt used `http://100.105.134.43:7680` from plato
+itself, which does not hairpin — `curl` returns `000` from plato while the same
+URL is fine from another machine. `classify_generate_error` reads a connection
+failure as `FallbackLocal`, so `mold run` quietly rendered on the local GPU and
+printed `Using local GPU inference`. That is the documented remote-to-local
+fallback behaving correctly on an unreachable host, not identity being ignored —
+but in a log it looks exactly like an accept-and-ignore, so anyone repeating
+this check should confirm the host is reachable before reading the result.
+
+## 16. Remote render over HTTP
+
+This build was served on a second port with its own `MOLD_HOME`. The production
+`/storage/mold/output` is owned by the `mold` user, and a scratch server running
+as a different user cannot take the gallery batch-authority lock there — it
+exits with `Permission denied` on `.mold-batch-parent-*.lock`:
+
+```bash
+MOLD_HOME=/home/jamesbrink/uat-q8-home \
+MOLD_MODELS_DIR=/storage/mold/models MOLD_OUTPUT_DIR=$MOLD_HOME/output \
+MOLD_API_KEY=uat-1223 mold serve --bind 127.0.0.1 --port 7681
+```
+
+| Path | Output | SHA-256 |
+| --- | --- | --- |
+| forced-local (`--local`) | `q8-portrait-id-frank-rubio.png` | `200e0645dbb1a128f7b09afecc5c3aef4686e3e90c3fc307fd0d5effc51864c0` |
+| remote (HTTP + SSE) | `q8-remote-id-frank-rubio.png` | `200e0645dbb1a128f7b09afecc5c3aef4686e3e90c3fc307fd0d5effc51864c0` |
+
+**Byte-identical**, exactly as on q4.
+
+## 17. `supports_identity` per build
+
+The same 125-model listing, from two builds' `/api/models`:
+
+| Server | `supports_identity == true` |
+| --- | --- |
+| `:7681`, this build (`cuda,pulid`) | `['flux-dev:q4', 'flux-dev:q8']` |
+| `:7680`, stock 0.23.3 (no `pulid`) | none — all 125 report `false` |
+
+The field is present on both, so a client that reads it (rather than guessing
+from a version) gets the right answer from either. On the `pulid` build both
+qualified tiers report `downloaded: true` and the two unqualified `flux-dev`
+tiers report `false`, so the capability tracks the checkpoint and not the
+install state.
+
+## 18. Metal (halcyon) — still not run
+
+Unchanged from the [Metal](#metal-halcyon) section above, and re-checked rather
+than assumed. The disk objection has since cleared (167 GB free on the external
+volume at the time of this run), so the **only** remaining blocker is the token:
+
+```console
+$ echo "$HF_TOKEN" "$HUGGING_FACE_HUB_TOKEN"          # both empty
+$ ls ~/.cache/huggingface/token                        # No such file or directory
+$ ls $MOLD_HOME/catalog-credentials.json ~/.mold/catalog-credentials.json
+                                                       # No such file or directory
+$ MOLD_HOME=/Volumes/ExternalStorage/mold2 mold config list | grep -i hf
+                                                       # nothing
+```
+
+And the reason a token is required is now recorded concretely rather than
+inferred. `flux-dev:q4`'s own transformer is ungated (`city96/FLUX.1-dev-gguf`),
+but `shared_flux_files()` in `crates/mold-core/src/manifest.rs` takes the VAE
+from a BFL repo that is not — `ae.safetensors`, `gated: true`:
+
+```console
+$ curl -sI https://huggingface.co/black-forest-labs/FLUX.1-schnell/resolve/main/ae.safetensors
+HTTP/2 401
+x-error-code: GatedRepo
+x-error-message: Access to model black-forest-labs/FLUX.1-schnell is restricted. …
+```
+
+So no FLUX tier is obtainable on this machine without a Hugging Face account
+that has accepted BFL's terms. The gap is therefore unchanged, and unchanged in
+kind: the adapter's twenty cross-attention injections and the Metal VRAM
+accounting for them are still unverified on Apple Silicon, while the CPU
+extraction half continues to run there (it is what scored the cosines in #1222).
+Closing it needs a token on a Metal host and nothing more — the commands are
+#12 and #13 above with `--width 512 --height 512`.


### PR DESCRIPTION
Follow-up to #1270 / #1223: appends the `flux-dev:q8` UAT on plato (checks 12–17, all PASS) and the Metal status (not run — `flux-dev:q4`'s VAE comes from a gated repo and halcyon has no HF token) to `docs/architecture/pulid-uat.md`.

Highlights: three-way zero-weight SHA identity holds on q8 (A == B, C differs); ArcFace cosine 0.5993 / 0.7241 vs the q4 0.6055 / 0.7016; remote render byte-identical to forced-local; non-`pulid` server refuses with HTTP 422 and advertises `supports_identity` for exactly `flux-dev:q4` / `:q8`. Also records two traps for the next UAT run (a host that does not hairpin its own Tailscale address silently falls back to local inference; a scratch server cannot share the production `MOLD_HOME`).

Docs only.