### PR TITLE
refactor(mobile): isolate generation submission lifecycle

### DIFF
--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -676,12 +676,7 @@ describe("MobileApp sequence generation", () => {
     ).toBeUndefined();
     expect(
       invoke.mock.calls.filter(([command]) => command === "end_mobile_background_task"),
-    ).toEqual([
-      [
-        "end_mobile_background_task",
-        { token: "mobile-background-stale-source" },
-      ],
-    ]);
+    ).toEqual([["end_mobile_background_task", { token: "mobile-background-stale-source" }]]);
   });
 
   it("removes capability-restricted models from the picker before submission", async () => {

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -496,6 +496,38 @@ describe("MobileApp sequence generation", () => {
     expect(button.text()).toContain("Develop print");
   });
 
+  it("releases iOS background execution exactly once after placement cancellation settles", async () => {
+    isNativeIOSRuntime.mockReturnValue(true);
+    invoke.mockImplementation((command: string) => {
+      if (command === "keychain_get_api_key") return Promise.resolve(target.apiKey);
+      if (command === "begin_mobile_background_task") {
+        return Promise.resolve("mobile-background-placement-cancel");
+      }
+      return Promise.resolve(null);
+    });
+    const preview = deferred<ReturnType<typeof plannedPlacement>>();
+    previewGenerationPlacement.mockReturnValueOnce(preview.promise);
+    wrapper = mountMobileApp();
+    await flushPromises();
+    await fieldControl("Prompt").setValue("a placement cancellation cleanup check");
+
+    const button = wrapper.get("[data-test='mobile-develop-button']");
+    await button.trigger("click");
+    await vi.waitFor(() => expect(previewGenerationPlacement).toHaveBeenCalledTimes(1));
+    await button.trigger("click");
+    preview.resolve(plannedPlacement());
+
+    await vi.waitFor(() =>
+      expect(invoke).toHaveBeenCalledWith("end_mobile_background_task", {
+        token: "mobile-background-placement-cancel",
+      }),
+    );
+    expect(
+      invoke.mock.calls.filter(([command]) => command === "end_mobile_background_task"),
+    ).toHaveLength(1);
+    expect(openStreams).toHaveLength(0);
+  });
+
   it("holds iOS background execution through placement and server admission", async () => {
     isNativeIOSRuntime.mockReturnValue(true);
     invoke.mockImplementation((command: string) => {
@@ -606,6 +638,14 @@ describe("MobileApp sequence generation", () => {
   });
 
   it("releases Generate when invalidated source preparation rejects", async () => {
+    isNativeIOSRuntime.mockReturnValue(true);
+    invoke.mockImplementation((command: string) => {
+      if (command === "keychain_get_api_key") return Promise.resolve(target.apiKey);
+      if (command === "begin_mobile_background_task") {
+        return Promise.resolve("mobile-background-stale-source");
+      }
+      return Promise.resolve(null);
+    });
     const imageModel: ModelEntry = { ...model, name: "flux:image", family: "flux" };
     apiJsonTo.mockImplementation((_target: unknown, path: string) => {
       if (path === "/api/status") return Promise.resolve(status);
@@ -634,6 +674,14 @@ describe("MobileApp sequence generation", () => {
     expect(
       wrapper.get("[data-test='mobile-develop-button']").attributes("disabled"),
     ).toBeUndefined();
+    expect(
+      invoke.mock.calls.filter(([command]) => command === "end_mobile_background_task"),
+    ).toEqual([
+      [
+        "end_mobile_background_task",
+        { token: "mobile-background-stale-source" },
+      ],
+    ]);
   });
 
   it("removes capability-restricted models from the picker before submission", async () => {

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -111,7 +111,6 @@ import { h3BoundariesNeedingMedia } from "@studio/lib/h3BoundaryRestore";
 import {
   classifyPlacementPreview,
   previewChainPlacement,
-  previewGenerationPlacement,
   previewRequestForSiblingFanout,
   requiresAuthoritativePlacement,
   type GenerationPlacementPreview,
@@ -453,7 +452,11 @@ import {
 } from "./mobileGenerationRecovery";
 import { watchMobileGenerationHost, type MobileGenerationHostWatch } from "./mobileGenerationWatch";
 import { beginMobileBackgroundTask } from "./backgroundTask";
-import { mobilePlacementFailure, routeAutomaticMobileGeneration } from "./mobileGenerationRouting";
+import {
+  mobilePlacementFailure,
+  previewPinnedMobileGeneration,
+  routeAutomaticMobileGeneration,
+} from "./mobileGenerationRouting";
 import { prepareMobileGenerationRequest } from "./mobileGenerationPreparation";
 import {
   capturePreparedSubmission,
@@ -5728,67 +5731,29 @@ async function generate(): Promise<void> {
     placement = routed.placement;
     legacyUnsupported = routed.legacyUnsupported;
   } else {
-    try {
-      placement =
-        chainRouting.kind === "chain"
-          ? await previewChainPlacement(target, previewRequest, batchSize, {
-              signal: submitSignal,
-            })
-          : await previewGenerationPlacement(target, previewRequest, batchSize, {
-              signal: submitSignal,
-            });
-    } catch (error) {
-      if (!submissionAttempt.isCurrent()) {
-        releasePreparedSubmission();
-        return;
-      }
-      if (error instanceof ApiError && (error.status === 404 || error.status === 405)) {
-        if (requireAuthoritativePlacement) {
-          // An identity request lands here for its own reason — that server
-          // predates the partition and would ignore the face rather than
-          // refuse it — so it says that instead of talking about references.
-          setGenerationStatus(
-            mobileIdentityRouteRefusal({
-              carriesIdentity: Boolean(request.id_image),
-              hostLabel: route.label,
-              hostAdvertisesIdentity: true,
-              legacyPlacement: true,
-            }) ??
-              `${route.label} does not provide the authoritative placement preview required for reference media. Nothing was queued.`,
-            true,
-          );
-          releasePreparedSubmission();
-          return;
-        }
-        legacyUnsupported = true;
-      } else {
-        setGenerationStatus(describeTransportError(error, route.label), true);
-        releasePreparedSubmission();
-        return;
-      }
+    const preview = await previewPinnedMobileGeneration({
+      route,
+      request: previewRequest,
+      chain: chainRouting.kind === "chain",
+      copies: batchSize,
+      subject: "print",
+      requireAuthoritative: requireAuthoritativePlacement,
+      isCurrent: () => submissionAttempt.isCurrent(),
+      signal: submitSignal,
+    });
+    if (preview.kind === "abandoned") {
+      releasePreparedSubmission();
+      return;
     }
+    if (preview.kind === "error") {
+      setGenerationStatus(preview.message, true);
+      releasePreparedSubmission();
+      return;
+    }
+    placement = preview.placement;
+    legacyUnsupported = preview.legacyUnsupported;
   }
   if (!submissionAttempt.isCurrent()) {
-    releasePreparedSubmission();
-    return;
-  }
-  const classification: string = classifyPlacementPreview(placement);
-  if (requireAuthoritativePlacement && classification === "unsupported") {
-    setGenerationStatus(
-      mobileIdentityRouteRefusal({
-        carriesIdentity: Boolean(request.id_image),
-        hostLabel: route.label,
-        hostAdvertisesIdentity: true,
-        legacyPlacement: true,
-      }) ??
-        `${route.label} does not provide the authoritative placement preview required for reference media. Nothing was queued.`,
-      true,
-    );
-    releasePreparedSubmission();
-    return;
-  }
-  if (!legacyUnsupported && classification !== "unsupported" && classification !== "planned") {
-    setGenerationStatus(mobilePlacementFailure(placement, route.label, "print"), true);
     releasePreparedSubmission();
     return;
   }

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -461,6 +461,10 @@ import {
   preparedSubmissionIsCurrent,
   quickSubmissionIsCurrent,
 } from "./mobileGenerationSnapshot";
+import {
+  mobileCompletionSummary as completionSummary,
+  summarizeMobileGenerationOutcome,
+} from "./mobileGenerationOutcome";
 import { MobileSubmissionAttempts } from "./mobileSubmissionAttempt";
 
 type Tab = "generate" | "gallery" | "catalog" | "hosts";
@@ -2604,14 +2608,6 @@ const generationStatusIsError = computed(() => !activeGeneration.value && progre
 function setGenerationStatus(message: string, isError = false): void {
   progress.value = message;
   progressIsError.value = isError;
-}
-
-/** Seed/time line for a completed result; the time is omitted when a resumed
- * reconciliation lost the true duration with the stream. */
-function completionSummary(result: CompleteEvent): string {
-  const timing =
-    result.generation_time_ms > 0 ? `${(result.generation_time_ms / 1000).toFixed(1)}s · ` : "";
-  return `${timing}seed ${result.seed_used}`;
 }
 
 async function saveCompletedStillToPhotos(result: CompleteEvent, target: ApiTarget): Promise<void> {
@@ -5968,103 +5964,19 @@ async function generate(): Promise<void> {
       isActive: () => !unmounted,
     });
     if (unmounted) return;
-    requestAdvisories.value = [...new Set(jobs.flatMap((candidate) => candidate.requestWarnings))];
+    const outcome = summarizeMobileGenerationOutcome(jobs, {
+      hostLabel: route.label,
+      prepared: preparedSubmission !== null,
+    });
+    requestAdvisories.value = outcome.advisories;
     for (const candidate of jobs) handledGenerationClientIds.add(candidate.clientId);
-    const completed = jobs.filter(
-      (candidate) => candidate.status === "complete" && candidate.result,
-    );
-    for (const candidate of completed) {
+    for (const candidate of outcome.completed) {
       void saveCompletedStillToPhotos(candidate.result!, route.target);
     }
-    const latestCompleted = completed.at(-1);
-    const unconfirmedCancellation = jobs.find((candidate) =>
-      candidate.error?.includes("remote cancellation was not confirmed"),
-    );
-    const failed = jobs.find((candidate) => candidate.error && !isCancelledError(candidate.error));
-    const failedError = failed?.error ? describeTransportError(failed.error, route.label) : null;
-    const failedVariations = preparedSubmission
-      ? jobs.flatMap((candidate, index) => {
-          if (!candidate.error || isCancelledError(candidate.error)) return [];
-          const prompt =
-            candidate.prompt.length > 120 ? `${candidate.prompt.slice(0, 117)}…` : candidate.prompt;
-          return [
-            `Variation ${index + 1}, “${prompt}”, failed: ${describeTransportError(
-              candidate.error,
-              route.label,
-            )}`,
-          ];
-        })
-      : [];
-    const preparedFailureSummary = failedVariations.join(" ");
-    const failedCount = jobs.filter(
-      (candidate) => candidate.error && !isCancelledError(candidate.error),
-    ).length;
-    const cancelled = jobs.find((candidate) => isCancelledError(candidate.error));
-
-    if (latestCompleted?.result) {
-      latestResultClientId.value = latestCompleted.clientId;
-      if (latestCompleted.resultError) {
-        const previewDetail = describeTransportError(latestCompleted.resultError, route.label);
-        setGenerationStatus(previewDetail, true);
-        generationAnnouncement.value = `${completed.length} of ${jobs.length} generations completed, but the latest preview is unavailable. ${previewDetail}`;
-      } else {
-        setGenerationStatus(
-          `${completed.length > 1 ? `${completed.length} prints · ` : ""}${completionSummary(
-            latestCompleted.result,
-          )}`,
-        );
-        generationAnnouncement.value =
-          completed.length === 1 && jobs.length === 1
-            ? "Generation completed."
-            : `${completed.length} of ${jobs.length} generations completed.`;
-      }
-      if (unconfirmedCancellation?.error || failedError) {
-        setGenerationStatus(
-          [
-            `${completed.length} of ${jobs.length} completed`,
-            failedError,
-            unconfirmedCancellation?.error,
-          ]
-            .filter(Boolean)
-            .join(" · "),
-          true,
-        );
-        generationAnnouncement.value = [
-          `${completed.length} generations completed.`,
-          failedError
-            ? preparedSubmission
-              ? `${failedCount} failed. ${preparedFailureSummary}`
-              : `${failedCount} failed. ${failedError}`
-            : "",
-          unconfirmedCancellation?.error
-            ? `Cancellation failed. ${unconfirmedCancellation.error}`
-            : "",
-        ]
-          .filter(Boolean)
-          .join(" ");
-      }
-      if (tab.value === "gallery") void refreshGallery();
-    } else if (unconfirmedCancellation?.error || failedError) {
-      setGenerationStatus(
-        [failedError, unconfirmedCancellation?.error].filter(Boolean).join(" · "),
-        true,
-      );
-      generationAnnouncement.value = [
-        failedError
-          ? preparedSubmission
-            ? `Generation failed. ${preparedFailureSummary}`
-            : `Generation failed. ${failedError}`
-          : "",
-        unconfirmedCancellation?.error
-          ? `Cancellation failed. ${unconfirmedCancellation.error}`
-          : "",
-      ]
-        .filter(Boolean)
-        .join(" ");
-    } else if (cancelled) {
-      setGenerationStatus("Cancelled");
-      generationAnnouncement.value = `${jobs.length} generation${jobs.length === 1 ? "" : "s"} cancelled.`;
-    }
+    if (outcome.latestCompleted) latestResultClientId.value = outcome.latestCompleted.clientId;
+    if (outcome.status) setGenerationStatus(outcome.status.message, outcome.status.isError);
+    if (outcome.announcement !== null) generationAnnouncement.value = outcome.announcement;
+    if (outcome.refreshGallery && tab.value === "gallery") void refreshGallery();
     // Only terminal jobs whose callbacks have run are eligible: multiple
     // completion microtasks cannot prune one another before they promote the
     // correct latest result. The UI renders one result, so retain one Blob.

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -49,7 +49,6 @@ import {
 import { imageDimensionsFromBase64 } from "@studio/lib/imageDimensions";
 import {
   resolveDefaultSourceResolution,
-  resolveSourceConditioningTarget,
   resolveSourceCanvasTransition,
   resolveSourceResolution,
   type SourceDimensions,
@@ -102,7 +101,6 @@ import { promptPlaceholder, promptRequired } from "@studio/lib/promptRequirement
 import { applyAuthoredPrompt } from "@studio/lib/promptProvenance";
 import {
   appendMinimaxH3GalleryImageReference,
-  emptyMinimaxH3AuthoringState,
   isMinimaxH3Identity,
   minimaxH3AuthoringError,
   minimaxH3TaskForModel,
@@ -294,7 +292,7 @@ import { sequenceParams } from "../lib/sequenceParams";
 import { isGenerationModel } from "../stores/models";
 import type { HostRoute } from "../stores/hosts";
 import { domCanvasOps } from "../lib/sourceFitCanvas";
-import { applyH3BoundaryFit, applySourceFitPreprocess } from "../lib/sourceFitPreprocess";
+import { applySourceFitPreprocess } from "../lib/sourceFitPreprocess";
 import { coerceSourceFitForMaskless, parseSourceFitPolicy } from "@studio/lib/sourceFit";
 import { requestWarningsFromHeaders } from "@studio/lib/requestWarnings";
 import {
@@ -457,6 +455,7 @@ import {
 import { watchMobileGenerationHost, type MobileGenerationHostWatch } from "./mobileGenerationWatch";
 import { beginMobileBackgroundTask } from "./backgroundTask";
 import { mobilePlacementFailure, routeAutomaticMobileGeneration } from "./mobileGenerationRouting";
+import { prepareMobileGenerationRequest } from "./mobileGenerationPreparation";
 
 type Tab = "generate" | "gallery" | "catalog" | "hosts";
 
@@ -5410,125 +5409,28 @@ async function prepareGenerationRequest(
   isCurrent: () => boolean = () => true,
   signal?: AbortSignal,
 ) {
-  // Fixed recipe controls are not user choices: a stale draft value (restored
-  // before the recipe landed, model swapped under it) snaps to what the
-  // disabled control displays instead of queueing a shape the host refuses.
-  // It runs before the source fits below so their target is the canvas that
-  // actually renders. Shared with desktop and web.
-  Object.assign(
-    draft,
-    fixedRecipeControlOverrides(
-      effectiveGenerationRecipe(selectedGenerationModel.value, draft.pipeline),
-    ),
+  return prepareMobileGenerationRequest(
+    {
+      target,
+      draft,
+      selectedModel: selectedGenerationModel.value,
+      isCurrent,
+      ...(signal ? { signal } : {}),
+    },
+    {
+      cache: sourceFitCache,
+      ops: domCanvasOps,
+      upscale: (image, model, upscaleTarget, upscaleSignal, onProgress) =>
+        upscaleImage({
+          image,
+          model,
+          target: upscaleTarget,
+          ...(upscaleSignal ? { signal: upscaleSignal } : {}),
+          onProgress,
+        }),
+      onStatus: setGenerationStatus,
+    },
   );
-  const draftCaps = generationCapabilitiesForFamily(
-    draft.family,
-    draft.model,
-    draft.pipeline,
-    draft.guidanceCapabilities,
-    draft.sourceImageCapability,
-  );
-  if (draftCaps.sourceImageMode === "h3-boundaries") {
-    // H3 FL2VA boundaries take the same client-side fit, coerced maskless.
-    draft.h3Authoring =
-      (await applyH3BoundaryFit(
-        draft.h3Authoring,
-        draft.sourceFit,
-        { width: draft.width, height: draft.height },
-        {
-          ops: domCanvasOps,
-          cache: sourceFitCache,
-          upscale: (image, model) =>
-            upscaleImage({
-              image,
-              model,
-              target,
-              ...(signal ? { signal } : {}),
-              onProgress: (message) => {
-                if (isCurrent()) setGenerationStatus(message);
-              },
-            }),
-          onStatus: (message) => {
-            if (isCurrent()) setGenerationStatus(message);
-          },
-        },
-      )) ?? emptyMinimaxH3AuthoringState();
-  } else if (draftCaps.sourceImageMode === "qwen-edit" && draft.imageAttachments[0]) {
-    const sourceTarget = resolveSourceConditioningTarget(
-      { width: draft.width, height: draft.height },
-      selectedGenerationModel.value ?? draft.family,
-      draft.pipeline,
-    );
-    const result = await applySourceFitPreprocess(
-      {
-        source: draft.imageAttachments[0],
-        mask: null,
-        policy: coerceSourceFitForMaskless(draft.sourceFit),
-        target: sourceTarget,
-      },
-      {
-        ops: domCanvasOps,
-        cache: sourceFitCache,
-        upscale: (image, model) =>
-          upscaleImage({
-            image,
-            model,
-            target,
-            ...(signal ? { signal } : {}),
-            onProgress: (message) => {
-              if (isCurrent()) setGenerationStatus(message);
-            },
-          }),
-        onStatus: (message) => {
-          if (isCurrent()) setGenerationStatus(message);
-        },
-      },
-    );
-    if (result.source) draft.imageAttachments[0] = result.source;
-  } else if (
-    draftCaps.supportsImg2img &&
-    draftCaps.sourceImageMode === "single" &&
-    draft.sourceImage
-  ) {
-    const result = await applySourceFitPreprocess(
-      {
-        source: draft.sourceImage,
-        mask: draftCaps.supportsMask ? draft.maskImage : null,
-        policy: draftCaps.supportsMask
-          ? draft.sourceFit
-          : coerceSourceFitForMaskless(draft.sourceFit),
-        target: { width: draft.width, height: draft.height },
-      },
-      {
-        ops: domCanvasOps,
-        cache: sourceFitCache,
-        upscale: (image, model) =>
-          upscaleImage({
-            image,
-            model,
-            target,
-            ...(signal ? { signal } : {}),
-            onProgress: (message) => {
-              if (isCurrent()) setGenerationStatus(message);
-            },
-          }),
-        onStatus: (message) => {
-          if (isCurrent()) setGenerationStatus(message);
-        },
-      },
-    );
-    draft.sourceImage = result.source;
-    draft.maskImage = result.mask;
-  }
-  const mediaBudgetError = mobileMediaBudgetValidationError(draft);
-  if (mediaBudgetError) throw new Error(mediaBudgetError);
-  // `buildRequest` stamps the additive `title` and the File under fields from
-  // the FROZEN draft. Nothing may re-read the live title here: source fitting
-  // and the placement fan-out can take minutes, and a title edited inside that
-  // window would ship a name whose own ghost tag and collection match were
-  // derived from the previous one. The title is validated at the tap boundary
-  // instead (`generate()`, `submitMobileSequence`).
-  return buildRequest(draft);
 }
 
 async function generate(): Promise<void> {

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -5426,6 +5426,75 @@ async function prepareGenerationRequest(
   );
 }
 
+function clearSubmittedExpansionWork(
+  preparedSubmission: ReturnType<typeof capturePreparedSubmission>,
+  quickSubmission: ReturnType<typeof captureQuickSubmission>,
+  preparedSection: HTMLElement | null,
+  preparedSubmissionOwnedFocus: boolean,
+): void {
+  if (preparedSubmission) {
+    const active = document.activeElement;
+    const restoreFocus =
+      preparedSubmissionOwnedFocus &&
+      (active === document.body || (!!active && !!preparedSection?.contains(active)));
+    preparedBatch.value = null;
+    if (restoreFocus) {
+      void nextTick(() => document.querySelector<HTMLTextAreaElement>("#mobile-prompt")?.focus());
+    }
+  }
+  if (
+    quickSubmission &&
+    quickExpansionSnapshot.value?.requestToken === quickSubmission.requestToken
+  ) {
+    quickExpansionSnapshot.value = null;
+  }
+}
+
+async function presentSettledGeneration(
+  jobs: Job[],
+  route: HostRoute,
+  chain: boolean,
+  prepared: boolean,
+): Promise<void> {
+  if (unmounted || jobs.length === 0) return;
+  // iOS suspension kills every held SSE socket: reconcile against the frozen
+  // route before composing any status or accessibility announcement.
+  await reconcileInterruptedGenerationJobs(jobs, {
+    target: { ...route.target },
+    hostLabel: route.label,
+    queueCapacity: hostTelemetry[route.hostId]?.queueCapacity,
+    chain,
+    refreshResultUrl: (clientId) =>
+      void generation.refreshRemoteResultUrl(clientId).catch(() => {
+        // The reactive job carries the directed, user-visible error.
+      }),
+    isActive: () => !unmounted,
+  });
+  if (unmounted) return;
+  const outcome = summarizeMobileGenerationOutcome(jobs, {
+    hostLabel: route.label,
+    prepared,
+  });
+  requestAdvisories.value = outcome.advisories;
+  for (const candidate of jobs) handledGenerationClientIds.add(candidate.clientId);
+  for (const candidate of outcome.completed) {
+    void saveCompletedStillToPhotos(candidate.result!, route.target);
+  }
+  if (outcome.latestCompleted) latestResultClientId.value = outcome.latestCompleted.clientId;
+  if (outcome.status) setGenerationStatus(outcome.status.message, outcome.status.isError);
+  if (outcome.announcement !== null) generationAnnouncement.value = outcome.announcement;
+  if (outcome.refreshGallery && tab.value === "gallery") void refreshGallery();
+  // Only terminal jobs whose callbacks have run are eligible: multiple
+  // completion microtasks cannot prune one another before they promote the
+  // correct latest result. The UI renders one result, so retain one Blob.
+  generation.prune(1, latestResultClientId.value, handledGenerationClientIds);
+  for (const clientId of handledGenerationClientIds) {
+    if (!generation.jobs.some((candidate) => candidate.clientId === clientId)) {
+      handledGenerationClientIds.delete(clientId);
+    }
+  }
+}
+
 async function generate(): Promise<void> {
   clearSelectedQueueRender();
   fileUnderDropNotice.value = "";
@@ -5833,22 +5902,12 @@ async function generate(): Promise<void> {
     const admissionBackgroundTask = submissionAttempt.handoffBackgroundTask();
     void admission.finally(() => admissionBackgroundTask.release());
     releasePreparedSubmission();
-    if (preparedSubmission) {
-      const active = document.activeElement;
-      const restoreFocus =
-        preparedSubmissionOwnedFocus &&
-        (active === document.body || (!!active && !!preparedSection?.contains(active)));
-      preparedBatch.value = null;
-      if (restoreFocus) {
-        void nextTick(() => document.querySelector<HTMLTextAreaElement>("#mobile-prompt")?.focus());
-      }
-    }
-    if (
-      quickSubmission &&
-      quickExpansionSnapshot.value?.requestToken === quickSubmission.requestToken
-    ) {
-      quickExpansionSnapshot.value = null;
-    }
+    clearSubmittedExpansionWork(
+      preparedSubmission,
+      quickSubmission,
+      preparedSection,
+      preparedSubmissionOwnedFocus,
+    );
     if (!progressIsError.value) setGenerationStatus("Queued");
     generationAnnouncement.value = "";
     void admission.catch((error) => {
@@ -5892,66 +5951,22 @@ async function generate(): Promise<void> {
   const admissionBackgroundTask = submissionAttempt.handoffBackgroundTask();
   void (admitted ?? settled).finally(() => admissionBackgroundTask.release());
   releasePreparedSubmission();
-  if (preparedSubmission) {
-    const active = document.activeElement;
-    const restoreFocus =
-      preparedSubmissionOwnedFocus &&
-      (active === document.body || (!!active && !!preparedSection?.contains(active)));
-    preparedBatch.value = null;
-    if (restoreFocus) {
-      void nextTick(() => document.querySelector<HTMLTextAreaElement>("#mobile-prompt")?.focus());
-    }
-  }
-  if (
-    quickSubmission &&
-    quickExpansionSnapshot.value?.requestToken === quickSubmission.requestToken
-  ) {
-    quickExpansionSnapshot.value = null;
-  }
+  clearSubmittedExpansionWork(
+    preparedSubmission,
+    quickSubmission,
+    preparedSection,
+    preparedSubmissionOwnedFocus,
+  );
   setGenerationStatus("Queued");
   generationAnnouncement.value = "";
-  void settled.then(async (jobs) => {
-    if (unmounted || jobs.length === 0) return;
-    // iOS suspension kills every held SSE socket: jobs that settled with a
-    // dead-transport error are re-queried against their frozen submission
-    // route (finished prints render, queued/running jobs re-attach without
-    // cancellation) BEFORE any summary copy is composed, so raw transport
-    // text never reaches the status line or the announcement channel.
-    await reconcileInterruptedGenerationJobs(jobs, {
-      target: { ...route.target },
-      hostLabel: route.label,
-      queueCapacity: hostTelemetry[route.hostId]?.queueCapacity,
-      chain: chainRouting.kind === "chain",
-      refreshResultUrl: (clientId) =>
-        void generation.refreshRemoteResultUrl(clientId).catch(() => {
-          // The reactive job carries the directed, user-visible error.
-        }),
-      isActive: () => !unmounted,
-    });
-    if (unmounted) return;
-    const outcome = summarizeMobileGenerationOutcome(jobs, {
-      hostLabel: route.label,
-      prepared: preparedSubmission !== null,
-    });
-    requestAdvisories.value = outcome.advisories;
-    for (const candidate of jobs) handledGenerationClientIds.add(candidate.clientId);
-    for (const candidate of outcome.completed) {
-      void saveCompletedStillToPhotos(candidate.result!, route.target);
-    }
-    if (outcome.latestCompleted) latestResultClientId.value = outcome.latestCompleted.clientId;
-    if (outcome.status) setGenerationStatus(outcome.status.message, outcome.status.isError);
-    if (outcome.announcement !== null) generationAnnouncement.value = outcome.announcement;
-    if (outcome.refreshGallery && tab.value === "gallery") void refreshGallery();
-    // Only terminal jobs whose callbacks have run are eligible: multiple
-    // completion microtasks cannot prune one another before they promote the
-    // correct latest result. The UI renders one result, so retain one Blob.
-    generation.prune(1, latestResultClientId.value, handledGenerationClientIds);
-    for (const clientId of handledGenerationClientIds) {
-      if (!generation.jobs.some((candidate) => candidate.clientId === clientId)) {
-        handledGenerationClientIds.delete(clientId);
-      }
-    }
-  });
+  void settled.then((jobs) =>
+    presentSettledGeneration(
+      jobs,
+      route,
+      chainRouting.kind === "chain",
+      preparedSubmission !== null,
+    ),
+  );
 }
 
 async function cancelGeneration(job: Job): Promise<void> {

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -456,6 +456,7 @@ import { watchMobileGenerationHost, type MobileGenerationHostWatch } from "./mob
 import { beginMobileBackgroundTask } from "./backgroundTask";
 import { mobilePlacementFailure, routeAutomaticMobileGeneration } from "./mobileGenerationRouting";
 import { prepareMobileGenerationRequest } from "./mobileGenerationPreparation";
+import { MobileSubmissionAttempts } from "./mobileSubmissionAttempt";
 
 type Tab = "generate" | "gallery" | "catalog" | "hosts";
 
@@ -849,7 +850,7 @@ const appliedRemix = ref<MobileAppliedRemix | null>(null);
 const quickExpansionNegative = ref<{ before: string; baked: string } | null>(null);
 const preparedSubmitting = ref(false);
 const preparationGuard = new PreparationRequestGuard();
-const submissionGuard = new PreparationRequestGuard();
+const submissionAttempts = new MobileSubmissionAttempts();
 const sequenceSubmissionGuard = new PreparationRequestGuard();
 let expansionPullRequestId = 0;
 let expansionRecoveryId = 0;
@@ -4727,7 +4728,7 @@ async function expandForCurrentBatch(
   const expandOn = expansionRouteFor(route);
 
   clearExpansionRecovery();
-  submissionGuard.invalidate();
+  submissionAttempts.invalidate();
   const token = preparationGuard.begin();
   expansionRunning.value = true;
   expansionError.value = "";
@@ -4833,7 +4834,7 @@ async function remixCurrent(
   }
 
   clearExpansionRecovery();
-  submissionGuard.invalidate();
+  submissionAttempts.invalidate();
   const token = preparationGuard.begin();
   expansionRunning.value = true;
   expansionError.value = "";
@@ -4935,7 +4936,7 @@ function applyRemixSelection(): void {
   if (selected.length === 1) {
     rememberRemixUndo();
     preparationGuard.invalidate();
-    submissionGuard.invalidate();
+    submissionAttempts.invalidate();
     form.prompt = selected[0]!.prompt.trim();
     form.originalPrompt = review.rootPrompt ?? review.sourcePrompt;
     bakeStyleNegative(review.stylePreset ?? "", review.family);
@@ -5023,7 +5024,7 @@ function undoPromptPreparation(): void {
     restoreQuickExpansion();
     return;
   }
-  submissionGuard.invalidate();
+  submissionAttempts.invalidate();
   preparationGuard.invalidate();
   form.prompt = snapshot.prompt;
   form.originalPrompt = snapshot.originalPrompt;
@@ -5055,7 +5056,7 @@ function bakeStyleNegative(presetId: string, family: string): void {
 
 function restoreQuickExpansion(): void {
   if (quickExpansionOriginal.value === null) return;
-  submissionGuard.invalidate();
+  submissionAttempts.invalidate();
   preparationGuard.invalidate();
   // Undo re-arms the whole pre-expansion state, including the chip the
   // bake-and-clear apply removed and the negative fragments it merged in —
@@ -5082,7 +5083,7 @@ function restoreQuickExpansion(): void {
 
 async function developExpandedAnyway(): Promise<void> {
   if (!quickExpansionSnapshot.value) return;
-  submissionGuard.invalidate();
+  submissionAttempts.invalidate();
   quickExpansionSnapshot.value = null;
   expansionError.value = "";
   await generate();
@@ -5123,7 +5124,7 @@ async function copyMobileError(message: string): Promise<void> {
 function editPreparedPrompt(payload: { id: string; text: string }): void {
   if (preparedSubmitting.value || expansionRunning.value) return;
   supersedePreparedReplacement();
-  submissionGuard.invalidate();
+  submissionAttempts.invalidate();
   const prompt = preparedBatch.value?.prompts.find((candidate) => candidate.id === payload.id);
   if (prompt) prompt.text = payload.text;
 }
@@ -5133,7 +5134,7 @@ function removePreparedPrompt(id: string): void {
   if (!batch || batch.prompts.length <= 2 || preparedSubmitting.value || expansionRunning.value)
     return;
   supersedePreparedReplacement();
-  submissionGuard.invalidate();
+  submissionAttempts.invalidate();
   batch.prompts = batch.prompts.filter((prompt) => prompt.id !== id);
   batch.requestedCount = batch.prompts.length;
   form.batchSize = batch.prompts.length;
@@ -5158,7 +5159,7 @@ function collapsePreparedBatch(removedId: string): void {
   );
   const restoreFocus = !!preparedRoot?.contains(document.activeElement);
   preparationGuard.invalidate();
-  submissionGuard.invalidate();
+  submissionAttempts.invalidate();
   submissionUiId += 1;
   preparedBatch.value = null;
   expansionRunning.value = false;
@@ -5188,7 +5189,7 @@ function discardPreparedBatch(): void {
   );
   const restoreFocus = !!preparedRoot?.contains(document.activeElement);
   preparationGuard.invalidate();
-  submissionGuard.invalidate();
+  submissionAttempts.invalidate();
   submissionUiId += 1;
   preparedBatch.value = null;
   expansionRunning.value = false;
@@ -5554,7 +5555,6 @@ async function generate(): Promise<void> {
     return;
 
   const backgroundTask = await beginMobileBackgroundTask("Preparing remote generation");
-  let backgroundTaskTransferred = false;
 
   // Replaced by the fan-out winner under Auto / Most capable; frozen from here
   // on for every other path.
@@ -5605,13 +5605,13 @@ async function generate(): Promise<void> {
       : draft.batchSize;
   const guardedSubmission = !!preparedSubmission || !!quickSubmission;
   const liveFormIdentity = guardedSubmission ? JSON.stringify(cloneGenerateForm(form)) : "";
-  const token = submissionGuard.begin();
-  const submitSignal = submissionGuard.signalFor(token);
+  const submissionAttempt = submissionAttempts.begin(backgroundTask);
+  const submitSignal = submissionAttempt.signal;
   const uiId = ++submissionUiId;
   const ownsPreparedSubmission = () =>
     !unmounted &&
     uiId === submissionUiId &&
-    submissionGuard.isCurrent(token) &&
+    submissionAttempt.isCurrent() &&
     (!preparedSubmission || preparedBatch.value?.batchId === preparedSubmission.batchId);
   const releasePreparedSubmission = () => {
     if (!unmounted && uiId === submissionUiId) {
@@ -5619,7 +5619,7 @@ async function generate(): Promise<void> {
       generationSubmissionPhase.value = null;
     }
     if (ownsPreparedSubmission()) preparedSubmitting.value = false;
-    if (!backgroundTaskTransferred) void backgroundTask.release();
+    void submissionAttempt.releaseOwnedResources();
   };
   let request: GenerateRequest;
   preparingGeneration.value = true;
@@ -5629,7 +5629,7 @@ async function generate(): Promise<void> {
     request = await prepareGenerationRequest(
       target,
       draft,
-      () => submissionGuard.isCurrent(token),
+      () => submissionAttempt.isCurrent(),
       submitSignal,
     );
     if (request.source_image && originalSource) {
@@ -5665,7 +5665,7 @@ async function generate(): Promise<void> {
     return;
   }
 
-  if (!submissionGuard.isCurrent(token)) {
+  if (!submissionAttempt.isCurrent()) {
     releasePreparedSubmission();
     return;
   }
@@ -5747,7 +5747,7 @@ async function generate(): Promise<void> {
       family: draft.family,
       subject: "print",
       requireAuthoritative: requireAuthoritativePlacement,
-      isCurrent: () => submissionGuard.isCurrent(token),
+      isCurrent: () => submissionAttempt.isCurrent(),
       signal: submitSignal,
     });
     if (routed.kind === "abandoned") {
@@ -5776,7 +5776,7 @@ async function generate(): Promise<void> {
               signal: submitSignal,
             });
     } catch (error) {
-      if (!submissionGuard.isCurrent(token)) {
+      if (!submissionAttempt.isCurrent()) {
         releasePreparedSubmission();
         return;
       }
@@ -5806,7 +5806,7 @@ async function generate(): Promise<void> {
       }
     }
   }
-  if (!submissionGuard.isCurrent(token)) {
+  if (!submissionAttempt.isCurrent()) {
     releasePreparedSubmission();
     return;
   }
@@ -5863,7 +5863,7 @@ async function generate(): Promise<void> {
     target: route.target,
     requirements: licenseRequirements(placement?.pending_downloads),
   });
-  if (!accepted || !submissionGuard.isCurrent(token)) {
+  if (!accepted || !submissionAttempt.isCurrent()) {
     releasePreparedSubmission();
     return;
   }
@@ -5903,8 +5903,8 @@ async function generate(): Promise<void> {
     });
   if (durableLifecycle) {
     const admission = submitMobileDurableGeneration({ route, requests: durablePlans });
-    backgroundTaskTransferred = true;
-    void admission.finally(() => backgroundTask.release());
+    const admissionBackgroundTask = submissionAttempt.handoffBackgroundTask();
+    void admission.finally(() => admissionBackgroundTask.release());
     releasePreparedSubmission();
     if (preparedSubmission) {
       const active = document.activeElement;
@@ -5962,8 +5962,8 @@ async function generate(): Promise<void> {
   // accepted (or refused), foreground recovery and the remote queue own the
   // remaining lifecycle; generation itself never depends on the phone staying
   // awake.
-  backgroundTaskTransferred = true;
-  void (admitted ?? settled).finally(() => backgroundTask.release());
+  const admissionBackgroundTask = submissionAttempt.handoffBackgroundTask();
+  void (admitted ?? settled).finally(() => admissionBackgroundTask.release());
   releasePreparedSubmission();
   if (preparedSubmission) {
     const active = document.activeElement;
@@ -6188,7 +6188,7 @@ function durableGenerationCompletedResult(job: Job): CompleteEvent | null {
 
 function cancelGenerationSubmission(): void {
   if (!preparingGeneration.value) return;
-  submissionGuard.invalidate();
+  submissionAttempts.invalidate();
   submissionUiId += 1;
   preparingGeneration.value = false;
   preparedSubmitting.value = false;
@@ -9490,7 +9490,7 @@ onBeforeUnmount(() => {
     void cancelBarcodeScanner().catch(() => undefined);
   }
   preparationGuard.invalidate();
-  submissionGuard.invalidate();
+  submissionAttempts.invalidate();
   sequenceSubmissionGuard.invalidate();
   const sequenceCancellation = sequenceCancellationRequest;
   sequenceCancellationRequest = null;

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -210,7 +210,6 @@ import type {
   Ltx2CameraControlInfo,
   ModelEntry,
   OutputMetadata,
-  PromptTransformProvenance,
   RemixDimension,
   RemixSourceKind,
   ServerCapabilities,
@@ -456,6 +455,12 @@ import { watchMobileGenerationHost, type MobileGenerationHostWatch } from "./mob
 import { beginMobileBackgroundTask } from "./backgroundTask";
 import { mobilePlacementFailure, routeAutomaticMobileGeneration } from "./mobileGenerationRouting";
 import { prepareMobileGenerationRequest } from "./mobileGenerationPreparation";
+import {
+  capturePreparedSubmission,
+  captureQuickSubmission,
+  preparedSubmissionIsCurrent,
+  quickSubmissionIsCurrent,
+} from "./mobileGenerationSnapshot";
 import { MobileSubmissionAttempts } from "./mobileSubmissionAttempt";
 
 type Tab = "generate" | "gallery" | "catalog" | "hosts";
@@ -5203,18 +5208,6 @@ function discardPreparedBatch(): void {
   }
 }
 
-function preparedRemixDimensions(
-  batch: PreparedExpansionBatchState,
-  index: number,
-): RemixDimension[] {
-  const perVariant = (
-    batch as PreparedExpansionBatchState & {
-      remixVariantDimensions?: readonly (readonly RemixDimension[])[];
-    }
-  ).remixVariantDimensions;
-  return [...(perVariant?.[index] ?? batch.dimensions ?? [])];
-}
-
 async function pullExpansionModel(): Promise<void> {
   const recovery = expansionRecovery.value;
   if (!recovery || expansionRunning.value) return;
@@ -5454,40 +5447,13 @@ async function generate(): Promise<void> {
     return;
   }
 
-  const preparedSubmission = prepared
-    ? {
-        batchId: prepared.batchId,
-        promptIds: prepared.prompts.map((prompt) => prompt.id),
-        prompts: prepared.prompts.map((prompt) => prompt.text.trim()),
-        originalPrompt: prepared.rootPrompt ?? prepared.sourcePrompt,
-        promptTransforms:
-          prepared.kind === "remix"
-            ? prepared.prompts.map((_, index): PromptTransformProvenance => ({
-                operation: "remix",
-                ...(prepared.rootPrompt ? { root_prompt: prepared.rootPrompt } : {}),
-                source_prompt: prepared.sourcePrompt,
-                source_kind: prepared.sourceKind ?? "current",
-                task: prepared.task,
-                dimensions: preparedRemixDimensions(prepared, index),
-              }))
-            : undefined,
-        route: { ...prepared.route, target: { ...prepared.route.target } },
-      }
-    : null;
+  const preparedSubmission = capturePreparedSubmission(prepared);
   const preparedSection = preparedSubmission
     ? document.querySelector<HTMLElement>("[data-test='mobile-prepared-expansion']")
     : null;
   const preparedSubmissionOwnedFocus = !!preparedSection?.contains(document.activeElement);
   const quickSubmission = !preparedSubmission
-    ? quickExpansionSnapshot.value
-      ? {
-          requestToken: quickExpansionSnapshot.value.requestToken,
-          route: {
-            ...quickExpansionSnapshot.value.route,
-            target: { ...quickExpansionSnapshot.value.route.target },
-          },
-        }
-      : null
+    ? captureQuickSubmission(quickExpansionSnapshot.value)
     : null;
   // Prepared and quick work keeps the machine it was frozen on. An ordinary
   // submission under Auto / Most capable starts on a provisional machine — the
@@ -5689,23 +5655,23 @@ async function generate(): Promise<void> {
     return;
   }
   if (preparedSubmission) {
-    const current = preparedBatch.value;
-    const unchanged =
-      current?.batchId === preparedSubmission.batchId &&
-      current.prompts.length === preparedSubmission.prompts.length &&
-      current.prompts.every(
-        (prompt, index) =>
-          prompt.id === preparedSubmission.promptIds[index] &&
-          prompt.text.trim() === preparedSubmission.prompts[index],
-      );
-    if (!unchanged || preparedStaleReasons.value.length > 0) {
+    if (
+      !preparedSubmissionIsCurrent(
+        preparedSubmission,
+        preparedBatch.value,
+        preparedStaleReasons.value,
+      )
+    ) {
       releasePreparedSubmission();
       return;
     }
   } else if (quickSubmission) {
     if (
-      quickExpansionSnapshot.value?.requestToken !== quickSubmission.requestToken ||
-      quickStaleReasons.value.length > 0
+      !quickSubmissionIsCurrent(
+        quickSubmission,
+        quickExpansionSnapshot.value,
+        quickStaleReasons.value,
+      )
     ) {
       releasePreparedSubmission();
       return;

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -112,7 +112,6 @@ import {
 import { h3BoundariesNeedingMedia } from "@studio/lib/h3BoundaryRestore";
 import {
   classifyPlacementPreview,
-  comparePlacementPreviews,
   previewChainPlacement,
   previewGenerationPlacement,
   previewRequestForSiblingFanout,
@@ -122,7 +121,6 @@ import {
 import {
   AUTO_TARGET_ID,
   CAPABLE_TARGET_ID,
-  chooseRoutedHost,
   hostIdsForModel,
   isAutomaticTarget,
   pickAutoHost,
@@ -458,6 +456,7 @@ import {
 } from "./mobileGenerationRecovery";
 import { watchMobileGenerationHost, type MobileGenerationHostWatch } from "./mobileGenerationWatch";
 import { beginMobileBackgroundTask } from "./backgroundTask";
+import { mobilePlacementFailure, routeAutomaticMobileGeneration } from "./mobileGenerationRouting";
 
 type Tab = "generate" | "gallery" | "catalog" | "hosts";
 
@@ -561,36 +560,6 @@ interface MobileAppliedRemix {
   dimensions: RemixDimension[];
 }
 
-function sentence(text: string): string {
-  return /[.!?]$/.test(text) ? text : `${text}.`;
-}
-
-function mobilePlacementFailure(
-  preview: GenerationPlacementPreview | null,
-  hostLabel: string,
-  subject: "print" | "sequence",
-): string {
-  const classification = classifyPlacementPreview(preview);
-  if (classification === "infeasible" && preview) {
-    const missing = (preview.missing_components ?? [])
-      .filter((component) => !component.present)
-      .map((component) => component.name);
-    const reason =
-      typeof preview.reason === "string" && preview.reason.trim()
-        ? sentence(preview.reason.trim())
-        : sentence(`the server reported that this ${subject} is infeasible`);
-    return `${hostLabel} cannot run this ${subject}: ${reason}${missing.length ? ` Missing components: ${missing.join(", ")}.` : ""} Nothing was queued.`;
-  }
-  if (classification === "temporarily_unavailable") {
-    const reason =
-      typeof preview?.reason === "string" && preview.reason.trim()
-        ? ` Reason: ${sentence(preview.reason.trim())}`
-        : "";
-    return `${hostLabel} could not compute a placement plan right now.${reason} Try again. Nothing was queued.`;
-  }
-  return `${hostLabel} returned an invalid placement response. Nothing was queued.`;
-}
-
 const STORAGE_KEY = "mold.mobile.hosts.v1";
 const SELECTED_KEY = "mold.mobile.selected-host.v1";
 const LIBRARY_SEEN_AT_KEY = "mold.mobile.library-seen-at.v1";
@@ -600,10 +569,6 @@ const SEQUENCE_RECOVERY_KEY = "mold.mobile.sequence-job.v1";
 const LIVE_ACTIVITY_KEY = "mold.mobile.live-activity.v1";
 const GALLERY_CAPABILITIES_KEY = "mold.mobile.gallery-capabilities.v1";
 const HOST_PROBE_TIMEOUT_MS = 9_000;
-/** How long automatic routing keeps waiting for slower machines once one has
- *  answered `planned`. Nothing is abandoned before that first plan exists —
- *  a deadline that fires with no route would manufacture a dead end. */
-const MOBILE_PLACEMENT_SETTLE_MS = 1_500;
 const GALLERY_HOST_TIMEOUT_MS = 9_000;
 /** A broken WebView connection must not hold a thumbnail page forever. Five
  * seconds is long enough for a remote cache miss while keeping the next page
@@ -3887,29 +3852,6 @@ watch(
   },
 );
 
-/** One machine's answer to the automatic-routing fan-out. */
-interface MobilePlacementProbe {
-  host: MobileHost;
-  /** The machine's exact route as it stood when the probe was ISSUED. A slow
-   *  preview must never authorize one endpoint and then submit to another. */
-  route: HostRoute;
-  roundTripMs: number;
-  preview: GenerationPlacementPreview | null;
-  error: unknown;
-  legacyUnsupported: boolean;
-}
-
-type MobileAutomaticRoute =
-  | {
-      kind: "route";
-      host: MobileHost;
-      route: HostRoute;
-      placement: GenerationPlacementPreview | null;
-      legacyUnsupported: boolean;
-    }
-  | { kind: "error"; message: string }
-  | { kind: "abandoned" };
-
 /**
  * The machines an automatic policy may dispatch to: reachable, allowed to run
  * the model, and — when any of them already holds it — narrowed to the owners,
@@ -4005,26 +3947,6 @@ function provisionalAutomaticHost(
   return chosen?.host ?? null;
 }
 
-function mobileFleetPlacementFailure(
-  probes: readonly MobilePlacementProbe[],
-  subject: "print" | "sequence",
-): string {
-  if (probes.length === 1 && probes[0]!.preview) {
-    return mobilePlacementFailure(probes[0]!.preview, probes[0]!.host.name, subject);
-  }
-  const detail = probes
-    .map((probe) =>
-      probe.preview
-        ? mobilePlacementFailure(probe.preview, probe.host.name, subject).replace(
-            " Nothing was queued.",
-            "",
-          )
-        : `${probe.host.name} did not answer: ${describeTransportError(probe.error, probe.host.name)}`,
-    )
-    .join(" ");
-  return `No connected machine could run this ${subject}. ${detail} Nothing was queued.`;
-}
-
 /**
  * Ask every candidate machine for a placement plan and choose one.
  *
@@ -4044,144 +3966,19 @@ async function routeAutomaticGeneration(options: {
   requireAuthoritative: boolean;
   isCurrent?: () => boolean;
   signal?: AbortSignal;
-}): Promise<MobileAutomaticRoute> {
-  const isCurrent = options.isCurrent ?? (() => true);
-  // The frozen request is the authority on whether a face travels — never the
-  // live form, which may have moved while the fan-out ran.
-  const carriesIdentity = Boolean(options.request.id_image);
-  const { hosts: candidates, error } = automaticRoutingCandidates(options.model, options.family, {
-    requiresIdentity: carriesIdentity,
+}): ReturnType<typeof routeAutomaticMobileGeneration> {
+  const { model, family, isCurrent = () => true, ...routingOptions } = options;
+  const { hosts: candidates, error } = automaticRoutingCandidates(model, family, {
+    requiresIdentity: Boolean(options.request.id_image),
   });
   if (error) return { kind: "error", message: error };
-  const probes: MobilePlacementProbe[] = [];
-  const controllers = candidates.map(() => new AbortController());
-  let pending = candidates.length;
-  let resolveAllSettled!: () => void;
-  let resolveFirstPlanned!: () => void;
-  const allSettled = new Promise<void>((resolve) => (resolveAllSettled = resolve));
-  const firstPlanned = new Promise<void>((resolve) => (resolveFirstPlanned = resolve));
-  candidates.forEach((host, index) => {
-    void (async () => {
-      const controller = controllers[index]!;
-      const abortFromCaller = () => controller.abort(options.signal?.reason);
-      if (options.signal?.aborted) abortFromCaller();
-      else options.signal?.addEventListener("abort", abortFromCaller, { once: true });
-      const started = performance.now();
-      const elapsed = () => Math.max(0, performance.now() - started);
-      const probeOptions = { signal: controller.signal };
-      // Frozen before the request leaves: the winner carries this snapshot, so
-      // a URL, key, or instance that changed mid-flight is caught by the
-      // caller's connection fence instead of silently replacing the endpoint
-      // the plan was authorized for.
-      const route = routeForMobileHost(host);
-      const probeTarget = { ...route.target };
-      try {
-        const preview = options.chain
-          ? await previewChainPlacement(probeTarget, options.request, options.copies, probeOptions)
-          : await previewGenerationPlacement(
-              probeTarget,
-              options.request,
-              options.copies,
-              probeOptions,
-            );
-        probes.push({
-          host,
-          route,
-          roundTripMs: elapsed(),
-          preview,
-          error: null,
-          legacyUnsupported: false,
-        });
-        if (classifyPlacementPreview(preview) === "planned") resolveFirstPlanned();
-      } catch (probeError) {
-        probes.push({
-          host,
-          route,
-          roundTripMs: elapsed(),
-          preview: null,
-          error: probeError,
-          legacyUnsupported:
-            probeError instanceof ApiError &&
-            (probeError.status === 404 || probeError.status === 405),
-        });
-      } finally {
-        options.signal?.removeEventListener("abort", abortFromCaller);
-        pending -= 1;
-        if (pending === 0) resolveAllSettled();
-      }
-    })();
+  return routeAutomaticMobileGeneration({
+    ...routingOptions,
+    candidates: candidates.map((host) => ({ host, view: routingHostView(host) })),
+    routeForHost: routeForMobileHost,
+    policy: generateTarget.value,
+    isCurrent: () => !unmounted && isCurrent(),
   });
-  // Nothing to wait for: the settle promise is only ever resolved by a probe.
-  if (pending === 0) resolveAllSettled();
-  // A phone must not sit on a stalled machine once another one can run the
-  // print — but it must not manufacture a dead end either, so the settle
-  // window only starts once some machine has actually answered `planned`.
-  await Promise.race([
-    allSettled,
-    ...(candidates.length > 1
-      ? [
-          firstPlanned.then(
-            () => new Promise<void>((resolve) => setTimeout(resolve, MOBILE_PLACEMENT_SETTLE_MS)),
-          ),
-        ]
-      : []),
-  ]);
-  if (pending > 0) for (const controller of controllers) controller.abort();
-  if (unmounted || !isCurrent()) return { kind: "abandoned" };
-  // Route on the snapshot that met the settle window; a late cancellation row
-  // must not join the decision.
-  const settledProbes = probes.slice();
-  const planned = settledProbes.flatMap((probe) =>
-    probe.preview && classifyPlacementPreview(probe.preview) === "planned"
-      ? [{ host: routingHostView(probe.host), roundTripMs: probe.roundTripMs, probe }]
-      : [],
-  );
-  const chosen = chooseRoutedHost(
-    planned.map((entry) => ({
-      host: entry.host,
-      roundTripMs: entry.roundTripMs,
-      preview: entry.probe.preview!,
-    })),
-    generateTarget.value,
-    comparePlacementPreviews,
-    { lowestIdWins: true },
-  );
-  if (chosen) {
-    const winner = planned.find((entry) => entry.host.id === chosen.id)!;
-    return {
-      kind: "route",
-      host: winner.probe.host,
-      route: winner.probe.route,
-      placement: winner.probe.preview,
-      legacyUnsupported: false,
-    };
-  }
-  // Servers that predate the authoritative preview still route, unless the
-  // request itself requires that authority (reference media).
-  const legacy = settledProbes.filter(
-    (probe) => probe.legacyUnsupported || classifyPlacementPreview(probe.preview) === "unsupported",
-  );
-  // An older server answers the placement preview with 404/405 and would
-  // ignore the additive identity fields outright, so an identity request never
-  // takes this fallback — it is refused by the failure message below.
-  if (!options.requireAuthoritative && !carriesIdentity && legacy.length > 0) {
-    const views = legacy.map((probe) => routingHostView(probe.host));
-    const fallback =
-      generateTarget.value === CAPABLE_TARGET_ID
-        ? pickMostCapableHost(views, null, { lowestIdWins: true })
-        : pickAutoHost(views, { lowestIdWins: true });
-    if (fallback) {
-      const probe = legacy.find((entry) => entry.host.id === fallback.id)!;
-      return {
-        kind: "route",
-        host: probe.host,
-        route: probe.route,
-        placement: null,
-        legacyUnsupported: true,
-      };
-    }
-  }
-  return { kind: "error", message: mobileFleetPlacementFailure(settledProbes, options.subject) };
 }
 
 async function submitMobileSequence(): Promise<void> {

--- a/desktop/src/mobile/mobileGenerationOutcome.test.ts
+++ b/desktop/src/mobile/mobileGenerationOutcome.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import type { CompleteEvent, GenerateRequest } from "../lib/api/types";
+import { newJob, type Job } from "../lib/generationJob";
+import {
+  mobileCompletionSummary,
+  summarizeMobileGenerationOutcome,
+} from "./mobileGenerationOutcome";
+
+function job(overrides: Partial<Job> = {}): Job {
+  const request: GenerateRequest = {
+    prompt: "portrait",
+    model: "flux:test",
+    width: 1024,
+    height: 1024,
+    steps: 4,
+  };
+  return Object.assign(newJob(request), overrides);
+}
+
+function result(overrides: Partial<CompleteEvent> = {}): CompleteEvent {
+  return {
+    image: "",
+    seed_used: 42,
+    generation_time_ms: 1500,
+    width: 1024,
+    height: 1024,
+    model: "flux:test",
+    format: "png",
+    ...overrides,
+  };
+}
+
+describe("mobile generation terminal outcome", () => {
+  it("summarizes a successful single print", () => {
+    const complete = job({ status: "complete", result: result(), requestWarnings: ["notice"] });
+    const outcome = summarizeMobileGenerationOutcome([complete], {
+      hostLabel: "Studio",
+      prepared: false,
+    });
+
+    expect(outcome.status).toEqual({ message: "1.5s · seed 42", isError: false });
+    expect(outcome.announcement).toBe("Generation completed.");
+    expect(outcome.advisories).toEqual(["notice"]);
+    expect(outcome.latestCompleted).toBe(complete);
+  });
+
+  it("reports a missing latest preview as a completed generation error", () => {
+    const outcome = summarizeMobileGenerationOutcome(
+      [job({ status: "complete", result: result(), resultError: "ticket expired" })],
+      { hostLabel: "Studio", prepared: false },
+    );
+
+    expect(outcome.status).toEqual({ message: "ticket expired", isError: true });
+    expect(outcome.announcement).toContain("latest preview is unavailable");
+  });
+
+  it("names failed prepared variations alongside completed siblings", () => {
+    const outcome = summarizeMobileGenerationOutcome(
+      [
+        job({ status: "complete", result: result() }),
+        job({ status: "error", prompt: "alternate", error: "host refused" }),
+      ],
+      { hostLabel: "Studio", prepared: true },
+    );
+
+    expect(outcome.status?.isError).toBe(true);
+    expect(outcome.announcement).toContain("Variation 2, “alternate”, failed: host refused");
+  });
+
+  it("summarizes a fully failed ordinary submission", () => {
+    const outcome = summarizeMobileGenerationOutcome(
+      [job({ status: "error", error: "host refused" })],
+      { hostLabel: "Studio", prepared: false },
+    );
+
+    expect(outcome.status).toEqual({ message: "host refused", isError: true });
+    expect(outcome.announcement).toBe("Generation failed. host refused");
+  });
+
+  it("keeps cancellation copy singular and timing formatting stable", () => {
+    const outcome = summarizeMobileGenerationOutcome(
+      [job({ status: "error", error: "cancelled" })],
+      { hostLabel: "Studio", prepared: false },
+    );
+
+    expect(outcome.status).toEqual({ message: "Cancelled", isError: false });
+    expect(outcome.announcement).toBe("1 generation cancelled.");
+    expect(mobileCompletionSummary(result({ generation_time_ms: 0 }))).toBe("seed 42");
+  });
+});

--- a/desktop/src/mobile/mobileGenerationOutcome.ts
+++ b/desktop/src/mobile/mobileGenerationOutcome.ts
@@ -1,0 +1,125 @@
+import { describeTransportError } from "../lib/api/errors";
+import type { CompleteEvent } from "../lib/api/types";
+import { isCancelledError, type Job } from "../lib/generationJob";
+
+export interface MobileGenerationOutcome {
+  advisories: string[];
+  completed: Job[];
+  latestCompleted: Job | null;
+  status: { message: string; isError: boolean } | null;
+  announcement: string | null;
+  refreshGallery: boolean;
+}
+
+export function mobileCompletionSummary(result: CompleteEvent): string {
+  const timing =
+    result.generation_time_ms > 0 ? `${(result.generation_time_ms / 1000).toFixed(1)}s · ` : "";
+  return `${timing}seed ${result.seed_used}`;
+}
+
+export function summarizeMobileGenerationOutcome(
+  jobs: readonly Job[],
+  options: { hostLabel: string; prepared: boolean },
+): MobileGenerationOutcome {
+  const completed = jobs.filter(
+    (candidate): candidate is Job & { result: CompleteEvent } =>
+      candidate.status === "complete" && candidate.result !== null,
+  );
+  const latestCompleted = completed.at(-1) ?? null;
+  const unconfirmedCancellation = jobs.find((candidate) =>
+    candidate.error?.includes("remote cancellation was not confirmed"),
+  );
+  const failed = jobs.find((candidate) => candidate.error && !isCancelledError(candidate.error));
+  const failedError = failed?.error
+    ? describeTransportError(failed.error, options.hostLabel)
+    : null;
+  const failedVariations = options.prepared
+    ? jobs.flatMap((candidate, index) => {
+        if (!candidate.error || isCancelledError(candidate.error)) return [];
+        const prompt =
+          candidate.prompt.length > 120 ? `${candidate.prompt.slice(0, 117)}…` : candidate.prompt;
+        return [
+          `Variation ${index + 1}, “${prompt}”, failed: ${describeTransportError(
+            candidate.error,
+            options.hostLabel,
+          )}`,
+        ];
+      })
+    : [];
+  const preparedFailureSummary = failedVariations.join(" ");
+  const failedCount = jobs.filter(
+    (candidate) => candidate.error && !isCancelledError(candidate.error),
+  ).length;
+  const cancelled = jobs.some((candidate) => isCancelledError(candidate.error));
+  let status: MobileGenerationOutcome["status"] = null;
+  let announcement: string | null = null;
+
+  if (latestCompleted?.result) {
+    if (latestCompleted.resultError) {
+      const previewDetail = describeTransportError(latestCompleted.resultError, options.hostLabel);
+      status = { message: previewDetail, isError: true };
+      announcement = `${completed.length} of ${jobs.length} generations completed, but the latest preview is unavailable. ${previewDetail}`;
+    } else {
+      status = {
+        message: `${completed.length > 1 ? `${completed.length} prints · ` : ""}${mobileCompletionSummary(latestCompleted.result)}`,
+        isError: false,
+      };
+      announcement =
+        completed.length === 1 && jobs.length === 1
+          ? "Generation completed."
+          : `${completed.length} of ${jobs.length} generations completed.`;
+    }
+    if (unconfirmedCancellation?.error || failedError) {
+      status = {
+        message: [
+          `${completed.length} of ${jobs.length} completed`,
+          failedError,
+          unconfirmedCancellation?.error,
+        ]
+          .filter(Boolean)
+          .join(" · "),
+        isError: true,
+      };
+      announcement = [
+        `${completed.length} generations completed.`,
+        failedError
+          ? options.prepared
+            ? `${failedCount} failed. ${preparedFailureSummary}`
+            : `${failedCount} failed. ${failedError}`
+          : "",
+        unconfirmedCancellation?.error
+          ? `Cancellation failed. ${unconfirmedCancellation.error}`
+          : "",
+      ]
+        .filter(Boolean)
+        .join(" ");
+    }
+  } else if (unconfirmedCancellation?.error || failedError) {
+    status = {
+      message: [failedError, unconfirmedCancellation?.error].filter(Boolean).join(" · "),
+      isError: true,
+    };
+    announcement = [
+      failedError
+        ? options.prepared
+          ? `Generation failed. ${preparedFailureSummary}`
+          : `Generation failed. ${failedError}`
+        : "",
+      unconfirmedCancellation?.error ? `Cancellation failed. ${unconfirmedCancellation.error}` : "",
+    ]
+      .filter(Boolean)
+      .join(" ");
+  } else if (cancelled) {
+    status = { message: "Cancelled", isError: false };
+    announcement = `${jobs.length} generation${jobs.length === 1 ? "" : "s"} cancelled.`;
+  }
+
+  return {
+    advisories: [...new Set(jobs.flatMap((candidate) => candidate.requestWarnings))],
+    completed,
+    latestCompleted,
+    status,
+    announcement,
+    refreshGallery: latestCompleted !== null,
+  };
+}

--- a/desktop/src/mobile/mobileGenerationPreparation.test.ts
+++ b/desktop/src/mobile/mobileGenerationPreparation.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SourceFitPreprocessCache } from "@ui/lib/sourceFitPreprocessCache";
+import type { ModelEntry } from "../lib/api/types";
+import { newGenerateForm } from "../lib/generateForm";
+
+const { applyH3BoundaryFit, applySourceFitPreprocess } = vi.hoisted(() => ({
+  applyH3BoundaryFit: vi.fn(),
+  applySourceFitPreprocess: vi.fn(),
+}));
+
+vi.mock("../lib/sourceFitPreprocess", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../lib/sourceFitPreprocess")>()),
+  applyH3BoundaryFit,
+  applySourceFitPreprocess,
+}));
+
+import { prepareMobileGenerationRequest } from "./mobileGenerationPreparation";
+
+function model(overrides: Partial<ModelEntry> = {}): ModelEntry {
+  return {
+    name: "sdxl:test",
+    family: "sdxl",
+    size_gb: 1,
+    is_loaded: false,
+    hf_repo: "test/model",
+    default_steps: 4,
+    default_guidance: 3.5,
+    default_width: 1024,
+    default_height: 1024,
+    description: "Test model",
+    downloaded: true,
+    ...overrides,
+  };
+}
+
+function services() {
+  return {
+    cache: new SourceFitPreprocessCache(),
+    ops: {
+      imageSize: vi.fn(),
+      fitImage: vi.fn(),
+      buildMask: vi.fn(),
+    },
+    upscale: vi.fn(),
+    onStatus: vi.fn(),
+  };
+}
+
+describe("mobile generation request preparation", () => {
+  beforeEach(() => {
+    applyH3BoundaryFit.mockReset();
+    applySourceFitPreprocess.mockReset();
+  });
+
+  it("fits an ordinary source and mask on the frozen draft", async () => {
+    const selected = model();
+    const draft = newGenerateForm();
+    Object.assign(draft, {
+      model: selected.name,
+      family: selected.family,
+      sourceImage: "original-source",
+      sourceImageName: "source.png",
+      maskImage: "original-mask",
+      width: 768,
+      height: 512,
+    });
+    applySourceFitPreprocess.mockResolvedValue({
+      source: "fitted-source",
+      mask: "fitted-mask",
+      changed: true,
+    });
+
+    const request = await prepareMobileGenerationRequest(
+      {
+        target: { baseUrl: "http://studio.test:7680", apiKey: "secret" },
+        draft,
+        selectedModel: selected,
+      },
+      services(),
+    );
+
+    expect(applySourceFitPreprocess).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "original-source",
+        mask: "original-mask",
+        target: { width: 768, height: 512 },
+      }),
+      expect.anything(),
+    );
+    expect(request.source_image).toBe("fitted-source");
+    expect(request.mask_image).toBe("fitted-mask");
+  });
+
+  it("fits Qwen edit input as maskless attachment media", async () => {
+    const selected = model({ name: "qwen-image-edit:test", family: "qwen-image-edit" });
+    const draft = newGenerateForm();
+    Object.assign(draft, {
+      model: selected.name,
+      family: selected.family,
+      imageAttachments: ["original-edit"],
+      width: 1024,
+      height: 768,
+    });
+    applySourceFitPreprocess.mockResolvedValue({
+      source: "fitted-edit",
+      mask: null,
+      changed: true,
+    });
+
+    const request = await prepareMobileGenerationRequest(
+      {
+        target: { baseUrl: "http://studio.test:7680", apiKey: "secret" },
+        draft,
+        selectedModel: selected,
+      },
+      services(),
+    );
+
+    expect(applySourceFitPreprocess).toHaveBeenCalledWith(
+      expect.objectContaining({ source: "original-edit", mask: null }),
+      expect.anything(),
+    );
+    expect(request.edit_images).toEqual(["fitted-edit"]);
+  });
+
+  it("routes H3 frame boundaries through the dedicated fitter", async () => {
+    const selected = model({
+      name: "minimax-h3-fl2va:official-bf16",
+      family: "minimax-h3",
+    });
+    const draft = newGenerateForm();
+    Object.assign(draft, {
+      model: selected.name,
+      family: selected.family,
+      width: 832,
+      height: 480,
+    });
+    draft.h3Authoring!.firstFrame = {
+      data: "first-frame",
+      filename: "first.png",
+      mimeType: "image/png",
+      width: 640,
+      height: 360,
+    };
+    applyH3BoundaryFit.mockResolvedValue(draft.h3Authoring);
+
+    await prepareMobileGenerationRequest(
+      {
+        target: { baseUrl: "http://studio.test:7680", apiKey: "secret" },
+        draft,
+        selectedModel: selected,
+      },
+      services(),
+    );
+
+    expect(applyH3BoundaryFit).toHaveBeenCalledWith(
+      expect.objectContaining({ firstFrame: expect.objectContaining({ data: "first-frame" }) }),
+      draft.sourceFit,
+      { width: 832, height: 480 },
+      expect.anything(),
+    );
+    expect(applySourceFitPreprocess).not.toHaveBeenCalled();
+  });
+
+  it("suppresses late preprocessing status after the caller becomes stale", async () => {
+    const selected = model();
+    const draft = newGenerateForm();
+    Object.assign(draft, {
+      model: selected.name,
+      family: selected.family,
+      sourceImage: "source",
+    });
+    applySourceFitPreprocess.mockImplementation(async (_input, dependencies) => {
+      dependencies.onStatus?.("late status");
+      return { source: "source", mask: null, changed: false };
+    });
+    const dependencies = services();
+
+    await prepareMobileGenerationRequest(
+      {
+        target: { baseUrl: "http://studio.test:7680", apiKey: "secret" },
+        draft,
+        selectedModel: selected,
+        isCurrent: () => false,
+      },
+      dependencies,
+    );
+
+    expect(dependencies.onStatus).not.toHaveBeenCalled();
+  });
+});

--- a/desktop/src/mobile/mobileGenerationPreparation.ts
+++ b/desktop/src/mobile/mobileGenerationPreparation.ts
@@ -1,0 +1,126 @@
+import type { SourceFitPreprocessCache } from "@ui/lib/sourceFitPreprocessCache";
+import {
+  effectiveGenerationRecipe,
+  fixedRecipeControlOverrides,
+} from "@studio/lib/generationProfile";
+import { resolveSourceConditioningTarget } from "@studio/lib/sourceResolution";
+import { coerceSourceFitForMaskless } from "@studio/lib/sourceFit";
+import { emptyMinimaxH3AuthoringState } from "@studio/lib/minimaxH3Authoring";
+import type { ApiTarget } from "../lib/api/client";
+import type { GenerateRequest, ModelEntry } from "../lib/api/types";
+import { generationCapabilitiesForFamily } from "../lib/capabilities";
+import { buildRequest, type GenerateForm } from "../lib/generateForm";
+import { mobileMediaBudgetValidationError } from "../lib/generateValidation";
+import {
+  applyH3BoundaryFit,
+  applySourceFitPreprocess,
+  type SourceFitCanvasOps,
+} from "../lib/sourceFitPreprocess";
+
+export interface PrepareMobileGenerationInput {
+  target: ApiTarget;
+  /** Private frozen clone; preparation may rewrite its media in place. */
+  draft: GenerateForm;
+  selectedModel: ModelEntry | null;
+  isCurrent?: () => boolean;
+  signal?: AbortSignal;
+}
+
+export interface MobileGenerationPreparationServices {
+  cache: SourceFitPreprocessCache;
+  ops: SourceFitCanvasOps;
+  upscale(
+    image: string,
+    model: string,
+    target: ApiTarget,
+    signal: AbortSignal | undefined,
+    onProgress: (message: string) => void,
+  ): Promise<string>;
+  onStatus(message: string): void;
+}
+
+/**
+ * Convert one frozen mobile form into its final wire request.
+ *
+ * This function deliberately has no Vue or DOM access. The caller owns live
+ * state and supplies canvas/network ports; every decision here is made from
+ * the frozen draft and selected-model snapshot captured at the tap boundary.
+ */
+export async function prepareMobileGenerationRequest(
+  input: PrepareMobileGenerationInput,
+  services: MobileGenerationPreparationServices,
+): Promise<GenerateRequest> {
+  const isCurrent = input.isCurrent ?? (() => true);
+  const { draft } = input;
+  const report = (message: string) => {
+    if (isCurrent()) services.onStatus(message);
+  };
+  const upscale = (image: string, model: string) =>
+    services.upscale(image, model, input.target, input.signal, report);
+
+  Object.assign(
+    draft,
+    fixedRecipeControlOverrides(effectiveGenerationRecipe(input.selectedModel, draft.pipeline)),
+  );
+  const capabilities = generationCapabilitiesForFamily(
+    draft.family,
+    draft.model,
+    draft.pipeline,
+    draft.guidanceCapabilities,
+    draft.sourceImageCapability,
+  );
+  const preprocessing = {
+    ops: services.ops,
+    cache: services.cache,
+    upscale,
+    onStatus: report,
+  };
+
+  if (capabilities.sourceImageMode === "h3-boundaries") {
+    draft.h3Authoring =
+      (await applyH3BoundaryFit(
+        draft.h3Authoring,
+        draft.sourceFit,
+        { width: draft.width, height: draft.height },
+        preprocessing,
+      )) ?? emptyMinimaxH3AuthoringState();
+  } else if (capabilities.sourceImageMode === "qwen-edit" && draft.imageAttachments[0]) {
+    const target = resolveSourceConditioningTarget(
+      { width: draft.width, height: draft.height },
+      input.selectedModel ?? draft.family,
+      draft.pipeline,
+    );
+    const result = await applySourceFitPreprocess(
+      {
+        source: draft.imageAttachments[0],
+        mask: null,
+        policy: coerceSourceFitForMaskless(draft.sourceFit),
+        target,
+      },
+      preprocessing,
+    );
+    if (result.source) draft.imageAttachments[0] = result.source;
+  } else if (
+    capabilities.supportsImg2img &&
+    capabilities.sourceImageMode === "single" &&
+    draft.sourceImage
+  ) {
+    const result = await applySourceFitPreprocess(
+      {
+        source: draft.sourceImage,
+        mask: capabilities.supportsMask ? draft.maskImage : null,
+        policy: capabilities.supportsMask
+          ? draft.sourceFit
+          : coerceSourceFitForMaskless(draft.sourceFit),
+        target: { width: draft.width, height: draft.height },
+      },
+      preprocessing,
+    );
+    draft.sourceImage = result.source;
+    draft.maskImage = result.mask;
+  }
+
+  const mediaBudgetError = mobileMediaBudgetValidationError(draft);
+  if (mediaBudgetError) throw new Error(mediaBudgetError);
+  return buildRequest(draft);
+}

--- a/desktop/src/mobile/mobileGenerationRouting.test.ts
+++ b/desktop/src/mobile/mobileGenerationRouting.test.ts
@@ -15,7 +15,10 @@ vi.mock("@studio/api/generationPlacement", async (importOriginal) => ({
   previewGenerationPlacement,
 }));
 
-import { routeAutomaticMobileGeneration } from "./mobileGenerationRouting";
+import {
+  previewPinnedMobileGeneration,
+  routeAutomaticMobileGeneration,
+} from "./mobileGenerationRouting";
 
 function host(id: string): MobileHost {
   return {
@@ -213,5 +216,64 @@ describe("mobile automatic generation routing", () => {
 
     await expect(routing).resolves.toMatchObject({ kind: "route", host: { id: "render" } });
     expect(stalled.signal?.aborted).toBe(true);
+  });
+});
+
+describe("mobile pinned generation placement", () => {
+  beforeEach(() => {
+    previewChainPlacement.mockReset();
+    previewGenerationPlacement.mockReset();
+  });
+
+  function pinnedOptions(machine = host("studio")) {
+    return {
+      route: routeForHost(machine),
+      request: { model: "test-model" },
+      chain: false,
+      copies: 1,
+      subject: "print" as const,
+      requireAuthoritative: false,
+    };
+  }
+
+  it("accepts a planned placement on the frozen route", async () => {
+    previewGenerationPlacement.mockResolvedValue(planned(100));
+
+    await expect(previewPinnedMobileGeneration(pinnedOptions())).resolves.toMatchObject({
+      kind: "placement",
+      legacyUnsupported: false,
+      placement: { outcome: "planned" },
+    });
+  });
+
+  it("permits the legacy fallback only when authoritative placement is unnecessary", async () => {
+    previewGenerationPlacement.mockRejectedValue(new ApiError("missing", 404));
+
+    await expect(previewPinnedMobileGeneration(pinnedOptions())).resolves.toEqual({
+      kind: "placement",
+      placement: null,
+      legacyUnsupported: true,
+    });
+  });
+
+  it("refuses a legacy identity placement", async () => {
+    previewGenerationPlacement.mockRejectedValue(new ApiError("missing", 404));
+
+    const result = await previewPinnedMobileGeneration({
+      ...pinnedOptions(),
+      request: { model: "test-model", id_image: "face" },
+      requireAuthoritative: true,
+    });
+
+    expect(result).toMatchObject({ kind: "error" });
+    if (result.kind === "error") expect(result.message).toContain("identity");
+  });
+
+  it("abandons a late answer after cancellation", async () => {
+    previewGenerationPlacement.mockResolvedValue(planned(100));
+
+    await expect(
+      previewPinnedMobileGeneration({ ...pinnedOptions(), isCurrent: () => false }),
+    ).resolves.toEqual({ kind: "abandoned" });
   });
 });

--- a/desktop/src/mobile/mobileGenerationRouting.test.ts
+++ b/desktop/src/mobile/mobileGenerationRouting.test.ts
@@ -1,0 +1,217 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { GenerationPlacementPreview } from "@studio/api/generationPlacement";
+import { ApiError } from "../lib/api/client";
+import type { HostRoute } from "../stores/hosts";
+import type { MobileHost } from "./hosts";
+
+const { previewChainPlacement, previewGenerationPlacement } = vi.hoisted(() => ({
+  previewChainPlacement: vi.fn(),
+  previewGenerationPlacement: vi.fn(),
+}));
+
+vi.mock("@studio/api/generationPlacement", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@studio/api/generationPlacement")>()),
+  previewChainPlacement,
+  previewGenerationPlacement,
+}));
+
+import { routeAutomaticMobileGeneration } from "./mobileGenerationRouting";
+
+function host(id: string): MobileHost {
+  return {
+    id,
+    name: id === "studio" ? "Studio" : "Render",
+    baseUrl: `http://${id}.test:7680`,
+    apiKey: `${id}-secret`,
+    hostname: id,
+    version: "0.18.0",
+    instanceId: `${id}-instance`,
+    online: true,
+  };
+}
+
+function routeForHost(candidate: MobileHost): HostRoute {
+  return {
+    hostId: candidate.id,
+    label: candidate.name,
+    kind: "remote",
+    target: { baseUrl: candidate.baseUrl, apiKey: candidate.apiKey },
+    instanceId: candidate.instanceId ?? null,
+  };
+}
+
+function planned(completion: number): GenerationPlacementPreview {
+  return {
+    version: 1,
+    authoritative: true,
+    state_version: 1,
+    plan_version: 1,
+    outcome: "planned",
+    candidate: {
+      device_id: "cuda:0",
+      execution_fingerprint: "test",
+      predicted_start_after_ms: 0,
+      predicted_completion_after_ms: completion,
+      setup_ms: 0,
+      setup_kind: "warm",
+      estimate_confidence: "high",
+    },
+  };
+}
+
+function candidate(
+  machine: MobileHost,
+  options: {
+    backend?: string;
+    queueDepth?: number;
+    vramTotalMb?: number;
+  } = {},
+) {
+  return {
+    host: machine,
+    view: {
+      id: machine.id,
+      status: "ready" as const,
+      queueDepth: options.queueDepth ?? 0,
+      gpu: {
+        backend: options.backend ?? "metal",
+        name: options.backend === "cuda" ? "RTX 4090" : "Apple M3",
+        vramTotalMb: options.vramTotalMb ?? 24_000,
+      },
+    },
+  };
+}
+
+function options(candidates: ReturnType<typeof candidate>[]) {
+  return {
+    candidates,
+    routeForHost,
+    policy: "auto",
+    request: { model: "test-model" },
+    chain: false,
+    copies: 1,
+    subject: "print" as const,
+    requireAuthoritative: false,
+    settleMs: 0,
+  };
+}
+
+describe("mobile automatic generation routing", () => {
+  beforeEach(() => {
+    previewChainPlacement.mockReset();
+    previewGenerationPlacement.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("chooses Auto's soonest predicted completion and freezes that route", async () => {
+    const studio = host("studio");
+    const render = host("render");
+    previewGenerationPlacement.mockImplementation((target: { baseUrl: string }) =>
+      Promise.resolve(planned(target.baseUrl === render.baseUrl ? 100 : 9_000)),
+    );
+
+    const result = await routeAutomaticMobileGeneration(
+      options([candidate(studio), candidate(render)]),
+    );
+
+    expect(result).toMatchObject({
+      kind: "route",
+      host: { id: "render" },
+      route: {
+        hostId: "render",
+        target: { baseUrl: render.baseUrl, apiKey: render.apiKey },
+        instanceId: "render-instance",
+      },
+      legacyUnsupported: false,
+    });
+  });
+
+  it("uses each candidate's captured GPU when Most capable chooses", async () => {
+    const studio = host("studio");
+    const render = host("render");
+    previewGenerationPlacement.mockImplementation((target: { baseUrl: string }) =>
+      Promise.resolve(planned(target.baseUrl === render.baseUrl ? 9_000 : 100)),
+    );
+
+    const result = await routeAutomaticMobileGeneration({
+      ...options([
+        candidate(studio, { backend: "metal", vramTotalMb: 128_000 }),
+        candidate(render, { backend: "cuda", vramTotalMb: 24_000 }),
+      ]),
+      policy: "capable",
+    });
+
+    expect(result).toMatchObject({ kind: "route", host: { id: "render" } });
+  });
+
+  it("falls back to a legacy server only for media-free non-authoritative work", async () => {
+    const studio = host("studio");
+    previewGenerationPlacement.mockRejectedValue(new ApiError("not found", 404));
+
+    const result = await routeAutomaticMobileGeneration(options([candidate(studio)]));
+
+    expect(result).toMatchObject({
+      kind: "route",
+      host: { id: "studio" },
+      placement: null,
+      legacyUnsupported: true,
+    });
+  });
+
+  it("refuses the legacy fallback for identity requests", async () => {
+    const studio = host("studio");
+    previewGenerationPlacement.mockRejectedValue(new ApiError("not found", 404));
+
+    const result = await routeAutomaticMobileGeneration({
+      ...options([candidate(studio)]),
+      request: { model: "test-model", id_image: "face-bytes" },
+    });
+
+    expect(result.kind).toBe("error");
+  });
+
+  it("returns abandoned instead of authorizing a stale caller", async () => {
+    const studio = host("studio");
+    previewGenerationPlacement.mockResolvedValue(planned(100));
+
+    const result = await routeAutomaticMobileGeneration({
+      ...options([candidate(studio)]),
+      isCurrent: () => false,
+    });
+
+    expect(result).toEqual({ kind: "abandoned" });
+  });
+
+  it("stops waiting on a stalled candidate after another machine plans", async () => {
+    vi.useFakeTimers();
+    const studio = host("studio");
+    const render = host("render");
+    const stalled: { signal: AbortSignal | null } = { signal: null };
+    previewGenerationPlacement.mockImplementation(
+      (
+        target: { baseUrl: string },
+        _request: unknown,
+        _copies: number,
+        config: { signal: AbortSignal },
+      ) => {
+        if (target.baseUrl === studio.baseUrl) {
+          stalled.signal = config.signal;
+          return new Promise(() => {});
+        }
+        return Promise.resolve(planned(100));
+      },
+    );
+
+    const routing = routeAutomaticMobileGeneration({
+      ...options([candidate(studio), candidate(render)]),
+      settleMs: 25,
+    });
+    await vi.advanceTimersByTimeAsync(25);
+
+    await expect(routing).resolves.toMatchObject({ kind: "route", host: { id: "render" } });
+    expect(stalled.signal?.aborted).toBe(true);
+  });
+});

--- a/desktop/src/mobile/mobileGenerationRouting.ts
+++ b/desktop/src/mobile/mobileGenerationRouting.ts
@@ -1,0 +1,250 @@
+import { ApiError } from "../lib/api/client";
+import { describeTransportError } from "../lib/api/errors";
+import type { HostRoute } from "../stores/hosts";
+import {
+  classifyPlacementPreview,
+  comparePlacementPreviews,
+  previewChainPlacement,
+  previewGenerationPlacement,
+  type GenerationPlacementPreview,
+} from "@studio/api/generationPlacement";
+import {
+  CAPABLE_TARGET_ID,
+  chooseRoutedHost,
+  pickAutoHost,
+  pickMostCapableHost,
+  type CapableHostBase,
+} from "@studio/lib/hostRouting";
+import type { MobileHost } from "./hosts";
+
+/** One immutable routing candidate assembled by the mobile surface. */
+export interface MobileGenerationRoutingCandidate {
+  host: MobileHost;
+  view: CapableHostBase;
+}
+
+/** One machine's answer to the automatic-routing fan-out. */
+interface MobilePlacementProbe {
+  host: MobileHost;
+  /** Exact route captured immediately before this machine is probed. */
+  route: HostRoute;
+  view: CapableHostBase;
+  roundTripMs: number;
+  preview: GenerationPlacementPreview | null;
+  error: unknown;
+  legacyUnsupported: boolean;
+}
+
+export type MobileAutomaticRoute =
+  | {
+      kind: "route";
+      host: MobileHost;
+      route: HostRoute;
+      placement: GenerationPlacementPreview | null;
+      legacyUnsupported: boolean;
+    }
+  | { kind: "error"; message: string }
+  | { kind: "abandoned" };
+
+/** Default grace after the first machine produces a usable plan. */
+export const MOBILE_PLACEMENT_SETTLE_MS = 1_500;
+
+function sentence(text: string): string {
+  return /[.!?]$/.test(text) ? text : `${text}.`;
+}
+
+export function mobilePlacementFailure(
+  preview: GenerationPlacementPreview | null,
+  hostLabel: string,
+  subject: "print" | "sequence",
+): string {
+  const classification = classifyPlacementPreview(preview);
+  if (classification === "infeasible" && preview) {
+    const missing = (preview.missing_components ?? [])
+      .filter((component) => !component.present)
+      .map((component) => component.name);
+    const reason =
+      typeof preview.reason === "string" && preview.reason.trim()
+        ? sentence(preview.reason.trim())
+        : sentence(`the server reported that this ${subject} is infeasible`);
+    return `${hostLabel} cannot run this ${subject}: ${reason}${missing.length ? ` Missing components: ${missing.join(", ")}.` : ""} Nothing was queued.`;
+  }
+  if (classification === "temporarily_unavailable") {
+    const reason =
+      typeof preview?.reason === "string" && preview.reason.trim()
+        ? ` Reason: ${sentence(preview.reason.trim())}`
+        : "";
+    return `${hostLabel} could not compute a placement plan right now.${reason} Try again. Nothing was queued.`;
+  }
+  return `${hostLabel} returned an invalid placement response. Nothing was queued.`;
+}
+
+function mobileFleetPlacementFailure(
+  probes: readonly MobilePlacementProbe[],
+  subject: "print" | "sequence",
+): string {
+  if (probes.length === 1 && probes[0]!.preview) {
+    return mobilePlacementFailure(probes[0]!.preview, probes[0]!.host.name, subject);
+  }
+  const detail = probes
+    .map((probe) =>
+      probe.preview
+        ? mobilePlacementFailure(probe.preview, probe.host.name, subject).replace(
+            " Nothing was queued.",
+            "",
+          )
+        : `${probe.host.name} did not answer: ${describeTransportError(probe.error, probe.host.name)}`,
+    )
+    .join(" ");
+  return `No connected machine could run this ${subject}. ${detail} Nothing was queued.`;
+}
+
+export interface RouteAutomaticMobileGenerationOptions {
+  candidates: readonly MobileGenerationRoutingCandidate[];
+  routeForHost: (host: MobileHost) => HostRoute;
+  policy: string;
+  request: Record<string, unknown>;
+  chain: boolean;
+  copies: number;
+  subject: "print" | "sequence";
+  requireAuthoritative: boolean;
+  isCurrent?: () => boolean;
+  signal?: AbortSignal;
+  settleMs?: number;
+}
+
+/**
+ * Ask every eligible machine for a placement plan and freeze one exact route.
+ * Candidate eligibility remains a surface concern; this module owns only the
+ * asynchronous fan-out, legacy policy, and deterministic winner selection.
+ */
+export async function routeAutomaticMobileGeneration(
+  options: RouteAutomaticMobileGenerationOptions,
+): Promise<MobileAutomaticRoute> {
+  const isCurrent = options.isCurrent ?? (() => true);
+  const carriesIdentity = Boolean(options.request.id_image);
+  const probes: MobilePlacementProbe[] = [];
+  const controllers = options.candidates.map(() => new AbortController());
+  let pending = options.candidates.length;
+  let resolveAllSettled!: () => void;
+  let resolveFirstPlanned!: () => void;
+  const allSettled = new Promise<void>((resolve) => (resolveAllSettled = resolve));
+  const firstPlanned = new Promise<void>((resolve) => (resolveFirstPlanned = resolve));
+
+  options.candidates.forEach((candidate, index) => {
+    void (async () => {
+      const controller = controllers[index]!;
+      const abortFromCaller = () => controller.abort(options.signal?.reason);
+      if (options.signal?.aborted) abortFromCaller();
+      else options.signal?.addEventListener("abort", abortFromCaller, { once: true });
+      const started = performance.now();
+      const elapsed = () => Math.max(0, performance.now() - started);
+      const probeOptions = { signal: controller.signal };
+      const route = options.routeForHost(candidate.host);
+      const probeTarget = { ...route.target };
+      try {
+        const preview = options.chain
+          ? await previewChainPlacement(probeTarget, options.request, options.copies, probeOptions)
+          : await previewGenerationPlacement(
+              probeTarget,
+              options.request,
+              options.copies,
+              probeOptions,
+            );
+        probes.push({
+          ...candidate,
+          route,
+          roundTripMs: elapsed(),
+          preview,
+          error: null,
+          legacyUnsupported: false,
+        });
+        if (classifyPlacementPreview(preview) === "planned") resolveFirstPlanned();
+      } catch (probeError) {
+        probes.push({
+          ...candidate,
+          route,
+          roundTripMs: elapsed(),
+          preview: null,
+          error: probeError,
+          legacyUnsupported:
+            probeError instanceof ApiError &&
+            (probeError.status === 404 || probeError.status === 405),
+        });
+      } finally {
+        options.signal?.removeEventListener("abort", abortFromCaller);
+        pending -= 1;
+        if (pending === 0) resolveAllSettled();
+      }
+    })();
+  });
+
+  if (pending === 0) resolveAllSettled();
+  await Promise.race([
+    allSettled,
+    ...(options.candidates.length > 1
+      ? [
+          firstPlanned.then(
+            () =>
+              new Promise<void>((resolve) =>
+                setTimeout(resolve, options.settleMs ?? MOBILE_PLACEMENT_SETTLE_MS),
+              ),
+          ),
+        ]
+      : []),
+  ]);
+  if (pending > 0) for (const controller of controllers) controller.abort();
+  if (!isCurrent()) return { kind: "abandoned" };
+
+  const settledProbes = probes.slice();
+  const planned = settledProbes.flatMap((probe) =>
+    probe.preview && classifyPlacementPreview(probe.preview) === "planned"
+      ? [{ host: probe.view, roundTripMs: probe.roundTripMs, probe }]
+      : [],
+  );
+  const chosen = chooseRoutedHost(
+    planned.map((entry) => ({
+      host: entry.host,
+      roundTripMs: entry.roundTripMs,
+      preview: entry.probe.preview!,
+    })),
+    options.policy,
+    comparePlacementPreviews,
+    { lowestIdWins: true },
+  );
+  if (chosen) {
+    const winner = planned.find((entry) => entry.host.id === chosen.id)!;
+    return {
+      kind: "route",
+      host: winner.probe.host,
+      route: winner.probe.route,
+      placement: winner.probe.preview,
+      legacyUnsupported: false,
+    };
+  }
+
+  const legacy = settledProbes.filter(
+    (probe) => probe.legacyUnsupported || classifyPlacementPreview(probe.preview) === "unsupported",
+  );
+  if (!options.requireAuthoritative && !carriesIdentity && legacy.length > 0) {
+    const views = legacy.map((probe) => probe.view);
+    const fallback =
+      options.policy === CAPABLE_TARGET_ID
+        ? pickMostCapableHost(views, null, { lowestIdWins: true })
+        : pickAutoHost(views, { lowestIdWins: true });
+    if (fallback) {
+      const probe = legacy.find((entry) => entry.host.id === fallback.id)!;
+      return {
+        kind: "route",
+        host: probe.host,
+        route: probe.route,
+        placement: null,
+        legacyUnsupported: true,
+      };
+    }
+  }
+  return {
+    kind: "error",
+    message: mobileFleetPlacementFailure(settledProbes, options.subject),
+  };
+}

--- a/desktop/src/mobile/mobileGenerationRouting.ts
+++ b/desktop/src/mobile/mobileGenerationRouting.ts
@@ -16,6 +16,7 @@ import {
   type CapableHostBase,
 } from "@studio/lib/hostRouting";
 import type { MobileHost } from "./hosts";
+import { mobileIdentityRouteRefusal } from "./identity";
 
 /** One immutable routing candidate assembled by the mobile surface. */
 export interface MobileGenerationRoutingCandidate {
@@ -40,6 +41,15 @@ export type MobileAutomaticRoute =
       kind: "route";
       host: MobileHost;
       route: HostRoute;
+      placement: GenerationPlacementPreview | null;
+      legacyUnsupported: boolean;
+    }
+  | { kind: "error"; message: string }
+  | { kind: "abandoned" };
+
+export type MobilePinnedPlacement =
+  | {
+      kind: "placement";
       placement: GenerationPlacementPreview | null;
       legacyUnsupported: boolean;
     }
@@ -111,6 +121,80 @@ export interface RouteAutomaticMobileGenerationOptions {
   isCurrent?: () => boolean;
   signal?: AbortSignal;
   settleMs?: number;
+}
+
+export interface PreviewPinnedMobileGenerationOptions {
+  route: HostRoute;
+  request: Record<string, unknown>;
+  chain: boolean;
+  copies: number;
+  subject: "print" | "sequence";
+  requireAuthoritative: boolean;
+  isCurrent?: () => boolean;
+  signal?: AbortSignal;
+}
+
+/** Validate one frozen machine's placement answer under the same legacy policy as Auto. */
+export async function previewPinnedMobileGeneration(
+  options: PreviewPinnedMobileGenerationOptions,
+): Promise<MobilePinnedPlacement> {
+  const isCurrent = options.isCurrent ?? (() => true);
+  let placement: GenerationPlacementPreview | null = null;
+  let legacyUnsupported = false;
+  try {
+    placement = options.chain
+      ? await previewChainPlacement(options.route.target, options.request, options.copies, {
+          ...(options.signal ? { signal: options.signal } : {}),
+        })
+      : await previewGenerationPlacement(options.route.target, options.request, options.copies, {
+          ...(options.signal ? { signal: options.signal } : {}),
+        });
+  } catch (error) {
+    if (!isCurrent()) return { kind: "abandoned" };
+    if (error instanceof ApiError && (error.status === 404 || error.status === 405)) {
+      if (options.requireAuthoritative) {
+        return {
+          kind: "error",
+          message:
+            mobileIdentityRouteRefusal({
+              carriesIdentity: Boolean(options.request.id_image),
+              hostLabel: options.route.label,
+              hostAdvertisesIdentity: true,
+              legacyPlacement: true,
+            }) ??
+            `${options.route.label} does not provide the authoritative placement preview required for reference media. Nothing was queued.`,
+        };
+      }
+      legacyUnsupported = true;
+    } else {
+      return {
+        kind: "error",
+        message: describeTransportError(error, options.route.label),
+      };
+    }
+  }
+  if (!isCurrent()) return { kind: "abandoned" };
+  const classification = classifyPlacementPreview(placement);
+  if (options.requireAuthoritative && classification === "unsupported") {
+    return {
+      kind: "error",
+      message:
+        mobileIdentityRouteRefusal({
+          carriesIdentity: Boolean(options.request.id_image),
+          hostLabel: options.route.label,
+          hostAdvertisesIdentity: true,
+          legacyPlacement: true,
+        }) ??
+        `${options.route.label} does not provide the authoritative placement preview required for reference media. Nothing was queued.`,
+    };
+  }
+  if (!legacyUnsupported && classification !== "unsupported" && classification !== "planned") {
+    return {
+      kind: "error",
+      message: mobilePlacementFailure(placement, options.route.label, options.subject),
+    };
+  }
+  return { kind: "placement", placement, legacyUnsupported };
 }
 
 /**

--- a/desktop/src/mobile/mobileGenerationSnapshot.test.ts
+++ b/desktop/src/mobile/mobileGenerationSnapshot.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import type { PreparedExpansionBatch, QuickExpansionSnapshot } from "../lib/preparedExpansion";
+import {
+  capturePreparedSubmission,
+  captureQuickSubmission,
+  preparedSubmissionIsCurrent,
+  quickSubmissionIsCurrent,
+} from "./mobileGenerationSnapshot";
+
+function prepared(): PreparedExpansionBatch {
+  return {
+    kind: "remix",
+    batchId: "batch-1",
+    sourcePrompt: "source",
+    rootPrompt: "root",
+    sourceKind: "current",
+    model: "flux:test",
+    family: "flux",
+    task: "text-to-image",
+    requestedCount: 2,
+    stylePreset: null,
+    selectedHostPolicy: "studio",
+    dimensions: ["composition"],
+    prompts: [
+      { id: "one", text: " first " },
+      { id: "two", text: "second" },
+    ],
+    route: {
+      hostId: "studio",
+      label: "Studio",
+      kind: "remote",
+      target: { baseUrl: "http://studio.test:7680", apiKey: "secret" },
+    },
+  };
+}
+
+function quick(): QuickExpansionSnapshot {
+  return {
+    requestToken: 7,
+    originalPrompt: "source",
+    expandedPrompt: "expanded",
+    model: "flux:test",
+    family: "flux",
+    task: "text-to-image",
+    stylePreset: null,
+    selectedHostPolicy: "studio",
+    route: prepared().route,
+  };
+}
+
+describe("mobile generation submission snapshots", () => {
+  it("freezes trimmed prepared prompts, route credentials, and remix provenance", () => {
+    const source = prepared();
+    const snapshot = capturePreparedSubmission(source)!;
+    source.prompts[0]!.text = "changed";
+    source.route.target.apiKey = "changed";
+
+    expect(snapshot.prompts).toEqual(["first", "second"]);
+    expect(snapshot.route.target.apiKey).toBe("secret");
+    expect(snapshot.promptTransforms).toEqual([
+      expect.objectContaining({
+        operation: "remix",
+        root_prompt: "root",
+        dimensions: ["composition"],
+      }),
+      expect.objectContaining({
+        operation: "remix",
+        root_prompt: "root",
+        dimensions: ["composition"],
+      }),
+    ]);
+  });
+
+  it("rejects prepared work after prompt identity or staleness changes", () => {
+    const current = prepared();
+    const snapshot = capturePreparedSubmission(current)!;
+    expect(preparedSubmissionIsCurrent(snapshot, current, [])).toBe(true);
+    current.prompts[1]!.text = "different";
+    expect(preparedSubmissionIsCurrent(snapshot, current, [])).toBe(false);
+    expect(preparedSubmissionIsCurrent(snapshot, prepared(), ["host changed"])).toBe(false);
+  });
+
+  it("freezes quick routing and rejects a replaced request token", () => {
+    const current = quick();
+    const snapshot = captureQuickSubmission(current)!;
+    current.route.target.apiKey = "changed";
+
+    expect(snapshot.route.target.apiKey).toBe("secret");
+    expect(quickSubmissionIsCurrent(snapshot, current, [])).toBe(true);
+    expect(quickSubmissionIsCurrent(snapshot, { ...current, requestToken: 8 }, [])).toBe(false);
+  });
+});

--- a/desktop/src/mobile/mobileGenerationSnapshot.ts
+++ b/desktop/src/mobile/mobileGenerationSnapshot.ts
@@ -1,0 +1,85 @@
+import type { PromptTransformProvenance, RemixDimension } from "../lib/api/types";
+import type { PreparedExpansionBatch, QuickExpansionSnapshot } from "../lib/preparedExpansion";
+import type { HostRoute } from "../stores/hosts";
+
+export interface MobilePreparedSubmissionSnapshot {
+  batchId: string;
+  promptIds: string[];
+  prompts: string[];
+  originalPrompt: string;
+  promptTransforms?: PromptTransformProvenance[];
+  route: HostRoute;
+}
+
+export interface MobileQuickSubmissionSnapshot {
+  requestToken: number;
+  route: HostRoute;
+}
+
+function cloneRoute(route: HostRoute): HostRoute {
+  return { ...route, target: { ...route.target } };
+}
+
+function remixDimensions(batch: PreparedExpansionBatch, index: number): RemixDimension[] {
+  const perVariant = (
+    batch as PreparedExpansionBatch & {
+      remixVariantDimensions?: readonly (readonly RemixDimension[])[];
+    }
+  ).remixVariantDimensions;
+  return [...(perVariant?.[index] ?? batch.dimensions ?? [])];
+}
+
+export function capturePreparedSubmission(
+  prepared: PreparedExpansionBatch | null,
+): MobilePreparedSubmissionSnapshot | null {
+  if (!prepared) return null;
+  const promptTransforms =
+    prepared.kind === "remix"
+      ? prepared.prompts.map((_, index): PromptTransformProvenance => ({
+          operation: "remix",
+          ...(prepared.rootPrompt ? { root_prompt: prepared.rootPrompt } : {}),
+          source_prompt: prepared.sourcePrompt,
+          source_kind: prepared.sourceKind ?? "current",
+          task: prepared.task,
+          dimensions: remixDimensions(prepared, index),
+        }))
+      : null;
+  return {
+    batchId: prepared.batchId,
+    promptIds: prepared.prompts.map((prompt) => prompt.id),
+    prompts: prepared.prompts.map((prompt) => prompt.text.trim()),
+    originalPrompt: prepared.rootPrompt ?? prepared.sourcePrompt,
+    ...(promptTransforms ? { promptTransforms } : {}),
+    route: cloneRoute(prepared.route),
+  };
+}
+
+export function captureQuickSubmission(
+  quick: QuickExpansionSnapshot | null,
+): MobileQuickSubmissionSnapshot | null {
+  return quick ? { requestToken: quick.requestToken, route: cloneRoute(quick.route) } : null;
+}
+
+export function preparedSubmissionIsCurrent(
+  snapshot: MobilePreparedSubmissionSnapshot,
+  current: PreparedExpansionBatch | null,
+  staleReasons: readonly string[],
+): boolean {
+  return (
+    staleReasons.length === 0 &&
+    current?.batchId === snapshot.batchId &&
+    current.prompts.length === snapshot.prompts.length &&
+    current.prompts.every(
+      (prompt, index) =>
+        prompt.id === snapshot.promptIds[index] && prompt.text.trim() === snapshot.prompts[index],
+    )
+  );
+}
+
+export function quickSubmissionIsCurrent(
+  snapshot: MobileQuickSubmissionSnapshot,
+  current: QuickExpansionSnapshot | null,
+  staleReasons: readonly string[],
+): boolean {
+  return staleReasons.length === 0 && current?.requestToken === snapshot.requestToken;
+}

--- a/desktop/src/mobile/mobileSubmissionAttempt.test.ts
+++ b/desktop/src/mobile/mobileSubmissionAttempt.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from "vitest";
+import type { MobileBackgroundTaskLease } from "./backgroundTask";
+import { MobileSubmissionAttempts } from "./mobileSubmissionAttempt";
+
+function backgroundTask(): MobileBackgroundTaskLease & { release: ReturnType<typeof vi.fn> } {
+  return {
+    active: true,
+    release: vi.fn(() => Promise.resolve()),
+  };
+}
+
+describe("mobile generation submission attempt", () => {
+  it("releases its background task exactly once across repeated cleanup", async () => {
+    const lease = backgroundTask();
+    const attempt = new MobileSubmissionAttempts().begin(lease);
+
+    await attempt.releaseOwnedResources();
+    await attempt.releaseOwnedResources();
+
+    expect(lease.release).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops owning the background task after admission handoff", async () => {
+    const lease = backgroundTask();
+    const attempt = new MobileSubmissionAttempts().begin(lease);
+
+    expect(attempt.handoffBackgroundTask()).toBe(lease);
+    await attempt.releaseOwnedResources();
+
+    expect(lease.release).not.toHaveBeenCalled();
+  });
+
+  it("supersedes and aborts an earlier attempt", () => {
+    const attempts = new MobileSubmissionAttempts();
+    const first = attempts.begin(backgroundTask());
+    const firstSignal = first.signal;
+
+    const second = attempts.begin(backgroundTask());
+
+    expect(first.isCurrent()).toBe(false);
+    expect(firstSignal.aborted).toBe(true);
+    expect(second.isCurrent()).toBe(true);
+  });
+
+  it("invalidates and aborts the active attempt", () => {
+    const attempts = new MobileSubmissionAttempts();
+    const attempt = attempts.begin(backgroundTask());
+    const signal = attempt.signal;
+
+    attempts.invalidate();
+
+    expect(attempt.isCurrent()).toBe(false);
+    expect(signal.aborted).toBe(true);
+  });
+});

--- a/desktop/src/mobile/mobileSubmissionAttempt.ts
+++ b/desktop/src/mobile/mobileSubmissionAttempt.ts
@@ -1,0 +1,51 @@
+import { PreparationRequestGuard } from "../lib/preparedExpansion";
+import type { MobileBackgroundTaskLease } from "./backgroundTask";
+
+/**
+ * One generation submission's cancellable work and finite background lease.
+ * The lease stays owned here until server admission takes responsibility for
+ * releasing it, which makes every early return use the same cleanup path.
+ */
+export class MobileSubmissionAttempt {
+  private backgroundTaskHandedOff = false;
+  private released = false;
+
+  constructor(
+    private readonly guard: PreparationRequestGuard,
+    private readonly token: number,
+    private readonly backgroundTask: MobileBackgroundTaskLease,
+  ) {}
+
+  get signal(): AbortSignal {
+    return this.guard.signalFor(this.token);
+  }
+
+  isCurrent(): boolean {
+    return this.guard.isCurrent(this.token);
+  }
+
+  handoffBackgroundTask(): MobileBackgroundTaskLease {
+    this.backgroundTaskHandedOff = true;
+    return this.backgroundTask;
+  }
+
+  releaseOwnedResources(): Promise<void> {
+    if (this.released) return Promise.resolve();
+    this.released = true;
+    return this.backgroundTaskHandedOff ? Promise.resolve() : this.backgroundTask.release();
+  }
+}
+
+/** Coordinates the single generation submission that may prepare at a time. */
+export class MobileSubmissionAttempts {
+  constructor(private readonly guard = new PreparationRequestGuard()) {}
+
+  begin(backgroundTask: MobileBackgroundTaskLease): MobileSubmissionAttempt {
+    const token = this.guard.begin();
+    return new MobileSubmissionAttempt(this.guard, token, backgroundTask);
+  }
+
+  invalidate(): void {
+    this.guard.invalidate();
+  }
+}

--- a/desktop/src/views/HostDetailView.test.ts
+++ b/desktop/src/views/HostDetailView.test.ts
@@ -1,13 +1,13 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { flushPromises, mount } from "@vue/test-utils";
 import { createPinia, setActivePinia } from "pinia";
 import { createMemoryHistory, createRouter, type Router } from "vue-router";
 
-const { listDevices, setDeviceEnabled } = vi.hoisted(() => ({
+const { apiJsonTo, listDevices, setDeviceEnabled } = vi.hoisted(() => ({
+  apiJsonTo: vi.fn(),
   listDevices: vi.fn(),
   setDeviceEnabled: vi.fn(),
 }));
-const apiJsonTo = vi.fn();
 vi.mock("../lib/api/client", () => ({
   ApiError: class ApiError extends Error {},
   apiJsonTo: (...a: unknown[]) => apiJsonTo(...a),
@@ -176,6 +176,7 @@ function model(name: string, family: string): ModelEntry {
 
 let router: Router;
 let mountedHosts: ReturnType<typeof useHostsStore>;
+const mountedViews: Array<ReturnType<typeof mount>> = [];
 
 async function mountView(
   path = `/hosts/${REMOTE_ID}`,
@@ -252,6 +253,7 @@ async function mountView(
   const wrapper = mount(HostDetailView, {
     global: { plugins: [pinia, router] },
   });
+  mountedViews.push(wrapper);
   await flushPromises();
   return wrapper;
 }
@@ -283,6 +285,11 @@ beforeEach(() => {
     generateTargetHost: null,
   });
   installApi();
+});
+
+afterEach(() => {
+  for (const wrapper of mountedViews) wrapper.unmount();
+  mountedViews.length = 0;
 });
 
 describe("HostDetailView GPU lifecycle controls", () => {


### PR DESCRIPTION
## Summary

- split the mobile generation submission god flow into bounded routing, preparation, lifecycle, snapshot, and outcome modules
- unify pinned and automatic placement handling while preserving frozen route and request semantics
- centralize cancellation, background-task ownership, admission handoff, and partial-result cleanup
- add characterization and regression coverage around stale attempts, durable/SSE admission, and cleanup
- isolate desktop host-detail mounts to prevent cross-test state leakage

## Verification

- full frontend suite: 5,082 tests passed
- independent review suite: 386 targeted tests passed
- mobile production build and typecheck passed
- `nix develop -c ios-check` passed
- `git diff --check` passed
- iPhone 17 Pro Simulator build, install, launch, and navigation UAT passed
- live Plato2 placement and queue admission passed with `flux-dev:q8`; the UAT job was cancelled after admission because four pre-existing long-running video jobs occupied the host

## Review

An independent agent reviewed all nine commits against `main` and found no actionable issues. The remaining untested boundary is physical-device suspension/background expiration, which Simulator cannot fully reproduce.
