### PR TITLE
fix(mobile): make wide layouts responsive

### DIFF
--- a/apps/mobile/plugins/android/src/main/java/MoldMobileNativePlugin.kt
+++ b/apps/mobile/plugins/android/src/main/java/MoldMobileNativePlugin.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.app.Activity
 import android.content.res.Configuration
 import android.content.Intent
+import android.graphics.Color
 import android.os.Build
 import androidx.activity.result.ActivityResult
 import app.tauri.PermissionState
@@ -251,6 +252,7 @@ class MoldMobileNativePlugin(private val hostActivity: Activity) : Plugin(hostAc
     }
 
     @Command
+    @Suppress("DEPRECATION")
     fun setMobileAppearance(invoke: Invoke) {
         val args = invoke.parseArgs(AppearanceArgs::class.java)
         hostActivity.runOnUiThread {
@@ -268,6 +270,17 @@ class MoldMobileNativePlugin(private val hostActivity: Activity) : Plugin(hostAc
                 ).apply {
                     isAppearanceLightStatusBars = !dark
                     isAppearanceLightNavigationBars = !dark
+                }
+                // Native system bars sit outside the WebView; mirror the Safelight desk tokens.
+                val chromeColor = Color.parseColor(if (dark) "#0A0805" else "#E6DCC7")
+                hostActivity.window.apply {
+                    statusBarColor = chromeColor
+                    navigationBarColor = chromeColor
+                    decorView.setBackgroundColor(chromeColor)
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                        isStatusBarContrastEnforced = false
+                        isNavigationBarContrastEnforced = false
+                    }
                 }
                 invoke.resolve()
             }

--- a/apps/mobile/src-tauri/gen/android/app/src/main/java/com/utensils/mold/MainActivity.kt
+++ b/apps/mobile/src-tauri/gen/android/app/src/main/java/com/utensils/mold/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.utensils.mold
 
 import android.R
+import android.graphics.Color
 import android.os.Bundle
 import androidx.activity.enableEdgeToEdge
 import androidx.core.view.ViewCompat
@@ -10,6 +11,8 @@ class MainActivity : TauriActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     enableEdgeToEdge()
     super.onCreate(savedInstanceState)
