### PR TITLE
docs(changelog): note desktop restart fix

### DIFF
--- a/changelog.d/desktop-restart-notification-loop.md
+++ b/changelog.d/desktop-restart-notification-loop.md
@@ -1,0 +1,4 @@
+- **Desktop engine restarts no longer multiply notifications.** Rapid clicks or
+  command-palette key repeat now share one stop/start cycle, so Mold restarts
+  the engine once and reports one completion instead of flooding the
+  notification shelf.


### PR DESCRIPTION
## Summary

- add the required release-note fragment for the desktop restart notification-loop fix merged in #1342
- repair the changelog policy failure observed after #1342 merged

## Verification

- `git diff --check`
- fragment follows `changelog.d/README.md` policy