### PR TITLE
fix(discovery): prompt for authenticated host keys

### DIFF
--- a/apps/mobile/plugins/android/src/main/java/AndroidDiscovery.kt
+++ b/apps/mobile/plugins/android/src/main/java/AndroidDiscovery.kt
@@ -133,6 +133,7 @@ internal class AndroidDiscovery(
                                 resolved.serviceName.ifBlank { address },
                                 address,
                                 port,
+                                resolved.attributes["auth"]?.toString(Charsets.UTF_8) == "1",
                             )
                         }
                         resolveNext()
@@ -157,6 +158,7 @@ internal class AndroidDiscovery(
                 put("name", host.name)
                 put("host", host.host)
                 put("port", host.port)
+                put("authRequired", host.authRequired)
             })
         }
         invoke.resolve(JSObject().apply { put("hosts", array) })
@@ -195,7 +197,12 @@ internal class AndroidDiscovery(
         multicastLock = null
     }
 
-    private data class DiscoveredService(val name: String, val host: String, val port: Int)
+    private data class DiscoveredService(
+        val name: String,
+        val host: String,
+        val port: Int,
+        val authRequired: Boolean,
+    )
 
     companion object {
         private const val SERVICE_TYPE = "_mold._tcp."

--- a/apps/mobile/plugins/src/models.rs
+++ b/apps/mobile/plugins/src/models.rs
@@ -31,6 +31,7 @@ pub struct DiscoveredHost {
     pub name: String,
     pub host: String,
     pub port: u16,
+    pub auth_required: bool,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/apps/mobile/src-tauri/src/discovery.rs
+++ b/apps/mobile/src-tauri/src/discovery.rs
@@ -11,6 +11,24 @@ pub struct DiscoveredHost {
     pub name: String,
     pub host: String,
     pub port: u16,
+    pub auth_required: bool,
+}
+
+#[cfg(any(target_vendor = "apple", test))]
+fn auth_required_from_txt(txt: &[u8]) -> bool {
+    let mut cursor = 0;
+    while cursor < txt.len() {
+        let length = usize::from(txt[cursor]);
+        cursor += 1;
+        let Some(end) = cursor.checked_add(length).filter(|end| *end <= txt.len()) else {
+            break;
+        };
+        if txt[cursor..end] == *b"auth=1" {
+            return true;
+        }
+        cursor = end;
+    }
+    false
 }
 
 #[tauri::command]
@@ -39,6 +57,7 @@ async fn platform_discover(
                     name: host.name,
                     host: host.host,
                     port: host.port,
+                    auth_required: host.auth_required,
                 })
                 .collect()
         })
