### PR TITLE
docs(changelog): note Safelight Dark defaults

### DIFF
--- a/changelog.d/safelight-dark-defaults.md
+++ b/changelog.d/safelight-dark-defaults.md
@@ -1,0 +1,3 @@
+- **Safelight Dark defaults across Mold Studio.** Fresh desktop, web, iPhone,
+  and Android installs now open in Safelight Dark while preserving every valid
+  theme choice a user has already saved.


### PR DESCRIPTION
## Summary
- add the release-note fragment required for the Safelight Dark cross-surface fix merged in #1346

## Validation
- `bash scripts/release/check-changelog-fragments.sh origin/main HEAD`