### PR TITLE
fix(mobile): show source images from every host

### DIFF
--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -9934,6 +9934,27 @@ describe("MobileApp automatic generation routing", () => {
     expect(wrapper.get("[data-test='mobile-routing-hint']").text()).toContain("strongest GPU");
   });
 
+  it("offers every reachable gallery even when generation is pinned to one host", async () => {
+    twoHosts();
+    fleetApi({});
+    localStorage.setItem("mold.mobile.generate-target.v1", "studio-id");
+    wrapper = mountMobileApp();
+    await flushPromises();
+
+    const sources = wrapper.getComponent(MobileSourceControls).props("gallerySources") as Array<{
+      id: string;
+      label: string;
+      target: { baseUrl: string };
+    }>;
+    expect(sources.map(({ id, label, target: route }) => [id, label, route.baseUrl])).toEqual([
+      ["studio-id", "Studio", target.baseUrl],
+      ["render-id", "Render", renderTarget.baseUrl],
+    ]);
+    expect(wrapper.getComponent(MobileSourceControls).props("target")).toMatchObject({
+      baseUrl: target.baseUrl,
+    });
+  });
+
   it("hides the automatic options again while only one machine answers", async () => {
     twoHosts();
     apiJsonTo.mockImplementation((route: { baseUrl: string }, path: string) => {

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -1160,6 +1160,15 @@ const selectedHost = computed(() =>
 // at least two machines are reachable; with one machine the picker keeps
 // today's single-host behaviour exactly.
 const routingHosts = computed(() => mobileRoutingHosts(connectedHosts.value));
+/** Source conditioning can come from the whole reachable fleet, regardless
+ * of the machine selected to render the next print. */
+const sourceGalleryHosts = computed(() =>
+  routingHosts.value.map((host) => ({
+    id: host.id,
+    label: host.name,
+    target: mobileHostTarget(host),
+  })),
+);
 const autoRoutingAvailable = computed(() => mobileAutoRoutingAvailable(connectedHosts.value));
 const generateTarget = computed(() =>
   resolveMobileGenerateTarget(
@@ -10154,6 +10163,7 @@ onBeforeUnmount(() => {
               :upscalers="upscalers"
               :chain-limits="chainLimits"
               :target="generationTarget"
+              :gallery-sources="sourceGalleryHosts"
               :shared="sequenceParams(form, selectedGenerationModel)"
               :fps="form.fps"
               :submitting="sequenceStarting"
@@ -10397,6 +10407,7 @@ onBeforeUnmount(() => {
                 :form="form"
                 :model="selectedGenerationModel"
                 :target="generationTarget"
+                :gallery-sources="sourceGalleryHosts"
                 :control-models="controlModels"
                 :upscalers="upscalers"
                 @validity-change="sourceValid = $event"

--- a/desktop/src/mobile/MobileImagePickerSheet.test.ts
+++ b/desktop/src/mobile/MobileImagePickerSheet.test.ts
@@ -10,6 +10,7 @@ const { apiJsonTo, apiFetchTo } = vi.hoisted(() => ({
 vi.mock("../lib/api/client", () => ({ apiJsonTo, apiFetchTo }));
 
 const target = { baseUrl: "http://remote-host:7680", apiKey: "secret" };
+const peerTarget = { baseUrl: "http://peer-host:7680", apiKey: "peer-secret" };
 const metadata = {
   prompt: "p",
   model: "m",
@@ -83,6 +84,134 @@ describe("MobileImagePickerSheet", () => {
     });
   });
 
+  it("merges every available host and fetches a peer print from its own authenticated origin", async () => {
+    apiJsonTo.mockImplementation((route: typeof target) =>
+      Promise.resolve(
+        route.baseUrl === peerTarget.baseUrl
+          ? [{ filename: "peer.png", metadata, timestamp: 4 }]
+          : [{ filename: "selected.png", metadata, timestamp: 3 }],
+      ),
+    );
+    const gallerySources = [
+      { id: "selected", label: "Studio", target },
+      { id: "peer", label: "Render", target: peerTarget },
+    ];
+    const wrapper = mount(MobileImagePickerSheet, {
+      props: { open: true, target, gallerySources },
+      global: { stubs: { AuthedMedia: true } },
+    });
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-image-picker-gallery-tab']").trigger("click");
+
+    expect(apiJsonTo).toHaveBeenCalledWith(target, "/api/gallery", {
+      signal: expect.any(AbortSignal),
+    });
+    expect(apiJsonTo).toHaveBeenCalledWith(peerTarget, "/api/gallery", {
+      signal: expect.any(AbortSignal),
+    });
+    const items = wrapper.findAll("[data-test='mobile-image-picker-gallery-item']");
+    expect(items.map((item) => item.attributes("aria-label"))).toEqual([
+      "Use peer.png from Render",
+      "Use selected.png from Studio",
+    ]);
+    expect(
+      wrapper.findAll("[data-test='mobile-image-picker-host']").map((chip) => chip.text()),
+    ).toEqual(["Render", "Studio"]);
+
+    await items[0]!.trigger("click");
+    await flushPromises();
+    expect(apiFetchTo).toHaveBeenCalledWith(peerTarget, "/api/gallery/image/peer.png");
+  });
+
+  it("renders a healthy host without waiting for a peer that never settles", async () => {
+    apiJsonTo.mockImplementation((route: typeof target) =>
+      route.baseUrl === peerTarget.baseUrl
+        ? new Promise(() => {})
+        : Promise.resolve([{ filename: "healthy.png", metadata, timestamp: 3 }]),
+    );
+    const wrapper = mount(MobileImagePickerSheet, {
+      props: {
+        open: true,
+        target,
+        gallerySources: [
+          { id: "healthy", label: "Studio", target },
+          { id: "hanging", label: "Render", target: peerTarget },
+        ],
+      },
+      global: { stubs: { AuthedMedia: true } },
+    });
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-image-picker-gallery-tab']").trigger("click");
+
+    expect(wrapper.findAll("[data-test='mobile-image-picker-gallery-item']")).toHaveLength(1);
+    expect(wrapper.text()).not.toContain("Loading gallery");
+    wrapper.unmount();
+  });
+
+  it("keeps healthy gallery results when a peer fails", async () => {
+    apiJsonTo.mockImplementation((route: typeof target) =>
+      route.baseUrl === peerTarget.baseUrl
+        ? Promise.reject(new Error("peer offline"))
+        : Promise.resolve([{ filename: "healthy.png", metadata, timestamp: 3 }]),
+    );
+    const wrapper = mount(MobileImagePickerSheet, {
+      props: {
+        open: true,
+        target,
+        gallerySources: [
+          { id: "healthy", label: "Studio", target },
+          { id: "failed", label: "Render", target: peerTarget },
+        ],
+      },
+      global: { stubs: { AuthedMedia: true } },
+    });
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-image-picker-gallery-tab']").trigger("click");
+
+    expect(wrapper.findAll("[data-test='mobile-image-picker-gallery-item']")).toHaveLength(1);
+    expect(wrapper.find("[role='alert']").exists()).toBe(false);
+  });
+
+  it("removes stale tiles immediately when a host credential changes", async () => {
+    const rotatedTarget = { ...target, apiKey: "rotated-secret" };
+    let resolveRotated!: (
+      entries: Array<{ filename: string; metadata: typeof metadata; timestamp: number }>,
+    ) => void;
+    apiJsonTo
+      .mockReset()
+      .mockResolvedValueOnce([{ filename: "old.png", metadata, timestamp: 1 }])
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveRotated = resolve;
+          }),
+      );
+    const wrapper = mount(MobileImagePickerSheet, {
+      props: {
+        open: true,
+        target,
+        gallerySources: [{ id: "studio", label: "Studio", target }],
+      },
+      global: { stubs: { AuthedMedia: true } },
+    });
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-image-picker-gallery-tab']").trigger("click");
+    expect(wrapper.findAll("[data-test='mobile-image-picker-gallery-item']")).toHaveLength(1);
+
+    await wrapper.setProps({
+      gallerySources: [{ id: "studio", label: "Studio", target: rotatedTarget }],
+    });
+    expect(wrapper.findAll("[data-test='mobile-image-picker-gallery-item']")).toHaveLength(0);
+    resolveRotated([{ filename: "new.png", metadata, timestamp: 2 }]);
+    await flushPromises();
+    expect(apiJsonTo).toHaveBeenLastCalledWith(rotatedTarget, "/api/gallery", {
+      signal: expect.any(AbortSignal),
+    });
+    expect(
+      wrapper.get("[data-test='mobile-image-picker-gallery-item']").attributes("aria-label"),
+    ).toBe("Use new.png from Studio");
+  });
+
   it("honors a caller's combined-media budget before downloading gallery bytes", async () => {
     const wrapper = mount(MobileImagePickerSheet, {
       props: {
@@ -137,7 +266,9 @@ describe("MobileImagePickerSheet", () => {
     await wrapper.get("[data-test='mobile-image-picker-gallery-tab']").trigger("click");
     const items = wrapper.findAll("[data-test='mobile-image-picker-gallery-item']");
     expect(items).toHaveLength(1);
-    expect(items[0]!.attributes("aria-label")).toBe("Use next.png");
-    expect(apiJsonTo).toHaveBeenNthCalledWith(2, nextTarget, "/api/gallery");
+    expect(items[0]!.attributes("aria-label")).toBe("Use next.png from Selected machine");
+    expect(apiJsonTo).toHaveBeenNthCalledWith(2, nextTarget, "/api/gallery", {
+      signal: expect.any(AbortSignal),
+    });
   });
 });

--- a/desktop/src/mobile/MobileImagePickerSheet.vue
+++ b/desktop/src/mobile/MobileImagePickerSheet.vue
@@ -12,16 +12,29 @@ export interface MobilePickedImage {
   base64: string;
 }
 
+export interface MobileGallerySource {
+  id: string;
+  label: string;
+  target: ApiTarget;
+}
+
+interface MobileGalleryEntry {
+  image: GalleryImage;
+  source: MobileGallerySource;
+}
+
 const props = withDefaults(
   defineProps<{
     open: boolean;
     target: ApiTarget | null;
+    gallerySources?: MobileGallerySource[];
     title?: string;
     maxBytes?: number;
     oversizeMessage?: string;
   }>(),
   {
     title: "Opening image",
+    gallerySources: () => [],
     maxBytes: MAX_MOBILE_GENERATION_REQUEST_MEDIA_BYTES,
     oversizeMessage: "The opening image must be 45 MiB or smaller on this phone.",
   },
@@ -34,34 +47,85 @@ const emit = defineEmits<{
 
 const tab = ref<"file" | "gallery">("file");
 const input = ref<HTMLInputElement | null>(null);
-const entries = ref<GalleryImage[]>([]);
+const entries = ref<MobileGalleryEntry[]>([]);
 const loading = ref(false);
 const picking = ref(false);
 const error = ref("");
 
-const stillEntries = computed(() =>
-  entries.value.filter((entry) => isStillImageFile(entry.filename)),
+const sources = computed<MobileGallerySource[]>(() => {
+  if (props.gallerySources.length) return props.gallerySources;
+  return props.target
+    ? [{ id: props.target.baseUrl, label: "Selected machine", target: props.target }]
+    : [];
+});
+const sourceSignature = computed(() =>
+  sources.value
+    .map(
+      (source) =>
+        `${source.id}\u0000${source.label}\u0000${source.target.baseUrl}\u0000${source.target.apiKey ?? ""}`,
+    )
+    .join("\u0001"),
 );
+const stillEntries = computed(() =>
+  entries.value.filter((entry) => isStillImageFile(entry.image.filename)),
+);
+const showHostLabels = computed(() => sources.value.length > 1);
 
 watch(
-  [() => props.open, () => props.target?.baseUrl ?? "", () => props.target?.apiKey ?? ""] as const,
+  [() => props.open, sourceSignature] as const,
   async ([open], _previous, onCleanup) => {
     let active = true;
+    const controllers: AbortController[] = [];
     onCleanup(() => {
       active = false;
+      for (const controller of controllers) controller.abort();
     });
-    if (!open || !props.target) {
+    if (!open || sources.value.length === 0) {
       entries.value = [];
       loading.value = false;
       return;
     }
-    const target = props.target;
+    const requestedSources = [...sources.value];
+    // Authority changes invalidate every captured target immediately. Never
+    // leave a tile with an old key/instance clickable while its replacement
+    // fleet is loading.
+    entries.value = [];
     error.value = "";
     loading.value = true;
     try {
-      const gallery = await apiJsonTo<GalleryImage[]>(target, "/api/gallery");
+      const results = await Promise.allSettled(
+        requestedSources.map(async (source) => {
+          const controller = new AbortController();
+          controllers.push(controller);
+          const timeout = setTimeout(() => controller.abort(), 10_000);
+          try {
+            const images = await apiJsonTo<GalleryImage[]>(source.target, "/api/gallery", {
+              signal: controller.signal,
+            });
+            if (active) {
+              entries.value = [
+                ...entries.value,
+                ...images.map((image) => ({ image, source })),
+              ].sort((left, right) => right.image.timestamp - left.image.timestamp);
+              // A healthy host must become usable without waiting for a slow
+              // peer. Keep the remaining requests alive so their tiles join
+              // the same sorted grid when they arrive.
+              if (entries.value.length > 0) loading.value = false;
+            }
+            return { source, images };
+          } finally {
+            clearTimeout(timeout);
+          }
+        }),
+      );
       if (!active) return;
-      entries.value = gallery;
+      const failure = results.find(
+        (result): result is PromiseRejectedResult => result.status === "rejected",
+      );
+      if (failure && entries.value.length === 0) {
+        error.value =
+          failure.reason instanceof Error ? failure.reason.message : String(failure.reason);
+      }
     } catch (cause) {
       if (!active) return;
       entries.value = [];
@@ -99,12 +163,15 @@ async function chooseFile(event: Event): Promise<void> {
   emit("close");
 }
 
-async function chooseGallery(entry: GalleryImage): Promise<void> {
-  if (!props.target || picking.value) return;
+async function chooseGallery(entry: MobileGalleryEntry): Promise<void> {
+  if (picking.value) return;
   picking.value = true;
   error.value = "";
   try {
-    const response = await apiFetchTo(props.target, galleryMediaPath(entry.filename, "host"));
+    const response = await apiFetchTo(
+      entry.source.target,
+      galleryMediaPath(entry.image.filename, "host"),
+    );
     const declared = Number(response.headers?.get("content-length") ?? Number.NaN);
     if (Number.isFinite(declared) && declared > props.maxBytes) {
       throw new Error(props.oversizeMessage);
@@ -113,7 +180,7 @@ async function chooseGallery(entry: GalleryImage): Promise<void> {
     if (blob.size === 0) throw new Error("That gallery image is empty.");
     if (blob.size > props.maxBytes) throw new Error(props.oversizeMessage);
     emit("pick", {
-      filename: entry.filename,
+      filename: entry.image.filename,
       base64: await blobToBase64(blob),
     });
     emit("close");
@@ -144,7 +211,7 @@ async function chooseGallery(entry: GalleryImage): Promise<void> {
       <header>
         <div>
           <strong>{{ title }}</strong>
-          <p>Choose a PNG or JPEG from this phone or the selected machine.</p>
+          <p>Choose a PNG or JPEG from this phone or any available machine.</p>
         </div>
         <button
           type="button"
@@ -198,24 +265,31 @@ async function chooseGallery(entry: GalleryImage): Promise<void> {
 
       <div v-else class="mobile-image-picker-gallery">
         <p v-if="loading">Loading gallery…</p>
-        <p v-else-if="!target">Choose a machine first.</p>
+        <p v-else-if="!sources.length">Connect a machine first.</p>
         <p v-else-if="!stillEntries.length && !error">No PNG or JPEG prints yet.</p>
         <div v-else class="mobile-image-picker-grid">
           <button
             v-for="entry in stillEntries"
-            :key="entry.filename"
+            :key="`${entry.source.id}:${entry.image.filename}`"
             type="button"
-            :aria-label="`Use ${entry.filename}`"
+            :aria-label="`Use ${entry.image.filename} from ${entry.source.label}`"
             :disabled="picking"
             data-test="mobile-image-picker-gallery-item"
             @click="chooseGallery(entry)"
           >
             <AuthedMedia
-              :path="galleryMediaPath(entry.filename, 'host', true)"
-              :target="target"
-              :cache-key="target?.baseUrl ?? 'mobile-picker'"
-              :alt="entry.filename"
+              :path="galleryMediaPath(entry.image.filename, 'host', true)"
+              :target="entry.source.target"
+              :cache-key="entry.source.id"
+              :alt="entry.image.filename"
             />
+            <span
+              v-if="showHostLabels"
+              class="mobile-image-picker-host"
+              data-test="mobile-image-picker-host"
+            >
+              {{ entry.source.label }}
+            </span>
           </button>
         </div>
       </div>
@@ -300,12 +374,26 @@ async function chooseGallery(entry: GalleryImage): Promise<void> {
 }
 
 .mobile-image-picker-grid button {
+  position: relative;
   min-height: 44px;
   overflow: hidden;
   aspect-ratio: 1;
   border: 1px solid var(--edge);
   border-radius: 10px;
   background: var(--print-surface);
+}
+
+.mobile-image-picker-host {
+  position: absolute;
+  inset: auto 4px 4px;
+  overflow: hidden;
+  padding: 2px 5px;
+  border-radius: 6px;
+  background: rgb(0 0 0 / 68%);
+  color: white;
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .mobile-image-picker-grid :deep(img) {

--- a/desktop/src/mobile/MobileSequenceComposer.test.ts
+++ b/desktop/src/mobile/MobileSequenceComposer.test.ts
@@ -553,6 +553,25 @@ describe("MobileSequenceComposer guardrails", () => {
     );
   });
 
+  it("forwards every source gallery to the sequence opening picker", () => {
+    const gallerySources = [
+      {
+        id: "studio",
+        label: "Studio",
+        target: { baseUrl: "http://studio:7680", apiKey: "secret" },
+      },
+      {
+        id: "render",
+        label: "Render",
+        target: { baseUrl: "http://render:7680", apiKey: "render-secret" },
+      },
+    ];
+    mountComposer({ gallerySources });
+    expect(
+      wrapper!.getComponent({ name: "MobileSequenceOpeningImage" }).props("gallerySources"),
+    ).toEqual(gallerySources);
+  });
+
   it("exposes strength and fit controls after an opening image is attached", async () => {
     const form = newGenerateForm();
     const draft = useSequenceDraftStore();

--- a/desktop/src/mobile/MobileSequenceComposer.vue
+++ b/desktop/src/mobile/MobileSequenceComposer.vue
@@ -42,6 +42,7 @@ import type { Ltx2CameraControlInfo, ModelEntry } from "../lib/api/types";
 import type { GenerateForm } from "../lib/generateForm";
 import { generationCapabilitiesForFamily } from "../lib/capabilities";
 import MobileSequenceOpeningImage from "./MobileSequenceOpeningImage.vue";
+import type { MobileGallerySource } from "./MobileImagePickerSheet.vue";
 import MobileAdvancedSheet from "./MobileAdvancedSheet.vue";
 import MobileSeamSheet from "./MobileSeamSheet.vue";
 import { validateChain } from "@studio/api/chains";
@@ -53,6 +54,7 @@ const props = withDefaults(
     selectedModel: ModelEntry | null;
     chainLimits: ChainLimits | null;
     target: ApiTarget | null;
+    gallerySources?: MobileGallerySource[];
     /** Live shared generation parameters owned by MobileApp's form. */
     shared: SequenceSharedParams;
     /** The generate form's frame rate — shown, never stored here. */
@@ -71,6 +73,7 @@ const props = withDefaults(
   }>(),
   {
     target: null,
+    gallerySources: () => [],
     submitting: false,
     error: "",
     busy: false,
@@ -449,6 +452,7 @@ function removeClip(id: string): void {
         :form="form"
         :upscalers="upscalers"
         :target="target"
+        :gallery-sources="gallerySources"
         :locked="locked"
       />
     </details>

--- a/desktop/src/mobile/MobileSequenceOpeningImage.test.ts
+++ b/desktop/src/mobile/MobileSequenceOpeningImage.test.ts
@@ -67,6 +67,26 @@ describe("MobileSequenceOpeningImage", () => {
     expect(draft.openingImage).toBeNull();
   });
 
+  it("forwards the fleet galleries independently of the sequence render target", async () => {
+    const gallerySources = [
+      {
+        id: "studio",
+        label: "Studio",
+        target: { baseUrl: "http://studio:7680", apiKey: "secret" },
+      },
+      {
+        id: "render",
+        label: "Render",
+        target: { baseUrl: "http://render:7680", apiKey: "render-secret" },
+      },
+    ];
+    mountOpeningImage({ gallerySources });
+    await wrapper!.get("[data-test='mobile-sequence-source-pick']").trigger("click");
+    expect(
+      wrapper!.getComponent({ name: "MobileImagePickerSheet" }).props("gallerySources"),
+    ).toEqual(gallerySources);
+  });
+
   it("writes strength and fit onto the host form", async () => {
     const form = newGenerateForm();
     const draft = useSequenceDraftStore();

--- a/desktop/src/mobile/MobileSequenceOpeningImage.vue
+++ b/desktop/src/mobile/MobileSequenceOpeningImage.vue
@@ -27,7 +27,10 @@ import type { ApiTarget } from "../lib/api/client";
 import type { ModelEntry } from "../lib/api/types";
 import type { GenerateForm } from "../lib/generateForm";
 import { base64ToDataUrl } from "../lib/image";
-import MobileImagePickerSheet, { type MobilePickedImage } from "./MobileImagePickerSheet.vue";
+import MobileImagePickerSheet, {
+  type MobileGallerySource,
+  type MobilePickedImage,
+} from "./MobileImagePickerSheet.vue";
 
 const props = withDefaults(
   defineProps<{
@@ -35,11 +38,12 @@ const props = withDefaults(
      *  them from the same form a one-shot does. */
     form: GenerateForm;
     target: ApiTarget | null;
+    gallerySources?: MobileGallerySource[];
     upscalers?: ModelEntry[];
     /** A submit or a durable job is in flight. */
     locked?: boolean;
   }>(),
-  { target: null, upscalers: () => [], locked: false },
+  { target: null, gallerySources: () => [], upscalers: () => [], locked: false },
 );
 
 const draft = useSequenceDraftStore();
@@ -151,6 +155,7 @@ function sourceImageMime(filename: string): string {
     <MobileImagePickerSheet
       :open="imagePickerOpen"
       :target="target"
+      :gallery-sources="gallerySources"
       @pick="setOpeningImage"
       @close="imagePickerOpen = false"
     />

--- a/desktop/src/mobile/MobileSourceControls.test.ts
+++ b/desktop/src/mobile/MobileSourceControls.test.ts
@@ -217,12 +217,20 @@ describe("MobileSourceControls", () => {
     expect(form.sourceImageName).toBeNull();
   });
 
-  it("offers the selected machine's gallery for a single source image", async () => {
+  it("keeps the generation target separate from every available source gallery", async () => {
     const form = formFor("sd15");
     form.controlImage = btoa("control");
     const target = { baseUrl: "http://halcyon:7680", apiKey: "remote-key" };
+    const gallerySources = [
+      { id: "halcyon", label: "Halcyon", target },
+      {
+        id: "peer",
+        label: "Peer",
+        target: { baseUrl: "http://peer:7680", apiKey: "peer-key" },
+      },
+    ];
     const wrapper = mount(MobileSourceControls, {
-      props: { form, target },
+      props: { form, target, gallerySources },
       global: { stubs: { MobileImagePickerSheet: true } },
     });
 
@@ -236,6 +244,7 @@ describe("MobileSourceControls", () => {
     expect(picker.props()).toMatchObject({
       open: true,
       target,
+      gallerySources,
       title: "Source image",
       maxBytes: MAX_MOBILE_GENERATION_REQUEST_MEDIA_BYTES - 7,
     });

--- a/desktop/src/mobile/MobileSourceControls.vue
+++ b/desktop/src/mobile/MobileSourceControls.vue
@@ -24,7 +24,10 @@ import {
 } from "@studio/lib/sourceFit";
 import { strengthSemantics } from "@studio/lib/strengthSemantics";
 import { sourceConditioningLimitLabel } from "@studio/lib/sourceResolution";
-import MobileImagePickerSheet, { type MobilePickedImage } from "./MobileImagePickerSheet.vue";
+import MobileImagePickerSheet, {
+  type MobileGallerySource,
+  type MobilePickedImage,
+} from "./MobileImagePickerSheet.vue";
 import { effectiveGenerationRecipe } from "@studio/lib/generationProfile";
 import SourceMediaWells, { type SourceMediaSlot } from "@studio/components/SourceMediaWells.vue";
 import MinimaxH3AuthoringPanel from "@studio/components/MinimaxH3AuthoringPanel.vue";
@@ -41,12 +44,14 @@ const props = withDefaults(
   defineProps<{
     form: GenerateForm;
     target?: ApiTarget | null;
+    gallerySources?: MobileGallerySource[];
     controlModels?: ModelEntry[];
     upscalers?: ModelEntry[];
     model?: ModelEntry | null;
   }>(),
   {
     target: null,
+    gallerySources: () => [],
     controlModels: () => [],
     upscalers: () => [],
     model: null,
@@ -508,6 +513,7 @@ function applyMask(mask: string): void {
     <MobileImagePickerSheet
       :open="h3PickerTarget !== null"
       :target="target"
+      :gallery-sources="gallerySources"
       :title="h3PickerTarget === 'lastFrame' ? 'Last frame' : 'First frame'"
       :max-bytes="h3PickerMaxBytes"
       :oversize-message="MOBILE_MEDIA_BUDGET_ERROR"
@@ -968,6 +974,7 @@ function applyMask(mask: string): void {
       v-if="!isAttachmentMode || (plan.kind === 'attachments' && plan.primary === 'target')"
       :open="sourcePickerOpen"
       :target="target"
+      :gallery-sources="gallerySources"
       :title="isAttachmentMode ? 'Edit target' : 'Source image'"
       :max-bytes="sourcePickerMaxBytes"
       :oversize-message="MOBILE_MEDIA_BUDGET_ERROR"
@@ -978,6 +985,7 @@ function applyMask(mask: string): void {
       v-if="!isAttachmentMode && caps.supportsEndFrame"
       :open="endFramePickerOpen"
       :target="target"
+      :gallery-sources="gallerySources"
       title="End frame"
       :max-bytes="endFramePickerMaxBytes"
       :oversize-message="MOBILE_MEDIA_BUDGET_ERROR"


### PR DESCRIPTION
## Summary
- make iOS/Android source pickers merge PNG/JPEG galleries from every reachable host, independent of the selected generation target
- fetch thumbnails and selected bytes with the exact origin host credentials
- render healthy-host results incrementally, bound slow hosts, and invalidate stale authority immediately
- preserve existing desktop unified-gallery behavior; web remains single-host by design

## Regression guards
- fleet aggregation and origin-authenticated selection
- hanging peer and partial failure
- credential rotation/stale tile invalidation
- one-shot, edit target, end frame, H3 boundary, and sequence picker plumbing
- desktop unified multi-host gallery coverage

## Verification
- `bun run test` — 5,049 tests passed
- focused current-main suite — 483 tests passed
- `bun run build:mobile`
- `bun run fmt:check`
- rendered QA: generation pinned to one host, both host galleries visible, peer-host source selected with no console warnings/errors
- independent agent peer review: approved with no remaining findings