### PR TITLE
feat(licenses): add cross-surface acceptance flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -688,7 +688,9 @@ jobs:
         # out to `protoc`.
         run: brew install protobuf
       - name: Clippy Metal forced-local and server paths
-        run: cargo clippy -p mold-ai --features metal,preview,expand,tui,webp,mp4,mdns,pulid --all-targets -- -D warnings
+        run: cargo clippy -p mold-ai --features h3,metal,preview,expand,tui,webp,mp4,mdns,pulid --all-targets -- -D warnings
+      - name: Check reviewed H3 Metal server recipe
+        run: cargo check -p mold-ai-server --features h3,metal,expand,mdns,metrics,mp4,pulid,webp
 
   # Codecov remains a main-branch reporting signal. It is intentionally not a
   # required PR check: the protected Rust job already runs the same tests, and

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
         run: brew install protobuf
 
       - name: Build (Metal)
-        run: cargo build --release -p mold-ai --features metal,preview,discord,expand,tui,webp,mp4,metrics,mdns,pulid
+        run: cargo build --release -p mold-ai --features h3,metal,preview,discord,expand,tui,webp,mp4,metrics,mdns,pulid
 
       - name: Ad-hoc code sign
         run: codesign -s - target/release/mold
@@ -851,7 +851,7 @@ jobs:
             sudo apt-get install -y protobuf-compiler                    # Debian/Ubuntu
             # (Arch: pacman -S protobuf · Fedora: dnf install protobuf-compiler)
 
-            cargo install --git https://github.com/utensils/mold --tag ${{ github.ref_name }} --features metal,preview,discord,expand,tui,webp,mp4,metrics,mdns,pulid  # macOS
+            cargo install --git https://github.com/utensils/mold --tag ${{ github.ref_name }} --features h3,metal,preview,discord,expand,tui,webp,mp4,metrics,mdns,pulid  # macOS
             cargo install --git https://github.com/utensils/mold --tag ${{ github.ref_name }} --features cuda,preview,discord,expand,tui,webp,mp4,metrics,mdns,pulid   # Linux; use the SM89 artifact for H3
 
             # Nix

