### PR TITLE
test(ltx2): capture Metal INT8 verification evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,8 @@ jobs:
               - 'scripts/tests/regression-matrix-source-image.sh'
               - 'scripts/tests/regression-matrix-transient-retry.sh'
               - 'scripts/tests/wan-regression-matrix.sh'
+              - 'scripts/capture-ltx25-metal-verification.sh'
+              - 'scripts/tests/ltx25-metal-verification.sh'
               - 'scripts/tests/minimax-h3-private-uat-release-contract.sh'
               - 'scripts/qualify-cuda-sm86.sh'
               - 'docs/qualification/**'
@@ -449,6 +451,7 @@ jobs:
           bash scripts/tests/regression-matrix-source-image.sh
           bash scripts/tests/regression-matrix-transient-retry.sh
           bash scripts/tests/wan-regression-matrix.sh
+          bash scripts/tests/ltx25-metal-verification.sh
       - name: Test MiniMax H3 private-UAT release contract
         if: needs.changes.outputs.release == 'true'
         run: bash scripts/tests/minimax-h3-private-uat-release-contract.sh

--- a/docs/ltx-2.5.md
+++ b/docs/ltx-2.5.md
@@ -110,3 +110,16 @@ The implementation and parity fixtures are pinned to:
 Retained parity artifacts, logs, prompts, seeds, and run manifests live under
 `/Volumes/ExternalStorage/mold2/output/verification/ltx-2.5/`. Downloaded model
 files remain under `/Volumes/ExternalStorage/mold2` and are not cleanup data.
+
+Run `scripts/capture-ltx25-metal-verification.sh` on Apple Silicon to capture a
+machine-readable INT8 Metal report. The capture validates the pinned upstream
+clones, download-time SHA-256 markers, decoded retained media, and focused Rust
+parity/regression gates. It only reads existing model and media files; reports
+and logs are added under the verification directory without deleting renders.
+
+The executable compact-checkpoint A/B row is Mold versus ComfyUI on MPS. The
+official PyTorch and Diffusers BF16 pipelines remain static tensor/config
+oracles because neither directly loads the Comfy INT8 ConvRot checkpoint.
+CUDA qualification is performed on its dedicated host. BF16 remains available
+and retained, but a stopped BF16 runtime run is recorded as operator-deferred,
+not misreported as passing.

