### PR TITLE
feat(studio): retry failed downloads from notifications

### DIFF
--- a/changelog.d/notification-download-retry.md
+++ b/changelog.d/notification-download-retry.md
@@ -1,0 +1,3 @@
+- **Retry failed model downloads from notifications.** Web and desktop
+  notifications now retry the exact failed pull in place, and the web Downloads
+  panel keeps its close icon centered.

--- a/desktop/src/stores/downloads.notify.test.ts
+++ b/desktop/src/stores/downloads.notify.test.ts
@@ -4,6 +4,7 @@ import { useDownloadsStore } from "./downloads";
 import { useToastStore } from "./toasts";
 import { notifyPulled, notifyPullFailed } from "../lib/notify";
 import { emptyDownloadsState } from "../lib/downloads";
+import { useNotificationsStore } from "@studio/stores/notifications";
 import type { DownloadJob } from "../lib/api/types";
 
 vi.mock("../lib/api/catalog", () => ({ startCatalogDownload: vi.fn() }));
@@ -41,6 +42,27 @@ describe("pull failure notifications (G11)", () => {
     expect(notifyPullFailed).toHaveBeenCalledWith("flux2-klein:q4", "disk full", {
       kind: "models",
     });
+  });
+
+  it("retries a failed pull from its notification on the original host", async () => {
+    const store = useDownloadsStore();
+    const failedJob = failed({ id: "remote-failure" });
+    store.hostStates.hal9000 = {
+      ...emptyDownloadsState(),
+      label: "hal9000",
+      target: { baseUrl: "http://hal9000:7680", apiKey: "remote-key" },
+      subscribed: true,
+      abort: null,
+      cancelling: [],
+      ready: null,
+      history: [failedJob],
+    };
+    const retry = vi.spyOn(store, "retry").mockResolvedValue(undefined);
+
+    store.onJobFailed("remote-failure", "hal9000");
+    await useNotificationsStore().entries[0]!.action?.run();
+
+    expect(retry).toHaveBeenCalledWith("hal9000", failedJob);
   });
 
   it("routes an ordinary completed pull to Models", () => {

--- a/desktop/src/stores/downloads.ts
+++ b/desktop/src/stores/downloads.ts
@@ -464,7 +464,20 @@ export const useDownloadsStore = defineStore("downloads", {
       const model = job?.model ?? "the model";
       const suffix = host ? ` on ${host.label}` : "";
       const detail = job?.error ? ` — ${job.error}` : "";
-      useToastStore().push(`Couldn't pull ${model}${suffix}${detail}`, "error");
+      const failedJob = job;
+      const failedHostId = hostId ?? this.primaryHostId;
+      useToastStore().push(`Couldn't pull ${model}${suffix}${detail}`, "error", {
+        ...(failedJob
+          ? {
+              notificationAction: {
+                label: "Retry",
+                pendingLabel: "Retrying…",
+                doneLabel: "Queued",
+                run: () => this.retry(failedHostId, failedJob),
+              },
+            }
+          : {}),
+      });
       notifyPullFailed(
         model,
         job?.error ?? undefined,

--- a/desktop/src/stores/toasts.ts
+++ b/desktop/src/stores/toasts.ts
@@ -1,5 +1,5 @@
 import { defineStore } from "pinia";
-import { useNotificationsStore } from "@studio/stores/notifications";
+import { useNotificationsStore, type NotificationAction } from "@studio/stores/notifications";
 
 /** A labeled affordance rendered as a button on the toast (e.g. Undo, View). */
 export interface ToastAction {
@@ -29,6 +29,8 @@ export interface ToastOptions {
   sticky?: boolean;
   /** Override the 4 s default lifetime (e.g. a 6 s undo window). Ignored when sticky. */
   durationMs?: number;
+  /** Recovery action retained in the notifications center after this toast leaves. */
+  notificationAction?: NotificationAction;
 }
 
 let nextId = 1;
@@ -52,6 +54,7 @@ export const useToastStore = defineStore("toasts", {
         kind,
         text: message,
         description: options.description ?? null,
+        action: options.notificationAction ?? null,
       });
       const toast: Toast = {
         id: nextId++,

--- a/studio/components/NotificationsCenter.test.ts
+++ b/studio/components/NotificationsCenter.test.ts
@@ -84,6 +84,161 @@ describe("NotificationsCenter", () => {
     ).toContain("No notifications");
     wrapper.unmount();
   });
+
+  it("runs a recovery action from the message and reports its progress", async () => {
+    let resolve!: () => void;
+    const run = vi.fn(
+      () =>
+        new Promise<void>((done) => {
+          resolve = done;
+        }),
+    );
+    const store = useNotificationsStore();
+    store.record({
+      kind: "error",
+      text: "flux-dev:q4 failed to download",
+      atMs: 1,
+      action: {
+        label: "Retry",
+        pendingLabel: "Retrying…",
+        doneLabel: "Queued",
+        run,
+      },
+    });
+
+    const wrapper = mountCenter();
+    await wrapper.get('[data-test="notifications-bell"]').trigger("click");
+    await flushPromises();
+    const action = document.body.querySelector<HTMLButtonElement>(
+      '[data-test="notifications-action"]',
+    )!;
+
+    expect(
+      document.body
+        .querySelector('[data-test="notifications-panel"]')
+        ?.textContent?.match(/—/g),
+    ).toHaveLength(1);
+    expect(action.textContent?.trim()).toBe("Retry");
+    action.click();
+    await flushPromises();
+    expect(run).toHaveBeenCalledOnce();
+    expect(action.textContent?.trim()).toBe("Retrying…");
+    expect(action.disabled).toBe(true);
+
+    resolve();
+    await flushPromises();
+    expect(action.textContent?.trim()).toBe("Queued");
+    expect(action.disabled).toBe(true);
+    wrapper.unmount();
+  });
+
+  it("leaves a failed recovery action available to try again", async () => {
+    const run = vi.fn().mockRejectedValue(new Error("offline"));
+    const store = useNotificationsStore();
+    store.record({
+      kind: "error",
+      text: "Download failed",
+      atMs: 1,
+      action: { label: "Retry", run },
+    });
+
+    const wrapper = mountCenter();
+    await wrapper.get('[data-test="notifications-bell"]').trigger("click");
+    await flushPromises();
+    const action = document.body.querySelector<HTMLButtonElement>(
+      '[data-test="notifications-action"]',
+    )!;
+    action.click();
+    await flushPromises();
+
+    expect(action.textContent?.trim()).toBe("Retry failed");
+    expect(action.disabled).toBe(false);
+    action.click();
+    await flushPromises();
+    expect(run).toHaveBeenCalledTimes(2);
+    wrapper.unmount();
+  });
+
+  it("lets separate failed downloads retry concurrently", async () => {
+    const pending = () => new Promise<void>(() => {});
+    const first = vi.fn(pending);
+    const second = vi.fn(pending);
+    const store = useNotificationsStore();
+    store.record({
+      kind: "error",
+      text: "First download failed",
+      atMs: 1,
+      action: { label: "Retry", run: first },
+    });
+    store.record({
+      kind: "error",
+      text: "Second download failed",
+      atMs: 2,
+      action: { label: "Retry", run: second },
+    });
+
+    const wrapper = mountCenter();
+    await wrapper.get('[data-test="notifications-bell"]').trigger("click");
+    await flushPromises();
+    const actions = [
+      ...document.body.querySelectorAll<HTMLButtonElement>(
+        '[data-test="notifications-action"]',
+      ),
+    ];
+
+    actions[0]!.click();
+    await flushPromises();
+    expect(actions[0]!.disabled).toBe(true);
+    expect(actions[1]!.disabled).toBe(false);
+
+    actions[1]!.click();
+    await flushPromises();
+    expect(first).toHaveBeenCalledOnce();
+    expect(second).toHaveBeenCalledOnce();
+    expect(actions.every((action) => action.disabled)).toBe(true);
+    wrapper.unmount();
+  });
+
+  it("enables a new retry when the same download fails again", async () => {
+    const first = vi.fn().mockResolvedValue(undefined);
+    const second = vi.fn().mockResolvedValue(undefined);
+    const store = useNotificationsStore();
+    store.record({
+      kind: "error",
+      text: "Download failed",
+      atMs: 1,
+      action: { label: "Retry", doneLabel: "Queued", run: first },
+    });
+
+    const wrapper = mountCenter();
+    await wrapper.get('[data-test="notifications-bell"]').trigger("click");
+    await flushPromises();
+    const action = document.body.querySelector<HTMLButtonElement>(
+      '[data-test="notifications-action"]',
+    )!;
+    action.click();
+    await flushPromises();
+    expect(action.textContent?.trim()).toBe("Queued");
+    expect(action.disabled).toBe(true);
+
+    store.record({
+      kind: "error",
+      text: "Download failed",
+      atMs: 2,
+      action: { label: "Retry", doneLabel: "Queued", run: second },
+    });
+    await flushPromises();
+
+    expect(store.entries).toHaveLength(1);
+    expect(store.entries[0]!.repeat).toBe(2);
+    expect(action.textContent?.trim()).toBe("Retry");
+    expect(action.disabled).toBe(false);
+    action.click();
+    await flushPromises();
+    expect(first).toHaveBeenCalledOnce();
+    expect(second).toHaveBeenCalledOnce();
+    wrapper.unmount();
+  });
 });
 
 describe("NotificationsCenter severity colors", () => {

--- a/studio/components/NotificationsCenter.vue
+++ b/studio/components/NotificationsCenter.vue
@@ -4,6 +4,7 @@ import Icon from "@ui/components/Icon.vue";
 import Popover from "@ui/components/Popover.vue";
 import {
   useNotificationsStore,
+  type NotificationAction,
   type NotificationEntry,
 } from "../stores/notifications";
 import {
@@ -65,6 +66,12 @@ function toneLabel(entry: NotificationEntry): string {
  * origin or a denied permission is a normal case, not an edge.
  */
 const copyState = ref<{ id: number; ok: boolean } | null>(null);
+type ActionStatus = "pending" | "done" | "failed";
+interface EntryActionState {
+  action: NotificationAction;
+  status: ActionStatus;
+}
+const actionStates = ref<Record<number, EntryActionState>>({});
 let copyResetTimer: ReturnType<typeof setTimeout> | null = null;
 /** Rising token: only the newest click may paint the outcome. Clicking one row
  *  then another must not settle "Copied" on whichever promise resolves last. */
@@ -93,6 +100,45 @@ async function copyEntry(entry: NotificationEntry) {
 function copyLabel(entry: NotificationEntry): string {
   if (copyState.value?.id !== entry.id) return "Copy";
   return copyState.value.ok ? "Copied" : "Copy failed";
+}
+
+function actionLabel(entry: NotificationEntry): string {
+  if (!entry.action) return "";
+  const state = actionStates.value[entry.id];
+  const status = state?.action === entry.action ? state.status : undefined;
+  if (status === "pending") {
+    return entry.action.pendingLabel ?? "Working…";
+  }
+  if (status === "done") {
+    return entry.action.doneLabel ?? "Done";
+  }
+  return status === "failed"
+    ? `${entry.action.label} failed`
+    : entry.action.label;
+}
+
+function actionDisabled(entry: NotificationEntry): boolean {
+  const state = actionStates.value[entry.id];
+  return (
+    state?.action === entry.action &&
+    (state.status === "pending" || state.status === "done")
+  );
+}
+
+async function runEntryAction(entry: NotificationEntry) {
+  const action = entry.action;
+  if (!action || actionDisabled(entry)) return;
+  actionStates.value[entry.id] = { action, status: "pending" };
+  try {
+    await action.run();
+    if (actionStates.value[entry.id]?.action === action) {
+      actionStates.value[entry.id] = { action, status: "done" };
+    }
+  } catch {
+    if (actionStates.value[entry.id]?.action === action) {
+      actionStates.value[entry.id] = { action, status: "failed" };
+    }
+  }
 }
 
 /* The button's accessible name cannot change under the user's fingers, so the
@@ -192,6 +238,17 @@ function timeLabel(entry: NotificationEntry): string {
           <div class="notifications-panel__copy">
             <p class="notifications-panel__text">
               {{ entry.text }}
+              <span v-if="entry.action" aria-hidden="true"> — </span>
+              <button
+                v-if="entry.action"
+                type="button"
+                class="notifications-panel__inline-action"
+                data-test="notifications-action"
+                :disabled="actionDisabled(entry)"
+                @click="runEntryAction(entry)"
+              >
+                {{ actionLabel(entry) }}
+              </button>
               <span v-if="entry.repeat > 1" class="notifications-panel__repeat">
                 ×{{ entry.repeat }}
               </span>
@@ -364,6 +421,34 @@ function timeLabel(entry: NotificationEntry): string {
 .notifications-panel__repeat {
   color: var(--ink-3, #98a2b3);
   font-size: 11px;
+}
+
+.notifications-panel__inline-action {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: none;
+  color: var(--link, var(--rebate, #2563eb));
+  font: inherit;
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+}
+
+.notifications-panel__inline-action:hover:not(:disabled) {
+  text-decoration-thickness: 2px;
+}
+
+.notifications-panel__inline-action:focus-visible {
+  border-radius: 2px;
+  outline: 2px solid var(--safelight, currentColor);
+  outline-offset: 2px;
+}
+
+.notifications-panel__inline-action:disabled {
+  color: var(--ink-3, #98a2b3);
+  cursor: default;
 }
 
 .notifications-panel__detail {

--- a/studio/stores/notifications.ts
+++ b/studio/stores/notifications.ts
@@ -13,6 +13,14 @@ import { computed, ref } from "vue";
  *  plain info stays neutral. See `lib/notificationTone.ts`. */
 export type NotificationKind = "info" | "success" | "warning" | "error";
 
+/** A durable, session-scoped action rendered inline with a notification. */
+export interface NotificationAction {
+  label: string;
+  pendingLabel?: string;
+  doneLabel?: string;
+  run: () => void | Promise<void>;
+}
+
 export interface NotificationEntry {
   id: number;
   kind: NotificationKind;
@@ -26,6 +34,8 @@ export interface NotificationEntry {
   read: boolean;
   /** Consecutive identical messages collapse into one row with a count. */
   repeat: number;
+  /** Optional recovery action, such as retrying a failed model download. */
+  action: NotificationAction | null;
 }
 
 export interface NotificationInput {
@@ -33,6 +43,7 @@ export interface NotificationInput {
   text: string;
   description?: string | null;
   hostLabel?: string | null;
+  action?: NotificationAction | null;
   /** Wall-clock stamp; callers pass Date.now() (kept injectable for tests). */
   atMs?: number;
 }
@@ -63,6 +74,7 @@ export const useNotificationsStore = defineStore("studio-notifications", () => {
       newest.repeat += 1;
       newest.atMs = atMs;
       newest.read = false;
+      newest.action = input.action ?? null;
       return;
     }
     entries.value.unshift({
@@ -74,6 +86,7 @@ export const useNotificationsStore = defineStore("studio-notifications", () => {
       atMs,
       read: false,
       repeat: 1,
+      action: input.action ?? null,
     });
     if (entries.value.length > NOTIFICATION_CAP) {
       entries.value.length = NOTIFICATION_CAP;

--- a/web/src/components/shell/DownloadsPopover.vue
+++ b/web/src/components/shell/DownloadsPopover.vue
@@ -180,7 +180,10 @@ onBeforeUnmount(() => {
   border: 0;
   background: color-mix(in srgb, var(--rebate) 9%, transparent);
   color: var(--ink-2);
-  font-size: 13px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
   cursor: pointer;
   transition:
     background var(--dur-quick) var(--ease),

--- a/web/src/lib/notifications.test.ts
+++ b/web/src/lib/notifications.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { nextTick, ref } from "vue";
 import { flushPromises } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
 import {
   installNotifications,
   markGalleryVisited,
@@ -11,6 +12,7 @@ import { resetNotifications, useNotifications } from "./toasts";
 import type { Job } from "../composables/useGenerateStream";
 import type { UseDownloads } from "../composables/useDownloads";
 import type { DownloadJobWire } from "../types";
+import { useNotificationsStore } from "@studio/stores/notifications";
 
 const listStoredHosts = vi.hoisted(() => vi.fn());
 const hostStatus = vi.hoisted(() => vi.fn());
@@ -51,6 +53,7 @@ function fakeDownloads(history: DownloadJobWire[]): UseDownloads {
 const toasts = () => useNotifications().toasts;
 
 beforeEach(() => {
+  setActivePinia(createPinia());
   resetNotifications();
   __resetNotificationsForTest();
   listStoredHosts.mockReset();
@@ -135,6 +138,31 @@ describe("notifications — downloads (G11b)", () => {
     expect(texts.some((t) => t.includes("installed flux-dev:q4"))).toBe(true);
     expect(texts.some((t) => t.includes("sdxl:base failed"))).toBe(true);
     expect(texts.some((t) => t.includes("z-image:turbo"))).toBe(false);
+    stop();
+  });
+
+  it("retries a failed pull from the notification message", async () => {
+    const downloads = fakeDownloads([]);
+    downloads.enqueue = vi.fn().mockResolvedValue(null);
+    const stop = installNotifications({
+      jobs: ref<Job[]>([]),
+      downloads,
+      currentRouteName: () => "models",
+      hostPollMs: 1_000_000,
+    });
+
+    downloads.history.value = [dljob({ status: "failed" })];
+    await nextTick();
+
+    const failedToast = toasts().find((entry) =>
+      entry.text.includes("failed to download"),
+    );
+    expect(failedToast?.text).toBe("flux-dev:q4 failed to download");
+    expect(failedToast?.actionLabel).toBeUndefined();
+    await useNotificationsStore().entries[0]!.action?.run();
+
+    expect(downloads.enqueue).toHaveBeenCalledOnce();
+    expect(downloads.enqueue).toHaveBeenCalledWith("flux-dev:q4");
     stop();
   });
 

--- a/web/src/lib/notifications.ts
+++ b/web/src/lib/notifications.ts
@@ -103,10 +103,17 @@ export function installNotifications(deps: NotificationDeps): () => void {
         if (job.status === "completed") {
           toast("success", `installed ${job.model}`);
         } else if (job.status === "failed") {
-          toast(
-            "error",
-            `${job.model} failed to download — retry from downloads`,
-          );
+          const retry = async () => {
+            await deps.downloads.enqueue(job.model);
+          };
+          toast("error", `${job.model} failed to download`, {
+            notificationAction: {
+              label: "Retry",
+              pendingLabel: "Retrying…",
+              doneLabel: "Queued",
+              run: retry,
+            },
+          });
         }
         // cancelled → silent; the user asked for it.
       }

--- a/web/src/lib/toasts.ts
+++ b/web/src/lib/toasts.ts
@@ -1,6 +1,7 @@
 import { reactive, readonly } from "vue";
 import { getActivePinia } from "pinia";
 import { useNotificationsStore } from "@studio/stores/notifications";
+import type { NotificationAction } from "@studio/stores/notifications";
 
 /*
  * Web-surface notification store feeding @ui ToastShelf, plus the shared
@@ -83,6 +84,8 @@ export interface ToastOptions {
   onDismiss?: () => void;
   /** ms; errors are sticky by default (0 = sticky). */
   timeout?: number;
+  /** Recovery action retained in the notifications center after this toast leaves. */
+  notificationAction?: NotificationAction;
 }
 
 export function toast(
@@ -99,6 +102,7 @@ export function toast(
       kind,
       text,
       description: options.description ?? null,
+      action: options.notificationAction ?? null,
     });
   }
   const entry: Toast = { id, kind, text };


### PR DESCRIPTION
## Summary
- add an inline Retry action to failed-download notifications on web and desktop
- preserve exact web catalog routing and desktop host targeting
- center the web Downloads popover close icon
- keep retries independent across concurrent and repeated failures

## Verification
- `nix develop -c bun run check:frontend`
- browser UAT at `http://127.0.0.1:4173/models`
  - Downloads dialog rendered and opened successfully
  - close icon measured at 0 px horizontal/vertical center offset
  - no browser console warnings or errors
- independent agent peer review approved after findings were addressed