### PR TITLE
fix(studio): show installed MiniMax download-only models

### DIFF
--- a/changelog.d/minimax-h3-picker-visibility.md
+++ b/changelog.d/minimax-h3-picker-visibility.md
@@ -1,0 +1,1 @@
+- **MiniMax H3 model selection is explicit and consistent.** Create now keeps installed Official BF16 and NVFP4 acquisition-only variants visible as disabled rows with the reporting machine's runtime reason instead of silently dropping them, and every registered H3 manifest uses the same human-readable model and family labels across Studio surfaces.

--- a/desktop/src/components/create/InspectorPanel.test.ts
+++ b/desktop/src/components/create/InspectorPanel.test.ts
@@ -3,6 +3,7 @@ import { flushPromises, mount } from "@vue/test-utils";
 import { createPinia, setActivePinia } from "pinia";
 import { reactive } from "vue";
 import InspectorPanel from "./InspectorPanel.vue";
+import ModelPicker from "./ModelPicker.vue";
 import ShapePicker from "@ui/components/ShapePicker.vue";
 import ResolutionSelector from "@ui/components/ResolutionSelector.vue";
 import SliderRow from "@ui/components/SliderRow.vue";
@@ -22,6 +23,7 @@ import { useAppPrefsStore } from "../../stores/appPrefs";
 import { useLibraryPrefsStore } from "../../stores/libraryPrefs";
 import { useSequenceDraftStore } from "@studio/stores/sequenceDraft";
 import type { ModelEntry } from "../../lib/api/types";
