### PR TITLE
fix(ui): tighten library and machine layouts

### DIFF
--- a/desktop/src/components/gallery/Lightbox.test.ts
+++ b/desktop/src/components/gallery/Lightbox.test.ts
@@ -287,9 +287,16 @@ describe("Lightbox a11y", () => {
     expect(menu.entries).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ label: "Copy image", disabled: false }),
+        expect.objectContaining({ label: "Use as source", disabled: false }),
         expect.objectContaining({ label: "Copy file path" }),
       ]),
     );
+    const useSource = menu.entries.find(
+      (entry) => !("separator" in entry) && entry.label === "Use as source",
+    );
+    expect(useSource).toBeDefined();
+    menu.activate(useSource!);
+    expect(wrapper.emitted("useSource")).toHaveLength(1);
     wrapper.unmount();
   });
 });

--- a/desktop/src/components/gallery/Lightbox.vue
+++ b/desktop/src/components/gallery/Lightbox.vue
@@ -321,6 +321,11 @@ function imageMenu(): MenuEntry[] {
       action: () => void copyImage(),
     },
     {
+      label: "Use as source",
+      disabled: props.audio,
+      action: () => emit("useSource"),
+    },
+    {
       label: "Copy file path",
       action: () =>
         void copyLocalOutputPath(props.item.filename, fromTrash.value)

--- a/web/src/components/gallery/Lightbox.test.ts
+++ b/web/src/components/gallery/Lightbox.test.ts
@@ -162,6 +162,20 @@ describe("Lightbox (desktop two-pane)", () => {
     ).toBe("print.png");
   });
 
