### PR TITLE
fix(release): skip Android build for trusted release PRs

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -58,6 +58,14 @@ concurrency:
 jobs:
   changes:
     name: Classify Android changes
+    # Generated release-plz PRs only mirror an already-tested main revision's
+    # version metadata. Match the repository-owned app and branch prefix so a
+    # user-controlled branch cannot bypass Android validation.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.actor != 'release-plz-mold[bot]' ||
+      startsWith(github.head_ref, 'release-plz-') == false ||
+      github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/changelog.d/release-plz-android-fast-path.md
+++ b/changelog.d/release-plz-android-fast-path.md
@@ -1,0 +1,1 @@
+- **Release version bumps no longer rebuild Android.** Repository-owned release-plz PRs now use the same guarded metadata-only fast path as desktop and iOS, while untrusted lookalike branches still run the full Android validation route.

--- a/scripts/tests/ci-routing-contract.sh
+++ b/scripts/tests/ci-routing-contract.sh
@@ -65,7 +65,7 @@ fi
 
 # Assert the complete trusted-app predicates, then exercise the security truth
 # table. Fragment checks would pass if an operator were accidentally inverted.
-python3 - "$ci" "$desktop" "$ios" <<'PY' || exit 1
+python3 - "$ci" "$desktop" "$ios" "$android" <<'PY' || exit 1
 import re
 import sys
 from pathlib import Path
@@ -75,7 +75,7 @@ def normalize(value: str) -> str:
     return " ".join(value.split())
 
 
-ci_text, desktop_text, ios_text = (Path(path).read_text() for path in sys.argv[1:])
+ci_text, desktop_text, ios_text, android_text = (Path(path).read_text() for path in sys.argv[1:])
 trusted = (
     "github.event_name == 'pull_request' && "
     "github.actor == 'release-plz-mold[bot]' && "
@@ -92,7 +92,7 @@ untrusted = (
     "startsWith(github.head_ref, 'release-plz-') == false || "
     "github.event.pull_request.head.repo.full_name != github.repository"
 )
-for label, text in (("desktop", desktop_text), ("iOS", ios_text)):
+for label, text in (("desktop", desktop_text), ("iOS", ios_text), ("Android", android_text)):
     block = re.search(r"(?ms)^  changes:\n(.*?)(?=^  [A-Za-z0-9_-]+:\n)", text)
     condition = re.search(r"(?ms)^    if: >-\n(.*?)(?=^    [A-Za-z0-9_-]+:)", block.group(1) if block else "")
     if condition is None or normalize(condition.group(1)) != untrusted:


### PR DESCRIPTION
## Summary

- apply the repository-owned release-plz fast-path guard to Android CI
- keep untrusted actor, branch, event, and fork lookalikes on the full Android validation path
- extend the shared CI routing contract to cover Android's complete predicate

## Validation

- `nix develop -c bash scripts/tests/ci-routing-contract.sh`
- `nix develop -c bash scripts/tests/changelog-fragments-contract.sh`
- `nix run nixpkgs#actionlint -- .github/workflows/android.yml .github/workflows/ci.yml`
- `git diff --check`
