### PR TITLE
fix(h3): keep placement previews non-blocking

### DIFF
--- a/changelog.d/h3-nonblocking-placement-preview.md
+++ b/changelog.d/h3-nonblocking-placement-preview.md
@@ -1,0 +1,4 @@
+- **MiniMax H3 requests no longer wait for checkpoint hashing before they queue.**
+  Placement preview now consumes only an existing trusted artifact attestation;
+  first-time verification runs during admitted queue ownership instead of
+  blocking the Create screen on `Checking placement`.

--- a/crates/mold-core/src/download.rs
+++ b/crates/mold-core/src/download.rs
@@ -1059,14 +1059,43 @@ pub fn pinned_file_digest_from_open_file(
     Ok(digest)
 }
 
-/// Read-only pinned check: do this file's current bytes hash to `expected`?
+/// Non-destructive pinned check: do this file's current bytes hash to `expected`?
 ///
-/// Deletes nothing, writes nothing, and answers `false` for any file it cannot
-/// open or hash. This is the form a read-only placement preview may ask.
+/// Deletes nothing and answers `false` for any file it cannot open or hash. It
+/// may read the entire file and persist an owner-private digest attestation;
+/// use [`pinned_file_matches_attested`] for cheap planning.
 pub fn pinned_file_matches(path: &Path, expected_sha256: &str) -> bool {
     pinned_file_digest(path)
         .map(|digest| digest.eq_ignore_ascii_case(expected_sha256))
         .unwrap_or(false)
+}
+
+/// Does an existing process memo or owner-private durable attestation prove
+/// that this exact file identity has the expected digest?
+///
+/// Unlike [`pinned_file_matches`], this never reads the artifact body and
+/// never creates an attestation. Placement previews use it to stay a cheap,
+/// read-only planning operation; a cold file remains unproven until admission
+/// authenticates it after the request has entered the queue.
+pub fn pinned_file_matches_attested(path: &Path, expected_sha256: &str) -> bool {
+    let Ok(file) = crate::secure_file::open_regular_file_no_follow(path) else {
+        return false;
+    };
+    let Ok(identity) = pinned_file_identity(&file) else {
+        return false;
+    };
+    let memoized = pinned_digest_cache()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(&identity)
+        .cloned();
+    let digest = memoized
+        .or_else(|| read_durable_pinned_digest(path, identity))
+        .filter(|digest| digest.eq_ignore_ascii_case(expected_sha256));
+    let current_identity = crate::secure_file::open_regular_file_no_follow(path)
+        .ok()
+        .and_then(|current| pinned_file_identity(&current).ok());
+    digest.is_some() && current_identity == Some(identity)
 }
 
 /// Prove one already-placed file against a manifest-pinned SHA-256, writing
@@ -3897,6 +3926,26 @@ mod tests {
         // partial-cleanup sweep read it as a "fully written" signal. It is
         // just never read back as proof of content.
         assert_eq!(recorded_sha256_marker(&path).as_deref(), Some(&*expected));
+    }
+
+    #[test]
+    fn an_attested_only_check_never_hashes_a_cold_file() {
+        let _serial = pinned_digest_lock();
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cold-preview.bin");
+        std::fs::write(&path, b"the real pinned bytes").unwrap();
+        let expected = compute_sha256(&path).unwrap();
+        let before = pinned_digest_hash_count_for(&path);
+
+        assert!(!pinned_file_matches_attested(&path, &expected));
+        assert_eq!(
+            pinned_digest_hash_count_for(&path),
+            before,
+            "a read-only preview must not hash an unattested artifact"
+        );
+
+        assert!(pinned_file_matches(&path, &expected));
+        assert!(pinned_file_matches_attested(&path, &expected));
     }
 
     #[test]

--- a/crates/mold-server/src/variant_dependencies.rs
+++ b/crates/mold-server/src/variant_dependencies.rs
@@ -248,13 +248,13 @@ fn verify_cached_dependency(
         return CachedDependencyVerdict::Usable;
     };
     if policy == DependencyMaterializationPolicy::ExistingOnly {
-        // Read-only: hash the current bytes through a retained descriptor and
-        // answer. Never the `.sha256-verified` marker — it is a writable
+        // Read-only planning may consume an existing trusted memo, but it must
+        // not create one by reading tens of gigabytes before the request can
+        // queue. Never the `.sha256-verified` marker — it is a writable
         // sidecar in a models root the model-storage invariant lets a group
-        // write, so it attests nothing about content. The hash is memoized per
-        // file identity, so a preview of an unchanged installed bundle costs
-        // one `fstat` per asset after the first.
-        return if mold_core::download::pinned_file_matches(path, pin.sha256) {
+        // write, so it attests nothing about content. A cold copy remains
+        // pending until admission authenticates it after queue ownership.
+        return if mold_core::download::pinned_file_matches_attested(path, pin.sha256) {
             CachedDependencyVerdict::Usable
         } else {
             CachedDependencyVerdict::Unproven
@@ -2941,11 +2941,24 @@ mod tests {
             "a read-only preview must not write an attestation either"
         );
 
-        // Proven bytes are reused by both policies without a download.
+        // A cold preview reports even the correct bytes as pending rather than
+        // hashing them synchronously. Admission proves the copy; subsequent
+        // previews may consume that trusted memo without reading the body.
         std::fs::write(&path, PINNED_CONTENT).unwrap();
-        for policy in [
+        let cold_preview = ensure_downloaded(
+            None,
+            "cold-preview",
+            pinned_spec(cache.path(), &repo, PINNED_CONTENT_SHA256),
+            None,
             DependencyMaterializationPolicy::ExistingOnly,
+        )
+        .await
+        .expect("a preview never refuses");
+        assert!(matches!(cold_preview, ResolvedDependency::Pending(_)));
+
+        for policy in [
             DependencyMaterializationPolicy::Admission,
+            DependencyMaterializationPolicy::ExistingOnly,
         ] {
             let resolved = ensure_downloaded(
                 None,


### PR DESCRIPTION
## Summary

- make placement preview consume only an existing process memo or owner-private durable attestation
- never hash a cold pinned artifact during read-only planning
- defer first-time artifact authentication to admitted queue ownership

## Root cause

The deployed attestation persistence fix worked, but ExistingOnly placement planning still called pinned_file_matches. On a cold attestation store that function read and hashed all 39.56 GiB of the H3 checkpoint set before the pinned generation request could queue, leaving iPhone on Checking placement for roughly a minute.

Owner protection remains required: the group-writable model directory and its sidecars cannot authenticate their own bytes. This change retains exact-identity owner-private attestations while keeping the preview contract read-only and non-blocking.

## Validation

- nix develop -c cargo fmt --all -- --check
- nix develop -c cargo test -p mold-ai-core an_attested_only_check_never_hashes_a_cold_file
- nix develop -c cargo test -p mold-ai-server a_pre_existing_unattested_copy_is_verified_before_it_is_reused
- nix develop -c cargo test -p mold-ai-server a_forged_attestation_beside_wrong_bytes_is_refused_by_both_policies -- --nocapture
- nix develop -c cargo clippy -p mold-ai-core -p mold-ai-server --all-targets -- -D warnings