+  it("opens the Library action menu when the media is right-clicked", async () => {
+    const wrapper = mountWide();
+    await wrapper.get(".lb__stage").trigger("contextmenu", {
+      clientX: 120,
+      clientY: 240,
+    });
+
+    expect(wrapper.emitted("context-menu")?.[0]?.[0]).toEqual({
+      item,
+      x: 120,
+      y: 240,
+    });
+  });
+
   it("makes cached editing primary and keeps duplication explicit for sequence prints", async () => {
     const wrapper = mountWide({ isSequence: true, canEditSequence: true });
     expect(

--- a/web/src/components/gallery/Lightbox.vue
+++ b/web/src/components/gallery/Lightbox.vue
@@ -94,6 +94,10 @@ const emit = defineEmits<{
   (e: "new-collection", item: GalleryImage): void;
   (e: "restore", item: GalleryImage): void;
   (e: "delete-forever", item: GalleryImage): void;
+  (
+    e: "context-menu",
+    payload: { item: GalleryImage; x: number; y: number },
+  ): void;
 }>();
 
 const organizer = ref<InstanceType<typeof PrintOrganizer> | null>(null);
@@ -358,6 +362,16 @@ function onReuse() {
 function onUseSource() {
   if (props.item) emit("use-source", props.item);
 }
+function onMediaContextMenu(event: MouseEvent) {
+  if (!props.item || props.inTrash) return;
+  event.preventDefault();
+  event.stopPropagation();
+  emit("context-menu", {
+    item: props.item,
+    x: event.clientX,
+    y: event.clientY,
+  });
+}
 function onUpscale() {
   menuOpen.value = false;
   if (props.item) emit("upscale", props.item);
@@ -454,7 +468,7 @@ async function performVideoExport(options: VideoExportOptions) {
     >
       <!-- ============================ DESKTOP ============================ -->
       <div v-if="wide" class="lb__card" @click.stop>
-        <div class="lb__stage">
+        <div class="lb__stage" @contextmenu="onMediaContextMenu">
           <p v-if="streamBlocked" class="lb__blocked" role="status">
             <span class="lb__blocked-title">{{ blockedTitle }}</span>
             <span class="lb__blocked-body">{{ streamMessage }}</span>
@@ -851,7 +865,10 @@ async function performVideoExport(options: VideoExportOptions) {
           </div>
         </div>
 
-        <div class="lb__stage lb__stage--full">
+        <div
+          class="lb__stage lb__stage--full"
+          @contextmenu="onMediaContextMenu"
+        >
           <p v-if="streamBlocked" class="lb__blocked" role="status">
             <span class="lb__blocked-title">{{ blockedTitle }}</span>
             <span class="lb__blocked-body">{{ streamMessage }}</span>

--- a/web/src/pages/HostDetailPage.test.ts
+++ b/web/src/pages/HostDetailPage.test.ts
@@ -1112,6 +1112,7 @@ describe("HostDetailPage — library", () => {
   it("hides the Library card when the host has no trash", async () => {
     const w = await mountDetail();
     expect(w.find('[data-test="library-card"]').exists()).toBe(false);
+    expect(w.get(".md-grid").attributes("data-has-library")).toBeUndefined();
   });
 
   it("shows the host's retention and trash count, writes retention with the host key, and empties with a plain confirm", async () => {
@@ -1130,6 +1131,7 @@ describe("HostDetailPage — library", () => {
     ]);
     const w = await mountDetail();
     const card = w.get('[data-test="library-card"]');
+    expect(w.get(".md-grid").attributes("data-has-library")).toBe("true");
     const select = card.get<HTMLSelectElement>(
       '[data-test="library-retention"]',
     );

--- a/web/src/pages/HostDetailPage.vue
+++ b/web/src/pages/HostDetailPage.vue
@@ -868,7 +868,11 @@ onBeforeUnmount(() => {
         </button>
       </div>
 
-      <div class="md-grid" :data-dimmed="reconnecting ? 'true' : undefined">
+      <div
+        class="md-grid"
+        :data-dimmed="reconnecting ? 'true' : undefined"
+        :data-has-library="trashCapable ? 'true' : undefined"
+      >
         <CardSurface class="md-telemetry">
           <div class="md-label">Telemetry</div>
           <div class="md-gpu" data-test="telemetry-gpu">
@@ -1222,10 +1226,19 @@ onBeforeUnmount(() => {
 }
 
 .md-grid {
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 300px;
+  grid-template-areas:
+    "telemetry library"
+    "models models";
   gap: 16px;
   align-items: flex-start;
-  flex-wrap: wrap;
+}
+
+.md-grid:not([data-has-library="true"]) {
+  grid-template-areas:
+    "telemetry telemetry"
+    "models models";
 }
 
 .md-grid[data-dimmed="true"],
@@ -1235,21 +1248,37 @@ onBeforeUnmount(() => {
 }
 
 .md-telemetry {
-  flex: 1;
+  grid-area: telemetry;
   min-width: 280px;
 }
 
-.md-models,
-.md-library {
-  width: 300px;
-  flex: 0 0 300px;
+.md-models {
+  grid-area: models;
+  min-width: 0;
 }
 
-@media (max-width: 640px) {
-  .md-models,
+.md-library {
+  grid-area: library;
+  width: 300px;
+}
+
+@media (max-width: 820px) {
+  .md-grid {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas:
+      "telemetry"
+      "library"
+      "models";
+  }
+
+  .md-grid:not([data-has-library="true"]) {
+    grid-template-areas:
+      "telemetry"
+      "models";
+  }
+
   .md-library {
     width: 100%;
-    flex: 1 1 100%;
   }
 }
 
@@ -1390,9 +1419,13 @@ onBeforeUnmount(() => {
 }
 
 .md-models__list {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
   gap: 2px;
+  max-height: clamp(180px, 32vh, 320px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding-right: 4px;
 }
 
 .md-models__row {

--- a/web/src/pages/LibraryPage.vue
+++ b/web/src/pages/LibraryPage.vue
@@ -2968,6 +2968,7 @@ onBeforeUnmount(() => {
       @new-collection="onNewCollection"
       @restore="restoreOne"
       @delete-forever="deleteForeverOne"
+      @context-menu="openContextMenu"
     />
 
     <HistoryDrawer
@@ -3015,6 +3016,9 @@ onBeforeUnmount(() => {
 
 .gal__scope {
   flex: 0 0 auto;
+}
+.gal__scope :deep(.ms-seg__label) {
+  white-space: nowrap;
 }
 .gal__filter {
   flex: 0 0 auto;


### PR DESCRIPTION
## Summary
- keep web Library scope labels on one line so the header cannot grow vertically
- move the machine model inventory into a bounded responsive multi-column card while preserving full-width telemetry when Library controls are unavailable
- add Use as source to open-print context menus on web and desktop

## Validation
- `nix develop -c bun run test` in `web` — 106 files, 1,725 tests passed
- `nix develop -c bun run test` in `desktop` — 393 files, 5,042 tests passed
- `nix develop -c bun run build` in `web` and `desktop`
- Prettier checks in `web` and `desktop`
- rendered browser QA at 1600x1000 and 760x1000 with `/Volumes/ExternalStorage/mold2` (20 installed models, no horizontal overflow, clean console)
- independent agent peer review; one layout finding fixed and re-reviewed clean