### PR TITLE
fix(mobile): add Select to iOS image menu

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -195,8 +195,9 @@ pushed screen opened from the header.
   as a new draft (raising any clip duration the selected model's motion tail no
   longer allows, and saying so); iPhone is reuse-only — **Edit sequence** stays
   a desktop/web action until mobile has a chain-detail recovery route.
-  Generated stills open the same viewer on tap. Press and hold an image to keep
-  the native iOS Share, Save to Photos, Copy, Copy Subject, and Look Up menu.
+  Generated stills open the same viewer on tap. Press and hold a Library image
+  to keep the native iOS Share, Save to Photos, Copy, Copy Subject, and Look Up
+  menu, plus **Select** to enter multi-select with that print selected.
   Pinch the grid to resize thumbnails between two and five across — the iPhone
   counterpart to the web/desktop thumbnail-size slider. The choice persists at
   `mold.mobile.galleryColumns.v1`, separately from the shared pixel-target key

--- a/apps/mobile/src-tauri/Cargo.lock
+++ b/apps/mobile/src-tauri/Cargo.lock
@@ -1813,6 +1813,7 @@ version = "0.23.3"
 dependencies = [
  "base64 0.22.1",
  "block2",
+ "dispatch2",
  "libc",
  "objc2",
  "objc2-foundation",

--- a/apps/mobile/src-tauri/Cargo.toml
+++ b/apps/mobile/src-tauri/Cargo.toml
@@ -32,10 +32,11 @@ security-framework-sys = "2"
 
 [target.'cfg(target_os = "ios")'.dependencies]
 block2 = "0.6"
+dispatch2 = "0.3"
 objc2 = "0.6"
-objc2-foundation = { version = "0.3.2", default-features = false, features = ["NSData", "NSError", "NSString", "NSURL"] }
+objc2-foundation = { version = "0.3.2", default-features = false, features = ["NSArray", "NSData", "NSError", "NSString", "NSURL"] }
 objc2-photos = { version = "0.3.2", default-features = false, features = ["PHAssetChangeRequest", "PHChangeRequest", "PHPhotoLibrary", "block2", "dispatch2"] }
-objc2-ui-kit = { version = "0.3.2", default-features = false, features = ["UIActivity", "UIActivityViewController", "UIInterface", "UIImage", "UIPasteboard", "UIPopoverPresentationController", "UIPresentationController", "UIResponder", "UIScrollView", "UIView", "UIViewController", "objc2-core-foundation"] }
+objc2-ui-kit = { version = "0.3.2", default-features = false, features = ["UIAction", "UIActivity", "UIActivityViewController", "UIInterface", "UIImage", "UIMenu", "UIMenuElement", "UIPasteboard", "UIPopoverPresentationController", "UIPresentationController", "UIResponder", "UIScrollView", "UIView", "UIViewController", "block2", "objc2-core-foundation"] }
 reqwest = { version = "0.13", default-features = false, features = ["rustls-no-provider"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 

--- a/apps/mobile/src-tauri/src/context_menu.rs
+++ b/apps/mobile/src-tauri/src/context_menu.rs
@@ -1,0 +1,144 @@
+//! Extend WKWebView's already-presented image menu through UIKit's public
+//! `UIContextMenuInteraction` API.
+//!
+//! WebKit does not route image-element menus through the public WKUIDelegate
+//! context-menu callback. The frontend therefore tells the shell when its
+//! gallery image received `contextmenu`; the shell updates the visible UIKit
+//! menu without replacing WebKit's Share, Save, Copy, or system actions.
+
+#[cfg(target_os = "ios")]
+use std::{ptr::NonNull, time::Duration};
+
+#[cfg(target_os = "ios")]
+use block2::RcBlock;
+#[cfg(target_os = "ios")]
+use dispatch2::{DispatchQueue, DispatchTime};
+#[cfg(target_os = "ios")]
+use objc2::{rc::Retained, runtime::AnyObject, sel};
+#[cfg(target_os = "ios")]
+use objc2_foundation::{NSArray, NSString};
+#[cfg(target_os = "ios")]
+use objc2_ui_kit::{UIAction, UIImage, UIMenu};
+
+#[cfg(target_os = "ios")]
+const SELECT_GALLERY_PRINT_SCRIPT: &str =
+    "window.dispatchEvent(new CustomEvent('mold:native-gallery-select'))";
+
+#[cfg(target_os = "ios")]
+fn evaluate(webview: NonNull<AnyObject>, script: &str) {
+    let script = NSString::from_str(script);
+    // SAFETY: The pointer is the app-owned WKWebView and every caller runs on
+    // the main queue while the window remains alive.
+    unsafe {
+        let _: () = objc2::msg_send![
+            webview.as_ref(),
+            evaluateJavaScript: &*script,
+            completionHandler: core::ptr::null::<core::ffi::c_void>()
+        ];
+    }
+}
+
+#[cfg(target_os = "ios")]
+fn append_select(menu: NonNull<UIMenu>, webview: NonNull<AnyObject>) -> NonNull<UIMenu> {
+    // SAFETY: UIKit owns the visible menu for the duration of this block.
+    let menu = unsafe { menu.as_ref() };
+    let children = menu.children();
+    let select_title = NSString::from_str("Select");
+    for index in 0..children.count() {
+        if children.objectAtIndex(index).title() == select_title {
+            return NonNull::from(menu);
+        }
+    }
+
+    let select_handler = RcBlock::new(move |_action: NonNull<UIAction>| {
+        evaluate(webview, SELECT_GALLERY_PRINT_SCRIPT);
+    });
+    let symbol = UIImage::systemImageNamed(&NSString::from_str("checkmark.circle"));
+    // SAFETY: UIKit copies the handler block into the UIAction.
+    let action = unsafe {
+        UIAction::actionWithTitle_image_identifier_handler(
+            &select_title,
+            symbol.as_deref(),
+            None,
+            RcBlock::as_ptr(&select_handler),
+            objc2::MainThreadMarker::new_unchecked(),
+        )
+    };
+    let children = children.arrayByAddingObject(&action.into_super());
+    let updated = menu.menuByReplacingChildren(&children);
+    // UIKit expects an autoreleased menu from the update block.
+    NonNull::new(Retained::autorelease_return(updated)).expect("UIKit returned a null menu")
+}
+
+#[cfg(target_os = "ios")]
+fn update_context_menu_interactions(view: NonNull<AnyObject>, webview: NonNull<AnyObject>) {
+    // SAFETY: `view` belongs to the live WKWebView hierarchy. `interactions`
+    // and `subviews` are public UIView properties, and this function only runs
+    // on UIKit's main queue.
+    unsafe {
+        let interactions: Retained<NSArray<AnyObject>> =
+            objc2::msg_send![view.as_ref(), interactions];
+        for index in 0..interactions.count() {
+            let interaction = interactions.objectAtIndex(index);
+            let supports_update: bool = objc2::msg_send![
+                &*interaction,
+                respondsToSelector: sel!(updateVisibleMenuWithBlock:)
+            ];
+            if supports_update {
+                let update = RcBlock::new(move |menu: NonNull<UIMenu>| -> NonNull<UIMenu> {
+                    append_select(menu, webview)
+                });
+                let _: () = objc2::msg_send![
+                    &*interaction,
+                    updateVisibleMenuWithBlock: &*update
+                ];
+            }
+        }
+
+        let subviews: Retained<NSArray<AnyObject>> = objc2::msg_send![view.as_ref(), subviews];
+        for index in 0..subviews.count() {
+            update_context_menu_interactions(
+                NonNull::from(&*subviews.objectAtIndex(index)),
+                webview,
+            );
+        }
+    }
+}
+
+#[cfg(target_os = "ios")]
+fn update_now_and_after_presentation(webview: NonNull<AnyObject>) {
+    update_context_menu_interactions(webview, webview);
+
+    // The DOM `contextmenu` notification can race UIKit's presentation by a
+    // run-loop turn. Retry briefly; duplicate insertion is prevented above.
+    for delay in [80, 240] {
+        let address = webview.as_ptr() as usize;
+        let when = DispatchTime::try_from(Duration::from_millis(delay))
+            .expect("context-menu retry delay must fit dispatch time");
+        DispatchQueue::main()
+            .after(when, move || {
+                // SAFETY: The WKWebView is app-owned for the window lifetime,
+                // and this closure executes on the main queue.
+                let webview = unsafe { NonNull::new_unchecked(address as *mut AnyObject) };
+                update_context_menu_interactions(webview, webview);
+            })
+            .expect("main dispatch queue must accept context-menu update");
+    }
+}
+
+#[tauri::command]
+pub fn extend_gallery_context_menu(window: tauri::WebviewWindow) -> Result<(), String> {
+    #[cfg(target_os = "ios")]
+    window
+        .with_webview(|webview| {
+            let webview = NonNull::new(webview.inner().cast::<AnyObject>())
+                .expect("Tauri supplied a null WKWebView");
+            update_now_and_after_presentation(webview);
+        })
+        .map_err(|error| format!("failed to extend iOS gallery context menu: {error}"))?;
+
+    #[cfg(not(target_os = "ios"))]
+    let _ = window;
+
+    Ok(())
+}

--- a/apps/mobile/src-tauri/src/lib.rs
+++ b/apps/mobile/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@
 //! Mold servers.
 
 mod appearance;
+mod context_menu;
 mod discovery;
 mod identity;
 mod keychain;
@@ -46,6 +47,7 @@ pub fn run() {
         })
         .invoke_handler(tauri::generate_handler![
             appearance::set_mobile_appearance,
+            context_menu::extend_gallery_context_menu,
             discovery::discover_mold_hosts,
             keychain::keychain_set_api_key,
             keychain::keychain_get_api_key,

--- a/changelog.d/ios-library-long-press-select.md
+++ b/changelog.d/ios-library-long-press-select.md
@@ -1,0 +1,3 @@
+- **Select prints from the iPhone long-press menu.** Press and hold a Library
+  image and choose **Select** to enter multi-select with that print already
+  selected, while retaining the native Share, Save, Copy, and system actions.

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -6682,7 +6682,8 @@ describe("MobileApp gallery", () => {
     expect(wrapper.text()).not.toContain("host unavailable");
   });
 
-  it("keeps the native image context menu and enters multi-select from Select", async () => {
+  it("keeps the native image context menu and enters multi-select from its native Select action", async () => {
+    isNativeIOSRuntime.mockReturnValue(true);
     wrapper = mountMobileApp();
     await flushPromises();
     await wrapper.get("[data-test='mobile-tab-gallery']").trigger("click");
@@ -6692,9 +6693,10 @@ describe("MobileApp gallery", () => {
     wrapper.get("[data-test='gallery-item'] img").element.dispatchEvent(contextMenu);
     expect(contextMenu.defaultPrevented).toBe(false);
     expect(wrapper.find("[data-test='mobile-gallery-actions']").exists()).toBe(false);
+    expect(invoke).toHaveBeenCalledWith("extend_gallery_context_menu");
 
-    await wrapper.get("[data-test='mobile-gallery-select']").trigger("click");
-    await wrapper.get("[data-test='gallery-item']").trigger("click");
+    window.dispatchEvent(new CustomEvent("mold:native-gallery-select"));
+    await flushPromises();
     expect(wrapper.get("[data-test='mobile-gallery-actions']").text()).toContain("1 selected");
     expect(wrapper.get("[data-test='gallery-item']").attributes("aria-pressed")).toBe("true");
     expect(wrapper.get("[data-test='mobile-gallery-selection-indicator']").text()).toBe("✓");

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -793,6 +793,7 @@ const galleryRemaining = ref(0);
 const gallerySentinel = ref<HTMLElement | null>(null);
 const gallerySentinelVisible = ref(false);
 const gallerySelectMode = ref(false);
+let nativeGalleryContextKey: string | null = null;
 const gallerySelection = ref<Set<string>>(new Set());
 const galleryDeleteConfirming = ref(false);
 /** Library thumbnail size, driven by the pinch gesture below. */
@@ -7293,6 +7294,26 @@ function toggleGallerySelection(print: GalleryPrint): void {
   galleryDeleteConfirming.value = false;
 }
 
+function rememberNativeGalleryContext(print: GalleryPrint): void {
+  nativeGalleryContextKey = galleryPrintKey(print);
+  if (isNativeIOSRuntime()) {
+    void invoke("extend_gallery_context_menu").catch(() => undefined);
+  }
+}
+
+function selectNativeGalleryContextPrint(): void {
+  const key = nativeGalleryContextKey;
+  nativeGalleryContextKey = null;
+  if (!key) return;
+  const print = gallery.value.find((candidate) => galleryPrintKey(candidate) === key);
+  if (!print) return;
+  setGallerySelectMode(true);
+  const next = new Set(gallerySelection.value);
+  next.add(key);
+  gallerySelection.value = next;
+  galleryDeleteConfirming.value = false;
+}
+
 function applyGalleryDragSelection(print: GalleryPrint): void {
   const key = galleryPrintKey(print);
   if (galleryDragVisited.has(key)) return;
@@ -7908,6 +7929,7 @@ onMounted(async () => {
   window.addEventListener("pointermove", moveGallerySelectionDrag, { passive: false });
   window.addEventListener("pointerup", finishGallerySelectionDrag);
   window.addEventListener("pointercancel", finishGallerySelectionDrag);
+  window.addEventListener("mold:native-gallery-select", selectNativeGalleryContextPrint);
   // The pinch tracks globally so a finger that slides off the grid mid-gesture
   // still reports, and so a lift outside the grid always ends it.
   window.addEventListener("pointermove", moveGalleryPinch, { passive: false });
@@ -7987,6 +8009,8 @@ onBeforeUnmount(() => {
   window.removeEventListener("pointermove", moveGallerySelectionDrag);
   window.removeEventListener("pointerup", finishGallerySelectionDrag);
   window.removeEventListener("pointercancel", finishGallerySelectionDrag);
+  window.removeEventListener("mold:native-gallery-select", selectNativeGalleryContextPrint);
+  nativeGalleryContextKey = null;
   finishGallerySelectionDrag();
   window.removeEventListener("pointermove", moveGalleryPinch);
   window.removeEventListener("pointerup", endGalleryPinch);
@@ -9269,6 +9293,7 @@ onBeforeUnmount(() => {
                   :src="print.thumbnailUrl"
                   :alt="print.metadata.prompt || print.filename"
                   loading="lazy"
+                  @contextmenu="rememberNativeGalleryContext(print)"
                 />
                 <span
                   v-if="isVideoItem(print) || isAudioItem(print)"


### PR DESCRIPTION
## Summary
- preserve the native iOS image context menu and append a Select action
- enter Library multi-select with the long-pressed print already selected
- cover the native bridge flow and document the interaction

## Validation
- `nix develop -c ./scripts/ios.sh check`
- `nix develop -c ./scripts/ios.sh simulator`
- `nix develop -c cargo clippy --manifest-path apps/mobile/src-tauri/Cargo.toml --target aarch64-apple-ios-sim -- -D warnings`
- focused MobileApp context-menu test
- iOS release asset contract
- agent peer review: no blocking findings

## Note
- no Simulator was booted, so the signed Simulator bundle was built but the visible native menu was not interactively exercised in this worktree.