### PR TITLE
feat(gallery): add prompt copy controls

### DIFF
--- a/changelog.d/gallery-prompt-copy.md
+++ b/changelog.d/gallery-prompt-copy.md
@@ -1,0 +1,1 @@
+- **Reusable gallery prompts.** Print prompts are now selectable and have a visible copy-to-clipboard action in the web, desktop, iPhone, and Android gallery viewers.

--- a/crates/mold-core/src/download.rs
+++ b/crates/mold-core/src/download.rs
@@ -525,7 +525,7 @@ fn verify_file_integrity(
     if skip_verify {
         return Ok(());
     }
-    let actual = match compute_sha256(clean_path) {
+    let actual = match pinned_file_digest(clean_path) {
         Ok(d) => d,
         Err(e) => {
             // I/O failure during hashing — log and move on without a marker.
@@ -575,10 +575,10 @@ fn verify_file_integrity(
 /// models roots the model-storage invariant supports is not the owner alone.
 /// `ctime` updates on every inode change and cannot be set directly at all, so
 /// an in-place rewrite that restores size and mtime still misses the cache.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, serde::Deserialize, serde::Serialize)]
 struct PinnedFileIdentity {
     len: u64,
-    platform: [u64; 6],
+    platform: [u64; 9],
 }
 
 fn pinned_file_identity(file: &std::fs::File) -> std::io::Result<PinnedFileIdentity> {
@@ -591,6 +591,9 @@ fn pinned_file_identity(file: &std::fs::File) -> std::io::Result<PinnedFileIdent
             platform: [
                 metadata.dev(),
                 metadata.ino(),
+                u64::from(metadata.mode()),
+                u64::from(metadata.uid()),
+                u64::from(metadata.gid()),
                 metadata.mtime() as u64,
                 metadata.mtime_nsec() as u64,
                 metadata.ctime() as u64,
@@ -620,25 +623,259 @@ fn pinned_file_identity(file: &std::fs::File) -> std::io::Result<PinnedFileIdent
                 0,
                 0,
                 0,
+                0,
+                0,
+                0,
             ],
         })
     }
 }
 
 type PinnedDigestCache = std::sync::Mutex<std::collections::HashMap<PinnedFileIdentity, String>>;
+type PinnedDigestFlights = std::sync::Mutex<
+    std::collections::HashMap<PinnedFileIdentity, std::sync::Arc<std::sync::Mutex<()>>>,
+>;
 
 fn pinned_digest_cache() -> &'static PinnedDigestCache {
     static CACHE: std::sync::OnceLock<PinnedDigestCache> = std::sync::OnceLock::new();
     CACHE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
 }
 
+fn pinned_digest_flights() -> &'static PinnedDigestFlights {
+    static FLIGHTS: std::sync::OnceLock<PinnedDigestFlights> = std::sync::OnceLock::new();
+    FLIGHTS.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+struct PinnedDigestFlightCleanup {
+    identity: PinnedFileIdentity,
+    flight: std::sync::Arc<std::sync::Mutex<()>>,
+}
+
+impl Drop for PinnedDigestFlightCleanup {
+    fn drop(&mut self) {
+        let mut flights = pinned_digest_flights()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let removable = flights.get(&self.identity).is_some_and(|held| {
+            std::sync::Arc::ptr_eq(held, &self.flight)
+                // map + caller-local `flight` + this cleanup guard
+                && std::sync::Arc::strong_count(held) == 3
+        });
+        if removable {
+            flights.remove(&self.identity);
+        }
+    }
+}
+
+#[derive(serde::Deserialize, serde::Serialize)]
+struct DurablePinnedDigest {
+    schema: u32,
+    path: PathBuf,
+    identity: PinnedFileIdentity,
+    sha256: String,
+}
+
+const DURABLE_PINNED_DIGEST_SCHEMA: u32 = 1;
+const DURABLE_PINNED_DIGEST_DIR: &str = ".artifact-attestations-v1";
+const MAX_DURABLE_PINNED_DIGEST_BYTES: u64 = 16 * 1024;
+
+#[cfg(unix)]
+fn directory_protects_entries(path: &Path) -> bool {
+    use std::os::unix::fs::MetadataExt;
+    let Ok(metadata) = std::fs::symlink_metadata(path) else {
+        return false;
+    };
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        return false;
+    }
+    // SAFETY: geteuid takes no arguments and cannot fail.
+    let euid = unsafe { libc::geteuid() };
+    let mode = metadata.mode();
+    if mode & 0o1000 != 0 {
+        metadata.uid() == euid || metadata.uid() == 0
+    } else {
+        metadata.uid() == euid && mode & 0o022 == 0
+    }
+}
+
+#[cfg(unix)]
+fn private_attestation_dir(create: bool) -> Option<PathBuf> {
+    private_attestation_dir_at(&crate::Config::mold_dir()?, create)
+}
+
+#[cfg(unix)]
+fn private_attestation_dir_at(mold_dir: &Path, create: bool) -> Option<PathBuf> {
+    use std::os::unix::fs::{DirBuilderExt, MetadataExt};
+
+    // The containing directory is the authority boundary. A 0700 child in a
+    // group-writable, non-sticky parent can be renamed away and replaced.
+    if !directory_protects_entries(mold_dir) {
+        return None;
+    }
+    let dir = mold_dir.join(DURABLE_PINNED_DIGEST_DIR);
+    if !dir.exists() && create {
+        let mut builder = std::fs::DirBuilder::new();
+        builder.mode(0o700);
+        if builder.create(&dir).is_err() && !dir.is_dir() {
+            return None;
+        }
+    }
+    let metadata = std::fs::symlink_metadata(&dir).ok()?;
+    // SAFETY: geteuid takes no arguments and cannot fail.
+    let euid = unsafe { libc::geteuid() };
+    (metadata.is_dir()
+        && !metadata.file_type().is_symlink()
+        && metadata.uid() == euid
+        && metadata.mode() & 0o077 == 0)
+        .then_some(dir)
+}
+
+#[cfg(not(unix))]
+fn private_attestation_dir(_create: bool) -> Option<PathBuf> {
+    // A DACL proof equivalent to the Unix owner/mode policy is not implemented.
+    // Falling back to the process cache preserves authentication correctness.
+    None
+}
+
+fn absolute_pinned_path(path: &Path) -> anyhow::Result<PathBuf> {
+    if path.is_absolute() {
+        Ok(path.to_path_buf())
+    } else {
+        Ok(std::env::current_dir()?.join(path))
+    }
+}
+
+fn durable_pinned_digest_path(dir: &Path, path: &Path) -> PathBuf {
+    use sha2::{Digest, Sha256};
+    let mut hash = Sha256::new();
+    hash.update(path.as_os_str().as_encoded_bytes());
+    dir.join(format!("{:x}.json", hash.finalize()))
+}
+
+fn read_durable_pinned_digest(path: &Path, identity: PinnedFileIdentity) -> Option<String> {
+    let dir = private_attestation_dir(false)?;
+    read_durable_pinned_digest_from_dir(&dir, path, identity)
+}
+
+fn read_durable_pinned_digest_from_dir(
+    dir: &Path,
+    path: &Path,
+    identity: PinnedFileIdentity,
+) -> Option<String> {
+    let absolute = absolute_pinned_path(path).ok()?;
+    let record_path = durable_pinned_digest_path(dir, &absolute);
+    let file = crate::secure_file::open_regular_file_no_follow(&record_path).ok()?;
+    if file.metadata().ok()?.len() > MAX_DURABLE_PINNED_DIGEST_BYTES {
+        return None;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        let metadata = file.metadata().ok()?;
+        // SAFETY: geteuid takes no arguments and cannot fail.
+        let euid = unsafe { libc::geteuid() };
+        if metadata.uid() != euid || metadata.mode() & 0o077 != 0 || metadata.nlink() != 1 {
+            return None;
+        }
+    }
+    let record: DurablePinnedDigest = serde_json::from_reader(file).ok()?;
+    (record.schema == DURABLE_PINNED_DIGEST_SCHEMA
+        && record.path == absolute
+        && record.identity == identity
+        && record.sha256.len() == 64
+        && record.sha256.bytes().all(|byte| byte.is_ascii_hexdigit()))
+    .then(|| record.sha256.to_ascii_lowercase())
+}
+
+#[cfg(unix)]
+fn write_durable_pinned_digest(
+    path: &Path,
+    identity: PinnedFileIdentity,
+    sha256: &str,
+) -> std::io::Result<()> {
+    use std::io::Write;
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let Some(dir) = private_attestation_dir(true) else {
+        return Ok(());
+    };
+    let absolute = absolute_pinned_path(path).map_err(std::io::Error::other)?;
+    let target = durable_pinned_digest_path(&dir, &absolute);
+    let temp = dir.join(format!(
+        ".tmp-{}-{}",
+        std::process::id(),
+        uuid::Uuid::new_v4()
+    ));
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(&temp)?;
+    let record = DurablePinnedDigest {
+        schema: DURABLE_PINNED_DIGEST_SCHEMA,
+        path: absolute,
+        identity,
+        sha256: sha256.to_ascii_lowercase(),
+    };
+    serde_json::to_writer(&mut file, &record).map_err(std::io::Error::other)?;
+    file.write_all(b"\n")?;
+    file.sync_all()?;
+    drop(file);
+    let result = std::fs::rename(&temp, &target);
+    if result.is_err() {
+        let _ = std::fs::remove_file(&temp);
+    }
+    result
+}
+
+#[cfg(not(unix))]
+fn write_durable_pinned_digest(
+    _path: &Path,
+    _identity: PinnedFileIdentity,
+    _sha256: &str,
+) -> std::io::Result<()> {
+    Ok(())
+}
+
 static PINNED_DIGEST_HASHES: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+#[cfg(test)]
