### PR TITLE
fix(windows): prevent nightly build starvation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,7 @@ jobs:
               - 'scripts/tests/desktop-candle-nix-source-hash.sh'
               - 'scripts/tests/desktop-dmg-packaging.sh'
               - 'scripts/tests/android-apk-distribution.sh'
+              - 'scripts/tests/windows-self-signing.sh'
               - 'scripts/tests/release-sync-pr.sh'
               - 'scripts/tests/changelog-fragments-contract.sh'
               - 'scripts/tests/crates-publish-contract.sh'
@@ -435,6 +436,7 @@ jobs:
           bash scripts/tests/desktop-candle-nix-source-hash.sh
           bash scripts/tests/desktop-dmg-packaging.sh
           bash scripts/tests/android-apk-distribution.sh
+          bash scripts/tests/windows-self-signing.sh
           bash scripts/tests/cuda-distribution-contract.sh
           python3 scripts/tests/cuda-ptx-parser-contract.py
           bash scripts/tests/install-cuda-arch.sh

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -326,6 +326,13 @@ jobs:
         run: >-
           bunx tauri build --features pulid --bundles nsis --ci -v
           --config src-tauri/tauri.windows-self-signed.conf.json
+      - name: Re-sign the final standalone desktop executable
+        if: github.event_name == 'push'
+        shell: pwsh
+        run: |
+          & ../scripts/sign-windows-binary.ps1 `
+            -ConfigPath src-tauri/tauri.windows-self-signed.conf.json `
+            -FilePath src-tauri/target/release/mold-desktop.exe
       - name: Verify Authenticode on the installer and standalone executable
         if: github.event_name == 'push'
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,9 @@ jobs:
   # every executable; its public half ships beside the artifacts so managed
   # machines can opt into trust without making the private key public.
   build-windows:
-    if: github.event_name != 'schedule'
+    # Rolling Windows artifacts have their own non-cancellable workflow. Keep
+    # this copy only for immutable tagged releases.
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
@@ -156,6 +158,13 @@ jobs:
         run: >-
           bunx tauri build --features pulid --bundles nsis --ci -v
           --config src-tauri/tauri.windows-self-signed.conf.json
+
+      - name: Re-sign the final standalone desktop executable
+        shell: pwsh
+        run: |
+          ./scripts/sign-windows-binary.ps1 `
+            -ConfigPath desktop/src-tauri/tauri.windows-self-signed.conf.json `
+            -FilePath desktop/src-tauri/target/release/mold-desktop.exe
 
       - name: Verify and package Windows artifacts
         shell: pwsh
@@ -823,7 +832,6 @@ jobs:
     needs:
       [
         build-macos,
-        build-windows,
         build-linux-sm86,
         build-linux-sm89,
         build-linux-sm100,
@@ -831,6 +839,9 @@ jobs:
         build-android-apk,
       ]
     runs-on: ubuntu-latest
+    concurrency:
+      group: rolling-native-publication
+      cancel-in-progress: false
     permissions:
       contents: write
     steps:
@@ -841,8 +852,32 @@ jobs:
           path: artifacts
           merge-multiple: true
 
+      # Windows rolls independently so a 40+ minute Windows compile cannot be
+      # starved by frequent main pushes. Preserve its newest completed assets
+      # in the shared checksum manifest when they already exist.
+      - name: Include latest completed Windows artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          for asset in \
+            Mold-windows-x64-self-signed.exe \
+            mold-windows-self-signing.cert.cer \
+            mold-x86_64-pc-windows-msvc-cpu.zip; do
+            gh release download latest \
+              --repo "$GITHUB_REPOSITORY" \
+              --pattern "$asset" \
+              --dir artifacts \
+              || echo "::notice::No completed rolling $asset exists yet"
+          done
+
       - name: Generate checksums
