### PR TITLE
fix(pulid): support FLUX and SDXL families

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,9 @@ with prompt, model, seed, and generation metadata.
 - **Images**: text-to-image, img2img, multimodal editing, inpainting,
   ControlNet, LoRA, prompt expansion, and Real-ESRGAN upscaling
 - **Face identity (PuLID)**: keep one person's face across arbitrary prompts
-  with `--id-image` (repeatable up to 4, averaged into one identity), on FLUX
-  (`flux-dev:q4`, `flux-dev:q8`, the `pulid-flux` bundle) and SDXL
-  (`sdxl-base:fp16`, `juggernaut-xl:fp16`, `realvis-xl:fp16`,
-  `dreamshaper-xl:fp16`, the `pulid-sdxl` bundle) — pure Rust SCRFD, ArcFace, a
+  with `--id-image` (repeatable up to 4, averaged into one identity), across all
+  FLUX.1 models (the `pulid-flux` bundle) and all SDXL models except SDXL Turbo
+  (the `pulid-sdxl` bundle) — pure Rust SCRFD, ArcFace, a
   BiSeNet face mask, EVA02-CLIP, and IDFormer shared by both adapters, feeding
   twenty cross-attention modules inside the FLUX transformer or seventy inside
   the SDXL UNet, plus `--true-cfg` on FLUX for a real negative branch on an

--- a/changelog.d/pulid-family-wide.md
+++ b/changelog.d/pulid-family-wide.md
@@ -1,0 +1,1 @@
+- **Family-wide PuLID support.** Enable identity-photo generation for every FLUX and non-Turbo SDXL checkpoint, including live Hugging Face and Civitai catalog models, while continuing to reject SDXL Turbo.

--- a/crates/mold-cli/src/main.rs
+++ b/crates/mold-cli/src/main.rs
@@ -1120,10 +1120,9 @@ Examples:
 
         /// Reference photograph to preserve the face of (PuLID). Repeat up to
         /// 4 times to average several references of the same person.
-        /// Qualified for flux-dev:q4 / flux-dev:q8 (`mold pull pulid-flux`)
-        /// and for sdxl-base:fp16, juggernaut-xl:fp16, realvis-xl:fp16,
-        /// dreamshaper-xl:fp16 (`mold pull pulid-sdxl`), on a server built
-        /// with the `pulid` feature. Either bundle needs
+        /// Supported across FLUX.1 (`mold pull pulid-flux`) and SDXL except
+        /// SDXL Turbo (`mold pull pulid-sdxl`), on a server built with the
+        /// `pulid` feature. Either bundle needs
         /// `--accept-license insightface-antelopev2`; a machine that already
         /// has one pulls only the other's adapter.
         #[arg(

--- a/crates/mold-cli/src/skill/SKILL.md
+++ b/crates/mold-cli/src/skill/SKILL.md
@@ -746,11 +746,10 @@ mold run "a golden retriever" --image park.png --mask mask.png
 
 ### Face-identity conditioning (PuLID)
 
