### PR TITLE
fix: harden remix parsing and library hydration

### DIFF
--- a/changelog.d/remix-library-hydration.md
+++ b/changelog.d/remix-library-hydration.md
@@ -1,0 +1,4 @@
+- **Reliable remixes and Library thumbnails.** Remix now ignores model reasoning
+  and safely extracts the requested prompt set, while Library thumbnails render
+  immediately, recover after returning to the app, and find collection covers
+  from any available host.

--- a/crates/mold-core/src/expand.rs
+++ b/crates/mold-core/src/expand.rs
@@ -458,47 +458,83 @@ pub fn clean_expanded_prompt_public(text: &str) -> String {
 /// Parse multiple variations from LLM output.
 /// Tries JSON array first, then numbered list, then line-separated.
 fn parse_variations(text: &str, expected: usize) -> Vec<String> {
-    let trimmed = text.trim();
+    let trimmed = strip_thinking_preamble(text);
 
     // Try JSON array
     if let Ok(arr) = serde_json::from_str::<Vec<String>>(trimmed) {
         if !arr.is_empty() {
-            return arr.into_iter().map(|s| clean_expanded_prompt(&s)).collect();
+            return arr
+                .into_iter()
+                .take(expected)
+                .map(|s| clean_expanded_prompt(&s))
+                .collect();
         }
     }
 
-    // Try to find a JSON array embedded in the text (LLM may include preamble)
-    if let Some(start) = trimmed.find('[') {
-        if let Some(end) = trimmed.rfind(']') {
-            if start < end {
-                let json_slice = &trimmed[start..=end];
-                if let Ok(arr) = serde_json::from_str::<Vec<String>>(json_slice) {
-                    if !arr.is_empty() {
+    // Try every bracket-bounded slice so prose brackets cannot swallow a
+    // later JSON array. Prefer an exact candidate; a sole short candidate is
+    // retained for the exact-count retry. Multiple singleton arrays belong to
+    // the line-oriented compatibility fallback below.
+    let starts = trimmed.match_indices('[').map(|(index, _)| index);
+    let ends = trimmed
+        .match_indices(']')
+        .map(|(index, _)| index)
+        .collect::<Vec<_>>();
+    let mut embedded = Vec::new();
+    for start in starts {
+        for &end in ends.iter().filter(|&&end| end > start) {
+            if let Ok(arr) = serde_json::from_str::<Vec<String>>(&trimmed[start..=end]) {
+                if !arr.is_empty() {
+                    if arr.len() == expected {
                         return arr.into_iter().map(|s| clean_expanded_prompt(&s)).collect();
                     }
+                    embedded.push(arr);
                 }
             }
         }
     }
+    if embedded.len() == 1 {
+        return embedded
+            .pop()
+            .unwrap()
+            .into_iter()
+            .take(expected)
+            .map(|s| clean_expanded_prompt(&s))
+            .collect();
+    }
 
-    // Fall back to numbered list parsing (1. ... 2. ... etc.)
-    let lines: Vec<String> = trimmed
+    // Fall back to a genuine consecutive numbered list (1. ... 2. ... etc.).
+    // An oversize unnumbered response is ambiguous and must reach the exact
+    // count guard unchanged rather than turning reasoning into prompts.
+    let raw_lines = trimmed
         .lines()
         .map(|l| l.trim())
         .filter(|l| !l.is_empty())
-        .map(|l| {
-            // Strip numbered prefix: "1. ", "2) ", etc.
-            let stripped = l
-                .trim_start_matches(|c: char| c.is_ascii_digit())
-                .trim_start_matches(['.', ')', ':', '-'])
-                .trim_start_matches('"')
-                .trim_end_matches('"')
-                .trim();
-            clean_expanded_prompt(stripped)
-        })
-        .filter(|l| !l.is_empty())
-        .collect();
+        .collect::<Vec<_>>();
+    let numbered = raw_lines
+        .iter()
+        .map(|line| parse_numbered_variation(line))
+        .collect::<Option<Vec<_>>>();
+    if let Some(numbered) = numbered {
+        if numbered
+            .iter()
+            .enumerate()
+            .all(|(index, (number, _))| *number == index + 1)
+            && numbered.len() >= expected
+        {
+            return numbered
+                .into_iter()
+                .take(expected)
+                .map(|(_, prompt)| prompt)
+                .collect();
+        }
+    }
 
+    let lines = raw_lines
+        .iter()
+        .map(|line| clean_expanded_prompt(line))
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>();
     if lines.len() >= expected {
         return lines;
     }
@@ -516,6 +552,31 @@ fn parse_variations(text: &str, expected: usize) -> Vec<String> {
 
     // Ultimate fallback: return the whole text as a single variation
     vec![clean_expanded_prompt(trimmed)]
+}
+
+/// Remove a complete Qwen-style reasoning preamble before structural parsing.
+/// Thinking may still appear even when disabled, and its prose can contain
+/// brackets or numbered lines that must never be mistaken for variations.
+fn strip_thinking_preamble(text: &str) -> &str {
+    let trimmed = text.trim();
+    if trimmed.starts_with("<think>") {
+        if let Some(end) = trimmed.rfind("</think>") {
+            return trimmed[end + "</think>".len()..].trim();
+        }
+    }
+    trimmed
+}
+
+fn parse_numbered_variation(line: &str) -> Option<(usize, String)> {
+    let digit_len = line.bytes().take_while(u8::is_ascii_digit).count();
+    if digit_len == 0 {
+        return None;
+    }
+    let number = line[..digit_len].parse().ok()?;
+    let rest = line[digit_len..].trim_start();
+    let rest = rest.strip_prefix(['.', ')', ':', '-'])?.trim();
+    let prompt = clean_expanded_prompt(rest);
+    (!prompt.is_empty()).then_some((number, prompt))
 }
 
 /// Clean up an expanded prompt: trim whitespace, remove quotes, collapse whitespace.
@@ -829,6 +890,57 @@ mod tests {
         // parse_variations should find the embedded JSON array.
         let result = parse_variations(input, 3);
         assert_eq!(result.len(), 3);
+    }
+
+    #[test]
+    fn parse_variations_ignores_brackets_and_lines_in_thinking() {
+        let input = r#"<think>
+I need four alternatives [composition, camera, lighting, setting].
+1. Preserve the subject.
+2. Keep the action.
+3. Return JSON.
+</think>
+["wide composition", "low camera", "rim lighting", "desert setting"]"#;
+        let result = parse_variations(input, 4);
+        assert_eq!(
+            result,
+            vec![
+                "wide composition",
+                "low camera",
+                "rim lighting",
+                "desert setting"
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_variations_caps_backend_overshoot_to_requested_count() {
+        let json = r#"["one", "two", "three", "four", "five"]"#;
+        assert_eq!(
+            parse_variations(json, 4),
+            vec!["one", "two", "three", "four"]
+        );
+
+        let numbered = "1. one\n2. two\n3. three\n4. four\n5. five";
+        assert_eq!(
+            parse_variations(numbered, 4),
+            vec!["one", "two", "three", "four"]
+        );
+    }
+
+    #[test]
+    fn parse_variations_does_not_truncate_ambiguous_overshoot() {
+        let input =
+            "First I will preserve the subject.\nThen vary the camera.\none\ntwo\nthree\nfour";
+        let result = parse_variations(input, 4);
+        assert_eq!(result.len(), 6);
+        assert_eq!(result[0], "First I will preserve the subject.");
+    }
+
+    #[test]
+    fn parse_variations_accepts_short_json_after_prose_brackets_for_retry() {
+        let input = "Consider [composition and lighting].\n[\"prompt one\", \"prompt two\"]";
+        assert_eq!(parse_variations(input, 4), vec!["prompt one", "prompt two"]);
     }
 
     #[test]

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -7122,6 +7122,64 @@ describe("MobileApp primary navigation", () => {
 });
 
 describe("MobileApp gallery", () => {
+  it("hydrates a live gallery replacement when its cached keys are unchanged", async () => {
+    Object.defineProperty(globalThis, "indexedDB", {
+      configurable: true,
+      value: new IDBFactory(),
+    });
+    localStorage.setItem(
+      "mold.mobile.hosts.v1",
+      JSON.stringify([
+        {
+          id: "url-derived-id",
+          instanceId: "studio-instance",
+          name: "Studio",
+          baseUrl: target.baseUrl,
+          online: true,
+        },
+      ]),
+    );
+    await storeCachedGallery("studio-instance", [print]);
+    await storeCachedGalleryMedia(
+      "studio-instance",
+      print.filename,
+      "thumbnail",
+      new Blob(["cached thumbnail"], { type: "image/webp" }),
+    );
+    const liveGallery = deferred<GalleryImage[]>();
+    apiJsonTo.mockImplementation((_target: unknown, path: string) => {
+      if (path === "/api/status")
+        return Promise.resolve({ ...status, instance_id: "studio-instance" });
+      if (path === "/api/models") return Promise.resolve([model]);
+      if (path === "/api/capabilities") return Promise.resolve(null);
+      if (path === "/api/gallery") return liveGallery.promise;
+      if (path === "/api/activity")
+        return Promise.resolve({
+          instance_id: "studio-instance",
+          observed_at_unix_ms: 1,
+          items: [],
+        });
+      return Promise.reject(new Error(`Unexpected API path: ${path}`));
+    });
+
+    wrapper = mountMobileApp();
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-tab-gallery']").trigger("click");
+    // Cached metadata hydrates behind the loading surface while the live host
+    // read is pending. Wait for those bytes to resolve before replacing the
+    // proxies with the same physical keys.
+    await vi.waitFor(() => expect(URL.createObjectURL).toHaveBeenCalled());
+
+    liveGallery.resolve([print]);
+    await flushPromises();
+
+    await vi.waitFor(() => {
+      const tile = wrapper!.get("[data-test='gallery-item']");
+      expect(tile.find(".mobile-media-placeholder").exists()).toBe(false);
+      expect(tile.get("img").attributes("src")).toContain("blob:");
+    });
+  });
+
   it("reuses a cached print immediately while its host is offline", async () => {
     Object.defineProperty(globalThis, "indexedDB", {
       configurable: true,
@@ -10431,6 +10489,28 @@ describe("MobileApp Library organization", () => {
     await wrapper?.get("[data-test='mobile-collection-back']").trigger("click");
     await flushPromises();
     expect(wrapper?.find("[data-test='mobile-collection-list']").exists()).toBe(true);
+  });
+
+  it("falls back to a readable collection member when its explicit cover is unavailable", async () => {
+    installLibraryApi();
+    apiFetchTo.mockImplementation((_target: unknown, path: string) => {
+      if (path.includes("cover.png")) return Promise.reject(new Error("cover host offline"));
+      return Promise.resolve({
+        status: 200,
+        blob: () => Promise.resolve(new Blob(["member thumbnail"], { type: "image/png" })),
+        text: () => Promise.resolve(""),
+      } as unknown as Response);
+    });
+    await openLibrary();
+
+    await wrapper?.get("[data-test='mobile-library-scope-collections']").trigger("click");
+    await flushPromises();
+
+    const card = wrapper!.get("[data-test='mobile-collection-portraits']");
+    await vi.waitFor(() => expect(card.find(".mobile-collection-cover img").exists()).toBe(true));
+    expect(
+      apiFetchTo.mock.calls.some(([, path]) => String(path).includes(favoritePrint.filename)),
+    ).toBe(true);
   });
 
   it("offers Hide from Library from a collection card on iPhone and Android", async () => {

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -971,6 +971,7 @@ const collectionDeleteConfirmSlug = ref<string | null>(null);
 interface CollectionCoverState {
   hostId: string;
   filename: string;
+  candidatesKey: string;
   url: string;
   status: "loading" | "ready" | "error";
 }
@@ -6937,6 +6938,12 @@ async function loadMoreGalleryPage(): Promise<void> {
   }
   markMobileLibrarySeen(galleryCopies);
   if (pendingLibraryScrollRestore) restoreMobileLibraryScroll();
+  // A cached snapshot and its live replacement commonly contain the exact
+  // same physical keys. The visible-key watcher therefore does not fire for
+  // the replacement proxies, leaving every new row on its placeholder until
+  // scrolling changes the window. Hydrate the proxies we just installed.
+  await nextTick();
+  syncVisibleGalleryThumbnails();
 }
 
 async function reusePrint(print: GalleryPrint): Promise<void> {
@@ -7542,31 +7549,33 @@ watch(
   () => void nextTick(measureMobileGalleryWindow),
 );
 
+function syncVisibleGalleryThumbnails(): void {
+  const retained = new Set(visibleGallery.value.map(galleryThumbnailRetryKey));
+  if (selectedPrint.value) retained.add(galleryThumbnailRetryKey(selectedPrint.value));
+  visibleGalleryThumbnailKeys = retained;
+  for (const [key, handle] of galleryThumbnailHandles) {
+    if (retained.has(key)) continue;
+    handle.cancel();
+    galleryThumbnailHandles.delete(key);
+  }
+  for (const [key, timer] of galleryThumbnailRetryTimers) {
+    if (retained.has(key)) continue;
+    clearTimeout(timer);
+    galleryThumbnailRetryTimers.delete(key);
+  }
+  for (const print of gallery.value) {
+    const key = galleryThumbnailRetryKey(print);
+    if (retained.has(key) || print.thumbnailPending) continue;
+    revokeObjectUrl(print.thumbnailUrl);
+    print.thumbnailUrl = GALLERY_THUMBNAIL_PLACEHOLDER;
+    print.thumbnailPending = true;
+  }
+  for (const print of visibleGallery.value) loadGalleryThumbnail(print);
+}
+
 watch(
   () => visibleGallery.value.map(galleryThumbnailRetryKey).join("\u0000"),
-  () => {
-    const retained = new Set(visibleGallery.value.map(galleryThumbnailRetryKey));
-    if (selectedPrint.value) retained.add(galleryThumbnailRetryKey(selectedPrint.value));
-    visibleGalleryThumbnailKeys = retained;
-    for (const [key, handle] of galleryThumbnailHandles) {
-      if (retained.has(key)) continue;
-      handle.cancel();
-      galleryThumbnailHandles.delete(key);
-    }
-    for (const [key, timer] of galleryThumbnailRetryTimers) {
-      if (retained.has(key)) continue;
-      clearTimeout(timer);
-      galleryThumbnailRetryTimers.delete(key);
-    }
-    for (const print of gallery.value) {
-      const key = galleryThumbnailRetryKey(print);
-      if (retained.has(key) || print.thumbnailPending) continue;
-      revokeObjectUrl(print.thumbnailUrl);
-      print.thumbnailUrl = GALLERY_THUMBNAIL_PLACEHOLDER;
-      print.thumbnailPending = true;
-    }
-    for (const print of visibleGallery.value) loadGalleryThumbnail(print);
-  },
+  syncVisibleGalleryThumbnails,
   { immediate: true },
 );
 
@@ -7975,6 +7984,30 @@ function closeCollection(): void {
 /** Collection cards own their cover URL. Grid URLs are revoked whenever scope
  * paging resets, so borrowing one here produces a broken image after the user
  * switches from Prints to Collections. */
+function collectionCoverCandidates(
+  card: MobileCollectionCard,
+): Array<{ hostId: string; filename: string }> {
+  const candidates: Array<{ hostId: string; filename: string }> = [];
+  const seen = new Set<string>();
+  const add = (candidate: { hostId: string; filename: string } | null) => {
+    if (!candidate) return;
+    const key = `${candidate.hostId}\u0000${candidate.filename}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    candidates.push(candidate);
+  };
+  add(card.cover);
+  // A merged collection can name its explicit cover on a sleeping machine.
+  // Every cached/live member is a valid visual fallback, matching the desktop
+  // and web mosaics instead of blanking the whole card for one unavailable host.
+  for (const print of galleryCopies) {
+    if (organizationOf(print)?.collections.includes(card.slug)) {
+      add({ hostId: print.hostId, filename: print.filename });
+    }
+  }
+  return candidates;
+}
+
 function syncCollectionCovers(cards: readonly MobileCollectionCard[]): void {
   if (!collectionShelfVisible.value) return;
   const liveSlugs = new Set(cards.map((card) => card.slug));
@@ -7990,9 +8023,12 @@ function syncCollectionCovers(cards: readonly MobileCollectionCard[]): void {
   }
 
   for (const card of cards) {
-    const cover = card.cover;
+    const candidates = collectionCoverCandidates(card);
+    const candidatesKey = candidates
+      .map((candidate) => `${candidate.hostId}\u0000${candidate.filename}`)
+      .join("\u0001");
     const prior = collectionCovers[card.slug];
-    if (!cover) {
+    if (candidates.length === 0) {
       if (prior) revokeObjectUrl(prior.url);
       const timer = collectionCoverRetryTimers.get(card.slug);
       if (timer) clearTimeout(timer);
@@ -8001,7 +8037,7 @@ function syncCollectionCovers(cards: readonly MobileCollectionCard[]): void {
       delete collectionCovers[card.slug];
       continue;
     }
-    if (prior?.hostId === cover.hostId && prior.filename === cover.filename) {
+    if (prior?.candidatesKey === candidatesKey) {
       if (prior.status !== "error" || collectionCoverRetryTimers.has(card.slug)) continue;
     } else if (prior) {
       revokeObjectUrl(prior.url);
@@ -8011,30 +8047,52 @@ function syncCollectionCovers(cards: readonly MobileCollectionCard[]): void {
       collectionCoverRetryAttempts.delete(card.slug);
     }
 
+    const first = candidates[0]!;
     const state: CollectionCoverState = {
-      hostId: cover.hostId,
-      filename: cover.filename,
+      hostId: first.hostId,
+      filename: first.filename,
+      candidatesKey,
       url: "",
       status: "loading",
     };
     collectionCovers[card.slug] = state;
-    const host = connectedHosts.value.find((candidate) => candidate.id === cover.hostId);
-    if (!host) {
-      state.status = "error";
-      continue;
-    }
-    void thumbnailUrl(mobileHostTarget(host), mobileGalleryCacheKey(host), cover.filename)
-      .then((url) => {
+    void (async () => {
+      for (const candidate of candidates) {
+        const host = connectedHosts.value.find((entry) => entry.id === candidate.hostId);
+        if (!host) continue;
+        // Do not wait through the network timeout for a host already known to
+        // be offline. Its Lightroom-style local thumbnail remains eligible;
+        // otherwise move immediately to a reachable physical copy.
+        if (host.online === false) {
+          const cached = await loadCachedGalleryMedia(
+            mobileGalleryCacheKey(host),
+            candidate.filename,
+            "thumbnail",
+          );
+          if (!cached) continue;
+        }
+        try {
+          const url = await thumbnailUrl(
+            mobileHostTarget(host),
+            mobileGalleryCacheKey(host),
+            candidate.filename,
+          );
+          return { ...candidate, url };
+        } catch {
+          // A collection is cross-host. Try its next physical member before
+          // turning the entire card into an error placeholder.
+        }
+      }
+      throw new Error("No collection cover is currently readable");
+    })()
+      .then(({ hostId, filename, url }) => {
         const current = collectionCovers[card.slug];
-        if (
-          !current ||
-          current.hostId !== cover.hostId ||
-          current.filename !== cover.filename ||
-          unmounted
-        ) {
+        if (!current || current.candidatesKey !== candidatesKey || unmounted) {
           revokeObjectUrl(url);
           return;
         }
+        current.hostId = hostId;
+        current.filename = filename;
         current.url = url;
         current.status = "ready";
         const timer = collectionCoverRetryTimers.get(card.slug);
@@ -8044,7 +8102,7 @@ function syncCollectionCovers(cards: readonly MobileCollectionCard[]): void {
       })
       .catch(() => {
         const current = collectionCovers[card.slug];
-        if (current?.hostId === cover.hostId && current.filename === cover.filename) {
+        if (current?.candidatesKey === candidatesKey) {
           current.status = "error";
           scheduleCollectionCoverRetry(card);
         }
@@ -8053,11 +8111,12 @@ function syncCollectionCovers(cards: readonly MobileCollectionCard[]): void {
 }
 
 function scheduleCollectionCoverRetry(card: MobileCollectionCard): void {
+  const candidates = collectionCoverCandidates(card);
   if (
     unmounted ||
     !collectionShelfVisible.value ||
     collectionCoverRetryTimers.has(card.slug) ||
-    !card.cover
+    candidates.length === 0
   )
     return;
   const attempt = collectionCoverRetryAttempts.get(card.slug) ?? 0;
@@ -8069,15 +8128,17 @@ function scheduleCollectionCoverRetry(card: MobileCollectionCard): void {
       if (
         !current ||
         current.status !== "error" ||
-        current.hostId !== card.cover?.hostId ||
-        current.filename !== card.cover.filename
+        current.candidatesKey !==
+          collectionCoverCandidates(card)
+            .map((candidate) => `${candidate.hostId}\u0000${candidate.filename}`)
+            .join("\u0001")
       ) {
         return;
       }
       delete collectionCovers[card.slug];
       syncCollectionCovers(libraryCollectionCards.value);
     },
-    galleryThumbnailRetryDelay(card.cover.filename, attempt),
+    galleryThumbnailRetryDelay(candidates[0]!.filename, attempt),
   );
   collectionCoverRetryTimers.set(card.slug, timer);
 }
@@ -9536,7 +9597,16 @@ function handleForegroundResume(): void {
   void refreshMobileActivity();
   if (modelLoadError.value && !loadingModels.value) void refreshModels();
   renewGeneratedResult(false);
-  if (tab.value === "gallery") void refreshGallery();
+  if (tab.value === "gallery") {
+    // WebKit can restore the old scroll tree without notifying ResizeObserver.
+    // Re-measure and rehydrate immediately; waiting for the first user scroll
+    // made a resumed Library look empty even though its metadata was present.
+    void nextTick(() => {
+      measureMobileGalleryWindow();
+      syncVisibleGalleryThumbnails();
+    });
+    void refreshGallery();
+  }
 }
 
 function usesSoftwareKeyboard(target: EventTarget | null): target is HTMLElement {

--- a/desktop/src/mobile/mobile.css
+++ b/desktop/src/mobile/mobile.css
@@ -2678,6 +2678,7 @@ button:disabled {
 
 .gallery-item img,
 .gallery-item video {
+  display: block;
   width: 100%;
   height: 100%;
   object-fit: cover;
@@ -4701,6 +4702,7 @@ button:disabled {
 }
 
 .mobile-collection-cover img {
+  display: block;
   width: 100%;
   height: 100%;
   object-fit: cover;

--- a/desktop/src/views/LibraryView.vue
+++ b/desktop/src/views/LibraryView.vue
@@ -1434,6 +1434,14 @@ async function deleteSelectedPrints() {
 let resizeObserver: ResizeObserver | null = null;
 let pollTimer: ReturnType<typeof setInterval> | null = null;
 
+function remeasureLibraryAfterResume() {
+  if (document.visibilityState === "hidden") return;
+  void nextTick(() => {
+    if (scrollEl.value) containerWidth.value = scrollEl.value.clientWidth;
+    virtualizer.value?.measure?.();
+  });
+}
+
 /** Justified layout over the visible set; each laid tile keeps its merged
  *  entry so origin (badge, target, actions) travels with it. */
 const rows = computed(() => {
@@ -1917,6 +1925,9 @@ onMounted(() => {
   window.addEventListener("pointermove", moveSelectionDrag, { passive: false });
   window.addEventListener("pointerup", finishSelectionDrag);
   window.addEventListener("pointercancel", finishSelectionDrag);
+  window.addEventListener("pageshow", remeasureLibraryAfterResume);
+  window.addEventListener("focus", remeasureLibraryAfterResume);
+  document.addEventListener("visibilitychange", remeasureLibraryAfterResume);
   pollTimer = setInterval(() => void gallery.pollExtras(), EXTRA_POLL_MS);
   if (scrollEl.value) {
     containerWidth.value = scrollEl.value.clientWidth;
@@ -1946,6 +1957,9 @@ onUnmounted(() => {
   window.removeEventListener("pointermove", moveSelectionDrag);
   window.removeEventListener("pointerup", finishSelectionDrag);
   window.removeEventListener("pointercancel", finishSelectionDrag);
+  window.removeEventListener("pageshow", remeasureLibraryAfterResume);
+  window.removeEventListener("focus", remeasureLibraryAfterResume);
+  document.removeEventListener("visibilitychange", remeasureLibraryAfterResume);
   finishSelectionDrag();
   if (pollTimer) clearInterval(pollTimer);
   pollTimer = null;

--- a/web/src/components/GalleryCard.test.ts
+++ b/web/src/components/GalleryCard.test.ts
@@ -41,6 +41,17 @@ describe("GalleryCard", () => {
     expect(wrapper.text()).toContain("visible image");
   });
 
+  it("hydrates a card immediately when the observer is silent until scroll", async () => {
+    const wrapper = mount(GalleryCard, {
+      props: { item },
+      attachTo: document.body,
+    });
+
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find("img").exists()).toBe(true);
+    wrapper.unmount();
+  });
+
   it("shows the title caption and favorite heart only when the print has them", () => {
     const plain = mount(GalleryCard, { props: { item, variant: "feed" } });
     expect(plain.find('[data-test="card-title"]').exists()).toBe(false);

--- a/web/src/components/GalleryCard.vue
+++ b/web/src/components/GalleryCard.vue
@@ -89,6 +89,14 @@ const loaded = ref(false);
 
 let observer: IntersectionObserver | null = null;
 
+function refreshVisibility() {
+  if (!root.value) return;
+  const rect = root.value.getBoundingClientRect();
+  const near = rect.bottom >= -600 && rect.top <= window.innerHeight + 600;
+  if (near) visible.value = true;
+  onScreen.value = rect.bottom >= 0 && rect.top <= window.innerHeight;
+}
+
 onMounted(() => {
   if (!root.value) return;
   observer = new IntersectionObserver(
@@ -115,10 +123,15 @@ onMounted(() => {
     { rootMargin: "600px 0px", threshold: 0.01 },
   );
   observer.observe(root.value);
+  refreshVisibility();
+  window.addEventListener("pageshow", refreshVisibility);
+  document.addEventListener("visibilitychange", refreshVisibility);
 });
 
 onBeforeUnmount(() => {
   observer?.disconnect();
+  window.removeEventListener("pageshow", refreshVisibility);
+  document.removeEventListener("visibilitychange", refreshVisibility);
 });
 
 const kind = computed(() => mediaKind(props.item.format, props.item.filename));

--- a/web/src/components/gallery/GalleryGrid.vue
+++ b/web/src/components/gallery/GalleryGrid.vue
@@ -140,10 +140,17 @@ function scheduleMeasure() {
   frame = requestAnimationFrame(measureWindow);
 }
 
+function resumeMeasure() {
+  if (document.visibilityState === "hidden") return;
+  void nextTick(measureWindow);
+}
+
 onMounted(() => {
   measureWindow();
   window.addEventListener("scroll", scheduleMeasure, { passive: true });
   window.addEventListener("resize", scheduleMeasure, { passive: true });
+  window.addEventListener("pageshow", resumeMeasure);
+  document.addEventListener("visibilitychange", resumeMeasure);
   if (gridRoot.value && typeof ResizeObserver !== "undefined") {
     resizeObserver = new ResizeObserver(scheduleMeasure);
     resizeObserver.observe(gridRoot.value);
@@ -310,6 +317,8 @@ onBeforeUnmount(() => {
   window.removeEventListener("pointermove", onPointerMove);
   window.removeEventListener("scroll", scheduleMeasure);
   window.removeEventListener("resize", scheduleMeasure);
+  window.removeEventListener("pageshow", resumeMeasure);
+  document.removeEventListener("visibilitychange", resumeMeasure);
   resizeObserver?.disconnect();
   if (frame) cancelAnimationFrame(frame);
 });


### PR DESCRIPTION
## Summary

- strip complete Qwen thinking preambles and parse only structurally valid Remix alternatives
- hydrate replacement gallery proxies even when cached and live snapshots use identical keys
- remeasure mobile, desktop, and web Library windows after foreground/page restoration
- remove the WebKit inline-image gap that exposed placeholders above loaded tiles
- fall back across cached/reachable physical collection copies when the explicit cover host is unavailable

## Root causes

The expansion parser treated every non-empty fallback line as a prompt. A local Qwen completion containing reasoning plus the requested Remix alternatives was therefore parsed as 14 prompts. `expand_exact_with` correctly rejected that result because the request asked for exactly 4. Both plato and hal9000 run the same Mold 0.25.0 build; their journals do not retain the API response body or this returned parser error.

Mobile Library refresh replaced cached rows with new Vue proxies carrying the same physical keys. The visible-key watcher therefore did not rerun, so placeholders remained until scrolling changed the virtual window. Collection cards also tried only the first merged host cover, and inline WebKit images retained line-box space above the media.

## Verification

- `nix develop -c cargo test -p mold-ai-core expand::tests --lib` (60 passed)
- `nix develop -c cargo clippy -p mold-ai-core --all-targets -- -D warnings`
- desktop Vitest: 393 files, 5,044 tests passed
- web Vitest: 106 files, 1,725 tests passed
- mobile, desktop, and web production builds passed
- rendered mobile QA: 18 thumbnails on first paint, collection cover present, all 18 restored after leaving and returning without scroll, clean console
- `git diff --check`
- independent agent peer review: no P0-P2 findings

A broader core run passed 1,453 tests and hit one unrelated intermittent stream-retention test; that exact test passed immediately on isolated rerun. Two environment-sensitive default-path tests were excluded because this workstation intentionally persists `MOLD_HOME` at `/Volumes/ExternalStorage/mold2`.