@@ -71,7 +90,7 @@ mod apple {
     use std::ffi::{c_char, c_void};
     use std::time::{Duration, Instant};
 
-    use super::DiscoveredHost;
+    use super::{DiscoveredHost, auth_required_from_txt};
 
     type ServiceRef = *mut c_void;
     type Flags = u32;
@@ -176,8 +195,8 @@ mod apple {
         fullname: *const c_char,
         hosttarget: *const c_char,
         port_be: u16,
-        _txt_len: u16,
-        _txt: *const u8,
+        txt_len: u16,
+        txt: *const u8,
         context: *mut c_void,
     ) {
         let state = unsafe { &mut *(context as *mut ResolveState) };
@@ -191,10 +210,16 @@ mod apple {
             .to_string();
         let full = unsafe { CStr::from_ptr(fullname) }.to_string_lossy();
         let name = full.split("._mold").next().unwrap_or(&host).to_string();
+        let auth_required = if txt.is_null() || txt_len == 0 {
+            false
+        } else {
+            auth_required_from_txt(unsafe { std::slice::from_raw_parts(txt, usize::from(txt_len)) })
+        };
         state.host = Some(DiscoveredHost {
             name,
             host,
             port: u16::from_be(port_be),
+            auth_required,
         });
     }
 
@@ -285,5 +310,23 @@ mod apple {
         }
         found.sort_by(|left, right| left.name.cmp(&right.name));
         Ok(found)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::auth_required_from_txt;
+
+    #[test]
+    fn reads_auth_required_from_dns_sd_txt() {
+        let txt = [
+            6, b'a', b'u', b't', b'h', b'=', b'1', 9, b'v', b'e', b'r', b's', b'i', b'o', b'n',
+            b'=', b'1',
+        ];
+        assert!(auth_required_from_txt(&txt));
+        assert!(!auth_required_from_txt(&[
+            6, b'a', b'u', b't', b'h', b'=', b'0'
+        ]));
+        assert!(!auth_required_from_txt(&[8, b'a', b'u']));
     }
 }

--- a/changelog.d/discovered-host-api-key-prompt.md
+++ b/changelog.d/discovered-host-api-key-prompt.md
@@ -1,0 +1,3 @@
+- **Connect to protected machines discovered on the network.** Desktop, iPhone,
+  and Android now ask for a discovered machine's API key before connecting
+  instead of sending an unauthenticated request and stopping at an error.

--- a/desktop/src/components/machines/ConnectMachineModal.test.ts
+++ b/desktop/src/components/machines/ConnectMachineModal.test.ts
@@ -139,4 +139,57 @@ describe("ConnectMachineModal", () => {
     expect(testRemoteHost).toHaveBeenCalledWith("http://192.168.1.20:7680", null);
     expect(wrapper.find("[data-test='connect-confirm']").exists()).toBe(true);
   });
+
+  it("prompts for a key before connecting an authenticated discovered host", async () => {
+    discoverServers.mockResolvedValue([
+      {
+        name: "locked-7680",
+        url: "http://192.168.1.30:7680",
+        host: "192.168.1.30",
+        port: 7680,
+        version: "1",
+        authRequired: true,
+        isThisMachine: false,
+      },
+    ]);
+    const wrapper = await mountModal();
+    await wrapper.get("[data-test='connect-type-lan']").trigger("click");
+    await wrapper.get("[data-test='connect-continue']").trigger("click");
+    await flushPromises();
+
+    await wrapper.get("[data-test='connect-discovered-add']").trigger("click");
+    await flushPromises();
+    expect(wrapper.get("[data-test='connect-discovered-selected']").text()).toContain(
+      "locked-7680",
+    );
+    expect(testRemoteHost).not.toHaveBeenCalled();
+
+    await wrapper.get("[data-test='connect-key']").setValue("peer-secret");
+    await wrapper.get("[data-test='connect-continue']").trigger("click");
+    await flushPromises();
+    expect(testRemoteHost).toHaveBeenCalledWith("http://192.168.1.30:7680", "peer-secret");
+  });
+
+  it("clears a direct discovered-host prompt when navigating back to LAN discovery", async () => {
+    const initialHost = {
+      name: "locked-7680",
+      url: "http://192.168.1.30:7680",
+      host: "192.168.1.30",
+      port: 7680,
+      version: "1",
+      authRequired: true,
+      isThisMachine: false,
+    };
+    const wrapper = await mountModal();
+    await wrapper.setProps({ open: false, initialHost });
+    await wrapper.setProps({ open: true });
+    await flushPromises();
+    expect(wrapper.find("[data-test='connect-discovered-selected']").exists()).toBe(true);
+
+    await wrapper.get("[data-test='connect-back']").trigger("click");
+    await wrapper.get("[data-test='connect-type-lan']").trigger("click");
+    await wrapper.get("[data-test='connect-continue']").trigger("click");
+    await flushPromises();
+    expect(wrapper.find("[data-test='connect-discovered-selected']").exists()).toBe(false);
+  });
 });

--- a/desktop/src/components/machines/ConnectMachineModal.vue
+++ b/desktop/src/components/machines/ConnectMachineModal.vue
@@ -16,7 +16,7 @@ import { ipc, type DiscoveredHost } from "../../lib/ipc";
 import { addressLabel, prepareHosts, versionLabel } from "../../lib/discovery";
 import { useHostsStore } from "../../stores/hosts";
 
-const props = defineProps<{ open: boolean }>();
+const props = defineProps<{ open: boolean; initialHost?: DiscoveredHost | null }>();
 const emit = defineEmits<{ close: []; connected: [] }>();
 
 const router = useRouter();
@@ -34,9 +34,16 @@ const connecting = ref(false);
 const connectedName = ref("");
 
 const discovered = ref<DiscoveredHost[]>([]);
+const selectedDiscovered = ref<DiscoveredHost | null>(null);
 const scanning = ref(false);
 
 const addressInput = ref<HTMLInputElement | null>(null);
