### PR TITLE
fix(h3): queue prints behind active host memory

### DIFF
--- a/changelog.d/minimax-h3-busy-admission.md
+++ b/changelog.d/minimax-h3-busy-admission.md
@@ -1,0 +1,6 @@
+- **Overlapping MiniMax H3 prints now wait in the queue for host memory.**
+  Placement preview reports memory held by an active GPU render as a
+  non-authoritative transient condition, allowing compatible clients to use
+  their existing direct-queue fallback. Admission remains pending while that
+  owner runs, then retries from a fresh sample after it settles. Idle cached
+  models are still reclaimed immediately before the request waits.

--- a/crates/mold-server/src/batch_runtime.rs
+++ b/crates/mold-server/src/batch_runtime.rs
@@ -2052,6 +2052,7 @@ mod tests {
                 authority_fingerprint: "prepared".to_string(),
                 by_device: BTreeMap::new(),
                 retryable_device_failures: BTreeMap::new(),
+                host_memory_retry_after_devices: Default::default(),
                 model_config_overlay: None,
                 #[cfg(any(feature = "h3", feature = "h3-private-uat"))]
                 h3_private_ingress_grant: None,

--- a/crates/mold-server/src/execution_plan.rs
+++ b/crates/mold-server/src/execution_plan.rs
@@ -1076,6 +1076,17 @@ pub struct PreparedExecutionInputs {
     /// at least one sibling succeeded. These omissions are retryable; they
     /// must not silently become the device set for the lifetime of the job.
     pub retryable_device_failures: BTreeMap<String, String>,
+    /// Active GPU owners whose transient host allocations prevented exact
+    /// dependency admission.
+    ///
+    /// Preparation leaves the generation queued while any named owner is
+    /// busy, then retries once those owners settle. Placement preview turns
+    /// this marker into a non-authoritative answer so compatible clients take
+    /// their established direct-queue fallback. This is distinct from an
+    /// ordinary retryable device failure: polling admission while a long H3
+    /// render still owns the same host bytes would repeatedly hash the full
+    /// artifact set without changing the answer.
+    pub host_memory_retry_after_devices: BTreeSet<String>,
     /// Runtime-only catalog config synthesized from an installed sidecar.
     ///
     /// The scheduler applies this overlay when the current config lacks the
@@ -6257,6 +6268,7 @@ mod tests {
                 },
             )]),
             retryable_device_failures: BTreeMap::new(),
+            host_memory_retry_after_devices: Default::default(),
             model_config_overlay: None,
             #[cfg(any(feature = "h3", feature = "h3-private-uat"))]
             h3_private_ingress_grant: None,
@@ -6346,6 +6358,7 @@ mod tests {
                 },
             )]),
             retryable_device_failures: BTreeMap::new(),
+            host_memory_retry_after_devices: Default::default(),
             model_config_overlay: Some(Arc::new(model_config)),
             #[cfg(any(feature = "h3", feature = "h3-private-uat"))]
             h3_private_ingress_grant: None,
@@ -6407,6 +6420,7 @@ mod tests {
                 },
             )]),
             retryable_device_failures: BTreeMap::new(),
+            host_memory_retry_after_devices: Default::default(),
             model_config_overlay: None,
             #[cfg(any(feature = "h3", feature = "h3-private-uat"))]
             h3_private_ingress_grant: None,
@@ -6876,6 +6890,7 @@ mod tests {
                 },
             )]),
             retryable_device_failures: BTreeMap::new(),
+            host_memory_retry_after_devices: Default::default(),
             model_config_overlay: None,
             #[cfg(any(feature = "h3", feature = "h3-private-uat"))]
             h3_private_ingress_grant: None,

--- a/crates/mold-server/src/host_reclaim.rs
+++ b/crates/mold-server/src/host_reclaim.rs
@@ -45,6 +45,7 @@ use std::time::Instant;
 
 use crate::model_cache::ReclaimableEntry;
 use crate::state::AppState;
+use std::collections::BTreeSet;
 
 /// One cached engine this reclaim may release.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -210,6 +211,24 @@ fn worker_release_state(worker: &crate::gpu_pool::GpuWorker) -> WorkerReleaseSta
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
                 .is_some(),
     }
+}
+
+/// Stable IDs of owners whose current work can return host memory when it
+/// settles.
+///
+/// These workers are deliberately not reclaim targets: an Admin unload would
+/// only wait behind the render that already owns the bytes. H3 preparation
+/// uses this snapshot to keep a short request queued until that transient
+/// pressure is gone.
+pub(crate) fn busy_worker_device_ids(state: &AppState) -> BTreeSet<String> {
+    state
+        .gpu_pool
+        .workers
+        .snapshot()
+        .into_iter()
+        .filter(|worker| worker_release_state(worker).busy)
+        .map(|worker| crate::scheduler::worker_device_id(&worker))
+        .collect()
 }
 
 /// Collect every engine this server could release right now.

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -4130,6 +4130,13 @@ async fn placement_preview_for_request_authenticated(
             return Ok(response);
         }
     };
