### PR TITLE
fix(ui): repair cold-start model downloads

### DIFF
--- a/changelog.d/cold-start-model-downloads.md
+++ b/changelog.d/cold-start-model-downloads.md
@@ -1,0 +1,1 @@
+- **Reliable first-run model downloads.** Fixed the Z-Image Turbo and SDXL starter buttons so every first-run model can be downloaded, with visible errors when a pull cannot start.

--- a/crates/mold-server/src/routes_test.rs
+++ b/crates/mold-server/src/routes_test.rs
@@ -11354,6 +11354,36 @@ mod tests {
         assert_eq!(listing.queued[0].model, "flux-schnell:q4");
     }
 
+    #[tokio::test]
+    async fn post_api_downloads_accepts_every_cold_start_starter() {
+        let state = AppState::empty(
+            mold_core::Config::default(),
+            crate::state::QueueHandle::new(tokio::sync::mpsc::channel(1).0),
+            AppState::empty_gpu_pool_for_test(),
+            200,
+        );
+        let app = app_with_state(state.clone());
+
+        for model in ["flux2-klein:q4", "z-image-turbo:q8", "sdxl-base:fp16"] {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::post("/api/downloads")
+                        .header("content-type", "application/json")
+                        .body(Body::from(
+                            serde_json::json!({ "model": model }).to_string(),
+                        ))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK, "starter {model}");
+        }
+
+        let listing = state.downloads.listing().await;
+        assert_eq!(listing.queued.len(), 3);
+    }
+
     /// Point `MOLD_HOME` at a throwaway root through the SHARED env guard.
     ///
     /// License acceptance is per Mold data root, so these tests write to it —

--- a/desktop/src/components/generate/StarterCards.test.ts
+++ b/desktop/src/components/generate/StarterCards.test.ts
@@ -1,8 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { mount } from "@vue/test-utils";
+import { flushPromises, mount } from "@vue/test-utils";
 import { createPinia, setActivePinia } from "pinia";
 import StarterCards from "./StarterCards.vue";
 import { useDownloadsStore } from "../../stores/downloads";