--- a/scripts/capture-ltx25-metal-verification.sh
+++ b/scripts/capture-ltx25-metal-verification.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+mold_home="${MOLD_HOME:-/Volumes/ExternalStorage/mold2}"
+references_root="${LTX25_REFERENCES_ROOT:-$repo_root/tmp}"
+verification_root="${LTX25_VERIFICATION_ROOT:-$mold_home/output/verification/ltx-2.5}"
+audio_video="${LTX25_AUDIO_VIDEO:-$mold_home/output/ltx25-final-int8-metal-audio-seed-25026.mp4}"
+silent_video="${LTX25_SILENT_VIDEO:-$verification_root/phase2-int8-metal-smoke-seed-25025.apng}"
+timestamp="${LTX25_CAPTURE_TIMESTAMP:-$(date -u +%Y%m%dT%H%M%SZ)}"
+report="${LTX25_REPORT:-$verification_root/ltx25-metal-int8-verification-$timestamp.json}"
+skip_gates="${LTX25_SKIP_GATES:-0}"
+contract_test="${LTX25_CONTRACT_TEST:-0}"
+database="${MOLD_DB_PATH:-$mold_home/mold.db}"
+
+fail() {
+  echo "LTX-2.5 Metal verification failed: $*" >&2
+  exit 1
+}
+
+for command in ffprobe git jq shasum sqlite3; do
+  command -v "$command" >/dev/null 2>&1 || fail "missing command: $command"
+done
+
+if [[ "$contract_test" == 1 ]]; then
+  [[ "${LTX25_ALLOW_TEST_HOME:-0}" == 1 && "$skip_gates" == 1 ]] \
+    || fail "contract test mode requires isolated home and skipped gates"
+else
+  [[ "${LTX25_ALLOW_TEST_HOME:-0}" != 1 && "$skip_gates" != 1 ]] \
+    || fail "test overrides require LTX25_CONTRACT_TEST=1"
+  [[ -z "${LTX25_HOST_JSON:-}" ]] \
+    || fail "injected host JSON requires LTX25_CONTRACT_TEST=1"
+  [[ "$mold_home" == /Volumes/ExternalStorage/mold2 ]] \
+    || fail "MOLD_HOME must be /Volumes/ExternalStorage/mold2"
+  [[ "$(uname -s)" == Darwin && "$(uname -m)" == arm64 ]] \
+    || fail "runtime capture is restricted to Apple Silicon Metal"
+fi
+
+mkdir -p "$verification_root" "$(dirname "$report")"
+evidence_dir="${report%.json}.d"
+mkdir -p "$evidence_dir"
+
+file_size() {
+  stat -c '%s' "$1" 2>/dev/null || stat -f '%z' "$1"
+}
+
+file_sha256() {
+  shasum -a 256 "$1" | awk '{print $1}'
+}
+
+assets='[]'
+record_asset() {
+  local role="$1" relative="$2" expected_sha="$3"
+  local path
+  path="$mold_home/$relative"
+  local marker="$path.sha256-verified"
+  [[ -s "$path" ]] || fail "missing $role asset: $path"
+  [[ -f "$marker" ]] || fail "missing verified SHA marker: $marker"
+  local marker_sha
+  marker_sha="$(tr -d '[:space:]' <"$marker")"
+  [[ "$marker_sha" == "$expected_sha" ]] \
+    || fail "$role marker mismatch: expected $expected_sha, found $marker_sha"
+  local actual_sha=""
+  local identity_proof="contract test: current bytes not qualified"
+  if [[ "$contract_test" != 1 ]]; then
+    actual_sha="$(file_sha256 "$path")"
+    [[ "$actual_sha" == "$expected_sha" ]] \
+      || fail "$role byte hash mismatch: expected $expected_sha, found $actual_sha"
+    identity_proof="current bytes rehashed and matched manifest"
+  fi
+  assets="$(jq -c \
+    --arg role "$role" --arg path "$path" --arg expected_sha "$expected_sha" \
+    --arg actual_sha "$actual_sha" --arg identity_proof "$identity_proof" \
+    --argjson bytes "$(file_size "$path")" \
+    '. + [{role: $role, path: $path, bytes: $bytes,
+      expected_sha256: $expected_sha,
+      actual_sha256: (if $actual_sha == "" then null else $actual_sha end),
+      identity_proof: $identity_proof}]' <<<"$assets")"
+}
+
+record_asset transformer \
+  models/ltx-2.5-22b-distilled-int8-conv/diffusion_models/ltx-2.5-22b-distilled-transformer-comfy-int8-convrot.safetensors \
+  c4279eeff115cbeaca494bd2183e7d768c38fe85a184dc6afbb7159157c44334
+record_asset gemma4 \
+  models/shared/ltx2/text_encoders/gemma4-12b-with-proj-ltx-2.5-comfy-int8-convrot.safetensors \
+  6ce688a0aa98a5fa36a9f1e6c3f42152a498cc2b53ee8c15674c64244f91487f
+record_asset video_vae_conv \
+  models/shared/ltx2/vae/ltx-2.5-video-vae-conv-bf16.safetensors \
+  685b06ee3d9b2039647698fc4ea33175112462fc374e2777312c907897dfce8d
+record_asset audio_vae \
+  models/shared/ltx2/vae/ltx-2.5-audio-vae-bf16.safetensors \
+  c52733d37f6a7fb7949c3dc0fb468c6cb2169e4d836983a73babb9f0d54837a5
+record_asset duration_head \
+  models/shared/ltx2/model_patches/ltx-2.5-duration-head-bf16.safetensors \
+  2ec71e4206ed365d015f00c05a48caccfb0ee862986809d06ae376c09f5d9190
+record_asset spatial_upscaler \
+  models/shared/ltx2/latent_upscale_models/ltx-2.5-latent-spatial-upscaler-x2-bf16-1.0.safetensors \
+  eb5a71fe4068ee87ccdb1c3aa635e547ca76bd2d30ae20ae889f2c325c0677e8
+record_asset temporal_upscaler \
+  models/shared/ltx2/latent_upscale_models/ltx-2.5-latent-temporal-upscaler-x2-bf16-1.0.safetensors \
+  2bc3300f2b3c3c1834d72164fbf13a3b9fd73e5a741e8a2c3f4035f89a75c3fe
+
+references='[]'
+record_reference() {
+  local name="$1" expected="$2" path
+  path="$references_root/$1"
+  [[ -d "$path/.git" ]] || fail "missing pinned reference clone: $path"
+  local actual
+  actual="$(git -C "$path" rev-parse HEAD)"
+  [[ "$actual" == "$expected" ]] \
+    || fail "$name is at $actual, expected $expected"
+  [[ -z "$(git -C "$path" status --porcelain)" ]] \
+    || fail "$name reference clone has uncommitted or untracked changes"
+  references="$(jq -c --arg name "$name" --arg path "$path" --arg commit "$actual" \
+    '. + [{name: $name, path: $path, commit: $commit, status: "pinned_clean"}]' \
+    <<<"$references")"
+}
+
+record_reference ltx-2-upstream 400fd31054597515f47125691032c04b1c3ee24e
+record_reference comfyui-ltxvideo-upstream 15d09abb5a187a8dcaea2fc31fe51ee96e6c9d0d
+record_reference comfyui-upstream a1079ba16f2674734b065eb036fbfdddaa321a4d
+record_reference diffusers-upstream 95c0d467cc2a4770b71fa25a117320377e6eb08f
+
+media='[]'
+record_media() {
+  local label="$1" path="$2" seed="$3" prompt="$4" expects_audio="$5"
+  [[ -s "$path" ]] || fail "missing retained media: $path"
+  local probe="$evidence_dir/$label.ffprobe.json"
+  ffprobe -v error -count_frames -show_entries \
+    format=filename,size,duration:stream=index,codec_name,profile,codec_type,width,height,pix_fmt,r_frame_rate,nb_frames,nb_read_frames,sample_rate,channels \
+    -of json "$path" >"$probe"
+  jq -e '.streams[] | select(.codec_type == "video" and .width == 256 and .height == 256)' \
+    "$probe" >/dev/null || fail "$label is not decoded 256x256 video"
+  jq -e '.streams[] | select(.codec_type == "video" and .r_frame_rate == "24/1"
+    and ((.nb_frames // .nb_read_frames) | tonumber) == 9)' "$probe" >/dev/null \
+    || fail "$label is not exactly 9 frames at 24 fps"
+  if [[ "$expects_audio" == true ]]; then
+    jq -e '.streams[] | select(.codec_type == "audio" and .codec_name == "aac"
+      and .sample_rate == "48000" and .channels == 2)' "$probe" >/dev/null \
+      || fail "$label is missing stereo 48 kHz AAC"
+  else
+    jq -e '[.streams[] | select(.codec_type == "audio")] | length == 0' "$probe" >/dev/null \
+      || fail "$label unexpectedly contains audio"
+  fi
+  local filename output_dir escaped_filename rows row
+  filename="$(basename "$path")"
+  output_dir="$(dirname "$path")"
+  escaped_filename="${filename//\'/\'\'}"
+  rows="$(sqlite3 -json "$database" \
+    "SELECT id, filename, output_dir, format, title, prompt, model, seed, steps,
+      guidance, width, height, frames, fps, generation_time_ms, backend, hostname,
+      source, metadata_synthetic, file_size_bytes, metadata_json
+     FROM generations WHERE filename = '$escaped_filename'")"
+  row="$(jq -c --arg output_dir "$output_dir" \
+    '[.[] | select(.output_dir == $output_dir)] | if length == 1 then .[0] else empty end' \
+    <<<"$rows")"
+  [[ -n "$row" ]] || fail "$label has no unique matching generation database row"
+  jq -e --arg prompt "$prompt" --arg model "ltx-2.5-22b-distilled:int8-conv" \
+    --arg format "${path##*.}" --argjson seed "$seed" --argjson audio "$expects_audio" \
+    --argjson bytes "$(file_size "$path")" '
+      .prompt == $prompt and .model == $model and .seed == $seed
+      and .width == 256 and .height == 256 and .steps == 1 and .guidance == 1
+      and .frames == 9 and .fps == 24 and .format == $format
+      and .backend == "metal" and .source == "cli" and .metadata_synthetic == 0
+      and .file_size_bytes == $bytes
+      and ((.metadata_json | fromjson).enable_audio == $audio)
+      and ((.metadata_json | fromjson).output_format == $format)
+    ' <<<"$row" >/dev/null || fail "$label generation database provenance mismatch"
+  media="$(jq -c \
+    --arg label "$label" --arg path "$path" --arg sha "$(file_sha256 "$path")" \
+    --arg prompt "$prompt" --argjson seed "$seed" --argjson audio "$expects_audio" \
+    --argjson generation "$row" --slurpfile probe "$probe" \
+    '. + [{label: $label, path: $path, sha256: $sha, prompt: $prompt, seed: $seed,
+      model: "ltx-2.5-22b-distilled:int8-conv", settings: {
+        width: 256, height: 256, frames: 9, fps: 24, steps: 1, guidance: 1,
+        audio: $audio}, generation: $generation, ffprobe: $probe[0],
+      retained_in_library: true}]' <<<"$media")"
+}
+
+record_media audio_video "$audio_video" 25026 \
+  'A small brass automaton drummer performing in gentle rain, locked camera, cinematic reflections' true
+record_media silent_video "$silent_video" 25025 \
+  'A red fox walking through sunlit desert grass, cinematic natural motion' false
+
+gates='[]'
+run_gate() {
+  local label="$1"
+  shift
+  local log="$evidence_dir/$label.log" started ended status=passed exit_code=0
+  started="$(date +%s)"
+  if [[ "$skip_gates" == 1 ]]; then
+    status=skipped_contract_test
+    : >"$log"
+  else
+    set +e
+    (cd "$repo_root" && "$@") >"$log" 2>&1
+    exit_code=$?
+    set -e
+    [[ "$exit_code" -eq 0 ]] || status=failed
+  fi
+  ended="$(date +%s)"
+  gates="$(jq -c --arg label "$label" --arg status "$status" \
+    --arg command "$(printf '%q ' "$@")" --arg log "$log" \
+    --arg log_sha "$(file_sha256 "$log")" --argjson exit_code "$exit_code" \
+    --argjson seconds "$((ended - started))" \
+    '. + [{label: $label, status: $status, exit_code: $exit_code, seconds: $seconds,
+      command: $command, log_path: $log, log_sha256: $log_sha}]' <<<"$gates")"
+  [[ "$status" != failed ]] || fail "$label failed; see $log"
+}
+
+run_gate core_ltx25_manifest nix develop -c cargo test -p mold-ai-core ltx25_manifest
+run_gate inference_ltx25_oracles nix develop -c cargo test -p mold-ai-inference ltx25
+run_gate inference_ltx2_regression nix develop -c cargo test -p mold-ai-inference ltx2
+
+host='{}'
+if [[ -n "${LTX25_HOST_JSON:-}" ]]; then
+  host="$LTX25_HOST_JSON"
+else
+  displays="$(system_profiler SPDisplaysDataType -json)"
+  host="$(jq -c --arg os "$(sw_vers -productVersion)" --arg arch "$(uname -m)" \
+    '{os: "macOS", os_version: $os, arch: $arch,
+      metal_devices: [.SPDisplaysDataType[] | {name: .sppci_model,
+        metal_support: .spdisplays_metal, vram: .spdisplays_vram_shared}]}' <<<"$displays")"
+fi
+
+source_commit="$(git -C "$repo_root" rev-parse HEAD)"
+qualification_status=passed
+[[ "$contract_test" != 1 ]] || qualification_status=not_qualified_contract_test
+tmp_report="$report.tmp.$$"
+jq -n \
+  --arg captured_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --arg source_commit "$source_commit" --arg mold_home "$mold_home" \
+  --arg qualification_status "$qualification_status" \
+  --argjson host "$host" --argjson assets "$assets" --argjson references "$references" \
+  --argjson media "$media" --argjson gates "$gates" \
+  '{schema_version: "mold.ltx25.metal-int8.verification.v1", captured_at: $captured_at,
+    source_commit: $source_commit, mold_home: $mold_home, backend_scope: "metal",
+    default_model: "ltx-2.5-22b-distilled:int8-conv", host: $host,
+    assets: $assets, references: $references, gates: $gates, media: $media,
+    comparison_matrix: [
+      {implementation: "Mold", checkpoint: "distilled INT8 ConvRot", backend: "Metal",
+        status: $qualification_status,
+        evidence: "database-bound retained decoded audio and silent media"},
+      {implementation: "ComfyUI", checkpoint: "distilled INT8 ConvRot", backend: "MPS",
+        status: "pending", evidence: "exact-weight executable A/B remains required"},
+      {implementation: "official PyTorch", checkpoint: "BF16", backend: "Metal",
+        status: "static_oracle_only", evidence: "compact Comfy INT8 is not directly executable"},
+      {implementation: "Diffusers", checkpoint: "BF16", backend: "Metal",
+        status: "static_oracle_only", evidence: "compact Comfy INT8 is not directly executable"},
+      {implementation: "Mold", checkpoint: "BF16", backend: "Metal",
+        status: "operator_deferred", evidence: "runtime stopped; downloaded assets retained"},
+      {implementation: "Mold", checkpoint: "all", backend: "CUDA",
+        status: "separate_host_deferred", evidence: "outside this Apple Metal qualification"}
+    ], preservation: {downloaded_models_deleted: false, rendered_media_deleted: false}}' \
+  >"$tmp_report"
+mv "$tmp_report" "$report"
+echo "$report"

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -281,7 +281,8 @@ if wants contracts; then
                   minimax-h3-attention-release-contract bench-qwen-parse \
                   regression-matrix-aggregate-failures regression-matrix-concurrency \
                   regression-matrix-family-sizing regression-matrix-source-image \