+import { apiJsonTo } from "../../lib/api/client";
 
 vi.mock("vue-router", () => ({ useRouter: () => ({ push: vi.fn() }) }));
 vi.mock("../../lib/api/client", () => ({
@@ -826,6 +828,87 @@ describe("InspectorPanel — model picker", () => {
     expect(option.text()).toBe("RealVisXL V5.0 by SG161222");
     await option.trigger("click");
     expect(form.model).toBe("cv:23423432");
+  });
+
+  it("shows a remote H3 download-only install with readable labels and its refusal", async () => {
+    const h3 = {
+      ...model,
+      name: "minimax-h3-fl2va:comfy-pruned-nvfp4",
+      family: "minimax-h3",
+      runtime_available: false,
+      runtime_unavailable_reason: "This H3 weight layout has no executable loader.",
+    } as ModelEntry;
+    useHostsStore().extras.push({
+      id: "hal9000-7680",
+      label: "HAL 9000",
+      url: "http://hal9000:7680",
+      apiKey: null,
+      status: "ready",
+      error: null,
+      instanceId: null,
+    });
+    useHostModelsStore().byHost["hal9000-7680"] = {
+      entries: [h3],
+      fetchedAt: Date.now(),
+      error: null,
+    };
+    vi.mocked(apiJsonTo).mockResolvedValueOnce([h3]);
+    const form = useGenerateFormStore().form;
+    const wrapper = mount(InspectorPanel, { props: { form }, attachTo: document.body });
+
+    await wrapper.get('[data-test="selected-model-name"]').trigger("click");
+
+    expect(wrapper.get(".ms-model__group").text()).toBe("MiniMax H3");
+    expect(wrapper.get('[data-test="model-option-name"]').text()).toBe("MiniMax H3 FL2VA · NVFP4");
+    expect(wrapper.get('[data-test="model-disabled-reason"]').text()).toBe(
+      "Download only — This H3 weight layout has no executable loader.",
+    );
+    expect(wrapper.get(".ms-model__option").attributes("disabled")).toBeDefined();
+  });
+
+  it("keeps an unavailable model disabled on the pinned host when another host can run it", () => {
+    const name = "shared-runtime-model";
+    const runnable = {
+      ...model,
+      name,
+      runtime_available: true,
+    } as ModelEntry;
+    const unavailable = {
+      ...runnable,
+      runtime_available: false,
+      runtime_unavailable_reason: "HAL cannot execute this H3 weight layout.",
+    } as ModelEntry;
+    const connection = useConnectionStore();
+    connection.info = { mode: "local", baseUrl: "http://127.0.0.1:7680", apiKey: "k" };
+    connection.status = "ready";
+    useHostsStore().extras.push({
+      id: "hal9000-7680",
+      label: "HAL 9000",
+      url: "http://hal9000:7680",
+      apiKey: null,
+      status: "ready",
+      error: null,
+      instanceId: null,
+    });
+    const hostModels = useHostModelsStore();
+    hostModels.byHost.local = { entries: [runnable], fetchedAt: Date.now(), error: null };
+    hostModels.byHost["hal9000-7680"] = {
+      entries: [unavailable],
+      fetchedAt: Date.now(),
+      error: null,
+    };
+    useModelStore().all = [runnable];
+    useAppPrefsStore().settings = { generateTargetHost: "hal9000-7680" } as never;
+    const form = useGenerateFormStore().form;
+    form.model = name;
+    const wrapper = mount(InspectorPanel, { props: { form }, attachTo: document.body });
+
+    const disabledReason = wrapper.getComponent(ModelPicker).props("disabledReason");
+    expect(disabledReason).toBeTypeOf("function");
+    if (!disabledReason) throw new Error("ModelPicker disabledReason prop is required");
+    expect(disabledReason(unavailable)).toBe(
+      "Download only — HAL cannot execute this H3 weight layout.",
+    );
   });
 });
 

--- a/desktop/src/components/create/InspectorPanel.vue
+++ b/desktop/src/components/create/InspectorPanel.vue
@@ -13,6 +13,11 @@ import { useSequenceDraftStore } from "@studio/stores/sequenceDraft";
 import { isMinimaxH3Identity } from "@studio/lib/minimaxH3Authoring";
 import { defaultClipFrames, modelsForOutput, sequenceMotionTailFrames } from "@studio/lib/sequence";
 import { filterRestrictedModels } from "@studio/lib/modelAccess";
+import {
+  isModelRuntimeUnavailable,
+  modelRuntimeNotice,
+  RUNTIME_UNAVAILABLE_BADGE,
+} from "@studio/lib/modelRuntimeAvailability";
 import type { ChainLimits } from "@studio/lib/api/chainTypes";
 import type { GenerateForm } from "../../lib/generateForm";
 import { buildRequest, resetFormToModelDefaults, seedMode } from "../../lib/generateForm";
@@ -27,11 +32,7 @@ import {
   syncCameraMotionLora,
 } from "@studio/lib/cameraMotion";
 import { apiJsonTo } from "../../lib/api/client";
-import {
-  filterModelsForTarget,
-  findInstalledModel,
-  mergeInstalledModels,
-} from "../../lib/generateModels";
+import { findInstalledModel, mergeInstalledModels } from "../../lib/generateModels";
 import { normalizeTargetHost } from "../../lib/hosts";
 import { modelDisplayName } from "../../lib/models";
 import { generationCapabilitiesForFamily } from "../../lib/capabilities";
@@ -269,12 +270,36 @@ const installedModels = computed(() =>
     hostModels.unionInstalled,
   ),
 );
