### PR TITLE
fix(studio): expose MiniMax H3 references

### DIFF
--- a/changelog.d/minimax-h3-source-controls.md
+++ b/changelog.d/minimax-h3-source-controls.md
@@ -1,0 +1,4 @@
+- **Expose MiniMax H3 reference inputs.** Ref2VA image, video, and audio
+  references now appear beside the required-media warning in Create on web,
+  desktop, and mobile, and every registered H3 model identity is classified
+  consistently.

--- a/desktop/src/components/create/AdvancedSettings.test.ts
+++ b/desktop/src/components/create/AdvancedSettings.test.ts
@@ -475,7 +475,7 @@ describe("AdvancedSettings — video (LTX-2)", () => {
     expect(form.keyframes[0]!.frame).toBe(0);
   });
 
-  it("keeps only the Ref2VA ordered-reference panel in Advanced for H3", () => {
+  it("keeps all H3 media controls out of Advanced", () => {
     const fl2va = formFor("minimax-h3");
     fl2va.model = "minimax-h3-fl2va:comfy-pruned-int8";
     const fl2vaWrapper = mountSettings(fl2va, {
@@ -493,8 +493,8 @@ describe("AdvancedSettings — video (LTX-2)", () => {
     const ref2vaWrapper = mountSettings(ref2va, {
       selectedModel: { name: ref2va.model, family: ref2va.family } as ModelEntry,
     });
-    expect(ref2vaWrapper.find("[data-test='section-h3-authoring']").exists()).toBe(true);
-    expect(accordionTitles(ref2vaWrapper)).toContain("Ordered references");
+    expect(ref2vaWrapper.find("[data-test='section-h3-authoring']").exists()).toBe(false);
+    expect(accordionTitles(ref2vaWrapper)).not.toContain("Ordered references");
   });
 
   it("shows the chained-clips cue when frames exceed one clip for a chainable model", async () => {

--- a/desktop/src/components/create/AdvancedSettings.vue
+++ b/desktop/src/components/create/AdvancedSettings.vue
@@ -107,12 +107,6 @@ import { AUDIO_ONLY_PIPELINE, isAudioOnlyPipeline } from "@studio/lib/ltx2Pipeli
 import LoraStack from "../generate/LoraStack.vue";
 import ImagePickerModal from "../generate/ImagePickerModal.vue";
 import { attachPickedVideo } from "../../lib/sourceAttachment";
-import MinimaxH3AuthoringPanel from "@studio/components/MinimaxH3AuthoringPanel.vue";
-import {
-  emptyMinimaxH3AuthoringState,
-  minimaxH3TaskForModel,
-  type MinimaxH3AuthoringState,
-} from "@studio/lib/minimaxH3Authoring";
 
 const props = withDefaults(
   defineProps<{
@@ -156,13 +150,6 @@ const caps = computed(() =>
 );
 const formats = computed(() => caps.value.outputFormats as OutputFormat[]);
 const advancedCount = computed(() => advancedActiveCount(props.form));
-const h3Task = computed(() =>
-  props.selectedModel ? minimaxH3TaskForModel(props.form.model) : null,
-);
-const h3Authoring = computed(() => props.form.h3Authoring ?? emptyMinimaxH3AuthoringState());
-function setH3Authoring(value: MinimaxH3AuthoringState): void {
-  props.form.h3Authoring = value;
-}
 
 // ── Scheduler & sampling ─────────────────────────────────────────────────────
 const schedulerSummary = computed(() => schedulerLabel(props.form.scheduler));
@@ -740,20 +727,6 @@ function reset() {
         >
           {{ identityMessage }}
         </p>
-      </AccordionSection>
-
-      <!-- H3 Ref2VA ordered references. FL2VA boundaries and every other
-           image well live in the primary form (InspectorPanel), not here. -->
-      <AccordionSection
-        v-if="h3Task === 'ref2va'"
-        icon="video"
-        title="Ordered references"
-        :summary="`${h3Authoring.references.length} in semantic order`"
-        :open="true"
-        :header-interactive="false"
-        data-test="section-h3-authoring"
-      >
-        <MinimaxH3AuthoringPanel :model-value="h3Authoring" @update:model-value="setH3Authoring" />
       </AccordionSection>
 
       <!-- 4 · LoRA stack -->

--- a/desktop/src/components/create/InspectorPanel.test.ts
+++ b/desktop/src/components/create/InspectorPanel.test.ts
@@ -992,14 +992,15 @@ describe("InspectorPanel — source media in the primary form", () => {
     expect(wrapper.find("[data-test='inspector-identity']").exists()).toBe(false);
   });
 
-  it("keeps H3 Ref2VA references out of the primary form", () => {
+  it("exposes H3 Ref2VA references in the primary form", () => {
     const form = formFor("minimax-h3");
     form.model = "minimax-h3-ref2va:comfy-pruned-int8";
     useModelStore().all = [
       { name: form.model, family: form.family, downloaded: true } as ModelEntry,
     ];
     const wrapper = mount(InspectorPanel, { props: { form } });
-    expect(wrapper.find("[data-test='inspector-source-media']").exists()).toBe(false);
+    expect(wrapper.find("[data-test='inspector-source-media']").exists()).toBe(true);
+    expect(wrapper.find("[data-test='h3-reference-files']").exists()).toBe(true);
   });
 
   it("stands down in sequence mode — the sequence composer owns its opening image", () => {

--- a/desktop/src/components/create/InspectorPanel.vue
+++ b/desktop/src/components/create/InspectorPanel.vue
@@ -219,18 +219,12 @@ const caps = computed(() =>
   ),
 );
 /** The model's image-attachment shape — one shared policy, never a local
- * heuristic. `none` hides the well outright; `h3-references` keeps the H3
- * ordered-reference editor in Advanced. */
+ * heuristic. Only `none` hides the primary conditioning editor. */
 const sourcePlan = computed(() => sourceMediaPlan(caps.value));
 const sequenceSourceImagesSupported = computed(
   () => (selectedModel.value?.source_image ?? props.form.sourceImageCapability) !== "unsupported",
 );
-const showSourceMedia = computed(
-  () =>
-    !isSequence.value &&
-    sourcePlan.value.kind !== "none" &&
-    sourcePlan.value.kind !== "h3-references",
-);
+const showSourceMedia = computed(() => !isSequence.value && sourcePlan.value.kind !== "none");
 /** Identity is capability-gated on positive knowledge only: an unread or
  * absent `supports_identity` renders nothing at all rather than a control for
  * a feature this host does not have. Sequence clips carry no identity slot.

--- a/desktop/src/components/generate/SourceImageWell.test.ts
+++ b/desktop/src/components/generate/SourceImageWell.test.ts
@@ -380,6 +380,18 @@ describe("SourceImageWell — per-model source conditioning (#772, #779)", () =>
     });
   }
 
+  it("exposes Ref2VA ordered references in the primary source control", () => {
+    const form = reactive({
+      ...newGenerateForm(),
+      family: "minimax-h3",
+      model: "minimax-h3-ref2va:comfy-pruned-int8",
+    });
+    const wrapper = mount(SourceImageWell, { props: { form }, attachTo: document.body });
+
+    expect(wrapper.find("[data-test='h3-reference-controls']").exists()).toBe(true);
+    expect(wrapper.find("[data-test='h3-reference-files']").exists()).toBe(true);
+  });
+
   it("keeps today's well and offers no end frame when the server advertises nothing", () => {
     const form = wanForm(undefined);
     const wrapper = mount(SourceImageWell, { props: { form }, attachTo: document.body });

--- a/desktop/src/components/generate/SourceImageWell.vue
+++ b/desktop/src/components/generate/SourceImageWell.vue
@@ -22,6 +22,7 @@ import { useToastStore } from "../../stores/toasts";
 import { attachPickedImage } from "../../lib/sourceAttachment";
 import ImageDropWell from "@studio/components/ImageDropWell.vue";
 import SourceMediaWells, { type SourceMediaSlot } from "@studio/components/SourceMediaWells.vue";
+import MinimaxH3AuthoringPanel from "@studio/components/MinimaxH3AuthoringPanel.vue";
 import { sourceMediaPlan } from "@studio/lib/sourceMediaPlan";
 import { strengthSemantics } from "@studio/lib/strengthSemantics";
 import { sourceConditioningLimitLabel } from "@studio/lib/sourceResolution";
@@ -72,8 +73,7 @@ const caps = computed(() =>
 // Family-scoped label for the shared `strength` wire field (#1055).
 const strength = computed(() => strengthSemantics(props.form.family));
 /** The model's own image-attachment shape — the single policy every surface
- * renders (`@studio/lib/sourceMediaPlan`). `none` and `h3-references` render
- * nothing here. */
+ * renders (`@studio/lib/sourceMediaPlan`). */
 const plan = computed(() => sourceMediaPlan(caps.value));
 const flux2Dev = computed(() => isFlux2DevModel(props.form.model));
 /** Why the attached conditioning would be refused, in the server's own order. */
@@ -286,6 +286,9 @@ function onWellClear(slot: SourceMediaSlot) {
 // shared studio setters so a file and a gallery pick produce identical facts.
 
 const h3Authoring = computed(() => props.form.h3Authoring ?? emptyMinimaxH3AuthoringState());
+function setH3Authoring(value: typeof h3Authoring.value): void {
+  props.form.h3Authoring = value;
+}
 const h3PickerTarget = ref<MinimaxH3BoundaryEndpoint | null>(null);
 const h3Error = ref<string | null>(null);
 
@@ -345,8 +348,16 @@ function setSourceFitMode(e: Event) {
 </script>
 
 <template>
+  <div v-if="plan.kind === 'h3-references'" data-test="h3-reference-controls">
+    <div class="mb-2 flex items-center gap-2">
+      <span class="edge-code">Ordered references</span>
+      <div class="border-edge h-px flex-1 border-t" />
+    </div>
+    <MinimaxH3AuthoringPanel :model-value="h3Authoring" @update:model-value="setH3Authoring" />
+  </div>
+
   <!-- Ordered Qwen edit pictures or FLUX.2 reference images. -->
-  <div v-if="plan.kind === 'attachments'">
+  <div v-else-if="plan.kind === 'attachments'">
     <SourceMediaWells
       v-if="plan.primary === 'target'"
       :plan="plan"

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -7587,8 +7587,8 @@ describe("MobileApp gallery", () => {
       ),
     );
 
-    await wrapper.get("[data-test='mobile-open-advanced']").trigger("click");
-    await flushPromises();
+    // Ref2VA references live in the primary Create stack, not behind Advanced.
+    expect(wrapper.find("[data-test='mobile-h3-authoring']").exists()).toBe(true);
     expect(wrapper.get("[data-test='h3-reference-0']").text()).toContain("ordered subject.png");
   });
 

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -1239,12 +1239,9 @@ const caps = computed(() =>
   ),
 );
 /** The model's image-attachment shape — one shared policy (`sourceMediaPlan`).
- * `none` hides the source section outright; `h3-references` keeps the H3
- * ordered-reference editor in the Advanced sheet. */
+ * Only `none` hides the primary conditioning editor. */
 const sourcePlan = computed(() => sourceMediaPlan(caps.value));
-const showSourceMedia = computed(
-  () => sourcePlan.value.kind !== "none" && sourcePlan.value.kind !== "h3-references",
-);
+const showSourceMedia = computed(() => sourcePlan.value.kind !== "none");
 const h3AuthoringError = computed(() =>
   minimaxH3AuthoringError(
     form.family,

--- a/desktop/src/mobile/MobileGenerateParameters.test.ts
+++ b/desktop/src/mobile/MobileGenerateParameters.test.ts
@@ -70,7 +70,7 @@ async function attachFile(wrapper: VueWrapper, selector: string, file: File): Pr
 }
 
 describe("MobileGenerateParameters", () => {
-  it("keeps only the Ref2VA ordered-reference panel in the Advanced sheet for H3", () => {
+  it("keeps all H3 media controls out of the Advanced sheet", () => {
     const fl2va = {
       name: "minimax-h3-fl2va:comfy-pruned-int8",
       family: "minimax-h3",
@@ -85,8 +85,8 @@ describe("MobileGenerateParameters", () => {
       family: "minimax-h3",
     } as ModelEntry;
     const references = mountParameters(formFor(ref2va.family, ref2va.name), [], [], [], ref2va);
-    expect(references.wrapper.find("[data-test='mobile-h3-authoring']").exists()).toBe(true);
-    expect(references.wrapper.text()).toContain("Ordered references");
+    expect(references.wrapper.find("[data-test='mobile-h3-authoring']").exists()).toBe(false);
+    expect(references.wrapper.text()).not.toContain("Ordered references");
   });
 
   it("resets model-owned controls when the recipe changes", async () => {

--- a/desktop/src/mobile/MobileGenerateParameters.vue
+++ b/desktop/src/mobile/MobileGenerateParameters.vue
@@ -92,12 +92,6 @@ import {
   isControlAdapterPipeline,
   pipelineForControlId,
 } from "@studio/lib/ltx2Control";
-import MinimaxH3AuthoringPanel from "@studio/components/MinimaxH3AuthoringPanel.vue";
-import {
-  emptyMinimaxH3AuthoringState,
-  minimaxH3TaskForModel,
-  type MinimaxH3AuthoringState,
-} from "@studio/lib/minimaxH3Authoring";
 
 const props = withDefaults(
   defineProps<{
@@ -135,13 +129,6 @@ const caps = computed(() =>
     effectiveGenerationRecipe(props.selectedModel, props.form.pipeline),
   ),
 );
-const h3Task = computed(() =>
-  props.selectedModel ? minimaxH3TaskForModel(props.form.model) : null,
-);
-const h3Authoring = computed(() => props.form.h3Authoring ?? emptyMinimaxH3AuthoringState());
-function setH3Authoring(value: MinimaxH3AuthoringState): void {
-  props.form.h3Authoring = value;
-}
 const videoContract = computed(() => props.selectedModel ?? { family: props.form.family });
 const frameGridLabel = computed(() => videoFrameGridLabel(videoContract.value));
 const frameStep = computed(() => videoFrameStep(videoContract.value));
@@ -747,21 +734,6 @@ const fpsErrorId = `mobile-fps-error-${useId()}`;
       >
         {{ identityError }}
       </p>
-    </fieldset>
-
-    <!-- H3 Ref2VA ordered references. FL2VA boundaries render as the shared
-         source wells in the primary Create stack, not in this sheet. -->
-    <fieldset
-      v-if="h3Task === 'ref2va'"
-      class="mobile-generate-section"
-      data-test="mobile-h3-authoring"
-    >
-      <legend class="mobile-generate-legend">Ordered references</legend>
-      <MinimaxH3AuthoringPanel
-        :model-value="h3Authoring"
-        touch-friendly
-        @update:model-value="setH3Authoring"
-      />
     </fieldset>
 
     <fieldset

--- a/desktop/src/mobile/MobileSourceControls.test.ts
+++ b/desktop/src/mobile/MobileSourceControls.test.ts
@@ -568,6 +568,18 @@ describe("MobileSourceControls", () => {
 });
 
 describe("MobileSourceControls — MiniMax H3 FL2VA boundaries", () => {
+  it("exposes Ref2VA ordered references in the primary Create stack", () => {
+    const form = formFor("minimax-h3");
+    form.model = "minimax-h3-ref2va:comfy-pruned-int8";
+    const wrapper = mount(MobileSourceControls, {
+      props: { form, model: model(form.model, form.family) },
+    });
+
+    expect(wrapper.find("[data-test='mobile-h3-authoring']").exists()).toBe(true);
+    expect(wrapper.find("[data-test='h3-reference-files']").exists()).toBe(true);
+    expect(wrapper.text()).toContain("Add at least one image or video reference.");
+  });
+
   it("renders the shared wells and applies a gallery pick to the first frame", async () => {
     const form = formFor("minimax-h3");
     form.model = "minimax-h3-fl2va:comfy-pruned-int8";

--- a/desktop/src/mobile/MobileSourceControls.vue
+++ b/desktop/src/mobile/MobileSourceControls.vue
@@ -27,6 +27,7 @@ import { sourceConditioningLimitLabel } from "@studio/lib/sourceResolution";
 import MobileImagePickerSheet, { type MobilePickedImage } from "./MobileImagePickerSheet.vue";
 import { effectiveGenerationRecipe } from "@studio/lib/generationProfile";
 import SourceMediaWells, { type SourceMediaSlot } from "@studio/components/SourceMediaWells.vue";
+import MinimaxH3AuthoringPanel from "@studio/components/MinimaxH3AuthoringPanel.vue";
 import { sourceMediaPlan } from "@studio/lib/sourceMediaPlan";
 import {
   emptyMinimaxH3AuthoringState,
@@ -86,6 +87,9 @@ const sourceLimitLabel = computed(() =>
 // The same standard wells, backed by the dedicated H3 authoring state and the
 // shared studio setters so a file and a gallery pick produce identical facts.
 const h3Authoring = computed(() => props.form.h3Authoring ?? emptyMinimaxH3AuthoringState());
+function setH3Authoring(value: typeof h3Authoring.value): void {
+  props.form.h3Authoring = value;
+}
 const h3PickerTarget = ref<MinimaxH3BoundaryEndpoint | null>(null);
 const h3Error = ref<string | null>(null);
 const h3PickerMaxBytes = computed(() =>
@@ -455,8 +459,21 @@ function applyMask(mask: string): void {
 </script>
 
 <template>
+  <fieldset
+    v-if="plan.kind === 'h3-references'"
+    class="mobile-source-controls"
+    data-test="mobile-h3-authoring"
+  >
+    <legend class="mobile-source-legend">Ordered references · Required</legend>
+    <MinimaxH3AuthoringPanel
+      :model-value="h3Authoring"
+      touch-friendly
+      @update:model-value="setH3Authoring"
+    />
+  </fieldset>
+
   <!-- MiniMax H3 FL2VA boundaries: the exact same wells, H3-owned state. -->
-  <template v-if="plan.kind === 'h3-boundaries'">
+  <template v-else-if="plan.kind === 'h3-boundaries'">
     <fieldset class="mobile-source-controls" data-test="mobile-h3-boundaries">
       <SourceMediaWells
         :plan="plan"

--- a/studio/lib/minimaxH3Authoring.test.ts
+++ b/studio/lib/minimaxH3Authoring.test.ts
@@ -3,7 +3,9 @@ import type { GenerationReference } from "./generationReferences";
 import {
   MINIMAX_H3_FIXED_FPS,
   MINIMAX_H3_FL2VA_COMFY,
+  MINIMAX_H3_FL2VA_COMFY_NVFP4,
   MINIMAX_H3_REF2VA_COMFY,
+  MINIMAX_H3_REF2VA_COMFY_NVFP4,
   MINIMAX_H3_RESYNTHESIS_GUIDANCE,
   appendMinimaxH3GalleryImageReference,
   canonicalMinimaxH3ModelName,
@@ -75,6 +77,8 @@ describe("MiniMax H3 Studio authority", () => {
     expect(minimaxH3TaskForModel("minimax_h3_ref2va:comfy-pruned-int8")).toBe(
       "ref2va",
     );
+    expect(minimaxH3TaskForModel(MINIMAX_H3_FL2VA_COMFY_NVFP4)).toBe("fl2va");
+    expect(minimaxH3TaskForModel(MINIMAX_H3_REF2VA_COMFY_NVFP4)).toBe("ref2va");
     expect(minimaxH3TaskForModel("hf:opaque")).toBeNull();
     expect(isMinimaxH3Identity(null, "minimax_h3_ref2va")).toBe(true);
     expect(isMinimaxH3Identity(null, "hf:opaque")).toBe(false);

--- a/studio/lib/minimaxH3Authoring.ts
+++ b/studio/lib/minimaxH3Authoring.ts
@@ -21,10 +21,12 @@ export {
   isMinimaxH3Identity,
   minimaxH3TaskForModel,
   MINIMAX_H3_FL2VA_COMFY,
+  MINIMAX_H3_FL2VA_COMFY_NVFP4,
   MINIMAX_H3_FL2VA_COMFY_TURBO_4STEP_768P,
   MINIMAX_H3_FL2VA_COMFY_TURBO_8STEP,
   MINIMAX_H3_FL2VA_OFFICIAL,
   MINIMAX_H3_REF2VA_COMFY,
+  MINIMAX_H3_REF2VA_COMFY_NVFP4,
   MINIMAX_H3_REF2VA_OFFICIAL,
   type MinimaxH3Task,
 } from "./minimaxH3Identity";
@@ -32,8 +34,8 @@ export {
 export const MINIMAX_H3_FIXED_FPS = 24;
 // Mirrors `mold_core::minimax_h3::REVIEWED_COMPACT_FRAMES` — the exact clip
 // length the reviewed compact runtime renders, which every Studio surface
-// authors because the official BF16 tags are policy-hidden and never reach a
-// picker. Deliberately NOT `MIN_FRAMES`, whose 107 is the family floor derived
+// authors because runtime-unavailable official/NVFP4 tags are filtered from
+// Create. Deliberately NOT `MIN_FRAMES`, whose 107 is the family floor derived
 // from the model card's 4-second minimum: the two were one constant until they
 // were separated, and a compact request clamped to 107 is one the runtime
 // refuses.

--- a/studio/lib/minimaxH3Identity.ts
+++ b/studio/lib/minimaxH3Identity.ts
@@ -4,6 +4,10 @@ export const MINIMAX_H3_FL2VA_OFFICIAL = "minimax-h3-fl2va:official-bf16";
 export const MINIMAX_H3_REF2VA_OFFICIAL = "minimax-h3-ref2va:official-bf16";
 export const MINIMAX_H3_FL2VA_COMFY = "minimax-h3-fl2va:comfy-pruned-int8";
 export const MINIMAX_H3_REF2VA_COMFY = "minimax-h3-ref2va:comfy-pruned-int8";
+export const MINIMAX_H3_FL2VA_COMFY_NVFP4 =
+  "minimax-h3-fl2va:comfy-pruned-nvfp4";
+export const MINIMAX_H3_REF2VA_COMFY_NVFP4 =
+  "minimax-h3-ref2va:comfy-pruned-nvfp4";
 export const MINIMAX_H3_FL2VA_COMFY_TURBO_8STEP =
   "minimax-h3-fl2va:comfy-pruned-int8-turbo-8step";
 export const MINIMAX_H3_FL2VA_COMFY_TURBO_4STEP_768P =
@@ -33,6 +37,8 @@ export function canonicalMinimaxH3ModelName(
     value === MINIMAX_H3_REF2VA_OFFICIAL ||
     value === MINIMAX_H3_FL2VA_COMFY ||
     value === MINIMAX_H3_REF2VA_COMFY ||
+    value === MINIMAX_H3_FL2VA_COMFY_NVFP4 ||
+    value === MINIMAX_H3_REF2VA_COMFY_NVFP4 ||
     value === MINIMAX_H3_FL2VA_COMFY_TURBO_8STEP ||
     value === MINIMAX_H3_FL2VA_COMFY_TURBO_4STEP_768P
   ) {

--- a/studio/lib/sourceMediaPlan.test.ts
+++ b/studio/lib/sourceMediaPlan.test.ts
@@ -59,15 +59,27 @@ describe("sourceMediaPlan", () => {
   });
 
   it("maps MiniMax H3 tasks to boundary wells and the reference panel", () => {
-    expect(plan("minimax-h3", "minimax-h3-fl2va:comfy-pruned-int8")).toEqual({
-      kind: "h3-boundaries",
-      requiredEndpoint: null,
-    });
+    for (const model of [
+      "minimax-h3-fl2va:official-bf16",
+      "minimax-h3-fl2va:comfy-pruned-int8",
+      "minimax-h3-fl2va:comfy-pruned-int8-turbo-8step",
+      "minimax-h3-fl2va:comfy-pruned-int8-turbo-4step-768p",
+      "minimax-h3-fl2va:comfy-pruned-nvfp4",
+    ]) {
+      expect(plan("minimax-h3", model)).toEqual({
+        kind: "h3-boundaries",
+        requiredEndpoint: null,
+      });
+    }
     expect(
       plan("minimax-h3", "minimax-h3-fl2va:comfy-pruned-int8", "required"),
     ).toEqual({ kind: "h3-boundaries", requiredEndpoint: "first" });
-    expect(plan("minimax-h3", "minimax-h3-ref2va:comfy-pruned-int8")).toEqual({
-      kind: "h3-references",
-    });
+    for (const model of [
+      "minimax-h3-ref2va:official-bf16",
+      "minimax-h3-ref2va:comfy-pruned-int8",
+      "minimax-h3-ref2va:comfy-pruned-nvfp4",
+    ]) {
+      expect(plan("minimax-h3", model)).toEqual({ kind: "h3-references" });
+    }
   });
 });

--- a/web/src/components/create/AdvancedDrawer.test.ts
+++ b/web/src/components/create/AdvancedDrawer.test.ts
@@ -77,7 +77,7 @@ function factory(
 }
 
 describe("AdvancedDrawer sequence contract", () => {
-  it("keeps only the Ref2VA ordered-reference panel — boundaries live in the primary form", () => {
+  it("keeps all H3 media controls in the primary form", () => {
     const fl2va = {
       name: "minimax-h3-fl2va:comfy-pruned-int8",
       family: "minimax-h3",
@@ -104,9 +104,9 @@ describe("AdvancedDrawer sequence contract", () => {
       { models: [ref2va] },
     );
     expect(references.find("[data-test='section-h3-authoring']").exists()).toBe(
-      true,
+      false,
     );
-    expect(references.text()).toContain("Ordered references");
+    expect(references.text()).not.toContain("Ordered references");
   });
 
   it("preserves but disables clip negatives for a distilled recipe", () => {

--- a/web/src/components/create/AdvancedDrawer.vue
+++ b/web/src/components/create/AdvancedDrawer.vue
@@ -24,7 +24,6 @@ import LoraPicker from "../LoraPicker.vue";
 import PlacementPanel from "../PlacementPanel.vue";
 import ExtendVideoControls from "./advanced/ExtendVideoControls.vue";
 import Ltx2VideoControls from "./advanced/Ltx2VideoControls.vue";
-import MinimaxH3AuthoringPanel from "@studio/components/MinimaxH3AuthoringPanel.vue";
 import { DEFAULT_EXTEND_OVERLAP_FRAMES } from "@studio/lib/extend";
 import type { CanvasIntent } from "@studio/lib/outputShape";
 import UpscaleSection from "./advanced/UpscaleSection.vue";
@@ -81,12 +80,9 @@ import {
   isCameraMotionPreset,
 } from "@studio/lib/cameraMotion";
 import {
-  emptyMinimaxH3AuthoringState,
   isMinimaxH3Identity,
-  minimaxH3TaskForModel,
   MINIMAX_H3_MAX_FRAMES,
   MINIMAX_H3_REVIEWED_COMPACT_FRAMES,
-  type MinimaxH3AuthoringState,
 } from "@studio/lib/minimaxH3Authoring";
 import {
   effectiveGenerationRecipe,
@@ -239,18 +235,9 @@ const caps = computed(() =>
     effectiveGenerationRecipe(selectedModel.value, props.modelValue.pipeline),
   ),
 );
-const h3Task = computed(() =>
-  selectedModel.value ? minimaxH3TaskForModel(props.modelValue.model) : null,
-);
 const h3Family = computed(() =>
   isMinimaxH3Identity(props.family, props.modelValue.model),
 );
-const h3Authoring = computed(
-  () => props.modelValue.h3Authoring ?? emptyMinimaxH3AuthoringState(),
-);
-function setH3Authoring(value: MinimaxH3AuthoringState) {
-  patch({ h3Authoring: value });
-}
 const formats = computed(() => caps.value.outputFormats as OutputFormat[]);
 
 // Wan puts its solver in the recipe section below, next to the flow shift it
@@ -654,23 +641,6 @@ function setSequenceCameraMode(mode: string) {
         </AccordionSection>
       </template>
       <template v-else>
-        <!-- H3 Ref2VA ordered references. FL2VA boundaries and every other
-             image well live in the primary form (SourceMediaPanel). -->
-        <AccordionSection
-          v-if="h3Task === 'ref2va'"
-          icon="video"
-          title="Ordered references"
-          :summary="`${h3Authoring.references.length} in semantic order`"
-          :open="true"
-          :header-interactive="false"
-          data-test="section-h3-authoring"
-        >
-          <MinimaxH3AuthoringPanel
-            :model-value="h3Authoring"
-            @update:model-value="setH3Authoring"
-          />
-        </AccordionSection>
-
         <AccordionSection
           v-if="showScheduler"
           icon="scheduler"

--- a/web/src/components/create/SourceMediaPanel.test.ts
+++ b/web/src/components/create/SourceMediaPanel.test.ts
@@ -347,7 +347,7 @@ describe("SourceMediaPanel — MiniMax H3 FL2VA boundaries", () => {
     expect(wrapper.emitted("open-h3-last-frame-picker")).toHaveLength(1);
   });
 
-  it("keeps H3 Ref2VA references out of the primary form", () => {
+  it("exposes H3 Ref2VA ordered references in the primary form", () => {
     const ref2va = {
       name: "minimax-h3-ref2va:comfy-pruned-int8",
       family: "minimax-h3",
@@ -359,7 +359,11 @@ describe("SourceMediaPanel — MiniMax H3 FL2VA boundaries", () => {
       { models: [ref2va] },
     );
     expect(wrapper.find("[data-test='source-media-panel']").exists()).toBe(
-      false,
+      true,
+    );
+    expect(wrapper.text()).toContain("Ordered references");
+    expect(wrapper.find("[data-test='h3-reference-files']").exists()).toBe(
+      true,
     );
   });
 });

--- a/web/src/components/create/SourceMediaPanel.vue
+++ b/web/src/components/create/SourceMediaPanel.vue
@@ -5,6 +5,7 @@ import SliderRow from "@ui/components/SliderRow.vue";
 import SourceMediaWells, {
   type SourceMediaSlot,
 } from "@studio/components/SourceMediaWells.vue";
+import MinimaxH3AuthoringPanel from "@studio/components/MinimaxH3AuthoringPanel.vue";
 import { sourceMediaPlan } from "@studio/lib/sourceMediaPlan";
 import {
   generationCapabilitiesForFamily,
@@ -99,11 +100,13 @@ const sourceLimitLabel = computed(() =>
 const kicker = computed(() =>
   plan.value.kind === "h3-boundaries"
     ? "Frame endpoints"
-    : plan.value.kind === "attachments"
-      ? flux2Dev.value
-        ? "Reference images"
-        : "Edit images"
-      : "Source image",
+    : plan.value.kind === "h3-references"
+      ? "Ordered references"
+      : plan.value.kind === "attachments"
+        ? flux2Dev.value
+          ? "Reference images"
+          : "Edit images"
+        : "Source image",
 );
 
 const hasSource = computed(() => props.modelValue.imageAttachments.length > 0);
@@ -224,6 +227,9 @@ function onH3Clear(slot: SourceMediaSlot) {
     h3Authoring: { ...h3Authoring.value, [h3Endpoint(slot)]: null },
   });
 }
+function setH3Authoring(value: typeof h3Authoring.value) {
+  patch({ h3Authoring: value });
+}
 
 // ── Fit / strength / mask (single-source refinement) ──────────────────
 const fitOptions = SOURCE_FIT_OPTIONS;
@@ -276,7 +282,7 @@ function clearControl() {
 
 <template>
   <section
-    v-if="plan.kind !== 'none' && plan.kind !== 'h3-references'"
+    v-if="plan.kind !== 'none'"
     class="smp"
     data-test="source-media-panel"
   >
@@ -284,8 +290,14 @@ function clearControl() {
       <span class="smp__kicker">{{ kicker }}</span>
     </div>
 
+    <MinimaxH3AuthoringPanel
+      v-if="plan.kind === 'h3-references'"
+      :model-value="h3Authoring"
+      @update:model-value="setH3Authoring"
+    />
+
     <!-- Ordered picture strip (Qwen edit / FLUX.2 references). -->
-    <template v-if="plan.kind === 'attachments'">
+    <template v-else-if="plan.kind === 'attachments'">
       <SourceMediaWells
         v-if="plan.primary === 'target'"
         :plan="plan"


### PR DESCRIPTION
## Summary
- expose MiniMax H3 Ref2VA ordered references in the primary Create form on web, desktop, and mobile
- remove duplicated/hidden Ref2VA controls from Advanced settings
- recognize all eight registered H3 identities, including both NVFP4 acquisition-only variants

## Validation
- `nix develop -c bun run check:frontend` (1,191 studio, 1,613 web, and 4,861 desktop tests; web and desktop production builds)
- rendered QA at desktop and 390px with a Ref2VA model: primary picker visible, blocker visible beside the required input, no console errors
- Claude Sonnet peer review: no findings