### PR TITLE
fix(windows): restrict nightly publication to main

### DIFF
--- a/.github/workflows/windows-nightly.yml
+++ b/.github/workflows/windows-nightly.yml
@@ -17,6 +17,7 @@ permissions:
 
 jobs:
   build-windows:
+    if: github.ref == 'refs/heads/main'
     runs-on: windows-latest
     timeout-minutes: 120
     steps:
@@ -130,6 +131,7 @@ jobs:
 
   publish-windows:
     needs: build-windows
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     concurrency:
       group: rolling-native-publication
@@ -149,6 +151,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          git fetch --quiet --no-tags origin refs/heads/main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" FETCH_HEAD; then
+            echo "Windows Nightly source $GITHUB_SHA is not in main history." >&2
+            exit 1
+          fi
+
           if ! gh release view latest --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             gh release create latest \
               --repo "$GITHUB_REPOSITORY" \

--- a/changelog.d/windows-nightly-main-only.md
+++ b/changelog.d/windows-nightly-main-only.md
@@ -1,1 +1,1 @@
-Prevent manual Windows Nightly runs from signing or publishing non-main refs, and reject sources outside current main history before they update the rolling release.
+- **Restrict Windows Nightly publication to main.** Prevent manual runs from signing or publishing non-main refs, and reject sources outside current main history before they update the rolling release.

--- a/changelog.d/windows-nightly-main-only.md
+++ b/changelog.d/windows-nightly-main-only.md
@@ -1,0 +1,1 @@
+Prevent manual Windows Nightly runs from signing or publishing non-main refs, and reject sources outside current main history before they update the rolling release.

--- a/scripts/tests/windows-self-signing.sh
+++ b/scripts/tests/windows-self-signing.sh
@@ -12,6 +12,15 @@ importer="$root/scripts/import-windows-signing-certificate.ps1"
 verifier="$root/scripts/verify-windows-signatures.ps1"
 verifier_test="$root/scripts/tests/windows-signature-verifier.ps1"
 
+nightly_job_text() {
+  local job="$1"
+  awk -v job="$job" '
+    $0 == "  " job ":" { in_job = 1 }
+    in_job && /^  [[:alnum:]_-]+:$/ && $0 != "  " job ":" { exit }
+    in_job { print }
+  ' "$nightly"
+}
+
 thumbprint=$(jq -r '.bundle.windows.certificateThumbprint' "$config")
 [[ "$thumbprint" =~ ^[A-F0-9]{40}$ ]] || {
   echo "self-signing thumbprint must be a 40-character uppercase SHA-1 hash" >&2
@@ -54,6 +63,53 @@ grep -Fq 'mold.windows-nightly.v1' "$nightly"
 grep -Fq 'Re-sign the final standalone desktop executable' "$nightly"
 grep -Fq 'Re-sign the final standalone desktop executable' "$workflow"
 grep -Fq 'Re-sign the final standalone desktop executable' "$release"
+
+build_job="$(nightly_job_text build-windows)"
+publish_job="$(nightly_job_text publish-windows)"
+[[ "$build_job" == *"if: github.ref == 'refs/heads/main'"* ]] || {
+  echo "Windows Nightly must not expose signing secrets to non-main dispatches" >&2
+  exit 1
+}
+[[ "$publish_job" == *"if: github.ref == 'refs/heads/main'"* ]] || {
+  echo "Windows Nightly must not publish non-main dispatches" >&2
+  exit 1
+}
+[[ "$publish_job" == *'needs: build-windows'* ]] || {
+  echo "Windows Nightly publication must depend on its exact build" >&2
+  exit 1
+}
+# shellcheck disable=SC2016
+[[ "$publish_job" == *'git merge-base --is-ancestor "$GITHUB_SHA" FETCH_HEAD'* ]] || {
+  echo "Windows Nightly must reject sources outside main history" >&2
+  exit 1
+}
+
+ancestry_line="$(
+  # shellcheck disable=SC2016
+  grep -nF 'git merge-base --is-ancestor "$GITHUB_SHA" FETCH_HEAD' "$nightly" |
+    cut -d: -f1
+)"
+release_create_line="$(
+  grep -n -m1 'gh release create latest' "$nightly" |
+    cut -d: -f1
+)"
+first_upload_line="$(
+  grep -n -m1 'gh release upload latest' "$nightly" |
+    cut -d: -f1
+)"
+checksum_upload_line="$(
+  grep -n 'gh release upload latest artifacts/SHA256SUMS' "$nightly" |
+    cut -d: -f1
+)"
+[[ "$ancestry_line" -lt "$release_create_line" \
+  && "$ancestry_line" -lt "$first_upload_line" ]] || {
+  echo "Windows Nightly ancestry guard must precede release mutation" >&2
+  exit 1
+}
+[[ "$checksum_upload_line" -gt "$first_upload_line" ]] || {
+  echo "Windows Nightly must publish SHA256SUMS after its Windows assets" >&2
+  exit 1
+}
 
 # The verifier must never write a certificate store. Importing the self-signed
 # certificate into Cert:\CurrentUser\Root to force a `Valid` status needs


### PR DESCRIPTION
## Summary

- prevent non-main `workflow_dispatch` runs from allocating the secret-bearing Windows build job
- prevent non-main refs from publishing to the official rolling Nightly release
- accept completed builds whose source remains in current main history, preserving forward progress when main advances during the 45-minute build
- reject branch, tag, or force-pushed-away sources before any release creation or upload
- add job-scoped contract assertions for main gates, exact build dependency, ancestry-before-mutation, and checksum-last ordering

## Validation

- `actionlint .github/workflows/windows-nightly.yml`
- `bash scripts/tests/windows-self-signing.sh`
- `bash scripts/tests/changelog-fragments-contract.sh`
- `shellcheck scripts/tests/windows-self-signing.sh`
- live ancestry check: merged main SHA accepted; PR-only SHA rejected
- `git diff --check`

## Peer review

Independent subagent review found no remaining blockers after the guard changed from exact-head equality to main-ancestry validation. The review confirmed non-main dispatches cannot reach signing secrets or publication, forward progress is preserved for older commits still in main history, validation precedes all release mutation, and checksums remain last.