+fn pinned_digest_hashes_by_identity(
+) -> &'static std::sync::Mutex<std::collections::HashMap<PinnedFileIdentity, u64>> {
+    static HASHES: std::sync::OnceLock<
+        std::sync::Mutex<std::collections::HashMap<PinnedFileIdentity, u64>>,
+    > = std::sync::OnceLock::new();
+    HASHES.get_or_init(Default::default)
+}
+
+#[cfg(test)]
+fn pinned_digest_hash_count_for(path: &Path) -> u64 {
+    let Ok(file) = crate::secure_file::open_regular_file_no_follow(path) else {
+        return 0;
+    };
+    let Ok(identity) = pinned_file_identity(&file) else {
+        return 0;
+    };
+    pinned_digest_hash_count_for_identity(identity)
+}
+
+#[cfg(test)]
+fn pinned_digest_hash_count_for_identity(identity: PinnedFileIdentity) -> u64 {
+    pinned_digest_hashes_by_identity()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(&identity)
+        .copied()
+        .unwrap_or(0)
+}
 
 /// How many times this process has actually read a file end-to-end to answer a
 /// pinned-digest question.
 ///
-/// Exported so tests can prove the memo is doing its job: a 2.3 GB bundle must
-/// be hashed once per process per unchanged file, not once per admission.
+/// Exported so tests can prove the verifier is doing its job: a 2.3 GB bundle
+/// must be hashed at most once for one unchanged identity, not once per
+/// admission. A valid durable attestation can make the count zero after a
+/// process restart.
 pub fn pinned_digest_hash_count() -> u64 {
     PINNED_DIGEST_HASHES.load(std::sync::atomic::Ordering::Relaxed)
 }