+/** Keep downloaded-but-unrunnable rows visible in Create. They remain outside
+ * `installedModels`, so routing and submission cannot select them; the picker
+ * only discloses what is already on disk and why generation is unavailable. */
+const downloadOnlyModels = computed(() =>
+  mergeInstalledModels(
+    models.installed.filter(isModelRuntimeUnavailable),
+    hostModels.unionDownloaded.filter(isModelRuntimeUnavailable),
+  ),
+);
 const stickyTarget = computed<string | null>(() =>
   normalizeTargetHost(appPrefs.settings?.generateTargetHost ?? null, hosts.all),
 );
 
 const selectedModel = computed<ModelEntry | null>(() =>
   hostModels.installedEntryForTarget(props.form.model, stickyTarget.value),
+);
+
+const pickerCandidates = computed<ModelEntry[]>(() => {
+  const byName = new Map(installedModels.value.map((model) => [model.name, model]));
+  for (const model of downloadOnlyModels.value) {
+    if (!byName.has(model.name)) byName.set(model.name, model);
+  }
+  return [...byName.values()];
+});
+
+const selectedPickerModel = computed<ModelEntry | null>(
+  () =>
+    selectedModel.value ??
+    pickerCandidates.value.find((model) => model.name === props.form.model) ??
+    null,
 );
 
 /**
@@ -284,20 +309,33 @@ const selectedModel = computed<ModelEntry | null>(() =>
  * request either way.
  */
 const missingModelId = computed<string | null>(() =>
-  props.form.model && !selectedModel.value ? props.form.model : null,
+  props.form.model && !selectedPickerModel.value ? props.form.model : null,
 );
 
 const pickerModels = computed<ModelEntry[]>(() => {
   const target = stickyTarget.value;
   const fetched = target && target !== "capable" && (hostModels.byHost[target]?.fetchedAt ?? 0) > 0;
-  const forTarget = filterModelsForTarget(
-    installedModels.value,
-    target,
-    fetched ? new Set(hostModels.installedOn(target).map((m) => m.name)) : null,
-  );
+  const forTarget = fetched
+    ? hostModels.downloadedOn(target).filter((model) => {
+        const runnable = hostModels
+          .installedOn(target)
+          .some((candidate) => candidate.name === model.name);
+        return runnable || isModelRuntimeUnavailable(model);
+      })
+    : pickerCandidates.value;
   // Sequence output narrows the picker to chain-capable video models.
   return modelsForOutput(forTarget, draft.output);
 });
+
+function pickerDisabledReason(model: ModelEntry): string | null {
+  if (isModelRuntimeUnavailable(model)) {
+    const reason = modelRuntimeNotice(model)?.message ?? "No selected machine can run this model.";
+    return `${RUNTIME_UNAVAILABLE_BADGE} — ${reason}`;
+  }
+  if (installedModels.value.some((candidate) => candidate.name === model.name)) return null;
+  const reason = modelRuntimeNotice(model)?.message ?? "No selected machine can run this model.";
+  return `${RUNTIME_UNAVAILABLE_BADGE} — ${reason}`;
+}
 
 // ── Output (One shot | Sequence) — a setting, not a place ────────────────────
 const draft = useSequenceDraftStore();