+const apiKeyInput = ref<HTMLInputElement | null>(null);
+
+async function focusApiKey() {
+  await nextTick();
+  window.requestAnimationFrame(() => apiKeyInput.value?.focus());
+}
 
 interface TypeOption {
   value: MachineType;
@@ -68,12 +75,21 @@ function reset() {
   connecting.value = false;
   connectedName.value = "";
   discovered.value = [];
+  selectedDiscovered.value = null;
 }
 
 watch(
   () => props.open,
-  (open) => {
-    if (open) reset();
+  async (open) => {
+    if (!open) return;
+    reset();
+    if (props.initialHost) {
+      type.value = "lan";
+      step.value = 2;
+      discovered.value = [props.initialHost];
+      selectedDiscovered.value = props.initialHost;
+      await focusApiKey();
+    }
   },
 );
 
@@ -128,7 +144,19 @@ function isThisMachine(host: DiscoveredHost): boolean {
 }
 
 async function pickDiscovered(host: DiscoveredHost) {
+  if (host.authRequired && !apiKey.value.trim()) {
+    selectedDiscovered.value = host;
+    error.value = null;
+    await focusApiKey();
+    return;
+  }
   await connect(host.url, apiKey.value || null, host.name);
+}
+
+function clearDiscoveredSelection() {
+  selectedDiscovered.value = null;
+  apiKey.value = "";
+  error.value = null;
 }
 
 async function onContinue() {
@@ -151,8 +179,9 @@ async function onContinue() {
   if (step.value === 2) {
     if (type.value === "remote") {
       await connect(address.value, apiKey.value || null, displayName.value || null);
+    } else if (selectedDiscovered.value) {
+      await pickDiscovered(selectedDiscovered.value);
     }
-    // Local network advances via pickDiscovered, not the primary button.
     return;
   }
   emit("close");
@@ -160,6 +189,8 @@ async function onContinue() {
 
 function onBack() {
   error.value = null;
+  selectedDiscovered.value = null;
+  apiKey.value = "";
   step.value = 1;
 }
 
@@ -167,7 +198,13 @@ const continueLabel = computed(() =>
   step.value === 1 ? "Continue" : step.value === 2 ? "Connect" : "Done",
 );
 const continueDisabled = computed(
-  () => connecting.value || (step.value === 2 && type.value === "remote" && !address.value.trim()),
+  () =>
+    connecting.value ||
+    (step.value === 2 && type.value === "remote" && !address.value.trim()) ||
+    (step.value === 2 &&
+      type.value === "lan" &&
+      selectedDiscovered.value?.authRequired === true &&
+      !apiKey.value.trim()),
 );
 </script>
 
@@ -291,7 +328,7 @@ const continueDisabled = computed(
             {{ scanning ? "Scanning…" : "Scan again" }}
           </button>
         </div>
-        <ul v-if="discovered.length" class="mt-2 flex flex-col gap-1.5">
+        <ul v-if="discovered.length && !selectedDiscovered" class="mt-2 flex flex-col gap-1.5">
           <li
             v-for="host in discovered"
             :key="host.url"
@@ -320,22 +357,48 @@ const continueDisabled = computed(
             </button>
           </li>
         </ul>
-        <p v-else-if="!scanning" class="mt-2 text-caption text-ink-3">
+        <p v-else-if="!scanning && !selectedDiscovered" class="mt-2 text-caption text-ink-3">
           No other mold servers found on your network.
         </p>
-        <label class="mt-4 block text-caption font-semibold text-ink-2" for="connect-lan-key">
-          API key
-        </label>
-        <input
-          id="connect-lan-key"
-          v-model="apiKey"
-          data-selectable
-          data-test="connect-key"
-          type="password"
-          autocomplete="off"
-          placeholder="Optional — used when a picked host needs one"
-          class="data-mono mt-1.5 w-full rounded-chrome border border-ce bg-bath px-3 py-2.5 text-body text-ink outline-none placeholder:text-ink-3"
-        />
+        <template v-if="selectedDiscovered">
+          <div
+            data-test="connect-discovered-selected"
+            class="border-edge mt-2 flex items-center gap-3 rounded-control border bg-bath px-3 py-2"
+          >
+            <div class="min-w-0 flex-1">
+              <div class="truncate text-body text-ink">{{ selectedDiscovered.name }}</div>
+              <div class="data-mono mt-0.5 truncate text-caption text-ink-3">
+                {{ addressLabel(selectedDiscovered) }} · {{ versionLabel(selectedDiscovered) }}
+              </div>
+            </div>
+            <button
+              v-if="!initialHost"
+              type="button"
+              class="text-caption text-ink-3 hover:text-ink"
+              @click="clearDiscoveredSelection"
+            >
+              Choose another
+            </button>
+          </div>
+          <label class="mt-4 block text-caption font-semibold text-ink-2" for="connect-lan-key">
+            API key
+          </label>
+          <input
+            id="connect-lan-key"
+            ref="apiKeyInput"
+            v-model="apiKey"
+            data-selectable
+            data-test="connect-key"
+            type="password"
+            autocomplete="off"
+            placeholder="Required by this machine"
+            class="data-mono mt-1.5 w-full rounded-chrome border border-ce bg-bath px-3 py-2.5 text-body text-ink outline-none placeholder:text-ink-3"
+            @keydown.enter="onContinue"
+          />
+          <p class="mt-2 text-caption text-ink-3">
+            This machine requires its own API key. The key is stored only on this device.
+          </p>
+        </template>
       </template>
 
       <p v-if="error" data-test="connect-error" class="mt-3 text-caption text-stop">{{ error }}</p>
@@ -380,6 +443,7 @@ const continueDisabled = computed(
       </button>
       <div class="flex-1" />
       <button
+        v-if="step !== 2 || type === 'remote' || selectedDiscovered"
         type="button"
         data-test="connect-continue"
         class="rounded-chrome bg-safelight px-6 py-2.5 text-body font-bold text-on-accent hover:brightness-105 active:translate-y-px disabled:opacity-50"

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -8864,7 +8864,14 @@ describe("MobileApp host and catalog coordination", () => {
     invoke.mockImplementation((command: string) => {
       if (command === "keychain_get_api_key") return Promise.resolve(target.apiKey);
       if (command === "discover_mold_hosts") {
-        return Promise.resolve([{ name: "Render Box", host: "192.168.1.50", port: 7680 }]);
+        return Promise.resolve([
+          {
+            name: "Render Box",
+            host: "192.168.1.50",
+            port: 7680,
+            authRequired: true,
+          },
+        ]);
       }
       return Promise.resolve(null);
     });
@@ -8881,7 +8888,21 @@ describe("MobileApp host and catalog coordination", () => {
     expect(wrapper.get("[data-test='mobile-discovered-host']").text()).toContain(
       "192.168.1.50:7680",
     );
-    expect(wrapper.text()).toContain("API key");
+    await wrapper.get("[data-test='mobile-discovered-host'] button").trigger("click");
+    await flushPromises();
+    expect(wrapper.find("[data-test='mobile-discovered-key-prompt']").exists()).toBe(true);
+    expect(apiJsonTo).not.toHaveBeenCalledWith(
+      expect.objectContaining({ baseUrl: "http://192.168.1.50:7680" }),
+      "/api/status",
+    );
+
+    await wrapper.get("[data-test='mobile-discovered-api-key']").setValue("peer-secret");
+    await wrapper.get("[data-test='mobile-discovered-key-prompt']").trigger("submit");
+    await flushPromises();
+    expect(apiJsonTo).toHaveBeenCalledWith(
+      { baseUrl: "http://192.168.1.50:7680", apiKey: "peer-secret" },
+      "/api/status",
+    );
   });
 
   it("names Google Play instead of TestFlight in Android settings", async () => {

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -485,6 +485,7 @@ interface DiscoveredHost {
   name: string;
   host: string;
   port: number;
+  authRequired: boolean;
 }
 
 interface GalleryPrint extends MobileGalleryImage {
@@ -665,6 +666,8 @@ let catalogIntentToken = 0;
 const hostDetailId = ref("");
 const hostInput = reactive({ name: "", address: "", apiKey: "" });
 const discovered = ref<DiscoveredHost[]>([]);
+const selectedDiscovered = ref<DiscoveredHost | null>(null);
+const discoveredApiKeyInput = ref<HTMLInputElement | null>(null);
 const discovering = ref(false);
 const pairing = ref(false);
 const pairingScannerOpen = ref(false);
@@ -3218,11 +3221,34 @@ async function connectHost(address?: string, discoveredName?: string): Promise<v
     hostInput.name = "";
     hostInput.address = "";
     hostInput.apiKey = "";
+    selectedDiscovered.value = null;
     await refreshModels();
   } catch (error) {
     const label = hostInput.name.trim() || discoveredName || (address ?? hostInput.address).trim();
     hostError.value = describeTransportError(error, label);
   }
+}
+
+async function pickDiscoveredHost(host: DiscoveredHost): Promise<void> {
+  if (!host.authRequired) {
+    await connectHost(`${host.host}:${host.port}`, host.name);
+    return;
+  }
+  selectedDiscovered.value = host;
+  hostInput.name = host.name;
+  hostInput.address = `${host.host}:${host.port}`;
+  hostInput.apiKey = "";
+  hostError.value = "";
+  await nextTick();
+  discoveredApiKeyInput.value?.focus();
+}
+
+function clearDiscoveredHost() {
+  selectedDiscovered.value = null;
+  hostInput.name = "";
+  hostInput.address = "";
+  hostInput.apiKey = "";
+  hostError.value = "";
 }
 
 async function discoverHosts(): Promise<void> {
@@ -11579,16 +11605,44 @@ onBeforeUnmount(() => {
                 <div class="host-name">{{ host.name }}</div>
                 <div class="host-url">{{ host.host }}:{{ host.port }}</div>
               </div>
-              <button
-                class="secondary-button"
-                type="button"
-                @click="connectHost(`${host.host}:${host.port}`, host.name)"
-              >
+              <button class="secondary-button" type="button" @click="pickDiscoveredHost(host)">
                 Connect
               </button>
             </div>
           </div>
-          <form style="margin-top: 20px" @submit.prevent="connectHost()">
+          <form
+            v-if="selectedDiscovered"
+            style="margin-top: 20px"
+            data-test="mobile-discovered-key-prompt"
+            @submit.prevent="connectHost(hostInput.address, hostInput.name)"
+          >
+            <div class="host-row">
+              <div class="host-name">{{ selectedDiscovered.name }}</div>
+              <div class="host-url">
+                {{ selectedDiscovered.host }}:{{ selectedDiscovered.port }}
+              </div>
+            </div>
+            <label class="field"
+              ><span>API key</span
+              ><input
+                ref="discoveredApiKeyInput"
+                v-model="hostInput.apiKey"
+                class="control"
+                type="password"
+                placeholder="Required by this machine"
+                autocomplete="off"
+                data-test="mobile-discovered-api-key"
+                required
+            /></label>
+            <p class="section-note">This machine requires its own API key.</p>
+            <div class="mobile-inline-actions">
+              <button class="secondary-button" type="button" @click="clearDiscoveredHost">
+                Choose another
+              </button>
+              <button class="primary-button" type="submit">Test and save</button>
+            </div>
+          </form>
+          <form v-else style="margin-top: 20px" @submit.prevent="connectHost()">
             <label class="field"
               ><span>Name</span
               ><input

--- a/desktop/src/mobile/mobile.css
+++ b/desktop/src/mobile/mobile.css
@@ -4068,6 +4068,16 @@ button:disabled {
   border-bottom: 1px solid var(--edge);
 }
 
+.mobile-inline-actions {
+  display: flex;
+  gap: 10px;
+}
+
+.mobile-inline-actions > button {
+  min-width: 0;
+  flex: 1;
+}
+
 .host-row-button {
   display: block;
   width: 100%;

--- a/desktop/src/views/MachinesView.test.ts
+++ b/desktop/src/views/MachinesView.test.ts
@@ -6,6 +6,13 @@ import { createMemoryHistory, createRouter, type Router } from "vue-router";
 const appSettingsGet = vi.fn();
 const discoverServers = vi.fn();
 const secretGet = vi.fn().mockResolvedValue(null);
+const testRemoteHost = vi.fn().mockResolvedValue({
+  ok: true,
+  version: "1",
+  error: null,
+  instanceId: null,
+  hostname: null,
+});
 vi.mock("../lib/ipc", () => ({
   inTauri: () => false,
   ipc: {
@@ -14,9 +21,7 @@ vi.mock("../lib/ipc", () => ({
     secretGet: (...a: unknown[]) => secretGet(...a),
     secretSet: vi.fn().mockResolvedValue(undefined),
     discoverServers: (...a: unknown[]) => discoverServers(...(a as [])),
-    testRemoteHost: vi
-      .fn()
-      .mockResolvedValue({ ok: true, version: "1", error: null, instanceId: null, hostname: null }),
+    testRemoteHost: (...a: unknown[]) => testRemoteHost(...a),
     forgetRemoteHost: vi.fn().mockResolvedValue([]),
   },
 }));
@@ -231,6 +236,34 @@ describe("MachinesView overview", () => {
     expect(discovered.find("[data-test='discovered-add']").exists()).toBe(true);
   });
 
+  it("prompts for a key before connecting an authenticated discovered host", async () => {
+    discoverServers.mockResolvedValue([
+      {
+        name: "locked-7680",
+        url: "http://192.168.1.30:7680",
+        host: "192.168.1.30",
+        port: 7680,
+        version: "1",
+        authRequired: true,
+        isThisMachine: false,
+      },
+    ]);
+    const wrapper = await mountView();
+
+    await wrapper.get("[data-test='discovered-add']").trigger("click");
+    await flushPromises();
+    expect(wrapper.get("[data-test='connect-discovered-selected']").text()).toContain(
+      "locked-7680",
+    );
+    expect(wrapper.find("[data-test='connect-key']").exists()).toBe(true);
+    expect(wrapper.find("[data-test='connect-error']").exists()).toBe(false);
+
+    await wrapper.get("[data-test='connect-key']").setValue("peer-secret");
+    await wrapper.get("[data-test='connect-continue']").trigger("click");
+    await flushPromises();
+    expect(testRemoteHost).toHaveBeenCalledWith("http://192.168.1.30:7680", "peer-secret");
+  });
+
   it("hides the app's own embedded server from On your network but keeps standalone same-machine servers", async () => {
     discoverServers.mockResolvedValue([
       {
@@ -321,5 +354,6 @@ describe("MachinesView overview", () => {
     await flushPromises();
     expect(secretGet).toHaveBeenCalledWith("remote-api-key.192-168-1-20-7680");
     expect(secretGet).toHaveBeenCalledWith("remote-api-key.studio-7680");
+    expect(testRemoteHost).toHaveBeenCalledWith("http://192.168.1.20:7680", "twin-key");
   });
 });

--- a/desktop/src/views/MachinesView.vue
+++ b/desktop/src/views/MachinesView.vue
@@ -58,6 +58,17 @@ async function stopPod(pod: RunPodPod) {
 }
 
 const connectOpen = ref(false);
+const connectPromptHost = ref<DiscoveredHost | null>(null);
+
+function openConnectModal(host: DiscoveredHost | null = null) {
+  connectPromptHost.value = host;
+  connectOpen.value = true;
+}
+
+function closeConnectModal() {
+  connectOpen.value = false;
+  connectPromptHost.value = null;
+}
 
 function openDetail(host: HostView) {
   void router.push(`/machines/${host.id}`);
@@ -308,6 +319,10 @@ async function addDiscovered(host: DiscoveredHost) {
         // Settings unreadable — connect proceeds without a key.
       }
     }
+    if (host.authRequired && !key) {
+      openConnectModal(host);
+      return;
+    }
     const view = await hosts.connect(host.url, key, host.name);
     toasts.push(`Connected to ${view.label}`);
     await refreshSaved();
@@ -335,7 +350,7 @@ async function onConnected() {
         type="button"
         data-test="add-machine"
         class="border-ce flex items-center gap-1.5 rounded-chrome border px-3.5 py-2 text-body font-semibold text-ink-2 transition-colors hover:text-ink active:translate-y-px"
-        @click="connectOpen = true"
+        @click="openConnectModal()"
       >
         <Icon name="plus" :size="14" :stroke-width="2" />
         Add machine
@@ -522,7 +537,8 @@ async function onConnected() {
 
     <ConnectMachineModal
       :open="connectOpen"
-      @close="connectOpen = false"
+      :initial-host="connectPromptHost"
+      @close="closeConnectModal"
       @connected="onConnected"
     />
     <ConfirmDialog


### PR DESCRIPTION
## Summary

- prompt for the API key before connecting to authenticated desktop-discovered nodes
- carry DNS-SD auth metadata through iOS and Android discovery and add the same key prompt on mobile
- keep the existing web behavior, which already prompted correctly

## Validation

- 331 targeted desktop/mobile Vitest tests passed
- 12 web discovery modal tests passed
- mobile Rust DNS-SD TXT parser test passed
- desktop and mobile production builds passed
- rendered desktop UAT: prompt focused, Connect disabled until a key was entered, then connection succeeded; zero console errors
- Android build reached Kotlin compilation; existing generated MainActivity.kt fails because TauriActivity is unavailable (unrelated to this change)
- independent agent peer review approved after desktop Back-flow and mobile parity findings were addressed
