### PR TITLE
fix(desktop): coalesce engine restart requests

### DIFF
--- a/desktop/src/components/settings/HostsSection.vue
+++ b/desktop/src/components/settings/HostsSection.vue
@@ -32,10 +32,9 @@ async function copyLocalApiKey() {
 }
 
 async function restartEngine() {
-  await conn.stopEngine();
-  await conn.useLocal();
-  if (conn.ready) toasts.push("Engine restarted");
-  else if (conn.error) toasts.push(conn.error, "error");
+  const result = await conn.restartEngine();
+  if (result === "restarted") toasts.push("Engine restarted");
+  else if (result === "failed" && conn.error) toasts.push(conn.error, "error");
 }
 
 function hostDot(status: "ready" | "connecting" | "error"): string {

--- a/desktop/src/components/settings/PerformanceSection.vue
+++ b/desktop/src/components/settings/PerformanceSection.vue
@@ -30,12 +30,11 @@ async function setKnob(key: string, value: string) {
 }
 
 async function restartEngine() {
-  await conn.stopEngine();
-  await conn.useLocal();
-  if (conn.ready) {
+  const result = await conn.restartEngine();
+  if (result === "restarted") {
     dirty.clear();
     toasts.push("Engine restarted — knobs applied");
-  } else if (conn.error) {
+  } else if (result === "failed" && conn.error) {
     toasts.push(conn.error, "error");
   }
 }

--- a/desktop/src/components/shell/CommandPalette.vue
+++ b/desktop/src/components/shell/CommandPalette.vue
@@ -260,10 +260,10 @@ const staticCommands = computed<Command[]>(() => {
       title: "Restart engine",
       keywords: ["engine", "reload", "reboot"],
       run: () => {
-        void conn
-          .stopEngine()
-          .then(() => conn.useLocal())
-          .then(() => toasts.push("Engine restarted"));
+        void conn.restartEngine().then((result) => {
+          if (result === "restarted") toasts.push("Engine restarted");
+          else if (result === "failed" && conn.error) toasts.push(conn.error, "error");
+        });
         close();
       },
     },

--- a/desktop/src/stores/connection.test.ts
+++ b/desktop/src/stores/connection.test.ts
@@ -111,4 +111,33 @@ describe("connection store", () => {
     await store.init();
     expect(mocked.startLocalEngine).toHaveBeenCalledTimes(1);
   });
+
+  it("coalesces overlapping restart requests into one stop/start cycle", async () => {
+    let finishStop!: (value: typeof local) => void;
+    mocked.stopLocalEngine.mockImplementation(
+      () => new Promise((resolve) => (finishStop = resolve)),
+    );
+    mocked.startLocalEngine.mockResolvedValue(local);
+    mocked.appSettingsGet.mockResolvedValue(defaults);
+    mocked.appSettingsSet.mockResolvedValue(undefined);
+
+    const store = useConnectionStore();
+    store.info = local;
+    store.status = "ready";
+    store.localInfo = localServer;
+    store.localStatus = "ready";
+
+    const first = store.restartEngine();
+    const repeated = store.restartEngine();
+
+    expect(store.status).toBe("starting");
+    expect(mocked.stopLocalEngine).toHaveBeenCalledTimes(1);
+
+    finishStop(local);
+    await expect(first).resolves.toBe("restarted");
+    await expect(repeated).resolves.toBe("coalesced");
+    expect(mocked.ensureLocalServer).toHaveBeenCalledTimes(1);
+    expect(mocked.startLocalEngine).toHaveBeenCalledTimes(1);
+    expect(store.ready).toBe(true);
+  });
 });

--- a/desktop/src/stores/connection.ts
+++ b/desktop/src/stores/connection.ts
@@ -2,6 +2,12 @@ import { defineStore } from "pinia";
 import { ipc, type ConnectionInfo, type LocalServerInfo } from "../lib/ipc";
 
 export type ConnectionStatus = "idle" | "starting" | "ready" | "error";
+export type EngineRestartResult = "restarted" | "coalesced" | "failed";
+
+// Restart is a process-wide operation, not a component action. Keep its
+// promise outside Pinia state (which must stay serializable) so command-palette
+// key repeat and rapid clicks across Settings cannot overlap stop/start cycles.
+let restartInFlight: Promise<boolean> | null = null;
 
 /**
  * Which engine the app is talking to. The built-in engine is always the
@@ -78,6 +84,45 @@ export const useConnectionStore = defineStore("connection", {
       this.localStatus = "idle";
       this.localError = null;
       this.status = "idle";
+    },
+    async restartEngine(): Promise<EngineRestartResult> {
+      if (restartInFlight) {
+        await restartInFlight;
+        return "coalesced";
+      }
+
+      // Flip the visible state before the first IPC await. The Settings
+      // buttons disable immediately, closing the re-entry window that used to
+      // remain open for the full shutdown timeout.
+      this.status = "starting";
+      this.error = null;
+      this.localStatus = "starting";
+      this.localError = null;
+
+      const operation = (async () => {
+        try {
+          this.info = await ipc.stopLocalEngine();
+          this.localInfo = null;
+          // useLocal() owns the fresh ensure/start sequence. Mark the local
+          // server idle first so ensureLocal() does not mistake this restart
+          // for another already-running start request.
+          this.localStatus = "idle";
+          await this.useLocal();
+          return this.ready;
+        } catch (err) {
+          this.status = "error";
+          this.error = String(err);
+          this.localStatus = "error";
+          this.localError = String(err);
+          return false;
+        }
+      })();
+      restartInFlight = operation;
+      try {
+        return (await operation) ? "restarted" : "failed";
+      } finally {
+        if (restartInFlight === operation) restartInFlight = null;
+      }
     },
   },
 });


### PR DESCRIPTION
## Summary

- make desktop engine restarts a single-flight connection-store operation
- route Settings and command-palette restart actions through the shared operation
- suppress duplicate success notifications from coalesced restart requests

## Root cause

The three restart entry points independently composed stop + start. During the awaited shutdown, the connection still appeared ready, so rapid clicks or command-palette key repeat could launch overlapping stop/start cycles. Every overlapping caller emitted its own `Engine restarted` notification.

## Verification

- `bun --cwd desktop test src/stores/connection.test.ts src/components/shell/CommandPalette.test.ts` (26 passed)
- `bunx vue-tsc -b desktop`
- Prettier check on all changed files
- `git diff --check`