### PR TITLE
fix(ui): move batch into general settings

### DIFF
--- a/changelog.d/batch-general-settings.md
+++ b/changelog.d/batch-general-settings.md
@@ -1,0 +1,1 @@
+- **Batch in general settings.** Batch controls now live in the main Create form on mobile, and each surface's primary Reset returns Batch to one without letting Advanced Reset change it.

--- a/desktop/src/components/create/InspectorPanel.test.ts
+++ b/desktop/src/components/create/InspectorPanel.test.ts
@@ -628,7 +628,7 @@ describe("InspectorPanel — reset to model defaults", () => {
     expect(reset.attributes("aria-label")).toBe("Reset settings to model defaults");
   });
 
-  it("restores the model's defaults while preserving prompt, model, and batch", async () => {
+  it("restores the model's defaults while preserving prompt/model and resetting Batch", async () => {
     useModelStore().all = [model];
     const form = useGenerateFormStore().form;
     form.model = model.name;
@@ -644,7 +644,7 @@ describe("InspectorPanel — reset to model defaults", () => {
 
     expect(form.prompt).toBe("a lighthouse at dusk");
     expect(form.model).toBe("sdxl:base");
-    expect(form.batchSize).toBe(4);
+    expect(form.batchSize).toBe(1);
     expect(form.negativePrompt).toBe("");
     expect(form.seed).toBe("");
     expect(form.steps).toBe(30);

--- a/desktop/src/components/create/InspectorPanel.vue
+++ b/desktop/src/components/create/InspectorPanel.vue
@@ -568,8 +568,9 @@ function setFileUnder(next: FileUnderState) {
   props.form.fileUnder = next;
 }
 
-// Same contract as the Advanced pane's Reset, surfaced without opening it:
-// the prompt, the model, and any prepared batch size survive.
+// The primary Reset restores every general setting, including Batch. Prompt,
+// model, and retained prepared work survive; changing Batch makes that work
+// explicitly stale instead of silently discarding it.
 function resetSettings() {
   resetFormToModelDefaults(props.form, selectedModel.value);
   // The canvas is part of what Reset restores, so its authority resets with

--- a/desktop/src/lib/generateForm.test.ts
+++ b/desktop/src/lib/generateForm.test.ts
@@ -2352,14 +2352,14 @@ describe("resetFormToModelDefaults", () => {
     return form;
   }
 
-  it("preserves the prompt, its expand provenance, the model, and the prepared batch size", () => {
+  it("preserves authored prompt/model state and resets Batch to one", () => {
     const form = dirtyForm();
     resetFormToModelDefaults(form, sdxl);
     expect(form.prompt).toBe("a lighthouse at dusk");
     expect(form.originalPrompt).toBe("a lighthouse");
     expect(form.model).toBe("sdxl:base");
     expect(form.family).toBe("sdxl");
-    expect(form.batchSize).toBe(4);
+    expect(form.batchSize).toBe(1);
   });
 
   it("restores every other field to its default", () => {
@@ -2394,7 +2394,7 @@ describe("resetFormToModelDefaults", () => {
     expect(form.model).toBe("sdxl:base");
     expect(form.family).toBe("sdxl");
     expect(form.prompt).toBe("a lighthouse at dusk");
-    expect(form.batchSize).toBe(4);
+    expect(form.batchSize).toBe(1);
     expect(form.steps).toBe(defaults.steps);
     expect(form.negativePrompt).toBe("");
   });
@@ -2489,6 +2489,7 @@ describe("resetAdvancedToModelDefaults", () => {
 
   it("still resets the genuinely advanced fields and keeps the prompt", () => {
     const form = mediaDirtyForm();
+    form.batchSize = 4;
     resetAdvancedToModelDefaults(form, ltx2);
     expect(form.prompt).toBe("a river at dawn");
     expect(form.negativePrompt).toBe("");
@@ -2500,6 +2501,7 @@ describe("resetAdvancedToModelDefaults", () => {
     expect(form.cameraControl).toBeNull();
     expect(form.width).toBe(1280);
     expect(form.height).toBe(704);
+    expect(form.batchSize).toBe(4);
   });
 
   it("keeps media even when no model entry is available", () => {

--- a/desktop/src/lib/generateForm.ts
+++ b/desktop/src/lib/generateForm.ts
@@ -759,10 +759,11 @@ export function keepingPrintIdentity(form: GenerateForm, rewrite: () => void): v
 
 /**
  * Restore every generation knob to the selected model's defaults. The prompt
- * (with its expand provenance), the model/family, and the batch size survive:
- * the prompt is the user's authored work, and prepared batch siblings must
- * never be silently resized by an unrelated control. The print's name and
- * filing survive too — see {@link keepingPrintIdentity}.
+ * (with its expand provenance) and the model/family survive. Batch is a
+ * general generation setting, so the primary Reset restores it to one. Any
+ * prepared siblings remain retained and become explicitly stale rather than
+ * being silently discarded. The print's name and filing survive too — see
+ * {@link keepingPrintIdentity}.
  *
  * With no `ModelEntry` — an uninstalled or not-yet-resolved model — the named
  * model and family are kept and the form falls back to `newGenerateForm()`
@@ -772,7 +773,7 @@ export function resetFormToModelDefaults(
   form: GenerateForm,
   m: ModelEntry | null | undefined,
 ): void {
-  const { prompt, originalPrompt, batchSize, model, family } = form;
+  const { prompt, originalPrompt, model, family } = form;
   keepingPrintIdentity(form, () => Object.assign(form, newGenerateForm()));
   if (m) {
     applyModelDefaults(form, m);
@@ -782,9 +783,7 @@ export function resetFormToModelDefaults(
   }
   form.prompt = prompt;
   form.originalPrompt = originalPrompt;
-  form.batchSize = generationCapabilitiesForFamily(form.family, form.model).forcesBatchSizeOne
-    ? 1
-    : batchSize;
+  form.batchSize = 1;
 }
 
 /**
@@ -798,6 +797,7 @@ export function resetAdvancedToModelDefaults(
   form: GenerateForm,
   m: ModelEntry | null | undefined,
 ): void {
+  const batchSize = form.batchSize;
   const media = {
     strength: form.strength,
     sourceImage: form.sourceImage,
@@ -827,6 +827,9 @@ export function resetAdvancedToModelDefaults(
     h3Authoring: form.h3Authoring,
   };
   resetFormToModelDefaults(form, m);
+  form.batchSize = generationCapabilitiesForFamily(form.family, form.model).forcesBatchSizeOne
+    ? 1
+    : batchSize;
   Object.assign(form, media);
 }
 

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -5903,6 +5903,13 @@ describe("MobileApp create settings reset", () => {
     await fieldControl("Prompt").setValue("a ship crossing violet lightning");
     await fieldControl("Negative prompt").setValue("calm water");
     await fieldControl("Steps").setValue("12");
+    await wrapper.get("[data-test='mobile-batch-increment']").trigger("click");
+    expect(wrapper.get("[data-test='mobile-batch-value']").attributes("value")).toBe("2");
+    expect(
+      wrapper
+        .get("[data-test='mobile-batch-control']")
+        .element.closest("[data-test='mobile-advanced-sheet']"),
+    ).toBeNull();
     await wrapper.get("[data-test='mobile-settings-reset']").trigger("click");
     await flushPromises();
 
@@ -5912,12 +5919,18 @@ describe("MobileApp create settings reset", () => {
     expect((fieldControl("Negative prompt").element as HTMLInputElement).value).toBe("");
     // The selected model's defaults, not the bare form defaults.
     expect((fieldControl("Steps").element as HTMLInputElement).value).toBe("30");
+    expect(wrapper.get("[data-test='mobile-batch-value']").attributes("value")).toBe("1");
     expect(wrapper.get("[data-test='mobile-settings-reset']").attributes("aria-label")).toBe(
       "Reset settings to model defaults",
     );
     expect(wrapper.get("[data-test='mobile-settings-reset']").element.parentElement).toBe(
       wrapper.get(".mobile-create-head").element,
     );
+
+    await wrapper.get("[data-test='mobile-batch-increment']").trigger("click");
+    await wrapper.get("[data-test='mobile-open-advanced']").trigger("click");
+    await wrapper.get("[data-test='mobile-advanced-reset']").trigger("click");
+    expect(wrapper.get("[data-test='mobile-batch-value']").attributes("value")).toBe("2");
 
     const draft = useSequenceDraftStore();
     draft.output = "sequence";

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -357,6 +357,7 @@ import {
   tracksPointer,
 } from "./galleryZoom";
 import MobileAdvancedSheet from "./MobileAdvancedSheet.vue";
+import MobileBatchControl from "./MobileBatchControl.vue";
 import MobileCatalogView from "./MobileCatalogView.vue";
 import MobileExpansionPullStatus from "./MobileExpansionPullStatus.vue";
 import MobileFileUnder from "./MobileFileUnder.vue";
@@ -692,8 +693,9 @@ function closeAdvancedSheet(): void {
 }
 
 /** Restore every generation knob to the selected model's defaults, keeping the
- * prompt, the model, and any prepared batch size. Same contract as the desktop
- * inspector's Reset — the sheet's scoped reset below is deliberately narrower. */
+ * prompt and model while returning the general Batch control to one. Same
+ * contract as the desktop inspector's Reset — the sheet's scoped reset below
+ * is deliberately narrower. */
 /**
  * Run a wholesale form reset while keeping the print's own identity.
  *
@@ -8698,6 +8700,8 @@ onBeforeUnmount(() => {
               @seed-validity="seedValid = $event"
               @canvas-intent="setCanvasIntent"
             />
+
+            <MobileBatchControl :form="form" :selected-model="selectedGenerationModel" />
 
             <label
               v-if="caps.supportsAudio && !isMinimaxH3Identity(form.family, form.model)"

--- a/desktop/src/mobile/MobileBatchControl.test.ts
+++ b/desktop/src/mobile/MobileBatchControl.test.ts
@@ -1,0 +1,54 @@
+import { flushPromises, mount } from "@vue/test-utils";
+import { reactive } from "vue";
+import { describe, expect, it } from "vitest";
+import { newGenerateForm, type GenerateForm } from "../lib/generateForm";
+import type { ModelEntry } from "../lib/api/types";
+import MobileBatchControl from "./MobileBatchControl.vue";
+
+function mountControl(form: GenerateForm, selectedModel: ModelEntry | null = null) {
+  return mount(MobileBatchControl, {
+    props: { form: reactive(form), selectedModel },
+  });
+}
+
+describe("MobileBatchControl", () => {
+  it("owns the general-form batch stepper and accepts direct values", async () => {
+    const form = newGenerateForm();
+    form.family = "flux";
+    form.model = "flux-dev:fp8";
+    const wrapper = mountControl(form);
+
+    await wrapper.get("[data-test='mobile-batch-increment']").trigger("click");
+    expect(form.batchSize).toBe(2);
+
+    await wrapper.get("[data-test='mobile-batch-value']").setValue("300");
+    await wrapper.get("[data-test='mobile-batch-value']").trigger("change");
+    expect(form.batchSize).toBe(300);
+
+    await wrapper.get("[data-test='mobile-batch-decrement']").trigger("click");
+    expect(form.batchSize).toBe(299);
+
+    await wrapper.get("[data-test='mobile-batch-value']").setValue("999999999999");
+    await wrapper.get("[data-test='mobile-batch-value']").trigger("change");
+    expect(form.batchSize).toBe(10_000);
+    expect(
+      wrapper.get("[data-test='mobile-batch-increment']").attributes("disabled"),
+    ).toBeDefined();
+  });
+
+  it("locks edit models to one", async () => {
+    const form = newGenerateForm();
+    form.family = "qwen-image-edit";
+    form.model = "qwen-image-edit:q4";
+    form.batchSize = 4;
+    const wrapper = mountControl(form, {
+      name: form.model,
+      family: form.family,
+    } as ModelEntry);
+    await flushPromises();
+
+    expect(form.batchSize).toBe(1);
+    expect(wrapper.get("[data-test='mobile-batch-value']").attributes("disabled")).toBeDefined();
+    expect(wrapper.get("[data-test='mobile-batch-locked']").text()).toContain("one at a time");
+  });
+});

--- a/desktop/src/mobile/MobileBatchControl.vue
+++ b/desktop/src/mobile/MobileBatchControl.vue
@@ -1,0 +1,101 @@
+<script setup lang="ts">
+import { computed, watch } from "vue";
+import { effectiveGenerationRecipe } from "@studio/lib/generationProfile";
+import { generationCapabilitiesForFamily } from "../lib/capabilities";
+import type { ModelEntry } from "../lib/api/types";
+import type { GenerateForm } from "../lib/generateForm";
+
+const props = withDefaults(
+  defineProps<{
+    form: GenerateForm;
+    selectedModel?: ModelEntry | null;
+  }>(),
+  { selectedModel: null },
+);
+
+const MAX_BATCH_SIZE = 10_000;
+const caps = computed(() =>
+  generationCapabilitiesForFamily(
+    props.form.family,
+    props.form.model,
+    props.form.pipeline,
+    props.selectedModel?.guidance_capabilities,
+    props.selectedModel?.source_image ?? props.form.sourceImageCapability,
+    effectiveGenerationRecipe(props.selectedModel, props.form.pipeline),
+  ),
+);
+const batchLocked = computed(
+  () =>
+    caps.value.forcesBatchSizeOne ||
+    (caps.value.sourceImageMode === "references" && props.form.imageAttachments.length > 0),
+);
+
+watch(
+  () => [batchLocked.value, props.form.batchSize] as const,
+  ([locked, batchSize]) => {
+    const normalized = locked
+      ? 1
+      : Math.min(MAX_BATCH_SIZE, Math.max(1, Math.round(batchSize) || 1));
+    if (batchSize !== normalized) props.form.batchSize = normalized;
+  },
+  { immediate: true },
+);
+
+function stepBatch(delta: -1 | 1): void {
+  if (batchLocked.value) return;
+  props.form.batchSize = Math.min(MAX_BATCH_SIZE, Math.max(1, props.form.batchSize + delta));
+}
+
+function setBatch(raw: string): void {
+  if (batchLocked.value) return;
+  const value = Number(raw);
+  props.form.batchSize = Number.isFinite(value)
+    ? Math.min(MAX_BATCH_SIZE, Math.max(1, Math.round(value)))
+    : 1;
+}
+</script>
+
+<template>
+  <section class="mobile-batch-control" data-test="mobile-batch-control">
+    <div class="mobile-generate-label-row">
+      <span class="mobile-generate-label">Batch</span>
+      <span v-if="batchLocked" class="mobile-generate-note" data-test="mobile-batch-locked">
+        Edit models render one at a time
+      </span>
+    </div>
+    <div class="mobile-generate-stepper" role="group" aria-label="Batch size">
+      <button
+        type="button"
+        class="mobile-generate-stepper-button"
+        data-test="mobile-batch-decrement"
+        aria-label="Decrease batch size"
+        :disabled="batchLocked || form.batchSize <= 1"
+        @click="stepBatch(-1)"
+      >
+        −
+      </button>
+      <input
+        class="mobile-generate-stepper-value"
+        data-test="mobile-batch-value"
+        type="number"
+        inputmode="numeric"
+        min="1"
+        step="1"
+        aria-label="Batch size"
+        :value="batchLocked ? 1 : form.batchSize"
+        :disabled="batchLocked"
+        @change="setBatch(($event.target as HTMLInputElement).value)"
+      />
+      <button
+        type="button"
+        class="mobile-generate-stepper-button"
+        data-test="mobile-batch-increment"
+        aria-label="Increase batch size"
+        :disabled="batchLocked || form.batchSize >= MAX_BATCH_SIZE"
+        @click="stepBatch(1)"
+      >
+        +
+      </button>
+    </div>
+  </section>
+</template>

--- a/desktop/src/mobile/MobileGenerateParameters.test.ts
+++ b/desktop/src/mobile/MobileGenerateParameters.test.ts
@@ -168,39 +168,18 @@ describe("MobileGenerateParameters", () => {
     );
   });
 
-  it("offers an editable unbounded batch stepper and image-only post upscale", async () => {
+  it("offers image-only post upscale without unrelated scheduler controls", async () => {
     const { wrapper, form } = mountParameters(formFor("flux"), [upscaler]);
 
-    expect(wrapper.get("[data-test='mobile-batch-value']").attributes("value")).toBe("1");
     expect(wrapper.find("[data-test='mobile-scheduler']").exists()).toBe(false);
     expect(wrapper.find("[data-test='mobile-cfg-plus']").exists()).toBe(false);
     expect(wrapper.get("[data-test='mobile-upscale']").text()).toContain("downloads on first use");
 
-    for (let index = 0; index < 10; index += 1) {
-      await wrapper.get("[data-test='mobile-batch-increment']").trigger("click");
-    }
-    expect(form.batchSize).toBe(11);
-    expect(wrapper.get("[data-test='mobile-batch-increment']").attributes()).not.toHaveProperty(
-      "disabled",
-    );
-
-    await wrapper.get("[data-test='mobile-batch-value']").setValue("250");
-    await wrapper.get("[data-test='mobile-batch-value']").trigger("change");
-    expect(form.batchSize).toBe(250);
-
-    await wrapper.get("[data-test='mobile-batch-value']").setValue("999999999999");
-    await wrapper.get("[data-test='mobile-batch-value']").trigger("change");
-    expect(form.batchSize).toBe(10_000);
-
-    await wrapper.get("[data-test='mobile-batch-value']").setValue("250");
-    await wrapper.get("[data-test='mobile-batch-value']").trigger("change");
-    await wrapper.get("[data-test='mobile-batch-decrement']").trigger("click");
-    expect(form.batchSize).toBe(249);
     await wrapper.get("[data-test='mobile-upscale']").setValue(upscaler.name);
     expect(form.upscaleModel).toBe(upscaler.name);
   });
 
-  it("capability-gates scheduler and CFG++, and locks edit-model batches to one", async () => {
+  it("capability-gates scheduler and CFG++", async () => {
     const sd15 = mountParameters(formFor("sd15"));
     expect(sd15.wrapper.find("[data-test='mobile-scheduler']").exists()).toBe(true);
     await sd15.wrapper.get("[data-test='mobile-scheduler']").setValue("ddim");
@@ -212,18 +191,6 @@ describe("MobileGenerateParameters", () => {
     await sd3.wrapper.get("[data-test='mobile-cfg-plus']").setValue(true);
     expect(sd3.form.cfgPlus).toBe(true);
     sd3.wrapper.unmount();
-
-    const editForm = formFor("qwen-image-edit");
-    editForm.batchSize = 6;
-    const edit = mountParameters(editForm);
-    await flushPromises();
-    expect(edit.form.batchSize).toBe(1);
-    expect(edit.wrapper.get("[data-test='mobile-batch-locked']").text()).toContain(
-      "render one at a time",
-    );
-    expect(edit.wrapper.get("[data-test='mobile-batch-increment']").attributes()).toHaveProperty(
-      "disabled",
-    );
   });
 
   it("swaps the scheduler row for wan's sampler recipe", async () => {

--- a/desktop/src/mobile/MobileGenerateParameters.vue
+++ b/desktop/src/mobile/MobileGenerateParameters.vue
@@ -121,8 +121,6 @@ const props = withDefaults(
     cameraUnsupportedReason: null,
   },
 );
-const MAX_BATCH_SIZE = 10_000;
-
 const emit = defineEmits<{
   "validity-change": [valid: boolean];
 }>();
@@ -149,11 +147,6 @@ const frameGridLabel = computed(() => videoFrameGridLabel(videoContract.value));
 const frameStep = computed(() => videoFrameStep(videoContract.value));
 const frameMinimum = computed(() => minVideoFrames(videoContract.value));
 const fixedFps = computed(() => fixedVideoFps(videoContract.value));
-const batchLocked = computed(
-  () =>
-    caps.value.forcesBatchSizeOne ||
-    (caps.value.sourceImageMode === "references" && props.form.imageAttachments.length > 0),
-);
 const generationRequest = computed(() => buildRequest(props.form));
 const frameError = computed(() =>
   caps.value.supportsVideo
@@ -221,30 +214,6 @@ watch(
   },
   { immediate: true },
 );
-watch(
-  () => [caps.value.forcesBatchSizeOne, props.form.batchSize] as const,
-  ([forced, batchSize]) => {
-    const normalized = forced
-      ? 1
-      : Math.min(MAX_BATCH_SIZE, Math.max(1, Math.round(batchSize) || 1));
-    if (batchSize !== normalized) props.form.batchSize = normalized;
-  },
-  { immediate: true },
-);
-
-function stepBatch(delta: -1 | 1): void {
-  if (batchLocked.value) return;
-  props.form.batchSize = Math.min(MAX_BATCH_SIZE, Math.max(1, props.form.batchSize + delta));
-}
-
-function setBatch(raw: string): void {
-  if (batchLocked.value) return;
-  const value = Number(raw);
-  props.form.batchSize = Number.isFinite(value)
-    ? Math.min(MAX_BATCH_SIZE, Math.max(1, Math.round(value)))
-    : 1;
-}
-
 function snapFramesField(): void {
   props.form.frames =
     fixedFps.value !== null
@@ -597,49 +566,6 @@ const fpsErrorId = `mobile-fps-error-${useId()}`;
   <section class="mobile-generate-parameters" data-test="mobile-generate-parameters">
     <fieldset class="mobile-generate-section mobile-generate-print-options">
       <legend class="mobile-generate-legend">Print options</legend>
-
-      <div class="mobile-generate-field">
-        <div class="mobile-generate-label-row">
-          <span class="mobile-generate-label">Batch</span>
-          <span v-if="batchLocked" class="mobile-generate-note" data-test="mobile-batch-locked">
-            Edit models render one at a time
-          </span>
-        </div>
-        <div class="mobile-generate-stepper" role="group" aria-label="Batch size">
-          <button
-            type="button"
-            class="mobile-generate-stepper-button"
-            data-test="mobile-batch-decrement"
-            aria-label="Decrease batch size"
-            :disabled="batchLocked || form.batchSize <= 1"
-            @click="stepBatch(-1)"
-          >
-            −
-          </button>
-          <input
-            class="mobile-generate-stepper-value"
-            data-test="mobile-batch-value"
-            type="number"
-            inputmode="numeric"
-            min="1"
-            step="1"
-            aria-label="Batch size"
-            :value="batchLocked ? 1 : form.batchSize"
-            :disabled="batchLocked"
-            @change="setBatch(($event.target as HTMLInputElement).value)"
-          />
-          <button
-            type="button"
-            class="mobile-generate-stepper-button"
-            data-test="mobile-batch-increment"
-            aria-label="Increase batch size"
-            :disabled="batchLocked || form.batchSize >= MAX_BATCH_SIZE"
-            @click="stepBatch(1)"
-          >
-            +
-          </button>
-        </div>
-      </div>
 
       <label
         v-if="caps.supportsScheduler && !caps.wanRecipe.supported"

--- a/desktop/src/mobile/mobile.css
+++ b/desktop/src/mobile/mobile.css
@@ -1647,6 +1647,10 @@ textarea.control {
   margin: 4px 0 16px;
 }
 
+.mobile-batch-control {
+  margin: 4px 0 16px;
+}
+
 .mobile-generate-section {
   padding: 14px 0 0;
   border-top: 1px solid var(--edge);

--- a/web/src/components/create/AdvancedDrawer.test.ts
+++ b/web/src/components/create/AdvancedDrawer.test.ts
@@ -607,6 +607,7 @@ describe("AdvancedDrawer interactions", () => {
   it("Reset clears advanced fields but preserves the prompt", async () => {
     const wrapper = factory("sdxl", {
       prompt: "a lighthouse in a storm",
+      batchSize: 4,
       negativePrompt: "blurry",
       loras: [{ path: "a", scale: 1 }],
       upscaleModel: "real-esrgan-x4plus",
@@ -616,6 +617,7 @@ describe("AdvancedDrawer interactions", () => {
       GenerateFormState,
     ];
     expect(next.prompt).toBe("a lighthouse in a storm");
+    expect(next.batchSize).toBe(4);
     expect(next.negativePrompt).toBe("");
     expect(next.loras).toEqual([]);
     expect(next.upscaleModel).toBe("");

--- a/web/src/composables/useGenerateForm.test.ts
+++ b/web/src/composables/useGenerateForm.test.ts
@@ -1219,15 +1219,13 @@ describe("useGenerateForm", () => {
     expect(form.state.value.gifPreview).toBe(false);
   });
 
-  it("resetSettings preserves the prompt, style, model and batch size", () => {
+  it("resetSettings preserves the prompt, style, and model while resetting Batch", () => {
     const form = useGenerateForm();
     const model = makeModel({ name: "sdxl:fp16", family: "sdxl" });
     form.applyModelDefaults(model);
     Object.assign(form.state.value, {
       prompt: "a lighthouse in a storm",
       stylePreset: "cinematic",
-      // Prepared batch work is never silently resized (CLAUDE.md), so the
-      // batch stepper survives a settings reset.
       batchSize: 4,
       steps: 3,
     });
@@ -1238,7 +1236,7 @@ describe("useGenerateForm", () => {
     expect(form.state.value.stylePreset).toBe("cinematic");
     expect(form.state.value.model).toBe("sdxl:fp16");
     expect(form.state.value.modelFamily).toBe("sdxl");
-    expect(form.state.value.batchSize).toBe(4);
+    expect(form.state.value.batchSize).toBe(1);
     expect(form.state.value.steps).toBe(20);
   });
 

--- a/web/src/composables/useGenerateForm.ts
+++ b/web/src/composables/useGenerateForm.ts
@@ -515,11 +515,11 @@ function modelDefaultsPatch(
  * the factory default, then to the selected model's own defaults on top.
  *
  * What survives is what the reset is *for* — the user is re-tuning a print they
- * are still composing: the prompt, the style preset, the selected model/family,
- * and the batch size (prepared batch work is never silently resized, see
- * CLAUDE.md). Everything else — shape, resolution, detail, prompt strength,
- * seed, and every advanced field including source media, LoRAs and the video
- * suite — goes back to defaults.
+ * are still composing: the prompt, the style preset, and the selected
+ * model/family. Batch is a general setting and returns to one; prepared work is
+ * retained and becomes explicitly stale. Everything else — shape, resolution,
+ * detail, prompt strength, seed, and every advanced field including source
+ * media, LoRAs and the video suite — goes back to defaults.
  */
 export function settingsResetPatch(
   current: GenerateFormState,
@@ -531,7 +531,7 @@ export function settingsResetPatch(
     stylePreset: current.stylePreset,
     model: current.model,
     modelFamily: current.modelFamily,
-    batchSize: current.batchSize,
+    batchSize: 1,
   };
   // With a resolved catalog row the model's own defaults (and its capability
   // gates) win over the generic ones; without it the generic defaults stand and
@@ -1002,7 +1002,7 @@ export interface UseGenerateForm {
   state: Ref<GenerateFormState>;
   reset: () => void;
   /** Restore every generation setting to the selected model's defaults while
-   * keeping the prompt, style, model and batch size (`settingsResetPatch`). */
+   * keeping the prompt, style, and model (`settingsResetPatch`). */
   resetSettings: (model: ModelInfoExtended | null) => void;
   applyModelDefaults: (model: ModelInfoExtended) => void;
   /**

--- a/web/src/pages/CreatePage.test.ts
+++ b/web/src/pages/CreatePage.test.ts
@@ -817,6 +817,7 @@ describe("CreatePage layout and behavior", () => {
     form.state.value.seedMode = "static";
     form.state.value.seed = 42;
     form.state.value.negativePrompt = "blurry";
+    form.state.value.batchSize = 4;
     await wrapper.get("[data-test='controls-reset']").trigger("click");
     expect(form.state.value.steps).toBe(30);
     expect(form.state.value.guidance).toBe(7.5);
@@ -824,6 +825,7 @@ describe("CreatePage layout and behavior", () => {
     expect(form.state.value.negativePrompt).toBe("");
     expect(form.state.value.prompt).toBe("a lighthouse in a storm");
     expect(form.state.value.model).toBe("sdxl:fp16");
+    expect(form.state.value.batchSize).toBe(1);
 
     const notifications = useNotifications();
     const settingsToast = notifications.toasts.find((t) =>
@@ -834,6 +836,7 @@ describe("CreatePage layout and behavior", () => {
     expect(form.state.value.steps).toBe(3);
     expect(form.state.value.seed).toBe(42);
     expect(form.state.value.negativePrompt).toBe("blurry");
+    expect(form.state.value.batchSize).toBe(4);
 
     const draft = useSequenceDraftStore();
     draft.output = "sequence";

--- a/web/src/pages/CreatePage.vue
+++ b/web/src/pages/CreatePage.vue
@@ -2598,11 +2598,10 @@ function onNewPrint() {
 }
 
 // Controls rail "Reset" (spec §06): put every generation setting back to the
-// current model's defaults. The prompt, style, model and batch size stay —
-// this re-tunes the print being composed, it does not start a new one, and
-// prepared batch work is never silently resized. Nothing leaves the browser,
-// so an undo toast is enough; a blocking confirm would be heavier than the
-// action deserves.
+// current model's defaults. The prompt, style, and model stay while Batch
+// returns to one. Prepared work remains retained and becomes explicitly stale;
+// nothing leaves the browser, so an undo toast is enough and a blocking confirm
+// would be heavier than the action deserves.
 function onResetSettings() {
   // resetSettings swaps in a freshly built state object, so the previous one is
   // never mutated and can be handed straight back on undo.


### PR DESCRIPTION
## Summary
- move the shared iOS/Android Batch stepper out of Advanced and into the primary Create form
- reset Batch to one from each surface's primary/general Reset while keeping Advanced Reset scoped
- preserve prepared work and surface its existing stale-state recovery when Batch changes
- retain capability and source-reference batch locks

## Verification
- desktop focused Vitest: 538 passed
- web focused Vitest: 319 passed
- desktop, web, and shared mobile production builds
- `nix develop -c ios-check`
- `nix develop -c env RUSTC_WRAPPER= android-build` (release AAB)
- rendered 393x852 mobile QA: Batch outside Advanced; Advanced Reset preserves Batch; primary Reset returns Batch to one
- Claude Sonnet 5 peer review: no findings (the skill's former pinned Opus model was retired)

## Merge
Do not merge as part of this task.