### PR TITLE
fix(h3): default optional dependency context fields

### DIFF
--- a/changelog.d/h3-dependency-context-defaults.md
+++ b/changelog.d/h3-dependency-context-defaults.md
@@ -1,0 +1,4 @@
+- **Hardened H3 server builds against additive dependency-preparation inputs.**
+  The H3-only placement-preview and scheduler contexts now default optional
+  fields, preventing another shared-struct addition from breaking release
+  compilation.

--- a/changelog.d/h3-frozen-identity-compile.md
+++ b/changelog.d/h3-frozen-identity-compile.md
@@ -3,4 +3,6 @@
   field; the non-H3 construction sites were updated but their `h3`-gated twins
   in the placement-preview route and the scheduler were not, so every
   `h3-cuda` build — the feature set the Linux sm89 release artifact ships —
-  failed to compile while CI stayed green.
+  failed to compile while CI stayed green. Those H3-only contexts now default
+  additive optional inputs so the same shared-struct change cannot break them
+  again.

--- a/changelog.d/h3-frozen-identity-compile.md
+++ b/changelog.d/h3-frozen-identity-compile.md
@@ -3,6 +3,4 @@
   field; the non-H3 construction sites were updated but their `h3`-gated twins
   in the placement-preview route and the scheduler were not, so every
   `h3-cuda` build — the feature set the Linux sm89 release artifact ships —
-  failed to compile while CI stayed green. Those H3-only contexts now default
-  additive optional inputs so the same shared-struct change cannot break them
-  again.
+  failed to compile while CI stayed green.

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -3775,8 +3775,9 @@ async fn placement_preview_for_request_authenticated(
         h3_resolved_references: None,
         // Same boundary: only the scheduler carries a parent's frozen
         // identity, from the owning job. This probe has no job and must not
-        // invent one.
-        frozen_identity: None,
+        // invent one. Default the remaining context so additive optional
+        // preparation inputs cannot leave this H3-only literal unbuildable.
+        ..Default::default()
     };
     // Ref2VA plans depend on the staged reference media, which this probe
     // deliberately never carries. Preparation would therefore fail for the

--- a/crates/mold-server/src/scheduler/mod.rs
+++ b/crates/mold-server/src/scheduler/mod.rs
@@ -1752,9 +1752,11 @@ impl Coordinator {
                     .resolved_references
                     .as_ref()
                     .map(crate::reference_uploads::ResolvedReferenceSet::admission_view),
-                // Replaced immediately below with the parent's frozen value;
-                // named here because a struct literal must be total.
-                frozen_identity: None,
+                // The parent's frozen identity is grafted on immediately
+                // below. Default the remaining context so additive optional
+                // preparation inputs cannot leave this H3-only literal
+                // unbuildable.
+                ..Default::default()
             };
             // A batch child arrives already holding the parent's frozen
             // identity. Handing it to preparation is what keeps ONE extraction


### PR DESCRIPTION
Fixes #1278

## Summary
- preserve the direct frozen_identity compile repair already on main
- default remaining optional dependency-preparation fields in both H3-only contexts
- prevent future additive optional fields from breaking cfg-gated server builds
- document the hardened behavior in the existing changelog fragment

## Verification
- nix develop -c cargo fmt --all -- --check
- nix develop -c cargo check -p mold-ai-server --lib
- nix develop -c cargo clippy -p mold-ai-server --lib -- -D warnings
- nix develop -c cargo test -p mold-ai-server --lib variant_dependencies (36 passed)
- nix develop -c bash scripts/tests/minimax-h3-private-uat-release-contract.sh (6 tests passed; contract PASS)
- independent Codex agent peer review: no findings

## Platform note
A local h3,metal,pulid server check compiled both changed H3-only literals, then stopped on pre-existing CUDA-only references in gpu_worker.rs. The exact h3-cuda release build requires a Linux CUDA toolchain and remains covered by the release workflow.