### PR TITLE
fix(prompts): normalize CLI/API newlines across surfaces

### DIFF
--- a/changelog.d/gallery-prompt-copy.md
+++ b/changelog.d/gallery-prompt-copy.md
@@ -1,0 +1,1 @@
+- **Reusable gallery prompts.** Print prompts are now selectable and have a visible copy-to-clipboard action in the web, desktop, iPhone, and Android gallery viewers.

--- a/crates/mold-cli/src/commands/chain.rs
+++ b/crates/mold-cli/src/commands/chain.rs
@@ -406,6 +406,12 @@ pub async fn run_chain(
     // before the first stage renders, exactly as the single-clip path does
     // (#1050).
     let mut req = req;
+    // Script/repeated CLI prompts are raw here. Auto-expanded prompts carry
+    // `original_prompt` and are already canonical model output, so only the
+    // raw CLI shapes take the one normalization pass.
+    if req.original_prompt.is_none() {
+        req.normalize_prompt_newlines();
+    }
     req.output_format = super::generate::reconcile_video_format_with_output_extension(
         req.output_format,
         output.as_deref(),

--- a/crates/mold-cli/src/commands/run.rs
+++ b/crates/mold-cli/src/commands/run.rs
@@ -134,6 +134,15 @@ fn require_prompt(
     ))
 }
 
+fn require_normalized_prompt(
+    prompt: Option<String>,
+    family: &str,
+    has_visual_conditioning: bool,
+) -> Result<String> {
+    require_prompt(prompt, family, has_visual_conditioning)
+        .map(|prompt| mold_core::normalize_prompt_newlines(&prompt).into_owned())
+}
+
 #[derive(Default, Clone, Copy)]
 struct FileArgRefs<'a> {
     lora: Option<&'a str>,
@@ -1230,7 +1239,7 @@ pub async fn run(
         || keyframes.as_ref().is_some_and(|k| !k.is_empty())
         || source_video_bytes.is_some()
         || extend_video_bytes.is_some();
-    let prompt = require_prompt(prompt, &family, has_visual_conditioning)?;
+    let prompt = require_normalized_prompt(prompt, &family, has_visual_conditioning)?;
 
     // --- Prompt expansion ---
     // An unprompted conditioned video run has nothing to expand; handing "" to
@@ -1443,6 +1452,15 @@ pub async fn run(
         (prompt, None, None, None)
     };
 
+    let final_prompt = mold_core::normalize_prompt_newlines(&final_prompt).into_owned();
+    let original_prompt =
+        original_prompt.map(|prompt| mold_core::normalize_prompt_newlines(&prompt).into_owned());
+    let batch_prompts = batch_prompts.map(|prompts| {
+        prompts
+            .into_iter()
+            .map(|prompt| mold_core::normalize_prompt_newlines(&prompt).into_owned())
+            .collect()
+    });
     let effective_negative_prompt = resolve_effective_negative_prompt(
         is_h3,
         no_negative,
@@ -1451,7 +1469,8 @@ pub async fn run(
             .resolved_model_config(&model)
             .effective_negative_prompt(&config),
         &family,
-    );
+    )
+    .map(|prompt| mold_core::normalize_prompt_newlines(&prompt).into_owned());
 
     // Resolve LoRA: explicit CLI values override config defaults.
     let model_cfg = config.resolved_model_config(&model);
@@ -2775,6 +2794,19 @@ mod tests {
         assert_eq!(
             require_prompt(Some("a turtle".to_string()), "ltx2", true).unwrap(),
             "a turtle"
+        );
+    }
+
+    #[test]
+    fn cli_prompt_arguments_decode_literal_newlines_before_generation() {
+        assert_eq!(
+            require_normalized_prompt(
+                Some(r"first line\n\nsecond line\r\nthird line".to_string()),
+                "flux",
+                false,
+            )
+            .unwrap(),
+            "first line\n\nsecond line\nthird line"
         );
     }
 }

--- a/crates/mold-cli/src/commands/run.rs
+++ b/crates/mold-cli/src/commands/run.rs
@@ -1452,15 +1452,6 @@ pub async fn run(
         (prompt, None, None, None)
     };
 
-    let final_prompt = mold_core::normalize_prompt_newlines(&final_prompt).into_owned();
-    let original_prompt =
-        original_prompt.map(|prompt| mold_core::normalize_prompt_newlines(&prompt).into_owned());
-    let batch_prompts = batch_prompts.map(|prompts| {
-        prompts
-            .into_iter()
-            .map(|prompt| mold_core::normalize_prompt_newlines(&prompt).into_owned())
-            .collect()
-    });
     let effective_negative_prompt = resolve_effective_negative_prompt(
         is_h3,
         no_negative,
@@ -2798,15 +2789,13 @@ mod tests {
     }
 
     #[test]
-    fn cli_prompt_arguments_decode_literal_newlines_before_generation() {
-        assert_eq!(
-            require_normalized_prompt(
-                Some(r"first line\n\nsecond line\r\nthird line".to_string()),
-                "flux",
-                false,
-            )
-            .unwrap(),
-            "first line\n\nsecond line\nthird line"
-        );
+    fn cli_prompt_arguments_decode_once_before_local_or_remote_generation() {
+        let prompt = require_normalized_prompt(
+            Some(r"first line\n\nsecond line\\n literal".to_string()),
+            "flux",
+            false,
+        )
+        .unwrap();
+        assert_eq!(prompt, "first line\n\nsecond line\\n literal");
     }
 }

--- a/crates/mold-core/src/chain.rs
+++ b/crates/mold-core/src/chain.rs
@@ -46,6 +46,7 @@ pub enum TransitionMode {
 /// per-stage seeds, encoded as decimal strings (full-range u64).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct ChainStageMetadata {
+    #[serde(deserialize_with = "crate::prompt_text::deserialize_prompt")]
     pub prompt: String,
     pub frames: u32,
     pub transition: TransitionMode,
@@ -107,6 +108,7 @@ pub struct ChainStage {
     /// (auto-expand form replicates it); the movie-maker UI in v2 will let
     /// users author per-stage prompts.
     #[schema(example = "a cat walking through autumn leaves")]
+    #[serde(deserialize_with = "crate::prompt_text::deserialize_prompt")]
     pub prompt: String,
 
     /// Frame count for this stage. Must be `8k+1` (LTX-2 pipeline constraint:
@@ -127,7 +129,11 @@ pub struct ChainStage {
     /// Optional negative prompt for CFG-based stages. v1 LTX-2 ignores this
     /// (the distilled family doesn't use CFG); the field is reserved so the
     /// movie-maker can round-trip it without re-migrating the wire format.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::prompt_text::deserialize_optional_prompt"
+    )]
     pub negative_prompt: Option<String>,
 
     /// Optional per-stage seed offset. `None` in v1 — the orchestrator
@@ -250,7 +256,11 @@ pub struct ChainRequest {
     pub collection: Option<crate::CollectionRef>,
 
     /// Original source prompt shared by a client-prepared sibling batch.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::prompt_text::deserialize_optional_prompt"
+    )]
     pub original_prompt: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub prompt_transform: Option<crate::PromptTransformProvenance>,
@@ -271,7 +281,11 @@ pub struct ChainRequest {
     // These are only read when `stages` is empty; `normalise` clears them
     // after expansion so the canonical form only ever carries `stages`.
     /// Auto-expand: single prompt replicated across all stages.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::prompt_text::deserialize_optional_prompt"
+    )]
     pub prompt: Option<String>,
 
     /// Auto-expand: total pixel frames the stitched output should cover.