-        run: cd artifacts && sha256sum -- *.tar.gz *.zip *.exe *.cer *.apk > SHA256SUMS
+        run: |
+          cd artifacts
+          find . -maxdepth 1 -type f \
+            \( -name '*.tar.gz' -o -name '*.zip' -o -name '*.exe' -o -name '*.cer' -o -name '*.apk' \) \
+            -printf '%f\0' \
+            | sort -z \
+            | xargs -0 sha256sum -- > SHA256SUMS
 
       - name: Verify rolling release source is current main
         run: scripts/check-desktop-nightly-main-head.sh "$GITHUB_SHA"
@@ -860,9 +895,6 @@ jobs:
             artifacts/mold-x86_64-unknown-linux-gnu-cuda-sm89.tar.gz
             artifacts/mold-x86_64-unknown-linux-gnu-cuda-sm100.tar.gz
             artifacts/mold-x86_64-unknown-linux-gnu-cuda-sm120.tar.gz
-            artifacts/mold-x86_64-pc-windows-msvc-cpu.zip
-            artifacts/Mold-windows-x64-self-signed.exe
-            artifacts/mold-windows-self-signing.cert.cer
             artifacts/Mold-android.apk
             artifacts/SHA256SUMS
           body: |
@@ -882,6 +914,11 @@ jobs:
             | Linux x86_64 | CUDA — RTX 40-series (Ada Lovelace) | `mold-x86_64-unknown-linux-gnu-cuda-sm89.tar.gz` |
             | Linux x86_64 | CUDA — B200 / B300 (datacenter Blackwell; simulated, not hardware-qualified) | `mold-x86_64-unknown-linux-gnu-cuda-sm100.tar.gz` |
             | Linux x86_64 | CUDA — RTX 50-series (consumer Blackwell) | `mold-x86_64-unknown-linux-gnu-cuda-sm120.tar.gz` |
+
+            Windows artifacts are published independently from the newest
+            completed non-cancellable Windows build and may briefly lag the
+            aggregate commit above. `mold-windows-nightly.json` records their
+            exact source commit and hashes.
 
             GH200, GB200, and GB300 require future linux/arm64 artifacts and are unsupported.
             Current Linux release archives and container images are linux/amd64 only.

