### PR TITLE
fix(library): support trash over insecure HTTP

### DIFF
--- a/changelog.d/browser-trash-uuid.md
+++ b/changelog.d/browser-trash-uuid.md
@@ -1,0 +1,3 @@
+- **Library trash works when Mold is opened over plain LAN HTTP.** Trash all,
+  selected-print trash, desktop bulk organization, and retained offline edits
+  no longer depend on the secure-context-only `crypto.randomUUID` browser API.

--- a/desktop/src/stores/gallery.test.ts
+++ b/desktop/src/stores/gallery.test.ts
@@ -38,6 +38,7 @@ vi.mock("@studio/api/galleryOrganization", () => ({
   emptyTrash: vi.fn(),
   sweepTrash: vi.fn(),
   listTrash: vi.fn(),
+  mutateGalleryBulk: vi.fn(),
 }));
 
 vi.mock("../lib/api/client", () => ({
@@ -1479,6 +1480,36 @@ describe("organization fan-out", () => {
     expect(organization.patchGalleryImage).toHaveBeenCalledWith(LOCAL_TARGET, "shared.png", {
       title: "",
     });
+  });
+
+  it("uses bulk organization mutations when crypto.randomUUID is unavailable", async () => {
+    const gallery = seed();
+    useHostsStore().capabilities.local!.gallery!.bulk_mutations = true;
+    useHostsStore().capabilities["hal9000-7680"]!.gallery!.bulk_mutations = true;
+    vi.mocked(organization.mutateGalleryBulk).mockResolvedValue({
+      operation_id: "op",
+      changed: 1,
+      revision: 1,
+    });
+    vi.stubGlobal("crypto", {
+      getRandomValues(bytes: Uint8Array) {
+        bytes.fill(0);
+        return bytes;
+      },
+    });
+    try {
+      const result = await gallery.setTitle(gallery.merged[0]!, "Compatible title");
+      expect(result.failed).toBe(0);
+      expect(organization.mutateGalleryBulk).toHaveBeenCalledWith(
+        HAL_TARGET,
+        expect.objectContaining({
+          operation_id: "00000000-0000-4000-8000-000000000000",
+          titles: [{ filename: "shared.png", title: "Compatible title" }],
+        }),
+      );
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 
   it("setFavorite / addTags / removeTags go through /organize per host and update rows + tag counts", async () => {

--- a/desktop/src/stores/gallery.ts
+++ b/desktop/src/stores/gallery.ts
@@ -58,6 +58,7 @@ import {
   removeGalleryMutation,
   updateGalleryMutationFailure,
 } from "@studio/lib/galleryMutationOutbox";
+import { createUuid } from "@studio/lib/id";
 
 export type {
   MergedCollection,
@@ -1446,7 +1447,7 @@ export const useGalleryStore = defineStore("gallery", {
       if (!target) throw new Error("Host is not connected.");
       switch (op.kind) {
         case "setTitle": {
-          const bulk = galleryBulkRequest(crypto.randomUUID(), op);
+          const bulk = galleryBulkRequest(createUuid(), op);
           if (bulk && useHostsStore().capabilities[op.hostId]?.gallery?.bulk_mutations === true) {
             await mutateGalleryBulk(target, bulk);
             for (const filename of op.filenames) {
@@ -1549,7 +1550,7 @@ export const useGalleryStore = defineStore("gallery", {
           throw new Error(`${op.kind} is not an organize mutation; use the trash actions.`);
       }
     },
-    async retainOrganizationOp(op: OrganizationFanoutOp, operationId = crypto.randomUUID()) {
+    async retainOrganizationOp(op: OrganizationFanoutOp, operationId = createUuid()) {
       const host = this.hostFor(op.hostId);
       if (!host || host.kind !== "remote") throw new Error("Host is not connected.");
       await enqueueGalleryMutation({

--- a/studio/lib/galleryMutationOutbox.ts
+++ b/studio/lib/galleryMutationOutbox.ts
@@ -2,6 +2,7 @@
 
 import type { OrganizationFanoutOp } from "./libraryOrganization";
 import type { GalleryBulkMutationRequest } from "./api/galleryOrganization";
+import { createUuid } from "./id";
 
 const DB_NAME = "mold-gallery-mutation-outbox";
 const DB_VERSION = 1;
@@ -129,10 +130,7 @@ export function enqueueGalleryMutation(
     );
     const item: QueuedGalleryMutation = {
       ...input,
-      id:
-        input.id ??
-        globalThis.crypto?.randomUUID?.() ??
-        `${createdAt}-${Math.random().toString(16).slice(2)}`,
+      id: input.id ?? createUuid(),
       createdAt,
       sequence,
       attempts: 0,

--- a/web/src/lib/libraryOrganization.test.ts
+++ b/web/src/lib/libraryOrganization.test.ts
@@ -461,6 +461,34 @@ describe("mutations fan out to every copy's host", () => {
     expect(api.deleteGalleryImageForever).not.toHaveBeenCalled();
   });
 
+  it("moves prints to trash when crypto.randomUUID is unavailable", async () => {
+    vi.stubGlobal("crypto", {
+      getRandomValues(bytes: Uint8Array) {
+        bytes.fill(0);
+        return bytes;
+      },
+    });
+    try {
+      await applyOrganizationMutation(
+        copies,
+        { kind: "trash" },
+        {
+          hostById,
+          snapshots: [
+            snapshot("origin", { bulkMutations: true }),
+            snapshot("plato", { bulkMutations: true }),
+          ],
+        },
+      );
+      expect(api.trashMany).toHaveBeenCalledWith(platoTarget, [
+        "twin.png",
+        "other.png",
+      ]);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("creates a missing collection by name before adding, reusing an existing one by slug", async () => {
     const snapshots = [
       snapshot("origin", { collections: [collection("c-origin", "Smurfs")] }),

--- a/web/src/lib/libraryOrganization.ts
+++ b/web/src/lib/libraryOrganization.ts
@@ -44,6 +44,7 @@ import {
   type RetentionHost,
 } from "@studio/lib/libraryOrganization";
 import { galleryBulkRequest } from "@studio/lib/galleryMutationOutbox";
+import { createUuid } from "@studio/lib/id";
 import {
   hostApiTarget,
   hostCapabilities,
@@ -516,7 +517,7 @@ export async function applyOrganizationMutation(
     const bulk =
       snapshotFor(context.snapshots, op.hostId)?.bulkMutations === true;
     if (bulk) {
-      const request = galleryBulkRequest(crypto.randomUUID(), op);
+      const request = galleryBulkRequest(createUuid(), op);
       if (request) {
         await mutateGalleryBulk(target, request);
         return;


### PR DESCRIPTION
## Summary
- route web and desktop Library operation IDs through the browser-compatible shared UUID helper
- use the same helper for retained/offline gallery mutations
- add regressions for bulk trash and desktop bulk organization when `crypto.randomUUID` is unavailable

## Root cause
Mold is commonly opened from another machine over plain LAN HTTP. In that insecure context, browsers may omit `crypto.randomUUID`. The web Library generated an operation ID before determining that a trash operation did not need a bulk mutation request, so both Trash all and Select all → Trash threw before sending the server request. Desktop Library paths had the same direct API dependency.

## Verification
- `nix develop -c bun run check:frontend`
- focused web Library: 21 passed
- focused desktop gallery: 86 passed
- shared ID/outbox: 5 passed
- Browser QA at `http://192.168.1.142:4173/library` where `crypto` is unavailable: Select all → Trash and Trash all completed without the UUID error or console warnings
- independent agent peer review: no actionable findings