@@ -652,8 +889,34 @@ pub fn pinned_digest_hash_count() -> u64 {
 /// replacement between the check and the read cannot substitute different
 /// content.
 pub fn pinned_file_digest(path: &Path) -> anyhow::Result<String> {
+    pinned_file_digest_with_progress(path, |_, _| Ok(()))
+}
+
+/// [`pinned_file_digest`] with bounded read progress. A callback receiving
+/// `(0, total)` is also used as a cancellable heartbeat while another thread
+/// owns the same file-identity flight.
+pub fn pinned_file_digest_with_progress(
+    path: &Path,
+    progress: impl FnMut(u64, u64) -> anyhow::Result<()>,
+) -> anyhow::Result<String> {
     let file = crate::secure_file::open_regular_file_no_follow(path)?;
-    let identity = pinned_file_identity(&file)?;
+    pinned_file_digest_from_open_file(path, &file, progress)
+}
+
+/// Digest the exact retained descriptor supplied by a caller and bind any
+/// cache or durable attestation to that descriptor's identity. `path` is used
+/// only to key the durable record and to prove the same identity still
+/// occupies the pathname after hashing.
+pub fn pinned_file_digest_from_open_file(
+    path: &Path,
+    file: &std::fs::File,
+    mut progress: impl FnMut(u64, u64) -> anyhow::Result<()>,
+) -> anyhow::Result<String> {
+    anyhow::ensure!(
+        file.metadata()?.is_file(),
+        "pinned artifact is not a regular file"
+    );
+    let identity = pinned_file_identity(file)?;
     if let Some(digest) = pinned_digest_cache()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
@@ -662,12 +925,93 @@ pub fn pinned_file_digest(path: &Path) -> anyhow::Result<String> {
     {
         return Ok(digest);
     }
-    let digest = crate::secure_file::sha256_open_file(&file)?;
+    let flight = {
+        let mut flights = pinned_digest_flights()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        flights.entry(identity).or_default().clone()
+    };
+    // Declared before the mutex guard so return/unwind drops the guard first;
+    // the last participant then removes this identity from the flight map.
+    let _flight_cleanup = PinnedDigestFlightCleanup {
+        identity,
+        flight: flight.clone(),
+    };
+    let _flight = loop {
+        match flight.try_lock() {
+            Ok(guard) => break guard,
+            Err(std::sync::TryLockError::Poisoned(poisoned)) => break poisoned.into_inner(),
+            Err(std::sync::TryLockError::WouldBlock) => {
+                progress(0, identity.len)?;
+                std::thread::sleep(std::time::Duration::from_millis(100));
+            }
+        }
+    };
+    if let Some(digest) = pinned_digest_cache()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(&identity)
+        .cloned()
+    {
+        return Ok(digest);
+    }
+    if let Some(digest) = read_durable_pinned_digest(path, identity) {
+        pinned_digest_cache()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .insert(identity, digest.clone());
+        progress(identity.len, identity.len)?;
+        return Ok(digest);
+    }
+    use sha2::{Digest, Sha256};
+    use std::io::{Read, Seek, SeekFrom};
+    let mut reader = file.try_clone()?;
+    reader.seek(SeekFrom::Start(0))?;
+    let mut hash = Sha256::new();
+    let mut buffer = vec![0_u8; 1024 * 1024];
+    let mut read_total = 0_u64;
+    progress(0, identity.len)?;
+    loop {
+        let read = reader.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hash.update(&buffer[..read]);
+        read_total = read_total
+            .checked_add(read as u64)
+            .ok_or_else(|| anyhow::anyhow!("pinned file byte count overflow"))?;
+        progress(read_total, identity.len)?;
+    }
+    anyhow::ensure!(
+        read_total == identity.len,
+        "pinned file changed length while hashing"
+    );
+    anyhow::ensure!(
+        pinned_file_identity(file)? == identity,
+        "pinned file changed while hashing"
+    );
+    let current = crate::secure_file::open_regular_file_no_follow(path)?;
+    anyhow::ensure!(
+        pinned_file_identity(&current)? == identity,
+        "pinned file path changed while hashing"
+    );
+    let digest = format!("{:x}", hash.finalize());
     PINNED_DIGEST_HASHES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    #[cfg(test)]
+    {
+        *pinned_digest_hashes_by_identity()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .entry(identity)
+            .or_default() += 1;
+    }
     pinned_digest_cache()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
         .insert(identity, digest.clone());
+    if let Err(error) = write_durable_pinned_digest(path, identity, &digest) {
+        tracing::warn!(path = %path.display(), %error, "failed to persist artifact digest attestation");
+    }
     Ok(digest)
 }
 
@@ -697,9 +1041,11 @@ pub fn pinned_file_matches(path: &Path, expected_sha256: &str) -> bool {
 /// root — which the model-storage invariant explicitly supports, `0664` and
 /// all — anyone who can write the weights can also write a sidecar naming the
 /// expected digest, and a stale marker can outlive a replace. A writable
-/// attestation is not content authentication. The bytes are hashed every time;
-/// the cost is paid once per process per unchanged file by
-/// [`pinned_file_digest`]'s memo. The marker is still WRITTEN, because
+/// attestation is not content authentication. Instead, the digest is cached by
+/// exact descriptor identity and persisted only in Mold's owner-only,
+/// parent-protected attestation directory. Changed identities hash again; an
+/// unchanged identity survives a process restart without rereading the model.
+/// The marker is still WRITTEN, because
 /// `Config::manifest_files_exist` and the partial-cleanup sweep read it as an
 /// "this file is fully written" signal.
 ///
@@ -2555,7 +2901,7 @@ async fn fetch_recipe_inner(
         // Skipped under `skip_verify` — the user has explicitly asked us
         // not to read the file, so we have nothing to attest.
         if !opts.skip_verify {
-            let actual = compute_sha256(dest_path).map_err(|e| {
+            let actual = pinned_file_digest(dest_path).map_err(|e| {
                 DownloadError::Other(format!(
                     "failed to compute SHA-256 for {}: {e}",
                     dest_path.display()
@@ -3353,9 +3699,9 @@ mod tests {
         std::fs::write(&path, b"the real pinned bytes").unwrap();
         let expected = compute_sha256(&path).unwrap();
 
-        let before = pinned_digest_hash_count();
+        let before = pinned_digest_hash_count_for(&path);
         verify_pinned_file(&path, &expected, "stable.bin", "pinned-bundle").unwrap();
-        let after_first = pinned_digest_hash_count();
+        let after_first = pinned_digest_hash_count_for(&path);
         assert_eq!(
             after_first,
             before + 1,
@@ -3367,7 +3713,7 @@ mod tests {
             assert!(pinned_file_matches(&path, &expected));
         }
         assert_eq!(
-            pinned_digest_hash_count(),
+            pinned_digest_hash_count_for(&path),
             after_first,
             "an unchanged file must not be re-read once it is memoized"
         );
@@ -3375,6 +3721,124 @@ mod tests {
         // partial-cleanup sweep read it as a "fully written" signal. It is
         // just never read back as proof of content.
         assert_eq!(recorded_sha256_marker(&path).as_deref(), Some(&*expected));
+    }
+
+    #[test]
+    fn concurrent_pinned_checks_share_one_physical_hash() {
+        let _serial = pinned_digest_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("single-flight.bin");
+        std::fs::write(&path, vec![0x5a; 4 * 1024 * 1024]).unwrap();
+        let expected = compute_sha256(&path).unwrap();
+        let before = pinned_digest_hash_count_for(&path);
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(5));
+        let mut threads = Vec::new();
+        for _ in 0..4 {
+            let path = path.clone();
+            let expected = expected.clone();
+            let barrier = barrier.clone();
+            threads.push(std::thread::spawn(move || {
+                barrier.wait();
+                assert!(pinned_file_matches(&path, &expected));
+            }));
+        }
+        barrier.wait();
+        for thread in threads {
+            thread.join().unwrap();
+        }
+        assert_eq!(
+            pinned_digest_hash_count_for(&path),
+            before + 1,
+            "concurrent misses for one file identity must share one body read"
+        );
+        let identity =
+            pinned_file_identity(&crate::secure_file::open_regular_file_no_follow(&path).unwrap())
+                .unwrap();
+        assert!(
+            !pinned_digest_flights()
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .contains_key(&identity),
+            "the last flight participant must evict the completed identity"
+        );
+    }
+
+    #[test]
+    fn opened_digest_never_authenticates_a_path_replacement() {
+        let _serial = pinned_digest_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("artifact.bin");
+        let original = dir.path().join("original.bin");
+        std::fs::write(&path, b"reviewed bytes").unwrap();
+        let file = crate::secure_file::open_regular_file_no_follow(&path).unwrap();
+        std::fs::rename(&path, &original).unwrap();
+        std::fs::write(&path, b"attacker bytes").unwrap();
+
+        let error = pinned_file_digest_from_open_file(&path, &file, |_, _| Ok(()))
+            .expect_err("the retained descriptor and current path must name one identity");
+        assert!(error.to_string().contains("path changed"), "{error:#}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn durable_attestation_survives_process_cache_loss_and_rejects_mutation() {
+        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+        let _serial = pinned_digest_lock();
+        let home = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(home.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        let path = home.path().join("model.bin");
+        std::fs::write(&path, b"verified model bytes").unwrap();
+        let file = crate::secure_file::open_regular_file_no_follow(&path).unwrap();
+        let identity = pinned_file_identity(&file).unwrap();
+        let digest = crate::secure_file::sha256_open_file(&file).unwrap();
+        let attestation_dir = private_attestation_dir_at(home.path(), true).unwrap();
+        let absolute = absolute_pinned_path(&path).unwrap();
+        let target = durable_pinned_digest_path(&attestation_dir, &absolute);
+        let record = DurablePinnedDigest {
+            schema: DURABLE_PINNED_DIGEST_SCHEMA,
+            path: absolute,
+            identity,
+            sha256: digest.clone(),
+        };
+        let record_file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&target)
+            .unwrap();
+        serde_json::to_writer(record_file, &record).unwrap();
+
+        pinned_digest_cache()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .remove(&identity);
+        assert_eq!(
+            read_durable_pinned_digest_from_dir(&attestation_dir, &path, identity).as_deref(),
+            Some(digest.as_str()),
+            "a valid private attestation must replace the process-lifetime body read"
+        );
+
+        std::fs::write(&path, b"tampered model bytes").unwrap();
+        let changed = crate::secure_file::open_regular_file_no_follow(&path).unwrap();
+        let changed_identity = pinned_file_identity(&changed).unwrap();
+        assert_ne!(changed_identity, identity);
+        assert_eq!(
+            read_durable_pinned_digest_from_dir(&attestation_dir, &path, changed_identity),
+            None,
+            "a durable digest is valid only for the exact attested file identity"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn durable_attestation_is_disabled_in_renamable_parent() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let home = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(home.path(), std::fs::Permissions::from_mode(0o770)).unwrap();
+        assert!(private_attestation_dir_at(home.path(), true).is_none());
+        assert!(!home.path().join(DURABLE_PINNED_DIGEST_DIR).exists());
     }
 
     /// The memo must not become the hole the marker was: a file whose bytes
@@ -3388,11 +3852,13 @@ mod tests {
         std::fs::write(&path, b"the real pinned bytes").unwrap();
         let expected = compute_sha256(&path).unwrap();
         verify_pinned_file(&path, &expected, "swapped.bin", "pinned-bundle").unwrap();
-        let after_good = pinned_digest_hash_count();
-
         // Same path, same length, different content — the shape of an
         // in-place substitution in a shared models root.
         std::fs::write(&path, b"the fake pinned bytes").unwrap();
+        let changed_identity =
+            pinned_file_identity(&crate::secure_file::open_regular_file_no_follow(&path).unwrap())
+                .unwrap();
+        let before_changed = pinned_digest_hash_count_for_identity(changed_identity);
         let error = verify_pinned_file(&path, &expected, "swapped.bin", "pinned-bundle")
             .expect_err("replaced bytes must be caught, not served from the memo");
 
@@ -3401,8 +3867,8 @@ mod tests {
             "{error}"
         );
         assert_eq!(
-            pinned_digest_hash_count(),
-            after_good + 1,
+            pinned_digest_hash_count_for_identity(changed_identity),
+            before_changed + 1,
             "a changed file identity must force a fresh read"
         );
         assert!(!path.exists());

--- a/crates/mold-inference/src/minimax_h3/private_qualification.rs
+++ b/crates/mold-inference/src/minimax_h3/private_qualification.rs
@@ -908,66 +908,6 @@ fn require_regular_artifact(artifact: &ResolvedArtifact<'_>) -> Result<()> {
     Ok(())
 }
 
-/// Process-lifetime SHA-256 digest cache for the bulk artifact reads.
-///
-/// Placement previews and admission run full artifact qualification per
-/// request — and per candidate device — which re-hashed the same ~42 GB
-/// checkpoint set every time and made an H3 preview take minutes (the desktop
-/// sat in "Planning…" with no feedback). A digest may be reused only when the
-/// file's complete metadata identity (device, inode, size, mode, owner,
-/// mtime, ctime — the same `FileIdentity` the admission→dispatch revalidation
-/// already trusts) is byte-for-byte unchanged AND the pinned manifest hash
-/// matches; anything else re-hashes. Every structural, scope, and support
-/// check still runs on each qualification — only the redundant bulk read is
-/// skipped.
-static ARTIFACT_DIGEST_CACHE: std::sync::OnceLock<
-    std::sync::Mutex<std::collections::HashMap<PathBuf, (FileIdentity, String)>>,
-> = std::sync::OnceLock::new();
-
-fn artifact_digest_cache(
-) -> &'static std::sync::Mutex<std::collections::HashMap<PathBuf, (FileIdentity, String)>> {
-    ARTIFACT_DIGEST_CACHE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
-}
-
-fn lookup_cached_artifact_digest(
-    canonical_path: &Path,
-    identity: &FileIdentity,
-    expected_sha: &str,
-) -> Option<String> {
-    let cache = artifact_digest_cache().lock().ok()?;
-    let (cached_identity, cached_sha) = cache.get(canonical_path)?;
-    if cached_identity == identity && cached_sha.eq_ignore_ascii_case(expected_sha) {
-        Some(cached_sha.clone())
-    } else {
-        None
-    }
-}
-
-fn store_cached_artifact_digest(canonical_path: &Path, identity: FileIdentity, sha256: String) {
-    if let Ok(mut cache) = artifact_digest_cache().lock() {
-        cache.insert(canonical_path.to_path_buf(), (identity, sha256));
-    }
-}
-
-/// Per-canonical-path single-flight guard: concurrent qualifications that both
-/// miss the digest cache must not duplicate a cold multi-gigabyte hash. The
-/// loser blocks until the winner stores its digest, then reuses it through the
-/// ordinary cache lookup. Poisoning is deliberately ignored — a panicking
-/// winner leaves no cache entry, so the next holder simply re-hashes.
-static ARTIFACT_HASH_FLIGHTS: std::sync::OnceLock<
-    std::sync::Mutex<std::collections::HashMap<PathBuf, std::sync::Arc<std::sync::Mutex<()>>>>,
-> = std::sync::OnceLock::new();
-
-fn artifact_hash_flight(canonical_path: &Path) -> std::sync::Arc<std::sync::Mutex<()>> {
-    let flights = ARTIFACT_HASH_FLIGHTS
-        .get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()));
-    let mut map = match flights.lock() {
-        Ok(map) => map,
-        Err(poisoned) => poisoned.into_inner(),
-    };
-    map.entry(canonical_path.to_path_buf()).or_default().clone()
-}
-
 fn hash_exact_file(
     artifact: &ResolvedArtifact<'_>,
     expected_sha: &str,
@@ -983,7 +923,7 @@ fn hash_exact_file(
         bail!("private H3 artifact {relative_path} is no longer a regular non-symlink file")
     }
     let before_path = FileIdentity::from_metadata(&before_path_metadata);
-    let mut file = File::open(&artifact.canonical_path)
+    let file = mold_core::secure_file::open_regular_file_no_follow(&artifact.canonical_path)
         .with_context(|| format!("failed to open private H3 artifact {relative_path}"))?;
     let before = FileIdentity::from_metadata(
         &file
@@ -1000,74 +940,23 @@ fn hash_exact_file(
             artifact.file.size_bytes
         )
     }
-    let flight = artifact_hash_flight(&artifact.canonical_path);
-    let _hash_flight = loop {
-        match flight.try_lock() {
-            Ok(guard) => break guard,
-            Err(std::sync::TryLockError::Poisoned(poisoned)) => break poisoned.into_inner(),
-            Err(std::sync::TryLockError::WouldBlock) => {
-                // A zero-progress heartbeat keeps the caller's cooperative
-                // cancellation live while another attempt owns the flight.
-                progress(H3ArtifactHashProgress {
-                    relative_path: relative_path.clone(),
-                    artifact_bytes_verified: 0,
-                    artifact_bytes_total: before.len,
-                    total_bytes_verified: verified_before,
-                    total_bytes,
-                })?;
-                std::thread::sleep(std::time::Duration::from_millis(100));
-            }
-        }
-    };
-    if let Some(cached_sha) =
-        lookup_cached_artifact_digest(&artifact.canonical_path, &before, expected_sha)
-    {
-        progress(H3ArtifactHashProgress {
-            relative_path,
-            artifact_bytes_verified: before.len,
-            artifact_bytes_total: before.len,
-            total_bytes_verified: verified_before
-                .checked_add(before.len)
-                .ok_or_else(|| anyhow!("private H3 progress byte count overflow"))?,
-            total_bytes,
-        })?;
-        return Ok((cached_sha, before));
-    }
-    let mut digest = Sha256::new();
-    let mut buffer = vec![0_u8; HASH_BUFFER_BYTES];
-    let mut artifact_bytes_verified = 0_u64;
-    progress(H3ArtifactHashProgress {
-        relative_path: relative_path.clone(),
-        artifact_bytes_verified,
-        artifact_bytes_total: before.len,
-        total_bytes_verified: verified_before,
-        total_bytes,
-    })?;
-    loop {
-        let read = file
-            .read(&mut buffer)
-            .with_context(|| format!("failed to hash private H3 artifact {relative_path}"))?;
-        if read == 0 {
-            break;
-        }
-        digest.update(&buffer[..read]);
-        artifact_bytes_verified = artifact_bytes_verified
-            .checked_add(read as u64)
-            .ok_or_else(|| anyhow!("private H3 artifact hash byte count overflow"))?;
-        let total_bytes_verified = verified_before
-            .checked_add(artifact_bytes_verified)
-            .ok_or_else(|| anyhow!("private H3 progress byte count overflow"))?;
-        progress(H3ArtifactHashProgress {
-            relative_path: relative_path.clone(),
-            artifact_bytes_verified,
-            artifact_bytes_total: before.len,
-            total_bytes_verified,
-            total_bytes,
-        })?;
-    }
-    if artifact_bytes_verified != before.len {
-        bail!("private H3 artifact {relative_path} changed length during hashing")
-    }
+    let actual = mold_core::download::pinned_file_digest_from_open_file(
+        &artifact.canonical_path,
+        &file,
+        |artifact_bytes_verified, artifact_bytes_total| {
+            let total_bytes_verified = verified_before
+                .checked_add(artifact_bytes_verified)
+                .ok_or_else(|| anyhow!("private H3 progress byte count overflow"))?;
+            progress(H3ArtifactHashProgress {
+                relative_path: relative_path.clone(),
+                artifact_bytes_verified,
+                artifact_bytes_total,
+                total_bytes_verified,
+                total_bytes,
+            })
+        },
+    )
+    .with_context(|| format!("failed to hash private H3 artifact {relative_path}"))?;
     let after_open = FileIdentity::from_metadata(&file.metadata()?);
     let after_path_metadata = fs::symlink_metadata(&artifact.canonical_path)?;
     if !after_path_metadata.file_type().is_file() || after_path_metadata.file_type().is_symlink() {
@@ -1077,13 +966,11 @@ fn hash_exact_file(
     if before != after_open || before != after_path {
         bail!("private H3 artifact {relative_path} changed during hashing")
     }
-    let actual = format!("{:x}", digest.finalize());
     if !actual.eq_ignore_ascii_case(expected_sha) {
         bail!(
             "private H3 artifact {relative_path} SHA-256 mismatch: expected {expected_sha}, found {actual}"
         )
     }
-    store_cached_artifact_digest(&artifact.canonical_path, before.clone(), actual.clone());
     Ok((actual, before))
 }
 
@@ -1831,80 +1718,6 @@ mod tests {
             canonical_path: link,
         };
         assert!(require_regular_artifact(&aliased).is_err());
-    }
-
-    #[test]
-    fn digest_cache_reuses_only_byte_identical_metadata_identities() {
-        let directory = tempfile::tempdir().unwrap();
-        let path = directory.path().join("artifact.safetensors");
-        fs::write(&path, b"cached artifact bytes").unwrap();
-        let identity = FileIdentity::from_metadata(&fs::symlink_metadata(&path).unwrap());
-        let sha = "a".repeat(64);
-
-        // Nothing cached yet.
-        assert!(lookup_cached_artifact_digest(&path, &identity, &sha).is_none());
-
-        store_cached_artifact_digest(&path, identity.clone(), sha.clone());
-        assert_eq!(
-            lookup_cached_artifact_digest(&path, &identity, &sha).as_deref(),
-            Some(sha.as_str())
-        );
-        // The pinned manifest digest is part of the hit condition — a cache
-        // entry can never satisfy a different expected hash.
-        assert!(lookup_cached_artifact_digest(&path, &identity, &"b".repeat(64)).is_none());
-
-        // Any metadata drift (here: a rewrite bumping mtime/ctime/size) is a
-        // miss, so changed bytes are always re-hashed.
-        fs::write(&path, b"replaced artifact bytes!").unwrap();
-        let changed = FileIdentity::from_metadata(&fs::symlink_metadata(&path).unwrap());
-        assert!(lookup_cached_artifact_digest(&path, &changed, &sha).is_none());
-
-        // Storing the new identity evicts the stale entry.
-        let new_sha = "c".repeat(64);
-        store_cached_artifact_digest(&path, changed.clone(), new_sha.clone());
-        assert_eq!(
-            lookup_cached_artifact_digest(&path, &changed, &new_sha).as_deref(),
-            Some(new_sha.as_str())
-        );
-        assert!(lookup_cached_artifact_digest(&path, &identity, &sha).is_none());
-    }
-
-    #[test]
-    fn hash_flight_serializes_cold_fills_per_path() {
-        let directory = tempfile::tempdir().unwrap();
-        let path = directory.path().join("flight.safetensors");
-        fs::write(&path, b"flight artifact bytes").unwrap();
-        let other = directory.path().join("other.safetensors");
-
-        // One flight per canonical path, shared across callers.
-        assert!(std::sync::Arc::ptr_eq(
-            &artifact_hash_flight(&path),
-            &artifact_hash_flight(&path)
-        ));
-        assert!(!std::sync::Arc::ptr_eq(
-            &artifact_hash_flight(&path),
-            &artifact_hash_flight(&other)
-        ));
-
-        // A loser blocked on the winner's flight observes the winner's stored
-        // digest as soon as it acquires the lock — it never re-hashes.
-        let identity = FileIdentity::from_metadata(&fs::symlink_metadata(&path).unwrap());
-        let sha = "d".repeat(64);
-        let flight = artifact_hash_flight(&path);
-        let winner_guard = flight.lock().unwrap();
-        let loser = std::thread::spawn({
-            let flight = artifact_hash_flight(&path);
-            let path = path.clone();
-            let identity = identity.clone();
-            let sha = sha.clone();
-            move || {
-                let _guard = flight.lock().unwrap();
-                lookup_cached_artifact_digest(&path, &identity, &sha)
-            }
-        });
-        store_cached_artifact_digest(&path, identity, sha.clone());
-        drop(winner_guard);
-        assert_eq!(loser.join().unwrap().as_deref(), Some(sha.as_str()));
     }
 
     #[cfg(unix)]

--- a/crates/mold-server/src/host_reclaim.rs
+++ b/crates/mold-server/src/host_reclaim.rs
@@ -248,6 +248,17 @@ async fn reclaim_candidates(state: &AppState, requested_model: &str) -> Vec<Recl
     plan_reclaim(candidates, requested_model)
 }
 
+/// Whether a real admission could make host headroom by releasing Mold's own
+/// idle model cache.
+///
+/// Placement preview is a read-only authority boundary, so it may ask this
+/// question but must never call [`reclaim_host_headroom`]. The answer carries
+/// no byte estimate: only the completed teardown and a fresh OS sample can say
+/// how many host pages an engine actually returned.
+pub(crate) async fn has_reclaimable_cached_model(state: &AppState, requested_model: &str) -> bool {
+    !reclaim_candidates(state, requested_model).await.is_empty()
+}
+
 /// Why one eviction did not happen.
 ///
 /// The two arms differ in what they say about the NEXT target: a failure is

--- a/crates/mold-server/src/scheduler/mod.rs
+++ b/crates/mold-server/src/scheduler/mod.rs
@@ -4173,8 +4173,11 @@ impl Coordinator {
             Err(error) => {
                 let failure =
                     classify_generation_plan_failure(error, &self.total_vram_bytes_by_device_id());
-                let outcome = placement_preview_outcome_for_plan_failure(&failure);
-                return empty(outcome, failure.to_string());
+                let (authoritative, outcome) =
+                    placement_preview_disposition_for_plan_failure(&failure);
+                let mut response = empty(outcome, failure.to_string());
+                response.authoritative = authoritative;
+                return response;
             }
         };
         if cancelled() {
@@ -6626,12 +6629,18 @@ fn classify_generation_plan_failure(
     }
 }
 
-fn placement_preview_outcome_for_plan_failure(failure: &GenerationPlanFailure) -> &'static str {
+fn placement_preview_disposition_for_plan_failure(
+    failure: &GenerationPlanFailure,
+) -> (bool, &'static str) {
     match failure {
-        GenerationPlanFailure::Terminal(_) => "infeasible",
-        GenerationPlanFailure::Transient(_) | GenerationPlanFailure::StalePreparation(_) => {
-            "temporarily_unavailable"
-        }
+        GenerationPlanFailure::Terminal(_) => (true, "infeasible"),
+        GenerationPlanFailure::Transient(_) => (true, "temporarily_unavailable"),
+        // A queued generation already resets stale preparation and runs the
+        // admission preparer again. Publishing this as authoritative transient
+        // pressure prevents clients from reaching that recovery path. Decline
+        // preview authority instead: compatible requests may enter normal
+        // admission, where cache reclaim and fresh evidence are both owned.
+        GenerationPlanFailure::StalePreparation(_) => (false, "unsupported"),
     }
 }
 
@@ -9834,9 +9843,25 @@ mod tests {
             "a physically fitting job waits for the active lane instead of being refused"
         );
         assert_eq!(
-            placement_preview_outcome_for_plan_failure(&failure),
-            "temporarily_unavailable",
+            placement_preview_disposition_for_plan_failure(&failure),
+            (true, "temporarily_unavailable"),
             "placement preview must not turn current lane pressure into infeasibility"
+        );
+    }
+
+    #[test]
+    fn stale_preparation_declines_preview_authority_so_admission_can_reclaim() {
+        let failure = classify_generation_plan_failure(
+            crate::execution_plan::ExecutionPlanError::PreparedInputsStale(
+                "host capacity changed after private admission".to_string(),
+            ),
+            &BTreeMap::new(),
+        );
+
+        assert_eq!(
+            placement_preview_disposition_for_plan_failure(&failure),
+            (false, "unsupported"),
+            "the mutating admission path must get the chance to refresh evidence and unload cache"
         );
     }
 
@@ -15601,8 +15626,8 @@ mod tests {
             &BTreeMap::from([("cuda:0".to_string(), RTX_4090_TOTAL)]),
         );
         assert_eq!(
-            placement_preview_outcome_for_plan_failure(&impossible),
-            "infeasible"
+            placement_preview_disposition_for_plan_failure(&impossible),
+            (true, "infeasible")
         );
         assert!(
             !insufficient_vram_is_terminal(20_000_000_000, RTX_4090_TOTAL),

--- a/crates/mold-server/src/variant_dependencies.rs
+++ b/crates/mold-server/src/variant_dependencies.rs
@@ -1786,6 +1786,28 @@ mod preparation_cancellation_tests {
 #[cfg(any(feature = "h3", feature = "h3-private-uat"))]
 type HostShortfall = mold_inference::H3PrivateHostHeadroomShortfall;
 
+/// Host headroom private preparation may use without mutating server state.
+///
+/// A real admission always uses the sampled value. A read-only preview may
+/// prove the immutable H3 execution shape against the host's physical ceiling
+/// when Mold has an idle, non-requested engine it can release at admission.
+/// The later live recheck still sees the sampled value and deliberately turns
+/// that conditional plan into a non-authoritative fallback; it can never be
+/// published as an exact placement while the cache remains resident.
+#[cfg(any(feature = "h3", feature = "h3-private-uat"))]
+fn h3_preparation_host_headroom(
+    policy: DependencyMaterializationPolicy,
+    host: crate::h3_admission::H3HostMemory,
+    has_reclaimable_cached_model: bool,
+) -> u64 {
+    let sampled = host.headroom_bytes();
+    if policy == DependencyMaterializationPolicy::ExistingOnly && has_reclaimable_cached_model {
+        host.total_bytes.saturating_sub(host.safety_floor_bytes())
+    } else {
+        sampled
+    }
+}
+
 /// How much host headroom a reclaim has to reach for this attempt to be worth
 /// retrying, or `None` when it must not run at all.
 ///
@@ -1881,8 +1903,19 @@ async fn prepare_h3_private_inputs_for_devices(
     if devices.is_empty() {
         return Err("request placement has no eligible schedulable device".into());
     }
+    let host_memory = crate::h3_admission::current_h3_host_memory();
+    let has_reclaimable_cached_model = if policy == DependencyMaterializationPolicy::ExistingOnly {
+        match state {
+            Some(state) => {
+                crate::host_reclaim::has_reclaimable_cached_model(state, &request.model).await
+            }
+            None => false,
+        }
+    } else {
+        false
+    };
     let mut available_host_headroom_bytes =
-        crate::h3_admission::current_h3_host_memory().headroom_bytes();
+        h3_preparation_host_headroom(policy, host_memory, has_reclaimable_cached_model);
     let uat_paths =
         crate::h3_private_bridge::H3PrivateUatPathSet::resolve(config.resolved_models_dir());
     // The public runtime owns its MOLD_HOME-derived staging root; create it
@@ -2386,6 +2419,38 @@ mod tests {
             ),
             None,
             "a read-only placement preview must never evict a model cache"
+        );
+    }
+
+    #[cfg(any(feature = "h3", feature = "h3-private-uat"))]
+    #[test]
+    fn preview_can_prepare_against_only_cache_reclaimable_host_capacity() {
+        const GIB: u64 = 1 << 30;
+        let host = crate::h3_admission::H3HostMemory {
+            total_bytes: 64 * GIB,
+            available_bytes: 20 * GIB,
+        };
+        let sampled = host.headroom_bytes();
+        let physical_ceiling = host.total_bytes - host.safety_floor_bytes();
+
+        assert_eq!(
+            h3_preparation_host_headroom(DependencyMaterializationPolicy::Admission, host, true),
+            sampled,
+            "real admission must never spend memory an eviction has not returned"
+        );
+        assert_eq!(
+            h3_preparation_host_headroom(
+                DependencyMaterializationPolicy::ExistingOnly,
+                host,
+                false
+            ),
+            sampled,
+            "external pressure is not reclaimable"
+        );
+        assert_eq!(
+            h3_preparation_host_headroom(DependencyMaterializationPolicy::ExistingOnly, host, true),
+            physical_ceiling,
+            "preview may derive evidence conditionally when admission owns an idle cache victim"
         );
     }
 

--- a/desktop/src/components/gallery/Lightbox.test.ts
+++ b/desktop/src/components/gallery/Lightbox.test.ts
@@ -161,6 +161,23 @@ describe("Lightbox metadata panel", () => {
     },
   };
 
+  it("makes the prompt selectable and copies it from the visible control", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+    const wrapper = mountLightbox();
+
+    expect(wrapper.get("[data-test='lightbox-prompt']").attributes()).toHaveProperty(
+      "data-selectable",
+    );
+    await wrapper.get("[data-test='copy-prompt']").trigger("click");
+
+    expect(writeText).toHaveBeenCalledWith("a lighthouse at dusk");
+    expect(useToastStore().items.at(-1)?.message).toBe("Copied");
+  });
+
   it("renders the full embedded field set when present", () => {
     const wrapper = mountLightbox(richItem, true);
     const text = wrapper.get("aside").text();

--- a/desktop/src/components/gallery/Lightbox.vue
+++ b/desktop/src/components/gallery/Lightbox.vue
@@ -588,9 +588,28 @@ async function performVideoExport(options: VideoExportOptions) {
             </template>
             <template v-else>In the trash · kept until you empty it</template>
           </p>
-          <p data-selectable class="mt-3 text-body text-ink" :title="meta.prompt">
-            {{ meta.prompt }}
-          </p>
+          <div class="mt-3 flex items-start gap-2">
+            <p
+              data-selectable
+              data-test="lightbox-prompt"
+              class="min-w-0 flex-1 whitespace-pre-wrap text-body text-ink"
+              :title="meta.prompt"
+            >
+              {{ meta.prompt }}
+            </p>
+            <button
+              v-if="meta.prompt"
+              type="button"
+              data-test="copy-prompt"
+              class="flex h-[30px] shrink-0 items-center gap-1.5 rounded-chrome border border-edge px-2 font-utility text-[11px] text-ink-2 transition-colors hover:text-ink"
+              aria-label="Copy prompt"
+              title="Copy prompt"
+              @click="copy(meta.prompt)"
+            >
+              <Icon name="copy" :size="14" />
+              Copy
+            </button>
+          </div>
           <template v-if="showOrganization">
             <p class="lightbox-kicker mt-4 mb-1.5">Tags</p>
             <TagEditor

--- a/desktop/src/mobile/MobileGalleryViewer.test.ts
+++ b/desktop/src/mobile/MobileGalleryViewer.test.ts
@@ -100,6 +100,32 @@ afterEach(() => {
 });
 
 describe("MobileGalleryViewer", () => {
+  it("makes the prompt selectable and copies it in the viewer and Info sheet", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+    const view = mountViewer();
+    await flushPromises();
+
+    const viewerPrompt = view.get(".gallery-viewer-prompt > p[data-selectable]");
+    expect(viewerPrompt.text()).toBe("a lighthouse at dusk");
+    await view.get("[data-test='gallery-viewer-copy-prompt']").trigger("click");
+    await flushPromises();
+    expect(view.get("[data-test='gallery-viewer-copy-status']").text()).toBe("Prompt copied");
+
+    await view.get("[data-test='gallery-viewer-info']").trigger("click");
+    const infoPrompt = view.get("[data-test='gallery-viewer-info-prompt']");
+    expect(infoPrompt.attributes()).toHaveProperty("data-selectable");
+    await view.get("[data-test='gallery-viewer-info-copy-prompt']").trigger("click");
+    await flushPromises();
+
+    expect(writeText).toHaveBeenNthCalledWith(1, "a lighthouse at dusk");
+    expect(writeText).toHaveBeenNthCalledWith(2, "a lighthouse at dusk");
+    expect(view.get("[data-test='gallery-viewer-info-copy-status']").text()).toBe("Prompt copied");
+  });
+
   it("leaves the native iOS image context menu available", async () => {
     const view = mountViewer();
     await flushPromises();

--- a/desktop/src/mobile/MobileGalleryViewer.vue
+++ b/desktop/src/mobile/MobileGalleryViewer.vue
@@ -150,6 +150,7 @@ const originalPrompt = computed(() =>
 );
 const upscaled = computed(() => isUpscaledImage(props.item));
 const actionStatus = ref("");
+const promptCopyStatus = ref("");
 const actionBusy = ref<"copy" | "save" | "save-video" | null>(null);
 const exportOpen = ref(false);
 const exportBusy = ref(false);
@@ -226,7 +227,23 @@ function openInfo(): void {
   infoCollectionDraft.value = "";
   infoCollectionError.value = "";
   deleteForeverArmed.value = false;
+  promptCopyStatus.value = "";
   infoOpen.value = true;
+}
+
+function closeInfo(): void {
+  promptCopyStatus.value = "";
+  infoOpen.value = false;
+}
+
+async function copyPrompt(): Promise<void> {
+  promptCopyStatus.value = "";
+  try {
+    await navigator.clipboard.writeText(props.item.metadata.prompt);
+    promptCopyStatus.value = "Prompt copied";
+  } catch {
+    promptCopyStatus.value = "Couldn’t copy prompt.";
+  }
 }
 
 /** Done commits the title through PATCH; blank clears it. */
@@ -465,6 +482,7 @@ watch(
   ],
   () => {
     if (mounted) reloadMedia();
+    promptCopyStatus.value = "";
   },
 );
 
@@ -733,8 +751,28 @@ onBeforeUnmount(() => {
     <footer class="gallery-viewer-details">
       <div class="gallery-viewer-prompt">
         <span v-if="preparedPosition" data-test="gallery-viewer-batch">{{ preparedPosition }}</span>
-        <span>Prompt</span>
+        <div class="gallery-viewer-prompt-heading">
+          <span>Prompt</span>
+          <button
+            v-if="item.metadata.prompt"
+            class="gallery-viewer-copy-prompt"
+            type="button"
+            data-test="gallery-viewer-copy-prompt"
+            aria-label="Copy prompt"
+            @click="copyPrompt"
+          >
+            Copy
+          </button>
+        </div>
         <p data-selectable>{{ item.metadata.prompt || "No prompt was used for this print." }}</p>
+        <p
+          v-if="promptCopyStatus && !infoOpen"
+          class="gallery-viewer-copy-status"
+          role="status"
+          data-test="gallery-viewer-copy-status"
+        >
+          {{ promptCopyStatus }}
+        </p>
         <p v-if="pipeline" data-test="gallery-viewer-pipeline" data-selectable>
           <span>Pipeline</span> {{ pipeline }}
         </p>
@@ -840,7 +878,7 @@ onBeforeUnmount(() => {
       :title="viewerTitle"
       :focus-first-control="false"
       test-id="gallery-viewer-info-sheet"
-      @close="infoOpen = false"
+      @close="closeInfo"
     >
       <p
         v-if="organizationError"
@@ -1003,8 +1041,33 @@ onBeforeUnmount(() => {
       <section class="gallery-viewer-print-details" data-test="gallery-viewer-print-details">
         <p class="mobile-library-sheet-label">Print details</p>
         <p class="gallery-viewer-info-filename" :title="item.filename">{{ item.filename }}</p>
-        <p class="gallery-viewer-info-prompt" :title="item.metadata.prompt">
-          {{ item.metadata.prompt }}
+        <div class="gallery-viewer-info-prompt-row">
+          <p
+            class="gallery-viewer-info-prompt"
+            data-selectable
+            data-test="gallery-viewer-info-prompt"
+            :title="item.metadata.prompt"
+          >
+            {{ item.metadata.prompt }}
+          </p>
+          <button
+            v-if="item.metadata.prompt"
+            class="secondary-button gallery-viewer-copy-prompt"
+            type="button"
+            data-test="gallery-viewer-info-copy-prompt"
+            aria-label="Copy prompt"
+            @click="copyPrompt"
+          >
+            Copy
+          </button>
+        </div>
+        <p
+          v-if="promptCopyStatus"
+          class="gallery-viewer-copy-status"
+          role="status"
+          data-test="gallery-viewer-info-copy-status"
+        >
+          {{ promptCopyStatus }}
         </p>
         <p
           v-if="item.metadata.prompt.trim() && item.metadata.original_prompt"
@@ -1166,9 +1229,48 @@ onBeforeUnmount(() => {
 }
 
 .gallery-viewer-info-prompt {
+  min-width: 0;
   color: var(--rebate);
   font-size: var(--text-body);
   overflow-wrap: anywhere;
+}
+
+.gallery-viewer-info-prompt-row,
+.gallery-viewer-prompt-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.gallery-viewer-copy-prompt {
+  min-width: 44px;
+  min-height: 44px;
+  flex: 0 0 auto;
+}
+
+.gallery-viewer-prompt-heading .gallery-viewer-copy-prompt {
+  border: 0;
+  background: transparent;
+  color: var(--safelight);
+  font: inherit;
+}
+
+.gallery-viewer-prompt-heading > span {
+  color: rgba(245, 239, 255, 0.62);
+  font-family: var(--font-utility);
+  font-size: var(--text-edge-code);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.gallery-viewer-copy-status {
+  display: block;
+  overflow: visible;
+  margin: 0;
+  color: var(--ink-2);
+  font-size: 13px;
+  -webkit-line-clamp: unset;
 }
 
 .gallery-viewer-info-secondary {

--- a/web/src/components/gallery/Lightbox.test.ts
+++ b/web/src/components/gallery/Lightbox.test.ts
@@ -106,6 +106,9 @@ describe("Lightbox (desktop two-pane)", () => {
 
     await wrapper.get('[data-test="copy-prompt"]').trigger("click");
     await wrapper.get('[data-test="copy-seed"]').trigger("click");
+    expect(wrapper.get(".lb__prompt").attributes()).toHaveProperty(
+      "data-selectable",
+    );
     expect(writeText).toHaveBeenNthCalledWith(1, "a lighthouse at dusk");
     expect(writeText).toHaveBeenNthCalledWith(2, "4242");
   });

--- a/web/src/components/gallery/Lightbox.vue
+++ b/web/src/components/gallery/Lightbox.vue
@@ -610,10 +610,12 @@ async function performVideoExport(options: VideoExportOptions) {
           </p>
 
           <div v-if="prompt" class="lb__prompt-wrap">
-            <p class="lb__prompt">{{ prompt }}</p>
+            <p class="lb__prompt" data-selectable>{{ prompt }}</p>
             <button
+              type="button"
               data-test="copy-prompt"
               class="lb__copy"
+              aria-label="Copy prompt"
               @click="copyText(prompt)"
             >
               Copy prompt
@@ -937,10 +939,12 @@ async function performVideoExport(options: VideoExportOptions) {
             {{ purgeLabel }}
           </p>
           <div v-if="prompt" class="lb__prompt-wrap">
-            <p class="lb__prompt">{{ prompt }}</p>
+            <p class="lb__prompt" data-selectable>{{ prompt }}</p>
             <button
+              type="button"
               data-test="copy-prompt"
               class="lb__copy"
+              aria-label="Copy prompt"
               @click="copyText(prompt)"
             >
               Copy prompt
@@ -1320,6 +1324,11 @@ async function performVideoExport(options: VideoExportOptions) {
   color: var(--rebate);
   margin: 0 0 20px;
   white-space: pre-wrap;
+}
+.lb__prompt[data-selectable] {
+  -webkit-user-select: text;
+  user-select: text;
+  cursor: text;
 }
 .lb__prompt-wrap {
   margin-bottom: 20px;


### PR DESCRIPTION
## Summary
- make gallery print prompts explicitly selectable on web, desktop, iPhone, and Android
- add visible accessible copy-to-clipboard controls, including the mobile Info sheet
- report mobile copy success/failure without duplicate live-region announcements

## Verification
- `nix develop -c bun run check:frontend`
- `nix develop -c bun --cwd desktop run build:mobile`
- rendered browser QA at desktop and 390x844 mobile viewports: selectable prompt, visible control, exact clipboard contents, no console warnings/errors
- independent agent peer review: no findings