+    // Avoid a light flash before the WebView applies the persisted appearance.
+    window.decorView.setBackgroundColor(Color.parseColor("#0A0805"))
     val content = findViewById<android.view.View>(R.id.content)
     ViewCompat.setOnApplyWindowInsetsListener(content) { view, insets ->
       val safeChrome = insets.getInsets(

--- a/changelog.d/mobile-wide-responsive-layout.md
+++ b/changelog.d/mobile-wide-responsive-layout.md
@@ -1,0 +1,1 @@
+- **Responsive mobile wide layouts.** Android tablets and iPhones in landscape now use the full available width with notch-aware navigation, cleaner multi-column controls, and matching Android system-bar colors ([#1395](https://github.com/utensils/mold/pull/1395)).

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -11206,7 +11206,7 @@ onBeforeUnmount(() => {
               <button class="primary-button" type="submit">Test and save</button>
             </div>
           </form>
-          <form v-else style="margin-top: 20px" @submit.prevent="connectHost()">
+          <form v-else class="mobile-host-form" @submit.prevent="connectHost()">
             <label class="field"
               ><span>Name</span
               ><input

--- a/desktop/src/mobile/mobile.css
+++ b/desktop/src/mobile/mobile.css
@@ -4492,11 +4492,172 @@ button:disabled {
   color: var(--stop);
 }
 
-@media (min-width: 700px) {
+/*
+ * Wide-mobile shell. Portrait phones keep the bottom tabs; landscape phones
+ * and tablets get a persistent, notch-aware navigation rail and use their
+ * working area instead of centering a phone column inside a large WebView.
+ */
+@media (min-width: 640px) {
+  .mobile-shell:not(.is-settings-open) {
+    grid-template-columns: calc(82px + env(safe-area-inset-left)) minmax(0, 1fr);
+    grid-template-rows: auto minmax(0, 1fr) auto;
+    grid-template-areas:
+      "tabs header"
+      "tabs content"
+      "tabs action";
+  }
+
+  .mobile-shell.is-settings-open {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: auto minmax(0, 1fr);
+    grid-template-areas:
+      "header"
+      "content";
+  }
+
+  .mobile-header {
+    grid-area: header;
+    min-height: 64px;
+    padding: 10px max(28px, env(safe-area-inset-right)) 10px max(28px, env(safe-area-inset-left));
+  }
+
   .mobile-content {
-    width: min(760px, 100%);
+    grid-area: content;
+    width: 100%;
     box-sizing: border-box;
     justify-self: center;
+    padding: 24px max(28px, env(safe-area-inset-right)) 28px max(28px, env(safe-area-inset-left));
+    overscroll-behavior-y: contain;
+    scrollbar-gutter: stable;
+  }
+
+  .mobile-tabs {
+    grid-area: tabs;
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: repeat(4, minmax(72px, 1fr));
+    align-content: center;
+    gap: 8px;
+    padding: max(8px, env(safe-area-inset-top)) 8px max(8px, env(safe-area-inset-bottom))
+      max(8px, env(safe-area-inset-left));
+    border-top: 0;
+    border-right: 1px solid var(--edge);
+  }
+
+  .mobile-tab {
+    min-height: 72px;
+    padding: 8px 4px;
+  }
+
+  .mobile-tab[aria-current="page"] {
+    background: color-mix(in srgb, var(--safelight) 10%, transparent);
+  }
+
+  .mobile-create-action {
+    grid-area: action;
+    padding-right: max(28px, env(safe-area-inset-right));
+    padding-left: max(28px, env(safe-area-inset-left));
+  }
+
+  .mobile-host-form {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: end;
+    gap: 0 18px;
+    margin-top: 20px;
+  }
+
+  .mobile-host-form > .primary-button {
+    grid-column: 1 / -1;
+  }
+
+  .mobile-advanced-sheet-head,
+  .mobile-advanced-sheet-body {
+    width: min(760px, 100%);
+    box-sizing: border-box;
+    margin-inline: auto;
+  }
+
+  .mobile-seam-sheet-panel,
+  .mobile-library-sheet-panel,
+  .mobile-catalog-target-panel {
+    width: min(720px, calc(100% - 48px));
+    align-self: center;
+    border-right: 1px solid var(--edge);
+    border-left: 1px solid var(--edge);
+    border-radius: 18px 18px 0 0;
+  }
+
+  .mobile-catalog-detail-scroll {
+    box-sizing: border-box;
+    padding-right: env(safe-area-inset-right);
+    padding-left: env(safe-area-inset-left);
+  }
+}
+
+@media (min-width: 768px) {
+  .mobile-shell:not(.is-settings-open) {
+    grid-template-columns: calc(92px + env(safe-area-inset-left)) minmax(0, 1fr);
+  }
+
+  .mobile-settings {
+    width: min(1080px, 100%);
+  }
+
+  .mobile-settings-section {
+    display: grid;
+    grid-template-columns: minmax(220px, 0.72fr) minmax(0, 1.28fr);
+    column-gap: 40px;
+    align-items: start;
+  }
+
+  .mobile-settings-section-copy {
+    margin-bottom: 0;
+  }
+
+  .mobile-settings-section > :not(.mobile-settings-section-copy) {
+    grid-column: 2;
+  }
+
+  .mobile-catalog-results {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 12px;
+    overflow: visible;
+    border: 0;
+    background: transparent;
+  }
+
+  .mobile-catalog-card,
+  .mobile-catalog-card + .mobile-catalog-card {
+    border: 1px solid var(--edge);
+    border-radius: var(--radius-card);
+    background: var(--bench);
+  }
+}
+
+/* Keep compact, notched landscape phones on the safe single-column detail view. */
+@media (min-width: 900px) {
+  .mobile-catalog-detail-scroll {
+    display: grid;
+    grid-template-columns: minmax(320px, 0.8fr) minmax(420px, 1.2fr);
+    align-items: start;
+    overflow-x: hidden;
+  }
+
+  .mobile-catalog-detail-preview {
+    position: sticky;
+    top: 0;
+    height: 100%;
+    max-height: none;
+    border-right: 1px solid var(--edge);
+    border-bottom: 0;
+  }
+
+  .mobile-catalog-detail-copy {
+    width: 100%;
+    max-width: 760px;
+    box-sizing: border-box;
+    padding: 28px 32px 40px;
   }
 }
 

--- a/desktop/src/mobile/mobile.css.test.ts
+++ b/desktop/src/mobile/mobile.css.test.ts
@@ -104,6 +104,33 @@ describe("mobile scrolling", () => {
     expect(content?.[1]).toMatch(/overscroll-behavior:\s*none\s*;/);
     expect(content?.[1]).not.toMatch(/-webkit-overflow-scrolling/);
   });
+
+  it("turns wide mobile surfaces into a full-width responsive workspace", () => {
+    const tablet = css.match(/@media \(min-width: 640px\) \{([\s\S]*?)\n\}/);
+    expect(tablet?.[1]).toMatch(/grid-template-areas:[\s\S]*"tabs header"/);
+    expect(tablet?.[1]).toMatch(
+      /\.mobile-shell\.is-settings-open\s*\{[\s\S]*grid-template-areas:[\s\S]*"header"[\s\S]*"content"/,
+    );
+    expect(tablet?.[1]).toMatch(/\.mobile-content\s*\{[\s\S]*width:\s*100%/);
+    expect(tablet?.[1]).toMatch(
+      /\.mobile-tabs\s*\{[\s\S]*grid-template-columns:\s*minmax\(0,\s*1fr\)/,
+    );
+    expect(tablet?.[1]).toMatch(/\.mobile-host-form\s*\{[\s\S]*repeat\(2,/);
+    expect(tablet?.[1]).toMatch(
+      /\.mobile-catalog-detail-scroll\s*\{[\s\S]*padding-right:\s*env\(safe-area-inset-right\)[\s\S]*padding-left:\s*env\(safe-area-inset-left\)/,
+    );
+    expect(tablet?.[1]).toContain("env(safe-area-inset-left)");
+
+    const roomyTablet = css.match(/@media \(min-width: 768px\) \{([\s\S]*?)\n\}/);
+    expect(roomyTablet?.[1]).toMatch(/\.mobile-settings-section\s*\{[\s\S]*minmax\(220px,/);
+    expect(roomyTablet?.[1]).toMatch(/\.mobile-catalog-results\s*\{[\s\S]*repeat\(2,/);
+    expect(roomyTablet?.[1]).not.toMatch(/\.mobile-catalog-detail-scroll/);
+
+    const wideDetail = css.match(/@media \(min-width: 900px\) \{([\s\S]*?)\n\}/);
+    expect(wideDetail?.[1]).toMatch(
+      /\.mobile-catalog-detail-scroll\s*\{[\s\S]*minmax\(320px,[\s\S]*minmax\(420px,/,
+    );
+  });
 });
 
 describe("mobile navigation", () => {


### PR DESCRIPTION
## Summary
- replace the centered phone column with a full-width, notch-aware navigation rail on landscape phones and tablets
- add responsive two-column settings, host, catalog, and model-detail layouts while keeping compact notched landscape detail screens single-column
- synchronize Android status/navigation bar colors with the selected appearance and prevent the light startup flash
- add regression coverage for wide layouts, safe-area padding, and compact landscape breakpoints

## UAT
- Android API 37 tablet emulator at 2560x1600 (1280x800 CSS): Create, Advanced, Sequence seam editor, populated 292-item Library, viewer, Models, model detail, Machines, and Settings
- iPhone 17 Pro iOS 26.5 Simulator in portrait and landscape: Create, populated Library, viewer, Models, Machines, and responsive Settings
- retained visual evidence under /Volumes/ExternalStorage/mold2/output/verification/mobile-responsive

## Verification
- `bun run test`: 399 files / 5096 tests passed
- `bun run build:mobile`
- `bun run fmt:check`
- `scripts/android.sh test`: 17/17 instrumentation tests passed
- rebased `scripts/android.sh check` APK build
- `scripts/ios.sh check`
- rebased signed `scripts/ios.sh simulator` build
- Android/iOS release asset contract scripts
- independent agent review: no actionable findings

This PR is ready for review and must not be merged as part of this task.