@@ -610,8 +648,9 @@ function resetSettings() {
         <div class="ms-field__label">Model</div>
         <ModelPicker
           :models="pickerModels"
-          :selected="selectedModel"
+          :selected="selectedPickerModel"
           :missing-model="missingModelId"
+          :disabled-reason="pickerDisabledReason"
           :show-availability="!stickyTarget || stickyTarget === 'capable'"
           :browse-target="caps.supportsVideo ? '/models?type=video' : '/models'"
           @pick="pickModel"

--- a/desktop/src/components/create/ModelPicker.vue
+++ b/desktop/src/components/create/ModelPicker.vue
@@ -4,6 +4,7 @@ import { useRouter } from "vue-router";
 import type { ModelEntry } from "../../lib/api/types";
 import { modelAvailabilityTag } from "../../lib/hosts";
 import { modelDisplayName, modelDisplayNameForId } from "../../lib/models";
+import { familyLabel } from "@studio/lib/modelFamily";
 import { modelSource } from "../../lib/modelSource";
 import { formatGB } from "../../lib/format";
 import { useHostModelsStore } from "../../stores/hostModels";
@@ -149,7 +150,7 @@ onBeforeUnmount(() => {
         </span>
       </button>
       <template v-for="[family, list] in families" :key="family">
-        <div class="ms-model__group">{{ family.toUpperCase() }}</div>
+        <div class="ms-model__group">{{ familyLabel(family) }}</div>
         <button
           v-for="m in list"
           :key="m.name"
@@ -227,10 +228,15 @@ onBeforeUnmount(() => {
   width: 100%;
   min-width: 16rem;
   overflow-y: auto;
+  overflow-x: hidden;
   border: 1px solid var(--edge);
   border-radius: 12px;
   background: var(--bench);
   box-shadow: 0 18px 50px rgba(0, 0, 0, 0.4);
+}
+.ms-model__option .edge-code {
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 .ms-model__group {
   font-family: var(--f-mono);

--- a/desktop/src/mobile/MobileCatalogView.test.ts
+++ b/desktop/src/mobile/MobileCatalogView.test.ts
@@ -480,7 +480,7 @@ describe("MobileCatalogView", () => {
 
     const card = wrapper
       .findAll("[data-test='mobile-catalog-card']")
-      .find((candidate) => candidate.text().includes(installed.name))!;
+      .find((candidate) => candidate.text().includes("MiniMax H3 Ref2VA"))!;
     expect(card.text()).toContain("Installed");
     await card.get(".mobile-catalog-card-open").trigger("click");
     await flushPromises();
@@ -561,7 +561,7 @@ describe("MobileCatalogView", () => {
     await flushPromises();
     const card = wrapper
       .findAll("[data-test='mobile-catalog-card']")
-      .find((candidate) => candidate.text().includes("minimax-h3-fl2va"))!;
+      .find((candidate) => candidate.text().includes("MiniMax H3 FL2VA"))!;
     await card.get(".mobile-catalog-card-open").trigger("click");
     await flushPromises();
     let detail = document.querySelector<HTMLElement>("[data-test='mobile-catalog-detail']")!;

--- a/desktop/src/views/HostDetailView.test.ts
+++ b/desktop/src/views/HostDetailView.test.ts
@@ -781,7 +781,7 @@ describe("HostDetailView models", () => {
     const wrapper = await mountView(`/hosts/${REMOTE_ID}`, [h3Nvfp4]);
     const rows = wrapper.findAll("[data-test='model-row']");
     expect(rows).toHaveLength(1);
-    expect(rows[0]!.text()).toContain("minimax-h3-fl2va:comfy-pruned-nvfp4");
+    expect(rows[0]!.text()).toContain("MiniMax H3 FL2VA · NVFP4");
   });
 
   it("repeats model kind and mature-content classification in the host inventory", async () => {

--- a/studio/lib/modelDisplay.test.ts
+++ b/studio/lib/modelDisplay.test.ts
@@ -48,6 +48,26 @@ describe("modelDisplayName", () => {
     );
   });
 
+  it("names every registered MiniMax H3 manifest consistently", () => {
+    expect(
+      modelDisplayName({ name: "minimax-h3-fl2va:comfy-pruned-int8" }),
+    ).toBe("MiniMax H3 FL2VA");
+    expect(
+      modelDisplayName({ name: "minimax-h3-ref2va:comfy-pruned-int8" }),
+    ).toBe("MiniMax H3 Ref2VA");
+    expect(modelDisplayName({ name: "minimax-h3-fl2va:official-bf16" })).toBe(
+      "MiniMax H3 FL2VA · Official BF16",
+    );
+    expect(
+      modelDisplayName({ name: "minimax-h3-ref2va:comfy-pruned-nvfp4" }),
+    ).toBe("MiniMax H3 Ref2VA · NVFP4");
+    expect(
+      modelDisplayName({
+        name: "minimax-h3-fl2va:comfy-pruned-int8-turbo-4step-768p",
+      }),
+    ).toBe("MiniMax H3 FL2VA Turbo 4-step 768p");
+  });
+
   it("resolves a wire model id through the model inventory", () => {
     expect(
       modelDisplayNameForId("cv:23423432", [

--- a/studio/lib/modelDisplay.ts
+++ b/studio/lib/modelDisplay.ts
@@ -9,6 +9,22 @@ export function isCatalogModelId(name: string): boolean {
   return name.startsWith("cv:") || name.startsWith("hf:");
 }
 
+/** Built-in H3 manifests predate the additive `display_name` wire field.
+ * Keep their stable request ids while giving every Studio surface the same
+ * task/layout label, including acquisition-only rows. */
+const MINIMAX_H3_DISPLAY_NAMES: Readonly<Record<string, string>> = {
+  "minimax-h3-fl2va:official-bf16": "MiniMax H3 FL2VA · Official BF16",
+  "minimax-h3-ref2va:official-bf16": "MiniMax H3 Ref2VA · Official BF16",
+  "minimax-h3-fl2va:comfy-pruned-int8": "MiniMax H3 FL2VA",
+  "minimax-h3-ref2va:comfy-pruned-int8": "MiniMax H3 Ref2VA",
+  "minimax-h3-fl2va:comfy-pruned-nvfp4": "MiniMax H3 FL2VA · NVFP4",
+  "minimax-h3-ref2va:comfy-pruned-nvfp4": "MiniMax H3 Ref2VA · NVFP4",
+  "minimax-h3-fl2va:comfy-pruned-int8-turbo-8step":
+    "MiniMax H3 FL2VA Turbo 8-step",
+  "minimax-h3-fl2va:comfy-pruned-int8-turbo-4step-768p":
+    "MiniMax H3 FL2VA Turbo 4-step 768p",
+};
+
 /**
  * Catalog models use an opaque id as their runnable `name`. Keep that id in
  * form values and requests, but prefer the catalog-provided description in UI
@@ -17,6 +33,8 @@ export function isCatalogModelId(name: string): boolean {
 export function modelDisplayName(model: DisplayableModel): string {
   const displayName = model.display_name?.trim();
   if (displayName) return displayName;
+  const builtInDisplayName = MINIMAX_H3_DISPLAY_NAMES[model.name.toLowerCase()];
+  if (builtInDisplayName) return builtInDisplayName;
   if (isCatalogModelId(model.name)) {
     const description = model.description?.trim();
     if (description) return description;

--- a/web/src/components/create/CreateModelPicker.vue
+++ b/web/src/components/create/CreateModelPicker.vue
@@ -15,6 +15,7 @@ import {
   modelDisplayName,
   modelDisplayNameForId,
 } from "@studio/lib/modelDisplay";
+import { familyLabel } from "@studio/lib/modelFamily";
 
 const props = defineProps<{
   models: ModelInfoExtended[];
@@ -104,7 +105,7 @@ function onChange(event: Event) {
       <optgroup
         v-for="group in groups"
         :key="group.family"
-        :label="group.family"
+        :label="familyLabel(group.family)"
       >
         <option v-for="m in group.list" :key="m.name" :value="m.name">
           {{ modelDisplayName(m) }}


### PR DESCRIPTION
## Summary

- show installed MiniMax H3 acquisition-only models in the Create picker as disabled rows with the host-provided runtime reason
- normalize MiniMax H3 task/layout names and family headings across desktop and web model pickers
- keep runnable-only inventories authoritative for routing and submission
- wrap long availability reasons without horizontal picker overflow

## Verification

- `nix develop -c bun run check:frontend` (1192 Studio, 1613 web, and 4864 desktop tests passed on the first post-fix run; a repeat hit two unrelated router timeouts under full-suite load)
- isolated retry: 80/80 `InspectorPanel` and router tests passed
- desktop and web production builds passed
- browser QA verified friendly H3 labels, disabled download-only rows, exact runtime reasons, and no horizontal overflow
- independent agent peer review completed; its mixed-host disabled-state finding was fixed and regression-tested

## Follow-up

Follow-up: #1338 tracks Ampere/Ada W4A8 execution. Native NVFP4 remains correctly download-only on pre-Blackwell GPUs.