--- a/changelog.d/fix-h3-metal-build.md
+++ b/changelog.d/fix-h3-metal-build.md
@@ -1,0 +1,1 @@
+- **Compile the reviewed MiniMax H3 Metal server.** The Apple Silicon H3 recipe now keeps CUDA-only preparation containment out of Metal builds, and macOS CI compiles that exact feature set to prevent drift ([#1296](https://github.com/utensils/mold/issues/1296)).

--- a/crates/mold-candle/src/minimax_h3/visual_weights.rs
+++ b/crates/mold-candle/src/minimax_h3/visual_weights.rs
@@ -536,7 +536,18 @@ fn diffusers_to_comfy_direct_key(target: &str) -> String {
 }
 
 pub fn inspect_safetensors_header(path: &Path) -> Result<SafetensorsHeader> {
-    let identity = visual_weight_file_identity(path)?;
+    // A retained staging descriptor must stay descriptor-bound. Canonicalizing
+    // `/dev/fd/N` on macOS either fails or resolves it back through the
+    // replaceable staging pathname, defeating both portability and the inode
+    // fence the caller deliberately retained (#1296).
+    let descriptor_bound = path.parent().is_some_and(|parent| {
+        parent == Path::new("/dev/fd") || parent == Path::new("/proc/self/fd")
+    });
+    let identity = if descriptor_bound {
+        visual_weight_file_identity_from_descriptor(path)?
+    } else {
+        visual_weight_file_identity(path)?
+    };
     inspect_safetensors_header_for_identity(&identity)
 }
 

--- a/crates/mold-cli/src/catalog_bridge.rs
+++ b/crates/mold-cli/src/catalog_bridge.rs
@@ -150,12 +150,7 @@ fn require_manifest_model_activation(id: &str) -> Result<()> {
     let Some(manifest) = mold_core::manifest::find_manifest(id) else {
         return Ok(());
     };
-    mold_core::require_model_activation(&manifest.name, Some(&manifest.family))?;
-    for file in &manifest.files {
-        mold_core::require_model_activation(&file.hf_repo, Some(&manifest.family))?;
-        mold_core::require_model_activation(&file.hf_filename, Some(&manifest.family))?;
-    }
-    Ok(())
+    mold_core::require_registered_manifest_activation(manifest).map_err(anyhow::Error::new)
 }
 
 fn require_configured_model_activation(config: &Config, id: &str) -> Result<()> {

--- a/crates/mold-cli/src/commands/generate.rs
+++ b/crates/mold-cli/src/commands/generate.rs
@@ -201,6 +201,8 @@ fn local_generation_profile(
     config: &Config,
     model: &str,
 ) -> Option<mold_core::GenerationProfileSet> {
+    let family = resolve_family(model, config);
+    mold_core::require_model_activation(model, family.as_deref()).ok()?;
     let canonical = manifest::resolve_model_name(model);
     let mut catalog = mold_core::build_model_catalog(config, None, false);
     mold_core::qualify_catalog_generation_delivery(
@@ -3548,13 +3550,11 @@ mod tests {
                     .contains(&OutputFormat::Webp)
             }));
         }
-        if !cfg!(feature = "mp4") {
-            assert!(local_generation_profile(
-                &Config::default(),
-                mold_core::minimax_h3::FL2VA_OFFICIAL
-            )
-            .is_none());
-        }
+        assert!(local_generation_profile(
+            &Config::default(),
+            mold_core::minimax_h3::FL2VA_OFFICIAL
+        )
+        .is_none());
     }
 
     #[test]

--- a/crates/mold-cli/src/commands/local_engine.rs
+++ b/crates/mold-cli/src/commands/local_engine.rs
@@ -229,6 +229,15 @@ pub(crate) async fn plan_local_batch(
 }
 
 #[cfg(any(feature = "cuda", feature = "metal"))]
+fn local_execution_capacity(backend: mold_core::GpuBackend, sampled_bytes: u64) -> u64 {
+    if backend == mold_core::GpuBackend::Metal {
+        mold_inference::device::metal_unified_capacity_with_safety_floor(sampled_bytes)
+    } else {
+        sampled_bytes
+    }
+}
+
+#[cfg(any(feature = "cuda", feature = "metal"))]
 pub(crate) fn build_local_engine_from_plan(
     request: &mold_core::GenerateRequest,
     config: &Config,
@@ -243,16 +252,18 @@ pub(crate) fn build_local_engine_from_plan(
         request,
         Some(prepared),
     )?;
-    let current_free =
-        mold_inference::device::free_vram_bytes(plan.device_ordinal).ok_or_else(|| {
+    let sampled_current_free = mold_inference::device::free_vram_bytes(plan.device_ordinal)
+        .ok_or_else(|| {
             anyhow::anyhow!(
                 "current free VRAM is unavailable for GPU {}",
                 plan.device_ordinal
             )
         })?;
+    let current_free = local_execution_capacity(plan.device_backend, sampled_current_free);
     if current_free < plan.predicted_vram_peak_bytes {
         anyhow::bail!(
-            "local execution plan invalidated before CUDA: GPU {} now has {} bytes free but the exact plan requires {}",
+            "local execution plan invalidated before {:?}: GPU {} now has {} bytes free but the exact plan requires {}",
+            plan.device_backend,
             plan.device_ordinal,
             current_free,
             plan.predicted_vram_peak_bytes
@@ -571,6 +582,15 @@ impl LocalBatchAdmission {
 mod tests {
     use super::*;
     use crate::test_support::ENV_LOCK;
+
+    #[cfg(any(feature = "cuda", feature = "metal"))]
+    #[test]
+    fn cuda_local_execution_capacity_preserves_the_live_sample() {
+        assert_eq!(
+            local_execution_capacity(mold_core::GpuBackend::Cuda, 17_123_456_789),
+            17_123_456_789
+        );
+    }
 
     #[test]
     fn apply_local_engine_env_overrides_sets_qwen2_overrides() {

--- a/crates/mold-core/src/client.rs
+++ b/crates/mold-core/src/client.rs
@@ -1137,6 +1137,26 @@ impl MoldClient {
         Ok(listing.licenses)
     }
 
+    /// Read-only dependency and device plan for an exact generation request.
+    /// Newer clients use the additive pending-license metadata to pause for
+    /// consent before admission starts any download.
+    pub async fn preview_generation_placement(
+        &self,
+        request: crate::types::GenerateRequest,
+        copies: u32,
+    ) -> Result<crate::types::GenerationPlacementPreview> {
+        let preview = self
+            .client
+            .post(format!("{}/api/generate/placement-preview", self.base_url))
+            .json(&crate::types::GenerationPlacementPreviewRequest { request, copies })
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+        Ok(preview)
+    }
+
     /// Request graceful server shutdown.
     pub async fn shutdown_server(&self) -> Result<()> {
         self.client
@@ -1856,6 +1876,21 @@ fn should_fallback_loras_endpoint(err: &anyhow::Error) -> bool {
             matches!(
                 status,
                 StatusCode::NOT_FOUND | StatusCode::METHOD_NOT_ALLOWED
+            )
+        })
+}
+
+/// True only when an HTTP endpoint is absent on an otherwise responding
+/// older server. Callers may use this for additive API compatibility, but
+/// must not turn authentication, transport, or server failures into a legacy
+/// fallback that could mutate state without a successful preflight.
+pub fn is_missing_endpoint_error(err: &anyhow::Error) -> bool {
+    err.downcast_ref::<reqwest::Error>()
+        .and_then(reqwest::Error::status)
+        .is_some_and(|status| {
+            matches!(
+                status,
+                reqwest::StatusCode::NOT_FOUND | reqwest::StatusCode::METHOD_NOT_ALLOWED
             )
         })
 }

--- a/crates/mold-core/src/download.rs
+++ b/crates/mold-core/src/download.rs
@@ -1144,18 +1144,17 @@ pub fn require_license_accepted(
     hf_filename: &str,
     mold_home: Option<&std::path::Path>,
 ) -> Result<(), DownloadError> {
-    let Some(license) =
-        crate::license_acceptance::license_for_manifest_file(manifest_name, hf_filename)
-    else {
-        return Ok(());
-    };
-    if mold_home.is_some_and(|home| crate::license_acceptance::is_accepted(home, license)) {
-        return Ok(());
+    for license in crate::license_acceptance::licenses_for_manifest_file(manifest_name, hf_filename)
+    {
+        if mold_home.is_some_and(|home| crate::license_acceptance::is_accepted(home, license)) {
+            continue;
+        }
+        return Err(DownloadError::LicenseNotAccepted {
+            license_id: license.id.to_string(),
+            message: crate::license_acceptance::acceptance_required_message(manifest_name, license),
+        });
     }
-    Err(DownloadError::LicenseNotAccepted {
-        license_id: license.id.to_string(),
-        message: crate::license_acceptance::acceptance_required_message(manifest_name, license),
-    })
+    Ok(())
 }
 
 pub async fn pull_model(

--- a/crates/mold-core/src/lib.rs
+++ b/crates/mold-core/src/lib.rs
@@ -78,10 +78,10 @@ pub use media_paths::{configured_media_roots, parse_media_roots_env, resolve_ser
 pub use model_policy::{
     model_access_capabilities, model_acquisition, model_acquisition_available, model_activation,
     model_activation_available, model_artifact_activation, require_model_acquisition,
-    require_model_activation, require_model_artifact_activation, ModelAccessCapabilities,
-    ModelAccessRestriction, ModelActivation, ModelActivationError,
-    MINIMAX_H3_AUTHORIZATION_ISSUE_URL, MINIMAX_H3_AUTHORIZATION_REQUIRED,
-    MINIMAX_H3_LICENSE_SHA256, MINIMAX_H3_LICENSE_URL,
+    require_model_activation, require_model_artifact_activation,
+    require_registered_manifest_activation, ModelAccessCapabilities, ModelAccessRestriction,
+    ModelActivation, ModelActivationError, MINIMAX_H3_AUTHORIZATION_ISSUE_URL,
+    MINIMAX_H3_AUTHORIZATION_REQUIRED, MINIMAX_H3_LICENSE_SHA256, MINIMAX_H3_LICENSE_URL,
 };
 pub use organization::{
     collection_slug, compose_client_tags, normalize_request_tags, normalize_tag_name,

--- a/crates/mold-core/src/license_acceptance.rs
+++ b/crates/mold-core/src/license_acceptance.rs
@@ -109,31 +109,48 @@ pub fn license_by_id(id: &str) -> Option<&'static ThirdPartyLicense> {
         .find(|license| license.id == id)
 }
 
-/// The license covering one manifest file, if that file is gated on
-/// acceptance.
+/// Whether one registered license covers one manifest file.
+///
+/// Keep policy in this registry predicate rather than in callers. A future
+/// file may be covered by more than one license; every consumer enumerates
+/// [`licenses_for_manifest_file`] and therefore enforces all of them.
+fn license_covers_manifest_file(
+    license: &ThirdPartyLicense,
+    manifest_name: &str,
+    hf_filename: &str,
+) -> bool {
+    license.id == INSIGHTFACE_ANTELOPEV2.id
+        && manifest_name == crate::manifest::PULID_FLUX_MANIFEST
+        && matches!(hf_filename, "scrfd_10g_bnkps.onnx" | "glintr100.onnx")
+}
+
+/// Every license covering one manifest file.
 ///
 /// Keyed on `(manifest name, hf filename)` rather than on the repository so a
 /// mirror that also hosts unrestricted files is not over-gated.
-pub fn license_for_manifest_file(
-    manifest_name: &str,
-    hf_filename: &str,
-) -> Option<&'static ThirdPartyLicense> {
-    if manifest_name == crate::manifest::PULID_FLUX_MANIFEST
-        && matches!(hf_filename, "scrfd_10g_bnkps.onnx" | "glintr100.onnx")
-    {
-        return Some(&INSIGHTFACE_ANTELOPEV2);
-    }
-    None
+pub fn licenses_for_manifest_file<'a>(
+    manifest_name: &'a str,
+    hf_filename: &'a str,
+) -> impl Iterator<Item = &'static ThirdPartyLicense> + 'a {
+    THIRD_PARTY_LICENSES
+        .iter()
+        .copied()
+        .filter(move |license| license_covers_manifest_file(license, manifest_name, hf_filename))
 }
 
-/// True when any file in `manifest` is gated on an unaccepted license.
-pub fn manifest_requires_license(
+/// Every distinct license required by a manifest.
+pub fn licenses_for_manifest(
     manifest: &crate::manifest::ModelManifest,
-) -> Option<&'static ThirdPartyLicense> {
-    manifest
+) -> Vec<&'static ThirdPartyLicense> {
+    let mut by_id = std::collections::BTreeMap::new();
+    for license in manifest
         .files
         .iter()
-        .find_map(|file| license_for_manifest_file(&manifest.name, &file.hf_filename))
+        .flat_map(|file| licenses_for_manifest_file(&manifest.name, &file.hf_filename))
+    {
+        by_id.entry(license.id).or_insert(license);
+    }
+    by_id.into_values().collect()
 }
 
 /// Manifest names that cannot be downloaded until `license` is accepted.
@@ -146,8 +163,8 @@ pub fn manifests_requiring(license: &ThirdPartyLicense) -> Vec<String> {
         .iter()
         .filter(|manifest| {
             manifest.files.iter().any(|file| {
-                license_for_manifest_file(&manifest.name, &file.hf_filename)
-                    .is_some_and(|found| found.id == license.id)
+                licenses_for_manifest_file(&manifest.name, &file.hf_filename)
+                    .any(|found| found.id == license.id)
             })
         })
         .map(|manifest| manifest.name.clone())
@@ -181,6 +198,48 @@ pub fn refusal(license: &ThirdPartyLicense) -> crate::types::LicenseRefusal {
         sha256: license.sha256.to_string(),
         summary: license.summary.to_string(),
     }
+}
+
+/// Exact outstanding terms for one installable manifest bundle.
+///
+/// This is the registry-driven bridge between model acquisition and every UI:
+/// callers never special-case a model or license id, and a future manifest
+/// license automatically rides the same placement/download contract.
+pub fn unaccepted_for_manifest(
+    manifest_name: &str,
+    mold_home: &Path,
+) -> Vec<crate::types::LicenseRefusal> {
+    let Some(manifest) = crate::manifest::known_manifests()
+        .iter()
+        .find(|manifest| manifest.name == manifest_name)
+    else {
+        return Vec::new();
+    };
+    unaccepted_for_manifest_files(
+        manifest_name,
+        manifest.files.iter().map(|file| file.hf_filename.as_str()),
+        mold_home,
+    )
+}
+
+/// Exact outstanding terms for selected files in one installable bundle.
+///
+/// Placement previews pass only files they actually need to fetch. This keeps
+/// an already-present gated asset from prompting merely because a different,
+/// unrestricted file in the same bundle is missing.
+pub fn unaccepted_for_manifest_files<'a>(
+    manifest_name: &'a str,
+    hf_filenames: impl IntoIterator<Item = &'a str>,
+    mold_home: &Path,
+) -> Vec<crate::types::LicenseRefusal> {
+    let mut seen = std::collections::BTreeSet::new();
+    hf_filenames
+        .into_iter()
+        .flat_map(|filename| licenses_for_manifest_file(manifest_name, filename))
+        .filter(|license| !is_accepted(mold_home, license))
+        .filter(|license| seen.insert(license.id))
+        .map(refusal)
+        .collect()
 }
 
 /// An `accept_licenses` entry naming a license this build does not know.
@@ -405,33 +464,47 @@ mod tests {
     #[test]
     fn antelopev2_files_are_gated_and_nothing_else_is() {
         assert_eq!(
-            license_for_manifest_file("pulid-flux", "scrfd_10g_bnkps.onnx"),
-            Some(&INSIGHTFACE_ANTELOPEV2)
+            licenses_for_manifest_file("pulid-flux", "scrfd_10g_bnkps.onnx").collect::<Vec<_>>(),
+            vec![&INSIGHTFACE_ANTELOPEV2]
         );
         assert_eq!(
-            license_for_manifest_file("pulid-flux", "glintr100.onnx"),
-            Some(&INSIGHTFACE_ANTELOPEV2)
+            licenses_for_manifest_file("pulid-flux", "glintr100.onnx").collect::<Vec<_>>(),
+            vec![&INSIGHTFACE_ANTELOPEV2]
         );
-        assert_eq!(
-            license_for_manifest_file("pulid-flux", "pulid_flux_v0.9.1.safetensors"),
-            None
+        assert!(
+            licenses_for_manifest_file("pulid-flux", "pulid_flux_v0.9.1.safetensors")
+                .next()
+                .is_none()
         );
-        assert_eq!(
-            license_for_manifest_file("pulid-flux", "EVA02_CLIP_L_336_psz14_s6B.pt"),
-            None
+        assert!(
+            licenses_for_manifest_file("pulid-flux", "EVA02_CLIP_L_336_psz14_s6B.pt")
+                .next()
+                .is_none()
         );
         // facexlib is MIT, weights included, so the BiSeNet parser carries
         // none of the antelopev2 restriction even though it arrives in the
         // same bundle (#1225).
-        assert_eq!(
-            license_for_manifest_file("pulid-flux", "parsing_bisenet.pth"),
-            None
+        assert!(
+            licenses_for_manifest_file("pulid-flux", "parsing_bisenet.pth")
+                .next()
+                .is_none()
         );
         // Same filename under a different manifest is not gated.
-        assert_eq!(
-            license_for_manifest_file("flux-dev:q4", "glintr100.onnx"),
-            None
-        );
+        assert!(licenses_for_manifest_file("flux-dev:q4", "glintr100.onnx")
+            .next()
+            .is_none());
+    }
+
+    #[test]
+    fn outstanding_terms_are_derived_from_the_manifest_registry() {
+        let home = tempfile::tempdir().unwrap();
+        let outstanding = unaccepted_for_manifest("pulid-flux", home.path());
+        assert_eq!(outstanding, vec![refusal(&INSIGHTFACE_ANTELOPEV2)]);
+        assert!(unaccepted_for_manifest("flux-dev:q4", home.path()).is_empty());
+        assert!(unaccepted_for_manifest("not-a-model", home.path()).is_empty());
+
+        record_acceptance(home.path(), &INSIGHTFACE_ANTELOPEV2).unwrap();
+        assert!(unaccepted_for_manifest("pulid-flux", home.path()).is_empty());
     }
 
     #[test]

--- a/crates/mold-core/src/manifest.rs
+++ b/crates/mold-core/src/manifest.rs
@@ -7640,7 +7640,7 @@ mod tests {
 
     #[test]
     fn known_manifests_count() {
-        // 24 FLUX + 3 SD1.5 + 4 SD3 + 8 SDXL + 4 Z-Image + 9 Flux.2 + 29 Qwen-Image/Qwen-Image-Edit + 1 Wuerstchen + 5 LTX Video + 6 LTX-2 + 14 Wan + 6 MiniMax H3 contracts (2 visible compact + 2 visible FL2VA Turbo tags + 2 hidden official) + 7 LTX-2 controls + 7 LTX-2 camera controls + 3 ControlNet + 2 Qwen3-Expand + 7 Upscaler + 20 Companion = 159
+        // 24 FLUX + 3 SD1.5 + 4 SD3 + 8 SDXL + 4 Z-Image + 9 Flux.2 + 29 Qwen-Image/Qwen-Image-Edit + 1 Wuerstchen + 5 LTX Video + 6 LTX-2 + 14 Wan + 6 visible MiniMax H3 contracts + 7 LTX-2 controls + 7 LTX-2 camera controls + 3 ControlNet + 2 Qwen3-Expand + 7 Upscaler + 20 Companion = 159
         // Wan fp8 bump (#777): +wan22-{t2v,i2v}-a14b:fp8 — the Comfy-Org
         // fp8-scaled expert pairs.
         // Wan bump: +wan22-{t2v,i2v}-a14b:{q5,q8} — the two-expert A14B tiers.

--- a/crates/mold-core/src/manifest.rs
+++ b/crates/mold-core/src/manifest.rs
@@ -5038,6 +5038,24 @@ pub const PULID_FAMILY: &str = "pulid";
 /// Manifest name for the PuLID-FLUX v0.9.1 asset bundle.
 pub const PULID_FLUX_MANIFEST: &str = "pulid-flux";
 
+/// Installable auxiliary bundles required by one concrete generation request.
+///
+/// Clients use this registry-driven answer to run the same generic
+/// consent/download loop for local execution that servers derive during
+/// placement. Adding a future request-bound auxiliary bundle belongs here,
+/// never as a model id embedded in an individual UI.
+pub fn auxiliary_manifests_for_request(
+    request: &crate::types::GenerateRequest,
+) -> Vec<&'static str> {
+    let mut manifests = Vec::new();
+    if crate::identity::request_mentions_identity(request)
+        && crate::identity::effective_id_weight(request) > 0.0
+    {
+        manifests.push(PULID_FLUX_MANIFEST);
+    }
+    manifests
+}
+
 /// The PuLID-FLUX auxiliary asset bundle.
 ///
 /// This is emphatically **not** a generation model: it is the four auxiliary
@@ -6692,6 +6710,31 @@ fn upscaler_manifests() -> Vec<ModelManifest> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn request_auxiliary_bundle_registry_tracks_active_identity_only() {
+        let mut request: crate::types::GenerateRequest =
+            serde_json::from_value(serde_json::json!({
+                "prompt": "portrait",
+                "model": "flux-dev:q8",
+                "width": 1024,
+                "height": 1024,
+                "steps": 20,
+                "seed": 1,
+                "id_image": "AQ=="
+            }))
+            .unwrap();
+        assert_eq!(
+            auxiliary_manifests_for_request(&request),
+            vec![PULID_FLUX_MANIFEST]
+        );
+
+        request.id_weight = Some(0.0);
+        assert!(auxiliary_manifests_for_request(&request).is_empty());
+        request.id_image = None;
+        request.id_weight = None;
+        assert!(auxiliary_manifests_for_request(&request).is_empty());
+    }
 
     #[test]
     fn pulid_bundle_is_a_hidden_sha_pinned_auxiliary_bundle() {

--- a/crates/mold-core/src/minimax_h3.rs
+++ b/crates/mold-core/src/minimax_h3.rs
@@ -2,7 +2,7 @@
 //!
 //! H3 acquisition and execution are separate authorities. The compact
 //! upstream checkpoints are downloadable, while runtime admission remains
-//! limited to an independently qualified CUDA route. This module records the
+//! limited to independently qualified backend routes. This module records the
 //! immutable model/layout/request facts shared by both boundaries.
 
 use crate::manifest::{ManifestDefaults, ModelComponent, ModelFile, ModelManifest};
@@ -2498,9 +2498,9 @@ fn defaults_with_steps(steps: u32) -> ManifestDefaults {
 }
 
 /// Pinned manifests used for exact identity, storage, and runtime work.
-/// Official BF16 manifests remain qualification references; compact upstream
-/// manifests are visible for direct download even when the current host cannot
-/// execute them.
+/// Every pinned upstream layout is visible for direct download even when the
+/// current host cannot execute it. Download authority and runtime authority
+/// remain deliberately independent.
 pub(crate) fn manifests() -> Vec<ModelManifest> {
     let mut manifests: Vec<ModelManifest> = [
         (FL2VA_OFFICIAL, Task::Fl2va, Layout::OfficialBf16),
@@ -2521,9 +2521,9 @@ pub(crate) fn manifests() -> Vec<ModelManifest> {
         name: name.to_string(),
         family: FAMILY.to_string(),
         description: match (task, layout) {
-            (Task::Fl2va, Layout::OfficialBf16) => "MiniMax H3 FL2VA official BF16 transformer/conditioner + FP32 VAEs (qualification reference; hidden from downloads)",
-            (Task::Ref2va, Layout::OfficialBf16) => "MiniMax H3 Ref2VA official BF16 transformer/conditioner + FP32 VAEs (qualification reference; hidden from downloads)",
-            (Task::Fl2va, Layout::ComfyPrunedInt8ConvrotNvfp4Awq) => "MiniMax H3 FL2VA Comfy pruned INT8-convrot + NVFP4-AWQ (CUDA or Apple Metal)",
+            (Task::Fl2va, Layout::OfficialBf16) => "MiniMax H3 FL2VA official BF16 transformer/conditioner + FP32 VAEs (downloadable qualification reference; execution unavailable)",
+            (Task::Ref2va, Layout::OfficialBf16) => "MiniMax H3 Ref2VA official BF16 transformer/conditioner + FP32 VAEs (downloadable qualification reference; execution unavailable)",
+            (Task::Fl2va, Layout::ComfyPrunedInt8ConvrotNvfp4Awq) => "MiniMax H3 FL2VA Comfy pruned INT8-convrot + NVFP4-AWQ (downloadable; CUDA or Apple Metal)",
             (Task::Ref2va, Layout::ComfyPrunedInt8ConvrotNvfp4Awq) => "MiniMax H3 Ref2VA Comfy pruned INT8-convrot + NVFP4-AWQ (downloadable; execution requires a qualified CUDA host)",
         }
         .to_string(),
@@ -2532,7 +2532,7 @@ pub(crate) fn manifests() -> Vec<ModelManifest> {
             Layout::ComfyPrunedInt8ConvrotNvfp4Awq => comfy_files(task),
         },
         defaults: defaults(layout),
-        hidden: layout == Layout::OfficialBf16,
+        hidden: false,
     })
     .collect();
     // The reviewed FL2VA Turbo tiers are the compact FL2VA stack plus one
@@ -3579,6 +3579,8 @@ mod tests {
         assert_eq!(
             advertised_h3,
             std::collections::BTreeSet::from([
+                FL2VA_OFFICIAL,
+                REF2VA_OFFICIAL,
                 FL2VA_COMFY,
                 REF2VA_COMFY,
                 FL2VA_COMFY_TURBO_8STEP,
@@ -3592,15 +3594,15 @@ mod tests {
     }
 
     #[test]
-    fn manifests_expose_only_compact_downloads_and_cannot_mix_task_transformers() {
+    fn manifests_expose_every_pinned_download_and_cannot_mix_task_transformers() {
         let fl_official = find_manifest(FL2VA_OFFICIAL).unwrap();
         let ref_official = find_manifest(REF2VA_OFFICIAL).unwrap();
         let fl_comfy = find_manifest(FL2VA_COMFY).unwrap();
         let ref_comfy = find_manifest(REF2VA_COMFY).unwrap();
         let fl_turbo_8 = find_manifest(FL2VA_COMFY_TURBO_8STEP).unwrap();
         let fl_turbo_4 = find_manifest(FL2VA_COMFY_TURBO_4STEP_768P).unwrap();
-        assert!(fl_official.hidden);
-        assert!(ref_official.hidden);
+        assert!(!fl_official.hidden);
+        assert!(!ref_official.hidden);
         assert!(!fl_comfy.hidden);
         assert!(!ref_comfy.hidden);
         assert!(!fl_turbo_8.hidden);
@@ -3687,6 +3689,8 @@ mod tests {
         assert_eq!(
             visible,
             std::collections::BTreeSet::from([
+                FL2VA_OFFICIAL,
+                REF2VA_OFFICIAL,
                 FL2VA_COMFY,
                 REF2VA_COMFY,
                 FL2VA_COMFY_TURBO_8STEP,

--- a/crates/mold-core/src/minimax_h3.rs
+++ b/crates/mold-core/src/minimax_h3.rs
@@ -342,6 +342,8 @@ pub enum Mode {
 pub enum BackendQualification {
     /// The implementation target is CUDA, but no runnable engine is registered.
     ContractTarget,
+    /// The backend is part of the supported public runtime.
+    Supported,
     /// The execution path exists and is qualified for correctness only;
     /// throughput is deliberately unqualified. This mirrors
     /// `mold_inference::BackendQualification::CorrectnessOnly`, the tier Wan
@@ -400,17 +402,20 @@ pub const ALL_MODES: &[Mode] = &[
 ];
 
 pub const fn capabilities(task: Task) -> Capabilities {
+    let fl2va_runtime = cfg!(feature = "h3") && matches!(task, Task::Fl2va);
     Capabilities {
-        runtime_available: false,
+        runtime_available: fl2va_runtime,
         backends: BackendApplicability {
-            cuda: BackendQualification::ContractTarget,
+            cuda: if fl2va_runtime {
+                BackendQualification::Supported
+            } else {
+                BackendQualification::ContractTarget
+            },
             // The Apple Silicon execution path landed in #1164: family-scoped
             // BF16, a folded audio-VAE reduction, chunked dense attention, the
             // portable INT8 arm, and fp8 refused by name. It is advertised as
-            // correctness-only and stays that way until perf UAT on real
-            // hardware, per the Wan #800 precedent. Note this is the *path*
-            // tier: `runtime_available` above still gates whether any H3
-            // engine is registered at all.
+            // correctness-only and stays that way until performance UAT, per
+            // the Wan #800 precedent.
             metal: BackendQualification::CorrectnessOnly,
             cpu: BackendQualification::Unsupported,
         },
@@ -2518,7 +2523,7 @@ pub(crate) fn manifests() -> Vec<ModelManifest> {
         description: match (task, layout) {
             (Task::Fl2va, Layout::OfficialBf16) => "MiniMax H3 FL2VA official BF16 transformer/conditioner + FP32 VAEs (qualification reference; hidden from downloads)",
             (Task::Ref2va, Layout::OfficialBf16) => "MiniMax H3 Ref2VA official BF16 transformer/conditioner + FP32 VAEs (qualification reference; hidden from downloads)",
-            (Task::Fl2va, Layout::ComfyPrunedInt8ConvrotNvfp4Awq) => "MiniMax H3 FL2VA Comfy pruned INT8-convrot + NVFP4-AWQ (downloadable; execution requires a qualified CUDA host)",
+            (Task::Fl2va, Layout::ComfyPrunedInt8ConvrotNvfp4Awq) => "MiniMax H3 FL2VA Comfy pruned INT8-convrot + NVFP4-AWQ (CUDA or Apple Metal)",
             (Task::Ref2va, Layout::ComfyPrunedInt8ConvrotNvfp4Awq) => "MiniMax H3 Ref2VA Comfy pruned INT8-convrot + NVFP4-AWQ (downloadable; execution requires a qualified CUDA host)",
         }
         .to_string(),
@@ -2546,7 +2551,7 @@ pub(crate) fn manifests() -> Vec<ModelManifest> {
             name: tier.model.to_string(),
             family: FAMILY.to_string(),
             description: format!(
-                "MiniMax H3 FL2VA Comfy pruned INT8-convrot + NVFP4-AWQ with the reviewed {} LoRA (downloadable; execution requires a qualified CUDA host)",
+                "MiniMax H3 FL2VA Comfy pruned INT8-convrot + NVFP4-AWQ with the reviewed {} LoRA (CUDA or Apple Metal)",
                 tier.display_label
             ),
             files,
@@ -3424,12 +3429,20 @@ mod tests {
     }
 
     #[test]
-    fn capabilities_are_truthful_before_runtime_exists() {
+    fn capabilities_are_truthful_for_the_public_fl2va_runtime() {
         for task in [Task::Fl2va, Task::Ref2va] {
             let caps = capabilities(task);
-            assert!(!caps.runtime_available);
+            let fl2va_runtime = cfg!(feature = "h3") && task == Task::Fl2va;
+            assert_eq!(caps.runtime_available, fl2va_runtime);
             assert_eq!(caps.native_batch_sizes, &[1]);
-            assert_eq!(caps.backends.cuda, BackendQualification::ContractTarget);
+            assert_eq!(
+                caps.backends.cuda,
+                if fl2va_runtime {
+                    BackendQualification::Supported
+                } else {
+                    BackendQualification::ContractTarget
+                }
+            );
             // #1164: Metal is a real execution path, qualified for
             // correctness only. CPU stays unsupported — a real capability
             // limit, not a licence gate.
@@ -3523,18 +3536,26 @@ mod tests {
             assert_eq!(contract.task, task);
             assert_eq!(contract.layout, layout);
             assert_eq!(contract.generation.modes, modes);
-            assert!(!contract.generation.runtime_available);
+            let runnable = cfg!(feature = "h3") && task == Task::Fl2va;
+            assert_eq!(contract.generation.runtime_available, runnable);
             assert_eq!(contract.generation.native_batch_sizes, &[1]);
             assert_eq!(
                 contract.generation.backends,
                 BackendApplicability {
-                    cuda: BackendQualification::ContractTarget,
+                    cuda: if runnable {
+                        BackendQualification::Supported
+                    } else {
+                        BackendQualification::ContractTarget
+                    },
                     metal: BackendQualification::CorrectnessOnly,
                     cpu: BackendQualification::Unsupported,
                 }
             );
             assert!(contract.generation.synchronized_audio);
-            assert!(runnable_capability_contract_for_model(model).is_none());
+            assert_eq!(
+                runnable_capability_contract_for_model(model).is_some(),
+                runnable
+            );
             observed_modes.extend_from_slice(modes);
         }
         observed_modes.sort_by_key(|mode| *mode as u8);
@@ -3543,7 +3564,10 @@ mod tests {
 
         for alias in FAMILY_ALIASES {
             assert!(capability_contract_for_model(alias).is_some());
-            assert!(runnable_capability_contract_for_model(alias).is_none());
+            assert_eq!(
+                runnable_capability_contract_for_model(alias).is_some(),
+                cfg!(feature = "h3")
+            );
         }
 
         let advertised = crate::build_model_catalog(&crate::Config::default(), None, false);
@@ -3590,7 +3614,10 @@ mod tests {
             fl_turbo_4,
         ] {
             let contract = manifest_contract(manifest).unwrap();
-            assert!(!contract.runtime_available);
+            assert_eq!(
+                contract.runtime_available,
+                cfg!(feature = "h3") && contract.task == Task::Fl2va
+            );
             assert_eq!(contract.license_url, MINIMAX_H3_LICENSE_URL);
             assert_eq!(contract.license_sha256, LICENSE_SHA256);
             assert_eq!(

--- a/crates/mold-core/src/minimax_h3.rs
+++ b/crates/mold-core/src/minimax_h3.rs
@@ -2551,7 +2551,7 @@ pub(crate) fn manifests() -> Vec<ModelManifest> {
             name: tier.model.to_string(),
             family: FAMILY.to_string(),
             description: format!(
-                "MiniMax H3 FL2VA Comfy pruned INT8-convrot + NVFP4-AWQ with the reviewed {} LoRA (CUDA or Apple Metal)",
+                "MiniMax H3 FL2VA Comfy pruned INT8-convrot + NVFP4-AWQ with the reviewed {} LoRA (downloadable; CUDA or Apple Metal)",
                 tier.display_label
             ),
             files,

--- a/crates/mold-core/src/model_policy.rs
+++ b/crates/mold-core/src/model_policy.rs
@@ -145,6 +145,33 @@ pub fn require_model_activation(
     }
 }
 
+/// Validate one exact source-controlled manifest for runtime use.
+///
+/// A reviewed H3 manifest deliberately contains raw upstream repository and
+/// filename identities that remain forbidden as caller-selected models. Those
+/// locators are safe only when the manifest is the exact static registry
+/// object; a clone or caller-authored lookalike must not self-authorize.
+pub fn require_registered_manifest_activation(
+    manifest: &crate::manifest::ModelManifest,
+) -> Result<(), ModelActivationError> {
+    require_model_activation(&manifest.name, Some(&manifest.family))?;
+    let contains_gated_source = manifest.files.iter().any(|file| {
+        require_model_activation(&file.hf_repo, Some(&manifest.family)).is_err()
+            || require_model_activation(&file.hf_filename, Some(&manifest.family)).is_err()
+    });
+    if !contains_gated_source {
+        return Ok(());
+    }
+    let registered = crate::manifest::find_manifest(&manifest.name);
+    if is_reviewed_minimax_h3_model(&manifest.name)
+        && registered.is_some_and(|registered| std::ptr::eq(registered, manifest))
+    {
+        Ok(())
+    } else {
+        Err(ModelActivationError)
+    }
+}
+
 /// Return the activation state for one concrete model artifact path.
 ///
 /// `artifact_root` is a caller-owned trust boundary such as
@@ -446,5 +473,19 @@ mod tests {
                 ModelActivation::ComplianceGated
             );
         }
+    }
+
+    #[test]
+    fn only_the_registered_h3_manifest_may_bind_its_raw_sources() {
+        let registered = crate::manifest::find_manifest(minimax_h3::FL2VA_COMFY_TURBO_4STEP_768P)
+            .expect("reviewed H3 Turbo manifest");
+        require_registered_manifest_activation(registered)
+            .expect("the exact source-controlled manifest must activate");
+
+        let copied = registered.clone();
+        assert!(require_registered_manifest_activation(&copied).is_err());
+        assert!(
+            require_model_activation("hf:Comfy-Org/MiniMax-H3", Some(minimax_h3::FAMILY),).is_err()
+        );
     }
 }

--- a/crates/mold-core/src/model_policy.rs
+++ b/crates/mold-core/src/model_policy.rs
@@ -237,7 +237,7 @@ fn is_minimax_h3_identity(value: &str) -> bool {
 
 fn is_reviewed_minimax_h3_acquisition_identity(value: &str) -> bool {
     let normalized = value.trim().to_ascii_lowercase();
-    normalized == "minimax-h3" || minimax_h3::is_reviewed_compact_model(&normalized)
+    minimax_h3::resolve_model_name(&normalized).is_some()
 }
 
 pub fn is_reviewed_minimax_h3_model(value: &str) -> bool {
@@ -345,6 +345,19 @@ mod tests {
             model_activation("minimax-h3", Some("minimax-h3")),
             ModelActivation::ComplianceGated
         );
+
+        for official in [minimax_h3::FL2VA_OFFICIAL, minimax_h3::REF2VA_OFFICIAL] {
+            assert_eq!(
+                model_acquisition(official, Some("minimax-h3")),
+                ModelActivation::Available,
+                "{official}"
+            );
+            assert_eq!(
+                model_activation(official, Some("minimax-h3")),
+                ModelActivation::ComplianceGated,
+                "{official}"
+            );
+        }
 
         for unreviewed in [
             "hf:Comfy-Org/MiniMax-H3",
@@ -461,6 +474,16 @@ mod tests {
             assert_eq!(
                 model_activation(reviewed, Some("minimax-h3")),
                 ModelActivation::Available
+            );
+        }
+        for official in [minimax_h3::FL2VA_OFFICIAL, minimax_h3::REF2VA_OFFICIAL] {
+            assert_eq!(
+                model_acquisition(official, Some("minimax-h3")),
+                ModelActivation::Available
+            );
+            assert_eq!(
+                model_activation(official, Some("minimax-h3")),
+                ModelActivation::ComplianceGated
             );
         }
         for unreviewed in [

--- a/crates/mold-core/src/types.rs
+++ b/crates/mold-core/src/types.rs
@@ -8678,6 +8678,17 @@ pub struct PendingModelDownload {
     pub name: String,
     pub repo: String,
     pub bytes: u64,
+    /// Manifest bundle admission will install to materialize this file.
+    ///
+    /// Additive and generic: clients use this as the retry target after any
+    /// outstanding `licenses` are accepted instead of inferring a model name
+    /// from a repository or dependency kind.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub install_model: Option<String>,
+    /// Exact, server-pinned terms that still block this dependency.
+    /// Empty means admission may transparently materialize it on first use.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub licenses: Vec<LicenseRefusal>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]

--- a/crates/mold-inference/src/batch.rs
+++ b/crates/mold-inference/src/batch.rs
@@ -567,7 +567,7 @@ mod tests {
 
     #[test]
     fn production_family_batch_registry_is_explicit_valid_and_singleton_only() {
-        let mut expected = vec![
+        let expected = vec![
             "flux",
             "flux2",
             "sd15",
@@ -582,7 +582,11 @@ mod tests {
             "wuerstchen",
         ];
         #[cfg(feature = "h3")]
-        expected.insert(9, mold_core::minimax_h3::FAMILY);
+        let expected = {
+            let mut expected = expected;
+            expected.insert(9, mold_core::minimax_h3::FAMILY);
+            expected
+        };
         assert_eq!(
             production_batch_capabilities()
                 .iter()

--- a/crates/mold-inference/src/batch.rs
+++ b/crates/mold-inference/src/batch.rs
@@ -373,6 +373,38 @@ const PRODUCTION_FAMILY_CAPABILITIES: &[FamilyBatchCapability] = &[
             "crates/mold-inference/src/ltx_video/pipeline.rs::decode_apng_round_trips_rgb_frames",
         ),
     },
+    #[cfg(feature = "h3")]
+    FamilyBatchCapability {
+        family: mold_core::minimax_h3::FAMILY,
+        aliases: &["minimax_h3", "minimaxh3"],
+        backends: BackendApplicability {
+            cuda: BackendQualification::Supported,
+            metal: BackendQualification::CorrectnessOnly,
+            cpu: BackendQualification::Unsupported,
+        },
+        placement: ComponentPlacementCapability {
+            text_encoder_cpu: true,
+            vae_cpu: false,
+            audio_components_cpu: false,
+        },
+        block_offload: true,
+        tiled_vae: TiledVaeCapability::NativeTemporalChunks,
+        execution: SINGLETON,
+        determinism: EXACT,
+        seed_contract: CPU_SEED,
+        media: MediaKind::Video,
+        workflows: WorkflowCapabilities {
+            source: true,
+            edit_references: false,
+            lora: true,
+            generated_audio: true,
+            chain: false,
+        },
+        tier1: TIER1,
+        tier2: deep(
+            "crates/mold-inference/src/minimax_h3/private_fl2va_runtime.rs::streamed_core_requires_the_bound_backend",
+        ),
+    },
     FamilyBatchCapability {
         family: "ltx2",
         aliases: &["ltx-2", "ltx2.3"],
@@ -535,7 +567,7 @@ mod tests {
 
     #[test]
     fn production_family_batch_registry_is_explicit_valid_and_singleton_only() {
-        let expected = [
+        let mut expected = vec![
             "flux",
             "flux2",
             "sd15",
@@ -549,6 +581,8 @@ mod tests {
             "wan",
             "wuerstchen",
         ];
+        #[cfg(feature = "h3")]
+        expected.insert(9, mold_core::minimax_h3::FAMILY);
         assert_eq!(
             production_batch_capabilities()
                 .iter()

--- a/crates/mold-inference/src/device.rs
+++ b/crates/mold-inference/src/device.rs
@@ -1773,6 +1773,24 @@ pub fn total_system_memory_bytes() -> Option<u64> {
     (ret == 0 && size > 0).then_some(size)
 }
 
+/// Stable unified-memory capacity for an explicitly selected large Metal job.
+///
+/// `free + inactive` is the right immediate-pressure sample for ordinary
+/// scheduling, but it excludes clean active file cache and compressed or
+/// swappable application pages. H3 authenticates ~44 GB of model files before
+/// allocation, so that sample falls sharply from the verification I/O itself
+/// and can make a 48 GB Mac report only ~20 GB even though the reviewed 33.9 GB
+/// runtime fits while retaining the canonical host safety floor. For this
+/// explicit large-model path, use installed unified memory minus the same
+/// `max(15%, 8 GiB)` floor as the host ledger. If installed memory cannot be
+/// queried, retain the live sample unchanged.
+pub fn metal_unified_capacity_with_safety_floor(live_available_bytes: u64) -> u64 {
+    total_system_memory_bytes().map_or(live_available_bytes, |total| {
+        let safety_floor = total.saturating_mul(15).saturating_div(100).max(8 << 30);
+        total.saturating_sub(safety_floor)
+    })
+}
+
 #[cfg(not(target_os = "macos"))]
 pub fn total_system_memory_bytes() -> Option<u64> {
     None
@@ -3296,6 +3314,18 @@ mod tests {
             installed >= available,
             "installed RAM ({installed}) must bound available ({available})"
         );
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn large_metal_capacity_retains_the_canonical_host_safety_floor() {
+        let installed = total_system_memory_bytes().expect("macOS reports installed RAM");
+        let floor = (installed.saturating_mul(15) / 100).max(8 << 30);
+        assert_eq!(
+            metal_unified_capacity_with_safety_floor(1),
+            installed.saturating_sub(floor)
+        );
+        assert!(floor >= 8 << 30);
     }
 
     // --- should_use_gpu: Metal always GPU ---

--- a/crates/mold-inference/src/factory.rs
+++ b/crates/mold-inference/src/factory.rs
@@ -982,10 +982,14 @@ mod tests {
 
     #[test]
     fn frozen_factory_never_calls_h3_loader_before_the_runtime_gate() {
-        for model in [
+        #[cfg(feature = "h3")]
+        let models = vec![mold_core::minimax_h3::REF2VA_COMFY];
+        #[cfg(not(feature = "h3"))]
+        let models = vec![
             mold_core::minimax_h3::FL2VA_COMFY,
             mold_core::minimax_h3::REF2VA_COMFY,
-        ] {
+        ];
+        for model in models {
             let mut frozen = FrozenEngineConfig::resolve(model, &Config::default());
             frozen.family = mold_core::minimax_h3::FAMILY.to_string();
             frozen.h3_factory_authority = Some(h3_factory_authority(&frozen, model));
@@ -1020,9 +1024,16 @@ mod tests {
         for alias in mold_core::minimax_h3::FAMILY_ALIASES {
             assert_eq!(
                 factory_family_availability(alias),
-                Some(FactoryFamilyAvailability::ContractOnly)
+                Some(if cfg!(feature = "h3") {
+                    FactoryFamilyAvailability::Runnable
+                } else {
+                    FactoryFamilyAvailability::ContractOnly
+                })
             );
-            assert!(crate::production_family_capability_for_family(alias).is_none());
+            assert_eq!(
+                crate::production_family_capability_for_family(alias).is_some(),
+                cfg!(feature = "h3")
+            );
         }
         assert_eq!(
             factory_family_availability("flux"),

--- a/crates/mold-inference/src/h3_factory.rs
+++ b/crates/mold-inference/src/h3_factory.rs
@@ -68,16 +68,12 @@ impl H3FactoryComponentAuthority {
 
 /// Where the scheduler placed the Qwen conditioner for one frozen attempt.
 ///
-/// `AssignedCudaThenDrop` is CUDA-named on purpose and is NOT auto-mapped onto
-/// Apple Silicon. A Metal route reaches this enum with
-/// `compute_capability: None`, and silently reading a CUDA-named placement as
-/// `MetalResident` would freeze a plan whose recorded intent nobody wrote --
-/// so the pair is refused at construction instead (#1164). A Metal
-/// device-resident conditioner needs its own variant, added when Metal
-/// execution is qualified and something actually places one.
+/// CUDA and Metal use distinct device-resident variants so a frozen authority
+/// can never silently cross backend classes.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum H3FactoryConditionerPlacement {
     AssignedCudaThenDrop,
+    AssignedMetalThenDrop,
     HostCpuThenDrop,
 }
 
@@ -1432,7 +1428,8 @@ impl H3FactoryPreparedAttemptAuthority {
             || self.target_budget.qwen_retained_header_host_bytes
                 != projection.qwen_retained_raw_header_bytes
             || match projection.conditioner_placement {
-                H3FactoryConditionerPlacement::AssignedCudaThenDrop => {
+                H3FactoryConditionerPlacement::AssignedCudaThenDrop
+                | H3FactoryConditionerPlacement::AssignedMetalThenDrop => {
                     self.target_budget.qwen_activation_device_bytes
                         != projection.qwen_activation_workspace_bytes
                 }
@@ -2615,7 +2612,8 @@ fn validate_target_budget(
         "H3 VAE load phase",
     )?;
     let qwen_encode = match conditioner_placement {
-        H3FactoryConditionerPlacement::AssignedCudaThenDrop => checked_u64_sum(
+        H3FactoryConditionerPlacement::AssignedCudaThenDrop
+        | H3FactoryConditionerPlacement::AssignedMetalThenDrop => checked_u64_sum(
             [
                 memory.fixed_runtime_device_bytes,
                 retained_vaes,
@@ -2631,7 +2629,8 @@ fn validate_target_budget(
         )?,
     };
     let qwen_transfer = match conditioner_placement {
-        H3FactoryConditionerPlacement::AssignedCudaThenDrop => 0,
+        H3FactoryConditionerPlacement::AssignedCudaThenDrop
+        | H3FactoryConditionerPlacement::AssignedMetalThenDrop => 0,
         H3FactoryConditionerPlacement::HostCpuThenDrop => checked_u64_sum(
             [
                 memory.fixed_runtime_device_bytes,
@@ -3168,7 +3167,8 @@ fn validate_target_budget(
         predicted_device
     );
     match conditioner_placement {
-        H3FactoryConditionerPlacement::AssignedCudaThenDrop => {
+        H3FactoryConditionerPlacement::AssignedCudaThenDrop
+        | H3FactoryConditionerPlacement::AssignedMetalThenDrop => {
             expect!(
                 "qwen_host_parameter_bytes (cuda placement)",
                 memory.qwen_host_parameter_bytes != 0
@@ -4114,27 +4114,26 @@ impl FrozenH3FactoryAuthority {
                 })
                 .collect::<Result<Vec<_>>>()?,
         )?;
-        // A CUDA-named placement on a route with no compute capability is a
-        // Metal route wearing a CUDA plan: the conditioner would freeze as
-        // `CudaResident`, hash into the authority identity as `qwen-cuda`, and
-        // then be validated only for device-id equality -- which a Metal
-        // device id satisfies. Refuse it rather than translate it.
-        if input.compute_capability.is_none()
-            && input.conditioner_placement == H3FactoryConditionerPlacement::AssignedCudaThenDrop
+        if (input.compute_capability.is_none()
+            && input.conditioner_placement == H3FactoryConditionerPlacement::AssignedCudaThenDrop)
+            || (input.compute_capability.is_some()
+                && input.conditioner_placement
+                    == H3FactoryConditionerPlacement::AssignedMetalThenDrop)
         {
-            bail!(
-                "MiniMax H3 Metal route cannot freeze the CUDA-assigned conditioner placement; \
-                 Metal has no device-resident conditioner placement yet"
-            );
+            bail!("MiniMax H3 conditioner placement does not match its frozen backend");
         }
         let conditioner_execution = match input.conditioner_placement {
             H3FactoryConditionerPlacement::AssignedCudaThenDrop => {
                 H3ConditionerExecution::CudaResident
             }
+            H3FactoryConditionerPlacement::AssignedMetalThenDrop => {
+                H3ConditionerExecution::MetalResident
+            }
             H3FactoryConditionerPlacement::HostCpuThenDrop => H3ConditionerExecution::CpuOffloaded,
         };
         let conditioner_device = match input.conditioner_placement {
-            H3FactoryConditionerPlacement::AssignedCudaThenDrop => input.device_id.clone(),
+            H3FactoryConditionerPlacement::AssignedCudaThenDrop
+            | H3FactoryConditionerPlacement::AssignedMetalThenDrop => input.device_id.clone(),
             H3FactoryConditionerPlacement::HostCpuThenDrop => "cpu".to_string(),
         };
         let conditioner_placement = FrozenH3ConditionerPlacement::new(
@@ -4799,6 +4798,7 @@ fn frozen_identity(authority: &FrozenH3FactoryAuthority) -> String {
     hash.update(authority.device_ordinal.to_le_bytes());
     hash.update(match authority.conditioner_placement {
         H3FactoryConditionerPlacement::AssignedCudaThenDrop => b"qwen-cuda".as_slice(),
+        H3FactoryConditionerPlacement::AssignedMetalThenDrop => b"qwen-metal".as_slice(),
         H3FactoryConditionerPlacement::HostCpuThenDrop => b"qwen-cpu".as_slice(),
     });
     hash.update(authority.qwen_parameter_bytes.to_le_bytes());

--- a/crates/mold-inference/src/h3_factory.rs
+++ b/crates/mold-inference/src/h3_factory.rs
@@ -4115,13 +4115,15 @@ impl FrozenH3FactoryAuthority {
                 })
                 .collect::<Result<Vec<_>>>()?,
         )?;
-        if (input.compute_capability.is_none()
-            && input.conditioner_placement == H3FactoryConditionerPlacement::AssignedCudaThenDrop)
-            || (input.compute_capability.is_some()
-                && input.conditioner_placement
-                    == H3FactoryConditionerPlacement::AssignedMetalThenDrop)
+        if input.compute_capability.is_none()
+            && input.conditioner_placement == H3FactoryConditionerPlacement::AssignedCudaThenDrop
         {
-            bail!("MiniMax H3 conditioner placement does not match its frozen backend");
+            bail!("MiniMax H3 CUDA conditioner placement does not match its frozen Metal backend");
+        }
+        if input.compute_capability.is_some()
+            && input.conditioner_placement == H3FactoryConditionerPlacement::AssignedMetalThenDrop
+        {
+            bail!("MiniMax H3 Metal conditioner placement does not match its frozen CUDA backend");
         }
         let conditioner_execution = match input.conditioner_placement {
             H3FactoryConditionerPlacement::AssignedCudaThenDrop => {
@@ -6805,9 +6807,12 @@ mod tests {
         assert!(frozen
             .validate_engine_seam(contract::FL2VA_COMFY_TURBO_4STEP_768P, 0, true)
             .is_ok());
-        assert!(frozen
-            .validate_engine_seam(contract::FL2VA_COMFY, 0, true)
-            .is_err());
+        assert_eq!(
+            frozen
+                .validate_engine_seam(contract::FL2VA_COMFY, 0, true)
+                .is_ok(),
+            cfg!(feature = "h3-private-uat")
+        );
         assert!(!media_model_matches_h3_authority(
             contract::FL2VA_COMFY_TURBO_8STEP,
             &frozen

--- a/crates/mold-inference/src/h3_factory.rs
+++ b/crates/mold-inference/src/h3_factory.rs
@@ -4618,7 +4618,7 @@ impl FrozenH3FactoryAuthority {
         self.validate_frozen()?;
         let request_contract = contract::capability_contract_for_model(model)
             .ok_or_else(|| anyhow!("{model:?} has no MiniMax H3 capability contract"))?;
-        if request_contract.canonical_model != self.canonical_model()
+        if !media_model_matches_h3_authority(model, self)
             || request_contract.task != self.task()
             || gpu_ordinal != self.device_ordinal
             || offload != self.block_offload
@@ -4757,7 +4757,7 @@ impl FrozenH3FactoryAuthority {
         let request_contract = contract::capability_contract_for_model(model)
             .ok_or_else(|| anyhow!("{model:?} has no MiniMax H3 capability contract"))?;
         if !contract::is_family(family)
-            || request_contract.canonical_model != self.canonical_model()
+            || !media_model_matches_h3_authority(model, self)
             || request_contract.task != self.task()
             || gpu_ordinal != self.device_ordinal
             || offload != self.block_offload
@@ -6802,6 +6802,12 @@ mod tests {
             contract::FL2VA_COMFY_TURBO_4STEP_768P,
             &frozen
         ));
+        assert!(frozen
+            .validate_engine_seam(contract::FL2VA_COMFY_TURBO_4STEP_768P, 0, true)
+            .is_ok());
+        assert!(frozen
+            .validate_engine_seam(contract::FL2VA_COMFY, 0, true)
+            .is_err());
         assert!(!media_model_matches_h3_authority(
             contract::FL2VA_COMFY_TURBO_8STEP,
             &frozen

--- a/crates/mold-inference/src/h3_factory.rs
+++ b/crates/mold-inference/src/h3_factory.rs
@@ -3940,6 +3940,7 @@ impl FrozenH3FactoryAuthority {
     pub fn new_contract_only(input: H3FactoryAuthorityInput) -> Result<Self> {
         let model_contract = contract::capability_contract_for_model(&input.model)
             .ok_or_else(|| anyhow!("{:?} has no MiniMax H3 capability contract", input.model))?;
+        #[cfg(not(feature = "h3"))]
         if model_contract.generation.runtime_available {
             bail!(
                 "contract-only MiniMax H3 factory authority cannot be created for a runnable contract"

--- a/crates/mold-inference/src/minimax_h3/backend.rs
+++ b/crates/mold-inference/src/minimax_h3/backend.rs
@@ -389,7 +389,7 @@ impl FrozenH3Fl2VaCandlePlan {
             bail!("MiniMax H3 backend model, task, or layout authority changed after freezing");
         }
         if self.device_id.trim().is_empty() {
-            bail!("MiniMax H3 backend requires one frozen CUDA device ID");
+            bail!("MiniMax H3 backend requires one frozen GPU device ID");
         }
         self.backend.validate()?;
         require_sha256(&self.execution_fingerprint, "H3 scheduler execution")?;

--- a/crates/mold-inference/src/minimax_h3/private_fl2va_runtime.rs
+++ b/crates/mold-inference/src/minimax_h3/private_fl2va_runtime.rs
@@ -751,10 +751,12 @@ where
     ) -> Result<Self> {
         let kind = if execution_authority.device().is_cuda() {
             H3PipelineBackendKind::Cuda
+        } else if execution_authority.device().is_metal() {
+            H3PipelineBackendKind::Metal
         } else if cfg!(test) && execution_authority.device().is_cpu() {
             H3PipelineBackendKind::SyntheticCpu
         } else {
-            bail!("private MiniMax H3 streamed core requires one CUDA execution device");
+            bail!("private MiniMax H3 streamed core requires one CUDA or Metal execution device");
         };
         let frozen_identity = H3PipelineBackendIdentity {
             kind,
@@ -1040,16 +1042,21 @@ fn validate_private_execution_route_facts(
         },
         None => H3AttentionDevice::Metal,
     };
+    let expected_location = match admitted.compute_capability {
+        Some(_) => DeviceLocation::Cuda {
+            gpu_id: admitted.device_ordinal,
+        },
+        None => DeviceLocation::Metal {
+            gpu_id: admitted.device_ordinal,
+        },
+    };
     if !actual.active
         || actual.lease_id.trim().is_empty()
         || actual.device_id != admitted.device_id
         || actual.execution_fingerprint != admitted.execution_fingerprint
         || actual.backend
             != H3CandleBackendDevice::from_compute_capability(admitted.compute_capability)
-        || actual.location
-            != (DeviceLocation::Cuda {
-                gpu_id: admitted.device_ordinal,
-            })
+        || actual.location != expected_location
         || admitted.attention.device != expected_attention_device
         || actual.attention_device != admitted.attention.device
     {

--- a/crates/mold-inference/src/minimax_h3/private_opened_evidence.rs
+++ b/crates/mold-inference/src/minimax_h3/private_opened_evidence.rs
@@ -499,9 +499,9 @@ fn private_comfy_manifest(task: Task) -> Result<&'static ModelManifest> {
         || manifest.family != contract::FAMILY
         || manifest_contract.task != task
         || manifest_contract.layout != Layout::ComfyPrunedInt8ConvrotNvfp4Awq
-        || manifest_contract.runtime_available
+        || (!cfg!(feature = "h3") && manifest_contract.runtime_available)
     {
-        bail!("private H3 storage requires the exact inactive {expected_model} Comfy manifest")
+        bail!("private H3 storage requires the exact {expected_model} Comfy manifest")
     }
     Ok(manifest)
 }

--- a/crates/mold-inference/src/minimax_h3/private_qualification.rs
+++ b/crates/mold-inference/src/minimax_h3/private_qualification.rs
@@ -841,12 +841,11 @@ fn qualification_manifest(
         || manifest.family != contract::FAMILY
         || authority.task != task
         || authority.layout != contract::Layout::ComfyPrunedInt8ConvrotNvfp4Awq
-        || authority.runtime_available
+        || (!cfg!(feature = "h3") && authority.runtime_available)
     {
-        bail!(
-            "private H3 artifact qualification requires the exact inactive compact family manifest"
-        )
+        bail!("private H3 artifact qualification requires the exact compact family manifest")
     }
+    #[cfg(not(feature = "h3"))]
     if contract::capabilities(task).runtime_available {
         bail!("private artifact qualification refuses an already-active public H3 runtime")
     }

--- a/crates/mold-inference/src/minimax_h3/private_qwen.rs
+++ b/crates/mold-inference/src/minimax_h3/private_qwen.rs
@@ -42,10 +42,11 @@ const QWEN_VISION_LAYER_COUNT: usize = 27;
 const QWEN_VISION_CHECKPOINTS_PER_PASS: usize = 1 + QWEN_VISION_LAYER_COUNT;
 
 /// Private admission route used to derive the exact retained representation
-/// before a concrete CUDA device is created.
+/// before a concrete accelerator device is created.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum H3PrivateQwenLoaderMemoryRoute {
     Cuda,
+    Metal,
     Cpu,
 }
 
@@ -101,6 +102,9 @@ impl H3PrivateQwenOpenRouteAuthority {
             H3FactoryConditionerPlacement::AssignedCudaThenDrop => {
                 H3PrivateQwenLoaderMemoryRoute::Cuda
             }
+            H3FactoryConditionerPlacement::AssignedMetalThenDrop => {
+                H3PrivateQwenLoaderMemoryRoute::Metal
+            }
             H3FactoryConditionerPlacement::HostCpuThenDrop => H3PrivateQwenLoaderMemoryRoute::Cpu,
         };
         let placement = route.placement();
@@ -151,6 +155,9 @@ impl H3PrivateQwenOpenRouteAuthority {
             H3FactoryConditionerPlacement::AssignedCudaThenDrop => {
                 H3PrivateQwenLoaderMemoryRoute::Cuda
             }
+            H3FactoryConditionerPlacement::AssignedMetalThenDrop => {
+                H3PrivateQwenLoaderMemoryRoute::Metal
+            }
             H3FactoryConditionerPlacement::HostCpuThenDrop => H3PrivateQwenLoaderMemoryRoute::Cpu,
         };
         let expected_memory =
@@ -184,7 +191,7 @@ impl H3PrivateQwenOpenRouteAuthority {
 impl H3PrivateQwenLoaderMemoryRoute {
     const fn placement(self) -> H3QwenNvfp4RuntimePlacement {
         match self {
-            Self::Cuda => H3QwenNvfp4RuntimePlacement::Accelerated,
+            Self::Cuda | Self::Metal => H3QwenNvfp4RuntimePlacement::Accelerated,
             Self::Cpu => H3QwenNvfp4RuntimePlacement::Cpu,
         }
     }
@@ -196,7 +203,9 @@ pub fn released_h3_private_qwen_loader_memory_authority(
     route: H3PrivateQwenLoaderMemoryRoute,
 ) -> Result<H3PrivateQwenLoaderMemoryAuthority> {
     let placement = match route {
-        H3PrivateQwenLoaderMemoryRoute::Cuda => H3QwenNvfp4RuntimePlacement::Accelerated,
+        H3PrivateQwenLoaderMemoryRoute::Cuda | H3PrivateQwenLoaderMemoryRoute::Metal => {
+            H3QwenNvfp4RuntimePlacement::Accelerated
+        }
         H3PrivateQwenLoaderMemoryRoute::Cpu => H3QwenNvfp4RuntimePlacement::Cpu,
     };
     let facts = released_h3_qwen_nvfp4_runtime_memory_facts_for_placement(placement)?;
@@ -224,7 +233,9 @@ pub fn validate_h3_private_qwen_loader_memory_authority(
     route: H3PrivateQwenLoaderMemoryRoute,
 ) -> Result<()> {
     let placement = match route {
-        H3PrivateQwenLoaderMemoryRoute::Cuda => H3QwenNvfp4RuntimePlacement::Accelerated,
+        H3PrivateQwenLoaderMemoryRoute::Cuda | H3PrivateQwenLoaderMemoryRoute::Metal => {
+            H3QwenNvfp4RuntimePlacement::Accelerated
+        }
         H3PrivateQwenLoaderMemoryRoute::Cpu => H3QwenNvfp4RuntimePlacement::Cpu,
     };
     let facts = released_h3_qwen_nvfp4_runtime_memory_facts_for_placement(placement)?;
@@ -912,8 +923,10 @@ struct LeaseBindingClaims {
     loaded_matches_conditioner_device: bool,
     conditioner_is_cpu: bool,
     conditioner_is_cuda: bool,
+    conditioner_is_metal: bool,
     conditioner_matches_execution_device: bool,
     execution_is_cuda: bool,
+    execution_is_metal: bool,
 }
 
 fn frozen_binding_claims(authority: &FrozenH3FactoryAuthority) -> Result<FrozenBindingClaims> {
@@ -980,8 +993,10 @@ where
         loaded_matches_conditioner_device,
         conditioner_is_cpu: conditioner.device().is_cpu(),
         conditioner_is_cuda: conditioner.device().is_cuda(),
+        conditioner_is_metal: conditioner.device().is_metal(),
         conditioner_matches_execution_device: conditioner.device().same_device(execution.device()),
         execution_is_cuda: execution.device().is_cuda(),
+        execution_is_metal: execution.device().is_metal(),
     }
 }
 
@@ -1025,7 +1040,8 @@ fn validate_parameter_memory(
         )
     }
     let residency_is_bound = match authority.conditioner_placement() {
-        H3FactoryConditionerPlacement::AssignedCudaThenDrop => {
+        H3FactoryConditionerPlacement::AssignedCudaThenDrop
+        | H3FactoryConditionerPlacement::AssignedMetalThenDrop => {
             facts.host_resident_parameter_bytes > 0 && facts.device_resident_parameter_bytes > 0
         }
         H3FactoryConditionerPlacement::HostCpuThenDrop => {
@@ -1141,6 +1157,11 @@ where
                 && conditioner.device().is_cuda()
                 && conditioner.device().same_device(execution.device())
         }
+        H3FactoryConditionerPlacement::AssignedMetalThenDrop => {
+            conditioner.device_id() == authority.device_id()
+                && conditioner.device().is_metal()
+                && conditioner.device().same_device(execution.device())
+        }
         H3FactoryConditionerPlacement::HostCpuThenDrop => {
             conditioner.device_id() == "cpu" && conditioner.device().is_cpu()
         }
@@ -1246,6 +1267,11 @@ fn validate_binding(
                 && leases.conditioner_is_cuda
                 && leases.conditioner_matches_execution_device
         }
+        H3FactoryConditionerPlacement::AssignedMetalThenDrop => {
+            leases.conditioner_device_id == frozen.device_id
+                && leases.conditioner_is_metal
+                && leases.conditioner_matches_execution_device
+        }
         H3FactoryConditionerPlacement::HostCpuThenDrop => {
             leases.conditioner_device_id == "cpu" && leases.conditioner_is_cpu
         }
@@ -1260,9 +1286,12 @@ fn validate_binding(
         || leases.execution_device_id != frozen.device_id
         || leases.execution_fingerprint != frozen.execution_fingerprint
         || leases.execution_backend != expected_backend
-        || !leases.execution_is_cuda
+        || match expected_backend {
+            H3CandleBackendDevice::Cuda { .. } => !leases.execution_is_cuda,
+            H3CandleBackendDevice::Metal => !leases.execution_is_metal,
+        }
     {
-        bail!("private H3 Qwen execution lease differs from the frozen CUDA route")
+        bail!("private H3 Qwen execution lease differs from the frozen GPU route")
     }
     if !leases.artifact_active {
         bail!("private H3 Qwen artifact lease was revoked")
@@ -1939,8 +1968,10 @@ mod tests {
             loaded_matches_conditioner_device: true,
             conditioner_is_cpu: false,
             conditioner_is_cuda: true,
+            conditioner_is_metal: false,
             conditioner_matches_execution_device: true,
             execution_is_cuda: true,
+            execution_is_metal: false,
         };
         (loaded, frozen, leases)
     }

--- a/crates/mold-inference/src/minimax_h3/private_qwen_support.rs
+++ b/crates/mold-inference/src/minimax_h3/private_qwen_support.rs
@@ -329,9 +329,9 @@ fn production_support_contracts(model: &str) -> Result<Vec<SupportFileContract>>
         || manifest.family != contract::FAMILY
         || manifest_authority.task != task
         || manifest_authority.layout != Layout::ComfyPrunedInt8ConvrotNvfp4Awq
-        || manifest_authority.runtime_available
+        || (!cfg!(feature = "h3") && manifest_authority.runtime_available)
     {
-        bail!("private H3 Qwen support requires the exact inactive Comfy manifest")
+        bail!("private H3 Qwen support requires the exact Comfy manifest")
     }
 
     let mut contracts = Vec::with_capacity(SupportRole::ALL.len());

--- a/crates/mold-inference/src/minimax_h3/private_server.rs
+++ b/crates/mold-inference/src/minimax_h3/private_server.rs
@@ -7723,7 +7723,7 @@ mod tests {
             &artifact_report(),
             DEVICE_0,
             0,
-            Some((8, 9)),
+            (8, 9),
             &runtime_identity,
             kernel.identity(),
             &runtime_identity,

--- a/crates/mold-inference/src/minimax_h3/private_server.rs
+++ b/crates/mold-inference/src/minimax_h3/private_server.rs
@@ -168,14 +168,15 @@ pub const fn reviewed_h3_private_runtime_available_for_task(task: Task) -> bool 
     }
 }
 
-/// One scheduler-visible CUDA route eligible for authenticated private H3
+/// One scheduler-visible GPU route eligible for authenticated H3
 /// capability presentation. Supplying this record grants nothing: the
 /// source-controlled runtime record must match it exactly.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct H3PrivatePresentationRoute<'a> {
     pub device_id: &'a str,
     pub device_ordinal: usize,
-    pub compute_capability: (u16, u16),
+    /// `Some` identifies an exact CUDA architecture; `None` identifies Metal.
+    pub compute_capability: Option<(u16, u16)>,
 }
 
 /// Payload-free proof that the exact reviewed FL2VA qualification, external
@@ -187,7 +188,7 @@ pub struct H3PrivatePresentationAuthority {
     task: Task,
     device_id: String,
     device_ordinal: usize,
-    compute_capability: (u16, u16),
+    compute_capability: Option<(u16, u16)>,
 }
 
 impl H3PrivatePresentationAuthority {
@@ -207,7 +208,7 @@ impl H3PrivatePresentationAuthority {
         self.device_ordinal
     }
 
-    pub const fn compute_capability(&self) -> (u16, u16) {
+    pub const fn compute_capability(&self) -> Option<(u16, u16)> {
         self.compute_capability
     }
 }
@@ -1039,7 +1040,8 @@ pub struct H3PrivateFl2VaAdmissionInput<'a> {
     pub paths: H3PrivateFl2VaUatPaths<'a>,
     pub device_id: &'a str,
     pub device_ordinal: usize,
-    pub compute_capability: (u16, u16),
+    /// `Some` identifies an exact CUDA architecture; `None` identifies Metal.
+    pub compute_capability: Option<(u16, u16)>,
     pub available_device_bytes: u64,
     /// Host RAM available after the server's canonical 15%-or-8-GiB safety
     /// floor, never the raw operating-system available-memory sample.
@@ -1164,7 +1166,7 @@ pub struct H3PrivateFl2VaAdmissionEvidence {
     mode: Mode,
     device_id: String,
     device_ordinal: usize,
-    compute_capability: (u16, u16),
+    compute_capability: Option<(u16, u16)>,
     admitted_available_device_bytes: u64,
     admitted_host_headroom_bytes: u64,
     base_factory_authority: FrozenH3FactoryAuthority,
@@ -1207,7 +1209,7 @@ impl H3PrivateFl2VaAdmissionEvidence {
         self.device_ordinal
     }
 
-    pub const fn compute_capability(&self) -> (u16, u16) {
+    pub const fn compute_capability(&self) -> Option<(u16, u16)> {
         self.compute_capability
     }
 
@@ -1295,7 +1297,7 @@ impl H3PrivateFl2VaAdmissionEvidence {
         Ok(resolved)
     }
 
-    /// Revalidate this immutable DTO against an exact request and CUDA route.
+    /// Revalidate this immutable DTO against an exact request and GPU route.
     /// Current capacity may differ from the admission snapshot, but both
     /// current values must still cover the canonical target peaks.
     #[allow(clippy::too_many_arguments)]
@@ -1304,7 +1306,7 @@ impl H3PrivateFl2VaAdmissionEvidence {
         request: &GenerateRequest,
         device_id: &str,
         device_ordinal: usize,
-        compute_capability: (u16, u16),
+        compute_capability: Option<(u16, u16)>,
         available_device_bytes: u64,
         available_host_headroom_bytes: u64,
     ) -> Result<()> {
@@ -1338,10 +1340,7 @@ impl H3PrivateFl2VaAdmissionEvidence {
             || self.base_factory_authority.task() != self.task
             || self.base_factory_authority.device_id() != self.device_id
             || self.base_factory_authority.device_ordinal() != self.device_ordinal
-            // The public runtime profile is CUDA SM89 only, so a Metal factory
-            // authority (which carries no compute capability) can never match
-            // here and fails closed without a separate branch.
-            || self.base_factory_authority.compute_capability() != Some(self.compute_capability)
+            || self.base_factory_authority.compute_capability() != self.compute_capability
             || self.base_factory_authority.execution_fingerprint() != self.execution_fingerprint
             || self.base_factory_authority.component_set_identity_sha256()
                 != self.component_set_identity_sha256
@@ -1449,11 +1448,11 @@ fn prepare_reviewed_h3_private_fl2va_admission(
         available_host_headroom_bytes,
     } = input;
     if device_id.trim().is_empty()
-        || compute_capability.0 == 0
+        || compute_capability.is_some_and(|capability| capability.0 == 0)
         || available_device_bytes == 0
         || available_host_headroom_bytes == 0
     {
-        bail!("private H3 admission requires one concrete nonempty CUDA capacity sample")
+        bail!("private H3 admission requires one concrete nonempty GPU capacity sample")
     }
     // The admitted route is derived once, from the request model's own pinned
     // contract, and threaded through every step below. Reading it again from a
@@ -1581,13 +1580,17 @@ fn prepare_reviewed_h3_private_fl2va_admission(
         },
     )?;
 
-    let attention_device = H3AttentionDevice::Cuda {
-        compute_capability: Some(compute_capability),
-    };
     let attention_model = H3AttentionModelContract::released_bf16();
-    let attention =
-        H3AttentionRuntimeAuthority::qualify_flash_attention_v2(attention_device, attention_model)
-            .map_err(|error| anyhow!(error.to_string()))?;
+    let attention = match compute_capability {
+        Some(compute_capability) => H3AttentionRuntimeAuthority::qualify_flash_attention_v2(
+            H3AttentionDevice::Cuda {
+                compute_capability: Some(compute_capability),
+            },
+            attention_model,
+        ),
+        None => H3AttentionRuntimeAuthority::metal_chunked_dense(attention_model),
+    }
+    .map_err(|error| anyhow!(error.to_string()))?;
     #[cfg(feature = "h3")]
     let attention_qualification_sha256 = attention.identity_sha256().to_string();
     #[cfg(not(feature = "h3"))]
@@ -1617,11 +1620,14 @@ fn prepare_reviewed_h3_private_fl2va_admission(
     let turbo_adapter =
         super::turbo::resolve_turbo_authority_for_request(admitted_model, paths.models_root)?;
     #[cfg(not(feature = "h3"))]
+    let private_compute_capability = compute_capability
+        .ok_or_else(|| anyhow!("private H3 reviewed evidence requires one concrete CUDA route"))?;
+    #[cfg(not(feature = "h3"))]
     let runtime_qualification = runtime_qualification_source.authenticate(
         &artifact_report,
         device_id,
         device_ordinal,
-        compute_capability,
+        private_compute_capability,
         attention.identity_sha256(),
         attention.kernel().identity(),
         &attention_qualification_sha256,
@@ -1719,10 +1725,7 @@ fn prepare_reviewed_h3_private_fl2va_admission(
             model: partition_model.into(),
             device_id: device_id.into(),
             device_ordinal,
-            // The public H3 runtime profile is CUDA SM89, so this is always a
-            // CUDA route; the factory input is optional only because a Metal
-            // plan carries no compute capability.
-            compute_capability: Some(compute_capability),
+            compute_capability,
             execution_fingerprint: execution_fingerprint.clone(),
             conditioner_placement: H3FactoryConditionerPlacement::HostCpuThenDrop,
             qwen_parameter_bytes: qwen_memory.source_parameter_bytes,
@@ -1744,7 +1747,11 @@ fn prepare_reviewed_h3_private_fl2va_admission(
             condition_visual_rows: admission_request.request.rows.condition_visual_rows,
             resident_block_count: 0,
             prefetch_depth: 0,
-            attention_backend: AttentionBackend::Flash,
+            attention_backend: if compute_capability.is_some() {
+                AttentionBackend::Flash
+            } else {
+                AttentionBackend::Math
+            },
             attention_chunk: AttentionChunkPolicy::Off,
             attention_kernel_identity: attention.kernel().identity().into(),
             attention_qualification_sha256: attention_qualification_sha256.clone(),
@@ -1770,7 +1777,7 @@ fn prepare_reviewed_h3_private_fl2va_admission(
         &qwen_support,
         device_id,
         device_ordinal,
-        Some(compute_capability),
+        compute_capability,
         &qwen_artifact.sha256,
         qwen_header_identity,
         qwen_policy_identity,
@@ -2116,7 +2123,7 @@ fn private_h3_admission_execution_fingerprint(
     runtime_qualification_identity_sha256: &str,
     device_id: &str,
     device_ordinal: usize,
-    compute_capability: (u16, u16),
+    compute_capability: Option<(u16, u16)>,
     attention_runtime_identity_sha256: &str,
     components: &[H3PrivateComponentDigest],
 ) -> String {
@@ -2138,8 +2145,14 @@ fn private_h3_admission_execution_fingerprint(
         update_string(&mut digest, value);
     }
     digest.update((device_ordinal as u64).to_le_bytes());
-    digest.update(compute_capability.0.to_le_bytes());
-    digest.update(compute_capability.1.to_le_bytes());
+    match compute_capability {
+        Some((major, minor)) => {
+            digest.update(b"cuda\0");
+            digest.update(major.to_le_bytes());
+            digest.update(minor.to_le_bytes());
+        }
+        None => digest.update(b"metal\0"),
+    }
     for component in components {
         update_string(&mut digest, private_h3_component_role_id(component.role));
         update_string(&mut digest, &component.content_sha256);
@@ -2199,10 +2212,15 @@ fn private_h3_admission_evidence_identity(evidence: &H3PrivateFl2VaAdmissionEvid
         Task::Fl2va => b"fl2va".as_slice(),
         Task::Ref2va => b"ref2va".as_slice(),
     });
+    let (backend, major, minor) = match evidence.compute_capability {
+        Some((major, minor)) => (1, u64::from(major), u64::from(minor)),
+        None => (2, 0, 0),
+    };
     for value in [
         evidence.device_ordinal as u64,
-        u64::from(evidence.compute_capability.0),
-        u64::from(evidence.compute_capability.1),
+        backend,
+        major,
+        minor,
         evidence.admitted_available_device_bytes,
         evidence.admitted_host_headroom_bytes,
         evidence.predicted_device_peak_bytes,
@@ -2256,7 +2274,8 @@ pub struct H3PrivateFl2VaOwnerFenceFacts {
     pub cancellation_scope_identity_sha256: String,
     pub device_id: String,
     pub device_ordinal: usize,
-    pub compute_capability: (u16, u16),
+    /// `Some` identifies an exact CUDA architecture; `None` identifies Metal.
+    pub compute_capability: Option<(u16, u16)>,
     pub memory_ledger_sequence: u64,
     pub admission_evidence_identity_sha256: String,
     pub artifact_qualification_identity_sha256: String,
@@ -2270,7 +2289,9 @@ pub struct H3PrivateFl2VaOwnerFenceFacts {
 impl H3PrivateFl2VaOwnerFenceFacts {
     pub fn validate(&self) -> Result<()> {
         if self.device_id.trim().is_empty()
-            || self.compute_capability.0 == 0
+            || self
+                .compute_capability
+                .is_some_and(|capability| capability.0 == 0)
             || self.memory_ledger_sequence == 0
             || self.predicted_device_peak_bytes == 0
             || self.predicted_host_increment_bytes == 0
@@ -2619,10 +2640,14 @@ fn prepare_reviewed_h3_private_fl2va_attempt(
         paths.runtime_qualification_record,
     )?;
     #[cfg(not(feature = "h3"))]
+    let private_compute_capability = owner_fence
+        .compute_capability
+        .ok_or_else(|| anyhow!("private H3 reviewed evidence requires one concrete CUDA route"))?;
+    #[cfg(not(feature = "h3"))]
     runtime_qualification_source.validate_route(
         &owner_fence.device_id,
         owner_fence.device_ordinal,
-        owner_fence.compute_capability,
+        private_compute_capability,
     )?;
 
     let artifact_report = qualify_private_artifacts_with_control(
@@ -2647,13 +2672,17 @@ fn prepare_reviewed_h3_private_fl2va_attempt(
     }
     progress.checkpoint()?;
 
-    let attention_device = H3AttentionDevice::Cuda {
-        compute_capability: Some(owner_fence.compute_capability),
-    };
     let attention_model = H3AttentionModelContract::released_bf16();
-    let attention =
-        H3AttentionRuntimeAuthority::qualify_flash_attention_v2(attention_device, attention_model)
-            .map_err(|error| anyhow!(error.to_string()))?;
+    let attention = match owner_fence.compute_capability {
+        Some(compute_capability) => H3AttentionRuntimeAuthority::qualify_flash_attention_v2(
+            H3AttentionDevice::Cuda {
+                compute_capability: Some(compute_capability),
+            },
+            attention_model,
+        ),
+        None => H3AttentionRuntimeAuthority::metal_chunked_dense(attention_model),
+    }
+    .map_err(|error| anyhow!(error.to_string()))?;
     #[cfg(feature = "h3")]
     let attention_qualification_sha256 = attention.identity_sha256().to_string();
     #[cfg(not(feature = "h3"))]
@@ -2678,7 +2707,7 @@ fn prepare_reviewed_h3_private_fl2va_attempt(
         &artifact_report,
         &owner_fence.device_id,
         owner_fence.device_ordinal,
-        owner_fence.compute_capability,
+        private_compute_capability,
         attention.identity_sha256(),
         attention.kernel().identity(),
         &attention_qualification_sha256,
@@ -2775,7 +2804,7 @@ fn prepare_reviewed_h3_private_fl2va_attempt(
         &qwen_support,
         &owner_fence.device_id,
         owner_fence.device_ordinal,
-        Some(owner_fence.compute_capability),
+        owner_fence.compute_capability,
         &qwen_artifact.sha256,
         qwen_header_identity,
         qwen_policy_identity,
@@ -2945,7 +2974,7 @@ fn validate_base_factory(
         || factory.canonical_model() != contract::base_compact_model_for_task(task)
         || factory.device_id() != owner.device_id
         || factory.device_ordinal() != owner.device_ordinal
-        || factory.compute_capability() != Some(owner.compute_capability)
+        || factory.compute_capability() != owner.compute_capability
         || factory.prepared_target_attempt_identities().is_some()
         || !factory.attention_runtime_identity_sha256().is_empty()
         || factory.attention_backend() != AttentionBackend::Flash
@@ -3668,50 +3697,70 @@ impl H3PrivateFl2VaPreparedRunner for H3PrivateConcretePreparedRunner {
             H3AttentionDevice::Cuda {
                 compute_capability: Some((major, minor)),
             } => [major, minor],
-            device => bail!(
-                "private H3 terminal authority requires a concrete CUDA compute capability, got {device:?}"
-            ),
+            H3AttentionDevice::Metal => [0, 0],
+            device => bail!("private H3 terminal authority requires CUDA or Metal, got {device:?}"),
         };
-        let observed_authority = H3PrivateRuntimeAuthorityObservation {
-            bootstrap_record_sha256: activation.runtime_qualification.record_file_sha256().into(),
-            runtime_qualification_identity_sha256: activation
-                .runtime_qualification
-                .identity_sha256()
-                .into(),
-            device_id: owner.device_id.clone(),
-            device_ordinal: owner.device_ordinal,
-            compute_capability: observed_compute_capability,
-            attention_runtime_identity_sha256: attention.identity_sha256().into(),
-            attention_kernel_identity: attention.kernel().identity().into(),
-            attention_qualification_sha256: artifact_lease.attention_qualification_sha256.clone(),
-            process: capture_process_observation()?,
-        };
+        let observed_authority = authority
+            .compute_capability()
+            .map(|_| {
+                Ok::<_, anyhow::Error>(H3PrivateRuntimeAuthorityObservation {
+                    bootstrap_record_sha256: activation
+                        .runtime_qualification
+                        .record_file_sha256()
+                        .into(),
+                    runtime_qualification_identity_sha256: activation
+                        .runtime_qualification
+                        .identity_sha256()
+                        .into(),
+                    device_id: owner.device_id.clone(),
+                    device_ordinal: owner.device_ordinal,
+                    compute_capability: observed_compute_capability,
+                    attention_runtime_identity_sha256: attention.identity_sha256().into(),
+                    attention_kernel_identity: attention.kernel().identity().into(),
+                    attention_qualification_sha256: artifact_lease
+                        .attention_qualification_sha256
+                        .clone(),
+                    process: capture_process_observation()?,
+                })
+            })
+            .transpose()?;
         with_private_h3_cuda_execution_attempt(|| {
             consumption_binding.revalidate(&owner, &activation.scheduler_ledger)?;
-            let cuda_device = commit_private_h3_allocation_then(&mut allocation_commit, || {
-                Device::new_cuda(owner.device_ordinal)
-                    .context("failed to construct the reviewed private H3 CUDA route")
-            })?;
+            let execution_device =
+                commit_private_h3_allocation_then(&mut allocation_commit, || {
+                    match authority.compute_capability() {
+                        Some(_) => Device::new_cuda(owner.device_ordinal)
+                            .context("failed to construct the reviewed H3 CUDA route"),
+                        None => Device::new_metal(owner.device_ordinal)
+                            .context("failed to construct the H3 Metal route"),
+                    }
+                })?;
             let qwen_on_cpu = matches!(
                 authority.conditioner_placement(),
                 H3FactoryConditionerPlacement::HostCpuThenDrop
             );
-            let runtime_bound_capture = H3PrivateRuntimeBoundCapture::begin(
-                &cuda_device,
-                qwen_on_cpu,
-                observed_envelope,
-                observed_authority,
-            )?;
+            let runtime_bound_capture = observed_authority
+                .map(|authority| {
+                    H3PrivateRuntimeBoundCapture::begin(
+                        &execution_device,
+                        qwen_on_cpu,
+                        observed_envelope,
+                        authority,
+                    )
+                })
+                .transpose()?;
             // Keep one completion fence alive outside the concrete owner graph.
             // It runs only after a successful pipeline result and before any
             // CUDA-bearing local leaves the execution-attempt boundary.
-            let completion_device = cuda_device.clone();
+            let completion_device = execution_device.clone();
             let conditioner_device = match authority.conditioner_placement() {
-                H3FactoryConditionerPlacement::AssignedCudaThenDrop => cuda_device.clone(),
+                H3FactoryConditionerPlacement::AssignedCudaThenDrop
+                | H3FactoryConditionerPlacement::AssignedMetalThenDrop => execution_device.clone(),
                 H3FactoryConditionerPlacement::HostCpuThenDrop => Device::Cpu,
             };
             let conditioner_device_id = match authority.conditioner_placement() {
-                H3FactoryConditionerPlacement::AssignedCudaThenDrop => owner.device_id.clone(),
+                H3FactoryConditionerPlacement::AssignedCudaThenDrop
+                | H3FactoryConditionerPlacement::AssignedMetalThenDrop => owner.device_id.clone(),
                 H3FactoryConditionerPlacement::HostCpuThenDrop => "cpu".into(),
             };
             let conditioner_lease = H3PrivateServerConditionerLease::new(
@@ -3724,7 +3773,7 @@ impl H3PrivateFl2VaPreparedRunner for H3PrivateConcretePreparedRunner {
             );
             let execution_lease = H3PrivateServerExecutionLease::new(
                 &authority,
-                cuda_device,
+                execution_device,
                 &owner.work_identity_sha256,
                 &owner.cancellation_scope_identity_sha256,
                 "runtime-execution",
@@ -3754,12 +3803,14 @@ impl H3PrivateFl2VaPreparedRunner for H3PrivateConcretePreparedRunner {
             cancellation.checkpoint()?;
             progress.checkpoint()?;
             let output = private_run_output(output, owner, &consumption_binding, started)?;
-            let runtime_bound_observation = runtime_bound_capture.finish()?;
-            tracing::info!(
-                target: "mold::minimax_h3::private_runtime_bound",
-                observation = %serde_json::to_string(&runtime_bound_observation)?,
-                "captured private MiniMax H3 runtime bounds"
-            );
+            if let Some(runtime_bound_capture) = runtime_bound_capture {
+                let runtime_bound_observation = runtime_bound_capture.finish()?;
+                tracing::info!(
+                    target: "mold::minimax_h3::private_runtime_bound",
+                    observation = %serde_json::to_string(&runtime_bound_observation)?,
+                    "captured private MiniMax H3 runtime bounds"
+                );
+            }
             Ok(output)
         })
     }
@@ -4404,7 +4455,7 @@ pub struct H3PrivateRuntimeQualificationAuthority {
     bounds: H3PrivateQualifiedRuntimeBounds,
     device_id: String,
     device_ordinal: usize,
-    compute_capability: (u16, u16),
+    compute_capability: Option<(u16, u16)>,
 }
 
 impl std::fmt::Debug for H3PrivateRuntimeQualificationAuthority {
@@ -4438,7 +4489,7 @@ impl H3PrivateRuntimeQualificationAuthority {
         self.device_ordinal
     }
 
-    pub const fn compute_capability(&self) -> (u16, u16) {
+    pub const fn compute_capability(&self) -> Option<(u16, u16)> {
         self.compute_capability
     }
 
@@ -4523,7 +4574,7 @@ impl RuntimeQualificationStorage {
 #[cfg(feature = "h3")]
 const PUBLIC_RUNTIME_PROFILE_SCHEMA: &str = "mold.minimax-h3.public-runtime-profile.v1";
 #[cfg(feature = "h3")]
-const PUBLIC_RUNTIME_PROFILE_DECISION: &str = "supported-compact-fl2va-sm89";
+const PUBLIC_RUNTIME_PROFILE_DECISION: &str = "supported-compact-fl2va-cuda-sm89-or-metal";
 
 /// Margin applied to every measured workspace bound, then rounded up to
 /// [`PUBLIC_RUNTIME_BOUND_GRID_BYTES`].
@@ -4736,11 +4787,11 @@ fn validate_public_runtime_profile_with_turbo(
         || record.decision != PUBLIC_RUNTIME_PROFILE_DECISION
         || record.canonical_model != contract::FL2VA_COMFY
         || record.task != "fl2va"
-        || record.compute_capability != [8, 9]
+        || !matches!(record.compute_capability, [8, 9] | [0, 0])
         || record.identity_sha256 != runtime_qualification_identity(record)
         || profile_sha256 != record.identity_sha256
     {
-        bail!("public H3 runtime profile changed or is not the supported SM89 profile")
+        bail!("public H3 runtime profile changed or is not the supported CUDA/Metal profile")
     }
     Ok(())
 }
@@ -5040,7 +5091,7 @@ fn capture_runtime_qualification(
         bounds,
         device_id: device_id.into(),
         device_ordinal,
-        compute_capability,
+        compute_capability: Some(compute_capability),
     })
 }
 
@@ -5089,7 +5140,7 @@ fn public_runtime_qualification(
     artifact: &H3PrivateArtifactQualificationReport,
     device_id: &str,
     device_ordinal: usize,
-    compute_capability: (u16, u16),
+    compute_capability: Option<(u16, u16)>,
     attention_runtime_identity_sha256: &str,
     attention_kernel_identity: &str,
     attention_qualification_sha256: &str,
@@ -5108,14 +5159,14 @@ fn public_runtime_qualification(
         }
     }
     let turbo_steps = turbo.map(H3FactoryTurboAdapterAuthority::grid_points);
-    if compute_capability != (8, 9)
+    if !matches!(compute_capability, Some((8, 9)) | None)
         || artifact.canonical_model != contract::FL2VA_COMFY
         || artifact.task != "fl2va"
         || !valid_sha256(attention_runtime_identity_sha256)
         || !valid_sha256(attention_qualification_sha256)
         || attention_kernel_identity.is_empty()
     {
-        bail!("public H3 runtime requires the exact compact FL2VA SM89 authority")
+        bail!("public H3 runtime requires the exact compact FL2VA CUDA SM89 or Metal authority")
     }
     let mut record = H3PrivateRuntimeQualificationRecord {
         schema: PUBLIC_RUNTIME_PROFILE_SCHEMA.into(),
@@ -5134,7 +5185,9 @@ fn public_runtime_qualification(
         artifact_total_bytes: artifact.total_bytes,
         device_id: device_id.into(),
         device_ordinal,
-        compute_capability: [8, 9],
+        compute_capability: compute_capability
+            .map(|(major, minor)| [major, minor])
+            .unwrap_or([0, 0]),
         attention_runtime_identity_sha256: attention_runtime_identity_sha256.into(),
         attention_kernel_identity: attention_kernel_identity.into(),
         attention_qualification_sha256: attention_qualification_sha256.into(),
@@ -5273,7 +5326,7 @@ impl H3PrivateReviewedRuntimeQualification {
             bounds,
             device_id: device_id.to_string(),
             device_ordinal,
-            compute_capability,
+            compute_capability: Some(compute_capability),
         };
         authority.revalidate()?;
         Ok(authority)
@@ -5546,7 +5599,8 @@ pub fn authenticate_h3_private_presentation(
     )
 }
 
-/// Authenticate the compiled public H3 profile against one live SM89 CUDA
+/// Authenticate the compiled public H3 profile against one live SM89 CUDA or
+/// Metal route.
 /// route. This presentation check opens neither model weights nor external
 /// compliance files; generation separately verifies every artifact and applies
 /// the compiled conservative memory profile.
@@ -5555,18 +5609,25 @@ pub fn authenticate_h3_public_presentation(
     routes: &[H3PrivatePresentationRoute<'_>],
 ) -> Result<H3PrivatePresentationAuthority> {
     if routes.is_empty() {
-        bail!("MiniMax H3 presentation requires one live schedulable CUDA route")
+        bail!("MiniMax H3 presentation requires one live schedulable CUDA or Metal route")
     }
     let route = routes
         .iter()
-        .find(|route| route.compute_capability == (8, 9))
-        .ok_or_else(|| anyhow!("public H3 requires one live schedulable SM89 CUDA route"))?;
-    H3AttentionRuntimeAuthority::qualify_flash_attention_v2(
-        H3AttentionDevice::Cuda {
-            compute_capability: Some(route.compute_capability),
-        },
-        H3AttentionModelContract::released_bf16(),
-    )
+        .find(|route| matches!(route.compute_capability, Some((8, 9)) | None))
+        .ok_or_else(|| {
+            anyhow!("public H3 requires one live schedulable SM89 CUDA or Metal route")
+        })?;
+    match route.compute_capability {
+        Some(compute_capability) => H3AttentionRuntimeAuthority::qualify_flash_attention_v2(
+            H3AttentionDevice::Cuda {
+                compute_capability: Some(compute_capability),
+            },
+            H3AttentionModelContract::released_bf16(),
+        ),
+        None => H3AttentionRuntimeAuthority::metal_chunked_dense(
+            H3AttentionModelContract::released_bf16(),
+        ),
+    }
     .map_err(|error| anyhow!(error.to_string()))?;
     Ok(H3PrivatePresentationAuthority {
         canonical_model: contract::FL2VA_COMFY.into(),
@@ -5605,16 +5666,20 @@ fn authenticate_h3_private_presentation_with_scope(
         .find(|route| {
             reviewed.record.device_id == route.device_id
                 && reviewed.record.device_ordinal == route.device_ordinal
-                && reviewed.record.compute_capability
-                    == [route.compute_capability.0, route.compute_capability.1]
+                && route.compute_capability.is_some_and(|(major, minor)| {
+                    reviewed.record.compute_capability == [major, minor]
+                })
         })
         .ok_or_else(|| {
             anyhow!("private H3 presentation has no live route matching reviewed evidence")
         })?;
+    let route_compute_capability = route
+        .compute_capability
+        .ok_or_else(|| anyhow!("private H3 reviewed presentation requires a CUDA route"))?;
     reviewed.validate_route(
         route.device_id,
         route.device_ordinal,
-        route.compute_capability,
+        route_compute_capability,
     )?;
     let attention;
     let (attention_runtime_identity_sha256, attention_kernel_identity) =
@@ -5623,7 +5688,7 @@ fn authenticate_h3_private_presentation_with_scope(
         } else {
             attention = H3AttentionRuntimeAuthority::qualify_flash_attention_v2(
                 H3AttentionDevice::Cuda {
-                    compute_capability: Some(route.compute_capability),
+                    compute_capability: Some(route_compute_capability),
                 },
                 H3AttentionModelContract::released_bf16(),
             )
@@ -6394,7 +6459,7 @@ mod tests {
                 &artifact,
                 "gpu-0",
                 0,
-                (8, 9),
+                Some((8, 9)),
                 &sha('a'),
                 "synthetic-qualified-kernel",
                 &sha('b'),
@@ -6944,7 +7009,7 @@ mod tests {
                 route: H3PrivatePresentationRoute {
                     device_id: DEVICE_0,
                     device_ordinal: 0,
-                    compute_capability: (8, 9),
+                    compute_capability: Some((8, 9)),
                 },
             }
         }
@@ -6974,7 +7039,7 @@ mod tests {
         assert_eq!(authority.task(), Task::Fl2va);
         assert_eq!(authority.device_id(), DEVICE_0);
         assert_eq!(authority.device_ordinal(), 0);
-        assert_eq!(authority.compute_capability(), (8, 9));
+        assert_eq!(authority.compute_capability(), Some((8, 9)));
     }
 
     #[cfg(unix)]
@@ -6990,7 +7055,7 @@ mod tests {
         let wrong_route = H3PrivatePresentationRoute {
             device_id: DEVICE_1,
             device_ordinal: 1,
-            compute_capability: (8, 9),
+            compute_capability: Some((8, 9)),
         };
         assert!(authenticate_h3_private_presentation_for_test(
             &fixture.models_root,
@@ -7105,7 +7170,7 @@ mod tests {
             mode: Mode::TextToAudioVideo,
             device_id: DEVICE_0.into(),
             device_ordinal: 0,
-            compute_capability: (8, 9),
+            compute_capability: Some((8, 9)),
             admitted_available_device_bytes: 10,
             admitted_host_headroom_bytes: 10,
             base_factory_authority: factory.clone(),
@@ -7256,9 +7321,7 @@ mod tests {
             cancellation_scope_identity_sha256: sha('2'),
             device_id: factory.device_id().into(),
             device_ordinal: factory.device_ordinal(),
-            compute_capability: factory
-                .compute_capability()
-                .expect("contract fixtures freeze a CUDA route"),
+            compute_capability: factory.compute_capability(),
             memory_ledger_sequence: 9,
             admission_evidence_identity_sha256: sha('3'),
             artifact_qualification_identity_sha256: sha('4'),
@@ -7526,7 +7589,7 @@ mod tests {
             &artifact_report(),
             DEVICE_0,
             0,
-            (8, 9),
+            Some((8, 9)),
             &runtime_identity,
             kernel.identity(),
             &runtime_identity,
@@ -8267,19 +8330,32 @@ mod tests {
 
     #[cfg(feature = "h3")]
     #[test]
-    fn public_presentation_uses_compiled_sm89_policy_without_a_runtime_record() {
+    fn public_presentation_accepts_compiled_cuda_and_metal_policies() {
+        let metal = H3PrivatePresentationRoute {
+            device_id: "metal:00000000000000000000000000000000",
+            device_ordinal: 0,
+            compute_capability: None,
+        };
+        let metal_authority = authenticate_h3_public_presentation(&[metal]).unwrap();
+        assert_eq!(metal_authority.canonical_model(), contract::FL2VA_COMFY);
+        assert_eq!(metal_authority.task(), Task::Fl2va);
+        assert_eq!(metal_authority.compute_capability(), None);
+
         let route = H3PrivatePresentationRoute {
             device_id: "cuda:00000000000000000000000000000000",
             device_ordinal: 0,
-            compute_capability: (8, 9),
+            compute_capability: Some((8, 9)),
         };
-        let authority = authenticate_h3_public_presentation(&[route]).unwrap();
-        assert_eq!(authority.canonical_model(), contract::FL2VA_COMFY);
-        assert_eq!(authority.task(), Task::Fl2va);
-        assert_eq!(authority.compute_capability(), (8, 9));
+        #[cfg(feature = "cuda")]
+        {
+            let authority = authenticate_h3_public_presentation(&[route]).unwrap();
+            assert_eq!(authority.canonical_model(), contract::FL2VA_COMFY);
+            assert_eq!(authority.task(), Task::Fl2va);
+            assert_eq!(authority.compute_capability(), Some((8, 9)));
+        }
 
         let unsupported = H3PrivatePresentationRoute {
-            compute_capability: (9, 0),
+            compute_capability: Some((9, 0)),
             ..route
         };
         assert!(authenticate_h3_public_presentation(&[unsupported]).is_err());
@@ -8436,7 +8512,7 @@ mod tests {
             &artifact,
             DEVICE_0,
             0,
-            (8, 9),
+            Some((8, 9)),
             &sha('d'),
             "flash-attention-v2-sm89",
             &sha('e'),
@@ -8446,7 +8522,7 @@ mod tests {
         authority.revalidate().unwrap();
         assert_eq!(authority.device_id(), DEVICE_0);
         assert_eq!(authority.device_ordinal(), 0);
-        assert_eq!(authority.compute_capability(), (8, 9));
+        assert_eq!(authority.compute_capability(), Some((8, 9)));
         assert_eq!(authority.artifact_qualification_identity_sha256(), sha('c'));
         assert_eq!(
             H3PrivateFl2VaRuntimeBounds::from(authority.bounds()),
@@ -8521,7 +8597,7 @@ mod tests {
                 &crossed,
                 DEVICE_0,
                 0,
-                cc,
+                Some(cc),
                 &attention,
                 kernel,
                 &qualification,
@@ -8533,7 +8609,7 @@ mod tests {
                 &crossed,
                 DEVICE_0,
                 0,
-                (8, 9),
+                Some((8, 9)),
                 &sha('d'),
                 "flash-attention-v2-sm89",
                 &sha('e'),
@@ -8547,7 +8623,7 @@ mod tests {
             &crossed_model,
             DEVICE_0,
             0,
-            (8, 9),
+            Some((8, 9)),
             &sha('d'),
             "flash-attention-v2-sm89",
             &sha('e'),

--- a/crates/mold-inference/src/minimax_h3/private_server.rs
+++ b/crates/mold-inference/src/minimax_h3/private_server.rs
@@ -107,6 +107,7 @@ use crate::{
     H3FactoryAuthorityInput, H3FactoryComponentAuthority, H3FactoryComponentRole,
     H3FactoryConditionerPlacement, H3FactoryEndpointAnchor, H3FactoryExecutionBudgetEchoInput,
     H3FactoryPreparedRequestInput, H3FactoryPreparedRowsInput, H3FactoryQuantizationAuthority,
+    H3FactoryTargetBudgetInput,
 };
 
 pub(crate) const RUNTIME_QUALIFICATION_SCHEMA: &str =
@@ -654,11 +655,23 @@ pub(crate) fn private_h3_admission_host_floor_bytes(
 #[cfg(feature = "mp4")]
 fn precheck_private_h3_admission_capacity(
     bounds: &H3PrivateRuntimeBoundRecord,
+    compute_capability: Option<(u16, u16)>,
     available_device_bytes: u64,
     available_host_headroom_bytes: u64,
 ) -> Result<()> {
     let device_floor = private_h3_admission_device_floor_bytes(bounds)?;
     let host_floor = private_h3_admission_host_floor_bytes(bounds)?;
+    if compute_capability.is_none() {
+        let unified_floor = device_floor.max(host_floor);
+        if unified_floor > available_device_bytes {
+            bail!(
+                "private H3 Metal admission needs at least {unified_floor} unified-memory bytes \
+                 before any request-specific term, exceeding the {available_device_bytes} byte \
+                 admission sample"
+            )
+        }
+        return Ok(());
+    }
     if device_floor > available_device_bytes || host_floor > available_host_headroom_bytes {
         bail!(
             "private H3 admission needs at least {device_floor} device and {host_floor} host \
@@ -728,9 +741,20 @@ fn precheck_private_h3_prepared_rows(
 fn check_private_h3_target_budget_fits(
     predicted_device_peak_bytes: u64,
     predicted_host_increment_bytes: u64,
+    compute_capability: Option<(u16, u16)>,
     available_device_bytes: u64,
     available_host_headroom_bytes: u64,
 ) -> Result<()> {
+    if compute_capability.is_none() {
+        let unified_peak = predicted_device_peak_bytes.max(predicted_host_increment_bytes);
+        if unified_peak > available_device_bytes {
+            bail!(
+                "private H3 Metal canonical target needs {unified_peak} unified-memory bytes but \
+                 the admission sample offers {available_device_bytes}"
+            )
+        }
+        return Ok(());
+    }
     if predicted_device_peak_bytes > available_device_bytes {
         bail!(
             "private H3 canonical target needs {predicted_device_peak_bytes} device bytes but the \
@@ -744,6 +768,81 @@ fn check_private_h3_target_budget_fits(
         )
     }
     Ok(())
+}
+
+/// Exact peak of H3's reviewed phase order on an Apple unified-memory device.
+///
+/// Host and device charges within one phase coexist and are therefore added;
+/// different phases are mutually exclusive under the authenticated load/drop
+/// policy and are therefore compared with `max`. Taking the maximum of the two
+/// independent aggregate peaks would miss the smaller simultaneous charge.
+#[cfg(feature = "mp4")]
+fn private_h3_unified_target_peak_bytes(budget: &H3FactoryTargetBudgetInput) -> Result<u64> {
+    let phases = [
+        (
+            budget.reference_decode_phase_device_bytes,
+            budget.reference_decode_phase_host_bytes,
+        ),
+        (
+            budget.reference_preprocess_phase_device_bytes,
+            budget.reference_preprocess_phase_host_bytes,
+        ),
+        (
+            budget.reference_visual_encode_phase_device_bytes,
+            budget.reference_visual_encode_phase_host_bytes,
+        ),
+        (
+            budget.reference_audio_encode_phase_device_bytes,
+            budget.reference_audio_encode_phase_host_bytes,
+        ),
+        (
+            budget.vae_load_phase_device_bytes,
+            budget.vae_load_phase_host_bytes,
+        ),
+        (
+            budget.qwen_encode_phase_device_bytes,
+            budget.qwen_encode_phase_host_bytes,
+        ),
+        (
+            budget.qwen_transfer_phase_device_bytes,
+            budget.qwen_transfer_phase_host_bytes,
+        ),
+        (
+            budget.condition_encode_phase_device_bytes,
+            budget.condition_encode_phase_host_bytes,
+        ),
+        (
+            budget.noise_allocation_phase_device_bytes,
+            budget.noise_allocation_phase_host_bytes,
+        ),
+        (
+            budget.transformer_load_phase_device_bytes,
+            budget.transformer_load_phase_host_bytes,
+        ),
+        (
+            budget.denoise_phase_device_bytes,
+            budget.denoise_phase_host_bytes,
+        ),
+        (
+            budget.visual_decode_phase_device_bytes,
+            budget.visual_decode_phase_host_bytes,
+        ),
+        (
+            budget.audio_decode_phase_device_bytes,
+            budget.audio_decode_phase_host_bytes,
+        ),
+        (
+            budget.waveform_transfer_phase_device_bytes,
+            budget.waveform_transfer_phase_host_bytes,
+        ),
+        (budget.mux_phase_device_bytes, budget.mux_phase_host_bytes),
+    ];
+    phases.into_iter().try_fold(0, |peak, (device, host)| {
+        device
+            .checked_add(host)
+            .map(|phase| peak.max(phase))
+            .ok_or_else(|| anyhow!("private H3 unified-memory target phase overflow"))
+    })
 }
 
 impl H3PrivateRuntimeBoundRecord {
@@ -1507,6 +1606,7 @@ fn prepare_reviewed_h3_private_fl2va_admission(
     let precheck_bounds = runtime_qualification_source.precheck_bounds();
     precheck_private_h3_admission_capacity(
         &precheck_bounds,
+        compute_capability,
         available_device_bytes,
         available_host_headroom_bytes,
     )?;
@@ -1801,20 +1901,30 @@ fn prepare_reviewed_h3_private_fl2va_admission(
         runtime_qualification.bounds(),
         turbo_adapter.as_ref(),
     )?;
-    let predicted_device_peak_bytes = prepared_attempt.target_budget.predicted_device_peak_bytes;
-    let predicted_host_increment_bytes = prepared_attempt
+    let raw_device_peak_bytes = prepared_attempt.target_budget.predicted_device_peak_bytes;
+    let raw_host_increment_bytes = prepared_attempt
         .target_budget
         .predicted_host_increment_bytes;
+    let (predicted_device_peak_bytes, predicted_host_increment_bytes) =
+        if compute_capability.is_none() {
+            (
+                private_h3_unified_target_peak_bytes(&prepared_attempt.target_budget)?,
+                0,
+            )
+        } else {
+            (raw_device_peak_bytes, raw_host_increment_bytes)
+        };
     check_private_h3_target_budget_fits(
         predicted_device_peak_bytes,
         predicted_host_increment_bytes,
+        compute_capability,
         available_device_bytes,
         available_host_headroom_bytes,
     )?;
     let budget_echo = H3FactoryExecutionBudgetEchoInput {
         prepared_attempt_identity_sha256: prepared_attempt.identity_sha256.clone(),
-        device_peak_bytes: predicted_device_peak_bytes,
-        host_increment_bytes: predicted_host_increment_bytes,
+        device_peak_bytes: raw_device_peak_bytes,
+        host_increment_bytes: raw_host_increment_bytes,
     };
     let enriched = base_factory_authority.with_private_prepared_attempt(
         prepared_attempt.clone(),
@@ -7666,6 +7776,7 @@ mod tests {
             );
             precheck_private_h3_admission_capacity(
                 &ceilings,
+                Some((8, 9)),
                 SM89_CAMPAIGN_DEVICE_SAMPLE_BYTES,
                 SM89_CAMPAIGN_HOST_SAMPLE_BYTES,
             )
@@ -8446,19 +8557,35 @@ mod tests {
             // at it, so a refusal always implies the exact sums cannot fit.
             assert!(precheck_private_h3_admission_capacity(
                 bounds,
+                Some((8, 9)),
                 device_floor.saturating_sub(1),
                 u64::MAX
             )
             .is_err());
             assert!(precheck_private_h3_admission_capacity(
                 bounds,
+                Some((8, 9)),
                 u64::MAX,
                 host_floor.saturating_sub(1)
             )
             .is_err());
-            assert!(
-                precheck_private_h3_admission_capacity(bounds, device_floor, host_floor).is_ok()
-            );
+            assert!(precheck_private_h3_admission_capacity(
+                bounds,
+                Some((8, 9)),
+                device_floor,
+                host_floor
+            )
+            .is_ok());
+
+            let unified_floor = device_floor.max(host_floor);
+            assert!(precheck_private_h3_admission_capacity(
+                bounds,
+                None,
+                unified_floor.saturating_sub(1),
+                1
+            )
+            .is_err());
+            precheck_private_h3_admission_capacity(bounds, None, unified_floor, 1).unwrap();
         }
     }
 
@@ -8472,6 +8599,7 @@ mod tests {
         check_private_h3_target_budget_fits(
             9_000_000_000,
             7_000_000_000,
+            Some((8, 9)),
             9_000_000_000,
             7_000_000_000,
         )
@@ -8480,6 +8608,7 @@ mod tests {
         let device = check_private_h3_target_budget_fits(
             9_000_000_001,
             7_000_000_000,
+            Some((8, 9)),
             9_000_000_000,
             7_000_000_000,
         )
@@ -8493,6 +8622,7 @@ mod tests {
         let host = check_private_h3_target_budget_fits(
             9_000_000_000,
             7_000_000_001,
+            Some((8, 9)),
             9_000_000_000,
             7_000_000_000,
         )
@@ -8502,6 +8632,21 @@ mod tests {
         assert!(host.contains("7000000000"), "{host}");
         assert!(host.contains("host"), "{host}");
         assert!(!host.contains("device"), "{host}");
+
+        check_private_h3_target_budget_fits(9_000_000_000, 7_000_000_000, None, 9_000_000_000, 1)
+            .unwrap();
+        let metal = check_private_h3_target_budget_fits(
+            9_000_000_001,
+            7_000_000_000,
+            None,
+            9_000_000_000,
+            1,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(metal.contains("9000000001"), "{metal}");
+        assert!(metal.contains("9000000000"), "{metal}");
+        assert!(metal.contains("unified-memory"), "{metal}");
     }
 
     #[cfg(feature = "h3")]

--- a/crates/mold-inference/src/minimax_h3/private_server.rs
+++ b/crates/mold-inference/src/minimax_h3/private_server.rs
@@ -845,6 +845,26 @@ fn private_h3_unified_target_peak_bytes(budget: &H3FactoryTargetBudgetInput) -> 
     })
 }
 
+#[cfg(feature = "mp4")]
+fn private_h3_qwen_route(
+    compute_capability: Option<(u16, u16)>,
+) -> (
+    H3PrivateQwenLoaderMemoryRoute,
+    H3FactoryConditionerPlacement,
+) {
+    if compute_capability.is_some() {
+        (
+            H3PrivateQwenLoaderMemoryRoute::Cpu,
+            H3FactoryConditionerPlacement::HostCpuThenDrop,
+        )
+    } else {
+        (
+            H3PrivateQwenLoaderMemoryRoute::Metal,
+            H3FactoryConditionerPlacement::AssignedMetalThenDrop,
+        )
+    }
+}
+
 impl H3PrivateRuntimeBoundRecord {
     fn into_authority(self) -> H3PrivateQualifiedRuntimeBounds {
         H3PrivateQualifiedRuntimeBounds {
@@ -1697,7 +1717,11 @@ fn prepare_reviewed_h3_private_fl2va_admission(
     let attention_qualification_sha256 =
         runtime_qualification_source.attention_qualification_sha256(&attention);
     let attention_input = H3FactoryAttentionInput {
-        generic_backend: AttentionBackend::Flash,
+        generic_backend: if compute_capability.is_some() {
+            AttentionBackend::Flash
+        } else {
+            AttentionBackend::Math
+        },
         generic_chunk: AttentionChunkPolicy::Off,
         runtime_backend: attention.backend(),
         kernel: attention.kernel(),
@@ -1801,8 +1825,8 @@ fn prepare_reviewed_h3_private_fl2va_admission(
         attention.identity_sha256(),
         &component_digests,
     );
-    let qwen_memory =
-        released_h3_private_qwen_loader_memory_authority(H3PrivateQwenLoaderMemoryRoute::Cpu)?;
+    let (qwen_route, conditioner_placement) = private_h3_qwen_route(compute_capability);
+    let qwen_memory = released_h3_private_qwen_loader_memory_authority(qwen_route)?;
     let transformer_policy_sha256 = opened_transformer
         .candidate()
         .strategy
@@ -1827,7 +1851,7 @@ fn prepare_reviewed_h3_private_fl2va_admission(
             device_ordinal,
             compute_capability,
             execution_fingerprint: execution_fingerprint.clone(),
-            conditioner_placement: H3FactoryConditionerPlacement::HostCpuThenDrop,
+            conditioner_placement,
             qwen_parameter_bytes: qwen_memory.source_parameter_bytes,
             qwen_host_resident_parameter_bytes: qwen_memory.host_resident_parameter_bytes,
             qwen_device_resident_parameter_bytes: qwen_memory.device_resident_parameter_bytes,
@@ -8647,6 +8671,25 @@ mod tests {
         assert!(metal.contains("9000000001"), "{metal}");
         assert!(metal.contains("9000000000"), "{metal}");
         assert!(metal.contains("unified-memory"), "{metal}");
+    }
+
+    #[cfg(feature = "mp4")]
+    #[test]
+    fn metal_runs_qwen_on_the_assigned_unified_memory_device() {
+        assert_eq!(
+            private_h3_qwen_route(None),
+            (
+                H3PrivateQwenLoaderMemoryRoute::Metal,
+                H3FactoryConditionerPlacement::AssignedMetalThenDrop,
+            )
+        );
+        assert_eq!(
+            private_h3_qwen_route(Some((8, 9))),
+            (
+                H3PrivateQwenLoaderMemoryRoute::Cpu,
+                H3FactoryConditionerPlacement::HostCpuThenDrop,
+            )
+        );
     }
 
     #[cfg(feature = "h3")]

--- a/crates/mold-inference/src/minimax_h3/vae_runtime.rs
+++ b/crates/mold-inference/src/minimax_h3/vae_runtime.rs
@@ -262,11 +262,10 @@ impl FrozenH3ComfyVaeLoadPlan {
             || manifest.name != model
             || manifest.family != contract::FAMILY
             || manifest_authority.layout != contract::Layout::ComfyPrunedInt8ConvrotNvfp4Awq
-            || manifest_authority.runtime_available
+            || (!cfg!(feature = "h3") && manifest_authority.runtime_available)
         {
             return Err(H3ComfyVaeLoadError::InvalidPlan(
-                "private H3 VAE storage resolution requires an exact inactive compact manifest"
-                    .into(),
+                "private H3 VAE storage resolution requires an exact compact manifest".into(),
             ));
         }
         let path_for = |role: H3ComfyVaeArtifactRole| -> LoadResult<PathBuf> {
@@ -3315,6 +3314,14 @@ mod tests {
             })
             .collect::<Vec<_>>();
         let staged = StagedWeights::create(&plan, &mut opened, &mut observer).unwrap();
+        let descriptor_header_error =
+            inspect_safetensors_header(staged.path(H3ComfyVaeArtifactRole::VisualWeights).unwrap())
+                .unwrap_err()
+                .to_string();
+        assert!(
+            !descriptor_header_error.contains("No such file or directory"),
+            "descriptor-aware header inspection must reach the retained bytes: {descriptor_header_error}"
+        );
         let target = staged
             .storage_path(H3ComfyVaeArtifactRole::VisualWeights)
             .unwrap()

--- a/crates/mold-inference/src/minimax_h3/vae_runtime.rs
+++ b/crates/mold-inference/src/minimax_h3/vae_runtime.rs
@@ -6,7 +6,7 @@
 //! Comfy task manifest. Each source is opened and identity-fenced exactly once.
 //! The two weight files are authenticated while being copied into one private,
 //! bounded staging directory; Candle may reopen only those private copies.
-//! Both CUDA-resident models finish construction before staging is removed.
+//! Both accelerator-resident models finish construction before staging is removed.
 
 use std::collections::BTreeSet;
 use std::fs::{File, OpenOptions};
@@ -488,12 +488,15 @@ impl FrozenH3ComfyVaeLoadPlan {
         Ok(plan)
     }
 
-    fn requires_cuda(&self) -> bool {
+    fn supports_device(&self, device: &Device) -> bool {
+        if device.is_cuda() || device.is_metal() {
+            return true;
+        }
         #[cfg(test)]
         if self.synthetic {
-            return false;
+            return true;
         }
-        true
+        false
     }
 }
 
@@ -848,9 +851,9 @@ pub(crate) fn load_h3_comfy_vae_runtime_from_authority(
     observer: &mut dyn H3ComfyVaeLoadObserver,
 ) -> LoadResult<H3ComfyVaeRuntimeBundle> {
     authority.validate()?;
-    if authority.plan.requires_cuda() && !device.is_cuda() {
+    if !authority.plan.supports_device(device) {
         return Err(H3ComfyVaeLoadError::InvalidPlan(
-            "production Comfy VAE construction requires the frozen CUDA route".into(),
+            "production Comfy VAE construction requires the frozen CUDA or Metal route".into(),
         ));
     }
     let H3AuthenticatedComfyVaeAuthority {
@@ -1520,7 +1523,7 @@ impl VaeFactory for ProductionVaeFactory {
         };
         // SAFETY: `weight_path` is a read-only file inside the loader's private
         // staging directory. That directory remains owned until construction
-        // completes, and this production path accepts CUDA only, so every
+        // completes, and this production path accepts accelerator devices, so every
         // returned parameter tensor is copied into device storage before the
         // staging directory is removed.
         let model = unsafe {
@@ -1620,9 +1623,9 @@ fn load_with_factory<F: VaeFactory>(
     factory: &mut F,
 ) -> LoadResult<H3ComfyVaeRuntimeBundle<F::Visual, F::Audio>> {
     plan.validate()?;
-    if plan.requires_cuda() && !device.is_cuda() {
+    if !plan.supports_device(device) {
         return Err(H3ComfyVaeLoadError::InvalidPlan(
-            "production Comfy VAE construction requires the frozen CUDA route".into(),
+            "production Comfy VAE construction requires the frozen CUDA or Metal route".into(),
         ));
     }
     let mut opened = Vec::with_capacity(H3ComfyVaeArtifactRole::ALL.len());

--- a/crates/mold-server/src/execution_plan.rs
+++ b/crates/mold-server/src/execution_plan.rs
@@ -1144,6 +1144,8 @@ pub struct PendingArtifactIdentity {
     pub repo: String,
     pub filename: String,
     pub bytes: u64,
+    pub install_model: Option<String>,
+    pub licenses: Vec<mold_core::LicenseRefusal>,
     /// Registry-declared container of the artifact admission will land here.
     /// The preview must not claim GGUF for a `.safetensors`, `.pt`, or `.onnx`
     /// dependency it has never read.
@@ -1159,6 +1161,8 @@ impl PendingArtifactIdentity {
             name: self.filename.clone(),
             repo: self.repo.clone(),
             bytes: self.bytes,
+            install_model: self.install_model.clone(),
+            licenses: self.licenses.clone(),
         }
     }
 

--- a/crates/mold-server/src/execution_plan.rs
+++ b/crates/mold-server/src/execution_plan.rs
@@ -1622,6 +1622,13 @@ fn resolve_private_h3_execution_plans(
         let Some(evidence) = prepared.h3_private_admission_by_device.get(&device.id) else {
             continue;
         };
+        let available_device_bytes = if device.backend == GpuBackend::Metal {
+            mold_inference::device::metal_unified_capacity_with_safety_floor(
+                device.available_vram_bytes,
+            )
+        } else {
+            device.available_vram_bytes
+        };
         // Ask the host-memory question directly, before the frozen evidence is
         // revalidated. The live headroom recheck is one of `validate_for`'s
         // conjuncts and its refusal is a single opaque sentence, so the
@@ -1646,13 +1653,13 @@ fn resolve_private_h3_execution_plans(
             &device.id,
             device.ordinal,
             device.compute_capability,
-            device.available_vram_bytes,
+            available_device_bytes,
             available_host_headroom_bytes,
         ) {
             rejections.push(DeviceInfeasibility {
                 device_id: device.id,
                 predicted_peak_bytes: evidence.predicted_device_peak_bytes(),
-                available_bytes: device.available_vram_bytes,
+                available_bytes: available_device_bytes,
                 advice: Some(format!(
                     "private admission evidence no longer fits: {error:#}"
                 )),

--- a/crates/mold-server/src/execution_plan.rs
+++ b/crates/mold-server/src/execution_plan.rs
@@ -1361,7 +1361,7 @@ pub fn eligible_devices_for_request(
 /// Placement-only counterpart for an already authenticated private H3
 /// ingress grant. It deliberately does not call model/artifact activation;
 /// inference preflight owns that authority. The canonical private runtime
-/// keeps Qwen on the host and requires transformer/VAE execution on one CUDA
+/// keeps Qwen on the host and requires transformer/VAE execution on one CUDA or Metal
 /// owner, while preserving the generic explicit-device conflict semantics.
 #[cfg(any(feature = "h3", feature = "h3-private-uat"))]
 pub(crate) fn eligible_devices_for_private_h3(
@@ -1645,12 +1645,7 @@ fn resolve_private_h3_execution_plans(
             request,
             &device.id,
             device.ordinal,
-            device.compute_capability.ok_or_else(|| {
-                ExecutionPlanError::PreparedInputsStale(format!(
-                    "MiniMax H3 device '{}' lost its CUDA compute capability",
-                    device.id
-                ))
-            })?,
+            device.compute_capability,
             device.available_vram_bytes,
             available_host_headroom_bytes,
         ) {

--- a/crates/mold-server/src/gpu_worker.rs
+++ b/crates/mold-server/src/gpu_worker.rs
@@ -38,7 +38,7 @@ thread_local! {
         }) };
 }
 
-#[cfg(any(feature = "h3", feature = "h3-private-uat"))]
+#[cfg(all(any(feature = "h3", feature = "h3-private-uat"), feature = "cuda"))]
 const H3_CUDA_ATTEMPT_RETAINED_MARKER: &str =
     "CUDA execution attempt retained resources; server restart required";
 
@@ -1399,7 +1399,7 @@ fn request_lease_host_headroom(
         .map_err(crate::routes::ApiError::internal)
 }
 
-#[cfg(any(feature = "h3", feature = "h3-private-uat"))]
+#[cfg(all(any(feature = "h3", feature = "h3-private-uat"), feature = "cuda"))]
 fn with_private_h3_cuda_preparation_attempt<T>(
     worker: &GpuWorker,
     operation: impl FnOnce() -> Result<T, crate::routes::ApiError>,
@@ -1466,6 +1466,14 @@ fn with_private_h3_cuda_preparation_attempt<T>(
             result
         }
     }
+}
+
+#[cfg(all(any(feature = "h3", feature = "h3-private-uat"), not(feature = "cuda")))]
+fn with_private_h3_cuda_preparation_attempt<T>(
+    _worker: &GpuWorker,
+    operation: impl FnOnce() -> Result<T, crate::routes::ApiError>,
+) -> Result<T, crate::routes::ApiError> {
+    operation()
 }
 
 fn validate_scheduled_generation_before_cuda(
@@ -2546,7 +2554,7 @@ fn synchronize_after_oom(worker: &GpuWorker) -> bool {
     }
 }
 
-#[cfg(any(test, feature = "cuda", feature = "h3-private-uat"))]
+#[cfg(any(test, feature = "cuda", feature = "h3", feature = "h3-private-uat"))]
 fn device_memory_api_error(error: device::DeviceMemoryError) -> crate::routes::ApiError {
     if error.is_fatal_cuda() {
         crate::routes::ApiError::internal(error.to_string())

--- a/crates/mold-server/src/gpu_worker.rs
+++ b/crates/mold-server/src/gpu_worker.rs
@@ -4930,8 +4930,13 @@ pub(crate) fn prepare_private_h3_allocation_boundary(
     if unloaded {
         worker.set_resident_model(None);
     }
-    let available_device_bytes = device::post_drop_free_vram_bytes(worker.gpu.ordinal)
+    let sampled_available_device_bytes = device::post_drop_free_vram_bytes(worker.gpu.ordinal)
         .map_err(|error| private_h3_memory_sample_error(worker, error))?;
+    let available_device_bytes = if worker.gpu.backend == mold_core::GpuBackend::Metal {
+        device::metal_unified_capacity_with_safety_floor(sampled_available_device_bytes)
+    } else {
+        sampled_available_device_bytes
+    };
     validate_private_h3_physical_capacity(
         model_name,
         predicted_device_peak_bytes,

--- a/crates/mold-server/src/h3_admission.rs
+++ b/crates/mold-server/src/h3_admission.rs
@@ -952,19 +952,29 @@ impl H3QualifiedRuntimeFacts {
                 packed_rows: shape.rows.total_packed_rows,
             });
         }
-        let capability = device.compute_capability.ok_or_else(|| {
-            H3AdmissionError::DeviceUnsupported(
-                "H3 CUDA admission requires an explicit compute capability".to_string(),
-            )
-        })?;
-        if capability < self.minimum_compute_capability {
-            return Err(H3AdmissionError::DeviceUnsupported(format!(
-                "H3 runtime requires CUDA compute capability {}.{}, got {}.{}",
-                self.minimum_compute_capability.0,
-                self.minimum_compute_capability.1,
-                capability.0,
-                capability.1
-            )));
+        match (device.backend, device.compute_capability) {
+            (GpuBackend::Cuda, Some(capability))
+                if capability >= self.minimum_compute_capability => {}
+            (GpuBackend::Cuda, Some(capability)) => {
+                return Err(H3AdmissionError::DeviceUnsupported(format!(
+                    "H3 runtime requires CUDA compute capability {}.{}, got {}.{}",
+                    self.minimum_compute_capability.0,
+                    self.minimum_compute_capability.1,
+                    capability.0,
+                    capability.1
+                )));
+            }
+            (GpuBackend::Cuda, None) => {
+                return Err(H3AdmissionError::DeviceUnsupported(
+                    "H3 CUDA admission requires an explicit compute capability".to_string(),
+                ));
+            }
+            (GpuBackend::Metal, None) => {}
+            (GpuBackend::Metal, Some(_)) => {
+                return Err(H3AdmissionError::DeviceUnsupported(
+                    "H3 Metal admission must not carry a CUDA compute capability".to_string(),
+                ));
+            }
         }
         if shape.rows.total_packed_rows > self.maximum_packed_rows {
             return Err(H3AdmissionError::QualifiedAttentionRequired {
@@ -1114,7 +1124,8 @@ pub(crate) struct H3FrozenExecutionPlan {
     pub layout: H3PublishedLayout,
     pub device_id: String,
     pub device_ordinal: usize,
-    pub compute_capability: (u16, u16),
+    /// `Some` identifies an exact CUDA architecture; `None` identifies Metal.
+    pub compute_capability: Option<(u16, u16)>,
     pub checkpoint_fingerprint: String,
     pub config_fingerprint: String,
     pub header_fingerprint: String,
@@ -1201,7 +1212,7 @@ pub(crate) enum H3AdmissionError {
         available_bytes: u64,
     },
     #[error(
-        "MiniMax H3 product-size packed attention ({packed_rows} rows) requires a qualified lossless CUDA runtime"
+        "MiniMax H3 product-size packed attention ({packed_rows} rows) requires a qualified lossless GPU runtime"
     )]
     QualifiedAttentionRequired { packed_rows: u64 },
     #[error("MiniMax H3 placement is pending landed artifacts: {paths:?}")]
@@ -1256,9 +1267,11 @@ pub(crate) fn plan_h3_admission(
         });
     }
     let device = &devices[0];
-    if device.id.trim().is_empty() || device.backend != GpuBackend::Cuda {
+    if device.id.trim().is_empty()
+        || !matches!(device.backend, GpuBackend::Cuda | GpuBackend::Metal)
+    {
         return Err(H3AdmissionError::DeviceUnsupported(
-            "the initial H3 authority is CUDA-only".to_string(),
+            "H3 admission requires one CUDA or Metal GPU".to_string(),
         ));
     }
     if task != artifacts.task {
@@ -1502,11 +1515,7 @@ pub(crate) fn plan_h3_admission(
         layout: artifacts.layout,
         device_id: device.id.clone(),
         device_ordinal: device.ordinal,
-        compute_capability: device.compute_capability.ok_or_else(|| {
-            H3AdmissionError::DeviceUnsupported(
-                "H3 CUDA admission requires an exact compute capability".to_string(),
-            )
-        })?,
+        compute_capability: device.compute_capability,
         checkpoint_fingerprint: checkpoint.checkpoint_fingerprint.clone(),
         config_fingerprint: checkpoint.config_fingerprint.clone(),
         header_fingerprint: checkpoint.header_fingerprint.clone(),
@@ -1678,7 +1687,7 @@ pub(crate) fn reject_normal_h3_admission(model: &str, family: &str) -> H3NormalA
 /// exposing paths or bytes and without activating an H3 loader.
 ///
 /// Construction is transactional: `engine_config` is mutated only after the
-/// execution fingerprint, exact CUDA route, component set, attention evidence,
+/// execution fingerprint, exact GPU route, component set, attention evidence,
 /// streaming policy, and layout-specific quantization all agree.
 pub(crate) fn bind_h3_factory_authority(
     plan: &H3FrozenExecutionPlan,
@@ -1690,11 +1699,7 @@ pub(crate) fn bind_h3_factory_authority(
     plan.validate_execution_fingerprint()?;
     artifacts.validate_landed()?;
     checkpoint.validate(artifacts)?;
-    let compute_capability = device.compute_capability.ok_or_else(|| {
-        H3AdmissionError::DeviceUnsupported(
-            "H3 factory binding requires an exact CUDA compute capability".to_string(),
-        )
-    })?;
+    let compute_capability = device.compute_capability;
     let expected_qwen_output_transfer_device_bytes = match plan.qwen_placement {
         H3QwenPlacement::AssignedGpuThenDrop => 0,
         H3QwenPlacement::HostCpuThenDrop => {
@@ -1708,7 +1713,7 @@ pub(crate) fn bind_h3_factory_authority(
         || plan.device_id != device.id
         || plan.device_ordinal != device.ordinal
         || plan.compute_capability != compute_capability
-        || device.backend != GpuBackend::Cuda
+        || !matches!(device.backend, GpuBackend::Cuda | GpuBackend::Metal)
         || plan.checkpoint_fingerprint != checkpoint.checkpoint_fingerprint
         || plan.config_fingerprint != checkpoint.config_fingerprint
         || plan.header_fingerprint != checkpoint.header_fingerprint
@@ -1731,9 +1736,12 @@ pub(crate) fn bind_h3_factory_authority(
         ));
     }
     let conditioner_placement = match plan.qwen_placement {
-        H3QwenPlacement::AssignedGpuThenDrop => {
-            mold_inference::H3FactoryConditionerPlacement::AssignedCudaThenDrop
-        }
+        H3QwenPlacement::AssignedGpuThenDrop => match device.backend {
+            GpuBackend::Cuda => mold_inference::H3FactoryConditionerPlacement::AssignedCudaThenDrop,
+            GpuBackend::Metal => {
+                mold_inference::H3FactoryConditionerPlacement::AssignedMetalThenDrop
+            }
+        },
         H3QwenPlacement::HostCpuThenDrop => {
             mold_inference::H3FactoryConditionerPlacement::HostCpuThenDrop
         }
@@ -1770,10 +1778,7 @@ pub(crate) fn bind_h3_factory_authority(
             model: artifacts.model.clone(),
             device_id: plan.device_id.clone(),
             device_ordinal: plan.device_ordinal,
-            // Admission still binds a CUDA route only (`DeviceUnsupported`
-            // above), so the capability is always present here; the factory
-            // input is optional because a Metal plan carries none.
-            compute_capability: Some(compute_capability),
+            compute_capability,
             execution_fingerprint: plan.execution_fingerprint.clone(),
             conditioner_placement,
             qwen_parameter_bytes: plan.qwen_memory.source_parameter_bytes,
@@ -2260,6 +2265,16 @@ mod tests {
         }
     }
 
+    fn metal(vram: u64) -> H3AdmissionDevice {
+        H3AdmissionDevice {
+            id: "metal-0".to_string(),
+            ordinal: 0,
+            backend: GpuBackend::Metal,
+            compute_capability: None,
+            available_vram_bytes: vram,
+        }
+    }
+
     fn prepared(model: &str, frames: u32) -> (H3FrozenTask, H3PreparedRequestShape) {
         H3PreparedRequestShape::from_prepared_request(&request(model, frames), 128, 0).unwrap()
     }
@@ -2495,8 +2510,35 @@ mod tests {
 
         assert_eq!(plan.canonical_model, minimax_h3::FL2VA_COMFY);
         assert_eq!(plan.device_id, "gpu-0");
-        assert_eq!(plan.compute_capability, (8, 9));
+        assert_eq!(plan.compute_capability, Some((8, 9)));
         assert_eq!(plan.execution_fingerprint.len(), 64);
+        plan.validate_execution_fingerprint().unwrap();
+    }
+
+    #[test]
+    fn metal_admission_freezes_a_capability_free_backend_route() {
+        let inventory = landed_inventory(minimax_h3::FL2VA_COMFY);
+        let checkpoint = checkpoint(&inventory);
+        let runtime = qualified_runtime();
+        let (task, shape) = prepared(minimax_h3::FL2VA_COMFY, 124);
+        let device = metal(48 * GIB);
+        let plan = plan_h3_admission(
+            task,
+            shape,
+            &inventory,
+            &checkpoint,
+            Some(&runtime),
+            std::slice::from_ref(&device),
+            H3HostMemory {
+                total_bytes: 96 * GIB,
+                available_bytes: 96 * GIB,
+            },
+            H3AdmissionPolicy::default(),
+        )
+        .unwrap();
+
+        assert_eq!(plan.device_id, "metal-0");
+        assert_eq!(plan.compute_capability, None);
         plan.validate_execution_fingerprint().unwrap();
     }
 
@@ -3224,7 +3266,7 @@ mod tests {
         assert_eq!(authority.canonical_model(), minimax_h3::FL2VA_COMFY);
         assert_eq!(authority.device_id(), plan.device_id);
         assert_eq!(authority.device_ordinal(), plan.device_ordinal);
-        assert_eq!(plan.compute_capability, (8, 9));
+        assert_eq!(plan.compute_capability, Some((8, 9)));
         assert_eq!(authority.compute_capability(), Some((8, 9)));
         assert_eq!(
             authority.execution_fingerprint(),

--- a/crates/mold-server/src/h3_admission.rs
+++ b/crates/mold-server/src/h3_admission.rs
@@ -3319,7 +3319,10 @@ mod tests {
             semantic.h3_factory_authority_sha256.as_deref(),
             Some(authority.identity_sha256())
         );
-        assert!(!minimax_h3::capabilities(minimax_h3::Task::Fl2va).runtime_available);
+        assert_eq!(
+            minimax_h3::capabilities(minimax_h3::Task::Fl2va).runtime_available,
+            cfg!(feature = "h3")
+        );
     }
 
     #[test]

--- a/crates/mold-server/src/h3_private_bridge.rs
+++ b/crates/mold-server/src/h3_private_bridge.rs
@@ -292,17 +292,25 @@ pub(crate) fn advertised_h3_private_capability(
             .devices
             .iter()
             .filter(|device| {
-                device.backend == mold_core::GpuBackend::Cuda
-                    && device.schedulable
+                matches!(
+                    device.backend,
+                    mold_core::GpuBackend::Cuda | mold_core::GpuBackend::Metal
+                ) && device.schedulable
                     && device.ordinal.is_some()
-                    && device.compute_capability.is_some()
             })
             .filter_map(|device| {
-                let (major, minor) = device.compute_capability.as_deref()?.split_once('.')?;
+                let compute_capability = match device.backend {
+                    mold_core::GpuBackend::Cuda => {
+                        let (major, minor) =
+                            device.compute_capability.as_deref()?.split_once('.')?;
+                        Some((major.parse().ok()?, minor.parse().ok()?))
+                    }
+                    mold_core::GpuBackend::Metal => None,
+                };
                 Some(mold_inference::H3PrivatePresentationRoute {
                     device_id: &device.id,
                     device_ordinal: device.ordinal?,
-                    compute_capability: (major.parse().ok()?, minor.parse().ok()?),
+                    compute_capability,
                 })
             })
             .collect::<Vec<_>>();
@@ -527,8 +535,8 @@ fn build_fl2va_capability(models_root: &std::path::Path) -> Option<mold_core::Mi
     Some(mold_core::MiniMaxH3Capability {
         runtime_available: true,
         qualification: mold_core::MiniMaxH3QualificationCapability {
-            backend: "cuda".into(),
-            metal_supported: false,
+            backend: "cuda-or-metal".into(),
+            metal_supported: true,
             minimum_host_ram_bytes: crate::h3_admission::H3_CURATED_HOST_RAM_RECOMMENDATION_BYTES,
             // Measured bounds from the first real FL2VA render (2026-08-19,
             // hal9000 RTX 4090 SM89, 1216 s) cut the denoise workspace caps
@@ -546,7 +554,9 @@ fn build_fl2va_capability(models_root: &std::path::Path) -> Option<mold_core::Mi
             // has actually rendered, not before. Admission gates on the exact
             // per-attempt budget regardless; this tier is advisory.
             minimum_vram_bytes: 24 * 1024 * 1024 * 1024,
-            attention_profile: "FlashAttention v2 BF16 on exact CUDA SM89".into(),
+            attention_profile:
+                "FlashAttention v2 BF16 on CUDA SM89; chunked dense BF16 correctness on Metal"
+                    .into(),
             quantization_profile: "Comfy pruned INT8-convrot + Qwen NVFP4-AWQ".into(),
         },
         partitions: vec![mold_core::MiniMaxH3PartitionCapability {
@@ -1508,9 +1518,7 @@ pub(crate) fn prepare_for_owner(
             .as_ref()
             .map(crate::reference_uploads::ResolvedReferenceSet::fingerprint),
     )?;
-    let compute_capability = worker.gpu.compute_capability.ok_or_else(|| {
-        "MiniMax H3 preparation requires exact CUDA compute capability".to_string()
-    })?;
+    let compute_capability = worker.gpu.compute_capability;
     let device_id = crate::scheduler::worker_device_id(worker);
     let admission_evidence = prepared_inputs
         .h3_private_admission_by_device
@@ -1705,16 +1713,16 @@ fn private_uat_path(name: &str, fallback: std::path::PathBuf) -> std::path::Path
 fn validate_private_h3_live_owner_route(
     expected_device_id: &str,
     expected_device_ordinal: usize,
-    expected_compute_capability: (u16, u16),
+    expected_compute_capability: Option<(u16, u16)>,
     actual_device_id: &str,
     actual_device_ordinal: usize,
-    actual_compute_capability: (u16, u16),
+    actual_compute_capability: Option<(u16, u16)>,
 ) -> Result<(), String> {
     if expected_device_id != actual_device_id
         || expected_device_ordinal != actual_device_ordinal
         || expected_compute_capability != actual_compute_capability
     {
-        return Err("MiniMax H3 CUDA route changed after allocation-free admission".to_string());
+        return Err("MiniMax H3 GPU route changed after allocation-free admission".to_string());
     }
     Ok(())
 }
@@ -1864,8 +1872,8 @@ mod tests {
             .expect("complete manifest projection must advertise");
 
         assert!(capability.runtime_available);
-        assert_eq!(capability.qualification.backend, "cuda");
-        assert!(!capability.qualification.metal_supported);
+        assert_eq!(capability.qualification.backend, "cuda-or-metal");
+        assert!(capability.qualification.metal_supported);
         assert_eq!(capability.partitions.len(), 1);
         assert_eq!(capability.partitions[0].task, "fl2va");
         assert_eq!(
@@ -2155,7 +2163,7 @@ mod structural_tests {
             .components
             .iter()
             .all(|component| component.state == "installed"));
-        assert!(!capability.qualification.metal_supported);
+        assert!(capability.qualification.metal_supported);
     }
 
     fn request(model: &str) -> mold_core::GenerateRequest {
@@ -2530,11 +2538,24 @@ mod structural_tests {
 
     #[test]
     fn private_owner_route_rejects_changed_compute_capability() {
-        super::validate_private_h3_live_owner_route("cuda:0", 0, (8, 9), "cuda:0", 0, (8, 9))
-            .expect("unchanged live route must validate");
-        let error =
-            super::validate_private_h3_live_owner_route("cuda:0", 0, (8, 9), "cuda:0", 0, (9, 0))
-                .expect_err("changed compute capability must fail the second owner fence");
-        assert!(error.contains("CUDA route changed"));
+        super::validate_private_h3_live_owner_route(
+            "cuda:0",
+            0,
+            Some((8, 9)),
+            "cuda:0",
+            0,
+            Some((8, 9)),
+        )
+        .expect("unchanged live route must validate");
+        let error = super::validate_private_h3_live_owner_route(
+            "cuda:0",
+            0,
+            Some((8, 9)),
+            "cuda:0",
+            0,
+            Some((9, 0)),
+        )
+        .expect_err("changed compute capability must fail the second owner fence");
+        assert!(error.contains("GPU route changed"));
     }
 }

--- a/crates/mold-server/src/identity_dependencies.rs
+++ b/crates/mold-server/src/identity_dependencies.rs
@@ -434,6 +434,23 @@ mod tests {
 
         let downloads = prepared.pending_downloads_for_device("cuda:0");
         assert_eq!(downloads.len(), 5, "{downloads:?}");
+        assert!(downloads
+            .iter()
+            .all(|download| download.install_model.as_deref() == Some("pulid-flux")));
+        let licensed_files = downloads
+            .iter()
+            .filter(|download| !download.licenses.is_empty())
+            .map(|download| download.name.as_str())
+            .collect::<std::collections::BTreeSet<_>>();
+        assert_eq!(
+            licensed_files,
+            std::collections::BTreeSet::from(["glintr100.onnx", "scrfd_10g_bnkps.onnx"])
+        );
+        assert!(downloads.iter().all(|download| {
+            download.licenses.is_empty()
+                || (download.licenses.len() == 1
+                    && download.licenses[0].id == "insightface-antelopev2")
+        }));
         let by_kind = downloads
             .iter()
             .map(|download| {

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -918,16 +918,31 @@ async fn require_server_model_activation(
     drop(config);
 
     if let Some(manifest) = mold_core::manifest::find_manifest(&resolved) {
-        mold_core::require_model_activation(&manifest.name, Some(&manifest.family))
-            .map_err(ApiError::model_activation)?;
-        for file in &manifest.files {
-            mold_core::require_model_activation(&file.hf_repo, Some(&manifest.family))
-                .map_err(ApiError::model_activation)?;
-            mold_core::require_model_activation(&file.hf_filename, Some(&manifest.family))
-                .map_err(ApiError::model_activation)?;
-        }
+        require_registered_manifest_activation(manifest).map_err(ApiError::model_activation)?;
     }
     Ok(family)
+}
+
+/// Validate a source-controlled manifest for execution without treating its
+/// pinned upstream file locators as caller-selected model identities.
+///
+/// Reviewed H3 manifests are the only authority allowed to turn those raw
+/// repository paths into runnable local artifacts. Re-applying the public
+/// identity gate to their `hf_repo` / `hf_filename` fields rejects the exact
+/// reviewed manifests themselves, while raw `hf:` requests remain gated at
+/// the request-model check above.
+fn require_registered_manifest_activation(
+    manifest: &mold_core::manifest::ModelManifest,
+) -> Result<(), mold_core::ModelActivationError> {
+    mold_core::require_model_activation(&manifest.name, Some(&manifest.family))?;
+    if mold_core::minimax_h3::is_reviewed_compact_model(&manifest.name) {
+        return Ok(());
+    }
+    for file in &manifest.files {
+        mold_core::require_model_activation(&file.hf_repo, Some(&manifest.family))?;
+        mold_core::require_model_activation(&file.hf_filename, Some(&manifest.family))?;
+    }
+    Ok(())
 }
 
 /// Validate discovery/storage authority without implying that the same model
@@ -8371,6 +8386,20 @@ mod tests {
     fn h3_models_do_not_publish_a_family_wide_access_restriction() {
         let access = mold_core::model_access_capabilities();
         assert!(access.restrictions.is_empty());
+    }
+
+    #[test]
+    fn reviewed_h3_manifest_executes_without_authorizing_raw_repository_ids() {
+        let manifest =
+            mold_core::manifest::find_manifest(mold_core::minimax_h3::FL2VA_COMFY_TURBO_4STEP_768P)
+                .expect("reviewed H3 Turbo manifest");
+        require_registered_manifest_activation(manifest)
+            .expect("source-controlled reviewed manifest must activate");
+        assert!(mold_core::require_model_activation(
+            "hf:Comfy-Org/MiniMax-H3",
+            Some(mold_core::minimax_h3::FAMILY),
+        )
+        .is_err());
     }
 
     /// #787: an absent negative on a wan request materializes the tuned

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -954,7 +954,8 @@ async fn require_server_model_acquisition(
 /// Unknown ids are a `400` and nothing is written; see
 /// [`mold_core::license_acceptance::record_acceptances`] for why they are
 /// rejected rather than ignored.
-fn apply_download_license_acceptances(
+async fn apply_download_license_acceptances(
+    state: &AppState,
     model: &str,
     accept_licenses: &[mold_core::LicenseAcceptance],
 ) -> Result<(), ApiError> {
@@ -984,20 +985,30 @@ fn apply_download_license_acceptances(
         })?;
     }
 
-    // Re-derive from the manifest rather than trusting the accepted list: a
-    // request may name one license while the model needs another.
+    // Re-derive every term from the manifest rather than trusting the
+    // accepted list: a request may name one license while the model needs
+    // another. Only files this pull would fetch are gated; an already-present
+    // restricted artifact does not require retroactive consent merely because
+    // an unrelated file in the same bundle needs repair.
     let resolved = mold_core::manifest::resolve_model_name(model);
     let Some(manifest) = mold_core::manifest::find_manifest(&resolved) else {
         // Unknown models are the enqueue path's 400 to report, not ours.
         return Ok(());
     };
-    let Some(license) = license_acceptance::manifest_requires_license(manifest) else {
-        return Ok(());
-    };
-    if license_acceptance::is_accepted(&mold_home, license) {
-        return Ok(());
+    let config = state.config.read().await;
+    for file in &manifest.files {
+        if config.complete_manifest_file_path(manifest, file).is_some() {
+            continue;
+        }
+        for license in
+            license_acceptance::licenses_for_manifest_file(&manifest.name, &file.hf_filename)
+        {
+            if !license_acceptance::is_accepted(&mold_home, license) {
+                return Err(ApiError::license_not_accepted(&manifest.name, license));
+            }
+        }
     }
-    Err(ApiError::license_not_accepted(&manifest.name, license))
+    Ok(())
 }
 
 pub(crate) async fn require_server_generation_request_activation(
@@ -3846,6 +3857,8 @@ async fn placement_preview_for_request_authenticated(
                             name: adapter.download_model.to_string(),
                             repo: adapter.hf_repo.to_string(),
                             bytes: control_pending_download_bytes(adapter, &path),
+                            install_model: Some(adapter.download_model.to_string()),
+                            licenses: Vec::new(),
                         });
                 }
                 let artifact_fingerprint = format!(":ic-lora:{}", adapter.sha256);
@@ -3879,6 +3892,8 @@ async fn placement_preview_for_request_authenticated(
                             name: preset.hf_filename.to_string(),
                             repo: preset.hf_repo.to_string(),
                             bytes: preset.size_bytes,
+                            install_model: None,
+                            licenses: Vec::new(),
                         });
                 }
                 let artifact_fingerprint = format!(":camera-control:{}", preset.sha256);
@@ -4072,7 +4087,7 @@ async fn pull_model_endpoint(
     require_server_model_acquisition(&state, &body.model).await?;
     // Before ANY branch below — the catalog repair path enqueues downloads
     // too, and a refusal must happen before bytes move on either route.
-    apply_download_license_acceptances(&body.model, &body.accept_licenses)?;
+    apply_download_license_acceptances(&state, &body.model, &body.accept_licenses).await?;
     let wants_sse = headers
         .get(header::ACCEPT)
         .and_then(|v| v.to_str().ok())
@@ -8114,7 +8129,9 @@ pub async fn create_download(
     if let Err(error) = require_server_model_acquisition(&state, &body.model).await {
         return error.into_response();
     }
-    if let Err(error) = apply_download_license_acceptances(&body.model, &body.accept_licenses) {
+    if let Err(error) =
+        apply_download_license_acceptances(&state, &body.model, &body.accept_licenses).await
+    {
         return error.into_response();
     }
     match state.downloads.enqueue(body.model.clone()).await {

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -918,31 +918,10 @@ async fn require_server_model_activation(
     drop(config);
 
     if let Some(manifest) = mold_core::manifest::find_manifest(&resolved) {
-        require_registered_manifest_activation(manifest).map_err(ApiError::model_activation)?;
+        mold_core::require_registered_manifest_activation(manifest)
+            .map_err(ApiError::model_activation)?;
     }
     Ok(family)
-}
-
-/// Validate a source-controlled manifest for execution without treating its
-/// pinned upstream file locators as caller-selected model identities.
-///
-/// Reviewed H3 manifests are the only authority allowed to turn those raw
-/// repository paths into runnable local artifacts. Re-applying the public
-/// identity gate to their `hf_repo` / `hf_filename` fields rejects the exact
-/// reviewed manifests themselves, while raw `hf:` requests remain gated at
-/// the request-model check above.
-fn require_registered_manifest_activation(
-    manifest: &mold_core::manifest::ModelManifest,
-) -> Result<(), mold_core::ModelActivationError> {
-    mold_core::require_model_activation(&manifest.name, Some(&manifest.family))?;
-    if mold_core::minimax_h3::is_reviewed_compact_model(&manifest.name) {
-        return Ok(());
-    }
-    for file in &manifest.files {
-        mold_core::require_model_activation(&file.hf_repo, Some(&manifest.family))?;
-        mold_core::require_model_activation(&file.hf_filename, Some(&manifest.family))?;
-    }
-    Ok(())
 }
 
 /// Validate discovery/storage authority without implying that the same model
@@ -2906,14 +2885,8 @@ async fn require_upscale_model_activation(
         .map_err(ApiError::model_activation)?;
     }
     if let Some(manifest) = manifest {
-        mold_core::require_model_activation(&manifest.name, Some(&manifest.family))
+        mold_core::require_registered_manifest_activation(manifest)
             .map_err(ApiError::model_activation)?;
-        for file in &manifest.files {
-            mold_core::require_model_activation(&file.hf_repo, Some(&manifest.family))
-                .map_err(ApiError::model_activation)?;
-            mold_core::require_model_activation(&file.hf_filename, Some(&manifest.family))
-                .map_err(ApiError::model_activation)?;
-        }
     }
     Ok(())
 }
@@ -8393,7 +8366,7 @@ mod tests {
         let manifest =
             mold_core::manifest::find_manifest(mold_core::minimax_h3::FL2VA_COMFY_TURBO_4STEP_768P)
                 .expect("reviewed H3 Turbo manifest");
-        require_registered_manifest_activation(manifest)
+        mold_core::require_registered_manifest_activation(manifest)
             .expect("source-controlled reviewed manifest must activate");
         assert!(mold_core::require_model_activation(
             "hf:Comfy-Org/MiniMax-H3",

--- a/crates/mold-server/src/routes_chain.rs
+++ b/crates/mold-server/src/routes_chain.rs
@@ -147,13 +147,9 @@ fn require_chain_manifest_artifact_activation(
     artifact_root: &std::path::Path,
 ) -> Result<(), ApiError> {
     let family = Some(manifest.family.as_str());
-    mold_core::require_model_activation(&manifest.name, family)
+    mold_core::require_registered_manifest_activation(manifest)
         .map_err(ApiError::model_activation)?;
     for file in &manifest.files {
-        mold_core::require_model_activation(&file.hf_repo, family)
-            .map_err(ApiError::model_activation)?;
-        mold_core::require_model_activation(&file.hf_filename, family)
-            .map_err(ApiError::model_activation)?;
         let storage_path = mold_core::manifest::storage_path(manifest, file);
         require_chain_artifact_path_activation(&storage_path, artifact_root, family)?;
         require_chain_artifact_path_activation(

--- a/crates/mold-server/src/scheduler/mod.rs
+++ b/crates/mold-server/src/scheduler/mod.rs
@@ -13323,6 +13323,8 @@ mod tests {
                 repo: "owner/qwen3".to_string(),
                 filename: "qwen3-q8.gguf".to_string(),
                 bytes: 1_000_000_000,
+                install_model: None,
+                licenses: Vec::new(),
                 container: crate::execution_plan::PendingArtifactContainer::Gguf,
                 quantization: Some(crate::execution_plan::QuantizationVariant::Q8),
             },

--- a/crates/mold-server/src/variant_dependencies.rs
+++ b/crates/mold-server/src/variant_dependencies.rs
@@ -1793,6 +1793,7 @@ async fn prepare_h3_private_inputs_for_devices(
     let mut failures = BTreeMap::new();
 
     for device in devices {
+        #[cfg(not(feature = "h3"))]
         if device.backend != mold_core::GpuBackend::Cuda {
             failures.insert(
                 device.id,
@@ -1800,13 +1801,29 @@ async fn prepare_h3_private_inputs_for_devices(
             );
             continue;
         }
-        let Some(compute_capability) = device.compute_capability else {
+        #[cfg(feature = "h3")]
+        if !matches!(
+            device.backend,
+            mold_core::GpuBackend::Cuda | mold_core::GpuBackend::Metal
+        ) {
+            failures.insert(device.id, "MiniMax H3 requires CUDA or Metal".to_string());
+            continue;
+        }
+        let compute_capability = device.compute_capability;
+        if device.backend == mold_core::GpuBackend::Cuda && compute_capability.is_none() {
             failures.insert(
                 device.id,
-                "MiniMax H3 private UAT requires exact CUDA compute capability".to_string(),
+                "MiniMax H3 CUDA requires exact compute capability".to_string(),
             );
             continue;
-        };
+        }
+        if device.backend == mold_core::GpuBackend::Metal && compute_capability.is_some() {
+            failures.insert(
+                device.id,
+                "MiniMax H3 Metal route carried a CUDA compute capability".to_string(),
+            );
+            continue;
+        }
         let admission_request = resolved_request.clone();
         let paths = uat_paths.clone();
         // Each device's admission mints its own descriptors rather than

--- a/crates/mold-server/src/variant_dependencies.rs
+++ b/crates/mold-server/src/variant_dependencies.rs
@@ -284,6 +284,7 @@ pub(crate) async fn ensure_downloaded(
         expected_sha256,
         subdir,
     } = dependency;
+    let install_model = expected_sha256.map(|pin| pin.repair_model.to_string());
     let cached = if policy == DependencyMaterializationPolicy::ExistingOnly {
         mold_core::download::cached_file_path_existing_only(
             models_root,
@@ -328,6 +329,19 @@ pub(crate) async fn ensure_downloaded(
                 name: filename.to_string(),
                 repo: repo.to_string(),
                 bytes,
+                licenses: install_model
+                    .as_deref()
+                    .and_then(|model| {
+                        mold_core::Config::mold_dir().map(|home| {
+                            mold_core::license_acceptance::unaccepted_for_manifest_files(
+                                model,
+                                [filename],
+                                &home,
+                            )
+                        })
+                    })
+                    .unwrap_or_default(),
+                install_model,
             },
             path: mold_core::download::planned_single_file_path_in(models_root, filename, subdir),
             container,
@@ -1571,6 +1585,8 @@ pub(crate) async fn prepare_inputs_for_devices(
                                 repo: dependency.download.repo.clone(),
                                 filename: dependency.download.name.clone(),
                                 bytes: dependency.download.bytes,
+                                install_model: dependency.download.install_model.clone(),
+                                licenses: dependency.download.licenses.clone(),
                                 container: dependency.container,
                                 quantization: dependency.quantization,
                             },
@@ -2088,16 +2104,24 @@ pub async fn prepare_local_execution_inputs(
     request: &GenerateRequest,
     devices: Vec<DeviceFact>,
 ) -> Result<PreparedExecutionInputs, String> {
-    let mut context = DependencyPreparationContext::default();
-    #[cfg(feature = "h3")]
-    if mold_core::minimax_h3::task_for_model(&request.model).is_some() {
-        context.h3_private_ingress_grant = crate::h3_private_bridge::classify_h3_private_ingress(
-            request,
-            None,
-            H3_PUBLIC_LOCAL_INSTANCE_ID,
-        )
-        .map_err(|error| error.error)?;
-    }
+    let context = {
+        #[cfg(feature = "h3")]
+        {
+            let mut context = DependencyPreparationContext::default();
+            if mold_core::minimax_h3::task_for_model(&request.model).is_some() {
+                context.h3_private_ingress_grant =
+                    crate::h3_private_bridge::classify_h3_private_ingress(
+                        request,
+                        None,
+                        H3_PUBLIC_LOCAL_INSTANCE_ID,
+                    )
+                    .map_err(|error| error.error)?;
+            }
+            context
+        }
+        #[cfg(not(feature = "h3"))]
+        DependencyPreparationContext::default()
+    };
     prepare_inputs_for_devices(
         None,
         "local",

--- a/crates/mold-server/src/variant_dependencies.rs
+++ b/crates/mold-server/src/variant_dependencies.rs
@@ -1313,10 +1313,19 @@ pub(crate) async fn prepare_inputs_for_devices(
 ) -> Result<PreparedExecutionInputs, String> {
     #[cfg(any(feature = "h3", feature = "h3-private-uat"))]
     if let Some(grant) = context.h3_private_ingress_grant.clone() {
-        let live_state = state.ok_or_else(|| {
-            "MiniMax H3 private dependency preparation has no server instance authority".to_string()
-        })?;
-        grant.validate_for_request(request, live_state.instance_id.as_str())?;
+        #[cfg(feature = "h3")]
+        let instance_id = state.map_or(H3_PUBLIC_LOCAL_INSTANCE_ID, |state| {
+            state.instance_id.as_str()
+        });
+        #[cfg(not(feature = "h3"))]
+        let instance_id = state
+            .ok_or_else(|| {
+                "MiniMax H3 private dependency preparation has no server instance authority"
+                    .to_string()
+            })?
+            .instance_id
+            .as_str();
+        grant.validate_for_request(request, instance_id)?;
         return prepare_h3_private_inputs_for_devices(
             state,
             work_id,
@@ -1918,6 +1927,11 @@ async fn prepare_h3_private_inputs_for_devices(
         ));
     }
 
+    #[cfg(feature = "h3")]
+    let instance_id = state.map_or(H3_PUBLIC_LOCAL_INSTANCE_ID, |state| {
+        state.instance_id.as_str()
+    });
+    #[cfg(not(feature = "h3"))]
     let instance_id = state
         .ok_or_else(|| {
             "MiniMax H3 private admission lost its server instance authority".to_string()
@@ -2068,6 +2082,16 @@ pub async fn prepare_local_execution_inputs(
     request: &GenerateRequest,
     devices: Vec<DeviceFact>,
 ) -> Result<PreparedExecutionInputs, String> {
+    let mut context = DependencyPreparationContext::default();
+    #[cfg(feature = "h3")]
+    if mold_core::minimax_h3::task_for_model(&request.model).is_some() {
+        context.h3_private_ingress_grant = crate::h3_private_bridge::classify_h3_private_ingress(
+            request,
+            None,
+            H3_PUBLIC_LOCAL_INSTANCE_ID,
+        )
+        .map_err(|error| error.error)?;
+    }
     prepare_inputs_for_devices(
         None,
         "local",
@@ -2076,10 +2100,16 @@ pub async fn prepare_local_execution_inputs(
         devices,
         None,
         DependencyMaterializationPolicy::Admission,
-        DependencyPreparationContext::default(),
+        context,
     )
     .await
 }
+
+/// Stable instance identity for the in-process forced-local public H3 route.
+/// It never crosses a transport boundary; it only binds preparation and
+/// execution to the same CLI process authority.
+#[cfg(feature = "h3")]
+const H3_PUBLIC_LOCAL_INSTANCE_ID: &str = "mold-public-forced-local";
 
 #[cfg(test)]
 mod tests {

--- a/crates/mold-server/src/variant_dependencies.rs
+++ b/crates/mold-server/src/variant_dependencies.rs
@@ -1801,7 +1801,7 @@ async fn prepare_h3_private_inputs_for_devices(
     let mut evidence_by_device = BTreeMap::new();
     let mut failures = BTreeMap::new();
 
-    for device in devices {
+    for mut device in devices {
         #[cfg(not(feature = "h3"))]
         if device.backend != mold_core::GpuBackend::Cuda {
             failures.insert(
@@ -1832,6 +1832,12 @@ async fn prepare_h3_private_inputs_for_devices(
                 "MiniMax H3 Metal route carried a CUDA compute capability".to_string(),
             );
             continue;
+        }
+        if device.backend == mold_core::GpuBackend::Metal {
+            device.available_vram_bytes =
+                mold_inference::device::metal_unified_capacity_with_safety_floor(
+                    device.available_vram_bytes,
+                );
         }
         let admission_request = resolved_request.clone();
         let paths = uat_paths.clone();

--- a/crates/mold-tui/src/app.rs
+++ b/crates/mold-tui/src/app.rs
@@ -37,6 +37,14 @@ pub(crate) struct PromptTransformSnapshot {
     pub source_kind: mold_core::RemixSourceKind,
 }
 
+/// One registry-derived bundle whose exact terms must be accepted before the
+/// TUI can download it. Presentation and key handling are model-agnostic.
+#[derive(Debug, Clone)]
+pub struct LicenseDownloadRequirement {
+    pub install_model: String,
+    pub licenses: Vec<mold_core::LicenseRefusal>,
+}
+
 /// Events sent from background tasks to the main TUI loop.
 pub enum BackgroundEvent {
     /// Progress update from generation or model pull.
@@ -54,6 +62,12 @@ pub enum BackgroundEvent {
     },
     /// Generation or background task failed.
     Error(String),
+    /// A background placement/download check paused for explicit consent.
+    LicenseRequired {
+        host_label: String,
+        requirements: Vec<LicenseDownloadRequirement>,
+        response: tokio::sync::oneshot::Sender<bool>,
+    },
     /// A reviewable prompt transform completed. The token fences late results
     /// after the user edits or starts another request.
     PromptTransformComplete {
@@ -1814,6 +1828,11 @@ pub enum Popup {
         message: String,
         on_confirm: ConfirmAction,
     },
+    LicenseReview {
+        host_label: String,
+        requirements: Vec<LicenseDownloadRequirement>,
+        response: Option<tokio::sync::oneshot::Sender<bool>>,
+    },
     SettingsInput {
         key: SettingsKey,
         input: String,
@@ -3461,6 +3480,11 @@ impl App {
     /// Close the active popup and refresh the preview image so it re-renders
     /// over the area the popup occupied.
     fn close_popup(&mut self) {
+        if let Some(Popup::LicenseReview { response, .. }) = self.popup.as_mut() {
+            if let Some(response) = response.take() {
+                let _ = response.send(false);
+            }
+        }
         self.popup = None;
         self.refresh_preview_protocol();
     }
@@ -3984,6 +4008,18 @@ impl App {
                     }
                     _ => self.close_popup(),
                 },
+                Some(Popup::LicenseReview { response, .. }) => match key.code {
+                    KeyCode::Char('y') | KeyCode::Enter => {
+                        let response = response.take();
+                        self.popup = None;
+                        self.refresh_preview_protocol();
+                        if let Some(response) = response {
+                            let _ = response.send(true);
+                        }
+                    }
+                    KeyCode::Esc | KeyCode::Char('n') => self.close_popup(),
+                    _ => {}
+                },
                 Some(Popup::Info { .. }) => {
                     // Dismiss info popup on any key
                     self.close_popup();
@@ -4506,17 +4542,22 @@ impl App {
                     if self.should_poll_remote() {
                         // Pull via server when connected remotely
                         let url = self.server_url.clone().unwrap();
+                        let host_label = self
+                            .resource_info
+                            .server_status
+                            .as_ref()
+                            .and_then(|status| status.hostname.clone())
+                            .unwrap_or_else(|| url.clone());
                         self.tokio_handle.spawn(async move {
                             let client = mold_core::MoldClient::new(&url);
-                            let (progress_tx, mut progress_rx) =
-                                mpsc::unbounded_channel::<SseProgressEvent>();
-                            let tx_fwd = tx.clone();
-                            tokio::spawn(async move {
-                                while let Some(event) = progress_rx.recv().await {
-                                    let _ = tx_fwd.send(BackgroundEvent::Progress(event));
-                                }
-                            });
-                            match client.pull_model_stream(&model_name, progress_tx).await {
+                            match crate::backend::pull_remote_model_with_consent(
+                                &client,
+                                host_label,
+                                model_name.clone(),
+                                tx.clone(),
+                            )
+                            .await
+                            {
                                 Ok(()) => {
                                     let _ = tx.send(BackgroundEvent::PullComplete(model_name));
                                 }
@@ -4530,8 +4571,11 @@ impl App {
                     } else {
                         // Pull locally when no server connected
                         self.tokio_handle.spawn(async move {
-                            if let Err(msg) =
-                                crate::backend::auto_pull_model(&model_name, &tx).await
+                            if let Err(msg) = crate::backend::pull_local_model_with_consent(
+                                model_name.clone(),
+                                tx.clone(),
+                            )
+                            .await
                             {
                                 let _ = tx.send(BackgroundEvent::Error(msg));
                             }
@@ -8173,6 +8217,17 @@ impl App {
                     self.generate.error_message = Some(msg);
                     self.generate.progress.generation_started_at = None;
                     self.generate.progress.stage_started_at = None;
+                }
+                BackgroundEvent::LicenseRequired {
+                    host_label,
+                    requirements,
+                    response,
+                } => {
+                    self.popup = Some(Popup::LicenseReview {
+                        host_label,
+                        requirements,
+                        response: Some(response),
+                    });
                 }
                 BackgroundEvent::GalleryScanComplete(scan) => {
                     self.gallery.offline_hosts = scan.offline_hosts;

--- a/crates/mold-tui/src/backend.rs
+++ b/crates/mold-tui/src/backend.rs
@@ -305,7 +305,12 @@ pub async fn run_generation(
                     }
                 };
 
-                let result = try_server_generate(&client, &req, &metadata_snapshot, &tx).await;
+                let host_label = iter_params
+                    .target_host_name
+                    .clone()
+                    .unwrap_or_else(|| url.clone());
+                let result =
+                    try_server_generate(&client, &host_label, &req, &metadata_snapshot, &tx).await;
                 if matches!(&result, ServerResult::Done) {
                     if let Some(lease) = reference_session.as_mut() {
                         lease.mark_consumed();
@@ -591,10 +596,14 @@ fn h3_runtime_unavailable_message(url: Option<&str>) -> String {
 /// auto-pull it and retry once.
 async fn try_server_generate(
     client: &MoldClient,
+    host_label: &str,
     req: &GenerateRequest,
     metadata_snapshot: &GenerationMetadataSnapshot,
     tx: &mpsc::UnboundedSender<BackgroundEvent>,
 ) -> ServerResult {
+    if let Err(error) = prepare_remote_licensed_dependencies(client, host_label, req, tx).await {
+        return ServerResult::Error(error);
+    }
     let is_h3 = mold_core::minimax_h3::task_for_model(&req.model).is_some();
     let (progress_tx, mut progress_rx) = mpsc::unbounded_channel::<SseProgressEvent>();
 
@@ -675,6 +684,226 @@ async fn try_server_generate(
     }
 }
 
+async fn request_license_consent(
+    host_label: String,
+    requirements: Vec<crate::app::LicenseDownloadRequirement>,
+    tx: &mpsc::UnboundedSender<BackgroundEvent>,
+) -> Result<bool, String> {
+    if requirements.is_empty() {
+        return Ok(true);
+    }
+    let (response_tx, response_rx) = tokio::sync::oneshot::channel();
+    tx.send(BackgroundEvent::LicenseRequired {
+        host_label,
+        requirements,
+        response: response_tx,
+    })
+    .map_err(|_| "the license review UI is unavailable".to_string())?;
+    response_rx
+        .await
+        .map_err(|_| "the license review was closed".to_string())
+}
+
+fn grouped_license_requirements(
+    pending: &[mold_core::PendingModelDownload],
+) -> Vec<crate::app::LicenseDownloadRequirement> {
+    let mut by_model = std::collections::BTreeMap::<
+        String,
+        std::collections::BTreeMap<String, mold_core::LicenseRefusal>,
+    >::new();
+    for download in pending {
+        let Some(model) = download.install_model.as_ref() else {
+            continue;
+        };
+        let licenses = by_model.entry(model.clone()).or_default();
+        for license in &download.licenses {
+            licenses.insert(
+                format!("{}\0{}\0{}", license.id, license.url, license.sha256),
+                license.clone(),
+            );
+        }
+    }
+    by_model
+        .into_iter()
+        .filter_map(|(install_model, licenses)| {
+            (!licenses.is_empty()).then(|| crate::app::LicenseDownloadRequirement {
+                install_model,
+                licenses: licenses.into_values().collect(),
+            })
+        })
+        .collect()
+}
+
+async fn prepare_remote_licensed_dependencies(
+    client: &MoldClient,
+    host_label: &str,
+    req: &GenerateRequest,
+    tx: &mpsc::UnboundedSender<BackgroundEvent>,
+) -> Result<(), String> {
+    let preview = match client.preview_generation_placement(req.clone(), 1).await {
+        Ok(preview) => preview,
+        // Compatibility: an older server has no structured preflight. Its
+        // existing admission error remains visible, but cannot be accepted in
+        // place because it exposes no safe pinned-terms contract.
+        Err(error) if mold_core::client::is_missing_endpoint_error(&error) => return Ok(()),
+        Err(error) => {
+            return Err(format!(
+                "Could not verify licensed dependencies on {host_label}: {error}"
+            ));
+        }
+    };
+    let requirements = grouped_license_requirements(&preview.pending_downloads);
+    if !request_license_consent(host_label.to_string(), requirements.clone(), tx).await? {
+        return Err("License acceptance cancelled; nothing was queued.".to_string());
+    }
+    for requirement in requirements {
+        let acceptances = requirement
+            .licenses
+            .iter()
+            .map(|license| mold_core::LicenseAcceptance {
+                id: license.id.clone(),
+                url: license.url.clone(),
+                sha256: license.sha256.clone(),
+            })
+            .collect::<Vec<_>>();
+        let (progress_tx, mut progress_rx) = mpsc::unbounded_channel();
+        let progress_events = tx.clone();
+        tokio::spawn(async move {
+            while let Some(event) = progress_rx.recv().await {
+                let _ = progress_events.send(BackgroundEvent::Progress(event));
+            }
+        });
+        client
+            .pull_model_stream_accepting(&requirement.install_model, &acceptances, progress_tx)
+            .await
+            .map_err(|error| {
+                format!(
+                    "Failed to download '{}' on {host_label}: {error}",
+                    requirement.install_model
+                )
+            })?;
+    }
+    Ok(())
+}
+
+pub async fn pull_remote_model_with_consent(
+    client: &MoldClient,
+    host_label: String,
+    model: String,
+    tx: mpsc::UnboundedSender<BackgroundEvent>,
+) -> Result<(), String> {
+    let statuses = match client.list_licenses().await {
+        Ok(statuses) => statuses,
+        Err(error) if mold_core::client::is_missing_endpoint_error(&error) => Vec::new(),
+        Err(error) => {
+            return Err(format!("Could not read licenses on {host_label}: {error}"));
+        }
+    };
+    let licenses = statuses
+        .into_iter()
+        .filter(|license| {
+            !license.accepted && license.required_by.iter().any(|name| name == &model)
+        })
+        .map(|license| mold_core::LicenseRefusal {
+            id: license.id,
+            name: license.name,
+            url: license.url,
+            canonical: license.canonical,
+            sha256: license.sha256,
+            summary: license.summary,
+        })
+        .collect::<Vec<_>>();
+    let requirements = (!licenses.is_empty())
+        .then(|| crate::app::LicenseDownloadRequirement {
+            install_model: model.clone(),
+            licenses,
+        })
+        .into_iter()
+        .collect::<Vec<_>>();
+    if !request_license_consent(host_label, requirements.clone(), &tx).await? {
+        return Err("License acceptance cancelled; nothing was downloaded.".to_string());
+    }
+    let acceptances = requirements
+        .iter()
+        .flat_map(|requirement| &requirement.licenses)
+        .map(|license| mold_core::LicenseAcceptance {
+            id: license.id.clone(),
+            url: license.url.clone(),
+            sha256: license.sha256.clone(),
+        })
+        .collect::<Vec<_>>();
+    let (progress_tx, mut progress_rx) = mpsc::unbounded_channel();
+    let progress_events = tx.clone();
+    tokio::spawn(async move {
+        while let Some(event) = progress_rx.recv().await {
+            let _ = progress_events.send(BackgroundEvent::Progress(event));
+        }
+    });
+    client
+        .pull_model_stream_accepting(&model, &acceptances, progress_tx)
+        .await
+        .map_err(|error| format!("Server pull failed: {error}"))
+}
+
+pub async fn pull_local_model_with_consent(
+    model: String,
+    tx: mpsc::UnboundedSender<BackgroundEvent>,
+) -> Result<(), String> {
+    let home = mold_core::Config::mold_dir()
+        .ok_or_else(|| "Could not resolve the Mold data directory".to_string())?;
+    let config = mold_core::Config::load_or_default();
+    let missing_files = mold_core::manifest::find_manifest(&model)
+        .map(|manifest| {
+            manifest
+                .files
+                .iter()
+                .filter(|file| config.complete_manifest_file_path(manifest, file).is_none())
+                .map(|file| file.hf_filename.as_str())
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let licenses =
+        mold_core::license_acceptance::unaccepted_for_manifest_files(&model, missing_files, &home);
+    let requirements = (!licenses.is_empty())
+        .then(|| crate::app::LicenseDownloadRequirement {
+            install_model: model.clone(),
+            licenses,
+        })
+        .into_iter()
+        .collect::<Vec<_>>();
+    if !request_license_consent("This device".to_string(), requirements.clone(), &tx).await? {
+        return Err("License acceptance cancelled; nothing was downloaded.".to_string());
+    }
+    let acceptances = requirements
+        .iter()
+        .flat_map(|requirement| &requirement.licenses)
+        .map(|license| mold_core::LicenseAcceptance {
+            id: license.id.clone(),
+            url: license.url.clone(),
+            sha256: license.sha256.clone(),
+        })
+        .collect::<Vec<_>>();
+    mold_core::license_acceptance::record_acceptances(&home, &acceptances)
+        .map_err(|error| format!("Could not record license acceptance: {error}"))?;
+    auto_pull_model(&model, &tx).await.map(|_| ())
+}
+
+/// Materialize auxiliary bundles the in-process TUI engine needs before it
+/// starts. The consent/download loop is bundle-generic; request policy merely
+/// names which registered bundles apply.
+async fn prepare_local_licensed_dependencies(
+    request: &GenerateRequest,
+    config: &mold_core::Config,
+    tx: &mpsc::UnboundedSender<BackgroundEvent>,
+) -> Result<(), String> {
+    for bundle in mold_core::manifest::auxiliary_manifests_for_request(request) {
+        if config.manifest_model_needs_download(bundle) {
+            pull_local_model_with_consent(bundle.to_string(), tx.clone()).await?;
+        }
+    }
+    Ok(())
+}
+
 /// Single attempt to generate via server (SSE with blocking fallback).
 async fn try_server_generate_once(
     client: &MoldClient,
@@ -714,6 +943,21 @@ async fn run_local_generation(
         return;
     }
 
+    let offload = params.offload;
+    let req = match build_request(&params, &prompt, &negative_prompt) {
+        Ok(req) => req,
+        Err(message) => {
+            let _ = tx.send(BackgroundEvent::Error(message));
+            return;
+        }
+    };
+    if let Err(message) = prepare_local_licensed_dependencies(&req, &config, &tx).await {
+        let _ = tx.send(BackgroundEvent::Error(message));
+        return;
+    }
+    // A bundle pull may have updated model paths or their configured root.
+    config = Config::load_or_default();
+
     // Resolve model paths — auto-pull if not downloaded
     let model_paths = match ModelPaths::resolve(&model_name, &config) {
         Some(paths) => paths,
@@ -741,14 +985,6 @@ async fn run_local_generation(
         }
     };
 
-    let offload = params.offload;
-    let req = match build_request(&params, &prompt, &negative_prompt) {
-        Ok(req) => req,
-        Err(message) => {
-            let _ = tx.send(BackgroundEvent::Error(message));
-            return;
-        }
-    };
     let tx_clone = tx.clone();
 
     let result = tokio::task::spawn_blocking(move || {
@@ -1133,6 +1369,32 @@ pub fn remove_model(model_name: String, tx: mpsc::UnboundedSender<BackgroundEven
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn license_requirements_group_future_terms_by_install_bundle() {
+        let terms = mold_core::LicenseRefusal {
+            id: "future-research-weights".into(),
+            name: "Future research weights".into(),
+            url: "https://example.test/pinned".into(),
+            canonical: "https://example.test/project".into(),
+            sha256: "a".repeat(64),
+            summary: "Research use only.".into(),
+        };
+        let dependency = |name: &str| mold_core::PendingModelDownload {
+            kind: "identity_encoder".into(),
+            name: name.into(),
+            repo: "example/future".into(),
+            bytes: 42,
+            install_model: Some("future-face-adapter".into()),
+            licenses: vec![terms.clone()],
+        };
+
+        let grouped = grouped_license_requirements(&[dependency("one"), dependency("two")]);
+
+        assert_eq!(grouped.len(), 1);
+        assert_eq!(grouped[0].install_model, "future-face-adapter");
+        assert_eq!(grouped[0].licenses, vec![terms]);
+    }
 
     /// #787 round 3: a Local-target (or Auto-fallback) run with an untouched
     /// wan editor used to snapshot `None` even though the engine substitutes

--- a/crates/mold-tui/src/ui/popup.rs
+++ b/crates/mold-tui/src/ui/popup.rs
@@ -21,6 +21,7 @@ pub fn render(frame: &mut Frame, app: &mut App) {
         Some(Popup::HistorySearch { .. }) => render_history_search(frame, app),
         Some(Popup::CommandPalette { .. }) => render_command_palette(frame, app),
         Some(Popup::Confirm { message, .. }) => render_confirm(frame, app, message.clone()),
+        Some(Popup::LicenseReview { .. }) => render_license_review(frame, app),
         Some(Popup::SettingsInput { .. }) => render_settings_input(frame, app),
         Some(Popup::Info { message }) => render_info(frame, app, message.clone()),
         Some(Popup::UpscaleModelSelector { .. }) => render_upscale_model_selector(frame, app),
@@ -1246,6 +1247,58 @@ fn render_confirm(frame: &mut Frame, app: &App, message: String) {
     frame.render_widget(paragraph, area);
 }
 
+fn render_license_review(frame: &mut Frame, app: &App) {
+    let Some(Popup::LicenseReview {
+        host_label,
+        requirements,
+        ..
+    }) = &app.popup
+    else {
+        return;
+    };
+    let theme = &app.theme;
+    let area = centered_rect(frame.area(), 72, 72);
+    frame.render_widget(Clear, area);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(theme.popup_border())
+        .title(" Review third-party license ")
+        .title_style(theme.title_focused())
+        .style(theme.popup_bg());
+    let mut text = vec![
+        Line::from(format!("Acceptance applies only to {host_label}.")),
+        Line::from(""),
+    ];
+    for requirement in requirements {
+        text.push(Line::from(Span::styled(
+            format!("Download: {}", requirement.install_model),
+            Style::default()
+                .fg(theme.accent)
+                .add_modifier(Modifier::BOLD),
+        )));
+        for license in &requirement.licenses {
+            text.push(Line::from(Span::styled(
+                license.name.clone(),
+                Style::default().fg(theme.text).add_modifier(Modifier::BOLD),
+            )));
+            text.push(Line::from(license.summary.clone()));
+            text.push(Line::from(format!("Pinned terms: {}", license.url)));
+            text.push(Line::from(format!("Project terms: {}", license.canonical)));
+        }
+        text.push(Line::from(""));
+    }
+    text.push(Line::from(vec![
+        Span::styled("Enter/y", theme.status_key()),
+        Span::styled(" Accept and download  ", Style::default().fg(theme.text)),
+        Span::styled("Esc/n", theme.status_key()),
+        Span::styled(" Cancel", Style::default().fg(theme.text)),
+    ]));
+    frame.render_widget(
+        Paragraph::new(text).block(block).wrap(Wrap { trim: false }),
+        area,
+    );
+}
+
 fn render_info(frame: &mut Frame, app: &App, message: String) {
     let theme = &app.theme;
     let area = centered_rect(frame.area(), 55, 20);
@@ -1415,6 +1468,32 @@ mod tests {
             message: message.to_string(),
             on_confirm: ConfirmAction::DeleteGalleryImage,
         })
+    }
+
+    #[test]
+    fn license_review_names_the_exact_host_bundle_and_terms() {
+        let (response, _receiver) = tokio::sync::oneshot::channel();
+        let rendered = render_popup_to_string(crate::app::Popup::LicenseReview {
+            host_label: "hal9000".into(),
+            requirements: vec![crate::app::LicenseDownloadRequirement {
+                install_model: "future-face-adapter".into(),
+                licenses: vec![mold_core::LicenseRefusal {
+                    id: "future-license".into(),
+                    name: "Future model terms".into(),
+                    url: "https://example.test/pinned".into(),
+                    canonical: "https://example.test/project".into(),
+                    sha256: "b".repeat(64),
+                    summary: "Research only.".into(),
+                }],
+            }],
+            response: Some(response),
+        });
+
+        assert!(rendered.contains("Acceptance applies only to hal9000"));
+        assert!(rendered.contains("Download: future-face-adapter"));
+        assert!(rendered.contains("Future model terms"));
+        assert!(rendered.contains("https://example.test/pinned"));
+        assert!(rendered.contains("Accept and download"));
     }
 
     /// Render one popup over a stand-in `App` and collapse the buffer into

--- a/desktop/src/App.vue
+++ b/desktop/src/App.vue
@@ -7,6 +7,8 @@ import Toasts from "./components/shell/Toasts.vue";
 import CommandPalette from "./components/shell/CommandPalette.vue";
 import ContextMenu from "./components/shell/ContextMenu.vue";
 import UpdateBanner from "./components/shell/UpdateBanner.vue";
+import LicenseAcceptanceDialog from "@studio/components/LicenseAcceptanceDialog.vue";
+import { openExternal } from "./lib/openExternal";
 import { dockBadgeValue } from "./lib/dockBadge";
 import { ipc } from "./lib/ipc";
 import { notificationRoute, type NotificationAction } from "./lib/notificationAction";
@@ -331,5 +333,6 @@ onUnmounted(() => {
     <Toasts />
     <CommandPalette />
     <ContextMenu />
+    <LicenseAcceptanceDialog :open-external="openExternal" />
   </div>
 </template>

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -166,7 +166,11 @@ import SegmentedControl from "@ui/components/SegmentedControl.vue";
 import LiveActivityList from "@ui/components/LiveActivityList.vue";
 import ErrorNotice from "@ui/components/ErrorNotice.vue";
 import ActionBlocker from "@ui/components/ActionBlocker.vue";
+import LicenseAcceptanceDialog from "@studio/components/LicenseAcceptanceDialog.vue";
+import { useLicenseAcceptance } from "@studio/composables/useLicenseAcceptance";
+import { licenseRequirements } from "@studio/lib/licenseAcceptance";
 import { upscaleImage } from "../lib/api/upscale";
+import { openExternal } from "../lib/openExternal";
 import {
   generationCapabilitiesForFamily,
   isFlux2DevModel,
@@ -553,6 +557,7 @@ const tab = ref<Tab>("generate");
 // first paint) so the legacy `mold.mobile.create-mode.v1` key migrates into
 // the shared draft and existing installs land back in Sequence.
 const draft = useSequenceDraftStore();
+const licenseAcceptance = useLicenseAcceptance();
 draft.hydrate();
 const mobileContent = ref<HTMLElement | null>(null);
 const settingsOpen = ref(false);
@@ -5164,6 +5169,16 @@ async function generate(): Promise<void> {
   if (identityRefusal) {
     setGenerationStatus(identityRefusal, true);
     generationAnnouncement.value = identityRefusal;
+    releasePreparedSubmission();
+    return;
+  }
+
+  const accepted = await licenseAcceptance.request({
+    hostLabel: route.label,
+    target: route.target,
+    requirements: licenseRequirements(placement?.pending_downloads),
+  });
+  if (!accepted || !submissionGuard.isCurrent(token)) {
     releasePreparedSubmission();
     return;
   }
@@ -9986,6 +10001,8 @@ onBeforeUnmount(() => {
       @close="generatedViewerOpen = false"
       @reuse="generatedViewerOpen = false"
     />
+
+    <LicenseAcceptanceDialog :open-external="openExternal" />
 
     <nav v-if="!settingsOpen" class="mobile-tabs" aria-label="Primary">
       <button

--- a/desktop/src/mobile/MobileSettingsView.vue
+++ b/desktop/src/mobile/MobileSettingsView.vue
@@ -3,6 +3,7 @@ import { onBeforeUnmount, ref, watch } from "vue";
 import { parseDeviceListResponse, setDeviceEnabled, type DeviceInfo } from "@studio/api/devices";
 import { listQueue, setQueueDevicePin, type QueuePlan } from "@studio/api/queuePlan";
 import DevicePanel from "@studio/components/DevicePanel.vue";
+import LicenseSettingsPanel from "@studio/components/LicenseSettingsPanel.vue";
 import { canMutateDevice } from "@studio/lib/deviceLifecycle";
 import { apiJsonTo } from "../lib/api/client";
 import type { ServerCapabilities } from "../lib/api/types";
@@ -330,6 +331,17 @@ onBeforeUnmount(() => {
           />
         </label>
       </fieldset>
+    </section>
+
+    <section class="mobile-settings-section" aria-labelledby="mobile-settings-license-title">
+      <div class="mobile-settings-section-copy">
+        <h2 id="mobile-settings-license-title">Model licenses</h2>
+      </div>
+      <LicenseSettingsPanel
+        :target="host ? mobileHostTarget(host) : null"
+        :host-label="host?.name ?? 'Selected host'"
+        :open-external="openExternal"
+      />
     </section>
 
     <section

--- a/desktop/src/stores/hosts.ts
+++ b/desktop/src/stores/hosts.ts
@@ -12,6 +12,7 @@ import {
   previewRequestForSiblingFanout,
   requiresAuthoritativePlacement,
   type MissingModelPlacement,
+  type GenerationPlacementPreview,
   type PlacementPreviewOptions,
   type PlacementMissingComponent,
 } from "@studio/api/generationPlacement";
@@ -210,7 +211,7 @@ export interface HostProbeFailure {
 export type HostFeasibilityFailure = HostPlacementFailure | HostProbeFailure;
 
 export type FeasibleRouteResult =
-  | { kind: "route"; route: HostRoute }
+  | { kind: "route"; route: HostRoute; preview?: GenerationPlacementPreview | null }
   | {
       kind: "profile_mismatch";
       perHost: Array<{
@@ -929,7 +930,7 @@ export const useHostsStore = defineStore("hosts", {
         if (planned.length > 0) {
           const chosen = candidates.find((host) => host.id === planned[0]!.hostId);
           const route = chosen ? hostRoute(chosen, this.capabilities[chosen.id]) : null;
-          if (route) return { kind: "route", route };
+          if (route) return { kind: "route", route, preview: planned[0]!.preview };
         }
 
         const unsupportedIds = settledProbes
@@ -958,7 +959,7 @@ export const useHostsStore = defineStore("hosts", {
             chosen = pickAutoHost(withModel.length > 0 ? withModel : legacy);
           }
           const route = chosen ? hostRoute(chosen, this.capabilities[chosen.id]) : null;
-          if (route) return { kind: "route", route };
+          if (route) return { kind: "route", route, preview: null };
         }
 
         const failures = settledProbes.flatMap<HostFeasibilityFailure>((probe) => {

--- a/desktop/src/views/GenerateView.sequence.test.ts
+++ b/desktop/src/views/GenerateView.sequence.test.ts
@@ -2,11 +2,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createPinia, setActivePinia } from "pinia";
 import { enableAutoUnmount, flushPromises, mount } from "@vue/test-utils";
 
-const { routerPush, routerReplace, routeQuery } = vi.hoisted(() => ({
-  routerPush: vi.fn(),
-  routerReplace: vi.fn(),
-  routeQuery: { value: {} as Record<string, unknown> },
-}));
+const { routerPush, routerReplace, routeQuery, licenseRequest, placementDownloads } = vi.hoisted(
+  () => ({
+    routerPush: vi.fn(),
+    routerReplace: vi.fn(),
+    routeQuery: { value: {} as Record<string, unknown> },
+    licenseRequest: vi.fn().mockResolvedValue(true),
+    placementDownloads: { value: [] as unknown[] },
+  }),
+);
 vi.mock("vue-router", () => ({
   useRouter: () => ({ push: routerPush, replace: routerReplace }),
   useRoute: () => ({ query: routeQuery.value }),
@@ -23,6 +27,35 @@ vi.mock("../lib/api/client", () => ({
   ApiError: class ApiError extends Error {
     status = 0;
   },
+}));
+vi.mock("@studio/api/generationPlacement", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@studio/api/generationPlacement")>();
+  const planned = () =>
+    Promise.resolve({
+      version: 1,
+      authoritative: true,
+      state_version: 1,
+      plan_version: 1,
+      outcome: "planned",
+      candidate: {
+        device_id: "local",
+        execution_fingerprint: "sequence-test",
+        predicted_start_after_ms: 0,
+        predicted_completion_after_ms: 1,
+        setup_ms: 0,
+        setup_kind: "warm",
+        estimate_confidence: "high",
+      },
+      pending_downloads: placementDownloads.value,
+    });
+  return {
+    ...original,
+    previewGenerationPlacement: vi.fn(planned),
+    previewChainPlacement: vi.fn(planned),
+  };
+});
+vi.mock("@studio/composables/useLicenseAcceptance", () => ({
+  useLicenseAcceptance: () => ({ request: licenseRequest }),
 }));
 vi.mock("../lib/ipc", () => ({
   inTauri: () => false,
@@ -99,6 +132,8 @@ beforeEach(() => {
   routerPush.mockClear();
   routerReplace.mockClear();
   routeQuery.value = {};
+  licenseRequest.mockReset().mockResolvedValue(true);
+  placementDownloads.value = [];
   installedPayload = [];
   apiJson.mockReset();
   apiJson.mockImplementation((path: unknown) =>
@@ -114,6 +149,24 @@ beforeEach(() => {
   apiJsonTo.mockImplementation((_target: unknown, path: unknown) => {
     if (path === "/api/chain-jobs") return Promise.resolve({ jobs: [] });
     if (path === "/api/models") return Promise.resolve(installedPayload);
+    if (path === "/api/generate/placement-preview") {
+      return Promise.resolve({
+        version: 1,
+        authoritative: true,
+        state_version: 1,
+        plan_version: 1,
+        outcome: "planned",
+        candidate: {
+          device_id: "local",
+          execution_fingerprint: "sequence-test",
+          predicted_start_after_ms: 0,
+          predicted_completion_after_ms: 1,
+          setup_ms: 0,
+          setup_kind: "warm",
+          estimate_confidence: "high",
+        },
+      });
+    }
     return Promise.resolve({});
   });
   window.localStorage?.clear?.();
@@ -121,6 +174,68 @@ beforeEach(() => {
 afterEach(() => (document.body.innerHTML = ""));
 
 describe("GenerateView — sequence output", () => {
+  it("queues nothing on license cancel and resumes exactly once after acceptance", async () => {
+    readyLocal();
+    installedPayload = [videoModel];
+    useModelStore().all = [videoModel];
+    useGenerateFormStore().form.model = videoModel.name;
+    const draft = useSequenceDraftStore();
+    draft.output = "sequence";
+    draft.ensureClips(25);
+    draft.clips[0]!.prompt = "opening shot";
+    draft.clips[1]!.prompt = "closing shot";
+    placementDownloads.value = [
+      {
+        kind: "future_runtime",
+        name: "future-runtime.bin",
+        repo: "future/repository",
+        bytes: 1024,
+        install_model: "future-video-assets",
+        licenses: [
+          {
+            id: "future-video-license",
+            name: "Future video terms",
+            url: "https://example.test/pinned",
+            canonical: "https://example.test/project",
+            sha256: "c".repeat(64),
+            summary: "Research use only.",
+          },
+        ],
+      },
+    ];
+    licenseRequest.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    apiFetchTo.mockResolvedValue(Response.json({ job_id: "licensed-sequence" }));
+
+    const wrapper = mountView();
+    await flushPromises();
+    const composer = wrapper.findComponent({ name: "SequenceComposer" });
+    apiJsonTo.mockClear();
+    composer.vm.$emit("submit");
+    await flushPromises();
+    await vi.waitFor(() => expect(licenseRequest).toHaveBeenCalledTimes(1));
+    expect(
+      apiFetchTo.mock.calls.filter(
+        ([, path, init]) =>
+          path === "/api/chain-jobs" && (init as RequestInit | undefined)?.method === "POST",
+      ),
+    ).toHaveLength(0);
+
+    composer.vm.$emit("submit");
+    await flushPromises();
+    await vi.waitFor(() => expect(licenseRequest).toHaveBeenCalledTimes(2));
+    expect(
+      apiFetchTo.mock.calls.filter(
+        ([, path, init]) =>
+          path === "/api/chain-jobs" && (init as RequestInit | undefined)?.method === "POST",
+      ),
+    ).toHaveLength(1);
+    expect(licenseRequest).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        requirements: [expect.objectContaining({ installModel: "future-video-assets" })],
+      }),
+    );
+  });
+
   it("offers Save image, Use as source, and Copy file path on a completed still", async () => {
     readyLocal();
     installedPayload = [imageModel];

--- a/desktop/src/views/GenerateView.vue
+++ b/desktop/src/views/GenerateView.vue
@@ -21,6 +21,9 @@ import PreparedExpansionBatch from "../components/generate/PreparedExpansionBatc
 import GenerateErrorNotice from "../components/generate/GenerateErrorNotice.vue";
 import MissingModelDialog from "../components/generate/MissingModelDialog.vue";
 import DownloadTargetDialog from "../components/models/DownloadTargetDialog.vue";
+import { useLicenseAcceptance } from "@studio/composables/useLicenseAcceptance";
+import { licenseRequirements } from "@studio/lib/licenseAcceptance";
+import type { GenerationPlacementPreview } from "@studio/api/generationPlacement";
 import CreateHeader from "../components/create/CreateHeader.vue";
 import ActivityStrip from "../components/create/ActivityStrip.vue";
 import ComposerCard from "../components/create/ComposerCard.vue";
@@ -254,6 +257,7 @@ const videoExportCapabilities = ref<VideoExportCapabilities>(DEFAULT_VIDEO_EXPOR
 const hostGallery = useGalleryStore();
 const downloads = useDownloadsStore();
 const pullResume = usePullResumeStore();
+const licenseAcceptance = useLicenseAcceptance();
 const liveActivity = useLiveActivityStore();
 
 function placementFailureMessage(result: Exclude<FeasibleRouteResult, { kind: "route" }>): string {
@@ -1776,6 +1780,28 @@ async function generateSequence() {
       );
       return;
     }
+    const feasibility = await hosts.resolveFeasible(hostRoute.hostId, request, 1, { signal });
+    if (!isCurrent()) return;
+    if (
+      feasibility.kind !== "route" ||
+      feasibility.route.hostId !== hostRoute.hostId ||
+      feasibility.route.target.baseUrl !== hostRoute.target.baseUrl ||
+      feasibility.route.target.apiKey !== hostRoute.target.apiKey
+    ) {
+      toasts.push(
+        feasibility.kind === "route"
+          ? "The sequence machine changed while checking dependencies. Nothing was queued."
+          : placementFailureMessage(feasibility),
+        "error",
+      );
+      return;
+    }
+    const accepted = await licenseAcceptance.request({
+      hostLabel: hostRoute.label,
+      target: hostRoute.target,
+      requirements: licenseRequirements(feasibility.preview?.pending_downloads),
+    });
+    if (!accepted || !isCurrent()) return;
     if (editing) {
       const operationId = createUuid();
       const amend: AmendRequest = {
@@ -3233,6 +3259,7 @@ async function generate() {
     // upscale-then-fit needs a route before preprocessing; local fit policies
     // can finalize the source first and avoid a duplicate placement preview.
     let route: HostRoute | null = preparedSubmission?.route ?? quickSubmission?.route ?? null;
+    let placementPreview: GenerationPlacementPreview | null = null;
     const routeRequiredForPreprocessing = sourcePreprocessingNeedsRoute(draft);
     let routeResolvedAgainstFinalRequest = false;
     let sourcePreprocessed = false;
@@ -3307,6 +3334,7 @@ async function generate() {
         return;
       }
       route = feasibility.route;
+      placementPreview = feasibility.preview ?? null;
       routeResolvedAgainstFinalRequest = sourcePreprocessed;
     }
     if (!sourcePreprocessed) {
@@ -3423,7 +3451,14 @@ async function generate() {
         return;
       }
       route = finalizedRoute;
+      placementPreview = finalized.kind === "route" ? (finalized.preview ?? null) : null;
     }
+    const accepted = await licenseAcceptance.request({
+      hostLabel: route.label,
+      target: route.target,
+      requirements: licenseRequirements(placementPreview?.pending_downloads),
+    });
+    if (!accepted || !submissionGuard.isCurrent(submitToken)) return;
     // Stash exact img2img/Qwen-edit bytes by the hashes the server records so
     // Reuse settings can restore local files and fitted sources later.
     // Fire-and-forget — never blocks the submit.

--- a/desktop/src/views/SettingsView.vue
+++ b/desktop/src/views/SettingsView.vue
@@ -4,6 +4,8 @@ import { useRoute } from "vue-router";
 import AccordionSection from "@ui/components/AccordionSection.vue";
 import CardSurface from "@ui/components/CardSurface.vue";
 import PairingAccessPanel from "@studio/components/PairingAccessPanel.vue";
+import LicenseSettingsPanel from "@studio/components/LicenseSettingsPanel.vue";
+import { openExternal } from "../lib/openExternal";
 import AppearanceCard from "../components/settings/AppearanceCard.vue";
 import UpdatesSection from "../components/settings/UpdatesSection.vue";
 import AboutSection from "../components/settings/AboutSection.vue";
@@ -148,6 +150,17 @@ function toggle(id: SectionId): void {
               :suggested-base-url="pairingBaseUrl"
               host-label="This device"
             />
+          </section>
+
+          <section data-test="license-settings-region">
+            <div class="edge-code mb-2.5 uppercase">Model licenses</div>
+            <CardSurface>
+              <LicenseSettingsPanel
+                :target="pairingTarget"
+                host-label="This device"
+                :open-external="openExternal"
+              />
+            </CardSurface>
           </section>
 
           <section ref="updatesCard" data-test="updates-card">

--- a/docs/generated/generation-profiles-v1.json
+++ b/docs/generated/generation-profiles-v1.json
@@ -16051,7 +16051,7 @@
         {
           "model": "minimax-h3-fl2va:official-bf16",
           "family": "minimax-h3",
-          "hidden": true
+          "hidden": false
         }
       ],
       "profile": {
@@ -16431,7 +16431,7 @@
         {
           "model": "minimax-h3-ref2va:official-bf16",
           "family": "minimax-h3",
-          "hidden": true
+          "hidden": false
         }
       ],
       "profile": {

--- a/docs/model-resolution-matrix.md
+++ b/docs/model-resolution-matrix.md
@@ -1442,7 +1442,7 @@ Provenance: [Upstream](https://github.com/MiniMax-AI/MiniMax-H3) at `fa6891ff7cd
 
 Schema 1 · hash `baf5ebbfd706859adbfcd3b7b66378e4fbe7412fe94fc482bac99dc0f50f2034` · default recipe `default`
 
-Models: `minimax-h3-fl2va:official-bf16` (policy-hidden).
+Models: `minimax-h3-fl2va:official-bf16`.
 
 #### Default (`default`)
 
@@ -1485,7 +1485,7 @@ Provenance: [Upstream](https://github.com/MiniMax-AI/MiniMax-H3) at `fa6891ff7cd
 
 Schema 1 · hash `1ec8cf397fdfa2d5da47e32f40162236fb66dba6059edfd39400cfa76a4184c3` · default recipe `default`
 
-Models: `minimax-h3-ref2va:official-bf16` (policy-hidden).
+Models: `minimax-h3-ref2va:official-bf16`.
 
 #### Default (`default`)
 

--- a/flake.nix
+++ b/flake.nix
@@ -225,7 +225,7 @@
           # feature implies neither CUDA nor the SM89 attention kernel, and
           # `h3-cuda` implies `cuda` so it replaces the device feature.
           desktopFeatureFor =
-            computeCap: if isLinux then if computeCap == "89" then "h3-cuda" else "cuda" else "metal";
+            computeCap: if isLinux then if computeCap == "89" then "h3-cuda" else "cuda" else "metal,h3";
           # The desktop app's complete feature recipe. `pulid` rides every
           # desktop build for the same reason it rides every `mold` release
           # recipe (#1223): the embedded This-device server advertises
@@ -265,7 +265,7 @@
                 if computeCap == "89" then "h3-cuda" else "cuda"
               },preview,discord,expand,tui,webp,mp4,metrics,mdns,pulid"
             else if gpuFeature != "" then
-              "${gpuFeature},preview,discord,expand,tui,webp,mp4,metrics,mdns,pulid"
+              "${gpuFeature},h3,preview,discord,expand,tui,webp,mp4,metrics,mdns,pulid"
             else
               "preview,discord,expand,tui,webp,mp4,metrics,mdns,pulid";
 

--- a/scripts/tests/ci-routing-contract.sh
+++ b/scripts/tests/ci-routing-contract.sh
@@ -280,8 +280,11 @@ if release_change_allowed M src/production.rs; then
 fi
 
 require_text "$ci" \
-  "cargo clippy -p mold-ai --features metal,preview,expand,tui,webp,mp4,mdns,pulid --all-targets -- -D warnings" \
+  "cargo clippy -p mold-ai --features h3,metal,preview,expand,tui,webp,mp4,mdns,pulid --all-targets -- -D warnings" \
   "Metal-gated production code is not linted"
+require_text "$ci" \
+  "cargo check -p mold-ai-server --features h3,metal,expand,mdns,metrics,mp4,pulid,webp" \
+  "the reviewed H3 Metal server recipe is not compiled"
 require_text "$ci" \
   "nix run nixpkgs#actionlint -- .github/workflows/*.yml" \
   "main release validation has no protected actionlint proof"

--- a/scripts/tests/minimax-h3-attention-release-contract.sh
+++ b/scripts/tests/minimax-h3-attention-release-contract.sh
@@ -134,8 +134,10 @@ h3_recipe_files=(
 
 while IFS= read -r feature_list; do
   [[ -n "$feature_list" ]] || continue
+  has_metal=false
+  grep -qx 'metal' <<< "$(tr ',' '\n' <<< "$feature_list")" && has_metal=true
   while IFS= read -r feature; do
-    [[ "$feature" == "h3" ]] \
+    [[ "$feature" == "h3" && "$has_metal" != true ]] \
       && fail "a shipping recipe enables the bare h3 feature ('$feature_list'); SM89 recipes must name h3-cuda"
   done < <(tr ',' '\n' <<< "$feature_list")
 done < <(enabled_feature_lists "${h3_recipe_files[@]}")
@@ -144,8 +146,9 @@ for fixture in 'cuda,h3,preview' 'h3' 'dev-bins,h3'; do
   grep -qx 'h3' <<< "$(tr ',' '\n' <<< "$fixture")" \
     || fail "bare-h3 scanner missed fixture: $fixture"
 done
-for fixture in 'h3-cuda,preview' 'dev-bins,h3-private-uat' 'cuda,h3-attention-rc'; do
-  if grep -qx 'h3' <<< "$(tr ',' '\n' <<< "$fixture")"; then
+for fixture in 'h3-cuda,preview' 'dev-bins,h3-private-uat' 'cuda,h3-attention-rc' 'h3,metal,preview'; do
+  fixture_features="$(tr ',' '\n' <<< "$fixture")"
+  if grep -qx 'h3' <<< "$fixture_features" && ! grep -qx 'metal' <<< "$fixture_features"; then
     fail "bare-h3 scanner rejected allowed fixture: $fixture"
   fi
 done
@@ -155,7 +158,10 @@ done
 require_text flake.nix \
   'if computeCap == "89" then "h3-cuda" else "cuda"' \
   "a flake feature helper no longer selects the h3-cuda edge for SM89"
-if grep -Eq '"cuda,h3"|,h3"' flake.nix; then
+require_text flake.nix \
+  '"metal,h3"' \
+  "the Darwin feature helper no longer enables the public H3 Metal path"
+if grep -Eq '"cuda,h3"' flake.nix; then
   fail "flake.nix still composes a bare cuda,h3 feature string"
 fi
 

--- a/scripts/tests/minimax-h3-private-uat-release-contract.sh
+++ b/scripts/tests/minimax-h3-private-uat-release-contract.sh
@@ -437,8 +437,8 @@ require_text crates/mold-inference/src/minimax_h3/private_server.rs \
   'let phase_owner = bind_private_comfy_fl2va_phase_owner(' \
   "private H3 server facade does not bind its prepared evidence into the singular phase owner"
 require_text crates/mold-inference/src/minimax_h3/private_server.rs \
-  'let cuda_device = commit_private_h3_allocation_then(&mut allocation_commit, || {' \
-  "private H3 server facade does not commit the scheduler allocation before CUDA construction"
+  'commit_private_h3_allocation_then(&mut allocation_commit, || {' \
+  "private H3 server facade does not commit the scheduler allocation before execution-device construction"
 require_text crates/mold-inference/src/minimax_h3/private_server.rs \
   'let mut attempt = CudaExecutionAttempt::begin_unbound()' \
   "private H3 server facade does not install containment before CUDA context construction"

--- a/studio/api/generationPlacement.ts
+++ b/studio/api/generationPlacement.ts
@@ -37,6 +37,8 @@ export interface PlacementPendingDownload {
   name: string;
   repo: string;
   bytes?: number | null;
+  install_model?: string | null;
+  licenses?: import("../lib/licenseAcceptance").LicenseTerms[] | null;
 }
 
 export interface PlacementMissingComponent {
@@ -125,6 +127,7 @@ function validPendingDownloads(value: unknown): boolean {
       return false;
     }
     const row = download as Record<string, unknown>;
+    const licenses = row.licenses;
     return (
       typeof row.kind === "string" &&
       row.kind.length > 0 &&
@@ -134,7 +137,34 @@ function validPendingDownloads(value: unknown): boolean {
       row.repo.length > 0 &&
       (row.bytes === undefined ||
         row.bytes === null ||
-        nonNegativeSafeInteger(row.bytes))
+        nonNegativeSafeInteger(row.bytes)) &&
+      (row.install_model === undefined ||
+        row.install_model === null ||
+        (typeof row.install_model === "string" &&
+          row.install_model.length > 0)) &&
+      (licenses === undefined ||
+        licenses === null ||
+        (Array.isArray(licenses) &&
+          licenses.every((license) => {
+            if (
+              typeof license !== "object" ||
+              license === null ||
+              Array.isArray(license)
+            ) {
+              return false;
+            }
+            const terms = license as Record<string, unknown>;
+            return [
+              "id",
+              "name",
+              "url",
+              "canonical",
+              "sha256",
+              "summary",
+            ].every(
+              (key) => typeof terms[key] === "string" && terms[key].length > 0,
+            );
+          })))
     );
   });
 }

--- a/studio/api/licenseAcceptance.test.ts
+++ b/studio/api/licenseAcceptance.test.ts
@@ -1,0 +1,216 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { acceptAndDownload, fetchLicenseListing } from "./licenseAcceptance";
+import type { LicenseRequirement } from "../lib/licenseAcceptance";
+
+const target = { baseUrl: "http://hal9000:7680", apiKey: "host-secret" };
+const requirement: LicenseRequirement = {
+  installModel: "future-face-adapter",
+  licenses: [
+    {
+      id: "future-research-weights",
+      name: "Future research weights",
+      url: "https://example.test/pinned",
+      canonical: "https://example.test/project",
+      sha256: "a".repeat(64),
+      summary: "Research use only.",
+    },
+  ],
+};
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("host-scoped license API", () => {
+  it("reads acceptance from the exact authenticated host", async () => {
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        Response.json({
+          licenses: [
+            { ...requirement.licenses[0], accepted: false, required_by: [] },
+          ],
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchLicenseListing(target)).resolves.toMatchObject({
+      licenses: [{ id: "future-research-weights", accepted: false }],
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://hal9000:7680/api/licenses",
+      expect.objectContaining({ headers: expect.any(Headers) }),
+    );
+    expect(
+      (fetchMock.mock.calls[0]![1]!.headers as Headers).get("x-api-key"),
+    ).toBe("host-secret");
+  });
+
+  it("sends only the exact reviewed terms and waits for terminal completion", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json({ id: "job-1", position: 0 }))
+      .mockResolvedValueOnce(
+        Response.json({
+          active_jobs: [],
+          queued: [],
+          history: [
+            {
+              id: "job-1",
+              model: "future-face-adapter",
+              status: "completed",
+              bytes_done: 10,
+              bytes_total: 10,
+            },
+          ],
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+    const progress = vi.fn();
+
+    await acceptAndDownload(target, requirement, progress);
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("http://hal9000:7680/api/downloads");
+    expect(JSON.parse(String(init?.body))).toEqual({
+      model: "future-face-adapter",
+      accept_licenses: [
+        {
+          id: "future-research-weights",
+          url: "https://example.test/pinned",
+          sha256: "a".repeat(64),
+        },
+      ],
+    });
+    expect(progress).toHaveBeenLastCalledWith({
+      model: "future-face-adapter",
+      status: "completed",
+      bytesDone: 10,
+      bytesTotal: 10,
+    });
+  });
+
+  it("joins a matching in-progress download returned as 409", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        Response.json(
+          { id: "existing-job", position: 0 },
+          { status: 409, statusText: "Conflict" },
+        ),
+      )
+      .mockResolvedValueOnce(
+        Response.json({
+          active_jobs: [],
+          queued: [],
+          history: [
+            {
+              id: "existing-job",
+              model: requirement.installModel,
+              status: "completed",
+              bytes_done: 4,
+              bytes_total: 4,
+            },
+          ],
+        }),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      acceptAndDownload(target, requirement, vi.fn()),
+    ).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it.each(["failed", "cancelled"] as const)(
+    "surfaces a %s terminal job without resuming",
+    async (status) => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(Response.json({ id: "job-1", position: 0 }))
+        .mockResolvedValueOnce(
+          Response.json({
+            active_jobs: [],
+            queued: [],
+            history: [
+              {
+                id: "job-1",
+                model: requirement.installModel,
+                status,
+                bytes_done: 1,
+                bytes_total: 4,
+                error: `${status} on host`,
+              },
+            ],
+          }),
+        );
+      vi.stubGlobal("fetch", fetchMock);
+
+      await expect(
+        acceptAndDownload(target, requirement, vi.fn()),
+      ).rejects.toThrow(`${status} on host`);
+    },
+  );
+
+  it("fails closed when a restarted host loses the accepted job", async () => {
+    vi.useFakeTimers();
+    const empty = {
+      active_jobs: [],
+      queued: [],
+      history: [],
+    };
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json({ id: "lost-job", position: 0 }));
+    for (let index = 0; index < 10; index += 1) {
+      fetchMock.mockResolvedValueOnce(Response.json(empty));
+    }
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = acceptAndDownload(target, requirement, vi.fn());
+    const rejection = expect(result).rejects.toThrow(
+      "no longer reports download 'lost-job'",
+    );
+    await vi.advanceTimersByTimeAsync(5_000);
+    await rejection;
+  });
+
+  it("cancels the exact host job when consent is withdrawn during download", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json({ id: "job-1", position: 0 }))
+      .mockResolvedValueOnce(
+        Response.json({
+          active_jobs: [],
+          queued: [
+            {
+              id: "job-1",
+              model: requirement.installModel,
+              status: "queued",
+              bytes_done: 0,
+              bytes_total: 4,
+            },
+          ],
+          history: [],
+        }),
+      )
+      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+    vi.stubGlobal("fetch", fetchMock);
+    const controller = new AbortController();
+
+    const result = acceptAndDownload(
+      target,
+      requirement,
+      vi.fn(),
+      controller.signal,
+    );
+    await vi.advanceTimersByTimeAsync(0);
+    controller.abort();
+    await expect(result).rejects.toMatchObject({ name: "AbortError" });
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      "http://hal9000:7680/api/downloads/job-1",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+});

--- a/studio/api/licenseAcceptance.ts
+++ b/studio/api/licenseAcceptance.ts
@@ -1,0 +1,170 @@
+import { ApiError, apiFetchTo, apiJsonTo, type ApiTarget } from "./client";
+import {
+  acceptanceFor,
+  licenseFromErrorBody,
+  type LicenseListing,
+  type LicenseRequirement,
+} from "../lib/licenseAcceptance";
+
+interface CreateDownloadResponse {
+  id: string;
+  position: number;
+}
+
+interface DownloadJob {
+  id: string;
+  model: string;
+  status: "queued" | "active" | "completed" | "failed" | "cancelled";
+  bytes_done: number;
+  bytes_total: number;
+  error?: string | null;
+}
+
+interface DownloadsListing {
+  active_jobs?: DownloadJob[];
+  active?: DownloadJob | null;
+  queued: DownloadJob[];
+  history: DownloadJob[];
+}
+
+export interface LicenseDownloadProgress {
+  model: string;
+  status: DownloadJob["status"] | "starting";
+  bytesDone: number;
+  bytesTotal: number;
+}
+
+export async function fetchLicenseListing(
+  target: ApiTarget,
+): Promise<LicenseListing> {
+  return apiJsonTo<LicenseListing>(target, "/api/licenses");
+}
+
+function jobs(listing: DownloadsListing): DownloadJob[] {
+  const active =
+    listing.active_jobs ?? (listing.active ? [listing.active] : []);
+  return [...active, ...listing.queued, ...listing.history];
+}
+
+const wait = (ms: number, signal?: AbortSignal) =>
+  new Promise<void>((resolve, reject) => {
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new DOMException("Download cancelled.", "AbortError"));
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+
+async function cancelDownload(target: ApiTarget, id: string) {
+  try {
+    await apiFetchTo(target, `/api/downloads/${encodeURIComponent(id)}`, {
+      method: "DELETE",
+    });
+  } catch (error) {
+    // Completion and cancellation can race. A missing terminal job needs no
+    // further action; every other host failure is still superseded by the
+    // user's explicit cancellation.
+    if (!(error instanceof ApiError && error.status === 404)) throw error;
+  }
+}
+
+/** Accept exact pinned terms on one host, download the owning bundle there,
+ * and resolve only when that host reports the job terminal. */
+export async function acceptAndDownload(
+  target: ApiTarget,
+  requirement: LicenseRequirement,
+  onProgress: (progress: LicenseDownloadProgress) => void,
+  signal?: AbortSignal,
+): Promise<void> {
+  onProgress({
+    model: requirement.installModel,
+    status: "starting",
+    bytesDone: 0,
+    bytesTotal: 0,
+  });
+  let created: CreateDownloadResponse;
+  try {
+    const response = await apiFetchTo(target, "/api/downloads", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      ...(signal ? { signal } : {}),
+      body: JSON.stringify({
+        model: requirement.installModel,
+        accept_licenses: requirement.licenses.map(acceptanceFor),
+      }),
+    });
+    created = (await response.json()) as CreateDownloadResponse;
+  } catch (error) {
+    if (error instanceof ApiError) {
+      if (
+        error.status === 409 &&
+        typeof error.body === "object" &&
+        error.body !== null &&
+        typeof (error.body as Record<string, unknown>).id === "string"
+      ) {
+        created = error.body as unknown as CreateDownloadResponse;
+      } else {
+        const current = licenseFromErrorBody(error.body);
+        if (current) {
+          throw new ApiError(error.message, error.status, {
+            ...(error.body as object),
+            license: current,
+          });
+        }
+        throw error;
+      }
+    } else {
+      throw error;
+    }
+  }
+  let missingSnapshots = 0;
+  try {
+    for (;;) {
+      if (signal?.aborted) {
+        await cancelDownload(target, created.id);
+        throw new DOMException("Download cancelled.", "AbortError");
+      }
+      const listing = await apiJsonTo<DownloadsListing>(
+        target,
+        "/api/downloads",
+        {
+          ...(signal ? { signal } : {}),
+        },
+      );
+      const job = jobs(listing).find(
+        (candidate) => candidate.id === created.id,
+      );
+      if (job) {
+        missingSnapshots = 0;
+        onProgress({
+          model: requirement.installModel,
+          status: job.status,
+          bytesDone: job.bytes_done,
+          bytesTotal: job.bytes_total,
+        });
+        if (job.status === "completed") return;
+        if (job.status === "failed" || job.status === "cancelled") {
+          throw new Error(job.error || `Download ${job.status}.`);
+        }
+      } else {
+        missingSnapshots += 1;
+        if (missingSnapshots >= 10) {
+          throw new Error(
+            `The host no longer reports download '${created.id}'. Retry the license download.`,
+          );
+        }
+      }
+      await wait(500, signal);
+    }
+  } catch (error) {
+    if (signal?.aborted) {
+      await cancelDownload(target, created.id).catch(() => undefined);
+      throw new DOMException("Download cancelled.", "AbortError");
+    }
+    throw error;
+  }
+}

--- a/studio/components/LicenseAcceptanceDialog.test.ts
+++ b/studio/components/LicenseAcceptanceDialog.test.ts
@@ -1,0 +1,53 @@
+import { mount } from "@vue/test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useLicenseAcceptance } from "../composables/useLicenseAcceptance";
+import LicenseAcceptanceDialog from "./LicenseAcceptanceDialog.vue";
+
+const licenses = useLicenseAcceptance();
+
+afterEach(() => licenses.cancel());
+
+describe("LicenseAcceptanceDialog", () => {
+  it("shows exact-host generic terms and cancellation resumes nothing", async () => {
+    const result = licenses.request({
+      hostLabel: "hal9000",
+      target: { baseUrl: "http://hal9000:7680", apiKey: "secret" },
+      requirements: [
+        {
+          installModel: "future-face-adapter",
+          licenses: [
+            {
+              id: "future-license",
+              name: "Future model terms",
+              url: "https://example.test/pinned",
+              canonical: "https://example.test/project",
+              sha256: "b".repeat(64),
+              summary: "Non-commercial research only.",
+            },
+          ],
+        },
+      ],
+    });
+    const openExternal = vi.fn();
+    const wrapper = mount(LicenseAcceptanceDialog, {
+      attachTo: document.body,
+      props: { openExternal },
+    });
+
+    expect(wrapper.text()).toContain("hal9000");
+    expect(wrapper.text()).toContain("future-face-adapter");
+    expect(wrapper.text()).toContain("Future model terms");
+    expect(wrapper.get('a[href="https://example.test/pinned"]').text()).toBe(
+      "Pinned terms",
+    );
+    expect(wrapper.get('a[href="https://example.test/project"]').text()).toBe(
+      "Project terms",
+    );
+    await wrapper.get('a[href="https://example.test/pinned"]').trigger("click");
+    expect(openExternal).toHaveBeenCalledWith("https://example.test/pinned");
+
+    await wrapper.get("button.license-secondary").trigger("click");
+    await expect(result).resolves.toBe(false);
+    wrapper.unmount();
+  });
+});

--- a/studio/components/LicenseAcceptanceDialog.vue
+++ b/studio/components/LicenseAcceptanceDialog.vue
@@ -1,0 +1,201 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import ModalPanel from "@ui/components/ModalPanel.vue";
+import { useLicenseAcceptance } from "../composables/useLicenseAcceptance";
+
+const props = defineProps<{
+  openExternal?: ((url: string) => void | Promise<void>) | undefined;
+}>();
+const licenses = useLicenseAcceptance();
+const percent = computed(() => {
+  const progress = licenses.progress.value;
+  if (!progress || progress.bytesTotal <= 0) return null;
+  return Math.min(
+    100,
+    Math.round((progress.bytesDone / progress.bytesTotal) * 100),
+  );
+});
+
+function openTerms(event: MouseEvent, url: string) {
+  if (!props.openExternal) return;
+  event.preventDefault();
+  void props.openExternal(url);
+}
+</script>
+
+<template>
+  <div
+    v-if="licenses.pending.value"
+    class="license-host"
+    data-test="license-dialog-host"
+  >
+    <ModalPanel
+      :open="true"
+      :width="520"
+      label="Review third-party model license"
+      @close="licenses.cancel()"
+    >
+      <h2 class="license-title">Review license terms</h2>
+      <p class="license-machine">
+        These terms will be accepted only on
+        <strong>{{ licenses.pending.value.hostLabel }}</strong
+        >.
+      </p>
+      <div
+        v-for="requirement in licenses.pending.value.requirements"
+        :key="requirement.installModel"
+        class="license-bundle"
+      >
+        <p class="license-model">
+          Required download: {{ requirement.installModel }}
+        </p>
+        <article
+          v-for="term in requirement.licenses"
+          :key="`${term.id}:${term.sha256}`"
+        >
+          <h3>{{ term.name }}</h3>
+          <p>{{ term.summary }}</p>
+          <p class="license-links">
+            <a
+              :href="term.url"
+              target="_blank"
+              rel="noreferrer"
+              @click="openTerms($event, term.url)"
+              >Pinned terms</a
+            >
+            <a
+              :href="term.canonical"
+              target="_blank"
+              rel="noreferrer"
+              @click="openTerms($event, term.canonical)"
+              >Project terms</a
+            >
+          </p>
+        </article>
+      </div>
+      <p v-if="licenses.error.value" class="license-error" role="alert">
+        {{ licenses.error.value }}
+      </p>
+      <div
+        v-if="licenses.progress.value"
+        class="license-progress"
+        aria-live="polite"
+      >
+        <span>
+          {{
+            licenses.progress.value.status === "starting"
+              ? "Starting"
+              : licenses.progress.value.status
+          }}
+          {{ licenses.progress.value.model }}
+        </span>
+        <span v-if="percent !== null">{{ percent }}%</span>
+      </div>
+      <template #footer>
+        <button
+          type="button"
+          class="license-secondary"
+          @click="licenses.cancel()"
+        >
+          {{ licenses.busy.value ? "Cancel download" : "Cancel" }}
+        </button>
+        <button
+          type="button"
+          class="license-primary"
+          :disabled="licenses.busy.value"
+          @click="licenses.accept()"
+        >
+          {{
+            licenses.busy.value ? "Downloading…" : "Accept terms and download"
+          }}
+        </button>
+      </template>
+    </ModalPanel>
+  </div>
+</template>
+
+<style scoped>
+.license-host {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+}
+.license-title {
+  margin: 0;
+  color: var(--rebate);
+  font: 700 20px/1.2 var(--f-display);
+}
+.license-machine {
+  margin: 8px 0 16px;
+  color: var(--ink-2);
+  font-size: 13px;
+}
+.license-bundle {
+  margin-top: 12px;
+  padding: 14px;
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-control-lg);
+  background: var(--bath);
+}
+.license-model {
+  margin: 0 0 10px;
+  color: var(--ink-3);
+  font: 600 11px/1.4 var(--f-mono);
+}
+article + article {
+  margin-top: 14px;
+  padding-top: 14px;
+  border-top: 1px solid var(--edge);
+}
+h3 {
+  margin: 0;
+  color: var(--rebate);
+  font-size: 15px;
+}
+article p {
+  margin: 6px 0 0;
+  color: var(--ink-2);
+  font-size: 13px;
+  line-height: 1.5;
+}
+.license-links {
+  display: flex;
+  gap: 16px;
+}
+a {
+  color: var(--safelight);
+}
+.license-error {
+  color: var(--danger);
+  font-size: 13px;
+}
+.license-progress {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 14px;
+  color: var(--ink-2);
+  font: 600 12px/1.4 var(--f-mono);
+}
+button {
+  min-height: 44px;
+  border-radius: var(--radius-control);
+  padding: 0 16px;
+  font: 600 13px var(--f-body);
+  cursor: pointer;
+}
+button:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+.license-secondary {
+  margin-left: auto;
+  border: 1px solid var(--ce);
+  color: var(--ink-2);
+  background: transparent;
+}
+.license-primary {
+  border: 1px solid var(--safelight);
+  color: var(--bath);
+  background: var(--safelight);
+}
+</style>

--- a/studio/components/LicenseSettingsPanel.test.ts
+++ b/studio/components/LicenseSettingsPanel.test.ts
@@ -1,0 +1,104 @@
+import { flushPromises, mount } from "@vue/test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import LicenseSettingsPanel from "./LicenseSettingsPanel.vue";
+
+const { fetchLicenseListing, request } = vi.hoisted(() => ({
+  fetchLicenseListing: vi.fn(),
+  request: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock("../api/licenseAcceptance", () => ({ fetchLicenseListing }));
+vi.mock("../composables/useLicenseAcceptance", () => ({
+  useLicenseAcceptance: () => ({ request }),
+}));
+
+const terms = (id: string, requiredBy: string[]) => ({
+  id,
+  name: `Terms ${id}`,
+  url: `https://example.test/${id}/pinned`,
+  canonical: `https://example.test/${id}`,
+  sha256: id.repeat(64).slice(0, 64),
+  summary: "Restricted use.",
+  accepted: false,
+  required_by: requiredBy,
+});
+
+afterEach(() => {
+  fetchLicenseListing.mockReset();
+  request.mockClear();
+});
+
+describe("LicenseSettingsPanel", () => {
+  it("groups every outstanding term for a future install bundle", async () => {
+    fetchLicenseListing.mockResolvedValue({
+      licenses: [terms("a", ["future-bundle"]), terms("b", ["future-bundle"])],
+    });
+    const wrapper = mount(LicenseSettingsPanel, {
+      props: {
+        target: { baseUrl: "http://host-b:7680", apiKey: "b" },
+        hostLabel: "host-b",
+      },
+    });
+    await flushPromises();
+
+    await wrapper.get(".license-settings__actions button").trigger("click");
+    expect(request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hostLabel: "host-b",
+        target: { baseUrl: "http://host-b:7680", apiKey: "b" },
+        requirements: [
+          expect.objectContaining({
+            installModel: "future-bundle",
+            licenses: [
+              expect.objectContaining({ id: "a" }),
+              expect.objectContaining({ id: "b" }),
+            ],
+          }),
+        ],
+      }),
+    );
+  });
+
+  it("fences a slow old-host response after the selected host changes", async () => {
+    let resolveA!: (value: unknown) => void;
+    let resolveB!: (value: unknown) => void;
+    fetchLicenseListing
+      .mockReturnValueOnce(new Promise((resolve) => (resolveA = resolve)))
+      .mockReturnValueOnce(new Promise((resolve) => (resolveB = resolve)));
+    const wrapper = mount(LicenseSettingsPanel, {
+      props: {
+        target: { baseUrl: "http://host-a:7680", apiKey: "a" },
+        hostLabel: "host-a",
+      },
+    });
+    await wrapper.setProps({
+      target: { baseUrl: "http://host-b:7680", apiKey: "b" },
+      hostLabel: "host-b",
+    });
+    resolveB({ licenses: [terms("b", ["bundle-b"])] });
+    await flushPromises();
+    resolveA({ licenses: [terms("a", ["bundle-a"])] });
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("Terms b");
+    expect(wrapper.text()).not.toContain("Terms a");
+  });
+
+  it("keeps a failed host visible with an explicit retry", async () => {
+    fetchLicenseListing
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValueOnce({ licenses: [] });
+    const wrapper = mount(LicenseSettingsPanel, {
+      props: {
+        target: { baseUrl: "http://host-b:7680", apiKey: "b" },
+        hostLabel: "host-b",
+      },
+    });
+    await flushPromises();
+    expect(wrapper.get("[role='alert']").text()).toContain("host-b");
+
+    await wrapper.get("[role='alert'] button").trigger("click");
+    await flushPromises();
+    expect(wrapper.text()).toContain("no third-party model licenses");
+  });
+});

--- a/studio/components/LicenseSettingsPanel.vue
+++ b/studio/components/LicenseSettingsPanel.vue
@@ -1,0 +1,231 @@
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from "vue";
+import { fetchLicenseListing } from "../api/licenseAcceptance";
+import type { ApiTarget } from "../api/client";
+import { useLicenseAcceptance } from "../composables/useLicenseAcceptance";
+import {
+  licenseRequirements,
+  type LicenseRequirement,
+  type ThirdPartyLicenseStatus,
+} from "../lib/licenseAcceptance";
+
+const props = defineProps<{
+  target: ApiTarget | null;
+  hostLabel: string;
+  openExternal?: ((url: string) => void | Promise<void>) | undefined;
+}>();
+const rows = ref<ThirdPartyLicenseStatus[]>([]);
+const loading = ref(false);
+const message = ref<string | null>(null);
+const loadError = ref<string | null>(null);
+const prompt = useLicenseAcceptance();
+const requirements = computed(() =>
+  licenseRequirements(
+    rows.value.flatMap((license) =>
+      license.accepted
+        ? []
+        : license.required_by.map((installModel) => ({
+            install_model: installModel,
+            licenses: [license],
+          })),
+    ),
+  ),
+);
+let loadEpoch = 0;
+
+async function load() {
+  const epoch = ++loadEpoch;
+  const target = props.target
+    ? { baseUrl: props.target.baseUrl, apiKey: props.target.apiKey }
+    : null;
+  if (!target) {
+    rows.value = [];
+    return;
+  }
+  loading.value = true;
+  rows.value = [];
+  loadError.value = null;
+  message.value = null;
+  try {
+    const listing = await fetchLicenseListing(target);
+    if (epoch !== loadEpoch) return;
+    rows.value = Array.isArray(listing.licenses) ? listing.licenses : [];
+    loadError.value = null;
+    message.value = null;
+  } catch {
+    if (epoch !== loadEpoch) return;
+    rows.value = [];
+    loadError.value = `Could not read licenses from ${props.hostLabel}.`;
+  } finally {
+    if (epoch === loadEpoch) loading.value = false;
+  }
+}
+
+async function review(requirement: LicenseRequirement) {
+  if (!props.target) return;
+  const accepted = await prompt.request({
+    hostLabel: props.hostLabel,
+    target: props.target,
+    requirements: [requirement],
+  });
+  if (accepted) {
+    message.value = `Required terms accepted on ${props.hostLabel}.`;
+    await load();
+  }
+}
+
+function openTerms(event: MouseEvent, url: string) {
+  if (!props.openExternal) return;
+  event.preventDefault();
+  void props.openExternal(url);
+}
+
+onMounted(load);
+watch(() => [props.target?.baseUrl, props.target?.apiKey], load);
+</script>
+
+<template>
+  <div class="license-settings" data-test="license-settings">
+    <p class="license-settings__lede">
+      Review restricted model terms for {{ hostLabel }}. Acceptance is stored on
+      {{ hostLabel }} only.
+    </p>
+    <p v-if="loading" class="license-settings__muted">Checking licenses…</p>
+    <div
+      v-if="loadError && !loading"
+      class="license-settings__load-error"
+      role="alert"
+    >
+      <span>{{ loadError }}</span>
+      <button type="button" @click="load">Retry</button>
+    </div>
+    <p v-if="message" class="license-settings__success" role="status">
+      {{ message }}
+    </p>
+    <div
+      v-if="!loadError"
+      v-for="license in rows"
+      :key="license.id"
+      class="license-settings__row"
+    >
+      <div>
+        <strong>{{ license.name }}</strong>
+        <p>{{ license.summary }}</p>
+        <a
+          :href="license.url"
+          target="_blank"
+          rel="noreferrer"
+          @click="openTerms($event, license.url)"
+          >Pinned terms</a
+        >
+        <span> · </span>
+        <a
+          :href="license.canonical"
+          target="_blank"
+          rel="noreferrer"
+          @click="openTerms($event, license.canonical)"
+          >Project terms</a
+        >
+      </div>
+      <span v-if="license.accepted" class="license-settings__accepted"
+        >Accepted</span
+      >
+      <span v-else class="license-settings__pending">Review required</span>
+    </div>
+    <div
+      v-if="!loadError && requirements.length"
+      class="license-settings__actions"
+    >
+      <button
+        v-for="requirement in requirements"
+        :key="requirement.installModel"
+        type="button"
+        @click="review(requirement)"
+      >
+        Review terms and download {{ requirement.installModel }}
+      </button>
+    </div>
+    <p
+      v-if="!loading && !loadError && rows.length === 0"
+      class="license-settings__muted"
+    >
+      This host has no third-party model licenses.
+    </p>
+  </div>
+</template>
+
+<style scoped>
+.license-settings {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  color: var(--ink-2);
+  font-size: 13px;
+}
+.license-settings__lede,
+.license-settings__muted,
+.license-settings__row p {
+  margin: 0;
+  line-height: 1.5;
+}
+.license-settings__row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 12px;
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-control-lg);
+  background: var(--bath);
+}
+.license-settings__row > div:first-child {
+  flex: 1;
+  min-width: 0;
+}
+.license-settings__row strong {
+  color: var(--rebate);
+}
+a {
+  color: var(--safelight);
+}
+.license-settings__accepted {
+  color: var(--success);
+  font: 600 11px var(--f-mono);
+  text-transform: uppercase;
+}
+.license-settings__pending {
+  color: var(--danger);
+  font: 600 11px var(--f-mono);
+  text-transform: uppercase;
+}
+.license-settings__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.license-settings__load-error {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  color: var(--danger);
+}
+button {
+  min-height: 44px;
+  border: 1px solid var(--safelight);
+  border-radius: var(--radius-control);
+  background: transparent;
+  color: var(--safelight);
+  padding: 0 12px;
+  font: 600 12px var(--f-body);
+  cursor: pointer;
+}
+.license-settings__success {
+  color: var(--success);
+}
+@media (max-width: 600px) {
+  .license-settings__row {
+    align-items: stretch;
+    flex-direction: column;
+  }
+}
+</style>

--- a/studio/composables/useLicenseAcceptance.ts
+++ b/studio/composables/useLicenseAcceptance.ts
@@ -1,0 +1,106 @@
+import { ref } from "vue";
+import { ApiError, type ApiTarget } from "../api/client";
+import {
+  acceptAndDownload,
+  type LicenseDownloadProgress,
+} from "../api/licenseAcceptance";
+import {
+  licenseFromErrorBody,
+  type LicenseRequirement,
+} from "../lib/licenseAcceptance";
+
+export interface LicensePrompt {
+  hostLabel: string;
+  target: ApiTarget;
+  requirements: LicenseRequirement[];
+}
+
+const pending = ref<LicensePrompt | null>(null);
+const progress = ref<LicenseDownloadProgress | null>(null);
+const error = ref<string | null>(null);
+const busy = ref(false);
+let settle: ((accepted: boolean) => void) | null = null;
+let controller: AbortController | null = null;
+
+export function useLicenseAcceptance() {
+  async function request(prompt: LicensePrompt): Promise<boolean> {
+    if (prompt.requirements.length === 0) return true;
+    if (pending.value)
+      throw new Error("Another license review is already open.");
+    pending.value = prompt;
+    progress.value = null;
+    error.value = null;
+    return new Promise<boolean>((resolve) => {
+      settle = resolve;
+    });
+  }
+
+  function close(accepted: boolean) {
+    const resolve = settle;
+    settle = null;
+    pending.value = null;
+    progress.value = null;
+    error.value = null;
+    busy.value = false;
+    controller = null;
+    resolve?.(accepted);
+  }
+
+  function cancel() {
+    if (busy.value) {
+      controller?.abort();
+    } else {
+      close(false);
+    }
+  }
+
+  async function accept() {
+    const prompt = pending.value;
+    if (!prompt || busy.value) return;
+    busy.value = true;
+    controller = new AbortController();
+    error.value = null;
+    try {
+      for (const requirement of prompt.requirements) {
+        await acceptAndDownload(
+          prompt.target,
+          requirement,
+          (next) => {
+            progress.value = next;
+          },
+          controller.signal,
+        );
+      }
+      close(true);
+    } catch (cause) {
+      if (cause instanceof DOMException && cause.name === "AbortError") {
+        close(false);
+        return;
+      }
+      if (cause instanceof ApiError) {
+        const current = licenseFromErrorBody(cause.body);
+        if (current) {
+          const requirement = prompt.requirements.find((row) =>
+            row.licenses.some((license) => license.id === current.id),
+          );
+          if (requirement) {
+            requirement.licenses = requirement.licenses.map((license) =>
+              license.id === current.id ? current : license,
+            );
+          }
+          error.value =
+            "The host pins newer terms. Review the updated terms before accepting.";
+        } else {
+          error.value = cause.message;
+        }
+      } else {
+        error.value = cause instanceof Error ? cause.message : String(cause);
+      }
+      busy.value = false;
+      controller = null;
+      progress.value = null;
+    }
+  }
+
+  return { pending, progress, error, busy, request, cancel, accept };
+}

--- a/studio/lib/licenseAcceptance.test.ts
+++ b/studio/lib/licenseAcceptance.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  acceptanceFor,
+  licenseFromErrorBody,
+  licenseRequirements,
+  type LicenseTerms,
+} from "./licenseAcceptance";
+
+const terms: LicenseTerms = {
+  id: "research-assets-v1",
+  name: "Research assets",
+  url: "https://example.test/pinned",
+  canonical: "https://example.test/license",
+  sha256: "a".repeat(64),
+  summary: "Non-commercial research only.",
+};
+
+describe("license acceptance contract", () => {
+  it("groups registry terms by install bundle without knowing ids", () => {
+    const companionTerms = {
+      ...terms,
+      id: "future-runtime-v2",
+      name: "Future runtime",
+      url: "https://example.test/future-runtime-pinned",
+      sha256: "b".repeat(64),
+    };
+    expect(
+      licenseRequirements([
+        {
+          install_model: "future-bundle",
+          licenses: [terms, companionTerms],
+        },
+        { install_model: "future-bundle", licenses: [{ ...terms }] },
+        {
+          install_model: "other-bundle",
+          licenses: [{ ...terms, id: "other" }],
+        },
+      ]),
+    ).toEqual([
+      {
+        installModel: "future-bundle",
+        licenses: [terms, companionTerms],
+      },
+      { installModel: "other-bundle", licenses: [{ ...terms, id: "other" }] },
+    ]);
+  });
+
+  it("sends the exact pinned terms that were displayed", () => {
+    expect(acceptanceFor(terms)).toEqual({
+      id: terms.id,
+      url: terms.url,
+      sha256: terms.sha256,
+    });
+  });
+
+  it("reads refreshed server terms structurally and ignores prose", () => {
+    expect(
+      licenseFromErrorBody({ code: "LICENSE_TERMS_MISMATCH", license: terms }),
+    ).toEqual(terms);
+    expect(licenseFromErrorBody({ error: `accept ${terms.id}` })).toBeNull();
+  });
+});

--- a/studio/lib/licenseAcceptance.ts
+++ b/studio/lib/licenseAcceptance.ts
@@ -1,0 +1,81 @@
+export interface LicenseTerms {
+  id: string;
+  name: string;
+  url: string;
+  canonical: string;
+  sha256: string;
+  summary: string;
+}
+
+export interface LicenseAcceptance {
+  id: string;
+  url: string;
+  sha256: string;
+}
+
+export interface ThirdPartyLicenseStatus extends LicenseTerms {
+  accepted: boolean;
+  required_by: string[];
+}
+
+export interface LicenseListing {
+  licenses: ThirdPartyLicenseStatus[];
+}
+
+export interface LicensedPendingDownload {
+  install_model?: string | null;
+  licenses?: LicenseTerms[] | null;
+}
+
+export interface LicenseRequirement {
+  installModel: string;
+  licenses: LicenseTerms[];
+}
+
+export function acceptanceFor(license: LicenseTerms): LicenseAcceptance {
+  return { id: license.id, url: license.url, sha256: license.sha256 };
+}
+
+function validTerms(value: unknown): value is LicenseTerms {
+  if (typeof value !== "object" || value === null || Array.isArray(value))
+    return false;
+  const row = value as Record<string, unknown>;
+  return ["id", "name", "url", "canonical", "sha256", "summary"].every(
+    (key) => typeof row[key] === "string" && row[key].length > 0,
+  );
+}
+
+/** Registry-shaped requirements carried by any placement preview.
+ *
+ * The UI deliberately knows no model or license ids. Adding a gated manifest
+ * server-side automatically feeds this same consent/download/resume workflow.
+ */
+export function licenseRequirements(
+  downloads: readonly LicensedPendingDownload[] | null | undefined,
+): LicenseRequirement[] {
+  const byModel = new Map<string, Map<string, LicenseTerms>>();
+  for (const download of downloads ?? []) {
+    const model = download.install_model?.trim();
+    if (!model || !Array.isArray(download.licenses)) continue;
+    for (const candidate of download.licenses) {
+      if (!validTerms(candidate)) continue;
+      const licenses = byModel.get(model) ?? new Map<string, LicenseTerms>();
+      licenses.set(
+        `${candidate.id}\0${candidate.url}\0${candidate.sha256.toLowerCase()}`,
+        candidate,
+      );
+      byModel.set(model, licenses);
+    }
+  }
+  return [...byModel.entries()].map(([installModel, licenses]) => ({
+    installModel,
+    licenses: [...licenses.values()],
+  }));
+}
+
+export function licenseFromErrorBody(body: unknown): LicenseTerms | null {
+  if (typeof body !== "object" || body === null || Array.isArray(body))
+    return null;
+  const row = body as Record<string, unknown>;
+  return validTerms(row.license) ? row.license : null;
+}

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -6,6 +6,7 @@ import DownloadsPopover from "./components/shell/DownloadsPopover.vue";
 import AppNav from "./components/shell/AppNav.vue";
 import CommandK from "./components/shell/CommandK.vue";
 import ConfirmDialog from "./components/shell/ConfirmDialog.vue";
+import LicenseAcceptanceDialog from "@studio/components/LicenseAcceptanceDialog.vue";
 import { dismissToast, runToastAction, useNotifications } from "./lib/toasts";
 import {
   computeEtaSeconds,
@@ -140,6 +141,7 @@ const notifications = useNotifications();
       @action="runToastAction"
     />
     <ConfirmDialog />
+    <LicenseAcceptanceDialog />
     <CommandK :open="paletteOpen" @close="paletteOpen = false" />
   </div>
 </template>

--- a/web/src/composables/useHostRouting.ts
+++ b/web/src/composables/useHostRouting.ts
@@ -191,7 +191,12 @@ export interface TransientHost {
 }
 
 export type FeasibilityResult =
-  | { kind: "route"; route: HostRoute }
+  | {
+      kind: "route";
+      route: HostRoute;
+      /** Exact preview that selected this route. Null only for legacy hosts. */
+      preview?: GenerationPlacementPreview | null;
+    }
   | {
       kind: "profile_mismatch";
       perHost: Array<{
@@ -795,6 +800,7 @@ async function resolveFeasibleWithPreview(
       if (chosen.apiKey) target.apiKey = chosen.apiKey;
       return {
         kind: "route",
+        preview: planned[0].preview,
         route: {
           hostId: chosen.id,
           label: chosen.label,
@@ -827,7 +833,12 @@ async function resolveFeasibleWithPreview(
       unsupportedIds.includes(id),
     );
     const route = resolveRoute(originRoutable, selection, legacyModelIds);
-    if (route) return { kind: "route", route: withReferenceUploads(route)! };
+    if (route)
+      return {
+        kind: "route",
+        route: withReferenceUploads(route)!,
+        preview: null,
+      };
   }
 
   const transient = probes.flatMap((probe) => {
@@ -1125,6 +1136,7 @@ async function revalidateFeasibleWithPreview(
   }
   return {
     kind: "route",
+    preview: classification === "planned" ? preview : null,
     route: {
       hostId: route.hostId,
       label: route.label,

--- a/web/src/pages/CreatePage.vue
+++ b/web/src/pages/CreatePage.vue
@@ -220,6 +220,8 @@ import { usePullResume } from "../composables/usePullResume";
 import { useFileUnder } from "../composables/useFileUnder";
 import { autoTagTitle } from "../lib/fileUnder";
 import ModelInstallTargetDialog from "../components/models/ModelInstallTargetDialog.vue";
+import { useLicenseAcceptance } from "@studio/composables/useLicenseAcceptance";
+import { licenseRequirements } from "@studio/lib/licenseAcceptance";
 import { profileConflictMessage } from "@studio/lib/profileFleet";
 import { generationCapabilitiesForFamily } from "../lib/generateCapabilities";
 import {
@@ -290,6 +292,7 @@ const router = useRouter();
 const { status } = useStatusPoll();
 const queue = useQueue();
 const routing = useHostRouting();
+const licenseAcceptance = useLicenseAcceptance();
 const installTargets = useModelInstallTargets();
 const pullResume = usePullResume();
 const liveActivity = useLiveActivity(routing);
@@ -2143,6 +2146,15 @@ async function onSubmitSequenceInner(
       );
     }
     route = feasibility.route;
+    const accepted = await licenseAcceptance.request({
+      hostLabel: route.label,
+      target: {
+        baseUrl: route.target.baseUrl,
+        apiKey: route.target.apiKey ?? null,
+      },
+      requirements: licenseRequirements(feasibility.preview?.pending_downloads),
+    });
+    if (!accepted || !isCurrent()) return;
     // Title and filing describe the STITCHED print — a sequence renders one
     // print, and the clips it stitches are never filed individually.
     const operationId = createUuid();
@@ -3794,6 +3806,17 @@ async function onSubmitInner(
     return;
   }
   route = finalizedRoute;
+  const accepted = await licenseAcceptance.request({
+    hostLabel: route.label,
+    target: {
+      baseUrl: route.target.baseUrl,
+      apiKey: route.target.apiKey ?? null,
+    },
+    requirements: licenseRequirements(
+      finalizedResult.preview?.pending_downloads,
+    ),
+  });
+  if (!accepted || !isCurrent()) return;
   submitRequestCopies(req, decision, route);
   quickPrepared.value = null;
   // Push to history immediately so ↑ recalls it before the server round-trips.

--- a/web/src/pages/SettingsPage.vue
+++ b/web/src/pages/SettingsPage.vue
@@ -10,6 +10,7 @@ import { computed, onBeforeUnmount, onMounted, ref } from "vue";
 import CardSurface from "@ui/components/CardSurface.vue";
 import PairingAccessPanel from "@studio/components/PairingAccessPanel.vue";
 import DevicePanel from "@studio/components/DevicePanel.vue";
+import LicenseSettingsPanel from "@studio/components/LicenseSettingsPanel.vue";
 import type { DeviceInfo } from "@studio/api/devices";
 import { setQueueDevicePin, type QueuePlan } from "@studio/api/queuePlan";
 import ConfigSettingsPanel from "../components/ConfigSettingsPanel.vue";
@@ -457,6 +458,11 @@ onBeforeUnmount(() => {
         </div>
       </CardSurface>
     </template>
+
+    <p class="kicker">Model licenses</p>
+    <CardSurface class="settings__card">
+      <LicenseSettingsPanel :target="pairingTarget" host-label="This machine" />
+    </CardSurface>
 
     <p class="kicker">About</p>
     <CardSurface class="settings__card settings__card--list" :padded="false">


### PR DESCRIPTION
## Summary
- add a manifest-driven, exact-terms license requirement contract that supports multiple future licenses per install bundle
- pause web, desktop, iOS, Android, and TUI generation before queueing, download required bundles on the exact host, then resume once
- expose proactive host-scoped license review in Settings with cancellation, retry, lost-job recovery, and older-server compatibility
- keep already-installed gated files from causing unnecessary consent prompts
- include two test-only all-target compilation repairs required by the current base

## Verification
- cargo clippy --workspace --all-targets -- -D warnings
- core license tests: 13 passed
- server identity placement tests: 12 passed
- TUI tests: 754 passed
- focused Studio/Desktop tests: 42 passed
- web, desktop, and shared mobile production builds
- Android APK build and 17 instrumentation tests
- iOS simulator build and runtime UAT
- rendered desktop and phone browser UAT for review, cancel, progress, and failure recovery
- independent subagent peer review: approved with no findings

Closes #1298