-Keep one person's face across arbitrary prompts. FLUX takes PuLID-FLUX v0.9.1
-(`flux-dev:q4`, `flux-dev:q8`); SDXL takes PuLID v1.1 (`sdxl-base:fp16`,
-`juggernaut-xl:fp16`, `realvis-xl:fp16`, `dreamshaper-xl:fp16`). On CUDA and
-Metal, in every official release build. Clients read the server's advertised
-`/api/models[].supports_identity` rather than this list.
+Keep one person's face across arbitrary prompts. Every FLUX.1 checkpoint takes
+PuLID-FLUX v0.9.1; every SDXL checkpoint except SDXL Turbo takes PuLID v1.1.
+Available on CUDA and Metal in every official release build. Clients read the
+server's advertised `/api/models[].supports_identity` capability.
 
 ```bash
 # FLUX — one-time setup: the bundle is licence-gated and will not download without this
@@ -828,12 +827,10 @@ Wire contract — additive `GenerateRequest` fields (read `supports_identity`, n
 
 Identity gate — every rule below is a 422 at admission, never a silent drop:
 
-- Only the identity-qualified checkpoints are accepted: FLUX's `flux-dev:q4`
-  and `flux-dev:q8` (bare `flux-dev` resolves to `:q8`, and the legacy dash
-  form `flux-dev-q4` resolves too), and SDXL's `sdxl-base:fp16`,
-  `juggernaut-xl:fp16`, `realvis-xl:fp16`, and `dreamshaper-xl:fp16`.
-  `flux-dev:bf16`, every SDXL checkpoint not on that list (turbo/lightning
-  tiers, Playground, the Pony derivatives), and every other model are refused.
+- Every FLUX.1 checkpoint is accepted, regardless of quantization or fine-tune.
+  Every SDXL checkpoint is accepted except `sdxl-turbo:fp16`, whose distilled
+  base remains an explicit compatibility exception. Flux.2 and every other
+  architecture are refused.
 - Identity may not be combined with a LoRA or with an img2img `source_image` —
   neither combination is qualified yet, on either family.
 - Any of `id_weight` / `id_start_step` / `id_image_name` without `id_image`

--- a/crates/mold-core/src/generation_profile.rs
+++ b/crates/mold-core/src/generation_profile.rs
@@ -1233,7 +1233,7 @@ fn recipe(
     // AND the landed runtime adapter, never a bare `cfg!(feature = "pulid")`,
     // which would advertise a control the worker cannot honour.
     let identity_supported = crate::identity::identity_runtime_available()
-        && crate::identity::identity_qualified_model(input.model);
+        && crate::identity::identity_qualified_model_with_family(input.model, Some(family));
     let output = if audio_only {
         OutputCapabilitiesProfile {
             default_format: OutputFormat::Wav,
@@ -1677,8 +1677,11 @@ mod tests {
         if crate::identity::IDENTITY_RUNTIME_READY {
             return;
         }
-        for model in ["flux-dev", "flux-dev:q4", "flux-dev:q8", "flux-dev-q4"] {
-            let profile = resolve_generation_profile(input(model, "flux"));
+        for model in crate::identity::identity_qualified_models() {
+            let family = crate::identity::identity_family(model)
+                .expect("qualified model has an identity family")
+                .family();
+            let profile = resolve_generation_profile(input(model, family));
             assert!(
                 !profile.supports_identity(),
                 "{model} must not advertise identity while the adapter is pending \
@@ -1697,17 +1700,10 @@ mod tests {
     }
 
     #[test]
-    fn identity_capability_is_never_advertised_for_an_unqualified_checkpoint() {
+    fn identity_capability_is_never_advertised_outside_supported_families_or_for_turbo() {
         for (model, family) in [
-            ("flux-dev:bf16", "flux"),
-            ("flux-schnell:q8", "flux"),
             ("flux2-klein", "flux2"),
-            // Being an SDXL checkpoint is necessary and never sufficient:
-            // these four are the family's recorded refusals.
             ("sdxl-turbo:fp16", "sdxl"),
-            ("playground-v2.5:fp16", "sdxl"),
-            ("pony-v6:fp16", "sdxl"),
-            ("cyberrealistic-pony:fp16", "sdxl"),
             ("z-image-turbo:q4", "z-image"),
         ] {
             let profile = resolve_generation_profile(input(model, family));
@@ -1726,18 +1722,21 @@ mod tests {
             // until #1221 flips the constant.
             return;
         }
-        for model in ["flux-dev", "flux-dev:q4", "flux-dev:q8", "flux-dev-q4"] {
-            let profile = resolve_generation_profile(input(model, "flux"));
+        for model in crate::identity::identity_qualified_models() {
+            let family = crate::identity::identity_family(model)
+                .expect("qualified model has an identity family")
+                .family();
+            let profile = resolve_generation_profile(input(model, family));
             assert!(
                 profile.supports_identity(),
                 "{model} must advertise identity conditioning"
             );
         }
-        for model in crate::identity::IDENTITY_QUALIFIED_SDXL_MODELS {
-            let profile = resolve_generation_profile(input(model, "sdxl"));
+        for (model, family) in [("cv:123", "flux"), ("hf:owner/sdxl-finetune", "sdxl")] {
+            let profile = resolve_generation_profile(input(model, family));
             assert!(
                 profile.supports_identity(),
-                "{model} must advertise identity conditioning"
+                "opaque catalog model {model} must inherit {family} identity support"
             );
         }
     }

--- a/crates/mold-core/src/identity.rs
+++ b/crates/mold-core/src/identity.rs
@@ -227,10 +227,10 @@ pub fn identity_cache_key(image_sha256: &str, assets: &IdentityAssetDigests) -> 
 /// footprints, so every layer that has to behave differently asks this one
 /// question rather than re-deriving the answer from a model name.
 ///
-/// The variants are deliberately NOT the manifest `family` string: `"sdxl"`
-/// covers turbo and Playground checkpoints that are not qualified, so a family
-/// match is necessary and never sufficient. [`identity_family`] is the only
-/// authority.
+/// The variants map to the manifest architecture family. FLUX.1 is supported
+/// family-wide; SDXL is supported family-wide except for the explicitly
+/// excluded distilled Turbo checkpoint. [`identity_family`] is the only
+/// authority for that policy.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum IdentityFamily {
     /// PuLID-FLUX v0.9.1 — `pulid-flux`, `pulid_flux_v0.9.1.safetensors`.
@@ -256,11 +256,14 @@ impl IdentityFamily {
         }
     }
 
-    /// The resolved checkpoints qualified for this family.
-    pub fn qualified_models(self) -> &'static [&'static str] {
+    /// Whether a resolved manifest belongs to this identity-compatible family.
+    pub fn qualifies_manifest(self, manifest: &crate::manifest::ModelManifest) -> bool {
         match self {
-            Self::Flux => IDENTITY_QUALIFIED_FLUX_MODELS,
-            Self::Sdxl => IDENTITY_QUALIFIED_SDXL_MODELS,
+            Self::Flux => manifest.family == self.family(),
+            Self::Sdxl => {
+                manifest.family == self.family()
+                    && !IDENTITY_EXCLUDED_SDXL_MODELS.contains(&manifest.name.as_str())
+            }
         }
     }
 
@@ -268,52 +271,23 @@ impl IdentityFamily {
     pub const ALL: &'static [IdentityFamily] = &[IdentityFamily::Flux, IdentityFamily::Sdxl];
 }
 
-/// FLUX checkpoints qualified to accept identity conditioning.
+/// SDXL checkpoints excluded from family-wide identity conditioning.
 ///
-/// These are resolved manifest names. A request naming the bare `flux-dev`
-/// resolves to `flux-dev:q8` through [`crate::manifest::resolve_model_name`],
-/// and the legacy dash form `flux-dev-q4` resolves to `flux-dev:q4`, so both
-/// are accepted; `flux-dev:bf16` and every other checkpoint are not.
-pub const IDENTITY_QUALIFIED_FLUX_MODELS: &[&str] = &["flux-dev:q4", "flux-dev:q8"];
+/// PuLID v1.1's release note reports degraded behavior on the distilled Turbo
+/// base, so that checkpoint remains the sole exception. Every other model
+/// routed through mold's standard SDXL UNet can load the same adapter.
+pub const IDENTITY_EXCLUDED_SDXL_MODELS: &[&str] = &["sdxl-turbo:fp16"];
 
-/// SDXL checkpoints qualified to accept identity conditioning.
-///
-/// PuLID v1.1's own release note (`ToTheBeginning/PuLID`, `docs/pulid_v1.1.md`)
-/// is the authority for the list, and every `family: "sdxl"` manifest entry was
-/// decided against it explicitly rather than by pattern:
-///
-/// | manifest entry | qualified | why |
-/// | --- | --- | --- |
-/// | `sdxl-base:fp16` | yes | the architecture the adapter was trained against |
-/// | `juggernaut-xl:fp16` | yes | named by `docs/pulid_v1.1.md` ("Juggernaut-XL") and the demo's own `--base RunDiffusion/Juggernaut-XL-v9` |
-/// | `realvis-xl:fp16` | yes | named by `docs/pulid_v1.1.md` ("RealVisXL") |
-/// | `dreamshaper-xl:fp16` | yes | named by `docs/pulid_v1.1.md` ("DreamShaper-XL-Lightning") and the demo's `--base Lykon/dreamshaper-xl-lightning`; mold's entry is the sibling `Lykon/dreamshaper-xl-v2-turbo` |
-/// | `sdxl-turbo:fp16` | no | the distilled base upstream's own caveat covers — "does not perform as well as v1 on the SDXL-lightning-4step base model" |
-/// | `playground-v2.5:fp16` | no | EDM-parameterized, a different training objective the adapter never saw |
-/// | `pony-v6:fp16` | no | a retrained conditioning vocabulary upstream never evaluated, and mold carries it without a pinned SHA-256 |
-/// | `cyberrealistic-pony:fp16` | no | same, a Pony derivative |
-///
-/// The unqualified entries are refusals pending UAT, not architectural
-/// impossibilities: every one of them is a standard SDXL UNet the adapter would
-/// physically load. Qualification is about whether the render is one mold is
-/// willing to promise, which is why the list is enumerated rather than
-/// pattern-matched on the family.
-pub const IDENTITY_QUALIFIED_SDXL_MODELS: &[&str] = &[
-    "sdxl-base:fp16",
-    "juggernaut-xl:fp16",
-    "realvis-xl:fp16",
-    "dreamshaper-xl:fp16",
-];
-
-/// Every qualified checkpoint, across every family, in [`IdentityFamily::ALL`]
+/// Every registered checkpoint that supports identity conditioning, in manifest
 /// order.
 ///
-/// Composed rather than restated so a family added above cannot be missing
-/// from the refusal a client reads.
+/// Derived rather than restated so future FLUX.1 and SDXL manifests inherit the
+/// family-wide policy automatically.
 pub fn identity_qualified_models() -> Vec<&'static str> {
-    IdentityFamily::ALL
+    crate::manifest::known_manifests()
         .iter()
-        .flat_map(|family| family.qualified_models().iter().copied())
+        .filter(|manifest| identity_family(&manifest.name).is_some())
+        .map(|manifest| manifest.name.as_str())
         .collect()
 }
 
@@ -489,17 +463,32 @@ pub const TRUE_CFG_REQUIRES_IDENTITY: &str =
 /// The single authority. `supports_identity` on the generation profile,
 /// `/api/models[].supports_identity`, the dependency planner's bundle choice,
 /// the memory charge, and the engine's adapter all derive from this one
-/// answer; none of them re-derives it from the manifest family, which is
-/// necessary and never sufficient (`sdxl` also covers turbo and Playground).
+/// answer. Compatibility is architecture-wide for FLUX.1 and SDXL, with the
+/// explicitly documented SDXL Turbo exception.
 ///
 /// The name is resolved first, so callers may pass whatever the request
 /// carried — bare, tagged, or the legacy dash form.
 pub fn identity_family(model: &str) -> Option<IdentityFamily> {
-    let resolved = crate::manifest::resolve_model_name(model);
-    IdentityFamily::ALL
-        .iter()
-        .copied()
-        .find(|family| family.qualified_models().contains(&resolved.as_str()))
+    identity_family_with_hint(model, None)
+}
+
+/// The identity architecture for a model plus its resolved family.
+///
+/// Built-in manifests remain authoritative, including the SDXL Turbo
+/// exception. Live-catalog `cv:`/`hf:` ids have no built-in manifest, so their
+/// server-resolved family is the authority instead.
+pub fn identity_family_with_hint(model: &str, family_hint: Option<&str>) -> Option<IdentityFamily> {
+    if let Some(manifest) = crate::manifest::find_manifest(model) {
+        return IdentityFamily::ALL
+            .iter()
+            .copied()
+            .find(|family| family.qualifies_manifest(manifest));
+    }
+    match family_hint {
+        Some("flux") => Some(IdentityFamily::Flux),
+        Some("sdxl") => Some(IdentityFamily::Sdxl),
+        _ => None,
+    }
 }
 
 /// Whether `model` is qualified for identity conditioning.
@@ -508,6 +497,12 @@ pub fn identity_family(model: &str) -> Option<IdentityFamily> {
 /// carried — bare, tagged, or the legacy dash form.
 pub fn identity_qualified_model(resolved_model: &str) -> bool {
     identity_family(resolved_model).is_some()
+}
+
+/// Whether a model is identity-compatible using its resolved family when its
+/// id is an opaque live-catalog identifier.
+pub fn identity_qualified_model_with_family(model: &str, family_hint: Option<&str>) -> bool {
+    identity_family_with_hint(model, family_hint).is_some()
 }
 
 /// The refusal a surface shows for a checkpoint that cannot take an identity
@@ -519,8 +514,8 @@ pub fn identity_qualified_model(resolved_model: &str) -> bool {
 /// built-in fallback and the wording authority, not a second capability.
 pub fn identity_model_gate_message(model: &str) -> String {
     format!(
-        "{model} does not support face-identity conditioning; identity is qualified only for {}",
-        identity_qualified_models().join(", ")
+        "{model} does not support face-identity conditioning; identity is supported for FLUX.1 \
+         and SDXL checkpoints except sdxl-turbo:fp16"
     )
 }
 
@@ -651,10 +646,19 @@ pub fn request_identity_marker(req: &GenerateRequest) -> Option<String> {
 /// A render that needs one and does not have it is an error at the engine,
 /// never a silently unconditioned negative pass.
 pub fn request_needs_unconditional_identity(req: &GenerateRequest) -> bool {
+    request_needs_unconditional_identity_for_family(req, identity_family(&req.model))
+}
+
+/// Family-aware form used after server dependency planning has resolved an
+/// opaque catalog id to its concrete PuLID bundle.
+pub fn request_needs_unconditional_identity_for_family(
+    req: &GenerateRequest,
+    family: Option<IdentityFamily>,
+) -> bool {
     if !request_carries_identity_photo(req) || effective_id_weight(req) == 0.0 {
         return false;
     }
-    match identity_family(&req.model) {
+    match family {
         Some(IdentityFamily::Sdxl) => true,
         _ => request_uses_true_cfg(req),
     }
@@ -946,6 +950,14 @@ pub fn validate_id_image_bytes(bytes: &[u8]) -> Result<(), String> {
 /// A request that mentions no identity field at all is untouched, so this is
 /// safe to call unconditionally from the shared generate-request validator.
 pub fn validate_identity_conditioning(req: &GenerateRequest) -> Result<(), String> {
+    validate_identity_conditioning_with_family(req, None)
+}
+
+/// Validate identity conditioning with the model family resolved by admission.
+pub fn validate_identity_conditioning_with_family(
+    req: &GenerateRequest,
+    family_hint: Option<&str>,
+) -> Result<(), String> {
     if !request_mentions_identity(req) {
         // True CFG rides on the identity contract and nothing else in this
         // milestone, so a request that names it without a face is refused here
@@ -998,7 +1010,7 @@ pub fn validate_identity_conditioning(req: &GenerateRequest) -> Result<(), Strin
         return Err("id_image_name requires id_image".to_string());
     }
 
-    let Some(family) = identity_family(&req.model) else {
+    let Some(family) = identity_family_with_hint(&req.model, family_hint) else {
         return Err(identity_model_gate_message(&req.model));
     };
 
@@ -1420,8 +1432,16 @@ mod tests {
     }
 
     #[test]
-    fn qualified_models_accept_every_resolved_spelling() {
-        for name in ["flux-dev", "flux-dev:q4", "flux-dev:q8", "flux-dev-q4"] {
+    fn family_wide_models_accept_resolved_spellings_and_variants() {
+        for name in [
+            "flux-dev",
+            "flux-dev:q4",
+            "flux-dev:bf16",
+            "flux-dev-q4",
+            "flux-schnell:q8",
+            "flux-krea:fp8",
+            "jibmix-flux:q4",
+        ] {
             assert_eq!(
                 identity_family(name),
                 Some(IdentityFamily::Flux),
@@ -1436,6 +1456,9 @@ mod tests {
             "juggernaut-xl:fp16",
             "realvis-xl:fp16",
             "dreamshaper-xl:fp16",
+            "playground-v2.5:fp16",
+            "pony-v6:fp16",
+            "cyberrealistic-pony:fp16",
         ] {
             assert_eq!(
                 identity_family(name),
@@ -1446,13 +1469,12 @@ mod tests {
     }
 
     #[test]
-    fn unqualified_models_are_rejected() {
+    fn other_families_and_sdxl_turbo_are_rejected() {
         for name in [
-            "flux-dev:bf16",
             "flux-dev:fp8",
-            "flux-schnell",
-            "flux-schnell:q8",
             "flux2-klein",
+            "sdxl-turbo",
+            "sdxl-turbo:fp16",
             "sdxl",
             "qwen-image",
             "",
@@ -1464,51 +1486,51 @@ mod tests {
         }
     }
 
-    /// Every `family: "sdxl"` manifest entry is decided explicitly. A future
-    /// SDXL checkpoint therefore lands in this test as an unreviewed name
-    /// rather than silently inheriting qualification from its family — the
-    /// whole reason [`IDENTITY_QUALIFIED_SDXL_MODELS`] is enumerated.
     #[test]
-    fn every_sdxl_manifest_entry_has_a_recorded_identity_decision() {
-        let qualified = ["sdxl-base", "juggernaut-xl", "realvis-xl", "dreamshaper-xl"];
-        let refused = [
-            "sdxl-turbo",
-            "playground-v2.5",
-            "pony-v6",
-            "cyberrealistic-pony",
-        ];
-
-        let entries: Vec<String> = crate::manifest::known_manifests()
-            .iter()
-            .filter(|manifest| manifest.family == "sdxl")
-            .map(|manifest| manifest.name.clone())
-            .collect();
+    fn opaque_catalog_ids_use_the_resolved_family_without_overriding_known_models() {
         assert_eq!(
-            entries.len(),
-            qualified.len() + refused.len(),
-            "an SDXL manifest entry appeared or vanished without an identity \
-             decision: {entries:?}"
+            identity_family_with_hint("cv:123", Some("flux")),
+            Some(IdentityFamily::Flux)
         );
+        assert_eq!(
+            identity_family_with_hint("hf:owner/sdxl-finetune", Some("sdxl")),
+            Some(IdentityFamily::Sdxl)
+        );
+        assert_eq!(identity_family_with_hint("cv:123", None), None);
+        assert_eq!(
+            identity_family_with_hint("sdxl-turbo:fp16", Some("sdxl")),
+            None,
+            "a family hint must not override the canonical Turbo exception"
+        );
+        assert_eq!(
+            identity_family_with_hint("flux2-klein:q8", Some("flux")),
+            None,
+            "a family hint must not override a known manifest architecture"
+        );
+    }
 
-        for name in &entries {
-            let base = name.split(':').next().unwrap();
-            if qualified.contains(&base) {
-                assert_eq!(
-                    identity_family(name),
-                    Some(IdentityFamily::Sdxl),
-                    "{name} is on the qualified list"
-                );
+    /// Identity compatibility follows the engine architecture. New FLUX.1 and
+    /// SDXL manifests inherit support automatically, while Turbo remains an
+    /// explicit reviewed exception.
+    #[test]
+    fn every_flux_and_non_turbo_sdxl_manifest_supports_identity() {
+        for manifest in crate::manifest::known_manifests()
+            .iter()
+            .filter(|manifest| matches!(manifest.family.as_str(), "flux" | "sdxl"))
+        {
+            let expected = if manifest.family == "flux" {
+                Some(IdentityFamily::Flux)
+            } else if IDENTITY_EXCLUDED_SDXL_MODELS.contains(&manifest.name.as_str()) {
+                None
             } else {
-                assert!(
-                    refused.contains(&base),
-                    "{name} has no recorded identity decision"
-                );
-                assert_eq!(
-                    identity_family(name),
-                    None,
-                    "{name} is deliberately refused"
-                );
-            }
+                Some(IdentityFamily::Sdxl)
+            };
+            assert_eq!(
+                identity_family(&manifest.name),
+                expected,
+                "{}",
+                manifest.name
+            );
         }
     }
 
@@ -1532,21 +1554,18 @@ mod tests {
         assert_eq!(IdentityFamily::Sdxl.family(), "sdxl");
     }
 
-    /// The union a refusal names is composed from the per-family lists, so a
-    /// family added to [`IdentityFamily::ALL`] cannot be missing from it.
+    /// The public inventory is the exact family-derived set.
     #[test]
-    fn the_qualified_union_is_every_familys_list() {
+    fn the_qualified_union_is_every_supported_manifest() {
         let union = identity_qualified_models();
-        for family in IdentityFamily::ALL.iter().copied() {
-            for model in family.qualified_models() {
-                assert!(union.contains(model), "{model} missing from the union");
-                assert_eq!(identity_family(model), Some(family));
-            }
+        for manifest in crate::manifest::known_manifests() {
+            assert_eq!(
+                union.contains(&manifest.name.as_str()),
+                identity_family(&manifest.name).is_some(),
+                "{}",
+                manifest.name
+            );
         }
-        assert_eq!(
-            union.len(),
-            IDENTITY_QUALIFIED_FLUX_MODELS.len() + IDENTITY_QUALIFIED_SDXL_MODELS.len()
-        );
     }
 
     /// The three extracted helpers are what the TUI and the Discord bot call
@@ -1557,9 +1576,8 @@ mod tests {
     fn extracted_helpers_match_the_request_validator_wording() {
         assert_eq!(
             identity_model_gate_message("sdxl"),
-            "sdxl does not support face-identity conditioning; identity is qualified only for \
-             flux-dev:q4, flux-dev:q8, sdxl-base:fp16, juggernaut-xl:fp16, realvis-xl:fp16, \
-             dreamshaper-xl:fp16"
+            "sdxl does not support face-identity conditioning; identity is supported for FLUX.1 \
+             and SDXL checkpoints except sdxl-turbo:fp16"
         );
 
         assert!(validate_id_weight(0.0).is_ok());
@@ -1750,7 +1768,16 @@ mod tests {
     #[cfg(feature = "pulid")]
     #[test]
     fn identity_conditioning_accepts_a_qualified_request() {
-        for model in ["flux-dev", "flux-dev:q4", "flux-dev:q8", "flux-dev-q4"] {
+        for model in [
+            "flux-dev",
+            "flux-dev:q4",
+            "flux-dev:q8",
+            "flux-dev:bf16",
+            "flux-dev-q4",
+            "flux-schnell:q8",
+            "flux-krea:fp8",
+            "jibmix-flux:q4",
+        ] {
             let mut req = identity_request(model);
             req.id_weight = Some(ID_WEIGHT_MAX);
             req.id_start_step = Some(req.steps - 1);
@@ -1882,24 +1909,19 @@ mod tests {
 
         let cases = [
             Case {
-                name: "unqualified quantization",
-                mutate: |req| req.model = "flux-dev:bf16".to_string(),
-                expect: "flux-dev:q8",
-            },
-            Case {
-                name: "unqualified flux checkpoint",
-                mutate: |req| req.model = "flux-schnell".to_string(),
-                expect: "flux-dev:q8",
+                name: "excluded sdxl turbo checkpoint",
+                mutate: |req| req.model = "sdxl-turbo".to_string(),
+                expect: "except sdxl-turbo:fp16",
             },
             Case {
                 name: "unqualified family flux2",
                 mutate: |req| req.model = "flux2-klein".to_string(),
-                expect: "flux-dev:q8",
+                expect: "FLUX.1 and SDXL",
             },
             Case {
                 name: "unqualified family sdxl",
                 mutate: |req| req.model = "sdxl".to_string(),
-                expect: "flux-dev:q4",
+                expect: "FLUX.1 and SDXL",
             },
             Case {
                 name: "weight above the range",
@@ -2027,7 +2049,7 @@ mod tests {
     /// before it reaches any of them.
     #[cfg(feature = "pulid")]
     #[test]
-    fn the_model_refusal_names_every_supported_model() {
+    fn the_model_refusal_names_the_supported_families_and_exception() {
         let mut req = identity_request("sdxl");
         if !IDENTITY_RUNTIME_READY {
             assert_runtime_pending(validate_identity_conditioning(&req), "unqualified model");
@@ -2036,9 +2058,9 @@ mod tests {
             return;
         }
         let error = validate_identity_conditioning(&req).unwrap_err();
-        for model in identity_qualified_models() {
-            assert!(error.contains(model), "{model} must be named: {error}");
-        }
+        assert!(error.contains("FLUX.1"), "{error}");
+        assert!(error.contains("SDXL"), "{error}");
+        assert!(error.contains("sdxl-turbo:fp16"), "{error}");
         req.model = "flux-dev:q4".to_string();
         assert!(validate_identity_conditioning(&req).is_ok());
     }
@@ -2444,7 +2466,10 @@ mod tests {
         if !identity_runtime_available() {
             return;
         }
-        for model in IDENTITY_QUALIFIED_SDXL_MODELS {
+        for model in identity_qualified_models()
+            .into_iter()
+            .filter(|model| identity_family(model) == Some(IdentityFamily::Sdxl))
+        {
             let mut req = identity_request(model);
             req.true_cfg = Some(2.0);
             assert_eq!(
@@ -2481,7 +2506,10 @@ mod tests {
         if !identity_runtime_available() {
             return;
         }
-        for model in IDENTITY_QUALIFIED_SDXL_MODELS {
+        for model in identity_qualified_models()
+            .into_iter()
+            .filter(|model| identity_family(model) == Some(IdentityFamily::Sdxl))
+        {
             let mut plain = identity_request(model);
             validate_identity_conditioning(&plain)
                 .unwrap_or_else(|error| panic!("{model} must be accepted: {error}"));
@@ -2530,7 +2558,10 @@ mod tests {
     /// a plausible print with most of the identity cancelled out.
     #[test]
     fn the_unconditional_identity_is_needed_by_every_sdxl_render_and_only_true_cfg_flux() {
-        for model in IDENTITY_QUALIFIED_SDXL_MODELS {
+        for model in identity_qualified_models()
+            .into_iter()
+            .filter(|model| identity_family(model) == Some(IdentityFamily::Sdxl))
+        {
             let req = identity_request(model);
             assert!(
                 request_needs_unconditional_identity(&req),
@@ -2550,6 +2581,16 @@ mod tests {
         let mut true_cfg = identity_request("flux-dev:q8");
         true_cfg.true_cfg = Some(2.0);
         assert!(request_needs_unconditional_identity(&true_cfg));
+
+        let catalog_sdxl = identity_request("cv:123");
+        assert!(request_needs_unconditional_identity_for_family(
+            &catalog_sdxl,
+            Some(IdentityFamily::Sdxl)
+        ));
+        assert!(!request_needs_unconditional_identity_for_family(
+            &catalog_sdxl,
+            Some(IdentityFamily::Flux)
+        ));
 
         // No photograph, no extraction, nothing to compute.
         let mut bare = crate::test_support::minimal_generate_request("sdxl-base:fp16");

--- a/crates/mold-core/src/manifest.rs
+++ b/crates/mold-core/src/manifest.rs
@@ -5047,6 +5047,14 @@ pub const PULID_FLUX_MANIFEST: &str = "pulid-flux";
 pub fn auxiliary_manifests_for_request(
     request: &crate::types::GenerateRequest,
 ) -> Vec<&'static str> {
+    auxiliary_manifests_for_request_with_family(request, None)
+}
+
+/// Family-aware auxiliary bundle lookup for opaque live-catalog model ids.
+pub fn auxiliary_manifests_for_request_with_family(
+    request: &crate::types::GenerateRequest,
+    family_hint: Option<&str>,
+) -> Vec<&'static str> {
     let mut manifests = Vec::new();
     if crate::identity::request_mentions_identity(request)
         && crate::identity::effective_id_weight(request) > 0.0
@@ -5054,7 +5062,9 @@ pub fn auxiliary_manifests_for_request(
         // The bundle follows the checkpoint's family — `pulid-flux` or
         // `pulid-sdxl` — through the one identity authority; a model no family
         // qualifies needs no bundle because admission refuses it first.
-        if let Some(family) = crate::identity::identity_family(&request.model) {
+        if let Some(family) =
+            crate::identity::identity_family_with_hint(&request.model, family_hint)
+        {
             manifests.push(family.manifest());
         }
     }
@@ -6823,6 +6833,17 @@ mod tests {
         assert_eq!(
             auxiliary_manifests_for_request(&request_for("flux-dev")),
             vec![PULID_FLUX_MANIFEST]
+        );
+        assert_eq!(
+            auxiliary_manifests_for_request_with_family(&request_for("cv:123"), Some("flux")),
+            vec![PULID_FLUX_MANIFEST]
+        );
+        assert_eq!(
+            auxiliary_manifests_for_request_with_family(
+                &request_for("hf:owner/sdxl-finetune"),
+                Some("sdxl")
+            ),
+            vec![PULID_SDXL_MANIFEST]
         );
         assert!(
             auxiliary_manifests_for_request(&request_for("sdxl-turbo:fp16")).is_empty(),

--- a/crates/mold-core/src/types.rs
+++ b/crates/mold-core/src/types.rs
@@ -1240,10 +1240,9 @@ pub struct GenerateRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_fit: Option<serde_json::Value>,
     /// Face-identity reference image for identity conditioning (raw PNG/JPEG
-    /// bytes, base64-encoded in JSON). Milestone 1 accepts this only on the
-    /// identity-qualified checkpoints named by
-    /// `mold_core::identity::identity_qualified_models()`, and never alongside
-    /// a LoRA or an img2img `source_image`. The payload is bounds-checked
+    /// bytes, base64-encoded in JSON). Accepted family-wide on FLUX.1 and SDXL
+    /// except for SDXL Turbo, and never alongside a LoRA or an img2img
+    /// `source_image`. The payload is bounds-checked
     /// from its header alone before any decode
     /// (`identity::validate_id_image_bytes`).
     #[serde(default, skip_serializing_if = "Option::is_none", with = "base64_opt")]

--- a/crates/mold-core/src/validation.rs
+++ b/crates/mold-core/src/validation.rs
@@ -1971,7 +1971,7 @@ fn validate_generate_request_after_activation(
     }
     // Face-identity conditioning is its own contract; `crate::identity` owns
     // every rule so this validator does not grow a second authority.
-    crate::identity::validate_identity_conditioning(req)?;
+    crate::identity::validate_identity_conditioning_with_family(req, family)?;
     if req.batch_size == 0 {
         return Err("batch_size must be >= 1".to_string());
     }
@@ -6492,9 +6492,19 @@ mod tests {
             .expect("flux-dev resolves to the qualified flux-dev:q8");
 
         req.model = "flux-dev:bf16".to_string();
+        validate_generate_request_with_family(&req, None)
+            .expect("identity support applies to every FLUX.1 quantization");
+
+        req.model = "cv:123".to_string();
+        validate_generate_request_with_family(&req, Some("flux"))
+            .expect("a catalog-installed FLUX model uses its resolved family");
+        req.model = "hf:owner/sdxl-finetune".to_string();
+        validate_generate_request_with_family(&req, Some("sdxl"))
+            .expect("a catalog-installed SDXL model uses its resolved family");
+
+        req.model = "sdxl-turbo:fp16".to_string();
         let error = validate_generate_request_with_family(&req, None).unwrap_err();
-        assert!(error.contains("flux-dev:q4"), "{error}");
-        assert!(error.contains("flux-dev:q8"), "{error}");
+        assert!(error.contains("except sdxl-turbo:fp16"), "{error}");
 
         // A knob without the reference is refused, never silently ignored.
         let mut bare = valid_req();

--- a/crates/mold-inference/src/engine.rs
+++ b/crates/mold-inference/src/engine.rs
@@ -292,8 +292,8 @@ pub trait InferenceEngine: Send + Sync {
         if embedding.is_some() {
             anyhow::bail!(
                 "this engine does not support face-identity conditioning; \
-                 identity is qualified only for {}",
-                mold_core::identity::identity_qualified_models().join(", ")
+                 identity is supported for FLUX.1 and SDXL checkpoints except \
+                 sdxl-turbo:fp16"
             );
         }
         Ok(())

--- a/crates/mold-inference/src/factory.rs
+++ b/crates/mold-inference/src/factory.rs
@@ -411,8 +411,10 @@ pub fn create_engine_with_pool(
     // prefix does not exist. `identity_family` is the same authority admission
     // uses, so the forced-local and served paths choose identically.
     if frozen.identity_assets.is_none() {
-        frozen.identity_assets = mold_core::identity::identity_family(&model_name)
-            .and_then(|family| mold_core::pulid_assets::pulid_paths_for(config, family));
+        let family_hint = config.resolved_model_config(&model_name).family;
+        frozen.identity_assets =
+            mold_core::identity::identity_family_with_hint(&model_name, family_hint.as_deref())
+                .and_then(|family| mold_core::pulid_assets::pulid_paths_for(config, family));
     }
     create_engine_with_frozen_config(
         model_name,

--- a/crates/mold-server/src/identity_dependencies.rs
+++ b/crates/mold-server/src/identity_dependencies.rs
@@ -31,8 +31,8 @@ use crate::variant_dependencies::{
 /// engine and therefore what decides which adapter the checkpoint can accept:
 /// PuLID-FLUX injects between transformer blocks, PuLID v1.1 injects into the
 /// UNet's cross-attentions, and neither file loads in the other's engine.
-/// `mold_core::identity` already restricts identity conditioning to the
-/// enumerated qualified checkpoints at the request boundary, so reaching this
+/// `mold_core::identity` already restricts identity conditioning to supported
+/// FLUX.1/SDXL checkpoints at the request boundary, so reaching this
 /// with an unconditioning family means that gate was bypassed. Refusing is
 /// deliberate: an identity that is accepted and then silently ignored is the
 /// failure this slice exists to prevent.
@@ -59,7 +59,9 @@ fn identity_family_for(request: &GenerateRequest, family: &str) -> Result<Identi
     // `routes::placement_preview_for_request_authenticated` — the same seam the
     // source-image contract uses, and for the same reason, so a preview can
     // never plan a bundle for a request generation would refuse.
-    if let Some(from_model) = mold_core::identity::identity_family(&request.model) {
+    if let Some(from_model) =
+        mold_core::identity::identity_family_with_hint(&request.model, Some(family))
+    {
         if from_model != resolved {
             return Err(format!(
                 "identity conditioning for '{}' expects model family '{}', but this model \

--- a/crates/mold-server/src/identity_extraction.rs
+++ b/crates/mold-server/src/identity_extraction.rs
@@ -317,7 +317,11 @@ pub fn resolve_identity_for_lease(
     // — FLUX's true-CFG opt-in versus SDXL's always-on classifier-free
     // negative pass — and `mold_core::identity` owns it so this and the
     // engine's own requirement cannot disagree.
-    let want_uncond = mold_core::identity::request_needs_unconditional_identity(request);
+    let resolved_family = paths.map(|paths| paths.family);
+    let want_uncond = mold_core::identity::request_needs_unconditional_identity_for_family(
+        request,
+        resolved_family,
+    );
     let Some(paths) = paths.cloned() else {
         // A missing bundle is a machine that has not been provisioned, not a
         // photograph the caller can fix — but it is equally not a fault the
@@ -327,7 +331,8 @@ pub fn resolve_identity_for_lease(
             "this request asks for face-identity conditioning but no PuLID bundle resolved \
                  on any eligible device; run `mold pull {bundle} --accept-license \
                  insightface-antelopev2`",
-            bundle = mold_core::identity::identity_family(&request.model)
+            bundle = resolved_family
+                .or_else(|| mold_core::identity::identity_family(&request.model))
                 .map(mold_core::identity::IdentityFamily::manifest)
                 .unwrap_or(mold_core::manifest::PULID_FLUX_MANIFEST),
         )));
@@ -661,6 +666,24 @@ mod tests {
         assert_eq!(
             frozen.source_sha256(),
             mold_core::identity::id_image_sha256(b"pretend-png")
+        );
+    }
+
+    #[test]
+    fn an_opaque_catalog_sdxl_request_uses_the_planned_family_for_unconditional_identity() {
+        let _stubbed = StubbedExtractor::install(stub);
+        let mut request = request(None);
+        request.model = "hf:owner/sdxl-finetune".to_string();
+        let mut sdxl_paths = paths();
+        sdxl_paths.family = mold_core::identity::IdentityFamily::Sdxl;
+        let frozen =
+            resolve_identity_for_lease(&request, Some(&sdxl_paths), LEASED_BACKEND, LEASED_ORDINAL)
+                .expect("the catalog SDXL request extracts")
+                .embedding
+                .expect("the request is conditioned");
+        assert!(
+            frozen.has_uncond(),
+            "SDXL's ordinary classifier-free branch needs the unconditional identity"
         );
     }
 

--- a/crates/mold-server/src/memory_preflight.rs
+++ b/crates/mold-server/src/memory_preflight.rs
@@ -753,12 +753,26 @@ pub(crate) fn identity_overhead_family(
     identity_overhead_family_with_projection(req, None)
 }
 
+#[cfg(test)]
 pub(crate) fn identity_overhead_family_with_projection(
     req: &GenerateRequest,
     projection: Option<&crate::queue_media_store::QueueMediaProjection>,
 ) -> Option<mold_core::identity::IdentityFamily> {
+    identity_overhead_family_with_projection_and_hint(req, projection, None)
+}
+
+fn identity_overhead_family_with_projection_and_hint(
+    req: &GenerateRequest,
+    projection: Option<&crate::queue_media_store::QueueMediaProjection>,
+    hint: Option<ActivationHint>,
+) -> Option<mold_core::identity::IdentityFamily> {
+    let family_hint = hint.and_then(|hint| match hint.family {
+        ActivationFamily::FluxDit => Some("flux"),
+        ActivationFamily::SdxlUnet => Some("sdxl"),
+        _ => None,
+    });
     request_charges_identity_overhead_with_projection(req, projection)
-        .then(|| mold_core::identity::identity_family(&req.model))
+        .then(|| mold_core::identity::identity_family_with_hint(&req.model, family_hint))
         .flatten()
 }
 
@@ -1590,7 +1604,7 @@ pub(crate) fn estimate_generation_memory_for_request_with_projection(
     // The adapter term follows the FAMILY, because the adapter does. The
     // extraction term does not: the detector, recognizer, parser, and tower are
     // shared, and only the IDFormer's prefix differs.
-    let peak = match identity_overhead_family_with_projection(req, projection) {
+    let peak = match identity_overhead_family_with_projection_and_hint(req, projection, hint) {
         Some(family) => peak
             .saturating_add(identity_adapter_overhead_bytes(family))
             .saturating_add(IDENTITY_EXTRACTION_VRAM_OVERHEAD_BYTES),
@@ -2975,6 +2989,26 @@ mod fail_closed_tests {
         assert_eq!(
             identity_overhead_family(&flux),
             Some(mold_core::identity::IdentityFamily::Flux)
+        );
+
+        let mut catalog = flux.clone();
+        catalog.model = "cv:123".to_string();
+        assert_eq!(identity_overhead_family(&catalog), None);
+        assert_eq!(
+            identity_overhead_family_with_projection_and_hint(
+                &catalog,
+                None,
+                Some(hint(ActivationFamily::FluxDit))
+            ),
+            Some(mold_core::identity::IdentityFamily::Flux)
+        );
+        assert_eq!(
+            identity_overhead_family_with_projection_and_hint(
+                &catalog,
+                None,
+                Some(hint(ActivationFamily::SdxlUnet))
+            ),
+            Some(mold_core::identity::IdentityFamily::Sdxl)
         );
 
         let mut turbo = sdxl.clone();

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -4430,7 +4430,10 @@ async fn placement_preview_for_request_authenticated(
     // `id_image` — or a build without the `pulid` feature, or a LoRA beside
     // the photograph — would have its preview plan the PuLID bundle and
     // answer `planned` for a request generation then refuses.
-    if let Err(error) = mold_core::identity::validate_identity_conditioning(&request) {
+    if let Err(error) = mold_core::identity::validate_identity_conditioning_with_family(
+        &request,
+        resolved_family.as_deref(),
+    ) {
         let mut response = unavailable("infeasible", error);
         response.authoritative = true;
         return Ok(response);

--- a/crates/mold-server/src/routes_test.rs
+++ b/crates/mold-server/src/routes_test.rs
@@ -10175,8 +10175,7 @@ mod tests {
             }
         };
 
-        // A refused SDXL tier: qualification is enumerated, not inherited
-        // from the family.
+        // The sole refused SDXL tier remains an explicit family exception.
         let body = preview("sdxl-turbo:fp16").await;
         assert_eq!(body["outcome"], "infeasible");
         assert_eq!(body["authoritative"], true);

--- a/crates/mold-tui/src/backend.rs
+++ b/crates/mold-tui/src/backend.rs
@@ -896,7 +896,10 @@ async fn prepare_local_licensed_dependencies(
     config: &mold_core::Config,
     tx: &mpsc::UnboundedSender<BackgroundEvent>,
 ) -> Result<(), String> {
-    for bundle in mold_core::manifest::auxiliary_manifests_for_request(request) {
+    let family = config.resolved_model_config(&request.model).family;
+    for bundle in
+        mold_core::manifest::auxiliary_manifests_for_request_with_family(request, family.as_deref())
+    {
         if config.manifest_model_needs_download(bundle) {
             pull_local_model_with_consent(bundle.to_string(), tx.clone()).await?;
         }

--- a/docs/architecture/pulid-uat.md
+++ b/docs/architecture/pulid-uat.md
@@ -5,6 +5,10 @@ The record of what was actually run on real hardware to close the
 measured numbers. Everything below is reproducible; where a check could not be
 run, this says so rather than omitting it.
 
+> **Historical qualification snapshot:** the model lists below record what was
+> tested when PuLID first shipped. Current admission is family-wide for FLUX.1
+> and SDXL, with `sdxl-turbo:fp16` as the sole SDXL exception.
+
 ## Hosts
 
 | Host | Backend | GPU | Build | Mold home |

--- a/docs/architecture/pulid.md
+++ b/docs/architecture/pulid.md
@@ -704,10 +704,9 @@ which the scheduler's learned phase timings observe rather than predict.
   Discord surfaces. #1226 shipped the contract, the runtime, and the CLI only.
   SDXL gets both for free once those surfaces gate on `supports_identity`
   rather than a hard-coded FLUX check, since neither is family-specific.
-- Identity on FLUX/SDXL tiers beyond the qualified list (see `CLAUDE.md`'s
-  identity bullets), alongside a LoRA, or alongside img2img. All three are
-  refused by name at the request contract; a later qualification pass owns
-  them.
+- Identity alongside a LoRA or img2img. Both combinations remain refused by
+  name at the request contract; a later qualification pass owns them. FLUX.1
+  and non-Turbo SDXL checkpoints are supported family-wide.
 - **`StableDiffusionConfig` exposes no accessor for its `unet` field**, so
   `sdxl::pulid::sdxl_unet_layout()` is mold's own copy of the published SDXL
   `unet/config.json` rather than reading it off the loaded config. A one-line
@@ -717,7 +716,7 @@ which the scheduler's learned phase timings observe rather than predict.
 - **No PuLID checkpoint exists yet for SD1.5.** `plan_attn_layers` already
   handles its geometry (16 `attn2` modules, pinned against
   `attn_layer_map_sd15.json`), so if one is ever published the remaining work
-  is a manifest entry and a qualified-model list entry, not a new adapter.
+  is a manifest entry and a new identity-family mapping, not a new adapter.
 - **PuLID weights are opened by pathname, on both families** — a
   cross-family hardening issue rather than a per-PR fix. `SdxlPulidAdapter::load`
   and `flux::pulid`'s loader, plus the `id_adapter.*` / `pulid_encoder.*`


### PR DESCRIPTION
## Summary

- derive PuLID support from the resolved FLUX.1 or SDXL architecture instead of a checkpoint allowlist
- retain `sdxl-turbo:fp16` as the sole SDXL exception and keep known manifests authoritative
- carry live-catalog `cv:`/`hf:` families through capability advertising, admission, bundle selection, VRAM pricing, forced-local/TUI preparation, and SDXL unconditional identity extraction
- update CLI help, embedded skill guidance, README, and architecture docs

## Verification

- `nix develop -c cargo test -p mold-ai-core --features pulid identity::tests --lib`
- `nix develop -c cargo test -p mold-ai-core --features pulid generation_profile::tests::identity --lib`
- `nix develop -c cargo test -p mold-ai-core --features pulid validation::tests::generate_request_validation_enforces_identity_conditioning --lib`
- `nix develop -c cargo test -p mold-ai-core --features pulid manifest::tests::request_auxiliary_bundle_follows_the_identity_family --lib`
- `nix develop -c cargo test -p mold-ai-server --features pulid identity_extraction::tests::an_opaque_catalog_sdxl_request_uses_the_planned_family_for_unconditional_identity --lib`
- `nix develop -c cargo test -p mold-ai-server --features pulid memory_preflight::fail_closed_tests::the_identity_charge_follows_the_family_of_the_requested_model --lib`
- `nix develop -c cargo test -p mold-ai-server --features pulid identity --lib`
- `nix develop -c cargo clippy -p mold-ai-core -p mold-ai-server -p mold-ai-inference -p mold-ai-tui --features mold-ai-server/pulid --all-targets -- -D warnings`
- independent agent peer review approved after its catalog-model finding was addressed