### PR TITLE
feat(library): hide collection members from prints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,6 +229,8 @@ Sequence mode on web, desktop, and iPhone filters the picker to chain-capable in
 
 ## Key design decisions
 
+**Hidden collections invariant:** A collection's additive `hidden` flag fans out to every host copy. Hidden collections stay visible and openable in Collections, but their member prints are excluded from the default Prints grid and every text-search result on web, desktop, iPhone, and Android; collection drill-in always reveals them.
+
 1. **Crate boundaries are clean** — `mold-cli` doesn't depend on candle; `mold-server` doesn't depend on clap; `mold-discord` only depends on `mold-core`.
 2. **candle over tch/ort** — pure Rust, no libtorch. Mold keeps upstream Candle's official crate names so the ecosystem shares one `Tensor` type. Application-owned models and public-API extensions live in `mold-ai-candle`; the narrow same-name `[patch.crates-io]` compatibility branch contains only backend changes that cannot be implemented outside Candle and is removed patch-by-patch as upstream accepts them.
 3. **Single binary** — `mold` includes `serve` via `mold-server` library; GPU flags forward `mold-cli` → `mold-server` → `mold-inference`.

--- a/changelog.d/hidden-library-collections.md
+++ b/changelog.d/hidden-library-collections.md
@@ -1,0 +1,1 @@
+- **Hide collections from Prints.** Web, desktop, iPhone, and Android can hide a collection's members from the default Library and search while keeping the collection available to browse or show again.

