### PR TITLE
perf(pulid): resident candle face stack and a full-stack extraction benchmark (#1227 phase 1)

### DIFF
--- a/changelog.d/pulid-perf.md
+++ b/changelog.d/pulid-perf.md
@@ -1,0 +1,8 @@
+- **PuLID face extraction runs resident, and the whole extraction is finally
+  measured.** SCRFD and `glintr100` are now ordinary `candle` modules built once
+  from the same SHA-pinned ONNX files, instead of re-materializing 278 MB of
+  initializers on every conditioned request. `pulid_face_probe bench` gained
+  `--full`, `--compare`, and `--regress-against`, and reports the EVA02-CLIP
+  tower and the IDFormer — which had no number anywhere in the repository even
+  though they run on every identity request
+  ([#1227](https://github.com/utensils/mold/issues/1227)).

--- a/changelog.d/pulid-perf.md
+++ b/changelog.d/pulid-perf.md
@@ -1,8 +1,10 @@
-- **PuLID face extraction runs resident, and the whole extraction is finally
-  measured.** SCRFD and `glintr100` are now ordinary `candle` modules built once
-  from the same SHA-pinned ONNX files, instead of re-materializing 278 MB of
-  initializers on every conditioned request. `pulid_face_probe bench` gained
-  `--full`, `--compare`, and `--regress-against`, and reports the EVA02-CLIP
-  tower and the IDFormer — which had no number anywhere in the repository even
-  though they run on every identity request
+- **PuLID face extraction now runs as resident candle modules, and the whole
+  extraction is measured for the first time.** SCRFD and `glintr100` are built
+  once from the same SHA-pinned ONNX files instead of re-materializing 278 MB of
+  initializers on every conditioned request; the port is parity-exact (SCRFD
+  bit-identical to the evaluator it replaces, ArcFace cosine 1.0) and is what
+  makes a future device path possible at all. `pulid_face_probe bench` gained
+  `--full`, `--compare`, and `--regress-against`, which together show that the
+  re-materialization was worth ~4% and that the EVA02-CLIP vision tower — which
+  had no number anywhere in the repository — is 79% of a real extraction
   ([#1227](https://github.com/utensils/mold/issues/1227)).

--- a/crates/mold-inference/src/bin/pulid_face_probe.rs
+++ b/crates/mold-inference/src/bin/pulid_face_probe.rs
@@ -1,20 +1,39 @@
-//! Step-0 probe for #1222: can `candle-onnx` run the two InsightFace graphs,
-//! and how fast?
-//!
-//! Two subcommands, both taking a directory holding `scrfd_10g_bnkps.onnx` and
-//! `glintr100.onnx`:
+//! Step-0 probe for #1222, extended for #1227: what does one identity
+//! extraction cost, stage by stage?
 //!
 //! ```text
 //! pulid_face_probe inventory <dir> [--write <path>]
 //! pulid_face_probe bench     <dir> [--warmups 5] [--runs 20]
+//!                                  [--compare] [--regress-against halcyon|plato]
+//!                                  [--full --adapter <path> --eva <path>]
 //! ```
 //!
+//! `<dir>` holds `scrfd_10g_bnkps.onnx` and `glintr100.onnx`.
+//!
 //! `inventory` prints (and optionally writes) the op/attribute inventory the
-//! hermetic gate test consumes. `bench` measures WARM repeated `simple_eval`,
-//! which is the number the decision gate is stated in — `simple_eval`
-//! re-materializes every initializer and retains every intermediate on each
-//! call (`candle-onnx/src/eval.rs:191-257`), so there is no cold/warm split to
-//! amortize and the second call costs what the thousandth does.
+//! hermetic gate test consumes.
+//!
+//! `bench` measures WARM repeated evaluation, which is the protocol both gates
+//! are stated in: neither the `candle-onnx` evaluator this probe originally
+//! measured nor the resident hand port that replaced it (#1227) has a cold/warm
+//! split to amortize once weights are in memory, so the second call costs what
+//! the thousandth does and five warmups are enough.
+//!
+//! Three things #1227 added, each for a reason `docs/architecture/pulid-perf.md`
+//! records:
+//!
+//! * `--compare` re-measures the retained `candle-onnx` oracle beside the
+//!   resident port, on the same machine in the same run, so the speedup is a
+//!   measurement rather than a comparison against a number recorded on a
+//!   differently loaded box (§4).
+//! * `--regress-against` turns §1's "p95 at least 25% faster" acceptance
+//!   criterion into a mechanical check against the baselines committed to this
+//!   repository, instead of a percentage a reviewer recomputes by hand (§4).
+//! * `--full` additionally measures the EVA02-CLIP tower and the IDFormer,
+//!   which §0 found had **no number anywhere in the repository** even though
+//!   they run on every conditioned request. It needs the rest of the bundle:
+//!   `--adapter` (`pulid_flux_v0.9.1.safetensors`) and `--eva`
+//!   (`EVA02_CLIP_L_336_psz14_s6B.pt`).
 //!
 //! Development-only: `dev-bins` + `pulid`, never in a release recipe.
 
@@ -28,13 +47,51 @@ use mold_inference::identity::onnx_inventory::{
     graph_inventory, ignored_attributes, pinned_input_makes_pooling_exact,
     unsupported_by_candle_onnx, GraphInventory,
 };
+use candle_core::Device;
+use mold_core::pulid_assets::PulidPaths;
+use mold_inference::identity::extraction::{compose_identity_tokens_observed, ComposeStage};
+use mold_inference::identity::arcface_net::IResNet100;
+use mold_inference::identity::scrfd_net::ScrfdNet;
 use mold_inference::identity::{arcface::ArcFaceRecognizer, scrfd::ScrfdDetector};
 
 /// #1222's Step-0 latency gate, in milliseconds of warm p95 per image.
 const LATENCY_BUDGET_MS: f64 = 2000.0;
 
+/// #1222's recorded SCRFD + ArcFace warm p95, `candle-onnx`, per host.
+///
+/// These are the numbers `docs/architecture/pulid-face-extraction.md` published
+/// and `pulid-perf.md` §1 states its acceptance criterion against. They are
+/// baselines, not budgets: a build that beats them by less than
+/// [`REGRESSION_MARGIN`] fails `--regress-against`.
+const BASELINE_HALCYON_P95_MS: f64 = 415.7;
+const BASELINE_PLATO_P95_MS: f64 = 1574.5;
+
+/// §1's acceptance criterion, "p95 at least 25% faster", as a ratio.
+const REGRESSION_MARGIN: f64 = 0.75;
+
 const DETECTOR: &str = "scrfd_10g_bnkps.onnx";
 const RECOGNIZER: &str = "glintr100.onnx";
+
+/// A named measurement host from `pulid-perf.md` §4.
+#[derive(Debug, Clone, Copy)]
+struct Baseline {
+    host: &'static str,
+    p95_ms: f64,
+}
+
+fn baseline_for(name: &str) -> Result<Baseline> {
+    match name {
+        "halcyon" => Ok(Baseline {
+            host: "halcyon",
+            p95_ms: BASELINE_HALCYON_P95_MS,
+        }),
+        "plato" => Ok(Baseline {
+            host: "plato",
+            p95_ms: BASELINE_PLATO_P95_MS,
+        }),
+        other => bail!("unknown baseline host `{other}`; pulid-perf.md names halcyon and plato"),
+    }
+}
 
 /// Resident-set peak, in bytes.
 fn peak_rss_bytes() -> u64 {
@@ -97,20 +154,6 @@ fn validate_bench_args(warmups: usize, runs: usize) -> Result<Option<String>> {
         )));
     }
     Ok(None)
-}
-
-fn report(label: &str, mut samples: Vec<f64>) {
-    samples.sort_by(|a, b| a.partial_cmp(b).unwrap());
-    let mean = samples.iter().sum::<f64>() / samples.len() as f64;
-    println!(
-        "{label:<10} n={:<3} min={:8.1} ms  mean={:8.1} ms  p50={:8.1} ms  p95={:8.1} ms  max={:8.1} ms",
-        samples.len(),
-        samples.first().copied().unwrap_or_default(),
-        mean,
-        percentile(&samples, 50.0),
-        percentile(&samples, 95.0),
-        samples.last().copied().unwrap_or_default(),
-    );
 }
 
 fn synthetic_face(width: u32, height: u32) -> RgbImage {
@@ -183,7 +226,50 @@ fn run_inventory(dir: &Path, write: Option<&Path>) -> Result<()> {
     Ok(())
 }
 
-fn run_bench(dir: &Path, warmups: usize, runs: usize) -> Result<()> {
+/// What one `bench` invocation was asked to measure.
+struct BenchOptions {
+    warmups: usize,
+    runs: usize,
+    /// Also measure the retained `candle-onnx` oracle and report the speedup.
+    compare: bool,
+    /// Apply §1's "at least 25% faster" criterion against a named host.
+    regress_against: Option<Baseline>,
+    /// Also measure the EVA tower and the IDFormer.
+    full: Option<PulidPaths>,
+}
+
+/// Sorted samples plus the two percentiles every row reports.
+fn report(label: &str, mut samples: Vec<f64>) -> f64 {
+    samples.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let mean = samples.iter().sum::<f64>() / samples.len() as f64;
+    let p95 = percentile(&samples, 95.0);
+    println!(
+        "{label:<12} n={:<3} min={:8.1} ms  mean={:8.1} ms  p50={:8.1} ms  p95={:8.1} ms  max={:8.1} ms",
+        samples.len(),
+        samples.first().copied().unwrap_or_default(),
+        mean,
+        percentile(&samples, 50.0),
+        p95,
+        samples.last().copied().unwrap_or_default(),
+    );
+    p95
+}
+
+/// Time one closure, in milliseconds.
+fn timed<T>(f: impl FnOnce() -> Result<T>) -> Result<f64> {
+    let t = Instant::now();
+    f()?;
+    Ok(t.elapsed().as_secs_f64() * 1000.0)
+}
+
+fn run_bench(dir: &Path, options: BenchOptions) -> Result<()> {
+    let BenchOptions {
+        warmups,
+        runs,
+        compare,
+        regress_against,
+        full,
+    } = options;
     let advisory = validate_bench_args(warmups, runs)?;
     if let Some(note) = &advisory {
         println!("{note}\n");
@@ -198,11 +284,15 @@ fn run_bench(dir: &Path, warmups: usize, runs: usize) -> Result<()> {
             "release"
         }
     );
+    println!("load average at start: {}", load_average());
     let rss_start = peak_rss_bytes();
 
     let load = Instant::now();
     let detector_model = load_onnx_model(&dir.join(DETECTOR), None)?;
     let recognizer_model = load_onnx_model(&dir.join(RECOGNIZER), None)?;
+    // The oracle keeps its own copy of each graph, because the shipped
+    // constructors consume theirs — which is the point of #1227.
+    let oracle = compare.then(|| (detector_model.model.clone(), recognizer_model.model.clone()));
     let detector = ScrfdDetector::new(detector_model.model)?;
     let recognizer = ArcFaceRecognizer::new(recognizer_model.model)?;
     println!(
@@ -213,29 +303,151 @@ fn run_bench(dir: &Path, warmups: usize, runs: usize) -> Result<()> {
 
     let source = synthetic_face(1024, 768);
     let crop = synthetic_face(112, 112);
+    let eva_crop = synthetic_face(512, 512);
+    let arcface_vector = vec![0.05f32; 512];
 
     let mut detect_ms = Vec::new();
     let mut embed_ms = Vec::new();
+    let mut eva_build_ms = Vec::new();
+    let mut eva_forward_ms = Vec::new();
+    let mut idformer_build_ms = Vec::new();
+    let mut idformer_forward_ms = Vec::new();
     for i in 0..(warmups + runs) {
-        let t = Instant::now();
-        let _ = detector.detect(&source).context("SCRFD evaluation")?;
-        let d = t.elapsed().as_secs_f64() * 1000.0;
-        let t = Instant::now();
-        let _ = recognizer.embed_crop(&crop).context("ArcFace evaluation")?;
-        let e = t.elapsed().as_secs_f64() * 1000.0;
+        let d = timed(|| detector.detect(&source).context("SCRFD evaluation"))?;
+        let e = timed(|| recognizer.embed_crop(&crop).context("ArcFace evaluation"))?;
+        let mut stages = [0.0f64; 4];
+        if let Some(paths) = &full {
+            compose_identity_tokens_observed(
+                paths,
+                &arcface_vector,
+                &eva_crop,
+                &mut |stage, elapsed| {
+                    let ms = elapsed.as_secs_f64() * 1000.0;
+                    let slot = match stage {
+                        ComposeStage::EvaBuild => 0,
+                        ComposeStage::EvaForward => 1,
+                        ComposeStage::IdFormerBuild => 2,
+                        ComposeStage::IdFormerForward => 3,
+                    };
+                    stages[slot] = ms;
+                },
+            )
+            .context("EVA tower + IDFormer evaluation")?;
+        }
         if i >= warmups {
             detect_ms.push(d);
             embed_ms.push(e);
+            if full.is_some() {
+                eva_build_ms.push(stages[0]);
+                eva_forward_ms.push(stages[1]);
+                idformer_build_ms.push(stages[2]);
+                idformer_forward_ms.push(stages[3]);
+            }
         }
     }
-    let total: Vec<f64> = detect_ms
+
+    // The per-image total is the sum of the stages that actually ran, sample by
+    // sample — never the sum of independently sorted percentiles, which is a
+    // different and larger number.
+    let mut total: Vec<f64> = detect_ms
         .iter()
         .zip(embed_ms.iter())
         .map(|(d, e)| d + e)
         .collect();
-    report("scrfd", detect_ms);
-    report("arcface", embed_ms);
-    report("per-image", total.clone());
+    report("scrfd", detect_ms.clone());
+    report("arcface", embed_ms.clone());
+    let face_p95 = report("face-stack", total.clone());
+    let mut full_p95 = None;
+    if full.is_some() {
+        // Build and forward are reported apart because they answer different
+        // questions: the forward is arithmetic, the build is what the
+        // drop-and-reload rule re-pays on every request and is therefore what a
+        // residency change (`pulid-perf.md` §3) would buy back.
+        report("eva-build", eva_build_ms.clone());
+        report("eva-forward", eva_forward_ms.clone());
+        report("idformer-build", idformer_build_ms.clone());
+        report("idformer-fwd", idformer_forward_ms.clone());
+        for (i, sample) in total.iter_mut().enumerate() {
+            *sample +=
+                eva_build_ms[i] + eva_forward_ms[i] + idformer_build_ms[i] + idformer_forward_ms[i];
+        }
+        full_p95 = Some(report("per-image", total.clone()));
+    }
+
+    if let Some((detector_graph, recognizer_graph)) = oracle {
+        println!("\n--- paired against the candle-onnx oracle (the path #1227 replaced) ---");
+        // Paired and INTERLEAVED, on byte-identical blobs, comparing network to
+        // network rather than production entry point to raw graph. Two
+        // sequential blocks on a shared machine measure whatever else the box
+        // was doing during each block; alternating within one iteration makes
+        // both evaluators see the same contention. The blob and letterbox are
+        // excluded from BOTH sides because they are common to both.
+        let boxed = mold_inference::identity::warp::letterbox_top_left(&source, 640);
+        let detect_blob = ScrfdDetector::blob(&boxed.image)?;
+        let embed_blob = ArcFaceRecognizer::blob(&crop)?;
+        let scrfd_net = ScrfdNet::new(&detector_graph, &Device::Cpu)?;
+        let arcface_net = IResNet100::new(&recognizer_graph, &Device::Cpu)?;
+        let mut port_detect = Vec::new();
+        let mut port_embed = Vec::new();
+        let mut oracle_detect = Vec::new();
+        let mut oracle_embed = Vec::new();
+        for i in 0..(warmups + runs) {
+            let pd = timed(|| scrfd_net.forward(&detect_blob))?;
+            let od = timed(|| {
+                mold_inference::identity::scrfd_net::reference_forward(
+                    &detector_graph,
+                    &detect_blob,
+                )
+            })?;
+            let pe = timed(|| arcface_net.forward(&embed_blob))?;
+            let oe = timed(|| {
+                mold_inference::identity::arcface_net::reference_forward(
+                    &recognizer_graph,
+                    &embed_blob,
+                )
+            })?;
+            if i >= warmups {
+                port_detect.push(pd);
+                port_embed.push(pe);
+                oracle_detect.push(od);
+                oracle_embed.push(oe);
+            }
+        }
+        let pair = |port: Vec<f64>, oracle: Vec<f64>| -> (f64, f64) {
+            let sum = |v: &[f64]| v.iter().sum::<f64>() / v.len() as f64;
+            (sum(&port), sum(&oracle))
+        };
+        let port_total: Vec<f64> = port_detect
+            .iter()
+            .zip(port_embed.iter())
+            .map(|(d, e)| d + e)
+            .collect();
+        let oracle_total: Vec<f64> = oracle_detect
+            .iter()
+            .zip(oracle_embed.iter())
+            .map(|(d, e)| d + e)
+            .collect();
+        report("port-scrfd", port_detect.clone());
+        report("onnx-scrfd", oracle_detect.clone());
+        report("port-arcface", port_embed.clone());
+        report("onnx-arcface", oracle_embed.clone());
+        let port_p95 = report("port-graph", port_total.clone());
+        let oracle_p95 = report("onnx-graph", oracle_total.clone());
+        for (label, (port, orc)) in [
+            ("scrfd", pair(port_detect, oracle_detect)),
+            ("arcface", pair(port_embed, oracle_embed)),
+            ("graph", pair(port_total, oracle_total)),
+        ] {
+            println!(
+                "{label:<12} mean speedup {:.2}x  ({orc:.1} ms -> {port:.1} ms)",
+                orc / port.max(f64::MIN_POSITIVE)
+            );
+        }
+        println!(
+            "graph p95 speedup {:.2}x  ({oracle_p95:.1} ms -> {port_p95:.1} ms)",
+            oracle_p95 / port_p95.max(f64::MIN_POSITIVE)
+        );
+    }
 
     let rss_end = peak_rss_bytes();
     println!(
@@ -243,12 +455,25 @@ fn run_bench(dir: &Path, warmups: usize, runs: usize) -> Result<()> {
         rss_end as f64 / 1024.0 / 1024.0,
         (rss_end.saturating_sub(rss_start)) as f64 / 1024.0 / 1024.0
     );
-    let mut sorted = total;
-    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
-    let p95 = percentile(&sorted, 95.0);
+    println!("load average at end: {}", load_average());
+
+    if let Some(per_image) = full_p95 {
+        // Reported, never gated. #1222's budget was stated over SCRFD + ArcFace
+        // and nothing else, so applying it to a measurement that now covers
+        // four stages would fail a gate this build was never subject to. What
+        // the number IS good for is recorded in `pulid-perf.md` §4: it is the
+        // first per-request figure for the whole extraction, and it is what any
+        // future budget should be stated over.
+        println!(
+            "\nWHOLE EXTRACTION: p95 per image = {per_image:.1} ms across four stages. No budget \
+             has ever been stated over this; #1222's is the face stack alone."
+        );
+    }
+
+    let p95 = face_p95;
     let passed = p95 <= LATENCY_BUDGET_MS;
     println!(
-        "\n{}: p95 per image = {p95:.1} ms, budget = {LATENCY_BUDGET_MS:.0} ms -> {}",
+        "\n{}: face-stack p95 per image = {p95:.1} ms, budget = {LATENCY_BUDGET_MS:.0} ms -> {}",
         if advisory.is_some() {
             "ADVISORY (not the gate protocol)"
         } else {
@@ -263,38 +488,106 @@ fn run_bench(dir: &Path, warmups: usize, runs: usize) -> Result<()> {
     if !passed {
         bail!("latency gate failed: p95 {p95:.1} ms exceeds the {LATENCY_BUDGET_MS:.0} ms budget");
     }
+
+    if let Some(baseline) = regress_against {
+        // The baselines cover SCRFD + ArcFace only, so the comparison is made
+        // against the face stack even when `--full` measured more. Comparing a
+        // four-stage total to a two-stage baseline would report a regression
+        // that is really a wider measurement.
+        let ceiling = baseline.p95_ms * REGRESSION_MARGIN;
+        let improvement = (1.0 - face_p95 / baseline.p95_ms) * 100.0;
+        println!(
+            "\nREGRESSION vs {} ({:.1} ms baseline): face-stack p95 {face_p95:.1} ms is \
+             {improvement:.1}% faster, ceiling {ceiling:.1} ms -> {}",
+            baseline.host,
+            baseline.p95_ms,
+            if face_p95 <= ceiling { "PASS" } else { "FAIL" }
+        );
+        if advisory.is_some() {
+            bail!("--regress-against needs the gate protocol, not an advisory sample count");
+        }
+        if face_p95 > ceiling {
+            bail!(
+                "regression gate failed: face-stack p95 {face_p95:.1} ms exceeds {ceiling:.1} ms \
+                 (75% of the {} baseline)",
+                baseline.host
+            );
+        }
+    }
     Ok(())
+}
+
+/// The 1-minute load average, so a recorded number carries the conditions it
+/// was measured under.
+///
+/// `pulid-face-extraction.md`'s own cautionary example is a p95 that tripled
+/// under load average 83; a benchmark that does not report this invites the
+/// same mistake again.
+fn load_average() -> String {
+    let mut loads = [0f64; 3];
+    // SAFETY: `getloadavg` writes at most `nelem` doubles into the buffer.
+    let n = unsafe { libc::getloadavg(loads.as_mut_ptr(), 3) };
+    if n < 1 {
+        return "unavailable".to_string();
+    }
+    format!("{:.2}", loads[0])
 }
 
 fn main() -> Result<()> {
     let args: Vec<String> = std::env::args().collect();
     let usage = "usage: pulid_face_probe <inventory|bench> <assets-dir> [--write PATH] \
-                 [--warmups N] [--runs N]";
+                 [--warmups N] [--runs N] [--compare] [--regress-against halcyon|plato] \
+                 [--full --adapter PATH --eva PATH]";
     if args.len() < 3 {
         bail!("{usage}");
     }
     let dir = PathBuf::from(&args[2]);
     let mut write: Option<PathBuf> = None;
-    let mut warmups = 5usize;
-    let mut runs = 20usize;
+    let mut warmups = GATE_WARMUPS;
+    let mut runs = GATE_RUNS;
+    let mut compare = false;
+    let mut regress_against: Option<Baseline> = None;
+    let mut full = false;
+    let mut adapter: Option<PathBuf> = None;
+    let mut eva: Option<PathBuf> = None;
     let mut i = 3;
+    let value = |i: usize, flag: &str| -> Result<String> {
+        args.get(i + 1)
+            .cloned()
+            .with_context(|| format!("{flag} needs a value"))
+    };
     while i < args.len() {
         match args[i].as_str() {
             "--write" => {
-                write = Some(PathBuf::from(
-                    args.get(i + 1).context("--write needs a path")?,
-                ));
+                write = Some(PathBuf::from(value(i, "--write")?));
                 i += 2;
             }
             "--warmups" => {
-                warmups = args
-                    .get(i + 1)
-                    .context("--warmups needs a count")?
-                    .parse()?;
+                warmups = value(i, "--warmups")?.parse()?;
                 i += 2;
             }
             "--runs" => {
-                runs = args.get(i + 1).context("--runs needs a count")?.parse()?;
+                runs = value(i, "--runs")?.parse()?;
+                i += 2;
+            }
+            "--compare" => {
+                compare = true;
+                i += 1;
+            }
+            "--regress-against" => {
+                regress_against = Some(baseline_for(&value(i, "--regress-against")?)?);
+                i += 2;
+            }
+            "--full" => {
+                full = true;
+                i += 1;
+            }
+            "--adapter" => {
+                adapter = Some(PathBuf::from(value(i, "--adapter")?));
+                i += 2;
+            }
+            "--eva" => {
+                eva = Some(PathBuf::from(value(i, "--eva")?));
                 i += 2;
             }
             other => bail!("unknown argument `{other}`\n{usage}"),
@@ -302,7 +595,37 @@ fn main() -> Result<()> {
     }
     match args[1].as_str() {
         "inventory" => run_inventory(&dir, write.as_deref()),
-        "bench" => run_bench(&dir, warmups, runs),
+        "bench" => {
+            let full = if full {
+                Some(PulidPaths {
+                    adapter: adapter.context(
+                        "--full needs --adapter <pulid_flux_v0.9.1.safetensors>: the IDFormer \
+                         lives in the adapter checkpoint",
+                    )?,
+                    vision_encoder_source: eva.context(
+                        "--full needs --eva <EVA02_CLIP_L_336_psz14_s6B.pt>: the vision tower is \
+                         derived from it on first use",
+                    )?,
+                    face_detector: dir.join(DETECTOR),
+                    face_recognizer: dir.join(RECOGNIZER),
+                })
+            } else {
+                if adapter.is_some() || eva.is_some() {
+                    bail!("--adapter and --eva only mean something with --full");
+                }
+                None
+            };
+            run_bench(
+                &dir,
+                BenchOptions {
+                    warmups,
+                    runs,
+                    compare,
+                    regress_against,
+                    full,
+                },
+            )
+        }
         other => bail!("unknown subcommand `{other}`\n{usage}"),
     }
 }
@@ -350,6 +673,24 @@ mod tests {
         assert!(validate_bench_args(GATE_WARMUPS - 1, GATE_RUNS)
             .unwrap()
             .is_some());
+    }
+
+    #[test]
+    fn the_named_baselines_are_the_ones_the_doc_records() {
+        assert_eq!(baseline_for("halcyon").unwrap().p95_ms, 415.7);
+        assert_eq!(baseline_for("plato").unwrap().p95_ms, 1574.5);
+        let err = baseline_for("hal9000").unwrap_err();
+        assert!(format!("{err}").contains("halcyon and plato"), "{err}");
+    }
+
+    /// "At least 25% faster" has to mean one thing. A build landing exactly on
+    /// the ceiling passes; a hair over it fails.
+    #[test]
+    fn the_regression_ceiling_is_three_quarters_of_the_baseline() {
+        let ceiling = BASELINE_HALCYON_P95_MS * REGRESSION_MARGIN;
+        assert!((ceiling - 311.775).abs() < 1e-9, "{ceiling}");
+        assert!(ceiling <= BASELINE_HALCYON_P95_MS * REGRESSION_MARGIN);
+        assert!(ceiling + 1e-6 > BASELINE_HALCYON_P95_MS * REGRESSION_MARGIN);
     }
 
     #[test]

--- a/crates/mold-inference/src/bin/pulid_face_probe.rs
+++ b/crates/mold-inference/src/bin/pulid_face_probe.rs
@@ -41,16 +41,16 @@ use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use anyhow::{bail, Context, Result};
+use candle_core::Device;
 use image::RgbImage;
+use mold_core::pulid_assets::PulidPaths;
+use mold_inference::identity::arcface_net::IResNet100;
+use mold_inference::identity::extraction::{compose_identity_tokens_observed, ComposeStage};
 use mold_inference::identity::onnx_graph::load_onnx_model;
 use mold_inference::identity::onnx_inventory::{
     graph_inventory, ignored_attributes, pinned_input_makes_pooling_exact,
     unsupported_by_candle_onnx, GraphInventory,
 };
-use candle_core::Device;
-use mold_core::pulid_assets::PulidPaths;
-use mold_inference::identity::extraction::{compose_identity_tokens_observed, ComposeStage};
-use mold_inference::identity::arcface_net::IResNet100;
 use mold_inference::identity::scrfd_net::ScrfdNet;
 use mold_inference::identity::{arcface::ArcFaceRecognizer, scrfd::ScrfdDetector};
 
@@ -354,8 +354,8 @@ fn run_bench(dir: &Path, options: BenchOptions) -> Result<()> {
         .zip(embed_ms.iter())
         .map(|(d, e)| d + e)
         .collect();
-    report("scrfd", detect_ms.clone());
-    report("arcface", embed_ms.clone());
+    report("scrfd", detect_ms);
+    report("arcface", embed_ms);
     let face_p95 = report("face-stack", total.clone());
     let mut full_p95 = None;
     if full.is_some() {
@@ -371,7 +371,7 @@ fn run_bench(dir: &Path, options: BenchOptions) -> Result<()> {
             *sample +=
                 eva_build_ms[i] + eva_forward_ms[i] + idformer_build_ms[i] + idformer_forward_ms[i];
         }
-        full_p95 = Some(report("per-image", total.clone()));
+        full_p95 = Some(report("per-image", total));
     }
 
     if let Some((detector_graph, recognizer_graph)) = oracle {

--- a/crates/mold-inference/src/identity/arcface.rs
+++ b/crates/mold-inference/src/identity/arcface.rs
@@ -18,14 +18,13 @@
 //! travels to #1229, and [`ArcFaceEmbedding::l2_normalized`] is offered beside
 //! it for the cosine-similarity comparisons parity testing needs.
 
-use std::collections::HashMap;
-
 use anyhow::{bail, Context, Result};
-use candle_core::{DType, Device, Tensor};
+use candle_core::{Device, Tensor};
 use candle_onnx::onnx::ModelProto;
 use image::RgbImage;
 
 use super::align::{estimate_arcface_norm, Landmarks5};
+use super::arcface_net::IResNet100;
 use super::warp::warp_affine;
 
 /// The aligned crop size the recognizer takes, `glintr100`'s declared input.
@@ -82,37 +81,35 @@ pub fn norm_crop(image: &RgbImage, landmarks: &Landmarks5) -> Result<RgbImage> {
         .context("the ArcFace alignment transform was not invertible")
 }
 
-/// The recognizer: one decoded `glintr100` graph.
+/// The recognizer: the resident `glintr100` network.
+///
+/// The `ModelProto` is consumed at construction and dropped — see
+/// [`super::arcface_net`] and `docs/architecture/pulid-perf.md` §1. This is
+/// where the per-call re-materialization of 261 MB of initializers used to be.
 pub struct ArcFaceRecognizer {
-    model: ModelProto,
-    input_name: String,
-    output_name: String,
+    net: IResNet100,
 }
 
 impl ArcFaceRecognizer {
-    /// Wrap a decoded `glintr100` graph.
+    /// Wrap a decoded `glintr100` graph, on the CPU.
     pub fn new(model: ModelProto) -> Result<Self> {
+        Self::new_on_device(model, &Device::Cpu)
+    }
+
+    /// Wrap a decoded `glintr100` graph, placing its weights on `device`.
+    pub fn new_on_device(model: ModelProto, device: &Device) -> Result<Self> {
         let graph = model
             .graph
             .as_ref()
             .context("the ArcFace model carries no graph")?;
-        let input_name = graph
-            .input
-            .first()
-            .context("the ArcFace graph declares no input")?
-            .name
-            .clone();
         if graph.output.len() != 1 {
             bail!(
                 "expected exactly one ArcFace output (arcface_onnx.py:56), got {}",
                 graph.output.len()
             );
         }
-        let output_name = graph.output[0].name.clone();
         Ok(Self {
-            model,
-            input_name,
-            output_name,
+            net: IResNet100::new(&model, device).context("building the ArcFace network")?,
         })
     }
 
@@ -142,17 +139,10 @@ impl ArcFaceRecognizer {
 
     /// Embed an already-aligned 112x112 crop.
     pub fn embed_crop(&self, crop: &RgbImage) -> Result<ArcFaceEmbedding> {
-        let mut inputs = HashMap::new();
-        inputs.insert(self.input_name.clone(), Self::blob(crop)?);
-        let outputs = candle_onnx::simple_eval(&self.model, inputs)
-            .context("ArcFace graph evaluation failed")?;
-        let tensor = outputs
-            .get(&self.output_name)
-            .with_context(|| format!("ArcFace produced no `{}` output", self.output_name))?;
-        let raw = tensor
-            .to_dtype(DType::F32)?
-            .flatten_all()?
-            .to_vec1::<f32>()?;
+        let raw = self
+            .net
+            .forward(&Self::blob(crop)?)
+            .context("ArcFace evaluation failed")?;
         if raw.len() != EMBEDDING_DIM {
             bail!(
                 "ArcFace returned {} values, expected {EMBEDDING_DIM}",
@@ -167,15 +157,16 @@ impl ArcFaceRecognizer {
         self.embed_crop(&norm_crop(image, landmarks)?)
     }
 
-    /// The device every evaluation runs on.
+    /// The device this recognizer's weights are resident on.
     ///
-    /// `candle-onnx` materializes each initializer with `Device::Cpu`
-    /// (`candle-onnx/src/eval.rs:191-232`) and `Gemm` builds its `alpha`/`beta`
-    /// tensors there too (`:1794-1798`), so the evaluator is CPU-only by
-    /// construction. Stated as a function rather than a comment so a caller
-    /// that plans placement reads it from one place.
-    pub fn device() -> Device {
-        Device::Cpu
+    /// Since #1227 the network is an ordinary resident candle module, so this
+    /// is a real property of the instance rather than the `candle-onnx`
+    /// evaluator's hardcoded `Device::Cpu`. Milestone 1 still only ever builds
+    /// it on the CPU — extraction runs at admission, before any device is
+    /// leased (`docs/architecture/pulid-perf.md` §1) — and
+    /// [`super::IdentityExtractor::load`] keeps asserting that.
+    pub fn device(&self) -> &Device {
+        self.net.device()
     }
 }
 
@@ -251,10 +242,5 @@ mod tests {
         assert!((n[1] - 0.8).abs() < 1e-6);
         let len: f32 = n.iter().map(|v| v * v).sum::<f32>().sqrt();
         assert!((len - 1.0).abs() < 1e-6);
-    }
-
-    #[test]
-    fn the_evaluator_device_is_cpu() {
-        assert!(ArcFaceRecognizer::device().is_cpu());
     }
 }

--- a/crates/mold-inference/src/identity/arcface_net.rs
+++ b/crates/mold-inference/src/identity/arcface_net.rs
@@ -1,0 +1,272 @@
+//! `glintr100` (iResNet100) as a resident candle module (#1227).
+//!
+//! The recognizer is where the re-materialization tax bites hardest: 261 MB of
+//! initializers copied onto `Device::Cpu` on **every** `simple_eval` call
+//! (`candle-onnx/src/eval.rs:191-232`), for a 112x112 forward pass.
+//! `docs/architecture/pulid-perf.md` §1 chose to read them once and keep them.
+//!
+//! ## The topology
+//!
+//! Ported from `insightface/recognition/arcface_torch/backbones/iresnet.py`
+//! (`IBasicBlock.forward`, lines 30-50; `IResNet.forward`, lines 145-160;
+//! `iresnet100` = `IResNet(IBasicBlock, [3, 13, 30, 3])`, line 190), with the
+//! exported graph as the authority for what survived the export. `IBasicBlock`
+//! is pre-activation:
+//!
+//! ```text
+//!   out = bn1(x)
+//!   out = prelu(bn2(conv1(out)))
+//!   out = bn3(conv2(out))
+//!   out += downsample(x) if downsample else x
+//! ```
+//!
+//! and the export folds `bn2`, `bn3`, and the downsample's batch-norm into
+//! their convolutions' biases — which is why the graph carries 103 `Conv` nodes
+//! but only 51 `BatchNormalization`s: one `bn1` per block (49), the trunk's
+//! closing `bn2`, and the `features` batch-norm after the fully-connected
+//! layer. `iresnet.py:124` gives every layer `stride=2`, including the first,
+//! so 112 -> 56 -> 28 -> 14 -> 7 and the flatten is `512 * 7 * 7 = 25088`.
+//!
+//! ## The output is RAW
+//!
+//! `ArcFaceONNX.get` stores the network output unnormalized
+//! (`arcface_onnx.py:63-66`) and PuLID conditions on exactly that
+//! (`pipeline_flux.py:130`, `:156-158`). Nothing here normalizes; see
+//! [`super::arcface`]'s module doc for the full argument.
+//!
+//! ONNX op semantics used here, opset 11
+//! (<https://github.com/onnx/onnx/blob/main/docs/Operators.md>): `Conv`,
+//! `BatchNormalization`, `PRelu`, `Add`, `Flatten`, `Gemm`.
+
+use anyhow::{bail, Context, Result};
+use candle_core::{Device, Module, Tensor};
+use candle_nn::{Conv2d, PReLU};
+use candle_onnx::onnx::ModelProto;
+
+use super::onnx_weights::{FoldedBatchNorm, WeightTape};
+
+/// `iresnet100`'s block ladder, `iresnet.py:190`.
+const LAYER_BLOCKS: [usize; 4] = [3, 13, 30, 3];
+/// Channel width per layer, `iresnet.py:120-133`.
+const LAYER_CHANNELS: [usize; 4] = [64, 128, 256, 512];
+/// The trunk's stem width, `iresnet.py:113`.
+const STEM_CHANNELS: usize = 64;
+/// Spatial extent reaching the flatten: 112 halved four times.
+const FINAL_EXTENT: usize = 7;
+/// Embedding width, `iresnet.py:139`.
+pub const EMBEDDING_DIM: usize = 512;
+
+/// One pre-activation IR block.
+struct IrBlock {
+    bn1: FoldedBatchNorm,
+    conv1: Conv2d,
+    prelu: PReLU,
+    conv2: Conv2d,
+    /// The 1x1 projection on a stage's first block. Unlike SCRFD's, it is
+    /// **strided** rather than pooled, and it is applied to the block's input
+    /// *before* `bn1` (`iresnet.py:41-42`: `identity = self.downsample(x)`).
+    downsample: Option<Conv2d>,
+}
+
+impl IrBlock {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let identity = match &self.downsample {
+            Some(conv) => conv.forward(xs)?,
+            None => xs.clone(),
+        };
+        let out = self.bn1.forward(xs)?;
+        let out = self.conv1.forward(&out)?;
+        let out = self.prelu.forward(&out)?;
+        let out = self.conv2.forward(&out)?;
+        Ok((out + identity)?)
+    }
+}
+
+/// `glintr100`'s iResNet100 as resident tensors.
+pub struct IResNet100 {
+    stem_conv: Conv2d,
+    stem_prelu: PReLU,
+    blocks: Vec<IrBlock>,
+    bn2: FoldedBatchNorm,
+    /// `[512, 25088]`, applied as `x @ w^T` because the graph's `Gemm` sets
+    /// `transB = 1`.
+    fc_weight: Tensor,
+    fc_bias: Tensor,
+    features: FoldedBatchNorm,
+    device: Device,
+}
+
+impl IResNet100 {
+    /// Read every parameter out of a decoded graph, in graph order.
+    ///
+    /// `device` is a parameter so a future GPU path needs no change here;
+    /// milestone 1 always passes `Device::Cpu`.
+    pub fn new(model: &ModelProto, device: &Device) -> Result<Self> {
+        let mut tape = WeightTape::new(model, device)?;
+        let stem_conv = tape
+            .next_conv(STEM_CHANNELS, 3, 3, 1)
+            .context("the iResNet stem convolution")?;
+        let stem_prelu = tape
+            .next_prelu(STEM_CHANNELS)
+            .context("the iResNet stem PReLU")?;
+
+        let mut blocks = Vec::with_capacity(LAYER_BLOCKS.iter().sum());
+        let mut in_channels = STEM_CHANNELS;
+        for (layer, (&channels, &count)) in
+            LAYER_CHANNELS.iter().zip(LAYER_BLOCKS.iter()).enumerate()
+        {
+            for block in 0..count {
+                // `iresnet.py:124`: every layer is built with `stride=2`, so
+                // each layer's FIRST block strides and projects its shortcut.
+                let strided = block == 0;
+                let stride = if strided { 2 } else { 1 };
+                let block_in = if strided { in_channels } else { channels };
+                let bn1 = tape
+                    .next_batch_norm(block_in)
+                    .with_context(|| format!("layer {layer} block {block} bn1"))?;
+                let conv1 = tape
+                    .next_conv(channels, block_in, 3, 1)
+                    .with_context(|| format!("layer {layer} block {block} conv 1"))?;
+                let prelu = tape
+                    .next_prelu(channels)
+                    .with_context(|| format!("layer {layer} block {block} prelu"))?;
+                let conv2 = tape
+                    .next_conv(channels, channels, 3, stride)
+                    .with_context(|| format!("layer {layer} block {block} conv 2"))?;
+                let downsample = if strided {
+                    Some(
+                        tape.next_conv(channels, block_in, 1, 2)
+                            .with_context(|| format!("layer {layer} block {block} shortcut"))?,
+                    )
+                } else {
+                    None
+                };
+                blocks.push(IrBlock {
+                    bn1,
+                    conv1,
+                    prelu,
+                    conv2,
+                    downsample,
+                });
+            }
+            in_channels = channels;
+        }
+
+        let bn2 = tape
+            .next_batch_norm(EMBEDDING_DIM)
+            .context("the iResNet closing batch-norm")?;
+        let (fc_weight, fc_bias) = tape
+            .next_gemm(EMBEDDING_DIM, EMBEDDING_DIM * FINAL_EXTENT * FINAL_EXTENT)
+            .context("the iResNet fully-connected layer")?;
+        let features = tape
+            .next_batch_norm(EMBEDDING_DIM)
+            .context("the iResNet feature batch-norm")?;
+        tape.finish()
+            .context("the ArcFace graph carries parameters this port does not run")?;
+
+        Ok(Self {
+            stem_conv,
+            stem_prelu,
+            blocks,
+            bn2,
+            fc_weight,
+            fc_bias,
+            features,
+            device: device.clone(),
+        })
+    }
+
+    /// The device every parameter is resident on.
+    pub fn device(&self) -> &Device {
+        &self.device
+    }
+
+    /// Embed one `[1, 3, 112, 112]` blob, returning the RAW 512-d output.
+    pub fn forward(&self, blob: &Tensor) -> Result<Vec<f32>> {
+        let (batch, _, _, _) = blob.dims4()?;
+        if batch != 1 {
+            bail!("the ArcFace port runs one crop at a time, got a batch of {batch}");
+        }
+        let mut xs = self.stem_conv.forward(blob)?;
+        xs = self.stem_prelu.forward(&xs)?;
+        for block in &self.blocks {
+            xs = block.forward(&xs)?;
+        }
+        xs = self.bn2.forward(&xs)?;
+        // ONNX `Flatten(axis = 1)`: `[1, C, H, W] -> [1, C * H * W]`, C-major,
+        // which is what the fully-connected layer's 25088 columns are ordered
+        // by.
+        let xs = xs.flatten_from(1)?;
+        // `Gemm(alpha = 1, beta = 1, transB = 1)`.
+        let xs = xs.matmul(&self.fc_weight.t()?.contiguous()?)?;
+        let xs = xs.broadcast_add(&self.fc_bias.reshape((1, EMBEDDING_DIM))?)?;
+        let xs = self.features.forward(&xs)?;
+        Ok(xs.flatten_all()?.to_vec1::<f32>()?)
+    }
+}
+
+/// Evaluate the graph through `candle-onnx`, the path this module replaced.
+///
+/// Retained as the **parity oracle** for `tests/pulid_handport_parity.rs`, and
+/// for nothing else — it is exactly the per-call re-materialization
+/// `pulid-perf.md` §1 set out to remove.
+#[doc(hidden)]
+pub fn reference_forward(model: &ModelProto, blob: &Tensor) -> Result<Vec<f32>> {
+    let graph = model
+        .graph
+        .as_ref()
+        .context("the ArcFace model carries no graph")?;
+    let input = graph
+        .input
+        .first()
+        .context("the ArcFace graph declares no input")?
+        .name
+        .clone();
+    let output = graph
+        .output
+        .first()
+        .context("the ArcFace graph declares no output")?
+        .name
+        .clone();
+    let outputs = candle_onnx::simple_eval(
+        model,
+        std::collections::HashMap::from([(input, blob.clone())]),
+    )
+    .context("ArcFace graph evaluation failed")?;
+    Ok(outputs
+        .get(&output)
+        .with_context(|| format!("ArcFace produced no `{output}` output"))?
+        .to_dtype(candle_core::DType::F32)?
+        .flatten_all()?
+        .to_vec1::<f32>()?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The ladder must account for exactly the op counts the pinned graph
+    /// declares, or the tape runs out of nodes on the real weights.
+    #[test]
+    fn the_block_ladder_matches_the_pinned_graphs_op_counts() {
+        let blocks: usize = LAYER_BLOCKS.iter().sum();
+        assert_eq!(blocks, 49);
+        // 1 stem + 2 per block + one 1x1 shortcut per layer.
+        let convs = 1 + blocks * 2 + LAYER_BLOCKS.len();
+        // The inventory records 4 + 95 + 4 = 103 convolutions.
+        assert_eq!(convs, 103);
+        // One `bn1` per block, plus `bn2` and `features`.
+        assert_eq!(blocks + 2, 51);
+        // One PReLU per block, plus the stem's.
+        assert_eq!(blocks + 1, 50);
+        // One residual add per block.
+        assert_eq!(blocks, 49);
+    }
+
+    #[test]
+    fn the_flatten_width_is_the_fully_connected_layers_column_count() {
+        assert_eq!(EMBEDDING_DIM * FINAL_EXTENT * FINAL_EXTENT, 25_088);
+        // 112 halved once per layer.
+        assert_eq!(112 >> LAYER_BLOCKS.len(), FINAL_EXTENT);
+    }
+}

--- a/crates/mold-inference/src/identity/arcface_net.rs
+++ b/crates/mold-inference/src/identity/arcface_net.rs
@@ -201,9 +201,11 @@ impl IResNet100 {
         //
         // Computed as `W @ X^T` rather than `X @ W^T` on purpose. `W` is
         // `[512, 25088]` — 51 MB — so materializing its transpose is 51 MB read
-        // and 51 MB written **per forward**, which measured as roughly a fifth
-        // of the whole 112x112 embedding. `X^T` is 25088 values. Same product,
-        // one transpose of the small operand.
+        // and 51 MB written **per forward**. That was about a sixth of the
+        // whole 112x112 embedding when this module first shipped it (~241 ms
+        // mean, against ~204 ms once it was gone), which was enough to make the
+        // resident port SLOWER than the evaluator it replaced. `X^T` is 25088
+        // values. Same product, one transpose of the small operand.
         let xs = self
             .fc_weight
             .matmul(&xs.t()?.contiguous()?)?

--- a/crates/mold-inference/src/identity/arcface_net.rs
+++ b/crates/mold-inference/src/identity/arcface_net.rs
@@ -43,7 +43,7 @@ use candle_core::{Device, Module, Tensor};
 use candle_nn::{Conv2d, PReLU};
 use candle_onnx::onnx::ModelProto;
 
-use super::onnx_weights::{FoldedBatchNorm, WeightTape};
+use super::onnx_weights::{place_input, FoldedBatchNorm, WeightTape};
 
 /// `iresnet100`'s block ladder, `iresnet.py:190`.
 const LAYER_BLOCKS: [usize; 4] = [3, 13, 30, 3];
@@ -182,12 +182,17 @@ impl IResNet100 {
     }
 
     /// Embed one `[1, 3, 112, 112]` blob, returning the RAW 512-d output.
+    ///
+    /// The blob arrives from [`super::arcface::ArcFaceRecognizer::blob`], built
+    /// on the CPU where the aligned crop lives, and is moved onto the weights'
+    /// device first — see [`place_input`].
     pub fn forward(&self, blob: &Tensor) -> Result<Vec<f32>> {
         let (batch, _, _, _) = blob.dims4()?;
         if batch != 1 {
             bail!("the ArcFace port runs one crop at a time, got a batch of {batch}");
         }
-        let mut xs = self.stem_conv.forward(blob)?;
+        let blob = place_input(blob, &self.device)?;
+        let mut xs = self.stem_conv.forward(&blob)?;
         xs = self.stem_prelu.forward(&xs)?;
         for block in &self.blocks {
             xs = block.forward(&xs)?;

--- a/crates/mold-inference/src/identity/arcface_net.rs
+++ b/crates/mold-inference/src/identity/arcface_net.rs
@@ -197,8 +197,17 @@ impl IResNet100 {
         // which is what the fully-connected layer's 25088 columns are ordered
         // by.
         let xs = xs.flatten_from(1)?;
-        // `Gemm(alpha = 1, beta = 1, transB = 1)`.
-        let xs = xs.matmul(&self.fc_weight.t()?.contiguous()?)?;
+        // `Gemm(alpha = 1, beta = 1, transB = 1)`: `Y = X @ W^T + B`.
+        //
+        // Computed as `W @ X^T` rather than `X @ W^T` on purpose. `W` is
+        // `[512, 25088]` — 51 MB — so materializing its transpose is 51 MB read
+        // and 51 MB written **per forward**, which measured as roughly a fifth
+        // of the whole 112x112 embedding. `X^T` is 25088 values. Same product,
+        // one transpose of the small operand.
+        let xs = self
+            .fc_weight
+            .matmul(&xs.t()?.contiguous()?)?
+            .reshape((1, EMBEDDING_DIM))?;
         let xs = xs.broadcast_add(&self.fc_bias.reshape((1, EMBEDDING_DIM))?)?;
         let xs = self.features.forward(&xs)?;
         Ok(xs.flatten_all()?.to_vec1::<f32>()?)

--- a/crates/mold-inference/src/identity/extraction.rs
+++ b/crates/mold-inference/src/identity/extraction.rs
@@ -140,6 +140,31 @@ fn adapter_sha256() -> String {
         .to_string()
 }
 
+/// Which half of [`compose_identity_tokens_observed`] a timing sample belongs
+/// to.
+///
+/// `docs/architecture/pulid-perf.md` §0 recorded that this half of the
+/// extraction had never been measured anywhere in the repository, and §4 made
+/// measuring it the first deliverable of the implementation phase. The two
+/// halves are reported separately because they are separately expensive and
+/// separately optimizable: the tower is a 24-block ViT over 577 tokens, the
+/// IDFormer is a much smaller cross-attention stack over 32 queries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ComposeStage {
+    /// Materializing the derived safetensors, preprocessing the crop, and
+    /// building the EVA02-CLIP vision tower — everything before its forward
+    /// pass. Separate from [`ComposeStage::EvaForward`] because it is what the
+    /// drop-and-reload rule pays for on every request, and therefore what a
+    /// residency change would buy back.
+    EvaBuild,
+    /// The EVA02-CLIP vision tower's forward pass.
+    EvaForward,
+    /// Reading the adapter and building the PuLID IDFormer.
+    IdFormerBuild,
+    /// The IDFormer's forward pass.
+    IdFormerForward,
+}
+
 /// Run the EVA tower and the IDFormer over one aligned crop.
 ///
 /// Split out from [`extract_identity_embedding`] so the weight-gated parity
@@ -149,7 +174,24 @@ pub(crate) fn compose_identity_tokens(
     arcface: &[f32],
     eva_crop_512: &image::RgbImage,
 ) -> Result<Vec<f32>> {
+    compose_identity_tokens_observed(paths, arcface, eva_crop_512, &mut |_, _| {})
+}
+
+/// [`compose_identity_tokens`] with a per-stage wall-clock observer.
+///
+/// The observer is the ONLY difference — `compose_identity_tokens` delegates
+/// here with a no-op, so there is one implementation and the benchmark cannot
+/// drift from the production path by measuring a copy of it. It exists for
+/// `pulid_face_probe bench --full`, which §4 requires before any performance
+/// claim about identity extraction is made.
+pub fn compose_identity_tokens_observed(
+    paths: &PulidPaths,
+    arcface: &[f32],
+    eva_crop_512: &image::RgbImage,
+    observe: &mut dyn FnMut(ComposeStage, std::time::Duration),
+) -> Result<Vec<f32>> {
     let device = Device::Cpu;
+    let mut stage_started = std::time::Instant::now();
     let vision_path = ensure_eva_clip_vision_safetensors(paths)
         .context("materializing the EVA02-CLIP vision tower")?;
 
@@ -178,11 +220,15 @@ pub(crate) fn compose_identity_tokens(
         };
         let tower = EvaClipVisionTower::new(vb, &device)
             .context("building the EVA02-CLIP-L-14-336 vision tower")?;
+        observe(ComposeStage::EvaBuild, stage_started.elapsed());
+        stage_started = std::time::Instant::now();
         let output = tower
             .forward(&pixels)
             .context("running the EVA02-CLIP vision tower")?;
+        observe(ComposeStage::EvaForward, stage_started.elapsed());
         (output.hidden_states, output.cls_projection)
     };
+    stage_started = std::time::Instant::now();
 
     // `pipeline_flux.py:181`: `cat([id_ante_embedding, id_cond_vit])` — the
     // RAW ArcFace output, not the L2-normalized one; only the CLIP projection
@@ -203,18 +249,22 @@ pub(crate) fn compose_identity_tokens(
         .with_context(|| format!("reading the PuLID adapter {}", paths.adapter.display()))?
     };
     let idformer = IdFormer::new(vb.pp("pulid_encoder")).context("building the PuLID IDFormer")?;
+    observe(ComposeStage::IdFormerBuild, stage_started.elapsed());
+    stage_started = std::time::Instant::now();
     let tokens = idformer
         .forward(&id_cond, &hidden_states)
         .context("running the PuLID IDFormer")?;
 
     let tokens = tokens.i(0).context("the IDFormer returned no batch")?;
-    tokens
+    let tokens = tokens
         .flatten_all()
         .context("flattening the identity tokens")?
         .to_dtype(DType::F32)
         .context("the identity tokens are numeric")?
         .to_vec1::<f32>()
-        .context("reading the identity tokens")
+        .context("reading the identity tokens")?;
+    observe(ComposeStage::IdFormerForward, stage_started.elapsed());
+    Ok(tokens)
 }
 
 #[cfg(test)]

--- a/crates/mold-inference/src/identity/mod.rs
+++ b/crates/mold-inference/src/identity/mod.rs
@@ -20,10 +20,13 @@
 
 pub mod align;
 pub mod arcface;
+pub mod arcface_net;
 pub mod extraction;
 pub mod onnx_graph;
 pub mod onnx_inventory;
+pub mod onnx_weights;
 pub mod scrfd;
+pub mod scrfd_net;
 pub mod warp;
 
 use std::path::Path;
@@ -99,15 +102,20 @@ impl IdentityExtractor {
     /// Load the detector and recognizer from a resolved PuLID bundle.
     ///
     /// `device` is accepted for symmetry with every other engine and is
-    /// asserted, not honoured: `candle-onnx` materializes every tensor on the
-    /// CPU (see [`arcface::ArcFaceRecognizer::device`]), so a caller that
-    /// believes it placed this on a GPU would be wrong. A non-CPU request is
-    /// an explicit error rather than a silent demotion.
+    /// asserted, not honoured. Since #1227 the two networks are ordinary
+    /// resident candle modules that *could* be placed anywhere
+    /// ([`scrfd_net::ScrfdNet::new`], [`arcface_net::IResNet100::new`] both
+    /// take a device), so this is no longer an evaluator limitation — it is the
+    /// call-site contract: extraction runs at ADMISSION, before the scheduler
+    /// has leased a device, so there is no device to name yet
+    /// (`docs/architecture/pulid-perf.md` §1 and §3, which design the post-lease
+    /// phase that would lift this). A non-CPU request is an explicit error
+    /// rather than a silent demotion.
     pub fn load(paths: &PulidPaths, device: &candle_core::Device) -> Result<Self> {
         if !device.is_cpu() {
             anyhow::bail!(
-                "PuLID face extraction runs on the CPU: candle-onnx materializes every \
-                 initializer on Device::Cpu (candle-onnx/src/eval.rs:191-232)"
+                "PuLID face extraction runs on the CPU: it happens at admission, before a \
+                 device is leased (docs/architecture/pulid-perf.md)"
             );
         }
         Self::from_paths(&paths.face_detector, &paths.face_recognizer)

--- a/crates/mold-inference/src/identity/onnx_weights.rs
+++ b/crates/mold-inference/src/identity/onnx_weights.rs
@@ -1,0 +1,645 @@
+//! Resident weights for the hand-ported face networks (#1227).
+//!
+//! `candle-onnx`'s `simple_eval` re-materializes **every** initializer on
+//! `Device::Cpu` on **every** call (`candle-onnx/src/eval.rs:191-232`), so the
+//! second call costs what the thousandth does — 261 MB of `glintr100` copied
+//! per embedding. `docs/architecture/pulid-perf.md` §1 chose option A: keep the
+//! ONNX file as the weight *container*, parse it once at load, and run ordinary
+//! resident `candle-core`/`candle-nn` forward passes thereafter.
+//!
+//! This module is the load-time half. It exists so [`super::scrfd_net`] and
+//! [`super::arcface_net`] never touch a `ModelProto` at inference time, and so
+//! the `ModelProto` itself can be dropped the moment construction finishes.
+//!
+//! ## Why the ONNX file and not a converted safetensors sidecar
+//!
+//! `encoders::eva_clip_convert`'s secure-publish pattern exists because its
+//! source is a **torch pickle**, which mold's runtime must never open more than
+//! once, in a private staging copy. Nothing of the kind applies here: both
+//! graphs are already read through
+//! [`super::onnx_graph::load_onnx_model`], which performs one bounded read of a
+//! retained descriptor and authenticates *those exact bytes* against the
+//! manifest pin before anything is decoded. Converting would add a second
+//! artifact, a second digest, a second staging-and-publish dance, and a cache
+//! whose freshness is another thing to get wrong — to save a one-time proto
+//! parse that already happens. The pinned file stays the single authority.
+//!
+//! ## Why the weights are consumed in graph order
+//!
+//! Both graphs name most of their parameters opaquely (`547`, `1335`), so a
+//! lookup table of hard-coded strings would be an unreadable transcription with
+//! nothing checking it. Instead [`WeightTape`] walks `graph.node` in
+//! **topological order** and hands each parameterized op's tensors to the
+//! hand-written module in the order that module visits them, asserting the
+//! shape of every one. A reordered or substituted graph fails at load with the
+//! op index and the shapes that disagreed, and [`WeightTape::finish`] refuses a
+//! graph with parameters nobody consumed.
+//!
+//! ONNX op semantics are taken from the spec
+//! (<https://github.com/onnx/onnx/blob/main/docs/Operators.md>), opset 11 for
+//! both graphs; each reimplemented op cites its section where it is used.
+
+use std::collections::HashMap;
+
+use anyhow::{bail, Context, Result};
+use candle_core::{Device, Tensor};
+use candle_nn::{Conv2d, Conv2dConfig, PReLU};
+use candle_onnx::onnx::{tensor_proto, NodeProto, TensorProto};
+
+/// ONNX ops that carry learned parameters in these two graphs.
+///
+/// The tape refuses to skip one of these. Everything else — `Relu`, `Add`,
+/// `Shape`, `Gather`, `Slice`, `Concat`, `Unsqueeze`, `Reshape`, `Transpose`,
+/// `Sigmoid`, `MaxPool`, `AveragePool`, `Resize`, `Flatten` — is structure the
+/// hand-written module already encodes, and is stepped over.
+const PARAMETERIZED: [&str; 5] = ["Conv", "BatchNormalization", "PRelu", "Gemm", "Mul"];
+
+/// `BatchNormalization` in inference mode, pre-folded.
+///
+/// ONNX spec: `Y = (X - mean) / sqrt(var + epsilon) * scale + B`, normalizing
+/// over the channel axis (dim 1). The division and the two affine terms are
+/// constant per channel, so they collapse at load into one multiply and one
+/// add:
+///
+/// ```text
+///   w = scale / sqrt(var + epsilon)
+///   b = B - mean * w
+///   Y = X * w + b
+/// ```
+///
+/// That is the same arithmetic, not an approximation of it, and the fold is
+/// computed in `f64` so the reciprocal square root does not lose a bit that the
+/// per-element form would have kept. `epsilon` comes from the node's own
+/// attribute — never a constant retyped here, because a graph exported with a
+/// different one would then be evaluated with mold's.
+#[derive(Debug, Clone)]
+pub struct FoldedBatchNorm {
+    /// Per-channel multiplier, shaped for the rank it will meet.
+    weight: Tensor,
+    /// Per-channel offset, shaped for the rank it will meet.
+    bias: Tensor,
+    channels: usize,
+}
+
+impl FoldedBatchNorm {
+    /// Apply to an `[N, C, ...]` tensor of any rank ≥ 2.
+    pub fn forward(&self, xs: &Tensor) -> candle_core::Result<Tensor> {
+        let rank = xs.rank();
+        let mut shape = vec![1usize; rank];
+        shape[1] = self.channels;
+        let w = self.weight.reshape(shape.clone())?;
+        let b = self.bias.reshape(shape)?;
+        xs.broadcast_mul(&w)?.broadcast_add(&b)
+    }
+
+    /// Channel count, so a builder can assert the shape it expected.
+    pub fn channels(&self) -> usize {
+        self.channels
+    }
+}
+
+/// Every float initializer of one graph, plus a cursor over its nodes.
+pub struct WeightTape<'a> {
+    nodes: Vec<&'a NodeProto>,
+    initializers: HashMap<&'a str, &'a TensorProto>,
+    cursor: usize,
+    device: Device,
+}
+
+impl<'a> WeightTape<'a> {
+    /// Start a tape over a decoded graph.
+    pub fn new(model: &'a candle_onnx::onnx::ModelProto, device: &Device) -> Result<Self> {
+        let graph = model
+            .graph
+            .as_ref()
+            .context("the ONNX model carries no graph")?;
+        Ok(Self {
+            nodes: graph.node.iter().collect(),
+            initializers: graph
+                .initializer
+                .iter()
+                .map(|t| (t.name.as_str(), t))
+                .collect(),
+            cursor: 0,
+            device: device.clone(),
+        })
+    }
+
+    /// Advance to the next node of `op_type`, refusing to step over any other
+    /// parameterized op.
+    fn next_node(&mut self, op_type: &str) -> Result<&'a NodeProto> {
+        while self.cursor < self.nodes.len() {
+            let node = self.nodes[self.cursor];
+            self.cursor += 1;
+            if node.op_type == op_type {
+                return Ok(node);
+            }
+            if PARAMETERIZED.contains(&node.op_type.as_str()) {
+                bail!(
+                    "the graph's parameter order does not match the hand-ported module: \
+                     expected `{op_type}` at node {}, found `{}`",
+                    self.cursor - 1,
+                    node.op_type
+                );
+            }
+        }
+        bail!("the graph ran out of nodes while looking for `{op_type}`")
+    }
+
+    /// Every parameterized op has been consumed.
+    pub fn finish(mut self) -> Result<()> {
+        while self.cursor < self.nodes.len() {
+            let node = self.nodes[self.cursor];
+            self.cursor += 1;
+            if PARAMETERIZED.contains(&node.op_type.as_str()) {
+                bail!(
+                    "the graph carries a `{}` at node {} that the hand-ported module never \
+                     consumed",
+                    node.op_type,
+                    self.cursor - 1
+                );
+            }
+        }
+        Ok(())
+    }
+
+    /// Materialize one float initializer by name.
+    ///
+    /// ONNX stores a `FLOAT` tensor either in `raw_data` (little-endian, which
+    /// is the only byte order the format defines) or in the `float_data`
+    /// repeated field. Both are accepted; anything else fails rather than being
+    /// coerced, because a silently reinterpreted dtype is a wrong render, not
+    /// an error.
+    fn initializer(&self, name: &str) -> Result<Tensor> {
+        let proto = self
+            .initializers
+            .get(name)
+            .with_context(|| format!("the graph names `{name}` but carries no such initializer"))?;
+        if proto.data_type != tensor_proto::DataType::Float as i32 {
+            bail!(
+                "initializer `{name}` is ONNX data type {}, expected FLOAT",
+                proto.data_type
+            );
+        }
+        let dims: Vec<usize> = proto
+            .dims
+            .iter()
+            .map(|d| usize::try_from(*d).context("a negative initializer dimension"))
+            .collect::<Result<_>>()?;
+        let count: usize = dims.iter().product();
+        let values: Vec<f32> = if !proto.raw_data.is_empty() {
+            if proto.raw_data.len() != count * 4 {
+                bail!(
+                    "initializer `{name}` holds {} raw bytes for {count} floats",
+                    proto.raw_data.len()
+                );
+            }
+            proto
+                .raw_data
+                .chunks_exact(4)
+                .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+                .collect()
+        } else {
+            proto.float_data.clone()
+        };
+        if values.len() != count {
+            bail!(
+                "initializer `{name}` holds {} values for dims {dims:?}",
+                values.len()
+            );
+        }
+        Tensor::from_vec(values, dims, &self.device)
+            .with_context(|| format!("materializing initializer `{name}`"))
+    }
+
+    fn expect_dims(name: &str, tensor: &Tensor, expected: &[usize]) -> Result<()> {
+        if tensor.dims() != expected {
+            bail!(
+                "initializer `{name}` has shape {:?}, the module expected {expected:?}",
+                tensor.dims()
+            );
+        }
+        Ok(())
+    }
+
+    fn int_attr(node: &NodeProto, name: &str) -> Option<i64> {
+        node.attribute.iter().find(|a| a.name == name).map(|a| a.i)
+    }
+
+    fn ints_attr(node: &NodeProto, name: &str) -> Option<Vec<i64>> {
+        node.attribute
+            .iter()
+            .find(|a| a.name == name)
+            .map(|a| a.ints.clone())
+    }
+
+    fn float_attr(node: &NodeProto, name: &str) -> Option<f32> {
+        node.attribute.iter().find(|a| a.name == name).map(|a| a.f)
+    }
+
+    /// The next `Conv`, as a `candle_nn::Conv2d`.
+    ///
+    /// ONNX `Conv` (opset 11) with `auto_pad = NOTSET`: `pads` is
+    /// `[x1_begin, x2_begin, x1_end, x2_end]`, and candle's `Conv2dConfig`
+    /// carries one symmetric padding, so an asymmetric `pads` is refused rather
+    /// than silently halved. Both shipped graphs use `[0,0,0,0]` or
+    /// `[1,1,1,1]`, and `dilations` is always `[1,1]`, `group` always 1.
+    pub fn next_conv(
+        &mut self,
+        out_channels: usize,
+        in_channels: usize,
+        kernel: usize,
+        stride: usize,
+    ) -> Result<Conv2d> {
+        let node = self.next_node("Conv")?;
+        let kernel_shape = Self::ints_attr(node, "kernel_shape").unwrap_or_default();
+        if kernel_shape != vec![kernel as i64, kernel as i64] {
+            bail!(
+                "Conv at node {}: kernel_shape {kernel_shape:?}, expected [{kernel}, {kernel}]",
+                self.cursor - 1
+            );
+        }
+        let strides = Self::ints_attr(node, "strides").unwrap_or_else(|| vec![1, 1]);
+        if strides != vec![stride as i64, stride as i64] {
+            bail!(
+                "Conv at node {}: strides {strides:?}, expected [{stride}, {stride}]",
+                self.cursor - 1
+            );
+        }
+        let pads = Self::ints_attr(node, "pads").unwrap_or_else(|| vec![0, 0, 0, 0]);
+        if pads.len() != 4 || pads[0] != pads[1] || pads[0] != pads[2] || pads[0] != pads[3] {
+            bail!(
+                "Conv at node {}: candle takes one symmetric padding, the graph asks for {pads:?}",
+                self.cursor - 1
+            );
+        }
+        let padding = usize::try_from(pads[0]).context("a negative Conv padding")?;
+        let dilations = Self::ints_attr(node, "dilations").unwrap_or_else(|| vec![1, 1]);
+        if dilations != vec![1, 1] {
+            bail!(
+                "Conv at node {}: dilations {dilations:?} are unsupported",
+                self.cursor - 1
+            );
+        }
+        if Self::int_attr(node, "group").unwrap_or(1) != 1 {
+            bail!(
+                "Conv at node {}: grouped convolution is unsupported",
+                self.cursor - 1
+            );
+        }
+        let weight_name = node
+            .input
+            .get(1)
+            .context("a Conv with no weight input")?
+            .clone();
+        let weight = self.initializer(&weight_name)?;
+        Self::expect_dims(
+            &weight_name,
+            &weight,
+            &[out_channels, in_channels, kernel, kernel],
+        )?;
+        let bias = match node.input.get(2) {
+            Some(name) if !name.is_empty() => {
+                let bias = self.initializer(name)?;
+                Self::expect_dims(name, &bias, &[out_channels])?;
+                Some(bias)
+            }
+            _ => None,
+        };
+        Ok(Conv2d::new(
+            weight,
+            bias,
+            Conv2dConfig {
+                padding,
+                stride,
+                dilation: 1,
+                groups: 1,
+                cudnn_fwd_algo: None,
+            },
+        ))
+    }
+
+    /// The next `BatchNormalization`, folded to one multiply-add.
+    pub fn next_batch_norm(&mut self, channels: usize) -> Result<FoldedBatchNorm> {
+        let node = self.next_node("BatchNormalization")?;
+        // ONNX defaults `epsilon` to 1e-5; both shipped graphs state it.
+        let epsilon = Self::float_attr(node, "epsilon").unwrap_or(1e-5) as f64;
+        let mut parts = Vec::with_capacity(4);
+        for slot in 1..5 {
+            let name = node
+                .input
+                .get(slot)
+                .with_context(|| format!("BatchNormalization is missing input {slot}"))?;
+            let tensor = self.initializer(name)?;
+            Self::expect_dims(name, &tensor, &[channels])?;
+            parts.push(tensor.to_vec1::<f32>()?);
+        }
+        let (scale, bias, mean, var) = (&parts[0], &parts[1], &parts[2], &parts[3]);
+        let mut w = Vec::with_capacity(channels);
+        let mut b = Vec::with_capacity(channels);
+        for c in 0..channels {
+            let inv = (var[c] as f64 + epsilon).sqrt();
+            if inv <= 0.0 {
+                bail!("BatchNormalization channel {c} has a non-positive variance");
+            }
+            let wc = scale[c] as f64 / inv;
+            w.push(wc as f32);
+            b.push((bias[c] as f64 - mean[c] as f64 * wc) as f32);
+        }
+        Ok(FoldedBatchNorm {
+            weight: Tensor::from_vec(w, channels, &self.device)?,
+            bias: Tensor::from_vec(b, channels, &self.device)?,
+            channels,
+        })
+    }
+
+    /// The next `PRelu`.
+    ///
+    /// ONNX `PRelu`: `f(x) = slope * x` for `x < 0`, `x` otherwise, with
+    /// `slope` unidirectionally broadcast. `glintr100` stores it as `[C, 1, 1]`,
+    /// which `candle_nn::PReLU` reshapes to `[1, C, 1, 1]` against a rank-4
+    /// input.
+    pub fn next_prelu(&mut self, channels: usize) -> Result<PReLU> {
+        let node = self.next_node("PRelu")?;
+        let name = node.input.get(1).context("a PRelu with no slope")?.clone();
+        let slope = self.initializer(&name)?;
+        if slope.elem_count() != channels {
+            bail!(
+                "PRelu slope `{name}` holds {} values, expected {channels}",
+                slope.elem_count()
+            );
+        }
+        Ok(PReLU::new(slope, false))
+    }
+
+    /// The next `Mul` by a scalar initializer.
+    ///
+    /// SCRFD's regression head is scaled by a learned per-stride scalar
+    /// (`bbox_head.scales.N.scale`); ONNX `Mul` broadcasts it over the whole
+    /// tensor.
+    pub fn next_scalar_mul(&mut self) -> Result<f32> {
+        let node = self.next_node("Mul")?;
+        let name = node.input.get(1).context("a Mul with no operand")?.clone();
+        let tensor = self.initializer(&name)?;
+        if tensor.elem_count() != 1 {
+            bail!(
+                "Mul operand `{name}` holds {} values, expected a scalar",
+                tensor.elem_count()
+            );
+        }
+        Ok(tensor.flatten_all()?.to_vec1::<f32>()?[0])
+    }
+
+    /// The next `Gemm`, as `(weight, bias)` in `[out, in]` layout.
+    ///
+    /// ONNX `Gemm`: `Y = alpha * A' * B' + beta * C`. Only the
+    /// `alpha = beta = 1, transA = 0, transB = 1` form both graphs use is
+    /// accepted; anything else is refused rather than approximated.
+    pub fn next_gemm(
+        &mut self,
+        out_features: usize,
+        in_features: usize,
+    ) -> Result<(Tensor, Tensor)> {
+        let node = self.next_node("Gemm")?;
+        let alpha = Self::float_attr(node, "alpha").unwrap_or(1.0);
+        let beta = Self::float_attr(node, "beta").unwrap_or(1.0);
+        if alpha != 1.0 || beta != 1.0 {
+            bail!("Gemm with alpha={alpha}, beta={beta} is unsupported");
+        }
+        if Self::int_attr(node, "transA").unwrap_or(0) != 0 {
+            bail!("Gemm with transA=1 is unsupported");
+        }
+        if Self::int_attr(node, "transB").unwrap_or(0) != 1 {
+            bail!("Gemm with transB=0 is unsupported");
+        }
+        let weight_name = node.input.get(1).context("a Gemm with no weight")?.clone();
+        let weight = self.initializer(&weight_name)?;
+        Self::expect_dims(&weight_name, &weight, &[out_features, in_features])?;
+        let bias_name = node.input.get(2).context("a Gemm with no bias")?.clone();
+        let bias = self.initializer(&bias_name)?;
+        Self::expect_dims(&bias_name, &bias, &[out_features])?;
+        Ok((weight, bias))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candle_onnx::onnx::{AttributeProto, GraphProto, ModelProto};
+
+    fn float_initializer(name: &str, dims: Vec<i64>, values: Vec<f32>) -> TensorProto {
+        TensorProto {
+            name: name.to_string(),
+            dims,
+            data_type: tensor_proto::DataType::Float as i32,
+            float_data: values,
+            ..Default::default()
+        }
+    }
+
+    fn ints(name: &str, values: Vec<i64>) -> AttributeProto {
+        AttributeProto {
+            name: name.to_string(),
+            r#type: candle_onnx::onnx::attribute_proto::AttributeType::Ints as i32,
+            ints: values,
+            ..Default::default()
+        }
+    }
+
+    fn node(op: &str, inputs: &[&str], attrs: Vec<AttributeProto>) -> NodeProto {
+        NodeProto {
+            op_type: op.to_string(),
+            input: inputs.iter().map(|s| s.to_string()).collect(),
+            output: vec!["out".to_string()],
+            attribute: attrs,
+            ..Default::default()
+        }
+    }
+
+    fn model(nodes: Vec<NodeProto>, initializers: Vec<TensorProto>) -> ModelProto {
+        ModelProto {
+            graph: Some(GraphProto {
+                node: nodes,
+                initializer: initializers,
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn a_conv_is_read_with_its_padding_and_stride() {
+        let m = model(
+            vec![node(
+                "Conv",
+                &["x", "w", "b"],
+                vec![
+                    ints("kernel_shape", vec![3, 3]),
+                    ints("strides", vec![2, 2]),
+                    ints("pads", vec![1, 1, 1, 1]),
+                    ints("dilations", vec![1, 1]),
+                ],
+            )],
+            vec![
+                float_initializer("w", vec![2, 1, 3, 3], vec![0.5; 18]),
+                float_initializer("b", vec![2], vec![1.0, -1.0]),
+            ],
+        );
+        let mut tape = WeightTape::new(&m, &Device::Cpu).unwrap();
+        let conv = tape.next_conv(2, 1, 3, 2).unwrap();
+        assert_eq!(conv.config().padding, 1);
+        assert_eq!(conv.config().stride, 2);
+        assert_eq!(conv.weight().dims(), &[2, 1, 3, 3]);
+        tape.finish().unwrap();
+    }
+
+    #[test]
+    fn a_shape_mismatch_names_the_initializer_rather_than_panicking_later() {
+        let m = model(
+            vec![node(
+                "Conv",
+                &["x", "w"],
+                vec![ints("kernel_shape", vec![3, 3])],
+            )],
+            vec![float_initializer("w", vec![2, 1, 3, 3], vec![0.5; 18])],
+        );
+        let mut tape = WeightTape::new(&m, &Device::Cpu).unwrap();
+        let err = tape.next_conv(4, 1, 3, 1).unwrap_err();
+        assert!(format!("{err}").contains("shape [2, 1, 3, 3]"), "{err}");
+    }
+
+    #[test]
+    fn a_reordered_parameterized_op_is_refused_rather_than_consumed() {
+        let m = model(
+            vec![
+                node("Relu", &["x"], vec![]),
+                node("PRelu", &["x", "s"], vec![]),
+                node("Conv", &["x", "w"], vec![ints("kernel_shape", vec![1, 1])]),
+            ],
+            vec![
+                float_initializer("s", vec![2, 1, 1], vec![0.25, 0.25]),
+                float_initializer("w", vec![2, 2, 1, 1], vec![1.0; 4]),
+            ],
+        );
+        let mut tape = WeightTape::new(&m, &Device::Cpu).unwrap();
+        let err = tape.next_conv(2, 2, 1, 1).unwrap_err();
+        assert!(format!("{err}").contains("found `PRelu`"), "{err}");
+    }
+
+    #[test]
+    fn an_unconsumed_parameterized_op_is_refused_at_finish() {
+        let m = model(
+            vec![
+                node("Conv", &["x", "w"], vec![ints("kernel_shape", vec![1, 1])]),
+                node("PRelu", &["x", "s"], vec![]),
+            ],
+            vec![
+                float_initializer("w", vec![2, 2, 1, 1], vec![1.0; 4]),
+                float_initializer("s", vec![2, 1, 1], vec![0.25, 0.25]),
+            ],
+        );
+        let mut tape = WeightTape::new(&m, &Device::Cpu).unwrap();
+        tape.next_conv(2, 2, 1, 1).unwrap();
+        let err = tape.finish().unwrap_err();
+        assert!(format!("{err}").contains("never consumed"), "{err}");
+    }
+
+    /// The fold must be the ONNX formula, not an approximation of it.
+    #[test]
+    fn the_batch_norm_fold_reproduces_the_spec_formula() {
+        let epsilon = 1e-5f32;
+        let mut eps_attr = AttributeProto {
+            name: "epsilon".to_string(),
+            r#type: candle_onnx::onnx::attribute_proto::AttributeType::Float as i32,
+            ..Default::default()
+        };
+        eps_attr.f = epsilon;
+        let m = model(
+            vec![node(
+                "BatchNormalization",
+                &["x", "scale", "b", "mean", "var"],
+                vec![eps_attr],
+            )],
+            vec![
+                float_initializer("scale", vec![2], vec![2.0, 0.5]),
+                float_initializer("b", vec![2], vec![-1.0, 3.0]),
+                float_initializer("mean", vec![2], vec![0.25, -2.0]),
+                float_initializer("var", vec![2], vec![4.0, 9.0]),
+            ],
+        );
+        let mut tape = WeightTape::new(&m, &Device::Cpu).unwrap();
+        let bn = tape.next_batch_norm(2).unwrap();
+        assert_eq!(bn.channels(), 2);
+        let xs = [1.0f32, -3.0];
+        let got = bn
+            .forward(&Tensor::from_vec(xs.to_vec(), (1, 2), &Device::Cpu).unwrap())
+            .unwrap()
+            .to_vec2::<f32>()
+            .unwrap();
+        let (scale, bias, mean, var) = (
+            [2.0f32, 0.5],
+            [-1.0f32, 3.0],
+            [0.25f32, -2.0],
+            [4.0f32, 9.0],
+        );
+        for c in 0..2 {
+            let expected = (xs[c] - mean[c]) / (var[c] + epsilon).sqrt() * scale[c] + bias[c];
+            assert!(
+                (got[0][c] - expected).abs() < 1e-6,
+                "channel {c}: {} vs {expected}",
+                got[0][c]
+            );
+        }
+    }
+
+    #[test]
+    fn a_non_float_initializer_is_refused_rather_than_reinterpreted() {
+        let m = model(
+            vec![node(
+                "Conv",
+                &["x", "w"],
+                vec![ints("kernel_shape", vec![1, 1])],
+            )],
+            vec![TensorProto {
+                name: "w".to_string(),
+                dims: vec![1, 1, 1, 1],
+                data_type: tensor_proto::DataType::Int64 as i32,
+                int64_data: vec![7],
+                ..Default::default()
+            }],
+        );
+        let mut tape = WeightTape::new(&m, &Device::Cpu).unwrap();
+        let err = tape.next_conv(1, 1, 1, 1).unwrap_err();
+        assert!(format!("{err}").contains("expected FLOAT"), "{err}");
+    }
+
+    #[test]
+    fn raw_little_endian_data_and_float_data_agree() {
+        let values = [1.5f32, -2.25, 0.0, 7.75];
+        let raw: Vec<u8> = values.iter().flat_map(|v| v.to_le_bytes()).collect();
+        let m = model(
+            vec![node(
+                "Conv",
+                &["x", "w"],
+                vec![ints("kernel_shape", vec![1, 1])],
+            )],
+            vec![TensorProto {
+                name: "w".to_string(),
+                dims: vec![4, 1, 1, 1],
+                data_type: tensor_proto::DataType::Float as i32,
+                raw_data: raw,
+                ..Default::default()
+            }],
+        );
+        let mut tape = WeightTape::new(&m, &Device::Cpu).unwrap();
+        let conv = tape.next_conv(4, 1, 1, 1).unwrap();
+        assert_eq!(
+            conv.weight()
+                .flatten_all()
+                .unwrap()
+                .to_vec1::<f32>()
+                .unwrap(),
+            values.to_vec()
+        );
+    }
+}

--- a/crates/mold-inference/src/identity/onnx_weights.rs
+++ b/crates/mold-inference/src/identity/onnx_weights.rs
@@ -98,6 +98,25 @@ impl FoldedBatchNorm {
     }
 }
 
+/// Move an input blob onto the device the weights are resident on.
+///
+/// Both face networks take their input from image code that builds on the CPU
+/// (`ScrfdDetector::blob`, `ArcFaceRecognizer::blob`) — an `RgbImage` lives in
+/// host memory, so there is nowhere else for it to start. The weights, since
+/// #1227, live wherever the caller placed them. candle refuses a convolution
+/// whose input and kernel are on different devices, so the very first `Conv`
+/// would fail the moment anything passed a non-CPU device to
+/// `ScrfdNet::new` / `IResNet100::new` — the seam that exists precisely so
+/// `pulid-perf.md` §5 can.
+///
+/// `Tensor::to_device` short-circuits to a clone when the devices already
+/// match, so this is free on today's CPU-only path and cannot change its
+/// numerics.
+pub fn place_input(blob: &Tensor, device: &Device) -> Result<Tensor> {
+    blob.to_device(device)
+        .context("moving the face-network input onto the device holding its weights")
+}
+
 /// Every float initializer of one graph, plus a cursor over its nodes.
 pub struct WeightTape<'a> {
     nodes: Vec<&'a NodeProto>,
@@ -194,10 +213,17 @@ impl<'a> WeightTape<'a> {
                     proto.raw_data.len()
                 );
             }
+            // `as_chunks` rather than `chunks_exact`: same iteration, but it
+            // yields `[u8; 4]` directly so `from_le_bytes` needs no
+            // reassembly, and clippy's `chunks_exact_to_as_chunks` asks for it.
+            // The length check above already proved the remainder is empty.
+            // Mirrors `mold_core::identity::FrozenIdentityEmbedding::values`.
             proto
                 .raw_data
-                .chunks_exact(4)
-                .map(|c| f32::from_le_bytes([c[0], c[1], c[2], c[3]]))
+                .as_chunks::<4>()
+                .0
+                .iter()
+                .map(|chunk| f32::from_le_bytes(*chunk))
                 .collect()
         } else {
             proto.float_data.clone()
@@ -465,6 +491,55 @@ mod tests {
             }),
             ..Default::default()
         }
+    }
+
+    /// The CPU path must be a no-op in every sense: same device, same values,
+    /// and no reallocation-driven difference the parity goldens could pick up.
+    #[test]
+    fn placing_a_cpu_input_on_the_cpu_changes_nothing() {
+        let blob =
+            Tensor::from_vec(vec![1.0f32, -2.0, 3.5, 0.0], (1, 1, 2, 2), &Device::Cpu).unwrap();
+        let placed = place_input(&blob, &Device::Cpu).unwrap();
+        assert!(placed.device().same_device(&Device::Cpu));
+        assert_eq!(
+            placed.flatten_all().unwrap().to_vec1::<f32>().unwrap(),
+            blob.flatten_all().unwrap().to_vec1::<f32>().unwrap()
+        );
+    }
+
+    /// The case the CPU test cannot reach: a host-built blob meeting weights
+    /// that are not on the host. Without this move candle rejects the first
+    /// convolution outright, so the device seam would be a seam in name only.
+    #[cfg(all(target_os = "macos", feature = "metal"))]
+    #[test]
+    fn a_cpu_input_is_moved_onto_a_metal_net() {
+        // `crate::device::metal_device`, never `Device::new_metal`: mold opens
+        // each Metal GPU exactly once per process, and a second device for the
+        // same GPU is the split-identity bug
+        // `production_code_never_constructs_a_metal_device_directly` exists to
+        // stop. A test that compared against a device production would never
+        // use would be testing something else.
+        let Ok(metal) = crate::device::metal_device(0) else {
+            eprintln!("skipping: no Metal device on this machine");
+            return;
+        };
+        let values = vec![1.0f32, -2.0, 3.5, 0.0];
+        let blob = Tensor::from_vec(values.clone(), (1, 1, 2, 2), &Device::Cpu).unwrap();
+        let placed = place_input(&blob, &metal).unwrap();
+        assert!(
+            placed.device().same_device(&metal),
+            "the input must follow the weights, not the image decoder"
+        );
+        assert_eq!(
+            placed
+                .to_device(&Device::Cpu)
+                .unwrap()
+                .flatten_all()
+                .unwrap()
+                .to_vec1::<f32>()
+                .unwrap(),
+            values
+        );
     }
 
     #[test]

--- a/crates/mold-inference/src/identity/scrfd.rs
+++ b/crates/mold-inference/src/identity/scrfd.rs
@@ -12,14 +12,13 @@
 //! `static_input_size` is `None` and the detector runs at the 640x640 default
 //! (`scrfd.py:97`, `DEFAULT_DET_SIZES[-1]`).
 
-use std::collections::HashMap;
-
 use anyhow::{bail, Context, Result};
-use candle_core::{DType, Device, Tensor};
+use candle_core::{Device, Tensor};
 use candle_onnx::onnx::ModelProto;
 use image::RgbImage;
 
 use super::align::Landmarks5;
+use super::scrfd_net::ScrfdNet;
 use super::warp::letterbox_top_left;
 
 /// Feature-pyramid strides, `scrfd.py:122`.
@@ -119,11 +118,13 @@ pub fn non_max_suppression(boxes: &[[f32; 4]], threshold: f32) -> Vec<usize> {
     keep
 }
 
-/// The SCRFD detector: one decoded graph plus upstream's thresholds.
+/// The SCRFD detector: the resident network plus upstream's thresholds.
+///
+/// The `ModelProto` is consumed at construction and dropped — see
+/// [`super::scrfd_net`] and `docs/architecture/pulid-perf.md` §1. Nothing here
+/// touches `candle-onnx` after `new` returns.
 pub struct ScrfdDetector {
-    model: ModelProto,
-    input_name: String,
-    output_names: Vec<String>,
+    net: ScrfdNet,
     /// Score threshold; defaults to [`DEFAULT_SCORE_THRESHOLD`].
     pub score_threshold: f32,
     /// NMS IoU threshold; defaults to [`DEFAULT_NMS_THRESHOLD`].
@@ -131,36 +132,37 @@ pub struct ScrfdDetector {
 }
 
 impl ScrfdDetector {
-    /// Wrap a decoded `scrfd_10g_bnkps` graph.
+    /// Wrap a decoded `scrfd_10g_bnkps` graph, on the CPU.
+    pub fn new(model: ModelProto) -> Result<Self> {
+        Self::new_on_device(model, &Device::Cpu)
+    }
+
+    /// Wrap a decoded `scrfd_10g_bnkps` graph, placing its weights on `device`.
     ///
     /// Fails closed on any graph whose output arity is not the nine-tensor
     /// keypoint variant, because every stride offset below is derived from
     /// `fmc = 3`.
-    pub fn new(model: ModelProto) -> Result<Self> {
+    pub fn new_on_device(model: ModelProto, device: &Device) -> Result<Self> {
         let graph = model
             .graph
             .as_ref()
             .context("the SCRFD model carries no graph")?;
-        let input_name = graph
-            .input
-            .first()
-            .context("the SCRFD graph declares no input")?
-            .name
-            .clone();
-        let output_names: Vec<String> = graph.output.iter().map(|o| o.name.clone()).collect();
-        if output_names.len() != FEATURE_STRIDES.len() * 3 {
+        let outputs = graph.output.len();
+        if outputs != FEATURE_STRIDES.len() * 3 {
             bail!(
-                "expected a 9-output SCRFD keypoint graph (scrfd.py:127-132), got {} outputs",
-                output_names.len()
+                "expected a 9-output SCRFD keypoint graph (scrfd.py:127-132), got {outputs} outputs"
             );
         }
         Ok(Self {
-            model,
-            input_name,
-            output_names,
+            net: ScrfdNet::new(&model, device).context("building the SCRFD network")?,
             score_threshold: DEFAULT_SCORE_THRESHOLD,
             nms_threshold: DEFAULT_NMS_THRESHOLD,
         })
+    }
+
+    /// The device the detector's weights are resident on.
+    pub fn device(&self) -> &Device {
+        self.net.device()
     }
 
     /// Build the network blob from an already letterboxed RGB canvas.
@@ -186,26 +188,13 @@ impl ScrfdDetector {
     pub fn detect(&self, image: &RgbImage) -> Result<Vec<DetectedFace>> {
         let boxed = letterbox_top_left(image, DETECTOR_INPUT);
         let blob = Self::blob(&boxed.image)?;
-        let mut inputs = HashMap::new();
-        inputs.insert(self.input_name.clone(), blob);
-        let outputs = candle_onnx::simple_eval(&self.model, inputs)
-            .context("SCRFD graph evaluation failed")?;
-        let fetch = |name: &str| -> Result<Vec<f32>> {
-            let tensor = outputs
-                .get(name)
-                .with_context(|| format!("SCRFD produced no `{name}` output"))?;
-            Ok(tensor
-                .to_dtype(DType::F32)?
-                .flatten_all()?
-                .to_vec1::<f32>()?)
-        };
+        let raw = self.net.forward(&blob).context("SCRFD evaluation failed")?;
 
         let mut candidates: Vec<DetectedFace> = Vec::new();
-        let fmc = FEATURE_STRIDES.len();
         for (idx, stride) in FEATURE_STRIDES.iter().copied().enumerate() {
-            let scores = fetch(&self.output_names[idx])?;
-            let bbox_preds = fetch(&self.output_names[idx + fmc])?;
-            let kps_preds = fetch(&self.output_names[idx + fmc * 2])?;
+            let scores = &raw.scores[idx];
+            let bbox_preds = &raw.bboxes[idx];
+            let kps_preds = &raw.keypoints[idx];
             let extent = DETECTOR_INPUT as usize / stride;
             let centres = anchor_centers(extent, extent, stride, ANCHORS_PER_CELL);
             if scores.len() != centres.len() {

--- a/crates/mold-inference/src/identity/scrfd_net.rs
+++ b/crates/mold-inference/src/identity/scrfd_net.rs
@@ -1,0 +1,516 @@
+//! `scrfd_10g_bnkps` as a resident candle module (#1227).
+//!
+//! The hand port `docs/architecture/pulid-perf.md` §1 chose: the pinned ONNX
+//! file stays the weight container, [`super::onnx_weights::WeightTape`] reads
+//! it once at load, and this module runs ordinary `candle-core`/`candle-nn`
+//! forward passes thereafter. Everything downstream of the raw head outputs —
+//! anchor decoding, thresholding, NMS — is unchanged in
+//! [`super::scrfd`], because none of it was ever inside the graph
+//! (`scrfd.py:158-225`).
+//!
+//! ## The topology, and why it is written out rather than inferred
+//!
+//! Upstream SCRFD is `mmdet`-configured
+//! (`insightface/detection/scrfd/configs/scrfd/scrfd_10g_bnkps.py`: a
+//! `ResNetV1e`-style backbone, `PAFPN` neck, `SCRFDHead` with `stacked_convs=3`
+//! and per-stride `cls`/`reg`/`kps` outputs), but the exported graph is the
+//! authority for what actually runs: batch-norm is already folded into every
+//! backbone convolution (the inventory carries **no** `BatchNormalization` for
+//! this graph), and the export pairs `neck.fpn_convs.1`'s weight with
+//! `neck.downsample_convs.0`'s bias — an exporter quirk this port reproduces
+//! exactly by consuming parameters in graph order rather than by module name.
+//!
+//! Traced from the pinned graph
+//! (`sha256 5838f7fe…`, `crates/mold-inference/testdata/pulid/onnx-inventory.json`):
+//!
+//! ```text
+//!  stem   conv3x3/2 3->28, relu; conv3x3 28->28, relu; conv3x3 28->56, relu; maxpool 2/2
+//!  stage1 3 x basic(56)                                  ->  160x160
+//!  stage2 down(56->88) + 3 x basic(88)                    ->   80x80   C2 (stride 8)
+//!  stage3 down(88->88) + 1 x basic(88)                    ->   40x40   C3 (stride 16)
+//!  stage4 down(88->224) + 2 x basic(224)                  ->   20x20   C4 (stride 32)
+//!  neck   lateral 1x1 -> 56 on each of C2/C3/C4
+//!         top-down    P3 = L3 + nearest2x(L4); P2 = L2 + nearest2x(P3)
+//!         fpn convs   F2 = c(P2); F3 = c(P3); F4 = c(L4)
+//!         bottom-up   B3 = F3 + down(F2); B4 = F4 + down(B3)
+//!         pafpn       H2 = F2; H3 = pafpn0(B3); H4 = pafpn1(B4)
+//!  heads  per stride: 3 x (conv3x3 ->80, relu), then cls->2 (sigmoid),
+//!         reg->8 (x learned scale), kps->20
+//! ```
+//!
+//! ONNX op semantics used here, opset 11
+//! (<https://github.com/onnx/onnx/blob/main/docs/Operators.md>):
+//! `Conv`, `Relu`, `Add`, `MaxPool`, `AveragePool`, `Resize` (nearest,
+//! `asymmetric`, `nearest_mode=floor`), `Mul`, `Transpose`, `Reshape`,
+//! `Sigmoid`. The graph's `Shape`/`Gather`/`Slice`/`Concat`/`Unsqueeze` nodes
+//! exist only to compute each `Resize`'s target size from the lateral it is
+//! being added to; at a fixed square input those sizes are exactly twice the
+//! source, which is what `upsample_nearest2d` is given.
+
+use anyhow::{bail, Context, Result};
+use candle_core::{Device, Module, Tensor};
+use candle_nn::Conv2d;
+use candle_onnx::onnx::ModelProto;
+
+use super::onnx_weights::WeightTape;
+use super::scrfd::{ANCHORS_PER_CELL, FEATURE_STRIDES};
+
+/// Backbone channel widths, in stage order.
+const STAGE_CHANNELS: [usize; 4] = [56, 88, 88, 224];
+/// Basic blocks per stage, the first of each stage after the first being a
+/// strided downsample block.
+const STAGE_BLOCKS: [usize; 4] = [3, 4, 2, 3];
+/// Every neck level is projected to this width.
+const NECK_CHANNELS: usize = 56;
+/// `stacked_convs`, and their width.
+const HEAD_STACK: usize = 3;
+const HEAD_CHANNELS: usize = 80;
+
+/// The nine raw head tensors, flattened exactly as the graph's
+/// `Transpose(2,3,0,1)` + `Reshape` produce them: one row per anchor, in
+/// `(y, x, anchor)` order.
+#[derive(Debug, Clone)]
+pub struct ScrfdRawOutputs {
+    /// Per-anchor sigmoid score, one value per row, per stride.
+    pub scores: [Vec<f32>; 3],
+    /// Per-anchor distance-encoded box, four values per row, per stride.
+    pub bboxes: [Vec<f32>; 3],
+    /// Per-anchor distance-encoded keypoints, ten values per row, per stride.
+    pub keypoints: [Vec<f32>; 3],
+}
+
+/// One residual block. `downsample` is present exactly on a stage's first
+/// block, where the shortcut is `AveragePool(2, ceil) -> Conv1x1`.
+struct BasicBlock {
+    conv1: Conv2d,
+    conv2: Conv2d,
+    downsample: Option<Conv2d>,
+}
+
+impl BasicBlock {
+    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
+        let identity = match &self.downsample {
+            Some(conv) => {
+                let pooled = average_pool_2x2_ceil(xs)?;
+                conv.forward(&pooled)?
+            }
+            None => xs.clone(),
+        };
+        let out = self.conv1.forward(xs)?.relu()?;
+        let out = self.conv2.forward(&out)?;
+        Ok((out + identity)?.relu()?)
+    }
+}
+
+/// One stride's detection head.
+struct Head {
+    stack: Vec<Conv2d>,
+    cls: Conv2d,
+    reg: Conv2d,
+    kps: Conv2d,
+    /// `bbox_head.scales.N.scale`, applied to the regression output.
+    scale: f32,
+}
+
+/// The whole detector as resident tensors.
+pub struct ScrfdNet {
+    stem: Vec<Conv2d>,
+    stages: Vec<Vec<BasicBlock>>,
+    laterals: Vec<Conv2d>,
+    fpn_convs: Vec<Conv2d>,
+    downsample_convs: Vec<Conv2d>,
+    pafpn_convs: Vec<Conv2d>,
+    heads: Vec<Head>,
+    device: Device,
+}
+
+impl ScrfdNet {
+    /// Read every parameter out of a decoded graph, in graph order.
+    ///
+    /// `device` is a parameter so a future GPU path (`pulid-perf.md` §3) needs
+    /// no change here; milestone 1 always passes `Device::Cpu`, which
+    /// [`super::IdentityExtractor::load`] still asserts.
+    pub fn new(model: &ModelProto, device: &Device) -> Result<Self> {
+        let mut tape = WeightTape::new(model, device)?;
+
+        // Stem: 3 -> 28 -> 28 -> 56, the first strided.
+        let stem = vec![
+            tape.next_conv(28, 3, 3, 2).context("stem conv 1")?,
+            tape.next_conv(28, 28, 3, 1).context("stem conv 2")?,
+            tape.next_conv(56, 28, 3, 1).context("stem conv 3")?,
+        ];
+
+        let mut stages = Vec::with_capacity(STAGE_CHANNELS.len());
+        let mut in_channels = 56usize;
+        for (stage, (&channels, &blocks)) in
+            STAGE_CHANNELS.iter().zip(STAGE_BLOCKS.iter()).enumerate()
+        {
+            let mut built = Vec::with_capacity(blocks);
+            for block in 0..blocks {
+                // Every stage after the first opens with a strided block whose
+                // shortcut is pooled and projected. SCRFD strides the FIRST
+                // convolution of that block and pools the shortcut — the
+                // opposite of `glintr100`, which strides the second and strides
+                // its 1x1 shortcut instead (see `arcface_net.rs`). Swapping
+                // them still type-checks and still produces the right shapes.
+                let strided = stage > 0 && block == 0;
+                let stride = if strided { 2 } else { 1 };
+                let block_in = if block == 0 { in_channels } else { channels };
+                let conv1 = tape
+                    .next_conv(channels, block_in, 3, stride)
+                    .with_context(|| format!("stage {stage} block {block} conv 1"))?;
+                let conv2 = tape
+                    .next_conv(channels, channels, 3, 1)
+                    .with_context(|| format!("stage {stage} block {block} conv 2"))?;
+                let downsample = if strided {
+                    Some(
+                        tape.next_conv(channels, block_in, 1, 1)
+                            .with_context(|| format!("stage {stage} block {block} shortcut"))?,
+                    )
+                } else {
+                    None
+                };
+                built.push(BasicBlock {
+                    conv1,
+                    conv2,
+                    downsample,
+                });
+            }
+            in_channels = channels;
+            stages.push(built);
+        }
+
+        // Neck. The laterals come first, then the three fpn convs, then the
+        // two bottom-up downsamples, then the two pafpn convs — graph order,
+        // which is also the order the forward pass below visits them.
+        let laterals = vec![
+            tape.next_conv(NECK_CHANNELS, STAGE_CHANNELS[1], 1, 1)
+                .context("neck lateral 0")?,
+            tape.next_conv(NECK_CHANNELS, STAGE_CHANNELS[2], 1, 1)
+                .context("neck lateral 1")?,
+            tape.next_conv(NECK_CHANNELS, STAGE_CHANNELS[3], 1, 1)
+                .context("neck lateral 2")?,
+        ];
+        let mut fpn_convs = Vec::with_capacity(3);
+        for level in 0..3 {
+            fpn_convs.push(
+                tape.next_conv(NECK_CHANNELS, NECK_CHANNELS, 3, 1)
+                    .with_context(|| format!("neck fpn conv {level}"))?,
+            );
+        }
+        // The two bottom-up convolutions are interleaved with their `Add`s in
+        // the graph, so they are consumed one at a time.
+        let mut downsample_convs = Vec::with_capacity(2);
+        let mut pafpn_convs = Vec::with_capacity(2);
+        downsample_convs.push(
+            tape.next_conv(NECK_CHANNELS, NECK_CHANNELS, 3, 2)
+                .context("neck downsample conv 0")?,
+        );
+        downsample_convs.push(
+            tape.next_conv(NECK_CHANNELS, NECK_CHANNELS, 3, 2)
+                .context("neck downsample conv 1")?,
+        );
+        pafpn_convs.push(
+            tape.next_conv(NECK_CHANNELS, NECK_CHANNELS, 3, 1)
+                .context("neck pafpn conv 0")?,
+        );
+        pafpn_convs.push(
+            tape.next_conv(NECK_CHANNELS, NECK_CHANNELS, 3, 1)
+                .context("neck pafpn conv 1")?,
+        );
+
+        let mut heads = Vec::with_capacity(FEATURE_STRIDES.len());
+        for stride in FEATURE_STRIDES {
+            let mut stack = Vec::with_capacity(HEAD_STACK);
+            for i in 0..HEAD_STACK {
+                let input = if i == 0 { NECK_CHANNELS } else { HEAD_CHANNELS };
+                stack.push(
+                    tape.next_conv(HEAD_CHANNELS, input, 3, 1)
+                        .with_context(|| format!("stride {stride} head conv {i}"))?,
+                );
+            }
+            let cls = tape
+                .next_conv(ANCHORS_PER_CELL, HEAD_CHANNELS, 3, 1)
+                .with_context(|| format!("stride {stride} cls head"))?;
+            let reg = tape
+                .next_conv(ANCHORS_PER_CELL * 4, HEAD_CHANNELS, 3, 1)
+                .with_context(|| format!("stride {stride} reg head"))?;
+            let scale = tape
+                .next_scalar_mul()
+                .with_context(|| format!("stride {stride} regression scale"))?;
+            let kps = tape
+                .next_conv(ANCHORS_PER_CELL * 10, HEAD_CHANNELS, 3, 1)
+                .with_context(|| format!("stride {stride} kps head"))?;
+            heads.push(Head {
+                stack,
+                cls,
+                reg,
+                kps,
+                scale,
+            });
+        }
+
+        tape.finish()
+            .context("the SCRFD graph carries parameters this port does not run")?;
+
+        Ok(Self {
+            stem,
+            stages,
+            laterals,
+            fpn_convs,
+            downsample_convs,
+            pafpn_convs,
+            heads,
+            device: device.clone(),
+        })
+    }
+
+    /// The device every parameter is resident on.
+    pub fn device(&self) -> &Device {
+        &self.device
+    }
+
+    /// Run the network over one `[1, 3, H, W]` blob.
+    pub fn forward(&self, blob: &Tensor) -> Result<ScrfdRawOutputs> {
+        let mut xs = blob.clone();
+        for conv in &self.stem {
+            xs = conv.forward(&xs)?.relu()?;
+        }
+        // `MaxPool` kernel 2, stride 2, `ceil_mode = 0`.
+        xs = xs.max_pool2d(2)?;
+
+        let mut features = Vec::with_capacity(3);
+        for (stage, blocks) in self.stages.iter().enumerate() {
+            for block in blocks {
+                xs = block.forward(&xs)?;
+            }
+            if stage > 0 {
+                features.push(xs.clone());
+            }
+        }
+        if features.len() != 3 {
+            bail!(
+                "the SCRFD backbone produced {} levels, expected 3",
+                features.len()
+            );
+        }
+
+        // Lateral 1x1 projections, then the top-down path.
+        let l2 = self.laterals[0].forward(&features[0])?;
+        let l3 = self.laterals[1].forward(&features[1])?;
+        let l4 = self.laterals[2].forward(&features[2])?;
+        let p3 = (&l3 + upsample_to(&l4, &l3)?)?;
+        let p2 = (&l2 + upsample_to(&p3, &l2)?)?;
+
+        // `neck.fpn_convs.2` runs on the *lateral*, not on a top-down sum:
+        // level 2 is the top of the pyramid and has nothing above it.
+        let f2 = self.fpn_convs[0].forward(&p2)?;
+        let f3 = self.fpn_convs[1].forward(&p3)?;
+        let f4 = self.fpn_convs[2].forward(&l4)?;
+
+        let b3 = (&f3 + self.downsample_convs[0].forward(&f2)?)?;
+        let b4 = (&f4 + self.downsample_convs[1].forward(&b3)?)?;
+
+        let inputs = [
+            f2,
+            self.pafpn_convs[0].forward(&b3)?,
+            self.pafpn_convs[1].forward(&b4)?,
+        ];
+
+        let mut scores = Vec::with_capacity(3);
+        let mut bboxes = Vec::with_capacity(3);
+        let mut keypoints = Vec::with_capacity(3);
+        for (head, input) in self.heads.iter().zip(inputs.iter()) {
+            let mut xs = input.clone();
+            for conv in &head.stack {
+                xs = conv.forward(&xs)?.relu()?;
+            }
+            let cls = candle_nn::ops::sigmoid(&head.cls.forward(&xs)?)?;
+            let reg = (head.reg.forward(&xs)? * head.scale as f64)?;
+            let kps = head.kps.forward(&xs)?;
+            scores.push(anchor_major(&cls)?);
+            bboxes.push(anchor_major(&reg)?);
+            keypoints.push(anchor_major(&kps)?);
+        }
+
+        let take = |mut v: Vec<Vec<f32>>| -> [Vec<f32>; 3] {
+            let c = v.pop().expect("three levels");
+            let b = v.pop().expect("three levels");
+            let a = v.pop().expect("three levels");
+            [a, b, c]
+        };
+        Ok(ScrfdRawOutputs {
+            scores: take(scores),
+            bboxes: take(bboxes),
+            keypoints: take(keypoints),
+        })
+    }
+}
+
+/// `AveragePool` kernel 2, stride 2, `ceil_mode = 1`.
+///
+/// `ceil_mode` only changes the output when an extent is odd, and it is the one
+/// attribute `candle-onnx` silently ignored (`onnx_inventory.rs`'s
+/// `ignored_attributes`). Every extent this pool ever sees at the pinned 640 px
+/// input is even (160, 80, 40), so ceil and floor agree — and rather than
+/// inherit the old evaluator's silent assumption, an odd extent is refused
+/// here, because a rounded-down pool would produce a plausible detection from
+/// the wrong receptive field.
+fn average_pool_2x2_ceil(xs: &Tensor) -> Result<Tensor> {
+    let (_, _, h, w) = xs.dims4()?;
+    if h % 2 != 0 || w % 2 != 0 {
+        bail!(
+            "SCRFD's shortcut pool has ceil_mode=1 and this port only implements the even case; \
+             got {h}x{w}"
+        );
+    }
+    Ok(xs.avg_pool2d(2)?)
+}
+
+/// `Resize` with `mode = nearest`, `coordinate_transformation_mode =
+/// asymmetric`, `nearest_mode = floor`, to the exact spatial size of `like`.
+///
+/// The graph computes that size at run time from the lateral being added to;
+/// with a square input it is always exactly twice the source, where nearest
+/// resampling is a plain 2x pixel replication under any rounding convention.
+/// A non-integer ratio is refused rather than approximated.
+fn upsample_to(xs: &Tensor, like: &Tensor) -> Result<Tensor> {
+    let (_, _, sh, sw) = xs.dims4()?;
+    let (_, _, th, tw) = like.dims4()?;
+    if th != sh * 2 || tw != sw * 2 {
+        bail!("SCRFD's top-down Resize expected an exact 2x, got {sh}x{sw} -> {th}x{tw}");
+    }
+    Ok(xs.upsample_nearest2d(th, tw)?)
+}
+
+/// `Transpose(perm = 2,3,0,1)` then `Reshape(-1, k)`, flattened.
+///
+/// The head emits `[1, C, H, W]`; the transpose reorders it to `[H, W, 1, C]`
+/// and the reshape splits `C` into `anchors x k`, so every row is one anchor
+/// and the rows run `(y, x, anchor)`. That ordering is exactly what
+/// [`super::scrfd::anchor_centers`] enumerates, and getting it wrong would pair
+/// each score with another cell's box. Flattening `[N, H, W, C]` in place gives
+/// the same value sequence for `N = 1`, without materializing the transpose.
+fn anchor_major(xs: &Tensor) -> Result<Vec<f32>> {
+    let (n, _, _, _) = xs.dims4()?;
+    if n != 1 {
+        bail!("the SCRFD head port runs one image at a time, got a batch of {n}");
+    }
+    Ok(xs
+        .permute((0, 2, 3, 1))?
+        .contiguous()?
+        .flatten_all()?
+        .to_vec1::<f32>()?)
+}
+
+/// Evaluate the graph through `candle-onnx`, the path this module replaced.
+///
+/// Retained as the **parity oracle** for `tests/pulid_handport_parity.rs`, and
+/// for nothing else: it is exactly the per-call re-materialization
+/// `pulid-perf.md` §1 set out to remove, so no production path may call it.
+#[doc(hidden)]
+pub fn reference_forward(model: &ModelProto, blob: &Tensor) -> Result<ScrfdRawOutputs> {
+    let graph = model
+        .graph
+        .as_ref()
+        .context("the SCRFD model carries no graph")?;
+    let input = graph
+        .input
+        .first()
+        .context("the SCRFD graph declares no input")?
+        .name
+        .clone();
+    let names: Vec<String> = graph.output.iter().map(|o| o.name.clone()).collect();
+    let outputs = candle_onnx::simple_eval(
+        model,
+        std::collections::HashMap::from([(input, blob.clone())]),
+    )
+    .context("SCRFD graph evaluation failed")?;
+    let fetch = |name: &String| -> Result<Vec<f32>> {
+        Ok(outputs
+            .get(name)
+            .with_context(|| format!("SCRFD produced no `{name}` output"))?
+            .to_dtype(candle_core::DType::F32)?
+            .flatten_all()?
+            .to_vec1::<f32>()?)
+    };
+    let fmc = FEATURE_STRIDES.len();
+    let mut scores = Vec::new();
+    let mut bboxes = Vec::new();
+    let mut keypoints = Vec::new();
+    for idx in 0..fmc {
+        scores.push(fetch(&names[idx])?);
+        bboxes.push(fetch(&names[idx + fmc])?);
+        keypoints.push(fetch(&names[idx + fmc * 2])?);
+    }
+    let take = |mut v: Vec<Vec<f32>>| -> [Vec<f32>; 3] {
+        let c = v.pop().expect("three levels");
+        let b = v.pop().expect("three levels");
+        let a = v.pop().expect("three levels");
+        [a, b, c]
+    };
+    Ok(ScrfdRawOutputs {
+        scores: take(scores),
+        bboxes: take(bboxes),
+        keypoints: take(keypoints),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The block ladder must sum to the convolution count the pinned graph
+    /// declares, or the tape would run out of nodes at load — on the real
+    /// weights, not in CI.
+    #[test]
+    fn the_backbone_ladder_accounts_for_every_convolution_in_the_pinned_graph() {
+        // 3 stem + per stage (2 per block, plus one shortcut on each strided
+        // opener) + 3 laterals + 3 fpn + 2 downsample + 2 pafpn
+        // + 3 x (3 stacked + cls + reg + kps).
+        let backbone: usize = STAGE_BLOCKS
+            .iter()
+            .enumerate()
+            .map(|(stage, blocks)| blocks * 2 + usize::from(stage > 0))
+            .sum();
+        let neck = 3 + 3 + 2 + 2;
+        let heads = FEATURE_STRIDES.len() * (HEAD_STACK + 3);
+        // The inventory records 6 + 46 + 6 = 58 convolutions.
+        assert_eq!(3 + backbone + neck + heads, 58);
+    }
+
+    #[test]
+    fn an_odd_pooling_extent_is_refused_rather_than_rounded() {
+        let xs = Tensor::zeros((1, 2, 5, 4), candle_core::DType::F32, &Device::Cpu).unwrap();
+        let err = average_pool_2x2_ceil(&xs).unwrap_err();
+        assert!(format!("{err}").contains("ceil_mode"), "{err}");
+    }
+
+    #[test]
+    fn a_non_doubling_resize_is_refused() {
+        let small = Tensor::zeros((1, 2, 5, 5), candle_core::DType::F32, &Device::Cpu).unwrap();
+        let odd = Tensor::zeros((1, 2, 11, 10), candle_core::DType::F32, &Device::Cpu).unwrap();
+        assert!(upsample_to(&small, &odd).is_err());
+        let doubled = Tensor::zeros((1, 2, 10, 10), candle_core::DType::F32, &Device::Cpu).unwrap();
+        assert!(upsample_to(&small, &doubled).is_ok());
+    }
+
+    /// The anchor-major flattening is the one place a silent transposition
+    /// would pair every score with another cell's box.
+    #[test]
+    fn anchor_major_flattening_runs_y_then_x_then_anchor() {
+        // [1, 2, 1, 3]: channel c, column w -> value 10*c + w.
+        let xs = Tensor::from_vec(
+            vec![0.0f32, 1.0, 2.0, 10.0, 11.0, 12.0],
+            (1, 2, 1, 3),
+            &Device::Cpu,
+        )
+        .unwrap();
+        // Rows are (y, x); each row carries both channels consecutively, which
+        // for k = 1 means two anchors per cell.
+        assert_eq!(
+            anchor_major(&xs).unwrap(),
+            vec![0.0, 10.0, 1.0, 11.0, 2.0, 12.0]
+        );
+    }
+}

--- a/crates/mold-inference/src/identity/scrfd_net.rs
+++ b/crates/mold-inference/src/identity/scrfd_net.rs
@@ -52,7 +52,7 @@ use candle_core::{Device, Module, Tensor};
 use candle_nn::Conv2d;
 use candle_onnx::onnx::ModelProto;
 
-use super::onnx_weights::WeightTape;
+use super::onnx_weights::{place_input, WeightTape};
 use super::scrfd::{ANCHORS_PER_CELL, FEATURE_STRIDES};
 
 /// Backbone channel widths, in stage order.
@@ -271,8 +271,14 @@ impl ScrfdNet {
     }
 
     /// Run the network over one `[1, 3, H, W]` blob.
+    ///
+    /// The blob arrives from [`super::scrfd::ScrfdDetector::blob`], which builds
+    /// it on the CPU because that is where an `RgbImage` lives. It is moved onto
+    /// the weights' device first — a clone on today's CPU path, and the
+    /// difference between working and a cross-device `Conv` failure on any
+    /// other.
     pub fn forward(&self, blob: &Tensor) -> Result<ScrfdRawOutputs> {
-        let mut xs = blob.clone();
+        let mut xs = place_input(blob, &self.device)?;
         for conv in &self.stem {
             xs = conv.forward(&xs)?.relu()?;
         }

--- a/crates/mold-inference/tests/pulid_handport_parity.rs
+++ b/crates/mold-inference/tests/pulid_handport_parity.rs
@@ -281,13 +281,22 @@ const GATE_RUNS: usize = 20;
 ///
 /// The margin is generous — the port only has to not regress — because the
 /// measured win is small: see `docs/architecture/pulid-perf.md` §4, which
-/// records why re-materialization turned out not to be the cost centre.
+/// records why re-materialization turned out not to be the cost centre. It is
+/// still tight enough to catch the transpose bug, which cost ~16% of the
+/// recognizer.
 const NO_SLOWER_THAN: f64 = 0.95;
 
-fn p95(mut samples: Vec<f64>) -> f64 {
+/// The best and median samples.
+///
+/// The ratio below is taken over the BEST sample of each side, not the p95.
+/// Both evaluators are deterministic, so their fastest run is the one least
+/// contaminated by another process — and this box routinely sits at load
+/// average 15 with peer builds running, where a p95 is whatever stall happened
+/// to land in the 19th sample. The median is reported alongside so a reader can
+/// see the spread rather than trusting one number.
+fn best_and_median(mut samples: Vec<f64>) -> (f64, f64) {
     samples.sort_by(|a, b| a.partial_cmp(b).unwrap());
-    let rank = ((0.95 * samples.len() as f64).ceil() as usize).clamp(1, samples.len());
-    samples[rank - 1]
+    (samples[0], samples[samples.len() / 2])
 }
 
 fn milliseconds(f: impl FnOnce()) -> f64 {
@@ -333,13 +342,65 @@ fn the_resident_port_is_never_slower_than_the_evaluator_it_replaced() {
             oracle.push(o);
         }
     }
-    let (port_p95, oracle_p95) = (p95(port), p95(oracle));
-    let ratio = oracle_p95 / port_p95;
-    println!("face stack p95: port {port_p95:.1} ms, candle-onnx {oracle_p95:.1} ms ({ratio:.2}x)");
+    let (port_best, port_median) = best_and_median(port);
+    let (oracle_best, oracle_median) = best_and_median(oracle);
+    let ratio = oracle_best / port_best;
+    println!(
+        "face stack: port {port_best:.1}/{port_median:.1} ms, candle-onnx \
+         {oracle_best:.1}/{oracle_median:.1} ms (best/median), {ratio:.2}x"
+    );
     assert!(
         ratio >= NO_SLOWER_THAN,
         "the resident port is {ratio:.2}x the evaluator it replaced \
-         ({port_p95:.1} ms vs {oracle_p95:.1} ms); a resident forward must not cost more than one \
-         that re-materializes 278 MB of initializers per call"
+         ({port_best:.1} ms vs {oracle_best:.1} ms best of {GATE_RUNS}); a resident forward must \
+         not cost more than one that re-materializes 278 MB of initializers per call"
     );
+}
+
+/// The device seam, exercised end to end rather than only at the blob.
+///
+/// `place_input`'s unit test proves the input follows the weights; this proves
+/// the rest of the network does too — every convolution, the folded batch
+/// norms, the PReLUs, and the `Gemm` — because a seam that compiles but cannot
+/// complete a forward is not a seam. It is what makes
+/// `docs/architecture/pulid-perf.md` §5 implementable rather than aspirational.
+///
+/// Metal reassociates reductions differently from the CPU, so the comparison is
+/// a tolerance rather than bit-identity — deliberately looser than the
+/// CPU-vs-`candle-onnx` budgets above, and still far tighter than the 0.99
+/// cosine the upstream gate asks for.
+#[cfg(all(target_os = "macos", feature = "metal"))]
+#[test]
+#[ignore = "requires the antelopev2 ONNX models via MOLD_TEST_PULID_ASSETS"]
+fn the_device_seam_completes_a_forward_off_the_cpu() {
+    let dir = assets().expect("set MOLD_TEST_PULID_ASSETS to the antelopev2 directory");
+    // `metal_device`, never `Device::new_metal`. Two reasons, and the second
+    // is the one that bites: mold opens each Metal GPU exactly once per
+    // process (a second device for the same GPU is the split-identity bug),
+    // and `device::tests::production_code_never_constructs_a_metal_device_directly`
+    // scans every `.rs` under `crates/` treating everything before the first
+    // `#[cfg(test)]` as production — which, in an integration-test file that
+    // has no such marker, is the whole file.
+    let Ok(metal) = mold_inference::device::metal_device(0) else {
+        eprintln!("skipping: no Metal device on this machine");
+        return;
+    };
+    let recognizer = load_onnx_model(&dir.join("glintr100.onnx"), None).expect("the model loads");
+    let on_cpu = IResNet100::new(&recognizer.model, &Device::Cpu).expect("the CPU port builds");
+    let on_metal = IResNet100::new(&recognizer.model, &metal).expect("the Metal port builds");
+    assert!(on_metal.device().same_device(&metal));
+
+    let (image, landmarks, _) = fixtures().remove(0);
+    let crop = norm_crop(&image, &landmarks).expect("a warpable face");
+    // The blob is built on the CPU, as production builds it: this call is the
+    // regression the finding was about.
+    let blob = ArcFaceRecognizer::blob(&crop).expect("the blob builds");
+
+    let host = on_cpu.forward(&blob).expect("the CPU forward");
+    let device = on_metal.forward(&blob).expect("the Metal forward");
+    let delta = max_abs(&host, &device, "embedding");
+    let cosine =
+        ArcFaceEmbedding { raw: host }.cosine_similarity(&ArcFaceEmbedding { raw: device });
+    println!("metal vs cpu: worst |delta| {delta:e}, cosine {cosine:.8}");
+    assert!(cosine >= 0.9999, "metal cosine {cosine:.8} against the CPU");
 }

--- a/crates/mold-inference/tests/pulid_handport_parity.rs
+++ b/crates/mold-inference/tests/pulid_handport_parity.rs
@@ -1,0 +1,257 @@
+//! Parity for the hand-ported face networks (#1227) against the `candle-onnx`
+//! path they replace.
+//!
+//! `docs/architecture/pulid-perf.md` §1 replaced `candle_onnx::simple_eval`
+//! with resident `candle-core`/`candle-nn` forward passes
+//! (`identity::scrfd_net`, `identity::arcface_net`) to stop re-materializing
+//! 278 MB of initializers on every request. The port invents no numerics, so
+//! the qualifying question is narrow and answerable exactly: **do the two
+//! evaluators agree, tensor for tensor, on the pinned weights?**
+//!
+//! That is what this file asks. The *upstream* qualification — landmark ≤ 1.0
+//! px, bbox ≤ 2.0 px, score ≤ 0.02, ArcFace cosine ≥ 0.99 against InsightFace's
+//! own goldens — is unchanged and still lives in `pulid_face_parity.rs`, which
+//! after the swap exercises this port rather than `simple_eval`. No new
+//! tolerance is invented here; the numbers below are tighter than that gate by
+//! design, because two float32 evaluators of the same graph should differ only
+//! by summation order.
+//!
+//! Weight-gated, like every other test that needs the antelopev2 files:
+//!
+//! ```text
+//! MOLD_TEST_PULID_ASSETS=/path/to/antelopev2 \
+//!   cargo test -p mold-ai-inference --features pulid \
+//!   --test pulid_handport_parity -- --ignored --nocapture
+//! ```
+
+#![cfg(feature = "pulid")]
+
+use std::path::{Path, PathBuf};
+
+use candle_core::Device;
+use image::RgbImage;
+use mold_inference::identity::align::Landmarks5;
+use mold_inference::identity::arcface::{norm_crop, ArcFaceEmbedding, ArcFaceRecognizer};
+use mold_inference::identity::arcface_net::IResNet100;
+use mold_inference::identity::onnx_graph::load_onnx_model;
+use mold_inference::identity::scrfd::ScrfdDetector;
+use mold_inference::identity::scrfd_net::ScrfdNet;
+use mold_inference::identity::warp::letterbox_top_left;
+use serde::Deserialize;
+
+/// SCRFD's port carries no batch-norm fold — the export already folded them —
+/// and calls the same `candle-core` kernels in the same order, so measured
+/// drift across the whole fixture set is **exactly zero** on every one of the
+/// nine head tensors. The budget is not zero only because a different
+/// platform's `rayon` split could reassociate a sum.
+const SCORE_TOLERANCE: f32 = 1e-5;
+/// Distance-encoded box and keypoint predictions are in stride units, roughly
+/// `[-20, 20]` before scaling. Measured worst case: 0.
+const DISTANCE_TOLERANCE: f32 = 1e-4;
+/// Raw ArcFace components run to about ±5 with a vector norm near 20. This is
+/// the one place the port differs arithmetically: `FoldedBatchNorm` collapses
+/// the spec's divide-and-affine into one multiply-add per channel, which moves
+/// the last bits. Measured worst case across the fixture set: 1.16e-5.
+const EMBEDDING_TOLERANCE: f32 = 1e-4;
+/// The upstream gate is 0.99 against InsightFace. Against the evaluator this
+/// port replaced, anything below five nines means the graphs diverged.
+const SELF_COSINE_FLOOR: f32 = 0.999_99;
+
+#[derive(Debug, Deserialize)]
+struct Golden {
+    image: String,
+    landmarks: [[f64; 2]; 5],
+}
+
+fn testdata() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("testdata/pulid")
+        .canonicalize()
+        .expect("crates/mold-inference/testdata/pulid is committed")
+}
+
+fn assets() -> Option<PathBuf> {
+    std::env::var_os("MOLD_TEST_PULID_ASSETS").map(PathBuf::from)
+}
+
+/// Every committed face fixture with its InsightFace landmarks.
+fn fixtures() -> Vec<(RgbImage, Landmarks5, String)> {
+    let faces = testdata().join("faces");
+    let mut out = Vec::new();
+    for entry in std::fs::read_dir(&faces).expect("fixture faces directory") {
+        let path = entry.expect("readable fixture entry").path();
+        if !path.to_string_lossy().ends_with(".golden.json") {
+            continue;
+        }
+        let golden: Golden =
+            serde_json::from_slice(&std::fs::read(&path).expect("readable golden"))
+                .unwrap_or_else(|e| panic!("malformed golden {}: {e}", path.display()));
+        let image = image::open(faces.join(&golden.image))
+            .expect("fixture image decodes")
+            .to_rgb8();
+        out.push((image, golden.landmarks, golden.image));
+    }
+    out.sort_by(|a, b| a.2.cmp(&b.2));
+    assert!(out.len() >= 3, "the parity set needs at least three faces");
+    out
+}
+
+fn max_abs(a: &[f32], b: &[f32], what: &str) -> f32 {
+    assert_eq!(
+        a.len(),
+        b.len(),
+        "{what}: length {} vs {}",
+        a.len(),
+        b.len()
+    );
+    a.iter()
+        .zip(b.iter())
+        .map(|(x, y)| (x - y).abs())
+        .fold(0.0f32, f32::max)
+}
+
+// ---------------------------------------------------------------------------
+// Hermetic: the port is wired in, and refuses the wrong graph.
+// ---------------------------------------------------------------------------
+
+/// A detector graph handed the recognizer's weights (or any other graph whose
+/// parameter order differs) must fail at LOAD with a shape complaint, never
+/// produce a plausible-looking detection from misaligned tensors.
+#[test]
+fn a_graph_whose_parameters_do_not_match_the_port_is_refused_at_load() {
+    let Some(dir) = assets() else {
+        eprintln!("skipping: set MOLD_TEST_PULID_ASSETS to run the cross-graph refusal");
+        return;
+    };
+    let recognizer = load_onnx_model(&dir.join("glintr100.onnx"), None).expect("the model loads");
+    let rendered = match ScrfdNet::new(&recognizer.model, &Device::Cpu) {
+        Ok(_) => panic!("the recognizer graph is not a detector and must not build one"),
+        Err(err) => format!("{err:#}"),
+    };
+    assert!(
+        rendered.contains("stem conv") || rendered.contains("shape"),
+        "the refusal must name where the graph diverged: {rendered}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Weight-gated: the two evaluators, tensor for tensor.
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "requires the antelopev2 ONNX models via MOLD_TEST_PULID_ASSETS"]
+fn the_scrfd_hand_port_matches_candle_onnx_on_every_head_tensor() {
+    let dir = assets().expect("set MOLD_TEST_PULID_ASSETS to the antelopev2 directory");
+    let loaded = load_onnx_model(&dir.join("scrfd_10g_bnkps.onnx"), None).expect("the model loads");
+    let net = ScrfdNet::new(&loaded.model, &Device::Cpu).expect("the hand port builds");
+
+    let mut worst_score = 0.0f32;
+    let mut worst_distance = 0.0f32;
+    for (image, _, name) in fixtures() {
+        let boxed = letterbox_top_left(&image, 640);
+        let blob = ScrfdDetector::blob(&boxed.image).expect("the blob builds");
+        let mine = net.forward(&blob).expect("the hand port runs");
+        let theirs = mold_inference::identity::scrfd_net::reference_forward(&loaded.model, &blob)
+            .expect("candle-onnx runs");
+
+        for level in 0..3 {
+            worst_score = worst_score.max(max_abs(
+                &mine.scores[level],
+                &theirs.scores[level],
+                "scores",
+            ));
+            worst_distance = worst_distance.max(max_abs(
+                &mine.bboxes[level],
+                &theirs.bboxes[level],
+                "bboxes",
+            ));
+            worst_distance = worst_distance.max(max_abs(
+                &mine.keypoints[level],
+                &theirs.keypoints[level],
+                "keypoints",
+            ));
+        }
+        println!("{name}: worst score {worst_score:e}, worst distance {worst_distance:e}");
+    }
+    assert!(
+        worst_score < SCORE_TOLERANCE,
+        "score drift {worst_score:e} exceeds {SCORE_TOLERANCE:e}"
+    );
+    assert!(
+        worst_distance < DISTANCE_TOLERANCE,
+        "distance drift {worst_distance:e} exceeds {DISTANCE_TOLERANCE:e}"
+    );
+}
+
+#[test]
+#[ignore = "requires the antelopev2 ONNX models via MOLD_TEST_PULID_ASSETS"]
+fn the_arcface_hand_port_matches_candle_onnx_on_the_raw_embedding() {
+    let dir = assets().expect("set MOLD_TEST_PULID_ASSETS to the antelopev2 directory");
+    let loaded = load_onnx_model(&dir.join("glintr100.onnx"), None).expect("the model loads");
+    let net = IResNet100::new(&loaded.model, &Device::Cpu).expect("the hand port builds");
+
+    let mut worst_delta = 0.0f32;
+    let mut worst_cosine = 1.0f32;
+    for (image, landmarks, name) in fixtures() {
+        let crop = norm_crop(&image, &landmarks).expect("a warpable face");
+        let blob = ArcFaceRecognizer::blob(&crop).expect("the blob builds");
+        let mine = net.forward(&blob).expect("the hand port runs");
+        let theirs = mold_inference::identity::arcface_net::reference_forward(&loaded.model, &blob)
+            .expect("candle-onnx runs");
+        assert_eq!(mine.len(), 512);
+
+        worst_delta = worst_delta.max(max_abs(&mine, &theirs, "embedding"));
+        let cosine =
+            ArcFaceEmbedding { raw: mine }.cosine_similarity(&ArcFaceEmbedding { raw: theirs });
+        worst_cosine = worst_cosine.min(cosine);
+        println!("{name}: worst |delta| {worst_delta:e}, cosine {cosine:.8}");
+    }
+    assert!(
+        worst_delta < EMBEDDING_TOLERANCE,
+        "embedding drift {worst_delta:e} exceeds {EMBEDDING_TOLERANCE:e}"
+    );
+    assert!(
+        worst_cosine >= SELF_COSINE_FLOOR,
+        "cosine {worst_cosine:.8} against the evaluator this port replaced"
+    );
+}
+
+/// The whole point of the port: a second evaluation must not re-read the
+/// weights. Nothing observable proves that directly, so this pins the property
+/// that motivated it — repeated forwards are deterministic AND the graph is no
+/// longer needed, so the `ModelProto` can be dropped before the first call.
+#[test]
+#[ignore = "requires the antelopev2 ONNX models via MOLD_TEST_PULID_ASSETS"]
+fn the_port_outlives_the_graph_it_was_built_from() {
+    let dir = assets().expect("set MOLD_TEST_PULID_ASSETS to the antelopev2 directory");
+    let crop = RgbImage::from_pixel(112, 112, image::Rgb([90, 110, 130]));
+    let blob = ArcFaceRecognizer::blob(&crop).expect("the blob builds");
+    let net = {
+        let loaded = load_onnx_model(&dir.join("glintr100.onnx"), None).expect("the model loads");
+        IResNet100::new(&loaded.model, &Device::Cpu).expect("the hand port builds")
+        // `loaded` — the whole 261 MB `ModelProto` — is dropped here.
+    };
+    let first = net.forward(&blob).expect("the first forward");
+    let second = net.forward(&blob).expect("the second forward");
+    assert_eq!(first, second, "resident weights must be deterministic");
+    assert!(net.device().is_cpu(), "milestone 1 stays CPU-resident");
+}
+
+/// Placement is now a real property of the instance rather than the
+/// evaluator's hardcoded `Device::Cpu`, and milestone 1 must still answer CPU
+/// through the ordinary constructors.
+#[test]
+#[ignore = "requires the antelopev2 ONNX models via MOLD_TEST_PULID_ASSETS"]
+fn the_shipped_constructors_stay_cpu_resident() {
+    let dir = assets().expect("set MOLD_TEST_PULID_ASSETS to the antelopev2 directory");
+    let detector = load_onnx_model(&dir.join("scrfd_10g_bnkps.onnx"), None).expect("the model");
+    let recognizer = load_onnx_model(&dir.join("glintr100.onnx"), None).expect("the model");
+    assert!(ScrfdDetector::new(detector.model)
+        .expect("the detector builds")
+        .device()
+        .is_cpu());
+    assert!(ArcFaceRecognizer::new(recognizer.model)
+        .expect("the recognizer builds")
+        .device()
+        .is_cpu());
+}

--- a/crates/mold-inference/tests/pulid_handport_parity.rs
+++ b/crates/mold-inference/tests/pulid_handport_parity.rs
@@ -255,3 +255,87 @@ fn the_shipped_constructors_stay_cpu_resident() {
         .device()
         .is_cpu());
 }
+
+// ---------------------------------------------------------------------------
+// Weight-gated: the performance property, pinned relatively.
+// ---------------------------------------------------------------------------
+
+/// Warmups and measured runs, the `pulid_face_probe` gate protocol.
+const GATE_WARMUPS: usize = 5;
+const GATE_RUNS: usize = 20;
+
+/// The port must never be SLOWER than the evaluator it replaced.
+///
+/// This is deliberately a **relative** pin rather than a millisecond ceiling.
+/// An absolute number is a property of the machine and the machine's load —
+/// `pulid-face-extraction.md` records a p95 that tripled under load average 83
+/// — so a committed millisecond threshold either flakes on a busy box or is set
+/// so loose it catches nothing. Running both evaluators alternately in one loop
+/// makes them share whatever contention exists, and the ratio survives it.
+///
+/// It is not a hypothetical guard. The first version of `arcface_net` computed
+/// the fully-connected layer as `X @ W^T` and so materialized a transpose of
+/// the 51 MB weight on **every forward**, which made the "faster" port 6%
+/// slower than `simple_eval`; this ratio is what caught it.
+///
+/// The margin is generous — the port only has to not regress — because the
+/// measured win is small: see `docs/architecture/pulid-perf.md` §4, which
+/// records why re-materialization turned out not to be the cost centre.
+const NO_SLOWER_THAN: f64 = 0.95;
+
+fn p95(mut samples: Vec<f64>) -> f64 {
+    samples.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let rank = ((0.95 * samples.len() as f64).ceil() as usize).clamp(1, samples.len());
+    samples[rank - 1]
+}
+
+fn milliseconds(f: impl FnOnce()) -> f64 {
+    let started = std::time::Instant::now();
+    f();
+    started.elapsed().as_secs_f64() * 1000.0
+}
+
+#[test]
+#[ignore = "requires the antelopev2 ONNX models via MOLD_TEST_PULID_ASSETS"]
+fn the_resident_port_is_never_slower_than_the_evaluator_it_replaced() {
+    let dir = assets().expect("set MOLD_TEST_PULID_ASSETS to the antelopev2 directory");
+    let detector = load_onnx_model(&dir.join("scrfd_10g_bnkps.onnx"), None).expect("the model");
+    let recognizer = load_onnx_model(&dir.join("glintr100.onnx"), None).expect("the model");
+    let scrfd = ScrfdNet::new(&detector.model, &Device::Cpu).expect("the hand port builds");
+    let arcface = IResNet100::new(&recognizer.model, &Device::Cpu).expect("the hand port builds");
+
+    let (image, landmarks, _) = fixtures().remove(0);
+    let boxed = letterbox_top_left(&image, 640);
+    let detect_blob = ScrfdDetector::blob(&boxed.image).expect("the blob builds");
+    let crop = norm_crop(&image, &landmarks).expect("a warpable face");
+    let embed_blob = ArcFaceRecognizer::blob(&crop).expect("the blob builds");
+
+    let mut port = Vec::new();
+    let mut oracle = Vec::new();
+    for i in 0..(GATE_WARMUPS + GATE_RUNS) {
+        // Alternated inside one iteration so both see the same contention.
+        let p = milliseconds(|| {
+            scrfd.forward(&detect_blob).expect("the port runs");
+            arcface.forward(&embed_blob).expect("the port runs");
+        });
+        let o = milliseconds(|| {
+            mold_inference::identity::scrfd_net::reference_forward(&detector.model, &detect_blob)
+                .expect("candle-onnx runs");
+            mold_inference::identity::arcface_net::reference_forward(&recognizer.model, &embed_blob)
+                .expect("candle-onnx runs");
+        });
+        if i >= GATE_WARMUPS {
+            port.push(p);
+            oracle.push(o);
+        }
+    }
+    let (port_p95, oracle_p95) = (p95(port), p95(oracle));
+    let ratio = oracle_p95 / port_p95;
+    println!("face stack p95: port {port_p95:.1} ms, candle-onnx {oracle_p95:.1} ms ({ratio:.2}x)");
+    assert!(
+        ratio >= NO_SLOWER_THAN,
+        "the resident port is {ratio:.2}x the evaluator it replaced \
+         ({port_p95:.1} ms vs {oracle_p95:.1} ms); a resident forward must not cost more than one \
+         that re-materializes 278 MB of initializers per call"
+    );
+}

--- a/crates/mold-inference/tests/pulid_handport_parity.rs
+++ b/crates/mold-inference/tests/pulid_handport_parity.rs
@@ -51,7 +51,7 @@ const DISTANCE_TOLERANCE: f32 = 1e-4;
 /// Raw ArcFace components run to about ±5 with a vector norm near 20. This is
 /// the one place the port differs arithmetically: `FoldedBatchNorm` collapses
 /// the spec's divide-and-affine into one multiply-add per channel, which moves
-/// the last bits. Measured worst case across the fixture set: 1.16e-5.
+/// the last bits. Measured worst case across the fixture set: 2.62e-6.
 const EMBEDDING_TOLERANCE: f32 = 1e-4;
 /// The upstream gate is 0.99 against InsightFace. Against the evaluator this
 /// port replaced, anything below five nines means the graphs diverged.
@@ -275,8 +275,9 @@ const GATE_RUNS: usize = 20;
 ///
 /// It is not a hypothetical guard. The first version of `arcface_net` computed
 /// the fully-connected layer as `X @ W^T` and so materialized a transpose of
-/// the 51 MB weight on **every forward**, which made the "faster" port 6%
-/// slower than `simple_eval`; this ratio is what caught it.
+/// the 51 MB weight on **every forward**, which made the "faster" port about a
+/// tenth SLOWER than `simple_eval` on the recognizer; this ratio is what caught
+/// it.
 ///
 /// The margin is generous — the port only has to not regress — because the
 /// measured win is small: see `docs/architecture/pulid-perf.md` §4, which
@@ -321,8 +322,11 @@ fn the_resident_port_is_never_slower_than_the_evaluator_it_replaced() {
         let o = milliseconds(|| {
             mold_inference::identity::scrfd_net::reference_forward(&detector.model, &detect_blob)
                 .expect("candle-onnx runs");
-            mold_inference::identity::arcface_net::reference_forward(&recognizer.model, &embed_blob)
-                .expect("candle-onnx runs");
+            mold_inference::identity::arcface_net::reference_forward(
+                &recognizer.model,
+                &embed_blob,
+            )
+            .expect("candle-onnx runs");
         });
         if i >= GATE_WARMUPS {
             port.push(p);

--- a/docs/architecture/pulid-1227-docs.md
+++ b/docs/architecture/pulid-1227-docs.md
@@ -1,0 +1,85 @@
+# Staged agent-doc deltas for #1227
+
+`CLAUDE.md` (and its `AGENTS.md` symlink), `README.md`,
+`crates/mold-cli/src/skill/SKILL.md`, and the `website/` navigation are edited
+by several PuLID issues at once, and every one of those edits lands on the same
+few paragraphs. So #1227 stages its deltas here instead of racing for those
+lines; whoever lands last applies this file and deletes it.
+
+Nothing here is new policy. Each entry is an existing sentence that #1227 made
+factually wrong, plus the sentence that replaces it.
+
+---
+
+## 1. `CLAUDE.md` — the "PuLID face extraction" bullet
+
+**Title.** `- **PuLID face extraction is a CPU `candle-onnx` path, and the
+embedding it produces is RAW.**` is no longer true of the runtime: `candle-onnx`
+parses the pinned files at load and is otherwise only the parity oracle.
+Replace the title with:
+
+> **PuLID face extraction is a CPU path over resident candle modules, and the
+> embedding it produces is RAW.**
+
+**Point (1).** Replace, in full:
+
+> (1) `candle-onnx` is CPU-only by construction — `get_tensor` places every
+> initializer on `Device::Cpu` and `Gemm` builds `alpha`/`beta` there — so
+> `IdentityExtractor::load` REFUSES a non-CPU device rather than demoting
+> silently, and `simple_eval` re-materializes initializers every call, which is
+> why the qualifying latency number is warm-repeated (halcyon p95 415.7 ms /
+> plato p95 1574.5 ms against a 2.0 s budget; plato's 1.27x margin is the one to
+> watch, and `pulid_face_probe bench` re-measures instead of re-arguing).
+
+with:
+
+> (1) The two graphs are **weight containers, not a runtime**: `identity/
+> onnx_weights.rs` reads their initializers ONCE at load through the same
+> authenticated bounded read, and `identity/scrfd_net.rs` /
+> `identity/arcface_net.rs` run them as ordinary resident `candle-core`/
+> `candle-nn` modules (#1227). `candle_onnx::simple_eval` survives only as
+> `reference_forward`, the parity oracle — never a production path, because it
+> re-materializes every initializer on `Device::Cpu` on every call. The
+> `WeightTape` consumes parameters in **graph order** with a shape assertion on
+> each, so a reordered or substituted graph fails at load naming the op index,
+> and `finish()` refuses a graph carrying parameters nobody ran. Both modules
+> take a device, so `IdentityExtractor::load`'s CPU refusal is now the
+> ADMISSION-ORDERING contract (extraction runs before the scheduler leases a
+> device) rather than an evaluator limitation — `docs/architecture/
+> pulid-perf.md` §3 designs the phase that lifts it. The qualifying latency is
+> still warm-repeated, 5 warmups / 20 runs, and `pulid_face_probe bench`
+> re-measures instead of re-arguing: `--compare` runs both evaluators
+> alternately in one loop, `--full` adds the EVA tower and the IDFormer, and
+> `--regress-against` checks a p95 against the committed per-host baselines.
+> **The re-materialization was not the cost centre** — §4 records the measured
+> numbers, and the EVA02-CLIP tower, unmeasured until #1227, is the majority of
+> a real extraction.
+
+**Point (2)** stays, with one clause added at the end, because the workaround is
+now oracle-only:
+
+> … until the one-condition candle fix lands. Since #1227 that rewrite only
+> affects `simple_eval`, i.e. the parity oracle; the resident port reads the
+> `Resize` nodes' target size from the tensor it is adding to.
+
+**Point (5)** stays verbatim — the authenticated bounded read is unchanged and
+is still the only way an extractor is constructed.
+
+## 2. `CLAUDE.md` — the "Identity is extracted once per request" bullet
+
+One sentence to add after "Because extraction completes and releases its ~1.4 GB
+before a device is leased…":
+
+> The ~1.4 GB peak is unchanged, but its composition moved: the recognizer's
+> 261 MB is now resident tensors rather than a retained `ModelProto` plus a
+> per-call copy of it, so the transient half of that stage is gone.
+
+## 3. `crates/mold-cli/src/skill/SKILL.md`
+
+No change. The skill documents user-facing CLI surface, and #1227 adds no flag,
+env var, endpoint, or model.
+
+## 4. `README.md`, `website/` navigation
+
+No change, same reason. `website/guide/configuration.md` gains no row: #1227
+reads no new environment variable.

--- a/docs/architecture/pulid-1227-docs.md
+++ b/docs/architecture/pulid-1227-docs.md
@@ -51,9 +51,11 @@ with:
 > re-measures instead of re-arguing: `--compare` runs both evaluators
 > alternately in one loop, `--full` adds the EVA tower and the IDFormer, and
 > `--regress-against` checks a p95 against the committed per-host baselines.
-> **The re-materialization was not the cost centre** — §4 records the measured
-> numbers, and the EVA02-CLIP tower, unmeasured until #1227, is the majority of
-> a real extraction.
+> **The re-materialization was not the cost centre** — measured 1.04x, not the
+> 25% #1227 set out to find, because a 261 MB copy is cheap next to 23 GFLOP of
+> f32 convolution. §4 records the numbers, and the EVA02-CLIP tower, unmeasured
+> until #1227, is **79%** of a real extraction (2,237 ms of 2,840 ms p50 on
+> halcyon) against the face stack's 13%.
 
 **Point (2)** stays, with one clause added at the end, because the workaround is
 now oracle-only:

--- a/docs/architecture/pulid-face-extraction.md
+++ b/docs/architecture/pulid-face-extraction.md
@@ -11,6 +11,18 @@ adapter, and the FLUX attention hooks are other issues'.
 
 Code: `crates/mold-inference/src/identity/`, behind the `pulid` feature.
 
+> **Step 0's runtime choice was superseded by
+> [#1227](https://github.com/utensils/mold/issues/1227).** `candle-onnx` no
+> longer evaluates either graph at request time: `identity/scrfd_net.rs` and
+> `identity/arcface_net.rs` run them as resident `candle` modules built once
+> from the same SHA-pinned files, and `candle_onnx::simple_eval` survives only
+> as the parity oracle those modules are tested against. Everything else on this
+> page still stands — the op inventory, the pinned digests, the alignment and
+> warp goldens, the tolerances, and the deferrals — and the measured latencies
+> below remain the baselines #1227 compares against.
+> `docs/architecture/pulid-perf.md` §4 records what that swap actually bought,
+> including the part of Step 0's reasoning it falsified.
+
 ---
 
 ## Step 0 — the runtime decision

--- a/docs/architecture/pulid-perf.md
+++ b/docs/architecture/pulid-perf.md
@@ -1,0 +1,578 @@
+# PuLID performance: GPU face extraction, embedding cache, and qualification
+
+Issue [#1227](https://github.com/utensils/mold/issues/1227). This is the
+research-and-design record for the perf half of face-identity conditioning:
+whether extraction should move off `candle-onnx`/CPU, a cross-request
+identity-embedding cache, EVA-CLIP residency under a GPU path, and the
+benchmark protocol that qualifies whichever of these ships.
+
+This is a **decision record, written before code**, exactly as
+[#1222](https://github.com/utensils/mold/issues/1222)'s Step 0 was. Nothing in
+this document changes Rust — see `docs/architecture/pulid-face-extraction.md`
+(Step 0: the `candle-onnx` runtime decision, the measured budget, the stage
+table), `docs/architecture/pulid.md` (encoder lifecycle, residency, the
+extraction call site), and `docs/architecture/pulid-uat.md` (real-hardware
+render numbers) for what already shipped. Code cited below:
+`crates/mold-inference/src/identity/`, `crates/mold-inference/src/flux/identity.rs`,
+`crates/mold-server/src/identity_extraction.rs`,
+`crates/mold-server/src/identity_dependencies.rs`,
+`crates/mold-core/src/identity.rs`, `crates/mold-core/src/pulid_assets.rs`,
+`crates/mold-inference/src/bin/pulid_face_probe.rs`,
+`crates/mold-scheduler/src/estimates.rs`, `crates/mold-inference/src/progress.rs`.
+
+---
+
+## 0. What changed since Step 0, and the gap Step 0 left open
+
+Two facts qualify everything below.
+
+**The candle-fork Resize PR Step 0 deferred has already landed upstream, but
+mold does not consume it.** `docs/architecture/pulid-face-extraction.md`
+records the fix as "a separate candle-fork PR, deliberately not folded into
+this work" (`candle-onnx/src/eval.rs`, the `Resize` arm, lines 2291-2301). It
+has since merged into `utensils/candle`'s `fix/mold-compat-0.11` branch:
+commit `87f3adb3` ("fix(onnx): treat zero-element optional Resize inputs as
+absent"), merged via PR #8 (`0655b4c1`), rewriting exactly the
+`optional_input` presence check the mold doc predicted. **This does not change
+anything below** — it fixes a correctness bug (an exporter's empty-tensor
+idiom for an unset `Resize` input), not a performance one, and mold's own
+`identity/onnx_graph.rs::normalize_empty_optional_resize_inputs` workaround
+stays load-bearing regardless, because `Cargo.toml` does not patch
+`candle-onnx` from the fork at all — it takes `candle-onnx = { version =
+"0.11", optional = true }` straight from crates.io
+(`crates/mold-inference/Cargo.toml:158`), unlike `candle-core`/`candle-nn`/
+`candle-transformers`, which are `[patch.crates-io]`'d to the fork
+(`Cargo.toml:59-60`). Noted here as bookkeeping only: a future housekeeping PR
+could add `candle-onnx` to the patch table and drop the mold-side
+normalization as redundant, but that is independent of this issue.
+
+**The measured 2.0 s p95 budget covers less than half of what one identity
+extraction actually does.** `pulid_face_probe bench` measures exactly
+`ScrfdDetector::detect` + `ArcFaceRecognizer::embed_crop`
+(`crates/mold-inference/src/bin/pulid_face_probe.rs`, the `run_bench` loop) —
+the two `candle-onnx`-evaluated stages. The EVA02-CLIP vision tower and the
+IDFormer are never invoked by that binary. But
+`mold_inference::identity::extraction::extract_identity_embedding` — the ONE
+production entry point (`crates/mold-server/src/identity_extraction.rs::
+resolve_identity_embedding` calls it directly) — always runs SCRFD → ArcFace
+→ EVA tower → IDFormer in sequence
+(`crates/mold-inference/src/identity/extraction.rs:93-126`, `147-218`), and
+the tower + IDFormer halves are unmeasured, ungated, ordinary
+`candle-core`/`candle-nn` forward passes on `Device::Cpu`
+(`extraction.rs:152`: `let device = Device::Cpu;`, hardcoded independently of
+the ONNX constraint — see §1). EVA02-CLIP-L-14-336 is a 24-block, 1024-wide,
+16-head ViT running 577 tokens through an MLP hidden width of 2730
+(`docs/architecture/pulid.md`, "Vision tower"), in f32, single-threaded CPU —
+a workload of the same order of magnitude as the `glintr100` ArcFace backbone
+`pulid_face_probe` already measures at 222–1051 ms, plausibly more. **No
+number for it exists anywhere in the repository.** Any perf-qualification
+claim this issue produces is incomplete until this is measured — §4 makes
+extending the bench harness to cover it the first concrete deliverable of the
+implementation phase, ahead of deciding where to spend GPU/hand-port effort.
+
+---
+
+## 1. Runtime decision: hand-ported candle vs. a cached ONNX evaluator
+
+### The two options on the table
+
+**A — hand-ported iResNet100 (`glintr100`) + SCRFD backbone in
+`candle-core`/`candle-nn`**, loaded once via an ordinary `VarBuilder` and run
+on whichever device (CPU, CUDA, Metal) the caller supplies — the same shape
+every other mold engine (including this crate's own EVA tower) already takes.
+Named, and scoped as mechanical, in Step 0's "What was NOT needed" section:
+"Conv → BN → PReLU → Add, Flatten → FC → BN, no global pooling... would load
+weights straight from the ONNX initializers, which `candle-onnx` can still
+parse" (`pulid-face-extraction.md`).
+
+**B — a device-aware cached evaluator inside the `utensils/candle` fork**:
+change `candle-onnx::simple_eval` (or a new entry point) to materialize
+initializers once and place them on a caller-supplied device, rather than
+re-copying every initializer onto `Device::Cpu` on every call
+(`candle-onnx/src/eval.rs`, `simple_eval_`'s `for t in graph.initializer.iter()
+{ let tensor = get_tensor(t, ...); values.insert(...) }` loop, confirmed at
+this exact fork revision — `get_tensor` hardcodes `Device::Cpu` at four call
+sites, `eval.rs:192-231`, and the `Gemm` arm builds its `alpha`/`beta` scalars
+on `Device::Cpu` too, `eval.rs:1796-1797`).
+
+### What the numbers say
+
+The Step-0 stage table (`pulid-face-extraction.md`) is the only measured
+evidence, and it covers SCRFD + ArcFace only:
+
+| | SCRFD share of p95 | ArcFace share of p95 | EVA + IDFormer share |
+| --- | --- | --- | --- |
+| halcyon | 180.8 / 415.7 = **43%** | 234.9 / 415.7 = **57%** | **unmeasured** |
+| plato | 536.4 / 1574.5 = **34%** | 1050.7 / 1574.5 = **67%** | **unmeasured** |
+
+ArcFace (`glintr100`, 260,665,334 bytes of initializers) dominates the
+measured half on both hosts, and dominates harder on plato — consistent with
+`simple_eval_`'s per-call re-materialization cost scaling with initializer
+size, not with per-request compute (`eval.rs:191-232`, `:249-257`; the Step-0
+doc: "the second call costs what the thousandth does and there is nothing to
+amortize"). SCRFD's 16,923,827-byte graph pays the same tax at ~1/15th the
+size and shows a correspondingly smaller, though still real, share.
+
+### Why B does not answer the question B looks like it answers
+
+A cached evaluator removes the re-materialization tax — real, and probably
+the majority of ArcFace's cost — but it **cannot reach a GPU**, because
+`get_tensor`'s `Device::Cpu` and the `Gemm` arm's `Device::Cpu` are
+independent of caching; a cache still has to build tensors somewhere the
+first time, and every other evaluator arm (`Conv`, `BatchNormalization`,
+`PRelu`, ...) reads the cached CPU tensors and computes on `Device::Cpu`
+throughout `simple_eval_`. Making the *whole* evaluator device-generic is a
+materially larger fork change than the already-merged Resize fix — every
+arm's implicit `Device::Cpu` would need auditing, not one presence check —
+and it is a **hard external prerequisite**: nothing in mold can ship GPU
+identity extraction until that lands, reviews, and mold repoints
+`candle-onnx` at the fork in `[patch.crates-io]` (which it does not do today,
+per §0). Option A has no such gate: `IdentityExtractor::load` already
+asserts CPU today only because `candle-onnx` forces it
+(`identity/mod.rs:106-114`), not because SCRFD/ArcFace math is CPU-bound —
+the anchor decode, NMS, alignment, and warp code the ONNX graphs feed into
+are already plain candle/host Rust with no such constraint
+(`identity/scrfd.rs`, `identity/align.rs`, `identity/warp.rs`).
+
+### Cost of A under the drop-and-reload rule
+
+SCRFD's weights are 17 MB; `glintr100`'s are 261 MB (f32, per the manifest
+pins in `pulid-face-extraction.md`'s op-gate table). A `VarBuilder`-resident
+copy of both plus forward-pass activations at their respective fixed input
+sizes (640×640 detector, 112×112 recognizer) is on the order of 300–350 MB
+device-resident, held only for the extraction and dropped immediately after
+— the same build-encode-drop discipline the EVA tower already follows
+(`pulid.md`: "The tower is ~609 MB and follows the crate's drop-and-reload
+rule: build, encode, drop. Nothing caches it."). That is *smaller* than the
+`IDENTITY_VRAM_OVERHEAD_BYTES` already budgeted for the adapter
+(1,250,000,000 bytes, `pulid.md`'s memory table) and does not add host RAM —
+if anything it reduces `EXTRACTION_HOST_PEAK_BYTES` (`extraction.rs:61-77`)
+by moving the two largest host allocations (the re-materialized ONNX graphs)
+onto a device.
+
+### The tension a GPU path reopens, and why milestone 1 should not resolve it yet
+
+Extraction runs today at **admission, before the scheduler leases any
+device** — deliberately. `identity_extraction.rs`'s own module doc states the
+reason plainly: it "runs at admission, before the scheduler has leased a
+device, so the T5 and CLIP encoders it must not compete with do not exist
+yet... its ~1.4 GB of host RAM is allocated and released before the job is
+dispatched. That is a stronger guarantee than a scheduled slot: the two peaks
+cannot coexist rather than being arranged not to." Running SCRFD/ArcFace on a
+GPU means running them on *some* device, and there is no device to name until
+a lease exists — which is exactly the ordering #1223 built this architecture
+to avoid needing. Resolving that ordering is a real, separate design (§3
+proposes it as a typed scheduler phase); it should not be smuggled in as a
+side effect of "port the backbone to candle."
+
+### Recommendation
+
+**Ship option A (hand-ported SCRFD + iResNet100 in candle), but keep it
+CPU-resident at today's call site for milestone 1.** Concretely: replace only
+the internals of `IdentityExtractor` (`identity/mod.rs`,
+`identity/scrfd.rs`'s backbone forward, `identity/arcface.rs`'s backbone
+forward) from `candle-onnx::simple_eval` calls to ordinary
+`VarBuilder`-loaded candle-core/candle-nn forward passes — loading the ONNX
+initializers once (candle-onnx's tensor-proto parsing can still be reused
+*at load time only*, to pull weights out, exactly as `onnx_inventory.rs`
+already introspects the graphs, or the weights can be converted once to
+safetensors mirroring `encoders::eva_clip_convert`'s pattern) and calling
+`.forward()` per request against a resident, mmap-backed set of tensors. Keep
+`IdentityExtractor::load`'s `Device::Cpu` argument and assertion exactly as
+they are (`identity/mod.rs:106-114`) — the call site, the lifetime, the
+`ExtractionSlot`, and the pre-lease admission-time architecture all stay
+untouched. This buys most of the re-materialization win with **zero**
+scheduler, ledger, or lease-ordering changes, and it is a strict prerequisite
+for a future GPU path either way (candle-onnx cannot reach a GPU at all,
+hand-ported candle can once someone asks it to). Defer GPU dispatch (all four
+stages on the render's leased device) to the phase §3 designs, gated on
+actually needing it once §4's extended measurement shows where the real time
+goes — including the currently-unmeasured EVA/IDFormer half, which may turn
+out to dominate SCRFD/ArcFace entirely.
+
+### Acceptance test
+
+- **Parity**: the hand-ported CPU forward passes must match the existing
+  `candle-onnx` CPU output within the milestone-1 tolerances already recorded
+  in `crates/mold-inference/testdata/pulid/README.md` and
+  `pulid-face-extraction.md`'s weight-gated table — landmark position ≤ 1.0
+  px, bbox corner ≤ 2.0 px, detection score ≤ 0.02, ArcFace cosine ≥ 0.99 vs.
+  the same InsightFace/upstream goldens (`MOLD_TEST_PULID_ASSETS`-gated,
+  `capture_goldens.py`). No new tolerance is invented; the hand port is
+  qualified against the same fixtures the shipped path is.
+- **Speed**: p95 ≥ 25% faster than the recorded baseline (415.7 ms halcyon,
+  1574.5 ms plato, SCRFD+ArcFace only — see §4 for how this is checked
+  mechanically rather than by eyeballing a percentage).
+
+---
+
+## 2. Cross-request identity-embedding cache
+
+### Where it lives
+
+`crates/mold-server/src/identity_extraction.rs::resolve_identity_embedding`,
+immediately before `ExtractionSlot::acquire()` (line 192) — a cache hit skips
+the slot, the host-memory gate, and the extraction entirely; nothing is
+serialized or counted for a hit, because nothing is computed. This is the
+single call site every admission path already funnels through
+(`request_resolves_identity`, `EXTRACTIONS`, the `#[cfg(test)] test_stub`
+seam), so the cache needs no second integration point.
+
+### Key composition
+
+Enumerated exactly, because the task calls for the exact asset SHAs and
+version constants involved:
+
+| Component | Source | Available before extraction runs? |
+| --- | --- | --- |
+| `sha256(id_image bytes)` | `mold_core::identity::id_image_sha256` (`identity.rs:517-522`) | Yes — pure function of the request |
+| **A new `IDENTITY_PIPELINE_VERSION: u32`** | Does not exist today; add to `mold_core::identity` | Yes — a compiled constant |
+| Adapter SHA | `mold_core::pulid_assets::pulid_manifest()`'s pin for `ModelComponent::IdentityAdapter` — the same read `extraction.rs::adapter_sha256()` (lines 133-141) already performs | Yes — a manifest pin, no file read |
+| Vision (derived tower) SHA | `crate::encoders::eva_clip_convert::DERIVED_SHA256` — a compiled constant | Yes |
+| Face-detector SHA | `onnx_graph::pinned_artifact(ModelComponent::FaceDetector)`'s pin | Yes — the manifest pin, not the post-load `det.sha256` (which is checked equal to the pin or the load fails, so they never disagree) |
+| Face-recognizer SHA | `onnx_graph::pinned_artifact(ModelComponent::FaceRecognizer)`'s pin | Yes, same reasoning |
+
+This is deliberately the same four-asset shape `IdentityAssetDigests` already
+carries (`identity.rs:380-391`) — but that struct is populated **after**
+extraction, from what actually ran. The cache key needs the same four
+digests **before** extraction runs, which is why the table above resolves
+each one from its manifest/compiled-constant source rather than from an
+`IdentityAssetDigests` a request hasn't produced yet. Compose the key exactly
+as `fingerprint_of` already composes the *output* fingerprint
+(`identity.rs:496-513`) — domain-separated, newline/NUL-joined SHA-256 — but
+over these six inputs instead of the extracted values:
+
+```
+sha256("mold.identity.cache.v1\0"
+       || id_image_sha256 || "\0"
+       || IDENTITY_PIPELINE_VERSION.to_le_bytes() || "\0"
+       || adapter_sha || "\0" || vision_sha || "\0"
+       || face_detector_sha || "\0" || face_recognizer_sha)
+```
+
+**Never key on `id_image` bytes alone** (the task's own framing, and the
+reason the table above exists): a bare-photo key would serve a stale
+embedding across a repair-pull that swapped the adapter or a code change that
+altered SCRFD/ArcFace/EVA/IDFormer semantics without re-running anything —
+exactly the failure `IDENTITY_PIPELINE_VERSION` exists to catch (see
+invalidation, below), and exactly why every asset SHA is a mandatory input
+rather than an optimization to drop for a smaller key.
+
+### Storage
+
+An in-process LRU, small — 8 to 16 entries is enough (see memory bound,
+below) — living as a new module-level static beside `EXTRACTION_SLOT` and
+`EXTRACTIONS` in `identity_extraction.rs`, same file, same
+process-global-admission-state ownership boundary those already establish.
+Value = `FrozenIdentityEmbedding` (already `Clone`, `Eq`, `Hash`,
+device-independent, 256 KiB — `identity.rs:405-482`) plus the `Option<String>`
+multi-face warning. On a hit: return both immediately, touch neither
+`EXTRACTION_SLOT` nor `EXTRACTIONS`. On a miss: proceed exactly as today (slot
+→ counter → `extract_blocking`), then insert.
+
+### Invalidation
+
+1. **Different photo bytes** → different key automatically; not
+   invalidation, just a fresh entry via content addressing.
+2. **A repair-pull swaps an asset** (`mold pull pulid-flux
+   --accept-license ...` after `mold rm pulid-flux`, or a re-pinned release) →
+   the manifest pin or `DERIVED_SHA256` changes → the key changes
+   automatically; stale entries simply become unreachable and age out under
+   LRU pressure. No explicit purge needed.
+3. **A pipeline code change** (this issue's own hand-port swap in §1, or
+   #1225's future BiSeNet mask) → **must** bump `IDENTITY_PIPELINE_VERSION`,
+   or a cache entry computed by the old code silently serves a result the new
+   code would compute differently, under an unchanged photo+asset-SHA key.
+   This is the one invalidation case that is not structural — it needs a test
+   pinning "the key changes when the version changes" (so a reviewer can
+   check the constant actually moved) and a note in whichever PR ships a
+   semantic change to SCRFD/align/warp/arcface/eva_clip_preprocess/
+   eva_clip_vision/pulid_encoder.
+4. **Process restart** → the cache is in-process only; cold on every
+   restart. Acceptable — see persistence, below.
+
+### Hit/miss tests to write
+
+In `identity_extraction.rs`, alongside the existing lifetime tests
+(`a_conditioned_request_extracts_exactly_once`,
+`concurrent_identity_preparations_serialize_on_the_extraction_slot`):
+
+- Two requests, byte-identical `id_image` → `extraction_count()` advances by
+  exactly 1 total; a new `cache_hit_count()` (mirroring `extraction_count()`'s
+  existing test-only counter pattern) advances by exactly 1 on the second.
+- Two requests, different `id_image` bytes → `extraction_count()` advances by
+  2, zero cache hits.
+- Same photo, second request has `id_weight: 0.0` → zero extractions **and**
+  zero cache lookups — `request_needs_identity_assets`
+  (`identity_dependencies.rs`) short-circuits before the cache is even
+  consulted, exactly as it short-circuits `ExtractionSlot` today
+  (`a_zero_weight_request_performs_no_extraction`).
+- A slow/panicking stub installed via the existing `StubbedExtractor` seam,
+  driven twice with the same photo: the stub must be entered exactly once —
+  proves a hit never touches `ExtractionSlot::acquire()`.
+- Bump a test-local `IDENTITY_PIPELINE_VERSION` stand-in and confirm the key
+  changes for byte-identical photo + assets — pins the one non-structural
+  invalidation case.
+
+### Memory bound
+
+Each entry is 256 KiB (`ID_EMBEDDING_VALUES = 32 × 2048` f32,
+`identity.rs:369-370`) plus a short warning string and a ~64-byte key — call
+it 260 KiB. An 8–16 entry cap is 2–4 MiB total, irrelevant next to
+`EXTRACTION_HOST_PEAK_BYTES`'s 1.4 GB transient extraction peak. Size the cap
+for *this session's* concurrent hot set — a batch's siblings, a sequence's
+per-clip identity, a `Prepare N variations` review — not for a photo
+library; a byte-budget cap is unneeded complexity given the fixed entry size,
+so an entry-count cap alone is sufficient.
+
+### Interaction with #1226's multi-photo averaging
+
+Confirmed directly with the #1226 implementer while writing this doc, rather
+than assumed: averaging happens **after** the IDFormer, per-photo, mirroring
+`cubiq/PuLID_ComfyUI`'s `pulid.py:406,415-419` (append each photo's IDFormer
+*output*, then `torch.mean(dim=0)` across the stacked outputs) —
+`ToTheBeginning/PuLID`'s own `pipeline_flux.py:120-194` only ever handles one
+photo, so ComfyUI is the reference for the N-photo case. **This means caching
+the final per-photo `[1, 32, 2048]` tokens (256 KiB) is sufficient and
+correct** — there is no need to cache the larger pre-IDFormer intermediates
+(ArcFace raw + EVA hidden states + CLS projection, ~2.4 MB/photo) this doc
+originally considered before confirming the averaging stage. Each photo in a
+multi-photo request independently hits or misses this same per-photo cache;
+#1226's averaging step composes over N independent lookups because the mean
+is order-independent at the *value* level even though #1226's extended
+`FrozenIdentityEmbedding` fingerprint carries an ordered `source_sha256s` list
+and is therefore order-*sensitive* at the fingerprint level — that ordering
+concern applies to the composed multi-photo value #1226 produces downstream
+of this cache, not to this cache's own per-photo key, which stays a scalar
+per photo and is unaffected by request-level photo ordering.
+
+One more fact from #1226 worth designing for now rather than retrofitting
+later: a true-CFG **uncond** embedding — `IDFormer(zeros_like(id_cond),
+[zeros_like(h) for h in id_vit_hidden])` (`pipeline_flux.py:188-192`) — is a
+pure function of the adapter checkpoint alone, never of any photo. Cache it
+as a **separate, degenerate one-time memo** keyed only on the adapter SHA
+(effectively a lazily-initialized `OnceCell`, not an LRU entry keyed on "no
+photo") — it is computed once per process and reused by every subsequent
+true-CFG request regardless of which photo(s) are supplied. Folding it into
+the per-photo LRU would waste a slot on a value that never needs eviction and
+would need an awkward sentinel key.
+
+### Persistence
+
+**Recommend no**, unless a future need is demonstrated. Three reasons:
+
+1. `FrozenIdentityEmbedding`'s `Debug` impl exists specifically to redact its
+   values because "they are a biometric derivative and must never reach a log
+   line, an error body, or a probe payload" (`identity.rs:484-494`). Writing
+   them to a persistent on-disk store — even one scoped to `$MOLD_HOME` —
+   introduces a retention and deletion story (how long, who can read it, what
+   `mold rm pulid-flux` or a gallery purge should do to it) that nothing in
+   the codebase's current posture toward these bytes anticipates; every other
+   identity artifact is either a manifest-pinned model file or a SHA, never a
+   raw biometric-derived float array at rest.
+2. The entries are cheap enough to recompute — especially once §1's hand
+   port lands — that persistence buys comparatively little against that
+   liability.
+3. The in-process LRU already covers the actual hot path this issue is aimed
+   at: repeat renders within one session (batch siblings, `Prepare N
+   variations`, a sequence's per-clip identity, an interactive retry). A
+   cross-restart cache would only help a rarer workflow (the same face across
+   separate `mold run` invocations on different days), which is exactly where
+   the privacy cost of a persistent biometric store is least justified
+   relative to the benefit.
+
+### Interaction with the durable queue/journal
+
+This cache sits entirely upstream of the durable queue: it is consulted (or
+populated) during `resolve_identity_embedding`, at admission, before a
+`QueueTicket` or `generation_queue` row exists at all (CLAUDE.md's queue
+durability section; `mold-server`'s `scheduler/mod.rs`/`gpu_worker.rs`). A
+replayed job after a crash re-submits the ORIGINAL request — including its
+full `id_image` bytes, already retained by the journal within its byte budget
+— through the ordinary admission path, so replay simply re-runs
+`resolve_identity_embedding`: a cache hit if the process never restarted (or
+another still-live entry matches the same photo+assets), an ordinary cache
+miss otherwise. The cache has no observable effect on the frozen embedding's
+*value*, only on how fast it is produced, so it needs no special-casing in
+the journal/replay path — but it deserves one regression test: call
+`resolve_identity_embedding` twice for the same request, once simulating "no
+restart" (cache warm) and once after clearing the process-global cache
+(simulating "restarted before replay"), and assert the resulting
+`FrozenIdentityEmbedding` is byte-identical either way.
+
+---
+
+## 3. EVA-CLIP residency and a proposed typed scheduler phase
+
+### Current residency already matches the drop-and-reload rule
+
+The EVA tower and the IDFormer already run through ordinary
+`candle-core`/`candle-nn` (never `candle-onnx`), on `Device::Cpu`, inside
+`compose_identity_tokens` (`extraction.rs:147-218`): loaded via
+`VarBuilder::from_mmaped_safetensors`, built (`EvaClipVisionTower::new`),
+forwarded once, and released when the block scope ends — before the IDFormer
+is even built (`extraction.rs:163-166`'s comment: "The tower and the IDFormer
+are built and dropped in sequence, never held together... admission is the
+one place in the process where host RAM is not already committed to a
+render."). `pulid.md` confirms this is the intended policy: "The tower is ~609
+MB and follows the crate's drop-and-reload rule: build, encode, drop. Nothing
+caches it." **There is no live residency gap today** — this already satisfies
+CLAUDE.md's drop-and-reload discipline for identity assets exactly as it does
+for T5/CLIP.
+
+### What changes if GPU dispatch (§1's deferred follow-up) ships
+
+If the EVA tower and IDFormer (and, per §1, the hand-ported SCRFD/ArcFace
+backbones) move from `Device::Cpu` to the render's leased device, the same
+build-encode-drop discipline must hold on that device: build, forward, drop
+— fully released — **before** `flux::identity::EngineIdentityState`'s
+ordinary adapter-residency logic begins for that dispatch
+(`crates/mold-inference/src/flux/identity.rs:8-21`'s own residency doc). The
+extraction's transient allocation must never coexist with the resident
+cross-attention adapter or the transformer's own peak; it is a strictly
+earlier, strictly disjoint phase of the same lease, not a third permanent
+resident.
+
+### The host-RAM ledger fold-in this implies
+
+Today, extraction's host RAM is charged at `ExtractionSlot::acquire()`
+(`identity_extraction.rs:106-134`) against a **fresh** `ram_snapshot()` read,
+gated by a bare `tokio::sync::Semaphore::const_new(1)` — deliberately **not**
+the scheduler's `HostMemoryLedger`, because (the module's own doc) "extraction
+happens strictly BEFORE this job has a lease... Re-entering the planner from
+admission to charge a transient CPU peak would invert that ownership." Once
+extraction runs on a leased device, that ordering argument inverts: the job
+now *has* a lease, so its host-RAM charge belongs in the same
+`admission_host_demand_bytes` frozen-plan-recheck discipline every other
+phase already uses (CLAUDE.md: "the worker rechecks the exact frozen
+`admission_host_demand_bytes` against headroom from the granting ledger...
+before any fresh load"). Concretely, this milestone would retire
+`ExtractionSlot`'s bespoke semaphore-plus-snapshot gate in favor of the
+ledger, rather than running the two in parallel — two independent admission-
+time memory gates that can disagree is worse than one, and the ledger's
+recheck-at-dispatch discipline already exists to answer exactly this
+question for six other phases.
+
+### The proposed phase
+
+Add `ProgressPhase::IdentityExtract` to
+`crates/mold-inference/src/progress.rs:74-89` (alongside `ModelLoad`,
+`PromptEncode`, `Vae`, `VisualDecode`, `AudioDecode`, `Mux`, `Upscale`),
+emitted as `ProgressEvent::PhaseDone { phase: ProgressPhase::IdentityExtract,
+name, elapsed }` bracketing the (now post-lease) SCRFD+ArcFace+EVA+IDFormer
+run.
+
+Files that change, and why:
+
+| File | Change |
+| --- | --- |
+| `crates/mold-inference/src/progress.rs` | New `IdentityExtract` arm on `ProgressPhase` (line ~74-89) |
+| `crates/mold-scheduler/src/estimates.rs` | New `identity_extract_ms: Option<u64>` on `EstimatePhaseTimings` (beside `cold_load_ms`/`prompt_encode_ms`, ~line 90-101); new `ewma_identity_extract_ms: Option<f64>` on `EstimateBucket` (~line 128-145) |
+| `crates/mold-server/src/gpu_worker.rs` | New `add_phase_sample(&mut timings.identity_extract_ms, elapsed)` arm in `record_phase_timing`'s match (mirrors the existing `PromptEncode`/`Vae`/etc. arms) — and a decision that only the ONE sibling that actually performed the (once-per-parent) extraction records the sample; every other sibling's `identity_extract_ms` stays `None`, exactly like `cold_load_ms` already being `None` on a warm reuse — the EWMA machinery is already `Option`-tolerant throughout |
+| `crates/mold-db/src/scheduler_estimates.rs` | New `ewma_identity_extract_ms` column in the `scheduler_estimates` read/write/upsert SQL, mirroring every existing `ewma_*_ms` column |
+| `crates/mold-db/src/migrations.rs` | A schema bump: `SCHEMA_VERSION` 20 → 21, adding the new column via `ALTER TABLE scheduler_estimates ADD COLUMN ewma_identity_extract_ms REAL` — this one is **not** a bare additive Rust `Option` an old row already reads as `NULL`; SQLite needs the column to exist before the new `INSERT`/`UPDATE` statement can reference it |
+| `crates/mold-server/src/identity_dependencies.rs` / the scheduler dispatch path | The call site for extraction moves (or gains a second, post-lease trigger) from `variant_dependencies::prepare_inputs_for_devices` (pre-lease, current) to inside the leased job's own pipeline, first, before prompt encode |
+
+### Recommendation
+
+**Do not build this phase for milestone 1.** It only pays for itself once
+extraction genuinely competes for time on a leased device — i.e., once GPU
+dispatch ships. Wiring the enum arm, the `EstimatePhaseTimings`/`EstimateBucket`
+fields, the schema bump, and the ledger fold-in now, while extraction stays
+CPU/pre-lease (§1's milestone-1 recommendation), would land a migration and
+five touched files that only ever record `None`. Land this phase in the same
+change that moves extraction post-lease, not before it.
+
+---
+
+## 4. Qualification protocol
+
+### Existing harness
+
+`pulid_face_probe bench <dir> [--warmups N] [--runs N]`
+(`crates/mold-inference/src/bin/pulid_face_probe.rs`), gated at
+`LATENCY_BUDGET_MS = 2000.0` per image (SCRFD detect + ArcFace embed only,
+per §0). `GATE_WARMUPS = 5` / `GATE_RUNS = 20` is the real protocol;
+anything short of it prints an ADVISORY, not a GATE verdict
+(`validate_bench_args`), and `--runs 0` is refused outright rather than
+reporting a vacuous PASS.
+
+```bash
+cargo build --release -p mold-ai-inference --features dev-bins,pulid --bin pulid_face_probe
+./target/release/pulid_face_probe bench /path/to/pulid-assets-dir
+```
+
+### Required extension (first implementation-phase deliverable, not this doc)
+
+A second bench mode covering the currently-unmeasured half of §0's finding —
+`pulid_face_probe bench --full` (or a separate `bench-full` subcommand) that
+additionally warm-repeats `extraction::compose_identity_tokens` (EVA tower +
+IDFormer forward, given a fixed aligned 512×512 crop and ArcFace vector so
+the bench isolates encode cost from detection) per image, reusing the exact
+5-warmup/20-run protocol and `validate_bench_args`'s existing refusal/advisory
+logic verbatim. Report a **four-row** stage table (SCRFD / ArcFace / EVA /
+IDFormer / per-image total) rather than today's two-row one. This must land
+and produce real numbers before any claim of "performance qualification" is
+made, because today's gate is silent on what may be the larger half of the
+real cost.
+
+### Warm-repeat protocol
+
+Unchanged from Step 0: `simple_eval` (and, after §1's hand port, an ordinary
+resident `VarBuilder` forward) has no cold/warm split to amortize once
+weights are resident — "the second call costs what the thousandth does" — so
+5 warmups / 20 runs is the floor, and a short run reports noise as signal (the
+Step-0 doc's own cautionary example: 588.4 ms p95 under load average 83 with
+the full protocol vs. 2533.7 ms from `--runs 2` on the same host).
+
+### Named configurations
+
+Identical to Step 0's, so before/after numbers are directly comparable
+without re-baselining:
+
+- **halcyon** — Apple M4 Max, 16 cores, 48 GiB, macOS (aarch64-darwin), this
+  Mac.
+- **plato** — 128-core x86_64 NixOS, 1.5 TiB RAM, 4× L40S, reached via `ssh
+  plato` (Tailscale `100.105.134.43`).
+
+### Regression test at the measured numbers
+
+Add pinned baseline constants beside `LATENCY_BUDGET_MS` in
+`pulid_face_probe.rs` — `BASELINE_HALCYON_P95_MS: f64 = 415.7`,
+`BASELINE_PLATO_P95_MS: f64 = 1574.5` (the SCRFD+ArcFace numbers this doc
+cites from `pulid-face-extraction.md`; add the EVA/IDFormer baselines once
+the extended bench above produces them) — and a `--regress-against
+<halcyon|plato>` flag that fails (non-zero exit, matching the existing gate's
+convention) when the measured p95 exceeds 0.75× the named baseline, i.e. the
+literal "p95 ≥ 25% faster" acceptance criterion expressed as a mechanically
+checkable ratio against numbers already committed to this repository, rather
+than a comment a reviewer has to recompute by hand.
+
+### Device-path parity
+
+No new tolerances: the hand port from §1 is qualified against the exact
+tolerances already recorded in `crates/mold-inference/testdata/pulid/README.md`
+and `pulid-face-extraction.md`'s weight-gated table (landmark ≤ 1.0 px, bbox
+≤ 2.0 px, score ≤ 0.02, ArcFace cosine ≥ 0.99) and `pulid.md`'s encoder-parity
+numbers (IDFormer output to 1.5e-7 of scale, CLS projection to 1.3e-5
+absolute, hidden states to ~1e-4 of peak magnitude) — run through the
+existing `capture_goldens.py`/`capture_eva_goldens.py` fixtures,
+`MOLD_TEST_PULID_ASSETS`-gated, `#[ignore]`d in the ordinary suite exactly as
+they are today.
+
+---
+
+## Summary of what this issue does and does not decide
+
+- **Decides**: hand-port SCRFD + iResNet100 into candle (§1), keep it
+  CPU-resident at today's admission-time call site for milestone 1, add a
+  small in-process per-photo LRU cache of final IDFormer output keyed on
+  photo + pipeline-version + all four asset SHAs (§2), and extend
+  `pulid_face_probe` to measure and gate the EVA/IDFormer half nobody has
+  measured yet (§4).
+- **Designs but defers**: GPU dispatch of the whole extraction stack on the
+  render's leased device, the `ExtractionSlot`-to-`HostMemoryLedger` fold-in
+  it implies, and the `ProgressPhase::IdentityExtract` scheduler phase +
+  schema v21 bump that would give it learned runtime evidence (§3) — gated on
+  §4's extended measurement actually showing GPU dispatch is worth the
+  lease-ordering change, not assumed from the issue title alone.

--- a/docs/architecture/pulid-perf.md
+++ b/docs/architecture/pulid-perf.md
@@ -6,9 +6,14 @@ whether extraction should move off `candle-onnx`/CPU, a cross-request
 identity-embedding cache, EVA-CLIP residency under a GPU path, and the
 benchmark protocol that qualifies whichever of these ships.
 
-This is a **decision record, written before code**, exactly as
-[#1222](https://github.com/utensils/mold/issues/1222)'s Step 0 was. Nothing in
-this document changes Rust — see `docs/architecture/pulid-face-extraction.md`
+This began as a **decision record, written before code**, exactly as
+[#1222](https://github.com/utensils/mold/issues/1222)'s Step 0 was. Phase 1 has
+since shipped, so the sections below now carry what was measured beside what was
+predicted — and in one case (§1's re-materialization hypothesis) the measurement
+**falsified** the prediction. Those corrections are inline and marked
+`MEASURED`, never quietly edited over the original reasoning: a decision record
+that reads as if it had been right all along teaches nobody why it was wrong.
+For what already shipped before this issue, see `docs/architecture/pulid-face-extraction.md`
 (Step 0: the `candle-onnx` runtime decision, the measured budget, the stage
 table), `docs/architecture/pulid.md` (encoder lifecycle, residency, the
 extraction call site), and `docs/architecture/pulid-uat.md` (real-hardware
@@ -70,6 +75,14 @@ claim this issue produces is incomplete until this is measured — §4 makes
 extending the bench harness to cover it the first concrete deliverable of the
 implementation phase, ahead of deciding where to spend GPU/hand-port effort.
 
+> **MEASURED (phase 1).** `pulid_face_probe bench --full` now measures it, and
+> the suspicion was an understatement. On halcyon, one identity extraction is
+> **2,840 ms** (p50) end to end, of which the EVA tower is **2,237 ms — 79%**
+> and the face stack `pulid_face_probe` had been gating on is **360 ms — 13%**.
+> The full table is in §4. Every number below that reasons about SCRFD and
+> ArcFace is reasoning about an eighth of the problem, which is exactly what §0
+> was written to find out and is what §5's phase-2 plan is aimed at.
+
 ---
 
 ## 1. Runtime decision: hand-ported candle vs. a cached ONNX evaluator
@@ -112,6 +125,18 @@ size, not with per-request compute (`eval.rs:191-232`, `:249-257`; the Step-0
 doc: "the second call costs what the thousandth does and there is nothing to
 amortize"). SCRFD's 16,923,827-byte graph pays the same tax at ~1/15th the
 size and shows a correspondingly smaller, though still real, share.
+
+> **MEASURED (phase 1) — this inference was wrong.** "Consistent with" was
+> doing all the work: ArcFace also dominates because it is ~23 GFLOP against
+> SCRFD's ~10, and that, not the memcpy, is why it costs more. Running both
+> evaluators **alternately inside one loop** on byte-identical blobs
+> (`pulid_face_probe bench --compare`, so both see the same contention) puts
+> the resident port at **1.04x** the `candle-onnx` evaluator on the face stack —
+> 371.0 ms to 357.9 ms mean, 376.5 ms to 364.9 ms p95. Re-materializing 278 MB
+> is worth about 3-4%, not the majority of anything: halcyon is an M4 Max, whose
+> memory bandwidth makes a 261 MB copy cheap next to 23 GFLOP of f32
+> convolution at candle's ~110 GFLOP/s. The hypothesis was testable and is now
+> tested; §4 records the consequence for the acceptance criterion.
 
 ### Why B does not answer the question B looks like it answers
 
@@ -167,6 +192,15 @@ side effect of "port the backbone to candle."
 
 ### Recommendation
 
+> **MEASURED (phase 1).** Option A shipped and the port is parity-exact, but
+> read the "buys most of the re-materialization win" clause below as the
+> prediction it was: the win it buys is ~4%, because the tax it removes was
+> ~4%. What survives unqualified is the SECOND half of the argument — "it is a
+> strict prerequisite for a future GPU path either way, because candle-onnx
+> cannot reach a GPU at all" — and that is now the load-bearing reason the port
+> is worth keeping. It also removes a retained 261 MB `ModelProto` per
+> extractor, which the evaluator had to keep alive to re-read on every call.
+
 **Ship option A (hand-ported SCRFD + iResNet100 in candle), but keep it
 CPU-resident at today's call site for milestone 1.** Concretely: replace only
 the internals of `IdentityExtractor` (`identity/mod.rs`,
@@ -203,6 +237,20 @@ out to dominate SCRFD/ArcFace entirely.
 - **Speed**: p95 ≥ 25% faster than the recorded baseline (415.7 ms halcyon,
   1574.5 ms plato, SCRFD+ArcFace only — see §4 for how this is checked
   mechanically rather than by eyeballing a percentage).
+
+> **MEASURED (phase 1): parity PASSES, speed FAILS, and the threshold was not
+> moved.** Parity is exact — SCRFD is bit-identical to `simple_eval` on all
+> nine head tensors across the whole fixture set, ArcFace agrees to 2.62e-6
+> with cosine 1.0, and the unchanged InsightFace golden gate still reports
+> worst landmark 0.232 px and worst cosine 0.999384. Speed does not:
+> face-stack p95 is **370.9 ms against the 415.7 ms baseline, 10.8% faster**,
+> where the criterion asked for 25% (ceiling 311.8 ms). That gap is not a
+> missing optimization in the port, it is the falsified premise in §1's "what
+> the numbers say" — the criterion was sized against a cost that turned out not
+> to exist. `--regress-against halcyon` reports exactly this and exits non-zero,
+> which is what it is for. The port is kept anyway, for the prerequisite
+> argument above; the 25% target moves to §5, restated over the whole
+> extraction, where there is a 79% cost centre to take it out of.
 
 ---
 
@@ -502,19 +550,117 @@ cargo build --release -p mold-ai-inference --features dev-bins,pulid --bin pulid
 ./target/release/pulid_face_probe bench /path/to/pulid-assets-dir
 ```
 
-### Required extension (first implementation-phase deliverable, not this doc)
+### The extension, as it shipped
 
-A second bench mode covering the currently-unmeasured half of §0's finding —
-`pulid_face_probe bench --full` (or a separate `bench-full` subcommand) that
-additionally warm-repeats `extraction::compose_identity_tokens` (EVA tower +
-IDFormer forward, given a fixed aligned 512×512 crop and ArcFace vector so
-the bench isolates encode cost from detection) per image, reusing the exact
-5-warmup/20-run protocol and `validate_bench_args`'s existing refusal/advisory
-logic verbatim. Report a **four-row** stage table (SCRFD / ArcFace / EVA /
-IDFormer / per-image total) rather than today's two-row one. This must land
-and produce real numbers before any claim of "performance qualification" is
-made, because today's gate is silent on what may be the larger half of the
-real cost.
+`pulid_face_probe bench <dir>` gained three flags in phase 1:
+
+| flag | what it adds | why |
+| --- | --- | --- |
+| `--full --adapter <safetensors> --eva <pt>` | four more rows: `eva-build`, `eva-forward`, `idformer-build`, `idformer-fwd`, plus a whole-extraction total | §0's finding. Build and forward are separate rows because they answer different questions: the forward is arithmetic, the build is what the drop-and-reload rule **re-pays on every request** and is therefore what §5 would buy back |
+| `--compare` | re-measures the retained `candle-onnx` oracle, **alternating with the port inside one iteration**, on byte-identical blobs | Two sequential blocks measure whatever else a shared box was doing during each block. Alternating makes both evaluators see the same contention, which is what makes the 1.04x number above trustworthy on a machine that never goes quiet |
+| `--regress-against halcyon\|plato` | checks the face-stack p95 against `BASELINE_*_P95_MS` at `REGRESSION_MARGIN` (0.75) | §1's "25% faster" as a mechanical check with a non-zero exit, not a percentage a reviewer recomputes |
+
+It runs through `extraction::compose_identity_tokens_observed` — the SAME
+implementation the server calls, with a per-stage observer;
+`compose_identity_tokens` delegates to it with a no-op closure, so the benchmark
+cannot drift from production by measuring a copy of it.
+
+Two scoping rules, both load-bearing:
+
+- **The whole-extraction total is reported, never gated.** #1222's
+  `LATENCY_BUDGET_MS` was stated over SCRFD + ArcFace and nothing else, so
+  applying it to a four-stage measurement would fail a gate this build was
+  never subject to. The gate stays on the face stack; the total is printed as
+  the first per-request figure for the whole extraction, and §5 states the
+  budget that *should* cover it.
+- **Every run prints the 1-minute load average at both ends.**
+  `pulid-face-extraction.md`'s own cautionary example is a p95 that tripled
+  under load average 83. A benchmark that does not report this invites the same
+  mistake again.
+
+```bash
+cargo build --release -p mold-ai-inference --features dev-bins,pulid --bin pulid_face_probe
+./target/release/pulid_face_probe bench /path/to/antelopev2 --compare --full \
+  --adapter /path/to/pulid_flux_v0.9.1.safetensors \
+  --eva /path/to/EVA02_CLIP_L_336_psz14_s6B.pt
+```
+
+### MEASURED: one identity extraction on halcyon
+
+Apple M4 Max, 16 cores, 48 GiB, macOS aarch64, release build, the 5-warmup /
+20-run gate protocol, **load average 9.76 at start and 12.22 at end** — the box
+was running peer builds throughout and a quiet window never came, which is why
+the paired `--compare` numbers rather than the absolutes carry the argument.
+Sample spread was nonetheless tight (every stage's min-to-max is under 6%).
+
+| stage | p50 (ms) | p95 (ms) | share of p50 total |
+| --- | ---: | ---: | ---: |
+| `scrfd` — letterbox, blob, detect, decode, NMS | 160.0 | 165.1 | 5.6% |
+| `arcface` — align, blob, embed | 198.7 | 209.4 | 7.0% |
+| **face stack** (what #1222 measured) | **359.7** | **370.9** | **12.7%** |
+| `eva-build` — re-authenticate 609 MB, mmap, widen f16→f32, construct | 1267.9 | 1273.1 | 44.6% |
+| `eva-forward` — 24 blocks, 577 tokens, f32 | 969.2 | 981.6 | 34.1% |
+| `idformer-build` | 46.0 | 47.1 | 1.6% |
+| `idformer-fwd` | 194.2 | 202.4 | 6.8% |
+| **whole extraction** | **2840.4** | **2863.9** | **100%** |
+
+Three things fall out of that table and none of them was predictable from the
+Step-0 numbers:
+
+1. **The EVA tower is 79% of an extraction** (2,237 ms of 2,840 ms). Every
+   optimization argument in §1 was about the 13% the harness happened to be
+   pointed at.
+2. **`eva-build` is the single largest line item in the entire pipeline** —
+   larger than the tower's own forward pass, and nearly four times the whole
+   face stack. It is pure per-request setup: `derived_artifact_is_authentic`
+   re-hashes the 609 MB derived safetensors on every call (deliberately —
+   CLAUDE.md's "reuse is authenticated by the compiled-in `DERIVED_SHA256`,
+   never by the sidecar"), and `VarBuilder::from_mmaped_safetensors(...,
+   DType::F32, ...)` then widens those f16 weights into ~1.2 GB of f32. The
+   drop-and-reload rule pays for both on every conditioned request. Splitting
+   that line further — hash vs. mmap vs. construct — is the first thing §5
+   should measure, because the two halves have completely different fixes.
+3. **The IDFormer's build is nearly free** (46 ms) while its forward is 194 ms,
+   the opposite shape, because its `VarBuilder` is lazily mmap-backed over the
+   adapter file rather than a re-authenticated widening copy.
+
+### MEASURED: the port against the evaluator it replaced
+
+Same run, `--compare`, alternating inside one iteration:
+
+| | `candle-onnx` mean | resident port mean | speedup |
+| --- | ---: | ---: | ---: |
+| SCRFD graph | 163.7 ms | 159.1 ms | 1.03x |
+| ArcFace graph | 207.3 ms | 198.8 ms | 1.04x |
+| both | 371.0 ms | 357.9 ms | 1.04x |
+| both, p95 | 376.5 ms | 364.9 ms | 1.03x |
+
+That is the honest value of the hand port as a speed change, and it is the
+number §1's "what the numbers say" was wrong about. Its real value is
+elsewhere: `candle-onnx` cannot place a tensor anywhere but `Device::Cpu`, so
+without this port §5 is not implementable at all.
+
+The regression pin committed for this is deliberately **relative** —
+`the_resident_port_is_never_slower_than_the_evaluator_it_replaced` in
+`tests/pulid_handport_parity.rs`, asset-gated and `#[ignore]`d, alternating the
+two evaluators exactly as `--compare` does. A millisecond ceiling is a property
+of the machine and its load; a ratio survives both. It is not a hypothetical
+guard: the first version of `arcface_net` computed the fully-connected layer as
+`X @ W^T`, materializing a transpose of the 51 MB weight on **every forward**,
+which made the "faster" port about a tenth slower than `simple_eval` on the
+recognizer. This ratio is what caught it, before it shipped.
+
+### plato: not measured
+
+Deliberately skipped in phase 1 and named rather than quietly omitted. A release
+build of `mold-ai-inference` on plato is well past the time this issue had for
+it, and the conclusion does not turn on it: the falsified claim is about
+*whether re-materialization is the cost centre*, and the four-stage table shows
+the answer is "no, and neither is the face stack" on any host where the EVA
+tower runs the same 300 GFLOP. plato's own 1574.5 ms face-stack baseline stays
+committed in `pulid_face_probe` for whoever runs `--regress-against plato`
+there. A phase-2 measurement should take both hosts, because §5's win is a
+device question and plato has four L40S.
 
 ### Warm-repeat protocol
 
@@ -537,16 +683,21 @@ without re-baselining:
 
 ### Regression test at the measured numbers
 
-Add pinned baseline constants beside `LATENCY_BUDGET_MS` in
-`pulid_face_probe.rs` — `BASELINE_HALCYON_P95_MS: f64 = 415.7`,
-`BASELINE_PLATO_P95_MS: f64 = 1574.5` (the SCRFD+ArcFace numbers this doc
-cites from `pulid-face-extraction.md`; add the EVA/IDFormer baselines once
-the extended bench above produces them) — and a `--regress-against
-<halcyon|plato>` flag that fails (non-zero exit, matching the existing gate's
-convention) when the measured p95 exceeds 0.75× the named baseline, i.e. the
-literal "p95 ≥ 25% faster" acceptance criterion expressed as a mechanically
-checkable ratio against numbers already committed to this repository, rather
-than a comment a reviewer has to recompute by hand.
+Shipped as described: `BASELINE_HALCYON_P95_MS = 415.7`,
+`BASELINE_PLATO_P95_MS = 1574.5`, `REGRESSION_MARGIN = 0.75`, and
+`--regress-against <halcyon|plato>` exiting non-zero when the face-stack p95
+exceeds the ceiling. On halcyon it currently **fails at 370.9 ms against a
+311.8 ms ceiling**, and that is left as-is rather than loosened: the flag is
+reporting a real gap between what §1 predicted and what the port delivers, and
+a threshold edited to match the outcome measures nothing. §5 is where the 25%
+is now expected to come from.
+
+The committed *pass/fail* pin is the relative one described above
+(`the_resident_port_is_never_slower_than_the_evaluator_it_replaced`), because
+it holds on any machine under any load. The absolute baselines stay as
+documentation of where the numbers came from, checked into
+`pulid_face_probe.rs` where the flag that reads them lives, and pinned by
+`the_named_baselines_are_the_ones_the_doc_records`.
 
 ### Device-path parity
 
@@ -559,6 +710,88 @@ absolute, hidden states to ~1e-4 of peak magnitude) — run through the
 existing `capture_goldens.py`/`capture_eva_goldens.py` fixtures,
 `MOLD_TEST_PULID_ASSETS`-gated, `#[ignore]`d in the ordinary suite exactly as
 they are today.
+
+---
+
+## 5. Phase 2 — the plan the phase-1 numbers actually justify
+
+Phase 1 kept extraction exactly where it was: CPU, at admission, before any
+lease. §4 says that is now the expensive decision, not a free one. This section
+is the concrete follow-up, written against the measured table rather than
+against the issue title. It is **not** implemented on the phase-1 branch, for a
+reason worth stating: everything below edits
+`crates/mold-server/src/identity_extraction.rs`, which #1226 is rewriting for
+multi-photo and true-CFG conditioning. Phase 2 rebases onto #1226; landing both
+into that file at once buys nothing and costs a merge.
+
+### What moves, and what deliberately does not
+
+| stage | p50 today | phase 2 |
+| --- | ---: | --- |
+| `eva-build` | 1268 ms | **the first target, and it is not a device question.** Roughly half is `derived_artifact_is_authentic` re-hashing 609 MB and half is widening f16 → f32 into ~1.2 GB. Measure that split first (one more `ComposeStage`); the hash half wants a process-lifetime memo keyed on `(dev, ino, size, mtime)` **plus** a re-verify on any mismatch — never a bare "we checked once" flag, because the whole point of the compiled-in `DERIVED_SHA256` is that the file may change under us — and the widening half wants the tower built at its stored f16/bf16 dtype on a device that has one. |
+| `eva-forward` | 969 ms | **moves to the leased device.** ~300 GFLOP of dense f32 matmul is the canonical GPU workload; candle already runs this tower on any device, and phase 1 is what makes the whole stack device-capable. |
+| `idformer-fwd` | 194 ms | moves with it — same `VarBuilder`, same device, no separate decision. |
+| `scrfd` / `arcface` | 360 ms | move last, or not at all. They are 13% of the extraction and their kernels are small; taking them along is nearly free once the device exists, but they do not justify the lease-ordering change on their own. That was §1's mistake and phase 2 must not repeat it. |
+| `idformer-build` | 46 ms | leave alone. |
+
+### Where it runs, and the ordering that makes it legal
+
+Extraction moves from `variant_dependencies::prepare_inputs_for_devices`
+(pre-lease) to **inside the leased job, first, before prompt encode** — the
+`ProgressPhase::IdentityExtract` arm §3 designs, with the
+`EstimatePhaseTimings` / `EstimateBucket` fields and the schema bump §3
+enumerates. Only the sibling that actually performs the once-per-parent
+extraction records a sample; every other sibling's `identity_extract_ms` stays
+`None`, exactly as `cold_load_ms` already does on a warm reuse.
+
+`ExtractionSlot`'s bespoke semaphore-plus-`ram_snapshot()` gate is **retired**,
+not run in parallel with the ledger. Its module doc's own justification —
+"extraction happens strictly BEFORE this job has a lease" — stops being true the
+moment this lands, and two admission-time memory gates that can disagree is
+worse than one.
+
+### The drop-before-adapter rule
+
+Non-negotiable, and the reason this is a phase and not a residency change: the
+tower and the IDFormer are **built, forwarded, and fully released** before
+`flux::identity::EngineIdentityState` begins the adapter's ordinary residency
+for that dispatch. The extraction is a strictly earlier, strictly disjoint
+phase of the same lease — never a third permanent resident alongside the
+~1.14 GB adapter and the transformer's own peak. Phase 1's measurement makes
+this concrete: the tower is ~609 MB at rest and ~1.2 GB widened, which is not
+memory a conditioned FLUX render has spare.
+
+### CUDA versus Metal are different problems
+
+- **CUDA**: a discrete VRAM budget. The tower's transient peak is charged
+  against the frozen plan's grant and released before the adapter loads. This
+  is the ordinary case and the ledger discipline already exists for it.
+- **Metal**: unified memory, so "moving to the device" does not move bytes off
+  the host, and mold's existing rule is that Metal reserves no host RAM
+  separately — its host claim rides the unified device gate. Phase 2 must
+  therefore charge the tower ONCE on Apple Silicon, through that gate, not
+  once to the host ledger and once to the device. It is also the host where
+  phase 1 measured everything, so a Metal `eva-forward` number is the direct
+  before/after: 969 ms on the CPU of the same machine.
+
+### Acceptance
+
+Stated over the **whole extraction**, which is what §4 showed the previous
+criterion should have been stated over all along.
+
+- **Speed**: whole-extraction p95 at least **25% under 2,863.9 ms**, i.e.
+  **≤ 2,147.9 ms** on halcyon under `pulid_face_probe bench --full` at the
+  5-warmup / 20-run protocol, with the load average reported. Add
+  `BASELINE_HALCYON_FULL_P95_MS` beside the existing constants and a
+  `--regress-against-full` that reads it, so the check stays mechanical. Take
+  plato too — it has four L40S and phase 2 is a device change, so skipping it
+  a second time would leave the interesting host unmeasured.
+- **Parity**: unchanged tolerances, and one addition — the device path must
+  produce a `FrozenIdentityEmbedding` byte-identical to the CPU path's for the
+  same photo and assets, or the fingerprint stops identifying an identity and
+  every cache and provenance claim built on it breaks.
+- **Ordering**: a test proving the tower is released before the adapter is
+  resident, not merely that both fit.
 
 ---
 
@@ -576,3 +809,19 @@ they are today.
   schema v21 bump that would give it learned runtime evidence (§3) — gated on
   §4's extended measurement actually showing GPU dispatch is worth the
   lease-ordering change, not assumed from the issue title alone.
+
+### What phase 1 actually shipped, and what it changed about the above
+
+- **Shipped**: the §1 hand port (parity-exact) and the §4 harness, with the
+  measurements in §4 and §5's plan derived from them.
+- **Not shipped, deliberately**: §2's embedding cache. It lives in
+  `mold-server/src/identity_extraction.rs`, which
+  [#1226](https://github.com/utensils/mold/issues/1226) is rewriting for
+  multi-photo and true-CFG conditioning; landing a cache into that file
+  concurrently would conflict for no benefit, and §2's own design already
+  depends on #1226's post-IDFormer averaging. It rebases on top.
+- **Changed**: §3's gating condition is satisfied, from the other direction
+  than expected. §4 was supposed to decide "is GPU dispatch worth the
+  lease-ordering change"; the answer is yes, but the case rests on the EVA
+  tower rather than on SCRFD/ArcFace, and half of the tower's cost is setup
+  rather than arithmetic. §5 restates the phase accordingly.

--- a/docs/architecture/pulid.md
+++ b/docs/architecture/pulid.md
@@ -358,13 +358,17 @@ That position is chosen, not incidental.
   `batch_runtime::submit_child` clones into every `BatchChildExecution`. Storing
   the embedding there makes "one extraction, every sibling" structural rather
   than a convention somebody has to keep.
-- **On the CPU**, because `candle-onnx` materializes every initializer on
-  `Device::Cpu` and refuses anything else — and because at admission the
-  scheduler has not leased a device yet, so there is no GPU to run it on. That
-  constraint turns into the guarantee the issue asked for: extraction's ~1.4 GB
-  peak is allocated and released before the job is dispatched, so it *cannot*
-  overlap the T5/CLIP encode peak. No scheduled slot and no new typed
-  learned-scheduling phase was needed, because the two peaks cannot coexist.
+- **On the CPU**, because at admission the scheduler has not leased a device
+  yet, so there is no GPU to run it on. (Until #1227 there was a second reason:
+  `candle-onnx` materializes every initializer on `Device::Cpu` and refuses
+  anything else. The two face networks are now resident `candle` modules that
+  take a device — `identity::scrfd_net`, `identity::arcface_net` — so only the
+  admission-ordering reason remains, and `docs/architecture/pulid-perf.md` §3
+  designs the phase that would lift it.) That constraint turns into the
+  guarantee the issue asked for: extraction's ~1.4 GB peak is allocated and
+  released before the job is dispatched, so it *cannot* overlap the T5/CLIP
+  encode peak. No scheduled slot and no new typed learned-scheduling phase was
+  needed, because the two peaks cannot coexist.
 
 ### The frozen value
 


### PR DESCRIPTION
Phase 1 of #1227. Records the implementation decision before code (`docs/architecture/pulid-perf.md`), then delivers it honestly.

## What changed
- **SCRFD-10G and iResNet100 (`glintr100`) are resident candle modules** (`identity/scrfd_net.rs`, `identity/arcface_net.rs`). `identity/onnx_weights.rs` reads the two SHA-pinned ONNX files once through the same authenticated bounded read, consuming parameters in graph order with a per-op shape assertion; `candle_onnx::simple_eval` survives only as the parity oracle (`reference_forward`). Parity is exact: SCRFD bit-identical on all nine head tensors, ArcFace max |Δ| 2.6e-6 / cosine 1.0, InsightFace golden gate unchanged (worst landmark 0.232 px, cosine 0.9994). `tests/pulid_handport_parity.rs` pins it.
- **`pulid_face_probe bench` gained `--full`, `--compare`, `--regress-against`** plus a per-stage observer in `extraction.rs`, giving the whole extraction its first measurement.

## What was measured (halcyon, release, 5 warmups / 20 runs)
Whole extraction 2,840 ms p50 / 2,864 ms p95: face stack 360 ms (13%), **EVA02-CLIP tower 2,237 ms (79%)** — of which `eva-build` (re-authenticating the 609 MB derived tower + f16→f32 widening, paid per request by drop-and-reload) is 1,268 ms — IDFormer 240 ms.

**The decision record's premise is falsified and recorded as such:** the candle-onnx per-call re-materialization was worth ~4%, not 25%. Face-stack p95 is 370.9 ms vs the 415.7 ms baseline (10.8%); the 25% criterion is NOT met by this phase, the threshold is untouched, and `--regress-against halcyon` reports the gap and exits non-zero. plato was skipped (release build budget) and says so.

## What follows (§5 of the doc, after #1226 merges)
Split `eva-build` (digest memoization vs widening), post-lease GPU dispatch of EVA + IDFormer with a typed `IdentityExtract` phase, and the per-photo embedding cache — acceptance: whole-extraction p95 ≤ 2,148 ms on halcyon (25% under this phase's full-stack baseline).

Docs: `pulid-perf.md` (§0/§1 measured corrections beside the original reasoning, §4 numbers, §5 plan), supersession note in `pulid-face-extraction.md`, a paragraph in `pulid.md`; CLAUDE.md deltas staged in `docs/architecture/pulid-1227-docs.md` for the consolidation PR. `changelog.d/pulid-perf.md` added.

Gate: fmt, `clippy --workspace --all-targets -D warnings`, `clippy -p mold-ai-inference --features dev-bins,pulid`, `check -p mold-ai --features preview,discord,expand,tui,webp,mp4`, weight-gated PuLID suites 14/14 + 6/6 — all clean. Codex review running.