### PR TITLE
fix(mobile): keep Library Select visible while scrolling

### DIFF
--- a/changelog.d/mobile-library-sticky-select.md
+++ b/changelog.d/mobile-library-sticky-select.md
@@ -1,0 +1,1 @@
+- **Reachable mobile Library selection.** The Select and Done actions now stay visible while scrolling through long Libraries on iPhone and Android.

--- a/desktop/src/mobile/mobile.css
+++ b/desktop/src/mobile/mobile.css
@@ -2594,10 +2594,19 @@ button:disabled {
 }
 
 .mobile-library-heading {
+  position: sticky;
+  top: -16px;
+  z-index: 9;
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
   gap: 12px;
+  margin: -16px -16px 0;
+  padding: 16px 16px 12px;
+  border-bottom: 1px solid var(--edge);
+  background: color-mix(in srgb, var(--bath) 94%, transparent);
+  box-shadow: 0 8px 18px color-mix(in srgb, var(--bath) 72%, transparent);
+  backdrop-filter: blur(16px);
 }
 
 .mobile-library-heading .section-note {

--- a/desktop/src/mobile/mobile.css.test.ts
+++ b/desktop/src/mobile/mobile.css.test.ts
@@ -486,6 +486,16 @@ describe("mobile gallery viewer", () => {
 });
 
 describe("mobile Library organization", () => {
+  it("keeps the Library heading and Select action reachable while the grid scrolls", () => {
+    const heading = css.match(/\.mobile-library-heading\s*\{([^}]*)\}/s);
+
+    expect(heading?.[1]).toMatch(/position:\s*sticky\s*;/);
+    expect(heading?.[1]).toMatch(/top:\s*-16px\s*;/);
+    expect(heading?.[1]).toMatch(/z-index:\s*9\s*;/);
+    expect(heading?.[1]).toMatch(/background:/);
+    expect(heading?.[1]).toMatch(/backdrop-filter:\s*blur\(/);
+  });
+
   it("keeps the scope row, chips, and tag targets at the 44pt floor", () => {
     for (const selector of [
       ".mobile-library-scope button",


### PR DESCRIPTION
## Summary
- pin the mobile Library heading so Select/Done remains reachable while browsing deep grids
- add translucent separation so scrolled prints remain visually distinct from the action row
- cover the sticky behavior with a focused CSS regression test

## Verification
- `nix develop -c bun --cwd desktop test --run src/mobile/mobile.css.test.ts` (45 passed)
- `nix develop -c bun run test --run src/mobile/MobileApp.test.ts src/mobile/mobile.css.test.ts` from `desktop/` (336 passed)
- `nix develop -c bun run build:mobile` from `desktop/`
- iPhone 17 Pro / iOS 26.5 native simulator: Select visible at prints 13–27; selection, continued scrolling, Done, and bottom actions verified
- Pixel 9 Pro / Android 17 native emulator: Select visible at prints 22–36; selection, continued scrolling, Done, and bottom actions verified
- independent agent peer review: no findings