### PR TITLE
fix(desktop): preserve generation order in collections

### DIFF
--- a/changelog.d/collection-generation-order.md
+++ b/changelog.d/collection-generation-order.md
@@ -1,0 +1,3 @@
+- **Collections keep generation order.** Desktop collection drill-ins now stay
+  sorted newest-first by when each print was generated, rather than by when it
+  was added to the collection.

--- a/desktop/src/stores/gallery.test.ts
+++ b/desktop/src/stores/gallery.test.ts
@@ -1373,7 +1373,7 @@ describe("organization union + filters", () => {
     expect(gallery.filtered.map((e) => e.item.filename)).toEqual(["shared.png"]);
   });
 
-  it("the open collection narrows the grid only in the Collections scope, ordered by the origin list when loaded", () => {
+  it("the open collection preserves the gallery's newest-first order", () => {
     const gallery = seed();
     gallery.collectionSlug = "smurfs";
     expect(gallery.filtered).toHaveLength(3); // Prints scope ignores the drill-in
@@ -1381,9 +1381,7 @@ describe("organization union + filters", () => {
     expect(gallery.filtered.map((e) => e.item.filename)).toEqual(["shared.png", "remote.png"]);
     expect(gallery.collectionCounts("smurfs")).toBe(2);
     expect(gallery.collectionCounts("river-studies")).toBe(0);
-    // Origin order: hal's list puts remote first.
-    gallery.collectionItemsByHost["hal9000-7680"] = { h9: ["remote.png", "shared.png"] };
-    expect(gallery.filtered.map((e) => e.item.filename)).toEqual(["remote.png", "shared.png"]);
+    expect(gallery.filtered.map((e) => e.item.filename)).toEqual(["shared.png", "remote.png"]);
   });
 
   it("text search also matches the title", () => {

--- a/desktop/src/stores/gallery.ts
+++ b/desktop/src/stores/gallery.ts
@@ -351,9 +351,6 @@ export const useGalleryStore = defineStore("gallery", {
     collectionsByHost: {} as Record<string, CollectionsBucket>,
     /** Per-host tag counts, merged by case-insensitive name in `mergedTags`. */
     tagsByHost: {} as Record<string, TagsBucket>,
-    /** Per-host `{ collectionId → ordered filenames }` from
-     *  `GET /api/gallery/collections/:id`; orders a drill-in when present. */
-    collectionItemsByHost: {} as Record<string, Record<string, string[]>>,
   }),
   getters: {
     /**
@@ -650,9 +647,9 @@ export const useGalleryStore = defineStore("gallery", {
     /**
      * What the Gallery grid renders: host chip → media kind → text query →
      * ♥ favorites → tag chips (AND over the union tags) → the open
-     * collection (Collections scope drill-in only). Inside a collection the
-     * origin's recorded order wins when its item list has loaded; otherwise
-     * newest first.
+     * collection (Collections scope drill-in only). Filtering preserves the
+     * gallery's newest-first generation order; collection membership order is
+     * deliberately irrelevant because it records when prints were filed.
      */
     filtered(): MergedPrint[] {
       let entries = this.narrowByKindAndQuery(this.hostFiltered);
@@ -672,39 +669,7 @@ export const useGalleryStore = defineStore("gallery", {
         if (slug && !org.collections.includes(slug)) return false;
         return true;
       });
-      if (slug) {
-        const order = this.collectionOrder(slug);
-        if (order) {
-          const rank = (entry: MergedPrint): number => {
-            let best = Number.POSITIVE_INFINITY;
-            const copies = entry.copies ?? [{ sourceKey: entry.sourceKey, item: entry.item }];
-            for (const copy of copies) {
-              const at = order.get(copy.item.filename);
-              if (at !== undefined && at < best) best = at;
-            }
-            return best;
-          };
-          entries = [...entries].sort((a, b) => rank(a) - rank(b));
-        }
-      }
       return entries;
-    },
-    /** `filename → position` for a collection's origin order (local host
-     *  preferred, else the first host whose item list has loaded). */
-    collectionOrder(): (slug: string) => Map<string, number> | null {
-      return (slug) => {
-        const merged = this.mergedCollections.find((c) => c.slug === slug);
-        if (!merged) return null;
-        const hosts = [...merged.hosts].sort((a, b) =>
-          a.hostId === "local" ? -1 : b.hostId === "local" ? 1 : 0,
-        );
-        for (const host of hosts) {
-          const filenames = this.collectionItemsByHost[host.hostId]?.[host.id];
-          if (!filenames) continue;
-          return new Map(filenames.map((filename, index) => [filename, index]));
-        }
-        return null;
-      };
     },
     /** Per-kind counts for the All/Images/Video/Audio chips. Computed over
      *  the host-chip-filtered set only, so chip labels stay stable while the
@@ -840,9 +805,6 @@ export const useGalleryStore = defineStore("gallery", {
       }
       for (const key of Object.keys(this.tagsByHost)) {
         if (!keys.has(key)) delete this.tagsByHost[key];
-      }
-      for (const key of Object.keys(this.collectionItemsByHost)) {
-        if (!keys.has(key)) delete this.collectionItemsByHost[key];
       }
       if (this.filter !== "all" && !keys.has(this.filter)) this.filter = "all";
     },
@@ -1356,31 +1318,6 @@ export const useGalleryStore = defineStore("gallery", {
       this.syncBuckets();
       await Promise.all([this.fetchCollections(), this.fetchTags(), this.fetchTrash()]);
     },
-    /** `GET /api/gallery/collections/:id` on every host holding the slug —
-     *  records the origin order used inside a drill-in. */
-    async fetchCollectionItems(slug: string) {
-      const merged = this.mergedCollections.find((c) => c.slug === slug);
-      if (!merged) return;
-      await Promise.all(
-        merged.hosts.map(async (host) => {
-          const target = this.targetOf(host.hostId);
-          if (!target) return;
-          try {
-            const detail = await apiJsonTo<{ filenames?: string[] }>(
-              target,
-              `/api/gallery/collections/${encodeURIComponent(host.id)}`,
-            );
-            const filenames = Array.isArray(detail?.filenames) ? detail.filenames : [];
-            const byHost = this.collectionItemsByHost[host.hostId] ?? {};
-            byHost[host.id] = filenames;
-            this.collectionItemsByHost[host.hostId] = byHost;
-          } catch {
-            // Order is a nicety; the drill-in falls back to newest first.
-          }
-        }),
-      );
-    },
-
     // ── Organization: mutate ─────────────────────────────────────────────
     /** Organize-capable per-host targets for a set of copies. Hosts that
      *  cannot organize (old servers, the offline IPC bucket) are skipped,
@@ -1705,8 +1642,6 @@ export const useGalleryStore = defineStore("gallery", {
               }
             }
           }
-          const items = this.collectionItemsByHost[host.hostId];
-          if (items) delete items[host.id];
         }),
       );
       const outcome = this.settleHosts(keys, results);

--- a/desktop/src/views/LibraryView.shelf.test.ts
+++ b/desktop/src/views/LibraryView.shelf.test.ts
@@ -744,11 +744,23 @@ describe("Collections scope", () => {
     expect(wrapper.get("[data-test='library-count']").text()).toBe("2 collections");
     expect(wrapper.find("input[aria-label='Thumbnail size']").exists()).toBe(false);
 
+    // The collection endpoint records membership order (when prints were
+    // added), which is deliberately the reverse of generation time here.
+    apiJsonTo.mockImplementation(async (_target: unknown, path: string) => {
+      if (path === "/api/gallery") return live.map((p) => structuredClone(p));
+      if (path.startsWith("/api/gallery/collections/")) {
+        return { filenames: [smurf03.filename, smurf04.filename] };
+      }
+      return undefined;
+    });
     await cards[1]!.trigger("click");
     await flushPromises();
     expect(router.currentRoute.value.query).toMatchObject({ scope: "collections", c: "smurfs" });
     expect(wrapper.get("[data-test='crumb-here']").text()).toBe("Smurfs");
     expect(wrapper.findAll(".ms-lib-tile")).toHaveLength(2);
+    expect(wrapper.findAll(".ms-lib-tile").map((tile) => tile.attributes("data-filename"))).toEqual(
+      [smurf04.filename, smurf03.filename],
+    );
     expect(wrapper.get("[data-test='collection-chip']").text()).toContain("Smurfs");
 
     // Inside the collection the tile menu offers Use as cover / Remove.

--- a/desktop/src/views/LibraryView.vue
+++ b/desktop/src/views/LibraryView.vue
@@ -796,7 +796,6 @@ function openCollectionSlug(slug: string) {
   gallery.collectionSlug = slug;
   setSelectMode(false);
   selected.value = null;
-  void gallery.fetchCollectionItems(slug);
 }
 function exitCollection() {
   gallery.collectionSlug = null;
@@ -1905,15 +1904,6 @@ watch(
     ] as const,
   ([, organize, trash]) => {
     if (organize || trash) void gallery.fetchOrganization();
-  },
-  { immediate: true },
-);
-
-// A drill-in needs the origin order of its collection.
-watch(
-  () => (inCollections.value ? gallery.collectionSlug : null),
-  (slug) => {
-    if (slug) void gallery.fetchCollectionItems(slug);
   },
   { immediate: true },
 );


### PR DESCRIPTION
## Summary
- keep collection drill-ins sorted newest-first by generation time
- remove obsolete collection-membership ordering requests and state
- add store and view regressions for reverse membership order

## Verification
- `nix develop -c bash -lc 'cd desktop && bun run test -- src/stores/gallery.test.ts src/views/LibraryView.shelf.test.ts'` (121 passed)\n- `nix develop -c bash -lc 'cd desktop && bun run build'`\n- `nix develop -c bash -lc 'bunx prettier --check desktop/src/stores/gallery.ts desktop/src/stores/gallery.test.ts desktop/src/views/LibraryView.vue desktop/src/views/LibraryView.shelf.test.ts'`\n- independent sub-agent peer review: approved, no remaining findings\n\n## Full-suite note\n- Full desktop suite: 4,823 passed; one unrelated mobile timing test failed once and passed immediately when rerun in isolation.