--- a/crates/mold-core/src/types.rs
+++ b/crates/mold-core/src/types.rs
@@ -7343,6 +7343,9 @@ pub struct Collection {
     /// the newest member.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cover_filename: Option<String>,
+    /// Whether members are omitted from the default Library grid and search.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub hidden: bool,
     /// Number of prints in the collection (trashed members included; they
     /// keep their membership until purged).
     pub count: u64,
@@ -7436,6 +7439,9 @@ pub struct CollectionUpdateRequest {
     pub description: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cover_filename: Option<String>,
+    /// Hide/show this collection's members in the default Library and search.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hidden: Option<bool>,
 }
 
 /// Body of `PUT /api/gallery/collections/:id/items` — gallery filenames to
@@ -9165,12 +9171,14 @@ mod server_event_tests {
             slug: "smurfs".into(),
             description: None,
             cover_filename: Some("cat.png".into()),
+            hidden: false,
             count: 3,
             created_at: 1_700_000_000,
             updated_at: 1_700_000_050,
         };
         let wire = serde_json::to_value(&collection).unwrap();
         assert!(wire.get("description").is_none());
+        assert!(wire.get("hidden").is_none());
         assert_eq!(wire["cover_filename"], "cat.png");
         let back: Collection = serde_json::from_value(wire).unwrap();
         assert_eq!(back, collection);

--- a/crates/mold-db/src/migrations.rs
+++ b/crates/mold-db/src/migrations.rs
@@ -511,6 +511,12 @@ CREATE TABLE collection_items (
 CREATE INDEX IF NOT EXISTS idx_collection_items_generation ON collection_items(generation_id);
 "#;
 
+/// Hidden collections stay visible on the Collections shelf, but clients omit
+/// their members from the default Library grid and its search results.
+const V21_HIDDEN_COLLECTIONS: &str = r#"
+ALTER TABLE collections ADD COLUMN hidden INTEGER NOT NULL DEFAULT 0;
+"#;
+
 /// Ordered list of schema migrations. Version numbers must be strictly
 /// increasing — [`apply_pending`] validates this at startup.
 pub(crate) const MIGRATIONS: &[Migration] = &[
@@ -594,11 +600,15 @@ pub(crate) const MIGRATIONS: &[Migration] = &[
         version: 20,
         kind: MigrationKind::Sql(V20_LIBRARY_ORGANIZATION),
     },
+    Migration {
+        version: 21,
+        kind: MigrationKind::Sql(V21_HIDDEN_COLLECTIONS),
+    },
 ];
 
 /// The highest migration version this build ships. Exposed publicly so
 /// operators / tests can assert what schema level they're running against.
-pub const SCHEMA_VERSION: i64 = 20;
+pub const SCHEMA_VERSION: i64 = 21;
 
 /// v1 → v2: rewrite every `output_dir` value to its canonical form so
 /// rows written by the v0.8.x release (which keyed on raw paths) keep
@@ -974,7 +984,7 @@ mod tests {
             SCHEMA_VERSION,
             "fresh DB must end at the latest SCHEMA_VERSION",
         );
-        assert_eq!(SCHEMA_VERSION, 20);
+        assert_eq!(SCHEMA_VERSION, 21);
         assert!(table_exists(&conn, "device_preferences"));
         assert_eq!(
             column_names(&conn, "device_preferences"),
@@ -1127,8 +1137,8 @@ mod tests {
 
         apply_pending(&mut conn).unwrap();
 
-        assert_eq!(current_version(&conn).unwrap(), 20);
-        assert_eq!(SCHEMA_VERSION, 20);
+        assert_eq!(current_version(&conn).unwrap(), 21);
+        assert_eq!(SCHEMA_VERSION, 21);
         assert!(table_exists(&conn, "generation_queue"));
         let columns = column_names(&conn, "generation_queue");
         for expected in [
@@ -1163,9 +1173,8 @@ mod tests {
         assert_eq!(kept, 1, "the upgrade must not disturb existing rows");
     }
 
-    /// v20: a v19 database gains the organization columns, side tables, and
-    /// indexes while every existing gallery row survives with the
-    /// user-owned columns at their neutral defaults.
+    /// v20/v21: a v19 database gains organization plus hidden collections
+    /// while every existing gallery row survives at neutral defaults.
     #[test]
     fn v20_upgrade_adds_library_organization_and_preserves_existing_rows() {
         let mut conn = Connection::open_in_memory().unwrap();
@@ -1192,8 +1201,8 @@ mod tests {
 
         apply_pending(&mut conn).unwrap();
 
-        assert_eq!(current_version(&conn).unwrap(), 20);
-        assert_eq!(SCHEMA_VERSION, 20);
+        assert_eq!(current_version(&conn).unwrap(), 21);
+        assert_eq!(SCHEMA_VERSION, 21);
         let columns = column_names(&conn, "generations");
         for expected in ["title", "favorite", "trashed_at_ms"] {
             assert!(
@@ -1204,6 +1213,8 @@ mod tests {
         for table in ["tags", "generation_tags", "collections", "collection_items"] {
             assert!(table_exists(&conn, table), "missing table {table}");
         }
+        let collection_columns = column_names(&conn, "collections");
+        assert!(collection_columns.iter().any(|column| column == "hidden"));
         for index in [
             "idx_gen_trashed",
             "idx_gen_favorite",
@@ -1452,7 +1463,7 @@ mod v9_tests {
 
     #[test]
     fn schema_version_is_current() {
-        assert_eq!(SCHEMA_VERSION, 20);
+        assert_eq!(SCHEMA_VERSION, 21);
     }
 
     #[test]

--- a/crates/mold-db/src/organization.rs
+++ b/crates/mold-db/src/organization.rs
@@ -85,6 +85,8 @@ pub struct CollectionRow {
     pub slug: String,
     pub description: Option<String>,
     pub cover_filename: Option<String>,
+    /// Whether members are omitted from the default Library grid and search.
+    pub hidden: bool,
     /// Number of prints in the collection.
     pub count: u64,
     pub created_at_ms: i64,
@@ -456,7 +458,7 @@ fn touch_collection(conn: &Connection, collection_id: &str, now_ms: i64) -> OrgR
 fn read_collection(conn: &Connection, id: &str) -> OrgResult<Option<CollectionRow>> {
     Ok(conn
         .query_row(
-            "SELECT c.id, c.name, c.slug, c.description, c.cover_filename,
+            "SELECT c.id, c.name, c.slug, c.description, c.cover_filename, c.hidden,
                     (SELECT COUNT(*) FROM collection_items ci WHERE ci.collection_id = c.id),
                     c.created_at_ms, c.updated_at_ms
              FROM collections c WHERE c.id = ?1",
@@ -473,9 +475,10 @@ fn collection_from_row(r: &rusqlite::Row<'_>) -> rusqlite::Result<CollectionRow>
         slug: r.get(2)?,
         description: r.get(3)?,
         cover_filename: r.get(4)?,
-        count: r.get::<_, i64>(5)?.max(0) as u64,
-        created_at_ms: r.get(6)?,
-        updated_at_ms: r.get(7)?,
+        hidden: r.get::<_, i64>(5)? != 0,
+        count: r.get::<_, i64>(6)?.max(0) as u64,
+        created_at_ms: r.get(7)?,
+        updated_at_ms: r.get(8)?,
     })
 }
 
@@ -836,7 +839,7 @@ impl MetadataDb {
     pub fn list_collections(&self) -> OrgResult<Vec<CollectionRow>> {
         self.with_conn_typed(|conn| {
             let mut stmt = conn.prepare(
-                "SELECT c.id, c.name, c.slug, c.description, c.cover_filename,
+                "SELECT c.id, c.name, c.slug, c.description, c.cover_filename, c.hidden,
                         (SELECT COUNT(*) FROM collection_items ci WHERE ci.collection_id = c.id),
                         c.created_at_ms, c.updated_at_ms
                  FROM collections c
@@ -862,6 +865,7 @@ impl MetadataDb {
         name: Option<&str>,
         description: Option<&str>,
         cover_filename: Option<&str>,
+        hidden: Option<bool>,
     ) -> OrgResult<CollectionRow> {
         let renamed = name.map(validate_collection_name).transpose()?;
         let description = description.map(|d| normalize_title(Some(d)));
@@ -908,6 +912,12 @@ impl MetadataDb {
                 conn.execute(
                     "UPDATE collections SET cover_filename = ?2 WHERE id = ?1",
                     params![id, cover],
+                )?;
+            }
+            if let Some(hidden) = hidden {
+                conn.execute(
+                    "UPDATE collections SET hidden = ?2 WHERE id = ?1",
+                    params![id, hidden],
                 )?;
             }
             touch_collection(conn, id, now)?;
@@ -1297,23 +1307,29 @@ mod tests {
 
         let other = db.create_collection("Day Owls", None).unwrap();
         assert!(matches!(
-            db.update_collection(&other.id, Some("NIGHT-OWLS"), None, None),
+            db.update_collection(&other.id, Some("NIGHT-OWLS"), None, None, None),
             Err(OrganizationError::Conflict(_))
         ));
         // Renaming to a different casing of itself is fine.
         let renamed = db
-            .update_collection(&c.id, Some("NIGHT OWLS"), Some(""), None)
+            .update_collection(&c.id, Some("NIGHT OWLS"), Some(""), None, None)
             .unwrap();
         assert_eq!(renamed.name, "NIGHT OWLS");
         assert_eq!(renamed.slug, "night-owls");
         assert_eq!(renamed.description, None);
+
+        let hidden = db
+            .update_collection(&c.id, None, None, None, Some(true))
+            .unwrap();
+        assert!(hidden.hidden);
+        assert!(db.get_collection(&c.id).unwrap().unwrap().hidden);
 
         assert_eq!(db.list_collections().unwrap().len(), 2);
         assert!(db.delete_collection(&other.id).unwrap());
         assert!(!db.delete_collection(&other.id).unwrap());
         assert!(db.get_collection(&other.id).unwrap().is_none());
         assert!(matches!(
-            db.update_collection(&other.id, Some("x"), None, None),
+            db.update_collection(&other.id, Some("x"), None, None, None),
             Err(OrganizationError::NotFound)
         ));
     }
@@ -1351,11 +1367,11 @@ mod tests {
 
         // Cover must be a member; removing the cover clears it.
         assert!(matches!(
-            db.update_collection(&c.id, None, None, Some("nope.png")),
+            db.update_collection(&c.id, None, None, Some("nope.png"), None),
             Err(OrganizationError::Invalid(_))
         ));
         let with_cover = db
-            .update_collection(&c.id, None, None, Some("a.png"))
+            .update_collection(&c.id, None, None, Some("a.png"), None)
             .unwrap();
         assert_eq!(with_cover.cover_filename.as_deref(), Some("a.png"));
         assert_eq!(

--- a/crates/mold-server/src/gallery_organization.rs
+++ b/crates/mold-server/src/gallery_organization.rs
@@ -180,6 +180,7 @@ fn collection_to_wire(row: CollectionRow) -> Collection {
         slug: row.slug,
         description: row.description,
         cover_filename: row.cover_filename,
+        hidden: row.hidden,
         count: row.count,
         created_at: (row.created_at_ms / 1000).max(0) as u64,
         updated_at: (row.updated_at_ms / 1000).max(0) as u64,
@@ -498,6 +499,7 @@ pub(crate) async fn update_collection(
                 request.name.as_deref(),
                 request.description.as_deref(),
                 request.cover_filename.as_deref(),
+                request.hidden,
             )
             .map_err(map_org_error)
     })

--- a/crates/mold-server/src/routes_test.rs
+++ b/crates/mold-server/src/routes_test.rs
@@ -12597,6 +12597,7 @@ mod tests {
         assert_eq!(created["slug"], "smurf-village");
         assert_eq!(created["description"], "blue");
         assert_eq!(created["count"], 0);
+        assert!(created.get("hidden").is_none());
         assert!(matches!(
             events.try_recv().unwrap(),
             mold_core::ServerEvent::GalleryCollectionsChanged {}
@@ -12672,13 +12673,13 @@ mod tests {
         assert_eq!(detail["collection"]["id"], id);
         assert_eq!(detail["filenames"], serde_json::json!(["b.png"]));
 
-        // Rename + cover.
+        // Rename + cover + hide from the default Library.
         let resp = app
             .clone()
             .oneshot(json_request(
                 "PATCH",
                 &format!("/api/gallery/collections/{id}"),
-                serde_json::json!({"name": "Gargamel", "cover_filename": "b.png"}),
+                serde_json::json!({"name": "Gargamel", "cover_filename": "b.png", "hidden": true}),
             ))
             .await
             .unwrap();
@@ -12686,6 +12687,7 @@ mod tests {
         let updated = json_body(resp).await;
         assert_eq!(updated["slug"], "gargamel");
         assert_eq!(updated["cover_filename"], "b.png");
+        assert_eq!(updated["hidden"], true);
         // A cover that is not a member → 422.
         let resp = app
             .clone()
@@ -12702,6 +12704,7 @@ mod tests {
         let listed = gallery_rows(&app, "/api/gallery/collections").await;
         assert_eq!(listed.len(), 1);
         assert_eq!(listed[0]["name"], "Gargamel");
+        assert_eq!(listed[0]["hidden"], true);
         let rows = gallery_rows(&app, "/api/gallery").await;
         let b = rows.iter().find(|r| r["filename"] == "b.png").unwrap();
         assert_eq!(b["collections"], serde_json::json!([id]));

--- a/desktop/src/components/library/CollectionCard.vue
+++ b/desktop/src/components/library/CollectionCard.vue
@@ -31,6 +31,7 @@ const props = withDefaults(
     updatedAt?: number | null;
     /** Up to four cover thumbnails, set cover first. */
     covers: readonly CoverTile[];
+    hidden?: boolean;
     /** Optional clock for deterministic tests. */
     nowMs?: number | undefined;
   }>(),
@@ -84,6 +85,12 @@ const mosaic = computed(() => props.covers.slice(0, 4));
     </span>
     <span class="font-display text-[15px] font-semibold text-ink" data-test="collection-name">
       {{ name }}
+      <span
+        v-if="hidden"
+        class="ml-1.5 font-utility text-[9.5px] font-medium uppercase text-ink-3"
+        data-test="collection-hidden-badge"
+        >Hidden</span
+      >
     </span>
     <span class="font-utility text-[10.5px] text-ink-3" data-test="collection-meta">{{
       meta

--- a/desktop/src/components/library/CollectionsShelf.test.ts
+++ b/desktop/src/components/library/CollectionsShelf.test.ts
@@ -25,6 +25,7 @@ const cards: ShelfCard[] = [
       { path: "/api/gallery/thumbnail/d.png", target: null, cacheKey: "plato" },
       { path: "/api/gallery/thumbnail/e.png", target: null, cacheKey: "plato" },
     ],
+    hidden: true,
   },
   {
     slug: "river-studies",
@@ -33,6 +34,7 @@ const cards: ShelfCard[] = [
     hostLabels: ["This Mac"],
     updatedAt: null,
     covers: [],
+    hidden: false,
   },
 ];
 
@@ -44,7 +46,8 @@ describe("CollectionCard", () => {
     });
     expect(wrapper.findAll("img")).toHaveLength(4);
     expect(wrapper.get("[data-test='collection-mosaic']").classes()).toContain("grid-cols-2");
-    expect(wrapper.get("[data-test='collection-name']").text()).toBe("Smurfs");
+    expect(wrapper.get("[data-test='collection-name']").text()).toContain("Smurfs");
+    expect(wrapper.get("[data-test='collection-hidden-badge']").text()).toBe("Hidden");
     const meta = wrapper.get("[data-test='collection-meta']");
     expect(meta.text()).toBe("9 prints · This Mac · plato");
     expect(meta.classes()).toContain("font-utility");

--- a/desktop/src/components/library/CollectionsShelf.vue
+++ b/desktop/src/components/library/CollectionsShelf.vue
@@ -17,6 +17,7 @@ export interface ShelfCard {
   hostLabels: string[];
   updatedAt: number | null;
   covers: CoverTile[];
+  hidden: boolean;
 }
 
 withDefaults(
@@ -76,6 +77,7 @@ defineExpose({ startCreate, isCreating: () => creating.value });
       :host-labels="card.hostLabels"
       :updated-at="card.updatedAt"
       :covers="card.covers"
+      :hidden="card.hidden"
       :now-ms="nowMs"
       :data-slug="card.slug"
       @open="emit('open', card.slug)"

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -9054,14 +9054,27 @@ describe("MobileApp Library organization", () => {
     trashed_at: nowSecs - 86_400,
     purge_at: nowSecs + 3 * 86_400,
   });
+  let libraryCollectionHidden = false;
 
   function installLibraryApi(): void {
+    libraryCollectionHidden = false;
     apiJsonTo.mockImplementation((_target: unknown, path: string, init?: RequestInit) => {
       if (path === "/api/status") return Promise.resolve(status);
       if (path === "/api/models") return Promise.resolve([model]);
       if (path === "/api/capabilities") return Promise.resolve(organizedCapabilities);
       if (path === "/api/gallery") return Promise.resolve([favoritePrint, plainPrint]);
       if (path === "/api/gallery?view=trash") return Promise.resolve([trashedPrint]);
+      if (path.startsWith("/api/gallery/collections/") && init?.method === "PATCH") {
+        const body = JSON.parse(String(init.body)) as { hidden?: boolean };
+        libraryCollectionHidden = body.hidden === true;
+        return Promise.resolve({
+          id: "c1",
+          name: "Portraits",
+          slug: "portraits",
+          count: 1,
+          hidden: libraryCollectionHidden,
+        });
+      }
       if (path === "/api/gallery/collections") {
         return Promise.resolve([
           {
@@ -9073,6 +9086,7 @@ describe("MobileApp Library organization", () => {
             count: 1,
             created_at: 1,
             updated_at: 1,
+            hidden: libraryCollectionHidden,
           },
         ]);
       }
@@ -9193,6 +9207,28 @@ describe("MobileApp Library organization", () => {
     await wrapper?.get("[data-test='mobile-collection-back']").trigger("click");
     await flushPromises();
     expect(wrapper?.find("[data-test='mobile-collection-list']").exists()).toBe(true);
+  });
+
+  it("offers Hide from Library from a collection card on iPhone and Android", async () => {
+    installLibraryApi();
+    await openLibrary();
+
+    await wrapper?.get("[data-test='mobile-library-scope-collections']").trigger("click");
+    await flushPromises();
+    const card = wrapper!.get("[data-test='mobile-collection-portraits']");
+    await card.get("[data-test='mobile-collection-menu']").trigger("click");
+    expect(card.get("[data-test='mobile-collection-hidden']").text()).toBe("Hide from Library");
+    await card.get("[data-test='mobile-collection-hidden']").trigger("click");
+    await flushPromises();
+
+    const patch = apiJsonTo.mock.calls.find(
+      ([, path, init]) => path === "/api/gallery/collections/c1" && init?.method === "PATCH",
+    );
+    expect(JSON.parse(String(patch?.[2]?.body))).toEqual({ hidden: true });
+    await wrapper?.get("[data-test='mobile-library-scope-prints']").trigger("click");
+    await flushPromises();
+    expect(wrapper?.get("[data-test='mobile-library-scope-prints']").text()).toContain("1");
+    expect(wrapper?.find("[data-test='mobile-library-chip-tag']").exists()).toBe(false);
   });
 
   it("fans a bulk favorite out through /api/gallery/organize", async () => {

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -64,6 +64,7 @@ import {
   planOrganizationFanout,
   tagKey,
   trashRetentionSummary,
+  visibleTagCounts,
   type OrganizationMutation,
   type OrganizationUnion,
 } from "@studio/lib/libraryOrganization";
@@ -76,6 +77,7 @@ import {
   listTags as listHostTags,
   listTrash as listHostTrash,
   updateCollection as updateHostCollection,
+  updateCollectionHidden as updateHostCollectionHidden,
 } from "@studio/api/galleryOrganization";
 import {
   defaultClipFrames,
@@ -6260,6 +6262,10 @@ const hostNamesById = computed(() =>
 const libraryCollectionCards = computed<MobileCollectionCard[]>(() =>
   collectionCards(mergedCollectionsFor(hostCollections, connectedHosts.value), hostNamesById.value),
 );
+const hiddenCollectionSlugs = computed(
+  () =>
+    new Set(libraryCollectionCards.value.filter((card) => card.hidden).map((card) => card.slug)),
+);
 // Scoped to connected hosts so a disconnected or forgotten machine's
 // retained bucket leaves no ghost chips (its bucket is also pruned below).
 const mergedTags = computed(() =>
@@ -6268,7 +6274,32 @@ const mergedTags = computed(() =>
     connectedHosts.value.map((host) => host.id),
   ),
 );
-const libraryTagChips = computed(() => tagChipPlan(mergedTags.value, libraryFilters.tag));
+const libraryFilterTags = computed(() => {
+  const representatives = groupLogicalGalleryPrints(galleryCopies).map(
+    (group) => group.representative,
+  );
+  const visible =
+    libraryScope.value === "prints"
+      ? representatives.filter(
+          (print) =>
+            !(organizationOf(print)?.collections ?? []).some((slug) =>
+              hiddenCollectionSlugs.value.has(slug),
+            ),
+        )
+      : representatives;
+  const excluded =
+    libraryScope.value === "prints"
+      ? representatives.filter((print) => !visible.includes(print))
+      : [];
+  return visibleTagCounts(
+    mergedTags.value,
+    visible.map((print) => organizationOf(print) ?? { tags: [] }),
+    excluded.map((print) => organizationOf(print) ?? { tags: [] }),
+  );
+});
+const libraryTagChips = computed(() =>
+  tagChipPlan(libraryFilterTags.value, libraryFilters.tag),
+);
 
 const libraryHostChips = computed(() =>
   connectedHosts.value.length > 1
@@ -6486,9 +6517,20 @@ function rebuildGalleryOrganization(): void {
     selectedHostId.value || null,
   );
   const counts: Record<string, number> = {};
-  for (const copy of galleryCopies) counts[copy.hostId] = (counts[copy.hostId] ?? 0) + 1;
+  for (const copy of galleryCopies) {
+    const hidden = (organizationOf(copy)?.collections ?? []).some((slug) =>
+      hiddenCollectionSlugs.value.has(slug),
+    );
+    if (!hidden) counts[copy.hostId] = (counts[copy.hostId] ?? 0) + 1;
+  }
   libraryHostCounts.value = counts;
-  libraryPrintCount.value = groupLogicalGalleryPrints(galleryCopies).length;
+  const logicalPrints = groupLogicalGalleryPrints(galleryCopies);
+  libraryPrintCount.value = logicalPrints.filter(
+    (group) =>
+      !(organizationOf(group.representative)?.collections ?? []).some((slug) =>
+        hiddenCollectionSlugs.value.has(slug),
+      ),
+  ).length;
   trashCount.value = groupLogicalGalleryPrints(trashCopies).length;
 }
 
@@ -6502,8 +6544,12 @@ function visibleRepresentatives(): PendingGalleryPrint[] {
       : libraryScope.value === "collections"
         ? { ...EMPTY_LIBRARY_FILTERS, collectionSlug: libraryFilters.collectionSlug }
         : { ...EMPTY_LIBRARY_FILTERS };
-  return filterLibraryPrints(representatives, filters, organizationOf, (print) =>
-    logicalCopiesOf(copies, print),
+  return filterLibraryPrints(
+    representatives,
+    filters,
+    organizationOf,
+    (print) => logicalCopiesOf(copies, print),
+    libraryScope.value === "prints" ? hiddenCollectionSlugs.value : new Set(),
   );
 }
 
@@ -6996,6 +7042,44 @@ async function renameCollectionFromSheet(): Promise<void> {
     closeLibrarySheet();
   } finally {
     librarySheetBusy.value = false;
+  }
+}
+
+async function setCollectionHidden(card: MobileCollectionCard): Promise<void> {
+  organizationBusy.value = true;
+  organizationError.value = "";
+  try {
+    const hosts = connectedHosts.value.filter((host) =>
+      collectionOnHost(hostCollections, host.id, card.slug),
+    );
+    const hidden = !card.hidden;
+    const results = await Promise.allSettled(
+      hosts.map((host) =>
+        updateHostCollectionHidden(
+          mobileHostTarget(host),
+          collectionOnHost(hostCollections, host.id, card.slug)!.id,
+          hidden,
+        ),
+      ),
+    );
+    const failures = results.flatMap((result, index) =>
+      result.status === "rejected"
+        ? [{ hostId: hosts[index]!.id, hostName: hosts[index]!.name, error: result.reason }]
+        : [],
+    );
+    if (failures.length > 0) {
+      organizationError.value = fanoutFailureMessage(
+        `${hidden ? "hide" : "show"} “${card.name}”`,
+        failures,
+        (error, name) => describeTransportError(error, name),
+      );
+    }
+    await refreshHostOrganization(hosts.map((host) => host.id));
+    rebuildGalleryOrganization();
+    await requeueGallery();
+    collectionMenuSlug.value = null;
+  } finally {
+    organizationBusy.value = false;
   }
 }
 
@@ -9082,6 +9166,12 @@ onBeforeUnmount(() => {
                 <span class="mobile-collection-copy">
                   <strong>{{ card.name }}</strong>
                   <span
+                    v-if="card.hidden"
+                    class="mobile-collection-hidden"
+                    data-test="mobile-collection-hidden-badge"
+                    >Hidden</span
+                  >
+                  <span
                     ><span class="mobile-collection-count">{{ card.count }}</span>
                     <template v-if="card.hostsLabel"> · {{ card.hostsLabel }}</template></span
                   >
@@ -9107,6 +9197,15 @@ onBeforeUnmount(() => {
                   Delete collection “{{ card.name }}”? Its prints stay in the Library.
                 </p>
                 <div class="row-actions">
+                  <button
+                    class="secondary-button"
+                    type="button"
+                    :disabled="organizationBusy"
+                    data-test="mobile-collection-hidden"
+                    @click="setCollectionHidden(card)"
+                  >
+                    {{ card.hidden ? "Show in Library" : "Hide from Library" }}
+                  </button>
                   <button
                     class="secondary-button"
                     type="button"
@@ -9599,7 +9698,7 @@ onBeforeUnmount(() => {
         >
           <div class="mobile-library-tag-list">
             <button
-              v-for="tag in mergedTags"
+              v-for="tag in libraryFilterTags"
               :key="`all-${tag.name}`"
               class="mobile-library-chip"
               type="button"

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -6297,9 +6297,7 @@ const libraryFilterTags = computed(() => {
     excluded.map((print) => organizationOf(print) ?? { tags: [] }),
   );
 });
-const libraryTagChips = computed(() =>
-  tagChipPlan(libraryFilterTags.value, libraryFilters.tag),
-);
+const libraryTagChips = computed(() => tagChipPlan(libraryFilterTags.value, libraryFilters.tag));
 
 const libraryHostChips = computed(() =>
   connectedHosts.value.length > 1

--- a/desktop/src/mobile/MobileGalleryViewer.test.ts
+++ b/desktop/src/mobile/MobileGalleryViewer.test.ts
@@ -866,6 +866,7 @@ describe("MobileGalleryViewer info sheet", () => {
       hostIds: ["studio"],
       hostsLabel: "Studio",
       cover: null,
+      hidden: false,
     },
     {
       slug: "landscapes",
@@ -874,6 +875,7 @@ describe("MobileGalleryViewer info sheet", () => {
       hostIds: ["studio"],
       hostsLabel: "Studio",
       cover: null,
+      hidden: false,
     },
   ];
 

--- a/desktop/src/mobile/fileUnder.test.ts
+++ b/desktop/src/mobile/fileUnder.test.ts
@@ -98,6 +98,7 @@ describe("mobileFileUnderCollections", () => {
           hostIds: ["studio", "plato"],
           hostsLabel: "studio · plato",
           cover: null,
+          hidden: false,
         },
       ]),
     ).toEqual([{ name: "Smurfs", slug: "smurfs", count: 12 }]);

--- a/desktop/src/mobile/libraryOrganization.test.ts
+++ b/desktop/src/mobile/libraryOrganization.test.ts
@@ -165,6 +165,9 @@ describe("organization index and filters", () => {
 
     expect(filterLibraryPrints(representatives, base, organizationOf)).toHaveLength(2);
     expect(
+      filterLibraryPrints(representatives, base, organizationOf, copiesOf, new Set(["smurfs"])),
+    ).toEqual([copies[2]]);
+    expect(
       filterLibraryPrints(representatives, { ...base, favoritesOnly: true }, organizationOf),
     ).toEqual([copies[0]]);
     expect(

--- a/desktop/src/mobile/libraryOrganization.ts
+++ b/desktop/src/mobile/libraryOrganization.ts
@@ -244,13 +244,26 @@ export function filterLibraryPrints<T extends { hostId: string; filename: string
   filters: MobileLibraryFilters,
   organizationOf: (print: T) => OrganizationUnion | undefined,
   copiesOf: (print: T) => readonly { hostId: string }[] = (print) => [print],
+  hiddenCollectionSlugs: ReadonlySet<string> = new Set(),
 ): T[] {
   return prints.filter((print) => {
     if (filters.hostId && !copiesOf(print).some((copy) => copy.hostId === filters.hostId)) {
       return false;
     }
-    if (!filters.favoritesOnly && !filters.tag && !filters.collectionSlug) return true;
+    if (
+      !filters.favoritesOnly &&
+      !filters.tag &&
+      !filters.collectionSlug &&
+      hiddenCollectionSlugs.size === 0
+    )
+      return true;
     const organization = organizationOf(print);
+    if (
+      hiddenCollectionSlugs.size > 0 &&
+      (organization?.collections ?? []).some((slug) => hiddenCollectionSlugs.has(slug))
+    ) {
+      return false;
+    }
     if (filters.favoritesOnly && !organization?.favorite) return false;
     if (filters.tag && !(organization?.tags ?? []).some((tag) => tagKey(tag) === filters.tag)) {
       return false;
@@ -330,6 +343,7 @@ export interface MobileCollectionCard {
   /** "This Mac · plato" style label from the host names. */
   hostsLabel: string;
   cover: { hostId: string; filename: string } | null;
+  hidden: boolean;
 }
 
 export function collectionCards(
@@ -345,6 +359,7 @@ export function collectionCards(
       hostIds,
       hostsLabel: hostIds.map((id) => hostNames[id] ?? id).join(" · "),
       cover: collection.cover,
+      hidden: collection.hidden === true,
     };
   });
 }

--- a/desktop/src/mobile/mobile.css
+++ b/desktop/src/mobile/mobile.css
@@ -4594,6 +4594,14 @@ button:disabled {
   font-size: 12px;
 }
 
+.mobile-collection-copy > .mobile-collection-hidden {
+  font-family: var(--font-utility);
+  font-size: 10px;
+  font-weight: 650;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
 .mobile-collection-count {
   font-family: var(--font-utility);
   color: var(--ink-2);

--- a/desktop/src/stores/gallery.test.ts
+++ b/desktop/src/stores/gallery.test.ts
@@ -25,6 +25,7 @@ vi.mock("@studio/api/galleryOrganization", () => ({
   listCollections: vi.fn(),
   createCollection: vi.fn(),
   updateCollection: vi.fn(),
+  updateCollectionHidden: vi.fn(),
   deleteCollection: vi.fn(),
   setCollectionItems: vi.fn(),
   listTags: vi.fn(),
@@ -1389,6 +1390,44 @@ describe("organization union + filters", () => {
     const gallery = seed();
     gallery.query = "grain";
     expect(gallery.filtered.map((e) => e.item.filename)).toEqual(["shared.png"]);
+  });
+
+  it("omits hidden collection members from Prints and search but keeps drill-in access", () => {
+    const gallery = seed();
+    gallery.collectionsByHost["local"] = loadedCollections([
+      { ...collection("l1", "Smurfs", 1), hidden: true },
+    ]);
+    gallery.collectionsByHost["hal9000-7680"] = loadedCollections([
+      { ...collection("h9", "Smurfs", 2), hidden: true },
+      collection("h2", "River studies", 0),
+    ]);
+    expect(gallery.filtered.map((entry) => entry.item.filename)).toEqual(["solo.png"]);
+    expect(gallery.basePrintCount).toBe(1);
+    expect(gallery.kindCounts).toEqual({ all: 1, image: 1, video: 0, audio: 0 });
+    expect(gallery.chipCounts.map(({ key, count }) => ({ key, count }))).toEqual([
+      { key: "local", count: 1 },
+      { key: "hal9000-7680", count: 0 },
+    ]);
+    expect(gallery.filterChipTags).toEqual([
+      { name: "blue", count: 1 },
+      { name: "portrait", count: 1 },
+    ]);
+    gallery.query = "shared";
+    expect(gallery.filtered).toEqual([]);
+    gallery.query = "";
+    gallery.scope = "collections";
+    gallery.collectionSlug = "smurfs";
+    expect(gallery.basePrintCount).toBe(3);
+    expect(gallery.kindCounts.all).toBe(3);
+    expect(gallery.filterChipTags).toEqual([
+      { name: "Blue", count: 2 },
+      { name: "keep", count: 1 },
+      { name: "portrait", count: 1 },
+    ]);
+    expect(gallery.filtered.map((entry) => entry.item.filename)).toEqual([
+      "shared.png",
+      "remote.png",
+    ]);
   });
 });
 

--- a/desktop/src/stores/gallery.ts
+++ b/desktop/src/stores/gallery.ts
@@ -26,6 +26,7 @@ import {
   sortTags,
   tagKey,
   unionOrganization,
+  visibleTagCounts,
   type MergedCollection,
   type OrganizationFanoutOp,
   type OrganizationMutation,
@@ -44,6 +45,7 @@ import {
   restoreTrashed,
   sweepTrash as sweepTrashOn,
   updateCollection,
+  updateCollectionHidden,
 } from "@studio/api/galleryOrganization";
 
 export type {
@@ -533,6 +535,40 @@ export const useGalleryStore = defineStore("gallery", {
         );
       };
     },
+    /** Excludes members of hidden collections only from the default Prints scope. */
+    visibleInDefaultLibrary(): (entry: MergedPrint) => boolean {
+      const hiddenSlugs = new Set(
+        this.mergedCollections
+          .filter((collection) => collection.hidden)
+          .map((collection) => collection.slug),
+      );
+      const organizationOf = this.organizationOf;
+      return (entry) =>
+        !organizationOf(entry).collections.some((slug) => hiddenSlugs.has(slug));
+    },
+    /** Logical prints available to default filter-chip counts. */
+    basePrints(): MergedPrint[] {
+      return this.scope === "prints"
+        ? this.merged.filter(this.visibleInDefaultLibrary)
+        : this.merged;
+    },
+    /** Header/chip count before host, kind, search, and organization narrowing. */
+    basePrintCount(): number {
+      return this.basePrints.length;
+    },
+    /** Exact tag counts over the same logical prints as the default grid. */
+    filterChipTags(): TagCount[] {
+      const visible = this.basePrints;
+      const excluded =
+        this.scope === "prints"
+          ? this.merged.filter((entry) => !this.visibleInDefaultLibrary(entry))
+          : [];
+      return visibleTagCounts(
+        this.mergedTags,
+        visible.map(this.organizationOf),
+        excluded.map(this.organizationOf),
+      );
+    },
     /** Logical prints per collection slug, over the merged live grid — the
      *  count a shelf card shows (a mirrored print counts once). */
     collectionCounts(): (slug: string) => number {
@@ -624,7 +660,9 @@ export const useGalleryStore = defineStore("gallery", {
       const wantsFavorites = this.favoritesOnly;
       const tagKeys = this.tagFilter.map((t) => tagKey(t)).filter((k) => k.length > 0);
       const slug = this.scope === "collections" ? this.collectionSlug : null;
-      if (!wantsFavorites && tagKeys.length === 0 && !slug) return entries;
+      if (this.scope === "prints") entries = entries.filter(this.visibleInDefaultLibrary);
+      if (!wantsFavorites && tagKeys.length === 0 && !slug)
+        return entries;
       const organizationOf = this.organizationOf;
       entries = entries.filter((entry) => {
         const org = organizationOf(entry);
@@ -674,7 +712,10 @@ export const useGalleryStore = defineStore("gallery", {
      *  the host-chip-filtered set only, so chip labels stay stable while the
      *  kind chip or search narrows the grid. */
     kindCounts(): GalleryKindCounts {
-      const entries = this.hostFiltered;
+      const entries =
+        this.scope === "prints"
+          ? this.hostFiltered.filter(this.visibleInDefaultLibrary)
+          : this.hostFiltered;
       let video = 0;
       let audio = 0;
       for (const e of entries) {
@@ -690,11 +731,21 @@ export const useGalleryStore = defineStore("gallery", {
     },
     /** Per-source chips for the gallery header (HostFilterChips adds All). */
     chipCounts(): GalleryChip[] {
-      return this.sources.map((s) => ({
-        key: s.key,
-        label: s.label,
-        count: this.buckets[s.key]?.items.length ?? 0,
-      }));
+      return this.sources.map((source) => {
+        const items = this.buckets[source.key]?.items ?? [];
+        const count =
+          this.scope === "prints"
+            ? items.filter((item) =>
+                this.visibleInDefaultLibrary({
+                  item,
+                  sourceKey: source.key,
+                  hostLabel: source.label,
+                  availableOn: [source],
+                }),
+              ).length
+            : items.length;
+        return { key: source.key, label: source.label, count };
+      });
     },
     /** Bytes across the filtered set — the header stat. */
     totalBytes(): number {
@@ -1616,6 +1667,25 @@ export const useGalleryStore = defineStore("gallery", {
         this.collectionSlug = slugOfCollection(trimmed) || slug;
       }
       return outcome;
+    },
+    /** Hide/show the collection on every host holding the slug. */
+    async setCollectionHidden(slug: string, hidden: boolean): Promise<FanoutResult> {
+      const merged = this.mergedCollections.find((collection) => collection.slug === slug);
+      if (!merged)
+        return { applied: 0, failed: 0, failedHosts: [], error: "Collection not found." };
+      const keys = merged.hosts.map((host) => host.hostId);
+      const results = await Promise.allSettled(
+        merged.hosts.map(async (host) => {
+          const target = this.targetOf(host.hostId);
+          if (!target) throw new Error("Host is not connected.");
+          const updated = await updateCollectionHidden(target, host.id, hidden);
+          const bucket = this.ensureCollectionsBucket(host.hostId);
+          const at = bucket.items.findIndex((collection) => collection.id === host.id);
+          if (at === -1) bucket.items.push(updated);
+          else bucket.items.splice(at, 1, updated);
+        }),
+      );
+      return this.settleHosts(keys, results);
     },
     /** Delete the collection on every host (never its prints). */
     async deleteCollection(slug: string): Promise<FanoutResult> {

--- a/desktop/src/stores/gallery.ts
+++ b/desktop/src/stores/gallery.ts
@@ -543,8 +543,7 @@ export const useGalleryStore = defineStore("gallery", {
           .map((collection) => collection.slug),
       );
       const organizationOf = this.organizationOf;
-      return (entry) =>
-        !organizationOf(entry).collections.some((slug) => hiddenSlugs.has(slug));
+      return (entry) => !organizationOf(entry).collections.some((slug) => hiddenSlugs.has(slug));
     },
     /** Logical prints available to default filter-chip counts. */
     basePrints(): MergedPrint[] {
@@ -661,8 +660,7 @@ export const useGalleryStore = defineStore("gallery", {
       const tagKeys = this.tagFilter.map((t) => tagKey(t)).filter((k) => k.length > 0);
       const slug = this.scope === "collections" ? this.collectionSlug : null;
       if (this.scope === "prints") entries = entries.filter(this.visibleInDefaultLibrary);
-      if (!wantsFavorites && tagKeys.length === 0 && !slug)
-        return entries;
+      if (!wantsFavorites && tagKeys.length === 0 && !slug) return entries;
       const organizationOf = this.organizationOf;
       entries = entries.filter((entry) => {
         const org = organizationOf(entry);

--- a/desktop/src/views/LibraryView.shelf.test.ts
+++ b/desktop/src/views/LibraryView.shelf.test.ts
@@ -20,6 +20,7 @@ const { apiFetchTo, apiJsonTo, localGalleryList, localGalleryTrashList, org } = 
     listCollections: vi.fn(),
     createCollection: vi.fn(),
     updateCollection: vi.fn(),
+    updateCollectionHidden: vi.fn(),
     deleteCollection: vi.fn().mockResolvedValue(undefined),
     setCollectionItems: vi.fn(),
     listTags: vi.fn(),
@@ -234,9 +235,16 @@ async function mountView(
     count: 0,
   }));
   org.updateCollection.mockImplementation(
-    async (_t: unknown, id: string, body: { name?: string }) => ({
+    async (_t: unknown, id: string, body: { name?: string; hidden?: boolean }) => ({
       ...(id === "col-smurfs" ? smurfs : riverStudies),
+      ...body,
       ...(body.name ? { name: body.name, slug: body.name.toLowerCase() } : {}),
+    }),
+  );
+  org.updateCollectionHidden.mockImplementation(
+    async (_t: unknown, id: string, hidden: boolean) => ({
+      ...(id === "col-smurfs" ? smurfs : riverStudies),
+      hidden,
     }),
   );
 
@@ -782,6 +790,30 @@ describe("Collections scope", () => {
     expect(gallery.mergedCollections.map((c) => c.name)).not.toContain("Smurfs");
     // The prints are untouched.
     expect(gallery.merged).toHaveLength(4);
+    wrapper.unmount();
+  });
+
+  it("hides collection members from Prints and search while preserving drill-in", async () => {
+    const { wrapper, gallery } = await mountView("/library?scope=collections");
+    await wrapper.get("[data-test='collection-card'][data-slug='smurfs']").trigger("contextmenu");
+    useContextMenuStore().activate(menuEntry("Hide from Library")!);
+    await flushPromises();
+    expect(org.updateCollectionHidden).toHaveBeenCalledWith(PLATO, "col-smurfs", true);
+    expect(
+      gallery.mergedCollections.find((collection) => collection.slug === "smurfs")?.hidden,
+    ).toBe(true);
+    expect(wrapper.get("[data-test='collection-hidden-badge']").text()).toBe("Hidden");
+
+    gallery.scope = "prints";
+    gallery.query = "smurf";
+    await flushPromises();
+    expect(wrapper.findAll(".ms-lib-tile")).toHaveLength(0);
+
+    gallery.query = "";
+    gallery.scope = "collections";
+    gallery.collectionSlug = "smurfs";
+    await flushPromises();
+    expect(wrapper.findAll(".ms-lib-tile")).toHaveLength(2);
     wrapper.unmount();
   });
 

--- a/desktop/src/views/LibraryView.vue
+++ b/desktop/src/views/LibraryView.vue
@@ -191,11 +191,21 @@ const hostScopeLabel = computed(() =>
     ? null
     : (gallery.sources.find((s) => s.key === gallery.filter)?.label ?? null),
 );
-const scopeCounts = computed(() => ({
-  prints: gallery.merged.length,
-  collections: gallery.mergedCollections.length,
-  trash: gallery.trashCount,
-}));
+const scopeCounts = computed(() => {
+  const hidden = new Set(
+    gallery.mergedCollections
+      .filter((collection) => collection.hidden)
+      .map((collection) => collection.slug),
+  );
+  const prints = gallery.merged.filter(
+    (entry) => !gallery.organizationOf(entry).collections.some((slug) => hidden.has(slug)),
+  ).length;
+  return {
+    prints,
+    collections: gallery.mergedCollections.length,
+    trash: gallery.trashCount,
+  };
+});
 const countLabel = computed(() => {
   if (showShelf.value) {
     const n = shelfCards.value.length;
@@ -213,7 +223,9 @@ const countLabel = computed(() => {
 const trashBytes = computed(() =>
   gallery.trashMerged.reduce((sum, e) => sum + (e.item.size_bytes ?? 0), 0),
 );
-const favoritesCount = computed(() => gallery.merged.filter((e) => isFavorite(e)).length);
+const favoritesCount = computed(
+  () => gallery.basePrints.filter((entry) => isFavorite(entry)).length,
+);
 const sourceLabel = (key: string) => gallery.sources.find((s) => s.key === key)?.label ?? key;
 /** "This Mac · plato" — every organize-capable host, for the fan-out notes. */
 const organizeHostNote = computed(() => {
@@ -575,6 +587,14 @@ async function onCollectionRenameSave(name: string) {
   reportFanout(await gallery.renameCollection(slug, name), `Renamed to “${name}”`);
 }
 
+async function setCollectionHidden(slug: string, hidden: boolean) {
+  const name = collectionNamed(slug);
+  reportFanout(
+    await gallery.setCollectionHidden(slug, hidden),
+    hidden ? `Hidden collection “${name}”` : `Showing collection “${name}”`,
+  );
+}
+
 async function confirmDeleteCollection() {
   const slug = collectionDeleteSlug.value;
   collectionDeleteSlug.value = null;
@@ -766,6 +786,7 @@ const shelfCards = computed<ShelfCard[]>(() => {
       hostLabels: c.hosts.map((h) => sourceLabel(h.hostId)),
       updatedAt: collectionUpdatedAt(c),
       covers: coversFor(c),
+      hidden: c.hidden === true,
     }));
 });
 
@@ -785,8 +806,14 @@ function exitCollection() {
 }
 
 function collectionMenu(slug: string): MenuEntry[] {
+  const hidden =
+    gallery.mergedCollections.find((collection) => collection.slug === slug)?.hidden === true;
   return [
     { label: "Open", action: () => openCollectionSlug(slug) },
+    {
+      label: hidden ? "Show in Library" : "Hide from Library",
+      action: () => void setCollectionHidden(slug, !hidden),
+    },
     { label: "Rename…", action: () => (collectionRenameSlug.value = slug) },
     { separator: true },
     {
@@ -1962,11 +1989,11 @@ onUnmounted(() => {
       :organize="organizeAvailable"
       :favorites-only="gallery.favoritesOnly"
       :favorites-count="favoritesCount"
-      :tags="gallery.mergedTags"
+      :tags="gallery.filterChipTags"
       :active-tags="gallery.tagFilter"
       :host-chips="gallery.chipCounts"
       :host-filter="gallery.filter"
-      :all-count="gallery.merged.length"
+      :all-count="gallery.basePrintCount"
       :collection-name="drillInName"
       @update:favorites-only="gallery.favoritesOnly = $event"
       @toggle-tag="toggleTagFilter"

--- a/studio/api/galleryOrganization.test.ts
+++ b/studio/api/galleryOrganization.test.ts
@@ -19,6 +19,7 @@ import {
   trashGalleryImage,
   trashMany,
   updateCollection,
+  updateCollectionHidden,
 } from "./galleryOrganization";
 
 const target: ApiTarget = { baseUrl: "http://plato:7680", apiKey: "secret" };
@@ -163,6 +164,30 @@ describe("gallery organization API", () => {
       method: "DELETE",
     });
     expect(captured().headers.get("x-api-key")).toBe("secret");
+  });
+
+  it("rejects an older server that silently ignores hidden collection updates", async () => {
+    stub(() => Response.json({ id: "c1", name: "Studio" }));
+    await expect(updateCollectionHidden(target, "c1", true)).rejects.toThrow(
+      /does not support hidden collections/,
+    );
+  });
+
+  it("accepts a hidden collection update only when the echoed state matches", async () => {
+    let captured = stub(() => Response.json({ id: "c1", hidden: true }));
+    await expect(
+      updateCollectionHidden(target, "c1", true),
+    ).resolves.toMatchObject({
+      hidden: true,
+    });
+    expect(captured().body).toEqual({ hidden: true });
+
+    captured = stub(() => Response.json({ id: "c1", hidden: false }));
+    await expect(
+      updateCollectionHidden(target, "c1", false),
+    ).resolves.toMatchObject({
+      hidden: false,
+    });
   });
 
   it("PUTs collection item changes and hands back the collection when returned", async () => {

--- a/studio/api/galleryOrganization.ts
+++ b/studio/api/galleryOrganization.ts
@@ -110,6 +110,24 @@ export function updateCollection(
   );
 }
 
+/**
+ * Update collection visibility and verify the server actually understood it.
+ * Older organizing servers ignore unknown PATCH fields while still returning
+ * 200, so a successful response alone cannot prove that hiding took effect.
+ */
+export async function updateCollectionHidden(
+  target: ApiTarget,
+  id: string,
+  hidden: boolean,
+): Promise<Collection> {
+  const updated = await updateCollection(target, id, { hidden });
+  const matches = hidden ? updated.hidden === true : updated.hidden !== true;
+  if (!matches) {
+    throw new Error("This host does not support hidden collections.");
+  }
+  return updated;
+}
+
 /** Deletes the collection only — never the prints in it (D7). */
 export async function deleteCollection(
   target: ApiTarget,

--- a/studio/lib/api/galleryOrganization.ts
+++ b/studio/lib/api/galleryOrganization.ts
@@ -46,6 +46,8 @@ export interface Collection {
   slug: string;
   description: string | null;
   cover_filename: string | null;
+  /** Members stay available in Collections but are omitted from Prints/search. */
+  hidden?: boolean;
   /** Number of prints on this host in the collection. */
   count: number;
   /** Unix seconds. */
@@ -111,6 +113,7 @@ export interface CollectionUpdateRequest {
   name?: string | null;
   description?: string | null;
   cover_filename?: string | null;
+  hidden?: boolean | null;
 }
 
 /** `PUT /api/gallery/collections/:id/items` body — filenames. */

--- a/studio/lib/libraryOrganization.test.ts
+++ b/studio/lib/libraryOrganization.test.ts
@@ -13,11 +13,13 @@ import {
   retentionLabel,
   sortCollections,
   sortTags,
+  tagCountsForOrganizations,
   tagKey,
   titleSlug,
   trashRetentionSummary,
   unionOrganization,
   validatePrintTitle,
+  visibleTagCounts,
 } from "./libraryOrganization";
 
 /**
@@ -236,6 +238,7 @@ describe("mergeCollectionsAcrossHosts", () => {
             name: "studio shots",
             count: 2,
             cover_filename: "s.png",
+            hidden: true,
           }),
           collection({ id: "p1", name: "Alpha", count: 5 }),
         ],
@@ -255,6 +258,7 @@ describe("mergeCollectionsAcrossHosts", () => {
       { hostId: "plato", id: "p9", count: 2 },
     ]);
     expect(studio.cover).toEqual({ hostId: "plato", filename: "s.png" });
+    expect(studio.hidden).toBe(true);
     expect(merged.find((entry) => entry.slug === "zebras")!.cover).toEqual({
       hostId: "local",
       filename: "z.png",
@@ -675,6 +679,36 @@ describe("sorting", () => {
       "alpha",
       "zeta",
       "gamma",
+    ]);
+  });
+
+  it("counts each logical print once per normalized tag", () => {
+    expect(
+      tagCountsForOrganizations([
+        { tags: ["Blue", "blue", "Portrait"] },
+        { tags: ["BLUE"] },
+        { tags: [] },
+      ]),
+    ).toEqual([
+      { name: "Blue", count: 2 },
+      { name: "Portrait", count: 1 },
+    ]);
+  });
+
+  it("keeps inventory-only legacy tags but removes tags known only on excluded prints", () => {
+    expect(
+      visibleTagCounts(
+        [
+          { name: "Blue", count: 4 },
+          { name: "Legacy", count: 2 },
+          { name: "Secret", count: 1 },
+        ],
+        [{ tags: ["Blue"] }],
+        [{ tags: ["Secret"] }],
+      ),
+    ).toEqual([
+      { name: "Legacy", count: 2 },
+      { name: "Blue", count: 1 },
     ]);
   });
 });

--- a/studio/lib/libraryOrganization.ts
+++ b/studio/lib/libraryOrganization.ts
@@ -164,6 +164,8 @@ export interface MergedCollection {
   hosts: MergedCollectionHost[];
   /** First non-null cover across hosts, in input order. */
   cover: { hostId: string; filename: string } | null;
+  /** True when any host copy is hidden. Mutations fan out to keep copies aligned. */
+  hidden?: boolean;
 }
 
 function resolvedCollectionSlug(entry: Collection): string {
@@ -184,7 +186,14 @@ export function mergeCollectionsAcrossHosts(
       if (!slug) continue;
       let merged = bySlug.get(slug);
       if (!merged) {
-        merged = { slug, name: entry.name, count: 0, hosts: [], cover: null };
+        merged = {
+          slug,
+          name: entry.name,
+          count: 0,
+          hosts: [],
+          cover: null,
+          hidden: false,
+        };
         bySlug.set(slug, merged);
       }
       merged.count += entry.count;
@@ -193,6 +202,7 @@ export function mergeCollectionsAcrossHosts(
         id: entry.id,
         count: entry.count,
       });
+      if (entry.hidden === true) merged.hidden = true;
       if (!merged.cover && entry.cover_filename) {
         merged.cover = { hostId: host.hostId, filename: entry.cover_filename };
       }
@@ -553,4 +563,52 @@ export function sortTags<T extends TagCount>(list: readonly T[]): T[] {
   return [...list].sort(
     (a, b) => b.count - a.count || compareNames(a.name, b.name),
   );
+}
+
+/** Exact logical-print tag counts for filter chips (one count per print/tag). */
+export function tagCountsForOrganizations(
+  organizations: readonly { tags?: readonly string[] | null }[],
+): TagCount[] {
+  const counts = new Map<string, TagCount>();
+  for (const organization of organizations) {
+    const seen = new Set<string>();
+    for (const raw of organization.tags ?? []) {
+      const name = normalizeTagName(raw);
+      const key = tagKey(name);
+      if (!key || seen.has(key)) continue;
+      seen.add(key);
+      const existing = counts.get(key);
+      if (existing) existing.count += 1;
+      else counts.set(key, { name, count: 1 });
+    }
+  }
+  return sortTags([...counts.values()]);
+}
+
+/**
+ * Filter-chip tag counts with a compatibility fallback for older gallery rows
+ * that do not carry per-print tags. Known memberships use exact logical-print
+ * counts; inventory-only tags remain available unless they are known to occur
+ * exclusively on excluded prints.
+ */
+export function visibleTagCounts(
+  inventory: readonly TagCount[],
+  visibleOrganizations: readonly { tags?: readonly string[] | null }[],
+  excludedOrganizations: readonly { tags?: readonly string[] | null }[] = [],
+): TagCount[] {
+  const exact = tagCountsForOrganizations(visibleOrganizations);
+  const exactByKey = new Map(exact.map((tag) => [tagKey(tag.name), tag]));
+  const excludedKeys = new Set(
+    tagCountsForOrganizations(excludedOrganizations).map((tag) =>
+      tagKey(tag.name),
+    ),
+  );
+  const result = new Map<string, TagCount>();
+  for (const tag of inventory) {
+    const key = tagKey(tag.name);
+    if (!key || (excludedKeys.has(key) && !exactByKey.has(key))) continue;
+    result.set(key, exactByKey.get(key) ?? { ...tag });
+  }
+  for (const [key, tag] of exactByKey) result.set(key, tag);
+  return sortTags([...result.values()]);
 }

--- a/web/src/components/library/CollectionsShelf.vue
+++ b/web/src/components/library/CollectionsShelf.vue
@@ -26,6 +26,7 @@ const emit = defineEmits<{
   (e: "open", slug: string): void;
   (e: "new"): void;
   (e: "rename", slug: string): void;
+  (e: "hidden", slug: string, hidden: boolean): void;
   (e: "delete", slug: string): void;
 }>();
 
@@ -80,9 +81,15 @@ function metaLine(card: CollectionCard): string {
               <Icon name="collection" :size="22" :stroke-width="1.5" />
             </span>
           </span>
-          <span class="ccard__name" data-test="collection-name">{{
-            card.name
-          }}</span>
+          <span class="ccard__name" data-test="collection-name"
+            >{{ card.name }}
+            <span
+              v-if="card.merged.hidden"
+              class="ccard__hidden"
+              data-test="collection-hidden-badge"
+              >Hidden</span
+            ></span
+          >
           <span class="ccard__meta" data-test="collection-meta">{{
             metaLine(card)
           }}</span>
@@ -116,6 +123,17 @@ function metaLine(card: CollectionCard): string {
           data-test="collection-card-menu"
           @click.stop
         >
+          <button
+            type="button"
+            role="menuitem"
+            data-test="collection-hidden"
+            @click="
+              closeMenu();
+              emit('hidden', card.slug, !card.merged.hidden);
+            "
+          >
+            {{ card.merged.hidden ? "Show in Library" : "Hide from Library" }}
+          </button>
           <button
             type="button"
             role="menuitem"
@@ -282,6 +300,14 @@ function metaLine(card: CollectionCard): string {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+.ccard__hidden {
+  margin-left: 6px;
+  color: var(--ink-3);
+  font-family: var(--f-mono);
+  font-size: 9.5px;
+  font-weight: 500;
+  text-transform: uppercase;
 }
 .ccard__meta {
   font-family: var(--f-mono);

--- a/web/src/lib/libraryOrganization.test.ts
+++ b/web/src/lib/libraryOrganization.test.ts
@@ -335,6 +335,11 @@ describe("filtering", () => {
     expect(
       filterByOrganization([smurf, frog], { collectionSlug: "smurfs" }),
     ).toEqual([smurf]);
+    expect(
+      filterByOrganization([smurf, frog], {
+        excludeCollectionSlugs: new Set(["smurfs"]),
+      }),
+    ).toEqual([frog]);
   });
 
   it("searches title and tags as well as prompt, model, and filename", () => {

--- a/web/src/lib/libraryOrganization.ts
+++ b/web/src/lib/libraryOrganization.ts
@@ -26,6 +26,7 @@ import {
   setCollectionItems,
   trashMany,
   updateCollection,
+  updateCollectionHidden,
 } from "@studio/api/galleryOrganization";
 import type { ApiTarget } from "@studio/api/client";
 import {
@@ -263,6 +264,8 @@ export interface OrganizationFilter {
   tags?: readonly string[];
   /** Collection slug the print must belong to. */
   collectionSlug?: string | null;
+  /** Collection slugs whose members are omitted from the default Prints view. */
+  excludeCollectionSlugs?: ReadonlySet<string>;
 }
 
 function entryTagKeys(entry: GalleryImage): Set<string> {
@@ -287,6 +290,14 @@ export function entryMatchesOrganization(
   if (filter.collectionSlug) {
     if (!entryCollectionSlugs(entry).includes(filter.collectionSlug))
       return false;
+  }
+  if (
+    filter.excludeCollectionSlugs?.size &&
+    entryCollectionSlugs(entry).some((slug) =>
+      filter.excludeCollectionSlugs!.has(slug),
+    )
+  ) {
+    return false;
   }
   return true;
 }
@@ -581,6 +592,17 @@ export function renameCollectionEverywhere(
 ): Promise<FanoutResult> {
   return fanout(collection.hosts, hostById, (host, _entry, target) =>
     updateCollection(target, host.id, { name }).then(() => undefined),
+  );
+}
+
+/** Hide/show every host copy of a merged collection. */
+export function setCollectionHiddenEverywhere(
+  collection: MergedCollection,
+  hidden: boolean,
+  hostById: HostLookup,
+): Promise<FanoutResult> {
+  return fanout(collection.hosts, hostById, (host, _entry, target) =>
+    updateCollectionHidden(target, host.id, hidden).then(() => undefined),
   );
 }
 

--- a/web/src/pages/LibraryPage.organization.test.ts
+++ b/web/src/pages/LibraryPage.organization.test.ts
@@ -53,6 +53,10 @@ const orgApi = vi.hoisted(() => ({
     updated_at: 0,
   })),
   updateCollection: vi.fn(async () => ({})),
+  updateCollectionHidden: vi.fn(async (_target: unknown, id: string, hidden: boolean) => ({
+    id,
+    hidden,
+  })),
   deleteCollection: vi.fn(async () => undefined),
   setCollectionItems: vi.fn(async () => null),
   trashMany: vi.fn(async () => undefined),
@@ -437,7 +441,7 @@ describe("Collections scope", () => {
     });
   });
 
-  it("renames and deletes a collection with a plain confirm that names it", async () => {
+  it("hides, renames, and deletes a collection with a plain confirm that names it", async () => {
     const wrapper = await mounted();
     await wrapper
       .get("[data-test='library-scope']")
@@ -456,6 +460,11 @@ describe("Collections scope", () => {
       "c-smurfs",
       { name: "Blue folk" },
     );
+
+    await card.get("[data-test='collection-menu']").trigger("click");
+    await card.get("[data-test='collection-hidden']").trigger("click");
+    await flushPromises();
+    expect(orgApi.updateCollectionHidden).toHaveBeenCalledWith(ORIGIN_TARGET, "c-smurfs", true);
 
     await card.get("[data-test='collection-menu']").trigger("click");
     await card.get("[data-test='collection-delete']").trigger("click");

--- a/web/src/pages/LibraryPage.organization.test.ts
+++ b/web/src/pages/LibraryPage.organization.test.ts
@@ -53,10 +53,12 @@ const orgApi = vi.hoisted(() => ({
     updated_at: 0,
   })),
   updateCollection: vi.fn(async () => ({})),
-  updateCollectionHidden: vi.fn(async (_target: unknown, id: string, hidden: boolean) => ({
-    id,
-    hidden,
-  })),
+  updateCollectionHidden: vi.fn(
+    async (_target: unknown, id: string, hidden: boolean) => ({
+      id,
+      hidden,
+    }),
+  ),
   deleteCollection: vi.fn(async () => undefined),
   setCollectionItems: vi.fn(async () => null),
   trashMany: vi.fn(async () => undefined),
@@ -464,7 +466,11 @@ describe("Collections scope", () => {
     await card.get("[data-test='collection-menu']").trigger("click");
     await card.get("[data-test='collection-hidden']").trigger("click");
     await flushPromises();
-    expect(orgApi.updateCollectionHidden).toHaveBeenCalledWith(ORIGIN_TARGET, "c-smurfs", true);
+    expect(orgApi.updateCollectionHidden).toHaveBeenCalledWith(
+      ORIGIN_TARGET,
+      "c-smurfs",
+      true,
+    );
 
     await card.get("[data-test='collection-menu']").trigger("click");
     await card.get("[data-test='collection-delete']").trigger("click");

--- a/web/src/pages/LibraryPage.vue
+++ b/web/src/pages/LibraryPage.vue
@@ -60,6 +60,7 @@ import {
 import {
   tagKey,
   trashRetentionSummary,
+  visibleTagCounts,
   type MergedCollection,
   type OrganizationMutation,
 } from "@studio/lib/libraryOrganization";
@@ -100,6 +101,7 @@ import {
   mergedCollections,
   mergedTags,
   renameCollectionEverywhere,
+  setCollectionHiddenEverywhere,
   retentionHosts,
   setCollectionCover,
   type FanoutResult,
@@ -436,7 +438,27 @@ function missingHostError(entry: GalleryImage): Error {
 // ── Organization state (merged across hosts) ───────────────────────────────
 const resolver = computed(() => collectionResolver(snapshots.value));
 const collections = computed(() => mergedCollections(snapshots.value));
+const hiddenCollectionSlugs = computed(
+  () =>
+    new Set(
+      collections.value
+        .filter((collection) => collection.hidden)
+        .map((collection) => collection.slug),
+    ),
+);
 const tags = computed(() => mergedTags(snapshots.value));
+const filterChipTags = computed(() => {
+  const visible = filterByOrganization(entries.value, {
+    excludeCollectionSlugs:
+      scope.value === "prints" ? hiddenCollectionSlugs.value : undefined,
+  });
+  const visibleKeys = new Set(visible.map((entry) => keyOf(entry)));
+  const excluded =
+    scope.value === "prints"
+      ? entries.value.filter((entry) => !visibleKeys.has(keyOf(entry)))
+      : [];
+  return visibleTagCounts(tags.value, visible, excluded);
+});
 const canOrganize = computed(() => anyHostOrganizes(snapshots.value));
 const canTrash = computed(() => anyHostTrashes(snapshots.value));
 const organizingHostCount = computed(
@@ -475,7 +497,11 @@ const currentCard = computed(() =>
     : null,
 );
 const favoriteCount = computed(
-  () => entries.value.filter((e) => e.favorite).length,
+  () =>
+    filterByOrganization(entries.value, {
+      excludeCollectionSlugs:
+        scope.value === "prints" ? hiddenCollectionSlugs.value : undefined,
+    }).filter((entry) => entry.favorite).length,
 );
 const retentionSummary = computed(() =>
   trashRetentionSummary(retentionHosts(snapshots.value)),
@@ -1004,6 +1030,20 @@ async function renameCollection(slug: string) {
   }
 }
 
+async function setCollectionHidden(slug: string, hidden: boolean) {
+  const collection = collections.value.find(
+    (candidate) => candidate.slug === slug,
+  );
+  if (!collection) return;
+  const result = await setCollectionHiddenEverywhere(
+    collection,
+    hidden,
+    hostById,
+  );
+  reportFanout(result, hidden ? "hide the collection" : "show the collection");
+  await refresh();
+}
+
 async function deleteCollection(slug: string) {
   const collection = collections.value.find((c) => c.slug === slug);
   if (!collection) return;
@@ -1370,6 +1410,8 @@ const organizationFiltered = computed(() => {
     favoritesOnly: favoritesOnly.value,
     tags: tagFilter.value,
     collectionSlug: scope.value === "collections" ? collectionSlug.value : null,
+    excludeCollectionSlugs:
+      scope.value === "prints" ? hiddenCollectionSlugs.value : undefined,
   });
 });
 
@@ -1379,7 +1421,12 @@ const filtered = computed(() => {
   return organizationFiltered.value.filter((e) => entryMatchesSearch(e, q));
 });
 
-const total = computed(() => entries.value.length);
+const total = computed(
+  () =>
+    filterByOrganization(entries.value, {
+      excludeCollectionSlugs: hiddenCollectionSlugs.value,
+    }).length,
+);
 const searchActive = computed(() => search.value.trim().length > 0);
 const organizationFilterActive = computed(
   () => favoritesOnly.value || tagFilter.value.length > 0,
@@ -2323,7 +2370,7 @@ onBeforeUnmount(() => {
       :organize="canOrganize"
       :favorites-only="favoritesOnly"
       :favorite-count="favoriteCount"
-      :tags="tags"
+      :tags="filterChipTags"
       :active-tags="tagFilter"
       :host-options="hostOptions"
       :host-filter="hostFilter"
@@ -2489,6 +2536,7 @@ onBeforeUnmount(() => {
           @open="openCollection"
           @new="onNewCollection()"
           @rename="renameCollection"
+          @hidden="setCollectionHidden"
           @delete="deleteCollection"
         />
       </template>


### PR DESCRIPTION
## Summary
- add persistent hidden state for collections and fan it out across every host copy
- exclude hidden collection members from the default Prints grid, search, filter counts, and tags on web, desktop, iPhone, and Android
- keep hidden collections visible and reversible in Collections, with full drill-in access
- detect older servers that silently ignore the hidden field and report the host failure

## Verification
- nix develop -c bun run check:frontend
- nix develop -c bun run build:mobile
- nix develop -c cargo test -p mold-ai-db
- nix develop -c cargo test -p mold-ai-core collection_and_tag_count_round_trip
- nix develop -c cargo test -p mold-ai-server gallery_collections_crud_and_membership_round_trip
- nix flake check
- rendered UAT: web and shared iPhone/Android surface; native desktop compiled and launched
- independent agent peer review: approved with no findings