### PR TITLE
test(mobile): guard batch advanced badge

### DIFF
--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -6108,6 +6108,26 @@ describe("MobileApp create settings reset", () => {
     expect(wrapper.find("[data-test='mobile-advanced-trigger-count']").exists()).toBe(false);
   });
 
+  it("does not badge the general Batch setting as Advanced", async () => {
+    wrapper = mountMobileApp();
+    await flushPromises();
+
+    const batch = wrapper.get("[data-test='mobile-batch-value']");
+    await batch.setValue("30");
+    await batch.trigger("change");
+    await flushPromises();
+
+    expect(batch.attributes("value")).toBe("30");
+    expect(wrapper.find("[data-test='mobile-advanced-trigger-count']").exists()).toBe(false);
+
+    await fieldControl("Negative prompt").setValue("anime, cartoon, graphic, washed out");
+    await flushPromises();
+    expect(wrapper.get("[data-test='mobile-advanced-trigger-count']").text()).toBe("1");
+
+    await wrapper.get("[data-test='mobile-open-advanced']").trigger("click");
+    expect(wrapper.get("[data-test='mobile-advanced-count']").text()).toBe("1");
+  });
+
   it("keeps generated audio in the primary Create settings", async () => {
     wrapper = mountMobileApp();
     await flushPromises();

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -6120,6 +6120,8 @@ describe("MobileApp create settings reset", () => {
     expect(batch.attributes("value")).toBe("30");
     expect(wrapper.find("[data-test='mobile-advanced-trigger-count']").exists()).toBe(false);
 
+    // The reported Hal9000 batch restored this actual Advanced field; it is
+    // the source of the pictured `1`, not the adjacent Batch value.
     await fieldControl("Negative prompt").setValue("anime, cartoon, graphic, washed out");
     await flushPromises();
     expect(wrapper.get("[data-test='mobile-advanced-trigger-count']").text()).toBe("1");


### PR DESCRIPTION
## Summary
- add mobile regression coverage proving the primary Batch control does not activate the Advanced badge
- retain the positive control that a real advanced negative prompt increments both Advanced badges
- document the verified behavior behind the reported Batch 30 screenshot

## Investigation
- Hal9000 gallery metadata for the pictured 30-print batch records `negative_prompt: "anime, cartoon, graphic, washed out"`
- Batch itself is absent from `advancedActiveCount`; the restored negative prompt is the displayed `1`

## Verification
- `nix develop -c bun --cwd desktop vitest run src/mobile/MobileApp.test.ts` (291 passed)
- `nix develop -c bunx prettier --check desktop/src/mobile/MobileApp.test.ts`
- rendered 393x852 mobile QA against Hal9000: Batch 30 => no badge; negative prompt => badge 1; clearing negative prompt => no badge; no console warnings/errors
- independent Codex agent review: no findings
- Claude Sonnet review: no findings