### PR TITLE
fix(desktop): round starter download progress

### DIFF
--- a/changelog.d/starter-download-progress-decimals.md
+++ b/changelog.d/starter-download-progress-decimals.md
@@ -1,0 +1,1 @@
+- **Cleaner first-run download progress.** Starter model downloads now show a whole-number percentage instead of exposing floating-point decimals in the desktop app.

--- a/desktop/src/components/generate/StarterCards.test.ts
+++ b/desktop/src/components/generate/StarterCards.test.ts
@@ -73,14 +73,20 @@ describe("StarterCards (cold start G10)", () => {
 
   it("shows inline progress on the pulling card instead of a Pull button", () => {
     const store = useDownloadsStore();
-    store.activeJobs = [job({ model: "flux2-klein:q4", bytes_done: 40, bytes_total: 100 })];
+    store.activeJobs = [
+      job({
+        model: "flux2-klein:q4",
+        bytes_done: 45_870_258_557,
+        bytes_total: 100_000_000_000,
+      }),
+    ];
     const wrapper = mount(StarterCards);
 
     const cards = wrapper.findAll("[data-test='starter-card']");
     // The first (matching) card is pulling; the others still offer Pull.
     expect(cards[0]!.find("[data-test='starter-pulling']").exists()).toBe(true);
     expect(cards[0]!.find("[data-test='starter-pull']").exists()).toBe(false);
-    expect(cards[0]!.text()).toContain("40%");
+    expect(cards[0]!.get("[data-test='starter-pulling']").text()).toBe("Pulling… 46%");
     expect(cards[1]!.find("[data-test='starter-pull']").exists()).toBe(true);
   });
 

--- a/desktop/src/components/generate/StarterCards.vue
+++ b/desktop/src/components/generate/StarterCards.vue
@@ -81,7 +81,11 @@ async function pull(model: string) {
           </div>
           <span class="edge-code" data-test="starter-pulling">
             Pulling…
-            {{ percent(jobFor(starter.model)!.bytes_done, jobFor(starter.model)!.bytes_total) }}%
+            {{
+              Math.round(
+                percent(jobFor(starter.model)!.bytes_done, jobFor(starter.model)!.bytes_total),
+              )
+            }}%
           </span>
         </template>
         <button

--- a/desktop/src/mobile/mobileDownloads.test.ts
+++ b/desktop/src/mobile/mobileDownloads.test.ts
@@ -367,6 +367,29 @@ describe("mobile download authority", () => {
     expect(store.pullStatusForHost(entry, studio.id)?.phase).toBe("queued");
   });
 
+  it("rounds active pull progress to a whole-number percentage", () => {
+    const store = useMobileDownloadsStore();
+    store.registerConsumer("catalog", [studio]);
+    streams[0]!.onEvent(
+      "download",
+      JSON.stringify(
+        snapshot([
+          {
+            ...queuedJob("fractional-progress", entry.name),
+            status: "active",
+            bytes_done: 45_870_258_557,
+            bytes_total: 100_000_000_000,
+          },
+        ]),
+      ),
+    );
+
+    expect(store.pullStatusForHost(entry, studio.id)).toEqual({
+      label: "Pulling 46%",
+      phase: "active",
+    });
+  });
+
   it("replaces changed host targets, ignores stale frames, and isolates equal job ids", () => {
     const store = useMobileDownloadsStore();
     store.registerConsumer("catalog", [studio, render]);

--- a/web/src/components/create/ColdStartGuide.test.ts
+++ b/web/src/components/create/ColdStartGuide.test.ts
@@ -84,8 +84,8 @@ describe("ColdStartGuide", () => {
         id: "d1",
         model: "flux2-klein:q4",
         status: "active",
-        bytes_done: 3_000,
-        bytes_total: 10_000,
+        bytes_done: 45_870_258_557,
+        bytes_total: 100_000_000_000,
       },
     ];
     dlState.queued = [];
@@ -96,7 +96,7 @@ describe("ColdStartGuide", () => {
     expect(
       wrapper.find('[data-test="starter-pull-flux2-klein:q4"]').exists(),
     ).toBe(false);
-    expect(wrapper.text()).toContain("pulling 30%");
+    expect(wrapper.text()).toContain("pulling 46%");
   });
 
   it("marks a queued starter as queued", () => {


### PR DESCRIPTION
## Summary
- round the desktop first-run starter download label to a whole-number percentage
- guard fractional progress formatting across desktop, web, and shared iPhone/Android mobile flows

## Verification
- `nix develop -c bun run check:frontend`
- rendered starter card QA: `45.870258557%` displays as `Pulling… 46%` with a clean browser console