### PR TITLE
fix(mobile): keep gallery pagination responsive

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -202,6 +202,9 @@ pushed screen opened from the header.
   counterpart to the web/desktop thumbnail-size slider. The choice persists at
   `mold.mobile.galleryColumns.v1`, separately from the shared pixel-target key
   so a phone's zoom never rewrites a Mac's grid, and defaults to three across.
+  Infinite scroll gives each thumbnail load a fixed deadline and keeps paging
+  while its sentinel remains visible, so one stalled iOS or Android WebView
+  request can never strand older prints behind a permanent loading state.
   Tap the 44pt **Select** control to enter multi-select, then select all, clear,
   or delete the chosen prints. Delete removes every matching copy from
   reachable saved hosts; a host failure leaves that copy visible and reports

--- a/changelog.d/mobile-gallery-pagination.md
+++ b/changelog.d/mobile-gallery-pagination.md
@@ -1,0 +1,1 @@
+- **Mobile Library no longer stalls while loading older prints.** iPhone and Android now time out an unresponsive thumbnail request, clear the loading state reliably, and continue paging until every reachable older print can load.

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -4767,7 +4767,7 @@ describe("MobileApp generation queue", () => {
     expect(galleryCalls).toBe(2);
   });
 
-  it("auto-loads older prints on scroll and serializes with a completion refresh", async () => {
+  it("auto-loads older prints and defers a completion refresh while the viewer is open", async () => {
     const prints = Array.from({ length: 41 }, (_, index) => ({
       ...print,
       filename: `print-${index}.mp4`,
@@ -4793,20 +4793,13 @@ describe("MobileApp generation queue", () => {
     );
     expect(wrapper.find("button.gallery-more").exists()).toBe(false);
 
-    const olderThumbnail = { release: null as (() => void) | null };
-    apiFetchTo.mockImplementationOnce(
-      () =>
-        new Promise<Response>((resolve) => {
-          olderThumbnail.release = () =>
-            resolve({ blob: () => Promise.resolve(new Blob(["older"])) } as Response);
-        }),
-    );
     scrollToGallerySentinel();
-    await vi.waitFor(() =>
-      expect(wrapper?.get("[data-test='mobile-gallery-sentinel']").text()).toBe(
-        "Loading older prints…",
-      ),
-    );
+    await vi.waitFor(() => expect(wrapper?.findAll("[data-test='gallery-item']")).toHaveLength(41));
+    expect(wrapper.find("[data-test='mobile-gallery-sentinel']").exists()).toBe(false);
+
+    await wrapper.get("[data-test='gallery-item']").trigger("click");
+    await flushPromises();
+    expect(wrapper.find("[data-test='gallery-viewer']").exists()).toBe(true);
 
     openStreams[0]!.options.onEvent(
       "complete",
@@ -4821,15 +4814,6 @@ describe("MobileApp generation queue", () => {
       }),
     );
     openStreams[0]!.resolve();
-    await flushPromises();
-    expect(galleryCalls).toBe(1);
-
-    await wrapper.get("[data-test='gallery-item']").trigger("click");
-    await flushPromises();
-    expect(wrapper.find("[data-test='gallery-viewer']").exists()).toBe(true);
-
-    if (!olderThumbnail.release) throw new Error("Older thumbnail request did not start");
-    olderThumbnail.release();
     await flushPromises();
     expect(galleryCalls).toBe(1);
 
@@ -4872,8 +4856,158 @@ describe("MobileApp generation queue", () => {
     scrollToGallerySentinel();
 
     await vi.waitFor(() => expect(thumbnailCall).toBe(81));
-    expect(wrapper.findAll("[data-test='gallery-item']")).toHaveLength(41);
+    expect(wrapper.findAll("[data-test='gallery-item']")).toHaveLength(81);
+    expect(wrapper.findAll("[data-test='gallery-thumbnail-pending']")).toHaveLength(40);
     expect(wrapper.find("[data-test='mobile-gallery-sentinel']").exists()).toBe(false);
+  });
+
+  it("does not let a stalled thumbnail block every older print", async () => {
+    vi.useFakeTimers();
+    try {
+      const prints = Array.from({ length: 81 }, (_, index) => ({
+        ...print,
+        filename: `stalled-pagination-print-${index}.mp4`,
+        timestamp: print.timestamp - index,
+      }));
+      apiJsonTo.mockImplementation((_target: unknown, path: string) => {
+        if (path === "/api/status") return Promise.resolve(status);
+        if (path === "/api/models") return Promise.resolve([model]);
+        if (path === "/api/gallery") return Promise.resolve(prints);
+        return Promise.reject(new Error(`Unexpected API path: ${path}`));
+      });
+      let thumbnailCall = 0;
+      let stalledSignal: AbortSignal | undefined;
+      const requestedPaths: string[] = [];
+      apiFetchTo.mockImplementation((_target, path, init) => {
+        thumbnailCall += 1;
+        requestedPaths.push(path);
+        if (thumbnailCall === 41) {
+          stalledSignal = init?.signal;
+          // Model a WebView transport that ignores AbortSignal as well as
+          // never resolving. The page deadline must still advance the grid.
+          return new Promise(() => {});
+        }
+        return Promise.resolve({
+          blob: () => Promise.resolve(new Blob([`thumbnail-${thumbnailCall}`])),
+        } as Response);
+      });
+
+      wrapper = mountMobileApp();
+      await vi.advanceTimersByTimeAsync(0);
+      await wrapper.get("[data-test='mobile-tab-gallery']").trigger("click");
+      await vi.advanceTimersByTimeAsync(0);
+      expect(wrapper.findAll("[data-test='gallery-item']")).toHaveLength(40);
+
+      scrollToGallerySentinel();
+      await vi.advanceTimersByTimeAsync(50);
+
+      expect(wrapper.findAll("[data-test='gallery-item']")).toHaveLength(81);
+      expect(wrapper.findAll("[data-test='gallery-thumbnail-pending']")).toHaveLength(1);
+      expect(wrapper.text()).not.toContain("Loading older prints…");
+
+      await vi.advanceTimersByTimeAsync(5_020);
+
+      expect(stalledSignal?.aborted).toBe(true);
+      expect(requestedPaths).toContain("/api/gallery/thumbnail/stalled-pagination-print-80.mp4");
+      expect(wrapper.findAll("[data-test='gallery-item']")).toHaveLength(81);
+      expect(wrapper.findAll("[data-test='gallery-thumbnail-pending']")).toHaveLength(1);
+      expect(wrapper.find("[data-test='mobile-gallery-sentinel']").exists()).toBe(false);
+      expect(wrapper.text()).not.toContain("Loading older prints…");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("retries a failed thumbnail without blocking later prints", async () => {
+    vi.useFakeTimers();
+    try {
+      const prints = Array.from({ length: 41 }, (_, index) => ({
+        ...print,
+        filename: `retry-pagination-print-${index}.mp4`,
+        timestamp: print.timestamp - index,
+      }));
+      apiJsonTo.mockImplementation((_target: unknown, path: string) => {
+        if (path === "/api/status") return Promise.resolve(status);
+        if (path === "/api/models") return Promise.resolve([model]);
+        if (path === "/api/gallery") return Promise.resolve(prints);
+        return Promise.reject(new Error(`Unexpected API path: ${path}`));
+      });
+      const attempts = new Map<string, number>();
+      apiFetchTo.mockImplementation((_target, path) => {
+        const attempt = (attempts.get(path) ?? 0) + 1;
+        attempts.set(path, attempt);
+        if (path.endsWith("retry-pagination-print-40.mp4") && attempt === 1) {
+          return Promise.reject(new Error("temporary thumbnail failure"));
+        }
+        return Promise.resolve({
+          blob: () => Promise.resolve(new Blob([`${path}-${attempt}`])),
+        } as Response);
+      });
+
+      wrapper = mountMobileApp();
+      await vi.advanceTimersByTimeAsync(0);
+      await wrapper.get("[data-test='mobile-tab-gallery']").trigger("click");
+      await vi.advanceTimersByTimeAsync(0);
+      scrollToGallerySentinel();
+      await vi.advanceTimersByTimeAsync(20);
+
+      expect(wrapper.findAll("[data-test='gallery-item']")).toHaveLength(41);
+      expect(wrapper.findAll("[data-test='gallery-thumbnail-pending']")).toHaveLength(1);
+
+      await vi.advanceTimersByTimeAsync(4_000);
+
+      expect(wrapper.find("[data-test='gallery-thumbnail-pending']").exists()).toBe(false);
+      expect(attempts.get("/api/gallery/thumbnail/retry-pagination-print-40.mp4")).toBe(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("aborts pending thumbnail work when the mobile app unmounts", async () => {
+    const prints = Array.from({ length: 41 }, (_, index) => ({
+      ...print,
+      filename: `unmount-pagination-print-${index}.mp4`,
+      timestamp: print.timestamp - index,
+    }));
+    apiJsonTo.mockImplementation((_target: unknown, path: string) => {
+      if (path === "/api/status") return Promise.resolve(status);
+      if (path === "/api/models") return Promise.resolve([model]);
+      if (path === "/api/gallery") return Promise.resolve(prints);
+      return Promise.reject(new Error(`Unexpected API path: ${path}`));
+    });
+    const lateThumbnail = deferred<Response>();
+    let pendingSignal: AbortSignal | undefined;
+    apiFetchTo.mockImplementation((_target, path, init) => {
+      if (path.endsWith("unmount-pagination-print-40.mp4")) {
+        pendingSignal = init?.signal;
+        return lateThumbnail.promise;
+      }
+      return Promise.resolve({ blob: () => Promise.resolve(new Blob([path])) } as Response);
+    });
+
+    wrapper = mountMobileApp();
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-tab-gallery']").trigger("click");
+    await vi.waitFor(() =>
+      expect(wrapper?.find("[data-test='mobile-gallery-sentinel']").exists()).toBe(true),
+    );
+    scrollToGallerySentinel();
+    await vi.waitFor(() => expect(pendingSignal).toBeDefined());
+    const objectUrlsBeforeUnmount = vi.mocked(URL.createObjectURL).mock.calls.length;
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+
+    wrapper.unmount();
+    wrapper = null;
+    expect(pendingSignal?.aborted).toBe(true);
+    timeoutSpy.mockClear();
+    lateThumbnail.resolve({ blob: () => Promise.resolve(new Blob(["late"])) } as Response);
+    await flushPromises();
+
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(objectUrlsBeforeUnmount);
+    expect(
+      timeoutSpy.mock.calls.filter(([, delay]) => typeof delay === "number" && delay >= 2_000),
+    ).toHaveLength(0);
+    timeoutSpy.mockRestore();
   });
 
   it("keeps focus stable when the viewer closes before a queued Gallery refresh starts", async () => {
@@ -4901,20 +5035,11 @@ describe("MobileApp generation queue", () => {
       expect(wrapper?.find("[data-test='mobile-gallery-sentinel']").exists()).toBe(true),
     );
 
-    const olderThumbnail = { release: null as (() => void) | null };
-    apiFetchTo.mockImplementationOnce(
-      () =>
-        new Promise<Response>((resolve) => {
-          olderThumbnail.release = () =>
-            resolve({ blob: () => Promise.resolve(new Blob(["older"])) } as Response);
-        }),
-    );
     scrollToGallerySentinel();
-    await vi.waitFor(() =>
-      expect(wrapper?.get("[data-test='mobile-gallery-sentinel']").text()).toBe(
-        "Loading older prints…",
-      ),
-    );
+    await vi.waitFor(() => expect(wrapper?.findAll("[data-test='gallery-item']")).toHaveLength(41));
+
+    await wrapper.get("[data-test='gallery-item']").trigger("click");
+    await flushPromises();
 
     openStreams[0]!.options.onEvent(
       "complete",
@@ -4932,18 +5057,11 @@ describe("MobileApp generation queue", () => {
     await flushPromises();
     expect(galleryCalls).toBe(1);
 
-    await wrapper.get("[data-test='gallery-item']").trigger("click");
-    await flushPromises();
     await wrapper.get("[data-test='gallery-viewer-close']").trigger("click");
-    await flushPromises();
+    await vi.waitFor(() => expect(galleryCalls).toBe(2));
 
     expect(wrapper.find("[data-test='gallery-viewer']").exists()).toBe(false);
     expect(document.activeElement).toBe(wrapper.get("[data-test='mobile-tab-gallery']").element);
-    expect(galleryCalls).toBe(1);
-
-    if (!olderThumbnail.release) throw new Error("Older thumbnail request did not start");
-    olderThumbnail.release();
-    await vi.waitFor(() => expect(galleryCalls).toBe(2));
     await vi.waitFor(() => expect(wrapper?.findAll("[data-test='gallery-item']")).toHaveLength(40));
     expect(document.activeElement).toBe(wrapper.get("[data-test='mobile-tab-gallery']").element);
   });

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -432,6 +432,7 @@ interface GalleryPrint extends MobileGalleryImage {
   hostName: string;
   target: ApiTarget;
   thumbnailUrl: string;
+  thumbnailPending: boolean;
 }
 
 interface PendingGalleryPrint extends MobileGalleryImage {
@@ -542,6 +543,12 @@ const HOST_PROBE_TIMEOUT_MS = 9_000;
  *  a deadline that fires with no route would manufacture a dead end. */
 const MOBILE_PLACEMENT_SETTLE_MS = 1_500;
 const GALLERY_HOST_TIMEOUT_MS = 9_000;
+/** A broken WebView connection must not hold a thumbnail page forever. Five
+ * seconds is long enough for a remote cache miss while keeping the next page
+ * visibly responsive on a degraded mobile network. */
+const GALLERY_THUMBNAIL_TIMEOUT_MS = 5_000;
+const GALLERY_THUMBNAIL_PLACEHOLDER = "data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=";
+const GALLERY_THUMBNAIL_RETRY_MAX_MS = 30_000;
 const REUSE_PRESENTATION_TIMEOUT_MS = 9_000;
 const OUTPUT_OPTIONS = [
   { value: "single" as const, label: "One shot" },
@@ -878,8 +885,9 @@ let galleryRefreshTask: Promise<void> | null = null;
 let galleryOperationTail: Promise<void> = Promise.resolve();
 let galleryLoadMoreQueued = false;
 let gallerySentinelObserver: IntersectionObserver | null = null;
-let galleryChainedFetches = 0;
-const MAX_GALLERY_CHAINED_FETCHES = 3;
+let galleryContinuationFrame: number | null = null;
+const activeGalleryThumbnailControllers = new Set<AbortController>();
+const galleryThumbnailRetryTimers = new Map<string, ReturnType<typeof setTimeout>>();
 let galleryDragPointerId: number | null = null;
 let galleryDragActive = false;
 let galleryDragSelect = true;
@@ -5454,24 +5462,103 @@ function retryGeneratedPreview(): void {
 }
 
 async function thumbnailUrl(target: ApiTarget, hostId: string, filename: string): Promise<string> {
-  let blob = await loadCachedGalleryMedia(hostId, filename, "thumbnail");
-  if (!blob) {
-    const response = await apiFetchTo(target, galleryMediaPath(filename, "host", true));
-    blob = await response.blob();
-    void storeCachedGalleryMedia(hostId, filename, "thumbnail", blob);
+  const controller = new AbortController();
+  activeGalleryThumbnailControllers.add(controller);
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+  const deadline = new Promise<never>((_resolve, reject) => {
+    controller.signal.addEventListener(
+      "abort",
+      () => reject(new Error(`Gallery thumbnail timed out: ${filename}`)),
+      { once: true },
+    );
+    timeout = setTimeout(() => controller.abort(), GALLERY_THUMBNAIL_TIMEOUT_MS);
+  });
+  const load = async () => {
+    let blob = await loadCachedGalleryMedia(hostId, filename, "thumbnail");
+    if (controller.signal.aborted) throw new Error(`Gallery thumbnail timed out: ${filename}`);
+    if (!blob) {
+      const response = await apiFetchTo(target, galleryMediaPath(filename, "host", true), {
+        signal: controller.signal,
+      });
+      blob = await response.blob();
+      if (controller.signal.aborted) throw new Error(`Gallery thumbnail timed out: ${filename}`);
+      void storeCachedGalleryMedia(hostId, filename, "thumbnail", blob);
+    }
+    // WKWebView's native image context menu forwards an object URL as text to
+    // Share extensions. Give iOS an inline image resource so Share, Copy, and
+    // Save to Photos receive image data rather than a process-local `blob:` URL.
+    // Thumbnails are bounded to 256 px by the server, so the base64 expansion
+    // stays small; browser development keeps cheaper revocable object URLs.
+    if (isNativeIOSRuntime()) {
+      const mimeType = blob.type.startsWith("image/") ? blob.type : "image/png";
+      return `data:${mimeType};base64,${await blobToBase64(blob)}`;
+    }
+    const url = URL.createObjectURL(blob);
+    objectUrls.add(url);
+    return url;
+  };
+  try {
+    // The explicit race is intentional: some WKWebView/Android WebView fetch
+    // implementations have been observed to ignore an abort while suspended.
+    return await Promise.race([load(), deadline]);
+  } finally {
+    if (timeout !== null) clearTimeout(timeout);
+    activeGalleryThumbnailControllers.delete(controller);
   }
-  // WKWebView's native image context menu forwards an object URL as text to
-  // Share extensions. Give iOS an inline image resource so Share, Copy, and
-  // Save to Photos receive image data rather than a process-local `blob:` URL.
-  // Thumbnails are bounded to 256 px by the server, so the base64 expansion
-  // stays small; browser development keeps cheaper revocable object URLs.
-  if (isNativeIOSRuntime()) {
-    const mimeType = blob.type.startsWith("image/") ? blob.type : "image/png";
-    return `data:${mimeType};base64,${await blobToBase64(blob)}`;
-  }
-  const url = URL.createObjectURL(blob);
-  objectUrls.add(url);
-  return url;
+}
+
+function galleryThumbnailRetryKey(print: Pick<GalleryPrint, "cacheKey" | "filename">): string {
+  return `${print.cacheKey}\u0000${print.filename}`;
+}
+
+function cancelGalleryThumbnailRetries(): void {
+  for (const timer of galleryThumbnailRetryTimers.values()) clearTimeout(timer);
+  galleryThumbnailRetryTimers.clear();
+}
+
+function galleryThumbnailRetryDelay(filename: string, attempt: number): number {
+  const backoff = Math.min(2_000 * 2 ** attempt, GALLERY_THUMBNAIL_RETRY_MAX_MS);
+  // Spread a failed page across two seconds instead of waking every tile at
+  // once. The filename makes the stagger stable across reactive rerenders.
+  const stagger =
+    [...filename].reduce((sum, character) => sum + character.charCodeAt(0), 0) % 2_000;
+  return backoff + stagger;
+}
+
+function scheduleGalleryThumbnailRetry(print: GalleryPrint, attempt = 0): void {
+  if (unmounted) return;
+  const key = galleryThumbnailRetryKey(print);
+  if (galleryThumbnailRetryTimers.has(key)) return;
+  const timer = setTimeout(
+    () => {
+      galleryThumbnailRetryTimers.delete(key);
+      if (unmounted) return;
+      const current = gallery.value.find(
+        (candidate) => galleryThumbnailRetryKey(candidate) === key && candidate.thumbnailPending,
+      );
+      if (!current) return;
+      loadGalleryThumbnail(current, attempt + 1);
+    },
+    galleryThumbnailRetryDelay(print.filename, attempt),
+  );
+  galleryThumbnailRetryTimers.set(key, timer);
+}
+
+function loadGalleryThumbnail(print: GalleryPrint, failedAttempts = 0): void {
+  const key = galleryThumbnailRetryKey(print);
+  void thumbnailUrl(print.target, print.cacheKey, print.filename)
+    .then((url) => {
+      const latest = gallery.value.find(
+        (candidate) => galleryThumbnailRetryKey(candidate) === key && candidate.thumbnailPending,
+      );
+      if (!latest || unmounted) {
+        revokeObjectUrl(url);
+        return;
+      }
+      latest.thumbnailUrl = url;
+      latest.thumbnailPending = false;
+    })
+    .catch(() => scheduleGalleryThumbnailRetry(print, failedAttempts));
 }
 
 function mobileGalleryCacheKey(host: MobileHost): string {
@@ -5522,6 +5609,7 @@ function enqueueGalleryOperation(operation: () => Promise<void>): Promise<void> 
 }
 
 async function performGalleryRefresh(): Promise<void> {
+  cancelGalleryThumbnailRetries();
   clearGallerySelection();
   galleryLoading.value = true;
   galleryError.value = "";
@@ -5678,22 +5766,27 @@ function loadMoreGallery(): Promise<void> {
 
 async function loadMoreGalleryPage(): Promise<void> {
   galleryLoadingMore.value = true;
-  const page = pendingGallery.splice(0, 40);
-  for (let offset = 0; offset < page.length; offset += 4) {
-    const batch = await Promise.allSettled(
-      page.slice(offset, offset + 4).map(async ({ target, ...print }) => ({
-        ...print,
-        target,
-        thumbnailUrl: await thumbnailUrl(target, print.cacheKey, print.filename),
-      })),
-    );
-    gallery.value.push(
-      ...batch.flatMap((result) => (result.status === "fulfilled" ? [result.value] : [])),
-    );
+  try {
+    const page = pendingGallery.splice(0, 40);
+    // Place every row immediately, then hydrate each thumbnail independently.
+    // One slow WebView request cannot withhold the other 39 rows or the page's
+    // layout; browser connection pooling still bounds sockets per host.
+    const placed = page.map((print): GalleryPrint => ({
+      ...print,
+      thumbnailUrl: GALLERY_THUMBNAIL_PLACEHOLDER,
+      thumbnailPending: true,
+    }));
+    gallery.value.push(...placed);
+    for (const print of placed) loadGalleryThumbnail(print);
+    markMobileLibrarySeen(galleryCopies);
+  } finally {
+    // Loading state must settle even if a future cache/rendering change throws.
+    if (!unmounted) {
+      galleryRemaining.value = pendingGallery.length;
+      galleryLoadingMore.value = false;
+      scheduleGalleryContinuation();
+    }
   }
-  markMobileLibrarySeen(galleryCopies);
-  galleryRemaining.value = pendingGallery.length;
-  galleryLoadingMore.value = false;
 }
 
 async function reusePrint(print: GalleryPrint): Promise<void> {
@@ -6554,6 +6647,7 @@ function visibleRepresentatives(): PendingGalleryPrint[] {
 
 /** Rebuild the paged grid from the current scope, filters, and organization. */
 async function resetGalleryPaging(): Promise<void> {
+  cancelGalleryThumbnailRetries();
   for (const item of gallery.value) revokeObjectUrl(item.thumbnailUrl);
   gallery.value = [];
   pendingGallery = visibleRepresentatives();
@@ -7857,7 +7951,6 @@ watch(gallerySentinel, (sentinel) => {
     (entries) => {
       for (const entry of entries) gallerySentinelVisible.value = entry.isIntersecting;
       if (gallerySentinelVisible.value) {
-        galleryChainedFetches = 0;
         void loadMoreGallery();
       }
     },
@@ -7866,14 +7959,21 @@ watch(gallerySentinel, (sentinel) => {
   gallerySentinelObserver.observe(sentinel);
 });
 
-// Failed thumbnails can leave the sentinel in view without producing another
-// observer event. Advance a bounded number of pages so valid older prints
-// behind that failed page still become reachable.
+function scheduleGalleryContinuation(): void {
+  if (!gallerySentinelVisible.value || galleryRemaining.value === 0) return;
+  if (galleryContinuationFrame !== null) return;
+  galleryContinuationFrame = requestAnimationFrame(() => {
+    galleryContinuationFrame = null;
+    if (gallerySentinelVisible.value && galleryRemaining.value > 0) void loadMoreGallery();
+  });
+}
+
+// A sentinel can remain in view without producing another observer event.
+// Re-check once the browser has laid out the completed placeholder page; there
+// is deliberately no arbitrary page cap that can strand older prints.
 watch(galleryLoadingMore, (loading) => {
-  if (loading || !gallerySentinelVisible.value || galleryRemaining.value === 0) return;
-  if (galleryChainedFetches >= MAX_GALLERY_CHAINED_FETCHES) return;
-  galleryChainedFetches += 1;
-  void loadMoreGallery();
+  if (loading) return;
+  scheduleGalleryContinuation();
 });
 
 // One failed model load must not become a manual-Retry dead end: the 10s
@@ -8116,6 +8216,11 @@ onBeforeUnmount(() => {
   liveActivityTimer = null;
   gallerySentinelObserver?.disconnect();
   gallerySentinelObserver = null;
+  cancelGalleryThumbnailRetries();
+  for (const controller of activeGalleryThumbnailControllers) controller.abort();
+  activeGalleryThumbnailControllers.clear();
+  if (galleryContinuationFrame !== null) cancelAnimationFrame(galleryContinuationFrame);
+  galleryContinuationFrame = null;
   stopSequenceTransport();
   for (const id of [...hostProbes.keys()]) cancelHostProbe(id);
   generation.resetJobs();
@@ -9389,9 +9494,17 @@ onBeforeUnmount(() => {
                 <img
                   :src="print.thumbnailUrl"
                   :alt="print.metadata.prompt || print.filename"
+                  :class="{ 'is-thumbnail-pending': print.thumbnailPending }"
                   loading="lazy"
                   @contextmenu="rememberNativeGalleryContext(print)"
                 />
+                <span
+                  v-if="print.thumbnailPending"
+                  class="gallery-thumbnail-pending"
+                  data-test="gallery-thumbnail-pending"
+                  aria-hidden="true"
+                  >↻</span
+                >
                 <span
                   v-if="isVideoItem(print) || isAudioItem(print)"
                   class="gallery-video-badge"

--- a/desktop/src/mobile/mobile.css
+++ b/desktop/src/mobile/mobile.css
@@ -2631,6 +2631,20 @@ button:disabled {
   object-fit: cover;
 }
 
+.gallery-item img.is-thumbnail-pending {
+  opacity: 0;
+}
+
+.gallery-thumbnail-pending {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  color: var(--ink-3);
+  font-family: var(--font-utility);
+  font-size: 20px;
+}
+
 .gallery-video-badge {
   position: absolute;
   right: 8px;


### PR DESCRIPTION
## Summary
- render each mobile Gallery page immediately with stable placeholder tiles
- give thumbnail requests a fixed deadline and retry failures in the background with staggered backoff
- continue paging while the sentinel remains visible without an arbitrary page cap
- clean up pending requests, retries, and late results on refresh and unmount

## Verification
- `nix develop -c bun run --cwd desktop test --run src/mobile/MobileApp.test.ts` (290 passed)
- `nix develop -c bun run --cwd desktop build:mobile`
- `nix develop -c ios-check`
- `MOLD_ANDROID_CARGO_TARGET_DIR=/Volumes/ExternalStorage/Android/cargo-target-c4a2327a nix develop -c android-check`
- in-app browser QA at iPhone dimensions with no console warnings or errors
- Prettier and `git diff --check`

## Review
- independent agent peer review approved with no blocking findings

Closes the permanent `Loading older prints…` stall on both iOS and Android.