-                  regression-matrix-transient-retry wan-regression-matrix; do
+                  regression-matrix-transient-retry wan-regression-matrix \
+                  ltx25-metal-verification; do
     script="scripts/tests/${contract}.sh"
     if [ -f "$script" ]; then
       step "contracts: ${contract}" bash "$script"

--- a/scripts/tests/ltx25-metal-verification.sh
+++ b/scripts/tests/ltx25-metal-verification.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+runner="$repo_root/scripts/capture-ltx25-metal-verification.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+bash -n "$runner"
+mkdir -p "$tmp/home/output/verification/ltx-2.5" "$tmp/home/output" "$tmp/refs"
+
+make_asset() {
+  local relative="$1" sha="$2" path
+  path="$tmp/home/$relative"
+  mkdir -p "$(dirname "$path")"
+  printf 'fixture for %s\n' "$relative" >"$path"
+  printf '%s\n' "$sha" >"$path.sha256-verified"
+}
+
+make_asset \
+  models/ltx-2.5-22b-distilled-int8-conv/diffusion_models/ltx-2.5-22b-distilled-transformer-comfy-int8-convrot.safetensors \
+  c4279eeff115cbeaca494bd2183e7d768c38fe85a184dc6afbb7159157c44334
+make_asset models/shared/ltx2/text_encoders/gemma4-12b-with-proj-ltx-2.5-comfy-int8-convrot.safetensors \
+  6ce688a0aa98a5fa36a9f1e6c3f42152a498cc2b53ee8c15674c64244f91487f
+make_asset models/shared/ltx2/vae/ltx-2.5-video-vae-conv-bf16.safetensors \
+  685b06ee3d9b2039647698fc4ea33175112462fc374e2777312c907897dfce8d
+make_asset models/shared/ltx2/vae/ltx-2.5-audio-vae-bf16.safetensors \
+  c52733d37f6a7fb7949c3dc0fb468c6cb2169e4d836983a73babb9f0d54837a5
+make_asset models/shared/ltx2/model_patches/ltx-2.5-duration-head-bf16.safetensors \
+  2ec71e4206ed365d015f00c05a48caccfb0ee862986809d06ae376c09f5d9190
+make_asset models/shared/ltx2/latent_upscale_models/ltx-2.5-latent-spatial-upscaler-x2-bf16-1.0.safetensors \
+  eb5a71fe4068ee87ccdb1c3aa635e547ca76bd2d30ae20ae889f2c325c0677e8
+make_asset models/shared/ltx2/latent_upscale_models/ltx-2.5-latent-temporal-upscaler-x2-bf16-1.0.safetensors \
+  2bc3300f2b3c3c1834d72164fbf13a3b9fd73e5a741e8a2c3f4035f89a75c3fe
+
+for name in ltx-2-upstream comfyui-ltxvideo-upstream comfyui-upstream diffusers-upstream; do
+  mkdir -p "$tmp/refs/$name/.git"
+done
+
+mkdir -p "$tmp/bin"
+real_git="$(command -v git)"
+cat >"$tmp/bin/git" <<FAKE
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "\$1" == -C && "\$2" == "$tmp/refs/"* ]]; then
+  if [[ "\$3" == status && "\$4" == --porcelain ]]; then
+    exit 0
+  fi
+  [[ "\$3" == rev-parse && "\$4" == HEAD ]] || exec "$real_git" "\$@"
+  case "\$2" in
+    */ltx-2-upstream) echo 400fd31054597515f47125691032c04b1c3ee24e ;;
+    */comfyui-ltxvideo-upstream) echo 15d09abb5a187a8dcaea2fc31fe51ee96e6c9d0d ;;
+    */comfyui-upstream) echo a1079ba16f2674734b065eb036fbfdddaa321a4d ;;
+    */diffusers-upstream) echo 95c0d467cc2a4770b71fa25a117320377e6eb08f ;;
+  esac
+else
+  exec "$real_git" "\$@"
+fi
+FAKE
+chmod +x "$tmp/bin/git"
+cat >"$tmp/bin/ffprobe" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+path="${@: -1}"
+if [[ "$path" == *.mp4 ]]; then
+  printf '%s\n' '{"streams":[{"codec_type":"video","codec_name":"h264","width":256,"height":256,"r_frame_rate":"24/1","nb_frames":"9"},{"codec_type":"audio","codec_name":"aac","sample_rate":"48000","channels":2}],"format":{"size":"12","duration":"0.375"}}'
+else
+  printf '%s\n' '{"streams":[{"codec_type":"video","codec_name":"apng","width":256,"height":256,"r_frame_rate":"24/1","nb_read_frames":"9"}],"format":{"size":"13"}}'
+fi
+FAKE
+chmod +x "$tmp/bin/ffprobe"
+printf 'mp4 fixture\n' >"$tmp/home/output/ltx25-final-int8-metal-audio-seed-25026.mp4"
+printf 'apng fixture\n' >"$tmp/home/output/verification/ltx-2.5/phase2-int8-metal-smoke-seed-25025.apng"
+database="$tmp/home/mold.db"
+sqlite3 "$database" 'CREATE TABLE generations (
+  id INTEGER PRIMARY KEY, filename TEXT, output_dir TEXT, format TEXT, title TEXT,
+  prompt TEXT, model TEXT, seed INTEGER, steps INTEGER, guidance REAL, width INTEGER,
+  height INTEGER, frames INTEGER, fps INTEGER, generation_time_ms INTEGER,
+  backend TEXT, hostname TEXT, source TEXT, metadata_synthetic INTEGER,
+  file_size_bytes INTEGER, metadata_json TEXT);'
+sqlite3 "$database" "INSERT INTO generations VALUES
+  (1, 'ltx25-final-int8-metal-audio-seed-25026.mp4', '$tmp/home/output', 'mp4',
+   'fixture', 'A small brass automaton drummer performing in gentle rain, locked camera, cinematic reflections',
+   'ltx-2.5-22b-distilled:int8-conv', 25026, 1, 1, 256, 256, 9, 24, 1,
+   'metal', 'fixture', 'cli', 0, 12, '{\"enable_audio\":true,\"output_format\":\"mp4\"}'),
+  (2, 'phase2-int8-metal-smoke-seed-25025.apng', '$tmp/home/output/verification/ltx-2.5',
+   'apng', NULL, 'A red fox walking through sunlit desert grass, cinematic natural motion',
+   'ltx-2.5-22b-distilled:int8-conv', 25025, 1, 1, 256, 256, 9, 24, 1,
+   'metal', 'fixture', 'cli', 0, 13, '{\"enable_audio\":false,\"output_format\":\"apng\"}');"
+
+report="$tmp/report.json"
+PATH="$tmp/bin:$PATH" \
+MOLD_HOME="$tmp/home" \
+LTX25_ALLOW_TEST_HOME=1 \
+LTX25_CONTRACT_TEST=1 \
+LTX25_REFERENCES_ROOT="$tmp/refs" \
+LTX25_REPORT="$report" \
+LTX25_CAPTURE_TIMESTAMP=fixture \
+LTX25_SKIP_GATES=1 \
+LTX25_HOST_JSON='{"os":"fixture","arch":"arm64","metal_devices":[{"name":"fixture"}]}' \
+  "$runner" >/dev/null
+
+jq -e '
+  .schema_version == "mold.ltx25.metal-int8.verification.v1"
+  and .backend_scope == "metal"
+  and .default_model == "ltx-2.5-22b-distilled:int8-conv"
+  and (.assets | length) == 7
+  and ([.assets[].expected_sha256] | all(test("^[0-9a-f]{64}$")))
+  and ([.assets[].actual_sha256] | all(. == null))
+  and (.references | length) == 4
+  and ([.references[].status] | all(. == "pinned_clean"))
+  and (.media | length) == 2
+  and ([.media[].retained_in_library] | all(. == true))
+  and ([.gates[].status] | all(. == "skipped_contract_test"))
+  and (.comparison_matrix[] | select(.implementation == "Mold"
+    and .backend == "Metal" and .checkpoint == "distilled INT8 ConvRot").status)
+    == "not_qualified_contract_test"
+  and (.comparison_matrix[] | select(.implementation == "ComfyUI").status) == "pending"
+  and .preservation.downloaded_models_deleted == false
+  and .preservation.rendered_media_deleted == false
+' "$report" >/dev/null
+
+bad_marker="$tmp/home/models/shared/ltx2/model_patches/ltx-2.5-duration-head-bf16.safetensors.sha256-verified"
+printf '%064d\n' 0 >"$bad_marker"
+if PATH="$tmp/bin:$PATH" MOLD_HOME="$tmp/home" LTX25_ALLOW_TEST_HOME=1 \
+  LTX25_CONTRACT_TEST=1 LTX25_REFERENCES_ROOT="$tmp/refs" \
+  LTX25_REPORT="$tmp/bad.json" LTX25_SKIP_GATES=1 \
+  LTX25_HOST_JSON='{}' "$runner" >/dev/null 2>&1; then
+  echo "runner accepted a mismatched verified SHA marker" >&2
+  exit 1
+fi
+
+echo "LTX-2.5 Metal verification contract OK"


