### PR TITLE
feat(web): add recent print context menu

### DIFF
--- a/changelog.d/web-recent-context-menu.md
+++ b/changelog.d/web-recent-context-menu.md
@@ -1,0 +1,4 @@
+- **Use Recent prints without leaving Create.** Right-clicking a Recent print
+  on the web Create page now offers Open, Reuse settings, Use as source, and
+  Delete, with media-aware source routing and keyboard-accessible navigation
+  ([#1365](https://github.com/utensils/mold/pull/1365)).

--- a/web/src/components/create/RecentGrid.test.ts
+++ b/web/src/components/create/RecentGrid.test.ts
@@ -76,6 +76,21 @@ describe("RecentGrid", () => {
     expect(w.emitted("open")?.[0]?.[0]).toStrictEqual(item);
   });
 
+  it("emits a positioned context menu request for a right-clicked entry", async () => {
+    const item = entry("a.png");
+    const w = mountGrid([item]);
+    await w.get("[data-test='recent-tile']").trigger("contextmenu", {
+      clientX: 120,
+      clientY: 80,
+    });
+    expect(w.emitted("context-menu")?.[0]?.[0]).toStrictEqual({
+      item,
+      x: 120,
+      y: 80,
+      trigger: w.get("[data-test='recent-tile']").element,
+    });
+  });
+
   it("shows an empty hint when there are no prints", () => {
     const w = mountGrid([]);
     expect(w.find("[data-test='recent-empty']").exists()).toBe(true);

--- a/web/src/components/create/RecentGrid.vue
+++ b/web/src/components/create/RecentGrid.vue
@@ -25,7 +25,17 @@ const props = withDefaults(
   { limit: 18 },
 );
 
-const emit = defineEmits<{ open: [item: GalleryImage] }>();
+const emit = defineEmits<{
+  open: [item: GalleryImage];
+  "context-menu": [
+    payload: {
+      item: GalleryImage;
+      x: number;
+      y: number;
+      trigger: HTMLElement | null;
+    },
+  ];
+}>();
 
 const shown = computed(() => props.entries.slice(0, props.limit));
 const overflow = computed(() =>
@@ -37,6 +47,14 @@ function isVideo(item: GalleryImage): boolean {
 }
 function tileAlt(item: GalleryImage): string {
   return item.metadata.prompt || item.filename;
+}
+function openContextMenu(item: GalleryImage, event: MouseEvent): void {
+  emit("context-menu", {
+    item,
+    x: event.clientX,
+    y: event.clientY,
+    trigger: event.currentTarget as HTMLElement | null,
+  });
 }
 </script>
 
@@ -57,6 +75,7 @@ function tileAlt(item: GalleryImage): string {
         :alt="tileAlt(item)"
         :data-test="`recent-tile`"
         @open="emit('open', item)"
+        @contextmenu.prevent.stop="openContextMenu(item, $event)"
       >
         <template v-if="isVideo(item)" #overlay>
           <span class="recent__badge" data-test="recent-video-badge">

--- a/web/src/pages/CreatePage.test.ts
+++ b/web/src/pages/CreatePage.test.ts
@@ -797,6 +797,248 @@ describe("CreatePage layout and behavior", () => {
     globalThis.fetch = originalFetch;
   });
 
+  it("offers the gallery actions when a Recent tile is right-clicked", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      blob: async () => new Blob(["image"]),
+    })) as never;
+    const stubs: Record<string, Component> = pageStubs();
+    stubs.RecentGrid = defineComponent({
+      props: ["entries"],
+      template:
+        '<button data-test="context-recent" @contextmenu.prevent="$emit(\'context-menu\', { item: entries[0], x: 99999, y: 99999, trigger: $event.currentTarget })">context</button>',
+    });
+    const wrapper = mount(CreatePage, {
+      attachTo: document.body,
+      global: { stubs },
+    });
+    await flushPromises();
+
+    await wrapper.get('[data-test="context-recent"]').trigger("contextmenu");
+    const menu = wrapper.get('[data-test="recent-context-menu"]');
+    const style = menu.attributes("style") ?? "";
+    const left = Number(/left: (\d+(?:\.\d+)?)px/.exec(style)?.[1]);
+    const top = Number(/top: (\d+(?:\.\d+)?)px/.exec(style)?.[1]);
+    expect(left).toBeLessThan(window.innerWidth);
+    expect(top).toBeLessThan(window.innerHeight);
+    expect(menu.text()).toContain("Open");
+    expect(menu.text()).toContain("Reuse settings");
+    expect(menu.text()).toContain("Use as source");
+    expect(menu.text()).toContain("Delete");
+    expect((document.activeElement as HTMLElement).textContent?.trim()).toBe(
+      "Open",
+    );
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }),
+    );
+    expect((document.activeElement as HTMLElement).textContent?.trim()).toBe(
+      "Reuse settings",
+    );
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }),
+    );
+    expect((document.activeElement as HTMLElement).textContent?.trim()).toBe(
+      "Use as source",
+    );
+
+    await wrapper.get('[data-test="recent-context-source"]').trigger("click");
+    await flushPromises();
+    expect(useGenerateForm().state.value.imageAttachments[0]?.filename).toBe(
+      entry.filename,
+    );
+    expect(wrapper.find('[data-test="recent-context-menu"]').exists()).toBe(
+      false,
+    );
+
+    await wrapper.get('[data-test="context-recent"]').trigger("contextmenu");
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+    );
+    await nextTick();
+    expect(document.activeElement).toBe(
+      wrapper.get('[data-test="context-recent"]').element,
+    );
+    wrapper.unmount();
+    globalThis.fetch = originalFetch;
+  });
+
+  it("routes Recent videos into the source-video field", async () => {
+    const video = { ...entry, filename: "clip.mp4", format: "mp4" as const };
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      blob: async () => new Blob(["video"], { type: "video/mp4" }),
+    })) as never;
+    const stubs: Record<string, Component> = pageStubs();
+    stubs.RecentGrid = defineComponent({
+      props: ["entries"],
+      setup: () => ({ video }),
+      template:
+        '<button data-test="context-recent-video" @contextmenu.prevent="$emit(\'context-menu\', { item: video, x: 20, y: 20 })">context</button>',
+    });
+    const wrapper = mount(CreatePage, { global: { stubs } });
+    await flushPromises();
+
+    await wrapper
+      .get('[data-test="context-recent-video"]')
+      .trigger("contextmenu");
+    await wrapper.get('[data-test="recent-context-source"]').trigger("click");
+    await flushPromises();
+    expect(useGenerateForm().state.value.sourceVideo).toMatchObject({
+      filename: "clip.mp4",
+      mime: "video/mp4",
+    });
+    expect(useGenerateForm().state.value.imageAttachments).toHaveLength(0);
+    wrapper.unmount();
+    globalThis.fetch = originalFetch;
+  });
+
+  it("keeps animated Recent images in the image-source field", async () => {
+    const animated = {
+      ...entry,
+      filename: "loop.gif",
+      format: "gif" as const,
+    };
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      blob: async () => new Blob(["image"], { type: "image/gif" }),
+    })) as never;
+    const stubs: Record<string, Component> = pageStubs();
+    stubs.RecentGrid = defineComponent({
+      props: ["entries"],
+      setup: () => ({ animated }),
+      template:
+        '<button data-test="context-recent-gif" @contextmenu.prevent="$emit(\'context-menu\', { item: animated, x: 20, y: 20 })">context</button>',
+    });
+    const wrapper = mount(CreatePage, { global: { stubs } });
+    await flushPromises();
+
+    await wrapper
+      .get('[data-test="context-recent-gif"]')
+      .trigger("contextmenu");
+    await wrapper.get('[data-test="recent-context-source"]').trigger("click");
+    await flushPromises();
+    expect(useGenerateForm().state.value.imageAttachments[0]).toMatchObject({
+      filename: "loop.gif",
+    });
+    expect(useGenerateForm().state.value.sourceVideo).toBeNull();
+    wrapper.unmount();
+    globalThis.fetch = originalFetch;
+  });
+
+  it("uses a Recent still as the Sequence opening image", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      blob: async () => new Blob(["image"], { type: "image/png" }),
+    })) as never;
+    const stubs: Record<string, Component> = pageStubs();
+    stubs.RecentGrid = defineComponent({
+      props: ["entries"],
+      template:
+        '<button data-test="context-recent-sequence" @contextmenu.prevent="$emit(\'context-menu\', { item: entries[0], x: 20, y: 20 })">context</button>',
+    });
+    const wrapper = mount(CreatePage, { global: { stubs } });
+    await flushPromises();
+    const draft = enterSequenceMode();
+
+    await wrapper
+      .get('[data-test="context-recent-sequence"]')
+      .trigger("contextmenu");
+    await wrapper.get('[data-test="recent-context-source"]').trigger("click");
+    await flushPromises();
+    expect(draft.openingImage).toMatchObject({ filename: entry.filename });
+    expect(useGenerateForm().state.value.imageAttachments).toHaveLength(0);
+    wrapper.unmount();
+    globalThis.fetch = originalFetch;
+  });
+
+  it("disables Recent video sources while Sequence is active", async () => {
+    const video = { ...entry, filename: "clip.mp4", format: "mp4" as const };
+    const originalFetch = globalThis.fetch;
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as never;
+    const stubs: Record<string, Component> = pageStubs();
+    stubs.RecentGrid = defineComponent({
+      props: ["entries"],
+      setup: () => ({ video }),
+      template:
+        '<button data-test="context-recent-sequence-video" @contextmenu.prevent="$emit(\'context-menu\', { item: video, x: 20, y: 20 })">context</button>',
+    });
+    const wrapper = mount(CreatePage, {
+      attachTo: document.body,
+      global: { stubs },
+    });
+    await flushPromises();
+    enterSequenceMode();
+
+    await wrapper
+      .get('[data-test="context-recent-sequence-video"]')
+      .trigger("contextmenu");
+    const action = wrapper.get('[data-test="recent-context-source"]');
+    expect(action.attributes("disabled")).toBeDefined();
+    expect(action.attributes("title")).toContain("must be an image");
+    expect((document.activeElement as HTMLElement).textContent?.trim()).toBe(
+      "Open",
+    );
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }),
+    );
+    expect((document.activeElement as HTMLElement).textContent?.trim()).toBe(
+      "Reuse settings",
+    );
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }),
+    );
+    expect((document.activeElement as HTMLElement).textContent?.trim()).toBe(
+      "Delete",
+    );
+    await action.trigger("click");
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(useGenerateForm().state.value.sourceVideo).toBeNull();
+    wrapper.unmount();
+    globalThis.fetch = originalFetch;
+  });
+
+  it("routes a Recent still into the active MiniMax H3 first frame", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      blob: async () => new Blob(["image"], { type: "image/png" }),
+    })) as never;
+    const stubs: Record<string, Component> = pageStubs();
+    stubs.RecentGrid = defineComponent({
+      props: ["entries"],
+      template:
+        '<button data-test="context-recent-h3" @contextmenu.prevent="$emit(\'context-menu\', { item: entries[0], x: 20, y: 20 })">context</button>',
+    });
+    const wrapper = mount(CreatePage, { global: { stubs } });
+    await flushPromises();
+    const form = useGenerateForm().state.value;
+    form.model = "minimax-h3-fl2va:comfy-pruned-int8";
+    form.modelFamily = "minimax-h3";
+    form.h3Authoring = {
+      firstFrame: null,
+      lastFrame: null,
+      references: [],
+    };
+
+    await wrapper.get('[data-test="context-recent-h3"]').trigger("contextmenu");
+    await wrapper.get('[data-test="recent-context-source"]').trigger("click");
+    await flushPromises();
+    expect(form.h3Authoring.firstFrame).toMatchObject({
+      filename: entry.filename,
+      mimeType: "image/png",
+      width: entry.metadata.width,
+      height: entry.metadata.height,
+    });
+    expect(form.imageAttachments).toHaveLength(0);
+    wrapper.unmount();
+    globalThis.fetch = originalFetch;
+  });
+
   it("restores a recent normal print into One shot while Sequence is active", async () => {
     const stubs: Record<string, Component> = pageStubs();
     stubs.RecentGrid = defineComponent({

--- a/web/src/pages/CreatePage.vue
+++ b/web/src/pages/CreatePage.vue
@@ -237,11 +237,13 @@ import {
 } from "@studio/lib/extend";
 import { promptOptional, promptRequired } from "@studio/lib/promptRequirement";
 import {
+  appendMinimaxH3GalleryImageReference,
   MINIMAX_H3_PROMPT_PLACEHOLDER,
   emptyMinimaxH3AuthoringState,
   isMinimaxH3Identity,
   minimaxH3AuthoringError,
   minimaxH3TaskForModel,
+  setMinimaxH3GalleryImageFirstFrame,
   setMinimaxH3PickedImageBoundary,
   type MinimaxH3BoundaryEndpoint,
 } from "@studio/lib/minimaxH3Authoring";
@@ -283,7 +285,7 @@ import type {
   SourceFitPolicy,
   SourceImageState,
 } from "../types";
-import { MAX_LORA_STACK } from "../types";
+import { MAX_LORA_STACK, mediaKind } from "../types";
 function loadMuted(): boolean {
   try {
     return localStorage.getItem("mold.gallery.muted") !== "false";
@@ -515,12 +517,39 @@ function onTemplatesPointerDown(event: PointerEvent) {
   ) {
     showTemplates.value = false;
   }
+  const target = event.target as HTMLElement | null;
+  if (!target?.closest("[data-test='recent-context-menu']")) {
+    closeRecentContextMenu();
+  }
 }
 
 function onTemplatesKeydown(event: KeyboardEvent) {
   if (showTemplates.value && event.key === "Escape") {
     event.preventDefault();
     showTemplates.value = false;
+  }
+  if (recentContextMenu.value && event.key === "Escape") {
+    event.preventDefault();
+    closeRecentContextMenu(true);
+    return;
+  }
+  if (!recentContextMenu.value) return;
+  const items = Array.from(
+    recentContextMenuElement.value?.querySelectorAll<HTMLButtonElement>(
+      '[role="menuitem"]:not(:disabled)',
+    ) ?? [],
+  );
+  if (items.length === 0) return;
+  const active = document.activeElement;
+  const index = items.findIndex((item) => item === active);
+  let next = -1;
+  if (event.key === "ArrowDown") next = (index + 1) % items.length;
+  if (event.key === "ArrowUp") next = (index - 1 + items.length) % items.length;
+  if (event.key === "Home") next = 0;
+  if (event.key === "End") next = items.length - 1;
+  if (next >= 0) {
+    event.preventDefault();
+    items[next]?.focus();
   }
 }
 
@@ -4502,7 +4531,69 @@ function onApplyMask(mask: SourceImageState) {
 }
 
 // ── Gallery drawer (preserved) ────────────────────────────────────────
+const recentContextMenu = ref<{
+  item: GalleryImage;
+  x: number;
+  y: number;
+  trigger: HTMLElement | null;
+} | null>(null);
+const recentContextMenuElement = ref<HTMLElement | null>(null);
+const RECENT_CONTEXT_WIDTH = 182;
+const RECENT_CONTEXT_HEIGHT = 172;
+const RECENT_CONTEXT_MARGIN = 6;
+const recentContextPosition = computed(() => {
+  const menu = recentContextMenu.value;
+  if (!menu) return {};
+  return {
+    left: `${Math.max(
+      RECENT_CONTEXT_MARGIN,
+      Math.min(
+        menu.x,
+        window.innerWidth - RECENT_CONTEXT_WIDTH - RECENT_CONTEXT_MARGIN,
+      ),
+    )}px`,
+    top: `${Math.max(
+      RECENT_CONTEXT_MARGIN,
+      Math.min(
+        menu.y,
+        window.innerHeight - RECENT_CONTEXT_HEIGHT - RECENT_CONTEXT_MARGIN,
+      ),
+    )}px`,
+  };
+});
+const recentSourceDisabled = computed(() => {
+  const item = recentContextMenu.value?.item;
+  if (!item || !sequenceMode.value) return false;
+  const kind = mediaKind(item.format, item.filename);
+  return kind === "video" || kind === "audio";
+});
+
+async function openRecentContextMenu(payload: {
+  item: GalleryImage;
+  x: number;
+  y: number;
+  trigger?: HTMLElement | null;
+}) {
+  recentContextMenu.value = { ...payload, trigger: payload.trigger ?? null };
+  await nextTick();
+  recentContextMenuElement.value
+    ?.querySelector<HTMLButtonElement>('[role="menuitem"]')
+    ?.focus();
+}
+
+function closeRecentContextMenu(restoreFocus = false) {
+  const trigger = recentContextMenu.value?.trigger;
+  recentContextMenu.value = null;
+  if (restoreFocus) void nextTick(() => trigger?.focus());
+}
+
+async function useRecentAsSource(item: GalleryImage) {
+  if (recentSourceDisabled.value) return;
+  await onLightboxUseSource(item);
+}
+
 function openItem(item: GalleryImage) {
+  closeRecentContextMenu();
   selectedIndex.value = galleryEntries.value.findIndex(
     (e) => e.filename === item.filename,
   );
@@ -4729,6 +4820,7 @@ function closeDrawer() {
 }
 
 function onLightboxReuse(item: GalleryImage) {
+  closeRecentContextMenu();
   recreateFromGallery(item);
   closeDrawer();
 }
@@ -4737,10 +4829,72 @@ async function attachLightboxSource(item: GalleryImage): Promise<boolean> {
   try {
     const res = await fetch(imageUrl(item.filename));
     if (!res.ok) throw new Error(`Fetch failed: ${res.status}`);
-    const base64 = await blobToBase64(await res.blob());
-    form.state.value.imageAttachments = [
-      { kind: "gallery", filename: item.filename, base64 },
-    ];
+    const blob = await res.blob();
+    const base64 = await blobToBase64(blob);
+    const kind = mediaKind(item.format, item.filename);
+    if (kind === "video") {
+      form.state.value.sourceVideo = {
+        kind: "upload",
+        filename: item.filename,
+        base64,
+        mime: blob.type || null,
+      };
+      form.state.value.sourceVideoPath = "";
+    } else if (kind === "audio") {
+      form.state.value.audioFile = {
+        kind: "upload",
+        filename: item.filename,
+        base64,
+        mime: blob.type || null,
+      };
+      form.state.value.audioFilePath = "";
+    } else {
+      const state = form.state.value;
+      if (sequenceMode.value) {
+        const dimensions = imageDimensionsFromBase64(base64) ?? {
+          width: item.metadata.width,
+          height: item.metadata.height,
+        };
+        draft.openingImage = {
+          filename: item.filename,
+          base64,
+          width: dimensions.width,
+          height: dimensions.height,
+        };
+        state.sourceFitPolicy = coerceSourceFitForMaskless(
+          state.sourceFitPolicy ?? { mode: "crop-fill" },
+        );
+        return true;
+      }
+      const h3Task = minimaxH3TaskForModel(state.model);
+      if (h3Task) {
+        const dimensions = imageDimensionsFromBase64(base64) ?? {
+          width: item.metadata.width,
+          height: item.metadata.height,
+        };
+        const image = {
+          filename: item.filename,
+          mimeType: blob.type || `image/${item.format}`,
+          width: dimensions.width,
+          height: dimensions.height,
+          data: base64,
+        };
+        const result =
+          h3Task === "ref2va"
+            ? appendMinimaxH3GalleryImageReference(state.h3Authoring, image)
+            : setMinimaxH3GalleryImageFirstFrame(state.h3Authoring, image);
+        if (!result.ok) throw new Error(result.error);
+        state.h3Authoring = result.state;
+      } else if (isMinimaxH3Identity(state.modelFamily, state.model)) {
+        throw new Error(
+          "Choose an explicit MiniMax H3 FL2VA or Ref2VA model before adding a source.",
+        );
+      } else {
+        state.imageAttachments = [
+          { kind: "gallery", filename: item.filename, base64 },
+        ];
+      }
+    }
     return true;
   } catch (err) {
     toast("error", err instanceof Error ? err.message : String(err));
@@ -4749,6 +4903,7 @@ async function attachLightboxSource(item: GalleryImage): Promise<boolean> {
 }
 
 async function onLightboxUseSource(item: GalleryImage) {
+  closeRecentContextMenu();
   if (!(await attachLightboxSource(item))) return;
   closeDrawer();
 }
@@ -4773,6 +4928,7 @@ function stepDrawer(delta: number) {
   selected.value = galleryEntries.value[next] ?? null;
 }
 async function handleDelete(item: GalleryImage) {
+  closeRecentContextMenu();
   try {
     await deleteGalleryImage(item.filename);
     galleryEntries.value = galleryEntries.value.filter(
@@ -5430,6 +5586,7 @@ onBeforeUnmount(() => {
             :entries="galleryEntries"
             :limit="isPhone ? 18 : 50"
             @open="openItem"
+            @context-menu="openRecentContextMenu"
           />
         </section>
       </main>
@@ -5671,8 +5828,101 @@ onBeforeUnmount(() => {
       @delete="handleDelete"
     />
 
+    <div
+      v-if="recentContextMenu"
+      ref="recentContextMenuElement"
+      class="recent-context"
+      data-test="recent-context-menu"
+      role="menu"
+      :style="recentContextPosition"
+    >
+      <button
+        type="button"
+        role="menuitem"
+        @click="openItem(recentContextMenu.item)"
+      >
+        Open
+      </button>
+      <button
+        type="button"
+        role="menuitem"
+        data-test="recent-context-reuse"
+        @click="onLightboxReuse(recentContextMenu.item)"
+      >
+        Reuse settings
+      </button>
+      <button
+        type="button"
+        role="menuitem"
+        data-test="recent-context-source"
+        :disabled="recentSourceDisabled"
+        :title="
+          recentSourceDisabled
+            ? 'Sequence opening media must be an image.'
+            : undefined
+        "
+        @click="useRecentAsSource(recentContextMenu.item)"
+      >
+        Use as source
+      </button>
+      <button
+        type="button"
+        role="menuitem"
+        class="recent-context__danger"
+        data-test="recent-context-delete"
+        @click="handleDelete(recentContextMenu.item)"
+      >
+        Delete
+      </button>
+    </div>
+
     <!-- The machine picker for a pre-submit missing-model pull. The Models
          page mounts the same dialog; only one route is mounted at a time. -->
     <ModelInstallTargetDialog />
   </div>
 </template>
+
+<style scoped>
+.recent-context {
+  position: fixed;
+  z-index: 70;
+  display: grid;
+  min-width: 170px;
+  padding: 6px;
+  border: 1px solid var(--ce);
+  border-radius: var(--radius-control-lg);
+  background: var(--bench);
+  box-shadow: var(--shadow-popover);
+}
+
+.recent-context button {
+  min-height: 40px;
+  padding: 0 10px;
+  border: 0;
+  border-radius: var(--radius-control);
+  background: transparent;
+  color: var(--rebate);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.recent-context button:hover,
+.recent-context button:focus-visible {
+  background: var(--sel-bg);
+}
+
+.recent-context button:disabled {
+  color: var(--ink-3);
+  cursor: default;
+}
+
+.recent-context button:focus-visible {
+  outline: 2px solid var(--safelight);
+  outline-offset: -2px;
+}
+
+.recent-context__danger {
+  color: var(--stop) !important;
+}
+</style>


### PR DESCRIPTION
## Summary
- add the Library-style right-click menu to Recent prints on the web Create page
- route Use as source to still, animated, video, audio, MiniMax H3, and Sequence authoring state correctly
- keep the menu onscreen and add keyboard focus/navigation with disabled-state handling

## Verification
- `nix develop -c bun run test:web` (106 files, 1,732 tests)
- `nix develop -c bun run build:web`
- in-app browser: `/create` rendered 50 Recent tiles, context menu actions verified, Use as source attached a still, clean console
- independent agent peer review: no remaining actionable findings
