### PR TITLE
fix(library): repair thumbnails and restore scroll

### DIFF
--- a/changelog.d/library-thumbnails-scroll.md
+++ b/changelog.d/library-thumbnails-scroll.md
@@ -1,0 +1,4 @@
+- **Reliable Library thumbnails and navigation.** Collection covers no longer
+  break when the print grid refreshes, loading and failed previews use a clean
+  recoverable placeholder, and Library views return to the previous scroll
+  position during the current session on web, desktop, iPhone, and Android.

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -13,6 +13,7 @@ import {
   storeCachedGalleryMedia,
   storeCachedHostPresentation,
 } from "./galleryCache";
+import { clearSessionScrollForTests, sessionScrollPosition } from "@studio/lib/libraryOrganization";
 
 const {
   invoke,
@@ -279,6 +280,7 @@ function deferred<T>() {
 }
 
 beforeEach(() => {
+  clearSessionScrollForTests();
   FakeIntersectionObserver.instances = [];
   (globalThis as { IntersectionObserver?: unknown }).IntersectionObserver =
     FakeIntersectionObserver;
@@ -6268,6 +6270,73 @@ describe("MobileApp primary navigation", () => {
 
     expect(content.scrollTop).toBe(0);
   });
+
+  it("restores the Library scroll position when returning during the session", async () => {
+    wrapper = mountMobileApp();
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-tab-gallery']").trigger("click");
+    await flushPromises();
+
+    const content = wrapper.get(".mobile-content").element as HTMLElement;
+    content.scrollTop = 420;
+    await wrapper.get("[data-test='mobile-tab-catalog']").trigger("click");
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-tab-gallery']").trigger("click");
+
+    await vi.waitFor(() => expect(content.scrollTop).toBe(420));
+  });
+
+  it("restores a deep Library position against the virtual grid extent", async () => {
+    const manyPrints = Array.from({ length: 81 }, (_, index) => ({
+      ...print,
+      filename: `deep-scroll-${index}.png`,
+      timestamp: print.timestamp - index,
+    }));
+    apiJsonTo.mockImplementation((_target: unknown, path: string) => {
+      if (path === "/api/status") return Promise.resolve(status);
+      if (path === "/api/models") return Promise.resolve([model]);
+      if (path === "/api/gallery") return Promise.resolve(manyPrints);
+      if (path === "/api/activity") {
+        return Promise.resolve({
+          instance_id: "mobile-host",
+          observed_at_unix_ms: 1,
+          items: [],
+        });
+      }
+      return Promise.reject(new Error(`Unexpected API path: ${path}`));
+    });
+    wrapper = mountMobileApp();
+    await flushPromises();
+    const content = wrapper.get(".mobile-content").element as HTMLElement;
+    let scrollTop = 0;
+    Object.defineProperty(content, "scrollTop", {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => {
+        const grid = wrapper!.find("[data-test='mobile-gallery-grid']");
+        const logicalExtent = grid.exists()
+          ? Number(grid.attributes("data-gallery-total")) * 10
+          : 0;
+        scrollTop = Math.min(value, logicalExtent);
+      },
+    });
+
+    await wrapper.get("[data-test='mobile-tab-gallery']").trigger("click");
+
+    await vi.waitFor(() =>
+      expect(
+        wrapper!.get("[data-test='mobile-gallery-grid']").attributes("data-gallery-total"),
+      ).toBe("81"),
+    );
+    await flushPromises();
+    content.scrollTop = 700;
+    await wrapper.get("[data-test='mobile-tab-catalog']").trigger("click");
+    await flushPromises();
+    expect(scrollTop).toBe(0);
+    expect(sessionScrollPosition("mobile:library").top).toBe(700);
+    await wrapper.get("[data-test='mobile-tab-gallery']").trigger("click");
+    await vi.waitFor(() => expect(scrollTop).toBe(700));
+  });
 });
 
 describe("MobileApp gallery", () => {
@@ -9299,7 +9368,7 @@ describe("MobileApp Library organization", () => {
             name: "Portraits",
             slug: "portraits",
             description: null,
-            cover_filename: "fav.png",
+            cover_filename: "cover.png",
             count: 1,
             created_at: 1,
             updated_at: 1,
@@ -9409,12 +9478,36 @@ describe("MobileApp Library organization", () => {
     installLibraryApi();
     await openLibrary();
 
+    const gridThumbnail = wrapper!.get("[data-test='gallery-item'] img").attributes("src");
+
     await wrapper?.get("[data-test='mobile-library-scope-collections']").trigger("click");
     await flushPromises();
 
     const card = wrapper!.get("[data-test='mobile-collection-portraits']");
     expect(card.text()).toContain("Portraits");
     expect(card.text()).toContain("1");
+    await vi.waitFor(() => expect(card.find(".mobile-collection-cover img").exists()).toBe(true));
+    expect(card.get(".mobile-collection-cover img").attributes("src")).not.toBe(gridThumbnail);
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith(gridThumbnail);
+
+    vi.useFakeTimers();
+    await card.get(".mobile-collection-cover img").trigger("error");
+    expect(card.find(".mobile-collection-cover img").exists()).toBe(false);
+    expect(card.findComponent({ name: "MobileMediaPlaceholder" }).exists()).toBe(true);
+    const coverFetchCount = () =>
+      apiFetchTo.mock.calls.filter(([, path]) => String(path).includes("cover.png")).length;
+    const callsBeforeHidingShelf = coverFetchCount();
+    await wrapper?.get("[data-test='mobile-tab-catalog']").trigger("click");
+    await vi.advanceTimersByTimeAsync(5_000);
+    await flushPromises();
+    expect(coverFetchCount()).toBe(callsBeforeHidingShelf);
+    await wrapper?.get("[data-test='mobile-tab-gallery']").trigger("click");
+    await flushPromises();
+    const restoredCard = wrapper!.get("[data-test='mobile-collection-portraits']");
+    await vi.waitFor(() =>
+      expect(restoredCard.find(".mobile-collection-cover img").exists()).toBe(true),
+    );
+    vi.useRealTimers();
 
     await card.get("[data-test='mobile-collection-open']").trigger("click");
     await flushPromises();

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -64,6 +64,8 @@ import {
   collectionSlugResolver,
   displayTitle,
   planOrganizationFanout,
+  rememberSessionScroll,
+  sessionScrollPosition,
   tagKey,
   trashRetentionSummary,
   visibleTagCounts,
@@ -386,6 +388,7 @@ import MobileGenerateParameters from "./MobileGenerateParameters.vue";
 import MobileHostDetail from "./MobileHostDetail.vue";
 import MobileIdentityWell from "./MobileIdentityWell.vue";
 import MobileLibrarySheet from "./MobileLibrarySheet.vue";
+import MobileMediaPlaceholder from "./MobileMediaPlaceholder.vue";
 import MobileLoraControls from "./MobileLoraControls.vue";
 import MobilePromptTools from "./MobilePromptTools.vue";
 import MobileRemixReview, { type MobileRemixReviewVariant } from "./MobileRemixReview.vue";
@@ -571,6 +574,7 @@ const GALLERY_HOST_TIMEOUT_MS = 9_000;
 const GALLERY_THUMBNAIL_TIMEOUT_MS = 5_000;
 const GALLERY_THUMBNAIL_PLACEHOLDER = "data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=";
 const GALLERY_THUMBNAIL_RETRY_MAX_MS = 30_000;
+const MOBILE_LIBRARY_SCROLL_KEY = "mobile:library";
 const REUSE_PRESENTATION_TIMEOUT_MS = 9_000;
 const OUTPUT_OPTIONS = [
   { value: "single" as const, label: "One shot" },
@@ -925,7 +929,15 @@ const emptyingTrash = ref(false);
 const galleryRestoring = ref(false);
 const collectionMenuSlug = ref<string | null>(null);
 const collectionDeleteConfirmSlug = ref<string | null>(null);
-const collectionCovers = reactive<Record<string, string>>({});
+interface CollectionCoverState {
+  hostId: string;
+  filename: string;
+  url: string;
+  status: "loading" | "ready" | "error";
+}
+const collectionCovers = reactive<Record<string, CollectionCoverState>>({});
+const collectionCoverRetryTimers = new Map<string, ReturnType<typeof setTimeout>>();
+const collectionCoverRetryAttempts = new Map<string, number>();
 const librarySheet = ref<LibrarySheet | null>(null);
 const librarySheetInput = ref("");
 const librarySheetError = ref("");
@@ -966,6 +978,8 @@ let galleryRefreshRequested = false;
 let galleryRefreshDeferred = false;
 let galleryRefreshTask: Promise<void> | null = null;
 let galleryOperationTail: Promise<void> = Promise.resolve();
+let pendingLibraryScrollRestore: { top: number; left: number } | null = null;
+let libraryScrollRestoreTimer: ReturnType<typeof setTimeout> | null = null;
 const activeGalleryThumbnailControllers = new Set<AbortController>();
 const galleryThumbnailHandles = new Map<string, ThumbnailHandle<string>>();
 let visibleGalleryThumbnailKeys = new Set<string>();
@@ -5931,6 +5945,7 @@ async function loadMoreGalleryPage(): Promise<void> {
     galleryByThumbnailKey.set(galleryThumbnailRetryKey(print), print);
   }
   markMobileLibrarySeen(galleryCopies);
+  if (pendingLibraryScrollRestore) restoreMobileLibraryScroll();
 }
 
 async function reusePrint(print: GalleryPrint): Promise<void> {
@@ -6747,6 +6762,21 @@ const activeCollection = computed(
     libraryCollectionCards.value.find((card) => card.slug === libraryFilters.collectionSlug) ??
     null,
 );
+const collectionShelfVisible = computed(
+  () => tab.value === "gallery" && libraryScope.value === "collections" && !activeCollection.value,
+);
+watch(
+  [
+    collectionShelfVisible,
+    libraryCollectionCards,
+    () => connectedHosts.value.map((host) => `${host.id}:${host.online}:${host.baseUrl}`).join("|"),
+  ],
+  ([visible, cards]) => {
+    if (visible) syncCollectionCovers(cards as MobileCollectionCard[]);
+    else pauseCollectionCoverRetries();
+  },
+  { immediate: true },
+);
 const libraryScopeCounts = computed<Record<MobileLibraryScope, number>>(() => ({
   prints: libraryPrintCount.value,
   collections: libraryCollectionCards.value.length,
@@ -6947,28 +6977,136 @@ function closeCollection(): void {
   void requeueGallery();
 }
 
-/** Cover thumbnail for a collection card: a loaded tile when the cover print
- * is on screen, otherwise fetched once through the cached media pipeline. */
-function collectionCoverUrl(card: MobileCollectionCard): string {
-  const loaded = gallery.value.find((print) =>
-    (organizationOf(print)?.collections ?? []).includes(card.slug),
-  );
-  if (loaded) return loaded.thumbnailUrl;
-  const cached = collectionCovers[card.slug];
-  if (cached) return cached;
-  const cover = card.cover;
-  if (!cover) return "";
-  const host = connectedHosts.value.find((candidate) => candidate.id === cover.hostId);
-  if (!host) return "";
-  collectionCovers[card.slug] = "";
-  void thumbnailUrl(mobileHostTarget(host), mobileGalleryCacheKey(host), cover.filename)
-    .then((url) => {
-      collectionCovers[card.slug] = url;
-    })
-    .catch(() => {
+/** Collection cards own their cover URL. Grid URLs are revoked whenever scope
+ * paging resets, so borrowing one here produces a broken image after the user
+ * switches from Prints to Collections. */
+function syncCollectionCovers(cards: readonly MobileCollectionCard[]): void {
+  if (!collectionShelfVisible.value) return;
+  const liveSlugs = new Set(cards.map((card) => card.slug));
+  for (const [slug, state] of Object.entries(collectionCovers)) {
+    if (!liveSlugs.has(slug)) {
+      revokeObjectUrl(state.url);
+      const timer = collectionCoverRetryTimers.get(slug);
+      if (timer) clearTimeout(timer);
+      collectionCoverRetryTimers.delete(slug);
+      collectionCoverRetryAttempts.delete(slug);
+      delete collectionCovers[slug];
+    }
+  }
+
+  for (const card of cards) {
+    const cover = card.cover;
+    const prior = collectionCovers[card.slug];
+    if (!cover) {
+      if (prior) revokeObjectUrl(prior.url);
+      const timer = collectionCoverRetryTimers.get(card.slug);
+      if (timer) clearTimeout(timer);
+      collectionCoverRetryTimers.delete(card.slug);
+      collectionCoverRetryAttempts.delete(card.slug);
       delete collectionCovers[card.slug];
-    });
-  return "";
+      continue;
+    }
+    if (prior?.hostId === cover.hostId && prior.filename === cover.filename) {
+      if (prior.status !== "error" || collectionCoverRetryTimers.has(card.slug)) continue;
+    } else if (prior) {
+      revokeObjectUrl(prior.url);
+      const timer = collectionCoverRetryTimers.get(card.slug);
+      if (timer) clearTimeout(timer);
+      collectionCoverRetryTimers.delete(card.slug);
+      collectionCoverRetryAttempts.delete(card.slug);
+    }
+
+    const state: CollectionCoverState = {
+      hostId: cover.hostId,
+      filename: cover.filename,
+      url: "",
+      status: "loading",
+    };
+    collectionCovers[card.slug] = state;
+    const host = connectedHosts.value.find((candidate) => candidate.id === cover.hostId);
+    if (!host) {
+      state.status = "error";
+      continue;
+    }
+    void thumbnailUrl(mobileHostTarget(host), mobileGalleryCacheKey(host), cover.filename)
+      .then((url) => {
+        const current = collectionCovers[card.slug];
+        if (
+          !current ||
+          current.hostId !== cover.hostId ||
+          current.filename !== cover.filename ||
+          unmounted
+        ) {
+          revokeObjectUrl(url);
+          return;
+        }
+        current.url = url;
+        current.status = "ready";
+        const timer = collectionCoverRetryTimers.get(card.slug);
+        if (timer) clearTimeout(timer);
+        collectionCoverRetryTimers.delete(card.slug);
+        collectionCoverRetryAttempts.delete(card.slug);
+      })
+      .catch(() => {
+        const current = collectionCovers[card.slug];
+        if (current?.hostId === cover.hostId && current.filename === cover.filename) {
+          current.status = "error";
+          scheduleCollectionCoverRetry(card);
+        }
+      });
+  }
+}
+
+function scheduleCollectionCoverRetry(card: MobileCollectionCard): void {
+  if (
+    unmounted ||
+    !collectionShelfVisible.value ||
+    collectionCoverRetryTimers.has(card.slug) ||
+    !card.cover
+  )
+    return;
+  const attempt = collectionCoverRetryAttempts.get(card.slug) ?? 0;
+  collectionCoverRetryAttempts.set(card.slug, attempt + 1);
+  const timer = setTimeout(
+    () => {
+      collectionCoverRetryTimers.delete(card.slug);
+      const current = collectionCovers[card.slug];
+      if (
+        !current ||
+        current.status !== "error" ||
+        current.hostId !== card.cover?.hostId ||
+        current.filename !== card.cover.filename
+      ) {
+        return;
+      }
+      delete collectionCovers[card.slug];
+      syncCollectionCovers(libraryCollectionCards.value);
+    },
+    galleryThumbnailRetryDelay(card.cover.filename, attempt),
+  );
+  collectionCoverRetryTimers.set(card.slug, timer);
+}
+
+function pauseCollectionCoverRetries(): void {
+  for (const timer of collectionCoverRetryTimers.values()) clearTimeout(timer);
+  collectionCoverRetryTimers.clear();
+}
+
+function handleCollectionCoverError(card: MobileCollectionCard): void {
+  const state = collectionCovers[card.slug];
+  if (!state) return;
+  revokeObjectUrl(state.url);
+  state.url = "";
+  state.status = "error";
+  scheduleCollectionCoverRetry(card);
+}
+
+function handleGalleryThumbnailError(print: GalleryPrint): void {
+  if (print.thumbnailPending) return;
+  revokeObjectUrl(print.thumbnailUrl);
+  print.thumbnailUrl = GALLERY_THUMBNAIL_PLACEHOLDER;
+  print.thumbnailPending = true;
+  scheduleGalleryThumbnailRetry(print);
 }
 
 // ── Library organization: mutations ─────────────────────────────────────────
@@ -8184,14 +8322,55 @@ function reuseSelectedPrint(): void {
 }
 
 function openSettings(): void {
+  if (tab.value === "gallery" && mobileContent.value) {
+    rememberSessionScroll(MOBILE_LIBRARY_SCROLL_KEY, {
+      top: mobileContent.value.scrollTop,
+      left: mobileContent.value.scrollLeft,
+    });
+  }
   settingsOpen.value = true;
   void nextTick(() => settingsBackButton.value?.focus());
 }
 
 function closeSettings(): void {
   settingsOpen.value = false;
-  void nextTick(() => settingsButton.value?.focus());
+  void nextTick(() => {
+    if (tab.value === "gallery" && mobileContent.value) {
+      const position = sessionScrollPosition(MOBILE_LIBRARY_SCROLL_KEY);
+      mobileContent.value.scrollTop = position.top;
+      mobileContent.value.scrollLeft = position.left;
+    }
+    settingsButton.value?.focus();
+  });
 }
+
+/** Restore after the logical gallery index has been placed. The virtual grid
+ * keeps the complete scroll extent available even though it mounts only the
+ * visible rows, so deep offsets restore in one frame. */
+function restoreMobileLibraryScroll(): void {
+  const target = pendingLibraryScrollRestore;
+  if (!target || tab.value !== "gallery" || unmounted || libraryScrollRestoreTimer !== null) return;
+  libraryScrollRestoreTimer = setTimeout(() => {
+    libraryScrollRestoreTimer = null;
+    if (pendingLibraryScrollRestore !== target || tab.value !== "gallery" || unmounted) return;
+    const scroller = mobileContent.value;
+    if (!scroller) return;
+    const gridExpected = libraryScope.value !== "collections" || activeCollection.value !== null;
+    if (
+      galleryLoading.value ||
+      (gridExpected && gallery.value.length > 0 && !galleryGridSurface.value)
+    ) {
+      return;
+    }
+    scroller.scrollTop = target.top;
+    scroller.scrollLeft = target.left;
+    pendingLibraryScrollRestore = null;
+  }, 0);
+}
+
+watch([galleryLoading, galleryGridSurface, libraryScope, activeCollection], () => {
+  restoreMobileLibraryScroll();
+});
 
 function manageHostsFromSettings(): void {
   settingsOpen.value = false;
@@ -8283,19 +8462,27 @@ watch(
   { flush: "sync" },
 );
 
-watch(tab, (next) => {
-  // The primary destinations share this one WebView scroller. Reset it after
-  // Vue swaps the destination so a long Library cannot open Models, Machines,
-  // or Create at the same inherited offset.
-  void nextTick(() => {
-    if (!mobileContent.value) return;
-    mobileContent.value.scrollTop = 0;
-    mobileContent.value.scrollLeft = 0;
-  });
+watch(tab, (next, previous) => {
+  if (previous === "gallery" && mobileContent.value) {
+    rememberSessionScroll(MOBILE_LIBRARY_SCROLL_KEY, {
+      top: mobileContent.value.scrollTop,
+      left: mobileContent.value.scrollLeft,
+    });
+  }
   if (next === "gallery") {
     librarySeenAtBaseline = loadLibrarySeenAt();
     libraryPreviouslyVisited = localStorage.getItem(LIBRARY_VISITED_KEY) === "true";
-    void refreshGallery();
+    pendingLibraryScrollRestore = sessionScrollPosition(MOBILE_LIBRARY_SCROLL_KEY);
+    void refreshGallery().then(restoreMobileLibraryScroll);
+  } else {
+    pendingLibraryScrollRestore = null;
+    // The primary destinations share this one WebView scroller. Non-Library
+    // destinations still start at the top rather than inheriting its offset.
+    void nextTick(() => {
+      if (!mobileContent.value) return;
+      mobileContent.value.scrollTop = 0;
+      mobileContent.value.scrollLeft = 0;
+    });
   }
   if (next !== "hosts") hostDetailId.value = "";
 });
@@ -8554,8 +8741,13 @@ onBeforeUnmount(() => {
   if (liveActivityTimer) clearInterval(liveActivityTimer);
   liveActivityTimer = null;
   cancelGalleryThumbnailRetries();
+  if (libraryScrollRestoreTimer !== null) clearTimeout(libraryScrollRestoreTimer);
+  libraryScrollRestoreTimer = null;
   for (const handle of galleryThumbnailHandles.values()) handle.cancel();
   galleryThumbnailHandles.clear();
+  for (const timer of collectionCoverRetryTimers.values()) clearTimeout(timer);
+  collectionCoverRetryTimers.clear();
+  collectionCoverRetryAttempts.clear();
   for (const controller of activeGalleryThumbnailControllers) controller.abort();
   activeGalleryThumbnailControllers.clear();
   galleryGridResizeObserver?.disconnect();
@@ -9654,7 +9846,16 @@ onBeforeUnmount(() => {
                 @contextmenu.prevent="openCollectionMenu(card.slug)"
               >
                 <span class="mobile-collection-cover" aria-hidden="true">
-                  <img v-if="collectionCoverUrl(card)" :src="collectionCoverUrl(card)" alt="" />
+                  <img
+                    v-if="collectionCovers[card.slug]?.status === 'ready'"
+                    :src="collectionCovers[card.slug]?.url"
+                    alt=""
+                    @error="handleCollectionCoverError(card)"
+                  />
+                  <MobileMediaPlaceholder
+                    v-else
+                    :loading="collectionCovers[card.slug]?.status === 'loading'"
+                  />
                 </span>
                 <span class="mobile-collection-copy">
                   <strong>{{ card.name }}</strong>
@@ -9875,15 +10076,14 @@ onBeforeUnmount(() => {
                     :alt="print.metadata.prompt || print.filename"
                     :class="{ 'is-thumbnail-pending': print.thumbnailPending }"
                     loading="lazy"
+                    @error="handleGalleryThumbnailError(print)"
                     @contextmenu="rememberNativeGalleryContext(print)"
                   />
-                  <span
+                  <MobileMediaPlaceholder
                     v-if="print.thumbnailPending"
-                    class="gallery-thumbnail-pending"
+                    loading
                     data-test="gallery-thumbnail-pending"
-                    aria-hidden="true"
-                    >Loading preview</span
-                  >
+                  />
                   <span
                     v-if="isVideoItem(print) || isAudioItem(print)"
                     class="gallery-video-badge"

--- a/desktop/src/mobile/MobileMediaPlaceholder.vue
+++ b/desktop/src/mobile/MobileMediaPlaceholder.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+withDefaults(
+  defineProps<{
+    loading?: boolean;
+  }>(),
+  { loading: false },
+);
+</script>
+
+<template>
+  <span
+    class="mobile-media-placeholder"
+    :class="{ 'is-loading': loading }"
+    aria-hidden="true"
+    data-test="mobile-media-placeholder"
+  >
+    <svg viewBox="0 0 32 32" fill="none">
+      <rect x="5.5" y="6.5" width="21" height="19" rx="4.5" />
+      <circle cx="20.5" cy="12" r="2.25" />
+      <path d="m8.5 22 6.1-6.1 3.8 3.8 2.1-2.1 3 3" />
+    </svg>
+  </span>
+</template>

--- a/desktop/src/mobile/mobile.css
+++ b/desktop/src/mobile/mobile.css
@@ -2671,22 +2671,62 @@ button:disabled {
   opacity: 0;
 }
 
-.gallery-thumbnail-pending {
+.mobile-media-placeholder {
   position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  background:
+    radial-gradient(
+      circle at 28% 22%,
+      color-mix(in srgb, var(--safelight) 9%, transparent),
+      transparent 44%
+    ),
+    linear-gradient(145deg, var(--bench), color-mix(in srgb, var(--bench) 86%, var(--bath)));
+  box-shadow: inset 0 0 0 1px var(--edge);
   color: var(--ink-3);
-  font-family: var(--font-utility);
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  width: max-content;
-  height: max-content;
-  padding: 6px 10px;
-  border: 1px solid color-mix(in srgb, var(--ink-3) 22%, transparent);
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--color-print-surface) 78%, transparent);
-  font-size: 10px;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
+}
+
+.mobile-media-placeholder::after {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    108deg,
+    transparent 28%,
+    color-mix(in srgb, var(--rebate) 8%, transparent) 48%,
+    transparent 68%
+  );
+  content: "";
+  opacity: 0;
+  transform: translateX(-70%);
+}
+
+.mobile-media-placeholder.is-loading::after {
+  opacity: 1;
+  animation: mobile-media-shimmer 1.8s ease-in-out infinite;
+}
+
+.mobile-media-placeholder svg {
+  position: relative;
+  z-index: 1;
+  width: clamp(28px, 28%, 52px);
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.35;
+}
+
+@keyframes mobile-media-shimmer {
+  to {
+    transform: translateX(70%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mobile-media-placeholder.is-loading::after {
+    animation: none;
+  }
 }
 
 .gallery-video-badge {
@@ -4627,6 +4667,7 @@ button:disabled {
 }
 
 .mobile-collection-cover {
+  position: relative;
   display: grid;
   width: 48px;
   height: 48px;

--- a/desktop/src/views/LibraryView.test.ts
+++ b/desktop/src/views/LibraryView.test.ts
@@ -56,6 +56,7 @@ import { useGenerateFormStore } from "../stores/generateForm";
 import { useToastStore } from "../stores/toasts";
 import type { GalleryImage } from "../lib/api/types";
 import { installMemoryLocalStorage } from "../lib/testSupport/memoryLocalStorage";
+import { clearSessionScrollForTests } from "@studio/lib/libraryOrganization";
 
 installMemoryLocalStorage();
 
@@ -157,9 +158,25 @@ async function mountView(
 }
 
 beforeEach(() => {
+  clearSessionScrollForTests();
   vi.clearAllMocks();
   localStorage.clear();
   apiFetchTo.mockResolvedValue(new Response());
+});
+
+describe("LibraryView session scroll", () => {
+  it("restores its own scroller after leaving and returning", async () => {
+    const first = await mountView();
+    const firstScroller = first.wrapper.get("div[style='contain: strict;']").element as HTMLElement;
+    firstScroller.scrollTop = 420;
+    first.wrapper.unmount();
+
+    const second = await mountView();
+    const secondScroller = second.wrapper.get("div[style='contain: strict;']")
+      .element as HTMLElement;
+    await vi.waitFor(() => expect(secondScroller.scrollTop).toBe(420));
+    second.wrapper.unmount();
+  });
 });
 
 describe("LibraryView notification deep links", () => {

--- a/desktop/src/views/LibraryView.vue
+++ b/desktop/src/views/LibraryView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, onUnmounted, ref, watch } from "vue";
+import { computed, nextTick, onBeforeUnmount, onMounted, onUnmounted, ref, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { useVirtualizer } from "@tanstack/vue-virtual";
 import Icon from "@ui/components/Icon.vue";
@@ -38,6 +38,8 @@ import {
 } from "@studio/lib/sequenceReuse";
 import {
   displayTitle,
+  rememberSessionScroll,
+  sessionScrollPosition,
   validatePrintTitle,
   type MergedCollection,
 } from "@studio/lib/libraryOrganization";
@@ -85,6 +87,7 @@ const MENU_TAG_LIMIT = 12;
 /** Pointer sweep selection auto-scrolls near the top/bottom of the grid. */
 const DRAG_SCROLL_EDGE = 72;
 const DRAG_SCROLL_MAX = 18;
+const DESKTOP_LIBRARY_SCROLL_KEY = "desktop:library";
 
 const router = useRouter();
 const route = useRoute();
@@ -1921,6 +1924,20 @@ onMounted(() => {
       containerWidth.value = observed[0]?.contentRect.width ?? containerWidth.value;
     });
     resizeObserver.observe(scrollEl.value);
+  }
+  void nextTick(() => {
+    if (!scrollEl.value) return;
+    const position = sessionScrollPosition(DESKTOP_LIBRARY_SCROLL_KEY);
+    scrollEl.value.scrollTop = position.top;
+    scrollEl.value.scrollLeft = position.left;
+  });
+});
+onBeforeUnmount(() => {
+  if (scrollEl.value) {
+    rememberSessionScroll(DESKTOP_LIBRARY_SCROLL_KEY, {
+      top: scrollEl.value.scrollTop,
+      left: scrollEl.value.scrollLeft,
+    });
   }
 });
 onUnmounted(() => {

--- a/studio/lib/libraryOrganization.ts
+++ b/studio/lib/libraryOrganization.ts
@@ -612,3 +612,28 @@ export function visibleTagCounts(
   for (const [key, tag] of exactByKey) result.set(key, tag);
   return sortTags([...result.values()]);
 }
+
+/** In-memory workspace offsets. A fresh app/browser session starts at the top. */
+const sessionScrollPositions = new Map<string, { top: number; left: number }>();
+
+export function rememberSessionScroll(
+  key: string,
+  position: { top: number; left?: number },
+): void {
+  sessionScrollPositions.set(key, {
+    top: Math.max(0, position.top),
+    left: Math.max(0, position.left ?? 0),
+  });
+}
+
+export function sessionScrollPosition(key: string): {
+  top: number;
+  left: number;
+} {
+  return sessionScrollPositions.get(key) ?? { top: 0, left: 0 };
+}
+
+/** Test-only reset kept explicit so product code cannot accidentally persist it. */
+export function clearSessionScrollForTests(): void {
+  sessionScrollPositions.clear();
+}

--- a/web/src/pages/LibraryPage.test.ts
+++ b/web/src/pages/LibraryPage.test.ts
@@ -14,6 +14,7 @@ import {
   useGenerateForm,
 } from "../composables/useGenerateForm";
 import type { GalleryImage } from "../types";
+import { clearSessionScrollForTests } from "@studio/lib/libraryOrganization";
 
 const { listGalleryMock, deleteMock, fetchModelsMock } = vi.hoisted(() => ({
   listGalleryMock: vi.fn(),
@@ -215,6 +216,7 @@ beforeEach(() => setActivePinia(createPinia()));
 
 describe("LibraryPage", () => {
   beforeEach(() => {
+    clearSessionScrollForTests();
     localStorage.clear();
     resetNotifications();
     formTesting.resetForTest();
@@ -249,6 +251,27 @@ describe("LibraryPage", () => {
     pushMock.mockReset();
     replaceMock.mockReset();
     vi.mocked(requestConfirm).mockReset().mockResolvedValue(true);
+  });
+
+  it("restores the window scroll position after leaving and returning", async () => {
+    const scrollTo = vi
+      .spyOn(window, "scrollTo")
+      .mockImplementation(() => undefined);
+    const first = await mounted();
+    Object.defineProperty(window, "scrollY", {
+      configurable: true,
+      value: 420,
+    });
+    Object.defineProperty(window, "scrollX", { configurable: true, value: 0 });
+    first.unmount();
+    scrollTo.mockClear();
+
+    const second = await mounted();
+    await vi.waitFor(() =>
+      expect(scrollTo).toHaveBeenCalledWith({ top: 420, left: 0 }),
+    );
+    second.unmount();
+    scrollTo.mockRestore();
   });
 
   afterEach(() => {

--- a/web/src/pages/LibraryPage.vue
+++ b/web/src/pages/LibraryPage.vue
@@ -61,6 +61,8 @@ import {
   tagKey,
   trashRetentionSummary,
   visibleTagCounts,
+  rememberSessionScroll,
+  sessionScrollPosition,
   type MergedCollection,
   type OrganizationMutation,
 } from "@studio/lib/libraryOrganization";
@@ -137,6 +139,8 @@ import {
   minimaxH3TaskForModel,
   setMinimaxH3GalleryImageFirstFrame,
 } from "@studio/lib/minimaxH3Authoring";
+
+const WEB_LIBRARY_SCROLL_KEY = "web:library";
 
 type FilterKind = "all" | "images" | "video" | "audio";
 type ViewMode = "feed" | "grid";
@@ -2101,6 +2105,10 @@ onMounted(() => {
   document.addEventListener("keydown", onDocumentKeydown);
 });
 onBeforeUnmount(() => {
+  rememberSessionScroll(WEB_LIBRARY_SCROLL_KEY, {
+    top: window.scrollY,
+    left: window.scrollX,
+  });
   window.removeEventListener("scroll", onScroll);
   document.removeEventListener("pointerdown", onDocumentPointerDown);
   document.removeEventListener("keydown", onDocumentKeydown);
@@ -2115,6 +2123,9 @@ onMounted(async () => {
   ]);
   if (disposed) return;
   models.value = listing;
+  await nextTick();
+  const position = sessionScrollPosition(WEB_LIBRARY_SCROLL_KEY);
+  window.scrollTo({ top: position.top, left: position.left });
   refreshTimer = setInterval(() => {
     if (!document.hidden) void refresh();
   }, 10_000);


### PR DESCRIPTION
## Summary

- give collection covers independent cached object URLs so grid refreshes cannot revoke them
- replace broken/loading mobile thumbnails with a clean theme-aware placeholder and bounded retry recovery
- restore current-session Library scroll position across mobile, desktop, and web navigation, including deep paginated mobile positions
- pause collection-cover network retries whenever the Collections shelf is not visible

## Validation

- `nix develop -c bun run check:frontend`
- `nix develop -c bun run build:mobile`
- `cd desktop && bunx vitest run src/mobile/MobileApp.test.ts` (293 passed)
- focused desktop/web scroll-restoration tests
- Prettier and `git diff --check`
- rendered mobile QA at 390×844: placeholders, decoded collection covers, zero console errors, and 617px Library scroll restoration
- independent agent review: no findings after all follow-ups were addressed