--- a/crates/mold-core/src/chain.rs
+++ b/crates/mold-core/src/chain.rs
@@ -108,7 +108,6 @@ pub struct ChainStage {
     /// (auto-expand form replicates it); the movie-maker UI in v2 will let
     /// users author per-stage prompts.
     #[schema(example = "a cat walking through autumn leaves")]
-    #[serde(deserialize_with = "crate::prompt_text::deserialize_prompt")]
     pub prompt: String,
 
     /// Frame count for this stage. Must be `8k+1` (LTX-2 pipeline constraint:
@@ -129,11 +128,7 @@ pub struct ChainStage {
     /// Optional negative prompt for CFG-based stages. v1 LTX-2 ignores this
     /// (the distilled family doesn't use CFG); the field is reserved so the
     /// movie-maker can round-trip it without re-migrating the wire format.
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "crate::prompt_text::deserialize_optional_prompt"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub negative_prompt: Option<String>,
 
     /// Optional per-stage seed offset. `None` in v1 — the orchestrator
@@ -256,11 +251,7 @@ pub struct ChainRequest {
     pub collection: Option<crate::CollectionRef>,
 
     /// Original source prompt shared by a client-prepared sibling batch.
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "crate::prompt_text::deserialize_optional_prompt"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub original_prompt: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub prompt_transform: Option<crate::PromptTransformProvenance>,
@@ -281,11 +272,7 @@ pub struct ChainRequest {
     // These are only read when `stages` is empty; `normalise` clears them
     // after expansion so the canonical form only ever carries `stages`.
     /// Auto-expand: single prompt replicated across all stages.
-    #[serde(
-        default,
-        skip_serializing_if = "Option::is_none",
-        deserialize_with = "crate::prompt_text::deserialize_optional_prompt"
-    )]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub prompt: Option<String>,
 
     /// Auto-expand: total pixel frames the stitched output should cover.
@@ -717,6 +704,27 @@ pub fn routing_clip_frames(family: &str, model: &str) -> Option<u32> {
 }
 
 impl ChainRequest {
+    /// Canonicalize raw prompt text at one chain ingress. Callers that forward
+    /// an already-canonical request must protect backslashes on that wire hop
+    /// instead of applying this method twice.
+    pub fn normalize_prompt_newlines(&mut self) {
+        for stage in &mut self.stages {
+            stage.prompt = crate::normalize_prompt_newlines(&stage.prompt).into_owned();
+            stage.negative_prompt = stage
+                .negative_prompt
+                .take()
+                .map(|prompt| crate::normalize_prompt_newlines(&prompt).into_owned());
+        }
+        self.original_prompt = self
+            .original_prompt
+            .take()
+            .map(|prompt| crate::normalize_prompt_newlines(&prompt).into_owned());
+        self.prompt = self
+            .prompt
+            .take()
+            .map(|prompt| crate::normalize_prompt_newlines(&prompt).into_owned());
+    }
+
     /// Build a synthetic single-clip `GenerateRequest` describing the
     /// stitched output, so gallery rows and embedded metadata can reuse
     /// the existing single-clip schema. `stages[0]` supplies the prompt,

--- a/crates/mold-core/src/chain_job.rs
+++ b/crates/mold-core/src/chain_job.rs
@@ -691,6 +691,15 @@ pub struct RetakeRequest {
     pub prompt: Option<String>,
 }
 
+impl RetakeRequest {
+    pub fn normalize_prompt_newlines(&mut self) {
+        self.prompt = self
+            .prompt
+            .take()
+            .map(|prompt| crate::normalize_prompt_newlines(&prompt).into_owned());
+    }
+}
+
 /// Body of `POST /api/chain-jobs/:id/amend`: the FULL edited stage list (in
 /// canonical order) replaces the job's stages, plus optional chain-level
 /// overlays (omitted = keep current). NOT amendable — the client must create
@@ -714,6 +723,18 @@ pub struct AmendRequest {
     pub strength: Option<f64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub enable_audio: Option<bool>,
+}
+
+impl AmendRequest {
+    pub fn normalize_prompt_newlines(&mut self) {
+        for stage in &mut self.stages {
+            stage.prompt = crate::normalize_prompt_newlines(&stage.prompt).into_owned();
+            stage.negative_prompt = stage
+                .negative_prompt
+                .take()
+                .map(|prompt| crate::normalize_prompt_newlines(&prompt).into_owned());
+        }
+    }
 }
 
 /// 202 body of `POST /api/chain-jobs/:id/amend`.

--- a/crates/mold-core/src/client.rs
+++ b/crates/mold-core/src/client.rs
@@ -1031,6 +1031,7 @@ impl MoldClient {
     }
 
     pub async fn retake_chain_job(&self, id: &str, req: &RetakeRequest) -> Result<ChainJobSummary> {
+        let wire_req = crate::prompt_text::protect_retake_request_for_wire(req);
         let resp = self
             .client
             .post(format!(
@@ -1038,7 +1039,7 @@ impl MoldClient {
                 self.base_url,
                 encode_path_segment(id)
             ))
-            .json(req)
+            .json(&wire_req)
             .send()
             .await?;
         Ok(error_for_status_with_body(resp)

--- a/crates/mold-core/src/client.rs
+++ b/crates/mold-core/src/client.rs
@@ -171,13 +171,16 @@ impl MoldClient {
         &self,
         request: &ReferenceUploadSessionRequest,
     ) -> Result<ReferenceUploadSessionResponse> {
+        let mut wire_request = request.clone();
+        wire_request.request =
+            crate::prompt_text::protect_generate_request_for_wire(&request.request);
         let response = self
             .client
             .post(format!(
                 "{}/api/generate/reference-upload-sessions",
                 self.base_url
             ))
-            .json(request)
+            .json(&wire_request)
             .send()
             .await?;
         Ok(error_for_status_with_body(response)
@@ -306,10 +309,11 @@ impl MoldClient {
     /// The server returns raw bytes, not JSON — callers are responsible for
     /// writing the bytes to disk or further processing.
     pub async fn generate_raw(&self, req: &GenerateRequest) -> Result<Vec<u8>> {
+        let wire_req = crate::prompt_text::protect_generate_request_for_wire(req);
         let bytes = self
             .client
             .post(format!("{}/api/generate", self.base_url))
-            .json(req)
+            .json(&wire_req)
             .send()
             .await?
             .error_for_status()?
@@ -329,12 +333,13 @@ impl MoldClient {
         let height = req.height;
         let model = req.model.clone();
         let format = req.resolved_output_format();
+        let wire_req = crate::prompt_text::protect_generate_request_for_wire(&req);
 
         let start = std::time::Instant::now();
         let resp = self
             .client
             .post(format!("{}/api/generate", self.base_url))
-            .json(&req)
+            .json(&wire_req)
             .send()
             .await?
             .error_for_status()?;
@@ -566,10 +571,11 @@ impl MoldClient {
         req: &GenerateRequest,
         progress_tx: tokio::sync::mpsc::UnboundedSender<SseProgressEvent>,
     ) -> Result<Option<GenerateResponse>> {
+        let wire_req = crate::prompt_text::protect_generate_request_for_wire(req);
         let mut resp = self
             .client
             .post(format!("{}/api/generate/stream", self.base_url))
-            .json(req)
+            .json(&wire_req)
             .send()
             .await?;
 
@@ -812,10 +818,11 @@ impl MoldClient {
     /// chains take minutes — prefer [`Self::generate_chain_stream`] for
     /// interactive clients that want progress updates.
     pub async fn generate_chain(&self, req: &ChainRequest) -> Result<ChainResponse> {
+        let wire_req = crate::prompt_text::protect_chain_request_for_wire(req);
         let resp = self
             .client
             .post(format!("{}/api/generate/chain", self.base_url))
-            .json(req)
+            .json(&wire_req)
             .send()
             .await?;
 
@@ -861,10 +868,11 @@ impl MoldClient {
         req: &ChainRequest,
         progress_tx: tokio::sync::mpsc::UnboundedSender<ChainProgressEvent>,
     ) -> Result<Option<ChainResponse>> {
+        let wire_req = crate::prompt_text::protect_chain_request_for_wire(req);
         let mut resp = self
             .client
             .post(format!("{}/api/generate/chain/stream", self.base_url))
-            .json(req)
+            .json(&wire_req)
             .send()
             .await?;
 
@@ -960,10 +968,11 @@ impl MoldClient {
     }
 
     pub async fn create_chain_job(&self, req: &ChainRequest) -> Result<CreateChainJobResponse> {
+        let wire_req = crate::prompt_text::protect_chain_request_for_wire(req);
         let resp = self
             .client
             .post(format!("{}/api/chain-jobs", self.base_url))
-            .json(req)
+            .json(&wire_req)
             .send()
             .await?;
         Ok(error_for_status_with_body(resp)
@@ -1131,6 +1140,7 @@ impl MoldClient {
         request: crate::types::GenerateRequest,
         copies: u32,
     ) -> Result<crate::types::GenerationPlacementPreview> {
+        let request = crate::prompt_text::protect_generate_request_for_wire(&request);
         let preview = self
             .client
             .post(format!("{}/api/generate/placement-preview", self.base_url))
@@ -1780,10 +1790,11 @@ impl MoldClient {
 
     /// Expand a prompt using the server's LLM prompt expansion endpoint.
     pub async fn expand_prompt(&self, req: &ExpandRequest) -> Result<ExpandResponse> {
+        let wire_req = crate::prompt_text::protect_expand_request_for_wire(req);
         let resp = self
             .client
             .post(format!("{}/api/expand", self.base_url))
-            .json(req)
+            .json(&wire_req)
             .send()
             .await?
             .error_for_status()?
@@ -1795,10 +1806,11 @@ impl MoldClient {
     /// Generate subject-preserving prompt alternatives. A distinct endpoint is
     /// intentional: older hosts return 404 instead of silently expanding.
     pub async fn remix_prompt(&self, req: &crate::RemixRequest) -> Result<crate::RemixResponse> {
+        let wire_req = crate::prompt_text::protect_remix_request_for_wire(req);
         let resp = self
             .client
             .post(format!("{}/api/remix", self.base_url))
-            .json(req)
+            .json(&wire_req)
             .send()
             .await?
             .error_for_status()?

--- a/crates/mold-core/src/download.rs
+++ b/crates/mold-core/src/download.rs
@@ -525,7 +525,7 @@ fn verify_file_integrity(
     if skip_verify {
         return Ok(());
     }
-    let actual = match compute_sha256(clean_path) {
+    let actual = match pinned_file_digest(clean_path) {
         Ok(d) => d,
         Err(e) => {
             // I/O failure during hashing — log and move on without a marker.
@@ -575,10 +575,10 @@ fn verify_file_integrity(
 /// models roots the model-storage invariant supports is not the owner alone.
 /// `ctime` updates on every inode change and cannot be set directly at all, so
 /// an in-place rewrite that restores size and mtime still misses the cache.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, serde::Deserialize, serde::Serialize)]
 struct PinnedFileIdentity {
     len: u64,
-    platform: [u64; 6],
+    platform: [u64; 9],
 }
 
 fn pinned_file_identity(file: &std::fs::File) -> std::io::Result<PinnedFileIdentity> {
@@ -591,6 +591,9 @@ fn pinned_file_identity(file: &std::fs::File) -> std::io::Result<PinnedFileIdent
             platform: [
                 metadata.dev(),
                 metadata.ino(),
+                u64::from(metadata.mode()),
+                u64::from(metadata.uid()),
+                u64::from(metadata.gid()),
                 metadata.mtime() as u64,
                 metadata.mtime_nsec() as u64,
                 metadata.ctime() as u64,
@@ -620,25 +623,259 @@ fn pinned_file_identity(file: &std::fs::File) -> std::io::Result<PinnedFileIdent
                 0,
                 0,
                 0,
+                0,
+                0,
+                0,
             ],
         })
     }
 }
 
 type PinnedDigestCache = std::sync::Mutex<std::collections::HashMap<PinnedFileIdentity, String>>;
+type PinnedDigestFlights = std::sync::Mutex<
+    std::collections::HashMap<PinnedFileIdentity, std::sync::Arc<std::sync::Mutex<()>>>,
+>;
 
 fn pinned_digest_cache() -> &'static PinnedDigestCache {
     static CACHE: std::sync::OnceLock<PinnedDigestCache> = std::sync::OnceLock::new();
     CACHE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
 }
 
+fn pinned_digest_flights() -> &'static PinnedDigestFlights {
+    static FLIGHTS: std::sync::OnceLock<PinnedDigestFlights> = std::sync::OnceLock::new();
+    FLIGHTS.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+struct PinnedDigestFlightCleanup {
+    identity: PinnedFileIdentity,
+    flight: std::sync::Arc<std::sync::Mutex<()>>,
+}
+
+impl Drop for PinnedDigestFlightCleanup {
+    fn drop(&mut self) {
+        let mut flights = pinned_digest_flights()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let removable = flights.get(&self.identity).is_some_and(|held| {
+            std::sync::Arc::ptr_eq(held, &self.flight)
+                // map + caller-local `flight` + this cleanup guard
+                && std::sync::Arc::strong_count(held) == 3
+        });
+        if removable {
+            flights.remove(&self.identity);
+        }
+    }
+}
+
+#[derive(serde::Deserialize, serde::Serialize)]
+struct DurablePinnedDigest {
+    schema: u32,
+    path: PathBuf,
+    identity: PinnedFileIdentity,
+    sha256: String,
+}
+
+const DURABLE_PINNED_DIGEST_SCHEMA: u32 = 1;
+const DURABLE_PINNED_DIGEST_DIR: &str = ".artifact-attestations-v1";
+const MAX_DURABLE_PINNED_DIGEST_BYTES: u64 = 16 * 1024;
+
+#[cfg(unix)]
+fn directory_protects_entries(path: &Path) -> bool {
+    use std::os::unix::fs::MetadataExt;
+    let Ok(metadata) = std::fs::symlink_metadata(path) else {
+        return false;
+    };
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        return false;
+    }
+    // SAFETY: geteuid takes no arguments and cannot fail.
+    let euid = unsafe { libc::geteuid() };
+    let mode = metadata.mode();
+    if mode & 0o1000 != 0 {
+        metadata.uid() == euid || metadata.uid() == 0
+    } else {
+        metadata.uid() == euid && mode & 0o022 == 0
+    }
+}
+
+#[cfg(unix)]
+fn private_attestation_dir(create: bool) -> Option<PathBuf> {
+    private_attestation_dir_at(&crate::Config::mold_dir()?, create)
+}
+
+#[cfg(unix)]
+fn private_attestation_dir_at(mold_dir: &Path, create: bool) -> Option<PathBuf> {
+    use std::os::unix::fs::{DirBuilderExt, MetadataExt};
+
+    // The containing directory is the authority boundary. A 0700 child in a
+    // group-writable, non-sticky parent can be renamed away and replaced.
+    if !directory_protects_entries(mold_dir) {
+        return None;
+    }
+    let dir = mold_dir.join(DURABLE_PINNED_DIGEST_DIR);
+    if !dir.exists() && create {
+        let mut builder = std::fs::DirBuilder::new();
+        builder.mode(0o700);
+        if builder.create(&dir).is_err() && !dir.is_dir() {
+            return None;
+        }
+    }
+    let metadata = std::fs::symlink_metadata(&dir).ok()?;
+    // SAFETY: geteuid takes no arguments and cannot fail.
+    let euid = unsafe { libc::geteuid() };
+    (metadata.is_dir()
+        && !metadata.file_type().is_symlink()
+        && metadata.uid() == euid
+        && metadata.mode() & 0o077 == 0)
+        .then_some(dir)
+}
+
+#[cfg(not(unix))]
+fn private_attestation_dir(_create: bool) -> Option<PathBuf> {
+    // A DACL proof equivalent to the Unix owner/mode policy is not implemented.
+    // Falling back to the process cache preserves authentication correctness.
+    None
+}
+
+fn absolute_pinned_path(path: &Path) -> anyhow::Result<PathBuf> {
+    if path.is_absolute() {
+        Ok(path.to_path_buf())
+    } else {
+        Ok(std::env::current_dir()?.join(path))
+    }
+}
+
+fn durable_pinned_digest_path(dir: &Path, path: &Path) -> PathBuf {
+    use sha2::{Digest, Sha256};
+    let mut hash = Sha256::new();
+    hash.update(path.as_os_str().as_encoded_bytes());
+    dir.join(format!("{:x}.json", hash.finalize()))
+}
+
+fn read_durable_pinned_digest(path: &Path, identity: PinnedFileIdentity) -> Option<String> {
+    let dir = private_attestation_dir(false)?;
+    read_durable_pinned_digest_from_dir(&dir, path, identity)
+}
+
+fn read_durable_pinned_digest_from_dir(
+    dir: &Path,
+    path: &Path,
+    identity: PinnedFileIdentity,
+) -> Option<String> {
+    let absolute = absolute_pinned_path(path).ok()?;
+    let record_path = durable_pinned_digest_path(dir, &absolute);
+    let file = crate::secure_file::open_regular_file_no_follow(&record_path).ok()?;
+    if file.metadata().ok()?.len() > MAX_DURABLE_PINNED_DIGEST_BYTES {
+        return None;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        let metadata = file.metadata().ok()?;
+        // SAFETY: geteuid takes no arguments and cannot fail.
+        let euid = unsafe { libc::geteuid() };
+        if metadata.uid() != euid || metadata.mode() & 0o077 != 0 || metadata.nlink() != 1 {
+            return None;
+        }
+    }
+    let record: DurablePinnedDigest = serde_json::from_reader(file).ok()?;
+    (record.schema == DURABLE_PINNED_DIGEST_SCHEMA
+        && record.path == absolute
+        && record.identity == identity
+        && record.sha256.len() == 64
+        && record.sha256.bytes().all(|byte| byte.is_ascii_hexdigit()))
+    .then(|| record.sha256.to_ascii_lowercase())
+}
+
+#[cfg(unix)]
+fn write_durable_pinned_digest(
+    path: &Path,
+    identity: PinnedFileIdentity,
+    sha256: &str,
+) -> std::io::Result<()> {
+    use std::io::Write;
+    use std::os::unix::fs::OpenOptionsExt;
+
+    let Some(dir) = private_attestation_dir(true) else {
+        return Ok(());
+    };
+    let absolute = absolute_pinned_path(path).map_err(std::io::Error::other)?;
+    let target = durable_pinned_digest_path(&dir, &absolute);
+    let temp = dir.join(format!(
+        ".tmp-{}-{}",
+        std::process::id(),
+        uuid::Uuid::new_v4()
+    ));
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(&temp)?;
+    let record = DurablePinnedDigest {
+        schema: DURABLE_PINNED_DIGEST_SCHEMA,
+        path: absolute,
+        identity,
+        sha256: sha256.to_ascii_lowercase(),
+    };
+    serde_json::to_writer(&mut file, &record).map_err(std::io::Error::other)?;
+    file.write_all(b"\n")?;
+    file.sync_all()?;
+    drop(file);
+    let result = std::fs::rename(&temp, &target);
+    if result.is_err() {
+        let _ = std::fs::remove_file(&temp);
+    }
+    result
+}
+
+#[cfg(not(unix))]
+fn write_durable_pinned_digest(
+    _path: &Path,
+    _identity: PinnedFileIdentity,
+    _sha256: &str,
+) -> std::io::Result<()> {
+    Ok(())
+}
+
 static PINNED_DIGEST_HASHES: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+#[cfg(test)]
+fn pinned_digest_hashes_by_identity(
+) -> &'static std::sync::Mutex<std::collections::HashMap<PinnedFileIdentity, u64>> {
+    static HASHES: std::sync::OnceLock<
+        std::sync::Mutex<std::collections::HashMap<PinnedFileIdentity, u64>>,
+    > = std::sync::OnceLock::new();
+    HASHES.get_or_init(Default::default)
+}
+
+#[cfg(test)]
+fn pinned_digest_hash_count_for(path: &Path) -> u64 {
+    let Ok(file) = crate::secure_file::open_regular_file_no_follow(path) else {
+        return 0;
+    };
+    let Ok(identity) = pinned_file_identity(&file) else {
+        return 0;
+    };
+    pinned_digest_hash_count_for_identity(identity)
+}
+
+#[cfg(test)]
+fn pinned_digest_hash_count_for_identity(identity: PinnedFileIdentity) -> u64 {
+    pinned_digest_hashes_by_identity()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(&identity)
+        .copied()
+        .unwrap_or(0)
+}
 
 /// How many times this process has actually read a file end-to-end to answer a
 /// pinned-digest question.
 ///
-/// Exported so tests can prove the memo is doing its job: a 2.3 GB bundle must
-/// be hashed once per process per unchanged file, not once per admission.
+/// Exported so tests can prove the verifier is doing its job: a 2.3 GB bundle
+/// must be hashed at most once for one unchanged identity, not once per
+/// admission. A valid durable attestation can make the count zero after a
+/// process restart.
 pub fn pinned_digest_hash_count() -> u64 {
     PINNED_DIGEST_HASHES.load(std::sync::atomic::Ordering::Relaxed)
 }
@@ -652,8 +889,34 @@ pub fn pinned_digest_hash_count() -> u64 {
 /// replacement between the check and the read cannot substitute different
 /// content.
 pub fn pinned_file_digest(path: &Path) -> anyhow::Result<String> {
+    pinned_file_digest_with_progress(path, |_, _| Ok(()))
+}
+
+/// [`pinned_file_digest`] with bounded read progress. A callback receiving
+/// `(0, total)` is also used as a cancellable heartbeat while another thread
+/// owns the same file-identity flight.
+pub fn pinned_file_digest_with_progress(
+    path: &Path,
+    progress: impl FnMut(u64, u64) -> anyhow::Result<()>,
+) -> anyhow::Result<String> {
     let file = crate::secure_file::open_regular_file_no_follow(path)?;
-    let identity = pinned_file_identity(&file)?;
+    pinned_file_digest_from_open_file(path, &file, progress)
+}
+
+/// Digest the exact retained descriptor supplied by a caller and bind any
+/// cache or durable attestation to that descriptor's identity. `path` is used
+/// only to key the durable record and to prove the same identity still
+/// occupies the pathname after hashing.
+pub fn pinned_file_digest_from_open_file(
+    path: &Path,
+    file: &std::fs::File,
+    mut progress: impl FnMut(u64, u64) -> anyhow::Result<()>,
+) -> anyhow::Result<String> {
+    anyhow::ensure!(
+        file.metadata()?.is_file(),
+        "pinned artifact is not a regular file"
+    );
+    let identity = pinned_file_identity(file)?;
     if let Some(digest) = pinned_digest_cache()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
@@ -662,12 +925,93 @@ pub fn pinned_file_digest(path: &Path) -> anyhow::Result<String> {
     {
         return Ok(digest);
     }
-    let digest = crate::secure_file::sha256_open_file(&file)?;
+    let flight = {
+        let mut flights = pinned_digest_flights()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        flights.entry(identity).or_default().clone()
+    };
+    // Declared before the mutex guard so return/unwind drops the guard first;
+    // the last participant then removes this identity from the flight map.
+    let _flight_cleanup = PinnedDigestFlightCleanup {
+        identity,
+        flight: flight.clone(),
+    };
+    let _flight = loop {
+        match flight.try_lock() {
+            Ok(guard) => break guard,
+            Err(std::sync::TryLockError::Poisoned(poisoned)) => break poisoned.into_inner(),
+            Err(std::sync::TryLockError::WouldBlock) => {
+                progress(0, identity.len)?;
+                std::thread::sleep(std::time::Duration::from_millis(100));
+            }
+        }
+    };
+    if let Some(digest) = pinned_digest_cache()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(&identity)
+        .cloned()
+    {
+        return Ok(digest);
+    }
+    if let Some(digest) = read_durable_pinned_digest(path, identity) {
+        pinned_digest_cache()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .insert(identity, digest.clone());
+        progress(identity.len, identity.len)?;
+        return Ok(digest);
+    }
+    use sha2::{Digest, Sha256};
+    use std::io::{Read, Seek, SeekFrom};
+    let mut reader = file.try_clone()?;
+    reader.seek(SeekFrom::Start(0))?;
+    let mut hash = Sha256::new();
+    let mut buffer = vec![0_u8; 1024 * 1024];
+    let mut read_total = 0_u64;
+    progress(0, identity.len)?;
+    loop {
+        let read = reader.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hash.update(&buffer[..read]);
+        read_total = read_total
+            .checked_add(read as u64)
+            .ok_or_else(|| anyhow::anyhow!("pinned file byte count overflow"))?;
+        progress(read_total, identity.len)?;
+    }
+    anyhow::ensure!(
+        read_total == identity.len,
+        "pinned file changed length while hashing"
+    );
+    anyhow::ensure!(
+        pinned_file_identity(file)? == identity,
+        "pinned file changed while hashing"
+    );
+    let current = crate::secure_file::open_regular_file_no_follow(path)?;
+    anyhow::ensure!(
+        pinned_file_identity(&current)? == identity,
+        "pinned file path changed while hashing"
+    );
+    let digest = format!("{:x}", hash.finalize());
     PINNED_DIGEST_HASHES.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    #[cfg(test)]
+    {
+        *pinned_digest_hashes_by_identity()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .entry(identity)
+            .or_default() += 1;
+    }
     pinned_digest_cache()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
         .insert(identity, digest.clone());
+    if let Err(error) = write_durable_pinned_digest(path, identity, &digest) {
+        tracing::warn!(path = %path.display(), %error, "failed to persist artifact digest attestation");
+    }
     Ok(digest)
 }
 
@@ -697,9 +1041,11 @@ pub fn pinned_file_matches(path: &Path, expected_sha256: &str) -> bool {
 /// root — which the model-storage invariant explicitly supports, `0664` and
 /// all — anyone who can write the weights can also write a sidecar naming the
 /// expected digest, and a stale marker can outlive a replace. A writable
-/// attestation is not content authentication. The bytes are hashed every time;
-/// the cost is paid once per process per unchanged file by
-/// [`pinned_file_digest`]'s memo. The marker is still WRITTEN, because
+/// attestation is not content authentication. Instead, the digest is cached by
+/// exact descriptor identity and persisted only in Mold's owner-only,
+/// parent-protected attestation directory. Changed identities hash again; an
+/// unchanged identity survives a process restart without rereading the model.
+/// The marker is still WRITTEN, because
 /// `Config::manifest_files_exist` and the partial-cleanup sweep read it as an
 /// "this file is fully written" signal.
 ///
@@ -2555,7 +2901,7 @@ async fn fetch_recipe_inner(
         // Skipped under `skip_verify` — the user has explicitly asked us
         // not to read the file, so we have nothing to attest.
         if !opts.skip_verify {
-            let actual = compute_sha256(dest_path).map_err(|e| {
+            let actual = pinned_file_digest(dest_path).map_err(|e| {
                 DownloadError::Other(format!(
                     "failed to compute SHA-256 for {}: {e}",
                     dest_path.display()
@@ -3353,9 +3699,9 @@ mod tests {
         std::fs::write(&path, b"the real pinned bytes").unwrap();
         let expected = compute_sha256(&path).unwrap();
 
-        let before = pinned_digest_hash_count();
+        let before = pinned_digest_hash_count_for(&path);
         verify_pinned_file(&path, &expected, "stable.bin", "pinned-bundle").unwrap();
-        let after_first = pinned_digest_hash_count();
+        let after_first = pinned_digest_hash_count_for(&path);
         assert_eq!(
             after_first,
             before + 1,
@@ -3367,7 +3713,7 @@ mod tests {
             assert!(pinned_file_matches(&path, &expected));
         }
         assert_eq!(
-            pinned_digest_hash_count(),
+            pinned_digest_hash_count_for(&path),
             after_first,
             "an unchanged file must not be re-read once it is memoized"
         );
@@ -3375,6 +3721,124 @@ mod tests {
         // partial-cleanup sweep read it as a "fully written" signal. It is
         // just never read back as proof of content.
         assert_eq!(recorded_sha256_marker(&path).as_deref(), Some(&*expected));
+    }
+
+    #[test]
+    fn concurrent_pinned_checks_share_one_physical_hash() {
+        let _serial = pinned_digest_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("single-flight.bin");
+        std::fs::write(&path, vec![0x5a; 4 * 1024 * 1024]).unwrap();
+        let expected = compute_sha256(&path).unwrap();
+        let before = pinned_digest_hash_count_for(&path);
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(5));
+        let mut threads = Vec::new();
+        for _ in 0..4 {
+            let path = path.clone();
+            let expected = expected.clone();
+            let barrier = barrier.clone();
+            threads.push(std::thread::spawn(move || {
+                barrier.wait();
+                assert!(pinned_file_matches(&path, &expected));
+            }));
+        }
+        barrier.wait();
+        for thread in threads {
+            thread.join().unwrap();
+        }
+        assert_eq!(
+            pinned_digest_hash_count_for(&path),
+            before + 1,
+            "concurrent misses for one file identity must share one body read"
+        );
+        let identity =
+            pinned_file_identity(&crate::secure_file::open_regular_file_no_follow(&path).unwrap())
+                .unwrap();
+        assert!(
+            !pinned_digest_flights()
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .contains_key(&identity),
+            "the last flight participant must evict the completed identity"
+        );
+    }
+
+    #[test]
+    fn opened_digest_never_authenticates_a_path_replacement() {
+        let _serial = pinned_digest_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("artifact.bin");
+        let original = dir.path().join("original.bin");
+        std::fs::write(&path, b"reviewed bytes").unwrap();
+        let file = crate::secure_file::open_regular_file_no_follow(&path).unwrap();
+        std::fs::rename(&path, &original).unwrap();
+        std::fs::write(&path, b"attacker bytes").unwrap();
+
+        let error = pinned_file_digest_from_open_file(&path, &file, |_, _| Ok(()))
+            .expect_err("the retained descriptor and current path must name one identity");
+        assert!(error.to_string().contains("path changed"), "{error:#}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn durable_attestation_survives_process_cache_loss_and_rejects_mutation() {
+        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+        let _serial = pinned_digest_lock();
+        let home = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(home.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+        let path = home.path().join("model.bin");
+        std::fs::write(&path, b"verified model bytes").unwrap();
+        let file = crate::secure_file::open_regular_file_no_follow(&path).unwrap();
+        let identity = pinned_file_identity(&file).unwrap();
+        let digest = crate::secure_file::sha256_open_file(&file).unwrap();
+        let attestation_dir = private_attestation_dir_at(home.path(), true).unwrap();
+        let absolute = absolute_pinned_path(&path).unwrap();
+        let target = durable_pinned_digest_path(&attestation_dir, &absolute);
+        let record = DurablePinnedDigest {
+            schema: DURABLE_PINNED_DIGEST_SCHEMA,
+            path: absolute,
+            identity,
+            sha256: digest.clone(),
+        };
+        let record_file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&target)
+            .unwrap();
+        serde_json::to_writer(record_file, &record).unwrap();
+
+        pinned_digest_cache()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .remove(&identity);
+        assert_eq!(
+            read_durable_pinned_digest_from_dir(&attestation_dir, &path, identity).as_deref(),
+            Some(digest.as_str()),
+            "a valid private attestation must replace the process-lifetime body read"
+        );
+
+        std::fs::write(&path, b"tampered model bytes").unwrap();
+        let changed = crate::secure_file::open_regular_file_no_follow(&path).unwrap();
+        let changed_identity = pinned_file_identity(&changed).unwrap();
+        assert_ne!(changed_identity, identity);
+        assert_eq!(
+            read_durable_pinned_digest_from_dir(&attestation_dir, &path, changed_identity),
+            None,
+            "a durable digest is valid only for the exact attested file identity"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn durable_attestation_is_disabled_in_renamable_parent() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let home = tempfile::tempdir().unwrap();
+        std::fs::set_permissions(home.path(), std::fs::Permissions::from_mode(0o770)).unwrap();
+        assert!(private_attestation_dir_at(home.path(), true).is_none());
+        assert!(!home.path().join(DURABLE_PINNED_DIGEST_DIR).exists());
     }
 
     /// The memo must not become the hole the marker was: a file whose bytes
@@ -3388,11 +3852,13 @@ mod tests {
         std::fs::write(&path, b"the real pinned bytes").unwrap();
         let expected = compute_sha256(&path).unwrap();
         verify_pinned_file(&path, &expected, "swapped.bin", "pinned-bundle").unwrap();
-        let after_good = pinned_digest_hash_count();
-
         // Same path, same length, different content — the shape of an
         // in-place substitution in a shared models root.
         std::fs::write(&path, b"the fake pinned bytes").unwrap();
+        let changed_identity =
+            pinned_file_identity(&crate::secure_file::open_regular_file_no_follow(&path).unwrap())
+                .unwrap();
+        let before_changed = pinned_digest_hash_count_for_identity(changed_identity);
         let error = verify_pinned_file(&path, &expected, "swapped.bin", "pinned-bundle")
             .expect_err("replaced bytes must be caught, not served from the memo");
 
@@ -3401,8 +3867,8 @@ mod tests {
             "{error}"
         );
         assert_eq!(
-            pinned_digest_hash_count(),
-            after_good + 1,
+            pinned_digest_hash_count_for_identity(changed_identity),
+            before_changed + 1,
             "a changed file identity must force a fresh read"
         );
         assert!(!path.exists());

--- a/crates/mold-core/src/lib.rs
+++ b/crates/mold-core/src/lib.rs
@@ -30,6 +30,7 @@ pub mod minimax_h3;
 pub mod model_policy;
 pub mod organization;
 pub mod print_title;
+pub mod prompt_text;
 pub mod pulid_assets;
 pub mod reference_upload;
 pub mod removal;
@@ -94,6 +95,7 @@ pub use print_title::{
     validate_print_title, DOWNLOAD_FALLBACK_STEM, DOWNLOAD_MODEL_SLUG_MAX_LEN,
     DOWNLOAD_NAME_SEPARATOR, PRINT_TITLE_MAX_CHARS, TITLE_SLUG_MAX_LEN, TITLE_SLUG_SEPARATOR,
 };
+pub use prompt_text::normalize_prompt_newlines;
 pub use reference_upload::{ReferenceUploadLease, ReferenceUploadSource};
 pub use types::GenerateRequest;
 pub use types::Scheduler;

--- a/crates/mold-core/src/prompt_text.rs
+++ b/crates/mold-core/src/prompt_text.rs
@@ -6,6 +6,8 @@ use std::borrow::Cow;
 ///
 /// A doubled backslash preserves a literal escape (`\\\\n` -> `\\n`), so a
 /// prompt can still describe source text or paths containing those characters.
+/// This transformation is deliberately single-pass and must be applied at
+/// exactly one input boundary.
 pub fn normalize_prompt_newlines(input: &str) -> Cow<'_, str> {
     if !input.contains(['\\', '\r']) {
         return Cow::Borrowed(input);
@@ -68,9 +70,78 @@ where
         .map(|value| value.map(|prompt| normalize_prompt_newlines(&prompt).into_owned()))
 }
 
+fn protect_prompt_for_wire(prompt: &mut String) {
+    if prompt.contains('\\') {
+        *prompt = prompt.replace('\\', "\\\\");
+    }
+}
+
+pub(crate) fn protect_generate_request_for_wire(
+    request: &crate::GenerateRequest,
+) -> crate::GenerateRequest {
+    let mut wire = request.clone();
+    protect_prompt_for_wire(&mut wire.prompt);
+    if let Some(prompt) = wire.negative_prompt.as_mut() {
+        protect_prompt_for_wire(prompt);
+    }
+    if let Some(prompt) = wire.original_prompt.as_mut() {
+        protect_prompt_for_wire(prompt);
+    }
+    if let Some(transform) = wire.prompt_transform.as_mut() {
+        if let Some(prompt) = transform.root_prompt.as_mut() {
+            protect_prompt_for_wire(prompt);
+        }
+        protect_prompt_for_wire(&mut transform.source_prompt);
+    }
+    wire
+}
+
+pub(crate) fn protect_chain_request_for_wire(request: &crate::ChainRequest) -> crate::ChainRequest {
+    let mut wire = request.clone();
+    for stage in &mut wire.stages {
+        protect_prompt_for_wire(&mut stage.prompt);
+        if let Some(prompt) = stage.negative_prompt.as_mut() {
+            protect_prompt_for_wire(prompt);
+        }
+    }
+    if let Some(prompt) = wire.original_prompt.as_mut() {
+        protect_prompt_for_wire(prompt);
+    }
+    if let Some(prompt) = wire.prompt.as_mut() {
+        protect_prompt_for_wire(prompt);
+    }
+    if let Some(transform) = wire.prompt_transform.as_mut() {
+        if let Some(prompt) = transform.root_prompt.as_mut() {
+            protect_prompt_for_wire(prompt);
+        }
+        protect_prompt_for_wire(&mut transform.source_prompt);
+    }
+    wire
+}
+
+pub(crate) fn protect_expand_request_for_wire(
+    request: &crate::ExpandRequest,
+) -> crate::ExpandRequest {
+    let mut wire = request.clone();
+    protect_prompt_for_wire(&mut wire.prompt);
+    wire
+}
+
+pub(crate) fn protect_remix_request_for_wire(request: &crate::RemixRequest) -> crate::RemixRequest {
+    let mut wire = request.clone();
+    protect_prompt_for_wire(&mut wire.source_prompt);
+    if let Some(prompt) = wire.root_prompt.as_mut() {
+        protect_prompt_for_wire(prompt);
+    }
+    wire
+}
+
 #[cfg(test)]
 mod tests {
-    use super::normalize_prompt_newlines;
+    use super::{
+        normalize_prompt_newlines, protect_chain_request_for_wire, protect_expand_request_for_wire,
+        protect_generate_request_for_wire, protect_remix_request_for_wire,
+    };
     use crate::{
         ChainRequest, ExpandRequest, GenerateRequest, OutputMetadata, RemixRequest, Scheduler,
     };
@@ -152,7 +223,7 @@ mod tests {
 
     #[test]
     fn sequence_and_prompt_transform_api_shapes_share_normalization() {
-        let chain: ChainRequest = serde_json::from_value(serde_json::json!({
+        let mut chain: ChainRequest = serde_json::from_value(serde_json::json!({
             "model": "ltx-2-19b-distilled:fp8",
             "stages": [{
                 "prompt": r"opening\n\nshot",
@@ -167,6 +238,7 @@ mod tests {
             "prompt": r"automatic\r\nsequence"
         }))
         .unwrap();
+        chain.normalize_prompt_newlines();
         assert_eq!(chain.stages[0].prompt, "opening\n\nshot");
         assert_eq!(
             chain.stages[0].negative_prompt.as_deref(),
@@ -188,5 +260,84 @@ mod tests {
         .unwrap();
         assert_eq!(remix.source_prompt, "source\nprompt");
         assert_eq!(remix.root_prompt.as_deref(), Some("root\n\nprompt"));
+    }
+
+    #[test]
+    fn shared_rust_client_wire_hop_preserves_canonical_prompt_text() {
+        let request: GenerateRequest = serde_json::from_value(serde_json::json!({
+            "prompt": "placeholder",
+            "model": "flux-schnell",
+            "width": 512,
+            "height": 512,
+            "steps": 4,
+            "batch_size": 1
+        }))
+        .unwrap();
+        let mut request = request;
+        request.prompt = r"canonical C:\new\render and \n token".to_string();
+        request.negative_prompt = Some("blur\nwatermark\\n literal".to_string());
+        request.original_prompt = Some("source\n\nidea\\n literal".to_string());
+        let admitted: GenerateRequest = serde_json::from_slice(
+            &serde_json::to_vec(&protect_generate_request_for_wire(&request)).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(admitted.prompt, request.prompt);
+        assert_eq!(admitted.negative_prompt, request.negative_prompt);
+        assert_eq!(admitted.original_prompt, request.original_prompt);
+
+        let expand = ExpandRequest {
+            prompt: r"expand C:\new and \n token".to_string(),
+            model_family: "flux".to_string(),
+            variations: 1,
+            style: None,
+            task: None,
+        };
+        let admitted: ExpandRequest = serde_json::from_slice(
+            &serde_json::to_vec(&protect_expand_request_for_wire(&expand)).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(admitted.prompt, expand.prompt);
+
+        let remix = RemixRequest {
+            source_prompt: r"remix C:\new and \n token".to_string(),
+            root_prompt: Some("root\nidea\\n literal".to_string()),
+            ..serde_json::from_value(serde_json::json!({
+                "source_prompt": "placeholder"
+            }))
+            .unwrap()
+        };
+        let admitted: RemixRequest = serde_json::from_slice(
+            &serde_json::to_vec(&protect_remix_request_for_wire(&remix)).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(admitted.source_prompt, remix.source_prompt);
+        assert_eq!(admitted.root_prompt, remix.root_prompt);
+
+        let mut chain: ChainRequest = serde_json::from_value(serde_json::json!({
+            "model": "ltx-2-19b-distilled:fp8",
+            "stages": [{
+                "prompt": "placeholder",
+                "frames": 97
+            }],
+            "width": 768,
+            "height": 512,
+            "steps": 8,
+            "guidance": 3.0
+        }))
+        .unwrap();
+        chain.stages[0].prompt = r"sequence C:\new and \n token".to_string();
+        chain.stages[0].negative_prompt = Some("jitter\nflicker\\n literal".to_string());
+        chain.original_prompt = Some("source\nidea\\n literal".to_string());
+        let mut admitted: ChainRequest = serde_json::from_slice(
+            &serde_json::to_vec(&protect_chain_request_for_wire(&chain)).unwrap(),
+        )
+        .unwrap();
+        admitted.normalize_prompt_newlines();
+        assert_eq!(admitted.stages[0].prompt, chain.stages[0].prompt);
+        assert_eq!(
+            admitted.stages[0].negative_prompt,
+            chain.stages[0].negative_prompt
+        );
+        assert_eq!(admitted.original_prompt, chain.original_prompt);
     }
 }

--- a/crates/mold-core/src/prompt_text.rs
+++ b/crates/mold-core/src/prompt_text.rs
@@ -1,0 +1,192 @@
+use serde::{Deserialize, Deserializer};
+use std::borrow::Cow;
+
+/// Canonicalize prompt line endings and decode newline escapes left literal
+/// by shell arguments or over-encoded API clients.
+///
+/// A doubled backslash preserves a literal escape (`\\\\n` -> `\\n`), so a
+/// prompt can still describe source text or paths containing those characters.
+pub fn normalize_prompt_newlines(input: &str) -> Cow<'_, str> {
+    if !input.contains(['\\', '\r']) {
+        return Cow::Borrowed(input);
+    }
+
+    let mut chars = input.chars().peekable();
+    let mut output = String::with_capacity(input.len());
+    while let Some(ch) = chars.next() {
+        match ch {
+            '\r' => {
+                if chars.peek() == Some(&'\n') {
+                    chars.next();
+                }
+                output.push('\n');
+            }
+            '\\' => match chars.peek().copied() {
+                Some('\\') => {
+                    chars.next();
+                    output.push('\\');
+                }
+                Some('n') => {
+                    chars.next();
+                    output.push('\n');
+                }
+                Some('r') => {
+                    chars.next();
+                    if chars.peek() == Some(&'\\') {
+                        let mut lookahead = chars.clone();
+                        lookahead.next();
+                        if lookahead.peek() == Some(&'n') {
+                            chars.next();
+                            chars.next();
+                        }
+                    }
+                    output.push('\n');
+                }
+                _ => output.push('\\'),
+            },
+            _ => output.push(ch),
+        }
+    }
+    Cow::Owned(output)
+}
+
+pub(crate) fn deserialize_prompt<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = String::deserialize(deserializer)?;
+    Ok(normalize_prompt_newlines(&value).into_owned())
+}
+
+pub(crate) fn deserialize_optional_prompt<'de, D>(
+    deserializer: D,
+) -> Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Option::<String>::deserialize(deserializer)
+        .map(|value| value.map(|prompt| normalize_prompt_newlines(&prompt).into_owned()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_prompt_newlines;
+    use crate::{
+        ChainRequest, ExpandRequest, GenerateRequest, OutputMetadata, RemixRequest, Scheduler,
+    };
+
+    #[test]
+    fn decodes_literal_and_platform_newlines() {
+        assert_eq!(
+            normalize_prompt_newlines(r"first\n\nsecond\r\nthird"),
+            "first\n\nsecond\nthird"
+        );
+        assert_eq!(
+            normalize_prompt_newlines("first\r\nsecond\rthird"),
+            "first\nsecond\nthird"
+        );
+    }
+
+    #[test]
+    fn doubled_backslash_preserves_literal_escape_text() {
+        assert_eq!(
+            normalize_prompt_newlines(r"show \\n literally"),
+            r"show \n literally"
+        );
+        assert_eq!(
+            normalize_prompt_newlines(r"C:\\new\\render"),
+            r"C:\new\render"
+        );
+    }
+
+    #[test]
+    fn leaves_plain_prompts_borrowed_and_unchanged() {
+        let prompt = "a portrait with soft window light";
+        let normalized = normalize_prompt_newlines(prompt);
+        assert!(matches!(normalized, std::borrow::Cow::Borrowed(_)));
+        assert_eq!(normalized, prompt);
+    }
+
+    #[test]
+    fn direct_api_generation_normalizes_all_prompt_provenance() {
+        let request: GenerateRequest = serde_json::from_value(serde_json::json!({
+            "prompt": r"first\n\nsecond",
+            "negative_prompt": r"blur\r\nwatermark",
+            "original_prompt": r"first\n\nsecond",
+            "prompt_transform": {
+                "operation": "expand",
+                "root_prompt": r"root\n\nidea",
+                "source_prompt": r"source\r\nprompt",
+                "source_kind": "direct",
+                "task": "text-to-image"
+            },
+            "model": "flux-schnell",
+            "width": 512,
+            "height": 512,
+            "steps": 4,
+            "batch_size": 1
+        }))
+        .unwrap();
+
+        assert_eq!(request.prompt, "first\n\nsecond");
+        assert_eq!(request.negative_prompt.as_deref(), Some("blur\nwatermark"));
+        assert_eq!(request.original_prompt.as_deref(), Some("first\n\nsecond"));
+        let transform = request.prompt_transform.as_ref().unwrap();
+        assert_eq!(transform.root_prompt.as_deref(), Some("root\n\nidea"));
+        assert_eq!(transform.source_prompt, "source\nprompt");
+
+        // Legacy embedded metadata is deserialized through the same contract,
+        // so Library and Reuse settings improve without regenerating a print.
+        let metadata =
+            OutputMetadata::from_generate_request(&request, 42, Some(Scheduler::Ddim), "test");
+        let mut wire = serde_json::to_value(metadata).unwrap();
+        wire["prompt"] = serde_json::Value::String(r"legacy\n\nprompt".to_string());
+        wire["negative_prompt"] = serde_json::Value::String(r"legacy\r\nnegative".to_string());
+        let restored: OutputMetadata = serde_json::from_value(wire).unwrap();
+        assert_eq!(restored.prompt, "legacy\n\nprompt");
+        assert_eq!(
+            restored.negative_prompt.as_deref(),
+            Some("legacy\nnegative")
+        );
+    }
+
+    #[test]
+    fn sequence_and_prompt_transform_api_shapes_share_normalization() {
+        let chain: ChainRequest = serde_json::from_value(serde_json::json!({
+            "model": "ltx-2-19b-distilled:fp8",
+            "stages": [{
+                "prompt": r"opening\n\nshot",
+                "negative_prompt": r"jitter\r\nflicker",
+                "frames": 97
+            }],
+            "width": 768,
+            "height": 512,
+            "steps": 8,
+            "guidance": 3.0,
+            "original_prompt": r"source\n\nidea",
+            "prompt": r"automatic\r\nsequence"
+        }))
+        .unwrap();
+        assert_eq!(chain.stages[0].prompt, "opening\n\nshot");
+        assert_eq!(
+            chain.stages[0].negative_prompt.as_deref(),
+            Some("jitter\nflicker")
+        );
+        assert_eq!(chain.original_prompt.as_deref(), Some("source\n\nidea"));
+        assert_eq!(chain.prompt.as_deref(), Some("automatic\nsequence"));
+
+        let expand: ExpandRequest = serde_json::from_value(serde_json::json!({
+            "prompt": r"expand\n\nthis"
+        }))
+        .unwrap();
+        assert_eq!(expand.prompt, "expand\n\nthis");
+
+        let remix: RemixRequest = serde_json::from_value(serde_json::json!({
+            "source_prompt": r"source\r\nprompt",
+            "root_prompt": r"root\n\nprompt"
+        }))
+        .unwrap();
+        assert_eq!(remix.source_prompt, "source\nprompt");
+        assert_eq!(remix.root_prompt.as_deref(), Some("root\n\nprompt"));
+    }
+}

--- a/crates/mold-core/src/prompt_text.rs
+++ b/crates/mold-core/src/prompt_text.rs
@@ -136,11 +136,22 @@ pub(crate) fn protect_remix_request_for_wire(request: &crate::RemixRequest) -> c
     wire
 }
 
+pub(crate) fn protect_retake_request_for_wire(
+    request: &crate::chain_job::RetakeRequest,
+) -> crate::chain_job::RetakeRequest {
+    let mut wire = request.clone();
+    if let Some(prompt) = wire.prompt.as_mut() {
+        protect_prompt_for_wire(prompt);
+    }
+    wire
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
         normalize_prompt_newlines, protect_chain_request_for_wire, protect_expand_request_for_wire,
         protect_generate_request_for_wire, protect_remix_request_for_wire,
+        protect_retake_request_for_wire,
     };
     use crate::{
         ChainRequest, ExpandRequest, GenerateRequest, OutputMetadata, RemixRequest, Scheduler,
@@ -339,5 +350,18 @@ mod tests {
             chain.stages[0].negative_prompt
         );
         assert_eq!(admitted.original_prompt, chain.original_prompt);
+
+        let retake = crate::chain_job::RetakeRequest {
+            stage_idx: 0,
+            mode: crate::chain_job::RetakeMode::Cascade,
+            seed_offset: None,
+            prompt: Some("retake\nidea\\n literal".to_string()),
+        };
+        let mut admitted: crate::chain_job::RetakeRequest = serde_json::from_slice(
+            &serde_json::to_vec(&protect_retake_request_for_wire(&retake)).unwrap(),
+        )
+        .unwrap();
+        admitted.normalize_prompt_newlines();
+        assert_eq!(admitted.prompt, retake.prompt);
     }
 }

--- a/crates/mold-core/src/types.rs
+++ b/crates/mold-core/src/types.rs
@@ -442,8 +442,13 @@ pub enum PromptTransformOperation {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct PromptTransformProvenance {
     pub operation: PromptTransformOperation,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::prompt_text::deserialize_optional_prompt"
+    )]
     pub root_prompt: Option<String>,
+    #[serde(deserialize_with = "crate::prompt_text::deserialize_prompt")]
     pub source_prompt: String,
     #[serde(default)]
     pub source_kind: RemixSourceKind,
@@ -457,6 +462,7 @@ pub struct PromptTransformProvenance {
 pub struct ExpandRequest {
     /// Short prompt to expand
     #[schema(example = "a cat")]
+    #[serde(deserialize_with = "crate::prompt_text::deserialize_prompt")]
     pub prompt: String,
     /// Model family for prompt style (flux, sdxl, sd15, sd3, etc.)
     #[serde(default = "default_expand_model_family")]
@@ -504,8 +510,13 @@ fn default_remix_variations() -> usize {
 /// silently ignoring a mode field and returning the wrong transform.
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct RemixRequest {
+    #[serde(deserialize_with = "crate::prompt_text::deserialize_prompt")]
     pub source_prompt: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::prompt_text::deserialize_optional_prompt"
+    )]
     pub root_prompt: Option<String>,
     #[serde(default)]
     pub source_kind: RemixSourceKind,
@@ -1175,11 +1186,16 @@ impl CollectionRef {
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct GenerateRequest {
     #[schema(example = "a cat sitting on a windowsill at sunset")]
+    #[serde(deserialize_with = "crate::prompt_text::deserialize_prompt")]
     pub prompt: String,
     /// Negative prompt — describes what to avoid generating.
     /// Effective for CFG-based models such as SD1.5, SDXL, SD3, and Wuerstchen.
     /// Ignored by distilled / non-CFG families such as FLUX schnell, Z-Image, etc.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::prompt_text::deserialize_optional_prompt"
+    )]
     #[schema(example = "blurry, low quality, watermark")]
     pub negative_prompt: Option<String>,
     #[schema(example = "flux-schnell:q8")]
@@ -1343,7 +1359,11 @@ pub struct GenerateRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub expand: Option<bool>,
     /// Original user prompt before expansion (set by client when expanding locally).
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::prompt_text::deserialize_optional_prompt"
+    )]
     pub original_prompt: Option<String>,
     /// Structured prompt-transform provenance. New clients also populate
     /// `original_prompt` so older hosts retain the root/source prompt.
@@ -2139,6 +2159,7 @@ pub enum GenerationOutputMode {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct OutputMetadata {
+    #[serde(deserialize_with = "crate::prompt_text::deserialize_prompt")]
     pub prompt: String,
     /// User-authored print title as it was at creation. Embedded so mirrors
     /// and imports carry it; the gallery row (`generations.title`) is the
@@ -2157,9 +2178,17 @@ pub struct OutputMetadata {
     /// actually resolve. Additive.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub collection: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::prompt_text::deserialize_optional_prompt"
+    )]
     pub negative_prompt: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "crate::prompt_text::deserialize_optional_prompt"
+    )]
     pub original_prompt: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub prompt_transform: Option<PromptTransformProvenance>,

--- a/crates/mold-inference/src/minimax_h3/private_qualification.rs
+++ b/crates/mold-inference/src/minimax_h3/private_qualification.rs
@@ -908,66 +908,6 @@ fn require_regular_artifact(artifact: &ResolvedArtifact<'_>) -> Result<()> {
     Ok(())
 }
 
-/// Process-lifetime SHA-256 digest cache for the bulk artifact reads.
-///
-/// Placement previews and admission run full artifact qualification per
-/// request — and per candidate device — which re-hashed the same ~42 GB
-/// checkpoint set every time and made an H3 preview take minutes (the desktop
-/// sat in "Planning…" with no feedback). A digest may be reused only when the
-/// file's complete metadata identity (device, inode, size, mode, owner,
-/// mtime, ctime — the same `FileIdentity` the admission→dispatch revalidation
-/// already trusts) is byte-for-byte unchanged AND the pinned manifest hash
-/// matches; anything else re-hashes. Every structural, scope, and support
-/// check still runs on each qualification — only the redundant bulk read is
-/// skipped.
-static ARTIFACT_DIGEST_CACHE: std::sync::OnceLock<
-    std::sync::Mutex<std::collections::HashMap<PathBuf, (FileIdentity, String)>>,
-> = std::sync::OnceLock::new();
-
-fn artifact_digest_cache(
-) -> &'static std::sync::Mutex<std::collections::HashMap<PathBuf, (FileIdentity, String)>> {
-    ARTIFACT_DIGEST_CACHE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
-}
-
-fn lookup_cached_artifact_digest(
-    canonical_path: &Path,
-    identity: &FileIdentity,
-    expected_sha: &str,
-) -> Option<String> {
-    let cache = artifact_digest_cache().lock().ok()?;
-    let (cached_identity, cached_sha) = cache.get(canonical_path)?;
-    if cached_identity == identity && cached_sha.eq_ignore_ascii_case(expected_sha) {
-        Some(cached_sha.clone())
-    } else {
-        None
-    }
-}
-
-fn store_cached_artifact_digest(canonical_path: &Path, identity: FileIdentity, sha256: String) {
-    if let Ok(mut cache) = artifact_digest_cache().lock() {
-        cache.insert(canonical_path.to_path_buf(), (identity, sha256));
-    }
-}
-
-/// Per-canonical-path single-flight guard: concurrent qualifications that both
-/// miss the digest cache must not duplicate a cold multi-gigabyte hash. The
-/// loser blocks until the winner stores its digest, then reuses it through the
-/// ordinary cache lookup. Poisoning is deliberately ignored — a panicking
-/// winner leaves no cache entry, so the next holder simply re-hashes.
-static ARTIFACT_HASH_FLIGHTS: std::sync::OnceLock<
-    std::sync::Mutex<std::collections::HashMap<PathBuf, std::sync::Arc<std::sync::Mutex<()>>>>,
-> = std::sync::OnceLock::new();
-
-fn artifact_hash_flight(canonical_path: &Path) -> std::sync::Arc<std::sync::Mutex<()>> {
-    let flights = ARTIFACT_HASH_FLIGHTS
-        .get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()));
-    let mut map = match flights.lock() {
-        Ok(map) => map,
-        Err(poisoned) => poisoned.into_inner(),
-    };
-    map.entry(canonical_path.to_path_buf()).or_default().clone()
-}
-
 fn hash_exact_file(
     artifact: &ResolvedArtifact<'_>,
     expected_sha: &str,
@@ -983,7 +923,7 @@ fn hash_exact_file(
         bail!("private H3 artifact {relative_path} is no longer a regular non-symlink file")
     }
     let before_path = FileIdentity::from_metadata(&before_path_metadata);
-    let mut file = File::open(&artifact.canonical_path)
+    let file = mold_core::secure_file::open_regular_file_no_follow(&artifact.canonical_path)
         .with_context(|| format!("failed to open private H3 artifact {relative_path}"))?;
     let before = FileIdentity::from_metadata(
         &file
@@ -1000,74 +940,23 @@ fn hash_exact_file(
             artifact.file.size_bytes
         )
     }
-    let flight = artifact_hash_flight(&artifact.canonical_path);
-    let _hash_flight = loop {
-        match flight.try_lock() {
-            Ok(guard) => break guard,
-            Err(std::sync::TryLockError::Poisoned(poisoned)) => break poisoned.into_inner(),
-            Err(std::sync::TryLockError::WouldBlock) => {
-                // A zero-progress heartbeat keeps the caller's cooperative
-                // cancellation live while another attempt owns the flight.
-                progress(H3ArtifactHashProgress {
-                    relative_path: relative_path.clone(),
-                    artifact_bytes_verified: 0,
-                    artifact_bytes_total: before.len,
-                    total_bytes_verified: verified_before,
-                    total_bytes,
-                })?;
-                std::thread::sleep(std::time::Duration::from_millis(100));
-            }
-        }
-    };
-    if let Some(cached_sha) =
-        lookup_cached_artifact_digest(&artifact.canonical_path, &before, expected_sha)
-    {
-        progress(H3ArtifactHashProgress {
-            relative_path,
-            artifact_bytes_verified: before.len,
-            artifact_bytes_total: before.len,
-            total_bytes_verified: verified_before
-                .checked_add(before.len)
-                .ok_or_else(|| anyhow!("private H3 progress byte count overflow"))?,
-            total_bytes,
-        })?;
-        return Ok((cached_sha, before));
-    }
-    let mut digest = Sha256::new();
-    let mut buffer = vec![0_u8; HASH_BUFFER_BYTES];
-    let mut artifact_bytes_verified = 0_u64;
-    progress(H3ArtifactHashProgress {
-        relative_path: relative_path.clone(),
-        artifact_bytes_verified,
-        artifact_bytes_total: before.len,
-        total_bytes_verified: verified_before,
-        total_bytes,
-    })?;
-    loop {
-        let read = file
-            .read(&mut buffer)
-            .with_context(|| format!("failed to hash private H3 artifact {relative_path}"))?;
-        if read == 0 {
-            break;
-        }
-        digest.update(&buffer[..read]);
-        artifact_bytes_verified = artifact_bytes_verified
-            .checked_add(read as u64)
-            .ok_or_else(|| anyhow!("private H3 artifact hash byte count overflow"))?;
-        let total_bytes_verified = verified_before
-            .checked_add(artifact_bytes_verified)
-            .ok_or_else(|| anyhow!("private H3 progress byte count overflow"))?;
-        progress(H3ArtifactHashProgress {
-            relative_path: relative_path.clone(),
-            artifact_bytes_verified,
-            artifact_bytes_total: before.len,
-            total_bytes_verified,
-            total_bytes,
-        })?;
-    }
-    if artifact_bytes_verified != before.len {
-        bail!("private H3 artifact {relative_path} changed length during hashing")
-    }
+    let actual = mold_core::download::pinned_file_digest_from_open_file(
+        &artifact.canonical_path,
+        &file,
+        |artifact_bytes_verified, artifact_bytes_total| {
+            let total_bytes_verified = verified_before
+                .checked_add(artifact_bytes_verified)
+                .ok_or_else(|| anyhow!("private H3 progress byte count overflow"))?;
+            progress(H3ArtifactHashProgress {
+                relative_path: relative_path.clone(),
+                artifact_bytes_verified,
+                artifact_bytes_total,
+                total_bytes_verified,
+                total_bytes,
+            })
+        },
+    )
+    .with_context(|| format!("failed to hash private H3 artifact {relative_path}"))?;
     let after_open = FileIdentity::from_metadata(&file.metadata()?);
     let after_path_metadata = fs::symlink_metadata(&artifact.canonical_path)?;
     if !after_path_metadata.file_type().is_file() || after_path_metadata.file_type().is_symlink() {
@@ -1077,13 +966,11 @@ fn hash_exact_file(
     if before != after_open || before != after_path {
         bail!("private H3 artifact {relative_path} changed during hashing")
     }
-    let actual = format!("{:x}", digest.finalize());
     if !actual.eq_ignore_ascii_case(expected_sha) {
         bail!(
             "private H3 artifact {relative_path} SHA-256 mismatch: expected {expected_sha}, found {actual}"
         )
     }
-    store_cached_artifact_digest(&artifact.canonical_path, before.clone(), actual.clone());
     Ok((actual, before))
 }
 
@@ -1831,80 +1718,6 @@ mod tests {
             canonical_path: link,
         };
         assert!(require_regular_artifact(&aliased).is_err());
-    }
-
-    #[test]
-    fn digest_cache_reuses_only_byte_identical_metadata_identities() {
-        let directory = tempfile::tempdir().unwrap();
-        let path = directory.path().join("artifact.safetensors");
-        fs::write(&path, b"cached artifact bytes").unwrap();
-        let identity = FileIdentity::from_metadata(&fs::symlink_metadata(&path).unwrap());
-        let sha = "a".repeat(64);
-
-        // Nothing cached yet.
-        assert!(lookup_cached_artifact_digest(&path, &identity, &sha).is_none());
-
-        store_cached_artifact_digest(&path, identity.clone(), sha.clone());
-        assert_eq!(
-            lookup_cached_artifact_digest(&path, &identity, &sha).as_deref(),
-            Some(sha.as_str())
-        );
-        // The pinned manifest digest is part of the hit condition — a cache
-        // entry can never satisfy a different expected hash.
-        assert!(lookup_cached_artifact_digest(&path, &identity, &"b".repeat(64)).is_none());
-
-        // Any metadata drift (here: a rewrite bumping mtime/ctime/size) is a
-        // miss, so changed bytes are always re-hashed.
-        fs::write(&path, b"replaced artifact bytes!").unwrap();
-        let changed = FileIdentity::from_metadata(&fs::symlink_metadata(&path).unwrap());
-        assert!(lookup_cached_artifact_digest(&path, &changed, &sha).is_none());
-
-        // Storing the new identity evicts the stale entry.
-        let new_sha = "c".repeat(64);
-        store_cached_artifact_digest(&path, changed.clone(), new_sha.clone());
-        assert_eq!(
-            lookup_cached_artifact_digest(&path, &changed, &new_sha).as_deref(),
-            Some(new_sha.as_str())
-        );
-        assert!(lookup_cached_artifact_digest(&path, &identity, &sha).is_none());
-    }
-
-    #[test]
-    fn hash_flight_serializes_cold_fills_per_path() {
-        let directory = tempfile::tempdir().unwrap();
-        let path = directory.path().join("flight.safetensors");
-        fs::write(&path, b"flight artifact bytes").unwrap();
-        let other = directory.path().join("other.safetensors");
-
-        // One flight per canonical path, shared across callers.
-        assert!(std::sync::Arc::ptr_eq(
-            &artifact_hash_flight(&path),
-            &artifact_hash_flight(&path)
-        ));
-        assert!(!std::sync::Arc::ptr_eq(
-            &artifact_hash_flight(&path),
-            &artifact_hash_flight(&other)
-        ));
-
-        // A loser blocked on the winner's flight observes the winner's stored
-        // digest as soon as it acquires the lock — it never re-hashes.
-        let identity = FileIdentity::from_metadata(&fs::symlink_metadata(&path).unwrap());
-        let sha = "d".repeat(64);
-        let flight = artifact_hash_flight(&path);
-        let winner_guard = flight.lock().unwrap();
-        let loser = std::thread::spawn({
-            let flight = artifact_hash_flight(&path);
-            let path = path.clone();
-            let identity = identity.clone();
-            let sha = sha.clone();
-            move || {
-                let _guard = flight.lock().unwrap();
-                lookup_cached_artifact_digest(&path, &identity, &sha)
-            }
-        });
-        store_cached_artifact_digest(&path, identity, sha.clone());
-        drop(winner_guard);
-        assert_eq!(loser.join().unwrap().as_deref(), Some(sha.as_str()));
     }
 
     #[cfg(unix)]

--- a/crates/mold-server/src/host_reclaim.rs
+++ b/crates/mold-server/src/host_reclaim.rs
@@ -248,6 +248,17 @@ async fn reclaim_candidates(state: &AppState, requested_model: &str) -> Vec<Recl
     plan_reclaim(candidates, requested_model)
 }
 
+/// Whether a real admission could make host headroom by releasing Mold's own
+/// idle model cache.
+///
+/// Placement preview is a read-only authority boundary, so it may ask this
+/// question but must never call [`reclaim_host_headroom`]. The answer carries
+/// no byte estimate: only the completed teardown and a fresh OS sample can say
+/// how many host pages an engine actually returned.
+pub(crate) async fn has_reclaimable_cached_model(state: &AppState, requested_model: &str) -> bool {
+    !reclaim_candidates(state, requested_model).await.is_empty()
+}
+
 /// Why one eviction did not happen.
 ///
 /// The two arms differ in what they say about the NEXT target: a failure is

--- a/crates/mold-server/src/routes_chain.rs
+++ b/crates/mold-server/src/routes_chain.rs
@@ -1059,6 +1059,7 @@ pub async fn validate_chain(
     State(state): State<AppState>,
     Json(mut req): Json<ChainRequest>,
 ) -> Result<Json<ChainValidationResponse>, ApiError> {
+    req.normalize_prompt_newlines();
     let opening_transition = req.stages.first().map(|stage| stage.transition);
     let requested_motion_tail = req.motion_tail_frames;
     let mut warnings = Vec::new();
@@ -1182,11 +1183,12 @@ async fn chain_vram_estimate(
 )]
 pub async fn generate_chain(
     State(state): State<AppState>,
-    Json(req): Json<ChainRequest>,
+    Json(mut req): Json<ChainRequest>,
 ) -> axum::response::Response {
     use axum::http::StatusCode;
     use axum::response::IntoResponse;
 
+    req.normalize_prompt_newlines();
     if let Some(reason) = state.generation_unavailable() {
         return ApiError::generation_unavailable(reason).into_response();
     }
@@ -1276,7 +1278,7 @@ pub async fn generate_chain(
 pub async fn generate_chain_stream(
     State(state): State<AppState>,
     headers: HeaderMap,
-    Json(req): Json<ChainRequest>,
+    Json(mut req): Json<ChainRequest>,
 ) -> Result<
     (
         HeaderMap,
@@ -1284,6 +1286,7 @@ pub async fn generate_chain_stream(
     ),
     ApiError,
 > {
+    req.normalize_prompt_newlines();
     if let Some(reason) = state.generation_unavailable() {
         return Err(ApiError::generation_unavailable(reason));
     }

--- a/crates/mold-server/src/routes_chain_jobs.rs
+++ b/crates/mold-server/src/routes_chain_jobs.rs
@@ -457,8 +457,9 @@ pub async fn resume_chain_job(
 pub async fn retake_chain_job(
     State(state): State<AppState>,
     Path(id): Path<String>,
-    Json(req): Json<RetakeRequest>,
+    Json(mut req): Json<RetakeRequest>,
 ) -> Result<(StatusCode, Json<ChainJobSummary>), ApiError> {
+    req.normalize_prompt_newlines();
     crate::routes::ensure_generation_available(&state)?;
     let handle = chain_jobs_handle(&state)?;
     let db = metadata_db(&state)?;
@@ -528,8 +529,9 @@ pub async fn amend_chain_job(
     State(state): State<AppState>,
     Path(id): Path<String>,
     headers: HeaderMap,
-    Json(req): Json<AmendRequest>,
+    Json(mut req): Json<AmendRequest>,
 ) -> Result<(StatusCode, Json<AmendResponse>), ApiError> {
+    req.normalize_prompt_newlines();
     let handle = chain_jobs_handle(&state)?;
     let db = metadata_db(&state)?;
     let root = jobs_root()?;
@@ -540,7 +542,6 @@ pub async fn amend_chain_job(
     // inside `apply_amend`). The gate may normalise chain-level fields (e.g.
     // ltx-video forces motion_tail_frames to 0); carry that back into the
     // amend overlays so the stored request matches what was validated.
-    let mut req = req;
     {
         let row = chain_jobs::get_job(db, &id)
             .map_err(|e| ApiError::internal(format!("failed to load chain job: {e:#}")))?
@@ -2082,10 +2083,10 @@ mod tests {
         let mut events_rx = state.events.subscribe();
         let mut stages = request.stages;
         stages.push(ChainStage {
-            prompt: "appended clip".into(),
+            prompt: r"appended\n\nclip\\n literal".into(),
             frames: 9,
             source_image: None,
-            negative_prompt: None,
+            negative_prompt: Some(r"jitter\r\nflicker".into()),
             seed_offset: None,
             transition: TransitionMode::Cut,
             fade_frames: None,
@@ -2110,6 +2111,17 @@ mod tests {
         );
         assert_eq!(body.summary.state, ChainJobState::Queued);
         assert_eq!(body.summary.stage_count, 2);
+
+        let row = chain_jobs::get_job(db.as_ref().as_ref().unwrap(), &created.job_id)
+            .unwrap()
+            .unwrap();
+        let manifest = ChainJobManifest::read_from_dir(&row.job_dir).unwrap();
+        let effective = crate::chain_job_runner::effective_request(&manifest).unwrap();
+        assert_eq!(effective.stages[1].prompt, "appended\n\nclip\\n literal");
+        assert_eq!(
+            effective.stages[1].negative_prompt.as_deref(),
+            Some("jitter\nflicker")
+        );
 
         let event = events_rx.try_recv().expect("chain_job_queued published");
         let wire = serde_json::to_value(&event).unwrap();
@@ -2684,7 +2696,7 @@ mod tests {
                     stage_idx: 0,
                     mode: mold_core::chain_job::RetakeMode::Cascade,
                     seed_offset: Some(9),
-                    prompt: Some("ordinary retake".into()),
+                    prompt: Some(r"ordinary\n\nretake\\n literal".into()),
                 }),
             ))
         })
@@ -2696,7 +2708,7 @@ mod tests {
         assert_eq!(manifest.retakes.len(), 1);
         assert_eq!(
             manifest.retakes[0].new_prompt.as_deref(),
-            Some("ordinary retake")
+            Some("ordinary\n\nretake\\n literal")
         );
     }
 

--- a/crates/mold-server/src/routes_chain_jobs.rs
+++ b/crates/mold-server/src/routes_chain_jobs.rs
@@ -105,6 +105,7 @@ pub async fn create_chain_job(
     ),
     ApiError,
 > {
+    req.normalize_prompt_newlines();
     crate::routes::ensure_generation_available(&state)?;
     let handle = chain_jobs_handle(&state)?;
     let db = metadata_db(&state)?;

--- a/crates/mold-server/src/scheduler/mod.rs
+++ b/crates/mold-server/src/scheduler/mod.rs
@@ -4173,8 +4173,11 @@ impl Coordinator {
             Err(error) => {
                 let failure =
                     classify_generation_plan_failure(error, &self.total_vram_bytes_by_device_id());
-                let outcome = placement_preview_outcome_for_plan_failure(&failure);
-                return empty(outcome, failure.to_string());
+                let (authoritative, outcome) =
+                    placement_preview_disposition_for_plan_failure(&failure);
+                let mut response = empty(outcome, failure.to_string());
+                response.authoritative = authoritative;
+                return response;
             }
         };
         if cancelled() {
@@ -6626,12 +6629,18 @@ fn classify_generation_plan_failure(
     }
 }
 
-fn placement_preview_outcome_for_plan_failure(failure: &GenerationPlanFailure) -> &'static str {
+fn placement_preview_disposition_for_plan_failure(
+    failure: &GenerationPlanFailure,
+) -> (bool, &'static str) {
     match failure {
-        GenerationPlanFailure::Terminal(_) => "infeasible",
-        GenerationPlanFailure::Transient(_) | GenerationPlanFailure::StalePreparation(_) => {
-            "temporarily_unavailable"
-        }
+        GenerationPlanFailure::Terminal(_) => (true, "infeasible"),
+        GenerationPlanFailure::Transient(_) => (true, "temporarily_unavailable"),
+        // A queued generation already resets stale preparation and runs the
+        // admission preparer again. Publishing this as authoritative transient
+        // pressure prevents clients from reaching that recovery path. Decline
+        // preview authority instead: compatible requests may enter normal
+        // admission, where cache reclaim and fresh evidence are both owned.
+        GenerationPlanFailure::StalePreparation(_) => (false, "unsupported"),
     }
 }
 
@@ -9834,9 +9843,25 @@ mod tests {
             "a physically fitting job waits for the active lane instead of being refused"
         );
         assert_eq!(
-            placement_preview_outcome_for_plan_failure(&failure),
-            "temporarily_unavailable",
+            placement_preview_disposition_for_plan_failure(&failure),
+            (true, "temporarily_unavailable"),
             "placement preview must not turn current lane pressure into infeasibility"
+        );
+    }
+
+    #[test]
+    fn stale_preparation_declines_preview_authority_so_admission_can_reclaim() {
+        let failure = classify_generation_plan_failure(
+            crate::execution_plan::ExecutionPlanError::PreparedInputsStale(
+                "host capacity changed after private admission".to_string(),
+            ),
+            &BTreeMap::new(),
+        );
+
+        assert_eq!(
+            placement_preview_disposition_for_plan_failure(&failure),
+            (false, "unsupported"),
+            "the mutating admission path must get the chance to refresh evidence and unload cache"
         );
     }
 
@@ -15601,8 +15626,8 @@ mod tests {
             &BTreeMap::from([("cuda:0".to_string(), RTX_4090_TOTAL)]),
         );
         assert_eq!(
-            placement_preview_outcome_for_plan_failure(&impossible),
-            "infeasible"
+            placement_preview_disposition_for_plan_failure(&impossible),
+            (true, "infeasible")
         );
         assert!(
             !insufficient_vram_is_terminal(20_000_000_000, RTX_4090_TOTAL),

--- a/crates/mold-server/src/variant_dependencies.rs
+++ b/crates/mold-server/src/variant_dependencies.rs
@@ -1786,6 +1786,28 @@ mod preparation_cancellation_tests {
 #[cfg(any(feature = "h3", feature = "h3-private-uat"))]
 type HostShortfall = mold_inference::H3PrivateHostHeadroomShortfall;
 
+/// Host headroom private preparation may use without mutating server state.
+///
+/// A real admission always uses the sampled value. A read-only preview may
+/// prove the immutable H3 execution shape against the host's physical ceiling
+/// when Mold has an idle, non-requested engine it can release at admission.
+/// The later live recheck still sees the sampled value and deliberately turns
+/// that conditional plan into a non-authoritative fallback; it can never be
+/// published as an exact placement while the cache remains resident.
+#[cfg(any(feature = "h3", feature = "h3-private-uat"))]
+fn h3_preparation_host_headroom(
+    policy: DependencyMaterializationPolicy,
+    host: crate::h3_admission::H3HostMemory,
+    has_reclaimable_cached_model: bool,
+) -> u64 {
+    let sampled = host.headroom_bytes();
+    if policy == DependencyMaterializationPolicy::ExistingOnly && has_reclaimable_cached_model {
+        host.total_bytes.saturating_sub(host.safety_floor_bytes())
+    } else {
+        sampled
+    }
+}
+
 /// How much host headroom a reclaim has to reach for this attempt to be worth
 /// retrying, or `None` when it must not run at all.
 ///
@@ -1881,8 +1903,19 @@ async fn prepare_h3_private_inputs_for_devices(
     if devices.is_empty() {
         return Err("request placement has no eligible schedulable device".into());
     }
+    let host_memory = crate::h3_admission::current_h3_host_memory();
+    let has_reclaimable_cached_model = if policy == DependencyMaterializationPolicy::ExistingOnly {
+        match state {
+            Some(state) => {
+                crate::host_reclaim::has_reclaimable_cached_model(state, &request.model).await
+            }
+            None => false,
+        }
+    } else {
+        false
+    };
     let mut available_host_headroom_bytes =
-        crate::h3_admission::current_h3_host_memory().headroom_bytes();
+        h3_preparation_host_headroom(policy, host_memory, has_reclaimable_cached_model);
     let uat_paths =
         crate::h3_private_bridge::H3PrivateUatPathSet::resolve(config.resolved_models_dir());
     // The public runtime owns its MOLD_HOME-derived staging root; create it
@@ -2386,6 +2419,38 @@ mod tests {
             ),
             None,
             "a read-only placement preview must never evict a model cache"
+        );
+    }
+
+    #[cfg(any(feature = "h3", feature = "h3-private-uat"))]
+    #[test]
+    fn preview_can_prepare_against_only_cache_reclaimable_host_capacity() {
+        const GIB: u64 = 1 << 30;
+        let host = crate::h3_admission::H3HostMemory {
+            total_bytes: 64 * GIB,
+            available_bytes: 20 * GIB,
+        };
+        let sampled = host.headroom_bytes();
+        let physical_ceiling = host.total_bytes - host.safety_floor_bytes();
+
+        assert_eq!(
+            h3_preparation_host_headroom(DependencyMaterializationPolicy::Admission, host, true),
+            sampled,
+            "real admission must never spend memory an eviction has not returned"
+        );
+        assert_eq!(
+            h3_preparation_host_headroom(
+                DependencyMaterializationPolicy::ExistingOnly,
+                host,
+                false
+            ),
+            sampled,
+            "external pressure is not reclaimable"
+        );
+        assert_eq!(
+            h3_preparation_host_headroom(DependencyMaterializationPolicy::ExistingOnly, host, true),
+            physical_ceiling,
+            "preview may derive evidence conditionally when admission owns an idle cache victim"
         );
     }
 

--- a/desktop/src/components/gallery/Lightbox.test.ts
+++ b/desktop/src/components/gallery/Lightbox.test.ts
@@ -161,6 +161,23 @@ describe("Lightbox metadata panel", () => {
     },
   };
 
+  it("makes the prompt selectable and copies it from the visible control", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+    const wrapper = mountLightbox();
+
+    expect(wrapper.get("[data-test='lightbox-prompt']").attributes()).toHaveProperty(
+      "data-selectable",
+    );
+    await wrapper.get("[data-test='copy-prompt']").trigger("click");
+
+    expect(writeText).toHaveBeenCalledWith("a lighthouse at dusk");
+    expect(useToastStore().items.at(-1)?.message).toBe("Copied");
+  });
+
   it("renders the full embedded field set when present", () => {
     const wrapper = mountLightbox(richItem, true);
     const text = wrapper.get("aside").text();

--- a/desktop/src/components/gallery/Lightbox.vue
+++ b/desktop/src/components/gallery/Lightbox.vue
@@ -588,9 +588,28 @@ async function performVideoExport(options: VideoExportOptions) {
             </template>
             <template v-else>In the trash · kept until you empty it</template>
           </p>
-          <p data-selectable class="mt-3 text-body text-ink" :title="meta.prompt">
-            {{ meta.prompt }}
-          </p>
+          <div class="mt-3 flex items-start gap-2">
+            <p
+              data-selectable
+              data-test="lightbox-prompt"
+              class="min-w-0 flex-1 whitespace-pre-wrap text-body text-ink"
+              :title="meta.prompt"
+            >
+              {{ meta.prompt }}
+            </p>
+            <button
+              v-if="meta.prompt"
+              type="button"
+              data-test="copy-prompt"
+              class="flex h-[30px] shrink-0 items-center gap-1.5 rounded-chrome border border-edge px-2 font-utility text-[11px] text-ink-2 transition-colors hover:text-ink"
+              aria-label="Copy prompt"
+              title="Copy prompt"
+              @click="copy(meta.prompt)"
+            >
+              <Icon name="copy" :size="14" />
+              Copy
+            </button>
+          </div>
           <template v-if="showOrganization">
             <p class="lightbox-kicker mt-4 mb-1.5">Tags</p>
             <TagEditor

--- a/desktop/src/lib/generateForm.test.ts
+++ b/desktop/src/lib/generateForm.test.ts
@@ -1708,6 +1708,29 @@ function richImageMetadata(): OutputMetadata {
 }
 
 describe("applyMetadataToForm", () => {
+  it("preserves canonical multiline prompts through desktop Library reuse", () => {
+    const form = newGenerateForm();
+    applyMetadataToForm(
+      form,
+      {
+        ...richImageMetadata(),
+        prompt: "first line\n\nsecond line",
+        negative_prompt: "blur\nwatermark",
+        original_prompt: "source\nidea",
+      },
+      [sd15Model()],
+    );
+
+    expect(form.prompt).toBe("first line\n\nsecond line");
+    expect(form.negativePrompt).toBe("blur\nwatermark");
+    expect(form.originalPrompt).toBe("source\nidea");
+    expect(buildRequest(form)).toMatchObject({
+      prompt: "first line\n\nsecond line",
+      negative_prompt: "blur\nwatermark",
+      original_prompt: "source\nidea",
+    });
+  });
+
   it("keeps automatic-chain reuse eligible for the same generation count and notches", () => {
     const form = newGenerateForm();
     applyMetadataToForm(

--- a/desktop/src/mobile/MobileGalleryViewer.test.ts
+++ b/desktop/src/mobile/MobileGalleryViewer.test.ts
@@ -100,6 +100,32 @@ afterEach(() => {
 });
 
 describe("MobileGalleryViewer", () => {
+  it("makes the prompt selectable and copies it in the viewer and Info sheet", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+    const view = mountViewer();
+    await flushPromises();
+
+    const viewerPrompt = view.get(".gallery-viewer-prompt > p[data-selectable]");
+    expect(viewerPrompt.text()).toBe("a lighthouse at dusk");
+    await view.get("[data-test='gallery-viewer-copy-prompt']").trigger("click");
+    await flushPromises();
+    expect(view.get("[data-test='gallery-viewer-copy-status']").text()).toBe("Prompt copied");
+
+    await view.get("[data-test='gallery-viewer-info']").trigger("click");
+    const infoPrompt = view.get("[data-test='gallery-viewer-info-prompt']");
+    expect(infoPrompt.attributes()).toHaveProperty("data-selectable");
+    await view.get("[data-test='gallery-viewer-info-copy-prompt']").trigger("click");
+    await flushPromises();
+
+    expect(writeText).toHaveBeenNthCalledWith(1, "a lighthouse at dusk");
+    expect(writeText).toHaveBeenNthCalledWith(2, "a lighthouse at dusk");
+    expect(view.get("[data-test='gallery-viewer-info-copy-status']").text()).toBe("Prompt copied");
+  });
+
   it("leaves the native iOS image context menu available", async () => {
     const view = mountViewer();
     await flushPromises();

--- a/desktop/src/mobile/MobileGalleryViewer.vue
+++ b/desktop/src/mobile/MobileGalleryViewer.vue
@@ -150,6 +150,7 @@ const originalPrompt = computed(() =>
 );
 const upscaled = computed(() => isUpscaledImage(props.item));
 const actionStatus = ref("");
+const promptCopyStatus = ref("");
 const actionBusy = ref<"copy" | "save" | "save-video" | null>(null);
 const exportOpen = ref(false);
 const exportBusy = ref(false);
@@ -226,7 +227,23 @@ function openInfo(): void {
   infoCollectionDraft.value = "";
   infoCollectionError.value = "";
   deleteForeverArmed.value = false;
+  promptCopyStatus.value = "";
   infoOpen.value = true;
+}
+
+function closeInfo(): void {
+  promptCopyStatus.value = "";
+  infoOpen.value = false;
+}
+
+async function copyPrompt(): Promise<void> {
+  promptCopyStatus.value = "";
+  try {
+    await navigator.clipboard.writeText(props.item.metadata.prompt);
+    promptCopyStatus.value = "Prompt copied";
+  } catch {
+    promptCopyStatus.value = "Couldn’t copy prompt.";
+  }
 }
 
 /** Done commits the title through PATCH; blank clears it. */
@@ -465,6 +482,7 @@ watch(
   ],
   () => {
     if (mounted) reloadMedia();
+    promptCopyStatus.value = "";
   },
 );
 
@@ -733,8 +751,28 @@ onBeforeUnmount(() => {
     <footer class="gallery-viewer-details">
       <div class="gallery-viewer-prompt">
         <span v-if="preparedPosition" data-test="gallery-viewer-batch">{{ preparedPosition }}</span>
-        <span>Prompt</span>
+        <div class="gallery-viewer-prompt-heading">
+          <span>Prompt</span>
+          <button
+            v-if="item.metadata.prompt"
+            class="gallery-viewer-copy-prompt"
+            type="button"
+            data-test="gallery-viewer-copy-prompt"
+            aria-label="Copy prompt"
+            @click="copyPrompt"
+          >
+            Copy
+          </button>
+        </div>
         <p data-selectable>{{ item.metadata.prompt || "No prompt was used for this print." }}</p>
+        <p
+          v-if="promptCopyStatus && !infoOpen"
+          class="gallery-viewer-copy-status"
+          role="status"
+          data-test="gallery-viewer-copy-status"
+        >
+          {{ promptCopyStatus }}
+        </p>
         <p v-if="pipeline" data-test="gallery-viewer-pipeline" data-selectable>
           <span>Pipeline</span> {{ pipeline }}
         </p>
@@ -840,7 +878,7 @@ onBeforeUnmount(() => {
       :title="viewerTitle"
       :focus-first-control="false"
       test-id="gallery-viewer-info-sheet"
-      @close="infoOpen = false"
+      @close="closeInfo"
     >
       <p
         v-if="organizationError"
@@ -1003,8 +1041,33 @@ onBeforeUnmount(() => {
       <section class="gallery-viewer-print-details" data-test="gallery-viewer-print-details">
         <p class="mobile-library-sheet-label">Print details</p>
         <p class="gallery-viewer-info-filename" :title="item.filename">{{ item.filename }}</p>
-        <p class="gallery-viewer-info-prompt" :title="item.metadata.prompt">
-          {{ item.metadata.prompt }}
+        <div class="gallery-viewer-info-prompt-row">
+          <p
+            class="gallery-viewer-info-prompt"
+            data-selectable
+            data-test="gallery-viewer-info-prompt"
+            :title="item.metadata.prompt"
+          >
+            {{ item.metadata.prompt }}
+          </p>
+          <button
+            v-if="item.metadata.prompt"
+            class="secondary-button gallery-viewer-copy-prompt"
+            type="button"
+            data-test="gallery-viewer-info-copy-prompt"
+            aria-label="Copy prompt"
+            @click="copyPrompt"
+          >
+            Copy
+          </button>
+        </div>
+        <p
+          v-if="promptCopyStatus"
+          class="gallery-viewer-copy-status"
+          role="status"
+          data-test="gallery-viewer-info-copy-status"
+        >
+          {{ promptCopyStatus }}
         </p>
         <p
           v-if="item.metadata.prompt.trim() && item.metadata.original_prompt"
@@ -1166,9 +1229,48 @@ onBeforeUnmount(() => {
 }
 
 .gallery-viewer-info-prompt {
+  min-width: 0;
   color: var(--rebate);
   font-size: var(--text-body);
   overflow-wrap: anywhere;
+}
+
+.gallery-viewer-info-prompt-row,
+.gallery-viewer-prompt-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.gallery-viewer-copy-prompt {
+  min-width: 44px;
+  min-height: 44px;
+  flex: 0 0 auto;
+}
+
+.gallery-viewer-prompt-heading .gallery-viewer-copy-prompt {
+  border: 0;
+  background: transparent;
+  color: var(--safelight);
+  font: inherit;
+}
+
+.gallery-viewer-prompt-heading > span {
+  color: rgba(245, 239, 255, 0.62);
+  font-family: var(--font-utility);
+  font-size: var(--text-edge-code);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.gallery-viewer-copy-status {
+  display: block;
+  overflow: visible;
+  margin: 0;
+  color: var(--ink-2);
+  font-size: 13px;
+  -webkit-line-clamp: unset;
 }
 
 .gallery-viewer-info-secondary {

--- a/desktop/src/mobile/mobile.css
+++ b/desktop/src/mobile/mobile.css
@@ -3019,6 +3019,7 @@ button:disabled {
 
 .gallery-viewer-details {
   display: grid;
+  grid-template-columns: minmax(0, 1fr);
   width: 100%;
   min-width: 0;
   box-sizing: border-box;
@@ -3026,6 +3027,10 @@ button:disabled {
   padding: 14px max(16px, env(safe-area-inset-right)) 16px max(16px, env(safe-area-inset-left));
   border-top: 1px solid rgba(245, 239, 255, 0.12);
   background: #12101d;
+}
+
+.gallery-viewer-prompt {
+  min-width: 0;
 }
 
 .gallery-viewer-prompt > span {
@@ -3043,6 +3048,7 @@ button:disabled {
   color: #f5efff;
   font-size: var(--text-body-lg);
   line-height: 1.4;
+  overflow-wrap: anywhere;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 3;
 }
@@ -3061,6 +3067,7 @@ button:disabled {
 
 .gallery-viewer-actions {
   display: grid;
+  min-width: 0;
   gap: 8px;
 }
 

--- a/desktop/src/mobile/mobile.css.test.ts
+++ b/desktop/src/mobile/mobile.css.test.ts
@@ -483,6 +483,9 @@ describe("mobile gallery viewer", () => {
     const header = css.match(/\.gallery-viewer-header\s*\{([^}]*)\}/s);
     const origin = css.match(/\.gallery-viewer-origin\s*\{([^}]*)\}/s);
     const details = css.match(/\.gallery-viewer-details\s*\{([^}]*)\}/s);
+    const prompt = css.match(/\.gallery-viewer-prompt\s*\{([^}]*)\}/s);
+    const promptText = css.match(/\.gallery-viewer-prompt p\s*\{([^}]*)\}/s);
+    const actions = css.match(/\.gallery-viewer-actions\s*\{([^}]*)\}/s);
     expect(header?.[1]).toMatch(/width:\s*100%\s*;/);
     expect(header?.[1]).toMatch(/min-width:\s*0\s*;/);
     expect(header?.[1]).toMatch(/box-sizing:\s*border-box\s*;/);
@@ -491,6 +494,10 @@ describe("mobile gallery viewer", () => {
     expect(details?.[1]).toMatch(/width:\s*100%\s*;/);
     expect(details?.[1]).toMatch(/min-width:\s*0\s*;/);
     expect(details?.[1]).toMatch(/box-sizing:\s*border-box\s*;/);
+    expect(details?.[1]).toMatch(/grid-template-columns:\s*minmax\(0,\s*1fr\)\s*;/);
+    expect(prompt?.[1]).toMatch(/min-width:\s*0\s*;/);
+    expect(promptText?.[1]).toMatch(/overflow-wrap:\s*anywhere\s*;/);
+    expect(actions?.[1]).toMatch(/min-width:\s*0\s*;/);
   });
 });
 

--- a/desktop/src/mobile/reuse.test.ts
+++ b/desktop/src/mobile/reuse.test.ts
@@ -48,6 +48,29 @@ const metadata: OutputMetadata = {
 };
 
 describe("applyMobileGalleryMetadata", () => {
+  it("preserves canonical multiline prompts through mobile Library reuse", () => {
+    const form = newGenerateForm();
+    applyMobileGalleryMetadata(
+      form,
+      {
+        ...metadata,
+        prompt: "first line\n\nsecond line",
+        negative_prompt: "blur\nwatermark",
+        original_prompt: "source\nidea",
+      },
+      [model],
+    );
+
+    expect(form.prompt).toBe("first line\n\nsecond line");
+    expect(form.negativePrompt).toBe("blur\nwatermark");
+    expect(form.originalPrompt).toBe("source\nidea");
+    expect(buildRequest(form)).toMatchObject({
+      prompt: "first line\n\nsecond line",
+      negative_prompt: "blur\nwatermark",
+      original_prompt: "source\nidea",
+    });
+  });
+
   it("keeps an auto-chained One shot out of the sequence editor", () => {
     const form = newGenerateForm();
     const result = applyMobileGalleryMetadata(

--- a/web/src/components/gallery/Lightbox.test.ts
+++ b/web/src/components/gallery/Lightbox.test.ts
@@ -106,6 +106,9 @@ describe("Lightbox (desktop two-pane)", () => {
 
     await wrapper.get('[data-test="copy-prompt"]').trigger("click");
     await wrapper.get('[data-test="copy-seed"]').trigger("click");
+    expect(wrapper.get(".lb__prompt").attributes()).toHaveProperty(
+      "data-selectable",
+    );
     expect(writeText).toHaveBeenNthCalledWith(1, "a lighthouse at dusk");
     expect(writeText).toHaveBeenNthCalledWith(2, "4242");
   });

--- a/web/src/components/gallery/Lightbox.vue
+++ b/web/src/components/gallery/Lightbox.vue
@@ -610,10 +610,12 @@ async function performVideoExport(options: VideoExportOptions) {
           </p>
 
           <div v-if="prompt" class="lb__prompt-wrap">
-            <p class="lb__prompt">{{ prompt }}</p>
+            <p class="lb__prompt" data-selectable>{{ prompt }}</p>
             <button
+              type="button"
               data-test="copy-prompt"
               class="lb__copy"
+              aria-label="Copy prompt"
               @click="copyText(prompt)"
             >
               Copy prompt
@@ -937,10 +939,12 @@ async function performVideoExport(options: VideoExportOptions) {
             {{ purgeLabel }}
           </p>
           <div v-if="prompt" class="lb__prompt-wrap">
-            <p class="lb__prompt">{{ prompt }}</p>
+            <p class="lb__prompt" data-selectable>{{ prompt }}</p>
             <button
+              type="button"
               data-test="copy-prompt"
               class="lb__copy"
+              aria-label="Copy prompt"
               @click="copyText(prompt)"
             >
               Copy prompt
@@ -1320,6 +1324,11 @@ async function performVideoExport(options: VideoExportOptions) {
   color: var(--rebate);
   margin: 0 0 20px;
   white-space: pre-wrap;
+}
+.lb__prompt[data-selectable] {
+  -webkit-user-select: text;
+  user-select: text;
+  cursor: text;
 }
 .lb__prompt-wrap {
   margin-bottom: 20px;

--- a/web/src/composables/useGenerateForm.test.ts
+++ b/web/src/composables/useGenerateForm.test.ts
@@ -2742,6 +2742,29 @@ describe("generate form serialization helpers", () => {
     ]);
   });
 
+  it("preserves canonical multiline prompts through web Library reuse", () => {
+    const next = applyMetadataToForm(
+      makeForm(),
+      {
+        prompt: "first line\n\nsecond line",
+        negative_prompt: "blur\nwatermark",
+        original_prompt: "source\nidea",
+        model: "sdxl:fp16",
+        seed: 42,
+        steps: 30,
+        guidance: 7.5,
+        width: 768,
+        height: 512,
+        version: "test",
+      },
+      { models: [makeModel({ name: "sdxl:fp16", family: "sdxl" })] },
+    );
+
+    expect(next.prompt).toBe("first line\n\nsecond line");
+    expect(next.negativePrompt).toBe("blur\nwatermark");
+    expect(next.originalPrompt).toBe("source\nidea");
+  });
+
   it("applyMetadataToForm restores the wan recipe a print was rendered with", () => {
     const next = applyMetadataToForm(
       makeForm(),


### PR DESCRIPTION
## Summary
- contain long and unbroken prompt text inside the mobile Library viewer and Info sheet
- canonicalize real and escaped newlines at every CLI/API prompt ingress, including durable sequence retake/amend
- preserve literal `\n` text across shared Rust client HTTP hops and leave model-expanded text untouched
- normalize legacy output metadata so Library and Reuse settings improve for existing prints
- cover prompt reuse on desktop, web, and mobile

## Verification
- rendered `MobileGalleryViewer` at 393x852 with an adversarial long prompt; viewer/details/actions stayed within the viewport and Info opened without console errors
- isolated `mold-ai-core` package: 1,488 tests passed across targets
- prompt wire-hop tests cover Generate, Expand, Remix, Chain, Retake, literal escapes, and CRLF
- server chain routes: 51 tests passed; focused retake/amend persistence regressions passed
- desktop selected tests: 295 passed
- web selected tests: 293 passed
- `cargo fmt --all -- --check`
- Clippy for core, server, and CLI with warnings denied
- mobile, desktop, and web production builds

## Review
- independent agent review: no findings on mobile containment
- Claude Code final exact-head review: NO FINDINGS after two rounds of findings were fixed

Closes the mobile Library overflow and literal-newline regressions shown in the supplied iOS screenshots.