+    if !prepared.host_memory_retry_after_devices.is_empty() {
+        return Ok(unavailable(
+            "unsupported",
+            "MiniMax H3 placement is waiting for active GPU work to release host memory; the request may be queued through the compatible fallback"
+                .to_string(),
+        ));
+    }
     match state
         .scheduled_work
         .preview_placement(request, copies, prepared)

--- a/crates/mold-server/src/scheduler/mod.rs
+++ b/crates/mold-server/src/scheduler/mod.rs
@@ -2812,6 +2812,15 @@ impl Coordinator {
         pending: &PendingGeneration,
         device_facts: &[crate::execution_plan::DeviceFact],
     ) -> Result<Vec<crate::execution_plan::ResolvedExecutionPlan>, GenerationPlanFailure> {
+        if pending
+            .prepared_inputs
+            .as_ref()
+            .is_some_and(|prepared| !prepared.host_memory_retry_after_devices.is_empty())
+        {
+            return Err(GenerationPlanFailure::Transient(
+                "waiting for active GPU work to release host memory".to_string(),
+            ));
+        }
         let config = self.state.config.try_read().map_err(|_| {
             GenerationPlanFailure::Transient(
                 "configuration changed while resolving execution plan".to_string(),
@@ -3022,6 +3031,7 @@ impl Coordinator {
             .collect::<BTreeSet<_>>();
         let device_facts = self.device_facts_from_snapshots(&self.device_snapshots());
         let now_ms = monotonic_ms();
+        let busy_worker_devices = crate::host_reclaim::busy_worker_device_ids(&self.state);
         let mut refresh = BTreeSet::new();
         for (id, pending) in &mut self.pending {
             if stale.contains(id) || pending.preparation != PreparationState::Ready {
@@ -3031,6 +3041,16 @@ impl Coordinator {
                 pending.preparation_refresh_observation = None;
                 continue;
             };
+            if !prepared.host_memory_retry_after_devices.is_empty() {
+                pending.preparation_refresh_observation = None;
+                if prepared
+                    .host_memory_retry_after_devices
+                    .is_disjoint(&busy_worker_devices)
+                {
+                    refresh.insert(id.clone());
+                }
+                continue;
+            }
             let signature = Self::preparation_refresh_signature(prepared, &device_facts);
             if signature.is_empty() {
                 pending.preparation_refresh_observation = None;
@@ -12842,6 +12862,83 @@ mod tests {
 
     struct SelectiveBlockingPreparer {
         release_blocked: Arc<tokio::sync::Notify>,
+    }
+
+    /// An H3 sibling submitted while another render owns transient host RAM
+    /// must stay in the scheduler queue. Retrying only after the owner settles
+    /// avoids both the old terminal refusal and repeated full artifact hashes
+    /// while the capacity fact cannot change.
+    #[tokio::test]
+    async fn h3_host_shortfall_waits_in_queue_until_the_busy_owner_settles() {
+        let (worker, _worker_rx) = test_worker(0);
+        let device_id = worker_device_id(&worker);
+        let pool = Arc::new(GpuPool {
+            workers: vec![worker.clone()].into(),
+        });
+        let (ingress_tx, mut ingress_rx) = tokio::sync::mpsc::channel(2);
+        let queue = QueueHandle::new(ingress_tx);
+        let state = AppState::empty(mold_core::Config::default(), queue.clone(), pool, 2);
+        state
+            .job_registry
+            .register("waiting-h3", "minimax-h3-fl2va");
+        let (job, _result) = fake_generation("waiting-h3");
+        queue.submit(job, 2).await.unwrap();
+
+        let mut coordinator = Coordinator::with_preparer_and_memory(
+            state,
+            Arc::new(ImmediatePreparer),
+            ample_memory(),
+        );
+        let mut immediate = false;
+        coordinator.enqueue(ingress_rx.recv().await.unwrap(), &mut immediate);
+        coordinator
+            .pending
+            .get_mut("waiting-h3")
+            .unwrap()
+            .preparation = PreparationState::Preparing;
+        worker.in_flight.store(1, Ordering::SeqCst);
+        let mut deferred = crate::execution_plan::PreparedExecutionInputs::default();
+        deferred
+            .host_memory_retry_after_devices
+            .insert(device_id.clone());
+        coordinator.handle_preparation_event(
+            PreparationEvent::Ready {
+                work_id: "waiting-h3".to_string(),
+                prepared: Box::new(PreparedGeneration {
+                    execution_inputs: Some(deferred),
+                    ..Default::default()
+                }),
+            },
+            &mut immediate,
+        );
+
+        assert!(!coordinator.reset_stale_preparations());
+        assert_eq!(
+            coordinator.pending["waiting-h3"].preparation,
+            PreparationState::Ready
+        );
+        assert!(matches!(
+            coordinator.generation_plans(&coordinator.pending["waiting-h3"]),
+            Err(GenerationPlanFailure::Transient(_))
+        ));
+
+        worker.in_flight.store(0, Ordering::SeqCst);
+        assert!(coordinator.reset_stale_preparations());
+        assert_eq!(
+            coordinator.pending["waiting-h3"].preparation,
+            PreparationState::Preparing
+        );
+        let event = tokio::time::timeout(Duration::from_secs(1), coordinator.preparation_rx.recv())
+            .await
+            .expect("settled owner must trigger preparation")
+            .expect("preparation event");
+        coordinator.handle_preparation_event(event, &mut immediate);
+        assert!(coordinator.pending.contains_key("waiting-h3"));
+        assert_eq!(
+            coordinator.pending["waiting-h3"].preparation,
+            PreparationState::Ready
+        );
+        coordinator.stop_preparations().await;
     }
 
     impl DependencyPreparer for SelectiveBlockingPreparer {

--- a/crates/mold-server/src/variant_dependencies.rs
+++ b/crates/mold-server/src/variant_dependencies.rs
@@ -1652,6 +1652,7 @@ pub(crate) async fn prepare_inputs_for_devices(
         authority_fingerprint,
         by_device,
         retryable_device_failures: failures,
+        host_memory_retry_after_devices: Default::default(),
         model_config_overlay,
         identity_embedding,
         identity_warning,
@@ -1814,6 +1815,22 @@ fn h3_reclaim_requirement(
     Some(shortfall?.required_host_bytes)
 }
 
+/// Admit one bounded retry only when a newer host sample changes the answer.
+/// Attempt indexes 0 and 1 may advance to the second and third pass; attempt 2
+/// is terminal even if memory keeps moving.
+#[cfg(any(feature = "h3", feature = "h3-private-uat"))]
+fn h3_fresh_retry_headroom(
+    attempt: usize,
+    admitted_headroom: u64,
+    shortfall: Option<HostShortfall>,
+    fresh_headroom: u64,
+) -> Option<u64> {
+    (attempt < 2
+        && fresh_headroom > admitted_headroom
+        && shortfall.is_some_and(|shortfall| shortfall.required_host_bytes <= fresh_headroom))
+    .then_some(fresh_headroom)
+}
+
 /// Why one device's H3 admission attempt did not produce evidence.
 ///
 /// The two arms fail for unrelated reasons — a staged reference could not be
@@ -1883,12 +1900,14 @@ async fn prepare_h3_private_inputs_for_devices(
     // A host-headroom refusal is asked one more question before it becomes an
     // answer: is mold's own model cache holding the memory? If it is, the cache
     // is released least-recently-used first and admission is retried exactly
-    // once against a fresh sample (#1289). Two attempts, never more — the first
-    // reclaim already released everything it could, so a third pass would only
-    // re-ask a question whose answer cannot have changed.
+    // against a fresh sample (#1289). A third and final attempt is allowed only
+    // when a later exact-target failure discovers a larger requirement and a
+    // new sample proves that requirement now fits (for example, because the
+    // active render finished during the artifact hash). Reclaim itself still
+    // runs at most once.
     let mut host_shortfall: Option<mold_inference::H3PrivateHostHeadroomShortfall> = None;
     let mut reclaim = crate::host_reclaim::HostReclaimOutcome::default();
-    for attempt in 0..2 {
+    for attempt in 0..3 {
         evidence_by_device.clear();
         failures.clear();
         host_shortfall = None;
@@ -2028,6 +2047,16 @@ async fn prepare_h3_private_inputs_for_devices(
         if !evidence_by_device.is_empty() {
             break;
         }
+        let fresh_headroom = crate::h3_admission::current_h3_host_memory().headroom_bytes();
+        if let Some(retry_headroom) = h3_fresh_retry_headroom(
+            attempt,
+            available_host_headroom_bytes,
+            host_shortfall,
+            fresh_headroom,
+        ) {
+            available_host_headroom_bytes = retry_headroom;
+            continue;
+        }
         let (Some(required_host_bytes), Some(state)) = (
             h3_reclaim_requirement(policy, attempt, host_shortfall),
             state,
@@ -2044,13 +2073,35 @@ async fn prepare_h3_private_inputs_for_devices(
             &|| crate::h3_admission::current_h3_host_memory().headroom_bytes(),
         )
         .await;
-        if !reclaim.released_anything() {
-            break;
-        }
         available_host_headroom_bytes =
             crate::h3_admission::current_h3_host_memory().headroom_bytes();
+        if available_host_headroom_bytes < required_host_bytes {
+            break;
+        }
     }
     if evidence_by_device.is_empty() {
+        let busy_devices = state
+            .filter(|_| host_shortfall.is_some())
+            .map(crate::host_reclaim::busy_worker_device_ids)
+            .unwrap_or_default();
+        if !busy_devices.is_empty() {
+            let reason = host_shortfall
+                .map(|shortfall| shortfall.to_string())
+                .unwrap_or_else(|| "MiniMax H3 is waiting for host memory".to_string());
+            send_dependency_wait(progress, "MiniMax H3 host memory", reason);
+            return Ok(PreparedExecutionInputs {
+                authority_fingerprint: ingress_grant.authority_identity_sha256().to_string(),
+                by_device: BTreeMap::new(),
+                retryable_device_failures: failures,
+                host_memory_retry_after_devices: busy_devices,
+                model_config_overlay: None,
+                identity_embedding: None,
+                identity_warning: None,
+                identity_pin: crate::execution_plan::IdentityPin::default(),
+                h3_private_ingress_grant: Some(ingress_grant),
+                h3_private_admission_by_device: BTreeMap::new(),
+            });
+        }
         let mut message = format!(
             "no request-eligible device passed MiniMax H3 private admission: {}",
             failures
@@ -2136,6 +2187,7 @@ async fn prepare_h3_private_inputs_for_devices(
         authority_fingerprint: format!("{:x}", authority.finalize()),
         by_device,
         retryable_device_failures: failures,
+        host_memory_retry_after_devices: Default::default(),
         model_config_overlay: None,
         // The private H3 ingress has no face-identity path; FLUX is the only
         // family qualified for it. The pin is minted empty rather than omitted
@@ -2331,6 +2383,31 @@ mod tests {
             ),
             None,
             "a read-only placement preview must never evict a model cache"
+        );
+    }
+
+    #[cfg(any(feature = "h3", feature = "h3-private-uat"))]
+    #[test]
+    fn a_fresh_exact_target_sample_can_start_one_bounded_third_attempt() {
+        let exact = HostShortfall {
+            context: "private H3 canonical target",
+            required_host_bytes: 22_893_717_751,
+            available_host_headroom_bytes: 19_948_656_026,
+        };
+        assert_eq!(
+            h3_fresh_retry_headroom(1, 19_948_656_026, Some(exact), 22_893_717_751),
+            Some(22_893_717_751),
+            "an owner finishing during attempt two must permit the final pass"
+        );
+        assert_eq!(
+            h3_fresh_retry_headroom(2, 19_948_656_026, Some(exact), 22_893_717_751),
+            None,
+            "the third pass is the hard retry bound"
+        );
+        assert_eq!(
+            h3_fresh_retry_headroom(1, 19_948_656_026, Some(exact), 22_893_717_750),
+            None,
+            "a fresh sample must cover the exact target"
         );
     }
 


### PR DESCRIPTION
## Root cause

A second MiniMax H3 print sampled host headroom while another H3 worker still owned transient host memory. Placement preview treated that temporary shortfall as authoritative infeasibility, so clients refused to submit and reported that nothing was queued. The scheduler also treated the same admission result as terminal.

## Fix

- Detect busy worker device ownership when private H3 host admission is temporarily short.
- Return a non-authoritative placement preview result so existing direct-submit fallback can queue the print.
- Hold the queued print pending while the captured worker owner remains busy, then re-run full preparation once it settles.
- Bound fresh headroom resampling to three attempts and reclaim to the first attempt only; admission remains fail-closed without evidence.
- Cover the reported 22,893,717,751 required / 19,948,656,026 offered byte case.

## Validation

- `nix develop -c cargo check -p mold-ai-server --features preview,discord,expand,tui,webp,mp4`
- `nix develop -c cargo clippy -p mold-ai-server --all-targets --features metal,h3 -- -D warnings`
- `cargo fmt --all -- --check`
- H3 feature regression for bounded fresh resampling
- Scheduler regression proving the print waits and resumes after the busy owner settles
- Full server suite: 1,690 passed; five environment/load-sensitive failures all passed in isolated reruns (including clean `MOLD_MODELS_DIR` for installed-model isolation)

Agent peer review completed with no blocking findings after the bounded retry and stale-sample race fixes.