--- a/.github/workflows/windows-nightly.yml
+++ b/.github/workflows/windows-nightly.yml
@@ -1,0 +1,212 @@
+name: Windows Nightly
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# A Windows release build takes longer than the normal main-branch merge
+# cadence. Keep the running build alive; GitHub retains at most one pending run
+# in this group and replaces that pending run with the newest commit.
+concurrency:
+  group: windows-nightly
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            . -> target
+            desktop/src-tauri -> desktop/src-tauri/target
+          key: windows-nightly
+          cache-on-failure: true
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install protoc and nasm
+        shell: pwsh
+        env:
+          PROTOC_VERSION: "29.3"
+        run: |
+          $zip = "$env:RUNNER_TEMP\protoc.zip"
+          $dest = "$env:RUNNER_TEMP\protoc"
+          $url = "https://github.com/protocolbuffers/protobuf/releases/download/v$env:PROTOC_VERSION/protoc-$env:PROTOC_VERSION-win64.zip"
+          Invoke-WebRequest -Uri $url -OutFile $zip
+          Expand-Archive -Path $zip -DestinationPath $dest -Force
+          "$dest\bin" >> $env:GITHUB_PATH
+          "PROTOC=$dest\bin\protoc.exe" >> $env:GITHUB_ENV
+          choco install --no-progress -y nasm
+          "$env:ProgramFiles\NASM" >> $env:GITHUB_PATH
+          & "$dest\bin\protoc.exe" --version
+          if (-not (Test-Path "$env:ProgramFiles\NASM\nasm.exe")) {
+            throw 'nasm was not installed'
+          }
+
+      - name: Build embedded web SPA
+        shell: bash
+        run: ./scripts/ensure-web-dist.sh
+
+      - name: Import the self-signed Windows certificate
+        id: windows-signing
+        shell: pwsh
+        env:
+          WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
+          WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
+        run: |
+          $certificate = Join-Path $env:RUNNER_TEMP 'mold-windows-self-signing.cert.cer'
+          $thumbprint = & ./scripts/import-windows-signing-certificate.ps1 `
+            -ConfigPath desktop/src-tauri/tauri.windows-self-signed.conf.json `
+            -PublicCertificatePath $certificate
+          "thumbprint=$thumbprint" >> $env:GITHUB_OUTPUT
+          "WINDOWS_PUBLIC_CERTIFICATE=$certificate" >> $env:GITHUB_ENV
+
+      - name: Build and sign the Windows CLI
+        shell: pwsh
+        run: |
+          cargo build --release -p mold-ai `
+            --features preview,discord,expand,tui,webp,metrics,mdns,pulid
+          ./scripts/sign-windows-binary.ps1 `
+            -ConfigPath desktop/src-tauri/tauri.windows-self-signed.conf.json `
+            -FilePath target/release/mold.exe
+
+      - name: Build the self-signed Windows desktop installer
+        working-directory: desktop
+        run: >-
+          bunx tauri build --features pulid --bundles nsis --ci -v
+          --config src-tauri/tauri.windows-self-signed.conf.json
+
+      # Tauri signs while bundling, then may rewrite the standalone executable.
+      # Re-sign the final bytes that verification and publication consume.
+      - name: Re-sign the final standalone desktop executable
+        shell: pwsh
+        run: |
+          ./scripts/sign-windows-binary.ps1 `
+            -ConfigPath desktop/src-tauri/tauri.windows-self-signed.conf.json `
+            -FilePath desktop/src-tauri/target/release/mold-desktop.exe
+
+      - name: Verify and package Windows artifacts
+        shell: pwsh
+        run: |
+          $installer = Get-ChildItem `
+            desktop/src-tauri/target/release/bundle/nsis `
+            -Filter *.exe `
+            -ErrorAction Stop | Select-Object -First 1
+          if (-not $installer) { throw 'no NSIS installer was produced' }
+
+          ./scripts/verify-windows-signatures.ps1 `
+            -CertificatePath $env:WINDOWS_PUBLIC_CERTIFICATE `
+            -ExpectedThumbprint '${{ steps.windows-signing.outputs.thumbprint }}' `
+            -FilePath @(
+              'target/release/mold.exe',
+              'desktop/src-tauri/target/release/mold-desktop.exe',
+              $installer.FullName
+            )
+
+          Copy-Item $installer.FullName 'Mold-windows-x64-self-signed.exe'
+          Copy-Item $env:WINDOWS_PUBLIC_CERTIFICATE 'mold-windows-self-signing.cert.cer'
+          Compress-Archive `
+            -Path @('target/release/mold.exe', 'mold-windows-self-signing.cert.cer') `
+            -DestinationPath 'mold-x86_64-pc-windows-msvc-cpu.zip'
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: mold-windows-nightly-${{ github.sha }}
+          path: |
+            Mold-windows-x64-self-signed.exe
+            mold-windows-self-signing.cert.cer
+            mold-x86_64-pc-windows-msvc-cpu.zip
+          retention-days: 14
+
+  publish-windows:
+    needs: build-windows
+    runs-on: ubuntu-latest
+    concurrency:
+      group: rolling-native-publication
+      cancel-in-progress: false
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: mold-windows-nightly-${{ github.sha }}
+          path: artifacts
+
+      - name: Update rolling Windows artifacts and checksums
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if ! gh release view latest --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release create latest \
+              --repo "$GITHUB_REPOSITORY" \
+              --target main \
+              --title "Latest Build" \
+              --prerelease \
+              --notes "Rolling pre-release built from main."
+          fi
+
+          mkdir -p artifacts/current-checksums
+          if gh release download latest \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern SHA256SUMS \
+            --dir artifacts/current-checksums; then
+            cp artifacts/current-checksums/SHA256SUMS artifacts/SHA256SUMS
+          else
+            : > artifacts/SHA256SUMS
+          fi
+
+          awk '
+            $2 != "Mold-windows-x64-self-signed.exe" &&
+            $2 != "mold-windows-self-signing.cert.cer" &&
+            $2 != "mold-x86_64-pc-windows-msvc-cpu.zip"
+          ' artifacts/SHA256SUMS > artifacts/SHA256SUMS.next
+          mv artifacts/SHA256SUMS.next artifacts/SHA256SUMS
+          (
+            cd artifacts
+            sha256sum -- \
+              Mold-windows-x64-self-signed.exe \
+              mold-windows-self-signing.cert.cer \
+              mold-x86_64-pc-windows-msvc-cpu.zip >> SHA256SUMS
+            sort -k2,2 -o SHA256SUMS SHA256SUMS
+          )
+
+          jq -n \
+            --arg source_sha "$GITHUB_SHA" \
+            --arg built_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --arg installer_sha "$(sha256sum artifacts/Mold-windows-x64-self-signed.exe | cut -d' ' -f1)" \
+            --arg certificate_sha "$(sha256sum artifacts/mold-windows-self-signing.cert.cer | cut -d' ' -f1)" \
+            --arg cli_sha "$(sha256sum artifacts/mold-x86_64-pc-windows-msvc-cpu.zip | cut -d' ' -f1)" \
+            '{
+              schema_version: "mold.windows-nightly.v1",
+              source_sha: $source_sha,
+              built_at: $built_at,
+              assets: {
+                "Mold-windows-x64-self-signed.exe": $installer_sha,
+                "mold-windows-self-signing.cert.cer": $certificate_sha,
+                "mold-x86_64-pc-windows-msvc-cpu.zip": $cli_sha
+              }
+            }' > artifacts/mold-windows-nightly.json
+
+          gh release upload latest \
+            artifacts/Mold-windows-x64-self-signed.exe \
+            artifacts/mold-windows-self-signing.cert.cer \
+            artifacts/mold-x86_64-pc-windows-msvc-cpu.zip \
+            artifacts/mold-windows-nightly.json \
+            --repo "$GITHUB_REPOSITORY" \
+            --clobber
+          gh release upload latest artifacts/SHA256SUMS \
+            --repo "$GITHUB_REPOSITORY" \
+            --clobber

--- a/changelog.d/windows-nightly-starvation.md
+++ b/changelog.d/windows-nightly-starvation.md
@@ -1,0 +1,6 @@
+- **Windows nightlies finish even while `main` stays busy.** Windows CLI and
+  desktop artifacts now build in a dedicated non-cancellable workflow: the
+  active build completes while GitHub keeps only the newest pending commit.
+  Rolling publication preserves the shared checksums, tagged releases retain
+  their existing immutable build, and the final standalone desktop executable
+  is explicitly re-signed after Tauri finishes bundling it.

--- a/scripts/tests/cuda-distribution-contract.sh
+++ b/scripts/tests/cuda-distribution-contract.sh
@@ -182,7 +182,7 @@ for release_job in release-latest release-version release-native; do
 done
 require_release_job_need "release-version" "build-macos"
 require_release_job_need "release-version" "build-desktop-dmg"
-require_release_job_need "release-latest" "build-windows"
+reject_release_job_need "release-latest" "build-windows"
 for target in 86 89 100 120; do
   require_release_job_need "release-native" "build-linux-sm${target}"
 done
@@ -354,7 +354,11 @@ require_text "flake.nix" \
 require_release_job_need "publish" "release-version"
 require_release_job_need "publish-aur" "release-native"
 require_release_job_text "release-latest" \
-  'sha256sum -- *.tar.gz *.zip *.exe *.cer *.apk > SHA256SUMS'
+  'Include latest completed Windows artifacts'
+require_release_job_text "release-latest" \
+  "-printf '%f\\0'"
+require_release_job_text "release-latest" \
+  'xargs -0 sha256sum -- > SHA256SUMS'
 require_release_job_text "release-version" \
   'sha256sum -- *.tar.gz *.dmg *.zip > SHA256SUMS'
 for checksum_job in release-native release-containers; do

--- a/scripts/tests/windows-self-signing.sh
+++ b/scripts/tests/windows-self-signing.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
 workflow="$root/.github/workflows/desktop.yml"
 release="$root/.github/workflows/release.yml"
+nightly="$root/.github/workflows/windows-nightly.yml"
 config="$root/desktop/src-tauri/tauri.windows-self-signed.conf.json"
 docs="$root/website/guide/desktop.md"
 home="$root/website/index.md"
@@ -30,7 +31,8 @@ grep -Fq 'tauri.windows-self-signed.conf.json' "$workflow"
 grep -Fq 'verify-windows-signatures.ps1' "$workflow"
 grep -Fq 'mold-desktop-windows-x64-self-signed' "$workflow"
 grep -Fq 'build-windows:' "$release"
-grep -Fq 'require_release_job_need "release-latest" "build-windows"' \
+grep -Fq "if: startsWith(github.ref, 'refs/tags/v')" "$release"
+grep -Fq 'reject_release_job_need "release-latest" "build-windows"' \
   "$root/scripts/tests/cuda-distribution-contract.sh"
 grep -Fq 'require_release_job_need "release-native" "build-windows"' \
   "$root/scripts/tests/cuda-distribution-contract.sh"
@@ -41,6 +43,17 @@ grep -Fq 'Import-PfxCertificate' "$importer"
 grep -Fq 'Get-AuthenticodeSignature' "$verifier"
 grep -Fq 'windows-signature-verifier.ps1' "$workflow"
 grep -Fq 'New-SelfSignedCertificate' "$verifier_test"
+grep -Fq 'group: windows-nightly' "$nightly"
+grep -Fq 'cancel-in-progress: false' "$nightly"
+grep -Fq 'workflow_dispatch:' "$nightly"
+grep -Fq 'group: rolling-native-publication' "$nightly"
+grep -Fq 'Mold-windows-x64-self-signed.exe' "$nightly"
+grep -Fq 'mold-x86_64-pc-windows-msvc-cpu.zip' "$nightly"
+grep -Fq 'mold-windows-nightly.json' "$nightly"
+grep -Fq 'mold.windows-nightly.v1' "$nightly"
+grep -Fq 'Re-sign the final standalone desktop executable' "$nightly"
+grep -Fq 'Re-sign the final standalone desktop executable' "$workflow"
+grep -Fq 'Re-sign the final standalone desktop executable' "$release"
 
 # The verifier must never write a certificate store. Importing the self-signed
 # certificate into Cert:\CurrentUser\Root to force a `Valid` status needs


### PR DESCRIPTION
## Summary

- move rolling Windows CLI/NSIS production into a dedicated workflow whose running build is never cancelled while GitHub retains only the newest pending commit
- keep tagged Windows builds in `release.yml`, remove Windows from the cancellation-prone aggregate rolling dependency chain, and serialize shared checksum publication
- explicitly re-sign the final standalone desktop executable after Tauri bundling, fixing the `NotSigned` failure observed after #1379 merged
- publish `mold-windows-nightly.json` with the exact source SHA and artifact hashes; support manual dispatch without requiring it

## Validation

- `actionlint .github/workflows/*.yml`
- `bash scripts/tests/windows-self-signing.sh`
- `bash scripts/tests/android-apk-distribution.sh`
- `bash scripts/tests/ci-routing-contract.sh`
- `bash scripts/tests/changelog-fragments-contract.sh`
- `shellcheck scripts/tests/windows-self-signing.sh scripts/tests/cuda-distribution-contract.sh`
- `git diff --check origin/main...HEAD`

The broader CUDA distribution contract passed its updated workflow assertions, then its ELF fixture phase could not run locally on macOS: native fixtures are Mach-O, while GNU `readelf` correctly rejects them. CI runs that phase on Linux.
