### PR TITLE
fix: retain bulk work across disconnects

### DIFF
--- a/changelog.d/durable-bulk-admission-gallery-outbox.md
+++ b/changelog.d/durable-bulk-admission-gallery-outbox.md
@@ -1,0 +1,1 @@
+- **Bulk work now survives disconnects and offline hosts.** Prepared iPhone batches are admitted atomically to the durable host queue, while gallery selections use replay-safe bulk operations and retain organization edits across app restarts until the exact target host returns.

--- a/crates/mold-core/src/types.rs
+++ b/crates/mold-core/src/types.rs
@@ -7667,6 +7667,79 @@ pub struct GalleryOrganizeRequest {
     pub remove_from_collections: Option<Vec<String>>,
 }
 
+/// One title assignment inside a bulk organization request.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct GalleryTitleAssignment {
+    pub filename: String,
+    /// Empty clears the title.
+    pub title: String,
+}
+
+/// Capability-gated bulk gallery mutation. `operation_id` is a client-owned
+/// replay key; current mutations are idempotent and servers retain receipts.
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct GalleryBulkMutationRequest {
+    pub operation_id: String,
+    #[serde(default)]
+    pub filenames: Vec<String>,
+    #[serde(default)]
+    pub titles: Vec<GalleryTitleAssignment>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub favorite: Option<bool>,
+    #[serde(default)]
+    pub add_tags: Vec<String>,
+    #[serde(default)]
+    pub remove_tags: Vec<String>,
+    /// Ensure this collection name/slug exists, then add every filename.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub add_to_collection: Option<CollectionRef>,
+    /// Collection slug to remove every filename from.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub remove_from_collection_slug: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct GalleryBulkMutationResult {
+    pub operation_id: String,
+    pub changed: u64,
+    pub revision: u64,
+}
+
+/// Idempotent heterogeneous generation admission. Every child is validated
+/// before any child is persisted; execution remains independent afterwards.
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct GenerationBatchAdmissionRequest {
+    pub client_batch_id: String,
+    pub requests: Vec<GenerateRequest>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum GenerationBatchChildState {
+    Accepted,
+    Running,
+    Complete,
+    Failed,
+    Cancelled,
+    Held,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct GenerationBatchChild {
+    pub index: u32,
+    pub job_id: String,
+    pub state: GenerationBatchChildState,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct GenerationBatchStatus {
+    pub id: String,
+    pub client_batch_id: String,
+    pub children: Vec<GenerationBatchChild>,
+}
+
 /// Body of `POST /api/gallery/collections`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct CollectionCreateRequest {
@@ -7764,6 +7837,10 @@ pub struct GalleryCapabilities {
     /// DB is disabled.
     #[serde(default, skip_serializing_if = "is_false")]
     pub organize: bool,
+    /// `POST /api/gallery/mutations` and bulk permanent deletion are
+    /// available. Absent means clients use the legacy routes.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub bulk_mutations: bool,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -7820,6 +7897,11 @@ pub struct QueueCapabilities {
     /// servers and whenever live server batches are unavailable.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub server_batch_max_outputs: Option<u32>,
+    /// Server accepts one idempotent heterogeneous prepared-batch admission.
+    #[serde(default)]
+    pub heterogeneous_batch: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub heterogeneous_batch_max_outputs: Option<u32>,
 }
 
 /// Authenticated, stable-URL reference-media ingress advertised by current
@@ -9452,6 +9534,7 @@ mod server_event_tests {
                 retention_days: 30,
             }),
             organize: true,
+            bulk_mutations: true,
         };
         let wire = serde_json::to_value(&full).unwrap();
         assert_eq!(
@@ -9459,7 +9542,8 @@ mod server_event_tests {
             serde_json::json!({
                 "can_delete": true,
                 "trash": {"enabled": true, "retention_days": 30},
-                "organize": true
+                "organize": true,
+                "bulk_mutations": true
             })
         );
         let back: GalleryCapabilities = serde_json::from_value(wire).unwrap();

--- a/crates/mold-db/src/gallery_mutations.rs
+++ b/crates/mold-db/src/gallery_mutations.rs
@@ -1,0 +1,181 @@
+//! Durable replay receipts for idempotent client-side gallery mutation queues.
+
+use anyhow::Result;
+use std::path::Path;
+
+use rusqlite::{params, OptionalExtension};
+
+use crate::organization::{
+    collection_id_for_slug, create_collection_with_conn, mutate_bulk_on_conn, normalize_tag_list,
+    validate_collection_name, OrgResult, OrganizationError,
+};
+use crate::path::canonical_dir_string;
+use crate::MetadataDb;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GalleryMutationReceipt {
+    pub request_sha256: String,
+    pub response_json: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GalleryMutationApply {
+    Applied,
+    Replayed(String),
+}
+
+impl MetadataDb {
+    /// Apply the complete mutation and store its replay receipt under one
+    /// `BEGIN IMMEDIATE` transaction. A conflicting operation id cannot race
+    /// between receipt lookup, collection creation, print edits, and receipt
+    /// publication.
+    #[allow(clippy::too_many_arguments)]
+    pub fn apply_gallery_mutation_once(
+        &self,
+        operation_id: &str,
+        request_sha256: &str,
+        response_json: &str,
+        created_at_ms: i64,
+        dir: &Path,
+        titles: &[(String, Option<String>)],
+        filenames: &[String],
+        favorite: Option<bool>,
+        add_tags: &[String],
+        remove_tags: &[String],
+        add_collection_id: Option<&str>,
+        add_collection_name: Option<&str>,
+        remove_collection_slug: Option<&str>,
+    ) -> OrgResult<GalleryMutationApply> {
+        let dir_key = canonical_dir_string(dir);
+        let add_tags = normalize_tag_list(add_tags)?;
+        let remove_tags = normalize_tag_list(remove_tags)?;
+        self.transact_typed(|conn| {
+            if let Some(receipt) = conn
+                .query_row(
+                    "SELECT request_sha256, response_json
+                     FROM gallery_mutation_receipts WHERE operation_id = ?1",
+                    params![operation_id],
+                    |row| {
+                        Ok(GalleryMutationReceipt {
+                            request_sha256: row.get(0)?,
+                            response_json: row.get(1)?,
+                        })
+                    },
+                )
+                .optional()?
+            {
+                if receipt.request_sha256 != request_sha256 {
+                    return Err(OrganizationError::Conflict(
+                        "operation id was already used for a different gallery mutation".into(),
+                    ));
+                }
+                return Ok(GalleryMutationApply::Replayed(receipt.response_json));
+            }
+
+            let now = created_at_ms;
+            let mut add_ids = Vec::new();
+            if let Some(id) = add_collection_id {
+                add_ids.push(id.to_string());
+            } else if let Some(raw_name) = add_collection_name {
+                let (name, slug) = validate_collection_name(raw_name)?;
+                let id = match collection_id_for_slug(conn, &slug)? {
+                    Some(id) => id,
+                    None => create_collection_with_conn(conn, &name, &slug, now)?,
+                };
+                add_ids.push(id);
+            }
+            let mut remove_ids = Vec::new();
+            if let Some(slug) = remove_collection_slug {
+                if let Some(id) = collection_id_for_slug(conn, slug)? {
+                    remove_ids.push(id);
+                }
+            }
+
+            mutate_bulk_on_conn(
+                conn,
+                &dir_key,
+                titles,
+                filenames,
+                favorite,
+                Some(&add_tags),
+                Some(&remove_tags),
+                Some(&add_ids),
+                Some(&remove_ids),
+                now,
+            )?;
+            conn.execute(
+                "INSERT INTO gallery_mutation_receipts
+                    (operation_id, request_sha256, response_json, created_at_ms)
+                 VALUES (?1, ?2, ?3, ?4)",
+                params![operation_id, request_sha256, response_json, created_at_ms],
+            )?;
+            Ok(GalleryMutationApply::Applied)
+        })
+    }
+
+    pub fn gallery_mutation_receipt(
+        &self,
+        operation_id: &str,
+    ) -> Result<Option<GalleryMutationReceipt>> {
+        self.with_conn(|conn| {
+            Ok(conn
+                .query_row(
+                    "SELECT request_sha256, response_json
+                     FROM gallery_mutation_receipts WHERE operation_id = ?1",
+                    params![operation_id],
+                    |row| {
+                        Ok(GalleryMutationReceipt {
+                            request_sha256: row.get(0)?,
+                            response_json: row.get(1)?,
+                        })
+                    },
+                )
+                .optional()?)
+        })
+    }
+
+    pub fn record_gallery_mutation_receipt(
+        &self,
+        operation_id: &str,
+        request_sha256: &str,
+        response_json: &str,
+        created_at_ms: i64,
+    ) -> Result<()> {
+        self.transact_immediate(|conn| {
+            conn.execute(
+                "INSERT INTO gallery_mutation_receipts
+                    (operation_id, request_sha256, response_json, created_at_ms)
+                 VALUES (?1, ?2, ?3, ?4)
+                 ON CONFLICT(operation_id) DO NOTHING",
+                params![operation_id, request_sha256, response_json, created_at_ms],
+            )?;
+            Ok(())
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn receipt_survives_reopen_and_first_writer_wins() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("mold.db");
+        {
+            let db = MetadataDb::open(&path).unwrap();
+            db.record_gallery_mutation_receipt("op-1", "hash-1", r#"{"changed":30}"#, 1)
+                .unwrap();
+            db.record_gallery_mutation_receipt("op-1", "hash-2", "different", 2)
+                .unwrap();
+        }
+        let db = MetadataDb::open(&path).unwrap();
+        assert_eq!(
+            db.gallery_mutation_receipt("op-1").unwrap(),
+            Some(GalleryMutationReceipt {
+                request_sha256: "hash-1".into(),
+                response_json: r#"{"changed":30}"#.into(),
+            })
+        );
+    }
+}

--- a/crates/mold-db/src/generation_batches.rs
+++ b/crates/mold-db/src/generation_batches.rs
@@ -1,0 +1,317 @@
+//! Lightweight durable grouping for heterogeneous generation admission.
+//!
+//! Child execution authority remains `generation_queue`; these tables only
+//! make one client admission idempotent and retain terminal child summaries
+//! after the queue rows are removed.
+
+use anyhow::{bail, Result};
+use rusqlite::{params, OptionalExtension};
+
+use crate::generation_queue::{self, GenerationQueueRow};
+use crate::MetadataDb;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GenerationBatchRow {
+    pub id: String,
+    pub client_batch_id: String,
+    pub owner_uuid: String,
+    pub request_sha256: String,
+    pub created_at_ms: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GenerationBatchChildRow {
+    pub batch_id: String,
+    pub job_id: String,
+    pub batch_index: u32,
+    pub state: String,
+    pub error: Option<String>,
+    pub updated_at_ms: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GenerationBatchDetail {
+    pub batch: GenerationBatchRow,
+    pub children: Vec<GenerationBatchChildRow>,
+}
+
+/// Insert the grouping rows and every ordinary durable queue row atomically.
+/// A retry with the same client id returns the existing detail; a different
+/// payload using that id is rejected.
+pub fn insert_or_get(
+    db: &MetadataDb,
+    batch: &GenerationBatchRow,
+    children: &[(GenerationBatchChildRow, GenerationQueueRow)],
+) -> Result<(GenerationBatchDetail, bool)> {
+    db.transact_immediate(|conn| {
+        if let Some(existing) =
+            get_by_client_on_conn(conn, &batch.owner_uuid, &batch.client_batch_id)?
+        {
+            if existing.batch.request_sha256 != batch.request_sha256 {
+                bail!("client_batch_id was already used for a different request");
+            }
+            return Ok((existing, false));
+        }
+        conn.execute(
+            "INSERT INTO generation_batches
+                (id, client_batch_id, owner_uuid, request_sha256, created_at_ms)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![
+                batch.id,
+                batch.client_batch_id,
+                batch.owner_uuid,
+                batch.request_sha256,
+                batch.created_at_ms,
+            ],
+        )?;
+        for (child, queue_row) in children {
+            generation_queue::insert_on_conn(conn, queue_row)?;
+            conn.execute(
+                "INSERT INTO generation_batch_children
+                    (batch_id, job_id, batch_index, state, error, updated_at_ms)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                params![
+                    child.batch_id,
+                    child.job_id,
+                    child.batch_index,
+                    child.state,
+                    child.error,
+                    child.updated_at_ms,
+                ],
+            )?;
+        }
+        Ok((
+            GenerationBatchDetail {
+                batch: batch.clone(),
+                children: children.iter().map(|(child, _)| child.clone()).collect(),
+            },
+            true,
+        ))
+    })
+}
+
+pub fn get(db: &MetadataDb, owner_uuid: &str, id: &str) -> Result<Option<GenerationBatchDetail>> {
+    db.with_conn(|conn| {
+        let batch = conn
+            .query_row(
+                "SELECT id, client_batch_id, owner_uuid, request_sha256, created_at_ms
+                   FROM generation_batches WHERE id = ?1 AND owner_uuid = ?2",
+                params![id, owner_uuid],
+                batch_from_row,
+            )
+            .optional()?;
+        batch.map(|batch| detail_on_conn(conn, batch)).transpose()
+    })
+}
+
+pub fn get_by_client(
+    db: &MetadataDb,
+    owner_uuid: &str,
+    client_batch_id: &str,
+) -> Result<Option<GenerationBatchDetail>> {
+    db.with_conn(|conn| get_by_client_on_conn(conn, owner_uuid, client_batch_id))
+}
+
+pub fn set_child_state(
+    db: &MetadataDb,
+    job_id: &str,
+    state: &str,
+    error: Option<&str>,
+    updated_at_ms: i64,
+) -> Result<bool> {
+    db.with_conn(|conn| {
+        Ok(conn.execute(
+            "UPDATE generation_batch_children
+                SET state = ?2, error = ?3, updated_at_ms = ?4
+              WHERE job_id = ?1",
+            params![job_id, state, error, updated_at_ms],
+        )? > 0)
+    })
+}
+
+fn get_by_client_on_conn(
+    conn: &rusqlite::Connection,
+    owner_uuid: &str,
+    client_batch_id: &str,
+) -> Result<Option<GenerationBatchDetail>> {
+    let batch = conn
+        .query_row(
+            "SELECT id, client_batch_id, owner_uuid, request_sha256, created_at_ms
+               FROM generation_batches WHERE owner_uuid = ?1 AND client_batch_id = ?2",
+            params![owner_uuid, client_batch_id],
+            batch_from_row,
+        )
+        .optional()?;
+    batch.map(|batch| detail_on_conn(conn, batch)).transpose()
+}
+
+fn detail_on_conn(
+    conn: &rusqlite::Connection,
+    batch: GenerationBatchRow,
+) -> Result<GenerationBatchDetail> {
+    let mut stmt = conn.prepare(
+        "SELECT batch_id, job_id, batch_index, state, error, updated_at_ms
+           FROM generation_batch_children WHERE batch_id = ?1 ORDER BY batch_index",
+    )?;
+    let children = stmt
+        .query_map(params![batch.id], |row| {
+            Ok(GenerationBatchChildRow {
+                batch_id: row.get(0)?,
+                job_id: row.get(1)?,
+                batch_index: row.get::<_, i64>(2)? as u32,
+                state: row.get(3)?,
+                error: row.get(4)?,
+                updated_at_ms: row.get(5)?,
+            })
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(GenerationBatchDetail { batch, children })
+}
+
+fn batch_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<GenerationBatchRow> {
+    Ok(GenerationBatchRow {
+        id: row.get(0)?,
+        client_batch_id: row.get(1)?,
+        owner_uuid: row.get(2)?,
+        request_sha256: row.get(3)?,
+        created_at_ms: row.get(4)?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+    use crate::generation_queue::QueueRowState;
+
+    fn rows(count: usize) -> Vec<(GenerationBatchChildRow, GenerationQueueRow)> {
+        (0..count)
+            .map(|index| {
+                let id = format!("job-{index}");
+                (
+                    GenerationBatchChildRow {
+                        batch_id: "batch-1".into(),
+                        job_id: id.clone(),
+                        batch_index: index as u32 + 1,
+                        state: "accepted".into(),
+                        error: None,
+                        updated_at_ms: 1,
+                    },
+                    GenerationQueueRow {
+                        id,
+                        owner_uuid: "owner-1".into(),
+                        state: QueueRowState::Queued,
+                        model: format!("model-{index}"),
+                        request_json: format!(r#"{{"prompt":"prompt-{index}"}}"#),
+                        output_dir: PathBuf::from("/gallery"),
+                        target_gpu: None,
+                        target_device_id: None,
+                        completion_payload: "metadata_only".into(),
+                        seed_pinned: false,
+                        dispatch_attempts: 0,
+                        replay_seen: 0,
+                        held_reason: None,
+                        created_at_ms: 1,
+                        updated_at_ms: 1,
+                        started_at_ms: None,
+                    },
+                )
+            })
+            .collect()
+    }
+
+    fn batch(hash: &str) -> GenerationBatchRow {
+        GenerationBatchRow {
+            id: "batch-1".into(),
+            client_batch_id: "client-1".into(),
+            owner_uuid: "owner-1".into(),
+            request_sha256: hash.into(),
+            created_at_ms: 1,
+        }
+    }
+
+    #[test]
+    fn inserts_all_children_and_replays_same_ids() {
+        let db = MetadataDb::open_in_memory().unwrap();
+        let children = rows(30);
+        let (first, inserted) = insert_or_get(&db, &batch("same"), &children).unwrap();
+        assert!(inserted);
+        assert_eq!(first.children.len(), 30);
+
+        let (retry, inserted) = insert_or_get(&db, &batch("same"), &children).unwrap();
+        assert!(!inserted);
+        assert_eq!(retry, first);
+        assert_eq!(
+            crate::generation_queue::list_all(&db, "owner-1")
+                .unwrap()
+                .len(),
+            30
+        );
+    }
+
+    #[test]
+    fn all_admitted_children_survive_database_reopen_for_queue_replay() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("mold.db");
+        let first_ids = {
+            let db = MetadataDb::open(&path).unwrap();
+            let children = rows(30);
+            let (detail, inserted) = insert_or_get(&db, &batch("same"), &children).unwrap();
+            assert!(inserted);
+            detail
+                .children
+                .into_iter()
+                .map(|child| child.job_id)
+                .collect::<Vec<_>>()
+        };
+
+        let reopened = MetadataDb::open(&path).unwrap();
+        let detail = get_by_client(&reopened, "owner-1", "client-1")
+            .unwrap()
+            .expect("batch grouping survives restart");
+        assert_eq!(
+            detail
+                .children
+                .into_iter()
+                .map(|child| child.job_id)
+                .collect::<Vec<_>>(),
+            first_ids
+        );
+        assert_eq!(
+            crate::generation_queue::list_all(&reopened, "owner-1")
+                .unwrap()
+                .into_iter()
+                .map(|row| row.id)
+                .collect::<Vec<_>>(),
+            first_ids,
+            "the ordinary durable queue reopens with every child exactly once"
+        );
+    }
+
+    #[test]
+    fn rejects_changed_payload_without_partial_rows() {
+        let db = MetadataDb::open_in_memory().unwrap();
+        let children = rows(2);
+        insert_or_get(&db, &batch("first"), &children).unwrap();
+        assert!(insert_or_get(&db, &batch("changed"), &children).is_err());
+        assert_eq!(
+            crate::generation_queue::list_all(&db, "owner-1")
+                .unwrap()
+                .len(),
+            2
+        );
+    }
+
+    #[test]
+    fn child_insert_failure_rolls_back_parent_and_every_child() {
+        let db = MetadataDb::open_in_memory().unwrap();
+        let mut children = rows(2);
+        children[1].1.id = children[0].1.id.clone();
+        assert!(insert_or_get(&db, &batch("same"), &children).is_err());
+        assert!(get(&db, "owner-1", "batch-1").unwrap().is_none());
+        assert!(crate::generation_queue::list_all(&db, "owner-1")
+            .unwrap()
+            .is_empty());
+    }
+}

--- a/crates/mold-db/src/generation_queue.rs
+++ b/crates/mold-db/src/generation_queue.rs
@@ -88,35 +88,37 @@ pub struct GenerationQueueRow {
 }
 
 pub fn insert(db: &MetadataDb, row: &GenerationQueueRow) -> Result<()> {
-    db.with_conn(|conn| {
-        conn.execute(
-            "INSERT INTO generation_queue (
+    db.with_conn(|conn| insert_on_conn(conn, row))
+}
+
+pub(crate) fn insert_on_conn(conn: &rusqlite::Connection, row: &GenerationQueueRow) -> Result<()> {
+    conn.execute(
+        "INSERT INTO generation_queue (
                 id, owner_uuid, state, model, request_json, output_dir,
                 target_gpu, target_device_id, completion_payload, seed_pinned,
                 dispatch_attempts, replay_seen, held_reason, created_at, updated_at,
                 started_at
              ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
-            params![
-                &row.id,
-                &row.owner_uuid,
-                row.state.as_str(),
-                &row.model,
-                &row.request_json,
-                row.output_dir.to_string_lossy().into_owned(),
-                row.target_gpu.map(|gpu| gpu as i64),
-                row.target_device_id.as_deref(),
-                &row.completion_payload,
-                row.seed_pinned as i64,
-                row.dispatch_attempts as i64,
-                row.replay_seen as i64,
-                row.held_reason.as_deref(),
-                row.created_at_ms,
-                row.updated_at_ms,
-                row.started_at_ms,
-            ],
-        )?;
-        Ok(())
-    })
+        params![
+            &row.id,
+            &row.owner_uuid,
+            row.state.as_str(),
+            &row.model,
+            &row.request_json,
+            row.output_dir.to_string_lossy().into_owned(),
+            row.target_gpu.map(|gpu| gpu as i64),
+            row.target_device_id.as_deref(),
+            &row.completion_payload,
+            row.seed_pinned as i64,
+            row.dispatch_attempts as i64,
+            row.replay_seen as i64,
+            row.held_reason.as_deref(),
+            row.created_at_ms,
+            row.updated_at_ms,
+            row.started_at_ms,
+        ],
+    )?;
+    Ok(())
 }
 
 /// Remove one row. Returns whether it existed.

--- a/crates/mold-db/src/lib.rs
+++ b/crates/mold-db/src/lib.rs
@@ -11,6 +11,8 @@ pub mod chain_jobs;
 pub mod config_sync;
 mod db;
 mod device_preferences;
+pub mod gallery_mutations;
+pub mod generation_batches;
 pub mod generation_queue;
 pub mod metadata_io;
 pub mod migrations;
@@ -29,6 +31,7 @@ pub mod trash;
 
 pub use db::MetadataDb;
 pub use device_preferences::{DevicePreference, DevicePreferences};
+pub use gallery_mutations::GalleryMutationApply;
 pub use migrations::SCHEMA_VERSION;
 pub use model_prefs::ModelPrefs;
 pub use organization::{

--- a/crates/mold-db/src/migrations.rs
+++ b/crates/mold-db/src/migrations.rs
@@ -608,6 +608,10 @@ pub(crate) const MIGRATIONS: &[Migration] = &[
         version: 22,
         kind: MigrationKind::Sql(V22_IDENTITY_EXTRACT_ESTIMATE),
     },
+    Migration {
+        version: 23,
+        kind: MigrationKind::Sql(V23_HETEROGENEOUS_GENERATION_BATCHES),
+    },
 ];
 
 /// #1227 phase 2 moved face-identity extraction from admission onto the
@@ -622,9 +626,43 @@ const V22_IDENTITY_EXTRACT_ESTIMATE: &str = r#"
 ALTER TABLE scheduler_estimates ADD COLUMN ewma_identity_extract_ms REAL;
 "#;
 
+/// Durable grouping and idempotency for one heterogeneous client admission.
+/// Child requests continue to live in `generation_queue` as the sole replay
+/// authority; terminal summaries survive after those queue rows are removed.
+const V23_HETEROGENEOUS_GENERATION_BATCHES: &str = r#"
+CREATE TABLE generation_batches (
+    id             TEXT PRIMARY KEY,
+    client_batch_id TEXT NOT NULL,
+    owner_uuid     TEXT NOT NULL,
+    request_sha256 TEXT NOT NULL,
+    created_at_ms  INTEGER NOT NULL,
+    UNIQUE(owner_uuid, client_batch_id)
+);
+
+CREATE TABLE generation_batch_children (
+    batch_id      TEXT NOT NULL REFERENCES generation_batches(id) ON DELETE CASCADE,
+    job_id        TEXT PRIMARY KEY,
+    batch_index   INTEGER NOT NULL,
+    state         TEXT NOT NULL,
+    error         TEXT,
+    updated_at_ms INTEGER NOT NULL,
+    UNIQUE(batch_id, batch_index)
+);
+
+CREATE INDEX generation_batch_children_parent
+ON generation_batch_children(batch_id, batch_index);
+
+CREATE TABLE gallery_mutation_receipts (
+    operation_id   TEXT PRIMARY KEY,
+    request_sha256 TEXT NOT NULL,
+    response_json  TEXT NOT NULL,
+    created_at_ms  INTEGER NOT NULL
+);
+"#;
+
 /// The highest migration version this build ships. Exposed publicly so
 /// operators / tests can assert what schema level they're running against.
-pub const SCHEMA_VERSION: i64 = 22;
+pub const SCHEMA_VERSION: i64 = 23;
 
 /// v1 → v2: rewrite every `output_dir` value to its canonical form so
 /// rows written by the v0.8.x release (which keyed on raw paths) keep
@@ -1000,7 +1038,7 @@ mod tests {
             SCHEMA_VERSION,
             "fresh DB must end at the latest SCHEMA_VERSION",
         );
-        assert_eq!(SCHEMA_VERSION, 22);
+        assert_eq!(SCHEMA_VERSION, 23);
         assert!(table_exists(&conn, "device_preferences"));
         assert_eq!(
             column_names(&conn, "device_preferences"),
@@ -1153,8 +1191,8 @@ mod tests {
 
         apply_pending(&mut conn).unwrap();
 
-        assert_eq!(current_version(&conn).unwrap(), 22);
-        assert_eq!(SCHEMA_VERSION, 22);
+        assert_eq!(current_version(&conn).unwrap(), 23);
+        assert_eq!(SCHEMA_VERSION, 23);
         assert!(table_exists(&conn, "generation_queue"));
         let columns = column_names(&conn, "generation_queue");
         for expected in [
@@ -1217,8 +1255,8 @@ mod tests {
 
         apply_pending(&mut conn).unwrap();
 
-        assert_eq!(current_version(&conn).unwrap(), 22);
-        assert_eq!(SCHEMA_VERSION, 22);
+        assert_eq!(current_version(&conn).unwrap(), 23);
+        assert_eq!(SCHEMA_VERSION, 23);
         let columns = column_names(&conn, "generations");
         for expected in ["title", "favorite", "trashed_at_ms"] {
             assert!(
@@ -1479,7 +1517,7 @@ mod v9_tests {
 
     #[test]
     fn schema_version_is_current() {
-        assert_eq!(SCHEMA_VERSION, 22);
+        assert_eq!(SCHEMA_VERSION, 23);
     }
 
     #[test]

--- a/crates/mold-db/src/organization.rs
+++ b/crates/mold-db/src/organization.rs
@@ -123,7 +123,7 @@ pub fn normalize_tag_name(raw: &str) -> OrgResult<Option<String>> {
 
 /// Normalize a list of tag names, dropping empties and case-insensitive
 /// duplicates while preserving first-seen order.
-fn normalize_tag_list(raw: &[String]) -> OrgResult<Vec<String>> {
+pub(crate) fn normalize_tag_list(raw: &[String]) -> OrgResult<Vec<String>> {
     let mut seen: HashSet<String> = HashSet::new();
     let mut out = Vec::new();
     for name in raw {
@@ -139,7 +139,7 @@ fn normalize_tag_list(raw: &[String]) -> OrgResult<Vec<String>> {
 /// Validate a collection name, returning `(normalized name, slug)`.
 /// Delegates to [`mold_core::organization::validate_collection_name`] and
 /// only re-types the error.
-fn validate_collection_name(raw: &str) -> OrgResult<(String, String)> {
+pub(crate) fn validate_collection_name(raw: &str) -> OrgResult<(String, String)> {
     mold_core::organization::validate_collection_name(raw).map_err(OrganizationError::Invalid)
 }
 
@@ -180,14 +180,38 @@ pub(crate) fn generation_id(conn: &Connection, dir_key: &str, filename: &str) ->
 /// Resolve every filename to its row id, failing on the first unknown one.
 fn generation_ids(conn: &Connection, dir_key: &str, filenames: &[String]) -> OrgResult<Vec<i64>> {
     let mut seen = HashSet::new();
-    let mut ids = Vec::with_capacity(filenames.len());
-    for filename in filenames {
-        if !seen.insert(filename.as_str()) {
-            continue;
-        }
-        ids.push(generation_id(conn, dir_key, filename)?);
+    let unique: Vec<&str> = filenames
+        .iter()
+        .map(String::as_str)
+        .filter(|filename| seen.insert(*filename))
+        .collect();
+    if unique.is_empty() {
+        return Ok(Vec::new());
     }
-    Ok(ids)
+    // Leave room for output_dir below SQLite's historical 999-variable cap.
+    // Every chunk remains inside the caller's transaction.
+    const LOOKUP_CHUNK: usize = 900;
+    let mut by_name = HashMap::with_capacity(unique.len());
+    for chunk in unique.chunks(LOOKUP_CHUNK) {
+        let placeholders = std::iter::repeat_n("?", chunk.len())
+            .collect::<Vec<_>>()
+            .join(",");
+        let sql = format!(
+            "SELECT filename, id FROM generations WHERE output_dir = ? AND filename IN ({placeholders})"
+        );
+        let mut values: Vec<&dyn rusqlite::ToSql> = Vec::with_capacity(chunk.len() + 1);
+        values.push(&dir_key);
+        values.extend(chunk.iter().map(|name| name as &dyn rusqlite::ToSql));
+        let mut stmt = conn.prepare(&sql)?;
+        let rows = stmt.query_map(values.as_slice(), |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+        })?;
+        by_name.extend(rows.collect::<rusqlite::Result<HashMap<_, _>>>()?);
+    }
+    if by_name.len() != unique.len() {
+        return Err(OrganizationError::NotFound);
+    }
+    Ok(unique.iter().map(|filename| by_name[*filename]).collect())
 }
 
 /// Find-or-create a tag by (already normalized) name; returns its id.
@@ -318,7 +342,7 @@ fn dedupe_case_insensitively(names: Vec<String>) -> Vec<String> {
 /// the caller's transaction, returning its new id. Loses a race to a
 /// concurrent creator gracefully by adopting the winner's row — the slug is
 /// the identity, so either row is the right answer.
-fn create_collection_with_conn(
+pub(crate) fn create_collection_with_conn(
     conn: &Connection,
     name: &str,
     slug: &str,
@@ -1027,6 +1051,35 @@ impl MetadataDb {
         })
     }
 
+    /// Apply distinct title edits and one common organization mutation in a
+    /// single transaction. Used by the idempotent bulk mutation endpoint.
+    pub fn mutate_bulk(
+        &self,
+        dir: &Path,
+        titles: &[(String, Option<String>)],
+        filenames: &[String],
+        op: BulkOrganize<'_>,
+    ) -> OrgResult<()> {
+        let dir_key = canonical_dir_string(dir);
+        let add_tags = op.add_tags.map(normalize_tag_list).transpose()?;
+        let remove_tags = op.remove_tags.map(normalize_tag_list).transpose()?;
+        let now = now_ms();
+        self.transact_typed(|conn| {
+            mutate_bulk_on_conn(
+                conn,
+                &dir_key,
+                titles,
+                filenames,
+                op.favorite,
+                add_tags.as_deref(),
+                remove_tags.as_deref(),
+                op.add_to_collections,
+                op.remove_from_collections,
+                now,
+            )
+        })
+    }
+
     /// Slugs of every collection a print belongs to, sorted. Used to build
     /// trash tombstones, which carry slugs rather than ids so a different
     /// host (or a rebuilt DB) can re-home the print by name.
@@ -1043,6 +1096,65 @@ impl MetadataDb {
             Ok(rows.collect::<rusqlite::Result<Vec<_>>>()?)
         })
     }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn mutate_bulk_on_conn(
+    conn: &Connection,
+    dir_key: &str,
+    titles: &[(String, Option<String>)],
+    filenames: &[String],
+    favorite: Option<bool>,
+    add_tags: Option<&[String]>,
+    remove_tags: Option<&[String]>,
+    add_to_collections: Option<&[String]>,
+    remove_from_collections: Option<&[String]>,
+    now: i64,
+) -> OrgResult<()> {
+    let ids = generation_ids(conn, dir_key, filenames)?;
+    let title_names = titles
+        .iter()
+        .map(|(name, _)| name.clone())
+        .collect::<Vec<_>>();
+    generation_ids(conn, dir_key, &title_names)?;
+    for (filename, title) in titles {
+        conn.execute(
+            "UPDATE generations SET title = ?3 WHERE output_dir = ?1 AND filename = ?2",
+            params![dir_key, filename, normalize_title(title.as_deref())],
+        )?;
+    }
+    if let Some(favorite) = favorite {
+        for id in &ids {
+            conn.execute(
+                "UPDATE generations SET favorite = ?2 WHERE id = ?1",
+                params![id, favorite as i64],
+            )?;
+        }
+    }
+    if let Some(names) = add_tags {
+        for id in &ids {
+            attach_tags(conn, *id, names, now)?;
+        }
+    }
+    if let Some(names) = remove_tags {
+        for id in &ids {
+            detach_tags(conn, *id, names)?;
+        }
+    }
+    if let Some(collections) = add_to_collections {
+        for cid in collections {
+            collection_add_ids(conn, cid, &ids, now)?;
+        }
+    }
+    if let Some(collections) = remove_from_collections {
+        for cid in collections {
+            collection_remove_ids(conn, cid, &ids, now)?;
+        }
+    }
+    if remove_tags.is_some() {
+        gc_orphan_tags(conn)?;
+    }
+    Ok(())
 }
 
 fn tags_for_generation(conn: &Connection, generation_id: i64) -> OrgResult<Vec<String>> {
@@ -1531,6 +1643,37 @@ mod tests {
                 .unwrap()
                 .favorite
         );
+    }
+
+    #[test]
+    fn organize_bulk_chunks_more_than_sqlites_legacy_bind_limit() {
+        let db = MetadataDb::open_in_memory().unwrap();
+        let names = (0..1_200)
+            .map(|index| format!("large-{index}.png"))
+            .collect::<Vec<_>>();
+        for name in &names {
+            db.upsert(&GenerationRecord::from_save(
+                dir(),
+                name,
+                OutputFormat::Png,
+                meta(),
+                RecordSource::Server,
+                1,
+            ))
+            .unwrap();
+        }
+        db.organize_bulk(
+            dir(),
+            &names,
+            BulkOrganize {
+                favorite: Some(true),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let organized = db.organization_for_dir(dir()).unwrap();
+        assert_eq!(organized.len(), names.len());
+        assert!(organized.values().all(|row| row.favorite));
     }
 
     #[test]

--- a/crates/mold-server/src/gallery_organization.rs
+++ b/crates/mold-server/src/gallery_organization.rs
@@ -13,7 +13,7 @@
 //! disabled every route answers 501 and `GET /api/capabilities` advertises
 //! `gallery.organize = false`.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -24,10 +24,11 @@ use axum::{
 };
 use mold_core::{
     Collection, CollectionCreateRequest, CollectionDetail, CollectionItemsRequest,
-    CollectionUpdateRequest, GalleryImage, GalleryOrganizeRequest, GalleryPatchRequest,
-    ServerEvent, TagCount, TagRenameRequest,
+    CollectionUpdateRequest, GalleryBulkMutationRequest, GalleryBulkMutationResult, GalleryImage,
+    GalleryOrganizeRequest, GalleryPatchRequest, ServerEvent, TagCount, TagRenameRequest,
 };
 use mold_db::{CollectionRow, MetadataDb, OrganizationError, PrintOrganization};
+use sha2::Digest;
 
 use crate::batch_transaction::CommittedArchiveIndex;
 use crate::routes::ApiError;
@@ -370,6 +371,142 @@ pub(crate) async fn organize_gallery(
             .publish(ServerEvent::GalleryCollectionsChanged {});
     }
     Ok(StatusCode::NO_CONTENT)
+}
+
+// ── POST /api/gallery/mutations ────────────────────────────────────────────
+
+/// Apply a replay-safe bulk organization mutation. This folds bulk title
+/// edits and portable collection slugs into one request; retries with the
+/// same operation id return the retained result without duplicating work.
+#[utoipa::path(
+    post,
+    path = "/api/gallery/mutations",
+    tag = "gallery",
+    request_body = GalleryBulkMutationRequest,
+    responses(
+        (status = 200, description = "Applied or replayed", body = GalleryBulkMutationResult),
+        (status = 409, description = "Operation id was reused with a different payload"),
+        (status = 422, description = "Invalid operation, filename, title, tag, or collection"),
+        (status = 501, description = "Metadata DB disabled — organization unavailable"),
+    )
+)]
+pub(crate) async fn mutate_gallery_bulk(
+    State(state): State<AppState>,
+    Json(request): Json<GalleryBulkMutationRequest>,
+) -> Result<Json<GalleryBulkMutationResult>, ApiError> {
+    let _gallery_reader = state.gallery_publication_gate.read().await;
+    let dir = gallery_output_dir(&state).await?;
+    uuid::Uuid::parse_str(&request.operation_id)
+        .map_err(|_| ApiError::validation("operation_id must be a UUID"))?;
+    if request.filenames.is_empty() && request.titles.is_empty() {
+        return Err(ApiError::validation(
+            "filenames or title assignments must not be empty",
+        ));
+    }
+    let filenames = request
+        .filenames
+        .iter()
+        .map(|name| clean_gallery_filename(name))
+        .collect::<Result<Vec<_>, _>>()?;
+    let titles = request
+        .titles
+        .iter()
+        .map(|assignment| {
+            let filename = clean_gallery_filename(&assignment.filename)?;
+            let title =
+                mold_core::validate_print_title(&assignment.title).map_err(ApiError::validation)?;
+            Ok((filename, title))
+        })
+        .collect::<Result<Vec<_>, ApiError>>()?;
+    let collection_ref_fields = request.add_to_collection.as_ref().map(|reference| {
+        usize::from(reference.id.is_some()) + usize::from(reference.name.is_some())
+    });
+    if collection_ref_fields.is_some_and(|count| count != 1) {
+        return Err(ApiError::validation(
+            "add_to_collection must contain exactly one of id or name",
+        ));
+    }
+    let request_json = serde_json::to_vec(&request).map_err(|error| {
+        ApiError::internal(format!("gallery mutation encoding failed: {error}"))
+    })?;
+    let request_sha256 = format!("{:x}", sha2::Sha256::digest(request_json));
+    let operation_id = request.operation_id.clone();
+    let event_filenames = filenames
+        .iter()
+        .chain(titles.iter().map(|(filename, _)| filename))
+        .cloned()
+        .collect::<HashSet<_>>();
+    let db = state.metadata_db.clone();
+    require_metadata_db(&db)?;
+    let collection_may_change =
+        request.add_to_collection.is_some() || request.remove_from_collection_slug.is_some();
+    let changed = filenames
+        .iter()
+        .chain(titles.iter().map(|(filename, _)| filename))
+        .collect::<HashSet<_>>()
+        .len() as u64;
+    let revision = mold_core::time::now_epoch_ms().max(0) as u64;
+    let result = GalleryBulkMutationResult {
+        operation_id: operation_id.clone(),
+        changed,
+        revision,
+    };
+    let response_json = serde_json::to_string(&result)
+        .map_err(|error| ApiError::internal(format!("gallery receipt encoding failed: {error}")))?;
+    let (result, replayed) = tokio::task::spawn_blocking(
+        move || -> Result<(GalleryBulkMutationResult, bool), ApiError> {
+            let db = require_metadata_db(&db)?;
+            let applied = db
+                .apply_gallery_mutation_once(
+                    &operation_id,
+                    &request_sha256,
+                    &response_json,
+                    revision as i64,
+                    &dir,
+                    &titles,
+                    &filenames,
+                    request.favorite,
+                    &request.add_tags,
+                    &request.remove_tags,
+                    request
+                        .add_to_collection
+                        .as_ref()
+                        .and_then(|value| value.id.as_deref()),
+                    request
+                        .add_to_collection
+                        .as_ref()
+                        .and_then(|value| value.name.as_deref()),
+                    request.remove_from_collection_slug.as_deref(),
+                )
+                .map_err(map_org_error)?;
+            match applied {
+                mold_db::GalleryMutationApply::Applied => Ok((result, false)),
+                mold_db::GalleryMutationApply::Replayed(json) => {
+                    let retained = serde_json::from_str(&json).map_err(|error| {
+                        ApiError::internal(format!("gallery receipt decode failed: {error}"))
+                    })?;
+                    Ok((retained, true))
+                }
+            }
+        },
+    )
+    .await
+    .map_err(|error| ApiError::internal(format!("gallery mutation task failed: {error}")))??;
+
+    if !replayed {
+        for filename in event_filenames {
+            state.events.publish(ServerEvent::GalleryUpdated {
+                filename,
+                image: None,
+            });
+        }
+        if collection_may_change {
+            state
+                .events
+                .publish(ServerEvent::GalleryCollectionsChanged {});
+        }
+    }
+    Ok(Json(result))
 }
 
 // ── /api/gallery/collections ────────────────────────────────────────────────

--- a/crates/mold-server/src/gallery_trash.rs
+++ b/crates/mold-server/src/gallery_trash.rs
@@ -617,6 +617,69 @@ pub(crate) async fn restore_gallery_files(
     }
 }
 
+// ── POST /api/gallery/trash/delete-forever ────────────────────────────────
+
+/// Permanently delete several live or trashed prints through one host call.
+/// Stops at the first failure and names it; earlier removals stay removed.
+#[utoipa::path(
+    post,
+    path = "/api/gallery/trash/delete-forever",
+    tag = "gallery",
+    request_body = TrashFilenamesRequest,
+    responses(
+        (status = 204, description = "Every listed print was permanently removed"),
+        (status = 404, description = "A print does not exist"),
+        (status = 409, description = "A live file changed since publication"),
+        (status = 422, description = "Empty list or invalid filename"),
+    )
+)]
+pub(crate) async fn delete_gallery_files_forever(
+    State(state): State<AppState>,
+    Json(request): Json<TrashFilenamesRequest>,
+) -> Result<StatusCode, ApiError> {
+    let _gallery_writer = state.gallery_publication_gate.write().await;
+    let dir = gallery_output_dir(&state).await?;
+    let names = clean_filenames(&request)?;
+    let db = state.metadata_db.clone();
+    let gate = state.gallery_publication_gate.clone();
+    let (removed, failure) = tokio::task::spawn_blocking(
+        move || -> Result<(Vec<String>, Option<ApiError>), ApiError> {
+            let mut removed = Vec::new();
+            for name in names {
+                let outcome = if let Some(db) = db.as_ref().as_ref() {
+                    let trashed = db
+                        .get(&dir, &name)
+                        .map_err(|error| internal("metadata DB read failed", format!("{error:#}")))?
+                        .is_some_and(|row| row.trashed_at_ms.is_some());
+                    if trashed {
+                        purge_trashed_print_blocking(&dir, &name, db, &gate)
+                    } else {
+                        hard_delete_live_print_blocking(&dir, &name, Some(db), &gate)
+                    }
+                } else {
+                    hard_delete_live_print_blocking(&dir, &name, None, &gate)
+                };
+                match outcome {
+                    Ok(()) => removed.push(name),
+                    Err(error) => return Ok((removed, Some(name_failure(&name, error)))),
+                }
+            }
+            Ok((removed, None))
+        },
+    )
+    .await
+    .map_err(|error| ApiError::internal(format!("gallery bulk delete task failed: {error}")))??;
+    for filename in removed {
+        state
+            .events
+            .publish(ServerEvent::GalleryRemoved { filename });
+    }
+    match failure {
+        Some(error) => Err(error),
+        None => Ok(StatusCode::NO_CONTENT),
+    }
+}
+
 // ── DELETE /api/gallery/trash ───────────────────────────────────────────────
 
 /// Purge every trashed print now.

--- a/crates/mold-server/src/queue_journal.rs
+++ b/crates/mold-server/src/queue_journal.rs
@@ -20,6 +20,9 @@ use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
+use mold_db::generation_batches::{
+    self, GenerationBatchChildRow, GenerationBatchDetail, GenerationBatchRow,
+};
 use mold_db::generation_queue::{self, GenerationQueueRow, QueueRowState};
 use mold_db::MetadataDb;
 
@@ -105,6 +108,13 @@ pub struct JournalAdmission<'a> {
     /// True when the request carries reference-upload authority. Those bytes
     /// are bearer secrets staged outside the DB and are never journaled.
     pub carries_reference_authority: bool,
+}
+
+pub struct BatchJournalAdmission<'a> {
+    pub id: &'a str,
+    pub client_batch_id: &'a str,
+    pub request_sha256: &'a str,
+    pub children: &'a [JournalAdmission<'a>],
 }
 
 /// Whether this request carries a face photograph.
@@ -609,6 +619,120 @@ impl QueueJournal {
             id: admission.id.to_string(),
             settled: false,
         })
+    }
+
+    /// Persist one heterogeneous parent index and all ordinary queue children
+    /// in a single SQLite transaction. `None` tickets means this was an
+    /// idempotent retry of an already-admitted parent.
+    pub fn record_batch(
+        self: &Arc<Self>,
+        admission: BatchJournalAdmission<'_>,
+    ) -> Result<(GenerationBatchDetail, Option<Vec<QueueTicket>>), String> {
+        let owner_uuid = self
+            .owner_uuid
+            .as_deref()
+            .ok_or_else(|| "durable generation queue is unavailable".to_string())?;
+        let db = self
+            .db()
+            .ok_or_else(|| "metadata DB is unavailable".to_string())?;
+        if admission.children.is_empty() {
+            return Err("batch must contain at least one child".to_string());
+        }
+        let now = now_ms();
+        let mut rows = Vec::with_capacity(admission.children.len());
+        for (offset, child) in admission.children.iter().enumerate() {
+            let output_dir = child
+                .output_dir
+                .ok_or_else(|| "heterogeneous batches require gallery output".to_string())?;
+            if child.batch_child || child.carries_reference_authority {
+                return Err(
+                    "heterogeneous batches cannot carry temporary reference authority".to_string(),
+                );
+            }
+            if carries_identity_photograph(child.request) {
+                return Err("heterogeneous batches cannot persist identity photographs".to_string());
+            }
+            let request_json = serde_json::to_string(child.request)
+                .map_err(|error| format!("could not serialize batch child: {error}"))?;
+            if request_json.len() > self.max_bytes {
+                return Err(format!(
+                    "batch child {} exceeds the durable queue payload ceiling",
+                    offset + 1
+                ));
+            }
+            let queue_row = GenerationQueueRow {
+                id: child.id.to_string(),
+                owner_uuid: owner_uuid.to_string(),
+                state: QueueRowState::Queued,
+                model: child.request.model.clone(),
+                request_json,
+                output_dir: output_dir.to_path_buf(),
+                target_gpu: child.target_gpu,
+                target_device_id: None,
+                completion_payload: completion_payload_as_str(child.completion_payload).to_string(),
+                seed_pinned: child.request.seed.is_some(),
+                dispatch_attempts: 0,
+                replay_seen: 0,
+                held_reason: None,
+                created_at_ms: now,
+                updated_at_ms: now,
+                started_at_ms: None,
+            };
+            let batch_child = GenerationBatchChildRow {
+                batch_id: admission.id.to_string(),
+                job_id: child.id.to_string(),
+                batch_index: (offset + 1) as u32,
+                state: "accepted".to_string(),
+                error: None,
+                updated_at_ms: now,
+            };
+            rows.push((batch_child, queue_row));
+        }
+        let batch = GenerationBatchRow {
+            id: admission.id.to_string(),
+            client_batch_id: admission.client_batch_id.to_string(),
+            owner_uuid: owner_uuid.to_string(),
+            request_sha256: admission.request_sha256.to_string(),
+            created_at_ms: now,
+        };
+        let (detail, inserted) = generation_batches::insert_or_get(db, &batch, &rows)
+            .map_err(|error| format!("could not persist generation batch: {error:#}"))?;
+        let tickets = inserted.then(|| {
+            rows.iter()
+                .map(|(_, row)| QueueTicket {
+                    journal: Arc::clone(self),
+                    id: row.id.clone(),
+                    settled: false,
+                })
+                .collect()
+        });
+        Ok((detail, tickets))
+    }
+
+    pub fn generation_batch(&self, id: &str) -> Option<GenerationBatchDetail> {
+        let (Some(db), Some(owner)) = (self.db(), self.owner_uuid.as_deref()) else {
+            return None;
+        };
+        generation_batches::get(db, owner, id).ok().flatten()
+    }
+
+    pub fn generation_batch_by_client(
+        &self,
+        client_batch_id: &str,
+    ) -> Option<GenerationBatchDetail> {
+        let (Some(db), Some(owner)) = (self.db(), self.owner_uuid.as_deref()) else {
+            return None;
+        };
+        generation_batches::get_by_client(db, owner, client_batch_id)
+            .ok()
+            .flatten()
+    }
+
+    fn set_batch_child_state(&self, id: &str, state: &str, error: Option<&str>) {
+        let Some(db) = self.db() else { return };
+        if let Err(error) = generation_batches::set_child_state(db, id, state, error, now_ms()) {
+            tracing::warn!(job = %id, %error, "could not update generation batch child state");
+        }
     }
 
     /// Re-attach a ticket to a row that already exists. Used by replay, which
@@ -1172,6 +1296,8 @@ impl QueueTicket {
     /// completed job must never be replayed, fence or no fence.
     pub fn complete(mut self) {
         self.settled = true;
+        self.journal
+            .set_batch_child_state(&self.id, "complete", None);
         self.journal.discard_id(&self.id);
     }
 
@@ -1180,6 +1306,8 @@ impl QueueTicket {
     /// fence.
     pub fn discard(mut self) {
         self.settled = true;
+        self.journal
+            .set_batch_child_state(&self.id, "cancelled", Some("Cancelled"));
         self.journal.discard_id(&self.id);
     }
 
@@ -1211,9 +1339,15 @@ impl QueueTicket {
                         "could not hold an exhausted durable queue row"
                     );
                 }
+                self.journal
+                    .set_batch_child_state(&self.id, "held", Some(&reason));
                 DispatchClaim::Exhausted { attempts, cap }
             }
-            Ok(Some(_)) => DispatchClaim::Granted,
+            Ok(Some(_)) => {
+                self.journal
+                    .set_batch_child_state(&self.id, "running", None);
+                DispatchClaim::Granted
+            }
             Ok(None) => DispatchClaim::Untracked,
             Err(error) => {
                 tracing::warn!(
@@ -1229,6 +1363,8 @@ impl QueueTicket {
     /// Park the row: listed, never auto-run, and no longer owned by a ticket.
     pub fn hold(mut self, reason: &str) {
         self.settled = true;
+        self.journal
+            .set_batch_child_state(&self.id, "held", Some(reason));
         let Some(db) = self.journal.db() else {
             return;
         };
@@ -1254,6 +1390,11 @@ impl Drop for QueueTicket {
             );
             return;
         }
+        self.journal.set_batch_child_state(
+            &self.id,
+            "failed",
+            Some("generation ended before publishing an output"),
+        );
         self.journal.discard_id(&self.id);
     }
 }

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -16,6 +16,7 @@ use mold_core::{
     ServerStatus, SseErrorEvent, SseProgressEvent,
 };
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::convert::Infallible;
 use tokio_stream::StreamExt as _;
 use utoipa::OpenApi;
@@ -261,6 +262,8 @@ use crate::queue::clean_error_message;
     paths(
         generate,
         generate_stream,
+        admit_generation_batch,
+        get_generation_batch,
         generate_placement_preview,
         crate::reference_uploads::create_reference_upload_session,
         crate::reference_uploads::upload_reference,
@@ -283,6 +286,7 @@ use crate::queue::clean_error_message;
         import_gallery_file,
         crate::gallery_organization::patch_gallery_image,
         crate::gallery_organization::organize_gallery,
+        crate::gallery_organization::mutate_gallery_bulk,
         crate::gallery_organization::list_collections,
         crate::gallery_organization::create_collection,
         crate::gallery_organization::get_collection,
@@ -295,6 +299,7 @@ use crate::queue::clean_error_message;
         crate::gallery_trash::delete_gallery_image,
         crate::gallery_trash::trash_gallery_files,
         crate::gallery_trash::restore_gallery_files,
+        crate::gallery_trash::delete_gallery_files_forever,
         crate::gallery_trash::empty_gallery_trash,
         crate::gallery_trash::sweep_gallery_trash,
         server_status,
@@ -460,6 +465,8 @@ use crate::queue::clean_error_message;
         GalleryGifRepeat,
         mold_core::GalleryPatchRequest,
         mold_core::GalleryOrganizeRequest,
+        mold_core::GalleryBulkMutationRequest,
+        mold_core::GalleryBulkMutationResult,
         mold_core::Collection,
         mold_core::CollectionDetail,
         mold_core::CollectionCreateRequest,
@@ -496,6 +503,8 @@ pub fn create_router(state: AppState) -> Router {
             post(generate_placement_preview),
         )
         .route("/api/generate/stream", post(generate_stream))
+        .route("/api/generation-batches", post(admit_generation_batch))
+        .route("/api/generation-batches/:id", get(get_generation_batch))
         .route(
             "/api/generate/reference-upload-sessions",
             post(crate::reference_uploads::create_reference_upload_session)
@@ -598,6 +607,10 @@ pub fn create_router(state: AppState) -> Router {
             post(crate::gallery_organization::organize_gallery),
         )
         .route(
+            "/api/gallery/mutations",
+            post(crate::gallery_organization::mutate_gallery_bulk),
+        )
+        .route(
             "/api/gallery/collections",
             get(crate::gallery_organization::list_collections)
                 .post(crate::gallery_organization::create_collection),
@@ -629,6 +642,10 @@ pub fn create_router(state: AppState) -> Router {
         .route(
             "/api/gallery/trash/restore",
             post(crate::gallery_trash::restore_gallery_files),
+        )
+        .route(
+            "/api/gallery/trash/delete-forever",
+            post(crate::gallery_trash::delete_gallery_files_forever),
         )
         .route(
             "/api/gallery/trash/sweep",
@@ -2162,6 +2179,258 @@ fn validate_live_server_batch_admission(
             StatusCode::UNPROCESSABLE_ENTITY,
         )
     })
+}
+
+const MAX_HETEROGENEOUS_BATCH_OUTPUTS: usize = 64;
+
+fn generation_batch_status(
+    detail: mold_db::generation_batches::GenerationBatchDetail,
+) -> mold_core::GenerationBatchStatus {
+    use mold_core::GenerationBatchChildState as State;
+    mold_core::GenerationBatchStatus {
+        id: detail.batch.id,
+        client_batch_id: detail.batch.client_batch_id,
+        children: detail
+            .children
+            .into_iter()
+            .map(|child| mold_core::GenerationBatchChild {
+                index: child.batch_index,
+                job_id: child.job_id,
+                state: match child.state.as_str() {
+                    "running" => State::Running,
+                    "complete" => State::Complete,
+                    "failed" => State::Failed,
+                    "cancelled" => State::Cancelled,
+                    "held" => State::Held,
+                    _ => State::Accepted,
+                },
+                error: child.error,
+            })
+            .collect(),
+    }
+}
+
+/// Admit distinct prepared prompts as one durable, idempotent parent. Every
+/// child validates before the single DB commit; after admission children run
+/// independently through the ordinary generation queue.
+#[utoipa::path(
+    post,
+    path = "/api/generation-batches",
+    tag = "generation",
+    request_body = mold_core::GenerationBatchAdmissionRequest,
+    responses(
+        (status = 202, description = "Every child durably admitted", body = mold_core::GenerationBatchStatus),
+        (status = 200, description = "Idempotent replay of an admitted batch", body = mold_core::GenerationBatchStatus),
+        (status = 409, description = "Client batch id reused with changed requests"),
+        (status = 422, description = "A child is invalid; nothing admitted"),
+        (status = 503, description = "Durable heterogeneous admission unavailable"),
+    )
+)]
+async fn admit_generation_batch(
+    State(state): State<AppState>,
+    authenticated: Option<Extension<crate::auth::ApiKeyAuthenticated>>,
+    Json(mut body): Json<mold_core::GenerationBatchAdmissionRequest>,
+) -> Result<(StatusCode, Json<mold_core::GenerationBatchStatus>), ApiError> {
+    if !state.scheduled_work.v2_authoritative() || !state.queue_journal.is_enabled() {
+        return Err(ApiError::with_code(
+            "heterogeneous batch admission requires Scheduler V2 and the durable queue",
+            "HETEROGENEOUS_BATCH_UNAVAILABLE",
+            StatusCode::SERVICE_UNAVAILABLE,
+        ));
+    }
+    if uuid::Uuid::parse_str(body.client_batch_id.trim()).is_err() {
+        return Err(ApiError::validation("client_batch_id must be a UUID"));
+    }
+    if body.requests.is_empty() || body.requests.len() > MAX_HETEROGENEOUS_BATCH_OUTPUTS {
+        return Err(ApiError::validation(format!(
+            "requests must contain 1..={MAX_HETEROGENEOUS_BATCH_OUTPUTS} children"
+        )));
+    }
+    let count = body.requests.len() as u32;
+    for (offset, request) in body.requests.iter_mut().enumerate() {
+        mold_core::minimax_h3::canonicalize_request_model(request);
+        if request.batch_size != 1 {
+            return Err(ApiError::validation(format!(
+                "requests[{}].batch_size must be 1",
+                offset
+            )));
+        }
+        request.batch_id = Some(body.client_batch_id.clone());
+        request.batch_index = Some(offset as u32 + 1);
+        request.batch_count = Some(count);
+    }
+    let fingerprint_bytes = serde_json::to_vec(&body.requests)
+        .map_err(|error| ApiError::internal(format!("batch serialization failed: {error}")))?;
+    let request_sha256 = format!("{:x}", Sha256::digest(&fingerprint_bytes));
+    if let Some(existing) = state
+        .queue_journal
+        .generation_batch_by_client(&body.client_batch_id)
+    {
+        if existing.batch.request_sha256 != request_sha256 {
+            return Err(ApiError::with_code(
+                "client_batch_id was already used for a different request",
+                "GENERATION_BATCH_IDEMPOTENCY_CONFLICT",
+                StatusCode::CONFLICT,
+            ));
+        }
+        return Ok((StatusCode::OK, Json(generation_batch_status(existing))));
+    }
+
+    let mut prepared_children = Vec::with_capacity(body.requests.len());
+    for mut request in body.requests {
+        let typed = (
+            request.prompt.clone(),
+            request.negative_prompt.clone(),
+            request.model.clone(),
+        );
+        let prepared = prepare_generation(
+            &state,
+            &mut request,
+            authenticated.as_ref().map(|Extension(auth)| auth),
+        )
+        .await?;
+        if prepared.output_dir.is_none() {
+            return Err(ApiError::validation(
+                "heterogeneous batches require server gallery output",
+            ));
+        }
+        if prepared.resolved_references.is_some() || request.references.is_some() {
+            return Err(ApiError::validation(
+                "heterogeneous batches cannot persist temporary reference uploads",
+            ));
+        }
+        prepared_children.push((request, typed, prepared));
+    }
+
+    let batch_id = uuid::Uuid::new_v4().to_string();
+    let job_ids: Vec<String> = (0..prepared_children.len())
+        .map(|_| uuid::Uuid::new_v4().to_string())
+        .collect();
+    let admissions: Vec<crate::queue_journal::JournalAdmission<'_>> = prepared_children
+        .iter()
+        .zip(&job_ids)
+        .map(
+            |((request, _, prepared), job_id)| crate::queue_journal::JournalAdmission {
+                id: job_id,
+                request,
+                output_dir: prepared.output_dir.as_deref(),
+                target_gpu: prepared.preferred_gpu,
+                completion_payload: SseCompletionPayload::MetadataOnly,
+                batch_child: false,
+                carries_reference_authority: false,
+            },
+        )
+        .collect();
+    let (detail, tickets) = state
+        .queue_journal
+        .record_batch(crate::queue_journal::BatchJournalAdmission {
+            id: &batch_id,
+            client_batch_id: &body.client_batch_id,
+            request_sha256: &request_sha256,
+            children: &admissions,
+        })
+        .map_err(|message| {
+            ApiError::with_code(
+                message,
+                "GENERATION_BATCH_NOT_DURABLE",
+                StatusCode::UNPROCESSABLE_ENTITY,
+            )
+        })?;
+    let Some(tickets) = tickets else {
+        return Ok((StatusCode::OK, Json(generation_batch_status(detail))));
+    };
+
+    let mut jobs = Vec::with_capacity(prepared_children.len());
+    for ((((request, typed, prepared), job_id), ticket), _) in prepared_children
+        .into_iter()
+        .zip(job_ids.iter())
+        .zip(tickets)
+        .zip(0..)
+    {
+        record_prompt_history(&state, &typed.0, typed.1.as_deref(), &typed.2);
+        let queue_metadata = Box::new(mold_core::OutputMetadata::from_generate_request(
+            &request,
+            request.seed.unwrap_or(0),
+            request.scheduler,
+            mold_core::build_info::version_string(),
+        ));
+        let cancel = state.job_registry.register_job(
+            job_id,
+            &request.model,
+            prepared.preferred_gpu,
+            Some(request.seed.is_some()),
+            Some(queue_metadata),
+        );
+        let crate::job_supervisor::SupervisedJob {
+            result_tx,
+            outcome_rx,
+        } = crate::job_supervisor::supervise_job(job_id.clone(), cancel);
+        drop(outcome_rx);
+        jobs.push(GenerationJob {
+            id: job_id.clone(),
+            request,
+            resolved_references: prepared.resolved_references,
+            completion_payload: SseCompletionPayload::MetadataOnly,
+            progress_tx: None,
+            result_tx,
+            output_dir: prepared.output_dir,
+            batch_child: None,
+            journal: Some(ticket),
+            #[cfg(any(feature = "h3", feature = "h3-private-uat"))]
+            h3_private_ingress_grant: prepared.h3_private_ingress_grant,
+        });
+    }
+    // Persistence is the admission acknowledgement. Feed every ordinary
+    // child into the bounded runtime queue independently in detached tasks,
+    // so an iPhone socket disappearing after the commit cannot cancel the
+    // remaining children and current queue occupancy cannot partially admit.
+    for job in jobs {
+        let queue = state.queue.clone();
+        let registry = state.job_registry.clone();
+        let capacity = state.queue_capacity;
+        let id = job.id.clone();
+        tokio::spawn(async move {
+            let mut pending = Some(job);
+            let keep_waiting = tokio_util::sync::CancellationToken::new();
+            if let Err(error) = queue
+                .submit_when_available(&mut pending, capacity, &keep_waiting)
+                .await
+            {
+                if let Some(mut retained) = pending {
+                    if let Some(ticket) = retained.journal.take() {
+                        ticket.retain();
+                    }
+                }
+                registry.remove(&id);
+                tracing::warn!(job = %id, ?error, "batch child retained for replay after queue transport stopped");
+            }
+        });
+    }
+    Ok((StatusCode::ACCEPTED, Json(generation_batch_status(detail))))
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/generation-batches/{id}",
+    tag = "generation",
+    params(("id" = String, Path, description = "Generation batch id")),
+    responses(
+        (status = 200, description = "Authoritative child states", body = mold_core::GenerationBatchStatus),
+        (status = 404, description = "Batch not found"),
+    )
+)]
+async fn get_generation_batch(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Json<mold_core::GenerationBatchStatus>, ApiError> {
+    let detail = state.queue_journal.generation_batch(&id).ok_or_else(|| {
+        ApiError::with_code(
+            "generation batch not found",
+            "GENERATION_BATCH_NOT_FOUND",
+            StatusCode::NOT_FOUND,
+        )
+    })?;
+    Ok(Json(generation_batch_status(detail)))
 }
 
 #[utoipa::path(
@@ -5601,6 +5870,7 @@ async fn server_capabilities(
     // makes it a systematic over-promise rather than an edge case, and clients
     // read this to decide whether to keep polling a job whose stream died.
     let durable_queue = state.queue_journal.is_enabled() && !state.is_output_disabled(&config);
+    let heterogeneous_batch = durable_queue && state.scheduled_work.v2_authoritative();
     // Trash and organization both live in the metadata DB; trash additionally
     // needs somewhere to move bytes to. With the DB disabled, DELETE stays a
     // hard delete and the organization routes answer 501.
@@ -5612,6 +5882,7 @@ async fn server_capabilities(
             retention_days: config.gallery.effective_trash_retention_days(),
         }),
         organize: db_available,
+        bulk_mutations: db_available,
     };
     Json(mold_core::ServerCapabilities {
         generation_profile_v1: true,
@@ -5643,6 +5914,9 @@ async fn server_capabilities(
             server_batch,
             server_batch_max_outputs: server_batch
                 .then_some(crate::batch_runtime::MAX_LIVE_SERVER_BATCH_OUTPUTS),
+            heterogeneous_batch,
+            heterogeneous_batch_max_outputs: heterogeneous_batch
+                .then_some(MAX_HETEROGENEOUS_BATCH_OUTPUTS as u32),
         },
         reference_uploads: mold_core::ReferenceUploadCapabilities {
             available: true,

--- a/crates/mold-server/src/routes_test.rs
+++ b/crates/mold-server/src/routes_test.rs
@@ -4230,6 +4230,107 @@ mod tests {
         root.join("gallery")
     }
 
+    #[tokio::test]
+    async fn heterogeneous_batch_admits_thirty_once_and_returns_same_ids_on_retry() {
+        let root = tempfile::tempdir().unwrap();
+        let db_path = root.path().join("mold.db");
+        let first_ids = {
+            let db = Arc::new(Some(mold_db::MetadataDb::open(&db_path).unwrap()));
+            let (mut state, mut rx) = durable_state(db, root.path());
+            state.queue_capacity = 64;
+            let (scheduled_tx, _scheduled_rx) = tokio::sync::mpsc::channel(1);
+            state.scheduled_work = crate::scheduler::ScheduledWorkHandle::new(scheduled_tx);
+            let journal = state.queue_journal.clone();
+            let app = app_with_state(state);
+            let client_batch_id = uuid::Uuid::new_v4().to_string();
+            let requests: Vec<serde_json::Value> = (0..30)
+                .map(|index| {
+                    let mut request: serde_json::Value =
+                        serde_json::from_str(&generate_body(&format!("moon {index}"), 512, 512))
+                            .unwrap();
+                    request["batch_size"] = serde_json::json!(1);
+                    request
+                })
+                .collect();
+            let body = serde_json::json!({
+                "client_batch_id": client_batch_id,
+                "requests": requests,
+            });
+
+            let admitted = app
+                .clone()
+                .oneshot(json_request(
+                    "POST",
+                    "/api/generation-batches",
+                    body.clone(),
+                ))
+                .await
+                .unwrap();
+            assert_eq!(admitted.status(), StatusCode::ACCEPTED);
+            let admitted = json_body(admitted).await;
+            let first_ids: Vec<String> = admitted["children"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|child| child["job_id"].as_str().unwrap().to_string())
+                .collect();
+            assert_eq!(first_ids.len(), 30);
+            assert_eq!(
+                journal.list_all().len(),
+                30,
+                "all rows commit before response"
+            );
+
+            let retry = app
+                .oneshot(json_request("POST", "/api/generation-batches", body))
+                .await
+                .unwrap();
+            assert_eq!(retry.status(), StatusCode::OK);
+            let retry = json_body(retry).await;
+            let retry_ids: Vec<String> = retry["children"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|child| child["job_id"].as_str().unwrap().to_string())
+                .collect();
+            assert_eq!(retry_ids, first_ids);
+
+            let mut admitted_jobs = Vec::new();
+            for _ in 0..30 {
+                admitted_jobs.push(
+                    tokio::time::timeout(Duration::from_secs(5), rx.recv())
+                        .await
+                        .expect("every admitted child reaches the ordinary queue")
+                        .expect("queue remains open"),
+                );
+            }
+            journal.retain_all();
+            drop(admitted_jobs);
+            drop(journal);
+            first_ids
+        };
+
+        let reopened = Arc::new(Some(mold_db::MetadataDb::open(&db_path).unwrap()));
+        let (state, mut rx) = durable_state(reopened, root.path());
+        let replay_state = state.clone();
+        let replay_task =
+            tokio::spawn(async move { crate::queue_journal::replay(&replay_state, true).await });
+        let mut replayed = Vec::new();
+        for _ in 0..30 {
+            replayed.push(
+                tokio::time::timeout(Duration::from_secs(5), rx.recv())
+                    .await
+                    .expect("replayed batch child")
+                    .expect("queue remains open")
+                    .id,
+            );
+        }
+        let report = replay_task.await.unwrap();
+        assert_eq!(report.resumed, 30);
+        assert_eq!(replayed, first_ids);
+        assert!(rx.try_recv().is_err(), "no child replays twice");
+    }
+
     /// The end-to-end shape: admit jobs, fence, drop the coordinator, rebuild
     /// `AppState` on the same DB, replay. The rows come back under their
     /// original ids, in submit order, through the ordinary queue.
@@ -10053,6 +10154,7 @@ mod tests {
         // Same bytes under the same identity may not silently rewrite
         // provenance.
         let conflict = app
+            .clone()
             .oneshot(
                 Request::put("/api/gallery/import/print.png")
                     .header("content-type", "application/vnd.mold.gallery-import")
@@ -12839,6 +12941,127 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn gallery_mutations_bulk_titles_and_replays_by_operation_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let (state, db) = organized_state(dir.path());
+        let filenames: Vec<String> = (0..30).map(|index| format!("{index}.png")).collect();
+        for filename in &filenames {
+            seed_print(&db, dir.path(), filename, None);
+        }
+        let app = app_with_state(state);
+        let operation_id = uuid::Uuid::new_v4().to_string();
+        let request = serde_json::json!({
+            "operation_id": operation_id,
+            "filenames": filenames,
+            "titles": (0..30).map(|index| serde_json::json!({
+                "filename": format!("{index}.png"),
+                "title": format!("Moon {index}")
+            })).collect::<Vec<_>>(),
+            "favorite": true,
+            "add_tags": ["bulk"],
+            "add_to_collection": {"name": "Moon studies"}
+        });
+        let first = app
+            .clone()
+            .oneshot(json_request(
+                "POST",
+                "/api/gallery/mutations",
+                request.clone(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(first.status(), StatusCode::OK);
+        let first_body = json_body(first).await;
+        assert_eq!(first_body["changed"], 30);
+
+        let retry = app
+            .clone()
+            .oneshot(json_request(
+                "POST",
+                "/api/gallery/mutations",
+                request.clone(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(retry.status(), StatusCode::OK);
+        assert_eq!(json_body(retry).await, first_body);
+
+        let rows = gallery_rows(&app, "/api/gallery").await;
+        assert_eq!(rows.len(), 30);
+        assert!(rows.iter().all(|row| row["favorite"] == true));
+        assert!(rows
+            .iter()
+            .all(|row| row["tags"] == serde_json::json!(["bulk"])));
+        let collections = app
+            .clone()
+            .oneshot(empty_request("GET", "/api/gallery/collections"))
+            .await
+            .unwrap();
+        let collections = json_body(collections).await;
+        assert_eq!(
+            collections.as_array().unwrap().len(),
+            1,
+            "retry creates no duplicate"
+        );
+
+        let mut changed = request;
+        changed["favorite"] = serde_json::json!(false);
+        let conflict = app
+            .clone()
+            .oneshot(json_request("POST", "/api/gallery/mutations", changed))
+            .await
+            .unwrap();
+        assert_eq!(conflict.status(), StatusCode::CONFLICT);
+
+        // Conflicting concurrent payloads serialize at the DB transaction:
+        // exactly one applies and the other observes its receipt.
+        let race_id = uuid::Uuid::new_v4().to_string();
+        let race_a = serde_json::json!({
+            "operation_id": race_id.clone(),
+            "filenames": ["0.png"],
+            "add_tags": ["race-a"]
+        });
+        let race_b = serde_json::json!({
+            "operation_id": race_id,
+            "filenames": ["0.png"],
+            "add_tags": ["race-b"]
+        });
+        let (a, b) = tokio::join!(
+            app.clone()
+                .oneshot(json_request("POST", "/api/gallery/mutations", race_a)),
+            app.clone()
+                .oneshot(json_request("POST", "/api/gallery/mutations", race_b)),
+        );
+        let mut statuses = [a.unwrap().status(), b.unwrap().status()];
+        statuses.sort_by_key(|status| status.as_u16());
+        assert_eq!(statuses, [StatusCode::OK, StatusCode::CONFLICT]);
+
+        // Collection creation shares the print-validation transaction and is
+        // rolled back when any selected filename is missing.
+        let invalid = app
+            .clone()
+            .oneshot(json_request(
+                "POST",
+                "/api/gallery/mutations",
+                serde_json::json!({
+                    "operation_id": uuid::Uuid::new_v4().to_string(),
+                    "filenames": ["ghost.png"],
+                    "add_to_collection": {"name": "Must roll back"}
+                }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(invalid.status(), StatusCode::NOT_FOUND);
+        let collections = json_body(
+            app.oneshot(empty_request("GET", "/api/gallery/collections"))
+                .await
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(collections.as_array().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
     async fn gallery_collections_crud_and_membership_round_trip() {
         let dir = tempfile::tempdir().unwrap();
         let (state, db) = organized_state(dir.path());
@@ -13172,6 +13395,7 @@ mod tests {
         assert_eq!(caps["gallery"]["trash"]["enabled"], true);
         assert_eq!(caps["gallery"]["trash"]["retention_days"], 30);
         assert_eq!(caps["gallery"]["organize"], true);
+        assert_eq!(caps["gallery"]["bulk_mutations"], true);
     }
 
     /// `DELETE /api/gallery/image/:filename` moves to the trash when the
@@ -13241,6 +13465,8 @@ mod tests {
         let (state, db) = organized_state(dir.path());
         seed_print(&db, dir.path(), "binned.png", None);
         seed_print(&db, dir.path(), "live.png", None);
+        seed_print(&db, dir.path(), "bulk-binned.png", None);
+        seed_print(&db, dir.path(), "bulk-live.png", None);
         let mdb = db.as_ref().as_ref().unwrap();
         let mut events = state.events.subscribe();
         let app = app_with_state(state);
@@ -13289,6 +13515,36 @@ mod tests {
             events.try_recv().unwrap(),
             mold_core::ServerEvent::GalleryRemoved { filename } if filename == "live.png"
         ));
+
+        let resp = app
+            .clone()
+            .oneshot(empty_request(
+                "DELETE",
+                "/api/gallery/image/bulk-binned.png",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+        drain_events(&mut events);
+        let resp = app
+            .clone()
+            .oneshot(json_request(
+                "POST",
+                "/api/gallery/trash/delete-forever",
+                serde_json::json!({"filenames": ["bulk-binned.png", "bulk-live.png"]}),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+        assert!(mdb.get(dir.path(), "bulk-binned.png").unwrap().is_none());
+        assert!(mdb.get(dir.path(), "bulk-live.png").unwrap().is_none());
+        assert_eq!(
+            drain_events(&mut events)
+                .into_iter()
+                .filter(|event| matches!(event, mold_core::ServerEvent::GalleryRemoved { .. }))
+                .count(),
+            2
+        );
         assert!(gallery_rows(&app, "/api/gallery?view=trash")
             .await
             .is_empty());

--- a/desktop/src/lib/api/types.ts
+++ b/desktop/src/lib/api/types.ts
@@ -122,6 +122,8 @@ export interface ServerCapabilities {
     /** Titles / favorites / tags / collections can be edited here. Absent
      * on older servers ⇒ hide the organization UI. */
     organize?: boolean;
+    /** Replay-safe bulk organization endpoint. */
+    bulk_mutations?: boolean;
   };
   /** Server-enforced model families that are not activated in this build. */
   model_access?: {
@@ -183,9 +185,29 @@ export interface ServerCapabilities {
     can_reorder?: boolean;
     cooperative_cancellation?: boolean;
     durable_queue?: boolean;
+    heterogeneous_batch?: boolean;
+    heterogeneous_batch_max_outputs?: number | null;
   } | null;
   /** Absent on older servers means unknown, not unavailable. */
   expand?: ExpandCapabilities | null;
+}
+
+export interface GenerationBatchAdmissionRequest {
+  client_batch_id: string;
+  requests: GenerateRequest[];
+}
+
+export interface GenerationBatchChild {
+  index: number;
+  job_id: string;
+  state: "accepted" | "running" | "complete" | "failed" | "cancelled" | "held";
+  error?: string | null;
+}
+
+export interface GenerationBatchStatus {
+  id: string;
+  client_batch_id: string;
+  children: GenerationBatchChild[];
 }
 
 // ── Models ───────────────────────────────────────────────────────────────

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -65,6 +65,7 @@ import {
   tagKey,
   trashRetentionSummary,
   visibleTagCounts,
+  type OrganizationFanoutOp,
   type OrganizationMutation,
   type OrganizationUnion,
 } from "@studio/lib/libraryOrganization";
@@ -76,9 +77,17 @@ import {
   listCollections as listHostCollections,
   listTags as listHostTags,
   listTrash as listHostTrash,
+  mutateGalleryBulk,
   updateCollection as updateHostCollection,
   updateCollectionHidden as updateHostCollectionHidden,
 } from "@studio/api/galleryOrganization";
+import {
+  enqueueGalleryMutation,
+  galleryBulkRequest,
+  listGalleryMutations,
+  removeGalleryMutation,
+  updateGalleryMutationFailure,
+} from "@studio/lib/galleryMutationOutbox";
 import {
   defaultClipFrames,
   modelsForOutput,
@@ -322,6 +331,7 @@ import {
   fanoutFailureMessage,
   filterLibraryPrints,
   libraryOrganizationSupport,
+  logicalCopyIndex,
   logicalCopiesOf,
   mergeHostTags,
   mergeTrashSnapshot,
@@ -546,6 +556,7 @@ const LEGACY_LIBRARY_SEEN_KEY = "mold.mobile.library-seen.v1";
 const LIBRARY_VISITED_KEY = "mold.mobile.library-visited.v1";
 const SEQUENCE_RECOVERY_KEY = "mold.mobile.sequence-job.v1";
 const LIVE_ACTIVITY_KEY = "mold.mobile.live-activity.v1";
+const GALLERY_CAPABILITIES_KEY = "mold.mobile.gallery-capabilities.v1";
 const HOST_PROBE_TIMEOUT_MS = 9_000;
 /** How long automatic routing keeps waiting for slower machines once one has
  *  answered `planned`. Nothing is abandoned before that first plan exists —
@@ -645,6 +656,59 @@ const sequenceRoute = shallowRef<{ hostId: string; target: ApiTarget } | null>(n
 let sequenceWatch: SequenceWatchHandle | null = null;
 const expandCapabilities = reactive<Record<string, ExpandCapabilities | null | undefined>>({});
 const serverCapabilities = reactive<Record<string, ServerCapabilities | null | undefined>>({});
+interface SavedGalleryCapability {
+  instanceId: string | null;
+  gallery: ServerCapabilities["gallery"];
+}
+function loadSavedGalleryCapabilities(): Record<string, SavedGalleryCapability> {
+  try {
+    return JSON.parse(localStorage.getItem(GALLERY_CAPABILITIES_KEY) ?? "{}") as Record<
+      string,
+      SavedGalleryCapability
+    >;
+  } catch {
+    return {};
+  }
+}
+const savedGalleryCapabilities = reactive(loadSavedGalleryCapabilities());
+const effectiveGalleryCapabilities = computed<
+  Record<string, ServerCapabilities | null | undefined>
+>(() => {
+  const effective: Record<string, ServerCapabilities | null | undefined> = {
+    ...serverCapabilities,
+  };
+  for (const host of connectedHosts.value) {
+    if (effective[host.id]?.gallery) continue;
+    const saved = savedGalleryCapabilities[host.id];
+    if (!saved) continue;
+    if (saved.instanceId && saved.instanceId !== (host.instanceId?.trim() || null)) continue;
+    effective[host.id] = { gallery: saved.gallery } as ServerCapabilities;
+  }
+  return effective;
+});
+watch(
+  () =>
+    connectedHosts.value.map((host) => ({
+      id: host.id,
+      instanceId: host.instanceId?.trim() || null,
+      gallery: serverCapabilities[host.id]?.gallery ?? null,
+    })),
+  (snapshots) => {
+    let changed = false;
+    for (const snapshot of snapshots) {
+      if (!snapshot.gallery) continue;
+      savedGalleryCapabilities[snapshot.id] = {
+        instanceId: snapshot.instanceId,
+        gallery: snapshot.gallery,
+      };
+      changed = true;
+    }
+    if (changed) {
+      localStorage.setItem(GALLERY_CAPABILITIES_KEY, JSON.stringify(savedGalleryCapabilities));
+    }
+  },
+  { deep: true },
+);
 const form = reactive<GenerateForm>(newGenerateForm());
 // The shared builder defaults `fileUnderAutoTag` to FALSE so a surface with no
 // File under UI can never auto-tag invisibly. The phone HAS the removable
@@ -842,6 +906,8 @@ const organizationError = ref("");
 /** Accepted-request advisories stay visible until dismissed or superseded. */
 const requestAdvisories = ref<string[]>([]);
 const organizationBusy = ref(false);
+const pendingGalleryMutationCount = ref(0);
+let flushingGalleryOutbox = false;
 /** Trash listing, fetched lazily the first time the Trash scope opens. */
 let trashCopies: PendingGalleryPrint[] = [];
 const trashCount = ref(0);
@@ -2261,6 +2327,7 @@ async function saveCompletedStillToPhotos(result: CompleteEvent, target: ApiTarg
 }
 
 function routeForMobileHost(host: MobileHost): HostRoute {
+  const queue = serverCapabilities[host.id]?.queue;
   return {
     hostId: host.id,
     label: host.name,
@@ -2268,6 +2335,8 @@ function routeForMobileHost(host: MobileHost): HostRoute {
     target: { ...mobileHostTarget(host) },
     instanceId: host.instanceId ?? null,
     referenceUploads: serverCapabilities[host.id]?.reference_uploads ?? null,
+    heterogeneousBatch: queue?.heterogeneous_batch === true,
+    heterogeneousBatchMaxOutputs: queue?.heterogeneous_batch_max_outputs ?? null,
   };
 }
 
@@ -5270,6 +5339,8 @@ async function generate(): Promise<void> {
       target: { ...route.target },
       instanceId: route.instanceId ?? null,
       referenceUploads: route.referenceUploads ?? null,
+      heterogeneousBatch: route.heterogeneousBatch ?? false,
+      heterogeneousBatchMaxOutputs: route.heterogeneousBatchMaxOutputs ?? null,
       mirrorRemoteOutput: false,
       retainEncodedResult: false,
       metadataOnlyCompletion: true,
@@ -6408,7 +6479,7 @@ function allGalleryPrints(): Array<GalleryPrint | PendingGalleryPrint> {
 // ── Library organization: support, merges, filters ──────────────────────────
 
 const librarySupport = computed(() =>
-  libraryOrganizationSupport(connectedHosts.value, serverCapabilities),
+  libraryOrganizationSupport(connectedHosts.value, effectiveGalleryCapabilities.value),
 );
 const libraryOrganizeEnabled = computed(() => librarySupport.value.organize);
 const libraryTrashEnabled = computed(() => librarySupport.value.trash);
@@ -6820,9 +6891,12 @@ function selectedRepresentatives(): Array<GalleryPrint | PendingGalleryPrint> {
 /** Every physical copy behind the selected logical prints. */
 function selectedPhysicalCopies(): PendingGalleryPrint[] {
   const copies = scopeCopies();
+  const copyIndex = logicalCopyIndex(copies);
   const seen = new Map<string, PendingGalleryPrint>();
   for (const print of selectedRepresentatives()) {
-    for (const copy of logicalCopiesOf(copies, print)) seen.set(galleryPrintKey(copy), copy);
+    for (const copy of copyIndex.get(galleryPrintKey(print)) ?? []) {
+      seen.set(galleryPrintKey(copy), copy);
+    }
   }
   return [...seen.values()];
 }
@@ -6844,9 +6918,99 @@ function fanoutHosts(): Record<
   );
 }
 
+function bulkGalleryHostIds(): Set<string> {
+  return new Set(
+    connectedHosts.value
+      .filter(
+        (host) => effectiveGalleryCapabilities.value[host.id]?.gallery?.bulk_mutations === true,
+      )
+      .map((host) => host.id),
+  );
+}
+
 interface LibraryMutationOutcome {
   failedHostIds: Set<string>;
   ok: boolean;
+}
+
+async function executeGalleryOrganizationOp(
+  id: string,
+  op: OrganizationFanoutOp,
+  host: MobileHost,
+): Promise<void> {
+  const request = galleryBulkRequest(id, op);
+  if (request && effectiveGalleryCapabilities.value[host.id]?.gallery?.bulk_mutations === true) {
+    await mutateGalleryBulk(mobileHostTarget(host), request);
+    return;
+  }
+  const result = await runOrganizationFanout(
+    [op],
+    {
+      [host.id]: {
+        id: host.id,
+        name: host.name,
+        target: mobileHostTarget(host),
+        collections: hostCollections[host.id] ?? [],
+      },
+    },
+    undefined,
+    {
+      trashHostIds: librarySupport.value.trashHostIds,
+      bulkHostIds: bulkGalleryHostIds(),
+    },
+  );
+  if (result.failures[0]) throw result.failures[0].error;
+}
+
+async function retainGalleryOrganizationOp(
+  op: OrganizationFanoutOp,
+  host: MobileHost,
+  id = createUuid(),
+): Promise<void> {
+  await enqueueGalleryMutation({
+    id,
+    hostId: host.id,
+    hostInstanceId: host.instanceId?.trim() || null,
+    hostName: host.name,
+    op,
+  });
+  pendingGalleryMutationCount.value = (await listGalleryMutations()).length;
+}
+
+async function flushGalleryMutationOutbox(): Promise<void> {
+  if (flushingGalleryOutbox) return;
+  flushingGalleryOutbox = true;
+  try {
+    const queued = await listGalleryMutations();
+    for (const item of queued) {
+      const host = connectedHosts.value.find((candidate) => candidate.id === item.hostId);
+      if (!host?.online) continue;
+      if (item.hostInstanceId && item.hostInstanceId !== (host.instanceId?.trim() || null)) {
+        await updateGalleryMutationFailure(
+          item.id,
+          "Host identity changed; the retained edit was not sent.",
+        );
+        continue;
+      }
+      try {
+        await executeGalleryOrganizationOp(item.id, item.op, host);
+        await removeGalleryMutation(item.id);
+      } catch (error) {
+        await updateGalleryMutationFailure(
+          item.id,
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+    }
+    pendingGalleryMutationCount.value = (await listGalleryMutations()).length;
+    if (pendingGalleryMutationCount.value === 0 && organizationError.value.includes("retained")) {
+      organizationError.value = "";
+    }
+  } catch (error) {
+    organizationError.value = `Couldn’t read retained gallery edits. ${String(error)}`;
+  } finally {
+    flushingGalleryOutbox = false;
+  }
 }
 
 /**
@@ -6862,19 +7026,42 @@ async function runLibraryMutation(
   organizationBusy.value = true;
   try {
     const ops = planOrganizationFanout(copies, mutation);
-    const result = await runOrganizationFanout(ops, fanoutHosts(), undefined, {
-      trashHostIds: librarySupport.value.trashHostIds,
-    });
-    if (result.createdCollections.length > 0) {
-      await refreshHostOrganization(result.createdCollections.map((entry) => entry.hostId));
-    }
-    const failedHostIds = new Set(result.failures.map((failure) => failure.hostId));
-    if (result.failures.length > 0) {
-      organizationError.value = fanoutFailureMessage(action, result.failures, (error, name) =>
+    const failures: Array<{ hostId: string; hostName: string; error: unknown }> = [];
+    let retained = 0;
+    await Promise.all(
+      ops.map(async (op) => {
+        const host = connectedHosts.value.find((candidate) => candidate.id === op.hostId);
+        if (!host) {
+          failures.push({ hostId: op.hostId, hostName: op.hostId, error: "Host was removed." });
+          return;
+        }
+        const id = createUuid();
+        if (!host.online) {
+          await retainGalleryOrganizationOp(op, host, id);
+          retained += 1;
+          return;
+        }
+        try {
+          await executeGalleryOrganizationOp(id, op, host);
+        } catch (error) {
+          if (!(error instanceof ApiError)) {
+            await retainGalleryOrganizationOp(op, host, id);
+            retained += 1;
+            return;
+          }
+          failures.push({ hostId: host.id, hostName: host.name, error });
+        }
+      }),
+    );
+    const failedHostIds = new Set(failures.map((failure) => failure.hostId));
+    if (failures.length > 0) {
+      organizationError.value = fanoutFailureMessage(action, failures, (error, name) =>
         describeTransportError(error, name),
       );
+    } else if (retained > 0) {
+      organizationError.value = `${retained} gallery edit${retained === 1 ? " was" : "s were"} retained on this device and will sync when the host returns.`;
     }
-    return { failedHostIds, ok: result.failures.length === 0 };
+    return { failedHostIds, ok: failures.length === 0 };
   } finally {
     organizationBusy.value = false;
   }
@@ -7793,7 +7980,10 @@ async function deleteSelectedGalleryPrints(): Promise<void> {
     ),
     fanoutHosts(),
     undefined,
-    { trashHostIds: librarySupport.value.trashHostIds },
+    {
+      trashHostIds: librarySupport.value.trashHostIds,
+      bulkHostIds: bulkGalleryHostIds(),
+    },
   );
   const failedHostIds = new Set(result.failures.map((failure) => failure.hostId));
   const removedKeys = new Set(
@@ -7835,6 +8025,10 @@ async function deleteSelectedGalleryPrints(): Promise<void> {
           ? `Deleted ${donePrints} of ${selected.length} prints forever.`
           : `Deleted ${donePrints} of ${selected.length} prints everywhere.`;
     galleryError.value = `${verb} ${failedPrints} still have a copy on an unavailable device.`;
+    // A bulk permanent-delete request can lose its response after deleting a
+    // prefix. Re-read every host before preserving failed selections so the
+    // client converges to server truth instead of resurrecting removed tiles.
+    await refreshGallery();
   }
   gallerySelection.value = new Set(
     [...gallerySelection.value].filter((key) =>
@@ -8058,6 +8252,13 @@ watch(
   },
 );
 
+watch(
+  () => connectedHosts.value.map((host) => `${host.id}:${host.online}:${host.instanceId ?? ""}`),
+  (next, previous) => {
+    if (next.join("|") !== previous?.join("|")) void flushGalleryMutationOutbox();
+  },
+);
+
 /**
  * iOS froze this WebView and tore down every socket while the app was
  * backgrounded. On return: probe hosts immediately (instead of waiting out
@@ -8078,6 +8279,7 @@ function handleForegroundResume(): void {
     void invoke("restore_mobile_viewport").catch(() => undefined);
   }
   probeHosts();
+  void flushGalleryMutationOutbox();
   void refreshMobileActivity();
   if (modelLoadError.value && !loadingModels.value) void refreshModels();
   renewGeneratedResult(false);
@@ -8201,6 +8403,10 @@ onMounted(async () => {
   }
   await hydrateApiKeys();
   if (unmounted) return;
+  pendingGalleryMutationCount.value = (await listGalleryMutations()).length;
+  if (pendingGalleryMutationCount.value > 0) {
+    organizationError.value = `${pendingGalleryMutationCount.value} retained gallery edit${pendingGalleryMutationCount.value === 1 ? " is" : "s are"} waiting for its host.`;
+  }
   if ("__TAURI_INTERNALS__" in window) {
     try {
       await listenForPairingDeepLinks();

--- a/desktop/src/mobile/libraryOrganization.test.ts
+++ b/desktop/src/mobile/libraryOrganization.test.ts
@@ -10,6 +10,7 @@ import {
   fanoutFailureMessage,
   filterLibraryPrints,
   libraryOrganizationSupport,
+  logicalCopyIndex,
   logicalCopiesOf,
   mergedCollectionsFor,
   mergeHostTags,
@@ -152,6 +153,9 @@ describe("organization index and filters", () => {
     expect(index.get("plato|b.png")?.title).toBe("Solo");
     expect(logicalCopiesOf(copies, { hostId: "plato", filename: "a.png" })).toHaveLength(2);
     expect(logicalCopiesOf(copies, { hostId: "plato", filename: "b.png" })).toHaveLength(1);
+    const copyIndex = logicalCopyIndex(copies);
+    expect(copyIndex.get("studio|a.png")).toBe(copyIndex.get("plato|a.png"));
+    expect(copyIndex.get("plato|b.png")).toHaveLength(1);
   });
 
   it("filters representatives by favorite, tag, host, and collection", () => {
@@ -336,6 +340,7 @@ describe("runOrganizationFanout", () => {
       trashMany: vi.fn().mockResolvedValue(undefined),
       restoreTrashed: vi.fn().mockResolvedValue(undefined),
       deleteGalleryImageForever: vi.fn().mockResolvedValue(undefined),
+      deleteManyForever: vi.fn().mockResolvedValue(undefined),
       deleteGalleryImage: vi.fn().mockResolvedValue(undefined),
     };
   }
@@ -430,6 +435,21 @@ describe("runOrganizationFanout", () => {
     expect(api.trashMany).toHaveBeenCalledWith(fanoutHosts.studio.target, ["a.png"]);
     expect(api.deleteGalleryImage).toHaveBeenCalledTimes(2);
     expect(api.trashMany).toHaveBeenCalledTimes(1);
+  });
+
+  it("permanently deletes a capable host selection in one request", async () => {
+    const api = fakeApi();
+    await runOrganizationFanout(
+      planOrganizationFanout(targets, { kind: "deleteForever" }),
+      fanoutHosts,
+      api,
+      { bulkHostIds: new Set(["plato"]) },
+    );
+    expect(api.deleteManyForever).toHaveBeenCalledWith(fanoutHosts.plato.target, [
+      "a.png",
+      "b.png",
+    ]);
+    expect(api.deleteGalleryImageForever).toHaveBeenCalledTimes(1);
   });
 
   it("reports a failed host without blocking the others", async () => {

--- a/desktop/src/mobile/libraryOrganization.ts
+++ b/desktop/src/mobile/libraryOrganization.ts
@@ -13,6 +13,7 @@ import type { ApiTarget } from "@studio/api/client";
 import {
   createCollection,
   deleteGalleryImageForever,
+  deleteManyForever,
   organizeGallery,
   patchGalleryImage,
   restoreTrashed,
@@ -234,6 +235,17 @@ export function logicalCopiesOf<T extends OrganizationCopyLike>(
   }
   const exact = copies.find((copy) => printOrganizationKey(copy) === key);
   return exact ? [exact] : [];
+}
+
+/** Index every physical key to its logical group in one gallery pass. */
+export function logicalCopyIndex<T extends OrganizationCopyLike>(
+  copies: readonly T[],
+): Map<string, readonly T[]> {
+  const index = new Map<string, readonly T[]>();
+  for (const group of groupLogicalGalleryPrints(copies)) {
+    for (const copy of group.copies) index.set(printOrganizationKey(copy), group.copies);
+  }
+  return index;
 }
 
 // ── Filtering ───────────────────────────────────────────────────────────────
@@ -515,6 +527,7 @@ export interface FanoutApi {
   trashMany: typeof trashMany;
   restoreTrashed: typeof restoreTrashed;
   deleteGalleryImageForever: typeof deleteGalleryImageForever;
+  deleteManyForever?: typeof deleteManyForever;
   /** Hard delete for hosts without a trash (today's `DELETE`). */
   deleteGalleryImage: (target: ApiTarget, filename: string) => Promise<void>;
 }
@@ -527,6 +540,7 @@ export const defaultFanoutApi: FanoutApi = {
   trashMany,
   restoreTrashed,
   deleteGalleryImageForever,
+  deleteManyForever,
   // A host without a trash hard-deletes on the plain `DELETE` it has always
   // answered; `?permanent=true` is never sent to a host that lacks the trash.
   deleteGalleryImage: (target, filename) => trashGalleryImage(target, filename),
@@ -542,7 +556,7 @@ export async function runOrganizationFanout(
   ops: readonly OrganizationFanoutOp[],
   hosts: Record<string, FanoutHost | undefined>,
   api: FanoutApi = defaultFanoutApi,
-  options: { trashHostIds?: ReadonlySet<string> } = {},
+  options: { trashHostIds?: ReadonlySet<string>; bulkHostIds?: ReadonlySet<string> } = {},
 ): Promise<FanoutResult> {
   const result: FanoutResult = { failures: [], createdCollections: [], succeededHostIds: [] };
   await Promise.all(
@@ -557,7 +571,7 @@ export async function runOrganizationFanout(
         return;
       }
       try {
-        await runHostOp(op, host, api, result, options.trashHostIds);
+        await runHostOp(op, host, api, result, options.trashHostIds, options.bulkHostIds);
         result.succeededHostIds.push(host.id);
       } catch (error) {
         result.failures.push({ hostId: host.id, hostName: host.name, error });
@@ -573,6 +587,7 @@ async function runHostOp(
   api: FanoutApi,
   result: FanoutResult,
   trashHostIds: ReadonlySet<string> | undefined,
+  bulkHostIds: ReadonlySet<string> | undefined,
 ): Promise<void> {
   switch (op.kind) {
     case "setTitle":
@@ -619,8 +634,12 @@ async function runHostOp(
       await api.restoreTrashed(host.target, op.filenames);
       return;
     case "deleteForever":
-      for (const filename of op.filenames) {
-        await api.deleteGalleryImageForever(host.target, filename);
+      if (bulkHostIds?.has(host.id) && api.deleteManyForever) {
+        await api.deleteManyForever(host.target, op.filenames);
+      } else {
+        for (const filename of op.filenames) {
+          await api.deleteGalleryImageForever(host.target, filename);
+        }
       }
       return;
   }

--- a/desktop/src/stores/gallery.ts
+++ b/desktop/src/stores/gallery.ts
@@ -1,5 +1,6 @@
 import { defineStore } from "pinia";
 import { apiFetchTo, apiJsonTo, type ApiTarget } from "../lib/api/client";
+import { isTransportFailure } from "../lib/api/errors";
 import {
   evictHostMedia,
   evictMedia,
@@ -35,18 +36,28 @@ import {
 } from "@studio/lib/libraryOrganization";
 import {
   createCollection as createCollectionOn,
+  deleteManyForever,
   deleteCollection as deleteCollectionOn,
   emptyTrash as emptyTrashOn,
   listCollections,
   listTags,
   listTrash,
+  mutateGalleryBulk,
   organizeGallery,
   patchGalleryImage,
   restoreTrashed,
   sweepTrash as sweepTrashOn,
+  trashMany,
   updateCollection,
   updateCollectionHidden,
 } from "@studio/api/galleryOrganization";
+import {
+  enqueueGalleryMutation,
+  galleryBulkRequest,
+  listGalleryMutations,
+  removeGalleryMutation,
+  updateGalleryMutationFailure,
+} from "@studio/lib/galleryMutationOutbox";
 
 export type {
   MergedCollection,
@@ -351,6 +362,8 @@ export const useGalleryStore = defineStore("gallery", {
     collectionsByHost: {} as Record<string, CollectionsBucket>,
     /** Per-host tag counts, merged by case-insensitive name in `mergedTags`. */
     tagsByHost: {} as Record<string, TagsBucket>,
+    /** Organization edits retained in IndexedDB for unreachable hosts. */
+    pendingOrganizationMutations: 0,
   }),
   getters: {
     /**
@@ -991,6 +1004,9 @@ export const useGalleryStore = defineStore("gallery", {
       } else {
         throw new Error("Host is not connected.");
       }
+      this.applyRemovalToBuckets(sourceKey, filename, permanent);
+    },
+    applyRemovalToBuckets(sourceKey: string, filename: string, permanent: boolean) {
       const row = takeRow(this.buckets[sourceKey], filename);
       if (!permanent && this.trashCapable(sourceKey)) {
         const trash = this.trashBuckets[sourceKey];
@@ -1008,29 +1024,58 @@ export const useGalleryStore = defineStore("gallery", {
       takeRow(this.trashBuckets[sourceKey], filename);
       this.evictItemMedia(sourceKey, filename);
     },
+    async removeHostMany(sourceKey: string, filenames: string[], permanent = false) {
+      const target = this.targetOf(sourceKey);
+      const bulk = useHostsStore().capabilities[sourceKey]?.gallery?.bulk_mutations === true;
+      if (target && bulk && (permanent || this.trashCapable(sourceKey))) {
+        try {
+          if (permanent) await deleteManyForever(target, filenames);
+          else await trashMany(target, filenames);
+          for (const filename of filenames) {
+            this.applyRemovalToBuckets(sourceKey, filename, permanent);
+          }
+          return { deleted: [...filenames], failed: [] as string[] };
+        } catch {
+          return { deleted: [] as string[], failed: [...filenames] };
+        }
+      }
+      const results = await Promise.allSettled(
+        filenames.map((filename) => this.remove(sourceKey, filename, { permanent })),
+      );
+      return {
+        deleted: filenames.filter((_, index) => results[index]?.status === "fulfilled"),
+        failed: filenames.filter((_, index) => results[index]?.status === "rejected"),
+      };
+    },
     /**
-     * Bulk delete. Each print is deleted exactly like the single-delete
-     * path — `remove()` per item, routed to that item's represented origin
-     * (IPC for the host-less This-Mac bucket, authed HTTP for a host) — so
-     * bulk semantics can never drift from the tile's Delete action.
+     * Bulk delete. Current hosts receive one request per origin; legacy and
+     * native-only origins preserve the per-file path.
      * Origins whose delete failed are refetched to reconverge with the
      * server (a lost response may still have deleted server-side).
      */
     async removeMany(
       items: Array<{ sourceKey: string; filename: string }>,
     ): Promise<{ deleted: number; failed: number }> {
-      const results = await Promise.allSettled(
-        items.map((i) => this.remove(i.sourceKey, i.filename)),
+      const groups = new Map<string, string[]>();
+      for (const item of items) {
+        const names = groups.get(item.sourceKey) ?? [];
+        names.push(item.filename);
+        groups.set(item.sourceKey, names);
+      }
+      const grouped = [...groups];
+      const results = await Promise.all(
+        grouped.map(([sourceKey, filenames]) => this.removeHostMany(sourceKey, filenames)),
       );
       let deleted = 0;
       const failedOrigins = new Set<string>();
       results.forEach((r, idx) => {
-        if (r.status === "fulfilled") deleted++;
-        else failedOrigins.add(items[idx]!.sourceKey);
+        const [sourceKey] = grouped[idx]!;
+        deleted += r.deleted.length;
+        if (r.failed.length > 0) failedOrigins.add(sourceKey);
       });
       await Promise.all([...failedOrigins].map((key) => this.refreshHost(key)));
       await this.refreshTrash(items.map((i) => i.sourceKey));
-      return { deleted, failed: results.length - deleted };
+      return { deleted, failed: items.length - deleted };
     },
     /**
      * Delete each selected logical print from every device bucket that
@@ -1048,18 +1093,30 @@ export const useGalleryStore = defineStore("gallery", {
         }
       }
       const locations = [...unique.values()];
-      const results = await Promise.allSettled(
-        locations.map((location) =>
-          this.remove(location.sourceKey, location.filename).then(() => location),
+      const byHost = new Map<string, GalleryLocation[]>();
+      for (const location of locations) {
+        const host = byHost.get(location.sourceKey) ?? [];
+        host.push(location);
+        byHost.set(location.sourceKey, host);
+      }
+      const hostGroups = [...byHost];
+      const results = await Promise.all(
+        hostGroups.map(([sourceKey, group]) =>
+          this.removeHostMany(
+            sourceKey,
+            group.map((location) => location.filename),
+          ),
         ),
       );
       const failedKeys = new Set<string>();
       const failedOrigins = new Set<string>();
       results.forEach((result, index) => {
-        if (result.status === "fulfilled") return;
-        const location = locations[index]!;
-        failedKeys.add(`${location.sourceKey}::${location.filename}`);
-        failedOrigins.add(location.sourceKey);
+        if (result.failed.length === 0) return;
+        const [sourceKey] = hostGroups[index]!;
+        failedOrigins.add(sourceKey);
+        for (const filename of result.failed) {
+          failedKeys.add(`${sourceKey}::${filename}`);
+        }
       });
       await Promise.all([...failedOrigins].map((key) => this.refreshHost(key)));
       await this.refreshTrash(locations.map((l) => l.sourceKey));
@@ -1069,7 +1126,7 @@ export const useGalleryStore = defineStore("gallery", {
       return {
         deletedPrints: entries.length - failedPrints,
         failedPrints,
-        deletedCopies: results.length - failedKeys.size,
+        deletedCopies: locations.length - failedKeys.size,
       };
     },
     evictItemMedia(sourceKey: string, filename: string) {
@@ -1317,6 +1374,7 @@ export const useGalleryStore = defineStore("gallery", {
     async fetchOrganization() {
       this.syncBuckets();
       await Promise.all([this.fetchCollections(), this.fetchTags(), this.fetchTrash()]);
+      await this.flushOrganizationOutbox();
     },
     // ── Organization: mutate ─────────────────────────────────────────────
     /** Organize-capable per-host targets for a set of copies. Hosts that
@@ -1388,6 +1446,15 @@ export const useGalleryStore = defineStore("gallery", {
       if (!target) throw new Error("Host is not connected.");
       switch (op.kind) {
         case "setTitle": {
+          const bulk = galleryBulkRequest(crypto.randomUUID(), op);
+          if (bulk && useHostsStore().capabilities[op.hostId]?.gallery?.bulk_mutations === true) {
+            await mutateGalleryBulk(target, bulk);
+            for (const filename of op.filenames) {
+              const row = this.rowOf(op.hostId, filename);
+              if (row) row.title = op.title;
+            }
+            return;
+          }
           for (const filename of op.filenames) {
             const echoed = await patchGalleryImage<GalleryImage>(target, filename, {
               title: op.title ?? "",
@@ -1482,6 +1549,49 @@ export const useGalleryStore = defineStore("gallery", {
           throw new Error(`${op.kind} is not an organize mutation; use the trash actions.`);
       }
     },
+    async retainOrganizationOp(op: OrganizationFanoutOp, operationId = crypto.randomUUID()) {
+      const host = this.hostFor(op.hostId);
+      if (!host || host.kind !== "remote") throw new Error("Host is not connected.");
+      await enqueueGalleryMutation({
+        id: operationId,
+        hostId: host.id,
+        hostInstanceId: host.instanceId,
+        hostName: host.label,
+        op,
+      });
+      this.pendingOrganizationMutations = (await listGalleryMutations()).length;
+    },
+    async flushOrganizationOutbox() {
+      const queued = await listGalleryMutations();
+      for (const item of queued) {
+        const host = useHostsStore().all.find((candidate) => candidate.id === item.hostId);
+        if (!host || host.status !== "ready") continue;
+        if (item.hostInstanceId && item.hostInstanceId !== (host.instanceId ?? null)) {
+          await updateGalleryMutationFailure(
+            item.id,
+            "Host identity changed; the retained edit was not sent.",
+          );
+          continue;
+        }
+        try {
+          const target = this.targetOf(item.hostId);
+          const bulk = galleryBulkRequest(item.id, item.op);
+          if (
+            target &&
+            bulk &&
+            useHostsStore().capabilities[item.hostId]?.gallery?.bulk_mutations
+          ) {
+            await mutateGalleryBulk(target, bulk);
+          } else {
+            await this.runOrganizationOp(item.op);
+          }
+          await removeGalleryMutation(item.id);
+        } catch (error) {
+          await updateGalleryMutationFailure(item.id, errorMessage(error));
+        }
+      }
+      this.pendingOrganizationMutations = (await listGalleryMutations()).length;
+    },
     /**
      * One organization mutation over every copy of the given prints: plan
      * per host (`planOrganizationFanout`), run each host's op, refetch the
@@ -1492,7 +1602,21 @@ export const useGalleryStore = defineStore("gallery", {
       mutation: OrganizationMutation,
     ): Promise<FanoutResult> {
       const ops = planOrganizationFanout(this.organizeTargetsFor(entries), mutation);
-      const results = await Promise.allSettled(ops.map((op) => this.runOrganizationOp(op)));
+      const queuedHosts = new Set<string>();
+      const results = await Promise.allSettled(
+        ops.map(async (op) => {
+          try {
+            await this.runOrganizationOp(op);
+          } catch (error) {
+            if (isTransportFailure(error) && this.hostFor(op.hostId)?.kind === "remote") {
+              await this.retainOrganizationOp(op);
+              queuedHosts.add(op.hostId);
+              return;
+            }
+            throw error;
+          }
+        }),
+      );
       const failedHosts: string[] = [];
       let error: string | null = null;
       results.forEach((result, index) => {
@@ -1513,7 +1637,11 @@ export const useGalleryStore = defineStore("gallery", {
         applied: ops.length - failedHosts.length,
         failed: failedHosts.length,
         failedHosts,
-        error,
+        error:
+          error ??
+          (queuedHosts.size > 0
+            ? `${queuedHosts.size} host edit${queuedHosts.size === 1 ? " was" : "s were"} retained and will sync when reachable.`
+            : null),
       };
     },
     setTitle(entry: MergedPrint, title: string | null): Promise<FanoutResult> {

--- a/desktop/src/stores/generation.concurrency.test.ts
+++ b/desktop/src/stores/generation.concurrency.test.ts
@@ -3,12 +3,17 @@ import { flushPromises } from "@vue/test-utils";
 import { createPinia, setActivePinia } from "pinia";
 
 vi.mock("../lib/api/sse", () => ({ sseStream: vi.fn() }));
+vi.mock("../lib/api/client", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../lib/api/client")>()),
+  apiJsonTo: vi.fn(),
+}));
 vi.mock("../lib/notify", () => ({
   notifyGenerated: vi.fn(),
   notifyGenerationFailed: vi.fn(),
 }));
 
 import { sseStream } from "../lib/api/sse";
+import { apiJsonTo } from "../lib/api/client";
 import { runWithConcurrency, useGenerationStore } from "./generation";
 import type { GenerateRequest } from "../lib/api/types";
 
@@ -90,6 +95,7 @@ describe("submitBatch connection cap", () => {
     setActivePinia(createPinia());
     streams.length = 0;
     mockSse.mockReset();
+    vi.mocked(apiJsonTo).mockReset();
     // Each POST parks open until the test resolves it, so we can observe how
     // many held streams the batch opens at once.
     mockSse.mockImplementation((_url, opts) => {
@@ -129,6 +135,58 @@ describe("submitBatch connection cap", () => {
     resolveStream(100);
     await flushPromises();
     expect(streams.map((s) => s.seed).sort()).toEqual([101, 102, 103, 104]);
+  });
+
+  it("retries one committed heterogeneous admission with the same UUID and maps all 30 ids", async () => {
+    const calls: Array<{ path: string; body: string | undefined }> = [];
+    let admissions = 0;
+    vi.mocked(apiJsonTo).mockImplementation(async (_target, path, init) => {
+      calls.push({ path, body: typeof init?.body === "string" ? init.body : undefined });
+      if (path === "/api/generation-batches") {
+        admissions += 1;
+        if (admissions === 1) throw new TypeError("Load failed");
+        return {
+          batch_id: "server-batch",
+          client_batch_id: "client-batch",
+          state: "queued",
+          created_at_ms: 1,
+          updated_at_ms: 1,
+          children: Array.from({ length: 30 }, (_, index) => ({
+            index: index + 1,
+            job_id: `job-${index + 1}`,
+            state: "queued",
+            error: null,
+          })),
+        } as never;
+      }
+      return new Promise<never>(() => {});
+    });
+    const store = useGenerationStore();
+    const { jobs } = store.submitBatch(
+      req,
+      30,
+      {
+        hostId: "hal9000",
+        label: "hal9000",
+        kind: "remote",
+        target: { baseUrl: "http://hal9000:7680", apiKey: "fresh-key" },
+        heterogeneousBatch: true,
+        heterogeneousBatchMaxOutputs: 64,
+      },
+      null,
+      { batchId: "client-batch" },
+    );
+    await flushPromises();
+    await flushPromises();
+
+    const admissionCalls = calls.filter((call) => call.path === "/api/generation-batches");
+    expect(admissionCalls).toHaveLength(2);
+    expect(admissionCalls[1]!.body).toBe(admissionCalls[0]!.body);
+    expect(JSON.parse(admissionCalls[0]!.body!).client_batch_id).toBe("client-batch");
+    expect(jobs.map((job) => job.id)).toEqual(
+      Array.from({ length: 30 }, (_, index) => `job-${index + 1}`),
+    );
+    expect(mockSse).not.toHaveBeenCalled();
   });
 
   it("holds at most four streams across separate Generate submissions", async () => {

--- a/desktop/src/stores/generation.ts
+++ b/desktop/src/stores/generation.ts
@@ -1,11 +1,11 @@
 import { reactive } from "vue";
 import { defineStore } from "pinia";
-import { apiFetchTo, currentTarget, type ApiTarget } from "../lib/api/client";
+import { apiFetchTo, apiJsonTo, currentTarget, type ApiTarget } from "../lib/api/client";
 import { sseStream } from "../lib/api/sse";
 import { evictMedia, galleryMediaPath, streamableMediaUrl } from "../lib/gallery/media";
 import { ipc } from "../lib/ipc";
 import { notifyGenerated, notifyGenerationFailed } from "../lib/notify";
-import { describeTransportError } from "../lib/api/errors";
+import { describeTransportError, isTransportFailure } from "../lib/api/errors";
 import {
   isInterruptedGenerationError,
   reconcileInterruptedGenerationJobs,
@@ -17,6 +17,7 @@ import type {
   ChainProgressEvent,
   CompleteEvent,
   GenerateRequest,
+  GenerationBatchStatus,
   PromptTransformProvenance,
   ProgressEvent,
   SseChainCompleteEvent,
@@ -82,6 +83,8 @@ export interface JobRoute {
   /** Exact server installation and upload protocol captured at submit time. */
   instanceId?: string | null;
   referenceUploads?: ReferenceUploadCapabilities | null;
+  heterogeneousBatch?: boolean;
+  heterogeneousBatchMaxOutputs?: number | null;
 }
 
 interface ReferenceUploadAuthority {
@@ -500,7 +503,64 @@ export const useGenerationStore = defineStore("generation", {
         if (job.status === "error") return Promise.resolve();
         return this.streamJob(job, plans[i]!);
       });
-      const settled = runWithConcurrency(tasks, MAX_STREAMS_PER_TARGET)
+      const serverAdmission =
+        size > 1 &&
+        requestOptions.batchId !== undefined &&
+        route?.heterogeneousBatch === true &&
+        size <= (route.heterogeneousBatchMaxOutputs ?? 0) &&
+        chainRouting?.kind !== "chain" &&
+        !plans.some(requestNeedsReferenceUpload);
+      const submit = serverAdmission
+        ? (async () => {
+            const target = route!.target;
+            const body = {
+              client_batch_id: requestOptions.batchId!,
+              requests: plans,
+            };
+            let admitted: GenerationBatchStatus;
+            try {
+              admitted = await apiJsonTo<GenerationBatchStatus>(target, "/api/generation-batches", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(body),
+              });
+            } catch (error) {
+              if (!isTransportFailure(error)) throw error;
+              admitted = await apiJsonTo<GenerationBatchStatus>(target, "/api/generation-batches", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify(body),
+              });
+            }
+            if (admitted.children.length !== jobs.length) {
+              throw new Error(
+                `The host admitted ${admitted.children.length} of ${jobs.length} prepared variations.`,
+              );
+            }
+            for (const [index, job] of jobs.entries()) {
+              const child = admitted.children[index]!;
+              if (child.index !== index + 1 || !child.job_id) {
+                throw new Error("The host returned an invalid prepared-batch child mapping.");
+              }
+              job.id = child.job_id;
+              job.streamStarted = true;
+              job.status = "error";
+              job.error = "The generation stream closed before completion.";
+              job.interrupted = true;
+              job.retainedByHost = true;
+            }
+            await this.reconcileInterrupted(jobs);
+          })()
+        : runWithConcurrency(tasks, MAX_STREAMS_PER_TARGET);
+      const settled = submit
+        .catch((error) => {
+          for (const job of jobs) {
+            if (job.status === "complete" || job.status === "error") continue;
+            job.status = "error";
+            markJobSettled(job);
+            job.error = error instanceof Error ? error.message : String(error);
+          }
+        })
         // A stream that died while the host kept working is not an outcome.
         // Reconcile against the frozen route BEFORE anyone reads these jobs:
         // every shell renders `status: "error"` as a failure (desktop Create

--- a/desktop/src/stores/hosts.ts
+++ b/desktop/src/stores/hosts.ts
@@ -183,6 +183,9 @@ export interface HostRoute {
   instanceId?: string | null;
   /** Frozen authenticated reference-ingress contract for this exact host. */
   referenceUploads?: ReferenceUploadCapabilities | null;
+  /** Exact host supports one durable heterogeneous prepared-batch admission. */
+  heterogeneousBatch?: boolean;
+  heterogeneousBatchMaxOutputs?: number | null;
 }
 
 export interface HostPlacementFailure {
@@ -235,6 +238,8 @@ function hostRoute(host: HostView, capabilities?: ServerCapabilities): HostRoute
     target: { baseUrl: host.baseUrl, apiKey: host.apiKey },
     instanceId: host.instanceId,
     referenceUploads: capabilities?.reference_uploads ?? null,
+    heterogeneousBatch: capabilities?.queue?.heterogeneous_batch === true,
+    heterogeneousBatchMaxOutputs: capabilities?.queue?.heterogeneous_batch_max_outputs ?? null,
   };
 }
 
@@ -631,6 +636,9 @@ export const useHostsStore = defineStore("hosts", {
         target: { baseUrl: chosen.baseUrl, apiKey: chosen.apiKey },
         instanceId: chosen.instanceId,
         referenceUploads: this.capabilities[chosen.id]?.reference_uploads ?? null,
+        heterogeneousBatch: this.capabilities[chosen.id]?.queue?.heterogeneous_batch === true,
+        heterogeneousBatchMaxOutputs:
+          this.capabilities[chosen.id]?.queue?.heterogeneous_batch_max_outputs ?? null,
       };
     },
     async resolveFeasible(

--- a/desktop/src/views/GenerateView.prepared.test.ts
+++ b/desktop/src/views/GenerateView.prepared.test.ts
@@ -723,6 +723,8 @@ describe("GenerateView prepared expansion batches", () => {
       target: { baseUrl: "http://127.0.0.1:7680", apiKey: "local-key" },
       instanceId: null,
       referenceUploads: null,
+      heterogeneousBatch: false,
+      heterogeneousBatchMaxOutputs: null,
     };
     const remoteRoute = {
       hostId: "remote-one",

--- a/studio/api/galleryOrganization.test.ts
+++ b/studio/api/galleryOrganization.test.ts
@@ -5,6 +5,7 @@ import {
   createCollection,
   deleteCollection,
   deleteGalleryImageForever,
+  deleteManyForever,
   deleteTag,
   emptyTrash,
   listCollections,
@@ -262,6 +263,14 @@ describe("gallery organization API", () => {
       url: "http://plato:7680/api/gallery/trash/restore",
       method: "POST",
       body: { filenames: ["a.png"] },
+    });
+
+    captured = stub();
+    await deleteManyForever(target, ["a.png", "b.png"]);
+    expect(captured()).toMatchObject({
+      url: "http://plato:7680/api/gallery/trash/delete-forever",
+      method: "POST",
+      body: { filenames: ["a.png", "b.png"] },
     });
   });
 

--- a/studio/api/galleryOrganization.ts
+++ b/studio/api/galleryOrganization.ts
@@ -12,6 +12,8 @@ import type {
   CollectionUpdateRequest,
   EmptyTrashResult,
   GalleryEntryWire,
+  GalleryBulkMutationRequest,
+  GalleryBulkMutationResult,
   GalleryOrganizeRequest,
   GalleryPatchRequest,
   GalleryView,
@@ -73,6 +75,22 @@ export async function organizeGallery(
     headers: JSON_HEADERS,
     body: JSON.stringify(body),
   });
+}
+
+/** Replay-safe bulk titles/tags/favorites/collection membership. */
+export function mutateGalleryBulk(
+  target: ApiTarget,
+  body: GalleryBulkMutationRequest,
+): Promise<GalleryBulkMutationResult> {
+  return apiJsonTo<GalleryBulkMutationResult>(
+    target,
+    "/api/gallery/mutations",
+    {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(body),
+    },
+  );
 }
 
 // ── Collections ─────────────────────────────────────────────────────────────
@@ -211,6 +229,20 @@ export async function deleteGalleryImageForever(
     `/api/gallery/image/${encodePath(filename)}?permanent=true`,
     { method: "DELETE" },
   );
+}
+
+/** `POST /api/gallery/trash/delete-forever {filenames}` — one destructive
+ * request for a confirmed selection on a bulk-capable host. */
+export async function deleteManyForever(
+  target: ApiTarget,
+  filenames: string[],
+): Promise<void> {
+  const body: TrashFilenamesRequest = { filenames };
+  await apiFetchTo(target, "/api/gallery/trash/delete-forever", {
+    method: "POST",
+    headers: JSON_HEADERS,
+    body: JSON.stringify(body),
+  });
 }
 
 /** `POST /api/gallery/trash {filenames}` — bulk move to trash. */

--- a/studio/lib/api/galleryOrganization.ts
+++ b/studio/lib/api/galleryOrganization.ts
@@ -76,6 +76,8 @@ export interface GalleryCapabilitiesWire {
   trash?: GalleryTrashCapabilities | null;
   /** Titles / favorites / tags / collections are available. */
   organize?: boolean;
+  /** Replay-safe bulk organization endpoint. */
+  bulk_mutations?: boolean;
 }
 
 /** `PATCH /api/gallery/image/:filename` body. Every field is optional; an
@@ -100,6 +102,28 @@ export interface GalleryOrganizeRequest {
   add_to_collections?: string[] | null;
   /** Collection ids. */
   remove_from_collections?: string[] | null;
+}
+
+export interface GalleryTitleAssignment {
+  filename: string;
+  title: string;
+}
+
+export interface GalleryBulkMutationRequest {
+  operation_id: string;
+  filenames: string[];
+  titles?: GalleryTitleAssignment[];
+  favorite?: boolean;
+  add_tags?: string[];
+  remove_tags?: string[];
+  add_to_collection?: { id?: string; name?: string };
+  remove_from_collection_slug?: string;
+}
+
+export interface GalleryBulkMutationResult {
+  operation_id: string;
+  changed: number;
+  revision: number;
 }
 
 /** `POST /api/gallery/collections` body. */

--- a/studio/lib/galleryMutationOutbox.test.ts
+++ b/studio/lib/galleryMutationOutbox.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { IDBFactory } from "fake-indexeddb";
+
+import {
+  enqueueGalleryMutation,
+  galleryBulkRequest,
+  listGalleryMutations,
+  removeGalleryMutation,
+  updateGalleryMutationFailure,
+} from "./galleryMutationOutbox";
+
+beforeEach(() => {
+  Object.defineProperty(globalThis, "indexedDB", {
+    configurable: true,
+    value: new IDBFactory(),
+  });
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("gallery mutation outbox", () => {
+  it("retains secret-free host-bound work and removes it after replay", async () => {
+    await enqueueGalleryMutation({
+      id: "op-1",
+      hostId: "hal9000",
+      hostInstanceId: "instance-1",
+      hostName: "hal9000",
+      op: {
+        kind: "addTags",
+        hostId: "hal9000",
+        filenames: ["a.png", "b.png"],
+        tags: ["blue"],
+      },
+    });
+    await updateGalleryMutationFailure("op-1", "offline");
+
+    expect(await listGalleryMutations()).toEqual([
+      expect.objectContaining({
+        id: "op-1",
+        hostInstanceId: "instance-1",
+        attempts: 1,
+        lastError: "offline",
+      }),
+    ]);
+    expect(JSON.stringify(await listGalleryMutations())).not.toContain(
+      "apiKey",
+    );
+
+    await removeGalleryMutation("op-1");
+    expect(await listGalleryMutations()).toEqual([]);
+  });
+
+  it("turns a large title selection into one bulk request", () => {
+    const filenames = Array.from({ length: 30 }, (_, index) => `${index}.png`);
+    expect(
+      galleryBulkRequest("op-30", {
+        kind: "setTitle",
+        hostId: "hal9000",
+        filenames,
+        title: "Moon studies",
+      }),
+    ).toEqual({
+      operation_id: "op-30",
+      filenames: [],
+      titles: filenames.map((filename) => ({
+        filename,
+        title: "Moon studies",
+      })),
+    });
+  });
+
+  it("persists strict enqueue order when inverse edits share a millisecond", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(1000);
+    await Promise.all([
+      enqueueGalleryMutation({
+        id: "z-add",
+        hostId: "hal9000",
+        hostInstanceId: "instance-1",
+        hostName: "hal9000",
+        op: {
+          kind: "addTags",
+          hostId: "hal9000",
+          filenames: ["a.png"],
+          tags: ["blue"],
+        },
+      }),
+      enqueueGalleryMutation({
+        id: "a-remove",
+        hostId: "hal9000",
+        hostInstanceId: "instance-1",
+        hostName: "hal9000",
+        op: {
+          kind: "removeTags",
+          hostId: "hal9000",
+          filenames: ["a.png"],
+          tags: ["blue"],
+        },
+      }),
+    ]);
+    expect((await listGalleryMutations()).map((item) => item.id)).toEqual([
+      "z-add",
+      "a-remove",
+    ]);
+  });
+});

--- a/studio/lib/galleryMutationOutbox.ts
+++ b/studio/lib/galleryMutationOutbox.ts
@@ -1,0 +1,226 @@
+/** Restart-safe, secret-free queue for organization edits targeting offline hosts. */
+
+import type { OrganizationFanoutOp } from "./libraryOrganization";
+import type { GalleryBulkMutationRequest } from "./api/galleryOrganization";
+
+const DB_NAME = "mold-gallery-mutation-outbox";
+const DB_VERSION = 1;
+const STORE = "operations";
+const volatileFallback = new Map<string, QueuedGalleryMutation>();
+
+export interface QueuedGalleryMutation {
+  id: string;
+  hostId: string;
+  hostInstanceId: string | null;
+  hostName: string;
+  op: OrganizationFanoutOp;
+  createdAt: number;
+  /** Strict enqueue order, persisted so inverse edits replay in order. */
+  sequence: number;
+  attempts: number;
+  lastError: string | null;
+}
+
+/** Translate a planned organization op to the server's single bulk wire call. */
+export function galleryBulkRequest(
+  operationId: string,
+  op: OrganizationFanoutOp,
+): GalleryBulkMutationRequest | null {
+  const base = { operation_id: operationId, filenames: [...op.filenames] };
+  switch (op.kind) {
+    case "setTitle":
+      return {
+        ...base,
+        filenames: [],
+        titles: op.filenames.map((filename) => ({
+          filename,
+          title: op.title ?? "",
+        })),
+      };
+    case "setFavorite":
+      return { ...base, favorite: op.favorite };
+    case "addTags":
+      return { ...base, add_tags: [...op.tags] };
+    case "removeTags":
+      return { ...base, remove_tags: [...op.tags] };
+    case "addToCollection":
+      return { ...base, add_to_collection: { name: op.ensureCollection.name } };
+    case "removeFromCollection":
+      return { ...base, remove_from_collection_slug: op.slug };
+    case "trash":
+    case "restore":
+    case "deleteForever":
+      return null;
+  }
+}
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE))
+        db.createObjectStore(STORE, { keyPath: "id" });
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () =>
+      reject(request.error ?? new Error("Could not open gallery outbox."));
+  });
+}
+
+async function transaction<T>(
+  mode: IDBTransactionMode,
+  run: (
+    store: IDBObjectStore,
+    resolve: (value: T) => void,
+    reject: (reason: unknown) => void,
+  ) => void,
+): Promise<T> {
+  const db = await openDb();
+  return new Promise<T>((resolve, reject) => {
+    const tx = db.transaction(STORE, mode);
+    let result: T | undefined;
+    let hasResult = false;
+    let failed = false;
+    const succeed = (value: T) => {
+      result = value;
+      hasResult = true;
+    };
+    const fail = (reason: unknown) => {
+      if (failed) return;
+      failed = true;
+      try {
+        tx.abort();
+      } catch {
+        // The request may already have aborted the transaction.
+      }
+      reject(reason);
+    };
+    tx.oncomplete = () => {
+      if (!failed && hasResult) resolve(result as T);
+    };
+    tx.onabort = () =>
+      fail(tx.error ?? new Error("Gallery outbox transaction aborted."));
+    tx.onerror = () =>
+      fail(tx.error ?? new Error("Gallery outbox transaction failed."));
+    run(tx.objectStore(STORE), succeed, fail);
+  }).finally(() => db.close());
+}
+
+let enqueueTail: Promise<void> = Promise.resolve();
+
+export function enqueueGalleryMutation(
+  input: Omit<
+    QueuedGalleryMutation,
+    "id" | "createdAt" | "sequence" | "attempts" | "lastError"
+  > & {
+    id?: string;
+  },
+): Promise<QueuedGalleryMutation> {
+  const pending = enqueueTail.then(async () => {
+    const existing = await listGalleryMutations();
+    const createdAt = Date.now();
+    const sequence = Math.max(
+      createdAt * 1000,
+      existing.reduce(
+        (max, item) => Math.max(max, item.sequence ?? item.createdAt * 1000),
+        0,
+      ) + 1,
+    );
+    const item: QueuedGalleryMutation = {
+      ...input,
+      id:
+        input.id ??
+        globalThis.crypto?.randomUUID?.() ??
+        `${createdAt}-${Math.random().toString(16).slice(2)}`,
+      createdAt,
+      sequence,
+      attempts: 0,
+      lastError: null,
+    };
+    if (typeof indexedDB === "undefined") {
+      volatileFallback.set(item.id, item);
+      return item;
+    }
+    return transaction<QueuedGalleryMutation>(
+      "readwrite",
+      (store, resolve, reject) => {
+        const request = store.put(item);
+        request.onsuccess = () => resolve(item);
+        request.onerror = () => reject(request.error);
+      },
+    );
+  });
+  enqueueTail = pending.then(
+    () => undefined,
+    () => undefined,
+  );
+  return pending;
+}
+
+function mutationOrder(
+  a: QueuedGalleryMutation,
+  b: QueuedGalleryMutation,
+): number {
+  const aSequence = a.sequence ?? a.createdAt * 1000;
+  const bSequence = b.sequence ?? b.createdAt * 1000;
+  return aSequence - bSequence || a.id.localeCompare(b.id);
+}
+
+export function listGalleryMutations(): Promise<QueuedGalleryMutation[]> {
+  if (typeof indexedDB === "undefined") {
+    return Promise.resolve([...volatileFallback.values()].sort(mutationOrder));
+  }
+  return transaction<QueuedGalleryMutation[]>(
+    "readonly",
+    (store, resolve, reject) => {
+      const request = store.getAll();
+      request.onsuccess = () =>
+        resolve(
+          (request.result as QueuedGalleryMutation[]).sort(mutationOrder),
+        );
+      request.onerror = () => reject(request.error);
+    },
+  );
+}
+
+export function removeGalleryMutation(id: string): Promise<void> {
+  if (typeof indexedDB === "undefined") {
+    volatileFallback.delete(id);
+    return Promise.resolve();
+  }
+  return transaction<void>("readwrite", (store, resolve, reject) => {
+    const request = store.delete(id);
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error);
+  });
+}
+
+export function updateGalleryMutationFailure(
+  id: string,
+  error: string,
+): Promise<void> {
+  if (typeof indexedDB === "undefined") {
+    const item = volatileFallback.get(id);
+    if (item)
+      volatileFallback.set(id, {
+        ...item,
+        attempts: item.attempts + 1,
+        lastError: error,
+      });
+    return Promise.resolve();
+  }
+  return transaction<void>("readwrite", (store, resolve, reject) => {
+    const get = store.get(id);
+    get.onsuccess = () => {
+      const item = get.result as QueuedGalleryMutation | undefined;
+      if (!item) return resolve();
+      item.attempts += 1;
+      item.lastError = error;
+      const put = store.put(item);
+      put.onsuccess = () => resolve();
+      put.onerror = () => reject(put.error);
+    };
+    get.onerror = () => reject(get.error);
+  });
+}

--- a/web/src/lib/libraryOrganization.test.ts
+++ b/web/src/lib/libraryOrganization.test.ts
@@ -6,6 +6,11 @@ import type { Collection, GalleryImage } from "../types";
 const api = vi.hoisted(() => ({
   patchGalleryImage: vi.fn(async () => null),
   organizeGallery: vi.fn(async () => undefined),
+  mutateGalleryBulk: vi.fn(async () => ({
+    operation_id: "op",
+    changed: 1,
+    revision: 1,
+  })),
   createCollection: vi.fn(async (_t: unknown, body: { name: string }) => ({
     id: `new-${body.name}`,
     name: body.name,
@@ -22,6 +27,7 @@ const api = vi.hoisted(() => ({
   trashMany: vi.fn(async () => undefined),
   restoreTrashed: vi.fn(async () => undefined),
   deleteGalleryImageForever: vi.fn(async () => undefined),
+  deleteManyForever: vi.fn(async () => undefined),
   emptyTrash: vi.fn(async () => ({ purged: 2 })),
   listCollections: vi.fn(async () => []),
   listTags: vi.fn(async () => []),
@@ -103,6 +109,7 @@ function snapshot(
     hostId,
     hostLabel: hostId,
     organize: true,
+    bulkMutations: false,
     trash: { enabled: true, retentionDays: 30 },
     collections: [],
     tags: [],
@@ -418,6 +425,40 @@ describe("mutations fan out to every copy's host", () => {
       filenames: ["twin.png", "other.png"],
       favorite: true,
     });
+  });
+
+  it("uses one replay-safe request per modern host for title selections and permanent delete", async () => {
+    const context = {
+      hostById,
+      snapshots: [
+        snapshot("origin", { bulkMutations: true }),
+        snapshot("plato", { bulkMutations: true }),
+      ],
+    };
+    await applyOrganizationMutation(
+      copies,
+      { kind: "setTitle", title: "Twin" },
+      context,
+    );
+    expect(api.mutateGalleryBulk).toHaveBeenCalledTimes(2);
+    expect(api.mutateGalleryBulk).toHaveBeenCalledWith(
+      platoTarget,
+      expect.objectContaining({
+        filenames: [],
+        titles: [
+          { filename: "twin.png", title: "Twin" },
+          { filename: "other.png", title: "Twin" },
+        ],
+      }),
+    );
+
+    await applyOrganizationMutation(copies, { kind: "deleteForever" }, context);
+    expect(api.deleteManyForever).toHaveBeenCalledTimes(2);
+    expect(api.deleteManyForever).toHaveBeenCalledWith(platoTarget, [
+      "twin.png",
+      "other.png",
+    ]);
+    expect(api.deleteGalleryImageForever).not.toHaveBeenCalled();
   });
 
   it("creates a missing collection by name before adding, reusing an existing one by slug", async () => {

--- a/web/src/lib/libraryOrganization.ts
+++ b/web/src/lib/libraryOrganization.ts
@@ -17,9 +17,11 @@ import {
   createCollection,
   deleteCollection,
   deleteGalleryImageForever,
+  deleteManyForever,
   emptyTrash,
   listCollections,
   listTags,
+  mutateGalleryBulk,
   organizeGallery,
   patchGalleryImage,
   restoreTrashed,
@@ -41,6 +43,7 @@ import {
   type OrganizationMutation,
   type RetentionHost,
 } from "@studio/lib/libraryOrganization";
+import { galleryBulkRequest } from "@studio/lib/galleryMutationOutbox";
 import {
   hostApiTarget,
   hostCapabilities,
@@ -62,6 +65,8 @@ export interface HostOrganizationSnapshot {
    * deliberately distinguishable from an answered `organize: false`, because
    * unknown hosts stay in the mutation fan-out (codex review). */
   organize: boolean | null;
+  /** Replay-safe organization/permanent-delete batches on current hosts. */
+  bulkMutations: boolean;
   /** `gallery.trash` — DELETE moves to the trash; `null` = permanent delete. */
   trash: { enabled: boolean; retentionDays: number } | null;
   collections: Collection[];
@@ -101,6 +106,7 @@ function emptySnapshot(host: HostEntry): HostOrganizationSnapshot {
     hostId: host.id,
     hostLabel: host.name,
     organize: null,
+    bulkMutations: false,
     trash: null,
     collections: [],
     tags: [],
@@ -121,6 +127,7 @@ async function fetchHostSnapshot(
   // The positive test itself is the shared `fileUnderAvailable`, so the
   // Library's organization gate and Create's "File under" gate cannot drift.
   snapshot.organize = caps ? fileUnderAvailable(caps) : null;
+  snapshot.bulkMutations = gallery?.bulk_mutations === true;
   snapshot.trash = gallery?.trash
     ? {
         enabled: gallery.trash.enabled,
@@ -506,6 +513,19 @@ export async function applyOrganizationMutation(
     mutation,
   );
   return fanout(ops, context.hostById, async (op, _host, target) => {
+    const bulk =
+      snapshotFor(context.snapshots, op.hostId)?.bulkMutations === true;
+    if (bulk) {
+      const request = galleryBulkRequest(crypto.randomUUID(), op);
+      if (request) {
+        await mutateGalleryBulk(target, request);
+        return;
+      }
+      if (op.kind === "deleteForever") {
+        await deleteManyForever(target, op.filenames);
+        return;
+      }
+    }
     switch (op.kind) {
       case "setTitle":
         await Promise.all(

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -203,6 +203,8 @@ export interface GalleryCapabilities {
   can_delete?: boolean;
   trash?: GalleryTrashCapabilities | null;
   organize?: boolean;
+  /** Replay-safe titles/tags/favorites/collection and permanent-delete batches. */
+  bulk_mutations?: boolean;
 }
 
 // Mirror of `mold_core::ServerCapabilities`.


### PR DESCRIPTION
## Summary

- atomically admit heterogeneous prepared batches into the durable queue so all siblings survive an iPhone/WebView disconnect and host restart
- add replay-safe bulk gallery organization and permanent-delete APIs, including chunked SQLite lookups for very large selections
- retain offline gallery edits in a restart-safe, secret-free client outbox with exact host-instance fencing and fresh credentials on replay
- use bulk paths across iPhone, desktop, and web while preserving legacy-host fallbacks

## Root cause

The iPhone submitted a prepared 30-item print as 30 independent streaming requests with only four sockets active at once. Backgrounding the WebView tore down active sockets and prevented three later siblings from ever reaching hal9000; another accepted sibling lost its stream acknowledgement, so the client displayed 26/30 while the host had accepted 27.

## Validation

- Claude peer-reviewed the implementation plan before coding
- independent agent review completed; all four P1 and two P2 findings fixed; final re-review found no remaining P0-P2 issues
- `cargo clippy -p mold-ai-db -p mold-ai-core -p mold-ai-server --all-targets -- -D warnings`
- `cargo test -p mold-ai-db` (214 unit + integration tests)
- server integration tests: atomic 30-child admission/retry/restart replay, replay-safe gallery mutation/concurrency/rollback, bulk permanent deletion
- desktop/mobile/studio affected suite: 448 tests
- web Library suite: 20 tests
- desktop and web Vue TypeScript project checks
- 1,200-item gallery mutation regression test