### PR DESCRIPTION
## Summary

- add a non-destructive LTX-2.5 Metal INT8 verification capture
- bind retained renders to exact Mold database provenance and decoded media facts
- rehash current model bytes and require clean pinned upstream references
- keep contract-test runs explicitly non-qualifying
- wire the verifier contract into local and GitHub CI

## Verification

- `bash scripts/tests/ltx25-metal-verification.sh`
- ShellCheck
- CI routing contract
- actionlint
- rustfmt
- real Metal report: `/Volumes/ExternalStorage/mold2/output/verification/ltx-2.5/ltx25-metal-int8-verification-20260826T035258Z.json`
- real focused gates: 6 manifest tests, 8 LTX-2.5 oracle tests, 501 LTX-2 regression tests
- independent agent review approved exact commit `379efe4698bf1d7c230c32922c4e1c95dcf28857`

## Scope

- Apple Metal only; CUDA qualification remains on its dedicated host
- compact distilled INT8 ConvRot remains the default
- BF16 assets remain offered and retained, but runtime comparison is operator-deferred
- ComfyUI exact-weight MPS A/B remains accurately pending; no 1280x720 default workflow was queued after the prior machine crash
- no downloaded models or rendered library media were moved or deleted

Closes the verification-tooling portion of #1376; the issue remains open for the safe ComfyUI 256x256 executable A/B row.