### PR TITLE
fix(ltx2): align LTX 2.5 capabilities and progress

### DIFF
--- a/changelog.d/ltx-2-5-audit-parity.md
+++ b/changelog.d/ltx-2-5-audit-parity.md
@@ -1,0 +1,5 @@
+- **Align LTX-2.5 controls and progress with upstream.** Installed LTX-2.5
+  checkpoints now advertise synchronized audio to every Studio surface, use
+  the current upstream refinement schedule and duration/frame authority, and
+  report bounded Gemma and transformer progress instead of appearing stuck
+  during long Metal work ([#1401](https://github.com/utensils/mold/issues/1401)).

--- a/crates/mold-cli/src/commands/mcp.rs
+++ b/crates/mold-cli/src/commands/mcp.rs
@@ -1025,6 +1025,11 @@ fn progress_summary(event: &SseProgressEvent) -> String {
         SseProgressEvent::StageDone { name, elapsed_ms } => {
             format!("stage done: {name} in {:.1}s", *elapsed_ms as f64 / 1000.0)
         }
+        SseProgressEvent::StageProgress {
+            name,
+            current,
+            total,
+        } => format!("{name} {current}/{total}"),
         SseProgressEvent::Info { message } => message.clone(),
         SseProgressEvent::CacheHit { resource } => format!("cache hit: {resource}"),
         SseProgressEvent::DenoiseStep {
@@ -1889,6 +1894,18 @@ mod tests {
     use super::*;
     use crate::test_support::ENV_LOCK;
     use serde_json::json;
+
+    #[test]
+    fn async_status_summarizes_bounded_stage_progress() {
+        assert_eq!(
+            progress_summary(&SseProgressEvent::StageProgress {
+                name: "Evaluating transformer (conditional)".to_string(),
+                current: 9,
+                total: 48,
+            }),
+            "Evaluating transformer (conditional) 9/48"
+        );
+    }
 
     #[test]
     fn initialize_declares_tools_capability() {

--- a/crates/mold-cli/src/commands/runpod.rs
+++ b/crates/mold-cli/src/commands/runpod.rs
@@ -1934,6 +1934,11 @@ fn format_progress_event(ev: &mold_core::types::SseProgressEvent) -> String {
         }
         E::Preview { step, total, .. } => format!("denoise preview {step}/{total}"),
         E::StageStart { name } => format!("stage: {name}"),
+        E::StageProgress {
+            name,
+            current,
+            total,
+        } => format!("{name} {current}/{total}"),
         E::StageDone { name, elapsed_ms } => format!("done: {name} ({elapsed_ms}ms)"),
         E::Info { message } => message.clone(),
         E::CacheHit { resource } => format!("cached: {resource}"),
@@ -3297,6 +3302,14 @@ mod tests {
                 name: "denoise".into()
             }),
             "stage: denoise"
+        );
+        assert_eq!(
+            format_progress_event(&E::StageProgress {
+                name: "denoise blocks".into(),
+                current: 7,
+                total: 48,
+            }),
+            "denoise blocks 7/48"
         );
         assert_eq!(
             format_progress_event(&E::StageDone {

--- a/crates/mold-cli/src/ui.rs
+++ b/crates/mold-cli/src/ui.rs
@@ -277,6 +277,19 @@ pub(crate) async fn render_progress(
                     );
                 });
             }
+            SseProgressEvent::StageProgress {
+                name,
+                current,
+                total,
+            } => {
+                let message = format!("{name} {current}/{total}");
+                if let Some(db) = denoise_bar.as_ref() {
+                    db.set_message(message);
+                } else {
+                    pb.set_message(message);
+                    pb.tick();
+                }
+            }
             SseProgressEvent::Info { message } => {
                 pb.suspend(|| {
                     status!("  {} {}", theme::icon_bullet(), message.dimmed());

--- a/crates/mold-core/src/catalog.rs
+++ b/crates/mold-core/src/catalog.rs
@@ -990,6 +990,24 @@ mod tests {
         assert!(!flux.defaults.recommended_dimensions.is_empty());
     }
 
+    #[test]
+    fn ltx25_catalog_uses_the_shared_duration_and_frame_grid_authority() {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let catalog = build_model_catalog(&Config::default(), None, false);
+        let model = catalog
+            .iter()
+            .find(|model| model.name == crate::ltx25_manifest::DISTILLED_INT8_CONV)
+            .expect("LTX-2.5 distilled INT8 manifest row");
+
+        assert_eq!(model.defaults.default_frames, Some(121));
+        assert_eq!(model.defaults.default_fps, Some(24));
+        assert_eq!(model.defaults.max_runtime_seconds, Some(20));
+        assert_eq!(model.defaults.max_frames, Some(481));
+        assert_eq!(model.defaults.max_frames_absolute, Some(604));
+        assert_eq!(model.defaults.frame_step, Some(8));
+        assert_eq!(model.defaults.frame_offset, Some(1));
+    }
+
     /// `/api/models` is the single source Studio surfaces read the grid from:
     /// the 5B must advertise its 2.2 VAE's 32px grid while the 2.1-VAE
     /// checkpoints keep the family's 16, and every advertised bucket must sit

--- a/crates/mold-core/src/types.rs
+++ b/crates/mold-core/src/types.rs
@@ -4163,6 +4163,14 @@ pub enum SseProgressEvent {
         name: String,
         elapsed_ms: u64,
     },
+    /// Bounded work inside a named stage. Unlike `DenoiseStep`, this does not
+    /// claim that a generation step has completed; it keeps long model-layer
+    /// evaluations visibly alive without inflating denoise percentage.
+    StageProgress {
+        name: String,
+        current: usize,
+        total: usize,
+    },
     Info {
         message: String,
     },
@@ -6476,6 +6484,26 @@ mod tests {
         assert!(
             matches!(back, SseProgressEvent::StageStart { name } if name == "Loading T5 encoder")
         );
+    }
+
+    #[test]
+    fn sse_progress_stage_progress_roundtrip() {
+        let event = SseProgressEvent::StageProgress {
+            name: "Encoding prompt (Gemma)".to_string(),
+            current: 17,
+            total: 48,
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains(r#""type":"stage_progress""#));
+        let back: SseProgressEvent = serde_json::from_str(&json).unwrap();
+        assert!(matches!(
+            back,
+            SseProgressEvent::StageProgress {
+                name,
+                current: 17,
+                total: 48,
+            } if name == "Encoding prompt (Gemma)"
+        ));
     }
 
     #[test]

--- a/crates/mold-core/src/validation.rs
+++ b/crates/mold-core/src/validation.rs
@@ -74,8 +74,9 @@ pub fn family_supports_lora(family: &str) -> bool {
 /// and mold's own RoPE path convert the temporal axis to *seconds* before
 /// normalizing by it: `ltx2/model/rope.rs`'s `scale_video_time_to_seconds`
 /// divides the pixel-frame coordinate by the request's fps. So `20` bounds
-/// twenty seconds of runtime, not twenty latent frames — which is exactly the
-/// ~20 s single-generation duration Lightricks advertises for LTX-2.3.
+/// twenty seconds of runtime, not twenty latent frames. Current upstream
+/// LTX-2.5 expresses the same authority as `AutoDuration { min_seconds: 1,
+/// max_seconds: 20 }`; the frame count remains derived from the request FPS.
 pub const LTX2_MAX_RUNTIME_SECONDS: u32 = 20;
 
 /// fps assumed for LTX-2 when a caller must name a frame ceiling without a
@@ -85,7 +86,7 @@ pub const LTX2_DEFAULT_FPS: u32 = 24;
 
 /// Absolute pixel-frame ceiling for LTX-2 regardless of fps.
 ///
-/// This is a resource guard, not a model limit: the seconds budget alone would
+/// This is Mold's resource guard, not an upstream model limit: the seconds budget alone would
 /// admit 2404 frames at the maximum allowed 120 fps, which no current GPU can
 /// denoise in one pass. 604 is `LTX2_MAX_RUNTIME_SECONDS` at 30 fps — the point
 /// where a practical frame budget meets the model's real duration budget.

--- a/crates/mold-discord/src/format.rs
+++ b/crates/mold-discord/src/format.rs
@@ -40,6 +40,11 @@ pub fn format_progress(event: &SseProgressEvent) -> String {
         SseProgressEvent::StageDone { name, elapsed_ms } => {
             format!("{name} ({elapsed_ms}ms)")
         }
+        SseProgressEvent::StageProgress {
+            name,
+            current,
+            total,
+        } => format!("{name} {current}/{total}"),
         SseProgressEvent::Info { message } => message.clone(),
         SseProgressEvent::CacheHit { resource } => {
             format!("Cache hit: {resource}")

--- a/crates/mold-inference/src/audio.rs
+++ b/crates/mold-inference/src/audio.rs
@@ -1,6 +1,6 @@
 //! Shared audio primitives, independent of any model family.
 
-use mold_core::ModelPaths;
+use mold_core::{Config, ModelPaths};
 
 #[derive(Debug, Clone)]
 pub struct NativeAudioTrack {
@@ -33,9 +33,28 @@ pub fn output_probe_registered(family: &str) -> bool {
 /// `None` means the family has no registered capability probe. This keeps the
 /// server annotation generic: adding a future audio/video family requires one
 /// registry arm here, not another server-side family special case.
-pub fn output_supported(family: &str, paths: &ModelPaths) -> Option<bool> {
+pub fn output_supported(
+    family: &str,
+    model_name: &str,
+    config: &Config,
+    paths: &ModelPaths,
+) -> Option<bool> {
     match output_probe(family)? {
-        AudioOutputProbe::Ltx2 => Some(crate::ltx2::audio_output_supported(paths)),
+        AudioOutputProbe::Ltx2 => {
+            // LTX-2.5 is a split pack whose audio VAE/vocoder is deliberately
+            // absent from legacy `ModelPaths`. Resolve the lossless manifest
+            // graph here, inside the inference-owned family registry, so the
+            // generic server annotation cannot accidentally probe only the
+            // video assets. Older monolithic LTX-2 checkpoints retain their
+            // header-only transformer/VAE path.
+            let audio_components =
+                mold_core::ltx25_manifest::Ltx25ModelPaths::resolve(config, model_name)
+                    .map(|split| split.audio_vae);
+            Some(crate::ltx2::audio_output_supported_with_components(
+                paths,
+                audio_components.as_deref(),
+            ))
+        }
     }
 }
 

--- a/crates/mold-inference/src/ltx2/mod.rs
+++ b/crates/mold-inference/src/ltx2/mod.rs
@@ -36,6 +36,16 @@ pub fn audio_output_supported(paths: &mold_core::ModelPaths) -> bool {
     audio_output_gap(paths).is_none()
 }
 
+/// Whether a resolved LTX-2 checkpoint set plus an optional split-pack audio
+/// component contains every tensor required for native synchronized audio.
+/// LTX-2.5 keeps that component outside legacy [`mold_core::ModelPaths`].
+pub(crate) fn audio_output_supported_with_components(
+    paths: &mold_core::ModelPaths,
+    audio_components_path: Option<&std::path::Path>,
+) -> bool {
+    audio_output_gap_with_components(paths, audio_components_path).is_none()
+}
+
 /// Why native LTX-2 audio output is unavailable for this checkpoint set, or
 /// `None` when it is available.
 ///

--- a/crates/mold-inference/src/ltx2/model/audio_transformer.rs
+++ b/crates/mold-inference/src/ltx2/model/audio_transformer.rs
@@ -406,6 +406,7 @@ impl Ltx2AudioTransformerModel {
         })
     }
 
+    #[allow(dead_code)]
     pub fn forward_with_static_inputs(
         &self,
         audio_hidden_states: &Tensor,
@@ -413,6 +414,28 @@ impl Ltx2AudioTransformerModel {
         audio_timestep: &Tensor,
         static_inputs: &LtxPreparedModalityStatic,
         perturbations: Option<&BatchedPerturbationConfig>,
+    ) -> Result<Tensor> {
+        self.forward_with_static_inputs_and_progress(
+            audio_hidden_states,
+            audio_sigma,
+            audio_timestep,
+            static_inputs,
+            perturbations,
+            "Evaluating audio transformer",
+            None,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn forward_with_static_inputs_and_progress(
+        &self,
+        audio_hidden_states: &Tensor,
+        audio_sigma: &Tensor,
+        audio_timestep: &Tensor,
+        static_inputs: &LtxPreparedModalityStatic,
+        perturbations: Option<&BatchedPerturbationConfig>,
+        progress_name: &str,
+        progress: Option<&crate::progress::ProgressCallback>,
     ) -> Result<Tensor> {
         let compute_dtype = self.compute_dtype();
         let audio_sigma = audio_sigma.to_dtype(compute_dtype)?.affine(1000.0, 0.0)?;
@@ -465,6 +488,13 @@ impl Ltx2AudioTransformerModel {
                 eprintln!("[ltx2-block-debug] enter audio block={index}");
             }
             audio.x = block.forward(index, &audio, &perturbations)?;
+            if let Some(progress) = progress {
+                progress(crate::progress::ProgressEvent::StageProgress {
+                    name: progress_name.to_string(),
+                    current: index + 1,
+                    total: self.transformer_blocks.len(),
+                });
+            }
             if ltx2_block_debug_enabled() {
                 let (a_mean, a_abs_mean, a_abs_max) = tensor_debug_stats(&audio.x)?;
                 eprintln!(

--- a/crates/mold-inference/src/ltx2/model/video_transformer.rs
+++ b/crates/mold-inference/src/ltx2/model/video_transformer.rs
@@ -4039,6 +4039,34 @@ impl Ltx2AvTransformer3DModel {
         static_inputs: &LtxPreparedStaticInputs,
         perturbations: Option<&BatchedPerturbationConfig>,
     ) -> Result<(Tensor, Option<Tensor>)> {
+        self.forward_with_static_inputs_and_progress(
+            video_hidden_states,
+            audio_hidden_states,
+            video_sigma,
+            video_timestep,
+            audio_sigma,
+            audio_timestep,
+            static_inputs,
+            perturbations,
+            "Evaluating transformer",
+            None,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn forward_with_static_inputs_and_progress(
+        &self,
+        video_hidden_states: &Tensor,
+        audio_hidden_states: Option<&Tensor>,
+        video_sigma: &Tensor,
+        video_timestep: &Tensor,
+        audio_sigma: Option<&Tensor>,
+        audio_timestep: Option<&Tensor>,
+        static_inputs: &LtxPreparedStaticInputs,
+        perturbations: Option<&BatchedPerturbationConfig>,
+        progress_name: &str,
+        progress: Option<&crate::progress::ProgressCallback>,
+    ) -> Result<(Tensor, Option<Tensor>)> {
         let compute_dtype = match self.patchify_proj.weight().dtype() {
             DType::F8E4M3 => DType::BF16,
             other => other,
@@ -4135,6 +4163,12 @@ impl Ltx2AvTransformer3DModel {
                     if let (Some(audio), Some(ax)) = (audio.as_mut(), ax) {
                         audio.x = ax;
                     }
+                    emit_transformer_block_progress(
+                        progress,
+                        progress_name,
+                        index,
+                        self.config.num_layers,
+                    );
                     if ltx2_block_debug_enabled() {
                         let (v_mean, v_abs_mean, v_abs_max) = tensor_debug_stats(&video.x)?;
                         if let Some(audio) = audio.as_ref() {
@@ -4164,6 +4198,12 @@ impl Ltx2AvTransformer3DModel {
                     if let (Some(audio), Some(ax)) = (audio.as_mut(), ax) {
                         audio.x = ax;
                     }
+                    emit_transformer_block_progress(
+                        progress,
+                        progress_name,
+                        index,
+                        self.config.num_layers,
+                    );
                     if ltx2_block_debug_enabled() {
                         let (v_mean, v_abs_mean, v_abs_max) = tensor_debug_stats(&video.x)?;
                         if let Some(audio) = audio.as_ref() {
@@ -4219,6 +4259,12 @@ impl Ltx2AvTransformer3DModel {
                     if let (Some(audio), Some(ax)) = (audio.as_mut(), ax) {
                         audio.x = ax;
                     }
+                    emit_transformer_block_progress(
+                        progress,
+                        progress_name,
+                        index,
+                        self.config.num_layers,
+                    );
                     if ltx2_block_debug_enabled() {
                         let (v_mean, v_abs_mean, v_abs_max) = tensor_debug_stats(&video.x)?;
                         if let Some(audio) = audio.as_ref() {
@@ -4306,6 +4352,21 @@ impl Ltx2AvTransformer3DModel {
             &static_inputs,
             perturbations,
         )
+    }
+}
+
+fn emit_transformer_block_progress(
+    progress: Option<&crate::progress::ProgressCallback>,
+    name: &str,
+    index: usize,
+    total: usize,
+) {
+    if let Some(progress) = progress {
+        progress(crate::progress::ProgressEvent::StageProgress {
+            name: name.to_string(),
+            current: index + 1,
+            total,
+        });
     }
 }
 

--- a/crates/mold-inference/src/ltx2/runtime.rs
+++ b/crates/mold-inference/src/ltx2/runtime.rs
@@ -756,13 +756,19 @@ impl Ltx2RuntimeSession {
             };
             let prompt_encode_start = Instant::now();
             let prompt_probe = PhaseVramProbe::enter_if("prompt_encode", prompt_device_is_cuda);
+            if let Some(progress) = progress {
+                progress(ProgressEvent::StageStart {
+                    name: "Encoding prompt (Gemma)".to_string(),
+                });
+            }
             // Closure so an encode that dies of OOM is still reported before
             // the error leaves `prepare`.
             let encoded = (|| -> Result<NativePromptEncoding> {
                 move_prompt_encoding_to_device(
-                    prompt_encoder.encode_prompt_pair_with_unconditional(
+                    prompt_encoder.encode_prompt_pair_with_progress(
                         &plan.prompt_tokens,
                         encode_unconditional_prompt,
+                        progress,
                     )?,
                     &prepared_device,
                 )
@@ -1441,14 +1447,13 @@ const DISTILLED_STAGE1_SIGMAS_NO_TERMINAL: &[f32] = &[
 ];
 
 const DISTILLED_STAGE2_SIGMAS_NO_TERMINAL: &[f32] = &[0.909375, 0.725, 0.421875];
-const LTX25_DISTILLED_STAGE2_SIGMAS_NO_TERMINAL: &[f32] = &[0.85, 0.725, 0.4219];
 
-fn distilled_stage2_sigmas_no_terminal(plan: &Ltx2GeneratePlan) -> &'static [f32] {
-    if plan.preset.name == "ltx-2.5-22b" {
-        LTX25_DISTILLED_STAGE2_SIGMAS_NO_TERMINAL
-    } else {
-        DISTILLED_STAGE2_SIGMAS_NO_TERMINAL
-    }
+fn distilled_stage2_sigmas_no_terminal(_plan: &Ltx2GeneratePlan) -> &'static [f32] {
+    // One authority for every distilled LTX-2 generation: current upstream
+    // `STAGE_2_DISTILLED_SIGMA_VALUES` is the fixed subset beginning at
+    // 0.909375. A ComfyUI fixture briefly introduced a model-name fork at
+    // 0.85, but the official pipeline does not version this schedule.
+    DISTILLED_STAGE2_SIGMAS_NO_TERMINAL
 }
 
 /// Refuse a resolution past the trained RoPE span on a pipeline that denoises
@@ -4726,6 +4731,11 @@ fn run_real_distilled_stage(
     );
     let mut run_sigmas = sigmas_no_terminal.to_vec();
     run_sigmas.push(0.0);
+    if let Some(progress) = progress {
+        progress(ProgressEvent::StageStart {
+            name: format!("Denoising ({} steps)", run_sigmas.len().saturating_sub(1)),
+        });
+    }
     let base_video_token_count = video_patchifier.get_token_count(video_shape);
     let clean_video_override = video_clean_latents
         .map(|latents| video_patchifier.patchify(latents))
@@ -4970,6 +4980,7 @@ fn run_real_distilled_stage(
                 video_guider,
                 audio_guider,
                 step_idx,
+                progress,
             )?;
             (video_denoised, audio_denoised, None)
         } else if let Some(audio_latents_ref) = audio_latents.as_ref() {
@@ -4981,7 +4992,7 @@ fn run_real_distilled_stage(
                     .as_ref()
                     .context("missing conditional static inputs for multimodal stage")?;
                 let (uncond_video_velocity, uncond_audio_velocity) = transformer
-                    .forward_with_static_inputs(
+                    .forward_with_static_inputs_and_progress(
                         &video_latents,
                         Some(audio_latents_ref),
                         &video_sigma,
@@ -4990,9 +5001,11 @@ fn run_real_distilled_stage(
                         audio_timestep.as_ref(),
                         uncond_static_inputs,
                         None,
+                        "Evaluating transformer (unconditional)",
+                        progress,
                     )?;
                 let (cond_video_velocity, cond_audio_velocity) = transformer
-                    .forward_with_static_inputs(
+                    .forward_with_static_inputs_and_progress(
                         &video_latents,
                         Some(audio_latents_ref),
                         &video_sigma,
@@ -5001,6 +5014,8 @@ fn run_real_distilled_stage(
                         audio_timestep.as_ref(),
                         cond_static_inputs,
                         None,
+                        "Evaluating transformer (conditional)",
+                        progress,
                     )?;
                 let uncond_audio_velocity = uncond_audio_velocity
                     .context("audio branch unexpectedly returned no unconditional output")?;
@@ -5036,7 +5051,7 @@ fn run_real_distilled_stage(
                     .as_ref()
                     .context("missing conditional static inputs for multimodal stage")?;
                 let (cond_video_velocity, cond_audio_velocity) = transformer
-                    .forward_with_static_inputs(
+                    .forward_with_static_inputs_and_progress(
                         &video_latents,
                         Some(audio_latents_ref),
                         &video_sigma,
@@ -5045,11 +5060,13 @@ fn run_real_distilled_stage(
                         audio_timestep.as_ref(),
                         cond_static_inputs,
                         None,
+                        "Evaluating transformer (conditional)",
+                        progress,
                     )?;
                 if ltx_debug_compare_uncond_enabled() && step_idx == 0 {
                     if let Some(uncond_static_inputs) = uncond_static_inputs.as_ref() {
                         let (uncond_video_velocity, uncond_audio_velocity) = transformer
-                            .forward_with_static_inputs(
+                            .forward_with_static_inputs_and_progress(
                                 &video_latents,
                                 Some(audio_latents_ref),
                                 &video_sigma,
@@ -5058,6 +5075,8 @@ fn run_real_distilled_stage(
                                 audio_timestep.as_ref(),
                                 uncond_static_inputs,
                                 None,
+                                "Evaluating transformer (debug unconditional)",
+                                progress,
                             )?;
                         log_distilled_prompt_sensitivity(
                             debug_stage,
@@ -5075,7 +5094,7 @@ fn run_real_distilled_stage(
                 if step_idx == 0 {
                     if let Some(alt_static_inputs) = alt_static_inputs.as_ref() {
                         let (alt_video_velocity, alt_audio_velocity) = transformer
-                            .forward_with_static_inputs(
+                            .forward_with_static_inputs_and_progress(
                                 &video_latents,
                                 Some(audio_latents_ref),
                                 &video_sigma,
@@ -5084,6 +5103,8 @@ fn run_real_distilled_stage(
                                 audio_timestep.as_ref(),
                                 alt_static_inputs,
                                 None,
+                                "Evaluating transformer (debug alternate prompt)",
+                                progress,
                             )?;
                         log_distilled_alternate_prompt_sensitivity(
                             debug_stage,
@@ -5114,7 +5135,7 @@ fn run_real_distilled_stage(
             let cond_static_inputs = cond_static_inputs
                 .as_ref()
                 .context("missing conditional static inputs for video stage")?;
-            let (uncond_video_velocity, _) = transformer.forward_with_static_inputs(
+            let (uncond_video_velocity, _) = transformer.forward_with_static_inputs_and_progress(
                 &video_latents,
                 None,
                 &video_sigma,
@@ -5123,8 +5144,10 @@ fn run_real_distilled_stage(
                 None,
                 uncond_static_inputs,
                 None,
+                "Evaluating transformer (unconditional)",
+                progress,
             )?;
-            let (cond_video_velocity, _) = transformer.forward_with_static_inputs(
+            let (cond_video_velocity, _) = transformer.forward_with_static_inputs_and_progress(
                 &video_latents,
                 None,
                 &video_sigma,
@@ -5133,6 +5156,8 @@ fn run_real_distilled_stage(
                 None,
                 cond_static_inputs,
                 None,
+                "Evaluating transformer (conditional)",
+                progress,
             )?;
             (
                 denoised_from_velocity(
@@ -5154,7 +5179,7 @@ fn run_real_distilled_stage(
                 .as_ref()
                 .context("missing conditional static inputs for video stage")?;
             let (cond_video_velocity, _cond_audio_velocity) = transformer
-                .forward_with_static_inputs(
+                .forward_with_static_inputs_and_progress(
                     &video_latents,
                     None,
                     &video_sigma,
@@ -5163,19 +5188,24 @@ fn run_real_distilled_stage(
                     None,
                     cond_static_inputs,
                     None,
+                    "Evaluating transformer (conditional)",
+                    progress,
                 )?;
             if ltx_debug_compare_uncond_enabled() && step_idx == 0 {
                 if let Some(uncond_static_inputs) = uncond_static_inputs.as_ref() {
-                    let (uncond_video_velocity, _) = transformer.forward_with_static_inputs(
-                        &video_latents,
-                        None,
-                        &video_sigma,
-                        &video_timestep,
-                        None,
-                        None,
-                        uncond_static_inputs,
-                        None,
-                    )?;
+                    let (uncond_video_velocity, _) = transformer
+                        .forward_with_static_inputs_and_progress(
+                            &video_latents,
+                            None,
+                            &video_sigma,
+                            &video_timestep,
+                            None,
+                            None,
+                            uncond_static_inputs,
+                            None,
+                            "Evaluating transformer (debug unconditional)",
+                            progress,
+                        )?;
                     log_distilled_prompt_sensitivity(
                         debug_stage,
                         step_idx,
@@ -5191,16 +5221,19 @@ fn run_real_distilled_stage(
             }
             if step_idx == 0 {
                 if let Some(alt_static_inputs) = alt_static_inputs.as_ref() {
-                    let (alt_video_velocity, _) = transformer.forward_with_static_inputs(
-                        &video_latents,
-                        None,
-                        &video_sigma,
-                        &video_timestep,
-                        None,
-                        None,
-                        alt_static_inputs,
-                        None,
-                    )?;
+                    let (alt_video_velocity, _) = transformer
+                        .forward_with_static_inputs_and_progress(
+                            &video_latents,
+                            None,
+                            &video_sigma,
+                            &video_timestep,
+                            None,
+                            None,
+                            alt_static_inputs,
+                            None,
+                            "Evaluating transformer (debug alternate prompt)",
+                            progress,
+                        )?;
                     log_distilled_alternate_prompt_sensitivity(
                         debug_stage,
                         step_idx,
@@ -5455,18 +5488,21 @@ fn audio_guided_denoise_step(
     audio_timestep: &Tensor,
     audio_guider: &MultiModalGuider,
     step_idx: usize,
+    progress: Option<&ProgressCallback>,
 ) -> Result<Tensor> {
     let batch = audio_latents.dim(0)?;
     let batched_latents = repeat_batch(audio_latents, static_batch.repeat_count)?;
     let batched_sigma = repeat_batch(audio_sigma, static_batch.repeat_count)?;
     let batched_timestep = repeat_batch(audio_timestep, static_batch.repeat_count)?;
 
-    let all_velocity = transformer.forward_with_static_inputs(
+    let all_velocity = transformer.forward_with_static_inputs_and_progress(
         &batched_latents,
         &batched_sigma,
         &batched_timestep,
         &static_batch.static_inputs,
         Some(&static_batch.perturbations),
+        "Evaluating audio transformer",
+        progress,
     )?;
 
     let cond = denoised_from_velocity_with_sigma(
@@ -5530,6 +5566,11 @@ fn run_real_audio_only_stage(
     );
     let mut run_sigmas = sigmas_no_terminal.to_vec();
     run_sigmas.push(0.0);
+    if let Some(progress) = progress {
+        progress(ProgressEvent::StageStart {
+            name: format!("Denoising ({} steps)", run_sigmas.len().saturating_sub(1)),
+        });
+    }
 
     let mut audio_latents = audio_patchifier.patchify(audio_start_latents)?;
     let audio_sampler_noise = audio_sampler_noise
@@ -5574,6 +5615,7 @@ fn run_real_audio_only_stage(
             &audio_timestep,
             &audio_guider,
             step_idx,
+            progress,
         )?;
         transformer_secs += transformer_start.elapsed().as_secs_f64();
 
@@ -6625,6 +6667,7 @@ fn multimodal_guided_denoise_step(
     video_guider: &MultiModalGuider,
     audio_guider: &MultiModalGuider,
     step_idx: usize,
+    progress: Option<&ProgressCallback>,
 ) -> Result<(Tensor, Option<Tensor>)> {
     let video_skip = video_guider.should_skip_step(step_idx);
     let audio_skip = audio_guider.should_skip_step(step_idx);
@@ -6647,16 +6690,19 @@ fn multimodal_guided_denoise_step(
         .as_ref()
         .context("missing prepared static multimodal guidance inputs")?;
 
-    let (all_video_velocity, all_audio_velocity) = transformer.forward_with_static_inputs(
-        &batched_video_latents,
-        batched_audio_latents.as_ref(),
-        &batched_video_sigma,
-        &batched_video_timestep,
-        batched_audio_sigma.as_ref(),
-        batched_audio_timestep.as_ref(),
-        static_inputs,
-        Some(&static_batch.perturbations),
-    )?;
+    let (all_video_velocity, all_audio_velocity) = transformer
+        .forward_with_static_inputs_and_progress(
+            &batched_video_latents,
+            batched_audio_latents.as_ref(),
+            &batched_video_sigma,
+            &batched_video_timestep,
+            batched_audio_sigma.as_ref(),
+            batched_audio_timestep.as_ref(),
+            static_inputs,
+            Some(&static_batch.perturbations),
+            "Evaluating transformer",
+            progress,
+        )?;
 
     let cond_video = denoised_from_velocity_with_sigma(
         video_latents,
@@ -9161,7 +9207,7 @@ mod tests {
     }
 
     #[test]
-    fn ltx25_stage2_sigmas_match_the_official_workflow_without_changing_ltx23() {
+    fn distilled_stage2_sigmas_share_the_upstream_authority() {
         let ltx25 = req(
             "ltx-2.5-22b-distilled:int8-conv",
             OutputFormat::Mp4,
@@ -9176,7 +9222,7 @@ mod tests {
         );
         assert_eq!(
             super::distilled_stage2_sigmas_no_terminal(&ltx25_plan),
-            &[0.85, 0.725, 0.4219]
+            &[0.909375, 0.725, 0.421875]
         );
 
         let ltx23 = req("ltx-2.3-22b-distilled:fp8", OutputFormat::Mp4, Some(false));

--- a/crates/mold-inference/src/ltx2/text/gemma4.rs
+++ b/crates/mold-inference/src/ltx2/text/gemma4.rs
@@ -11,6 +11,7 @@ use candle_nn::{linear_b as linear, Activation, Embedding, Linear, Module, VarBu
 
 use super::encoder::{build_attention_mask, build_position_ids, GemmaHiddenStates};
 use super::gemma::{GemmaAssets, PromptTokens};
+use crate::progress::{ProgressCallback, ProgressEvent};
 
 const HIDDEN_SIZE: usize = 3_840;
 const INTERMEDIATE_SIZE: usize = 15_360;
@@ -421,17 +422,43 @@ impl Gemma4HiddenStateEncoder {
     }
 
     pub fn encode_prompt_tokens(&mut self, tokens: &PromptTokens) -> Result<GemmaHiddenStates> {
+        self.encode_prompt_tokens_with_progress(tokens, None, "Encoding prompt (Gemma)")
+    }
+
+    pub fn encode_prompt_tokens_with_progress(
+        &mut self,
+        tokens: &PromptTokens,
+        progress: Option<&ProgressCallback>,
+        stage_name: &str,
+    ) -> Result<GemmaHiddenStates> {
         let ids = Tensor::new(tokens.input_ids.as_slice(), &self.device)?.unsqueeze(0)?;
         let attention_mask =
             Tensor::new(tokens.attention_mask.as_slice(), &self.device)?.unsqueeze(0)?;
-        let hidden_states = self.forward_hidden_states(&ids, &attention_mask)?;
+        let hidden_states =
+            self.forward_hidden_states_with_progress(&ids, &attention_mask, progress, stage_name)?;
         Ok(GemmaHiddenStates {
             hidden_states,
             attention_mask,
         })
     }
 
+    #[cfg(test)]
     fn forward_hidden_states(&self, ids: &Tensor, attention_mask: &Tensor) -> Result<Vec<Tensor>> {
+        self.forward_hidden_states_with_progress(
+            ids,
+            attention_mask,
+            None,
+            "Encoding prompt (Gemma)",
+        )
+    }
+
+    fn forward_hidden_states_with_progress(
+        &self,
+        ids: &Tensor,
+        attention_mask: &Tensor,
+        progress: Option<&ProgressCallback>,
+        stage_name: &str,
+    ) -> Result<Vec<Tensor>> {
         let (batch, seq) = ids.dims2()?;
         if seq > self.cfg.sliding_window {
             bail!(
@@ -463,6 +490,13 @@ impl Gemma4HiddenStateEncoder {
             if index + 1 < self.cfg.num_layers {
                 hidden_states.push(xs.clone());
             }
+            if let Some(progress) = progress {
+                progress(ProgressEvent::StageProgress {
+                    name: stage_name.to_string(),
+                    current: index + 1,
+                    total: self.cfg.num_layers,
+                });
+            }
         }
         hidden_states.push(self.norm.forward(&xs)?);
         if hidden_states
@@ -478,6 +512,7 @@ impl Gemma4HiddenStateEncoder {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
 
     use candle_core::{DType, Device, Tensor};
     use candle_nn::VarBuilder;
@@ -642,5 +677,42 @@ mod tests {
         for (actual, expected) in final_values.iter().zip(expected) {
             assert!((actual - expected).abs() < 1e-6, "{actual} != {expected}");
         }
+    }
+
+    #[test]
+    fn streaming_layers_emit_bounded_stage_progress() {
+        let cfg = tiny_config();
+        let encoder = Gemma4HiddenStateEncoder::new_streaming(cfg, tiny_var_builder(cfg)).unwrap();
+        let ids = Tensor::new(&[[3u32]], &Device::Cpu).unwrap();
+        let mask = Tensor::new(&[[1u8]], &Device::Cpu).unwrap();
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let captured = Arc::clone(&seen);
+        let progress: crate::progress::ProgressCallback = Box::new(move |event| {
+            if let crate::progress::ProgressEvent::StageProgress {
+                name,
+                current,
+                total,
+            } = event
+            {
+                captured.lock().unwrap().push((name, current, total));
+            }
+        });
+
+        encoder
+            .forward_hidden_states_with_progress(
+                &ids,
+                &mask,
+                Some(&progress),
+                "Encoding prompt (Gemma, conditional)",
+            )
+            .unwrap();
+
+        assert_eq!(
+            *seen.lock().unwrap(),
+            vec![
+                ("Encoding prompt (Gemma, conditional)".to_string(), 1, 2),
+                ("Encoding prompt (Gemma, conditional)".to_string(), 2, 2),
+            ]
+        );
     }
 }

--- a/crates/mold-inference/src/ltx2/text/prompt_encoder.rs
+++ b/crates/mold-inference/src/ltx2/text/prompt_encoder.rs
@@ -17,6 +17,7 @@ use super::gemma3_gguf::GgufGemmaEncoder;
 use super::gemma4::Gemma4HiddenStateEncoder;
 use crate::ltx2::model::LtxRopeType;
 use crate::ltx2::preset::{GemmaArchitecture, GemmaFeatureExtractorKind, Ltx2ModelPreset};
+use crate::progress::ProgressCallback;
 
 /// Backend for the Gemma 3 12B prompt encoder. The two variants both produce
 /// `Vec<Tensor>` of hidden states with `len() == num_hidden_layers + 1`, so
@@ -53,11 +54,21 @@ impl GemmaHiddenStateBackend {
         }
     }
 
-    fn encode_prompt_tokens(&mut self, tokens: &PromptTokens) -> Result<GemmaHiddenStates> {
+    fn encode_prompt_tokens(
+        &mut self,
+        tokens: &PromptTokens,
+        progress: Option<&ProgressCallback>,
+        stage_name: &str,
+    ) -> Result<GemmaHiddenStates> {
         match self {
             Self::Safetensors(encoder) => encoder.encode_prompt_tokens(tokens),
             Self::Gguf(encoder) => encoder.encode_prompt_tokens(tokens),
-            Self::Gemma4(encoder) => encoder.encode_prompt_tokens(tokens),
+            Self::Gemma4(encoder) => match progress {
+                Some(progress) => {
+                    encoder.encode_prompt_tokens_with_progress(tokens, Some(progress), stage_name)
+                }
+                None => encoder.encode_prompt_tokens(tokens),
+            },
         }
     }
 }
@@ -227,12 +238,29 @@ impl NativePromptEncoder {
         pair: &EncodedPromptPair,
         encode_unconditional: bool,
     ) -> Result<NativePromptEncoding> {
+        self.encode_prompt_pair_with_progress(pair, encode_unconditional, None)
+    }
+
+    pub fn encode_prompt_pair_with_progress(
+        &mut self,
+        pair: &EncodedPromptPair,
+        encode_unconditional: bool,
+        progress: Option<&ProgressCallback>,
+    ) -> Result<NativePromptEncoding> {
         let conditional = self
-            .encode_prompt_tokens(&pair.conditional)
+            .encode_prompt_tokens(
+                &pair.conditional,
+                progress,
+                "Encoding prompt (Gemma, conditional)",
+            )
             .context("failed to build conditional native LTX-2 embeddings")?;
         let unconditional = if encode_unconditional {
-            self.encode_prompt_tokens(&pair.unconditional)
-                .context("failed to build unconditional native LTX-2 embeddings")?
+            self.encode_prompt_tokens(
+                &pair.unconditional,
+                progress,
+                "Encoding prompt (Gemma, unconditional)",
+            )
+            .context("failed to build unconditional native LTX-2 embeddings")?
         } else {
             conditional.clone()
         };
@@ -247,10 +275,15 @@ impl NativePromptEncoder {
         self.gemma_backend.device()
     }
 
-    fn encode_prompt_tokens(&mut self, tokens: &PromptTokens) -> Result<EmbeddingsProcessorOutput> {
+    fn encode_prompt_tokens(
+        &mut self,
+        tokens: &PromptTokens,
+        progress: Option<&ProgressCallback>,
+        stage_name: &str,
+    ) -> Result<EmbeddingsProcessorOutput> {
         let encoded = self
             .gemma_backend
-            .encode_prompt_tokens(tokens)
+            .encode_prompt_tokens(tokens, progress, stage_name)
             .context("failed to encode Gemma prompt tokens")?;
         self.embeddings_processor
             .process_hidden_states(

--- a/crates/mold-inference/src/progress.rs
+++ b/crates/mold-inference/src/progress.rs
@@ -106,6 +106,14 @@ pub enum ProgressEvent {
     StageStart { name: String },
     /// The most recent stage completed, with its elapsed time
     StageDone { name: String, elapsed: Duration },
+    /// Bounded work inside a stage, such as one streaming transformer layer.
+    /// This remains separate from `DenoiseStep` so setup and inner evaluations
+    /// never masquerade as completed sampler steps.
+    StageProgress {
+        name: String,
+        current: usize,
+        total: usize,
+    },
     /// A scheduler-observable phase completed. This maps to the same
     /// StageDone SSE shape as a display-only stage but retains typed identity
     /// inside the inference/server boundary.
@@ -169,6 +177,14 @@ impl ProgressReporter {
         self.emit(ProgressEvent::StageDone {
             name: name.to_string(),
             elapsed,
+        });
+    }
+
+    pub fn stage_progress(&self, name: &str, current: usize, total: usize) {
+        self.emit(ProgressEvent::StageProgress {
+            name: name.to_string(),
+            current,
+            total,
         });
     }
 
@@ -262,6 +278,15 @@ impl From<ProgressEvent> for mold_core::SseProgressEvent {
             ProgressEvent::StageDone { name, elapsed } => mold_core::SseProgressEvent::StageDone {
                 name,
                 elapsed_ms: elapsed.as_millis() as u64,
+            },
+            ProgressEvent::StageProgress {
+                name,
+                current,
+                total,
+            } => mold_core::SseProgressEvent::StageProgress {
+                name,
+                current,
+                total,
             },
             ProgressEvent::PhaseDone {
                 name,

--- a/crates/mold-server/src/model_manager.rs
+++ b/crates/mold-server/src/model_manager.rs
@@ -313,8 +313,14 @@ fn annotate_audio_capabilities(catalog: &mut [ModelInfoExtended], config: &Confi
         {
             continue;
         }
-        entry.supports_audio = ModelPaths::resolve(&entry.info.name, config)
-            .and_then(|paths| mold_inference::audio::output_supported(&entry.info.family, &paths));
+        entry.supports_audio = ModelPaths::resolve(&entry.info.name, config).and_then(|paths| {
+            mold_inference::audio::output_supported(
+                &entry.info.family,
+                &entry.info.name,
+                config,
+                &paths,
+            )
+        });
     }
 }
 
@@ -3267,6 +3273,58 @@ mod tests {
         );
         let combined = installed_catalog_models(&state, &config, dir.path(), None, false);
         assert_eq!(combined[0].supports_audio, Some(true));
+    }
+
+    #[test]
+    fn downloaded_ltx25_uses_split_audio_component_for_capability() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut config = Config {
+            models_dir: dir.path().to_string_lossy().into_owned(),
+            ..Default::default()
+        };
+        let model = mold_core::ltx25_manifest::DISTILLED_INT8_CONV;
+        let split = mold_core::ltx25_manifest::Ltx25ModelPaths::resolve(&config, model).unwrap();
+        config.models.insert(
+            model.to_string(),
+            mold_core::ModelConfig {
+                transformer: Some(split.transformer.to_string_lossy().into_owned()),
+                vae: Some(split.video_vae.to_string_lossy().into_owned()),
+                family: Some("ltx2".to_string()),
+                ..Default::default()
+            },
+        );
+        std::fs::create_dir_all(split.audio_vae.parent().unwrap()).unwrap();
+        write_safetensors_with_keys(
+            &split.audio_vae,
+            &[
+                "audio_vae.per_channel_statistics.mean-of-means",
+                "vocoder.vocoder.conv_pre.weight",
+            ],
+        );
+
+        let mut catalog = mold_core::catalog::build_model_catalog(&config, None, false);
+        let row = catalog
+            .iter_mut()
+            .find(|entry| entry.info.name == model)
+            .unwrap();
+        row.downloaded = true;
+        row.supports_audio = None;
+
+        annotate_audio_capabilities(&mut catalog, &config);
+        synchronize_generation_profile_capabilities(&mut catalog);
+
+        let row = catalog
+            .iter()
+            .find(|entry| entry.info.name == model)
+            .unwrap();
+        assert_eq!(row.supports_audio, Some(true));
+        assert!(row
+            .generation_profile
+            .as_ref()
+            .unwrap()
+            .recipes
+            .iter()
+            .any(|recipe| recipe.capabilities.supports_audio));
     }
 
     /// `/api/models` must advertise H3's synchronized audio for every

--- a/crates/mold-tui/src/app.rs
+++ b/crates/mold-tui/src/app.rs
@@ -2907,6 +2907,7 @@ impl App {
                             | mold_core::SseProgressEvent::DownloadDone { .. }
                             | mold_core::SseProgressEvent::PullComplete { .. }
                             | mold_core::SseProgressEvent::StageStart { .. }
+                            | mold_core::SseProgressEvent::StageProgress { .. }
                             | mold_core::SseProgressEvent::Info { .. } => {
                                 let _ =
                                     tx_sse.send(BackgroundEvent::UpscaleDownloadProgress(event));
@@ -9039,6 +9040,13 @@ fn reduce_progress_state(progress: &mut ProgressState, event: SseProgressEvent) 
                 style: ProgressStyle::Done,
             });
         }
+        SseProgressEvent::StageProgress {
+            name,
+            current,
+            total,
+        } => {
+            progress.current_stage = Some(format!("{name} {current}/{total}"));
+        }
         SseProgressEvent::Info { message } => {
             // Download status messages go to the stage spinner only (not the log)
             // to avoid duplicate display.
@@ -9481,6 +9489,25 @@ mod tests {
         assert!(state.stage_started_at.is_none());
         assert!(state.download_filename.is_empty());
         assert!(state.weight_component.is_empty());
+    }
+
+    #[test]
+    fn bounded_stage_progress_keeps_inner_work_visible() {
+        let mut state = ProgressState::default();
+        reduce_progress_state(
+            &mut state,
+            SseProgressEvent::StageProgress {
+                name: "Encoding prompt (Gemma, conditional)".to_string(),
+                current: 17,
+                total: 48,
+            },
+        );
+
+        assert_eq!(
+            state.current_stage.as_deref(),
+            Some("Encoding prompt (Gemma, conditional) 17/48")
+        );
+        assert_eq!(state.denoise_step, 0);
     }
 
     #[test]

--- a/desktop/src/lib/api/types.ts
+++ b/desktop/src/lib/api/types.ts
@@ -617,6 +617,7 @@ export type ProgressEvent =
   | { type: "dependency_wait"; dependency: string; reason: string }
   | { type: "stage_start"; name: string }
   | { type: "stage_done"; name: string; elapsed_ms: number }
+  | { type: "stage_progress"; name: string; current: number; total: number }
   | { type: "info"; message: string }
   | { type: "cache_hit"; resource: string }
   | { type: "denoise_step"; step: number; total: number; elapsed_ms: number }

--- a/desktop/src/lib/generationJob.ts
+++ b/desktop/src/lib/generationJob.ts
@@ -230,6 +230,11 @@ export function applyProgress(job: Job, event: ProgressEvent): Job {
         job.stage = event.type === "stage_start" ? event.name : "Loading weights";
       }
       break;
+    case "stage_progress":
+      if (job.status !== "denoising" && job.status !== "finishing") job.status = "loading";
+      job.queuePosition = null;
+      job.stage = `${event.name} ${event.current}/${event.total}`;
+      break;
     case "denoise_step":
       job.status = "denoising";
       job.queuePosition = null;

--- a/desktop/src/stores/generation.test.ts
+++ b/desktop/src/stores/generation.test.ts
@@ -105,6 +105,22 @@ describe("generation SSE reducer", () => {
     expect(jobProgressCopy(job)).toBe("Developing 4/20 — Streaming MiniMax H3 transformer blocks");
   });
 
+  it("shows bounded inner progress without advancing the denoise step", () => {
+    const job = newJob({ ...req, steps: 4 });
+    applyProgress(job, { type: "denoise_step", step: 1, total: 4, elapsed_ms: 1 });
+    applyProgress(job, {
+      type: "stage_progress",
+      name: "Evaluating transformer",
+      current: 17,
+      total: 48,
+    });
+
+    expect(job.status).toBe("denoising");
+    expect(job.step).toBe(1);
+    expect(job.stage).toBe("Evaluating transformer 17/48");
+    expect(jobProgress(job)).toBe(0.25);
+  });
+
   it("uses the requested seed for the grain, or a stable stand-in", () => {
     expect(newJob({ ...req, seed: 42 }).visualSeed).toBe("42");
     const a = newJob(req).visualSeed;

--- a/scripts/capture-ltx25-comfy-metal-reference.sh
+++ b/scripts/capture-ltx25-comfy-metal-reference.sh
@@ -100,7 +100,7 @@ validate_graph() {
     and .["11"].inputs.noise_seed == 25026
     and .["13"].inputs.sigmas == "1.0, 0.99375, 0.9875, 0.98125, 0.975, 0.909375, 0.725, 0.421875, 0.0"
     and .["20"].inputs.noise_seed == 42
-    and .["22"].inputs.sigmas == "0.85, 0.7250, 0.4219, 0.0"
+    and .["22"].inputs.sigmas == "0.909375, 0.7250, 0.421875, 0.0"
     and .["26"].inputs.tile_size == 256
     and .["28"].inputs.fps == 24
     and .["29"].inputs.filename_prefix == "ltx25-comfy-int8-mps-seed-25026"

--- a/scripts/fixtures/ltx25-comfy-metal-api-prompt.json
+++ b/scripts/fixtures/ltx25-comfy-metal-api-prompt.json
@@ -117,7 +117,7 @@
   },
   "22": {
     "class_type": "ManualSigmas",
-    "inputs": { "sigmas": "0.85, 0.7250, 0.4219, 0.0" }
+    "inputs": { "sigmas": "0.909375, 0.7250, 0.421875, 0.0" }
   },
   "23": {
     "class_type": "LTXVDualCFGGuider",

--- a/scripts/tests/ltx25-comfy-metal-reference.sh
+++ b/scripts/tests/ltx25-comfy-metal-reference.sh
@@ -14,7 +14,7 @@ jq -e '
   and .["8"].inputs == {width:128,height:128,length:9,batch_size:1}
   and .["11"].inputs.noise_seed == 25026
   and .["20"].inputs.noise_seed == 42
-  and .["22"].inputs.sigmas == "0.85, 0.7250, 0.4219, 0.0"
+  and .["22"].inputs.sigmas == "0.909375, 0.7250, 0.421875, 0.0"
   and .["28"].inputs.fps == 24
   and .["29"].inputs.filename_prefix == "ltx25-comfy-int8-mps-seed-25026"
 ' "$fixture" >/dev/null

--- a/web/src/composables/useGenerateStream.test.ts
+++ b/web/src/composables/useGenerateStream.test.ts
@@ -448,6 +448,16 @@ describe("workStarted tracking", () => {
     lastSingleHandlers!.onProgress({ type: "stage_start", name: "Loading" });
     expect(job.workStarted).toBe(true);
     expect(job.progress.queuePosition).toBeNull();
+
+    lastSingleHandlers!.onProgress({
+      type: "stage_progress",
+      name: "Encoding prompt (Gemma, conditional)",
+      current: 8,
+      total: 48,
+    });
+    expect(job.progress.stage).toBe(
+      "Encoding prompt (Gemma, conditional) 8/48",
+    );
   });
 
   it("keeps a chain queued until a stage starts and between durable stages", () => {

--- a/web/src/composables/useGenerateStream.ts
+++ b/web/src/composables/useGenerateStream.ts
@@ -366,6 +366,10 @@ function applyProgress(job: Job, evt: SseProgressEvent) {
       p.stage = `${evt.name} (done)`;
       p.elapsedMs = evt.elapsed_ms;
       break;
+    case "stage_progress":
+      markWorkStarted(job);
+      p.stage = `${evt.name} ${evt.current}/${evt.total}`;
+      break;
     case "info":
       // Dimension warnings are emitted before the server queues the job, so
       // an info event only proves real work has started if the job has

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -622,6 +622,7 @@ export type SseProgressEvent =
   | { type: "dependency_wait"; dependency: string; reason: string }
   | { type: "stage_start"; name: string }
   | { type: "stage_done"; name: string; elapsed_ms: number }
+  | { type: "stage_progress"; name: string; current: number; total: number }
   | { type: "info"; message: string }
   | { type: "cache_hit"; resource: string }
   | { type: "denoise_step"; step: number; total: number; elapsed_ms: number }


### PR DESCRIPTION
## Summary

- resolve LTX-2.5 synchronized-audio support from the inference-owned capability registry, including the split audio VAE/vocoder component, so every Studio surface reads the same truthful API capability
- align distilled stage-2 sigmas and the retained Comfy Metal contract fixture with current upstream LTX-Video
- lock LTX-2.5 duration/frame metadata to the shared 20-second, 8k+1 authority while retaining Mold's distinct 604-frame resource guard
- add additive bounded stage progress for Gemma and LTX video/audio transformer work, consumed across web, desktop, CLI, MCP, TUI, Discord, and RunPod without inflating denoise progress

## Validation

- `nix develop -c cargo clippy --workspace --all-targets -- -D warnings`
- `nix develop -c cargo check -p mold-ai --features preview,discord,expand,tui,webp,mp4`
- focused Rust regressions for catalog limits, audio capability, upstream sigmas, Gemma progress, SSE serialization, and all Rust progress consumers
- web: 2,449 tests; desktop: 5,097 tests; Studio: 1,265 tests
- web, desktop, and mobile production builds
- LTX-2.5 Comfy Metal fixture contract
- `git diff --check`

Full `cargo test --workspace` reached 661/663 CLI tests before two unrelated local baseline failures: a macOS `/var` versus `/private/var` path-alias assertion in `commands::rm`, and the `commands::info` smoke test observing the real external model library/server configuration. Neither failing file is changed here.

No generation/model UAT was run, per direction. This improves honest Metal progress reporting; it does not claim a Metal throughput improvement. A separate agent reviewed the complete local diff and reported no actionable findings.

Closes #1401
