### PR TITLE
fix(mobile): queue pinned H3 before verification

### DIFF
--- a/changelog.d/mobile-pinned-generation-admission.md
+++ b/changelog.d/mobile-pinned-generation-admission.md
@@ -1,0 +1,4 @@
+- **Pinned MiniMax H3 prints no longer wait behind “Checking placement.”**
+  iPhone and Android submit ordinary H3 prints directly to the selected machine,
+  while automatic routing and authoritative identity/reference-media checks keep
+  their existing placement fence.

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -5786,10 +5786,16 @@ async function generate(): Promise<void> {
     releasePreparedSubmission();
     return;
   }
-  if (!unmounted && uiId === submissionUiId) generationSubmissionPhase.value = "placement";
   const requireAuthoritativePlacement = requiresAuthoritativePlacement(
     request as unknown as Record<string, unknown>,
   );
+  const skipPinnedH3Placement =
+    !automaticOrdinary &&
+    !requireAuthoritativePlacement &&
+    isMinimaxH3Identity(draft.family, request.model);
+  if (!unmounted && uiId === submissionUiId && !skipPinnedH3Placement) {
+    generationSubmissionPhase.value = "placement";
+  }
   let placement: GenerationPlacementPreview | null = null;
   let legacyUnsupported = false;
   const previewRequest =

--- a/desktop/src/mobile/mobileGenerationRouting.test.ts
+++ b/desktop/src/mobile/mobileGenerationRouting.test.ts
@@ -256,6 +256,24 @@ describe("mobile pinned generation placement", () => {
     });
   });
 
+  it("submits pinned H3 directly so cold verification happens after queueing", async () => {
+    await expect(
+      previewPinnedMobileGeneration({
+        ...pinnedOptions(),
+        request: {
+          model: "minimax-h3-fl2va:comfy-pruned-int8-turbo-4step-768p",
+          source_image: "frame",
+        },
+      }),
+    ).resolves.toEqual({
+      kind: "placement",
+      placement: null,
+      legacyUnsupported: false,
+    });
+    expect(previewGenerationPlacement).not.toHaveBeenCalled();
+    expect(previewChainPlacement).not.toHaveBeenCalled();
+  });
+
   it("refuses a legacy identity placement", async () => {
     previewGenerationPlacement.mockRejectedValue(new ApiError("missing", 404));
 

--- a/desktop/src/mobile/mobileGenerationRouting.ts
+++ b/desktop/src/mobile/mobileGenerationRouting.ts
@@ -15,6 +15,7 @@ import {
   pickMostCapableHost,
   type CapableHostBase,
 } from "@studio/lib/hostRouting";
+import { isMinimaxH3Identity } from "@studio/lib/minimaxH3Identity";
 import type { MobileHost } from "./hosts";
 import { mobileIdentityRouteRefusal } from "./identity";
 
@@ -134,11 +135,21 @@ export interface PreviewPinnedMobileGenerationOptions {
   signal?: AbortSignal;
 }
 
-/** Validate one frozen machine's placement answer under the same legacy policy as Auto. */
+/**
+ * Validate one frozen machine only when the request needs an authoritative
+ * capability fence. Ordinary pinned work has no routing decision to make, so
+ * it goes straight to admission; the server queues it before expensive model
+ * preparation and remains authoritative for every execution check.
+ */
 export async function previewPinnedMobileGeneration(
   options: PreviewPinnedMobileGenerationOptions,
 ): Promise<MobilePinnedPlacement> {
   const isCurrent = options.isCurrent ?? (() => true);
+  if (!isCurrent()) return { kind: "abandoned" };
+  const model = typeof options.request.model === "string" ? options.request.model : null;
+  if (!options.requireAuthoritative && isMinimaxH3Identity(null, model)) {
+    return { kind: "placement", placement: null, legacyUnsupported: false };
+  }
   let placement: GenerationPlacementPreview | null = null;
   let legacyUnsupported = false;
   try {


### PR DESCRIPTION
## Summary

- skip the advisory placement preview for pinned MiniMax H3 requests that do not carry identity/reference placement authority
- submit those requests directly to the already-selected host so server admission registers the job before cold H3 qualification
- keep Auto/Most capable routing and authoritative identity/reference previews unchanged

## Root cause

The iPhone was pinned to hal9000, but mobile still called `/api/generate/placement-preview` before opening the attached generation request. A cold valid H3 preview executes private qualification and can take tens of seconds. Since no host choice exists for a pinned target, that duplicated work kept the UI on `Checking placement` and prevented the real request from reaching the queue.

Owner-protected artifact verification remains enforced by server admission and execution. This change removes only the redundant advisory client probe for the narrow pinned-H3 case.

## Validation

- `nix develop -c bun test src/mobile/mobileGenerationRouting.test.ts src/mobile/MobileApp.test.ts` (324 passed)
- `nix develop -c bun run build:mobile`
- `nix develop -c bun run fmt:check`

Follow-up to #1388.