+import { useToastStore } from "../../stores/toasts";
 import type { DownloadJob } from "../../lib/api/types";
 
 function job(overrides: Partial<DownloadJob> = {}): DownloadJob {
@@ -37,17 +38,37 @@ describe("StarterCards (cold start G10)", () => {
     expect(wrapper.text()).toContain("Browse all models");
   });
 
-  it("pulls a model through the downloads store on click", async () => {
+  it("pulls every starter with its canonical manifest id", async () => {
     const store = useDownloadsStore();
     const createDownload = vi.spyOn(store, "createDownload").mockResolvedValue(undefined);
     const subscribe = vi.spyOn(store, "subscribe").mockResolvedValue(undefined);
     const wrapper = mount(StarterCards);
 
-    await wrapper.findAll("[data-test='starter-pull']")[0]!.trigger("click");
-    await Promise.resolve();
+    for (const button of wrapper.findAll("[data-test='starter-pull']")) {
+      await button.trigger("click");
+      await flushPromises();
+    }
 
-    expect(createDownload).toHaveBeenCalledWith("flux2-klein:q4");
-    expect(subscribe).toHaveBeenCalled();
+    expect(createDownload.mock.calls).toEqual([
+      ["flux2-klein:q4"],
+      ["z-image-turbo:q8"],
+      ["sdxl-base:fp16"],
+    ]);
+    expect(subscribe).toHaveBeenCalledTimes(3);
+  });
+
+  it("reports a rejected starter pull instead of failing silently", async () => {
+    const store = useDownloadsStore();
+    vi.spyOn(store, "createDownload").mockRejectedValue(new Error("unknown model"));
+    const wrapper = mount(StarterCards);
+
+    await wrapper.findAll("[data-test='starter-pull']")[1]!.trigger("click");
+    await flushPromises();
+
+    expect(useToastStore().items.at(-1)).toMatchObject({
+      kind: "error",
+      message: "Couldn't pull z-image-turbo:q8 — unknown model",
+    });
   });
 
   it("shows inline progress on the pulling card instead of a Pull button", () => {

--- a/desktop/src/components/generate/StarterCards.vue
+++ b/desktop/src/components/generate/StarterCards.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed } from "vue";
-import { STARTER_MODELS } from "@studio/lib/starterModels";
+import { STARTER_MODELS } from "@mold/studio";
 import { useDownloadsStore } from "../../stores/downloads";
 import { useToastStore } from "../../stores/toasts";
 import { percent } from "../../lib/format";

--- a/desktop/src/components/generate/StarterCards.vue
+++ b/desktop/src/components/generate/StarterCards.vue
@@ -1,25 +1,19 @@
 <script setup lang="ts">
 import { computed } from "vue";
+import { STARTER_MODELS } from "@studio/lib/starterModels";
 import { useDownloadsStore } from "../../stores/downloads";
+import { useToastStore } from "../../stores/toasts";
 import { percent } from "../../lib/format";
 import type { DownloadJob } from "../../lib/api/types";
 
 const emit = defineEmits<{ (e: "browse"): void }>();
 
 const downloads = useDownloadsStore();
+const toasts = useToastStore();
 
 // Cold start (§08 G10): the shortest path to a first print. Three small,
 // fast-to-pull models — the recommended one first — each a one-click pull.
-interface Starter {
-  model: string;
-  label: string;
-  recommended?: boolean;
-}
-const STARTERS: Starter[] = [
-  { model: "flux2-klein:q4", label: "fast, 6.9 GB", recommended: true },
-  { model: "z-image:turbo", label: "fastest, 3.4 GB" },
-  { model: "sdxl:base", label: "classic, 6.6 GB" },
-];
+const STARTERS = STARTER_MODELS;
 
 // Match an in-flight download to a starter by model base name (the server may
 // canonicalize the tag we posted).
@@ -30,8 +24,16 @@ function jobFor(model: string): DownloadJob | null {
 const pulling = computed(() => new Set(STARTERS.map((s) => s.model).filter((m) => jobFor(m))));
 
 async function pull(model: string) {
-  await downloads.createDownload(model);
-  downloads.subscribe();
+  try {
+    await downloads.createDownload(model);
+    void downloads.subscribe().catch((error) => {
+      const detail = error instanceof Error ? error.message : String(error);
+      toasts.push(`Pull started, but progress is unavailable — ${detail}`, "error");
+    });
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    toasts.push(`Couldn't pull ${model} — ${detail}`, "error");
+  }
 }
 </script>
 
@@ -66,7 +68,7 @@ async function pull(model: string) {
             Recommended
           </span>
         </div>
-        <span class="text-caption text-ink-3">{{ starter.label }}</span>
+        <span class="text-caption text-ink-3">{{ starter.speed }}, {{ starter.size }}</span>
         <div class="flex-1" />
         <template v-if="jobFor(starter.model)">
           <div class="h-1.5 overflow-hidden rounded-full bg-bath">

--- a/knip.json
+++ b/knip.json
@@ -3,7 +3,7 @@
   "include": ["files", "dependencies", "exports"],
   "ignoreExportsUsedInFile": true,
   "ignoreBinaries": ["gh"],
-  "ignoreDependencies": ["@mold/studio", "@mold/ui", "tailwindcss"],
+  "ignoreDependencies": ["@mold/ui", "tailwindcss"],
   "ignoreFiles": ["docs/**", "website/**", "result*", "result*/**"],
   "workspaces": {
     "studio": {

--- a/studio/index.ts
+++ b/studio/index.ts
@@ -8,3 +8,4 @@ export * from "./lib/chainRouting";
 export * from "./lib/modelDisplay";
 export * from "./lib/sequence";
 export * from "./lib/base64";
+export * from "./lib/starterModels";

--- a/studio/lib/starterModels.ts
+++ b/studio/lib/starterModels.ts
@@ -1,0 +1,37 @@
+export interface StarterModel {
+  model: string;
+  displayName: string;
+  speed: string;
+  size: string;
+  recommended: boolean;
+}
+
+/**
+ * Canonical manifest ids offered on an empty Create surface.
+ *
+ * Keep the explicit tags here: these values go directly to `/api/downloads`,
+ * whose `name:tag` inputs are treated as canonical rather than alias-resolved.
+ */
+export const STARTER_MODELS = [
+  {
+    model: "flux2-klein:q4",
+    displayName: "FLUX.2 Klein",
+    speed: "fast",
+    size: "6.9 GB",
+    recommended: true,
+  },
+  {
+    model: "z-image-turbo:q8",
+    displayName: "Z-Image Turbo",
+    speed: "fastest",
+    size: "3.4 GB",
+    recommended: false,
+  },
+  {
+    model: "sdxl-base:fp16",
+    displayName: "SDXL",
+    speed: "classic",
+    size: "6.6 GB",
+    recommended: false,
+  },
+] as const satisfies readonly StarterModel[];

--- a/web/src/components/create/ColdStartGuide.test.ts
+++ b/web/src/components/create/ColdStartGuide.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { mount } from "@vue/test-utils";
 import ColdStartGuide from "./ColdStartGuide.vue";
 
 const enqueue = vi.hoisted(() => vi.fn(async () => undefined));
+const toastMock = vi.hoisted(() => vi.fn());
 const dlState = vi.hoisted(() => ({
   active: [] as unknown[],
   queued: [] as unknown[],
@@ -14,10 +15,17 @@ vi.mock("../../composables/useDownloads", () => ({
     enqueue,
   }),
 }));
+vi.mock("../../lib/toasts", () => ({ toast: toastMock }));
 
 function mountGuide() {
   return mount(ColdStartGuide);
 }
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  dlState.active = [];
+  dlState.queued = [];
+});
 
 describe("ColdStartGuide", () => {
   it("renders the guide with three starter models, recommended first", () => {
@@ -29,21 +37,45 @@ describe("ColdStartGuide", () => {
     expect(wrapper.find('[data-test="starter-flux2-klein:q4"]').exists()).toBe(
       true,
     );
-    expect(wrapper.find('[data-test="starter-z-image:turbo"]').exists()).toBe(
+    expect(
+      wrapper.find('[data-test="starter-z-image-turbo:q8"]').exists(),
+    ).toBe(true);
+    expect(wrapper.find('[data-test="starter-sdxl-base:fp16"]').exists()).toBe(
       true,
     );
-    expect(wrapper.find('[data-test="starter-sdxl:base"]').exists()).toBe(true);
     expect(wrapper.text()).toContain("recommended");
   });
 
-  it("enqueues a download when a starter's Pull is clicked", async () => {
+  it("enqueues every starter with its canonical manifest id", async () => {
     dlState.active = [];
     dlState.queued = [];
     const wrapper = mountGuide();
+    for (const model of [
+      "flux2-klein:q4",
+      "z-image-turbo:q8",
+      "sdxl-base:fp16",
+    ]) {
+      await wrapper.get(`[data-test="starter-pull-${model}"]`).trigger("click");
+    }
+    expect(enqueue.mock.calls).toEqual([
+      ["flux2-klein:q4"],
+      ["z-image-turbo:q8"],
+      ["sdxl-base:fp16"],
+    ]);
+  });
+
+  it("reports a rejected starter pull instead of failing silently", async () => {
+    enqueue.mockRejectedValueOnce(new Error("unknown model"));
+    const wrapper = mountGuide();
+
     await wrapper
-      .get('[data-test="starter-pull-flux2-klein:q4"]')
+      .get('[data-test="starter-pull-z-image-turbo:q8"]')
       .trigger("click");
-    expect(enqueue).toHaveBeenCalledWith("flux2-klein:q4");
+
+    expect(toastMock).toHaveBeenCalledWith(
+      "error",
+      "couldn't pull z-image-turbo:q8 — unknown model",
+    );
   });
 
   it("shows inline progress in place of Pull while a starter is downloading", () => {
@@ -70,7 +102,7 @@ describe("ColdStartGuide", () => {
   it("marks a queued starter as queued", () => {
     dlState.active = [];
     dlState.queued = [
-      { id: "q1", model: "sdxl:base", status: "queued", bytes_total: 0 },
+      { id: "q1", model: "sdxl-base:fp16", status: "queued", bytes_total: 0 },
     ];
     const wrapper = mountGuide();
     expect(wrapper.text()).toContain("queued");

--- a/web/src/components/create/ColdStartGuide.vue
+++ b/web/src/components/create/ColdStartGuide.vue
@@ -8,30 +8,16 @@
  * returns to the normal empty state (the parent stops rendering this).
  */
 import { computed } from "vue";
+import { STARTER_MODELS } from "@studio/lib/starterModels";
 import Icon from "@ui/components/Icon.vue";
 import ProgressBar from "@ui/components/ProgressBar.vue";
 import { useDownloads } from "../../composables/useDownloads";
+import { toast } from "../../lib/toasts";
 import type { DownloadJobWire } from "../../types";
-
-interface Starter {
-  name: string;
-  label: string;
-  note: string;
-  recommended?: boolean;
-}
 
 // Recommended-first: a fast, capable default, then the smallest/fastest, then a
 // familiar classic. Names are canonical manifest ids the downloads API accepts.
-const starters: Starter[] = [
-  {
-    name: "flux2-klein:q4",
-    label: "FLUX.2 Klein",
-    note: "fast · 6.9 GB",
-    recommended: true,
-  },
-  { name: "z-image:turbo", label: "Z-Image Turbo", note: "fastest · 3.4 GB" },
-  { name: "sdxl:base", label: "SDXL", note: "classic · 6.6 GB" },
-];
+const starters = STARTER_MODELS;
 
 const downloads = useDownloads();
 
@@ -55,11 +41,16 @@ function statusLabel(job: DownloadJobWire): string {
 }
 
 const anyPulling = computed(() =>
-  starters.some((s) => jobFor(s.name) !== null),
+  starters.some((s) => jobFor(s.model) !== null),
 );
 
-function pull(name: string) {
-  void downloads.enqueue(name);
+async function pull(model: string) {
+  try {
+    await downloads.enqueue(model);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    toast("error", `couldn't pull ${model} — ${detail}`);
+  }
 }
 </script>
 
@@ -76,36 +67,36 @@ function pull(name: string) {
     <div class="cold__starters">
       <div
         v-for="s in starters"
-        :key="s.name"
+        :key="s.model"
         class="cold__card"
-        :data-test="`starter-${s.name}`"
+        :data-test="`starter-${s.model}`"
       >
         <div class="cold__meta">
           <div class="cold__name-row">
-            <span class="cold__name">{{ s.label }}</span>
+            <span class="cold__name">{{ s.displayName }}</span>
             <span v-if="s.recommended" class="cold__rec">recommended</span>
           </div>
-          <span class="cold__note">{{ s.note }}</span>
+          <span class="cold__note">{{ s.speed }} · {{ s.size }}</span>
         </div>
 
         <div
-          v-if="jobFor(s.name)"
+          v-if="jobFor(s.model)"
           class="cold__progress"
-          :data-test="`starter-progress-${s.name}`"
+          :data-test="`starter-progress-${s.model}`"
         >
           <ProgressBar
-            :value="pct(jobFor(s.name)!)"
+            :value="pct(jobFor(s.model)!)"
             tone="accent"
             :height="6"
           />
-          <span class="cold__status">{{ statusLabel(jobFor(s.name)!) }}</span>
+          <span class="cold__status">{{ statusLabel(jobFor(s.model)!) }}</span>
         </div>
         <button
           v-else
           type="button"
           class="cold__pull"
-          :data-test="`starter-pull-${s.name}`"
-          @click="pull(s.name)"
+          :data-test="`starter-pull-${s.model}`"
+          @click="pull(s.model)"
         >
           Pull
         </button>

--- a/web/src/components/create/ColdStartGuide.vue
+++ b/web/src/components/create/ColdStartGuide.vue
@@ -8,7 +8,7 @@
  * returns to the normal empty state (the parent stops rendering this).
  */
 import { computed } from "vue";
-import { STARTER_MODELS } from "@studio/lib/starterModels";
+import { STARTER_MODELS } from "@mold/studio";
 import Icon from "@ui/components/Icon.vue";
 import ProgressBar from "@ui/components/ProgressBar.vue";
 import { useDownloads } from "../../composables/useDownloads";


### PR DESCRIPTION
## Summary

- centralize the three cold-start choices with canonical manifest IDs shared by desktop and web
- show pull and progress-subscription failures instead of leaving starter buttons visually inert
- cover every starter through both UI click tests and the real POST /api/downloads endpoint

## Verification

- nix develop -c bun --cwd desktop test --run src/components/generate/StarterCards.test.ts (5 passed)
- nix develop -c bun --cwd web test --run src/components/create/ColdStartGuide.test.ts (5 passed)
- nix develop -c env RUSTC_WRAPPER= cargo test -p mold-ai-server post_api_downloads_accepts_every_cold_start_starter --lib (1 passed)
- nix develop -c bun --cwd desktop build
- nix develop -c bun --cwd web build
- rendered /create QA: all three canonical IDs present; rejected pull reports visibly; no framework overlay

## Review

Independent agent peer review completed with no findings.