### PR TITLE
docs(changelog): note fleet source gallery

### DIFF
--- a/changelog.d/mobile-all-host-source-gallery.md
+++ b/changelog.d/mobile-all-host-source-gallery.md
@@ -1,0 +1,1 @@
+- **Fleet-wide mobile source gallery.** iPhone and Android source-image pickers now show stills from every reachable Mold host, while fetching each selection securely from its origin machine.


### PR DESCRIPTION
Adds the release-note fragment required by the changelog policy for merged PR #1369.

Verification: `bash scripts/release/check-changelog-fragments.sh origin/main HEAD`.