### PR TITLE
fix(ui): report generation finalization accurately

### DIFF
--- a/changelog.d/minimax-progress-status.md
+++ b/changelog.d/minimax-progress-status.md
@@ -1,0 +1,4 @@
+- **Truthful generation progress.** MiniMax and other multi-stage renders now keep
+  showing their real denoising step while transformer blocks stream, then name
+  video/audio decoding, encoding, muxing, and saving as finalization instead of
+  appearing stuck at a premature 100%.

--- a/crates/mold-cli/src/ui.rs
+++ b/crates/mold-cli/src/ui.rs
@@ -242,6 +242,12 @@ pub(crate) async fn render_progress(
                 pb.tick();
             }
             SseProgressEvent::StageStart { name } => {
+                if let Some(db) = denoise_bar.as_ref() {
+                    if db.position() < db.length().unwrap_or_default() {
+                        db.set_message(name);
+                        continue;
+                    }
+                }
                 if let Some(db) = denoise_bar.take() {
                     db.finish_and_clear();
                 }
@@ -252,6 +258,12 @@ pub(crate) async fn render_progress(
                 pb.tick();
             }
             SseProgressEvent::StageDone { name, elapsed_ms } => {
+                if let Some(db) = denoise_bar.as_ref() {
+                    if db.position() < db.length().unwrap_or_default() {
+                        db.set_message("");
+                        continue;
+                    }
+                }
                 if let Some(db) = denoise_bar.take() {
                     db.finish_and_clear();
                 }

--- a/crates/mold-tui/src/ui/preview.rs
+++ b/crates/mold-tui/src/ui/preview.rs
@@ -217,14 +217,20 @@ fn render_generating(frame: &mut Frame, app: &App, inner: Rect) {
     let theme = &app.theme;
     let progress = &app.generate.progress;
 
-    // The stage line: denoise progress once it starts, the download text
-    // during a pull, else the current pipeline stage.
-    let (stage_line, bar, stats) = if progress.denoise_total > 0 {
-        let (line, bar, stats) = preview_progress(
+    // Keep nested pipeline work (for example MiniMax H3's streamed blocks)
+    // attached to the truthful denoise counter. Once N/N is complete, switch
+    // to the actual final-output stage instead of leaving a stale full bar.
+    let denoising = progress.denoise_total > 0 && progress.denoise_step < progress.denoise_total;
+    let (stage_line, bar, stats) = if denoising {
+        let (mut line, bar, stats) = preview_progress(
             progress.denoise_step,
             progress.denoise_total,
             progress.denoise_elapsed_ms,
         );
+        if let Some(stage) = &progress.current_stage {
+            line.push_str(" · ");
+            line.push_str(stage);
+        }
         (line, Some(bar), Some(stats))
     } else if progress.is_downloading() {
         (progress.download_status_text().to_string(), None, None)

--- a/desktop/src/components/create/ActivityStrip.test.ts
+++ b/desktop/src/components/create/ActivityStrip.test.ts
@@ -82,6 +82,14 @@ describe("ActivityStrip", () => {
     expect(wrapper.text()).toContain("50%");
   });
 
+  it("names finalization instead of presenting a bare 100%", () => {
+    const generation = useGenerationStore();
+    generation.jobs = [{ ...baseJob(), status: "finishing", step: 10, total: 10 }];
+    const wrapper = mount(ActivityStrip);
+    expect(wrapper.get("[data-test='activity-strip']").text()).toContain("Finalizing");
+    expect(wrapper.get("[data-test='activity-strip']").text()).not.toContain("100%");
+  });
+
   it("cancels the running print once and acknowledges the pending request", async () => {
     const generation = useGenerationStore();
     const cancel = vi.spyOn(generation, "cancel").mockResolvedValue(false);

--- a/desktop/src/components/create/ActivityStrip.vue
+++ b/desktop/src/components/create/ActivityStrip.vue
@@ -118,6 +118,7 @@ const hiddenQueuedCount = computed(() =>
 const runningPct = computed(() =>
   running.value ? Math.round(jobProgress(running.value) * 100) : 0,
 );
+const runningFinalizing = computed(() => running.value?.status === "finishing");
 const runningHost = computed(() =>
   running.value?.hostId
     ? (hosts.all.find((host) => host.id === running.value?.hostId) ?? null)
@@ -326,9 +327,15 @@ function deleteConfirmed() {
               :cost-per-hr="runningPod.costPerHr"
               :uptime-seconds="runningPod.uptimeSeconds"
             />
-            <span class="ms-activity__pct data-mono">{{ runningPct }}%</span>
+            <span class="ms-activity__pct data-mono">
+              {{ runningFinalizing ? "Finalizing" : `${runningPct}%` }}
+            </span>
           </div>
-          <ProgressBar :value="runningPct" :height="4" label="Print progress" />
+          <ProgressBar
+            :value="runningPct"
+            :height="4"
+            :label="runningFinalizing ? 'Finalizing print' : 'Print progress'"
+          />
         </button>
         <button
           type="button"

--- a/desktop/src/components/machines/QueueColumn.test.ts
+++ b/desktop/src/components/machines/QueueColumn.test.ts
@@ -14,6 +14,7 @@ vi.mock("../../lib/ipc", () => ({ inTauri: () => false, ipc: {} }));
 
 import QueueColumn from "./QueueColumn.vue";
 import { useConnectionStore } from "../../stores/connection";
+import { useGenerationStore, type Job } from "../../stores/generation";
 import { useJobsStore, type HostQueueCaps, type QueueEntry } from "../../stores/jobs";
 
 function entry(over: Partial<QueueEntry> = {}): QueueEntry {
@@ -62,6 +63,41 @@ describe("QueueColumn", () => {
     expect(rows).toHaveLength(1);
     expect(rows[0]!.text()).toContain("flux2-klein");
     expect(rows[0]!.text()).toContain("queued · This device");
+  });
+
+  it("labels a running print as finalizing after denoising completes", async () => {
+    setActivePinia(createPinia());
+    const conn = useConnectionStore();
+    conn.info = { mode: "local", baseUrl: "http://127.0.0.1:49152", apiKey: null };
+    conn.status = "ready";
+    const jobs = useJobsStore();
+    jobs.queues.local = {
+      hostId: "local",
+      entries: [entry({ state: "running", position: 0 })],
+      paused: null,
+      caps: { canPause: true, canCancelAll: true, canReorder: false },
+      gpuOrdinals: [],
+      error: null,
+    };
+    useGenerationStore().jobs = [
+      {
+        id: "srv-1",
+        clientId: 7,
+        prompt: "a lighthouse",
+        status: "finishing",
+        step: 10,
+        total: 10,
+        error: null,
+        submittedAtUnixMs: Date.now(),
+        settledAtMs: null,
+      } as Job,
+    ];
+    const wrapper = mount(QueueColumn);
+    await flushPromises();
+
+    const text = wrapper.get("[data-test='queue-surface-row']").text();
+    expect(text).toContain("finalizing · This device");
+    expect(text).not.toContain("developing · This device");
   });
 
   it("keeps deeper host work reachable through an explicit continuation", async () => {

--- a/desktop/src/components/machines/QueueColumn.vue
+++ b/desktop/src/components/machines/QueueColumn.vue
@@ -35,7 +35,7 @@ function promptFor(row: QueueSurfaceRow): string {
   return ownJob(row)?.prompt ?? row.entry.model;
 }
 
-/** developing 18/28 · This Mac (own denoising) → developing/queued/held · host.
+/** developing 18/28 · This Mac (own denoising) → developing/finalizing/queued/held · host.
  *  Held is not waiting for a turn — the host parked it and will not start it —
  *  so it must never borrow the word that means "your turn is coming". */
 function statusLine(row: QueueSurfaceRow): string {
@@ -46,9 +46,11 @@ function statusLine(row: QueueSurfaceRow): string {
   }
   const state =
     row.entry.state === "running"
-      ? job && job.total > 0 && job.status === "denoising"
-        ? `developing ${job.step}/${job.total}`
-        : "developing"
+      ? job?.status === "finishing"
+        ? "finalizing"
+        : job && job.total > 0 && job.status === "denoising"
+          ? `developing ${job.step}/${job.total}`
+          : "developing"
       : "queued";
   return `${state} · ${row.hostLabel}`;
 }

--- a/desktop/src/lib/generationJob.ts
+++ b/desktop/src/lib/generationJob.ts
@@ -8,6 +8,11 @@ import type {
 import type { DevelopPhase } from "@ui/lib/grain";
 import { queueWaitCode, resolveQueueWait } from "@studio/lib/queuePosition";
 import { requestWarningsFromCompleteEvent } from "@studio/lib/requestWarnings";
+import {
+  generationProgressCopy,
+  phaseForStageStart,
+  type GenerationWorkPhase,
+} from "@studio/lib/generationProgress";
 
 export type JobStatus = "queued" | "loading" | "denoising" | "finishing" | "complete" | "error";
 
@@ -206,11 +211,18 @@ export function applyProgress(job: Job, event: ProgressEvent): Job {
       break;
     case "weight_load":
     case "stage_start":
-      // Stages after the denoise loop (transformer drop, VAE decode, encode)
-      // are the fixer bath: the steps read N/N but the print isn't done.
+      // StageStart is also used for nested work inside a denoise evaluation.
+      // MiniMax H3, for example, starts a 50-block transformer stage before
+      // each DenoiseStep. Keep that work attached to its truthful N/N count;
+      // only a stage beginning after N/N is final output preparation.
       if (job.status === "denoising" || job.status === "finishing") {
         if (event.type === "stage_start") {
-          job.status = "finishing";
+          const current: GenerationWorkPhase =
+            job.status === "finishing" ? "finalizing" : "denoising";
+          job.status =
+            phaseForStageStart(current, job.step, job.total) === "finalizing"
+              ? "finishing"
+              : "denoising";
           job.stage = event.name;
         }
       } else {
@@ -349,6 +361,21 @@ export function jobProgress(job: Job): number {
   if (job.status === "complete" || job.status === "finishing") return 1;
   if (job.total <= 0) return 0;
   return job.step / job.total;
+}
+
+export function jobProgressCopy(job: Job): string {
+  const phase: GenerationWorkPhase =
+    job.status === "finishing"
+      ? "finalizing"
+      : job.status === "denoising"
+        ? "denoising"
+        : "preparing";
+  return generationProgressCopy({
+    phase,
+    step: job.step,
+    total: job.total,
+    stage: job.stage,
+  });
 }
 
 /** Normalize cancellation emitted by the server or initiated by this client. */

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -4680,7 +4680,7 @@ describe("MobileApp generation queue", () => {
     // iPhone already keeps the changing status outside and below the noisy
     // preview, matching the desktop/web placement invariant.
     const summary = wrapper.get("[data-test='mobile-generation-summary']");
-    expect(summary.text()).toBe("Developing 2 / 8");
+    expect(summary.text()).toBe("Developing 2/8");
     expect(bed.find("[data-test='mobile-generation-summary']").exists()).toBe(false);
     expect(
       bed.element.compareDocumentPosition(summary.element) & Node.DOCUMENT_POSITION_FOLLOWING,

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -321,6 +321,7 @@ import {
   isCancelledError,
   jobPhase,
   jobProgress,
+  jobProgressCopy,
   jobStatusCode,
   planBatchRequests,
   railOrder,
@@ -2620,9 +2621,9 @@ const generationStatus = computed(() => {
     case "loading":
       return active.stage ?? "Loading model";
     case "denoising":
-      return `Developing ${active.step} / ${active.total}`;
+      return jobProgressCopy(active);
     case "finishing":
-      return active.stage ?? "Finalizing";
+      return jobProgressCopy(active);
     default:
       return jobStatusCode(active);
   }

--- a/desktop/src/stores/generation.test.ts
+++ b/desktop/src/stores/generation.test.ts
@@ -4,6 +4,7 @@ import {
   applyProgress,
   jobPhase,
   jobProgress,
+  jobProgressCopy,
   jobStatusCode,
   newJob,
   planBatchRequests,
@@ -89,6 +90,19 @@ describe("generation SSE reducer", () => {
       component: "vae",
     });
     expect(job.status).toBe("finishing");
+  });
+
+  it("keeps MiniMax transformer blocks in the active denoise step", () => {
+    const job = newJob({ ...req, steps: 20 });
+    applyProgress(job, { type: "denoise_step", step: 4, total: 20, elapsed_ms: 1 });
+    applyProgress(job, {
+      type: "stage_start",
+      name: "Streaming MiniMax H3 transformer blocks",
+    });
+
+    expect(job.status).toBe("denoising");
+    expect(jobProgress(job)).toBe(0.2);
+    expect(jobProgressCopy(job)).toBe("Developing 4/20 — Streaming MiniMax H3 transformer blocks");
   });
 
   it("uses the requested seed for the grain, or a stable stand-in", () => {

--- a/desktop/src/stores/generation.ts
+++ b/desktop/src/stores/generation.ts
@@ -87,6 +87,7 @@ export {
   isCancelledError,
   jobPhase,
   jobProgress,
+  jobProgressCopy,
   jobStatusCode,
   metadataOnlyResult,
   newJob,

--- a/desktop/src/views/GenerateView.vue
+++ b/desktop/src/views/GenerateView.vue
@@ -105,6 +105,7 @@ import {
   useGenerationStore,
   jobPhase,
   jobProgress,
+  jobProgressCopy,
   needsHostRoute,
   suggestOutputFilename,
   type BatchRequestOptions,
@@ -2124,8 +2125,8 @@ const liveGenerationStatus = computed(() => {
   if (!j || j.status === "complete" || j.status === "error") return "";
   if (j.status === "queued") return "Queued";
   if (j.status === "loading") return `${j.stage ?? "Preparing"}…`;
-  if (j.status === "finishing") return `Fixing — ${j.stage ?? "finishing"}…`;
-  return `Developing ${j.step}/${j.total}`;
+  const copy = jobProgressCopy(j);
+  return j.status === "finishing" ? `${copy}…` : copy;
 });
 
 const edgeCode = computed(() => {

--- a/studio/lib/generationProgress.test.ts
+++ b/studio/lib/generationProgress.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import {
+  generationProgressCopy,
+  phaseForStageStart,
+} from "./generationProgress";
+
+describe("generation progress phases", () => {
+  it("keeps a nested transformer-block stage inside denoising", () => {
+    expect(phaseForStageStart("denoising", 4, 20)).toBe("denoising");
+    expect(
+      generationProgressCopy({
+        phase: "denoising",
+        step: 4,
+        total: 20,
+        stage: "Streaming MiniMax H3 transformer blocks",
+      }),
+    ).toBe("Developing 4/20 — Streaming MiniMax H3 transformer blocks");
+  });
+
+  it("reserves finalizing for a stage after the last denoise evaluation", () => {
+    expect(phaseForStageStart("denoising", 20, 20)).toBe("finalizing");
+    expect(
+      generationProgressCopy({
+        phase: "finalizing",
+        step: 20,
+        total: 20,
+        stage: "Decoding MiniMax H3 video",
+      }),
+    ).toBe("Finalizing — Decoding MiniMax H3 video");
+  });
+});

--- a/studio/lib/generationProgress.ts
+++ b/studio/lib/generationProgress.ts
@@ -1,0 +1,46 @@
+export type GenerationWorkPhase = "preparing" | "denoising" | "finalizing";
+
+export interface GenerationProgressCopy {
+  phase: GenerationWorkPhase;
+  step: number;
+  total: number;
+  stage?: string | null;
+}
+
+function meaningfulStage(stage: string | null | undefined): string | null {
+  if (!stage || stage === "Denoising" || stage.endsWith(" (done)")) return null;
+  return stage;
+}
+
+/**
+ * A StageStart can be a nested phase inside a denoise evaluation (MiniMax H3
+ * streams 50 transformer blocks per evaluation) or genuinely post-denoise
+ * work. Only the completed denoise counter can distinguish those cases.
+ */
+export function phaseForStageStart(
+  current: GenerationWorkPhase,
+  step: number,
+  total: number,
+): GenerationWorkPhase {
+  if (current === "finalizing") return "finalizing";
+  if (current !== "denoising") return "preparing";
+  return total > 0 && step >= total ? "finalizing" : "denoising";
+}
+
+/** One progress sentence shared by web, desktop, iPhone, and Android. */
+export function generationProgressCopy({
+  phase,
+  step,
+  total,
+  stage,
+}: GenerationProgressCopy): string {
+  const detail = meaningfulStage(stage);
+  if (phase === "denoising") {
+    const count = total > 0 ? `${step}/${total}` : String(step);
+    return `Developing ${count}${detail ? ` — ${detail}` : ""}`;
+  }
+  if (phase === "finalizing") {
+    return `Finalizing${detail ? ` — ${detail}` : ""}`;
+  }
+  return detail ?? "Preparing";
+}

--- a/web/src/components/create/ActivityStrip.test.ts
+++ b/web/src/components/create/ActivityStrip.test.ts
@@ -151,6 +151,20 @@ describe("ActivityStrip", () => {
     expect(wrapper.text()).toContain("50%");
   });
 
+  it("names finalization instead of presenting a bare 100%", () => {
+    const job = makeJob({
+      progress: {
+        ...makeJob().progress,
+        stage: "Decoding video",
+        step: 28,
+        totalSteps: 28,
+      },
+    });
+    const wrapper = mount(ActivityStrip, { props: { jobs: [job] } });
+    expect(wrapper.text()).toContain("Finalizing");
+    expect(wrapper.text()).not.toContain("100%");
+  });
+
   it("prefers the print title over the prompt, and falls back to Untitled print", () => {
     const titled = makeJob({
       request: {

--- a/web/src/components/create/ActivityStrip.vue
+++ b/web/src/components/create/ActivityStrip.vue
@@ -175,6 +175,17 @@ function percentFor(job: Job): number | null {
   return null;
 }
 
+function isFinalizing(job: Job): boolean {
+  const { stage, step, totalSteps } = job.progress;
+  return (
+    step !== null &&
+    totalSteps !== null &&
+    step >= totalSteps &&
+    stage !== "Denoising" &&
+    stage !== "Developing"
+  );
+}
+
 /** `title ?? prompt ?? "Untitled print"` — a chain request carries no title
  * slot, so the `in` check keeps the union honest. */
 function promptFor(job: Job): string {
@@ -283,10 +294,19 @@ const active = computed(
             :value="percentFor(job) ?? 0"
             tone="accent"
             :height="3"
-            :label="`${promptFor(job)} progress`"
+            :label="
+              isFinalizing(job)
+                ? `${promptFor(job)} finalizing`
+                : `${promptFor(job)} progress`
+            "
           />
         </span>
-        <span v-if="percentFor(job) !== null" class="activity__pct"
+        <span
+          v-if="isFinalizing(job)"
+          class="activity__pct activity__pct--stage"
+          >Finalizing</span
+        >
+        <span v-else-if="percentFor(job) !== null" class="activity__pct"
           >{{ percentFor(job) }}%</span
         >
         <span v-else class="activity__pct activity__pct--stage">{{

--- a/web/src/pages/CreatePage.vue
+++ b/web/src/pages/CreatePage.vue
@@ -11,6 +11,7 @@ import { requestChoice, toast, undoableAction } from "../lib/toasts";
 import { useRoute, useRouter } from "vue-router";
 import ComposerCard from "../components/create/ComposerCard.vue";
 import ResultCanvas from "../components/create/ResultCanvas.vue";
+import { generationProgressCopy } from "@studio/lib/generationProgress";
 import ControlsAside from "../components/create/ControlsAside.vue";
 import CreateModelPicker from "../components/create/CreateModelPicker.vue";
 import AdvancedDrawer from "../components/create/AdvancedDrawer.vue";
@@ -2916,8 +2917,18 @@ const genStage = computed(() => {
   const j = runningJob.value;
   if (!j) return "";
   const p = j.progress;
-  if (p.step !== null && p.totalSteps)
-    return `Developing ${p.step} / ${p.totalSteps}`;
+  if (p.step !== null && p.totalSteps) {
+    const phase =
+      p.step >= p.totalSteps && p.stage !== "Denoising"
+        ? "finalizing"
+        : "denoising";
+    return generationProgressCopy({
+      phase,
+      step: p.step,
+      total: p.totalSteps,
+      stage: p.stage,
+    });
+  }
   return p.stage || "Loading model";
 });
 


### PR DESCRIPTION
## Summary

- keep nested MiniMax transformer-block stages inside the active denoising phase instead of switching the job to finalizing and forcing 100%
- expose truthful shared Developing N/N and Finalizing status copy across desktop, web, iPhone/Android, CLI, and TUI
- label Activity and Machines surfaces as Finalizing instead of leaving users at a bare 100%

## Root cause

MiniMax emits nested `stage_start` events while denoising. Desktop treated every stage after denoising began as finalization, so a nested transformer-block event at 4/20 changed the state to `finishing`; the progress helper maps that state to 100%. Real post-denoise work then includes video/audio decoding, encoding, muxing, and saving.

## Verification

- Studio: 1,264 tests passed
- Web: 1,734 tests passed
- TUI: 763 tests passed
- focused desktop reducer/components: 96 tests passed
- desktop and web production builds passed
- `cargo check -p mold-ai -p mold-ai-tui` passed
- rendered desktop and mobile-width browser QA completed
- independent agent peer review completed with no remaining findings